### PR TITLE
Defer the mutation stage to a scheduled workflow and cite its result

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,93 @@
+name: Mutation
+
+# Mutation testing over the numeric core, on a schedule instead of on every
+# tag. It measured about two hours of the v0.6.2 release gate's 2 h 20 m, over
+# three modules that most releases do not touch, and paying that per tag bought
+# nothing a weekly run does not. The release record no longer reproduces this
+# measurement; it CITES it, naming the score, the commit it was measured at,
+# and this workflow run.
+#
+# So the committed record is the product of this workflow, not a side effect:
+# `docs/validation/mutation-evidence.json` is written here and pushed back to
+# the default branch, which is where `collect-evidence.mjs` reads it from when
+# the gate did not run the stage itself.
+#
+# This fails, it does not merely report. `stryker.conf.json` sets break: 75
+# against a measured 87.23; the runner breaks on it and
+# collect-mutation-evidence.mjs latches the same threshold a second time, so a
+# regression is a red run whether or not the runner's exit code survives.
+on:
+  schedule:
+    # 04:00 UTC every Monday — a full run costs about two hours, and the point
+    # is to catch a weakening within a week of it landing, not within an hour.
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One mutation run at a time. Two concurrent runs would race to push the same
+# evidence file, and the loser's measurement would vanish without a trace.
+concurrency:
+  group: mutation
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    # Measured basis: 188 mutants over the numeric core at ~174 tests each ran
+    # in roughly 2 h inside the v0.6.2 release gate on this runner class. 180
+    # minutes is that figure with headroom; it is the budget the release gate
+    # used to have to carry.
+    timeout-minutes: 180
+    permissions:
+      # Only to push the evidence file back to the default branch.
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+      - run: npm ci
+      - name: Lockfile is unchanged by a clean install
+        run: git diff --exit-code -- package-lock.json
+
+      # Stryker's break threshold makes this step the pass/fail signal. The
+      # evidence step below re-checks the same threshold, so neither a
+      # swallowed exit code nor a loosened runner config can turn a regression
+      # into a green run.
+      - name: Mutation run
+        run: npm run mutation
+
+      - name: Record the score, the commit, and this run
+        run: node scripts/collect-mutation-evidence.mjs
+
+      - name: Publish the mutation reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-reports
+          retention-days: 90
+          path: |
+            reports/mutation/
+            docs/validation/mutation-evidence.json
+
+      # Only from the default branch, and only when the figure actually moved.
+      # A dispatch against a feature branch still produces the artifact above;
+      # what it must not do is publish a measurement of that branch as the one
+      # every release cites.
+      - name: Commit the evidence to the default branch
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain -- docs/validation/mutation-evidence.json)" ]; then
+            echo "Mutation evidence is unchanged; nothing to commit."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add docs/validation/mutation-evidence.json
+          SCORE="$(node -p "require('./docs/validation/mutation-evidence.json').score")"
+          git commit -m "Record mutation score ${SCORE} from run ${GITHUB_RUN_ID}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,19 +59,24 @@ jobs:
         run: node scripts/validate-release-ref.mjs
 
   # ── Every mandatory stage, one log, one record ────────────────────────────
-  # Static gate, e2e, docs build, production audit, fixture checksums,
-  # coverage and mutation all run here, in release mode, into one gate.log.
-  # The evidence is derived from that log's stage markers, so a stage that
-  # did not run cannot be described as passed. Packaging happens in the SAME
-  # job on the SAME still-clean checkout.
+  # Static gate, e2e, docs build, production audit, fixture checksums and
+  # coverage all run here, in release mode, into one gate.log. The evidence is
+  # derived from that log's stage markers, so a stage that did not run cannot
+  # be described as passed. Mutation is not among them: it runs on its own
+  # schedule (mutation.yml) and the record cites its last result, naming the
+  # commit that result was measured at. Packaging happens in the SAME job on
+  # the SAME still-clean checkout.
   gate:
     runs-on: ubuntu-latest
     needs: validate
-    # The mutation stage runs 188 mutants over the numeric core at ~174 tests
-    # each, about an hour on this runner class, and coverage precedes it. The
-    # 90 minute budget fitted only while a TypeScript 7 incompatibility made
-    # Stryker exit in seconds; a run that finishes needs the larger one.
-    timeout-minutes: 300
+    # Measured basis: the v0.6.2 release gate took 2 h 20 m wall clock, of
+    # which the mutation stage — 188 mutants over the numeric core at ~174
+    # tests each — was roughly 2 h. Removing it leaves about 20 minutes of
+    # gate, plus npm ci, the Playwright install and packaging. 60 minutes is
+    # that measurement with room for a slow runner, and it is short enough that
+    # a hung stage is caught the same day rather than five hours later. The
+    # scheduled mutation workflow carries its own, larger budget.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,40 @@ The format is based on Keep a Changelog and the project follows Semantic Version
   earlier carry no attestation, and `release:verify` remains the check for
   those.
 
