### PR TITLE
Record clean-clone as unrun inside an archive, not failed

### DIFF
--- a/scripts/verify-archive-portability.mjs
+++ b/scripts/verify-archive-portability.mjs
@@ -221,8 +221,10 @@ check('documented-scripts-exist', 'every `npm run` command named in shipping doc
 
 /**
  * Run the archive's own dependency-free verification, inside the archive.
- * A tool that cannot start without node_modules is recorded as `needs-deps`
- * rather than counted as a pass — an unrunnable check is not a green one.
+ * A tool that cannot start is recorded as unrun rather than counted as a pass,
+ * because an unrunnable check is not a green one: `needs-install` without
+ * node_modules, `needs-build` without a bundle, `needs-repo` when the check's
+ * subject is the repository the archive was cut from.
  */
 check('archive-self-verification', 'the archive’s own node-only verification scripts run and pass inside the archive', (c) => {
   const f = [];
@@ -267,6 +269,12 @@ check('archive-self-verification', 'the archive’s own node-only verification s
     }
     if (code !== 0 && /No build found/.test(out)) {
       ran.push({ name, status: 'needs-build' });
+      continue;
+    }
+    // A check whose subject is the repository cannot run against an extract by
+    // definition: the extract is what it would have been asked to produce.
+    if (code !== 0 && /needs a git repository|not a git repository/.test(out)) {
+      ran.push({ name, status: 'needs-repo' });
       continue;
     }
     ran.push({ name, status: code === 0 ? 'pass' : 'fail', exit: code });

--- a/scripts/verify-clean-clone.mjs
+++ b/scripts/verify-clean-clone.mjs
@@ -122,6 +122,20 @@ async function main() {
   const dropAt = argv.indexOf('--drop');
   const drop = dropAt === -1 ? null : argv[dropAt + 1];
 
+  // The tree under test comes from `git archive HEAD`, so this needs a
+  // repository. An extracted source archive has none, and the archive
+  // portability suite runs every node-only script inside one. Say so in a
+  // sentence a caller can classify, rather than letting git's own "not a git
+  // repository" reach the caller as an ordinary failure.
+  if (!existsSync(join(REPO_ROOT, '.git'))) {
+    process.stderr.write(
+      'clean-clone needs a git repository: the tree under test is materialised ' +
+        'from git archive HEAD, and this directory is not a repository. ' +
+        'Not run.\n',
+    );
+    return 3;
+  }
+
   const dest = mkdtempSync(join(tmpdir(), 'olv-clean-clone-'));
   const failures = [];
   try {


### PR DESCRIPTION
`test:release:execute` exited 1. `benchmark:archive-portability` runs every node-only script inside the extracted archive, and `benchmark:clean-clone` materialises its tree from `git archive HEAD`. An extracted archive has no `.git`, so it died on `fatal: not a git repository` and the gate counted that as a failed check.

The collision is inherent rather than accidental: a check whose subject is the repository cannot run against an extract, because the extract is what it would have been asked to produce.

The self-verification step already handles this class. It records `needs-install` without `node_modules` and `needs-build` without a bundle, on the stated principle that an unrunnable check is not a green one. `needs-repo` joins them, and `verify-clean-clone.mjs` exits 3 with a sentence a caller can classify instead of letting git's own error reach the caller as an ordinary failure.

Recorded, not passed:

```
needs-build    check:bundle
needs-install  check:deps
needs-repo     benchmark:clean-clone
```

`benchmark:clean-clone` still exits 0 in a repository, so the suite itself is unchanged where it can actually run.

`benchmark:archive-portability` now reports 12 passed, 0 failed. The full release gate prints `GATE EXIT: 0`.