### PR TITLE
Extract colour-legend/range reads from Viewer into colorLegend

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.3.md
+++ b/KNOWN_LIMITATIONS_v0.6.3.md
@@ -6,7 +6,7 @@ Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 7,323 lines and `src/render/Viewer.ts` is 7,073, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 7,323 lines and `src/render/Viewer.ts` is 6,959, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -117,7 +117,7 @@ candidates:
 | `generateReportPdf` / `exportGeoContext` | 402 | export/report wiring module |
 | `importSession` | 177 | `src/app/sessionIo.ts` *(planned)* |
 
-**`src/render/Viewer.ts` (7,073)** — the constructor and a handful of large
+**`src/render/Viewer.ts` (6,959)** — the constructor and a handful of large
 methods dominate:
 
 Spans below are the symbol's real extent, read from the TypeScript symbol graph
@@ -135,6 +135,12 @@ Done: `_buildExportAdapter` (265 lines) now lives in `src/render/exportAdapter.t
 which takes a structural host rather than the Viewer, so the Studio's scene
 reads are unit-testable without a WebGL context (`tests/exportAdapter.test.ts`).
 `Viewer` keeps a twelve-line factory that binds its own state to that host.
+
+Done: the colour-legend / scalar-range reads (`activeColorbar`, `elevationExtent`,
+`intensityExtent`) now live in `src/render/colorLegend.ts` behind the same host
+shape, so the origin math, seeded gating and extent scans test without a WebGL
+context (`tests/viewerActiveColorbar.test.ts`). `Viewer` keeps three thin
+delegates and one host binding.
 
 Each extraction is one gated step: move the block, have it take its collaborators
 as parameters, keep the deterministic e2e project green, and re-run the coverage

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -5,7 +5,7 @@
       "goal": 2500
     },
     "src/render/Viewer.ts": {
-      "lines": 7073,
+      "lines": 6959,
       "goal": 2000
     }
   }

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -65,6 +65,7 @@ import {
 
 import type { PointCloud } from '../model/PointCloud';
 import { buildExportAdapter } from './exportAdapter';
+import { buildColorLegend, type ColorLegend } from './colorLegend';
 import { resolveSceneOrigin } from '../io/coordinateBridge';
 import type { ClassVisibility } from './class/classVisibility';
 import { buildPointFilterAccept } from './pointFilterAccept';
@@ -83,13 +84,9 @@ import { isZUpFormat, sceneUpAxisPolicy } from '../io/sniffFormat';
 import { classifyScanShape } from '../terrain/scanShape';
 import { yUpToCanonicalZUp } from '../terrain/canonicalFrame';
 import type { SourceFormat } from '../io/sniffFormat';
-import { colorForMode, defaultMode, rampRangeForMode } from './colorModes';
+import { colorForMode, defaultMode } from './colorModes';
 import type { ColorMode, CoverageColorGrid } from './colorModes';
-import {
-  buildActiveColorbarSpec,
-  burnInColorbarLayout,
-  type ActiveColorbar,
-} from './activeColorbar';
+import { burnInColorbarLayout, type ActiveColorbar } from './activeColorbar';
 import { colorbarStops, niceTicks, formatColorbarValue } from './colorbar';
 import { type ClipBox, clipKeepsPoint, countKept } from './clip/clipBox';
 import { edlDefaultEnabled, EDL_DEFAULTS, EDL_DEPTH_BIAS } from './edl';
@@ -1130,6 +1127,23 @@ export class Viewer {
    * camera reprojection. RAF-debounce collapses them to one per frame.
    */
   private _resizeRafId: number | null = null;
+
+  /** Colour-legend + scalar-range reads, bound to this Viewer's live state. */
+  private readonly _colorLegend: ColorLegend = buildColorLegend({
+    activeColorMode: () => this.activeColorMode(),
+    firstStaticCloud: () => this._clouds.values().next().value?.cloud ?? null,
+    streaming: () => this._streaming,
+    heightPercentileTrim: () => this._heightPercentileTrim,
+    elevationUnitLabel: () => this._elevationUnitLabel,
+    worldUpIsZ: () => this._worldUp.z === 1,
+    residentIntensityBuffers: () => {
+      const buffers: ArrayLike<number>[] = [];
+      for (const { decoded } of this._streamingPickData.values()) {
+        if (decoded.intensity && decoded.intensity.length > 0) buffers.push(decoded.intensity);
+      }
+      return buffers;
+    },
+  });
 
   // ── Picking tools (measure / inspect) ────────────────────────────────────
   private readonly _canvas: HTMLCanvasElement;
@@ -2363,93 +2377,13 @@ export class Viewer {
   }
 
   /**
-   * The colorbar for the ACTIVE colour mode, or null when the mode carries
-   * no continuous legend. This is the single source both consumers read:
-   * the live overlay (via the host) and the snapshot burn-in — so the PNG
-   * a user exports always matches the legend they saw.
-   *
-   * Static clouds: the range comes from {@link rampRangeForMode} — the very
-   * function `colorForMode` painted with — evaluated against the FIRST
-   * static cloud (the same dispatch `activeColorMode` uses; in the rare
-   * multi-cloud scene each cloud ramps its own window and the legend
-   * honestly describes the primary one). Elevation adds the cloud's origin
-   * back so the labels read world/source values, not render-local ones.
-   *
-   * Streaming clouds: the ranges are read VERBATIM from the renderer's
-   * seeded cloud-global windows — recomputing them here would race the
-   * reseed. Before the first seed only elevation is labelable (header cube
-   * extent, no trim); the other scalar fields are 0..1 placeholders and
-   * yield null. The seeded elevation/gpsTime windows come from the
-   * percentile-clipped core (default p5–p95), which is what the note
-   * discloses. NOTE: the streaming reseed path does not (yet) honour the
-   * height-trim slider — it always clips at the default p5–p95 — so the
-   * legend reports that fixed window rather than pretending the slider
-   * applied (see StreamingRenderer.onNodeReady).
+   * The colorbar for the ACTIVE colour mode, or null when the mode carries no
+   * continuous legend. The single source both consumers read — the live
+   * overlay (via the host) and the snapshot burn-in — so the exported PNG
+   * matches the legend the user saw. Logic lives in {@link buildColorLegend}.
    */
   activeColorbar(): ActiveColorbar | null {
-    const mode = this.activeColorMode();
-    if (this._streaming) {
-      const r = this._streaming.renderer.colorRanges;
-      const seeded = this._streaming.renderer.colorRangesSeeded;
-      // Streaming sources are LAS-derived and Z-up by spec; positions are
-      // render-local, so add the render origin's Z back for display.
-      const zOff = this._streaming.cloud.renderOrigin[2];
-      let range: { min: number; max: number } | null = null;
-      let trim = 0;
-      switch (mode) {
-        case 'elevation':
-          range = { min: r.minZ + zOff, max: r.maxZ + zOff };
-          // Seeded window = computeElevationRange defaults (p5–p95);
-          // pre-seed = raw header cube (no trim to disclose).
-          trim = seeded ? 5 : 0;
-          break;
-        case 'intensity':
-          range = seeded ? { min: r.minIntensity, max: r.maxIntensity } : null;
-          break;
-        case 'gpsTime':
-          range = seeded ? { min: r.minGpsTime, max: r.maxGpsTime } : null;
-          // computeScalarRange defaults — see StreamingRenderer.onNodeReady.
-          trim = 5;
-          break;
-        case 'returnNumber':
-          range = seeded ? { min: r.minReturnNumber, max: r.maxReturnNumber } : null;
-          break;
-        default:
-          return null;
-      }
-      return buildActiveColorbarSpec({
-        mode,
-        range,
-        trimPercent: trim,
-        elevationUnit: this._elevationUnitLabel,
-      });
-    }
-    const entry = this._clouds.values().next().value;
-    if (!entry) return null;
-    const upAxis = isZUpFormat(entry.cloud.sourceFormat) ? 2 : 1;
-    const range = rampRangeForMode(mode, entry.cloud, {
-      heightPercentileTrim: this._heightPercentileTrim,
-      upAxis,
-    });
-    if (!range) return null;
-    // Elevation ranges come out in render-local coordinates (the loader
-    // subtracted `origin`); add the up-axis origin back so the legend reads
-    // true world/source heights — the same reconstruction elevationExtent()
-    // performs for the filter controls.
-    const display =
-      mode === 'elevation'
-        ? {
-            min: range.min + entry.cloud.sourceOrigin[upAxis],
-            max: range.max + entry.cloud.sourceOrigin[upAxis],
-          }
-        : range;
-    return buildActiveColorbarSpec({
-      mode,
-      range: display,
-      trimPercent:
-        mode === 'elevation' ? this._heightPercentileTrim : mode === 'gpsTime' ? 5 : 0,
-      elevationUnit: this._elevationUnitLabel,
-    });
+    return this._colorLegend.activeColorbar();
   }
 
   /**
@@ -3680,32 +3614,12 @@ export class Viewer {
   }
 
   /**
-   * The first static cloud's elevation extent in world/source units, along the
-   * current up-axis, for seeding the elevation-filter control. `bounds()` is in
-   * local (origin-shifted) space, so the world extent adds the cloud's origin
-   * back. Returns null when no static cloud is loaded (e.g. a streaming-only
-   * session), leaving the control to accept typed values.
+   * The first static cloud's elevation extent in world/source units, for seeding
+   * the elevation-filter control. Streaming falls back to the header data
+   * bounds. Null when nothing is loaded. Logic lives in {@link buildColorLegend}.
    */
   elevationExtent(): { min: number; max: number } | null {
-    const axisIdx = this._worldUp.z === 1 ? 2 : 1;
-    const entry = this._clouds.values().next().value;
-    if (entry) {
-      const b = entry.cloud.bounds();
-      const o = entry.cloud.sourceOrigin[axisIdx];
-      return { min: b.min[axisIdx] + o, max: b.max[axisIdx] + o };
-    }
-    // Streaming: the tight data bounds come from the file header (known at open,
-    // stable as nodes stream in), so the elevation control seeds once and never
-    // reseeds. Convert the attribute-space bound back to world with the render
-    // origin, matching the static branch above.
-    const sc = this._streaming?.cloud;
-    if (sc) {
-      // Box6 is [minX,minY,minZ, maxX,maxY,maxZ]; the max lives at axisIdx + 3.
-      const b = sc.dataBounds();
-      const o = sc.renderOrigin[axisIdx];
-      return { min: b[axisIdx] + o, max: b[axisIdx + 3] + o };
-    }
-    return null;
+    return this._colorLegend.elevationExtent();
   }
 
   /**
@@ -3730,39 +3644,11 @@ export class Viewer {
 
   /**
    * The first static cloud's intensity min/max, for seeding the intensity-filter
-   * control. Returns null when no static cloud is loaded or the cloud has no
-   * intensity channel. O(n) over the intensity array — run once on load.
+   * control. Streaming scans the resident chunks. Null when nothing is loaded or
+   * the cloud has no intensity channel. Logic lives in {@link buildColorLegend}.
    */
   intensityExtent(): { min: number; max: number } | null {
-    const entry = this._clouds.values().next().value;
-    const inten = entry?.cloud.intensity;
-    if (inten && inten.length > 0) return this._intensityRange([inten]);
-    // Streaming: LAS headers carry no intensity range, so scan the resident
-    // chunks' intensity buffers. Called once when the streaming scan seeds its
-    // control (not per node), so the O(resident) pass is paid a single time and
-    // the extent stays stable even as more nodes stream in.
-    if (this._streaming?.cloud) {
-      const buffers: ArrayLike<number>[] = [];
-      for (const { decoded } of this._streamingPickData.values()) {
-        if (decoded.intensity && decoded.intensity.length > 0) buffers.push(decoded.intensity);
-      }
-      return buffers.length > 0 ? this._intensityRange(buffers) : null;
-    }
-    return null;
-  }
-
-  /** Min/max over one or more intensity buffers, or null when none are finite. */
-  private _intensityRange(buffers: readonly ArrayLike<number>[]): { min: number; max: number } | null {
-    let min = Infinity;
-    let max = -Infinity;
-    for (const buf of buffers) {
-      for (let i = 0; i < buf.length; i++) {
-        const v = buf[i];
-        if (v < min) min = v;
-        if (v > max) max = v;
-      }
-    }
-    return Number.isFinite(min) && Number.isFinite(max) ? { min, max } : null;
+    return this._colorLegend.intensityExtent();
   }
 
   /**

--- a/src/render/colorLegend.ts
+++ b/src/render/colorLegend.ts
@@ -1,0 +1,210 @@
+/**
+ * colorLegend.ts — the colour-legend and scalar-range reads the Viewer answers.
+ *
+ * Three questions the UI asks about the active scalar colouring: what the
+ * legend should say ({@link ColorLegend.activeColorbar}), and the world-unit
+ * extents that seed the elevation and intensity filter controls
+ * ({@link ColorLegend.elevationExtent}, {@link ColorLegend.intensityExtent}).
+ * All three are pure reads over live scene state, so they move out of the
+ * Viewer behind a structural {@link ColorLegendHost} and become testable
+ * without a WebGL context — the same seam the export adapter uses. `Viewer`
+ * keeps thin methods that bind its own state to the host.
+ *
+ * Every read answers streaming-first, then folds to the first static cloud: a
+ * scan is either one streaming source with authoritative header metadata or a
+ * set of loaded files. Part of the v0.6 decomposition (see
+ * `docs/architecture/architecture-map.md`).
+ */
+
+import { rampRangeForMode, type ColorMode } from './colorModes';
+import { buildActiveColorbarSpec, type ActiveColorbar } from './activeColorbar';
+import { isZUpFormat } from '../io/sniffFormat';
+import type { PointCloud } from '../model/PointCloud';
+import type { StreamingColorRanges } from './streaming/streamingColors';
+
+/** The streaming slice the legend reads — a structural subset of the session. */
+export interface ColorLegendStreaming {
+  readonly renderer: {
+    readonly colorRanges: StreamingColorRanges;
+    readonly colorRangesSeeded: boolean;
+  };
+  readonly cloud: {
+    readonly renderOrigin: readonly [number, number, number];
+    dataBounds(): readonly [number, number, number, number, number, number];
+  };
+}
+
+/**
+ * What the legend needs from the live scene. Accessors are functions, not
+ * snapshots, so a stored {@link ColorLegend} always reflects the CURRENT scene.
+ */
+export interface ColorLegendHost {
+  activeColorMode(): ColorMode;
+  /** The primary (first) static cloud, or null in a streaming-only/empty scene. */
+  firstStaticCloud(): PointCloud | null;
+  streaming(): ColorLegendStreaming | null;
+  heightPercentileTrim(): number;
+  /** CRS-resolved elevation unit ('m' / 'ft'), or null when unknown. */
+  elevationUnitLabel(): string | null;
+  worldUpIsZ(): boolean;
+  /** Resident streaming intensity buffers, non-empty only, for the extent scan. */
+  residentIntensityBuffers(): readonly ArrayLike<number>[];
+}
+
+export interface ColorLegend {
+  activeColorbar(): ActiveColorbar | null;
+  elevationExtent(): { min: number; max: number } | null;
+  intensityExtent(): { min: number; max: number } | null;
+}
+
+/** Min/max over one or more intensity buffers, or null when none are finite. */
+function intensityRange(
+  buffers: readonly ArrayLike<number>[],
+): { min: number; max: number } | null {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const buf of buffers) {
+    for (let i = 0; i < buf.length; i++) {
+      const v = buf[i];
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  return Number.isFinite(min) && Number.isFinite(max) ? { min, max } : null;
+}
+
+/** Build the colour-legend / range reads the Viewer delegates to. */
+export function buildColorLegend(host: ColorLegendHost): ColorLegend {
+  return {
+    /**
+     * The colorbar for the ACTIVE colour mode, or null when the mode carries
+     * no continuous legend. One source for both consumers — the live overlay
+     * and the snapshot burn-in — so the exported PNG matches the on-screen
+     * legend.
+     *
+     * Static clouds: the range comes from `rampRangeForMode` (the function
+     * `colorForMode` painted with) against the first static cloud; elevation
+     * adds the cloud's origin back so the labels read world/source heights.
+     *
+     * Streaming clouds: ranges are read VERBATIM from the renderer's seeded
+     * cloud-global windows — recomputing here would race the reseed. Pre-seed,
+     * only elevation is labelable (header cube extent); the other scalar
+     * fields are placeholders and yield null. The streaming reseed always
+     * clips at the default p5–p95, so the legend reports that fixed window
+     * (see StreamingRenderer.onNodeReady).
+     */
+    activeColorbar(): ActiveColorbar | null {
+      const mode = host.activeColorMode();
+      const streaming = host.streaming();
+      if (streaming) {
+        const r = streaming.renderer.colorRanges;
+        const seeded = streaming.renderer.colorRangesSeeded;
+        // Streaming sources are LAS-derived and Z-up by spec; positions are
+        // render-local, so add the render origin's Z back for display.
+        const zOff = streaming.cloud.renderOrigin[2];
+        let range: { min: number; max: number } | null = null;
+        let trim = 0;
+        switch (mode) {
+          case 'elevation':
+            range = { min: r.minZ + zOff, max: r.maxZ + zOff };
+            // Seeded window = computeElevationRange defaults (p5–p95);
+            // pre-seed = raw header cube (no trim to disclose).
+            trim = seeded ? 5 : 0;
+            break;
+          case 'intensity':
+            range = seeded ? { min: r.minIntensity, max: r.maxIntensity } : null;
+            break;
+          case 'gpsTime':
+            range = seeded ? { min: r.minGpsTime, max: r.maxGpsTime } : null;
+            // computeScalarRange defaults — see StreamingRenderer.onNodeReady.
+            trim = 5;
+            break;
+          case 'returnNumber':
+            range = seeded ? { min: r.minReturnNumber, max: r.maxReturnNumber } : null;
+            break;
+          default:
+            return null;
+        }
+        return buildActiveColorbarSpec({
+          mode,
+          range,
+          trimPercent: trim,
+          elevationUnit: host.elevationUnitLabel(),
+        });
+      }
+      const cloud = host.firstStaticCloud();
+      if (!cloud) return null;
+      const upAxis = isZUpFormat(cloud.sourceFormat) ? 2 : 1;
+      const range = rampRangeForMode(mode, cloud, {
+        heightPercentileTrim: host.heightPercentileTrim(),
+        upAxis,
+      });
+      if (!range) return null;
+      // Elevation ranges come out in render-local coordinates (the loader
+      // subtracted `origin`); add the up-axis origin back so the legend reads
+      // true world/source heights — the same reconstruction elevationExtent()
+      // performs for the filter controls.
+      const display =
+        mode === 'elevation'
+          ? {
+              min: range.min + cloud.sourceOrigin[upAxis],
+              max: range.max + cloud.sourceOrigin[upAxis],
+            }
+          : range;
+      return buildActiveColorbarSpec({
+        mode,
+        range: display,
+        trimPercent:
+          mode === 'elevation' ? host.heightPercentileTrim() : mode === 'gpsTime' ? 5 : 0,
+        elevationUnit: host.elevationUnitLabel(),
+      });
+    },
+
+    /**
+     * The first static cloud's elevation extent in world/source units, along
+     * the current up-axis, for seeding the elevation-filter control. `bounds()`
+     * is local (origin-shifted), so the world extent adds the cloud's origin
+     * back. Streaming falls back to the header data bounds. Null when nothing
+     * is loaded, leaving the control to accept typed values.
+     */
+    elevationExtent(): { min: number; max: number } | null {
+      const axisIdx = host.worldUpIsZ() ? 2 : 1;
+      const cloud = host.firstStaticCloud();
+      if (cloud) {
+        const b = cloud.bounds();
+        const o = cloud.sourceOrigin[axisIdx];
+        return { min: b.min[axisIdx] + o, max: b.max[axisIdx] + o };
+      }
+      // Streaming: the tight data bounds come from the file header (known at
+      // open, stable as nodes stream in), so the control seeds once. Convert
+      // the attribute-space bound back to world with the render origin.
+      const streaming = host.streaming();
+      if (streaming) {
+        // Box6 is [minX,minY,minZ, maxX,maxY,maxZ]; the max lives at axisIdx + 3.
+        const b = streaming.cloud.dataBounds();
+        const o = streaming.cloud.renderOrigin[axisIdx];
+        return { min: b[axisIdx] + o, max: b[axisIdx + 3] + o };
+      }
+      return null;
+    },
+
+    /**
+     * The first static cloud's intensity min/max, for seeding the intensity-
+     * filter control. Null when nothing is loaded or the cloud has no intensity
+     * channel. O(n) over the intensity array — run once on load.
+     */
+    intensityExtent(): { min: number; max: number } | null {
+      const inten = host.firstStaticCloud()?.intensity;
+      if (inten && inten.length > 0) return intensityRange([inten]);
+      // Streaming: LAS headers carry no intensity range, so scan the resident
+      // chunks' intensity buffers. Called once when the streaming scan seeds
+      // its control, so the O(resident) pass is paid a single time and the
+      // extent stays stable even as more nodes stream in.
+      if (host.streaming()) {
+        const buffers = host.residentIntensityBuffers();
+        return buffers.length > 0 ? intensityRange(buffers) : null;
+      }
+      return null;
+    },
+  };
+}

--- a/tests/viewerActiveColorbar.test.ts
+++ b/tests/viewerActiveColorbar.test.ts
@@ -1,66 +1,66 @@
 /**
  * viewerActiveColorbar.test.ts
  *
- * Pins the Viewer glue that assembles the colorbar spec — the seam between the
- * pure spec-builder (covered in activeColorbar.test.ts) and the live scene
- * state. The pure builder can't see the two things that only the Viewer knows:
+ * Pins the colour-legend glue that assembles the colorbar spec — the seam
+ * between the pure spec-builder (covered in activeColorbar.test.ts) and the
+ * live scene state. The pure builder can't see the two things only the scene
+ * knows:
  *
  *   - the STATIC path adds the cloud's up-axis origin back so the legend reads
  *     true world/source heights, not the render-local values the loader shifted
- *     to (`range + entry.cloud.origin[upAxis]`);
+ *     to (`range + cloud.sourceOrigin[upAxis]`);
  *   - the STREAMING path reads the renderer's seeded cloud-global windows
  *     VERBATIM (adding the render origin's Z), gates the non-elevation scalar
  *     fields on `colorRangesSeeded` (pre-seed placeholders → null), and pins
  *     the trim disclosure to the fixed p5–p95 the reseed core uses.
  *
- * The Viewer is far too heavy to instantiate in the node test env (WebGPU +
- * canvas), and `activeColorbar()` only touches a handful of instance members,
- * so — following the repo's Viewer-glue convention (see streamingReseed.test.ts,
- * which drives a real class method against a hand-built `this`) — we invoke the
- * REAL method bodies via `Viewer.prototype.*.call(fakeThis)`. This exercises the
- * actual shipped glue (origin math, seeded gating, mode dispatch), not a copy.
+ * That glue moved off the Viewer into `buildColorLegend` (v0.6 decomposition),
+ * so the test drives the collaborator against a hand-built host — no WebGL, no
+ * class instantiation. `elevationExtent` / `intensityExtent` live on the same
+ * collaborator and are pinned at the bottom.
  */
 
 import { describe, it, expect } from 'vitest';
-import { Viewer } from '../src/render/Viewer';
+import {
+  buildColorLegend,
+  type ColorLegendHost,
+  type ColorLegendStreaming,
+} from '../src/render/colorLegend';
 import type { ColorMode } from '../src/render/colorModes';
 import type { ActiveColorbar } from '../src/render/activeColorbar';
 import { PointCloud } from '../src/model/PointCloud';
 import type { StreamingColorRanges } from '../src/render/streaming/streamingColors';
 
-// ── Invoke the real Viewer glue against a minimal hand-built `this`. ─────────
+// ── Build a minimal host over hand-built scene state. ────────────────────────
 
-interface FakeStaticCloudEntry {
-  cloud: PointCloud;
+interface HostState {
+  streaming: ColorLegendStreaming | null;
+  cloud: PointCloud | null;
   mode: ColorMode;
+  heightPercentileTrim: number;
+  elevationUnitLabel: string | null;
+  worldUpIsZ?: boolean;
+  residentIntensityBuffers?: readonly ArrayLike<number>[];
 }
 
-interface FakeViewerState {
-  _streaming: null | {
-    renderer: {
-      colorMode: ColorMode;
-      colorRanges: StreamingColorRanges;
-      colorRangesSeeded: boolean;
-    };
-    cloud: { renderOrigin: readonly [number, number, number] };
+function host(state: HostState): ColorLegendHost {
+  return {
+    activeColorMode: () => state.mode,
+    firstStaticCloud: () => state.cloud,
+    streaming: () => state.streaming,
+    heightPercentileTrim: () => state.heightPercentileTrim,
+    elevationUnitLabel: () => state.elevationUnitLabel,
+    worldUpIsZ: () => state.worldUpIsZ ?? true,
+    residentIntensityBuffers: () => state.residentIntensityBuffers ?? [],
   };
-  _clouds: Map<string, FakeStaticCloudEntry>;
-  _heightPercentileTrim: number;
-  _elevationUnitLabel: string | null;
 }
 
-/** Run the shipped `activeColorbar()` against a fake `this` (with the real
- *  `activeColorMode()` attached, since the method calls it). */
-function callActiveColorbar(state: FakeViewerState): ActiveColorbar | null {
-  const self = {
-    ...state,
-    activeColorMode: Viewer.prototype.activeColorMode,
-  } as unknown as Viewer;
-  return Viewer.prototype.activeColorbar.call(self);
+function activeColorbar(state: HostState): ActiveColorbar | null {
+  return buildColorLegend(host(state)).activeColorbar();
 }
 
 /** A tiny Z-up (LAS) cloud with Z spanning 0..30 and a non-zero world origin. */
-function staticCloud(mode: ColorMode): FakeViewerState {
+function staticCloud(mode: ColorMode): HostState {
   const positions = new Float32Array([
     0, 0, 0,
     1, 0, 10,
@@ -79,10 +79,11 @@ function staticCloud(mode: ColorMode): FakeViewerState {
     name: 'origin.las',
   });
   return {
-    _streaming: null,
-    _clouds: new Map([['c0', { cloud, mode }]]),
-    _heightPercentileTrim: 0, // deterministic true-extent window for origin math
-    _elevationUnitLabel: 'm',
+    streaming: null,
+    cloud,
+    mode,
+    heightPercentileTrim: 0, // deterministic true-extent window for origin math
+    elevationUnitLabel: 'm',
   };
 }
 
@@ -92,7 +93,7 @@ function streamingState(
   ranges: Partial<StreamingColorRanges> = {},
   zOff = 0,
   unit: string | null = 'm',
-): FakeViewerState {
+): HostState {
   const full: StreamingColorRanges = {
     minZ: 0,
     maxZ: 30,
@@ -105,13 +106,17 @@ function streamingState(
     ...ranges,
   };
   return {
-    _streaming: {
-      renderer: { colorMode: mode, colorRanges: full, colorRangesSeeded: seeded },
-      cloud: { renderOrigin: [0, 0, zOff] },
+    streaming: {
+      renderer: { colorRanges: full, colorRangesSeeded: seeded },
+      cloud: {
+        renderOrigin: [0, 0, zOff],
+        dataBounds: () => [0, 0, full.minZ, 0, 0, full.maxZ],
+      },
     },
-    _clouds: new Map(),
-    _heightPercentileTrim: 0,
-    _elevationUnitLabel: unit,
+    cloud: null,
+    mode,
+    heightPercentileTrim: 0,
+    elevationUnitLabel: unit,
   };
 }
 
@@ -119,9 +124,9 @@ function streamingState(
 // Static path
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('Viewer.activeColorbar — static path', () => {
+describe('colorLegend.activeColorbar — static path', () => {
   it('elevation adds the up-axis origin back so labels read world heights', () => {
-    const bar = callActiveColorbar(staticCloud('elevation'));
+    const bar = activeColorbar(staticCloud('elevation'));
     expect(bar).not.toBeNull();
     expect(bar!.mode).toBe('elevation');
     // render-local Z is 0..30; origin[2] = 1000 → world 1000..1030.
@@ -135,20 +140,20 @@ describe('Viewer.activeColorbar — static path', () => {
 
   it('elevation discloses the p5–p95 window when the trim slider is active', () => {
     const state = staticCloud('elevation');
-    state._heightPercentileTrim = 5;
-    const bar = callActiveColorbar(state);
+    state.heightPercentileTrim = 5;
+    const bar = activeColorbar(state);
     expect(bar!.note).toContain('p5–p95');
   });
 
   it('elevation shows bare numbers when the CRS unit is unknown', () => {
     const state = staticCloud('elevation');
-    state._elevationUnitLabel = null;
-    const bar = callActiveColorbar(state);
+    state.elevationUnitLabel = null;
+    const bar = activeColorbar(state);
     expect(bar!.spec.unit).toBeUndefined();
   });
 
   it('intensity is grayscale, raw window, NO origin add-back and NO unit', () => {
-    const bar = callActiveColorbar(staticCloud('intensity'));
+    const bar = activeColorbar(staticCloud('intensity'));
     expect(bar!.spec.palette).toBe('grayscale');
     // finiteMinMax over [7,100,200,900] — NOT shifted by the origin.
     expect(bar!.spec.min).toBe(7);
@@ -157,7 +162,7 @@ describe('Viewer.activeColorbar — static path', () => {
   });
 
   it('gpsTime normalises to seconds-from-window-start and discloses it', () => {
-    const bar = callActiveColorbar(staticCloud('gpsTime'));
+    const bar = activeColorbar(staticCloud('gpsTime'));
     expect(bar!.spec.min).toBe(0);
     expect(bar!.spec.max).toBeGreaterThan(0);
     expect(bar!.spec.unit).toBe('s');
@@ -166,7 +171,7 @@ describe('Viewer.activeColorbar — static path', () => {
   });
 
   it('returnNumber shows the raw ordinal window, no unit, no note', () => {
-    const bar = callActiveColorbar(staticCloud('returnNumber'));
+    const bar = activeColorbar(staticCloud('returnNumber'));
     expect(bar!.spec.min).toBe(1);
     expect(bar!.spec.max).toBe(5);
     expect(bar!.spec.unit).toBeUndefined();
@@ -174,16 +179,17 @@ describe('Viewer.activeColorbar — static path', () => {
   });
 
   it('categorical modes and the empty scene yield no colorbar', () => {
-    expect(callActiveColorbar(staticCloud('rgb'))).toBeNull();
-    expect(callActiveColorbar(staticCloud('classification'))).toBeNull();
-    // No clouds at all → activeColorMode() falls back to 'rgb' → null.
-    const empty: FakeViewerState = {
-      _streaming: null,
-      _clouds: new Map(),
-      _heightPercentileTrim: 0,
-      _elevationUnitLabel: 'm',
+    expect(activeColorbar(staticCloud('rgb'))).toBeNull();
+    expect(activeColorbar(staticCloud('classification'))).toBeNull();
+    // No clouds at all → null.
+    const empty: HostState = {
+      streaming: null,
+      cloud: null,
+      mode: 'rgb',
+      heightPercentileTrim: 0,
+      elevationUnitLabel: 'm',
     };
-    expect(callActiveColorbar(empty)).toBeNull();
+    expect(activeColorbar(empty)).toBeNull();
   });
 });
 
@@ -191,9 +197,9 @@ describe('Viewer.activeColorbar — static path', () => {
 // Streaming path
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('Viewer.activeColorbar — streaming path (seeded)', () => {
+describe('colorLegend.activeColorbar — streaming path (seeded)', () => {
   it('elevation reads the seeded window + render-origin Z, p5–p95 note', () => {
-    const bar = callActiveColorbar(
+    const bar = activeColorbar(
       streamingState('elevation', true, { minZ: 2, maxZ: 40 }, 1000),
     );
     expect(bar).not.toBeNull();
@@ -203,7 +209,7 @@ describe('Viewer.activeColorbar — streaming path (seeded)', () => {
   });
 
   it('intensity reads the seeded grayscale window verbatim (no origin shift)', () => {
-    const bar = callActiveColorbar(
+    const bar = activeColorbar(
       streamingState('intensity', true, { minIntensity: 3, maxIntensity: 4095 }, 1000),
     );
     expect(bar!.spec.palette).toBe('grayscale');
@@ -212,7 +218,7 @@ describe('Viewer.activeColorbar — streaming path (seeded)', () => {
   });
 
   it('gpsTime normalises the seeded window to seconds-from-start', () => {
-    const bar = callActiveColorbar(
+    const bar = activeColorbar(
       streamingState('gpsTime', true, { minGpsTime: 300_000_000, maxGpsTime: 300_000_480 }),
     );
     expect(bar!.spec.min).toBe(0);
@@ -222,7 +228,7 @@ describe('Viewer.activeColorbar — streaming path (seeded)', () => {
   });
 
   it('returnNumber reads the seeded ordinal window', () => {
-    const bar = callActiveColorbar(
+    const bar = activeColorbar(
       streamingState('returnNumber', true, { minReturnNumber: 1, maxReturnNumber: 4 }),
     );
     expect(bar!.spec.min).toBe(1);
@@ -231,11 +237,11 @@ describe('Viewer.activeColorbar — streaming path (seeded)', () => {
   });
 });
 
-describe('Viewer.activeColorbar — streaming path (pre-seed)', () => {
+describe('colorLegend.activeColorbar — streaming path (pre-seed)', () => {
   it('elevation is labelable pre-seed from the header cube, with NO trim note', () => {
     // Before the first node seeds, minZ/maxZ hold the header cube extent —
     // an honest window, and there is no percentile trim to disclose.
-    const bar = callActiveColorbar(
+    const bar = activeColorbar(
       streamingState('elevation', false, { minZ: 0, maxZ: 30 }, 0),
     );
     expect(bar).not.toBeNull();
@@ -247,13 +253,60 @@ describe('Viewer.activeColorbar — streaming path (pre-seed)', () => {
   it('intensity / gpsTime / returnNumber yield NO colorbar pre-seed (placeholders)', () => {
     // The scalar fields are 0..1 placeholders before a node seeds them —
     // labelling them would assert a window that describes nothing.
-    expect(callActiveColorbar(streamingState('intensity', false))).toBeNull();
-    expect(callActiveColorbar(streamingState('gpsTime', false))).toBeNull();
-    expect(callActiveColorbar(streamingState('returnNumber', false))).toBeNull();
+    expect(activeColorbar(streamingState('intensity', false))).toBeNull();
+    expect(activeColorbar(streamingState('gpsTime', false))).toBeNull();
+    expect(activeColorbar(streamingState('returnNumber', false))).toBeNull();
   });
 
   it('categorical streaming modes yield no colorbar', () => {
-    expect(callActiveColorbar(streamingState('rgb', true))).toBeNull();
-    expect(callActiveColorbar(streamingState('classification', true))).toBeNull();
+    expect(activeColorbar(streamingState('rgb', true))).toBeNull();
+    expect(activeColorbar(streamingState('classification', true))).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Extent seeds (elevation / intensity filter controls)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('colorLegend.elevationExtent', () => {
+  it('static: adds the up-axis origin back to the local bounds', () => {
+    // Z-up cloud, Z spans 0..30 render-local, origin[2] = 1000 → world 1000..1030.
+    const state = staticCloud('elevation');
+    expect(buildColorLegend(host(state)).elevationExtent()).toEqual({ min: 1000, max: 1030 });
+  });
+
+  it('streaming: reads the header data bounds plus the render origin', () => {
+    const state = streamingState('elevation', true, { minZ: 2, maxZ: 40 }, 1000);
+    expect(buildColorLegend(host(state)).elevationExtent()).toEqual({ min: 1002, max: 1040 });
+  });
+
+  it('empty scene yields null', () => {
+    const state: HostState = {
+      streaming: null,
+      cloud: null,
+      mode: 'elevation',
+      heightPercentileTrim: 0,
+      elevationUnitLabel: 'm',
+    };
+    expect(buildColorLegend(host(state)).elevationExtent()).toBeNull();
+  });
+});
+
+describe('colorLegend.intensityExtent', () => {
+  it('static: min/max over the cloud intensity buffer', () => {
+    const state = staticCloud('intensity'); // intensity [7,100,200,900]
+    expect(buildColorLegend(host(state)).intensityExtent()).toEqual({ min: 7, max: 900 });
+  });
+
+  it('streaming: min/max over the resident intensity buffers', () => {
+    const state = streamingState('intensity', true);
+    state.residentIntensityBuffers = [new Uint16Array([12, 40]), new Uint16Array([5, 900])];
+    expect(buildColorLegend(host(state)).intensityExtent()).toEqual({ min: 5, max: 900 });
+  });
+
+  it('streaming with no resident intensity yields null', () => {
+    const state = streamingState('intensity', true);
+    state.residentIntensityBuffers = [];
+    expect(buildColorLegend(host(state)).intensityExtent()).toBeNull();
   });
 });


### PR DESCRIPTION
First decomposition of the Viewer.ts monolith (stabilization plan, goal 3).

## What moved

`activeColorbar`, `elevationExtent`, and `intensityExtent` — the colour-legend and scalar-range reads — move out of `Viewer.ts` into `src/render/colorLegend.ts`. The new module takes a structural `ColorLegendHost` (the same seam `exportAdapter.ts` uses), so the origin math, seeded-window gating, and resident-buffer extent scans are testable without a WebGL context. `Viewer` keeps three thin delegates and one host binding.

The pure `buildActiveColorbarSpec` / `rampRangeForMode` were already extracted; this lifts the remaining live-state glue that sat on the class.

## Behaviour

Unchanged. The logic is moved verbatim — same streaming-first dispatch, same elevation origin add-back, same p5–p95 disclosure, same pre-seed gating. Static and streaming axis conventions are preserved exactly (`activeColorbar` keys off `isZUpFormat(sourceFormat)`, `elevationExtent` off world-up).

## Tests

`tests/viewerActiveColorbar.test.ts` retargets from `Viewer.prototype.*.call(fakeThis)` to `buildColorLegend(host)`, drops the prototype-hack, and gains `elevationExtent` / `intensityExtent` coverage — 20 cases, green.

## Counts

`Viewer.ts` 7,073 -> 6,959 (114 fewer). Baseline rebanked in `docs/validation/monolith-size-baseline.json`. `KNOWN_LIMITATIONS_v0.6.3.md` and `docs/architecture/architecture-map.md` updated to the new count.

## Gates

- `npm run typecheck` — 0 errors
- `npm run lint:monolith-size` — OK, Viewer shrunk, baseline banked
- `npm run lint:release-truth` — OK
- `npx vitest run` — 7,586 passed; only `terrainRunnerDensityWiring.test.ts` timed out under full-suite load (known flake), passes in isolation (5/5, 22s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)