### PR TITLE
Track the two-platform portability result instead of leaving it in CI

### DIFF
--- a/docs/validation/evidence/portability-v0.6.2/PROVENANCE.md
+++ b/docs/validation/evidence/portability-v0.6.2/PROVENANCE.md
@@ -1,0 +1,21 @@
+# Cross-platform reproducibility evidence
+
+These files are the output of the `Benchmark portability` workflow, copied here
+so the result is tracked in the repository rather than living only as a CI
+artifact with a retention window.
+
+| Field | Value |
+| --- | --- |
+| Workflow run | https://github.com/Aurtechmx/openlidarviewer/actions/runs/30221805663 |
+| Evaluated commit | 50e76d22d405f716386dea50138e684fbe5a6911 |
+| Status | reproduced |
+| Platforms | darwin-arm64, linux-x64 |
+
+`benchmark-results/` is untracked, so a local run produces only the platform it
+ran on and reports `single-platform`. That is the correct verdict for one leg
+and is not the verdict this evidence carries: both legs ran on the workflow
+above.
+
+Regenerate with `gh workflow run "Benchmark portability" --ref <ref>`, then
+replace this directory with the run's `portability-comparison` artifact and
+update the run URL and commit above.

--- a/docs/validation/evidence/portability-v0.6.2/comparison.csv
+++ b/docs/validation/evidence/portability-v0.6.2/comparison.csv
@@ -1,0 +1,40 @@
+section,field,kind,verdict,platform,value
+status,status,comparison,reproduced,,reproduced
+status,claimEstablished,comparison,established,,true
+precondition,endianness,host,recorded,darwin-arm64,LE
+precondition,endianness,host,recorded,linux-x64,LE
+fixture,sourceCloudHash,sha256,identical,darwin-arm64,4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3
+fixture,sourceCloudHash,sha256,identical,linux-x64,4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3
+fixture,descriptorHash,sha256,identical,darwin-arm64,98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9
+fixture,descriptorHash,sha256,identical,linux-x64,98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9
+science,hashesCompared,count,evaluated,,15
+science,hashesMismatched,count,evaluated,,0
+science,scalarsCompared,count,evaluated,,18
+science,scalarsMismatched,count,evaluated,,0
+expected-difference,os,host,expected,darwin-arm64,darwin 25.4.0
+expected-difference,os,host,expected,linux-x64,linux 6.17.0-1020-azure
+expected-difference,arch,host,expected,darwin-arm64,arm64
+expected-difference,arch,host,expected,linux-x64,x64
+expected-difference,cpuModel,host,expected,darwin-arm64,Apple M1 (Virtual)
+expected-difference,cpuModel,host,expected,linux-x64,AMD EPYC 9V74 80-Core Processor
+expected-difference,logicalCpuCount,host,expected,darwin-arm64,3
+expected-difference,logicalCpuCount,host,expected,linux-x64,4
+expected-difference,totalMemoryBytes,host,expected,darwin-arm64,7516192768
+expected-difference,totalMemoryBytes,host,expected,linux-x64,16766423040
+expected-difference,loadAverage,host,expected,darwin-arm64,10.88 11.31 11.32
+expected-difference,loadAverage,host,expected,linux-x64,0.97 0.27 0.09
+expected-difference,medianAnalysisMs,timing,expected,darwin-arm64,1305.1736865
+expected-difference,medianAnalysisMs,timing,expected,linux-x64,1060.506257
+expected-difference,peakRssBytes,timing,expected,darwin-arm64,440418304
+expected-difference,peakRssBytes,timing,expected,linux-x64,413757440
+expected-difference,timestamps,structural,not-compared,,"Run start and completion times are wall-clock readings. The framework strips them from every hashed artifact, and they are recorded in each platform manifest rather than compared."
+expected-difference,archive paths,structural,not-compared,,Each platform writes into its own results directory and each CI runner has its own workspace root. Paths are relative in every manifest and are not part of any hash.
+expected-difference,build identity,structural,not-compared,,"The build identity string embeds the commit and the runtime that produced it. The scientific record and the processing manifest are seeded from it, which is why both are build-scoped and compared separately."
+timing,medianAnalysisMs,ms,measured,darwin-arm64,1305.1736865
+timing,analysisCv,ratio,measured,darwin-arm64,0.05316730554592729
+timing,peakRssBytes,bytes,measured,darwin-arm64,440418304
+timing,recordedRuns,count,measured,darwin-arm64,10
+timing,medianAnalysisMs,ms,measured,linux-x64,1060.506257
+timing,analysisCv,ratio,measured,linux-x64,0.052659910444877854
+timing,peakRssBytes,bytes,measured,linux-x64,413757440
+timing,recordedRuns,count,measured,linux-x64,10

