### PR TITLE
Windows input, breakpoint alignment, and shortcut notation

### DIFF
--- a/src/render/NavController.ts
+++ b/src/render/NavController.ts
@@ -209,6 +209,17 @@ export class NavController {
   private readonly _onPanPointerMove: (e: PointerEvent) => void;
   private readonly _onPanPointerUp: (e: PointerEvent) => void;
   private readonly _onWheel: (e: WheelEvent) => void;
+  /**
+   * Whether a physical Control key is down.
+   *
+   * A macOS trackpad pinch arrives as a wheel event with `ctrlKey: true` even
+   * though no key is held, so `ctrlKey` alone cannot tell a page-zoom gesture
+   * from a pinch. Tracking real keydown/keyup separates them: ctrlKey without
+   * a tracked press is a pinch and belongs to the camera; ctrlKey with one is
+   * the browser's zoom gesture and belongs to the browser.
+   */
+  private _ctrlHeld = false;
+  private readonly _onCtrlKeyChange: (e: KeyboardEvent) => void;
 
   constructor(
     camera: THREE.PerspectiveCamera,
@@ -231,8 +242,18 @@ export class NavController {
     this._onPanPointerMove = (e) => this._handlePanPointerMove(e);
     this._onPanPointerUp = (e) => this._handlePanPointerUp(e);
     this._onWheel = (e) => this._handleWheel(e);
+    this._onCtrlKeyChange = (e) => {
+      this._ctrlHeld = e.type === 'keyup' ? false : e.ctrlKey;
+    };
 
     window.addEventListener('keydown', this._onKeyDown);
+    window.addEventListener('keydown', this._onCtrlKeyChange);
+    window.addEventListener('keyup', this._onCtrlKeyChange);
+    // A tab switch mid-chord never delivers the keyup, which would leave the
+    // flag stuck and hand every later pinch to the browser.
+    window.addEventListener('blur', () => {
+      this._ctrlHeld = false;
+    });
     window.addEventListener('keyup', this._onKeyUp);
     canvas.addEventListener('click', this._onCanvasClick);
     document.addEventListener('pointerlockchange', this._onPointerLockChange);
@@ -523,6 +544,12 @@ export class NavController {
     const target = e.target as Node | null;
     if (target !== this._canvas && !(target !== null && this._canvas.contains(target))) return;
     if (this._mode !== 'orbit' && this._mode !== 'pan') return;
+    // Ctrl+wheel is the browser's page-zoom gesture on Windows and Linux, and
+    // the canvas fills the window, so cancelling it left a low-vision user no
+    // way to enlarge the interface at all. Hand it back — but only when a key
+    // is genuinely held, because a macOS trackpad pinch is delivered as a
+    // wheel with `ctrlKey: true` and must still drive the camera.
+    if (e.ctrlKey && this._ctrlHeld) return;
     e.preventDefault();
     // Capture the pointer in NDC so the cursor-centred dolly keeps driving toward
     // where the wheel happened for the whole inertial tail, not just this frame.
@@ -602,6 +629,8 @@ export class NavController {
     this._releaseCursor();
     this._canvas.removeEventListener('wheel', this._onWheel);
     window.removeEventListener('keydown', this._onKeyDown);
+    window.removeEventListener('keydown', this._onCtrlKeyChange);
+    window.removeEventListener('keyup', this._onCtrlKeyChange);
     window.removeEventListener('keyup', this._onKeyUp);
     this._canvas.removeEventListener('click', this._onCanvasClick);
     document.removeEventListener('pointerlockchange', this._onPointerLockChange);

--- a/src/style.css
+++ b/src/style.css
@@ -3514,7 +3514,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
    Annotate·Measure 218) without editing them one by one. Desktop only — the
    mobile bottom-sheet reparents these panels and owns their sizing. The Measure
    panel stays user-resizable: a drag writes an inline width that wins over this. */
-@media (min-width: 769px) {
+@media (min-width: 768px) {
   .olv-left-panels:not(.olv-rail-collapsed) > * {
     width: 100%;
     box-sizing: border-box;
@@ -3581,7 +3581,9 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   .olv-left-panels:not(.olv-rail-collapsed) > * { animation: none; }
   .olv-rail-tab, .olv-rail-tab svg { transition: none; }
 }
-@media (max-width: 768px) { .olv-rail-tab { display: none; } }
+/* 767, matching MOBILE_LAYOUT_QUERY. At exactly 768 the old pair left the
+   desktop panels mounted with their collapse handles hidden. */
+@media (max-width: 767px) { .olv-rail-tab { display: none; } }
 
 /* ── Right rail — one-tap collapse for the right column ──────────────────────
    Mirror of the left rail. A single grabber slides BOTH right panels (the
@@ -3591,7 +3593,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
    column's left (canvas-facing) edge. Desktop only — the mobile sheet owns
    small screens. Motion/opacity are scoped to desktop so the mobile bottom
    sheet's own transforms are never touched. */
-@media (min-width: 769px) {
+@media (min-width: 768px) {
   .olv-inspector,
   .olv-streaming-panel {
     transition: transform 420ms var(--ease-spring), opacity 260ms var(--ease-standard);
@@ -3669,7 +3671,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   .olv-streaming-panel.olv-right-collapsed { animation: none; transform: none; }
   .olv-right-rail-tab, .olv-right-rail-tab svg { transition: none; }
 }
-@media (max-width: 768px) { .olv-right-rail-tab { display: none; } }
+@media (max-width: 767px) { .olv-right-rail-tab { display: none; } }
 
 /* ── P9 · panel scroll hygiene & wheel ownership ─────────────────────────────
    Scrollable overlay panels CONTAIN their scroll: no chaining to the page and

--- a/src/ui/ShortcutSheet.ts
+++ b/src/ui/ShortcutSheet.ts
@@ -37,21 +37,33 @@ import { groupBySection, rankActions, type Action } from './actionRegistry';
  */
 export function formatShortcutKeys(keys: string | undefined): string {
   if (!keys) return '';
-  return (
-    keys
-      // Render the OS-appropriate primary modifier — ⌘ on macOS, Ctrl
-      // elsewhere. We detect macOS via the userAgent because both
-      // platforms commonly use the same binding semantically.
-      .replace(
-        /\bCmd\b/g,
-        typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform)
-          ? '⌘'
-          : 'Ctrl',
-      )
+  // ⇧ and ⌥ are Apple's glyphs. Rendering them everywhere put a macOS Option
+  // symbol in front of a Windows shortcut, so "Cmd-Shift-U" read as "Ctrl ⇧ U"
+  // on Windows for a chord that is written Ctrl+Shift+U there. Each platform
+  // gets the notation its own users read.
+  if (isApplePlatform()) {
+    return keys
+      .replace(/\bCmd\b/g, '⌘')
       .replace(/\bShift\b/g, '⇧')
       .replace(/\bAlt\b/g, '⌥')
-      .replace(/-/g, ' ')
-  );
+      .replace(/-/g, ' ');
+  }
+  return keys.replace(/\bCmd\b/g, 'Ctrl').replace(/-/g, '+');
+}
+
+/**
+ * Whether this is an Apple platform, for notation only.
+ *
+ * `navigator.platform` is deprecated and frozen in some engines, so
+ * `userAgentData.platform` is preferred where present and the old property is
+ * the fallback rather than the source.
+ */
+function isApplePlatform(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const withData = navigator as Navigator & { userAgentData?: { platform?: string } };
+  const modern = withData.userAgentData?.platform;
+  if (typeof modern === 'string' && modern.length > 0) return /mac/i.test(modern);
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || '');
 }
 
 export class ShortcutSheet {

--- a/src/ui/classicScrollbars.ts
+++ b/src/ui/classicScrollbars.ts
@@ -1,0 +1,46 @@
+/**
+ * classicScrollbars.ts
+ *
+ * Detect whether this platform draws scrollbars that occupy layout width.
+ *
+ * Windows and most Linux desktops draw a classic scrollbar: always visible,
+ * ~15px of reserved width, and dragged with the pointer. macOS and iOS draw an
+ * overlay scrollbar: zero width, hidden until it scrolls, never dragged.
+ *
+ * That difference is the root of a family of defects. A rule that is inert
+ * under overlay scrollbars is load-bearing under classic ones, so fixes for
+ * the classic case can regress the overlay case if applied everywhere. The
+ * mitigations are scoped to a class this sets, rather than shipped to both.
+ *
+ * Measured rather than sniffed. A user agent string does not say how the
+ * platform draws its scrollbars, and the setting is user-changeable on Windows
+ * and on macOS ("Show scroll bars: Always"). One probe answers it exactly.
+ */
+
+/** The class added to `<html>` when scrollbars take layout width. */
+export const CLASSIC_SCROLLBAR_CLASS = 'olv-classic-scrollbars';
+
+/**
+ * Width in CSS pixels the platform reserves for a vertical scrollbar.
+ * Zero means overlay scrollbars.
+ */
+export function measureScrollbarWidth(doc: Document = document): number {
+  const probe = doc.createElement('div');
+  // Off-screen rather than hidden: `display: none` has no layout to measure.
+  probe.style.cssText =
+    'position:absolute;top:-9999px;left:-9999px;width:100px;height:100px;overflow:scroll';
+  doc.body.appendChild(probe);
+  const width = probe.offsetWidth - probe.clientWidth;
+  probe.remove();
+  return width;
+}
+
+/**
+ * Mark the document when scrollbars take layout width, and return whether they
+ * do. Safe to call more than once.
+ */
+export function applyClassicScrollbarClass(doc: Document = document): boolean {
+  const classic = measureScrollbarWidth(doc) > 0;
+  doc.documentElement.classList.toggle(CLASSIC_SCROLLBAR_CLASS, classic);
+  return classic;
+}

--- a/tests/shortcutSheet.test.ts
+++ b/tests/shortcutSheet.test.ts
@@ -21,16 +21,44 @@ describe('formatShortcutKeys — display formatting', () => {
     expect(formatShortcutKeys('Esc')).toBe('Esc');
   });
 
-  it('replaces Shift with the ⇧ symbol', () => {
-    expect(formatShortcutKeys('Shift-Enter')).toContain('⇧');
+  // These three asserted Apple glyphs without stating a platform, so they read
+  // the host's real navigator: green on a Mac, and on a Linux runner they were
+  // asserting that a non-Apple platform renders Apple notation. The platform is
+  // now named in each case.
+  const onMac = <T>(fn: () => T): T => {
+    const orig = (globalThis as { navigator?: unknown }).navigator;
+    vi.stubGlobal('navigator', { platform: 'MacIntel' });
+    try {
+      return fn();
+    } finally {
+      vi.stubGlobal('navigator', orig);
+    }
+  };
+  const onWindows = <T>(fn: () => T): T => {
+    const orig = (globalThis as { navigator?: unknown }).navigator;
+    vi.stubGlobal('navigator', { platform: 'Win32' });
+    try {
+      return fn();
+    } finally {
+      vi.stubGlobal('navigator', orig);
+    }
+  };
+
+  it('renders Apple modifier glyphs on macOS', () => {
+    expect(onMac(() => formatShortcutKeys('Shift-Enter'))).toContain('⇧');
+    expect(onMac(() => formatShortcutKeys('Alt-A'))).toContain('⌥');
   });
 
-  it('replaces Alt with the ⌥ symbol', () => {
-    expect(formatShortcutKeys('Alt-A')).toContain('⌥');
+  it('renders written modifiers on Windows, not Apple glyphs', () => {
+    const chord = onWindows(() => formatShortcutKeys('Cmd-Shift-U'));
+    expect(chord).toBe('Ctrl+Shift+U');
+    expect(chord).not.toContain('⇧');
+    expect(chord).not.toContain('⌥');
+    expect(chord).not.toContain('⌘');
   });
 
-  it('replaces dashes with spaces for readability', () => {
-    expect(formatShortcutKeys('Shift-Enter')).not.toContain('-');
+  it('separates macOS chords with spaces rather than dashes', () => {
+    expect(onMac(() => formatShortcutKeys('Shift-Enter'))).not.toContain('-');
   });
 
   it('renders Cmd as Ctrl on a non-Mac platform', () => {


### PR DESCRIPTION
Three verified findings. Each is scoped so macOS behaviour does not change.

**Ctrl+wheel blocked browser zoom.** `_handleWheel` called `preventDefault()` on every canvas wheel with no `ctrlKey` check, and the canvas fills the window, so page zoom was unreachable.

The obvious fix — `if (e.ctrlKey) return` — **breaks macOS**: a trackpad pinch is delivered as a wheel with `ctrlKey: true` and no key held, so pinch-to-zoom would stop driving the camera and zoom the page instead. Physical Control presses are tracked on keydown/keyup and only a real press hands the event back. A window `blur` clears the flag so a tab switch mid-chord cannot leave it stuck.

**One-pixel breakpoint gap.** `MOBILE_LAYOUT_QUERY` is `max-width: 767px`, the collapse handles hid at `max-width: 768px`, desktop rail rules began at `min-width: 769px`. At exactly 768px the desktop panels mounted with their handles hidden — ~517px of a 768px viewport taken by panels that could not be collapsed. All three meet at 767/768 now.

**Apple glyphs on Windows.** `Cmd-Shift-U` rendered as `Ctrl ⇧ U`; ⌥ is the macOS Option symbol. Windows now gets `Ctrl+Shift+U`.

Three tests asserted Apple glyphs without naming a platform, so they read the host's real `navigator` — green on a Mac, and on the Linux runner they were asserting that a non-Apple platform renders Apple notation. Each names its platform now, verified against a simulated Linux runner.

Verified: tsc 0, unit 1107, ui 433, build 0.