### PR TITLE
State the hillshade encoding difference without narrating the choice

### DIFF
--- a/docs/validation/cross-implementation.md
+++ b/docs/validation/cross-implementation.md
@@ -31,8 +31,7 @@ and its own evidence level.
 
 ## Hillshade agrees, but read its tolerance carefully
 
-The hillshade figures deserve a caveat the slope and aspect ones do not, and it
-is recorded here rather than smoothed over.
+The hillshade figures carry a caveat the slope and aspect ones do not.
 
 Both implementations compute the same illumination model,
 `h = cos(zenith)·cos(slope) + sin(zenith)·sin(slope)·cos(azimuth − aspect)`,
@@ -56,11 +55,10 @@ sharp:
   `round(1 + 254·h)`, reproduces the committed `hillshade-gdal.asc` **exactly**
   at every one of those cells.
 
-The encoding difference is deliberately left in the reported figures instead of
-being divided out, and our `255·h` encoding was deliberately not changed to
-match GDAL's: the product ships that encoding, and adjusting the implementation
-to flatter the comparison would invert what the comparison is for. Full detail
-in `tests/fixtures/reference/hillshade/README.md`.
+The reported figures include the encoding difference rather than subtracting it,
+so the headline number describes the two products as they ship. The application
+writes `round(255·h)`; that is the encoding its rasters carry. Full detail in
+`tests/fixtures/reference/hillshade/README.md`.
 
 The check covers the single-direction model only. `computeMultiHillshade` is a
 different illumination model with its own claim, unchanged by this.

--- a/tests/fixtures/reference/hillshade/README.md
+++ b/tests/fixtures/reference/hillshade/README.md
@@ -51,10 +51,9 @@ expressed in. Our implementation is `shadeFromSlopeAspect` in
 **The one place they differ is the 8-bit encoding, not the shading.** We write
 `round(255·h)`. GDAL writes `round(1 + 254·h)`, reserving level 0 for nodata.
 The two encodings of one intensity differ by exactly `(1 − h)` levels, which is
-strictly below one level for any lit cell. That difference is deliberately left
-**visible** in the reported figures rather than divided out — see "What this does
-and does not establish" below, because it is what makes the headline number sit
-where it does.
+strictly below one level for any lit cell. The reported figures include that
+difference rather than subtracting it, which is why the headline number sits
+where it does — see "What this does and does not establish" below.
 
 ## Producing the reference
 


### PR DESCRIPTION
Removes wording that narrates how the hillshade text was written instead of stating what is true.

Three passages described the writing rather than the software: that the caveat "is recorded here rather than smoothed over", that the encoding difference is "deliberately left visible ... rather than divided out", and that the application's encoding was "deliberately not changed" because doing so "would invert what the comparison is for".

Every technical fact is kept. The reported figures still include the encoding difference, the application still writes its own encoding, and the statement that the comparison against GDAL is a weak instrument on its own still stands, because that is a property of the measurement rather than an account of a decision.

These files ship inside the source archive and the Zenodo deposit, so the prose is part of the published record.
