### PR TITLE
Scope scrollbar work to Windows, shrink the nav legend, drop the F11 claim

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1972,8 +1972,11 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   background: rgba(11, 17, 33,0.82);
   -webkit-backdrop-filter: blur(10px); backdrop-filter: blur(10px);
   border: 0.5px solid var(--hairline);
-  border-radius: var(--radius-lg); padding: var(--space-lg) var(--space-xl);
-  max-width: 640px;
+  border-radius: var(--radius-lg);
+  /* Tighter than it was, and narrower. At 640px with the roomier padding the
+     legend covered the middle of the view, which is where the scan is. */
+  padding: var(--space-md) var(--space-lg);
+  max-width: 460px;
 }
 /* v0.3.10 — Header row carries the title + X close button.
    Flex layout keeps the title flush-left and the X flush-right so the
@@ -3477,7 +3480,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
    be dragged and the rail reads as stalled. wireRailScrollAffordance() adds
    this class only while the column actually overflows, so the canvas keeps its
    pass-through everywhere a scrollbar is not present. */
-.olv-left-panels.olv-rail-scrollable { pointer-events: auto; }
+.olv-classic-scrollbars .olv-left-panels.olv-rail-scrollable { pointer-events: auto; }
 
 /* ── P11 · premium left rail — dock clearance, one-tap collapse, even sizing ─────
    Desktop/tablet only (mobile bottom-sheet owns small screens). Token-driven so
@@ -3741,50 +3744,50 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
     scrollbar-color: var(--hairline-strong) transparent;
   }
 }
-.olv-palette-list::-webkit-scrollbar,
-.olv-modal-body::-webkit-scrollbar,
-.olv-help-body::-webkit-scrollbar,
-.olv-msheet-body::-webkit-scrollbar,
-.olv-measure-panel::-webkit-scrollbar,
-.olv-bc-dialog::-webkit-scrollbar,
-.olv-wfc-card::-webkit-scrollbar,
-.olv-left-panels::-webkit-scrollbar,
-.olv-inspector::-webkit-scrollbar,
-.olv-streaming-panel::-webkit-scrollbar,
-.olv-catalog-results::-webkit-scrollbar,
-.olv-mp-stations-wrap::-webkit-scrollbar,
-.olv-shortcuts-list::-webkit-scrollbar {
+.olv-classic-scrollbars .olv-palette-list::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-modal-body::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-help-body::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-msheet-body::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-measure-panel::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-bc-dialog::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-wfc-card::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-left-panels::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-inspector::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-streaming-panel::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-catalog-results::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-mp-stations-wrap::-webkit-scrollbar,
+.olv-classic-scrollbars .olv-shortcuts-list::-webkit-scrollbar {
   width: 10px;
   height: 10px;
 }
-.olv-palette-list::-webkit-scrollbar-track,
-.olv-modal-body::-webkit-scrollbar-track,
-.olv-help-body::-webkit-scrollbar-track,
-.olv-msheet-body::-webkit-scrollbar-track,
-.olv-measure-panel::-webkit-scrollbar-track,
-.olv-bc-dialog::-webkit-scrollbar-track,
-.olv-wfc-card::-webkit-scrollbar-track,
-.olv-left-panels::-webkit-scrollbar-track,
-.olv-inspector::-webkit-scrollbar-track,
-.olv-streaming-panel::-webkit-scrollbar-track,
-.olv-catalog-results::-webkit-scrollbar-track,
-.olv-mp-stations-wrap::-webkit-scrollbar-track,
-.olv-shortcuts-list::-webkit-scrollbar-track {
+.olv-classic-scrollbars .olv-palette-list::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-modal-body::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-help-body::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-msheet-body::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-measure-panel::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-bc-dialog::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-wfc-card::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-left-panels::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-inspector::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-streaming-panel::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-catalog-results::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-mp-stations-wrap::-webkit-scrollbar-track,
+.olv-classic-scrollbars .olv-shortcuts-list::-webkit-scrollbar-track {
   background: transparent;
 }
-.olv-palette-list::-webkit-scrollbar-thumb,
-.olv-modal-body::-webkit-scrollbar-thumb,
-.olv-help-body::-webkit-scrollbar-thumb,
-.olv-msheet-body::-webkit-scrollbar-thumb,
-.olv-measure-panel::-webkit-scrollbar-thumb,
-.olv-bc-dialog::-webkit-scrollbar-thumb,
-.olv-wfc-card::-webkit-scrollbar-thumb,
-.olv-left-panels::-webkit-scrollbar-thumb,
-.olv-inspector::-webkit-scrollbar-thumb,
-.olv-streaming-panel::-webkit-scrollbar-thumb,
-.olv-catalog-results::-webkit-scrollbar-thumb,
-.olv-mp-stations-wrap::-webkit-scrollbar-thumb,
-.olv-shortcuts-list::-webkit-scrollbar-thumb {
+.olv-classic-scrollbars .olv-palette-list::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-modal-body::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-help-body::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-msheet-body::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-measure-panel::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-bc-dialog::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-wfc-card::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-left-panels::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-inspector::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-streaming-panel::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-catalog-results::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-mp-stations-wrap::-webkit-scrollbar-thumb,
+.olv-classic-scrollbars .olv-shortcuts-list::-webkit-scrollbar-thumb {
   background: var(--hairline-strong);
   border-radius: 999px;
   /* Inset the thumb without shrinking the 10px hit area: the border is
@@ -3793,36 +3796,36 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   border: 2px solid transparent;
   background-clip: padding-box;
 }
-.olv-palette-list::-webkit-scrollbar-thumb:hover,
-.olv-modal-body::-webkit-scrollbar-thumb:hover,
-.olv-help-body::-webkit-scrollbar-thumb:hover,
-.olv-msheet-body::-webkit-scrollbar-thumb:hover,
-.olv-measure-panel::-webkit-scrollbar-thumb:hover,
-.olv-bc-dialog::-webkit-scrollbar-thumb:hover,
-.olv-wfc-card::-webkit-scrollbar-thumb:hover,
-.olv-left-panels::-webkit-scrollbar-thumb:hover,
-.olv-inspector::-webkit-scrollbar-thumb:hover,
-.olv-streaming-panel::-webkit-scrollbar-thumb:hover,
-.olv-catalog-results::-webkit-scrollbar-thumb:hover,
-.olv-mp-stations-wrap::-webkit-scrollbar-thumb:hover,
-.olv-shortcuts-list::-webkit-scrollbar-thumb:hover {
+.olv-classic-scrollbars .olv-palette-list::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-modal-body::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-help-body::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-msheet-body::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-measure-panel::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-bc-dialog::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-wfc-card::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-left-panels::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-inspector::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-streaming-panel::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-catalog-results::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-mp-stations-wrap::-webkit-scrollbar-thumb:hover,
+.olv-classic-scrollbars .olv-shortcuts-list::-webkit-scrollbar-thumb:hover {
   background: var(--accent);
   background-clip: padding-box;
 }
 /* The corner where two scrollbars meet defaults to opaque white. */
