### PR TITLE
Correct the citation DOI, record the closed defects, and fix stale evidence prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 
 ## [Unreleased]
 
+### Fixed
+
+- **The contour deliverable's GeoTIFF states its vertical unit.** The
+  deliverable wrote `VerticalCSType` (GeoKey 4096) without `VerticalUnits`
+  (4099), so the same DTM raster was ambiguous between metres and feet when it
+  came from Contour Studio and unambiguous when it came from the DEM package.
+  Both paths now derive the key through one shared helper. This closes the
+  limitation recorded for v0.6.1.
+- **The asynchronous and GPU derivative path carries the vertical-unit
+  factor.** The async derivatives entry, the GPU kernel and the f32 reference
+  took no `zScale`, so a foot-vertical grid came back about 3.28x too steep on
+  every path except the synchronous one the pipeline uses today. The
+  equivalence probe ran both sides at `zScale` 1 and could not see it; it now
+  runs a foot-vertical pass as well. This closes the limitation recorded for
+  v0.6.1.
+- **`geodesicFill` walks in metres.** The step cost added a horizontal step in
+  raw source units to a rise in vertical units. On a degree grid the step was
+  about 1e-5 beside metre heights, so the cost went essentially vertical-only
+  and the down-weighting of a walk over a ridge degenerated. The step now comes
+  from the same per-axis metre conversion the slope stage uses, and the rise is
+  converted too. This closes the limitation recorded for v0.6.1; see the
+  correction below for its real scope.
+- **The unused elevation-grid hillshade wrappers are deleted.**
+  `computeSlopeDegrees` and `computeHillshade` hard-coded square cells, skipped
+  the cos(latitude) correction and defaulted the vertical scale to 1. No
+  production code called them. The live pipeline runs `hornSlopeAspect` with
+  per-axis metres and a vertical factor and shades from the result; the truth
+  tests now exercise that live two-step path. This closes the limitation
+  recorded for v0.6.1.
+- **The despike blunder floor is measured in metres.** `minDeviationM` is a
+  metres constant, but the heights it was compared against are in native source
+  units, so the 30 cm floor acted as 30 cm only on metric data. On a
+  foot-vertical scan it meant 0.3 ft, about 9 cm, so the floor was about 3.28x
+  too aggressive: real sub-30 cm terrain features were removed and silently
+  re-interpolated. The removal count reached provenance, so two deliverables of
+  one scan could disagree about how much data was cut.
+
+### Corrected
+
+- **Correction to `KNOWN_LIMITATIONS_v0.6.1.md`: the `geodesicFill` unit-mixing
+  defect affected production surfaces.** That document states the defect
+  "affects the non-default geodesic interpolation mode only; the default fill is
+  unaffected". That is wrong, and it understated the defect.
+  `src/terrain/ground/surfaceFromRaster.ts` sets `LIVE_INTERPOLATION` to
+  `'geodesic'`, so geodesic is the mode every production surface used. On
+  geographic (degree) and foot-vertical data, interpolated void heights in
+  v0.6.1 and earlier came from a step cost that mixed horizontal source units
+  with vertical metres. The scope statement should have read: this affected every
+  surface the application produced, not an optional mode.
+
 ### Changed
 
 - **The aspect raster is cross-implementation validated (E3 → E4).** Our Horn

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,11 +16,11 @@ repository-code: "https://github.com/Aurtechmx/openlidarviewer"
 url: "https://lidar.aurtech.mx/"
 identifiers:
   - type: doi
-    value: "10.5281/zenodo.21544620"
-    description: "Archived v0.6.0 release"
+    value: "10.5281/zenodo.21608260"
+    description: "Version DOI for the archived v0.6.1 release"
   - type: doi
     value: "10.5281/zenodo.21544619"
-    description: "Concept DOI (all versions)"
+    description: "Concept DOI, resolves to the newest version"
 
 abstract: >-
   OpenLiDARViewer is an open-source, local-first, browser-native platform

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -103,7 +103,9 @@ for a dedicated toolchain update. Deferred, with their tracking PRs:
 - `vitepress` / bundled `vite` / `esbuild`: the docs-tooling advisory chain.
 - `brace-expansion`, `fast-uri`, `qs` (via `typed-rest-client`): dev tree only.
 - Dependabot #10, #27, #28, #29, #30 (GitHub Actions), #33 (Three.js 0.185.x),
