### PR TITLE
Scope the brace-expansion override so Stryker loads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2486,6 +2486,29 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@stryker-mutator/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@stryker-mutator/core/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -2523,24 +2546,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/minimatch/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@stryker-mutator/core/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/@stryker-mutator/instrumenter": {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,9 @@
     "vitest": "^4.1.7"
   },
   "overrides": {
-    "brace-expansion": "^1.1.16",
+    "minimatch@3": {
+      "brace-expansion": "^1.1.16"
+    },
     "qs": "^6.15.2",
     "vitepress": {
       "vite": "^6.4.3"


### PR DESCRIPTION
**A regression I introduced.** The blanket `brace-expansion: ^1.1.16` override that closed CVE-2026-13149 forced every copy in the tree to v1 — including the one Stryker's `minimatch@10` imports. That major is ESM with a named `expand`; v1 is CommonJS without one.

The Mutation workflow died on its first line:

```
SyntaxError: Named export 'expand' not found. The requested module
'brace-expansion' is a CommonJS module...
```

Nothing caught it locally, because mutation had already moved out of the tag gate — so the first run of the fixed Stryker config was also the first run against the broken override.

The override is now keyed on `minimatch@3`, the consumer that genuinely wants v1. `minimatch@10` keeps v5. Both are patched versions, so the advisory stays closed.

Verified: `stryker --version` exits **0** on the tree that failed; `npm audit` shows the same five unfixable `brace-expansion` advisories and no more; runtime audit **0**; unit 1117; build 0.

Release-blocking: the gate refuses without a cited mutation result.