### PR TITLE
Fail closed on unknown projected linear unit in epoch cut/fill

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6836,6 +6836,14 @@ function compareLoadedLayers(): void {
         verticalUnitToMetres: a.metadata?.crs?.verticalUnitToMetres,
         isGeographic:
           a.metadata?.crs?.isGeographic === true || b.metadata?.crs?.isGeographic === true,
+        // A projected CRS whose linear unit is 'unknown' carries the inert
+        // placeholder factor 1: using it would print source-unit spacing/heights
+        // as metres. Gate on the unit being KNOWN (either epoch declaring
+        // 'unknown' is enough to fail closed) so compareDtms withholds the metre
+        // figures instead of leaking them. A geographic frame is 'unknown' too
+        // but is handled by isGeographic above; compareDtms keeps them distinct.
+        horizontalUnitKnown:
+          a.metadata?.crs?.linearUnit !== 'unknown' && b.metadata?.crs?.linearUnit !== 'unknown',
       });
       const header = `${baseName(a.name)} (before) → ${baseName(b.name)} (after)`;
       inspector.setCompareResult([header, summarizeAlignment(alignment), ...summarizeChange(cmp)]);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6834,16 +6834,8 @@ function compareLoadedLayers(): void {
       const cmp = compareDtms(dtms.before, dtms.after, {
         horizontalUnitToMetres: a.metadata?.crs?.linearUnitToMetres,
         verticalUnitToMetres: a.metadata?.crs?.verticalUnitToMetres,
-        isGeographic:
-          a.metadata?.crs?.isGeographic === true || b.metadata?.crs?.isGeographic === true,
-        // A projected CRS whose linear unit is 'unknown' carries the inert
-        // placeholder factor 1: using it would print source-unit spacing/heights
-        // as metres. Gate on the unit being KNOWN (either epoch declaring
-        // 'unknown' is enough to fail closed) so compareDtms withholds the metre
-        // figures instead of leaking them. A geographic frame is 'unknown' too
-        // but is handled by isGeographic above; compareDtms keeps them distinct.
-        horizontalUnitKnown:
-          a.metadata?.crs?.linearUnit !== 'unknown' && b.metadata?.crs?.linearUnit !== 'unknown',
+        isGeographic: a.metadata?.crs?.isGeographic === true || b.metadata?.crs?.isGeographic === true,
+        horizontalUnitKnown: a.metadata?.crs?.linearUnit !== 'unknown' && b.metadata?.crs?.linearUnit !== 'unknown', // KNOWN in both epochs ⇒ compareDtms fails closed instead of leaking source units as metres ('unknown' = placeholder factor 1; geographic frames go via isGeographic)
       });
       const header = `${baseName(a.name)} (before) → ${baseName(b.name)} (after)`;
       inspector.setCompareResult([header, summarizeAlignment(alignment), ...summarizeChange(cmp)]);

--- a/src/terrain/change/compareDtms.ts
+++ b/src/terrain/change/compareDtms.ts
@@ -49,6 +49,19 @@ export interface CompareDtmsOptions extends ChangeDetectionOptions {
    * degree-based numbers as m³, and says so in the co-registration notes.
    */
   readonly isGeographic?: boolean;
+  /**
+   * False when the horizontal frame is PROJECTED but its linear unit is unknown
+   * (a CRS whose `linearUnit` is 'unknown', carrying the inert placeholder
+   * factor 1). Distinct from geographic: the frame is planar, so it passes the
+   * `isGeographic` gate, yet the source unit could be feet, US survey feet, or
+   * links — the factor 1 is a placeholder, not a measurement. Multiplying by it
+   * silently reports non-metre spacing (and, since the vertical unit falls back
+   * to this same horizontal unit, non-metre heights) as metres. When false, the
+   * comparison withholds the metre figures (cut/fill AND Δz) rather than
+   * captioning source-unit numbers as m³/m — fail closed on the unknown unit.
+   * Omitted/true means the unit is known (or a metre CRS) and figures print.
+   */
+  readonly horizontalUnitKnown?: boolean;
 }
 
 /** A two-epoch comparison plus the co-registration verdict the grids can't carry. */
@@ -81,6 +94,14 @@ export interface EpochComparison {
    * captioning them.
    */
   readonly frameIncompatible: boolean;
+  /**
+   * True when the horizontal frame is projected but its linear unit is unknown
+   * (see {@link CompareDtmsOptions.horizontalUnitKnown}). Like `frameIncompatible`,
+   * the metre figures are then withheld — an unknown source unit can't be
+   * multiplied into metres — but the cause is a missing unit, not a proven frame
+   * clash, so `summarizeChange` says so distinctly.
+   */
+  readonly horizontalUnitUnknown: boolean;
 }
 
 /**
@@ -107,6 +128,23 @@ export function compareDtms(
       'Geographic (degree) grid — cell areas are in degrees², so cut/fill volumes ' +
         'are not computable. Reproject both epochs to a projected CRS to measure ' +
         'volumes; the per-cell elevation differences remain valid.',
+    );
+  }
+
+  // Projected frame with an UNKNOWN linear unit: the frame is planar (so it is
+  // not geographic), but the source unit is undetermined and the factor fed in
+  // is the inert placeholder 1. Unlike the geographic case, z gives no reprieve
+  // — the vertical unit falls back to this same unknown horizontal unit — so
+  // BOTH the cut/fill volumes and the Δz figures would be source-unit numbers
+  // mislabelled as m³/m. Refuse the numbers (fail closed) rather than caption
+  // an unverified unit as metres; the diagnosis note says exactly what to fix.
+  const horizontalUnitUnknown =
+    options.isGeographic !== true && options.horizontalUnitKnown === false;
+  if (horizontalUnitUnknown) {
+    notes.push(
+      'Horizontal linear unit is unknown — the grid spacing has no confirmed metre scale, ' +
+        'so cut/fill volumes and elevation differences cannot be reported in metres. Set the ' +
+        'CRS linear unit (or reproject to a projected metre/foot CRS) to measure.',
     );
   }
 
@@ -172,7 +210,7 @@ export function compareDtms(
   // overall co-registration verdict folds those in too.
   const coregistered = result.aligned && notes.length === 0;
   const levelOfDetectionM = Math.max(0, options.levelOfDetectionM ?? DEFAULT_LOD_M);
-  return { result, coregistered, coregistrationNotes: notes, levelOfDetectionM, volumesComputable, frameIncompatible };
+  return { result, coregistered, coregistrationNotes: notes, levelOfDetectionM, volumesComputable, frameIncompatible, horizontalUnitUnknown };
 }
 
 /**
@@ -192,6 +230,19 @@ export function summarizeChange(comparison: EpochComparison): string[] {
     lines.push(
       '✗ Not comparable — the two epochs are in provably different frames, so no ' +
         'difference is reported. Reproject them to a common CRS and vertical datum first.',
+    );
+    for (const note of coregistrationNotes) lines.push(`• ${note}`);
+    return lines;
+  }
+  if (comparison.horizontalUnitUnknown) {
+    // Projected frame, unknown linear unit: the source spacing has no confirmed
+    // metre scale, so every metre figure (m³ and Δz) would be a source-unit
+    // number wearing a metre label. Withhold them all — same posture as a proven
+    // frame clash — and keep only the diagnosis so the fix is clear.
+    lines.push(
+      '✗ Not comparable — the horizontal linear unit is unknown, so cut/fill volumes and ' +
+        'elevation differences are not reported in metres. Set the CRS linear unit (or ' +
+        'reproject to a metre/foot CRS) and compare again.',
     );
     for (const note of coregistrationNotes) lines.push(`• ${note}`);
     return lines;

--- a/tests/compareDtms.test.ts
+++ b/tests/compareDtms.test.ts
@@ -209,3 +209,58 @@ describe('compareDtms — a proven frame mismatch refuses the numbers', () => {
     expect(summarizeChange(cmp).join('\n')).toContain('Net volume');
   });
 });
+
+/**
+ * A projected CRS with an UNKNOWN linear unit refuses the metre figures.
+ *
+ * The frame is planar (not geographic), and its CRS name may even match across
+ * epochs, so it passes every co-registration check — yet its linear unit is
+ * 'unknown', so the factor fed in is the inert placeholder 1. Multiplying the
+ * grid spacing (and, via the vertical fallback, the heights) by that placeholder
+ * would report source-unit numbers as m³/m. Fail closed: withhold the metres.
+ */
+describe('compareDtms — an unknown projected linear unit refuses the metres', () => {
+  const flat = [1, 1, 1, 1];
+
+  it('flags horizontalUnitUnknown when the projected unit is unknown', () => {
+    const cmp = compareDtms(grid(flat, 2, 2), grid(flat, 2, 2), {
+      horizontalUnitKnown: false,
+    });
+    expect(cmp.horizontalUnitUnknown).toBe(true);
+    // Not a proven frame clash — the frames may well agree, the unit is just missing.
+    expect(cmp.frameIncompatible).toBe(false);
+  });
+
+  it('does NOT flag when the unit is known (or omitted / a metre CRS)', () => {
+    expect(compareDtms(grid(flat, 2, 2), grid(flat, 2, 2)).horizontalUnitUnknown).toBe(false);
+    expect(
+      compareDtms(grid(flat, 2, 2), grid(flat, 2, 2), { horizontalUnitKnown: true })
+        .horizontalUnitUnknown,
+    ).toBe(false);
+  });
+
+  it('does NOT flag a geographic frame (handled by isGeographic, keeps Δz)', () => {
+    // Geographic CRSs also report linearUnit 'unknown', but their vertical unit
+    // is a valid linear unit, so the geographic path withholds only volumes and
+    // keeps the elevation differences — it must not be swept into this refusal.
+    const cmp = compareDtms(grid(flat, 2, 2), grid(flat, 2, 2), {
+      isGeographic: true,
+      horizontalUnitKnown: false,
+    });
+    expect(cmp.horizontalUnitUnknown).toBe(false);
+    expect(cmp.volumesComputable).toBe(false);
+  });
+
+  it('summarizeChange withholds every metre figure and says why', () => {
+    const cmp = compareDtms(grid([1, 1, 1, 1], 2, 2), grid([2, 2, 2, 2], 2, 2), {
+      horizontalUnitKnown: false,
+    });
+    const lines = summarizeChange(cmp);
+    expect(lines[0]).toMatch(/not comparable/i);
+    const text = lines.join('\n');
+    expect(text).not.toContain('Net volume');
+    expect(text).not.toContain('Largest gain');
+    expect(text).not.toContain('m³');
+    expect(text).toMatch(/linear unit is unknown/i);
+  });
+});


### PR DESCRIPTION
## Problem

The epoch-compare cut/fill (`src/main.ts` ~6834) calls `compareDtms` with the CRS's `linearUnitToMetres`. A projected CRS whose `linearUnit` is `'unknown'` carries the inert placeholder factor `1` and `isGeographic: false`. It therefore passes the `isGeographic` gate and, if the CRS name matches across epochs, every co-registration check — so `summarizeChange` printed `Net volume change: X m³` plus Δz/extremes in `m` with **no disclosure**. Those are source-unit numbers (the unit could be feet, US survey feet, links) wearing metre labels. The vertical factor falls back to the same unknown horizontal unit (`crs.ts` doc), so the Δz "m" lines leak too.

This is the same class as PR #217: a consumer using `linearUnitToMetres` without gating on `linearUnit !== 'unknown'`.

## Fix

On the existing `isGeographic`/`frameIncompatible` seam:

- `CompareDtmsOptions.horizontalUnitKnown?: boolean` and a new `EpochComparison.horizontalUnitUnknown` verdict.
- When the frame is projected (`!isGeographic`) and the unit is unknown, `compareDtms` records a diagnosis note and `summarizeChange` withholds **every** metre figure (volumes AND Δz — the vertical unit is unknown too), keeping only the fix-it diagnosis. Fail closed.
- Geographic frames keep their own path (volumes-only refusal, Δz preserved) — the geographic branch takes precedence, so `horizontalUnitUnknown` stays `false` for them.
- `main.ts` gates on either epoch declaring `'unknown'`.

Absent-CRS (no metadata) stays "indicative" as before — the refusal fires only when a CRS is present with an explicitly unknown unit.

### Other two sub-sites audited, left unchanged
- **6819 `spanUnitToM`** (alignment residual threshold): unit-invariant — the gate is 10%-of-span and the residual compared against it is in the same source units, so the factor cancels. Internal, not a display claim.
- **6856 `gridUnitToMetres`** (`.asc` export): factor `1` is a no-op; the ESRI `.asc` has no unit field and its geometry+values are both source-unit-consistent. Matches how the geographic case still exports the raster.

## Tests
New `compareDtms.test.ts` suite: flags `horizontalUnitUnknown` for an unknown projected unit, does not flag known/omitted/metre or geographic frames, and asserts `summarizeChange` withholds `Net volume`/`Largest gain`/`m³` while surfacing the "linear unit is unknown" diagnosis.

## Gates
- `npm run typecheck` — 0 errors
- `npx vitest run` (compareDtms + changeDetection + compareEpochs) — 43 passed
- `npm run lint:main-deferral` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)