### PR TITLE
Add the cross-platform scientific reproducibility suite

### DIFF
--- a/.github/workflows/benchmark-portability.yml
+++ b/.github/workflows/benchmark-portability.yml
@@ -1,0 +1,103 @@
+name: Benchmark portability
+
+# Cross-Platform Scientific Reproducibility. Each leg runs the seeded
+# reproducibility suite on its own runner and uploads its record; the compare
+# job downloads both and checks that the science-scoped outputs are identical.
+#
+# Not on every push. The suite is ten recorded runs over 250,000 points per
+# platform, which is minutes of real terrain work, and a result set is only
+# meaningful next to the commit that produced it.
+#
+# Windows is deliberately out of scope for this workflow. It is a little-endian
+# platform and would be a legitimate third leg, but it has not been run, and the
+# claim covers only the platforms listed in the matrix below.
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  leg:
+    name: Record ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      # Both legs always run. Failing fast would leave the compare job with one
+      # platform, which reports as single-platform and establishes nothing —
+      # a green-looking result for a leg that never happened.
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, platform: linux-x64 }
+          - { os: macos-latest, platform: darwin-arm64 }
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      # Every leg must install from the committed lockfile. The comparison
+      # records the lockfile digest and refuses two legs that disagree, so a
+      # rewrite here would fail the compare job later rather than silently
+      # comparing two different dependency trees.
+      - name: Lockfile is unchanged by a clean install
+        run: git diff --exit-code -- package-lock.json
+      - name: Record this platform's leg
+        run: npm run benchmark:repro:portable
+      - name: Verify the result tree
+        run: npm run benchmark:verify
+      - name: Upload the platform leg
+        uses: actions/upload-artifact@v4
+        with:
+          name: portability-leg-${{ matrix.platform }}
+          path: benchmark-results/portability/${{ matrix.platform }}
+          if-no-files-found: error
+          retention-days: 30
+      # The full result tree, so the ten runs behind the leg can be inspected
+      # rather than taken on trust.
+      - name: Upload the full result tree
+        uses: actions/upload-artifact@v4
+        with:
+          name: portability-results-${{ matrix.platform }}
+          path: benchmark-results/latest
+          if-no-files-found: error
+          retention-days: 30
+
+  compare:
+    name: Compare platforms
+    runs-on: ubuntu-latest
+    needs: leg
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Download every platform leg
+        uses: actions/download-artifact@v4
+        with:
+          pattern: portability-leg-*
+          path: legs
+      - name: Compare the science-scoped outputs
+        # BENCHMARK_REQUIRE_PLATFORMS is what makes a missing leg a failure. Without
+        # it a job that lost one platform would publish a single-platform result,
+        # which is honest on its own terms and wrong as the outcome of a workflow
+        # whose whole purpose is the comparison.
+        env:
+          BENCHMARK_PORTABILITY_DIRS: legs/portability-leg-linux-x64,legs/portability-leg-darwin-arm64
+          BENCHMARK_REQUIRE_PLATFORMS: linux-x64,darwin-arm64
+        run: npm run benchmark:compare-platforms
+      - name: Upload the comparison
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: portability-comparison
+          path: benchmark-results/portability
+          if-no-files-found: warn
+          retention-days: 90

--- a/benchmarks/framework/index.ts
+++ b/benchmarks/framework/index.ts
@@ -72,7 +72,7 @@ export type {
 } from './artifacts';
 
 export { toJson } from './reporters/json';