-.olv-palette-list::-webkit-scrollbar-corner,
-.olv-modal-body::-webkit-scrollbar-corner,
-.olv-help-body::-webkit-scrollbar-corner,
-.olv-msheet-body::-webkit-scrollbar-corner,
-.olv-measure-panel::-webkit-scrollbar-corner,
-.olv-bc-dialog::-webkit-scrollbar-corner,
-.olv-wfc-card::-webkit-scrollbar-corner,
-.olv-left-panels::-webkit-scrollbar-corner,
-.olv-inspector::-webkit-scrollbar-corner,
-.olv-streaming-panel::-webkit-scrollbar-corner,
-.olv-catalog-results::-webkit-scrollbar-corner,
-.olv-mp-stations-wrap::-webkit-scrollbar-corner,
-.olv-shortcuts-list::-webkit-scrollbar-corner {
+.olv-classic-scrollbars .olv-palette-list::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-modal-body::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-help-body::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-msheet-body::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-measure-panel::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-bc-dialog::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-wfc-card::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-left-panels::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-inspector::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-streaming-panel::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-catalog-results::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-mp-stations-wrap::-webkit-scrollbar-corner,
+.olv-classic-scrollbars .olv-shortcuts-list::-webkit-scrollbar-corner {
   background: transparent;
 }
 

--- a/src/ui/FullscreenToggle.ts
+++ b/src/ui/FullscreenToggle.ts
@@ -4,8 +4,15 @@
  * A header button that toggles the browser Fullscreen API on the whole app
  * (document root). The glyph swaps between an "expand to corners" enter mark
  * and an "arrows inward" exit mark, and stays in sync with the actual
- * fullscreen state — so it reflects the user pressing F11 or Esc directly,
- * not just clicks on this button. Self-contained: no host wiring needed.
+ * Fullscreen API state, so Esc and a second click both leave the button
+ * correct. Self-contained: no host wiring needed.
+ *
+ * It does NOT track F11. F11 is the browser's own fullscreen, which is a
+ * window state rather than an element one: it fires no `fullscreenchange` and
+ * leaves `document.fullscreenElement` null, and no cross-browser API reports
+ * it. An earlier comment here claimed the button reflected F11, and on Windows
+ * — where F11 is the usual way to do this — it did not. The labels say "app
+ * full screen" so the two are not conflated.
  *
  * Safari still ships the webkit-prefixed Fullscreen API, so request/exit/state
  * and the change event are all read through prefixed fallbacks.
@@ -64,8 +71,8 @@ export class FullscreenToggle {
     this.element = el('button', {
       className: 'olv-fs-toggle',
       unsafeHtml: ICON_ENTER,
-      title: 'Enter full screen',
-      ariaLabel: 'Enter full screen',
+      title: 'Enter app full screen',
+      ariaLabel: 'Enter app full screen',
     }) as HTMLButtonElement;
     this.element.type = 'button';
     this.element.setAttribute('aria-pressed', 'false');
@@ -110,8 +117,8 @@ export class FullscreenToggle {
   private _sync(): void {
     const fs = this._isFullscreen();
     this.element.innerHTML = fs ? ICON_EXIT : ICON_ENTER;
-    this.element.title = fs ? 'Exit full screen' : 'Enter full screen';
-    this.element.setAttribute('aria-label', fs ? 'Exit full screen' : 'Enter full screen');
+    this.element.title = fs ? 'Exit app full screen' : 'Enter app full screen';
+    this.element.setAttribute('aria-label', fs ? 'Exit app full screen' : 'Enter app full screen');
     this.element.setAttribute('aria-pressed', fs ? 'true' : 'false');
     this.element.classList.toggle('is-fs', fs);
   }

--- a/src/ui/NavBar.ts
+++ b/src/ui/NavBar.ts
@@ -1,4 +1,5 @@
 import { el } from './dom';
+import { storageGet, storageSet } from './safeStorage';
 import type { NavMode } from '../render/NavController';
 import {
   CAMERA_PRESET_KEY,
@@ -123,6 +124,29 @@ function legendItem(keys: string[], caption: string): HTMLElement {
   ]);
 }
 
+
+/**
+ * Persisted state for the navigation legend.
+ *
+ * Absent means the user has never chosen, which is the only case that opens
+ * the legend for them. Storage failures degrade to "does not persist", so a
+ * sandboxed embed still opens with the legend rather than crashing.
+ */
+const HELP_PINNED_KEY = 'olv.nav.helpPinned';
+
+function hasStoredHelpPinned(): boolean {
+  return storageGet(HELP_PINNED_KEY) !== null;
+}
+
+function readStoredHelpPinned(): boolean {
+  const stored = storageGet(HELP_PINNED_KEY);
+  return stored === null ? true : stored === '1';
+}
+
+function writeStoredHelpPinned(pinned: boolean): void {
+  storageSet(HELP_PINNED_KEY, pinned ? '1' : '0');
+}
+
 /**
  * The bottom-centre navigation bar: a three-way mode switcher (Orbit / Walk /
  * Fly), a speed slider for walk & fly, a glassy controls HUD, and a centred
@@ -155,7 +179,17 @@ export class NavBar {
   // and the H keyboard shortcut both flip this; flashHelp() is a no-op
   // when already pinned. Camera presets and the legend stay on screen
   // until the user explicitly dismisses them.
-  private _helpPinned = true;
+  /**
+   * Whether the navigation legend is pinned open.
+   *
+   * It used to start open on every scan, and `flashHelp()` re-pinned it each
+   * time a new one loaded. The legend is a 640px panel over the middle of the
+   * view, so the first thing a user saw of their own scan was the help for
+   * reading it. It now opens for a first-time user and remembers the choice
+   * after that; H, the dock's Help button and the command palette all bring it
+   * back.
+   */
+  private _helpPinned = readStoredHelpPinned();
   private _hintTimer: number | null = null;
   private _touchTimer: number | null = null;
 
@@ -494,6 +528,7 @@ export class NavBar {
   /** Toggle the controls HUD (the `H` key / help action). */
   toggleHelp(): void {
     this._helpPinned = !this._helpPinned;
+    writeStoredHelpPinned(this._helpPinned);
     this._render();
   }
 
@@ -504,6 +539,13 @@ export class NavBar {
    * having the HUD come back, then auto-close = surprising).
    */
   flashHelp(): void {
+    // Only for someone who has never chosen. Re-pinning on every scan load
+    // overrode a dismissal the user had already made, so the panel came back
+    // over the view each time they opened a file.
+    if (hasStoredHelpPinned()) {
+      this._render();
+      return;
+    }
     this._helpPinned = true;
     if (this._hintTimer !== null) {
       clearTimeout(this._hintTimer);

--- a/src/ui/classicScrollbars.ts
+++ b/src/ui/classicScrollbars.ts
@@ -1,0 +1,46 @@
+/**
+ * classicScrollbars.ts
+ *
+ * Detect whether this platform draws scrollbars that occupy layout width.
+ *
+ * Windows and most Linux desktops draw a classic scrollbar: always visible,
+ * ~15px of reserved width, and dragged with the pointer. macOS and iOS draw an
+ * overlay scrollbar: zero width, hidden until it scrolls, never dragged.
+ *
+ * That difference is the root of a family of defects. A rule that is inert
+ * under overlay scrollbars is load-bearing under classic ones, so fixes for
+ * the classic case can regress the overlay case if applied everywhere. The
+ * mitigations are scoped to a class this sets, rather than shipped to both.
+ *
+ * Measured rather than sniffed. A user agent string does not say how the
+ * platform draws its scrollbars, and the setting is user-changeable on Windows
+ * and on macOS ("Show scroll bars: Always"). One probe answers it exactly.
+ */
+
+/** The class added to `<html>` when scrollbars take layout width. */
+export const CLASSIC_SCROLLBAR_CLASS = 'olv-classic-scrollbars';
+
+/**
+ * Width in CSS pixels the platform reserves for a vertical scrollbar.
+ * Zero means overlay scrollbars.
+ */
+export function measureScrollbarWidth(doc: Document = document): number {
+  const probe = doc.createElement('div');
+  // Off-screen rather than hidden: `display: none` has no layout to measure.
+  probe.style.cssText =
+    'position:absolute;top:-9999px;left:-9999px;width:100px;height:100px;overflow:scroll';
+  doc.body.appendChild(probe);
+  const width = probe.offsetWidth - probe.clientWidth;
+  probe.remove();
+  return width;
+}
+
+/**
+ * Mark the document when scrollbars take layout width, and return whether they
+ * do. Safe to call more than once.
+ */
+export function applyClassicScrollbarClass(doc: Document = document): boolean {
+  const classic = measureScrollbarWidth(doc) > 0;
+  doc.documentElement.classList.toggle(CLASSIC_SCROLLBAR_CLASS, classic);
+  return classic;
+}

--- a/src/ui/panelChrome.ts
+++ b/src/ui/panelChrome.ts
@@ -8,6 +8,7 @@
  * custom properties — so they belong beside the panels rather than in main.ts.
  */
 import { el } from './dom';
+import { applyClassicScrollbarClass } from './classicScrollbars';
 
 /**
  * Keep the left panel column clear of the measure toolbar (v0.4.5 overlap
@@ -50,7 +51,7 @@ export function wireMeasureBarClearance(bar: HTMLElement, column: HTMLElement): 
 export function wireDockClearance(dock: HTMLElement, column: HTMLElement): void {
   // The column's scroll affordance travels with it, so the composition root
   // wires the rail once rather than remembering two calls that must agree.
-  wireRailScrollAffordance(column);
+  wireRailScrollAffordance(column, applyClassicScrollbarClass());
   if (typeof ResizeObserver === 'undefined') return;
   try {
     const ro = new ResizeObserver(() => {
@@ -82,7 +83,15 @@ export function wireDockClearance(dock: HTMLElement, column: HTMLElement): void 
  * hit-testable while its content actually overflows, which is exactly when a
  * scrollbar exists for the user to reach.
  */
-export function wireRailScrollAffordance(column: HTMLElement): () => void {
+export function wireRailScrollAffordance(
+  column: HTMLElement,
+  classicScrollbars = true,
+): () => void {
+  // Overlay-scrollbar platforms have nothing to grab, so the class would cost
+  // the canvas its pass-through in the gaps between panels and buy nothing.
+  // Passed in rather than read here: platform detection belongs at the point
+  // that composes the UI, and this stays testable without a document.
+  if (!classicScrollbars) return () => {};
   const sync = (): void => {
     column.classList.toggle('olv-rail-scrollable', column.scrollHeight > column.clientHeight);
   };

--- a/tests/railScrollAffordance.test.ts
+++ b/tests/railScrollAffordance.test.ts
@@ -45,8 +45,8 @@ function makeColumn(scrollHeight: number, clientHeight: number): ColumnStub {
   };
 }
 
-const wire = (c: ColumnStub): (() => void) =>
-  wireRailScrollAffordance(c as unknown as HTMLElement);
+const wire = (c: ColumnStub, classic = true): (() => void) =>
+  wireRailScrollAffordance(c as unknown as HTMLElement, classic);
 
 /**
  * The node environment has neither observer, and with none attached the
@@ -115,5 +115,13 @@ describe('wireRailScrollAffordance', () => {
     const column = makeColumn(400, 400); // fits, and still opts in
     disposers.push(wire(column));
     expect(column.classes.has('olv-rail-scrollable')).toBe(true);
+  });
+
+  it('does nothing on an overlay-scrollbar platform', () => {
+    // macOS draws no scrollbar to grab, so opting the column in would only
+    // take the canvas's pass-through in the gaps between panels.
+    const column = makeColumn(1200, 400);
+    disposers.push(wire(column, false));
+    expect(column.classes.has('olv-rail-scrollable')).toBe(false);
   });
 });


### PR DESCRIPTION
**macOS regression from my own earlier change.** The themed scrollbars replaced macOS's overlay scrollbars with always-visible classic ones — a regression there for a fix only Windows needed.

`classicScrollbars.ts` measures the platform once and marks the document only where scrollbars take layout width. The theming, the stable gutter and the rail hit-target all sit behind that class. Measured, not user-agent sniffed: the setting is user-changeable on Windows and on macOS.

```
overlay platform: measured 0 -> not marked -> native scrollbar (1px)
class forced:                             -> themed bar     (11px)
```

**Navigation legend.** Pinned open on load, and `flashHelp()` re-pinned it on every scan — so the first thing a user saw of their scan was a 640px panel of help for reading it, and dismissing it did not stick. It now opens for a first-time user, remembers the choice, and is narrower (460px) and tighter. H, the dock Help button and the command palette all bring it back.

**F11.** The comment claimed the button reflected F11. F11 is browser fullscreen — a window state, not an element one: no `fullscreenchange`, `document.fullscreenElement` stays null, no cross-browser API reports it. On Windows, where F11 is the usual way, the button was wrong. Claim removed, labels say "app full screen".

Verified: tsc 0, unit 1112, ui 433, build 0, four gates 0.