### PR TITLE
Hygiene quick wins: signed-URL secret scan + shipped-file cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,20 +143,15 @@ _private/
 .agents/
 skills-lock.json
 
-# Editor and agent working directories. These were excluded through
-# .git/info/exclude, which is local to one clone: it is not committed, does not
-# survive a fresh clone, and protects nobody else. `.claude/launch.json` was
-# committed once before that exclusion existed, and the agent scaffolding above
-# reached the repository the same way, through `git add -A` on a tree nothing
-# was ignoring. Listing them here makes the protection travel with the code.
+# Editor and agent working directories — local scratch, not part of the
+# software. Ignored here (rather than only in .git/info/exclude) so the
+# exclusion travels with the repository and survives a fresh clone.
 .claude/
 .vscode/
 .idea/
 
-# Python bytecode. scripts/__pycache__/make-ept-fixture.cpython-311.pyc was
-# tracked, so every run of the fixture generator showed up as a change to a
-# compiled artifact nobody reads. It also pins one interpreter version into a
-# tree that states 3.11 in .python-version and checks it in CI.
+# Python bytecode — a compiled artifact nobody reads, and one that would pin an
+# interpreter version into a tree that states 3.11 in .python-version.
 __pycache__/
 *.py[cod]
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,5 @@
 # OpenLiDARViewer
 
-<!-- Ten badges in three rows of three, three and four. Two rows put six
-     badges on one line, which wrapped and stranded the last one on a line of
-     its own; three groups also say more. Building and running is one
-     question, being measured by an outside service is another, and being
-     findable is a third. Every one is set by a
-     workflow run or an external service, so none of them is a claim this
-     repository makes about itself. That is the only rule this block follows,
-     and it is why the list keeps getting shorter rather than longer.
-
-     The quality gate badge went in when it began reporting a score, which is
-     the rule above. It reads passed on reliability, security, maintainability,
-     duplication and reviewed hotspots. Five findings behind it are resolved
-     rather than fixed, and the distinction is on the issues: two are marked
-     false positive, because the rule reported path injection on a flow that
-     carries an argparse integer into JSON content while the path beside it is
-     a literal; three are accepted, because the code is deliberate, a seeded
-     generator a fixture test depends on and a spawn that runs no shell.
-
-     fair-software.eu reads three of five. Both of the ones it withholds are
-     real: this is not in a package registry, and it carries no OpenSSF Best
-     Practices badge, which is deferred rather than overlooked. The score is
-     measured from the repository by `.github/workflows/fair-software.yml`.
-
-     Gone, and worth recording so nobody adds them back. A
-     fairsoftwarechecklist.net badge sat next to fair-software.eu for a while.
-     It is a self-assessment, so it reported whatever we had typed into its
-     URL, and next to a measured score it read as a second opinion when it was
-     really the same opinion twice. Rendering, privacy, status, Node and the
-     live demo went earlier, each restating something the paragraph below or
-     the Live version line already said.
-
-     One slot is held open: OpenSSF Scorecard, between CI and Security audit.
-     The workflow publishes (last run 6.1, transparency-log entry recorded) but
-     api.scorecard.dev has not ingested the project and the badge still renders
-     "invalid repo path". Rechecked 2026-07-30, still invalid. It goes in when
-     it renders a score, making ten. -->
-
 <!-- Does it build and run, everywhere it claims to -->
 [![CI](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/ci.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/ci.yml)
 [![Clean clone](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/clean-clone.yml/badge.svg)](https://github.com/Aurtechmx/openlidarviewer/actions/workflows/clean-clone.yml)

--- a/scripts/lint-archive-vocab.mjs
+++ b/scripts/lint-archive-vocab.mjs
@@ -10,6 +10,10 @@
  * The patterns are assembled from fragments (see `rx` below) so the phrasings
  * this lint rejects never appear as literal strings in this file.
  *
+ * It also fails on a signed-URL secret — an AWS/Azure/GCS pre-authenticated
+ * query string or an OAuth token — reaching a shipped file, so a credential
+ * pasted into a doc or fixture cannot ship.
+ *
  * Scope is the shipped surface: the files `git archive` would include. Files
  * that are already export-ignored are exempt.
  */
@@ -53,6 +57,15 @@ const ALLOW = [
   /\balpha\.\d (development|baseline|release)/i,
   /\bfirst (established|introduced) during\b/i,
 ];
+
+/**
+ * Query parameters that carry the secret in a signed / pre-authenticated URL —
+ * AWS SigV4, Azure SAS, GCS signed URLs, and OAuth bearer tokens. A signed URL
+ * committed to the tree ships a live (if short-lived) credential. Matched only
+ * with a long value so an ordinary `?token=next` or `?sig=off` in prose or a
+ * fixture does not trip the check; a real signature or token is a long blob.
+ */
+const LEAKED_URL_SECRET = /[?&](X-Amz-Signature|X-Amz-Credential|X-Amz-Security-Token|X-Goog-Signature|AWSAccessKeyId|sig|access_token)=[A-Za-z0-9%_\-+/]{16,}/i;
 
 /**
  * The files `git archive HEAD` would ship; attributes resolve from the
@@ -118,6 +131,12 @@ for (const rel of shipped) {
   if (rel.endsWith('lint-archive-vocab.mjs')) continue;
   const lines = readFileSync(full, 'utf8').split('\n');
   lines.forEach((line, i) => {
+    const secret = line.match(LEAKED_URL_SECRET);
+    if (secret) {
+      problems.push(
+        `  • ${rel}:${i + 1}: "${secret[1]}=…" — a signed-URL secret in a shipped file; redact the query string before committing.`,
+      );
+    }
     if (ALLOW.some((re) => re.test(line))) return;
     for (const re of BANNED) {
       const m = line.match(re);


### PR DESCRIPTION
Three near-complete items from the hygiene audit, each independent.

1. **Signed-URL secret scan** — `lint:archive-vocab` now also fails if a shipped file contains an AWS SigV4 / Azure SAS / GCS signed-URL query string or an OAuth token (matched only with a long value, so `?token=next` in prose is fine). Verified: passes on the clean tree, catches an injected `X-Amz-Signature`, clean again after. Closes the audit's 'redact signed URL query strings' item at the archive boundary.
2. **.gitignore** — rewrote two comments that recounted specific commit accidents into plain what/why.
3. **README** — removed a 36-line hidden comment that narrated badge-inclusion decisions and resolved-finding rationale in the shipped source. Badges and their row labels stay.

Gates: lint:archive-vocab, lint:release-sync green.