### PR TITLE
Harden scan-load lifecycle: transactional replacement + stale-callback and session-race guards (audit F4/F5/F6)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1424,6 +1424,7 @@ const inspector = new Inspector({
     const cloud = viewer.getCloud(id);
     if (!cloud || !cloud.colors) return;
     void loadRgbAutoNormalize().then(({ rgbAutoNormalize }) => {
+      if (scans.activeId !== id) return; // scan changed while we waited
       const suggestion = rgbAutoNormalize({ colorsU8: cloud.colors! });
       if (!suggestion) return;
       viewer.setRgbAppearance(suggestion.settings);
@@ -5975,8 +5976,10 @@ async function handleFile(file: File): Promise<void> {
       // geo path.
       {
         const profileCloud = result.cloud;
+        const targetId = id;
         void loadApplyDisplayProfile()
           .then(({ applyDisplayProfile }) => {
+            if (scans.activeId !== targetId) return; // scan changed while we waited
             applyDisplayProfile(profileCloud, inspector);
           })
           // The card is additive and no-op on absence; a chunk-load or

--- a/src/main.ts
+++ b/src/main.ts
@@ -5637,6 +5637,12 @@ async function importSession(file: File, opts: { skipScanConfirm?: boolean } = {
     // is nothing to rebase against; keep the verbatim geometry (the missing-
     // scan toast below already tells the user to drop the scan).
     const haveCloud = viewer.clouds().length > 0 || viewer.hasStreamingCloud;
+    // Capture the scan this import matches against, re-checked before we attach
+    // state. A session restore routes ahead of the loading guard, so a scan
+    // swapped in mid-import must not inherit another scan's measurements.
+    const targetId = scans.activeId;
+    const targetStreamingCloud = viewer.streamingCloud;
+    const targetStaticCloud = targetId ? viewer.getCloud(targetId) : undefined;
     // Guard the rebase: a session's geometry is local to the scan it was
     // captured over, so realigning it onto the loaded cloud is only correct when
     // that IS its scan. Compare the session's stored fingerprint (built the same
@@ -5706,6 +5712,18 @@ async function importSession(file: File, opts: { skipScanConfirm?: boolean } = {
           delta: [0, 0, 0] as const,
         };
     const rebased = geo.delta[0] !== 0 || geo.delta[1] !== 0 || geo.delta[2] !== 0;
+    // The scan could have been swapped in under us since we matched (this import
+    // routes ahead of the loading guard). Refuse to attach the session's state
+    // to a scan it was never matched against. (mirrors the 1723/1808 guard.)
+    if (
+      haveCloud &&
+      (scans.activeId !== targetId ||
+        viewer.streamingCloud !== targetStreamingCloud ||
+        (targetId ? viewer.getCloud(targetId) : undefined) !== targetStaticCloud)
+    ) {
+      showLassoToast('Session not applied — the active scan changed while it was importing.');
+      return;
+    }
     viewer.measure.loadMeasurements(geo.measurements);
     viewer.annotate.loadAnnotations(geo.annotations);
     // v7 — a view may carry a display bundle beyond its camera; hydrate it

--- a/src/main.ts
+++ b/src/main.ts
@@ -5865,9 +5865,6 @@ async function handleFile(file: File): Promise<void> {
       );
       return;
     }
-    // A static load replaces any open streaming scan.
-    if (viewer.hasStreamingCloud) closeStreaming();
-
     // Phones get a tighter point budget — limited GPU memory and fill-rate.
     // The dropped file is wrapped in a LocalFileSource — the source
     // abstraction; v0.3 streaming sources slot in beside it.
@@ -5899,6 +5896,11 @@ async function handleFile(file: File): Promise<void> {
 
     dropZone.setProgress(formatProgress({ stage: 'uploading' }));
     stage.hideEmptyState();
+    // A static load replaces any open streaming scan — but only now that the
+    // file parsed. A failed or cancelled parse above must leave the current
+    // scene intact rather than clearing it for a scan that never arrived.
+    if (controller.signal.aborted) throw new LoadCancelledError();
+    if (viewer.hasStreamingCloud) closeStreaming();
     const uploadStartedAt = performance.now();
     const id = viewer.addCloud(result.cloud);
     const gpuUploadMs = performance.now() - uploadStartedAt;
@@ -6225,8 +6227,6 @@ async function openStreamingCopc(
     ? (ms) => streamingBenchmark?.recordDecodeMs(ms)
     : undefined;
 
-  // A streaming scan is exclusive — clear any open static layers first.
-  clearOpenStaticLayers();
   stage.hideEmptyState();
   // Local-first counter — categorical only ('copc' or 'ept'); never the URL.
   recordUsage('scan-open', cloud.kind === 'ept' ? 'ept' : 'copc');
@@ -6247,6 +6247,11 @@ async function openStreamingCopc(
   } catch (err) {
     if (debug) console.warn('[crs] refreshCrsForStreamingCloud threw', err);
   }
+  // A streaming scan is exclusive — clear open static layers at the last
+  // moment, after the source opened above and just before its replacement
+  // attaches, so a failed open left the current scene intact. The abort check
+  // at the open still guards this; nothing yields between it and here.
+  clearOpenStaticLayers();
   await viewer.attachStreamingCloud(
     cloud,
     copcDecoder,
@@ -6254,6 +6259,9 @@ async function openStreamingCopc(
     isPhone(),
     streamingBenchmark,
   );
+  // attachStreamingCloud takes no signal; if the user cancelled while it ran,
+  // drop the fresh cloud so a cancel adds nothing rather than half-attaching.
+  if (signal.aborted) { closeStreaming(); throw new LoadCancelledError(); }
   viewer.setMode('orbit');
   viewer.frameAll();
 
@@ -6471,7 +6479,6 @@ async function handleRemoteEpt(url: string, signal?: AbortSignal): Promise<void>
       throw new Error(`Not a valid EPT manifest — ${detection.reason}`);
     }
 
-    if (viewer.hasStreamingCloud) closeStreaming();
     await viewer.ready;
     streamingPanel.setPhase('Building hierarchy…');
     streamingPanel.show();
@@ -6508,8 +6515,6 @@ async function handleRemoteEpt(url: string, signal?: AbortSignal): Promise<void>
     );
     if (controller.signal.aborted) throw new LoadCancelledError();
 
-    // A streaming scan is exclusive — clear any open static layers first.
-    clearOpenStaticLayers();
     stage.hideEmptyState();
 
     // Laszip tiles are CPU-heavy (laz-perf decompress + coordinate transform);
@@ -6524,6 +6529,12 @@ async function handleRemoteEpt(url: string, signal?: AbortSignal): Promise<void>
       cloud,
       cloud.dataType === 'laszip' ? eptLaszipDecoder : null,
     );
+    // A streaming scan is exclusive — replace any prior streaming/static scene
+    // at the last moment, after the EPT source opened and the decoder is ready,
+    // so a failed or cancelled step above left the current scene intact.
+    if (controller.signal.aborted) throw new LoadCancelledError();
+    if (viewer.hasStreamingCloud) closeStreaming();
+    clearOpenStaticLayers();
     await viewer.attachStreamingCloud(
       cloud,
       decoder,
@@ -6531,6 +6542,9 @@ async function handleRemoteEpt(url: string, signal?: AbortSignal): Promise<void>
       isPhone(),
       null,
     );
+    // attachStreamingCloud takes no signal; if the user cancelled while it ran,
+    // drop the fresh cloud so a cancel adds nothing rather than half-attaching.
+    if (controller.signal.aborted) { closeStreaming(); throw new LoadCancelledError(); }
     viewer.setMode('orbit');
     viewer.frameAll();
 
@@ -6680,6 +6694,11 @@ async function handleRemoteCopc(url: string, signal?: AbortSignal): Promise<void
     // a host that cannot stream reports a precise reason instead of stalling.
     await range.probe(controller.signal);
     if (controller.signal.aborted) throw new LoadCancelledError();
+    // TODO(gate F4): closes the prior scan before openStreamingCopc's own fetch,
+    // so a malformed COPC that passes the range probe still blanks the scene.
+    // Deferring needs the teardown moved into the shared openStreamingCopc (the
+    // local path relies on attach's internal detach) — a larger refactor. The
+    // probe above already guards the common remote failures (CORS / ranges / 404).
     if (viewer.hasStreamingCloud) closeStreaming();
     await openStreamingCopc(range, remoteCopcName(url), controller.signal);
     dropZone.setCancelHandler(null);

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -1980,7 +1980,6 @@ export class Viewer {
         loadStreamingRenderer(),
         loadStreamingScheduler(),
       ]);
-    this.detachStreamingCloud();
     // Fade-in is enabled on desktop/mid+ profiles only; mobile and
     // low-tier sessions skip it to preserve frame-budget headroom.
     const fadeIn = !isMobile && quality !== 'low';
@@ -2034,6 +2033,10 @@ export class Viewer {
       },
       streamingBudgets(quality, isMobile),
     );
+    // Detach the prior streaming cloud only now that the replacement renderer
+    // and scheduler are built. A throw in the lazy load or the constructors
+    // above then leaves the current scan on screen instead of a blank scene.
+    this.detachStreamingCloud();
     this._streaming = { cloud, scheduler, renderer, decoder, benchmark: benchmark ?? null };
     this._streamingFrame = 0;
     // Guaranteed scheduler cadence, render-loop-independent (see the field's


### PR DESCRIPTION
Fixes three confirmed load-lifecycle defects from the v0.6.3 code audit. Each was verified against the real code before implementing; F5/F6 copy a guard pattern that already exists elsewhere in main.ts.

## F6 (release-blocker) — stale lazy callbacks apply to a different active scan
RGB auto-balance and the display-profile card applied their (dynamically-imported) results to whatever scan was active when the promise resolved, not the one they started for — so loading scan B while A's lazy chunk was still resolving discoloured/mis-profiled B. Added the same `if (scans.activeId !== id) return; // scan changed while we waited` guard already used at main.ts:6001-6003 and 1723/1808.

## F5 (borderline blocker) — session import races a scan load
`importSession` routes ahead of the loading guard and applies measurements/annotations/CRS synchronously against the active scan without rechecking it hadn't changed. Captured the matched scan identity and added a bail (with a user toast) if the active scan swapped mid-import. The intentional "routes ahead of the loading guard" behaviour is preserved; only the apply refuses a scan that moved.

## F4 (release-blocker) — destructive scan replacement before the replacement is ready
Five paths tore down the current scene before the replacement was fetched/decoded/attached, so a malformed file, failed fetch, or cancel left a blank scene. Applied the conservative subset (no transactional rewrite): move each destructive `closeStreaming()`/`clearOpenStaticLayers()`/`detachStreamingCloud()` to just before the attach that's expected to succeed, with abort checks after the clear and after attach. Hardened 5 of 6 sites; the remote-COPC path is left with a documented `TODO(gate F4)` rather than force a riskier refactor (its range probe already guards the common failures).

## Verification
tsc, lint:monolith-size (main.ts 7314, Viewer.ts 7073 — under baseline), test:unit, and lint:release-truth all pass. The static-replacement path is diff-verified; a malformed-drop device check confirmed the scene survives. The streaming-replacement reorders are code-reviewed-correct but were not device-run (no COPC/EPT fixture available) — noted for the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
