### PR TITLE
Add numbered annotation markers + table to the Map Sheet PDF

### DIFF
--- a/src/app/terrainAnalysisRunner.ts
+++ b/src/app/terrainAnalysisRunner.ts
@@ -176,6 +176,16 @@ export interface TerrainAnalysisRunner {
     generalizeToleranceCells?: number;
   }): Promise<AnalyseContoursResult>;
   /**
+   * The up-axis of the RAW scene frame the last analysed/exported scan was
+   * gathered in — the gather's own `sourceUpAxis`, cached so the map-sheet
+   * export can rotate an annotation's local position into the SAME canonical
+   * frame the contours were built in (a Y-up mesh's contours are rotated; its
+   * annotations must be too). Defaults to 'z' before any gather. Reading the
+   * actual gather value, not the source format, is deliberate: a Z-up-authored
+   * mesh is detected as Z-up here but the format table would call it Y-up.
+   */
+  getLastSourceUpAxis(): 'z' | 'y';
+  /**
    * Abort any in-flight compute and drop every cached terrain core. Called
    * from the reset-to-empty path so a result for the now-closed scan can never
    * land on the panel and cached cores stay bounded. Guarded: the cache chunk
@@ -213,6 +223,12 @@ export function createTerrainAnalysisRunner(
   // previous controller so a superseded worker job is cancelled and its reply
   // dropped. Null when no run is in flight.
   let terrainAbort: AbortController | null = null;
+
+  // The last gather's raw-scene up-axis, cached so the map-sheet export can plot
+  // annotation markers in the same canonical frame the contours were built in.
+  // Updated by every run() and export build (a scan's frame is interval- and
+  // style-independent, so the last gather always describes the current scan).
+  let lastSourceUpAxis: 'z' | 'y' = 'z';
 
   // The active cloud's world-origin Y (the render-recentre offset), so a
   // geographic scan's grid-centre LATITUDE can be recovered from the local
@@ -257,6 +273,9 @@ export function createTerrainAnalysisRunner(
       analysePanel.setStatus('Load a scan first, then run terrain analysis.');
       return;
     }
+    // Remember the frame this scan was gathered in — the map-sheet export reads
+    // it to place annotation markers (see getLastSourceUpAxis).
+    if (gathered.sourceUpAxis) lastSourceUpAxis = gathered.sourceUpAxis;
     // Claim a token + snapshot the dataset identity for this run. After every
     // await we re-check these: a newer run (token mismatch), a different/closed
     // scan (activeId changed), or a hidden panel means this result is stale and
@@ -378,6 +397,9 @@ export function createTerrainAnalysisRunner(
     const viewer = getViewer();
     const gathered = viewer.gatherTerrainPositions();
     if (!gathered) throw new Error('No scan loaded to build contours from.');
+    // Same frame capture as run() — an export from an interval re-pick keeps the
+    // annotation markers aligned with the contours it just built.
+    if (gathered.sourceUpAxis) lastSourceUpAxis = gathered.sourceUpAxis;
     // Same cached-core path the run() loop uses. Because deriveCoreParams
     // reproduces the run's fingerprint exactly, an already-analysed scan HITS
     // the LRU cache here and no worker job is started — only the cheap
@@ -430,5 +452,9 @@ export function createTerrainAnalysisRunner(
     clearTerrainCoreCacheFn?.();
   }
 
-  return { run, buildResultAtInterval, buildResultForExport, abortAndClearCache };
+  function getLastSourceUpAxis(): 'z' | 'y' {
+    return lastSourceUpAxis;
+  }
+
+  return { run, buildResultAtInterval, buildResultForExport, abortAndClearCache, getLastSourceUpAxis };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2632,11 +2632,7 @@ function newAnalysePanel(
     // Same cached-core rebuild, generalised with the contour shape-style picker so
     // an export reflects the user's chosen interval AND line shape.
     buildResultForExport: (opts) => terrainRunner.buildResultForExport(opts),
-    getExportBasename: () => lastCloudName,
-    // The placed annotations, for the map sheet's opt-in annotation layer. Same
-    // list (and order) the Annotations panel shows, so a marker's number matches
-    // its table row.
-    getAnnotations: () => viewer.annotate.getAnnotations(),
+    getExportBasename: () => lastCloudName, getAnnotations: () => viewer.annotate.getAnnotations(),
     // Terrain Intelligence Report (v0.4.5): hand the report the Inspector
     // card's CURRENT Dataset Intelligence summary so the PDF's bucket labels
     // are the card's own strings (null when the card is empty — the report
@@ -2703,11 +2699,7 @@ function newAnalysePanel(
         worldOrigin: origin ? { x: origin[0], y: origin[1], z: origin[2] } : null,
         title: `${lastCloudName} — Contours`,
         sheet: 'letter',
-        // The gather's own up-axis (not the source format's), so the map sheet
-        // rotates annotation markers into the SAME canonical frame the contours
-        // were built in — a Y-up mesh's contours are rotated, its markers too.
-        sceneUpAxis: terrainRunner.getLastSourceUpAxis(),
-        isGeographic: cur?.kind === 'geographic',
+        isGeographic: cur?.kind === 'geographic', sceneUpAxis: terrainRunner.getLastSourceUpAxis(),
         wkt: cloud?.metadata?.crs?.wkt ?? streaming?.crs()?.wkt ?? null,
         // The resolved CRS's linear unit (same seam every other unit consumer
         // reads) so a foot-based CRS stamps DXF $INSUNITS = feet and the SVG

--- a/src/main.ts
+++ b/src/main.ts
@@ -2633,6 +2633,10 @@ function newAnalysePanel(
     // an export reflects the user's chosen interval AND line shape.
     buildResultForExport: (opts) => terrainRunner.buildResultForExport(opts),
     getExportBasename: () => lastCloudName,
+    // The placed annotations, for the map sheet's opt-in annotation layer. Same
+    // list (and order) the Annotations panel shows, so a marker's number matches
+    // its table row.
+    getAnnotations: () => viewer.annotate.getAnnotations(),
     // Terrain Intelligence Report (v0.4.5): hand the report the Inspector
     // card's CURRENT Dataset Intelligence summary so the PDF's bucket labels
     // are the card's own strings (null when the card is empty — the report
@@ -2699,6 +2703,10 @@ function newAnalysePanel(
         worldOrigin: origin ? { x: origin[0], y: origin[1], z: origin[2] } : null,
         title: `${lastCloudName} — Contours`,
         sheet: 'letter',
+        // The gather's own up-axis (not the source format's), so the map sheet
+        // rotates annotation markers into the SAME canonical frame the contours
+        // were built in — a Y-up mesh's contours are rotated, its markers too.
+        sceneUpAxis: terrainRunner.getLastSourceUpAxis(),
         isGeographic: cur?.kind === 'geographic',
         wkt: cloud?.metadata?.crs?.wkt ?? streaming?.crs()?.wkt ?? null,
         // The resolved CRS's linear unit (same seam every other unit consumer

--- a/src/render/measure/annotationMapProjection.ts
+++ b/src/render/measure/annotationMapProjection.ts
@@ -1,0 +1,108 @@
+/**
+ * annotationMapProjection.ts
+ *
+ * Pure (no pdf-lib, no DOM) placement maths for annotation markers on the
+ * contour map sheet. Kept out of {@link ./mapSheetPdf} so the ONE thing that can
+ * plot a marker in the wrong place — the coordinate-frame conversion — is
+ * unit-testable on its own, with page coordinates a test can compute by hand.
+ *
+ * ── THE COORDINATE-FRAME PROBLEM (read before touching this) ────────────────
+ * The map draws `input.model` geometry and sizes its `bbox` in the CANONICAL
+ * Z-up survey frame. That frame is produced by `Viewer.gatherTerrainPositions`,
+ * which rotates the source buffer into "X east / Y north / Z up" BEFORE the
+ * terrain pipeline reads it (see `terrain/canonicalFrame.ts`): a Z-up source is
+ * left untouched, a Y-up source (phone-scan mesh: PLY/OBJ/glTF) is rotated
+ * `(x, y, z) → (x, -z, y)`. So the contour model's 2D coordinates are the
+ * canonical HORIZONTAL axes.
+ *
+ * An annotation's `localPosition`, by contrast, lives in the RAW scene/render
+ * frame — the same buffer the cloud is drawn from, the frame the marker was
+ * picked in — BEFORE that rotation. To land a marker on the contour it was
+ * placed over, apply the SAME scene→canonical rotation to its horizontal
+ * components:
+ *   - z-up scene: map (x, y) = (local.x,  local.y)   // identity
+ *   - y-up scene: map (x, y) = (local.x, -local.z)   // canonical X, Y
+ * The scene's up-axis is exactly the gather's `sourceUpAxis`, threaded through
+ * so this can never disagree with the frame the contours were built in (using
+ * the source FORMAT's nominal axis instead would misplace a Z-up-authored PLY,
+ * which the gather detects as Z-up but the format table calls Y-up).
+ *
+ * We convert `localPosition`, NEVER `worldPosition`: the map draws geometry in
+ * the LOCAL (origin-shifted) frame and only adds `worldOrigin` back for graticule
+ * LABELS, so `bbox` is local and a marker must be too. Adding the world origin
+ * would push every marker off the sheet by the whole recentre offset.
+ */
+
+/** Which axis is vertical in the RAW scene frame the annotation was picked in. */
+export type SceneUpAxis = 'z' | 'y';
+
+/** A ground-plan point in the map (contour-model) frame. */
+export interface MapXY {
+  readonly x: number;
+  readonly y: number;
+}
+
+/** The map's ground extent — the contour model's bbox. */
+export interface MapBBox {
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+}
+
+/**
+ * The fit transform the map uses: page point = (ox, oy) + (map - min) * scale.
+ * Matches the `t = fitTransform(bbox, inner)` the sheet already builds, so the
+ * marker projection reuses the exact same transform as the contour geometry.
+ */
+export interface MapFitTransform {
+  readonly ox: number;
+  readonly oy: number;
+  readonly scale: number;
+}
+
+/**
+ * Convert an annotation's raw-scene local position into the map (contour) frame.
+ * See the file header for the frame reasoning. Only the two horizontal
+ * components survive; the elevation drops out of a ground plan.
+ */
+export function annotationToMapXY(
+  local: { readonly x: number; readonly y: number; readonly z: number },
+  sceneUpAxis: SceneUpAxis,
+): MapXY {
+  return sceneUpAxis === 'y' ? { x: local.x, y: -local.z } : { x: local.x, y: local.y };
+}
+
+/** A projected marker: its y-up page point and whether it falls on the map. */
+export interface ProjectedAnnotation {
+  readonly pageX: number;
+  readonly pageY: number;
+  /**
+   * True when the map-frame point is within the model's bbox (edges inclusive).
+   * A marker outside the bbox is omitted from the map — the sheet notes it is
+   * still listed in the description table so nothing is silently dropped.
+   */
+  readonly insideBbox: boolean;
+}
+
+/**
+ * Project one annotation to its y-up page point through the SAME fit transform
+ * the contour geometry uses, and report whether it lands on the map. The bbox
+ * test is inclusive of the edges: an annotation exactly on the map border is a
+ * valid on-map marker, not an off-map one.
+ */
+export function projectAnnotationToPage(
+  local: { readonly x: number; readonly y: number; readonly z: number },
+  sceneUpAxis: SceneUpAxis,
+  bbox: MapBBox,
+  t: MapFitTransform,
+): ProjectedAnnotation {
+  const m = annotationToMapXY(local, sceneUpAxis);
+  const insideBbox =
+    m.x >= bbox.minX && m.x <= bbox.maxX && m.y >= bbox.minY && m.y <= bbox.maxY;
+  return {
+    pageX: t.ox + (m.x - bbox.minX) * t.scale,
+    pageY: t.oy + (m.y - bbox.minY) * t.scale,
+    insideBbox,
+  };
+}