--- a/docs/validation/evidence/portability-v0.6.2/comparison.json
+++ b/docs/validation/evidence/portability-v0.6.2/comparison.json
@@ -1,0 +1,156 @@
+{
+  "portabilitySchemaVersion": 1,
+  "status": "reproduced",
+  "ok": true,
+  "claimEstablished": true,
+  "claim": "At commit 50e76d2, OpenLiDARViewer produced identical science-scoped artifacts from the same seeded fixture on darwin-arm64 and linux-x64. Build-scoped provenance and execution timing differed, as expected. Nothing is claimed for platforms not in that list.",
+  "platforms": [
+    "darwin-arm64",
+    "linux-x64"
+  ],
+  "evaluatedCommit": "50e76d22d405f716386dea50138e684fbe5a6911",
+  "lockfileSha256": "60a48b52d87325ac5e6ab823b64fafa86d7aeccc7474733d066cd1358f50e559",
+  "releaseVersion": "0.6.1",
+  "scalarTolerance": 0,
+  "endianness": {
+    "darwin-arm64": "LE",
+    "linux-x64": "LE"
+  },
+  "preconditionFailures": [],
+  "fixture": {
+    "identical": true,
+    "seed": 20260726,
+    "requestedPointCount": 250000,
+    "generatedPointCount": 250000,
+    "datasetId": "synthetic-250000-seed20260726",
+    "sourceCloudHashes": {
+      "darwin-arm64": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+      "linux-x64": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3"
+    },
+    "descriptorHashes": {
+      "darwin-arm64": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+      "linux-x64": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9"
+    },
+    "mismatches": [],
+    "likelyCause": null
+  },
+  "science": {
+    "evaluated": true,
+    "suppressedReason": null,
+    "hashesCompared": 15,
+    "hashesMismatched": 0,
+    "scalarsCompared": 18,
+    "scalarsMismatched": 0,
+    "mismatches": []
+  },
+  "expectedDifferences": [
+    {
+      "category": "host",
+      "field": "os",
+      "why": "The operating system and its release are properties of the host, not of the analysis.",
+      "values": {
+        "darwin-arm64": "darwin 25.4.0",
+        "linux-x64": "linux 6.17.0-1020-azure"
+      }
+    },
+    {
+      "category": "host",
+      "field": "arch",
+      "why": "The instruction set is a property of the host. Byte order is the part that must match, and it is checked as a precondition.",
+      "values": {
+        "darwin-arm64": "arm64",
+        "linux-x64": "x64"
+      }
+    },
+    {
+      "category": "host",
+      "field": "cpuModel",
+      "why": "The CPU model changes timing and nothing else; every science-scoped value is deterministic arithmetic.",
+      "values": {
+        "darwin-arm64": "Apple M1 (Virtual)",
+        "linux-x64": "AMD EPYC 9V74 80-Core Processor"
+      }
+    },
+    {
+      "category": "host",
+      "field": "logicalCpuCount",
+      "why": "Core count is a property of the runner. The pipeline is single-threaded here.",
+      "values": {
+        "darwin-arm64": "3",
+        "linux-x64": "4"
+      }
+    },
+    {
+      "category": "host",
+      "field": "totalMemoryBytes",
+      "why": "Installed memory is a property of the runner.",
+      "values": {
+        "darwin-arm64": "7516192768",
+        "linux-x64": "16766423040"
+      }
+    },
+    {
+      "category": "host",
+      "field": "loadAverage",
+      "why": "Host load at the moment of writing. It moves the timing column and nothing else.",
+      "values": {
+        "darwin-arm64": "10.88 11.31 11.32",
+        "linux-x64": "0.97 0.27 0.09"
+      }
+    },
+    {
+      "category": "timing",
+      "field": "medianAnalysisMs",
+      "why": "Execution time is a property of the machine. Reported per platform and never pooled.",
+      "values": {
+        "darwin-arm64": "1305.1736865",
+        "linux-x64": "1060.506257"
+      }
+    },
+    {
+      "category": "timing",
+      "field": "peakRssBytes",
+      "why": "Memory high-water observations track the allocator and the host, not the outputs.",
+      "values": {
+        "darwin-arm64": "440418304",
+        "linux-x64": "413757440"
+      }
+    }
+  ],
+  "structuralExclusions": [
+    {
+      "field": "timestamps",
+      "why": "Run start and completion times are wall-clock readings. The framework strips them from every hashed artifact, and they are recorded in each platform manifest rather than compared."
+    },
+    {
+      "field": "archive paths",
+      "why": "Each platform writes into its own results directory and each CI runner has its own workspace root. Paths are relative in every manifest and are not part of any hash."
+    },
+    {
+      "field": "build identity",
+      "why": "The build identity string embeds the commit and the runtime that produced it. The scientific record and the processing manifest are seeded from it, which is why both are build-scoped and compared separately."
+    }
+  ],
+  "timing": [
+    {
+      "platformId": "darwin-arm64",
+      "medianAnalysisMs": 1305.1736865,
+      "medianAnalysisUnavailableReason": null,
+      "analysisCv": 0.05316730554592729,
+      "analysisCvUnavailableReason": null,
+      "peakRssBytes": 440418304,
+      "peakRssUnavailableReason": null,
+      "recordedRuns": 10
+    },
+    {
+      "platformId": "linux-x64",
+      "medianAnalysisMs": 1060.506257,
+      "medianAnalysisUnavailableReason": null,
+      "analysisCv": 0.052659910444877854,
+      "analysisCvUnavailableReason": null,
+      "peakRssBytes": 413757440,
+      "peakRssUnavailableReason": null,
+      "recordedRuns": 10
+    }
+  ]
+}

--- a/docs/validation/evidence/portability-v0.6.2/darwin-arm64/environment.json
+++ b/docs/validation/evidence/portability-v0.6.2/darwin-arm64/environment.json
@@ -1,0 +1,51 @@
+{
+  "os": {
+    "status": "captured",
+    "value": "darwin 25.4.0"
+  },
+  "cpuModel": {
+    "status": "captured",
+    "value": "Apple M1 (Virtual)"
+  },
+  "arch": {
+    "status": "captured",
+    "value": "arm64"
+  },
+  "nodeVersion": {
+    "status": "captured",
+    "value": "v22.23.1"
+  },
+  "gitCommitFull": {
+    "status": "captured",
+    "value": "50e76d22d405f716386dea50138e684fbe5a6911"
+  },
+  "gitCommitShort": {
+    "status": "captured",
+    "value": "50e76d2"
+  },
+  "gitDirty": {
+    "status": "captured",
+    "value": "clean"
+  },
+  "releaseVersion": {
+    "status": "captured",
+    "value": "0.6.1"
+  },
+  "logicalCpuCount": {
+    "status": "captured",
+    "value": "3"
+  },
+  "totalMemoryBytes": {
+    "status": "captured",
+    "value": "7516192768"
+  },
+  "loadAverage": {
+    "status": "captured",
+    "value": "10.88 11.31 11.32"
+  },
+  "npmVersion": {
+    "status": "captured",
+    "value": "10.9.8"
+  },
+  "endianness": "LE"
+}

