### PR TITLE
Disclose unverified units in the stockpile volume figures

### DIFF
--- a/src/render/measure/stockpilePresenter.ts
+++ b/src/render/measure/stockpilePresenter.ts
@@ -39,6 +39,14 @@ export interface StockpileView {
   readonly rows: ReadonlyArray<StockpileViewRow>;
   /** Honesty notes, verbatim from the result. */
   readonly caveats: ReadonlyArray<string>;
+  /**
+   * Whether the horizontal unit was verified. When false every m³/m²/m figure
+   * here rests on an assumed-metres scale (an unknown-unit CRS yields the
+   * placeholder factor 1); the `caveats` carry the full disclosure and
+   * {@link stockpileToastLine} appends a short note, so a bare "X m³" is never
+   * presented as a confirmed metric claim.
+   */
+  readonly unitVerified: boolean;
 }
 
 export interface StockpilePresentOptions {
@@ -107,12 +115,16 @@ export function presentStockpile(
     confidenceLabel: CONFIDENCE_LABEL[r.confidence],
     rows,
     caveats: r.caveats,
+    unitVerified: r.densityUnitKnown,
   };
 }
 
 /** One-line summary for a toast: "Stockpile: 1,254 m³ ± 41 m³ (1σ) (±3.3%) · Medium confidence". */
 export function stockpileToastLine(view: StockpileView): string {
-  return `Stockpile: ${view.headline} (${view.relative}) · ${view.confidenceLabel} confidence`;
+  const line = `Stockpile: ${view.headline} (${view.relative}) · ${view.confidenceLabel} confidence`;
+  // The toast renders no caveats, so the unverified-unit disclosure has to live
+  // in the line itself — otherwise an unknown-unit CRS shows a bare "X m³".
+  return view.unitVerified ? line : `${line} · units unverified (assumes metres)`;
 }
 
 /**

--- a/src/render/measure/stockpileVolume.ts
+++ b/src/render/measure/stockpileVolume.ts
@@ -172,6 +172,18 @@ export interface StockpileVolumeResult {
 /** Sparse-footprint floor: below this, the band is unreliable, not just wide. */
 const MIN_RELIABLE_POINTS = 100;
 
+/**
+ * Disclosure for an unknown-unit CRS. The volume/footprint/thickness are labelled
+ * m³/m²/m downstream, but on an unknown unit they rest on the placeholder
+ * `linearUnitToMetres = 1`, so they only ASSUME metres — a foot survey read as
+ * metres overstates volume ~35×. Emitted as the LEAD caveat so the panel and the
+ * signed report disclose it (both render `caveats` verbatim); the toast, which
+ * shows no caveats, appends its own short note. Mirrors spaceMetrics'
+ * UNVERIFIED_UNIT_CAVEAT and the footprint-area / epoch-cut-fill fail-closed seams.
+ */
+const UNIT_UNVERIFIED_CAVEAT =
+  'Coordinate units are unverified — the volume, footprint and thickness assume metres; confirm the source CRS before relying on the figures.';
+
 function isZUp(up: Vec3): boolean {
   return Math.abs(up[2] - 1) < 1e-6 && Math.abs(up[0]) < 1e-6 && Math.abs(up[1]) < 1e-6;
 }
@@ -324,6 +336,7 @@ export function stockpileVolume(input: StockpileInput): StockpileVolumeResult {
     baseMode,
     baseUncertainty,
     input.sourceReduced ?? false,
+    densityUnitKnown,
   );
 
   return {
@@ -389,6 +402,7 @@ function buildCaveats(
   baseMode: BasePlaneMode,
   baseUncertainty: number,
   sourceReduced: boolean,
+  densityUnitKnown: boolean,
 ): string[] {
   const out: string[] = [];
   if (pointsInPolygon < MIN_RELIABLE_POINTS) {
@@ -420,6 +434,13 @@ function buildCaveats(
   );
   if (confidence === 'high') {
     out.unshift('Dense, even coverage with a clean base — suitable for a documented stockpile figure once validated.');
+  }
+  // Fail closed on an unverified scale: with an unknown horizontal unit every
+  // metre figure is an assume-metres default, so lead with the disclosure rather
+  // than let "X m³" read as a confirmed metric claim. (Unknown units cannot earn
+  // HIGH, so this never displaces the high-confidence lead above.)
+  if (!densityUnitKnown) {
+    out.unshift(UNIT_UNVERIFIED_CAVEAT);
   }
   return out;
 }
@@ -453,9 +474,15 @@ function zeroResult(
       basePlaneError: 0,
     },
     validity,
-    caveats:
-      validity === 'ok'
-        ? ['No points fell inside the footprint.']
-        : [`Footprint is not usable (${validity}).`],
+    caveats: zeroCaveats(validity, densityUnitKnown),
   };
+}
+
+function zeroCaveats(validity: PolygonValidity, densityUnitKnown: boolean): string[] {
+  const out =
+    validity === 'ok'
+      ? ['No points fell inside the footprint.']
+      : [`Footprint is not usable (${validity}).`];
+  if (!densityUnitKnown) out.unshift(UNIT_UNVERIFIED_CAVEAT);
+  return out;
 }

--- a/tests/sessionFindings.test.ts
+++ b/tests/sessionFindings.test.ts
@@ -70,6 +70,19 @@ describe('converters preserve band + caveats', () => {
     expect(single.value).toBeCloseTo(1000 * 0.3048 ** 3, 6);
   });
 
