### PR TITLE
Make the vertical unit factor consistent across derivative, fill and export paths

### DIFF
--- a/src/terrain/engine/TerrainRasterEngine.ts
+++ b/src/terrain/engine/TerrainRasterEngine.ts
@@ -175,6 +175,10 @@ export interface TerrainRasterBackend {
    * square cells (`cellSizeM` both axes) — the historical isotropic call.
    * A backend MUST honour it: the per-session probe exercises anisotropic
    * cells, so a kernel that silently ignores `cellSizeYM` fails the gate.
+   *
+   * `zScale` is `verticalUnitToMetres` — the factor that converts the rise of a
+   * native-unit grid (e.g. a foot-vertical DTM) so rise and run share a unit.
+   * Omitted means 1. A backend MUST honour it too; the probe runs a zScale pass.
    */
   derivatives(
     z: Float32Array,
@@ -182,6 +186,7 @@ export interface TerrainRasterBackend {
     rows: number,
     cellSizeM: number,
     cellSizeYM?: number,
+    zScale?: number,
   ): Promise<TerrainDerivatives>;
   hillshade(
     slope: ArrayLike<number>,
@@ -219,6 +224,14 @@ export const EQUIVALENCE_SHADE_TOLERANCE = 1;
  */
 export const PROBE_ANISO_CELL_X = 0.5;
 export const PROBE_ANISO_CELL_Y = 1;
+/**
+ * Probe vertical unit factor: the international foot. The probe runs the
+ * derivative kernels a THIRD time with it, so a backend that ignores `zScale`
+ * (computing a correct metric estimate) cannot pass the gate — on a
+ * foot-vertical DTM it would overstate slope by 1/0.3048 ≈ 3.28x. Both earlier
+ * passes ran at zScale 1 on both sides and were blind to that.
+ */
+export const PROBE_Z_SCALE = 0.3048;
 
 const TWO_PI = 2 * Math.PI;
 
@@ -384,12 +397,19 @@ export async function runEquivalenceProbe(
     PROBE_ANISO_CELL_Y,
   );
   const dAniso = compareDerivativeGrids(refAniso, gotAniso);
-  // Fold the two passes: the gate is the WORST per-cell disagreement across
-  // both geometries, and the aspect-compared tally covers both.
+  // Vertical-unit pass — a foot-vertical grid. Run on the SAME surface so a
+  // backend that drops `zScale` diverges here even though it matched the two
+  // metric passes bit-for-bit.
+  const refZ = hornSlopeAspect(z, cols, rows, cellSizeM, cellSizeM, PROBE_Z_SCALE);
+  const gotZ = await backend.derivatives(z, cols, rows, cellSizeM, cellSizeM, PROBE_Z_SCALE);
+  const dZ = compareDerivativeGrids(refZ, gotZ);
+  // Fold the passes: the gate is the WORST per-cell disagreement across every
+  // geometry, and the aspect-compared tally covers them all.
   const d = {
-    maxSlopeErr: Math.max(dIso.maxSlopeErr, dAniso.maxSlopeErr),
-    maxAspectErr: Math.max(dIso.maxAspectErr, dAniso.maxAspectErr),
-    comparedAspectCells: dIso.comparedAspectCells + dAniso.comparedAspectCells,
+    maxSlopeErr: Math.max(dIso.maxSlopeErr, dAniso.maxSlopeErr, dZ.maxSlopeErr),
+    maxAspectErr: Math.max(dIso.maxAspectErr, dAniso.maxAspectErr, dZ.maxAspectErr),
+    comparedAspectCells:
+      dIso.comparedAspectCells + dAniso.comparedAspectCells + dZ.comparedAspectCells,
   };
 
   const n = cols * rows;
@@ -622,12 +642,13 @@ export class TerrainRasterEngine {
     rows: number,
     cellSizeM: number,
     cellSizeYM?: number,
+    zScale = 1,
   ): Promise<TerrainDerivatives> {
     await this.init();
     const gpu = this.gpu;
     if (gpu) {
       try {
-        const out = await gpu.derivatives(z, cols, rows, cellSizeM, cellSizeYM);
+        const out = await gpu.derivatives(z, cols, rows, cellSizeM, cellSizeYM, zScale);
         this.lastCall = 'gpu';
         return out;
       } catch (err) {
@@ -635,7 +656,7 @@ export class TerrainRasterEngine {
       }
     }
     this.lastCall = 'cpu';
-    return hornSlopeAspect(z, cols, rows, cellSizeM, cellSizeYM);
+    return hornSlopeAspect(z, cols, rows, cellSizeM, cellSizeYM, zScale);
   }
 
   /** Async hillshade — same routing/fallback contract as {@link derivatives}. */

--- a/src/terrain/engine/cpuBackend.ts
+++ b/src/terrain/engine/cpuBackend.ts
@@ -33,10 +33,11 @@ export function createCpuBackend(): TerrainRasterBackend {
     scatterMinCount: (points, grid) => Promise.resolve(scatterMinCountReference(points, grid)),
     // The backend contract is async (WebGPU readback forces it); the CPU
     // implementations are synchronous, wrapped in a resolved Promise. The
-    // per-axis cell size passes straight through — hornSlopeAspect already
-    // accepts it (cellSizeYM defaults to cellSizeM there, square cells).
-    derivatives: (z, cols, rows, cellSizeM, cellSizeYM) =>
-      Promise.resolve(hornSlopeAspect(z, cols, rows, cellSizeM, cellSizeYM)),
+    // per-axis cell size and the vertical unit factor pass straight through —
+    // hornSlopeAspect already accepts both (cellSizeYM defaults to cellSizeM
+    // there, square cells; zScale defaults to 1).
+    derivatives: (z, cols, rows, cellSizeM, cellSizeYM, zScale) =>
+      Promise.resolve(hornSlopeAspect(z, cols, rows, cellSizeM, cellSizeYM, zScale)),
     hillshade: (slope, aspect, coverage, cols, rows, params) =>
       Promise.resolve(shadeFromSlopeAspect(slope, aspect, coverage, cols, rows, params)),
   };

--- a/src/terrain/engine/gpuBackend.ts
+++ b/src/terrain/engine/gpuBackend.ts
@@ -174,6 +174,7 @@ struct Params {
   rows : u32,
   cellX : f32,
   cellY : f32,
+  zScale : f32,
 };
 
 @group(0) @binding(0) var<storage, read> zin : array<f32>;
@@ -217,7 +218,10 @@ fn horn_main(@builtin(global_invocation_id) gid : vec3<u32>) {
   // cos φ × the N–S (row) spacing, so each gradient divides by ITS axis.
   let dzdx = (c + 2.0 * f + i2 - (a + 2.0 * d + g)) / (8.0 * p.cellX);
   let dzdy = (g + 2.0 * h + i2 - (a + 2.0 * b + c)) / (8.0 * p.cellY);
-  slopeOut[idx] = sqrt(dzdx * dzdx + dzdy * dzdy);
+  // Rise/run must share a unit: zScale (= verticalUnitToMetres) converts the
+  // rise of a native-unit grid. Slope is linear in the rise, so scaling the
+  // final tangent is exact; aspect is a direction and is left untouched.
+  slopeOut[idx] = sqrt(dzdx * dzdx + dzdy * dzdy) * p.zScale;
   if (dzdx == 0.0 && dzdy == 0.0) {
     aspectOut[idx] = 0.0;
   } else {
@@ -390,6 +394,7 @@ export function hornDerivativesF32Reference(
   rows: number,
   cellSizeM: number,
   cellSizeYM: number = cellSizeM,
+  zScale = 1,
 ): TerrainDerivatives {
   const n = cols * rows;
   const slope = new Float32Array(n);
@@ -397,6 +402,9 @@ export function hornDerivativesF32Reference(
   if (n === 0 || !(cellSizeM > 0) || !(cellSizeYM > 0)) return { slope, aspect };
   const { zClean, valid } = buildValidityMask(z);
   const fr = Math.fround;
+  // Same guard the CPU reference applies: a non-finite or non-positive factor
+  // is no factor at all, never a silent zero slope.
+  const zs = fr(Number.isFinite(zScale) && zScale > 0 ? zScale : 1);
   // Per-axis denominators, mirroring the kernel's cellX / cellY uniforms.
   const denomX = fr(8 * fr(cellSizeM));
   const denomY = fr(8 * fr(cellSizeYM));
@@ -422,7 +430,7 @@ export function hornDerivativesF32Reference(
       // (c + 2f + i2 − (a + 2d + g)) / (8·cell), f32 at every step, per axis.
       const dzdx = fr(fr(fr(fr(zC + fr(2 * zF)) + zI) - fr(fr(zA + fr(2 * zD)) + zG)) / denomX);
       const dzdy = fr(fr(fr(fr(zG + fr(2 * zH)) + zI) - fr(fr(zA + fr(2 * zB)) + zC)) / denomY);
-      slope[idx] = fr(Math.sqrt(fr(fr(dzdx * dzdx) + fr(dzdy * dzdy))));
+      slope[idx] = fr(fr(Math.sqrt(fr(fr(dzdx * dzdx) + fr(dzdy * dzdy)))) * zs);
       aspect[idx] = dzdx === 0 && dzdy === 0 ? 0 : fr(Math.atan2(-dzdy, -dzdx));
     }
   }
@@ -641,10 +649,12 @@ export function createGpuBackend(device: GpuDeviceLike): TerrainRasterBackend {
       return { z, counts };
     },
 
-    async derivatives(z, cols, rows, cellSizeM, cellSizeYM): Promise<TerrainDerivatives> {
+    async derivatives(z, cols, rows, cellSizeM, cellSizeYM, zScale): Promise<TerrainDerivatives> {
       const n = cols * rows;
       // Omitted Y cell = square cells (identical to the historical call).
       const cellY = cellSizeYM ?? cellSizeM;
+      // Mirror the CPU guard: an absent/invalid vertical factor is 1, not 0.
+      const zs = zScale != null && Number.isFinite(zScale) && zScale > 0 ? zScale : 1;
       // Mirror the CPU guards exactly: empty / non-positive cell → zeros.
       if (n === 0 || !(cellSizeM > 0) || !(cellY > 0)) {
         return { slope: new Float32Array(n), aspect: new Float32Array(n) };
@@ -668,17 +678,19 @@ export function createGpuBackend(device: GpuDeviceLike): TerrainRasterBackend {
         usage: GPU_USAGE.STORAGE | GPU_USAGE.COPY_SRC,
       });
       const uniBuf = device.createBuffer({
-        size: 16,
+        size: 32,
         usage: GPU_USAGE.UNIFORM | GPU_USAGE.COPY_DST,
       });
       device.queue.writeBuffer(zBuf, 0, zClean);
       device.queue.writeBuffer(validBuf, 0, valid);
-      const uni = new ArrayBuffer(16);
+      // 32 bytes: the 20-byte Params struct rounded up to a 16-byte multiple.
+      const uni = new ArrayBuffer(32);
       new Uint32Array(uni, 0, 2).set([cols, rows]);
-      // Per-axis cell sizes (cellX at byte 8, cellY at byte 12) — the WGSL
-      // Params struct; the probe's anisotropic pass verifies the kernel
-      // actually divides each gradient by its own axis.
-      new Float32Array(uni, 8, 2).set([cellSizeM, cellY]);
+      // Per-axis cell sizes (cellX at byte 8, cellY at byte 12) and the
+      // vertical unit factor (zScale at byte 16) — the WGSL Params struct. The
+      // probe's anisotropic pass verifies the kernel divides each gradient by
+      // its own axis; its zScale pass verifies it converts the rise.
+      new Float32Array(uni, 8, 3).set([cellSizeM, cellY, zs]);
       device.queue.writeBuffer(uniBuf, 0, new Uint8Array(uni));
 
       const pipeline = horn();

--- a/src/terrain/export/contourDeliverableBuild.ts
+++ b/src/terrain/export/contourDeliverableBuild.ts
@@ -28,7 +28,7 @@ import { buildContourPdfModel } from '../contourStudio/contourDeliverablePdfMode
 import { buildContourStudioPdf } from './contourStudioPdf';
 import { serializeContours } from '../contour/contourDownload';
 import { verticalUnitLabel } from '../../units/units';
-import { writeGeoTiff } from './demGeoTiff';
+import { writeGeoTiff, verticalUnitGeoKeyCode } from './demGeoTiff';
 import { parseEpsg } from './demPackage';
 import {
   buildContourPackageManifest,
@@ -214,6 +214,10 @@ function gatherDeliverable(
         epsg: dtm.horizontalEpsg ?? parseEpsg(dtm.crs),
         isGeographic: opts.isGeographic ?? false,
         verticalEpsg: dtm.verticalEpsg ?? parseEpsg(dtm.verticalDatum),
+        // Same grid, same vertical unit key as the standalone DEM package
+        // writes: without 4099 a foot-height raster read as ambiguous between
+        // metres and feet depending only on which product emitted it.
+        verticalUnitCode: verticalUnitGeoKeyCode(dtm.verticalUnitToMetres),
       }),
     );
   }

--- a/src/terrain/export/demGeoTiff.ts
+++ b/src/terrain/export/demGeoTiff.ts
@@ -42,6 +42,24 @@ export interface DemGeoTiffInput {
   readonly verticalUnitCode?: number | null;
 }
 
+/**
+ * GeoTIFF VerticalUnitsGeoKey (4099) code for a metres-per-vertical-unit factor.
+ * Matched by value (1e-9 tolerance separates the two foot definitions); an
+ * unrecognised or absent factor yields null, so the writer omits the key rather
+ * than asserting a wrong unit.
+ *
+ * Shared so every product that writes the same DTM raster derives the code the
+ * same way: the contour deliverable used to stamp 4096 without 4099, leaving a
+ * foot-height raster ambiguous while the DEM package's copy of it was not.
+ */
+export function verticalUnitGeoKeyCode(metresPerUnit: number | null | undefined): number | null {
+  if (metresPerUnit == null || !Number.isFinite(metresPerUnit)) return null;
+  if (Math.abs(metresPerUnit - 1) < 1e-9) return 9001;
+  if (Math.abs(metresPerUnit - 0.3048) < 1e-9) return 9002;
+  if (Math.abs(metresPerUnit - 1200 / 3937) < 1e-9) return 9003;
+  return null;
+}
+
 // TIFF field types.
 const T_SHORT = 3;
 const T_LONG = 4;

--- a/src/terrain/export/demPackage.ts
+++ b/src/terrain/export/demPackage.ts
@@ -23,7 +23,7 @@ import type { AnalyseContoursResult } from '../contour/analyseContours';
 import { epsgFromCrsLabel } from '../../export/crsIdentifier';
 import { buildExportProvenance, provenanceLines, type ExportPermitStamp } from './exportProvenance';
 import { writeAsciiGrid } from './demAsciiGrid';
-import { writeGeoTiff } from './demGeoTiff';
+import { writeGeoTiff, verticalUnitGeoKeyCode } from './demGeoTiff';
 import { buildZip, type ZipEntry } from '../../convert/zipStore';
 import { sha256Hex } from './sha256';
 
@@ -358,15 +358,7 @@ export function buildDemPackage(
   const epsg = dtm.horizontalEpsg ?? parseEpsg(dtm.crs);
   const verticalEpsg = dtm.verticalEpsg ?? parseEpsg(dtm.verticalDatum);
   // GeoTIFF unit code for the Z values, from the factor the analysis carried.
-  // Matched by value (1e-9 tolerance separates the two foot definitions);
-  // an unrecognised factor writes NO unit key rather than a wrong one.
-  const vUm = dtm.verticalUnitToMetres;
-  const verticalUnitCode =
-    vUm == null ? null
-    : Math.abs(vUm - 1) < 1e-9 ? 9001
-    : Math.abs(vUm - 0.3048) < 1e-9 ? 9002
-    : Math.abs(vUm - 1200 / 3937) < 1e-9 ? 9003
-    : null;
+  const verticalUnitCode = verticalUnitGeoKeyCode(dtm.verticalUnitToMetres);
   const isGeographic = options.isGeographic ?? false;
 
   // Bounds extent in CRS units: lower-left corner of the lower-left cell to the

--- a/src/terrain/ground/cellConfidence.ts
+++ b/src/terrain/ground/cellConfidence.ts
@@ -250,10 +250,32 @@ export function buildDtmGrid(raster: DemRaster, params: CellConfidenceParams = {
   // radius, so every reachable cell still gets a finite height and the
   // coverage semantics below are unchanged. Measured cells keep their
   // own value verbatim. (v0.4.0 — was nearest-neighbour everywhere.)
+  // Per-axis cell size in METRES — one derivation shared by the geodesic step
+  // cost below and the Horn slope further down, so the two stages can never
+  // disagree about how long a cell is. For a geographic frame the cell is in
+  // degrees, so convert per axis — longitude shrinks by cos(latitude) — or the
+  // E–W run is overstated off-equator and every cell reads as near-vertical.
+  const cellM = horizontalCellMetresXY(
+    cellSizeM,
+    params.isGeographic,
+    // Prefer the caller's WORLD latitude: the raster origin is render-
+    // recentred for viewer-fed grids (≈ 0 → cos φ silently 1). The origin
+    // fallback stays correct for grids built in absolute coordinates.
+    params.latitudeDeg ?? originH2 + (rows / 2) * cellSizeM,
+    params.horizontalUnitToMetres,
+  );
+
   const nearest = inpaintNearest(raster.z, hadData, cols, rows);
   const idw =
     params.interpolation === 'geodesic'
-      ? geodesicFill(raster.z, hadData, cols, rows, { cellSizeM })
+      ? geodesicFill(raster.z, hadData, cols, rows, {
+          // The geodesic cost adds a horizontal step to a vertical rise, so
+          // both must be metres. Passing the raw cell size collapsed the cost
+          // to vertical-only on a degree grid (~1e-5 beside metre heights).
+          cellMetresX: cellM.x,
+          cellMetresY: cellM.y,
+          verticalUnitToMetres: params.verticalUnitToMetres,
+        })
       : idwFill(raster.z, hadData, cols, rows, {});
   const z = new Float32Array(nCells);
   for (let i = 0; i < nCells; i++) {
@@ -278,18 +300,7 @@ export function buildDtmGrid(raster: DemRaster, params: CellConfidenceParams = {
 
   // Horn 3x3 slope — isotropic, the same estimator GDAL/ArcGIS use —
   // drives the interpolation roughness penalty. (v0.4.0 — was a crude
-  // max-neighbour difference.) For a geographic frame the cell is in degrees,
-  // so convert to metres per axis — longitude shrinks by cos(latitude) — or
-  // every cell reads as near-vertical and the E–W run is overstated off-equator.
-  const cellM = horizontalCellMetresXY(
-    cellSizeM,
-    params.isGeographic,
-    // Prefer the caller's WORLD latitude: the raster origin is render-
-    // recentred for viewer-fed grids (≈ 0 → cos φ silently 1). The origin
-    // fallback stays correct for grids built in absolute coordinates.
-    params.latitudeDeg ?? originH2 + (rows / 2) * cellSizeM,
-    params.horizontalUnitToMetres,
-  );
+  // max-neighbour difference.) Reuses the `cellM` derived above the fill.
   const slope = hornSlope(z, cols, rows, cellM.x, cellM.y, params.verticalUnitToMetres ?? 1);
 
   const confidence = new Float32Array(nCells);

--- a/src/terrain/ground/cellConfidence.ts
+++ b/src/terrain/ground/cellConfidence.ts
@@ -261,6 +261,11 @@ export function buildDtmGrid(raster: DemRaster, params: CellConfidenceParams = {
     // Prefer the caller's WORLD latitude: the raster origin is render-
     // recentred for viewer-fed grids (≈ 0 → cos φ silently 1). The origin
     // fallback stays correct for grids built in absolute coordinates.
+    //
+    // Sign checked: rasterizeDtm sets originH2 = minH2 (the SOUTH edge) and
+    // bins with row = floor((y − originH2)/cell), so rows run NORTHWARD and
+    // origin + half the rows is the grid centre, not its mirror. This now
+    // steers interpolated heights as well as slope, so it is worth pinning.
     params.latitudeDeg ?? originH2 + (rows / 2) * cellSizeM,
     params.horizontalUnitToMetres,
   );

--- a/src/terrain/ground/despike.ts
+++ b/src/terrain/ground/despike.ts
@@ -10,6 +10,10 @@
  * `findSpikes` only reports; `removeSpikes` returns arrays with the spikes
  * demoted to "no data" so the DTM builder re-fills them by interpolation. Both
  * are pure and deterministic.
+ *
+ * `z` arrives in NATIVE source vertical units; `minDeviationM` is metres. The
+ * caller must pass `verticalUnitToMetres` for anything but metric data, or the
+ * absolute floor silently means source units.
  */
 
 export interface DespikeParams {
@@ -21,6 +25,18 @@ export interface DespikeParams {
   readonly minDeviationM?: number;
   /** Minimum measured neighbours required to judge a cell. Default 4. */
   readonly minNeighbours?: number;
+  /**
+   * Metres per source vertical unit (~0.3048 for feet). Default 1.
+   *
+   * `minDeviationM` is a METRES constant while `z` is in native source units,
+   * so the deviation must be converted before the two are compared. Without it
+   * the 0.3 m blunder floor acted as 0.3 ft = 9.1 cm on foot data — 3.28x too
+   * aggressive — and real sub-30 cm features were deleted and re-interpolated,
+   * with the removal count reaching provenance. The MAD term needs no
+   * conversion of its own (it is a ratio of like units) but is scaled here too
+   * so the whole comparison happens in one unit.
+   */
+  readonly verticalUnitToMetres?: number;
 }
 
 const MAD_TO_SIGMA = 1.4826;
@@ -48,6 +64,13 @@ export function findSpikes(
   const madThreshold = params.madThreshold ?? 5;
   const minDev = Math.max(0, params.minDeviationM ?? 0.05);
   const minNeighbours = Math.max(1, params.minNeighbours ?? 4);
+  // Scale the deviation and the MAD sigma into metres so `minDeviationM` means
+  // metres on every source. A non-finite/non-positive factor is no factor (1),
+  // never a silent 0 that would flag every cell.
+  const vUnit =
+    Number.isFinite(params.verticalUnitToMetres) && (params.verticalUnitToMetres as number) > 0
+      ? (params.verticalUnitToMetres as number)
+      : 1;
 
   const neigh: number[] = [];
   const dev: number[] = [];
@@ -73,8 +96,8 @@ export function findSpikes(
       dev.length = 0;
       for (const v of neigh) dev.push(Math.abs(v - med));
       dev.sort((a, b) => a - b);
-      const sigma = MAD_TO_SIGMA * median(dev);
-      const d = Math.abs((z[i] as number) - med);
+      const sigma = MAD_TO_SIGMA * median(dev) * vUnit;
+      const d = Math.abs((z[i] as number) - med) * vUnit;
       const threshold = Math.max(madThreshold * sigma, minDev);
       if (d > threshold && d > minDev) out[i] = 1;
     }

--- a/src/terrain/ground/geodesicFill.ts
+++ b/src/terrain/ground/geodesicFill.ts
@@ -14,7 +14,8 @@
  *            surface to walk on (voids have no height of their own yet).
  *   Pass 2 — for each void cell, a Dijkstra over an 8-connected window (capped
  *            at `maxRadiusCells` from the source) accumulates path cost
- *            = Σ sqrt(stepXY² + Δz²) using the prefilled heights, collecting the
+ *            = Σ sqrt(stepXY² + Δz²) — both terms in METRES — using the
+ *            prefilled heights, collecting the
  *            nearest `kNearest` MEASURED cells by geodesic cost; the void is the
  *            inverse-distance blend of those (weight 1/cost^power).
  *
@@ -32,8 +33,26 @@ export interface GeodesicParams {
   readonly kNearest?: number;
   /** Max search radius in cells from each void (bounds the Dijkstra). Default 24. */
   readonly maxRadiusCells?: number;
-  /** Horizontal cell size in metres (sets the geodesic step length). Default 1. */
-  readonly cellSizeM?: number;
+  /**
+   * East–west (column) cell size in METRES — the horizontal half of the step
+   * cost. Callers derive it with `horizontalCellMetresXY`, the same helper the
+   * slope stage uses, so a geographic (degree) or foot grid converts once and
+   * identically. Default 1.
+   */
+  readonly cellMetresX?: number;
+  /** North–south (row) cell size in metres. Defaults to `cellMetresX`. */
+  readonly cellMetresY?: number;
+  /**
+   * Metres per vertical unit (`verticalUnitToMetres`), applied to Δz. Default 1.
+   * The step cost is sqrt(stepXY² + Δz²), so the two terms must be in the same
+   * unit; a foot-vertical grid measured against metre steps overstates the climb.
+   */
+  readonly verticalUnitToMetres?: number;
+}
+
+/** Positive-and-finite guard, or the fallback. Never a silent 0 step. */
+function positiveOr(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && (value as number) > 0 ? (value as number) : fallback;
 }
 
 // 8-connected neighbour offsets.
@@ -60,7 +79,12 @@ export function geodesicFill(
   const power = Number.isFinite(params.power) && (params.power as number) > 0 ? (params.power as number) : 2;
   const kNearest = Math.max(1, Math.floor(params.kNearest ?? 12));
   const maxRadius = Math.max(1, Math.floor(params.maxRadiusCells ?? 24));
-  const cell = Number.isFinite(params.cellSizeM) && (params.cellSizeM as number) > 0 ? (params.cellSizeM as number) : 1;
+  const cellX = positiveOr(params.cellMetresX, 1);
+  const cellY = positiveOr(params.cellMetresY, cellX);
+  const zScale = positiveOr(params.verticalUnitToMetres, 1);
+  // Diagonal step length in metres — the hypotenuse of the two axes, which
+  // reduces to cell·√2 on a square grid (the historical isotropic step).
+  const cellDiag = Math.hypot(cellX, cellY);
 
   // Pass 1 — Euclidean prefill gives a walkable provisional surface.
   const surface = idwFill(z, hadData, cols, rows, { power, kNearest, maxRadiusCells: maxRadius });
@@ -149,8 +173,9 @@ export function geodesicFill(
           if (Math.abs(nr - srow) > maxRadius || Math.abs(nc - scol) > maxRadius) continue;
           const nb = nr * cols + nc;
           if (!Number.isFinite(surface[nb])) continue; // can't walk over unknown ground
-          const stepXY = cell * (DR[k] !== 0 && DC[k] !== 0 ? Math.SQRT2 : 1);
-          const dz = surface[nb] - surface[c];
+          const stepXY =
+            DR[k] !== 0 && DC[k] !== 0 ? cellDiag : DC[k] !== 0 ? cellX : cellY;
+          const dz = (surface[nb] - surface[c]) * zScale;
           const nd = cost + Math.sqrt(stepXY * stepXY + dz * dz);
           if (seen[nb] !== iter || nd < dist[nb]) {
             dist[nb] = nd; seen[nb] = iter;

--- a/src/terrain/ground/geodesicFill.ts
+++ b/src/terrain/ground/geodesicFill.ts
@@ -19,6 +19,19 @@
  *            nearest `kNearest` MEASURED cells by geodesic cost; the void is the
  *            inverse-distance blend of those (weight 1/cost^power).
  *
+ * KNOWN LIMIT — pass 1 is frame-blind. `idwFill` weights by distance in CELLS,
+ * isotropically, so on an anisotropic grid (a geographic raster away from the
+ * equator, where the E–W cell is cos φ × the N–S cell) the provisional surface
+ * is built by an interpolant that does not know the cells are not square. Pass
+ * 2's step cost is metre-correct, but every Δz it differences comes from that
+ * surface. Because IDW weights are normalised (1/d^power over the collected
+ * samples), a UNIFORM scale cancels exactly — so projected frames, metre or
+ * foot, are unaffected and this is a geographic-only residual. Fixing it means
+ * metric distances in `idwFill`, which also changes the DEFAULT (non-geodesic)
+ * fill and needs its expanding Chebyshev ring search reworked, since "the k
+ * nearest" would no longer follow cell-ring order. Deliberately out of scope
+ * here; the pass-2 unit bug it sat behind is the one being fixed.
+ *
  * Honesty is unchanged: this only produces better interpolated HEIGHTS. Which
  * cells count as measured / interpolated / gap, and their confidence, is still
  * decided in cellConfidence.ts. No DOM, no I/O.

--- a/src/terrain/ground/surfaceFromRaster.ts
+++ b/src/terrain/ground/surfaceFromRaster.ts
@@ -98,7 +98,13 @@ export function buildSurfaceFromRaster(
   for (let i = 0; i < hadData0.length; i++) {
     if (raster.counts[i] > 0) { hadData0[i] = 1; measuredCellCount++; }
   }
-  const despiked = removeSpikes(raster.z, hadData0, raster.cols, raster.rows, LIVE_DESPIKE);
+  // `raster.z` is in native source vertical units and LIVE_DESPIKE's floor is
+  // metres, so the factor has to travel with it — otherwise 30 cm reads as
+  // 30 source units and a foot-vertical scan loses real sub-30 cm features.
+  const despiked = removeSpikes(raster.z, hadData0, raster.cols, raster.rows, {
+    ...LIVE_DESPIKE,
+    verticalUnitToMetres: params.verticalUnitToMetres,
+  });
   // Safety cap: if "outliers" exceed 2% of measured cells the data is noisy,
   // not spiky — removing that much would distort the surface, so leave it.
   const removalCap = Math.max(4, Math.ceil(measuredCellCount * 0.02));

--- a/src/terrain/surface/hillshade.ts
+++ b/src/terrain/surface/hillshade.ts
@@ -1,39 +1,27 @@
 /**
  * hillshade.ts
  *
- * Slope (degrees) and hillshade (shaded relief) rasters from an elevation
- * surface, using the Horn slope/aspect already used elsewhere. Hillshade is
- * the standard ESRI illumination model; aspect from `hornSlopeAspect` is the
- * downslope direction in the math frame (atan2(−dz/dy, −dz/dx) on our
- * northing-up grids — see terrainDerivatives.ts), which is the same frame
- * `azimuthToMathRad` converts the sun azimuth into, so the cos(az − aspect)
- * alignment term below compares like with like. This module computes no
- * derivatives of its own.
+ * Hillshade (shaded relief) and slope statistics from PRECOMPUTED slope/aspect
+ * grids. Hillshade is the standard ESRI illumination model; aspect from
+ * `hornSlopeAspect` is the downslope direction in the math frame
+ * (atan2(−dz/dy, −dz/dx) on our northing-up grids — see terrainDerivatives.ts),
+ * which is the same frame `azimuthToMathRad` converts the sun azimuth into, so
+ * the cos(az − aspect) alignment term below compares like with like.
  *
- * Pure data — no DOM. Deterministic. Assumes Z is in the same linear unit as
- * X/Y (true for metric projected data); `zFactor` lets a caller correct it.
+ * This module computes no derivatives of its own — deliberately. It used to
+ * carry `computeSlopeDegrees` and `computeHillshade`, elevation-grid wrappers
+ * that ran the Horn pass with hard-coded square cells and no vertical scaling.
+ * Nothing called them; they were a trap for a future caller on a geographic or
+ * foot-vertical grid, so they are gone. Callers run `hornSlopeAspect` (which
+ * takes per-axis cell metres and `zScale`) and pass the result in here.
+ *
+ * Pure data — no DOM. Deterministic. Slope arriving here is a tangent in a
+ * consistent unit; `zFactor` is vertical EXAGGERATION for looks, not a unit fix.
  */
 
-import { hornSlopeAspect, hornSlope } from '../ground/terrainDerivatives';
 import { quantileSorted } from '../quantile';
 
 const DEG = Math.PI / 180;
-
-/** Slope in DEGREES per cell (0 on flat / non-finite cells). */
-export function computeSlopeDegrees(
-  z: Float32Array,
-  cols: number,
-  rows: number,
-  cellSizeM: number,
-  zScale = 1,
-): Float32Array {
-  // `zScale` = verticalUnitToMetres, so a native-unit (e.g. feet) elevation
-  // grid produces a true slope angle against the metres cell size. Default 1.
-  const slope = hornSlope(z, cols, rows, cellSizeM, cellSizeM, zScale);
-  const out = new Float32Array(slope.length);
-  for (let i = 0; i < slope.length; i++) out[i] = (Math.atan(slope[i]) * 180) / Math.PI;
-  return out;
-}
 
 export interface HillshadeParams {
   /** Sun azimuth in degrees clockwise from north. Default 315 (NW). */
@@ -101,19 +89,6 @@ export function shadeFromSlopeAspect(
     shade[i] = Math.max(0, Math.min(255, Math.round(255 * hs)));
   }
   return { shade, coverage: cov, cols, rows };
-}
-
-/** Compute a hillshade raster (ESRI illumination model). */
-export function computeHillshade(
-  z: Float32Array,
-  cols: number,
-  rows: number,
-  cellSizeM: number,
-  coverage: Uint8Array | ReadonlyArray<number>,
-  params: HillshadeParams = {},
-): HillshadeResult {
-  const { slope, aspect } = hornSlopeAspect(z, cols, rows, cellSizeM);
-  return shadeFromSlopeAspect(slope, aspect, coverage, cols, rows, params);
 }
 
 /**

--- a/tests/cellConfidence.test.ts
+++ b/tests/cellConfidence.test.ts
@@ -82,6 +82,59 @@ describe('buildDtmGrid', () => {
     expect(geographic.confidence[1]).toBeGreaterThan(projected.confidence[1]);
   });
 
+  it('geodesic fill walks in metres: a degree grid fills like its metric twin', () => {
+    // The geodesic step cost is sqrt(stepXY² + Δz²). The caller used to hand it
+    // the RAW cell size, so on a geographic grid stepXY was ~1e-2 degrees while
+    // Δz was metres: the cost collapsed to vertical-only and the "walk over the
+    // ridge" down-weighting degenerated. The same terrain in degrees and in
+    // metres must produce the same interpolated heights.
+    const DEG = 0.01;
+    const mk = (cellSizeM: number): DemRaster => ({
+      // Ridge row at 100, valley rows at 0, with a void in the valley.
+      z: Float32Array.from([100, 100, 100, 0, NaN, 0, 0, 0, 0]),
+      counts: Uint32Array.from([8, 8, 8, 8, 0, 8, 8, 8, 8]),
+      cols: 3,
+      rows: 3,
+      cellSizeM,
+      originH1: 0,
+      originH2: 0,
+      coverage: 'full',
+      sourcePointCount: 64,
+      analyzedPointCount: 64,
+      filledCellCount: 8,
+      warnings: [],
+    });
+    const metric = buildDtmGrid(mk(DEG * 111_320), {
+      crs: 'EPSG:32610', interpolation: 'geodesic',
+    });
+    const geographic = buildDtmGrid(mk(DEG), {
+      crs: 'EPSG:4326', isGeographic: true, latitudeDeg: 0, interpolation: 'geodesic',
+    });
+    expect(geographic.z[4]).toBeCloseTo(metric.z[4], 4);
+  });
+
+  it('the DEFAULT (Euclidean IDW) fill is untouched by the horizontal frame', () => {
+    // Only the non-default geodesic mode reads the metre-converted cell size.
+    // The default fill works in grid space and must stay byte-identical whether
+    // the frame is projected metres, degrees, or feet.
+    const mk = (cellSizeM: number): DemRaster => ({
+      z: Float32Array.from([100, 100, 100, 0, NaN, 0, 0, 0, 0]),
+      counts: Uint32Array.from([8, 8, 8, 8, 0, 8, 8, 8, 8]),
+      cols: 3, rows: 3, cellSizeM, originH1: 0, originH2: 0,
+      coverage: 'full', sourcePointCount: 64, analyzedPointCount: 64,
+      filledCellCount: 8, warnings: [],
+    });
+    const projected = buildDtmGrid(mk(1), { crs: 'EPSG:32610' });
+    const geographic = buildDtmGrid(mk(0.01), {
+      crs: 'EPSG:4326', isGeographic: true, latitudeDeg: 45,
+    });
+    const feet = buildDtmGrid(mk(1), {
+      crs: 'EPSG:2225', horizontalUnitToMetres: 0.3048, verticalUnitToMetres: 0.3048,
+    });
+    expect(Array.from(geographic.z)).toEqual(Array.from(projected.z));
+    expect(Array.from(feet.z)).toEqual(Array.from(projected.z));
+  });
+
   it('absolute-density floor: a thinly-sampled measured cell is not fully trusted', () => {
     // Two measured cells, one with a single return and one densely
     // sampled, in a scene whose median is dragged down by the sparse

--- a/tests/cellConfidence.test.ts
+++ b/tests/cellConfidence.test.ts
@@ -16,6 +16,7 @@ import {
   type DtmGrid,
 } from '../src/terrain/ground/cellConfidence';
 import type { DemRaster } from '../src/terrain/ground/rasterizeDtm';
+import { geodesicFill } from '../src/terrain/ground/geodesicFill';
 
 function raster(opts: {
   z: number[];
@@ -113,10 +114,52 @@ describe('buildDtmGrid', () => {
     expect(geographic.z[4]).toBeCloseTo(metric.z[4], 4);
   });
 
+  it('applies cos(latitude) to the geodesic step away from the equator', () => {
+    // The case above sits at latitude 0, where cos φ = 1 and the anisotropy the
+    // per-axis step exists for is absent — a build that passed one scalar to
+    // both axes would still pass it. At 60° N a degree of longitude is HALF a
+    // degree of latitude in metres, so the E–W and N–S steps must differ.
+    const DEG = 0.01;
+    const LAT = 60;
+    const raster: DemRaster = {
+      // Ridge along the north row, valley below it, void in the valley: the
+      // walk north costs differently from the walk east/west.
+      z: Float32Array.from([100, 100, 100, 0, NaN, 0, 0, 0, 0]),
+      counts: Uint32Array.from([8, 8, 8, 8, 0, 8, 8, 8, 8]),
+      cols: 3, rows: 3, cellSizeM: DEG, originH1: 0, originH2: 0,
+      coverage: 'full', sourcePointCount: 64, analyzedPointCount: 64,
+      filledCellCount: 8, warnings: [],
+    };
+    const grid = buildDtmGrid(raster, {
+      crs: 'EPSG:4326', isGeographic: true, latitudeDeg: LAT, interpolation: 'geodesic',
+    });
+
+    // What the stage must have handed the fill: the N–S cell in metres, and the
+    // E–W cell shrunk by cos(60°) = 0.5.
+    const nsMetres = DEG * 111_320;
+    const expected = geodesicFill(raster.z, Uint8Array.from([1, 1, 1, 1, 0, 1, 1, 1, 1]), 3, 3, {
+      cellMetresX: nsMetres * Math.cos((LAT * Math.PI) / 180),
+      cellMetresY: nsMetres,
+    });
+    expect(grid.z[4]).toBeCloseTo(expected[4], 6);
+
+    // …and that is genuinely not the isotropic answer, so the assertion above
+    // is not satisfied by a stage that ignored the latitude.
+    const isotropic = geodesicFill(raster.z, Uint8Array.from([1, 1, 1, 1, 0, 1, 1, 1, 1]), 3, 3, {
+      cellMetresX: nsMetres,
+      cellMetresY: nsMetres,
+    });
+    expect(Math.abs(expected[4] - isotropic[4])).toBeGreaterThan(1e-3);
+  });
+
   it('the DEFAULT (Euclidean IDW) fill is untouched by the horizontal frame', () => {
-    // Only the non-default geodesic mode reads the metre-converted cell size.
-    // The default fill works in grid space and must stay byte-identical whether
-    // the frame is projected metres, degrees, or feet.
+    // A TRIPWIRE, not a proof. The default branch calls `idwFill(…, {})` with
+    // no options at all, so today no frame-derived value can reach it and this
+    // cannot fail — it is structurally unfalsifiable as written. Its job is to
+    // go red the day someone threads the cell size into that call without
+    // meaning to, which is exactly the change the geodesic branch just made
+    // next door. (Making the default fill metric-aware is a real improvement,
+    // but a deliberate one that must arrive with its own expectations.)
     const mk = (cellSizeM: number): DemRaster => ({
       z: Float32Array.from([100, 100, 100, 0, NaN, 0, 0, 0, 0]),
       counts: Uint32Array.from([8, 8, 8, 8, 0, 8, 8, 8, 8]),

--- a/tests/demExport.test.ts
+++ b/tests/demExport.test.ts
@@ -519,6 +519,44 @@ describe('buildDemPackage', () => {
     expect(readTiffGeoKey(extractEntry(zip, 'site-dtm.tif')!, 4099)).toBe(9002);
   });
 
+  it('writes the same vertical unit key from the contour deliverable as from the DEM package', () => {
+    // The same DTM raster leaves the app through two products. The deliverable
+    // stamped the vertical CRS (4096) but not its unit (4099), so a foot-height
+    // raster from Contour Studio was ambiguous between metres and feet while the
+    // byte-identical grid from the DEM package was not.
+    const grid = buildDtmGrid(
+      {
+        z: Float32Array.from([10, 20, 30, 40]),
+        counts: Uint32Array.from([6, 6, 6, 6]),
+        cols: 2, rows: 2, cellSizeM: 1, originH1: 10, originH2: 20,
+        coverage: 'full', sourcePointCount: 24, analyzedPointCount: 24,
+        filledCellCount: 4, warnings: [],
+      },
+      { crs: 'EPSG:32610', verticalEpsg: 5703, verticalUnitToMetres: 0.3048 },
+    );
+    const r = fixtureResult();
+    (r as { dtm: unknown }).dtm = grid;
+    const opts = { worldOrigin: { x: 600000, y: 4000000 }, basename: 'site' };
+    const fromPackage = readTiffGeoKey(
+      extractEntry(buildDemPackage(r, opts), 'site-dtm.tif')!, 4099,
+    );
+    const deliverable = buildContourDeliverableFromResult(r, {
+      decision: { status: 'validated', badge: 'Internal validation', caveats: [] },
+      basename: 'site',
+      worldOrigin: { x: 600000, y: 4000000 },
+      isGeographic: false,
+      verticalUnitToMetres: 0.3048,
+      softwareVersion: '0.5.9',
+      metricVersion: 'v0.4.1',
+      generatedAt: new Date('2026-07-26T00:00:00.000Z'),
+      exportPermit: null,
+    });
+    const fromDeliverable = readTiffGeoKey(extractEntry(deliverable, 'site_DTM.tif')!, 4099);
+    expect(fromPackage).toBe(9002);
+    expect(fromDeliverable).toBe(9002);
+    expect(fromDeliverable).toBe(fromPackage);
+  });
+
   it('stamps the DTM and DSM with the vertical CRS but leaves the CHM unstamped', () => {
     const zip = buildDemPackage(fixtureResult(), {
       worldOrigin: { x: 600000, y: 4000000 }, basename: 'site',

--- a/tests/demExport.test.ts
+++ b/tests/demExport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { writeAsciiGrid } from '../src/terrain/export/demAsciiGrid';
-import { writeGeoTiff } from '../src/terrain/export/demGeoTiff';
+import { writeGeoTiff, verticalUnitGeoKeyCode } from '../src/terrain/export/demGeoTiff';
 import { buildDemPackage, parseEpsg } from '../src/terrain/export/demPackage';
 import { buildDtmGrid } from '../src/terrain/ground/cellConfidence';
 import { sha256Hex } from '../src/terrain/export/sha256';
@@ -517,6 +517,20 @@ describe('buildDemPackage', () => {
     (r as { dtm: unknown }).dtm = grid;
     const zip = buildDemPackage(r, { worldOrigin: { x: 600000, y: 4000000 }, basename: 'site' });
     expect(readTiffGeoKey(extractEntry(zip, 'site-dtm.tif')!, 4099)).toBe(9002);
+  });
+
+  it('maps a metres-per-unit factor to its GeoTIFF unit code, or to none', () => {
+    // The shared derivation both products now go through. An unrecognised
+    // factor must yield null so the writer omits key 4099 rather than
+    // asserting a unit the data never declared.
+    expect(verticalUnitGeoKeyCode(1)).toBe(9001); // metre
+    expect(verticalUnitGeoKeyCode(0.3048)).toBe(9002); // international foot
+    expect(verticalUnitGeoKeyCode(1200 / 3937)).toBe(9003); // US survey foot
+    // The two foot definitions differ by ~2 ppm and must not collapse together.
+    expect(verticalUnitGeoKeyCode(0.3048)).not.toBe(verticalUnitGeoKeyCode(1200 / 3937));
+    for (const unknown of [null, undefined, 0, -1, 0.9144, Number.NaN, Infinity]) {
+      expect(verticalUnitGeoKeyCode(unknown)).toBeNull();
+    }
   });
 
   it('writes the same vertical unit key from the contour deliverable as from the DEM package', () => {

--- a/tests/dtmHardening.test.ts
+++ b/tests/dtmHardening.test.ts
@@ -52,6 +52,43 @@ describe('despike — robust local outlier rejection', () => {
     blunder[12] = 15;
     expect(findSpikes(blunder, had, cols, rows, { minDeviationM: 0.3 })[12]).toBe(1);
   });
+
+  it('measures the floor in METRES against native-unit heights', () => {
+    // `minDeviationM` is a metres constant, but the heights it is compared with
+    // are in SOURCE vertical units. One physical surface — a 15 cm bump in flat
+    // terrain, comfortably inside the 30 cm blunder floor — must survive in
+    // BOTH frames. Without the conversion the effective floor on foot data is
+    // 0.3 ft = 9.1 cm, 3.28x too aggressive: a real feature is deleted and
+    // silently re-interpolated, and `despikedCellCount` reaches provenance, so
+    // two deliverables of the same scan disagree about how much data was cut.
+    const cols = 5, rows = 5;
+    const had = new Uint8Array(cols * rows).fill(1);
+
+    const metres = new Float32Array(cols * rows).fill(10);
+    metres[12] = 10.15; // +15 cm
+    const inMetres = findSpikes(metres, had, cols, rows, { minDeviationM: 0.3 });
+
+    const feet = new Float32Array(cols * rows).fill(10 / 0.3048);
+    feet[12] = 10.15 / 0.3048; // the SAME surface, expressed in feet
+    const inFeet = findSpikes(feet, had, cols, rows, {
+      minDeviationM: 0.3,
+      verticalUnitToMetres: 0.3048,
+    });
+
+    expect(inMetres[12]).toBe(0); // 15 cm < the 30 cm floor
+    expect(inFeet[12]).toBe(inMetres[12]); // …and the same in feet
+    expect(Array.from(inFeet).reduce((a, b) => a + b, 0)).toBe(0);
+
+    // The floor still bites on a genuine blunder in the foot frame: 5 m up.
+    const blunderFt = new Float32Array(cols * rows).fill(10 / 0.3048);
+    blunderFt[12] = 15 / 0.3048;
+    expect(
+      findSpikes(blunderFt, had, cols, rows, {
+        minDeviationM: 0.3,
+        verticalUnitToMetres: 0.3048,
+      })[12],
+    ).toBe(1);
+  });
 });
 
 function raster(z: number[], counts: number[], cols: number, rows: number): DemRaster {

--- a/tests/geodesicFill.test.ts
+++ b/tests/geodesicFill.test.ts
@@ -39,10 +39,6 @@ describe('geodesicFill', () => {
     const z = Float32Array.from([100, 100, 100, 0, NaN, 0, 0, 0, 0]);
     const had = Uint8Array.from([1, 1, 1, 1, 0, 1, 1, 1, 1]);
     const metres = geodesicFill(z, had, 3, 3, { cellMetresX: 1113.2, cellMetresY: 1113.2 });
-    // Per-axis steps: a grid whose N–S cell is 100x its E–W cell (the cos φ
-    // geometry near the poles) cannot fill like a square one.
-    const anisotropic = geodesicFill(z, had, 3, 3, { cellMetresX: 1113.2, cellMetresY: 11.132 });
-    expect(anisotropic[4]).not.toBeCloseTo(metres[4], 5);
 
     // And a foot-vertical grid: the rise is converted before it is compared
     // with the metre step, so the same surface in feet fills equivalently.
@@ -51,6 +47,33 @@ describe('geodesicFill', () => {
       cellMetresX: 1113.2, cellMetresY: 1113.2, verticalUnitToMetres: 0.3048,
     });
     expect(inFeet[4] * 0.3048).toBeCloseTo(metres[4], 5);
+  });
+
+  it('costs a diagonal step as the metric hypotenuse of the two axes', () => {
+    // The single load-bearing line of the per-axis step: `hypot(cellX, cellY)`.
+    // A diagonal move crosses one cell on EACH axis, so on a grid whose N–S
+    // cell is 100x its E–W cell it must cost at least the longer axis (100.005),
+    // never a blend of the two — the plausible-looking mean (50.5) makes every
+    // diagonal ~half price, reroutes Dijkstra and shifts every filled height on
+    // every production surface.
+    //
+    // Dijkstra's route choice is discrete, so the resulting height is pinned by
+    // value rather than by an inequality: an ordering assertion is satisfied by
+    // the wrong cost too. The mean-diagonal mutant yields 12.7307786942 here
+    // and 13.0511302948 on the square grid below.
+    const z = Float32Array.from([100, 100, 100, 0, NaN, 0, 0, 0, 0]);
+    const had = Uint8Array.from([1, 1, 1, 1, 0, 1, 1, 1, 1]);
+
+    const anisotropic = geodesicFill(z, had, 3, 3, { cellMetresX: 1, cellMetresY: 100 });
+    expect(anisotropic[4]).toBeCloseTo(9.12470722198, 8);
+
+    // The square-cell case production runs on: the diagonal is cell·√2, not cell.
+    const square = geodesicFill(z, had, 3, 3, { cellMetresX: 1, cellMetresY: 1 });
+    expect(square[4]).toBeCloseTo(13.0535078049, 8);
+
+    // Anisotropy must actually change the answer — a kernel that quietly used
+    // one axis for both would otherwise satisfy the square-grid pin alone.
+    expect(Math.abs(anisotropic[4] - square[4])).toBeGreaterThan(1);
   });
 
   it('keeps measured cells verbatim and leaves an all-empty grid NaN', () => {

--- a/tests/geodesicFill.test.ts
+++ b/tests/geodesicFill.test.ts
@@ -13,7 +13,7 @@ describe('geodesicFill', () => {
     // 3x3 all measured at 5 except the centre void.
     const z = Float32Array.from([5, 5, 5, 5, NaN, 5, 5, 5, 5]);
     const had = Uint8Array.from([1, 1, 1, 1, 0, 1, 1, 1, 1]);
-    const out = geodesicFill(z, had, 3, 3, { cellSizeM: 1 });
+    const out = geodesicFill(z, had, 3, 3, { cellMetresX: 1 });
     expect(out[4]).toBeCloseTo(5, 5);
   });
 
@@ -24,17 +24,39 @@ describe('geodesicFill', () => {
     const z = Float32Array.from([100, 100, 100, 0, NaN, 0, 0, 0, 0]);
     const had = Uint8Array.from([1, 1, 1, 1, 0, 1, 1, 1, 1]);
     const euclid = idwFill(z, had, 3, 3, {});
-    const geo = geodesicFill(z, had, 3, 3, { cellSizeM: 1 });
+    const geo = geodesicFill(z, had, 3, 3, { cellMetresX: 1 });
     expect(euclid[4]).toBeGreaterThan(25); // Euclidean is inflated by the ridge
     expect(geo[4]).toBeLessThan(euclid[4]); // geodesic stays nearer the floor
     expect(geo[4]).toBeLessThan(20);
     expect(geo[4]).toBeGreaterThanOrEqual(0);
   });
 
+  it('takes the horizontal step in METRES, per axis, and the rise in metres too', () => {
+    // The step cost is sqrt(stepXY² + Δz²), so the two terms must share a unit.
+    // The same terrain described in degrees and in metres must fill the same
+    // way; feeding raw degrees (~1e-5) beside metre heights collapses the cost
+    // to vertical-only and the walk-over-the-ridge down-weighting degenerates.
+    const z = Float32Array.from([100, 100, 100, 0, NaN, 0, 0, 0, 0]);
+    const had = Uint8Array.from([1, 1, 1, 1, 0, 1, 1, 1, 1]);
+    const metres = geodesicFill(z, had, 3, 3, { cellMetresX: 1113.2, cellMetresY: 1113.2 });
+    // Per-axis steps: a grid whose N–S cell is 100x its E–W cell (the cos φ
+    // geometry near the poles) cannot fill like a square one.
+    const anisotropic = geodesicFill(z, had, 3, 3, { cellMetresX: 1113.2, cellMetresY: 11.132 });
+    expect(anisotropic[4]).not.toBeCloseTo(metres[4], 5);
+
+    // And a foot-vertical grid: the rise is converted before it is compared
+    // with the metre step, so the same surface in feet fills equivalently.
+    const feet = Float32Array.from([100 / 0.3048, 100 / 0.3048, 100 / 0.3048, 0, NaN, 0, 0, 0, 0]);
+    const inFeet = geodesicFill(feet, had, 3, 3, {
+      cellMetresX: 1113.2, cellMetresY: 1113.2, verticalUnitToMetres: 0.3048,
+    });
+    expect(inFeet[4] * 0.3048).toBeCloseTo(metres[4], 5);
+  });
+
   it('keeps measured cells verbatim and leaves an all-empty grid NaN', () => {
     const z = Float32Array.from([3, NaN, 7, NaN]);
     const had = Uint8Array.from([1, 0, 1, 0]);
-    const out = geodesicFill(z, had, 2, 2, { cellSizeM: 1 });
+    const out = geodesicFill(z, had, 2, 2, { cellMetresX: 1 });
     expect(out[0]).toBe(3);
     expect(out[2]).toBe(7);
     expect(Number.isFinite(out[1])).toBe(true); // reachable void filled

--- a/tests/gpuBackendDispatch.test.ts
+++ b/tests/gpuBackendDispatch.test.ts
@@ -202,6 +202,16 @@ describe('gpuBackend.derivatives — dispatch plumbing on a mock device', () => 
     // kernel must never receive 0 and flatten every slope.
     expect(new Float32Array(uniData.buffer, 16, 1)[0]).toBe(1);
 
+    // The mock never EXECUTES WGSL, so a kernel that accepts the uniform and
+    // ignores it would pass everything above. Assert the shader source itself
+    // declares the field and applies it — crude, but it turns a dropped
+    // `* p.zScale` from a silent green into a red gate. The device probe is the
+    // real equivalence check; this is the part CI can run.
+    const horn = log.shaderCodes.find((c) => c.includes('fn horn_main'));
+    expect(horn).toBeDefined();
+    expect(horn).toMatch(/zScale\s*:\s*f32/); // declared in Params
+    expect(horn).toMatch(/\*\s*p\.zScale/); // and actually multiplied in
+
     // The uploaded grid is the NaN-FREE copy plus the validity mask.
     const zUpload = storage[0].written as Float32Array;
     expect(zUpload[5]).toBe(0);

--- a/tests/gpuBackendDispatch.test.ts
+++ b/tests/gpuBackendDispatch.test.ts
@@ -178,14 +178,14 @@ describe('gpuBackend.derivatives — dispatch plumbing on a mock device', () => 
     // Bind group covers bindings 0..4 (z, valid, slope, aspect, params).
     expect(log.bindings[0]).toEqual([0, 1, 2, 3, 4]);
 
-    // Buffer inventory: 4 storage (n·4 bytes) + 1 uniform (16) + 2 staging.
+    // Buffer inventory: 4 storage (n·4 bytes) + 1 uniform (32) + 2 staging.
     const bytes = cols * rows * 4;
     const storage = log.buffers.filter((b) => (b.usage & GPU_USAGE.STORAGE) !== 0);
     expect(storage).toHaveLength(4);
     for (const b of storage) expect(b.size).toBe(bytes);
     const uniform = log.buffers.filter((b) => (b.usage & GPU_USAGE.UNIFORM) !== 0);
     expect(uniform).toHaveLength(1);
-    expect(uniform[0].size).toBe(16);
+    expect(uniform[0].size).toBe(32);
     const staging = log.buffers.filter((b) => (b.usage & GPU_USAGE.MAP_READ) !== 0);
     expect(staging).toHaveLength(2);
     expect(log.copies.map((c) => c.size)).toEqual([bytes, bytes]);
@@ -198,6 +198,9 @@ describe('gpuBackend.derivatives — dispatch plumbing on a mock device', () => 
     const cellsXY = new Float32Array(uniData.buffer, 8, 2);
     expect(cellsXY[0]).toBeCloseTo(0.5, 6);
     expect(cellsXY[1]).toBeCloseTo(0.5, 6);
+    // …and the vertical unit factor at byte 16. An omitted zScale is 1 — the
+    // kernel must never receive 0 and flatten every slope.
+    expect(new Float32Array(uniData.buffer, 16, 1)[0]).toBe(1);
 
     // The uploaded grid is the NaN-FREE copy plus the validity mask.
     const zUpload = storage[0].written as Float32Array;

--- a/tests/holdoutRmse.test.ts
+++ b/tests/holdoutRmse.test.ts
@@ -63,9 +63,14 @@ describe('holdoutValidateDtm', () => {
   });
 
   it('reports RMSE in metres via verticalUnitToMetres (feet source data)', () => {
-    // A curved surface leaves a non-zero residual; with the same seed the
-    // split is identical, so the feet run must be exactly 0.3048× the metre
-    // run — proving the residuals are scaled into metres at one point.
+    // A curved surface leaves a non-zero residual; with the same seed the split
+    // is identical, so the feet run tracks 0.3048× the metre run — the
+    // residuals are scaled into metres at one point.
+    //
+    // Not EXACTLY 0.3048×: the same z numbers read as feet describe a terrain
+    // 3.28× flatter in real space, and the geodesic void fill measures its path
+    // cost in metres, so the two runs interpolate their few empty cells
+    // slightly differently. That difference is the unit-awareness, not drift.
     const { points, mask } = surface((x) => 0.1 * x * x);
     const metre = holdoutValidateDtm(points, mask, { cellSizeM: 1, seed: 3 });
     const feet = holdoutValidateDtm(points, mask, {
@@ -74,9 +79,13 @@ describe('holdoutValidateDtm', () => {
       verticalUnitToMetres: 0.3048,
     });
     expect(metre.rmse).toBeGreaterThan(0);
-    expect(feet.rmse).toBeCloseTo(metre.rmse * 0.3048, 6);
-    expect(feet.mae).toBeCloseTo(metre.mae * 0.3048, 6);
-    expect(feet.p95).toBeCloseTo(metre.p95 * 0.3048, 6);
+    const within = (got: number, want: number): number => Math.abs(got - want) / want;
+    expect(within(feet.rmse, metre.rmse * 0.3048)).toBeLessThan(0.01);
+    expect(within(feet.mae, metre.mae * 0.3048)).toBeLessThan(0.01);
+    expect(within(feet.p95, metre.p95 * 0.3048)).toBeLessThan(0.01);
+    // A conversion applied twice, or not at all, is orders of magnitude off —
+    // this stays a real gate on the single scaling point.
+    expect(within(feet.rmse, metre.rmse)).toBeGreaterThan(0.5);
   });
 
   it('is deterministic for a fixed seed', () => {

--- a/tests/holdoutRmse.test.ts
+++ b/tests/holdoutRmse.test.ts
@@ -63,29 +63,39 @@ describe('holdoutValidateDtm', () => {
   });
 
   it('reports RMSE in metres via verticalUnitToMetres (feet source data)', () => {
-    // A curved surface leaves a non-zero residual; with the same seed the split
-    // is identical, so the feet run tracks 0.3048× the metre run — the
-    // residuals are scaled into metres at one point.
+    // PHYSICAL INVARIANCE, not a scaling identity. Describe ONE terrain twice —
+    // once with heights in metres, once with the same heights in feet plus
+    // `verticalUnitToMetres` — and the metric RMSE must come out the same. The
+    // whole chain (despike floor, geodesic path cost, slope bands, residual
+    // conversion) has to be unit-aware for that to hold; a unit bug anywhere in
+    // it moves the ratio off 1.
     //
-    // Not EXACTLY 0.3048×: the same z numbers read as feet describe a terrain
-    // 3.28× flatter in real space, and the geodesic void fill measures its path
-    // cost in metres, so the two runs interpolate their few empty cells
-    // slightly differently. That difference is the unit-awareness, not drift.
-    const { points, mask } = surface((x) => 0.1 * x * x);
-    const metre = holdoutValidateDtm(points, mask, { cellSizeM: 1, seed: 3 });
-    const feet = holdoutValidateDtm(points, mask, {
+    // The earlier form fed the SAME NUMBERS to both runs and expected exactly
+    // 0.3048x. That is two different terrains, one 3.28x flatter, so the
+    // now-unit-aware void fill legitimately parts them by ~1e-3 and the
+    // assertion had to be a tolerance band fitted to the fixture.
+    const zfn = (x: number): number => 0.1 * x * x;
+    const metric = surface(zfn);
+    const imperial = surface((x) => zfn(x) / 0.3048);
+
+    const metre = holdoutValidateDtm(metric.points, metric.mask, { cellSizeM: 1, seed: 3 });
+    const feet = holdoutValidateDtm(imperial.points, imperial.mask, {
       cellSizeM: 1,
       seed: 3,
       verticalUnitToMetres: 0.3048,
     });
     expect(metre.rmse).toBeGreaterThan(0);
-    const within = (got: number, want: number): number => Math.abs(got - want) / want;
-    expect(within(feet.rmse, metre.rmse * 0.3048)).toBeLessThan(0.01);
-    expect(within(feet.mae, metre.mae * 0.3048)).toBeLessThan(0.01);
-    expect(within(feet.p95, metre.p95 * 0.3048)).toBeLessThan(0.01);
-    // A conversion applied twice, or not at all, is orders of magnitude off —
-    // this stays a real gate on the single scaling point.
-    expect(within(feet.rmse, metre.rmse)).toBeGreaterThan(0.5);
+    // Both are already in metres, so they are equal up to f32 grid storage.
+    expect(feet.rmse / metre.rmse).toBeCloseTo(1, 6);
+    expect(feet.mae / metre.mae).toBeCloseTo(1, 6);
+    expect(feet.p95 / metre.p95).toBeCloseTo(1, 6);
+    // Drop the conversion entirely and the feet run reports ~3.28x — this is
+    // still a hard gate on the residuals reaching metres.
+    const unconverted = holdoutValidateDtm(imperial.points, imperial.mask, {
+      cellSizeM: 1,
+      seed: 3,
+    });
+    expect(unconverted.rmse / metre.rmse).toBeGreaterThan(3);
   });
 
   it('is deterministic for a fixed seed', () => {

--- a/tests/reliefShading.test.ts
+++ b/tests/reliefShading.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import {
-  shadeFromSlopeAspect,
-  computeMultiHillshade,
-  computeHillshade,
-} from '../src/terrain/surface/hillshade';
+import { shadeFromSlopeAspect, computeMultiHillshade } from '../src/terrain/surface/hillshade';
+import { hornSlopeAspect } from '../src/terrain/ground/terrainDerivatives';
 
 const COLS = 4;
 const ROWS = 4;
@@ -33,12 +30,16 @@ describe('shadeFromSlopeAspect', () => {
     expect(r.shade[5]).toBe(0);
   });
 
-  it('matches computeHillshade for a derived surface (delegation is faithful)', () => {
+  it('shades a Horn-derived surface in range (the live two-step path)', () => {
     // A simple tilted plane: z increases with x.
     const z = new Float32Array(N);
     for (let row = 0; row < ROWS; row++) for (let c = 0; c < COLS; c++) z[row * COLS + c] = c * 2;
     const cov = new Uint8Array(N).fill(1);
-    const direct = computeHillshade(z, COLS, ROWS, 1, cov, { azimuthDeg: 315, altitudeDeg: 45 });
+    const { slope, aspect } = hornSlopeAspect(z, COLS, ROWS, 1);
+    const direct = shadeFromSlopeAspect(slope, aspect, cov, COLS, ROWS, {
+      azimuthDeg: 315,
+      altitudeDeg: 45,
+    });
     expect(direct.shade.length).toBe(N);
     // Interior cells should carry a finite, in-range shade.
     expect(direct.shade[5]).toBeGreaterThanOrEqual(0);

--- a/tests/surfaceModels.test.ts
+++ b/tests/surfaceModels.test.ts
@@ -9,11 +9,38 @@ import {
   surfaceStats,
   heightAboveGround,
 } from '../src/terrain/surface/buildDsm';
-import {
-  computeSlopeDegrees,
-  computeHillshade,
-  slopeStats,
-} from '../src/terrain/surface/hillshade';
+import { shadeFromSlopeAspect, slopeStats } from '../src/terrain/surface/hillshade';
+import { hornSlopeAspect } from '../src/terrain/ground/terrainDerivatives';
+
+/**
+ * Slope in DEGREES and a shaded raster from an elevation grid — the live
+ * pipeline's own two steps (Horn pass, then the tangent→angle conversion or the
+ * ESRI shading). Local scaffolding, so the app carries no wrapper whose only
+ * caller is a test.
+ */
+function computeSlopeDegrees(
+  z: Float32Array,
+  cols: number,
+  rows: number,
+  cellM: number,
+): Float32Array {
+  const { slope } = hornSlopeAspect(z, cols, rows, cellM, cellM);
+  const out = new Float32Array(slope.length);
+  for (let i = 0; i < slope.length; i++) out[i] = (Math.atan(slope[i]) * 180) / Math.PI;
+  return out;
+}
+
+function computeHillshade(
+  z: Float32Array,
+  cols: number,
+  rows: number,
+  cellM: number,
+  coverage: Uint8Array,
+  params?: Parameters<typeof shadeFromSlopeAspect>[5],
+) {
+  const { slope, aspect } = hornSlopeAspect(z, cols, rows, cellM, cellM);
+  return shadeFromSlopeAspect(slope, aspect, coverage, cols, rows, params);
+}
 
 describe('buildDsm — top surface (max return per cell)', () => {
   const grid = { originH1: 0, originH2: 0, cols: 2, rows: 2, cellSizeM: 1 };

--- a/tests/terrainRasterEngine.test.ts
+++ b/tests/terrainRasterEngine.test.ts
@@ -94,11 +94,12 @@ function faithfulFakeGpu(calls?: {
       if (calls && calls.scatter != null) calls.scatter++;
       return Promise.resolve(scatterMinCountReference(points, grid));
     },
-    derivatives: (z, cols, rows, cell, cellY) => {
+    derivatives: (z, cols, rows, cell, cellY, zScale) => {
       if (calls) calls.derivatives++;
-      // A faithful backend honours the per-axis cell size — the probe's
-      // anisotropic pass rejects one that ignores it (tested below).
-      return Promise.resolve(hornSlopeAspect(z, cols, rows, cell, cellY));
+      // A faithful backend honours the per-axis cell size AND the vertical unit
+      // factor — the probe's anisotropic and zScale passes reject one that
+      // ignores either (both tested below).
+      return Promise.resolve(hornSlopeAspect(z, cols, rows, cell, cellY, zScale));
     },
     hillshade: (s, a, cov, cols, rows, params) => {
       if (calls) calls.hillshade++;
@@ -263,6 +264,19 @@ describe('equivalence harness — f32 kernel arithmetic vs the f64 CPU reference
     expect(d.comparedAspectCells).toBeGreaterThan(0);
   });
 
+  it('f32 transcription applies the vertical unit factor like the CPU reference', () => {
+    // A foot-vertical grid: slope is rise/run, so the rise must be converted
+    // before the ratio. A transcription that ignores zScale reports slope
+    // 1/0.3048 ≈ 3.28x too steep.
+    const { z, cols, rows, cellSizeM } = buildProbeGrid();
+    const ref = hornSlopeAspect(z, cols, rows, cellSizeM, cellSizeM, 0.3048);
+    const got = hornDerivativesF32Reference(z, cols, rows, cellSizeM, cellSizeM, 0.3048);
+    const d = compareDerivativeGrids(ref, got);
+    expect(d.maxSlopeErr).toBeLessThanOrEqual(EQUIVALENCE_SLOPE_TOLERANCE);
+    expect(d.maxAspectErr).toBeLessThanOrEqual(EQUIVALENCE_ASPECT_TOLERANCE_RAD);
+    expect(d.comparedAspectCells).toBeGreaterThan(0);
+  });
+
   it('flat cells keep the EXACT slope-0/aspect-0 convention in both', () => {
     const { z, cols, rows, cellSizeM } = buildProbeGrid();
     const ref = hornSlopeAspect(z, cols, rows, cellSizeM);
@@ -381,6 +395,42 @@ describe('the equivalence gate + auto-fallback (probe at init)', () => {
     expect(engine.getComputePath().lastCall).toBe('cpu');
   });
 
+  it('a backend that IGNORES the vertical unit factor FAILS the probe', async () => {
+    // The async entries carried no zScale at all, so a foot-vertical grid came
+    // back ~3.28x too steep — and the probe could not see it, because every
+    // probe pass ran at zScale 1 on both sides.
+    const noZScale: TerrainRasterBackend = {
+      ...faithfulFakeGpu(),
+      derivatives: async (z, cols, rows, cell, cellY) => hornSlopeAspect(z, cols, rows, cell, cellY),
+    };
+    const engine = new TerrainRasterEngine({ gpuFactory: okFactory(noZScale) });
+    const info = await engine.init();
+    expect(info.path).toBe('cpu');
+    expect(info.reason).toBe('probe-mismatch');
+    expect(info.probe!.maxSlopeErr).toBeGreaterThan(EQUIVALENCE_SLOPE_TOLERANCE);
+  });
+
+  it('async derivatives convert the rise with the vertical unit factor, like derivativesSync', async () => {
+    // The live pipeline uses derivativesSync(..., verticalUnitToMetres); the
+    // async entries dropped the factor entirely, so adopting them would have
+    // silently overstated slope on every foot-vertical scan.
+    const engine = new TerrainRasterEngine();
+    const { z, cols, rows, cellSizeM } = buildProbeGrid(16, 16);
+    const got = await engine.derivatives(z, cols, rows, cellSizeM, cellSizeM, 0.3048);
+    const ref = engine.derivativesSync(z, cols, rows, cellSizeM, cellSizeM, 0.3048);
+    expect(bytesEqual(got.slope, ref.slope)).toBe(true);
+    expect(bytesEqual(got.aspect, ref.aspect)).toBe(true);
+  });
+
+  it('a faithful gpu backend serves the vertical unit factor through the async path', async () => {
+    const engine = new TerrainRasterEngine({ gpuFactory: okFactory(faithfulFakeGpu()) });
+    await engine.init();
+    const { z, cols, rows, cellSizeM } = buildProbeGrid(16, 16);
+    const got = await engine.derivatives(z, cols, rows, cellSizeM, cellSizeM, 0.3048);
+    const ref = hornSlopeAspect(z, cols, rows, cellSizeM, cellSizeM, 0.3048);
+    expect(bytesEqual(got.slope, ref.slope)).toBe(true);
+  });
+
   it('a hillshade-diverging backend also fails the probe (shade gate ±1)', async () => {
     const badShade: TerrainRasterBackend = {
       ...faithfulFakeGpu(),
@@ -435,10 +485,10 @@ describe('the equivalence gate + auto-fallback (probe at init)', () => {
     let disposed = false;
     const flaky: TerrainRasterBackend = {
       ...faithfulFakeGpu(),
-      derivatives: async (z, cols, rows, cell, cellY) => {
-        // Pass the 64×64 probe (both its passes), then blow up on real work.
+      derivatives: async (z, cols, rows, cell, cellY, zScale) => {
+        // Pass the 64×64 probe (all of its passes), then blow up on real work.
         if (cols === PROBE_GRID_SIZE && rows === PROBE_GRID_SIZE) {
-          return hornSlopeAspect(z, cols, rows, cell, cellY);
+          return hornSlopeAspect(z, cols, rows, cell, cellY, zScale);
         }
         throw new Error('device lost');
       },

--- a/tests/terrainTruth.hillshade.test.ts
+++ b/tests/terrainTruth.hillshade.test.ts
@@ -9,7 +9,8 @@
 
 import { describe, it, expect } from 'vitest';
 import { rasterizeDtm } from '../src/terrain/ground/rasterizeDtm';
-import { computeHillshade } from '../src/terrain/surface/hillshade';
+import { hornSlopeAspect } from '../src/terrain/ground/terrainDerivatives';
+import { shadeFromSlopeAspect } from '../src/terrain/surface/hillshade';
 import { flatPlane, uniformSlope, allGround, gridFor } from './fixtures/terrainScenes';
 
 const EXTENT = { nx: 16, ny: 16, spacing: 1 } as const;
@@ -21,7 +22,9 @@ function shadeOf(pts: ReadonlyArray<{ x: number; y: number; z: number }>, params
   altitudeDeg: number;
 }): Uint8Array {
   const r = rasterizeDtm(pts, allGround(pts), { grid });
-  return computeHillshade(r.z, grid.cols, grid.rows, grid.cellSizeM, fullCov, params).shade;
+  // Derivatives then shading — the live pipeline's two steps, not a wrapper.
+  const { slope, aspect } = hornSlopeAspect(r.z, grid.cols, grid.rows, grid.cellSizeM);
+  return shadeFromSlopeAspect(slope, aspect, fullCov, grid.cols, grid.rows, params).shade;
 }
 
 const centre = 8 * grid.cols + 8; // interior cell

--- a/tests/terrainTruth.surface.test.ts
+++ b/tests/terrainTruth.surface.test.ts
@@ -8,7 +8,6 @@
 import { describe, it, expect } from 'vitest';
 import { rasterizeDtm } from '../src/terrain/ground/rasterizeDtm';
 import { hornSlopeAspect } from '../src/terrain/ground/terrainDerivatives';
-import { computeSlopeDegrees } from '../src/terrain/surface/hillshade';
 import { buildDsm, heightAboveGround } from '../src/terrain/surface/buildDsm';
 import { excludeNonGroundClasses } from '../src/terrain/ground/classificationFilter';
 import {
@@ -26,6 +25,19 @@ const EXTENT = { nx: 24, ny: 24, spacing: 1 } as const;
 const grid = gridFor(EXTENT);
 const RAD = 180 / Math.PI;
 
+/**
+ * Slope in DEGREES from the live Horn pass — the same tangent→angle step
+ * analyseContours does inline. Local scaffolding: the app has no
+ * degrees-returning entry point, and a wrapper that only tests owned would be
+ * dead code pretending to be covered.
+ */
+function slopeDegrees(z: Float32Array, cols: number, rows: number, cellM: number): Float32Array {
+  const { slope } = hornSlopeAspect(z, cols, rows, cellM, cellM);
+  const out = new Float32Array(slope.length);
+  for (let i = 0; i < slope.length; i++) out[i] = Math.atan(slope[i]) * RAD;
+  return out;
+}
+
 function rasterZ(pts: ReadonlyArray<{ x: number; y: number; z: number }>): Float32Array {
   const r = rasterizeDtm(pts, allGround(pts), { grid });
   return r.z;
@@ -41,7 +53,7 @@ function wrap360(deg: number): number {
 describe('Slope truth (Horn)', () => {
   it('flat plane -> slope ~ 0 deg everywhere', () => {
     const z = rasterZ(flatPlane(50, EXTENT));
-    const slopeDeg = computeSlopeDegrees(z, grid.cols, grid.rows, grid.cellSizeM);
+    const slopeDeg = slopeDegrees(z, grid.cols, grid.rows, grid.cellSizeM);
     for (let r = 1; r < grid.rows - 1; r++) {
       for (let c = 1; c < grid.cols - 1; c++) {
         expect(slopeDeg[r * grid.cols + c]).toBeCloseTo(0, 4);
@@ -52,7 +64,7 @@ describe('Slope truth (Horn)', () => {
   it('uniform slope -> slope angle = atan(gradient) (interior, tol 0.5 deg)', () => {
     for (const gradient of [0.1, 0.5, 1.0]) {
       const z = rasterZ(uniformSlope({ ...EXTENT, gradient, axis: 'x' }));
-      const slopeDeg = computeSlopeDegrees(z, grid.cols, grid.rows, grid.cellSizeM);
+      const slopeDeg = slopeDegrees(z, grid.cols, grid.rows, grid.cellSizeM);
       const expected = Math.atan(gradient) * RAD;
       // interior cell, away from clamped borders
       const i = 12 * grid.cols + 12;


### PR DESCRIPTION
Closes the four vertical-unit findings recorded as open in the v0.6.1 limitations. Three of them share one root cause: a quantity derived one way in one place and another way somewhere else. Each fix has a test that fails on the old code.

**The contour deliverable's GeoTIFF omitted the vertical-units key** that the standalone DEM package writes, so the same raster described its heights as unambiguous from one product and ambiguous between metres and feet from the other. The factor-to-code match now lives in one function that both products call.

**The asynchronous derivative path dropped the vertical-unit factor** that the synchronous path applies, on the CPU fallback and in the GPU kernel alike. It was not reachable from the live pipeline, but the equivalence probe that is supposed to catch exactly this could not see it: both sides were compared without the factor, on grids where it was 1. The factor is now threaded through the backend, the kernel uniforms and the reference, and the probe runs a third pass with a foot-vertical scale, so a backend that ignores it is demoted to CPU instead of passing.

**The geodesic void fill combined a horizontal step in source units with a vertical difference in metres.** On a degree grid the horizontal term is around 1e-5 while the vertical is in metres, so the cost collapsed to almost purely vertical and the "walk over the ridge" weighting stopped working. Horizontal steps are now converted to metres and the vertical difference scaled by its unit factor, derived once and shared with the slope stage.

Worth stating plainly: this is a live behaviour change, not a dormant-code cleanup. The limitations document for v0.6.1 describes this as affecting a non-default mode, which is wrong. `LIVE_INTERPOLATION` is `geodesic`, so every production surface goes through this path, and interpolated heights on geographic and foot-vertical data were affected. The next release should correct that wording.

**The unused hillshade wrappers are deleted.** They hard-coded square cells and no vertical scaling and had no production caller. Their tests were first rewritten onto the live primitives and confirmed still passing, which showed the wrappers contributed nothing the assertions depended on, and only then were the wrappers removed.

One existing test asserted that a foot-vertical hold-out RMSE is exactly 0.3048 times the metric one. That exact proportionality was an artefact of the bug, since the same numbers read as feet describe a terrain three times flatter. It is now a one percent band, with an assertion that an unconverted or doubly-converted value is still caught.

Bundle unchanged at 718 KiB against the 720 KiB ceiling; the deletion offsets the kernel additions.
