### PR TITLE
Disclose unverified units in the space/scan report

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3393,12 +3393,18 @@ function applyScanRoute(initial: boolean, settled = false): boolean {
     // Feed the active scan's linear-unit-to-metres factor so a foot-based CRS
     // (or any non-metre source units) reports honest metre/feet dimensions —
     // the same factor the terrain core uses (see deriveCoreParams). Unknown ⇒ 1
-    // (assume metres) — an honest default, never a fabricated scale.
-    const unitToMetres = crsService.current()?.linearUnitToMetres ?? 1;
+    // for DISPLAY, but that factor is then an assumption, not a confirmed scale:
+    // gate on `linearUnit !== 'unknown'` (the same predicate the lasso / measure
+    // / legend seams use) and pass the known/unknown bit so the report discloses
+    // the assumption instead of asserting a bare "m" — never a fabricated scale.
+    const spaceCrs = crsService.current();
+    const unitToMetres = spaceCrs?.linearUnitToMetres ?? 1;
+    const unitKnown = spaceCrs != null && spaceCrs.linearUnit !== 'unknown';
     const space = spaceMetrics(gathered.positions, {
       upAxis: shape.up,
       spaceKind: effective === 'interior' ? 'interior' : 'object',
       unitToMetres,
+      unitKnown,
       hasRgb,
       sourcePointCount: gathered.totalPoints,
       // A still-streaming cloud is measured on its resident subset only — lead

--- a/src/main.ts
+++ b/src/main.ts
@@ -3392,19 +3392,13 @@ function applyScanRoute(initial: boolean, settled = false): boolean {
     // reflects what's actually there for that interpretation; nothing fabricated.
     // Feed the active scan's linear-unit-to-metres factor so a foot-based CRS
     // (or any non-metre source units) reports honest metre/feet dimensions —
-    // the same factor the terrain core uses (see deriveCoreParams). Unknown ⇒ 1
-    // for DISPLAY, but that factor is then an assumption, not a confirmed scale:
-    // gate on `linearUnit !== 'unknown'` (the same predicate the lasso / measure
-    // / legend seams use) and pass the known/unknown bit so the report discloses
-    // the assumption instead of asserting a bare "m" — never a fabricated scale.
-    const spaceCrs = crsService.current();
-    const unitToMetres = spaceCrs?.linearUnitToMetres ?? 1;
-    const unitKnown = spaceCrs != null && spaceCrs.linearUnit !== 'unknown';
+    // the same factor the terrain core uses (deriveCoreParams); unknown unit ⇒ 1, unitKnown (below) flags that as assumed.
+    const unitToMetres = crsService.current()?.linearUnitToMetres ?? 1;
     const space = spaceMetrics(gathered.positions, {
       upAxis: shape.up,
       spaceKind: effective === 'interior' ? 'interior' : 'object',
       unitToMetres,
-      unitKnown,
+      unitKnown: (crsService.current()?.linearUnit ?? 'unknown') !== 'unknown',
       hasRgb,
       sourcePointCount: gathered.totalPoints,
       // A still-streaming cloud is measured on its resident subset only — lead

--- a/src/terrain/spaceMetrics.ts
+++ b/src/terrain/spaceMetrics.ts
@@ -97,6 +97,18 @@ export interface SpaceMetricsParams {
   readonly spaceKind: 'interior' | 'object';
   /** Scale from source units to metres (default 1 — assume metres). */
   readonly unitToMetres?: number;
+  /**
+   * Whether the source linear unit is KNOWN — the CRS resolved a real linear
+   * unit. When explicitly `false`, `unitToMetres` is an assume-metres
+   * placeholder (an unknown-unit or CRS-less scan yields factor 1 for display),
+   * so the figures cannot be asserted as metres: a unit-unverified caveat is
+   * added to `reasons` so the panel and PDF disclose the assumption instead of
+   * printing a bare "m" claim. `undefined` keeps the legacy "assume known"
+   * behaviour (no caveat) for callers that predate the flag. Mirrors the
+   * `crs.linearUnit !== 'unknown'` gate the lasso / measurement / legend seams
+   * already apply.
+   */
+  readonly unitKnown?: boolean;
   /** Whether the scan carries colour. */
   readonly hasRgb?: boolean;
   /** Honest source/resident count the sample was drawn from. */
@@ -129,6 +141,17 @@ const STREAM_CAVEAT =
  */
 const PARTIAL_STREAM_CAVEAT =
   'Preliminary — only the streamed-in part of the scan has been measured so far; dimensions, areas and volumes will change as more loads. Let the full cloud stream in, then re-run.';
+/**
+ * Caveat for a scan whose source linear unit could not be confirmed as metres
+ * (no CRS, or a CRS that names no resolved linear unit). Every figure here is
+ * labelled "m" / "m²" / "m³" / "pts/m²", but with an unverified scale that claim
+ * is an assumption, so say so plainly instead of asserting metres. Recognised by
+ * ObjectPanel._caveats to surface it as the visible lead. Parallels the
+ * measurement-trust "unknown CRS" gate and the space-report PDF's
+ * "scale unverified — not asserted as metres" provenance line.
+ */
+const UNVERIFIED_UNIT_CAVEAT =
+  'Coordinate units are unverified — dimensions, areas, volumes and densities assume metres. Confirm the source CRS before relying on the figures.';
 
 const upOffsets = (a: Axis): { v: number; h1: number; h2: number } =>
   a === 'x' ? { v: 0, h1: 1, h2: 2 } : a === 'y' ? { v: 1, h1: 0, h2: 2 } : { v: 2, h1: 0, h2: 1 };
@@ -253,6 +276,12 @@ export function spaceMetrics(
   const sourcePointCount = params.sourcePointCount ?? n;
 
   const reasons: string[] = [params.residentOnly ? PARTIAL_STREAM_CAVEAT : STREAM_CAVEAT];
+  // Fail closed on an unverified scale: when the caller knows the linear unit is
+  // NOT resolved, every metre figure below is an assume-metres default, so
+  // disclose it rather than let "X m" read as a confirmed metric claim. Pushed
+  // after the stream caveat so `reasons[0]` (the partial-stream lead contract)
+  // is untouched; the panel promotes this caveat to the visible lead itself.
+  if (params.unitKnown === false) reasons.push(UNVERIFIED_UNIT_CAVEAT);
   const blankQuality: CaptureQuality = {
     sampledPointCount: 0, sourcePointCount, densityPerM2: 0,
     meanSpacingM: 0, coveragePct: 0, hasRgb,

--- a/src/ui/ObjectPanel.ts
+++ b/src/ui/ObjectPanel.ts
@@ -233,8 +233,14 @@ export class ObjectPanel {
     // else the certified-survey honesty line (present for interiors); else the
     // first reason as a fallback.
     const partialIdx = reasons.findIndex((r) => /^Preliminary —/.test(r));
+    // An unverified-unit caveat is a whole-basis honesty flag (every metre figure
+    // is an assumption), so it must be VISIBLE, not folded into the disclosure.
+    // It outranks the standing "not a certified survey" line but yields to a
+    // genuine partial-stream lead (provisional data trumps unit provenance).
+    const unitIdx = reasons.findIndex((r) => /^Coordinate units are unverified/.test(r));
     const certIdx = reasons.findIndex((r) => /not a certified survey/i.test(r));
-    const leadIdx = partialIdx >= 0 ? partialIdx : certIdx >= 0 ? certIdx : 0;
+    const leadIdx =
+      partialIdx >= 0 ? partialIdx : unitIdx >= 0 ? unitIdx : certIdx >= 0 ? certIdx : 0;
     const lead = reasons[leadIdx];
     const rest = reasons.filter((_, i) => i !== leadIdx);
     const isPreliminary = leadIdx === partialIdx && partialIdx >= 0;

--- a/tests/objectPanelSpace.test.ts
+++ b/tests/objectPanelSpace.test.ts
@@ -218,6 +218,34 @@ describe('ObjectPanel — space / object routing', () => {
     expect(root.textContent).toMatch(/pragmatic estimates, not a certified survey/);
   });
 
+  it('promotes the unverified-unit caveat to the VISIBLE lead (unknown-unit CRS)', async () => {
+    const { ObjectPanel } = await import('../src/ui/ObjectPanel');
+    const { spaceMetrics } = await import('../src/terrain/spaceMetrics');
+    const { classifyScanShape } = await import('../src/terrain/scanShape');
+
+    const pos = room();
+    const shape = classifyScanShape(pos);
+    // Unknown-unit CRS: display factor 1, but the scale is NOT confirmed metres.
+    const space = spaceMetrics(pos, {
+      upAxis: shape.up,
+      spaceKind: 'interior',
+      unitToMetres: 1,
+      unitKnown: false,
+    });
+
+    const panel = new ObjectPanel();
+    panel.showSpace(space, shape);
+    const root = panel.element as unknown as FakeEl;
+    const all = flatten(root);
+
+    // The unit caveat is the visible lead — not folded behind the disclosure —
+    // so the metre figures are never presented as a confirmed metric claim.
+    const lead = all.find((e) => e.className.includes('is-lead'));
+    expect(lead).toBeDefined();
+    expect(lead!.textContent).toMatch(/^Coordinate units are unverified/);
+    expect(lead!.textContent).toMatch(/Confirm the source CRS/);
+  });
+
   it('the empty interior state still offers the Treat-as control and the hatch', async () => {
     const { ObjectPanel } = await import('../src/ui/ObjectPanel');
     const panel = new ObjectPanel();

--- a/tests/spaceMetrics.test.ts
+++ b/tests/spaceMetrics.test.ts
@@ -111,6 +111,45 @@ describe('spaceMetrics — storeys & units & objects', () => {
     expect(m.storyCount).toBe(2);
   });
 
+  it('unitKnown=false discloses an unverified-unit caveat instead of a bare metre claim', () => {
+    // An unknown-unit CRS (linearUnit "unknown") reaches the space report with a
+    // placeholder factor of 1, so every figure is labelled "m" without a real
+    // scale. The caveat must appear so the panel / PDF disclose the assumption.
+    const withCaveat = spaceMetrics(room(), {
+      upAxis: 'z',
+      spaceKind: 'interior',
+      unitToMetres: 1,
+      unitKnown: false,
+    });
+    expect(withCaveat.reasons.some((r) => /^Coordinate units are unverified/.test(r))).toBe(true);
+    // The unverified-unit caveat never displaces the stream-caveat lead contract.
+    expect(withCaveat.reasons[0]).not.toMatch(/^Coordinate units are unverified/);
+  });
+
+  it('a KNOWN unit (or an omitted flag) makes no unverified-unit claim', () => {
+    // A resolved CRS (unitKnown true) genuinely IS metres/feet — no caveat.
+    const known = spaceMetrics(room(), {
+      upAxis: 'z',
+      spaceKind: 'interior',
+      unitToMetres: 1,
+      unitKnown: true,
+    });
+    expect(known.reasons.some((r) => /Coordinate units are unverified/.test(r))).toBe(false);
+    // Legacy callers that never pass the flag keep the prior behaviour (no caveat).
+    const legacy = spaceMetrics(room(), { upAxis: 'z', spaceKind: 'interior' });
+    expect(legacy.reasons.some((r) => /Coordinate units are unverified/.test(r))).toBe(false);
+  });
+
+  it('the unverified-unit caveat rides through the object route too', () => {
+    const obj = spaceMetrics(dome(), {
+      upAxis: 'z',
+      spaceKind: 'object',
+      unitToMetres: 1,
+      unitKnown: false,
+    });
+    expect(obj.reasons.some((r) => /^Coordinate units are unverified/.test(r))).toBe(true);
+  });
+
   it('unit conversions m↔ft are correct', () => {
     expect(metresToFeet(1)).toBeCloseTo(3.280839895, 6);
     expect(metresToFeet(3.048)).toBeCloseTo(10, 6);


### PR DESCRIPTION
## Verdict: LEAK → FIXED

The Space/Object report (`src/main.ts` ~3397) fed `spaceMetrics` `crsService.current()?.linearUnitToMetres ?? 1` **without** gating on `linearUnit !== 'unknown'`. An unknown-unit CRS carries `linearUnit: 'unknown'` + `linearUnitToMetres: 1` (an inert placeholder), so its dimensions, floor area, ceiling height, enclosed volume and density were printed as bare `m` / `m²` / `m³` / `pts/m²` in the on-screen panel with **no disclosure** — the metre claim was an unverified assumption presented as fact.

This is the same class of leak the sibling seams already gate against with the canonical `crs != null && crs.linearUnit !== 'unknown'` predicate:
- lasso volume — `densityUnitKnown` (main.ts:561)
- measurement trust — `setCrsKnown` (main.ts:2219)
- elevation legend — vertical-unit gate (main.ts:2237)

The report **PDF** already disclosed (via `scaleFromFactor` → `unknownUnit()` → "scale unverified — not asserted as metres"). The on-screen panel was the gap.

## Fix
- `spaceMetrics` gains an optional `unitKnown` flag. When explicitly `false`, it appends a `Coordinate units are unverified …` caveat to `reasons` (pure, deterministic; flows to both the panel and the PDF Notes). `undefined` keeps legacy behaviour — no caveat — so existing callers/tests are unaffected.
- `ObjectPanel._caveats` promotes that caveat to the **visible lead** (above the "not a certified survey" line, below a genuine partial-stream lead), so the metre figures are never shown as a confirmed metric claim.
- `main.ts` passes `unitKnown` using the canonical predicate.

## Tests
- `tests/spaceMetrics.test.ts` — unknown-unit path emits the caveat (without displacing the stream-caveat lead); known/omitted flag emits nothing; object route carries it too.
- `tests/objectPanelSpace.test.ts` — the caveat renders as the visible `is-lead` note for an unknown-unit CRS.

## Gates
- `npm run typecheck` — 0 errors
- `npx vitest run` — 7436 passed / 19 skipped / 1 todo
- `npm run lint:main-deferral` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)