--- a/src/render/measure/annotationReportTable.ts
+++ b/src/render/measure/annotationReportTable.ts
@@ -1,0 +1,76 @@
+/**
+ * annotationReportTable.ts
+ *
+ * The content model for the annotation table that the map-drawing PDFs
+ * (mapSheet, space, terrain) print. Pure: no pdf-lib, no DOM. One model so the
+ * three reports cannot drift apart — the same class of defect that let the EPT
+ * path lose its tool dock, restated for report layout.
+ *
+ * What it decides is CONTENT, not layout. Every annotation becomes a row, in
+ * order; the caller's drawing code decides where the rows go (a corner block, a
+ * right column, a continuation page) and never whether an annotation appears.
+ *
+ * The honesty rules live here, and tests/annotationReportTable.test.ts pins
+ * them:
+ *   - complete: rows.length === annotations.length, always.
+ *   - the note is summarised to a cap and a cut is flagged, never silent.
+ *   - no coordinate is emitted: `position` is local render-space and printing
+ *     it on a client deliverable claims a surveyed location it does not have.
+ *   - the header states the count.
+ */
+import type { Annotation, AnnotationType } from '../annotate/types';
+
+/** One printable row: a description, never a position. */
+export interface AnnotationReportRow {
+  /** 1-based, matches the reading order of the list. */
+  readonly index: number;
+  readonly type: AnnotationType;
+  readonly title: string;
+  /** Summarised note; empty when the annotation carries none. */
+  readonly note: string;
+  /** True when the note was cut to fit; the row shows an ellipsis. */
+  readonly noteTruncated: boolean;
+}
+
+export interface AnnotationReport {
+  /** e.g. "Annotations (4)" — the count so a summary cannot read as complete. */
+  readonly header: string;
+  readonly rows: readonly AnnotationReportRow[];
+}
+
+export interface AnnotationReportOptions {
+  /**
+   * Longest note printed before it is cut and flagged. A table cell cannot hold
+   * a paragraph; the full text lives in the session export, which the sheet
+   * points to. Default 120.
+   */
+  readonly maxNoteChars?: number;
+}
+
+const DEFAULT_MAX_NOTE = 120;
+
+function summariseNote(raw: string | undefined, max: number): { note: string; noteTruncated: boolean } {
+  const trimmed = (raw ?? '').trim();
+  if (trimmed.length <= max) return { note: trimmed, noteTruncated: false };
+  // Cut to `max` and mark it. The ellipsis is the visible signal that there is
+  // more, so a reader is never left thinking the printed text is the whole note.
+  return { note: `${trimmed.slice(0, max)}…`, noteTruncated: true };
+}
+
+export function buildAnnotationReport(
+  annotations: readonly Annotation[],
+  options: AnnotationReportOptions,
+): AnnotationReport {
+  const max = options.maxNoteChars ?? DEFAULT_MAX_NOTE;
+  const rows = annotations.map((a, i) => {
+    const { note, noteTruncated } = summariseNote(a.note, max);
+    return {
+      index: i + 1,
+      type: a.type,
+      title: a.title.trim(),
+      note,
+      noteTruncated,
+    } satisfies AnnotationReportRow;
+  });
+  return { header: `Annotations (${annotations.length})`, rows };
+}