+### Changed
+
+- Mutation testing moved out of the tag-time gate. It ran roughly two hours of
+  the v0.6.2 release gate's 2 h 20 m, against three numeric modules, and forced
+  the gate job's timeout from 90 to 300 minutes. It now runs weekly and on
+  demand in `.github/workflows/mutation.yml`. The release gate's timeout is
+  back to 60 minutes, which is the twenty minutes the remaining stages measured
+  plus headroom.
+- The release record cites the mutation result instead of reproducing it.
+  `mutation` left `MANDATORY_RELEASE_STAGES` and joined a new
+  `DEFERRED_RELEASE_STAGES`. A deferred stage is always written into the record
+  as `not-executed` rather than left out, and the record carries the score, the
+  break threshold, the commit the score was measured at, and the workflow run
+  that produced it. `coversReleaseCommit` states whether that commit is the
+  release commit; where it is not, the record and the manifest say so instead
+  of implying currency. Evidence schema version 2 becomes 3.
+- A release record with no mutation result to cite, or one whose cited score
+  sits under the `break: 75` threshold, is refused. `release:verify` repeats
+  both checks against the shipped assets. It also gained an `advisories`
+  channel for statements that are true without being defects, such as a cited
+  score that predates the release commit.
+- `scripts/collect-mutation-evidence.mjs` recomputes the score from Stryker's
+  JSON report and re-checks the threshold, so a regression fails the scheduled
+  run even where the runner's exit code is lost.
+
+### Notes
+
+- `docs/validation/mutation-evidence.json` is produced by the Mutation
+  workflow; the repository does not ship a seeded copy, because there is no
+  honest way to write one without running the measurement. Dispatch that
+  workflow once before the next tag, or run the release gate with
+  `OLV_GATE_MUTATION=1`, which runs the stage inline and cites the release
+  commit directly.
+
 ## [0.6.2] - 2026-07-27
 
 A validation-and-correction release. Twelve validation suites were added, covering

--- a/scripts/collect-evidence.mjs
+++ b/scripts/collect-evidence.mjs
@@ -100,8 +100,25 @@ export const MANDATORY_RELEASE_STAGES = [
   'productionAudit',
   'fixtureChecksums',
   'coverage',
-  'mutation',
 ];
+
+/**
+ * Stages a release run may legitimately NOT execute, provided the record
+ * carries the out-of-band result it is standing on instead.
+ *
+ * `mutation` is here because it costs about two hours per run — the v0.6.2
+ * gate took 2 h 20 m end to end, of which mutation was roughly two — while
+ * measuring a slice of the tree (three numeric modules) that most releases do
+ * not touch. It runs on its own schedule now, and the release record cites
+ * that run: score, the commit it was measured at, and the workflow run that
+ * produced it. A deferred stage is written into the record as
+ * `not-executed`, never omitted: a release that skipped mutation and a
+ * release whose record simply forgot to mention it must not look the same.
+ */
+export const DEFERRED_RELEASE_STAGES = ['mutation'];
+
+/** The three states a stage can be in. `not-executed` is only legal for a deferred stage. */
+export const STAGE_STATES = ['passed', 'failed', 'not-executed'];
 
 /** Parse `GATE STAGE <name> EXIT: <code>` markers into { name: exitCode }. */
 export function parseGateStages(text) {
@@ -110,6 +127,72 @@ export function parseGateStages(text) {
     stages[m[1]] = Number(m[2]);
   }
   return stages;
+}
+
+/**
+ * Stage exit codes → the published vocabulary, with the deferred stages always
+ * present. `Object.entries` alone would omit a stage that never ran, and an
+ * absent key reads as "not applicable" rather than "not measured here".
+ */
+export function summariseStages(stages) {
+  if (!stages) return null;
+  const out = {};
+  for (const [name, code] of Object.entries(stages)) out[name] = code === 0 ? 'passed' : 'failed';
+  for (const s of DEFERRED_RELEASE_STAGES) if (out[s] === undefined) out[s] = 'not-executed';
+  return out;
+}
+
+/**
+ * Validate a mutation result read from `mutation-evidence.json` and bind it to
+ * the commit this record describes.
+ *
+ * Returns `{ problems, reference }`. The reference is written into the record
+ * whether or not it covers the release commit — a stale measurement is still
+ * the measurement the release stands on, and hiding that fact is the failure
+ * mode this whole file exists to prevent. What it must never do is imply
+ * currency it does not have, so `coversReleaseCommit` is explicit and
+ * `measuredAtCommit` is always named.
+ */
+export function bindMutationEvidence(mutation, releaseCommit, { required }) {
+  const problems = [];
+  if (!mutation) {
+    if (required) {
+      problems.push(
+        'no mutation result to stand on: run the Mutation workflow, or set ' +
+          'OLV_GATE_MUTATION=1 to run the stage inline',
+      );
+    }
+    return { problems, reference: null };
+  }
+  const score = typeof mutation.score === 'number' ? mutation.score : null;
+  const breakAt = typeof mutation.break === 'number' ? mutation.break : null;
+  if (score === null) problems.push('mutation evidence carries no score');
+  if (breakAt === null) problems.push('mutation evidence carries no break threshold');
+  if (!mutation.commit) problems.push('mutation evidence names no commit');
+  if (score !== null && breakAt !== null && score < breakAt) {
+    problems.push(`mutation score ${score} is below the break threshold ${breakAt}`);
+  }
+  const covers = Boolean(releaseCommit) && mutation.commit === releaseCommit;
+  return {
+    problems,
+    reference: {
+      score,
+      break: breakAt,
+      mutants: mutation.mutants ?? null,
+      mutate: mutation.mutate ?? null,
+      measuredAtCommit: mutation.commit ?? null,
+      measuredAt: mutation.measuredAt ?? null,
+      coversReleaseCommit: covers,
+      ranInThisGate: mutation.ranInThisGate === true,
+      workflow: mutation.workflow ?? null,
+      workflowRunId: mutation.workflowRunId ?? null,
+      workflowRunUrl: mutation.workflowRunUrl ?? null,
+      nodeVersion: mutation.nodeVersion ?? null,
+      note: covers
+        ? 'Measured at this release commit.'
+        : 'Measured at a different commit; this figure does not cover the release commit.',
+    },
+  };
 }
 
 /**
@@ -160,6 +243,7 @@ export function buildEvidenceRecord(input) {
     science = null,
     stages = null,
     canonicalNode = null,
+    mutation = null,
   } = input;
 
   const problems = [];
@@ -226,7 +310,19 @@ export function buildEvidenceRecord(input) {
       if (code === undefined) problems.push(`mandatory stage "${s}" did not run (no marker in the gate log)`);
       else if (code !== 0) problems.push(`mandatory stage "${s}" exited ${code}`);
     }
+    // A deferred stage may be absent, but if it DID run here it still has to
+    // have passed — running it and ignoring the result is the worst of both.
+    for (const s of DEFERRED_RELEASE_STAGES) {
+      const code = stages?.[s];
+      if (code !== undefined && code !== 0) problems.push(`deferred stage "${s}" exited ${code}`);
+    }
   }
+
+  // The mutation figure is required for a release record and optional for a
+  // development one: a developer who has never run Stryker locally still gets
+  // usable evidence, it just carries no mutation claim.
+  const bound = bindMutationEvidence(mutation, commit, { required: release });
+  problems.push(...bound.problems);
 
   if (problems.length > 0) return { ok: false, problems, record: null };
 
@@ -237,7 +333,7 @@ export function buildEvidenceRecord(input) {
     ok: true,
     problems: [],
     record: {
-      schemaVersion: 2,
+      schemaVersion: 3,
       project: 'openlidarviewer',
       version,
       releaseChannel: release ? 'prerelease' : 'development',
@@ -256,11 +352,8 @@ export function buildEvidenceRecord(input) {
       gateExit: 0,
       gateLog: 'release/gate.log',
       gateLogSha256,
-      stages: stages
-        ? Object.fromEntries(
-            Object.entries(stages).map(([k, v]) => [k, v === 0 ? 'passed' : 'failed']),
-          )
-        : null,
+      stages: summariseStages(stages),
+      mutation: bound.reference,
       buckets,
       total: { passed: totalPassed, skipped: totalSkipped },
       bundle,
@@ -388,6 +481,18 @@ function main() {
     };
   } catch { /* the claim-register lint reports its absence */ }
 
