### PR TITLE
Fix vertical-unit labelling in LAS and contour exports, and guard EPT laszip positions

### DIFF
--- a/src/convert/writeLas.ts
+++ b/src/convert/writeLas.ts
@@ -150,6 +150,25 @@ function deriveQuantisation(
  * larger code (e.g. some ESRI codes) would corrupt to a wrong CRS, so we omit
  * the VLR rather than write a lie. The caller surfaces a warning.
  */
+/**
+ * The vertical GeoKeys alone (VerticalCSType + VerticalUnits). A horizontal-only
+ * WKT — what `wktForEpsg` produces, and what most source WKTs are — carries no
+ * vertical axis, so LAS 1.4 pairs it with these rather than dropping them: a
+ * file that declared neither datum nor unit left foot heights on NAVD88 to be
+ * read as metres, 3.28× wrong with the provenance gone. No horizontal key is
+ * emitted here, so the WKT stays the sole authority on the horizontal frame.
+ */
+function buildVerticalGeoKeys(opts: WriteLasOptions): Array<[number, number]> {
+  const geoKeys: Array<[number, number]> = [];
+  if (opts.verticalEpsg != null && opts.verticalEpsg > 0 && opts.verticalEpsg <= 65535) {
+    geoKeys.push([4096, opts.verticalEpsg]); // VerticalCSType
+    if (opts.verticalUnitCode != null && opts.verticalUnitCode > 0) {
+      geoKeys.push([4099, opts.verticalUnitCode]); // VerticalUnits
+    }
+  }
+  return geoKeys;
+}
+
 function buildGeoKeys(opts: WriteLasOptions, geo: boolean): Array<[number, number]> {
   const hasCrs = opts.epsg != null && Number.isFinite(opts.epsg) && opts.epsg > 0 && opts.epsg <= 65535;
   const geoKeys: Array<[number, number]> = [];
@@ -159,17 +178,12 @@ function buildGeoKeys(opts: WriteLasOptions, geo: boolean): Array<[number, numbe
     if (!geo && opts.linearUnitCode != null && opts.linearUnitCode > 0) {
       geoKeys.push([3076, opts.linearUnitCode]); // ProjLinearUnits (metre/foot/US ft)
     }
-    if (opts.verticalEpsg != null && opts.verticalEpsg > 0 && opts.verticalEpsg <= 65535) {
-      geoKeys.push([4096, opts.verticalEpsg]); // VerticalCSType
-      // VerticalUnits is the SOURCE's vertical unit, never derived from the
-      // horizontal: no convert mode moves Z, so after a horizontal reprojection
-      // to metres a foot-height source still carries foot Z values — the old
-      // "match the horizontal, else metres" rule stamped those as metres.
-      // Unknown ⇒ omit the key rather than guess.
-      if (opts.verticalUnitCode != null && opts.verticalUnitCode > 0) {
-        geoKeys.push([4099, opts.verticalUnitCode]); // VerticalUnits
-      }
-    }
+    // VerticalUnits is the SOURCE's vertical unit, never derived from the
+    // horizontal: no convert mode moves Z, so after a horizontal reprojection
+    // to metres a foot-height source still carries foot Z values — the old
+    // "match the horizontal, else metres" rule stamped those as metres.
+    // Unknown ⇒ omit the key rather than guess.
+    geoKeys.push(...buildVerticalGeoKeys(opts));
   }
   return geoKeys;
 }
@@ -371,7 +385,10 @@ export function writeLas14(g: GlobalPoints, opts: WriteLas14Options = {}): Uint8
   const wkt = opts.wkt != null && opts.wkt.trim().length > 0 && opts.wkt.length + 1 <= 0xffff
     ? opts.wkt
     : null;
-  const geoKeys = wkt == null ? buildGeoKeys(opts, geo) : [];
+  // With a WKT, the GeoKey VLR carries ONLY the vertical keys: LAS 1.4 permits
+  // both VLRs to coexist, and a horizontal-only WKT would otherwise take the
+  // vertical datum and unit down with it (see buildVerticalGeoKeys).
+  const geoKeys = wkt == null ? buildGeoKeys(opts, geo) : buildVerticalGeoKeys(opts);
   const geoKeyDataBytes = geoKeys.length > 0 ? 8 + geoKeys.length * 8 : 0;
   const wktDataBytes = wkt != null ? wkt.length + 1 : 0;
   const vlrCount = (wkt != null ? 1 : 0) + (geoKeys.length > 0 ? 1 : 0);
@@ -435,8 +452,15 @@ export function writeLas14(g: GlobalPoints, opts: WriteLas14Options = {}): Uint8
     for (let i = 0; i < wkt.length; i++) {
       bytes[p + VLR_HEADER_SIZE + i] = wkt.charCodeAt(i) & 0x7f;
     }
-  } else if (geoKeys.length > 0) {
-    writeGeoKeyVlr(view, bytes, HEADER_SIZE_14, geoKeys);
+  }
+  if (geoKeys.length > 0) {
+    // Placed after the WKT VLR when both are present.
+    writeGeoKeyVlr(
+      view,
+      bytes,
+      HEADER_SIZE_14 + (wkt != null ? VLR_HEADER_SIZE + wktDataBytes : 0),
+      geoKeys,
+    );
   }
 
   // ── Point records (extended layout, 30/36 bytes) ───────────────────────

