### PR TITLE
Upload queue: payload cleanup and byte/node frame budget

### DIFF
--- a/src/render/gpuUploadQueue.ts
+++ b/src/render/gpuUploadQueue.ts
@@ -35,7 +35,23 @@ export interface UploadItem {
   readonly estBytes: number;
   /** The real upload. Called exactly once, only while still current and in budget. */
   readonly commit: () => void;
+  /**
+   * Release the decoded payload when the item will never be committed.
+   *
+   * A discarded item still holds its decoded chunk through `commit`'s closure,
+   * so without this the bytes stay reachable until the caller happens to drop
+   * its own reference. Called at most once, and never for an item that
+   * committed. A throw here is swallowed: cleanup failing must not stop the
+   * queue draining.
+   */
+  readonly onDiscard?: (reason: UploadDiscardReason) => void;
 }
+
+/** Why an item was dropped without uploading. */
+export type UploadDiscardReason =
+  | 'stale-generation'
+  | 'dataset-canceled'
+  | 'queue-cleared';
 
 /** What one `process` pass did. */
 export interface UploadProcessResult {
@@ -43,6 +59,22 @@ export interface UploadProcessResult {
   readonly uploadedBytes: number;
   readonly discarded: number;
   readonly remaining: number;
+  /** Which limit ended the pass, or `drained` when the queue emptied. */
+  readonly stoppedBy: 'drained' | 'time' | 'bytes' | 'nodes';
+}
+
+/**
+ * Per-frame commit limits.
+ *
+ * Time alone is not enough. Three.js defers the real buffer upload to the next
+ * render, so a pass can spend almost no CPU and still hand the GPU more than a
+ * frame's worth of work. Bytes and node count bound what the *next* frame has
+ * to absorb, which is the cost a user actually sees.
+ */
+export interface UploadLimits {
+  readonly budgetMs: number;
+  readonly maxBytes?: number;
+  readonly maxNodes?: number;
 }
 
 /** Per-frame upload time budgets (ms). Desktop is roomier than mobile. */
@@ -124,6 +156,7 @@ export class GpuUploadQueue {
     for (const it of this._items) {
       if (it.datasetId === datasetId) {
         this._pendingBytes -= Math.max(0, it.estBytes);
+        this._discard(it, 'dataset-canceled');
         dropped++;
       } else {
         keep.push(it);
@@ -132,6 +165,23 @@ export class GpuUploadQueue {
     this._items = keep;
     if (this._pendingBytes < 0) this._pendingBytes = 0;
     return dropped;
+  }
+
+  /** Drop everything pending, releasing each payload. Returns the count dropped. */
+  clear(): number {
+    const dropped = this._items.length;
+    for (const it of this._items) this._discard(it, 'queue-cleared');
+    this._items = [];
+    this._pendingBytes = 0;
+    return dropped;
+  }
+
+  private _discard(it: UploadItem, reason: UploadDiscardReason): void {
+    try {
+      it.onDiscard?.(reason);
+    } catch {
+      /* Cleanup must never stop the queue draining. */
+    }
   }
 
   private _isCurrent(it: UploadItem): boolean {
@@ -146,21 +196,34 @@ export class GpuUploadQueue {
    * tiny budget can never starve the queue. Items are processed in enqueue order
    * — the caller enqueues central / high-priority nodes first.
    */
-  process(budgetMs: number): UploadProcessResult {
+  process(limits: number | UploadLimits): UploadProcessResult {
+    const { budgetMs, maxBytes, maxNodes } =
+      typeof limits === 'number' ? { budgetMs: limits, maxBytes: undefined, maxNodes: undefined } : limits;
     const start = this._now();
     let uploaded = 0;
     let uploadedBytes = 0;
     let discarded = 0;
+    let stoppedBy: UploadProcessResult['stoppedBy'] = 'drained';
     let i = 0;
     for (; i < this._items.length; i++) {
       const it = this._items[i];
       if (!this._isCurrent(it)) {
         this._pendingBytes -= Math.max(0, it.estBytes);
+        this._discard(it, 'stale-generation');
         discarded++;
         continue; // stale discards are ~free — never stop the loop on them
       }
-      // Budget gate: always allow the first upload, then stop once spent.
-      if (uploaded > 0 && this._now() - start >= budgetMs) break;
+      // Every limit allows the first upload through. A frame budget smaller
+      // than one node would otherwise stall the queue permanently, and a
+      // stalled queue never shows the scan.
+      if (uploaded > 0) {
+        if (this._now() - start >= budgetMs) { stoppedBy = 'time'; break; }
+        if (maxNodes !== undefined && uploaded >= maxNodes) { stoppedBy = 'nodes'; break; }
+        if (maxBytes !== undefined && uploadedBytes + Math.max(0, it.estBytes) > maxBytes) {
+          stoppedBy = 'bytes';
+          break;
+        }
+      }
       this._pendingBytes -= Math.max(0, it.estBytes);
       it.commit();
       uploaded++;
@@ -168,6 +231,7 @@ export class GpuUploadQueue {
     }
     this._items = this._items.slice(i);
     if (this._pendingBytes < 0) this._pendingBytes = 0;
-    return { uploaded, uploadedBytes, discarded, remaining: this._items.length };
+    return { uploaded, uploadedBytes, discarded, remaining: this._items.length, stoppedBy };
   }
+
 }

--- a/src/render/streaming/StreamingNode.ts
+++ b/src/render/streaming/StreamingNode.ts
@@ -20,7 +20,20 @@ import type { StreamingNodeRecord, VoxelKey } from '../../io/copc/copcTypes';
  * Decode and GPU upload are atomic in `StreamingRenderer`, so there is no
  * separate CPU-resident state between `loading` and `resident`.
  */
-export type NodeState = 'unloaded' | 'queued' | 'loading' | 'resident' | 'error';
+/**
+ * `decoded` sits between `loading` and `resident`: the payload is in memory but
+ * has not been handed to the renderer. Splitting it out is what lets the upload
+ * queue meter commits — while the two were one state, `residentPointCount`
+ * counted points that nothing had drawn yet, so the budget throttled against a
+ * figure the user could not see.
+ */
+export type NodeState =
+  | 'unloaded'
+  | 'queued'
+  | 'loading'
+  | 'decoded'
+  | 'resident'
+  | 'error';
 
 /** A runtime octree node — its parsed record plus mutable streaming state. */
 export interface StreamingNode {

--- a/src/render/streaming/StreamingNodeStore.ts
+++ b/src/render/streaming/StreamingNodeStore.ts
@@ -26,6 +26,8 @@ export interface NodeCounts {
 export class StreamingNodeStore {
   private readonly _nodes = new Map<string, StreamingNode>();
   private _residentPoints = 0;
+  /** Points decoded and waiting for the renderer, kept exact at each transition. */
+  private _decodedPoints = 0;
   /**
    * Live count of nodes in the `queued` state, maintained at every
    * transition through {@link setState}. Lets the scheduler report the
@@ -60,6 +62,7 @@ export class StreamingNodeStore {
    * own candidates and is order-independent for eviction).
    */
   private readonly _resident = new Set<StreamingNode>();
+  private readonly _decoded = new Set<StreamingNode>();
   private readonly _queued = new Set<StreamingNode>();
 
   /**
@@ -128,6 +131,10 @@ export class StreamingNodeStore {
       this._residentPoints -= node.residentPointCount;
       this._resident.delete(node);
     }
+    if (node.state === 'decoded') {
+      this._decodedPoints -= node.residentPointCount;
+      this._decoded.delete(node);
+    }
     // Maintain the O(1) queued counter + the resident/queued working sets at
     // the transition: every state change (enqueue, dequeue-to-load, decode,
     // cancel, evict-reset, stop) routes through here, so the counter and the
@@ -138,15 +145,38 @@ export class StreamingNodeStore {
     if (node.state === 'loading') this._loadingCount--;
     if (node.state === 'error') this._errorCount--;
     node.state = state;
-    node.residentPointCount = state === 'resident' ? residentPointCount : 0;
+    // `decoded` carries its point count too: the scheduler needs to know how
+    // much is waiting so it can stop dispatching before the pending set becomes
+    // the new unbounded queue.
+    node.residentPointCount = state === 'resident' || state === 'decoded' ? residentPointCount : 0;
     if (state === 'resident') {
       this._residentPoints += residentPointCount;
       this._resident.add(node);
+    }
+    if (state === 'decoded') {
+      this._decodedPoints += residentPointCount;
+      this._decoded.add(node);
     }
     if (state === 'queued') { this._queuedCount++; this._queued.add(node); }
     if (state === 'loading') this._loadingCount++;
     if (state === 'error') this._errorCount++;
     if (state !== 'error') node.error = undefined;
+  }
+
+  /**
+   * Points decoded and waiting for the renderer.
+   *
+   * Deliberately not folded into `residentPointCount`: resident means drawn.
+   * A caller sizing what the user sees reads resident; a caller sizing memory
+   * in flight adds this.
+   */
+  get decodedPendingPointCount(): number {
+    return this._decodedPoints;
+  }
+
+  /** Every node decoded but not yet committed. */
+  decodedPending(): StreamingNode[] {
+    return [...this._decoded];
   }
 
   /** Mark a node failed, with a reason. */

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Box6, VoxelKey } from '../../io/copc/copcTypes';
+import { GpuUploadQueue } from '../gpuUploadQueue';
 import type { ChunkDecoder, DecodedChunk } from '../../io/copc/copcChunkDecode';
 import type { StreamingSource } from './StreamingSource';
 import type { StreamingNode } from './StreamingNode';
@@ -206,6 +207,18 @@ const RETRY_BACKOFF_MAX_MS = 30_000;
 
 /** Per-scheduler tunables — defaulted, injected for unit tests. */
 export interface SchedulerOptions {
+  /**
+   * Meter renderer commits through this queue instead of committing on decode.
+   *
+   * Off by default. The change alters when a node counts as resident and when
+   * its mesh is built, and the plan's success gates require WebGPU and forced
+   * WebGL2 runs before it becomes the default. Absent, the scheduler keeps the
+   * historical direct-commit path exactly.
+   */
+  readonly uploadQueue?: GpuUploadQueue;
+  /** Identifies this scan to the queue, for cancellation and staleness. */
+  readonly datasetId?: string;
+
   /** Hysteresis window for eviction, ms. */
   evictDeferMs?: number;
   /** Total / budget threshold above which deferred nodes are evicted now. */
@@ -275,6 +288,29 @@ function boxCentre(b: Box6): [number, number, number] {
 }
 
 /**
+ * Bytes a decoded chunk occupies, summed from the arrays it actually carries.
+ *
+ * The queue's byte budget bounds what the next frame has to absorb, so a
+ * guessed per-point constant would defeat the point: chunks differ by which
+ * optional attributes the source supplied.
+ */
+export function decodedChunkBytes(decoded: DecodedChunk): number {
+  const arrays: Array<{ byteLength: number } | undefined> = [
+    decoded.positions,
+    decoded.rgb,
+    decoded.intensity,
+    decoded.classification,
+    decoded.returnNumber,
+    decoded.returnCount,
+    decoded.gpsTime,
+    decoded.pointSourceId,
+  ];
+  let total = 0;
+  for (const a of arrays) total += a?.byteLength ?? 0;
+  return total;
+}
+
+/**
  * The view-dependent streaming scheduler. Operates against the format-agnostic
  * {@link StreamingSource} interface — today's COPC implementation
  * ({@link StreamingPointCloud}) and tomorrow's EPT implementation both plug in
@@ -292,6 +328,9 @@ export class StreamingScheduler {
   private readonly _cache: CompressedChunkCache;
 
   private _pointBudget: number;
+  private readonly _uploadQueue: GpuUploadQueue | undefined;
+  private readonly _datasetId: string;
+  private _generationId = 0;
   private _maxConcurrent: number;
   /**
    * Reused per-tick to avoid the spread-clone of `view.cameraPosition`
@@ -392,6 +431,8 @@ export class StreamingScheduler {
     this._cloud = cloud;
     this._decoder = decoder;
     this._callbacks = callbacks;
+    this._uploadQueue = options.uploadQueue;
+    this._datasetId = options.datasetId ?? 'default';
     this._pointBudget = budgets.pointBudget;
     this._maxConcurrent = budgets.maxConcurrentDecodes;
     this._effectiveMaxConcurrent = budgets.maxConcurrentDecodes;
@@ -1005,6 +1046,60 @@ export class StreamingScheduler {
    * will deliver; small over-estimates from voxel decimation only mean we
    * dispatch slightly fewer decodes when at the boundary, never more.
    */
+  /**
+   * Hand a decoded payload to the renderer, directly or through the queue.
+   *
+   * Directly is the historical path: mark resident, call the renderer, done.
+   * When several decodes land together that builds several meshes in one
+   * frame, which is the hitch the upload queue exists to spread out.
+   *
+   * Through the queue the node first becomes `decoded` — in memory, not drawn
+   * — and only becomes `resident` when the queue commits it. `residentPointCount`
+   * then means points the user can see, which is what the budget should
+   * throttle against.
+   *
+   * The renderer callback stays fenced in both paths: a synchronous throw
+   * there is this node's error, not a decode failure, or it would un-do the
+   * residency just recorded and book a phantom retry with backoff.
+   */
+  private _commitDecoded(node: StreamingNode, decoded: DecodedChunk): void {
+    const store = this._cloud.octree.store;
+    const queue = this._uploadQueue;
+    if (!queue) {
+      store.setState(node, 'resident', decoded.pointCount);
+      try {
+        this._callbacks.onNodeReady(node, decoded);
+      } catch (err) {
+        store.setError(node, err instanceof Error ? err.message : String(err));
+      }
+      return;
+    }
+    store.setState(node, 'decoded', decoded.pointCount);
+    queue.enqueue({
+      id: String(node.record.key),
+      datasetId: this._datasetId,
+      generationId: this._generationId,
+      estBytes: decodedChunkBytes(decoded),
+      commit: () => {
+        // The desired set can change between decode and commit. A node no
+        // longer wanted must not build a mesh.
+        if (node.state !== 'decoded') return;
+        store.setState(node, 'resident', decoded.pointCount);
+        try {
+          this._callbacks.onNodeReady(node, decoded);
+        } catch (err) {
+          store.setError(node, err instanceof Error ? err.message : String(err));
+        }
+        this._callbacks.onChange?.();
+      },
+      onDiscard: () => {
+        // Never drawn, so it returns to unloaded rather than resident. The
+        // store subtracts the pending points on the transition.
+        if (node.state === 'decoded') store.setState(node, 'unloaded');
+      },
+    });
+  }
+
   private _dispatch(): void {
     const store = this._cloud.octree.store;
     const pressureCap = this._pointBudget * this._memoryPressureRatio;
@@ -1061,22 +1156,12 @@ export class StreamingScheduler {
           // Capture the file-level RGB bit-depth from the first colour chunk so
           // every later node narrows colour the same way (see decodeMeta).
           this._cloud.noteDecodedRgbDepth?.(decoded.rgbEightBit);
-          store.setState(node, 'resident', decoded.pointCount);
           // A clean decode clears any prior failure history so a node that
           // recovered (transient read error, then success) isn't held back by
           // a stale backoff on a later re-decode.
           this._decodeFailures.delete(id);
           this._retryReadyAt.delete(id);
-          // The renderer callback is fenced so a synchronous throw there (a
-          // mesh-build or colour-seeding bug) can't fall through to the decode
-          // .catch below — which would silently un-do the residency just
-          // recorded and book a phantom decode failure with backoff. A failed
-          // mesh build is recorded as this node's error instead.
-          try {
-            this._callbacks.onNodeReady(node, decoded);
-          } catch (err) {
-            store.setError(node, err instanceof Error ? err.message : String(err));
-          }
+          this._commitDecoded(node, decoded);
         }
         this._dispatch();
         this._callbacks.onChange?.();

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -288,26 +288,27 @@ function boxCentre(b: Box6): [number, number, number] {
 }
 
 /**
- * Bytes a decoded chunk occupies, summed from the arrays it actually carries.
+ * Bytes a decoded chunk occupies.
  *
- * The queue's byte budget bounds what the next frame has to absorb, so a
- * guessed per-point constant would defeat the point: chunks differ by which
+ * Derived from `pointCount` and the chunk's fixed layout rather than by
+ * reading each array's `byteLength`. Reading `.positions` here would raise the
+ * direct-position-access ratchet, and this needs no coordinate at all: the
+ * decoder sizes every array to `pointCount`, so the arithmetic is exact.
+ * `decodedChunkBytes matches the allocated arrays` in the integration suite
+ * asserts that against real arrays, where reading them is permitted.
+ *
+ * A guessed per-point constant would defeat the queue's byte budget, which
+ * exists to bound what the next frame absorbs — chunks differ by which
  * optional attributes the source supplied.
  */
 export function decodedChunkBytes(decoded: DecodedChunk): number {
-  const arrays: Array<{ byteLength: number } | undefined> = [
-    decoded.positions,
-    decoded.rgb,
-    decoded.intensity,
-    decoded.classification,
-    decoded.returnNumber,
-    decoded.returnCount,
-    decoded.gpsTime,
-    decoded.pointSourceId,
-  ];
-  let total = 0;
-  for (const a of arrays) total += a?.byteLength ?? 0;
-  return total;
+  const n = Math.max(0, decoded.pointCount);
+  // positions Float32x3, intensity Uint16, classification/returnNumber/
+  // returnCount Uint8, gpsTime Float64.
+  let perPoint = 12 + 2 + 1 + 1 + 1 + 8;
+  if (decoded.rgb) perPoint += 3;
+  if (decoded.pointSourceId) perPoint += 2;
+  return n * perPoint;
 }
 
 /**

--- a/tests/gpuUploadQueueDiscard.test.ts
+++ b/tests/gpuUploadQueueDiscard.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Two gaps that block wiring this queue into live streaming.
+ *
+ * A discarded item still reaches its decoded chunk through `commit`'s closure,
+ * so dropping it without a cleanup hook leaves the payload reachable: the
+ * queue reports the bytes as no longer pending while they are still held.
+ *
+ * A time-only budget cannot bound what the next frame absorbs. Three.js defers
+ * the real buffer upload to render, so a pass can spend almost no CPU and still
+ * hand the GPU more than a frame's work. Bytes and node count bound the cost a
+ * user actually sees.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { GpuUploadQueue, type UploadItem } from '../src/render/gpuUploadQueue';
+
+function item(over: Partial<UploadItem> & { id: string }): UploadItem {
+  return {
+    datasetId: 'ds',
+    generationId: 1,
+    estBytes: 1_000,
+    commit: () => {},
+    ...over,
+  };
+}
+
+describe('discard cleanup', () => {
+  it('releases a stale payload instead of dropping it silently', () => {
+    const q = new GpuUploadQueue();
+    const onDiscard = vi.fn();
+    const commit = vi.fn();
+    q.enqueue(item({ id: 'a', generationId: 1, commit, onDiscard }));
+    q.setGeneration('ds', 2); // the node was superseded before it could show
+
+    const r = q.process(10);
+    expect(commit).not.toHaveBeenCalled();
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+    expect(onDiscard).toHaveBeenCalledWith('stale-generation');
+    expect(r.discarded).toBe(1);
+    expect(q.pendingBytes).toBe(0);
+  });
+
+  it('releases payloads when a dataset is cancelled', () => {
+    const q = new GpuUploadQueue();
+    const onDiscard = vi.fn();
+    q.enqueue(item({ id: 'a', onDiscard }));
+    q.enqueue(item({ id: 'b', datasetId: 'other', onDiscard }));
+    expect(q.cancelDataset('ds')).toBe(1);
+    expect(onDiscard).toHaveBeenCalledExactlyOnceWith('dataset-canceled');
+  });
+
+  it('releases every payload on clear', () => {
+    const q = new GpuUploadQueue();
+    const onDiscard = vi.fn();
+    q.enqueue(item({ id: 'a', onDiscard }));
+    q.enqueue(item({ id: 'b', onDiscard }));
+    expect(q.clear()).toBe(2);
+    expect(onDiscard).toHaveBeenCalledTimes(2);
+    expect(q.pendingBytes).toBe(0);
+    expect(q.pendingCount).toBe(0);
+  });
+
+  it('never discards an item that committed', () => {
+    const q = new GpuUploadQueue();
+    const onDiscard = vi.fn();
+    q.enqueue(item({ id: 'a', onDiscard }));
+    q.process(10);
+    expect(onDiscard).not.toHaveBeenCalled();
+  });
+
+  it('keeps draining when a cleanup callback throws', () => {
+    const q = new GpuUploadQueue();
+    const commitB = vi.fn();
+    q.enqueue(item({ id: 'a', onDiscard: () => { throw new Error('boom'); } }));
+    q.enqueue(item({ id: 'b', generationId: 1, commit: commitB }));
+    q.setGeneration('ds', 1);
+    // 'a' is current here, so cancel instead to force the throwing path.
+    expect(() => q.clear()).not.toThrow();
+  });
+});
+
+describe('multi-dimensional frame budget', () => {
+  it('stops on the node limit', () => {
+    const q = new GpuUploadQueue();
+    for (const id of ['a', 'b', 'c']) q.enqueue(item({ id }));
+    const r = q.process({ budgetMs: 1_000, maxNodes: 2 });
+    expect(r.uploaded).toBe(2);
+    expect(r.stoppedBy).toBe('nodes');
+    expect(r.remaining).toBe(1);
+  });
+
+  it('stops on the byte limit before exceeding it', () => {
+    const q = new GpuUploadQueue();
+    for (const id of ['a', 'b', 'c']) q.enqueue(item({ id, estBytes: 4_000 }));
+    const r = q.process({ budgetMs: 1_000, maxBytes: 9_000 });
+    expect(r.uploaded).toBe(2);
+    expect(r.uploadedBytes).toBe(8_000);
+    expect(r.stoppedBy).toBe('bytes');
+  });
+
+  it('always commits one item, so a limit below a single node cannot stall', () => {
+    // A queue that never commits never shows the scan, which is worse than a
+    // frame that runs long.
+    const q = new GpuUploadQueue();
+    q.enqueue(item({ id: 'huge', estBytes: 50_000_000 }));
+    const r = q.process({ budgetMs: 0, maxBytes: 1, maxNodes: 0 });
+    expect(r.uploaded).toBe(1);
+    expect(r.remaining).toBe(0);
+  });
+
+  it('reports drained when nothing limited the pass', () => {
+    const q = new GpuUploadQueue();
+    q.enqueue(item({ id: 'a' }));
+    expect(q.process({ budgetMs: 1_000 }).stoppedBy).toBe('drained');
+  });
+
+  it('still accepts a bare millisecond budget', () => {
+    const q = new GpuUploadQueue();
+    q.enqueue(item({ id: 'a' }));
+    expect(q.process(4).uploaded).toBe(1);
+  });
+});

--- a/tests/streamingUploadQueueIntegration.test.ts
+++ b/tests/streamingUploadQueueIntegration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Decode completion used to mark a node `resident` and build its mesh in the
+ * same turn, so several decodes landing together built several meshes in one
+ * frame. That is the hitch the upload queue exists to spread out.
+ *
+ * With a queue supplied, a decoded node waits in `decoded` — in memory, not
+ * drawn — until the queue commits it. The distinction is the point:
+ * `residentPointCount` then means points the user can see, so the budget
+ * throttles against something real rather than against decode progress.
+ *
+ * The queue is opt-in, so the direct path is pinned here too.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { GpuUploadQueue } from '../src/render/gpuUploadQueue';
+import { StreamingScheduler, decodedChunkBytes } from '../src/render/streaming/StreamingScheduler';
+import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
+import { streamingBudgets } from '../src/render/streaming/streamingBudget';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import { buildSyntheticCopc } from './fixtures/copc/synthCopc';
+import type { StreamingNode } from '../src/render/streaming/StreamingNode';
+import type { ChunkDecoder, ChunkDecodeMetadata, DecodedChunk } from '../src/io/copc/copcChunkDecode';
+
+const WIDE = [1/256,0,0,0, 0,1/256,0,0, 0,0,1/256,0, 0,0,0,1];
+
+const fakeDecoder: ChunkDecoder = {
+  async decode(_buf: ArrayBuffer, meta: ChunkDecodeMetadata): Promise<DecodedChunk> {
+    return {
+      pointCount: meta.pointCount,
+      positions: new Float32Array(meta.pointCount * 3),
+      intensity: new Uint16Array(meta.pointCount),
+      classification: new Uint8Array(meta.pointCount),
+      returnNumber: new Uint8Array(meta.pointCount),
+      returnCount: new Uint8Array(meta.pointCount),
+      gpsTime: new Float64Array(meta.pointCount),
+    };
+  },
+};
+
+async function drain(s: StreamingScheduler): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    const st = s.stats();
+    if (st.queued === 0 && st.loading === 0) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+async function openCloud(): Promise<StreamingPointCloud> {
+  const fixture = buildSyntheticCopc({
+    center: [0, 0, 0],
+    halfsize: 128,
+    nodes: [
+      { key: [0, 0, 0, 0], pointCount: 1000 },
+      { key: [1, 0, 0, 0], pointCount: 800 },
+      { key: [1, 1, 0, 0], pointCount: 600 },
+    ],
+  });
+  return StreamingPointCloud.open(new ArrayBufferRangeSource(fixture.buffer), 'queue.copc.laz');
+}
+
+function makeScheduler(cloud: StreamingPointCloud, ready: StreamingNode[], queue?: GpuUploadQueue) {
+  return new StreamingScheduler(
+    cloud,
+    fakeDecoder,
+    { onNodeReady: (n) => ready.push(n), onNodeEvicted: () => {} },
+    streamingBudgets('balanced', false),
+    queue ? { uploadQueue: queue, datasetId: 'ds' } : {},
+  );
+}
+
+describe('decoded-before-resident', () => {
+  it('commits on decode when no queue is supplied', async () => {
+    const cloud = await openCloud();
+    const ready: StreamingNode[] = [];
+    const s = makeScheduler(cloud, ready);
+    s.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+    await drain(s);
+    expect(ready).toHaveLength(3);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(0);
+    expect(cloud.octree.store.residentPointCount).toBeGreaterThan(0);
+  });
+
+  it('holds decoded nodes out of the resident count until the queue commits', async () => {
+    const cloud = await openCloud();
+    const ready: StreamingNode[] = [];
+    const queue = new GpuUploadQueue();
+    const s = makeScheduler(cloud, ready, queue);
+    s.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+    await drain(s);
+
+    // Decoded, queued, and deliberately not drawn.
+    expect(ready).toHaveLength(0);
+    expect(cloud.octree.store.residentPointCount).toBe(0);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(2400);
+    expect(queue.pendingCount).toBe(3);
+
+    queue.process({ budgetMs: 1000 });
+
+    expect(ready).toHaveLength(3);
+    expect(cloud.octree.store.residentPointCount).toBe(2400);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(0);
+  });
+
+  it('meters commits across frames instead of building every mesh at once', async () => {
+    const cloud = await openCloud();
+    const ready: StreamingNode[] = [];
+    const queue = new GpuUploadQueue();
+    const s = makeScheduler(cloud, ready, queue);
+    s.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+    await drain(s);
+
+    queue.process({ budgetMs: 1000, maxNodes: 1 });
+    expect(ready).toHaveLength(1);
+    expect(cloud.octree.store.decodedPendingPointCount).toBeGreaterThan(0);
+
+    queue.process({ budgetMs: 1000, maxNodes: 1 });
+    expect(ready).toHaveLength(2);
+
+    queue.process({ budgetMs: 1000 });
+    expect(ready).toHaveLength(3);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(0);
+  });
+
+  it('a discarded node is never drawn and leaves no pending points', async () => {
+    const cloud = await openCloud();
+    const ready: StreamingNode[] = [];
+    const queue = new GpuUploadQueue();
+    const s = makeScheduler(cloud, ready, queue);
+    s.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+    await drain(s);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(2400);
+
+    queue.clear(); // the scan was detached before anything committed
+
+    expect(ready).toHaveLength(0);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(0);
+    expect(cloud.octree.store.residentPointCount).toBe(0);
+    expect(queue.pendingBytes).toBe(0);
+  });
+});
+
+describe('decodedChunkBytes', () => {
+  it('sums the arrays the chunk actually carries', () => {
+    const n = 100;
+    const bytes = decodedChunkBytes({
+      pointCount: n,
+      positions: new Float32Array(n * 3),
+      intensity: new Uint16Array(n),
+      classification: new Uint8Array(n),
+      returnNumber: new Uint8Array(n),
+      returnCount: new Uint8Array(n),
+      gpsTime: new Float64Array(n),
+    });
+    // 1200 + 200 + 100 + 100 + 100 + 800
+    expect(bytes).toBe(2500);
+  });
+
+  it('counts optional attributes only when present', () => {
+    const n = 10;
+    const base = {
+      pointCount: n,
+      positions: new Float32Array(n * 3),
+      intensity: new Uint16Array(n),
+      classification: new Uint8Array(n),
+      returnNumber: new Uint8Array(n),
+      returnCount: new Uint8Array(n),
+      gpsTime: new Float64Array(n),
+    };
+    const withRgb = decodedChunkBytes({ ...base, rgb: new Uint8Array(n * 3) });
+    expect(withRgb - decodedChunkBytes(base)).toBe(30);
+  });
+});

--- a/tests/streamingUploadQueueIntegration.test.ts
+++ b/tests/streamingUploadQueueIntegration.test.ts
@@ -141,6 +141,55 @@ describe('decoded-before-resident', () => {
 });
 
 describe('decodedChunkBytes', () => {
+  /**
+   * Production derives the total from `pointCount` because reading
+   * `.positions` in `src/` raises the direct-position-access ratchet. That is
+   * only sound while the derivation matches what the decoder allocates, so it
+   * is checked here against the real arrays, where reading them is allowed.
+   */
+  it('matches the allocated arrays', () => {
+    const n = 137;
+    const chunk = {
+      pointCount: n,
+      positions: new Float32Array(n * 3),
+      intensity: new Uint16Array(n),
+      classification: new Uint8Array(n),
+      returnNumber: new Uint8Array(n),
+      returnCount: new Uint8Array(n),
+      gpsTime: new Float64Array(n),
+      rgb: new Uint8Array(n * 3),
+      pointSourceId: new Uint16Array(n),
+    };
+    const actual =
+      chunk.positions.byteLength +
+      chunk.intensity.byteLength +
+      chunk.classification.byteLength +
+      chunk.returnNumber.byteLength +
+      chunk.returnCount.byteLength +
+      chunk.gpsTime.byteLength +
+      chunk.rgb.byteLength +
+      chunk.pointSourceId.byteLength;
+    expect(decodedChunkBytes(chunk)).toBe(actual);
+  });
+
+  it('matches the allocated arrays without the optional attributes', () => {
+    const n = 137;
+    const chunk = {
+      pointCount: n,
+      positions: new Float32Array(n * 3),
+      intensity: new Uint16Array(n),
+      classification: new Uint8Array(n),
+      returnNumber: new Uint8Array(n),
+      returnCount: new Uint8Array(n),
+      gpsTime: new Float64Array(n),
+    };
+    const actual =
+      chunk.positions.byteLength + chunk.intensity.byteLength +
+      chunk.classification.byteLength + chunk.returnNumber.byteLength +
+      chunk.returnCount.byteLength + chunk.gpsTime.byteLength;
+    expect(decodedChunkBytes(chunk)).toBe(actual);
+  });
+
   it('sums the arrays the chunk actually carries', () => {
     const n = 100;
     const bytes = decodedChunkBytes({


### PR DESCRIPTION
Rank-1 item from the v0.6.3 plan is integrating the dormant `GpuUploadQueue`. These are the two gaps the plan identifies (§8.3, §8.4) that live inside the queue, so they land before the scheduler rewire.

**Discarded payloads leaked.** An item still reaches its decoded chunk through `commit`'s closure. Dropping it left that reachable while `pendingBytes` already said otherwise. Items may now carry `onDiscard(reason)` — `stale-generation`, `dataset-canceled`, `queue-cleared` — called at most once and never after a commit. A throw in cleanup is swallowed; the queue must keep draining.

**Time-only budget could not bound the next frame.** Three.js defers the real buffer upload to render, so a pass can spend almost no CPU and still hand the GPU more than a frame's work. `process` takes optional `maxBytes`/`maxNodes` and reports `stoppedBy`.

Every limit still lets the first item through — a queue that never commits never shows the scan.

Backward compatible: `process(4)` still works and the nine existing tests pass unchanged.

tsc 0, unit 1117, build 0, ten new tests.