### PR TITLE
Fail closed on unknown projected linear unit in epoch alignment residual/shift

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6819,6 +6819,7 @@ function compareLoadedLayers(): void {
       const spanUnitToM = a.metadata?.crs?.linearUnitToMetres ?? 1;
       const { after: alignedAfter, alignment } = alignEpochClouds(beforeCloud, afterCloud, {
         maxResidualM: span > 0 ? span * 0.1 * spanUnitToM : undefined,
+        horizontalUnitKnown: a.metadata?.crs?.linearUnit !== 'unknown' && b.metadata?.crs?.linearUnit !== 'unknown', // KNOWN in both epochs ⇒ summarizeAlignment reports the shift/residual in metres; 'unknown' = placeholder factor 1, so the metre figures are withheld (geographic frames are refused before the fit)
       });
       const dtms = buildSharedEpochDtms(beforeCloud, alignedAfter);
       if (!dtms) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6811,8 +6811,7 @@ function compareLoadedLayers(): void {
       const span = horizontalSpanXY(a.positions, a.sourceOrigin);
       const spanUnitToM = a.metadata?.crs?.linearUnitToMetres ?? 1;
       const { after: alignedAfter, alignment } = alignEpochClouds(beforeCloud, afterCloud, {
-        maxResidualM: span > 0 ? span * 0.1 * spanUnitToM : undefined,
-        horizontalUnitKnown: a.metadata?.crs?.linearUnit !== 'unknown' && b.metadata?.crs?.linearUnit !== 'unknown', // KNOWN in both epochs ⇒ summarizeAlignment reports the shift/residual in metres; 'unknown' = placeholder factor 1, so the metre figures are withheld (geographic frames are refused before the fit)
+        maxResidualM: span > 0 ? span * 0.1 * spanUnitToM : undefined, horizontalUnitKnown: a.metadata?.crs?.linearUnit !== 'unknown' && b.metadata?.crs?.linearUnit !== 'unknown', // both KNOWN ⇒ summarizeAlignment reports the shift/residual in metres; 'unknown' withholds the metre figures (geographic frames are refused before the fit)
       });
       const dtms = buildSharedEpochDtms(beforeCloud, alignedAfter);
       if (!dtms) {

--- a/src/terrain/change/alignEpochs.ts
+++ b/src/terrain/change/alignEpochs.ts
@@ -57,6 +57,20 @@ export interface AlignEpochOptions {
    * apply the full 3-D transform.
    */
   readonly horizontalOnly?: boolean;
+  /**
+   * False when the horizontal frame is PROJECTED but its linear unit is unknown
+   * (a CRS whose `linearUnit` is 'unknown', carrying the inert placeholder
+   * factor 1 in `linearUnitToMetres`). The fit still runs — the transform is
+   * geometrically valid in the cloud's own units — but the residual and shift
+   * this module reports "in metres" are computed with that placeholder, so they
+   * are source-unit numbers (feet, US survey feet, links) wearing a metre label.
+   * When false, `summarizeAlignment` withholds those metre figures rather than
+   * captioning an unverified unit as metres — the same fail-closed posture as
+   * `compareDtms`' `horizontalUnitKnown`. Omitted/true means the unit is known
+   * (or a metre CRS) and the figures print. Geographic frames never reach this
+   * option — they are refused before the fit (see {@link EpochAlignment.geographicSkipped}).
+   */
+  readonly horizontalUnitKnown?: boolean;
 }
 
 export interface EpochAlignment {
@@ -102,6 +116,15 @@ export interface EpochAlignment {
    * evidence of georeferenced agreement.
    */
   readonly frameUnverified?: boolean;
+  /**
+   * True when the fit ran on a projected frame whose linear unit is unknown
+   * (see {@link AlignEpochOptions.horizontalUnitKnown}). The residual and shift
+   * were scaled by the inert placeholder factor 1, so they carry source-unit
+   * magnitudes under a metre label. `summarizeAlignment` then withholds those
+   * metre figures — an unknown source unit cannot be multiplied into metres —
+   * and keeps only the unit-free parts (yaw, sample count) plus the diagnosis.
+   */
+  readonly horizontalUnitUnknown?: boolean;
 }
 
 const NO_ALIGNMENT: EpochAlignment = {
@@ -242,6 +265,15 @@ export function alignEpochClouds(
     };
   }
 
+  // Projected frame with an UNKNOWN linear unit. The fit still runs (the
+  // transform is valid in the cloud's own units and the residual gate is
+  // self-consistent — both the span-derived threshold and the residual live in
+  // source units), but the metresPerUnit below is the inert placeholder 1, so
+  // the residual/shift this module labels "m" are actually source-unit numbers.
+  // Carry the flag so the summary withholds those metre figures. Geographic
+  // frames are already refused above, so this is purely the projected case.
+  const horizontalUnitUnknown = options.horizontalUnitKnown === false;
+
   const maxSamples = options.maxSamples ?? 1500;
   const beforeSample = sampleWorld(before.positions, before.origin ?? ZERO, maxSamples);
   const afterSample = sampleWorld(after.positions, after.origin ?? ZERO, maxSamples);
@@ -287,6 +319,7 @@ export function alignEpochClouds(
         translation: toMetres(fit.translation),
         sampleCount,
         frameUnverified,
+        horizontalUnitUnknown,
       },
     };
   }
@@ -325,6 +358,7 @@ export function alignEpochClouds(
       translation: toMetres(applied.translation),
       sampleCount,
       frameUnverified,
+      horizontalUnitUnknown,
     },
   };
 }
