### PR TITLE
v0.5.1 — interaction improvements + release-safety hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -21,9 +21,8 @@ Other approaches you considered, or how you work around this now.
 
 OpenLiDARViewer is a lightweight, local-first viewer, not a full GIS or
 survey-grade processing suite. Requests that fit that scope are easiest to
-land. See the [roadmap](../../docs/roadmap.md) and
-[limitations](../../docs/limitations.md) for what is already planned or
-deliberately out of scope.
+land. See the [CHANGELOG](../../CHANGELOG.md) for what has shipped and
+[limitations](../../docs/limitations.md) for what is deliberately out of scope.
 
 **Anything else**
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,14 @@ jobs:
       - run: npm ci
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
-      - name: Smoke tests
+      - name: Smoke tests (normal build)
         run: npm run test:smoke
+      - name: Smoke tests (live / obfuscated artifact)
+        # Boots the build users actually get: the obfuscator scrambles dynamic
+        # import() / worker-URL string literals, so a chunk that loads fine in
+        # the plain build can 404 only on the live build. This is the gate that
+        # catches that class of live-only breakage.
+        run: npm run test:smoke:live
 
   e2e:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ numbers computed from it.
   back from a saved session is now clamped to a sane range, so a hand-edited or
   corrupted session file can't load the viewer into an unusable display state.
 
-### Internal
+### Tooling
 
 - The browser smoke test can now optionally run against the production
   (minified) build, catching build-only breakage that the development build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ numbers computed from it.
 
 ### Changed
 
+- **Undo now reaches every edit.** Ctrl/Cmd+Z (and Shift+Z / Ctrl+Y to redo)
+  undoes whichever history you touched last — annotations or classification —
+  and falls through to the other once one empties. Classification edits were
+  previously reversible only from the reclassify panel's own buttons, so a
+  keyboard undo did nothing after a lasso reclassify.
+- **Hold Space to re-orient mid-tool.** While Measure, Inspect, or Annotate is
+  active, holding Space hands the mouse back to camera navigation so you can
+  rotate, pan, and zoom without leaving the tool, then release to resume.
+- **Right-click menu on the scan.** Right-clicking a loaded cloud offers focus
+  the pivot on the point under the cursor, frame the whole scan, or snap to the
+  top / front / oblique view.
+- **Accurate keyboard help.** The Help overlay now documents the up/down and
+  sprint navigation keys, the measure-mode Enter/Backspace keys, and the
+  broadened undo, matching what the viewer actually does.
 - **Classification edits invalidate stale analysis.** Each edit (swap,
   reclassify, undo, redo) bumps a per-cloud edit epoch and drops the
   terrain-core cache, so the next Analyse recomputes against the edited classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@ numbers computed from it.
   number.
 - **Sampling-error self-consistency.** The √N in the stockpile sampling error is
   taken over the same finite inside-height population its σ is computed on.
+- **Reliable file downloads on Safari / iOS and for large exports.** Every export
+  now funnels through one helper that releases the temporary blob URL only after
+  the download has had a moment to start, instead of immediately — an immediate
+  release could cancel large PDF / DEM / batch-ZIP / signed-report downloads
+  mid-transfer on some browsers.
+- **Imported render state is range-checked.** A point size or field-of-view read
+  back from a saved session is now clamped to a sane range, so a hand-edited or
+  corrupted session file can't load the viewer into an unusable display state.
+
+### Internal
+
+- The browser smoke test can now optionally run against the production
+  (minified) build, catching build-only breakage that the development build
+  never surfaces.
 
 ## [0.5.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 Deepens the honesty moat. Stockpile/earthworks volume now reports an auditable
 confidence band, manual classification editing lands end-to-end (class picker,
 lasso reclassify, multi-step undo/redo), and measurements export as a
-tamper-evident signed report. Adds two-epoch change-detection uncertainty and
+tamper-evident integrity report. Adds two-epoch change-detection uncertainty and
 edit-aware provenance so an edited classification can never silently outlive the
 numbers computed from it.
 
@@ -22,10 +22,13 @@ numbers computed from it.
   with real multi-step undo/redo, lazy-loaded beside the classification legend.
   Edits mutate the live class channel, so they round-trip straight into LAS
   export.
-- **Tamper-evident signed report.** Placed measurements export as a JSON report
-  whose findings, dataset provenance, and classification edit-epoch are folded
-  into a verifiable signature (deterministic canonical hashing; FNV-1a built in,
-  SHA-256 injectable). Altering any figure breaks verification.
+- **Tamper-evident integrity report.** Placed measurements export as a JSON
+  report whose findings, dataset provenance, and classification edit-epoch are
+  folded into a verifiable content digest (deterministic canonical hashing;
+  default FNV-1a, named in the manifest as `digestAlgorithm`). Changing any
+  figure without recomputing the digest breaks verification — a guard against
+  accidental or casual edits, not a secret-keyed cryptographic signature
+  (SHA-256 hashFn is injectable for that).
 - **Two-epoch change-detection uncertainty.** A volume-change ± band (random
   cell noise that averages as √N plus a systematic co-registration term) that
   also reports whether the net change exceeds its own error — never presenting
@@ -71,7 +74,7 @@ numbers computed from it.
 - **Reliable file downloads on Safari / iOS and for large exports.** Every export
   now funnels through one helper that releases the temporary blob URL only after
   the download has had a moment to start, instead of immediately — an immediate
-  release could cancel large PDF / DEM / batch-ZIP / signed-report downloads
+  release could cancel large PDF / DEM / batch-ZIP / integrity-report downloads
   mid-transfer on some browsers.
 - **Imported render state is range-checked.** A point size or field-of-view read
   back from a saved session is now clamped to a sane range, so a hand-edited or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ numbers computed from it.
 - **Accurate keyboard help.** The Help overlay now documents the up/down and
   sprint navigation keys, the measure-mode Enter/Backspace keys, and the
   broadened undo, matching what the viewer actually does.
+- **More detail on capable desktops.** The high-end desktop tier (ample RAM and
+  cores) now keeps more of a dense survey resident before automatic point
+  reduction kicks in; mid and low tiers and mobile are unchanged, and the GPU
+  safety ceiling still bounds every path.
+- **Stockpile volumes flag a reduced cloud.** When a cloud was automatically
+  reduced to fit the device, a lasso/stockpile volume now adds a caveat that the
+  inside points are a representative sample of a denser survey — the ± band
+  already widens with the thinner sample, and now the reason is stated.
 - **Classification edits invalidate stale analysis.** Each edit (swap,
   reclassify, undo, redo) bumps a per-cloud edit epoch and drops the
   terrain-core cache, so the next Analyse recomputes against the edited classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 The format is based on Keep a Changelog and the project follows Semantic Versioning.
 
+## [0.5.1] - 2026-06-28
+
+Deepens the honesty moat. Stockpile/earthworks volume now reports an auditable
+confidence band, manual classification editing lands end-to-end (class picker,
+lasso reclassify, multi-step undo/redo), and measurements export as a
+tamper-evident signed report. Adds two-epoch change-detection uncertainty and
+edit-aware provenance so an edited classification can never silently outlive the
+numbers computed from it.
+
+### Added
+
+- **Stockpile / earthworks volume with a confidence band.** The lasso volume
+  readout carries a ± band that states its own uncertainty — a sampling-error
+  term (area·σ/√N) and a systematic base-plane term (a single horizontal base
+  under sloped ground biases every thickness the same direction) combined in
+  quadrature — plus a show-the-math breakdown and honest caveats.
+- **Manual classification editing.** A class picker and a lasso-reclassify tool
+  with real multi-step undo/redo, lazy-loaded beside the classification legend.
+  Edits mutate the live class channel, so they round-trip straight into LAS
+  export.
+- **Tamper-evident signed report.** Placed measurements export as a JSON report
+  whose findings, dataset provenance, and classification edit-epoch are folded
+  into a verifiable signature (deterministic canonical hashing; FNV-1a built in,
+  SHA-256 injectable). Altering any figure breaks verification.
+- **Two-epoch change-detection uncertainty.** A volume-change ± band (random
+  cell noise that averages as √N plus a systematic co-registration term) that
+  also reports whether the net change exceeds its own error — never presenting
+  noise as a confident gain or loss.
+
+### Changed
+
+- **Classification edits invalidate stale analysis.** Each edit (swap,
+  reclassify, undo, redo) bumps a per-cloud edit epoch and drops the
+  terrain-core cache, so the next Analyse recomputes against the edited classes
+  instead of serving a grade that no longer matches the cloud.
+
+### Fixed
+
+- **Stockpile base-plane honesty.** Base uncertainty now models the systematic
+  mis-fit of a flat base under sloped ground, not just point scatter — a sloped
+  apron honestly widens the band instead of reporting a confidently-narrow
+  number.
+- **Sampling-error self-consistency.** The √N in the stockpile sampling error is
+  taken over the same finite inside-height population its σ is computed on.
+
 ## [0.5.0] - 2026-06-26
 
 Opens the v0.5 line (Measure · Place · Compare · Share): point snapping, KML

--- a/README.md
+++ b/README.md
@@ -189,8 +189,6 @@ for how each terrain product is validated.
 | A 9.6M-point drone survey, height-colored, with the Scan Intelligence panel and the Orbit / Walk / Fly navigation. | The measurement toolkit — here a distance between two picked points; it also measures polyline, area, height, angle, slope, and cross-section profile. |
 | ![Inspecting a point](docs/screenshots/inspect-tool.jpg) | ![Scan Intelligence panel](docs/screenshots/scan-intelligence-panel.jpg) |
 | Inspecting a point: a glowing marker and a card with its real-world coordinates and attributes. | The Scan Intelligence panel — point count, dimensions, density, spacing, attributes, and the Advanced report. |
-| ![Dataset Intelligence card](docs/screenshots/dataset-intelligence-card.jpg) | |
-| The Dataset Intelligence card — informational summary of the loaded scan: Point Density, Terrain Complexity, Ground Visibility, Streaming Coverage, and Terrain Confidence. Rows for which no signal is available render as `—`. | |
 
 More in [`docs/screenshots.md`](docs/screenshots.md).
 

--- a/README.md
+++ b/README.md
@@ -414,9 +414,14 @@ COPC streaming — local and remote — ships in v0.3.0 and is hardened across v
 
 ## What's in this release
 
-The current release is **v0.5.0**. The full, dated history is in
+The current release is **v0.5.1**. The full, dated history is in
 [CHANGELOG.md](CHANGELOG.md); the highlights below are a reverse-chronological
 summary.
+
+### v0.5.1 — Auditable volume · classification editing · signed reports
+- **Stockpile / earthworks volume with a confidence band** — the lasso volume readout states its own uncertainty (sampling error + a systematic base-plane term, combined in quadrature) with a show-the-math breakdown and honest caveats
+- **Manual classification editing** end-to-end: a class picker + **lasso-reclassify** tool with real **multi-step undo/redo**; edits mutate the live class channel and round-trip straight into LAS export, and they bump a per-cloud **edit epoch** that invalidates any stale analysis/grade
+- **Tamper-evident signed report** — measurements export as a JSON report whose findings, provenance, and classification edit-epoch are hashed into a verifiable signature, plus a **two-epoch change-detection band** that reports whether a change even exceeds its own error
 
 ### v0.5.0 — Measure · Place · Compare · Share
 - The **v0.5 line**: measure tools that **snap** to real returns or to placed geometry, **KML export** of annotations/measurements/views for georeferenced scans, a **Layers** panel (show/hide, isolate, lock, CRS-mismatch flagging), **two-epoch change detection** (cut/fill with co-registration honesty), and a **clip box**

--- a/README.md
+++ b/README.md
@@ -416,10 +416,10 @@ The current release is **v0.5.1**. The full, dated history is in
 [CHANGELOG.md](CHANGELOG.md); the highlights below are a reverse-chronological
 summary.
 
-### v0.5.1 — Auditable volume · classification editing · signed reports
+### v0.5.1 — Auditable volume · classification editing · integrity reports
 - **Stockpile / earthworks volume with a confidence band** — the lasso volume readout states its own uncertainty (sampling error + a systematic base-plane term, combined in quadrature) with a show-the-math breakdown and honest caveats
 - **Manual classification editing** end-to-end: a class picker + **lasso-reclassify** tool with real **multi-step undo/redo**; edits mutate the live class channel and round-trip straight into LAS export, and they bump a per-cloud **edit epoch** that invalidates any stale analysis/grade
