### PR TITLE
Point testers at the form that fits what they scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,27 @@ optional permission.
 A failed file, an unexpected warning or one confusing screenshot is worth
 sending. Negative results are the useful kind here.
 
-[Submit a test report](https://lidar.aurtech.mx/test-report.html). The form runs
-in your browser and builds one self-contained report file, screenshots included,
-which you read before anything is sent. Send it to the project server, or
-download it and email it yourself. Reports are kept privately for development
-and are not published or passed to any third party.
+There are two forms, and which one fits depends on what you scan.
+
+[Terrestrial LiDAR evaluation](https://lidar.aurtech.mx/testing.html) takes five
+to ten minutes. Use it for tripod and mobile scanners, indoor and building
+capture, and any work where scan stations, occlusion and coverage matter more
+than a coordinate reference system.
+
+[GIS comparison](https://lidar.aurtech.mx/terrain-test.html) is longer. Use it
+when you can put a number beside a number: metadata, CRS and units, elevations,
+terrain products, and how the browser workflow compares with ArcGIS, QGIS,
+CloudCompare or PDAL. It asks for the values you read in both tools, so have the
+reference open.
+
+Either one is worth sending on its own. Neither needs the other.
+
+[Submit a test report](https://lidar.aurtech.mx/test-report.html) is the general
+form, for anything the two above do not cover. It runs in your browser and
+builds one self-contained report file, screenshots included, which you read
+before anything is sent. Send it to the project server, or download it and email
+it yourself. Reports are kept privately for development and are not published or
+passed to any third party.
 
 ## Overview
 

--- a/docs-site/guide/index.md
+++ b/docs-site/guide/index.md
@@ -34,7 +34,9 @@ npm run preview
 
 A file that refuses to open, a warning that looks wrong, one screen that confused you: all of it is worth writing down. Negative results are the useful kind here.
 
-[Submit a test report](https://lidar.aurtech.mx/test-report.html) assembles the report in your own browser, screenshots and all. You read the finished thing before anything leaves the page, then either send it or download it and email it yourself. Reports go to the project's own server, are kept privately for development, and are not published or shared with anyone else.
+Three forms, by what you scan. [Terrestrial LiDAR evaluation](https://lidar.aurtech.mx/testing.html) for tripod and mobile scanners and building capture, five to ten minutes. [GIS comparison](https://lidar.aurtech.mx/terrain-test.html) when you can put a number beside a number against ArcGIS, QGIS, CloudCompare or PDAL, so have the reference tool open. [Submit a test report](https://lidar.aurtech.mx/test-report.html) for anything else.
+
+All three assemble the report in your own browser, screenshots and all. You read the finished thing before anything leaves the page. Reports go to the project's own server, are kept privately for development, and are not published or shared with anyone else.
 
 ## Where next
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -83,5 +83,5 @@ AddType application/manifest+json .webmanifest
   #     labels with inline style="" attributes. Style injection is low-risk and
   #     no user-derived string reaches the unsafeHtml/innerHTML sinks (guarded by
   #     `npm run lint:unsafe-html`), so this does not open an XSS path.
-  Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' https:; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; base-uri 'self'; form-action 'self'"
+  Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' https:; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; base-uri 'self'; form-action 'self' https://usebasin.com"
 </IfModule>

--- a/public/_headers
+++ b/public/_headers
@@ -21,7 +21,7 @@
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   X-Frame-Options: SAMEORIGIN
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' https:; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' https:; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; base-uri 'self'; form-action 'self' https://usebasin.com
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
Two evaluation forms are live and neither was linked from anywhere. A tester arriving at the README found one general form and no way to know a shorter terrestrial evaluation and a longer GIS comparison exist.

The README now routes by what a tester scans. Terrestrial for tripod and mobile capture, where scan stations, occlusion and coverage matter more than a coordinate reference system. GIS comparison for work where a number can be put beside a number, which is why it says to have the reference tool open. The general form for anything else. The guide carries the same routing in a paragraph. Both are stated as independent, so nobody files the long one believing the short one was a prerequisite.

The pages stay out of the repository, as asked, so these are external links that the shipped-asset lint classifies rather than resolves. All three were requested directly and return 200.

**The CSP is also brought back into agreement with what the host serves, and this is the part that matters.** Both new forms POST to `usebasin.com`. The live header already permits that, having been edited on the host. The repository still said `form-action 'self'`. The next deploy from this tree would have restored the narrower policy and both forms would have stopped submitting, showing the tester nothing, because a CSP-blocked form submission is silent. That is the same failure shape as the inline-script form that shipped dead earlier.

Verified: repository policy byte-matches the served header, all three pages return 200, `lint:csp-html` 0 with `.htaccess` matching `_headers`, `lint:html-assets` 0, `lint:claims-language` 0, `docs:build` 0. The prose checker's findings on both touched files are pre-existing and the added lines carry no em dash.