### PR TITLE
Record mutation score 98.32 (v0.6.3, covers the new terrain-derivatives code)

### DIFF
--- a/docs/validation/mutation-evidence.json
+++ b/docs/validation/mutation-evidence.json
@@ -1,30 +1,30 @@
 {
   "schemaVersion": 1,
   "project": "openlidarviewer",
-  "score": 96.81,
+  "score": 98.32,
   "break": 75,
   "mutants": {
-    "killed": 136,
-    "timeout": 46,
+    "killed": 313,
+    "timeout": 39,
     "survived": 5,
     "noCoverage": 1,
     "ignored": 0,
     "errors": 0,
-    "detected": 182,
+    "detected": 352,
     "undetected": 6,
-    "scored": 188
+    "scored": 358
   },
   "mutate": [
     "src/process/numerics.ts",
     "src/terrain/quantile.ts",
     "src/terrain/ground/terrainDerivatives.ts"
   ],
-  "commit": "b6ec0f16964d2afd1d8c37a2d13087cf51cfeea8",
-  "measuredAt": "2026-07-30T12:08:09.159Z",
+  "commit": "a537e7dc47059b55aef39ee02479a359e4ca8ca0",
+  "measuredAt": "2026-08-01T13:52:35.385Z",
   "ranInThisGate": false,
   "workflow": "Mutation",
-  "workflowRunId": "30532907233",
-  "workflowRunUrl": "https://github.com/Aurtechmx/openlidarviewer/actions/runs/30532907233",
+  "workflowRunId": "30697202511",
+  "workflowRunUrl": "https://github.com/Aurtechmx/openlidarviewer/actions/runs/30697202511",
   "nodeVersion": "v22.17.1",
   "platform": "linux-x64"
 }


### PR DESCRIPTION
Evidence from mutation.yml run 30697202511 on main (a537e7d, with the #202 killing tests). The workflow measured and committed the record but could not open its own PR — the org blocks the Actions bot from creating PRs — so opening it here.

Score 98.32% over the numeric core (break 75), now covering terrainDerivatives.ts's v0.6.3 additions. This refreshes the stale 96.81% that predated that code, so v0.6.3 can cite a current figure.