### PR TITLE
Fix classifier-worker crash recovery and worker-client job leaks (audit F1/F2)

### DIFF
--- a/src/render/class/deriveClassificationWorkerClient.ts
+++ b/src/render/class/deriveClassificationWorkerClient.ts
@@ -70,6 +70,11 @@ export class DeriveClassificationWorkerClient implements DeriveClassificationCli
   private _nextJobId = 0;
   private _disposed = false;
 
+  /** In-flight job count. Diagnostic — asserted by the settlement tests. */
+  get pendingCount(): number {
+    return this._pending.size;
+  }
+
   classify(
     positions: Float32Array,
     n: number,
@@ -104,10 +109,19 @@ export class DeriveClassificationWorkerClient implements DeriveClassificationCli
       // copy's buffer it can own zero-copy. The transient ~2× memory during the
       // call is deliberate — correctness over saving one buffer.
       const copy = positions.slice();
-      worker.postMessage(
-        { jobId, positions: copy.buffer, n, options },
-        [copy.buffer],
-      );
+      try {
+        worker.postMessage(
+          { jobId, positions: copy.buffer, n, options },
+          [copy.buffer],
+        );
+      } catch (err) {
+        // A synchronous post failure (e.g. DataCloneError, or posting to a
+        // worker that just died) would otherwise strand this job in `_pending`
+        // with its abort listener still attached. Settle it and surface the
+        // error to the caller.
+        this._settle(jobId);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
     });
   }
 
