### PR TITLE
Correct the defect composition figures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ A validation-and-correction release. Ten validation suites were added, covering
 reproducibility, scaling, cross-platform portability, GPU-versus-CPU backend
 equivalence, failure recovery, provenance integrity, contour correctness, LAS
 round-trip fidelity, unit integrity and archive portability. Eighteen defects
-are fixed: four carried from the v0.6.1 vertical-unit audit, fourteen found by
-the new suites. The evidence ceiling moves from one cross-implemented product to
+are fixed. Twelve were exposed by a validation suite; six came from code review,
+five of those carried from the v0.6.1 vertical-unit audit. Every one was missed
+by the test suite as it stood at v0.6.1, which passes on the defective code.
+Per-defect records are in `validation/defects/defect-registry.json`.
+The evidence ceiling moves from one cross-implemented product to
 three, with aspect and hillshade joining slope at E4 against GDAL 3.13.1 on the
 shared analytic DEM. The reproducibility comparator and its two-platform CI
 matrix, darwin-arm64 and linux-x64, are in place, and the two-platform result is

--- a/KNOWN_LIMITATIONS_v0.6.2.md
+++ b/KNOWN_LIMITATIONS_v0.6.2.md
@@ -1,6 +1,6 @@
 # Known limitations: OpenLiDARViewer v0.6.2
 
-This is a validation-and-correction release. Ten validation suites were added, eighteen defects were fixed, and four defects that reached published v0.6.1 output are corrected. The limits below are the v0.6.1 limits with the closed items removed, plus what the new suites named as uncovered. They are recorded here rather than hidden, in keeping with the project's honesty contract.
+This is a validation-and-correction release. Ten validation suites were added, eighteen defects were fixed, and four defects that reached published v0.6.1 output are corrected. Twelve of the eighteen were exposed by a validation suite and six by code review. The limits below are the v0.6.1 limits with the closed items removed, plus what the new suites named as uncovered.
 
 Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.md`. One of them is a correction to the previous version of this file: its scope statement for the `geodesicFill` unit-mixing defect was wrong.
 


### PR DESCRIPTION
The CHANGELOG said four carried defects and fourteen found by the new suites. The registry establishes twelve exposed by a validation suite and six by code review, five of those carried from the v0.6.1 audit. The total of eighteen is unchanged.

Also states that all eighteen were missed by the v0.6.1 suite, established by running it: exit 0, 6182 tests passed on the defective code.

Dropped a sentence in KNOWN_LIMITATIONS that described the authors rather than the software.

Six release lints pass.