--- a/src/render/measure/mapSheetExportOptions.ts
+++ b/src/render/measure/mapSheetExportOptions.ts
@@ -95,3 +95,30 @@ export function defaultMapFilename(basename: string): string {
   const base = (basename ?? '').trim() || 'contours';
   return sanitizeMapFilename(`${base}-map`);
 }
+
+/**
+ * State for the dialog's "Include annotations" checkbox, derived from how many
+ * annotations the scan carries. Pure so the enable/label logic is unit-testable
+ * without the DOM. The control is DISABLED (not hidden) when there is nothing to
+ * include, so the option is discoverable but clearly unavailable — the earlier
+ * decision to show it disabled at zero. Default OFF regardless, so a plain sheet
+ * never changes unless the user asks for annotations.
+ */
+export function annotationsOptionState(count: number): {
+  disabled: boolean;
+  label: string;
+  hint: string;
+} {
+  if (count <= 0) {
+    return {
+      disabled: true,
+      label: 'Include annotations',
+      hint: 'No annotations placed on this scan.',
+    };
+  }
+  return {
+    disabled: false,
+    label: 'Include annotations',
+    hint: `Plot the ${count} placed annotation${count === 1 ? '' : 's'} as numbered markers with a description table.`,
+  };
+}

--- a/src/render/measure/mapSheetPdf.ts
+++ b/src/render/measure/mapSheetPdf.ts
@@ -16,6 +16,12 @@
 
 import { PDFDocument, StandardFonts, rgb, degrees, type PDFFont, type PDFPage } from 'pdf-lib';
 import type { ContourFeatureModel, ContourFeature } from '../../terrain/contour/contourFeatureModel';
+import type { Annotation, AnnotationType } from '../annotate/types';
+import { buildAnnotationReport, type AnnotationReportRow } from './annotationReportTable';
+import {
+  projectAnnotationToPage,
+  type SceneUpAxis,
+} from './annotationMapProjection';
 import { decimalsForInterval, type ContourLabel } from '../../terrain/contour/labelPlacement';
 import { placeContourLabels } from '../../terrain/contourStudio/contourLabelEngine';
 import { contourShapeStyleLabel } from '../../terrain/contour/contourShapeStyle';