+  test('stockpileFinding carries the unverified-unit disclosure into the report', () => {
+    // The result caveats already lead with the disclosure for an unknown unit;
+    // the finding passes them through, so the signed report never presents the
+    // m³ value as a confirmed metric claim.
+    const unknown = stockpileFinding(
+      stock({
+        densityUnitKnown: false,
+        caveats: ['Coordinate units are unverified — assume metres.', 'Point-sample estimate.'],
+      }),
+    );
+    expect(unknown.caveats?.[0]).toMatch(/Coordinate units are unverified/);
+  });
+
   test('changeFinding carries detectability honesty', () => {
     const u = changeVolumeUncertainty({
       netVolumeM3: 2,

--- a/tests/stockpilePresenter.test.ts
+++ b/tests/stockpilePresenter.test.ts
@@ -61,6 +61,21 @@ describe('presentStockpile', () => {
     expect(density).toMatch(/13\.2 pts\/unit²/);
   });
 
+  test('an unknown-unit result flags the view and discloses on the toast', () => {
+    // The headline still prints "m³" (like the space report keeps "m"), but the
+    // toast — which renders no caveats — must carry the disclosure inline so a
+    // bare "X m³" is never presented as a confirmed metric claim.
+    const known = presentStockpile(result());
+    expect(known.unitVerified).toBe(true);
+    expect(stockpileToastLine(known)).not.toMatch(/units unverified/);
+
+    const unknown = presentStockpile(result({ densityUnitKnown: false }));
+    expect(unknown.unitVerified).toBe(false);
+    expect(stockpileToastLine(unknown)).toBe(
+      'Stockpile: 1,254 m³ ± 41 m³ (1σ) (±3.3%) · Medium confidence · units unverified (assumes metres)',
+    );
+  });
+
   test('a foot-CRS result converts to true metres (lin = 0.3048)', () => {
     // Same native figures, but in feet → volume in m³ is value × 0.3048³.
     const v = presentStockpile(result({ volume: 1000, sigma: 0 }), { lin: 0.3048 });

--- a/tests/stockpileVolume.test.ts
+++ b/tests/stockpileVolume.test.ts
@@ -90,6 +90,39 @@ describe('stockpileVolume — volume + auditable band', () => {
     expect(unknown.confidence).toBe('medium');
   });
 
+  test('an unknown unit leads the caveats with a units-unverified disclosure', () => {
+    // The volume/footprint/thickness are printed as m³/m²/m downstream but rest
+    // on the placeholder factor 1, so the result must SAY the metres are assumed
+    // — otherwise a foot survey reads ~35× too large as a confident m³ figure.
+    const footprint = squareFootprint(10);
+    const positions = grid(10, 0.9, () => 2);
+    const base = { mode: 'explicit', z: 0 } as const;
+
+    const known = stockpileVolume({ polygon: footprint, positions, base });
+    expect(known.caveats.join(' ')).not.toMatch(/units are unverified/i);
+
+    const unknown = stockpileVolume({ polygon: footprint, positions, base, densityUnitKnown: false });
+    // Lead position: the disclosure is a whole-basis honesty flag.
+    expect(unknown.caveats[0]).toMatch(/Coordinate units are unverified/);
+    expect(unknown.caveats[0]).toMatch(/assume metres/);
+  });
+
+  test('a degenerate footprint on an unknown unit still discloses the unverified scale', () => {
+    // The zero-result path must fail closed too: it echoes footprintArea as "m²".
+    const collinear: Vec3[] = [
+      [0, 0, 0],
+      [5, 0, 0],
+      [10, 0, 0],
+    ];
+    const r = stockpileVolume({
+      polygon: collinear,
+      positions: grid(10, 1, () => 1),
+      densityUnitKnown: false,
+    });
+    expect(r.volume).toBe(0);
+    expect(r.caveats[0]).toMatch(/Coordinate units are unverified/);
+  });
+
   test('every result carries the spatial-correlation caveat (√N assumes independence)', () => {
     // The sampling-error term divides by √N under an independence assumption
     // scan noise routinely violates — the caveat must say so, mirroring


### PR DESCRIPTION
## What

An unknown-unit CRS carries the inert placeholder `linearUnitToMetres = 1`. The stockpile path threaded a `densityUnitKnown` flag from the lasso, but it only guarded the **density row** and the **HIGH-confidence grade**. The headline volume (`X m³ ± Y m³`), footprint (`m²`), mean thickness (`m`), error bands (`m³`), and the signed-report finding all still printed as **confirmed metres**. A foot survey whose unit resolves to `unknown` reported a ~35×-too-large "m³" as a confident financial figure — the class of leak `#217`/`#219`/`#220` already fail-closed elsewhere.

The live surface — the lasso toast (`stockpileToastLine`) — renders no caveats at all, so it showed a bare `Stockpile: 1,254 m³ … Medium confidence` with zero disclosure.

## Fix

Reuse the `densityUnitKnown` signal already on the result (no new wiring from `main.ts`), following the `#220` disclose pattern:

- `stockpileVolume` emits a **lead** `Coordinate units are unverified …` caveat when `densityUnitKnown` is false, on both the success and zero-result paths. The panel and the signed report both render `caveats` verbatim, so both now disclose.
- `StockpileView` gains `unitVerified`; `stockpileToastLine` appends `· units unverified (assumes metres)` when false, because the toast shows no caveats otherwise.
- Figures keep their `m³/m²/m` labels (matching the space-report and epoch-cut-fill seams, which disclose rather than relabel).

## Tests

- `stockpileVolume`: unknown unit leads the caveats with the disclosure; known does not; degenerate/zero-result footprint on an unknown unit still discloses.
- `stockpilePresenter`: `unitVerified` reflects the flag; the toast line discloses for an unknown unit and is unchanged for a known one.
- `sessionFindings`: the disclosure rides into the report finding.

Gates: `npm run typecheck` clean (0 errors); touched suites (stockpile/presenter/findings + adjacent lasso/report/volume) pass — 108 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)