### PR TITLE
Regex metacharacter escaping and null-prototype class maps

### DIFF
--- a/scripts/lint-release-sync.mjs
+++ b/scripts/lint-release-sync.mjs
@@ -22,6 +22,7 @@
  */
 
 import { execSync } from 'node:child_process';
+import { escapeRegExp } from './regex-escape.mjs';
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -66,7 +67,7 @@ if (!m) problems.push('README.md has no "current release is **vX.Y.Z**" line to 
 else if (m[1] !== version) problems.push(`README.md says current release v${m[1]}, expected v${version}.`);
 
 // 3. CHANGELOG section — present, DATED, and not a work-in-progress stub.
-const escaped = version.replace(/\./g, '\\.');
+const escaped = escapeRegExp(version);
 const changelog = read('CHANGELOG.md');
 const heading = changelog.match(new RegExp(`^## \\[${escaped}\\][^\\n]*`, 'm'));
 let changelogDate = null;

--- a/scripts/regex-escape.mjs
+++ b/scripts/regex-escape.mjs
@@ -1,0 +1,14 @@
+/**
+ * Escape every regular-expression metacharacter in a literal string.
+ *
+ * Several gates build a RegExp around a version number to find a heading or an
+ * archive name. Those call sites escaped `.` and nothing else, which is correct
+ * for the versions shipped so far and silently wrong for any that carries a
+ * metacharacter: a `+build` suffix would make the `+` a quantifier, and the
+ * gate would stop matching the heading it exists to check rather than report a
+ * failure. Escaping the full set removes the class of bug instead of the one
+ * instance of it.
+ */
+export function escapeRegExp(literal) {
+  return String(literal).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/validation-snapshot-lib.mjs
+++ b/scripts/validation-snapshot-lib.mjs
@@ -16,6 +16,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { escapeRegExp } from './regex-escape.mjs';
 
 /** The inputs the snapshot collects, in report order. */
 export const INPUTS = Object.freeze([
@@ -426,7 +427,7 @@ export function deriveIdentity(read, has) {
   } else {
     add('buildIdentityVersion', buildMetaPath, buildMeta.version ?? null);
     const name = buildMeta.artifacts?.source?.file ?? null;
-    const expected = candidate ? new RegExp(`^openlidarviewer-v${candidate.replace(/\./g, '\\.')}-source-`) : null;
+    const expected = candidate ? new RegExp(`^openlidarviewer-v${escapeRegExp(candidate)}-source-`) : null;
     add('archiveName', buildMetaPath, name, {
       status: name == null ? 'not-executed' : expected.test(name) ? 'agrees' : 'disagrees',
       note: name == null ? 'the build identity records no source archive' : null,
@@ -439,7 +440,7 @@ export function deriveIdentity(read, has) {
     changelogText == null || citationVersion == null
       ? null
       : changelogText.match(
-          new RegExp(`^##\\s*\\[${citationVersion.replace(/\./g, '\\.')}\\]\\s*-\\s*(\\d{4}-\\d{2}-\\d{2})`, 'm'),
+          new RegExp(`^##\\s*\\[${escapeRegExp(citationVersion)}\\]\\s*-\\s*(\\d{4}-\\d{2}-\\d{2})`, 'm'),
         )?.[1] ?? null;
   const dates = {
     citationVersion,

--- a/scripts/verify-archive-portability.mjs
+++ b/scripts/verify-archive-portability.mjs
@@ -31,6 +31,7 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, statSync, mkdirSync, rmSync, mkdtempSync } from 'node:fs';
+import { escapeRegExp } from './regex-escape.mjs';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { resolve, dirname, join, relative, posix } from 'node:path';
@@ -514,7 +515,7 @@ check('version-coherence', 'package.json, the citation file, the changelog and t
   }
   const changelog = c.read('CHANGELOG.md');
   if (changelog == null) f.push({ level: 'error', message: 'CHANGELOG.md is not in the archive.' });
-  else if (!new RegExp(`^##\\s*\\[${v.replace(/\./g, '\\.')}\\]`, 'm').test(changelog)) {
+  else if (!new RegExp(`^##\\s*\\[${escapeRegExp(v)}\\]`, 'm').test(changelog)) {
     f.push({ level: 'error', message: `CHANGELOG.md has no released section for ${v}.` });
   }
   for (const doc of [`RELEASE_NOTES_v${v}.md`, `KNOWN_LIMITATIONS_v${v}.md`, `VALIDATION_REPORT_v${v}.md`, `REPRODUCIBILITY_v${v}.md`]) {
@@ -530,7 +531,7 @@ check('version-coherence', 'package.json, the citation file, the changelog and t
   // A CITATION date must match the changelog entry for the same version.
   if (cff && changelog) {
     const cffDate = cff.match(/^date-released:\s*"?([\d-]+)"?/m)?.[1];
-    const clDate = changelog.match(new RegExp(`^##\\s*\\[${v.replace(/\./g, '\\.')}\\]\\s*-\\s*([\\d-]+)`, 'm'))?.[1];
+    const clDate = changelog.match(new RegExp(`^##\\s*\\[${escapeRegExp(v)}\\]\\s*-\\s*([\\d-]+)`, 'm'))?.[1];
     if (cffDate && clDate && cffDate !== clDate) {
       f.push({ level: 'error', message: `CITATION.cff date-released ${cffDate} disagrees with the CHANGELOG entry for ${v} (${clDate}).` });
     }

--- a/src/render/class/deriveClassification.ts
+++ b/src/render/class/deriveClassification.ts
@@ -584,14 +584,18 @@ export function deriveClassification(
 
   // Counts + per-class support accumulation over the FINAL codes, so the legend
   // totals and the per-class confidence both match what is rendered.
-  const counts: Record<number, number> = {};
-  const classSupportSum: Record<number, number> = {};
+  // Null-prototype: the keys are classification codes read from the file, and
+  // a plain object literal would resolve inherited names on lookup. The codes
+  // are numeric, so this is defence rather than a fix, but two registries in
+  // this release shipped with exactly that collision.
+  const counts: Record<number, number> = Object.create(null) as Record<number, number>;
+  const classSupportSum: Record<number, number> = Object.create(null) as Record<number, number>;
   for (let i = 0; i < count; i++) {
     const c = codes[i];
     counts[c] = (counts[c] ?? 0) + 1;
     classSupportSum[c] = (classSupportSum[c] ?? 0) + support[i];
   }
-  const classConfidence: Record<number, number> = {};
+  const classConfidence: Record<number, number> = Object.create(null) as Record<number, number>;
   for (const k of Object.keys(counts)) {
     const c = Number(k);
     classConfidence[c] = counts[c] > 0 ? classSupportSum[c] / counts[c] : 0;


### PR DESCRIPTION
Two changes from the CodeQL triage. Neither is a live vulnerability; both remove a class of defect.

**Version patterns.** Five gates built a `RegExp` around a version by escaping `.` and nothing else. Correct for every version shipped so far, wrong for any carrying a metacharacter: a `+build` suffix makes the `+` a quantifier and the gate silently stops matching the heading it exists to check.

```
old: new RegExp('^1.0.0+b.1$')  -> does not match '1.0.0+b.1'
new: escapeRegExp('1.0.0+b.1')  -> matches
```

`scripts/regex-escape.mjs` escapes the full set; the five call sites use it.

**Classification maps.** Null-prototype. Keys are numeric codes read from the file, so this is defence rather than a fix, but two registries in this release shipped with a prototype-key collision.

Verified: `tsc` 0, unit suite 1106 passed, archive-portability 12 passed, four document gates 0.