### PR TITLE
Write the v0.6.2 erratum and bring the truth documents up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 The format is based on Keep a Changelog and the project follows Semantic Versioning.
 
-## [Unreleased]
+## [0.6.2] - 2026-07-26
+
+A validation-and-correction release. Ten validation suites were added, covering
+reproducibility, scaling, cross-platform portability, GPU-versus-CPU backend
+equivalence, failure recovery, provenance integrity, contour correctness, LAS
+round-trip fidelity, unit integrity and archive portability. Eighteen defects
+are fixed: four carried from the v0.6.1 vertical-unit audit, fourteen found by
+the new suites. The evidence ceiling moves from one cross-implemented product to
+three, with aspect and hillshade joining slope at E4 against GDAL 3.13.1 on the
+shared analytic DEM. The reproducibility comparator and its two-platform CI
+matrix, darwin-arm64 and linux-x64, are in place; the only run recorded in the
+tree so far is a single darwin-arm64 leg, which establishes single-platform
+reproducibility and nothing cross-platform.
+
+Four defects reached published v0.6.1 output. `docs/release/ERRATUM_v0.6.2.md`
+states, for each, what the software did, which outputs carry the error and what
+recovers a correct figure. Open limits are in `KNOWN_LIMITATIONS_v0.6.2.md`.
 
 ### Fixed
 
@@ -55,19 +71,123 @@ The format is based on Keep a Changelog and the project follows Semantic Version
   too aggressive: real sub-30 cm terrain features were removed and silently
   re-interpolated. The removal count reached provenance, so two deliverables of
   one scan could disagree about how much data was cut.
+- **The PDF report footprint reads a Y-up scan on the right axes.** The PDF path
+  fed raw X/Y/Z bounds into `footprintMetres`, which assumed Z-up. A PLY, OBJ or
+  glTF scan therefore printed its height as Depth, divided the point count by a
+  vertical cross-section, and put the vertical unit factor on a ground span. The
+  on-screen Scan Report has swizzled by `isZUpFormat` since it was written, so
+  the two disagreed on every mesh-format scan. See the erratum for the figures a
+  v0.6.1 report carries.
+- **The streaming header box converts to cubic metres before density is
+  tiered.** The static refresher scaled the bounding box by the CRS unit factors
+  before the per-cubic-metre bucketing; the streaming one, a few lines below it,
+  passed the raw header extents through. A foot-CRS tile's box is 35.31 times
+  larger in source units, so one scan graded "sparse" streamed and "moderate"
+  loaded statically.
+- **A LAS 1.4 file keeps its vertical datum when it carries WKT plus GeoKeys.**
+  `parseCrsFromVlrs` returned the WKT CRS and discarded the GeoKeyDirectory.
+  This application's own 1.4 writer puts the vertical datum and vertical unit in
+  those keys beside a horizontal-only WKT, so a NAVD88 height in feet came back
+  with no vertical unit and the terrain tools fell back to metres. The WKT still
+  owns the horizontal frame and any vertical axis it declares; only the vertical
+  fields it leaves empty are filled from the keys. See the erratum.
+- **A declared linear unit that cannot be resolved reads as unknown, not as
+  metre.** `crsFromGeoTiff` resolved a `ProjLinearUnits` code outside
+  9001/9002/9003 to metre with a factor of 1, so a file declaring British foot
+  measured 3.28 times wrong and was indistinguishable from a file declaring no
+  unit at all. A declared code the software cannot honour is now tagged unknown,
+  which the downstream unit gates read to withhold the label; an absent key
+  still takes the format default. See the erratum.
+- **Three quantities stop being reported as measured when nothing was
+  measured.** `spaceMetrics` sized its occupancy grid with a 1 metre placeholder
+  cell on an axis with no extent and then multiplied that placeholder out as
+  floor area, so a cloud of coincident points came back with 1 m2 of floor, 40
+  points per m2 and a mean spacing of 0.158 m. The placeholder still divides and
+  no longer contributes area. The PDF report returned a grade of 0 for a slope
+  with no horizontal run, stating a level grade for a vertical face while the
+  live overlay called the same two points "vertical"; it follows
+  `gradePercentOf` and prints the same word. `formatLinear` had no finiteness
+  guard and printed "NaN cm" where `formatVolume` in the same file already
+  returned an em dash.
+- **A prototype key is refused as a method id.** `METHOD_REGISTRY['__proto__']`
+  and `['toString']` resolve on the prototype chain, so `method()` returned a
+  truthy non-entry and `methodRef()` handed back `{id: undefined, version:
+  undefined}`. Two different unregistered ids composed to one method tag and one
+  record fingerprint. The own-property check the registry already had in
+  `isMethodId` now governs both lookups.
+- **The benchmark result verifier sees the files it publishes.** `toHashable`
+  built its output on a plain literal, so assigning a `__proto__` key
+  re-parented the object instead of creating an own property and the key
+  vanished before hashing; two artifacts differing only there hashed the same.
+  The verifier also checked only that every listed file is present, never that
+  every present file is listed, and never re-derived the two artifact JSONs it
+  publishes, so an entry removed from the listing took its file out of the
+  digest check and an edited hash table with a refreshed digest passed.
+- **The contour GeoJSON carries the run warnings and the canonical limitation
+  wording.** The merge rule "model-derived keys win" applied to `warnings` too,
+  so a run whose provenance carried a warning shipped a GeoJSON declaring an
+  empty list while every text stamp of the same run printed it. The file now
+  carries the de-duplicated union of both sources, model order then provenance
+  order, which is stable because these artifacts are hashed. The writer's own
+  copy of the not-survey-grade sentence is gone; it reads `NOT_SURVEY_GRADE_NOTE`,
+  so a GeoJSON reader and a DXF, SVG or README reader get the same string.
+- **A LAS file names the build that produced it.** The 32-byte generating
+  software field was the fixed literal `OpenLiDARViewer converter`, so a LAS file
+  could not answer which version or commit produced it while every other export
+  could. It carries the product name, the release and the short commit, composed
+  longest-first and accepted only when a candidate fits whole. A prefix of a
+  commit hash names a build that does not exist, so the commit is dropped entire
+  rather than truncated, an unresolved commit is never written, and when
+  `+dirty` pushes the string past 32 bytes the commit goes with the marker.
+- **The source archive no longer ships release pages whose include target is
+  excluded.** Each `docs-site/releases/v0.4.x` and `v0.5.x` page is a bare
+  `@include` of a `RELEASE_NOTES` file that `.gitattributes` already excludes, so
+  the archive carried 15 pages that resolved to nothing. The sidebar reads the
+  releases directory, so it follows the pages.
 
 ### Corrected
