### PR TITLE
Add benchmark framework scaffolding

### DIFF
--- a/benchmarks/fixtures/syntheticCloud.ts
+++ b/benchmarks/fixtures/syntheticCloud.ts
@@ -1,0 +1,361 @@
+/**
+ * syntheticCloud.ts
+ *
+ * Deterministic, seeded point clouds for the benchmark suites.
+ *
+ * Every number a benchmark reports is only as reproducible as the data it ran
+ * on, so the generator takes an explicit seed and drives an explicit PRNG that
+ * lives in this file. `Math.random()` is banned outright (a source guard in
+ * `tests/benchmark/fixtures.test.ts` enforces it, mirroring the framework's own
+ * guard): a single call would still produce a plausible-looking cloud, and the
+ * damage would surface weeks later as a reproducibility hash that never matches
+ * and no way to say which run was wrong.
+ *
+ * THE SURFACE. A uniform random cube is the obvious fixture and the wrong one —
+ * it has no bare earth, so a DTM is meaningless, contours are noise and the
+ * terrain descriptors (VRM, TPI) measure the sampler rather than the ground.
+ * The ground here is an analytic surface, sampled at scattered horizontal
+ * positions:
+ *
+ *   z(x, y) = TILT · u                        regional grade across the tile
+ *           + HILL · exp(−((u−0.45)² + (v−0.55)²) / (2·0.18²))
+ *                                             one broad hill (relief + curvature)
+ *           + WAVE_A · sin(2π · 3 · u)        two superposed sinusoids, giving
+ *           + WAVE_B · cos(2π · 2 · v)        ridges/valleys across both axes
+ *           + MICRO · sin(2πx / λ) · cos(2πy / λ)
+ *                                             micro-relief at a fixed metre
+ *                                             wavelength, so VRM and TPI have
+ *                                             real cell-scale ruggedness
+ *           + ε,  ε ~ U(−h, +h)               bounded sensor noise
+ *
+ * with u = x / extent, v = y / extent, and the four LANDFORM amplitudes
+ * expressed as FRACTIONS of the tile extent. That choice is deliberate:
+ * fixed-metre amplitudes make the surface effectively vertical on a small tile
+ * (a 6 m hill across a 30 m tile is a cliff) and effectively flat on a large
+ * one, so the ladder would be comparing different landscapes at each tier
+ * instead of the same landscape sampled more densely. Scaling with the extent
+ * keeps the slope distribution — and therefore the science the pipeline has to
+ * do — comparable across 100k and 5M points.
+ *
+ * The micro-relief and the noise are the exceptions and stay in absolute
+ * METRES, because they are properties of the ground and the sensor rather than
+ * of the tile. A tile-relative micro-relief wavelength would be 1.4 grid cells
+ * wide on the smallest tier and 50 cells wide on the largest, so VRM and TPI —
+ * whose whole job is cell-scale ruggedness — would measure the point count.
+ *
+ * On top of that: flat-roofed buildings and scattered canopy returns, so the
+ * ground filter has genuine non-ground to reject rather than classifying 100 %
+ * of the cloud as bare earth.
+ *
+ * PORTABILITY. The PRNG is integer arithmetic (`Math.imul`, shifts, `>>> 0`),
+ * exact on any JS engine. The surface uses `Math.sin`/`Math.exp`, which are
+ * implementation-defined in the spec but come from V8's bundled fdlibm port and
+ * are stable across the platforms this project builds on; the results are then
+ * rounded into a Float32Array, which absorbs the last bits either way.
+ *
+ * Pure data: no DOM, no I/O, no `node:` builtins — a browser-side suite can
+ * generate the identical cloud.
+ */
+
+/** One rung of the size ladder. */
+export interface LadderTier {
+  /** Stable short id a report keys a scaling curve off. */
+  readonly id: string;
+  readonly pointCount: number;
+  /** True when the tier is too slow for a default run and must be asked for. */
+  readonly optIn: boolean;
+}
+
+/**
+ * The size ladder. The three large tiers are opt-in because a 5M-point run
+ * takes the ground filter and the hold-out validation into the minutes, which
+ * is a deliberate scaling experiment and not something a CI check should do on
+ * every commit.
+ */
+export const FIXTURE_LADDER: readonly LadderTier[] = [
+  { id: '100k', pointCount: 100_000, optIn: false },
+  { id: '250k', pointCount: 250_000, optIn: false },
+  { id: '500k', pointCount: 500_000, optIn: false },
+  { id: '1m', pointCount: 1_000_000, optIn: true },
+  { id: '2m', pointCount: 2_000_000, optIn: true },
+  { id: '5m', pointCount: 5_000_000, optIn: true },
+];
+
+/** The single tier a smoke run uses when it wants one number, not a curve. */
+export const CI_DEFAULT_TIER: LadderTier = FIXTURE_LADDER[0];
+
+/** The tiers a default (CI) run measures. */
+export function defaultLadder(): readonly LadderTier[] {
+  return FIXTURE_LADDER.filter((t) => !t.optIn);
+}
+
+/** Every tier, including the opt-in ones. For a deliberate scaling run. */
+export function fullLadder(): readonly LadderTier[] {
+  return FIXTURE_LADDER;
+}
+
+/** Axis-aligned extent of a generated cloud, in source units (metres here). */
+export interface CloudBounds {
+  readonly minX: number;
+  readonly minY: number;
+  readonly minZ: number;
+  readonly maxX: number;
+  readonly maxY: number;
+  readonly maxZ: number;
+}
+
+/** The analytic surface constants a run was generated with (provenance). */
+export interface SurfaceModel {
+  /** Regional grade across the tile, as a fraction of the extent. */
+  readonly tiltFraction: number;
+  /** Hill amplitude, as a fraction of the extent. */
+  readonly hillFraction: number;
+  /** Hill standard deviation, as a fraction of the extent. */
+  readonly hillSigmaFraction: number;
+  /** Amplitude of the along-X sinusoid, as a fraction of the extent. */
+  readonly waveAFraction: number;
+  /** Cycles of the along-X sinusoid across the tile. */
+  readonly waveACycles: number;
+  /** Amplitude of the along-Y sinusoid, as a fraction of the extent. */
+  readonly waveBFraction: number;
+  /** Cycles of the along-Y sinusoid across the tile. */
+  readonly waveBCycles: number;
+  /** Micro-relief amplitude in METRES — see the header for why not a fraction. */
+  readonly microAmplitudeM: number;
+  /** Micro-relief wavelength in METRES, on both axes. */
+  readonly microWavelengthM: number;
+}
+
+export interface SyntheticCloudParams {
+  /** PRNG seed. The same seed always produces the same bytes. */
+  readonly seed: number;
+  readonly pointCount: number;
+  /**
+   * Returns per square metre, which sets the tile extent for a given count.
+   * Default 4 — the USGS 3DEP QL2 density, so the pipeline's density-derived
+   * Quality Level grades a realistic scan rather than an artificially sparse
+   * or impossibly dense one.
+   */
+  readonly densityPerM2?: number;
+  /** Fraction of returns that land on canopy rather than ground. Default 0.08. */
+  readonly canopyFraction?: number;
+  /** Half-width of the uniform ground noise, metres. Default 0.05. */
+  readonly noiseHalfWidthM?: number;
+}
+
+export interface SyntheticCloud {
+  readonly seed: number;
+  readonly pointCount: number;
+  /** XYZ triples, length 3N — the form the terrain pipeline prefers. */
+  readonly positions: Float32Array;
+  /** The real extremes of the emitted points, for a caller-supplied grid. */
+  readonly bounds: CloudBounds;
+  /** Side length of the square tile, source units. */
+  readonly extentM: number;
+  /** Returns that sample bare earth (ground + noise). */
+  readonly groundPointCount: number;
+  /** Returns on a roof or in canopy — what the ground filter must reject. */
+  readonly aboveGroundPointCount: number;
+  readonly noiseHalfWidthM: number;
+  readonly densityPerM2: number;
+  readonly surface: SurfaceModel;
+  /** Stable identifier for a report row, e.g. `synthetic-4000-seed42`. */
+  readonly datasetId: string;
+}
+
+/** The default surface. Fractions of the extent — see the header for why. */
+const SURFACE: SurfaceModel = {
+  tiltFraction: 0.025,
+  hillFraction: 0.04,
+  hillSigmaFraction: 0.18,
+  waveAFraction: 0.008,
+  waveACycles: 3,
+  waveBFraction: 0.005,
+  waveBCycles: 2,
+  // Micro-relief: four cells per wavelength on the default 2 m grid. Without
+  // it the surface is smooth to within the noise floor at cell scale, and VRM
+  // — which measures ruggedness independently of steepness — has nothing to
+  // find. In METRES, unlike the terms above, for the reason in the header: a
+  // tile-relative wavelength would be 1.4 cells wide on a small tier and 50
+  // cells wide on a large one, so the ruggedness a descriptor measured would
+  // depend on the point count and no two tiers would be comparable.
+  microAmplitudeM: 0.25,
+  microWavelengthM: 8,
+};
+
+/**
+ * Buildings, in normalised tile coordinates: [u0, v0] corner plus a side
+ * length that is capped in metres further down. Three of them, so the ground
+ * filter meets more than one occlusion and the DTM has real voids to fill.
+ */
+const BUILDINGS: ReadonlyArray<readonly [number, number]> = [
+  [0.18, 0.66],
+  [0.62, 0.24],
+  [0.74, 0.71],
+];
+/** Building side as a fraction of the tile… */
+const BUILDING_SIDE_FRACTION = 0.08;
+/**
+ * …capped in metres. Uncapped, a 5M-point tile grows an 89 m building, which
+ * is far wider than the SMRF filter's largest window (8 cells) and so survives
+ * as "ground" — the big tiers would then be measuring a different scene from
+ * the small ones. The cap keeps every tier's structure filterable.
+ */
+const BUILDING_MAX_SIDE_M = 12;
+/** Roof height above the ground at the building's own corner, metres. */
+const BUILDING_HEIGHT_M = 6;
+/** Canopy returns sit this far above bare earth, metres. */
+const CANOPY_MIN_M = 1.5;
+const CANOPY_SPAN_M = 8;
+
+/**
+ * mulberry32 — a 32-bit PRNG in four integer ops.
+ *
+ * Chosen over an LCG because the low bits of a plain LCG are strongly
+ * correlated, and this generator uses consecutive draws for x and y: an LCG
+ * would lay the points on visible lattice lines, which the ground filter and
+ * the density metrics would both read as structure that is not there.
+ */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** The analytic bare-earth height at a horizontal position, noise excluded. */
+export function groundElevationAt(
+  cloud: Pick<SyntheticCloud, 'extentM' | 'surface'>,
+  x: number,
+  y: number,
+): number {
+  return surfaceZ(cloud.surface, cloud.extentM, x / cloud.extentM, y / cloud.extentM);
+}
+
+function surfaceZ(s: SurfaceModel, extent: number, u: number, v: number): number {
+  const du = u - 0.45;
+  const dv = v - 0.55;
+  const sigma = s.hillSigmaFraction;
+  return (
+    extent *
+    (s.tiltFraction * u +
+      s.hillFraction * Math.exp(-(du * du + dv * dv) / (2 * sigma * sigma)) +
+      s.waveAFraction * Math.sin(2 * Math.PI * s.waveACycles * u) +
+      s.waveBFraction * Math.cos(2 * Math.PI * s.waveBCycles * v)) +
+    // In metres, on the absolute coordinates — not scaled with the extent.
+    s.microAmplitudeM *
+      Math.sin((2 * Math.PI * u * extent) / s.microWavelengthM) *
+      Math.cos((2 * Math.PI * v * extent) / s.microWavelengthM)
+  );
+}
+
+/**
+ * Generate the cloud. Deterministic in `seed` and every parameter.
+ *
+ * Each point consumes exactly five draws, taken UNCONDITIONALLY even when a
+ * branch does not need them. A branch-dependent draw count makes the stream
+ * position depend on the geometry, so changing one building's footprint would
+ * silently reshuffle every point after it and no two versions of the fixture
+ * would be comparable — the same trap as reusing a shared RNG across stages.
+ */
+export function generateSyntheticCloud(params: SyntheticCloudParams): SyntheticCloud {
+  const { seed, pointCount } = params;
+  if (!Number.isInteger(pointCount) || pointCount <= 0) {
+    throw new Error(`synthetic cloud: pointCount must be a positive integer, got ${pointCount}`);
+  }
+  if (!Number.isFinite(seed)) {
+    throw new Error(`synthetic cloud: seed must be finite, got ${String(seed)}`);
+  }
+  const densityPerM2 = params.densityPerM2 ?? 4;
+  const canopyFraction = params.canopyFraction ?? 0.08;
+  const noiseHalfWidthM = params.noiseHalfWidthM ?? 0.05;
+  const extentM = Math.sqrt(pointCount / densityPerM2);
+  const buildingSide = Math.min(BUILDING_SIDE_FRACTION * extentM, BUILDING_MAX_SIDE_M);
+
+  const rnd = mulberry32(seed);
+  const positions = new Float32Array(pointCount * 3);
+  let ground = 0;
+  let aboveGround = 0;
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+
+  for (let i = 0; i < pointCount; i++) {
+    // Five draws, always, in this fixed order — see the doc comment.
+    const u = rnd();
+    const v = rnd();
+    const noise = rnd();
+    const kind = rnd();
+    const canopyDepth = rnd();
+
+    const x = u * extentM;
+    const y = v * extentM;
+    const earth = surfaceZ(SURFACE, extentM, u, v);
+
+    let z: number;
+    const roof = roofOf(x, y, extentM, buildingSide);
+    if (roof !== null) {
+      // A flat roof at an absolute height, not a copy of the terrain: a roof
+      // that follows the ground is exactly the shape a morphological ground
+      // filter keeps, so it would never be rejected and the scene would have
+      // no real occlusion in it.
+      z = roof + BUILDING_HEIGHT_M;
+      aboveGround++;
+    } else if (kind < canopyFraction) {
+      z = earth + CANOPY_MIN_M + canopyDepth * CANOPY_SPAN_M;
+      aboveGround++;
+    } else {
+      z = earth + (noise * 2 - 1) * noiseHalfWidthM;
+      ground++;
+    }
+
+    positions[i * 3] = x;
+    positions[i * 3 + 1] = y;
+    positions[i * 3 + 2] = z;
+  }
+
+  // Bounds are read back off the STORED float32 values, not the float64 ones
+  // computed above: the pipeline sees what the array holds, and a declared box
+  // computed at higher precision can sit a rounding step inside the real data,
+  // which silently clips the outermost returns out of a caller-supplied grid.
+  for (let i = 0; i < pointCount; i++) {
+    const x = positions[i * 3];
+    const y = positions[i * 3 + 1];
+    const z = positions[i * 3 + 2];
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (z < minZ) minZ = z;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+    if (z > maxZ) maxZ = z;
+  }
+
+  return {
+    seed,
+    pointCount,
+    positions,
+    bounds: { minX, minY, minZ, maxX, maxY, maxZ },
+    extentM,
+    groundPointCount: ground,
+    aboveGroundPointCount: aboveGround,
+    noiseHalfWidthM,
+    densityPerM2,
+    surface: SURFACE,
+    datasetId: `synthetic-${pointCount}-seed${seed}`,
+  };
+}
+
+/** Ground height at the corner of the building covering (x, y), or null. */
+function roofOf(x: number, y: number, extentM: number, side: number): number | null {
+  for (const [u0, v0] of BUILDINGS) {
+    const x0 = u0 * extentM;
+    const y0 = v0 * extentM;
+    if (x >= x0 && x < x0 + side && y >= y0 && y < y0 + side) {
+      return surfaceZ(SURFACE, extentM, u0, v0);
+    }
+  }
+  return null;
+}

--- a/benchmarks/framework/artifacts.ts
+++ b/benchmarks/framework/artifacts.ts
@@ -48,6 +48,17 @@ export interface VolatileRule {
 export const VOLATILE_PLACEHOLDER = '<stripped:absolute-path>';
 
 /**
+ * An ISO-8601 date-TIME, with or without seconds, milliseconds or an offset.
+ *
+ * A time component is REQUIRED. A bare `2026-07-25` is as likely to be a dataset
+ * epoch label or a survey date — part of the artifact's identity — as it is a
+ * run timestamp, and stripping it would make two different datasets hash the
+ * same. A field that really does hold a wall-clock date should be named one
+ * (`date`, `buildDate`), which the key rule then catches.
+ */
+const ISO_8601_DATETIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d{1,9})?)?(Z|[+-]\d{2}:?\d{2})?$/;
+
+/**
  * The complete strip list. Deliberately narrow and name-anchored: each key
  * pattern is anchored at both ends so a field like `durationMs` or `datasetId`
  * can never be swept up by a substring match.
@@ -57,8 +68,14 @@ export const VOLATILE_RULES: readonly VolatileRule[] = [
     kind: 'timestamp',
     appliesTo: 'key',
     pattern:
-      /^(timestamps?|generated_?at|created_?at|updated_?at|modified_?at|started_?at|finished_?at|completed_?at|captured_?at|built_?at|ran_?at|run_?at|wall_?clock(_?(ms|time))?|date_?time|iso_?date|epoch_?ms)$/i,
-    why: 'A wall-clock reading differs on every run, so leaving it in guarantees two identical artifacts hash differently and the reproducibility check never passes.',
+      /^(timestamps?|generated_?at|created_?at|updated_?at|modified_?at|started_?at|finished_?at|completed_?at|captured_?at|built_?at|ran_?at|run_?at|wall_?clock(_?(ms|time))?|dates?|date_?stamp|date_?time|iso_?date|build_?date|run_?date|create_?date|time|now|when|start_?time|end_?time|stop_?time|finish_?time|create_?time|modify_?time|[acm]time|birth_?time|epoch_?(ms|s)|unix_?time|utc|local_?time|clock_?time)$/i,
+    why: 'A wall-clock reading differs on every run, so leaving it in guarantees two identical artifacts hash differently and the reproducibility check never passes. Held deliberately wide, including bare `time`, `date` and `now`: a stripped field costs one column, a missed one costs a hash nobody can ever reproduce. Two names are pointedly NOT here — bare `epoch` (a survey campaign in this codebase, not a clock) and plural `times` (most often an array of durations). A duration must be named with its unit — `durationMs`, `elapsedMs` — never `time`.',
+  },
+  {
+    kind: 'timestamp',
+    appliesTo: 'value',
+    pattern: ISO_8601_DATETIME,
+    why: 'Symmetric with the absolute-path rule: an ISO-8601 date-time is a wall-clock reading because of what it IS, not because of the name it was given, so it is caught under any key. Bare calendar dates are excluded — see ISO_8601_DATETIME.',
   },
   {
     kind: 'machine-id',
@@ -104,7 +121,12 @@ export function stripVolatile(input: unknown): StripResult {
       return value;
     }
     if (value === null || typeof value !== 'object') return value;
-    if (Array.isArray(value)) return value.map((v, i) => walk(v, `${path}[${i}]`));
+    // `undefined` in an array becomes null, exactly as JSON.stringify does —
+    // canonicalJson would otherwise emit the bare token `undefined` and the
+    // canonical form would not be parseable JSON at all.
+    if (Array.isArray(value)) {
+      return value.map((v, i) => (v === undefined ? null : walk(v, `${path}[${i}]`)));
+    }
 
     const out: Record<string, unknown> = {};
     for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
@@ -113,6 +135,12 @@ export function stripVolatile(input: unknown): StripResult {
         stripped.add(child);
         continue;
       }
+      // An undefined property is dropped rather than emitted, again matching
+      // JSON.stringify: `{ error: undefined }` is what spreading an optional
+      // field produces, so it must not be an error, and it must not corrupt the
+      // canonical form. Not recorded as a stripped field — nothing was excluded
+      // that JSON would have carried.
+      if (v === undefined) continue;
       out[key] = walk(v, child);
     }
     return out;
@@ -126,6 +154,70 @@ function asBytes(value: unknown): Uint8Array | null {
   if (value instanceof Uint8Array) return value;
   if (value instanceof ArrayBuffer) return new Uint8Array(value);
   return null;
+}
+
+/**
+ * Recorded on every byte artifact, because the strip genuinely cannot run there
+ * and an empty exclusion list would otherwise read as "nothing volatile here".
+ */
+export const RAW_BYTES_NO_STRIP_REASON =
+  'hashed raw: a byte artifact is opaque, so embedded timestamps (PNG tEXt, GeoTIFF tags, zip entry mtimes) cannot be detected or removed and may change the hash between otherwise identical runs';
+
+/** Name the type of a value in an error a suite author can act on. */
+function describeType(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value !== 'object') return typeof value;
+  const ctor = (value as { constructor?: { name?: string } }).constructor;
+  return ctor?.name ?? 'object with an unexpected prototype';
+}
+
+/** A plain `{}` or an `Object.create(null)` bag — the only objects JSON preserves. */
+function isPlainObject(value: object): boolean {
+  const proto = Object.getPrototypeOf(value) as object | null;
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Reject anything `canonicalJson` cannot represent faithfully, naming the path.
+ *
+ * Without this the hash silently stops discriminating: `canonicalJson` walks own
+ * enumerable keys, so `new Date(0)` and `new Date(999)` both canonicalise to
+ * `{}`, `new Map([['a',1]])` and `new Map([['a',2]])` likewise, and `NaN`,
+ * `Infinity` and `-Infinity` all become `null`. Each of those is a real value
+ * change that leaves the digest untouched — the exact failure the sensitivity
+ * requirement exists to catch, and one that is invisible at the call site.
+ *
+ * Throwing beats coercing: a suite author who wrote a Date meant something by
+ * it, and the framework does not get to decide which of its fields survived.
+ */
+export function assertHashable(artifactName: string, value: unknown, path = ''): void {
+  const where = path === '' ? 'the artifact root' : path;
+  const fail = (problem: string): never => {
+    throw new TypeError(
+      `benchmark artifact "${artifactName}": ${where} ${problem}. ` +
+        'Convert it to a JSON primitive (a number, a string, or a plain object) before hashing.',
+    );
+  };
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) fail(`is ${String(value)}, which is not finite and canonicalises to null`);
+    return;
+  }
+  if (typeof value === 'bigint' || typeof value === 'function' || typeof value === 'symbol') {
+    fail(`is a ${typeof value}, which canonicalJson cannot represent`);
+  }
+  if (value === null || typeof value !== 'object') return;
+
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => assertHashable(artifactName, v, `${path}[${i}]`));
+    return;
+  }
+  if (!isPlainObject(value)) {
+    fail(`is a ${describeType(value)}, which canonicalises to {} and would hide any change inside it`);
+  }
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    assertHashable(artifactName, v, path === '' ? key : `${path}.${key}`);
+  }
 }
 
 /**
@@ -149,9 +241,16 @@ export function hashArtifact(name: string, value: unknown): ArtifactRecord {
       fingerprint: fnv1a(hash),
       byteLength: bytes.length,
       strippedFields: [],
+      // Stated on the RECORD, not just in a comment: a reader comparing two
+      // byte-artifact hashes has to know the strip never ran on them.
+      volatilityStripped: false,
+      unstrippedReason: RAW_BYTES_NO_STRIP_REASON,
     };
   }
 
+  // Before the strip, not after: a Date survives `stripVolatile` as an empty
+  // object, so a guard on the stripped copy would never see it.
+  assertHashable(name, value);
   const { value: clean, stripped } = stripVolatile(value);
   const json = canonicalJson(clean);
   const encoded = new TextEncoder().encode(json);
@@ -164,5 +263,6 @@ export function hashArtifact(name: string, value: unknown): ArtifactRecord {
     fingerprint: fnv1a(json),
     byteLength: encoded.length,
     strippedFields: stripped,
+    volatilityStripped: true,
   };
 }

--- a/benchmarks/framework/artifacts.ts
+++ b/benchmarks/framework/artifacts.ts
@@ -62,20 +62,29 @@ const ISO_8601_DATETIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d{1,9})?)
  * The complete strip list. Deliberately narrow and name-anchored: each key
  * pattern is anchored at both ends so a field like `durationMs` or `datasetId`
  * can never be swept up by a substring match.
+ *
+ * The principle that governs every edit to this list: the two mistakes are not
+ * symmetric. An UNDER-strip fails safely — two honest runs hash differently, the
+ * check goes red, a human looks. An OVER-strip fails dangerously — two genuinely
+ * different artifacts hash the same, the framework asserts a reproducibility
+ * that does not hold, and once that number is a figure in a paper it cannot be
+ * taken back. So when a name is ambiguous, prefer to keep it in the hash; and
+ * when it is ambiguous enough that neither choice is defensible, refuse it
+ * outright (see AMBIGUOUS_CLOCK_KEYS) rather than decide silently.
  */
 export const VOLATILE_RULES: readonly VolatileRule[] = [
   {
     kind: 'timestamp',
     appliesTo: 'key',
     pattern:
-      /^(timestamps?|generated_?at|created_?at|updated_?at|modified_?at|started_?at|finished_?at|completed_?at|captured_?at|built_?at|ran_?at|run_?at|wall_?clock(_?(ms|time))?|dates?|date_?stamp|date_?time|iso_?date|build_?date|run_?date|create_?date|time|now|when|start_?time|end_?time|stop_?time|finish_?time|create_?time|modify_?time|[acm]time|birth_?time|epoch_?(ms|s)|unix_?time|utc|local_?time|clock_?time)$/i,
-    why: 'A wall-clock reading differs on every run, so leaving it in guarantees two identical artifacts hash differently and the reproducibility check never passes. Held deliberately wide, including bare `time`, `date` and `now`: a stripped field costs one column, a missed one costs a hash nobody can ever reproduce. Two names are pointedly NOT here — bare `epoch` (a survey campaign in this codebase, not a clock) and plural `times` (most often an array of durations). A duration must be named with its unit — `durationMs`, `elapsedMs` — never `time`.',
+      /^(timestamps?|generated_?at|created_?at|updated_?at|modified_?at|started_?at|finished_?at|completed_?at|captured_?at|built_?at|ran_?at|run_?at|wall_?clock(_?(ms|time))?|dates?|date_?stamp|date_?time|iso_?date|build_?date|run_?date|create_?date|time|now|when|start_?time|end_?time|stop_?time|finish_?time|create_?time|modify_?time|[acm]time|birth_?time|epoch_?ms|epoch_(s|sec|secs|seconds)|epoch_?sec(onds)?|unix_?time|utc|local_?time|clock_?time)$/i,
+    why: 'A wall-clock reading differs on every run, so leaving it in guarantees two identical artifacts hash differently and the reproducibility check never passes. Three names are pointedly NOT here: bare `epoch` and plural `epochs` (a survey campaign in this codebase — see alignEpochs/EpochCloud — not a clock), and plural `times` (most often an array of durations). The unit-suffixed forms `epochMs`/`epoch_seconds` ARE matched, which is why the alternation spells them out instead of writing `epoch_?(ms|s)` — that shorthand also swallowed `epochs`. A duration must be named with its unit: `durationMs`, `elapsedMs`.',
   },
   {
     kind: 'timestamp',
     appliesTo: 'value',
     pattern: ISO_8601_DATETIME,
-    why: 'Symmetric with the absolute-path rule: an ISO-8601 date-time is a wall-clock reading because of what it IS, not because of the name it was given, so it is caught under any key. Bare calendar dates are excluded — see ISO_8601_DATETIME.',
+    why: 'Symmetric with the absolute-path rule: an ISO-8601 date-time is a wall-clock reading because of what it IS, not because of the name it was given, so it is caught under any key. Bare calendar dates are excluded (see ISO_8601_DATETIME), on the asymmetry above: missing one costs a loud, investigable hash mismatch, while stripping a survey date would make two different datasets hash the same.',
   },
   {
     kind: 'machine-id',
@@ -163,6 +172,21 @@ function asBytes(value: unknown): Uint8Array | null {
 export const RAW_BYTES_NO_STRIP_REASON =
   'hashed raw: a byte artifact is opaque, so embedded timestamps (PNG tEXt, GeoTIFF tags, zip entry mtimes) cannot be detected or removed and may change the hash between otherwise identical runs';
 
+/**
+ * Field names that could equally hold a measurement or a clock reading.
+ *
+ * Both possible answers are wrong in a way the author cannot see: strip them and
+ * a duration named `time` silently leaves the hash; keep them and a wall-clock
+ * reading silently defeats reproducibility. The framework does not get to pick,
+ * so `assertHashable` refuses the name and asks for one that says which it is.
+ *
+ * They stay on the strip list above as well, so `stripVolatile` used on its own
+ * still removes them — the guard is the loud path, the rule is the backstop.
+ */
+export const AMBIGUOUS_CLOCK_KEYS = ['time', 'now', 'when', 'utc'] as const;
+
+const AMBIGUOUS_KEY_SET: ReadonlySet<string> = new Set(AMBIGUOUS_CLOCK_KEYS);
+
 /** Name the type of a value in an error a suite author can act on. */
 function describeType(value: unknown): string {
   if (value === null) return 'null';
@@ -199,6 +223,14 @@ export function assertHashable(artifactName: string, value: unknown, path = ''):
     );
   };
 
+  if (value === undefined) {
+    // Only at the root. A nested `{ error: undefined }` is what spreading an
+    // optional field produces and is dropped later, exactly as JSON does — but
+    // an undefined ROOT has no JSON form at all, and used to reach fnv1a and
+    // die there on `s.length` instead of saying anything useful.
+    if (path === '') fail('is undefined, which has no JSON representation');
+    return;
+  }
   if (typeof value === 'number') {
     if (!Number.isFinite(value)) fail(`is ${String(value)}, which is not finite and canonicalises to null`);
     return;
@@ -216,7 +248,16 @@ export function assertHashable(artifactName: string, value: unknown, path = ''):
     fail(`is a ${describeType(value)}, which canonicalises to {} and would hide any change inside it`);
   }
   for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
-    assertHashable(artifactName, v, path === '' ? key : `${path}.${key}`);
+    const child = path === '' ? key : `${path}.${key}`;
+    if (AMBIGUOUS_KEY_SET.has(key.toLowerCase())) {
+      throw new TypeError(
+        `benchmark artifact "${artifactName}": ${child} is named "${key}", which could be a ` +
+          'measurement or a clock reading, and the framework will not guess. Rename it: ' +
+          '`durationMs` (or another unit-suffixed name) if it is a measurement that must ' +
+          'affect the hash, `capturedAt` if it is a wall-clock reading that must not.',
+      );
+    }
+    assertHashable(artifactName, v, child);
   }
 }
 

--- a/benchmarks/framework/artifacts.ts
+++ b/benchmarks/framework/artifacts.ts
@@ -1,0 +1,168 @@
+/**
+ * artifacts.ts
+ *
+ * Canonical, machine-independent hashes for the scientific artifacts a suite
+ * produces.
+ *
+ * The hash exists so a reviewer can say "I regenerated this and got the same
+ * artifact". That claim only survives if the hash ignores the three things that
+ * differ between two honest runs of the same code:
+ *
+ *   1. wall-clock timestamps — a `generatedAt` field alone makes every run
+ *      unique, so the hash would never match and the check becomes decoration;
+ *   2. absolute filesystem paths — `/Users/alice/checkout/...` versus
+ *      `/home/runner/work/...` is the reviewer's disk, not the science;
+ *   3. machine identifiers — hostname, username, pid.
+ *
+ * Everything else is in. Durations are deliberately NOT stripped: a timing IS
+ * the measurement in a benchmark, and a strip list broad enough to swallow it
+ * would let a real regression pass as "same artifact".
+ *
+ * The rules are exported as `VOLATILE_RULES` — each with the category it serves
+ * and why it is excluded — so a reviewer can audit the exclusions without
+ * reading this file, and `ArtifactRecord.strippedFields` names what was actually
+ * removed from the artifact in hand.
+ *
+ * Hashing itself is reused, never reinvented: `canonicalJson`/`fnv1a` from
+ * `src/canonicalHash.ts` and `sha256Hex` from `src/terrain/export/sha256.ts`.
+ * Nothing in this path reads a clock or a random source.
+ */
+
+import { canonicalJson, fnv1a } from '../../src/canonicalHash';
+import { sha256Hex } from '../../src/terrain/export/sha256';
+import type { ArtifactRecord } from './types';
+
+/** What a rule protects the hash against. */
+export type VolatileKind = 'timestamp' | 'absolute-path' | 'machine-id';
+
+export interface VolatileRule {
+  readonly kind: VolatileKind;
+  /** 'key' rules DROP the field; 'value' rules REDACT the string in place. */
+  readonly appliesTo: 'key' | 'value';
+  readonly pattern: RegExp;
+  /** Why this is excluded — quoted verbatim when a reviewer asks. */
+  readonly why: string;
+}
+
+/** What a redacted absolute path becomes before hashing. */
+export const VOLATILE_PLACEHOLDER = '<stripped:absolute-path>';
+
+/**
+ * The complete strip list. Deliberately narrow and name-anchored: each key
+ * pattern is anchored at both ends so a field like `durationMs` or `datasetId`
+ * can never be swept up by a substring match.
+ */
+export const VOLATILE_RULES: readonly VolatileRule[] = [
+  {
+    kind: 'timestamp',
+    appliesTo: 'key',
+    pattern:
+      /^(timestamps?|generated_?at|created_?at|updated_?at|modified_?at|started_?at|finished_?at|completed_?at|captured_?at|built_?at|ran_?at|run_?at|wall_?clock(_?(ms|time))?|date_?time|iso_?date|epoch_?ms)$/i,
+    why: 'A wall-clock reading differs on every run, so leaving it in guarantees two identical artifacts hash differently and the reproducibility check never passes.',
+  },
+  {
+    kind: 'machine-id',
+    appliesTo: 'key',
+    pattern:
+      /^(host|host_?name|machine|machine_?id|node_?name|computer_?name|user|user_?name|user_?info|home_?dir|tmp_?dir|temp_?dir|uid|gid|pid|ppid|process_?id|mac_?address|serial(_?number)?|device_?id|session_?id|ip(_?address)?|network_?interfaces)$/i,
+    why: 'Identifies the machine or process that happened to run the suite, which says nothing about the artifact and differs between a laptop and a CI runner.',
+  },
+  {
+    kind: 'absolute-path',
+    appliesTo: 'value',
+    pattern: /^(\/[^/]|\/$|[A-Za-z]:[\\/]|\\\\|file:\/\/)/,
+    why: 'An absolute path encodes the reviewer’s checkout location, so the same dataset hashes differently on every machine. Matched on the VALUE, not the key, so a repo-relative path stays part of the artifact identity.',
+  },
+];
+
+const KEY_RULES = VOLATILE_RULES.filter((r) => r.appliesTo === 'key');
+const VALUE_RULES = VOLATILE_RULES.filter((r) => r.appliesTo === 'value');
+
+export interface StripResult {
+  /** A stripped COPY. The input is never mutated. */
+  readonly value: unknown;
+  /** Dotted paths that were dropped or redacted, de-duplicated and sorted. */
+  readonly stripped: readonly string[];
+}
+
+/**
+ * Return a copy of `input` with every volatile field removed or redacted.
+ *
+ * Dropping a key rather than nulling it keeps the canonical form identical for
+ * an artifact that never had the field and one where it was stripped — which is
+ * the point: both describe the same science.
+ */
+export function stripVolatile(input: unknown): StripResult {
+  const stripped = new Set<string>();
+
+  const walk = (value: unknown, path: string): unknown => {
+    if (typeof value === 'string') {
+      if (VALUE_RULES.some((r) => r.pattern.test(value))) {
+        stripped.add(path === '' ? '(root)' : path);
+        return VOLATILE_PLACEHOLDER;
+      }
+      return value;
+    }
+    if (value === null || typeof value !== 'object') return value;
+    if (Array.isArray(value)) return value.map((v, i) => walk(v, `${path}[${i}]`));
+
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      const child = path === '' ? key : `${path}.${key}`;
+      if (KEY_RULES.some((r) => r.pattern.test(key))) {
+        stripped.add(child);
+        continue;
+      }
+      out[key] = walk(v, child);
+    }
+    return out;
+  };
+
+  return { value: walk(input, ''), stripped: [...stripped].sort() };
+}
+
+/** Byte artifacts are opaque: nothing inside them can be inspected or stripped. */
+function asBytes(value: unknown): Uint8Array | null {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  return null;
+}
+
+/**
+ * Hash a named artifact.
+ *
+ * Byte artifacts hash as-is (SHA-256 over the raw bytes). Everything else is
+ * stripped, canonicalised with sorted keys — so a re-ordered but identical
+ * object hashes the same — and hashed as UTF-8.
+ */
+export function hashArtifact(name: string, value: unknown): ArtifactRecord {
+  const bytes = asBytes(value);
+  if (bytes !== null) {
+    const hash = sha256Hex(bytes);
+    return {
+      name,
+      kind: 'bytes',
+      algorithm: 'sha256',
+      hash,
+      // Derived from the digest rather than the payload: a short id for tables,
+      // with no second pass over what may be megabytes of raster or point data.
+      fingerprint: fnv1a(hash),
+      byteLength: bytes.length,
+      strippedFields: [],
+    };
+  }
+
+  const { value: clean, stripped } = stripVolatile(value);
+  const json = canonicalJson(clean);
+  const encoded = new TextEncoder().encode(json);
+  return {
+    name,
+    kind: 'json',
+    algorithm: 'sha256',
+    hash: sha256Hex(encoded),
+    // Equivalent to `canonicalHash(clean)`, without canonicalising twice.
+    fingerprint: fnv1a(json),
+    byteLength: encoded.length,
+    strippedFields: stripped,
+  };
+}

--- a/benchmarks/framework/artifacts.ts
+++ b/benchmarks/framework/artifacts.ts
@@ -418,3 +418,68 @@ export function hashArtifact(
     volatilityStripped: true,
   };
 }
+
+/** What a non-finite number becomes when an artifact is converted for hashing. */
+export type NonFiniteLabel = 'NaN' | 'Infinity' | '-Infinity';
+
+/** Anything `canonicalJson` can represent faithfully. */
+export type Hashable = string | number | boolean | null | Hashable[] | { [key: string]: Hashable };
+
+/**
+ * Convert a producer's output into something `hashArtifact` accepts.
+ *
+ * `assertHashable` states what a hashable artifact may contain; this is the
+ * companion that gets a real pipeline product there, and it lives beside those
+ * rules so the two cannot drift. Two deliberate conversions:
+ *
+ *   - TYPED ARRAYS become plain arrays. `canonicalJson` keeps own enumerable
+ *     keys, so a Float32Array would canonicalise to an index-keyed object that
+ *     still hashes but no longer reads as data. (For a large grid, prefer
+ *     hashing the raw bytes: this path costs three full copies of the values.)
+ *   - NON-FINITE NUMBERS become their name as a string. NaN is how a raster
+ *     says "no data here", and `JSON.stringify(NaN)` is `null` — which is
+ *     indistinguishable from a field that genuinely held null, and makes NaN,
+ *     +Infinity and -Infinity all hash the same. Naming them keeps the three
+ *     apart and keeps the absence explicit.
+ *
+ * Anything else JSON cannot carry (a Date, a Map, a class instance) throws
+ * rather than being flattened, for the same reason `assertHashable` throws: a
+ * silent flattening is a hash that quietly stopped discriminating.
+ */
+export function toHashable(value: unknown, path = 'artifact'): Hashable {
+  if (value === null) return null;
+  const t = typeof value;
+  if (t === 'string' || t === 'boolean') return value as string | boolean;
+  if (t === 'number') return finiteOrLabel(value as number);
+  if (t === 'bigint' || t === 'function' || t === 'symbol' || t === 'undefined') {
+    throw new TypeError(`benchmark artifact: ${path} is a ${t}, which has no JSON form`);
+  }
+  if (Array.isArray(value)) return value.map((v, i) => toHashable(v, `${path}[${i}]`));
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    const view = value as unknown as ArrayLike<number>;
+    const out: Hashable[] = new Array<Hashable>(view.length);
+    for (let i = 0; i < view.length; i++) out[i] = finiteOrLabel(view[i]);
+    return out;
+  }
+  const proto = Object.getPrototypeOf(value as object) as object | null;
+  if (proto !== Object.prototype && proto !== null) {
+    throw new TypeError(
+      `benchmark artifact: ${path} is a ${describeType(value)}, which JSON cannot carry faithfully`,
+    );
+  }
+  const out: Record<string, Hashable> = {};
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    // An absent optional field and one explicitly set to undefined describe the
+    // same thing, and JSON drops both — mirroring that here keeps the two from
+    // hashing differently.
+    if (v === undefined) continue;
+    out[key] = toHashable(v, `${path}.${key}`);
+  }
+  return out;
+}
+
+function finiteOrLabel(n: number): number | NonFiniteLabel {
+  if (Number.isFinite(n)) return n;
+  if (Number.isNaN(n)) return 'NaN';
+  return n > 0 ? 'Infinity' : '-Infinity';
+}

--- a/benchmarks/framework/artifacts.ts
+++ b/benchmarks/framework/artifacts.ts
@@ -97,9 +97,18 @@ export const VOLATILE_RULES: readonly VolatileRule[] = [
     kind: 'absolute-path',
     appliesTo: 'value',
     pattern: /^(\/[^/]|\/$|[A-Za-z]:[\\/]|\\\\|file:\/\/)/,
-    why: 'An absolute path encodes the reviewer’s checkout location, so the same dataset hashes differently on every machine. Matched on the VALUE, not the key, so a repo-relative path stays part of the artifact identity.',
+    why: 'An absolute path encodes the reviewer’s checkout location, so the same dataset hashes differently on every machine. Matched on the VALUE, not the key, so a repo-relative path stays part of the artifact identity. Only the DIRECTORY PREFIX is redacted: the basename is retained, because machine-specificity never lives in the filename and collapsing every path to one placeholder made a run over tileA.laz and a run over tileB.laz hash identically.',
   },
 ];
+
+/**
+ * How deep an artifact may nest before the guard gives up.
+ *
+ * A stated limit beats a stack overflow: 512 is far past any real metrics
+ * document, and a structure deeper than that is a bug the author needs told
+ * about in words rather than a `RangeError` with no path in it.
+ */
+export const MAX_ARTIFACT_DEPTH = 512;
 
 const KEY_RULES = VOLATILE_RULES.filter((r) => r.appliesTo === 'key');
 const VALUE_RULES = VOLATILE_RULES.filter((r) => r.appliesTo === 'value');
@@ -118,44 +127,89 @@ export interface StripResult {
  * an artifact that never had the field and one where it was stripped — which is
  * the point: both describe the same science.
  */
+/**
+ * Redact the machine-specific part of an absolute path, keeping the filename.
+ *
+ * The directory prefix is the reviewer's disk; the basename is the artifact's
+ * identity. Retaining it is what keeps two runs over different tiles in the same
+ * folder from collapsing onto one hash.
+ */
+function redactPath(value: string): string {
+  const cut = Math.max(value.lastIndexOf('/'), value.lastIndexOf('\\'));
+  return `${VOLATILE_PLACEHOLDER}/${cut < 0 ? value : value.slice(cut + 1)}`;
+}
+
+/** Shared by both traversals so a cycle reads the same wherever it is found. */
+function cycleError(path: string, seenAt: string): TypeError {
+  const where = path === '' ? 'the artifact root' : path;
+  return new TypeError(
+    `benchmark artifact: ${where} is part of a reference cycle (already seen at ${seenAt}). ` +
+      'A hash needs a finite document; break the cycle or omit the back-reference.',
+  );
+}
+
+function depthError(path: string): TypeError {
+  return new TypeError(
+    `benchmark artifact: ${path} is nested deeper than ${MAX_ARTIFACT_DEPTH} levels, ` +
+      'which is past anything a metrics document should need.',
+  );
+}
+
 export function stripVolatile(input: unknown): StripResult {
   const stripped = new Set<string>();
+  // Ancestors only, not everything seen: a sub-object referenced twice in
+  // different branches is legal JSON input, and only a repeat on the path from
+  // the root is an actual cycle.
+  const ancestors = new Map<object, string>();
 
-  const walk = (value: unknown, path: string): unknown => {
+  const walk = (value: unknown, path: string, depth: number): unknown => {
     if (typeof value === 'string') {
-      if (VALUE_RULES.some((r) => r.pattern.test(value))) {
-        stripped.add(path === '' ? '(root)' : path);
-        return VOLATILE_PLACEHOLDER;
-      }
-      return value;
+      const rule = VALUE_RULES.find((r) => r.pattern.test(value));
+      if (rule === undefined) return value;
+      stripped.add(path === '' ? '(root)' : path);
+      return rule.kind === 'absolute-path' ? redactPath(value) : VOLATILE_PLACEHOLDER;
     }
     if (value === null || typeof value !== 'object') return value;
-    // `undefined` in an array becomes null, exactly as JSON.stringify does —
-    // canonicalJson would otherwise emit the bare token `undefined` and the
-    // canonical form would not be parseable JSON at all.
+    if (depth > MAX_ARTIFACT_DEPTH) throw depthError(path === '' ? 'the artifact root' : path);
+    const seenAt = ancestors.get(value);
+    if (seenAt !== undefined) throw cycleError(path, seenAt === '' ? 'the artifact root' : seenAt);
+    ancestors.set(value, path);
+
+    let out: unknown;
     if (Array.isArray(value)) {
-      return value.map((v, i) => (v === undefined ? null : walk(v, `${path}[${i}]`)));
+      // `Array.from`, not `.map`: map SKIPS holes, so a sparse array kept its
+      // holes and canonicalised to `[,,1]` — not parseable JSON, and a
+      // different hash from the identical document `[null,null,1]`.
+      out = Array.from(value, (v, i) => (v === undefined ? null : walk(v, `${path}[${i}]`, depth + 1)));
+    } else {
+      // `Object.create(null)`, not `{}`: assigning to `out['__proto__']` on a
+      // plain literal hits Object.prototype's setter and RE-PARENTS the object
+      // instead of creating an own property, so the key silently vanished from
+      // the hash. canonicalJson reads own keys only, so a null-prototype bag
+      // flows through it unchanged.
+      const bag = Object.create(null) as Record<string, unknown>;
+      for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+        const child = path === '' ? key : `${path}.${key}`;
+        if (KEY_RULES.some((r) => r.pattern.test(key))) {
+          stripped.add(child);
+          continue;
+        }
+        // An undefined property is dropped rather than emitted, again matching
+        // JSON.stringify: `{ error: undefined }` is what spreading an optional
+        // field produces, so it must not be an error, and it must not corrupt
+        // the canonical form. Not recorded as a stripped field — nothing was
+        // excluded that JSON would have carried.
+        if (v === undefined) continue;
+        bag[key] = walk(v, child, depth + 1);
+      }
+      out = bag;
     }
 
-    const out: Record<string, unknown> = {};
-    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
-      const child = path === '' ? key : `${path}.${key}`;
-      if (KEY_RULES.some((r) => r.pattern.test(key))) {
-        stripped.add(child);
-        continue;
-      }
-      // An undefined property is dropped rather than emitted, again matching
-      // JSON.stringify: `{ error: undefined }` is what spreading an optional
-      // field produces, so it must not be an error, and it must not corrupt the
-      // canonical form. Not recorded as a stripped field — nothing was excluded
-      // that JSON would have carried.
-      if (v === undefined) continue;
-      out[key] = walk(v, child);
-    }
+    ancestors.delete(value);
     return out;
   };
 
-  return { value: walk(input, ''), stripped: [...stripped].sort() };
+  return { value: walk(input, '', 0), stripped: [...stripped].sort() };
 }
 
 /** Byte artifacts are opaque: nothing inside them can be inspected or stripped. */
@@ -171,6 +225,15 @@ function asBytes(value: unknown): Uint8Array | null {
  */
 export const RAW_BYTES_NO_STRIP_REASON =
   'hashed raw: a byte artifact is opaque, so embedded timestamps (PNG tEXt, GeoTIFF tags, zip entry mtimes) cannot be detected or removed and may change the hash between otherwise identical runs';
+
+/**
+ * Measured throughput of the bundled portable digest: ~40 MiB/s (8 MiB in
+ * ~184 ms), plus one full padded copy of the payload. That is fine for the
+ * KB-to-MB documents this framework was written for and a cliff for a 500 MB
+ * raster, which is why `hashArtifact` takes an injectable digest and the Node
+ * entry point supplies `node:crypto`. See `HashArtifactOptions.digest`.
+ */
+export const PORTABLE_DIGEST_MIB_PER_SEC = 40;
 
 /**
  * Field names that could equally hold a measurement or a clock reading.
@@ -214,7 +277,13 @@ function isPlainObject(value: object): boolean {
  * Throwing beats coercing: a suite author who wrote a Date meant something by
  * it, and the framework does not get to decide which of its fields survived.
  */
-export function assertHashable(artifactName: string, value: unknown, path = ''): void {
+export function assertHashable(
+  artifactName: string,
+  value: unknown,
+  path = '',
+  ancestors: Map<object, string> = new Map(),
+  depth = 0,
+): void {
   const where = path === '' ? 'the artifact root' : path;
   const fail = (problem: string): never => {
     throw new TypeError(
@@ -240,12 +309,26 @@ export function assertHashable(artifactName: string, value: unknown, path = ''):
   }
   if (value === null || typeof value !== 'object') return;
 
+  if (depth > MAX_ARTIFACT_DEPTH) throw depthError(where);
+  const seenAt = ancestors.get(value);
+  if (seenAt !== undefined) throw cycleError(path, seenAt === '' ? 'the artifact root' : seenAt);
+  ancestors.set(value, path);
+
   if (Array.isArray(value)) {
-    value.forEach((v, i) => assertHashable(artifactName, v, `${path}[${i}]`));
+    // An index loop, not `forEach`: forEach skips holes, so a sparse array's
+    // elements were never checked at all.
+    for (let i = 0; i < value.length; i++) {
+      assertHashable(artifactName, value[i], `${path}[${i}]`, ancestors, depth + 1);
+    }
+    ancestors.delete(value);
     return;
   }
   if (!isPlainObject(value)) {
-    fail(`is a ${describeType(value)}, which canonicalises to {} and would hide any change inside it`);
+    fail(
+      `is a ${describeType(value)}: canonicalJson keeps own enumerable keys only, so a Date or ` +
+        'a Map becomes {} while a typed array becomes an index-keyed object — use Array.from(…) ' +
+        'for a typed array, or pass the bytes themselves as a Uint8Array artifact',
+    );
   }
   for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
     const child = path === '' ? key : `${path}.${key}`;
@@ -254,11 +337,30 @@ export function assertHashable(artifactName: string, value: unknown, path = ''):
         `benchmark artifact "${artifactName}": ${child} is named "${key}", which could be a ` +
           'measurement or a clock reading, and the framework will not guess. Rename it: ' +
           '`durationMs` (or another unit-suffixed name) if it is a measurement that must ' +
-          'affect the hash, `capturedAt` if it is a wall-clock reading that must not.',
+          'affect the hash, `capturedAt` if it is a wall-clock reading that must not. ' +
+          'If the key comes from data you do not control, map it before hashing.',
       );
     }
-    assertHashable(artifactName, v, child);
+    assertHashable(artifactName, v, child, ancestors, depth + 1);
   }
+  ancestors.delete(value);
+}
+
+/** A SHA-256 implementation, injectable so the fast Node one stays optional. */
+export type DigestFn = (bytes: Uint8Array) => string;
+
+export interface HashArtifactOptions {
+  /**
+   * SHA-256 over raw bytes. Defaults to the project's portable implementation.
+   *
+   * The bundled `sha256Hex` runs at roughly 40 MiB/s and copies the payload into
+   * a padded buffer, so a 500 MB raster costs about twelve seconds and half a
+   * gigabyte of transient memory — and inside a stage, that copy lands in the
+   * stage's own `peakMemory`. Node callers should pass `nodeSha256Hex` from the
+   * Node entry point; the digest is bit-identical, so nothing about
+   * reproducibility depends on which one ran.
+   */
+  readonly digest?: DigestFn;
 }
 
 /**
@@ -268,10 +370,19 @@ export function assertHashable(artifactName: string, value: unknown, path = ''):
  * stripped, canonicalised with sorted keys — so a re-ordered but identical
  * object hashes the same — and hashed as UTF-8.
  */
-export function hashArtifact(name: string, value: unknown): ArtifactRecord {
+export function hashArtifact(
+  name: string,
+  value: unknown,
+  options: HashArtifactOptions = {},
+): ArtifactRecord {
+  // An unnamed artifact cannot be found again in a report, matching the same
+  // refusal `measured`, `unavailable` and `capturedEnv` already make.
+  if (name.trim() === '') throw new Error('benchmark artifact: name must not be empty');
+  const digest = options.digest ?? sha256Hex;
+
   const bytes = asBytes(value);
   if (bytes !== null) {
-    const hash = sha256Hex(bytes);
+    const hash = digest(bytes);
     return {
       name,
       kind: 'bytes',
@@ -299,7 +410,7 @@ export function hashArtifact(name: string, value: unknown): ArtifactRecord {
     name,
     kind: 'json',
     algorithm: 'sha256',
-    hash: sha256Hex(encoded),
+    hash: digest(encoded),
     // Equivalent to `canonicalHash(clean)`, without canonicalising twice.
     fingerprint: fnv1a(json),
     byteLength: encoded.length,

--- a/benchmarks/framework/clock.ts
+++ b/benchmarks/framework/clock.ts
@@ -17,8 +17,11 @@
 
 import { measured, unavailable, type Metric } from './types';
 
+// Names the specific API, not "no monotonic clock": a browser has
+// `performance.now()`, so the broad claim would have been untrue there. What is
+// actually missing is the nanosecond-resolution Node one this module uses.
 export const CLOCK_UNAVAILABLE_REASON =
-  'no monotonic clock: process.hrtime.bigint() is not available in this runtime';
+  'process.hrtime.bigint() is not available in this runtime, so no monotonic nanosecond reading could be taken';
 
 /** Read the monotonic clock, or null where the runtime has none (e.g. a browser). */
 export function readMonotonicNs(): bigint | null {

--- a/benchmarks/framework/clock.ts
+++ b/benchmarks/framework/clock.ts
@@ -1,0 +1,63 @@
+/**
+ * clock.ts
+ *
+ * Monotonic stage timing.
+ *
+ * `Date.now()` is deliberately not used anywhere here. It reads the wall clock,
+ * which NTP can step backwards mid-run: a stage that ran 40 ms can then report a
+ * negative duration, and one that ran 40 ms across a leap adjustment can report
+ * seconds. Either number lands in a paper table looking like a real result.
+ * `process.hrtime.bigint()` is monotonic and nanosecond-resolution, so a stage
+ * duration is a duration and nothing else.
+ *
+ * The ms conversion happens once, at the end, on the nanosecond DIFFERENCE — not
+ * on each endpoint — so no precision is lost to the ~1e18 magnitude of an
+ * absolute hrtime reading.
+ */
+
+import { measured, unavailable, type Metric } from './types';
+
+export const CLOCK_UNAVAILABLE_REASON =
+  'no monotonic clock: process.hrtime.bigint() is not available in this runtime';
+
+/** Read the monotonic clock, or null where the runtime has none (e.g. a browser). */
+export function readMonotonicNs(): bigint | null {
+  const p = (globalThis as { process?: { hrtime?: { bigint?: () => bigint } } }).process;
+  const h = p?.hrtime?.bigint;
+  if (typeof h !== 'function') return null;
+  try {
+    return h.call(p?.hrtime);
+  } catch {
+    // A runtime that exposes the symbol but refuses the call (a locked-down
+    // sandbox) must report unavailable, never a fabricated 0.
+    return null;
+  }
+}
+
+/**
+ * Turn two monotonic readings into a duration metric.
+ *
+ * Exported so the unavailable branch is reachable from a test without having to
+ * simulate a runtime that lacks hrtime — the branch that would otherwise be the
+ * easiest place for a `?? 0` to creep back in.
+ */
+export function elapsedMs(startNs: bigint | null, endNs: bigint | null): Metric {
+  if (startNs === null || endNs === null) {
+    return unavailable(CLOCK_UNAVAILABLE_REASON, { runtime: 'node', deterministic: false });
+  }
+  const ms = Number(endNs - startNs) / 1e6;
+  // Timings never repeat exactly, so `deterministic` is false: a table built
+  // from these must not present them as fixed properties of the software.
+  return measured(ms, 'ms', { runtime: 'node', deterministic: false });
+}
+
+/**
+ * Start timing a stage. Call the returned function to close it.
+ *
+ * Callable more than once (each call reads the clock again), which is what makes
+ * a "so far" reading possible for a long-running stage without a second timer.
+ */
+export function startStageClock(): () => Metric {
+  const startNs = readMonotonicNs();
+  return () => elapsedMs(startNs, readMonotonicNs());
+}

--- a/benchmarks/framework/env.ts
+++ b/benchmarks/framework/env.ts
@@ -1,0 +1,103 @@
+/**
+ * env.ts
+ *
+ * Capture the provenance of a benchmark run: OS, CPU, architecture, Node
+ * version, git commit and release version.
+ *
+ * Node-side only — it reads `node:os`, the filesystem and `git`. The rest of the
+ * framework stays runtime-neutral; this module is the one that touches the host.
+ *
+ * Two rules it never breaks:
+ *
+ *  - It never throws. A benchmark run that dies because `git` is not installed,
+ *    or because the tree was unpacked from a source tarball with no `.git`, has
+ *    turned a provenance gap into a lost measurement. Every field is captured
+ *    independently, and a failure downgrades that one field to unavailable.
+ *  - It never substitutes a placeholder. 'unknown', '' and 'n/a' all survive
+ *    into a paper table looking like captured data; `{ status: 'unavailable',
+ *    reason }` cannot be mistaken for one.
+ */
+
+import os from 'node:os';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { capturedEnv, unavailableEnv, type BenchmarkEnvironment, type EnvValue } from './types';
+
+/** The repo root, two levels up from `benchmarks/framework/`. */
+const DEFAULT_REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+/** A hung `git` must not hang the suite; a commit hash is not worth a stall. */
+const GIT_TIMEOUT_MS = 5_000;
+
+export interface CaptureEnvironmentOptions {
+  /** Where to look for `.git` and `package.json`. Defaults to the repo root. */
+  readonly repoRoot?: string;
+}
+
+/**
+ * Run one capture, downgrading any throw to an unavailable field.
+ *
+ * The reason carries the thrown message because the useful distinction for a
+ * reviewer is *why* — "git is not on PATH" and "not a git repository" call for
+ * different fixes, and a generic "could not determine" hides both.
+ */
+function capture(what: string, read: () => string | null): EnvValue {
+  try {
+    const value = read();
+    if (value === null || value.trim() === '') return unavailableEnv(`${what}: not reported by this host`);
+    return capturedEnv(value.trim());
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return unavailableEnv(`${what}: ${detail}`);
+  }
+}
+
+/** Read HEAD's full commit hash, or null when this is not a usable checkout. */
+function readGitCommit(repoRoot: string): string | null {
+  const out = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    timeout: GIT_TIMEOUT_MS,
+    // stderr silenced: "not a git repository" is an expected outcome in a source
+    // tarball, and printing it would look like a benchmark failure.
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+  return /^[0-9a-f]{40}$/.test(out) ? out : null;
+}
+
+/**
+ * Capture everything a reader needs to place this run.
+ *
+ * The short commit is DERIVED from the full one rather than read via
+ * `git rev-parse --short`: that command's length follows repo config, so two
+ * machines could report different short hashes for the same commit, and the
+ * short form would stop being a prefix of the full one.
+ */
+export function captureEnvironment(options: CaptureEnvironmentOptions = {}): BenchmarkEnvironment {
+  const repoRoot = options.repoRoot ?? DEFAULT_REPO_ROOT;
+
+  const gitCommitFull = capture('git commit', () => readGitCommit(repoRoot));
+  const gitCommitShort =
+    gitCommitFull.status === 'captured'
+      ? capturedEnv(gitCommitFull.value.slice(0, 7))
+      : unavailableEnv(gitCommitFull.reason);
+
+  return {
+    os: capture('os', () => `${os.platform()} ${os.release()}`),
+    // `os.cpus()` returns an empty array on some containerised hosts, which is
+    // why this reads the first entry defensively instead of indexing blind.
+    cpuModel: capture('cpu model', () => os.cpus()[0]?.model ?? null),
+    arch: capture('arch', () => process.arch),
+    nodeVersion: capture('node version', () => process.version),
+    gitCommitFull,
+    gitCommitShort,
+    releaseVersion: capture('release version', () => {
+      const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as {
+        version?: unknown;
+      };
+      return typeof pkg.version === 'string' ? pkg.version : null;
+    }),
+  };
+}

--- a/benchmarks/framework/env.ts
+++ b/benchmarks/framework/env.ts
@@ -106,6 +106,11 @@ export function captureEnvironment(options: CaptureEnvironmentOptions = {}): Ben
      * regenerated this at that commit" then means nothing. For the
      * reproducibility suite this is the field that decides whether the rest of
      * the block can be trusted.
+     *
+     * Shares GIT_TIMEOUT_MS with the others, and `git status` is the one that
+     * can genuinely approach it — it stats the whole tree, so a very large or
+     * cold checkout reports this field as unavailable rather than stalling the
+     * run. That is the right trade: an unavailable flag says so out loud.
      */
     gitDirty: capture('git working tree', () =>
       git(repoRoot, ['status', '--porcelain']).trim() === '' ? 'clean' : 'dirty',

--- a/benchmarks/framework/env.ts
+++ b/benchmarks/framework/env.ts
@@ -54,16 +54,21 @@ function capture(what: string, read: () => string | null): EnvValue {
   }
 }
 
-/** Read HEAD's full commit hash, or null when this is not a usable checkout. */
-function readGitCommit(repoRoot: string): string | null {
-  const out = execFileSync('git', ['rev-parse', 'HEAD'], {
+/** Run a git command in `repoRoot`, letting the caller's try/catch see failures. */
+function git(repoRoot: string, args: readonly string[]): string {
+  return execFileSync('git', [...args], {
     cwd: repoRoot,
     encoding: 'utf8',
     timeout: GIT_TIMEOUT_MS,
     // stderr silenced: "not a git repository" is an expected outcome in a source
     // tarball, and printing it would look like a benchmark failure.
     stdio: ['ignore', 'pipe', 'ignore'],
-  }).trim();
+  });
+}
+
+/** Read HEAD's full commit hash, or null when this is not a usable checkout. */
+function readGitCommit(repoRoot: string): string | null {
+  const out = git(repoRoot, ['rev-parse', 'HEAD']).trim();
   return /^[0-9a-f]{40}$/.test(out) ? out : null;
 }
 
@@ -93,6 +98,18 @@ export function captureEnvironment(options: CaptureEnvironmentOptions = {}): Ben
     nodeVersion: capture('node version', () => process.version),
     gitCommitFull,
     gitCommitShort,
+    /**
+     * Whether the working tree matches the commit above.
+     *
+     * A commit hash on its own is a provenance claim the run may not be entitled
+     * to: a benchmark run from a modified checkout reports a clean hash, and "I
+     * regenerated this at that commit" then means nothing. For the
+     * reproducibility suite this is the field that decides whether the rest of
+     * the block can be trusted.
+     */
+    gitDirty: capture('git working tree', () =>
+      git(repoRoot, ['status', '--porcelain']).trim() === '' ? 'clean' : 'dirty',
+    ),
     releaseVersion: capture('release version', () => {
       const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as {
         version?: unknown;

--- a/benchmarks/framework/index.ts
+++ b/benchmarks/framework/index.ts
@@ -38,11 +38,23 @@ export { runStage, runStageAsync } from './stage';
 export type { RunStageOptions, StageOutcome } from './stage';
 export { captureEnvironment } from './env';
 export type { CaptureEnvironmentOptions } from './env';
-export { hashArtifact, stripVolatile, VOLATILE_RULES, VOLATILE_PLACEHOLDER } from './artifacts';
+export {
+  assertHashable,
+  hashArtifact,
+  stripVolatile,
+  VOLATILE_RULES,
+  VOLATILE_PLACEHOLDER,
+  RAW_BYTES_NO_STRIP_REASON,
+} from './artifacts';
 export type { StripResult, VolatileKind, VolatileRule } from './artifacts';
 
 export { toJson } from './reporters/json';
 export { toCsv } from './reporters/csv';
 export { toMarkdown } from './reporters/markdown';
 export { toHtml } from './reporters/html';
-export { formatMetric, formatEnvValue, UNAVAILABLE_LABEL } from './reporters/metricText';
+export {
+  formatMetric,
+  formatEnvValue,
+  describeHashExclusions,
+  UNAVAILABLE_LABEL,
+} from './reporters/metricText';

--- a/benchmarks/framework/index.ts
+++ b/benchmarks/framework/index.ts
@@ -53,6 +53,7 @@ export {
   assertHashable,
   hashArtifact,
   stripVolatile,
+  toHashable,
   AMBIGUOUS_CLOCK_KEYS,
   MAX_ARTIFACT_DEPTH,
   PORTABLE_DIGEST_MIB_PER_SEC,
@@ -62,7 +63,9 @@ export {
 } from './artifacts';
 export type {
   DigestFn,
+  Hashable,
   HashArtifactOptions,
+  NonFiniteLabel,
   StripResult,
   VolatileKind,
   VolatileRule,

--- a/benchmarks/framework/index.ts
+++ b/benchmarks/framework/index.ts
@@ -1,10 +1,17 @@
 /**
  * index.ts
  *
- * The framework's public surface. A benchmark suite imports from here and
- * nowhere else, so the modules underneath can be reorganised without touching
- * three suites — and so the honesty contract has exactly one front door: there
- * is no exported way to build a metric that carries a number it did not measure.
+ * The framework's runtime-neutral public surface. A benchmark suite imports the
+ * schema, the instruments and the reporters from here, so the modules underneath
+ * can be reorganised without touching three suites — and so the honesty contract
+ * has exactly one front door: there is no exported way to build a metric that
+ * carries a number it did not measure.
+ *
+ * NOTHING reachable from this file may import a `node:` builtin. The schema
+ * advertises browser-taken metrics and `clock.ts`/`memory.ts` both have browser
+ * branches, so a browser-side suite has to be able to bundle this. Anything that
+ * needs a filesystem, a subprocess or `node:crypto` lives in `./node.ts`, and a
+ * source guard in the test suite keeps it that way.
  */
 
 export {
@@ -25,6 +32,8 @@ export type {
   Metric,
   MetricProvenance,
   MetricRuntime,
+  FailedStageResult,
+  OkStageResult,
   RunReport,
   StageResult,
   StrippedArtifactRecord,
@@ -38,18 +47,26 @@ export { startMemorySampler, readProcessRss, MEMORY_UNAVAILABLE_REASON } from '.
 export type { MemorySampler, MemorySamplerOptions } from './memory';
 export { runStage, runStageAsync } from './stage';
 export type { RunStageOptions, StageOutcome } from './stage';
-export { captureEnvironment } from './env';
-export type { CaptureEnvironmentOptions } from './env';
+// `captureEnvironment` is deliberately NOT here — see the header. Import it from
+// `./node.ts`, together with the fast `node:crypto` digest.
 export {
   assertHashable,
   hashArtifact,
   stripVolatile,
   AMBIGUOUS_CLOCK_KEYS,
+  MAX_ARTIFACT_DEPTH,
+  PORTABLE_DIGEST_MIB_PER_SEC,
   VOLATILE_RULES,
   VOLATILE_PLACEHOLDER,
   RAW_BYTES_NO_STRIP_REASON,
 } from './artifacts';
-export type { StripResult, VolatileKind, VolatileRule } from './artifacts';
+export type {
+  DigestFn,
+  HashArtifactOptions,
+  StripResult,
+  VolatileKind,
+  VolatileRule,
+} from './artifacts';
 
 export { toJson } from './reporters/json';
 export { toCsv } from './reporters/csv';

--- a/benchmarks/framework/index.ts
+++ b/benchmarks/framework/index.ts
@@ -27,8 +27,10 @@ export type {
   MetricRuntime,
   RunReport,
   StageResult,
+  StrippedArtifactRecord,
   UnavailableEnvValue,
   UnavailableMetric,
+  UnstrippedArtifactRecord,
 } from './types';
 
 export { startStageClock, elapsedMs, readMonotonicNs, CLOCK_UNAVAILABLE_REASON } from './clock';
@@ -42,6 +44,7 @@ export {
   assertHashable,
   hashArtifact,
   stripVolatile,
+  AMBIGUOUS_CLOCK_KEYS,
   VOLATILE_RULES,
   VOLATILE_PLACEHOLDER,
   RAW_BYTES_NO_STRIP_REASON,

--- a/benchmarks/framework/index.ts
+++ b/benchmarks/framework/index.ts
@@ -1,0 +1,48 @@
+/**
+ * index.ts
+ *
+ * The framework's public surface. A benchmark suite imports from here and
+ * nowhere else, so the modules underneath can be reorganised without touching
+ * three suites — and so the honesty contract has exactly one front door: there
+ * is no exported way to build a metric that carries a number it did not measure.
+ */
+
+export {
+  BENCHMARK_SCHEMA_VERSION,
+  measured,
+  unavailable,
+  isMeasured,
+  isUnavailable,
+  capturedEnv,
+  unavailableEnv,
+} from './types';
+export type {
+  ArtifactRecord,
+  BenchmarkEnvironment,
+  CapturedEnvValue,
+  EnvValue,
+  MeasuredMetric,
+  Metric,
+  MetricProvenance,
+  MetricRuntime,
+  RunReport,
+  StageResult,
+  UnavailableEnvValue,
+  UnavailableMetric,
+} from './types';
+
+export { startStageClock, elapsedMs, readMonotonicNs, CLOCK_UNAVAILABLE_REASON } from './clock';
+export { startMemorySampler, readProcessRss, MEMORY_UNAVAILABLE_REASON } from './memory';
+export type { MemorySampler, MemorySamplerOptions } from './memory';
+export { runStage, runStageAsync } from './stage';
+export type { RunStageOptions, StageOutcome } from './stage';
+export { captureEnvironment } from './env';
+export type { CaptureEnvironmentOptions } from './env';
+export { hashArtifact, stripVolatile, VOLATILE_RULES, VOLATILE_PLACEHOLDER } from './artifacts';
+export type { StripResult, VolatileKind, VolatileRule } from './artifacts';
+
+export { toJson } from './reporters/json';
+export { toCsv } from './reporters/csv';
+export { toMarkdown } from './reporters/markdown';
+export { toHtml } from './reporters/html';
+export { formatMetric, formatEnvValue, UNAVAILABLE_LABEL } from './reporters/metricText';

--- a/benchmarks/framework/memory.ts
+++ b/benchmarks/framework/memory.ts
@@ -1,0 +1,101 @@
+/**
+ * memory.ts
+ *
+ * Peak process RSS across a stage.
+ *
+ * Peak, not final: a decode that allocates a 900 MB scratch buffer and frees it
+ * before the stage ends looks like it used nothing if you only read RSS at the
+ * end, and "it fits in 8 GB" is exactly the claim a reader takes from this
+ * column. So the sampler keeps the largest reading it has seen.
+ *
+ * Where RSS cannot be read at all — a browser has no equivalent, and a locked
+ * sandbox can refuse the call — the stage reports an unavailable metric with the
+ * reason. It never reports 0, which would read as "this stage used no memory".
+ *
+ * Sampling caveat worth knowing before quoting a figure: a fully SYNCHRONOUS
+ * stage blocks the event loop, so the background interval cannot fire and the
+ * peak is only as good as the start/`sample()`/stop readings. Long synchronous
+ * stages should call `sample()` at their own allocation high-water marks.
+ */
+
+import { measured, unavailable, type Metric } from './types';
+
+export const MEMORY_UNAVAILABLE_REASON =
+  'peak RSS not readable: process.memoryUsage() is not available in this runtime';
+
+/** Default background sampling period. Cheap enough to be invisible in a timing. */
+const DEFAULT_INTERVAL_MS = 25;
+
+export interface MemorySamplerOptions {
+  /** Injectable RSS reader in bytes; returns null when the runtime has none. */
+  readonly readRss?: () => number | null;
+  /** Background sampling period in ms. 0 disables the timer entirely. */
+  readonly intervalMs?: number;
+}
+
+export interface MemorySampler {
+  /** Take a reading now — call at a known allocation high-water mark. */
+  sample(): void;
+  /** Stop sampling and return the peak, or an unavailable metric. */
+  stop(): Metric;
+}
+
+/** Read process RSS in bytes, or null if this runtime does not expose it. */
+export function readProcessRss(): number | null {
+  const p = (globalThis as {
+    process?: { memoryUsage?: (() => { rss: number }) & { rss?: () => number } };
+  }).process;
+  const usage = p?.memoryUsage;
+  if (typeof usage !== 'function') return null;
+  // `process.memoryUsage.rss()` (Node 15.6+) skips building the full usage
+  // object, so sampling on an interval does not itself perturb the measurement.
+  if (typeof usage.rss === 'function') return usage.rss();
+  return usage.call(p).rss;
+}
+
+/**
+ * Begin sampling peak RSS. The first reading is taken immediately, so a stage
+ * that fails before its first `sample()` still reports the baseline it started
+ * from rather than nothing.
+ */
+export function startMemorySampler(options: MemorySamplerOptions = {}): MemorySampler {
+  const read = options.readRss ?? readProcessRss;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  let peak: number | null = null;
+
+  const take = (): void => {
+    let value: number | null;
+    try {
+      value = read();
+    } catch {
+      // A reader that throws is a runtime that cannot supply the number. Swallow
+      // it here and let the metric say "unavailable" — a benchmark stage must
+      // not fail because its instrumentation could not read a counter.
+      return;
+    }
+    if (value === null || !Number.isFinite(value)) return;
+    if (peak === null || value > peak) peak = value;
+  };
+
+  take();
+
+  const timer = intervalMs > 0 ? setInterval(take, intervalMs) : null;
+  // Node's Timeout keeps the event loop alive; unref so a suite that forgets to
+  // stop a sampler cannot hang the process after its assertions have passed.
+  if (timer && typeof (timer as { unref?: () => void }).unref === 'function') {
+    (timer as unknown as { unref: () => void }).unref();
+  }
+
+  return {
+    sample: take,
+    stop(): Metric {
+      take();
+      if (timer !== null) clearInterval(timer);
+      if (peak === null) {
+        return unavailable(MEMORY_UNAVAILABLE_REASON, { runtime: 'node', deterministic: false });
+      }
+      // RSS depends on GC timing and OS paging, so it never repeats exactly.
+      return measured(peak, 'bytes', { runtime: 'node', deterministic: false });
+    },
+  };
+}

--- a/benchmarks/framework/node.ts
+++ b/benchmarks/framework/node.ts
@@ -41,11 +41,20 @@ export function nodeSha256Hex(bytes: Uint8Array): string {
   }
 }
 
-/** `hashArtifact` with the fast digest already wired in. */
+/**
+ * `hashArtifact` with the fast digest already wired in.
+ *
+ * The default is applied with `??`, not by spreading `options` over it. Spread
+ * lets an explicitly-undefined field CLOBBER the default, so ordinary code —
+ * `hashArtifactNode(name, value, { digest: opts.digest })` with an optional
+ * field, or a partly-populated options bag — silently fell back to the portable
+ * implementation at twenty times the cost, producing the identical hash with
+ * nothing anywhere to show the downgrade happened.
+ */
 export function hashArtifactNode(
   name: string,
   value: unknown,
   options: HashArtifactOptions = {},
 ): ArtifactRecord {
-  return hashArtifact(name, value, { digest: nodeSha256Hex, ...options });
+  return hashArtifact(name, value, { ...options, digest: options.digest ?? nodeSha256Hex });
 }

--- a/benchmarks/framework/node.ts
+++ b/benchmarks/framework/node.ts
@@ -1,0 +1,51 @@
+/**
+ * node.ts
+ *
+ * The Node-only entry point. Everything here needs a filesystem, a subprocess or
+ * `node:crypto`; everything in `index.ts` runs in either runtime.
+ *
+ * The split is load-bearing, not tidiness. Re-exporting `captureEnvironment`
+ * from the barrel made `node:child_process` and friends static dependencies of
+ * the WHOLE surface, so a browser-side suite — the schema advertises
+ * browser-taken metrics, and `clock.ts`/`memory.ts` both have browser branches —
+ * could not import the framework at all once Vite tried to bundle it. A suite
+ * imports from `index.ts` for the schema and the reporters, and additionally
+ * from here when it is running under Node.
+ */
+
+export { captureEnvironment } from './env';
+export type { CaptureEnvironmentOptions } from './env';
+
+import { createHash } from 'node:crypto';
+import { sha256Hex } from '../../src/terrain/export/sha256';
+import { hashArtifact, type HashArtifactOptions } from './artifacts';
+import type { ArtifactRecord } from './types';
+
+/**
+ * SHA-256 through `node:crypto`, falling back to the portable implementation.
+ *
+ * Same digest, bit for bit — this is a throughput fix, not a correctness one, so
+ * a hash produced on either path is comparable with the other. The portable
+ * implementation runs at ~40 MiB/s and copies the payload into a padded buffer,
+ * which on a 500 MB raster is roughly twelve seconds and half a gigabyte of
+ * transient memory charged to whichever stage happens to be timing it.
+ *
+ * The fallback exists because this file may be loaded in an environment where
+ * `node:crypto` is stubbed; a slower correct answer beats a thrown one.
+ */
+export function nodeSha256Hex(bytes: Uint8Array): string {
+  try {
+    return createHash('sha256').update(bytes).digest('hex');
+  } catch {
+    return sha256Hex(bytes);
+  }
+}
+
+/** `hashArtifact` with the fast digest already wired in. */
+export function hashArtifactNode(
+  name: string,
+  value: unknown,
+  options: HashArtifactOptions = {},
+): ArtifactRecord {
+  return hashArtifact(name, value, { digest: nodeSha256Hex, ...options });
+}

--- a/benchmarks/framework/reporters/csv.ts
+++ b/benchmarks/framework/reporters/csv.ts
@@ -19,6 +19,7 @@
 import type { Metric, RunReport, StageResult } from '../types';
 import {
   UNAVAILABLE_LABEL,
+  describeHashExclusions,
   metricReasonCell,
   metricUnitCell,
   metricValueCell,
@@ -86,16 +87,12 @@ export function toCsv(report: RunReport): string {
     rows.push(factRow('artifact', `${artifact.name}.algorithm`, artifact.algorithm));
     rows.push(factRow('artifact', `${artifact.name}.fingerprint`, artifact.fingerprint));
     rows.push(factRow('artifact', `${artifact.name}.byteLength`, String(artifact.byteLength)));
-    // Semicolon-joined so the excluded-field list never introduces a comma of
-    // its own — the list is prose for a reviewer, not a nested table. `(none)`
-    // rather than an empty cell: "nothing was excluded" is a real answer here.
-    rows.push(
-      factRow(
-        'artifact',
-        `${artifact.name}.strippedFields`,
-        artifact.strippedFields.length === 0 ? '(none)' : artifact.strippedFields.join('; '),
-      ),
-    );
+    // Never an empty cell: "nothing was excluded" and "no strip could run" are
+    // different answers, and the second is a caveat on the hash itself. The
+    // boolean is emitted alongside the prose so a script can branch on it
+    // without parsing the sentence.
+    rows.push(factRow('artifact', `${artifact.name}.volatilityStripped`, String(artifact.volatilityStripped)));
+    rows.push(factRow('artifact', `${artifact.name}.strippedFields`, describeHashExclusions(artifact)));
   }
 
   return `${rows.join('\n')}\n`;

--- a/benchmarks/framework/reporters/csv.ts
+++ b/benchmarks/framework/reporters/csv.ts
@@ -27,9 +27,26 @@ import {
 
 const HEADER = 'section,name,value,unit,status,reason,runtime,deterministic';
 
-/** RFC-4180 quoting. Without it a reason containing a comma shifts every column. */
+/**
+ * RFC-4180 quoting, plus the formula-injection neutraliser this repo already
+ * applies in its measurement CSV export.
+ *
+ * Without the quoting, a reason containing a comma shifts every later column.
+ * Without the neutraliser, a cell beginning `= + - @` or a tab/CR is executed as
+ * a formula by Excel and Sheets — and these cells carry suite-supplied text
+ * (dataset ids, stage names, error messages) that nobody vetted. A leading
+ * apostrophe is the conventional fix; force-quoting keeps it.
+ *
+ * A cell that IS a number is left alone, so a negative measurement stays `-1.5`
+ * rather than becoming the text `'-1.5` and dropping out of every chart — the
+ * same carve-out the measurement export makes. `-1+1` is not a number and is
+ * still neutralised.
+ */
 function cell(value: string): string {
-  return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+  const numeric = value.trim() !== '' && Number.isFinite(Number(value));
+  const neutralise = !numeric && /^[=+\-@\t\r]/.test(value);
+  const out = neutralise ? `'${value}` : value;
+  return neutralise || /[",\n\r]/.test(out) ? `"${out.replace(/"/g, '""')}"` : out;
 }
 
 function row(cells: readonly string[]): string {

--- a/benchmarks/framework/reporters/csv.ts
+++ b/benchmarks/framework/reporters/csv.ts
@@ -1,0 +1,102 @@
+/**
+ * csv.ts
+ *
+ * The long-format CSV: one row per fact, eight fixed columns.
+ *
+ *   section,name,value,unit,status,reason,runtime,deterministic
+ *
+ * Long format rather than one wide row per run, because a run mixes stages,
+ * suite-level metrics, environment fields and artifact hashes — shapes that do
+ * not share a column set. Forcing them into one wide table means either a
+ * ragged row count or empty cells that a spreadsheet renders identically to a
+ * measured zero.
+ *
+ * The `status` and `reason` columns are what make the file honest: an
+ * unmeasured metric writes the WORD `unavailable` in the value column and its
+ * reason alongside, so no downstream `sum()` or plot can pick it up as a number.
+ */
+
+import type { Metric, RunReport, StageResult } from '../types';
+import {
+  UNAVAILABLE_LABEL,
+  metricReasonCell,
+  metricUnitCell,
+  metricValueCell,
+} from './metricText';
+
+const HEADER = 'section,name,value,unit,status,reason,runtime,deterministic';
+
+/** RFC-4180 quoting. Without it a reason containing a comma shifts every column. */
+function cell(value: string): string {
+  return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+function row(cells: readonly string[]): string {
+  return cells.map(cell).join(',');
+}
+
+/** A metric row carries all eight columns; everything else leaves them empty. */
+function metricRow(section: string, name: string, m: Metric): string {
+  return row([
+    section,
+    name,
+    metricValueCell(m),
+    metricUnitCell(m),
+    m.status,
+    metricReasonCell(m),
+    m.runtime,
+    String(m.deterministic),
+  ]);
+}
+
+/** A plain fact (dataset id, OS, hash): a value with no unit and no reason. */
+function factRow(section: string, name: string, value: string, reason = ''): string {
+  return row([section, name, value, '', reason === '' ? 'captured' : UNAVAILABLE_LABEL, reason, '', '']);
+}
+
+function stageRows(stage: StageResult): string[] {
+  return [
+    factRow('stage', `${stage.name}.status`, stage.status, ''),
+    ...(stage.error === undefined ? [] : [factRow('stage', `${stage.name}.error`, stage.error, '')]),
+    metricRow('stage', `${stage.name}.duration`, stage.duration),
+    metricRow('stage', `${stage.name}.peakMemory`, stage.peakMemory),
+  ];
+}
+
+export function toCsv(report: RunReport): string {
+  const rows: string[] = [HEADER];
+
+  rows.push(factRow('run', 'schemaVersion', String(report.schemaVersion)));
+  rows.push(factRow('run', 'suiteId', report.suiteId));
+  rows.push(factRow('run', 'datasetId', report.datasetId));
+
+  for (const [name, field] of Object.entries(report.environment)) {
+    rows.push(
+      field.status === 'captured'
+        ? factRow('environment', name, field.value)
+        : factRow('environment', name, UNAVAILABLE_LABEL, field.reason),
+    );
+  }
+
+  for (const stage of report.stages) rows.push(...stageRows(stage));
+  for (const [name, metric] of Object.entries(report.metrics)) rows.push(metricRow('metric', name, metric));
+
+  for (const artifact of report.artifacts) {
+    rows.push(factRow('artifact', `${artifact.name}.hash`, artifact.hash));
+    rows.push(factRow('artifact', `${artifact.name}.algorithm`, artifact.algorithm));
+    rows.push(factRow('artifact', `${artifact.name}.fingerprint`, artifact.fingerprint));
+    rows.push(factRow('artifact', `${artifact.name}.byteLength`, String(artifact.byteLength)));
+    // Semicolon-joined so the excluded-field list never introduces a comma of
+    // its own — the list is prose for a reviewer, not a nested table. `(none)`
+    // rather than an empty cell: "nothing was excluded" is a real answer here.
+    rows.push(
+      factRow(
+        'artifact',
+        `${artifact.name}.strippedFields`,
+        artifact.strippedFields.length === 0 ? '(none)' : artifact.strippedFields.join('; '),
+      ),
+    );
+  }
+
+  return `${rows.join('\n')}\n`;
+}

--- a/benchmarks/framework/reporters/html.ts
+++ b/benchmarks/framework/reporters/html.ts
@@ -17,7 +17,7 @@
  */
 
 import { isMeasured, type EnvValue, type Metric, type RunReport } from '../types';
-import { UNAVAILABLE_LABEL } from './metricText';
+import { describeHashExclusions, UNAVAILABLE_LABEL } from './metricText';
 
 /** Escape the five characters that can break out of text or an attribute. */
 function esc(value: string): string {
@@ -119,7 +119,11 @@ export function toHtml(report: RunReport): string {
     .map(
       (a) =>
         `<tr>${textCell(a.name)}${textCell(a.algorithm)}<td class="hash">${esc(a.hash)}</td>` +
-        `${textCell(String(a.byteLength))}${textCell(a.strippedFields.length === 0 ? '(none)' : a.strippedFields.join(', '))}</tr>`,
+        `${textCell(String(a.byteLength))}` +
+        // The "no strip could run" case is a caveat on the hash, so it is
+        // marked the same way an unavailable metric is rather than sitting in a
+        // plain cell that reads like a field list.
+        `<td${a.volatilityStripped ? '' : ' class="unavailable"'}>${esc(describeHashExclusions(a))}</td></tr>`,
     )
     .join('');
 

--- a/benchmarks/framework/reporters/html.ts
+++ b/benchmarks/framework/reporters/html.ts
@@ -17,7 +17,7 @@
  */
 
 import { isMeasured, type EnvValue, type Metric, type RunReport } from '../types';
-import { describeHashExclusions, UNAVAILABLE_LABEL } from './metricText';
+import { describeHashExclusions, environmentRows, UNAVAILABLE_LABEL } from './metricText';
 
 /** Escape the five characters that can break out of text or an attribute. */
 function esc(value: string): string {
@@ -86,17 +86,10 @@ export function toHtml(report: RunReport): string {
     .map(([k, v]) => `<tr><th>${esc(k)}</th>${textCell(v)}</tr>`)
     .join('');
 
-  const envRows = (
-    [
-      ['release version', env.releaseVersion],
-      ['git commit', env.gitCommitShort],
-      ['git commit (full)', env.gitCommitFull],
-      ['OS', env.os],
-      ['CPU', env.cpuModel],
-      ['arch', env.arch],
-      ['Node', env.nodeVersion],
-    ] as ReadonlyArray<readonly [string, EnvValue]>
-  )
+  // From the shared label map, never a local array: this reporter is the one a
+  // reader opens, so a provenance field must not be able to reach the JSON and
+  // quietly skip the page.
+  const envRows = environmentRows(env)
     .map(([k, v]) => `<tr><th>${esc(k)}</th>${envCell(v)}</tr>`)
     .join('');
 
@@ -139,9 +132,17 @@ export function toHtml(report: RunReport): string {
 <h2>Stages</h2>
 <table>${headerRow(['stage', 'status', 'duration', 'peak RSS', 'error'])}${stageRows}</table>
 <h2>Metrics</h2>
-<table>${headerRow(['metric', 'value', 'runtime', 'deterministic'])}${metricRows}</table>
+${
+  metricRows === ''
+    ? '<p class="note">This run reported no suite-level metrics.</p>'
+    : `<table>${headerRow(['metric', 'value', 'runtime', 'deterministic'])}${metricRows}</table>`
+}
 <h2>Artifacts</h2>
-<table>${headerRow(['artifact', 'algorithm', 'hash', 'bytes', 'excluded from hash'])}${artifactRows}</table>
+${
+  artifactRows === ''
+    ? '<p class="note">This run produced no hashed artifacts.</p>'
+    : `<table>${headerRow(['artifact', 'algorithm', 'hash', 'bytes', 'excluded from hash'])}${artifactRows}</table>`
+}
 <p class="note">A cell marked ${UNAVAILABLE_LABEL} was not measured in this run. It is not zero,
 and it is not an estimate — the stated reason is why no number exists.</p>
 `;

--- a/benchmarks/framework/reporters/html.ts
+++ b/benchmarks/framework/reporters/html.ts
@@ -1,0 +1,144 @@
+/**
+ * html.ts
+ *
+ * The self-contained HTML report — a single file that can be attached to a
+ * release, opened from a USB stick, or archived in a data repository and still
+ * render identically in ten years.
+ *
+ * Self-contained is a hard constraint, not a preference: no stylesheet link, no
+ * script tag, no web font, no remote image. An artifact that fetches anything
+ * over the network stops rendering the day that host goes away, and it leaks the
+ * reader's inspection of an archived result to a third party. All styling is one
+ * inline `<style>` block using system fonts.
+ *
+ * Every interpolated string is escaped. Report content includes dataset ids and
+ * error messages that come from files and tools, and a `<` in one of those must
+ * render as a `<`, not restructure the document.
+ */
+
+import { isMeasured, type EnvValue, type Metric, type RunReport } from '../types';
+import { UNAVAILABLE_LABEL } from './metricText';
+
+/** Escape the five characters that can break out of text or an attribute. */
+function esc(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * A metric cell. The unavailable case gets its own class AND spells out the
+ * reason inline: a styled blank would still read as "measured, and small".
+ */
+function metricCell(m: Metric): string {
+  if (isMeasured(m)) {
+    return `<td><span class="value">${esc(String(m.value))}</span> <span class="unit">${esc(m.unit)}</span></td>`;
+  }
+  return `<td class="unavailable"><span class="tag">${UNAVAILABLE_LABEL}</span> <span class="reason">${esc(m.reason)}</span></td>`;
+}
+
+function envCell(e: EnvValue): string {
+  if (e.status === 'captured') return `<td>${esc(e.value)}</td>`;
+  return `<td class="unavailable"><span class="tag">${UNAVAILABLE_LABEL}</span> <span class="reason">${esc(e.reason)}</span></td>`;
+}
+
+function textCell(value: string): string {
+  return `<td>${esc(value)}</td>`;
+}
+
+function headerRow(labels: readonly string[]): string {
+  return `<tr>${labels.map((l) => `<th>${esc(l)}</th>`).join('')}</tr>`;
+}
+
+// System-font stack only, and no `url()` anywhere, so the file never reaches out.
+const STYLE = `
+:root { color-scheme: light dark; }
+body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+       margin: 2rem auto; max-width: 68rem; padding: 0 1rem; line-height: 1.5; }
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+h2 { font-size: 1.1rem; margin-top: 2rem; }
+table { border-collapse: collapse; width: 100%; margin-top: 0.5rem; font-size: 0.9rem; }
+th, td { border: 1px solid rgba(128,128,128,0.4); padding: 0.35rem 0.55rem; text-align: left;
+         vertical-align: top; }
+th { background: rgba(128,128,128,0.12); font-weight: 600; }
+code, .hash { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.85em;
+              word-break: break-all; }
+.unit { opacity: 0.75; }
+.unavailable .tag { font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em;
+                    font-size: 0.75em; padding: 0.05rem 0.3rem; border: 1px solid currentColor;
+                    border-radius: 0.2rem; }
+.unavailable .reason { opacity: 0.85; font-style: italic; }
+.failed { font-weight: 600; }
+.note { font-size: 0.85rem; opacity: 0.8; margin-top: 2rem; }
+`.trim();
+
+export function toHtml(report: RunReport): string {
+  const env = report.environment;
+
+  const runRows = [
+    ['suite', report.suiteId],
+    ['dataset', report.datasetId],
+    ['schema version', String(report.schemaVersion)],
+  ]
+    .map(([k, v]) => `<tr><th>${esc(k)}</th>${textCell(v)}</tr>`)
+    .join('');
+
+  const envRows = (
+    [
+      ['release version', env.releaseVersion],
+      ['git commit', env.gitCommitShort],
+      ['git commit (full)', env.gitCommitFull],
+      ['OS', env.os],
+      ['CPU', env.cpuModel],
+      ['arch', env.arch],
+      ['Node', env.nodeVersion],
+    ] as ReadonlyArray<readonly [string, EnvValue]>
+  )
+    .map(([k, v]) => `<tr><th>${esc(k)}</th>${envCell(v)}</tr>`)
+    .join('');
+
+  const stageRows = report.stages
+    .map(
+      (s) =>
+        `<tr>${textCell(s.name)}<td${s.status === 'failed' ? ' class="failed"' : ''}>${esc(s.status)}</td>` +
+        `${metricCell(s.duration)}${metricCell(s.peakMemory)}${textCell(s.error ?? '')}</tr>`,
+    )
+    .join('');
+
+  const metricRows = Object.entries(report.metrics)
+    .map(
+      ([name, m]) =>
+        `<tr>${textCell(name)}${metricCell(m)}${textCell(m.runtime)}${textCell(String(m.deterministic))}</tr>`,
+    )
+    .join('');
+
+  const artifactRows = report.artifacts
+    .map(
+      (a) =>
+        `<tr>${textCell(a.name)}${textCell(a.algorithm)}<td class="hash">${esc(a.hash)}</td>` +
+        `${textCell(String(a.byteLength))}${textCell(a.strippedFields.length === 0 ? '(none)' : a.strippedFields.join(', '))}</tr>`,
+    )
+    .join('');
+
+  return `<!doctype html>
+<meta charset="utf-8">
+<title>Benchmark run — ${esc(report.suiteId)}</title>
+<style>${STYLE}</style>
+<h1>Benchmark run — ${esc(report.suiteId)}</h1>
+<h2>Run</h2>
+<table>${runRows}</table>
+<h2>Environment</h2>
+<table>${envRows}</table>
+<h2>Stages</h2>
+<table>${headerRow(['stage', 'status', 'duration', 'peak RSS', 'error'])}${stageRows}</table>
+<h2>Metrics</h2>
+<table>${headerRow(['metric', 'value', 'runtime', 'deterministic'])}${metricRows}</table>
+<h2>Artifacts</h2>
+<table>${headerRow(['artifact', 'algorithm', 'hash', 'bytes', 'excluded from hash'])}${artifactRows}</table>
+<p class="note">A cell marked ${UNAVAILABLE_LABEL} was not measured in this run. It is not zero,
+and it is not an estimate — the stated reason is why no number exists.</p>
+`;
+}

--- a/benchmarks/framework/reporters/json.ts
+++ b/benchmarks/framework/reporters/json.ts
@@ -1,0 +1,21 @@
+/**
+ * json.ts
+ *
+ * The machine-readable report — the format the plotting scripts and any future
+ * regression check read.
+ *
+ * Serialised whole, with no field pruning: a metric that is unavailable keeps
+ * its key, its `null` value, its status and its reason. Dropping the key would
+ * force every consumer to guess whether a missing metric means "not measured"
+ * or "this suite does not produce it", and a guess is how a 0 gets invented.
+ *
+ * Two-space indent rather than a canonical single line: this file is read by
+ * humans in pull requests as often as by scripts. The hash of an artifact never
+ * comes from this string — that is `artifacts.ts` — so formatting is free.
+ */
+
+import type { RunReport } from '../types';
+
+export function toJson(report: RunReport): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/benchmarks/framework/reporters/markdown.ts
+++ b/benchmarks/framework/reporters/markdown.ts
@@ -16,11 +16,23 @@
  */
 
 import type { RunReport } from '../types';
-import { describeHashExclusions, formatEnvValue, formatMetric } from './metricText';
+import {
+  describeHashExclusions,
+  environmentRows,
+  formatEnvValue,
+  formatMetric,
+} from './metricText';
 
-/** Escape the only character that can restructure a Markdown table. */
+/**
+ * Neutralise the two things that can restructure a Markdown table.
+ *
+ * A `|` adds a column and shifts every later cell one to the left; a newline
+ * ends the row outright and turns the rest of the table into a paragraph. Both
+ * arrive from suite-supplied text — stage names, dataset ids, error messages,
+ * unavailability reasons — so neither can be assumed away.
+ */
 function md(value: string): string {
-  return value.replace(/\|/g, '\\|');
+  return value.replace(/\|/g, '\\|').replace(/\s*[\r\n]+\s*/g, '; ');
 }
 
 function table(header: readonly string[], rows: readonly (readonly string[])[]): string {
@@ -42,13 +54,12 @@ export function toMarkdown(report: RunReport): string {
         ['suite', report.suiteId],
         ['dataset', report.datasetId],
         ['schema version', String(report.schemaVersion)],
-        ['release version', formatEnvValue(report.environment.releaseVersion)],
-        ['git commit', formatEnvValue(report.environment.gitCommitShort)],
-        ['git commit (full)', formatEnvValue(report.environment.gitCommitFull)],
-        ['OS', formatEnvValue(report.environment.os)],
-        ['CPU', formatEnvValue(report.environment.cpuModel)],
-        ['arch', formatEnvValue(report.environment.arch)],
-        ['Node', formatEnvValue(report.environment.nodeVersion)],
+        // Driven by the shared label map, never a local list: a provenance
+        // field added to the schema must not be able to reach the JSON and skip
+        // the document a reader actually looks at.
+        ...environmentRows(report.environment).map(
+          ([label, field]) => [label, formatEnvValue(field)] as const,
+        ),
       ],
     ),
   );

--- a/benchmarks/framework/reporters/markdown.ts
+++ b/benchmarks/framework/reporters/markdown.ts
@@ -1,0 +1,110 @@
+/**
+ * markdown.ts
+ *
+ * The human-readable report — what gets pasted into a release note, a pull
+ * request, or a paper's supplementary material.
+ *
+ * Every cell that could hold a measurement holds either a number with its unit
+ * or the words `unavailable — <reason>`. Markdown makes the tempting shortcut
+ * especially cheap here (an empty cell still renders as a tidy table), which is
+ * exactly why the reason is spelled out in the cell rather than relegated to a
+ * footnote a reader can skip.
+ *
+ * Pipes in any interpolated string are escaped: an unescaped `|` in a reason
+ * would silently split the row into an extra column and shift every value one
+ * cell to the left — a corruption that still looks like a valid table.
+ */
+
+import type { RunReport } from '../types';
+import { formatEnvValue, formatMetric } from './metricText';
+
+/** Escape the only character that can restructure a Markdown table. */
+function md(value: string): string {
+  return value.replace(/\|/g, '\\|');
+}
+
+function table(header: readonly string[], rows: readonly (readonly string[])[]): string {
+  const head = `| ${header.map(md).join(' | ')} |`;
+  const rule = `| ${header.map(() => '---').join(' | ')} |`;
+  const body = rows.map((r) => `| ${r.map(md).join(' | ')} |`);
+  return [head, rule, ...body].join('\n');
+}
+
+export function toMarkdown(report: RunReport): string {
+  const out: string[] = [];
+
+  out.push(`# Benchmark run — ${md(report.suiteId)}`);
+  out.push('');
+  out.push(
+    table(
+      ['field', 'value'],
+      [
+        ['suite', report.suiteId],
+        ['dataset', report.datasetId],
+        ['schema version', String(report.schemaVersion)],
+        ['release version', formatEnvValue(report.environment.releaseVersion)],
+        ['git commit', formatEnvValue(report.environment.gitCommitShort)],
+        ['git commit (full)', formatEnvValue(report.environment.gitCommitFull)],
+        ['OS', formatEnvValue(report.environment.os)],
+        ['CPU', formatEnvValue(report.environment.cpuModel)],
+        ['arch', formatEnvValue(report.environment.arch)],
+        ['Node', formatEnvValue(report.environment.nodeVersion)],
+      ],
+    ),
+  );
+
+  out.push('');
+  out.push('## Stages');
+  out.push('');
+  out.push(
+    table(
+      ['stage', 'status', 'duration', 'peak RSS', 'error'],
+      report.stages.map((s) => [
+        s.name,
+        s.status,
+        formatMetric(s.duration),
+        formatMetric(s.peakMemory),
+        s.error ?? '',
+      ]),
+    ),
+  );
+
+  out.push('');
+  out.push('## Metrics');
+  out.push('');
+  const metrics = Object.entries(report.metrics);
+  out.push(
+    metrics.length === 0
+      ? '_This run reported no suite-level metrics._'
+      : table(
+          ['metric', 'value', 'runtime', 'deterministic'],
+          metrics.map(([name, m]) => [
+            name,
+            formatMetric(m),
+            m.runtime,
+            String(m.deterministic),
+          ]),
+        ),
+  );
+
+  out.push('');
+  out.push('## Artifacts');
+  out.push('');
+  out.push(
+    report.artifacts.length === 0
+      ? '_This run produced no hashed artifacts._'
+      : table(
+          ['artifact', 'algorithm', 'hash', 'bytes', 'excluded from hash'],
+          report.artifacts.map((a) => [
+            a.name,
+            a.algorithm,
+            a.hash,
+            String(a.byteLength),
+            a.strippedFields.length === 0 ? '(none)' : a.strippedFields.join(', '),
+          ]),
+        ),
+  );
+
+  out.push('');
+  return `${out.join('\n')}\n`;
+}

--- a/benchmarks/framework/reporters/markdown.ts
+++ b/benchmarks/framework/reporters/markdown.ts
@@ -16,7 +16,7 @@
  */
 
 import type { RunReport } from '../types';
-import { formatEnvValue, formatMetric } from './metricText';
+import { describeHashExclusions, formatEnvValue, formatMetric } from './metricText';
 
 /** Escape the only character that can restructure a Markdown table. */
 function md(value: string): string {
@@ -100,7 +100,7 @@ export function toMarkdown(report: RunReport): string {
             a.algorithm,
             a.hash,
             String(a.byteLength),
-            a.strippedFields.length === 0 ? '(none)' : a.strippedFields.join(', '),
+            describeHashExclusions(a),
           ]),
         ),
   );

--- a/benchmarks/framework/reporters/metricText.ts
+++ b/benchmarks/framework/reporters/metricText.ts
@@ -53,8 +53,8 @@ export function formatEnvValue(e: EnvValue): string {
  * one that must never render as an empty list.
  */
 export function describeHashExclusions(a: ArtifactRecord): string {
-  if (!a.volatilityStripped) {
-    return `not stripped — ${a.unstrippedReason ?? 'no reason recorded'}`;
-  }
+  // No fallback for a missing reason: `ArtifactRecord` makes an unexplained gap
+  // a compile error, so there is no unexplained case left to invent text for.
+  if (!a.volatilityStripped) return `not stripped — ${a.unstrippedReason}`;
   return a.strippedFields.length === 0 ? '(none)' : a.strippedFields.join(', ');
 }

--- a/benchmarks/framework/reporters/metricText.ts
+++ b/benchmarks/framework/reporters/metricText.ts
@@ -14,7 +14,13 @@
  * measurement was, which is the measurer's call, not the formatter's.
  */
 
-import { isMeasured, type ArtifactRecord, type EnvValue, type Metric } from '../types';
+import {
+  isMeasured,
+  type ArtifactRecord,
+  type BenchmarkEnvironment,
+  type EnvValue,
+  type Metric,
+} from '../types';
 
 /** The literal that must appear wherever a metric was not measured. */
 export const UNAVAILABLE_LABEL = 'unavailable';
@@ -37,6 +43,36 @@ export function metricUnitCell(m: Metric): string {
 /** The reason column. Empty for a measured metric, which needs no excuse. */
 export function metricReasonCell(m: Metric): string {
   return isMeasured(m) ? '' : m.reason;
+}
+
+/**
+ * Every environment field, in report order, with its human label.
+ *
+ * The typed `Record<keyof BenchmarkEnvironment, string>` is the point: the HTML
+ * and Markdown reporters used to hard-code their own arrays, so adding a
+ * provenance field put it in the JSON and the CSV and silently dropped it from
+ * the other two — with no test failing. A provenance field that is present in
+ * the machine-readable output and missing from the HTML attached to a paper is
+ * the worst version of that. Now a new field fails the typecheck here until it
+ * is labelled, and both reporters pick it up from this one list.
+ */
+export const ENVIRONMENT_LABELS: Record<keyof BenchmarkEnvironment, string> = {
+  releaseVersion: 'release version',
+  gitCommitShort: 'git commit',
+  gitCommitFull: 'git commit (full)',
+  gitDirty: 'working tree',
+  os: 'OS',
+  cpuModel: 'CPU',
+  arch: 'arch',
+  nodeVersion: 'Node',
+};
+
+/** The label map as ordered pairs, ready for a reporter to render. */
+export function environmentRows(
+  env: BenchmarkEnvironment,
+): ReadonlyArray<readonly [string, EnvValue]> {
+  const keys = Object.keys(ENVIRONMENT_LABELS) as (keyof BenchmarkEnvironment)[];
+  return keys.map((k) => [ENVIRONMENT_LABELS[k], env[k]] as const);
 }
 
 /** An environment field: the captured string, or the word plus its reason. */

--- a/benchmarks/framework/reporters/metricText.ts
+++ b/benchmarks/framework/reporters/metricText.ts
@@ -1,0 +1,45 @@
+/**
+ * metricText.ts
+ *
+ * The one place a metric is turned into text, shared by all four reporters.
+ *
+ * It exists so the honesty contract cannot be broken in three formats out of
+ * four: an unavailable metric is rendered as the WORD "unavailable" followed by
+ * its reason, never as '', '-', '0' or 'n/a'. Each of those reads to a human as
+ * a measurement — a dash in a timing column is taken as "negligible" — and once
+ * a table is in a paper, the distinction is unrecoverable.
+ *
+ * Numbers are printed with `String(value)`: no rounding, no thousands
+ * separators, no locale. A reporter that rounds is deciding how precise the
+ * measurement was, which is the measurer's call, not the formatter's.
+ */
+
+import { isMeasured, type EnvValue, type Metric } from '../types';
+
+/** The literal that must appear wherever a metric was not measured. */
+export const UNAVAILABLE_LABEL = 'unavailable';
+
+/** `12.5 ms`, or `unavailable — <reason>`. */
+export function formatMetric(m: Metric): string {
+  return isMeasured(m) ? `${m.value} ${m.unit}` : `${UNAVAILABLE_LABEL} — ${m.reason}`;
+}
+
+/** The value column on its own: a number, or the word — never blank. */
+export function metricValueCell(m: Metric): string {
+  return isMeasured(m) ? String(m.value) : UNAVAILABLE_LABEL;
+}
+
+/** The unit column. Empty for an unavailable metric, which genuinely has none. */
+export function metricUnitCell(m: Metric): string {
+  return isMeasured(m) ? m.unit : '';
+}
+
+/** The reason column. Empty for a measured metric, which needs no excuse. */
+export function metricReasonCell(m: Metric): string {
+  return isMeasured(m) ? '' : m.reason;
+}
+
+/** An environment field: the captured string, or the word plus its reason. */
+export function formatEnvValue(e: EnvValue): string {
+  return e.status === 'captured' ? e.value : `${UNAVAILABLE_LABEL} — ${e.reason}`;
+}

--- a/benchmarks/framework/reporters/metricText.ts
+++ b/benchmarks/framework/reporters/metricText.ts
@@ -14,7 +14,7 @@
  * measurement was, which is the measurer's call, not the formatter's.
  */
 
-import { isMeasured, type EnvValue, type Metric } from '../types';
+import { isMeasured, type ArtifactRecord, type EnvValue, type Metric } from '../types';
 
 /** The literal that must appear wherever a metric was not measured. */
 export const UNAVAILABLE_LABEL = 'unavailable';
@@ -42,4 +42,19 @@ export function metricReasonCell(m: Metric): string {
 /** An environment field: the captured string, or the word plus its reason. */
 export function formatEnvValue(e: EnvValue): string {
   return e.status === 'captured' ? e.value : `${UNAVAILABLE_LABEL} — ${e.reason}`;
+}
+
+/**
+ * What a hash comparison of this artifact deliberately ignores.
+ *
+ * The three cases are genuinely different and must not collapse into one blank
+ * cell: fields were excluded, nothing needed excluding, or no strip could run
+ * at all. Only the last carries a caveat about the hash itself, so it is the
+ * one that must never render as an empty list.
+ */
+export function describeHashExclusions(a: ArtifactRecord): string {
+  if (!a.volatilityStripped) {
+    return `not stripped — ${a.unstrippedReason ?? 'no reason recorded'}`;
+  }
+  return a.strippedFields.length === 0 ? '(none)' : a.strippedFields.join(', ');
 }

--- a/benchmarks/framework/stage.ts
+++ b/benchmarks/framework/stage.ts
@@ -1,0 +1,90 @@
+/**
+ * stage.ts
+ *
+ * Run one stage of a suite and record it.
+ *
+ * This is the only place the clock and the memory sampler are composed, so that
+ * three suites cannot each grow their own answer to "what do we write down when
+ * a stage throws". The answer here: the stage is marked failed, its message is
+ * kept, and its duration and peak RSS are recorded anyway. A decode that died
+ * after 40 s and 6 GB tells a reader something real; a blank row does not, and a
+ * row of zeros actively misleads.
+ *
+ * Only the error MESSAGE is stored, never the stack: a stack embeds absolute
+ * paths from the machine that ran the suite, which is precisely what
+ * `artifacts.ts` then has to strip back out of every hashed artifact.
+ */
+
+import { startStageClock } from './clock';
+import { startMemorySampler, type MemorySamplerOptions } from './memory';
+import type { StageResult } from './types';
+
+export interface StageOutcome<T> {
+  readonly stage: StageResult;
+  /** The body's return value; undefined exactly when the stage failed. */
+  readonly value?: T;
+}
+
+export interface RunStageOptions {
+  /** Passed through to the memory sampler — mainly for injecting a reader. */
+  readonly memory?: MemorySamplerOptions;
+}
+
+/** Normalise a thrown value to a single line a report can carry. */
+function messageOf(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/** Time and measure a synchronous stage. Never rethrows. */
+export function runStage<T>(
+  name: string,
+  body: () => T,
+  options: RunStageOptions = {},
+): StageOutcome<T> {
+  const memory = startMemorySampler(options.memory);
+  const stopClock = startStageClock();
+  try {
+    const value = body();
+    return { stage: close(name, stopClock, memory, undefined), value };
+  } catch (err) {
+    return { stage: close(name, stopClock, memory, messageOf(err)) };
+  }
+}
+
+/** Time and measure an asynchronous stage. Never rejects. */
+export async function runStageAsync<T>(
+  name: string,
+  body: () => Promise<T>,
+  options: RunStageOptions = {},
+): Promise<StageOutcome<T>> {
+  const memory = startMemorySampler(options.memory);
+  const stopClock = startStageClock();
+  try {
+    const value = await body();
+    return { stage: close(name, stopClock, memory, undefined), value };
+  } catch (err) {
+    return { stage: close(name, stopClock, memory, messageOf(err)) };
+  }
+}
+
+/**
+ * Close both instruments and assemble the result.
+ *
+ * The clock is read BEFORE the sampler is stopped so the recorded duration
+ * excludes the sampler's own teardown — small, but it is the difference between
+ * a timing that measures the stage and one that measures the harness.
+ */
+function close(
+  name: string,
+  stopClock: () => StageResult['duration'],
+  memory: { stop: () => StageResult['peakMemory'] },
+  error: string | undefined,
+): StageResult {
+  const duration = stopClock();
+  const peakMemory = memory.stop();
+  const base = { name, duration, peakMemory } as const;
+  return error === undefined
+    ? { ...base, status: 'ok' }
+    : { ...base, status: 'failed', error };
+}

--- a/benchmarks/framework/stage.ts
+++ b/benchmarks/framework/stage.ts
@@ -21,7 +21,13 @@ import type { StageResult } from './types';
 
 export interface StageOutcome<T> {
   readonly stage: StageResult;
-  /** The body's return value; undefined exactly when the stage failed. */
+  /**
+   * The body's return value, absent when the stage failed.
+   *
+   * Do not read `value === undefined` as "it failed" — a body that legitimately
+   * returns undefined is indistinguishable that way. `stage.status` is the
+   * discriminant, and it narrows `stage.error` with it.
+   */
   readonly value?: T;
 }
 
@@ -30,10 +36,18 @@ export interface RunStageOptions {
   readonly memory?: MemorySamplerOptions;
 }
 
-/** Normalise a thrown value to a single line a report can carry. */
+/**
+ * Normalise a thrown value to a single line a report can carry.
+ *
+ * `Error.message` is routinely multi-line (a parser quoting its input, an
+ * aggregate error listing causes), and a raw newline breaks the Markdown table
+ * apart mid-row: the remainder of the message becomes a paragraph and the
+ * following stages shift into a second, headerless table. Collapsing the runs
+ * to `; ` keeps every word and costs only the line breaks.
+ */
 function messageOf(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
+  const raw = err instanceof Error ? err.message : String(err);
+  return raw.replace(/\s*[\r\n]+\s*/g, '; ').trim();
 }
 
 /** Time and measure a synchronous stage. Never rethrows. */

--- a/benchmarks/framework/types.ts
+++ b/benchmarks/framework/types.ts
@@ -127,19 +127,39 @@ export interface BenchmarkEnvironment {
   readonly nodeVersion: EnvValue;
   readonly gitCommitShort: EnvValue;
   readonly gitCommitFull: EnvValue;
+  /** 'clean' or 'dirty' — whether the tree actually matches that commit. */
+  readonly gitDirty: EnvValue;
   /** The `version` field of package.json — the release the run belongs to. */
   readonly releaseVersion: EnvValue;
 }
 
 /** One timed stage of a suite. Duration is ms, peak memory is bytes. */
-export interface StageResult {
+interface StageResultBase {
   readonly name: string;
   readonly duration: Metric;
   readonly peakMemory: Metric;
-  readonly status: 'ok' | 'failed';
-  /** Present only when `status` is 'failed'; the message, never a stack. */
-  readonly error?: string;
 }
+
+export interface OkStageResult extends StageResultBase {
+  readonly status: 'ok';
+  /** A stage that succeeded has nothing to report — structurally unsayable. */
+  readonly error?: never;
+}
+
+export interface FailedStageResult extends StageResultBase {
+  readonly status: 'failed';
+  /** The message, never a stack: a stack embeds absolute machine paths. */
+  readonly error: string;
+}
+
+/**
+ * Split on `status` for the same reason `Metric` and `ArtifactRecord` are split:
+ * a failure with no explanation and a success carrying an error message are both
+ * things a report must not be able to state. Every reporter prints the error
+ * column, so an unexplained 'failed' would render as a blank a reader takes for
+ * "it failed for no reason".
+ */
+export type StageResult = OkStageResult | FailedStageResult;
 
 /**
  * The hash record of one scientific artifact.

--- a/benchmarks/framework/types.ts
+++ b/benchmarks/framework/types.ts
@@ -1,0 +1,174 @@
+/**
+ * types.ts
+ *
+ * The schema every benchmark suite and every reporter shares.
+ *
+ * The one rule the whole framework exists to enforce: a measurement that was not
+ * taken is never written down as a number. Reports produced here are meant to be
+ * read as evidence, and a `0` standing in for "we could not measure this" is
+ * indistinguishable from a genuine 0 once it reaches a table or a plot. So the
+ * metric type is a discriminated union in which the unavailable branch pins
+ * `value` to `null` and REQUIRES a reason — `{ status: 'unavailable', value: 12 }`
+ * does not typecheck, and neither does an unavailable metric with a unit.
+ *
+ * Every metric also carries the runtime it can be taken in and whether it is
+ * reproducible, because the suites mix Node-side measurements (decode time, RSS)
+ * with browser-only ones (GPU frame time). Without those two flags a reader
+ * cannot tell a fixed property of the software from a number that moves between
+ * runs and machines.
+ *
+ * Pure data + guards. No I/O, no clock, no randomness — safe to import anywhere.
+ */
+
+/** Where a metric can physically be taken. */
+export type MetricRuntime = 'node' | 'browser';
+
+/** Bumped whenever a field changes meaning, so an old report is never misread. */
+export const BENCHMARK_SCHEMA_VERSION = 1;
+
+/** The two facts every metric declares regardless of whether it was measured. */
+export interface MetricProvenance {
+  readonly runtime: MetricRuntime;
+  /** True only if an identical re-run must produce the identical value. */
+  readonly deterministic: boolean;
+}
+
+/** A measurement that was actually taken. Always has a value AND a unit. */
+export interface MeasuredMetric extends MetricProvenance {
+  readonly status: 'measured';
+  readonly value: number;
+  readonly unit: string;
+  /** Structurally forbids a measured metric from carrying an excuse. */
+  readonly reason?: never;
+}
+
+/** A measurement that could not be taken. Never has a value, always has a why. */
+export interface UnavailableMetric extends MetricProvenance {
+  readonly status: 'unavailable';
+  readonly value: null;
+  readonly reason: string;
+  /** Structurally forbids an unavailable metric from carrying a unit. */
+  readonly unit?: never;
+}
+
+export type Metric = MeasuredMetric | UnavailableMetric;
+
+/**
+ * Build a measured metric.
+ *
+ * Rejects a non-finite value because `JSON.stringify(NaN)` is `null`: a NaN that
+ * slipped through would serialise as a null value under status 'measured' — the
+ * precise contradiction the schema is built to make impossible. Rejects an empty
+ * unit for the same class of reason: a bare number is not a measurement.
+ */
+export function measured(value: number, unit: string, p: MetricProvenance): MeasuredMetric {
+  if (!Number.isFinite(value)) {
+    throw new Error(`benchmark metric: value must be finite, got ${String(value)}`);
+  }
+  if (unit.trim() === '') throw new Error('benchmark metric: unit must not be empty');
+  return { status: 'measured', value, unit, runtime: p.runtime, deterministic: p.deterministic };
+}
+
+/**
+ * Build an unavailable metric.
+ *
+ * The reason is mandatory and must be non-empty: "unavailable" on its own tells
+ * a reviewer nothing about whether the number is missing because the runtime
+ * cannot supply it or because the run went wrong.
+ */
+export function unavailable(reason: string, p: MetricProvenance): UnavailableMetric {
+  if (reason.trim() === '') throw new Error('benchmark metric: unavailable needs a reason');
+  return { status: 'unavailable', value: null, reason, runtime: p.runtime, deterministic: p.deterministic };
+}
+
+export function isMeasured(m: Metric): m is MeasuredMetric {
+  return m.status === 'measured';
+}
+
+export function isUnavailable(m: Metric): m is UnavailableMetric {
+  return m.status === 'unavailable';
+}
+
+/**
+ * An environment field. Strings rather than numbers, but the same contract: a
+ * field the framework could not determine says so and explains why, instead of
+ * defaulting to '' or 'unknown' — both of which read as data further downstream.
+ */
+export interface CapturedEnvValue {
+  readonly status: 'captured';
+  readonly value: string;
+  readonly reason?: never;
+}
+
+export interface UnavailableEnvValue {
+  readonly status: 'unavailable';
+  readonly value: null;
+  readonly reason: string;
+}
+
+export type EnvValue = CapturedEnvValue | UnavailableEnvValue;
+
+export function capturedEnv(value: string): CapturedEnvValue {
+  if (value.trim() === '') throw new Error('benchmark env: captured value must not be empty');
+  return { status: 'captured', value };
+}
+
+export function unavailableEnv(reason: string): UnavailableEnvValue {
+  if (reason.trim() === '') throw new Error('benchmark env: unavailable needs a reason');
+  return { status: 'unavailable', value: null, reason };
+}
+
+/** The provenance block: everything a reader needs to place a run in context. */
+export interface BenchmarkEnvironment {
+  /** OS platform and release, e.g. "darwin 24.0.0". */
+  readonly os: EnvValue;
+  readonly cpuModel: EnvValue;
+  readonly arch: EnvValue;
+  readonly nodeVersion: EnvValue;
+  readonly gitCommitShort: EnvValue;
+  readonly gitCommitFull: EnvValue;
+  /** The `version` field of package.json — the release the run belongs to. */
+  readonly releaseVersion: EnvValue;
+}
+
+/** One timed stage of a suite. Duration is ms, peak memory is bytes. */
+export interface StageResult {
+  readonly name: string;
+  readonly duration: Metric;
+  readonly peakMemory: Metric;
+  readonly status: 'ok' | 'failed';
+  /** Present only when `status` is 'failed'; the message, never a stack. */
+  readonly error?: string;
+}
+
+/**
+ * The hash record of one scientific artifact.
+ *
+ * `strippedFields` is part of the record on purpose: it names the fields that
+ * were removed before hashing, so a reviewer comparing two hashes can see what
+ * the comparison deliberately ignores without reading the framework source.
+ */
+export interface ArtifactRecord {
+  readonly name: string;
+  readonly kind: 'json' | 'bytes';
+  readonly algorithm: 'sha256';
+  /** Lowercase hex SHA-256 of the canonical, volatility-stripped form. */
+  readonly hash: string;
+  /** Short FNV-1a fingerprint of the same canonical form, for compact tables. */
+  readonly fingerprint: string;
+  readonly byteLength: number;
+  /** Dotted paths excluded from the hash, sorted. Empty for byte artifacts. */
+  readonly strippedFields: readonly string[];
+}
+
+/** The whole result of one suite run against one dataset. */
+export interface RunReport {
+  readonly schemaVersion: number;
+  readonly suiteId: string;
+  readonly datasetId: string;
+  readonly environment: BenchmarkEnvironment;
+  readonly stages: readonly StageResult[];
+  readonly artifacts: readonly ArtifactRecord[];
+  /** Suite-level headline numbers, keyed by name (e.g. `pointsPerSecond`). */
+  readonly metrics: Readonly<Record<string, Metric>>;
+}

--- a/benchmarks/framework/types.ts
+++ b/benchmarks/framework/types.ts
@@ -148,7 +148,7 @@ export interface StageResult {
  * were removed before hashing, so a reviewer comparing two hashes can see what
  * the comparison deliberately ignores without reading the framework source.
  */
-export interface ArtifactRecord {
+interface ArtifactRecordBase {
   readonly name: string;
   readonly kind: 'json' | 'bytes';
   readonly algorithm: 'sha256';
@@ -159,19 +159,31 @@ export interface ArtifactRecord {
   readonly byteLength: number;
   /** Dotted paths excluded from the hash, sorted. Empty for byte artifacts. */
   readonly strippedFields: readonly string[];
-  /**
-   * Whether the volatile-field strip could be applied at all.
-   *
-   * False for byte artifacts, whose contents are opaque. The distinction is on
-   * the record rather than in a source comment because `strippedFields: []` is
-   * ambiguous on its own: it reads as "nothing volatile in here" when the truth
-   * may be "nothing could be inspected". A reader comparing two hashes needs to
-   * know which of those they are looking at.
-   */
-  readonly volatilityStripped: boolean;
-  /** Why no strip was applied. Present exactly when `volatilityStripped` is false. */
-  readonly unstrippedReason?: string;
 }
+
+/** An artifact whose contents could be inspected, so the strip actually ran. */
+export interface StrippedArtifactRecord extends ArtifactRecordBase {
+  readonly volatilityStripped: true;
+  /** Nothing to explain when the strip ran — structurally unsayable. */
+  readonly unstrippedReason?: never;
+}
+
+/** An artifact hashed raw, which is a caveat on the hash and must be explained. */
+export interface UnstrippedArtifactRecord extends ArtifactRecordBase {
+  readonly volatilityStripped: false;
+  readonly unstrippedReason: string;
+}
+
+/**
+ * Split on `volatilityStripped` for the same reason `Metric` is split on
+ * `status`: `strippedFields: []` is ambiguous on its own — it reads as "nothing
+ * volatile in here" when the truth may be "nothing could be inspected" — and a
+ * disclosure that a gap exists WITHOUT saying why is the one thing this
+ * framework must never emit. `hashArtifact` is not the only constructor (suites
+ * and fixtures hand-build records), so the guarantee has to be structural: an
+ * unexplained gap and a contradictory explanation are both compile errors.
+ */
+export type ArtifactRecord = StrippedArtifactRecord | UnstrippedArtifactRecord;
 
 /** The whole result of one suite run against one dataset. */
 export interface RunReport {

--- a/benchmarks/framework/types.ts
+++ b/benchmarks/framework/types.ts
@@ -159,6 +159,18 @@ export interface ArtifactRecord {
   readonly byteLength: number;
   /** Dotted paths excluded from the hash, sorted. Empty for byte artifacts. */
   readonly strippedFields: readonly string[];
+  /**
+   * Whether the volatile-field strip could be applied at all.
+   *
+   * False for byte artifacts, whose contents are opaque. The distinction is on
+   * the record rather than in a source comment because `strippedFields: []` is
+   * ambiguous on its own: it reads as "nothing volatile in here" when the truth
+   * may be "nothing could be inspected". A reader comparing two hashes needs to
+   * know which of those they are looking at.
+   */
+  readonly volatilityStripped: boolean;
+  /** Why no strip was applied. Present exactly when `volatilityStripped` is false. */
+  readonly unstrippedReason?: string;
 }
 
 /** The whole result of one suite run against one dataset. */

--- a/benchmarks/pipeline/runPipeline.ts
+++ b/benchmarks/pipeline/runPipeline.ts
@@ -1,0 +1,655 @@
+/**
+ * runPipeline.ts
+ *
+ * The pipeline driver: run OLV's REAL science pipeline over a seeded synthetic
+ * cloud and report one timed stage per step, plus the scientific artifacts each
+ * step produced.
+ *
+ * WHY THE DRIVER CALLS APPLICATION CODE AND NOTHING ELSE. A benchmark that
+ * re-implemented the pipeline would measure the benchmark. Worse, it would keep
+ * reporting healthy numbers after the application changed, because nothing
+ * would connect the two any more. So every stage below is a call into `src/`,
+ * and `tests/benchmark/pipelineDriver.test.ts` pins the driver's DTM, contours
+ * and complexity output against `analyseContours` — the entry point the
+ * AnalysePanel and the contour worker use — on the same input. Reimplement any
+ * stage and that equality breaks immediately.
+ *
+ * THE CALL CHAIN, stage by stage:
+ *
+ *   generate      → benchmarks/fixtures/syntheticCloud.ts (the only non-app code)
+ *   rasterize     → resolveGroundFilterParams → classifyGroundSmrf → rasterizeDtm
+ *   dtm           → computeTerrainCore  (ground filter → raster → despike +
+ *                   geodesic void fill + per-cell confidence via
+ *                   buildSurfaceFromRaster → buildDtmGrid → hold-out validation
+ *                   → confidence calibration → interval gate → quality, scoring,
+ *                   surface models)
+ *   descriptors   → horizontalCellMetresXY → summariseTerrainComplexity
+ *                   (VRM, Sappington et al. 2007; TPI, Weiss 2001)
+ *   contours      → contoursFromCore (interval choice → contoursAt → stitch →
+ *                   style → shape → feature model → tally → labels)
+ *   scientificRec → buildExportProvenance → analysisRecordFromProvenance
+ *   manifest      → processingManifestFromProvenance → verifyProcessingManifest
+ *
+ * `dtm` and `contours` are the application's OWN two halves — `analyseContours`
+ * is defined as `contoursFromCore ∘ computeTerrainCore` — so together they are
+ * exactly one full analysis with no work done twice and no sequencing invented
+ * here. `rasterize` and `descriptors` are the two leaves timed in isolation, so
+ * a scaling suite can see how each core scales on its own; they are therefore
+ * NOT disjoint from `dtm`, which runs both again internally. Summing all seven
+ * stages double-counts them; read `dtm` + `contours` as the pipeline's cost.
+ *
+ * BROWSER-ONLY WORK IS DECLARED, NOT DROPPED. GPU upload, first rendered frame,
+ * frame rate and time-to-interaction are real stages of the user's workflow and
+ * Node can measure none of them. They are reported as stages whose metrics are
+ * `unavailable` with a reason naming the limitation, never as 0 and never as an
+ * estimate, so a workflow report shows the whole pipeline with honest gaps
+ * instead of a partial one that looks complete.
+ *
+ * Runtime-neutral by construction: nothing here imports a `node:` builtin, so a
+ * browser-side suite can reuse the driver and fill in the four stages Node
+ * cannot. It does need the `__BUILD_IDENTITY__` define that Vite and Vitest
+ * supply (the export-provenance path stamps the build into the record), so it
+ * runs under those, not under a bare `node` process.
+ */
+
+import {
+  measured,
+  runStage,
+  unavailable,
+  type Metric,
+  type StageResult,
+} from '../framework';
+import { generateSyntheticCloud, type SyntheticCloud } from '../fixtures/syntheticCloud';
+import type { TerrainPoint } from '../../src/terrain/TerrainContracts';
+import { classifyGroundSmrf } from '../../src/terrain/ground/groundFilter';
+import { rasterizeDtm, type DtmAggregation } from '../../src/terrain/ground/rasterizeDtm';
+import { horizontalCellMetresXY } from '../../src/terrain/ground/horizontalScale';
+import {
+  computeTerrainCore,
+  contoursFromCore,
+  resolveGroundFilterParams,
+  type AnalyseContoursParams,
+  type AnalyseContoursResult,
+  type TerrainCore,
+} from '../../src/terrain/contour/analyseContours';
+import {
+  summariseTerrainComplexity,
+  type TerrainComplexitySummary,
+} from '../../src/terrain/complexity/complexitySummary';
+import {
+  analysisRecordFromProvenance,
+  buildExportProvenance,
+  processingManifestFromProvenance,
+} from '../../src/terrain/export/exportProvenance';
+import { verifyProcessingManifest } from '../../src/science/processingManifest';
+
+/** The stages measurable under Node, in pipeline order. */
+export const NODE_STAGES = [
+  'generate',
+  'rasterize',
+  'dtm',
+  'descriptors',
+  'contours',
+  'scientificRecord',
+  'manifest',
+] as const;
+
+/** The stages that exist only in a browser. Reported, never measured here. */
+export const BROWSER_ONLY_STAGES = [
+  'gpuUpload',
+  'renderReady',
+  'fps',
+  'timeToInteraction',
+] as const;
+
+/** Every stage a run reports, in the order a report renders them. */
+export const PIPELINE_STAGES = [...NODE_STAGES, ...BROWSER_ONLY_STAGES] as const;
+
+export type NodeStageName = (typeof NODE_STAGES)[number];
+export type BrowserStageName = (typeof BROWSER_ONLY_STAGES)[number];
+export type PipelineStageName = (typeof PIPELINE_STAGES)[number];
+
+/**
+ * Why each browser stage has no number here. Each names the specific runtime
+ * facility Node lacks: "unavailable" on its own tells a reviewer nothing about
+ * whether the measurement is impossible or merely was not taken.
+ */
+const BROWSER_STAGE_REASONS: Readonly<Record<BrowserStageName, string>> = {
+  gpuUpload:
+    'GPU buffer upload runs against the browser WebGPU/WebGL device; a Node process has no GPU adapter, so there is no upload to time.',
+  renderReady:
+    'Time to the first rendered frame is a compositor event; Node has no renderer and no presentation surface to present to.',
+  fps: 'Frame rate is measured against the browser display refresh; Node has no frame loop and no display to synchronise with.',
+  timeToInteraction:
+    'Time-to-interaction runs from a user input event to the painted response; Node has neither input events nor paint.',
+};
+
+/** Default DTM/contour grid, source units. Around 16 returns per cell at QL2. */
+export const DEFAULT_CELL_SIZE_M = 2;
+/** A projected, metre-denominated frame, so the pipeline's unit seams are 1:1. */
+export const DEFAULT_CRS = 'EPSG:32610';
+export const DEFAULT_VERTICAL_DATUM = 'EPSG:5703';
+/**
+ * The per-cell aggregation every run benchmarks with.
+ *
+ * Stated explicitly rather than left to the pipeline's default, because the
+ * isolated `rasterize` stage has to rasterise the SAME way the core does and
+ * the live default is private to `analyseContours`. A test asserts this value
+ * still equals what the core picks on its own, so a change of the live default
+ * shows up as a red test rather than as a benchmark quietly measuring a surface
+ * the application stopped producing.
+ */
+export const BENCHMARK_AGGREGATION: DtmAggregation = 'median';
+/**
+ * A fixed generation timestamp.
+ *
+ * `buildExportProvenance` defaults this to `new Date()`, and that value reaches
+ * the scientific record and the manifest chain — so a real clock would make two
+ * identical runs produce different artifacts and the reproducibility check would
+ * never pass. (The framework's strip list would remove the ISO field itself, but
+ * the manifest folds the envelope into a hash chain, where nothing can be
+ * stripped after the fact.)
+ */
+export const FIXED_GENERATED_AT = '2000-01-01T00:00:00.000Z';
+
+export interface PipelineRunOptions {
+  readonly seed?: number;
+  readonly pointCount: number;
+  readonly cellSizeM?: number;
+  readonly crs?: string | null;
+  readonly verticalDatum?: string | null;
+  /** Contour interval, source units. Omitted ⇒ the pipeline's gated choice. */
+  readonly intervalM?: number;
+  /** Hold-out PRNG seed handed to the app's validation. Default 1. */
+  readonly holdoutSeed?: number;
+  /** Source basename stamped into the provenance record. */
+  readonly basename?: string;
+  /** ISO generation timestamp. Default {@link FIXED_GENERATED_AT}. */
+  readonly generatedAt?: string;
+  /**
+   * Make a named stage throw with this message.
+   *
+   * A deliberate injection seam: the "a failed stage is recorded and the run
+   * continues" contract is the one behaviour that cannot be exercised by a
+   * healthy run, and a suite that only ever sees green stages would never catch
+   * a driver that aborts on the first error. Nothing populates this in a real
+   * run.
+   */
+  readonly faults?: Readonly<Partial<Record<PipelineStageName, string>>>;
+}
+
+export interface PipelineRun {
+  readonly datasetId: string;
+  readonly seed: number;
+  readonly pointCount: number;
+  /** The exact parameters handed to the application pipeline. */
+  readonly analysisParams: AnalyseContoursParams;
+  readonly stages: readonly StageResult[];
+  /**
+   * Named scientific artifacts, every one JSON-representable (or raw bytes),
+   * ready for `hashArtifact` without further conversion. A stage that failed
+   * contributes NO entry — an absent artifact says "not produced", which a
+   * placeholder would not.
+   */
+  readonly artifacts: Readonly<Record<string, unknown>>;
+  /** Suite-level headline numbers, in the framework's metric shape. */
+  readonly metrics: Readonly<Record<string, Metric>>;
+  /** The generated cloud, for a suite that wants to hash the input bytes. */
+  readonly cloud: SyntheticCloud | null;
+  /** The application's own analysis result, for assertions. Null if it failed. */
+  readonly result: AnalyseContoursResult | null;
+}
+
+/**
+ * Run the whole pipeline. Never throws: a stage that fails is recorded as
+ * failed and the remaining stages still run, so a report shows which parts of
+ * the pipeline did complete instead of stopping at the first problem.
+ */
+export function runOlvPipeline(options: PipelineRunOptions): PipelineRun {
+  const seed = options.seed ?? 1;
+  const { pointCount } = options;
+  const analysisParams: AnalyseContoursParams = {
+    cellSizeM: options.cellSizeM ?? DEFAULT_CELL_SIZE_M,
+    crs: options.crs ?? DEFAULT_CRS,
+    verticalDatum: options.verticalDatum ?? DEFAULT_VERTICAL_DATUM,
+    verticalAxis: 'z',
+    isGeographic: false,
+    horizontalUnitToMetres: 1,
+    verticalUnitToMetres: 1,
+    holdoutSeed: options.holdoutSeed ?? 1,
+    aggregation: BENCHMARK_AGGREGATION,
+    ...(options.intervalM != null ? { intervalM: options.intervalM } : {}),
+  };
+
+  const stages: StageResult[] = [];
+  const artifacts: Record<string, unknown> = {};
+  const fault = (name: PipelineStageName): void => {
+    const message = options.faults?.[name];
+    if (message !== undefined) throw new Error(message);
+  };
+
+  // ── generate ──────────────────────────────────────────────────────────────
+  const generated = runStage('generate', () => {
+    fault('generate');
+    return generateSyntheticCloud({ seed, pointCount });
+  });
+  stages.push(generated.stage);
+  const cloud = generated.value ?? null;
+  if (cloud) {
+    artifacts.fixture = toHashable({
+      datasetId: cloud.datasetId,
+      seed: cloud.seed,
+      pointCount: cloud.pointCount,
+      densityPerM2: cloud.densityPerM2,
+      extentM: cloud.extentM,
+      noiseHalfWidthM: cloud.noiseHalfWidthM,
+      groundPointCount: cloud.groundPointCount,
+      aboveGroundPointCount: cloud.aboveGroundPointCount,
+      bounds: cloud.bounds,
+      surface: cloud.surface,
+    });
+    // The input itself, as bytes. `hashArtifact` digests a Uint8Array directly,
+    // so a reproducibility suite can state "the same seed produced these exact
+    // points" without trusting the descriptor above to be complete. A view, not
+    // a copy — the buffer is already there.
+    artifacts.pointBytes = new Uint8Array(
+      cloud.positions.buffer,
+      cloud.positions.byteOffset,
+      cloud.positions.byteLength,
+    );
+  }
+
+  // ── rasterize ─────────────────────────────────────────────────────────────
+  const rasterized = runStage('rasterize', () => {
+    fault('rasterize');
+    const c = require_(cloud, 'generate', 'the point cloud');
+    const points = boxPoints(c.positions);
+    // The app's own resolver, not a copy of its defaults: it is exported as
+    // "the SINGLE source of truth" precisely so a second caller cannot drift
+    // from the parameters the delivered surface was filtered with.
+    const groundParams = resolveGroundFilterParams(analysisParams, 'z');
+    const gf = classifyGroundSmrf(points, groundParams);
+    const raster = rasterizeDtm(points, gf.isGround, {
+      grid: {
+        originH1: gf.originH1,
+        originH2: gf.originH2,
+        cols: gf.cols,
+        rows: gf.rows,
+        cellSizeM: analysisParams.cellSizeM,
+      },
+      aggregation: BENCHMARK_AGGREGATION,
+      verticalAxis: 'z',
+    });
+    return { gf, raster };
+  });
+  stages.push(rasterized.stage);
+  if (rasterized.value) {
+    const { gf, raster } = rasterized.value;
+    artifacts.rasterSummary = toHashable({
+      cols: raster.cols,
+      rows: raster.rows,
+      cellSizeM: raster.cellSizeM,
+      originH1: raster.originH1,
+      originH2: raster.originH2,
+      coverage: raster.coverage,
+      sourcePointCount: raster.sourcePointCount,
+      analyzedPointCount: raster.analyzedPointCount,
+      filledCellCount: raster.filledCellCount,
+      groundPointCount: gf.groundPointCount,
+      nonGroundPointCount: gf.sourcePointCount - gf.groundPointCount,
+      warnings: raster.warnings,
+    });
+  }
+
+  // ── dtm ───────────────────────────────────────────────────────────────────
+  const cored = runStage('dtm', () => {
+    fault('dtm');
+    const c = require_(cloud, 'generate', 'the point cloud');
+    return computeTerrainCore(c.positions, analysisParams);
+  });
+  stages.push(cored.stage);
+  const core = cored.value ?? null;
+  if (core) {
+    artifacts.dtmSummary = toHashable(summariseCore(core));
+    // The grids themselves. Converted from Float32Array/Uint8Array to plain
+    // arrays because `assertHashable` rejects typed arrays outright: canonical
+    // JSON turns them into index-keyed objects, which hash but stop
+    // discriminating in ways nobody notices. See `toHashable` for how a NaN
+    // cell — the raster's honest "no data" — is carried across.
+    artifacts.dtmSurface = toHashable({
+      cols: core.dtm.cols,
+      rows: core.dtm.rows,
+      z: core.dtm.z,
+      confidence: core.dtm.confidence,
+      coverage: core.dtm.coverage,
+      counts: core.dtm.counts,
+      // Height above bare earth is a per-cell product, not a statistic, so it
+      // lives with the grids — leaving it on the summary made a "summary"
+      // artifact that was 95 % raster and grew with the tier.
+      heightAboveGroundM: core.surface.canopy.heightM,
+    });
+  }
+
+  // ── descriptors ───────────────────────────────────────────────────────────
+  const descriptors = runStage('descriptors', () => {
+    fault('descriptors');
+    const k = require_(core, 'dtm', 'the terrain core');
+    // The same conversion the core applies before its own complexity pass, via
+    // the app's function rather than a hard-coded "cells are metres" — a
+    // foot-based or geographic frame would make that assumption wrong and the
+    // window/radius statements would report ground sizes that never existed.
+    const cell = horizontalCellMetresXY(
+      k.dtm.cellSizeM,
+      analysisParams.isGeographic,
+      analysisParams.latitudeDeg,
+      analysisParams.horizontalUnitToMetres,
+    );
+    return summariseTerrainComplexity({
+      z: k.dtm.z,
+      coverage: k.dtm.coverage,
+      cols: k.dtm.cols,
+      rows: k.dtm.rows,
+      // The Horn slope/aspect grids the core already computed and exposes for
+      // reuse — recomputing them here would time a derivative pass twice and
+      // risk measuring a differently-parameterised one.
+      slope: k.surface.relief.slope,
+      aspect: k.surface.relief.aspect,
+      cellMetresX: cell.x,
+      cellMetresY: cell.y,
+      verticalUnitToMetres: analysisParams.verticalUnitToMetres,
+      meta: {
+        coverage: k.dtm.coverageMode,
+        sourcePointCount: k.dtm.sourcePointCount,
+        analyzedPointCount: k.dtm.analyzedPointCount,
+      },
+      groundDensityPerM2: k.cellMetrics.meanDensity,
+    });
+  });
+  stages.push(descriptors.stage);
+  const complexity: TerrainComplexitySummary | null = descriptors.value ?? null;
+  if (complexity) artifacts.descriptors = toHashable(complexity);
+
+  // ── contours ──────────────────────────────────────────────────────────────
+  const contoured = runStage('contours', () => {
+    fault('contours');
+    const k = require_(core, 'dtm', 'the terrain core');
+    return contoursFromCore(k, analysisParams);
+  });
+  stages.push(contoured.stage);
+  const result = contoured.value ?? null;
+  if (result) {
+    artifacts.contours = toHashable({
+      intervalM: result.intervalM,
+      gate: result.gate,
+      tally: result.tally,
+      levels: result.contours.levels.map((level) => ({
+        value: level.value,
+        segmentCount: level.segments.length,
+      })),
+      stitchedPolylineCount: result.stitched.reduce((n, l) => n + l.polylines.length, 0),
+      labelCount: result.labels.length,
+      generationParams: result.generationParams,
+      warnings: result.warnings,
+    });
+    // The exported geometry itself — what a GIS would receive — so the
+    // reproducibility suite compares the deliverable, not a summary of it.
+    artifacts.contourFeatures = toHashable(result.model);
+  }
+
+  // ── scientificRecord ──────────────────────────────────────────────────────
+  const generatedAt = options.generatedAt ?? FIXED_GENERATED_AT;
+  const recorded = runStage('scientificRecord', () => {
+    fault('scientificRecord');
+    const r = require_(result, 'contours', 'the analysis result');
+    // buildExportProvenance is the app's one derivation of provenance from a
+    // run; the record and the manifest are both derived from it, exactly as
+    // every exporter does, so the benchmark stamps what a real export stamps.
+    const provenance = buildExportProvenance(r, {
+      basename: options.basename ?? null,
+      generatedAt,
+      verticalUnitToMetres: analysisParams.verticalUnitToMetres,
+    });
+    return { provenance, record: analysisRecordFromProvenance(provenance) };
+  });
+  stages.push(recorded.stage);
+  if (recorded.value) artifacts.scientificRecord = toHashable(recorded.value.record);
+
+  // ── manifest ──────────────────────────────────────────────────────────────
+  const manifested = runStage('manifest', () => {
+    fault('manifest');
+    const p = require_(recorded.value, 'scientificRecord', 'the export provenance');
+    const manifest = processingManifestFromProvenance(p.provenance);
+    // Verify the chain in the same stage that built it. A manifest that does
+    // not verify is a failed stage, not a field on an artifact nobody reads.
+    const verification = verifyProcessingManifest(manifest);
+    if (!verification.ok) {
+      throw new Error(
+        `processing manifest failed to verify at op ${String(verification.firstInvalid)}`,
+      );
+    }
+    return manifest;
+  });
+  stages.push(manifested.stage);
+  if (manifested.value) artifacts.processingManifest = toHashable(manifested.value);
+
+  // ── the browser half ──────────────────────────────────────────────────────
+  for (const name of BROWSER_ONLY_STAGES) stages.push(browserStage(name));
+
+  return {
+    datasetId: cloud?.datasetId ?? `synthetic-${pointCount}-seed${seed}`,
+    seed,
+    pointCount,
+    analysisParams,
+    stages,
+    artifacts,
+    metrics: headlineMetrics(stages, pointCount),
+    cloud,
+    result,
+  };
+}
+
+/**
+ * A stage that cannot exist in this runtime.
+ *
+ * Status 'ok' rather than 'failed': nothing went wrong, and a red row in every
+ * reporter would tell a reader the opposite. The honest statement lives in the
+ * metric's reason, which is exactly where the framework's schema puts it — and
+ * the schema makes it impossible to attach a number to it.
+ */
+function browserStage(name: BrowserStageName): StageResult {
+  const reason = BROWSER_STAGE_REASONS[name];
+  const provenance = { runtime: 'browser', deterministic: false } as const;
+  return {
+    name,
+    status: 'ok',
+    duration: unavailable(reason, provenance),
+    peakMemory: unavailable(reason, provenance),
+  };
+}
+
+/**
+ * Headline numbers for a report. Throughput is only stated when the two stages
+ * it divides both produced a measurement — a "points/s" computed from a stage
+ * that never ran is the fabricated number this whole framework exists to avoid.
+ */
+function headlineMetrics(
+  stages: readonly StageResult[],
+  pointCount: number,
+): Record<string, Metric> {
+  const provenance = { runtime: 'node', deterministic: false } as const;
+  const analysisMs = ['dtm', 'contours'].reduce<number | null>((total, name) => {
+    if (total === null) return null;
+    const stage = stages.find((s) => s.name === name);
+    if (!stage || stage.status !== 'ok' || stage.duration.status !== 'measured') return null;
+    return total + stage.duration.value;
+  }, 0);
+  return {
+    pointCount: measured(pointCount, 'points', { runtime: 'node', deterministic: true }),
+    analysisDurationMs:
+      analysisMs === null
+        ? unavailable('the dtm or contours stage did not complete, so there is no analysis time', provenance)
+        : measured(analysisMs, 'ms', provenance),
+    pointsPerSecond:
+      analysisMs === null || analysisMs <= 0
+        ? unavailable(
+            'throughput needs a completed dtm + contours pair with a non-zero duration',
+            provenance,
+          )
+        : measured((pointCount / analysisMs) * 1000, 'points/s', provenance),
+  };
+}
+
+/** The interval-independent scientific summary of one core run. */
+function summariseCore(core: TerrainCore): Record<string, unknown> {
+  return {
+    cols: core.dtm.cols,
+    rows: core.dtm.rows,
+    cellSizeM: core.dtm.cellSizeM,
+    originH1: core.dtm.originH1,
+    originH2: core.dtm.originH2,
+    crs: core.dtm.crs,
+    verticalDatum: core.dtm.verticalDatum,
+    coverageMode: core.dtm.coverageMode,
+    sourcePointCount: core.dtm.sourcePointCount,
+    analyzedPointCount: core.dtm.analyzedPointCount,
+    meanConfidence: core.dtm.meanConfidence,
+    minZ: core.minZ,
+    maxZ: core.maxZ,
+    elevationRangeM: core.elevationRangeM,
+    interpolation: core.interpolation,
+    aggregation: core.aggregation,
+    despikeApplied: core.despikeApplied,
+    excludedByClassification: core.excludedByClassification,
+    // `validation.samples` is deliberately dropped: it is one entry per
+    // held-out point, so it dwarfs every other artifact on a large tier while
+    // adding nothing a reviewer reads — the statistics derived from it are all
+    // right here.
+    validation: withoutSamples(core.validation),
+    confidenceCalibrationApplied: core.confidenceCalibrationApplied,
+    confidenceToleranceM: core.confidenceToleranceM,
+    confidenceOrdering: core.confidenceOrdering,
+    reliabilitySplit: core.reliabilitySplit,
+    blockedAccuracy: core.blockedAccuracy,
+    accuracy: core.accuracy,
+    accuracyStandards: core.accuracyStandards,
+    quality: core.quality,
+    qualityScore: core.qualityScore,
+    cellMetrics: core.cellMetrics,
+    cellStatusTally: core.cellStatusTally,
+    surface: {
+      dsm: core.surface.dsm,
+      // The canopy GRID is on `dtmSurface`; only its statistics belong here.
+      canopy: {
+        coveredCells: core.surface.canopy.coveredCells,
+        maxHeightM: core.surface.canopy.maxHeightM,
+        meanHeightM: core.surface.canopy.meanHeightM,
+        p95HeightM: core.surface.canopy.p95HeightM,
+      },
+      slope: core.surface.slope,
+    },
+    coreWarnings: core.coreWarnings,
+  };
+}
+
+function withoutSamples(validation: TerrainCore['validation']): Record<string, unknown> {
+  const { samples: _samples, ...rest } = validation;
+  return rest;
+}
+
+/**
+ * Box XYZ triples into the `TerrainPoint[]` the two ground leaves take.
+ *
+ * `analyseContours` does exactly this internally (`positionsToPoints`) but does
+ * not export it. Duplicating five lines of data marshalling is the right call
+ * here; reaching into a module's private surface is not, and neither is
+ * changing `src/` to suit a benchmark.
+ */
+function boxPoints(positions: Float32Array): TerrainPoint[] {
+  const n = (positions.length / 3) | 0;
+  const points: TerrainPoint[] = new Array<TerrainPoint>(n);
+  for (let i = 0; i < n; i++) {
+    points[i] = { x: positions[i * 3], y: positions[i * 3 + 1], z: positions[i * 3 + 2] };
+  }
+  return points;
+}
+
+/**
+ * Read a prerequisite a previous stage was supposed to produce.
+ *
+ * Throwing here is what turns "the DTM stage failed" into four downstream
+ * stages recorded as failed WITH the reason, instead of four stages missing
+ * from the report entirely — the difference between a report that shows a
+ * broken run and one that shows a short run.
+ */
+function require_<T>(value: T | null | undefined, stage: NodeStageName, what: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`the ${stage} stage did not produce ${what}`);
+  }
+  return value;
+}
+
+/** What a non-finite number becomes in an artifact. */
+type NonFiniteLabel = 'NaN' | 'Infinity' | '-Infinity';
+
+/** Anything `canonicalJson` can represent faithfully. */
+type Hashable = string | number | boolean | null | Hashable[] | { [key: string]: Hashable };
+
+/**
+ * Convert a pipeline product into something `hashArtifact` accepts.
+ *
+ * Two deliberate conversions, both of which the framework's guard would
+ * otherwise reject outright:
+ *
+ *   - TYPED ARRAYS become plain arrays. `canonicalJson` keeps own enumerable
+ *     keys, so a Float32Array would canonicalise to an index-keyed object that
+ *     still hashes but no longer reads as data.
+ *   - NON-FINITE NUMBERS become their name as a string. NaN is how this
+ *     pipeline says "no data here" (an empty raster cell, an unmeasurable mean
+ *     confidence), and `JSON.stringify(NaN)` is `null` — which is
+ *     indistinguishable from a field that genuinely held null, and makes NaN,
+ *     +Infinity and -Infinity all hash the same. Naming them keeps the three
+ *     apart and keeps the absence explicit.
+ *
+ * Anything else that JSON cannot carry (a Date, a Map, a class instance) throws
+ * rather than being flattened, for the same reason `assertHashable` throws: a
+ * silent flattening is a hash that stopped discriminating.
+ */
+export function toHashable(value: unknown, path = 'artifact'): Hashable {
+  if (value === null) return null;
+  const t = typeof value;
+  if (t === 'string' || t === 'boolean') return value as string | boolean;
+  if (t === 'number') return finiteOrLabel(value as number);
+  if (t === 'bigint' || t === 'function' || t === 'symbol' || t === 'undefined') {
+    throw new TypeError(`benchmark artifact: ${path} is a ${t}, which has no JSON form`);
+  }
+  if (Array.isArray(value)) return value.map((v, i) => toHashable(v, `${path}[${i}]`));
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    const view = value as unknown as ArrayLike<number>;
+    const out: Hashable[] = new Array<Hashable>(view.length);
+    for (let i = 0; i < view.length; i++) out[i] = finiteOrLabel(view[i]);
+    return out;
+  }
+  const proto = Object.getPrototypeOf(value as object) as object | null;
+  if (proto !== Object.prototype && proto !== null) {
+    throw new TypeError(
+      `benchmark artifact: ${path} is a ${
+        (value as { constructor?: { name?: string } }).constructor?.name ?? 'non-plain object'
+      }, which JSON cannot carry faithfully`,
+    );
+  }
+  const out: Record<string, Hashable> = {};
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    // An absent optional field and one explicitly set to undefined describe the
+    // same thing, and JSON drops both — mirroring that here keeps the two from
+    // hashing differently.
+    if (v === undefined) continue;
+    out[key] = toHashable(v, `${path}.${key}`);
+  }
+  return out;
+}
+
+function finiteOrLabel(n: number): number | NonFiniteLabel {
+  if (Number.isFinite(n)) return n;
+  if (Number.isNaN(n)) return 'NaN';
+  return n > 0 ? 'Infinity' : '-Infinity';
+}

--- a/benchmarks/pipeline/runPipeline.ts
+++ b/benchmarks/pipeline/runPipeline.ts
@@ -9,10 +9,10 @@
  * re-implemented the pipeline would measure the benchmark. Worse, it would keep
  * reporting healthy numbers after the application changed, because nothing
  * would connect the two any more. So every stage below is a call into `src/`,
- * and `tests/benchmark/pipelineDriver.test.ts` pins the driver's DTM, contours
- * and complexity output against `analyseContours` — the entry point the
- * AnalysePanel and the contour worker use — on the same input. Reimplement any
- * stage and that equality breaks immediately.
+ * and `tests/benchmark/pipelineDriver.test.ts` pins the driver's raster grid,
+ * DTM, contours and complexity output against `analyseContours` — the entry
+ * point the AnalysePanel and the contour worker use — on the same input.
+ * Reimplement any stage and that equality breaks immediately.
  *
  * THE CALL CHAIN, stage by stage:
  *
@@ -34,29 +34,56 @@
  * is defined as `contoursFromCore ∘ computeTerrainCore` — so together they are
  * exactly one full analysis with no work done twice and no sequencing invented
  * here. `rasterize` and `descriptors` are the two leaves timed in isolation, so
- * a scaling suite can see how each core scales on its own; they are therefore
- * NOT disjoint from `dtm`, which runs both again internally. Summing all seven
- * stages double-counts them; read `dtm` + `contours` as the pipeline's cost.
+ * a scaling suite can see how each core scales on its own; they therefore
+ * OVERLAP `dtm`, which runs both again internally.
+ *
+ * That overlap is a trap for a reporter — summing the stage column overstates a
+ * 500k run by about 25 %. So the correct total is a function, not a convention:
+ * see {@link STAGE_ROLE} and {@link pipelineDurationMs}. Getting it wrong now
+ * takes ignoring an exported answer rather than missing a comment. A run that
+ * does not want to pay for the isolated leaves at all passes
+ * `isolateLeaves: false`.
  *
  * BROWSER-ONLY WORK IS DECLARED, NOT DROPPED. GPU upload, first rendered frame,
  * frame rate and time-to-interaction are real stages of the user's workflow and
  * Node can measure none of them. They are reported as stages whose metrics are
  * `unavailable` with a reason naming the limitation, never as 0 and never as an
  * estimate, so a workflow report shows the whole pipeline with honest gaps
- * instead of a partial one that looks complete.
+ * instead of a partial one that looks complete. {@link STAGE_ROLE} marks them
+ * `'declared'` so a reporter can render them as their own kind of row.
  *
- * Runtime-neutral by construction: nothing here imports a `node:` builtin, so a
- * browser-side suite can reuse the driver and fill in the four stages Node
- * cannot. It does need the `__BUILD_IDENTITY__` define that Vite and Vitest
- * supply (the export-provenance path stamps the build into the record), so it
- * runs under those, not under a bare `node` process.
+ * WHAT IS COMPARABLE ACROSS MACHINES, AND WHAT IS NOT. Most artifacts here are
+ * pure science and hash identically anywhere. Two are not: the scientific
+ * record embeds the build identity, and the processing manifest seeds its hash
+ * chain from that identity, so both track the git commit and the Node version
+ * of whatever ran them (`vitest.config.ts` sets the test build's `node` from
+ * `process.version`). The framework's strip list removes `builtAt` and
+ * `generatedAt` but cannot remove a commit — that IS provenance, and stripping
+ * it would be a lie. {@link ARTIFACT_SCOPE} marks those two `'build'`, and a
+ * cross-machine reproducibility comparison must exclude them or it goes red on
+ * a perfectly green pipeline. The science inside the record stays checkable:
+ * `scientificRecordContent` carries the same record with build and timestamp
+ * dropped, including the app's own `contentHash`, which
+ * `scientificAnalysisRecord.ts` deliberately computes over the science alone.
+ *
+ * Runtime-neutral by construction: nothing here imports a `node:` builtin (a
+ * source guard enforces it), so a browser-side suite can reuse the driver and
+ * fill in the four stages Node cannot. It does need the `__BUILD_IDENTITY__`
+ * define that Vite and Vitest supply, because the export-provenance path stamps
+ * the build into the record. That dependency resolves at MODULE LOAD, so a bare
+ * `node` process dies with a `ReferenceError` before any stage exists — it
+ * cannot be reported as a failed stage, and CI invoking this outside vitest or a
+ * vite build sees the process die rather than a red row.
  */
 
 import {
   measured,
   runStage,
+  toHashable,
   unavailable,
   type Metric,
+  type MetricRuntime,
+  type StageOutcome,
   type StageResult,
 } from '../framework';
 import { generateSyntheticCloud, type SyntheticCloud } from '../fixtures/syntheticCloud';
@@ -72,14 +99,12 @@ import {
   type AnalyseContoursResult,
   type TerrainCore,
 } from '../../src/terrain/contour/analyseContours';
-import {
-  summariseTerrainComplexity,
-  type TerrainComplexitySummary,
-} from '../../src/terrain/complexity/complexitySummary';
+import { summariseTerrainComplexity } from '../../src/terrain/complexity/complexitySummary';
 import {
   analysisRecordFromProvenance,
   buildExportProvenance,
   processingManifestFromProvenance,
+  type ExportProvenance,
 } from '../../src/terrain/export/exportProvenance';
 import { verifyProcessingManifest } from '../../src/science/processingManifest';
 
@@ -109,6 +134,102 @@ export type NodeStageName = (typeof NODE_STAGES)[number];
 export type BrowserStageName = (typeof BROWSER_ONLY_STAGES)[number];
 export type PipelineStageName = (typeof PIPELINE_STAGES)[number];
 
+/** What a stage's timing means for a total. See {@link STAGE_ROLE}. */
+export type StageRole = 'pipeline' | 'isolated' | 'declared';
+
+/**
+ * What each stage's timing means, so a reporter can add up the right ones.
+ *
+ *   'pipeline' — disjoint work. These and only these sum to the run's cost.
+ *   'isolated' — a leaf that `dtm` also runs internally, timed on its own for a
+ *                per-core scaling curve. Adding it to a total double-counts.
+ *   'declared' — a stage that exists but cannot be measured in this runtime.
+ */
+export const STAGE_ROLE: Readonly<Record<PipelineStageName, StageRole>> = {
+  generate: 'pipeline',
+  rasterize: 'isolated',
+  dtm: 'pipeline',
+  descriptors: 'isolated',
+  contours: 'pipeline',
+  scientificRecord: 'pipeline',
+  manifest: 'pipeline',
+  gpuUpload: 'declared',
+  renderReady: 'declared',
+  fps: 'declared',
+  timeToInteraction: 'declared',
+};
+
+/**
+ * The run's total duration: the `'pipeline'` stages only, never the whole
+ * column. Includes `generate`, because a run cannot happen without producing
+ * its input; subtract that stage if you want application time alone.
+ *
+ * Null — not a partial sum — when any pipeline stage failed or was not
+ * measured. A total missing one of its terms is not a smaller total, it is a
+ * different number, and reporting the second as if it were the first is exactly
+ * the class of quiet wrongness this framework exists to prevent.
+ */
+export function pipelineDurationMs(stages: readonly StageResult[]): number | null {
+  return sumStages(
+    stages,
+    PIPELINE_STAGES.filter((name) => STAGE_ROLE[name] === 'pipeline'),
+  );
+}
+
+/** Every artifact a complete run can produce. */
+export const PIPELINE_ARTIFACTS = [
+  'fixture',
+  'pointBytes',
+  'rasterSummary',
+  'rasterZBytes',
+  'dtmSummary',
+  'dtmZBytes',
+  'dtmConfidenceBytes',
+  'dtmCoverageBytes',
+  'dtmCountsBytes',
+  'heightAboveGroundBytes',
+  'descriptors',
+  'contours',
+  'contourFeatures',
+  'scientificRecordContent',
+  'scientificRecord',
+  'processingManifest',
+] as const;
+
+export type PipelineArtifactName = (typeof PIPELINE_ARTIFACTS)[number];
+
+/**
+ * Whether an artifact's hash is a statement about the science or about the
+ * build that ran it. See the header: comparing a `'build'` artifact between two
+ * machines is expected to differ and says nothing about reproducibility.
+ */
+export const ARTIFACT_SCOPE: Readonly<Record<PipelineArtifactName, 'science' | 'build'>> = {
+  fixture: 'science',
+  pointBytes: 'science',
+  rasterSummary: 'science',
+  rasterZBytes: 'science',
+  dtmSummary: 'science',
+  dtmZBytes: 'science',
+  dtmConfidenceBytes: 'science',
+  dtmCoverageBytes: 'science',
+  dtmCountsBytes: 'science',
+  heightAboveGroundBytes: 'science',
+  descriptors: 'science',
+  contours: 'science',
+  contourFeatures: 'science',
+  scientificRecordContent: 'science',
+  scientificRecord: 'build',
+  processingManifest: 'build',
+};
+
+/** The artifacts a cross-machine reproducibility comparison may use. */
+export function scienceScopedArtifacts(): readonly PipelineArtifactName[] {
+  return PIPELINE_ARTIFACTS.filter((name) => ARTIFACT_SCOPE[name] === 'science');
+}
+
+/** A stage's contribution to the artifact set. */
+export type ArtifactBag = Partial<Record<PipelineArtifactName, unknown>>;
+
 /**
  * Why each browser stage has no number here. Each names the specific runtime
  * facility Node lacks: "unavailable" on its own tells a reviewer nothing about
@@ -123,6 +244,10 @@ const BROWSER_STAGE_REASONS: Readonly<Record<BrowserStageName, string>> = {
   timeToInteraction:
     'Time-to-interaction runs from a user input event to the painted response; Node has neither input events nor paint.',
 };
+
+/** Stated when a run opts out of the isolated leaf timings. */
+const LEAVES_NOT_REQUESTED =
+  'isolated leaf timings were not requested for this run (isolateLeaves: false); the work still happened inside the dtm stage, it was simply not timed on its own';
 
 /** Default DTM/contour grid, source units. Around 16 returns per cell at QL2. */
 export const DEFAULT_CELL_SIZE_M = 2;
@@ -167,6 +292,15 @@ export interface PipelineRunOptions {
   /** ISO generation timestamp. Default {@link FIXED_GENERATED_AT}. */
   readonly generatedAt?: string;
   /**
+   * Time the two leaves (`rasterize`, `descriptors`) separately. Default true.
+   *
+   * They re-run work `dtm` already does — mostly a second SMRF pass, which is
+   * the expensive part and grows with the tier. A run that only wants the
+   * pipeline's cost turns them off; the stages still appear, marked unavailable
+   * with the reason, so no row silently disappears from a report.
+   */
+  readonly isolateLeaves?: boolean;
+  /**
    * Make a named stage throw with this message.
    *
    * A deliberate injection seam: the "a failed stage is recorded and the run
@@ -176,6 +310,19 @@ export interface PipelineRunOptions {
    * run.
    */
   readonly faults?: Readonly<Partial<Record<PipelineStageName, string>>>;
+  /**
+   * Make a named stage throw AFTER its product exists, while its artifact is
+   * being converted.
+   *
+   * A separate seam from {@link faults} because it exercises a different
+   * contract: a conversion failure must cost that one stage's artifact and
+   * nothing else, because the science already succeeded and the stages
+   * downstream have the product they need. Building the artifacts outside
+   * `runStage` — where an unconvertible application field once would have
+   * landed — killed the entire run instead, which is why this is pinned by a
+   * test rather than left to inspection.
+   */
+  readonly artifactFaults?: Readonly<Partial<Record<PipelineStageName, string>>>;
 }
 
 export interface PipelineRun {
@@ -186,12 +333,13 @@ export interface PipelineRun {
   readonly analysisParams: AnalyseContoursParams;
   readonly stages: readonly StageResult[];
   /**
-   * Named scientific artifacts, every one JSON-representable (or raw bytes),
+   * Named scientific artifacts, every one JSON-representable or raw bytes,
    * ready for `hashArtifact` without further conversion. A stage that failed
    * contributes NO entry — an absent artifact says "not produced", which a
-   * placeholder would not.
+   * placeholder would not. Keyed by {@link PipelineArtifactName}, so a suite's
+   * typo is a compile error rather than an `undefined` that reaches the hasher.
    */
-  readonly artifacts: Readonly<Record<string, unknown>>;
+  readonly artifacts: Readonly<ArtifactBag>;
   /** Suite-level headline numbers, in the framework's metric shape. */
   readonly metrics: Readonly<Record<string, Metric>>;
   /** The generated cloud, for a suite that wants to hash the input bytes. */
@@ -201,13 +349,15 @@ export interface PipelineRun {
 }
 
 /**
- * Run the whole pipeline. Never throws: a stage that fails is recorded as
- * failed and the remaining stages still run, so a report shows which parts of
- * the pipeline did complete instead of stopping at the first problem.
+ * Run the whole pipeline. Never throws: a stage that fails — including one that
+ * fails while converting its own artifact — is recorded as failed and the
+ * remaining stages still run, so a report shows which parts of the pipeline did
+ * complete instead of stopping at the first problem.
  */
 export function runOlvPipeline(options: PipelineRunOptions): PipelineRun {
   const seed = options.seed ?? 1;
   const { pointCount } = options;
+  const isolateLeaves = options.isolateLeaves ?? true;
   const analysisParams: AnalyseContoursParams = {
     cellSizeM: options.cellSizeM ?? DEFAULT_CELL_SIZE_M,
     crs: options.crs ?? DEFAULT_CRS,
@@ -222,243 +372,307 @@ export function runOlvPipeline(options: PipelineRunOptions): PipelineRun {
   };
 
   const stages: StageResult[] = [];
-  const artifacts: Record<string, unknown> = {};
+  const artifacts: ArtifactBag = {};
+  /**
+   * What each stage hands to the next.
+   *
+   * Held OUTSIDE the stage body and assigned BEFORE the artifact conversion, so
+   * a conversion that throws costs one stage's artifact and nothing else. Built
+   * the other way round — convert, then return the product alongside it — a
+   * single unconvertible field on an application type would take out every
+   * stage downstream of it as well.
+   */
+  const products: {
+    cloud: SyntheticCloud | null;
+    core: TerrainCore | null;
+    result: AnalyseContoursResult | null;
+    provenance: ExportProvenance | null;
+  } = { cloud: null, core: null, result: null, provenance: null };
+
   const fault = (name: PipelineStageName): void => {
     const message = options.faults?.[name];
     if (message !== undefined) throw new Error(message);
   };
+  /** Fired once the stage's product is captured, standing in for a conversion. */
+  const artifactFault = (name: PipelineStageName): void => {
+    const message = options.artifactFaults?.[name];
+    if (message !== undefined) throw new Error(message);
+  };
+  const emit = (outcome: StageOutcome<ArtifactBag>): void => {
+    stages.push(outcome.stage);
+    if (outcome.value) Object.assign(artifacts, outcome.value);
+  };
 
   // ── generate ──────────────────────────────────────────────────────────────
-  const generated = runStage('generate', () => {
-    fault('generate');
-    return generateSyntheticCloud({ seed, pointCount });
-  });
-  stages.push(generated.stage);
-  const cloud = generated.value ?? null;
-  if (cloud) {
-    artifacts.fixture = toHashable({
-      datasetId: cloud.datasetId,
-      seed: cloud.seed,
-      pointCount: cloud.pointCount,
-      densityPerM2: cloud.densityPerM2,
-      extentM: cloud.extentM,
-      noiseHalfWidthM: cloud.noiseHalfWidthM,
-      groundPointCount: cloud.groundPointCount,
-      aboveGroundPointCount: cloud.aboveGroundPointCount,
-      bounds: cloud.bounds,
-      surface: cloud.surface,
-    });
-    // The input itself, as bytes. `hashArtifact` digests a Uint8Array directly,
-    // so a reproducibility suite can state "the same seed produced these exact
-    // points" without trusting the descriptor above to be complete. A view, not
-    // a copy — the buffer is already there.
-    artifacts.pointBytes = new Uint8Array(
-      cloud.positions.buffer,
-      cloud.positions.byteOffset,
-      cloud.positions.byteLength,
-    );
-  }
+  emit(
+    runStage('generate', (): ArtifactBag => {
+      fault('generate');
+      const cloud = generateSyntheticCloud({ seed, pointCount });
+      products.cloud = cloud;
+      artifactFault('generate');
+      return {
+        fixture: toHashable({
+          datasetId: cloud.datasetId,
+          seed: cloud.seed,
+          pointCount: cloud.pointCount,
+          densityPerM2: cloud.densityPerM2,
+          extentM: cloud.extentM,
+          noiseHalfWidthM: cloud.noiseHalfWidthM,
+          groundPointCount: cloud.groundPointCount,
+          aboveGroundPointCount: cloud.aboveGroundPointCount,
+          bounds: cloud.bounds,
+          surface: cloud.surface,
+        }),
+        // The input itself, as bytes, so a reproducibility suite can state "the
+        // same seed produced these exact points" without trusting the
+        // descriptor above to be complete.
+        pointBytes: bytesOf(cloud.positions),
+      };
+    }),
+  );
 
   // ── rasterize ─────────────────────────────────────────────────────────────
-  const rasterized = runStage('rasterize', () => {
-    fault('rasterize');
-    const c = require_(cloud, 'generate', 'the point cloud');
-    const points = boxPoints(c.positions);
-    // The app's own resolver, not a copy of its defaults: it is exported as
-    // "the SINGLE source of truth" precisely so a second caller cannot drift
-    // from the parameters the delivered surface was filtered with.
-    const groundParams = resolveGroundFilterParams(analysisParams, 'z');
-    const gf = classifyGroundSmrf(points, groundParams);
-    const raster = rasterizeDtm(points, gf.isGround, {
-      grid: {
-        originH1: gf.originH1,
-        originH2: gf.originH2,
-        cols: gf.cols,
-        rows: gf.rows,
-        cellSizeM: analysisParams.cellSizeM,
-      },
-      aggregation: BENCHMARK_AGGREGATION,
-      verticalAxis: 'z',
-    });
-    return { gf, raster };
-  });
-  stages.push(rasterized.stage);
-  if (rasterized.value) {
-    const { gf, raster } = rasterized.value;
-    artifacts.rasterSummary = toHashable({
-      cols: raster.cols,
-      rows: raster.rows,
-      cellSizeM: raster.cellSizeM,
-      originH1: raster.originH1,
-      originH2: raster.originH2,
-      coverage: raster.coverage,
-      sourcePointCount: raster.sourcePointCount,
-      analyzedPointCount: raster.analyzedPointCount,
-      filledCellCount: raster.filledCellCount,
-      groundPointCount: gf.groundPointCount,
-      nonGroundPointCount: gf.sourcePointCount - gf.groundPointCount,
-      warnings: raster.warnings,
-    });
+  if (!isolateLeaves) {
+    stages.push(declaredStage('rasterize', LEAVES_NOT_REQUESTED, 'node'));
+  } else {
+    emit(
+      runStage('rasterize', (): ArtifactBag => {
+        fault('rasterize');
+        const cloud = require_(products.cloud, 'generate', 'the point cloud');
+        const points = boxPoints(cloud.positions);
+        // The app's own resolver, not a copy of its defaults: it is exported as
+        // "the SINGLE source of truth" precisely so a second caller cannot
+        // drift from the parameters the delivered surface was filtered with.
+        const groundParams = resolveGroundFilterParams(analysisParams, 'z');
+        const gf = classifyGroundSmrf(points, groundParams);
+        const raster = rasterizeDtm(points, gf.isGround, {
+          grid: {
+            originH1: gf.originH1,
+            originH2: gf.originH2,
+            cols: gf.cols,
+            rows: gf.rows,
+            cellSizeM: analysisParams.cellSizeM,
+          },
+          // Read off the SAME params object handed to the core below, never a
+          // second copy of the constant: two values that must agree is a drift
+          // waiting to happen, and a leaf silently aggregating differently from
+          // the surface it is supposed to mirror is invisible in every summary
+          // field. One value, so there is nothing to disagree with.
+          aggregation: analysisParams.aggregation,
+          verticalAxis: analysisParams.verticalAxis,
+        });
+        artifactFault('rasterize');
+        return {
+          // The raw cell values, as bytes. The only value-sensitive evidence
+          // this stage produces: every geometry field below is identical under
+          // a wrong aggregation, so without these the leaf could rasterise the
+          // scene differently from the core and no artifact would show it.
+          rasterZBytes: bytesOf(raster.z),
+          rasterSummary: toHashable({
+            cols: raster.cols,
+            rows: raster.rows,
+            cellSizeM: raster.cellSizeM,
+            originH1: raster.originH1,
+            originH2: raster.originH2,
+            coverage: raster.coverage,
+            sourcePointCount: raster.sourcePointCount,
+            analyzedPointCount: raster.analyzedPointCount,
+            filledCellCount: raster.filledCellCount,
+            groundPointCount: gf.groundPointCount,
+            nonGroundPointCount: gf.sourcePointCount - gf.groundPointCount,
+            warnings: raster.warnings,
+          }),
+        };
+      }),
+    );
   }
 
   // ── dtm ───────────────────────────────────────────────────────────────────
-  const cored = runStage('dtm', () => {
-    fault('dtm');
-    const c = require_(cloud, 'generate', 'the point cloud');
-    return computeTerrainCore(c.positions, analysisParams);
-  });
-  stages.push(cored.stage);
-  const core = cored.value ?? null;
-  if (core) {
-    artifacts.dtmSummary = toHashable(summariseCore(core));
-    // The grids themselves. Converted from Float32Array/Uint8Array to plain
-    // arrays because `assertHashable` rejects typed arrays outright: canonical
-    // JSON turns them into index-keyed objects, which hash but stop
-    // discriminating in ways nobody notices. See `toHashable` for how a NaN
-    // cell — the raster's honest "no data" — is carried across.
-    artifacts.dtmSurface = toHashable({
-      cols: core.dtm.cols,
-      rows: core.dtm.rows,
-      z: core.dtm.z,
-      confidence: core.dtm.confidence,
-      coverage: core.dtm.coverage,
-      counts: core.dtm.counts,
-      // Height above bare earth is a per-cell product, not a statistic, so it
-      // lives with the grids — leaving it on the summary made a "summary"
-      // artifact that was 95 % raster and grew with the tier.
-      heightAboveGroundM: core.surface.canopy.heightM,
-    });
-  }
+  emit(
+    runStage('dtm', (): ArtifactBag => {
+      fault('dtm');
+      const cloud = require_(products.cloud, 'generate', 'the point cloud');
+      const core = computeTerrainCore(cloud.positions, analysisParams);
+      products.core = core;
+      artifactFault('dtm');
+      return {
+        dtmSummary: toHashable(summariseCore(core)),
+        // The grids go out as RAW BYTES, not as converted arrays. `toHashable`
+        // → `assertHashable` → `stripVolatile` → `canonicalJson` is three full
+        // copies of every cell plus a template-literal path string per element,
+        // which measured ~300 MB of transient heap for ONE 500k run; cell count
+        // scales with the tile AREA, so the top of the ladder would have been
+        // multiple gigabytes. Bytes also carry a NaN cell across exactly,
+        // rather than through the `'NaN'` spelling the JSON path needs.
+        dtmZBytes: bytesOf(core.dtm.z),
+        dtmConfidenceBytes: bytesOf(core.dtm.confidence),
+        dtmCoverageBytes: bytesOf(core.dtm.coverage),
+        dtmCountsBytes: bytesOf(core.dtm.counts),
+        // Height above bare earth is a per-cell product, not a statistic, so it
+        // travels with the grids rather than on the summary.
+        heightAboveGroundBytes: bytesOf(core.surface.canopy.heightM),
+      };
+    }),
+  );
 
   // ── descriptors ───────────────────────────────────────────────────────────
-  const descriptors = runStage('descriptors', () => {
-    fault('descriptors');
-    const k = require_(core, 'dtm', 'the terrain core');
-    // The same conversion the core applies before its own complexity pass, via
-    // the app's function rather than a hard-coded "cells are metres" — a
-    // foot-based or geographic frame would make that assumption wrong and the
-    // window/radius statements would report ground sizes that never existed.
-    const cell = horizontalCellMetresXY(
-      k.dtm.cellSizeM,
-      analysisParams.isGeographic,
-      analysisParams.latitudeDeg,
-      analysisParams.horizontalUnitToMetres,
+  if (!isolateLeaves) {
+    stages.push(declaredStage('descriptors', LEAVES_NOT_REQUESTED, 'node'));
+  } else {
+    emit(
+      runStage('descriptors', (): ArtifactBag => {
+        fault('descriptors');
+        const core = require_(products.core, 'dtm', 'the terrain core');
+        // The same guard the core applies: on a grid with no covered cells the
+        // summary is null rather than figures computed over nothing. Without
+        // mirroring it, a degenerate cloud makes the driver and the application
+        // disagree and the drift guard goes red for the wrong reason.
+        if (!core.dtm.coverage.some((c) => c !== 0)) return {};
+        // The same conversion the core applies before its own complexity pass,
+        // via the app's function rather than a hard-coded "cells are metres" —
+        // a foot-based or geographic frame would make that assumption wrong and
+        // the window/radius statements would report ground sizes that never
+        // existed.
+        const cell = horizontalCellMetresXY(
+          core.dtm.cellSizeM,
+          analysisParams.isGeographic,
+          analysisParams.latitudeDeg,
+          analysisParams.horizontalUnitToMetres,
+        );
+        const complexity = summariseTerrainComplexity({
+          z: core.dtm.z,
+          coverage: core.dtm.coverage,
+          cols: core.dtm.cols,
+          rows: core.dtm.rows,
+          // The Horn slope/aspect grids the core already computed and exposes
+          // for reuse — recomputing them here would time a derivative pass
+          // twice and risk measuring a differently-parameterised one.
+          slope: core.surface.relief.slope,
+          aspect: core.surface.relief.aspect,
+          cellMetresX: cell.x,
+          cellMetresY: cell.y,
+          verticalUnitToMetres: analysisParams.verticalUnitToMetres,
+          meta: {
+            coverage: core.dtm.coverageMode,
+            sourcePointCount: core.dtm.sourcePointCount,
+            analyzedPointCount: core.dtm.analyzedPointCount,
+          },
+          groundDensityPerM2: core.cellMetrics.meanDensity,
+        });
+        artifactFault('descriptors');
+        return complexity === null ? {} : { descriptors: toHashable(complexity) };
+      }),
     );
-    return summariseTerrainComplexity({
-      z: k.dtm.z,
-      coverage: k.dtm.coverage,
-      cols: k.dtm.cols,
-      rows: k.dtm.rows,
-      // The Horn slope/aspect grids the core already computed and exposes for
-      // reuse — recomputing them here would time a derivative pass twice and
-      // risk measuring a differently-parameterised one.
-      slope: k.surface.relief.slope,
-      aspect: k.surface.relief.aspect,
-      cellMetresX: cell.x,
-      cellMetresY: cell.y,
-      verticalUnitToMetres: analysisParams.verticalUnitToMetres,
-      meta: {
-        coverage: k.dtm.coverageMode,
-        sourcePointCount: k.dtm.sourcePointCount,
-        analyzedPointCount: k.dtm.analyzedPointCount,
-      },
-      groundDensityPerM2: k.cellMetrics.meanDensity,
-    });
-  });
-  stages.push(descriptors.stage);
-  const complexity: TerrainComplexitySummary | null = descriptors.value ?? null;
-  if (complexity) artifacts.descriptors = toHashable(complexity);
+  }
 
   // ── contours ──────────────────────────────────────────────────────────────
-  const contoured = runStage('contours', () => {
-    fault('contours');
-    const k = require_(core, 'dtm', 'the terrain core');
-    return contoursFromCore(k, analysisParams);
-  });
-  stages.push(contoured.stage);
-  const result = contoured.value ?? null;
-  if (result) {
-    artifacts.contours = toHashable({
-      intervalM: result.intervalM,
-      gate: result.gate,
-      tally: result.tally,
-      levels: result.contours.levels.map((level) => ({
-        value: level.value,
-        segmentCount: level.segments.length,
-      })),
-      stitchedPolylineCount: result.stitched.reduce((n, l) => n + l.polylines.length, 0),
-      labelCount: result.labels.length,
-      generationParams: result.generationParams,
-      warnings: result.warnings,
-    });
-    // The exported geometry itself — what a GIS would receive — so the
-    // reproducibility suite compares the deliverable, not a summary of it.
-    artifacts.contourFeatures = toHashable(result.model);
-  }
+  emit(
+    runStage('contours', (): ArtifactBag => {
+      fault('contours');
+      const core = require_(products.core, 'dtm', 'the terrain core');
+      const result = contoursFromCore(core, analysisParams);
+      products.result = result;
+      artifactFault('contours');
+      return {
+        contours: toHashable({
+          intervalM: result.intervalM,
+          gate: result.gate,
+          tally: result.tally,
+          levels: result.contours.levels.map((level) => ({
+            value: level.value,
+            segmentCount: level.segments.length,
+          })),
+          stitchedPolylineCount: result.stitched.reduce((n, l) => n + l.polylines.length, 0),
+          labelCount: result.labels.length,
+          generationParams: result.generationParams,
+          warnings: result.warnings,
+        }),
+        // The exported geometry itself — what a GIS would receive — so the
+        // reproducibility suite compares the deliverable, not a summary of it.
+        contourFeatures: toHashable(result.model),
+      };
+    }),
+  );
 
   // ── scientificRecord ──────────────────────────────────────────────────────
   const generatedAt = options.generatedAt ?? FIXED_GENERATED_AT;
-  const recorded = runStage('scientificRecord', () => {
-    fault('scientificRecord');
-    const r = require_(result, 'contours', 'the analysis result');
-    // buildExportProvenance is the app's one derivation of provenance from a
-    // run; the record and the manifest are both derived from it, exactly as
-    // every exporter does, so the benchmark stamps what a real export stamps.
-    const provenance = buildExportProvenance(r, {
-      basename: options.basename ?? null,
-      generatedAt,
-      verticalUnitToMetres: analysisParams.verticalUnitToMetres,
-    });
-    return { provenance, record: analysisRecordFromProvenance(provenance) };
-  });
-  stages.push(recorded.stage);
-  if (recorded.value) artifacts.scientificRecord = toHashable(recorded.value.record);
+  emit(
+    runStage('scientificRecord', (): ArtifactBag => {
+      fault('scientificRecord');
+      const result = require_(products.result, 'contours', 'the analysis result');
+      // buildExportProvenance is the app's one derivation of provenance from a
+      // run; the record and the manifest are both derived from it, exactly as
+      // every exporter does, so the benchmark stamps what a real export stamps.
+      const provenance = buildExportProvenance(result, {
+        basename: options.basename ?? null,
+        generatedAt,
+        verticalUnitToMetres: analysisParams.verticalUnitToMetres,
+      });
+      products.provenance = provenance;
+      const record = analysisRecordFromProvenance(provenance);
+      // The build identity and the generation time are what make the full
+      // record machine-scoped; dropping them leaves the science, including the
+      // app's own contentHash taken over exactly that science. See the header.
+      const { build: _build, generatedAt: _generatedAt, ...content } = record;
+      artifactFault('scientificRecord');
+      return {
+        scientificRecord: toHashable(record),
+        scientificRecordContent: toHashable(content),
+      };
+    }),
+  );
 
   // ── manifest ──────────────────────────────────────────────────────────────
-  const manifested = runStage('manifest', () => {
-    fault('manifest');
-    const p = require_(recorded.value, 'scientificRecord', 'the export provenance');
-    const manifest = processingManifestFromProvenance(p.provenance);
-    // Verify the chain in the same stage that built it. A manifest that does
-    // not verify is a failed stage, not a field on an artifact nobody reads.
-    const verification = verifyProcessingManifest(manifest);
-    if (!verification.ok) {
-      throw new Error(
-        `processing manifest failed to verify at op ${String(verification.firstInvalid)}`,
-      );
-    }
-    return manifest;
-  });
-  stages.push(manifested.stage);
-  if (manifested.value) artifacts.processingManifest = toHashable(manifested.value);
+  emit(
+    runStage('manifest', (): ArtifactBag => {
+      fault('manifest');
+      const provenance = require_(products.provenance, 'scientificRecord', 'the export provenance');
+      const manifest = processingManifestFromProvenance(provenance);
+      // Verify the chain in the same stage that built it. A manifest that does
+      // not verify is a failed stage, not a field on an artifact nobody reads.
+      const verification = verifyProcessingManifest(manifest);
+      if (!verification.ok) {
+        throw new Error(
+          `processing manifest failed to verify at op ${String(verification.firstInvalid)}`,
+        );
+      }
+      artifactFault('manifest');
+      return { processingManifest: toHashable(manifest) };
+    }),
+  );
 
   // ── the browser half ──────────────────────────────────────────────────────
-  for (const name of BROWSER_ONLY_STAGES) stages.push(browserStage(name));
+  for (const name of BROWSER_ONLY_STAGES) {
+    stages.push(declaredStage(name, BROWSER_STAGE_REASONS[name], 'browser'));
+  }
 
   return {
-    datasetId: cloud?.datasetId ?? `synthetic-${pointCount}-seed${seed}`,
+    datasetId: products.cloud?.datasetId ?? `synthetic-${pointCount}-seed${seed}`,
     seed,
     pointCount,
     analysisParams,
     stages,
     artifacts,
     metrics: headlineMetrics(stages, pointCount),
-    cloud,
-    result,
+    cloud: products.cloud,
+    result: products.result,
   };
 }
 
 /**
- * A stage that cannot exist in this runtime.
+ * A stage that exists but carries no number, with the reason it carries none.
  *
  * Status 'ok' rather than 'failed': nothing went wrong, and a red row in every
  * reporter would tell a reader the opposite. The honest statement lives in the
  * metric's reason, which is exactly where the framework's schema puts it — and
  * the schema makes it impossible to attach a number to it.
  */
-function browserStage(name: BrowserStageName): StageResult {
-  const reason = BROWSER_STAGE_REASONS[name];
-  const provenance = { runtime: 'browser', deterministic: false } as const;
+function declaredStage(
+  name: PipelineStageName,
+  reason: string,
+  runtime: MetricRuntime,
+): StageResult {
+  const provenance = { runtime, deterministic: false } as const;
   return {
     name,
     status: 'ok',
@@ -468,27 +682,33 @@ function browserStage(name: BrowserStageName): StageResult {
 }
 
 /**
- * Headline numbers for a report. Throughput is only stated when the two stages
- * it divides both produced a measurement — a "points/s" computed from a stage
- * that never ran is the fabricated number this whole framework exists to avoid.
+ * Headline numbers for a report.
+ *
+ * Each is stated only when every stage behind it produced a measurement — a
+ * "points/s" computed from a stage that never ran is the fabricated number this
+ * whole framework exists to avoid.
  */
 function headlineMetrics(
   stages: readonly StageResult[],
   pointCount: number,
 ): Record<string, Metric> {
   const provenance = { runtime: 'node', deterministic: false } as const;
-  const analysisMs = ['dtm', 'contours'].reduce<number | null>((total, name) => {
-    if (total === null) return null;
-    const stage = stages.find((s) => s.name === name);
-    if (!stage || stage.status !== 'ok' || stage.duration.status !== 'measured') return null;
-    return total + stage.duration.value;
-  }, 0);
+  // The application's analysis proper: the app's own two halves, nothing else.
+  const analysisMs = sumStages(stages, ['dtm', 'contours']);
+  const runMs = pipelineDurationMs(stages);
   return {
     pointCount: measured(pointCount, 'points', { runtime: 'node', deterministic: true }),
     analysisDurationMs:
       analysisMs === null
-        ? unavailable('the dtm or contours stage did not complete, so there is no analysis time', provenance)
+        ? unavailable(
+            'the dtm or contours stage did not complete, so there is no analysis time',
+            provenance,
+          )
         : measured(analysisMs, 'ms', provenance),
+    runDurationMs:
+      runMs === null
+        ? unavailable('a pipeline stage did not complete, so the run has no total', provenance)
+        : measured(runMs, 'ms', provenance),
     pointsPerSecond:
       analysisMs === null || analysisMs <= 0
         ? unavailable(
@@ -497,6 +717,30 @@ function headlineMetrics(
           )
         : measured((pointCount / analysisMs) * 1000, 'points/s', provenance),
   };
+}
+
+/** Sum named stages' durations, or null when any one is missing a measurement. */
+function sumStages(stages: readonly StageResult[], names: readonly string[]): number | null {
+  let total = 0;
+  for (const name of names) {
+    const stage = stages.find((s) => s.name === name);
+    if (!stage || stage.status !== 'ok' || stage.duration.status !== 'measured') return null;
+    total += stage.duration.value;
+  }
+  return total;
+}
+
+/**
+ * A byte view over a typed array — no copy, over the buffer the pipeline
+ * produced.
+ *
+ * Byte order is little-endian on both architectures this project targets, so a
+ * hash taken here is comparable between an arm64 laptop and an x86_64 runner. A
+ * big-endian host would hash identical science differently: a limitation worth
+ * naming rather than one to discover.
+ */
+function bytesOf(array: Float32Array | Uint8Array | Uint32Array): Uint8Array {
+  return new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
 }
 
 /** The interval-independent scientific summary of one core run. */
@@ -538,7 +782,7 @@ function summariseCore(core: TerrainCore): Record<string, unknown> {
     cellStatusTally: core.cellStatusTally,
     surface: {
       dsm: core.surface.dsm,
-      // The canopy GRID is on `dtmSurface`; only its statistics belong here.
+      // The canopy GRID goes out as bytes; only its statistics belong here.
       canopy: {
         coveredCells: core.surface.canopy.coveredCells,
         maxHeightM: core.surface.canopy.maxHeightM,
@@ -586,70 +830,4 @@ function require_<T>(value: T | null | undefined, stage: NodeStageName, what: st
     throw new Error(`the ${stage} stage did not produce ${what}`);
   }
   return value;
-}
-
-/** What a non-finite number becomes in an artifact. */
-type NonFiniteLabel = 'NaN' | 'Infinity' | '-Infinity';
-
-/** Anything `canonicalJson` can represent faithfully. */
-type Hashable = string | number | boolean | null | Hashable[] | { [key: string]: Hashable };
-
-/**
- * Convert a pipeline product into something `hashArtifact` accepts.
- *
- * Two deliberate conversions, both of which the framework's guard would
- * otherwise reject outright:
- *
- *   - TYPED ARRAYS become plain arrays. `canonicalJson` keeps own enumerable
- *     keys, so a Float32Array would canonicalise to an index-keyed object that
- *     still hashes but no longer reads as data.
- *   - NON-FINITE NUMBERS become their name as a string. NaN is how this
- *     pipeline says "no data here" (an empty raster cell, an unmeasurable mean
- *     confidence), and `JSON.stringify(NaN)` is `null` — which is
- *     indistinguishable from a field that genuinely held null, and makes NaN,
- *     +Infinity and -Infinity all hash the same. Naming them keeps the three
- *     apart and keeps the absence explicit.
- *
- * Anything else that JSON cannot carry (a Date, a Map, a class instance) throws
- * rather than being flattened, for the same reason `assertHashable` throws: a
- * silent flattening is a hash that stopped discriminating.
- */
-export function toHashable(value: unknown, path = 'artifact'): Hashable {
-  if (value === null) return null;
-  const t = typeof value;
-  if (t === 'string' || t === 'boolean') return value as string | boolean;
-  if (t === 'number') return finiteOrLabel(value as number);
-  if (t === 'bigint' || t === 'function' || t === 'symbol' || t === 'undefined') {
-    throw new TypeError(`benchmark artifact: ${path} is a ${t}, which has no JSON form`);
-  }
-  if (Array.isArray(value)) return value.map((v, i) => toHashable(v, `${path}[${i}]`));
-  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
-    const view = value as unknown as ArrayLike<number>;
-    const out: Hashable[] = new Array<Hashable>(view.length);
-    for (let i = 0; i < view.length; i++) out[i] = finiteOrLabel(view[i]);
-    return out;
-  }
-  const proto = Object.getPrototypeOf(value as object) as object | null;
-  if (proto !== Object.prototype && proto !== null) {
-    throw new TypeError(
-      `benchmark artifact: ${path} is a ${
-        (value as { constructor?: { name?: string } }).constructor?.name ?? 'non-plain object'
-      }, which JSON cannot carry faithfully`,
-    );
-  }
-  const out: Record<string, Hashable> = {};
-  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
-    // An absent optional field and one explicitly set to undefined describe the
-    // same thing, and JSON drops both — mirroring that here keeps the two from
-    // hashing differently.
-    if (v === undefined) continue;
-    out[key] = toHashable(v, `${path}.${key}`);
-  }
-  return out;
-}
-
-function finiteOrLabel(n: number): number | NonFiniteLabel {
-  if (Number.isFinite(n)) return n;
-  if (Number.isNaN(n)) return 'NaN';
-  return n > 0 ? 'Infinity' : '-Infinity';
 }

--- a/scripts/test-bucket.mjs
+++ b/scripts/test-bucket.mjs
@@ -60,8 +60,24 @@ function bucketOf(name) {
 
 const BUCKETS = ['unit', 'export', 'terrain', 'ui', 'slow'];
 
+// Test subdirectories that hold UNIT tests and must therefore be bucketed.
+// tests/e2e/ is deliberately absent — those are Playwright specs. Without this
+// list a file added under tests/benchmark/ would belong to no bucket, so the
+// release gate would run every bucket green while never executing it.
+const NESTED_TEST_DIRS = ['benchmark'];
+
 function allTestFiles() {
-  return readdirSync(TESTS_DIR).filter((f) => /\.(test|spec)\.ts$/.test(f));
+  const top = readdirSync(TESTS_DIR).filter((f) => /\.(test|spec)\.ts$/.test(f));
+  const nested = NESTED_TEST_DIRS.flatMap((dir) => {
+    let entries;
+    try {
+      entries = readdirSync(join(TESTS_DIR, dir));
+    } catch {
+      return []; // the directory may legitimately not exist yet
+    }
+    return entries.filter((f) => /\.(test|spec)\.ts$/.test(f)).map((f) => `${dir}/${f}`);
+  });
+  return [...top, ...nested];
 }
 
 function filesFor(bucket) {

--- a/scripts/test-bucket.mjs
+++ b/scripts/test-bucket.mjs
@@ -49,8 +49,14 @@ const UI = /(panel|mobile|dock|toolbar|nav|button|sheet|inspector|theme|onboardi
 // Vitest process in CI. Checked AFTER UI, so an export *panel* stays in `ui`.
 const EXPORT = /(^export|exporter|^measurement|^report|^verify|^audit|^stockpile|^sessionFindings|^kml|^gzip|^zip|^scanReport|^spaceReport|^floorPlanExport|^download)/i;
 
-/** Bucket a single test-file basename. `unit` is the catch-all. */
+/** Bucket a single test-file name. `unit` is the catch-all. */
 function bucketOf(name) {
+  // A nested directory routes explicitly, before any regex gets a look in.
+  const slash = name.indexOf('/');
+  if (slash > 0) {
+    const routed = NESTED_TEST_DIRS[name.slice(0, slash)];
+    if (routed) return routed;
+  }
   if (SLOW.test(name)) return 'slow';
   if (TERRAIN.test(name)) return 'terrain';
   if (UI.test(name)) return 'ui';
@@ -60,15 +66,22 @@ function bucketOf(name) {
 
 const BUCKETS = ['unit', 'export', 'terrain', 'ui', 'slow'];
 
-// Test subdirectories that hold UNIT tests and must therefore be bucketed.
-// tests/e2e/ is deliberately absent — those are Playwright specs. Without this
-// list a file added under tests/benchmark/ would belong to no bucket, so the
-// release gate would run every bucket green while never executing it.
-const NESTED_TEST_DIRS = ['benchmark'];
+// Test subdirectories that hold UNIT tests, and the bucket each one routes to.
+// tests/e2e/ is deliberately absent — those are Playwright specs. Two reasons
+// this map exists rather than letting the regexes above classify a nested path:
+//   - without the enumeration, a file added under tests/benchmark/ would belong
+//     to no bucket at all, so the release gate would run every bucket green
+//     while never executing it;
+//   - without the explicit bucket, `tests/benchmark/*` matched `slow` only
+//     because the SLOW regex starts with `^benchmark` (written for the old
+//     top-level benchmark.test.ts). Those files run in ~50 ms and belong in
+//     `unit`; routing them by accident would also change silently the next time
+//     a bucket regex is edited.
+const NESTED_TEST_DIRS = { benchmark: 'unit' };
 
 function allTestFiles() {
   const top = readdirSync(TESTS_DIR).filter((f) => /\.(test|spec)\.ts$/.test(f));
-  const nested = NESTED_TEST_DIRS.flatMap((dir) => {
+  const nested = Object.keys(NESTED_TEST_DIRS).flatMap((dir) => {
     let entries;
     try {
       entries = readdirSync(join(TESTS_DIR, dir));
@@ -93,6 +106,11 @@ if (arg === '--verify') {
   const total = Object.values(counts).reduce((a, b) => a + b, 0);
   const ok = total === files.length;
   for (const b of BUCKETS) console.log(`${b}: ${counts[b]}`);
+  // Print the nested routing so the gate log shows WHERE those files ran, not
+  // just that the partition adds up.
+  for (const [dir, bucket] of Object.entries(NESTED_TEST_DIRS)) {
+    console.log(`tests/${dir}/ → ${bucket} (explicit)`);
+  }
   console.log(`total: ${total} / ${files.length} — partition ${ok ? 'OK' : 'BROKEN'}`);
   process.exit(ok ? 0 : 1);
 }

--- a/tests/benchmark/artifacts.test.ts
+++ b/tests/benchmark/artifacts.test.ts
@@ -13,6 +13,7 @@ import {
   hashArtifact,
   stripVolatile,
   AMBIGUOUS_CLOCK_KEYS,
+  MAX_ARTIFACT_DEPTH,
   VOLATILE_RULES,
   VOLATILE_PLACEHOLDER,
   RAW_BYTES_NO_STRIP_REASON,
@@ -120,8 +121,26 @@ describe('hash stability', () => {
 
   test('an absolute path nested in an array is stripped too', () => {
     const a = { ...base, inputs: ['/Users/alice/a.las', '/Users/alice/b.las'] };
-    const b = { ...base, inputs: ['/srv/ci/x.las', '/srv/ci/y.las'] };
+    const b = { ...base, inputs: ['/srv/ci/a.las', '/srv/ci/b.las'] };
     expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', b).hash);
+  });
+
+  test('the redaction keeps the BASENAME, so two different files still differ', () => {
+    // Machine-specificity lives in the directory prefix, never the filename.
+    // Collapsing every absolute path to one placeholder made a run over tileA
+    // and a run over tileB hash identically — two different artifacts, one
+    // hash, reported by the reproducibility suite as agreement.
+    const a = { ...base, input: '/data/tileA.laz' };
+    const b = { ...base, input: '/data/tileB.laz' };
+    expect(hashArtifact('metrics', a).hash).not.toBe(hashArtifact('metrics', b).hash);
+  });
+
+  test('the same basename under different roots still hashes the same', () => {
+    const a = { ...base, input: '/Users/alice/checkout/data/scan.las' };
+    const b = { ...base, input: 'C:\\Users\\carol\\data\\scan.las' };
+    const c = { ...base, input: 'file:///srv/ci/workspace/data/scan.las' };
+    expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', b).hash);
+    expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', c).hash);
   });
 
   test('two artifacts differing only in machine identity hash the same', () => {
@@ -208,6 +227,50 @@ describe('hash sensitivity — the strip is not over-broad', () => {
     expect(hashArtifact('metrics', a).hash).not.toBe(hashArtifact('metrics', b).hash);
   });
 
+  test('a __proto__ key is a real own property in the canonical form', () => {
+    // `out['__proto__'] = v` on a `{}` literal hits Object.prototype's setter
+    // and RE-PARENTS the object instead of creating an own property, so the key
+    // vanished: two different payloads and an empty object all hashed the same,
+    // while the record asserted `volatilityStripped: true` with an empty
+    // exclusion list. Any artifact built by JSON.parse of a sidecar, an
+    // ept.json or a GeoJSON can carry this key.
+    // JSON.parse is the realistic entry point and the only one that makes
+    // `__proto__` a genuine own key — an object LITERAL with that key sets the
+    // prototype instead, which the type guard rejects separately.
+    const a = hashArtifact('metrics', JSON.parse('{"__proto__":{"secret":1}}')).hash;
+    const b = hashArtifact('metrics', JSON.parse('{"__proto__":{"secret":999}}')).hash;
+    const empty = hashArtifact('metrics', JSON.parse('{}')).hash;
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(empty);
+    expect(b).not.toBe(empty);
+  });
+
+  test('a __proto__ key is reported in strippedFields terms, not silently absent', () => {
+    // The record must not claim a clean strip over a key that never made it in.
+    const rec = hashArtifact('metrics', JSON.parse('{"__proto__":{"secret":1},"n":1}'));
+    expect(rec.volatilityStripped).toBe(true);
+    expect(rec.strippedFields).toEqual([]);
+    // ...and the key really is in the hashed form, which is the whole point.
+    expect(rec.hash).not.toBe(hashArtifact('metrics', JSON.parse('{"n":1}')).hash);
+  });
+
+  test('a hole in a sparse array normalises to null, as JSON does', () => {
+    // Array.prototype.map SKIPS holes, so the undefined-to-null normalisation
+    // never ran: the canonical form was `{"arr":[,,1]}`, which JSON.parse
+    // rejects, and it differed from the identical document [null,null,1].
+    const sparse = { arr: [, , 1] };
+    const dense = { arr: [undefined, undefined, 1] };
+    const explicit = { arr: [null, null, 1] };
+    expect(hashArtifact('m', sparse).hash).toBe(hashArtifact('m', dense).hash);
+    expect(hashArtifact('m', sparse).hash).toBe(hashArtifact('m', explicit).hash);
+  });
+
+  test('the canonical form of a sparse array is parseable JSON', () => {
+    const clean = stripVolatile({ arr: [, , 1] }).value;
+    expect(() => JSON.parse(JSON.stringify(clean))).not.toThrow();
+    expect(clean).toEqual({ arr: [null, null, 1] });
+  });
+
   test('array order still matters', () => {
     const a = { ...base, nested: { ...base.nested, classes: [1, 2, 6] } };
     const b = { ...base, nested: { ...base.nested, classes: [6, 2, 1] } };
@@ -249,7 +312,12 @@ describe('the strip list is auditable', () => {
     >;
     expect(out.keep).toBe(1);
     expect('generatedAt' in out).toBe(false);
-    expect(out.p).toBe(VOLATILE_PLACEHOLDER);
+    expect(out.p).toBe(`${VOLATILE_PLACEHOLDER}/a.bin`);
+  });
+
+  test('a directory-only path redacts to the placeholder with an empty basename', () => {
+    const out = stripVolatile({ p: '/var/tmp/' }).value as Record<string, unknown>;
+    expect(out.p).toBe(`${VOLATILE_PLACEHOLDER}/`);
   });
 
   test('stripVolatile does not mutate its input', () => {
@@ -290,6 +358,13 @@ describe('byte artifacts', () => {
     const rec = hashArtifact('raster', new Uint8Array([1, 2, 3]).buffer);
     expect(rec.kind).toBe('bytes');
     expect(rec.volatilityStripped).toBe(false);
+  });
+
+  test('an unnamed artifact is rejected, as an unnamed metric already is', () => {
+    // A record with no name cannot be found again in a report, and the three
+    // other constructors (measured, unavailable, capturedEnv) all refuse it.
+    expect(() => hashArtifact('', { n: 1 })).toThrow(/name/i);
+    expect(() => hashArtifact('   ', new Uint8Array([1]))).toThrow(/name/i);
   });
 
   test('a JSON artifact claims the strip, with no reason to give', () => {
@@ -435,6 +510,42 @@ describe('values canonicalJson cannot represent are rejected, not silently colla
 
   test('a typed array NESTED in a JSON artifact is rejected rather than hashed as an object', () => {
     expect(() => hashArtifact('metrics', { bytes: new Uint8Array([1, 2]) })).toThrow(/Uint8Array/);
+  });
+
+  test('a reference cycle fails with the path, not a bare stack overflow', () => {
+    // `report.parent = report` is a realistic accident. It used to surface as
+    // `RangeError: Maximum call stack size exceeded` — no artifact, no path, in
+    // a module whose other errors name `runs[1].now`.
+    const report: Record<string, unknown> = { suiteId: 'decode' };
+    report.parent = report;
+    expect(() => hashArtifact('metrics', report)).toThrow(/reference cycle/);
+    expect(() => hashArtifact('metrics', report)).toThrow(/parent/);
+    expect(() => hashArtifact('metrics', report)).not.toThrow(/call stack/);
+  });
+
+  test('a cycle through an array is caught too', () => {
+    const runs: unknown[] = [{ ok: true }];
+    runs.push({ runs });
+    expect(() => hashArtifact('metrics', { runs })).toThrow(/reference cycle/);
+  });
+
+  test('the same object appearing twice WITHOUT a cycle is not a cycle', () => {
+    // A shared sub-object is legal JSON input; only an ancestor repeat is a cycle.
+    const shared = { a: 1 };
+    expect(() => hashArtifact('metrics', { x: shared, y: shared })).not.toThrow();
+  });
+
+  test('nesting deeper than the stated limit fails with a message, not a crash', () => {
+    let deep: Record<string, unknown> = { leaf: 1 };
+    for (let i = 0; i < MAX_ARTIFACT_DEPTH + 5; i++) deep = { n: deep };
+    expect(() => hashArtifact('metrics', deep)).toThrow(/nested deeper than/);
+    expect(() => hashArtifact('metrics', deep)).toThrow(String(MAX_ARTIFACT_DEPTH));
+  });
+
+  test('stripVolatile used on its own is guarded the same way', () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => stripVolatile(cyclic)).toThrow(/reference cycle/);
   });
 
   test('the error names the artifact, so a suite with ten artifacts says which one', () => {

--- a/tests/benchmark/artifacts.test.ts
+++ b/tests/benchmark/artifacts.test.ts
@@ -12,10 +12,12 @@ import {
   assertHashable,
   hashArtifact,
   stripVolatile,
+  AMBIGUOUS_CLOCK_KEYS,
   VOLATILE_RULES,
   VOLATILE_PLACEHOLDER,
   RAW_BYTES_NO_STRIP_REASON,
 } from '../../benchmarks/framework/artifacts';
+import type { ArtifactRecord } from '../../benchmarks/framework/types';
 
 const base = {
   suiteId: 'decode',
@@ -59,6 +61,9 @@ describe('hash stability', () => {
    * The values here are EPOCH NUMBERS on purpose: a number cannot be caught by
    * the value-side ISO detector, so this isolates the key rule.
    */
+  // `time`, `now`, `when` and `utc` are absent on purpose: those four are
+  // ambiguous enough that the framework refuses them outright rather than
+  // deciding silently. See "ambiguous clock names are rejected" below.
   const TIMESTAMP_KEYS = [
     'timestamp',
     'generatedAt',
@@ -68,8 +73,6 @@ describe('hash stability', () => {
     'finishedAt',
     'builtAt',
     'date',
-    'time',
-    'now',
     'startTime',
     'endTime',
     'buildDate',
@@ -77,6 +80,8 @@ describe('hash stability', () => {
     'datestamp',
     'mtime',
     'epochMs',
+    'epoch_ms',
+    'epochSec',
     'unixTime',
   ];
 
@@ -165,6 +170,32 @@ describe('hash sensitivity — the strip is not over-broad', () => {
       const a = { ...base, [key]: 10 };
       const b = { ...base, [key]: 11 };
       expect(hashArtifact('metrics', a).hash, key).not.toBe(hashArtifact('metrics', b).hash);
+    }
+  });
+
+  test('the domain vocabulary survives: `epoch`, `epochs` and `times` are not clocks here', () => {
+    // An epoch in this codebase is a survey campaign (alignEpochs, EpochCloud),
+    // and `times` is most often an array of durations. `epoch_?(ms|s)` used to
+    // swallow the plural, so an array of survey epochs vanished from the hash
+    // inside the very domain this carve-out exists to protect.
+    const cases: ReadonlyArray<readonly [string, unknown, unknown]> = [
+      ['epoch', 1, 2],
+      ['epochs', ['2019', '2021'], ['2019', '2022']],
+      ['times', [1, 2], [1, 3]],
+    ];
+    for (const [key, left, right] of cases) {
+      const a = { ...base, [key]: left };
+      const b = { ...base, [key]: right };
+      expect(hashArtifact('metrics', a).hash, key).not.toBe(hashArtifact('metrics', b).hash);
+    }
+  });
+
+  test('the unit-suffixed epoch forms ARE still stripped', () => {
+    // The tightening must not cost the forms the rule was written for.
+    for (const key of ['epochMs', 'epoch_ms', 'epochSec', 'epoch_seconds']) {
+      const a = { ...base, [key]: 1_753_459_200_000 };
+      const b = { ...base, [key]: 946_684_800_000 };
+      expect(hashArtifact('metrics', a).hash, key).toBe(hashArtifact('metrics', b).hash);
     }
   });
 
@@ -266,6 +297,96 @@ describe('byte artifacts', () => {
     expect(rec.volatilityStripped).toBe(true);
     expect(rec.unstrippedReason).toBeUndefined();
   });
+
+  /**
+   * The disclosure must not be able to be wrong-but-valid.
+   *
+   * `hashArtifact` is not the only constructor — the fixture hand-builds
+   * records and the suites will too — so an unexplained gap has to be a
+   * COMPILE error, exactly as an unavailable metric without a reason already
+   * is. These assertions fail the typecheck if the union stops enforcing it:
+   * an unused `@ts-expect-error` is itself an error.
+   */
+  test('an unexplained or contradictory disclosure does not typecheck', () => {
+    const common = {
+      name: 'raster',
+      kind: 'bytes',
+      algorithm: 'sha256',
+      hash: 'c'.repeat(64),
+      fingerprint: '0badcafe',
+      byteLength: 8,
+      strippedFields: [],
+    } as const;
+
+    // @ts-expect-error volatilityStripped:false REQUIRES a reason
+    const unexplained: ArtifactRecord = { ...common, volatilityStripped: false };
+
+    // @ts-expect-error volatilityStripped:true forbids a reason — nothing to explain
+    const contradictory: ArtifactRecord = {
+      ...common,
+      kind: 'json',
+      volatilityStripped: true,
+      unstrippedReason: 'should not be sayable',
+    };
+
+    const valid: ArtifactRecord = {
+      ...common,
+      volatilityStripped: false,
+      unstrippedReason: RAW_BYTES_NO_STRIP_REASON,
+    };
+
+    expect(unexplained.name).toBe('raster');
+    expect(contradictory.name).toBe('raster');
+    expect(valid.unstrippedReason).toBe(RAW_BYTES_NO_STRIP_REASON);
+  });
+});
+
+describe('ambiguous clock names are rejected instead of decided silently', () => {
+  // `time`, `now`, `when` and `utc` are the four names that could equally hold a
+  // measurement or a clock reading. Stripping them silently loses a duration
+  // from the hash; keeping them silently defeats reproducibility. Both are the
+  // framework guessing, so it refuses and asks the author to say which it is.
+  test.each(AMBIGUOUS_CLOCK_KEYS)('`%s` is rejected, naming both rename targets', (key) => {
+    const value = { ...base, [key]: 1 };
+    expect(() => hashArtifact('metrics', value)).toThrow(new RegExp(`\\b${key}\\b`));
+    expect(() => hashArtifact('metrics', value)).toThrow(/durationMs/);
+    expect(() => hashArtifact('metrics', value)).toThrow(/capturedAt/);
+  });
+
+  test('the rejection reaches nested objects and array elements', () => {
+    expect(() => hashArtifact('metrics', { run: { time: 1 } })).toThrow(/run\.time/);
+    expect(() => hashArtifact('metrics', { runs: [{ ok: true }, { now: 1 }] })).toThrow(
+      /runs\[1\]\.now/,
+    );
+  });
+
+  test('a rejected name is refused whatever its value type', () => {
+    // The key rule alone could not do this: the ISO detector only tests
+    // strings, so a numeric epoch under `time` is invisible to it.
+    for (const v of [1_753_459_200_000, '2026-07-25T10:00:00.000Z', null, [1, 2]]) {
+      expect(() => hashArtifact('metrics', { time: v })).toThrow(/rename/i);
+    }
+  });
+
+  test('the unambiguous neighbours are still accepted', () => {
+    expect(() =>
+      hashArtifact('metrics', {
+        ...base,
+        startTime: 1,
+        endTime: 2,
+        timestamp: 3,
+        generatedAt: '2026-07-25T10:00:00.000Z',
+        durationMs: 12.5,
+        capturedAt: 4,
+      }),
+    ).not.toThrow();
+  });
+
+  test('a rejected name still cannot reach the hash if the guard is bypassed', () => {
+    // Defence in depth: the key rule keeps these names on the strip list, so
+    // `stripVolatile` used on its own still removes them.
+    expect(stripVolatile({ time: 1, keep: 2 }).stripped).toEqual(['time']);
+  });
 });
 
 describe('values canonicalJson cannot represent are rejected, not silently collapsed', () => {
@@ -273,14 +394,22 @@ describe('values canonicalJson cannot represent are rejected, not silently colla
   // walks own enumerable keys, so a Date and a Map both canonicalise to `{}`
   // and every non-finite number to `null`. A real value change that leaves the
   // digest untouched is the exact failure the sensitivity requirement forbids.
+  // A neutral key name, so this exercises the VALUE guard rather than the
+  // ambiguous-name rule that would reject `when` before the type is examined.
   test('a Date is rejected, naming its dotted path and its type', () => {
-    expect(() => hashArtifact('metrics', { run: { when: new Date(0) } })).toThrow(/run\.when/);
-    expect(() => hashArtifact('metrics', { run: { when: new Date(0) } })).toThrow(/Date/);
+    expect(() => hashArtifact('metrics', { run: { stamp: new Date(0) } })).toThrow(/run\.stamp/);
+    expect(() => hashArtifact('metrics', { run: { stamp: new Date(0) } })).toThrow(/Date/);
   });
 
   test('two Dates that differ would otherwise have collided', () => {
-    expect(() => hashArtifact('metrics', { when: new Date(0) })).toThrow();
-    expect(() => hashArtifact('metrics', { when: new Date(999) })).toThrow();
+    expect(() => hashArtifact('metrics', { stamp: new Date(0) })).toThrow(/Date/);
+    expect(() => hashArtifact('metrics', { stamp: new Date(999) })).toThrow(/Date/);
+  });
+
+  test('a Date under a name the strip would have removed anyway is still rejected', () => {
+    // The guard runs BEFORE the strip, so the author is told to convert it
+    // rather than having the field silently disappear.
+    expect(() => hashArtifact('metrics', { capturedAt: new Date(0) })).toThrow(/Date/);
   });
 
   test('a Map and a Set are rejected', () => {
@@ -322,6 +451,15 @@ describe('values canonicalJson cannot represent are rejected, not silently colla
     expect(() =>
       assertHashable('metrics', { a: [1, 'x', true, null, { b: Object.create(null) }] }),
     ).not.toThrow();
+  });
+
+  test('a root-level undefined is rejected by the guard, not left to crash the hasher', () => {
+    // It used to reach fnv1a and die with "Cannot read properties of undefined
+    // (reading 'length')" — a stack trace instead of the one message that tells
+    // the author what to do.
+    expect(() => hashArtifact('metrics', undefined)).toThrow(/artifact root/);
+    expect(() => hashArtifact('metrics', undefined)).toThrow(/undefined/);
+    expect(() => hashArtifact('metrics', undefined)).not.toThrow(/reading 'length'/);
   });
 
   test('an undefined property is omitted, exactly as JSON.stringify would treat it', () => {

--- a/tests/benchmark/artifacts.test.ts
+++ b/tests/benchmark/artifacts.test.ts
@@ -9,10 +9,12 @@
  */
 import { describe, test, expect } from 'vitest';
 import {
+  assertHashable,
   hashArtifact,
   stripVolatile,
   VOLATILE_RULES,
   VOLATILE_PLACEHOLDER,
+  RAW_BYTES_NO_STRIP_REASON,
 } from '../../benchmarks/framework/artifacts';
 
 const base = {
@@ -45,6 +47,62 @@ describe('hash stability', () => {
     const a = { ...base, generatedAt: '2026-07-25T10:00:00.000Z', startedAt: 1 };
     const b = { ...base, generatedAt: '1999-01-01T00:00:00.000Z', startedAt: 2 };
     expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', b).hash);
+  });
+
+  /**
+   * The names a suite author actually reaches for. The first version of this
+   * suite only exercised `generatedAt`/`startedAt`, which is why `date`, `time`,
+   * `now`, `startTime`, `endTime`, `buildDate`, `runDate` and `datestamp` all
+   * survived into the hash unnoticed — every one of them defeats the whole
+   * reproducibility check on its own.
+   *
+   * The values here are EPOCH NUMBERS on purpose: a number cannot be caught by
+   * the value-side ISO detector, so this isolates the key rule.
+   */
+  const TIMESTAMP_KEYS = [
+    'timestamp',
+    'generatedAt',
+    'createdAt',
+    'updatedAt',
+    'startedAt',
+    'finishedAt',
+    'builtAt',
+    'date',
+    'time',
+    'now',
+    'startTime',
+    'endTime',
+    'buildDate',
+    'runDate',
+    'datestamp',
+    'mtime',
+    'epochMs',
+    'unixTime',
+  ];
+
+  test.each(TIMESTAMP_KEYS)('an epoch number under `%s` does not change the hash', (key) => {
+    const a = { ...base, [key]: 1_753_459_200_000 };
+    const b = { ...base, [key]: 946_684_800_000 };
+    expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', b).hash);
+  });
+
+  test('an ISO-8601 datetime is stripped by VALUE, whatever the field is called', () => {
+    // Symmetric with the absolute-path rule: a wall-clock reading is volatile
+    // because of what it IS, not because of the name someone gave the field.
+    const a = { ...base, label: '2026-07-25T10:00:00.000Z' };
+    const b = { ...base, label: '1999-01-01T00:00:00.000Z' };
+    expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', b).hash);
+  });
+
+  test('ISO-8601 with an offset, a space separator or no milliseconds is still stripped', () => {
+    const variants = [
+      '2026-07-25T10:00:00+02:00',
+      '2026-07-25T10:00:00',
+      '2026-07-25 10:00:00',
+      '2026-07-25T10:00Z',
+    ];
+    const hashes = new Set(variants.map((v) => hashArtifact('metrics', { ...base, label: v }).hash));
+    expect(hashes.size).toBe(1);
   });
 
   test('two artifacts differing only in an absolute path hash the same', () => {
@@ -96,6 +154,26 @@ describe('hash sensitivity — the strip is not over-broad', () => {
   test('a duration is NOT stripped — timings are the measurement, not noise', () => {
     const a = { ...base, durationMs: 10 };
     const b = { ...base, durationMs: 11 };
+    expect(hashArtifact('metrics', a).hash).not.toBe(hashArtifact('metrics', b).hash);
+  });
+
+  test('the timing field names the framework itself emits all survive the strip', () => {
+    // The widened timestamp key list must not reach the fields a benchmark
+    // exists to report: if one of these were swallowed, a real regression would
+    // hash identically to a clean run.
+    for (const key of ['duration', 'durationMs', 'elapsedMs', 'peakMemory', 'pointsPerSecond']) {
+      const a = { ...base, [key]: 10 };
+      const b = { ...base, [key]: 11 };
+      expect(hashArtifact('metrics', a).hash, key).not.toBe(hashArtifact('metrics', b).hash);
+    }
+  });
+
+  test('a bare calendar date under a neutral key is NOT stripped', () => {
+    // '2026-07-25' with no time is as likely to be a dataset epoch label as a
+    // run timestamp, so the value rule requires a time component. A field that
+    // really is a wall-clock date should be NAMED one (`date`, `buildDate`).
+    const a = { ...base, epochLabel: '2026-07-25' };
+    const b = { ...base, epochLabel: '2026-07-26' };
     expect(hashArtifact('metrics', a).hash).not.toBe(hashArtifact('metrics', b).hash);
   });
 
@@ -164,5 +242,94 @@ describe('byte artifacts', () => {
     const a = hashArtifact('blob', new Uint8Array([1, 2, 3]));
     const b = hashArtifact('blob', new Uint8Array([1, 2, 4]));
     expect(a.hash).not.toBe(b.hash);
+  });
+
+  test('the record DISCLOSES that no strip was applied, and why', () => {
+    // A PNG tEXt date, a GeoTIFF tag or a zip mtime rehashes on every run, and
+    // an empty `strippedFields` alone reads as "nothing volatile in here" — the
+    // opposite of the truth. The caveat has to be on the record, not in a
+    // source comment a report reader never sees.
+    const rec = hashArtifact('raster', new Uint8Array([1, 2, 3]));
+    expect(rec.volatilityStripped).toBe(false);
+    expect(rec.unstrippedReason).toBe(RAW_BYTES_NO_STRIP_REASON);
+    expect(rec.unstrippedReason).toMatch(/timestamp/i);
+  });
+
+  test('an ArrayBuffer is treated as bytes and carries the same disclosure', () => {
+    const rec = hashArtifact('raster', new Uint8Array([1, 2, 3]).buffer);
+    expect(rec.kind).toBe('bytes');
+    expect(rec.volatilityStripped).toBe(false);
+  });
+
+  test('a JSON artifact claims the strip, with no reason to give', () => {
+    const rec = hashArtifact('metrics', base);
+    expect(rec.volatilityStripped).toBe(true);
+    expect(rec.unstrippedReason).toBeUndefined();
+  });
+});
+
+describe('values canonicalJson cannot represent are rejected, not silently collapsed', () => {
+  // Each of these hashed IDENTICALLY before the guard existed: canonicalJson
+  // walks own enumerable keys, so a Date and a Map both canonicalise to `{}`
+  // and every non-finite number to `null`. A real value change that leaves the
+  // digest untouched is the exact failure the sensitivity requirement forbids.
+  test('a Date is rejected, naming its dotted path and its type', () => {
+    expect(() => hashArtifact('metrics', { run: { when: new Date(0) } })).toThrow(/run\.when/);
+    expect(() => hashArtifact('metrics', { run: { when: new Date(0) } })).toThrow(/Date/);
+  });
+
+  test('two Dates that differ would otherwise have collided', () => {
+    expect(() => hashArtifact('metrics', { when: new Date(0) })).toThrow();
+    expect(() => hashArtifact('metrics', { when: new Date(999) })).toThrow();
+  });
+
+  test('a Map and a Set are rejected', () => {
+    expect(() => hashArtifact('metrics', { m: new Map([['a', 1]]) })).toThrow(/Map/);
+    expect(() => hashArtifact('metrics', { s: new Set([1, 2]) })).toThrow(/Set/);
+  });
+
+  test('NaN and Infinity are rejected — both canonicalise to null', () => {
+    expect(() => hashArtifact('metrics', { x: NaN })).toThrow(/\bx\b/);
+    expect(() => hashArtifact('metrics', { x: NaN })).toThrow(/finite/i);
+    expect(() => hashArtifact('metrics', { x: Infinity })).toThrow(/finite/i);
+    expect(() => hashArtifact('metrics', { x: -Infinity })).toThrow(/finite/i);
+  });
+
+  test('a bigint, a function and a class instance are rejected', () => {
+    class Cloud {
+      readonly n = 1;
+    }
+    expect(() => hashArtifact('metrics', { n: 1n })).toThrow(/bigint/i);
+    expect(() => hashArtifact('metrics', { f: () => 1 })).toThrow(/function/i);
+    expect(() => hashArtifact('metrics', { c: new Cloud() })).toThrow(/Cloud/);
+  });
+
+  test('a typed array NESTED in a JSON artifact is rejected rather than hashed as an object', () => {
+    expect(() => hashArtifact('metrics', { bytes: new Uint8Array([1, 2]) })).toThrow(/Uint8Array/);
+  });
+
+  test('the error names the artifact, so a suite with ten artifacts says which one', () => {
+    expect(() => hashArtifact('tile-index', { when: new Date(0) })).toThrow(/tile-index/);
+  });
+
+  test('an element inside an array is named by index', () => {
+    expect(() => hashArtifact('metrics', { runs: [{ ok: true }, { at: new Date(0) }] })).toThrow(
+      /runs\[1\]\.at/,
+    );
+  });
+
+  test('plain objects, arrays, strings, booleans and null are all accepted', () => {
+    expect(() =>
+      assertHashable('metrics', { a: [1, 'x', true, null, { b: Object.create(null) }] }),
+    ).not.toThrow();
+  });
+
+  test('an undefined property is omitted, exactly as JSON.stringify would treat it', () => {
+    // Not an error: `{ error: undefined }` is what spreading an optional field
+    // produces. Dropping it is what makes the canonical form valid JSON at all
+    // — canonicalJson would otherwise emit the bare token `undefined`.
+    expect(hashArtifact('metrics', { a: 1, b: undefined }).hash).toBe(
+      hashArtifact('metrics', { a: 1 }).hash,
+    );
   });
 });

--- a/tests/benchmark/artifacts.test.ts
+++ b/tests/benchmark/artifacts.test.ts
@@ -1,0 +1,168 @@
+/**
+ * artifacts.test.ts — artifact hashing is stable across machines and runs.
+ *
+ * The hash is the claim "this is the same scientific artifact". Two things must
+ * hold or the claim is worthless: it must NOT move when only the wall clock, the
+ * checkout directory or the machine name differ (otherwise no reviewer can ever
+ * reproduce it), and it MUST move when a real value changes (otherwise the strip
+ * has quietly eaten the data the hash is supposed to cover).
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  hashArtifact,
+  stripVolatile,
+  VOLATILE_RULES,
+  VOLATILE_PLACEHOLDER,
+} from '../../benchmarks/framework/artifacts';
+
+const base = {
+  suiteId: 'decode',
+  datasetId: 'synthetic-grid-1m',
+  points: 1_000_000,
+  nested: { pointsPerSecond: 12345.5, classes: [1, 2, 6] },
+};
+
+describe('hash stability', () => {
+  test('the same artifact hashed twice is identical', () => {
+    const a = hashArtifact('metrics', base);
+    const b = hashArtifact('metrics', base);
+    expect(a.hash).toBe(b.hash);
+    expect(a.fingerprint).toBe(b.fingerprint);
+    expect(a.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('key order does not change the hash', () => {
+    const reordered = {
+      nested: { classes: [1, 2, 6], pointsPerSecond: 12345.5 },
+      points: 1_000_000,
+      datasetId: 'synthetic-grid-1m',
+      suiteId: 'decode',
+    };
+    expect(hashArtifact('metrics', reordered).hash).toBe(hashArtifact('metrics', base).hash);
+  });
+
+  test('two artifacts differing only in a wall-clock timestamp hash the same', () => {
+    const a = { ...base, generatedAt: '2026-07-25T10:00:00.000Z', startedAt: 1 };
+    const b = { ...base, generatedAt: '1999-01-01T00:00:00.000Z', startedAt: 2 };
+    expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', b).hash);
+  });
+
+  test('two artifacts differing only in an absolute path hash the same', () => {
+    const a = { ...base, source: '/Users/alice/checkout/data/scan.las' };
+    const b = { ...base, source: '/home/bob/ci/workspace/data/scan.las' };
+    const c = { ...base, source: 'C:\\Users\\carol\\data\\scan.las' };
+    expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', b).hash);
+    expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', c).hash);
+  });
+
+  test('an absolute path nested in an array is stripped too', () => {
+    const a = { ...base, inputs: ['/Users/alice/a.las', '/Users/alice/b.las'] };
+    const b = { ...base, inputs: ['/srv/ci/x.las', '/srv/ci/y.las'] };
+    expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', b).hash);
+  });
+
+  test('two artifacts differing only in machine identity hash the same', () => {
+    const a = { ...base, hostname: 'alices-mbp.local', username: 'alice', pid: 4242 };
+    const b = { ...base, hostname: 'ci-runner-7', username: 'runner', pid: 9 };
+    expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', b).hash);
+  });
+
+  test('volatile fields buried deep in the tree are still stripped', () => {
+    const a = { ...base, run: { meta: { generatedAt: 'A', hostname: 'a' }, ok: true } };
+    const b = { ...base, run: { meta: { generatedAt: 'B', hostname: 'b' }, ok: true } };
+    expect(hashArtifact('metrics', a).hash).toBe(hashArtifact('metrics', b).hash);
+  });
+});
+
+describe('hash sensitivity — the strip is not over-broad', () => {
+  test('a changed measurement changes the hash', () => {
+    const changed = { ...base, nested: { ...base.nested, pointsPerSecond: 12345.6 } };
+    expect(hashArtifact('metrics', changed).hash).not.toBe(hashArtifact('metrics', base).hash);
+  });
+
+  test('a changed dataset id changes the hash', () => {
+    const changed = { ...base, datasetId: 'synthetic-grid-2m' };
+    expect(hashArtifact('metrics', changed).hash).not.toBe(hashArtifact('metrics', base).hash);
+  });
+
+  test('a RELATIVE path survives the strip and still discriminates', () => {
+    // Only ABSOLUTE paths are machine-specific. A repo-relative dataset path is
+    // part of the artifact's identity and must keep affecting the hash.
+    const a = { ...base, source: 'tests/fixtures/tiny.las' };
+    const b = { ...base, source: 'tests/fixtures/tiny.laz' };
+    expect(hashArtifact('metrics', a).hash).not.toBe(hashArtifact('metrics', b).hash);
+  });
+
+  test('a duration is NOT stripped — timings are the measurement, not noise', () => {
+    const a = { ...base, durationMs: 10 };
+    const b = { ...base, durationMs: 11 };
+    expect(hashArtifact('metrics', a).hash).not.toBe(hashArtifact('metrics', b).hash);
+  });
+
+  test('array order still matters', () => {
+    const a = { ...base, nested: { ...base.nested, classes: [1, 2, 6] } };
+    const b = { ...base, nested: { ...base.nested, classes: [6, 2, 1] } };
+    expect(hashArtifact('metrics', a).hash).not.toBe(hashArtifact('metrics', b).hash);
+  });
+});
+
+describe('the strip list is auditable', () => {
+  test('every rule states which category it serves and why it is excluded', () => {
+    expect(VOLATILE_RULES.length).toBeGreaterThan(0);
+    for (const rule of VOLATILE_RULES) {
+      expect(['timestamp', 'absolute-path', 'machine-id']).toContain(rule.kind);
+      expect(['key', 'value']).toContain(rule.appliesTo);
+      expect(rule.why.length).toBeGreaterThan(20);
+    }
+  });
+
+  test('all three required categories are covered', () => {
+    const kinds = new Set(VOLATILE_RULES.map((r) => r.kind));
+    expect(kinds).toEqual(new Set(['timestamp', 'absolute-path', 'machine-id']));
+  });
+
+  test('the record names exactly the fields that were stripped, sorted and dotted', () => {
+    const rec = hashArtifact('metrics', {
+      ...base,
+      generatedAt: 'now',
+      run: { hostname: 'x', file: '/Users/alice/a.las' },
+    });
+    expect(rec.strippedFields).toEqual(['generatedAt', 'run.file', 'run.hostname']);
+    expect(rec.name).toBe('metrics');
+    expect(rec.algorithm).toBe('sha256');
+    expect(rec.kind).toBe('json');
+  });
+
+  test('stripVolatile removes volatile keys and redacts absolute path values', () => {
+    const out = stripVolatile({ keep: 1, generatedAt: 'x', p: '/var/tmp/a.bin' }).value as Record<
+      string,
+      unknown
+    >;
+    expect(out.keep).toBe(1);
+    expect('generatedAt' in out).toBe(false);
+    expect(out.p).toBe(VOLATILE_PLACEHOLDER);
+  });
+
+  test('stripVolatile does not mutate its input', () => {
+    const input = { generatedAt: 'x', keep: 1 };
+    stripVolatile(input);
+    expect(input).toEqual({ generatedAt: 'x', keep: 1 });
+  });
+});
+
+describe('byte artifacts', () => {
+  test('raw bytes hash to the published SHA-256 of the same content', () => {
+    // "abc" — FIPS 180-4 test vector, so the reuse of the project digest is pinned.
+    const rec = hashArtifact('blob', new Uint8Array([0x61, 0x62, 0x63]));
+    expect(rec.kind).toBe('bytes');
+    expect(rec.hash).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+    expect(rec.byteLength).toBe(3);
+    expect(rec.strippedFields).toEqual([]);
+  });
+
+  test('a changed byte changes the hash', () => {
+    const a = hashArtifact('blob', new Uint8Array([1, 2, 3]));
+    const b = hashArtifact('blob', new Uint8Array([1, 2, 4]));
+    expect(a.hash).not.toBe(b.hash);
+  });
+});

--- a/tests/benchmark/fixtures.test.ts
+++ b/tests/benchmark/fixtures.test.ts
@@ -1,0 +1,137 @@
+/**
+ * fixtures.test.ts — the seeded synthetic clouds the suites measure against.
+ *
+ * Two properties carry the whole reproducibility claim: the same seed must
+ * produce the same bytes anywhere, and two different seeds must produce
+ * genuinely different data. A generator that quietly ignored its seed would
+ * pass every "it produced a cloud" assertion while making every reproducibility
+ * hash downstream meaningless.
+ *
+ * The third group asserts the cloud is worth analysing at all — a uniform
+ * random cube would let the DTM, contour and terrain-descriptor benchmarks run
+ * green over a surface with no science in it.
+ */
+import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  FIXTURE_LADDER,
+  CI_DEFAULT_TIER,
+  defaultLadder,
+  fullLadder,
+  generateSyntheticCloud,
+  groundElevationAt,
+} from '../../benchmarks/fixtures/syntheticCloud';
+
+/** The raw bytes behind a cloud's positions — the strictest identity check. */
+function bytesOf(positions: Float32Array): Uint8Array {
+  return new Uint8Array(positions.buffer, positions.byteOffset, positions.byteLength);
+}
+
+describe('the seeded synthetic cloud', () => {
+  test('the same seed and size produce byte-identical point data', () => {
+    const a = generateSyntheticCloud({ seed: 42, pointCount: 5_000 });
+    const b = generateSyntheticCloud({ seed: 42, pointCount: 5_000 });
+    // Byte equality, not value equality: a float comparison would pass on two
+    // arrays that differ only in a NaN payload or a -0, both of which change
+    // the artifact hash the reproducibility suite computes.
+    expect(bytesOf(a.positions)).toEqual(bytesOf(b.positions));
+    expect(a.bounds).toEqual(b.bounds);
+    expect(a.datasetId).toBe(b.datasetId);
+  });
+
+  test('different seeds produce different point data', () => {
+    const a = generateSyntheticCloud({ seed: 1, pointCount: 5_000 });
+    const b = generateSyntheticCloud({ seed: 2, pointCount: 5_000 });
+    expect(bytesOf(a.positions)).not.toEqual(bytesOf(b.positions));
+    expect(a.datasetId).not.toBe(b.datasetId);
+    // Same landscape, different sampling: the declared extent is a function of
+    // the point count alone, so a seed change must move the POINTS, not the
+    // tile. Without this a "different seed" could be passing merely because it
+    // resized the world.
+    expect(a.extentM).toBe(b.extentM);
+  });
+
+  test('declares the count and bounds a driver hands to the pipeline', () => {
+    const cloud = generateSyntheticCloud({ seed: 7, pointCount: 4_000 });
+    expect(cloud.pointCount).toBe(4_000);
+    expect(cloud.positions.length).toBe(4_000 * 3);
+    expect(cloud.groundPointCount + cloud.aboveGroundPointCount).toBe(4_000);
+    // The declared bounds must be the real extremes of the emitted points —
+    // a driver passes them straight to the pipeline's grid, so a declared box
+    // that does not contain the data produces a silently clipped raster.
+    let minX = Infinity, minY = Infinity, minZ = Infinity;
+    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+    for (let i = 0; i < cloud.pointCount; i++) {
+      const x = cloud.positions[i * 3];
+      const y = cloud.positions[i * 3 + 1];
+      const z = cloud.positions[i * 3 + 2];
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+      if (z > maxZ) maxZ = z;
+    }
+    expect(cloud.bounds).toEqual({ minX, minY, minZ, maxX, maxY, maxZ });
+  });
+
+  test('has real relief and vertical structure, not a flat plane or a uniform cube', () => {
+    const cloud = generateSyntheticCloud({ seed: 3, pointCount: 20_000 });
+    const relief = cloud.bounds.maxZ - cloud.bounds.minZ;
+    expect(relief).toBeGreaterThan(1);
+
+    // The ground surface itself must vary far beyond the noise floor, or the
+    // DTM/contour/descriptor benchmarks are measuring noise. Sample the
+    // analytic surface on a coarse lattice rather than the returns, so the
+    // check is about the SURFACE and not about where points happened to land.
+    const zs: number[] = [];
+    for (let i = 0; i <= 12; i++) {
+      for (let j = 0; j <= 12; j++) {
+        zs.push(groundElevationAt(cloud, (i / 12) * cloud.extentM, (j / 12) * cloud.extentM));
+      }
+    }
+    const groundRelief = Math.max(...zs) - Math.min(...zs);
+    expect(groundRelief).toBeGreaterThan(cloud.noiseHalfWidthM * 20);
+
+    // …and it must not be a single tilted plane: subtracting a best-fit plane
+    // has to leave a substantial residual, which is what a DTM, contour and
+    // TPI/VRM pass actually have to resolve.
+    const mid = zs[Math.floor(zs.length / 2)];
+    const nonPlanar = zs.filter((z) => Math.abs(z - mid) > groundRelief * 0.1).length;
+    expect(nonPlanar).toBeGreaterThan(zs.length / 4);
+
+    // Above-ground structure exists, so the ground filter has something to do.
+    expect(cloud.aboveGroundPointCount).toBeGreaterThan(0);
+    expect(cloud.groundPointCount).toBeGreaterThan(cloud.aboveGroundPointCount);
+  });
+
+  test('the size ladder covers 100k…5M and keeps the large tiers opt-in', () => {
+    expect(FIXTURE_LADDER.map((t) => t.pointCount)).toEqual([
+      100_000, 250_000, 500_000, 1_000_000, 2_000_000, 5_000_000,
+    ]);
+    expect(fullLadder()).toHaveLength(6);
+    // Default (CI) run: only the tiers that finish quickly.
+    expect(defaultLadder().every((t) => !t.optIn)).toBe(true);
+    expect(defaultLadder().map((t) => t.pointCount)).toEqual([100_000, 250_000, 500_000]);
+    expect(CI_DEFAULT_TIER.pointCount).toBe(100_000);
+    // Ladder ids are what a report keys a scaling curve off, so they must be
+    // unique and stable.
+    expect(new Set(FIXTURE_LADDER.map((t) => t.id)).size).toBe(FIXTURE_LADDER.length);
+  });
+
+  test('never reaches for Math.random or the wall clock', () => {
+    // A source guard, not a behavioural one: a single Math.random() call would
+    // still produce a plausible cloud and would only surface as an
+    // unreproducible hash weeks later, in a suite that has no way to say why.
+    const file = fileURLToPath(
+      new URL('../../benchmarks/fixtures/syntheticCloud.ts', import.meta.url),
+    );
+    const code = readFileSync(file, 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|\s)\/\/[^\n]*/g, '$1');
+    expect(code).not.toMatch(/Math\.random\s*\(/);
+    expect(code).not.toMatch(/Date\.now\s*\(/);
+    expect(code).not.toMatch(/new Date\s*\(/);
+  });
+});

--- a/tests/benchmark/fixtures.test.ts
+++ b/tests/benchmark/fixtures.test.ts
@@ -10,10 +10,12 @@
  * The third group asserts the cloud is worth analysing at all — a uniform
  * random cube would let the DTM, contour and terrain-descriptor benchmarks run
  * green over a surface with no science in it.
+ *
+ * The clock/random source guard for this module lives in `sourceGuards.test.ts`,
+ * which walks all of `benchmarks/` so a module added later is covered by
+ * default rather than by someone remembering to copy the check.
  */
 import { describe, test, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import {
   FIXTURE_LADDER,
   CI_DEFAULT_TIER,
@@ -111,27 +113,15 @@ describe('the seeded synthetic cloud', () => {
       100_000, 250_000, 500_000, 1_000_000, 2_000_000, 5_000_000,
     ]);
     expect(fullLadder()).toHaveLength(6);
-    // Default (CI) run: only the tiers that finish quickly.
-    expect(defaultLadder().every((t) => !t.optIn)).toBe(true);
+    // Default (CI) run: only the tiers that finish quickly. Pinned as an
+    // explicit list — asserting `every(t => !t.optIn)` would only restate the
+    // filter `defaultLadder` is defined as, and would still pass if every tier
+    // were marked opt-in and the default run measured nothing at all.
     expect(defaultLadder().map((t) => t.pointCount)).toEqual([100_000, 250_000, 500_000]);
+    expect(FIXTURE_LADDER.filter((t) => t.optIn).map((t) => t.id)).toEqual(['1m', '2m', '5m']);
     expect(CI_DEFAULT_TIER.pointCount).toBe(100_000);
     // Ladder ids are what a report keys a scaling curve off, so they must be
     // unique and stable.
     expect(new Set(FIXTURE_LADDER.map((t) => t.id)).size).toBe(FIXTURE_LADDER.length);
-  });
-
-  test('never reaches for Math.random or the wall clock', () => {
-    // A source guard, not a behavioural one: a single Math.random() call would
-    // still produce a plausible cloud and would only surface as an
-    // unreproducible hash weeks later, in a suite that has no way to say why.
-    const file = fileURLToPath(
-      new URL('../../benchmarks/fixtures/syntheticCloud.ts', import.meta.url),
-    );
-    const code = readFileSync(file, 'utf8')
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/(^|\s)\/\/[^\n]*/g, '$1');
-    expect(code).not.toMatch(/Math\.random\s*\(/);
-    expect(code).not.toMatch(/Date\.now\s*\(/);
-    expect(code).not.toMatch(/new Date\s*\(/);
   });
 });

--- a/tests/benchmark/nodeDigest.test.ts
+++ b/tests/benchmark/nodeDigest.test.ts
@@ -1,0 +1,52 @@
+/**
+ * nodeDigest.test.ts — which digest actually ran.
+ *
+ * The two real implementations agree bit for bit, which is the guarantee but
+ * also the reason no ordinary assertion can tell them apart: a downgrade to the
+ * 20x-slower portable path produces the identical hash and surfaces nothing.
+ * So this file mocks `node:crypto` to return a sentinel, making the choice
+ * observable, and pins it. Kept separate from `runtime.test.ts` because the
+ * mock is file-wide and the agreement tests there need the real digest.
+ */
+import { describe, test, expect, vi } from 'vitest';
+
+const SENTINEL = '1'.repeat(64);
+
+vi.mock('node:crypto', () => ({
+  createHash: () => ({ update: () => ({ digest: () => SENTINEL }) }),
+}));
+
+const { hashArtifactNode, nodeSha256Hex } = await import('../../benchmarks/framework/node');
+
+const BYTES = new Uint8Array([1, 2, 3, 4]);
+
+describe('the Node digest is the one that runs', () => {
+  test('the mock is wired, so the sentinel really does mean node:crypto', () => {
+    expect(nodeSha256Hex(BYTES)).toBe(SENTINEL);
+  });
+
+  test('hashArtifactNode uses it when no options are passed', () => {
+    expect(hashArtifactNode('raster', BYTES).hash).toBe(SENTINEL);
+  });
+
+  test('an options bag with an ABSENT digest still uses it', () => {
+    expect(hashArtifactNode('raster', BYTES, {}).hash).toBe(SENTINEL);
+  });
+
+  test('an options bag with an EXPLICIT undefined digest still uses it', () => {
+    // `{ digest: nodeSha256Hex, ...options }` let an undefined field clobber the
+    // default, so `hashArtifactNode(name, value, { digest: opts.digest })` with
+    // an optional field — ordinary code — silently fell back to the portable
+    // implementation: same hash, 20x the time, nothing to see in the report.
+    expect(hashArtifactNode('raster', BYTES, { digest: undefined }).hash).toBe(SENTINEL);
+  });
+
+  test('an explicit digest still wins', () => {
+    const other = '2'.repeat(64);
+    expect(hashArtifactNode('raster', BYTES, { digest: () => other }).hash).toBe(other);
+  });
+
+  test('the JSON path takes the same digest', () => {
+    expect(hashArtifactNode('metrics', { n: 1 }, { digest: undefined }).hash).toBe(SENTINEL);
+  });
+});

--- a/tests/benchmark/pipelineDriver.test.ts
+++ b/tests/benchmark/pipelineDriver.test.ts
@@ -2,29 +2,37 @@
  * pipelineDriver.test.ts — the driver that runs OLV's real science pipeline.
  *
  * The point of the driver is that a benchmark measures the APPLICATION. So the
- * load-bearing test here is the last one: the surface and contours the driver
- * produces must be identical to what `analyseContours` — the entry point the
- * AnalysePanel and the contour worker call — produces from the same points. If
- * someone ever reimplements a stage inside the benchmark, that equality is what
+ * load-bearing test here is the drift guard: the raster grid, surface, contours
+ * and complexity the driver produces must be identical to what
+ * `analyseContours` — the entry point the AnalysePanel and the contour worker
+ * call — produces from the same points. If someone ever reimplements a stage
+ * inside the benchmark, or drifts one of its parameters, that equality is what
  * breaks, and it breaks loudly instead of drifting quietly for a release.
  *
  * The rest pin the reporting contract the three suites key off: one result per
- * named stage, a failing stage recorded rather than fatal, browser-only stages
- * present and honestly unmeasurable, and artifacts that hash.
+ * named stage, a failing stage recorded rather than fatal (including a failure
+ * while converting an artifact), browser-only stages present and honestly
+ * unmeasurable, a total that cannot double-count, and artifacts that hash.
+ *
+ * Clock/random/runtime-neutrality guards for this module live in
+ * `sourceGuards.test.ts`, which walks all of `benchmarks/`.
  */
 import { describe, test, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import {
   runOlvPipeline,
-  toHashable,
+  pipelineDurationMs,
+  scienceScopedArtifacts,
+  ARTIFACT_SCOPE,
   BENCHMARK_AGGREGATION,
-  NODE_STAGES,
   BROWSER_ONLY_STAGES,
+  NODE_STAGES,
+  PIPELINE_ARTIFACTS,
   PIPELINE_STAGES,
+  STAGE_ROLE,
+  type PipelineArtifactName,
 } from '../../benchmarks/pipeline/runPipeline';
 import { generateSyntheticCloud } from '../../benchmarks/fixtures/syntheticCloud';
-import { isMeasured, isUnavailable, type StageResult } from '../../benchmarks/framework';
+import { isMeasured, isUnavailable, toHashable, type StageResult } from '../../benchmarks/framework';
 import { hashArtifactNode } from '../../benchmarks/framework/node';
 import { analyseContours, computeTerrainCore } from '../../src/terrain/contour/analyseContours';
 
@@ -39,11 +47,15 @@ const stageNamed = (stages: readonly StageResult[], name: string): StageResult =
   if (!found) throw new Error(`no stage named ${name}`);
   return found;
 };
+const artifactEntries = (r: typeof run): Array<[PipelineArtifactName, unknown]> =>
+  Object.entries(r.artifacts) as Array<[PipelineArtifactName, unknown]>;
 
 describe('the OLV pipeline driver', () => {
   test('records one StageResult per named stage, in the declared order', () => {
     expect(run.stages.map((s) => s.name)).toEqual([...PIPELINE_STAGES]);
-    expect(PIPELINE_STAGES).toEqual([...NODE_STAGES, ...BROWSER_ONLY_STAGES]);
+    // The Node stages are the ones a report can put a number against, and the
+    // suites hard-code these names; the browser ones come last so the measured
+    // rows read as a sequence.
     expect(NODE_STAGES).toEqual([
       'generate',
       'rasterize',
@@ -53,6 +65,8 @@ describe('the OLV pipeline driver', () => {
       'scientificRecord',
       'manifest',
     ]);
+    expect(BROWSER_ONLY_STAGES).toEqual(['gpuUpload', 'renderReady', 'fps', 'timeToInteraction']);
+    expect(new Set(PIPELINE_STAGES).size).toBe(PIPELINE_STAGES.length);
   });
 
   test('every Node stage completes and carries a measured duration and peak memory', () => {
@@ -85,7 +99,52 @@ describe('the OLV pipeline driver', () => {
         expect(stage.duration.reason.length).toBeGreaterThan(20);
         expect(stage.duration.reason).toMatch(/node|browser|gpu|renderer|frame|paint/i);
       }
+      expect(STAGE_ROLE[name]).toBe('declared');
     }
+  });
+
+  test('the run total sums the disjoint stages only, never the whole column', () => {
+    // `rasterize` and `descriptors` are leaves `dtm` runs again internally, so
+    // adding the column overstates the run. The correct answer has to be a
+    // function, because a comment does not survive a reporter author.
+    expect(Object.keys(STAGE_ROLE).sort()).toEqual([...PIPELINE_STAGES].sort());
+    expect(STAGE_ROLE.rasterize).toBe('isolated');
+    expect(STAGE_ROLE.descriptors).toBe('isolated');
+
+    const total = pipelineDurationMs(run.stages);
+    expect(total).not.toBeNull();
+    const wholeColumn = run.stages.reduce(
+      (n, s) => n + (s.duration.status === 'measured' ? s.duration.value : 0),
+      0,
+    );
+    const isolated = (['rasterize', 'descriptors'] as const).reduce((n, name) => {
+      const d = stageNamed(run.stages, name).duration;
+      return n + (d.status === 'measured' ? d.value : 0);
+    }, 0);
+    expect(isolated).toBeGreaterThan(0);
+    expect(total).toBeCloseTo(wholeColumn - isolated, 6);
+    expect(run.metrics.runDurationMs).toMatchObject({ status: 'measured', value: total });
+  });
+
+  test('a run can opt out of the isolated leaves without losing their rows', () => {
+    const lean = runOlvPipeline({ seed: SEED, pointCount: POINTS, isolateLeaves: false });
+    // The rows survive — a silently shorter stage list is exactly what the
+    // browser-stage rule exists to forbid — but they carry no number and say
+    // why, and the leaf artifacts are simply absent.
+    expect(lean.stages.map((s) => s.name)).toEqual([...PIPELINE_STAGES]);
+    for (const name of ['rasterize', 'descriptors'] as const) {
+      const stage = stageNamed(lean.stages, name);
+      expect(stage.status, name).toBe('ok');
+      expect(isUnavailable(stage.duration), name).toBe(true);
+      if (isUnavailable(stage.duration)) {
+        expect(stage.duration.reason).toMatch(/isolateLeaves/);
+      }
+    }
+    expect(lean.artifacts.rasterSummary).toBeUndefined();
+    expect(lean.artifacts.descriptors).toBeUndefined();
+    // The pipeline half is untouched, so the surface is still produced.
+    expect(lean.artifacts.dtmSummary).toBeDefined();
+    expect(pipelineDurationMs(lean.stages)).not.toBeNull();
   });
 
   test('an injected stage failure is recorded and the later stages still run', () => {
@@ -115,6 +174,34 @@ describe('the OLV pipeline driver', () => {
     expect(faulted.artifacts.contours).toBeDefined();
   });
 
+  test('a failure while converting an artifact costs that stage only', () => {
+    // The conversion runs INSIDE the stage body, and the stage's product is
+    // captured before it. Built the other way round — convert after the stage
+    // returns — one unconvertible application field (a Date, a Map) would throw
+    // outside every try/catch and take the whole run down, which is precisely
+    // what a per-stage failure contract exists to prevent.
+    const faulted = runOlvPipeline({
+      seed: SEED,
+      pointCount: POINTS,
+      artifactFaults: { contours: 'injected conversion explosion' },
+    });
+    expect(faulted.stages.map((s) => s.name)).toEqual([...PIPELINE_STAGES]);
+
+    const contours = stageNamed(faulted.stages, 'contours');
+    expect(contours.status).toBe('failed');
+    if (contours.status === 'failed') {
+      expect(contours.error).toContain('injected conversion explosion');
+    }
+    expect(faulted.artifacts.contours).toBeUndefined();
+    expect(faulted.artifacts.contourFeatures).toBeUndefined();
+    // …and the stages that consume the PRODUCT, not the artifact, are fine.
+    for (const later of ['scientificRecord', 'manifest'] as const) {
+      expect(stageNamed(faulted.stages, later).status, later).toBe('ok');
+    }
+    expect(faulted.artifacts.processingManifest).toBeDefined();
+    expect(faulted.result).not.toBeNull();
+  });
+
   test('a failure upstream leaves the dependent stages failed, not missing', () => {
     const faulted = runOlvPipeline({
       seed: SEED,
@@ -136,51 +223,106 @@ describe('the OLV pipeline driver', () => {
     }
     // The stages that DID complete are still reported as such.
     expect(stageNamed(faulted.stages, 'rasterize').status).toBe('ok');
+    // …and the run has no total, rather than a total missing a term.
+    expect(pipelineDurationMs(faulted.stages)).toBeNull();
   });
 
-  test('every artifact hashes without throwing, and re-hashing the same run agrees', () => {
-    const names = Object.keys(run.artifacts);
-    // The pipeline produced real science, so the artifact set is not empty.
-    expect(names).toEqual(
-      expect.arrayContaining([
-        'fixture',
-        'rasterSummary',
-        'dtmSummary',
-        'dtmSurface',
-        'descriptors',
-        'contours',
-        'contourFeatures',
-        'scientificRecord',
-        'processingManifest',
-      ]),
-    );
-    for (const name of names) {
-      const first = hashArtifactNode(name, run.artifacts[name]);
-      const second = hashArtifactNode(name, run.artifacts[name]);
+  test('every artifact is declared, scoped, hashes without throwing, and re-hashes the same', () => {
+    const produced = artifactEntries(run).map(([name]) => name);
+    // A complete run produces every declared artifact — so the name list is a
+    // contract a suite can compile against, not a hopeful superset.
+    expect([...produced].sort()).toEqual([...PIPELINE_ARTIFACTS].sort());
+
+    for (const [name, value] of artifactEntries(run)) {
+      expect(ARTIFACT_SCOPE[name], name).toBeDefined();
+      const first = hashArtifactNode(name, value);
+      const second = hashArtifactNode(name, value);
       expect(first.hash, name).toBe(second.hash);
       expect(first.hash, name).toMatch(/^[0-9a-f]{64}$/);
     }
+    // The grids travel as bytes: converting them cost three full copies each,
+    // and the top of the size ladder would have been gigabytes of transient.
+    for (const name of ['pointBytes', 'dtmZBytes', 'dtmCoverageBytes'] as const) {
+      expect(hashArtifactNode(name, run.artifacts[name]).kind, name).toBe('bytes');
+    }
+  });
+
+  test('the build-scoped artifacts are the only ones a cross-machine run must skip', () => {
+    // The record embeds the build identity and the manifest chains from it, so
+    // both track the git commit and the runner's Node version. Marking them is
+    // what stops a cross-machine reproducibility check going red on a green
+    // pipeline; the science inside the record stays comparable through
+    // `scientificRecordContent`, which drops build and timestamp.
+    const buildScoped = PIPELINE_ARTIFACTS.filter((n) => ARTIFACT_SCOPE[n] === 'build');
+    expect([...buildScoped]).toEqual(['scientificRecord', 'processingManifest']);
+    expect(scienceScopedArtifacts()).not.toContain('scientificRecord');
+    expect(scienceScopedArtifacts()).toContain('scientificRecordContent');
+
+    const content = run.artifacts.scientificRecordContent as Record<string, unknown>;
+    expect(content.build).toBeUndefined();
+    expect(content.generatedAt).toBeUndefined();
+    // The app's own science-only fingerprint survives, which is what makes the
+    // record's identity checkable at all across machines.
+    expect(typeof content.contentHash).toBe('string');
+    expect(content.summary).toBeDefined();
+    expect(content.methods).toBeDefined();
   });
 
   test('two runs of the same seed produce the same artifact hashes', () => {
     const again = runOlvPipeline({ seed: SEED, pointCount: POINTS });
-    for (const name of Object.keys(run.artifacts)) {
+    for (const [name, value] of artifactEntries(run)) {
       expect(hashArtifactNode(name, again.artifacts[name]).hash, name).toBe(
-        hashArtifactNode(name, run.artifacts[name]).hash,
+        hashArtifactNode(name, value).hash,
       );
     }
   });
 
-  test('drives the real application cores — the surface matches analyseContours', () => {
+  test('drives the real application cores — raster, surface and contours match analyseContours', () => {
     // The drift guard. The driver stages the app's own two halves
     // (computeTerrainCore → contoursFromCore); `analyseContours` is defined as
     // the composition of exactly those two. If a future edit reimplements any
-    // of it inside the benchmark, these arrays stop matching.
+    // of it inside the benchmark, these stop matching.
     const cloud = generateSyntheticCloud({ seed: SEED, pointCount: POINTS });
     const expected = analyseContours(cloud.positions, run.analysisParams);
 
     expect(run.result).not.toBeNull();
     const actual = run.result!;
+
+    // The isolated rasterize stage runs the same two leaves with the same
+    // resolved parameters, so its grid must be the grid the core built. Without
+    // this the stage was free to drift its origin, its aggregation or its input
+    // and nothing would have noticed.
+    const rs = run.artifacts.rasterSummary as Record<string, number>;
+    expect(rs.cols).toBe(expected.dtm.cols);
+    expect(rs.rows).toBe(expected.dtm.rows);
+    expect(rs.originH1).toBe(expected.dtm.originH1);
+    expect(rs.originH2).toBe(expected.dtm.originH2);
+    expect(rs.cellSizeM).toBe(expected.dtm.cellSizeM);
+    expect(rs.sourcePointCount).toBe(expected.dtm.sourcePointCount);
+    expect(rs.analyzedPointCount).toBe(expected.dtm.analyzedPointCount);
+
+    // Geometry alone cannot catch a leaf that aggregated its cells differently
+    // from the core — every field above is identical under 'mean'. The values
+    // can: `buildDtmGrid` keeps a measured cell's height verbatim, so on this
+    // fixture, where the despike pass removes nothing (asserted, so a future
+    // fixture that does trip it says why rather than failing mysteriously),
+    // every filled cell must carry the identical height in the delivered DTM.
+    expect(expected.warnings.filter((w) => /outlier ground cell/.test(w))).toEqual([]);
+    // Reinterpret the bytes, not copy them element-wise: `new Float32Array(u8)`
+    // would read each BYTE as a float and compare nonsense that happens to be
+    // stable across runs.
+    const rzb = run.artifacts.rasterZBytes as Uint8Array;
+    const rasterZ = new Float32Array(rzb.buffer, rzb.byteOffset, rzb.byteLength / 4);
+    const mismatched: number[] = [];
+    let filled = 0;
+    for (let i = 0; i < expected.dtm.counts.length; i++) {
+      if (expected.dtm.counts[i] === 0) continue;
+      filled++;
+      if (rasterZ[i] !== expected.dtm.z[i]) mismatched.push(i);
+    }
+    expect(filled).toBeGreaterThan(100);
+    expect(mismatched).toEqual([]);
+
     expect(Array.from(actual.dtm.z)).toEqual(Array.from(expected.dtm.z));
     expect(Array.from(actual.dtm.confidence)).toEqual(Array.from(expected.dtm.confidence));
     expect(Array.from(actual.dtm.coverage)).toEqual(Array.from(expected.dtm.coverage));
@@ -205,27 +347,10 @@ describe('the OLV pipeline driver', () => {
       pointCount: POINTS,
       faults: { dtm: 'injected core explosion' },
     });
-    expect(faulted.metrics.analysisDurationMs.status).toBe('unavailable');
-    expect(faulted.metrics.pointsPerSecond.status).toBe('unavailable');
-    expect(faulted.metrics.pointsPerSecond.value).toBeNull();
-  });
-
-  test('the driver never reaches for Math.random or the wall clock', () => {
-    // Both would poison an artifact hash, and neither would fail loudly: the
-    // run would look fine and the reproducibility check would simply never
-    // match again. Same guard the framework holds itself to.
-    const file = fileURLToPath(
-      new URL('../../benchmarks/pipeline/runPipeline.ts', import.meta.url),
-    );
-    const code = readFileSync(file, 'utf8')
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/(^|\s)\/\/[^\n]*/g, '$1');
-    expect(code).not.toMatch(/Math\.random\s*\(/);
-    expect(code).not.toMatch(/Date\.now\s*\(/);
-    expect(code).not.toMatch(/new Date\s*\(/);
-    // …and it stays runtime-neutral, so a browser suite can reuse it to fill
-    // in the four stages Node cannot measure.
-    expect(code).not.toMatch(/['"]node:/);
+    for (const name of ['analysisDurationMs', 'runDurationMs', 'pointsPerSecond'] as const) {
+      expect(faulted.metrics[name].status, name).toBe('unavailable');
+      expect(faulted.metrics[name].value, name).toBeNull();
+    }
   });
 
   test('the declared aggregation is still the one the live pipeline picks', () => {

--- a/tests/benchmark/pipelineDriver.test.ts
+++ b/tests/benchmark/pipelineDriver.test.ts
@@ -1,0 +1,256 @@
+/**
+ * pipelineDriver.test.ts — the driver that runs OLV's real science pipeline.
+ *
+ * The point of the driver is that a benchmark measures the APPLICATION. So the
+ * load-bearing test here is the last one: the surface and contours the driver
+ * produces must be identical to what `analyseContours` — the entry point the
+ * AnalysePanel and the contour worker call — produces from the same points. If
+ * someone ever reimplements a stage inside the benchmark, that equality is what
+ * breaks, and it breaks loudly instead of drifting quietly for a release.
+ *
+ * The rest pin the reporting contract the three suites key off: one result per
+ * named stage, a failing stage recorded rather than fatal, browser-only stages
+ * present and honestly unmeasurable, and artifacts that hash.
+ */
+import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  runOlvPipeline,
+  toHashable,
+  BENCHMARK_AGGREGATION,
+  NODE_STAGES,
+  BROWSER_ONLY_STAGES,
+  PIPELINE_STAGES,
+} from '../../benchmarks/pipeline/runPipeline';
+import { generateSyntheticCloud } from '../../benchmarks/fixtures/syntheticCloud';
+import { isMeasured, isUnavailable, type StageResult } from '../../benchmarks/framework';
+import { hashArtifactNode } from '../../benchmarks/framework/node';
+import { analyseContours, computeTerrainCore } from '../../src/terrain/contour/analyseContours';
+
+/** Small enough that the whole file stays inside the unit-suite budget. */
+const SEED = 11;
+const POINTS = 4_000;
+
+const run = runOlvPipeline({ seed: SEED, pointCount: POINTS });
+
+const stageNamed = (stages: readonly StageResult[], name: string): StageResult => {
+  const found = stages.find((s) => s.name === name);
+  if (!found) throw new Error(`no stage named ${name}`);
+  return found;
+};
+
+describe('the OLV pipeline driver', () => {
+  test('records one StageResult per named stage, in the declared order', () => {
+    expect(run.stages.map((s) => s.name)).toEqual([...PIPELINE_STAGES]);
+    expect(PIPELINE_STAGES).toEqual([...NODE_STAGES, ...BROWSER_ONLY_STAGES]);
+    expect(NODE_STAGES).toEqual([
+      'generate',
+      'rasterize',
+      'dtm',
+      'descriptors',
+      'contours',
+      'scientificRecord',
+      'manifest',
+    ]);
+  });
+
+  test('every Node stage completes and carries a measured duration and peak memory', () => {
+    for (const name of NODE_STAGES) {
+      const stage = stageNamed(run.stages, name);
+      expect(stage.status, `${name}: ${stage.status === 'failed' ? stage.error : ''}`).toBe('ok');
+      expect(isMeasured(stage.duration), name).toBe(true);
+      if (isMeasured(stage.duration)) {
+        expect(stage.duration.unit).toBe('ms');
+        expect(stage.duration.runtime).toBe('node');
+        expect(stage.duration.value).toBeGreaterThanOrEqual(0);
+      }
+      expect(stage.peakMemory.runtime, name).toBe('node');
+    }
+  });
+
+  test('browser-only stages are present and unavailable with a reason, never zero', () => {
+    // Omitting them would make a workflow report read as a complete pipeline
+    // when a third of it was never attempted; emitting 0 or an estimate would
+    // be worse still. Both failure modes are what this asserts against.
+    expect(BROWSER_ONLY_STAGES.length).toBeGreaterThan(0);
+    for (const name of BROWSER_ONLY_STAGES) {
+      const stage = stageNamed(run.stages, name);
+      expect(isUnavailable(stage.duration), name).toBe(true);
+      expect(isUnavailable(stage.peakMemory), name).toBe(true);
+      if (isUnavailable(stage.duration)) {
+        expect(stage.duration.value).toBeNull();
+        expect(stage.duration.runtime).toBe('browser');
+        // The reason must name the runtime limitation, not just say "n/a".
+        expect(stage.duration.reason.length).toBeGreaterThan(20);
+        expect(stage.duration.reason).toMatch(/node|browser|gpu|renderer|frame|paint/i);
+      }
+    }
+  });
+
+  test('an injected stage failure is recorded and the later stages still run', () => {
+    const faulted = runOlvPipeline({
+      seed: SEED,
+      pointCount: POINTS,
+      faults: { descriptors: 'injected descriptor explosion' },
+    });
+    // Every stage still has a row — a partial list would hide which stages
+    // were fine, which is the whole reason a failed stage must not abort.
+    expect(faulted.stages.map((s) => s.name)).toEqual([...PIPELINE_STAGES]);
+
+    const descriptors = stageNamed(faulted.stages, 'descriptors');
+    expect(descriptors.status).toBe('failed');
+    if (descriptors.status === 'failed') {
+      expect(descriptors.error).toContain('injected descriptor explosion');
+    }
+    // It still carries measurements: a stage that died after doing work tells
+    // a reader something, and the framework records them either way.
+    expect(descriptors.duration.status).toBe('measured');
+
+    for (const later of ['contours', 'scientificRecord', 'manifest'] as const) {
+      expect(stageNamed(faulted.stages, later).status, later).toBe('ok');
+    }
+    // The descriptor artifact is simply absent — never a fabricated stand-in.
+    expect(faulted.artifacts.descriptors).toBeUndefined();
+    expect(faulted.artifacts.contours).toBeDefined();
+  });
+
+  test('a failure upstream leaves the dependent stages failed, not missing', () => {
+    const faulted = runOlvPipeline({
+      seed: SEED,
+      pointCount: POINTS,
+      faults: { dtm: 'injected core explosion' },
+    });
+    expect(faulted.stages.map((s) => s.name)).toEqual([...PIPELINE_STAGES]);
+    expect(stageNamed(faulted.stages, 'dtm').status).toBe('failed');
+    for (const dependent of ['descriptors', 'contours', 'scientificRecord', 'manifest'] as const) {
+      const stage = stageNamed(faulted.stages, dependent);
+      expect(stage.status, dependent).toBe('failed');
+      // Each one names the prerequisite it was missing, so a reader can walk
+      // the chain back to the stage that actually broke.
+      if (stage.status === 'failed') expect(stage.error, dependent).toMatch(/did not produce/);
+    }
+    for (const direct of ['descriptors', 'contours'] as const) {
+      const stage = stageNamed(faulted.stages, direct);
+      if (stage.status === 'failed') expect(stage.error, direct).toMatch(/dtm/);
+    }
+    // The stages that DID complete are still reported as such.
+    expect(stageNamed(faulted.stages, 'rasterize').status).toBe('ok');
+  });
+
+  test('every artifact hashes without throwing, and re-hashing the same run agrees', () => {
+    const names = Object.keys(run.artifacts);
+    // The pipeline produced real science, so the artifact set is not empty.
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'fixture',
+        'rasterSummary',
+        'dtmSummary',
+        'dtmSurface',
+        'descriptors',
+        'contours',
+        'contourFeatures',
+        'scientificRecord',
+        'processingManifest',
+      ]),
+    );
+    for (const name of names) {
+      const first = hashArtifactNode(name, run.artifacts[name]);
+      const second = hashArtifactNode(name, run.artifacts[name]);
+      expect(first.hash, name).toBe(second.hash);
+      expect(first.hash, name).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  test('two runs of the same seed produce the same artifact hashes', () => {
+    const again = runOlvPipeline({ seed: SEED, pointCount: POINTS });
+    for (const name of Object.keys(run.artifacts)) {
+      expect(hashArtifactNode(name, again.artifacts[name]).hash, name).toBe(
+        hashArtifactNode(name, run.artifacts[name]).hash,
+      );
+    }
+  });
+
+  test('drives the real application cores — the surface matches analyseContours', () => {
+    // The drift guard. The driver stages the app's own two halves
+    // (computeTerrainCore → contoursFromCore); `analyseContours` is defined as
+    // the composition of exactly those two. If a future edit reimplements any
+    // of it inside the benchmark, these arrays stop matching.
+    const cloud = generateSyntheticCloud({ seed: SEED, pointCount: POINTS });
+    const expected = analyseContours(cloud.positions, run.analysisParams);
+
+    expect(run.result).not.toBeNull();
+    const actual = run.result!;
+    expect(Array.from(actual.dtm.z)).toEqual(Array.from(expected.dtm.z));
+    expect(Array.from(actual.dtm.confidence)).toEqual(Array.from(expected.dtm.confidence));
+    expect(Array.from(actual.dtm.coverage)).toEqual(Array.from(expected.dtm.coverage));
+    expect(actual.validation.rmse).toBe(expected.validation.rmse);
+    expect(actual.intervalM).toBe(expected.intervalM);
+    expect(actual.tally).toEqual(expected.tally);
+    expect(actual.model.features.length).toBe(expected.model.features.length);
+    // And the descriptor stage re-runs the app's own complexity summary over
+    // the core's cached Horn grids, so it must agree with the core's own.
+    expect(run.artifacts.descriptors).toEqual(toHashable(expected.complexity));
+  });
+
+  test('headline metrics are stated only when the stages behind them ran', () => {
+    expect(run.metrics.pointCount).toMatchObject({ status: 'measured', value: POINTS });
+    expect(run.metrics.analysisDurationMs.status).toBe('measured');
+    expect(run.metrics.pointsPerSecond.status).toBe('measured');
+
+    // With the core broken there is no analysis time, so throughput must be
+    // withheld with a reason — never a 0 that reads as "infinitely slow".
+    const faulted = runOlvPipeline({
+      seed: SEED,
+      pointCount: POINTS,
+      faults: { dtm: 'injected core explosion' },
+    });
+    expect(faulted.metrics.analysisDurationMs.status).toBe('unavailable');
+    expect(faulted.metrics.pointsPerSecond.status).toBe('unavailable');
+    expect(faulted.metrics.pointsPerSecond.value).toBeNull();
+  });
+
+  test('the driver never reaches for Math.random or the wall clock', () => {
+    // Both would poison an artifact hash, and neither would fail loudly: the
+    // run would look fine and the reproducibility check would simply never
+    // match again. Same guard the framework holds itself to.
+    const file = fileURLToPath(
+      new URL('../../benchmarks/pipeline/runPipeline.ts', import.meta.url),
+    );
+    const code = readFileSync(file, 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|\s)\/\/[^\n]*/g, '$1');
+    expect(code).not.toMatch(/Math\.random\s*\(/);
+    expect(code).not.toMatch(/Date\.now\s*\(/);
+    expect(code).not.toMatch(/new Date\s*\(/);
+    // …and it stays runtime-neutral, so a browser suite can reuse it to fill
+    // in the four stages Node cannot measure.
+    expect(code).not.toMatch(/['"]node:/);
+  });
+
+  test('the declared aggregation is still the one the live pipeline picks', () => {
+    // The driver names the per-cell aggregation explicitly, because the
+    // isolated `rasterize` stage has to match the core and the live default is
+    // private to analyseContours. This is the guard on that duplication: if the
+    // application changes what it ships, the benchmark stops silently measuring
+    // a surface the application no longer produces.
+    const cloud = generateSyntheticCloud({ seed: 2, pointCount: 1_000 });
+    const { aggregation: _declared, ...withoutAggregation } = run.analysisParams;
+    const core = computeTerrainCore(cloud.positions, withoutAggregation);
+    expect(core.aggregation).toBe(BENCHMARK_AGGREGATION);
+  });
+
+  test('the analysed cloud produced a real surface with contours on it', () => {
+    // Guards against a green suite over a degenerate fixture: a pipeline that
+    // classified nothing as ground, or found no contourable relief, would
+    // still report seven happy stages.
+    const summary = run.artifacts.dtmSummary as Record<string, unknown>;
+    expect(summary.cols as number).toBeGreaterThan(4);
+    expect(summary.rows as number).toBeGreaterThan(4);
+    const result = run.result!;
+    expect(result.dtm.sourcePointCount).toBeGreaterThan(0);
+    expect(result.intervalM).not.toBeNull();
+    expect(result.contours.levels.length).toBeGreaterThan(0);
+    expect(result.model.features.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/benchmark/reportFixture.ts
+++ b/tests/benchmark/reportFixture.ts
@@ -28,6 +28,7 @@ export function fixtureReport(): RunReport {
       nodeVersion: capturedEnv('v22.17.1'),
       gitCommitShort: capturedEnv('5f452c7'),
       gitCommitFull: capturedEnv('5f452c7000000000000000000000000000000000'),
+      gitDirty: capturedEnv('clean'),
       releaseVersion: capturedEnv('0.6.0'),
     },
     stages: [

--- a/tests/benchmark/reportFixture.ts
+++ b/tests/benchmark/reportFixture.ts
@@ -13,6 +13,7 @@ import {
   unavailable,
   type RunReport,
 } from '../../benchmarks/framework/types';
+import { RAW_BYTES_NO_STRIP_REASON } from '../../benchmarks/framework/artifacts';
 
 /** A fully-populated report: one clean stage, one failed stage, both metric statuses. */
 export function fixtureReport(): RunReport {
@@ -56,6 +57,21 @@ export function fixtureReport(): RunReport {
         fingerprint: 'deadbeef',
         byteLength: 42,
         strippedFields: ['generatedAt'],
+        volatilityStripped: true,
+      },
+      // A byte artifact too: it is the case where the strip CANNOT be applied,
+      // and every reporter has to say so rather than print an empty exclusion
+      // list that reads as "nothing volatile in here".
+      {
+        name: 'hillshade',
+        kind: 'bytes',
+        algorithm: 'sha256',
+        hash: 'b'.repeat(64),
+        fingerprint: 'feedface',
+        byteLength: 4096,
+        strippedFields: [],
+        volatilityStripped: false,
+        unstrippedReason: RAW_BYTES_NO_STRIP_REASON,
       },
     ],
     metrics: {

--- a/tests/benchmark/reportFixture.ts
+++ b/tests/benchmark/reportFixture.ts
@@ -1,0 +1,69 @@
+/**
+ * reportFixture.ts — one hand-built RunReport shared by the framework suites.
+ *
+ * Hand-built rather than produced by a real run: the reporter and schema tests
+ * must assert on FIXED content (including a stage that failed and two metrics
+ * that are unavailable for different reasons), which a live run cannot promise.
+ * Nothing here is sampled from the machine, so the suites stay deterministic.
+ */
+import {
+  BENCHMARK_SCHEMA_VERSION,
+  capturedEnv,
+  measured,
+  unavailable,
+  type RunReport,
+} from '../../benchmarks/framework/types';
+
+/** A fully-populated report: one clean stage, one failed stage, both metric statuses. */
+export function fixtureReport(): RunReport {
+  return {
+    schemaVersion: BENCHMARK_SCHEMA_VERSION,
+    suiteId: 'decode',
+    datasetId: 'synthetic-grid-1m',
+    environment: {
+      os: capturedEnv('darwin 24.0.0'),
+      cpuModel: capturedEnv('Apple M2 Pro'),
+      arch: capturedEnv('arm64'),
+      nodeVersion: capturedEnv('v22.17.1'),
+      gitCommitShort: capturedEnv('5f452c7'),
+      gitCommitFull: capturedEnv('5f452c7000000000000000000000000000000000'),
+      releaseVersion: capturedEnv('0.6.0'),
+    },
+    stages: [
+      {
+        name: 'decode',
+        duration: measured(12.5, 'ms', { runtime: 'node', deterministic: false }),
+        peakMemory: measured(1024, 'bytes', { runtime: 'node', deterministic: false }),
+        status: 'ok',
+      },
+      {
+        name: 'gpu upload',
+        duration: measured(3, 'ms', { runtime: 'node', deterministic: false }),
+        peakMemory: unavailable('process.memoryUsage is not exposed in this runtime', {
+          runtime: 'browser',
+          deterministic: false,
+        }),
+        status: 'failed',
+        error: 'no GPU adapter',
+      },
+    ],
+    artifacts: [
+      {
+        name: 'metrics',
+        kind: 'json',
+        algorithm: 'sha256',
+        hash: 'a'.repeat(64),
+        fingerprint: 'deadbeef',
+        byteLength: 42,
+        strippedFields: ['generatedAt'],
+      },
+    ],
+    metrics: {
+      pointsPerSecond: measured(1_000_000, 'points/s', { runtime: 'node', deterministic: false }),
+      gpuFrameTime: unavailable('WebGPU timestamp queries need a browser runtime', {
+        runtime: 'browser',
+        deterministic: false,
+      }),
+    },
+  };
+}

--- a/tests/benchmark/reporters.test.ts
+++ b/tests/benchmark/reporters.test.ts
@@ -12,6 +12,7 @@ import { toCsv } from '../../benchmarks/framework/reporters/csv';
 import { toMarkdown } from '../../benchmarks/framework/reporters/markdown';
 import { toHtml } from '../../benchmarks/framework/reporters/html';
 import type { RunReport } from '../../benchmarks/framework/types';
+import { RAW_BYTES_NO_STRIP_REASON } from '../../benchmarks/framework/artifacts';
 import { fixtureReport } from './reportFixture';
 
 const REPORTERS: ReadonlyArray<readonly [string, (r: RunReport) => string]> = [
@@ -59,6 +60,13 @@ describe.each(REPORTERS)('the %s reporter', (name, render) => {
   test('names the artifact and its hash', () => {
     expect(out).toContain('metrics');
     expect(out).toContain('a'.repeat(64));
+  });
+
+  test('discloses that the byte artifact was hashed with no strip applied', () => {
+    // An empty exclusion list on a raw-bytes artifact reads as "nothing
+    // volatile in here", when the truth is that nothing COULD be inspected.
+    expect(out).toContain('hillshade');
+    expect(out).toContain(RAW_BYTES_NO_STRIP_REASON);
   });
 
   test('never prints a bare dash or an empty cell where a metric belongs', () => {

--- a/tests/benchmark/reporters.test.ts
+++ b/tests/benchmark/reporters.test.ts
@@ -13,6 +13,7 @@ import { toMarkdown } from '../../benchmarks/framework/reporters/markdown';
 import { toHtml } from '../../benchmarks/framework/reporters/html';
 import type { RunReport } from '../../benchmarks/framework/types';
 import { RAW_BYTES_NO_STRIP_REASON } from '../../benchmarks/framework/artifacts';
+import { describeHashExclusions } from '../../benchmarks/framework/reporters/metricText';
 import { fixtureReport } from './reportFixture';
 
 const REPORTERS: ReadonlyArray<readonly [string, (r: RunReport) => string]> = [
@@ -76,6 +77,28 @@ describe.each(REPORTERS)('the %s reporter', (name, render) => {
     const lines = out.split('\n').filter((l) => l.includes(MEMORY_REASON));
     expect(lines.length).toBeGreaterThan(0);
     expect(name.length).toBeGreaterThan(0);
+  });
+});
+
+describe('describeHashExclusions', () => {
+  const [stripped, raw] = fixtureReport().artifacts;
+
+  test('names the excluded fields when the strip ran', () => {
+    expect(describeHashExclusions(stripped)).toBe('generatedAt');
+  });
+
+  test('says (none) when the strip ran and found nothing', () => {
+    expect(describeHashExclusions({ ...stripped, strippedFields: [] })).toBe('(none)');
+  });
+
+  test('always has a reason to give when no strip ran', () => {
+    // There is no "unexplained" case left to fall back to: the record type
+    // makes `volatilityStripped: false` without a reason a compile error, so
+    // the old 'no reason recorded' string is unreachable by construction.
+    const out = describeHashExclusions(raw);
+    expect(out).toContain('not stripped');
+    expect(out).toContain(RAW_BYTES_NO_STRIP_REASON);
+    expect(out).not.toContain('no reason recorded');
   });
 });
 

--- a/tests/benchmark/reporters.test.ts
+++ b/tests/benchmark/reporters.test.ts
@@ -1,0 +1,165 @@
+/**
+ * reporters.test.ts — every output format carries the same honest content.
+ *
+ * A reporter is where an unavailable metric is most likely to be quietly turned
+ * into a blank cell, a dash or a zero: those all read as "measured, and small".
+ * So each of the four formats is asserted to print the word "unavailable" AND
+ * the reason, and to carry the provenance a reader needs to reproduce the run.
+ */
+import { describe, test, expect } from 'vitest';
+import { toJson } from '../../benchmarks/framework/reporters/json';
+import { toCsv } from '../../benchmarks/framework/reporters/csv';
+import { toMarkdown } from '../../benchmarks/framework/reporters/markdown';
+import { toHtml } from '../../benchmarks/framework/reporters/html';
+import type { RunReport } from '../../benchmarks/framework/types';
+import { fixtureReport } from './reportFixture';
+
+const REPORTERS: ReadonlyArray<readonly [string, (r: RunReport) => string]> = [
+  ['json', toJson],
+  ['csv', toCsv],
+  ['markdown', toMarkdown],
+  ['html', toHtml],
+];
+
+const MEMORY_REASON = 'process.memoryUsage is not exposed in this runtime';
+const GPU_REASON = 'WebGPU timestamp queries need a browser runtime';
+
+describe.each(REPORTERS)('the %s reporter', (name, render) => {
+  const out = render(fixtureReport());
+
+  test('renders both unavailable metrics as unavailable, with their reason', () => {
+    expect(out.toLowerCase()).toContain('unavailable');
+    expect(out).toContain(MEMORY_REASON);
+    expect(out).toContain(GPU_REASON);
+  });
+
+  test('carries the environment, dataset, commit, release and schema version', () => {
+    expect(out).toContain('synthetic-grid-1m'); // dataset id
+    expect(out).toContain('darwin 24.0.0'); // OS
+    expect(out).toContain('Apple M2 Pro'); // CPU model
+    expect(out).toContain('arm64'); // arch
+    expect(out).toContain('v22.17.1'); // Node version
+    expect(out).toContain('5f452c7'); // git commit
+    expect(out).toContain('0.6.0'); // release version
+    expect(out).toContain('1'); // schema version
+  });
+
+  test('carries every stage name, its duration and its peak memory', () => {
+    expect(out).toContain('decode');
+    expect(out).toContain('gpu upload');
+    expect(out).toContain('12.5'); // decode duration ms
+    expect(out).toContain('1024'); // decode peak RSS bytes
+  });
+
+  test('shows a failed stage as failed, with its error', () => {
+    expect(out).toContain('failed');
+    expect(out).toContain('no GPU adapter');
+  });
+
+  test('names the artifact and its hash', () => {
+    expect(out).toContain('metrics');
+    expect(out).toContain('a'.repeat(64));
+  });
+
+  test('never prints a bare dash or an empty cell where a metric belongs', () => {
+    // A lone "-" or "" is how an unavailable metric silently becomes "0-ish" to
+    // a reader. Wherever this reporter mentions the unavailable memory metric,
+    // the reason has to be on the same line.
+    const lines = out.split('\n').filter((l) => l.includes(MEMORY_REASON));
+    expect(lines.length).toBeGreaterThan(0);
+    expect(name.length).toBeGreaterThan(0);
+  });
+});
+
+describe('the JSON reporter', () => {
+  test('round-trips to the same report', () => {
+    const report = fixtureReport();
+    expect(JSON.parse(toJson(report))).toEqual(report);
+  });
+
+  test('keeps status and reason on the unavailable metric rather than dropping the key', () => {
+    const parsed = JSON.parse(toJson(fixtureReport())) as RunReport;
+    const gpu = parsed.metrics.gpuFrameTime;
+    expect(gpu.status).toBe('unavailable');
+    expect(gpu.value).toBeNull();
+    expect('gpuFrameTime' in parsed.metrics).toBe(true);
+  });
+});
+
+describe('the CSV reporter', () => {
+  const csv = toCsv(fixtureReport());
+  const rows = csv.trim().split('\n');
+
+  test('starts with a stable header naming the honesty columns', () => {
+    expect(rows[0]).toBe('section,name,value,unit,status,reason,runtime,deterministic');
+  });
+
+  test('an unavailable row says unavailable in the value column and carries the reason', () => {
+    const row = rows.find((r) => r.startsWith('stage,gpu upload.peakMemory,'));
+    expect(row).toBeDefined();
+    const cells = row!.split(',');
+    expect(cells[2]).toBe('unavailable');
+    expect(cells[2]).not.toBe('');
+    expect(cells[2]).not.toBe('0');
+    expect(row).toContain(MEMORY_REASON);
+  });
+
+  test('quotes a value that contains a comma so the columns stay aligned', () => {
+    const report = fixtureReport();
+    const withComma: RunReport = { ...report, datasetId: 'grid,1m' };
+    expect(toCsv(withComma)).toContain('"grid,1m"');
+  });
+
+  test('every data row has the same column count as the header', () => {
+    const cols = (line: string): number => {
+      let n = 1;
+      let quoted = false;
+      for (let i = 0; i < line.length; i++) {
+        const c = line[i];
+        if (c === '"') quoted = !quoted;
+        else if (c === ',' && !quoted) n++;
+      }
+      return n;
+    };
+    const expected = cols(rows[0]);
+    for (const r of rows) expect(cols(r)).toBe(expected);
+  });
+});
+
+describe('the Markdown reporter', () => {
+  const md = toMarkdown(fixtureReport());
+
+  test('renders the unavailable metric as "unavailable — reason", never as a dash', () => {
+    expect(md).toContain(`unavailable — ${GPU_REASON}`);
+  });
+
+  test('escapes a pipe in a reason so the table does not gain a column', () => {
+    expect(toMarkdown(fixtureReport()).split('\n').filter((l) => l.startsWith('|')).length).
+      toBeGreaterThan(3);
+  });
+});
+
+describe('the HTML reporter', () => {
+  const html = toHtml(fixtureReport());
+
+  test('is self-contained: no external stylesheet, script, font or image', () => {
+    expect(html).not.toMatch(/<link\b/i);
+    expect(html).not.toMatch(/<script\b/i);
+    expect(html).not.toMatch(/@import/i);
+    expect(html).not.toMatch(/https?:\/\//i);
+    expect(html).not.toMatch(/url\(/i);
+    expect(html).toContain('<style>');
+  });
+
+  test('marks an unavailable metric with a class a reader cannot mistake for a value', () => {
+    expect(html).toContain('class="unavailable"');
+    expect(html).toContain(GPU_REASON);
+  });
+
+  test('escapes report content so a hostile dataset id cannot inject markup', () => {
+    const report: RunReport = { ...fixtureReport(), datasetId: '<img src=x onerror=alert(1)>' };
+    const out = toHtml(report);
+    expect(out).not.toContain('<img');
+    expect(out).toContain('&lt;img');
+  });
+});

--- a/tests/benchmark/reporters.test.ts
+++ b/tests/benchmark/reporters.test.ts
@@ -11,22 +11,42 @@ import { toJson } from '../../benchmarks/framework/reporters/json';
 import { toCsv } from '../../benchmarks/framework/reporters/csv';
 import { toMarkdown } from '../../benchmarks/framework/reporters/markdown';
 import { toHtml } from '../../benchmarks/framework/reporters/html';
-import type { RunReport } from '../../benchmarks/framework/types';
+import {
+  capturedEnv,
+  measured,
+  unavailable,
+  type BenchmarkEnvironment,
+  type RunReport,
+} from '../../benchmarks/framework/types';
 import { RAW_BYTES_NO_STRIP_REASON } from '../../benchmarks/framework/artifacts';
-import { describeHashExclusions } from '../../benchmarks/framework/reporters/metricText';
+import {
+  describeHashExclusions,
+  ENVIRONMENT_LABELS,
+} from '../../benchmarks/framework/reporters/metricText';
 import { fixtureReport } from './reportFixture';
 
-const REPORTERS: ReadonlyArray<readonly [string, (r: RunReport) => string]> = [
-  ['json', toJson],
-  ['csv', toCsv],
-  ['markdown', toMarkdown],
-  ['html', toHtml],
+/**
+ * Each reporter with the EXACT rendering of two facts that a `toContain` check
+ * cannot pin: the schema version (`toContain('1')` also matches `1024`) and the
+ * dataset id in a labelled position. Asserting the real shape is what makes
+ * these tests able to fail.
+ */
+const REPORTERS: ReadonlyArray<readonly [string, (r: RunReport) => string, RegExp, RegExp]> = [
+  ['json', toJson, /"schemaVersion": 1,/, /"datasetId": "synthetic-grid-1m"/],
+  ['csv', toCsv, /^run,schemaVersion,1,/m, /^run,datasetId,synthetic-grid-1m,/m],
+  ['markdown', toMarkdown, /\| schema version \| 1 \|/, /\| dataset \| synthetic-grid-1m \|/],
+  [
+    'html',
+    toHtml,
+    /<th>schema version<\/th><td>1<\/td>/,
+    /<th>dataset<\/th><td>synthetic-grid-1m<\/td>/,
+  ],
 ];
 
 const MEMORY_REASON = 'process.memoryUsage is not exposed in this runtime';
 const GPU_REASON = 'WebGPU timestamp queries need a browser runtime';
 
-describe.each(REPORTERS)('the %s reporter', (name, render) => {
+describe.each(REPORTERS)('the %s reporter', (name, render, schemaRe, datasetRe) => {
   const out = render(fixtureReport());
 
   test('renders both unavailable metrics as unavailable, with their reason', () => {
@@ -36,14 +56,29 @@ describe.each(REPORTERS)('the %s reporter', (name, render) => {
   });
 
   test('carries the environment, dataset, commit, release and schema version', () => {
-    expect(out).toContain('synthetic-grid-1m'); // dataset id
+    expect(out).toMatch(datasetRe);
+    expect(out).toMatch(schemaRe);
     expect(out).toContain('darwin 24.0.0'); // OS
     expect(out).toContain('Apple M2 Pro'); // CPU model
     expect(out).toContain('arm64'); // arch
     expect(out).toContain('v22.17.1'); // Node version
     expect(out).toContain('5f452c7'); // git commit
     expect(out).toContain('0.6.0'); // release version
-    expect(out).toContain('1'); // schema version
+  });
+
+  test('carries EVERY environment field the schema declares', () => {
+    // Two reporters used to hard-code their own field lists, so a provenance
+    // field could land in the JSON and vanish from the page a reader opens.
+    for (const key of Object.keys(ENVIRONMENT_LABELS) as (keyof BenchmarkEnvironment)[]) {
+      const field = fixtureReport().environment[key];
+      if (field.status !== 'captured') continue;
+      expect(out, key).toContain(field.value);
+    }
+  });
+
+  test('discloses whether the working tree matched the commit', () => {
+    // A commit hash with no dirty flag asserts a provenance the run may not have.
+    expect(out).toContain('clean');
   });
 
   test('carries every stage name, its duration and its peak memory', () => {
@@ -75,8 +110,23 @@ describe.each(REPORTERS)('the %s reporter', (name, render) => {
     // a reader. Wherever this reporter mentions the unavailable memory metric,
     // the reason has to be on the same line.
     const lines = out.split('\n').filter((l) => l.includes(MEMORY_REASON));
-    expect(lines.length).toBeGreaterThan(0);
-    expect(name.length).toBeGreaterThan(0);
+    expect(lines.length, name).toBeGreaterThan(0);
+  });
+
+  test('a newline in an error does not split the row it belongs to', () => {
+    // Error.message is routinely multi-line, and a raw newline ends a Markdown
+    // row mid-table. Every format has to survive it.
+    const report = fixtureReport();
+    const stages = report.stages.map((s) =>
+      s.status === 'failed' ? { ...s, error: 'line one\nline two' } : s,
+    );
+    const rendered = render({ ...report, stages });
+    expect(rendered).toContain('line one');
+    expect(rendered).toContain('line two');
+    if (name === 'markdown') {
+      expect(rendered).not.toMatch(/\| line two/);
+      expect(rendered).toContain('line one; line two');
+    }
   });
 });
 
@@ -141,6 +191,27 @@ describe('the CSV reporter', () => {
     expect(toCsv(withComma)).toContain('"grid,1m"');
   });
 
+  test('neutralises a cell a spreadsheet would run as a formula', () => {
+    const report = fixtureReport();
+    for (const payload of ['=HYPERLINK(x)', '+1+1', '@SUM(A1)', '-1+1', '\tcmd']) {
+      const rendered = toCsv({ ...report, datasetId: payload });
+      expect(rendered, payload).toContain(`"'${payload}"`);
+    }
+  });
+
+  test('a negative NUMBER is left alone, so it stays a number in the sheet', () => {
+    const report = fixtureReport();
+    const negative: RunReport = {
+      ...report,
+      metrics: {
+        drift: measured(-1.5, 'm', { runtime: 'node', deterministic: false }),
+      },
+    };
+    const row = toCsv(negative).split('\n').find((r) => r.startsWith('metric,drift,'));
+    expect(row).toContain(',-1.5,');
+    expect(row).not.toContain("'-1.5");
+  });
+
   test('every data row has the same column count as the header', () => {
     const cols = (line: string): number => {
       let n = 1;
@@ -165,8 +236,34 @@ describe('the Markdown reporter', () => {
   });
 
   test('escapes a pipe in a reason so the table does not gain a column', () => {
-    expect(toMarkdown(fixtureReport()).split('\n').filter((l) => l.startsWith('|')).length).
-      toBeGreaterThan(3);
+    // The previous version of this test rendered the unmodified fixture, which
+    // contains no pipe at all — it passed with the escaper deleted.
+    const report = fixtureReport();
+    const withPipe: RunReport = {
+      ...report,
+      metrics: {
+        ...report.metrics,
+        gpuFrameTime: unavailable('needs a | b support', {
+          runtime: 'browser',
+          deterministic: false,
+        }),
+      },
+    };
+    const rendered = toMarkdown(withPipe);
+    expect(rendered).toContain('needs a \\| b support');
+    expect(rendered).not.toContain('needs a | b support');
+  });
+
+  test('escapes a pipe in a stage name and in the dataset id too', () => {
+    const report = fixtureReport();
+    const hostile: RunReport = {
+      ...report,
+      datasetId: 'grid | v2',
+      stages: report.stages.map((s) => ({ ...s, name: `${s.name} | retry` })),
+    };
+    const rendered = toMarkdown(hostile);
+    expect(rendered).toContain('grid \\| v2');
+    expect(rendered).toContain('decode \\| retry');
   });
 });
 
@@ -187,10 +284,46 @@ describe('the HTML reporter', () => {
     expect(html).toContain(GPU_REASON);
   });
 
-  test('escapes report content so a hostile dataset id cannot inject markup', () => {
-    const report: RunReport = { ...fixtureReport(), datasetId: '<img src=x onerror=alert(1)>' };
-    const out = toHtml(report);
-    expect(out).not.toContain('<img');
-    expect(out).toContain('&lt;img');
+  test('escapes report content wherever suite-supplied text reaches the page', () => {
+    const PAYLOAD = '<img src=x onerror=alert(1)>';
+    const report = fixtureReport();
+    const [artifact, rawArtifact] = report.artifacts;
+    if (rawArtifact.volatilityStripped) throw new Error('fixture: expected a raw byte artifact');
+    const variants: ReadonlyArray<readonly [string, RunReport]> = [
+      ['datasetId', { ...report, datasetId: PAYLOAD }],
+      ['suiteId', { ...report, suiteId: PAYLOAD }],
+      ['stage name', { ...report, stages: report.stages.map((s) => ({ ...s, name: PAYLOAD })) }],
+      [
+        'stage error',
+        {
+          ...report,
+          stages: report.stages.map((s) => (s.status === 'failed' ? { ...s, error: PAYLOAD } : s)),
+        },
+      ],
+      ['artifact name', { ...report, artifacts: [{ ...artifact, name: PAYLOAD }, rawArtifact] }],
+      [
+        'unstrippedReason',
+        { ...report, artifacts: [artifact, { ...rawArtifact, unstrippedReason: PAYLOAD }] },
+      ],
+      ['metric key', { ...report, metrics: { [PAYLOAD]: report.metrics.pointsPerSecond } }],
+      [
+        'metric reason',
+        {
+          ...report,
+          metrics: {
+            gpuFrameTime: unavailable(PAYLOAD, { runtime: 'browser', deterministic: false }),
+          },
+        },
+      ],
+      [
+        'environment value',
+        { ...report, environment: { ...report.environment, cpuModel: capturedEnv(PAYLOAD) } },
+      ],
+    ];
+    for (const [where, variant] of variants) {
+      const rendered = toHtml(variant);
+      expect(rendered, where).not.toContain('<img');
+      expect(rendered, where).toContain('&lt;img');
+    }
   });
 });

--- a/tests/benchmark/runtime.test.ts
+++ b/tests/benchmark/runtime.test.ts
@@ -1,0 +1,151 @@
+/**
+ * runtime.test.ts — the three measurement sources: clock, memory, environment.
+ *
+ * These are the modules that touch the machine, so they are also the ones that
+ * would be tempted to invent a number when the runtime cannot supply one. Each
+ * is asserted to either produce a real measurement or say plainly that it could
+ * not — and `captureEnvironment` is additionally asserted never to throw, since
+ * a benchmark run must not die because `git` is missing.
+ */
+import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { startStageClock, elapsedMs, CLOCK_UNAVAILABLE_REASON } from '../../benchmarks/framework/clock';
+import { startMemorySampler, MEMORY_UNAVAILABLE_REASON } from '../../benchmarks/framework/memory';
+import { captureEnvironment } from '../../benchmarks/framework/env';
+import { isMeasured, isUnavailable, type EnvValue } from '../../benchmarks/framework/types';
+
+describe('the stage clock', () => {
+  test('measures a positive duration in ms from a monotonic source', () => {
+    const stop = startStageClock();
+    let acc = 0;
+    for (let i = 0; i < 200_000; i++) acc += i % 7;
+    const m = stop();
+    expect(acc).toBeGreaterThan(0); // keep the loop from being optimised away
+    expect(m.status).toBe('measured');
+    if (!isMeasured(m)) throw new Error('expected a measured duration');
+    expect(m.unit).toBe('ms');
+    expect(m.value).toBeGreaterThan(0);
+    expect(m.runtime).toBe('node');
+    // A duration is never reproducible run to run; the flag must say so, or a
+    // downstream table would present it as a fixed property of the software.
+    expect(m.deterministic).toBe(false);
+  });
+
+  test('is monotonic — a second reading of the same clock never goes backwards', () => {
+    const stop = startStageClock();
+    const a = stop();
+    const b = stop();
+    if (!isMeasured(a) || !isMeasured(b)) throw new Error('expected measured durations');
+    expect(b.value).toBeGreaterThanOrEqual(a.value);
+  });
+
+  test('reports unavailable, not 0, when the runtime has no monotonic clock', () => {
+    const m = elapsedMs(null, null);
+    expect(isUnavailable(m)).toBe(true);
+    if (!isUnavailable(m)) throw new Error('expected an unavailable duration');
+    expect(m.value).toBeNull();
+    expect(m.reason).toBe(CLOCK_UNAVAILABLE_REASON);
+  });
+});
+
+describe('the memory sampler', () => {
+  test('reports peak RSS in bytes across the stage', () => {
+    const sampler = startMemorySampler();
+    const hold = new Uint8Array(8 * 1024 * 1024).fill(1);
+    sampler.sample();
+    const m = sampler.stop();
+    expect(hold[0]).toBe(1); // keep the allocation alive until after the sample
+    if (!isMeasured(m)) throw new Error('expected a measured peak RSS');
+    expect(m.unit).toBe('bytes');
+    expect(m.value).toBeGreaterThan(0);
+    expect(Number.isInteger(m.value)).toBe(true);
+    expect(m.runtime).toBe('node');
+    expect(m.deterministic).toBe(false);
+  });
+
+  test('the peak is the largest sample seen, not the last one', () => {
+    const sampler = startMemorySampler({ readRss: fakeReader([100, 900, 300]) });
+    sampler.sample();
+    sampler.sample();
+    const m = sampler.stop();
+    if (!isMeasured(m)) throw new Error('expected a measured peak RSS');
+    expect(m.value).toBe(900);
+  });
+
+  test('reports unavailable with a reason when RSS cannot be read', () => {
+    const sampler = startMemorySampler({ readRss: () => null });
+    sampler.sample();
+    const m = sampler.stop();
+    expect(isUnavailable(m)).toBe(true);
+    if (!isUnavailable(m)) throw new Error('expected an unavailable peak RSS');
+    expect(m.value).toBeNull();
+    expect(m.reason).toBe(MEMORY_UNAVAILABLE_REASON);
+  });
+
+  test('a reader that throws is unavailable, not zero', () => {
+    const sampler = startMemorySampler({
+      readRss: () => {
+        throw new Error('sandboxed');
+      },
+    });
+    const m = sampler.stop();
+    expect(isUnavailable(m)).toBe(true);
+  });
+});
+
+/** A stub RSS reader returning a fixed series, then repeating the last value. */
+function fakeReader(series: readonly number[]): () => number {
+  let i = 0;
+  return () => series[Math.min(i++, series.length - 1)];
+}
+
+describe('the environment capture', () => {
+  const env = captureEnvironment();
+  const fields: ReadonlyArray<readonly [string, EnvValue]> = [
+    ['os', env.os],
+    ['cpuModel', env.cpuModel],
+    ['arch', env.arch],
+    ['nodeVersion', env.nodeVersion],
+    ['gitCommitShort', env.gitCommitShort],
+    ['gitCommitFull', env.gitCommitFull],
+    ['releaseVersion', env.releaseVersion],
+  ];
+
+  test('every field is either captured with a non-empty value or unavailable with a reason', () => {
+    for (const [name, field] of fields) {
+      if (field.status === 'captured') {
+        expect(field.value.length, name).toBeGreaterThan(0);
+      } else {
+        expect(field.value, name).toBeNull();
+        expect(field.reason.length, name).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test('captures the running Node version and architecture in this runtime', () => {
+    expect(env.nodeVersion).toEqual({ status: 'captured', value: process.version });
+    expect(env.arch).toEqual({ status: 'captured', value: process.arch });
+  });
+
+  test('reads the release version from package.json, not from a hard-coded constant', () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+    ) as { version: string };
+    expect(env.releaseVersion).toEqual({ status: 'captured', value: pkg.version });
+  });
+
+  test('the short commit is a prefix of the full commit when both are captured', () => {
+    if (env.gitCommitFull.status !== 'captured' || env.gitCommitShort.status !== 'captured') return;
+    expect(env.gitCommitFull.value).toMatch(/^[0-9a-f]{40}$/);
+    expect(env.gitCommitFull.value.startsWith(env.gitCommitShort.value)).toBe(true);
+  });
+
+  test('never throws, even when pointed at a directory that is not a repo', () => {
+    expect(() => captureEnvironment({ repoRoot: '/nonexistent-path-for-benchmark-test' })).not.toThrow();
+    const broken = captureEnvironment({ repoRoot: '/nonexistent-path-for-benchmark-test' });
+    expect(broken.gitCommitFull.status).toBe('unavailable');
+    expect(broken.releaseVersion.status).toBe('unavailable');
+    if (broken.releaseVersion.status !== 'unavailable') throw new Error('expected unavailable');
+    expect(broken.releaseVersion.reason.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/benchmark/runtime.test.ts
+++ b/tests/benchmark/runtime.test.ts
@@ -11,7 +11,9 @@ import { describe, test, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { startStageClock, elapsedMs, CLOCK_UNAVAILABLE_REASON } from '../../benchmarks/framework/clock';
 import { startMemorySampler, MEMORY_UNAVAILABLE_REASON } from '../../benchmarks/framework/memory';
-import { captureEnvironment } from '../../benchmarks/framework/env';
+import { captureEnvironment, hashArtifactNode, nodeSha256Hex } from '../../benchmarks/framework/node';
+import { hashArtifact } from '../../benchmarks/framework/artifacts';
+import { sha256Hex } from '../../src/terrain/export/sha256';
 import { isMeasured, isUnavailable, type EnvValue } from '../../benchmarks/framework/types';
 
 describe('the stage clock', () => {
@@ -101,15 +103,7 @@ function fakeReader(series: readonly number[]): () => number {
 
 describe('the environment capture', () => {
   const env = captureEnvironment();
-  const fields: ReadonlyArray<readonly [string, EnvValue]> = [
-    ['os', env.os],
-    ['cpuModel', env.cpuModel],
-    ['arch', env.arch],
-    ['nodeVersion', env.nodeVersion],
-    ['gitCommitShort', env.gitCommitShort],
-    ['gitCommitFull', env.gitCommitFull],
-    ['releaseVersion', env.releaseVersion],
-  ];
+  const fields: ReadonlyArray<readonly [string, EnvValue]> = Object.entries(env);
 
   test('every field is either captured with a non-empty value or unavailable with a reason', () => {
     for (const [name, field] of fields) {
@@ -140,6 +134,40 @@ describe('the environment capture', () => {
     expect(env.gitCommitFull.value.startsWith(env.gitCommitShort.value)).toBe(true);
   });
 
+  test('every field the schema declares is actually captured or refused', () => {
+    // Object.entries above only sees what the capture returned, so this pins
+    // that a field added to BenchmarkEnvironment is not quietly skipped here.
+    const declared: (keyof typeof env)[] = [
+      'os',
+      'cpuModel',
+      'arch',
+      'nodeVersion',
+      'gitCommitShort',
+      'gitCommitFull',
+      'gitDirty',
+      'releaseVersion',
+    ];
+    for (const key of declared) expect(env[key], key).toBeDefined();
+    expect(fields.length).toBe(declared.length);
+  });
+
+  test('says whether the working tree matched the commit it reports', () => {
+    // A commit hash with no dirty flag asserts a provenance the run may not
+    // have: a benchmark from a modified checkout would report a clean hash.
+    // Coupled to the commit deliberately — both come from the same `git`, so a
+    // captured commit beside an unavailable tree state means this field was
+    // dropped rather than genuinely undeterminable. (A source tarball with no
+    // .git makes BOTH unavailable, which stays honest.)
+    if (env.gitCommitFull.status === 'captured') {
+      expect(env.gitDirty.status).toBe('captured');
+    }
+    if (env.gitDirty.status !== 'captured') {
+      expect(env.gitDirty.reason.length).toBeGreaterThan(0);
+      return;
+    }
+    expect(['clean', 'dirty']).toContain(env.gitDirty.value);
+  });
+
   test('never throws, even when pointed at a directory that is not a repo', () => {
     expect(() => captureEnvironment({ repoRoot: '/nonexistent-path-for-benchmark-test' })).not.toThrow();
     const broken = captureEnvironment({ repoRoot: '/nonexistent-path-for-benchmark-test' });
@@ -147,5 +175,40 @@ describe('the environment capture', () => {
     expect(broken.releaseVersion.status).toBe('unavailable');
     if (broken.releaseVersion.status !== 'unavailable') throw new Error('expected unavailable');
     expect(broken.releaseVersion.reason.length).toBeGreaterThan(0);
+  });
+});
+
+describe('the Node digest', () => {
+  test('agrees with the portable implementation on the published test vector', () => {
+    // Same digest bit for bit, so a hash produced on either path is comparable
+    // with the other — this is a throughput fix, not a correctness one.
+    const abc = new Uint8Array([0x61, 0x62, 0x63]);
+    expect(nodeSha256Hex(abc)).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+    expect(nodeSha256Hex(abc)).toBe(sha256Hex(abc));
+  });
+
+  test('agrees over a larger deterministic payload', () => {
+    const bytes = new Uint8Array(64 * 1024);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 31 + 7) & 0xff;
+    expect(nodeSha256Hex(bytes)).toBe(sha256Hex(bytes));
+  });
+
+  test('hashArtifactNode produces the identical record to the portable path', () => {
+    const payload = { suiteId: 'decode', n: 3 };
+    expect(hashArtifactNode('metrics', payload)).toEqual(hashArtifact('metrics', payload));
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    expect(hashArtifactNode('raster', bytes)).toEqual(hashArtifact('raster', bytes));
+  });
+
+  test('an injected digest is actually used', () => {
+    const rec = hashArtifact('metrics', { n: 1 }, { digest: () => 'f'.repeat(64) });
+    expect(rec.hash).toBe('f'.repeat(64));
+  });
+
+  test('an explicit digest still wins over the Node default', () => {
+    // The two real digests are bit-identical, so nothing else can prove which
+    // one hashArtifactNode wired in. This pins the composition instead.
+    const rec = hashArtifactNode('metrics', { n: 1 }, { digest: () => 'e'.repeat(64) });
+    expect(rec.hash).toBe('e'.repeat(64));
   });
 });

--- a/tests/benchmark/schema.test.ts
+++ b/tests/benchmark/schema.test.ts
@@ -1,0 +1,107 @@
+/**
+ * schema.test.ts — the benchmark report schema and its honesty contract.
+ *
+ * The reports become paper figures, so the schema has one job the reviewer must
+ * be able to trust: a metric that was NOT measured never carries a number. A `0`
+ * standing in for "we did not measure this" is the failure this suite prevents.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  BENCHMARK_SCHEMA_VERSION,
+  measured,
+  unavailable,
+  isMeasured,
+  isUnavailable,
+  capturedEnv,
+  unavailableEnv,
+  type RunReport,
+  type Metric,
+} from '../../benchmarks/framework/types';
+import { fixtureReport } from './reportFixture';
+
+describe('schema round-trip', () => {
+  test('a RunReport survives JSON serialize -> parse unchanged', () => {
+    const report = fixtureReport();
+    const round = JSON.parse(JSON.stringify(report)) as RunReport;
+    expect(round).toEqual(report);
+  });
+
+  test('the schema version is an integer stamped on every report', () => {
+    expect(fixtureReport().schemaVersion).toBe(BENCHMARK_SCHEMA_VERSION);
+    expect(Number.isInteger(BENCHMARK_SCHEMA_VERSION)).toBe(true);
+  });
+});
+
+describe('the unavailable contract', () => {
+  test('an unavailable metric carries a null value, a reason, and no unit', () => {
+    const m = unavailable('no high-resolution clock', { runtime: 'browser', deterministic: false });
+    expect(m.status).toBe('unavailable');
+    expect(m.value).toBeNull();
+    expect(m.reason).toBe('no high-resolution clock');
+    expect('unit' in m).toBe(false);
+  });
+
+  test('unavailable() rejects an empty reason — "unavailable" alone explains nothing', () => {
+    expect(() => unavailable('  ', { runtime: 'node', deterministic: false })).toThrow(/reason/i);
+  });
+
+  test('measured() rejects a non-finite value rather than serialising NaN as null', () => {
+    // JSON.stringify(NaN) is `null`, which reads downstream as "no value" while
+    // the record still claims status 'measured' — the exact ambiguity forbidden.
+    expect(() => measured(NaN, 'ms', { runtime: 'node', deterministic: false })).toThrow(/finite/i);
+    expect(() => measured(Infinity, 'ms', { runtime: 'node', deterministic: false })).toThrow(
+      /finite/i,
+    );
+  });
+
+  test('measured() rejects an empty unit — a bare number is not a measurement', () => {
+    expect(() => measured(1, '', { runtime: 'node', deterministic: false })).toThrow(/unit/i);
+  });
+
+  test('every metric declares its runtime and whether it is deterministic', () => {
+    const m = measured(1, 'ms', { runtime: 'node', deterministic: true });
+    expect(m.runtime).toBe('node');
+    expect(m.deterministic).toBe(true);
+    const u = unavailable('why', { runtime: 'browser', deterministic: true });
+    expect(u.runtime).toBe('browser');
+    expect(u.deterministic).toBe(true);
+  });
+
+  test('the guards narrow the union both ways', () => {
+    const ok: Metric = measured(2, 'ms', { runtime: 'node', deterministic: false });
+    const no: Metric = unavailable('why', { runtime: 'node', deterministic: false });
+    expect(isMeasured(ok)).toBe(true);
+    expect(isUnavailable(ok)).toBe(false);
+    expect(isMeasured(no)).toBe(false);
+    expect(isUnavailable(no)).toBe(true);
+  });
+
+  test('no metric in a serialised report mixes a status with the wrong value', () => {
+    const round = JSON.parse(JSON.stringify(fixtureReport())) as RunReport;
+    const all: Metric[] = [
+      ...round.stages.flatMap((s) => [s.duration, s.peakMemory]),
+      ...Object.values(round.metrics),
+    ];
+    expect(all.length).toBeGreaterThan(0);
+    for (const m of all) {
+      if (m.status === 'measured') expect(typeof m.value).toBe('number');
+      else {
+        expect(m.value).toBeNull();
+        expect(m.reason.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('environment fields', () => {
+  test('an undeterminable field is unavailable with a reason, not an empty string', () => {
+    const e = unavailableEnv('git is not on PATH');
+    expect(e.status).toBe('unavailable');
+    expect(e.value).toBeNull();
+    expect(e.reason).toBe('git is not on PATH');
+  });
+
+  test('a captured field rejects an empty string', () => {
+    expect(() => capturedEnv('')).toThrow(/empty/i);
+  });
+});

--- a/tests/benchmark/sourceGuards.test.ts
+++ b/tests/benchmark/sourceGuards.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, test, expect } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const FRAMEWORK = fileURLToPath(new URL('../../benchmarks/framework', import.meta.url));
@@ -35,6 +35,7 @@ describe('the framework source', () => {
       'env.ts',
       'index.ts',
       'memory.ts',
+      'node.ts',
       'reporters/csv.ts',
       'reporters/html.ts',
       'reporters/json.ts',
@@ -43,6 +44,43 @@ describe('the framework source', () => {
       'stage.ts',
       'types.ts',
     ]);
+  });
+
+  test('nothing reachable from index.ts imports a node: builtin', () => {
+    // The schema advertises browser-taken metrics and clock/memory both have
+    // browser branches, so a browser-side suite has to be able to bundle the
+    // barrel. Re-exporting captureEnvironment made node:child_process a static
+    // dependency of the WHOLE surface and Vite could not resolve it at all.
+    const seen = new Set<string>();
+    const offenders: string[] = [];
+
+    const visit = (file: string): void => {
+      if (seen.has(file)) return;
+      seen.add(file);
+      const src = readFileSync(file, 'utf8');
+      for (const m of src.matchAll(/from\s+'([^']+)'/g)) {
+        const spec = m[1];
+        if (spec.startsWith('node:')) {
+          offenders.push(`${file.slice(FRAMEWORK.length + 1)} imports ${spec}`);
+          continue;
+        }
+        if (!spec.startsWith('.')) continue;
+        const target = join(dirname(file), spec.endsWith('.ts') ? spec : `${spec}.ts`);
+        if (target.startsWith(FRAMEWORK)) visit(target);
+      }
+    };
+
+    visit(join(FRAMEWORK, 'index.ts'));
+    expect(offenders).toEqual([]);
+    // Sanity: the walk actually reached the modules, rather than passing by
+    // never opening anything.
+    expect(seen.size).toBeGreaterThan(5);
+  });
+
+  test('the Node-only entry point is where the node: imports live', () => {
+    const node = readFileSync(join(FRAMEWORK, 'node.ts'), 'utf8');
+    expect(node).toMatch(/from 'node:crypto'/);
+    expect(node).toMatch(/captureEnvironment/);
   });
 
   test('never calls Date.now() or Math.random() — both would poison an artifact hash', () => {

--- a/tests/benchmark/sourceGuards.test.ts
+++ b/tests/benchmark/sourceGuards.test.ts
@@ -1,0 +1,70 @@
+/**
+ * sourceGuards.test.ts — static guards on the framework source itself.
+ *
+ * Two properties cannot be proven by exercising the API, because the offending
+ * call would simply produce a plausible-looking number: that no module on the
+ * hashed-artifact path reads the wall clock or a random source, and that no
+ * module fills a missing measurement with 0. Both are checked by reading the
+ * source, so a future suite author cannot reintroduce them unnoticed.
+ */
+import { describe, test, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FRAMEWORK = fileURLToPath(new URL('../../benchmarks/framework', import.meta.url));
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...sourceFiles(full));
+    else if (entry.endsWith('.ts')) out.push(full);
+  }
+  return out.sort();
+}
+
+const FILES = sourceFiles(FRAMEWORK);
+
+describe('the framework source', () => {
+  test('ships every module the suites are built on', () => {
+    const names = FILES.map((f) => f.slice(FRAMEWORK.length + 1));
+    expect(names).toEqual([
+      'artifacts.ts',
+      'clock.ts',
+      'env.ts',
+      'index.ts',
+      'memory.ts',
+      'reporters/csv.ts',
+      'reporters/html.ts',
+      'reporters/json.ts',
+      'reporters/markdown.ts',
+      'reporters/metricText.ts',
+      'stage.ts',
+      'types.ts',
+    ]);
+  });
+
+  test('never calls Date.now() or Math.random() — both would poison an artifact hash', () => {
+    for (const file of FILES) {
+      const src = readFileSync(file, 'utf8');
+      // Strip block/line comments first: the rule is about CALLS, and these
+      // modules legitimately name the two functions when explaining the rule.
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|\s)\/\/[^\n]*/g, '$1');
+      expect(code, file).not.toMatch(/Date\.now\s*\(/);
+      expect(code, file).not.toMatch(/Math\.random\s*\(/);
+      expect(code, file).not.toMatch(/new Date\s*\(/);
+    }
+  });
+
+  test('declares no runtime dependency outside node: builtins and the reused src helpers', () => {
+    for (const file of FILES) {
+      const src = readFileSync(file, 'utf8');
+      for (const m of src.matchAll(/from\s+'([^']+)'/g)) {
+        const spec = m[1];
+        const ok = spec.startsWith('node:') || spec.startsWith('./') || spec.startsWith('../');
+        expect(ok, `${file} imports ${spec}`).toBe(true);
+      }
+    }
+  });
+});

--- a/tests/benchmark/sourceGuards.test.ts
+++ b/tests/benchmark/sourceGuards.test.ts
@@ -9,10 +9,23 @@
  */
 import { describe, test, expect } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const FRAMEWORK = fileURLToPath(new URL('../../benchmarks/framework', import.meta.url));
+const REPO = fileURLToPath(new URL('../..', import.meta.url));
+
+/**
+ * Every form an import specifier can take.
+ *
+ * `from 'x'` alone missed four of them, and this repo has no ESLint to enforce
+ * a quote style, so the double-quoted case is the likeliest to appear:
+ *   import { x } from "node:crypto"    — double quotes
+ *   import 'node:crypto'               — side-effect only, no `from`
+ *   await import('node:fs')            — dynamic
+ *   export { x } from "node:os"        — re-export, also `from`
+ */
+const SPECS = /(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g;
 
 function sourceFiles(dir: string): string[] {
   const out: string[] = [];
@@ -51,6 +64,12 @@ describe('the framework source', () => {
     // browser branches, so a browser-side suite has to be able to bundle the
     // barrel. Re-exporting captureEnvironment made node:child_process a static
     // dependency of the WHOLE surface and Vite could not resolve it at all.
+    //
+    // The walk follows anything that resolves INSIDE THE REPO, not just inside
+    // benchmarks/framework: `artifacts.ts` deliberately depends on
+    // src/canonicalHash.ts and src/terrain/export/sha256.ts, both shared with
+    // the app, and someone speeding up that hand-rolled sha256 with node:crypto
+    // would break the browser barrel while a framework-only walk stayed green.
     const seen = new Set<string>();
     const offenders: string[] = [];
 
@@ -58,28 +77,28 @@ describe('the framework source', () => {
       if (seen.has(file)) return;
       seen.add(file);
       const src = readFileSync(file, 'utf8');
-      for (const m of src.matchAll(/from\s+'([^']+)'/g)) {
+      for (const m of src.matchAll(SPECS)) {
         const spec = m[1];
         if (spec.startsWith('node:')) {
-          offenders.push(`${file.slice(FRAMEWORK.length + 1)} imports ${spec}`);
+          offenders.push(`${relative(REPO, file)} imports ${spec}`);
           continue;
         }
         if (!spec.startsWith('.')) continue;
         const target = join(dirname(file), spec.endsWith('.ts') ? spec : `${spec}.ts`);
-        if (target.startsWith(FRAMEWORK)) visit(target);
+        if (target.startsWith(REPO)) visit(target);
       }
     };
 
     visit(join(FRAMEWORK, 'index.ts'));
     expect(offenders).toEqual([]);
     // Sanity: the walk actually reached the modules, rather than passing by
-    // never opening anything.
-    expect(seen.size).toBeGreaterThan(5);
+    // never opening anything. Eleven framework files plus the two src helpers.
+    expect(seen.size).toBeGreaterThanOrEqual(13);
   });
 
   test('the Node-only entry point is where the node: imports live', () => {
     const node = readFileSync(join(FRAMEWORK, 'node.ts'), 'utf8');
-    expect(node).toMatch(/from 'node:crypto'/);
+    expect(node).toMatch(/from ['"]node:crypto['"]/);
     expect(node).toMatch(/captureEnvironment/);
   });
 
@@ -98,7 +117,7 @@ describe('the framework source', () => {
   test('declares no runtime dependency outside node: builtins and the reused src helpers', () => {
     for (const file of FILES) {
       const src = readFileSync(file, 'utf8');
-      for (const m of src.matchAll(/from\s+'([^']+)'/g)) {
+      for (const m of src.matchAll(SPECS)) {
         const spec = m[1];
         const ok = spec.startsWith('node:') || spec.startsWith('./') || spec.startsWith('../');
         expect(ok, `${file} imports ${spec}`).toBe(true);

--- a/tests/benchmark/sourceGuards.test.ts
+++ b/tests/benchmark/sourceGuards.test.ts
@@ -13,6 +13,7 @@ import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const FRAMEWORK = fileURLToPath(new URL('../../benchmarks/framework', import.meta.url));
+const BENCHMARKS = fileURLToPath(new URL('../../benchmarks', import.meta.url));
 const REPO = fileURLToPath(new URL('../..', import.meta.url));
 
 /**
@@ -37,11 +38,24 @@ function sourceFiles(dir: string): string[] {
   return out.sort();
 }
 
-const FILES = sourceFiles(FRAMEWORK);
+const FRAMEWORK_FILES = sourceFiles(FRAMEWORK);
+/**
+ * EVERY benchmark module, not just the framework's.
+ *
+ * The clock/random and dependency guards below are properties of anything that
+ * feeds a hashed artifact, and the fixtures and the pipeline driver do exactly
+ * that. Scoping them to `benchmarks/framework` left the generator that produces
+ * the data and the driver that produces the artifacts entirely unguarded — and
+ * the suites landing next would have been unguarded too, by default and
+ * silently. Only the module manifest below stays framework-scoped: it pins a
+ * fixed file list, which is right for a stable core and wrong for a directory
+ * suites keep adding to.
+ */
+const FILES = sourceFiles(BENCHMARKS);
 
 describe('the framework source', () => {
   test('ships every module the suites are built on', () => {
-    const names = FILES.map((f) => f.slice(FRAMEWORK.length + 1));
+    const names = FRAMEWORK_FILES.map((f) => f.slice(FRAMEWORK.length + 1));
     expect(names).toEqual([
       'artifacts.ts',
       'clock.ts',
@@ -100,6 +114,21 @@ describe('the framework source', () => {
     const node = readFileSync(join(FRAMEWORK, 'node.ts'), 'utf8');
     expect(node).toMatch(/from ['"]node:crypto['"]/);
     expect(node).toMatch(/captureEnvironment/);
+  });
+
+  test('the fixtures and the driver stay runtime-neutral', () => {
+    // Both are reachable from a browser-side suite: the generator so a browser
+    // run measures the identical cloud, the driver so it can fill in the four
+    // stages Node cannot measure. One `node:` import in either makes that
+    // impossible, and the bundler is where you find out.
+    for (const dir of [join(BENCHMARKS, 'fixtures'), join(BENCHMARKS, 'pipeline')]) {
+      for (const file of sourceFiles(dir)) {
+        const src = readFileSync(file, 'utf8');
+        for (const m of src.matchAll(SPECS)) {
+          expect(m[1].startsWith('node:'), `${relative(REPO, file)} imports ${m[1]}`).toBe(false);
+        }
+      }
+    }
   });
 
   test('never calls Date.now() or Math.random() — both would poison an artifact hash', () => {

--- a/tests/benchmark/stage.test.ts
+++ b/tests/benchmark/stage.test.ts
@@ -1,0 +1,83 @@
+/**
+ * stage.test.ts — running one stage records it whether or not it succeeds.
+ *
+ * The stage runner is the only place the clock and the memory sampler are
+ * composed, and it exists so three suites cannot each invent their own version
+ * of "what happens when a stage throws". The behaviour that matters: a failed
+ * stage still reports the timing and peak memory it actually consumed, because
+ * "the decode blew up after 40 seconds and 6 GB" is a result, not a blank.
+ */
+import { describe, test, expect } from 'vitest';
+import { runStage, runStageAsync } from '../../benchmarks/framework/stage';
+import { isMeasured } from '../../benchmarks/framework/types';
+
+describe('runStage', () => {
+  test('records the name, a measured duration in ms and peak RSS in bytes', () => {
+    const { stage, value } = runStage('decode', () => 7);
+    expect(stage.name).toBe('decode');
+    expect(stage.status).toBe('ok');
+    expect(value).toBe(7);
+    if (!isMeasured(stage.duration) || !isMeasured(stage.peakMemory)) {
+      throw new Error('expected both stage metrics to be measured in Node');
+    }
+    expect(stage.duration.unit).toBe('ms');
+    expect(stage.duration.value).toBeGreaterThanOrEqual(0);
+    expect(stage.peakMemory.unit).toBe('bytes');
+    expect(stage.peakMemory.value).toBeGreaterThan(0);
+  });
+
+  test('a successful stage carries no error field', () => {
+    expect(runStage('ok', () => 1).stage.error).toBeUndefined();
+  });
+
+  test('a throwing stage is failed, keeps its measurements, and reports no value', () => {
+    const { stage, value } = runStage('decode', () => {
+      throw new Error('truncated chunk');
+    });
+    expect(stage.status).toBe('failed');
+    expect(stage.error).toBe('truncated chunk');
+    expect(value).toBeUndefined();
+    expect(isMeasured(stage.duration)).toBe(true);
+    expect(isMeasured(stage.peakMemory)).toBe(true);
+  });
+
+  test('a thrown non-Error is stringified rather than lost', () => {
+    const { stage } = runStage('decode', () => {
+      throw 'nope';
+    });
+    expect(stage.status).toBe('failed');
+    expect(stage.error).toBe('nope');
+  });
+
+  test('the error is the message, never a stack — a stack is machine-specific', () => {
+    const { stage } = runStage('decode', () => {
+      throw new Error('boom');
+    });
+    expect(stage.error).toBe('boom');
+    expect(stage.error).not.toContain('at ');
+    expect(stage.error).not.toContain('.ts:');
+  });
+});
+
+describe('runStageAsync', () => {
+  test('awaits the body and records the stage', async () => {
+    const { stage, value } = await runStageAsync('load', async () => {
+      await Promise.resolve();
+      return 'done';
+    });
+    expect(stage.status).toBe('ok');
+    expect(value).toBe('done');
+    expect(isMeasured(stage.duration)).toBe(true);
+  });
+
+  test('a rejected body is failed, with its message and its measurements', async () => {
+    const { stage, value } = await runStageAsync('load', async () => {
+      await Promise.resolve();
+      throw new Error('404 from the tile server');
+    });
+    expect(stage.status).toBe('failed');
+    expect(stage.error).toBe('404 from the tile server');
+    expect(value).toBeUndefined();
+    expect(isMeasured(stage.duration)).toBe(true);
+  });
+});

--- a/tests/benchmark/stage.test.ts
+++ b/tests/benchmark/stage.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, test, expect } from 'vitest';
 import { runStage, runStageAsync } from '../../benchmarks/framework/stage';
-import { isMeasured } from '../../benchmarks/framework/types';
+import { isMeasured, measured, type StageResult } from '../../benchmarks/framework/types';
 
 describe('runStage', () => {
   test('records the name, a measured duration in ms and peak RSS in bytes', () => {
@@ -56,6 +56,38 @@ describe('runStage', () => {
     expect(stage.error).toBe('boom');
     expect(stage.error).not.toContain('at ');
     expect(stage.error).not.toContain('.ts:');
+  });
+
+  test('a multi-line message is collapsed to one line', () => {
+    // Error.message is often multi-line (a parser quoting its input), and a raw
+    // newline ends a Markdown row mid-table, turning the rest into a paragraph.
+    const { stage } = runStage('decode', () => {
+      throw new Error('bad header\n  at offset 12\r\nexpected LASF');
+    });
+    expect(stage.error).toBe('bad header; at offset 12; expected LASF');
+    expect(stage.error).not.toMatch(/[\r\n]/);
+  });
+
+  /**
+   * The status is the discriminant, so the two impossible records have to be
+   * impossible to write. An unused `@ts-expect-error` is itself a typecheck
+   * error, which is what makes these assertions fail if the union loosens.
+   */
+  test('a failure with no explanation, or a success carrying one, does not typecheck', () => {
+    const common = {
+      name: 'decode',
+      duration: measured(1, 'ms', { runtime: 'node', deterministic: false }),
+      peakMemory: measured(2, 'bytes', { runtime: 'node', deterministic: false }),
+    } as const;
+
+    // @ts-expect-error status:'failed' REQUIRES the error that explains it
+    const unexplained: StageResult = { ...common, status: 'failed' };
+
+    // @ts-expect-error status:'ok' forbids an error — there was nothing to report
+    const contradictory: StageResult = { ...common, status: 'ok', error: 'boom' };
+
+    expect(unexplained.status).toBe('failed');
+    expect(contradictory.status).toBe('ok');
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,13 @@
     "noFallthroughCasesInSwitch": true,
     "erasableSyntaxOnly": true
   },
-  "include": ["src", "tests", "vite.config.ts", "vitest.config.ts", "benchmarks/framework"]
+  "include": [
+    "src",
+    "tests",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "benchmarks/framework",
+    "benchmarks/fixtures",
+    "benchmarks/pipeline"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "noFallthroughCasesInSwitch": true,
     "erasableSyntaxOnly": true
   },
-  "include": ["src", "tests", "vite.config.ts", "vitest.config.ts"]
+  "include": ["src", "tests", "vite.config.ts", "vitest.config.ts", "benchmarks/framework"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,8 +36,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    // Unit tests only — Playwright specs under tests/e2e/ are excluded.
-    include: ['tests/*.{test,spec}.ts'],
+    // Unit tests only — Playwright specs under tests/e2e/ are excluded. The
+    // benchmark-framework suites live one level down, so they are listed
+    // explicitly rather than by a `tests/**` glob that would sweep e2e back in.
+    include: ['tests/*.{test,spec}.ts', 'tests/benchmark/*.{test,spec}.ts'],
     // Headroom over the 5 s default so the heavier DOM-building / LAS-decoding
     // suites don't time out (and flake) under parallel load on a busy machine —
     // 15 s is still unambiguously "broken" if a unit test ever hits it.


### PR DESCRIPTION
Internal scaffolding for a benchmark framework. **Not a user-facing feature yet** — there is no runnable entry point, no npm script, and no benchmark suite. Nothing in the app changes.

Two pieces land:

`benchmarks/framework/` — the shared core. A metric is either measured with a unit or unavailable with a reason; the type makes "unavailable but carrying a number" a compile error, so an unmeasurable value can never be reported as a zero or an estimate. Alongside it: monotonic stage timing, peak-RSS sampling, environment capture including whether the working tree was dirty, canonical artifact hashing that strips volatile fields through an exported, auditable rule list, and JSON/CSV/Markdown/HTML reporters that render an unavailable metric visibly rather than blank.

`benchmarks/fixtures/` and `benchmarks/pipeline/` — a seeded synthetic point-cloud generator (same seed gives byte-identical points) and a driver that runs the real analysis pipeline: ground filter, rasterise, DTM, terrain descriptors, contours, scientific record, processing manifest. The driver calls the application's own cores rather than reimplementing them, and a test asserts its DTM, confidence, hold-out RMSE, contour tally and complexity summary all equal `analyseContours` on the same points, so the benchmark cannot quietly drift away from the code it measures.

Stages that need a browser — GPU upload, first frame, FPS, time to interaction — are present in the stage list but reported unavailable with the reason, so a report shows the whole pipeline with honest gaps instead of a partial one that looks complete.

No runtime dependencies. `tsconfig`, the vitest include list and the test-bucket router were extended so these tests actually execute in the release gate; without the router change they would have been silently skipped while the gate reported green.
