### PR TITLE
Assert the stress report's numbers before publishing them

### DIFF
--- a/tests/streamingStressReport.test.ts
+++ b/tests/streamingStressReport.test.ts
@@ -25,7 +25,7 @@
  * gated) so it never fires in default CI runs.
  */
 
-import { test } from 'vitest';
+import { test, expect } from 'vitest';
 import { runStressTier } from './streamingStressHarness.test';
 import { STRESS_TIERS, type StressTier } from './fixtures/copc/scaledSynthCopc';
 
@@ -61,6 +61,19 @@ if (tiers.length > 0) {
         globalThis as { performance?: { now: () => number } }
       ).performance!.now();
       const { result } = await runStressTier(tier);
+      // The table is the point of this file, but a report that prints NaN and
+      // passes is worse than no report: a partial or degenerate run would be
+      // formatted into a plausible-looking row and read as a measurement.
+      // These check the numbers are real before they are published, which is
+      // also what makes this a test rather than a script that happens to live
+      // in tests/.
+      expect(Number.isFinite(result.peakResidentPoints)).toBe(true);
+      expect(result.peakResidentPoints).toBeGreaterThan(0);
+      expect(Number.isFinite(result.peakResidentBytes)).toBe(true);
+      expect(Number.isFinite(result.schedulerTickMs.mean)).toBe(true);
+      expect(Number.isFinite(result.schedulerTickMs.p95)).toBe(true);
+      expect(result.schedulerTickMs.p95).toBeGreaterThanOrEqual(result.schedulerTickMs.mean);
+      expect(result.thrashEvents).toBeGreaterThanOrEqual(0);
       const wall =
         (globalThis as { performance?: { now: () => number } }).performance!.now() - wall0;
       const row = [


### PR DESCRIPTION
SonarQube flagged two Blockers, both "test case with no assertion". They are different cases.

**`streamingStressReport.test.ts:50` — real, now fixed.** The block formats a markdown table from a stress run and prints it. With no assertions, a partial or degenerate run would render `NaN` into a plausible-looking row and still pass. A report that publishes nonsense and reports success is worse than no report.

It now checks the figures are finite and ordered before formatting: peak residency positive, tick p95 at or above the mean, thrash count not negative.

Verified the assertions execute rather than assumed: forcing one to fail gives `expected 492678 to be greater than 1000000000000` and exit 1; restoring gives exit 0.

**`orbitSmoke.test.ts:133` — false positive, unchanged.** It is an `it.skip` with a deliberately empty body, a marker so the reporter shows why the production-build smoke did not run. Adding an assertion to an intentionally skipped test would satisfy the rule and mean nothing.

tsc 0, unit suite passing.