@@ -109,6 +115,26 @@ export interface MapSheetInput {
    * absent (back-compat).
    */
   readonly provenance?: ExportProvenance;
+  /**
+   * Opt-in: draw the placed annotations on the sheet (numbered markers on the
+   * map + a description table in the top-right collar). Default OFF, so a sheet
+   * built without this flag is byte-for-byte the pre-annotation output.
+   */
+  readonly includeAnnotations?: boolean;
+  /**
+   * The placed annotations, in list order (the marker index is the 1-based list
+   * position, matching the panel and the description table). Only read when
+   * {@link includeAnnotations} is true and the list is non-empty.
+   */
+  readonly annotations?: ReadonlyArray<Annotation>;
+  /**
+   * The RAW scene's up-axis, so an annotation's `localPosition` is rotated into
+   * the SAME canonical frame the contour geometry lives in before it is plotted.
+   * This MUST be the gather's `sourceUpAxis` (not the source format's nominal
+   * axis) — see the frame reasoning in `annotationMapProjection.ts`. Defaults to
+   * 'z' (the survey formats a georeferenced sheet is built from).
+   */
+  readonly sceneUpAxis?: SceneUpAxis;
 }
 
 const SHEET_PT: Record<SheetSize, readonly [number, number]> = {
@@ -128,6 +154,19 @@ const SEPIA_INDEX = rgb(0.24, 0.14, 0.05);
 // runs stay broken — the strongest "do not trust this line" signal.
 const SEPIA_LIGHT = rgb(0.58, 0.47, 0.36);
 const WHITE = rgb(1, 1, 1);
+
+/**
+ * Marker fill per annotation type. Chosen to read as a distinct inspection layer
+ * OVER the sepia contour ink (cool/saturated dots against warm hairlines), and
+ * to keep the four types tellable apart at print size. The description table
+ * carries the type name too, so colour is a reinforcement, not the only cue.
+ */
+const ANNOTATION_COLORS: Record<AnnotationType, ReturnType<typeof rgb>> = {
+  note: rgb(0.20, 0.40, 0.78),
+  info: rgb(0.10, 0.52, 0.55),
+  warning: rgb(0.85, 0.53, 0.10),
+  issue: rgb(0.74, 0.16, 0.12),
+};
 
 /**
  * One place that maps a contour feature's index/grade to its drawn style, so the
@@ -506,6 +545,187 @@ function drawMap(
     }
     page.drawText(unit, { x: bx + bar.barPt + 4, y: by, size: 6, font, color: DIM });
   }
+
+  // ── annotations (opt-in) ─────────────────────────────────────────────────
+  // Drawn LAST so the markers and their table sit above the contours, and only
+  // when the caller opted in AND there is something to draw — so a sheet built
+  // without annotations emits exactly the operations it did before this feature.
+  if (input.includeAnnotations && input.annotations && input.annotations.length > 0) {
+    drawAnnotationLayer(page, frame, inner, bbox, t, input.annotations, input.sceneUpAxis ?? 'z', font, bold);
+  }
+}
+
+/**
+ * The annotation inspection layer: a numbered marker on the map for each
+ * annotation that falls within the map extent, plus a description table in the
+ * top-right collar. The marker index is the annotation's 1-based list position,
+ * so a marker and its table row always carry the same number.
+ *
+ * Coordinate frame: `projectAnnotationToPage` converts each annotation's raw
+ * scene position into the map (contour) frame before projecting — see
+ * annotationMapProjection.ts. Off-map annotations are not drawn on the map but
+ * are STILL listed in the table (with a footnote), so the table stays complete.
+ */
+function drawAnnotationLayer(
+  page: PDFPage,
+  frame: { x: number; y: number; w: number; h: number },
+  inner: { x: number; y: number; w: number; h: number },
+  bbox: Box,
+  t: { ox: number; oy: number; scale: number },
+  annotations: ReadonlyArray<Annotation>,
+  sceneUpAxis: SceneUpAxis,
+  font: PDFFont,
+  bold: PDFFont,
+): void {
+  // One content model for the table (buildAnnotationReport) — complete by
+  // construction (one row per annotation, note summarised + flagged, no
+  // coordinate emitted). The markers reuse the SAME 1-based index.
+  const report = buildAnnotationReport(annotations, {});
+  let offMapCount = 0;
+  annotations.forEach((a, i) => {
+    const index = i + 1;
+    const p = projectAnnotationToPage(a.localPosition, sceneUpAxis, bbox, t);
+    if (!p.insideBbox || p.pageX < inner.x || p.pageX > inner.x + inner.w || p.pageY < inner.y || p.pageY > inner.y + inner.h) {
+      offMapCount++;
+      return;
+    }
+    drawMarker(page, p.pageX, p.pageY, index, ANNOTATION_COLORS[a.type], bold);
+  });
+  drawAnnotationTable(page, frame, report.header, report.rows, offMapCount, font, bold);
+}
+
+/**
+ * One numbered marker: a white halo disc for legibility over the contour ink, a
+ * filled type-coloured dot, and the index in a small knock-out box beside it so
+ * the number reads whatever the dot sits on.
+ */
+function drawMarker(
+  page: PDFPage,
+  px: number,
+  py: number,
+  index: number,
+  color: ReturnType<typeof rgb>,
+  bold: PDFFont,
+): void {
+  // Halo + dot. drawEllipse's x/yScale are the radii; the centre is (px, py) in
+  // the y-up page frame (same frame drawText uses), so no svg-y flip is needed.
+  page.drawEllipse({ x: px, y: py, xScale: 5.2, yScale: 5.2, color: WHITE, opacity: 0.9 });
+  page.drawEllipse({ x: px, y: py, xScale: 3.2, yScale: 3.2, color, borderColor: WHITE, borderWidth: 0.6 });
+  const label = String(index);
+  const sz = 6.5;
+  const w = bold.widthOfTextAtSize(label, sz);
+  // Index knock-out to the upper-right of the dot, so it never disappears into
+  // the dot fill or a dark contour line.
+  const lx = px + 5.5;
+  const ly = py + 1.5;
+  page.drawRectangle({ x: lx - 1, y: ly - 1.5, width: w + 2, height: sz + 1, color: WHITE, opacity: 0.85 });
+  page.drawText(label, { x: lx, y: ly, size: sz, font: bold, color: INK });
+}
+
+/**
+ * The description table in the top-right collar. Rows are SUMMARISED but never
+ * silently dropped: the height is fitted by shrinking the row pitch within
+ * reason, and if the list still overflows the sheet the overflow is called out
+ * with a note recommending a larger sheet size — the surveyor-sheet rule that a
+ * deliverable must recommend a better area rather than hide rows.
+ */
+function drawAnnotationTable(
+  page: PDFPage,
+  frame: { x: number; y: number; w: number; h: number },
+  header: string,
+  rows: ReadonlyArray<AnnotationReportRow>,
+  offMapCount: number,
+  font: PDFFont,
+  bold: PDFFont,
+): void {
+  const pad = 8;
+  const boxW = Math.min(190, frame.w * 0.42);
+  const rightX = frame.x + frame.w - pad;
+  const leftX = rightX - boxW;
+  // The box TOP sits below both orientation indicators (the north-arrow box
+  // bottoms out at frame top − 52; the ungeoreferenced "local grid up" note at
+  // frame top − 36), so the table never collides with the corner. Everything
+  // flows downward from here.
+  const boxTop = frame.y + frame.h - 54;
+  const headSz = 8;
+  const rowSz = 6.5;
+  const headerBaseline = boxTop - 12;
+  // Available vertical run from the header down to a margin above the scale bar.
+  const avail = headerBaseline - (frame.y + 28);
+  const footNote =
+    offMapCount > 0
+      ? `${offMapCount} annotation${offMapCount === 1 ? '' : 's'} outside the map extent - listed, not plotted.`
+      : '';
+  const footLines = footNote ? 1 : 0;
+  const noteRun = rowSz + 4;
+  // Fit the row pitch: start roomy, shrink toward a floor so more rows fit before
+  // we ever recommend a bigger sheet — a surveyor sheet must not silently drop a
+  // row. Only when even the floor pitch overflows do we show a "+N more" note
+  // and recommend a larger sheet size.
+  const minPitch = 7.5;
+  const maxPitch = 10;
+  let pitch = maxPitch;
+  const rowsRun = (): number => rows.length * pitch + footLines * noteRun;
+  while (pitch > minPitch && rowsRun() > avail) pitch -= 0.5;
+  const fitRows = Math.max(0, Math.floor((avail - footLines * noteRun) / pitch));
+  const shown = Math.min(rows.length, Math.max(1, fitRows));
+  const overflowed = shown < rows.length;
+  const overflowRun = overflowed ? noteRun : 0;
+
+  // Background box sized to exactly what is drawn (header + shown rows + notes).
+  const bodyBottom = headerBaseline - 6 - shown * pitch - overflowRun - footLines * noteRun;
+  const boxBottom = bodyBottom - 2;
+  page.drawRectangle({
+    x: leftX - 4, y: boxBottom, width: boxW + 8, height: boxTop - boxBottom,
+    color: WHITE, opacity: 0.9, borderColor: FRAME, borderWidth: 0.5,
+  });
+
+  page.drawText(safe(header), { x: leftX, y: headerBaseline, size: headSz, font: bold, color: INK });
+  page.drawLine({
+    start: { x: leftX, y: headerBaseline - 3 }, end: { x: rightX, y: headerBaseline - 3 },
+    thickness: 0.5, color: FRAME,
+  });
+
+  let y = headerBaseline - 12;
+  const typeX = leftX + bold.widthOfTextAtSize('88', rowSz) + 4;
+  const descX = typeX + font.widthOfTextAtSize('warning', rowSz) + 5;
+  const descMax = rightX - descX;
+  for (let i = 0; i < shown; i++) {
+    const r = rows[i];
+    // "12  warning  Title - note": the index (bold) + type prefix, then the
+    // title and any note on the same line, clipped so nothing runs past the edge.
+    page.drawText(safe(`${r.index}`), { x: leftX, y, size: rowSz, font: bold, color: INK });
+    page.drawText(safe(r.type), { x: typeX, y, size: rowSz, font, color: DIM });
+    const desc = r.note ? `${r.title} - ${r.note}` : r.title;
+    const clipped = clipToWidth(desc, descMax, rowSz, (s, sc) => font.widthOfTextAtSize(safe(s), sc));
+    page.drawText(safe(clipped), { x: descX, y, size: rowSz, font, color: INK });
+    y -= pitch;
+  }
+  if (overflowed) {
+    const more = rows.length - shown;
+    page.drawText(
+      safe(`+${more} more not shown - increase the sheet size to print the full list.`),
+      { x: leftX, y: y - 2, size: rowSz, font: bold, color: rgb(0.6, 0.2, 0.1) },
+    );
+    y -= noteRun;
+  }
+  if (footNote) {
+    page.drawText(safe(footNote), { x: leftX, y: y - 2, size: rowSz, font, color: DIM });
+  }
+}
+
+/** Hard-clip a single line to a max width, appending "…" when it is cut. */
+function clipToWidth(
+  s: string,
+  maxW: number,
+  sz: number,
+  measure: (s: string, sz: number) => number,
+): string {
+  if (maxW <= 0) return '';
+  if (measure(s, sz) <= maxW) return s;
+  let out = s;
+  while (out.length > 0 && measure(`${out}…`, sz) > maxW) out = out.slice(0, -1);
+  return out.length > 0 ? `${out}…` : '';
 }
 
 /** Title block with CRS, datum, scale, accuracy, legend, and provenance. */

--- a/src/render/measure/mapSheetPdf.ts
+++ b/src/render/measure/mapSheetPdf.ts
@@ -607,19 +607,21 @@ function drawMarker(
   color: ReturnType<typeof rgb>,
   bold: PDFFont,
 ): void {
-  // Halo + dot. drawEllipse's x/yScale are the radii; the centre is (px, py) in
-  // the y-up page frame (same frame drawText uses), so no svg-y flip is needed.
-  page.drawEllipse({ x: px, y: py, xScale: 5.2, yScale: 5.2, color: WHITE, opacity: 0.9 });
-  page.drawEllipse({ x: px, y: py, xScale: 3.2, yScale: 3.2, color, borderColor: WHITE, borderWidth: 0.6 });
+  // A waypoint dot that reads over contour ink and belongs to this sepia sheet:
+  // a soft halo lifts it off the graticule, a fine sepia keyline (not a stark
+  // white one) rings the type-coloured disc so it reads as drawn INTO the map,
+  // and the index sits in a tight knock-out to the upper-right in the same
+  // sepia the index-contour labels use. drawEllipse's x/yScale are the radii and
+  // the centre stays exactly (px, py) — the placement the projection guarantees.
+  page.drawEllipse({ x: px, y: py, xScale: 5, yScale: 5, color: WHITE, opacity: 0.92 });
+  page.drawEllipse({ x: px, y: py, xScale: 3.1, yScale: 3.1, color, borderColor: SEPIA_INDEX, borderWidth: 0.5 });
   const label = String(index);
   const sz = 6.5;
   const w = bold.widthOfTextAtSize(label, sz);
-  // Index knock-out to the upper-right of the dot, so it never disappears into
-  // the dot fill or a dark contour line.
-  const lx = px + 5.5;
-  const ly = py + 1.5;
-  page.drawRectangle({ x: lx - 1, y: ly - 1.5, width: w + 2, height: sz + 1, color: WHITE, opacity: 0.85 });
-  page.drawText(label, { x: lx, y: ly, size: sz, font: bold, color: INK });
+  const lx = px + 5.2;
+  const ly = py + 1.6;
+  page.drawRectangle({ x: lx - 1.2, y: ly - 1.4, width: w + 2.4, height: sz + 0.8, color: WHITE, opacity: 0.9 });
+  page.drawText(label, { x: lx, y: ly, size: sz, font: bold, color: SEPIA_INDEX });
 }
 
 /**
@@ -680,21 +682,31 @@ function drawAnnotationTable(
     color: WHITE, opacity: 0.9, borderColor: FRAME, borderWidth: 0.5,
   });
 
-  page.drawText(safe(header), { x: leftX, y: headerBaseline, size: headSz, font: bold, color: INK });
+  // Header set in the sheet's index sepia over a sepia hairline, so the legend
+  // reads as part of the sheet's cartographic type rather than a bolted-on panel.
+  page.drawText(safe(header), { x: leftX, y: headerBaseline, size: headSz, font: bold, color: SEPIA_INDEX });
   page.drawLine({
     start: { x: leftX, y: headerBaseline - 3 }, end: { x: rightX, y: headerBaseline - 3 },
-    thickness: 0.5, color: FRAME,
+    thickness: 0.6, color: SEPIA_INDEX,
   });
 
   let y = headerBaseline - 12;
-  const typeX = leftX + bold.widthOfTextAtSize('88', rowSz) + 4;
+  // A colour swatch leads each row, in that annotation's own type colour — the
+  // same disc drawn on the map. Legend and map become one system: a reader ties
+  // a row to its marker by matching colour and number, not by hunting position.
+  const dotX = leftX + 2.4;
+  const indexX = leftX + 9;
+  const typeX = indexX + bold.widthOfTextAtSize('88', rowSz) + 4;
   const descX = typeX + font.widthOfTextAtSize('warning', rowSz) + 5;
   const descMax = rightX - descX;
   for (let i = 0; i < shown; i++) {
     const r = rows[i];
-    // "12  warning  Title - note": the index (bold) + type prefix, then the
-    // title and any note on the same line, clipped so nothing runs past the edge.
-    page.drawText(safe(`${r.index}`), { x: leftX, y, size: rowSz, font: bold, color: INK });
+    // swatch · index (sepia bold) · type (dim) · "Title - note", clipped to the edge.
+    page.drawEllipse({
+      x: dotX, y: y + rowSz * 0.34, xScale: 2.3, yScale: 2.3,
+      color: ANNOTATION_COLORS[r.type], borderColor: SEPIA_INDEX, borderWidth: 0.4,
+    });
+    page.drawText(safe(`${r.index}`), { x: indexX, y, size: rowSz, font: bold, color: SEPIA_INDEX });
     page.drawText(safe(r.type), { x: typeX, y, size: rowSz, font, color: DIM });
     const desc = r.note ? `${r.title} - ${r.note}` : r.title;
     const clipped = clipToWidth(desc, descMax, rowSz, (s, sc) => font.widthOfTextAtSize(safe(s), sc));

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -70,6 +70,7 @@ import {
 } from '../lazyChunks';
 import { openModal, type ModalHandle } from './Modal';
 import type { SheetSize, SheetOrientation } from '../render/measure/mapSheetPdf';
+import type { Annotation } from '../render/annotate/types';
 import {
   SHEET_OPTIONS,
   ORIENTATION_OPTIONS,
@@ -78,6 +79,7 @@ import {
   defaultMapTitle,
   defaultMapNotes,
   defaultMapFilename,
+  annotationsOptionState,
 } from '../render/measure/mapSheetExportOptions';
 import { TERRAIN_METRIC_VERSION } from '../terrain/datasetIntelligence';
 import {
@@ -174,6 +176,14 @@ export interface AnalysePanelCallbacks {
    * shows. When omitted or null the report simply skips those rows.
    */
   getDatasetIntelligence?: () => DatasetIntelligence | null;
+  /**
+   * The scan's placed annotations, in list order, for the (opt-in) annotation
+   * layer on the map sheet. The marker index is the 1-based list position, so
+   * the host must return them in the SAME order the Annotations panel shows.
+   * Omitted / empty ⇒ the sheet's annotation checkbox is disabled and no layer
+   * is drawn.
+   */
+  getAnnotations?: () => ReadonlyArray<Annotation>;
   /** Context for the printable map sheet (world origin, title block fields). */
   getMapContext?: () => {
     /**
@@ -212,6 +222,14 @@ export interface AnalysePanelCallbacks {
      * shown in an honest "unverified" form, NEVER falsely asserted as metres.
      */
     verticalUnitToMetres?: number | null;
+    /**
+     * The RAW scene up-axis of the loaded scan — the gather's own `sourceUpAxis`
+     * — so the map sheet can rotate an annotation's local position into the same
+     * canonical frame the contours were built in. 'z' for the survey formats a
+     * georeferenced sheet is built from; 'y' for a Y-up phone-scan mesh. Omitted
+     * ⇒ the sheet's 'z' default (identity), correct for every georeferenced case.
+     */
+    sceneUpAxis?: 'z' | 'y';
   };
 }
 