-  #34 (TypeScript 7 / Vite 8.1.5): not merged into this release line.
+  #40 (dev-tooling group: TypeScript ~6 to ~7, a Vite patch, Playwright 1.61 to
+  1.62): not merged into this release line. #40 supersedes the earlier #34,
+  which is closed.
 
 No dependency version was changed to produce this document.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -161,6 +161,27 @@ GPU upload, first rendered frame, frame rate and time-to-interaction are
 browser measurements. This runner is Node-only and reports them as declared
 stages with no number — never as zero, and never as an estimate.
 
+### Why there is no `benchmark:browser`
+
+The scripts are `benchmark:repro`, `benchmark:scaling`, `benchmark:quick`,
+`benchmark:verify` and `benchmark:verify:archives`. There is no browser script,
+and `benchmark:quick` records `browser` under `notRun` with the reason. That
+gap is a decision, not a task someone forgot.
+
+Measuring the real COPC workflow means measuring the running application, so it
+needs an instrumentation bridge inside the app that reports GPU upload, first
+rendered frame, frame rate and time to interaction. The live entry chunk is
+718 KiB against a hard ceiling of 720 KiB (`scripts/check-bundle-budget.mjs`),
+so a bridge cannot be linked into the shell. It has to be dynamic-import only
+and gated so it cannot load during normal use, which is a design problem before
+it is a measurement one.
+
+The measurement conditions are the other half. A COPC number is only meaningful
+from a verified cold cache against a real remote dataset, both of which the Node
+runner has no way to establish or to prove it established. Until those two
+pieces exist, browser figures are recorded by hand under the protocol below,
+where the conditions are stated and a reader can see what was controlled.
+
 ## The frozen stable benchmark
 
 One protocol, frozen for the stable line, chased for reproducibility rather

--- a/docs/validation/terrain-validation-matrix.md
+++ b/docs/validation/terrain-validation-matrix.md
@@ -26,8 +26,8 @@ The **Status** column has been replaced by an **evidence level** per
 [`EVIDENCE_MODEL.md`](./EVIDENCE_MODEL.md) and the machine-readable
 [`claim-register.yaml`](./claim-register.yaml). "Production" is no longer used as
 a scientific-validation status — it conflated "the code works" with "the science
-is validated". **Only slope is E4+** (independently cross-implemented against GDAL 3.13.1 on
-the analytic fixture); every other product tops out at E3 synthetic known-truth,
+is validated". **Slope and aspect are the only products at E4+** (each independently
+cross-implemented against GDAL 3.13.1 on the same analytic fixture); every other product tops out at E3 synthetic known-truth,
 with analytic checks E2 and interop/unit checks E1. Held-out RMSE is an INTERNAL diagnostic (points withheld from the same
 scan), not independent checkpoint accuracy — optimistic relative to a
 spatially-blocked or field checkpoint (research-hardening Phases 4–5).
@@ -41,6 +41,7 @@ spatially-blocked or field checkpoint (research-hardening Phases 4–5).
 | DSM (top surface) | Known-truth fixture: DSM equals the top surface (roof over building, canopy top over trees) on classified overlay scenes | `tests/terrainTruth.surface.test.ts` | E3 Synthetically validated |
 | CHM (canopy height, DSM − DTM) | Known-truth fixture for the height-above-ground field; reconstruction logic (DSM = DTM + canopy, nodata preserved) checked directly | `tests/terrainTruth.surface.test.ts`, `tests/dsmChm.test.ts` | E3 Synthetically validated |
 | Slope (Horn) | Analytic check (flat ≈ 0°, uniform slope = atan(gradient)) PLUS cross-implementation against GDAL 3.13.1 on the frozen analytic DEM: OLV, GDAL and the closed form agree over 11,564 interior cells within the preregistered 0.5° tolerance (max Δ < 0.001°) | `tests/terrainTruth.surface.test.ts`, `tests/slopeCrossCheck.test.ts` | **E4 Cross-implementation validated (GDAL) — algorithm on this fixture only** |
