### PR TITLE
Make the orbit smoke marker a todo instead of an empty skipped test

### DIFF
--- a/tests/orbitSmoke.test.ts
+++ b/tests/orbitSmoke.test.ts
@@ -130,8 +130,9 @@ describeOrSkip('orbit navigation — production build smoke', () => {
 
 if (!shouldRun) {
   describe('orbit navigation — production build smoke', () => {
-    it.skip('dist/ not present — run `npm run build` first', () => {
-      // Marker for the test reporter; intentional skip in dev.
-    });
+    // A marker for the reporter, not a test: there is nothing to assert until
+    // a build exists. `todo` takes no body, which says that better than a
+    // skipped test with an empty one, and the tally counts both the same way.
+    it.todo('dist/ not present — run `npm run build` first');
   });
 }


### PR DESCRIPTION
The only assertion-free test in the repository, and it was never a test. The body was empty because there is nothing to assert until a build exists; the entry exists so the reporter says why the production-build suite did not run.

Adding an assertion to a body that never executes would satisfy the rule and mean nothing. `it.todo` takes no body, which states the intent directly.

The reporter still shows the line. The gate tally sums pending and todo, so the skipped count is unchanged: 24 across the unit shards before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)