### PR TITLE
Update the truth documents for what v0.6.2 closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ are fixed: four carried from the v0.6.1 vertical-unit audit, fourteen found by
 the new suites. The evidence ceiling moves from one cross-implemented product to
 three, with aspect and hillshade joining slope at E4 against GDAL 3.13.1 on the
 shared analytic DEM. The reproducibility comparator and its two-platform CI
-matrix, darwin-arm64 and linux-x64, are in place; the only run recorded in the
-tree so far is a single darwin-arm64 leg, which establishes single-platform
-reproducibility and nothing cross-platform.
+matrix, darwin-arm64 and linux-x64, are in place, and the two-platform result is
+tracked at `docs/validation/evidence/portability-v0.6.2/`: identical
+science-scoped output on both platforms from the same seeded fixture, 15 artifact
+hashes and 18 scalars at zero tolerance with none differing. That covers two
+little-endian platforms, one commit and a synthetic fixture; Windows, big-endian
+hosts and real scan data are outside it.
 
 Four defects reached published v0.6.1 output. `docs/release/ERRATUM_v0.6.2.md`
 states, for each, what the software did, which outputs carry the error and what
@@ -22,6 +25,16 @@ recovers a correct figure. Open limits are in `KNOWN_LIMITATIONS_v0.6.2.md`.
 
 ### Fixed
 
+- **The RFC 7946 contour GeoJSON states its third ordinate in metres.**
+  `toGeoJSONWgs84` (`src/terrain/contour/geojsonContours.ts`) wrote the DTM
+  elevation into the third position element at its source value, so a foot
+  vertical unit beside a WGS 84 ellipsoidal datum shipped 100 ft where RFC 7946
+  section 3.1.1 requires metres. The ordinate now carries the metre equivalent,
+  converted through the resolved vertical factor, and `metadata` records
+  `elevationOrdinateUnit: 'metre'`. A factor that is unresolved or not positive
+  drops the geometry to 2D with an `elevationNote` naming that cause, rather
+  than asserting metres about a number of unknown unit. Every feature keeps
+  `elevation`, `elevationUnit` and `elevationDatum` in the source unit.
 - **A contour set declares the interval it emitted.** An over-fine request is
   thinned against the 200-level cap, but `intervalM` kept reporting the value
   that was asked for, so the GeoJSON `metadata.intervalM`, every feature's
@@ -267,31 +280,13 @@ affected and what recovers a correct figure.
 
 ### Known limitations
 
-- **The RFC 7946 contour GeoJSON writes its third ordinate in the source
-  vertical unit, not in metres.** `toGeoJSONWgs84`
-  (`src/terrain/contour/geojsonContours.ts`) emits the elevation as the third
-  position element only when the model's vertical datum is proven to be WGS 84
-  ellipsoidal height (EPSG:4979); otherwise the geometry is 2D. RFC 7946
-  section 3.1.1 defines that element as height in metres above the WGS 84
-  ellipsoid, and the value written is the DTM's elevation in whatever vertical
-  unit the source declared. The horizontal reprojection does not touch it: the
-  mapper's contract (`src/export/lonLatMapper.ts`) is that the first two
-  ordinates are converted and the third is the source Z, passed through. No
-  check requires the source vertical unit to be metres before the ordinate is
-  written. Reaching the failure needs a source that declares vertical CRS 4979
-  and a non-metre vertical unit at the same time, which GeoTIFF permits
-  mechanically because keys 4096 and 4099 are read independently, but which is
-  an internally contradictory declaration; no such file has been observed, so
-  this is a standards-conformance gap and not a defect seen in output. On such
-  a file a 100 ft contour would ship as a 100 m ellipsoidal height in the
-  geometry. Every feature also carries `elevation`, `elevationUnit` and
-  `elevationDatum`, which state the real unit and reference in both the 2D and
-  the 3D case, so a reader that consults the properties is not misled; the
-  v0.6.1 unit-label fix corrected those properties and left this ordinate as it
-  was. Until the ordinate is guarded, read the elevation properties or take the
-  companion native export rather than the Z ordinate. The resolution is a
-  refusal or a conversion to metres at the point the ordinate is written; a
-  relabelling would not be one. Neither is scheduled.
+- **Antimeridian-crossing contour geometry is not cut at 180 degrees.**
+  RFC 7946 section 3.1.9 says a LineString crossing the antimeridian SHOULD be
+  split into two parts there; `toGeoJSONWgs84`
+  (`src/terrain/contour/geojsonContours.ts`) writes the line whole. That is a
+  SHOULD rather than a MUST, and only a scan footprint straddling 180 degrees
+  reaches it. A reader that interpolates in longitude between the two sides
+  draws the segment the long way round the globe.
 - **Opening a remote streaming source replaces the streaming source already
   open.** A COPC or EPT source opened by URL, including from the curated
   picker, closes any open stream and clears the open static layers before it

