### PR TITLE
Explicit height value type; datum-honest inspector Z label (P1 #6)

### DIFF
--- a/src/geo/height.ts
+++ b/src/geo/height.ts
@@ -1,0 +1,224 @@
+/**
+ * src/geo/height.ts
+ *
+ * An explicit vertical value type. The point of this module is to stop a height
+ * travelling through the pipeline as a bare number whose unit and datum are only
+ * implied by the field name it lands in. A horizontal conversion must not pass Z
+ * through and let a downstream field call it `altMetres`; a height carried here
+ * states what reference surface it is measured from, and admits `'unknown'` when
+ * the datum is undeclared rather than borrowing one.
+ *
+ * Pure and dependency-free: no DOM, no three.js, no proj4, no CRS types. It
+ * classifies a vertical datum into a coarse reference class and labels a height
+ * honestly. The reference classification deliberately mirrors the identity
+ * resolution in `model/layerCompatibility.ts` (EPSG-first, then a small explicit
+ * name map) so the two never disagree about what "NAVD88" is — but it lives here,
+ * one layer down, so the inspector, exporters and terrain tools can all reach a
+ * single honest answer instead of re-deriving the reference three ways.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The reference surface a height is measured from.
+ *
+ * `ellipsoidal` — height above the reference ellipsoid (GNSS / WGS 84 3D). NOT a
+ *                 sea-level elevation: it differs from one by the geoid
+ *                 separation, tens of metres in places.
+ * `orthometric` — height above a vertical datum's reference surface (approximately
+ *                 mean sea level): NAVD88, EGM2008/EGM96 geoid heights, ODN, etc.
+ * `depth` — a downward axis (e.g. MSL depth); positive values go below the
+ *           reference surface.
+ * `local` — the dataset's own local frame; not tied to a geodetic datum.
+ * `unknown` — no vertical datum is declared, so the reference is genuinely not
+ *             known. Never silently upgraded to orthometric or ellipsoidal.
+ */
+export type VerticalReference =
+  | 'ellipsoidal'
+  | 'orthometric'
+  | 'depth'
+  | 'local'
+  | 'unknown';
+
+/**
+ * A height as an explicit value + optional metres scale + reference.
+ *
+ * `value` is the magnitude in the source's own vertical unit — NOT assumed to be
+ * metres. `metresPerUnit` is the scale that converts `value` to metres when the
+ * source declared a vertical unit; `undefined` means the vertical scale is
+ * unknown, which is the honest state for a file that carried no vertical unit and
+ * must not be read as "metres". `reference` is the datum class above.
+ *
+ * The unit is carried as a metres-per-unit factor rather than a unit token to
+ * match how the CRS layer already represents a distinct vertical unit
+ * (`ResolvedCrs.verticalUnitToMetres`), so a height built from a CRS and the CRS
+ * itself can never diverge about the vertical scale.
+ */
+export interface HeightValue {
+  readonly value: number;
+  readonly metresPerUnit?: number;
+  readonly reference: VerticalReference;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Construction
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Build a {@link HeightValue}. `metresPerUnit` omitted ⇒ vertical scale unknown. */
+export function makeHeight(
+  value: number,
+  reference: VerticalReference,
+  metresPerUnit?: number,
+): HeightValue {
+  return metresPerUnit === undefined
+    ? { value, reference }
+    : { value, metresPerUnit, reference };
+}
+
+/**
+ * The height in metres, or `undefined` when the vertical scale is unknown.
+ *
+ * Honest by construction: a height whose source never declared a vertical unit
+ * has no metres value, and this returns `undefined` rather than treating the raw
+ * magnitude as metres. A non-finite scale is likewise `undefined`.
+ */
+export function heightInMetres(h: HeightValue): number | undefined {
+  if (h.metresPerUnit === undefined || !Number.isFinite(h.metresPerUnit)) return undefined;
+  return h.value * h.metresPerUnit;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reference classification
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Orthometric (height-above-datum) vertical CRS codes. */
+const ORTHOMETRIC_EPSG: ReadonlySet<number> = new Set([
+  5703, // NAVD88
+  5701, // ODN (Newlyn)
+  5714, // MSL height
+  3855, // EGM2008 geoid height
+  5773, // EGM96 geoid height
+  6647, // CGVD2013
+  5705, // Baltic 1977
+  5612, // EGM84 geoid height
+]);
+
+/** Depth (downward) vertical CRS codes. */
+const DEPTH_EPSG: ReadonlySet<number> = new Set([
+  5715, // MSL depth
+]);
+
+/**
+ * Ellipsoidal-height vertical CRS codes. Deliberately narrow, like the RFC-7946
+ * allow-list in `terrain/contour/geojsonContours.ts`: EPSG:4979 is WGS 84 3D
+ * (geographic lat/lon + ellipsoidal height). A guess in the permissive direction
+ * is what puts a height tens of metres out, so free-text "ellipsoid" is not
+ * accepted here.
+ */
+const ELLIPSOIDAL_EPSG: ReadonlySet<number> = new Set([
+  4979, // WGS 84 (3D) — ellipsoidal height
+]);
+
+/**
+ * Known vertical-datum names → EPSG. The same small, explicit map
+ * `model/layerCompatibility.ts` uses, so a datum that arrives as a catalog name
+ * ("NAVD88") and one that arrives as a code ("EPSG:5703") resolve to one identity.
+ */
+const NAME_TO_EPSG: Readonly<Record<string, number>> = {
+  navd88: 5703,
+  'odn (newlyn)': 5701,
+  'msl height': 5714,
+  'msl depth': 5715,
+  'egm2008 height': 3855,
+  'egm96 height': 5773,
+  cgvd2013: 6647,
+  'baltic 1977': 5705,
+  'egm84 height': 5612,
+};
+
+/** A declared vertical datum, however the source spelled it. */
+export interface VerticalDatumRef {
+  /** Vertical CRS EPSG code, when declared. Authoritative. */
+  readonly verticalEpsg?: number;
+  /** Vertical datum as a name ("NAVD88") or code string ("EPSG:5703"). */
+  readonly verticalDatum?: string;
+}
+
+/** Resolve a datum ref to its EPSG code, or `undefined` when none is recoverable. */
+function resolveVerticalEpsg(d: VerticalDatumRef): number | undefined {
+  if (d.verticalEpsg !== undefined && Number.isFinite(d.verticalEpsg) && d.verticalEpsg > 0) {
+    return d.verticalEpsg;
+  }
+  const raw = d.verticalDatum?.trim().toLowerCase();
+  if (!raw) return undefined;
+  const viaName = NAME_TO_EPSG[raw];
+  if (viaName !== undefined) return viaName;
+  const viaCode = /^epsg:(\d{4,6})$/.exec(raw) ?? /^(\d{4,6})$/.exec(raw);
+  if (viaCode) return Number(viaCode[1]);
+  return undefined;
+}
+
+/**
+ * Classify a declared vertical datum into its reference surface.
+ *
+ * EPSG-first, name second — the same precedence as the layer-compatibility key.
+ * A datum that is present but unrecognised (an EPSG code or free-text name not in
+ * the tables) resolves to `'unknown'`, NOT to a guessed orthometric height: the
+ * honest statement is that its reference is not known here. Never returns
+ * `'local'`, which is a property of the coordinate frame, not of a datum.
+ */
+export function verticalReferenceFromDatum(d: VerticalDatumRef): VerticalReference {
+  const code = resolveVerticalEpsg(d);
+  if (code === undefined) return 'unknown';
+  if (DEPTH_EPSG.has(code)) return 'depth';
+  if (ELLIPSOIDAL_EPSG.has(code)) return 'ellipsoidal';
+  if (ORTHOMETRIC_EPSG.has(code)) return 'orthometric';
+  return 'unknown';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Honest labelling
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A short label for a height with this reference, suitable as a readout row
+ * heading. The `unknown` case is the one that matters: it says the datum is
+ * unknown rather than printing "Elevation", which asserts a sea-level datum the
+ * source never carried.
+ */
+export function heightLabel(reference: VerticalReference): string {
+  switch (reference) {
+    case 'ellipsoidal':
+      return 'Ellipsoidal height';
+    case 'orthometric':
+      return 'Elevation';
+    case 'depth':
+      return 'Depth';
+    case 'local':
+      return 'Height (local frame)';
+    case 'unknown':
+      return 'Height (datum unknown)';
+  }
+}
+
+/**
+ * A one-line explanation of what a height with this reference is measured from,
+ * for a tooltip or a report line. Plain and factual: the unknown case states the
+ * consequence (not tied to a known reference) rather than implying one.
+ */
+export function heightReferenceNote(reference: VerticalReference): string {
+  switch (reference) {
+    case 'ellipsoidal':
+      return 'Height above the reference ellipsoid (GNSS / WGS 84). Not a sea-level elevation.';
+    case 'orthometric':
+      return 'Height above the vertical datum reference surface (approximately mean sea level).';
+    case 'depth':
+      return 'Depth below the vertical datum reference surface.';
+    case 'local':
+      return 'Height in the dataset local frame; not tied to a geodetic datum.';
+    case 'unknown':
+      return 'No vertical datum is declared, so this height is not tied to a known reference.';
+  }
+}

--- a/src/render/InspectTool.ts
+++ b/src/render/InspectTool.ts
@@ -28,7 +28,10 @@ import {
   pointInfoCopyText,
   splitPointCoords,
   worldCoordLabels,
+  pointHeight,
+  heightRowLabel,
 } from './pointInfo';
+import { heightReferenceNote } from '../geo/height';
 import type { ResolvedCrs } from '../geo/CoordinateTypes';
 import { latLonToUtm, utmLatitudeFailure, utmConverter } from '../geo/UtmConverter';
 import { buildPatchView } from './patchView';
@@ -418,7 +421,19 @@ export class InspectTool {
     // CRS-aware unit suffix so a lon/lat scan never reads "-122.4 m".
     rows.push(infoRow(worldLabels.x, `${split.world.x}${worldLabels.xUnit}`));
     rows.push(infoRow(worldLabels.y, `${split.world.y}${worldLabels.yUnit}`));
-    rows.push(infoRow(worldLabels.z, `${split.world.z}${worldLabels.zUnit}`));
+    // Z / height row. The label is datum-aware via an explicit HeightValue: a
+    // projected or geographic scan with no declared vertical datum reads
+    // "Height (datum unknown)" instead of "Elevation" (which would assert a
+    // sea-level datum the file never carried). The displayed value and unit
+    // suffix are unchanged — this only stops the label implying a reference.
+    const height = pointHeight(split.world.z, this._coordContext.crs);
+    rows.push(
+      infoRow(
+        heightRowLabel(this._coordContext.crs),
+        `${split.world.z}${worldLabels.zUnit}`,
+        heightReferenceNote(height.reference),
+      ),
+    );
 
     // Local group — only when an origin shift exists; otherwise local ==
     // world and a second identical group would be noise.

--- a/src/render/pointInfo.ts
+++ b/src/render/pointInfo.ts
@@ -9,6 +9,13 @@
 
 import type { ResolvedCrs } from '../geo/CoordinateTypes';
 import type { CrsLinearUnit } from '../io/crs';
+import {
+  type HeightValue,
+  type VerticalReference,
+  heightLabel,
+  makeHeight,
+  verticalReferenceFromDatum,
+} from '../geo/height';
 import { UNIT_FACTORS } from '../units/units';
 
 /**
@@ -121,6 +128,45 @@ export function worldCoordLabels(crs: ResolvedCrs | undefined): WorldCoordLabels
     yUnit: suffix,
     zUnit: verticalAxisSuffix(crs.verticalUnitToMetres, suffix),
   };
+}
+
+/**
+ * The vertical reference a picked point's height is measured from, per the
+ * resolved CRS. `local` and `unknown` scans have no georeferenced datum, so
+ * their heights are `'local'` / `'unknown'`; a projected or geographic scan
+ * takes the reference from its declared vertical datum (and is honestly
+ * `'unknown'` when none is declared — never upgraded to a datum it never had).
+ */
+export function pointVerticalReference(crs: ResolvedCrs | undefined): VerticalReference {
+  if (!crs || crs.kind === 'unknown') return 'unknown';
+  if (crs.kind === 'local') return 'local';
+  return verticalReferenceFromDatum({
+    verticalEpsg: crs.verticalEpsg,
+    verticalDatum: crs.verticalDatum,
+  });
+}
+
+/**
+ * A picked point's height (world Z) as an explicit {@link HeightValue}: the
+ * source-unit magnitude, the CRS's declared vertical scale (absent ⇒ unknown
+ * scale), and the reference from {@link pointVerticalReference}. Lets the
+ * inspector carry a typed height end to end instead of a bare "elevation" number.
+ */
+export function pointHeight(z: number, crs: ResolvedCrs | undefined): HeightValue {
+  return makeHeight(z, pointVerticalReference(crs), crs?.verticalUnitToMetres);
+}
+
+/**
+ * The inspector's Z-row label, honest about the vertical datum. A local or
+ * unknown-CRS scan keeps the neutral `'Z'` the World group already uses for its
+ * X / Y axes — no datum is implied there. A projected or geographic scan reads a
+ * reference-aware label, so an undeclared vertical datum shows "Height (datum
+ * unknown)" rather than "Elevation" (which asserts a sea-level datum the file
+ * never stated); a declared orthometric datum still reads "Elevation".
+ */
+export function heightRowLabel(crs: ResolvedCrs | undefined): string {
+  if (!crs || crs.kind === 'local' || crs.kind === 'unknown') return 'Z';
+  return heightLabel(pointVerticalReference(crs));
 }
 
 /**

--- a/tests/height.test.ts
+++ b/tests/height.test.ts
@@ -1,0 +1,139 @@
+/**
+ * tests/height.test.ts
+ *
+ * The explicit vertical value type: reference classification, honest labelling,
+ * and metres conversion. The central honesty claim is that an undeclared or
+ * unrecognised vertical datum classifies as `'unknown'` and labels as a datum-
+ * unknown height, never as a silently-assumed elevation.
+ */
+
+import { describe, expect, test } from 'vitest';
+import {
+  type HeightValue,
+  type VerticalReference,
+  heightInMetres,
+  heightLabel,
+  heightReferenceNote,
+  makeHeight,
+  verticalReferenceFromDatum,
+} from '../src/geo/height';
+
+describe('makeHeight / heightInMetres', () => {
+  test('omitting the scale leaves metresPerUnit undefined (unknown scale)', () => {
+    const h = makeHeight(123.4, 'orthometric');
+    expect(h).toEqual({ value: 123.4, reference: 'orthometric' });
+    expect(h.metresPerUnit).toBeUndefined();
+  });
+
+  test('a stated scale is carried and converts to metres', () => {
+    const feet = makeHeight(500, 'orthometric', 0.3048);
+    expect(feet.metresPerUnit).toBe(0.3048);
+    expect(heightInMetres(feet)).toBeCloseTo(152.4, 6);
+  });
+
+  test('a metre height converts to itself', () => {
+    expect(heightInMetres(makeHeight(42, 'ellipsoidal', 1))).toBe(42);
+  });
+
+  test('an unknown vertical scale has NO metres value — never treats the raw magnitude as metres', () => {
+    // The dishonest failure this guards: a foot height with no declared unit
+    // read straight through as "152 metres".
+    expect(heightInMetres(makeHeight(500, 'orthometric'))).toBeUndefined();
+  });
+
+  test('a non-finite scale yields no metres value', () => {
+    const bad: HeightValue = { value: 10, metresPerUnit: Number.NaN, reference: 'orthometric' };
+    expect(heightInMetres(bad)).toBeUndefined();
+  });
+});
+
+describe('verticalReferenceFromDatum', () => {
+  test('an undeclared datum is unknown — not upgraded to a reference', () => {
+    expect(verticalReferenceFromDatum({})).toBe('unknown');
+    expect(verticalReferenceFromDatum({ verticalDatum: '' })).toBe('unknown');
+    expect(verticalReferenceFromDatum({ verticalDatum: '   ' })).toBe('unknown');
+  });
+
+  test('orthometric height datums, by EPSG', () => {
+    for (const code of [5703, 5701, 5714, 3855, 5773, 6647, 5705, 5612]) {
+      expect(verticalReferenceFromDatum({ verticalEpsg: code })).toBe('orthometric');
+    }
+  });
+
+  test('depth axis is its own class, not orthometric', () => {
+    expect(verticalReferenceFromDatum({ verticalEpsg: 5715 })).toBe('depth');
+    expect(verticalReferenceFromDatum({ verticalDatum: 'MSL depth' })).toBe('depth');
+    // Height and depth are opposite axes — the height MSL code must not read as depth.
+    expect(verticalReferenceFromDatum({ verticalEpsg: 5714 })).toBe('orthometric');
+  });
+
+  test('WGS 84 3D is ellipsoidal, not a sea-level elevation', () => {
+    expect(verticalReferenceFromDatum({ verticalEpsg: 4979 })).toBe('ellipsoidal');
+    expect(verticalReferenceFromDatum({ verticalDatum: 'EPSG:4979' })).toBe('ellipsoidal');
+  });
+
+  test('names resolve the same as codes (catalog name vs EPSG string)', () => {
+    expect(verticalReferenceFromDatum({ verticalDatum: 'NAVD88' })).toBe('orthometric');
+    expect(verticalReferenceFromDatum({ verticalDatum: 'navd88' })).toBe('orthometric');
+    expect(verticalReferenceFromDatum({ verticalDatum: 'EPSG:5703' })).toBe('orthometric');
+    expect(verticalReferenceFromDatum({ verticalDatum: '5703' })).toBe('orthometric');
+    expect(verticalReferenceFromDatum({ verticalDatum: 'EGM2008 height' })).toBe('orthometric');
+  });
+
+  test('the authoritative EPSG wins over the name', () => {
+    expect(
+      verticalReferenceFromDatum({ verticalEpsg: 5715, verticalDatum: 'NAVD88' }),
+    ).toBe('depth');
+  });
+
+  test('a present but unrecognised datum is unknown — never a guessed orthometric', () => {
+    expect(verticalReferenceFromDatum({ verticalEpsg: 999999 })).toBe('unknown');
+    expect(verticalReferenceFromDatum({ verticalDatum: 'Some local benchmark' })).toBe('unknown');
+    // Free-text "ellipsoid" is deliberately NOT accepted as ellipsoidal.
+    expect(verticalReferenceFromDatum({ verticalDatum: 'WGS 84 (ellipsoid)' })).toBe('unknown');
+  });
+
+  test('placeholder / invalid codes are unknown, never a datum', () => {
+    expect(verticalReferenceFromDatum({ verticalEpsg: 0 })).toBe('unknown');
+    expect(verticalReferenceFromDatum({ verticalEpsg: -1 })).toBe('unknown');
+    expect(verticalReferenceFromDatum({ verticalEpsg: Number.NaN })).toBe('unknown');
+  });
+});
+
+describe('heightLabel', () => {
+  test('every reference has a label; unknown is honest about the missing datum', () => {
+    const labels: Record<VerticalReference, string> = {
+      ellipsoidal: heightLabel('ellipsoidal'),
+      orthometric: heightLabel('orthometric'),
+      depth: heightLabel('depth'),
+      local: heightLabel('local'),
+      unknown: heightLabel('unknown'),
+    };
+    expect(labels.ellipsoidal).toBe('Ellipsoidal height');
+    expect(labels.orthometric).toBe('Elevation');
+    expect(labels.depth).toBe('Depth');
+    expect(labels.local).toBe('Height (local frame)');
+    expect(labels.unknown).toBe('Height (datum unknown)');
+    // The unknown label must NOT read as a plain elevation — that is the whole point.
+    expect(labels.unknown).not.toBe('Elevation');
+    expect(labels.unknown.toLowerCase()).toContain('unknown');
+  });
+});
+
+describe('heightReferenceNote', () => {
+  test('the unknown note states the consequence rather than implying a datum', () => {
+    const note = heightReferenceNote('unknown');
+    expect(note.toLowerCase()).toContain('no vertical datum');
+    expect(note.toLowerCase()).toContain('not tied');
+  });
+
+  test('the ellipsoidal note warns it is not a sea-level elevation', () => {
+    expect(heightReferenceNote('ellipsoidal').toLowerCase()).toContain('not a sea-level');
+  });
+
+  test('every reference yields a non-empty note', () => {
+    for (const r of ['ellipsoidal', 'orthometric', 'depth', 'local', 'unknown'] as const) {
+      expect(heightReferenceNote(r).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/inspectorOrigin.test.ts
+++ b/tests/inspectorOrigin.test.ts
@@ -7,7 +7,14 @@
  * adding the origin a second time doubled every easting/northing and fed
  * the doubled values into the WGS-84 projection.
  */
-import { makePointInfo, splitPointCoords, worldCoordLabels } from '../src/render/pointInfo';
+import {
+  makePointInfo,
+  splitPointCoords,
+  worldCoordLabels,
+  pointVerticalReference,
+  pointHeight,
+  heightRowLabel,
+} from '../src/render/pointInfo';
 import type { RawPointInfo } from '../src/render/pointInfo';
 import type { ResolvedCrs } from '../src/geo/CoordinateTypes';
 
@@ -200,4 +207,65 @@ test('worldCoordLabels: an unrecognised vertical scale asserts NO suffix (never 
     userConfirmed: false,
   };
   expect(worldCoordLabels(oddVertical).zUnit).toBe('');
+});
+
+// ── Z-row datum honesty (the inspector's height label) ─────────────────────
+// The unit-suffix tests above pin what unit the Z value is shown in. These pin
+// what REFERENCE the label claims. The failure they guard: a georeferenced scan
+// with a KNOWN horizontal CRS but NO declared vertical datum printed
+// "Elevation", asserting a sea-level datum the file never carried. The label is
+// now built from an explicit HeightValue whose reference is honestly 'unknown'.
+
+/** A projected/geographic CRS carrying explicit vertical fields. */
+function crsWithVertical(kind: ResolvedCrs['kind'], vertical: Partial<ResolvedCrs>): ResolvedCrs {
+  return { ...crs(kind), ...vertical };
+}
+
+test('heightRowLabel: known horizontal CRS, NO vertical datum → "Height (datum unknown)", never "Elevation"', () => {
+  // The common, dangerous case: a UTM survey with no vertical CRS declared.
+  const projected = crs('projected', 'UTM zone 10N');
+  expect(projected.verticalDatum).toBeUndefined();
+  expect(heightRowLabel(projected)).toBe('Height (datum unknown)');
+  expect(heightRowLabel(projected)).not.toBe('Elevation');
+  // A geographic scan with no vertical datum is equally undeclared.
+  expect(heightRowLabel(crs('geographic', 'WGS 84'))).toBe('Height (datum unknown)');
+});
+
+test('heightRowLabel: a declared orthometric datum still reads "Elevation"', () => {
+  expect(heightRowLabel(crsWithVertical('projected', { verticalEpsg: 5703 }))).toBe('Elevation');
+  expect(heightRowLabel(crsWithVertical('projected', { verticalDatum: 'NAVD88' }))).toBe(
+    'Elevation',
+  );
+});
+
+test('heightRowLabel: an ellipsoidal (WGS 84 3D) height is labelled as such, not "Elevation"', () => {
+  const label = heightRowLabel(crsWithVertical('geographic', { verticalEpsg: 4979 }));
+  expect(label).toBe('Ellipsoidal height');
+});
+
+test('heightRowLabel: local / unknown / undefined scans keep the neutral "Z"', () => {
+  for (const c of [undefined, crs('local'), crs('unknown')]) {
+    expect(heightRowLabel(c)).toBe('Z');
+  }
+});
+
+test('pointVerticalReference maps CRS kind + datum to an honest reference', () => {
+  expect(pointVerticalReference(undefined)).toBe('unknown');
+  expect(pointVerticalReference(crs('unknown'))).toBe('unknown');
+  expect(pointVerticalReference(crs('local'))).toBe('local');
+  // Known horizontal CRS, undeclared vertical datum → unknown, not a guess.
+  expect(pointVerticalReference(crs('projected'))).toBe('unknown');
+  expect(pointVerticalReference(crsWithVertical('projected', { verticalEpsg: 5703 }))).toBe(
+    'orthometric',
+  );
+});
+
+test('pointHeight carries the world Z with its reference and the CRS vertical scale', () => {
+  const footZ = crsWithVertical('projected', { verticalEpsg: 5703, verticalUnitToMetres: 0.3048 });
+  const h = pointHeight(500, footZ);
+  expect(h.value).toBe(500);
+  expect(h.reference).toBe('orthometric');
+  expect(h.metresPerUnit).toBe(0.3048);
+  // No vertical datum declared → the height is honestly datum-unknown.
+  expect(pointHeight(500, crs('projected')).reference).toBe('unknown');
 });


### PR DESCRIPTION
## What

First increment of coordinate-integrity roadmap **P1 #6** (separate vertical from horizontal): introduce an explicit height value type and thread it through one clean consumer path.

### New foundation — `src/geo/height.ts` (pure, dependency-free)
- `VerticalReference = 'ellipsoidal' | 'orthometric' | 'depth' | 'local' | 'unknown'`
- `HeightValue { value; metresPerUnit?; reference }` — magnitude in source units, optional metres scale, explicit reference. The unit is carried as a metres-per-unit factor to match `ResolvedCrs.verticalUnitToMetres`, so a height and the CRS it came from cannot diverge about the vertical scale.
- Helpers: `makeHeight`, `heightInMetres` (honest `undefined` when scale unknown), `verticalReferenceFromDatum` (EPSG-first, small name map — the same identity resolution as `model/layerCompatibility`), `heightLabel`, `heightReferenceNote`.
- An undeclared or unrecognised datum classifies as `'unknown'`, never a guessed orthometric/ellipsoidal.

### Converted consumer — the point-inspection height readout
- `pointInfo` gains pure `pointVerticalReference` / `pointHeight` / `heightRowLabel`.
- `InspectTool` builds a `HeightValue` for the picked point Z and labels the row from its reference.
- Behaviour change: a projected/geographic scan with **no declared vertical datum** now reads **"Height (datum unknown)"** instead of "Elevation" (which asserted a sea-level datum the file never carried). A declared orthometric datum still reads "Elevation"; WGS 84 3D reads "Ellipsoidal height". Local / unknown-CRS scans keep the neutral "Z". Displayed value and unit suffix are unchanged.

## Tests
- `tests/height.test.ts` — new, full coverage of the type + classifier + labels.
- `tests/inspectorOrigin.test.ts` — added consumer cases proving an unknown-datum height is labelled honestly rather than implying a datum. No existing test weakened; `worldCoordLabels` is untouched.

## Gates (from the worktree)
- `npm run typecheck` — 0 errors
- Full unit bucket + UI bucket — green (GATE EXIT 0)
- `lint:monolith-size` — OK (main.ts/Viewer.ts untouched)
- `lint:layer-boundaries` — OK (`height.ts` imports nothing)

## Threading plan for the remaining height paths (next increments)
The following still pass heights as bare numbers with unit/reference only implied:
1. **Point-info clipboard / JSON** (`pointInfoCopyText` / `pointInfoJson` in `pointInfo.ts`) — Z is a bare `z` field. Byte-compatibility-sensitive; add reference as an additive field.
2. **Export fields** — `export/types.ts`, `export/measurementExport.ts`, KML (`kmlExport.ts` already has its own orthometric allow-list to fold into `verticalReferenceFromDatum`), GeoJSON (`geojsonContours.isWgs84EllipsoidalHeight`), HeightMap/DepthMap exporters.
3. **Measure Z** — `render/measure/*` elevation/height deltas and profile Z (`civilProfileStats`, `profileSummary`, `MeasureController`).
4. **Terrain elevation** — DTM/DSM/CHM elevation ranges and contour levels (`terrain/**`, `projectElevationRange.ts`); CHM is height-above-ground (`'local'`-adjacent) and already carries no absolute vertical CRS.
5. **Consolidation** — migrate the three existing ad-hoc classifiers (`layerCompatibility.verticalReferenceKey`, `geojsonContours.isWgs84EllipsoidalHeight`, `kmlExport.ORTHOMETRIC_METRIC_VERTICAL`) onto `verticalReferenceFromDatum` so reference is derived one way.

Please do **not** auto-merge.