+
+The four entries below correct statements or output published in v0.6.1.
+`docs/release/ERRATUM_v0.6.2.md` carries the full text, including who is
+affected and what recovers a correct figure.
 
 - **Correction to `KNOWN_LIMITATIONS_v0.6.1.md`: the `geodesicFill` unit-mixing
   defect affected production surfaces.** That document states the defect
   "affects the non-default geodesic interpolation mode only; the default fill is
   unaffected". That is wrong, and it understated the defect.
   `src/terrain/ground/surfaceFromRaster.ts` sets `LIVE_INTERPOLATION` to
-  `'geodesic'`, so geodesic is the mode every production surface used. On
-  geographic (degree) and foot-vertical data, interpolated void heights in
-  v0.6.1 and earlier came from a step cost that mixed horizontal source units
-  with vertical metres. The scope statement should have read: this affected every
-  surface the application produced, not an optional mode.
+  `'geodesic'` and `src/terrain/contour/analyseContours.ts` reads it on the live
+  path, so geodesic is the fill that built every DTM surface the application
+  produced, not an optional mode. Which surfaces changed value is narrower than
+  which used the path: the inverse-distance weights are normalised, so a single
+  common factor cancels and a projected metre-over-metre or foot-over-foot frame
+  interpolates identically before and after. Geographic (degree) frames and
+  compound frames whose vertical unit differs from the horizontal one do change,
+  because two different factors do not cancel.
+- **Correction to v0.6.1 PDF reports: Depth and density are wrong for Y-up
+  formats.** `footprintMetres` read a Y-up cloud's extents as Z-up, so every PDF
+  report from a PLY, OBJ or glTF scan printed the height as Depth and divided
+  the point count by a vertical cross-section. On a 30 by 40 m footprint 8 m
+  tall with 120,000 points, Depth read 8 m against 40 m and density read 500
+  pts/m2 against 100, a fivefold overstatement; on a compound CRS the vertical
+  factor landed on a horizontal span and Height read 12.192 m against 2.4384 m.
+  The on-screen Scan Report was correct throughout.
+- **Correction to v0.6.1 measurements from a CRS declaring an unresolvable
+  linear unit.** A projected CRS carrying `ProjLinearUnitsGeoKey` outside
+  9001/9002/9003 resolved to metre with a factor of 1, so `toMetres(100)`
+  returned 100 where roughly 30.48 is correct for a British-foot CRS, and the
+  file was indistinguishable from one declaring no unit at all. v0.6.2 resolves
+  such a code to unknown, which makes the file refusable rather than
+  convertible: figures already produced from one are not repaired by reopening
+  it.
+- **Correction to v0.6.1 results computed from a LAS 1.4 file this application
+  wrote.** `parseCrsFromVlrs` discarded the GeoKeyDirectory whenever a WKT was
+  present, and the 1.4 writer puts the vertical datum and unit in those keys
+  beside a horizontal-only WKT. `verticalEpsg` and the vertical unit read back
+  as undefined, so a NAVD88 height in US survey feet was taken for metres, 3.28
+  times wrong, and every elevation, contour interval, slope figure and cut/fill
+  volume derived from it inherited that. The files on disk are correct; the loss
+  was on read.
 
 ### Changed
 
@@ -81,8 +201,23 @@ The format is based on Keep a Changelog and the project follows Semantic Version
   (circular difference) and only where the closed-form slope exceeds 2 degrees,
   because a level cell has no aspect: GDAL writes NODATA there and our kernel
   returns 0, which is a real direction. No algorithm changed; this is a change
-  in what the evidence supports, and `HILLSHADE`, which consumes aspect, keeps
-  its own lower level.
+  in what the evidence supports.
+- **The hillshade raster is cross-implementation validated (E3 → E4).** The
+  third terrain product compared against GDAL 3.13.1, on the DEM the slope and
+  aspect references already share, pinned by hash rather than copied. Over
+  11,564 interior cells: ours against the closed form max 0.0000643, GDAL
+  against the closed form max 0.900, ours against GDAL max 1.00 as 8-bit levels,
+  all inside the 1.0 registered before the comparison ran. Both sides implement
+  the same illumination model over a Horn gradient and differ only in byte
+  encoding: we write 255·h, GDAL writes 1 + 254·h with level 0 reserved for
+  nodata. That offset is left visible in the reported figures rather than
+  divided out, and our encoding is unchanged. It spends most of a one-level
+  budget on its own, so the ours-against-GDAL leg is a weak instrument by
+  itself; the claim rests on the closed-form leg and on re-encoding our
+  intensity in GDAL's scale, which reproduces the reference exactly at every
+  cell. The limit is recorded in the fixture README and in
+  `docs/validation/THREATS_TO_VALIDITY.md`. The single-direction model only;
+  `computeMultiHillshade` keeps its own claim and its own level.
 - **The development toolchain moves to TypeScript 7.0.2, Vite 8.1.5 and
   Playwright 1.62.0.** TypeScript 7 is the native compiler and a major version,
   so the whole gate was re-run against it: the typecheck, all five test buckets
@@ -91,6 +226,44 @@ The format is based on Keep a Changelog and the project follows Semantic Version
   untouched. Vite 8.1.5 splits the output into 153 chunks where 8.0.12 produced
   140, which moves about 62 KiB out of the entry chunk; the total emitted
   JavaScript and the obfuscation coverage of the live build are unchanged.
