### PR TITLE
Extract render loop body to renderLoop.ts behind a host

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.3.md
+++ b/KNOWN_LIMITATIONS_v0.6.3.md
@@ -6,7 +6,7 @@ Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 6,976 lines and `src/render/Viewer.ts` is 6,458, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 6,976 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -114,7 +114,7 @@ called with a 19-member deps object. The candidates that remain:
 | `generateReportPdf` / `exportGeoContext` | 402 | export/report wiring module |
 | `importSession` | 177 | `src/app/sessionIo.ts` *(planned)* |
 
-**`src/render/Viewer.ts` (6,458)** — the constructor and a handful of large
+**`src/render/Viewer.ts` (6,419)** — the constructor and a handful of large
 methods dominate:
 
 Spans below are the symbol's real extent, read from the TypeScript symbol graph
@@ -125,7 +125,14 @@ been extracted, and both errors pointed the decomposition at the wrong work.
 | Block | Lines | Extraction target |
 |---|---:|---|
 | `constructor` | 564 | staged scene/pipeline builders |
-| `_startLoop` | 107 | `src/render/renderLoop.ts` *(planned)* |
+
+Done: the per-frame render loop body (`_startLoop`, 107 lines) now lives in
+`src/render/renderLoop.ts` as `runRenderFrame(host)` behind a structural
+`RenderLoopHost`, so the paint-path choice, the EDL snap-back on settle, the
+streaming tick cadence and the tool-overlay gating test against a fake host
+without a WebGL or rAF context (`tests/renderLoop.test.ts`). `Viewer` keeps a
+thin `_startLoop` that binds its state to the host and owns the
+requestAnimationFrame scheduling (browser-only, e2e-covered).
 
 Done: `_buildExportAdapter` (265 lines) now lives in `src/render/exportAdapter.ts`,
 which takes a structural host rather than the Viewer, so the Studio's scene
@@ -161,8 +168,9 @@ and reaches into nav, camera, measure-datum and colour-context, so it moves
 only behind an explicit host interface, the same shape used for the export
 adapter and the lasso walk. That is the next decomposition step worth taking.
 The EDL cluster (`_edl*`) is a smaller follow-on. Everything else on the class
-— the constructor's scene/pipeline build, the render loop body, event wiring —
-is the irreducibly view-bound remainder, and belongs here.
+— the constructor's scene/pipeline build, the render loop's requestAnimationFrame
+scheduling, event wiring — is the irreducibly view-bound remainder, and belongs
+here.
 
 ## Test and gate topology
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -5,7 +5,7 @@
       "goal": 2500
     },
     "src/render/Viewer.ts": {
-      "lines": 6458,
+      "lines": 6419,
       "goal": 2000
     }
   }

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -95,10 +95,9 @@ import { colorForMode, defaultMode } from './colorModes';
 import type { ColorMode, CoverageColorGrid } from './colorModes';
 import { type ActiveColorbar } from './activeColorbar';
 import { captureSnapshot, canvasToBlob, type SnapshotHost, type SnapshotOptions } from './snapshot';
+import { runRenderFrame, type RenderLoopHost } from './renderLoop';
 import { type ClipBox, clipKeepsPoint, countKept } from './clip/clipBox';
 import { edlDefaultEnabled, EDL_DEFAULTS, EDL_DEPTH_BIAS } from './edl';
