### PR TITLE
LAS memory estimate ignored colour

### DIFF
--- a/src/io/lasHeader.ts
+++ b/src/io/lasHeader.ts
@@ -227,12 +227,16 @@ export function parseLasHeader(buffer: ArrayBuffer): LasHeader {
 /**
  * The per-point attributes a decoded LAS/LAZ cloud carries in this viewer.
  *
- * The loader decodes position, intensity, classification, and — since
- * the inspection extras (return number/count, point source ID, GPS
- * time); not RGB or surface normals. The set is fixed regardless of the LAS
- * point format. It sizes the load-memory estimate
+ * The loader decodes position, intensity, classification, the inspection
+ * extras (return number/count, point source ID, GPS time), and RGB where the
+ * point format carries it. It sizes the load-memory estimate
  * (`estimateMemoryBytes`); `hasLasExtras` keeps that estimate honest about the
  * ~12 extra bytes per point the attributes add.
+ *
+ * Kept for callers that have no header to read. Anything holding a parsed
+ * header should use `lasDecodedAttributes(pointFormat)` instead: this constant
+ * declares no colour, and a colour-bearing file decodes one anyway, so the
+ * estimate comes in low exactly where memory is tightest.
  */
 export const LAS_DECODED_ATTRIBUTES: PointAttributes = {
   hasColor: false,
@@ -241,3 +245,29 @@ export const LAS_DECODED_ATTRIBUTES: PointAttributes = {
   hasNormals: false,
   hasLasExtras: true,
 };
+
+/**
+ * LAS point formats that carry RGB, per the ASPRS specification.
+ *
+ * 2, 3 and 5 are the LAS 1.2/1.3 colour formats; 7, 8 and 10 are their 1.4
+ * counterparts. 8 and 10 also carry NIR, which the loader does not decode.
+ */
+const RGB_POINT_FORMATS: ReadonlySet<number> = new Set([2, 3, 5, 7, 8, 10]);
+
+/** Whether a LAS point format carries RGB. */
+export function pointFormatHasRgb(pointFormat: number): boolean {
+  return RGB_POINT_FORMATS.has(pointFormat);
+}
+
+/**
+ * What the loader will actually decode from this point format.
+ *
+ * The memory estimate drives admission, so declaring no colour for a file that
+ * decodes colour understates the peak: three bytes per point in the cloud that
+ * ships, and six more per point while the raw 16-bit channels are still
+ * staged. On a large colour-bearing scan the planner admits a point budget the
+ * device cannot hold, which is the outcome the estimate exists to prevent.
+ */
+export function lasDecodedAttributes(pointFormat: number): PointAttributes {
+  return { ...LAS_DECODED_ATTRIBUTES, hasColor: pointFormatHasRgb(pointFormat) };
+}

--- a/src/io/loadFile.ts
+++ b/src/io/loadFile.ts
@@ -5,7 +5,7 @@ import { PointCloud } from '../model/PointCloud';
 import type { CloudMetadata } from '../model/PointCloud';
 import type { LoadResult } from './parseBuffer';
 import { POINT_BUDGET, parseBuffer } from './parseBuffer';
-import { parseLasHeader, LAS_DECODED_ATTRIBUTES } from './lasHeader';
+import { parseLasHeader, lasDecodedAttributes } from './lasHeader';
 import {
   planLoad,
   NON_STREAMING_FORMATS,
@@ -120,7 +120,7 @@ function buildLasPlan(
       budget,
       isMobile: options.isMobile ?? false,
       deviceMemoryGB: options.deviceMemoryGB,
-      attributes: LAS_DECODED_ATTRIBUTES,
+      attributes: lasDecodedAttributes(header.pointFormat),
       format,
     });
   } catch {

--- a/tests/lasColourEstimate.test.ts
+++ b/tests/lasColourEstimate.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The load-memory estimate drives admission: it sets the point budget and
+ * decides `mayExceedCeiling`. `LAS_DECODED_ATTRIBUTES` declared `hasColor:
+ * false` for every LAS point format, while the decoder emits a colour array
+ * for the formats that carry RGB. The estimate therefore came in low precisely
+ * on the files where memory is tightest, and the planner admitted budgets the
+ * device could not hold.
+ *
+ * These pin the format-to-attribute mapping and the direction of the error.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { lasDecodedAttributes, pointFormatHasRgb } from '../src/io/lasHeader';
+
+describe('LAS point formats that carry RGB', () => {
+  it('matches the ASPRS specification', () => {
+    // 2, 3, 5 are the 1.2/1.3 colour formats; 7, 8, 10 the 1.4 counterparts.
+    for (const f of [2, 3, 5, 7, 8, 10]) {
+      expect(pointFormatHasRgb(f), `format ${f} carries RGB`).toBe(true);
+    }
+    for (const f of [0, 1, 4, 6, 9]) {
+      expect(pointFormatHasRgb(f), `format ${f} carries no RGB`).toBe(false);
+    }
+  });
+
+  it('declares colour only for the formats that have it', () => {
+    expect(lasDecodedAttributes(3).hasColor).toBe(true);
+    expect(lasDecodedAttributes(0).hasColor).toBe(false);
+  });
+
+  it('leaves every other declared attribute alone', () => {
+    const colour = lasDecodedAttributes(3);
+    const plain = lasDecodedAttributes(0);
+    for (const key of ['hasIntensity', 'hasClassification', 'hasNormals', 'hasLasExtras'] as const) {
+      expect(colour[key]).toBe(plain[key]);
+    }
+  });
+
+  it('raises the per-point estimate for a colour-bearing format', async () => {
+    const { estimateMemoryBytes } = await import('../src/io/loadPlan');
+    const base = { pointCount: 1_000_000, fileBytes: 0, format: 'las' as const };
+    const withColour = estimateMemoryBytes({ ...base, attributes: lasDecodedAttributes(3) });
+    const without = estimateMemoryBytes({ ...base, attributes: lasDecodedAttributes(0) });
+    // Three bytes per point, so a million points differ by 3 MB. The old
+    // constant produced the lower figure for both.
+    expect(withColour).toBeGreaterThan(without);
+    expect(withColour - without).toBe(3_000_000);
+  });
+});


### PR DESCRIPTION
From the v0.6.3 master plan's §4.3.1 audit item, which it correctly filed as a hypothesis. Confirmed.

`LAS_DECODED_ATTRIBUTES` declared `hasColor: false` for **every** LAS point format, and `loadFile.ts` passed it to `planLoad` for all LAS. But `loadLas.ts:194` sets `colors` on the produced cloud, and `lasDecodeShared.ts` stages a `colors16` `Uint16Array` during decode.

So the estimate was low by 3 bytes/point on the shipped cloud plus 6 bytes/point transiently — on a 27 byte/point baseline. The estimate drives the point budget and `mayExceedCeiling`, so the planner admitted budgets the device could not hold, on precisely the large colour-bearing scans where that matters.

The point format is already parsed before the plan is made, so `lasDecodedAttributes(pointFormat)` derives the flag. Formats 2, 3, 5, 7, 8, 10 carry RGB.

Verified: one million points of a colour-bearing format now estimate exactly 3 MB higher.

tsc 0, unit 1112, build 0, four new tests.