### PR TITLE
Update the three bundled fonts to 5.3.0

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,9 +18,9 @@ end of the file.
 | laz-perf | ^0.0.7 | 0.0.7 | Apache-2.0 | https://github.com/hobuinc/laz-perf |
 | pdf-lib | ^1.17.1 | 1.17.1 | MIT | https://github.com/Hopding/pdf-lib |
 | proj4 | ^2.20.8 | 2.20.9 | MIT | https://github.com/proj4js/proj4js |
-| @fontsource-variable/inter | ^5.2.8 | 5.2.8 | OFL-1.1 | https://github.com/rsms/inter |
-| @fontsource/manrope | ^5.2.8 | 5.2.8 | OFL-1.1 | https://github.com/sharanda/manrope |
-| @fontsource/jetbrains-mono | ^5.2.8 | 5.2.8 | OFL-1.1 | https://github.com/JetBrains/JetBrainsMono |
+| @fontsource-variable/inter | ^5.3.0 | 5.3.0 | OFL-1.1 | https://github.com/rsms/inter |
+| @fontsource/manrope | ^5.3.0 | 5.3.0 | OFL-1.1 | https://github.com/sharanda/manrope |
+| @fontsource/jetbrains-mono | ^5.3.0 | 5.3.0 | OFL-1.1 | https://github.com/JetBrains/JetBrainsMono |
 
 ## Development-only dependencies (not bundled into the shipped build)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@fontsource-variable/inter": "^5.2.8",
-        "@fontsource/jetbrains-mono": "^5.2.8",
-        "@fontsource/manrope": "^5.2.8",
+        "@fontsource-variable/inter": "^5.3.0",
+        "@fontsource/jetbrains-mono": "^5.3.0",
+        "@fontsource/manrope": "^5.3.0",
         "@loaders.gl/core": "^4.4.2",
         "@loaders.gl/gltf": "^4.4.2",
         "@loaders.gl/obj": "^4.4.2",
@@ -931,27 +931,27 @@
       }
     },
     "node_modules/@fontsource-variable/inter": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
-      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource/jetbrains-mono": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
-      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
+      "integrity": "sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource/manrope": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/manrope/-/manrope-5.2.8.tgz",
-      "integrity": "sha512-gJHJmcuUk7qWcNCfcAri/DJQtXtBYqi9yKratr4jXhSo0I3xUtNNKI+igQIcw5c+m95g0vounk8ZnX/kb8o0TA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/manrope/-/manrope-5.3.0.tgz",
+      "integrity": "sha512-obJ1Dv3+uCA6HlHgW8u4BGYxJR9In2HW7gjJhlflEvkrj1X1iSEwu0fToL+JYGC/FEKFfIz1sBuPduvcL2gIAA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openlidarviewer",
   "version": "0.6.0",
-  "description": "Open any 3D scan \u2014 drone LiDAR, terrestrial laser scan, or phone scan \u2014 instantly and privately, in a browser tab. No install, no upload, no conversion.",
+  "description": "Open any 3D scan — drone LiDAR, terrestrial laser scan, or phone scan — instantly and privately, in a browser tab. No install, no upload, no conversion.",
   "license": "MIT",
   "author": "A. Urias",
   "homepage": "https://lidar.aurtech.mx/",
@@ -85,9 +85,9 @@
     "lint:archive-vocab": "node scripts/lint-archive-vocab.mjs"
   },
   "dependencies": {
-    "@fontsource-variable/inter": "^5.2.8",
-    "@fontsource/jetbrains-mono": "^5.2.8",
-    "@fontsource/manrope": "^5.2.8",
+    "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource/jetbrains-mono": "^5.3.0",
+    "@fontsource/manrope": "^5.3.0",
     "@loaders.gl/core": "^4.4.2",
     "@loaders.gl/gltf": "^4.4.2",
     "@loaders.gl/obj": "^4.4.2",

--- a/sbom.json
+++ b/sbom.json
@@ -125,8 +125,8 @@
       "type": "library",
       "name": "inter",
       "group": "@fontsource-variable",
-      "version": "5.2.8",
-      "bom-ref": "openlidarviewer@0.6.0|@fontsource-variable/inter@5.2.8",
+      "version": "5.3.0",
+      "bom-ref": "openlidarviewer@0.6.0|@fontsource-variable/inter@5.3.0",
       "author": "Google Inc.",
       "description": "Self-host the Inter font in a neatly bundled NPM package.",
       "licenses": [
@@ -137,7 +137,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/%40fontsource-variable/inter@5.2.8",
+      "purl": "pkg:npm/%40fontsource-variable/inter@5.3.0",
       "externalReferences": [
         {
           "url": "git+https://github.com/fontsource/font-files.git#fonts/variable/inter",
@@ -155,7 +155,7 @@
           "comment": "as detected from PackageJson property \"bugs.url\""
         },
         {
-          "url": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+          "url": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
@@ -171,8 +171,8 @@
       "type": "library",
       "name": "jetbrains-mono",
       "group": "@fontsource",
-      "version": "5.2.8",
-      "bom-ref": "openlidarviewer@0.6.0|@fontsource/jetbrains-mono@5.2.8",
+      "version": "5.3.0",
+      "bom-ref": "openlidarviewer@0.6.0|@fontsource/jetbrains-mono@5.3.0",
       "author": "Google Inc.",
       "description": "Self-host the JetBrains Mono font in a neatly bundled NPM package.",
       "licenses": [
@@ -183,7 +183,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/%40fontsource/jetbrains-mono@5.2.8",
+      "purl": "pkg:npm/%40fontsource/jetbrains-mono@5.3.0",
       "externalReferences": [
         {
           "url": "git+https://github.com/fontsource/font-files.git#fonts/google/jetbrains-mono",
@@ -201,7 +201,7 @@
           "comment": "as detected from PackageJson property \"bugs.url\""
         },
         {
-          "url": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+          "url": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
@@ -217,8 +217,8 @@
       "type": "library",
       "name": "manrope",
       "group": "@fontsource",
-      "version": "5.2.8",
-      "bom-ref": "openlidarviewer@0.6.0|@fontsource/manrope@5.2.8",
+      "version": "5.3.0",
+      "bom-ref": "openlidarviewer@0.6.0|@fontsource/manrope@5.3.0",
       "author": "Google Inc.",
       "description": "Self-host the Manrope font in a neatly bundled NPM package.",
       "licenses": [
@@ -229,7 +229,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/%40fontsource/manrope@5.2.8",
+      "purl": "pkg:npm/%40fontsource/manrope@5.3.0",
       "externalReferences": [
         {
           "url": "git+https://github.com/fontsource/font-files.git#fonts/google/manrope",
@@ -247,7 +247,7 @@
           "comment": "as detected from PackageJson property \"bugs.url\""
         },
         {
-          "url": "https://registry.npmjs.org/@fontsource/manrope/-/manrope-5.2.8.tgz",
+          "url": "https://registry.npmjs.org/@fontsource/manrope/-/manrope-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }


### PR DESCRIPTION
Bumps the three bundled fonts to 5.3.0: `@fontsource/manrope`, `@fontsource-variable/inter`, and `@fontsource/jetbrains-mono`.

Dependabot opened these as #36, #37, and #38, but each failed CI on its own: a version bump leaves `THIRD_PARTY_NOTICES.md` and `sbom.json` pointing at the old version, which the release-truth and SBOM lints reject, and Dependabot cannot edit those files. This does all three in one commit and updates both files to match, so the lints stay green. It supersedes the three Dependabot PRs.
