### PR TITLE
Fail closed on unknown CRS unit in streaming scan-report extents

### DIFF
--- a/src/analysis/streamingExtentRows.ts
+++ b/src/analysis/streamingExtentRows.ts
@@ -1,0 +1,83 @@
+import type { CrsLinearUnit } from '../io/crs';
+
+/** One extent/density/spacing row the streaming Scan-report emits. */
+export interface ExtentRowSpec {
+  readonly label: string;
+  readonly value: string;
+  /**
+   * true → the caller wraps this row with the class-scope honesty sentinel
+   * (the full-cloud header figures — density / spacing — that a class filter
+   * cannot scope). false → a plain info row.
+   */
+  readonly scoped: boolean;
+}
+
+export interface StreamingExtentResult {
+  /**
+   * Whether the source CRS declares a real linear unit. false when the CRS is
+   * absent or carries `linearUnit: 'unknown'` — in which case the rows are in
+   * raw source units and NOT labelled "m" / "pts/m²".
+   */
+  readonly unitConfirmed: boolean;
+  readonly rows: readonly ExtentRowSpec[];
+}
+
+type ExtentCrs = {
+  readonly linearUnit?: CrsLinearUnit;
+  readonly linearUnitToMetres?: number;
+  readonly verticalUnitToMetres?: number;
+} | null;
+
+/**
+ * Build the Width / Depth / Height / Density / Spacing rows for the streaming
+ * Scan-report, FAILING CLOSED on an unconfirmed linear unit.
+ *
+ * An unknown-unit CRS carries the inert placeholder `linearUnitToMetres: 1`,
+ * and a CRS-less cloud resolves the same way. Multiplying a source span by
+ * that factor and stamping "m" silently reports non-metre data as metres — a
+ * state-plane-FEET COPC would over-report extent ~3.28× mislabelled as metres.
+ * So metres are only claimed when the CRS declares a real linear unit
+ * (`crsInfo != null && crsInfo.linearUnit !== 'unknown'`), the same gate the
+ * measure tool (`setCrsKnown`) and the lasso (`densityUnitKnown`) already
+ * apply. When the unit is unconfirmed the metre factor is dropped, the raw
+ * source span is shown, and the "m" / "pts/m²" claim is withheld.
+ *
+ * COPC/EPT are Z-up by spec, so the horizontal footprint is X·Y and height is
+ * Z; the vertical span uses the vertical unit when the CRS declares one.
+ */
+export function streamingExtentRows(
+  header: { readonly min: readonly [number, number, number]; readonly max: readonly [number, number, number] },
+  crsInfo: ExtentCrs,
+  sourcePointCount: number,
+): StreamingExtentResult {
+  const unitConfirmed =
+    crsInfo != null && crsInfo.linearUnit !== undefined && crsInfo.linearUnit !== 'unknown';
+
+  // Apply the metre factor ONLY when the unit is real. Otherwise the span stays
+  // in raw source units (factor 1) and is not labelled "m".
+  const mpu = unitConfirmed ? (crsInfo?.linearUnitToMetres ?? 1) : 1;
+  const vmpu = unitConfirmed ? (crsInfo?.verticalUnitToMetres ?? mpu) : 1;
+
+  const w = (header.max[0] - header.min[0]) * mpu;
+  const d = (header.max[1] - header.min[1]) * mpu;
+  const h = (header.max[2] - header.min[2]) * vmpu;
+
+  const lenUnit = unitConfirmed ? ' m' : ' (source units)';
+  const rows: ExtentRowSpec[] = [
+    { label: 'Width', value: `${w.toFixed(1)}${lenUnit}`, scoped: false },
+    { label: 'Depth', value: `${d.toFixed(1)}${lenUnit}`, scoped: false },
+    { label: 'Height', value: `${h.toFixed(1)}${lenUnit}`, scoped: false },
+  ];
+
+  const footprintArea = w * d;
+  if (footprintArea > 0 && sourcePointCount > 0) {
+    const density = sourcePointCount / footprintArea;
+    const spacing = Math.sqrt(footprintArea / sourcePointCount);
+    const densityUnit = unitConfirmed ? ' pts/m²' : ' pts/unit²';
+    const spacingUnit = unitConfirmed ? ' m' : ' (source units)';
+    rows.push({ label: 'Density', value: `${density.toFixed(1)}${densityUnit}`, scoped: true });
+    rows.push({ label: 'Spacing', value: `${spacing.toFixed(2)}${spacingUnit}`, scoped: true });
+  }
+
+  return { unitConfirmed, rows };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4393,11 +4393,7 @@ function runStreamingModules(cloud: {
     readonly captureSensor?: string;
     readonly sourceSoftware?: string;
   };
-  readonly crs?: () => {
-    readonly linearUnit?: CrsLinearUnit;
-    readonly linearUnitToMetres?: number;
-    readonly verticalUnitToMetres?: number;
-  } | null;
+  readonly crs?: () => { readonly linearUnit?: CrsLinearUnit; readonly linearUnitToMetres?: number; readonly verticalUnitToMetres?: number } | null;
   readonly maxDepth?: () => number;
   readonly octree?: { nodes: () => readonly unknown[] };
 }, classFilterActive = false): AnalysisRow[] {
@@ -4431,10 +4427,9 @@ function runStreamingModules(cloud: {
     // Convert the source-CRS units to metres before printing "m" / "pts/m²",
     // exactly as the static Scan Report and the PDF do. A state-plane-FEET COPC
     // otherwise over-reports extent ~3.28× and density ~10.8×, mislabelled as
-    // metres. `streamingExtentRows` FAILS CLOSED on an unconfirmed unit: an
-    // unknown-unit CRS carries the inert placeholder `linearUnitToMetres: 1`,
-    // so it drops the "m"/"pts/m²" claim rather than stamping metres onto
-    // non-metre data — the same gate the measure tool and lasso apply.
+    // metres. `streamingExtentRows` FAILS CLOSED on an unconfirmed unit
+    // (placeholder `linearUnitToMetres: 1`): it drops the "m"/"pts/m²" claim
+    // rather than stamping metres onto non-metre data — as measure/lasso do.
     const crsInfo = cloud.crs?.() ?? null;
     const ext = streamingExtentRows(header, crsInfo, cloud.sourcePointCount);
     if (!ext.unitConfirmed) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -251,7 +251,8 @@ import { CatalogPanel } from './ui/CatalogPanel';
 // CRS detection + override — feeds the Inspector's Coordinate System
 // section. Static clouds carry `metadata.crs` (CrsInfo from src/io/crs);
 // streaming clouds expose `.crs()` returning the same shape.
-import type { CrsInfo } from './io/crs';
+import type { CrsInfo, CrsLinearUnit } from './io/crs';
+import { streamingExtentRows } from './analysis/streamingExtentRows';
 import { CrsService } from './geo/CrsService';
 // Shared vertical-unit labeller (already eager via terrainAnalysisRunner) —
 // feeds the colorbar legend's elevation unit from the resolved CRS.
@@ -4392,7 +4393,11 @@ function runStreamingModules(cloud: {
     readonly captureSensor?: string;
     readonly sourceSoftware?: string;
   };
-  readonly crs?: () => { readonly linearUnitToMetres?: number; readonly verticalUnitToMetres?: number } | null;
+  readonly crs?: () => {
+    readonly linearUnit?: CrsLinearUnit;
+    readonly linearUnitToMetres?: number;
+    readonly verticalUnitToMetres?: number;
+  } | null;
   readonly maxDepth?: () => number;
   readonly octree?: { nodes: () => readonly unknown[] };
 }, classFilterActive = false): AnalysisRow[] {
@@ -4426,21 +4431,21 @@ function runStreamingModules(cloud: {
     // Convert the source-CRS units to metres before printing "m" / "pts/m²",
     // exactly as the static Scan Report and the PDF do. A state-plane-FEET COPC
     // otherwise over-reports extent ~3.28× and density ~10.8×, mislabelled as
-    // metres. COPC/EPT are Z-up by spec, so the horizontal pair is X·Y.
+    // metres. `streamingExtentRows` FAILS CLOSED on an unconfirmed unit: an
+    // unknown-unit CRS carries the inert placeholder `linearUnitToMetres: 1`,
+    // so it drops the "m"/"pts/m²" claim rather than stamping metres onto
+    // non-metre data — the same gate the measure tool and lasso apply.
     const crsInfo = cloud.crs?.() ?? null;
-    const mpu = crsInfo?.linearUnitToMetres ?? 1;
-    const vmpu = crsInfo?.verticalUnitToMetres ?? mpu;
-    const w = (header.max[0] - header.min[0]) * mpu;
-    const d = (header.max[1] - header.min[1]) * mpu;
-    const h = (header.max[2] - header.min[2]) * vmpu;
-    rows.push(info('Width', `${w.toFixed(1)} m`));
-    rows.push(info('Depth', `${d.toFixed(1)} m`));
-    rows.push(info('Height', `${h.toFixed(1)} m`));
-    const footprintArea = w * d;
-    if (footprintArea > 0 && cloud.sourcePointCount > 0) {
-      const density = cloud.sourcePointCount / footprintArea;
-      rows.push(headerMetric('Density', `${density.toFixed(1)} pts/m²`));
-      rows.push(headerMetric('Spacing', `${Math.sqrt(footprintArea / cloud.sourcePointCount).toFixed(2)} m`));
+    const ext = streamingExtentRows(header, crsInfo, cloud.sourcePointCount);
+    if (!ext.unitConfirmed) {
+      rows.push({
+        label: 'Units',
+        value: 'unconfirmed — source CRS declares no linear unit; extents shown in source units',
+        status: 'warn',
+      });
+    }
+    for (const r of ext.rows) {
+      rows.push(r.scoped ? headerMetric(r.label, r.value) : info(r.label, r.value));
     }
   }
 

--- a/tests/streamingExtentRows.test.ts
+++ b/tests/streamingExtentRows.test.ts
@@ -1,0 +1,85 @@
+/**
+ * streamingExtentRows.test.ts
+ *
+ * Coordinate-integrity guard for the streaming Scan-report's extent block.
+ *
+ * The panel derives Width/Depth/Height/Density/Spacing from the file header's
+ * source-coordinate bounds and a per-CRS metre factor. An unknown-unit CRS
+ * carries the inert placeholder `linearUnitToMetres: 1`; consuming it WITHOUT
+ * gating on `linearUnit !== 'unknown'` stamps "m" / "pts/m²" onto non-metre
+ * data. `streamingExtentRows` fails closed: it only claims metres when the CRS
+ * declares a real linear unit, matching the measure tool and lasso.
+ */
+import { streamingExtentRows } from '../src/analysis/streamingExtentRows';
+
+const header = {
+  min: [0, 0, 0] as const,
+  max: [1000, 1000, 100] as const,
+};
+
+test('metre CRS: converts and labels "m" / "pts/m²" (byte-identical to before)', () => {
+  const { unitConfirmed, rows } = streamingExtentRows(
+    header,
+    { linearUnit: 'metre', linearUnitToMetres: 1 },
+    1_000_000,
+  );
+  expect(unitConfirmed).toBe(true);
+  const byLabel = Object.fromEntries(rows.map((r) => [r.label, r.value]));
+  expect(byLabel.Width).toBe('1000.0 m');
+  expect(byLabel.Depth).toBe('1000.0 m');
+  expect(byLabel.Height).toBe('100.0 m');
+  expect(byLabel.Density).toBe('1.0 pts/m²');
+  expect(byLabel.Spacing).toBe('1.00 m');
+});
+
+test('foot CRS: applies the 0.3048 factor before stamping metres', () => {
+  const { unitConfirmed, rows } = streamingExtentRows(
+    header,
+    { linearUnit: 'foot', linearUnitToMetres: 0.3048, verticalUnitToMetres: 0.3048 },
+    1_000_000,
+  );
+  expect(unitConfirmed).toBe(true);
+  const byLabel = Object.fromEntries(rows.map((r) => [r.label, r.value]));
+  // 1000 ft → 304.8 m; a foot cloud must NOT read 1000 m.
+  expect(byLabel.Width).toBe('304.8 m');
+  expect(byLabel.Height).toBe('30.5 m');
+});
+
+test('unknown-unit CRS: does NOT claim metres despite the placeholder factor', () => {
+  const { unitConfirmed, rows } = streamingExtentRows(
+    header,
+    // The leak shape: unknown unit, inert factor 1.
+    { linearUnit: 'unknown', linearUnitToMetres: 1 },
+    1_000_000,
+  );
+  expect(unitConfirmed).toBe(false);
+  for (const r of rows) {
+    // No bare metre / pts-per-square-metre claim anywhere.
+    expect(r.value).not.toMatch(/\bm\b/);
+    expect(r.value).not.toMatch(/pts\/m²/);
+  }
+  const byLabel = Object.fromEntries(rows.map((r) => [r.label, r.value]));
+  expect(byLabel.Width).toBe('1000.0 (source units)');
+  expect(byLabel.Density).toBe('1.0 pts/unit²');
+  expect(byLabel.Spacing).toBe('1.00 (source units)');
+});
+
+test('no CRS resolved (null): fails closed exactly like unknown', () => {
+  const { unitConfirmed, rows } = streamingExtentRows(header, null, 1_000_000);
+  expect(unitConfirmed).toBe(false);
+  const byLabel = Object.fromEntries(rows.map((r) => [r.label, r.value]));
+  expect(byLabel.Width).toBe('1000.0 (source units)');
+  expect(byLabel.Width).not.toMatch(/\bm\b/);
+});
+
+test('density & spacing rows carry the class-scope flag; extents do not', () => {
+  const { rows } = streamingExtentRows(header, { linearUnit: 'metre', linearUnitToMetres: 1 }, 1_000_000);
+  const scoped = new Set(rows.filter((r) => r.scoped).map((r) => r.label));
+  expect(scoped).toEqual(new Set(['Density', 'Spacing']));
+});
+
+test('degenerate footprint: emits extents only, no density/spacing', () => {
+  const flat = { min: [0, 0, 0] as const, max: [0, 100, 100] as const };
+  const { rows } = streamingExtentRows(flat, { linearUnit: 'metre', linearUnitToMetres: 1 }, 1000);
+  expect(rows.map((r) => r.label)).toEqual(['Width', 'Depth', 'Height']);
+});


### PR DESCRIPTION
## Problem

The streaming Scan-report (`runStreamingModules` in `src/main.ts`) printed **Width/Depth/Height "X m"**, **Density "pts/m²"** and **Spacing "X m"** directly from the header bounds × `linearUnitToMetres`, with **no gate on `crsInfo.linearUnit`**.

An unknown-unit CRS carries the inert placeholder `linearUnitToMetres: 1` (and a CRS-less cloud resolves the same). Consuming that factor without gating silently reports non-metre data as metres — the exact leak class fixed in #217.

## Fix

Extract a pure, tested `streamingExtentRows` helper (`src/analysis/streamingExtentRows.ts`) that **fails closed**: it only claims metres when the CRS declares a real linear unit —

```
crsInfo != null && crsInfo.linearUnit !== 'unknown'
```

— the same gate the measure tool (`setCrsKnown`) and the lasso (`densityUnitKnown`) already apply. When the unit is unconfirmed it drops the `m` / `pts/m²` claim, shows the raw source span (`… (source units)` / `pts/unit²`), and the panel adds a `Units — unconfirmed` caveat row.

Confirmed-unit output (metre / foot CRS) is byte-identical to before.

## Tests / gates

- New `tests/streamingExtentRows.test.ts` (metre byte-identity, foot conversion, unknown fail-closed, null fail-closed, scope flags, degenerate footprint).
- `npm run typecheck` — 0 errors
- `npx vitest run` touched + related (streamingExtentRows, scanReport, streamingSpacingLabel, unitIntegrity, crsValidation, streamingScanReveal) — all pass
- `npm run lint:main-deferral` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)