### PR TITLE
Count a dependency read out of node_modules by path as used

### DIFF
--- a/scripts/verify-archive-portability.mjs
+++ b/scripts/verify-archive-portability.mjs
@@ -113,6 +113,19 @@ export function scriptFileTargets(scripts) {
 }
 
 /** `npm run <name>` invocations named in prose. */
+/**
+ * Does any of `texts` read `name` out of node_modules? Each text is a shipped
+ * non-JS file that mentions node_modules at all. A scoped package may be
+ * assembled one path segment at a time, so the scope and the bare name are
+ * looked for separately rather than as one joined string. Every text is
+ * already known to mention node_modules, which is what keeps a bare name like
+ * "three" from matching unrelated prose.
+ */
+export function readsPackageFromNodeModules(texts, name) {
+  const [scope, bare] = name.startsWith('@') ? name.split('/') : [null, name];
+  return texts.some((t) => (scope == null ? t.includes(bare) : t.includes(scope) && t.includes(bare)));
+}
+
 export function documentedScripts(text) {
   return [...text.matchAll(/npm run ([a-z0-9][a-z0-9:_-]*)/g)].map((m) => m[1]);
 }
@@ -439,10 +452,25 @@ check('imports-declared', 'every package the archive imports is a declared depen
       if (!declared.has(b)) f.push({ level: 'error', message: `${p} imports "${b}", which is not declared in package.json.` });
     }
   }
+  // A package can be consumed by path rather than by import: a build script
+  // that reads a font file out of node_modules writes no import specifier, and
+  // may assemble the path one segment at a time so no full package name ever
+  // appears as a single string. Scanning imports alone reports such a package
+  // as unused, which is true of the import graph and false of the archive.
+  const byPath = new Set();
+  const nonJs = c.files
+    .filter((p) => /\.(py|sh|ya?ml|css|html)$/.test(p))
+    .map((p) => c.read(p))
+    .filter((t) => t != null && t.includes('node_modules'));
   for (const name of Object.keys(c.pkg.dependencies ?? {})) {
-    if (!used.has(name)) f.push({ level: 'warn', message: `runtime dependency "${name}" is declared but never imported by anything in the archive.` });
+    if (used.has(name)) continue;
+    if (readsPackageFromNodeModules(nonJs, name)) {
+      byPath.add(name);
+      continue;
+    }
+    f.push({ level: 'warn', message: `runtime dependency "${name}" is declared but nothing in the archive imports it or reads it out of node_modules.` });
   }
-  return { findings: f, detail: { imported: [...used].sort() } };
+  return { findings: f, detail: { imported: [...used].sort(), readByPath: [...byPath].sort() } };
 });
 
 check('sbom-matches-manifest', 'the SBOM ships and covers the declared dependency set', (c) => {

--- a/tests/benchmark/archivePortability.test.ts
+++ b/tests/benchmark/archivePortability.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error — plain .mjs tooling module, no type declarations
-import { bareSpecifier, markdownTargets, linkCandidates, importSpecifiers, scriptFileTargets, documentedScripts } from '../../scripts/verify-archive-portability.mjs';
+import { bareSpecifier, markdownTargets, linkCandidates, importSpecifiers, scriptFileTargets, documentedScripts, readsPackageFromNodeModules } from '../../scripts/verify-archive-portability.mjs';
 
 describe('bareSpecifier', () => {
   it('names the package for bare and scoped specifiers', () => {
@@ -108,5 +108,29 @@ describe('documentedScripts', () => {
 
   it('picks up nothing from prose that names no command', () => {
     expect(documentedScripts('Install the dependencies and open the page.')).toEqual([]);
+  });
+});
+
+describe('readsPackageFromNodeModules', () => {
+  // The real case: a build script assembles the path one segment at a time, so
+  // the joined package name never appears as a single string.
+  const segmented = 'ROOT / "node_modules" / "@fontsource-variable" / "inter" / "files" / "x.woff2"';
+
+  it('finds a scoped package whose path is built from separate segments', () => {
+    expect(readsPackageFromNodeModules([segmented], '@fontsource-variable/inter')).toBe(true);
+  });
+
+  it('finds a package named as one joined path', () => {
+    expect(readsPackageFromNodeModules(['open("node_modules/laz-perf/lib.wasm")'], 'laz-perf')).toBe(true);
+  });
+
+  it('does not report a package nothing reads', () => {
+    expect(readsPackageFromNodeModules([segmented], 'three')).toBe(false);
+    expect(readsPackageFromNodeModules([], '@fontsource-variable/inter')).toBe(false);
+  });
+
+  it('needs both halves of a scoped name, not either one', () => {
+    expect(readsPackageFromNodeModules(['node_modules/@fontsource-variable/roboto'], '@fontsource-variable/inter')).toBe(false);
+    expect(readsPackageFromNodeModules(['node_modules/other-scope/inter'], '@fontsource-variable/inter')).toBe(false);
   });
 });


### PR DESCRIPTION
`imports-declared` scanned only `.ts`/`.js` sources, so it reported `@fontsource-variable/inter` as declared but never imported. That is true of the import graph and false of the archive: `scripts/make-brand-rasters.py` reads `inter-latin-wght-normal.woff2` out of node_modules through fontTools to typeset the OG-card tagline, and removing the package drops the brand rasters to a DejaVu fallback.

Acting on that warning would have broken the build. It was also raised as a finding earlier in this cycle and only avoided because someone checked the Python before deleting anything.

The check now also scans shipped non-JS files that mention node_modules. The package name is looked for one half at a time for a scoped name, because the real path is assembled segment by segment — `ROOT / "node_modules" / "@fontsource-variable" / "inter" / …` — so no joined string exists to match. Requiring the file to mention node_modules at all is what stops a bare name like `three` matching unrelated prose.

Packages found this way are reported under `readByPath` in the result rather than folded silently into the imported set, so the distinction between imported and read-by-path stays visible.

`readsPackageFromNodeModules` is exported and unit-tested alongside the file's other pure helpers, with negative controls: a package nothing reads, an empty corpus, a same-scope different-package path, and a same-name different-scope path all return false.

`benchmark:archive-portability` goes from 2 warnings to 1. The remaining one is the known-benign `RELEASE_CHECKLIST.md` mention in `lint-release-truth.mjs`. 17 tests pass in that file.