### PR TITLE
State the code-unit ordering the build scripts rely on, and close two real defects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,17 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
-      - run: npm ci
+      # Four lockfile entries declare an install script: three copies of
+      # fsevents, which is darwin-only and is not installed on this runner, and
+      # vitepress's nested esbuild, which resolves its binary from a platform
+      # package and works without one. Nothing else can run code at install
+      # time, so disabling scripts removes that path at no cost. Measured on a
+      # full `npm ci --ignore-scripts` tree: the install succeeds, the
+      # typecheck, the laz-perf wasm tests and the production build all pass,
+      # and the resolved tree differs from the scripted install in nothing the
+      # suite reads. Playwright browsers come from an explicit
+      # `npx playwright install` step, which this flag does not touch.
+      - run: npm ci --ignore-scripts
       - name: Collect coverage
         run: npm run coverage
       - name: Upload to Codecov

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -49,7 +49,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
-      - run: npm ci
+      # See the note on the same step in ci.yml for what was measured. The only
+      # install scripts in the lockfile belong to darwin-only fsevents and to
+      # vitepress's nested esbuild, neither of which this job uses. The job
+      # holds `contents: write` to push the evidence file, so install-time code
+      # execution is worth removing here in particular.
+      - run: npm ci --ignore-scripts
       - name: Lockfile is unchanged by a clean install
         run: git diff --exit-code -- package-lock.json
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions: read-all
+# The single job below declares its own permissions, which replace these
+# outright, so this default applies to nothing today. It is stated narrowly
+# anyway: a job added without its own block inherits read access to the
+# repository contents and nothing else.
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/benchmarks/backends/record.ts
+++ b/benchmarks/backends/record.ts
@@ -38,6 +38,7 @@
  * Pure. No I/O, no clock, no randomness.
  */
 
+import { compareCodeUnits } from '../../src/canonicalHash';
 import { sha256Hex } from '../../src/terrain/export/sha256';
 import {
   ASPECT_COMPARISON_SLOPE_FLOOR,
@@ -193,7 +194,7 @@ function canonicalise(value: unknown): string {
   if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
   if (Array.isArray(value)) return `[${value.map(canonicalise).join(',')}]`;
   const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
-    a < b ? -1 : a > b ? 1 : 0,
+    compareCodeUnits(a, b),
   );
   return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalise(v)}`).join(',')}}`;
 }

--- a/benchmarks/framework/artifacts.ts
+++ b/benchmarks/framework/artifacts.ts
@@ -28,7 +28,7 @@
  * Nothing in this path reads a clock or a random source.
  */
 
-import { canonicalJson, fnv1a } from '../../src/canonicalHash';
+import { canonicalJson, compareCodeUnits, fnv1a } from '../../src/canonicalHash';
 import { sha256Hex } from '../../src/terrain/export/sha256';
 import type { ArtifactRecord } from './types';
 
@@ -209,21 +209,14 @@ export function stripVolatile(input: unknown): StripResult {
     return out;
   };
 
-  // Default sort, deliberately. Static analysis flags `.sort()` without a
-  // comparator and suggests `String.localeCompare`; taking that advice here
-  // would introduce the exact non-determinism this framework exists to detect.
-  // `localeCompare` orders by collation, which depends on the locale and on
-  // the ICU build behind the runtime, so darwin-arm64 and linux-x64 can
-  // legitimately disagree. Default sort on strings is UTF-16 code-unit order,
-  // fixed by the language spec and identical on every platform.
+  // Code-unit order, not collation. `compareCodeUnits` carries the reasoning:
+  // `localeCompare` would order this list by the runtime locale and ICU build,
+  // so darwin-arm64 and linux-x64 could legitimately disagree.
   //
   // This list ships inside ArtifactRecord and is compared across platforms at
   // zero tolerance, so a locale-dependent order would show up as a
   // reproducibility failure with no cause in the data.
-  //
-  // These are field paths, never numbers, so the other half of that rule --
-  // that default sort compares numbers as strings -- does not apply.
-  return { value: walk(input, '', 0), stripped: [...stripped].sort() };
+  return { value: walk(input, '', 0), stripped: [...stripped].sort(compareCodeUnits) };
 }
 
 /** Byte artifacts are opaque: nothing inside them can be inspected or stripped. */

--- a/benchmarks/portability/compare.ts
+++ b/benchmarks/portability/compare.ts
@@ -40,6 +40,7 @@
  * Pure. No I/O, no clock, no randomness.
  */
 
+import { compareCodeUnits } from '../../src/canonicalHash';
 import type { PlatformRecord } from './record';
 import { FIXTURE_DESCRIPTOR_ARTIFACT, PORTABILITY_SCHEMA_VERSION, SOURCE_CLOUD_ARTIFACT } from './record';
 import { SUPPORTED_ENDIANNESS, unsupportedEndiannessReason } from './preconditions';
