### PR TITLE
Move the testing call into Contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,51 +40,6 @@ No install, no account, no upload. Open **[lidar.aurtech.mx](https://lidar.aurte
 
 ---
 
-## Help test OpenLiDARViewer
-
-OpenLiDARViewer improves through feedback from people who work with point
-clouds day to day: GIS, drone mapping, terrain analysis, hydrology, surveying,
-web mapping.
-
-Open a workflow you already know, on the live demo or a local build. Use one of
-your own authorised files, compare the values you care about against ArcGIS,
-QGIS, CloudCompare, PDAL or whatever you normally trust, and say what worked,
-what failed, and what was unclear.
-
-The quick report takes five to ten minutes. A longer GIS comparison is there if
-you want to check metadata, CRS, units, elevations, measurements or terrain
-products against a reference tool, and it is optional.
-
-Participation is voluntary and unpaid. Please do not submit confidential,
-restricted or personal information, and do not send source datasets you are not
-free to redistribute. Public credit and research use are each a separate
-optional permission.
-
-A failed file, an unexpected warning or one confusing screenshot is worth
-sending. Negative results are the useful kind here.
-
-There are two forms, and which one fits depends on what you scan.
-
-[Terrestrial LiDAR evaluation](https://lidar.aurtech.mx/testing.html) takes five
-to ten minutes. Use it for tripod and mobile scanners, indoor and building
-capture, and any work where scan stations, occlusion and coverage matter more
-than a coordinate reference system.
-
-[GIS comparison](https://lidar.aurtech.mx/terrain-test.html) is longer. Use it
-when you can put a number beside a number: metadata, CRS and units, elevations,
-terrain products, and how the browser workflow compares with ArcGIS, QGIS,
-CloudCompare or PDAL. It asks for the values you read in both tools, so have the
-reference open.
-
-Either one is worth sending on its own. Neither needs the other.
-
-[Submit a test report](https://lidar.aurtech.mx/test-report.html) is the general
-form, for anything the two above do not cover. It runs in your browser and
-builds one self-contained report file, screenshots included, which you read
-before anything is sent. Send it to the project server, or download it and email
-it yourself. Reports are kept privately for development and are not published or
-passed to any third party.
-
 ## Overview
 
 OpenLiDARViewer opens LiDAR and point-cloud datasets straight in the browser. You can inspect a scan, navigate it in 3D, switch how it is colored, measure distances, and export results, without setting up a desktop GIS workflow.
@@ -539,6 +494,51 @@ No. WebGPU is the primary path and it falls back to WebGL 2 automatically.
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](.github/CONTRIBUTING.md), the [security policy](.github/SECURITY.md), and the [code of conduct](.github/CODE_OF_CONDUCT.md). The codebase is small, test-first (Vitest and Playwright), written in strict TypeScript, and deliberately modular.
+
+## Help test OpenLiDARViewer
+
+OpenLiDARViewer improves through feedback from people who work with point
+clouds day to day: GIS, drone mapping, terrain analysis, hydrology, surveying,
+web mapping.
+
+Open a workflow you already know, on the live demo or a local build. Use one of
+your own authorised files, compare the values you care about against ArcGIS,
+QGIS, CloudCompare, PDAL or whatever you normally trust, and say what worked,
+what failed, and what was unclear.
+
+The quick report takes five to ten minutes. A longer GIS comparison is there if
+you want to check metadata, CRS, units, elevations, measurements or terrain
+products against a reference tool, and it is optional.
+
+Participation is voluntary and unpaid. Please do not submit confidential,
+restricted or personal information, and do not send source datasets you are not
+free to redistribute. Public credit and research use are each a separate
+optional permission.
+
+A failed file, an unexpected warning or one confusing screenshot is worth
+sending. Negative results are the useful kind here.
+
+There are two forms, and which one fits depends on what you scan.
+
+[Terrestrial LiDAR evaluation](https://lidar.aurtech.mx/testing.html) takes five
+to ten minutes. Use it for tripod and mobile scanners, indoor and building
+capture, and any work where scan stations, occlusion and coverage matter more
+than a coordinate reference system.
+
+[GIS comparison](https://lidar.aurtech.mx/terrain-test.html) is longer. Use it
+when you can put a number beside a number: metadata, CRS and units, elevations,
+terrain products, and how the browser workflow compares with ArcGIS, QGIS,
+CloudCompare or PDAL. It asks for the values you read in both tools, so have the
+reference open.
+
+Either one is worth sending on its own. Neither needs the other.
+
+[Submit a test report](https://lidar.aurtech.mx/test-report.html) is the general
+form, for anything the two above do not cover. It runs in your browser and
+builds one self-contained report file, screenshots included, which you read
+before anything is sent. Send it to the project server, or download it and email
+it yourself. Reports are kept privately for development and are not published or
+passed to any third party.
 
 ## Acknowledgements
 


### PR DESCRIPTION
The testing request sat above Overview, so the first thing a reader met was a request for their time rather than what the project does. It now opens the Contributing section.

Pure move. Sorting both versions gives identical files, so no line was edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)