-import { cameraIsMoving, edlActiveThisFrame } from './edlMotionGate';
-import { shouldRunProbePick } from './hoverPickGate';
 import { angularVelocity } from './angularVelocity';
 import {
   targetPixelRatio,
@@ -6298,113 +6297,75 @@ export class Viewer {
   }
 
   private _startLoop(): void {
-    const loop = () => {
+    // The per-frame body lives in `renderLoop.ts` behind a structural
+    // RenderLoopHost; this starter binds the Viewer's own state to it and owns
+    // the requestAnimationFrame scheduling (browser-only, e2e-covered). The
+    // host is built once — its accessors read `this` on every frame, so the
+    // loop always sees current state.
+    const host = this._buildRenderLoopHost();
+    const loop = (): void => {
       this._rafId = requestAnimationFrame(loop);
-      this._timer.update();
-      const delta = this._timer.getDelta();
-      this._recordFrame(delta);
-      this._nav.update(delta);
-      // Orbit-pivot maintenance — soft-clamp + streaming bounds-refinement
-      // lerp. Cheap and bounded; runs every frame regardless of EDL state.
-      this._maintainOrbitCenter();
-      // adaptive EDL. Modulate strength based on
-      // camera-to-target distance — close inspection gets stronger depth
-      // cueing (carves out structure), overview gets lighter (avoids
-      // muddy contrast). Cheap, runs every frame.
-      this._updateAdaptiveEdl();
-      // Idle-render throttle — the dominant fix for "OpenLiDARViewer
-      // makes my laptop hot". When the scene is quiet (no input, no
-      // tween, no streaming work) we render only every Nth frame
-      // instead of every frame. The CPU path above still runs every
-      // iteration so OrbitControls damping integrates correctly and
-      // streaming keeps its cadence; only the GPU `render()` call is
-      // gated. See `_shouldRenderFrame` for the full predicate.
-      const rendered = this._shouldRenderFrame();
-      // Suspend EDL while the camera is moving: its full-screen post-process is
-      // the dominant per-frame cost during orbit/pan/fly. The depth cue returns
-      // the instant the view parks. `moving` reuses the same motion signal the
-      // frame-rate throttle uses, so the two never disagree.
-      const nowMs = (typeof performance !== 'undefined' && performance.now)
-        ? performance.now()
-        : Date.now();
-      const moving = cameraIsMoving(this._nav.isTweening, nowMs, this._renderGate.activityUntilMs);
-      const wantEdl = edlActiveThisFrame(this._edlEnabled, moving);
-      // P5 — pick this frame's DPR before rendering so the render uses it.
-      this._applyAdaptiveDpr(moving, delta, nowMs, rendered);
-      if (rendered) {
-        this._renderGate.noteRendered();
-        // EDL when parked → render through the post-processing pipeline; moving
-        // or EDL off → render the scene directly for zero post-processing cost.
-        if (wantEdl) this._post.render();
-        else this._renderer.render(this._scene, this._camera);
-        this._edlPaintedAtRest = wantEdl;
-      } else if (wantEdl && !this._edlPaintedAtRest) {
-        // Motion just settled and the last paint had EDL off — force one EDL
-        // repaint so the depth cue snaps back, then resume idle throttling.
-        this._renderGate.noteRendered();
-        this._post.render();
-        this._edlPaintedAtRest = true;
-      } else {
-        this._renderGate.noteSkipped();
-      }
-      // Streaming COPC — run the view-dependent scheduler on a throttled
-      // cadence (~10 Hz at 60 fps), never every frame.
-      if (this._streaming) {
-        // Metered commits drain every frame (no-op in immediate mode).
-        this._streaming.commit.pump(this._smoothedFrameMs());
-        this._streamingFrame++;
-        if (this._streamingFrame % 6 === 0) this._tickStreaming();
-      }
-      // After render, camera matrices are current — project the tool overlays.
-      if (this._toolMode === 'measure' && !this._measure.dragging && this._pointerMoved) {
-        this._pointerMoved = false;
-        const hit = this._pointerOnCanvas
-          ? this._pickPoint(this._pointerNdcX, this._pointerNdcY)
-          : null;
-        this._measure.setCursor(hit ? [hit.x, hit.y, hit.z] : null);
-      }
-      // Live probe — at most one detailed pick per frame, only when the
-      // pointer actually moved, so a hover readout costs no idle frame budget.
-      // v0.6 P6: skip the detailed GPU pick while the user is actively driving
-      // the camera (orbit/pan drag) — during a drag you are navigating, not
-      // reading a hover value, so the readback is wasted. `_pointerMoved` is NOT
-      // consumed here, so the probe fires once as soon as the drag settles.
-      // (No separate camera-tween flag exists, so only active interaction gates.)
-      if (
-        this._toolMode === 'probe' &&
-        this._pointerMoved &&
-        shouldRunProbePick({ userInteracting: this._userInteracting, tweening: false })
-      ) {
-        this._pointerMoved = false;
-        let info: PointInfo | null = null;
-        if (this._pointerOnCanvas) {
-          const hit = this._pickDetailed(this._pointerNdcX, this._pointerNdcY);
-          if (hit) {
-            info = this._infoForHit(hit);
-          } else {
-            // Fall back to resident streaming nodes — COPC live probe.
-            const streamHit = this._pickStreamingDetailed(
-              this._pointerNdcX,
-              this._pointerNdcY,
-            );
-            if (streamHit) info = this._infoForStreamingHit(streamHit);
-          }
-        }
-        this._probe.update(info, this._pointerClientX, this._pointerClientY);
-      }
-      // Re-project the 2D tool overlays only on frames we actually rendered
-      // (camera/scene changed). Pointer, keyboard and orbit input all bump
-      // render-activity → `rendered` is true during any interaction, so the
-      // live measure cursor stays responsive; quiet idle frames skip this DOM
-      // work instead of re-laying-out overlays 60×/s for a static scene. The
-      // idle heartbeat still renders periodically, keeping overlays fresh.
-      if (rendered) {
-        this._measure.render(this._camera, this._canvas);
-        this._inspect.render();
-        this._annotate.render(this._camera, this._canvas);
-      }
+      runRenderFrame(host);
     };
     loop();
+  }
+
+  /** Bind the Viewer's live render state to the {@link RenderLoopHost} contract. */
+  private _buildRenderLoopHost(): RenderLoopHost {
+    return {
+      advanceFrameClock: () => {
+        this._timer.update();
+        return this._timer.getDelta();
+      },
+      recordFrame: (delta) => this._recordFrame(delta),
+      updateNav: (delta) => this._nav.update(delta),
+      maintainOrbitCenter: () => this._maintainOrbitCenter(),
+      updateAdaptiveEdl: () => this._updateAdaptiveEdl(),
+      shouldRenderFrame: () => this._shouldRenderFrame(),
+      isTweening: () => this._nav.isTweening,
+      activityUntilMs: () => this._renderGate.activityUntilMs,
+      edlEnabled: () => this._edlEnabled,
+      applyAdaptiveDpr: (moving, delta, nowMs, rendered) =>
+        this._applyAdaptiveDpr(moving, delta, nowMs, rendered),
+      noteRendered: () => this._renderGate.noteRendered(),
+      noteSkipped: () => this._renderGate.noteSkipped(),
+      renderEdl: () => this._post.render(),
+      renderScene: () => this._renderer.render(this._scene, this._camera),
+      edlPaintedAtRest: () => this._edlPaintedAtRest,
+      setEdlPaintedAtRest: (value) => {
+        this._edlPaintedAtRest = value;
+      },
+      hasStreaming: () => this._streaming !== null,
+      pumpStreamingCommit: () => {
+        this._streaming?.commit.pump(this._smoothedFrameMs());
+      },
+      advanceStreamingFrame: () => ++this._streamingFrame,
+      tickStreaming: () => this._tickStreaming(),
+      toolMode: () => this._toolMode,
+      measureDragging: () => this._measure.dragging,
+      pointerMoved: () => this._pointerMoved,
+      clearPointerMoved: () => {
+        this._pointerMoved = false;
+      },
+      pointerOnCanvas: () => this._pointerOnCanvas,
+      pointerNdc: () => ({ x: this._pointerNdcX, y: this._pointerNdcY }),
+      pointerClient: () => ({ x: this._pointerClientX, y: this._pointerClientY }),
+      pickPoint: (ndcX, ndcY) => this._pickPoint(ndcX, ndcY),
+      setMeasureCursor: (point) => this._measure.setCursor(point),
+      userInteracting: () => this._userInteracting,
+      probePickStatic: (ndcX, ndcY) => {
+        const hit = this._pickDetailed(ndcX, ndcY);
+        return hit ? this._infoForHit(hit) : null;
+      },
+      probePickStreaming: (ndcX, ndcY) => {
+        const hit = this._pickStreamingDetailed(ndcX, ndcY);
+        return hit ? this._infoForStreamingHit(hit) : null;
+      },
+      updateProbe: (info, clientX, clientY) => this._probe.update(info, clientX, clientY),
+      renderMeasureOverlay: () => this._measure.render(this._camera, this._canvas),
+      renderInspectOverlay: () => this._inspect.render(),
+      renderAnnotateOverlay: () => this._annotate.render(this._camera, this._canvas),
+    };
   }
 
   /**

--- a/src/render/renderLoop.ts
+++ b/src/render/renderLoop.ts
@@ -1,0 +1,221 @@
+/**
+ * renderLoop.ts — the per-frame body the Viewer's `_startLoop` drives.
+ *
+ * `runRenderFrame` is one iteration of the animation loop: advance the frame
+ * clock and the CPU pipeline (nav integration, orbit-centre maintenance,
+ * adaptive EDL), decide whether this frame renders (idle-render throttle),
+ * paint through the EDL post-process or straight to the renderer, run the
+ * streaming scheduler on its throttled cadence, and re-project the tool
+ * overlays. The requestAnimationFrame scheduling itself stays in `Viewer`
+ * (browser-only, e2e-covered); only the body moves here.
+ *
+ * It reads the live scene through a structural {@link RenderLoopHost} — a set
+ * of accessor and command functions rather than the Viewer itself — the same
+ * seam the export adapter, colour legend and snapshot pipeline use, so nothing
+ * here imports `Viewer` at runtime. `Viewer` keeps a thin `_startLoop` that
+ * builds the host from its own state and schedules the loop. The stateless
+ * decisions (render-vs-skip, EDL snap-back, streaming cadence, tool gating) now
+ * unit-test against a fake host without a real WebGL or rAF context; the pure
+ * predicates they compose (`cameraIsMoving`, `edlActiveThisFrame`,
+ * `shouldRunProbePick`) are tested in their own modules. Part of the v0.6
+ * decomposition (see `docs/architecture/architecture-map.md`).
+ */
+
+import { cameraIsMoving, edlActiveThisFrame } from './edlMotionGate';
+import { shouldRunProbePick } from './hoverPickGate';
+import type { PointInfo } from './pointInfo';
+import type { ToolMode } from './Viewer';
+
+/**
+ * Run the streaming view-dependent scheduler once every this-many frames
+ * (~10 Hz at 60 fps), never every frame. The per-frame commit pump and frame
+ * counter still advance every iteration; only the scheduler tick is throttled.
+ */
+export const STREAMING_TICK_INTERVAL = 6;
+
+/**
+ * What the per-frame loop reads from the live scene. Accessors are functions,
+ * not captured values, so every frame sees the CURRENT Viewer state — the
+ * property the inline loop had by reading `this` per iteration. Commands wrap
+ * the side-effecting calls (render, note-rendered/skipped, streaming tick,
+ * overlay re-projection) so the ordering here is the whole contract.
+ */
+export interface RenderLoopHost {
+  /** Advance the frame clock and return the delta in seconds for this frame. */
+  advanceFrameClock(): number;
+  /** Record frame timing for the FPS/among-frame stats. */
+  recordFrame(delta: number): void;
+  /** Integrate the navigation controller (OrbitControls damping, tweens). */
+  updateNav(delta: number): void;
+  /** Soft-clamp + streaming bounds-refinement lerp for the orbit pivot. */
+  maintainOrbitCenter(): void;
+  /** Modulate EDL strength from camera-to-target distance. */
+  updateAdaptiveEdl(): void;
+
+  /** Should the GPU `render()` run this frame? (idle-render throttle). */
+  shouldRenderFrame(): boolean;
+  /** Is a camera tween animating this frame? */
+  isTweening(): boolean;
+  /** The render-activity holdover deadline (ms), for the motion signal. */
+  activityUntilMs(): number;
+  /** Is Eye-Dome Lighting enabled at all? */
+  edlEnabled(): boolean;
+  /** Pick this frame's device-pixel-ratio before the render uses it. */
+  applyAdaptiveDpr(moving: boolean, delta: number, nowMs: number, rendered: boolean): void;
+
+  /** Mark that this frame rendered (resets the idle-skip counter). */
+  noteRendered(): void;
+  /** Mark that this frame was skipped by the idle throttle. */
+  noteSkipped(): void;
+  /** Paint through the EDL post-processing pipeline. */
+  renderEdl(): void;
+  /** Paint the scene directly (zero post-processing). */
+  renderScene(): void;
+  /** Was the last at-rest paint drawn with EDL on? */
+  edlPaintedAtRest(): boolean;
+  /** Record whether this frame's at-rest paint used EDL. */
+  setEdlPaintedAtRest(value: boolean): void;
+
+  /** Is a streaming (COPC/EPT) session attached? */
+  hasStreaming(): boolean;
+  /** Drain metered streaming commits (no-op in immediate mode). */
+  pumpStreamingCommit(): void;
+  /** Advance the streaming frame counter and return its new value. */
+  advanceStreamingFrame(): number;
+  /** Run the throttled streaming scheduler tick. */
+  tickStreaming(): void;
+
+  /** The active tool mode. */
+  toolMode(): ToolMode;
+  /** Is a measurement drag in progress (suppresses the hover cursor)? */
+  measureDragging(): boolean;
+  /** Has the pointer moved since it was last consumed? */
+  pointerMoved(): boolean;
+  /** Consume the pointer-moved flag. */
+  clearPointerMoved(): void;
+  /** Is the pointer currently over the canvas? */
+  pointerOnCanvas(): boolean;
+  /** The pointer's normalised device coordinates. */
+  pointerNdc(): { x: number; y: number };
+  /** The pointer's client coordinates (for the probe readout placement). */
+  pointerClient(): { x: number; y: number };
+  /** Pick a world point under the given NDC for the live measure cursor. */
+  pickPoint(ndcX: number, ndcY: number): { x: number; y: number; z: number } | null;
+  /** Set (or clear) the live measurement cursor. */
+  setMeasureCursor(point: [number, number, number] | null): void;
+
+  /** Is the user actively driving the camera (orbit/pan drag)? */
+  userInteracting(): boolean;
+  /** Detailed probe pick against the static clouds, as display info, or null. */
+  probePickStatic(ndcX: number, ndcY: number): PointInfo | null;
+  /** Detailed probe pick against resident streaming nodes, or null. */
+  probePickStreaming(ndcX: number, ndcY: number): PointInfo | null;
+  /** Push the probe readout for this frame. */
+  updateProbe(info: PointInfo | null, clientX: number, clientY: number): void;
+
+  /** Re-project the measurement overlay against the current camera. */
+  renderMeasureOverlay(): void;
+  /** Re-project the inspector overlay. */
+  renderInspectOverlay(): void;
+  /** Re-project the annotation markers. */
+  renderAnnotateOverlay(): void;
+}
+
+/** The frame timestamp — `performance.now()` where available, else `Date.now()`. */
+function frameNow(): number {
+  return typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
+}
+
+/**
+ * One iteration of the render loop. The CPU pipeline (timer, nav,
+ * orbit-centre, adaptive EDL) runs every call regardless of whether the GPU
+ * frame renders, so damping integrates and streaming keeps cadence; only the
+ * `render()` call and the overlay re-projection are gated on `rendered`.
+ */
+export function runRenderFrame(host: RenderLoopHost): void {
+  const delta = host.advanceFrameClock();
+  host.recordFrame(delta);
+  host.updateNav(delta);
+  // Orbit-pivot maintenance — cheap and bounded; runs every frame regardless
+  // of EDL/render state.
+  host.maintainOrbitCenter();
+  // Adaptive EDL strength — cheap, runs every frame.
+  host.updateAdaptiveEdl();
+
+  // Idle-render throttle — when the scene is quiet we render only every Nth
+  // frame. The CPU path above still runs every iteration; only the GPU
+  // `render()` is gated.
+  const rendered = host.shouldRenderFrame();
+  const nowMs = frameNow();
+  // Suspend EDL while the camera moves: its full-screen post-process is the
+  // dominant per-frame cost during orbit/pan/fly. `moving` reuses the same
+  // motion signal the frame-rate throttle uses, so the two never disagree.
+  const moving = cameraIsMoving(host.isTweening(), nowMs, host.activityUntilMs());
+  const wantEdl = edlActiveThisFrame(host.edlEnabled(), moving);
+  // Pick this frame's DPR before rendering so the render uses it.
+  host.applyAdaptiveDpr(moving, delta, nowMs, rendered);
+
+  if (rendered) {
+    host.noteRendered();
+    // EDL when parked → post-processing pipeline; moving or EDL off → direct.
+    if (wantEdl) host.renderEdl();
+    else host.renderScene();
+    host.setEdlPaintedAtRest(wantEdl);
+  } else if (wantEdl && !host.edlPaintedAtRest()) {
+    // Motion just settled and the last paint had EDL off — force one EDL
+    // repaint so the depth cue snaps back, then resume idle throttling.
+    host.noteRendered();
+    host.renderEdl();
+    host.setEdlPaintedAtRest(true);
+  } else {
+    host.noteSkipped();
+  }
+
+  // Streaming COPC — throttled scheduler tick (~10 Hz), never every frame. The
+  // commit pump and frame counter advance every frame.
+  if (host.hasStreaming()) {
+    host.pumpStreamingCommit();
+    if (host.advanceStreamingFrame() % STREAMING_TICK_INTERVAL === 0) {
+      host.tickStreaming();
+    }
+  }
+
+  // After render, camera matrices are current — project the tool overlays.
+  if (host.toolMode() === 'measure' && !host.measureDragging() && host.pointerMoved()) {
+    host.clearPointerMoved();
+    const ndc = host.pointerNdc();
+    const hit = host.pointerOnCanvas() ? host.pickPoint(ndc.x, ndc.y) : null;
+    host.setMeasureCursor(hit ? [hit.x, hit.y, hit.z] : null);
+  }
+
+  // Live probe — at most one detailed pick per frame, only when the pointer
+  // actually moved, and never while the user is driving the camera. The
+  // pointer-moved flag is consumed here so the probe fires once as the drag
+  // settles. `tweening: false` matches the inline loop (no separate tween flag).
+  if (
+    host.toolMode() === 'probe' &&
+    host.pointerMoved() &&
+    shouldRunProbePick({ userInteracting: host.userInteracting(), tweening: false })
+  ) {
+    host.clearPointerMoved();
+    let info: PointInfo | null = null;
+    if (host.pointerOnCanvas()) {
+      const ndc = host.pointerNdc();
+      // Static clouds first; fall back to resident streaming nodes only when
+      // the static pick misses — the COPC live probe.
+      info = host.probePickStatic(ndc.x, ndc.y);
+      if (info === null) info = host.probePickStreaming(ndc.x, ndc.y);
+    }
+    const client = host.pointerClient();
+    host.updateProbe(info, client.x, client.y);
+  }
+
+  // Re-project the 2D tool overlays only on frames we actually rendered
+  // (camera/scene changed). Quiet idle frames skip this DOM work; the idle
+  // heartbeat still renders periodically, keeping overlays fresh.
+  if (rendered) {
+    host.renderMeasureOverlay();
+    host.renderInspectOverlay();
+    host.renderAnnotateOverlay();
+  }
+}

--- a/tests/architectureMap.test.ts
+++ b/tests/architectureMap.test.ts
@@ -88,8 +88,12 @@ describe('architecture map stays in step with the tree', () => {
     const text = mapText();
     // Table rows look like: | `blockName` | 265 | target |
     // A cell may name two blocks (`handleRemoteEpt` / `openStreamingCopc`).
+    // The floor is a sanity guard against the tables being deleted wholesale,
+    // not a fixed size: each completed extraction moves its row out of the
+    // pending table into "Done:" prose, so the count ratchets down over time
+    // (the render-loop extraction took it from 10 to 9).
     const rows = text.split('\n').filter((l) => /^\|\s*`?[A-Za-z_]/.test(l) && /\|\s*[\d,]+\s*\|/.test(l));
-    expect(rows.length, 'the extraction tables have gone missing').toBeGreaterThanOrEqual(10);
+    expect(rows.length, 'the extraction tables have gone missing').toBeGreaterThanOrEqual(9);
 
     const lines = [
       ...readFileSync(root + 'src/main.ts', 'utf8').split('\n'),

--- a/tests/renderLoop.test.ts
+++ b/tests/renderLoop.test.ts
@@ -1,0 +1,315 @@
+/**
+ * The render loop's per-frame decisions.
+ *
+ * `runRenderFrame` previously lived inline in `Viewer._startLoop` and could
+ * only be exercised through a real WebGL + requestAnimationFrame context, so
+ * every scheduling decision it makes was covered by e2e alone. Extracting it
+ * behind a structural {@link RenderLoopHost} makes those decisions directly
+ * testable with a fake host: which paint path runs, the EDL snap-back on
+ * settle, the streaming tick cadence, and the tool-overlay gating. The pure
+ * predicates it composes (cameraIsMoving / edlActiveThisFrame /
+ * shouldRunProbePick) are tested in their own modules; the parts that need a
+ * real rAF (the loop scheduling itself) stay on the e2e suite.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runRenderFrame, STREAMING_TICK_INTERVAL } from '../src/render/renderLoop';
+import type { RenderLoopHost } from '../src/render/renderLoop';
+import type { PointInfo } from '../src/render/pointInfo';
+
+/** A fake host — permissive defaults (parked, EDL off, no tool), overridable per case. */
+function makeHost(over: Partial<RenderLoopHost> = {}): RenderLoopHost {
+  return {
+    advanceFrameClock: () => 0.016,
+    recordFrame: vi.fn(),
+    updateNav: vi.fn(),
+    maintainOrbitCenter: vi.fn(),
+    updateAdaptiveEdl: vi.fn(),
+    shouldRenderFrame: () => true,
+    isTweening: () => false,
+    // Parked by default: frameNow() > 0, so cameraIsMoving is false.
+    activityUntilMs: () => 0,
+    edlEnabled: () => false,
+    applyAdaptiveDpr: vi.fn(),
+    noteRendered: vi.fn(),
+    noteSkipped: vi.fn(),
+    renderEdl: vi.fn(),
+    renderScene: vi.fn(),
+    edlPaintedAtRest: () => false,
+    setEdlPaintedAtRest: vi.fn(),
+    hasStreaming: () => false,
+    pumpStreamingCommit: vi.fn(),
+    advanceStreamingFrame: () => 1,
+    tickStreaming: vi.fn(),
+    toolMode: () => 'none',
+    measureDragging: () => false,
+    pointerMoved: () => false,
+    clearPointerMoved: vi.fn(),
+    pointerOnCanvas: () => true,
+    pointerNdc: () => ({ x: 0.1, y: 0.2 }),
+    pointerClient: () => ({ x: 100, y: 200 }),
+    pickPoint: () => null,
+    setMeasureCursor: vi.fn(),
+    userInteracting: () => false,
+    probePickStatic: () => null,
+    probePickStreaming: () => null,
+    updateProbe: vi.fn(),
+    renderMeasureOverlay: vi.fn(),
+    renderInspectOverlay: vi.fn(),
+    renderAnnotateOverlay: vi.fn(),
+    ...over,
+  };
+}
+
+const MOVING = () => Number.POSITIVE_INFINITY; // activityUntilMs → now < it → moving
+
+describe('runRenderFrame — CPU pipeline runs every frame', () => {
+  it('advances the clock and drives nav/orbit/EDL even when the frame is skipped', () => {
+    const host = makeHost({
+      shouldRenderFrame: () => false,
+      advanceFrameClock: () => 0.02,
+    });
+    runRenderFrame(host);
+
+    expect(host.recordFrame).toHaveBeenCalledWith(0.02);
+    expect(host.updateNav).toHaveBeenCalledWith(0.02);
+    expect(host.maintainOrbitCenter).toHaveBeenCalledTimes(1);
+    expect(host.updateAdaptiveEdl).toHaveBeenCalledTimes(1);
+    // DPR is picked every frame with the frame's delta and the render decision.
+    expect(host.applyAdaptiveDpr).toHaveBeenCalledWith(false, 0.02, expect.any(Number), false);
+  });
+});
+
+describe('runRenderFrame — paint path', () => {
+  it('renders through EDL when parked and EDL is enabled', () => {
+    const host = makeHost({ edlEnabled: () => true, activityUntilMs: () => 0 });
+    runRenderFrame(host);
+
+    expect(host.renderEdl).toHaveBeenCalledTimes(1);
+    expect(host.renderScene).not.toHaveBeenCalled();
+    expect(host.noteRendered).toHaveBeenCalledTimes(1);
+    expect(host.setEdlPaintedAtRest).toHaveBeenCalledWith(true);
+  });
+
+  it('renders the scene directly while moving, even with EDL enabled', () => {
+    const host = makeHost({ edlEnabled: () => true, activityUntilMs: MOVING });
+    runRenderFrame(host);
+
+    expect(host.renderScene).toHaveBeenCalledTimes(1);
+    expect(host.renderEdl).not.toHaveBeenCalled();
+    expect(host.setEdlPaintedAtRest).toHaveBeenCalledWith(false);
+  });
+
+  it('renders the scene directly when EDL is disabled', () => {
+    const host = makeHost({ edlEnabled: () => false });
+    runRenderFrame(host);
+
+    expect(host.renderScene).toHaveBeenCalledTimes(1);
+    expect(host.renderEdl).not.toHaveBeenCalled();
+    expect(host.setEdlPaintedAtRest).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('runRenderFrame — idle throttle and EDL snap-back', () => {
+  it('forces one EDL repaint when motion settles and the last paint had EDL off', () => {
+    const host = makeHost({
+      shouldRenderFrame: () => false, // idle this frame
+      edlEnabled: () => true,
+      activityUntilMs: () => 0, // parked
+      edlPaintedAtRest: () => false, // last paint was EDL-off (was moving)
+    });
+    runRenderFrame(host);
+
+    expect(host.noteRendered).toHaveBeenCalledTimes(1);
+    expect(host.renderEdl).toHaveBeenCalledTimes(1);
+    expect(host.setEdlPaintedAtRest).toHaveBeenCalledWith(true);
+    expect(host.noteSkipped).not.toHaveBeenCalled();
+  });
+
+  it('skips the frame once the EDL snap-back has already been painted', () => {
+    const host = makeHost({
+      shouldRenderFrame: () => false,
+      edlEnabled: () => true,
+      activityUntilMs: () => 0,
+      edlPaintedAtRest: () => true, // already snapped back
+    });
+    runRenderFrame(host);
+
+    expect(host.noteSkipped).toHaveBeenCalledTimes(1);
+    expect(host.renderEdl).not.toHaveBeenCalled();
+    expect(host.noteRendered).not.toHaveBeenCalled();
+  });
+
+  it('skips the frame outright when EDL is off and nothing needs painting', () => {
+    const host = makeHost({ shouldRenderFrame: () => false, edlEnabled: () => false });
+    runRenderFrame(host);
+
+    expect(host.noteSkipped).toHaveBeenCalledTimes(1);
+    expect(host.renderScene).not.toHaveBeenCalled();
+    expect(host.renderEdl).not.toHaveBeenCalled();
+  });
+});
+
+describe('runRenderFrame — streaming cadence', () => {
+  it('does nothing streaming-related when no session is attached', () => {
+    const host = makeHost({ hasStreaming: () => false });
+    runRenderFrame(host);
+
+    expect(host.pumpStreamingCommit).not.toHaveBeenCalled();
+    expect(host.tickStreaming).not.toHaveBeenCalled();
+  });
+
+  it('pumps commits every frame but ticks the scheduler only on the interval', () => {
+    // Drive the frame counter 1..2*interval and count scheduler ticks.
+    let counter = 0;
+    const host = makeHost({
+      hasStreaming: () => true,
+      advanceStreamingFrame: () => ++counter,
+    });
+    const frames = STREAMING_TICK_INTERVAL * 2;
+    for (let i = 0; i < frames; i++) runRenderFrame(host);
+
+    expect(host.pumpStreamingCommit).toHaveBeenCalledTimes(frames);
+    // Ticks land exactly on multiples of the interval → twice across 2×.
+    expect(host.tickStreaming).toHaveBeenCalledTimes(2);
+  });
+
+  it('ticks on the interval-th frame, not before', () => {
+    let counter = 0;
+    const host = makeHost({
+      hasStreaming: () => true,
+      advanceStreamingFrame: () => ++counter,
+    });
+    for (let i = 0; i < STREAMING_TICK_INTERVAL - 1; i++) runRenderFrame(host);
+    expect(host.tickStreaming).not.toHaveBeenCalled();
+    runRenderFrame(host); // the interval-th frame
+    expect(host.tickStreaming).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runRenderFrame — measure cursor gating', () => {
+  it('picks and sets the cursor when measuring, not dragging, pointer moved over canvas', () => {
+    const host = makeHost({
+      toolMode: () => 'measure',
+      pointerMoved: () => true,
+      pointerOnCanvas: () => true,
+      pickPoint: () => ({ x: 1, y: 2, z: 3 }),
+    });
+    runRenderFrame(host);
+
+    expect(host.clearPointerMoved).toHaveBeenCalledTimes(1);
+    expect(host.setMeasureCursor).toHaveBeenCalledWith([1, 2, 3]);
+  });
+
+  it('clears the cursor when the pointer is off-canvas (no pick)', () => {
+    const pickPoint = vi.fn(() => ({ x: 1, y: 2, z: 3 }));
+    const host = makeHost({
+      toolMode: () => 'measure',
+      pointerMoved: () => true,
+      pointerOnCanvas: () => false,
+      pickPoint,
+    });
+    runRenderFrame(host);
+
+    expect(pickPoint).not.toHaveBeenCalled();
+    expect(host.setMeasureCursor).toHaveBeenCalledWith(null);
+  });
+
+  it('does nothing while a measurement drag is in progress', () => {
+    const host = makeHost({
+      toolMode: () => 'measure',
+      measureDragging: () => true,
+      pointerMoved: () => true,
+    });
+    runRenderFrame(host);
+
+    expect(host.clearPointerMoved).not.toHaveBeenCalled();
+    expect(host.setMeasureCursor).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the pointer has not moved', () => {
+    const host = makeHost({ toolMode: () => 'measure', pointerMoved: () => false });
+    runRenderFrame(host);
+
+    expect(host.setMeasureCursor).not.toHaveBeenCalled();
+  });
+});
+
+describe('runRenderFrame — live probe gating', () => {
+  const staticInfo = { layer: 'static' } as unknown as PointInfo;
+  const streamInfo = { layer: 'stream' } as unknown as PointInfo;
+
+  it('reads the static pick and pushes it, skipping the streaming fallback', () => {
+    const host = makeHost({
+      toolMode: () => 'probe',
+      pointerMoved: () => true,
+      pointerOnCanvas: () => true,
+      probePickStatic: () => staticInfo,
+      probePickStreaming: vi.fn(() => streamInfo),
+    });
+    runRenderFrame(host);
+
+    expect(host.clearPointerMoved).toHaveBeenCalledTimes(1);
+    expect(host.probePickStreaming).not.toHaveBeenCalled();
+    expect(host.updateProbe).toHaveBeenCalledWith(staticInfo, 100, 200);
+  });
+
+  it('falls back to the streaming pick when the static pick misses', () => {
+    const host = makeHost({
+      toolMode: () => 'probe',
+      pointerMoved: () => true,
+      pointerOnCanvas: () => true,
+      probePickStatic: () => null,
+      probePickStreaming: () => streamInfo,
+    });
+    runRenderFrame(host);
+
+    expect(host.updateProbe).toHaveBeenCalledWith(streamInfo, 100, 200);
+  });
+
+  it('pushes a null readout when the pointer is off-canvas', () => {
+    const host = makeHost({
+      toolMode: () => 'probe',
+      pointerMoved: () => true,
+      pointerOnCanvas: () => false,
+    });
+    runRenderFrame(host);
+
+    expect(host.updateProbe).toHaveBeenCalledWith(null, 100, 200);
+  });
+
+  it('does not pick or consume the pointer while the user is driving the camera', () => {
+    const probePickStatic = vi.fn(() => staticInfo);
+    const host = makeHost({
+      toolMode: () => 'probe',
+      pointerMoved: () => true,
+      userInteracting: () => true,
+      probePickStatic,
+    });
+    runRenderFrame(host);
+
+    expect(probePickStatic).not.toHaveBeenCalled();
+    expect(host.updateProbe).not.toHaveBeenCalled();
+    expect(host.clearPointerMoved).not.toHaveBeenCalled();
+  });
+});
+
+describe('runRenderFrame — overlay re-projection gating', () => {
+  it('re-projects the tool overlays on rendered frames', () => {
+    const host = makeHost({ shouldRenderFrame: () => true });
+    runRenderFrame(host);
+
+    expect(host.renderMeasureOverlay).toHaveBeenCalledTimes(1);
+    expect(host.renderInspectOverlay).toHaveBeenCalledTimes(1);
+    expect(host.renderAnnotateOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips overlay re-projection on idle frames', () => {
+    const host = makeHost({ shouldRenderFrame: () => false, edlEnabled: () => false });
+    runRenderFrame(host);
+
+    expect(host.renderMeasureOverlay).not.toHaveBeenCalled();
+    expect(host.renderInspectOverlay).not.toHaveBeenCalled();
+    expect(host.renderAnnotateOverlay).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Extracts `Viewer._startLoop`'s per-frame body (~107 lines) into `src/render/renderLoop.ts` as `runRenderFrame(host)`, reading the live scene through a structural `RenderLoopHost` of accessor/command functions. This is the last named `(planned)` decomposition target for `Viewer.ts` in the architecture map, following the same host seam as `exportAdapter.ts`, `colorLegend.ts` and `snapshot.ts`.

`Viewer` keeps a thin `_startLoop` that binds its own state to the host and owns the `requestAnimationFrame` scheduling (browser-only, e2e-covered). The two cross-frame state fields the loop touches (`_streamingFrame`, `_edlPaintedAtRest`) stay Viewer-owned and are reached through host mutators, because both have lifecycle beyond a single loop (e.g. `_streamingFrame` is reset on scan attach).

## Behaviour

Identical. Same frame scheduling, same rAF/tick semantics, same start/stop. Preserved orderings: schedule-first rAF, `shouldRenderFrame()` before the motion/DPR computation, streaming `pump → advance → tick-on-interval`, and the probe gate consuming the pointer-moved flag only after it passes. The static-first / streaming-fallback probe pick is folded into two host methods that each return `PointInfo | null`, which reproduces the original `if (staticHit) … else if (streamHit) …` branch exactly.

## Tests

`tests/renderLoop.test.ts` (20 cases) drives `runRenderFrame` with a fake host and pins the decisions that previously only e2e could reach: EDL-vs-direct-vs-skip paint path, the EDL snap-back on settle, the streaming tick cadence (`STREAMING_TICK_INTERVAL`), and measure/probe/overlay gating. The pure predicates it composes stay tested in `edlMotionGate` / `hoverPickGate`; the rAF scheduling stays on the e2e suite.

## Ratchet + docs

- `Viewer.ts` 6,458 → 6,419; monolith-size baseline banked.
- `KNOWN_LIMITATIONS_v0.6.3.md` and `docs/architecture/architecture-map.md` counts updated; `_startLoop` moved from the pending table into a "Done:" note (matching how the earlier extractions were recorded), and the map's extraction-row floor lowered 10 → 9 to match.

## Gates (from the worktree)

- `npm run typecheck` — 0 errors
- `npm run lint:monolith-size` — OK (Viewer.ts under baseline, banked)
- `npm run lint:release-truth` + `npm run lint:main-deferral` — OK
- `npx vitest run tests/renderLoop.test.ts` — 20 passed; touched + Viewer-referencing suites — 132 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)