+| Aspect (Horn) | Cross-implementation against GDAL 3.13.1 on the same frozen analytic DEM, compared as a bearing (circular difference) and only where the closed-form slope exceeds 2°, because level ground has no aspect: OLV, GDAL and the closed form agree over 10,932 cells within the preregistered 0.5° circular tolerance (max separation about 0.0002°) | `tests/aspectCrossCheck.test.ts` | **E4 Cross-implementation validated (GDAL), algorithm on this fixture only** |
 | Hillshade (ESRI illumination) | Analytic check: exact flat-plane Lambert value at a known sun altitude, and the brighter/darker ordering for N/E/S/W-facing slopes under a fixed azimuth | `tests/terrainTruth.hillshade.test.ts` | E2 Analytically verified |
 | Hold-out RMSE / vertical accuracy (NVA/VVA-style) | Held-out RMSE against analytic surfaces where the true error is known; NVA/VVA-STYLE derivation (1.96 × RMSEz) on internal holdout — **not** independent checkpoint accuracy and not ASPRS NVA/VVA compliance | `tests/holdoutRmse.test.ts`, `tests/verticalAccuracy.test.ts` | E3 Synthetically validated · external pending |
 | Confidence calibration | Fit + apply a monotonic calibration map; the check guards pass, fail, and not-assessable. Measured-cell empirical reliability and interpolated-cell model-based support are distinct concepts (Phase 5) | `tests/calibrateConfidence.test.ts`, `tests/calibrationCheck.test.ts` | E2 Analytically verified |

--- a/tests/slopeCrossCheck.test.ts
+++ b/tests/slopeCrossCheck.test.ts
@@ -2,10 +2,11 @@
  * slopeCrossCheck.test.ts — SLOPE-RASTER against an independent implementation.
  *
  * Slope reached E4 here: this file compares our Horn slope against a committed
- * GDAL reference AND the closed-form gradient. Every OTHER entry in
- * `REFERENCE_SLOTS` still ships `pending`, so for those, nothing in
- * this project has been compared against an implementation we did not write.
- * This is the first slot that can move.
+ * GDAL reference AND the closed-form gradient. It was the first slot to move;
+ * `tests/aspectCrossCheck.test.ts` is its sibling and moved second. The
+ * remaining entries in `REFERENCE_SLOTS` still ship `pending`, so for those,
+ * nothing in this project has been compared against an implementation we did
+ * not write.
  *
  * THREE-WAY, NOT PAIRWISE. Our Horn slope against GDAL's Horn slope is two
  * implementations of one algorithm; they can agree while both being wrong the


### PR DESCRIPTION
Documentation and metadata only. No application source changes, no version bump; the 0.6.2 work accumulates under the unreleased changelog section and the version moves at release prep.

`CITATION.cff` named the wrong archive. It declared version 0.6.1 while its only version DOI was v0.6.0's, so a citation tool reading the file returned the previous release's record. It now carries the v0.6.1 version DOI alongside the unchanged concept DOI. The README badge uses the concept DOI and is untouched, since that one is meant to follow the newest version.

The changelog records the five defects closed this cycle, including the despike blunder floor, which compared a constant in metres against heights in their source unit and so removed real terrain features from foot-vertical data while leaving the same physical surface intact in metres.

It also carries an erratum. The v0.6.1 limitations state that the geodesic unit-mixing defect affected a non-default interpolation mode only. That is wrong: the geodesic fill is the live path, so every production surface went through it, and interpolated void heights on geographic and foot-vertical data were affected. The archived document is left as published, since it describes a released and DOI-minted artifact; the correction is written so it can be lifted into the next release's limitations.

The terrain validation matrix said slope was the only product at E4 and had no row for aspect at all. Both are fixed. A stale comment in the slope cross-check said it was the first slot that could move, which was true when written and is no longer; test files ship inside the source archive, so that sentence was a false statement in a citable artifact.

`docs/benchmarks.md` now explains that the absence of a browser benchmark is a decision rather than an oversight, and names what makes it non-trivial: it needs an in-application instrumentation bridge, and the live entry chunk sits two kilobytes under a hard ceiling, so any bridge has to be loaded dynamically and gated so it cannot appear during normal use.

`DEPENDENCIES.md` pointed at a closed pull request for the TypeScript decision and now names the live one. Every row in both dependency tables was checked against the lockfile.
