### PR TITLE
Clear the reliability findings on main

### DIFF
--- a/scripts/build-cross-implementation-summary.mjs
+++ b/scripts/build-cross-implementation-summary.mjs
@@ -35,6 +35,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 
 import {
+  byCodeUnit,
   verifyStudies,
   UNCOUNTED_STATUSES,
   RESULT_STATUSES,
@@ -111,7 +112,7 @@ export function summarise(studies) {
     evidenceEffect:
       'None. This file counts study outcomes. Evidence levels live in docs/validation/claim-register.yaml and move only by a human change to that file.',
     permittedStatuses: [...STUDY_STATUSES],
-    uncountedStatuses: [...UNCOUNTED_STATUSES].sort(),
+    uncountedStatuses: [...UNCOUNTED_STATUSES].sort(byCodeUnit),
     studiesRead: studies.length,
     countedStudies: counted.length,
     byStatus: sorted(byStatus),

--- a/scripts/test-bucket.mjs
+++ b/scripts/test-bucket.mjs
@@ -39,7 +39,7 @@ const TESTS_DIR = resolve(ROOT, 'tests');
 // get starved (and time out) under the parallel `unit` bucket, so they belong
 // here where the runner caps parallelism and raises the timeout.
 const SLOW =
-  /^(torture|benchmark|parse|loadLas|loadLaz|laszip)|integration|streaming|copc|ept|laz|octree|voxelDownsample|convertRoundTrip|convertBatch|moduleApi|preload|wasm|decode|packaging/i;
+  /^(?:torture|benchmark|parse|loadLas|loadLaz|laszip)|(?:integration|streaming|copc|ept|laz|octree|voxelDownsample|convertRoundTrip|convertBatch|moduleApi|preload|wasm|decode|packaging)/i;
 // The terrain-analysis pipeline.
 const TERRAIN = /^(analyse|analysis|contour|cell|ground|dem|hillshade|slope|calibrat|confidence|coverage|crs|datum|evidence|interval|civilProfile|profile|surface|quality|terrain|raster|gpuDeriv|scatter|aspect|canopy|dsm|dtm|seam|provenance|metricVersion|score|assessment|readiness|whyNot|recommend)/i;
 // The interface layer.

--- a/scripts/test-bucket.mjs
+++ b/scripts/test-bucket.mjs
@@ -38,8 +38,14 @@ const TESTS_DIR = resolve(ROOT, 'tests');
 // and buffer/worker decode tests spin up a WASM decoder and are the ones that
 // get starved (and time out) under the parallel `unit` bucket, so they belong
 // here where the runner caps parallelism and raises the timeout.
-const SLOW =
-  /^(?:torture|benchmark|parse|loadLas|loadLaz|laszip)|(?:integration|streaming|copc|ept|laz|octree|voxelDownsample|convertRoundTrip|convertBatch|moduleApi|preload|wasm|decode|packaging)/i;
+// Two rules, not one pattern. The first list matches a file name's opening
+// word, the second matches anywhere in it. Written as a single regex the `^`
+// bound to the first alternative only, which reads as a mistake whether or not
+// it is one, and both scanners flag it as one.
+const SLOW_PREFIX = /^(?:torture|benchmark|parse|loadLas|loadLaz|laszip)/i;
+const SLOW_ANYWHERE =
+  /integration|streaming|copc|ept|laz|octree|voxelDownsample|convertRoundTrip|convertBatch|moduleApi|preload|wasm|decode|packaging/i;
+const isSlow = (name) => SLOW_PREFIX.test(name) || SLOW_ANYWHERE.test(name);
 // The terrain-analysis pipeline.
 const TERRAIN = /^(analyse|analysis|contour|cell|ground|dem|hillshade|slope|calibrat|confidence|coverage|crs|datum|evidence|interval|civilProfile|profile|surface|quality|terrain|raster|gpuDeriv|scatter|aspect|canopy|dsm|dtm|seam|provenance|metricVersion|score|assessment|readiness|whyNot|recommend)/i;
 // The interface layer.
@@ -57,7 +63,7 @@ function bucketOf(name) {
     const routed = NESTED_TEST_DIRS[name.slice(0, slash)];
     if (routed) return routed;
   }
-  if (SLOW.test(name)) return 'slow';
+  if (isSlow(name)) return 'slow';
   if (TERRAIN.test(name)) return 'terrain';
   if (UI.test(name)) return 'ui';
   if (EXPORT.test(name)) return 'export';
@@ -73,7 +79,7 @@ const BUCKETS = ['unit', 'export', 'terrain', 'ui', 'slow'];
 //     to no bucket at all, so the release gate would run every bucket green
 //     while never executing it;
 //   - without the explicit bucket, `tests/benchmark/*` matched `slow` only
-//     because the SLOW regex starts with `^benchmark` (written for the old
+//     because SLOW_PREFIX starts with `benchmark` (written for the old
 //     top-level benchmark.test.ts). Those files run in ~50 ms and belong in
 //     `unit`; routing them by accident would also change silently the next time
 //     a bucket regex is edited.

--- a/scripts/verify-cross-implementation-study.mjs
+++ b/scripts/verify-cross-implementation-study.mjs
@@ -117,12 +117,27 @@ const FLOATING_TAG = /(^|:)latest$|(^|\s)latest(\s|$)/i;
 
 // ── canonical form + digests ────────────────────────────────────────────────
 
+/**
+ * UTF-16 code-unit order, written out rather than left to the default.
+ *
+ * Digests here depend on sort order, so the order has to be fixed by the
+ * specification and not by the machine that ran the script. That rules out
+ * `localeCompare`, whose result moves with the locale and the ICU build. A
+ * bare `.sort()` already does the right thing, but nothing on the page says
+ * so, and "the default happens to be what we need" is the kind of claim that
+ * gets refactored away.
+ */
+export function byCodeUnit(a, b) {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
 /** Key-sorted JSON, so a digest depends on values and not on key order. */
 export function canonicalJson(value) {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
   if (value !== null && typeof value === 'object') {
     const body = Object.keys(value)
-      .sort()
+      .sort(byCodeUnit)
       .map((k) => `${JSON.stringify(k)}:${canonicalJson(value[k])}`)
       .join(',');
     return `{${body}}`;
@@ -160,7 +175,7 @@ export function protocolDigestOf(manifest) {
  */
 export function derivedInputsDigest(derivedFrom, rawByPath) {
   const pairs = [...derivedFrom]
-    .sort()
+    .sort(byCodeUnit)
     .map((path) => ({ path, sha256: rawByPath.get(path) ?? null }));
   return `sha256:${sha256(canonicalJson(pairs))}`;
 }
@@ -618,7 +633,7 @@ if (isMain()) {
 
   const byStatus = new Map();
   for (const s of out.studies) byStatus.set(s.manifest.status, (byStatus.get(s.manifest.status) ?? 0) + 1);
-  const tally = [...byStatus.entries()].sort().map(([k, v]) => `${k} ${v}`).join(', ') || 'none';
+  const tally = [...byStatus.entries()].sort((a, b) => byCodeUnit(a[0], b[0])).map(([k, v]) => `${k} ${v}`).join(', ') || 'none';
   console.log(
     `verify:cross-implementation-study OK — ${out.studies.length} manifest(s) in ${out.studiesDir} ` +
       `(${tally}); dataset register ${out.datasetRegisterPath} ` +

--- a/src/geo/georefStatus.ts
+++ b/src/geo/georefStatus.ts
@@ -129,7 +129,7 @@ export function georefGlyphSvg(crsKnown: boolean, datumKnown: boolean): string {
   if (crsKnown) {
     // Planted pin (teardrop) — positioned on the map.
     parts.push(
-      `<path d="M12 ${markerY - 4} a4 4 0 0 1 4 4 c0 3 -4 ${datumKnown ? '5' : '5'} -4 ${datumKnown ? '5' : '5'} ` +
+      `<path d="M12 ${markerY - 4} a4 4 0 0 1 4 4 c0 3 -4 5 -4 5 ` +
         `c0 0 -4 -2 -4 -5 a4 4 0 0 1 4 -4 z" stroke="currentColor" stroke-width="1.4" fill="none"/>`,
       `<circle cx="12" cy="${markerY}" r="1.4" fill="currentColor"/>`,
     );

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -977,12 +977,12 @@ export class Viewer {
    */
   private _edlPaintedAtRest = false;
   /** EDL strength, and the camera near/far, as live uniforms. */
-  private readonly _edlStrength = uniform(EDL_DEFAULTS.strength);
+  private readonly _edlLiveStrength = uniform(EDL_DEFAULTS.strength);
   private readonly _edlNear = uniform(0.1);
   private readonly _edlFar = uniform(5_000_000);
   /**
    * The user-facing base EDL strength — what the slider directly controls.
-   * The live `_edlStrength` uniform is `base × adaptive_factor` each frame
+   * The live `_edlLiveStrength` uniform is `base × adaptive_factor` each frame
    * (see `_updateAdaptiveEdl`), so a user who sets a strong base still
    * gets a stronger close-inspection effect than a user with a weak base.
    */
@@ -1270,7 +1270,7 @@ export class Viewer {
     this._post = new THREE.RenderPipeline(this._renderer);
     this._post.outputNode = buildEdlOutputNode(
       this._scenePass,
-      this._edlStrength,
+      this._edlLiveStrength,
       this._edlNear,
       this._edlFar,
       EDL_DEFAULTS.radiusPx,
@@ -3526,10 +3526,10 @@ export class Viewer {
   setEdlStrength(strength: number): void {
     this._edlBaseStrength = Math.max(0, strength);
     // Immediate apply for the frame — adaptive update will refine next tick.
-    this._edlStrength.value = this._edlBaseStrength;
+    this._edlLiveStrength.value = this._edlBaseStrength;
   }
 
-  /** The base the user set, NOT live `_edlStrength` — edlStrengthPersistence.test.ts. */
+  /** The base the user set, NOT live `_edlLiveStrength` — edlStrengthPersistence.test.ts. */
   get edlStrength(): number {
     return this._edlBaseStrength;
   }
@@ -5769,7 +5769,7 @@ export class Viewer {
 
     // Final strength — base × distance × density. Normalise the distance
     // factor by 0.7 so the slider's "1.0" base lands at neutral close-up.
-    this._edlStrength.value =
+    this._edlLiveStrength.value =
       this._edlBaseStrength * (distanceFactor / 0.7) * densityFactor;
   }
 

--- a/src/ui/FullscreenToggle.ts
+++ b/src/ui/FullscreenToggle.ts
@@ -177,19 +177,17 @@ export class FullscreenToggle {
     const d = document as FsDoc;
     if (this._isFullscreen()) {
       const exit = document.exitFullscreen ?? d.webkitExitFullscreen;
-      const p = exit?.call(document);
-      if (p && typeof (p as Promise<void>).catch === 'function') {
-        (p as Promise<void>).catch(() => this._announce('Could not leave full screen.'));
+      const p = exit?.call(document) as Promise<void> | undefined;
+      if (typeof p?.catch === 'function') {
+        p.catch(() => this._announce('Could not leave full screen.'));
       }
       return;
     }
     const root = document.documentElement as FsEl;
     const request = root.requestFullscreen ?? root.webkitRequestFullscreen;
-    const p = request?.call(root);
-    if (p && typeof (p as Promise<void>).catch === 'function') {
-      (p as Promise<void>).catch(() =>
-        this._announce('The browser refused full screen for this page.'),
-      );
+    const p = request?.call(root) as Promise<void> | undefined;
+    if (typeof p?.catch === 'function') {
+      p.catch(() => this._announce('The browser refused full screen for this page.'));
     }
   }
 

--- a/tests/edlStrengthPersistence.test.ts
+++ b/tests/edlStrengthPersistence.test.ts
@@ -1,10 +1,10 @@
 /**
- * `Viewer.edlStrength` returns `_edlBaseStrength`, not `_edlStrength`. Static
+ * `Viewer.edlStrength` returns `_edlBaseStrength`, not `_edlLiveStrength`. Static
  * analysis reports that as a getter failing to refer to its matching field and
  * suggests "fixing" it. Doing so would introduce a real bug, which is why this
  * is a test rather than only a comment.
  *
- * The two fields hold different things. `_edlStrength` is the live uniform,
+ * The two fields hold different things. `_edlLiveStrength` is the live uniform,
  * recomputed each frame as the base times an adaptive factor that depends on
  * camera distance. `_edlBaseStrength` is what the user set.
  *


### PR DESCRIPTION
The quality gate on main is red on reliability. These are the findings behind it.

- `georefStatus`: a ternary with the same string in both branches.
- `FullscreenToggle`: two Promise values used directly as conditions.
- `Viewer`: the `edlStrength` getter read as a broken accessor because a private field shared its name. The live uniform is now `_edlLiveStrength`.
- `test-bucket`: the `^` in the SLOW pattern bound to one alternative only. The grouping now says so.
- Cross-implementation scripts: four sorts relied on the default comparator. That is the order these digests need, so it is now written down.

No behaviour changes. Study digests, the bucket partition (565/565) and the unit, ui and terrain buckets are identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)