### PR TITLE
Document signature and asset verification

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -11,19 +11,57 @@ with:
 - the affected version or commit.
 
 You can expect an acknowledgement and, where applicable, a fix or mitigation
-plan.
+plan. This is a single-maintainer project, so a report may sit for a few days
+before it gets a considered reply rather than a fast one, and a fix that
+changes measured output has to clear the release gate before it ships. If a
+report affects data a user already exported, the fix is published with an
+erratum describing what changed and how to tell whether your own output was
+affected.
+
+## Verifying what you received
+
+Commits on `main` are signed with an SSH key registered to the maintainer's
+GitHub account, so a commit carries evidence of who wrote it rather than only
+a name and address that anyone can set. To check one locally:
+
+```bash
+git verify-commit <sha>
+```
+
+GitHub shows the same result as a Verified badge beside the commit. An
+unsigned commit, or one signed by a key the account does not hold, will not
+carry that badge.
+
+Release assets are verified as a set rather than one file at a time:
+
+```bash
+shasum -a 256 -c SHA256SUMS
+npm run release:verify -- --dir <downloaded-assets>
+```
+
+`release:verify` walks the chain the release manifest records, from the tag to
+the commit to each asset digest, and fails if any link disagrees. Release tags
+cannot be moved or deleted once published, so a published citation keeps
+pointing at the bytes it was issued against. If you are checking a release for
+the first time, run both commands: the checksums prove the files arrived
+intact, and `release:verify` proves they belong to the release they claim.
 
 ## Local-first data handling
 
 OpenLiDARViewer is designed around local-first inspection. Scan files are read,
-parsed, and rendered entirely in the browser — there is no server to upload
+parsed, and rendered entirely in the browser, and there is no server to upload
 them to. The security of
 your data also depends on how and where you choose to deploy and run the app.
 
 ## Supported versions
 
 OpenLiDARViewer is an R&D-stage project. Security fixes are applied to the
-latest version on the default branch.
+latest version on the default branch, and there is no long-term support branch
+for older releases. Older tagged releases stay published and verifiable, since
+the archived assets are what a citation points at, but they do not receive
+backported fixes. If you depend on a specific version for a published result,
+cite that version and record the commit rather than expecting it to be
+maintained.
 
 | Version | Supported |
 |---|---|


### PR DESCRIPTION
Adds a verifying section to `SECURITY.md`: `git verify-commit` for authorship, and the checksum plus `release:verify` pair for the asset set, with what each proves.

- records that release tags are immutable once published;
- supported versions states that older tags stay verifiable but receive no backported fixes;
- reporting section states what a single maintainer can promise.

First PR through the new branch ruleset. Commits are signed.