### PR TITLE
E57 namespace anchoring and markdown cell escaping

### DIFF
--- a/benchmarks/framework/reporters/markdown.ts
+++ b/benchmarks/framework/reporters/markdown.ts
@@ -32,7 +32,8 @@ import {
  * unavailability reasons — so neither can be assumed away.
  */
 function md(value: string): string {
-  return value.replace(/\|/g, '\\|').replace(/\s*[\r\n]+\s*/g, '; ');
+  // Backslash first, or a literal `\` before a `|` escapes the escape.
+  return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\s*[\r\n]+\s*/g, '; ');
 }
 
 function table(header: readonly string[], rows: readonly (readonly string[])[]): string {

--- a/scripts/defect-replay-lib.mjs
+++ b/scripts/defect-replay-lib.mjs
@@ -423,7 +423,9 @@ function esc(v) {
 }
 
 function mdCell(v) {
-  return String(v ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  // Backslash first: escaping the pipe alone turns a literal `\` before a
+  // `|` into `\\|`, which markdown renders as a backslash plus a cell break.
+  return String(v ?? '').replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
 export function renderComparisons(registry, probes, records) {

--- a/scripts/render-claim-register.mjs
+++ b/scripts/render-claim-register.mjs
@@ -82,7 +82,8 @@ export function parseClaimRegister(yaml) {
 export function renderClaimRegisterMarkdown({ softwareVersion, generated, claims }) {
   // A literal `|` inside a cell would end the cell; nothing else in the
   // register's prose needs escaping inside a markdown table.
-  const cell = (s) => String(s ?? '—').replace(/\|/g, '\\|');
+  // Backslash first, or a literal `\` before a `|` escapes the escape.
+const cell = (s) => String(s ?? '—').replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
   const header =
     '| Claim | Product | Method@version | Current evidence | Required | External status | Approved claim | Prohibited claims |';
   const rule = `|${' --- |'.repeat(8)}`;

--- a/src/io/e57/schema.ts
+++ b/src/io/e57/schema.ts
@@ -287,8 +287,18 @@ function readScan(scan: XmlNode, warnings: string[]): E57Scan {
 // fabricated zero / blank. Malformed metadata degrades to omission.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** The ASTM E57 core namespace marker — elements in it are "standard". */
-const E57_CORE_NS = /astm\.org\/.*E57/i;
+/**
+ * The ASTM E57 core namespace marker. Elements in it are standard, so they are
+ * skipped when collecting vendor extensions.
+ *
+ * Anchored to the host on purpose. The unanchored form matched `astm.org` and
+ * `E57` anywhere in the URI, so a namespace such as
+ * `http://vendor.example/?ref=astm.org/E57` was read as core and its fields
+ * were dropped from the reported extensions instead of being declared. The
+ * real namespace is `http://www.astm.org/COMMIT/E57/2010-e57-v1.0`, so
+ * requiring astm.org to be the actual host loses nothing.
+ */
+const E57_CORE_NS = /^https?:\/\/(?:www\.)?astm\.org\/[^?#]*E57/i;
 
 /** Trimmed element text, or undefined when the element is missing / empty. */
 function declaredText(node: XmlNode | undefined): string | undefined {

--- a/src/style.css
+++ b/src/style.css
@@ -1483,6 +1483,13 @@ body.olv-theme-light .olv-empty::before {
   border: 0.5px solid var(--hairline);
   border-radius: var(--radius-md); padding: var(--space-lg) var(--space-xl);
   pointer-events: none;
+  /* The overlay scrolls and ignores the pointer, so its own scrollbar is not
+     hittable and cannot be dragged, the same collision the left rail had. It
+     is kept here rather than wired to a toggle: this is the `?debug=1` overlay
+     for a developer, the pass-through is the point, and the wheel still
+     scrolls it. The gutter is reserved so its readings do not shift sideways
+     the moment the list grows past the panel. */
+  scrollbar-gutter: stable;
 }
 .olv-debug-title {
   /* A real <button>: reset the chrome, keep it clickable while the rest of the


### PR DESCRIPTION
Three findings from the CodeQL triage that turned out to be real defects rather than noise.

**E57 core namespace was unanchored.** `/astm\.org\/.*E57/i` matched the strings anywhere in a URI:

```
http://www.astm.org/COMMIT/E57/2010-e57-v1.0   true   (correct)
http://vendor.example/?ref=astm.org/E57        true   (wrong)
http://evil.example/astm.org/x/E57             true   (wrong)
```

That check decides whether a namespaced element is core E57 or a vendor extension. A spoofed URI made a genuine extension read as core, so its declared fields were **silently dropped** from the reported extensions. Under-reporting what a file declares is the class of defect this project exists to avoid.

**Markdown cells escaped the pipe but not the backslash.** A value ending in `\` turned its own escape into a literal and broke the cell. Three writers fixed.

**Debug overlay** keeps `pointer-events: none` — the pass-through is the point for `?debug=1` and the wheel still scrolls it. It gains a stable gutter, and the tradeoff is now written down.

Verified: tsc 0, unit 1107, e57+architecture 53, build 0, claim register regenerates, three document gates 0.