### PR TITLE
Move panel layout chrome out of main.ts

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.1.md
+++ b/KNOWN_LIMITATIONS_v0.6.1.md
@@ -4,7 +4,7 @@ This is the v0.6.1 patch release. It fixes three defects found by an audit of th
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 7,510 lines and `src/render/Viewer.ts` is 7,104, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The ten blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 7,360 lines and `src/render/Viewer.ts` is 7,104, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 7,510 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 7,360 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -80,6 +80,12 @@ quietly undone, and no vanity extraction is forced to chase a number.
 - the two-finger tracker → `src/render/touchTracker.ts` (11 tests)
 - the render-frame decision → `src/render/renderActivityGate.ts` (9 tests)
 
+Moved for locality rather than testability: the panel column's layout chrome
+(measure-bar and dock clearance, the rail collapse, panel wheel containment)
+now lives in `src/ui/panelChrome.ts`. It is ResizeObserver and CSS custom
+property work with no logic a Node test could decide, but it is panel geometry,
+so it belongs beside the panels.
+
 ### Checked and deliberately NOT extracted
 
 Recorded so the next pass does not re-derive them:
@@ -96,7 +102,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (7,510)** — the largest blocks, which are the extraction
+**`src/main.ts` (7,360)** — the largest blocks, which are the extraction
 candidates:
 
 | Block | ~Lines | Extraction target |
@@ -104,7 +110,6 @@ candidates:
 | `buildActionRegistry` | 424 | `src/app/actionDefinitions.ts` *(planned)* — command/action definitions |
 | `seedStreamingFilterExtents` | 338 | streaming panel wiring module |
 | `handleFile` | 336 | `src/app/openScan.ts` *(planned)* — the open/load pipeline |
