### PR TITLE
Trim before the minLength check in the shared record validator

### DIFF
--- a/scripts/lib/recordSchema.mjs
+++ b/scripts/lib/recordSchema.mjs
@@ -86,7 +86,15 @@ export function validateAgainstSchema(value, schema, root, path, errors) {
   }
 
   if (typeof value === 'string') {
-    if (node.minLength !== undefined && value.length < node.minLength) {
+    // Trim before the length check. A minLength:1 field exists to require a
+    // substantive value, and `"   "` has length 3 but says nothing — it passed
+    // every register's minLength:1 guards, so a generalisation record could
+    // name a whitespace-only `boundary.doesNotExtendTo` and satisfy the schema's
+    // own "a reach with no boundary reads as universal" invariant on a
+    // technicality. Empty string and empty array were already rejected; only
+    // deliberately-typed whitespace slipped. Shared by every record register
+    // (field, reproduction, impact, generalization), so this hardens all four.
+    if (node.minLength !== undefined && value.trim().length < node.minLength) {
       errors.push(`${path}: shorter than minLength ${node.minLength}`);
     }
     if (node.pattern !== undefined && !new RegExp(node.pattern).test(value)) {


### PR DESCRIPTION
Fast-follow from the v0.6.3 adversarial quality review. Low severity, internal validation tooling, not a runtime path.

A whitespace-only string satisfies `minLength: 1` because the shared validator checks `value.length`, not the trimmed length. `"   "` has length 3. So a generalisation record could name a `boundary.doesNotExtendTo` of `["   "]` and pass the schema's own named invariant — that a reach with no boundary reads as universal — on a technicality. Empty string and empty array were already rejected; only deliberately-typed whitespace slipped.

The check is in `scripts/lib/recordSchema.mjs`, shared by four registers, so the one-line trim hardens field, reproduction, impact and generalization at once.

Verified safe before pushing: all four verifiers still pass against their committed records, so no committed record relied on the old behaviour. Red-green: a whitespace-only value now fails with `shorter than minLength 1`; a real one-character value passes. tsc clean, 104 register tests green.