### PR TITLE
Record the 96.81 mutation score and fix the push race

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -90,4 +90,21 @@ jobs:
           git add docs/validation/mutation-evidence.json
           SCORE="$(node -p "require('./docs/validation/mutation-evidence.json').score")"
           git commit -m "Record mutation score ${SCORE} from run ${GITHUB_RUN_ID}"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          # The campaign takes over two hours, so the branch has almost always
+          # moved by the time it finishes. A plain push is rejected and the
+          # measurement is lost with it — which is what happened to run
+          # 30414720675, whose 96.81 had to be recovered from the artifact.
+          # Rebase and retry: the evidence file is written by this job alone,
+          # so a conflict on it is not possible, and the record names the
+          # commit it was measured at rather than wherever the branch has got
+          # to, so replaying it onto a newer tip changes nothing it asserts.
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:${GITHUB_REF_NAME}"; then
+              echo "pushed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "push rejected; rebasing onto the current tip (attempt ${attempt})"
+            git pull --rebase --autostash origin "${GITHUB_REF_NAME}"
+          done
+          echo "::error::could not push the mutation evidence after three attempts"
+          exit 1

--- a/docs/validation/mutation-evidence.json
+++ b/docs/validation/mutation-evidence.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "project": "openlidarviewer",
+  "score": 96.81,
+  "break": 75,
+  "mutants": {
+    "killed": 129,
+    "timeout": 53,
+    "survived": 5,
+    "noCoverage": 1,
+    "ignored": 0,
+    "errors": 0,
+    "detected": 182,
+    "undetected": 6,
+    "scored": 188
+  },
+  "mutate": [
+    "src/process/numerics.ts",
+    "src/terrain/quantile.ts",
+    "src/terrain/ground/terrainDerivatives.ts"
+  ],
+  "commit": "7f72fa16c72152d2f65f5c9ebb795355fbd42327",
+  "measuredAt": "2026-07-29T03:54:56.232Z",
+  "ranInThisGate": false,
+  "workflow": "Mutation",
+  "workflowRunId": "30414720675",
+  "workflowRunUrl": "https://github.com/Aurtechmx/openlidarviewer/actions/runs/30414720675",
+  "nodeVersion": "v22.17.1",
+  "platform": "linux-x64"
+}


### PR DESCRIPTION
The campaign **completed** at **96.81** over 188 mutants, then failed on its last step: the push was rejected because `main` moved during the 2h15m run. The measurement survived only as a build artifact.

```
killed 129 · timeout 53 · survived 5 · no-coverage 1
detected 182 / scored 188 = 96.81
```

The evidence is recovered from the artifact unchanged. It names commit `7f72fa1`, which is no longer the tip, and the record carries that rather than implying currency — `release:verify` already reports `coversReleaseCommit` for exactly this case.

The push now rebases and retries up to three times. Only this job writes the file, so a conflict is impossible, and replaying onto a newer tip changes nothing the record asserts.

**One caveat worth reading past the headline:** 53 of the 182 detected mutants were killed by *timeout*, not by an assertion. Stryker counts those as detected, so the score is real but 28% of it rests on weaker evidence than a test failing on a wrong value. Previous measured score was 87.23.