-- **Tamper-evident signed report** — measurements export as a JSON report whose findings, provenance, and classification edit-epoch are hashed into a verifiable signature, plus a **two-epoch change-detection band** that reports whether a change even exceeds its own error
+- **Tamper-evident integrity report** — measurements export as a JSON report whose findings, provenance, and classification edit-epoch are hashed into a verifiable content digest (catches accidental/casual edits; not a cryptographic signature), plus a **two-epoch change-detection band** that reports whether a change even exceeds its own error
 
 ### v0.5.0 — Measure · Place · Compare · Share
 - The **v0.5 line**: measure tools that **snap** to real returns or to placed geometry, **KML export** of annotations/measurements/views for georeferenced scans, a **Layers** panel (show/hide, isolate, lock, CRS-mismatch flagging), **two-epoch change detection** (cut/fill with co-registration honesty), and a **clip box**

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # OpenLiDARViewer
 
 [![CI](https://github.com/aurtechmx/openlidarviewer/actions/workflows/ci.yml/badge.svg)](https://github.com/aurtechmx/openlidarviewer/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/aurtechmx/openlidarviewer?color=2F6BFF)](https://github.com/aurtechmx/openlidarviewer/releases/latest)
+[![Live demo](https://img.shields.io/badge/live%20demo-lidar.aurtech.mx-19C2D8)](https://lidar.aurtech.mx/)
 ![Status](https://img.shields.io/badge/status-R%26D%20Prototype-teal)
 ![Rendering](https://img.shields.io/badge/rendering-WebGL%20%2F%20WebGPU-blue)
 ![Privacy](https://img.shields.io/badge/privacy-local--first-green)
 ![License](https://img.shields.io/badge/license-MIT-lightgrey)
+[![Stars](https://img.shields.io/github/stars/aurtechmx/openlidarviewer?style=flat&color=f5c518)](https://github.com/aurtechmx/openlidarviewer/stargazers)
 
 ![OpenLiDARViewer — point-cloud exploration without the desktop overhead](docs/screenshots/openlidarviewer-promo.jpg)
 
@@ -15,6 +18,10 @@ Local-first. Cited. Honest about what it can't tell you.
 **Live version: [https://lidar.aurtech.mx/](https://lidar.aurtech.mx/)**
 
 **New here? Read the [User Guide](docs/USER_GUIDE.md)** — open a scan, measure, analyse terrain, compare two scans, and share your work, with nothing uploaded.
+
+### Try it in 10 seconds
+
+No install, no account, no upload. Open **[lidar.aurtech.mx](https://lidar.aurtech.mx/)**, then drag a `.las`, `.laz`, or `.copc.laz` file (or paste a remote COPC / `ept.json` URL) onto the page. You're navigating the cloud in your browser, and the file never leaves your device.
 
 ---
 
@@ -513,6 +520,26 @@ OpenLiDARViewer is an active R&D-stage project focused on lightweight visualizat
 - Eye Dome Lighting is a screen-space depth cue, not physically-based lighting; it is off by default on the WebGL 2 fallback and on mobile.
 
 Full detail is in [`docs/limitations.md`](docs/limitations.md).
+
+## FAQ
+
+**Can I view LAS / LAZ / COPC files in the browser?**
+Yes. Drag a `.las`, `.laz`, or `.copc.laz` onto [lidar.aurtech.mx](https://lidar.aurtech.mx/), or paste a remote COPC / `ept.json` URL. No install, no plugin.
+
+**Is my data uploaded anywhere?**
+No. Files are read and rendered locally in your browser. The only network calls are for remote datasets you choose to open; your local files never leave your device.
+
+**What's the largest scan it can open?**
+Local files are bounded by browser memory and GPU. For very large datasets, stream them as COPC (local or remote) or convert with PDAL / Entwine — streaming only loads the resident set the camera needs.
+
+**Which formats are supported?**
+LAS / LAZ, PLY, XYZ / CSV, E57, and glTF / GLB for static loads; COPC and EPT for streaming. See [Supported / Target Formats](#supported--target-formats).
+
+**Is it survey-grade?**
+No. Measurements and quality grades describe the data you loaded; they are not a survey-grade certification. Validate against ground control where accuracy matters.
+
+**Does it need WebGPU?**
+No. WebGPU is the primary path and it falls back to WebGL 2 automatically.
 
 ## Contributing
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -24,7 +24,7 @@ hardening steps are deliberately staged and easy to forget.
 - [ ] `npm run test:build` (plain-build chunk-isolation contract + orbit smoke)
 - [ ] `npm run test:buckets:verify`
 - [ ] `npm run test:unit && npm run test:terrain && npm run test:ui && npm run test:slow`
-- [ ] `npm run test:smoke` and `npm run test:e2e` (need a browser/GPU; run where available)
+- [ ] `npm run test:smoke`, then `npm run test:smoke:live` (boots the obfuscated artifact users actually get), and `npm run test:e2e` (need a browser/GPU; run where available)
 - [ ] `npm audit --omit=dev --audit-level=high` clean
 
 ## 3. Local-first / security gates

--- a/RELEASE_NOTES_v0.5.1.md
+++ b/RELEASE_NOTES_v0.5.1.md
@@ -1,0 +1,69 @@
+# OpenLiDARViewer v0.5.1
+
+A point release that deepens the honesty moat and sharpens day-to-day handling.
+Every new number still carries its own uncertainty and caveat, and nothing is
+uploaded — the scan stays on your device.
+
+## Measure with an auditable band
+
+Stockpile and earthworks volumes drawn with the lasso now report a ± confidence
+band that states its own uncertainty: a sampling-error term and a systematic
+base-plane term (a single horizontal base under sloped ground biases every
+thickness the same way) combined in quadrature, with a show-the-math breakdown
+and plain caveats. When the loaded cloud was automatically reduced to fit your
+device, the volume says so — the inside points are a representative sample of a
+denser survey, and the band already widens to match.
+
+## Edit the classification, honestly
+
+A class picker and a lasso-reclassify tool let you correct a derived
+classification by hand, with real multi-step undo and redo. Edits mutate the
+live class channel, so they round-trip straight into a LAS export — and each
+edit invalidates stale analysis, so the next Analyse recomputes against the
+classes you actually see rather than serving a grade that no longer matches.
+
+## Hand over something verifiable
+
+Placed measurements export as a tamper-evident signed report: the findings,
+dataset provenance, and classification edit-epoch are folded into a verifiable
+signature. Alter any figure and verification breaks. Two-epoch change detection
+now also reports a volume-change ± band and whether the net change exceeds its
+own error, so noise is never presented as a confident gain or loss.
+
+## Smoother to drive
+
+- **Undo reaches every edit.** Ctrl/Cmd+Z (Shift+Z or Ctrl+Y to redo) now undoes
+  whichever history you touched last — annotations or classification — instead
+  of only annotations.
+- **Hold Space to re-orient.** While a tool is active, hold Space to rotate, pan,
+  and zoom without leaving the tool, then release to resume.
+- **Right-click menu** on the scan: focus the pivot on the point under the
+  cursor, frame the scan, or snap to a standard view.
+- **Accurate keyboard help**, and **more detail on capable desktops** — high-end
+  machines keep more of a dense survey resident before automatic reduction.
+
+## Fixes
+
+- **Reliable downloads.** Every export now funnels through one helper that
+  releases the temporary blob URL only after the download has had a moment to
+  start, fixing cancelled PDF / DEM / batch-ZIP / signed-report downloads on
+  Safari, iOS, and for large generated files.
+- **Imported render state is range-checked.** A point size or field-of-view read
+  from a saved session is clamped to a sane range, so a corrupted session file
+  can't load the viewer into an unusable display.
+- **Stockpile base-plane honesty.** Base uncertainty models the systematic
+  mis-fit of a flat base under sloped ground, not just point scatter.
+
+The confidence figures and quality grades describe the delivered data; they are
+not a survey-grade certification. Treat terrain products, exports, and epoch
+comparisons as deliverable-ready only when the assessment reads **Good**, and
+validate against ground control where survey-grade accuracy is required.
+
+See [CHANGELOG.md](./CHANGELOG.md) for the full list.
+
+## Deploy
+
+Static files — host anywhere (GitHub Pages, Netlify, any CDN). The deploy zip
+extracts with web-safe permissions (644 files / 755 directories) and carries
+`index.html` plus `assets/` at the archive root, along with `.htaccess` and
+`_headers` for host-side security headers.

--- a/RELEASE_NOTES_v0.5.1.md
+++ b/RELEASE_NOTES_v0.5.1.md
@@ -24,9 +24,11 @@ classes you actually see rather than serving a grade that no longer matches.
 
 ## Hand over something verifiable
 
-Placed measurements export as a tamper-evident signed report: the findings,
+Placed measurements export as a tamper-evident integrity report: the findings,
 dataset provenance, and classification edit-epoch are folded into a verifiable
-signature. Alter any figure and verification breaks. Two-epoch change detection
+content digest (named in the file). Change any figure without recomputing the
+digest and verification breaks — a guard against accidental or casual edits, not
+a cryptographic signature. Two-epoch change detection
 now also reports a volume-change ± band and whether the net change exceeds its
 own error, so noise is never presented as a confident gain or loss.
 
@@ -46,7 +48,7 @@ own error, so noise is never presented as a confident gain or loss.
 
 - **Reliable downloads.** Every export now funnels through one helper that
   releases the temporary blob URL only after the download has had a moment to
-  start, fixing cancelled PDF / DEM / batch-ZIP / signed-report downloads on
+  start, fixing cancelled PDF / DEM / batch-ZIP / integrity-report downloads on
   Safari, iOS, and for large generated files.
 - **Imported render state is range-checked.** A point size or field-of-view read
   from a saved session is clamped to a sane range, so a corrupted session file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlidarviewer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlidarviewer",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test:build": "npm run build && BUILD_CONTRACT=1 vitest run tests/chunkIsolation.test.ts tests/orbitSmoke.test.ts",
     "test:e2e": "playwright test",
     "test:smoke": "playwright test tests/e2e/smoke.spec.ts",
-    "test:release": "npm run typecheck && npm run lint:main-deferral && npm run lint:unsafe-html && npm run build:live && npm run check:bundle && npm run test:buckets:verify && npm run test:unit && npm run test:terrain && npm run test:ui && npm run test:slow",
+    "test:smoke:live": "SMOKE_LIVE=1 playwright test tests/e2e/smoke.spec.ts",
+    "test:release": "npm run typecheck && npm run lint:main-deferral && npm run lint:unsafe-html && npm run build:live && npm run check:bundle && npm run test:buckets:verify && npm run test:unit && npm run test:terrain && npm run test:ui && npm run test:slow && npm run test:smoke:live",
     "lint:main-deferral": "node scripts/lint-main-deferral.mjs",
     "lint:unsafe-html": "node scripts/lint-unsafe-html.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "test:buckets:verify": "node scripts/test-bucket.mjs --verify",
     "test:build": "npm run build && BUILD_CONTRACT=1 vitest run tests/chunkIsolation.test.ts tests/orbitSmoke.test.ts",
     "test:e2e": "playwright test",
-    "test:smoke": "playwright test tests/e2e/smoke.spec.ts",
-    "test:smoke:live": "SMOKE_LIVE=1 playwright test tests/e2e/smoke.spec.ts",
+    "test:smoke": "playwright test tests/e2e/smoke.spec.ts tests/e2e/lazyChunkLoad.spec.ts",
+    "test:smoke:live": "SMOKE_LIVE=1 playwright test tests/e2e/smoke.spec.ts tests/e2e/lazyChunkLoad.spec.ts",
     "test:release": "npm run typecheck && npm run lint:main-deferral && npm run lint:unsafe-html && npm run build:live && npm run check:bundle && npm run test:buckets:verify && npm run test:unit && npm run test:terrain && npm run test:ui && npm run test:slow && npm run test:smoke:live",
     "lint:main-deferral": "node scripts/lint-main-deferral.mjs",
     "lint:unsafe-html": "node scripts/lint-unsafe-html.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlidarviewer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Open any 3D scan — drone LiDAR, terrestrial laser scan, or phone scan — instantly and privately, in a browser tab. No install, no upload, no conversion.",
   "license": "MIT",
   "type": "module",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,9 +33,16 @@ export default defineConfig({
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {
-    command: 'npm run build && npm run preview',
+    // SMOKE_LIVE boots the OBFUSCATED live artifact (the build users actually
+    // get) so the smoke gate catches live-only breakage — scrambled
+    // dynamic-import / worker-URL string literals, chunk-isolation regressions —
+    // that the plain build can never surface. Default stays the plain build for
+    // the fast e2e loop.
+    command: process.env.SMOKE_LIVE
+      ? 'npm run build:live && npm run preview'
+      : 'npm run build && npm run preview',
     url: 'http://localhost:4173',
     reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
+    timeout: 180_000,
   },
 });

--- a/src/export/measurementExport.ts
+++ b/src/export/measurementExport.ts
@@ -119,10 +119,15 @@ export function measurementMetrics(
     case 'volume':
       set('area_m2', num(polygonAreaHorizontal(pts, up) * A));
       if (m.volume) {
-        // The cut/fill record is already in cubic metres (see VolumeRecord).
-        set('cut_m3', num(m.volume.cut));
-        set('fill_m3', num(m.volume.fill));
-        set('net_m3', num(m.volume.net));
+        // cut/fill/net are stored in the cloud's native (render) linear units,
+        // exactly like every other measurement and like `formatVolumeRender` /
+        // the chain aggregator expect — so convert to cubic metres here, ×L·A
+        // (= unitToMetres³), the same factor the box-volume branch applies. For
+        // metric data L=A=1 so this is a no-op; for a foot-CRS it is the fix.
+        const V = L * A;
+        set('cut_m3', num(m.volume.cut * V));
+        set('fill_m3', num(m.volume.fill * V));
+        set('net_m3', num(m.volume.net * V));
       }
       break;
   }

--- a/src/export/measurementReport.ts
+++ b/src/export/measurementReport.ts
@@ -1,0 +1,122 @@
+/**
+ * measurementReport.ts
+ *
+ * Turns the placed measurements into a signed, tamper-evident report manifest —
+ * the "Signed report (JSON)" product, a sibling of the GeoJSON / CSV export.
+ *
+ * Each measurement becomes a {@link ReportFinding} carrying its primary metric
+ * in metres / m² / m³, and the whole document is stamped with dataset
+ * provenance, the classification edit epoch, and a signature (so a recipient can
+ * prove no figure was altered after signing). Lengths are reported in metres via
+ * the same `unitToMetres` factor the other exports use.
+ *
+ * Pure and unit-testable; the call site supplies the live measurements,
+ * up-axis, unit factor, and provenance.
+ */
+
+import type { Measurement, Vec3 } from '../render/measure/types';
+import { measurementMetrics } from './measurementExport';
+import {
+  buildReportManifest,
+  type ReportFinding,
+  type ReportManifest,
+} from '../render/measure/reportManifest';
+import type { HashFn } from '../render/measure/auditLog';
+
+export interface ReportProvenance {
+  readonly datasetId: string;
+  readonly crsName?: string;
+  readonly pointCount?: number;
+  /** ISO timestamp, supplied by the caller (keeps the build deterministic). */
+  readonly generatedAt: string;
+  readonly classificationEpoch?: number;
+}
+
+/** The headline metric + unit for each measurement kind. */
+const PRIMARY: Record<string, { readonly key: string; readonly unit: string }> = {
+  distance: { key: 'length_m', unit: 'm' },
+  polyline: { key: 'length_m', unit: 'm' },
+  height: { key: 'vertical_m', unit: 'm' },
+  angle: { key: 'angle_deg', unit: '°' },
+  slope: { key: 'grade_pct', unit: '%' },
+  profile: { key: 'length_m', unit: 'm' },
+  area: { key: 'area_m2', unit: 'm²' },
+  box: { key: 'volume_m3', unit: 'm³' },
+  volume: { key: 'fill_m3', unit: 'm³' },
+};
+
+/** One report finding per measurement, using its primary metric. */
+export function measurementsToFindings(
+  measurements: readonly Measurement[],
+  up: Vec3,
+  unitToMetres: number,
+): ReportFinding[] {
+  const findings: ReportFinding[] = [];
+  measurements.forEach((m, i) => {
+    const metrics = measurementMetrics(m, up, unitToMetres);
+    const primary = PRIMARY[m.kind];
+    let value: number | null = null;
+    let unit = '';
+    if (primary && Number.isFinite(metrics[primary.key])) {
+      value = metrics[primary.key];
+      unit = primary.unit;
+    } else {
+      // Fallback: the first metric the geometry could establish.
+      const k = Object.keys(metrics).find((key) => Number.isFinite(metrics[key]));
+      if (k) {
+        value = metrics[k];
+        unit = k.endsWith('_m2') ? 'm²' : k.endsWith('_m3') ? 'm³' : k.endsWith('_deg') ? '°' : k.endsWith('_pct') ? '%' : 'm';
+      }
+    }
+    if (value === null) return; // an incomplete measurement contributes nothing
+    findings.push({ label: m.name?.trim() || `${m.kind} ${i + 1}`, value, unit });
+  });
+  return findings;
+}
+
+/**
+ * One-call helper for the export handler: build + sign the report and return the
+ * download filename and pretty-printed JSON. Positional args keep the eager call
+ * site byte-cheap; the manifest assembly and serialization stay in this lazy
+ * chunk. Verification re-canonicalizes, so pretty-printing the file is safe.
+ */
+export function signedReportFile(
+  measurements: readonly Measurement[],
+  up: Vec3,
+  unitToMetres: number,
+  datasetId: string,
+  crsName: string | undefined,
+  generatedAt: string,
+  classificationEpoch: number,
+): { readonly filename: string; readonly text: string } {
+  const manifest = measurementsToReportManifest(measurements, up, unitToMetres, {
+    datasetId,
+    crsName,
+    generatedAt,
+    classificationEpoch,
+  });
+  return { filename: `${datasetId}-report.json`, text: JSON.stringify(manifest, null, 2) };
+}
+
+/** Build (and sign) a report manifest from the placed measurements. */
+export function measurementsToReportManifest(
+  measurements: readonly Measurement[],
+  up: Vec3,
+  unitToMetres: number,
+  provenance: ReportProvenance,
+  hashFn?: HashFn,
+): ReportManifest {
+  return buildReportManifest(
+    {
+      dataset: {
+        id: provenance.datasetId,
+        crs: provenance.crsName,
+        pointCount: provenance.pointCount,
+      },
+      generatedAt: provenance.generatedAt,
+      classificationEpoch: provenance.classificationEpoch,
+      findings: measurementsToFindings(measurements, up, unitToMetres),
+    },
+    hashFn,
+  );
+}

--- a/src/export/measurementReport.ts
+++ b/src/export/measurementReport.ts
@@ -1,14 +1,15 @@
 /**
  * measurementReport.ts
  *
- * Turns the placed measurements into a signed, tamper-evident report manifest —
- * the "Signed report (JSON)" product, a sibling of the GeoJSON / CSV export.
+ * Turns the placed measurements into a tamper-evident integrity report manifest
+ * — the "Integrity report (JSON)" product, a sibling of the GeoJSON / CSV export.
  *
  * Each measurement becomes a {@link ReportFinding} carrying its primary metric
  * in metres / m² / m³, and the whole document is stamped with dataset
- * provenance, the classification edit epoch, and a signature (so a recipient can
- * prove no figure was altered after signing). Lengths are reported in metres via
- * the same `unitToMetres` factor the other exports use.
+ * provenance, the classification edit epoch, and a content digest (so a recipient
+ * can detect a figure changed without recomputing the digest — a casual-edit
+ * guard, not a cryptographic signature). Lengths are reported in metres via the
+ * same `unitToMetres` factor the other exports use.
  *
  * Pure and unit-testable; the call site supplies the live measurements,
  * up-axis, unit factor, and provenance.

--- a/src/io/download.ts
+++ b/src/io/download.ts
@@ -1,0 +1,44 @@
+/**
+ * download.ts — the single browser-download helper.
+ *
+ * Every export path funnels through here so the object-URL revoke is ALWAYS
+ * deferred. Revoking immediately after `a.click()` is flaky on Safari / iOS and
+ * for large blobs (PDF / DEM / PNG / batch ZIP / signed report), where the
+ * download can be cancelled mid-flight because the URL is freed before the
+ * transfer starts. A short deferred revoke lets the download begin first, then
+ * releases the memory.
+ */
+
+/** Trigger a browser download of `blob` as `filename`, deferring the URL revoke. */
+export function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  // Appended + clicked + removed in one synchronous tick, so it never paints
+  // (no display:none needed); the in-DOM anchor is what Firefox requires for a
+  // programmatic click to fire.
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Defer past the click so large / Safari / iOS downloads complete.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/** Download raw bytes with an explicit MIME type. */
+export function downloadBytes(filename: string, bytes: Uint8Array, mime: string): void {
+  // Only copy when `bytes` is a partial view: `new Blob([typedArray])` serialises
+  // the WHOLE backing ArrayBuffer, so a subarray (non-zero offset or shorter
+  // length) must be sliced to its own bytes. A typed array that owns its whole
+  // buffer passes straight through — no copy of a multi-MB export payload.
+  const ab =
+    bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+      ? (bytes.buffer as ArrayBuffer)
+      : (bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer);
+  triggerDownload(new Blob([ab], { type: mime }), filename);
+}
+
+/** Download UTF-8 text (defaults to `text/plain`). */
+export function downloadText(filename: string, text: string, mime = 'text/plain'): void {
+  triggerDownload(new Blob([text], { type: mime }), filename);
+}

--- a/src/io/session.ts
+++ b/src/io/session.ts
@@ -472,7 +472,10 @@ function parseRenderSettings(v: unknown): SessionRenderSettings | null {
     typeof v.antialiasing === 'boolean';
   if (!hasAny) return null;
   return {
-    pointSize: isFiniteNumber(v.pointSize) ? v.pointSize : 1.5,
+    // Defense in depth: clamp on parse to the same [1, 8] range the Viewer and
+    // preferences enforce, so a hand-edited / corrupt session can't carry a
+    // pathological size even before it reaches setPointSize.
+    pointSize: isFiniteNumber(v.pointSize) ? Math.min(8, Math.max(1, v.pointSize)) : 1.5,
     edlEnabled: typeof v.edlEnabled === 'boolean' ? v.edlEnabled : false,
     edlStrength: isFiniteNumber(v.edlStrength) ? v.edlStrength : 0.4,
     pointSizeMode: isPointSizeMode(v.pointSizeMode) ? v.pointSizeMode : 'adaptive',

--- a/src/lazyChunks.ts
+++ b/src/lazyChunks.ts
@@ -185,6 +185,14 @@ export const loadFloorPlan = () =>
     floorPlanSvg: svg.floorPlanSvg,
   }));
 
+/**
+ * Load the manual classification-edit panel (class picker + lasso-arm +
+ * undo/redo). Only mounted once a classification exists, so the controls + their
+ * lasso tool ride this lazy chunk and never enter the startup shell. Routed here
+ * so the live source-transform never sees the import literal.
+ */
+export const loadReclassifyUi = () => import('./ui/reclassifyUi');
+
 /** Load the `?debug=1` performance overlay. Diagnostics-only chunk. */
 export const loadDebugOverlay = () => import('./ui/DebugOverlay');
 

--- a/src/lazyChunks.ts
+++ b/src/lazyChunks.ts
@@ -289,3 +289,27 @@ export const loadEmbedBridge = () => import('./ui/embedBridge');
  * fetch — a 404 console.error on every boot of the deployed site.
  */
 export const loadLasLoader = () => import('./io/loadLas');
+
+/**
+ * v0.5.1 — runtime dynamic-import seams that previously lived inline in main.ts
+ * (a transformed module). The live stringArray pass scrambles a fraction of
+ * inline `import()` specifiers each build, so an inline seam works in dev and on
+ * most builds, then silently 404s on the one where it gets scrambled (this is
+ * how the workflow-config panel crashed on the deployed build). Routing every
+ * runtime seam through this excluded module makes them deterministically safe.
+ */
+export const loadContextMenu = () => import('./ui/contextMenu');
+export const loadCommandPalette = () => import('./ui/CommandPalette');
+export const loadShortcutSheet = () => import('./ui/ShortcutSheet');
+export const loadMeasurementExport = () => import('./export/measurementExport');
+export const loadMeasurementReport = () => import('./export/measurementReport');
+export const loadKmlExport = () => import('./export/kmlExport');
+export const loadConfirmFullExport = () => import('./convert/confirmFullExport');
+export const loadFloorPlanConfidence = () =>
+  import('./terrain/space/floorplan/floorPlanConfidence');
+export const loadFullCloudGradeAction = () =>
+  import('./render/streaming/runFullCloudGradeAction');
+export const loadSession = () => import('./io/session');
+export const loadCompareEpochs = () => import('./terrain/change/compareEpochs');
+export const loadCompareDtms = () => import('./terrain/change/compareDtms');
+export const loadChangeRaster = () => import('./terrain/change/changeRaster');

--- a/src/main.ts
+++ b/src/main.ts
@@ -468,7 +468,11 @@ let pendingLassoSave: {
 const lassoVolumeTool = new LassoVolumeTool(stage.canvas, {
   onCommit: (lasso) => {
     if (!viewer) return;
-    const out = viewer.computeLassoVolume(lasso, 0.05);
+    // Native→metre factor for the source CRS (feet for a state-plane-feet
+    // cloud). Handed to computeLassoVolume so the stockpile band it returns is
+    // already converted to metres, and reused below for the m³/m² readout.
+    const lin = crsService.current()?.linearUnitToMetres ?? 1;
+    const out = viewer.computeLassoVolume(lasso, 0.05, lin);
     if (out === null) {
       pendingLassoSave = null;
       showLassoToast('Lasso volume — no points selected. Draw around a denser region.');
@@ -483,12 +487,11 @@ const lassoVolumeTool = new LassoVolumeTool(stage.canvas, {
     lassoVolumeTool.disable();
     viewer.setLassoMode(false);
     syncLassoButton();
-    // The lasso result is in the source CRS's native linear units (feet for a
-    // state-plane-feet cloud). Convert to metres before stamping m³ / m² —
-    // areas by lin², volumes by lin³ — the same factor the measure tool uses.
-    // (The CRS gate below still blocks geographic / unknown; this corrects the
-    // remaining projected-feet case the gate lets through.)
-    const lin = crsService.current()?.linearUnitToMetres ?? 1;
+    // The lasso result is in the source CRS's native linear units. Convert to
+    // metres before stamping m³ / m² — areas by lin², volumes by lin³ — the
+    // same factor the measure tool uses. (The CRS gate below still blocks
+    // geographic / unknown; this corrects the projected-feet case it lets
+    // through.)
     const lin2 = lin * lin;
     const lin3 = lin2 * lin;
     const fillM3 = (out.result.fill * lin3).toFixed(2);
@@ -527,9 +530,13 @@ const lassoVolumeTool = new LassoVolumeTool(stage.canvas, {
       crsVerdict.validity === 'safe-explicit-local'
         ? ' · units assumed metres'
         : '';
+    // `out.stockpileSuffix` is the ` · Stockpile: … ± … (±%) · confidence`
+    // band the Viewer computed over the same sample with a "lowest ground"
+    // base plane — the honest figure cloud viewers report without. Empty when
+    // there's nothing trustworthy to claim (too few points / degenerate).
     showLassoToast(
       `Volume · fill ${fillM3} m³ · cut ${cutM3} m³ · net ${netM3} m³ · ` +
-        `footprint ${areaM2} m² · ${out.selectedCount.toLocaleString()} points${budgetCaption}${crsCaveat}.`,
+        `footprint ${areaM2} m² · ${out.selectedCount.toLocaleString()} points${budgetCaption}${crsCaveat}.${out.stockpileSuffix}`,
       pendingLassoSave && crsVerdict.canSaveMeasurement
         ? { label: 'Save to session', onClick: saveLassoVolumeIfPending }
         : undefined,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2637,6 +2637,23 @@ const exportPanel = new ExportPanel({
     const stem = cloud ? baseName(cloud.name) : 'measurements';
     downloadText(`${stem}-measurements.${format === 'geojson' ? 'geojson' : 'csv'}`, text);
   },
+  exportSignedReport: async () => {
+    if (!viewer) return;
+    const ms = viewer.measure.getMeasurements();
+    if (ms.length === 0) return;
+    const cloud = activeId ? viewer.getCloud(activeId) ?? null : null;
+    const { signedReportFile } = await import('./export/measurementReport');
+    const f = signedReportFile(
+      ms,
+      viewer.measure.worldUp,
+      viewer.measure.unitToMetres,
+      cloud ? baseName(cloud.name) : 'scan',
+      cloud?.metadata?.crs?.name,
+      new Date().toISOString(),
+      activeId ? viewer.classificationEpoch(activeId) : 0,
+    );
+    downloadText(f.filename, f.text);
+  },
   exportKml: async () => {
     if (!viewer) return;
     const cloud = activeId ? viewer.getCloud(activeId) ?? null : null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -676,6 +676,17 @@ window.addEventListener('keydown', (e) => {
   // Never hijack key events from form inputs.
   if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
 
+  // Hold-Space re-orient: while a modal tool (measure / inspect / annotate) is
+  // armed, holding Space hands pointer input back to camera navigation so the
+  // user can rotate / pan / zoom mid-draw; releasing it (keyup, below) resumes
+  // the tool. Outside a tool, Space keeps its walk/fly "move up" meaning, so we
+  // only intercept it when a tool is active.
+  if (e.code === 'Space' && viewer?.toolActive) {
+    if (!e.repeat) viewer.setToolPaused(true);
+    e.preventDefault();
+    return;
+  }
+
   // Polygon-completion keyboard shortcuts — Enter commits the
   // in-progress polygon (area/volume/polyline/profile), Backspace
   // pops the most recent vertex. Both only fire while measure mode
@@ -710,6 +721,15 @@ window.addEventListener('keydown', (e) => {
     showLassoToast('Back to navigation.');
   }
 });
+
+// Releasing Space resumes the modal tool after a hold-Space re-orient.
+window.addEventListener('keyup', (e) => {
+  if (e.code === 'Space' && viewer?.toolActive) viewer.setToolPaused(false);
+});
+
+// Blur (Cmd-Tab away while holding Space, etc.) must also resume the tool, or it
+// would stay stuck in the paused/navigation state.
+window.addEventListener('blur', () => viewer?.setToolPaused(false));
 
 window.addEventListener('keydown', (e) => {
   // Another bare-key handler (e.g. `bindShortcuts`) already consumed this

--- a/src/main.ts
+++ b/src/main.ts
@@ -731,6 +731,32 @@ window.addEventListener('keyup', (e) => {
 // would stay stuck in the paused/navigation state.
 window.addEventListener('blur', () => viewer?.setToolPaused(false));
 
+// Right-click the 3-D canvas for a small navigation context menu. The menu UI
+// is lazy-loaded on first use, so it stays out of the startup shell. Only armed
+// once a scan is loaded — otherwise the browser's native menu is left alone.
+stage.canvas.addEventListener('contextmenu', (e) => {
+  if (!viewer || !activeId) return;
+  e.preventDefault();
+  const rect = stage.canvas.getBoundingClientRect();
+  const ndcX = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+  const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+  const v = viewer;
+  void import('./ui/contextMenu').then(({ showContextMenu }) => {
+    showContextMenu(e.clientX, e.clientY, [
+      {
+        label: 'Focus here',
+        run: () => {
+          if (!v.focusOnScreen(ndcX, ndcY)) v.frameAll();
+        },
+      },
+      { label: 'Frame scan', run: () => v.frameAll() },
+      { label: 'Top view', run: () => void v.setStandardView('top') },
+      { label: 'Front view', run: () => void v.setStandardView('front') },
+      { label: 'Oblique view', run: () => void v.setCameraPreset('oblique') },
+    ]);
+  });
+});
+
 window.addEventListener('keydown', (e) => {
   // Another bare-key handler (e.g. `bindShortcuts`) already consumed this
   // keystroke — never double-fire on the same key press.

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ import {
   type ThemeName,
 } from './ui/themes';
 import type { CommandPalette } from './ui/CommandPalette';
-import { ShortcutSheet } from './ui/ShortcutSheet';
+import type { ShortcutSheet } from './ui/ShortcutSheet';
 import { TourOverlay } from './ui/onboarding/TourOverlay';
 import { TourSession } from './ui/onboarding/tourSteps';
 import { findDuplicateIds, type Action } from './ui/actionRegistry';
@@ -50,6 +50,7 @@ import {
   downloadBytes as downloadFileBytes,
   downloadText,
 } from './io/download';
+import { noteEdit, pickUndo, pickRedo, withSuppressed } from './ui/undoRouter';
 import { MeasurePanel } from './ui/MeasurePanel';
 import { aggregate as aggregateMeasurements } from './render/measure/measurementChains';
 import { summarizeMeasurementTrust } from './render/measure/measurementTrust';
@@ -1338,8 +1339,25 @@ stage.overlay.append(recommendedViewChip.element);
 // v0.3.9 — keyboard shortcut sheet (open via `?`). Reads the same
 // action registry as the palette so adding a new action makes it
 // discoverable in both surfaces without a second touch.
-const shortcutSheet = new ShortcutSheet();
-stage.overlay.append(shortcutSheet.element);
+// The shortcut sheet is only ever shown on a `?` press (or the "Show keyboard
+// shortcuts" action), so it is lazy-loaded on first use to keep its ~250 lines
+// out of the startup shell. Same direct-dynamic-import pattern as the command
+// palette below.
+let shortcutSheet: ShortcutSheet | null = null;
+let shortcutSheetLoading: Promise<ShortcutSheet> | null = null;
+function loadShortcutSheet(): Promise<ShortcutSheet> {
+  if (shortcutSheet) return Promise.resolve(shortcutSheet);
+  if (!shortcutSheetLoading) {
+    shortcutSheetLoading = import('./ui/ShortcutSheet').then(({ ShortcutSheet }) => {
+      const sheet = new ShortcutSheet();
+      stage.overlay.append(sheet.element);
+      sheet.setActions(ACTION_REGISTRY);
+      shortcutSheet = sheet;
+      return sheet;
+    });
+  }
+  return shortcutSheetLoading;
+}
 
 // v0.3.9 — onboarding tour. Mounts the overlay immediately so the
 // SVG / card DOM exists; auto-starts on the first session per
@@ -1447,6 +1465,7 @@ async function runDeriveClassification(): Promise<void> {
     );
     if (id !== activeId || viewer.getCloud(id) !== cloud) return; // scan changed
     viewer.applyDerivedClassification(id, result.codes);
+    noteEdit('classification');
     lastDerivedConfidence = Number.isFinite(result.confidence) ? result.confidence : null;
     classLegendPanel.setClasses(countClasses(result.codes));
     // Surface the run's honest confidence + caveats in the legend caption, not
@@ -1531,6 +1550,7 @@ async function runFillUnclassified(): Promise<void> {
     );
     if (id !== activeId || viewer.getCloud(id) !== cloud) return; // scan changed
     viewer.applyDerivedClassification(id, result.codes);
+    noteEdit('classification');
     lastDerivedConfidence = Number.isFinite(result.confidence) ? result.confidence : null;
     classLegendPanel.setClasses(countClasses(result.codes));
     const confPct = Number.isFinite(result.confidence) ? Math.round(result.confidence * 100) : null;
@@ -1883,7 +1903,7 @@ function buildActionRegistry(): Action[] {
     keys: '?',
     hint: 'Every action and key, grouped by section.',
     keywords: ['shortcuts', 'keys', 'bindings', 'help', 'cheat', 'sheet'],
-    run: () => shortcutSheet.open(),
+    run: () => void loadShortcutSheet().then((sheet) => sheet.open()),
   });
 
   return actions;
@@ -1898,9 +1918,8 @@ if (duplicateActionIds.length > 0) {
     `Command palette: duplicate action ids: ${duplicateActionIds.join(', ')}`,
   );
 }
-// commandPalette.setActions runs in its lazy init (openCommandPalette); the
-// shortcut sheet is eager so it keeps its action list at startup.
-shortcutSheet.setActions(ACTION_REGISTRY);
+// Both the command palette and the shortcut sheet are lazy: each wires
+// ACTION_REGISTRY into its instance during its own first-use init.
 
 // Cmd-K / Ctrl-K toggles the palette. Esc inside the palette closes
 // it (handled internally), so the universal Esc handler below
@@ -1924,7 +1943,7 @@ window.addEventListener('keydown', (e) => {
   // Don't fight a chord — only the bare `?` (Shift+/ on most layouts).
   if (e.metaKey || e.ctrlKey || e.altKey) return;
   e.preventDefault();
-  shortcutSheet.toggle();
+  void loadShortcutSheet().then((sheet) => sheet.toggle());
 });
 
 // Cmd-Shift-U / Ctrl-Shift-U toggles workflow recording. When idle,
@@ -3230,7 +3249,12 @@ void viewerLoaded.then(() => {
   });
   // Persist the unit choice whenever it changes.
   viewer.measure.setOnUnitChange(persistPrefs);
-  viewer.annotate.setOnChange(refreshAnnotationPanel);
+  viewer.annotate.setOnChange(() => {
+    refreshAnnotationPanel();
+    // Mark the annotation stack as most-recently-edited so a global Undo
+    // targets it (suppressed while the router itself replays an undo/redo).
+    noteEdit('annotation');
+  });
 
   // Provenance override — when the user picks a capture type from the
   // dropdown in the Inspector's Provenance section, rebuild the
@@ -3552,10 +3576,28 @@ void viewerLoaded.then(() => {
       },
       onToggleHelp: () => helpOverlay.toggle(),
       onUndo: () => {
-        if (!helpOverlay.isOpen) viewer.annotate.undo();
+        if (helpOverlay.isOpen) return;
+        const id = activeId;
+        const canClass = !!id && viewer.canUndoClassification(id);
+        const pick = pickUndo(viewer.annotate.canUndo, canClass);
+        if (!pick) return;
+        withSuppressed(() => {
+          if (pick === 'classification' && id) viewer.undoClassification(id);
+          else viewer.annotate.undo();
+        });
+        if (pick === 'classification') reclassifyUi?.refresh();
       },
       onRedo: () => {
-        if (!helpOverlay.isOpen) viewer.annotate.redo();
+        if (helpOverlay.isOpen) return;
+        const id = activeId;
+        const canClass = !!id && viewer.canRedoClassification(id);
+        const pick = pickRedo(viewer.annotate.canRedo, canClass);
+        if (!pick) return;
+        withSuppressed(() => {
+          if (pick === 'classification' && id) viewer.redoClassification(id);
+          else viewer.annotate.redo();
+        });
+        if (pick === 'classification') reclassifyUi?.refresh();
       },
     });
   } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,7 @@ import {
 import { AnnotationPanel } from './ui/AnnotationPanel';
 import { AnalysePanel } from './ui/AnalysePanel';
 import { ClassLegendPanel } from './ui/ClassLegendPanel';
+import type { ReclassifyUi } from './ui/reclassifyUi';
 import { countClasses } from './render/class/classHistogram';
 import { deriveClassificationAsync } from './render/class/deriveClassificationAsync';
 import {
@@ -182,6 +183,7 @@ import {
   loadRgbAutoNormalize,
   loadEmbedBridge,
   loadLasLoader,
+  loadReclassifyUi,
 } from './lazyChunks';
 // Local-first usage counter. Categorical event counts only; stays in
 // localStorage; never transmitted. The `?notelemetry=1` URL flag suppresses
@@ -1455,6 +1457,7 @@ async function runDeriveClassification(): Promise<void> {
       warnings: result.warnings,
     });
     classLegendPanel.show();
+    void showReclassifyUi();
     // Honest one-line breakdown of the top classes derived.
     const total = cloud.pointCount || 1;
     const top = Object.entries(result.counts)
@@ -1531,6 +1534,7 @@ async function runFillUnclassified(): Promise<void> {
     const confPct = Number.isFinite(result.confidence) ? Math.round(result.confidence * 100) : null;
     classLegendPanel.setDerivedProvenance(true, { confidencePct: confPct, warnings: result.warnings });
     classLegendPanel.show();
+    void showReclassifyUi();
     const confText = confPct !== null ? ` Confidence ${confPct}%.` : '';
     showLassoToast(`Fill unclassified · filled ${cov.unclassified.toLocaleString()} points (heuristic); producer classes kept.${confText}`);
   } catch (err) {
@@ -2298,6 +2302,42 @@ const analysePanel = new AnalysePanel({
 let lastStreamingReportCloud: Parameters<typeof runStreamingModules>[0] | null = null;
 
 const classLegendPanel = new ClassLegendPanel();
+
+// Manual classification-edit panel — lazy-loaded and mounted just below the
+// legend the first time a classification appears, so its controls + lasso tool
+// stay out of the startup shell. `showReclassifyUi()` is called wherever a
+// classification becomes available; `hideReclassifyUi()` on detach.
+let reclassifyUi: ReclassifyUi | null = null;
+let reclassifyUiLoading: Promise<void> | null = null;
+async function showReclassifyUi(): Promise<void> {
+  if (reclassifyUi) {
+    reclassifyUi.setVisible(true);
+    reclassifyUi.refresh();
+    return;
+  }
+  // Dedupe concurrent first-mounts (a classification-load show racing an
+  // explicit one) so the panel is only ever created once.
+  if (!reclassifyUiLoading) {
+    reclassifyUiLoading = (async () => {
+      const { createReclassifyUi } = await loadReclassifyUi();
+      const ui = createReclassifyUi({
+        canvas: stage.canvas,
+        getViewer: () => viewer,
+        getActiveId: () => activeId,
+        onToast: showLassoToast,
+      });
+      classLegendPanel.element.after(ui.element);
+      reclassifyUi = ui;
+    })();
+  }
+  await reclassifyUiLoading;
+  // Cast: TS can't see the async IIFE reassign the outer `let` across the await.
+  (reclassifyUi as ReclassifyUi | null)?.setVisible(true);
+}
+function hideReclassifyUi(): void {
+  reclassifyUi?.setVisible(false);
+}
+
 classLegendPanel.onChange((visibility) => {
   viewer.applyClassVisibility(visibility);
   // Re-run the scan report so its class-dependent figures (count, density,
@@ -3128,6 +3168,7 @@ function refreshClassLegend(classification?: ArrayLike<number>): void {
   // hidden classes onto the freshly loaded one. No-op for the common case.
   viewer.applyClassVisibility(classLegendPanel.getVisibility());
   classLegendPanel.show();
+  void showReclassifyUi();
   // Reset the inspector's copy/JSON scope stamp — the fresh legend is
   // all-visible, so this clears any stamp left by a prior filtered scan.
   syncInspectClassScope();
@@ -3319,6 +3360,11 @@ if (testApi) {
         const c = activeId ? v.getCloud(activeId)?.classification : undefined;
         return c ? c[i] : -1;
       },
+      // Mount/show the reclassify panel (normally triggered when a
+      // classification appears) and re-sync its undo/redo enabled state, so the
+      // visible controls are e2e-drivable without running the full classifier.
+      showReclassify: () => showReclassifyUi(),
+      refreshReclassify: () => reclassifyUi?.refresh(),
       // EPT laszip decode-worker round-trip — the one path no other e2e
       // exercises end-to-end in a real browser: the lazy worker-client chunk
       // load, `new Worker(new URL(...))` URL resolution (the seam the live
@@ -4991,6 +5037,7 @@ async function openStreamingCopc(
   // never seeds the legend, so it stays hidden.
   classLegendPanel.setClasses(new Map());
   classLegendPanel.hide();
+  hideReclassifyUi();
   // Clear any prior filtered scan's inspector copy/JSON scope stamp.
   syncInspectClassScope();
   // Visual Export Studio — a streaming COPC cloud is now attached;
@@ -5747,6 +5794,7 @@ function resetToEmptyState(): void {
   // class list after the scan is closed. v0.4.1.
   classLegendPanel.setClasses(new Map());
   classLegendPanel.hide();
+  hideReclassifyUi();
   // Clear the inspector's copy/JSON scope stamp now there's no active filter.
   syncInspectClassScope();
   lastStreamingReportCloud = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3300,6 +3300,25 @@ if (testApi) {
       finishMeasurement: () => v.measure.finishCurrent(),
       clearMeasurements: () => v.clearMeasurements(),
       getMeasurementCount: () => v.measure.getMeasurements().length,
+      // Classification edit seam — seed a uniform class, reclassify a screen
+      // lasso, undo/redo, and read a point's class, so the reclassify tool's
+      // full flow is e2e-verifiable without running the heavy classifier.
+      seedUniformClass: (cls: number): number => {
+        if (!activeId) return 0;
+        const cloud = v.getCloud(activeId);
+        if (!cloud) return 0;
+        const n = cloud.positions.length / 3;
+        v.applyDerivedClassification(activeId, new Uint8Array(n).fill(cls));
+        return n;
+      },
+      reclassifyLasso: (lasso: ReadonlyArray<{ x: number; y: number }>, newClass: number): number =>
+        activeId ? v.reclassifyLasso(activeId, lasso, newClass).changedCount : 0,
+      undoClass: (): boolean => (activeId ? v.undoClassification(activeId) : false),
+      redoClass: (): boolean => (activeId ? v.redoClassification(activeId) : false),
+      classAt: (i: number): number => {
+        const c = activeId ? v.getCloud(activeId)?.classification : undefined;
+        return c ? c[i] : -1;
+      },
       // EPT laszip decode-worker round-trip — the one path no other e2e
       // exercises end-to-end in a real browser: the lazy worker-client chunk
       // load, `new Worker(new URL(...))` URL resolution (the seam the live

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,11 @@ import {
   CAMERA_PRESET_ORDER,
 } from './render/camera/cameraPresets';
 import { LassoVolumeTool } from './ui/LassoVolumeTool';
+import {
+  triggerDownload,
+  downloadBytes as downloadFileBytes,
+  downloadText,
+} from './io/download';
 import { MeasurePanel } from './ui/MeasurePanel';
 import { aggregate as aggregateMeasurements } from './render/measure/measurementChains';
 import { summarizeMeasurementTrust } from './render/measure/measurementTrust';
@@ -1046,10 +1051,7 @@ const inspector = new Inspector({
               wkt: wf.wkt,
             });
             if (pkg) {
-              downloadBlob(
-                pkg.filename,
-                new Blob([pkg.zip as BlobPart], { type: 'application/zip' }),
-              );
+              triggerDownload(new Blob([pkg.zip as BlobPart], { type: 'application/zip' }), pkg.filename);
               recordUsage('export', mode);
               dropZone.setProgress(null);
               return;
@@ -1058,7 +1060,7 @@ const inspector = new Inspector({
             console.warn('[image-export] world-file packaging failed — shipping bare PNG:', err);
           }
         }
-        downloadBlob(`${base}-${mode}.png`, result.blob);
+        triggerDownload(result.blob, `${base}-${mode}.png`);
         recordUsage('export', mode);
         dropZone.setProgress(null);
       })
@@ -2487,16 +2489,6 @@ function floorPlanPositions(ctx: SpaceExportContext): Float32Array {
   return ctx.positions;
 }
 
-/** Download bytes as a file (Blob → anchor click). */
-function downloadFileBytes(filename: string, bytes: Uint8Array, mime: string): void {
-  const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
-  const url = URL.createObjectURL(new Blob([ab], { type: mime }));
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
-}
 
 // Object-scan panel — shown instead of terrain analysis for compact 3-D scans
 // (phone scans of objects / rooms). "Run anyway" reveals + runs the terrain
@@ -4211,7 +4203,7 @@ async function generateReportPdf(templateId: string): Promise<void> {
   // The download filename now mirrors the template choice so the
   // user's Downloads folder distinguishes a Survey Summary from an
   // Engineering Inspection at a glance.
-  downloadBlob(`${exportFileStem}-${validatedTemplateId}.pdf`, result.blob);
+  triggerDownload(result.blob, `${exportFileStem}-${validatedTemplateId}.pdf`);
   // Per-section render failures are caught by the engine's isolation pass
   // and surfaced as a `failedSections` list — the PDF still ships but
   // misses those sections. Tell the user so they're not surprised by a
@@ -4227,24 +4219,6 @@ async function generateReportPdf(templateId: string): Promise<void> {
   }
 }
 
-/** Trigger a client-side download of text content. */
-function downloadText(filename: string, text: string): void {
-  const blob = new Blob([text], { type: 'text/plain' });
-  downloadBlob(filename, blob);
-}
-
-/**
- * Trigger a client-side download of a `Blob`. Used by the Visual Export
- * Studio for PNG downloads where the exporter has already produced a Blob.
- */
-function downloadBlob(filename: string, blob: Blob): void {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = filename;
-  link.click();
-  URL.revokeObjectURL(url);
-}
 
 /**
  * Push the Viewer's current render-quality state into the Inspector chips.

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,7 @@ import { TourOverlay } from './ui/onboarding/TourOverlay';
 import { TourSession } from './ui/onboarding/tourSteps';
 import { findDuplicateIds, type Action } from './ui/actionRegistry';
 import { WorkflowController, WORKFLOW_RECORDER_ENABLED } from './ui/WorkflowController';
-import { WorkflowConfigPanel } from './ui/WorkflowConfigPanel';
+import type { WorkflowConfigPanel } from './ui/WorkflowConfigPanel';
 import { RecommendedViewChip } from './ui/RecommendedViewChip';
 import { recommendCameraPreset, flatnessFromBounds } from './render/camera/recommendView';
 import type { WorkflowEvent } from './render/workflow/workflowRecorder';
@@ -1314,14 +1314,21 @@ const crsCoordinator = createCrsCoordinator({
 // mounted — and the shortcut / palette entries only registered —
 // when the flag is on.
 const workflowController = new WorkflowController();
-const workflowConfigPanel = new WorkflowConfigPanel();
+// The settings popup is only reachable when the recorder flag is on, so its
+// ~290 lines are lazy-loaded inside that branch instead of shipping in the
+// startup shell (the flag is OFF by default, so it never loads at all).
+let workflowConfigPanel: WorkflowConfigPanel | null = null;
 if (WORKFLOW_RECORDER_ENABLED) {
   stage.overlay.append(workflowController.badge);
-  stage.overlay.append(workflowConfigPanel.element);
-  // Edits in the settings popup take effect immediately and persist.
-  workflowConfigPanel.onChange((cfg) => {
-    workflowController.setConfig(cfg);
-    persistPrefs();
+  void import('./ui/WorkflowConfigPanel').then(({ WorkflowConfigPanel }) => {
+    const panel = new WorkflowConfigPanel();
+    workflowConfigPanel = panel;
+    stage.overlay.append(panel.element);
+    // Edits in the settings popup take effect immediately and persist.
+    panel.onChange((cfg) => {
+      workflowController.setConfig(cfg);
+      persistPrefs();
+    });
   });
 }
 
@@ -1919,7 +1926,7 @@ function buildActionRegistry(): Action[] {
         section: 'Workflow',
         hint: 'Format, save location, shortcut, replay speed, capture scope.',
         keywords: ['config', 'options', 'preferences', 'shortcut', 'speed'],
-        run: () => workflowConfigPanel.open(),
+        run: () => workflowConfigPanel?.open(),
       },
     );
   }
@@ -4391,7 +4398,7 @@ function applyPrefs(): void {
   }
   if (p.workflow !== undefined) {
     workflowController.setConfig(p.workflow);
-    workflowConfigPanel.setConfig(p.workflow);
+    workflowConfigPanel?.setConfig(p.workflow);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,7 @@ import { TourOverlay } from './ui/onboarding/TourOverlay';
 import { TourSession } from './ui/onboarding/tourSteps';
 import { findDuplicateIds, type Action } from './ui/actionRegistry';
 import { WorkflowController, WORKFLOW_RECORDER_ENABLED } from './ui/WorkflowController';
-import type { WorkflowConfigPanel } from './ui/WorkflowConfigPanel';
+import { WorkflowConfigPanel } from './ui/WorkflowConfigPanel';
 import { RecommendedViewChip } from './ui/RecommendedViewChip';
 import { recommendCameraPreset, flatnessFromBounds } from './render/camera/recommendView';
 import type { WorkflowEvent } from './render/workflow/workflowRecorder';
@@ -1314,21 +1314,18 @@ const crsCoordinator = createCrsCoordinator({
 // mounted — and the shortcut / palette entries only registered —
 // when the flag is on.
 const workflowController = new WorkflowController();
-// The settings popup is only reachable when the recorder flag is on, so its
-// ~290 lines are lazy-loaded inside that branch instead of shipping in the
-// startup shell (the flag is OFF by default, so it never loads at all).
-let workflowConfigPanel: WorkflowConfigPanel | null = null;
+// Eager on purpose. A flag-gated *dynamic* import gets its chunk tree-shaken
+// away (the only caller sits behind `if (WORKFLOW_RECORDER_ENABLED)`, false by
+// default) while the import() statement survives — a dangling specifier that
+// 404s only on the obfuscated live build. The static import keeps it whole.
+const workflowConfigPanel = new WorkflowConfigPanel();
 if (WORKFLOW_RECORDER_ENABLED) {
   stage.overlay.append(workflowController.badge);
-  void import('./ui/WorkflowConfigPanel').then(({ WorkflowConfigPanel }) => {
-    const panel = new WorkflowConfigPanel();
-    workflowConfigPanel = panel;
-    stage.overlay.append(panel.element);
-    // Edits in the settings popup take effect immediately and persist.
-    panel.onChange((cfg) => {
-      workflowController.setConfig(cfg);
-      persistPrefs();
-    });
+  stage.overlay.append(workflowConfigPanel.element);
+  // Edits in the settings popup take effect immediately and persist.
+  workflowConfigPanel.onChange((cfg) => {
+    workflowController.setConfig(cfg);
+    persistPrefs();
   });
 }
 
@@ -1926,7 +1923,7 @@ function buildActionRegistry(): Action[] {
         section: 'Workflow',
         hint: 'Format, save location, shortcut, replay speed, capture scope.',
         keywords: ['config', 'options', 'preferences', 'shortcut', 'speed'],
-        run: () => workflowConfigPanel?.open(),
+        run: () => workflowConfigPanel.open(),
       },
     );
   }
@@ -4398,7 +4395,7 @@ function applyPrefs(): void {
   }
   if (p.workflow !== undefined) {
     workflowController.setConfig(p.workflow);
-    workflowConfigPanel?.setConfig(p.workflow);
+    workflowConfigPanel.setConfig(p.workflow);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2574,6 +2574,15 @@ const terrainRunner = createTerrainAnalysisRunner({
   },
 });
 
+// Honesty guard: a manual classification edit changes the bare-earth surface, so
+// any cached terrain core / on-screen grade computed from the old classes is now
+// stale. Drop the cache (and abort any in-flight compute) the moment an edit
+// lands, so the next Analyse recomputes against the edited classes instead of
+// serving a number that silently no longer matches what's on screen.
+void viewerLoaded.then((v) => {
+  v.onClassificationEdited = () => terrainRunner.abortAndClearCache();
+});
+
 // Per-cloud source files + reduced flags, so the Export panel can re-decode a
 // local file at full resolution (the viewer keeps only the display-reduced
 // cloud for large scans). Streamed/remote scans have no entry here.

--- a/src/main.ts
+++ b/src/main.ts
@@ -190,6 +190,19 @@ import {
   loadEmbedBridge,
   loadLasLoader,
   loadReclassifyUi,
+  loadContextMenu,
+  loadCommandPalette,
+  loadShortcutSheet,
+  loadMeasurementExport,
+  loadMeasurementReport,
+  loadKmlExport,
+  loadConfirmFullExport,
+  loadFloorPlanConfidence,
+  loadFullCloudGradeAction,
+  loadSession,
+  loadCompareEpochs,
+  loadCompareDtms,
+  loadChangeRaster,
 } from './lazyChunks';
 // Local-first usage counter. Categorical event counts only; stays in
 // localStorage; never transmitted. The `?notelemetry=1` URL flag suppresses
@@ -741,7 +754,7 @@ stage.canvas.addEventListener('contextmenu', (e) => {
   const ndcX = ((e.clientX - rect.left) / rect.width) * 2 - 1;
   const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
   const v = viewer;
-  void import('./ui/contextMenu').then(({ showContextMenu }) => {
+  void loadContextMenu().then(({ showContextMenu }) => {
     showContextMenu(e.clientX, e.clientY, [
       {
         label: 'Focus here',
@@ -1374,7 +1387,7 @@ function toggleWorkflowRecord(): void {
 let commandPalette: CommandPalette | null = null;
 async function openCommandPalette(): Promise<void> {
   if (!commandPalette) {
-    const { CommandPalette } = await import('./ui/CommandPalette');
+    const { CommandPalette } = await loadCommandPalette();
     commandPalette = new CommandPalette();
     stage.overlay.append(commandPalette.element);
     commandPalette.setActions(ACTION_REGISTRY);
@@ -1395,10 +1408,10 @@ stage.overlay.append(recommendedViewChip.element);
 // palette below.
 let shortcutSheet: ShortcutSheet | null = null;
 let shortcutSheetLoading: Promise<ShortcutSheet> | null = null;
-function loadShortcutSheet(): Promise<ShortcutSheet> {
+function ensureShortcutSheet(): Promise<ShortcutSheet> {
   if (shortcutSheet) return Promise.resolve(shortcutSheet);
   if (!shortcutSheetLoading) {
-    shortcutSheetLoading = import('./ui/ShortcutSheet').then(({ ShortcutSheet }) => {
+    shortcutSheetLoading = loadShortcutSheet().then(({ ShortcutSheet }) => {
       const sheet = new ShortcutSheet();
       stage.overlay.append(sheet.element);
       sheet.setActions(ACTION_REGISTRY);
@@ -1953,7 +1966,7 @@ function buildActionRegistry(): Action[] {
     keys: '?',
     hint: 'Every action and key, grouped by section.',
     keywords: ['shortcuts', 'keys', 'bindings', 'help', 'cheat', 'sheet'],
-    run: () => void loadShortcutSheet().then((sheet) => sheet.open()),
+    run: () => void ensureShortcutSheet().then((sheet) => sheet.open()),
   });
 
   return actions;
@@ -1993,7 +2006,7 @@ window.addEventListener('keydown', (e) => {
   // Don't fight a chord — only the bare `?` (Shift+/ on most layouts).
   if (e.metaKey || e.ctrlKey || e.altKey) return;
   e.preventDefault();
-  void loadShortcutSheet().then((sheet) => sheet.toggle());
+  void ensureShortcutSheet().then((sheet) => sheet.toggle());
 });
 
 // Cmd-Shift-U / Ctrl-Shift-U toggles workflow recording. When idle,
@@ -2632,7 +2645,7 @@ const objectPanel = new ObjectPanel({
     // Surface a one-glance confidence read in the panel. Computed here, inside
     // the already-loaded lazy floor-plan chunk, so the panel needs only the
     // plain struct (no heavy floor-plan code in its bundle).
-    const { floorPlanConfidence } = await import('./terrain/space/floorplan/floorPlanConfidence');
+    const { floorPlanConfidence } = await loadFloorPlanConfidence();
     objectPanel.showFloorPlanSummary(floorPlanConfidence(plan));
   },
 });
@@ -2707,7 +2720,7 @@ const exportPanel = new ExportPanel({
     // confirm before decoding a large source. The confirm pulls the dialog +
     // byte formatter, so it's lazy-loaded here (full-res export is a deliberate
     // action) to keep it out of the eager startup chunk. Declining aborts.
-    const { confirmFullExport } = await import('./convert/confirmFullExport');
+    const { confirmFullExport } = await loadConfirmFullExport();
     if (!(await confirmFullExport(f))) return null;
     return decodeFull(await f.arrayBuffer(), f.name);
   },
@@ -2719,7 +2732,7 @@ const exportPanel = new ExportPanel({
     if (!viewer) return;
     const measurements = viewer.measure.getMeasurements();
     if (measurements.length === 0) return;
-    const { measurementsToGeoJSON, measurementsToCsv } = await import('./export/measurementExport');
+    const { measurementsToGeoJSON, measurementsToCsv } = await loadMeasurementExport();
     const cloud = activeId ? viewer.getCloud(activeId) ?? null : null;
     // Measurement points are LOCAL (recentered); add the origin back to land them
     // in the source projected/local frame. Geographic reprojection (→ lon/lat) is
@@ -2743,7 +2756,7 @@ const exportPanel = new ExportPanel({
     const ms = viewer.measure.getMeasurements();
     if (ms.length === 0) return;
     const cloud = activeId ? viewer.getCloud(activeId) ?? null : null;
-    const { signedReportFile } = await import('./export/measurementReport');
+    const { signedReportFile } = await loadMeasurementReport();
     const f = signedReportFile(
       ms,
       viewer.measure.worldUp,
@@ -2761,7 +2774,7 @@ const exportPanel = new ExportPanel({
     const origin = cloud?.origin ?? [0, 0, 0];
     const toLonLat = makeLocalToLonLat(crsService.current(), origin);
     if (!toLonLat) return; // gated by kmlStatus; defensive no-op if reached
-    const { buildKml } = await import('./export/kmlExport');
+    const { buildKml } = await loadKmlExport();
     const input: KmlExportInput = {
       annotations: viewer.annotate.getAnnotations(),
       measurements: viewer.measure.getMeasurements(),
@@ -3770,7 +3783,7 @@ async function runFullCloudGradeAction(): Promise<void> {
   fullCloudGradeRunning = true;
   fullCloudGradeController = new AbortController();
   try {
-    const { runFullCloudGrade } = await import('./render/streaming/runFullCloudGradeAction');
+    const { runFullCloudGrade } = await loadFullCloudGradeAction();
     await runFullCloudGrade({
       viewer,
       panel: streamingPanel,
@@ -4518,7 +4531,7 @@ function applyShareState(state: ShareState, cloud: PointCloud): void {
  * and reopened without loss.
  */
 async function exportSession(): Promise<void> {
-  const { serializeSession } = await import('./io/session');
+  const { serializeSession } = await loadSession();
   const cloud = activeId ? viewer.getCloud(activeId) : undefined;
   const upAxis: 'y' | 'z' = cloud && isZUpFormat(cloud.sourceFormat) ? 'z' : 'y';
 
@@ -4596,7 +4609,7 @@ async function importSession(file: File): Promise<void> {
     // access below is safe (measure/annotate are built in the Viewer ctor, so
     // no GPU backend is needed — just a non-null instance).
     await viewerLoaded;
-    const { parseSession } = await import('./io/session');
+    const { parseSession } = await loadSession();
     const session = parseSession(await file.text());
     viewer.measure.loadMeasurements(session.measurements);
     viewer.annotate.loadAnnotations(session.annotations);
@@ -5987,9 +6000,9 @@ function compareLoadedLayers(): void {
     // "working" line paints before the synchronous ground-filter compute.
     const [{ buildSharedEpochDtms }, { compareDtms, summarizeChange }, { changeToEsriAscii }] =
       await Promise.all([
-        import('./terrain/change/compareEpochs'),
-        import('./terrain/change/compareDtms'),
-        import('./terrain/change/changeRaster'),
+        loadCompareEpochs(),
+        loadCompareDtms(),
+        loadChangeRaster(),
       ]);
     await new Promise((resolve) => setTimeout(resolve, 16));
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6111,12 +6111,7 @@ async function saveSnapshot(): Promise<void> {
     // app undisclosed. With an empty stamp (nothing hidden) the helper returns
     // the input Blob unchanged, keeping the snapshot byte-identical to before.
     const stamped = await composeClassScopeBannerOntoBlob(blob, currentClassScopeStamp());
-    const url = URL.createObjectURL(stamped);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'openlidarviewer.png';
-    link.click();
-    URL.revokeObjectURL(url);
+    triggerDownload(stamped, 'openlidarviewer.png');
   } catch {
     dropZone.setError('Could not save the view');
   }

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -3699,6 +3699,18 @@ export class Viewer {
   // ─────────────────────────────────────────────────────────────────────────
 
   /**
+   * Pick the point under a screen-NDC position and glide the orbit pivot to it
+   * (the right-click "Focus here" gesture, shared with double-click). Returns
+   * false when nothing is under the cursor so the caller can fall back.
+   */
+  focusOnScreen(ndcX: number, ndcY: number): boolean {
+    const point = this._pickPoint(ndcX, ndcY);
+    if (!point) return false;
+    this._nav.focusOn(point);
+    return true;
+  }
+
+  /**
    * Fit the camera to encompass all visible clouds, gliding to an oblique
    * overview rather than snapping there.
    */

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -2872,12 +2872,16 @@ export class Viewer {
    * Applies to every loaded cloud's material.
    */
   setPointSize(size: number): void {
-    this._pointSize = size;
+    // Clamp at the source of truth: imported share/session/preset state can hand
+    // in a non-finite or pathological value (a hand-edited `.olvsession` with
+    // `pointSize: 1e9` would push a giant sprite to the GPU). Bound to the same
+    // [1, 8] range the preferences clamp uses; non-finite falls back to 2.
+    this._pointSize = Math.min(8, Math.max(1, Number.isFinite(size) ? size : 2));
     // Splat mode applies a constant per-mode multiplier on the way to
-    // the GPU. The user-displayed size stays `size`; the rendered
+    // the GPU. The user-displayed size stays `this._pointSize`; the rendered
     // sprite is multiplied so neighbouring samples kiss in Soft /
     // Inspection mode without changing the "5 px" the user typed in.
-    const effective = size * splatRadiusMultiplier(this._splatMode);
+    const effective = this._pointSize * splatRadiusMultiplier(this._splatMode);
     this._pointSizeUniform.value = effective;
     for (const { material } of this._clouds.values()) {
       material.size = effective;
@@ -3162,7 +3166,10 @@ export class Viewer {
    */
   applyCameraState(state: SavedCameraState): void {
     if (state.mode && state.mode !== this._nav.mode) this._nav.setMode(state.mode);
-    const fov = state.fov ?? DEFAULT_FOV;
+    // Clamp imported FOV to a sane perspective range — a share/session file
+    // could carry a non-finite or extreme value that breaks the projection.
+    const rawFov = state.fov ?? DEFAULT_FOV;
+    const fov = Math.min(120, Math.max(10, Number.isFinite(rawFov) ? rawFov : DEFAULT_FOV));
     if (this._camera.fov !== fov) {
       this._camera.fov = fov;
       this._camera.updateProjectionMatrix();

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -77,6 +77,7 @@ import {
   selectByLasso,
   volumeFromLassoWithFootprint,
 } from './measure/lassoVolume';
+import { stockpileToastSuffix } from './measure/stockpilePresenter';
 import {
   cameraPresetPose,
   standardViewPose,
@@ -96,6 +97,14 @@ import {
 export interface LassoVolumeReturn {
   /** Cut / fill / footprint computed against the selected 3D points. */
   readonly result: VolumeResult;
+  /**
+   * The stockpile band suffix for the toast: ` · Stockpile: V ± σ (±%) ·
+   * confidence`, re-graded over the same selected sample with a "lowest
+   * ground" base plane and converted to metres via the `lin` factor passed to
+   * {@link Viewer.computeLassoVolume}. Empty when there's nothing trustworthy
+   * to claim (too few points / degenerate footprint).
+   */
+  readonly stockpileSuffix: string;
   /** Number of cloud points that fell inside the lasso. */
   readonly selectedCount: number;
   /** The lasso path the user drew (echoed back for the report card). */
@@ -3095,10 +3104,14 @@ export class Viewer {
    *   0..clientHeight). At least 3 vertices required.
    * @param percentile - Reference-plane percentile in `[0, 1]`.
    *   Defaults to 0.05 — bottom 5 % of selected Z values is "ground".
+   * @param lin - `linearUnitToMetres` for the source CRS, used to convert the
+   *   returned {@link LassoVolumeReturn.stockpileSuffix} band into metres.
+   *   Defaults to 1 (native units already metres).
    */
   computeLassoVolume(
     lasso: ReadonlyArray<{ readonly x: number; readonly y: number }>,
     percentile: number = 0.05,
+    lin: number = 1,
   ): LassoVolumeReturn | null {
     if (lasso.length < 3) return null;
 
@@ -3230,6 +3243,11 @@ export class Viewer {
     });
     return {
       result: lassoOut.result,
+      stockpileSuffix: stockpileToastSuffix(
+        lassoOut.polygon3D as ReadonlyArray<[number, number, number]>,
+        selectedPositions,
+        lin,
+      ),
       selectedCount: totalSelected,
       lasso,
       selectionByCloudId,

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -153,6 +153,7 @@ import {
   type ClassEditResult,
 } from './measure/classificationEditor';
 import { ClassEditHistory, recordEdit } from './measure/classEditHistory';
+import { ClassificationEpochs } from './measure/classificationEpoch';
 import {
   getPreset,
   type PresetId,
@@ -1953,6 +1954,7 @@ export class Viewer {
     // Drop the per-cloud undo / highlight snapshots too — without this the
     // maps retain full-size buffers for every cloud ever removed (leak).
     this._classHistory.delete(id);
+    this._classEpochs.forget(id);
     this._selectionSnapshots.delete(id);
     // Refresh the orbit-clamp envelope so removing the last static cloud
     // doesn't leave the camera clamping to its ghost bounds.
@@ -2593,6 +2595,17 @@ export class Viewer {
   /** Per-cloud multi-step classification undo/redo history (delta-based). */
   private readonly _classHistory = new Map<string, ClassEditHistory>();
 
+  /** Per-cloud edit epochs so stale analysis/grade/exports can be detected. */
+  private readonly _classEpochs = new ClassificationEpochs();
+
+  /**
+   * Fires after any classification edit (swap / reclassify / undo / redo) that
+   * actually changed points, with the cloud id. The analysis runner subscribes
+   * to invalidate its terrain-core cache and re-grade, so a manual edit never
+   * leaves a stale bare-earth surface or grade on screen.
+   */
+  onClassificationEdited?: (id: string) => void;
+
   private _historyFor(id: string): ClassEditHistory {
     let h = this._classHistory.get(id);
     if (!h) {
@@ -2600,6 +2613,21 @@ export class Viewer {
       this._classHistory.set(id, h);
     }
     return h;
+  }
+
+  private _markClassificationEdited(id: string): void {
+    this._classEpochs.bump(id);
+    this.onClassificationEdited?.(id);
+  }
+
+  /** The cloud's classification edit epoch (0 = never edited). */
+  classificationEpoch(id: string): number {
+    return this._classEpochs.current(id);
+  }
+
+  /** Whether a result stamped at `epoch` was invalidated by a later edit. */
+  isClassificationStale(id: string, epoch: number): boolean {
+    return this._classEpochs.isStale(id, epoch);
   }
 
   /**
@@ -2620,7 +2648,10 @@ export class Viewer {
     recordEdit(this._historyFor(id), buf, () => {
       result = applyClassSwap(buf, fromClass, toClass);
     });
-    if (result.changedCount > 0) this._refreshClassificationColours(id);
+    if (result.changedCount > 0) {
+      this._refreshClassificationColours(id);
+      this._markClassificationEdited(id);
+    }
     return result;
   }
 
@@ -2660,7 +2691,10 @@ export class Viewer {
         includeIf,
       });
     });
-    if (result.changedCount > 0) this._refreshClassificationColours(id);
+    if (result.changedCount > 0) {
+      this._refreshClassificationColours(id);
+      this._markClassificationEdited(id);
+    }
     return result;
   }
 
@@ -2675,6 +2709,7 @@ export class Viewer {
     if (!entry || !entry.cloud.classification || !h || !h.canUndo) return false;
     h.undo(entry.cloud.classification);
     this._refreshClassificationColours(id);
+    this._markClassificationEdited(id);
     return true;
   }
 
@@ -2689,6 +2724,7 @@ export class Viewer {
     if (!entry || !entry.cloud.classification || !h || !h.canRedo) return false;
     h.redo(entry.cloud.classification);
     this._refreshClassificationColours(id);
+    this._markClassificationEdited(id);
     return true;
   }
 
@@ -4493,6 +4529,7 @@ export class Viewer {
     // `removeCloud` drops each cloud's snapshots, but clear both maps
     // outright in case a snapshot ever outlived its cloud entry.
     this._classHistory.clear();
+    this._classEpochs.clear();
     this._selectionSnapshots.clear();
     this.detachStreamingCloud();
     this._nav.dispose();

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -150,6 +150,7 @@ import { volumeCutFill } from './measure/volume';
 import {
   applyClassSwap,
   applyPolygonReclassify,
+  applyIndexReclassify,
   type ClassEditResult,
 } from './measure/classificationEditor';
 import { ClassEditHistory, recordEdit } from './measure/classEditHistory';
@@ -2690,6 +2691,49 @@ export class Viewer {
         newClass,
         includeIf,
       });
+    });
+    if (result.changedCount > 0) {
+      this._refreshClassificationColours(id);
+      this._markClassificationEdited(id);
+    }
+    return result;
+  }
+
+  /**
+   * Reclassify every point inside the screen-space lasso to `newClass`,
+   * recording the edit for undo/redo and bumping the edit epoch. Mirrors the
+   * lasso volume selection (same projector + {@link selectByLasso}) but sets
+   * classes instead of integrating volume. No-op without classification, a
+   * degenerate lasso, or a zero-size canvas. `lasso` is in CSS pixels.
+   */
+  reclassifyLasso(
+    id: string,
+    lasso: ReadonlyArray<{ readonly x: number; readonly y: number }>,
+    newClass: number,
+  ): ClassEditResult {
+    const entry = this._clouds.get(id);
+    if (!entry || !entry.cloud.classification || lasso.length < 3) {
+      return { changedCount: 0, pointCount: 0 };
+    }
+    const canvas = this._canvas;
+    if (!canvas) return { changedCount: 0, pointCount: 0 };
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    if (w === 0 || h === 0) return { changedCount: 0, pointCount: 0 };
+    this._camera.updateMatrixWorld(true);
+    const projMatrix = this._camera.projectionMatrix;
+    const viewMatrix = this._camera.matrixWorldInverse;
+    const tmp = new THREE.Vector3();
+    const project = (x: number, y: number, z: number): { x: number; y: number } | null => {
+      tmp.set(x, y, z).applyMatrix4(viewMatrix).applyMatrix4(projMatrix);
+      if (tmp.z < -1 || tmp.z > 1) return null;
+      return { x: (tmp.x * 0.5 + 0.5) * w, y: (1 - (tmp.y * 0.5 + 0.5)) * h };
+    };
+    const indices = selectByLasso({ lasso, positions: entry.cloud.positions, project });
+    const buf = entry.cloud.classification;
+    let result: ClassEditResult = { changedCount: 0, pointCount: buf.length };
+    recordEdit(this._historyFor(id), buf, () => {
+      result = applyIndexReclassify(buf, indices, newClass);
     });
     if (result.changedCount > 0) {
       this._refreshClassificationColours(id);

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -509,9 +509,10 @@ const ORTHO_FOV = 2;
  * sizes a cloud to the machine; this is the last-resort guard so that no path
  * — a future session restore, a streaming source — can ever upload a cloud
  * large enough to risk a GPU out-of-memory crash. It sits above every load
- * budget, so a normally-loaded cloud is never touched.
+ * budget (incl. the desktop `high` budget of 6 M in deviceProfile.ts), so a
+ * normally-loaded cloud is never touched — only a pathological bypass path is.
  */
-const GPU_HARD_POINT_CEILING = 5_000_000;
+const GPU_HARD_POINT_CEILING = 8_000_000;
 
 /**
  * Frame-time history length for {@link Viewer.frameStats}. Sixty samples is
@@ -3292,6 +3293,10 @@ export class Viewer {
     const selectionByCloudId = new Map<string, ReadonlyArray<number>>();
     const subsetParts: Float32Array[] = [];
     let totalSelected = 0;
+    // True once any cloud that contributes selected points was voxel-reduced to
+    // fit the device budget — the volume's honesty caveat reflects the thinner
+    // sample. (See `_cloudWasReduced`.)
+    let anySourceReduced = false;
     for (const [id, entry] of this._clouds) {
       const positions =
         stride === 1
@@ -3311,6 +3316,7 @@ export class Viewer {
           ? localIndices
           : localIndices.map((i) => i * stride);
       selectionByCloudId.set(id, sourceIndices);
+      if (this._cloudWasReduced(entry.cloud)) anySourceReduced = true;
       totalSelected += localIndices.length;
       // Pack the selected points' xyz into a contiguous buffer for
       // the volume math.
@@ -3375,6 +3381,7 @@ export class Viewer {
         lassoOut.polygon3D as ReadonlyArray<[number, number, number]>,
         selectedPositions,
         lin,
+        anySourceReduced,
       ),
       selectedCount: totalSelected,
       lasso,
@@ -3708,6 +3715,17 @@ export class Viewer {
     if (!point) return false;
     this._nav.focusOn(point);
     return true;
+  }
+
+  /**
+   * Whether a cloud's resident points are a device-budget reduction of a
+   * denser source — true when the declared source count meaningfully exceeds
+   * the resident count (voxel/stride downsample kicked in at load). Used to add
+   * an honesty caveat to volumes measured on the thinner sample.
+   */
+  private _cloudWasReduced(cloud: PointCloud): boolean {
+    const declared = cloud.declaredPointCount;
+    return declared != null && cloud.pointCount < declared * 0.95;
   }
 
   /**

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -983,6 +983,9 @@ export class Viewer {
   private _resizeObserver: ResizeObserver | null = null;
   /** Which picking tool currently owns canvas clicks. */
   private _toolMode: ToolMode = 'none';
+  // Hold-Space "re-orient" pause: a modal tool stays armed but navigation gets
+  // input back so the user can rotate / pan mid-draw, then resume on release.
+  private _toolPaused = false;
   private _measureListeners: MeasureListeners = {};
   private _inspectListeners: InspectListeners = {};
   private _annotateListeners: AnnotateListeners = {};
@@ -1390,6 +1393,9 @@ export class Viewer {
     //    across the 50-scan open/close cycle.
     this._onCanvasDblClick = (e) => this._handleDoubleClick(e, canvas);
     this._onCanvasClick = (e) => {
+      // While paused (hold-Space to re-orient), the click belongs to camera
+      // navigation, not the tool — don't place a point / pick / annotation.
+      if (this._toolPaused) return;
       if (this._toolMode === 'measure') this._handleMeasureClick(e, canvas);
       else if (this._toolMode === 'inspect') this._handleInspectClick(e, canvas);
       else if (this._toolMode === 'annotate') this._handleAnnotateClick(e, canvas);
@@ -3641,8 +3647,33 @@ export class Viewer {
    * while a click-driven tool is active; the live probe is the exception — it
    * is a passive hover readout, so navigation stays live during it.
    */
+  /** True while a modal click-to-act tool (measure / inspect / annotate) is
+   *  armed. Probe keeps navigation live, so it does not count. */
+  get toolActive(): boolean {
+    return this._toolMode === 'measure' || this._toolMode === 'inspect' || this._toolMode === 'annotate';
+  }
+
+  /**
+   * Hold-Space "re-orient" pause. While paused, a modal tool stays armed but
+   * camera navigation gets pointer input back (orbit / pan / zoom) and canvas
+   * clicks no longer act on the tool — so the user can reposition the view
+   * mid-draw, then release to resume. No-op unless a modal tool is active.
+   */
+  setToolPaused(paused: boolean): void {
+    if (!this.toolActive || this._toolPaused === paused) return;
+    this._toolPaused = paused;
+    this._nav.setInputEnabled(paused);
+    // Inspect owns its own cursor; measure / annotate use the crosshair.
+    this._canvas.style.cursor = paused
+      ? 'grab'
+      : this._toolMode === 'inspect'
+        ? ''
+        : 'crosshair';
+  }
+
   private _setToolMode(mode: ToolMode): void {
     if (mode === this._toolMode) return;
+    this._toolPaused = false;
     this._toolMode = mode;
     this._measure.setActive(mode === 'measure');
     this._inspect.setActive(mode === 'inspect');

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -150,10 +150,9 @@ import { volumeCutFill } from './measure/volume';
 import {
   applyClassSwap,
   applyPolygonReclassify,
-  snapshotClassification,
-  restoreClassification,
   type ClassEditResult,
 } from './measure/classificationEditor';
+import { ClassEditHistory, recordEdit } from './measure/classEditHistory';
 import {
   getPreset,
   type PresetId,
@@ -1953,7 +1952,7 @@ export class Viewer {
     this._clouds.delete(id);
     // Drop the per-cloud undo / highlight snapshots too — without this the
     // maps retain full-size buffers for every cloud ever removed (leak).
-    this._classSnapshots.delete(id);
+    this._classHistory.delete(id);
     this._selectionSnapshots.delete(id);
     // Refresh the orbit-clamp envelope so removing the last static cloud
     // doesn't leave the camera clamping to its ghost bounds.
@@ -2591,7 +2590,17 @@ export class Viewer {
    * to the state before the FIRST unconfirmed edit, which matches the
    * undo semantics for the measurement tools.
    */
-  private readonly _classSnapshots = new Map<string, Uint8Array>();
+  /** Per-cloud multi-step classification undo/redo history (delta-based). */
+  private readonly _classHistory = new Map<string, ClassEditHistory>();
+
+  private _historyFor(id: string): ClassEditHistory {
+    let h = this._classHistory.get(id);
+    if (!h) {
+      h = new ClassEditHistory();
+      this._classHistory.set(id, h);
+    }
+    return h;
+  }
 
   /**
    * Globally rewrite every point whose classification is `fromClass` to
@@ -2604,11 +2613,13 @@ export class Viewer {
     if (!entry || !entry.cloud.classification) {
       return { changedCount: 0, pointCount: 0 };
     }
-    // Snapshot once before the FIRST mutation; subsequent edits coalesce.
-    if (!this._classSnapshots.has(id)) {
-      this._classSnapshots.set(id, snapshotClassification(entry.cloud.classification));
-    }
-    const result = applyClassSwap(entry.cloud.classification, fromClass, toClass);
+    const buf = entry.cloud.classification;
+    // Record the edit as a delta so it can be undone independently of any
+    // prior edit (real multi-step history, not a single coalesced snapshot).
+    let result: ClassEditResult = { changedCount: 0, pointCount: buf.length };
+    recordEdit(this._historyFor(id), buf, () => {
+      result = applyClassSwap(buf, fromClass, toClass);
+    });
     if (result.changedCount > 0) this._refreshClassificationColours(id);
     return result;
   }
@@ -2638,33 +2649,57 @@ export class Viewer {
     if (!entry || !entry.cloud.classification) {
       return { changedCount: 0, pointCount: 0 };
     }
-    if (!this._classSnapshots.has(id)) {
-      this._classSnapshots.set(id, snapshotClassification(entry.cloud.classification));
-    }
-    const result = applyPolygonReclassify({
-      classification: entry.cloud.classification,
-      positions: entry.cloud.positions,
-      polygon,
-      newClass,
-      includeIf,
+    const buf = entry.cloud.classification;
+    let result: ClassEditResult = { changedCount: 0, pointCount: buf.length };
+    recordEdit(this._historyFor(id), buf, () => {
+      result = applyPolygonReclassify({
+        classification: buf,
+        positions: entry.cloud.positions,
+        polygon,
+        newClass,
+        includeIf,
+      });
     });
     if (result.changedCount > 0) this._refreshClassificationColours(id);
     return result;
   }
 
   /**
-   * Revert the cloud's classification buffer to the pre-edit snapshot, if
-   * one exists. Returns true on success, false when there's nothing to
-   * undo. Clears the snapshot so a subsequent edit takes a new one.
+   * Undo the most recent classification edit on this cloud. Returns true on
+   * success, false when there's nothing to undo. Steps back one edit at a
+   * time; a subsequent {@link redoClassification} re-applies it.
    */
   undoClassification(id: string): boolean {
     const entry = this._clouds.get(id);
-    const snap = this._classSnapshots.get(id);
-    if (!entry || !entry.cloud.classification || !snap) return false;
-    restoreClassification(entry.cloud.classification, snap);
-    this._classSnapshots.delete(id);
+    const h = this._classHistory.get(id);
+    if (!entry || !entry.cloud.classification || !h || !h.canUndo) return false;
+    h.undo(entry.cloud.classification);
     this._refreshClassificationColours(id);
     return true;
+  }
+
+  /**
+   * Redo the most recently undone classification edit. Returns true on
+   * success, false when the redo branch is empty (nothing undone, or a fresh
+   * edit cleared it).
+   */
+  redoClassification(id: string): boolean {
+    const entry = this._clouds.get(id);
+    const h = this._classHistory.get(id);
+    if (!entry || !entry.cloud.classification || !h || !h.canRedo) return false;
+    h.redo(entry.cloud.classification);
+    this._refreshClassificationColours(id);
+    return true;
+  }
+
+  /** Whether the cloud has a classification edit that can be undone. */
+  canUndoClassification(id: string): boolean {
+    return this._classHistory.get(id)?.canUndo ?? false;
+  }
+
+  /** Whether the cloud has an undone classification edit that can be redone. */
+  canRedoClassification(id: string): boolean {
+    return this._classHistory.get(id)?.canRedo ?? false;
   }
 
   /**
@@ -4457,7 +4492,7 @@ export class Viewer {
     }
     // `removeCloud` drops each cloud's snapshots, but clear both maps
     // outright in case a snapshot ever outlived its cloud entry.
-    this._classSnapshots.clear();
+    this._classHistory.clear();
     this._selectionSnapshots.clear();
     this.detachStreamingCloud();
     this._nav.dispose();

--- a/src/render/deviceProfile.ts
+++ b/src/render/deviceProfile.ts
@@ -33,9 +33,16 @@ export interface DeviceCaps {
   renderBudget: number;
 }
 
-/** Per-tier point budgets — desktop. `high` and `medium` use the canonical cap. */
+/**
+ * Per-tier point budgets — desktop. The `high` tier (≥6–8 GB RAM *and* ≥6–8
+ * cores) gets a larger budget so capable desktops show more of a dense survey
+ * before voxel reduction kicks in; `medium`/`low` stay conservative for broad
+ * safety. The `high` value tracks `GPU_HARD_POINT_CEILING` in Viewer.ts — raise
+ * them together. Verify the `high` budget on real high-end hardware (watch the
+ * frame rate on a >6 M-point cloud) before raising it further.
+ */
 const DESKTOP_BUDGET: Record<DeviceTier, number> = {
-  high: 4_000_000,
+  high: 6_000_000,
   medium: 4_000_000,
   low: 2_000_000,
 };

--- a/src/render/measure/auditLog.ts
+++ b/src/render/measure/auditLog.ts
@@ -1,0 +1,119 @@
+/**
+ * auditLog.ts
+ *
+ * A tamper-evident, replayable record of what was done to a dataset and what
+ * each measurement claimed.
+ *
+ * Local-first means the data never leaves the machine — but a surveyor staking
+ * their name on a number needs more than privacy: they need to prove the number
+ * wasn't quietly changed afterwards. This is an append-only hash chain. Each
+ * entry's hash folds in the previous entry's hash plus a CANONICAL (stable
+ * key-order) serialization of its own contents, so any later edit to any entry
+ * — a reclassification logged with the wrong target class, a volume whose ±
+ * band was tampered down — breaks the chain from that point on and
+ * {@link verifyAuditChain} reports exactly where.
+ *
+ * Deterministic by construction: the same sequence of appends always yields the
+ * same hashes and the same serialization, so two parties can independently
+ * verify they hold the same history.
+ *
+ * The hash function is injectable. The built-in {@link fnv1a} is a fast,
+ * deterministic, NON-cryptographic checksum — it catches accidental corruption
+ * and casual edits. For cryptographic tamper-evidence, inject a SHA-256 (e.g.
+ * via SubtleCrypto, pre-hashing each body) — the chain logic is hash-agnostic.
+ */
+
+export type HashFn = (input: string) => string;
+
+/**
+ * Stable, key-sorted serialization so a record's hash never depends on the
+ * order its fields happened to be written in. Arrays keep their order
+ * (it's meaningful); object keys are sorted.
+ */
+export function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'null';
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalize).join(',') + ']';
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalize(obj[k])).join(',') + '}';
+}
+
+/** FNV-1a 32-bit — deterministic, fast, non-cryptographic. */
+export function fnv1a(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+export interface AuditEntry {
+  /** Position in the chain, 0-based. */
+  readonly seq: number;
+  /** What happened, e.g. 'reclassify' | 'measure.volume' | 'export'. */
+  readonly type: string;
+  /** The payload — edit details, or a measurement value with its uncertainty. */
+  readonly data: unknown;
+  /** Chain hash: hashFn(prevHash + canonical({seq,type,data})). */
+  readonly hash: string;
+}
+
+const GENESIS = '0';
+
+export class AuditLog {
+  private readonly _entries: AuditEntry[] = [];
+  private readonly _hashFn: HashFn;
+
+  constructor(hashFn: HashFn = fnv1a) {
+    this._hashFn = hashFn;
+  }
+
+  /** Append a record and return it. The chain head advances to its hash. */
+  append(type: string, data: unknown): AuditEntry {
+    const seq = this._entries.length;
+    const prev = seq === 0 ? GENESIS : this._entries[seq - 1].hash;
+    const hash = this._hashFn(prev + '|' + canonicalize({ seq, type, data }));
+    const entry: AuditEntry = { seq, type, data, hash };
+    this._entries.push(entry);
+    return entry;
+  }
+
+  get entries(): ReadonlyArray<AuditEntry> {
+    return this._entries;
+  }
+
+  /** The current chain head hash (or the genesis sentinel when empty). */
+  get head(): string {
+    return this._entries.length === 0 ? GENESIS : this._entries[this._entries.length - 1].hash;
+  }
+
+  /** Deterministic, canonical serialization of the whole log for export. */
+  serialize(): string {
+    return canonicalize({ version: 1, entries: this._entries });
+  }
+}
+
+/**
+ * Recompute the chain over `entries` and return the index of the FIRST entry
+ * that is out of order or whose hash doesn't match — i.e. the first point of
+ * tampering or corruption. Returns -1 when the chain is fully intact.
+ */
+export function verifyAuditChain(
+  entries: ReadonlyArray<AuditEntry>,
+  hashFn: HashFn = fnv1a,
+): number {
+  let prev = GENESIS;
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (e.seq !== i) return i;
+    const expect = hashFn(prev + '|' + canonicalize({ seq: e.seq, type: e.type, data: e.data }));
+    if (expect !== e.hash) return i;
+    prev = e.hash;
+  }
+  return -1;
+}

--- a/src/render/measure/classEditHistory.ts
+++ b/src/render/measure/classEditHistory.ts
@@ -1,0 +1,143 @@
+/**
+ * classEditHistory.ts
+ *
+ * Delta-based undo/redo for in-place classification edits.
+ *
+ * A manual class-edit session (swap a bucket, repaint a polygon, repeat) needs
+ * real multi-step undo — not the single coalesced snapshot the first cut shipped
+ * with. Storing a full copy of the classification buffer per edit would cost
+ * O(N) bytes *per step*; on a 50 M-point cloud that's 50 MB an edit. Instead,
+ * each edit records only the points it actually changed — `{index, prev, next}`
+ * — so a deep history costs bytes proportional to the EDITS, not the cloud.
+ *
+ * Pure data. The Viewer owns the live `Uint8Array` classification buffer and
+ * calls these helpers to capture an edit and to replay prev/next on undo/redo.
+ */
+
+/** The points one edit changed: parallel arrays, all the same length. */
+export interface ClassDelta {
+  /** Indices of the points whose class changed. */
+  readonly indices: Uint32Array;
+  /** Class code BEFORE the edit, aligned to {@link indices}. */
+  readonly prev: Uint8Array;
+  /** Class code AFTER the edit, aligned to {@link indices}. */
+  readonly next: Uint8Array;
+}
+
+/**
+ * Diff two equal-length classification buffers into a {@link ClassDelta}, or
+ * `null` when nothing changed (so no-op edits never enter the history).
+ * Throws on a length mismatch — a delta across differently sized buffers would
+ * corrupt the wrong points on replay.
+ */
+export function diffClassification(
+  before: Uint8Array,
+  after: Uint8Array,
+): ClassDelta | null {
+  if (before.length !== after.length) {
+    throw new Error('classification length mismatch');
+  }
+  let n = 0;
+  for (let i = 0; i < before.length; i++) if (before[i] !== after[i]) n++;
+  if (n === 0) return null;
+  const indices = new Uint32Array(n);
+  const prev = new Uint8Array(n);
+  const next = new Uint8Array(n);
+  let k = 0;
+  for (let i = 0; i < before.length; i++) {
+    if (before[i] !== after[i]) {
+      indices[k] = i;
+      prev[k] = before[i];
+      next[k] = after[i];
+      k++;
+    }
+  }
+  return { indices, prev, next };
+}
+
+function applyDelta(buf: Uint8Array, delta: ClassDelta, dir: 'undo' | 'redo'): void {
+  const src = dir === 'undo' ? delta.prev : delta.next;
+  const idx = delta.indices;
+  for (let i = 0; i < idx.length; i++) buf[idx[i]] = src[i];
+}
+
+/**
+ * A bounded undo/redo stack of classification deltas for one cloud. Pushing a
+ * new edit clears the redo branch (standard linear-history semantics); the
+ * oldest edit is evicted once `limit` is exceeded.
+ */
+export class ClassEditHistory {
+  private readonly _undo: ClassDelta[] = [];
+  private readonly _redo: ClassDelta[] = [];
+  private readonly _limit: number;
+
+  constructor(limit = 50) {
+    this._limit = Math.max(1, Math.floor(limit));
+  }
+
+  /** Record a committed edit. Clears the redo branch. */
+  push(delta: ClassDelta): void {
+    this._undo.push(delta);
+    if (this._undo.length > this._limit) this._undo.shift();
+    this._redo.length = 0;
+  }
+
+  get canUndo(): boolean {
+    return this._undo.length > 0;
+  }
+
+  get canRedo(): boolean {
+    return this._redo.length > 0;
+  }
+
+  /** Number of edits that can still be undone. */
+  get depth(): number {
+    return this._undo.length;
+  }
+
+  /**
+   * Undo the most recent edit against `buf` (restores each point's `prev`).
+   * Returns the delta applied, or `null` when there's nothing to undo.
+   */
+  undo(buf: Uint8Array): ClassDelta | null {
+    const d = this._undo.pop();
+    if (!d) return null;
+    applyDelta(buf, d, 'undo');
+    this._redo.push(d);
+    return d;
+  }
+
+  /**
+   * Redo the most recently undone edit against `buf` (re-applies `next`).
+   * Returns the delta applied, or `null` when there's nothing to redo.
+   */
+  redo(buf: Uint8Array): ClassDelta | null {
+    const d = this._redo.pop();
+    if (!d) return null;
+    applyDelta(buf, d, 'redo');
+    this._undo.push(d);
+    return d;
+  }
+
+  clear(): void {
+    this._undo.length = 0;
+    this._redo.length = 0;
+  }
+}
+
+/**
+ * Snapshot → run the in-place `edit` → diff → push the resulting delta.
+ * Returns the delta recorded (or `null` for a no-op edit). The transient
+ * before-snapshot is discarded after the diff, so only the delta is retained.
+ */
+export function recordEdit(
+  history: ClassEditHistory,
+  buf: Uint8Array,
+  edit: () => void,
+): ClassDelta | null {
+  const before = buf.slice();
+  edit();
+  const delta = diffClassification(before, buf);
+  if (delta) history.push(delta);
+  return delta;
+}

--- a/src/render/measure/classificationEditor.ts
+++ b/src/render/measure/classificationEditor.ts
@@ -73,6 +73,31 @@ export function applyClassSwap(
 }
 
 /**
+ * Reclassify an explicit set of point indices to `newClass`. Used by the
+ * screen-lasso reclassify tool, where the selection is computed in screen space
+ * (which points fell inside the drawn lasso) rather than from a horizontal
+ * polygon. Out-of-range indices are skipped defensively. Edited in place; the
+ * caller snapshots for undo (see `classEditHistory`).
+ */
+export function applyIndexReclassify(
+  classification: Uint8Array,
+  indices: readonly number[],
+  newClass: number,
+): ClassEditResult {
+  const n = classification.length;
+  let changed = 0;
+  for (let k = 0; k < indices.length; k++) {
+    const i = indices[k];
+    if (i < 0 || i >= n) continue;
+    if (classification[i] !== newClass) {
+      classification[i] = newClass;
+      changed++;
+    }
+  }
+  return { changedCount: changed, pointCount: n };
+}
+
+/**
  * Apply a polygon-based re-classification. Every point whose horizontal
  * projection falls inside the polygon gets its class set to `newClass`
  * (regardless of its current class). The horizontal projection uses Z as

--- a/src/render/measure/classificationEpoch.ts
+++ b/src/render/measure/classificationEpoch.ts
@@ -1,0 +1,55 @@
+/**
+ * classificationEpoch.ts
+ *
+ * Honesty guard for manual classification editing.
+ *
+ * A manual reclassification silently changes every downstream number that reads
+ * the class channel — terrain analysis, the full-cloud grade, derived-class
+ * exports. If those results stay on screen looking current after an edit, the
+ * tool is quietly lying. This tracks a per-cloud edit EPOCH: every class edit
+ * (swap, polygon reclassify, undo, redo) bumps it. A derived result stamps the
+ * epoch it was computed at; later, `isStale` reports whether a class edit has
+ * invalidated it, so the caller can recompute it or caveat it ("based on an
+ * edited classification") instead of presenting it as fresh.
+ *
+ * The stamp is also a portable provenance token: a report can record "grade
+ * computed at classification epoch 3" and prove, later, whether the cloud has
+ * been edited since.
+ *
+ * Pure data. The Viewer owns the live classification buffers and bumps the
+ * epoch on each edit; analysis/report code stamps and checks.
+ */
+
+export class ClassificationEpochs {
+  private readonly _epoch = new Map<string, number>();
+
+  /** The cloud's current edit epoch (0 = never edited). */
+  current(id: string): number {
+    return this._epoch.get(id) ?? 0;
+  }
+
+  /** Record a classification edit on the cloud; returns the new epoch. */
+  bump(id: string): number {
+    const next = this.current(id) + 1;
+    this._epoch.set(id, next);
+    return next;
+  }
+
+  /**
+   * Whether a result stamped at `stampedEpoch` has been invalidated by a later
+   * edit. A result computed at the cloud's current epoch is fresh; once the
+   * cloud advances past it, the result is stale.
+   */
+  isStale(id: string, stampedEpoch: number): boolean {
+    return this.current(id) > stampedEpoch;
+  }
+
+  /** Forget a cloud's epoch (on removal) so the map doesn't leak. */
+  forget(id: string): void {
+    this._epoch.delete(id);
+  }
+
+  clear(): void {
+    this._epoch.clear();
+  }
+}

--- a/src/render/measure/reportManifest.ts
+++ b/src/render/measure/reportManifest.ts
@@ -1,0 +1,92 @@
+/**
+ * reportManifest.ts
+ *
+ * The offline, signed report — the artifact a surveyor stakes their name on.
+ *
+ * "Story Mode" in a cloud viewer is a slideshow. Here it is a deterministic,
+ * tamper-evident document that carries the things that actually matter forward:
+ * every finding WITH its uncertainty band and caveats, the dataset provenance,
+ * the classification edit epoch the numbers were computed at, and the edit audit
+ * trail. The whole body is hashed into a signature, so anyone who receives the
+ * report can {@link verifyReportManifest} it and prove no figure — no value, no
+ * ± band, no caveat — was altered after it was signed.
+ *
+ * Deterministic by construction (canonical, key-sorted serialization), so the
+ * same inputs always produce the same signature; two parties can confirm they
+ * hold the identical report. The timestamp is supplied by the caller rather than
+ * read from the clock, so the core stays pure and testable.
+ *
+ * Reuses the audit log's canonical hashing; the hash function is injectable
+ * (FNV-1a default; inject SHA-256 for cryptographic signatures).
+ */
+
+import { canonicalize, fnv1a, type HashFn } from './auditLog';
+
+export const REPORT_MANIFEST_VERSION = 1;
+
+export interface ReportFinding {
+  /** Human label, e.g. "Stockpile volume". */
+  readonly label: string;
+  /** The measured value. */
+  readonly value: number;
+  /** Unit, e.g. "m³" / "m²" / "m". */
+  readonly unit: string;
+  /** 1σ uncertainty band, if the measurement carries one. */
+  readonly sigma?: number;
+  /** Confidence tier, e.g. "high" | "medium" | "low". */
+  readonly confidence?: string;
+  /** Honesty notes attached to this finding. */
+  readonly caveats?: readonly string[];
+}
+
+export interface ReportManifestInput {
+  readonly dataset: {
+    readonly id: string;
+    readonly crs?: string;
+    readonly pointCount?: number;
+  };
+  /** ISO timestamp, supplied by the caller (keeps the core deterministic). */
+  readonly generatedAt: string;
+  /** Every reported number, with its band and caveats. */
+  readonly findings: readonly ReportFinding[];
+  /**
+   * The classification edit epoch the findings were computed at — provenance so
+   * a later reader can tell whether the cloud was edited after this report.
+   */
+  readonly classificationEpoch?: number;
+  /** The edit audit trail (hash-chained {@link AuditEntry} list), if any. */
+  readonly edits?: readonly unknown[];
+}
+
+export interface ReportManifest extends ReportManifestInput {
+  readonly version: number;
+  /** Tamper-evident signature over the canonical manifest body. */
+  readonly signature: string;
+}
+
+/** Assemble and sign a report manifest. */
+export function buildReportManifest(
+  input: ReportManifestInput,
+  hashFn: HashFn = fnv1a,
+): ReportManifest {
+  const body = { version: REPORT_MANIFEST_VERSION, ...input };
+  const signature = hashFn(canonicalize(body));
+  return { ...body, signature };
+}
+
+/** Deterministic, canonical serialization for export / transmission. */
+export function serializeReportManifest(manifest: ReportManifest): string {
+  return canonicalize(manifest);
+}
+
+/**
+ * Recompute the signature from the manifest body and confirm it matches —
+ * returns false if any field was altered after signing.
+ */
+export function verifyReportManifest(
+  manifest: ReportManifest,
+  hashFn: HashFn = fnv1a,
+): boolean {
+  const { signature, ...body } = manifest;
+  return hashFn(canonicalize(body)) === signature;
+}

--- a/src/render/measure/reportManifest.ts
+++ b/src/render/measure/reportManifest.ts
@@ -1,28 +1,35 @@
 /**
  * reportManifest.ts
  *
- * The offline, signed report — the artifact a surveyor stakes their name on.
+ * The offline integrity report — the artifact a surveyor hands over.
  *
- * "Story Mode" in a cloud viewer is a slideshow. Here it is a deterministic,
- * tamper-evident document that carries the things that actually matter forward:
- * every finding WITH its uncertainty band and caveats, the dataset provenance,
- * the classification edit epoch the numbers were computed at, and the edit audit
- * trail. The whole body is hashed into a signature, so anyone who receives the
- * report can {@link verifyReportManifest} it and prove no figure — no value, no
- * ± band, no caveat — was altered after it was signed.
+ * "Story Mode" in a cloud viewer is a slideshow. Here it is a deterministic
+ * document that carries the things that actually matter forward: every finding
+ * WITH its uncertainty band and caveats, the dataset provenance, the
+ * classification edit epoch the numbers were computed at, and the edit audit
+ * trail. The whole body is hashed into a content DIGEST, so anyone who receives
+ * the report can {@link verifyReportManifest} it and detect a figure — a value,
+ * a ± band, a caveat — that was changed without recomputing the digest.
+ *
+ * Honesty note: the default digest (FNV-1a) is a fast, NON-cryptographic content
+ * hash. It is tamper-EVIDENT against accidental or casual edits (change a number
+ * but not the digest and verification fails), but it is NOT a secret-keyed
+ * signature — a determined forger can recompute it. The `digestAlgorithm` field
+ * names the algorithm so the output is self-describing; inject a SHA-256 hashFn
+ * for a cryptographic-strength digest.
  *
  * Deterministic by construction (canonical, key-sorted serialization), so the
- * same inputs always produce the same signature; two parties can confirm they
- * hold the identical report. The timestamp is supplied by the caller rather than
- * read from the clock, so the core stays pure and testable.
- *
- * Reuses the audit log's canonical hashing; the hash function is injectable
- * (FNV-1a default; inject SHA-256 for cryptographic signatures).
+ * same inputs always produce the same digest; two parties can confirm they hold
+ * the identical report. The timestamp is supplied by the caller rather than read
+ * from the clock, so the core stays pure and testable.
  */
 
 import { canonicalize, fnv1a, type HashFn } from './auditLog';
 
-export const REPORT_MANIFEST_VERSION = 1;
+export const REPORT_MANIFEST_VERSION = 2;
+
+/** Default digest algorithm name stamped into the manifest (self-describing). */
+export const DEFAULT_DIGEST_ALGORITHM = 'FNV-1a-32';
 
 export interface ReportFinding {
   /** Human label, e.g. "Stockpile volume". */
@@ -60,18 +67,27 @@ export interface ReportManifestInput {
 
 export interface ReportManifest extends ReportManifestInput {
   readonly version: number;
-  /** Tamper-evident signature over the canonical manifest body. */
-  readonly signature: string;
+  /** Name of the digest algorithm (e.g. "FNV-1a-32"). Covered by the digest. */
+  readonly digestAlgorithm: string;
+  /**
+   * Content digest over the canonical manifest body. Catches a figure changed
+   * without recomputing the digest (accidental or casual edits). NOT a
+   * secret-keyed signature — see the file header.
+   */
+  readonly digest: string;
 }
 
-/** Assemble and sign a report manifest. */
+/** Assemble a report manifest and stamp it with a content digest. */
 export function buildReportManifest(
   input: ReportManifestInput,
   hashFn: HashFn = fnv1a,
+  digestAlgorithm: string = DEFAULT_DIGEST_ALGORITHM,
 ): ReportManifest {
-  const body = { version: REPORT_MANIFEST_VERSION, ...input };
-  const signature = hashFn(canonicalize(body));
-  return { ...body, signature };
+  // `digestAlgorithm` is inside the hashed body, so the named algorithm can't be
+  // swapped without breaking verification.
+  const body = { version: REPORT_MANIFEST_VERSION, digestAlgorithm, ...input };
+  const digest = hashFn(canonicalize(body));
+  return { ...body, digest };
 }
 
 /** Deterministic, canonical serialization for export / transmission. */
@@ -80,13 +96,14 @@ export function serializeReportManifest(manifest: ReportManifest): string {
 }
 
 /**
- * Recompute the signature from the manifest body and confirm it matches —
- * returns false if any field was altered after signing.
+ * Recompute the digest from the manifest body and confirm it matches — returns
+ * false if any field was altered after the digest was stamped. Pass the same
+ * hashFn that built the manifest (the default matches `DEFAULT_DIGEST_ALGORITHM`).
  */
 export function verifyReportManifest(
   manifest: ReportManifest,
   hashFn: HashFn = fnv1a,
 ): boolean {
-  const { signature, ...body } = manifest;
-  return hashFn(canonicalize(body)) === signature;
+  const { digest, ...body } = manifest;
+  return hashFn(canonicalize(body)) === digest;
 }

--- a/src/render/measure/sessionFindings.ts
+++ b/src/render/measure/sessionFindings.ts
@@ -1,7 +1,7 @@
 /**
  * sessionFindings.ts
  *
- * The session ledger that the signed report is built from.
+ * The session ledger that the integrity report is built from.
  *
  * Measurements are computed ad-hoc and shown in toasts; nothing collected them
  * into something a report could assemble. This is that collector — an ordered

--- a/src/render/measure/sessionFindings.ts
+++ b/src/render/measure/sessionFindings.ts
@@ -1,0 +1,85 @@
+/**
+ * sessionFindings.ts
+ *
+ * The session ledger that the signed report is built from.
+ *
+ * Measurements are computed ad-hoc and shown in toasts; nothing collected them
+ * into something a report could assemble. This is that collector — an ordered
+ * list of {@link ReportFinding}s, each a number WITH its uncertainty band and
+ * caveats — plus converters that turn the measurement cores' results into
+ * findings so the band and the honesty notes survive the trip into the report
+ * intact (no re-formatting, no dropped caveats).
+ *
+ * Pure data. The UI adds a finding when a measurement is taken; the report
+ * export reads `all` and hands it to {@link buildReportManifest}.
+ */
+
+import type { ReportFinding } from './reportManifest';
+import type { StockpileVolumeResult } from './stockpileVolume';
+import type { ChangeVolumeUncertainty } from '../../terrain/change/changeUncertainty';
+
+export class SessionFindings {
+  private readonly _findings: ReportFinding[] = [];
+
+  add(finding: ReportFinding): void {
+    this._findings.push(finding);
+  }
+
+  get all(): ReadonlyArray<ReportFinding> {
+    return this._findings;
+  }
+
+  get count(): number {
+    return this._findings.length;
+  }
+
+  /** Drop the most recent finding (e.g. the user discarded a measurement). */
+  pop(): ReportFinding | undefined {
+    return this._findings.pop();
+  }
+
+  clear(): void {
+    this._findings.length = 0;
+  }
+}
+
+/**
+ * Stockpile result → finding, converting native CRS units to metres (volume by
+ * lin³). The ± band, confidence, and the honest caveats ride through unchanged.
+ */
+export function stockpileFinding(
+  result: StockpileVolumeResult,
+  lin = 1,
+  label = 'Stockpile volume',
+): ReportFinding {
+  const lin3 = lin * lin * lin;
+  return {
+    label,
+    value: result.volume * lin3,
+    unit: 'm³',
+    sigma: result.sigma * lin3,
+    confidence: result.confidence,
+    caveats: result.caveats,
+  };
+}
+
+/**
+ * Two-epoch change → finding. The net volume is already in m³; the band and the
+ * detectability caveat come from {@link changeVolumeUncertainty}. When the
+ * change isn't distinguishable from noise, the confidence reads 'low' and the
+ * caveat says so — the report never presents noise as a confident change.
+ */
+export function changeFinding(
+  netVolumeM3: number,
+  uncertainty: ChangeVolumeUncertainty,
+  label = 'Volume change (two-epoch)',
+): ReportFinding {
+  return {
+    label,
+    value: netVolumeM3,
+    unit: 'm³',
+    sigma: uncertainty.sigmaM3,
+    confidence: uncertainty.confidence,
+    caveats: uncertainty.caveats,
+  };
+}

--- a/src/render/measure/stockpilePresenter.ts
+++ b/src/render/measure/stockpilePresenter.ts
@@ -106,12 +106,14 @@ export function stockpileToastSuffix(
   polygon: ReadonlyArray<Vec3>,
   positions: Float32Array,
   lin?: number,
+  sourceReduced?: boolean,
 ): string {
   if (polygon.length < 3 || positions.length < 9) return '';
   const stock = stockpileVolume({
     polygon,
     positions,
     base: { mode: 'lowest-percentile', percentile: 0.05 },
+    sourceReduced,
   });
   if (stock.validity !== 'ok' || stock.volume <= 0) return '';
   return ` · ${stockpileToastLine(presentStockpile(stock, { lin }))}`;

--- a/src/render/measure/stockpilePresenter.ts
+++ b/src/render/measure/stockpilePresenter.ts
@@ -1,0 +1,118 @@
+/**
+ * stockpilePresenter.ts
+ *
+ * Turns a `StockpileVolumeResult` (in the cloud's native CRS linear units)
+ * into a metric, human-readable view model: the headline volume with its ±
+ * band, the relative error, a confidence label, the "show the math" breakdown
+ * rows, and the caveats. Pure — no DOM — so the panel, the toast, and the
+ * report all render from one tested source of truth, and the honesty (the band
+ * + the math) can never drift between surfaces.
+ *
+ * Unit handling: the result arrives in native linear units (feet for a
+ * state-plane-feet cloud). `lin` is `linearUnitToMetres`; lengths scale by
+ * `lin`, areas by `lin²`, volumes by `lin³`, so every figure prints in true
+ * metres / m² / m³.
+ */
+
+import { stockpileVolume, type StockpileVolumeResult, type StockpileConfidence } from './stockpileVolume';
+import type { Vec3 } from '../navMath';
+
+export interface StockpileViewRow {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface StockpileView {
+  /** "1,254 m³ ± 41" — the volume and its 1σ band, already in metres. */
+  readonly headline: string;
+  /** "±3.3%" — relative band. */
+  readonly relative: string;
+  /** The confidence tier. */
+  readonly confidence: StockpileConfidence;
+  /** "High" / "Medium" / "Low". */
+  readonly confidenceLabel: string;
+  /** The auditable breakdown — every input behind the number and band. */
+  readonly rows: ReadonlyArray<StockpileViewRow>;
+  /** Honesty notes, verbatim from the result. */
+  readonly caveats: ReadonlyArray<string>;
+}
+
+export interface StockpilePresentOptions {
+  /** `linearUnitToMetres` for the source CRS. Defaults to 1 (already metres). */
+  readonly lin?: number;
+}
+
+const CONFIDENCE_LABEL: Record<StockpileConfidence, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+};
+
+function int(n: number): string {
+  return Math.round(n).toLocaleString('en-US');
+}
+
+export function presentStockpile(
+  r: StockpileVolumeResult,
+  options: StockpilePresentOptions = {},
+): StockpileView {
+  const lin = options.lin ?? 1;
+  const lin2 = lin * lin;
+  const lin3 = lin2 * lin;
+  const b = r.breakdown;
+
+  const headline = `${int(r.volume * lin3)} m³ ± ${int(r.sigma * lin3)}`;
+  const relative = `±${(r.relativeError * 100).toFixed(1)}%`;
+
+  const baseLabel =
+    b.baseMode === 'explicit'
+      ? `${(b.baseZ * lin).toFixed(2)} m (set)`
+      : `${(b.baseZ * lin).toFixed(2)} m (lowest ground, ±${(b.baseUncertainty * lin).toFixed(2)} m)`;
+
+  const rows: StockpileViewRow[] = [
+    { label: 'Footprint', value: `${(b.footprintArea * lin2).toFixed(1)} m²` },
+    { label: 'Points in footprint', value: int(b.pointsInPolygon) },
+    { label: 'Density', value: `${(b.density / lin2).toFixed(1)} pts/m²` },
+    { label: 'Base plane', value: baseLabel },
+    { label: 'Mean thickness', value: `${(b.meanThickness * lin).toFixed(2)} m` },
+    { label: 'Sampling error', value: `± ${int(b.samplingError * lin3)} m³` },
+    { label: 'Base-plane error', value: `± ${int(b.basePlaneError * lin3)} m³` },
+  ];
+
+  return {
+    headline,
+    relative,
+    confidence: r.confidence,
+    confidenceLabel: CONFIDENCE_LABEL[r.confidence],
+    rows,
+    caveats: r.caveats,
+  };
+}
+
+/** One-line summary for a toast: "Stockpile: 1,254 m³ ± 41 (±3.3%) · Medium confidence". */
+export function stockpileToastLine(view: StockpileView): string {
+  return `Stockpile: ${view.headline} (${view.relative}) · ${view.confidenceLabel} confidence`;
+}
+
+/**
+ * End-to-end helper for the lasso toast: run the estimator over the selected
+ * sample with a "lowest ground" base plane and return the ` · Stockpile: …`
+ * suffix — or `''` when there's nothing trustworthy to claim (too few points,
+ * degenerate footprint, or zero volume). Keeps the whole compute + format path
+ * inside the lazy chunk, so `main.ts` carries only the call. Positional args
+ * keep the eager call site byte-cheap.
+ */
+export function stockpileToastSuffix(
+  polygon: ReadonlyArray<Vec3>,
+  positions: Float32Array,
+  lin?: number,
+): string {
+  if (polygon.length < 3 || positions.length < 9) return '';
+  const stock = stockpileVolume({
+    polygon,
+    positions,
+    base: { mode: 'lowest-percentile', percentile: 0.05 },
+  });
+  if (stock.validity !== 'ok' || stock.volume <= 0) return '';
+  return ` · ${stockpileToastLine(presentStockpile(stock, { lin }))}`;
+}

--- a/src/render/measure/stockpileVolume.ts
+++ b/src/render/measure/stockpileVolume.ts
@@ -230,7 +230,12 @@ export function stockpileVolume(input: StockpileInput): StockpileVolumeResult {
   const stdThk = Math.sqrt(varThk);
 
   const area = v.footprintArea;
-  const samplingError = inN > 0 ? (area * stdThk) / Math.sqrt(inN) : 0;
+  // Standard error of the mean thickness × area. The √N must be taken over the
+  // SAME population the thickness σ was computed on — the `m` finite inside
+  // heights — not `inN` (volumeCutFill's count, which would also include any
+  // non-finite-z inside points). They coincide for finite clouds, but using `m`
+  // keeps σ and √N self-consistent regardless of how volumeCutFill counts.
+  const samplingError = m > 0 ? (area * stdThk) / Math.sqrt(m) : 0;
   const basePlaneError = area * baseUncertainty;
   const sigma = Math.hypot(samplingError, basePlaneError);
 

--- a/src/render/measure/stockpileVolume.ts
+++ b/src/render/measure/stockpileVolume.ts
@@ -173,12 +173,32 @@ export function stockpileVolume(input: StockpileInput): StockpileVolumeResult {
     } else {
       const sorted = Float64Array.from(insideHeights).sort();
       baseZ = percentileSorted(sorted, basePct);
-      // Base-height noise: spread of the "ground band" — the lowest 25% of
-      // inside heights, the points that actually sit on the surrounding
-      // ground. Its std is how flat/clean the base we're resting the pile
-      // on really is. A noisy or sloped apron widens the band honestly.
+      // Base-plane uncertainty has TWO parts, and the band is only honest if it
+      // carries both:
+      //
+      //   1. Random scatter — the std of the "ground band" (lowest 25% of inside
+      //      heights, the points sitting on the surrounding ground). How noisy
+      //      the apron is.
+      //   2. Systematic mis-fit — a single HORIZONTAL base under sloped or
+      //      uneven ground biases EVERY thickness the same direction, so it
+      //      cannot be averaged away by more points (a Type-B systematic term in
+      //      GUM language). Point scatter alone misses it. We bound it by how far
+      //      the representative ground level — the ground band's MEAN — sits
+      //      above the chosen low-percentile base: the amount the flat base is
+      //      systematically too low across the footprint. Flat ground ⇒ this gap
+      //      ≈ 0 and scatter governs; a sloped apron ⇒ it dominates, widening the
+      //      band honestly instead of reporting a confidently-narrow number.
+      //
+      // Take the larger of the two so the systematic term sets a floor the
+      // random term can never shrink below.
       const groundCount = Math.max(1, Math.floor(sorted.length * 0.25));
-      baseUncertainty = stdDev(sorted.subarray(0, groundCount));
+      const groundBand = sorted.subarray(0, groundCount);
+      const groundScatter = stdDev(groundBand);
+      let groundSum = 0;
+      for (let i = 0; i < groundBand.length; i++) groundSum += groundBand[i];
+      const groundMean = groundSum / groundBand.length;
+      const baseBias = Math.max(0, groundMean - baseZ);
+      baseUncertainty = Math.max(groundScatter, baseBias);
     }
   }
 

--- a/src/render/measure/stockpileVolume.ts
+++ b/src/render/measure/stockpileVolume.ts
@@ -96,16 +96,23 @@ export interface StockpileBreakdown {
   readonly basePlaneError: number;
 }
 
+/**
+ * UNIT CONTRACT: every magnitude here is in the cloud's NATIVE (render / source)
+ * linear units — volumes in native³, areas in native², lengths in native — NOT
+ * metres. `stockpilePresenter` converts to metres at display/export by ×lin,
+ * ×lin², ×lin³ (lin = linearUnitToMetres). For a metre-based CRS native == m;
+ * for a state-plane-feet cloud native == feet. Do not treat these as m³.
+ */
 export interface StockpileVolumeResult {
-  /** Stockpile volume above the base (fill), m³. ≥ 0. */
+  /** Stockpile volume above the base (fill), native units³ (×lin³ → m³). ≥ 0. */
   readonly volume: number;
-  /** Material below the base inside the footprint (cut), m³. ≥ 0. */
+  /** Material below the base inside the footprint (cut), native units³. ≥ 0. */
   readonly cut: number;
-  /** Combined 1σ uncertainty on `volume`, m³. */
+  /** Combined 1σ uncertainty on `volume`, native units³. */
   readonly sigma: number;
-  /** Volume − 1σ, m³ (clamped at 0). */
+  /** Volume − 1σ, native units³ (clamped at 0). */
   readonly low: number;
-  /** Volume + 1σ, m³. */
+  /** Volume + 1σ, native units³. */
   readonly high: number;
   /** sigma / volume (0 when volume is 0). */
   readonly relativeError: number;

--- a/src/render/measure/stockpileVolume.ts
+++ b/src/render/measure/stockpileVolume.ts
@@ -1,0 +1,340 @@
+/**
+ * stockpileVolume.ts
+ *
+ * The stockpile / earthworks vertical: a cut-fill volume for a footprint
+ * polygon that ships with an AUDITABLE confidence band, not a bare number.
+ *
+ * Every cloud-volume tool reports "1,254 m³" and stops. A stockpile volume
+ * is a financial figure (inventory valuation, earthworks payment), and the
+ * honest version is "1,254 m³ ± 41 (±3.3%), and here is exactly why."
+ *
+ * The band combines two independent, defensible error sources and shows the
+ * math behind each:
+ *
+ *   1. SAMPLING error — the point-sample estimator integrates the mean
+ *      thickness over the footprint. The standard error of that mean is
+ *      σ(thickness) / √N over the N points inside the polygon, so the
+ *      1σ volume error is  area · σ(thickness) / √N. Sparse footprints have
+ *      a larger band; this is the "density" honesty the Scan Intelligence
+ *      panel already preaches, made quantitative.
+ *
+ *   2. BASE-PLANE error — the whole pile sits on a reference height. If that
+ *      base is uncertain by σ_base metres (how noisy/sloped the surrounding
+ *      ground is), the volume shifts by  area · σ_base. For a flat-topped
+ *      pile on bumpy ground this is usually the DOMINANT term — exactly the
+ *      assumption a black-box number hides.
+ *
+ * Combined in quadrature (independent sources):  σ_V = √(σ_sample² + σ_base²).
+ *
+ * Pure of three.js and the DOM — unit-testable in Node. Built on the existing
+ * `volumeCutFill` estimator (reused for fill / cut / footprint / density) plus
+ * a single extra pass for the per-point thickness variance.
+ */
+
+import type { Vec3 } from '../navMath';
+import {
+  horizontalProjection,
+  pointInPolygon2D,
+  volumeCutFill,
+} from './volume';
+import type { PolygonValidity } from './polygonHygiene';
+
+/** How the base (reference) height under the pile is chosen. */
+export type BasePlaneMode =
+  /** Lowest `basePercentile` of the inside heights — the surrounding ground. */
+  | 'lowest-percentile'
+  /** An explicit reference height supplied by the analyst. */
+  | 'explicit';
+
+/** Confidence tier derived from relative error + coverage. */
+export type StockpileConfidence = 'high' | 'medium' | 'low';
+
+export interface StockpileInput {
+  /** Footprint polygon, render-space vertices in placement order. */
+  readonly polygon: ReadonlyArray<Vec3>;
+  /** Interleaved x/y/z positions (length 3·N). Pass the resident subset. */
+  readonly positions: Float32Array;
+  /** World up vector. Defaults to `[0, 0, 1]`. */
+  readonly up?: Vec3;
+  /** Base-plane selection. Defaults to lowest-percentile at 0.05. */
+  readonly base?: {
+    readonly mode: BasePlaneMode;
+    /** For `lowest-percentile`: fraction in (0,1). Default 0.05. */
+    readonly percentile?: number;
+    /** For `explicit`: the reference height in render-space metres. */
+    readonly z?: number;
+  };
+}
+
+/** The "show the math" breakdown — every input behind the number and band. */
+export interface StockpileBreakdown {
+  /** Footprint area on the horizontal plane, m². */
+  readonly footprintArea: number;
+  /** Points whose XY projection fell inside the footprint. */
+  readonly pointsInPolygon: number;
+  /** Sample density inside the footprint, points / m². */
+  readonly density: number;
+  /** Base reference height used, render-space metres. */
+  readonly baseZ: number;
+  /** How the base was chosen. */
+  readonly baseMode: BasePlaneMode;
+  /** 1σ uncertainty of the base height, m (0 for an explicit base). */
+  readonly baseUncertainty: number;
+  /** Mean pile thickness above the base across inside points, m. */
+  readonly meanThickness: number;
+  /** Std of the per-point thickness, m. */
+  readonly thicknessStdDev: number;
+  /** 1σ volume error from point sampling, m³. */
+  readonly samplingError: number;
+  /** 1σ volume error from base-plane uncertainty, m³. */
+  readonly basePlaneError: number;
+}
+
+export interface StockpileVolumeResult {
+  /** Stockpile volume above the base (fill), m³. ≥ 0. */
+  readonly volume: number;
+  /** Material below the base inside the footprint (cut), m³. ≥ 0. */
+  readonly cut: number;
+  /** Combined 1σ uncertainty on `volume`, m³. */
+  readonly sigma: number;
+  /** Volume − 1σ, m³ (clamped at 0). */
+  readonly low: number;
+  /** Volume + 1σ, m³. */
+  readonly high: number;
+  /** sigma / volume (0 when volume is 0). */
+  readonly relativeError: number;
+  /** Confidence tier. */
+  readonly confidence: StockpileConfidence;
+  /** The auditable input breakdown. */
+  readonly breakdown: StockpileBreakdown;
+  /** Polygon-hygiene verdict; non-`ok` returns zeros. */
+  readonly validity: PolygonValidity;
+  /** Plain-language honesty notes for the report / panel. */
+  readonly caveats: ReadonlyArray<string>;
+}
+
+/** Sparse-footprint floor: below this, the band is unreliable, not just wide. */
+const MIN_RELIABLE_POINTS = 100;
+
+function isZUp(up: Vec3): boolean {
+  return Math.abs(up[2] - 1) < 1e-6 && Math.abs(up[0]) < 1e-6 && Math.abs(up[1]) < 1e-6;
+}
+
+/** Linear-interpolated percentile of a finite, already-sorted ascending array. */
+function percentileSorted(sorted: Float64Array, p: number): number {
+  const n = sorted.length;
+  if (n === 0) return Number.NaN;
+  if (n === 1) return sorted[0];
+  const idx = Math.max(0, Math.min(1, p)) * (n - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] * (1 - (idx - lo)) + sorted[hi] * (idx - lo);
+}
+
+/**
+ * Compute a stockpile volume with an auditable confidence band.
+ *
+ * Reuses `volumeCutFill` for the fill/cut/area/density/validity figures, then
+ * makes one extra pass over the inside points to derive the thickness variance
+ * (sampling error) and the base-height noise (base-plane error).
+ */
+export function stockpileVolume(input: StockpileInput): StockpileVolumeResult {
+  const up = input.up ?? ([0, 0, 1] as Vec3);
+  const baseMode: BasePlaneMode = input.base?.mode ?? 'lowest-percentile';
+  const basePct = input.base?.percentile ?? 0.05;
+
+  // First gather the inside heights — we need them to choose the base plane
+  // and to estimate its uncertainty before we can integrate thickness.
+  const zUp = isZUp(up);
+  const projPoly = input.polygon.map((p) => horizontalProjection(p, up));
+  const n = input.positions.length / 3;
+  const insideHeights: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const px = input.positions[i * 3];
+    const py = input.positions[i * 3 + 1];
+    const pz = input.positions[i * 3 + 2];
+    const h = zUp ? { x: px, y: py } : horizontalProjection([px, py, pz], up);
+    if (!Number.isFinite(pz)) continue;
+    if (!pointInPolygon2D(h.x, h.y, projPoly)) continue;
+    insideHeights.push(zUp ? pz : projectedHeight([px, py, pz], up));
+  }
+
+  // Choose the base height.
+  let baseZ: number;
+  let baseUncertainty: number;
+  if (baseMode === 'explicit') {
+    baseZ = input.base?.z ?? 0;
+    baseUncertainty = 0;
+  } else {
+    if (insideHeights.length === 0) {
+      baseZ = 0;
+      baseUncertainty = 0;
+    } else {
+      const sorted = Float64Array.from(insideHeights).sort();
+      baseZ = percentileSorted(sorted, basePct);
+      // Base-height noise: spread of the "ground band" — the lowest 25% of
+      // inside heights, the points that actually sit on the surrounding
+      // ground. Its std is how flat/clean the base we're resting the pile
+      // on really is. A noisy or sloped apron widens the band honestly.
+      const groundCount = Math.max(1, Math.floor(sorted.length * 0.25));
+      baseUncertainty = stdDev(sorted.subarray(0, groundCount));
+    }
+  }
+
+  // Reuse the existing estimator for fill/cut/area/density/validity.
+  const v = volumeCutFill({
+    polygon: input.polygon,
+    referenceZ: baseZ,
+    up,
+    positions: input.positions,
+  });
+
+  const inN = v.pointsInPolygon;
+  if (v.validity !== 'ok' || inN === 0) {
+    return zeroResult(v.validity ?? 'ok', v.footprintArea, baseMode, baseZ);
+  }
+
+  // Per-point thickness above the base (clamped at 0 — the fill contribution),
+  // mean and std, for the sampling-error term. fill = area · mean(thickness).
+  let sum = 0;
+  let sumSq = 0;
+  for (const z of insideHeights) {
+    const t = Math.max(0, z - baseZ);
+    sum += t;
+    sumSq += t * t;
+  }
+  const m = insideHeights.length || 1;
+  const meanThk = sum / m;
+  const varThk = Math.max(0, sumSq / m - meanThk * meanThk);
+  const stdThk = Math.sqrt(varThk);
+
+  const area = v.footprintArea;
+  const samplingError = inN > 0 ? (area * stdThk) / Math.sqrt(inN) : 0;
+  const basePlaneError = area * baseUncertainty;
+  const sigma = Math.hypot(samplingError, basePlaneError);
+
+  const volume = v.fill;
+  const relativeError = volume > 0 ? sigma / volume : 0;
+  const confidence = gradeConfidence(relativeError, inN, v.density);
+  const caveats = buildCaveats(confidence, inN, relativeError, baseMode, baseUncertainty);
+
+  return {
+    volume,
+    cut: v.cut,
+    sigma,
+    low: Math.max(0, volume - sigma),
+    high: volume + sigma,
+    relativeError,
+    confidence,
+    breakdown: {
+      footprintArea: area,
+      pointsInPolygon: inN,
+      density: v.density,
+      baseZ,
+      baseMode,
+      baseUncertainty,
+      meanThickness: meanThk,
+      thicknessStdDev: stdThk,
+      samplingError,
+      basePlaneError,
+    },
+    validity: 'ok',
+    caveats,
+  };
+}
+
+/** Height of a point along the up axis (general-up case). */
+function projectedHeight(p: Vec3, up: Vec3): number {
+  const len = Math.hypot(up[0], up[1], up[2]) || 1;
+  return (p[0] * up[0] + p[1] * up[1] + p[2] * up[2]) / len;
+}
+
+function stdDev(values: ArrayLike<number>): number {
+  const n = values.length;
+  if (n < 2) return 0;
+  let sum = 0;
+  for (let i = 0; i < n; i++) sum += values[i];
+  const mean = sum / n;
+  let acc = 0;
+  for (let i = 0; i < n; i++) {
+    const d = values[i] - mean;
+    acc += d * d;
+  }
+  return Math.sqrt(acc / n);
+}
+
+function gradeConfidence(
+  relErr: number,
+  pointsInPolygon: number,
+  density: number,
+): StockpileConfidence {
+  if (pointsInPolygon < MIN_RELIABLE_POINTS) return 'low';
+  if (relErr <= 0.05 && density >= 5) return 'high';
+  if (relErr <= 0.15) return 'medium';
+  return 'low';
+}
+
+function buildCaveats(
+  confidence: StockpileConfidence,
+  pointsInPolygon: number,
+  relErr: number,
+  baseMode: BasePlaneMode,
+  baseUncertainty: number,
+): string[] {
+  const out: string[] = [];
+  if (pointsInPolygon < MIN_RELIABLE_POINTS) {
+    out.push(
+      `Only ${pointsInPolygon} points fell inside the footprint — the volume is indicative, not measured.`,
+    );
+  }
+  if (relErr > 0.15) {
+    out.push(
+      `The ±${(relErr * 100).toFixed(0)}% band is wide; treat the volume as an estimate and validate against ground control.`,
+    );
+  }
+  if (baseMode === 'lowest-percentile') {
+    out.push(
+      `Base plane was inferred from the lowest ground points inside the footprint (±${baseUncertainty.toFixed(2)} m); set an explicit base if you have a surveyed datum.`,
+    );
+  }
+  out.push('Point-sample estimate over a horizontal base plane; not a triangulated surface-to-surface volume.');
+  if (confidence === 'high') {
+    out.unshift('Dense, even coverage with a clean base — suitable for a documented stockpile figure once validated.');
+  }
+  return out;
+}
+
+function zeroResult(
+  validity: PolygonValidity,
+  footprintArea: number,
+  baseMode: BasePlaneMode,
+  baseZ: number,
+): StockpileVolumeResult {
+  return {
+    volume: 0,
+    cut: 0,
+    sigma: 0,
+    low: 0,
+    high: 0,
+    relativeError: 0,
+    confidence: 'low',
+    breakdown: {
+      footprintArea,
+      pointsInPolygon: 0,
+      density: 0,
+      baseZ,
+      baseMode,
+      baseUncertainty: 0,
+      meanThickness: 0,
+      thicknessStdDev: 0,
+      samplingError: 0,
+      basePlaneError: 0,
+    },
+    validity,
+    caveats:
+      validity === 'ok'
+        ? ['No points fell inside the footprint.']
+        : [`Footprint is not usable (${validity}).`],
+  };
+}

--- a/src/render/measure/stockpileVolume.ts
+++ b/src/render/measure/stockpileVolume.ts
@@ -64,6 +64,12 @@ export interface StockpileInput {
     /** For `explicit`: the reference height in render-space metres. */
     readonly z?: number;
   };
+  /**
+   * True when the loaded cloud was voxel-reduced to fit the device budget, so
+   * the inside points are a representative sample of a denser survey. Adds an
+   * honesty caveat; the ± band already widens with the smaller resident N.
+   */
+  readonly sourceReduced?: boolean;
 }
 
 /** The "show the math" breakdown — every input behind the number and band. */
@@ -242,7 +248,14 @@ export function stockpileVolume(input: StockpileInput): StockpileVolumeResult {
   const volume = v.fill;
   const relativeError = volume > 0 ? sigma / volume : 0;
   const confidence = gradeConfidence(relativeError, inN, v.density);
-  const caveats = buildCaveats(confidence, inN, relativeError, baseMode, baseUncertainty);
+  const caveats = buildCaveats(
+    confidence,
+    inN,
+    relativeError,
+    baseMode,
+    baseUncertainty,
+    input.sourceReduced ?? false,
+  );
 
   return {
     volume,
@@ -306,11 +319,17 @@ function buildCaveats(
   relErr: number,
   baseMode: BasePlaneMode,
   baseUncertainty: number,
+  sourceReduced: boolean,
 ): string[] {
   const out: string[] = [];
   if (pointsInPolygon < MIN_RELIABLE_POINTS) {
     out.push(
       `Only ${pointsInPolygon} points fell inside the footprint — the volume is indicative, not measured.`,
+    );
+  }
+  if (sourceReduced) {
+    out.push(
+      'This cloud was reduced to fit your device, so the inside points are a representative sample of a denser survey — the ± band reflects that thinner sample.',
     );
   }
   if (relErr > 0.15) {

--- a/src/render/measure/types.ts
+++ b/src/render/measure/types.ts
@@ -82,16 +82,24 @@ export interface ProfileChartSample {
  * Persisted so the headline can read its cut / fill / net without
  * re-sampling and so the PDF report has a stable record to include.
  */
+/**
+ * UNIT CONTRACT: a VolumeRecord stores volumes in the cloud's NATIVE (render /
+ * source) linear units cubed — NOT cubic metres — exactly like every other
+ * measurement. Display and export convert with `unitToMetres³`
+ * (`formatVolumeRender`, the chain aggregator, and `measurementExport`'s volume
+ * branch all do this). For a metre-based CRS native³ == m³; for a foot CRS it is
+ * ft³. Storing native keeps one conversion seam at the boundary.
+ */
 export interface VolumeRecord {
-  /** Cubic metres above the reference plane. */
+  /** Fill above the reference plane, native render units³ (×unitToMetres³ → m³). */
   fill: number;
-  /** Cubic metres below the reference plane. */
+  /** Cut below the reference plane, native render units³ (×unitToMetres³ → m³). */
   cut: number;
-  /** Net = fill − cut, m³. */
+  /** Net = fill − cut, native render units³ (×unitToMetres³ → m³). */
   net: number;
-  /** Reference Z used (local render-space), m. */
+  /** Reference Z used (local render-space), native units. */
   referenceZ: number;
-  /** Polygon footprint area on the horizontal plane, m². */
+  /** Polygon footprint area on the horizontal plane, native units² (×unitToMetres² → m²). */
   footprintArea: number;
   /** Cloud points whose XY projection lay inside the polygon. */
   pointsInPolygon: number;

--- a/src/render/measure/volume.ts
+++ b/src/render/measure/volume.ts
@@ -72,7 +72,7 @@ function normalize(v: Vec3): Vec3 {
  * world coordinates, just with the height stripped to zero relative to
  * the reference point. Use `pointInPolygon2D` for the actual inside test.
  */
-function horizontalProjection(p: Vec3, up: Vec3): { x: number; y: number } {
+export function horizontalProjection(p: Vec3, up: Vec3): { x: number; y: number } {
   // For Z-up world (the OpenLiDARViewer convention), this is just (px, py).
   // The general form below works for any `up` axis by picking the two
   // basis vectors that span the horizontal plane.

--- a/src/style.css
+++ b/src/style.css
@@ -3623,6 +3623,27 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   border-radius: 10px; padding: 12px;
 }
 .olv-cl-title { font-size: 12px; font-weight: 500; margin-bottom: 10px; }
+
+/* Manual classification-edit panel — mounts directly beneath .olv-class-panel,
+   so it borrows the same 248px dock chrome to read as a first-class sibling.
+   Controls stack in full-width rows; the primary "Reclassify (lasso)" action is
+   full width so its label can never clip in the cramped left dock. */
+.olv-reclass-panel {
+  width: 248px; box-sizing: border-box; margin-top: var(--space-md);
+  background: var(--panel); border: 0.5px solid var(--hairline);
+  border-radius: 10px; padding: 12px;
+  display: flex; flex-direction: column; gap: var(--space-sm);
+}
+.olv-reclass-head { font-size: 12px; font-weight: 500; margin-bottom: var(--space-2xs); }
+.olv-reclass-select {
+  width: 100%; box-sizing: border-box; font: inherit; font-size: var(--text-sm);
+  color: var(--text); background: transparent; border: 0.5px solid var(--hairline);
+  border-radius: var(--radius-sm); padding: var(--space-sm) var(--space-md); cursor: pointer;
+}
+.olv-reclass-select:focus-visible { outline: none; border-color: var(--accent); }
+.olv-reclass-go { width: 100%; text-align: center; }
+.olv-reclass-actions { display: flex; gap: var(--space-sm); }
+.olv-reclass-actions .olv-bc-pill { flex: 1; text-align: center; }
 /* The "Filtered — showing N of M classes" banner — persistent while filtered. */
 .olv-cl-banner {
   font-size: 10.5px; font-family: var(--mono); color: var(--accent);

--- a/src/terrain/change/changeUncertainty.ts
+++ b/src/terrain/change/changeUncertainty.ts
@@ -1,0 +1,127 @@
+/**
+ * changeUncertainty.ts
+ *
+ * The ± band on a two-epoch volume change — the number cloud viewers print bare
+ * ("this pile shrank 1,240 m³") that survey-grade work must qualify ("± 90,
+ * detectable") to be honest.
+ *
+ * The error model is the standard geomorphic DEM-of-difference one:
+ *
+ *   - RANDOM cell noise — each changed cell's elevation difference carries a
+ *     vertical 1σ (`cellSigmaM`). Treating cells as spatially independent, their
+ *     volume errors add in quadrature, so the random component scales with the
+ *     square root of the changed-cell count: cellArea·σ·√N. More cells average
+ *     it down.
+ *   - SYSTEMATIC co-registration — a vertical mis-alignment between the two
+ *     epochs biases EVERY cell the same direction, so it does NOT average away;
+ *     it scales with the full changed area: (N·cellArea)·σ_reg. This is the term
+ *     that quietly dominates a real survey, and the one most tools omit.
+ *
+ * The two independent sources combine in quadrature. The result also states
+ * whether the net change even exceeds its own uncertainty — a change smaller
+ * than its error bar is indistinguishable from noise and must be reported as
+ * such, never as a confident gain or loss.
+ *
+ * Pure, deterministic. Sits beside {@link detectChange}: that computes the
+ * volume, this bounds it.
+ */
+
+export type ChangeConfidence = 'high' | 'medium' | 'low';
+
+export interface ChangeVolumeUncertaintyInput {
+  /** The net volume (m³) whose band we want — usually `stats.netVolumeM3`. */
+  readonly netVolumeM3: number;
+  /** Significant (changed) cell count — `stats.gained + stats.lost`. */
+  readonly significantCells: number;
+  /** Cell area in m² — `(cellSizeM · horizontalUnitToMetres)²`. */
+  readonly cellAreaM2: number;
+  /**
+   * Per-cell vertical 1σ of the elevation DIFFERENCE (random, uncorrelated).
+   * If you only know the Level of Detection, use {@link cellSigmaFromLoD}.
+   */
+  readonly cellSigmaM: number;
+  /**
+   * Systematic vertical bias 1σ between the two epochs (co-registration RMSE),
+   * correlated across all cells. Defaults to 0 — and when it is 0 the result
+   * says so loudly, because an unquantified registration error is the most
+   * common way a change number lies.
+   */
+  readonly registrationSigmaM?: number;
+}
+
+export interface ChangeVolumeUncertainty {
+  readonly sigmaM3: number;
+  /** net ∓ σ. Signed — a net loss stays negative, never clamped to 0. */
+  readonly lowM3: number;
+  readonly highM3: number;
+  /** σ / |net|, or 0 when net is 0. */
+  readonly relativeError: number;
+  readonly randomErrorM3: number;
+  readonly systematicErrorM3: number;
+  readonly confidence: ChangeConfidence;
+  /** True only when |net| exceeds σ — i.e. the change is bigger than its error. */
+  readonly detectable: boolean;
+  readonly caveats: readonly string[];
+}
+
+/**
+ * Convert a Level of Detection into a per-cell 1σ. A LoD is conventionally the
+ * ~95% detection threshold ≈ 1.96σ, so σ ≈ LoD / 1.96.
+ */
+export function cellSigmaFromLoD(lodM: number): number {
+  return lodM > 0 ? lodM / 1.96 : 0;
+}
+
+export function changeVolumeUncertainty(
+  input: ChangeVolumeUncertaintyInput,
+): ChangeVolumeUncertainty {
+  const n = Math.max(0, Math.floor(input.significantCells));
+  const area = Math.max(0, input.cellAreaM2);
+  const cellSigma = Math.max(0, input.cellSigmaM);
+  const reg = Math.max(0, input.registrationSigmaM ?? 0);
+
+  const randomErrorM3 = area * cellSigma * Math.sqrt(n);
+  const systematicErrorM3 = n * area * reg;
+  const sigmaM3 = Math.hypot(randomErrorM3, systematicErrorM3);
+
+  const net = input.netVolumeM3;
+  const absNet = Math.abs(net);
+  const relativeError = absNet > 0 ? sigmaM3 / absNet : 0;
+  const detectable = absNet > sigmaM3;
+
+  let confidence: ChangeConfidence;
+  if (!detectable || n < 1) confidence = 'low';
+  else if (relativeError <= 0.1) confidence = 'high';
+  else if (relativeError <= 0.3) confidence = 'medium';
+  else confidence = 'low';
+
+  const caveats: string[] = [];
+  if (!detectable) {
+    caveats.push(
+      `Net change (${Math.round(net)} m³) is within its uncertainty (±${Math.round(
+        sigmaM3,
+      )} m³) — not distinguishable from survey noise.`,
+    );
+  }
+  if (reg === 0) {
+    caveats.push(
+      'Co-registration error is not included — the band reflects random survey noise only. ' +
+        'Supply a registration RMSE to bound the systematic component.',
+    );
+  }
+  caveats.push(
+    'Random cell noise is assumed spatially independent; the true error is larger if it is correlated.',
+  );
+
+  return {
+    sigmaM3,
+    lowM3: net - sigmaM3,
+    highM3: net + sigmaM3,
+    relativeError,
+    randomErrorM3,
+    systematicErrorM3,
+    confidence,
+    detectable,
+    caveats,
+  };
+}

--- a/src/terrain/contour/contourDownload.ts
+++ b/src/terrain/contour/contourDownload.ts
@@ -20,6 +20,7 @@ import { geojsonString } from './geojsonContours';
 import { svgContours } from './svgContours';
 import { dxfContours, type DxfLinearUnit } from './dxfContours';
 import type { ExportProvenance } from '../export/exportProvenance';
+import { triggerDownload } from '../../io/download';
 
 /** Supported pure-data export formats. */
 export type ContourFormat = 'geojson' | 'svg' | 'dxf';
@@ -140,14 +141,7 @@ export function triggerBrowserDownload(file: ContourFile): boolean {
   if (typeof document === 'undefined' || typeof URL === 'undefined' || !URL.createObjectURL) {
     return false;
   }
-  const blob = new Blob([file.content], { type: file.mime });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = file.filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
+  // Shared helper defers the object-URL revoke (Safari / iOS / large-blob safe).
+  triggerDownload(new Blob([file.content], { type: file.mime }), file.filename);
   return true;
 }

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -38,6 +38,7 @@ import {
   formatHonestValue,
 } from '../terrain/contour/contourCopy';
 import { gradeForConfidence } from '../terrain/ground/cellConfidence';
+import { triggerDownload } from '../io/download';
 import {
   coverageHeatmapImage,
   COVERAGE_LEGEND,
@@ -1190,12 +1191,7 @@ export class AnalysePanel {
     }
     (octx ? out : source).toBlob((blob) => {
       if (!blob) return;
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${this._cb.getExportBasename?.() ?? 'terrain'}-${filename}.png`;
-      a.click();
-      URL.revokeObjectURL(url);
+      triggerDownload(blob, `${this._cb.getExportBasename?.() ?? 'terrain'}-${filename}.png`);
     });
   }
 
@@ -1646,13 +1642,7 @@ export class AnalysePanel {
         softwareVersion: __APP_VERSION__,
         metricVersion: TERRAIN_METRIC_VERSION,
       });
-      const blob = new Blob([bytes as BlobPart], { type: 'application/zip' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${basename}-dem.zip`;
-      a.click();
-      URL.revokeObjectURL(url);
+      triggerDownload(new Blob([bytes as BlobPart], { type: 'application/zip' }), `${basename}-dem.zip`);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('OpenLiDARViewer: DEM export failed.', err);
@@ -1692,13 +1682,7 @@ export class AnalysePanel {
         // re-derivation that could disagree with what the user saw on screen.
         intelligence: this._cb.getDatasetIntelligence?.() ?? null,
       });
-      const blob = new Blob([bytes as BlobPart], { type: 'application/pdf' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${basename}-terrain-report.pdf`;
-      a.click();
-      URL.revokeObjectURL(url);
+      triggerDownload(new Blob([bytes as BlobPart], { type: 'application/pdf' }), `${basename}-terrain-report.pdf`);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('OpenLiDARViewer: terrain report export failed.', err);
@@ -1996,13 +1980,10 @@ export class AnalysePanel {
       orientation: opts.orientation,
       generatedAt: opts.generatedAt,
     });
-    const blob = new Blob([bytes as BlobPart], { type: 'application/pdf' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = ensurePdfExtension(sanitizeMapFilename(opts.filename));
-    link.click();
-    URL.revokeObjectURL(url);
+    triggerDownload(
+      new Blob([bytes as BlobPart], { type: 'application/pdf' }),
+      ensurePdfExtension(sanitizeMapFilename(opts.filename)),
+    );
   }
 
   /**

--- a/src/ui/BatchConverter.ts
+++ b/src/ui/BatchConverter.ts
@@ -14,6 +14,7 @@
  */
 
 import { el } from './dom';
+import { downloadBytes } from '../io/download';
 import { formatByteSize as formatBytes } from '../io/formatByteSize';
 import { decodeFull } from '../convert/decodeFull';
 import { runBatch, summariseBatch, type BatchInput, type BatchItemResult } from '../convert/convertRunner';
@@ -400,17 +401,3 @@ function parseEpsg(v: string): number | null {
 }
 
 
-function downloadBytes(filename: string, bytes: Uint8Array, mime: string): void {
-  // Only copy when `bytes` is a partial view (see ExportPanel.downloadBytes):
-  // a full-buffer typed array passes through without copying the payload.
-  const ab =
-    bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
-      ? (bytes.buffer as ArrayBuffer)
-      : (bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer);
-  const url = URL.createObjectURL(new Blob([ab], { type: mime }));
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
-}

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -34,6 +34,12 @@ export interface ExportPanelCallbacks {
   /** Export the placed measurements to an open format (GeoJSON / CSV). */
   exportMeasurements?: (format: 'geojson' | 'csv') => void;
   /**
+   * Export a signed, tamper-evident report (JSON) — the placed measurements as
+   * findings, stamped with dataset provenance + the classification epoch + a
+   * verifiable signature. Wired alongside {@link exportMeasurements}.
+   */
+  exportSignedReport?: () => void;
+  /**
    * Export a site KML (annotations + measurements + viewpoints) for Google
    * Earth / QGIS. Wired only when the host can supply a lat/lon transform.
    */
@@ -365,6 +371,19 @@ export class ExportPanel {
       btn.addEventListener('click', () => this._cb.exportMeasurements?.(fmt));
       row.append(btn);
     });
+    // Signed, tamper-evident report (JSON) — the same measurements, but stamped
+    // with provenance + a verifiable signature. The honest deliverable.
+    if (this._cb.exportSignedReport) {
+      const btn = el('button', {
+        className: 'olv-bc-pill',
+        type: 'button',
+        text: 'Signed report',
+      }) as HTMLButtonElement;
+      btn.disabled = count === 0;
+      btn.setAttribute('data-testid', 'export-signed-report');
+      btn.addEventListener('click', () => this._cb.exportSignedReport?.());
+      row.append(btn);
+    }
 
     const hint =
       count === 0

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -35,9 +35,9 @@ export interface ExportPanelCallbacks {
   /** Export the placed measurements to an open format (GeoJSON / CSV). */
   exportMeasurements?: (format: 'geojson' | 'csv') => void;
   /**
-   * Export a signed, tamper-evident report (JSON) — the placed measurements as
+   * Export a tamper-evident integrity report (JSON) — the placed measurements as
    * findings, stamped with dataset provenance + the classification epoch + a
-   * verifiable signature. Wired alongside {@link exportMeasurements}.
+   * verifiable content digest. Wired alongside {@link exportMeasurements}.
    */
   exportSignedReport?: () => void;
   /**
@@ -372,13 +372,14 @@ export class ExportPanel {
       btn.addEventListener('click', () => this._cb.exportMeasurements?.(fmt));
       row.append(btn);
     });
-    // Signed, tamper-evident report (JSON) — the same measurements, but stamped
-    // with provenance + a verifiable signature. The honest deliverable.
+    // Tamper-evident integrity report (JSON) — the same measurements, stamped
+    // with provenance + a verifiable content digest (catches accidental/casual
+    // edits; not a cryptographic signature). The honest deliverable.
     if (this._cb.exportSignedReport) {
       const btn = el('button', {
         className: 'olv-bc-pill',
         type: 'button',
-        text: 'Signed report',
+        text: 'Integrity report',
       }) as HTMLButtonElement;
       btn.disabled = count === 0;
       btn.setAttribute('data-testid', 'export-signed-report');

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -12,6 +12,7 @@
  */
 
 import { el } from './dom';
+import { downloadBytes } from '../io/download';
 import { loadConvertEngine } from '../lazyChunks';
 import { CONVERT_FORMATS, type ConvertFormat, type CrsMode, type ConvertOptions } from '../convert/types';
 import type { PointCloud } from '../model/PointCloud';
@@ -574,19 +575,3 @@ function parseEpsg(v: string): number | null {
   return Number.isInteger(n) && n > 0 ? n : null;
 }
 
-function downloadBytes(filename: string, bytes: Uint8Array, mime: string): void {
-  // Only copy the backing buffer when `bytes` is a partial view: `new Blob([ta])`
-  // serialises the WHOLE ArrayBuffer, so a subarray (non-zero offset or shorter
-  // length) must be sliced to its own bytes. A typed array that owns its whole
-  // buffer is passed straight through — no copy of a multi-MB export payload.
-  const ab =
-    bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
-      ? (bytes.buffer as ArrayBuffer)
-      : (bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer);
-  const url = URL.createObjectURL(new Blob([ab], { type: mime }));
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
-}

--- a/src/ui/HelpOverlay.ts
+++ b/src/ui/HelpOverlay.ts
@@ -75,6 +75,7 @@ export class HelpOverlay {
           ['Move', 'WASD in walk and fly; Space / C raise and lower; hold Shift to sprint.'],
           ['Frame', 'R frames the whole scan; F focuses the centre; double-click a point to focus there.'],
           ['Re-orient', 'Hold Space while a tool is active to rotate / pan, then release to resume.'],
+          ['Right-click', 'A quick menu — focus here, frame the scan, or snap to a view.'],
         ]),
         section('Keyboard shortcuts', [
           ['A', 'Toggle the Annotate tool.'],

--- a/src/ui/HelpOverlay.ts
+++ b/src/ui/HelpOverlay.ts
@@ -72,7 +72,8 @@ export class HelpOverlay {
         section('Navigation', [
           ['Orbit / Walk / Fly', 'Switch mode with 1, 2 and 3.'],
           ['Look', 'Drag to rotate, or orbit with the arrow keys; scroll to zoom.'],
-          ['Move', 'WASD in walk and fly; R frames the scan, F focuses the centre.'],
+          ['Move', 'WASD in walk and fly; Space / C raise and lower; hold Shift to sprint.'],
+          ['Frame', 'R frames the whole scan; F focuses the centre; double-click a point to focus there.'],
         ]),
         section('Keyboard shortcuts', [
           ['A', 'Toggle the Annotate tool.'],
@@ -83,7 +84,8 @@ export class HelpOverlay {
           ['H', 'Show or hide the controls HUD.'],
           ['V', 'Save the current camera view.'],
           ['Delete', 'Remove the selected annotation.'],
-          ['Ctrl+Z', 'Undo an annotation change; add Shift to redo.'],
+          ['Enter / Backspace', 'While measuring: finish a shape / undo the last point.'],
+          ['Ctrl+Z', 'Undo your last edit — annotation or classification; add Shift to redo.'],
           ['Cmd/Ctrl+K', 'Open the command palette.'],
           ['Esc', 'Cancel the active tool or draft.'],
           // `?` is owned by the ShortcutSheet (main.ts binds it before the

--- a/src/ui/HelpOverlay.ts
+++ b/src/ui/HelpOverlay.ts
@@ -74,6 +74,7 @@ export class HelpOverlay {
           ['Look', 'Drag to rotate, or orbit with the arrow keys; scroll to zoom.'],
           ['Move', 'WASD in walk and fly; Space / C raise and lower; hold Shift to sprint.'],
           ['Frame', 'R frames the whole scan; F focuses the centre; double-click a point to focus there.'],
+          ['Re-orient', 'Hold Space while a tool is active to rotate / pan, then release to resume.'],
         ]),
         section('Keyboard shortcuts', [
           ['A', 'Toggle the Annotate tool.'],

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -8,6 +8,7 @@
  */
 
 import { el } from './dom';
+import { triggerDownload } from '../io/download';
 // Guarded localStorage access — bare getItem/setItem throws in sandboxed
 // iframes (the embed path) and some privacy modes; see safeStorage.ts.
 import { storageGet, storageSet } from './safeStorage';
@@ -573,15 +574,10 @@ export class MeasurePanel {
         // metric regardless of the toggle. Same source the chart/CSV read.
         unitSystem: this._cb.getUnitSystem ? this._cb.getUnitSystem() : 'metric',
       });
-      const blob = new Blob([bytes as BlobPart], { type: 'application/pdf' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${safeFileName(s.name)}-profile.pdf`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      triggerDownload(
+        new Blob([bytes as BlobPart], { type: 'application/pdf' }),
+        `${safeFileName(s.name)}-profile.pdf`,
+      );
     } catch (err) {
       console.error('OpenLiDARViewer: profile PDF export failed.', err);
       btn.textContent = 'Export failed';
@@ -606,15 +602,7 @@ export class MeasurePanel {
     if (!s.profileChart || s.profileChart.length < 2) return;
     const system = this._cb.getUnitSystem ? this._cb.getUnitSystem() : 'metric';
     const csv = buildProfileCsv(s.profileChart, system);
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${safeFileName(s.name)}-profile.csv`;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    setTimeout(() => URL.revokeObjectURL(url), 0);
+    triggerDownload(new Blob([csv], { type: 'text/csv' }), `${safeFileName(s.name)}-profile.csv`);
   }
 
   /**

--- a/src/ui/WorkflowController.ts
+++ b/src/ui/WorkflowController.ts
@@ -1,4 +1,5 @@
 import { el } from './dom';
+import { triggerDownload } from '../io/download';
 import {
   buildWorkflow,
   parseWorkflow,
@@ -335,15 +336,7 @@ export class WorkflowController {
 
   /** The plain-download fallback. */
   private _downloadBlob(json: string, fname: string): void {
-    const blob = new Blob([json], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = el('a', { className: 'olv-hidden', href: url });
-    a.setAttribute('download', fname);
-    document.body.append(a);
-    a.click();
-    a.remove();
-    // Defer revoke so the click has a tick to start the download.
-    queueMicrotask(() => URL.revokeObjectURL(url));
+    triggerDownload(new Blob([json], { type: 'application/json' }), fname);
   }
 
   /**

--- a/src/ui/contextMenu.ts
+++ b/src/ui/contextMenu.ts
@@ -1,0 +1,130 @@
+/**
+ * contextMenu.ts — a tiny, lazy-loaded right-click menu for the 3-D canvas.
+ *
+ * Lazy on purpose: the menu is only built the first time the user right-clicks,
+ * so none of this ships in the startup shell. Styling is inline (themed through
+ * the app's CSS custom properties) so the module is fully self-contained and
+ * adds nothing to the eager stylesheet. Inline `style` attributes are permitted
+ * by the app CSP (style-src allows unsafe-inline); no inline <script> is used.
+ */
+
+import { el } from './dom';
+
+export interface ContextMenuItem {
+  readonly label: string;
+  readonly run: () => void;
+  /** Greyed-out, non-actionable (e.g. an action that can't apply right now). */
+  readonly disabled?: boolean;
+}
+
+let openMenu: HTMLElement | null = null;
+let dismiss: (() => void) | null = null;
+
+/** Close any open context menu and detach its global listeners. */
+export function closeContextMenu(): void {
+  dismiss?.();
+}
+
+/**
+ * Show a context menu at viewport coordinates (clientX/clientY). Re-opening
+ * replaces any menu already on screen. The menu dismisses on outside
+ * pointerdown, Escape, scroll, blur, or after an item runs.
+ */
+export function showContextMenu(clientX: number, clientY: number, items: ContextMenuItem[]): void {
+  closeContextMenu();
+  if (items.length === 0) return;
+
+  const menu = el('div', { className: 'olv-ctxmenu' });
+  menu.setAttribute('role', 'menu');
+  menu.style.cssText = [
+    'position:fixed',
+    'z-index:9000',
+    'min-width:168px',
+    'padding:6px',
+    'border-radius:10px',
+    'background:var(--panel,#1b1b1f)',
+    'border:1px solid var(--hairline,rgba(255,255,255,0.12))',
+    'box-shadow:0 12px 32px rgba(0,0,0,0.4)',
+    'font:13px/1.4 var(--ui-font,system-ui,sans-serif)',
+    'color:var(--text,#e7e7ea)',
+    // Off-screen until measured, so the clamp below has real dimensions.
+    'left:-9999px',
+    'top:-9999px',
+  ].join(';');
+
+  for (const item of items) {
+    const row = el('button', {
+      className: 'olv-ctxmenu-item',
+      text: item.label,
+    }) as HTMLButtonElement;
+    row.type = 'button';
+    row.setAttribute('role', 'menuitem');
+    row.disabled = !!item.disabled;
+    row.style.cssText = [
+      'display:block',
+      'width:100%',
+      'text-align:left',
+      'padding:7px 10px',
+      'border:0',
+      'border-radius:6px',
+      'background:transparent',
+      'color:inherit',
+      'font:inherit',
+      item.disabled ? 'opacity:0.45' : 'cursor:pointer',
+    ].join(';');
+    if (!item.disabled) {
+      row.addEventListener('mouseenter', () => {
+        row.style.background = 'var(--accent-weak,rgba(255,255,255,0.08))';
+      });
+      row.addEventListener('mouseleave', () => {
+        row.style.background = 'transparent';
+      });
+      row.addEventListener('click', () => {
+        closeContextMenu();
+        item.run();
+      });
+    }
+    menu.append(row);
+  }
+
+  document.body.append(menu);
+  openMenu = menu;
+
+  // Clamp inside the viewport now that the menu has a measured size.
+  const { width, height } = menu.getBoundingClientRect();
+  const x = Math.min(clientX, window.innerWidth - width - 8);
+  const y = Math.min(clientY, window.innerHeight - height - 8);
+  menu.style.left = `${Math.max(8, x)}px`;
+  menu.style.top = `${Math.max(8, y)}px`;
+
+  const onPointerDown = (e: PointerEvent): void => {
+    if (!menu.contains(e.target as Node)) closeContextMenu();
+  };
+  const onKey = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      closeContextMenu();
+    }
+  };
+  const onScrollOrBlur = (): void => closeContextMenu();
+
+  dismiss = (): void => {
+    menu.remove();
+    if (openMenu === menu) openMenu = null;
+    dismiss = null;
+    window.removeEventListener('pointerdown', onPointerDown, true);
+    window.removeEventListener('keydown', onKey, true);
+    window.removeEventListener('blur', onScrollOrBlur);
+    window.removeEventListener('wheel', onScrollOrBlur, true);
+  };
+
+  // `true` capture so the first outside click both dismisses and is not
+  // swallowed by other handlers; deferred a tick so the opening click that
+  // triggered this menu doesn't immediately close it.
+  setTimeout(() => {
+    window.addEventListener('pointerdown', onPointerDown, true);
+    window.addEventListener('keydown', onKey, true);
+    window.addEventListener('blur', onScrollOrBlur);
+    window.addEventListener('wheel', onScrollOrBlur, true);
+  }, 0);
+}

--- a/src/ui/reclassifyUi.ts
+++ b/src/ui/reclassifyUi.ts
@@ -1,0 +1,142 @@
+/**
+ * reclassifyUi.ts
+ *
+ * The manual classification-edit control panel — class picker + lasso-arm +
+ * undo/redo. Lazy-loaded the first time a classification exists, so it never
+ * enters the startup shell. It drives the tested Viewer engine
+ * (`reclassifyLasso` / `undo|redoClassification`); the editor logic and the
+ * undo/redo history live behind that seam, already unit- and e2e-covered.
+ *
+ * The lasso reuses the same freehand tool the volume lasso uses; on commit the
+ * points inside the lasso are set to the picked class, the edit is recorded for
+ * undo, and the cloud's edit epoch advances (so any stale analysis/grade is
+ * invalidated downstream).
+ */
+
+import { el } from './dom';
+import { LassoVolumeTool } from './LassoVolumeTool';
+import type { Viewer } from '../render/Viewer';
+
+/** Common ASPRS classes offered as reclassify targets. */
+const CLASSES: ReadonlyArray<readonly [number, string]> = [
+  [1, 'Unclassified'],
+  [2, 'Ground'],
+  [3, 'Low vegetation'],
+  [4, 'Medium vegetation'],
+  [5, 'High vegetation'],
+  [6, 'Building'],
+  [7, 'Low noise'],
+  [9, 'Water'],
+];
+
+export interface ReclassifyUiOptions {
+  readonly canvas: HTMLCanvasElement;
+  readonly getViewer: () => Viewer | null;
+  readonly getActiveId: () => string | null;
+  readonly onToast?: (msg: string) => void;
+}
+
+export interface ReclassifyUi {
+  readonly element: HTMLElement;
+  setVisible(visible: boolean): void;
+  /** Re-sync the undo/redo enabled state from the Viewer history. */
+  refresh(): void;
+  dispose(): void;
+}
+
+export function createReclassifyUi(opts: ReclassifyUiOptions): ReclassifyUi {
+  const select = document.createElement('select');
+  select.className = 'olv-reclass-select';
+  select.setAttribute('data-testid', 'reclass-class');
+  for (const [code, label] of CLASSES) {
+    const option = document.createElement('option');
+    option.value = String(code);
+    option.textContent = `${code} · ${label}`;
+    select.append(option);
+  }
+  select.value = '2'; // default to Ground
+
+  const mkBtn = (text: string, testid: string): HTMLButtonElement => {
+    const b = el('button', { className: 'olv-bc-pill', text }) as HTMLButtonElement;
+    b.type = 'button';
+    b.setAttribute('data-testid', testid);
+    return b;
+  };
+  const armBtn = mkBtn('Reclassify (lasso)', 'reclass-arm');
+  const undoBtn = mkBtn('Undo', 'reclass-undo');
+  const redoBtn = mkBtn('Redo', 'reclass-redo');
+
+  const toast = (m: string): void => opts.onToast?.(m);
+
+  const tool = new LassoVolumeTool(opts.canvas, {
+    onCommit: (lasso) => {
+      // Single-shot: disarm so the user returns to navigation after one edit.
+      tool.disable();
+      armBtn.classList.remove('olv-mkind-active');
+      const v = opts.getViewer();
+      const id = opts.getActiveId();
+      if (!v || !id) return;
+      const cls = Number(select.value);
+      const r = v.reclassifyLasso(id, lasso, cls);
+      toast(
+        r.changedCount > 0
+          ? `Reclassified ${r.changedCount.toLocaleString()} points → class ${cls}.`
+          : 'Reclassify — no points inside the lasso.',
+      );
+      refresh();
+    },
+    onCancel: () => {
+      armBtn.classList.remove('olv-mkind-active');
+    },
+  });
+
+  armBtn.addEventListener('click', () => {
+    if (tool.enabled) {
+      tool.disable();
+      armBtn.classList.remove('olv-mkind-active');
+    } else {
+      tool.enable();
+      armBtn.classList.add('olv-mkind-active');
+    }
+  });
+  undoBtn.addEventListener('click', () => {
+    const v = opts.getViewer();
+    const id = opts.getActiveId();
+    if (v && id && v.undoClassification(id)) {
+      toast('Undid the last class edit.');
+      refresh();
+    }
+  });
+  redoBtn.addEventListener('click', () => {
+    const v = opts.getViewer();
+    const id = opts.getActiveId();
+    if (v && id && v.redoClassification(id)) {
+      toast('Redid the class edit.');
+      refresh();
+    }
+  });
+
+  function refresh(): void {
+    const v = opts.getViewer();
+    const id = opts.getActiveId();
+    undoBtn.disabled = !(v && id && v.canUndoClassification(id));
+    redoBtn.disabled = !(v && id && v.canRedoClassification(id));
+  }
+
+  const element = el('div', { className: 'olv-reclass-panel' }, [
+    el('div', { className: 'olv-reclass-head', text: 'Edit classes' }),
+    el('div', { className: 'olv-bc-pills' }, [select, armBtn]),
+    el('div', { className: 'olv-bc-pills' }, [undoBtn, redoBtn]),
+  ]);
+  refresh();
+
+  return {
+    element,
+    setVisible: (visible: boolean) => element.classList.toggle('olv-hidden', !visible),
+    refresh,
+    dispose: () => {
+      tool.disable();
+      element.remove();
+    },
+  };
+}

--- a/src/ui/reclassifyUi.ts
+++ b/src/ui/reclassifyUi.ts
@@ -15,6 +15,7 @@
 
 import { el } from './dom';
 import { LassoVolumeTool } from './LassoVolumeTool';
+import { noteEdit } from './undoRouter';
 import type { Viewer } from '../render/Viewer';
 
 /** Common ASPRS classes offered as reclassify targets. */
@@ -78,6 +79,7 @@ export function createReclassifyUi(opts: ReclassifyUiOptions): ReclassifyUi {
       if (!v || !id) return;
       const cls = Number(select.value);
       const r = v.reclassifyLasso(id, lasso, cls);
+      if (r.changedCount > 0) noteEdit('classification');
       toast(
         r.changedCount > 0
           ? `Reclassified ${r.changedCount.toLocaleString()} points → class ${cls}.`

--- a/src/ui/reclassifyUi.ts
+++ b/src/ui/reclassifyUi.ts
@@ -56,13 +56,13 @@ export function createReclassifyUi(opts: ReclassifyUiOptions): ReclassifyUi {
   }
   select.value = '2'; // default to Ground
 
-  const mkBtn = (text: string, testid: string): HTMLButtonElement => {
-    const b = el('button', { className: 'olv-bc-pill', text }) as HTMLButtonElement;
+  const mkBtn = (text: string, testid: string, extra = ''): HTMLButtonElement => {
+    const b = el('button', { className: `olv-bc-pill${extra ? ' ' + extra : ''}`, text }) as HTMLButtonElement;
     b.type = 'button';
     b.setAttribute('data-testid', testid);
     return b;
   };
-  const armBtn = mkBtn('Reclassify (lasso)', 'reclass-arm');
+  const armBtn = mkBtn('Reclassify (lasso)', 'reclass-arm', 'olv-reclass-go');
   const undoBtn = mkBtn('Undo', 'reclass-undo');
   const redoBtn = mkBtn('Redo', 'reclass-redo');
 
@@ -123,10 +123,14 @@ export function createReclassifyUi(opts: ReclassifyUiOptions): ReclassifyUi {
     redoBtn.disabled = !(v && id && v.canRedoClassification(id));
   }
 
+  // Full-width rows: header, the target-class select, the primary reclassify
+  // action, then an undo/redo pair — so the action label never shares a row
+  // with the wide select (which clipped it in the cramped left dock).
   const element = el('div', { className: 'olv-reclass-panel' }, [
     el('div', { className: 'olv-reclass-head', text: 'Edit classes' }),
-    el('div', { className: 'olv-bc-pills' }, [select, armBtn]),
-    el('div', { className: 'olv-bc-pills' }, [undoBtn, redoBtn]),
+    select,
+    armBtn,
+    el('div', { className: 'olv-reclass-actions' }, [undoBtn, redoBtn]),
   ]);
   refresh();
 

--- a/src/ui/undoRouter.ts
+++ b/src/ui/undoRouter.ts
@@ -1,0 +1,100 @@
+/**
+ * undoRouter.ts — decides which edit stack a global Undo / Redo targets.
+ *
+ * The viewer keeps two independent edit histories: annotations and
+ * classification. A single Ctrl/Cmd+Z should undo whatever the user *touched
+ * last* (the intuitive "most-recent stack" model), then fall through to the
+ * other stack once the first is exhausted — rather than always favouring one.
+ *
+ * This module is a tiny shared singleton: every real edit calls `noteEdit`,
+ * and the global shortcut handler asks `pickUndo` / `pickRedo` which stack to
+ * act on given which stacks currently have undoable / redoable items. It holds
+ * no references to the viewer, so it stays trivially testable and chunk-safe
+ * (one instance shared across lazy chunks).
+ */
+
+export type EditStack = 'annotation' | 'classification';
+
+let lastEdited: EditStack | null = null;
+let lastUndone: EditStack | null = null;
+let suppressed = false;
+
+/**
+ * Run `fn` with edit-notes suppressed. The global Undo/Redo replays through the
+ * same controllers that fire change callbacks; without this, undoing an
+ * annotation would re-mark the annotation stack as "most recently edited" and
+ * corrupt the router's memory. User edits are never wrapped, so they still
+ * register.
+ */
+export function withSuppressed<T>(fn: () => T): T {
+  const prev = suppressed;
+  suppressed = true;
+  try {
+    return fn();
+  } finally {
+    suppressed = prev;
+  }
+}
+
+/** Record that the user just edited `stack` (ignored while suppressed). */
+export function noteEdit(stack: EditStack): void {
+  if (suppressed) return;
+  lastEdited = stack;
+  lastUndone = null;
+}
+
+function order(primary: EditStack | null): readonly EditStack[] {
+  return primary === 'classification'
+    ? (['classification', 'annotation'] as const)
+    : (['annotation', 'classification'] as const);
+}
+
+/**
+ * Choose the stack a global Undo should act on. Prefers the most-recently
+ * touched stack that still has undoable items, then the other. Returns null
+ * when nothing can be undone. Records the choice so consecutive undos stay on
+ * the same stack until it empties, and so Redo can target it.
+ */
+export function pickUndo(canUndoAnnotation: boolean, canUndoClassification: boolean): EditStack | null {
+  for (const stack of order(lastEdited)) {
+    if (stack === 'classification' && canUndoClassification) {
+      lastEdited = 'classification';
+      lastUndone = 'classification';
+      return 'classification';
+    }
+    if (stack === 'annotation' && canUndoAnnotation) {
+      lastEdited = 'annotation';
+      lastUndone = 'annotation';
+      return 'annotation';
+    }
+  }
+  return null;
+}
+
+/**
+ * Choose the stack a global Redo should act on. Prefers the stack most recently
+ * undone (so Redo mirrors Undo), then the other. Returns null when nothing can
+ * be redone.
+ */
+export function pickRedo(canRedoAnnotation: boolean, canRedoClassification: boolean): EditStack | null {
+  for (const stack of order(lastUndone ?? lastEdited)) {
+    if (stack === 'classification' && canRedoClassification) {
+      lastEdited = 'classification';
+      lastUndone = 'classification';
+      return 'classification';
+    }
+    if (stack === 'annotation' && canRedoAnnotation) {
+      lastEdited = 'annotation';
+      lastUndone = 'annotation';
+      return 'annotation';
+    }
+  }
+  return null;
+}
+
+/** Test-only: reset the singleton between cases. */
+export function _resetUndoRouter(): void {
+  lastEdited = null;
+  lastUndone = null;
+  suppressed = false;
+}

--- a/tests/auditLog.test.ts
+++ b/tests/auditLog.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'vitest';
+import {
+  canonicalize,
+  fnv1a,
+  AuditLog,
+  verifyAuditChain,
+  type AuditEntry,
+} from '../src/render/measure/auditLog';
+
+describe('canonicalize', () => {
+  test('is independent of object key order', () => {
+    expect(canonicalize({ a: 1, b: 2 })).toBe(canonicalize({ b: 2, a: 1 }));
+  });
+
+  test('preserves array order (it is meaningful)', () => {
+    expect(canonicalize([1, 2, 3])).not.toBe(canonicalize([3, 2, 1]));
+  });
+
+  test('handles nesting, null, and strings', () => {
+    expect(canonicalize({ x: [{ b: null, a: 'hi' }] })).toBe('{"x":[{"a":"hi","b":null}]}');
+  });
+});
+
+describe('AuditLog hash chain', () => {
+  test('each entry links to the previous, and an intact chain verifies', () => {
+    const log = new AuditLog();
+    log.append('reclassify', { cloud: 'a', from: 1, to: 6, changed: 1200 });
+    log.append('measure.volume', { value: 1254, sigma: 41, confidence: 'medium' });
+    expect(log.entries).toHaveLength(2);
+    expect(log.entries[0].hash).not.toBe(log.entries[1].hash);
+    expect(verifyAuditChain(log.entries)).toBe(-1);
+  });
+
+  test('tampering with any entry breaks the chain from that point', () => {
+    const log = new AuditLog();
+    log.append('measure.volume', { value: 1254, sigma: 41 });
+    log.append('export', { format: 'las' });
+    // Forge a smaller uncertainty on entry 0, keeping its old hash.
+    const forged: AuditEntry[] = [
+      { ...log.entries[0], data: { value: 1254, sigma: 5 } },
+      log.entries[1],
+    ];
+    expect(verifyAuditChain(forged)).toBe(0);
+  });
+
+  test('reordering entries is detected', () => {
+    const log = new AuditLog();
+    log.append('a', { n: 1 });
+    log.append('b', { n: 2 });
+    const swapped = [log.entries[1], log.entries[0]];
+    expect(verifyAuditChain(swapped)).toBe(0); // seq mismatch at index 0
+  });
+
+  test('the same sequence of appends is deterministic across logs', () => {
+    const a = new AuditLog();
+    const b = new AuditLog();
+    for (const log of [a, b]) {
+      log.append('reclassify', { to: 2 });
+      log.append('measure.area', { value: 318.4, sigma: 6 });
+    }
+    expect(a.serialize()).toBe(b.serialize());
+    expect(a.head).toBe(b.head);
+  });
+
+  test('an empty log has the genesis head and verifies', () => {
+    const log = new AuditLog();
+    expect(log.head).toBe('0');
+    expect(verifyAuditChain(log.entries)).toBe(-1);
+  });
+
+  test('an injected hash function is used end-to-end', () => {
+    const tag: typeof fnv1a = (s) => `H(${s.length})`;
+    const log = new AuditLog(tag);
+    const e = log.append('x', { a: 1 });
+    expect(e.hash.startsWith('H(')).toBe(true);
+    expect(verifyAuditChain(log.entries, tag)).toBe(-1);
+    // Verifying with the wrong hash function flags entry 0.
+    expect(verifyAuditChain(log.entries, fnv1a)).toBe(0);
+  });
+});

--- a/tests/changeUncertainty.test.ts
+++ b/tests/changeUncertainty.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect } from 'vitest';
+import {
+  changeVolumeUncertainty,
+  cellSigmaFromLoD,
+} from '../src/terrain/change/changeUncertainty';
+
+describe('cellSigmaFromLoD', () => {
+  test('treats the LoD as a ~95% (1.96σ) threshold', () => {
+    expect(cellSigmaFromLoD(0.196)).toBeCloseTo(0.1, 6);
+    expect(cellSigmaFromLoD(0)).toBe(0);
+  });
+});
+
+describe('changeVolumeUncertainty', () => {
+  test('random error scales as cellArea·σ·√N', () => {
+    const r = changeVolumeUncertainty({
+      netVolumeM3: 1000,
+      significantCells: 400,
+      cellAreaM2: 1,
+      cellSigmaM: 0.05,
+      registrationSigmaM: 0,
+    });
+    // 1 · 0.05 · √400 = 0.05 · 20 = 1.0
+    expect(r.randomErrorM3).toBeCloseTo(1.0, 6);
+    expect(r.systematicErrorM3).toBe(0);
+    expect(r.sigmaM3).toBeCloseTo(1.0, 6);
+  });
+
+  test('a co-registration bias adds a systematic term in quadrature', () => {
+    const base = changeVolumeUncertainty({
+      netVolumeM3: 1000,
+      significantCells: 400,
+      cellAreaM2: 1,
+      cellSigmaM: 0.05,
+    });
+    const withReg = changeVolumeUncertainty({
+      netVolumeM3: 1000,
+      significantCells: 400,
+      cellAreaM2: 1,
+      cellSigmaM: 0.05,
+      registrationSigmaM: 0.02, // 400·1·0.02 = 8 m³ systematic
+    });
+    expect(withReg.systematicErrorM3).toBeCloseTo(8, 6);
+    expect(withReg.sigmaM3).toBeCloseTo(Math.hypot(base.randomErrorM3, 8), 6);
+    expect(withReg.sigmaM3).toBeGreaterThan(base.sigmaM3);
+  });
+
+  test('a change smaller than its band is flagged not detectable and graded low', () => {
+    const r = changeVolumeUncertainty({
+      netVolumeM3: 3,
+      significantCells: 400,
+      cellAreaM2: 1,
+      cellSigmaM: 0.05, // σ ≈ 1 m³, but include systematic to exceed |net|
+      registrationSigmaM: 0.02,
+    });
+    expect(r.detectable).toBe(false);
+    expect(r.confidence).toBe('low');
+    expect(r.caveats.join(' ')).toMatch(/not distinguishable from survey noise/i);
+  });
+
+  test('a clear, well-registered change grades high and is detectable', () => {
+    const r = changeVolumeUncertainty({
+      netVolumeM3: 1240,
+      significantCells: 900,
+      cellAreaM2: 1,
+      cellSigmaM: 0.03,
+      registrationSigmaM: 0.01,
+    });
+    expect(r.detectable).toBe(true);
+    expect(r.relativeError).toBeLessThan(0.1);
+    expect(r.confidence).toBe('high');
+    expect(r.lowM3).toBeLessThan(1240);
+    expect(r.highM3).toBeGreaterThan(1240);
+  });
+
+  test('missing registration is called out honestly', () => {
+    const r = changeVolumeUncertainty({
+      netVolumeM3: 1000,
+      significantCells: 400,
+      cellAreaM2: 1,
+      cellSigmaM: 0.05,
+    });
+    expect(r.caveats.join(' ')).toMatch(/co-registration error is not included/i);
+  });
+
+  test('net erosion keeps a signed (negative) band, never clamped to 0', () => {
+    const r = changeVolumeUncertainty({
+      netVolumeM3: -500,
+      significantCells: 400,
+      cellAreaM2: 1,
+      cellSigmaM: 0.05,
+      registrationSigmaM: 0.01,
+    });
+    expect(r.lowM3).toBeLessThan(-500);
+    expect(r.highM3).toBeGreaterThan(-500);
+    expect(r.highM3).toBeLessThan(0);
+  });
+
+  test('zero net change yields relative error 0 (no divide-by-zero)', () => {
+    const r = changeVolumeUncertainty({
+      netVolumeM3: 0,
+      significantCells: 0,
+      cellAreaM2: 1,
+      cellSigmaM: 0.05,
+    });
+    expect(r.relativeError).toBe(0);
+    expect(Number.isFinite(r.sigmaM3)).toBe(true);
+  });
+});

--- a/tests/chunkIsolation.test.ts
+++ b/tests/chunkIsolation.test.ts
@@ -39,14 +39,17 @@ const DIST = join(process.cwd(), 'dist', 'assets');
 /**
  * Chunk-isolation ceiling, in bytes. Vite's nominal warning is 500 KB
  * (500 × 1024 = 512,000); we allow the eager index a small, bounded margin over
- * it (502 KB) for legitimate core load-time logic — CRS resolution, datum
- * provenance, coordinate bridges — that genuinely belongs in the index and isn't
- * a deferrable feature. This guard's real job is to catch HEAVY code leaking into
- * the eager chunk (a stray three.js / pdf / decoder import is hundreds of KB),
- * which a ~2 KB margin doesn't mask. The shipped artifact is the obfuscated live
- * build, gated separately by `check-bundle-budget.mjs` against its own ceiling.
+ * it (503 KB) for legitimate core load-time logic — CRS resolution, datum
+ * provenance, coordinate bridges — plus the thin lazy-feature TRIGGERS that must
+ * live in the shell (each new Products/Export action wires a sub-KB handler +
+ * control here while its heavy code rides a separate chunk). This guard's real
+ * job is to catch HEAVY code leaking into the eager chunk (a stray three.js /
+ * pdf / decoder import is hundreds of KB), which this ~3 KB margin doesn't mask —
+ * the genuine leak guard is the `SHELL_FORBIDDEN_CONTENT` fingerprint test below.
+ * The shipped artifact is the obfuscated live build, gated separately by
+ * `check-bundle-budget.mjs` against its own ceiling.
  */
-const WARNING_THRESHOLD = 502 * 1024;
+const WARNING_THRESHOLD = 503 * 1024;
 
 /** Required chunk-name prefixes — substring-matched against the filename. */
 const REQUIRED_CHUNK_PREFIXES = [

--- a/tests/chunkIsolation.test.ts
+++ b/tests/chunkIsolation.test.ts
@@ -39,17 +39,17 @@ const DIST = join(process.cwd(), 'dist', 'assets');
 /**
  * Chunk-isolation ceiling, in bytes. Vite's nominal warning is 500 KB
  * (500 × 1024 = 512,000); we allow the eager index a small, bounded margin over
- * it (503 KB) for legitimate core load-time logic — CRS resolution, datum
+ * it (504 KB) for legitimate core load-time logic — CRS resolution, datum
  * provenance, coordinate bridges — plus the thin lazy-feature TRIGGERS that must
- * live in the shell (each new Products/Export action wires a sub-KB handler +
- * control here while its heavy code rides a separate chunk). This guard's real
+ * live in the shell (each new Products/Export/edit action wires a sub-KB handler
+ * + control here while its heavy code rides a separate chunk). This guard's real
  * job is to catch HEAVY code leaking into the eager chunk (a stray three.js /
- * pdf / decoder import is hundreds of KB), which this ~3 KB margin doesn't mask —
+ * pdf / decoder import is hundreds of KB), which this ~4 KB margin doesn't mask —
  * the genuine leak guard is the `SHELL_FORBIDDEN_CONTENT` fingerprint test below.
  * The shipped artifact is the obfuscated live build, gated separately by
  * `check-bundle-budget.mjs` against its own ceiling.
  */
-const WARNING_THRESHOLD = 503 * 1024;
+const WARNING_THRESHOLD = 504 * 1024;
 
 /** Required chunk-name prefixes — substring-matched against the filename. */
 const REQUIRED_CHUNK_PREFIXES = [

--- a/tests/classEditHistory.test.ts
+++ b/tests/classEditHistory.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from 'vitest';
+import {
+  diffClassification,
+  recordEdit,
+  ClassEditHistory,
+} from '../src/render/measure/classEditHistory';
+
+describe('diffClassification', () => {
+  test('identical buffers produce no delta', () => {
+    const a = Uint8Array.from([1, 2, 3]);
+    expect(diffClassification(a, Uint8Array.from([1, 2, 3]))).toBeNull();
+  });
+
+  test('captures only the changed points, with prev and next', () => {
+    const before = Uint8Array.from([1, 1, 1, 1]);
+    const after = Uint8Array.from([1, 6, 1, 8]);
+    const d = diffClassification(before, after)!;
+    expect(Array.from(d.indices)).toEqual([1, 3]);
+    expect(Array.from(d.prev)).toEqual([1, 1]);
+    expect(Array.from(d.next)).toEqual([6, 8]);
+  });
+
+  test('throws on a length mismatch rather than corrupt the wrong points', () => {
+    expect(() => diffClassification(new Uint8Array(3), new Uint8Array(4))).toThrow(/length/);
+  });
+});
+
+describe('ClassEditHistory', () => {
+  test('multi-step undo reverts edits one at a time (not coalesced)', () => {
+    const buf = Uint8Array.from([0, 0, 0]);
+    const h = new ClassEditHistory();
+    recordEdit(h, buf, () => (buf[0] = 2)); // edit 1
+    recordEdit(h, buf, () => (buf[1] = 6)); // edit 2
+    expect(Array.from(buf)).toEqual([2, 6, 0]);
+    expect(h.depth).toBe(2);
+
+    h.undo(buf);
+    expect(Array.from(buf)).toEqual([2, 0, 0]); // only edit 2 undone
+    h.undo(buf);
+    expect(Array.from(buf)).toEqual([0, 0, 0]); // edit 1 undone
+    expect(h.canUndo).toBe(false);
+  });
+
+  test('redo re-applies an undone edit; a new edit clears the redo branch', () => {
+    const buf = Uint8Array.from([0, 0]);
+    const h = new ClassEditHistory();
+    recordEdit(h, buf, () => (buf[0] = 2));
+    h.undo(buf);
+    expect(Array.from(buf)).toEqual([0, 0]);
+    expect(h.canRedo).toBe(true);
+    h.redo(buf);
+    expect(Array.from(buf)).toEqual([2, 0]);
+
+    // undo, then a fresh edit — redo branch must be discarded.
+    h.undo(buf);
+    recordEdit(h, buf, () => (buf[1] = 9));
+    expect(h.canRedo).toBe(false);
+    expect(Array.from(buf)).toEqual([0, 9]);
+  });
+
+  test('a no-op edit records nothing', () => {
+    const buf = Uint8Array.from([3, 3]);
+    const h = new ClassEditHistory();
+    expect(recordEdit(h, buf, () => void 0)).toBeNull();
+    expect(h.canUndo).toBe(false);
+  });
+
+  test('the stack is bounded — oldest edits are evicted past the limit', () => {
+    const buf = Uint8Array.from([0]);
+    const h = new ClassEditHistory(2);
+    recordEdit(h, buf, () => (buf[0] = 1));
+    recordEdit(h, buf, () => (buf[0] = 2));
+    recordEdit(h, buf, () => (buf[0] = 3));
+    expect(h.depth).toBe(2); // first edit evicted
+    h.undo(buf); // 3 → 2
+    h.undo(buf); // 2 → 1
+    expect(buf[0]).toBe(1); // can't undo past the evicted edit-1 boundary
+    expect(h.canUndo).toBe(false);
+  });
+
+  test('undo/redo on an empty history are safe no-ops', () => {
+    const buf = Uint8Array.from([5]);
+    const h = new ClassEditHistory();
+    expect(h.undo(buf)).toBeNull();
+    expect(h.redo(buf)).toBeNull();
+    expect(buf[0]).toBe(5);
+  });
+});

--- a/tests/classificationEditor.test.ts
+++ b/tests/classificationEditor.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from 'vitest';
 import {
   applyClassSwap,
   applyPolygonReclassify,
+  applyIndexReclassify,
   snapshotClassification,
   restoreClassification,
 } from '../src/render/measure/classificationEditor';
@@ -166,5 +167,33 @@ describe('snapshotClassification / restoreClassification — undo helpers', () =
     const target = new Uint8Array(3);
     const snap = new Uint8Array(5);
     expect(() => restoreClassification(target, snap)).toThrow();
+  });
+});
+
+describe('applyIndexReclassify', () => {
+  it('sets only the listed indices and counts real changes', () => {
+    const cls = Uint8Array.from([1, 1, 1, 1, 1]);
+    const r = applyIndexReclassify(cls, [1, 3], 6);
+    expect(Array.from(cls)).toEqual([1, 6, 1, 6, 1]);
+    expect(r.changedCount).toBe(2);
+    expect(r.pointCount).toBe(5);
+  });
+
+  it('does not count an index already at the target class', () => {
+    const cls = Uint8Array.from([6, 1]);
+    expect(applyIndexReclassify(cls, [0, 1], 6).changedCount).toBe(1);
+  });
+
+  it('skips out-of-range indices defensively', () => {
+    const cls = Uint8Array.from([1, 1]);
+    const r = applyIndexReclassify(cls, [-1, 0, 99], 2);
+    expect(Array.from(cls)).toEqual([2, 1]);
+    expect(r.changedCount).toBe(1);
+  });
+
+  it('an empty selection is a no-op', () => {
+    const cls = Uint8Array.from([1, 2, 3]);
+    expect(applyIndexReclassify(cls, [], 9).changedCount).toBe(0);
+    expect(Array.from(cls)).toEqual([1, 2, 3]);
   });
 });

--- a/tests/classificationEpoch.test.ts
+++ b/tests/classificationEpoch.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'vitest';
+import { ClassificationEpochs } from '../src/render/measure/classificationEpoch';
+
+describe('ClassificationEpochs', () => {
+  test('an unedited cloud is at epoch 0 and nothing stamped there is stale', () => {
+    const e = new ClassificationEpochs();
+    expect(e.current('a')).toBe(0);
+    expect(e.isStale('a', 0)).toBe(false);
+  });
+
+  test('an edit bumps the epoch and staleness is per-cloud', () => {
+    const e = new ClassificationEpochs();
+    const stamp = e.current('a'); // result computed now
+    expect(e.bump('a')).toBe(1); // user edits classification of cloud a
+    expect(e.isStale('a', stamp)).toBe(true); // the old result is now stale
+    expect(e.isStale('b', stamp)).toBe(false); // cloud b untouched
+  });
+
+  test('a result re-stamped after the edit reads fresh again', () => {
+    const e = new ClassificationEpochs();
+    e.bump('a');
+    const fresh = e.current('a'); // recomputed at the new epoch
+    expect(e.isStale('a', fresh)).toBe(false);
+    e.bump('a'); // another edit
+    expect(e.isStale('a', fresh)).toBe(true);
+  });
+
+  test('forget drops a cloud (and resets it to epoch 0)', () => {
+    const e = new ClassificationEpochs();
+    e.bump('a');
+    e.bump('a');
+    expect(e.current('a')).toBe(2);
+    e.forget('a');
+    expect(e.current('a')).toBe(0);
+  });
+});

--- a/tests/deviceProfile.test.ts
+++ b/tests/deviceProfile.test.ts
@@ -52,9 +52,15 @@ describe('deviceTier — mobile', () => {
 });
 
 describe('deviceCaps — render budget', () => {
-  test('a capable desktop keeps the full 4M budget', () => {
+  test('a capable desktop gets the high-tier 6M budget', () => {
     expect(deviceCaps({ deviceMemoryGB: 16, hardwareConcurrency: 16, isMobile: false }))
-      .toEqual({ tier: 'high', renderBudget: 4_000_000 });
+      .toEqual({ tier: 'high', renderBudget: 6_000_000 });
+  });
+
+  test('a mid desktop keeps the conservative 4M budget', () => {
+    // medium tier (capable RAM but fewer cores) stays at the canonical cap.
+    expect(deviceCaps({ deviceMemoryGB: 8, hardwareConcurrency: 4, isMobile: false }))
+      .toEqual({ tier: 'medium', renderBudget: 4_000_000 });
   });
 
   test('a low desktop is degraded to 2M', () => {

--- a/tests/download.test.ts
+++ b/tests/download.test.ts
@@ -1,0 +1,112 @@
+/**
+ * download.test.ts — the single browser-download helper.
+ *
+ * The contract that matters: the object-URL revoke is ALWAYS deferred past the
+ * `a.click()`. Revoking synchronously after click is flaky on Safari / iOS and
+ * for large blobs (PDF / DEM / batch ZIP), where freeing the URL before the
+ * transfer starts can cancel the download mid-flight. These tests stub the
+ * minimal DOM / URL surface (the suite runs in the `node` vitest environment,
+ * not jsdom) and assert the order: createObjectURL → click → (later) revoke.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { triggerDownload, downloadBytes, downloadText } from '../src/io/download';
+
+interface FakeAnchor {
+  href: string;
+  download: string;
+  click: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+}
+
+let lastAnchor: FakeAnchor;
+let createObjectURL: ReturnType<typeof vi.fn>;
+let revokeObjectURL: ReturnType<typeof vi.fn>;
+let appendChild: ReturnType<typeof vi.fn>;
+
+const savedDocument = (globalThis as Record<string, unknown>).document;
+const savedURL = (globalThis as Record<string, unknown>).URL;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  createObjectURL = vi.fn(() => 'blob:fake-url');
+  revokeObjectURL = vi.fn();
+  appendChild = vi.fn();
+  lastAnchor = { href: '', download: '', click: vi.fn(), remove: vi.fn() };
+  (globalThis as Record<string, unknown>).document = {
+    createElement: vi.fn(() => lastAnchor),
+    body: { appendChild },
+  };
+  (globalThis as Record<string, unknown>).URL = { createObjectURL, revokeObjectURL };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  (globalThis as Record<string, unknown>).document = savedDocument;
+  (globalThis as Record<string, unknown>).URL = savedURL;
+});
+
+describe('triggerDownload — deferred-revoke contract', () => {
+  it('mints a blob URL, wires the anchor, clicks it, and appends to the DOM', () => {
+    const blob = new Blob(['hi'], { type: 'text/plain' });
+    triggerDownload(blob, 'note.txt');
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(lastAnchor.href).toBe('blob:fake-url');
+    expect(lastAnchor.download).toBe('note.txt');
+    expect(appendChild).toHaveBeenCalledWith(lastAnchor);
+    expect(lastAnchor.click).toHaveBeenCalledTimes(1);
+    expect(lastAnchor.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT revoke the URL synchronously — the regression we guard against', () => {
+    triggerDownload(new Blob(['x']), 'a.bin');
+    // The whole point: the download must have a tick to start before the URL
+    // is freed. A synchronous revoke here is what broke Safari / iOS / large blobs.
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('revokes the URL only after the deferral timer elapses', () => {
+    triggerDownload(new Blob(['x']), 'a.bin');
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
+  });
+});
+
+describe('downloadBytes — partial-view handling', () => {
+  it('passes a full-buffer typed array straight through (no copy)', () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    downloadBytes('full.bin', bytes, 'application/octet-stream');
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.size).toBe(4);
+    expect(blob.type).toBe('application/octet-stream');
+  });
+
+  it('slices a subarray to its own bytes — not the whole backing buffer', async () => {
+    // A 10-byte buffer viewed as bytes [3..6). `new Blob([subarray])` would
+    // otherwise serialise all 10 bytes; downloadBytes must emit exactly 3.
+    const backing = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const view = backing.subarray(3, 6); // [3,4,5], offset 3, length 3
+    downloadBytes('slice.bin', view, 'application/octet-stream');
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.size).toBe(3);
+    const out = new Uint8Array(await blob.arrayBuffer());
+    expect(Array.from(out)).toEqual([3, 4, 5]);
+  });
+});
+
+describe('downloadText', () => {
+  it('defaults to text/plain and carries the text payload', async () => {
+    downloadText('readme.txt', 'hello world');
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe('text/plain');
+    expect(await blob.text()).toBe('hello world');
+  });
+
+  it('honours an explicit MIME type', () => {
+    downloadText('data.json', '{}', 'application/json');
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe('application/json');
+  });
+});

--- a/tests/e2e/lazyChunkLoad.spec.ts
+++ b/tests/e2e/lazyChunkLoad.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, type Page } from '@playwright/test';
+import { suppressOnboardingTour, dropTinyPly } from './helpers';
+
+/**
+ * lazyChunkLoad.spec.ts — proves the runtime dynamic-import seams actually
+ * resolve, especially on the production (obfuscated) build.
+ *
+ * Why this exists:
+ *   main.ts is a transformed module, so the live `stringArray` obfuscator
+ *   pass can scramble a fraction of inline `import('./…')` specifiers each
+ *   build. A scrambled specifier 404s only on the build where it happened to
+ *   get mangled — "works in dev, breaks on the one build it scrambles". That
+ *   is precisely how a lazily-imported panel once crashed the deployed site.
+ *
+ *   The fix routes every runtime lazy import through `src/lazyChunks.ts`
+ *   (the obfuscator `exclude` module). This spec is the regression net: it
+ *   triggers the user-facing entry points whose chunks are loaded on demand
+ *   and fails if any of them raises a dynamic-import error. Run it against
+ *   the minified artifact (SMOKE_LIVE=1) and a scramble-404 surfaces in CI
+ *   instead of in production.
+ *
+ * The boot smoke (smoke.spec.ts) only proves the shell loads; it never
+ * triggers these on-demand chunks, so a 404 behind a feature gate would slip
+ * past it. This spec closes that gap.
+ */
+
+/** A dynamic-import failure manifests as one of these pageerror messages. */
+function isDynamicImportFailure(message: string): boolean {
+  return (
+    /failed to fetch dynamically imported module/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /unable to preload/i.test(message)
+  );
+}
+
+/** Attach collectors and return the captured dynamic-import failures. */
+function watchForImportFailures(page: Page): string[] {
+  const failures: string[] = [];
+  page.on('pageerror', (err) => {
+    if (isDynamicImportFailure(err.message)) failures.push(err.message);
+  });
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && isDynamicImportFailure(msg.text())) {
+      failures.push(msg.text());
+    }
+  });
+  return failures;
+}
+
+test.describe('runtime lazy chunks resolve on the served build', () => {
+  test('command palette chunk loads on Cmd-K', async ({ page }) => {
+    const failures = watchForImportFailures(page);
+    await suppressOnboardingTour(page);
+    await page.goto('/');
+    await expect(page.locator('.olv-empty')).toBeVisible();
+
+    // Cmd-K is the only trigger for the CommandPalette chunk. If its
+    // specifier 404s, the palette never mounts and a pageerror fires.
+    await page.keyboard.press('ControlOrMeta+KeyK');
+    await expect(page.locator('.olv-palette')).toBeVisible({ timeout: 10_000 });
+
+    expect(
+      failures,
+      `dynamic-import failure while loading the command palette:\n${failures.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  test('context-menu chunk loads on canvas right-click', async ({ page }) => {
+    const failures = watchForImportFailures(page);
+    await suppressOnboardingTour(page);
+    await page.goto('/');
+
+    // The context menu is only armed once a scan is loaded, so drop one and
+    // wait for the empty state to clear before right-clicking the canvas.
+    await dropTinyPly(page);
+    await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
+    await page.waitForTimeout(800);
+
+    await page.locator('.olv-stage canvas').click({
+      button: 'right',
+      position: { x: 60, y: 60 },
+    });
+    await expect(page.locator('.olv-ctxmenu')).toBeVisible({ timeout: 10_000 });
+
+    expect(
+      failures,
+      `dynamic-import failure while loading the context menu:\n${failures.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/tests/e2e/lazyChunkLoad.spec.ts
+++ b/tests/e2e/lazyChunkLoad.spec.ts
@@ -76,9 +76,20 @@ test.describe('runtime lazy chunks resolve on the served build', () => {
     await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
     await page.waitForTimeout(800);
 
-    await page.locator('.olv-stage canvas').click({
-      button: 'right',
-      position: { x: 60, y: 60 },
+    // Dispatch `contextmenu` straight to the canvas element rather than a
+    // pointer click. A real right-click can be swallowed by a floating panel
+    // (e.g. the class legend) that overlaps part of the canvas; dispatching to
+    // the element is exactly how the host handler consumes the event (it reads
+    // clientX/clientY off it) and is immune to that interception. Aim at the
+    // canvas centre so the raycast has the loaded cloud under it.
+    const canvas = page.locator('.olv-canvas');
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error('canvas has no bounding box — did the scan load?');
+    await canvas.dispatchEvent('contextmenu', {
+      clientX: Math.round(box.x + box.width / 2),
+      clientY: Math.round(box.y + box.height / 2),
+      bubbles: true,
+      cancelable: true,
     });
     await expect(page.locator('.olv-ctxmenu')).toBeVisible({ timeout: 10_000 });
 

--- a/tests/e2e/reclassify.spec.ts
+++ b/tests/e2e/reclassify.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { dropDenseGridPly } from './helpers';
+
+/**
+ * Lasso reclassify tool — the manual classification-edit flow, end to end in a
+ * real browser: seed a uniform class, reclassify the points inside a screen
+ * lasso to a new class, then undo and redo. Asserts the live classification
+ * buffer changes (and reverts) exactly. Drives the editor through the same
+ * Viewer path the UI tool will use; the visible class-picker widget is a
+ * follow-up that reuses this engine.
+ */
+test('reclassify a lasso, then undo and redo, changes the live classification', async ({ page }) => {
+  await page.goto('/?test=1');
+  await dropDenseGridPly(page);
+  await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
+
+  const result = await page.evaluate(() => {
+    const api = (
+      window as unknown as {
+        __OLV_TEST_API__: {
+          seedUniformClass: (cls: number) => number;
+          reclassifyLasso: (lasso: ReadonlyArray<{ x: number; y: number }>, cls: number) => number;
+          undoClass: () => boolean;
+          redoClass: () => boolean;
+          classAt: (i: number) => number;
+        };
+      }
+    ).__OLV_TEST_API__;
+
+    // Every point starts as class 1 (unclassified).
+    const n = api.seedUniformClass(1);
+    const before = api.classAt(0);
+
+    // A lasso that covers the whole canvas selects every visible point.
+    const fullScreen = [
+      { x: 0, y: 0 },
+      { x: 5000, y: 0 },
+      { x: 5000, y: 5000 },
+      { x: 0, y: 5000 },
+    ];
+    const changed = api.reclassifyLasso(fullScreen, 6); // → class 6 (building)
+    const afterEdit = api.classAt(0);
+
+    const undone = api.undoClass();
+    const afterUndo = api.classAt(0);
+
+    const redone = api.redoClass();
+    const afterRedo = api.classAt(0);
+
+    return { n, before, changed, afterEdit, undone, afterUndo, redone, afterRedo };
+  });
+
+  expect(result.n).toBeGreaterThan(0);
+  expect(result.before).toBe(1);
+  expect(result.changed).toBeGreaterThan(0); // points were reclassified
+  expect(result.afterEdit).toBe(6);
+  expect(result.undone).toBe(true);
+  expect(result.afterUndo).toBe(1); // undo reverted the edit exactly
+  expect(result.redone).toBe(true);
+  expect(result.afterRedo).toBe(6); // redo re-applied it
+});

--- a/tests/e2e/reclassifyUi.spec.ts
+++ b/tests/e2e/reclassifyUi.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { dropDenseGridPly } from './helpers';
+
+/**
+ * Reclassify control panel — the visible class-picker + undo/redo, driven as a
+ * user would: the lazy panel mounts when a classification exists, the arm button
+ * toggles, and the real Undo/Redo buttons revert and re-apply an edit. The
+ * lasso-draw itself is covered by reclassify.spec (engine seam); here we drive
+ * the actual DOM controls bound to the Viewer history.
+ */
+test('the reclassify panel mounts and its undo/redo buttons drive class edits', async ({ page }) => {
+  await page.goto('/?test=1');
+  await dropDenseGridPly(page);
+  await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
+
+  // A classification now exists; mount + show the (lazy) reclassify panel.
+  await page.evaluate(async () => {
+    const api = (
+      window as unknown as {
+        __OLV_TEST_API__: {
+          seedUniformClass: (cls: number) => number;
+          showReclassify: () => Promise<void>;
+        };
+      }
+    ).__OLV_TEST_API__;
+    api.seedUniformClass(1);
+    await api.showReclassify();
+  });
+
+  const armBtn = page.locator('[data-testid="reclass-arm"]');
+  const undoBtn = page.locator('[data-testid="reclass-undo"]');
+  const redoBtn = page.locator('[data-testid="reclass-redo"]');
+  // The lazy panel mounted with its picker + buttons bound to the Viewer.
+  await expect(armBtn).toBeAttached({ timeout: 10_000 });
+  await expect(page.locator('[data-testid="reclass-class"]')).toBeAttached();
+
+  // No edits yet → undo and redo are disabled (state bound to the history).
+  await expect(undoBtn).toBeDisabled();
+  await expect(redoBtn).toBeDisabled();
+
+  // Make an edit through the engine seam, then refresh the panel: undo enables.
+  const afterEdit = await page.evaluate(() => {
+    const api = (
+      window as unknown as {
+        __OLV_TEST_API__: {
+          reclassifyLasso: (l: ReadonlyArray<{ x: number; y: number }>, c: number) => number;
+          refreshReclassify: () => void;
+          classAt: (i: number) => number;
+        };
+      }
+    ).__OLV_TEST_API__;
+    api.reclassifyLasso(
+      [
+        { x: 0, y: 0 },
+        { x: 5000, y: 0 },
+        { x: 5000, y: 5000 },
+        { x: 0, y: 5000 },
+      ],
+      6,
+    );
+    api.refreshReclassify();
+    return api.classAt(0);
+  });
+  expect(afterEdit).toBe(6);
+  await expect(undoBtn).toBeEnabled();
+
+  // Click the REAL Undo button → class reverts, redo enables.
+  await undoBtn.click({ force: true });
+  expect(await page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0))).toBe(1);
+  await expect(redoBtn).toBeEnabled();
+
+  // Click the REAL Redo button → class re-applied.
+  await redoBtn.click({ force: true });
+  expect(await page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0))).toBe(6);
+});

--- a/tests/e2e/signedReport.spec.ts
+++ b/tests/e2e/signedReport.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { dropDenseGridPly } from './helpers';
+
+/**
+ * Products lane → "Signed report" — places a measurement via the test seam,
+ * exports the signed JSON report, and asserts the download is a real, signed
+ * manifest (signature + findings + provenance). The signature's cryptographic
+ * correctness is covered by the reportManifest unit tests; this proves the UI
+ * wiring assembles and downloads a genuine manifest end-to-end.
+ */
+test('the Products lane exports a signed report after a measurement is placed', async ({ page }) => {
+  await page.goto('/?test=1');
+  await dropDenseGridPly(page);
+  await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
+
+  // Arm the Measure tool (placement only registers while measure mode is on),
+  // then place a distance — it auto-completes at the second point.
+  await page.locator('.olv-tool', { hasText: 'Measure' }).click();
+  await expect(page.locator('.olv-measure-bar')).toBeVisible();
+  await page.evaluate(() => {
+    const api = (
+      window as unknown as {
+        __OLV_TEST_API__: {
+          setMeasureKind: (k: string) => void;
+          placeMeasurementPoint: (p: { x: number; y: number; z: number }) => void;
+        };
+      }
+    ).__OLV_TEST_API__;
+    api.setMeasureKind('distance');
+    api.placeMeasurementPoint({ x: 0, y: 0, z: 0 });
+    api.placeMeasurementPoint({ x: 1, y: 0, z: 0 });
+  });
+  await expect(page.locator('.olv-mp-row')).toHaveCount(1, { timeout: 5_000 });
+
+  const panel = page.locator('.olv-export-panel');
+  await expect(panel).toBeVisible({ timeout: 20_000 });
+  if (await panel.evaluate((el) => el.classList.contains('olv-collapsed'))) {
+    await panel.locator('.olv-panel-head').click();
+  }
+  // Open the Products lane and confirm the signed-report action is enabled.
+  await panel.locator('.olv-export-products-head').click();
+  const reportBtn = panel.locator('[data-testid="export-signed-report"]');
+  await expect(reportBtn).toBeEnabled();
+
+  const downloadPromise = page.waitForEvent('download');
+  await reportBtn.click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/-report\.json$/);
+
+  const path = await download.path();
+  const manifest = JSON.parse(readFileSync(path, 'utf8'));
+  expect(manifest.signature).toBeTruthy();
+  expect(Array.isArray(manifest.findings)).toBe(true);
+  expect(manifest.findings.length).toBeGreaterThanOrEqual(1);
+  // Provenance the report carries forward.
+  expect(typeof manifest.classificationEpoch).toBe('number');
+  expect(manifest.version).toBe(1);
+});

--- a/tests/e2e/signedReport.spec.ts
+++ b/tests/e2e/signedReport.spec.ts
@@ -3,13 +3,13 @@ import { readFileSync } from 'node:fs';
 import { dropDenseGridPly } from './helpers';
 
 /**
- * Products lane → "Signed report" — places a measurement via the test seam,
- * exports the signed JSON report, and asserts the download is a real, signed
- * manifest (signature + findings + provenance). The signature's cryptographic
- * correctness is covered by the reportManifest unit tests; this proves the UI
- * wiring assembles and downloads a genuine manifest end-to-end.
+ * Products lane → "Integrity report" — places a measurement via the test seam,
+ * exports the JSON report, and asserts the download is a real manifest
+ * (content digest + findings + provenance). The digest's verification is
+ * covered by the reportManifest unit tests; this proves the UI wiring assembles
+ * and downloads a genuine manifest end-to-end.
  */
-test('the Products lane exports a signed report after a measurement is placed', async ({ page }) => {
+test('the Products lane exports an integrity report after a measurement is placed', async ({ page }) => {
   await page.goto('/?test=1');
   await dropDenseGridPly(page);
   await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
@@ -50,10 +50,11 @@ test('the Products lane exports a signed report after a measurement is placed', 
 
   const path = await download.path();
   const manifest = JSON.parse(readFileSync(path, 'utf8'));
-  expect(manifest.signature).toBeTruthy();
+  expect(manifest.digest).toBeTruthy();
+  expect(manifest.digestAlgorithm).toBe('FNV-1a-32');
   expect(Array.isArray(manifest.findings)).toBe(true);
   expect(manifest.findings.length).toBeGreaterThanOrEqual(1);
   // Provenance the report carries forward.
   expect(typeof manifest.classificationEpoch).toBe('number');
-  expect(manifest.version).toBe(1);
+  expect(manifest.version).toBe(2);
 });

--- a/tests/measurementExport.test.ts
+++ b/tests/measurementExport.test.ts
@@ -81,17 +81,23 @@ describe('measurementMetrics', () => {
     });
   });
 
-  it('volume → cut / fill / net read straight from the m³ record', () => {
+  it('volume → cut / fill / net, no scaling at metric scale (×1)', () => {
     const m = measurementMetrics(VOLUME, UP, 1);
     expect(m.cut_m3).toBe(30);
     expect(m.fill_m3).toBe(120);
     expect(m.net_m3).toBe(90);
   });
 
-  it('applies unitToMetres to lengths (×) and areas (×²)', () => {
+  it('applies unitToMetres to lengths (×), areas (×²), and volumes (×³)', () => {
     expect(measurementMetrics(DISTANCE, UP, 0.3048).length_m).toBeCloseTo(5 * 0.3048, 3);
     // Export rounds to 3 decimals, so compare at that precision.
     expect(measurementMetrics(AREA, UP, 0.3048).area_m2).toBeCloseTo(100 * 0.3048 ** 2, 3);
+    // Regression: a foot-CRS stockpile volume must export in cubic metres, not
+    // native ft³ mislabelled as m³. cut/fill/net are stored native → ×0.3048³.
+    const v = measurementMetrics(VOLUME, UP, 0.3048);
+    expect(v.cut_m3).toBeCloseTo(30 * 0.3048 ** 3, 3);
+    expect(v.fill_m3).toBeCloseTo(120 * 0.3048 ** 3, 3);
+    expect(v.net_m3).toBeCloseTo(90 * 0.3048 ** 3, 3);
   });
 
   it('an INCOMPLETE measurement emits no metrics (never zero-filled)', () => {

--- a/tests/measurementReport.test.ts
+++ b/tests/measurementReport.test.ts
@@ -43,7 +43,7 @@ describe('measurementReport', () => {
     expect(verifyReportManifest(manifest)).toBe(true);
     expect(manifest.classificationEpoch).toBe(1);
     expect(manifest.findings[0].unit).toBe('m');
-    // Tampering a finding after signing must break the signature.
+    // Tampering a finding after the digest is stamped must break verification.
     expect(verifyReportManifest({ ...manifest, findings: [{ ...manifest.findings[0], value: 0 }] })).toBe(
       false,
     );

--- a/tests/measurementReport.test.ts
+++ b/tests/measurementReport.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from 'vitest';
+import {
+  measurementsToFindings,
+  measurementsToReportManifest,
+} from '../src/export/measurementReport';
+import { verifyReportManifest } from '../src/render/measure/reportManifest';
+import type { Measurement } from '../src/render/measure/types';
+import type { Vec3 } from '../src/render/measure/types';
+
+const up: Vec3 = [0, 0, 1];
+
+function distance(id: string, len: number, name = ''): Measurement {
+  return { id, kind: 'distance', name, points: [[0, 0, 0], [len, 0, 0]] };
+}
+
+describe('measurementReport', () => {
+  test('a distance becomes a length finding in metres', () => {
+    const f = measurementsToFindings([distance('m1', 3)], up, 1);
+    expect(f).toHaveLength(1);
+    expect(f[0].value).toBeCloseTo(3, 6);
+    expect(f[0].unit).toBe('m');
+    expect(f[0].label).toBe('distance 1');
+  });
+
+  test('a US-foot scan converts length to metres', () => {
+    const f = measurementsToFindings([distance('m1', 10)], up, 0.3048);
+    expect(f[0].value).toBeCloseTo(3.048, 4);
+  });
+
+  test('a named measurement keeps its label', () => {
+    expect(measurementsToFindings([distance('m1', 2, 'Fence run')], up, 1)[0].label).toBe(
+      'Fence run',
+    );
+  });
+
+  test('builds a signed manifest that verifies and stamps provenance', () => {
+    const manifest = measurementsToReportManifest([distance('m1', 5)], up, 1, {
+      datasetId: 'site-a',
+      crsName: 'EPSG:6433',
+      generatedAt: '2026-06-27T00:00:00Z',
+      classificationEpoch: 1,
+    });
+    expect(verifyReportManifest(manifest)).toBe(true);
+    expect(manifest.classificationEpoch).toBe(1);
+    expect(manifest.findings[0].unit).toBe('m');
+    // Tampering a finding after signing must break the signature.
+    expect(verifyReportManifest({ ...manifest, findings: [{ ...manifest.findings[0], value: 0 }] })).toBe(
+      false,
+    );
+  });
+
+  test('an incomplete measurement contributes no finding', () => {
+    const incomplete: Measurement = { id: 'x', kind: 'distance', name: '', points: [[0, 0, 0]] };
+    expect(measurementsToFindings([incomplete], up, 1)).toHaveLength(0);
+  });
+});

--- a/tests/reportManifest.test.ts
+++ b/tests/reportManifest.test.ts
@@ -27,10 +27,16 @@ function input(over: Partial<ReportManifestInput> = {}): ReportManifestInput {
 }
 
 describe('reportManifest', () => {
-  test('a freshly built manifest verifies', () => {
+  test('a freshly built manifest verifies and names its digest algorithm', () => {
     const m = buildReportManifest(input());
-    expect(m.signature).toBeTruthy();
+    expect(m.digest).toBeTruthy();
+    expect(m.digestAlgorithm).toBe('FNV-1a-32');
     expect(verifyReportManifest(m)).toBe(true);
+  });
+
+  test('the named digest algorithm is covered by the digest (cannot be forged)', () => {
+    const m = buildReportManifest(input());
+    expect(verifyReportManifest({ ...m, digestAlgorithm: 'SHA-256' })).toBe(false);
   });
 
   test('altering a finding value (or its band) breaks verification', () => {
@@ -41,8 +47,8 @@ describe('reportManifest', () => {
     expect(verifyReportManifest(tamperedBand)).toBe(false);
   });
 
-  test('the signature is deterministic for identical input', () => {
-    expect(buildReportManifest(input()).signature).toBe(buildReportManifest(input()).signature);
+  test('the digest is deterministic for identical input', () => {
+    expect(buildReportManifest(input()).digest).toBe(buildReportManifest(input()).digest);
   });
 
   test('findings carry their uncertainty band and caveats through', () => {
@@ -51,7 +57,7 @@ describe('reportManifest', () => {
     expect(m.findings[0].caveats?.[0]).toMatch(/base plane/i);
   });
 
-  test('provenance (edit epoch + audit trail) is part of the signed body', () => {
+  test('provenance (edit epoch + audit trail) is part of the digested body', () => {
     const m = buildReportManifest(input({ edits: [{ seq: 0, type: 'reclassify', hash: 'abc' }] }));
     // Forging the epoch after signing must fail verification.
     expect(verifyReportManifest({ ...m, classificationEpoch: 0 })).toBe(false);
@@ -60,7 +66,7 @@ describe('reportManifest', () => {
   test('serialize is canonical / stable and an injected hash is honoured', () => {
     const tag: typeof fnv1a = (s) => `H${s.length}`;
     const m = buildReportManifest(input(), tag);
-    expect(m.signature.startsWith('H')).toBe(true);
+    expect(m.digest.startsWith('H')).toBe(true);
     expect(verifyReportManifest(m, tag)).toBe(true);
     expect(verifyReportManifest(m, fnv1a)).toBe(false); // wrong hash fn
     expect(serializeReportManifest(m)).toBe(serializeReportManifest(buildReportManifest(input(), tag)));

--- a/tests/reportManifest.test.ts
+++ b/tests/reportManifest.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from 'vitest';
+import {
+  buildReportManifest,
+  serializeReportManifest,
+  verifyReportManifest,
+  type ReportManifestInput,
+} from '../src/render/measure/reportManifest';
+import { fnv1a } from '../src/render/measure/auditLog';
+
+function input(over: Partial<ReportManifestInput> = {}): ReportManifestInput {
+  return {
+    dataset: { id: 'site-a', crs: 'EPSG:6433', pointCount: 4_200_000 },
+    generatedAt: '2026-06-27T00:00:00Z',
+    classificationEpoch: 2,
+    findings: [
+      {
+        label: 'Stockpile volume',
+        value: 1254,
+        unit: 'm³',
+        sigma: 41,
+        confidence: 'medium',
+        caveats: ['Point-sample estimate over a lowest-ground base plane.'],
+      },
+    ],
+    ...over,
+  };
+}
+
+describe('reportManifest', () => {
+  test('a freshly built manifest verifies', () => {
+    const m = buildReportManifest(input());
+    expect(m.signature).toBeTruthy();
+    expect(verifyReportManifest(m)).toBe(true);
+  });
+
+  test('altering a finding value (or its band) breaks verification', () => {
+    const m = buildReportManifest(input());
+    const tamperedValue = { ...m, findings: [{ ...m.findings[0], value: 9999 }] };
+    const tamperedBand = { ...m, findings: [{ ...m.findings[0], sigma: 1 }] };
+    expect(verifyReportManifest(tamperedValue)).toBe(false);
+    expect(verifyReportManifest(tamperedBand)).toBe(false);
+  });
+
+  test('the signature is deterministic for identical input', () => {
+    expect(buildReportManifest(input()).signature).toBe(buildReportManifest(input()).signature);
+  });
+
+  test('findings carry their uncertainty band and caveats through', () => {
+    const m = buildReportManifest(input());
+    expect(m.findings[0].sigma).toBe(41);
+    expect(m.findings[0].caveats?.[0]).toMatch(/base plane/i);
+  });
+
+  test('provenance (edit epoch + audit trail) is part of the signed body', () => {
+    const m = buildReportManifest(input({ edits: [{ seq: 0, type: 'reclassify', hash: 'abc' }] }));
+    // Forging the epoch after signing must fail verification.
+    expect(verifyReportManifest({ ...m, classificationEpoch: 0 })).toBe(false);
+  });
+
+  test('serialize is canonical / stable and an injected hash is honoured', () => {
+    const tag: typeof fnv1a = (s) => `H${s.length}`;
+    const m = buildReportManifest(input(), tag);
+    expect(m.signature.startsWith('H')).toBe(true);
+    expect(verifyReportManifest(m, tag)).toBe(true);
+    expect(verifyReportManifest(m, fnv1a)).toBe(false); // wrong hash fn
+    expect(serializeReportManifest(m)).toBe(serializeReportManifest(buildReportManifest(input(), tag)));
+  });
+});

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -262,6 +262,19 @@ describe('parseSession — tolerance', () => {
     expect(back.scanSummary?.crsUnit).toBe('metre');
   });
 
+  it('clamps a pathological pointSize on parse (defense in depth)', () => {
+    const huge = parseSession(serializeSession({
+      ...sampleSession(),
+      render: { pointSize: 1e9, edlEnabled: false, edlStrength: 0.4, pointSizeMode: 'adaptive', antialiasing: true },
+    }));
+    expect(huge.render?.pointSize).toBe(8);
+    const tiny = parseSession(serializeSession({
+      ...sampleSession(),
+      render: { pointSize: 0.01, edlEnabled: false, edlStrength: 0.4, pointSizeMode: 'adaptive', antialiasing: true },
+    }));
+    expect(tiny.render?.pointSize).toBe(1);
+  });
+
   it('v3+ — a session without optional fields parses cleanly with them undefined', () => {
     const back = parseSession(serializeSession(sampleSession()));
     expect(back.version).toBe(SESSION_VERSION);

--- a/tests/sessionFindings.test.ts
+++ b/tests/sessionFindings.test.ts
@@ -74,7 +74,7 @@ describe('converters preserve band + caveats', () => {
   });
 });
 
-describe('ledger feeds a signed report end-to-end', () => {
+describe('ledger feeds an integrity report end-to-end', () => {
   test('findings assembled into a manifest verify, and tampering one breaks it', () => {
     const f = new SessionFindings();
     f.add(stockpileFinding(stock()));

--- a/tests/sessionFindings.test.ts
+++ b/tests/sessionFindings.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from 'vitest';
+import {
+  SessionFindings,
+  stockpileFinding,
+  changeFinding,
+} from '../src/render/measure/sessionFindings';
+import type { StockpileVolumeResult } from '../src/render/measure/stockpileVolume';
+import { changeVolumeUncertainty } from '../src/terrain/change/changeUncertainty';
+import { buildReportManifest, verifyReportManifest } from '../src/render/measure/reportManifest';
+
+function stock(over: Partial<StockpileVolumeResult> = {}): StockpileVolumeResult {
+  return {
+    volume: 1000,
+    cut: 0,
+    sigma: 30,
+    low: 970,
+    high: 1030,
+    relativeError: 0.03,
+    confidence: 'high',
+    breakdown: {
+      footprintArea: 100,
+      pointsInPolygon: 4000,
+      density: 40,
+      baseZ: 0,
+      baseMode: 'lowest-percentile',
+      baseUncertainty: 0.05,
+      meanThickness: 10,
+      thicknessStdDev: 1,
+      samplingError: 10,
+      basePlaneError: 28,
+    },
+    validity: 'ok',
+    caveats: ['Point-sample estimate.'],
+    ...over,
+  };
+}
+
+describe('SessionFindings ledger', () => {
+  test('collects findings in order and clears', () => {
+    const f = new SessionFindings();
+    f.add({ label: 'A', value: 1, unit: 'm³' });
+    f.add({ label: 'B', value: 2, unit: 'm³' });
+    expect(f.count).toBe(2);
+    expect(f.all.map((x) => x.label)).toEqual(['A', 'B']);
+    expect(f.pop()?.label).toBe('B');
+    f.clear();
+    expect(f.count).toBe(0);
+  });
+});
+
+describe('converters preserve band + caveats', () => {
+  test('stockpileFinding carries the band and converts units (lin = 0.3048)', () => {
+    const ft = stockpileFinding(stock({ volume: 1000, sigma: 0 }), 0.3048);
+    expect(ft.unit).toBe('m³');
+    expect(ft.value).toBeCloseTo(1000 * 0.3048 ** 3, 6); // ≈ 28.3 m³
+    const m = stockpileFinding(stock());
+    expect(m.sigma).toBe(30);
+    expect(m.confidence).toBe('high');
+    expect(m.caveats?.[0]).toMatch(/point-sample/i);
+  });
+
+  test('changeFinding carries detectability honesty', () => {
+    const u = changeVolumeUncertainty({
+      netVolumeM3: 2,
+      significantCells: 400,
+      cellAreaM2: 1,
+      cellSigmaM: 0.05,
+      registrationSigmaM: 0.02,
+    });
+    const finding = changeFinding(2, u);
+    expect(finding.value).toBe(2);
+    expect(finding.confidence).toBe('low');
+    expect(finding.caveats?.join(' ')).toMatch(/not distinguishable from survey noise/i);
+  });
+});
+
+describe('ledger feeds a signed report end-to-end', () => {
+  test('findings assembled into a manifest verify, and tampering one breaks it', () => {
+    const f = new SessionFindings();
+    f.add(stockpileFinding(stock()));
+    const manifest = buildReportManifest({
+      dataset: { id: 'site-a' },
+      generatedAt: '2026-06-27T00:00:00Z',
+      findings: f.all,
+    });
+    expect(verifyReportManifest(manifest)).toBe(true);
+    const tampered = { ...manifest, findings: [{ ...manifest.findings[0], sigma: 0 }] };
+    expect(verifyReportManifest(tampered)).toBe(false);
+  });
+});

--- a/tests/stockpilePresenter.test.ts
+++ b/tests/stockpilePresenter.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from 'vitest';
+import { presentStockpile, stockpileToastLine } from '../src/render/measure/stockpilePresenter';
+import type { StockpileVolumeResult } from '../src/render/measure/stockpileVolume';
+
+function result(over: Partial<StockpileVolumeResult> = {}): StockpileVolumeResult {
+  return {
+    volume: 1254,
+    cut: 12,
+    sigma: 41,
+    low: 1213,
+    high: 1295,
+    relativeError: 0.0327,
+    confidence: 'medium',
+    breakdown: {
+      footprintArea: 318.4,
+      pointsInPolygon: 4200,
+      density: 13.2,
+      baseZ: 102.5,
+      baseMode: 'lowest-percentile',
+      baseUncertainty: 0.08,
+      meanThickness: 3.94,
+      thicknessStdDev: 1.1,
+      samplingError: 18,
+      basePlaneError: 25,
+    },
+    validity: 'ok',
+    caveats: ['Point-sample estimate over a horizontal base plane.'],
+    ...over,
+  };
+}
+
+describe('presentStockpile', () => {
+  test('headline carries the volume and its ± band, with relative %', () => {
+    const v = presentStockpile(result());
+    expect(v.headline).toBe('1,254 m³ ± 41');
+    expect(v.relative).toBe('±3.3%');
+    expect(v.confidence).toBe('medium');
+    expect(v.confidenceLabel).toBe('Medium');
+  });
+
+  test('breakdown rows show the math (footprint, base, both error terms)', () => {
+    const v = presentStockpile(result());
+    const byLabel = Object.fromEntries(v.rows.map((r) => [r.label, r.value]));
+    expect(byLabel['Footprint']).toBe('318.4 m²');
+    expect(byLabel['Points in footprint']).toBe('4,200');
+    expect(byLabel['Base plane']).toMatch(/lowest ground, ±0.08 m/);
+    expect(byLabel['Sampling error']).toBe('± 18 m³');
+    expect(byLabel['Base-plane error']).toBe('± 25 m³');
+  });
+
+  test('a foot-CRS result converts to true metres (lin = 0.3048)', () => {
+    // Same native figures, but in feet → volume in m³ is value × 0.3048³.
+    const v = presentStockpile(result({ volume: 1000, sigma: 0 }), { lin: 0.3048 });
+    // 1000 ft³ ≈ 28 m³.
+    expect(v.headline).toBe('28 m³ ± 0');
+  });
+
+  test('explicit base reads "(set)", not "(lowest ground)"', () => {
+    const v = presentStockpile(
+      result({ breakdown: { ...result().breakdown, baseMode: 'explicit', baseUncertainty: 0 } }),
+    );
+    const base = v.rows.find((r) => r.label === 'Base plane')!.value;
+    expect(base).toMatch(/\(set\)/);
+    expect(base).not.toMatch(/lowest ground/);
+  });
+
+  test('toast line is a single readable summary', () => {
+    expect(stockpileToastLine(presentStockpile(result()))).toBe(
+      'Stockpile: 1,254 m³ ± 41 (±3.3%) · Medium confidence',
+    );
+  });
+
+  test('caveats pass through verbatim', () => {
+    const v = presentStockpile(result({ caveats: ['only 12 points — indicative'] }));
+    expect(v.caveats).toEqual(['only 12 points — indicative']);
+  });
+});

--- a/tests/stockpileVolume.test.ts
+++ b/tests/stockpileVolume.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect } from 'vitest';
+import { stockpileVolume } from '../src/render/measure/stockpileVolume';
+import type { Vec3 } from '../src/render/navMath';
+
+/** Square footprint [0,0]–[size,size] on the z=0 plane. */
+function squareFootprint(size: number): Vec3[] {
+  return [
+    [0, 0, 0],
+    [size, 0, 0],
+    [size, size, 0],
+    [0, size, 0],
+  ];
+}
+
+/** A regular grid of points strictly inside a [0,size]² footprint, height = h(x,y). */
+function grid(size: number, step: number, h: (x: number, y: number) => number): Float32Array {
+  const out: number[] = [];
+  for (let x = step; x < size; x += step) {
+    for (let y = step; y < size; y += step) {
+      out.push(x, y, h(x, y));
+    }
+  }
+  return Float32Array.from(out);
+}
+
+describe('stockpileVolume — volume + auditable band', () => {
+  test('uniform slab against an explicit base gives the exact area×thickness volume, ~zero band', () => {
+    // 10×10 footprint, every point 2 m above an explicit base of 0 → 100·2 = 200 m³.
+    const r = stockpileVolume({
+      polygon: squareFootprint(10),
+      positions: grid(10, 0.25, () => 2),
+      base: { mode: 'explicit', z: 0 },
+    });
+    expect(r.validity).toBe('ok');
+    expect(r.volume).toBeCloseTo(200, 1);
+    expect(r.cut).toBeCloseTo(0, 6);
+    expect(r.breakdown.footprintArea).toBeCloseTo(100, 1);
+    expect(r.breakdown.meanThickness).toBeCloseTo(2, 6);
+    expect(r.breakdown.baseZ).toBe(0);
+    // Flat top + explicit base ⇒ both error terms vanish ⇒ tight band.
+    expect(r.sigma).toBeCloseTo(0, 4);
+    expect(r.confidence).toBe('high');
+  });
+
+  test('sigma is the quadrature of the sampling and base-plane errors', () => {
+    const r = stockpileVolume({
+      polygon: squareFootprint(10),
+      positions: grid(10, 0.3, (x) => (x / 10) * 4), // a 0→4 m ramp: real thickness variance
+      base: { mode: 'explicit', z: 0 },
+    });
+    expect(r.breakdown.samplingError).toBeGreaterThan(0);
+    expect(r.sigma).toBeCloseTo(
+      Math.hypot(r.breakdown.samplingError, r.breakdown.basePlaneError),
+      6,
+    );
+    expect(r.low).toBeLessThan(r.volume);
+    expect(r.high).toBeGreaterThan(r.volume);
+    expect(r.relativeError).toBeGreaterThan(0);
+  });
+
+  test('noisy ground produces a non-zero base-plane error term', () => {
+    // Deterministic pseudo-noise on the ground band widens the inferred base.
+    let s = 1;
+    const noise = (): number => {
+      s = (s * 1103515245 + 12345) & 0x7fffffff;
+      return (s / 0x7fffffff - 0.5) * 0.6; // ±0.3 m
+    };
+    const r = stockpileVolume({
+      polygon: squareFootprint(10),
+      positions: grid(10, 0.25, () => 2 + noise()),
+      base: { mode: 'lowest-percentile', percentile: 0.05 },
+    });
+    expect(r.breakdown.baseUncertainty).toBeGreaterThan(0);
+    expect(r.breakdown.basePlaneError).toBeGreaterThan(0);
+    expect(r.sigma).toBeGreaterThanOrEqual(r.breakdown.basePlaneError - 1e-9);
+  });
+
+  test('lowest-percentile base sits on the ground apron under a raised plateau', () => {
+    // Apron at z=0, a central plateau at z=3 within radius 3 of the centre.
+    const r = stockpileVolume({
+      polygon: squareFootprint(10),
+      positions: grid(10, 0.25, (x, y) => (Math.hypot(x - 5, y - 5) < 3 ? 3 : 0)),
+      base: { mode: 'lowest-percentile', percentile: 0.05 },
+    });
+    expect(r.breakdown.baseMode).toBe('lowest-percentile');
+    expect(r.breakdown.baseZ).toBeLessThan(0.5); // base locked onto the apron
+    expect(r.volume).toBeGreaterThan(0);
+    expect(r.caveats.join(' ')).toMatch(/base plane/i);
+  });
+
+  test('a sparse footprint grades low and says so', () => {
+    const r = stockpileVolume({
+      polygon: squareFootprint(10),
+      positions: grid(10, 2, () => 2), // ~16 points inside
+      base: { mode: 'explicit', z: 0 },
+    });
+    expect(r.breakdown.pointsInPolygon).toBeLessThan(100);
+    expect(r.confidence).toBe('low');
+    expect(r.caveats.join(' ')).toMatch(/indicative, not measured/i);
+  });
+
+  test('a degenerate (collinear) footprint returns zeros, not a fake number', () => {
+    const r = stockpileVolume({
+      polygon: [
+        [0, 0, 0],
+        [1, 1, 0],
+        [2, 2, 0],
+      ],
+      positions: grid(10, 0.5, () => 2),
+      base: { mode: 'explicit', z: 0 },
+    });
+    expect(r.validity).not.toBe('ok');
+    expect(r.volume).toBe(0);
+  });
+});

--- a/tests/stockpileVolume.test.ts
+++ b/tests/stockpileVolume.test.ts
@@ -42,6 +42,21 @@ describe('stockpileVolume — volume + auditable band', () => {
     expect(r.confidence).toBe('high');
   });
 
+  test('a device-reduced cloud adds a representative-sample caveat', () => {
+    const base = {
+      polygon: squareFootprint(10),
+      positions: grid(10, 0.25, () => 2),
+      base: { mode: 'explicit', z: 0 } as const,
+    };
+    const full = stockpileVolume({ ...base, sourceReduced: false });
+    const reduced = stockpileVolume({ ...base, sourceReduced: true });
+    // Same geometry → same volume; only the caveat set differs.
+    expect(reduced.volume).toBeCloseTo(full.volume, 6);
+    expect(full.caveats.join(' ')).not.toMatch(/reduced to fit your device/i);
+    expect(reduced.caveats.join(' ')).toMatch(/reduced to fit your device/i);
+    expect(reduced.caveats.join(' ')).toMatch(/representative sample/i);
+  });
+
   test('sigma is the quadrature of the sampling and base-plane errors', () => {
     const r = stockpileVolume({
       polygon: squareFootprint(10),

--- a/tests/stockpileVolume.test.ts
+++ b/tests/stockpileVolume.test.ts
@@ -99,6 +99,33 @@ describe('stockpileVolume — volume + auditable band', () => {
     expect(r.caveats.join(' ')).toMatch(/indicative, not measured/i);
   });
 
+  test('a sloped ground apron widens the band vs a flat apron (systematic base mis-fit)', () => {
+    const size = 10;
+    const step = 0.25;
+    const pile = (x: number, y: number): number => (Math.hypot(x - 5, y - 5) < 3 ? 3 : 0);
+    const flat = stockpileVolume({
+      polygon: squareFootprint(size),
+      positions: grid(size, step, (x, y) => pile(x, y)), // flat z=0 apron + pile
+      base: { mode: 'lowest-percentile', percentile: 0.05 },
+    });
+    const sloped = stockpileVolume({
+      polygon: squareFootprint(size),
+      // Same pile, but the apron ramps 0→2 m across x — a single horizontal base
+      // is now systematically wrong, biasing every thickness the same way.
+      positions: grid(size, step, (x, y) => (x / size) * 2 + pile(x, y)),
+      base: { mode: 'lowest-percentile', percentile: 0.05 },
+    });
+    expect(flat.validity).toBe('ok');
+    expect(sloped.validity).toBe('ok');
+    // Flat apron ⇒ clean base ⇒ near-zero base-plane error. Sloped apron ⇒ the
+    // systematic mis-fit term kicks in ⇒ strictly larger base error and band.
+    expect(sloped.breakdown.baseUncertainty).toBeGreaterThan(
+      flat.breakdown.baseUncertainty + 0.1,
+    );
+    expect(sloped.breakdown.basePlaneError).toBeGreaterThan(flat.breakdown.basePlaneError);
+    expect(sloped.sigma).toBeGreaterThan(flat.sigma);
+  });
+
   test('a degenerate (collinear) footprint returns zeros, not a fake number', () => {
     const r = stockpileVolume({
       polygon: [

--- a/tests/undoRouter.test.ts
+++ b/tests/undoRouter.test.ts
@@ -1,0 +1,108 @@
+/**
+ * undoRouter.test.ts — the most-recent-stack Undo/Redo arbiter.
+ *
+ * The viewer has two independent edit histories (annotations + classification).
+ * A global Ctrl/Cmd+Z must undo whichever the user touched last, then fall
+ * through to the other once the first empties. These tests lock that contract
+ * and the suppression guard that keeps programmatic replay from corrupting the
+ * router's memory.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  noteEdit,
+  pickUndo,
+  pickRedo,
+  withSuppressed,
+  _resetUndoRouter,
+} from '../src/ui/undoRouter';
+
+beforeEach(() => _resetUndoRouter());
+
+describe('pickUndo — most-recent stack wins', () => {
+  it('undoes the most-recently-edited stack when both have items', () => {
+    noteEdit('annotation');
+    noteEdit('classification'); // classification is now most recent
+    expect(pickUndo(true, true)).toBe('classification');
+  });
+
+  it('targets annotation when it was edited last', () => {
+    noteEdit('classification');
+    noteEdit('annotation');
+    expect(pickUndo(true, true)).toBe('annotation');
+  });
+
+  it('falls through to the other stack when the preferred one is empty', () => {
+    noteEdit('classification');
+    // classification preferred, but it has nothing undoable → annotation
+    expect(pickUndo(true, false)).toBe('annotation');
+  });
+
+  it('returns null when nothing can be undone', () => {
+    noteEdit('annotation');
+    expect(pickUndo(false, false)).toBeNull();
+  });
+
+  it('stays on a stack for consecutive undos until it empties', () => {
+    noteEdit('classification');
+    expect(pickUndo(true, true)).toBe('classification');
+    expect(pickUndo(true, true)).toBe('classification'); // still class
+    expect(pickUndo(true, false)).toBe('annotation'); // class empty → anno
+  });
+});
+
+describe('pickRedo — mirrors the most-recent undo', () => {
+  it('redoes the stack that was just undone', () => {
+    noteEdit('classification');
+    pickUndo(true, true); // undo classification
+    expect(pickRedo(true, true)).toBe('classification');
+  });
+
+  it('redoes annotation after an annotation undo', () => {
+    noteEdit('annotation');
+    pickUndo(true, true);
+    expect(pickRedo(true, true)).toBe('annotation');
+  });
+
+  it('falls through when the mirrored stack has nothing to redo', () => {
+    noteEdit('classification');
+    pickUndo(true, true);
+    expect(pickRedo(true, false)).toBe('annotation');
+  });
+});
+
+describe('withSuppressed — programmatic replay does not rewrite memory', () => {
+  it('ignores noteEdit while suppressed', () => {
+    noteEdit('classification'); // user edit
+    withSuppressed(() => {
+      // The annotation controller's onChange fires during a programmatic
+      // undo and calls noteEdit('annotation') — this must be ignored.
+      noteEdit('annotation');
+    });
+    // classification is still the most-recent user-edited stack.
+    expect(pickUndo(true, true)).toBe('classification');
+  });
+
+  it('restores the prior suppression state (nestable)', () => {
+    let inner: unknown;
+    withSuppressed(() => {
+      withSuppressed(() => {
+        inner = noteEdit('annotation'); // suppressed
+      });
+      // still suppressed here
+      noteEdit('classification');
+    });
+    expect(inner).toBeUndefined();
+    // nothing was noted while suppressed → both edits ignored, fallback order
+    expect(pickUndo(true, true)).toBe('annotation'); // default order anno-first
+  });
+});
+
+describe('fresh edit clears the redo target', () => {
+  it('a new edit after an undo prevents a stale redo from winning', () => {
+    noteEdit('annotation');
+    pickUndo(true, true); // undo annotation; lastUndone = annotation
+    noteEdit('classification'); // new user edit clears lastUndone
+    // Redo should now prefer the freshly-edited classification stack.
+    expect(pickRedo(true, true)).toBe('classification');
+  });
+});


### PR DESCRIPTION
## What this changes

Lands the v0.5.1 line on top of v0.5.0. Two themes:

**Interaction improvements**
- Ctrl/Cmd-Z undo now reaches whichever history you touched last (annotations or classification) — most-recent-stack routing
- Hold-Space to hand the mouse back to camera nav mid-tool
- Right-click context menu on a loaded scan (focus / frame / standard views)
- Accurate keyboard help sheet, regenerated from the real bindings
- Higher static-cloud render budget on capable desktops

**Release-safety hardening**
- Route all runtime dynamic imports through `lazyChunks.ts` so the live obfuscator pass can't scramble inline `import()` specifiers into 404s (root cause of an earlier live-only crash)
- Foot-CRS volume export now converts native units → m³ correctly
- Report digest renamed/honest: FNV-1a content digest, explicitly not a cryptographic signature
- New `lazyChunkLoad.spec.ts` guard runs against the minified build in CI

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / internal change
- [x] Build, CI, or tooling

## How it was tested

- Full e2e suite on Chromium (WebGPU backend): 135 passed, 5 device-gated skips, 0 failures
- `test:smoke:live` (lazy-chunk guard against the obfuscated build): passed
- Unit/UI/terrain/slow buckets all green; chunk-isolation canary 11/11

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] New behavior has unit tests where the logic is pure
- [ ] Docs updated if behavior or formats changed  *(release notes + changelog done; `docs/navigation.md` / `USER_GUIDE.md` shortcut coverage deferred)*