### PR TITLE
Wire the Stryker Dashboard + scoped core-mutation-score badge

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -67,6 +67,10 @@ jobs:
       # swallowed exit code nor a loosened runner config can turn a regression
       # into a green run.
       - name: Mutation run
+        env:
+          # Enables the dashboard reporter to publish the core score. Absent
+          # locally, the reporter skips silently; the run itself is unchanged.
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
         run: npm run mutation
 
       - name: Record the score, the commit, and this run

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 <!-- Is it measured, and by whom -->
 [![Security audit](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/security.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/security.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/Aurtechmx/openlidarviewer?label=coverage&color=3fb950)](https://codecov.io/gh/Aurtechmx/openlidarviewer)
+[![Core mutation score](https://img.shields.io/endpoint?style=flat&label=core%20mutation%20score&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FAurtechmx%2Fopenlidarviewer%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Aurtechmx/openlidarviewer/main)
 [![Quality gate](https://sonarcloud.io/api/project_badges/measure?project=Aurtechmx_openlidarviewer&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Aurtechmx_openlidarviewer)
 
 <!-- Can the work be found and reused -->

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -9,8 +9,14 @@
   "reporters": [
     "clear-text",
     "progress",
-    "json"
+    "json",
+    "dashboard"
   ],
+  "_dashboard_comment": "The mutate list IS the numeric/terrain core, so this project score is the core score, not a repo-wide figure — the README badge is labelled 'core mutation score' to say so. The dashboard reporter only pushes when STRYKER_DASHBOARD_API_KEY is set (the mutation workflow supplies it from a secret); a local run without the key skips it silently.",
+  "dashboard": {
+    "project": "github.com/Aurtechmx/openlidarviewer",
+    "version": "main"
+  },
   "coverageAnalysis": "perTest",
   "mutate": [
     "src/process/numerics.ts",


### PR DESCRIPTION
Lights up the dashboard badge you set the `STRYKER_DASHBOARD_API_KEY` secret for.

- `stryker.conf.json`: add the `dashboard` reporter + a project-level `dashboard` block. Reporting stays project-level because the mutate list already IS the numeric/terrain core, so the project score is the core score.
- `mutation.yml`: pass `STRYKER_DASHBOARD_API_KEY` from the secret on the Mutation run step (skips silently when absent, e.g. local runs).
- `README.md`: a **core mutation score** badge (labelled, not repo-wide), linking to the dashboard report.

After this merges, dispatch `mutation.yml` once — it publishes the score (~98%) and the badge fills in. Does not touch the v0.6.3 tag.