### PR TITLE
Close the three surviving registered mutations

### DIFF
--- a/scripts/verify-archive-portability.mjs
+++ b/scripts/verify-archive-portability.mjs
@@ -130,6 +130,30 @@ export function documentedScripts(text) {
   return [...text.matchAll(/npm run ([a-z0-9][a-z0-9:_-]*)/g)].map((m) => m[1]);
 }
 
+/**
+ * The repository paths MANIFEST.md declares the archive to carry.
+ *
+ * MANIFEST.md is the archive's own inventory: every document it names in a
+ * code span is a promise to the reader that the file is in the deposit. The
+ * tokens are taken literally — one code span, no spaces, path characters only
+ * — so prose in code spans (`npm run gate`, a version string with a space)
+ * never enters the list. A trailing slash marks a directory and is kept, so
+ * the caller can tell "this file ships" from "something under here ships".
+ *
+ * Release-asset names such as `release-manifest-v0.6.2.json` come out of here
+ * too; the caller drops anything the repository does not track, because a file
+ * that is not in the tree cannot have been export-ignored out of the archive.
+ */
+export function manifestInventoryPaths(text) {
+  const out = new Set();
+  for (const m of text.matchAll(/`([^`\n]+)`/g)) {
+    const tok = m[1].trim();
+    if (!/^[A-Za-z0-9][\w.@-]*(?:\/[\w.@-]+)*\/?$/.test(tok)) continue;
+    out.add(tok);
+  }
+  return [...out];
+}
+
 // ── archive acquisition ──────────────────────────────────────────────────────
 
 function listFiles(root, base = root) {
@@ -349,7 +373,13 @@ check('no-dangling-references-to-excluded', 'nothing that ships references a fil
       f.push({ level: 'error', message: `${md} ${kind === 'include' ? 'includes' : 'links to'} ${target}, ${why}.` });
     }
   }
-  const codeFiles = c.files.filter((p) => /\.(ts|mts|mjs|js|sh|json|yaml|yml)$/.test(p));
+  // Markdown is scanned here as well as through its links. A shipped document
+  // that names an excluded file in prose or in a code span — no link syntax
+  // around it — used to be read by neither loop: `markdownTargets` only sees
+  // link and include syntax, and this scan only saw source and tooling. That
+  // is exactly how a governing document can be export-ignored while three
+  // shipped files still tell the reader to go and read it.
+  const codeFiles = c.files.filter((p) => /\.(ts|mts|mjs|js|sh|json|yaml|yml|md)$/.test(p));
   for (const p of excluded) {
     if (p === '.gitattributes') continue;
     for (const cf of codeFiles) {
@@ -360,6 +390,53 @@ check('no-dangling-references-to-excluded', 'nothing that ships references a fil
     }
   }
   return { findings: f, detail: { excludedCount: excluded.length, excluded } };
+}, { needsRepo: true });
+
+/**
+ * The archive against its own inventory.
+ *
+ * The dangling-reference check above answers "does anything shipped point at
+ * something absent", which degrades to a warning for a prose mention and so
+ * cannot, on its own, fail a release. This one asks the stronger question the
+ * deposit actually makes: MANIFEST.md tells a reader what the archive holds,
+ * so every path it names that the repository TRACKS must be in the archive.
+ * Tracked-but-absent is one thing and one thing only — an export-ignore that
+ * deleted a declared document — and it is an error, never a warning.
+ *
+ * Untracked names are skipped rather than flagged: `SHA256SUMS` and the
+ * per-release manifest are attached to the release, not committed, so their
+ * absence from a source archive is correct.
+ */
+check('manifest-inventory-ships', 'every tracked path MANIFEST.md declares is in the archive', (c) => {
+  const f = [];
+  const text = c.read('MANIFEST.md');
+  if (text === null) return [{ level: 'error', message: 'MANIFEST.md is not in the archive.' }];
+  const tracked = git(['ls-files']).split('\n').filter(Boolean);
+  const trackedFiles = new Set(tracked);
+  const trackedDirs = new Set();
+  for (const p of tracked) {
+    const parts = p.split('/');
+    for (let i = 1; i < parts.length; i++) trackedDirs.add(parts.slice(0, i).join('/'));
+  }
+  const declared = [];
+  for (const tok of manifestInventoryPaths(text)) {
+    const p = tok.replace(/\/$/, '');
+    if (trackedFiles.has(p)) {
+      declared.push({ token: tok, kind: 'file' });
+      if (!c.set.has(p)) {
+        f.push({ level: 'error', message: `MANIFEST.md declares ${tok}, which the repository tracks but the archive does not carry.` });
+      }
+    } else if (trackedDirs.has(p)) {
+      declared.push({ token: tok, kind: 'directory' });
+      if (!c.files.some((q) => q.startsWith(`${p}/`))) {
+        f.push({ level: 'error', message: `MANIFEST.md declares ${tok}, which the repository tracks but the archive carries nothing from.` });
+      }
+    }
+  }
+  if (declared.length === 0) {
+    f.push({ level: 'error', message: 'MANIFEST.md declares no tracked path at all — the inventory check has nothing to verify.' });
+  }
+  return { findings: f, detail: { declared } };
 }, { needsRepo: true });
 
 // ── 3. doc-link integrity across everything that ships ───────────────────────

--- a/tests/benchmark/archivePortability.test.ts
+++ b/tests/benchmark/archivePortability.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error — plain .mjs tooling module, no type declarations
-import { bareSpecifier, markdownTargets, linkCandidates, importSpecifiers, scriptFileTargets, documentedScripts, readsPackageFromNodeModules } from '../../scripts/verify-archive-portability.mjs';
+import { bareSpecifier, markdownTargets, linkCandidates, importSpecifiers, scriptFileTargets, documentedScripts, manifestInventoryPaths, readsPackageFromNodeModules } from '../../scripts/verify-archive-portability.mjs';
 
 describe('bareSpecifier', () => {
   it('names the package for bare and scoped specifiers', () => {
@@ -108,6 +108,31 @@ describe('documentedScripts', () => {
 
   it('picks up nothing from prose that names no command', () => {
     expect(documentedScripts('Install the dependencies and open the page.')).toEqual([]);
+  });
+});
+
+describe('manifestInventoryPaths', () => {
+  it('reads the documents and directories a manifest declares', () => {
+    const text = [
+      '- `POLICY_DOCUMENT.md`: the canonical policy.',
+      '- `docs/validation/test-evidence.json`: development runs.',
+      '- `src/`: application source.',
+      'MIT. See `LICENSE`.',
+    ].join('\n');
+    expect(manifestInventoryPaths(text)).toEqual([
+      'POLICY_DOCUMENT.md',
+      'docs/validation/test-evidence.json',
+      'src/',
+      'LICENSE',
+    ]);
+  });
+
+  it('reads nothing out of a code span that is prose rather than a path', () => {
+    expect(manifestInventoryPaths('Run `npm run gate` and read `the notes`.')).toEqual([]);
+  });
+
+  it('does not join a code span that spans a line break', () => {
+    expect(manifestInventoryPaths('walks `npm run\nrelease:verify` from the tag.')).toEqual([]);
   });
 });
 

--- a/tests/benchmark/contourCorrectness.test.ts
+++ b/tests/benchmark/contourCorrectness.test.ts
@@ -410,6 +410,47 @@ describe('contour correctness — topological invariants', () => {
     expect(diagonalCrossings(2.99)).toBe(2); // level > z*: high corners isolated
   });
 
+  it('an ambiguous cell whose saddle value equals the level joins the high corners', () => {
+    // The boundary of the saddle rule, at the one level where `≥` and `>`
+    // disagree. Corners (BL, BR, TR, TL) = (2, 0, 2, 0) give
+    //   z* = (v0·v2 − v1·v3) / (v0 + v2 − v1 − v3) = (2·2 − 0·0) / (2 + 2) = 1
+    // exactly: every input is a dyadic rational, exact in float32 storage and
+    // in the float64 arithmetic above it, so the equality z* == 1 is a
+    // property of the fixture and not of rounding. The three levels below
+    // bracket it — 0.75 under z*, 1 on it, 1.25 over it — so the test pins the
+    // transition rather than one point on one side of it. None of the three
+    // coincides with a corner value, so no crossing degenerates onto a corner.
+    const zByIndex = [2, 0, 0, 2]; // row-major: [BL, BR], [TL, TR]
+    const dtm = surfaceGrid((col, row) => zByIndex[row * 2 + col], {
+      cols: 2,
+      rows: 2,
+      cellSizeM: CELL,
+    });
+    const zStar = (2 * 2 - 0 * 0) / (2 + 2 - 0 - 0);
+    const diagonalCrossings = (level: number) => {
+      const set = contoursAt(dtm, { intervalM: 1, levels: [level] });
+      let n = 0;
+      for (const s of set.levels[0].segments) {
+        if (
+          properlyIntersect(
+            { x: 0.5, y: 0.5 }, // BL cell centre (one high corner)
+            { x: 1.5, y: 1.5 }, // TR cell centre (the other high corner)
+            { x: s.x1, y: s.y1 },
+            { x: s.x2, y: s.y2 },
+          )
+        ) {
+          n += 1;
+        }
+      }
+      return n;
+    };
+    // Stated as an exact equality, because that is the condition under test.
+    expect(zStar === 1).toBe(true);
+    expect(diagonalCrossings(0.75)).toBe(0); // level < z*: high corners joined
+    expect(diagonalCrossings(1)).toBe(0); // level == z*: the tie joins them too
+    expect(diagonalCrossings(1.25)).toBe(2); // level > z*: high corners isolated
+  });
+
   it('connectivity changes at the col: one ring below it, two above', () => {
     // Two Gaussian peaks joined by a col at z ≈ 4.53. Below the col the
     // {z ≥ level} region is one connected component, so its boundary is a

--- a/tests/benchmark/runnerOutput.test.ts
+++ b/tests/benchmark/runnerOutput.test.ts
@@ -20,7 +20,7 @@ import type { ReproducibilityConfig, ScalingConfig } from '../../benchmarks/runn
 import { runReproducibilitySuite } from '../../benchmarks/runner/reproducibility';
 import { runScalingSuite } from '../../benchmarks/runner/scaling';
 import { archiveStamp, writeResults } from '../../benchmarks/runner/writer';
-import { verifyArchives, verifyResultsDir } from '../../benchmarks/runner/verify';
+import { requiredFiles, verifyArchives, verifyResultsDir } from '../../benchmarks/runner/verify';
 import {
   overviewMarkdown,
   reproducibilityCsv,
@@ -500,6 +500,57 @@ describe('the verifier', () => {
     const outcome = verifyResultsDir(latest);
     expect(outcome.ok).toBe(false);
     expect(outcome.problems.join('\n')).toMatch(/scaling\/summary\.md/);
+  });
+
+  test('the required-file list covers every top-level artifact the writer emits', () => {
+    // Pinned as a set, not as a membership test, because the failure mode is
+    // silent subtraction: a name dropped from the list stops being required
+    // and nothing else in the tree notices, since every suite here writes the
+    // file anyway. The suite-conditional entries are derived from the manifest
+    // the publish actually produced.
+    const { latest } = publish();
+    const manifest = JSON.parse(readFileSync(join(latest, 'manifest.json'), 'utf8'));
+    const required = requiredFiles(manifest);
+    expect(required.slice(0, 4)).toEqual([
+      'manifest.json',
+      'environment.json',
+      'summary.md',
+      'summary.html',
+    ]);
+    expect([...required].sort()).toEqual(
+      [
+        'manifest.json',
+        'environment.json',
+        'summary.md',
+        'summary.html',
+        'reproducibility/raw.json',
+        'reproducibility/runs.csv',
+        'reproducibility/summary.json',
+        'reproducibility/summary.md',
+        'reproducibility/artifacts/science-hashes.json',
+        'scaling/raw.json',
+        'scaling/runs.csv',
+        'scaling/summary.json',
+        'scaling/summary.md',
+      ].sort(),
+    );
+  });
+
+  test('catches summary.html removed from the tree and from the listing', () => {
+    // The rendered overview page is the artifact a reader is most likely to
+    // open and the one least likely to be missed by eye, so its absence has to
+    // be reported by the required-file list itself — not only by the
+    // re-rendering check, which a tree could dodge by dropping the entry.
+    const { latest } = publish();
+    const manifestPath = join(latest, 'manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.files = manifest.files.filter((f: { path: string }) => f.path !== 'summary.html');
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    rmSync(join(latest, 'summary.html'));
+
+    const outcome = verifyResultsDir(latest);
+    expect(outcome.ok).toBe(false);
+    expect(outcome.problems).toContain('summary.html: required file is missing');
   });
 
   test('catches an edited number in the top-level summary.md', () => {


### PR DESCRIPTION
The saddle-tie, required-artifact and archive-inventory mutations survived the full gate at v0.6.2 and were recorded as gaps rather than passes. Each now has a test that fails when the mutation is applied.

- contour saddle rule: exact-equality boundary;
- benchmark artifacts: `summary.html` removal from the required set;
- archive inventory: omission of a document that shipped Markdown still references.

Archive portability goes from 12 checks to 13.

Verified: `tsc` 0, unit 1106 passed, benchmark 644 passed, archive-portability 13 passed.