--- a/src/io/ept/eptLaszipDecode.ts
+++ b/src/io/ept/eptLaszipDecode.ts
@@ -42,6 +42,7 @@
 import { parseLasHeader } from '../lasHeader';
 import { getLazPerf } from '../loadLas';
 import { validateDeclaredPointCount } from '../validateCount';
+import { assertFiniteNodeTransform, assertFinitePositions } from '../streamingFiniteGuard';
 import type { DecodedChunk } from '../copc/copcChunkDecode';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -200,6 +201,13 @@ export function decodeEptLaszipTileWith(
     1,
     'EPT laszip tile',
   );
+  // Fail before decoding a whole tile when its transform is outright non-finite
+  // (a bad scale/offset in the header, or a non-finite render origin). Cheap and
+  // O(1); it does NOT catch a finite-but-extreme scale overflowing
+  // `int32 · scale + offset`, so the finished positions are scanned below.
+  // The COPC and EPT-binary decoders refuse such a node the same way — this one
+  // drew it, sending Infinity to three.js with no structured error.
+  assertFiniteNodeTransform(ctx.scale, ctx.offset, renderOrigin);
   const fileBytes = new Uint8Array(buffer);
 
   const positions = new Float32Array(n * 3);
@@ -294,6 +302,10 @@ export function decodeEptLaszipTileWith(
       rgb[i] = usedEightBit ? rgb16[i] & 0xff : rgb16[i] >> 8;
     }
   }
