### PR TITLE
Report what was measured instead of asserting USGS, ASPRS and RFC 7946 conformance

### DIFF
--- a/src/render/streaming/sampleGrade.ts
+++ b/src/render/streaming/sampleGrade.ts
@@ -88,8 +88,10 @@ export interface SampleGrade {
 
 /**
  * Tier an AREAL point density (points per m²) using bands aligned to the USGS
- * quality levels the rest of the app references (QL2 ≈ 2 pts/m², QL1 ≈ 8): below
- * QL2 is sparse, QL2–QL1 moderate, above QL1 dense, and terrestrial / very
+ * 3DEP nominal density floors the rest of the app references (QL2 ≥ 2 pts/m²,
+ * QL1 ≥ 8). The output is a density word, never a quality level: below the QL2
+ * floor is sparse, between the floors moderate, above QL1 dense, and
+ * terrestrial / very
  * low-altitude drone (≳ 50 pts/m²) very dense. Reuses {@link DensityBucket} so
  * the streaming grade speaks the same Sparse/Moderate/Dense language as the
  * static path. Returns 'unknown' for a non-finite or non-positive density.

--- a/src/report/ReportFindings.ts
+++ b/src/report/ReportFindings.ts
@@ -12,7 +12,11 @@
  *  - It reports what was *measured*. Point density, extent and attribute
  *    presence are read straight from the loaded cloud. They are stated, not
  *    judged.
- *  - It only compares density against the USGS QL1 / QL2 tiers when the
+ *  - A density floor is a threshold, not a quality level. A 3DEP quality level
+ *    also carries vertical accuracy against independent checkpoints, coverage
+ *    and collection requirements nothing here validates, so the findings say
+ *    where the density sits relative to the QL1 / QL2 floors and stop there.
+ *  - It only compares density against the USGS QL1 / QL2 floors when the
  *    capture-type classifier has *itself* cited USGS QL literature for this
  *    scan (an airborne-ALS delivery). The Scan Acceptance template
  *    deliberately bakes in no QL thresholds because they would be misapplied
@@ -157,7 +161,7 @@ function densityFinding(
     return {
       label: DENSITY_LABEL,
       value,
-      detail: `Meets USGS QL1 (≥ ${USGS_QL1_PTS_PER_M2} pts/m²) on all-returns density.${GROUND_BASIS_NOTE}`,
+      detail: `All-returns density is at or above the USGS QL1 density floor (≥ ${USGS_QL1_PTS_PER_M2} pts/m²).${GROUND_BASIS_NOTE}`,
       tier: 'met',
       source: USGS_DENSITY_SOURCE,
     };
@@ -166,7 +170,7 @@ function densityFinding(
     return {
       label: DENSITY_LABEL,
       value,
-      detail: `Meets USGS QL2 (≥ ${USGS_QL2_PTS_PER_M2} pts/m²); below QL1 (≥ ${USGS_QL1_PTS_PER_M2}) on all-returns density.${GROUND_BASIS_NOTE}`,
+      detail: `All-returns density is at or above the USGS QL2 density floor (≥ ${USGS_QL2_PTS_PER_M2} pts/m²) and below the QL1 floor (≥ ${USGS_QL1_PTS_PER_M2} pts/m²).${GROUND_BASIS_NOTE}`,
       tier: 'met',
       source: USGS_DENSITY_SOURCE,
     };
@@ -174,7 +178,7 @@ function densityFinding(
   return {
     label: DENSITY_LABEL,
     value,
-    detail: `Below USGS QL2 (≥ ${USGS_QL2_PTS_PER_M2} pts/m²) on all-returns density.${GROUND_BASIS_NOTE}`,
+    detail: `All-returns density is below the USGS QL2 density floor (≥ ${USGS_QL2_PTS_PER_M2} pts/m²).${GROUND_BASIS_NOTE}`,
     tier: 'caution',
     source: USGS_DENSITY_SOURCE,
   };

--- a/src/terrain/contour/contourDownload.ts
+++ b/src/terrain/contour/contourDownload.ts
@@ -26,9 +26,13 @@ import { triggerDownload } from '../../io/download';
 /** Supported pure-data export formats. */
 /**
  * `geojson` is RFC 7946 — WGS 84 degrees, no `crs` member — because that is
- * what the extension promises a reader. `geojson-native` keeps the source
+ * what the extension promises a reader. The third position element is written
+ * only when the vertical reference is proven to be WGS 84 ellipsoidal height
+ * AND the vertical unit resolves, and it carries the metre value RFC 7946
+ * requires; otherwise the geometry is 2D and the elevation rides as a property
+ * that names its own unit and datum. `geojson-native` keeps the source
  * projected frame and the pre-RFC `crs` member for GIS that wants the survey
- * grid, under a filename that says so.
+ * grid, under a filename that says so — it is not RFC 7946.
  */
 export type ContourFormat = 'geojson' | 'geojson-native' | 'svg' | 'dxf';
 

--- a/src/terrain/contour/geojsonContours.ts
+++ b/src/terrain/contour/geojsonContours.ts
@@ -7,10 +7,13 @@
  * evidence grade, index flag, and confidence, so the recipient can style
  * or filter the uncertain spans rather than trusting one flat line.
  *
- * Elevation is written into the coordinate Z (3D positions, RFC 7946's
- * optional third element) AS WELL AS the `elevation` property — a 2D
- * LineString with attribute-only elevation imports flat (every contour at
- * Z=0) in 3D-aware GIS/CAD, which reads as "contours have no elevation".
+ * In the NATIVE writer elevation goes into the coordinate Z (3D positions) AS
+ * WELL AS the `elevation` property — a 2D LineString with attribute-only
+ * elevation imports flat (every contour at Z=0) in 3D-aware GIS/CAD, which
+ * reads as "contours have no elevation". The RFC 7946 writer gates that
+ * ordinate on a proven WGS 84 ellipsoidal height and a resolved vertical unit,
+ * and converts it to metres, because RFC 7946 defines the third element as
+ * exactly that and nothing else.
  *
  * CRS note (honest, documented): RFC 7946 assumes WGS84 lon/lat, but
  * LiDAR contours are in a projected CRS (UTM etc.). We emit the
@@ -230,23 +233,41 @@ export function toGeoJSONWgs84(
   // vertical reference is proven to be WGS 84 ellipsoidal height; otherwise
   // the geometry is 2D and the elevation survives as a property that states
   // its own unit and reference, which cannot be mistaken for a coordinate.
-  const ellipsoidal = isWgs84EllipsoidalHeight(model.verticalDatum);
+  //
+  // §3.1.1 also fixes that element's UNIT as metres. The source elevation is in
+  // the DTM's own vertical unit, which for a foot vertical CRS is feet, so the
+  // ordinate carries the metre equivalent and the source value survives on the
+  // `elevation` property beside the unit it is actually in. Writing the raw
+  // value there shipped 100 ft as 100 m — a 69 m error stated as a coordinate.
+  // The conversion needs a resolved vertical factor; without one the metre
+  // value cannot be computed, so the geometry drops to 2D rather than asserting
+  // metres about a number of unknown unit.
+  const vScale = model.verticalUnitToMetres;
+  const metresPerVerticalUnit =
+    vScale != null && Number.isFinite(vScale) && vScale > 0 ? vScale : null;
+  const ellipsoidal = isWgs84EllipsoidalHeight(model.verticalDatum) && metresPerVerticalUnit != null;
   metadata.elevationIn3d = ellipsoidal;
-  if (!ellipsoidal) {
-    metadata.elevationNote =
-      'Geometry is 2D: the source vertical reference is not WGS 84 ellipsoidal height, '
-      + 'which is the only thing RFC 7946 permits in the third position element. '
-      + 'Elevations are carried per feature as elevation / elevationUnit / elevationDatum.';
+  if (ellipsoidal) {
+    metadata.elevationOrdinateUnit = 'metre';
+  } else {
+    metadata.elevationNote = isWgs84EllipsoidalHeight(model.verticalDatum)
+      ? 'Geometry is 2D: the source vertical unit could not be resolved, so the height '
+        + 'cannot be expressed in the metres RFC 7946 requires in the third position element. '
+        + 'Elevations are carried per feature as elevation / elevationUnit / elevationDatum.'
+      : 'Geometry is 2D: the source vertical reference is not WGS 84 ellipsoidal height, '
+        + 'which is the only thing RFC 7946 permits in the third position element. '
+        + 'Elevations are carried per feature as elevation / elevationUnit / elevationDatum.';
   }
 
-  // The elevation is in the DTM's SOURCE vertical units, so its label comes
-  // from the resolved vertical factor. A constant 'metre' here shipped US
-  // survey feet as metres — 100 read as 100 m instead of 30.48 m — for the
-  // compound CRSs (metre horizontal over a foot height) that take this WGS 84
-  // path. An unresolved factor says so; it does not fall back to metre.
-  const vScale = model.verticalUnitToMetres;
+  // The elevation PROPERTY stays in the DTM's SOURCE vertical units, so its
+  // label comes from the resolved vertical factor. A constant 'metre' here
+  // shipped US survey feet as metres — 100 read as 100 m instead of 30.48 m —
+  // for the compound CRSs (metre horizontal over a foot height) that take this
+  // WGS 84 path. An unresolved factor says so; it does not fall back to metre.
   const elevationUnit =
-    vScale == null ? 'unknown' : ELEVATION_UNIT_NAME[verticalUnitLabel(vScale)];
+    metresPerVerticalUnit == null
+      ? 'unknown'
+      : ELEVATION_UNIT_NAME[verticalUnitLabel(metresPerVerticalUnit)];
 
   obj.features = (obj.features as Array<Record<string, unknown>>).map((f) => {
     const geom = f.geometry as { type: string; coordinates: number[][] };
@@ -263,7 +284,10 @@ export function toGeoJSONWgs84(
         ...geom,
         coordinates: geom.coordinates.map((c) => {
           const p = toLonLat([c[0], c[1], c[2] ?? 0]);
-          return ellipsoidal ? p : [p[0], p[1]];
+          // `toLonLat` converts the horizontal pair only and hands the source Z
+          // straight back (see LocalToLonLatSourceZ), so the metre conversion
+          // happens here.
+          return ellipsoidal ? [p[0], p[1], p[2] * (metresPerVerticalUnit as number)] : [p[0], p[1]];
         }),
       },
     };

--- a/src/terrain/export/exportProvenance.ts
+++ b/src/terrain/export/exportProvenance.ts
@@ -135,6 +135,19 @@ export interface ExportPermitStamp {
   readonly caveats: readonly string[];
 }
 
+/**
+ * What the exported accuracy figures actually are, for the machine-readable
+ * blocks whose keys carry no room for the "-style (hold-out)" / "(estimated)"
+ * qualifiers the text surfaces put in the label.
+ */
+export const ACCURACY_BASIS_NOTE =
+  'RMSEz, NVA and VVA are computed from hold-out residuals within this cloud using the '
+  + 'ASPRS 2014 formulas — withheld ground points, not independent survey checkpoints, and '
+  + 'the VVA figure is the 95th percentile of all hold-out residuals rather than '
+  + 'vegetated-class checkpoints. The quality level compares measured ground density and '
+  + 'that hold-out RMSEz against the 3DEP thresholds. This is not an ASPRS conformance '
+  + 'assessment and not a USGS 3DEP determination.';
+
 /** Validated vertical-accuracy figures, present only when the run measured them. */
 export interface ExportProvenanceAccuracy {
   /** Vertical RMSEz in metres. */
@@ -695,6 +708,11 @@ export function provenanceJson(p: ExportProvenance): Record<string, unknown> {
           nvaM: p.accuracy.nvaM,
           vvaM: p.accuracy.vvaM,
           usgsQualityLevel: p.accuracy.usgsQualityLevel,
+          // The text surfaces qualify these in the label itself ("NVA-style
+          // (95%, hold-out)", "QL2 (estimated)"). A JSON key cannot, and a
+          // consumer reading `nvaM` has nothing telling it the figure is not an
+          // ASPRS checkpoint result — so the qualifier is a field.
+          basis: ACCURACY_BASIS_NOTE,
         }
       : null,
     // The record is already plain data — copy it wholesale (fresh caveats

--- a/src/terrain/quality/scanFitness.ts
+++ b/src/terrain/quality/scanFitness.ts
@@ -87,7 +87,12 @@ export interface ScanFitness {
   readonly verdict: string;
   /** Worst dimension tone — drives the hero colour. */
   readonly overallTone: FitnessTone;
-  /** Named tier badge when earnable (e.g. "USGS QL2-class"), else null. */
+  /**
+   * Named tier badge when earnable, carrying the "(estimated)" qualifier every
+   * other surface stamps on the level (e.g. "QL2 (estimated)"), else null. The
+   * level's RMSEz leg is hold-out, not independent checkpoints, so an unadorned
+   * "QL2" on the hero would read as a 3DEP determination.
+   */
   readonly tierBadge: string | null;
   /** Headline accuracy string, or null when unvalidated. */
   readonly headlineAccuracy: string | null;
@@ -105,7 +110,13 @@ export interface ScanFitness {
 const SEVERITY: Record<FitnessTone, number> = { ready: 0, okay: 1, review: 2 };
 const worst = (a: FitnessTone, b: FitnessTone): FitnessTone => (SEVERITY[a] >= SEVERITY[b] ? a : b);
 
-/** USGS 3DEP nominal ground density floors (pts/m²): QL2 ≥ 2, QL1 ≥ 8. */
+/**
+ * Ground-density thresholds (pts/m²), taken from the USGS 3DEP nominal density
+ * floors: QL2 ≥ 2, QL1 ≥ 8. They are where the numbers come from, not a claim
+ * about the scan — a 3DEP quality level also carries vertical accuracy against
+ * independent checkpoints, coverage and collection requirements this
+ * application does not validate, so density alone establishes no tier.
+ */
 const QL2_DENSITY = 2;
 const QL1_DENSITY = 8;
 /** Coverage fractions where the measured surface is trustworthy vs sparse. */
@@ -146,10 +157,10 @@ function densityDimension(d: number | null): FitnessDimension {
   const v = d >= 100 ? Math.round(d) : Math.round(d * 10) / 10;
   const summary =
     tone === 'ready'
-      ? `${v} ground pts/m² — dense (QL1-class).`
+      ? `${v} ground pts/m² — at or above ${QL1_DENSITY} pts/m² (the 3DEP QL1 density floor).`
       : tone === 'okay'
-        ? `${v} ground pts/m² — meets the USGS QL2 floor (2 pts/m²).`
-        : `${v} ground pts/m² — below the USGS QL2 floor of 2 pts/m².`;
+        ? `${v} ground pts/m² — at or above ${QL2_DENSITY} pts/m² (the 3DEP QL2 density floor).`
+        : `${v} ground pts/m² — below ${QL2_DENSITY} pts/m² (the 3DEP QL2 density floor).`;
   return { key: 'density', label: 'Ground detail', tone, summary };
 }
 
@@ -278,7 +289,7 @@ export function buildScanFitness(inp: FitnessInputs): ScanFitness {
   const accTone = dimensions.find((d) => d.key === 'accuracy')!.tone;
   const tierBadge =
     inp.qualityLevel && !provisional && densTone !== 'review' && accTone !== 'review' && inp.crsKnown
-      ? inp.qualityLevel
+      ? `${inp.qualityLevel} (estimated)`
       : null;
 
   const headlineAccuracy = inp.verticalRmse != null ? `±${inp.verticalRmse.toFixed(2)} ${unit} vertical` : null;

--- a/src/terrain/validate/verticalAccuracy.ts
+++ b/src/terrain/validate/verticalAccuracy.ts
@@ -49,7 +49,12 @@ export interface VerticalAccuracy {
   readonly nmad: number;
   /** Held-out sample size behind the figures. */
   readonly sampleSize: number;
-  /** Standard tag for the deliverable. */
+  /**
+   * What the figures are, for a deliverable that prints this tag. It names the
+   * formulas and their basis, never a standard the figures conform to — a bare
+   * "ASPRS 2014" beside an NVA number is a conformance claim, and hold-out
+   * residuals are not an ASPRS checkpoint assessment.
+   */
   readonly standard: string;
 }
 
@@ -63,7 +68,7 @@ export function computeVerticalAccuracy(report: ValidationReport): VerticalAccur
     bias: Number.isFinite(report.bias) ? report.bias : Number.NaN,
     nmad: Number.isFinite(report.nmad) ? report.nmad : Number.NaN,
     sampleSize: report.sampleSize,
-    standard: 'ASPRS 2014',
+    standard: 'ASPRS 2014 formulas, hold-out basis',
   };
 }
 
@@ -79,7 +84,7 @@ export function formatVerticalAccuracy(report: ValidationReport, units = 'm'): s
   const u = ` ${units}`;
   const lines = [
     `Vertical RMSEz: ${a.rmseZ.toFixed(2)}${u} (n=${a.sampleSize}, hold-out)`,
-    `NVA-style @ 95% (${a.standard} formula, hold-out): ${a.nva95.toFixed(2)}${u} — ` +
+    `NVA-style @ 95% (${a.standard}): ${a.nva95.toFixed(2)}${u} — ` +
       `assumes normally distributed error; withheld points, not independent checkpoints`,
     `VVA-style @ 95% (percentile, hold-out): ${a.vva95.toFixed(2)}${u} — ` +
       `p95 of ALL residuals, not vegetated-class checkpoints`,

--- a/tests/analyseContours.test.ts
+++ b/tests/analyseContours.test.ts
@@ -64,7 +64,7 @@ describe('analyseContours', () => {
   });
 
   it('exposes ASPRS accuracy and index-contour labels', () => {
-    expect(r.accuracy.standard).toBe('ASPRS 2014');
+    expect(r.accuracy.standard).toBe('ASPRS 2014 formulas, hold-out basis');
     if (Number.isFinite(r.accuracy.rmseZ)) {
       expect(r.accuracy.nva95).toBeCloseTo(1.96 * r.accuracy.rmseZ, 6);
     }

--- a/tests/benchmark/contourCorrectness.test.ts
+++ b/tests/benchmark/contourCorrectness.test.ts
@@ -687,13 +687,15 @@ describe('contour correctness — the documented third-ordinate unit gap', () =>
     }
   });
 
-  it('EPSG:4979 with a foot vertical factor writes feet into a metre ordinate', () => {
-    // KNOWN_LIMITATIONS_v0.6.1.md records this combination as open. The check
-    // is on the CURRENT behaviour: the ordinate is written, and it carries the
-    // source-unit value while the per-feature property says the unit is foot.
+  it('EPSG:4979 with a foot vertical factor writes the METRE equivalent into the ordinate', () => {
+    // RFC 7946 §3.1.1 fixes the third position element as metres above the WGS
+    // 84 ellipsoid. The source elevation is in feet, so the ordinate carries
+    // elevation × 0.3048 while the property keeps the source value and names
+    // its own unit.
     const geo = toGeoJSONWgs84(footModel('EPSG:4979'), identityLonLat);
     const metadata = geo.metadata as Record<string, unknown>;
     expect(metadata.elevationIn3d).toBe(true);
+    expect(metadata.elevationOrdinateUnit).toBe('metre');
     const features = geo.features as Array<Record<string, unknown>>;
     expect(features.length).toBeGreaterThan(0);
     for (const f of features) {
@@ -702,13 +704,39 @@ describe('contour correctness — the documented third-ordinate unit gap', () =>
       const geom = f.geometry as { coordinates: number[][] };
       for (const c of geom.coordinates) {
         expect(c.length).toBe(3);
-        // The ordinate is the raw source value, NOT the metre equivalent.
-        expect(c[2]).toBe(props.elevation);
-        expect(c[2]).not.toBe((props.elevation as number) * 0.3048);
+        expect(c[2]).toBeCloseTo((props.elevation as number) * 0.3048, 9);
       }
     }
-    // Nothing refuses the self-contradictory combination.
-    expect(metadata.elevationNote).toBeUndefined();
+  });
+
+  it('EPSG:4979 with an unresolved vertical factor falls back to 2D', () => {
+    // Without a factor the metre value cannot be computed, and an unconverted
+    // ordinate would assert metres about a number of unknown unit.
+    const model = { ...footModel('EPSG:4979'), verticalUnitToMetres: null };
+    const geo = toGeoJSONWgs84(model, identityLonLat);
+    const metadata = geo.metadata as Record<string, unknown>;
+    expect(metadata.elevationIn3d).toBe(false);
+    expect(metadata.elevationNote).toMatch(/vertical unit/i);
+    for (const f of geo.features as Array<Record<string, unknown>>) {
+      const geom = f.geometry as { coordinates: number[][] };
+      for (const c of geom.coordinates) expect(c.length).toBe(2);
+    }
+  });
+
+  it('EPSG:4979 already in metres leaves the ordinate equal to the elevation', () => {
+    const dtm = surfaceGrid((col) => 0.5 * (col + 0.5), {
+      cols: 30,
+      rows: 8,
+      cellSizeM: CELL,
+      verticalDatum: 'EPSG:4979',
+      verticalUnitToMetres: 1,
+    });
+    const geo = toGeoJSONWgs84(modelFor(dtm, contoursAt(dtm, { intervalM: 2 })), identityLonLat);
+    for (const f of geo.features as Array<Record<string, unknown>>) {
+      const props = f.properties as Record<string, unknown>;
+      const geom = f.geometry as { coordinates: number[][] };
+      for (const c of geom.coordinates) expect(c[2]).toBe(props.elevation);
+    }
   });
 
   it('the native writer writes the third ordinate unconditionally, in source units', () => {

--- a/tests/exportProvenance.test.ts
+++ b/tests/exportProvenance.test.ts
@@ -375,3 +375,19 @@ describe('processingManifestFromProvenance — the verify-only manifest assembly
     expect(/replay/i.test(src)).toBe(false);
   });
 });
+
+describe('provenanceJson — the machine-readable accuracy block states its basis', () => {
+  const p: ExportProvenance = buildExportProvenance(readyResult(), OPTS);
+  it('carries a basis string beside nvaM / vvaM / usgsQualityLevel', () => {
+    const j = provenanceJson(p);
+    const acc = j.accuracy as Record<string, unknown>;
+    expect(acc.nvaM).toBeTypeOf('number');
+    // Every text surface says "-style (hold-out)" and "(estimated)". The JSON
+    // keys carry bare values, so the disclosure has to be a field of its own or
+    // a consumer reads nvaM as an ASPRS checkpoint figure.
+    expect(acc.basis).toMatch(/hold-out/i);
+    expect(acc.basis).toMatch(/not independent survey checkpoints/i);
+    expect(acc.basis).toMatch(/not an ASPRS conformance/i);
+    expect(acc.basis).toMatch(/not a USGS 3DEP determination/i);
+  });
+});

--- a/tests/provenanceConsistency.test.ts
+++ b/tests/provenanceConsistency.test.ts
@@ -28,6 +28,7 @@
 import { describe, it, expect } from 'vitest';
 import { inflateSync } from 'node:zlib';
 import {
+  ACCURACY_BASIS_NOTE,
   buildExportProvenance,
   provenanceLines,
   type ExportProvenance,
@@ -343,7 +344,9 @@ describe('provenance consistency — export-ready run', () => {
     expect(md.surfaceQuality).toBe(prov.surfaceQuality);
     expect(md.exportReadiness).toBe(prov.exportReadiness);
     expect(md.exportReason).toBe(prov.exportReason);
-    expect(md.accuracy).toEqual(prov.accuracy);
+    // Every figure mirrors, plus the basis field the JSON keys cannot carry in
+    // their labels the way the text surfaces do.
+    expect(md.accuracy).toEqual({ ...prov.accuracy, basis: ACCURACY_BASIS_NOTE });
     expect(md.pointDensityPerM2).toBe(prov.pointDensityPerM2);
     expect(md.measuredCells).toBe(prov.measuredCells);
     expect(md.totalCells).toBe(prov.totalCells);

--- a/tests/reportFindings.test.ts
+++ b/tests/reportFindings.test.ts
@@ -63,7 +63,7 @@ function find(summary: ReturnType<typeof buildInspectionSummary>, label: string)
 }
 
 describe('buildInspectionSummary — density tier gating', () => {
-  it('asserts USGS QL1 for airborne ALS at >= 8 pts/m²', () => {
+  it('reports the QL1 density floor for airborne ALS at >= 8 pts/m²', () => {
     const s = buildInspectionSummary(meta({ density: 16 }), alsProvenance());
     const d = find(s, 'Point density (all returns)');
     expect(d?.tier).toBe('met');
@@ -72,19 +72,19 @@ describe('buildInspectionSummary — density tier gating', () => {
     expect(s.densityBar?.measured).toBe(16);
   });
 
-  it('asserts USGS QL2 (below QL1) for airborne ALS between 2 and 8', () => {
+  it('reports the QL2 density floor (below QL1) for airborne ALS between 2 and 8', () => {
     const s = buildInspectionSummary(meta({ density: 4 }), alsProvenance());
     const d = find(s, 'Point density (all returns)');
     expect(d?.tier).toBe('met');
     expect(d?.detail).toMatch(/QL2/);
-    expect(d?.detail).toMatch(/below QL1/i);
+    expect(d?.detail).toMatch(/below the QL1 floor \(≥ 8 pts\/m²\)/i);
   });
 
   it('flags below-QL2 as caution for airborne ALS under 2 pts/m²', () => {
     const s = buildInspectionSummary(meta({ density: 1 }), alsProvenance());
     const d = find(s, 'Point density (all returns)');
     expect(d?.tier).toBe('caution');
-    expect(d?.detail).toMatch(/Below USGS QL2/);
+    expect(d?.detail).toMatch(/below the USGS QL2 density floor \(≥ 2 pts\/m²\)/i);
   });
 
   it('does NOT apply QL tiers for TLS (no QL literature cited)', () => {
@@ -160,5 +160,24 @@ describe('buildInspectionSummary — honesty invariants', () => {
     expect(s.headline).toMatch(/Aerial \/ airborne LiDAR/);
     expect(s.headline).toMatch(/ha/);
     expect(s.headline).toMatch(/M points/);
+  });
+});
+
+describe('buildInspectionSummary — density states the threshold, not the quality level', () => {
+  const detail = (density: number): string =>
+    find(buildInspectionSummary(meta({ density }), alsProvenance()), 'Point density (all returns)')!.detail!;
+
+  it('never reports the scan as meeting a USGS quality level', () => {
+    for (const d of [16, 4, 1]) {
+      expect(detail(d)).not.toMatch(/Meets USGS QL\d\b/);
+      expect(detail(d)).not.toMatch(/Below USGS QL\d\b/);
+    }
+  });
+
+  it('keeps the density floor each comparison was made against', () => {
+    expect(detail(16)).toMatch(/QL1 density floor \(≥ 8 pts\/m²\)/);
+    expect(detail(4)).toMatch(/QL2 density floor \(≥ 2 pts\/m²\)/);
+    expect(detail(4)).toMatch(/below the QL1 floor/i);
+    expect(detail(1)).toMatch(/below the USGS QL2 density floor \(≥ 2 pts\/m²\)/i);
   });
 });

--- a/tests/scanFitness.test.ts
+++ b/tests/scanFitness.test.ts
@@ -38,7 +38,7 @@ describe('buildScanFitness — scorecard tones', () => {
     const f = buildScanFitness(base());
     expect(f.overallTone).toBe<FitnessTone>('ready');
     expect(f.verdict).toMatch(/ready for terrain products/i);
-    expect(f.tierBadge).toBe('USGS QL1');
+    expect(f.tierBadge).toBe('USGS QL1 (estimated)');
     expect(f.headlineAccuracy).toBe('±0.07 m vertical');
     expect(f.dimensions).toHaveLength(6);
   });
@@ -95,7 +95,7 @@ describe('buildScanFitness — provisional (streaming / partial) state', () => {
   it('a full-cloud grade is not provisional and can earn its badge', () => {
     const f = buildScanFitness(base());
     expect(f.provisional).toBe(false);
-    expect(f.tierBadge).toBe('USGS QL1');
+    expect(f.tierBadge).toBe('USGS QL1 (estimated)');
   });
 });
 
@@ -173,5 +173,28 @@ describe('buildScanFitness — non-hideable caveats', () => {
   });
   it('a clean georeferenced survey-grade scan has no caveats', () => {
     expect(buildScanFitness(base()).caveats).toHaveLength(0);
+  });
+});
+
+describe('buildScanFitness — density reports a measurement, not a quality level', () => {
+  const summary = (d: number): string =>
+    buildScanFitness(base({ groundDensityPerM2: d })).dimensions.find((x) => x.key === 'density')!.summary;
+
+  it('never claims the scan IS a USGS quality level', () => {
+    for (const d of [12, 3, 0.9]) {
+      expect(summary(d)).not.toMatch(/QL\d-class/i);
+      expect(summary(d)).not.toMatch(/meets the USGS QL/i);
+    }
+  });
+
+  it('keeps the measured density and names the threshold it is compared against', () => {
+    expect(summary(12)).toMatch(/12 ground pts\/m²/);
+    expect(summary(12)).toMatch(/8 pts\/m².*QL1 density floor/i);
+    expect(summary(3)).toMatch(/2 pts\/m².*QL2 density floor/i);
+    expect(summary(0.9)).toMatch(/below.*2 pts\/m².*QL2 density floor/i);
+  });
+
+  it('marks the tier badge as an estimate, matching every other surface', () => {
+    expect(buildScanFitness(base()).tierBadge).toBe('USGS QL1 (estimated)');
   });
 });

--- a/tests/verticalAccuracy.test.ts
+++ b/tests/verticalAccuracy.test.ts
@@ -39,7 +39,7 @@ describe('computeVerticalAccuracy', () => {
     expect(a.rmseZ).toBe(0.5);
     expect(a.nva95).toBeCloseTo(0.5 * NVA_95_MULTIPLIER, 6);
     expect(a.vva95).toBe(1.1);
-    expect(a.standard).toBe('ASPRS 2014');
+    expect(a.standard).toBe('ASPRS 2014 formulas, hold-out basis');
   });
 
   it('carries signed bias + NMAD through, and formats them with direction', () => {
@@ -79,5 +79,14 @@ describe('formatVerticalAccuracy', () => {
     const lines = formatVerticalAccuracy(report(Number.NaN, Number.NaN, 0));
     expect(lines.length).toBe(1);
     expect(lines[0]).toMatch(/not enough ground points/i);
+  });
+});
+
+describe('VerticalAccuracy.standard — a basis tag, not a conformance tag', () => {
+  it('never reads as a bare "ASPRS 2014" conformance claim', () => {
+    const a = computeVerticalAccuracy(report(0.5, 1.1));
+    expect(a.standard).not.toBe('ASPRS 2014');
+    expect(a.standard).toMatch(/formulas/i);
+    expect(a.standard).toMatch(/hold-out/i);
   });
 });


### PR DESCRIPTION
Three places the software asserted authority it had not earned.

## USGS Quality Level

`ReportFindings.ts` asserted "Meets USGS QL1 (≥ 8 pts/m²)" from **all-returns density alone**, with no accuracy leg at all. That was the strongest form of this claim in the tree. It now reads "All-returns density is at or above the USGS QL1 density floor", which is what was measured.

`scanFitness.ts` summaries drop "dense (QL1-class)" and "meets the USGS QL2 floor" for "12 ground pts/m² — at or above 8 pts/m² (the 3DEP QL1 density floor)".

Two corrections to the premise. The `tierBadge` is **not** derived from density alone: `demAccuracyStandards` requires both ground density at or above the floor and hold-out RMSEz at or below the level's vertical threshold, and its reason string already said "an indicative comparison, not a USGS 3DEP determination". The defect was that the badge shipped the level bare while the panel chip, provenance stamp and report row all say "(estimated)"; the badge now renders `${ql} (estimated)` to match. And `inspectorCardRefreshers.ts` has no user-facing QL text — both hits are internal comments about unit conversion.

## NVA / VVA

The prose surfaces were already clean. `AnalysePanel`, the `mapSheetPdf` title block, `terrainReportContent`, the `exportProvenance` text stamp, `contourCopy` tooltips and the `methodRegistry` citation all read "NVA-style (95%, hold-out)" and "VVA-style (95th pct, hold-out)". A surveyor cannot read those as ASPRS conformance, so the terms stay.

Two places carried the figures without that hedge. `provenanceJson()` emits `{rmseZM, nvaM, vvaM, usgsQualityLevel}` into GeoJSON metadata and the manifest summary, and a JSON key has no label to hedge, so a consumer reading `nvaM` got an ASPRS-named figure with nothing saying it is hold-out. An `ACCURACY_BASIS_NOTE` `basis` field now sits beside them, additive, with every existing key and value unchanged. And `VerticalAccuracy.standard` was the bare literal `'ASPRS 2014'` on a public API, documented as the deliverable's standard tag; it is now `'ASPRS 2014 formulas, hold-out basis'`.

Three pre-existing assertions updated, none weakened: two pin the new tag exactly, and `provenanceConsistency` still compares field by field with the new field added.

## RFC 7946

`toGeoJSONWgs84` now converts the third ordinate to metres through `model.verticalUnitToMetres`. `toLonLat` passes source Z straight through, so the conversion belongs in the writer. An unresolved or non-positive factor drops the geometry to 2D with a distinct `elevationNote`; a resolved one adds `metadata.elevationOrdinateUnit: 'metre'`.

**Behaviour change.** A foot-vertical EPSG:4979 export's third ordinate now carries metres where it carried feet, and an EPSG:4979 export with an unresolved vertical factor is 2D where it was 3D.

The file is conformant in every configuration it emits: WGS 84 lon/lat and a refusal otherwise, no `crs` member, a third element in metres above the WGS 84 ellipsoid or absent, foreign members permitted under section 6.1. One residual, a SHOULD rather than a MUST: antimeridian-crossing geometry is not cut per section 3.1.9, which only a scan footprint straddling 180 degrees would trigger.

Tests named as changed: the pin `'EPSG:4979 with a foot vertical factor writes feet into a metre ordinate'` becomes `'…writes the METRE equivalent into the ordinate'` and asserts `toBeCloseTo(elevation * 0.3048, 9)`; a new case covers the unresolved-factor 2D fallback; a new regression guard covers a source already in metres. Both new cases failed first.

## Deferred

`contourCopy.ts` was owned by another branch. Its `nva` and `vva` tooltips are already correct. Its `qualityLevel` string still opens "the level the surface meets on point density and vertical accuracy together", which is a level claim even with the qualifier that follows; the replacement text is in the agent report and should land separately.

`KNOWN_LIMITATIONS_v0.6.2.md` carries an entry stating `toGeoJSONWgs84` writes a source-unit height into an RFC 7946 ordinate. That is now stale and belongs in the closed section, and the nearby 2D condition needs "and the vertical unit resolves" added.

## Checks

typecheck 0 · full suite 527 files, 6573 passed, 24 skipped · benchmark 567 passed, 8 skipped · bucket partition 530/530 · all five buckets 0 · `lint:claims-language`, `lint:claim-register` (26 claims in sync) and `lint:archive-vocab` all 0.

The `unit` bucket returned 1 on its first run — 12 timeouts in `compareEpochs`, `releaseAssetVerifier` and `provenanceIntegrity`, on a machine running four agents' suites at once. Those files pass in isolation and touch none of these changes. The rerun is clean, and the first red is reported rather than dropped.
