### PR TITLE
Preset contract: apply what is declared, reserve what is not

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.2.md
+++ b/KNOWN_LIMITATIONS_v0.6.2.md
@@ -6,7 +6,7 @@ Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 7,355 lines and `src/render/Viewer.ts` is 7,104, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 7,355 lines and `src/render/Viewer.ts` is 7,073, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -117,7 +117,7 @@ candidates:
 | `generateReportPdf` / `exportGeoContext` | 402 | export/report wiring module |
 | `importSession` | 177 | `src/app/sessionIo.ts` *(planned)* |
 
-**`src/render/Viewer.ts` (7,104)** — the constructor and a handful of large
+**`src/render/Viewer.ts` (7,073)** — the constructor and a handful of large
 methods dominate:
 
 Spans below are the symbol's real extent, read from the TypeScript symbol graph

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -5,7 +5,7 @@
       "goal": 2500
     },
     "src/render/Viewer.ts": {
-      "lines": 7104,
+      "lines": 7073,
       "goal": 2000
     }
   }

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -30,6 +30,7 @@
  */
 
 import * as THREE from 'three/webgpu';
+import { applyPresetColorMode, type ColorModeHost } from './colorModeSupport';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import {
   instancedBufferAttribute,
@@ -212,7 +213,7 @@ import {
   type PresetId,
   type SkyPreset,
 } from './inspectionPresets';
-import { getSkyDefinition } from './skyPresets';
+import { applySkyPreset } from './skyPresetApply';
 import type { SkyPreset as SkyPresetId } from './inspectionPresets';
 import {
   applyRgbAppearance,
@@ -3857,7 +3858,22 @@ export class Viewer {
     this.setPointSize(preset.pointSize);
     this.setPointSizeMode(preset.pointSizeMode);
     this._applySkyPreset(preset.sky);
-    this.lastPresetAoStrength = preset.aoStrength;
+    this.lastPresetAoStrength = preset.reserved.aoStrength;
+    applyPresetColorMode(this._colorModeHost(), preset.defaultColorMode);
+  }
+
+  /** Structural view of this Viewer for the colour-mode rule. */
+  private _colorModeHost(): ColorModeHost {
+    const st = this._streaming;
+    return {
+      clouds: this._clouds,
+      streaming: st
+        ? { currentMode: st.renderer.colorMode, sourceDefaultMode: st.cloud.defaultColorMode(),
+            setColorMode: (m) => st.renderer.setColorMode(m) }
+        : null,
+      setCloudColorMode: (id, m) => this.setColorMode(id, m),
+      notifyColorContextChanged: () => this._notifyColorContextChanged(),
+    };
   }
 
   /** The currently-applied preset id. */
@@ -3865,59 +3881,12 @@ export class Viewer {
     return this._presetId;
   }
 
-  /**
-   * Apply a sky preset to the scene + the canvas container CSS.
-   *
-   * The renderer is opaque (`alpha: false`), so the canvas paints over
-   * any CSS background set on its DOM parent. The user only sees what
-   * `scene.background` clears to each frame. Setting both means:
-   *   - `scene.background` is the source of truth the user sees
-   *   - the parent CSS background acts as a fallback for any non-render
-   *     edges (sheet transitions, resize blits) and matches the in-app
-   *     reading so screenshots and HTML embeds stay coherent.
-   *
-   * Radial-gradient presets fall back to their flat `fallbackColor`
-   * when fed into `scene.background` because Three.js takes a solid
-   * Color or a Texture there — CSS gradients can't render against a
-   * WebGPU clear. The fallback colour is chosen to match the centre
-   * of the gradient so the visual difference reads small.
-   */
   private _applySkyPreset(sky: SkyPreset): void {
-    const def = getSkyDefinition(sky);
-    const color = new THREE.Color(def.fallbackColor);
-    // Three places need the new colour or the user sees nothing:
-    //   1. scene.background — what `renderer.render(scene, camera)`
-    //      clears to when EDL is OFF and the renderer paints direct.
-    //   2. renderer.clearColor — what the EDL post-pipeline pass
-    //      framebuffer clears to when EDL is ON. Without this the
-    //      pass clears to the renderer default (opaque black) and
-    //      the scene.background change is invisible while EDL is on.
-    //   3. parent CSS background — sheet-edge fallback during resize
-    //      / transitions and the source we read back in screenshot
-    //      composition for in-context image exports.
-    this._scene.background = color;
-    this._renderer.setClearColor(color, 1.0);
-    const canvas = this._canvas;
-    if (!canvas) return;
-    const parent = canvas.parentElement;
-    if (!parent) return;
-    // Device-aware CSS layer.
-    //   Desktop (≥ 768 px) — apply the rich radial gradient. The wide
-    //     canvas viewport carries the gradient without leaking under
-    //     UI chrome.
-    //   Phone (< 768 px) — apply only the flat fallback colour. On
-    //     phones the Inspector becomes a bottom-sheet covering ~54 %
-    //     of the viewport; a radial gradient extending behind the
-    //     sheet edge or the topbar reads as visual leakage. The flat
-    //     colour confines the visible background to the canvas area
-    //     and matches what the renderer is clearing to anyway.
-    const isPhone =
-      typeof window !== 'undefined' &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(max-width: 767px)').matches;
-    this._lastSkyIsPhone = isPhone;
-    parent.style.background = isPhone ? def.fallbackColor : def.background;
-    parent.style.backgroundColor = def.fallbackColor;
+    this._lastSkyIsPhone = applySkyPreset(sky, {
+      scene: this._scene,
+      renderer: this._renderer,
+      canvas: this._canvas,
+    });
   }
 
   /** The current point-size mode. */

--- a/src/render/colorModeSupport.ts
+++ b/src/render/colorModeSupport.ts
@@ -1,0 +1,116 @@
+/**
+ * colorModeSupport.ts
+ *
+ * Whether a cloud carries the attribute a colour mode needs.
+ *
+ * A preset declares the colour mode it moves into, and that mode is not
+ * always available: an airborne survey with no classification field cannot
+ * render Classification, and a photogrammetric cloud with no intensity cannot
+ * render Intensity. Asking the renderer anyway produces a uniform wash, which
+ * a user reads as a broken render rather than as absent data.
+ *
+ * Pure — no DOM, no three.js — so the rule is testable on its own and the
+ * Viewer only decides what to do with the answer.
+ */
+
+import type { ColorMode } from './colorModes';
+
+/** The attributes this check needs. Structural, so tests can pass a literal. */
+export interface ColorModeCloudFacts {
+  readonly colors?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly normals?: Float32Array;
+  readonly gpsTime?: Float64Array;
+}
+
+const present = (a?: { length: number }): boolean => a != null && a.length > 0;
+
+/**
+ * True when `cloud` can be rendered in `mode`.
+ *
+ * Elevation and density derive from positions, which every cloud has, so they
+ * are always available. Unknown modes return true rather than false: a mode
+ * this function has not been taught about should fall through to the renderer
+ * that owns it, not be silently suppressed here.
+ */
+export function cloudSupportsColorMode(cloud: ColorModeCloudFacts, mode: ColorMode): boolean {
+  switch (mode) {
+    case 'rgb':
+      return present(cloud.colors);
+    case 'intensity':
+      return present(cloud.intensity);
+    case 'classification':
+      return present(cloud.classification);
+    case 'normal':
+      return present(cloud.normals);
+    case 'gpsTime':
+      return present(cloud.gpsTime);
+    default:
+      return true;
+  }
+}
+
+/**
+ * Which clouds should change colour mode, given the mode a preset asks for.
+ *
+ * Returned as a list of ids rather than performed here, so the decision stays
+ * free of three.js and the Viewer keeps sole ownership of the mutation. A
+ * cloud already in the mode is skipped, and so is one that cannot render it.
+ */
+export function planColorModeChanges(
+  entries: Iterable<readonly [string, { readonly mode: ColorMode; readonly cloud: ColorModeCloudFacts }]>,
+  mode: ColorMode,
+): string[] {
+  const ids: string[] = [];
+  for (const [id, entry] of entries) {
+    if (entry.mode === mode) continue;
+    if (!cloudSupportsColorMode(entry.cloud, mode)) continue;
+    ids.push(id);
+  }
+  return ids;
+}
+
+/** The parts of the Viewer this rule needs. Structural, so tests pass a literal. */
+export interface ColorModeHost {
+  readonly clouds: Iterable<readonly [string, { readonly mode: ColorMode; readonly cloud: ColorModeCloudFacts }]>;
+  readonly streaming: {
+    readonly currentMode: ColorMode;
+    readonly sourceDefaultMode: ColorMode;
+    setColorMode(mode: ColorMode): void;
+  } | null;
+  setCloudColorMode(id: string, mode: ColorMode): void;
+  notifyColorContextChanged(): void;
+}
+
+/**
+ * Move a host into `mode`, skipping anything that cannot render it.
+ *
+ * The whole rule lives here rather than in the Viewer: it is a decision about
+ * data availability, not about rendering, and it is worth testing without a
+ * GPU. The host interface keeps three.js out of this module.
+ */
+export function applyPresetColorMode(host: ColorModeHost, mode: ColorMode): void {
+  for (const id of planColorModeChanges(host.clouds, mode)) host.setCloudColorMode(id, mode);
+  const st = host.streaming;
+  if (st && streamingShouldFollow(st.sourceDefaultMode, st.currentMode, mode)) {
+    st.setColorMode(mode);
+    host.notifyColorContextChanged();
+  }
+}
+
+/**
+ * Whether the streaming renderer should follow a preset into `mode`.
+ *
+ * The tiles carry only what the format serves, which the source reports as its
+ * default mode. Elevation is the exception: it derives from position, which
+ * every tile has.
+ */
+export function streamingShouldFollow(
+  sourceDefaultMode: ColorMode,
+  currentMode: ColorMode,
+  mode: ColorMode,
+): boolean {
+  if (currentMode === mode) return false;
+  return mode === 'elevation' || sourceDefaultMode === mode;
+}

--- a/src/render/inspectionPresets.ts
+++ b/src/render/inspectionPresets.ts
@@ -6,11 +6,14 @@
  * the seven tunables that drive the readability of a LiDAR scan:
  *
  *   - EDL strength (depth-edge shading)
- *   - AO strength (cavity / crevice shading, when supported)
- *   - elevation palette (for the height colour mode)
  *   - point size + point-size mode (fixed vs adaptive)
  *   - sky preset (background gradient style)
- *   - hillshade enabled (terrain-only relief shading)
+ *   - the colour mode the preset moves into
+ *
+ * Three further settings the presets used to declare (AO strength,
+ * elevation palette, hillshade) have no runtime setter behind them. They
+ * live under `reserved` so the applied set and the aspirational set are
+ * not read as one thing.
  *
  * Pure data — no DOM, no three.js — so it ships through the same seam
  * every other v0.3.7 module reads. The Viewer applies a preset by
@@ -44,6 +47,38 @@ export type SkyPreset =
   | 'terrain'
   | 'black';
 
+/**
+ * Fields a preset declares but the live renderer does not apply.
+ *
+ * These sat in `InspectionPreset` and read as operational: a preset naming a
+ * palette, or switching hillshade on, appeared to change the scene and did
+ * not. `Viewer.applyPreset()` never touched any of them, and no runtime
+ * setter exists for them to call.
+ *
+ * They are kept rather than deleted, because the values were tuned against
+ * real survey data and are the right starting point once each capability
+ * lands. Holding them behind `reserved` makes the separation explicit:
+ * nothing in here is claimed to affect the live view.
+ */
+export interface ReservedPresetCapabilities {
+  /**
+   * SSAO strength 0..1. `ssaoApproximation.ts` computes an AO factor, but no
+   * pass consumes it, so there is nothing for a preset to set.
+   */
+  readonly aoStrength: number;
+  /**
+   * Elevation palette for height colouring. The Viewer exposes no palette
+   * setter; the ramp is selected inside `colorForMode`.
+   */
+  readonly elevationPalette: ElevationPalette;
+  /**
+   * Terrain relief shading. Hillshade is an analysis product derived from a
+   * DEM, not a live point-cloud render control, so a preset field cannot
+   * switch it on: there is no live hillshade renderer to switch.
+   */
+  readonly hillshade: boolean;
+}
+
 /** A complete preset bundle. */
 export interface InspectionPreset {
   /** Identifier — used for persistence and the chip label. */
@@ -56,24 +91,20 @@ export interface InspectionPreset {
   readonly edlStrength: number;
   /** Whether EDL is on in this preset. */
   readonly edlEnabled: boolean;
-  /**
-   * SSAO strength 0..1. Renderer ignores this on backends that don't
-   * yet have the SSAO pass plumbed; the field is shipped so when SSAO
-   * lands the presets pick up the right look without further edits.
-   */
-  readonly aoStrength: number;
-  /** Elevation palette for height colouring. */
-  readonly elevationPalette: ElevationPalette;
   /** Base point size in pixels. */
   readonly pointSize: number;
   /** Fixed or adaptive size by distance. */
   readonly pointSizeMode: 'fixed' | 'adaptive';
   /** Sky / background preset. */
   readonly sky: SkyPreset;
-  /** Whether the hillshade colour-mode overlay is on (terrain only). */
-  readonly hillshade: boolean;
-  /** Default colour-mode to switch into when the preset applies. */
+  /**
+   * Colour mode the preset moves into. Applied per cloud, and only where the
+   * cloud carries what that mode needs; a cloud with no classification keeps
+   * the mode it has rather than rendering a uniform default.
+   */
   readonly defaultColorMode: 'rgb' | 'elevation' | 'classification' | 'density' | 'intensity';
+  /** Declared, not applied to the live view. See `ReservedPresetCapabilities`. */
+  readonly reserved: ReservedPresetCapabilities;
 }
 
 /** The set of preset ids. Closed so the type system catches unknown names. */
@@ -95,13 +126,11 @@ const PRESETS: Readonly<Record<PresetId, InspectionPreset>> = {
     description: 'Balanced default — colour + EDL + light AO for general drone / mobile scans',
     edlEnabled: true,
     edlStrength: 0.7,
-    aoStrength: 0.35,
-    elevationPalette: 'cividis',
     pointSize: 2,
     pointSizeMode: 'adaptive',
     sky: 'survey-blue',
-    hillshade: false,
     defaultColorMode: 'rgb',
+    reserved: { aoStrength: 0.35, elevationPalette: 'cividis', hillshade: false },
   },
   terrain: {
     id: 'terrain',
@@ -109,13 +138,11 @@ const PRESETS: Readonly<Record<PresetId, InspectionPreset>> = {
     description: 'Bare-earth + DTM workflows — hillshade + cividis ramp + warm sky',
     edlEnabled: true,
     edlStrength: 0.55,
-    aoStrength: 0.25,
-    elevationPalette: 'cividis',
     pointSize: 2,
     pointSizeMode: 'adaptive',
     sky: 'terrain-sand',
-    hillshade: true,
     defaultColorMode: 'elevation',
+    reserved: { aoStrength: 0.25, elevationPalette: 'cividis', hillshade: true },
   },
   foliage: {
     id: 'foliage',
@@ -123,13 +150,11 @@ const PRESETS: Readonly<Record<PresetId, InspectionPreset>> = {
     description: 'Forestry + canopy work — soft EDL, deep teal sky, viridis ramp',
     edlEnabled: true,
     edlStrength: 0.5,
-    aoStrength: 0.2,
-    elevationPalette: 'viridis',
     pointSize: 2,
     pointSizeMode: 'adaptive',
     sky: 'foliage-teal',
-    hillshade: false,
     defaultColorMode: 'elevation',
+    reserved: { aoStrength: 0.2, elevationPalette: 'viridis', hillshade: false },
   },
   classification: {
     id: 'classification',
@@ -137,13 +162,11 @@ const PRESETS: Readonly<Record<PresetId, InspectionPreset>> = {
     description: 'ASPRS class review — class palette, modest EDL so colours dominate',
     edlEnabled: true,
     edlStrength: 0.45,
-    aoStrength: 0.15,
-    elevationPalette: 'cividis',
     pointSize: 2.25,
     pointSizeMode: 'adaptive',
     sky: 'deep',
-    hillshade: false,
     defaultColorMode: 'classification',
+    reserved: { aoStrength: 0.15, elevationPalette: 'cividis', hillshade: false },
   },
   qa: {
     id: 'qa',
@@ -151,13 +174,11 @@ const PRESETS: Readonly<Record<PresetId, InspectionPreset>> = {
     description: 'Acceptance review — high EDL + AO, cool sky, density colouring',
     edlEnabled: true,
     edlStrength: 0.85,
-    aoStrength: 0.5,
-    elevationPalette: 'inferno',
     pointSize: 2.5,
     pointSizeMode: 'fixed',
     sky: 'qa-cool',
-    hillshade: false,
     defaultColorMode: 'density',
+    reserved: { aoStrength: 0.5, elevationPalette: 'inferno', hillshade: false },
   },
 } as const;
 

--- a/src/render/skyPresetApply.ts
+++ b/src/render/skyPresetApply.ts
@@ -1,0 +1,77 @@
+/**
+ * skyPresetApply.ts
+ *
+ * Apply a sky preset to the scene, the renderer clear colour, and the canvas
+ * parent's CSS. Extracted from Viewer so the preset stack owns its own
+ * application path and the viewer monolith stops growing to hold it.
+ *
+ * Returns whether the phone layout was used, which the caller stores so a
+ * later resize can tell the two CSS layers apart.
+ */
+
+import * as THREE from 'three';
+
+import { getSkyDefinition } from './skyPresets';
+import type { SkyPreset } from './inspectionPresets';
+
+/** The parts of the Viewer this needs. Structural, so a test can pass a stub. */
+export interface SkyHost {
+  readonly scene: THREE.Scene;
+  readonly renderer: { setClearColor(c: THREE.Color, a: number): void };
+  readonly canvas: HTMLCanvasElement | null | undefined;
+}
+
+/**
+ * Apply a sky preset to the scene + the canvas container CSS.
+ *
+ * The renderer is opaque (`alpha: false`), so the canvas paints over
+ * any CSS background set on its DOM parent. The user only sees what
+ * `scene.background` clears to each frame. Setting both means:
+ *   - `scene.background` is the source of truth the user sees
+ *   - the parent CSS background acts as a fallback for any non-render
+ *     edges (sheet transitions, resize blits) and matches the in-app
+ *     reading so screenshots and HTML embeds stay coherent.
+ *
+ * Radial-gradient presets fall back to their flat `fallbackColor`
+ * when fed into `scene.background` because Three.js takes a solid
+ * Color or a Texture there — CSS gradients can't render against a
+ * WebGPU clear. The fallback colour is chosen to match the centre
+ * of the gradient so the visual difference reads small.
+ */
+export function applySkyPreset(sky: SkyPreset, host: SkyHost): boolean {
+  const def = getSkyDefinition(sky);
+  const color = new THREE.Color(def.fallbackColor);
+  // Three places need the new colour or the user sees nothing:
+  //   1. scene.background — what `renderer.render(scene, camera)`
+  //      clears to when EDL is OFF and the renderer paints direct.
+  //   2. renderer.clearColor — what the EDL post-pipeline pass
+  //      framebuffer clears to when EDL is ON. Without this the
+  //      pass clears to the renderer default (opaque black) and
+  //      the scene.background change is invisible while EDL is on.
+  //   3. parent CSS background — sheet-edge fallback during resize
+  //      / transitions and the source we read back in screenshot
+  //      composition for in-context image exports.
+  host.scene.background = color;
+  host.renderer.setClearColor(color, 1.0);
+  const canvas = host.canvas;
+  if (!canvas) return false;
+  const parent = canvas.parentElement;
+  if (!parent) return false;
+  // Device-aware CSS layer.
+  //   Desktop (≥ 768 px) — apply the rich radial gradient. The wide
+  //     canvas viewport carries the gradient without leaking under
+  //     UI chrome.
+  //   Phone (< 768 px) — apply only the flat fallback colour. On
+  //     phones the Inspector becomes a bottom-sheet covering ~54 %
+  //     of the viewport; a radial gradient extending behind the
+  //     sheet edge or the topbar reads as visual leakage. The flat
+  //     colour confines the visible background to the canvas area
+  //     and matches what the renderer is clearing to anyway.
+  const isPhone =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 767px)').matches;
+  parent.style.background = isPhone ? def.fallbackColor : def.background;
+  parent.style.backgroundColor = def.fallbackColor;
+  return isPhone;
+}

--- a/tests/colorModeSupport.test.ts
+++ b/tests/colorModeSupport.test.ts
@@ -1,0 +1,54 @@
+/**
+ * A preset names the colour mode it moves into, and the mode is not always
+ * available. Forcing Classification on a cloud with no classification field
+ * renders every point one colour, which reads as a broken renderer rather
+ * than as missing data. These tests pin the availability rule itself.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { cloudSupportsColorMode } from '../src/render/colorModeSupport';
+
+const empty = {};
+
+describe('cloudSupportsColorMode', () => {
+  it('requires the attribute each mode reads', () => {
+    expect(cloudSupportsColorMode({ colors: new Uint8Array([1, 2, 3]) }, 'rgb')).toBe(true);
+    expect(cloudSupportsColorMode(empty, 'rgb')).toBe(false);
+
+    expect(cloudSupportsColorMode({ intensity: new Uint16Array([7]) }, 'intensity')).toBe(true);
+    expect(cloudSupportsColorMode(empty, 'intensity')).toBe(false);
+
+    expect(cloudSupportsColorMode({ classification: new Uint8Array([2]) }, 'classification')).toBe(
+      true,
+    );
+    expect(cloudSupportsColorMode(empty, 'classification')).toBe(false);
+
+    expect(cloudSupportsColorMode({ normals: new Float32Array([0, 1, 0]) }, 'normal')).toBe(true);
+    expect(cloudSupportsColorMode(empty, 'normal')).toBe(false);
+
+    expect(cloudSupportsColorMode({ gpsTime: new Float64Array([3e8]) }, 'gpsTime')).toBe(true);
+    expect(cloudSupportsColorMode(empty, 'gpsTime')).toBe(false);
+  });
+
+  it('treats a present-but-empty attribute as absent', () => {
+    // A zero-length typed array is what a reader produces for a field the file
+    // declared and never filled. It is not data, and colouring by it yields a
+    // uniform result rather than an error.
+    expect(cloudSupportsColorMode({ colors: new Uint8Array(0) }, 'rgb')).toBe(false);
+    expect(cloudSupportsColorMode({ classification: new Uint8Array(0) }, 'classification')).toBe(
+      false,
+    );
+  });
+
+  it('allows modes derived from positions, which every cloud has', () => {
+    expect(cloudSupportsColorMode(empty, 'elevation')).toBe(true);
+  });
+
+  it('does not suppress a mode it has not been taught about', () => {
+    // Falling through to the renderer that owns the mode is the safer default.
+    // Returning false here would silently disable a new mode until someone
+    // remembered to edit this file.
+    expect(cloudSupportsColorMode(empty, 'density' as never)).toBe(true);
+  });
+});

--- a/tests/inspectionPresets.test.ts
+++ b/tests/inspectionPresets.test.ts
@@ -30,17 +30,17 @@ describe('listPresets — the catalogue', () => {
       expect(p.description.length).toBeGreaterThan(0);
       expect(p.edlStrength).toBeGreaterThanOrEqual(0);
       expect(p.edlStrength).toBeLessThanOrEqual(1.5);
-      expect(p.aoStrength).toBeGreaterThanOrEqual(0);
-      expect(p.aoStrength).toBeLessThanOrEqual(1);
+      expect(p.reserved.aoStrength).toBeGreaterThanOrEqual(0);
+      expect(p.reserved.aoStrength).toBeLessThanOrEqual(1);
       expect(p.pointSize).toBeGreaterThan(0);
       expect(['fixed', 'adaptive']).toContain(p.pointSizeMode);
-      expect(typeof p.hillshade).toBe('boolean');
+      expect(typeof p.reserved.hillshade).toBe('boolean');
       expect(typeof p.edlEnabled).toBe('boolean');
     }
   });
 
   it('hillshade is only on in the Terrain preset', () => {
-    const hillshadeOn = listPresets().filter((p) => p.hillshade);
+    const hillshadeOn = listPresets().filter((p) => p.reserved.hillshade);
     expect(hillshadeOn).toHaveLength(1);
     expect(hillshadeOn[0].id).toBe('terrain');
   });
@@ -74,5 +74,39 @@ describe('isPresetId', () => {
   it('rejects unknown strings', () => {
     expect(isPresetId('random')).toBe(false);
     expect(isPresetId('')).toBe(false);
+  });
+
+
+  // The v0.6.2 preset model declared aoStrength, elevationPalette and
+  // hillshade alongside fields Viewer.applyPreset() actually set. None of the
+  // three were ever applied and no runtime setter existed for them, so a
+  // preset advertised a palette and a relief mode it could not deliver.
+  // These assertions pin the split rather than the values: a field moved back
+  // into the applied set without a setter behind it fails here.
+  it('the applied surface carries no field the renderer cannot set', () => {
+    for (const p of listPresets()) {
+      expect(p).not.toHaveProperty('aoStrength');
+      expect(p).not.toHaveProperty('elevationPalette');
+      expect(p).not.toHaveProperty('hillshade');
+    }
+  });
+
+  it('every preset declares the reserved capabilities, with the tuned values kept', () => {
+    for (const p of listPresets()) {
+      expect(p.reserved.elevationPalette.length).toBeGreaterThan(0);
+      expect(typeof p.reserved.hillshade).toBe('boolean');
+      expect(Number.isFinite(p.reserved.aoStrength)).toBe(true);
+    }
+    // The values survived the move rather than being reset to a default.
+    expect(getPreset('qa').reserved.elevationPalette).toBe('inferno');
+    expect(getPreset('foliage').reserved.elevationPalette).toBe('viridis');
+    expect(getPreset('qa').reserved.aoStrength).toBe(0.5);
+  });
+
+  it('every preset names a colour mode the viewer can apply', () => {
+    const applicable = ['rgb', 'elevation', 'classification', 'density', 'intensity'];
+    for (const p of listPresets()) {
+      expect(applicable).toContain(p.defaultColorMode);
+    }
   });
 });


### PR DESCRIPTION
`applyPreset()` set five of nine declared fields.

| Field | Was | Now |
|---|---|---|
| `edlEnabled`, `edlStrength`, `pointSize`, `pointSizeMode`, `sky` | applied | applied |
| `defaultColorMode` | **ignored** | applied per cloud, guarded by data availability |
| `aoStrength` | **ignored** | `reserved` (no pass consumes the AO factor) |
| `elevationPalette` | **ignored** | `reserved` (no palette setter exists) |
| `hillshade` | **ignored** | `reserved` (analysis product, not a live control) |

Guarding `defaultColorMode` matters: forcing `classification` on a cloud without it renders a uniform wash that reads as a broken renderer, not as missing data.

- `src/render/colorModeSupport.ts` — availability rule and host interface, testable without a GPU;
- `src/render/skyPresetApply.ts` — sky application out of Viewer, which pays the monolith budget.

Viewer ends 31 lines **below** baseline; documented counts updated to match.

Verified: tsc 0, unit 1106, ui 433, preset 16, build 0, six gates 0.