+
+### Added
+
+- **Ten validation suites, each runnable and each stating what it does not
+  cover.** Reproducibility (`benchmark:repro`): one documented seed, 250k
+  points, ten recorded runs, passing only when every science-scoped hash and
+  scalar is identical across all ten, at zero tolerance. Scaling
+  (`benchmark:scaling`): 50k through 1M, five runs a tier, each tier in its own
+  process, no complexity class claimed. Cross-platform portability
+  (`benchmark:repro:portable`, `benchmark:compare-platforms`): a per-platform
+  leg and a comparator that checks the source-cloud hash first, then every
+  science-scoped hash and scalar at zero tolerance. Backend equivalence
+  (`benchmark:backends`): GPU against CPU, suppressed and recorded as
+  backend-unavailable when a requested backend fell back, so a Node run cannot
+  report the CPU agreeing with itself. Failure recovery (`benchmark:failures`):
+  truncated bodies, corrupt headers, degenerate geometry, missing and
+  unresolvable CRS, aborted reads, each with a healthy control off the same
+  fixture. Provenance integrity (`benchmark:provenance`): whether every exported
+  artifact names its source, its method chain with bound parameters, its build
+  and its limitation, and whether an edit stays detectable once the attacker
+  refreshes the digests. Contour correctness (`benchmark:contours`): generated
+  contours against plane, cone, paraboloid and saddle, the topological
+  invariants of a level set, and the declared-against-actual properties, with a
+  negative control on every predicate. LAS round-trip fidelity
+  (`benchmark:roundtrip`): both writers read back twice, once by an independent
+  spec-offset decoder in float64 and once by the application's own loader, with
+  tolerances derived from the scale factor the file declares. Unit integrity
+  (`benchmark:units`): one physical scene through a metre CRS, a foot CRS, a
+  compound frame and a Y-up axis order, comparing what each path reports.
+  Archive portability (`benchmark:archive-portability`): the released source
+  archive checked from an extract in a temp directory outside the repository,
+  which refuses an archive directory inside the repo or carrying a `.git` so
+  there is no working-tree fallback to pass by accident.
+- **A two-platform CI matrix for the portability suite**, darwin-arm64 and
+  linux-x64, with both legs always run: failing fast would leave the comparator
+  with one platform, which reports as single-platform and establishes nothing.
+  Byte order is a precondition rather than a result, and runtimes stay per
+  platform because a median over two machines describes neither.
 
 ### Known limitations
 
@@ -141,6 +314,20 @@ The format is based on Keep a Changelog and the project follows Semantic Version
   scans. No workaround places two streams in one session. Nothing is scheduled;
   concurrent streaming sources depend on the same shared-frame work that
   physical multi-layer mounting waits on.
+- **What the new suites name as uncovered.** Each suite states its own gaps
+  rather than leaving them implicit, and `KNOWN_LIMITATIONS_v0.6.2.md` carries
+  the list in full: GPU-computed derivatives beyond the two engine probe
+  surfaces, render-space lengths and the measurement HUD, rasterised report
+  composition, LAZ output (the application has no encoder, so there is no LAZ
+  file of its own to read back), third-party writer conformance, `npm ci` and a
+  build from a clean extract, and Windows as a reproducibility leg.
+- **The in-memory reconstruction is less precise than the LAS file it came
+  from.** Points are stored as Float32 local to a render origin, so the
+  application's read-back displaces further than the file's own quantisation
+  bound. Measured by the round-trip suite: 1.9 mm over a 50 km extent where the
+  file itself round-trips exactly, and 0.123 m over a 5000 km extent where the
+  file's own bound is 1.25 mm. The written file is not affected; the loss is in
+  what the viewer holds and measures.
 
 ## [0.6.1] - 2026-07-25
 

