### PR TITLE
Extract Viewer.snapshot behind a structural host

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.3.md
+++ b/KNOWN_LIMITATIONS_v0.6.3.md
@@ -6,7 +6,7 @@ Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 6,983 lines and `src/render/Viewer.ts` is 6,959, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 6,983 lines and `src/render/Viewer.ts` is 6,458, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -90,10 +90,6 @@ so it belongs beside the panels.
 
 Recorded so the next pass does not re-derive them:
 
-- **`snapshot`** — canvas compositing. Reaches into twelve Viewer internals and
-  twelve DOM/GL calls; the pure overlay maths (scale bar, colorbar, inspector
-  card) is already in its own modules. A host would expose the whole class for
-  no testable gain.
 - **The filter cluster** (`_classFiltered`, `_elevFilter*`, `_intenFilter*`) —
   not CPU predicates. They are three.js shader uniforms folded in a TSL pass;
   there is no Node-testable logic to lift.
@@ -119,7 +115,7 @@ called with a 19-member deps object. The candidates that remain:
 | `generateReportPdf` / `exportGeoContext` | 402 | export/report wiring module |
 | `importSession` | 177 | `src/app/sessionIo.ts` *(planned)* |
 
-**`src/render/Viewer.ts` (6,959)** — the constructor and a handful of large
+**`src/render/Viewer.ts` (6,458)** — the constructor and a handful of large
 methods dominate:
 
 Spans below are the symbol's real extent, read from the TypeScript symbol graph
@@ -130,7 +126,6 @@ been extracted, and both errors pointed the decomposition at the wrong work.
 | Block | Lines | Extraction target |
 |---|---:|---|
 | `constructor` | 564 | staged scene/pipeline builders |
-| `snapshot` | 143 | `src/render/snapshot.ts` *(planned)* |
 | `_startLoop` | 107 | `src/render/renderLoop.ts` *(planned)* |
 
 Done: `_buildExportAdapter` (265 lines) now lives in `src/render/exportAdapter.ts`,