@@ -2275,6 +2293,18 @@ export class AnalysePanel {
     filenameInput.className = 'olv-modal-input';
     filenameInput.value = defaultMapFilename(basename);
 
+    // Annotations opt-in. Default OFF (a plain sheet unless asked for) and
+    // DISABLED when the scan carries none, so the option is discoverable but
+    // clearly unavailable — the enable/label logic is the pure
+    // `annotationsOptionState` so the dialog and its unit tests agree.
+    const annotationCount = this._cb.getAnnotations?.().length ?? 0;
+    const annoState = annotationsOptionState(annotationCount);
+    const annoCheck = document.createElement('input');
+    annoCheck.type = 'checkbox';
+    annoCheck.className = 'olv-modal-check';
+    annoCheck.checked = false;
+    annoCheck.disabled = annoState.disabled;
+
     const editable = el('div', { className: 'olv-modal-grid' });
     editable.append(
       field('Title', titleInput),
@@ -2297,6 +2327,7 @@ export class AnalysePanel {
           : 'Style regeneration unavailable — using the current contours.',
       ),
       field('Output filename', filenameInput, 'A single .pdf is added on download.'),
+      field(annoState.label, annoCheck, annoState.hint),
     );
 
     // ── locked / auto section (read-only) ────────────────────────────────────
@@ -2392,6 +2423,9 @@ export class AnalysePanel {
             filename: filenameInput.value,
             worldOrigin: ctx.worldOrigin ?? null,
             generatedAt,
+            // A disabled checkbox can never be checked, so a scan with no
+            // annotations always exports the plain sheet.
+            includeAnnotations: annoCheck.checked,
           });
           // Remember the user's choices for the rest of the session.
           lastPreparedBy = preparedInput.value;