@@ -494,23 +495,12 @@ function compareFixture(records: readonly PlatformRecord[]): FixtureComparison {
 function compareScience(records: readonly PlatformRecord[]): ScienceComparison {
   const mismatches: Mismatch[] = [];
 
-/**
-   * Ordering note for the three `.sort()` calls below.
-   *
-   * Static analysis reports each as a reliability bug and suggests
-   * `String.localeCompare`. Do not take it. Collation depends on the locale and
-   * on the ICU build behind the runtime, so darwin-arm64 and linux-x64 can order
-   * the same names differently. This file decides whether two platforms agree;
-   * an ordering that varies by platform would manufacture the disagreement it
-   * exists to detect. Default sort on strings is UTF-16 code-unit order, fixed
-   * by the language spec.
-   *
-   * The rule's other half, that default sort compares numbers as strings, does
-   * not apply: these are artifact, scalar and build-hash names.
-   */
+  // Code-unit order for the three orderings in this function, never collation.
+  // This file decides whether two platforms agree; an order that varies by
+  // locale or ICU build would manufacture the disagreement it exists to detect.
   const names = [
     ...new Set([...REQUIRED_SCIENCE_ARTIFACTS, ...records.flatMap((r) => Object.keys(r.science.hashes))]),
-  ].sort();
+  ].sort(compareCodeUnits);
   for (const name of names) {
     const values: Record<string, string> = {};
     let missing = false;
@@ -529,7 +519,7 @@ function compareScience(records: readonly PlatformRecord[]): ScienceComparison {
   // scalar added to the pipeline must be compared, not skipped.
   const scalarsOf = (r: PlatformRecord): Record<string, unknown> =>
     r.science.scalars as unknown as Record<string, unknown>;
-  const scalarKeys = [...new Set(records.flatMap((r) => Object.keys(scalarsOf(r))))].sort();
+  const scalarKeys = [...new Set(records.flatMap((r) => Object.keys(scalarsOf(r))))].sort(compareCodeUnits);
   for (const key of scalarKeys) {
     // Object.is, matching the single-platform suite: it separates a genuine
     // null from a NaN and does not equate +0 with -0.
@@ -579,7 +569,7 @@ function expectedDifferencesOf(records: readonly PlatformRecord[]): ExpectedDiff
   add('runtime', 'v8Version', 'V8 supplies the transcendental functions the generator uses. Recorded because a difference here is the first thing to check if the fixture ever stops matching.', (r) => envText(r.environment.v8Version));
   add('runtime', 'npmVersion', 'The npm version does not affect an installed tree that came from the committed lockfile.', (r) => envText(r.environment.npmVersion));
 
-  const buildNames = [...new Set(records.flatMap((r) => Object.keys(r.buildScopedHashes)))].sort();
+  const buildNames = [...new Set(records.flatMap((r) => Object.keys(r.buildScopedHashes)))].sort(compareCodeUnits);
   for (const name of buildNames) {
     add(
       'build-scoped-hash',

--- a/benchmarks/runner/render.ts
+++ b/benchmarks/runner/render.ts
@@ -19,6 +19,7 @@
  * carried in the JSON the table points at.
  */
 
+import { compareCodeUnits } from '../../src/canonicalHash';
 import { UNAVAILABLE_LABEL, type EnvValue } from '../framework';
 import type { ForcedGcObservation } from './gcMode';
 import type { FirstRunCheck, SeriesSummary } from './stats';
@@ -92,6 +93,11 @@ export function csvField(value: string): string {
 
 function csvRow(fields: readonly string[]): string {
   return fields.map(csvField).join(',');
+}
+
+/** Hash-table entries in code-unit order of the artifact name. */
+function byName(hashes: Readonly<Record<string, string>>): [string, string][] {
+  return Object.entries(hashes).sort(([a], [b]) => compareCodeUnits(a, b));
 }
 
 /** Markdown table cell — a pipe would split the row into two columns. */
@@ -176,10 +182,12 @@ export function reproducibilityMarkdown(summary: ReproducibilitySummary): string
   lines.push('');
   lines.push('| artifact | scope | sha256 |');
   lines.push('| --- | --- | --- |');
-  for (const [name, hash] of Object.entries(summary.identity.referenceScienceHashes).sort()) {
+  // By artifact name. A default sort here would order the [name, hash] pairs
+  // by their comma-joined text, which folds the hash into the key.
+  for (const [name, hash] of byName(summary.identity.referenceScienceHashes)) {
     lines.push(`| ${cell(name)} | science | \`${cell(hash)}\` |`);
   }
-  for (const [name, hash] of Object.entries(summary.identity.referenceBuildScopedHashes).sort()) {
+  for (const [name, hash] of byName(summary.identity.referenceBuildScopedHashes)) {
     lines.push(`| ${cell(name)} | build | \`${cell(hash)}\` |`);
   }
   lines.push('');

--- a/benchmarks/runner/reproducibility.ts
+++ b/benchmarks/runner/reproducibility.ts
@@ -30,6 +30,7 @@
  * about reproducibility at all. See `ARTIFACT_SCOPE` in the driver.
  */
 
+import { compareCodeUnits } from '../../src/canonicalHash';
 import { scienceScopedArtifacts } from '../pipeline/runPipeline';
 import { BENCHMARK_PACKAGE_VERSION, BENCHMARK_SCHEMA_VERSION, type ReproducibilityConfig } from './config';
 import { executeRun } from './execute';
@@ -115,7 +116,7 @@ export interface ReproducibilityResult {
 
 /** Scalar field names, so a comparison cannot silently skip a new field. */
 function scalarKeys(observation: RunObservation): readonly string[] {
-  return Object.keys(observation.scalars).sort();
+  return Object.keys(observation.scalars).sort(compareCodeUnits);
 }
 
 export function runReproducibilitySuite(config: ReproducibilityConfig): ReproducibilityResult {

--- a/benchmarks/runner/summarise.ts
+++ b/benchmarks/runner/summarise.ts
@@ -12,6 +12,7 @@
  * number a reader asked for and answers a different question.
  */
 
+import { compareCodeUnits } from '../../src/canonicalHash';
 import { summariseSeries, type SeriesSummary } from './stats';
 import { describeSeries, type RunSeries } from './series';
 
@@ -53,7 +54,7 @@ export function summariseRuns(
   const available: SeriesBlock[] = [];
   const unavailable: UnavailableSeries[] = [];
 
-  for (const key of [...keys].sort()) {
+  for (const key of [...keys].sort(compareCodeUnits)) {
     const values: number[] = [];
     const missing: string[] = [];
     runs.forEach((run, i) => {
@@ -125,7 +126,7 @@ export function diffJson(
   if (aIsObject && bIsObject) {
     const ao = a as Record<string, unknown>;
     const bo = b as Record<string, unknown>;
-    const keys = [...new Set([...Object.keys(ao), ...Object.keys(bo)])].sort();
+    const keys = [...new Set([...Object.keys(ao), ...Object.keys(bo)])].sort(compareCodeUnits);
     for (const key of keys) {
       if (out.length >= limit) break;
       const child = path === '' ? key : `${path}.${key}`;

--- a/benchmarks/runner/verify.ts
+++ b/benchmarks/runner/verify.ts
@@ -33,6 +33,7 @@
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { compareCodeUnits } from '../../src/canonicalHash';
 import { nodeSha256Hex } from '../framework/node';
 import {
   BENCHMARK_SCHEMA_VERSION,
@@ -78,8 +79,8 @@ function checkSeriesBlock(
   recomputed: SummarisedSeries,
   problems: string[],
 ): void {
-  const publishedKeys = published.available.map((b) => b.key).sort();
-  const recomputedKeys = recomputed.available.map((b) => b.key).sort();
+  const publishedKeys = published.available.map((b) => b.key).sort(compareCodeUnits);
+  const recomputedKeys = recomputed.available.map((b) => b.key).sort(compareCodeUnits);
   if (publishedKeys.join('|') !== recomputedKeys.join('|')) {
     problems.push(
       `${label}: summarised series do not match the raw data — published [${publishedKeys.join(', ')}], recomputed [${recomputedKeys.join(', ')}]`,
@@ -383,7 +384,7 @@ export function verifyResultsDir(dir: string): VerifyOutcome {
   const listedPaths = new Set(manifest.files.map((f) => f.path));
   const unlisted = treeFiles(dir).filter((p) => p !== 'manifest.json' && !listedPaths.has(p));
   if (unlisted.length > 0) {
-    problems.push(`published files are not listed in the manifest: ${unlisted.sort().join(', ')}`);
+    problems.push(`published files are not listed in the manifest: ${unlisted.sort(compareCodeUnits).join(', ')}`);
   } else {
     checked.push('every file in the tree is listed in the manifest');
   }

--- a/scripts/build-defect-summary.mjs
+++ b/scripts/build-defect-summary.mjs
@@ -13,6 +13,7 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const DIR = resolve(ROOT, 'validation/defects');
@@ -56,7 +57,7 @@ function tally(pairs) {
   const counts = new Map();
   for (const key of pairs) counts.set(key, (counts.get(key) ?? 0) + 1);
   return Object.fromEntries(
-    [...counts].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
+    [...counts].sort((a, b) => b[1] - a[1] || compareCodeUnits(a[0], b[0])),
   );
 }
 

--- a/scripts/build-defect-summary.mjs
+++ b/scripts/build-defect-summary.mjs
@@ -170,8 +170,8 @@ const SUITE_LABEL = {
 /** Defect to evidence: what exposed each record, and what holds it fixed. */
 function mermaid() {
   const lines = ['```mermaid', 'flowchart LR'];
-  const mechanisms = [...new Set(defects.map((d) => d.detectingMechanism))].sort();
-  const files = [...new Set(defects.map((d) => d.regressionTest.file))].sort();
+  const mechanisms = [...new Set(defects.map((d) => d.detectingMechanism))].sort(compareCodeUnits);
+  const files = [...new Set(defects.map((d) => d.regressionTest.file))].sort(compareCodeUnits);
   const mId = (m) => `M_${m.replaceAll('-', '_')}`;
   const fId = (f) => `F_${f.replaceAll(/[^A-Za-z0-9]/g, '_')}`;
   for (const m of mechanisms) {

--- a/scripts/build-validation-snapshot.mjs
+++ b/scripts/build-validation-snapshot.mjs
@@ -35,6 +35,7 @@ import { dirname, resolve, join, relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { INPUTS, evidencePath, sha256, deriveSnapshot, renderSummary } from './validation-snapshot-lib.mjs';
+import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -63,7 +64,7 @@ function plan() {
     if (spec.dir) {
       for (const p of walk(join(ROOT, spec.dir.path), ROOT)) if (spec.dir.match.test(p)) paths.add(p);
     }
-    for (const p of [...paths].sort()) jobs.push({ id: spec.id, path: p });
+    for (const p of [...paths].sort(compareCodeUnits)) jobs.push({ id: spec.id, path: p });
   }
   return jobs;
 }
@@ -97,7 +98,7 @@ export function evidenceReader(dir, index) {
       const buf = readFileSync(stored.get(p));
       return { sha256: sha256(buf), bytes: buf.length };
     },
-    listed: (prefix) => [...stored.keys()].filter((p) => p.startsWith(`${prefix}/`)).sort(),
+    listed: (prefix) => [...stored.keys()].filter((p) => p.startsWith(`${prefix}/`)).sort(compareCodeUnits),
     storedPathOf: (p) => index.find((e) => e.sourcePath === p)?.storedPath ?? null,
   };
 }

--- a/scripts/build-validation-snapshot.mjs
+++ b/scripts/build-validation-snapshot.mjs
@@ -105,7 +105,7 @@ export function evidenceReader(dir, index) {
 
 /** Write SHA256SUMS over every file in the directory except the manifest. */
 export function writeManifest(dir) {
-  const files = walk(dir, dir).filter((p) => p !== 'SHA256SUMS').sort();
+  const files = walk(dir, dir).filter((p) => p !== 'SHA256SUMS').sort(compareCodeUnits);
   const lines = files.map((p) => `${sha256(readFileSync(join(dir, p)))}  ${p}`);
   writeFileSync(join(dir, 'SHA256SUMS'), `${lines.join('\n')}\n`);
   return files.length;

--- a/scripts/check-defect-registry.mjs
+++ b/scripts/check-defect-registry.mjs
@@ -16,6 +16,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const REGISTRY = resolve(ROOT, 'validation/defects/defect-registry.json');
@@ -139,7 +140,7 @@ function crossChecks(registry) {
     }
   }
   const ordered = registry.defects.map((d) => d.id);
-  if ([...ordered].sort().join() !== ordered.join()) {
+  if ([...ordered].sort(compareCodeUnits).join() !== ordered.join()) {
     errors.push('defects are not in id order');
   }
   return errors;

--- a/scripts/check-dep-singletons.mjs
+++ b/scripts/check-dep-singletons.mjs
@@ -29,6 +29,7 @@
 import { readdirSync, statSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const NODE_MODULES = join(ROOT, 'node_modules');
@@ -120,7 +121,7 @@ function main() {
 
   for (const pkg of CRITICAL) {
     const copies = findCopies(pkg, NODE_MODULES, new Map());
-    const dirs = [...copies.keys()].sort();
+    const dirs = [...copies.keys()].sort(compareCodeUnits);
 
     if (dirs.length === 0) {
       // A critical runtime package that is not installed at all is itself a

--- a/scripts/defect-replay-lib.mjs
+++ b/scripts/defect-replay-lib.mjs
@@ -13,6 +13,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
+import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
 
 const HERE = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -68,7 +69,7 @@ export function canonicalJson(value) {
   const sort = (v) => {
     if (Array.isArray(v)) return v.map(sort);
     if (v && typeof v === 'object') {
-      return Object.fromEntries(Object.keys(v).sort().map((k) => [k, sort(v[k])]));
+      return Object.fromEntries(Object.keys(v).sort(compareCodeUnits).map((k) => [k, sort(v[k])]));
     }
     return v;
   };
@@ -402,6 +403,10 @@ export function crossCheck(record) {
   // segments after one of them is a directory layout that survived redaction.
   // Checking only for the raw prefixes passes on `<home>/Documents/...`, which
   // is the leak this guard exists to stop.
+  //
+  // Static analysis reports the next line as use of a publicly writable
+  // directory. It is not. These are needles for `includes()` over captured
+  // text; nothing here opens, writes or resolves a path.
   const markers = ['/Users/', '/home/', '/private/tmp/', '/var/folders/', '<home>/', '<repo>/'];
   for (const marker of markers) {
     if (t.includes(marker) || (record.reporterJson ?? '').includes(marker)) {

--- a/scripts/lib/codeUnitOrder.mjs
+++ b/scripts/lib/codeUnitOrder.mjs
@@ -1,0 +1,31 @@
+/**
+ * codeUnitOrder.mjs. One string comparator for orderings that reach a
+ * committed record.
+ *
+ * Static analysis flags `.sort()` without a comparator and suggests
+ * `String.localeCompare`. That advice is wrong for every ordering in this
+ * directory. `localeCompare` orders by collation, which depends on the runtime
+ * locale and on the ICU build behind it, so darwin-arm64 and linux-x64 can
+ * order the same keys differently. The scripts here write snapshots, replay
+ * transcripts, defect summaries and portability records that are committed and
+ * re-derived on other machines, so a locale-dependent order turns a matching
+ * record into a false mismatch.
+ *
+ * `compareCodeUnits` is UTF-16 code-unit order, the same order a default
+ * `.sort()` on strings produces, fixed by the language spec and identical on
+ * every host. It is written out rather than left implicit so the ordering is
+ * stated in the code and the scanner has its comparator.
+ *
+ * The other half of the rule the scanner enforces, that a default `.sort()`
+ * compares numbers as strings, is a real defect. This comparator does not
+ * address it: it is for strings. Numeric arrays need `(a, b) => a - b`.
+ *
+ * The same reasoning is written out at the two TypeScript sites that predate
+ * this module, `benchmarks/framework/artifacts.ts` and
+ * `benchmarks/portability/compare.ts`.
+ */
+
+/** UTF-16 code-unit order. Locale-independent, so a committed order is stable. */
+export function compareCodeUnits(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/scripts/lib/codeUnitOrder.mjs
+++ b/scripts/lib/codeUnitOrder.mjs
@@ -20,9 +20,11 @@
  * compares numbers as strings, is a real defect. This comparator does not
  * address it: it is for strings. Numeric arrays need `(a, b) => a - b`.
  *
- * The same reasoning is written out at the two TypeScript sites that predate
- * this module, `benchmarks/framework/artifacts.ts` and
- * `benchmarks/portability/compare.ts`.
+ * The TypeScript tree has its own copy of this comparator in
+ * `src/canonicalHash.ts`, exported as `compareCodeUnits`. The two are separate
+ * because a `.ts` module cannot import a `.mjs` script helper without pulling
+ * the scripts directory into the application build. They are three lines each
+ * and they must stay in agreement.
  */
 
 /** UTF-16 code-unit order. Locale-independent, so a committed order is stable. */

--- a/scripts/make-big-surface.py
+++ b/scripts/make-big-surface.py
@@ -6,13 +6,22 @@ grid with sine-wave relief, varying intensity, and a few classification codes.
 Used to confirm the viewer renders a real multi-thousand-point cloud as a
 visible surface (not just the tiny bundled fixtures).
 
-Usage: python3 scripts/make-big-surface.py [out.las] [grid]
+Usage: python3 scripts/make-big-surface.py <out.las> [grid]
+
+The output path is required, with no default. A fixed name in a world-writable
+directory is a path any other account on the machine can create first, and the
+open() below follows a symlink planted there and writes through it. A fixed
+name also lets two runs overwrite each other silently.
 """
 import math
 import struct
 import sys
 
-out = sys.argv[1] if len(sys.argv) > 1 else "/tmp/big-surface.las"
+if len(sys.argv) < 2 or sys.argv[1].startswith("-"):
+    print("usage: python3 scripts/make-big-surface.py <out.las> [grid]", file=sys.stderr)
+    raise SystemExit(2)
+
+out = sys.argv[1]
 grid = int(sys.argv[2]) if len(sys.argv) > 2 else 400  # grid x grid points
 
 SCALE = (0.001, 0.001, 0.001)

--- a/scripts/replay-defects.mjs
+++ b/scripts/replay-defects.mjs
@@ -163,8 +163,8 @@ function injectProbe(baselineDir, entryRel, codePath) {
     }
   }
   return {
-    injected: injected.sort((a, b) => a.path.localeCompare(b.path)),
-    withheld: withheld.sort(),
+    injected: injected.sort((a, b) => compareCodeUnits(a.path, b.path)),
+    withheld: withheld.sort(compareCodeUnits),
   };
 }
 

--- a/scripts/validation-snapshot-lib.mjs
+++ b/scripts/validation-snapshot-lib.mjs
@@ -17,6 +17,7 @@
 
 import { createHash } from 'node:crypto';
 import { escapeRegExp } from './regex-escape.mjs';
+import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
 
 /** The inputs the snapshot collects, in report order. */
 export const INPUTS = Object.freeze([
@@ -322,7 +323,7 @@ export function derivedComposition(registry) {
 export function tally(values) {
   const counts = new Map();
   for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
-  return Object.fromEntries([...counts].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])));
+  return Object.fromEntries([...counts].sort((a, b) => b[1] - a[1] || compareCodeUnits(a[0], b[0])));
 }
 
 /**
@@ -341,7 +342,7 @@ export function jsonShape(text) {
   if (Array.isArray(value)) return { parsed: true, kind: 'array', length: value.length };
   if (value === null || typeof value !== 'object') return { parsed: true, kind: typeof value };
   const keys = {};
-  for (const k of Object.keys(value).sort()) {
+  for (const k of Object.keys(value).sort(compareCodeUnits)) {
     const v = value[k];
     if (Array.isArray(v)) keys[k] = `array[${v.length}]`;
     else if (v === null) keys[k] = 'null';
@@ -542,8 +543,8 @@ export function deriveSnapshot({ read, has, digest, listed, storedPathOf }) {
   for (const spec of INPUTS) {
     const paths = new Set(spec.files);
     if (spec.dir) for (const p of listed(spec.dir.path)) if (spec.dir.match.test(p)) paths.add(p);
-    const present = [...paths].filter((p) => has(p)).sort();
-    const missing = [...paths].filter((p) => !has(p)).sort();
+    const present = [...paths].filter((p) => has(p)).sort(compareCodeUnits);
+    const missing = [...paths].filter((p) => !has(p)).sort(compareCodeUnits);
 
     // Exactly one status, and the partial case is named rather than rounded to
     // either neighbour: a producer that left some of its declared records

--- a/scripts/verify-archive-portability.mjs
+++ b/scripts/verify-archive-portability.mjs
@@ -32,6 +32,7 @@
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, statSync, mkdirSync, rmSync, mkdtempSync } from 'node:fs';
 import { escapeRegExp } from './regex-escape.mjs';
+import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { resolve, dirname, join, relative, posix } from 'node:path';
@@ -229,7 +230,7 @@ export function rootDocumentReferences(text) {
   for (const m of text.matchAll(/(?<![\w./@-])([A-Z][A-Z0-9_]*(?:_v\d[\w.]*)?\.md)(?![\w])/g)) {
     out.add(m[1]);
   }
-  return [...out].sort();
+  return [...out].sort(compareCodeUnits);
 }
 
 // ── archive acquisition ──────────────────────────────────────────────────────
@@ -606,7 +607,7 @@ check('markdown-link-graph', 'every required reference in the shipped markdown g
     if (referenced.size === 0) {
       f.push({ level: 'error', message: 'no shipped document names a tracked root-level document; the root-document tier verified nothing.' });
     }
-    rootTier = { available: true, documents: [...referenced].sort() };
+    rootTier = { available: true, documents: [...referenced].sort(compareCodeUnits) };
   }
 
   return {
@@ -618,7 +619,7 @@ check('markdown-link-graph', 'every required reference in the shipped markdown g
         archiveFiles: c.files.length,
         edgesByClass: classes,
         edgesBySyntax: via,
-        externalHosts: [...externalHosts].sort(),
+        externalHosts: [...externalHosts].sort(compareCodeUnits),
       },
       rootDocuments: rootTier,
       unresolved,

--- a/scripts/verify-archive-portability.mjs
+++ b/scripts/verify-archive-portability.mjs
@@ -305,7 +305,7 @@ const check = (id, title, fn, opts = {}) => checks.push({ id, title, fn, ...opts
 const resolves = (c, target) => linkCandidates(target).some((p) => c.set.has(p) || existsSync(join(c.A, p)));
 
 function makeCtx(A) {
-  const files = listFiles(A).sort();
+  const files = listFiles(A).sort(compareCodeUnits);
   const set = new Set(files);
   const read = (p) => (set.has(p) ? readFileSync(join(A, p), 'utf8') : null);
   const pkg = JSON.parse(readFileSync(join(A, 'package.json'), 'utf8'));
@@ -444,7 +444,7 @@ check('no-internal-material', 'nothing internal or generated ships in the archiv
 check('no-dangling-references-to-excluded', 'nothing that ships references a file that does not', (c) => {
   const f = [];
   const tracked = git(['ls-files']).split('\n').filter(Boolean);
-  const excluded = tracked.filter((p) => !c.set.has(p)).sort();
+  const excluded = tracked.filter((p) => !c.set.has(p)).sort(compareCodeUnits);
   for (const md of c.markdown) {
     for (const { kind, target } of markdownTargets(c.read(md), md)) {
       if (resolves(c, target)) continue;
@@ -734,7 +734,7 @@ check('imports-declared', 'every package the archive imports is a declared depen
     }
     f.push({ level: 'warn', message: `runtime dependency "${name}" is declared but nothing in the archive imports it or reads it out of node_modules.` });
   }
-  return { findings: f, detail: { imported: [...used].sort(), readByPath: [...byPath].sort() } };
+  return { findings: f, detail: { imported: [...used].sort(compareCodeUnits), readByPath: [...byPath].sort(compareCodeUnits) } };
 });
 
 check('sbom-matches-manifest', 'the SBOM ships and covers the declared dependency set', (c) => {

--- a/scripts/verify-validation-snapshot.mjs
+++ b/scripts/verify-validation-snapshot.mjs
@@ -42,6 +42,7 @@ import {
   sha256, deriveSnapshot, renderSummary, artifactIndex, PRODUCER_STATUSES,
 } from './validation-snapshot-lib.mjs';
 import { evidenceReader, writeManifest } from './build-validation-snapshot.mjs';
+import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const DEFAULT_DIR = join(ROOT, 'validation/snapshot');
@@ -89,7 +90,7 @@ export function firstDifference(a, b, path = '') {
     return null;
   }
   if (ta === 'object') {
-    const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
+    const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort(compareCodeUnits);
     for (const k of keys) {
       const d = firstDifference(a[k], b[k], path ? `${path}.${k}` : k);
       if (d) return d;
@@ -118,7 +119,7 @@ export function checkManifest(dir) {
     const got = sha256(readFileSync(join(dir, p)));
     if (got !== want) problems.push(`${p} hashes ${got}, the manifest says ${want}.`);
   }
-  for (const p of [...present].sort()) {
+  for (const p of [...present].sort(compareCodeUnits)) {
     if (!listed.has(p)) problems.push(`${p} is in the snapshot and the manifest does not account for it.`);
   }
   return problems;

--- a/src/canonicalHash.ts
+++ b/src/canonicalHash.ts
@@ -5,14 +5,38 @@
  * Shared by the scientific-analysis record fingerprint and the Contour Studio
  * state hash so both produce identical, reproducible digests from the same
  * logical content. Zero dependencies — safe to import from any layer.
+ *
+ * `compareCodeUnits` lives here because ordering is half of canonicalisation:
+ * a digest is only reproducible if the keys that feed it are ordered the same
+ * way on every host. It is the TypeScript counterpart of
+ * `scripts/lib/codeUnitOrder.mjs`, which serves the build and verification
+ * scripts.
  */
+
+/**
+ * UTF-16 code-unit order. Locale-independent, so a committed order is stable.
+ *
+ * Static analysis flags `.sort()` without a comparator and suggests
+ * `String.localeCompare`. That advice is wrong for every ordering that reaches
+ * a digest or a committed record. `localeCompare` orders by collation, which
+ * depends on the runtime locale and on the ICU build behind it, so
+ * darwin-arm64 and linux-x64 can order the same keys differently and the same
+ * content then hashes to two values. Code-unit order is fixed by the language
+ * spec and identical on every host. It is the order a default `.sort()` on
+ * strings already produces, written out so the ordering is stated in the code.
+ *
+ * This comparator is for strings. Numeric arrays need `(a, b) => a - b`.
+ */
+export function compareCodeUnits(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
 
 /** Deterministic JSON with sorted object keys, so a fingerprint is stable. */
 export function canonicalJson(value: unknown): string {
   if (value === null || typeof value !== 'object') return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
   const obj = value as Record<string, unknown>;
-  const keys = Object.keys(obj).sort();
+  const keys = Object.keys(obj).sort(compareCodeUnits);
   return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`).join(',')}}`;
 }
 

--- a/src/model/layerCompatibility.ts
+++ b/src/model/layerCompatibility.ts
@@ -15,6 +15,7 @@
  * tens of metres; metres vs feet by a factor of three). That pair should align
  * in X/Y — the alignment is true — and must not be aligned or compared in Z.
  */
+import { compareCodeUnits } from '../canonicalHash';
 
 /** What a layer has proven about its relationship to the project frame. */
 export type LayerCompatibility =
@@ -147,7 +148,7 @@ export function classifyLayerCompatibility(
   for (const { key } of declared) counts.set(key, (counts.get(key) ?? 0) + 1);
   let referenceKey = '';
   let best = -1;
-  for (const key of [...counts.keys()].sort()) {
+  for (const key of [...counts.keys()].sort(compareCodeUnits)) {
     const n = counts.get(key) ?? 0;
     if (n > best) {
       best = n;

--- a/src/render/measure/auditLog.ts
+++ b/src/render/measure/auditLog.ts
@@ -22,6 +22,7 @@
  * and casual edits. For cryptographic tamper-evidence, inject a SHA-256 (e.g.
  * via SubtleCrypto, pre-hashing each body) — the chain logic is hash-agnostic.
  */
+import { compareCodeUnits } from '../../canonicalHash';
 
 export type HashFn = (input: string) => string;
 
@@ -44,7 +45,7 @@ export function canonicalize(value: unknown): string {
     return '[' + value.map(canonicalize).join(',') + ']';
   }
   const obj = value as Record<string, unknown>;
-  const keys = Object.keys(obj).filter((k) => obj[k] !== undefined).sort();
+  const keys = Object.keys(obj).filter((k) => obj[k] !== undefined).sort(compareCodeUnits);
   return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalize(obj[k])).join(',') + '}';
 }
 

--- a/validation/mutations/run-campaign.mjs
+++ b/validation/mutations/run-campaign.mjs
@@ -37,6 +37,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import os from 'node:os';
+import { compareCodeUnits } from '../../scripts/lib/codeUnitOrder.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '..', '..');
@@ -346,7 +347,7 @@ function runVitest(files, env) {
   return {
     exitCode: res.status,
     durationMs,
-    failures: failures.sort(),
+    failures: failures.sort(compareCodeUnits),
     ran,
     parsed,
     stderrTail: (res.stderr ?? '').split('\n').slice(-8).join('\n'),


### PR DESCRIPTION
The quality gate has been failing on `main` on every merge. This closes the reliability half of it, and two findings inside it are real defects rather than scanner noise.

**The count was three times what I first reported.** My earlier figure came from one paginated API page. Querying properly: `S2871` is **34 sites**, not 13. Cognitive complexity is **262** issues, not the 25 I said. `[` versus `[[` is 21, not 7, and 14 of those are in `package.sh` rather than the release gate.

**No site sorts numbers.** All 34 sort strings, so the scanner's "avoid sorting elements alphabetically" wording is misleading in every case here. Its suggested fix is also wrong for this repository: `localeCompare` orders by collation, which depends on the runtime locale and the ICU build, so identical keys order differently on two machines and a committed record stops reproducing. Two files already carry written instructions not to take that advice. Every site now uses an explicit code-unit comparator instead, which satisfies the rule and keeps the ordering the language spec fixes.

**Two comparators, not one, and the reason is a build boundary.** A `.ts` module cannot import a `scripts/` helper without pulling the script tree into the application build. `benchmarks/framework/` was not available either, because a source-guard test pins that directory's exact file list. The TypeScript one lives in `src/canonicalHash.ts`, which is zero-dependency, already imported by the benchmark framework, and the right home on merit: ordering is half of canonicalisation, since a digest only reproduces when its keys order identically on every host.

**A real ordering defect, and its exact reachability.** `benchmarks/runner/render.ts` sorted the output of `Object.entries()`. Default sort stringifies each pair to `name,hash`, so the hash participates in the comparison. I checked when that actually changes the result: only when a key contains a character below `,` (0x2C). `["a", "ab"]` and `["a", "a-b"]` order identically both ways, because `,` acts as a terminator and that is correct prefix ordering. `["a", "a b"]` and `["a", "a+b"]` do differ. So the defect is real but reachable only for keys containing a space or one of a few punctuation characters. Fixed by comparing the name alone, which is right regardless.

**A real security bug.** `scripts/make-big-surface.py` defaulted to writing `/tmp/big-surface.las`, a fixed predictable name in a world-writable directory, then opened it for writing. On a shared machine another user can pre-create that path as a symlink and the script writes through it. The default is removed; a missing path now prints usage and exits 2. There are no callers anywhere in the repository, docs or workflows, so nothing needed updating.

**The other `S5443` is left alone deliberately.** `scripts/defect-replay-lib.mjs` is flagged for the same rule, but that line is a denylist of path *strings* passed to `includes()` to detect leaked paths. No filesystem access. It needs a won't-fix in the Sonar UI, not a code change.

**262 complexity findings are deliberately untouched.** Blind refactoring of verification scripts is how a verifier stops verifying. The branch carries a ranked triage instead, recommending three for later, all sharing the property that makes a split safe: flat accumulation of independent rules into a `problems` array through an injected reader, no shared mutable state, no ordering dependence. Everything else encodes precedence that a split would scatter.

`gate.sh` is untouched for the same reason: 7 stylistic findings with no behavioural claim, in the release gate.

Verified in the branch, each run and observed: full suite **6,838 passed / 24 skipped across 550 files**, `tsc` 0, archive-portability 0, validation snapshot 0 with 8 of 8 controls refused, defect replay 0, and the Python generator produces a valid 72 KB LAS with a path and exits 2 without one. `lint:no-host-paths` reports a missing script here because it arrives with a different branch; a direct search confirms no tracked file names this machine.