--- a/docs/validation/evidence/portability-v0.6.2/darwin-arm64/manifest.json
+++ b/docs/validation/evidence/portability-v0.6.2/darwin-arm64/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": 2,
+  "portabilitySchemaVersion": 1,
+  "benchmarkPackageVersion": "1.1.0",
+  "kind": "platform",
+  "platformId": "darwin-arm64",
+  "commit": {
+    "status": "captured",
+    "value": "50e76d22d405f716386dea50138e684fbe5a6911"
+  },
+  "startedAtUtc": "2026-07-26T21:48:06.012Z",
+  "completedAtUtc": "2026-07-26T21:48:35.337Z",
+  "command": "npm run benchmark:repro:portable",
+  "files": [
+    {
+      "path": "environment.json",
+      "sha256": "497c15fdf48385c4b17dacd59f16415843aebd4e6be933d960ee8e715d199a81",
+      "bytes": 946
+    },
+    {
+      "path": "platform-record.json",
+      "sha256": "9a18d1a5c98a788fbc70d676272b1cab0a48ca57db90239de466e78bf556d4b3",
+      "bytes": 5113
+    },
+    {
+      "path": "science-hashes.json",
+      "sha256": "82a62437f1908a7e200cb051c5ccbcd289168ccac594c31d31ec7e2d3dcc5947",
+      "bytes": 18720
+    }
+  ]
+}

