### PR TITLE
Reject a budget that is not a usable number, at the argument

### DIFF
--- a/src/process/voxelDownsample.ts
+++ b/src/process/voxelDownsample.ts
@@ -222,6 +222,15 @@ export function voxelSizeForBudget(cloud: PointCloud, maxPoints: number): number
  * can detect "was it downsampled?" with a simple identity check.
  */
 export function downsampleToBudget(cloud: PointCloud, maxPoints: number): PointCloud {
+  // A budget that is not a positive number already fails, but it fails two
+  // calls down in `voxelDownsample` complaining about a voxel size the caller
+  // never chose. NaN is the one that matters: `pointCount <= NaN` is false, so
+  // a budget computed from a missing field walks past the early return and the
+  // error arrives from the wrong place. Rejecting it here names the argument
+  // that was actually wrong.
+  if (!Number.isFinite(maxPoints) || maxPoints < 1) {
+    throw new Error(`downsampleToBudget: maxPoints must be a finite number >= 1 (got ${maxPoints})`);
+  }
   if (cloud.pointCount <= maxPoints) return cloud;
 
   const MAX_PASSES = 12;

--- a/tests/voxelDownsample.test.ts
+++ b/tests/voxelDownsample.test.ts
@@ -186,3 +186,20 @@ test('a cloud with no inspection extras yields none after downsampling', () => {
   expect(out.pointSourceId).toBeUndefined();
   expect(out.gpsTime).toBeUndefined();
 });
+
+// A budget of NaN used to walk past the early return, because `pointCount <=
+// NaN` is false, and surface two calls later as a complaint about a voxel size
+// the caller never chose. These pin the refusal at the argument that was wrong.
+test('downsampleToBudget refuses a budget that is not a usable number', () => {
+  const cloud = makeCloud([0, 0, 0, 1, 1, 1, 2, 2, 2]);
+  for (const bad of [Number.NaN, 0, -5, Number.POSITIVE_INFINITY]) {
+    expect(() => downsampleToBudget(cloud, bad)).toThrow(/maxPoints/);
+  }
+});
+
+test('downsampleToBudget names the argument the caller passed', () => {
+  const cloud = makeCloud([0, 0, 0, 1, 1, 1, 2, 2, 2]);
+  // Not "voxelSize": the caller chose a budget, not a voxel.
+  expect(() => downsampleToBudget(cloud, Number.NaN)).toThrow(/got NaN/);
+  expect(() => downsampleToBudget(cloud, Number.NaN)).not.toThrow(/voxelSize/);
+});


### PR DESCRIPTION
A NaN budget walked past the early return, because `pointCount <= NaN` is false. It did not corrupt anything: `voxelDownsample` refuses a NaN voxel size. But the error named `voxelSize`, which the caller never chose, so it pointed at the wrong place.

The refusal now happens at `maxPoints`, with the value in the message.

Callers pass `GPU_HARD_POINT_CEILING` or `plan.budget`, both finite, and there is no Infinity sentinel in that path, so nothing relied on the old behaviour.

16 tests in the file, unit and slow buckets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)