### PR TITLE
Start analysis so the GPU derivatives gate runs

### DIFF
--- a/tests/e2e/gpuDerivatives.spec.ts
+++ b/tests/e2e/gpuDerivatives.spec.ts
@@ -1,131 +1,208 @@
-import { test, expect } from '@playwright/test';
-import { dropDenseGridPly } from './helpers';
-
 /**
- * REAL-GPU verification gate for the TerrainRasterEngine (deferred from the
- * Node suite — vitest has no WebGPU; there the kernels are validated via the
- * f32 transcription harness and a mock device, see
- * tests/terrainRasterEngine.test.ts / tests/gpuBackendDispatch.test.ts).
+ * gpuDerivatives.spec.ts
  *
- * What this spec asserts, on a browser that actually has WebGPU:
- *   - the engine's once-per-session equivalence probe (64×64 synthetic grid,
- *     CPU f64 reference vs WGSL f32 kernels, 1e-4 slope/aspect gate, ±1 shade)
- *     PASSES on the real device — a 'probe-mismatch' here is precisely the
- *     divergence the honesty contract forbids, so it fails loudly;
- *   - a fallback for a legitimate reason (no WebGPU, no adapter) is accepted
- *     and must be RECORDED in the compute-path telemetry.
+ * The GATE on the TerrainRasterEngine's real-WebGPU equivalence probe.
  *
- * Self-skips (honestly, with the reason) when the environment can't run it:
- * headless CI sandboxes often expose no WebGPU adapter, and the engine module
- * (whose debug hook this drives) only loads with the analysis chunk after a
- * scan is opened. Run locally with a real GPU for the verification to bite:
- *   npx playwright test tests/e2e/gpuDerivatives.spec.ts
+ * HOW THIS DIFFERS FROM backendGpuLeg.spec.ts. That spec is the recorder: it
+ * writes whatever the adapter did into a leg file and lets the comparator judge
+ * it, so a GPU that disagreed with the CPU is a finding rather than a failure.
+ * This spec is the gate: on a device that actually ran the kernels, a
+ * divergence fails the run. The two read the same hook and assert different
+ * things — the recorder never checks `probe.passed` or the error bounds, and
+ * the gate never writes a file.
+ *
+ * WHAT COUNTS AS HAVING RUN. `executedBackend` is derived by `buildBackendLeg`
+ * from the engine's own reason code, not from the fact that this spec asked for
+ * a GPU, and `gpuClaimNotCredible` refuses a GPU claim that carries no adapter
+ * descriptor read from `navigator.gpu`. Deriving it from the engine's `path`
+ * would be wrong in the one case that matters: after a probe mismatch the path
+ * is `cpu`, because falling back is the correct product behaviour, yet the GPU
+ * did run and did produce the diverging numbers.
+ *
+ * WHEN THE RUNNER HAS NO ADAPTER. Headless Chromium exposes `navigator.gpu` and
+ * returns null from `requestAdapter()`. There is nothing to gate, so the test
+ * skips — but only after the engine has been driven to a reason code, and the
+ * skip message carries that reason. It never skips because a wait quietly
+ * expired. The real leg runs headed:
+ *   npx playwright test tests/e2e/gpuDerivatives.spec.ts --project=gpu --headed
+ *
+ * @gpu — the outcome depends on the adapter the runner exposes, so this rides
+ * the advisory project rather than blocking the build.
  */
 