--- a/docs/validation/evidence/portability-v0.6.2/darwin-arm64/platform-record.json
+++ b/docs/validation/evidence/portability-v0.6.2/darwin-arm64/platform-record.json
@@ -1,0 +1,165 @@
+{
+  "portabilitySchemaVersion": 1,
+  "benchmarkSchemaVersion": 2,
+  "platformId": "darwin-arm64",
+  "environment": {
+    "platformId": "darwin-arm64",
+    "endianness": "LE",
+    "os": {
+      "status": "captured",
+      "value": "darwin 25.4.0"
+    },
+    "arch": {
+      "status": "captured",
+      "value": "arm64"
+    },
+    "cpuModel": {
+      "status": "captured",
+      "value": "Apple M1 (Virtual)"
+    },
+    "logicalCpuCount": {
+      "status": "captured",
+      "value": "3"
+    },
+    "totalMemoryBytes": {
+      "status": "captured",
+      "value": "7516192768"
+    },
+    "loadAverage": {
+      "status": "captured",
+      "value": "10.88 11.31 11.32"
+    },
+    "nodeVersion": {
+      "status": "captured",
+      "value": "v22.23.1"
+    },
+    "npmVersion": {
+      "status": "captured",
+      "value": "10.9.8"
+    },
+    "v8Version": {
+      "status": "captured",
+      "value": "12.4.254.21-node.56"
+    }
+  },
+  "evaluated": {
+    "commit": {
+      "status": "captured",
+      "value": "50e76d22d405f716386dea50138e684fbe5a6911"
+    },
+    "commitShort": {
+      "status": "captured",
+      "value": "50e76d2"
+    },
+    "workingTree": {
+      "status": "captured",
+      "value": "clean"
+    },
+    "releaseVersion": {
+      "status": "captured",
+      "value": "0.6.1"
+    },
+    "lockfileSha256": {
+      "status": "captured",
+      "value": "60a48b52d87325ac5e6ab823b64fafa86d7aeccc7474733d066cd1358f50e559"
+    },
+    "config": {
+      "suiteId": "reproducibility",
+      "seed": 20260726,
+      "pointCount": 250000,
+      "warmupRuns": 6,
+      "recordedRuns": 10,
+      "terrain": {
+        "cellSizeM": 2,
+        "crs": "EPSG:32610",
+        "verticalDatum": "EPSG:5703",
+        "holdoutSeed": 1
+      },
+      "scalarTolerance": 0
+    },
+    "benchmarkPackageVersion": "1.1.0"
+  },
+  "fixture": {
+    "datasetId": "synthetic-250000-seed20260726",
+    "seed": 20260726,
+    "requestedPointCount": 250000,
+    "generatedPointCount": 250000,
+    "sourceCloudHash": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+    "descriptorHash": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9"
+  },
+  "science": {
+    "hashes": {
+      "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+      "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+      "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+      "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+      "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+      "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+      "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+      "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+      "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+      "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+      "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+      "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+      "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+      "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+      "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+    },
+    "scalars": {
+      "gridCols": 125,
+      "gridRows": 125,
+      "gridCellCount": 15625,
+      "cellSizeM": 2,
+      "elevationMinM": -1.0761682987213135,
+      "elevationMaxM": 15.386188507080078,
+      "elevationRangeM": 16.46235680580139,
+      "meanConfidence": 70.191552,
+      "qualityScore": 82,
+      "qualityBand": "excellent",
+      "contourIntervalM": 0.5,
+      "contourLevelCount": 33,
+      "contourPolylineCount": 229,
+      "contourFeatureCount": 731,
+      "contourLabelCount": 16,
+      "sourcePointCount": 225262,
+      "analyzedPointCount": 225262,
+      "applicationContentHash": "299b2ad5"
+    },
+    "applicationContentHash": "299b2ad5"
+  },
+  "buildScopedHashes": {
+    "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+    "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+  },
+  "internal": {
+    "pass": true,
+    "failures": [],
+    "scienceHashesStable": true,
+    "scalarsStable": true,
+    "manifestVerifiedOnEveryRun": true,
+    "recordedRuns": 10,
+    "warmupRunsCompleted": 6
+  },
+  "timing": {
+    "medianAnalysisMs": {
+      "value": 1305.1736865,
+      "unit": "ms",
+      "reason": null
+    },
+    "analysisCv": {
+      "value": 0.05316730554592729,
+      "unit": "ratio",
+      "reason": null
+    },
+    "medianPipelineTotalMs": {
+      "value": 1372.8472275000001,
+      "unit": "ms",
+      "reason": null
+    },
+    "peakRssBytes": {
+      "value": 440418304,
+      "unit": "bytes",
+      "reason": null
+    }
+  }
+}

--- a/docs/validation/evidence/portability-v0.6.2/darwin-arm64/science-hashes.json
+++ b/docs/validation/evidence/portability-v0.6.2/darwin-arm64/science-hashes.json
@@ -1,0 +1,266 @@
+{
+  "note": "Science-scoped artifact hashes per recorded run on this platform. Build-scoped hashes are listed separately because they track the commit and the runtime, not the science.",
+  "reference": {
+    "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+    "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+    "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+    "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+    "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+    "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+    "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+    "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+    "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+    "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+    "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+    "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+    "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+    "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+    "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+  },
+  "buildScoped": {
+    "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+    "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+  },
+  "perRun": [
+    {
+      "run": 1,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 2,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 3,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 4,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 5,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 6,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 7,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 8,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 9,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 10,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    }
+  ]
+}

--- a/docs/validation/evidence/portability-v0.6.2/environments.json
+++ b/docs/validation/evidence/portability-v0.6.2/environments.json
@@ -1,0 +1,227 @@
+{
+  "note": "Full environment of every platform leg. Every field here is allowed to differ between platforms; the comparison lists the ones that actually did.",
+  "platforms": [
+    {
+      "platformId": "darwin-arm64",
+      "environment": {
+        "platformId": "darwin-arm64",
+        "endianness": "LE",
+        "os": {
+          "status": "captured",
+          "value": "darwin 25.4.0"
+        },
+        "arch": {
+          "status": "captured",
+          "value": "arm64"
+        },
+        "cpuModel": {
+          "status": "captured",
+          "value": "Apple M1 (Virtual)"
+        },
+        "logicalCpuCount": {
+          "status": "captured",
+          "value": "3"
+        },
+        "totalMemoryBytes": {
+          "status": "captured",
+          "value": "7516192768"
+        },
+        "loadAverage": {
+          "status": "captured",
+          "value": "10.88 11.31 11.32"
+        },
+        "nodeVersion": {
+          "status": "captured",
+          "value": "v22.23.1"
+        },
+        "npmVersion": {
+          "status": "captured",
+          "value": "10.9.8"
+        },
+        "v8Version": {
+          "status": "captured",
+          "value": "12.4.254.21-node.56"
+        }
+      },
+      "evaluated": {
+        "commit": {
+          "status": "captured",
+          "value": "50e76d22d405f716386dea50138e684fbe5a6911"
+        },
+        "commitShort": {
+          "status": "captured",
+          "value": "50e76d2"
+        },
+        "workingTree": {
+          "status": "captured",
+          "value": "clean"
+        },
+        "releaseVersion": {
+          "status": "captured",
+          "value": "0.6.1"
+        },
+        "lockfileSha256": {
+          "status": "captured",
+          "value": "60a48b52d87325ac5e6ab823b64fafa86d7aeccc7474733d066cd1358f50e559"
+        },
+        "config": {
+          "suiteId": "reproducibility",
+          "seed": 20260726,
+          "pointCount": 250000,
+          "warmupRuns": 6,
+          "recordedRuns": 10,
+          "terrain": {
+            "cellSizeM": 2,
+            "crs": "EPSG:32610",
+            "verticalDatum": "EPSG:5703",
+            "holdoutSeed": 1
+          },
+          "scalarTolerance": 0
+        },
+        "benchmarkPackageVersion": "1.1.0"
+      },
+      "internal": {
+        "pass": true,
+        "failures": [],
+        "scienceHashesStable": true,
+        "scalarsStable": true,
+        "manifestVerifiedOnEveryRun": true,
+        "recordedRuns": 10,
+        "warmupRunsCompleted": 6
+      },
+      "timing": {
+        "medianAnalysisMs": {
+          "value": 1305.1736865,
+          "unit": "ms",
+          "reason": null
+        },
+        "analysisCv": {
+          "value": 0.05316730554592729,
+          "unit": "ratio",
+          "reason": null
+        },
+        "medianPipelineTotalMs": {
+          "value": 1372.8472275000001,
+          "unit": "ms",
+          "reason": null
+        },
+        "peakRssBytes": {
+          "value": 440418304,
+          "unit": "bytes",
+          "reason": null
+        }
+      }
+    },
+    {
+      "platformId": "linux-x64",
+      "environment": {
+        "platformId": "linux-x64",
+        "endianness": "LE",
+        "os": {
+          "status": "captured",
+          "value": "linux 6.17.0-1020-azure"
+        },
+        "arch": {
+          "status": "captured",
+          "value": "x64"
+        },
+        "cpuModel": {
+          "status": "captured",
+          "value": "AMD EPYC 9V74 80-Core Processor"
+        },
+        "logicalCpuCount": {
+          "status": "captured",
+          "value": "4"
+        },
+        "totalMemoryBytes": {
+          "status": "captured",
+          "value": "16766423040"
+        },
+        "loadAverage": {
+          "status": "captured",
+          "value": "0.97 0.27 0.09"
+        },
+        "nodeVersion": {
+          "status": "captured",
+          "value": "v22.23.1"
+        },
+        "npmVersion": {
+          "status": "captured",
+          "value": "10.9.8"
+        },
+        "v8Version": {
+          "status": "captured",
+          "value": "12.4.254.21-node.56"
+        }
+      },
+      "evaluated": {
+        "commit": {
+          "status": "captured",
+          "value": "50e76d22d405f716386dea50138e684fbe5a6911"
+        },
+        "commitShort": {
+          "status": "captured",
+          "value": "50e76d2"
+        },
+        "workingTree": {
+          "status": "captured",
+          "value": "clean"
+        },
+        "releaseVersion": {
+          "status": "captured",
+          "value": "0.6.1"
+        },
+        "lockfileSha256": {
+          "status": "captured",
+          "value": "60a48b52d87325ac5e6ab823b64fafa86d7aeccc7474733d066cd1358f50e559"
+        },
+        "config": {
+          "suiteId": "reproducibility",
+          "seed": 20260726,
+          "pointCount": 250000,
+          "warmupRuns": 6,
+          "recordedRuns": 10,
+          "terrain": {
+            "cellSizeM": 2,
+            "crs": "EPSG:32610",
+            "verticalDatum": "EPSG:5703",
+            "holdoutSeed": 1
+          },
+          "scalarTolerance": 0
+        },
+        "benchmarkPackageVersion": "1.1.0"
+      },
+      "internal": {
+        "pass": true,
+        "failures": [],
+        "scienceHashesStable": true,
+        "scalarsStable": true,
+        "manifestVerifiedOnEveryRun": true,
+        "recordedRuns": 10,
+        "warmupRunsCompleted": 6
+      },
+      "timing": {
+        "medianAnalysisMs": {
+          "value": 1060.506257,
+          "unit": "ms",
+          "reason": null
+        },
+        "analysisCv": {
+          "value": 0.052659910444877854,
+          "unit": "ratio",
+          "reason": null
+        },
+        "medianPipelineTotalMs": {
+          "value": 1121.9685645,
+          "unit": "ms",
+          "reason": null
+        },
+        "peakRssBytes": {
+          "value": 413757440,
+          "unit": "bytes",
+          "reason": null
+        }
+      }
+    }
+  ]
+}

--- a/docs/validation/evidence/portability-v0.6.2/linux-x64/environment.json
+++ b/docs/validation/evidence/portability-v0.6.2/linux-x64/environment.json
@@ -1,0 +1,51 @@
+{
+  "os": {
+    "status": "captured",
+    "value": "linux 6.17.0-1020-azure"
+  },
+  "cpuModel": {
+    "status": "captured",
+    "value": "AMD EPYC 9V74 80-Core Processor"
+  },
+  "arch": {
+    "status": "captured",
+    "value": "x64"
+  },
+  "nodeVersion": {
+    "status": "captured",
+    "value": "v22.23.1"
+  },
+  "gitCommitFull": {
+    "status": "captured",
+    "value": "50e76d22d405f716386dea50138e684fbe5a6911"
+  },
+  "gitCommitShort": {
+    "status": "captured",
+    "value": "50e76d2"
+  },
+  "gitDirty": {
+    "status": "captured",
+    "value": "clean"
+  },
+  "releaseVersion": {
+    "status": "captured",
+    "value": "0.6.1"
+  },
+  "logicalCpuCount": {
+    "status": "captured",
+    "value": "4"
+  },
+  "totalMemoryBytes": {
+    "status": "captured",
+    "value": "16766423040"
+  },
+  "loadAverage": {
+    "status": "captured",
+    "value": "0.97 0.27 0.09"
+  },
+  "npmVersion": {
+    "status": "captured",
+    "value": "10.9.8"
+  },
+  "endianness": "LE"
+}

--- a/docs/validation/evidence/portability-v0.6.2/linux-x64/manifest.json
+++ b/docs/validation/evidence/portability-v0.6.2/linux-x64/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": 2,
+  "portabilitySchemaVersion": 1,
+  "benchmarkPackageVersion": "1.1.0",
+  "kind": "platform",
+  "platformId": "linux-x64",
+  "commit": {
+    "status": "captured",
+    "value": "50e76d22d405f716386dea50138e684fbe5a6911"
+  },
+  "startedAtUtc": "2026-07-26T21:47:56.537Z",
+  "completedAtUtc": "2026-07-26T21:48:21.325Z",
+  "command": "npm run benchmark:repro:portable",
+  "files": [
+    {
+      "path": "environment.json",
+      "sha256": "f79cbc2a92a5c144b34cb065af541a8974a95898e373e1d8428fe39578e954b4",
+      "bytes": 965
+    },
+    {
+      "path": "platform-record.json",
+      "sha256": "bdcbf4494d9456446ab69634e87b89793548042e41e88d952d5cc02407f3b6d3",
+      "bytes": 5120
+    },
+    {
+      "path": "science-hashes.json",
+      "sha256": "82a62437f1908a7e200cb051c5ccbcd289168ccac594c31d31ec7e2d3dcc5947",
+      "bytes": 18720
+    }
+  ]
+}

--- a/docs/validation/evidence/portability-v0.6.2/linux-x64/platform-record.json
+++ b/docs/validation/evidence/portability-v0.6.2/linux-x64/platform-record.json
@@ -1,0 +1,165 @@
+{
+  "portabilitySchemaVersion": 1,
+  "benchmarkSchemaVersion": 2,
+  "platformId": "linux-x64",
+  "environment": {
+    "platformId": "linux-x64",
+    "endianness": "LE",
+    "os": {
+      "status": "captured",
+      "value": "linux 6.17.0-1020-azure"
+    },
+    "arch": {
+      "status": "captured",
+      "value": "x64"
+    },
+    "cpuModel": {
+      "status": "captured",
+      "value": "AMD EPYC 9V74 80-Core Processor"
+    },
+    "logicalCpuCount": {
+      "status": "captured",
+      "value": "4"
+    },
+    "totalMemoryBytes": {
+      "status": "captured",
+      "value": "16766423040"
+    },
+    "loadAverage": {
+      "status": "captured",
+      "value": "0.97 0.27 0.09"
+    },
+    "nodeVersion": {
+      "status": "captured",
+      "value": "v22.23.1"
+    },
+    "npmVersion": {
+      "status": "captured",
+      "value": "10.9.8"
+    },
+    "v8Version": {
+      "status": "captured",
+      "value": "12.4.254.21-node.56"
+    }
+  },
+  "evaluated": {
+    "commit": {
+      "status": "captured",
+      "value": "50e76d22d405f716386dea50138e684fbe5a6911"
+    },
+    "commitShort": {
+      "status": "captured",
+      "value": "50e76d2"
+    },
+    "workingTree": {
+      "status": "captured",
+      "value": "clean"
+    },
+    "releaseVersion": {
+      "status": "captured",
+      "value": "0.6.1"
+    },
+    "lockfileSha256": {
+      "status": "captured",
+      "value": "60a48b52d87325ac5e6ab823b64fafa86d7aeccc7474733d066cd1358f50e559"
+    },
+    "config": {
+      "suiteId": "reproducibility",
+      "seed": 20260726,
+      "pointCount": 250000,
+      "warmupRuns": 6,
+      "recordedRuns": 10,
+      "terrain": {
+        "cellSizeM": 2,
+        "crs": "EPSG:32610",
+        "verticalDatum": "EPSG:5703",
+        "holdoutSeed": 1
+      },
+      "scalarTolerance": 0
+    },
+    "benchmarkPackageVersion": "1.1.0"
+  },
+  "fixture": {
+    "datasetId": "synthetic-250000-seed20260726",
+    "seed": 20260726,
+    "requestedPointCount": 250000,
+    "generatedPointCount": 250000,
+    "sourceCloudHash": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+    "descriptorHash": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9"
+  },
+  "science": {
+    "hashes": {
+      "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+      "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+      "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+      "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+      "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+      "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+      "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+      "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+      "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+      "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+      "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+      "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+      "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+      "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+      "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+    },
+    "scalars": {
+      "gridCols": 125,
+      "gridRows": 125,
+      "gridCellCount": 15625,
+      "cellSizeM": 2,
+      "elevationMinM": -1.0761682987213135,
+      "elevationMaxM": 15.386188507080078,
+      "elevationRangeM": 16.46235680580139,
+      "meanConfidence": 70.191552,
+      "qualityScore": 82,
+      "qualityBand": "excellent",
+      "contourIntervalM": 0.5,
+      "contourLevelCount": 33,
+      "contourPolylineCount": 229,
+      "contourFeatureCount": 731,
+      "contourLabelCount": 16,
+      "sourcePointCount": 225262,
+      "analyzedPointCount": 225262,
+      "applicationContentHash": "299b2ad5"
+    },
+    "applicationContentHash": "299b2ad5"
+  },
+  "buildScopedHashes": {
+    "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+    "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+  },
+  "internal": {
+    "pass": true,
+    "failures": [],
+    "scienceHashesStable": true,
+    "scalarsStable": true,
+    "manifestVerifiedOnEveryRun": true,
+    "recordedRuns": 10,
+    "warmupRunsCompleted": 6
+  },
+  "timing": {
+    "medianAnalysisMs": {
+      "value": 1060.506257,
+      "unit": "ms",
+      "reason": null
+    },
+    "analysisCv": {
+      "value": 0.052659910444877854,
+      "unit": "ratio",
+      "reason": null
+    },
+    "medianPipelineTotalMs": {
+      "value": 1121.9685645,
+      "unit": "ms",
+      "reason": null
+    },
+    "peakRssBytes": {
+      "value": 413757440,
+      "unit": "bytes",
+      "reason": null
+    }
+  }
+}

--- a/docs/validation/evidence/portability-v0.6.2/linux-x64/science-hashes.json
+++ b/docs/validation/evidence/portability-v0.6.2/linux-x64/science-hashes.json
@@ -1,0 +1,266 @@
+{
+  "note": "Science-scoped artifact hashes per recorded run on this platform. Build-scoped hashes are listed separately because they track the commit and the runtime, not the science.",
+  "reference": {
+    "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+    "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+    "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+    "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+    "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+    "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+    "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+    "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+    "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+    "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+    "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+    "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+    "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+    "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+    "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+  },
+  "buildScoped": {
+    "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+    "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+  },
+  "perRun": [
+    {
+      "run": 1,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 2,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 3,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 4,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 5,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 6,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 7,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 8,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 9,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    },
+    {
+      "run": 10,
+      "science": {
+        "fixture": "98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9",
+        "pointBytes": "4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3",
+        "rasterSummary": "590291e7510ed02eb404cb27c279a7484d0d14fb1cba483b54a9391212b8f286",
+        "rasterZBytes": "7b1f1e54c089912f0aedaf362d1ad6cffb83eebe6d6e9ef4b73988f6dce74ed9",
+        "dtmSummary": "f3f3aae42c69d882225f9788654f060da12d01ea658ca98b23aac8f4ec356d43",
+        "dtmZBytes": "37db0921f4d0982658963db9f146ab6e0de053eda68cb69f1521460c402d53ba",
+        "dtmConfidenceBytes": "1f4e3a9081b6bec650c19704773e7347cb444ea72389557b1b05672ea3f54ae0",
+        "dtmCoverageBytes": "dc68bb30f240b9096303c97eb55ce8d3a2a61f1a736a980fdf28dbe255cc6e9a",
+        "dtmCountsBytes": "8f4e945f948df46df1f0289b07421682871244849cf5e47fcb3d58e66d9958e3",
+        "heightAboveGroundBytes": "abb4f026c4647293f5f30e5151149f9f03b18279d09c032f26f4337ad489477a",
+        "descriptors": "32bec835720524d0f7cb3aee7c321535e20f6de15c9883fed1f390f9bd44d4ce",
+        "contours": "1dcaec1be9bd8ba0523c9317f1f5e75f15709a63ecf4b4cad229a70bd0aef541",
+        "contourFeatures": "9075d17a8143052968aa7e4186f34fdeaf03ec55009b7ec961ae23c108be83d8",
+        "scientificRecordContent": "80a2607572179f16c79c20ae7fdea14e6c568f6a2edf9e15344071ec241bc8f1",
+        "processingManifestContent": "f2f1a205c2cbe10d450d52f10c1374c51637c462434d0b371dcf31ebdc78c461"
+      },
+      "buildScoped": {
+        "scientificRecord": "d3bf8f8fefb9142914e7dffa2cc86ebe4ddc7cda0c07c6f596f9521483a84c5f",
+        "processingManifest": "d84d28446c23d051c30060d05adb9a9a374154a31e944f2c44b6eae1acd4c3cd"
+      }
+    }
+  ]
+}

--- a/docs/validation/evidence/portability-v0.6.2/manifest.json
+++ b/docs/validation/evidence/portability-v0.6.2/manifest.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": 2,
+  "portabilitySchemaVersion": 1,
+  "benchmarkPackageVersion": "1.1.0",
+  "kind": "comparison",
+  "platformId": null,
+  "commit": {
+    "status": "captured",
+    "value": "50e76d22d405f716386dea50138e684fbe5a6911"
+  },
+  "startedAtUtc": "2026-07-26T21:49:06.509Z",
+  "completedAtUtc": "2026-07-26T21:49:06.509Z",
+  "command": "npm run benchmark:compare-platforms",
+  "files": [
+    {
+      "path": "comparison.csv",
+      "sha256": "64e1e00511d701e422388a886e5fb5f1eeb9c504b936274b170ea7b04a30cea1",
+      "bytes": 3211
+    },
+    {
+      "path": "comparison.json",
+      "sha256": "2b2a9e14d9f9bf80a8fb54bdf681b8f1a879162ea9c1440c0e472263578af06e",
+      "bytes": 5216
+    },
+    {
+      "path": "darwin-arm64/environment.json",
+      "sha256": "497c15fdf48385c4b17dacd59f16415843aebd4e6be933d960ee8e715d199a81",
+      "bytes": 946
+    },
+    {
+      "path": "darwin-arm64/manifest.json",
+      "sha256": "ba4758732a3c297bf46a89df438778609976c6cbd531edb1b35c9f08a819cdfc",
+      "bytes": 871
+    },
+    {
+      "path": "darwin-arm64/platform-record.json",
+      "sha256": "9a18d1a5c98a788fbc70d676272b1cab0a48ca57db90239de466e78bf556d4b3",
+      "bytes": 5113
+    },
+    {
+      "path": "darwin-arm64/science-hashes.json",
+      "sha256": "82a62437f1908a7e200cb051c5ccbcd289168ccac594c31d31ec7e2d3dcc5947",
+      "bytes": 18720
+    },
+    {
+      "path": "environments.json",
+      "sha256": "94bf13bebefb05dbde0e5b6e9539142db2ab1ebe1b787d2855005f80480a8aae",
+      "bytes": 5886
+    },
+    {
+      "path": "linux-x64/environment.json",
+      "sha256": "f79cbc2a92a5c144b34cb065af541a8974a95898e373e1d8428fe39578e954b4",
+      "bytes": 965
+    },
+    {
+      "path": "linux-x64/manifest.json",
+      "sha256": "137eddafc6a4d2a60c6e61c5dcf877a021dbd783985e23f95ead5103fe92b25f",
+      "bytes": 868
+    },
+    {
+      "path": "linux-x64/platform-record.json",
+      "sha256": "bdcbf4494d9456446ab69634e87b89793548042e41e88d952d5cc02407f3b6d3",
+      "bytes": 5120
+    },
+    {
+      "path": "linux-x64/science-hashes.json",
+      "sha256": "82a62437f1908a7e200cb051c5ccbcd289168ccac594c31d31ec7e2d3dcc5947",
+      "bytes": 18720
+    },
+    {
+      "path": "summary.md",
+      "sha256": "0007fb4b8b83576f5835962934d967bd0d0e77fed5691c67446f59d6e6253c56",
+      "bytes": 4357
+    }
+  ]
+}

--- a/docs/validation/evidence/portability-v0.6.2/summary.md
+++ b/docs/validation/evidence/portability-v0.6.2/summary.md
@@ -1,0 +1,66 @@
+# Cross-platform scientific reproducibility
+
+Status: **reproduced**
+
+At commit 50e76d2, OpenLiDARViewer produced identical science-scoped artifacts from the same seeded fixture on darwin-arm64 and linux-x64. Build-scoped provenance and execution timing differed, as expected. Nothing is claimed for platforms not in that list.
+
+## What was evaluated
+
+| Field | Value |
+| --- | --- |
+| Platforms | darwin-arm64, linux-x64 |
+| Commit | 50e76d22d405f716386dea50138e684fbe5a6911 |
+| Release version | 0.6.1 |
+| Lockfile sha256 | 60a48b52d87325ac5e6ab823b64fafa86d7aeccc7474733d066cd1358f50e559 |
+| Fixture seed | 20260726 |
+| Fixture points | 250000 requested, 250000 generated |
+| Dataset | synthetic-250000-seed20260726 |
+| Scalar tolerance | 0 |
+| Byte order | darwin-arm64 LE, linux-x64 LE |
+
+## The seeded fixture, compared first
+
+The seeded source cloud is byte-identical on every platform, so any downstream difference would be a property of the analysis rather than of its input.
+
+| Platform | Source cloud sha256 | Fixture descriptor sha256 |
+| --- | --- | --- |
+| darwin-arm64 | 4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3 | 98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9 |
+| linux-x64 | 4026c8c9c008fa0ed97ee61d43d9cc63451ea4b09a5c6951221da49d57237ee3 | 98e511999d36f75773d20d807700c785cb1e159e4fe1982b3f936639d44174f9 |
+
+## Science-scoped outputs
+
+15 artifact hashes and 18 scalar values were compared at a tolerance of exactly zero. 0 hashes and 0 scalars differ.
+
+## Differences that are expected
+
+Each one is published with the value every platform reported. None of them gates the result.
+
+| Category | Field | Values | Why it may differ |
+| --- | --- | --- | --- |
+| host | os | darwin-arm64=darwin 25.4.0<br>linux-x64=linux 6.17.0-1020-azure | The operating system and its release are properties of the host, not of the analysis. |
+| host | arch | darwin-arm64=arm64<br>linux-x64=x64 | The instruction set is a property of the host. Byte order is the part that must match, and it is checked as a precondition. |
+| host | cpuModel | darwin-arm64=Apple M1 (Virtual)<br>linux-x64=AMD EPYC 9V74 80-Core Processor | The CPU model changes timing and nothing else; every science-scoped value is deterministic arithmetic. |
+| host | logicalCpuCount | darwin-arm64=3<br>linux-x64=4 | Core count is a property of the runner. The pipeline is single-threaded here. |
+| host | totalMemoryBytes | darwin-arm64=7516192768<br>linux-x64=16766423040 | Installed memory is a property of the runner. |
+| host | loadAverage | darwin-arm64=10.88 11.31 11.32<br>linux-x64=0.97 0.27 0.09 | Host load at the moment of writing. It moves the timing column and nothing else. |
+| timing | medianAnalysisMs | darwin-arm64=1305.1736865<br>linux-x64=1060.506257 | Execution time is a property of the machine. Reported per platform and never pooled. |
+| timing | peakRssBytes | darwin-arm64=440418304<br>linux-x64=413757440 | Memory high-water observations track the allocator and the host, not the outputs. |
+
+Excluded from the comparison by construction:
+
+- timestamps: Run start and completion times are wall-clock readings. The framework strips them from every hashed artifact, and they are recorded in each platform manifest rather than compared.
+- archive paths: Each platform writes into its own results directory and each CI runner has its own workspace root. Paths are relative in every manifest and are not part of any hash.
+- build identity: The build identity string embeds the commit and the runtime that produced it. The scientific record and the processing manifest are seeded from it, which is why both are build-scoped and compared separately.
+
+## Runtime, per platform
+
+Runtimes are not pooled. A median over two machines describes neither of them, and the result this suite reports is output identity rather than which host is faster.
+
+| Platform | Recorded runs | Median analysis | Analysis CV | Peak RSS |
+| --- | --- | --- | --- | --- |
+| darwin-arm64 | 10 | 1305.2 ms | 0.0532 | 420.0 MiB |
+| linux-x64 | 10 | 1060.5 ms | 0.0527 | 394.6 MiB |
+
+## Scope
+
+This result covers darwin-arm64 and linux-x64 on the Node major version the workflow pins, at the commit above. It is not a claim of platform independence: untested platforms, other runtime versions and big-endian hosts are outside it. Windows is not covered.


### PR DESCRIPTION
The cross-platform reproducibility result existed only as a CI artifact. `benchmark-results/` is untracked, so anyone reading the repository — or a validation pass run locally — sees only the leg that ran on their own machine and gets `single-platform`, which is the correct verdict for one leg and not the verdict the project holds.

This commits the `portability-comparison` artifact from run 30221805663 under `docs/validation/evidence/portability-v0.6.2/`, with a `PROVENANCE.md` naming the run URL, the evaluated commit `50e76d2`, and how to regenerate it.

The tracked result: status `reproduced`, `claimEstablished: true`, platforms darwin-arm64 and linux-x64, 15 artifact hashes and 18 scalars compared at a tolerance of exactly zero with none differing. Host and timing differences are carried with each platform's own value.

Publication evidence has to be frozen at the release tag. An artifact behind a retention window is not frozen.