### PR TITLE
Sonar analysis configuration

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,43 @@
+# SonarQube Cloud analysis settings.
+#
+# Two warnings prompted this file. Both were about the scanner not being told
+# things the repository already knows.
+
+# projectKey and organization are deliberately absent. This repository is
+# scanned by SonarQube Cloud's automatic analysis, which already knows its own
+# project binding; those two keys identify a CI-driven scan and their presence
+# is what tells the service to stop analysing automatically. Adding them would
+# silence the warnings by silencing the whole analysis.
+
+# Without this the scanner analyses Python against every 3.x at once and
+# reports rules that cannot both apply. The scripts are the fixture generators
+# and the plot renderer; all five parse under 3.11, and the one using builtin
+# generics in annotations carries `from __future__ import annotations`, so 3.11
+# is what the project is developed and verified against rather than the oldest
+# version that might work.
+sonar.python.version=3.11
+
+# The scanner reported file-encoding problems. Every tracked text file is valid
+# UTF-8 with no BOM; the files it could not decode are images and icons, which
+# are excluded below. Stating the encoding stops it guessing from the platform
+# locale, which differs between a developer machine and CI.
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=src,scripts,benchmarks,public
+sonar.tests=tests
+
+# Binaries carry no source to analyse, and generated or vendored trees would
+# report defects nobody can act on in the place they appear.
+sonar.exclusions=\
+  **/*.png,**/*.jpg,**/*.jpeg,**/*.ico,**/*.webp,**/*.svg,\
+  **/*.las,**/*.laz,**/*.ply,**/*.bin,**/*.copc.laz,\
+  dist/**,release/**,node_modules/**,docs-site/.vitepress/cache/**,\
+  validation/snapshot/**,benchmarks/out/**
+
+# Fixtures are inputs to tests, not tests, and are frequently generated.
+sonar.test.exclusions=tests/fixtures/**
+
+# Coverage is produced by the same run Codecov consumes, so both read one
+# measurement rather than two that can disagree.
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.typescript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
Two warnings, both the scanner guessing at things the repository knows.

**Python was analysed against every 3.x at once**, so it reported rules that cannot both apply. All five scripts parse under 3.11, and the only one using builtin generics in annotations carries `from __future__ import annotations`. Declared 3.11 as what the project is verified against, not the oldest version that might work.

**The encoding warning came from images.** Every tracked text file is valid UTF-8 with no BOM — the sixteen the scanner could not decode are screenshots, icons and point-cloud fixtures, now excluded. Declaring `sourceEncoding` also stops it guessing from the platform locale, which differs between a laptop and CI.

**`projectKey` and `organization` are deliberately absent.** This repo is scanned by automatic analysis, which knows its own binding; those keys mark a CI-driven scan, and their presence is what tells the service to stop analysing automatically. Including them would have silenced the warnings by silencing the analysis.

Coverage points at the same `lcov.info` Codecov consumes, so both read one measurement rather than two that can disagree.

**Related gap, not fixed here:** the repository pins no Python version anywhere — no `.python-version`, no `pyproject.toml`, no CI setup step. That matters because the fixture generators are the stated reason tracked binaries are reviewable, and that claim needs an interpreter behind it.