### PR TITLE
v0.6.3 hardening: defect-replay archive guard + banked monolith baseline

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.3.md
+++ b/KNOWN_LIMITATIONS_v0.6.3.md
@@ -6,7 +6,7 @@ Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 7,355 lines and `src/render/Viewer.ts` is 7,073, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 7,323 lines and `src/render/Viewer.ts` is 7,073, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 7,355 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 7,323 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -102,7 +102,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (7,355)** — the largest blocks, which are the extraction
+**`src/main.ts` (7,323)** — the largest blocks, which are the extraction
 candidates:
 
 | Block | ~Lines | Extraction target |

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 7355,
+      "lines": 7323,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/scripts/replay-defects.mjs
+++ b/scripts/replay-defects.mjs
@@ -64,6 +64,36 @@ import {
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
+// A source archive extracted without .git (a Zenodo download, say) has neither
+// the repository nor the v0.6.1 baseline tag this replay needs. Report that as a
+// structured unsupported state on stdout and exit clean, the way the freeze
+// verifier does, rather than throwing a raw `git worktree` error later. The
+// full-repo release gate still runs the real replay.
+function inGitRepo() {
+  try {
+    return (
+      execFileSync(GIT, ['rev-parse', '--is-inside-work-tree'], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim() === 'true'
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (!inGitRepo()) {
+  console.log(
+    JSON.stringify({
+      status: 'unsupported',
+      reason:
+        'Defect chronology replay requires Git history and the v0.6.1 tag; an extracted archive has neither.',
+    }),
+  );
+  process.exit(0);
+}
+
 function fail(message, code = 2) {
   console.error(message);
   process.exit(code);


### PR DESCRIPTION
Two items from the pre-publish review, done before re-tagging v0.6.3.

**#5 — defect-replay archive portability.** `validation:defects:replay` (`replay-defects.mjs`) uses `git worktree` against the v0.6.1 tag, so from an extracted source ZIP with no `.git` it threw a raw Git error. Added an `inGitRepo` guard mirroring #193's freeze-verify fix: it now prints `{"status":"unsupported",…}` and exits 0 in an archive, and still runs the real replay in the full repo. Verified end-to-end in an out-of-tree no-git dir.

**#2 — bank the monolith baseline.** main.ts (7,323) and Viewer.ts (7,073) were 32 lines under the stored baseline; banked so the ratchet ceiling can't drift back up. Synced `KNOWN_LIMITATIONS_v0.6.3.md` and `architecture-map.md`, which quoted the stale 7,355 (lint:release-truth enforces this).

Verified: lint:release-truth / monolith-size / release-sync / archive-vocab / claims-language all pass.