### PR TITLE
Date the v0.6.2 entry 27 July

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The format is based on Keep a Changelog and the project follows Semantic Versioning.
 
-## [0.6.2] - 2026-07-26
+## [0.6.2] - 2026-07-27
 
 A validation-and-correction release. Ten validation suites were added, covering
 reproducibility, scaling, cross-platform portability, GPU-versus-CPU backend


### PR DESCRIPTION
Publication date for v0.6.2.

`CITATION.cff` `date-released` stays on the v0.6.1 date until the version bump, which `lint:release-sync` requires to match the changelog entry for the version in `package.json`. Both move together at release.