+
+  // Backstop the up-front transform check: a finite-but-extreme scale/offset can
+  // still overflow a coordinate to ±Infinity, so refuse the tile if any did.
+  assertFinitePositions(positions);
 
   return {
     pointCount: n,

--- a/src/terrain/contour/analyseContours.ts
+++ b/src/terrain/contour/analyseContours.ts
@@ -361,6 +361,12 @@ export interface TerrainCore {
   readonly crs: string | null;
   /** Resolved vertical datum (echoed for the contour stage + result). */
   readonly verticalDatum: string | null;
+  /**
+   * Metres per source vertical unit, echoed for the contour stage: DTM
+   * elevations (and therefore contour values) are in source units, so an
+   * exporter naming that unit needs the factor. Null when unresolved.
+   */
+  readonly verticalUnitToMetres: number | null;
   /** Resolved grid cell size (source units). */
   readonly cellSizeM: number;
   /** Grid-recommendation geometry inputs (the contour stage adds the
@@ -952,6 +958,7 @@ export function computeTerrainCore(
     despikeApplied,
     crs,
     verticalDatum,
+    verticalUnitToMetres: params.verticalUnitToMetres ?? null,
     cellSizeM: params.cellSizeM,
     gridGeometry: {
       pointCount: gf.analyzedPointCount,
@@ -977,7 +984,7 @@ export function contoursFromCore(
   core: TerrainCore,
   intervalParams: IntervalContourParams = {},
 ): AnalyseContoursResult {
-  const { crs, verticalDatum, cellSizeM, dtm, gate, minZ, maxZ } = core;
+  const { crs, verticalDatum, verticalUnitToMetres, cellSizeM, dtm, gate, minZ, maxZ } = core;
   // The contour shape style for this run. Default 'smooth' reproduces the
   // historical Chaikin ×2 default exactly, so the live on-screen contours are
   // byte-identical. `shapeStyle` wins; otherwise the legacy `smooth:false`
@@ -1062,6 +1069,7 @@ export function contoursFromCore(
       model: buildFeatureModel([], [], {
         crs,
         verticalDatum,
+        verticalUnitToMetres,
         intervalM: 0,
         coverageMode: dtm.coverageMode,
         contourStyle: shapeStyle,
@@ -1102,6 +1110,7 @@ export function contoursFromCore(
   const model = buildFeatureModel(stitched, style.levels, {
     crs,
     verticalDatum,
+    verticalUnitToMetres,
     intervalM,
     coverageMode: dtm.coverageMode,
     contourStyle: shapeStyle,

--- a/src/terrain/contour/contourFeatureModel.ts
+++ b/src/terrain/contour/contourFeatureModel.ts
@@ -72,6 +72,15 @@ export interface ContourFeatureModel {
   readonly features: ContourFeature[];
   readonly crs: string | null;
   readonly verticalDatum: string | null;
+  /**
+   * Metres per unit of the SOURCE vertical axis. Feature `value`s are in that
+   * axis's own units, never metres, so a writer that wants to name the unit
+   * reads this instead of assuming — the RFC 7946 writer stamped a constant
+   * 'metre' and shipped US-survey-foot elevations under it. Null/absent means
+   * the factor was never resolved, and the honest label is then "unknown",
+   * not "metre".
+   */
+  readonly verticalUnitToMetres?: number | null;
   readonly intervalM: number;
   /** The contour shape style this model's geometry was produced with. */
   readonly contourStyle: ContourShapeStyle;
@@ -133,6 +142,8 @@ export function shiftFeatureModelToWorld(
 export interface FeatureModelParams {
   readonly crs: string | null;
   readonly verticalDatum?: string | null;
+  /** Metres per unit of the source vertical axis; null when unresolved. */
+  readonly verticalUnitToMetres?: number | null;
   readonly intervalM: number;
   /** Coverage provenance from the analysis (default 'full'). */
   readonly coverageMode?: TerrainCoverageMode;
@@ -245,6 +256,7 @@ export function buildFeatureModel(
     features,
     crs: params.crs,
     verticalDatum: params.verticalDatum ?? null,
+    verticalUnitToMetres: params.verticalUnitToMetres ?? null,
     intervalM: params.intervalM,
     contourStyle: params.contourStyle ?? defaultContourShapeStyle,
     bbox,

--- a/src/terrain/contour/geojsonContours.ts
+++ b/src/terrain/contour/geojsonContours.ts
@@ -27,6 +27,18 @@ import { contourEvidence, type ContourFeatureModel } from './contourFeatureModel
 import { contourShapeStyleLabel } from './contourShapeStyle';
 import { provenanceJson, type ExportProvenance } from '../export/exportProvenance';
 import { crsUrn as sharedCrsUrn } from '../../export/crsIdentifier';
+import { verticalUnitLabel } from '../../units/units';
+
+/**
+ * The short unit labels spelled out for a GeoJSON property, where the name is
+ * read by a person or a downstream schema rather than squeezed into a UI. The
+ * 'units' case keeps its unknown meaning: an unresolved factor is not metre.
+ */
+const ELEVATION_UNIT_NAME = {
+  m: 'metre',
+  ft: 'foot',
+  units: 'unknown',
+} as const;
 
 
 
@@ -208,6 +220,15 @@ export function toGeoJSONWgs84(
       + 'Elevations are carried per feature as elevation / elevationUnit / elevationDatum.';
   }
 
+  // The elevation is in the DTM's SOURCE vertical units, so its label comes
+  // from the resolved vertical factor. A constant 'metre' here shipped US
+  // survey feet as metres — 100 read as 100 m instead of 30.48 m — for the
+  // compound CRSs (metre horizontal over a foot height) that take this WGS 84
+  // path. An unresolved factor says so; it does not fall back to metre.
+  const vScale = model.verticalUnitToMetres;
+  const elevationUnit =
+    vScale == null ? 'unknown' : ELEVATION_UNIT_NAME[verticalUnitLabel(vScale)];
+
   obj.features = (obj.features as Array<Record<string, unknown>>).map((f) => {
     const geom = f.geometry as { type: string; coordinates: number[][] };
     return {
@@ -216,7 +237,7 @@ export function toGeoJSONWgs84(
         ...(f.properties as Record<string, unknown>),
         // Stated on every feature, so the height cannot be read without its
         // reference — including when a reader keeps only the properties.
-        elevationUnit: 'metre',
+        elevationUnit,
         elevationDatum: model.verticalDatum ?? null,
       },
       geometry: {

--- a/tests/contourDownload.test.ts
+++ b/tests/contourDownload.test.ts
@@ -31,6 +31,7 @@ function model(): ContourFeatureModel {
     features,
     crs: 'EPSG:32610',
     verticalDatum: 'EPSG:5703',
+    verticalUnitToMetres: 1,
     intervalM: 1,
     contourStyle: 'smooth',
     bbox: { minX: 0, minY: 0, maxX: 1, maxY: 1 },
@@ -237,6 +238,28 @@ describe('RFC 7946 third ordinate', () => {
     expect(p.elevation).toBeCloseTo(65.5, 6);
     expect(p.elevationDatum).toBe('EPSG:5703');
     expect(p.elevationUnit).toBe('metre');
+  });
+
+  /**
+   * The elevation property is in the DTM's SOURCE vertical units, and the
+   * label was the constant 'metre'. A NAVD88-in-US-survey-feet source over a
+   * metre horizontal takes the WGS 84 path and shipped feet labelled metres —
+   * 100 read as 100 m instead of 30.48 m.
+   */
+  it('labels the elevation unit from the source vertical factor, not a constant', () => {
+    const feet = { ...utmModel(), verticalDatum: 'EPSG:6360', verticalUnitToMetres: 1200 / 3937 };
+    const gj = JSON.parse(
+      serializeContours(feet, 'geojson', { toLonLat, worldOrigin: WORLD }).content,
+    );
+    expect(gj.features[0].properties.elevationUnit).toBe('foot');
+  });
+
+  it('says the unit is unknown rather than claiming metre for an unresolved factor', () => {
+    const unknown = { ...utmModel(), verticalDatum: 'EPSG:5703', verticalUnitToMetres: null };
+    const gj = JSON.parse(
+      serializeContours(unknown, 'geojson', { toLonLat, worldOrigin: WORLD }).content,
+    );
+    expect(gj.features[0].properties.elevationUnit).toBe('unknown');
   });
 
   it('writes the Z ordinate for a proven WGS 84 ellipsoidal height', () => {

--- a/tests/eptLaszipDecode.test.ts
+++ b/tests/eptLaszipDecode.test.ts
@@ -89,3 +89,32 @@ test('decodeEptLaszipTile rejects an unsupported PDRF', async () => {
   buf[104] = 9;
   await expect(decodeEptLaszipTile(buf.buffer, [0, 0, 0])).rejects.toThrow(/format 9|unsupported/i);
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Finite-coordinate guard
+//
+// The COPC chunk decoder and the EPT binary decoder both refuse a node whose
+// transform or decoded positions are non-finite. This path called neither, so a
+// corrupt or hostile remote tile delivered Infinity straight into three.js: NaN
+// bounding sphere, broken culling, blank cloud, and no structured error for the
+// scheduler to back off from.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('decodeEptLaszipTile refuses a non-finite render origin', async () => {
+  await expect(decodeEptLaszipTile(TINY_LAZ_BUF, [Number.NaN, 0, 0])).rejects.toThrow(
+    /non-finite value.*node is refused/s,
+  );
+});
+
+test('decodeEptLaszipTile refuses a tile whose scale overflows a coordinate', async () => {
+  // parseLasHeader accepts this scale — it is finite and positive — but
+  // int32 · 1e300 overflows to ±Infinity in the coordinate loop, which is
+  // exactly what the up-front transform check cannot catch.
+  const buf = new Uint8Array(TINY_LAZ_BUF.byteLength);
+  buf.set(new Uint8Array(TINY_LAZ_BUF));
+  const v = new DataView(buf.buffer);
+  for (let a = 0; a < 3; a++) v.setFloat64(131 + a * 8, 1e300, true);
+  await expect(decodeEptLaszipTile(buf.buffer, [0, 0, 0])).rejects.toThrow(
+    /non-finite coordinate at point/,
+  );
+});

--- a/tests/writeLas14.test.ts
+++ b/tests/writeLas14.test.ts
@@ -327,6 +327,36 @@ describe('GeoKeys — the vertical unit comes from the source, not the horizonta
     expect(key(bytes, 4099)).toBeUndefined();
   });
 
+  it('keeps the vertical GeoKeys alongside a WKT VLR', () => {
+    // A horizontal-only WKT (what wktForEpsg produces, and what most source
+    // WKTs are) says nothing about the vertical axis. Making the two VLRs
+    // mutually exclusive dropped VerticalCSType and VerticalUnits entirely,
+    // so foot heights on NAVD88 shipped as undeclared — read as metres, 3.28×
+    // wrong, with the datum gone.
+    const wkt = 'PROJCS["WGS 84 / UTM zone 13N",GEOGCS["WGS 84"],UNIT["metre",1],AUTHORITY["EPSG","32613"]]';
+    const bytes = writeLas14(g(), {
+      epsg: 32613, isGeographic: false, linearUnitCode: 9001, wkt,
+      verticalEpsg: 5703, verticalUnitCode: 9003,
+    });
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    expect(view.getUint16(6, true) & 0x10).toBe(0x10); // WKT still the horizontal authority
+    expect(view.getUint32(100, true)).toBe(2); // WKT VLR + GeoKey VLR
+    expect(key(bytes, 4096)).toBe(5703);
+    expect(key(bytes, 4099)).toBe(9003);
+    // The horizontal frame has exactly ONE authority: no horizontal keys that
+    // could contradict the WKT.
+    expect(key(bytes, 3072)).toBeUndefined();
+    expect(key(bytes, 3076)).toBeUndefined();
+    expect(key(bytes, 1024)).toBeUndefined();
+  });
+
+  it('writes no GeoKey VLR beside a WKT when there is no vertical to add', () => {
+    const wkt = 'PROJCS["WGS 84 / UTM zone 13N",GEOGCS["WGS 84"],UNIT["metre",1],AUTHORITY["EPSG","32613"]]';
+    const bytes = writeLas14(g(), { epsg: 32613, isGeographic: false, linearUnitCode: 9001, wkt });
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    expect(view.getUint32(100, true)).toBe(1);
+  });
+
   it('no longer copies a foot horizontal into the vertical slot', () => {
     // The old derivation: foot horizontal ⇒ foot vertical, even for metre Z.
     const bytes = writeLas14(g(), {


### PR DESCRIPTION
Three defects found by an audit of the v0.6.0 archive. Two of them silently mislabel exported elevations, which is the failure this project's honesty contract exists to prevent: the file looks correct, and a reader has no way to tell it isn't.

**LAS 1.4 dropped the vertical CRS and vertical unit.** The writer treated the WKT record and the GeoKey record as mutually exclusive, but the WKT it produces is horizontal-only, and the vertical datum and vertical unit live only in the GeoKeys. A scan carrying a NAVD88 height in US survey feet converted to LAS 1.4 came out declaring no vertical datum and no vertical unit at all, so a reader takes the feet for metres. LAS 1.4 allows both records, and the writer now emits the vertical GeoKeys alongside the WKT. The WKT stays the only horizontal authority, and no empty GeoKey record is written when there is no vertical to add.

**Contour GeoJSON labelled every elevation "metre".** The value is in the source vertical unit, so a compound CRS with feet above a metre grid shipped 100 ft labelled as 100 m. The label now comes from the resolved vertical factor, and an unresolved factor reads unknown rather than defaulting to metre. This required carrying the factor on the terrain core so the contour model can state its own unit.

**EPT laszip tiles skipped the finite-position check.** Its two sibling decoders refuse a node whose transform or decoded positions are not finite; this path had neither, so a header with an extreme but valid scale could overflow to infinite coordinates and reach the renderer as a blank cloud with no error. It now refuses with the same structured error the siblings raise.

Each fix has a test that fails on the old code, and all five test buckets pass.