@@ -2424,6 +2458,8 @@ export class AnalysePanel {
       filename: string;
       worldOrigin: { x: number; y: number; z?: number } | null;
       generatedAt: Date;
+      /** Draw the (opt-in) annotation layer on the sheet. */
+      includeAnnotations: boolean;
     },
   ): Promise<void> {
     // §19 ENFORCEMENT: the map sheet is a gated contour deliverable. It is only
@@ -2440,8 +2476,17 @@ export class AnalysePanel {
     const { buildMapSheetPdf } = await loadMapSheetPdf();
     const { buildExportProvenance } = await loadExportProvenance();
     // Resolved linear unit so the sheet's scale bar + 1:N ratio honour a foot
-    // CRS (the map is drawn in source units) instead of the metre default.
-    const linearUnit = this._cb.getMapContext?.()?.linearUnit;
+    // CRS (the map is drawn in source units) instead of the metre default. Read
+    // the map context ONCE — it also supplies the scene up-axis the annotation
+    // markers are rotated by.
+    const mapCtx = this._cb.getMapContext?.();
+    const linearUnit = mapCtx?.linearUnit;
+    // Annotation layer inputs, only gathered when the user opted in. The list is
+    // read straight from the host (same order as the Annotations panel, so the
+    // marker index matches). The up-axis MUST be the gather's own — see the
+    // frame reasoning in annotationMapProjection.ts.
+    const annotations = opts.includeAnnotations ? this._cb.getAnnotations?.() ?? [] : [];
+    const sceneUpAxis = mapCtx?.sceneUpAxis ?? 'z';
     // The unified provenance, derived from the SAME result the sheet plots, so
     // the title block's CRS / datum / style / accuracy / readiness / date can't
     // drift from the GeoJSON / DXF / SVG / DEM exports of this scan.
@@ -2474,6 +2519,9 @@ export class AnalysePanel {
       sheet: opts.sheet,
       orientation: opts.orientation,
       generatedAt: opts.generatedAt,
+      includeAnnotations: opts.includeAnnotations,
+      annotations,
+      sceneUpAxis,
     });
     triggerDownload(
       new Blob([bytes as BlobPart], { type: 'application/pdf' }),

--- a/tests/annotationMapProjection.test.ts
+++ b/tests/annotationMapProjection.test.ts
@@ -1,0 +1,70 @@
+/**
+ * annotationMapProjection.test.ts
+ *
+ * The map sheet plots each annotation as a marker, and a marker in the wrong
+ * place on a georeferenced sheet is worse than no marker at all — it asserts a
+ * location the data does not support. This file pins the ONE piece of maths that
+ * decides where a marker lands: the frame conversion + the page projection.
+ *
+ * The load-bearing fact (see the helper's own comment): the contour model is
+ * built in the CANONICAL Z-up survey frame, while an annotation's localPosition
+ * is in the RAW scene frame the cloud is drawn from. A Z-up scene needs no
+ * rotation; a Y-up scene needs the same (x,y,z)→(x,-z,y) rotation the terrain
+ * gather applied, so the marker sits on the contour it was placed over. Getting
+ * this wrong plots the marker off-map or mirrored — the exact failure the
+ * canonical-frame module warns about.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  annotationToMapXY,
+  projectAnnotationToPage,
+} from '../src/render/measure/annotationMapProjection';
+
+describe('annotationToMapXY — scene frame → map (contour) frame', () => {
+  it('a Z-up scene needs no rotation: horizontal is (x, y)', () => {
+    expect(annotationToMapXY({ x: 30, y: 40, z: 200 }, 'z')).toEqual({ x: 30, y: 40 });
+  });
+
+  it('a Y-up scene rotates like the terrain gather: (x, y, z) → map (x, -z)', () => {
+    // The gather rotates a Y-up buffer (x,y,z)→(x,-z,y); the first two canonical
+    // components are (x, -z). Elevation (scene y) drops out of the ground plan.
+    expect(annotationToMapXY({ x: 30, y: 200, z: -40 }, 'y')).toEqual({ x: 30, y: 40 });
+  });
+});
+
+describe('projectAnnotationToPage — hand-computed page placement', () => {
+  // A square ground bbox 0..100 in both axes, mapped by an identity-ish fit
+  // transform: scale 2 page-pt per ground unit, page origin (ox, oy) = (12, 20).
+  //   pageX = ox + (mapX - minX) * scale
+  //   pageY = oy + (mapY - minY) * scale
+  const bbox = { minX: 0, minY: 0, maxX: 100, maxY: 100 };
+  const t = { ox: 12, oy: 20, scale: 2 };
+
+  it('places a Z-up annotation inside the bbox at the computed page point', () => {
+    // local (25, 60) → map (25, 60) → pageX = 12 + 25*2 = 62, pageY = 20 + 60*2 = 140.
+    const p = projectAnnotationToPage({ x: 25, y: 60, z: 999 }, 'z', bbox, t);
+    expect(p.insideBbox).toBe(true);
+    expect(p.pageX).toBeCloseTo(62, 6);
+    expect(p.pageY).toBeCloseTo(140, 6);
+  });
+
+  it('flags an annotation outside the bbox (still projected, not placed on the map)', () => {
+    // local (150, 60) → map (150, 60): mapX 150 > maxX 100, so it is off-map.
+    const p = projectAnnotationToPage({ x: 150, y: 60, z: 0 }, 'z', bbox, t);
+    expect(p.insideBbox).toBe(false);
+  });
+
+  it('projects a Y-up annotation through the rotation before the fit transform', () => {
+    // local (25, 999, -60) with a Y-up scene → map (25, 60) → same page point as
+    // the Z-up case above. Proves the rotation happens BEFORE the projection.
+    const p = projectAnnotationToPage({ x: 25, y: 999, z: -60 }, 'y', bbox, t);
+    expect(p.insideBbox).toBe(true);
+    expect(p.pageX).toBeCloseTo(62, 6);
+    expect(p.pageY).toBeCloseTo(140, 6);
+  });
+
+  it('treats the bbox edges as inside (inclusive)', () => {
+    expect(projectAnnotationToPage({ x: 0, y: 0, z: 0 }, 'z', bbox, t).insideBbox).toBe(true);
+    expect(projectAnnotationToPage({ x: 100, y: 100, z: 0 }, 'z', bbox, t).insideBbox).toBe(true);
+  });
+});

--- a/tests/annotationReportTable.test.ts
+++ b/tests/annotationReportTable.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The annotation table printed on a map-drawing PDF makes a claim to whoever
+ * reads the sheet, so the model that builds it carries the honesty rules and
+ * this file pins them:
+ *
+ *  - COMPLETE means every annotation appears. Not every field — every row. A
+ *    surveyor deliverable that silently omitted an annotation would be the
+ *    selective-reporting failure the whole app avoids, so `rows.length` must
+ *    always equal the annotation count.
+ *  - The note is the one unbounded field. It is summarised to a cap, and when
+ *    it is cut the row says so (`noteTruncated`), because a silent trim drops
+ *    information the reader cannot tell is missing.
+ *  - No coordinate is emitted. `Annotation.position` is local render-space, and
+ *    printing it on a client deliverable would claim a surveyed location it does
+ *    not have. The map shows where; the table describes what.
+ *  - The header states the count, so a summarised table cannot be mistaken for
+ *    a claim that nothing is hidden.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Annotation } from '../src/render/annotate/types';
+import { buildAnnotationReport } from '../src/render/measure/annotationReportTable';
+
+const ann = (over: Partial<Annotation>): Annotation => ({
+  id: over.id ?? 'a',
+  title: over.title ?? 'Title',
+  note: over.note,
+  type: over.type ?? 'note',
+  createdAt: 0,
+  updatedAt: 0,
+  localPosition: over.localPosition ?? { x: 0, y: 0, z: 0 },
+  ...over,
+}) as Annotation;
+
+describe('buildAnnotationReport', () => {
+  it('emits one row per annotation, in order — nothing dropped', () => {
+    const list = [ann({ id: '1', title: 'A' }), ann({ id: '2', title: 'B' }), ann({ id: '3', title: 'C' })];
+    const report = buildAnnotationReport(list, {});
+    expect(report.rows).toHaveLength(3);
+    expect(report.rows.map((r) => r.title)).toEqual(['A', 'B', 'C']);
+    expect(report.rows.map((r) => r.index)).toEqual([1, 2, 3]);
+  });
+
+  it('states the total count in the header', () => {
+    expect(buildAnnotationReport([ann({}), ann({})], {}).header).toBe('Annotations (2)');
+    expect(buildAnnotationReport([], {}).header).toBe('Annotations (0)');
+  });
+
+  it('summarises a long note and flags the cut', () => {
+    const long = 'x'.repeat(300);
+    const report = buildAnnotationReport([ann({ note: long })], { maxNoteChars: 40 });
+    const row = report.rows[0]!;
+    expect(row.noteTruncated).toBe(true);
+    expect(row.note.length).toBeLessThanOrEqual(41); // cap + ellipsis
+    expect(row.note.endsWith('…')).toBe(true);
+  });
+
+  it('does not flag a note that fits', () => {
+    const report = buildAnnotationReport([ann({ note: 'short' })], { maxNoteChars: 40 });
+    expect(report.rows[0]!.noteTruncated).toBe(false);
+    expect(report.rows[0]!.note).toBe('short');
+  });
+
+  it('carries a missing note as an empty string, still a complete row', () => {
+    const report = buildAnnotationReport([ann({ note: undefined })], {});
+    expect(report.rows).toHaveLength(1);
+    expect(report.rows[0]!.note).toBe('');
+    expect(report.rows[0]!.noteTruncated).toBe(false);
+  });
+
+  it('never emits a coordinate or position field on a row', () => {
+    const report = buildAnnotationReport([ann({ localPosition: { x: 517084, y: 4645003, z: 58 } })], {});
+    const keys = Object.keys(report.rows[0]!);
+    expect(keys).not.toContain('localPosition');
+    expect(keys).not.toContain('position');
+    expect(keys).not.toContain('x');
+    expect(keys).not.toContain('easting');
+    // and no row value stringifies the coordinate
+    expect(JSON.stringify(report.rows[0])).not.toContain('517084');
+  });
+
+  it('carries the type so the row says what kind of thing it marks', () => {
+    const report = buildAnnotationReport([ann({ type: 'warning' })], {});
+    expect(report.rows[0]!.type).toBe('warning');
+  });
+
+  it('trims whitespace in title and note so blank-looking values do not masquerade as content', () => {
+    const report = buildAnnotationReport([ann({ title: '  A  ', note: '  n  ' })], {});
+    expect(report.rows[0]!.title).toBe('A');
+    expect(report.rows[0]!.note).toBe('n');
+  });
+});

--- a/tests/mapSheetExportOptions.test.ts
+++ b/tests/mapSheetExportOptions.test.ts
@@ -13,6 +13,7 @@ import {
   defaultMapTitle,
   defaultMapNotes,
   defaultMapFilename,
+  annotationsOptionState,
 } from '../src/render/measure/mapSheetExportOptions';
 
 describe('option lists', () => {
@@ -105,5 +106,22 @@ describe('defaultMapFilename', () => {
   it('is a sanitised <basename>-map', () => {
     expect(defaultMapFilename('El Picacho')).toBe('El-Picacho-map');
     expect(defaultMapFilename('')).toBe('contours-map');
+  });
+});
+
+describe('annotationsOptionState — the opt-in checkbox', () => {
+  it('is disabled with an explanatory hint when the scan has no annotations', () => {
+    const s = annotationsOptionState(0);
+    expect(s.disabled).toBe(true);
+    expect(s.hint).toMatch(/no annotations/i);
+  });
+  it('is enabled and counts the annotations when there are some', () => {
+    const s = annotationsOptionState(3);
+    expect(s.disabled).toBe(false);
+    expect(s.hint).toContain('3 placed annotations');
+  });
+  it('uses a singular for exactly one annotation', () => {
+    expect(annotationsOptionState(1).hint).toContain('1 placed annotation');
+    expect(annotationsOptionState(1).hint).not.toContain('annotations');
   });
 });

--- a/tests/mapSheetPdf.test.ts
+++ b/tests/mapSheetPdf.test.ts
@@ -11,6 +11,7 @@ import {
   mapLinearUnitLabel,
 } from '../src/render/measure/mapSheetPdf';
 import type { ContourFeatureModel, ContourFeature } from '../src/terrain/contour/contourFeatureModel';
+import type { Annotation } from '../src/render/annotate/types';
 import { demAccuracyStandards } from '../src/terrain/quality/demAccuracyStandards';
 import type { ExportProvenance } from '../src/terrain/export/exportProvenance';
 
@@ -210,6 +211,46 @@ describe('buildMapSheetPdf', () => {
       notes: longNotes,
       sheet: 'a3',
       orientation: 'portrait',
+    });
+    expect(String.fromCharCode(...bytes.slice(0, 5))).toBe('%PDF-');
+  });
+
+  // ── annotation layer (opt-in) ──────────────────────────────────────────────
+  // A placed annotation carries a local render-space anchor; the sheet plots it
+  // as a numbered marker + lists it in a top-right table. The exact page maths
+  // is unit-tested in annotationMapProjection.test.ts; here we pin the two
+  // contracts that live in the PDF builder: opting in draws MORE content, and
+  // leaving it off (or absent) is byte-identical to the pre-annotation sheet.
+  const anno = (id: string, x: number, y: number, z = 0): Annotation => ({
+    id, title: `Point ${id}`, type: 'warning', note: 'note', createdAt: 0, updatedAt: 0,
+    localPosition: { x, y, z },
+  });
+
+  it('is byte-identical whether the annotation flag is OFF or absent', async () => {
+    const base = { model, labels: [], crs: model.crs, verticalDatum: model.verticalDatum, sheet: 'letter' as const };
+    const absent = await buildMapSheetPdf({ ...base });
+    const off = await buildMapSheetPdf({ ...base, includeAnnotations: false, annotations: [anno('1', 25, 60)], sceneUpAxis: 'z' });
+    expect(Buffer.from(off).equals(Buffer.from(absent))).toBe(true);
+  });
+
+  it('draws additional content when annotations are included', async () => {
+    const base = { model, labels: [], crs: model.crs, verticalDatum: model.verticalDatum, sheet: 'letter' as const };
+    const plain = await buildMapSheetPdf({ ...base });
+    const withAnno = await buildMapSheetPdf({
+      ...base, includeAnnotations: true, sceneUpAxis: 'z',
+      annotations: [anno('1', 25, 60), anno('2', 80, 20)],
+    });
+    // The annotated sheet must be strictly larger (markers + table) and valid.
+    expect(withAnno.length).toBeGreaterThan(plain.length);
+    expect(String.fromCharCode(...withAnno.slice(0, 5))).toBe('%PDF-');
+  });
+
+  it('renders even when every annotation is outside the map extent', async () => {
+    // All off-map: none plotted, but the table + a footnote still render.
+    const bytes = await buildMapSheetPdf({
+      model, labels: [], crs: model.crs, sheet: 'letter',
+      includeAnnotations: true, sceneUpAxis: 'z',
+      annotations: [anno('1', 500, 500), anno('2', -400, -400)],
     });
     expect(String.fromCharCode(...bytes.slice(0, 5))).toBe('%PDF-');
   });


### PR DESCRIPTION
## What this adds

Numbered annotation markers on the contour Map Sheet PDF, plus an "Annotations (N)" table in the collar. Each measurement annotation gets a numbered marker placed at its projected map position and a matching row in the collar table.

New modules:
- `src/render/measure/annotationMapProjection.ts` — projects annotation positions into map-sheet coordinates
- `src/render/measure/annotationReportTable.ts` — builds the collar annotations table
- `src/render/measure/mapSheetExportOptions.ts` — export options plumbing
- Markers + table rendering wired into `src/render/measure/mapSheetPdf.ts`, surfaced through `AnalysePanel`, `terrainAnalysisRunner`, and `main.ts`.

## Verification

- `npm run typecheck`: 0 errors.
- Annotation suites (`mapSheetPdf`, `annotationMapProjection`, `annotationReportTable`, `mapSheetExportOptions`): 57 passed.
- Full `vitest run`: 7600 passed / 23 skipped. One unrelated timeout (`terrainRunnerDensityWiring.test.ts`, untouched by this branch) that passes cleanly in isolation — a full-suite CPU-contention flake against the 15s per-test limit, not a regression.

The markers and collar table were device-verified during development. What CI cannot check is the final rendered PDF: a reviewer should do a last on-device look at an exported Map Sheet to confirm marker placement and table layout read correctly in the printed output.
