### PR TITLE
Codecov reporting and badge ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,35 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  # ── Coverage, reported not enforced ───────────────────────────────────────
+  # Deliberately absent from ci-green's `needs`. The release gate already runs
+  # coverage as a mandatory stage and refuses an evidence record without it, so
+  # the authoritative measurement is not this job. What this adds is an
+  # external, per-pull-request view a reviewer can read without running the
+  # suite. Making it blocking would put merges at the mercy of a third-party
+  # service being reachable, to re-assert a number the gate already owns.
+  coverage:
+    runs-on: ubuntu-latest
+    needs: verify
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+      - run: npm ci
+      - name: Collect coverage
+        run: npm run coverage
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
+        with:
+          files: ./coverage/lcov.info
+          # A coverage upload failing must not read as a broken build.
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   # ── The single status to protect the branch with ──────────────────────────
   # Branch protection names one check, not fifteen. Requiring the matrix legs
   # by name would rebind the ruleset every time the sharding changes, and a

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 # OpenLiDARViewer
 
+<!-- Row 1 is software assurance. Two slots are held open:
+     - OpenSSF Scorecard, after api.securityscorecards.dev serves this repo
+       (the workflow already publishes; the last run scored 6.1);
+     - Codecov, after the repository is activated and CODECOV_TOKEN is set.
+     Neither badge is added before it renders a real value. -->
 [![CI](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/ci.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/ci.yml)
-[![Clean clone](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/clean-clone.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/clean-clone.yml)
-[![Benchmark portability](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/benchmark-portability.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/benchmark-portability.yml)
 [![Security audit](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/security.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/security.yml)
+[![Clean clone](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/clean-clone.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/clean-clone.yml)
 
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21544619-1682D4)](https://doi.org/10.5281/zenodo.21544619)
+[![FAIR checklist](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=11&a=22113&i=22322&r=113)
+[![Benchmark portability](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/benchmark-portability.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/benchmark-portability.yml)
 [![Latest release](https://img.shields.io/github/v/release/Aurtechmx/openlidarviewer?color=2F6BFF)](https://github.com/Aurtechmx/openlidarviewer/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey)](LICENSE)
-![Node](https://img.shields.io/badge/node-22.17.1-339933)
-[![FAIR checklist](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=11&a=22113&i=22322&r=113)
 
 [![Live demo](https://img.shields.io/badge/live%20demo-lidar.aurtech.mx-19C2D8)](https://lidar.aurtech.mx/)
-![Status](https://img.shields.io/badge/status-R%26D%20Prototype-teal)
 ![Rendering](https://img.shields.io/badge/rendering-WebGL%20%2F%20WebGPU-blue)
 ![Privacy](https://img.shields.io/badge/privacy-local--first-green)
+![Status](https://img.shields.io/badge/status-R%26D%20Prototype-teal)
+![Node](https://img.shields.io/badge/node-22.17.1-339933)
 
 **A browser-based LiDAR and point-cloud viewer for fast local inspection, 3D navigation, measurement, volume and cross-section analysis, theming, and a command palette — built on a research-derived approach to scan quality, capture provenance, and honesty about uncertainty.**
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,38 @@
+# Coverage is reported, not enforced by a second gate.
+#
+# The release gate already runs coverage as a mandatory stage and refuses an
+# evidence record when it did not run. Codecov's job here is to make the number
+# externally inspectable per pull request, so a reviewer sees what a change did
+# to coverage without running the suite. Setting it to block as well would give
+# two systems a veto over the same measurement, and the one with the weaker
+# claim would win arguments.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # A change that moves total coverage by less than this is noise from
+        # test sharding, not a regression worth a red mark.
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        # New code should carry tests. Informational so it reports rather than
+        # blocks: the branch ruleset names ci-green and CodeQL, and adding a
+        # third required check that depends on a third-party service would make
+        # merges dependent on that service being up.
+        target: 80%
+        informational: true
+
+comment:
+  layout: "condensed_header, diff, flags, components"
+  require_changes: true
+
+# Excluded from the measurement because a percentage over them says nothing
+# about whether the software works.
+ignore:
+  - "tests/**"
+  - "benchmarks/**"
+  - "scripts/**"
+  - "docs-site/**"
+  - "**/*.d.ts"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -102,7 +102,10 @@ export default defineConfig({
      */
     coverage: {
       provider: 'v8',
-      reporter: ['text-summary', 'json-summary'],
+      // lcov is for Codecov; the other two are read by the gate and by a
+      // human respectively. Adding a reporter does not change what is
+      // measured, only how it is written out.
+      reporter: ['text-summary', 'json-summary', 'lcov'],
       include: [
         'src/process/**/*.ts',
         'src/terrain/**/*.ts',


### PR DESCRIPTION
**Coverage.** It ran only inside the release gate, where the number is authoritative but invisible until a release. A CI job now collects and uploads it per pull request. `vitest` gains an `lcov` reporter; what is measured does not change.

Verified locally: `npm run coverage` exits 0 and writes `coverage/lcov.info` (385 KB). Lines 91.56%, functions 88.64%, branches 84.05%.

The upload job is **not** in `ci-green`'s `needs`, and both `codecov.yml` statuses are informational. The gate already refuses an evidence record when coverage did not run; making this blocking would let a third-party outage stop merges to re-assert a number the gate owns.

**Badges** ordered by what they assure. Two slots in row 1 are held open with a comment saying why:
- OpenSSF Scorecard — the workflow publishes (tlog index 2275824089, last score **6.1**), but `api.securityscorecards.dev` does not serve this repo yet;
- Codecov — needs repository activation and `CODECOV_TOKEN`.

Neither badge is added before it renders a real value.