@@ -129,24 +143,28 @@ export class DeriveClassificationWorkerClient implements DeriveClassificationCli
       this._onMessage(event.data);
     };
     worker.onerror = (): void => {
+      // The worker died. Reject the in-flight job and DROP the dead worker so
+      // the next job respawns a fresh one — leaving it installed would post
+      // into a corpse that never replies, hanging the promise (this client has
+      // no timeout) and defeating any fallback.
       this._failAll(new Error('The classifier worker failed.'));
+      worker.terminate();
+      if (this._worker === worker) this._worker = null;
     };
     this._worker = worker;
     return worker;
   }
 
   private _onMessage(reply: WorkerReply): void {
-    const pending = this._pending.get(reply.jobId);
-    if (!pending) return;
-    // Progress messages report a phase and do NOT settle the job.
+    // Progress messages report a phase and do NOT settle the job — peek
+    // without removing so a later real reply for the same job still lands.
     if (!('ok' in reply)) {
-      pending.onProgress?.(reply.phase);
+      const pending = this._pending.get(reply.jobId);
+      pending?.onProgress?.(reply.phase);
       return;
     }
-    this._pending.delete(reply.jobId);
-    if (pending.onAbort && pending.signal) {
-      pending.signal.removeEventListener('abort', pending.onAbort);
-    }
+    const pending = this._settle(reply.jobId);
+    if (!pending) return; // aborted or already settled — drop the stale reply
     if (reply.ok) {
       pending.resolve({
         codes: reply.codes,
@@ -163,6 +181,22 @@ export class DeriveClassificationWorkerClient implements DeriveClassificationCli
     } else {
       pending.reject(new Error(reply.error));
     }
+  }
+
+  /**
+   * Remove a job from `_pending` and detach its abort listener, returning it
+   * (or undefined if already gone). The single teardown path, so a reply, a
+   * sync post failure, and a fail-all all clean up identically — no map entry
+   * or signal listener is ever left behind.
+   */
+  private _settle(jobId: number): PendingRequest | undefined {
+    const pending = this._pending.get(jobId);
+    if (!pending) return undefined;
+    this._pending.delete(jobId);
+    if (pending.onAbort && pending.signal) {
+      pending.signal.removeEventListener('abort', pending.onAbort);
+    }
+    return pending;
   }
 
   private _failAll(error: Error): void {

--- a/src/terrain/worker/terrainCoreWorkerClient.ts
+++ b/src/terrain/worker/terrainCoreWorkerClient.ts
@@ -47,6 +47,11 @@ export class TerrainCoreWorkerClient {
   private _nextJobId = 0;
   private _disposed = false;
 
+  /** In-flight job count. Diagnostic — asserted by the settlement tests. */
+  get pendingCount(): number {
+    return this._pending.size;
+  }
+
   /**
    * Compute a terrain core in the worker. The `positions` array is COPIED (its
    * buffer is never detached), so the caller may keep using it after the call.
@@ -105,16 +110,25 @@ export class TerrainCoreWorkerClient {
       // the worker can re-attach it (avoids cloning it twice).
       const { classification: _drop, ...paramsNoClass } = coreParams;
       void _drop;
-      worker.postMessage(
-        {
-          jobId,
-          positions: copy.buffer,
-          n: nClamped,
-          coreParams: paramsNoClass,
-          classification,
-        },
-        [copy.buffer],
-      );
+      try {
+        worker.postMessage(
+          {
+            jobId,
+            positions: copy.buffer,
+            n: nClamped,
+            coreParams: paramsNoClass,
+            classification,
+          },
+          [copy.buffer],
+        );
+      } catch (err) {
+        // A synchronous post failure (e.g. DataCloneError, or posting to a
+        // worker that just died) would otherwise strand this job in `_pending`
+        // with its abort listener still attached. Settle it and surface the
+        // error so the async wrapper's fallback path runs.
+        this._settle(jobId);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
     });
   }
 
@@ -151,17 +165,29 @@ export class TerrainCoreWorkerClient {
   }
 
   private _onMessage(reply: WorkerReply): void {
-    const pending = this._pending.get(reply.jobId);
+    const pending = this._settle(reply.jobId);
     if (!pending) return; // aborted or already settled — drop the stale reply
-    this._pending.delete(reply.jobId);
-    if (pending.onAbort && pending.signal) {
-      pending.signal.removeEventListener('abort', pending.onAbort);
-    }
     if (reply.ok) {
       pending.resolve(reply.core);
     } else {
       pending.reject(new Error(reply.error));
     }
+  }
+
+  /**
+   * Remove a job from `_pending` and detach its abort listener, returning it
+   * (or undefined if already gone). The single teardown path, so a reply, a
+   * sync post failure, and a fail-all all clean up identically — no map entry
+   * or signal listener is ever left behind.
+   */
+  private _settle(jobId: number): PendingRequest | undefined {
+    const pending = this._pending.get(jobId);
+    if (!pending) return undefined;
+    this._pending.delete(jobId);
+    if (pending.onAbort && pending.signal) {
+      pending.signal.removeEventListener('abort', pending.onAbort);
+    }
+    return pending;
   }
 
   private _failAll(error: Error): void {

--- a/tests/deriveClassificationWorkerClient.test.ts
+++ b/tests/deriveClassificationWorkerClient.test.ts
@@ -1,0 +1,135 @@
+/**
+ * tests/deriveClassificationWorkerClient.test.ts
+ *
+ * Protocol tests for the classification worker CLIENT, mirroring
+ * `tests/terrainCoreWorkerClient.test.ts` (recovery after `onerror`) and
+ * `tests/copcWorkerClient.test.ts` (settlement on a synchronous `postMessage`
+ * failure). The worker body itself is browser-bound and covered elsewhere; the
+ * real `Worker` global is stubbed with a fake that records posts and lets the
+ * test drive `onmessage` / `onerror`.
+ */
+
+import { describe, test, expect, afterEach, vi } from 'vitest';
+import { DeriveClassificationWorkerClient } from '../src/render/class/deriveClassificationWorkerClient';
+import type { DeriveClassificationOptions } from '../src/render/class/deriveClassification';
+
+/** A fake Worker recording posts; the test drives onmessage / onerror. */
+class FakeWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  readonly posted: Array<Record<string, unknown>> = [];
+  terminated = false;
+  constructor() {
+    instances.push(this);
+  }
+  postMessage(message: unknown): void {
+    this.posted.push(message as Record<string, unknown>);
+  }
+  terminate(): void {
+    this.terminated = true;
+  }
+}
+
+let instances: FakeWorker[] = [];
+
+function positions(): Float32Array {
+  return Float32Array.from([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+}
+
+const OPTIONS: DeriveClassificationOptions = { cellSizeM: 1 };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('DeriveClassificationWorkerClient — recovery after onerror', () => {
+  test('drops the dead worker and respawns a fresh one on the next job', async () => {
+    instances = [];
+    vi.stubGlobal('Worker', FakeWorker);
+    const client = new DeriveClassificationWorkerClient();
+    const pos = positions();
+
+    const first = client.classify(pos, 3, OPTIONS);
+    expect(instances).toHaveLength(1);
+    const dead = instances[0];
+    dead.onerror?.({});
+    await expect(first).rejects.toThrow(/worker failed/i);
+
+    // The next job must NOT reuse the dead worker (which would never reply) —
+    // a fresh worker is constructed and receives the post.
+    const second = client.classify(pos, 3, OPTIONS);
+    expect(instances).toHaveLength(2);
+    const fresh = instances[1];
+    expect(fresh.posted).toHaveLength(1);
+    expect(dead.posted).toHaveLength(1); // the dead worker never got the second job
+
+    const jobId = fresh.posted[0].jobId as number;
+    fresh.onmessage?.({
+      data: {
+        jobId,
+        ok: true,
+        codes: new Uint8Array([2]),
+        counts: {},
+        cellSizeM: 1,
+        gridWidth: 1,
+        gridHeight: 1,
+        provenance: 'derived',
+        confidence: 1,
+        classConfidence: {},
+        warnings: [],
+      },
+    } as MessageEvent);
+    await expect(second).resolves.toMatchObject({ derived: true });
+  });
+});
+
+describe('DeriveClassificationWorkerClient — synchronous postMessage failure', () => {
+  test('rejects and leaves no pending state', async () => {
+    instances = [];
+    // The worker is constructed lazily inside classify()'s own call stack, so
+    // there's no handle to override postMessage on before the first post — the
+    // fake throws itself, driven by this closed-over flag.
+    let throwOnPost = true;
+    class ThrowingFakeWorker extends FakeWorker {
+      override postMessage(message: unknown): void {
+        if (throwOnPost) throw new Error('DataCloneError: could not be cloned');
+        super.postMessage(message);
+      }
+    }
+    vi.stubGlobal('Worker', ThrowingFakeWorker);
+    const client = new DeriveClassificationWorkerClient();
+    const ctrl = new AbortController();
+    const removeSpy = vi.spyOn(ctrl.signal, 'removeEventListener');
+
+    await expect(client.classify(positions(), 3, OPTIONS, ctrl.signal)).rejects.toThrow(
+      /DataCloneError/,
+    );
+    // The worker is constructed lazily, so it only exists after the call above.
+    const worker = instances[0];
+    expect(client.pendingCount).toBe(0);
+    expect(removeSpy).toHaveBeenCalled();
+    expect(() => ctrl.abort()).not.toThrow();
+
+    // Not wedged: a later classify still completes.
+    throwOnPost = false;
+    const ok = client.classify(positions(), 3, OPTIONS);
+    const id = (worker.posted[worker.posted.length - 1] as { jobId: number }).jobId;
+    worker.onmessage?.({
+      data: {
+        jobId: id,
+        ok: true,
+        codes: new Uint8Array([2]),
+        counts: {},
+        cellSizeM: 1,
+        gridWidth: 1,
+        gridHeight: 1,
+        provenance: 'derived',
+        confidence: 1,
+        classConfidence: {},
+        warnings: [],
+      },
+    } as MessageEvent);
+    await expect(ok).resolves.toMatchObject({ derived: true });
+    expect(client.pendingCount).toBe(0);
+  });
+});

--- a/tests/terrainCoreWorkerClient.test.ts
+++ b/tests/terrainCoreWorkerClient.test.ts
@@ -106,6 +106,46 @@ describe('TerrainCoreWorkerClient — recovery after onerror', () => {
   });
 });
 
+describe('TerrainCoreWorkerClient — synchronous postMessage failure', () => {
+  test('rejects and leaves no pending state', async () => {
+    instances = [];
+    // The worker is constructed lazily inside computeCore()'s own call stack,
+    // so there's no handle to override postMessage on before the first post —
+    // the fake throws itself, driven by this closed-over flag.
+    let throwOnPost = true;
+    class ThrowingFakeWorker extends FakeWorker {
+      override postMessage(message: unknown): void {
+        if (throwOnPost) throw new Error('DataCloneError: could not be cloned');
+        super.postMessage(message);
+      }
+    }
+    vi.stubGlobal('Worker', ThrowingFakeWorker);
+    const client = new TerrainCoreWorkerClient();
+    const pos = hillScene();
+    const n = pos.length / 3;
+    const ctrl = new AbortController();
+    const removeSpy = vi.spyOn(ctrl.signal, 'removeEventListener');
+
+    await expect(client.computeCore(pos, n, PARAMS, undefined, ctrl.signal)).rejects.toThrow(
+      /DataCloneError/,
+    );
+    // The worker is constructed lazily, so it only exists after the call above.
+    const worker = instances[0] as FakeWorker;
+    expect(client.pendingCount).toBe(0);
+    expect(removeSpy).toHaveBeenCalled();
+    expect(() => ctrl.abort()).not.toThrow();
+
+    // Not wedged: a later job still completes.
+    throwOnPost = false;
+    const sentinel = { __ok: true } as unknown as TerrainCore;
+    const ok = client.computeCore(pos, n, PARAMS, undefined);
+    const id = (worker.posted[worker.posted.length - 1] as { jobId: number }).jobId;
+    worker.onmessage?.({ data: { jobId: id, ok: true, core: sentinel } } as MessageEvent);
+    await expect(ok).resolves.toBe(sentinel);
+    expect(client.pendingCount).toBe(0);
+  });
+});
+
 describe('computeTerrainCoreAsync — fallback survives a dead worker', () => {
   test('falls back to the main thread after a worker crash, on the crash run and the run after it', async () => {
     instances = [];


### PR DESCRIPTION
Fixes two confirmed worker-client defects found in the v0.6.3 code audit. Both mirror correct patterns that already exist elsewhere in this codebase, so the change is small and pattern-consistent.

## F1 (release-blocker) — classifier worker could stay permanently dead after a crash
`deriveClassificationWorkerClient`'s `onerror` rejected in-flight jobs but left the dead worker assigned to `this._worker`, so the next `classify()` posted into a corpse that never replies — and this client has no timeout, so that promise (and every later one) could hang until page reload.

Fix mirrors `terrainCoreWorkerClient` (which already does this and has a regression test): on error, terminate the worker and clear `this._worker` if it's still the same one, so the next job respawns fresh.

## F2 — synchronous postMessage failure leaked the pending job
Both `deriveClassificationWorkerClient` and `terrainCoreWorkerClient` inserted a request into `_pending` and attached an abort listener, then called `worker.postMessage(...)` with no try/catch. A synchronous throw (DataCloneError, or posting to a failed worker) auto-rejected the promise but left the map entry and listener behind — a leak.

Fix mirrors the COPC/EPT clients: a shared `_settle(jobId)` teardown, a try/catch around `postMessage` that calls `_settle` then rejects, and a `pendingCount` getter as a test seam (as COPC/EPT already expose).

## Out of scope
F3 (aborting doesn't stop in-flight CPU work) is deliberately not addressed: it was verified to be an architecture-wide limitation present even in the "correct" COPC/EPT clients, not a regression.

## Verification
tsc, the two changed/new test files (5 tests, incl. red→green regression proof for each fix), and the full `test:unit` suite all pass. Diff is scoped to the two client files and their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
