### PR TITLE
Close three bypasses in the shipped-page guards

### DIFF
--- a/scripts/lib/htmlComments.mjs
+++ b/scripts/lib/htmlComments.mjs
@@ -19,7 +19,60 @@
  *
  * An unterminated comment runs to the end of input, matching how a browser
  * treats it: everything after it is comment, not markup.
+ *
+ * `-->` is not the only terminator. The HTML tokenizer also closes a comment on
+ * `--!>`, and treats `<!-->` and `<!--->` as complete empty comments. Searching
+ * for `-->` alone finds no terminator in those three cases and marks the rest of
+ * the document as comment, which hides every later <script> and every later
+ * href from the checks built on this file. The end of a comment is therefore
+ * found by walking the tokenizer's comment states below.
  */
+
+/**
+ * Exclusive end offset of the comment whose `<!--` ends at `after`.
+ *
+ * State names follow the HTML Standard's comment states so the transitions can
+ * be read against the spec.
+ */
+function commentEnd(html, after) {
+  let state = 'start';
+  for (let i = after; i < html.length; i++) {
+    const ch = html[i];
+    switch (state) {
+      case 'start': // comment start: `>` here closes an empty comment
+        if (ch === '-') state = 'startDash';
+        else if (ch === '>') return i + 1;
+        else state = 'body';
+        break;
+      case 'startDash': // comment start dash: `>` here also closes
+        if (ch === '-') state = 'end';
+        else if (ch === '>') return i + 1;
+        else state = 'body';
+        break;
+      case 'body':
+        if (ch === '-') state = 'endDash';
+        break;
+      case 'endDash':
+        state = ch === '-' ? 'end' : 'body';
+        break;
+      case 'end':
+        if (ch === '>') return i + 1;
+        else if (ch === '!') state = 'endBang';
+        else if (ch === '-') state = 'end';
+        else state = 'body';
+        break;
+      case 'endBang': // reached on `--!`
+        if (ch === '>') return i + 1;
+        else if (ch === '-') state = 'endDash';
+        else state = 'body';
+        break;
+      /* c8 ignore next 2 */
+      default:
+        state = 'body';
+    }
+  }
+  return html.length;
+}
 
 /** Half-open [start, end) spans covering every comment in `html`. */
 export function commentRanges(html) {
@@ -28,13 +81,10 @@ export function commentRanges(html) {
   for (;;) {
     const open = html.indexOf('<!--', from);
     if (open === -1) break;
-    const close = html.indexOf('-->', open + 4);
-    if (close === -1) {
-      ranges.push([open, html.length]);
-      break;
-    }
-    ranges.push([open, close + 3]);
-    from = close + 3;
+    const end = commentEnd(html, open + 4);
+    ranges.push([open, end]);
+    if (end >= html.length) break;
+    from = end;
   }
   return ranges;
 }

--- a/scripts/lint-csp-html.mjs
+++ b/scripts/lint-csp-html.mjs
@@ -92,11 +92,32 @@ function inlineScriptCount(html) {
   ).length;
 }
 