-export { toCsv } from './reporters/csv';
+export { toCsv, csvCell, csvRow } from './reporters/csv';
 export { toMarkdown } from './reporters/markdown';
 export { toHtml } from './reporters/html';
 export {

--- a/benchmarks/framework/reporters/csv.ts
+++ b/benchmarks/framework/reporters/csv.ts
@@ -42,20 +42,20 @@ const HEADER = 'section,name,value,unit,status,reason,runtime,deterministic';
  * same carve-out the measurement export makes. `-1+1` is not a number and is
  * still neutralised.
  */
-function cell(value: string): string {
+export function csvCell(value: string): string {
   const numeric = value.trim() !== '' && Number.isFinite(Number(value));
   const neutralise = !numeric && /^[=+\-@\t\r]/.test(value);
   const out = neutralise ? `'${value}` : value;
   return neutralise || /[",\n\r]/.test(out) ? `"${out.replace(/"/g, '""')}"` : out;
 }
 
-function row(cells: readonly string[]): string {
-  return cells.map(cell).join(',');
+export function csvRow(cells: readonly string[]): string {
+  return cells.map(csvCell).join(',');
 }
 
 /** A metric row carries all eight columns; everything else leaves them empty. */
 function metricRow(section: string, name: string, m: Metric): string {
-  return row([
+  return csvRow([
     section,
     name,
     metricValueCell(m),
@@ -69,7 +69,7 @@ function metricRow(section: string, name: string, m: Metric): string {
 
 /** A plain fact (dataset id, OS, hash): a value with no unit and no reason. */
 function factRow(section: string, name: string, value: string, reason = ''): string {
-  return row([section, name, value, '', reason === '' ? 'captured' : UNAVAILABLE_LABEL, reason, '', '']);
+  return csvRow([section, name, value, '', reason === '' ? 'captured' : UNAVAILABLE_LABEL, reason, '', '']);
 }
 
 function stageRows(stage: StageResult): string[] {

--- a/benchmarks/pipeline/runPipeline.ts
+++ b/benchmarks/pipeline/runPipeline.ts
@@ -192,6 +192,7 @@ export const PIPELINE_ARTIFACTS = [
   'contours',
   'contourFeatures',
   'scientificRecordContent',
+  'processingManifestContent',
   'scientificRecord',
   'processingManifest',
 ] as const;
@@ -218,6 +219,7 @@ export const ARTIFACT_SCOPE: Readonly<Record<PipelineArtifactName, 'science' | '
   contours: 'science',
   contourFeatures: 'science',
   scientificRecordContent: 'science',
+  processingManifestContent: 'science',
   scientificRecord: 'build',
   processingManifest: 'build',
 };
@@ -637,7 +639,27 @@ export function runOlvPipeline(options: PipelineRunOptions): PipelineRun {
         );
       }
       artifactFault('manifest');
-      return { processingManifest: toHashable(manifest) };
+      // The chain hashes are seeded by the build identity, so `head` and every
+      // `ops[i].hash` track the commit and the Node version rather than the
+      // processing. What is left once those and `build` are dropped is the
+      // ordered list of methods and bound parameters — the processing itself,
+      // which two machines running the same commit must describe identically.
+      // Kept as a separate artifact rather than a looser comparison of the
+      // full manifest: an exclusion a reader can see beats one they cannot.
+      const manifestContent = {
+        schemaVersion: manifest.schemaVersion,
+        source: manifest.source,
+        ops: manifest.ops.map((op) => ({
+          seq: op.seq,
+          method: op.method,
+          params: op.params,
+          ...(op.note !== undefined ? { note: op.note } : {}),
+        })),
+      };
+      return {
+        processingManifest: toHashable(manifest),
+        processingManifestContent: toHashable(manifestContent),
+      };
     }),
   );
 

--- a/benchmarks/portability/compare.ts
+++ b/benchmarks/portability/compare.ts
@@ -1,0 +1,599 @@
+/**
+ * compare.ts
+ *
+ * Cross-Platform Scientific Reproducibility: does the same commit, over the
+ * same seeded fixture, produce identical science-scoped outputs on independently
+ * executed platforms.
+ *
+ * THE NAME IS NARROWER THAN "PLATFORM INDEPENDENCE" ON PURPOSE. What this
+ * comparator can establish is a statement about the specific platforms whose
+ * records it was handed, on one Node major version, at one commit. Nothing here
+ * generalises to an untested platform, and the report says which platforms it
+ * covers rather than leaving a reader to assume the set is complete.
+ *
+ * THE FIXTURE IS COMPARED FIRST, AND ITS FAILURE IS A DIFFERENT FINDING. Every
+ * downstream artifact is a function of the seeded source cloud, so a generator
+ * that produced different points on two hosts makes every later hash differ as
+ * well. Reported in hash order that reads as "the science diverged", which
+ * would be wrong: the pipeline may be perfectly reproducible over an input that
+ * is not. So the source-cloud hash is checked before anything else and gets its
+ * own status, `generator-not-portable`, and the downstream comparison is
+ * reported as suppressed rather than run and blamed.
+ *
+ * WHAT A FIXTURE MISMATCH WOULD MOST LIKELY MEAN. The generator's PRNG is
+ * integer arithmetic and exact on any engine; its surface uses `Math.sin`,
+ * `Math.cos` and `Math.exp`, which ECMAScript leaves implementation-defined.
+ * That is the one place byte-identity rests on the engine rather than on
+ * integer arithmetic, and `syntheticCloud.ts` says so in its own header. A
+ * fixture mismatch between two hosts running the same V8 is a real portability
+ * finding about transcendental functions, to be reported precisely. It is not
+ * grounds for loosening the comparison: `scalarTolerance` is zero and there is
+ * no code path here that relaxes it.
+ *
+ * WHAT IS ALLOWED TO DIFFER IS ENUMERATED, NOT DISCARDED. Execution time,
+ * memory, CPU model, OS, architecture, Node and V8 metadata, build identity and
+ * everything derived from it, timestamps and archive paths all differ between
+ * two honest legs. Every one of them is listed in `expectedDifferences` with
+ * the values each platform reported, so a reader sees what was excluded rather
+ * than trusting that the exclusions were narrow.
+ *
+ * Pure. No I/O, no clock, no randomness.
+ */
+
+import type { PlatformRecord } from './record';
+import { FIXTURE_DESCRIPTOR_ARTIFACT, PORTABILITY_SCHEMA_VERSION, SOURCE_CLOUD_ARTIFACT } from './record';
+import { SUPPORTED_ENDIANNESS, unsupportedEndiannessReason } from './preconditions';
+
+/**
+ * The science-scoped artifacts every platform record must carry.
+ *
+ * Written out rather than derived from the pipeline's `ARTIFACT_SCOPE`, for two
+ * reasons that pull the same way. A comparison that iterates whatever keys
+ * happen to be present passes vacuously when a key is absent from both sides,
+ * which is exactly the hole a cross-platform check must not have. And this list
+ * is the comparator's own statement of what it requires, so an artifact
+ * silently dropped from the pipeline shows up here as a missing artifact rather
+ * than as a comparison that quietly got smaller. A test asserts this list
+ * equals `scienceScopedArtifacts()`, so the two cannot drift unnoticed.
+ */
+export const REQUIRED_SCIENCE_ARTIFACTS: readonly string[] = [
+  'fixture',
+  'pointBytes',
+  'rasterSummary',
+  'rasterZBytes',
+  'dtmSummary',
+  'dtmZBytes',
+  'dtmConfidenceBytes',
+  'dtmCoverageBytes',
+  'dtmCountsBytes',
+  'heightAboveGroundBytes',
+  'descriptors',
+  'contours',
+  'contourFeatures',
+  'scientificRecordContent',
+  'processingManifestContent',
+];
+
+/**
+ * Artifacts whose hash tracks the build rather than the science.
+ *
+ * Listed here so a record that files one of them under `science.hashes` is
+ * refused. Promoting a build-scoped hash into the scientific set would make the
+ * comparison fail on two honest legs for a reason that is not about
+ * reproducibility, and demoting a scientific one would make it pass on legs
+ * that disagreed. Both are misclassification, and both are caught.
+ */
+export const BUILD_SCOPED_ARTIFACTS: readonly string[] = ['scientificRecord', 'processingManifest'];
+
+export type ComparisonStatus =
+  /** Two or more platforms, every science-scoped output identical. */
+  | 'reproduced'
+  /** One platform only. Nothing cross-platform is established. */
+  | 'single-platform'
+  /** A platform reported a byte order the comparison is not defined for. */
+  | 'unsupported-architecture'
+  /** The legs are not comparable: different commit, lockfile, config or schema. */
+  | 'preconditions-not-met'
+  /** The seeded fixture itself differs. Downstream comparison is suppressed. */
+  | 'generator-not-portable'
+  /** Same fixture, different science. */
+  | 'science-diverged';
+
+/** One thing two platforms disagreed about. */
+export interface Mismatch {
+  readonly kind: 'scienceHash' | 'missingArtifact' | 'scalar' | 'applicationContentHash';
+  readonly field: string;
+  /** The value each platform reported, keyed by platform id. */
+  readonly values: Readonly<Record<string, string>>;
+}
+
+/** One category of difference two honest legs are expected to show. */
+export interface ExpectedDifference {
+  readonly category: 'host' | 'runtime' | 'build-scoped-hash' | 'timing';
+  readonly field: string;
+  readonly why: string;
+  /** What each platform reported. Present only for observed differences. */
+  readonly values: Readonly<Record<string, string>>;
+}
+
+/**
+ * A difference the comparison never looks at, named so its absence from the
+ * mismatch list is a stated exclusion rather than an omission.
+ */
+export interface ExcludedFromComparison {
+  readonly field: string;
+  readonly why: string;
+}
+
+export const STRUCTURAL_EXCLUSIONS: readonly ExcludedFromComparison[] = [
+  {
+    field: 'timestamps',
+    why: 'Run start and completion times are wall-clock readings. The framework strips them from every hashed artifact, and they are recorded in each platform manifest rather than compared.',
+  },
+  {
+    field: 'archive paths',
+    why: 'Each platform writes into its own results directory and each CI runner has its own workspace root. Paths are relative in every manifest and are not part of any hash.',
+  },
+  {
+    field: 'build identity',
+    why: 'The build identity string embeds the commit and the runtime that produced it. The scientific record and the processing manifest are seeded from it, which is why both are build-scoped and compared separately.',
+  },
+];
+
+export interface FixtureComparison {
+  readonly identical: boolean;
+  readonly seed: number | null;
+  readonly requestedPointCount: number | null;
+  readonly generatedPointCount: number | null;
+  readonly datasetId: string | null;
+  /** SHA-256 of the seeded cloud's coordinate bytes, per platform. */
+  readonly sourceCloudHashes: Readonly<Record<string, string | null>>;
+  readonly descriptorHashes: Readonly<Record<string, string | null>>;
+  readonly mismatches: readonly Mismatch[];
+  /** Stated whenever the fixtures differ. See the module header. */
+  readonly likelyCause: string | null;
+}
+
+export interface ScienceComparison {
+  readonly evaluated: boolean;
+  /** Why the comparison was not evaluated, when it was not. */
+  readonly suppressedReason: string | null;
+  readonly hashesCompared: number;
+  readonly hashesMismatched: number;
+  readonly scalarsCompared: number;
+  readonly scalarsMismatched: number;
+  readonly mismatches: readonly Mismatch[];
+}
+
+export interface PlatformTimingRow {
+  readonly platformId: string;
+  readonly medianAnalysisMs: number | null;
+  readonly medianAnalysisUnavailableReason: string | null;
+  readonly analysisCv: number | null;
+  readonly analysisCvUnavailableReason: string | null;
+  readonly peakRssBytes: number | null;
+  readonly peakRssUnavailableReason: string | null;
+  readonly recordedRuns: number;
+}
+
+export interface PortabilityComparison {
+  readonly portabilitySchemaVersion: number;
+  readonly status: ComparisonStatus;
+  /** True when the command should exit zero. See `claimEstablished` for the claim. */
+  readonly ok: boolean;
+  /**
+   * Whether the cross-platform claim holds on this evidence.
+   *
+   * Distinct from `ok` on purpose: a single-platform run is a legitimate
+   * outcome of the command and establishes nothing across platforms, so it
+   * exits zero with this false. Only a `reproduced` status sets it.
+   */
+  readonly claimEstablished: boolean;
+  readonly claim: string;
+  readonly platforms: readonly string[];
+  readonly evaluatedCommit: string | null;
+  readonly lockfileSha256: string | null;
+  readonly releaseVersion: string | null;
+  readonly scalarTolerance: 0;
+  readonly endianness: Readonly<Record<string, string>>;
+  readonly preconditionFailures: readonly string[];
+  readonly fixture: FixtureComparison;
+  readonly science: ScienceComparison;
+  readonly expectedDifferences: readonly ExpectedDifference[];
+  readonly structuralExclusions: readonly ExcludedFromComparison[];
+  readonly timing: readonly PlatformTimingRow[];
+}
+
+export interface CompareOptions {
+  /**
+   * Platform ids that must be present.
+   *
+   * Empty by default, which is what makes a local single-platform run report
+   * itself honestly instead of failing. CI sets it to both legs, so a missing
+   * leg fails the job rather than silently producing a one-platform comparison
+   * that reads like a cross-platform result.
+   */
+  readonly requirePlatforms?: readonly string[];
+}
+
+/** The exact wording the report carries, built from what was actually compared. */
+function claimFor(status: ComparisonStatus, platforms: readonly string[], commit: string | null): string {
+  const where = platforms.join(' and ');
+  const at = commit === null ? 'an unrecorded commit' : `commit ${commit.slice(0, 7)}`;
+  switch (status) {
+    case 'reproduced':
+      return `At ${at}, OpenLiDARViewer produced identical science-scoped artifacts from the same seeded fixture on ${where}. Build-scoped provenance and execution timing differed, as expected. Nothing is claimed for platforms not in that list.`;
+    case 'single-platform':
+      return `Only ${where} was recorded, so this run establishes single-platform reproducibility and nothing cross-platform. The cross-platform claim remains unestablished until a second platform's leg exists.`;
+    case 'generator-not-portable':
+      return `The seeded fixture itself differs between ${where}, so the source cloud is not byte-identical across these platforms and no downstream comparison is meaningful. This is a finding about the generator, not about the analysis pipeline.`;
+    case 'science-diverged':
+      return `The seeded fixture matched across ${where}, but at least one science-scoped output did not. Cross-platform scientific reproducibility does not hold on this evidence.`;
+    case 'unsupported-architecture':
+      return 'A platform reported a byte order this comparison is not defined for. Cross-platform reproducibility is claimed for little-endian platforms only.';
+    case 'preconditions-not-met':
+      return 'The recorded legs are not comparable — they differ in commit, lockfile, configuration or schema, or one failed its own reproducibility check. No cross-platform claim follows.';
+  }
+}
+
+function envText(value: { readonly status: string; readonly value: string | null }): string {
+  return value.status === 'captured' && value.value !== null ? value.value : 'unavailable';
+}
+
+function scalarText(value: unknown): string {
+  return value === null || value === undefined ? 'null' : JSON.stringify(value);
+}
+
+/** Every distinct value a field took across the records, keyed by platform. */
+function valuesOf(
+  records: readonly PlatformRecord[],
+  read: (r: PlatformRecord) => string,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const r of records) out[r.platformId] = read(r);
+  return out;
+}
+
+function allAgree(values: Readonly<Record<string, string>>): boolean {
+  const seen = Object.values(values);
+  return seen.every((v) => v === seen[0]);
+}
+
+export function comparePlatforms(
+  records: readonly PlatformRecord[],
+  options: CompareOptions = {},
+): PortabilityComparison {
+  if (records.length === 0) {
+    throw new Error('benchmark portability: a comparison needs at least one platform record');
+  }
+  // Sorted so two invocations over the same inputs in a different order produce
+  // byte-identical output. The comparison itself is order-independent; the
+  // report should be too.
+  const sorted = [...records].sort((a, b) => (a.platformId < b.platformId ? -1 : a.platformId > b.platformId ? 1 : 0));
+  const platforms = sorted.map((r) => r.platformId);
+
+  const duplicates = platforms.filter((id, i) => platforms.indexOf(id) !== i);
+  const preconditionFailures: string[] = [];
+  for (const id of [...new Set(duplicates)]) {
+    preconditionFailures.push(`platform ${id} appears more than once; each platform contributes exactly one leg`);
+  }
+
+  for (const id of options.requirePlatforms ?? []) {
+    if (!platforms.includes(id)) {
+      preconditionFailures.push(`required platform ${id} is absent from this comparison`);
+    }
+  }
+
+  // ── byte order ────────────────────────────────────────────────────────────
+  const endianness: Record<string, string> = {};
+  let unsupportedArchitecture = false;
+  for (const r of sorted) {
+    endianness[r.platformId] = r.environment.endianness;
+    if (r.environment.endianness !== SUPPORTED_ENDIANNESS) {
+      unsupportedArchitecture = true;
+      preconditionFailures.push(unsupportedEndiannessReason(r.platformId, r.environment.endianness));
+    }
+  }
+
+  // ── schema, commit, lockfile, configuration ───────────────────────────────
+  const schemaValues = valuesOf(sorted, (r) => `${r.portabilitySchemaVersion}/${r.benchmarkSchemaVersion}`);
+  if (!allAgree(schemaValues)) {
+    preconditionFailures.push(
+      `platform records were written by different schema versions: ${describeValues(schemaValues)}`,
+    );
+  }
+  for (const r of sorted) {
+    if (r.portabilitySchemaVersion !== PORTABILITY_SCHEMA_VERSION) {
+      preconditionFailures.push(
+        `${r.platformId} carries portability schema version ${String(r.portabilitySchemaVersion)}, this comparator writes ${PORTABILITY_SCHEMA_VERSION}`,
+      );
+    }
+  }
+
+  const commitValues = valuesOf(sorted, (r) => envText(r.evaluated.commit));
+  if (!allAgree(commitValues)) {
+    preconditionFailures.push(`platforms did not evaluate the same commit: ${describeValues(commitValues)}`);
+  }
+  const lockValues = valuesOf(sorted, (r) => envText(r.evaluated.lockfileSha256));
+  if (!allAgree(lockValues)) {
+    preconditionFailures.push(`platforms did not install from the same lockfile: ${describeValues(lockValues)}`);
+  }
+  const treeValues = valuesOf(sorted, (r) => envText(r.evaluated.workingTree));
+  for (const [id, value] of Object.entries(treeValues)) {
+    if (value !== 'clean') {
+      preconditionFailures.push(
+        `${id} ran from a ${value} working tree, so its commit does not describe what was executed`,
+      );
+    }
+  }
+  const configValues = valuesOf(sorted, (r) => JSON.stringify(r.evaluated.config));
+  if (!allAgree(configValues)) {
+    preconditionFailures.push('platforms ran different suite configurations (seed, point count, run counts or terrain parameters)');
+  }
+  const packageValues = valuesOf(sorted, (r) => r.evaluated.benchmarkPackageVersion);
+  if (!allAgree(packageValues)) {
+    preconditionFailures.push(`platforms ran different benchmark package versions: ${describeValues(packageValues)}`);
+  }
+  for (const r of sorted) {
+    if (r.evaluated.config.scalarTolerance !== 0) {
+      preconditionFailures.push(`${r.platformId} recorded a non-zero scalar tolerance; scientific tolerance is exactly zero`);
+    }
+  }
+
+  // ── each platform's own reproducibility check ─────────────────────────────
+  for (const r of sorted) {
+    if (!r.internal.pass) {
+      preconditionFailures.push(
+        `${r.platformId} failed its own reproducibility check (${r.internal.failures.length} failures), so its outputs do not represent that platform`,
+      );
+    }
+    if (r.internal.recordedRuns !== r.evaluated.config.recordedRuns) {
+      preconditionFailures.push(
+        `${r.platformId} recorded ${r.internal.recordedRuns} runs, its configuration says ${r.evaluated.config.recordedRuns}`,
+      );
+    }
+    if (!r.internal.manifestVerifiedOnEveryRun) {
+      preconditionFailures.push(`${r.platformId} has a run whose processing manifest did not verify`);
+    }
+    for (const name of BUILD_SCOPED_ARTIFACTS) {
+      if (name in r.science.hashes) {
+        preconditionFailures.push(
+          `${r.platformId} files the build-scoped artifact ${name} under its scientific hashes; a build-scoped hash tracks the commit and the runtime, not the science`,
+        );
+      }
+    }
+    for (const name of REQUIRED_SCIENCE_ARTIFACTS) {
+      if (!(name in r.science.hashes)) {
+        preconditionFailures.push(`${r.platformId} is missing the required science-scoped artifact ${name}`);
+      }
+    }
+  }
+
+  // ── the fixture, before anything downstream of it ─────────────────────────
+  const fixture = compareFixture(sorted);
+
+  // ── the science ───────────────────────────────────────────────────────────
+  const blocked = preconditionFailures.length > 0 || unsupportedArchitecture;
+  const science = blocked
+    ? suppressed('the legs are not comparable, so a hash comparison between them would not be interpretable')
+    : !fixture.identical
+      ? suppressed(
+          'the seeded fixture differs between platforms, so every downstream artifact differs as a consequence; reporting those as scientific divergence would name the wrong finding',
+        )
+      : compareScience(sorted);
+
+  const status: ComparisonStatus = unsupportedArchitecture
+    ? 'unsupported-architecture'
+    : preconditionFailures.length > 0
+      ? 'preconditions-not-met'
+      : !fixture.identical
+        ? 'generator-not-portable'
+        : sorted.length < 2
+          ? 'single-platform'
+          : science.mismatches.length > 0
+            ? 'science-diverged'
+            : 'reproduced';
+
+  const commit = sorted[0].evaluated.commit;
+  const evaluatedCommit = allAgree(commitValues) && commit.status === 'captured' ? commit.value : null;
+
+  return {
+    portabilitySchemaVersion: PORTABILITY_SCHEMA_VERSION,
+    status,
+    ok: status === 'reproduced' || status === 'single-platform',
+    claimEstablished: status === 'reproduced',
+    claim: claimFor(status, platforms, evaluatedCommit),
+    platforms,
+    evaluatedCommit,
+    lockfileSha256: allAgree(lockValues) ? envText(sorted[0].evaluated.lockfileSha256) : null,
+    releaseVersion: envText(sorted[0].evaluated.releaseVersion),
+    scalarTolerance: 0,
+    endianness,
+    preconditionFailures,
+    fixture,
+    science,
+    expectedDifferences: expectedDifferencesOf(sorted),
+    structuralExclusions: STRUCTURAL_EXCLUSIONS,
+    timing: sorted.map(timingRow),
+  };
+}
+
+function describeValues(values: Readonly<Record<string, string>>): string {
+  return Object.entries(values)
+    .map(([id, v]) => `${id}=${v}`)
+    .join(', ');
+}
+
+function suppressed(reason: string): ScienceComparison {
+  return {
+    evaluated: false,
+    suppressedReason: reason,
+    hashesCompared: 0,
+    hashesMismatched: 0,
+    scalarsCompared: 0,
+    scalarsMismatched: 0,
+    mismatches: [],
+  };
+}
+
+function compareFixture(records: readonly PlatformRecord[]): FixtureComparison {
+  const sourceCloudHashes: Record<string, string | null> = {};
+  const descriptorHashes: Record<string, string | null> = {};
+  for (const r of records) {
+    sourceCloudHashes[r.platformId] = r.fixture.sourceCloudHash;
+    descriptorHashes[r.platformId] = r.fixture.descriptorHash;
+  }
+
+  const mismatches: Mismatch[] = [];
+  const first = records[0].fixture;
+
+  const scalarFields: readonly [string, (r: PlatformRecord) => unknown][] = [
+    ['seed', (r) => r.fixture.seed],
+    ['requestedPointCount', (r) => r.fixture.requestedPointCount],
+    ['generatedPointCount', (r) => r.fixture.generatedPointCount],
+    ['datasetId', (r) => r.fixture.datasetId],
+    ['config.seed', (r) => r.evaluated.config.seed],
+    ['config.pointCount', (r) => r.evaluated.config.pointCount],
+  ];
+  for (const [field, read] of scalarFields) {
+    const values = valuesOf(records, (r) => scalarText(read(r)));
+    if (!allAgree(values)) mismatches.push({ kind: 'scalar', field, values });
+  }
+
+  for (const [field, bag] of [
+    [SOURCE_CLOUD_ARTIFACT, sourceCloudHashes],
+    [FIXTURE_DESCRIPTOR_ARTIFACT, descriptorHashes],
+  ] as const) {
+    const values: Record<string, string> = {};
+    let missing = false;
+    for (const r of records) {
+      const hash = bag[r.platformId];
+      if (hash === null) missing = true;
+      values[r.platformId] = hash ?? 'absent';
+    }
+    if (missing) mismatches.push({ kind: 'missingArtifact', field, values });
+    else if (!allAgree(values)) mismatches.push({ kind: 'scienceHash', field, values });
+  }
+
+  const identical = mismatches.length === 0;
+  return {
+    identical,
+    seed: first.seed,
+    requestedPointCount: first.requestedPointCount,
+    generatedPointCount: first.generatedPointCount,
+    datasetId: first.datasetId,
+    sourceCloudHashes,
+    descriptorHashes,
+    mismatches,
+    likelyCause: identical
+      ? null
+      : 'The generator drives an integer PRNG, which is exact on any engine, but its surface uses Math.sin, Math.cos and Math.exp, which ECMAScript leaves implementation-defined. A fixture that differs across hosts is a portability finding about those functions, not a reason to widen the comparison.',
+  };
+}
+
+function compareScience(records: readonly PlatformRecord[]): ScienceComparison {
+  const mismatches: Mismatch[] = [];
+
+  const names = [
+    ...new Set([...REQUIRED_SCIENCE_ARTIFACTS, ...records.flatMap((r) => Object.keys(r.science.hashes))]),
+  ].sort();
+  for (const name of names) {
+    const values: Record<string, string> = {};
+    let missing = false;
+    for (const r of records) {
+      const hash = r.science.hashes[name];
+      if (hash === undefined) missing = true;
+      values[r.platformId] = hash ?? 'absent';
+    }
+    if (missing) mismatches.push({ kind: 'missingArtifact', field: name, values });
+    else if (!allAgree(values)) mismatches.push({ kind: 'scienceHash', field: name, values });
+  }
+
+  // Read through `unknown`: RunScalars is a closed interface with no index
+  // signature, and the comparison must iterate whatever keys the records
+  // actually carry rather than the keys this file was compiled against — a
+  // scalar added to the pipeline must be compared, not skipped.
+  const scalarsOf = (r: PlatformRecord): Record<string, unknown> =>
+    r.science.scalars as unknown as Record<string, unknown>;
+  const scalarKeys = [...new Set(records.flatMap((r) => Object.keys(scalarsOf(r))))].sort();
+  for (const key of scalarKeys) {
+    // Object.is, matching the single-platform suite: it separates a genuine
+    // null from a NaN and does not equate +0 with -0.
+    const raw = records.map((r) => scalarsOf(r)[key]);
+    const values = valuesOf(records, (r) => scalarText(scalarsOf(r)[key]));
+    if (!raw.every((v) => Object.is(v, raw[0]))) {
+      mismatches.push({ kind: 'scalar', field: key, values });
+    }
+  }
+
+  const contentValues = valuesOf(records, (r) => r.science.applicationContentHash ?? 'absent');
+  if (!allAgree(contentValues)) {
+    mismatches.push({ kind: 'applicationContentHash', field: 'applicationContentHash', values: contentValues });
+  }
+
+  return {
+    evaluated: true,
+    suppressedReason: null,
+    hashesCompared: names.length,
+    hashesMismatched: mismatches.filter((m) => m.kind === 'scienceHash' || m.kind === 'missingArtifact').length,
+    scalarsCompared: scalarKeys.length,
+    scalarsMismatched: mismatches.filter((m) => m.kind === 'scalar').length,
+    mismatches,
+  };
+}
+
+/** Every allowed difference the records actually show, with both sides' values. */
+function expectedDifferencesOf(records: readonly PlatformRecord[]): ExpectedDifference[] {
+  const out: ExpectedDifference[] = [];
+  const add = (
+    category: ExpectedDifference['category'],
+    field: string,
+    why: string,
+    read: (r: PlatformRecord) => string,
+  ): void => {
+    const values = valuesOf(records, read);
+    if (!allAgree(values)) out.push({ category, field, why, values });
+  };
+
+  add('host', 'os', 'The operating system and its release are properties of the host, not of the analysis.', (r) => envText(r.environment.os));
+  add('host', 'arch', 'The instruction set is a property of the host. Byte order is the part that must match, and it is checked as a precondition.', (r) => envText(r.environment.arch));
+  add('host', 'cpuModel', 'The CPU model changes timing and nothing else; every science-scoped value is deterministic arithmetic.', (r) => envText(r.environment.cpuModel));
+  add('host', 'logicalCpuCount', 'Core count is a property of the runner. The pipeline is single-threaded here.', (r) => envText(r.environment.logicalCpuCount));
+  add('host', 'totalMemoryBytes', 'Installed memory is a property of the runner.', (r) => envText(r.environment.totalMemoryBytes));
+  add('host', 'loadAverage', 'Host load at the moment of writing. It moves the timing column and nothing else.', (r) => envText(r.environment.loadAverage));
+  add('runtime', 'nodeVersion', 'Node patch metadata differs between runner images. The major version is pinned by the workflow.', (r) => envText(r.environment.nodeVersion));
+  add('runtime', 'v8Version', 'V8 supplies the transcendental functions the generator uses. Recorded because a difference here is the first thing to check if the fixture ever stops matching.', (r) => envText(r.environment.v8Version));
+  add('runtime', 'npmVersion', 'The npm version does not affect an installed tree that came from the committed lockfile.', (r) => envText(r.environment.npmVersion));
+
+  const buildNames = [...new Set(records.flatMap((r) => Object.keys(r.buildScopedHashes)))].sort();
+  for (const name of buildNames) {
+    add(
+      'build-scoped-hash',
+      name,
+      'This artifact embeds the build identity, which carries the commit and the runtime that produced it. Two platforms are expected to differ here and it says nothing about the science.',
+      (r) => r.buildScopedHashes[name] ?? 'absent',
+    );
+  }
+
+  add('timing', 'medianAnalysisMs', 'Execution time is a property of the machine. Reported per platform and never pooled.', (r) =>
+    r.timing.medianAnalysisMs.value === null ? 'unavailable' : String(r.timing.medianAnalysisMs.value),
+  );
+  add('timing', 'peakRssBytes', 'Memory high-water observations track the allocator and the host, not the outputs.', (r) =>
+    r.timing.peakRssBytes.value === null ? 'unavailable' : String(r.timing.peakRssBytes.value),
+  );
+
+  return out;
+}
+
+function timingRow(r: PlatformRecord): PlatformTimingRow {
+  return {
+    platformId: r.platformId,
+    medianAnalysisMs: r.timing.medianAnalysisMs.value,
+    medianAnalysisUnavailableReason: r.timing.medianAnalysisMs.reason,
+    analysisCv: r.timing.analysisCv.value,
+    analysisCvUnavailableReason: r.timing.analysisCv.reason,
+    peakRssBytes: r.timing.peakRssBytes.value,
+    peakRssUnavailableReason: r.timing.peakRssBytes.reason,
+    recordedRuns: r.internal.recordedRuns,
+  };
+}

--- a/benchmarks/portability/preconditions.ts
+++ b/benchmarks/portability/preconditions.ts
@@ -1,0 +1,68 @@
+/**
+ * preconditions.ts
+ *
+ * The facts about a host that have to hold before a cross-platform comparison
+ * means anything, and the identifier a platform is filed under.
+ *
+ * ENDIANNESS IS A PRECONDITION, NOT A RESULT. Several science-scoped artifacts
+ * are raw typed-array bytes — the DTM grid, the confidence and coverage planes,
+ * the source point cloud. A typed array serialises in the host's byte order, so
+ * a little-endian and a big-endian host would produce different bytes for
+ * identical numbers. Compared without this check that lands as a science
+ * mismatch, which is the wrong finding: the arithmetic agreed and the
+ * serialisation did not. Every platform records its byte order, an unsupported
+ * one halts the comparison by name, and the claim covers little-endian hosts
+ * only because those are the only ones that have been run.
+ *
+ * Pure. No I/O, no clock, no `node:` builtin — the probe is a typed-array view,
+ * so a browser-side runner reaches the same answer.
+ */
+
+/** The byte order a host serialises typed arrays in. */
+export type Endianness = 'LE' | 'BE';
+
+/** The only byte order the comparison is defined for. See the header. */
+export const SUPPORTED_ENDIANNESS: Endianness = 'LE';
+
+/**
+ * Read the host's byte order by writing a word and reading back its low byte.
+ *
+ * `os.endianness()` reports the same thing on Node and is not used, so this
+ * module stays runtime-neutral and one implementation answers for both halves
+ * of the project.
+ */
+export function detectEndianness(): Endianness {
+  const probe = new Uint16Array([0x0102]);
+  return new Uint8Array(probe.buffer)[0] === 0x02 ? 'LE' : 'BE';
+}
+
+/** Why a byte order other than little-endian stops the comparison. */
+export function unsupportedEndiannessReason(platformId: string, found: Endianness): string {
+  return (
+    `${platformId} reports ${found} byte order. Several science-scoped artifacts are raw typed-array ` +
+    'bytes, which serialise in host order, so a comparison against a little-endian platform would ' +
+    'report a science mismatch for a serialisation difference. Cross-platform reproducibility is ' +
+    'claimed for little-endian platforms only.'
+  );
+}
+
+/**
+ * The directory name and table key one platform is filed under.
+ *
+ * Platform and architecture only. The Node version, the CPU model and the OS
+ * release are all recorded in the environment block and none of them belong in
+ * the key: a second macOS ARM64 leg on a different CPU is the same platform,
+ * and folding the model in would file it as a new one and quietly weaken a
+ * two-platform comparison into two single-platform ones.
+ */
+export function platformId(platform: string, arch: string): string {
+  const clean = (s: string): string => s.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  const p = clean(platform);
+  const a = clean(arch);
+  if (p === '' || a === '') {
+    throw new Error(
+      `benchmark portability: a platform id needs both a platform and an architecture, got ${JSON.stringify(platform)} and ${JSON.stringify(arch)}`,
+    );
+  }
+  return `${p}-${a}`;
+}

--- a/benchmarks/portability/record.ts
+++ b/benchmarks/portability/record.ts
@@ -1,0 +1,253 @@
+/**
+ * record.ts
+ *
+ * One platform's leg of the cross-platform comparison, reduced to the record
+ * the comparator reads.
+ *
+ * WHY A SEPARATE RECORD RATHER THAN THE WHOLE RESULT TREE. The comparator's
+ * inputs are what decide whether the published finding is honest, so they are
+ * named in one place and nowhere else. A comparator handed two `raw.json` files
+ * would be free to reach for any field in them, and the difference between a
+ * science-scoped hash and a build-scoped one — the whole distinction the claim
+ * rests on — would live in whichever line of the comparator happened to touch
+ * it. Here the record itself is sorted into four blocks: what must match
+ * exactly, what is compared first, what is expected to differ, and what is
+ * summarised per platform and never pooled.
+ *
+ * EVERY FIELD IS DERIVED FROM A RECORDED RUN. Nothing on this record is entered
+ * by hand or defaulted. A field the run did not produce is `null` next to the
+ * reason it is null, in the same shape the rest of the framework uses.
+ *
+ * Pure data + a builder over an already-completed suite result. No I/O, no
+ * clock.
+ */
+
+import type { EnvValue } from '../framework';
+import type { ReproducibilityConfig } from '../runner/config';
+import type { RunScalars } from '../runner/observe';
+import type { ReproducibilityRaw, ReproducibilitySummary } from '../runner/reproducibility';
+import { SERIES_ANALYSIS_MS, SERIES_PEAK_RSS_BYTES, SERIES_PIPELINE_TOTAL_MS } from '../runner/series';
+import type { Endianness } from './preconditions';
+
+/** Bumped when any field below changes meaning. Mixed versions never compare. */
+export const PORTABILITY_SCHEMA_VERSION = 1;
+
+/** The artifact carrying the seeded source cloud itself, compared first. */
+export const SOURCE_CLOUD_ARTIFACT = 'pointBytes';
+/** The artifact carrying the generator's own description of that cloud. */
+export const FIXTURE_DESCRIPTOR_ARTIFACT = 'fixture';
+
+/**
+ * The host block. Everything here is ALLOWED to differ between platforms and is
+ * reported as an expected difference rather than dropped.
+ */
+export interface PlatformEnvironment {
+  readonly platformId: string;
+  readonly endianness: Endianness;
+  readonly os: EnvValue;
+  readonly arch: EnvValue;
+  readonly cpuModel: EnvValue;
+  readonly logicalCpuCount: EnvValue;
+  readonly totalMemoryBytes: EnvValue;
+  readonly loadAverage: EnvValue;
+  readonly nodeVersion: EnvValue;
+  readonly npmVersion: EnvValue;
+  /** V8's own version, which is what actually supplies `Math.sin`. */
+  readonly v8Version: EnvValue;
+}
+
+/**
+ * What every platform must agree on before its outputs are comparable at all.
+ *
+ * A commit or a lockfile that differs makes a hash comparison meaningless: two
+ * platforms would be running two programs. These are checked before any science
+ * is looked at, so the report never says "the science diverged" about two
+ * different programs agreeing to disagree.
+ */
+export interface EvaluatedIdentity {
+  readonly commit: EnvValue;
+  readonly commitShort: EnvValue;
+  readonly workingTree: EnvValue;
+  readonly releaseVersion: EnvValue;
+  /** SHA-256 of the committed `package-lock.json` as the run resolved it. */
+  readonly lockfileSha256: EnvValue;
+  readonly config: ReproducibilityConfig;
+  readonly benchmarkPackageVersion: string;
+}
+
+/** The generator's output, compared before anything downstream of it. */
+export interface FixtureIdentity {
+  readonly datasetId: string;
+  readonly seed: number;
+  readonly requestedPointCount: number;
+  readonly generatedPointCount: number | null;
+  /** SHA-256 of the seeded cloud's raw coordinate bytes. */
+  readonly sourceCloudHash: string | null;
+  /** SHA-256 of the generator's own descriptor of that cloud. */
+  readonly descriptorHash: string | null;
+}
+
+/** The scientific outputs, all of which must match exactly. */
+export interface ScienceIdentity {
+  /** Science-scoped artifact hashes, keyed by artifact name. */
+  readonly hashes: Readonly<Record<string, string>>;
+  readonly scalars: RunScalars;
+  /** The application's own content hash, taken over the science alone. */
+  readonly applicationContentHash: string | null;
+}
+
+/** This platform's own reproducibility verdict, before any comparison. */
+export interface InternalCheck {
+  readonly pass: boolean;
+  readonly failures: readonly string[];
+  readonly scienceHashesStable: boolean;
+  readonly scalarsStable: boolean;
+  readonly manifestVerifiedOnEveryRun: boolean;
+  readonly recordedRuns: number;
+  readonly warmupRunsCompleted: number;
+}
+
+/** A statistic that was taken, or the reason it was not. */
+export interface PlatformStatistic {
+  readonly value: number | null;
+  readonly unit: string | null;
+  readonly reason: string | null;
+}
+
+/**
+ * Timing and memory, summarised PER PLATFORM and never pooled.
+ *
+ * Two platforms' runtimes are two samples from two machines. A median over the
+ * union of them describes no machine that exists, and the question this suite
+ * answers is whether the outputs are identical, not which host is faster. The
+ * comparator has no code path that combines these.
+ */
+export interface PlatformTiming {
+  readonly medianAnalysisMs: PlatformStatistic;
+  readonly analysisCv: PlatformStatistic;
+  readonly medianPipelineTotalMs: PlatformStatistic;
+  readonly peakRssBytes: PlatformStatistic;
+}
+
+export interface PlatformRecord {
+  readonly portabilitySchemaVersion: number;
+  readonly benchmarkSchemaVersion: number;
+  readonly platformId: string;
+  readonly environment: PlatformEnvironment;
+  readonly evaluated: EvaluatedIdentity;
+  readonly fixture: FixtureIdentity;
+  readonly science: ScienceIdentity;
+  /** Reported as expected differences. Never a pass condition. */
+  readonly buildScopedHashes: Readonly<Record<string, string>>;
+  readonly internal: InternalCheck;
+  readonly timing: PlatformTiming;
+}
+
+function statisticFrom(
+  summary: ReproducibilitySummary,
+  key: string,
+  field: 'median' | 'cv' | 'max',
+  unit: string,
+): PlatformStatistic {
+  const block = summary.timing.available.find((b) => b.key === key);
+  if (!block) {
+    const missing = summary.timing.unavailable.find((b) => b.key === key);
+    return {
+      value: null,
+      unit: null,
+      reason: missing?.reason ?? `series ${key} was not recorded on this platform`,
+    };
+  }
+  const value = block.summary[field];
+  if (value === null) {
+    return {
+      value: null,
+      unit: null,
+      reason: block.summary.unavailable[field] ?? `${field} of ${key} was not computed`,
+    };
+  }
+  // The coefficient of variation is a ratio, so it carries no unit of its own —
+  // and the schema forbids a measured quantity without one, which is why the
+  // unit is named here rather than left blank.
+  return { value, unit, reason: null };
+}
+
+export interface BuildPlatformRecordOptions {
+  readonly platformId: string;
+  readonly endianness: Endianness;
+  readonly environment: Omit<PlatformEnvironment, 'platformId' | 'endianness'>;
+  readonly commit: EnvValue;
+  readonly commitShort: EnvValue;
+  readonly workingTree: EnvValue;
+  readonly releaseVersion: EnvValue;
+  readonly lockfileSha256: EnvValue;
+  readonly benchmarkPackageVersion: string;
+  readonly raw: ReproducibilityRaw;
+  readonly summary: ReproducibilitySummary;
+}
+
+/**
+ * Reduce a completed reproducibility run to one platform's record.
+ *
+ * Run 1 is the reference for the hashes and the scalars, which is the same
+ * reference the reproducibility suite itself compared the other nine against —
+ * so a record whose `internal.pass` is true carries values every run on that
+ * platform agreed on, and one whose `internal.pass` is false carries run 1's
+ * values next to the failures that make them unrepresentative.
+ */
+export function buildPlatformRecord(options: BuildPlatformRecordOptions): PlatformRecord {
+  const { raw, summary } = options;
+  const reference = raw.runs[0]?.observation ?? null;
+  if (reference === null) {
+    throw new Error('benchmark portability: the reproducibility suite recorded no runs');
+  }
+
+  return {
+    portabilitySchemaVersion: PORTABILITY_SCHEMA_VERSION,
+    benchmarkSchemaVersion: summary.schemaVersion,
+    platformId: options.platformId,
+    environment: {
+      platformId: options.platformId,
+      endianness: options.endianness,
+      ...options.environment,
+    },
+    evaluated: {
+      commit: options.commit,
+      commitShort: options.commitShort,
+      workingTree: options.workingTree,
+      releaseVersion: options.releaseVersion,
+      lockfileSha256: options.lockfileSha256,
+      config: raw.config,
+      benchmarkPackageVersion: options.benchmarkPackageVersion,
+    },
+    fixture: {
+      datasetId: reference.datasetId,
+      seed: reference.seed,
+      requestedPointCount: reference.requestedPointCount,
+      generatedPointCount: reference.generatedPointCount,
+      sourceCloudHash: reference.scienceHashes[SOURCE_CLOUD_ARTIFACT] ?? null,
+      descriptorHash: reference.scienceHashes[FIXTURE_DESCRIPTOR_ARTIFACT] ?? null,
+    },
+    science: {
+      hashes: summary.identity.referenceScienceHashes,
+      scalars: reference.scalars,
+      applicationContentHash: summary.identity.applicationContentHash,
+    },
+    buildScopedHashes: summary.identity.referenceBuildScopedHashes,
+    internal: {
+      pass: summary.pass,
+      failures: summary.failures,
+      scienceHashesStable: summary.identity.scienceHashesStable,
+      scalarsStable: summary.identity.scalarsStable,
+      manifestVerifiedOnEveryRun: summary.identity.manifestVerifiedOnEveryRun,
+      recordedRuns: summary.runCount,
+      warmupRunsCompleted: raw.warmupRunsCompleted,
+    },
+    timing: {
+      medianAnalysisMs: statisticFrom(summary, SERIES_ANALYSIS_MS, 'median', 'ms'),
+      analysisCv: statisticFrom(summary, SERIES_ANALYSIS_MS, 'cv', 'ratio'),
+      medianPipelineTotalMs: statisticFrom(summary, SERIES_PIPELINE_TOTAL_MS, 'median', 'ms'),
+      peakRssBytes: statisticFrom(summary, SERIES_PEAK_RSS_BYTES, 'max', 'bytes'),
+    },
+  };
+}

--- a/benchmarks/portability/render.ts
+++ b/benchmarks/portability/render.ts
@@ -1,0 +1,302 @@
+/**
+ * render.ts
+ *
+ * `comparison.csv` and `summary.md`, both derived from `comparison.json` and
+ * from nothing else.
+ *
+ * WHY THE DERIVATION IS TOTAL. The Markdown is the file a reader quotes and the
+ * CSV is the file a plot reads, and neither is worth anything if it can drift
+ * from the JSON beside it. Every function here takes the comparison document as
+ * its only argument, so there is no second source a number could come from, and
+ * the verifier re-renders both and compares byte for byte. That is the same
+ * arrangement `benchmark:verify` already makes for the per-suite reports.
+ *
+ * Pure. No I/O, no clock.
+ */
+
+import { csvRow } from '../framework';
+import type { PortabilityComparison } from './compare';
+import type { PlatformRecord } from './record';
+
+const CSV_HEADER = 'section,field,kind,verdict,platform,value';
+
+/**
+ * Long format, one row per platform per field.
+ *
+ * A wide table with one column per platform would have to be reshaped every
+ * time a leg is added or dropped, and a two-platform file and a three-platform
+ * file would not share a column set. Long format keeps every result set
+ * readable by the same reader.
+ */
+export function comparisonCsv(comparison: PortabilityComparison): string {
+  const lines: string[] = [CSV_HEADER];
+
+  lines.push(csvRow(['status', 'status', 'comparison', comparison.status, '', comparison.status]));
+  lines.push(
+    csvRow([
+      'status',
+      'claimEstablished',
+      'comparison',
+      comparison.claimEstablished ? 'established' : 'not-established',
+      '',
+      String(comparison.claimEstablished),
+    ]),
+  );
+  for (const [platform, order] of Object.entries(comparison.endianness)) {
+    lines.push(csvRow(['precondition', 'endianness', 'host', 'recorded', platform, order]));
+  }
+  for (const [i, failure] of comparison.preconditionFailures.entries()) {
+    lines.push(csvRow(['precondition', `failure[${i}]`, 'blocking', 'failed', '', failure]));
+  }
+
+  for (const [platform, hash] of Object.entries(comparison.fixture.sourceCloudHashes)) {
+    lines.push(
+      csvRow([
+        'fixture',
+        'sourceCloudHash',
+        'sha256',
+        comparison.fixture.identical ? 'identical' : 'differs',
+        platform,
+        hash ?? 'absent',
+      ]),
+    );
+  }
+  for (const [platform, hash] of Object.entries(comparison.fixture.descriptorHashes)) {
+    lines.push(
+      csvRow([
+        'fixture',
+        'descriptorHash',
+        'sha256',
+        comparison.fixture.identical ? 'identical' : 'differs',
+        platform,
+        hash ?? 'absent',
+      ]),
+    );
+  }
+  for (const mismatch of comparison.fixture.mismatches) {
+    for (const [platform, value] of Object.entries(mismatch.values)) {
+      lines.push(csvRow(['fixture', mismatch.field, mismatch.kind, 'mismatch', platform, value]));
+    }
+  }
+
+  lines.push(
+    csvRow(['science', 'hashesCompared', 'count', comparison.science.evaluated ? 'evaluated' : 'suppressed', '', String(comparison.science.hashesCompared)]),
+    csvRow(['science', 'hashesMismatched', 'count', comparison.science.evaluated ? 'evaluated' : 'suppressed', '', String(comparison.science.hashesMismatched)]),
+    csvRow(['science', 'scalarsCompared', 'count', comparison.science.evaluated ? 'evaluated' : 'suppressed', '', String(comparison.science.scalarsCompared)]),
+    csvRow(['science', 'scalarsMismatched', 'count', comparison.science.evaluated ? 'evaluated' : 'suppressed', '', String(comparison.science.scalarsMismatched)]),
+  );
+  if (comparison.science.suppressedReason !== null) {
+    lines.push(csvRow(['science', 'suppressedReason', 'note', 'suppressed', '', comparison.science.suppressedReason]));
+  }
+  for (const mismatch of comparison.science.mismatches) {
+    for (const [platform, value] of Object.entries(mismatch.values)) {
+      lines.push(csvRow(['science', mismatch.field, mismatch.kind, 'mismatch', platform, value]));
+    }
+  }
+
+  for (const difference of comparison.expectedDifferences) {
+    for (const [platform, value] of Object.entries(difference.values)) {
+      lines.push(csvRow(['expected-difference', difference.field, difference.category, 'expected', platform, value]));
+    }
+  }
+  for (const exclusion of comparison.structuralExclusions) {
+    lines.push(csvRow(['expected-difference', exclusion.field, 'structural', 'not-compared', '', exclusion.why]));
+  }
+
+  for (const row of comparison.timing) {
+    lines.push(
+      csvRow([
+        'timing',
+        'medianAnalysisMs',
+        'ms',
+        row.medianAnalysisMs === null ? 'unavailable' : 'measured',
+        row.platformId,
+        row.medianAnalysisMs === null ? (row.medianAnalysisUnavailableReason ?? 'unavailable') : String(row.medianAnalysisMs),
+      ]),
+      csvRow([
+        'timing',
+        'analysisCv',
+        'ratio',
+        row.analysisCv === null ? 'unavailable' : 'measured',
+        row.platformId,
+        row.analysisCv === null ? (row.analysisCvUnavailableReason ?? 'unavailable') : String(row.analysisCv),
+      ]),
+      csvRow([
+        'timing',
+        'peakRssBytes',
+        'bytes',
+        row.peakRssBytes === null ? 'unavailable' : 'measured',
+        row.platformId,
+        row.peakRssBytes === null ? (row.peakRssUnavailableReason ?? 'unavailable') : String(row.peakRssBytes),
+      ]),
+      csvRow(['timing', 'recordedRuns', 'count', 'measured', row.platformId, String(row.recordedRuns)]),
+    );
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+/** A cell that never reads as a measurement when there is no measurement. */
+function numberCell(value: number | null, reason: string | null, format: (n: number) => string): string {
+  return value === null ? `unavailable (${reason ?? 'no reason recorded'})` : format(value);
+}
+
+function mib(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+export function comparisonMarkdown(comparison: PortabilityComparison): string {
+  const out: string[] = [];
+  out.push('# Cross-platform scientific reproducibility');
+  out.push('');
+  out.push(`Status: **${comparison.status}**`);
+  out.push('');
+  out.push(comparison.claim);
+  out.push('');
+  out.push('## What was evaluated');
+  out.push('');
+  out.push('| Field | Value |');
+  out.push('| --- | --- |');
+  out.push(`| Platforms | ${comparison.platforms.join(', ')} |`);
+  out.push(`| Commit | ${comparison.evaluatedCommit ?? 'not agreed across platforms'} |`);
+  out.push(`| Release version | ${comparison.releaseVersion} |`);
+  out.push(`| Lockfile sha256 | ${comparison.lockfileSha256 ?? 'not agreed across platforms'} |`);
+  out.push(`| Fixture seed | ${comparison.fixture.seed === null ? 'unavailable' : String(comparison.fixture.seed)} |`);
+  out.push(
+    `| Fixture points | ${comparison.fixture.requestedPointCount === null ? 'unavailable' : String(comparison.fixture.requestedPointCount)} requested, ${comparison.fixture.generatedPointCount === null ? 'unavailable' : String(comparison.fixture.generatedPointCount)} generated |`,
+  );
+  out.push(`| Dataset | ${comparison.fixture.datasetId ?? 'unavailable'} |`);
+  out.push(`| Scalar tolerance | ${comparison.scalarTolerance} |`);
+  out.push(
+    `| Byte order | ${Object.entries(comparison.endianness).map(([id, e]) => `${id} ${e}`).join(', ')} |`,
+  );
+  out.push('');
+
+  if (comparison.preconditionFailures.length > 0) {
+    out.push('## Preconditions that did not hold');
+    out.push('');
+    out.push('The legs are not comparable until every line below is resolved.');
+    out.push('');
+    for (const failure of comparison.preconditionFailures) out.push(`- ${failure}`);
+    out.push('');
+  }
+
+  out.push('## The seeded fixture, compared first');
+  out.push('');
+  out.push(
+    comparison.fixture.identical
+      ? 'The seeded source cloud is byte-identical on every platform, so any downstream difference would be a property of the analysis rather than of its input.'
+      : 'The seeded source cloud is not byte-identical across platforms. Every downstream artifact differs as a consequence, so the downstream comparison is suppressed and no conclusion is drawn about the analysis pipeline.',
+  );
+  out.push('');
+  out.push('| Platform | Source cloud sha256 | Fixture descriptor sha256 |');
+  out.push('| --- | --- | --- |');
+  for (const platform of comparison.platforms) {
+    out.push(
+      `| ${platform} | ${comparison.fixture.sourceCloudHashes[platform] ?? 'absent'} | ${comparison.fixture.descriptorHashes[platform] ?? 'absent'} |`,
+    );
+  }
+  out.push('');
+  if (comparison.fixture.likelyCause !== null) {
+    out.push(`Where to look first: ${comparison.fixture.likelyCause}`);
+    out.push('');
+  }
+  for (const mismatch of comparison.fixture.mismatches) {
+    out.push(
+      `- ${mismatch.field} (${mismatch.kind}): ${Object.entries(mismatch.values).map(([id, v]) => `${id}=${v}`).join(', ')}`,
+    );
+  }
+  if (comparison.fixture.mismatches.length > 0) out.push('');
+
+  out.push('## Science-scoped outputs');
+  out.push('');
+  if (!comparison.science.evaluated) {
+    out.push(`Not evaluated: ${comparison.science.suppressedReason ?? 'no reason recorded'}`);
+    out.push('');
+  } else {
+    out.push(
+      `${comparison.science.hashesCompared} artifact hashes and ${comparison.science.scalarsCompared} scalar values were compared at a tolerance of exactly zero. ${comparison.science.hashesMismatched} hashes and ${comparison.science.scalarsMismatched} scalars differ.`,
+    );
+    out.push('');
+    if (comparison.science.mismatches.length > 0) {
+      out.push('| Field | Kind | Values |');
+      out.push('| --- | --- | --- |');
+      for (const mismatch of comparison.science.mismatches) {
+        out.push(
+          `| ${mismatch.field} | ${mismatch.kind} | ${Object.entries(mismatch.values).map(([id, v]) => `${id}=${v}`).join('<br>')} |`,
+        );
+      }
+      out.push('');
+    }
+  }
+
+  out.push('## Differences that are expected');
+  out.push('');
+  out.push('These are reported, not discarded. None of them gates the result.');
+  out.push('');
+  if (comparison.expectedDifferences.length === 0) {
+    out.push('No expected difference was observed between these platforms.');
+    out.push('');
+  } else {
+    out.push('| Category | Field | Values | Why it may differ |');
+    out.push('| --- | --- | --- | --- |');
+    for (const difference of comparison.expectedDifferences) {
+      out.push(
+        `| ${difference.category} | ${difference.field} | ${Object.entries(difference.values).map(([id, v]) => `${id}=${v}`).join('<br>')} | ${difference.why} |`,
+      );
+    }
+    out.push('');
+  }
+  out.push('Excluded from the comparison by construction:');
+  out.push('');
+  for (const exclusion of comparison.structuralExclusions) {
+    out.push(`- ${exclusion.field}: ${exclusion.why}`);
+  }
+  out.push('');
+
+  out.push('## Runtime, per platform');
+  out.push('');
+  out.push(
+    'Runtimes are not pooled. A median over two machines describes neither of them, and the result this suite reports is output identity rather than which host is faster.',
+  );
+  out.push('');
+  out.push('| Platform | Recorded runs | Median analysis | Analysis CV | Peak RSS |');
+  out.push('| --- | --- | --- | --- | --- |');
+  for (const row of comparison.timing) {
+    out.push(
+      `| ${row.platformId} | ${row.recordedRuns} | ${numberCell(row.medianAnalysisMs, row.medianAnalysisUnavailableReason, (n) => `${n.toFixed(1)} ms`)} | ${numberCell(row.analysisCv, row.analysisCvUnavailableReason, (n) => n.toFixed(4))} | ${numberCell(row.peakRssBytes, row.peakRssUnavailableReason, mib)} |`,
+    );
+  }
+  out.push('');
+
+  out.push('## Scope');
+  out.push('');
+  out.push(
+    `This result covers ${comparison.platforms.join(' and ')} on the Node major version the workflow pins, at the commit above. It is not a claim of platform independence: untested platforms, other runtime versions and big-endian hosts are outside it. Windows is not covered.`,
+  );
+  out.push('');
+
+  return out.join('\n');
+}
+
+/**
+ * The environment document, one entry per platform.
+ *
+ * Separate from the comparison so a reader can answer "what were these two
+ * machines" without reading a comparison, and so the comparison stays about
+ * agreement rather than about hosts.
+ */
+export function environmentsDocument(records: readonly PlatformRecord[]): unknown {
+  return {
+    note: 'Full environment of every platform leg. Every field here is allowed to differ between platforms; the comparison lists the ones that actually did.',
+    platforms: [...records]
+      .sort((a, b) => (a.platformId < b.platformId ? -1 : 1))
+      .map((r) => ({
+        platformId: r.platformId,
+        environment: r.environment,
+        evaluated: r.evaluated,
+        internal: r.internal,
+        timing: r.timing,
+      })),
+  };
+}

--- a/benchmarks/portability/render.ts
+++ b/benchmarks/portability/render.ts
@@ -183,10 +183,16 @@ export function comparisonMarkdown(comparison: PortabilityComparison): string {
 
   out.push('## The seeded fixture, compared first');
   out.push('');
+  // Worded off the platform COUNT, not only off the verdict. With one leg
+  // "identical on every platform" is true and empty at the same time, and a
+  // sentence a reader can take for a cross-platform result is the one thing a
+  // single-platform report must not contain.
   out.push(
-    comparison.fixture.identical
-      ? 'The seeded source cloud is byte-identical on every platform, so any downstream difference would be a property of the analysis rather than of its input.'
-      : 'The seeded source cloud is not byte-identical across platforms. Every downstream artifact differs as a consequence, so the downstream comparison is suppressed and no conclusion is drawn about the analysis pipeline.',
+    comparison.platforms.length < 2
+      ? 'One platform was recorded, so the source cloud below has nothing to be compared against. It is published as the reference a second platform will be checked against.'
+      : comparison.fixture.identical
+        ? 'The seeded source cloud is byte-identical on every platform, so any downstream difference would be a property of the analysis rather than of its input.'
+        : 'The seeded source cloud differs between platforms. Every downstream artifact differs as a consequence, so the downstream comparison is suppressed and the finding stands against the generator rather than against the analysis pipeline.',
   );
   out.push('');
   out.push('| Platform | Source cloud sha256 | Fixture descriptor sha256 |');
@@ -214,8 +220,14 @@ export function comparisonMarkdown(comparison: PortabilityComparison): string {
     out.push(`Not evaluated: ${comparison.science.suppressedReason ?? 'no reason recorded'}`);
     out.push('');
   } else {
+    // With one leg there is no second value for anything to be compared
+    // against, and a sentence saying N hashes "were compared" would read as a
+    // comparison that happened. The counts are still worth publishing: they are
+    // what a second platform will be checked against.
     out.push(
-      `${comparison.science.hashesCompared} artifact hashes and ${comparison.science.scalarsCompared} scalar values were compared at a tolerance of exactly zero. ${comparison.science.hashesMismatched} hashes and ${comparison.science.scalarsMismatched} scalars differ.`,
+      comparison.platforms.length < 2
+        ? `${comparison.science.hashesCompared} artifact hashes and ${comparison.science.scalarsCompared} scalar values are recorded on the single platform above. Nothing was compared against them.`
+        : `${comparison.science.hashesCompared} artifact hashes and ${comparison.science.scalarsCompared} scalar values were compared at a tolerance of exactly zero. ${comparison.science.hashesMismatched} hashes and ${comparison.science.scalarsMismatched} scalars differ.`,
     );
     out.push('');
     if (comparison.science.mismatches.length > 0) {
@@ -232,7 +244,7 @@ export function comparisonMarkdown(comparison: PortabilityComparison): string {
 
   out.push('## Differences that are expected');
   out.push('');
-  out.push('These are reported, not discarded. None of them gates the result.');
+  out.push('Each one is published with the value every platform reported. None of them gates the result.');
   out.push('');
   if (comparison.expectedDifferences.length === 0) {
     out.push('No expected difference was observed between these platforms.');

--- a/benchmarks/portability/writer.ts
+++ b/benchmarks/portability/writer.ts
@@ -1,0 +1,507 @@
+/**
+ * writer.ts
+ *
+ * The portability output tree: one directory per platform leg, and one
+ * comparison built from two or more of them.
+ *
+ * WHY A PLATFORM LEG IS ITS OWN DIRECTORY WITH ITS OWN MANIFEST. The two legs
+ * are produced by two machines that never see each other. Whatever travels
+ * between them is the evidence, so it has to be self-describing and checkable
+ * on arrival: a leg carries the record, the environment it was taken in, and a
+ * manifest hashing both. The comparator refuses a leg whose manifest does not
+ * verify rather than comparing bytes of unknown provenance.
+ *
+ * WHY THE COMPARISON IS RECOMPUTED, NOT TRUSTED. `comparison.json` is a derived
+ * document, and the verifier re-derives it from the platform records in the
+ * subdirectories and compares field by field. That is what makes an edited
+ * verdict fail even when every SHA-256 in the manifest has been refreshed to
+ * match the edit: the digests only prove the tree is self-consistent, and
+ * self-consistency is exactly what a careful edit preserves.
+ *
+ * WHAT MUST NEVER REACH THESE FILES: a username, a home directory, an absolute
+ * path. Every path recorded is relative to its own directory, and the host
+ * fields come from the framework's environment capture.
+ *
+ * The clock is an argument, never read here, for the same reason it is an
+ * argument in the suite writer: nothing under `benchmarks/` may read the wall
+ * clock.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, sep } from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { capturedEnv, unavailableEnv, type EnvValue } from '../framework';
+import { captureEnvironment, nodeSha256Hex } from '../framework/node';
+import { BENCHMARK_PACKAGE_VERSION, BENCHMARK_SCHEMA_VERSION } from '../runner/config';
+import { captureHostExtras, type ManifestFileEntry } from '../runner/writer';
+import type { ReproducibilityResult } from '../runner/reproducibility';
+import { comparePlatforms, type CompareOptions, type PortabilityComparison } from './compare';
+import { detectEndianness, platformId } from './preconditions';
+import {
+  PORTABILITY_SCHEMA_VERSION,
+  buildPlatformRecord,
+  type PlatformRecord,
+} from './record';
+import { comparisonCsv, comparisonMarkdown, environmentsDocument } from './render';
+
+export const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+export const PORTABILITY_DIR = join(REPO_ROOT, 'benchmark-results', 'portability');
+
+/** The file a platform leg is identified by. */
+export const PLATFORM_RECORD_FILE = 'platform-record.json';
+
+export interface PortabilityManifest {
+  readonly schemaVersion: number;
+  readonly portabilitySchemaVersion: number;
+  readonly benchmarkPackageVersion: string;
+  readonly kind: 'platform' | 'comparison';
+  /** Present on a platform leg, absent on a comparison. */
+  readonly platformId: string | null;
+  readonly commit: EnvValue;
+  readonly startedAtUtc: string;
+  readonly completedAtUtc: string;
+  readonly command: string;
+  readonly files: readonly ManifestFileEntry[];
+}
+
+function writeFile(root: string, relPath: string, contents: string, files: ManifestFileEntry[]): void {
+  const full = join(root, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, contents, 'utf8');
+  const bytes = Buffer.from(contents, 'utf8');
+  files.push({ path: relPath.split(sep).join('/'), sha256: nodeSha256Hex(bytes), bytes: bytes.byteLength });
+}
+
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function writeManifest(dir: string, manifest: PortabilityManifest): void {
+  // Written last and never listing itself: a self-hash would have to cover
+  // bytes that do not exist yet.
+  writeFileSync(join(dir, 'manifest.json'), json(manifest), 'utf8');
+}
+
+function sortFiles(files: readonly ManifestFileEntry[]): ManifestFileEntry[] {
+  return [...files].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+/** SHA-256 of the committed lockfile, so two legs can prove one dependency tree. */
+export function captureLockfileHash(repoRoot: string = REPO_ROOT): EnvValue {
+  try {
+    return capturedEnv(nodeSha256Hex(readFileSync(join(repoRoot, 'package-lock.json'))));
+  } catch (err) {
+    return unavailableEnv(`lockfile hash: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export interface WritePlatformLegOptions {
+  readonly reproducibility: ReproducibilityResult;
+  readonly command: string;
+  readonly startedAtUtc: string;
+  readonly completedAtUtc: string;
+  /** Defaults to `benchmark-results/portability/<platformId>`. */
+  readonly outDir?: string;
+  readonly repoRoot?: string;
+}
+
+export interface WritePlatformLegOutcome {
+  readonly dir: string;
+  readonly record: PlatformRecord;
+  readonly manifest: PortabilityManifest;
+}
+
+/**
+ * Reduce a completed reproducibility run to one platform leg and write it.
+ *
+ * The suite is not re-run here and no measurement is taken: this reads a result
+ * the caller already has, so the leg and the ordinary result tree describe the
+ * same ten runs rather than two different sets of them.
+ */
+export function writePlatformLeg(options: WritePlatformLegOptions): WritePlatformLegOutcome {
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const environment = captureEnvironment({ repoRoot });
+  const hostExtras = captureHostExtras();
+  const platform = environment.os.status === 'captured' ? environment.os.value.split(' ')[0] : os.platform();
+  const arch = environment.arch.status === 'captured' ? environment.arch.value : process.arch;
+  const id = platformId(platform, arch);
+
+  const record = buildPlatformRecord({
+    platformId: id,
+    endianness: detectEndianness(),
+    environment: {
+      os: environment.os,
+      arch: environment.arch,
+      cpuModel: environment.cpuModel,
+      logicalCpuCount: hostExtras.logicalCpuCount,
+      totalMemoryBytes: hostExtras.totalMemoryBytes,
+      loadAverage: hostExtras.loadAverage,
+      nodeVersion: environment.nodeVersion,
+      npmVersion: hostExtras.npmVersion,
+      v8Version:
+        typeof process.versions.v8 === 'string' && process.versions.v8 !== ''
+          ? capturedEnv(process.versions.v8)
+          : unavailableEnv('v8 version: not reported by this runtime'),
+    },
+    commit: environment.gitCommitFull,
+    commitShort: environment.gitCommitShort,
+    workingTree: environment.gitDirty,
+    releaseVersion: environment.releaseVersion,
+    lockfileSha256: captureLockfileHash(repoRoot),
+    benchmarkPackageVersion: BENCHMARK_PACKAGE_VERSION,
+    raw: options.reproducibility.raw,
+    summary: options.reproducibility.summary,
+  });
+
+  const dir = options.outDir ?? join(PORTABILITY_DIR, id);
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+
+  const files: ManifestFileEntry[] = [];
+  writeFile(dir, PLATFORM_RECORD_FILE, json(record), files);
+  writeFile(dir, 'environment.json', json({ ...environment, ...hostExtras, endianness: record.environment.endianness }), files);
+  // The per-run hash table, so a reader diffing two legs by hand has the same
+  // evidence the comparator used rather than a summary of it.
+  writeFile(
+    dir,
+    'science-hashes.json',
+    json({
+      note: 'Science-scoped artifact hashes per recorded run on this platform. Build-scoped hashes are listed separately because they track the commit and the runtime, not the science.',
+      reference: record.science.hashes,
+      buildScoped: record.buildScopedHashes,
+      perRun: options.reproducibility.raw.runs.map((r) => ({
+        run: r.index,
+        science: r.observation.scienceHashes,
+        buildScoped: r.observation.buildScopedHashes,
+      })),
+    }),
+    files,
+  );
+
+  const manifest: PortabilityManifest = {
+    schemaVersion: BENCHMARK_SCHEMA_VERSION,
+    portabilitySchemaVersion: PORTABILITY_SCHEMA_VERSION,
+    benchmarkPackageVersion: BENCHMARK_PACKAGE_VERSION,
+    kind: 'platform',
+    platformId: id,
+    commit: environment.gitCommitFull,
+    startedAtUtc: options.startedAtUtc,
+    completedAtUtc: options.completedAtUtc,
+    command: options.command,
+    files: sortFiles(files),
+  };
+  writeManifest(dir, manifest);
+
+  return { dir, record, manifest };
+}
+
+export interface ReadLegOutcome {
+  readonly record: PlatformRecord | null;
+  readonly problems: readonly string[];
+  readonly checked: readonly string[];
+}
+
+/**
+ * Read one platform leg, refusing it unless its own manifest verifies.
+ *
+ * A leg arrives as a downloaded CI artifact, which is a tarball anyone could
+ * have rewritten between the runner and here. Checking the manifest first is
+ * what makes the later comparison a comparison of recorded measurements rather
+ * than of whatever bytes were on disk.
+ */
+export function readPlatformLeg(dir: string): ReadLegOutcome {
+  const problems: string[] = [];
+  const checked: string[] = [];
+
+  const manifestPath = join(dir, 'manifest.json');
+  if (!existsSync(manifestPath)) {
+    return { record: null, problems: [`${dir}: no manifest.json, so this is not a platform leg`], checked };
+  }
+
+  let manifest: PortabilityManifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as PortabilityManifest;
+  } catch (err) {
+    return {
+      record: null,
+      problems: [`${dir}/manifest.json: could not be read as JSON — ${err instanceof Error ? err.message : String(err)}`],
+      checked,
+    };
+  }
+
+  if (manifest.kind !== 'platform') {
+    problems.push(`${dir}: manifest kind is ${JSON.stringify(manifest.kind)}, expected "platform"`);
+  }
+  if (manifest.portabilitySchemaVersion !== PORTABILITY_SCHEMA_VERSION) {
+    problems.push(
+      `${dir}: portability schema version ${String(manifest.portabilitySchemaVersion)} is not ${PORTABILITY_SCHEMA_VERSION}`,
+    );
+  }
+
+  for (const entry of manifest.files) {
+    const full = join(dir, entry.path);
+    if (!existsSync(full)) {
+      problems.push(`${dir}/${entry.path}: listed in the manifest but absent`);
+      continue;
+    }
+    const bytes = readFileSync(full);
+    const hash = nodeSha256Hex(bytes);
+    if (hash !== entry.sha256) {
+      problems.push(`${dir}/${entry.path}: sha256 ${hash} does not match the manifest's ${entry.sha256}`);
+    } else if (bytes.byteLength !== entry.bytes) {
+      problems.push(`${dir}/${entry.path}: ${bytes.byteLength} bytes, manifest says ${entry.bytes}`);
+    }
+  }
+  if (!manifest.files.some((f) => f.path === PLATFORM_RECORD_FILE)) {
+    problems.push(`${dir}: the manifest does not list ${PLATFORM_RECORD_FILE}`);
+  }
+  checked.push(`${dir}: manifest lists and matches ${manifest.files.length} files`);
+
+  let record: PlatformRecord | null = null;
+  try {
+    record = JSON.parse(readFileSync(join(dir, PLATFORM_RECORD_FILE), 'utf8')) as PlatformRecord;
+  } catch (err) {
+    problems.push(`${dir}/${PLATFORM_RECORD_FILE}: could not be read — ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (record !== null && manifest.platformId !== record.platformId) {
+    problems.push(
+      `${dir}: manifest names platform ${String(manifest.platformId)} but the record names ${record.platformId}`,
+    );
+  }
+  // Checked on the RECORD as well as on the manifest. A manifest is cheap to
+  // rewrite and the record is the document the comparison actually reads, so a
+  // leg from an older schema carried beside a current manifest has to be
+  // refused on the strength of the record itself.
+  if (record !== null && record.portabilitySchemaVersion !== PORTABILITY_SCHEMA_VERSION) {
+    problems.push(
+      `${dir}/${PLATFORM_RECORD_FILE}: portability schema version ${String(record.portabilitySchemaVersion)} is not ${PORTABILITY_SCHEMA_VERSION}`,
+    );
+  }
+
+  return { record: problems.length === 0 ? record : null, problems, checked };
+}
+
+/** Every immediate subdirectory that looks like a platform leg. */
+export function findPlatformLegs(root: string): string[] {
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(root, e.name, PLATFORM_RECORD_FILE)))
+    .map((e) => join(root, e.name))
+    .sort();
+}
+
+export interface WriteComparisonOptions {
+  readonly legDirs: readonly string[];
+  readonly command: string;
+  readonly startedAtUtc: string;
+  readonly completedAtUtc: string;
+  readonly compare?: CompareOptions;
+  /** Defaults to `benchmark-results/portability`. */
+  readonly outDir?: string;
+}
+
+export interface WriteComparisonOutcome {
+  readonly dir: string;
+  readonly comparison: PortabilityComparison | null;
+  readonly problems: readonly string[];
+  readonly checked: readonly string[];
+}
+
+/**
+ * Verify every leg, compare them, and write the comparison tree.
+ *
+ * A leg that does not verify stops the write. Publishing a comparison over a
+ * leg whose provenance could not be checked would put a number in the output
+ * that nothing stands behind, which is the one thing this tree must not
+ * contain.
+ */
+export function writeComparison(options: WriteComparisonOptions): WriteComparisonOutcome {
+  const outDir = options.outDir ?? PORTABILITY_DIR;
+  const problems: string[] = [];
+  const checked: string[] = [];
+  const records: PlatformRecord[] = [];
+
+  if (options.legDirs.length === 0) {
+    return {
+      dir: outDir,
+      comparison: null,
+      problems: ['no platform legs were given, so there is nothing to compare'],
+      checked,
+    };
+  }
+
+  for (const legDir of options.legDirs) {
+    const outcome = readPlatformLeg(legDir);
+    problems.push(...outcome.problems);
+    checked.push(...outcome.checked);
+    if (outcome.record !== null) records.push(outcome.record);
+  }
+  if (problems.length > 0) return { dir: outDir, comparison: null, problems, checked };
+
+  const comparison = comparePlatforms(records, options.compare ?? {});
+
+  // Read every leg into memory BEFORE anything is removed. A leg directory is
+  // very often the destination subdirectory as well — a local run writes its
+  // own leg straight into the comparison tree — so copying in place would
+  // delete the source it was about to read.
+  const payloads = options.legDirs.map((legDir, i) => {
+    const legManifest = JSON.parse(readFileSync(join(legDir, 'manifest.json'), 'utf8')) as PortabilityManifest;
+    return {
+      platformId: records[i].platformId,
+      manifestText: json(legManifest),
+      files: legManifest.files.map((entry) => ({
+        path: entry.path,
+        contents: readFileSync(join(legDir, entry.path), 'utf8'),
+      })),
+    };
+  });
+
+  // The per-platform subdirectories are rebuilt from the legs that were
+  // actually read, so the published tree cannot contain a leg the comparison
+  // did not use, or omit one it did.
+  for (const record of records) {
+    rmSync(join(outDir, record.platformId), { recursive: true, force: true });
+  }
+  mkdirSync(outDir, { recursive: true });
+
+  const files: ManifestFileEntry[] = [];
+  for (const payload of payloads) {
+    for (const entry of payload.files) {
+      writeFile(outDir, join(payload.platformId, entry.path), entry.contents, files);
+    }
+    writeFile(outDir, join(payload.platformId, 'manifest.json'), payload.manifestText, files);
+  }
+
+  writeFile(outDir, 'comparison.json', json(comparison), files);
+  writeFile(outDir, 'comparison.csv', comparisonCsv(comparison), files);
+  writeFile(outDir, 'summary.md', comparisonMarkdown(comparison), files);
+  writeFile(outDir, 'environments.json', json(environmentsDocument(records)), files);
+
+  const manifest: PortabilityManifest = {
+    schemaVersion: BENCHMARK_SCHEMA_VERSION,
+    portabilitySchemaVersion: PORTABILITY_SCHEMA_VERSION,
+    benchmarkPackageVersion: BENCHMARK_PACKAGE_VERSION,
+    kind: 'comparison',
+    platformId: null,
+    commit:
+      comparison.evaluatedCommit === null
+        ? unavailableEnv('commit: the platforms did not agree on one')
+        : capturedEnv(comparison.evaluatedCommit),
+    startedAtUtc: options.startedAtUtc,
+    completedAtUtc: options.completedAtUtc,
+    command: options.command,
+    files: sortFiles(files),
+  };
+  writeManifest(outDir, manifest);
+
+  checked.push(`comparison written over ${records.length} platform legs`);
+  return { dir: outDir, comparison, problems: [], checked };
+}
+
+export interface VerifyPortabilityOutcome {
+  readonly ok: boolean;
+  readonly checked: readonly string[];
+  readonly problems: readonly string[];
+}
+
+/** Fields that must never carry private machine information. */
+const PRIVACY_FORBIDDEN = /(?:\/Users\/|\/home\/|C:\\Users\\|\b(?:\d{1,3}\.){3}\d{1,3}\b)/;
+
+/**
+ * Re-derive a published comparison tree from the platform legs inside it.
+ *
+ * Every check here fails on an edit whose SHA-256 was refreshed afterwards,
+ * because none of them consults the digest for the answer: the comparison is
+ * recomputed from the records, and the two rendered files are re-rendered from
+ * the recomputed document.
+ */
+export function verifyPortabilityDir(dir: string, compare: CompareOptions = {}): VerifyPortabilityOutcome {
+  const checked: string[] = [];
+  const problems: string[] = [];
+
+  const manifestPath = join(dir, 'manifest.json');
+  if (!existsSync(manifestPath)) return { ok: false, checked, problems: [`${manifestPath}: missing`] };
+
+  let manifest: PortabilityManifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as PortabilityManifest;
+  } catch (err) {
+    return { ok: false, checked, problems: [`${manifestPath}: ${err instanceof Error ? err.message : String(err)}`] };
+  }
+  if (manifest.kind !== 'comparison') {
+    problems.push(`manifest kind is ${JSON.stringify(manifest.kind)}, expected "comparison"`);
+  }
+
+  for (const entry of manifest.files) {
+    const full = join(dir, entry.path);
+    if (!existsSync(full)) {
+      problems.push(`${entry.path}: listed in the manifest but absent`);
+      continue;
+    }
+    const bytes = readFileSync(full);
+    if (nodeSha256Hex(bytes) !== entry.sha256) {
+      problems.push(`${entry.path}: sha256 does not match the manifest`);
+    }
+  }
+  checked.push(`manifest hashes match all ${manifest.files.length} listed files`);
+
+  for (const relPath of ['comparison.json', 'comparison.csv', 'summary.md', 'environments.json', 'manifest.json']) {
+    if (!existsSync(join(dir, relPath))) problems.push(`${relPath}: required file is missing`);
+  }
+
+  for (const relPath of ['manifest.json', ...manifest.files.map((f) => f.path)]) {
+    const full = join(dir, relPath);
+    if (!existsSync(full)) continue;
+    const match = PRIVACY_FORBIDDEN.exec(readFileSync(full, 'utf8'));
+    if (match) problems.push(`${relPath} carries a home-directory path or an IP address (${JSON.stringify(match[0])})`);
+  }
+  checked.push('no home-directory path or IP address in any published file');
+
+  const legs = findPlatformLegs(dir);
+  if (legs.length === 0) {
+    problems.push('the tree has no platform subdirectory, so the comparison cannot be re-derived');
+    return { ok: false, checked, problems };
+  }
+  const records: PlatformRecord[] = [];
+  for (const leg of legs) {
+    const outcome = readPlatformLeg(leg);
+    problems.push(...outcome.problems);
+    if (outcome.record !== null) records.push(outcome.record);
+  }
+  if (records.length !== legs.length) return { ok: false, checked, problems };
+  checked.push(`${legs.length} platform legs verify against their own manifests`);
+
+  const recomputed = comparePlatforms(records, compare);
+  let published: PortabilityComparison;
+  try {
+    published = JSON.parse(readFileSync(join(dir, 'comparison.json'), 'utf8')) as PortabilityComparison;
+  } catch (err) {
+    problems.push(`comparison.json: ${err instanceof Error ? err.message : String(err)}`);
+    return { ok: false, checked, problems };
+  }
+
+  if (JSON.stringify(published) !== JSON.stringify(recomputed)) {
+    problems.push(
+      'comparison.json does not re-derive from the platform records in this tree; a verdict, a count or a hash was edited after the comparison ran',
+    );
+  } else {
+    checked.push('comparison.json re-derives from the platform records');
+  }
+
+  for (const [relPath, expected] of [
+    ['comparison.csv', comparisonCsv(recomputed)],
+    ['summary.md', comparisonMarkdown(recomputed)],
+  ] as const) {
+    const full = join(dir, relPath);
+    if (!existsSync(full)) continue;
+    if (readFileSync(full, 'utf8') !== expected) {
+      problems.push(`${relPath}: does not match what the comparison re-renders to`);
+    } else {
+      checked.push(`${relPath} matches the re-derived comparison`);
+    }
+  }
+
+  return { ok: problems.length === 0, checked, problems };
+}

--- a/benchmarks/portability/writer.ts
+++ b/benchmarks/portability/writer.ts
@@ -406,8 +406,19 @@ export interface VerifyPortabilityOutcome {
   readonly problems: readonly string[];
 }
 
-/** Fields that must never carry private machine information. */
-const PRIVACY_FORBIDDEN = /(?:\/Users\/|\/home\/|C:\\Users\\|\b(?:\d{1,3}\.){3}\d{1,3}\b)/;
+/**
+ * Text that must never appear in a published file.
+ *
+ * The dotted-quad half is bounded more tightly than the suite verifier's copy,
+ * and the reason is a real false positive rather than a preference: V8 reports
+ * its version as `12.4.254.21-node.22`, which the plain `\b…\b` form reads as
+ * an IP address. That version is recorded on every leg precisely because V8
+ * supplies the transcendental functions the generator depends on, so dropping
+ * the field to satisfy the scan would remove the first thing anyone would check
+ * if the fixture ever stopped matching. Requiring no adjacent version character
+ * keeps a bare address caught and lets a version through.
+ */
+const PRIVACY_FORBIDDEN = /(?:\/Users\/|\/home\/|C:\\Users\\|(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?![\w.-]))/;
 
 /**
  * Re-derive a published comparison tree from the platform legs inside it.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -256,6 +256,96 @@ runner has no way to establish or to prove it established. Until those two
 pieces exist, browser figures are recorded by hand under the protocol below,
 where the conditions are stated and a reader can see what was controlled.
 
+## Cross-platform scientific reproducibility
+
+A third suite asks a question the two above cannot: does the same commit,
+over the same seeded fixture, produce the same science on a different machine
+and a different operating system.
+
+```
+npm run benchmark:repro:portable    # record this platform's leg
+npm run benchmark:compare-platforms # compare two or more recorded legs
+```
+
+The name is narrower than platform independence and stays that way. What the
+suite can establish is a statement about the platforms whose legs it was
+handed, on one Node major version, at one commit. Nothing in it generalises to
+an untested platform. The workflow `.github/workflows/benchmark-portability.yml`
+runs a matrix over `ubuntu-latest` and `macos-latest` on Node 22, uploads each
+leg, then downloads both and compares them. Windows is out of scope for this
+workflow. It is little-endian and would be a legitimate third leg, but it has
+not been run.
+
+### What must be identical
+
+The seeded source-cloud hash, the canonical DTM
+bytes, the DTM dimensions and cell size, the terrain scientific summary,
+elevation min and max, the contour artifact and contour count, terrain
+complexity, the build-stripped scientific record, the application's own
+science-content hash, the processing manifest's scientific content, and every
+scalar scientific value. Tolerance is exactly zero, the same tolerance
+benchmark 1 uses and for the same reason.
+
+### What is allowed to differ
+
+Every difference below is reported, never dropped. Execution time, memory observations, CPU model, operating system, architecture, Node and
+V8 metadata, timestamps, build identity, everything derived from build
+identity, and archive paths. `comparison.json` lists each observed difference
+with the value every platform reported, and names the categories excluded by
+construction.
+
+### The fixture is compared first
+
+Every downstream artifact is a function of
+the seeded source cloud, so a generator that produced different points on two
+hosts makes every later hash differ too. Sorted by hash that reads as "the
+science diverged", which would be the wrong conclusion: the pipeline may be
+perfectly reproducible over an input that is not. The source-cloud hash is
+therefore checked before anything else, a mismatch carries its own status
+(`generator-not-portable`), and the downstream comparison is reported as
+suppressed rather than run and blamed.
+
+The generator's PRNG is integer arithmetic and exact on any engine. Its surface
+uses `Math.sin`, `Math.cos` and `Math.exp`, which ECMAScript leaves
+implementation-defined, and `syntheticCloud.ts` flags that in its own header as
+the one place byte-identity rests on the engine. If this suite ever fails, that
+is the first thing to check. It would be a real portability finding about
+transcendental functions, not a defect to normalise away, and it is not grounds
+for widening the comparison.
+
+### Byte order is a precondition
+
+Several science-scoped artifacts are raw
+typed-array bytes, which serialise in host order. Every leg records its byte
+order, and a leg from an unsupported architecture halts the comparison by name
+instead of producing a mismatch that names the wrong cause. The claim covers
+little-endian platforms only.
+
+### Runtime is per platform
+
+Runtimes are never pooled. A median over two machines
+describes neither of them. `summary.md` carries one row per platform with
+median analysis time, the coefficient of variation, and peak RSS. The result
+this suite reports is output identity, not which host is faster.
+
+### Output
+
+`benchmark-results/portability/` holds `manifest.json`,
+`environments.json`, `comparison.json`, `comparison.csv`, `summary.md`, and one
+subdirectory per platform. Every human-readable file is rendered from
+`comparison.json`, and the verifier re-derives the comparison from the platform
+records in the subdirectories before re-rendering both and comparing byte for
+byte. That is what makes an edited verdict fail even when every digest in the
+manifest has been refreshed to match the edit.
+
+### A single leg reports itself as one
+
+Run on one machine the command
+writes a `single-platform` result and states that the cross-platform claim
+remains unestablished. CI sets `BENCHMARK_REQUIRE_PLATFORMS`, so a missing leg
+fails the job rather than publishing a one-platform result that reads like a
+comparison.
+
 ## The frozen stable benchmark
 
 One protocol, frozen for the stable line, chased for reproducibility rather

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "benchmark:quick": "BENCHMARK_SUITES=reproducibility,scaling vitest run tests/benchmark/runSuites.test.ts --testTimeout=3600000 && npm run benchmark:verify",
     "benchmark:scaling:gc": "BENCHMARK_FORCE_GC=1 npm run benchmark:scaling",
     "benchmark:quick:gc": "BENCHMARK_FORCE_GC=1 npm run benchmark:quick",
+    "benchmark:repro:portable": "BENCHMARK_PORTABLE=1 vitest run tests/benchmark/runPortable.test.ts --testTimeout=3600000",
+    "benchmark:compare-platforms": "BENCHMARK_COMPARE=1 vitest run tests/benchmark/comparePlatforms.test.ts --testTimeout=600000",
     "benchmark:verify": "BENCHMARK_VERIFY=1 vitest run tests/benchmark/verifyResults.test.ts --testTimeout=600000",
     "benchmark:verify:archives": "BENCHMARK_VERIFY_ARCHIVES=1 vitest run tests/benchmark/verifyResults.test.ts --testTimeout=1800000",
     "test:smoke": "playwright test --project=deterministic tests/e2e/smoke.spec.ts tests/e2e/lazyChunkLoad.spec.ts",

--- a/tests/benchmark/comparePlatforms.test.ts
+++ b/tests/benchmark/comparePlatforms.test.ts
@@ -1,0 +1,101 @@
+/**
+ * comparePlatforms.test.ts — the entry point `npm run benchmark:compare-platforms`
+ * invokes.
+ *
+ * It takes two or more platform legs, verifies each one against its own
+ * manifest, compares their science-scoped outputs at a tolerance of exactly
+ * zero, writes the comparison tree, and re-derives that tree to prove the
+ * published files follow from the records inside it.
+ *
+ * No measurement is taken here. Every number in the output comes off a leg that
+ * some machine recorded and signed with a manifest.
+ *
+ * `BENCHMARK_PORTABILITY_DIRS` names the legs, comma-separated. Left unset, the
+ * command uses whatever legs already sit under `benchmark-results/portability/`
+ * — which on a developer machine is the one leg that machine produced, and the
+ * report says so rather than implying a comparison happened.
+ *
+ * `BENCHMARK_REQUIRE_PLATFORMS` names the platform ids that must be present.
+ * CI sets both legs there, so a missing leg fails the job instead of quietly
+ * yielding a single-platform result that reads like a cross-platform one.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  PORTABILITY_DIR,
+  findPlatformLegs,
+  verifyPortabilityDir,
+  writeComparison,
+} from '../../benchmarks/portability/writer';
+import { comparePlatforms } from '../../benchmarks/portability/compare';
+
+const enabled = process.env.BENCHMARK_COMPARE === '1';
+
+function listed(name: string): string[] {
+  return (process.env[name] ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '');
+}
+
+describe('benchmark:compare-platforms', () => {
+  test.runIf(enabled)(
+    'compare the recorded platform legs and publish the result',
+    () => {
+      const explicit = listed('BENCHMARK_PORTABILITY_DIRS');
+      const legDirs = explicit.length > 0 ? explicit : findPlatformLegs(PORTABILITY_DIR);
+      expect(
+        legDirs.length,
+        `no platform legs found — run npm run benchmark:repro:portable first, or set BENCHMARK_PORTABILITY_DIRS`,
+      ).toBeGreaterThan(0);
+
+      const requirePlatforms = listed('BENCHMARK_REQUIRE_PLATFORMS');
+      const startedAtUtc = new Date().toISOString();
+      const outcome = writeComparison({
+        legDirs,
+        command: 'npm run benchmark:compare-platforms',
+        startedAtUtc,
+        completedAtUtc: new Date().toISOString(),
+        compare: { requirePlatforms },
+      });
+
+      for (const line of outcome.checked) console.log(`ok: ${line}`);
+      for (const line of outcome.problems) console.error(`FAIL: ${line}`);
+      expect(outcome.problems).toEqual([]);
+
+      const comparison = outcome.comparison;
+      expect(comparison).not.toBeNull();
+      if (comparison === null) return;
+
+      console.log(`comparison written to ${outcome.dir}`);
+      console.log(`status: ${comparison.status}`);
+      console.log(`platforms: ${comparison.platforms.join(', ')}`);
+      console.log(
+        `source cloud: ${comparison.fixture.identical ? 'byte-identical on every platform' : 'DIFFERS between platforms'}`,
+      );
+      console.log(
+        `science: ${comparison.science.hashesMismatched} of ${comparison.science.hashesCompared} hashes and ${comparison.science.scalarsMismatched} of ${comparison.science.scalarsCompared} scalars differ`,
+      );
+      console.log(`cross-platform claim established: ${comparison.claimEstablished}`);
+      for (const failure of comparison.preconditionFailures) console.error(`precondition: ${failure}`);
+      for (const mismatch of comparison.fixture.mismatches) console.error(`fixture: ${mismatch.field}`);
+      for (const mismatch of comparison.science.mismatches) console.error(`science: ${mismatch.field}`);
+
+      // The published tree must follow from the legs inside it. Checking this
+      // in the same command that wrote it catches a renderer that drifted from
+      // the document, before the tree is ever uploaded anywhere.
+      const verified = verifyPortabilityDir(outcome.dir, { requirePlatforms });
+      for (const line of verified.problems) console.error(`FAIL: ${line}`);
+      expect(verified.problems).toEqual([]);
+
+      // Scientific divergence fails the command. A single-platform run does
+      // not: it is an honest outcome that establishes nothing cross-platform,
+      // and the report says exactly that.
+      expect(comparison.ok, `comparison status is ${comparison.status}`).toBe(true);
+    },
+    600_000,
+  );
+
+  test.runIf(!enabled)('is inert until BENCHMARK_COMPARE=1', () => {
+    expect(typeof comparePlatforms).toBe('function');
+  });
+});

--- a/tests/benchmark/portability.test.ts
+++ b/tests/benchmark/portability.test.ts
@@ -1,0 +1,497 @@
+/**
+ * portability.test.ts — the comparator, and the tamper classes it must refuse.
+ *
+ * WHY THE TAMPER TESTS REGENERATE THE MANIFEST. A check that only recomputes
+ * SHA-256 catches a careless edit and nothing else: anyone editing a published
+ * result to make it say something it did not say would refresh the digests, and
+ * the tree would then be perfectly self-consistent about the wrong thing. So
+ * every tamper below edits a leg, writes a fresh manifest over the edited
+ * bytes, and the check still has to fail — because the comparator re-derives
+ * its verdict from the records rather than trusting the document beside them.
+ * This is the arrangement `benchmark:verify` already uses, applied to the
+ * cross-platform tree.
+ *
+ * These run in the unit bucket. Nothing here measures anything: the records are
+ * synthetic, so the whole file is milliseconds.
+ */
+import { describe, test, expect } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { capturedEnv } from '../../benchmarks/framework';
+import { nodeSha256Hex } from '../../benchmarks/framework/node';
+import { scienceScopedArtifacts, ARTIFACT_SCOPE, PIPELINE_ARTIFACTS } from '../../benchmarks/pipeline/runPipeline';
+import { REPRODUCIBILITY_CONFIG } from '../../benchmarks/runner/config';
+import {
+  BUILD_SCOPED_ARTIFACTS,
+  REQUIRED_SCIENCE_ARTIFACTS,
+  comparePlatforms,
+} from '../../benchmarks/portability/compare';
+import { comparisonCsv, comparisonMarkdown } from '../../benchmarks/portability/render';
+import { PORTABILITY_SCHEMA_VERSION, type PlatformRecord } from '../../benchmarks/portability/record';
+import { detectEndianness, platformId } from '../../benchmarks/portability/preconditions';
+import {
+  PLATFORM_RECORD_FILE,
+  readPlatformLeg,
+  verifyPortabilityDir,
+  writeComparison,
+  type PortabilityManifest,
+} from '../../benchmarks/portability/writer';
+
+// ── synthetic legs ──────────────────────────────────────────────────────────
+
+function hashesFor(salt: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const name of REQUIRED_SCIENCE_ARTIFACTS) out[name] = nodeSha256Hex(Buffer.from(`${name}:${salt}`));
+  return out;
+}
+
+const SCALARS = {
+  gridCols: 61,
+  gridRows: 61,
+  gridCellCount: 3721,
+  cellSizeM: 2,
+  elevationMinM: 10.5,
+  elevationMaxM: 41.25,
+  elevationRangeM: 30.75,
+  meanConfidence: 0.81,
+  qualityScore: 74,
+  qualityBand: 'good',
+  contourIntervalM: 1,
+  contourLevelCount: 31,
+  contourPolylineCount: 412,
+  contourFeatureCount: 412,
+  contourLabelCount: 96,
+  sourcePointCount: 250_000,
+  analyzedPointCount: 249_212,
+  applicationContentHash: 'a'.repeat(64),
+} as const;
+
+function legFor(id: string, options: { readonly medianMs: number } = { medianMs: 900 }): PlatformRecord {
+  return {
+    portabilitySchemaVersion: PORTABILITY_SCHEMA_VERSION,
+    benchmarkSchemaVersion: 2,
+    platformId: id,
+    environment: {
+      platformId: id,
+      endianness: 'LE',
+      os: capturedEnv(id.startsWith('linux') ? 'linux 6.8.0' : 'darwin 25.5.0'),
+      arch: capturedEnv(id.endsWith('x64') ? 'x64' : 'arm64'),
+      cpuModel: capturedEnv(id.endsWith('x64') ? 'AMD EPYC 7763' : 'Apple M3 Max'),
+      logicalCpuCount: capturedEnv('4'),
+      totalMemoryBytes: capturedEnv('17179869184'),
+      loadAverage: capturedEnv('0.40 0.30 0.20'),
+      nodeVersion: capturedEnv('v22.17.1'),
+      npmVersion: capturedEnv('10.9.2'),
+      v8Version: capturedEnv('12.4.254.21-node.22'),
+    },
+    evaluated: {
+      commit: capturedEnv('c'.repeat(40)),
+      commitShort: capturedEnv('ccccccc'),
+      workingTree: capturedEnv('clean'),
+      releaseVersion: capturedEnv('0.6.1'),
+      lockfileSha256: capturedEnv('d'.repeat(64)),
+      config: REPRODUCIBILITY_CONFIG,
+      benchmarkPackageVersion: '1.1.0',
+    },
+    fixture: {
+      datasetId: 'synthetic-250000-seed20260726',
+      seed: REPRODUCIBILITY_CONFIG.seed,
+      requestedPointCount: 250_000,
+      generatedPointCount: 250_000,
+      sourceCloudHash: hashesFor('shared').pointBytes,
+      descriptorHash: hashesFor('shared').fixture,
+    },
+    science: {
+      hashes: hashesFor('shared'),
+      scalars: { ...SCALARS },
+      applicationContentHash: SCALARS.applicationContentHash,
+    },
+    buildScopedHashes: {
+      // Build-scoped by construction: these differ per platform and must never
+      // gate the result.
+      scientificRecord: nodeSha256Hex(Buffer.from(`record:${id}`)),
+      processingManifest: nodeSha256Hex(Buffer.from(`manifest:${id}`)),
+    },
+    internal: {
+      pass: true,
+      failures: [],
+      scienceHashesStable: true,
+      scalarsStable: true,
+      manifestVerifiedOnEveryRun: true,
+      recordedRuns: REPRODUCIBILITY_CONFIG.recordedRuns,
+      warmupRunsCompleted: REPRODUCIBILITY_CONFIG.warmupRuns,
+    },
+    timing: {
+      medianAnalysisMs: { value: options.medianMs, unit: 'ms', reason: null },
+      analysisCv: { value: 0.021, unit: 'ratio', reason: null },
+      medianPipelineTotalMs: { value: options.medianMs + 300, unit: 'ms', reason: null },
+      peakRssBytes: { value: 512 * 1024 * 1024, unit: 'bytes', reason: null },
+    },
+  };
+}
+
+const LINUX = 'linux-x64';
+const MAC = 'darwin-arm64';
+
+/** A deep clone that keeps the record a plain JSON document. */
+function clone(record: PlatformRecord): PlatformRecord {
+  return JSON.parse(JSON.stringify(record)) as PlatformRecord;
+}
+
+// ── the comparator ──────────────────────────────────────────────────────────
+
+describe('the portability comparator', () => {
+  test('the required artifact list is exactly the pipeline science scope', () => {
+    // The comparator names its own requirements so a missing artifact fails
+    // loudly. This is what stops the two lists drifting apart in silence.
+    expect([...REQUIRED_SCIENCE_ARTIFACTS].sort()).toEqual([...scienceScopedArtifacts()].sort());
+    expect([...BUILD_SCOPED_ARTIFACTS].sort()).toEqual(
+      PIPELINE_ARTIFACTS.filter((n) => ARTIFACT_SCOPE[n] === 'build').slice().sort(),
+    );
+  });
+
+  test('two agreeing platforms reproduce, and the expected differences are reported', () => {
+    const comparison = comparePlatforms([legFor(LINUX), legFor(MAC, { medianMs: 640 })]);
+    expect(comparison.status).toBe('reproduced');
+    expect(comparison.ok).toBe(true);
+    expect(comparison.claimEstablished).toBe(true);
+    expect(comparison.fixture.identical).toBe(true);
+    expect(comparison.science.hashesMismatched).toBe(0);
+    expect(comparison.science.scalarsMismatched).toBe(0);
+    expect(comparison.science.hashesCompared).toBe(REQUIRED_SCIENCE_ARTIFACTS.length);
+    expect(comparison.scalarTolerance).toBe(0);
+
+    const fields = comparison.expectedDifferences.map((d) => d.field);
+    // Build-scoped hashes and timing differ and are REPORTED, never dropped.
+    expect(fields).toContain('scientificRecord');
+    expect(fields).toContain('processingManifest');
+    expect(fields).toContain('cpuModel');
+    expect(fields).toContain('os');
+    expect(fields).toContain('medianAnalysisMs');
+    expect(comparison.structuralExclusions.map((e) => e.field)).toContain('archive paths');
+  });
+
+  test('a single platform is reported honestly and establishes no cross-platform claim', () => {
+    const comparison = comparePlatforms([legFor(MAC)]);
+    expect(comparison.status).toBe('single-platform');
+    expect(comparison.ok).toBe(true);
+    expect(comparison.claimEstablished).toBe(false);
+    expect(comparison.claim).toContain('unestablished');
+  });
+
+  test('runtimes are never pooled across platforms', () => {
+    const comparison = comparePlatforms([legFor(LINUX, { medianMs: 1200 }), legFor(MAC, { medianMs: 600 })]);
+    expect(comparison.timing.map((t) => t.medianAnalysisMs)).toEqual([600, 1200]);
+    // No combined figure exists to be misread as "the" runtime.
+    expect(Object.keys(comparison)).not.toContain('medianAnalysisMs');
+  });
+
+  test('an unavailable statistic is never reported as zero', () => {
+    const leg = legFor(MAC);
+    const blind = clone(leg);
+    (blind.timing as { peakRssBytes: unknown }).peakRssBytes = {
+      value: null,
+      unit: null,
+      reason: 'process.memoryUsage() is not available in this runtime',
+    };
+    const comparison = comparePlatforms([legFor(LINUX), blind]);
+    const row = comparison.timing.find((t) => t.platformId === MAC);
+    expect(row?.peakRssBytes).toBeNull();
+    expect(row?.peakRssUnavailableReason).toContain('memoryUsage');
+    expect(comparisonMarkdown(comparison)).toContain('unavailable (process.memoryUsage()');
+  });
+
+  test('a big-endian leg halts the comparison instead of reporting a science mismatch', () => {
+    const big = clone(legFor(LINUX));
+    (big.environment as { endianness: string }).endianness = 'BE';
+    const comparison = comparePlatforms([big, legFor(MAC)]);
+    expect(comparison.status).toBe('unsupported-architecture');
+    expect(comparison.ok).toBe(false);
+    expect(comparison.science.evaluated).toBe(false);
+    expect(comparison.preconditionFailures.join(' ')).toContain('little-endian');
+  });
+
+  test('a differing fixture is a generator finding, not a science finding', () => {
+    const drifted = clone(legFor(MAC));
+    (drifted.fixture as { sourceCloudHash: string }).sourceCloudHash = 'f'.repeat(64);
+    (drifted.science.hashes as Record<string, string>).pointBytes = 'f'.repeat(64);
+    // Everything downstream differs too, exactly as it would in reality.
+    for (const name of REQUIRED_SCIENCE_ARTIFACTS) {
+      if (name !== 'fixture') (drifted.science.hashes as Record<string, string>)[name] = nodeSha256Hex(Buffer.from(`${name}:drift`));
+    }
+    const comparison = comparePlatforms([legFor(LINUX), drifted]);
+    expect(comparison.status).toBe('generator-not-portable');
+    expect(comparison.ok).toBe(false);
+    expect(comparison.fixture.identical).toBe(false);
+    // The downstream comparison is suppressed rather than blamed.
+    expect(comparison.science.evaluated).toBe(false);
+    expect(comparison.science.mismatches).toEqual([]);
+    expect(comparison.science.suppressedReason).toContain('wrong finding');
+    expect(comparison.fixture.likelyCause).toContain('Math.sin');
+  });
+
+  test('same fixture, different downstream hash is scientific divergence', () => {
+    const drifted = clone(legFor(MAC));
+    (drifted.science.hashes as Record<string, string>).dtmZBytes = 'e'.repeat(64);
+    const comparison = comparePlatforms([legFor(LINUX), drifted]);
+    expect(comparison.status).toBe('science-diverged');
+    expect(comparison.ok).toBe(false);
+    expect(comparison.fixture.identical).toBe(true);
+    expect(comparison.science.hashesMismatched).toBe(1);
+    expect(comparison.science.mismatches[0].field).toBe('dtmZBytes');
+  });
+
+  test('every human-readable file derives from the comparison document', () => {
+    const comparison = comparePlatforms([legFor(LINUX), legFor(MAC)]);
+    // Rendering twice from the same document is byte-stable, which is what
+    // makes the verifier's re-render check meaningful.
+    expect(comparisonCsv(comparison)).toEqual(comparisonCsv(comparison));
+    expect(comparisonMarkdown(comparison)).toEqual(comparisonMarkdown(comparison));
+    expect(comparisonMarkdown(comparison)).toContain(comparison.claim);
+    expect(comparisonCsv(comparison)).toContain(comparison.fixture.sourceCloudHashes[LINUX] ?? '');
+  });
+
+  test('the platform id is platform and architecture only', () => {
+    expect(platformId('darwin', 'arm64')).toBe('darwin-arm64');
+    expect(platformId('Linux', 'x64')).toBe('linux-x64');
+    expect(() => platformId('', 'x64')).toThrow(/platform and an architecture/);
+  });
+
+  test('this host is little-endian, which the comparison requires', () => {
+    expect(detectEndianness()).toBe('LE');
+  });
+});
+
+// ── tamper classes ──────────────────────────────────────────────────────────
+
+/** Write a leg directory and a manifest that matches its bytes exactly. */
+function writeLeg(root: string, record: PlatformRecord): string {
+  const dir = join(root, record.platformId);
+  const recordText = `${JSON.stringify(record, null, 2)}\n`;
+  const envText = `${JSON.stringify({ note: 'synthetic leg' }, null, 2)}\n`;
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, PLATFORM_RECORD_FILE), recordText, 'utf8');
+  writeFileSync(join(dir, 'environment.json'), envText, 'utf8');
+  regenerateManifest(dir, record.platformId);
+  return dir;
+}
+
+/**
+ * Rebuild a leg's manifest over whatever bytes are on disk right now.
+ *
+ * This is the step that makes each tamper below a real test. After it, every
+ * SHA-256 in the tree matches the tampered content, so nothing about the digest
+ * can be what catches the edit.
+ */
+function regenerateManifest(dir: string, platformId: string | null): void {
+  const names = [PLATFORM_RECORD_FILE, 'environment.json'];
+  const manifest: PortabilityManifest = {
+    schemaVersion: 2,
+    portabilitySchemaVersion: PORTABILITY_SCHEMA_VERSION,
+    benchmarkPackageVersion: '1.1.0',
+    kind: 'platform',
+    platformId,
+    commit: capturedEnv('c'.repeat(40)),
+    startedAtUtc: '2026-07-26T00:00:00.000Z',
+    completedAtUtc: '2026-07-26T00:10:00.000Z',
+    command: 'npm run benchmark:repro:portable',
+    files: names.map((name) => {
+      const bytes = readFileSync(join(dir, name));
+      return { path: name, sha256: nodeSha256Hex(bytes), bytes: bytes.byteLength };
+    }),
+  };
+  writeFileSync(join(dir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+}
+
+/** Edit a leg on disk, then refresh its manifest so the digests still match. */
+function tamper(dir: string, edit: (record: PlatformRecord) => void): void {
+  const record = JSON.parse(readFileSync(join(dir, PLATFORM_RECORD_FILE), 'utf8')) as PlatformRecord;
+  edit(record);
+  writeFileSync(join(dir, PLATFORM_RECORD_FILE), `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+  regenerateManifest(dir, record.platformId);
+}
+
+describe('tamper classes the comparison must refuse', () => {
+  function scratch(): { root: string; linux: string; mac: string; clean: () => void } {
+    const root = mkdtempSync(join(tmpdir(), 'olv-portability-'));
+    return {
+      root,
+      linux: writeLeg(root, legFor(LINUX)),
+      mac: writeLeg(root, legFor(MAC)),
+      clean: () => rmSync(root, { recursive: true, force: true }),
+    };
+  }
+
+  /** Run the published path end to end and return the problems plus the status. */
+  function run(dirs: readonly string[], root: string, requirePlatforms: readonly string[] = []) {
+    const outcome = writeComparison({
+      legDirs: dirs,
+      command: 'npm run benchmark:compare-platforms',
+      startedAtUtc: '2026-07-26T01:00:00.000Z',
+      completedAtUtc: '2026-07-26T01:00:05.000Z',
+      outDir: join(root, 'out'),
+      compare: { requirePlatforms },
+    });
+    return outcome;
+  }
+
+  test('an untampered pair passes the published path', () => {
+    const s = scratch();
+    try {
+      const outcome = run([s.linux, s.mac], s.root, [LINUX, MAC]);
+      expect(outcome.problems).toEqual([]);
+      expect(outcome.comparison?.status).toBe('reproduced');
+      expect(outcome.comparison?.ok).toBe(true);
+    } finally {
+      s.clean();
+    }
+  });
+
+  test('1. an altered science hash fails even with the manifest regenerated', () => {
+    const s = scratch();
+    try {
+      tamper(s.mac, (r) => {
+        (r.science.hashes as Record<string, string>).dtmZBytes = '0'.repeat(64);
+      });
+      // The leg itself still verifies: the digests were refreshed.
+      expect(readPlatformLeg(s.mac).problems).toEqual([]);
+      const outcome = run([s.linux, s.mac], s.root, [LINUX, MAC]);
+      expect(outcome.comparison?.status).toBe('science-diverged');
+      expect(outcome.comparison?.ok).toBe(false);
+    } finally {
+      s.clean();
+    }
+  });
+
+  test('2. an altered scalar fails even with the manifest regenerated', () => {
+    const s = scratch();
+    try {
+      tamper(s.mac, (r) => {
+        (r.science.scalars as { elevationMaxM: number }).elevationMaxM = 41.2500001;
+      });
+      expect(readPlatformLeg(s.mac).problems).toEqual([]);
+      const outcome = run([s.linux, s.mac], s.root, [LINUX, MAC]);
+      expect(outcome.comparison?.status).toBe('science-diverged');
+      expect(outcome.comparison?.science.scalarsMismatched).toBe(1);
+    } finally {
+      s.clean();
+    }
+  });
+
+  test('3. a replaced evaluated commit fails', () => {
+    const s = scratch();
+    try {
+      tamper(s.mac, (r) => {
+        (r.evaluated as { commit: unknown }).commit = capturedEnv('b'.repeat(40));
+      });
+      const outcome = run([s.linux, s.mac], s.root, [LINUX, MAC]);
+      expect(outcome.comparison?.status).toBe('preconditions-not-met');
+      expect(outcome.comparison?.preconditionFailures.join(' ')).toContain('same commit');
+    } finally {
+      s.clean();
+    }
+  });
+
+  test('4. a replaced fixture seed fails', () => {
+    const s = scratch();
+    try {
+      tamper(s.mac, (r) => {
+        (r.fixture as { seed: number }).seed = 1;
+      });
+      const outcome = run([s.linux, s.mac], s.root, [LINUX, MAC]);
+      expect(outcome.comparison?.status).toBe('generator-not-portable');
+      expect(outcome.comparison?.fixture.mismatches.map((m) => m.field)).toContain('seed');
+    } finally {
+      s.clean();
+    }
+  });
+
+  test('5. a changed point count fails', () => {
+    const s = scratch();
+    try {
+      tamper(s.mac, (r) => {
+        (r.fixture as { generatedPointCount: number }).generatedPointCount = 249_999;
+      });
+      const outcome = run([s.linux, s.mac], s.root, [LINUX, MAC]);
+      expect(outcome.comparison?.status).toBe('generator-not-portable');
+      expect(outcome.comparison?.fixture.mismatches.map((m) => m.field)).toContain('generatedPointCount');
+    } finally {
+      s.clean();
+    }
+  });
+
+  test('6. classifying a build-scoped hash as scientific fails', () => {
+    const s = scratch();
+    try {
+      tamper(s.mac, (r) => {
+        (r.science.hashes as Record<string, string>).processingManifest = r.buildScopedHashes.processingManifest;
+      });
+      const outcome = run([s.linux, s.mac], s.root, [LINUX, MAC]);
+      expect(outcome.comparison?.status).toBe('preconditions-not-met');
+      expect(outcome.comparison?.preconditionFailures.join(' ')).toContain('build-scoped artifact processingManifest');
+    } finally {
+      s.clean();
+    }
+  });
+
+  test('7. removing a required platform fails', () => {
+    const s = scratch();
+    try {
+      const outcome = run([s.linux], s.root, [LINUX, MAC]);
+      expect(outcome.comparison?.status).toBe('preconditions-not-met');
+      expect(outcome.comparison?.preconditionFailures.join(' ')).toContain(`required platform ${MAC} is absent`);
+      expect(outcome.comparison?.ok).toBe(false);
+    } finally {
+      s.clean();
+    }
+  });
+
+  test('8. mixing schema versions fails', () => {
+    const s = scratch();
+    try {
+      tamper(s.mac, (r) => {
+        (r as { portabilitySchemaVersion: number }).portabilitySchemaVersion = PORTABILITY_SCHEMA_VERSION + 1;
+      });
+      // The leg is refused before the comparison, by its own manifest check.
+      const leg = readPlatformLeg(s.mac);
+      expect(leg.problems.join(' ')).toContain('portability schema version');
+      const outcome = run([s.linux, s.mac], s.root, [LINUX, MAC]);
+      expect(outcome.problems.join(' ')).toContain('portability schema version');
+      expect(outcome.comparison).toBeNull();
+    } finally {
+      s.clean();
+    }
+  });
+
+  test('an edited published verdict does not re-derive, even with fresh digests', () => {
+    const s = scratch();
+    try {
+      const outcome = run([s.linux, s.mac], s.root, [LINUX, MAC]);
+      expect(outcome.problems).toEqual([]);
+      // Flip the published verdict and refresh every digest in the tree, the
+      // way a careful edit would.
+      const outDir = join(s.root, 'out');
+      const comparisonPath = join(outDir, 'comparison.json');
+      const published = JSON.parse(readFileSync(comparisonPath, 'utf8')) as { status: string };
+      published.status = 'reproduced-and-then-some';
+      writeFileSync(comparisonPath, `${JSON.stringify(published, null, 2)}\n`, 'utf8');
+      const manifestPath = join(outDir, 'manifest.json');
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as PortabilityManifest;
+      const refreshed = {
+        ...manifest,
+        files: manifest.files.map((f) => {
+          const bytes = readFileSync(join(outDir, f.path));
+          return { path: f.path, sha256: nodeSha256Hex(bytes), bytes: bytes.byteLength };
+        }),
+      };
+      writeFileSync(manifestPath, `${JSON.stringify(refreshed, null, 2)}\n`, 'utf8');
+
+      const verified = verifyPortabilityDir(outDir, { requirePlatforms: [LINUX, MAC] });
+      expect(verified.ok).toBe(false);
+      expect(verified.problems.join(' ')).toContain('does not re-derive');
+    } finally {
+      s.clean();
+    }
+  });
+});

--- a/tests/benchmark/runPortable.test.ts
+++ b/tests/benchmark/runPortable.test.ts
@@ -1,0 +1,97 @@
+/**
+ * runPortable.test.ts — the entry point `npm run benchmark:repro:portable`
+ * invokes.
+ *
+ * It runs the existing reproducibility suite, unchanged and with the shipped
+ * configuration, then writes two things from that single run: the ordinary
+ * result tree `benchmark:verify` already checks, and this platform's leg of the
+ * cross-platform comparison. One run behind both, so the leg and the tree can
+ * never describe two different sets of measurements.
+ *
+ * A vitest file rather than a bare node script, for the reason `runSuites`
+ * already is: the pipeline driver reads `__BUILD_IDENTITY__`, a Vite define,
+ * and under plain node that is a ReferenceError at module load.
+ *
+ * The wall clock is read HERE, outside `benchmarks/`, because nothing in that
+ * tree may read it. The manifests need start and completion times and this file
+ * supplies them.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  REPRODUCIBILITY_CONFIG,
+  parseReproducibilityConfig,
+} from '../../benchmarks/runner/config';
+import { runReproducibilitySuite } from '../../benchmarks/runner/reproducibility';
+import { writeResults } from '../../benchmarks/runner/writer';
+import { SUPPORTED_ENDIANNESS, detectEndianness } from '../../benchmarks/portability/preconditions';
+import { writePlatformLeg } from '../../benchmarks/portability/writer';
+
+const enabled = process.env.BENCHMARK_PORTABLE === '1';
+
+/** Named as deliberately not run, so `summary.md` says so rather than nothing. */
+const NOT_RUN = [
+  {
+    suiteId: 'scaling',
+    reason:
+      'the portable command records one seeded configuration so two platforms compare like with like; the scaling ladder is a separate experiment and is run by npm run benchmark:scaling',
+  },
+  {
+    suiteId: 'browser',
+    reason:
+      'GPU upload, first frame, frame rate and time-to-interaction need a browser; this runner is Node-only and reports no number for them',
+  },
+] as const;
+
+describe('benchmark:repro:portable', () => {
+  test.runIf(enabled)(
+    'record this platform as a leg of the cross-platform comparison',
+    () => {
+      // Checked before the suite runs, not after. A big-endian host would
+      // produce different bytes for identical numbers in every raw typed-array
+      // artifact, and a leg recorded from one would show up later as a science
+      // mismatch, which names the wrong cause.
+      const endianness = detectEndianness();
+      expect(
+        endianness,
+        `this host reports ${endianness} byte order; cross-platform reproducibility is defined here for ${SUPPORTED_ENDIANNESS} hosts only`,
+      ).toBe(SUPPORTED_ENDIANNESS);
+
+      const startedAtUtc = new Date().toISOString();
+      const reproducibility = runReproducibilitySuite(parseReproducibilityConfig(REPRODUCIBILITY_CONFIG));
+      const completedAtUtc = new Date().toISOString();
+
+      const command = 'npm run benchmark:repro:portable';
+      const results = writeResults({
+        command,
+        startedAtUtc,
+        completedAtUtc,
+        reproducibility,
+        scaling: null,
+        notRun: NOT_RUN,
+      });
+      const leg = writePlatformLeg({
+        reproducibility,
+        command,
+        startedAtUtc,
+        completedAtUtc,
+      });
+
+      console.log(`benchmark results written to ${results.latestDir}`);
+      console.log(`archived at ${results.archiveDir}`);
+      console.log(`platform leg written to ${leg.dir} as ${leg.record.platformId}`);
+      console.log(`source cloud sha256: ${leg.record.fixture.sourceCloudHash ?? 'absent'}`);
+
+      // The suite's verdict is the test's verdict, so a platform that cannot
+      // reproduce its own outputs never becomes a leg of a cross-platform
+      // claim.
+      expect(reproducibility.summary.failures).toEqual([]);
+      expect(leg.record.internal.pass).toBe(true);
+      expect(leg.record.fixture.sourceCloudHash).not.toBeNull();
+    },
+    3_600_000,
+  );
+
+  test.runIf(!enabled)('is inert until BENCHMARK_PORTABLE=1', () => {
+    expect(detectEndianness()).toBe(SUPPORTED_ENDIANNESS);
+  });
+});


### PR DESCRIPTION
Adds the cross-platform reproducibility suite: a seeded 250,000-point fixture, a recorder that separates science-scoped artifacts from build-scoped provenance, and a comparator that refuses to report agreement it cannot derive.

The distinction the suite is built around: a source cloud whose hash differs between architectures is a generator that is not portable, not science that diverged. Those produce different verdicts and different remediation, so the comparator checks the fixture hash first and classifies accordingly.

Only the macOS ARM64 leg has run. On that platform, ten recorded runs at this commit produce identical science-scoped artifacts. Nothing cross-platform is established yet; the Linux x86-64 leg is defined and automated in `.github/workflows/benchmark-portability.yml` but has not executed. No comparison result is written for a platform that has not run, and the report says `single-platform` rather than claiming a pass.

Tamper resistance: eight mutations were each rejected with the manifest regenerated over the tampered bytes, plus an edited verdict with every digest refreshed, which fails on re-derivation.

`git diff main...HEAD -- src/` is empty. No new dependencies. `benchmarks/pipeline/runPipeline.ts` gains a science-scoped view of the processing manifest so the manifest's methods and bound parameters can be required equal without the build-seeded chain hashes gating the comparison.

Checks: typecheck clean, 320 benchmark tests pass, test-bucket partition 522/522, `benchmark:verify` passes.
