### PR TITLE
Extract toClassBuffer to src/render/class/classBuffer.ts

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.3.md
+++ b/KNOWN_LIMITATIONS_v0.6.3.md
@@ -6,7 +6,7 @@ Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 6,983 lines and `src/render/Viewer.ts` is 6,959, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 6,976 lines and `src/render/Viewer.ts` is 6,951, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 6,983 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 6,976 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -102,7 +102,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (6,983)** — the largest blocks, which are the extraction
+**`src/main.ts` (6,976)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,
@@ -112,14 +112,13 @@ called with a 19-member deps object. The candidates that remain:
 |---|---:|---|
 | `seedStreamingFilterExtents` | 338 | streaming panel wiring module |
 | `handleFile` | 336 | `src/app/openScan.ts` *(planned)* — the open/load pipeline |
-| `toClassBuffer` | 268 | `src/model/` or `src/render/class/` |
 | `syncInspectorVisuals` | 266 | inspector wiring module |
 | `applyScanRoute` | 233 | joins `ScanRouteService` |
 | `handleRemoteEpt` / `openStreamingCopc` | 406 | `src/app/openStreaming.ts` *(planned)* |
 | `generateReportPdf` / `exportGeoContext` | 402 | export/report wiring module |
 | `importSession` | 177 | `src/app/sessionIo.ts` *(planned)* |
 
-**`src/render/Viewer.ts` (6,959)** — the constructor and a handful of large
+**`src/render/Viewer.ts` (6,951)** — the constructor and a handful of large
 methods dominate:
 
 Spans below are the symbol's real extent, read from the TypeScript symbol graph

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 6983,
+      "lines": 6976,
       "goal": 2500
     },
     "src/render/Viewer.ts": {
-      "lines": 6959,
+      "lines": 6951,
       "goal": 2000
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,7 @@ import type { AnalysePanel } from './ui/AnalysePanel';
 import { ClassLegendPanel } from './ui/ClassLegendPanel';
 import type { ReclassifyUi } from './ui/reclassifyUi';
 import { countClasses } from './render/class/classHistogram';
+import { toClassBuffer } from './render/class/classBuffer';
 import { deriveClassificationAsync } from './render/class/deriveClassificationAsync';
 import {
   classificationCoverage,
@@ -3591,14 +3592,6 @@ function refreshClassLegend(classification?: ArrayLike<number>): void {
   // Reset the inspector's copy/JSON scope stamp — the fresh legend is
   // all-visible, so this clears any stamp left by a prior filtered scan.
   syncInspectClassScope();
-}
-
-/** Narrow an ArrayLike classification source to a typed buffer for counting. */
-function toClassBuffer(src: ArrayLike<number>): Uint8Array {
-  if (src instanceof Uint8Array) return src;
-  const out = new Uint8Array(src.length);
-  for (let i = 0; i < src.length; i++) out[i] = src[i];
-  return out;
 }
 
 // Every listener-binding that synchronously dereferences `viewer.*` must

--- a/src/render/class/classBuffer.ts
+++ b/src/render/class/classBuffer.ts
@@ -1,0 +1,19 @@
+/**
+ * classBuffer.ts
+ *
+ * Narrows an arbitrary numeric classification source to a `Uint8Array`
+ * so the histogram can count over a concrete byte buffer. A source that
+ * is already a `Uint8Array` is returned as-is (no copy); any other
+ * `ArrayLike` is copied element by element into a fresh byte buffer,
+ * where each write truncates to the low 8 bits.
+ *
+ * Pure data — no DOM, no three.js, no I/O.
+ */
+
+/** Narrow an ArrayLike classification source to a typed buffer for counting. */
+export function toClassBuffer(src: ArrayLike<number>): Uint8Array {
+  if (src instanceof Uint8Array) return src;
+  const out = new Uint8Array(src.length);
+  for (let i = 0; i < src.length; i++) out[i] = src[i];
+  return out;
+}

--- a/tests/classBuffer.test.ts
+++ b/tests/classBuffer.test.ts
@@ -1,0 +1,59 @@
+/**
+ * tests/classBuffer.test.ts
+ *
+ * Coverage for the pure ArrayLike -> Uint8Array narrowing helper that
+ * feeds the class histogram. An existing Uint8Array is returned by
+ * identity (no copy); any other source is copied into a fresh byte
+ * buffer where each write truncates to the low 8 bits.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toClassBuffer } from '../src/render/class/classBuffer';
+
+describe('toClassBuffer', () => {
+  it('returns the same Uint8Array by identity (no copy)', () => {
+    const src = new Uint8Array([2, 6, 9]);
+    const out = toClassBuffer(src);
+    expect(out).toBe(src);
+  });
+
+  it('empty input yields an empty buffer', () => {
+    const out = toClassBuffer([]);
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(out.length).toBe(0);
+  });
+
+  it('copies a number[] into a fresh Uint8Array with identical values', () => {
+    const src = [0, 1, 2, 6, 255];
+    const out = toClassBuffer(src);
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(out).not.toBe(src as unknown as Uint8Array);
+    expect(Array.from(out)).toEqual([0, 1, 2, 6, 255]);
+  });
+
+  it('copies from a non-Uint8Array typed array (Float32Array), truncating to byte', () => {
+    // Uint8Array assignment truncates toward zero and wraps mod 256:
+    // 2.9 -> 2, 256 -> 0, 257 -> 1.
+    const src = new Float32Array([2.9, 256, 257]);
+    const out = toClassBuffer(src);
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(Array.from(out)).toEqual([2, 0, 1]);
+  });
+
+  it('values above the byte range wrap mod 256 on write', () => {
+    const out = toClassBuffer([256, 300, 511]);
+    // 256 -> 0, 300 -> 44, 511 -> 255
+    expect(Array.from(out)).toEqual([0, 44, 255]);
+  });
+
+  it('preserves ASPRS class codes within the byte range unchanged', () => {
+    const out = toClassBuffer([1, 2, 3, 4, 5, 6, 9]);
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5, 6, 9]);
+  });
+
+  it('accepts a plain ArrayLike (length + indexer) source', () => {
+    const src: ArrayLike<number> = { length: 3, 0: 2, 1: 6, 2: 9 };
+    const out = toClassBuffer(src);
+    expect(Array.from(out)).toEqual([2, 6, 9]);
+  });
+});


### PR DESCRIPTION
Moves the pure `toClassBuffer(src: ArrayLike<number>): Uint8Array` narrowing helper out of `src/main.ts` into `src/render/class/classBuffer.ts`, beside the already-extracted `countClasses`. Verbatim move, no logic change; main.ts imports it back at the one call site in `refreshClassLegend`.

`countClasses` was already in `classHistogram.ts`, so no co-located helper moved with it.

Tests: `tests/classBuffer.test.ts` (7 cases) covers identity return for an existing Uint8Array, empty input, `number[]` copy, `Float32Array` copy with byte truncation, values wrapping mod 256 on write, in-range ASPRS codes preserved, and a plain ArrayLike source.

Ratchet: main.ts 6,983 -> 6,976. Baseline banked (`--update`), architecture-map candidates table drops the `toClassBuffer` row, and the main.ts/Viewer.ts counts in KNOWN_LIMITATIONS and architecture-map are updated so `lint:release-truth` passes.

Gates: typecheck, lint:monolith-size, lint:release-truth, lint:layer-boundaries, and the classBuffer/classHistogram suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)