### PR TITLE
Build provenance attestation for release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,11 +215,34 @@ jobs:
     if: github.ref_type == 'tag'
     permissions:
       contents: write
+      # Sigstore identifies this workflow by an OIDC token rather than a key
+      # this repository holds, so there is nothing to store or rotate.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-assets
           path: assets
+
+      # The manifest already proves the asset set agrees with itself: tag,
+      # commit and per-asset digest all match. It cannot prove where the bytes
+      # came from, because this repository generates it, and a consistent
+      # manifest can be regenerated for substituted assets. Provenance is
+      # signed against a public transparency log instead, so a reader can
+      # establish that an archive was produced by this workflow at this commit
+      # without trusting anything published alongside it.
+      #
+      # Only the archives and the SBOM are attested. SHA256SUMS and the
+      # manifest are statements ABOUT those files; attesting a checksum of an
+      # attested file establishes nothing further.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            assets/**/openlidarviewer-*.zip
+            assets/**/sbom.json
+
       - name: Create the draft release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The format is based on Keep a Changelog and the project follows Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+
+- Build provenance attestation for release archives and the SBOM. The release
+  workflow signs a SLSA provenance statement through Sigstore, binding each
+  archive to the workflow run and commit that produced it. Verify a downloaded
+  archive with `gh attestation verify <file> --repo Aurtechmx/openlidarviewer`.
+  This applies from the next release onward; assets published for v0.6.2 and
+  earlier carry no attestation, and `release:verify` remains the check for
+  those.
+
 ## [0.6.2] - 2026-07-27
 
 A validation-and-correction release. Twelve validation suites were added, covering


### PR DESCRIPTION
Signs a SLSA provenance statement for the release archives and `sbom.json` through Sigstore, binding each to the workflow run and commit that produced it.

```bash
gh attestation verify <file> --repo Aurtechmx/openlidarviewer
```

- keyless: identity comes from an OIDC token, so there is no key to store or rotate;
- `publish` gains `id-token: write` and `attestations: write`;
- `SHA256SUMS` and the manifest are excluded, being statements about the attested files;
- action pinned to v4.1.1 by digest.

Applies from the next release. Already-published assets carry no attestation, and the changelog says so.

Touches `release.yml`, which the pending mutation-gate branch also edits. The two change different sections.