-| `containPanelWheel` | 293 | `src/ui/` behaviour helper |
 | `toClassBuffer` | 268 | `src/model/` or `src/render/class/` |
 | `syncInspectorVisuals` | 266 | inspector wiring module |
 | `applyScanRoute` | 233 | joins `ScanRouteService` |

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 7510,
+      "lines": 7360,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,14 @@ import { NavBar } from './ui/NavBar';
 import { ProjectCard } from './ui/ProjectCard';
 import { el } from './ui/dom';
 import {
+  wireMeasureBarClearance,
+  wireDockClearance,
+  wireRailToggle,
+  containPanelWheel,
+  RAIL_CHEVRON_LEFT,
+  RAIL_CHEVRON_RIGHT,
+} from './ui/panelChrome';
+import {
   applyTheme,
   readPersistedTheme,
   writePersistedTheme,
@@ -4250,169 +4258,6 @@ stage.overlay.append(navBar.element, navBar.prompt, navBar.touchHint);
 // before this resolves (start screen empty state, sample buttons, URL
 // field, drop zone) are all owned by Stage / DropZone and don't depend on
 // the Viewer.
-
-/**
- * Keep the left panel column clear of the measure toolbar (v0.4.5 overlap
- * fix). The toolbar (`.olv-measure-bar`) is centred at the same `top: 56px`
- * band the `.olv-left-panels` column anchors to, and activating Measure
- * auto-opens the Measurements panel into that column — so the panel used to
- * paint over the toolbar's left half, hiding the first kind pills. The
- * toolbar's height is dynamic (kind pills wrap at narrow widths, the
- * Finish-polygon button comes and goes, hint text reflows), so a static CSS
- * offset can't be right at every width. Instead a ResizeObserver mirrors
- * the toolbar's REAL height into the `--olv-measure-bar-clear` custom property
- * the column's `top` is computed from; `olv-hidden` is `display: none`, so
- * the observer fires with a zero box when the toolbar hides and the column
- * snaps back up. No-ops (keeping the static layout) where ResizeObserver
- * is unavailable.
- */
-function wireMeasureBarClearance(bar: HTMLElement, column: HTMLElement): void {
-  if (typeof ResizeObserver === 'undefined') return;
-  try {
-    const ro = new ResizeObserver(() => {
-      const h = bar.offsetHeight; // 0 while .olv-hidden (display: none)
-      // 8px = the column's own --space-md gap, so toolbar → first panel
-      // reads with the same rhythm as panel → panel.
-      column.style.setProperty('--olv-measure-bar-clear', h > 0 ? `${h + 8}px` : '0px');
-    });
-    ro.observe(bar);
-  } catch {
-    /* Static layout fallback — only ancient engines, overlap is cosmetic. */
-  }
-}
-
-/**
- * P11 — the dock (bottom tool bar) is a separate fixed element; the left column
- * must never scroll its last control under it. Mirrors wireMeasureBarClearance:
- * writes the dock's REAL height into `--olv-dock-clear` (= dock height + its 14px
- * bottom offset + an 8px gap) so the column's max-height always ends above the
- * dock. Fallback 80px (the previous static reserve) keeps layout unchanged where
- * ResizeObserver is unavailable.
- */
-function wireDockClearance(dock: HTMLElement, column: HTMLElement): void {
-  if (typeof ResizeObserver === 'undefined') return;
-  try {
-    const ro = new ResizeObserver(() => {
-      const h = dock.offsetHeight; // 0 while hidden (display: none)
-      column.style.setProperty('--olv-dock-clear', h > 0 ? `${h + 14 + 8}px` : '80px');
-    });
-    ro.observe(dock);
-  } catch {
-    /* Static 80px fallback — only ancient engines. */
-  }
-}
-
-/**
- * P11 — collapse / expand the whole left rail with one control. The column slides
- * off-screen (transform only) leaving a slim frosted grabber tab to reopen it;
- * state persists in localStorage. Desktop/tablet only — the mobile bottom-sheet
- * owns small screens and the tab is hidden there by CSS.
- */
-/**
- * Rail collapse — one grabber that slides a side panel column out of the way,
- * shared by the left rail (the single `.olv-left-panels` container) and the
- * right column (the Inspector plus the streaming/COPC card). Every element in
- * `panels` receives `collapsedClass` on toggle and is measured for centring and
- * the empty-state hide. The grabber only appears when the column holds visible
- * content, is centred on the union of the visible panels, and persists its
- * state in localStorage. Desktop only — on phones the panels live in the bottom
- * sheet and CSS hides the grabber.
- */
-interface RailToggleConfig {
-  overlay: HTMLElement;
-  panels: HTMLElement[];
-  tabClass: string;
-  chevron: string;
-  collapsedClass: string;
-  storageKey: string;
-  ariaControls: string;
-}
-function wireRailToggle(cfg: RailToggleConfig): void {
-  const tab = el('button', { className: cfg.tabClass, unsafeHtml: cfg.chevron });
-  tab.setAttribute('type', 'button');
-  tab.setAttribute('aria-controls', cfg.ariaControls);
-
-  const apply = (collapsed: boolean): void => {
-    for (const p of cfg.panels) p.classList.toggle(cfg.collapsedClass, collapsed);
-    // The tab carries its own collapsed state so it can snap to the screen edge
-    // independently — several tabs can share one edge (right column: one per
-    // panel) without a sibling selector confusing them.
-    tab.classList.toggle('is-collapsed', collapsed);
-    tab.setAttribute('aria-expanded', String(!collapsed));
-    const label = collapsed ? 'Show panel' : 'Hide panel';
-    tab.setAttribute('aria-label', label);
-    tab.title = label;
-  };
-
-  let collapsed = false;
-  try {
-    collapsed = localStorage.getItem(cfg.storageKey) === '1';
-  } catch {
-    /* private mode — default expanded */
-  }
-  apply(collapsed);
-
-  tab.addEventListener('click', () => {
-    collapsed = !collapsed;
-    apply(collapsed);
-    try {
-      localStorage.setItem(cfg.storageKey, collapsed ? '1' : '0');
-    } catch {
-      /* ignore */
-    }
-  });
-  cfg.overlay.append(tab);
-
-  // The grabber only makes sense when the column holds visible panels, and it
-  // must sit AGAINST them. Centre it on the union of the visible panels' boxes
-  // and hide it while the column is empty — the "Open a scan" state, where the
-  // panels are display:none / carry `olv-hidden`. The collapse is transform-
-  // only, so the vertical span is unchanged and the centre holds even collapsed.
-  // A ResizeObserver keeps it in step; CSS `translateY(-50%)` centres on `top`.
-  tab.classList.add('olv-hidden');
-  const positionTab = (): void => {
-    const boxes = cfg.panels
-      .filter((n) => n.offsetHeight > 0 && !n.classList.contains('olv-hidden'))
-      .map((n) => n.getBoundingClientRect());
-    const empty = boxes.length === 0;
-    tab.classList.toggle('olv-hidden', empty);
-    if (empty) return;
-    const top = Math.min(...boxes.map((b) => b.top));
-    const bottom = Math.max(...boxes.map((b) => b.bottom));
-    tab.style.top = `${Math.round((top + bottom) / 2)}px`;
-  };
-  if (typeof ResizeObserver !== 'undefined') {
-    try {
-      const ro = new ResizeObserver(positionTab);
-      for (const p of cfg.panels) ro.observe(p);
-    } catch {
-      /* static fallback — the window listener + initial call still run */
-    }
-  }
-  window.addEventListener('resize', positionTab);
-  positionTab();
-}
-
-// Inline, literally-embedded chevron SVGs — the sanctioned `unsafeHtml` use (see
-// dom.ts). Each points the way its rail moves to collapse; CSS flips it on state.
-const RAIL_CHEVRON_LEFT =
-  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" ' +
-  'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
-  '<path d="M15 6l-6 6 6 6"/></svg>';
-const RAIL_CHEVRON_RIGHT =
-  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" ' +
-  'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
-  '<path d="M9 6l6 6-6 6"/></svg>';
-
-/**
- * P9 — contain a scrollable overlay panel's wheel events so a wheel over the
- * panel scrolls only the panel and never bubbles to a handler that could move
- * the camera or scroll the page. Passive: this is normal scrolling, so it never
- * calls `preventDefault` (which would break natural / momentum scrolling).
- */
-function containPanelWheel(panel: HTMLElement): void {
-  panel.addEventListener('wheel', (e) => { e.stopPropagation(); }, { passive: true });
-}
 
 void viewerLoaded.then(() => {
   if (!bareMode) {

--- a/src/ui/panelChrome.ts
+++ b/src/ui/panelChrome.ts
@@ -1,0 +1,173 @@
+/**
+ * panelChrome.ts — the overlay column's own layout chrome.
+ *
+ * These helpers own the geometry of the side panel columns: keeping a column
+ * clear of the measure toolbar and the dock, the one-tap rail collapse, and
+ * wheel ownership over a scrolling panel. None of them touch the Viewer, the
+ * scan, or any application state — they read element boxes and write CSS
+ * custom properties — so they belong beside the panels rather than in main.ts.
+ */
+import { el } from './dom';
+
+/**
+ * Keep the left panel column clear of the measure toolbar (v0.4.5 overlap
+ * fix). The toolbar (`.olv-measure-bar`) is centred at the same `top: 56px`
+ * band the `.olv-left-panels` column anchors to, and activating Measure
+ * auto-opens the Measurements panel into that column — so the panel used to
+ * paint over the toolbar's left half, hiding the first kind pills. The
+ * toolbar's height is dynamic (kind pills wrap at narrow widths, the
+ * Finish-polygon button comes and goes, hint text reflows), so a static CSS
+ * offset can't be right at every width. Instead a ResizeObserver mirrors
+ * the toolbar's REAL height into the `--olv-measure-bar-clear` custom property
+ * the column's `top` is computed from; `olv-hidden` is `display: none`, so
+ * the observer fires with a zero box when the toolbar hides and the column
+ * snaps back up. No-ops (keeping the static layout) where ResizeObserver
+ * is unavailable.
+ */
+export function wireMeasureBarClearance(bar: HTMLElement, column: HTMLElement): void {
+  if (typeof ResizeObserver === 'undefined') return;
+  try {
+    const ro = new ResizeObserver(() => {
+      const h = bar.offsetHeight; // 0 while .olv-hidden (display: none)
+      // 8px = the column's own --space-md gap, so toolbar → first panel
+      // reads with the same rhythm as panel → panel.
+      column.style.setProperty('--olv-measure-bar-clear', h > 0 ? `${h + 8}px` : '0px');
+    });
+    ro.observe(bar);
+  } catch {
+    /* Static layout fallback — only ancient engines, overlap is cosmetic. */
+  }
+}
+
+/**
+ * P11 — the dock (bottom tool bar) is a separate fixed element; the left column
+ * must never scroll its last control under it. Mirrors wireMeasureBarClearance:
+ * writes the dock's REAL height into `--olv-dock-clear` (= dock height + its 14px
+ * bottom offset + an 8px gap) so the column's max-height always ends above the
+ * dock. Fallback 80px (the previous static reserve) keeps layout unchanged where
+ * ResizeObserver is unavailable.
+ */
+export function wireDockClearance(dock: HTMLElement, column: HTMLElement): void {
+  if (typeof ResizeObserver === 'undefined') return;
+  try {
+    const ro = new ResizeObserver(() => {
+      const h = dock.offsetHeight; // 0 while hidden (display: none)
+      column.style.setProperty('--olv-dock-clear', h > 0 ? `${h + 14 + 8}px` : '80px');
+    });
+    ro.observe(dock);
+  } catch {
+    /* Static 80px fallback — only ancient engines. */
+  }
+}
+
+/**
+ * P11 — collapse / expand the whole left rail with one control. The column slides
+ * off-screen (transform only) leaving a slim frosted grabber tab to reopen it;
+ * state persists in localStorage. Desktop/tablet only — the mobile bottom-sheet
+ * owns small screens and the tab is hidden there by CSS.
+ */
+/**
+ * Rail collapse — one grabber that slides a side panel column out of the way,
+ * shared by the left rail (the single `.olv-left-panels` container) and the
+ * right column (the Inspector plus the streaming/COPC card). Every element in
+ * `panels` receives `collapsedClass` on toggle and is measured for centring and
+ * the empty-state hide. The grabber only appears when the column holds visible
+ * content, is centred on the union of the visible panels, and persists its
+ * state in localStorage. Desktop only — on phones the panels live in the bottom
+ * sheet and CSS hides the grabber.
+ */
+export interface RailToggleConfig {
+  overlay: HTMLElement;
+  panels: HTMLElement[];
+  tabClass: string;
+  chevron: string;
+  collapsedClass: string;
+  storageKey: string;
+  ariaControls: string;
+}
+export function wireRailToggle(cfg: RailToggleConfig): void {
+  const tab = el('button', { className: cfg.tabClass, unsafeHtml: cfg.chevron });
+  tab.setAttribute('type', 'button');
+  tab.setAttribute('aria-controls', cfg.ariaControls);
+
+  const apply = (collapsed: boolean): void => {
+    for (const p of cfg.panels) p.classList.toggle(cfg.collapsedClass, collapsed);
+    // The tab carries its own collapsed state so it can snap to the screen edge
+    // independently — several tabs can share one edge (right column: one per
+    // panel) without a sibling selector confusing them.
+    tab.classList.toggle('is-collapsed', collapsed);
+    tab.setAttribute('aria-expanded', String(!collapsed));
+    const label = collapsed ? 'Show panel' : 'Hide panel';
+    tab.setAttribute('aria-label', label);
+    tab.title = label;
+  };
+
+  let collapsed = false;
+  try {
+    collapsed = localStorage.getItem(cfg.storageKey) === '1';
+  } catch {
+    /* private mode — default expanded */
+  }
+  apply(collapsed);
+
+  tab.addEventListener('click', () => {
+    collapsed = !collapsed;
+    apply(collapsed);
+    try {
+      localStorage.setItem(cfg.storageKey, collapsed ? '1' : '0');
+    } catch {
+      /* ignore */
+    }
+  });
+  cfg.overlay.append(tab);
+
+  // The grabber only makes sense when the column holds visible panels, and it
+  // must sit AGAINST them. Centre it on the union of the visible panels' boxes
+  // and hide it while the column is empty — the "Open a scan" state, where the
+  // panels are display:none / carry `olv-hidden`. The collapse is transform-
+  // only, so the vertical span is unchanged and the centre holds even collapsed.
+  // A ResizeObserver keeps it in step; CSS `translateY(-50%)` centres on `top`.
+  tab.classList.add('olv-hidden');
+  const positionTab = (): void => {
+    const boxes = cfg.panels
+      .filter((n) => n.offsetHeight > 0 && !n.classList.contains('olv-hidden'))
+      .map((n) => n.getBoundingClientRect());
+    const empty = boxes.length === 0;
+    tab.classList.toggle('olv-hidden', empty);
+    if (empty) return;
+    const top = Math.min(...boxes.map((b) => b.top));
+    const bottom = Math.max(...boxes.map((b) => b.bottom));
+    tab.style.top = `${Math.round((top + bottom) / 2)}px`;
+  };
+  if (typeof ResizeObserver !== 'undefined') {
+    try {
+      const ro = new ResizeObserver(positionTab);
+      for (const p of cfg.panels) ro.observe(p);
+    } catch {
+      /* static fallback — the window listener + initial call still run */
+    }
+  }
+  window.addEventListener('resize', positionTab);
+  positionTab();
+}
+
+// Inline, literally-embedded chevron SVGs — the sanctioned `unsafeHtml` use (see
+// dom.ts). Each points the way its rail moves to collapse; CSS flips it on state.
+export const RAIL_CHEVRON_LEFT =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" ' +
+  'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<path d="M15 6l-6 6 6 6"/></svg>';
+export const RAIL_CHEVRON_RIGHT =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" ' +
+  'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<path d="M9 6l6 6-6 6"/></svg>';
+
+/**
+ * P9 — contain a scrollable overlay panel's wheel events so a wheel over the
+ * panel scrolls only the panel and never bubbles to a handler that could move
+ * the camera or scroll the page. Passive: this is normal scrolling, so it never
+ * calls `preventDefault` (which would break natural / momentum scrolling).
+ */
+export function containPanelWheel(panel: HTMLElement): void {
+  panel.addEventListener('wheel', (e) => { e.stopPropagation(); }, { passive: true });
+}

--- a/tests/unsafeHtmlGuard.test.ts
+++ b/tests/unsafeHtmlGuard.test.ts
@@ -123,9 +123,9 @@ const ALLOWLIST: readonly string[] = [
   'src/ui/ExportPanel.ts::Export / Convert',
   'src/ui/FullscreenToggle.ts::ICON_ENTER',
   // P11 left-rail toggle: `chevron` is a hardcoded, literal static SVG string
-  // (a chevron path) defined inline in wireLeftRailToggle — no user data, same
+  // (a chevron path) defined inline in panelChrome.ts — no user data, same
   // sanctioned pattern as the other icon SVGs above.
-  'src/main.ts::cfg.chevron',
+  'src/ui/panelChrome.ts::cfg.chevron',
   // Colorbar legend overlay (hand-verified 2026-07-14). `buildColorbarSvg` is
   // the pure figure-legend generator: it XML-escapes EVERY text value it
   // interpolates (see `esc()` in src/render/colorbar.ts, pinned by


### PR DESCRIPTION
`lint:monolith-size` was failing on main: `src/main.ts` stood at 7515 lines against a 7510 baseline, and the ratchet only permits shrinking. It crossed when the footprint axis fix wired `isZUpFormat` at two `footprintMetres` call sites. That lint sits inside `test:release:execute`, so the release gate was red.

`src/ui/panelChrome.ts` now holds the overlay column's layout chrome, lifted verbatim: `wireMeasureBarClearance` and `wireDockClearance` (the ResizeObserver mirrors that write `--olv-measure-bar-clear` and `--olv-dock-clear`), `RailToggleConfig` with `wireRailToggle` and the two chevron constants, and `containPanelWheel`.

The cluster is one concern — panel column geometry. It reads element boxes and writes CSS custom properties, and it touches no viewer, scan or app state; its only dependency is `el` from `ui/dom`. The architecture map already listed this block as an extraction candidate targeted at `src/ui/`, so it is a step that map was asking for. Signatures, bodies and comments are unchanged; the only edits are the added `export` and the rewritten import.

`src/main.ts` goes 7515 to 7360, which is 150 below the old baseline, and the banked baseline in `docs/validation/monolith-size-baseline.json` is lowered to 7360. `Viewer.ts` is untouched at 7104. The lint script itself is unchanged and no baseline was raised.

Three drift gates keyed on the old number or location are updated to match: the `unsafeHtmlGuard` allowlist entry moves from `src/main.ts::cfg.chevron` to `src/ui/panelChrome.ts::cfg.chevron`; the architecture map's line counts and its now-extracted `containPanelWheel` row; and the monolith count in `KNOWN_LIMITATIONS_v0.6.1.md`. The map records the move as done for locality — the block has no Node-testable logic, so it is not claimed under the "extracted with Node tests" heading.

The footprint axis fix is intact. `git diff main -- src/main.ts` shows no change in either region, and `isZUpFormat` is still wired at both call sites.

Checks: typecheck clean, `lint:monolith-size` green at 7360, and `lint:layer-boundaries`, `lint:inline-imports`, `lint:main-deferral`, `lint:no-ignored-src`, `lint:unsafe-html`, `lint:release-truth`, `lint:claims-language`, `lint:archive-vocab`, `lint:position-access`, `lint:release-sync` and `lint:claim-register` all exit 0. All five buckets pass.