-interface EngineHook {
-  init(): Promise<{
-    path: 'cpu' | 'gpu';
-    reason: string;
-    probe: {
-      passed: boolean;
-      maxSlopeErr: number;
-      maxAspectErr: number;
-      maxShadeErr: number;
-      cells: number;
-      scatterExact: boolean | null;
-      scatterCells: number;
-    } | null;
-  }>;
+import { test, expect } from '@playwright/test';
+import { dropDenseGridPly } from './helpers';
+import {
+  buildBackendLeg,
+  gpuClaimNotCredible,
+  type AdapterDescriptor,
+  type EngineReason,
+} from '../../benchmarks/backends/record';
+import { currentWorkload, measurementsFrom } from '../../benchmarks/backends/leg';
+import {
+  ASPECT_GATE_RAD,
+  SCATTER_GATE,
+  SHADE_GATE_LEVELS,
+  SLOPE_GATE,
+} from '../../benchmarks/backends/tolerances';
+
+interface EngineStatus {
+  path: 'cpu' | 'gpu';
+  reason: string;
+  probe: {
+    passed: boolean;
+    cells: number;
+    comparedAspectCells: number;
+    maxSlopeErr: number;
+    maxAspectErr: number;
+    maxShadeErr: number;
+    coverageMatches: boolean;
+    scatterExact: boolean | null;
+    scatterCells: number;
+  } | null;
 }
 
-declare global {
-  interface Window {
-    __olvTerrainRasterEngine?: EngineHook;
-  }
-}
+/**
+ * The verification hook, reached through a local cast rather than a global
+ * `Window` augmentation: another spec already declares the same property with
+ * its own shape, and two augmentations of one property do not merge.
+ */
+type EngineHookWindow = {
+  __olvTerrainRasterEngine?: { init(): Promise<EngineStatus> };
+};
 
-// @gpu — the outcome depends on the WebGPU adapter the runner exposes (the
-// probe legitimately falls back on a headless sandbox), so this rides the
-// advisory project rather than blocking the build.
-test.describe('TerrainRasterEngine — real-WebGPU equivalence probe @gpu', () => {
-  test('the per-session probe passes on a real device (or falls back for a recorded reason)', async ({
-    page,
-  }) => {
-    // This test is a SEQUENCE of bounded waits (scan load, hook load, probe
-    // init), each of which honestly skips when the environment can't satisfy
-    // it. The default 30 s per-test budget is smaller than the SUM of those
-    // internal timeouts, so on a headless build where the engine hook never
-    // initialises the test budget expired BEFORE the hook-wait's own
-    // `.catch(() => skip)` could fire — surfacing as a hard timeout instead of
-    // the intended skip. Give the test room for its own guards to run; a real
-    // device finishes in a few seconds and never approaches this ceiling.
-    test.setTimeout(60_000);
+test.describe('TerrainRasterEngine — real-WebGPU equivalence gate @gpu', () => {
+  test('a GPU that ran must agree with the CPU reference', async ({ page }) => {
+    // A sequence of bounded waits — scan load, analysis start, hook load, device
+    // request. The default per-test budget is smaller than their sum.
+    test.setTimeout(90_000);
 
     await page.goto('/?test=1');
 
     const hasWebGpu = await page.evaluate(() => 'gpu' in navigator);
-    test.skip(!hasWebGpu, 'WebGPU is unavailable in this browser build');
 
-    // Load a scan so the analysis chunk (and with it the engine module +
-    // debug hook) is pulled in — the engine is not part of the boot bundle.
+    // The adapter descriptor, read from the browser rather than asserted here.
+    // A GPU claim without one is refused below.
+    const adapter = !hasWebGpu
+      ? null
+      : await page.evaluate<AdapterDescriptor | null>(async () => {
+          try {
+            const a = await navigator.gpu.requestAdapter();
+            if (!a) return null;
+            const info = a.info ?? { vendor: '', architecture: '', device: '', description: '' };
+            return {
+              vendor: info.vendor ?? '',
+              architecture: info.architecture ?? '',
+              device: info.device ?? '',
+              description: info.description ?? '',
+              features: [...a.features].sort(),
+            };
+          } catch {
+            return null;
+          }
+        });
+
+    // The engine module sits behind the terrain-analysis dynamic import, which
+    // nothing pulls in until the analysis is actually STARTED. Opening a scan
+    // mounts the Analyse panel and no more. Waiting for the hook after merely
+    // loading a scan is what made this spec skip on every runner, headed
+    // included, while reporting as a pass.
     await dropDenseGridPly(page);
     await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
+    await page.waitForTimeout(1500);
+    // The panel is revealed collapsed once a scan loads; expand it via its head.
+    const panel = page.locator('.olv-analyse-panel');
+    await expect(panel).toBeVisible({ timeout: 20_000 });
+    if (await panel.evaluate((el) => el.classList.contains('olv-collapsed'))) {
+      await panel.locator('.olv-panel-head').click();
+    }
+    await page.locator('.olv-analyse-run').click();
 
-    const hookReady = await page
-      .waitForFunction(() => window.__olvTerrainRasterEngine !== undefined, undefined, {
-        timeout: 15_000,
-      })
-      .then(() => true)
-      .catch(() => false);
-    test.skip(
-      !hookReady,
-      'terrain engine module not loaded (analysis chunk did not initialise in time)',
+    // Not a skip. Starting the analysis is what loads the engine chunk, and
+    // that does not depend on the runner's GPU — if the hook is absent here,
+    // the chunk or this spec's path through the UI is broken, and reporting
+    // that as "environment cannot run it" is how the spec went silent before.
+    await page.waitForFunction(
+      () => (window as unknown as EngineHookWindow).__olvTerrainRasterEngine !== undefined,
+      undefined,
+      { timeout: 20_000 },
     );
 
-    // init() requests a real WebGPU adapter/device. In a headless build that
-    // exposes `navigator.gpu` but has no working adapter, that request can HANG
-    // rather than reject — which would blow the whole test's 30 s budget. Race
-    // it against an in-page deadline so a non-resolving probe becomes an honest
-    // skip (the same "environment can't run it" outcome the spec documents),
-    // not a failure. A real device resolves in well under a second, so this
-    // never masks a genuine probe result.
+    // A headless build that exposes `navigator.gpu` with no working adapter can
+    // leave the device request pending rather than rejecting. Race it so a
+    // non-resolving probe becomes the engine's own `device-request-failed`
+    // rather than a timeout.
     const raced = await page.evaluate(
       () =>
         Promise.race([
-          window.__olvTerrainRasterEngine!.init(),
-          new Promise<null>((resolve) => setTimeout(() => resolve(null), 12_000)),
+          (window as unknown as EngineHookWindow).__olvTerrainRasterEngine!.init(),
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), 20_000)),
         ]),
     );
-    test.skip(
-      raced === null,
-      'WebGPU adapter/device request did not resolve in this environment (headless probe hang)',
-    );
-    const info = raced!;
+    const status: EngineStatus = raced ?? {
+      path: 'cpu',
+      reason: 'device-request-failed',
+      probe: null,
+    };
 
-    // The one outcome the honesty contract forbids: a GPU that disagrees
-    // with the CPU truth. Legitimate fallbacks remain acceptable — but they
-    // must carry their reason.
-    expect(info.reason).not.toBe('probe-mismatch');
-    expect(['gpu-active', 'webgpu-unavailable', 'device-request-failed']).toContain(info.reason);
+    // The engine must report a reason from its own vocabulary; a blank or
+    // unknown one would leave the outcome unclassifiable, and every branch
+    // below would be guessing.
+    expect([
+      'gpu-active',
+      'webgpu-unavailable',
+      'device-request-failed',
+      'probe-mismatch',
+      'gpu-dispatch-failed',
+    ]).toContain(status.reason);
 
-    if (info.path === 'gpu') {
-      // Probe evidence must exist and sit inside the equivalence gate.
-      expect(info.probe).not.toBeNull();
-      expect(info.probe!.passed).toBe(true);
-      expect(info.probe!.cells).toBe(64 * 64);
-      expect(info.probe!.maxSlopeErr).toBeLessThanOrEqual(1e-4);
-      expect(info.probe!.maxAspectErr).toBeLessThanOrEqual(1e-4);
-      expect(info.probe!.maxShadeErr).toBeLessThanOrEqual(1);
-      // Phase-2 DTM scatter (min/count) is integer-stable, so on a real
-      // device it must be EXACT — never merely close. A 'false' here is the
-      // same forbidden divergence as a derivative mismatch.
-      expect(info.probe!.scatterExact).not.toBe(false);
-      if (info.probe!.scatterExact === true) {
-        expect(info.probe!.scatterCells).toBeGreaterThan(0);
-      }
-    } else {
-      // CPU fallback: fine, silent to the user, but recorded — never blank.
-      expect(info.reason.length).toBeGreaterThan(0);
+    // `executedBackend` comes out of the engine's reason via the same function
+    // the leg recorder uses, so "did a GPU compute these numbers" is answered
+    // identically in both specs.
+    const leg = buildBackendLeg({
+      legId: 'gpu-gate',
+      environment: 'browser',
+      requestedBackend: 'gpu',
+      reason: status.reason as EngineReason,
+      path: status.path,
+      adapter,
+      commit: null,
+      workload: currentWorkload(),
+      measurements: status.probe === null ? null : measurementsFrom(status.probe),
+      runtime: 'playwright',
+    });
+
+    // A GPU claim standing on no adapter descriptor and no measurements is not
+    // evidence of anything, and is the one way this gate could report success
+    // over an empty run.
+    expect(gpuClaimNotCredible(leg)).toBeNull();
+
+    if (leg.executedBackend !== 'gpu') {
+      test.skip(
+        true,
+        `backend-unavailable: no GPU executed the probe (engine reason: ${status.reason}, adapter: ${adapter === null ? 'none' : adapter.vendor || 'unnamed'})`,
+      );
+      return;
     }
+
+    // From here a real device ran the kernels, so the equivalence contract is
+    // in force. A mismatch is the divergence the honesty contract forbids.
+    expect(status.reason).not.toBe('probe-mismatch');
+    expect(status.reason).not.toBe('gpu-dispatch-failed');
+    expect(status.reason).toBe('gpu-active');
+
+    const probe = status.probe!;
+    expect(probe.passed).toBe(true);
+    expect(probe.cells).toBe(64 * 64);
+    expect(probe.comparedAspectCells).toBeGreaterThan(0);
+    expect(probe.coverageMatches).toBe(true);
+    expect(probe.maxSlopeErr).toBeLessThanOrEqual(SLOPE_GATE);
+    expect(probe.maxAspectErr).toBeLessThanOrEqual(ASPECT_GATE_RAD);
+    expect(probe.maxShadeErr).toBeLessThanOrEqual(SHADE_GATE_LEVELS);
+    // Phase-2 DTM scatter (min/count) is integer-stable, so on a real device it
+    // must be EXACT — never merely close.
+    expect(SCATTER_GATE).toBe(0);
+    expect(probe.scatterExact).toBe(true);
+    expect(probe.scatterCells).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
The spec waited for `window.__olvTerrainRasterEngine` after loading a scan. That hook is behind the terrain-analysis dynamic import, which nothing pulls in until analysis starts. The wait always expired and the spec skipped, on every runner including headed.

It now drives the Analyse panel, derives `executedBackend` from the engine's reason code through `buildBackendLeg`, and asserts `gpuClaimNotCredible` is null so a GPU claim without an adapter descriptor is refused. Bounds come from `benchmarks/backends/tolerances.ts` instead of hardcoded values. The hook wait is now a failure, not a skip.

Headless reports `backend-unavailable` with the engine's reason. Headed runs the full assertion block.

Mutation: a 0.1 % error injected into the WGSL Horn kernel fails the new spec at `expect(status.reason).not.toBe('probe-mismatch')`; the old spec exited 0 and skipped. Reverted.

Not redundant with `backendGpuLeg.spec.ts`, which records a leg and checks no bounds. This is the gate.

No `src/` changes. typecheck 0; headed 1 passed, headless 1 skipped; `tests/e2e/ --project=deterministic` 161 passed, 4 skipped.