+/**
+ * Inline event handler attributes, by shape rather than by name.
+ *
+ * A fixed list of handler names passes anything left off it: onmousedown,
+ * onpointerdown, ontoggle and onpaste all reached this file's OK line while the
+ * policy refused them in the browser, which is the failure described at the top.
+ * So the match is any attribute whose name is `on` followed by letters.
+ *
+ * The tag-open anchor is `<` plus a name character, and `[^>]*?` cannot cross a
+ * `>`, so text between tags is never matched.
+ */
 function inlineHandlerCount(html) {
-  // Attributes only: `\son...=` inside a tag. Prose containing "on" is not a match.
+  return matchesOutsideComments(html, /<[a-z][^>]*?\son[a-z]+\s*=/gi).length;
+}
+
+/**
+ * `javascript:` URLs in src or href.
+ *
+ * script-src governs these as well, so they fail the same silent way as an
+ * inline handler: the link is there, the click does nothing. Every quoting form
+ * counts, including none.
+ */
+function javascriptUrlCount(html) {
   return matchesOutsideComments(
     html,
-    /<[^>]*?\son(?:click|load|error|change|input|submit|focus|blur)\s*=/gi,
+    /\b(?:src|href)\s*=\s*(?:"\s*javascript:|'\s*javascript:|javascript:)/gi,
   ).length;
 }
 
@@ -167,6 +188,13 @@ for (const file of shippedHtml()) {
       problems.push(
         `${file}: ${handlers} inline event handler attribute(s), which script-src refuses. ` +
           'Attach the listener from the external script instead.',
+      );
+    }
+    const jsUrls = javascriptUrlCount(html);
+    if (jsUrls > 0) {
+      problems.push(
+        `${file}: ${jsUrls} javascript: URL(s) in src or href, which script-src refuses. ` +
+          'Use a real URL and handle the click from the external script.',
       );
     }
   }

--- a/scripts/lint-html-assets.mjs
+++ b/scripts/lint-html-assets.mjs
@@ -80,8 +80,15 @@ function references(html) {
   //
   // Commented-out references are skipped by offset rather than by deleting the
   // comments, for the reasons in scripts/lib/htmlComments.mjs.
-  for (const m of matchesOutsideComments(html, /\b(?:src|href)\s*=\s*"([^"]*)"/gi)) {
-    found.add(m[1]);
+  //
+  // All three attribute-value forms, because HTML accepts all three and a check
+  // that reads only double quotes passes href='typo.pdf' unread. The unquoted
+  // form stops at whitespace and at the characters HTML forbids in it.
+  for (const m of matchesOutsideComments(
+    html,
+    /\b(?:src|href)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/gi,
+  )) {
+    found.add(m[1] ?? m[2] ?? m[3]);
   }
   return [...found];
 }

