### PR TITLE
Fail closed on footprint area (m²) for an unknown-unit CRS

### DIFF
--- a/src/intelligence/scanStory.ts
+++ b/src/intelligence/scanStory.ts
@@ -109,6 +109,25 @@ function formatArea(m2: number | undefined): string | null {
   return `${Math.round(m2)} m²`;
 }
 
+/**
+ * Footprint area in square metres, or `undefined` when it cannot be claimed.
+ *
+ * `spanX`/`spanY` are horizontal extents in the source CRS's linear unit. The
+ * area is returned only when that unit is known: an unknown unit would report a
+ * raw span² as if it were metres — a foot grid reads ~10.76x too large — so
+ * this fails closed and the caller shows no area rather than a wrong one.
+ */
+export function footprintAreaM2(
+  spanX: number,
+  spanY: number,
+  crs: { readonly linearUnit: string; readonly linearUnitToMetres?: number } | null | undefined,
+): number | undefined {
+  if (!crs || crs.linearUnit === 'unknown') return undefined;
+  const toM = crs.linearUnitToMetres ?? 1;
+  const area = spanX * spanY * toM * toM;
+  return Number.isFinite(area) && area > 0 ? area : undefined;
+}
+
 const isPartial = (m: ScanStoryInputs['coverageMode']): boolean =>
   m === 'resident-only' || m === 'sampled';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,7 @@ import {
   type DeriveClassificationOptions,
 } from './render/class/deriveClassification';
 import type { ScanStoryInputs } from './intelligence/scanStory';
+import { footprintAreaM2 } from './intelligence/scanStory';
 import { fullScope, scopeFrom, scopeStamp, notScopedSentinel, type ClassScope } from './render/class/classScope';
 import { classificationLabel } from './render/pointInfo';
 // ObjectPanel is lazy-mounted on first scan load (v0.6 P1, step 2): only the
@@ -1831,11 +1832,11 @@ function buildCurrentStoryInputs(): ScanStoryInputs {
 
   let pointCount: number | undefined;
   let areaM2: number | undefined;
-  // Render-space bounds are in the source CRS's native linear units (feet for a
-  // foot-CRS file), so a raw span² is ft², not m². Convert with linearUnitToMetres²
-  // — without it a foot-CRS scan reads ~10.76× too large in the Story / Health.
-  const linToM = crsService.current()?.linearUnitToMetres ?? 1;
-  const areaUnitToM2 = linToM * linToM;
+  // Footprint area in m², but only when the CRS's linear unit is known.
+  // `footprintAreaM2` fails closed on an unknown unit — which would report a raw
+  // span² as metres — so the Story / Health omit the area rather than claim a
+  // wrong one; a foot-CRS scan otherwise reads ~10.76x too large.
+  const areaCrs = crsService.current();
   // Metadata read is the FALLBACK for georef; when an analysis has run, the
   // authoritative quality.crsKnown / quality.datumKnown from storyFacts wins, so
   // the Story / Health never disagree with the panel's own CRS / Datum chips.
@@ -1845,7 +1846,7 @@ function buildCurrentStoryInputs(): ScanStoryInputs {
   try {
     if (cloud) {
       const b = cloud.bounds();
-      areaM2 = (b.max[0] - b.min[0]) * (b.max[1] - b.min[1]) * areaUnitToM2;
+      areaM2 = footprintAreaM2(b.max[0] - b.min[0], b.max[1] - b.min[1], areaCrs);
       pointCount = cloud.pointCount;
       const crs = cloud.metadata?.crs as { name?: string; verticalDatum?: unknown } | undefined;
       metaCrsKnown = !!crs?.name;
@@ -1855,7 +1856,7 @@ function buildCurrentStoryInputs(): ScanStoryInputs {
       // Tight data AABB, not the octree cube — the cube overstates footprint
       // area (and understates density) for a partial-footprint scan.
       const lb = streaming.dataBounds();
-      areaM2 = (lb[3] - lb[0]) * (lb[4] - lb[1]) * areaUnitToM2;
+      areaM2 = footprintAreaM2(lb[3] - lb[0], lb[4] - lb[1], areaCrs);
       pointCount = streaming.sourcePointCount;
       const sCrs = streaming.crs();
       metaCrsKnown = !!sCrs?.name;

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,8 +79,7 @@ import {
   classificationCoverage,
   type DeriveClassificationOptions,
 } from './render/class/deriveClassification';
-import type { ScanStoryInputs } from './intelligence/scanStory';
-import { footprintAreaM2 } from './intelligence/scanStory';
+import { footprintAreaM2, type ScanStoryInputs } from './intelligence/scanStory';
 import { fullScope, scopeFrom, scopeStamp, notScopedSentinel, type ClassScope } from './render/class/classScope';
 import { classificationLabel } from './render/pointInfo';
 // ObjectPanel is lazy-mounted on first scan load (v0.6 P1, step 2): only the

--- a/tests/scanStory.test.ts
+++ b/tests/scanStory.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildScanStory,
   buildExportHealth,
+  footprintAreaM2,
   type ScanStoryInputs,
   type StoryProduct,
 } from '../src/intelligence/scanStory';
@@ -215,5 +216,31 @@ describe('buildExportHealth — rows', () => {
     expect(
       buildExportHealth({ classification: 'none' }).rows.find((r) => r.label === 'Terrain products')?.value,
     ).toBe('Not analysed');
+  });
+});
+
+describe('footprintAreaM2 — fail closed on an unknown linear unit', () => {
+  it('returns square metres for a known metre CRS', () => {
+    expect(footprintAreaM2(10, 20, { linearUnit: 'metre', linearUnitToMetres: 1 })).toBe(200);
+  });
+
+  it('converts a foot CRS by the linear factor squared', () => {
+    // 10 ft x 20 ft = 200 ft^2 -> 200 * 0.3048^2 m^2.
+    expect(footprintAreaM2(10, 20, { linearUnit: 'foot', linearUnitToMetres: 0.3048 }))
+      .toBeCloseTo(200 * 0.3048 * 0.3048, 6);
+  });
+
+  it('returns undefined for an unknown unit rather than assuming metres', () => {
+    expect(footprintAreaM2(10, 20, { linearUnit: 'unknown', linearUnitToMetres: 1 })).toBeUndefined();
+  });
+
+  it('returns undefined when there is no CRS', () => {
+    expect(footprintAreaM2(10, 20, null)).toBeUndefined();
+    expect(footprintAreaM2(10, 20, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for a non-positive span', () => {
+    expect(footprintAreaM2(0, 20, { linearUnit: 'metre', linearUnitToMetres: 1 })).toBeUndefined();
+    expect(footprintAreaM2(-5, 20, { linearUnit: 'metre', linearUnitToMetres: 1 })).toBeUndefined();
   });
 });


### PR DESCRIPTION
Consumer-side follow-up to #215 (source-side fail-closed). Traced the `linearUnitToMetres ?? 1` sites in main.ts for silent-metre leaks.

**Fixed here:** the Story / Health footprint area. `buildCurrentStoryInputs` computed `areaM2` with `?? 1` and gated the CRS chip on `!!crs.name` (name-present, *not* unit-known), so a named CRS with an unknown linear unit reported its footprint in m² as if metre-based. Now a pure, tested `footprintAreaM2` returns `undefined` on an unknown unit and the headline omits the area.

Verified: typecheck, 29 scanStory tests (5 new red-green cases), main-deferral lint.