### PR TITLE
Record mutation score 96.81 from run 30532907233

### DIFF
--- a/docs/validation/mutation-evidence.json
+++ b/docs/validation/mutation-evidence.json
@@ -4,8 +4,8 @@
   "score": 96.81,
   "break": 75,
   "mutants": {
-    "killed": 129,
-    "timeout": 53,
+    "killed": 136,
+    "timeout": 46,
     "survived": 5,
     "noCoverage": 1,
     "ignored": 0,
@@ -19,12 +19,12 @@
     "src/terrain/quantile.ts",
     "src/terrain/ground/terrainDerivatives.ts"
   ],
-  "commit": "7f72fa16c72152d2f65f5c9ebb795355fbd42327",
-  "measuredAt": "2026-07-29T03:54:56.232Z",
+  "commit": "b6ec0f16964d2afd1d8c37a2d13087cf51cfeea8",
+  "measuredAt": "2026-07-30T12:08:09.159Z",
   "ranInThisGate": false,
   "workflow": "Mutation",
-  "workflowRunId": "30414720675",
-  "workflowRunUrl": "https://github.com/Aurtechmx/openlidarviewer/actions/runs/30414720675",
+  "workflowRunId": "30532907233",
+  "workflowRunUrl": "https://github.com/Aurtechmx/openlidarviewer/actions/runs/30532907233",
   "nodeVersion": "v22.17.1",
   "platform": "linux-x64"
 }


### PR DESCRIPTION
Run [30532907233](https://github.com/Aurtechmx/openlidarviewer/actions/runs/30532907233) measured `b6ec0f1` at 96.81 against a break threshold of 75, then failed on the push step because a ruleset requires pull requests on this branch. The measurement survived only in the run artifact.

This file is that artifact, byte for byte. Nothing was edited, and the record names the commit it was measured at.

182 detected of 188 scored, over `numerics.ts`, `quantile.ts` and `terrainDerivatives.ts`.

The workflow fix is in #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)