### PR TITLE
Fail closed on unknown CRS unit in the scan fitness scorecard

### DIFF
--- a/src/terrain/quality/scanFitness.ts
+++ b/src/terrain/quality/scanFitness.ts
@@ -62,6 +62,18 @@ export interface FitnessInputs {
    * without this a feet RMSE was graded against metre thresholds. Default 1.
    */
   readonly unitToMetres?: number;
+  /**
+   * Whether the source linear unit is KNOWN — the CRS resolved a real linear
+   * unit. When explicitly `false`, the "pts/m²" density verdict and the "m"
+   * vertical-accuracy verdict are assume-metres claims on an inert placeholder
+   * factor (an unknown-unit or CRS-less scan), so they are HELD BACK (graded
+   * `review`, the headline accuracy suppressed) and a unit-unverified caveat is
+   * added instead of asserting a bare metric figure. `undefined` keeps the
+   * legacy "assume known" behaviour (no change) for callers that predate the
+   * flag. Mirrors the `crs.linearUnit !== 'unknown'` gate the streaming-extent /
+   * space-metrics / lasso seams already apply.
+   */
+  readonly unitKnown?: boolean;
   // Classification: fraction unclassified (null = no classification at all) and
   // whether a ground class is present.
   readonly unclassifiedFraction: number | null;
@@ -127,6 +139,15 @@ const RMSE_READY = 0.1;
 const RMSE_OKAY = 0.3;
 /** Unclassified fraction below which the cloud is well classified. */
 const UNCLASSIFIED_OKAY = 0.1;
+/**
+ * Caveat when the source linear unit is unverified (unknown-unit or CRS-less
+ * scan): every density / accuracy figure here would be labelled "pts/m²" / "m"
+ * off an inert placeholder factor, so disclose the assumption rather than assert
+ * metres. Parallels the space-metrics `UNVERIFIED_UNIT_CAVEAT` and the
+ * streaming-extent "in source units" fallback.
+ */
+const UNVERIFIED_UNIT_CAVEAT =
+  'Coordinate units are unverified — density (pts/m²) and vertical accuracy (m) would assume metres, so both are held back until the source CRS is confirmed.';
 
 function pct(frac: number): number {
   return Math.round(frac * 100);
@@ -151,8 +172,19 @@ function coverageDimension(f: number | null): FitnessDimension {
   return { key: 'coverage', label: 'Coverage', tone, summary };
 }
 
-function densityDimension(d: number | null): FitnessDimension {
+function densityDimension(d: number | null, unitKnown: boolean): FitnessDimension {
   if (d == null) return { key: 'density', label: 'Ground detail', tone: 'review', summary: 'Ground density unknown.' };
+  // Fail closed on an unverified scale: a pts/m² figure derived off an inert
+  // placeholder factor is not assertable, so hold the metric verdict rather than
+  // grade an unknown-unit scan against the metric 3DEP density floors.
+  if (!unitKnown) {
+    return {
+      key: 'density',
+      label: 'Ground detail',
+      tone: 'review',
+      summary: 'Coordinate units are unverified — ground density can’t be graded in pts/m² until the source CRS is confirmed.',
+    };
+  }
   const tone: FitnessTone = d >= QL1_DENSITY ? 'ready' : d >= QL2_DENSITY ? 'okay' : 'review';
   const v = d >= 100 ? Math.round(d) : Math.round(d * 10) / 10;
   const summary =
@@ -164,9 +196,20 @@ function densityDimension(d: number | null): FitnessDimension {
   return { key: 'density', label: 'Ground detail', tone, summary };
 }
 
-function accuracyDimension(rmse: number | null, unit: string, unitToMetres: number): FitnessDimension {
+function accuracyDimension(rmse: number | null, unit: string, unitToMetres: number, unitKnown: boolean): FitnessDimension {
   if (rmse == null) {
     return { key: 'accuracy', label: 'Vertical accuracy', tone: 'review', summary: 'Not validated against any reference.' };
+  }
+  // Fail closed on an unverified scale: the RMSE would print "± m" and bucket
+  // against metric thresholds off an inert placeholder factor, so hold the
+  // verdict rather than assert a metre figure on an unknown-unit scan.
+  if (!unitKnown) {
+    return {
+      key: 'accuracy',
+      label: 'Vertical accuracy',
+      tone: 'review',
+      summary: 'Coordinate units are unverified — vertical accuracy can’t be stated in metres until the source CRS is confirmed.',
+    };
   }
   // Bucket on the METRIC value; the thresholds are metres. The displayed value
   // stays in the file's unit.
@@ -232,12 +275,15 @@ const LIMITER_PRIORITY: readonly FitnessKey[] = [
 export function buildScanFitness(inp: FitnessInputs): ScanFitness {
   const unit = inp.unit ?? 'm';
   const unitToMetres = inp.unitToMetres ?? 1;
+  // `undefined` keeps the legacy assume-known behaviour; only an explicit `false`
+  // fails the metric verdicts closed (unknown-unit / CRS-less scan).
+  const unitKnown = inp.unitKnown !== false;
   const provisional = inp.coverageMode !== 'full';
   const dimensions: FitnessDimension[] = [
     georefDimension(inp),
     coverageDimension(inp.measuredFraction),
-    densityDimension(inp.groundDensityPerM2),
-    accuracyDimension(inp.verticalRmse, unit, unitToMetres),
+    densityDimension(inp.groundDensityPerM2, unitKnown),
+    accuracyDimension(inp.verticalRmse, unit, unitToMetres, unitKnown),
     classificationDimension(inp.unclassifiedFraction, inp.hasGroundClass),
     integrityDimension(inp),
   ];
@@ -252,8 +298,12 @@ export function buildScanFitness(inp: FitnessInputs): ScanFitness {
   const limiterPhrase: Record<FitnessKey, string> = {
     georeferencing: 'it isn’t placed in the real world (no map position or height datum)',
     coverage: 'ground coverage is sparse — most of the surface is interpolated',
-    density: 'ground density is below survey thresholds',
-    accuracy: 'vertical accuracy isn’t validated',
+    density: unitKnown
+      ? 'ground density is below survey thresholds'
+      : 'coordinate units are unverified, so density can’t be graded',
+    accuracy: unitKnown
+      ? 'vertical accuracy isn’t validated'
+      : 'coordinate units are unverified, so accuracy can’t be stated',
     classification: 'points aren’t classified to ground',
     integrity: 'only part of the cloud was analysed',
   };
@@ -292,9 +342,15 @@ export function buildScanFitness(inp: FitnessInputs): ScanFitness {
       ? `${inp.qualityLevel} (estimated)`
       : null;
 
-  const headlineAccuracy = inp.verticalRmse != null ? `±${inp.verticalRmse.toFixed(2)} ${unit} vertical` : null;
+  // The headline is a bare "± m" claim, so it too is withheld on an unverified
+  // scale (the unit-unverified caveat carries the disclosure instead).
+  const headlineAccuracy =
+    unitKnown && inp.verticalRmse != null ? `±${inp.verticalRmse.toFixed(2)} ${unit} vertical` : null;
 
   const caveats: string[] = [];
+  // Lead with the unit-unverified disclosure when the scale is unconfirmed — it
+  // is the most use-limiting caveat, since it holds back the metric verdicts.
+  if (!unitKnown) caveats.push(UNVERIFIED_UNIT_CAVEAT);
   if (inp.notSurveyGrade && inp.verticalRmse != null) {
     caveats.push('Accuracy is internal consistency (held-out points), not independent checkpoint verification.');
   }

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -2571,6 +2571,14 @@ export class AnalysePanel {
     const covered = t.measured + t.interpolated + t.lowConfidence + t.edgeRisk;
     const ql = r.accuracyStandards.qualityLevel;
     const hasClass = r.excludedByClassification > 0;
+    // Whether the source linear unit is confirmed — the same gate every other
+    // unit consumer applies (`crs.linearUnit !== 'unknown'`). An unknown-unit or
+    // CRS-less scan carries the inert placeholder factor 1, so the density
+    // (pts/m²) and vertical-accuracy (m) verdicts would silently assert metres;
+    // pass the flag so scanFitness holds those metric claims and discloses the
+    // assumption instead of stamping a bare "pts/m²" / "m".
+    const fitLinearUnit = this._cb.getMapContext?.()?.linearUnit;
+    const unitKnown = fitLinearUnit != null && fitLinearUnit !== 'unknown';
     const inputs: FitnessInputs = {
       status: a.status,
       score: a.scoreKnown ? a.score : null,
@@ -2584,6 +2592,7 @@ export class AnalysePanel {
       notSurveyGrade: true,
       unit: 'm',
       unitToMetres: 1,
+      unitKnown,
       // The contour result doesn't carry the full class histogram; the presence
       // of classified returns dropped before ground filtering tells us the
       // source WAS classified (else ground was derived).

--- a/tests/scanFitness.test.ts
+++ b/tests/scanFitness.test.ts
@@ -198,3 +198,47 @@ describe('buildScanFitness — density reports a measurement, not a quality leve
     expect(buildScanFitness(base()).tierBadge).toBe('USGS QL1 (estimated)');
   });
 });
+
+describe('buildScanFitness — unverified units fail closed', () => {
+  const summary = (f: ReturnType<typeof buildScanFitness>, key: FitnessKey): string =>
+    f.dimensions.find((d) => d.key === key)!.summary;
+
+  it('an unknown-unit CRS holds the pts/m² and metre verdicts and discloses it', () => {
+    // Same dense, survey-grade numbers as the all-pass baseline, but the source
+    // linear unit is NOT confirmed (inert placeholder factor). The metric claims
+    // must be withheld rather than asserted as metres.
+    const f = buildScanFitness(base({ unitKnown: false }));
+    expect(tone(f, 'density')).toBe<FitnessTone>('review');
+    expect(tone(f, 'accuracy')).toBe<FitnessTone>('review');
+    // No bare metric figure survives in either summary.
+    expect(summary(f, 'density')).not.toMatch(/\d+\s*ground pts\/m²/);
+    expect(summary(f, 'density')).toMatch(/units are unverified/i);
+    expect(summary(f, 'accuracy')).not.toMatch(/±\s*\d/);
+    expect(summary(f, 'accuracy')).toMatch(/units are unverified/i);
+    // Headline accuracy (a bare "± m") is withheld too.
+    expect(f.headlineAccuracy).toBeNull();
+    // The disclosure leads the non-hideable caveats.
+    expect(f.caveats[0]).toMatch(/coordinate units are unverified/i);
+    // A QL tier can't be earned on an unverified scale, even though a QL was supplied.
+    expect(f.tierBadge).toBeNull();
+    // The hero tone is driven to review and the verdict names the unit limitation.
+    expect(f.overallTone).toBe<FitnessTone>('review');
+    expect(f.verdict).toMatch(/units are unverified/i);
+  });
+
+  it('omitting unitKnown keeps the legacy metric verdict (no regression)', () => {
+    const f = buildScanFitness(base()); // unitKnown undefined ⇒ assume known
+    expect(tone(f, 'density')).toBe<FitnessTone>('ready');
+    expect(tone(f, 'accuracy')).toBe<FitnessTone>('ready');
+    expect(f.headlineAccuracy).toBe('±0.07 m vertical');
+    expect(f.tierBadge).toBe('USGS QL1 (estimated)');
+    expect(f.caveats.some((c) => /units are unverified/i.test(c))).toBe(false);
+  });
+
+  it('unitKnown:true is unchanged from the assume-known baseline', () => {
+    const f = buildScanFitness(base({ unitKnown: true }));
+    expect(tone(f, 'density')).toBe<FitnessTone>('ready');
+    expect(tone(f, 'accuracy')).toBe<FitnessTone>('ready');
+    expect(f.tierBadge).toBe('USGS QL1 (estimated)');
+  });
+});


### PR DESCRIPTION
## What

The verdict-led Data Fitness scorecard hardcoded `unit: 'm'` / `unitToMetres: 1` and passed no unit-known signal to `buildScanFitness`. A projected CRS carrying `linearUnit: 'unknown'` (the inert placeholder factor `1`) therefore produced undisclosed metric claims:

- density verdict `X ground pts/m² — at or above 8 pts/m² (the 3DEP QL1 density floor)`
- accuracy verdict `±X.XX m vertical` and metric-threshold bucketing
- a `USGS QL… (estimated)` tier badge

`crsKnown` is `crs != null`, so an unknown-unit CRS reads as georeferenced, and the density is computed off the placeholder factor upstream (`cellMetrics.ts` `cellSizeMetres = cellSizeM * horizontalUnitToMetres`). Nothing disclosed that the "m" / "pts/m²" were assumptions.

## Fix

- `FitnessInputs.unitKnown?: boolean` — `undefined` keeps the legacy assume-known behaviour; explicit `false` fails the metric verdicts closed.
- When `false`, `buildScanFitness` grades density and accuracy `review` with a units summary (no `pts/m²` / `m` figure), withholds `headlineAccuracy`, voids the tier badge, and leads the caveats with the unit disclosure. The verdict names units as the limiter.
- `AnalysePanel` derives the flag from the resolved CRS using the same gate the streaming-extent / space-metrics / lasso seams apply: `linearUnit != null && linearUnit !== 'unknown'`.

Follows the sibling fail-closed fixes #217–#220.

## Gates

- `npm run typecheck` — 0 errors
- `npx vitest run` — 7454 passed, 0 failed (scanFitness: 26 passed, +3 new fail-closed cases)

## Out of scope

A known non-metre (foot) CRS still displays accuracy as "m" because the caller keeps `unit: 'm'` / `unitToMetres: 1`; that is a separate pre-existing labeling issue, not the unknown-unit leak addressed here.