@@ -341,6 +375,21 @@ export function summarizeAlignment(a: EpochAlignment): string {
     );
   }
   if (!a.attempted || a.degenerate) return 'Alignment: skipped (not enough points to register).';
+  // Projected frame, unknown linear unit: the residual and shift were scaled by
+  // the placeholder factor 1, so every "m" figure would be a source-unit number
+  // wearing a metre label. Withhold them — the same fail-closed posture as
+  // compareDtms — and keep only the unit-free parts (the applied/refused
+  // outcome, the yaw angle, the sample count) plus the diagnosis. Checked before
+  // the frameUnverified caveat: an unknown unit is the stronger claim (the
+  // figures are not even metres), and its guidance already covers the fix.
+  if (a.horizontalUnitUnknown) {
+    const unitNote =
+      'the horizontal linear unit is unknown, so the shift and residual have no confirmed ' +
+      'metre scale and are withheld; set the CRS linear unit (or reproject to a metre/foot CRS) to report them.';
+    return a.refused
+      ? `Alignment: refused — the fit residual exceeds the limit, so the clouds are compared as-is. Note: ${unitNote}`
+      : `Aligned the after cloud horizontally (${a.yawDeg.toFixed(2)}° yaw over ${a.sampleCount} sampled points); vertical change preserved. Note: ${unitNote}`;
+  }
   if (a.refused) {
     return `Alignment: refused — residual ${a.rmsResidualM.toFixed(2)} m exceeds the limit; comparing as-is.`;
   }

--- a/tests/alignEpochs.test.ts
+++ b/tests/alignEpochs.test.ts
@@ -333,3 +333,62 @@ describe('undeclared frames are labelled indicative', () => {
     expect(summarizeAlignment(r.alignment)).not.toMatch(/indicative/i);
   });
 });
