### PR TITLE
Split decoded from resident in the streaming scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # OpenLiDARViewer
 
-<!-- Row 1 is software assurance. Two slots are held open:
-     - OpenSSF Scorecard, after api.securityscorecards.dev serves this repo
-       (the workflow already publishes; the last run scored 6.1);
-     - Codecov, after the repository is activated and CODECOV_TOKEN is set.
-     Neither badge is added before it renders a real value. -->
+<!-- Row 1 is software assurance. One slot is still held open: OpenSSF
+     Scorecard. The workflow publishes (last run scored 6.1, tlog entry
+     recorded), but api.scorecard.dev has not ingested the project yet and its
+     badge renders "invalid repo path". It goes in when it renders a score. -->
 [![CI](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/ci.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/ci.yml)
 [![Security audit](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/security.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/security.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/Aurtechmx/openlidarviewer?label=coverage&color=3fb950)](https://codecov.io/gh/Aurtechmx/openlidarviewer)
 [![Clean clone](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/clean-clone.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/clean-clone.yml)
 
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21544619-1682D4)](https://doi.org/10.5281/zenodo.21544619)

--- a/src/io/lasHeader.ts
+++ b/src/io/lasHeader.ts
@@ -227,12 +227,16 @@ export function parseLasHeader(buffer: ArrayBuffer): LasHeader {
 /**
  * The per-point attributes a decoded LAS/LAZ cloud carries in this viewer.
  *
- * The loader decodes position, intensity, classification, and — since
- * the inspection extras (return number/count, point source ID, GPS
- * time); not RGB or surface normals. The set is fixed regardless of the LAS
- * point format. It sizes the load-memory estimate
+ * The loader decodes position, intensity, classification, the inspection
+ * extras (return number/count, point source ID, GPS time), and RGB where the
+ * point format carries it. It sizes the load-memory estimate
  * (`estimateMemoryBytes`); `hasLasExtras` keeps that estimate honest about the
  * ~12 extra bytes per point the attributes add.
+ *
+ * Kept for callers that have no header to read. Anything holding a parsed
+ * header should use `lasDecodedAttributes(pointFormat)` instead: this constant
+ * declares no colour, and a colour-bearing file decodes one anyway, so the
+ * estimate comes in low exactly where memory is tightest.
  */
 export const LAS_DECODED_ATTRIBUTES: PointAttributes = {
   hasColor: false,
@@ -241,3 +245,29 @@ export const LAS_DECODED_ATTRIBUTES: PointAttributes = {
   hasNormals: false,
   hasLasExtras: true,
 };
+
+/**
+ * LAS point formats that carry RGB, per the ASPRS specification.
+ *
+ * 2, 3 and 5 are the LAS 1.2/1.3 colour formats; 7, 8 and 10 are their 1.4
+ * counterparts. 8 and 10 also carry NIR, which the loader does not decode.
+ */
+const RGB_POINT_FORMATS: ReadonlySet<number> = new Set([2, 3, 5, 7, 8, 10]);
+
+/** Whether a LAS point format carries RGB. */
+export function pointFormatHasRgb(pointFormat: number): boolean {
+  return RGB_POINT_FORMATS.has(pointFormat);
+}
+
+/**
+ * What the loader will actually decode from this point format.
+ *
+ * The memory estimate drives admission, so declaring no colour for a file that
+ * decodes colour understates the peak: three bytes per point in the cloud that
+ * ships, and six more per point while the raw 16-bit channels are still
+ * staged. On a large colour-bearing scan the planner admits a point budget the
+ * device cannot hold, which is the outcome the estimate exists to prevent.
+ */
+export function lasDecodedAttributes(pointFormat: number): PointAttributes {
+  return { ...LAS_DECODED_ATTRIBUTES, hasColor: pointFormatHasRgb(pointFormat) };
+}

--- a/src/io/loadFile.ts
+++ b/src/io/loadFile.ts
@@ -5,7 +5,7 @@ import { PointCloud } from '../model/PointCloud';
 import type { CloudMetadata } from '../model/PointCloud';
 import type { LoadResult } from './parseBuffer';
 import { POINT_BUDGET, parseBuffer } from './parseBuffer';
-import { parseLasHeader, LAS_DECODED_ATTRIBUTES } from './lasHeader';
+import { parseLasHeader, lasDecodedAttributes } from './lasHeader';
 import {
   planLoad,
   NON_STREAMING_FORMATS,
@@ -120,7 +120,7 @@ function buildLasPlan(
       budget,
       isMobile: options.isMobile ?? false,
       deviceMemoryGB: options.deviceMemoryGB,
-      attributes: LAS_DECODED_ATTRIBUTES,
+      attributes: lasDecodedAttributes(header.pointFormat),
       format,
     });
   } catch {

--- a/src/render/streaming/StreamingNode.ts
+++ b/src/render/streaming/StreamingNode.ts
@@ -20,7 +20,20 @@ import type { StreamingNodeRecord, VoxelKey } from '../../io/copc/copcTypes';
  * Decode and GPU upload are atomic in `StreamingRenderer`, so there is no
  * separate CPU-resident state between `loading` and `resident`.
  */
-export type NodeState = 'unloaded' | 'queued' | 'loading' | 'resident' | 'error';
+/**
+ * `decoded` sits between `loading` and `resident`: the payload is in memory but
+ * has not been handed to the renderer. Splitting it out is what lets the upload
+ * queue meter commits — while the two were one state, `residentPointCount`
+ * counted points that nothing had drawn yet, so the budget throttled against a
+ * figure the user could not see.
+ */
+export type NodeState =
+  | 'unloaded'
+  | 'queued'
+  | 'loading'
+  | 'decoded'
+  | 'resident'
+  | 'error';
 
 /** A runtime octree node — its parsed record plus mutable streaming state. */
 export interface StreamingNode {

--- a/src/render/streaming/StreamingNodeStore.ts
+++ b/src/render/streaming/StreamingNodeStore.ts
@@ -26,6 +26,8 @@ export interface NodeCounts {
 export class StreamingNodeStore {
   private readonly _nodes = new Map<string, StreamingNode>();
   private _residentPoints = 0;
+  /** Points decoded and waiting for the renderer, kept exact at each transition. */
+  private _decodedPoints = 0;
   /**
    * Live count of nodes in the `queued` state, maintained at every
    * transition through {@link setState}. Lets the scheduler report the
@@ -60,6 +62,7 @@ export class StreamingNodeStore {
    * own candidates and is order-independent for eviction).
    */
   private readonly _resident = new Set<StreamingNode>();
+  private readonly _decoded = new Set<StreamingNode>();
   private readonly _queued = new Set<StreamingNode>();
 
   /**
@@ -128,6 +131,10 @@ export class StreamingNodeStore {
       this._residentPoints -= node.residentPointCount;
       this._resident.delete(node);
     }
+    if (node.state === 'decoded') {
+      this._decodedPoints -= node.residentPointCount;
+      this._decoded.delete(node);
+    }
     // Maintain the O(1) queued counter + the resident/queued working sets at
     // the transition: every state change (enqueue, dequeue-to-load, decode,
     // cancel, evict-reset, stop) routes through here, so the counter and the
@@ -138,15 +145,38 @@ export class StreamingNodeStore {
     if (node.state === 'loading') this._loadingCount--;
     if (node.state === 'error') this._errorCount--;
     node.state = state;
-    node.residentPointCount = state === 'resident' ? residentPointCount : 0;
+    // `decoded` carries its point count too: the scheduler needs to know how
+    // much is waiting so it can stop dispatching before the pending set becomes
+    // the new unbounded queue.
+    node.residentPointCount = state === 'resident' || state === 'decoded' ? residentPointCount : 0;
     if (state === 'resident') {
       this._residentPoints += residentPointCount;
       this._resident.add(node);
+    }
+    if (state === 'decoded') {
+      this._decodedPoints += residentPointCount;
+      this._decoded.add(node);
     }
     if (state === 'queued') { this._queuedCount++; this._queued.add(node); }
     if (state === 'loading') this._loadingCount++;
     if (state === 'error') this._errorCount++;
     if (state !== 'error') node.error = undefined;
+  }
+
+  /**
+   * Points decoded and waiting for the renderer.
+   *
+   * Deliberately not folded into `residentPointCount`: resident means drawn.
+   * A caller sizing what the user sees reads resident; a caller sizing memory
+   * in flight adds this.
+   */
+  get decodedPendingPointCount(): number {
+    return this._decodedPoints;
+  }
+
+  /** Every node decoded but not yet committed. */
+  decodedPending(): StreamingNode[] {
+    return [...this._decoded];
   }
 
   /** Mark a node failed, with a reason. */

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Box6, VoxelKey } from '../../io/copc/copcTypes';
+import { GpuUploadQueue } from '../gpuUploadQueue';
 import type { ChunkDecoder, DecodedChunk } from '../../io/copc/copcChunkDecode';
 import type { StreamingSource } from './StreamingSource';
 import type { StreamingNode } from './StreamingNode';
@@ -206,6 +207,18 @@ const RETRY_BACKOFF_MAX_MS = 30_000;
 
 /** Per-scheduler tunables — defaulted, injected for unit tests. */
 export interface SchedulerOptions {
+  /**
+   * Meter renderer commits through this queue instead of committing on decode.
+   *
+   * Off by default. The change alters when a node counts as resident and when
+   * its mesh is built, and the plan's success gates require WebGPU and forced
+   * WebGL2 runs before it becomes the default. Absent, the scheduler keeps the
+   * historical direct-commit path exactly.
+   */
+  readonly uploadQueue?: GpuUploadQueue;
+  /** Identifies this scan to the queue, for cancellation and staleness. */
+  readonly datasetId?: string;
+
   /** Hysteresis window for eviction, ms. */
   evictDeferMs?: number;
   /** Total / budget threshold above which deferred nodes are evicted now. */
@@ -275,6 +288,29 @@ function boxCentre(b: Box6): [number, number, number] {
 }
 
 /**
+ * Bytes a decoded chunk occupies, summed from the arrays it actually carries.
+ *
+ * The queue's byte budget bounds what the next frame has to absorb, so a
+ * guessed per-point constant would defeat the point: chunks differ by which
+ * optional attributes the source supplied.
+ */
+export function decodedChunkBytes(decoded: DecodedChunk): number {
+  const arrays: Array<{ byteLength: number } | undefined> = [
+    decoded.positions,
+    decoded.rgb,
+    decoded.intensity,
+    decoded.classification,
+    decoded.returnNumber,
+    decoded.returnCount,
+    decoded.gpsTime,
+    decoded.pointSourceId,
+  ];
+  let total = 0;
+  for (const a of arrays) total += a?.byteLength ?? 0;
+  return total;
+}
+
+/**
  * The view-dependent streaming scheduler. Operates against the format-agnostic
  * {@link StreamingSource} interface — today's COPC implementation
  * ({@link StreamingPointCloud}) and tomorrow's EPT implementation both plug in
@@ -292,6 +328,9 @@ export class StreamingScheduler {
   private readonly _cache: CompressedChunkCache;
 
   private _pointBudget: number;
+  private readonly _uploadQueue: GpuUploadQueue | undefined;
+  private readonly _datasetId: string;
+  private _generationId = 0;
   private _maxConcurrent: number;
   /**
    * Reused per-tick to avoid the spread-clone of `view.cameraPosition`
@@ -392,6 +431,8 @@ export class StreamingScheduler {
     this._cloud = cloud;
     this._decoder = decoder;
     this._callbacks = callbacks;
+    this._uploadQueue = options.uploadQueue;
+    this._datasetId = options.datasetId ?? 'default';
     this._pointBudget = budgets.pointBudget;
     this._maxConcurrent = budgets.maxConcurrentDecodes;
     this._effectiveMaxConcurrent = budgets.maxConcurrentDecodes;
@@ -1005,6 +1046,60 @@ export class StreamingScheduler {
    * will deliver; small over-estimates from voxel decimation only mean we
    * dispatch slightly fewer decodes when at the boundary, never more.
    */
+  /**
+   * Hand a decoded payload to the renderer, directly or through the queue.
+   *
+   * Directly is the historical path: mark resident, call the renderer, done.
+   * When several decodes land together that builds several meshes in one
+   * frame, which is the hitch the upload queue exists to spread out.
+   *
+   * Through the queue the node first becomes `decoded` — in memory, not drawn
+   * — and only becomes `resident` when the queue commits it. `residentPointCount`
+   * then means points the user can see, which is what the budget should
+   * throttle against.
+   *
+   * The renderer callback stays fenced in both paths: a synchronous throw
+   * there is this node's error, not a decode failure, or it would un-do the
+   * residency just recorded and book a phantom retry with backoff.
+   */
+  private _commitDecoded(node: StreamingNode, decoded: DecodedChunk): void {
+    const store = this._cloud.octree.store;
+    const queue = this._uploadQueue;
+    if (!queue) {
+      store.setState(node, 'resident', decoded.pointCount);
+      try {
+        this._callbacks.onNodeReady(node, decoded);
+      } catch (err) {
+        store.setError(node, err instanceof Error ? err.message : String(err));
+      }
+      return;
+    }
+    store.setState(node, 'decoded', decoded.pointCount);
+    queue.enqueue({
+      id: String(node.record.key),
+      datasetId: this._datasetId,
+      generationId: this._generationId,
+      estBytes: decodedChunkBytes(decoded),
+      commit: () => {
+        // The desired set can change between decode and commit. A node no
+        // longer wanted must not build a mesh.
+        if (node.state !== 'decoded') return;
+        store.setState(node, 'resident', decoded.pointCount);
+        try {
+          this._callbacks.onNodeReady(node, decoded);
+        } catch (err) {
+          store.setError(node, err instanceof Error ? err.message : String(err));
+        }
+        this._callbacks.onChange?.();
+      },
+      onDiscard: () => {
+        // Never drawn, so it returns to unloaded rather than resident. The
+        // store subtracts the pending points on the transition.
+        if (node.state === 'decoded') store.setState(node, 'unloaded');
+      },
+    });
+  }
+
   private _dispatch(): void {
     const store = this._cloud.octree.store;
     const pressureCap = this._pointBudget * this._memoryPressureRatio;
@@ -1061,22 +1156,12 @@ export class StreamingScheduler {
           // Capture the file-level RGB bit-depth from the first colour chunk so
           // every later node narrows colour the same way (see decodeMeta).
           this._cloud.noteDecodedRgbDepth?.(decoded.rgbEightBit);
-          store.setState(node, 'resident', decoded.pointCount);
           // A clean decode clears any prior failure history so a node that
           // recovered (transient read error, then success) isn't held back by
           // a stale backoff on a later re-decode.
           this._decodeFailures.delete(id);
           this._retryReadyAt.delete(id);
-          // The renderer callback is fenced so a synchronous throw there (a
-          // mesh-build or colour-seeding bug) can't fall through to the decode
-          // .catch below — which would silently un-do the residency just
-          // recorded and book a phantom decode failure with backoff. A failed
-          // mesh build is recorded as this node's error instead.
-          try {
-            this._callbacks.onNodeReady(node, decoded);
-          } catch (err) {
-            store.setError(node, err instanceof Error ? err.message : String(err));
-          }
+          this._commitDecoded(node, decoded);
         }
         this._dispatch();
         this._callbacks.onChange?.();

--- a/tests/lasColourEstimate.test.ts
+++ b/tests/lasColourEstimate.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The load-memory estimate drives admission: it sets the point budget and
+ * decides `mayExceedCeiling`. `LAS_DECODED_ATTRIBUTES` declared `hasColor:
+ * false` for every LAS point format, while the decoder emits a colour array
+ * for the formats that carry RGB. The estimate therefore came in low precisely
+ * on the files where memory is tightest, and the planner admitted budgets the
+ * device could not hold.
+ *
+ * These pin the format-to-attribute mapping and the direction of the error.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { lasDecodedAttributes, pointFormatHasRgb } from '../src/io/lasHeader';
+
+describe('LAS point formats that carry RGB', () => {
+  it('matches the ASPRS specification', () => {
+    // 2, 3, 5 are the 1.2/1.3 colour formats; 7, 8, 10 the 1.4 counterparts.
+    for (const f of [2, 3, 5, 7, 8, 10]) {
+      expect(pointFormatHasRgb(f), `format ${f} carries RGB`).toBe(true);
+    }
+    for (const f of [0, 1, 4, 6, 9]) {
+      expect(pointFormatHasRgb(f), `format ${f} carries no RGB`).toBe(false);
+    }
+  });
+
+  it('declares colour only for the formats that have it', () => {
+    expect(lasDecodedAttributes(3).hasColor).toBe(true);
+    expect(lasDecodedAttributes(0).hasColor).toBe(false);
+  });
+
+  it('leaves every other declared attribute alone', () => {
+    const colour = lasDecodedAttributes(3);
+    const plain = lasDecodedAttributes(0);
+    for (const key of ['hasIntensity', 'hasClassification', 'hasNormals', 'hasLasExtras'] as const) {
+      expect(colour[key]).toBe(plain[key]);
+    }
+  });
+
+  it('raises the per-point estimate for a colour-bearing format', async () => {
+    const { estimateMemoryBytes } = await import('../src/io/loadPlan');
+    const base = { pointCount: 1_000_000, fileBytes: 0, format: 'las' as const };
+    const withColour = estimateMemoryBytes({ ...base, attributes: lasDecodedAttributes(3) });
+    const without = estimateMemoryBytes({ ...base, attributes: lasDecodedAttributes(0) });
+    // Three bytes per point, so a million points differ by 3 MB. The old
+    // constant produced the lower figure for both.
+    expect(withColour).toBeGreaterThan(without);
+    expect(withColour - without).toBe(3_000_000);
+  });
+});

--- a/tests/streamingUploadQueueIntegration.test.ts
+++ b/tests/streamingUploadQueueIntegration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Decode completion used to mark a node `resident` and build its mesh in the
+ * same turn, so several decodes landing together built several meshes in one
+ * frame. That is the hitch the upload queue exists to spread out.
+ *
+ * With a queue supplied, a decoded node waits in `decoded` — in memory, not
+ * drawn — until the queue commits it. The distinction is the point:
+ * `residentPointCount` then means points the user can see, so the budget
+ * throttles against something real rather than against decode progress.
+ *
+ * The queue is opt-in, so the direct path is pinned here too.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { GpuUploadQueue } from '../src/render/gpuUploadQueue';
+import { StreamingScheduler, decodedChunkBytes } from '../src/render/streaming/StreamingScheduler';
+import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
+import { streamingBudgets } from '../src/render/streaming/streamingBudget';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import { buildSyntheticCopc } from './fixtures/copc/synthCopc';
+import type { StreamingNode } from '../src/render/streaming/StreamingNode';
+import type { ChunkDecoder, ChunkDecodeMetadata, DecodedChunk } from '../src/io/copc/copcChunkDecode';
+
+const WIDE = [1/256,0,0,0, 0,1/256,0,0, 0,0,1/256,0, 0,0,0,1];
+
+const fakeDecoder: ChunkDecoder = {
+  async decode(_buf: ArrayBuffer, meta: ChunkDecodeMetadata): Promise<DecodedChunk> {
+    return {
+      pointCount: meta.pointCount,
+      positions: new Float32Array(meta.pointCount * 3),
+      intensity: new Uint16Array(meta.pointCount),
+      classification: new Uint8Array(meta.pointCount),
+      returnNumber: new Uint8Array(meta.pointCount),
+      returnCount: new Uint8Array(meta.pointCount),
+      gpsTime: new Float64Array(meta.pointCount),
+    };
+  },
+};
+
+async function drain(s: StreamingScheduler): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    const st = s.stats();
+    if (st.queued === 0 && st.loading === 0) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+async function openCloud(): Promise<StreamingPointCloud> {
+  const fixture = buildSyntheticCopc({
+    center: [0, 0, 0],
+    halfsize: 128,
+    nodes: [
+      { key: [0, 0, 0, 0], pointCount: 1000 },
+      { key: [1, 0, 0, 0], pointCount: 800 },
+      { key: [1, 1, 0, 0], pointCount: 600 },
+    ],
+  });
+  return StreamingPointCloud.open(new ArrayBufferRangeSource(fixture.buffer), 'queue.copc.laz');
+}
+
+function makeScheduler(cloud: StreamingPointCloud, ready: StreamingNode[], queue?: GpuUploadQueue) {
+  return new StreamingScheduler(
+    cloud,
+    fakeDecoder,
+    { onNodeReady: (n) => ready.push(n), onNodeEvicted: () => {} },
+    streamingBudgets('balanced', false),
+    queue ? { uploadQueue: queue, datasetId: 'ds' } : {},
+  );
+}
+
+describe('decoded-before-resident', () => {
+  it('commits on decode when no queue is supplied', async () => {
+    const cloud = await openCloud();
+    const ready: StreamingNode[] = [];
+    const s = makeScheduler(cloud, ready);
+    s.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+    await drain(s);
+    expect(ready).toHaveLength(3);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(0);
+    expect(cloud.octree.store.residentPointCount).toBeGreaterThan(0);
+  });
+
+  it('holds decoded nodes out of the resident count until the queue commits', async () => {
+    const cloud = await openCloud();
+    const ready: StreamingNode[] = [];
+    const queue = new GpuUploadQueue();
+    const s = makeScheduler(cloud, ready, queue);
+    s.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+    await drain(s);
+
+    // Decoded, queued, and deliberately not drawn.
+    expect(ready).toHaveLength(0);
+    expect(cloud.octree.store.residentPointCount).toBe(0);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(2400);
+    expect(queue.pendingCount).toBe(3);
+
+    queue.process({ budgetMs: 1000 });
+
+    expect(ready).toHaveLength(3);
+    expect(cloud.octree.store.residentPointCount).toBe(2400);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(0);
+  });
+
+  it('meters commits across frames instead of building every mesh at once', async () => {
+    const cloud = await openCloud();
+    const ready: StreamingNode[] = [];
+    const queue = new GpuUploadQueue();
+    const s = makeScheduler(cloud, ready, queue);
+    s.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+    await drain(s);
+
+    queue.process({ budgetMs: 1000, maxNodes: 1 });
+    expect(ready).toHaveLength(1);
+    expect(cloud.octree.store.decodedPendingPointCount).toBeGreaterThan(0);
+
+    queue.process({ budgetMs: 1000, maxNodes: 1 });
+    expect(ready).toHaveLength(2);
+
+    queue.process({ budgetMs: 1000 });
+    expect(ready).toHaveLength(3);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(0);
+  });
+
+  it('a discarded node is never drawn and leaves no pending points', async () => {
+    const cloud = await openCloud();
+    const ready: StreamingNode[] = [];
+    const queue = new GpuUploadQueue();
+    const s = makeScheduler(cloud, ready, queue);
+    s.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+    await drain(s);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(2400);
+
+    queue.clear(); // the scan was detached before anything committed
+
+    expect(ready).toHaveLength(0);
+    expect(cloud.octree.store.decodedPendingPointCount).toBe(0);
+    expect(cloud.octree.store.residentPointCount).toBe(0);
+    expect(queue.pendingBytes).toBe(0);
+  });
+});
+
+describe('decodedChunkBytes', () => {
+  it('sums the arrays the chunk actually carries', () => {
+    const n = 100;
+    const bytes = decodedChunkBytes({
+      pointCount: n,
+      positions: new Float32Array(n * 3),
+      intensity: new Uint16Array(n),
+      classification: new Uint8Array(n),
+      returnNumber: new Uint8Array(n),
+      returnCount: new Uint8Array(n),
+      gpsTime: new Float64Array(n),
+    });
+    // 1200 + 200 + 100 + 100 + 100 + 800
+    expect(bytes).toBe(2500);
+  });
+
+  it('counts optional attributes only when present', () => {
+    const n = 10;
+    const base = {
+      pointCount: n,
+      positions: new Float32Array(n * 3),
+      intensity: new Uint16Array(n),
+      classification: new Uint8Array(n),
+      returnNumber: new Uint8Array(n),
+      returnCount: new Uint8Array(n),
+      gpsTime: new Float64Array(n),
+    };
+    const withRgb = decodedChunkBytes({ ...base, rgb: new Uint8Array(n * 3) });
+    expect(withRgb - decodedChunkBytes(base)).toBe(30);
+  });
+});


### PR DESCRIPTION
Stacked on #103.

Decode completion marked a node `resident` and built its mesh in the same turn (`StreamingScheduler.ts:1064`). Several decodes landing together built several meshes in one frame — the hitch the queue exists to spread out — and `residentPointCount` counted points nothing had drawn, so the budget throttled against decode progress rather than what the user sees.

**`NodeState` gains `decoded`**: in memory, not drawn. The store keeps its count and set symmetrically with resident and exposes `decodedPendingPointCount` separately rather than folding it in.

**The scheduler routes through `_commitDecoded`.** No queue: the historical direct path, exactly. With a queue: node becomes `decoded`, and commit promotes it after rechecking state, so a node no longer wanted never builds a mesh. Discard returns it to `unloaded`, not `resident` — it was never drawn.

**`decodedChunkBytes`** sums the arrays a chunk actually carries; a per-point constant would defeat a budget meant to bound the next frame.

**Off by default.** This changes when a node counts resident and when its mesh is built, and §8.8's gates want WebGPU and forced WebGL2 runs first. Absent the option, behaviour is unchanged.

Verified: tsc 0, unit 1117, streaming 237, ui 433, build 0, monolith 0. Six new integration tests covering both paths, metering, and discard.