+  // The mutation figure this record stands on. `release/` wins over the
+  // tracked copy because a gate that ran the stage inline writes there, and a
+  // measurement from THIS run beats one from the last scheduled run.
+  const MUTATION_SOURCES = ['release/mutation-evidence.json', 'docs/validation/mutation-evidence.json'];
+  let mutation = null;
+  for (const rel of [flag('mutation-evidence'), ...MUTATION_SOURCES].filter(Boolean)) {
+    try {
+      mutation = JSON.parse(readFileSync(resolve(ROOT, rel), 'utf8'));
+      break;
+    } catch { /* try the next source; absence is reported by buildEvidenceRecord */ }
+  }
+
   let canonicalNode = null;
   try {
     canonicalNode = readFileSync(resolve(ROOT, '.nvmrc'), 'utf8').trim() || null;
@@ -405,6 +510,7 @@ function main() {
     gateExit: 0,
     stages: parseGateStages(text),
     canonicalNode,
+    mutation,
     bundle: { liveEntryKiB, ceilingKiB },
     nodeVersion: process.version,
     npmVersion,
@@ -435,6 +541,13 @@ function main() {
   console.log(`test-evidence.json written: ${BUCKETS.map((b) => `${b} ${buckets[b].passed}`).join(' · ')}`);
   console.log(`total ${totalPassed} passed / ${totalSkipped} skipped`);
   console.log(`live entry ${liveEntryKiB ?? '?'} KiB / ${ceilingKiB ?? '?'} KiB`);
+  const mu = evidence.mutation;
+  console.log(
+    mu
+      ? `mutation ${mu.score} (break ${mu.break}) at ${String(mu.measuredAtCommit).slice(0, 12)} — ` +
+        (mu.coversReleaseCommit ? 'this commit' : 'NOT this commit')
+      : 'mutation: no measurement cited',
+  );
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/collect-mutation-evidence.mjs
+++ b/scripts/collect-mutation-evidence.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * collect-mutation-evidence.mjs — turn a Stryker run into a citable record.
+ *
+ * The mutation stage no longer runs inside the tag-time gate: it measured
+ * three numeric modules and cost about two hours of every release. It runs on
+ * a schedule instead, and the release record CITES its result rather than
+ * reproducing it. That only works if the citation is checkable, so this writes
+ * the score together with the commit it was measured at and the workflow run
+ * that produced it. A score with no commit is a number, not evidence.
+ *
+ * The break threshold is read from stryker.conf.json rather than restated, so
+ * the figure the record publishes and the figure the runner enforces cannot
+ * drift. This exits non-zero when the score is under it — the schedule must
+ * fail loudly on a real regression, not file a report about one.
+ *
+ *   node scripts/collect-mutation-evidence.mjs \
+ *     --report reports/mutation/mutation.json \
+ *     --output docs/validation/mutation-evidence.json
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Mutants whose status counts toward the score's denominator, per Stryker's definition. */
+const DETECTED = new Set(['Killed', 'Timeout']);
+const UNDETECTED = new Set(['Survived', 'NoCoverage']);
+
+/**
+ * Score a Stryker JSON report the way Stryker itself does: detected over
+ * (detected + undetected), with ignored, compile-error and runtime-error
+ * mutants excluded from both sides. Recomputing rather than reading the
+ * reporter's own summary keeps this honest about which mutants it counted —
+ * the counts ship next to the score so a reader can redo the division.
+ */
+export function scoreReport(report) {
+  const tally = { killed: 0, timeout: 0, survived: 0, noCoverage: 0, ignored: 0, errors: 0 };
+  for (const file of Object.values(report?.files ?? {})) {
+    for (const m of file.mutants ?? []) {
+      if (m.status === 'Killed') tally.killed += 1;
+      else if (m.status === 'Timeout') tally.timeout += 1;
+      else if (m.status === 'Survived') tally.survived += 1;
+      else if (m.status === 'NoCoverage') tally.noCoverage += 1;
+      else if (m.status === 'Ignored') tally.ignored += 1;
+      else tally.errors += 1;
+    }
+  }
+  const detected = tally.killed + tally.timeout;
+  const undetected = tally.survived + tally.noCoverage;
+  const total = detected + undetected;
+  return {
+    score: total === 0 ? null : Number(((detected / total) * 100).toFixed(2)),
+    mutants: { ...tally, detected, undetected, scored: total },
+  };
+}
+
+function flagOf(argv, name) {
+  const i = argv.indexOf(`--${name}`);
+  return i === -1 ? null : argv[i + 1];
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const reportPath = flagOf(argv, 'report') ?? 'reports/mutation/mutation.json';
+  const outPath = flagOf(argv, 'output') ?? 'docs/validation/mutation-evidence.json';
+  const ranInThisGate = argv.includes('--in-gate');
+
+  let report;
+  try {
+    report = JSON.parse(readFileSync(resolve(ROOT, reportPath), 'utf8'));
+  } catch (err) {
+    console.error(`Cannot read the Stryker report at ${reportPath}: ${err.message}`);
+    console.error('Run `npm run mutation` first; its json reporter writes that file.');
+    process.exit(1);
+  }
+
+  const conf = JSON.parse(readFileSync(resolve(ROOT, 'stryker.conf.json'), 'utf8'));
+  const breakAt = conf?.thresholds?.break ?? null;
+  const { score, mutants } = scoreReport(report);
+
+  if (score === null) {
+    console.error('The report scored no mutants at all. Refusing to publish an empty measurement.');
+    process.exit(1);
+  }
+
+  let commit = null;
+  try {
+    commit = execSync('git rev-parse HEAD', { cwd: ROOT, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch { /* handled below: a measurement with no commit is not citable */ }
+  if (!commit) {
+    console.error('Cannot resolve HEAD. A mutation figure with no commit cannot be cited.');
+    process.exit(1);
+  }
+
+  const server = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
+  const repo = process.env.GITHUB_REPOSITORY ?? null;
+  const runId = process.env.GITHUB_RUN_ID ?? null;
+
+  const record = {
+    schemaVersion: 1,
+    project: 'openlidarviewer',
+    score,
+    break: breakAt,
+    mutants,
+    mutate: conf?.mutate ?? null,
+    commit,
+    measuredAt: new Date().toISOString(),
+    ranInThisGate,
+    workflow: process.env.GITHUB_WORKFLOW ?? null,
+    workflowRunId: runId,
+    workflowRunUrl: repo && runId ? `${server}/${repo}/actions/runs/${runId}` : null,
+    nodeVersion: process.version,
+    platform: `${process.platform}-${process.arch}`,
+  };
+
+  const out = resolve(ROOT, outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(record, null, 2)}\n`);
+  console.log(
+    `mutation score ${score} (break ${breakAt}) — ` +
+      `${mutants.detected} detected / ${mutants.scored} scored, ` +
+      `${mutants.ignored} ignored, ${mutants.errors} errored`,
+  );
+  console.log(`written to ${outPath} at ${commit.slice(0, 12)}`);
+
+  // Stryker already breaks on the threshold, so this is a second latch rather
+  // than the only one. It exists because the schedule's whole job is to shout:
+  // if the runner's own break check is ever loosened or its exit code swallowed
+  // by a pipe, a regression must still fail here.
+  if (breakAt !== null && score < breakAt) {
+    console.error(`Mutation score ${score} is below the break threshold ${breakAt}.`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/create-release-manifest.mjs
+++ b/scripts/create-release-manifest.mjs
@@ -85,6 +85,12 @@ export function buildManifest({ version, evidence, assets, builtAt, sourceDateEp
     if (!evidence.stages) {
       problems.push('evidence carries no stage record; a release run proves every mandatory stage');
     }
+    // A stage recorded as not-executed has to name the out-of-band result it
+    // was deferred to. Without that the manifest would publish a gap dressed
+    // as a decision.
+    if (evidence.stages?.mutation === 'not-executed' && !evidence.mutation?.measuredAtCommit) {
+      problems.push('mutation is recorded as not-executed but no measured result is cited');
+    }
   }
 
   for (const kind of PAYLOAD_KINDS) {
@@ -130,6 +136,20 @@ export function buildManifest({ version, evidence, assets, builtAt, sourceDateEp
         referenceTool: 'GDAL',
         referenceVersion: '3.13.1',
         stages: evidence.stages ?? null,
+        // The mutation figure is cited, not re-measured, so the manifest
+        // carries the citation intact: a reader who sees `stages.mutation:
+        // not-executed` needs the commit that score WAS measured at in the
+        // same object, or the omission reads as a gap.
+        mutation: evidence.mutation
+          ? {
+              score: evidence.mutation.score ?? null,
+              break: evidence.mutation.break ?? null,
+              measuredAtCommit: evidence.mutation.measuredAtCommit ?? null,
+              measuredAt: evidence.mutation.measuredAt ?? null,
+              coversReleaseCommit: evidence.mutation.coversReleaseCommit ?? false,
+              workflowRunUrl: evidence.mutation.workflowRunUrl ?? null,
+            }
+          : null,
       },
       bundle: {
         liveEntryKiB: evidence.bundle?.liveEntryKiB ?? null,

--- a/scripts/gate.sh
+++ b/scripts/gate.sh
@@ -14,8 +14,10 @@
 #
 #   release                Runs EVERY mandatory release stage into ONE log:
 #                          static gate, deterministic e2e, docs build,
-#                          production audit, fixture checksums, coverage,
-#                          mutation. Writes the authoritative record to
+#                          production audit, fixture checksums, coverage.
+#                          Mutation is deferred to its own scheduled workflow
+#                          and cited by the record; OLV_GATE_MUTATION=1 runs it
+#                          here too. Writes the authoritative record to
 #                          release/test-evidence-v<version>.json and touches
 #                          no tracked file. That last property is the point:
 #                          the exact-tag workflow packages this same checkout
@@ -62,6 +64,17 @@ production_audit() {
   return $audit_code
 }
 
+# Mutation and its record are ONE stage. Splitting them would let the runner
+# pass while the record went unwritten, and collect-evidence would then quietly
+# fall back to the last scheduled figure — a stale number attributed to a run
+# that had actually measured this commit.
+mutation_with_evidence() {
+  npm run mutation || return $?
+  node scripts/collect-mutation-evidence.mjs \
+    --output release/mutation-evidence.json \
+    --in-gate
+}
+
 run_stage staticGate npm run test:release
 
 if [ "$MODE" = "release" ]; then
@@ -71,7 +84,18 @@ if [ "$MODE" = "release" ]; then
     run_stage productionAudit production_audit
     run_stage fixtureChecksums fixture_checksums
     run_stage coverage npm run coverage -- --reporter=dot
-    run_stage mutation npm run mutation
+    # Mutation is opt-in. It costs about two hours against three numeric
+    # modules, which is most of the release gate's wall time, so it runs on its
+    # own schedule and the record cites that run. OLV_GATE_MUTATION=1 keeps the
+    # everything-in-one-pass local path available; when set, the stage runs here
+    # and its result is written where collect-evidence prefers it, so the record
+    # cites THIS commit rather than the last scheduled one.
+    if [ "${OLV_GATE_MUTATION:-0}" = "1" ]; then
+      run_stage mutation mutation_with_evidence
+    else
+      echo "mutation: deferred to the scheduled workflow; the record cites its last result." | tee -a "$LOG"
+      echo "Set OLV_GATE_MUTATION=1 to run it inline." | tee -a "$LOG"
+    fi
   else
     echo "staticGate failed; the remaining release stages were not run." | tee -a "$LOG"
   fi

--- a/scripts/verify-release-assets.mjs
+++ b/scripts/verify-release-assets.mjs
@@ -24,7 +24,7 @@ import { createHash } from 'node:crypto';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 // eslint-disable-next-line import/no-relative-packages — same repo, ships in the archive
-import { MANDATORY_RELEASE_STAGES } from './collect-evidence.mjs';
+import { MANDATORY_RELEASE_STAGES, DEFERRED_RELEASE_STAGES, STAGE_STATES } from './collect-evidence.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -147,11 +147,16 @@ function readRegisterE4Claims() {
 export function verifyStagedRelease(dir, opts = {}) {
   const problems = [];
   const note = (m) => problems.push(m);
+  // Advisories are true statements about the release that are not defects.
+  // They exist so a fact like "the cited mutation score predates this commit"
+  // can be SAID without either blocking the release or being swallowed.
+  const advisories = [];
+  const advise = (m) => advisories.push(m);
   const pkgVersion =
     opts.version ?? JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')).version;
   const expectedTag = `v${pkgVersion}`;
 
-  if (!existsSync(dir)) return { ok: false, problems: [`staging directory not found: ${dir}`] };
+  if (!existsSync(dir)) return { ok: false, problems: [`staging directory not found: ${dir}`], advisories };
 
   const names = readdirSync(dir).filter((n) => statSync(resolve(dir, n)).isFile());
 
@@ -176,7 +181,7 @@ export function verifyStagedRelease(dir, opts = {}) {
       note(`asset from another release is staged: ${n} (expected v${pkgVersion})`);
     }
   }
-  if (problems.length > 0 && !found.manifest) return { ok: false, problems };
+  if (problems.length > 0 && !found.manifest) return { ok: false, problems, advisories };
 
   // ── 2. Identity agreement across manifest, evidence, SBOM, filenames ─────
   let manifest = null;
@@ -218,6 +223,39 @@ export function verifyStagedRelease(dir, opts = {}) {
     for (const s of MANDATORY_RELEASE_STAGES) {
       if (evidence.stages?.[s] !== 'passed') {
         note(`evidence does not record mandatory stage "${s}" as passed`);
+      }
+    }
+    // A deferred stage may be `not-executed`, and that is the only thing that
+    // makes deferral different from omission — so the state has to BE there,
+    // and it has to be one of the three the vocabulary allows. An unrecognised
+    // string would otherwise sail through as neither passed nor missing.
+    for (const s of DEFERRED_RELEASE_STAGES) {
+      const state = evidence.stages?.[s];
+      if (state === undefined) {
+        note(`evidence omits deferred stage "${s}"; it must be recorded, "not-executed" included`);
+      } else if (!STAGE_STATES.includes(state)) {
+        note(`evidence records stage "${s}" as "${state}", which is not a stage state`);
+      } else if (state === 'failed') {
+        note(`evidence records deferred stage "${s}" as failed`);
+      }
+    }
+    // Deferral is only honest if the record names what it deferred TO.
+    if (evidence.stages?.mutation === 'not-executed') {
+      const m = evidence.mutation;
+      if (!m?.measuredAtCommit) {
+        note('mutation is recorded as not-executed but the evidence cites no measured result');
+      } else if (m.score == null || m.break == null) {
+        note('the cited mutation result carries no score or no break threshold');
+      } else if (m.score < m.break) {
+        note(`the cited mutation score ${m.score} is below the break threshold ${m.break}`);
+      } else if (!m.coversReleaseCommit && m.measuredAtCommit !== evidence.commit) {
+        // Not a defect: a cited figure from another commit is the expected
+        // steady state between scheduled runs. It is recorded as an advisory
+        // so the release page says out loud what the record already encodes.
+        advise(
+          `mutation score ${m.score} was measured at ${String(m.measuredAtCommit).slice(0, 12)}, ` +
+            'not at the release commit',
+        );
       }
     }
     // The expected E4 set is DERIVED from the claim register, not typed in
@@ -343,7 +381,7 @@ export function verifyStagedRelease(dir, opts = {}) {
     }
   }
 
-  return { ok: problems.length === 0, problems };
+  return { ok: problems.length === 0, problems, advisories };
 }
 
 function isMain() {
@@ -366,7 +404,8 @@ if (isMain()) {
     }).trim();
   } catch { /* no tag locally: the identity checks that do not need it still run */ }
 
-  const { ok, problems } = verifyStagedRelease(resolve(dir), { tagCommit });
+  const { ok, problems, advisories } = verifyStagedRelease(resolve(dir), { tagCommit });
+  for (const a of advisories ?? []) console.log(`  ℹ ${a}`);
   if (ok) {
     console.log(`release:verify OK — ${dir} is a complete, self-consistent release asset set.`);
     process.exit(0);

--- a/tests/evidenceRecord.test.ts
+++ b/tests/evidenceRecord.test.ts
@@ -10,13 +10,26 @@
 
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error — plain .mjs script, no types
-import { buildEvidenceRecord, parseGateStages, parseGateLog, CANONICAL_NPM, MANDATORY_RELEASE_STAGES } from '../scripts/collect-evidence.mjs';
+import { buildEvidenceRecord, parseGateStages, parseGateLog, summariseStages, bindMutationEvidence, CANONICAL_NPM, MANDATORY_RELEASE_STAGES, DEFERRED_RELEASE_STAGES } from '../scripts/collect-evidence.mjs';
 
 const BUCKETS = ['unit', 'export', 'terrain', 'ui', 'slow'];
 const fullBuckets = () =>
   Object.fromEntries(BUCKETS.map((b) => [b, { passed: 10, skipped: 0, runs: 1 }]));
 const allStages = () =>
   Object.fromEntries((MANDATORY_RELEASE_STAGES as string[]).map((s) => [s, 0]));
+const RELEASE_COMMIT = 'a'.repeat(40);
+const mutationEvidence = (over: Record<string, unknown> = {}) => ({
+  schemaVersion: 1,
+  score: 87.23,
+  break: 75,
+  mutants: { detected: 164, undetected: 24, scored: 188 },
+  commit: RELEASE_COMMIT,
+  measuredAt: '2026-07-20T04:00:00.000Z',
+  workflow: 'Mutation',
+  workflowRunId: '123',
+  workflowRunUrl: 'https://github.com/o/r/actions/runs/123',
+  ...over,
+});
 
 const base = (over: Record<string, unknown> = {}) => ({
   mode: 'release',
@@ -33,6 +46,7 @@ const base = (over: Record<string, unknown> = {}) => ({
   gateLogSha256: 'b'.repeat(64),
   science: { e4ClaimCount: 2, e4Claims: ['SLOPE-RASTER', 'ASPECT-RASTER'], suppliedReferenceSlots: 2 },
   stages: allStages(),
+  mutation: mutationEvidence(),
   ...over,
 });
 
@@ -45,7 +59,7 @@ describe('buildEvidenceRecord — release mode', () => {
     expect(r.ok).toBe(true);
     expect(r.record.releaseAuthoritative).toBe(true);
     expect(r.record.releaseChannel).toBe('prerelease');
-    expect(r.record.schemaVersion).toBe(2);
+    expect(r.record.schemaVersion).toBe(3);
     expect(r.record.total).toEqual({ passed: 50, skipped: 0 });
   });
 
@@ -111,8 +125,8 @@ describe('buildEvidenceRecord — release mode', () => {
 
   it('refuses when a mandatory stage never ran', () => {
     const s = allStages();
-    delete (s as Record<string, number>).mutation;
-    expect(problems({ stages: s }).some((p) => p.includes('mutation') && p.includes('did not run'))).toBe(true);
+    delete (s as Record<string, number>).coverage;
+    expect(problems({ stages: s }).some((p) => p.includes('coverage') && p.includes('did not run'))).toBe(true);
   });
 
   it('refuses when a mandatory stage failed', () => {
@@ -141,6 +155,107 @@ describe('buildEvidenceRecord — release mode', () => {
     for (const s of MANDATORY_RELEASE_STAGES as string[]) {
       expect(r.record.stages[s]).toBe('passed');
     }
+  });
+});
+
+describe('the deferred mutation stage', () => {
+  it('is not mandatory, but is never silently omitted', () => {
+    expect(MANDATORY_RELEASE_STAGES as string[]).not.toContain('mutation');
+    expect(DEFERRED_RELEASE_STAGES as string[]).toContain('mutation');
+    const s = allStages();
+    expect((s as Record<string, number>).mutation).toBeUndefined();
+    const r = buildEvidenceRecord(base({ stages: s }));
+    expect(r.ok).toBe(true);
+    // The distinction the contract turns on: absent from the log, present in
+    // the record, and named as not-executed rather than left out.
+    expect(r.record.stages.mutation).toBe('not-executed');
+  });
+
+  it('refuses a release record with no mutation result to stand on', () => {
+    const p = problems({ mutation: null });
+    expect(p.some((x) => x.includes('no mutation result to stand on'))).toBe(true);
+    expect(buildEvidenceRecord(base({ mutation: null })).record).toBeNull();
+  });
+
+  it('cites the score, the commit it was measured at, and the run', () => {
+    const r = buildEvidenceRecord(base());
+    expect(r.record.mutation.score).toBe(87.23);
+    expect(r.record.mutation.break).toBe(75);
+    expect(r.record.mutation.measuredAtCommit).toBe(RELEASE_COMMIT);
+    expect(r.record.mutation.workflowRunUrl).toContain('/actions/runs/123');
+    expect(r.record.mutation.coversReleaseCommit).toBe(true);
+  });
+
+  it('says so when the measurement is for a different commit', () => {
+    const r = buildEvidenceRecord(base({ mutation: mutationEvidence({ commit: 'c'.repeat(40) }) }));
+    // Still a valid record — a cited stale figure beats no figure — but it
+    // must not read as covering the release commit.
+    expect(r.ok).toBe(true);
+    expect(r.record.mutation.coversReleaseCommit).toBe(false);
+    expect(r.record.mutation.measuredAtCommit).toBe('c'.repeat(40));
+    expect(r.record.mutation.note).toContain('does not cover the release commit');
+  });
+
+  it('refuses a score under the break threshold', () => {
+    expect(
+      problems({ mutation: mutationEvidence({ score: 74.9 }) })
+        .some((p) => p.includes('below the break threshold')),
+    ).toBe(true);
+  });
+
+  it('refuses a measurement with no commit or no score', () => {
+    expect(
+      problems({ mutation: mutationEvidence({ commit: null }) })
+        .some((p) => p.includes('names no commit')),
+    ).toBe(true);
+    expect(
+      problems({ mutation: mutationEvidence({ score: null }) })
+        .some((p) => p.includes('carries no score')),
+    ).toBe(true);
+  });
+
+  it('still fails a release when the stage DID run here and failed', () => {
+    const s = { ...allStages(), mutation: 1 };
+    expect(problems({ stages: s }).some((p) => p.includes('deferred stage "mutation" exited 1'))).toBe(true);
+  });
+
+  it('marks it passed when the local one-pass gate ran it inline', () => {
+    const s = { ...allStages(), mutation: 0 };
+    const r = buildEvidenceRecord(base({ stages: s, mutation: mutationEvidence({ ranInThisGate: true }) }));
+    expect(r.record.stages.mutation).toBe('passed');
+    expect(r.record.mutation.ranInThisGate).toBe(true);
+  });
+
+  it('leaves a development record usable without any mutation measurement', () => {
+    const r = buildEvidenceRecord(base({ mode: 'development', tag: null, mutation: null }));
+    expect(r.ok).toBe(true);
+    expect(r.record.mutation).toBeNull();
+  });
+});
+
+describe('summariseStages', () => {
+  it('translates exit codes and fills in every deferred stage', () => {
+    expect(summariseStages({ staticGate: 0, e2e: 3 })).toEqual({
+      staticGate: 'passed',
+      e2e: 'failed',
+      mutation: 'not-executed',
+    });
+  });
+
+  it('returns null when there are no stages at all', () => {
+    expect(summariseStages(null)).toBeNull();
+  });
+});
+
+describe('bindMutationEvidence', () => {
+  it('reports absence only when the caller requires a result', () => {
+    expect(bindMutationEvidence(null, RELEASE_COMMIT, { required: false }).problems).toEqual([]);
+    expect(bindMutationEvidence(null, RELEASE_COMMIT, { required: true }).problems.length).toBe(1);
+  });
+
+  it('does not claim coverage when the release commit is unknown', () => {
+    const r = bindMutationEvidence(mutationEvidence(), null, { required: false });
+    expect(r.reference.coversReleaseCommit).toBe(false);
   });
 });
 

--- a/tests/mutationEvidence.test.ts
+++ b/tests/mutationEvidence.test.ts
@@ -1,0 +1,64 @@
+/**
+ * mutationEvidence.test.ts — the score the release record cites is computed,
+ * not copied.
+ *
+ * The mutation figure is now measured somewhere other than the release gate,
+ * which makes the arithmetic that produces it part of the evidence chain
+ * rather than a detail of a log a human read once. Stryker's denominator is
+ * the part that gets misremembered: ignored mutants and compile errors are
+ * excluded from BOTH sides, so counting them anywhere moves the score.
+ */
+
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs script, no types
+import { scoreReport } from '../scripts/collect-mutation-evidence.mjs';
+
+const report = (statuses: string[]) => ({
+  files: { 'src/process/numerics.ts': { mutants: statuses.map((status) => ({ status })) } },
+});
+
+describe('scoreReport', () => {
+  it('counts killed and timed-out mutants as detected', () => {
+    const r = scoreReport(report(['Killed', 'Killed', 'Timeout', 'Survived']));
+    expect(r.mutants.detected).toBe(3);
+    expect(r.mutants.undetected).toBe(1);
+    expect(r.score).toBe(75);
+  });
+
+  it('counts NoCoverage against the score, not as an absence', () => {
+    // A mutant no test reaches is the strongest evidence of a gap there is.
+    // Dropping it from the denominator would let a shrinking suite raise the
+    // score.
+    expect(scoreReport(report(['Killed', 'NoCoverage'])).score).toBe(50);
+  });
+
+  it('excludes ignored and errored mutants from both sides', () => {
+    const r = scoreReport(report(['Killed', 'Survived', 'Ignored', 'CompileError', 'RuntimeError']));
+    expect(r.score).toBe(50);
+    expect(r.mutants.scored).toBe(2);
+    expect(r.mutants.ignored).toBe(1);
+    expect(r.mutants.errors).toBe(2);
+  });
+
+  it('sums across files', () => {
+    const r = scoreReport({
+      files: {
+        a: { mutants: [{ status: 'Killed' }, { status: 'Killed' }] },
+        b: { mutants: [{ status: 'Killed' }, { status: 'Survived' }] },
+      },
+    });
+    expect(r.score).toBe(75);
+    expect(r.mutants.scored).toBe(4);
+  });
+
+  it('returns no score rather than a fabricated one when nothing was scored', () => {
+    // 0/0 is not 100 %. A run that mutated nothing must not be publishable as
+    // a perfect one.
+    expect(scoreReport(report(['Ignored'])).score).toBeNull();
+    expect(scoreReport({}).score).toBeNull();
+  });
+
+  it('rounds to two decimals, the precision the published figure is quoted at', () => {
+    expect(scoreReport(report(['Killed', 'Killed', 'Survived'])).score).toBe(66.67);
+  });
+});

--- a/tests/releaseAssetVerifier.test.ts
+++ b/tests/releaseAssetVerifier.test.ts
@@ -54,9 +54,22 @@ const SOURCE_FILES: Record<string, string> = {
 
 const ALL_STAGES = [
   'staticGate', 'e2e', 'docsBuild', 'productionAudit',
-  'fixtureChecksums', 'coverage', 'mutation',
+  'fixtureChecksums', 'coverage',
 ] as const;
-const passedStages = () => Object.fromEntries(ALL_STAGES.map((s) => [s, 'passed']));
+/** The steady state: every mandatory stage ran here, mutation was cited. */
+const passedStages = () => ({
+  ...Object.fromEntries(ALL_STAGES.map((s) => [s, 'passed'])),
+  mutation: 'not-executed',
+});
+const citedMutation = (over: Record<string, unknown> = {}) => ({
+  score: 87.23,
+  break: 75,
+  measuredAtCommit: COMMIT,
+  measuredAt: '2026-07-20T04:00:00.000Z',
+  coversReleaseCommit: true,
+  workflowRunUrl: 'https://github.com/o/r/actions/runs/123',
+  ...over,
+});
 
 const DEPLOY_FILES: Record<string, string> = {
   'index.html': '<!doctype html>',
@@ -67,7 +80,7 @@ const DEPLOY_FILES: Record<string, string> = {
 
 function evidenceRecord(over: Record<string, unknown> = {}) {
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     version: VERSION,
     tag: TAG,
     commit: COMMIT,
@@ -79,6 +92,7 @@ function evidenceRecord(over: Record<string, unknown> = {}) {
     bundle: { liveEntryKiB: 713, ceilingKiB: 720 },
     science: { e4ClaimCount: 2, e4Claims: [...EXPECTED_E4], suppliedReferenceSlots: 2 },
     stages: passedStages(),
+    mutation: citedMutation(),
     gateLogSha256: '',
     ...over,
   };
@@ -146,6 +160,7 @@ const verify = () =>
   verifyStagedRelease(dir, { version: VERSION, expectedE4Claims: EXPECTED_E4 }) as {
     ok: boolean;
     problems: string[];
+    advisories: string[];
   };
 const failsWith = (needle: string) => {
   const r = verify();
@@ -245,9 +260,47 @@ describe('release:verify — mandatory stage record', () => {
 
   it('rejects evidence whose stage record omits a mandatory stage', () => {
     const s = passedStages();
+    delete (s as Record<string, string>).coverage;
+    stageRelease({ evidence: { stages: s } });
+    failsWith('coverage');
+  });
+
+  it('rejects evidence that omits the deferred mutation stage entirely', () => {
+    const s = passedStages();
     delete (s as Record<string, string>).mutation;
     stageRelease({ evidence: { stages: s } });
-    failsWith('mutation');
+    failsWith('omits deferred stage');
+  });
+
+  it('rejects a stage state outside the vocabulary', () => {
+    stageRelease({ evidence: { stages: { ...passedStages(), mutation: 'skipped' } } });
+    failsWith('not a stage state');
+  });
+
+  it('accepts mutation as not-executed when a passing result is cited', () => {
+    stageRelease();
+    expect(verify().ok).toBe(true);
+  });
+
+  it('rejects not-executed mutation with nothing cited', () => {
+    stageRelease({ evidence: { mutation: null } });
+    failsWith('cites no measured result');
+  });
+
+  it('rejects a cited mutation score under the break threshold', () => {
+    stageRelease({ evidence: { mutation: citedMutation({ score: 70 }) } });
+    failsWith('below the break threshold');
+  });
+
+  it('advises, without failing, when the cited score predates the release commit', () => {
+    stageRelease({
+      evidence: {
+        mutation: citedMutation({ coversReleaseCommit: false, measuredAtCommit: 'f'.repeat(40) }),
+      },
+    });
+    const r = verify();
+    expect(r.ok).toBe(true);
+    expect(r.advisories.some((a: string) => a.includes('not at the release commit'))).toBe(true);
   });
 
   it('rejects evidence recording a mandatory stage as failed', () => {


### PR DESCRIPTION
Mutation testing ran roughly two hours of the v0.6.2 release gate's 2 h 20 m, over three numeric modules, and forced the gate timeout from 90 to 300 minutes. It now runs weekly and on demand in `.github/workflows/mutation.yml`; the release gate's timeout returns to 60.

The release record cites the result rather than reproducing it. `mutation` moves from `MANDATORY_RELEASE_STAGES` to a new `DEFERRED_RELEASE_STAGES`; a deferred stage is always written as `not-executed` rather than omitted, and the record carries the score, the break threshold, the commit measured, and the workflow run. `coversReleaseCommit` states whether that commit is the release commit. Evidence schema 2 becomes 3.

A record with no cited result, or a cited score under `break: 75`, is refused, and `release:verify` repeats both checks against the shipped assets.

**Blocks the next tag until acted on.** No seeded `docs/validation/mutation-evidence.json` ships, so the next release-mode gate refuses with "no mutation result to stand on". Dispatch the Mutation workflow once first.

Rebased onto main; `release.yml` merged cleanly with the attestation and SHA-pinning changes. Verified: `tsc` 0, unit 1107 passed, evidence/verifier 77 passed, four document gates 0.