+
+/**
+ * A projected CRS can declare a name AND a datum yet leave its linear unit
+ * unknown — 'unknown' ⇒ the inert placeholder factor 1 in linearUnitToMetres.
+ * frameUnverified then stays false (both a CRS and a datum ARE declared), so
+ * the summary took the plain applied/refused path and printed the shift and
+ * residual as "N m", even though the placeholder means those numbers are
+ * source-unit magnitudes (feet, US survey feet, links) wearing a metre label.
+ * Same fail-closed rule as compareDtms' horizontalUnitKnown: on an unknown
+ * unit, withhold the metre figures rather than caption an unverified unit as m.
+ */
+describe('unknown projected linear unit withholds the metre figures', () => {
+  const shiftedScatter = (dx: number): EpochCloud =>
+    cloudFrom(scatter(200).map(([x, y, z]) => [x + dx, y, z] as P));
+  const declared = (base: EpochCloud, over: Partial<EpochCloud> = {}): EpochCloud => ({
+    ...base,
+    crs: 'EPSG:32612',
+    verticalDatum: 'EPSG:5703',
+    ...over,
+  });
+
+  test('an applied fit reports yaw but withholds the shift and residual', () => {
+    const before = declared(cloudFrom(scatter(200)));
+    const after = declared(shiftedScatter(10));
+    const r = alignEpochClouds(before, after, { horizontalUnitKnown: false });
+    expect(r.alignment.applied).toBe(true);
+    expect(r.alignment.horizontalUnitUnknown).toBe(true);
+    // frameUnverified is NOT the guard here — a CRS and a datum are declared.
+    expect(r.alignment.frameUnverified).not.toBe(true);
+    const s = summarizeAlignment(r.alignment);
+    expect(s).toMatch(/linear unit is unknown/i);
+    expect(s).toMatch(/yaw/i); // the angle is unit-free, so it still reads
+    expect(s).not.toMatch(/m shift/i); // the metre figures are withheld…
+    expect(s).not.toMatch(/m residual/i); // …not captioned as metres
+  });
+
+  test('a refused fit withholds the metre residual too', () => {
+    const before = declared(cloudFrom(scatter(200, 1)));
+    const after = declared(cloudFrom(scatter(200, 2)));
+    const r = alignEpochClouds(before, after, { maxResidualM: 0.001, horizontalUnitKnown: false });
+    expect(r.alignment.refused).toBe(true);
+    expect(r.alignment.horizontalUnitUnknown).toBe(true);
+    const s = summarizeAlignment(r.alignment);
+    expect(s).toMatch(/refused/i);
+    expect(s).toMatch(/linear unit is unknown/i);
+    expect(s).not.toMatch(/\d+(\.\d+)? m\b/); // no "N m" residual quoted
+  });
+
+  test('a known-unit projected fit still prints the metre shift and residual', () => {
+    // The honest path is unchanged: omitting horizontalUnitKnown means known.
+    const before = declared(cloudFrom(scatter(200)));
+    const after = declared(shiftedScatter(10));
+    const r = alignEpochClouds(before, after);
+    expect(r.alignment.horizontalUnitUnknown).not.toBe(true);
+    const s = summarizeAlignment(r.alignment);
+    expect(s).toMatch(/m shift/i);
+    expect(s).toMatch(/m residual/i);
+  });
+});


### PR DESCRIPTION
## What

`summarizeAlignment` (`src/terrain/change/alignEpochs.ts`) printed the fit **residual and shift in `m`** for a projected CRS whose `linearUnit` is `unknown`. `frameUnverified` only trips when a CRS or a vertical datum is *undeclared*, so when a CRS name **and** a datum are both declared the summary took the plain applied/refused path, scaled the figures by the inert placeholder factor `1` (`linearUnitToMetres`), and captioned source-unit magnitudes (feet, US survey feet, links) as metres with no disclosure.

This is the sibling leak flagged by #219, which fixed the same class in `compareDtms` cut/fill. Alignment-layer metre claim, owned by `alignEpochs.ts`.

## Fix (same seam as #219)

- `AlignEpochOptions.horizontalUnitKnown?` — `false` marks a projected frame whose linear unit is unknown.
- `EpochAlignment.horizontalUnitUnknown?` — set on the fit-result returns.
- The fit still runs: the transform is geometrically valid in the cloud's own units and the residual gate is self-consistent (both the span-derived threshold and the residual are source units). Only the **display** is corrected — `summarizeAlignment` withholds the metre shift and residual and keeps the unit-free parts (applied/refused outcome, yaw, sample count) plus a fix note. Checked before the `frameUnverified` caveat, since an unknown unit is the stronger claim (the figures are not even metres).
- `main.ts` `compareLoadedLayers` gates on either epoch declaring `linearUnit === 'unknown'`, mirroring its existing `horizontalUnitKnown` argument to `compareDtms`.

## Tests

`tests/alignEpochs.test.ts` — new block: applied fit withholds shift/residual (keeps yaw), refused fit withholds the metre residual, and a known-unit projected fit still prints both (no regression on the honest path).

## Gates

- `npm run typecheck` — 0 errors (exit 0)
- `npx vitest run tests/alignEpochs.test.ts tests/compareDtms.test.ts` — 56 passed (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)