### PR TITLE
Fail closed on unknown CRS unit in the static scan report

### DIFF
--- a/src/analysis/modules/scanReport.ts
+++ b/src/analysis/modules/scanReport.ts
@@ -1,6 +1,7 @@
 import type { AnalysisModule, AnalysisResult, AnalysisRow, RunOptions } from '../ModuleApi';
 import type { PointCloud } from '../../model/PointCloud';
 import type { ClassScope } from '../../render/class/classScope';
+import type { CrsLinearUnit } from '../../io/crs';
 import { isZUpFormat } from '../../io/sniffFormat';
 
 function rowInfo(label: string, value: string): AnalysisRow {
@@ -24,6 +25,56 @@ function withScope(row: AnalysisRow, scope: ClassScope | undefined): AnalysisRow
 /** Format a length in metres — centimetres below a metre, for readability. */
 function formatLength(metres: number): string {
   return metres < 1 ? `${(metres * 100).toFixed(1)} cm` : `${metres.toFixed(2)} m`;
+}
+
+/** The minimal CRS shape the unit basis reads — a subset of `CrsInfo`. */
+type UnitCrs = {
+  readonly linearUnit?: CrsLinearUnit;
+  readonly linearUnitToMetres?: number;
+  readonly verticalUnitToMetres?: number;
+} | null | undefined;
+
+/** Source→metre factors and unit labels for the extent block. */
+export interface ScanReportUnitBasis {
+  /** Whether the CRS declares a real, resolved linear unit (metres claimable). */
+  readonly unitKnown: boolean;
+  /** Horizontal source→metre factor; 1 (identity) when the unit is unconfirmed. */
+  readonly mpu: number;
+  /** Vertical source→metre factor; 1 (identity) when the unit is unconfirmed. */
+  readonly vmpu: number;
+  /** Length suffix: ' m' when confirmed, ' (source units)' otherwise. */
+  readonly lengthUnit: string;
+  /** Areal-density suffix: ' pts/m²' when confirmed, ' pts/unit²' otherwise. */
+  readonly densityUnit: string;
+}
+
+/**
+ * Resolve the extent block's unit basis, FAILING CLOSED on an unconfirmed
+ * linear unit.
+ *
+ * Metres are only CLAIMED when the CRS declares a real linear unit. An
+ * unknown-unit CRS carries the inert placeholder `linearUnitToMetres: 1`, and
+ * a CRS-less cloud resolves the same way — multiplying a source span by that 1
+ * and stamping "m" would report non-metre data (feet, or even degrees for a
+ * geographic CRS) as metres. So metres are claimed only when
+ * `crs != null && crs.linearUnit !== 'unknown'`, the same canonical gate the
+ * streaming report (`streamingExtentRows`), the space report (`spaceMetrics`),
+ * the measure tool and the lasso already apply. When the unit is unconfirmed
+ * the factor stays 1, the raw source span is shown, and the "m" / "pts/m²"
+ * claim is withheld.
+ */
+export function scanReportUnitBasis(crs: UnitCrs): ScanReportUnitBasis {
+  const unitKnown =
+    crs != null && crs.linearUnit !== undefined && crs.linearUnit !== 'unknown';
+  const mpu = unitKnown ? (crs?.linearUnitToMetres ?? 1) : 1;
+  const vmpu = unitKnown ? (crs?.verticalUnitToMetres ?? mpu) : 1;
+  return {
+    unitKnown,
+    mpu,
+    vmpu,
+    lengthUnit: unitKnown ? ' m' : ' (source units)',
+    densityUnit: unitKnown ? ' pts/m²' : ' pts/unit²',
+  };
 }
 
 /**
@@ -101,10 +152,16 @@ export const scanReport: AnalysisModule = {
     // Extent — bounds are in the source CRS's native linear units (feet for a
     // state-plane-feet cloud), so convert to metres before reporting "m" /
     // "pts/m²" / spacing. Horizontal spans use linearUnitToMetres; height uses
-    // the vertical unit when the CRS declares one separately. metre / CRS-less
-    // clouds resolve to factor 1 — byte-identical to before.
-    const mpu = cloud.metadata?.crs?.linearUnitToMetres ?? 1;
-    const vmpu = cloud.metadata?.crs?.verticalUnitToMetres ?? mpu;
+    // the vertical unit when the CRS declares one separately.
+    //
+    // FAIL CLOSED on the unit: `scanReportUnitBasis` claims metres only when the
+    // CRS declares a real linear unit. An unknown-unit CRS (or a CRS-less cloud)
+    // carries the inert placeholder factor 1; multiplying by it and stamping "m"
+    // would report non-metre data — feet, or even degrees for a geographic CRS —
+    // as metres. When unconfirmed, the factor stays 1, the raw source span is
+    // shown, and the "m" / "pts/m²" claim is withheld (matches #218/#220).
+    const basis = scanReportUnitBasis(cloud.metadata?.crs);
+    const { mpu, vmpu } = basis;
     // Footprint and height are axis-aware. LAS-family (and COPC/EPT) are Z-up
     // by spec, so the ground footprint is X·Y and height is Z. Mesh formats
     // (PLY/OBJ/GLB/GLTF) load in their native Y-up frame — the same up-axis
@@ -116,9 +173,9 @@ export const scanReport: AnalysisModule = {
     const width = spanX * mpu;
     const depth = (zUp ? spanY : spanZ) * mpu;
     const height = (zUp ? spanZ : spanY) * vmpu;
-    rows.push(withScope(rowInfo('Width', `${width.toFixed(1)} m`), scope));
-    rows.push(withScope(rowInfo('Depth', `${depth.toFixed(1)} m`), scope));
-    rows.push(withScope(rowInfo('Height', `${height.toFixed(1)} m`), scope));
+    rows.push(withScope(rowInfo('Width', `${width.toFixed(1)}${basis.lengthUnit}`), scope));
+    rows.push(withScope(rowInfo('Depth', `${depth.toFixed(1)}${basis.lengthUnit}`), scope));
+    rows.push(withScope(rowInfo('Height', `${height.toFixed(1)}${basis.lengthUnit}`), scope));
 
     const footprintArea = width * depth;
 
@@ -126,14 +183,18 @@ export const scanReport: AnalysisModule = {
     if (footprintArea <= 0 || reportedN === 0) {
       rows.push(withScope(rowWarn('Density', 'N/A (degenerate footprint)'), scope));
     } else {
-      rows.push(withScope(rowInfo('Density', `${(reportedN / footprintArea).toFixed(1)} pts/m²`), scope));
+      rows.push(withScope(rowInfo('Density', `${(reportedN / footprintArea).toFixed(1)}${basis.densityUnit}`), scope));
     }
 
-    // Estimated point spacing.
+    // Estimated point spacing. The cm/m formatter assumes metres, so it is used
+    // only when the unit is confirmed; an unconfirmed scan shows the raw source
+    // spacing without a metre label.
     if (footprintArea <= 0 || reportedN === 0) {
       rows.push(withScope(rowWarn('Spacing', 'N/A (degenerate footprint)'), scope));
     } else {
-      rows.push(withScope(rowInfo('Spacing', formatLength(Math.sqrt(footprintArea / reportedN))), scope));
+      const spacing = Math.sqrt(footprintArea / reportedN);
+      const spacingValue = basis.unitKnown ? formatLength(spacing) : `${spacing.toFixed(2)} (source units)`;
+      rows.push(withScope(rowInfo('Spacing', spacingValue), scope));
     }
 
     // Attribute coverage.

--- a/tests/scanReportUnits.test.ts
+++ b/tests/scanReportUnits.test.ts
@@ -1,0 +1,112 @@
+/**
+ * scanReportUnits.test.ts
+ *
+ * Coordinate-integrity guard for the static Scan Report's extent block.
+ *
+ * The report derives Width/Depth/Height/Density/Spacing from the cloud's
+ * source-coordinate bounds and a per-CRS metre factor. An unknown-unit CRS
+ * carries the inert placeholder `linearUnitToMetres: 1`; consuming it WITHOUT
+ * gating on `linearUnit !== 'unknown'` stamps "m" / "pts/m²" onto non-metre
+ * data — feet, or even degrees for a geographic CRS. `scanReportUnitBasis`
+ * fails closed: it only claims metres when the CRS declares a real linear unit,
+ * matching the streaming report (`streamingExtentRows`) and the measure tool.
+ */
+import { describe, it, expect, test } from 'vitest';
+import { scanReport, scanReportUnitBasis } from '../src/analysis/modules/scanReport';
+import { PointCloud } from '../src/model/PointCloud';
+import type { CrsInfo } from '../src/io/crs';
+
+function rowByLabel(result: ReturnType<typeof scanReport.run>, label: string) {
+  const row = result.rows.find((r) => r.label === label);
+  if (!row) throw new Error(`Row "${label}" not found. Rows: ${result.rows.map((r) => r.label).join(', ')}`);
+  return row;
+}
+
+describe('scanReportUnitBasis — fail-closed unit gate', () => {
+  test('metre CRS: confirmed, factor 1, "m" / "pts/m²"', () => {
+    const b = scanReportUnitBasis({ linearUnit: 'metre', linearUnitToMetres: 1 });
+    expect(b.unitKnown).toBe(true);
+    expect(b.mpu).toBe(1);
+    expect(b.vmpu).toBe(1);
+    expect(b.lengthUnit).toBe(' m');
+    expect(b.densityUnit).toBe(' pts/m²');
+  });
+
+  test('foot CRS: confirmed, applies the 0.3048 factor', () => {
+    const b = scanReportUnitBasis({ linearUnit: 'foot', linearUnitToMetres: 0.3048 });
+    expect(b.unitKnown).toBe(true);
+    expect(b.mpu).toBeCloseTo(0.3048, 6);
+    expect(b.vmpu).toBeCloseTo(0.3048, 6); // vertical falls back to the horizontal factor
+    expect(b.lengthUnit).toBe(' m');
+  });
+
+  test('unknown-unit CRS: fails closed to source units despite the placeholder factor', () => {
+    const b = scanReportUnitBasis({ linearUnit: 'unknown', linearUnitToMetres: 1 });
+    expect(b.unitKnown).toBe(false);
+    expect(b.mpu).toBe(1);
+    expect(b.vmpu).toBe(1);
+    expect(b.lengthUnit).toBe(' (source units)');
+    expect(b.densityUnit).toBe(' pts/unit²');
+  });
+
+  test('CRS-less (null / undefined): fails closed exactly like unknown', () => {
+    for (const crs of [null, undefined]) {
+      const b = scanReportUnitBasis(crs);
+      expect(b.unitKnown).toBe(false);
+      expect(b.mpu).toBe(1);
+      expect(b.lengthUnit).toBe(' (source units)');
+    }
+  });
+});
+
+describe('scanReport — unknown-unit CRS never claims metres', () => {
+  // 4 points spanning 2×2×1 in the SOURCE unit. With a resolved metre CRS these
+  // read as metres; with an unknown-unit CRS the same spans must NOT be labelled
+  // metres — the placeholder factor 1 is not a confirmed scale.
+  const positions = new Float32Array([0, 0, 0, 2, 0, 0, 0, 2, 0, 2, 2, 1]);
+  const make = (crs: CrsInfo): PointCloud =>
+    new PointCloud({
+      positions,
+      origin: [0, 0, 0],
+      sourceFormat: 'las',
+      name: 'unit-fixture',
+      metadata: { crs },
+    });
+
+  const EXTENT_LABELS = ['Width', 'Depth', 'Height', 'Density', 'Spacing'] as const;
+
+  it('unknown projected unit: no bare "m" / "pts/m²" on any extent row', () => {
+    const r = scanReport.run(
+      // The leak shape: a CRS was recovered, but its unit could not be resolved
+      // (e.g. a projected CRS with an unmapped unit code), so the factor is 1.
+      make({ source: 'wkt', name: 'Unknown-unit CRS', linearUnit: 'unknown', linearUnitToMetres: 1, isGeographic: false }),
+    );
+    for (const label of EXTENT_LABELS) {
+      const v = rowByLabel(r, label).value;
+      expect(v).not.toMatch(/\bm\b/);
+      expect(v).not.toMatch(/pts\/m²/);
+    }
+    expect(rowByLabel(r, 'Width').value).toBe('2.0 (source units)');
+    expect(rowByLabel(r, 'Density').value).toBe('1.0 pts/unit²');
+    expect(rowByLabel(r, 'Spacing').value).toBe('1.00 (source units)');
+  });
+
+  it('geographic CRS (degrees): the severe case is not stamped as metres', () => {
+    // A lat/lon cloud resolves to linearUnit "unknown" with factor 1. The spans
+    // are DEGREES; labelling them "m" would be grossly wrong (~111 km / deg).
+    const r = scanReport.run(
+      make({ source: 'wkt', name: 'WGS 84', linearUnit: 'unknown', linearUnitToMetres: 1, isGeographic: true }),
+    );
+    expect(rowByLabel(r, 'Width').value).not.toMatch(/\bm\b/);
+    expect(rowByLabel(r, 'Height').value).not.toMatch(/\bm\b/);
+  });
+
+  it('a resolved metre CRS still reports "m" / "pts/m²" (byte-identical to before)', () => {
+    const r = scanReport.run(
+      make({ source: 'wkt', name: 'WGS 84 / UTM zone 12N', linearUnit: 'metre', linearUnitToMetres: 1, isGeographic: false }),
+    );
+    expect(rowByLabel(r, 'Width').value).toBe('2.0 m');
+    expect(rowByLabel(r, 'Density').value).toBe('1.0 pts/m²');
+    expect(rowByLabel(r, 'Spacing').value).toBe('1.00 m');
+  });
+});


### PR DESCRIPTION
## Verdict: LEAK → FIXED

The static Inspector **Scan Report** (`src/analysis/modules/scanReport.ts`) derived its extent block from a per-CRS metre factor **without** gating on `linearUnit !== 'unknown'`:

```ts
const mpu  = cloud.metadata?.crs?.linearUnitToMetres ?? 1;
const vmpu = cloud.metadata?.crs?.verticalUnitToMetres ?? mpu;
```

An unknown-unit CRS carries the inert placeholder `linearUnitToMetres: 1`, and a CRS-less cloud resolves the same way. Multiplying a source span by that `1` and stamping "m" / "pts/m²" silently reported non-metre data as metres — Width/Depth/Height/Density/Spacing. The severe case: a **geographic (degrees) CRS** resolves to `linearUnit: 'unknown'`, factor 1, so lat/lon spans were labelled metres.

This is the static-report sibling of the already-merged streaming (#218) and space-report (#220) fixes.

## Fix

Small pure helper `scanReportUnitBasis(crs)` that fails closed on the canonical predicate `crs != null && crs.linearUnit !== 'unknown'`:

- **Confirmed unit** → apply the factor, label "m" / "pts/m²" (byte-identical to before).
- **Unknown / CRS-less** → factor stays 1, show the raw source span as `(source units)` / `pts/unit²`, withhold the metre claim.

Matches the shape of the merged `streamingExtentRows` (same Width/Depth/Height/Density/Spacing rows) and the `spaceMetrics` gate.

## Tests

New `tests/scanReportUnits.test.ts` (8 tests): the helper's gate for metre/foot/unknown/null, and the module proving the unknown-unit and geographic-CRS paths no longer claim metres while a resolved metre CRS still reports "m".

## Gates
- `npm run typecheck` — 0 errors
- `npx vitest run` on `scanReportUnits` + `scanReport` + `scanReportScope` — 36 passed
- Siblings `streamingExtentRows` + `spaceMetrics` + `unitIntegrity` — 61 passed (no collateral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
