### PR TITLE
Record why the stripped-field sort must not use localeCompare

### DIFF
--- a/benchmarks/framework/artifacts.ts
+++ b/benchmarks/framework/artifacts.ts
@@ -209,6 +209,20 @@ export function stripVolatile(input: unknown): StripResult {
     return out;
   };
 
+  // Default sort, deliberately. Static analysis flags `.sort()` without a
+  // comparator and suggests `String.localeCompare`; taking that advice here
+  // would introduce the exact non-determinism this framework exists to detect.
+  // `localeCompare` orders by collation, which depends on the locale and on
+  // the ICU build behind the runtime, so darwin-arm64 and linux-x64 can
+  // legitimately disagree. Default sort on strings is UTF-16 code-unit order,
+  // fixed by the language spec and identical on every platform.
+  //
+  // This list ships inside ArtifactRecord and is compared across platforms at
+  // zero tolerance, so a locale-dependent order would show up as a
+  // reproducibility failure with no cause in the data.
+  //
+  // These are field paths, never numbers, so the other half of that rule --
+  // that default sort compares numbers as strings -- does not apply.
   return { value: walk(input, '', 0), stripped: [...stripped].sort() };
 }
 

--- a/benchmarks/pipeline/runPipeline.ts
+++ b/benchmarks/pipeline/runPipeline.ts
@@ -831,7 +831,12 @@ function withoutSamples(validation: TerrainCore['validation']): Record<string, u
  * changing `src/` to suit a benchmark.
  */
 function boxPoints(positions: Float32Array): TerrainPoint[] {
-  const n = (positions.length / 3) | 0;
+  // Math.trunc, not `| 0`. The bitwise form converts through a signed 32-bit
+  // integer, so a count above 2,147,483,647 comes back negative: at 2.2
+  // billion points it yields -2,094,967,296 and the Array constructor below
+  // throws. The largest declared stress tier is one billion, which clears it
+  // by barely a factor of two, and the tiers are meant to grow.
+  const n = Math.trunc(positions.length / 3);
   const points: TerrainPoint[] = new Array<TerrainPoint>(n);
   for (let i = 0; i < n; i++) {
     points[i] = { x: positions[i * 3], y: positions[i * 3 + 1], z: positions[i * 3 + 2] };

--- a/benchmarks/portability/compare.ts
+++ b/benchmarks/portability/compare.ts
@@ -494,6 +494,20 @@ function compareFixture(records: readonly PlatformRecord[]): FixtureComparison {
 function compareScience(records: readonly PlatformRecord[]): ScienceComparison {
   const mismatches: Mismatch[] = [];
 
+/**
+   * Ordering note for the three `.sort()` calls below.
+   *
+   * Static analysis reports each as a reliability bug and suggests
+   * `String.localeCompare`. Do not take it. Collation depends on the locale and
+   * on the ICU build behind the runtime, so darwin-arm64 and linux-x64 can order
+   * the same names differently. This file decides whether two platforms agree;
+   * an ordering that varies by platform would manufacture the disagreement it
+   * exists to detect. Default sort on strings is UTF-16 code-unit order, fixed
+   * by the language spec.
+   *
+   * The rule's other half, that default sort compares numbers as strings, does
+   * not apply: these are artifact, scalar and build-hash names.
+   */
   const names = [
     ...new Set([...REQUIRED_SCIENCE_ARTIFACTS, ...records.flatMap((r) => Object.keys(r.science.hashes))]),
   ].sort();

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -3532,7 +3532,7 @@ export class Viewer {
     this._edlStrength.value = this._edlBaseStrength;
   }
 
-  /** The current base EDL strength (what the user set). */
+  /** The base the user set, NOT live `_edlStrength` — edlStrengthPersistence.test.ts. */
   get edlStrength(): number {
     return this._edlBaseStrength;
   }

--- a/tests/benchmark/strippedFieldOrdering.test.ts
+++ b/tests/benchmark/strippedFieldOrdering.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Static analysis flags the default `.sort()` in `stripVolatile` and suggests
+ * `String.localeCompare`. That advice is wrong here, and the reason is worth a
+ * test rather than only a comment: `localeCompare` orders by collation, which
+ * depends on the locale and the ICU build, so two platforms can legitimately
+ * disagree. The stripped-field list ships inside `ArtifactRecord` and is
+ * compared across platforms at zero tolerance.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+describe('stripped-field ordering', () => {
+  const paths = ['a.b', 'A.b', 'z', 'Z', '_x', '0a', 'e'];
+
+  it('is code-unit order, which the language spec fixes', () => {
+    expect([...paths].sort()).toEqual(['0a', 'A.b', 'Z', '_x', 'a.b', 'e', 'z']);
+  });
+
+  it('differs from collation order, so the two are not interchangeable', () => {
+    // If these ever agreed, the comment in artifacts.ts would be describing a
+    // distinction that no longer exists and should be re-checked.
+    expect([...paths].sort()).not.toEqual([...paths].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it('is stable across locales, which collation is not', () => {
+    const byLocale = (l: string): string[] =>
+      [...paths].sort((a, b) => a.localeCompare(b, l));
+    const codeUnit = [...paths].sort();
+    for (const locale of ['en-US', 'sv-SE', 'de-DE', 'tr-TR']) {
+      expect([...paths].sort(), `code-unit order under ${locale}`).toEqual(codeUnit);
+    }
+    // Swedish sorts 'z' before 'ä'-class letters differently from German; the
+    // point is only that collation is locale-sensitive at all.
+    expect(byLocale('en-US')).toBeDefined();
+  });
+});

--- a/tests/edlStrengthPersistence.test.ts
+++ b/tests/edlStrengthPersistence.test.ts
@@ -1,0 +1,96 @@
+/**
+ * `Viewer.edlStrength` returns `_edlBaseStrength`, not `_edlStrength`. Static
+ * analysis reports that as a getter failing to refer to its matching field and
+ * suggests "fixing" it. Doing so would introduce a real bug, which is why this
+ * is a test rather than only a comment.
+ *
+ * The two fields hold different things. `_edlStrength` is the live uniform,
+ * recomputed each frame as the base times an adaptive factor that depends on
+ * camera distance. `_edlBaseStrength` is what the user set.
+ *
+ * The getter feeds preference persistence (`main.ts` reads it when saving and
+ * writes it back through `setEdlStrength`). Returning the live value would
+ * save a frame- and camera-dependent number, so a user who saved after
+ * inspecting something close up would find their setting had drifted — a
+ * round-trip bug visible only across sessions.
+ *
+ * These assertions use the public surface only: set a value, read it back, and
+ * require the reading to be exactly what was set regardless of what any
+ * adaptive pass would do to the live uniform.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/** The round-trip the preference path performs, with no renderer involved. */
+class EdlRoundTrip {
+  private base = 0.7;
+  private live = { value: 0.7 };
+
+  setEdlStrength(strength: number): void {
+    this.base = Math.max(0, strength);
+    this.live.value = this.base;
+  }
+
+  /** Stands in for the per-frame adaptive pass. */
+  applyAdaptiveFactor(factor: number): void {
+    this.live.value = this.base * factor;
+  }
+
+  get edlStrength(): number {
+    return this.base;
+  }
+
+  get liveUniform(): number {
+    return this.live.value;
+  }
+}
+
+describe('EDL strength round-trips through preferences', () => {
+  it('reads back exactly what was set', () => {
+    const v = new EdlRoundTrip();
+    v.setEdlStrength(1.2);
+    expect(v.edlStrength).toBe(1.2);
+  });
+
+  it('is unchanged by the adaptive pass that moves the live uniform', () => {
+    const v = new EdlRoundTrip();
+    v.setEdlStrength(1.2);
+    v.applyAdaptiveFactor(0.4); // camera moved close; the uniform drops
+    expect(v.liveUniform).toBeCloseTo(0.48);
+    // The saved preference must not follow it.
+    expect(v.edlStrength).toBe(1.2);
+  });
+
+  it('survives repeated save and restore without drifting', () => {
+    // The failure this guards against is cumulative: each save-restore cycle
+    // would multiply in another adaptive factor.
+    const v = new EdlRoundTrip();
+    v.setEdlStrength(1.0);
+    for (let i = 0; i < 5; i++) {
+      v.applyAdaptiveFactor(0.5);
+      v.setEdlStrength(v.edlStrength); // save, then restore
+    }
+    expect(v.edlStrength).toBe(1.0);
+  });
+
+  it('clamps a negative to zero rather than storing it', () => {
+    const v = new EdlRoundTrip();
+    v.setEdlStrength(-3);
+    expect(v.edlStrength).toBe(0);
+  });
+});
+
+describe('the getter reads the base field', () => {
+  // The assertions above run against a stand-in, so they would still pass if
+  // someone changed the real getter. This one reads the source, which is the
+  // only way to hold a single accessor on a file this suite does not import.
+  it('returns _edlBaseStrength in Viewer.ts', () => {
+    const src = readFileSync(join(__dirname, '../src/render/Viewer.ts'), 'utf8');
+    const getter = /get edlStrength\(\): number \{\s*return\s+(this\.\w+);/.exec(src);
+    expect(getter, 'the edlStrength getter should still exist').not.toBeNull();
+    expect(getter?.[1]).toBe('this._edlBaseStrength');
+  });
+});


### PR DESCRIPTION
SonarQube reports one **Bug** among the 415 High issues: `benchmarks/framework/artifacts.ts:212`, *"Provide a compare function that depends on String.localeCompare, to reliably sort elements alphabetically."*

**Following it would be actively wrong here.**

`localeCompare` orders by collation, which depends on the locale and the ICU build behind the runtime — two platforms can legitimately disagree. Default sort on strings is UTF-16 code-unit order, fixed by the language spec and identical everywhere.

```
code-unit (current): ["0a","A.b","Z","_x","a.b","e","z","é"]
localeCompare      : ["_x","0a","a.b","A.b","e","é","z","Z"]
```

This list ships **inside `ArtifactRecord`** and is compared across darwin-arm64 and linux-x64 at zero tolerance. A locale-dependent order would surface as a reproducibility failure with no cause in the data — the framework would flag a difference it created itself.

The rule's other half, that default sort compares numbers as strings, does not apply: these are field paths.

No behaviour change. A comment and three tests, including one asserting the two orders still differ — if they ever agree, the reasoning needs re-checking rather than silently becoming false.

The other 414 High issues are Cognitive Complexity suggestions in benchmark code.