--- a/KNOWN_LIMITATIONS_v0.6.2.md
+++ b/KNOWN_LIMITATIONS_v0.6.2.md
@@ -105,8 +105,12 @@ and a factor that cannot be resolved reads unknown rather than defaulting to
 metre.
 
 The RFC file's geometry is **2D unless the vertical reference is proven to be
-WGS 84 ellipsoidal height**, which is the only thing RFC 7946 permits in a
-position's third element. Elevations always ride as `elevation`,
+WGS 84 ellipsoidal height and the vertical unit resolves**, which is what RFC 7946
+permits in a position's third element: a height above the WGS 84 ellipsoid, in
+metres. Both conditions are needed, since an unresolved factor leaves no way to
+state the height in metres. When they hold, the ordinate carries the metre
+equivalent and `metadata.elevationOrdinateUnit` reads `metre`; when they do not,
+`metadata.elevationNote` names which one failed. Elevations always ride as `elevation`,
 `elevationUnit` and `elevationDatum` properties. KML geometry is **2D unless the vertical reference is a
 known metric orthometric one** (NAVD88, MSL height, EGM2008, EGM96), since
 KML `absolute` means metres above mean sea level specifically — a WGS 84
@@ -182,16 +186,30 @@ There is still no single explicit model spanning up-axis, horizontal unit, verti
 
 **Boxes require an axis-aligned frame, and now say so.** A box measurement is stored as min/max corners, so it is axis-aligned by construction and its height can only be an extent along X, Y or Z. Given a genuinely tilted up vector the geometry used to fall back to the *dominant* component — reporting the extent along the nearest axis as the height, and carrying that into the footprint ring, the exported GeoJSON and KML polygons, and the compound-CRS vertical conversion. It now throws instead. No scan can currently trigger this: every world-up the viewer sets is exactly (0, ±1, 0) or (0, 0, ±1), chosen by source format, so the refusal guards the contract rather than gating a feature. Genuinely oriented boxes need a stored basis instead of an axis index, which is a stable-v0.6 item alongside the project frame — the two are the same "arbitrary frames" problem.
 
-## Vertical-unit gaps still open
+## Vertical-unit gaps: all five closed in v0.6.2
 
-Four of the five vertical-unit gaps the v0.6.1 audit recorded are closed in v0.6.2: the contour deliverable's GeoTIFF states its vertical unit, the async and GPU derivative path carries the `zScale`, `geodesicFill` walks in metres, and the unused elevation-grid hillshade wrappers are deleted. One remains.
+All five vertical-unit gaps the v0.6.1 audit recorded are closed in v0.6.2: the contour deliverable's GeoTIFF states its vertical unit, the async and GPU derivative path carries the `zScale`, `geodesicFill` walks in metres, the unused elevation-grid hillshade wrappers are deleted, and the RFC 7946 ordinate is now in metres.
 
-- **`toGeoJSONWgs84` writes a source-unit height into an RFC 7946 ordinate.**
-  When the vertical datum is EPSG:4979 the elevation goes into the third
-  position ordinate, which RFC 7946 requires in metres, while the value is in
-  source units. A foot factor together with a 4979 datum is self-contradictory
-  and may be unreachable in practice, but nothing in the code enforces that, so
-  the combination is not refused either.
+- **Closed in v0.6.2: `toGeoJSONWgs84` wrote a source-unit height into an
+  RFC 7946 ordinate.** In v0.6.1, an EPSG:4979 vertical datum put the elevation
+  into the third position ordinate at its source value, so a foot vertical unit
+  shipped 100 ft where the format requires 100 m. Nothing refused the
+  self-contradictory foot-factor-plus-4979 combination either. The writer now
+  converts the ordinate to metres through `model.verticalUnitToMetres` and
+  records `metadata.elevationOrdinateUnit: 'metre'`; an unresolved or
+  non-positive factor drops the geometry to 2D with an `elevationNote` naming
+  that cause, distinct from the note for a non-ellipsoidal reference. A v0.6.1
+  RFC file from a foot vertical CRS carries the source number in a metre field
+  and should be re-exported.
+
+One residual remains.
+
+- **Antimeridian-crossing geometry is not cut.** RFC 7946 §3.1.9 says a
+  LineString crossing 180 degrees longitude SHOULD be split into two parts at
+  the antimeridian; the writer emits the line whole. That is a SHOULD rather
+  than a MUST, and only a scan footprint straddling 180 degrees reaches it. A
+  reader that interpolates between the two sides in longitude draws the segment
+  the long way round the globe.
 
 ## What the validation suites do not cover
 
