### PR TITLE
Terminate the E57 XML parser on truncated input

### DIFF
--- a/src/io/e57/xml.ts
+++ b/src/io/e57/xml.ts
@@ -82,21 +82,29 @@ export function parseXml(source: string): XmlNode {
         continue;
       }
       if (source.startsWith('</', i)) {
-        i = source.indexOf('>', i) + 1;
+        const gt = source.indexOf('>', i);
+        // A missing '>' used to leave the cursor at 0 and re-parse forever.
+        if (gt === -1) throw new Error('Invalid XML: unterminated end tag.');
+        i = gt + 1;
         return;
       }
       if (source.startsWith('<![CDATA[', i)) {
         const end = source.indexOf(']]>', i);
+        if (end === -1) throw new Error('Invalid XML: unterminated CDATA section.');
         node.text += source.slice(i + 9, end);
         i = end + 3;
         continue;
       }
       if (source.startsWith('<!--', i)) {
-        i = source.indexOf('-->', i) + 3;
+        const end = source.indexOf('-->', i);
+        if (end === -1) throw new Error('Invalid XML: unterminated comment.');
+        i = end + 3;
         continue;
       }
       if (source.startsWith('<?', i)) {
-        i = source.indexOf('?>', i) + 2;
+        const end = source.indexOf('?>', i);
+        if (end === -1) throw new Error('Invalid XML: unterminated processing instruction.');
+        i = end + 2;
         continue;
       }
       node.children.push(parseElement());
@@ -107,11 +115,15 @@ export function parseXml(source: string): XmlNode {
   for (;;) {
     skipSpace();
     if (source.startsWith('<?', i)) {
-      i = source.indexOf('?>', i) + 2;
+      const end = source.indexOf('?>', i);
+      if (end === -1) throw new Error('Invalid XML: unterminated processing instruction.');
+      i = end + 2;
       continue;
     }
     if (source.startsWith('<!--', i)) {
-      i = source.indexOf('-->', i) + 3;
+      const end = source.indexOf('-->', i);
+      if (end === -1) throw new Error('Invalid XML: unterminated comment.');
+      i = end + 3;
       continue;
     }
     break;

--- a/tests/e57XmlUnterminated.test.ts
+++ b/tests/e57XmlUnterminated.test.ts
@@ -1,0 +1,54 @@
+/**
+ * e57XmlUnterminated.test.ts — the E57 XML parser must TERMINATE on a
+ * truncated document, not spin.
+ *
+ * `parseXml` advanced past each `<![CDATA[`, `<!--` and `<?…?>` by jumping to
+ * the index AFTER its closing delimiter. When the delimiter was missing,
+ * `String.indexOf` returned -1 and the cursor jumped to a tiny fixed index
+ * (2, or 1) instead of end-of-input, so the parser re-read the same bytes
+ * forever. In production this runs in the shared, gated parse worker: an
+ * unterminated section hung the worker at 100% CPU, the load promise never
+ * settled, and — because the gate is released in a `finally` that never ran —
+ * every subsequent file load in the session hung too. Only a reload recovered.
+ *
+ * Each case must throw a structured error quickly. A 2 s per-test timeout
+ * turns a regression back into a fast failure rather than a hung suite.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseXml } from '../src/io/e57/xml';
+
+const TIMEOUT = 2000;
+
+describe('e57 parseXml terminates on truncated input', () => {
+  it('throws on an unterminated CDATA section', () => {
+    expect(() => parseXml('<e57Root><data><![CDATA[oops never closed')).toThrow(/Invalid XML/i);
+  }, TIMEOUT);
+
+  it('throws on an unterminated comment', () => {
+    expect(() => parseXml('<e57Root><!-- never closed')).toThrow(/Invalid XML/i);
+  }, TIMEOUT);
+
+  it('throws on an unterminated processing instruction in content', () => {
+    expect(() => parseXml('<e57Root><?pi never closed')).toThrow(/Invalid XML/i);
+  }, TIMEOUT);
+
+  it('throws on an unterminated processing instruction in the prolog', () => {
+    expect(() => parseXml('<?xml version="1.0" never closed')).toThrow(/Invalid XML/i);
+  }, TIMEOUT);
+
+  it('throws on an unterminated comment in the prolog', () => {
+    expect(() => parseXml('<!-- never closed')).toThrow(/Invalid XML/i);
+  }, TIMEOUT);
+
+  it('throws on an unterminated end tag', () => {
+    expect(() => parseXml('<e57Root></e57Root never closed')).toThrow(/Invalid XML/i);
+  }, TIMEOUT);
+
+  it('still parses a well-formed document with a CDATA, comment and PI', () => {
+    const doc = parseXml('<?xml version="1.0"?><!-- ok --><e57Root><data><![CDATA[hello]]></data></e57Root>');
+    expect(doc.name).toBe('e57Root');
+    expect(doc.children[0]?.name).toBe('data');
+    expect(doc.children[0]?.text).toBe('hello');
+  }, TIMEOUT);
+});


### PR DESCRIPTION
## The bug
`parseXml` advanced past `<![CDATA[`, `<!--`, `<?…?>` and `</…>` by jumping to the index after the closing delimiter. When the delimiter was missing, `String.indexOf` returned `-1` and the cursor jumped to a tiny fixed index (2, or 1) instead of end-of-input, so the parser re-read the same bytes forever.

This runs in the shared, gated parse worker. A truncated `.e57` (XML section ending mid-CDATA/comment/PI) hung the worker at 100% CPU, the load promise never settled, and the worker gate — released only in a `finally` that never ran — stayed held, so **every subsequent file load in the session also hung**. Only a tab reload recovered.

## The fix
Every `indexOf` for a required closing delimiter now checks for `-1` and throws a structured `Invalid XML` error, in both the content parser and the prolog scanner. The load surfaces a normal parse failure instead of hanging.

## Tests
`tests/e57XmlUnterminated.test.ts` covers the four unterminated constructs (content + prolog) plus a well-formed control. The infinite loop is a synchronous busy-loop that a per-test timeout can't even interrupt, so on the old code these cases hard-killed the vitest worker — the new code makes them throw in milliseconds. Existing e57 suite unaffected (53 pass / 4 skip).