--- a/tests/htmlComments.test.ts
+++ b/tests/htmlComments.test.ts
@@ -1,0 +1,96 @@
+/**
+ * tests/htmlComments.test.ts
+ *
+ * commentRanges() decides which markup the CSP and asset lints are allowed to
+ * ignore, so anything it calls a comment is invisible to both. When it treated
+ * `-->` as the only terminator, `<!-->`, `<!--->` and `--!>` each left it with
+ * no terminator to find, and it marked the rest of the document as comment:
+ * `<!--><script>init()</script>` appended to a shipped page passed
+ * lint:csp-html while the deployed page carried an inline script that
+ * script-src refuses.
+ *
+ * These cases pin the tokenizer's four comment terminators, the end-of-input
+ * behaviour a browser also has, and the fact that quoting does not protect a
+ * `-->` inside comment text.
+ */
+
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error -- plain .mjs helper shared with the lint scripts, no types
+import { commentRanges, insideComment, matchesOutsideComments } from '../scripts/lib/htmlComments.mjs';
+
+type Range = [number, number];
+
+/** What the CSP lint counts: inline <script> tags the helper does not hide. */
+function visibleScripts(html: string): number {
+  return (matchesOutsideComments(html, /<script\b[^>]*>/gi) as unknown[]).length;
+}
+
+describe('commentRanges', () => {
+  it('treats <!--> as a complete empty comment', () => {
+    const html = '<!--><script>x</script>';
+    expect(commentRanges(html) as Range[]).toEqual([[0, 5]]);
+    expect(visibleScripts(html)).toBe(1);
+  });
+
+  it('treats <!---> as a complete empty comment', () => {
+    const html = '<!---><script>x</script>';
+    expect(commentRanges(html) as Range[]).toEqual([[0, 6]]);
+    expect(visibleScripts(html)).toBe(1);
+  });
+
+  it('closes a comment on --!>', () => {
+    const html = '<!-- n --!><script>x</script>';
+    expect(commentRanges(html) as Range[]).toEqual([[0, 11]]);
+    expect(visibleScripts(html)).toBe(1);
+  });
+
+  it('closes a comment on -->', () => {
+    const html = '<!-- n --><script>x</script>';
+    expect(commentRanges(html) as Range[]).toEqual([[0, 10]]);
+    expect(visibleScripts(html)).toBe(1);
+  });
+
+  it('does not nest: an inner <!-- is comment text, and the first --> ends both', () => {
+    const html = '<!-- <!-- --><script>x</script>';
+    expect(commentRanges(html) as Range[]).toEqual([[0, 13]]);
+    expect(visibleScripts(html)).toBe(1);
+  });
+
+  it('runs an unterminated comment to the end of input, as a browser does', () => {
+    const html = '<p>a</p><!-- never closed <script>x</script>';
+    expect(commentRanges(html) as Range[]).toEqual([[8, html.length]]);
+    expect(visibleScripts(html)).toBe(0);
+  });
+
+  it('ends at a --> inside quoted comment text, because the tokenizer ignores quotes', () => {
+    const html = '<!-- a "-->" b --><script>x</script>';
+    // The comment stops at the first -->, so `" b -->` is markup and the
+    // <script> that follows is visible.
+    expect(commentRanges(html) as Range[]).toEqual([[0, 11]]);
+    expect(visibleScripts(html)).toBe(1);
+  });
+
+  it('finds every comment in a document with several', () => {
+    const html = '<a><!--one--><b><!--two--><c><!--three-->';
+    expect(commentRanges(html) as Range[]).toEqual([
+      [3, 13],
+      [16, 26],
+      [29, 41],
+    ]);
+  });
+
+  it('returns nothing for a document with no comments', () => {
+    const html = '<p>plain markup, 4 > 3, a--b</p>';
+    expect(commentRanges(html) as Range[]).toEqual([]);
+    expect(insideComment([], 0)).toBe(false);
+  });
+});
+
+describe('insideComment', () => {
+  it('treats a span as half-open: the opening offset is in, the closing one is out', () => {
+    const ranges = commentRanges('<!-- x -->y') as Range[];
+    expect(insideComment(ranges, 0)).toBe(true);
+    expect(insideComment(ranges, 9)).toBe(true);
+    expect(insideComment(ranges, 10)).toBe(false);
+  });
+});


### PR DESCRIPTION
Three guards that exist to stop a page shipping broken could each be walked around. All three bypasses were reproduced before the fix and re-run after.

**The comment scanner missed three of the tokenizer's comment closers.** It treated `-->` as the only terminator, but the HTML tokenizer also closes on `--!>` and treats `<!-->` and `<!--->` as complete empty comments. In all three the helper found no `-->` and marked the rest of the document as comment, so markup after it was invisible. Appending `<!--><script>init()</script>` to a shipped page passed `lint:csp-html` at exit 0 while the page carried an inline script the policy refuses, which is the exact silent failure the lint was written to catch. Now a small state machine over the standard's comment states. Before 0, after 1.

**The CSP lint whitelisted eight event-handler names.** `onmousedown`, `onkeydown`, `onpointerdown`, `ontoggle`, `onwheel`, `onpaste` and `ondrop` all passed, so such a button shipped and did nothing. Replaced with a general inline-handler match anchored on a tag open so prose cannot match, plus `javascript:` URLs in `src` and `href`, which were not checked at all. Before 0, after 1 on both.

**The asset lint matched double-quoted attributes only.** A single-quoted or unquoted `href` yielded no matches and printed OK while the tester got a 404. Before 0, after 1 on both forms.

`htmlComments.mjs` had no test at all. It has ten now, asserting offsets rather than counts on nine of them, including nested-looking comments, an unterminated comment, and `-->` inside quoted text. Against the pre-fix helper the suite fails 3 of 10.

Verified: tsc 0, the new suite 0, both lints 0, archive-portability 0, full suite 6,848 passed / 24 skipped across 548 files, bucket partition 0. No shipped page regressed and `package.json` is untouched.