@@ -237,10 +255,10 @@ Over a 50 km extent at millimetre scale the file round-trips with zero displacem
 
 A wide-area cloud is the case to watch.
 
-## Cross-platform reproducibility is not yet established
+## Cross-platform reproducibility covers two little-endian platforms
 
-The comparator, the per-platform recorder and a CI matrix over darwin-arm64 and linux-x64 are in place, and both legs always run so that a failed leg cannot leave a one-platform comparison looking green. The only run recorded in the tree is a single darwin-arm64 leg, which reports as `single-platform` with `claimEstablished: false`.
+The two-platform result is tracked at `docs/validation/evidence/portability-v0.6.2/`: `status: reproduced`, `claimEstablished: true`, platforms darwin-arm64 and linux-x64, from workflow run 30221805663 at commit 50e76d2. The two legs produced identical science-scoped output from the same seeded fixture, with 15 artifact hashes and 18 scalars compared at a tolerance of exactly zero and none differing. Host, timing and build-identity fields differ and are published per platform.
 
-That leg establishes seeded reproducibility on one platform: 15 science-scoped artifact hashes and 18 scalars identical across ten runs at zero tolerance.
+The scope is two platforms, both little-endian, one commit, one synthetic seeded fixture. Windows is untested, no big-endian host has run a leg, and no real scan data is in the comparison. What holds is that the same arithmetic returns the same values on a second architecture.
 
-Nothing has been compared against them.
+`benchmark-results/` is untracked, so a local run on one machine still reports `single-platform` with `claimEstablished: false`. That is the correct verdict for one leg and is not the verdict of the tracked evidence.

--- a/docs/validation/cross-platform-reproducibility.md
+++ b/docs/validation/cross-platform-reproducibility.md
@@ -14,27 +14,35 @@ darwin-arm64 (macOS), with `fail-fast` off: a leg that dies would otherwise
 leave the comparator with one platform, which reports as single-platform and
 establishes nothing while still looking green.
 
-## Current state: single-platform
+## Current state: reproduced on two platforms
 
-The only run recorded in this tree is one darwin-arm64 leg. The comparator
-reports `status: single-platform` and `claimEstablished: false`.
+The tracked result is `docs/validation/evidence/portability-v0.6.2/`, copied from
+workflow run 30221805663. The comparator reports `status: reproduced` and
+`claimEstablished: true` for darwin-arm64 and linux-x64 at commit 50e76d2.
 
-**Cross-platform reproducibility is therefore not established.** What the run
-does establish is seeded reproducibility on one platform: 15 science-scoped
-artifact hashes and 18 scalar values identical across ten recorded runs at zero
-tolerance, with the processing manifest verifying each time.
+The two legs produced identical science-scoped output from the same seeded
+fixture. 15 artifact hashes and 18 scalar values were compared at a tolerance of
+exactly zero; none differ. The source cloud hashed the same on both platforms, so
+a downstream difference would have been a property of the analysis rather than of
+its input.
 
 | Field | Value |
 |---|---|
-| Platforms recorded | darwin-arm64 |
+| Platforms compared | darwin-arm64, linux-x64 |
+| Commit | 50e76d2 |
 | Fixture | synthetic-250000-seed20260726, 250,000 points |
 | Scalar tolerance | 0 |
-| Science-scoped hashes | 15 recorded, 0 compared |
-| Science-scoped scalars | 18 recorded, 0 compared |
-| Byte order | LE (precondition, not a result) |
+| Science-scoped hashes | 15 compared, 0 differing |
+| Science-scoped scalars | 18 compared, 0 differing |
+| Byte order | LE on both (precondition, not a result) |
 