@@ -143,6 +138,13 @@ Done: the colour-legend / scalar-range reads (`activeColorbar`, `elevationExtent
 shape, so the origin math, seeded gating and extent scans test without a WebGL
 context (`tests/viewerActiveColorbar.test.ts`). `Viewer` keeps three thin
 delegates and one host binding.
+
+Done: the `snapshot` capture pipeline (and its four overlay-compositing draw
+helpers) now lives in `src/render/snapshot.ts` behind a structural
+`SnapshotHost`, so the option resolution, fast-path decision and `toBlob`-null
+error path test without a canvas context (`tests/snapshot.test.ts`). The
+overlay-compositing branch still needs a real 2-D canvas and stays on the e2e
+export suite. `Viewer` keeps a one-line delegate and a host binding.
 
 Each extraction is one gated step: move the block, have it take its collaborators
 as parameters, keep the deterministic e2e project green, and re-run the coverage
@@ -160,8 +162,8 @@ and reaches into nav, camera, measure-datum and colour-context, so it moves
 only behind an explicit host interface, the same shape used for the export
 adapter and the lasso walk. That is the next decomposition step worth taking.
 The EDL cluster (`_edl*`) is a smaller follow-on. Everything else on the class
-— the constructor's scene/pipeline build, `snapshot`, the render loop body,
-event wiring — is the irreducibly view-bound remainder, and belongs here.
+— the constructor's scene/pipeline build, the render loop body, event wiring —
+is the irreducibly view-bound remainder, and belongs here.
 
 ## Test and gate topology
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -5,7 +5,7 @@
       "goal": 2500
     },
     "src/render/Viewer.ts": {
-      "lines": 6959,
+      "lines": 6458,
       "goal": 2000
     }
   }

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -93,8 +93,8 @@ import { yUpToCanonicalZUp } from '../terrain/canonicalFrame';
 import type { SourceFormat } from '../io/sniffFormat';
 import { colorForMode, defaultMode } from './colorModes';
 import type { ColorMode, CoverageColorGrid } from './colorModes';
-import { burnInColorbarLayout, type ActiveColorbar } from './activeColorbar';
-import { colorbarStops, niceTicks, formatColorbarValue } from './colorbar';
+import { type ActiveColorbar } from './activeColorbar';
+import { captureSnapshot, canvasToBlob, type SnapshotHost, type SnapshotOptions } from './snapshot';
 import { type ClipBox, clipKeepsPoint, countKept } from './clip/clipBox';
 import { edlDefaultEnabled, EDL_DEFAULTS, EDL_DEPTH_BIAS } from './edl';
 import { cameraIsMoving, edlActiveThisFrame } from './edlMotionGate';
@@ -177,7 +177,6 @@ export interface LassoVolumeReturn {
 }
 import { NavController } from './NavController';
 import type { NavMode, CameraPose } from './NavController';
-import { computeScaleBar, pixelsPerMetreAt } from './scaleBar';
 // Pure top-down framing math for the georeferenced Studio export (C4). A
 // dependency-free leaf, so this static import does NOT merge the lazy
 // pngWorldFile/Studio chunks into the shell bundle.
@@ -233,7 +232,6 @@ import { resolveStreamingCompatibility } from './streamingCompatibility';
 import { InspectTool } from './InspectTool';
 import { AnnotationController } from './annotate/AnnotationController';
 import type { SavedCameraState } from './annotate/types';
-import { loadSvgImage } from './snapshotSvg';
 import { LiveProbe } from './LiveProbe';
 import { downsampleToBudget } from '../process/voxelDownsample';
 import { makePointInfo } from './pointInfo';
@@ -417,62 +415,9 @@ export type ToolMode =
   | 'slice'
   | 'lasso';
 
-/**
- * Which overlay layers to burn into a {@link Viewer.snapshot}. With every
- * option off (the default) the snapshot is the bare rendered cloud, exactly as
- * before; enabling a layer composites that overlay's SVG on top.
- */
-export interface SnapshotOptions {
-  /** Include the annotation markers. */
-  annotations?: boolean;
-  /** Include the measurement geometry and value labels. */
-  measurements?: boolean;
-  /**
-   * Visual Export Studio — bake the active Inspect tool state:
-   * the selected-point marker (halo + dot) and a canvas-drawn point-info
-   * card (X/Y/Z, intensity, classification, RGB, etc.). When false (the
-   * default) the export is clean of inspector overlays even while the
-   * inspect tool is active in the UI.
-   */
-  inspector?: boolean;
-  /**
-   * Visual Export Studio — bake the most recent LiveProbe readout
-   * when probe mode is active. Uses the probe's last-known cursor position
-   * so the bake survives the "cursor moves to click Export" gap that would
-   * otherwise dismiss the live element before capture.
-   */
-  probe?: boolean;
-  /**
-   * v0.3.7 final-polish — supersample factor. 1 = native (default), 2 = 2×
-   * supersampled, 4 = 4× supersampled. The snapshot renders the GL canvas
-   * once at the requested resolution by upscaling the output canvas and
-   * compositing through the 2-D pipeline. Output dimensions become
-   * `canvas.width × factor` by `canvas.height × factor`.
-   *
-   * NOT a true MSAA — the GL framebuffer doesn't change. This is a
-   * post-render upscale that lets overlay SVGs and scale bars composite
-   * at higher resolution while the cloud itself reads at native quality.
-   * Use 2× for a sharp print-ready PNG; 4× for a hero shot.
-   */
-  supersample?: 1 | 2 | 4;
-  /**
-   * v0.3.7 final-polish — composite a scale-bar overlay at the bottom-left
-   * of the snapshot. The renderer feeds the bar a sane pixel-per-metre
-   * derived from the current camera, the bar picks a 1-2-5 nice step,
-   * and draws a contrasting bar + label.
-   */
-  scaleBar?: boolean;
-  /**
-   * Burn the labelled colorbar for the ACTIVE continuous colour mode
-   * (elevation / intensity / gpsTime / returnNumber) onto the right edge of
-   * the snapshot. Self-gating: categorical modes (rgb / classification /
-   * normal / density / coverage / confidence) draw nothing, so callers can
-   * request it unconditionally. The values come from the SAME spec-builder
-   * the on-screen legend overlay renders ({@link Viewer.activeColorbar}),
-   * so the exported figure and the live view can never disagree.
-   */
-  colorbar?: boolean;
-}
+// `SnapshotOptions` and the capture pipeline live in `snapshot.ts`; re-exported
+// here so existing importers keep resolving it from the Viewer module.
+export type { SnapshotOptions } from './snapshot';
 
 /**
  * A lightweight rendering-performance sample, surfaced by {@link Viewer.frameStats}
@@ -4686,7 +4631,6 @@ export class Viewer {
       gpuBytesEstimate,
     };
   }
-
   /**
    * Render one frame and capture it as a PNG `Blob`.
    *
@@ -4696,159 +4640,47 @@ export class Viewer {
    * resolution (high-DPI preserved), then each requested overlay is projected
    * with this exact camera, serialised to a self-styled SVG, rasterised and
    * drawn on top — so markers land precisely where they sit in the live view.
+   *
+   * The pipeline itself lives in `snapshot.ts` behind a structural
+   * {@link SnapshotHost}; this method only binds the Viewer's own state to it.
    */
   async snapshot(options?: SnapshotOptions): Promise<Blob> {
-    await this.ready;
-
-    // Render-and-present helper. The export pipeline mutates `colorAttr`
-    // immediately before calling snapshot — for WebGPU specifically, the
-    // first `render()` queues the new color buffer upload but the canvas
-    // won't carry the new frame until the browser ticks an animation
-    // frame. Calling `toBlob` immediately after a single un-awaited
-    // `render()` reads the *previous* frame, which is why every export
-    // mode came out looking identical (whatever was on screen before the
-    // swap). The fix is to render, wait for a present cycle, then render
-    // and wait once more — two frames is enough to flush the buffer
-    // upload, the post-processing pipeline if EDL is on, and the
-    // composited presentation.
-    const renderAndPresent = (): Promise<void> => {
-      if (this._edlEnabled) this._post.render();
-      else this._renderer.render(this._scene, this._camera);
-      return new Promise((resolve) => {
-        if (typeof requestAnimationFrame === 'function') {
-          requestAnimationFrame(() => resolve());
-        } else {
-          // Test / Node fallback — snapshot is browser-only in practice,
-          // but the type-check path goes through here without rAF.
-          setTimeout(resolve, 0);
-        }
-      });
-    };
-    await renderAndPresent();
-    await renderAndPresent();
-
-    const gl = this._renderer.domElement as HTMLCanvasElement;
-    const wantAnnotations = options?.annotations === true;
-    const wantMeasurements = options?.measurements === true;
-    const wantInspector = options?.inspector === true;
-    const wantProbe = options?.probe === true;
-    // v0.3.7 final-polish: supersample + scale bar both promote the
-    // export to the composite path so the upscaled output canvas can
-    // host overlays at the requested resolution.
-    const supersample =
-      options?.supersample === 2 || options?.supersample === 4 ? options.supersample : 1;
-    const wantScaleBar = options?.scaleBar === true;
-    // Colorbar burn-in — resolved up front so a categorical mode (which
-    // yields null) still takes the untouched fast path below. The spec is
-    // the SAME one the live overlay renders (activeColorbar), so the
-    // exported figure always matches the legend on screen.
-    const activeBar = options?.colorbar === true ? this.activeColorbar() : null;
-
-    // Fast path: no overlays + no upscale + no scale bar — return the
-    // GL canvas untouched at native resolution.
-    if (
-      !wantAnnotations &&
-      !wantMeasurements &&
-      !wantInspector &&
-      !wantProbe &&
-      !wantScaleBar &&
-      activeBar === null &&
-      supersample === 1
-    ) {
-      return this._canvasToBlob(gl);
-    }
-
-    // Composite path: draw the GL frame into a 2-D canvas at full
-    // (optionally upscaled) resolution.
-    const out = document.createElement('canvas');
-    out.width = gl.width * supersample;
-    out.height = gl.height * supersample;
-    const ctx = out.getContext('2d');
-    if (!ctx) return this._canvasToBlob(gl);
-    ctx.drawImage(gl, 0, 0, out.width, out.height);
-
-    // Re-project each overlay with the export camera, then serialise it, so
-    // alignment with the rendered frame is exact. Measurements sit beneath the
-    // annotation markers, matching the live stacking order; the inspector
-    // marker sits on top so the picked point is always identifiable.
-    const layers: string[] = [];
-    if (wantMeasurements) {
-      this._measure.render(this._camera, this._canvas);
-      layers.push(this._measure.overlaySVG());
-    }
-    if (wantAnnotations) {
-      this._annotate.render(this._camera, this._canvas);
-      layers.push(this._annotate.markerSVG());
-    }
-    if (wantInspector) {
-      // The marker overlay is re-rendered against the live canvas so the
-      // halo + dot coords match the current camera frame.
-      this._inspect.render();
-      layers.push(this._inspect.overlaySVG());
-    }
-    for (const svg of layers) {
-      const img = await loadSvgImage(svg);
-      if (img) ctx.drawImage(img, 0, 0, out.width, out.height);
-    }
-    // The point-info card the live UI shows is an HTML element, not SVG, so
-    // we redraw an equivalent on the 2-D canvas next to the marker. Only the
-    // selected-point fields the user actually sees are baked, so the card
-    // matches the live UI line for line.
-    if (wantInspector) {
-      const sel = this._inspect.selectionForExport();
-      if (sel) drawInspectorInfoCard(ctx, sel.info, sel.screen);
-    }
-    // v0.3.7 final-polish — scale bar overlay. Drawn last so it sits on
-    // top of everything else but underneath the inspector / probe cards.
-    if (wantScaleBar) {
-      // Estimate pixels-per-metre from the current camera. The reference
-      // distance is the orbit-target distance — what the analyst is
-      // actually looking at.
-      const dist = this._camera.position.distanceTo(this._controls.target);
-      const fovY = (this._camera.fov * Math.PI) / 180;
-      const ppm = pixelsPerMetreAt(fovY, out.height, dist);
-      // Use 22 % of the canvas width as the bar's budget — leaves room
-      // for the label and looks balanced in the bottom-left corner.
-      const budgetPx = Math.max(80, Math.min(out.width * 0.22, 400));
-      const bar = computeScaleBar(ppm, budgetPx);
-      if (bar.stepPixels > 0) {
-        drawScaleBar(ctx, out, bar);
-      }
-    }
-
-    // Colorbar legend burn-in — right edge, vertically centred, so it can
-    // never collide with the scale bar (bottom-left), the Studio's
-    // scan-report card (composed bottom-right after this snapshot), or the
-    // class-scope banner (top). Values and ramp come from the same
-    // `activeColorbar()` spec the on-screen overlay shows.
-    if (activeBar) {
-      drawColorbar(ctx, out, activeBar);
-    }
-
-    // LiveProbe — same compositing pattern. The probe stores its last known
-    // cursor position in CLIENT coordinates; translate to canvas-local pixels
-    // via the canvas's bounding rect so the bake lands where the user saw
-    // the readout.
-    if (wantProbe) {
-      const probe = this._probe.activeProbeForExport();
-      if (probe) {
-        const rect = this._canvas.getBoundingClientRect();
-        const sx = (probe.client.x - rect.left) * (out.width / rect.width);
-        const sy = (probe.client.y - rect.top) * (out.height / rect.height);
-        drawProbeReadoutCard(ctx, probe.info, { x: sx, y: sy });
-      }
-    }
-    return this._canvasToBlob(out);
+    return captureSnapshot(this._buildSnapshotHost(), options);
   }
 
-  /** Encode a canvas to a PNG `Blob`, rejecting if the browser returns none. */
-  private _canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
-    return new Promise<Blob>((resolve, reject) => {
-      canvas.toBlob((blob) => {
-        if (blob) resolve(blob);
-        else reject(new Error('Viewer.snapshot(): canvas.toBlob returned null'));
-      }, 'image/png');
-    });
+  /** Bind the Viewer's live render state to the {@link SnapshotHost} contract. */
+  private _buildSnapshotHost(): SnapshotHost {
+    return {
+      ready: () => this.ready,
+      renderFrame: () => {
+        if (this._edlEnabled) this._post.render();
+        else this._renderer.render(this._scene, this._camera);
+      },
+      glCanvas: () => this._renderer.domElement as HTMLCanvasElement,
+      activeColorbar: () => this.activeColorbar(),
+      measurementsOverlaySVG: () => {
+        this._measure.render(this._camera, this._canvas);
+        return this._measure.overlaySVG();
+      },
+      annotationsOverlaySVG: () => {
+        this._annotate.render(this._camera, this._canvas);
+        return this._annotate.markerSVG();
+      },
+      inspectorOverlaySVG: () => {
+        this._inspect.render();
+        return this._inspect.overlaySVG();
+      },
+      inspectorSelection: () => this._inspect.selectionForExport(),
+      probeReadout: () => this._probe.activeProbeForExport(),
+      canvasRect: () => {
+        const rect = this._canvas.getBoundingClientRect();
+        return { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
+      },
+      scaleBarCamera: () => ({
+        distanceToTarget: this._camera.position.distanceTo(this._controls.target),
+        fovYRadians: (this._camera.fov * Math.PI) / 180,
+      }),
+    };
   }
 
   /**
@@ -5110,7 +4942,7 @@ export class Viewer {
       };
       await present();
       await present();
-      return await this._canvasToBlob(gl);
+      return await canvasToBlob(gl);
     } finally {
       this._renderer.setPixelRatio(prevRatio);
       this._renderer.setSize(prevSize.x, prevSize.y, false);
@@ -6623,328 +6455,3 @@ export class Viewer {
   }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Visual Export Studio — inspector point-info card compositing
-// ─────────────────────────────────────────────────────────────────────────────
-
-import { classificationText, intensityText, rgbText } from './pointInfo';
-
-/**
- * Draw the InspectTool's "Point Info" card directly onto a 2-D canvas next
- * to the selected-point marker. Mirrors the live HTML card so the export
- * carries the same data the user saw on-screen — X/Y/Z, distance, intensity,
- * classification, RGB, optional LAS extras.
- *
- * Layout: small translucent dark card positioned to the right of the marker
- * (or left if there isn't room on the right). Auto-sizes to its content.
- */
-function drawInspectorInfoCard(
-  ctx: CanvasRenderingContext2D,
-  info: PointInfo,
-  screen: { x: number; y: number },
-): void {
-  // Build the rows the live card builds (see InspectTool._fillCard).
-  const rows: Array<[string, string]> = [
-    ['X', `${info.x} m`],
-    ['Y', `${info.y} m`],
-    ['Z', `${info.z} m`],
-    ['Distance', `${info.distance} m`],
-    ['Intensity', intensityText(info)],
-    ['Classification', classificationText(info)],
-    ['RGB', rgbText(info)],
-  ];
-  if (info.returnNumber !== undefined && info.returnCount !== undefined) {
-    rows.push(['Return', `${info.returnNumber} of ${info.returnCount}`]);
-  }
-  if (info.pointSourceId !== undefined) {
-    rows.push(['Point source', String(info.pointSourceId)]);
-  }
-  rows.push(['Layer', info.layer]);
-  rows.push(['Index', info.index.toLocaleString('en-US')]);
-
-  // Measure layout — the card width is driven by the widest row.
-  const PAD = 14;
-  const TITLE_SIZE = 14;
-  const ROW_SIZE = 12;
-  const ROW_GAP = 6;
-  ctx.save();
-  ctx.font = `600 ${TITLE_SIZE}px system-ui, -apple-system, sans-serif`;
-  const titleW = ctx.measureText('Point Info').width;
-  ctx.font = `${ROW_SIZE}px system-ui, -apple-system, sans-serif`;
-  let labelMax = 0;
-  let valueMax = 0;
-  for (const [l, v] of rows) {
-    labelMax = Math.max(labelMax, ctx.measureText(l).width);
-    valueMax = Math.max(valueMax, ctx.measureText(v).width);
-  }
-  const rowWidth = labelMax + 18 + valueMax;
-  const cardW = Math.max(titleW, rowWidth) + PAD * 2;
-  const cardH = PAD + TITLE_SIZE + 8 + rows.length * (ROW_SIZE + ROW_GAP) - ROW_GAP + PAD;
-
-  // Decide placement: prefer to the right of the marker, fall back to left
-  // if there isn't room on the right side of the canvas.
-  const MARKER_GAP = 18;
-  let x = screen.x + MARKER_GAP;
-  if (x + cardW > ctx.canvas.width - 8) x = screen.x - MARKER_GAP - cardW;
-  let y = screen.y - cardH / 2;
-  if (y < 8) y = 8;
-  if (y + cardH > ctx.canvas.height - 8) y = ctx.canvas.height - 8 - cardH;
-
-  // Card background with hairline border and accent stripe — visual style
-  // matches the scan-report card so the export reads as one consistent layer.
-  ctx.fillStyle = 'rgba(10, 14, 22, 0.92)';
-  ctx.strokeStyle = 'rgba(255, 255, 255, 0.14)';
-  ctx.lineWidth = 1;
-  const r = 6;
-  const rr = Math.min(r, cardW / 2, cardH / 2);
-  ctx.beginPath();
-  ctx.moveTo(x + rr, y);
-  ctx.arcTo(x + cardW, y, x + cardW, y + cardH, rr);
-  ctx.arcTo(x + cardW, y + cardH, x, y + cardH, rr);
-  ctx.arcTo(x, y + cardH, x, y, rr);
-  ctx.arcTo(x, y, x + cardW, y, rr);
-  ctx.closePath();
-  ctx.fill();
-  ctx.stroke();
-  ctx.fillStyle = '#4f9dff';
-  ctx.fillRect(x, y, 3, cardH);
-
-  // Title.
-  let cy = y + PAD + TITLE_SIZE;
-  ctx.fillStyle = '#f4f6fa';
-  ctx.font = `600 ${TITLE_SIZE}px system-ui, -apple-system, sans-serif`;
-  ctx.textBaseline = 'alphabetic';
-  ctx.textAlign = 'left';
-  ctx.fillText('Point Info', x + PAD, cy);
-
-  // Rows — label left, value right.
-  cy += 8;
-  ctx.font = `${ROW_SIZE}px system-ui, -apple-system, sans-serif`;
-  for (const [label, value] of rows) {
-    cy += ROW_SIZE;
-    ctx.fillStyle = '#a8b0bc';
-    ctx.textAlign = 'left';
-    ctx.fillText(label, x + PAD, cy);
-    ctx.fillStyle = '#f4f6fa';
-    ctx.textAlign = 'right';
-    ctx.fillText(value, x + cardW - PAD, cy);
-    cy += ROW_GAP;
-  }
-  ctx.restore();
-}
-
-/**
- * Draw the LiveProbe's compact readout (coordinates + key attributes) at
- * the cursor's last-known canvas position. Visually smaller than the
- * inspector card — the live probe is a glance-readout, not a study tool.
- */
-function drawProbeReadoutCard(
-  ctx: CanvasRenderingContext2D,
-  info: PointInfo,
-  screen: { x: number; y: number },
-): void {
-  const coords = `${info.x}, ${info.y}, ${info.z} m`;
-  const attrParts: string[] = [];
-  if (info.classification !== null) attrParts.push(classificationText(info));
-  if (info.intensity !== null) attrParts.push(`Intensity ${info.intensity}`);
-  const attrs = attrParts.join('  ·  ');
-
-  const PAD = 10;
-  const COORD_SIZE = 12;
-  const ATTR_SIZE = 11;
-  const ROW_GAP = 4;
-
-  ctx.save();
-  ctx.font = `600 ${COORD_SIZE}px system-ui, -apple-system, sans-serif`;
-  const coordW = ctx.measureText(coords).width;
-  ctx.font = `${ATTR_SIZE}px system-ui, -apple-system, sans-serif`;
-  const attrW = attrs ? ctx.measureText(attrs).width : 0;
-  const cardW = Math.max(coordW, attrW) + PAD * 2;
-  const cardH = PAD + COORD_SIZE + (attrs ? ROW_GAP + ATTR_SIZE : 0) + PAD;
-
-  // Cursor-aware placement — to the right and below, flipping when the
-  // card would clip the canvas edges.
-  const OFFSET = 16;
-  let x = screen.x + OFFSET;
-  if (x + cardW > ctx.canvas.width - 8) x = screen.x - OFFSET - cardW;
-  let y = screen.y + OFFSET;
-  if (y + cardH > ctx.canvas.height - 8) y = screen.y - OFFSET - cardH;
-  if (x < 8) x = 8;
-  if (y < 8) y = 8;
-
-  // Background — visually consistent with the inspector card but smaller
-  // and slightly less opaque so the cursor remains the dominant element.
-  ctx.fillStyle = 'rgba(10, 14, 22, 0.88)';
-  ctx.strokeStyle = 'rgba(255, 255, 255, 0.14)';
-  ctx.lineWidth = 1;
-  const r = 5;
-  const rr = Math.min(r, cardW / 2, cardH / 2);
-  ctx.beginPath();
-  ctx.moveTo(x + rr, y);
-  ctx.arcTo(x + cardW, y, x + cardW, y + cardH, rr);
-  ctx.arcTo(x + cardW, y + cardH, x, y + cardH, rr);
-  ctx.arcTo(x, y + cardH, x, y, rr);
-  ctx.arcTo(x, y, x + cardW, y, rr);
-  ctx.closePath();
-  ctx.fill();
-  ctx.stroke();
-
-  // Coordinates row.
-  let cy = y + PAD + COORD_SIZE;
-  ctx.fillStyle = '#f4f6fa';
-  ctx.font = `600 ${COORD_SIZE}px system-ui, -apple-system, sans-serif`;
-  ctx.textBaseline = 'alphabetic';
-  ctx.textAlign = 'left';
-  ctx.fillText(coords, x + PAD, cy);
-
-  // Attributes row (optional).
-  if (attrs) {
-    cy += ROW_GAP + ATTR_SIZE;
-    ctx.fillStyle = '#a8b0bc';
-    ctx.font = `${ATTR_SIZE}px system-ui, -apple-system, sans-serif`;
-    ctx.fillText(attrs, x + PAD, cy);
-  }
-  ctx.restore();
-}
-
-/**
- * v0.3.7 final-polish — paint a scale-bar overlay in the bottom-left
- * of the output canvas. Black bar with white tips + a white outline so
- * it stays legible against any cloud colour. Label sits above the bar.
- */
-function drawScaleBar(
-  ctx: CanvasRenderingContext2D,
-  out: HTMLCanvasElement,
-  bar: { stepPixels: number; label: string },
-): void {
-  if (bar.stepPixels <= 0) return;
-  // Padding scales with output height so the bar reads the same on a
-  // 1× snapshot and a 4× supersampled hero shot.
-  const padding = Math.max(12, Math.round(out.height * 0.022));
-  const barHeight = Math.max(6, Math.round(out.height * 0.008));
-  const tickHeight = barHeight * 1.6;
-  const fontSize = Math.max(11, Math.round(out.height * 0.018));
-  const x0 = padding;
-  const y0 = out.height - padding - barHeight;
-  ctx.save();
-  // White stroke under the bar so it reads against dark clouds.
-  ctx.strokeStyle = 'rgba(255, 255, 255, 0.95)';
-  ctx.lineWidth = 2;
-  ctx.strokeRect(x0 - 1, y0 - tickHeight + barHeight, bar.stepPixels + 2, tickHeight + 1);
-  // Black bar fill.
-  ctx.fillStyle = '#0d1117';
-  ctx.fillRect(x0, y0, bar.stepPixels, barHeight);
-  // White tick marks at the bar's ends.
-  ctx.fillStyle = '#ffffff';
-  ctx.fillRect(x0, y0 - tickHeight + barHeight, 2, tickHeight);
-  ctx.fillRect(x0 + bar.stepPixels - 2, y0 - tickHeight + barHeight, 2, tickHeight);
-  // Label above the bar — white with a black stroke so it reads on either tone.
-  ctx.font = `600 ${fontSize}px system-ui, -apple-system, sans-serif`;
-  ctx.textBaseline = 'bottom';
-  ctx.textAlign = 'left';
-  const labelY = y0 - tickHeight + barHeight - 4;
-  ctx.lineWidth = 3;
-  ctx.strokeStyle = 'rgba(13, 17, 23, 0.85)';
-  ctx.strokeText(bar.label, x0, labelY);
-  ctx.fillStyle = '#ffffff';
-  ctx.fillText(bar.label, x0, labelY);
-  ctx.restore();
-}
-
-/**
- * Burn the active colour mode's labelled colorbar onto the snapshot —
- * a vertical ramp on the right edge with the field name + unit above it,
- * tick labels to its left, and the honesty note (percentile window /
- * gpsTime normalisation) beneath the bar.
- *
- * RASTERISES the same data the SVG generator serialises: the ramp segments
- * come from {@link colorbarStops} (which samples the exact per-mode painting,
- * grayscale included) and the tick values from {@link niceTicks} — so the
- * burned-in legend and the on-screen SVG can never disagree. The geometry is
- * the pure {@link burnInColorbarLayout} (unit-tested separately); this
- * function only owns the ctx calls, mirroring `drawScaleBar`'s split. Text
- * is white with a dark stroke — the same treatment as the scale bar — so it
- * reads on any cloud colour without needing a backing card.
- */
-function drawColorbar(
-  ctx: CanvasRenderingContext2D,
-  out: HTMLCanvasElement,
-  active: ActiveColorbar,
-): void {
-  const spec = active.spec;
-  const L = burnInColorbarLayout(out.width, out.height);
-  const range = spec.max - spec.min;
-  if (!(range > 0)) return; // defensive — the spec-builder already refuses this
-
-  ctx.save();
-  const font = (px: number, weight = 400): string =>
-    `${weight} ${px}px system-ui, -apple-system, sans-serif`;
-  const strokedText = (text: string, x: number, y: number): void => {
-    // Dark stroke under white fill — legible on light and dark clouds alike.
-    ctx.lineWidth = 3;
-    ctx.strokeStyle = 'rgba(13, 17, 23, 0.85)';
-    ctx.strokeText(text, x, y);
-    ctx.fillStyle = '#ffffff';
-    ctx.fillText(text, x, y);
-  };
-
-  // Title (field name + unit when known) above the bar, right-aligned to the
-  // bar's right edge so long labels grow inward, never off-canvas.
-  ctx.textAlign = 'right';
-  ctx.textBaseline = 'bottom';
-  ctx.font = font(L.titleFontSize, 600);
-  const title = spec.unit ? `${spec.label} (${spec.unit})` : spec.label;
-  const titleY = L.barY - Math.round(L.titleFontSize * 0.6);
-  strokedText(title, L.barX + L.barWidth, titleY);
-  // Honesty note under the bar, smaller — e.g. "p5–p95 window".
-  if (active.note) {
-    ctx.font = font(Math.max(9, Math.round(L.fontSize * 0.85)));
-    strokedText(active.note, L.barX + L.barWidth, L.barY + L.barHeight + Math.round(L.fontSize * 1.4));
-  }
-
-  // The ramp — adjacent rects sampled from the SAME stops the SVG gradient
-  // uses, bottom = min → top = max. 64 samples ≈ visually continuous while
-  // staying trivially rasterisable on a bare 2D context (no gradient object,
-  // so the draw also works under the mock contexts tests use).
-  const stops = colorbarStops(spec.palette, 64);
-  for (let i = 0; i < stops.length - 1; i++) {
-    const t0 = stops[i].t;
-    const t1 = stops[i + 1].t;
-    const yTop = L.barY + (1 - t1) * L.barHeight;
-    const h = (t1 - t0) * L.barHeight;
-    const [r, g, b] = stops[i].rgb;
-    ctx.fillStyle = `rgb(${r},${g},${b})`;
-    // +1px overlap hides seam hairlines from fractional rects.
-    ctx.fillRect(L.barX, yTop, L.barWidth, h + 1);
-  }
-  // White outline so the bar reads against dark clouds (scale-bar treatment).
-  ctx.strokeStyle = 'rgba(255, 255, 255, 0.95)';
-  ctx.lineWidth = 1;
-  ctx.strokeRect(L.barX - 0.5, L.barY - 0.5, L.barWidth + 1, L.barHeight + 1);
-
-  // Tick labels to the LEFT of the bar (the right side is the canvas edge).
-  // The exact endpoints are always labelled — the legend MUST state min/max
-  // — and nice interior ticks fill in between, skipping any that would
-  // collide with the endpoint labels.
-  ctx.font = font(L.fontSize);
-  ctx.textAlign = 'right';
-  ctx.textBaseline = 'middle';
-  const labelX = L.barX - L.tickLength - 4;
-  const yOf = (v: number): number => L.barY + (1 - (v - spec.min) / range) * L.barHeight;
-  const drawTick = (v: number): void => {
-    const y = yOf(v);
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(L.barX - L.tickLength, Math.round(y) - 1, L.tickLength, 2);
-    strokedText(formatColorbarValue(v), labelX, y);
-  };
-  drawTick(spec.min);
-  drawTick(spec.max);
-  const clearance = L.fontSize * 1.1;
-  for (const v of niceTicks(spec.min, spec.max, spec.ticks ?? 5)) {
-    const y = yOf(v);
-    if (Math.abs(y - yOf(spec.min)) < clearance) continue;
-    if (Math.abs(y - yOf(spec.max)) < clearance) continue;
-    drawTick(v);
-  }
-  ctx.restore();
-}

--- a/src/render/snapshot.ts
+++ b/src/render/snapshot.ts
@@ -1,0 +1,616 @@
+/**
+ * snapshot.ts — the frame-capture pipeline the Viewer's `snapshot()` delegates to.
+ *
+ * Render one frame and return it as a PNG `Blob`. With no options (or all off)
+ * this returns the bare rendered cloud — the original, fast path. With an
+ * overlay enabled it becomes a compositor: the rendered frame is drawn into a
+ * 2-D canvas at the GL drawing-buffer resolution (high-DPI preserved), then each
+ * requested overlay is projected with the export camera, serialised to a
+ * self-styled SVG, rasterised and drawn on top — so markers land precisely where
+ * they sit in the live view.
+ *
+ * The logic reads the live scene through a structural {@link SnapshotHost} — a
+ * handful of accessor functions rather than the Viewer itself — so nothing here
+ * imports `Viewer`, the same seam the export adapter and colour legend use.
+ * `Viewer` keeps a thin method that binds its own state to the host. Part of the
+ * v0.6 decomposition (see `docs/architecture/architecture-map.md`).
+ */
+
+import { loadSvgImage } from './snapshotSvg';
+import { classificationText, intensityText, rgbText, type PointInfo } from './pointInfo';
+import { computeScaleBar, pixelsPerMetreAt } from './scaleBar';
+import { burnInColorbarLayout, type ActiveColorbar } from './activeColorbar';
+import { colorbarStops, niceTicks, formatColorbarValue } from './colorbar';
+
+export interface SnapshotOptions {
+  /** Include the annotation markers. */
+  annotations?: boolean;
+  /** Include the measurement geometry and value labels. */
+  measurements?: boolean;
+  /**
+   * Visual Export Studio — bake the active Inspect tool state:
+   * the selected-point marker (halo + dot) and a canvas-drawn point-info
+   * card (X/Y/Z, intensity, classification, RGB, etc.). When false (the
+   * default) the export is clean of inspector overlays even while the
+   * inspect tool is active in the UI.
+   */
+  inspector?: boolean;
+  /**
+   * Visual Export Studio — bake the most recent LiveProbe readout
+   * when probe mode is active. Uses the probe's last-known cursor position
+   * so the bake survives the "cursor moves to click Export" gap that would
+   * otherwise dismiss the live element before capture.
+   */
+  probe?: boolean;
+  /**
+   * v0.3.7 final-polish — supersample factor. 1 = native (default), 2 = 2×
+   * supersampled, 4 = 4× supersampled. The snapshot renders the GL canvas
+   * once at the requested resolution by upscaling the output canvas and
+   * compositing through the 2-D pipeline. Output dimensions become
+   * `canvas.width × factor` by `canvas.height × factor`.
+   *
+   * NOT a true MSAA — the GL framebuffer doesn't change. This is a
+   * post-render upscale that lets overlay SVGs and scale bars composite
+   * at higher resolution while the cloud itself reads at native quality.
+   * Use 2× for a sharp print-ready PNG; 4× for a hero shot.
+   */
+  supersample?: 1 | 2 | 4;
+  /**
+   * v0.3.7 final-polish — composite a scale-bar overlay at the bottom-left
+   * of the snapshot. The renderer feeds the bar a sane pixel-per-metre
+   * derived from the current camera, the bar picks a 1-2-5 nice step,
+   * and draws a contrasting bar + label.
+   */
+  scaleBar?: boolean;
+  /**
+   * Burn the labelled colorbar for the ACTIVE continuous colour mode
+   * (elevation / intensity / gpsTime / returnNumber) onto the right edge of
+   * the snapshot. Self-gating: categorical modes (rgb / classification /
+   * normal / density / coverage / confidence) draw nothing, so callers can
+   * request it unconditionally. The values come from the SAME spec-builder
+   * the on-screen legend overlay renders, so the exported figure and the live
+   * view can never disagree.
+   */
+  colorbar?: boolean;
+}
+
+/**
+ * What the snapshot pipeline needs from the live scene. Accessors are
+ * functions, not snapshots, so the capture always reflects the CURRENT scene —
+ * the property the previous inline method had by reading `this` per call.
+ */
+export interface SnapshotHost {
+  /** Resolves once the Viewer's first frame is ready. */
+  ready(): Promise<void>;
+  /** Render one frame through the active pipeline (EDL post-process or direct). */
+  renderFrame(): void;
+  /** The live GL drawing-buffer canvas. */
+  glCanvas(): HTMLCanvasElement;
+  /** The active continuous-colour legend spec, or null for categorical modes. */
+  activeColorbar(): ActiveColorbar | null;
+  /** Render the measurement overlay against the live camera and serialise it. */
+  measurementsOverlaySVG(): string;
+  /** Render the annotation markers against the live camera and serialise them. */
+  annotationsOverlaySVG(): string;
+  /** Render the inspector marker against the live camera and serialise it. */
+  inspectorOverlaySVG(): string;
+  /** The inspector's selected point for the info-card bake, or null. */
+  inspectorSelection(): { info: PointInfo; screen: { x: number; y: number } } | null;
+  /** The most recent probe readout for the bake, or null. */
+  probeReadout(): { info: PointInfo; client: { x: number; y: number } } | null;
+  /** The live canvas bounding rect, for translating client→canvas pixels. */
+  canvasRect(): { left: number; top: number; width: number; height: number };
+  /**
+   * Camera reference for the scale bar: the orbit-target distance (what the
+   * analyst is actually looking at) and the vertical field of view in radians.
+   */
+  scaleBarCamera(): { distanceToTarget: number; fovYRadians: number };
+}
+
+/** The resolved option flags a single capture acts on. */
+export interface SnapshotPlan {
+  wantAnnotations: boolean;
+  wantMeasurements: boolean;
+  wantInspector: boolean;
+  wantProbe: boolean;
+  wantScaleBar: boolean;
+  wantColorbar: boolean;
+  /** Only 2 or 4 promote; anything else (incl. undefined) stays native 1. */
+  supersample: 1 | 2 | 4;
+}
+
+/** Resolve the raw options into the flags the capture path branches on. */
+export function resolveSnapshotPlan(options?: SnapshotOptions): SnapshotPlan {
+  return {
+    wantAnnotations: options?.annotations === true,
+    wantMeasurements: options?.measurements === true,
+    wantInspector: options?.inspector === true,
+    wantProbe: options?.probe === true,
+    wantScaleBar: options?.scaleBar === true,
+    wantColorbar: options?.colorbar === true,
+    // supersample + scale bar both promote the export to the composite path so
+    // the upscaled output canvas can host overlays at the requested resolution.
+    supersample:
+      options?.supersample === 2 || options?.supersample === 4 ? options.supersample : 1,
+  };
+}
+
+/**
+ * True when the capture can return the GL canvas untouched at native
+ * resolution — no overlays, no upscale, no scale bar, no colorbar. `activeBar`
+ * is passed in because it is resolved from the host, not the options.
+ */
+export function fastPathEligible(plan: SnapshotPlan, activeBar: ActiveColorbar | null): boolean {
+  return (
+    !plan.wantAnnotations &&
+    !plan.wantMeasurements &&
+    !plan.wantInspector &&
+    !plan.wantProbe &&
+    !plan.wantScaleBar &&
+    activeBar === null &&
+    plan.supersample === 1
+  );
+}
+
+/** Encode a canvas to a PNG `Blob`, rejecting if the browser returns none. */
+export function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error('Viewer.snapshot(): canvas.toBlob returned null'));
+    }, 'image/png');
+  });
+}
+
+/**
+ * Render one frame and capture it as a PNG `Blob`. See the module doc for the
+ * fast-path / compositor split.
+ */
+export async function captureSnapshot(
+  host: SnapshotHost,
+  options?: SnapshotOptions,
+): Promise<Blob> {
+  await host.ready();
+
+  // Render-and-present helper. The export pipeline mutates `colorAttr`
+  // immediately before calling snapshot — for WebGPU specifically, the
+  // first `render()` queues the new color buffer upload but the canvas
+  // won't carry the new frame until the browser ticks an animation
+  // frame. Calling `toBlob` immediately after a single un-awaited
+  // `render()` reads the *previous* frame, which is why every export
+  // mode came out looking identical (whatever was on screen before the
+  // swap). The fix is to render, wait for a present cycle, then render
+  // and wait once more — two frames is enough to flush the buffer
+  // upload, the post-processing pipeline if EDL is on, and the
+  // composited presentation.
+  const renderAndPresent = (): Promise<void> => {
+    host.renderFrame();
+    return new Promise((resolve) => {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => resolve());
+      } else {
+        // Test / Node fallback — snapshot is browser-only in practice,
+        // but the type-check path goes through here without rAF.
+        setTimeout(resolve, 0);
+      }
+    });
+  };
+  await renderAndPresent();
+  await renderAndPresent();
+
+  const gl = host.glCanvas();
+  const plan = resolveSnapshotPlan(options);
+  // Colorbar burn-in — resolved up front so a categorical mode (which
+  // yields null) still takes the untouched fast path below. The spec is
+  // the SAME one the live overlay renders (activeColorbar), so the
+  // exported figure always matches the legend on screen.
+  const activeBar = plan.wantColorbar ? host.activeColorbar() : null;
+
+  // Fast path: no overlays + no upscale + no scale bar — return the
+  // GL canvas untouched at native resolution.
+  if (fastPathEligible(plan, activeBar)) {
+    return canvasToBlob(gl);
+  }
+
+  // Composite path: draw the GL frame into a 2-D canvas at full
+  // (optionally upscaled) resolution.
+  const out = document.createElement('canvas');
+  out.width = gl.width * plan.supersample;
+  out.height = gl.height * plan.supersample;
+  const ctx = out.getContext('2d');
+  if (!ctx) return canvasToBlob(gl);
+  ctx.drawImage(gl, 0, 0, out.width, out.height);
+
+  // Re-project each overlay with the export camera, then serialise it, so
+  // alignment with the rendered frame is exact. Measurements sit beneath the
+  // annotation markers, matching the live stacking order; the inspector
+  // marker sits on top so the picked point is always identifiable.
+  const layers: string[] = [];
+  if (plan.wantMeasurements) {
+    layers.push(host.measurementsOverlaySVG());
+  }
+  if (plan.wantAnnotations) {
+    layers.push(host.annotationsOverlaySVG());
+  }
+  if (plan.wantInspector) {
+    // The marker overlay is re-rendered against the live canvas so the
+    // halo + dot coords match the current camera frame.
+    layers.push(host.inspectorOverlaySVG());
+  }
+  for (const svg of layers) {
+    const img = await loadSvgImage(svg);
+    if (img) ctx.drawImage(img, 0, 0, out.width, out.height);
+  }
+  // The point-info card the live UI shows is an HTML element, not SVG, so
+  // we redraw an equivalent on the 2-D canvas next to the marker. Only the
+  // selected-point fields the user actually sees are baked, so the card
+  // matches the live UI line for line.
+  if (plan.wantInspector) {
+    const sel = host.inspectorSelection();
+    if (sel) drawInspectorInfoCard(ctx, sel.info, sel.screen);
+  }
+  // v0.3.7 final-polish — scale bar overlay. Drawn last so it sits on
+  // top of everything else but underneath the inspector / probe cards.
+  if (plan.wantScaleBar) {
+    // Estimate pixels-per-metre from the current camera. The reference
+    // distance is the orbit-target distance — what the analyst is
+    // actually looking at.
+    const { distanceToTarget, fovYRadians } = host.scaleBarCamera();
+    const ppm = pixelsPerMetreAt(fovYRadians, out.height, distanceToTarget);
+    // Use 22 % of the canvas width as the bar's budget — leaves room
+    // for the label and looks balanced in the bottom-left corner.
+    const budgetPx = Math.max(80, Math.min(out.width * 0.22, 400));
+    const bar = computeScaleBar(ppm, budgetPx);
+    if (bar.stepPixels > 0) {
+      drawScaleBar(ctx, out, bar);
+    }
+  }
+
+  // Colorbar legend burn-in — right edge, vertically centred, so it can
+  // never collide with the scale bar (bottom-left), the Studio's
+  // scan-report card (composed bottom-right after this snapshot), or the
+  // class-scope banner (top). Values and ramp come from the same
+  // `activeColorbar()` spec the on-screen overlay shows.
+  if (activeBar) {
+    drawColorbar(ctx, out, activeBar);
+  }
+
+  // LiveProbe — same compositing pattern. The probe stores its last known
+  // cursor position in CLIENT coordinates; translate to canvas-local pixels
+  // via the canvas's bounding rect so the bake lands where the user saw
+  // the readout.
+  if (plan.wantProbe) {
+    const probe = host.probeReadout();
+    if (probe) {
+      const rect = host.canvasRect();
+      const sx = (probe.client.x - rect.left) * (out.width / rect.width);
+      const sy = (probe.client.y - rect.top) * (out.height / rect.height);
+      drawProbeReadoutCard(ctx, probe.info, { x: sx, y: sy });
+    }
+  }
+  return canvasToBlob(out);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Visual Export Studio — overlay compositing onto the 2-D output canvas
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Draw the InspectTool's "Point Info" card directly onto a 2-D canvas next
+ * to the selected-point marker. Mirrors the live HTML card so the export
+ * carries the same data the user saw on-screen — X/Y/Z, distance, intensity,
+ * classification, RGB, optional LAS extras.
+ *
+ * Layout: small translucent dark card positioned to the right of the marker
+ * (or left if there isn't room on the right). Auto-sizes to its content.
+ */
+function drawInspectorInfoCard(
+  ctx: CanvasRenderingContext2D,
+  info: PointInfo,
+  screen: { x: number; y: number },
+): void {
+  // Build the rows the live card builds (see InspectTool._fillCard).
+  const rows: Array<[string, string]> = [
+    ['X', `${info.x} m`],
+    ['Y', `${info.y} m`],
+    ['Z', `${info.z} m`],
+    ['Distance', `${info.distance} m`],
+    ['Intensity', intensityText(info)],
+    ['Classification', classificationText(info)],
+    ['RGB', rgbText(info)],
+  ];
+  if (info.returnNumber !== undefined && info.returnCount !== undefined) {
+    rows.push(['Return', `${info.returnNumber} of ${info.returnCount}`]);
+  }
+  if (info.pointSourceId !== undefined) {
+    rows.push(['Point source', String(info.pointSourceId)]);
+  }
+  rows.push(['Layer', info.layer]);
+  rows.push(['Index', info.index.toLocaleString('en-US')]);
+
+  // Measure layout — the card width is driven by the widest row.
+  const PAD = 14;
+  const TITLE_SIZE = 14;
+  const ROW_SIZE = 12;
+  const ROW_GAP = 6;
+  ctx.save();
+  ctx.font = `600 ${TITLE_SIZE}px system-ui, -apple-system, sans-serif`;
+  const titleW = ctx.measureText('Point Info').width;
+  ctx.font = `${ROW_SIZE}px system-ui, -apple-system, sans-serif`;
+  let labelMax = 0;
+  let valueMax = 0;
+  for (const [l, v] of rows) {
+    labelMax = Math.max(labelMax, ctx.measureText(l).width);
+    valueMax = Math.max(valueMax, ctx.measureText(v).width);
+  }
+  const rowWidth = labelMax + 18 + valueMax;
+  const cardW = Math.max(titleW, rowWidth) + PAD * 2;
+  const cardH = PAD + TITLE_SIZE + 8 + rows.length * (ROW_SIZE + ROW_GAP) - ROW_GAP + PAD;
+
+  // Decide placement: prefer to the right of the marker, fall back to left
+  // if there isn't room on the right side of the canvas.
+  const MARKER_GAP = 18;
+  let x = screen.x + MARKER_GAP;
+  if (x + cardW > ctx.canvas.width - 8) x = screen.x - MARKER_GAP - cardW;
+  let y = screen.y - cardH / 2;
+  if (y < 8) y = 8;
+  if (y + cardH > ctx.canvas.height - 8) y = ctx.canvas.height - 8 - cardH;
+
+  // Card background with hairline border and accent stripe — visual style
+  // matches the scan-report card so the export reads as one consistent layer.
+  ctx.fillStyle = 'rgba(10, 14, 22, 0.92)';
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.14)';
+  ctx.lineWidth = 1;
+  const r = 6;
+  const rr = Math.min(r, cardW / 2, cardH / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + rr, y);
+  ctx.arcTo(x + cardW, y, x + cardW, y + cardH, rr);
+  ctx.arcTo(x + cardW, y + cardH, x, y + cardH, rr);
+  ctx.arcTo(x, y + cardH, x, y, rr);
+  ctx.arcTo(x, y, x + cardW, y, rr);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+  ctx.fillStyle = '#4f9dff';
+  ctx.fillRect(x, y, 3, cardH);
+
+  // Title.
+  let cy = y + PAD + TITLE_SIZE;
+  ctx.fillStyle = '#f4f6fa';
+  ctx.font = `600 ${TITLE_SIZE}px system-ui, -apple-system, sans-serif`;
+  ctx.textBaseline = 'alphabetic';
+  ctx.textAlign = 'left';
+  ctx.fillText('Point Info', x + PAD, cy);
+
+  // Rows — label left, value right.
+  cy += 8;
+  ctx.font = `${ROW_SIZE}px system-ui, -apple-system, sans-serif`;
+  for (const [label, value] of rows) {
+    cy += ROW_SIZE;
+    ctx.fillStyle = '#a8b0bc';
+    ctx.textAlign = 'left';
+    ctx.fillText(label, x + PAD, cy);
+    ctx.fillStyle = '#f4f6fa';
+    ctx.textAlign = 'right';
+    ctx.fillText(value, x + cardW - PAD, cy);
+    cy += ROW_GAP;
+  }
+  ctx.restore();
+}
+
+/**
+ * Draw the LiveProbe's compact readout (coordinates + key attributes) at
+ * the cursor's last-known canvas position. Visually smaller than the
+ * inspector card — the live probe is a glance-readout, not a study tool.
+ */
+function drawProbeReadoutCard(
+  ctx: CanvasRenderingContext2D,
+  info: PointInfo,
+  screen: { x: number; y: number },
+): void {
+  const coords = `${info.x}, ${info.y}, ${info.z} m`;
+  const attrParts: string[] = [];
+  if (info.classification !== null) attrParts.push(classificationText(info));
+  if (info.intensity !== null) attrParts.push(`Intensity ${info.intensity}`);
+  const attrs = attrParts.join('  ·  ');
+
+  const PAD = 10;
+  const COORD_SIZE = 12;
+  const ATTR_SIZE = 11;
+  const ROW_GAP = 4;
+
+  ctx.save();
+  ctx.font = `600 ${COORD_SIZE}px system-ui, -apple-system, sans-serif`;
+  const coordW = ctx.measureText(coords).width;
+  ctx.font = `${ATTR_SIZE}px system-ui, -apple-system, sans-serif`;
+  const attrW = attrs ? ctx.measureText(attrs).width : 0;
+  const cardW = Math.max(coordW, attrW) + PAD * 2;
+  const cardH = PAD + COORD_SIZE + (attrs ? ROW_GAP + ATTR_SIZE : 0) + PAD;
+
+  // Cursor-aware placement — to the right and below, flipping when the
+  // card would clip the canvas edges.
+  const OFFSET = 16;
+  let x = screen.x + OFFSET;
+  if (x + cardW > ctx.canvas.width - 8) x = screen.x - OFFSET - cardW;
+  let y = screen.y + OFFSET;
+  if (y + cardH > ctx.canvas.height - 8) y = screen.y - OFFSET - cardH;
+  if (x < 8) x = 8;
+  if (y < 8) y = 8;
+
+  // Background — visually consistent with the inspector card but smaller
+  // and slightly less opaque so the cursor remains the dominant element.
+  ctx.fillStyle = 'rgba(10, 14, 22, 0.88)';
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.14)';
+  ctx.lineWidth = 1;
+  const r = 5;
+  const rr = Math.min(r, cardW / 2, cardH / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + rr, y);
+  ctx.arcTo(x + cardW, y, x + cardW, y + cardH, rr);
+  ctx.arcTo(x + cardW, y + cardH, x, y + cardH, rr);
+  ctx.arcTo(x, y + cardH, x, y, rr);
+  ctx.arcTo(x, y, x + cardW, y, rr);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
+  // Coordinates row.
+  let cy = y + PAD + COORD_SIZE;
+  ctx.fillStyle = '#f4f6fa';
+  ctx.font = `600 ${COORD_SIZE}px system-ui, -apple-system, sans-serif`;
+  ctx.textBaseline = 'alphabetic';
+  ctx.textAlign = 'left';
+  ctx.fillText(coords, x + PAD, cy);
+
+  // Attributes row (optional).
+  if (attrs) {
+    cy += ROW_GAP + ATTR_SIZE;
+    ctx.fillStyle = '#a8b0bc';
+    ctx.font = `${ATTR_SIZE}px system-ui, -apple-system, sans-serif`;
+    ctx.fillText(attrs, x + PAD, cy);
+  }
+  ctx.restore();
+}
+
+/**
+ * v0.3.7 final-polish — paint a scale-bar overlay in the bottom-left
+ * of the output canvas. Black bar with white tips + a white outline so
+ * it stays legible against any cloud colour. Label sits above the bar.
+ */
+function drawScaleBar(
+  ctx: CanvasRenderingContext2D,
+  out: HTMLCanvasElement,
+  bar: { stepPixels: number; label: string },
+): void {
+  if (bar.stepPixels <= 0) return;
+  // Padding scales with output height so the bar reads the same on a
+  // 1× snapshot and a 4× supersampled hero shot.
+  const padding = Math.max(12, Math.round(out.height * 0.022));
+  const barHeight = Math.max(6, Math.round(out.height * 0.008));
+  const tickHeight = barHeight * 1.6;
+  const fontSize = Math.max(11, Math.round(out.height * 0.018));
+  const x0 = padding;
+  const y0 = out.height - padding - barHeight;
+  ctx.save();
+  // White stroke under the bar so it reads against dark clouds.
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.95)';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(x0 - 1, y0 - tickHeight + barHeight, bar.stepPixels + 2, tickHeight + 1);
+  // Black bar fill.
+  ctx.fillStyle = '#0d1117';
+  ctx.fillRect(x0, y0, bar.stepPixels, barHeight);
+  // White tick marks at the bar's ends.
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(x0, y0 - tickHeight + barHeight, 2, tickHeight);
+  ctx.fillRect(x0 + bar.stepPixels - 2, y0 - tickHeight + barHeight, 2, tickHeight);
+  // Label above the bar — white with a black stroke so it reads on either tone.
+  ctx.font = `600 ${fontSize}px system-ui, -apple-system, sans-serif`;
+  ctx.textBaseline = 'bottom';
+  ctx.textAlign = 'left';
+  const labelY = y0 - tickHeight + barHeight - 4;
+  ctx.lineWidth = 3;
+  ctx.strokeStyle = 'rgba(13, 17, 23, 0.85)';
+  ctx.strokeText(bar.label, x0, labelY);
+  ctx.fillStyle = '#ffffff';
+  ctx.fillText(bar.label, x0, labelY);
+  ctx.restore();
+}
+
+/**
+ * Burn the active colour mode's labelled colorbar onto the snapshot —
+ * a vertical ramp on the right edge with the field name + unit above it,
+ * tick labels to its left, and the honesty note (percentile window /
+ * gpsTime normalisation) beneath the bar.
+ *
+ * RASTERISES the same data the SVG generator serialises: the ramp segments
+ * come from {@link colorbarStops} (which samples the exact per-mode painting,
+ * grayscale included) and the tick values from {@link niceTicks} — so the
+ * burned-in legend and the on-screen SVG can never disagree. The geometry is
+ * the pure {@link burnInColorbarLayout} (unit-tested separately); this
+ * function only owns the ctx calls, mirroring `drawScaleBar`'s split. Text
+ * is white with a dark stroke — the same treatment as the scale bar — so it
+ * reads on any cloud colour without needing a backing card.
+ */
+function drawColorbar(
+  ctx: CanvasRenderingContext2D,
+  out: HTMLCanvasElement,
+  active: ActiveColorbar,
+): void {
+  const spec = active.spec;
+  const L = burnInColorbarLayout(out.width, out.height);
+  const range = spec.max - spec.min;
+  if (!(range > 0)) return; // defensive — the spec-builder already refuses this
+
+  ctx.save();
+  const font = (px: number, weight = 400): string =>
+    `${weight} ${px}px system-ui, -apple-system, sans-serif`;
+  const strokedText = (text: string, x: number, y: number): void => {
+    // Dark stroke under white fill — legible on light and dark clouds alike.
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = 'rgba(13, 17, 23, 0.85)';
+    ctx.strokeText(text, x, y);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillText(text, x, y);
+  };
+
+  // Title (field name + unit when known) above the bar, right-aligned to the
+  // bar's right edge so long labels grow inward, never off-canvas.
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'bottom';
+  ctx.font = font(L.titleFontSize, 600);
+  const title = spec.unit ? `${spec.label} (${spec.unit})` : spec.label;
+  const titleY = L.barY - Math.round(L.titleFontSize * 0.6);
+  strokedText(title, L.barX + L.barWidth, titleY);
+  // Honesty note under the bar, smaller — e.g. "p5–p95 window".
+  if (active.note) {
+    ctx.font = font(Math.max(9, Math.round(L.fontSize * 0.85)));
+    strokedText(active.note, L.barX + L.barWidth, L.barY + L.barHeight + Math.round(L.fontSize * 1.4));
+  }
+
+  // The ramp — adjacent rects sampled from the SAME stops the SVG gradient
+  // uses, bottom = min → top = max. 64 samples ≈ visually continuous while
+  // staying trivially rasterisable on a bare 2D context (no gradient object,
+  // so the draw also works under the mock contexts tests use).
+  const stops = colorbarStops(spec.palette, 64);
+  for (let i = 0; i < stops.length - 1; i++) {
+    const t0 = stops[i].t;
+    const t1 = stops[i + 1].t;
+    const yTop = L.barY + (1 - t1) * L.barHeight;
+    const h = (t1 - t0) * L.barHeight;
+    const [r, g, b] = stops[i].rgb;
+    ctx.fillStyle = `rgb(${r},${g},${b})`;
+    // +1px overlap hides seam hairlines from fractional rects.
+    ctx.fillRect(L.barX, yTop, L.barWidth, h + 1);
+  }
+  // White outline so the bar reads against dark clouds (scale-bar treatment).
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.95)';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(L.barX - 0.5, L.barY - 0.5, L.barWidth + 1, L.barHeight + 1);
+
+  // Tick labels to the LEFT of the bar (the right side is the canvas edge).
+  // The exact endpoints are always labelled — the legend MUST state min/max
+  // — and nice interior ticks fill in between, skipping any that would
+  // collide with the endpoint labels.
+  ctx.font = font(L.fontSize);
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'middle';
+  const labelX = L.barX - L.tickLength - 4;
+  const yOf = (v: number): number => L.barY + (1 - (v - spec.min) / range) * L.barHeight;
+  const drawTick = (v: number): void => {
+    const y = yOf(v);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(L.barX - L.tickLength, Math.round(y) - 1, L.tickLength, 2);
+    strokedText(formatColorbarValue(v), labelX, y);
+  };
+  drawTick(spec.min);
+  drawTick(spec.max);
+  const clearance = L.fontSize * 1.1;
+  for (const v of niceTicks(spec.min, spec.max, spec.ticks ?? 5)) {
+    const y = yOf(v);
+    if (Math.abs(y - yOf(spec.min)) < clearance) continue;
+    if (Math.abs(y - yOf(spec.max)) < clearance) continue;
+    drawTick(v);
+  }
+  ctx.restore();
+}

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -1,0 +1,183 @@
+/**
+ * The snapshot pipeline's option-resolution, fast-path and error contract.
+ *
+ * These behaviours previously lived inline in `Viewer.snapshot` and could only
+ * be exercised through a real WebGL Viewer (browser / e2e). Extracting the
+ * pipeline to take a structural host makes the parts that DON'T need a canvas
+ * context — how options map to the capture plan, when the untouched GL canvas
+ * is returned, and how `toBlob === null` is surfaced — directly testable with a
+ * fake host, mirroring `tests/exportAdapter.test.ts`.
+ *
+ * The composite (overlay-compositing) path needs a real 2-D canvas + DOM and
+ * stays covered by the e2e export suite; the node environment here deliberately
+ * lacks `document`, so every case below is one the fast path or the pure helpers
+ * fully own.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  captureSnapshot,
+  canvasToBlob,
+  resolveSnapshotPlan,
+  fastPathEligible,
+  type SnapshotHost,
+  type SnapshotPlan,
+} from '../src/render/snapshot';
+import type { ActiveColorbar } from '../src/render/activeColorbar';
+
+/** A fake GL canvas — only the fields the fast path reads. */
+function fakeCanvas(blob: Blob | null = new Blob(['png'])): HTMLCanvasElement {
+  return {
+    width: 800,
+    height: 600,
+    toBlob: (cb: BlobCallback) => cb(blob),
+  } as unknown as HTMLCanvasElement;
+}
+
+/** A host wired to defaults that keep every capture on the fast path. */
+function host(over: Partial<SnapshotHost> = {}): SnapshotHost {
+  return {
+    ready: vi.fn(async () => {}),
+    renderFrame: vi.fn(),
+    glCanvas: vi.fn(() => fakeCanvas()),
+    activeColorbar: vi.fn(() => null),
+    measurementsOverlaySVG: vi.fn(() => '<svg/>'),
+    annotationsOverlaySVG: vi.fn(() => '<svg/>'),
+    inspectorOverlaySVG: vi.fn(() => '<svg/>'),
+    inspectorSelection: vi.fn(() => null),
+    probeReadout: vi.fn(() => null),
+    canvasRect: vi.fn(() => ({ left: 0, top: 0, width: 800, height: 600 })),
+    scaleBarCamera: vi.fn(() => ({ distanceToTarget: 10, fovYRadians: 1 })),
+    ...over,
+  };
+}
+
+/** A minimal continuous-colour legend spec, enough to defeat the fast path. */
+const someColorbar = { spec: { min: 0, max: 1 }, note: null } as unknown as ActiveColorbar;
+
+describe('resolveSnapshotPlan — option → plan mapping', () => {
+  it('defaults to all-off, native resolution when no options are given', () => {
+    expect(resolveSnapshotPlan()).toEqual({
+      wantAnnotations: false,
+      wantMeasurements: false,
+      wantInspector: false,
+      wantProbe: false,
+      wantScaleBar: false,
+      wantColorbar: false,
+      supersample: 1,
+    } satisfies SnapshotPlan);
+  });
+
+  it('maps each boolean layer flag through verbatim', () => {
+    const plan = resolveSnapshotPlan({
+      annotations: true,
+      measurements: true,
+      inspector: true,
+      probe: true,
+      scaleBar: true,
+      colorbar: true,
+    });
+    expect(plan.wantAnnotations).toBe(true);
+    expect(plan.wantMeasurements).toBe(true);
+    expect(plan.wantInspector).toBe(true);
+    expect(plan.wantProbe).toBe(true);
+    expect(plan.wantScaleBar).toBe(true);
+    expect(plan.wantColorbar).toBe(true);
+  });
+
+  it('only accepts 2 or 4 as a supersample promotion; everything else stays 1', () => {
+    // The clamp is what keeps a bad caller value (or the native default) from
+    // silently upscaling the output canvas to a wrong size.
+    expect(resolveSnapshotPlan({ supersample: 2 }).supersample).toBe(2);
+    expect(resolveSnapshotPlan({ supersample: 4 }).supersample).toBe(4);
+    expect(resolveSnapshotPlan({ supersample: 1 }).supersample).toBe(1);
+    expect(resolveSnapshotPlan({ supersample: 3 as 1 | 2 | 4 }).supersample).toBe(1);
+    expect(resolveSnapshotPlan({}).supersample).toBe(1);
+  });
+});
+
+describe('fastPathEligible — when the untouched GL canvas can be returned', () => {
+  const bare = resolveSnapshotPlan();
+
+  it('is eligible with no overlays, no upscale, no scale bar and no colorbar', () => {
+    expect(fastPathEligible(bare, null)).toBe(true);
+  });
+
+  it('is defeated by any single overlay flag', () => {
+    for (const opt of [
+      { annotations: true },
+      { measurements: true },
+      { inspector: true },
+      { probe: true },
+      { scaleBar: true },
+    ]) {
+      expect(fastPathEligible(resolveSnapshotPlan(opt), null)).toBe(false);
+    }
+  });
+
+  it('is defeated by a supersample promotion', () => {
+    expect(fastPathEligible(resolveSnapshotPlan({ supersample: 2 }), null)).toBe(false);
+  });
+
+  it('is defeated by a resolved (non-null) colorbar, but NOT by a null one', () => {
+    // colorbar:true with a categorical mode yields a null spec, so the caller
+    // can request it unconditionally and still take the fast path.
+    expect(fastPathEligible(bare, someColorbar)).toBe(false);
+    expect(fastPathEligible(bare, null)).toBe(true);
+  });
+});
+
+describe('canvasToBlob — PNG encode + null rejection', () => {
+  it('resolves with the blob the browser hands back', async () => {
+    const blob = new Blob(['png']);
+    await expect(canvasToBlob(fakeCanvas(blob))).resolves.toBe(blob);
+  });
+
+  it('rejects with the stable message when toBlob returns null', async () => {
+    await expect(canvasToBlob(fakeCanvas(null))).rejects.toThrow(
+      'Viewer.snapshot(): canvas.toBlob returned null',
+    );
+  });
+});
+
+describe('captureSnapshot — fast path', () => {
+  it('awaits ready, renders two present frames, then returns the untouched GL blob', async () => {
+    const blob = new Blob(['native']);
+    const h = host({ glCanvas: () => fakeCanvas(blob) });
+    const result = await captureSnapshot(h);
+    expect(result).toBe(blob);
+    expect(h.ready).toHaveBeenCalledTimes(1);
+    // Two render()/present cycles flush the WebGPU colour-buffer upload — the
+    // fix for every export mode reading the previous frame.
+    expect(h.renderFrame).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not touch any overlay accessor or the colorbar on the fast path', async () => {
+    const h = host();
+    await captureSnapshot(h);
+    expect(h.measurementsOverlaySVG).not.toHaveBeenCalled();
+    expect(h.annotationsOverlaySVG).not.toHaveBeenCalled();
+    expect(h.inspectorOverlaySVG).not.toHaveBeenCalled();
+    expect(h.probeReadout).not.toHaveBeenCalled();
+    // colorbar off ⇒ activeColorbar is never even consulted.
+    expect(h.activeColorbar).not.toHaveBeenCalled();
+  });
+
+  it('consults activeColorbar only when colorbar is requested, and stays fast when it is null', async () => {
+    const h = host({ activeColorbar: vi.fn(() => null) });
+    const blob = new Blob(['native']);
+    (h.glCanvas as ReturnType<typeof vi.fn>).mockReturnValue(fakeCanvas(blob));
+    const result = await captureSnapshot(h, { colorbar: true });
+    expect(h.activeColorbar).toHaveBeenCalledTimes(1);
+    // A categorical mode (null spec) keeps the fast path: the GL blob is
+    // returned without ever building a 2-D output canvas.
+    expect(result).toBe(blob);
+  });
+
+  it('propagates the toBlob-null rejection through the fast path', async () => {
+    const h = host({ glCanvas: () => fakeCanvas(null) });
+    await expect(captureSnapshot(h)).rejects.toThrow(
+      'Viewer.snapshot(): canvas.toBlob returned null',
+    );
+  });
+});


### PR DESCRIPTION
## What

Decomposition round-2: lift `Viewer.snapshot()` and its four overlay-compositing draw helpers (inspector card, probe readout, scale bar, colorbar) out of `Viewer.ts` into a new `src/render/snapshot.ts`, behind a structural `SnapshotHost` interface. This is the same pattern already used by `exportAdapter.ts` and `colorLegend.ts`: `Viewer` keeps a thin delegate (`snapshot()` is now one line) plus a `_buildSnapshotHost()` factory that binds its own render state to the host.

## Host interface

`SnapshotHost` exposes accessor functions rather than the Viewer itself:
`ready()`, `renderFrame()` (EDL-aware), `glCanvas()`, `activeColorbar()`, `measurementsOverlaySVG()`, `annotationsOverlaySVG()`, `inspectorOverlaySVG()`, `inspectorSelection()`, `probeReadout()`, `canvasRect()`, `scaleBarCamera()`.

## Behaviour

Unchanged. Same option handling, same fast-path/composite split, same Blob output, same `canvas.toBlob returned null` reject message. The composite branch (`document.createElement`, SVG rasterisation, overlay draws) is reproduced verbatim; only the reads are routed through the host.

## Tests

`tests/snapshot.test.ts` (13 cases) drives the host-level and pure logic with a fake host, mirroring `exportAdapter.test.ts`:
- `resolveSnapshotPlan` option mapping + supersample clamp (only 2/4 promote).
- `fastPathEligible` truth table (each overlay flag, supersample, null vs resolved colorbar).
- `canvasToBlob` resolve + null-reject message.
- `captureSnapshot` fast path: awaits ready, renders two present frames, returns the untouched GL blob, touches no overlay accessor; consults `activeColorbar` only when requested; propagates the null-reject.

The overlay-compositing branch needs a real 2-D canvas and stays covered by the e2e export suite.

## Monolith ratchet

`Viewer.ts` 6,959 to 6,458 lines. Banked the new baseline; updated `KNOWN_LIMITATIONS_v0.6.3.md` and `docs/architecture/architecture-map.md` (marked the `snapshot` row done, removed the now-stale "deliberately NOT extracted" note).

## Gates (from the worktree)

- `npm run typecheck` — 0 errors
- `npm run lint:monolith-size` — Viewer.ts under baseline, banked
- `npm run lint:release-truth` — OK
- `npm run lint:main-deferral` — OK
- `npx vitest run` — 583 files / 7464 tests pass (incl. new `tests/snapshot.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)