### PR TITLE
Fail closed on unconfirmed unit in full-cloud grade

### DIFF
--- a/src/render/streaming/runFullCloudGradeAction.ts
+++ b/src/render/streaming/runFullCloudGradeAction.ts
@@ -41,14 +41,21 @@ export async function runFullCloudGrade(deps: {
   }
   panel.setGradeBusy('Planning octree sample…');
   // The decoded positions are in the source CRS's linear unit; convert spans to
-  // metres so the density (pts/m²) and vertical extent read in SI rather than
-  // in feet for a state-plane-feet cloud. Unknown CRS ⇒ factor 1 (treated as
-  // metres), matching the rest of the streaming readouts.
+  // metres so the density (pts/m²) and vertical extent read in SI rather than in
+  // feet for a state-plane-feet cloud. FAIL CLOSED on an unconfirmed unit: an
+  // unknown-unit CRS carries the inert placeholder linearUnitToMetres:1 (and a
+  // CRS-less cloud resolves the same), so applying that factor would stamp raw
+  // source spans as metres — pts/m² and vertical m for data that may be feet.
+  // Metres are only claimed when the CRS declares a real linear unit, the same
+  // gate the scan-report rows (streamingExtentRows) and the measure tool apply;
+  // otherwise the factor stays 1 and the summary labels the figures per source
+  // unit (see summarizeSampleGrade's unitConfirmed argument).
   const crs = source.crs();
-  const metresPerUnit = crs?.linearUnitToMetres ?? 1;
+  const unitConfirmed = crs != null && crs.linearUnit !== 'unknown';
+  const metresPerUnit = unitConfirmed ? (crs?.linearUnitToMetres ?? 1) : 1;
   // Z gets the vertical unit when the CRS declares one separately (e.g. NAVD88
   // feet over a metre grid); otherwise it follows the horizontal factor.
-  const verticalMetresPerUnit = crs?.verticalUnitToMetres ?? metresPerUnit;
+  const verticalMetresPerUnit = unitConfirmed ? (crs?.verticalUnitToMetres ?? metresPerUnit) : 1;
   try {
     const run = await gradeFullCloud({
       source,
@@ -72,7 +79,11 @@ export async function runFullCloudGrade(deps: {
     // it silently rather than paint a stale grade over a different (or absent)
     // cloud's panel.
     if (viewer.streamingCloud !== source) return;
-    panel.setGradeResult(run.coverage.label, summarizeSampleGrade(run.grade), run.coverage.note);
+    panel.setGradeResult(
+      run.coverage.label,
+      summarizeSampleGrade(run.grade, unitConfirmed),
+      run.coverage.note,
+    );
   } catch (err) {
     // A user-initiated cancel is not a failure — show a neutral note, not the
     // red error state.

--- a/src/render/streaming/sampleGrade.ts
+++ b/src/render/streaming/sampleGrade.ts
@@ -254,24 +254,64 @@ function clampInt(v: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, Math.round(v)));
 }
 
+/** The unit suffixes the grade summary stamps on its density / extent figures. */
+export interface GradeUnitSuffixes {
+  /** Areal density unit — "pts/m²" only when the source unit is confirmed. */
+  readonly areal: string;
+  /** Volumetric density unit — "pts/m³" only when confirmed. */
+  readonly volumetric: string;
+  /** Vertical-extent unit — "m" only when confirmed. */
+  readonly vertical: string;
+}
+
+/**
+ * Choose the summary's unit suffixes, FAILING CLOSED on an unconfirmed linear
+ * unit. `metresPerUnit` is 1 both for a real metre CRS and for the unknown /
+ * absent case (the inert `linearUnitToMetres: 1` placeholder), so the factor
+ * alone can't tell them apart — the caller passes `unitConfirmed` (its CRS
+ * carries a real, non-'unknown' linear unit). When it's false the spans are in
+ * raw source units, so the figures are labelled per source unit and never "m" /
+ * "pts/m²". Same gate as `streamingExtentRows` and the measure tool.
+ */
+export function gradeUnitSuffixes(unitConfirmed: boolean): GradeUnitSuffixes {
+  return unitConfirmed
+    ? { areal: 'pts/m²', volumetric: 'pts/m³', vertical: 'm' }
+    : { areal: 'pts/unit²', volumetric: 'pts/unit³', vertical: '(source units)' };
+}
+
 /**
  * A short, honest human summary of a {@link SampleGrade} for the panel. Pairs
  * with the runner's coverage label (passed separately) so the density figures
  * always travel with their "exact vs sampled" context.
+ *
+ * `unitConfirmed` gates every unit-bearing claim. The density TIER word
+ * (Sparse … Very Dense) is calibrated to metre-based density floors (USGS 3DEP
+ * pts/m²), so it is only truthful when the source declares a real linear unit.
+ * With the unit unconfirmed the spans are in raw source units: the tier verdict
+ * is withheld and only the raw figures — labelled per source unit — are shown,
+ * so a state-plane-FEET (or CRS-less) cloud is never reported in metres.
  */
-export function summarizeSampleGrade(grade: SampleGrade): string[] {
+export function summarizeSampleGrade(grade: SampleGrade, unitConfirmed = true): string[] {
+  const units = gradeUnitSuffixes(unitConfirmed);
   const lines: string[] = [];
   // Headline tier, annotated with the density it was judged on (areal for flat
   // data, volumetric for tall) so the number and its unit always agree.
   let densityFigure = '';
   if (grade.bucketBasis === 'areal' && grade.arealDensityPerM2 != null) {
-    densityFigure = ` · ≈ ${formatDensity(grade.arealDensityPerM2)} pts/m²`;
+    densityFigure = ` · ≈ ${formatDensity(grade.arealDensityPerM2)} ${units.areal}`;
   } else if (grade.bucketBasis === 'volumetric' && grade.volumetricDensityPerM3 != null) {
-    densityFigure = ` · ≈ ${formatDensity(grade.volumetricDensityPerM3)} pts/m³`;
+    densityFigure = ` · ≈ ${formatDensity(grade.volumetricDensityPerM3)} ${units.volumetric}`;
   }
-  lines.push(`Density: ${grade.bucketLabel}${densityFigure}`);
+  // The tier word claims an absolute pts/m² band, so withhold it when the unit
+  // is unconfirmed — the '—'/none case still reads '—'.
+  const tier = unitConfirmed
+    ? grade.bucketLabel
+    : grade.bucketBasis === 'none'
+      ? grade.bucketLabel
+      : 'units unknown';
+  lines.push(`Density: ${tier}${densityFigure}`);
   if (grade.verticalSpanM > 0) {
-    lines.push(`Vertical extent: ${grade.verticalSpanM.toFixed(1)} m`);
+    lines.push(`Vertical extent: ${grade.verticalSpanM.toFixed(1)} ${units.vertical}`);
   }
   if (grade.occupancyRatio != null) {
     const pct = Math.round(grade.occupancyRatio * 100);

--- a/tests/runFullCloudGradeAction.test.ts
+++ b/tests/runFullCloudGradeAction.test.ts
@@ -18,6 +18,7 @@ vi.mock('../src/render/streaming/sampleGrade', () => ({
 }));
 
 import { runFullCloudGrade } from '../src/render/streaming/runFullCloudGradeAction';
+import { summarizeSampleGrade } from '../src/render/streaming/sampleGrade';
 
 function makePanel() {
   return {
@@ -77,5 +78,40 @@ describe('runFullCloudGrade — stale-cloud guard', () => {
     await run(mkViewer(null, null), panel);
     expect(panel.setGradeError).toHaveBeenCalled();
     expect(gradeFullCloud).not.toHaveBeenCalled();
+  });
+});
+
+describe('runFullCloudGrade — unit-confirmation gate', () => {
+  beforeEach(() => {
+    gradeFullCloud.mockReset();
+    gradeFullCloud.mockResolvedValue(RUN);
+    vi.mocked(summarizeSampleGrade).mockClear();
+  });
+
+  const runWithCrs = async (crs: unknown) => {
+    const cloud = { crs: () => crs } as FakeViewer['streamingCloud'];
+    const panel = makePanel();
+    await run(mkViewer(cloud), panel);
+    return panel;
+  };
+
+  it('summarises unconfirmed for a CRS-less cloud (metre factor never applied)', async () => {
+    await runWithCrs(null);
+    expect(vi.mocked(summarizeSampleGrade).mock.calls[0][1]).toBe(false);
+  });
+
+  it("summarises unconfirmed for an unknown-unit CRS (linearUnitToMetres:1 placeholder)", async () => {
+    await runWithCrs({ linearUnit: 'unknown', linearUnitToMetres: 1 });
+    expect(vi.mocked(summarizeSampleGrade).mock.calls[0][1]).toBe(false);
+  });
+
+  it('summarises confirmed for a real metre CRS', async () => {
+    await runWithCrs({ linearUnit: 'metre', linearUnitToMetres: 1 });
+    expect(vi.mocked(summarizeSampleGrade).mock.calls[0][1]).toBe(true);
+  });
+
+  it('summarises confirmed for a foot CRS', async () => {
+    await runWithCrs({ linearUnit: 'foot', linearUnitToMetres: 0.3048 });
+    expect(vi.mocked(summarizeSampleGrade).mock.calls[0][1]).toBe(true);
   });
 });

--- a/tests/sampleGrade.test.ts
+++ b/tests/sampleGrade.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from 'vitest';
 import {
   gradeSampleDensity,
   summarizeSampleGrade,
+  gradeUnitSuffixes,
   classifyArealDensity,
 } from '../src/render/streaming/sampleGrade';
 
@@ -210,6 +211,52 @@ describe('summarizeSampleGrade', () => {
     expect(lines[0]).toBe('Density: —');
     expect(lines.some((l) => /pts\/m²/.test(l))).toBe(false);
     expect(lines.some((l) => /Coverage of bounding box/.test(l))).toBe(false);
+  });
+});
+
+describe('summarizeSampleGrade — fails closed on an unconfirmed unit', () => {
+  // A flat swath graded by AREA, so the density line carries an areal figure.
+  const flat = () => gradeSampleDensity(filledFlatCloud(50_000, 100, 2), 1);
+
+  it('claims metres only when the unit is confirmed', () => {
+    const lines = summarizeSampleGrade(flat(), true);
+    expect(lines[0]).toMatch(/pts\/m²/);
+    expect(lines.some((l) => /Vertical extent: [\d.]+ m$/.test(l))).toBe(true);
+    // The metre-calibrated tier word is asserted.
+    expect(lines[0]).toMatch(/^Density: (Sparse|Moderate|Dense|Very Dense)/);
+  });
+
+  it('withholds the metre claim and the tier when the unit is unconfirmed', () => {
+    const lines = summarizeSampleGrade(flat(), false);
+    // No bare metre units anywhere.
+    expect(lines.some((l) => /pts\/m²|pts\/m³/.test(l))).toBe(false);
+    expect(lines.some((l) => /\bm$/.test(l))).toBe(false);
+    // Raw figures are shown, labelled per source unit.
+    expect(lines[0]).toMatch(/pts\/unit²/);
+    expect(lines.some((l) => /Vertical extent: [\d.]+ \(source units\)/.test(l))).toBe(true);
+    // The absolute-band tier verdict is not asserted.
+    expect(lines[0]).not.toMatch(/Sparse|Moderate|Dense|Very Dense/);
+    expect(lines[0]).toMatch(/units unknown/);
+  });
+
+  it('keeps the (unit-independent) occupancy line under an unconfirmed unit', () => {
+    const lines = summarizeSampleGrade(flat(), false);
+    expect(lines.some((l) => /Coverage of bounding box: \d+%/.test(l))).toBe(true);
+  });
+
+  it('an empty grade still reads "Density: —" even when unconfirmed', () => {
+    const lines = summarizeSampleGrade(gradeSampleDensity(new Float32Array(0), 1), false);
+    expect(lines[0]).toBe('Density: —');
+  });
+});
+
+describe('gradeUnitSuffixes', () => {
+  it('uses metre suffixes only when confirmed, source-unit suffixes otherwise', () => {
+    expect(gradeUnitSuffixes(true)).toEqual({ areal: 'pts/m²', volumetric: 'pts/m³', vertical: 'm' });
+    const raw = gradeUnitSuffixes(false);
+    expect(raw.areal).not.toMatch(/m²/);
+    expect(raw.volumetric).not.toMatch(/m³/);
+    expect(raw.vertical).toBe('(source units)');
   });
 });
 


### PR DESCRIPTION
## Problem

`runFullCloudGradeAction.ts` computed `metresPerUnit = crs?.linearUnitToMetres ?? 1` and `verticalMetresPerUnit = crs?.verticalUnitToMetres ?? metresPerUnit` **without gating on the linear unit being real**.

An unknown-unit CRS carries the inert placeholder `linearUnitToMetres: 1` (`unitScaleForCode('unknown') === 1`), and a CRS-less cloud resolves the same way. So the decoded spans (in raw source units) were multiplied by 1 and displayed by `summarizeSampleGrade` as bare metric claims:

- `Density: <tier> · ≈ N pts/m²` (or `pts/m³`)
- `Vertical extent: N m`

For a state-plane-**feet** COPC whose unit didn't resolve (`linearUnit: 'unknown'`), or any CRS-less cloud, this reports feet data as metres, and the density **tier** — calibrated to USGS 3DEP metre floors (`< 2` sparse, `< 8` moderate, `< 50` dense) — misclassifies (a real 1 pt/ft² ≈ 10.76 pts/m² read as "1 pts/m² · Sparse").

## Fix

Gate on `crs != null && crs.linearUnit !== 'unknown'` — the same predicate `streamingExtentRows` (PRs #218/#220) and the measure tool already use.

- **Confirmed unit** → unchanged: real factors, `pts/m²` / `m`, tier asserted.
- **Unconfirmed** → factor stays 1 (raw source spans), summary labels figures per source unit (`pts/unit²` / `(source units)`), and the metre-band **tier verdict is withheld** (`units unknown`). The occupancy ratio (unit-independent) is kept.

Extracted a small pure helper `gradeUnitSuffixes(unitConfirmed)` for the label choice.

## Tests

- `sampleGrade.test.ts`: gated summary (confirmed vs unconfirmed), occupancy retained, empty-grade still `Density: —`, `gradeUnitSuffixes`.
- `runFullCloudGradeAction.test.ts`: wiring — CRS-less and unknown-unit → `summarizeSampleGrade(..., false)`; metre / foot CRS → `true`.

Gates: `npm run typecheck` 0 errors; `npx vitest run` on both touched files 31 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)