--- a/KNOWN_LIMITATIONS_v0.6.2.md
+++ b/KNOWN_LIMITATIONS_v0.6.2.md
@@ -1,0 +1,246 @@
+# Known limitations: OpenLiDARViewer v0.6.2
+
+This is a validation-and-correction release. Ten validation suites were added, eighteen defects were fixed, and four defects that reached published v0.6.1 output are corrected. The limits below are the v0.6.1 limits with the closed items removed, plus what the new suites named as uncovered. They are recorded here rather than hidden, in keeping with the project's honesty contract.
+
+Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.md`. One of them is a correction to the previous version of this file: its scope statement for the `geodesicFill` unit-mixing defect was wrong.
+
+## The two monoliths are still monoliths
+
+`src/main.ts` is 7,360 lines and `src/render/Viewer.ts` is 7,104, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+
+## The shared project frame is carried, not applied
+
+`ProjectSpatialFrame` / `LayerSpatialTransform` (value types + pure transform math) are tested and documented (`docs/architecture/project-spatial-frame.md`). This release carries **step 1** of the wiring plan: the app now owns a live project frame (`src/app/projectFrame.ts`, on `AppContext`), reseeded from the loaded layer set on every change, choosing one shared origin and deriving each layer's translation into it. A single layer anchors the frame at its own origin, so its transform is the identity and the single-scan path is unchanged.
+
+**Physical multi-layer mounting is DISABLED in v0.6.2** (`MULTI_LAYER_MOUNT_ENABLED = false`). The mount mechanism exists and is tested — a layer's placement in the project frame is a per-layer Float64 translation held beside the cloud, applied per mesh by the renderer and per read by the analysis consumers, so rendering, picking, terrain, lasso, profiles, volumes and exports all read one frame — but it is not the shipped behaviour. Multiple layers may be loaded and analysed individually; they are not co-registered and are not merged into one estimator. Turning mounting on waits on browser verification of two-layer placement (docs/architecture/float64-transform.md, step 6). Still staged for this release:
+
+- **Two-scan placement is unverified in a browser** — and cannot be verified while mounting is off, because nothing places them. That confirmation belongs to the cycle that turns mounting on.
+- **Mounting no longer rewrites the data.** Earlier alphas mounted by adding the project offset into the Float32 positions in place, which was lossy and made the round trip inexact. That mechanism is removed: source geometry is immutable (byte-identity pinned by `tests/sourceGeometryImmutable.test.ts`), and mount/unmount are exact inverses because setting and clearing a Float64 placement re-quantises nothing. The mm-precision refusal gates REMAIN as conservative admission rules — they model the retired mechanism's measured cost via `PointCloud.rebaseQuantum` (two tiles 1 km apart would have cost ~0.02 mm; 100 km a full millimetre) — until mounting is revisited with browser evidence.
+- Elevation colour ramps are normalised PER LAYER (each layer's own min/max), so a frame offset cancels in the normalisation and per-layer colours are correct — verified empirically. What ramps do NOT do is share one scale across layers, so the same colour on two layers does not mean the same absolute height; that is a pre-frame design choice, and a scene-shared ramp is the open step-5 decision. The measurement datum DOES follow the frame when every loaded layer is in it (step 4), and falls back to the pre-frame unanimity rule otherwise.
+
+For this release:
+
+- Cross-layer operations require a shared CRS, and no layer is moved: every layer stays in the frame its file declared.
+- **Multi-dataset comparison is experimental.** Compare Studio, cross-layer measurement, shared clipping and elevation ramps do not yet read the frame's offsets (steps 3–5 of the plan).
+- Results that depend on a common frame should be treated as indicative when common-frame compatibility can't be established.
+- Integrated Spatial Workflows are **not** claimed complete.
+- A layer whose declared CRS disagrees with the project's is excluded from the shared origin and reported as unaligned; it is never silently reprojected. Reprojection remains a downstream tool's job.
+
+## Cross-layer results require PROVEN frame compatibility
+
+Each layer carries what it has established about the project frame:
+`verified` (horizontal and vertical both proven), `horizontal-only`
+(horizontal proven; vertical undeclared or different), `unknown` (no declared
+CRS), or `incompatible` (a different frame).
+
+Only `verified` layers are merged into a combined estimator — terrain/DTM,
+profile, cut/fill volume, lasso — and only `verified` layers are aligned in Z.
+A `horizontal-only` pair is placed in plan, where the agreement is real, and
+keeps its own heights, because orthometric and ellipsoidal references differ by
+tens of metres and metre against foot by a factor of three. Undeclared is
+treated as unproven, not as agreement.
+
+**This is a deliberate refusal, not a limitation of the maths.** Loading an
+unreferenced mesh (PLY/OBJ/GLB) beside a georeferenced scan will now leave it
+out of combined results rather than merging frames that were never shown to
+correspond. A single layer is `verified` by definition, so single-scan work is
+unaffected.
+
+A mount is additionally refused when it would cost more than a millimetre of
+Float32 resolution. The step is judged **per axis group** — horizontal through
+the horizontal unit, vertical through the vertical one — because a compound CRS
+can be feet across and metres up, and putting a Z step through the horizontal
+factor understated a 1.95 mm error as 0.6 mm. Either axis alone can refuse. An
+undeclared unit refuses rather than borrowing the other axis's, and
+**geographic (degree) frames are refused outright** — a degree is not a length,
+and what it stands for depends on latitude.
+
+**Streaming sources meet the same bar, and are never merged with static ones
+in this release.** A stream's points are local to its own render origin and a
+static cloud's to its own — independent numbers — so agreeing on CRS is not
+occupying the same space. Merging requires a shared MOUNTED frame, and nothing
+is mounted here, so a stream is analysed on its own. Alone, it is fully usable.
+
+**The vertical anchor comes only from verified layers.** A horizontal-only
+layer helps set the horizontal origin and never the Z origin.
+
+**Excluded layers say so** in the layer panel, with the reason — a silent
+exclusion would leave a figure computed from fewer inputs than it appears.
+
+**Single layers are exempt.** Proof of a shared frame is required to MERGE
+layers; one visible layer is analysed in its own frame, whatever its
+compatibility state, because no combination is taking place.
+
+**No longer open: the transform is held in Float64 beside source-local
+vertices**, never written into them. The in-place Float32 rewrite the earlier
+alphas disclosed here is removed (docs/architecture/float64-transform.md,
+steps 1–5); positions stay byte-identical through mount, unmount and every
+read path, pinned by test. The refusal gates above are kept unchanged as
+conservative admission rules — they still quote the retired mechanism's
+measured cost — and multi-layer mounting itself remains disabled and
+browser-unverified (step 6).
+
+## Contour GeoJSON ships in two frames
+
+`<name>.geojson` is RFC 7946: WGS 84 longitude/latitude, no `crs` member, with
+the source CRS recorded in `metadata` as provenance. `<name>-native-EPSG<code>.geojson`
+carries the scan's own projected coordinates and the pre-RFC `crs` member for
+GIS that wants the survey grid — it is deliberately NOT RFC 7946, and its
+filename says so.
+
+Earlier builds wrote projected coordinates into `<name>.geojson` and declared
+them with the `crs` member. A compliant reader discards that member and reads
+an easting as a longitude without erroring, so files exported before this
+change should be treated as native-frame regardless of their name.
+
+When the source CRS cannot be converted to lon/lat, the RFC file is refused
+rather than written with projected numbers in degree fields, and only the
+native file is produced.
+
+Each contour's `elevationUnit` now states the unit the elevation is actually in.
+Until v0.6.1 every contour was labelled `metre` while the value stayed in the
+source vertical unit, so a compound CRS with feet over a metre grid shipped
+100 ft labelled 100 m. The label is derived from the resolved vertical factor,
+and a factor that cannot be resolved reads unknown rather than defaulting to
+metre.
+
+The RFC file's geometry is **2D unless the vertical reference is proven to be
+WGS 84 ellipsoidal height**, which is the only thing RFC 7946 permits in a
+position's third element. Elevations always ride as `elevation`,
+`elevationUnit` and `elevationDatum` properties. KML geometry is **2D unless the vertical reference is a
+known metric orthometric one** (NAVD88, MSL height, EGM2008, EGM96), since
+KML `absolute` means metres above mean sea level specifically — a WGS 84
+ellipsoidal height is not that, and a depth axis is sign-flipped as well. The
+source elevation, its unit and its datum are disclosed in each placemark
+description, so the omitted ordinate is stated rather than lost.
+
+## Residual streaming flicker at the budget boundary
+
+An anti-thrash resident-stickiness option exists in the budget selector and is unit-tested, but it is **opt-in and not wired** into the live scheduler — enabling it must first reconcile with the scheduler's ancestor-protection and be verified visually in a browser. Some budget-boundary "regions pulsing" may remain in this build.
+
+## Startup bundle above the early-warning line
+
+The live entry chunk measures 718 KiB against a hard 720 KiB ceiling — **2 KiB of headroom**, and above the 680 KiB early-warning threshold. Treat the ceiling as effectively reached: shed weight before adding any, and do not raise it. The figure is machine-derived into `docs/validation/test-evidence.json` and checked by `lint:evidence`, because three documents once quoted a size for a build that produced a different one.
+
+## Mutation and coverage evidence is advisory, not archived
+
+`npm run coverage` and `npm run mutation` both pass (numeric-core mutation score 87.23 % at the time of writing). The release-mode gate runs both as blocking stages, records them in the attached evidence, and ships their output inside `gate.log`; ordinary branch CI still runs neither, so between releases treat the figures as a working measurement rather than a preserved claim. `terrainRunnerDensityWiring.test.ts` is excluded from the coverage run only — v8 instrumentation makes it take about 75 s per test — and still runs in the release buckets.
+
+## LAS 1.4 CRS encoding depends on the source
+
+LAS 1.4 requires the horizontal CRS as OGC WKT for point data record formats
+6-10. The writer emits a `LASF_Projection` record 2112 with global-encoding bit
+4 set whenever a WKT is available, and a WKT is derived for WGS 84 UTM zones and
+WGS 84 geographic, whose parameters follow exactly from the code.
+
+Codes outside that set — ETRS89 or NAD83 UTM zones, national grids — still fall
+back to a GeoTIFF `GeoKeyDirectoryTag` with bit 4 clear. Those share a
+projection with a derivable zone but not a datum, and a datum is not something
+to infer when the difference is metres on the ground. Such a file records its
+code faithfully and every common reader resolves it, but a strict 1.4 reader
+may decline to take the CRS from it. The conversion log says which encoding was
+used.
+
+The two records are no longer alternatives. The WKT the writer emits is
+horizontal-only, while the vertical datum (GeoKey 4096) and the vertical unit
+(4099) exist only in the GeoKeys, so treating one record as excluding the other
+dropped both from every WKT-encoded file: a NAVD88 height in US survey feet came
+out declaring no vertical datum and no vertical unit, and a reader that assumes
+metres is wrong by a factor of 3.28. LAS 1.4 permits both records, so v0.6.1
+writes the vertical GeoKeys alongside the WKT. The WKT remains the sole
+horizontal authority, the GeoKey record carries the vertical keys and nothing
+else, and no GeoKey record is written at all when there is no vertical to add.
+
+What remains true is that a vertical reference the source never declared cannot
+be recovered. The file states what the source stated.
+
+An earlier build derived nothing, so a scan georeferenced by GeoKeys alone -
+what LAS 1.2 carries, and what PDAL commonly writes - came back out as a 1.4
+file with the right code in the wrong encoding.
+
+The read side matched the write side only from v0.6.2. Until then `parseCrsFromVlrs` returned the WKT and discarded the GeoKeyDirectory, so the vertical keys the v0.6.1 writer had just started emitting were dropped again on load. `docs/release/ERRATUM_v0.6.2.md` states which output that reached.
+
+## Evidence ceiling: three cross-implemented products, no field validation
+
+Three products have been compared against an independent implementation. Slope, aspect and hillshade each agreed with GDAL 3.13.1, and with the surface's closed-form gradient, on one frozen analytic DEM, within tolerances registered before the references were generated. `SLOPE-RASTER`, `ASPECT-RASTER` and `HILLSHADE` are at E4 on that basis.
+
+The hillshade tolerance carries a caveat the other two do not: the byte-encoding difference between the two implementations spends most of a one-level budget on its own, so the ours-against-GDAL leg is a weak instrument by itself and the claim rests on the closed-form leg and on an exact re-encoding identity. `docs/validation/cross-implementation.md` states it in full.
+
+Every other `REFERENCE_SLOT` still ships `pending`, and every other terrain product tops out at E3, which is synthetic known-truth against this project's own implementation.
+
+E5 is unreached. Nothing here is field-validated, and the three E4 results validate the algorithms on one analytic fixture rather than the point-cloud-to-DTM pipeline. This release does not claim survey-grade accuracy, standards compliance or independent field validation.
+
+## No cross-CRS reprojection
+
+Unchanged from prior releases: the viewer does not reproject between coordinate systems. Equal-CRS scans display alongside each other; mixed-CRS scans display in their on-disk local frames. Aligning different CRSs needs a downstream tool (PDAL / GDAL / proj4).
+
+## Axis and compound-unit handling is correct but not yet uniform
+
+alpha.2 fixed the two places where an axis or unit assumption produced a wrong number: box dimensions now follow the scan's up-axis (they previously hardcoded Z as height, which also mis-applied the vertical unit factor on a Y-up frame), and the Scan Report footprint follows the source up-axis. The PDF report's footprint did not follow until v0.6.2, so the on-screen panel and the printed page disagreed on every Y-up scan until then. The unit-integrity suite is what compared the two.
+
+There is still no single explicit model spanning up-axis, horizontal unit, vertical unit and CRS, so an unusual combination is more likely to be silently plausible than loudly refused. That model is a stable-v0.6 requirement.
+
+**Boxes require an axis-aligned frame, and now say so.** A box measurement is stored as min/max corners, so it is axis-aligned by construction and its height can only be an extent along X, Y or Z. Given a genuinely tilted up vector the geometry used to fall back to the *dominant* component — reporting the extent along the nearest axis as the height, and carrying that into the footprint ring, the exported GeoJSON and KML polygons, and the compound-CRS vertical conversion. It now throws instead. No scan can currently trigger this: every world-up the viewer sets is exactly (0, ±1, 0) or (0, 0, ±1), chosen by source format, so the refusal guards the contract rather than gating a feature. Genuinely oriented boxes need a stored basis instead of an axis index, which is a stable-v0.6 item alongside the project frame — the two are the same "arbitrary frames" problem.
+
+## Vertical-unit gaps still open
+
+Four of the five vertical-unit gaps the v0.6.1 audit recorded are closed in v0.6.2: the contour deliverable's GeoTIFF states its vertical unit, the async and GPU derivative path carries the `zScale`, `geodesicFill` walks in metres, and the unused elevation-grid hillshade wrappers are deleted. One remains.
+
+- **`toGeoJSONWgs84` writes a source-unit height into an RFC 7946 ordinate.**
+  When the vertical datum is EPSG:4979 the elevation goes into the third
+  position ordinate, which RFC 7946 requires in metres, while the value is in
+  source units. A foot factor together with a 4979 datum is self-contradictory
+  and may be unreachable in practice, but nothing in the code enforces that, so
+  the combination is not refused either.
+
+## What the validation suites do not cover
+
+Each suite states its own gaps rather than leaving them implicit. A check that cannot fail in the environment it runs in would pass without evidence, so these are named instead of tested.
+
+- **GPU-computed derivatives beyond the engine probe surfaces.** The WebGPU
+  backend takes the same cell-metres and `zScale` arguments as the CPU one, but
+  Node has no adapter, so the engine falls back to CPU and a unit check there
+  would test the CPU path twice. GPU-versus-CPU agreement is established by the
+  engine's own equivalence probe, which runs in a browser and covers the probe
+  surfaces only.
+- **Render-space lengths and the measurement HUD.** Values are read back from
+  three.js world transforms, which need a WebGL context.
+- **Rasterised report composition.** Colorbar and legend tick labels, the
+  on-canvas scan report drawing paths and the PDF report's page composition all
+  need a canvas context. Only the pure label and figure builders behind them are
+  checked. The unit strings a page prints come from those builders; the rendered
+  page itself is not inspected.
+- **LAZ output.** `CONVERT_FORMATS.laz.available` is false: there is no LAZ
+  encoder, so there is no LAZ file of the application's own to read back. The
+  LAZ read path shares record decoding with the `.las` path that is exercised,
+  but the compression leg is untested.
+- **Third-party writer conformance.** The round-trip suite reads every file back
+  with an independent ASPRS spec-offset decoder in float64 alongside the
+  application's own loader, which is two readers over one writer. Whether PDAL,
+  lastools or a commercial writer produces files this reader handles, and
+  whether they accept these files, is not measured.
+- **`npm ci` and a build from a clean extract.** The archive-portability suite
+  runs the archive's node-only verification inside an extract with no repository
+  around it. A tool that cannot start without `node_modules` is recorded as
+  needing dependencies, and one that needs a build is recorded as needing a
+  build, rather than counted as a pass. Neither the install nor the build is
+  performed there.
+- **Windows as a reproducibility leg.** The portability matrix is darwin-arm64
+  and linux-x64. Untested platforms, other runtime versions and big-endian hosts
+  are outside the result.
+
+## The in-memory reconstruction is less precise than the file it came from
+
+Points are held as Float32 local to a render origin, so what the application reconstructs from a LAS file displaces further than the file's own quantisation bound allows. The round-trip suite measures both and reports them separately.
+
+Over a 50 km extent at millimetre scale the file round-trips with zero displacement while the application's read-back reaches 1.9 mm. Over a 5000 km extent, where the writer widens the scale to stay inside int32, the file's own bound is 1.25 mm and the application's read-back reaches 0.123 m. The written file is unaffected either way. What the figures describe is the resolution of what the viewer holds, measures and derives from, and it grows with the extent of the cloud rather than with the declared scale.
+
+A wide-area cloud is the case to watch.
+
+## Cross-platform reproducibility is not yet established
+
+The comparator, the per-platform recorder and a CI matrix over darwin-arm64 and linux-x64 are in place, and both legs always run so that a failed leg cannot leave a one-platform comparison looking green. The only run recorded in the tree is a single darwin-arm64 leg, which reports as `single-platform` with `claimEstablished: false`.
+
+That leg establishes seeded reproducibility on one platform: 15 science-scoped artifact hashes and 18 scalars identical across ten runs at zero tolerance.
+
+Nothing has been compared against them.

--- a/docs/release/ERRATUM_v0.6.2.md
+++ b/docs/release/ERRATUM_v0.6.2.md
@@ -1,0 +1,142 @@
+# Erratum: corrections to v0.6.1
+
+Four defects were present in the published v0.6.1. All four are corrected in
+v0.6.2. Each one could have reached output a user still holds, so each entry
+below states what the software did, which outputs carry the error, and what
+recovers a correct figure.
+
+One of the four sits in a truth document rather than in code: the v0.6.1
+limitations file described a narrower scope for a fill defect than the code
+supported.
+
+## 1. The geodesic fill scope statement in `KNOWN_LIMITATIONS_v0.6.1.md` is wrong
+
+`KNOWN_LIMITATIONS_v0.6.1.md` says of the `geodesicFill` unit-mixing defect that
+it "affects the non-default geodesic interpolation mode only; the default fill
+is unaffected". Both halves of that sentence are false.
+
+`src/terrain/ground/surfaceFromRaster.ts` exports
+`LIVE_INTERPOLATION = 'geodesic'`, and `src/terrain/contour/analyseContours.ts`
+reads that constant on the live path. Geodesic is not an optional mode. It is
+the void fill that built every DTM surface the application produced, including
+the surface the hold-out validation measures.
+
+What the defect did: the Dijkstra step cost summed a horizontal step in raw
+source units with a vertical rise in raw vertical units, over one isotropic cell
+size used for both grid axes. The corrected cost converts both terms to metres
+through the same per-axis conversion the slope stage uses.
+
+The range of affected output is narrower than the range of affected code paths,
+because the inverse-distance weights are normalised over the samples they
+collect. A single common factor applied to every path cost cancels exactly. So:
+
+- Projected frames with one unit throughout, metre horizontal over metre
+  vertical or foot over foot, produce the same interpolated heights before and
+  after the fix. The grid cells are square there, and the unit change is a
+  uniform scale.
+- Geographic (degree) frames are affected. A degree step is about 1e-5 beside
+  metre heights, so the cost went effectively vertical-only and the
+  down-weighting of a path that climbs over a ridge stopped working. The
+  east-west and north-south cells also differ by cos(latitude), which no single
+  factor absorbs.
+- Compound frames whose vertical unit differs from the horizontal one are
+  affected for the same reason: two different factors do not cancel.
+
+Interpolated void heights in those two cases come from a differently weighted
+blend in v0.6.1 than in v0.6.2, and so does everything derived from them:
+contours, the terrain derivatives, volumes, the hold-out figures.
+
+Measured cells are kept verbatim by the fill, in any frame.
+
+There is no in-place correction for an existing deliverable. Regenerate from the
+source cloud in v0.6.2. A deliverable from a metre-over-metre or foot-over-foot
+projected scan needs no action, because its heights did not move.
+
+## 2. PDF report footprint read a Y-up scan's extents as Z-up
+
+`footprintMetres` (`src/report/reportFootprint.ts`) assumed the source frame was
+Z-up. PLY, OBJ and glTF load in their native Y-up frame, where Y carries height
+and Z carries ground depth. The on-screen Scan Report swizzled by `isZUpFormat`
+and was correct; the PDF path did not, so the two disagreed on every mesh-format
+scan.
+
+Three figures on the page were wrong for those formats. Depth printed the
+building's height and Height printed the ground depth, while Density divided the
+point count by a vertical cross-section rather than by the ground footprint.
+
+Measured on a 30 x 40 m footprint 8 m tall with 120,000 points: Depth read 8 m
+where 40 m is correct, and density read 500 pts/m2 where 100 pts/m2 is correct,
+a fivefold overstatement. On a compound CRS the vertical unit factor also landed
+on a horizontal span, so Height read 12.192 m where 2.4384 m is correct.
+
+Affects every PDF report generated from a PLY, OBJ or glTF scan by v0.6.1 or
+earlier. LAS-family, COPC and EPT scans are Z-up by specification, so their
+reports are unchanged.
+
+Recovery for a single-unit scan: the printed Depth and Height are each other's
+values, and the correct density is the printed density multiplied by the printed
+Depth and divided by the printed Height. For the example above, 500 x 8 / 40 =
+100 pts/m2. On a compound CRS the unit factor is on the wrong axis as well, so a
+swap does not recover the figures. Regenerate the report in v0.6.2.
+
+## 3. A declared linear unit that could not be resolved was answered as metres
+
+`crsFromGeoTiff` (`src/io/crs.ts`) mapped `ProjLinearUnitsGeoKey` (3076) through
+a table of 9001 metre, 9002 international foot and 9003 US survey foot. A
+projected CRS declaring any other code fell through to the projected-CRS default
+of metre with a factor of 1. For a British-foot CRS (9095), `toMetres(100)`
+returned 100 where roughly 30.48 is correct. Every length, area, volume or
+density derived from such a file went to the page in metres while the numbers
+were still in the source unit. The wrong answer was also unreachable by any
+gate: a file declaring a unit the software cannot honour resolved identically to
+a file declaring no unit at all, so nothing downstream could tell the two apart
+and no refusal could fire.
+
+v0.6.2 resolves a declared-but-unmappable code to `unknown`, which the
+downstream `linearUnit !== 'unknown'` gates read and withhold the label for. An
+absent key still takes the GeoTIFF default.
+
+The correction makes such a file refusable, not convertible. The application
+still cannot convert 9095. Figures already produced from one of these files are
+not repaired by opening it in v0.6.2; they need the unit supplied and the
+measurement re-derived, or the file relabelled with a downstream tool.
+
+Affects any GeoTIFF-georeferenced source whose `ProjLinearUnitsGeoKey` falls
+outside 9001/9002/9003. That is LAS 1.2, COPC and EPT, plus any LAS 1.4 file
+carrying a GeoKeyDirectory.
+
+## 4. LAS 1.4 vertical CRS was discarded on read
+
+`parseCrsFromVlrs` (`src/io/crs.ts`) treated the OGC WKT record and the
+GeoKeyDirectory record as alternatives: when a WKT was present it returned
+`crsFromWkt(...)` and dropped the GeoKeyDirectory entirely.
+
+This application's own LAS 1.4 writer places the vertical datum (GeoKey 4096)
+and the vertical unit (4099) beside a horizontal-only WKT. That is what LAS 1.4
+permits, and it is what v0.6.1 changed the writer to do. Most WKT describes the
+horizontal frame only, including every WKT `wktForEpsg` derives, so the read path
+threw away the only record carrying the vertical.
+
+`verticalEpsg` and the vertical unit read back as `undefined`.
+
+A file declaring neither leaves the terrain tools falling back to metres, so a
+NAVD88 height in US survey feet was taken for metres, wrong by a factor of 3.28.
+Every elevation inherits that, and so does every contour interval, slope figure
+and cut/fill volume computed from it. The written files are correct, because the
+loss is on read: the defect does not damage an archive, it damages what was
+computed from one. Affects every file this application wrote as LAS 1.4 with a
+source WKT or a `wktForEpsg`-derived one, whenever that file was opened again in
+v0.6.1.
+
+Recovery: reopen the file in v0.6.2 and regenerate anything derived from it. The
+vertical datum and unit read back from the GeoKeys, with the WKT still the sole
+authority on the horizontal frame and on any vertical axis it declares itself.
+Nothing about the file on disk changes.
+
+## What is not corrected here
+
+A vertical reference the source never declared cannot be recovered by any of
+these fixes. Files written by v0.6.0 and earlier carry no vertical GeoKeys
+beside a WKT at all, because the writer treated the two records as alternatives
+until v0.6.1. Those files state no vertical reference and reading them in v0.6.2
+does not invent one.

--- a/docs/validation/claim-register.yaml
+++ b/docs/validation/claim-register.yaml
@@ -4,14 +4,15 @@
 # identifiers + gate logic.
 #
 # Honesty rules (do not violate when editing):
-#   - currentEvidence must reflect evidence that EXISTS today. Two claims
-#     currently reach E4: SLOPE-RASTER and ASPECT-RASTER, each cross-implemented
-#     against GDAL 3.13.1 on the same frozen analytic fixture within the
-#     preregistered 0.5 degree tolerance. No claim reaches E5 (no field
-#     validation has been run). Synthetic known-truth fixtures alone remain E3,
-#     not accuracy.
+#   - currentEvidence must reflect evidence that EXISTS today. Three claims
+#     currently reach E4: SLOPE-RASTER, ASPECT-RASTER and HILLSHADE, each
+#     cross-implemented against GDAL 3.13.1 on the same frozen analytic fixture
+#     within the tolerance registered before its reference was generated (0.5
+#     degree for slope and aspect, 1.0 8-bit level for hillshade). No claim
+#     reaches E5 (no field validation has been run). Synthetic known-truth
+#     fixtures alone remain E3, not accuracy.
 #   - externalValidationStatus is `pending` wherever external data is required
-#     and unavailable. Two independent GDAL reference slots are supplied; all
+#     and unavailable. Three independent GDAL reference slots are supplied; all
 #     remaining independent-reference slots are pending. Never infer it from
 #     density / format / metadata.
 #   - prohibitedClaim lists statements the current evidence does NOT support.
@@ -21,8 +22,8 @@
 #
 # Phase 3–4 tooling (v0.5.8) — mechanisms exist to REACH the required levels:
 #   - Cross-implementation harness: src/validation/crossCheck.ts +
-#     docs/validation/cross-implementation.md. The SLOPE-RASTER and
-#     ASPECT-RASTER GDAL reference slots are supplied and promote those two
+#     docs/validation/cross-implementation.md. The SLOPE-RASTER, ASPECT-RASTER
+#     and HILLSHADE GDAL reference slots are supplied and promote those three
 #     claims to E4; all remaining reference slots are pending, each awaiting a
 #     real PDAL/GDAL/CloudCompare reference committed.
 #   - Honest estimators: src/terrain/validate/spatialBlockHoldout.ts
@@ -50,11 +51,21 @@ schemaVersion: 1
 # of always saying metre — and adds a finite-position refusal to the EPT laszip
 # decoder. None of the three changes what an algorithm computes, so every
 # evidence level is inherited unchanged.
-# 0.6.2 changes the EVIDENCE STATE of one more claim without changing any
-# algorithm: ASPECT-RASTER is promoted E3->E4 by a committed GDAL 3.13.1
-# cross-implementation reference, generated on the same frozen fixture the
-# slope reference uses. No algorithm changed; softwareVersion below is stamped
-# at release time.
+# 0.6.2 changes the EVIDENCE STATE of two more claims without changing any
+# algorithm: ASPECT-RASTER and HILLSHADE are promoted E3->E4 by committed GDAL
+# 3.13.1 cross-implementation references, generated on the same frozen fixture
+# the slope reference uses and pinning it by hash. The hillshade leg against
+# GDAL is a weak instrument on its own, because the two implementations' byte
+# encodings differ by up to one level and the gate is one level; that claim
+# rests on the closed-form leg and on an exact re-encoding identity, and the
+# limit is recorded in docs/validation/cross-implementation.md. 0.6.2 also
+# fixes eighteen defects, four of which reached published v0.6.1 output and are
+# corrected in docs/release/ERRATUM_v0.6.2.md; none of the eighteen changes
+# what a registered algorithm computes except the geodesic void fill, whose
+# unit correction changes interpolated heights on geographic and mixed-unit
+# compound frames. No claim's evidence level moves on that account, because the
+# fixtures behind every level are projected metre frames. softwareVersion below
+# is stamped at release time.
 softwareVersion: 0.6.1
 generated: 2026-07-26
 validationOwner: A. Urias / Aurtech

--- a/docs/validation/cross-platform-reproducibility.md
+++ b/docs/validation/cross-platform-reproducibility.md
@@ -1,0 +1,58 @@
+# Cross-platform scientific reproducibility
+
+Whether the same seeded input produces the same scientific output on a second
+machine of a different architecture. The suite that answers it has two halves: a
+recorder that runs on one platform and signs a leg, and a comparator that reads
+every leg and checks the source-cloud hash first, then every science-scoped hash
+and scalar at zero tolerance.
+
+Run it with `npm run benchmark:repro:portable` on each platform, then
+`npm run benchmark:compare-platforms` over the collected legs. Byte order is
+checked as a precondition rather than reported as a result. The CI workflow
+`benchmark-portability.yml` does both across a matrix of linux-x64 (ubuntu) and
+darwin-arm64 (macOS), with `fail-fast` off: a leg that dies would otherwise
+leave the comparator with one platform, which reports as single-platform and
+establishes nothing while still looking green.
+
+## Current state: single-platform
+
+The only run recorded in this tree is one darwin-arm64 leg. The comparator
+reports `status: single-platform` and `claimEstablished: false`.
+
+**Cross-platform reproducibility is therefore not established.** What the run
+does establish is seeded reproducibility on one platform: 15 science-scoped
+artifact hashes and 18 scalar values identical across ten recorded runs at zero
+tolerance, with the processing manifest verifying each time.
+
+| Field | Value |
+|---|---|
+| Platforms recorded | darwin-arm64 |
+| Fixture | synthetic-250000-seed20260726, 250,000 points |
+| Scalar tolerance | 0 |
+| Science-scoped hashes | 15 recorded, 0 compared |
+| Science-scoped scalars | 18 recorded, 0 compared |
+| Byte order | LE (precondition, not a result) |
+
+The darwin-arm64 source-cloud hash is published as the reference a second
+platform will be checked against, rather than as a comparison that succeeded.
+
+## What the comparator excludes, and why
+
+Three fields are outside the comparison by construction rather than by
+tolerance. Timestamps are wall-clock readings, stripped from every hashed
+artifact and recorded per platform. Archive paths are relative in every manifest
+and belong to no hash, because each runner has its own workspace root. Build
+identity embeds the commit and the runtime that produced it, which is why the
+scientific record and the processing manifest are seeded from it and compared
+separately from the science.
+
+Runtimes are reported per platform and never pooled. A median over two machines
+describes neither of them, and what this suite measures is output identity
+rather than which host is faster.
+
+## Scope
+
+A result here covers the platforms in the matrix, on the Node major version the
+workflow pins, at the commit recorded in the comparison. Untested platforms,
+other runtime versions and big-endian hosts are outside it. Windows is not
+covered.


### PR DESCRIPTION
Four defects present in the published v0.6.1, each stated with what the software did, which outputs carry the error, and what recovers a correct figure. One of the four sits in a truth document rather than in code.

Three corrections to the brief this was written from, all verified against the code:

**The geodesic scope statement is wrong in both directions.** `LIVE_INTERPOLATION = 'geodesic'` is real and `analyseContours` reads it, so v0.6.1's claim that the defect touched a non-default mode is false. But the pre-fix call passed a single `cellSizeM`, and the inverse-distance weights are normalised, so one common factor on every path cost cancels exactly. A metre-over-metre or foot-over-foot projected frame interpolates identically before and after. Geographic and mixed-unit compound frames do change. Claiming every surface moved would have been the opposite error to the one being corrected.

**Eighteen defects, not eleven.** Four carried from the v0.6.1 vertical-unit audit and fourteen from the new suites. All are enumerated.

**Defect 3 makes a file refusable, not convertible.** The application still cannot convert EPSG unit code 9095. Figures already produced are not repaired by reopening the file.

Also corrected in passing: the CHANGELOG's aspect entry said `HILLSHADE` keeps its own lower level, but hillshade was promoted to E4 in `f586642`. The hillshade entry is added with its weak-instrument caveat.

Two follow-ups this branch does not carry. The cross-platform result is now tracked in #67, so the single-platform wording here needs updating to match once that lands. And #68 closes the RFC 7946 third-ordinate gap, which makes the `KNOWN_LIMITATIONS_v0.6.2.md` entry at line 189 stale.

Checks: `lint:release-sync`, `lint:release-truth` (3 E4 / 3 supplied), `lint:claim-register` (26 claims), `lint:claims-language`, `lint:evidence` (6,182 passed / 16 skipped), `lint:archive-vocab` and typecheck all exit 0. `check-ai-writing` reports no tells on the erratum or the new validation page.