### PR TITLE
Add the Zenodo DOI to citation metadata and README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,13 @@ date-released: "2026-07-24"
 license: MIT
 repository-code: "https://github.com/Aurtechmx/openlidarviewer"
 url: "https://lidar.aurtech.mx/"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.21544620"
+    description: "Archived v0.6.0 release"
+  - type: doi
+    value: "10.5281/zenodo.21544619"
+    description: "Concept DOI (all versions)"
 
 abstract: >-
   OpenLiDARViewer is an open-source, local-first, browser-native platform

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/aurtechmx/openlidarviewer/actions/workflows/ci.yml/badge.svg)](https://github.com/aurtechmx/openlidarviewer/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/aurtechmx/openlidarviewer?color=2F6BFF)](https://github.com/aurtechmx/openlidarviewer/releases/latest)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21544619.svg)](https://doi.org/10.5281/zenodo.21544619)
 [![Live demo](https://img.shields.io/badge/live%20demo-lidar.aurtech.mx-19C2D8)](https://lidar.aurtech.mx/)
 ![Status](https://img.shields.io/badge/status-R%26D%20Prototype-teal)
 ![Rendering](https://img.shields.io/badge/rendering-WebGL%20%2F%20WebGPU-blue)


### PR DESCRIPTION
The v0.6.0 release is now archived on Zenodo.

- `CITATION.cff` records both the version DOI (`10.5281/zenodo.21544620`, this release) and the concept DOI (`10.5281/zenodo.21544619`, always-latest), following the standard Zenodo citation pattern.
- The README gets a DOI badge using the concept DOI, so it always points at the newest archived version.

Docs-only; both `lint:release-sync` and `lint:release-truth` stay green.