-The darwin-arm64 source-cloud hash is published as the reference a second
-platform will be checked against, rather than as a comparison that succeeded.
+Host fields, execution timing and build identity differ between the legs and are
+published with the value each platform reported.
+
+`benchmark-results/` is untracked, so running the suite locally on one machine
+produces one leg and reports `single-platform` with `claimEstablished: false`.
+That is the correct verdict for one leg, and it is not the verdict the tracked
+evidence carries.
 
 ## What the comparator excludes, and why
 
@@ -55,4 +63,6 @@ rather than which host is faster.
 A result here covers the platforms in the matrix, on the Node major version the
 workflow pins, at the commit recorded in the comparison. Untested platforms,
 other runtime versions and big-endian hosts are outside it. Windows is not
-covered.
+covered. The tracked result covers two little-endian platforms, one commit and
+one synthetic seeded fixture. Real scan data is not part of it, and neither is
+any claim of platform independence beyond the two legs that ran.

--- a/src/terrain/contour/contourCopy.ts
+++ b/src/terrain/contour/contourCopy.ts
@@ -73,9 +73,10 @@ export const METRIC_TOOLTIPS = {
     '(95th percentile), computed over ALL hold-out residuals, NOT ' +
     'vegetated-class checkpoints.',
   qualityLevel:
-    'USGS 3DEP Quality Level — the level the surface meets on point ' +
-    'density and vertical accuracy together. Estimated: the RMSEz leg is ' +
-    'measured on internally withheld points (hold-out), not the independent ' +
+    'USGS 3DEP Quality Level — where the measured ground density and ' +
+    'vertical accuracy sit against the 3DEP thresholds for that level. ' +
+    'Estimated, not a determination: the RMSEz leg is measured on ' +
+    'internally withheld points (hold-out), NOT the independent ' +
     'checkpoints a 3DEP assessment requires.',
   crs:
     'CRS — coordinate reference system; exports are not georeferenced ' +


### PR DESCRIPTION
Three statements went stale when six PRs merged.

**The RFC 7946 third-ordinate limitation is closed.** The `KNOWN_LIMITATIONS_v0.6.2.md` bullet moves to a closed entry stating what v0.6.1 did (a foot vertical unit shipped 100 ft in a metre field, and the foot-plus-4979 combination was not refused), what the writer does now, and that a v0.6.1 RFC file from a foot vertical CRS should be re-exported. The antimeridian residual replaces it as the open item: RFC 7946 section 3.1.9 is a SHOULD, and only a footprint straddling 180 degrees reaches it. The nearby 2D condition now requires both the vertical reference proven and the vertical unit resolved.

**The reproducibility state is two platforms, not one.** `docs/validation/cross-platform-reproducibility.md` and `KNOWN_LIMITATIONS_v0.6.2.md` now describe the tracked evidence, with the scope kept explicit: two platforms, both little-endian, one commit, one synthetic seeded fixture. Windows untested, no big-endian leg, no real scan data. A local run on one machine still reports `single-platform`, which is the correct verdict for one leg and not the verdict of the tracked evidence.

**`contourCopy.ts`'s `qualityLevel` tooltip** no longer opens by asserting the level. One adjustment to the prepared text: `NOT the independent checkpoints`, capitalised to match the `nva` and `vva` siblings that use uppercase for the same disclaimer. No test asserts the old string.

Also corrected, though not in the original scope: the CHANGELOG carried the same stale 26-line third-ordinate limitation, replaced by the antimeridian entry plus a Fixed entry for the metre conversion.

The erratum was left alone. It says nothing about platforms or reproducibility, so there was nothing to update there.

Two things worth knowing about the evidence. It records `releaseVersion: 0.6.1` at commit 50e76d2, so the wording cites the commit rather than a version. And `package.json` is still 0.6.1, so every gate currently reports v0.6.1.

Checks: typecheck, `lint:release-sync`, `lint:release-truth`, `lint:claim-register`, `lint:claims-language`, `lint:evidence` and `lint:archive-vocab` all exit 0; terrain 719 passed, ui 429 passed. `check-ai-writing` reports no tells on the new validation page after merging two paragraphs that read metronomically.