### PR TITLE
Measure fair-software.eu compliance on request

### DIFF
--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -1,0 +1,42 @@
+# Measures compliance with the five fair-software.eu recommendations: a public
+# repository, a licence, a registry entry, citation metadata, and a quality
+# checklist. It reports a score and suggests a badge.
+#
+# Two deliberate differences from the action's documented example.
+#
+# The action is pinned to a commit rather than the `0.2.1` tag. Every other
+# action in this repository is pinned the same way, because a tag can be moved
+# to different code by whoever owns it, and OpenSSF Scorecard scores pinned
+# dependencies. The tag this commit carried is in the trailing comment.
+#
+# The example runs on every push. This runs on request. The action is a Docker
+# action, so each run builds an image from a third-party Dockerfile, and the
+# score changes only when licensing, citation, registry or checklist metadata
+# changes. Running it on demand keeps that build off the path of every commit.
+#
+# The README already carries a fairsoftwarechecklist.net badge, which is a
+# self-assessment. This measures from evidence instead, so the two are not
+# interchangeable and the numbers can differ. Read a real score from a real run
+# before deciding what to display.
+name: fair-software
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    name: Measure fair-software.eu compliance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Measure compliance with fair-software.eu recommendations
+        uses: fair-software/howfairis-github-action@4c11146488125aa6e1531184eed51d781bcd5871 # 0.2.1
+        env:
+          # The tool colours its output only when it believes a terminal is
+          # attached; this is the flag its own example uses to get colour in a
+          # runner log.
+          PYCHARM_HOSTED: "Trick colorama into displaying colored output"
+        with:
+          MY_REPO_URL: "https://github.com/${{ github.repository }}"


### PR DESCRIPTION
Adds the howfairis action, with two deliberate departures from the marketplace example.

**Pinned to a commit, not the tag.** `4c11146488125aa6e1531184eed51d781bcd5871`, verified against the live `0.2.1` tag. Every other action here is pinned this way, because a tag can be repointed at different code by whoever owns it, and OpenSSF Scorecard scores pinned dependencies. Taking the example verbatim would have regressed that.

**On request, not on every push.** It is a Docker action, so each run builds an image from a third-party Dockerfile, and the score only moves when licensing, citation, registry or checklist metadata changes.

The example also omits `MY_REPO_URL`, which the action declares as required, so it would fail immediately as written. That is supplied.

**No badge yet, on purpose.** The README carries a `fairsoftwarechecklist.net` badge, which is a self-assessment you filled in. This measures from evidence. They are not the same number and can disagree, so the honest order is to run it, read the real score, then decide what to display.

Verified: pinned sha matches the live tag, `benchmark:archive-portability` 0, `lint:archive-vocab` 0, `lint:no-tracked-ignored` 0, `tsc` 0, zero tabs, prose check clean. `actionlint` is not installed here, so the workflow was checked structurally against the existing ones.