### PR TITLE
Extract importSession into src/app/sessionIo.ts

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.3.md
+++ b/KNOWN_LIMITATIONS_v0.6.3.md
@@ -6,7 +6,7 @@ Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 6,976 lines and `src/render/Viewer.ts` is 6,458, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 6,790 lines and `src/render/Viewer.ts` is 6,458, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 6,976 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 6,790 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -98,7 +98,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (6,976)** — the largest blocks, which are the extraction
+**`src/main.ts` (6,790)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,
@@ -112,7 +112,12 @@ called with a 19-member deps object. The candidates that remain:
 | `applyScanRoute` | 233 | joins `ScanRouteService` |
 | `handleRemoteEpt` / `openStreamingCopc` | 406 | `src/app/openStreaming.ts` *(planned)* |
 | `generateReportPdf` / `exportGeoContext` | 402 | export/report wiring module |
-| `importSession` | 177 | `src/app/sessionIo.ts` *(planned)* |
+
+Done: `importSession` (~208 lines) now lives in `src/app/sessionIo.ts`, called with a
+`SessionIoDeps` object of ~16 accessors the shell binds to its own state. The pure
+cloud→fingerprint adapter (`scanFactsFromStreaming` / `scanFactsFromStatic`) is
+exported and Node-tested, and the parse/verify/rebase halves it leans on already
+lived in `src/io/session.ts`; `main.ts` keeps a thin caller (`tests/sessionIo.test.ts`).
 
 **`src/render/Viewer.ts` (6,458)** — the constructor and a handful of large
 methods dominate:

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 6976,
+      "lines": 6790,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/app/sessionIo.ts
+++ b/src/app/sessionIo.ts
@@ -1,0 +1,348 @@
+/**
+ * sessionIo.ts — the session-restore orchestration lifted out of main.ts.
+ *
+ * `importSession` reads a saved `.olvsession`, verifies its stored scan
+ * fingerprint against the loaded cloud, rebases its geometry into that cloud's
+ * frame and applies the restored measurements / annotations / views / CRS /
+ * camera. The pure halves it leans on already live in `../io/session`
+ * (`parseSession`, `rebaseSessionGeometry`, `matchSessionToScan`) and are unit
+ * tested there; what remained inline in main.ts was the imperative apply step
+ * plus one pure adapter — turning the live loaded cloud into the `ScanFacts`
+ * fingerprint the matcher compares against. That adapter is extracted here as
+ * `scanFactsFromStreaming` / `scanFactsFromStatic` so it is Node-testable
+ * without a Viewer, and the apply step is parameterised through
+ * {@link SessionIoDeps} so the whole restore drives from plain fakes.
+ *
+ * main.ts keeps a thin caller that binds its own running state to the deps.
+ * Part of the v0.6 decomposition (see `docs/architecture/architecture-map.md`).
+ */
+
+import type { Viewer } from '../render/Viewer';
+import type { PointCloud } from '../model/PointCloud';
+import type { ViewBookmarksService } from './viewBookmarks';
+import type { CrsService } from '../geo/CrsService';
+import type { ViewStateBundle } from '../io/viewState';
+import { buildViewState } from '../io/viewState';
+import { isExportStale, staleExportReason } from '../export/exportStaleness';
+import { summarizeMeasurementTrust } from '../render/measure/measurementTrust';
+import type {
+  InspectionSession,
+  RebasedSessionGeometry,
+  ScanFacts,
+  ScanMatch,
+  SessionScanSummary,
+} from '../io/session';
+
+/** The streaming-source slice `scanFactsFromStreaming` reads — a structural subset of {@link StreamingSource}. */
+export interface StreamingScanSource {
+  readonly name: string;
+  readonly sourcePointCount: number;
+  dataBounds(): readonly [number, number, number, number, number, number];
+  crs(): { readonly name?: string; readonly epsg?: number } | null | undefined;
+}
+
+/** The static-cloud slice `scanFactsFromStatic` reads — a structural subset of {@link PointCloud}. */
+export interface StaticScanCloud {
+  readonly name: string;
+  readonly pointCount: number;
+  bounds(): {
+    readonly min: readonly [number, number, number];
+    readonly max: readonly [number, number, number];
+  };
+  readonly metadata?: {
+    readonly crs?: { readonly name?: string; readonly epsg?: number } | null;
+  };
+}
+
+/**
+ * Build the loaded-scan fingerprint from a streaming source — the input the
+ * matcher compares a session's stored summary against. Pure: reads the source's
+ * extent spans, point count, name and CRS, no DOM or render state. Extents come
+ * from `dataBounds()` (the true data extent, not the footprint span).
+ */
+export function scanFactsFromStreaming(cloud: StreamingScanSource): ScanFacts {
+  const b = cloud.dataBounds();
+  const crs = cloud.crs();
+  return {
+    fileName: cloud.name,
+    sourcePoints: cloud.sourcePointCount,
+    width: b[3] - b[0],
+    depth: b[4] - b[1],
+    height: b[5] - b[2],
+    crs: crs?.name,
+    epsg: crs?.epsg,
+  };
+}
+
+/**
+ * Build the loaded-scan fingerprint from a static cloud. Pure counterpart to
+ * {@link scanFactsFromStreaming}: extent spans from `bounds()`, point count and
+ * CRS from the cloud's own header metadata.
+ */
+export function scanFactsFromStatic(cloud: StaticScanCloud): ScanFacts {
+  const b = cloud.bounds();
+  return {
+    fileName: cloud.name,
+    sourcePoints: cloud.pointCount,
+    width: b.max[0] - b.min[0],
+    depth: b.max[1] - b.min[1],
+    height: b.max[2] - b.min[2],
+    crs: cloud.metadata?.crs?.name,
+    epsg: cloud.metadata?.crs?.epsg,
+  };
+}
+
+/** The three pure session functions `importSession` resolves lazily (from `../io/session`). */
+export interface SessionModule {
+  parseSession: (text: string) => InspectionSession;
+  rebaseSessionGeometry: (
+    session: InspectionSession,
+    cloudOrigin: readonly [number, number, number],
+  ) => RebasedSessionGeometry;
+  matchSessionToScan: (summary: SessionScanSummary | undefined, loaded: ScanFacts) => ScanMatch;
+}
+
+/**
+ * The running-app seam `importSession` writes through. Accessors are functions,
+ * not snapshots, so a mid-import scan swap is seen (the restore re-reads the
+ * viewer and active scan after every `await`, exactly as the inline version did
+ * against the module-level `let`s).
+ */
+export interface SessionIoDeps {
+  /** Resolves once the lazily-loaded Viewer chunk is in place — awaited before any `getViewer()`. */
+  readonly viewerReady: Promise<unknown>;
+  /** The live Viewer (a late-bound `let` in the shell). */
+  getViewer: () => Viewer;
+  /** The dynamic import of the pure session functions (`loadSession` in the shell). */
+  loadSession: () => Promise<SessionModule>;
+  /** The producing build's version string, for the stale-export disclosure (`__APP_VERSION__`). */
+  readonly appVersion: string;
+  /** The active scan id, or null when none is loaded. */
+  getActiveScanId: () => string | null;
+  /** The active static cloud, or null (streaming / no scan). */
+  getActiveCloud: () => PointCloud | null;
+  /** The source-frame origin the session's geometry is rebased against (`exportGeoContext().origin`). */
+  exportOrigin: () => readonly [number, number, number];
+  /** Saved-view store: `restore` replaces the list, `names` feeds the Inspector. */
+  bookmarks: Pick<ViewBookmarksService, 'restore' | 'names'>;
+  /** Push the restored view names into the Inspector panel. */
+  setInspectorViews: (names: string[]) => void;
+  /** Re-render the measurements panel from the viewer's store. */
+  refreshMeasurePanel: () => void;
+  /** Re-render the annotations panel from the viewer's store. */
+  refreshAnnotationPanel: () => void;
+  /** Apply a global view-state bundle through the shared, camera-last path. */
+  applyViewState: (vs: ViewStateBundle) => void;
+  /** Restore the author's CRS override (`crsService.setOverride`). */
+  setCrsOverride: (args: Parameters<CrsService['setOverride']>[0]) => void;
+  /** Fire a toast, optionally with one action button. */
+  showToast: (
+    message: string,
+    action?: { readonly label: string; readonly onClick: () => void },
+  ) => void;
+  /** Surface a fatal import error on the drop zone. */
+  setDropError: (message: string) => void;
+}
+
+/**
+ * Import an inspection session: restore measurements, annotations and views.
+ * `skipScanConfirm` is set only by the "Apply anyway" action after a partial
+ * scan-identity match, so the same restore re-runs past the confirmation gate.
+ */
+export async function importSession(
+  file: File,
+  opts: { skipScanConfirm?: boolean },
+  deps: SessionIoDeps,
+): Promise<void> {
+  try {
+    // The session path's imports are light (no three.js), so a session restore
+    // can finish before the lazily-imported Viewer chunk resolves — leaving
+    // `viewer` as its null sentinel. Await viewerReady so every `viewer.*`
+    // access below is safe (measure/annotate are built in the Viewer ctor, so
+    // no GPU backend is needed — just a non-null instance).
+    await deps.viewerReady;
+    const viewer = deps.getViewer();
+    const { parseSession, rebaseSessionGeometry, matchSessionToScan } = await deps.loadSession();
+    const session = parseSession(await file.text());
+    // If an older build wrote this session, a newer one may grade or label the
+    // scan differently — surface that so the user can re-save. Absent stamp
+    // (pre-v6 file) reads as "an earlier version".
+    if (isExportStale(session.software, deps.appVersion)) {
+      const note = staleExportReason(session.software, deps.appVersion);
+      if (note) deps.showToast(note);
+    }
+    // Session vertices are LOCAL to the origin of the scan they were captured
+    // against. Imported onto a DIFFERENT loaded cloud (a different floored
+    // origin), they must be rebased into that cloud's frame or they land
+    // displaced by the two origins' difference — and a later export would
+    // compound the error by adding the new origin. With no cloud loaded there
+    // is nothing to rebase against; keep the verbatim geometry (the missing-
+    // scan toast below already tells the user to drop the scan).
+    const haveCloud = viewer.clouds().length > 0 || viewer.hasStreamingCloud;
+    // Capture the scan this import matches against, re-checked before we attach
+    // state. A session restore routes ahead of the loading guard, so a scan
+    // swapped in mid-import must not inherit another scan's measurements.
+    const targetId = deps.getActiveScanId();
+    const targetStreamingCloud = viewer.streamingCloud;
+    const targetStaticCloud = targetId ? viewer.getCloud(targetId) : undefined;
+    // Guard the rebase: a session's geometry is local to the scan it was
+    // captured over, so realigning it onto the loaded cloud is only correct when
+    // that IS its scan. Compare the session's stored fingerprint (built the same
+    // way exportSession writes it) against the loaded scan. A clear conflict is
+    // refused rather than silently realigned onto the wrong scan; a partial
+    // match asks the user to confirm before anything is applied.
+    if (haveCloud) {
+      const streamingCloud = viewer.streamingCloud;
+      const staticCloud = deps.getActiveCloud() ?? undefined;
+      let loadedFacts: ScanFacts | undefined;
+      if (streamingCloud) {
+        loadedFacts = scanFactsFromStreaming(streamingCloud);
+      } else if (staticCloud) {
+        loadedFacts = scanFactsFromStatic(staticCloud);
+      }
+      if (loadedFacts) {
+        const match = matchSessionToScan(session.scanSummary, loadedFacts);
+        if (match.verdict === 'conflict') {
+          const why = match.reasons[0] ?? 'its scan fingerprint does not match';
+          const want = session.scanSummary?.fileName;
+          deps.showToast(
+            `This session was captured over a different scan (${why}) — it was not applied. ` +
+              (want ? `Load “${want}” to restore it on its own scan.` : 'Load its source scan to restore it.'),
+          );
+          return;
+        }
+        if (match.verdict === 'partial' && !opts.skipScanConfirm) {
+          // Not a clear conflict, but not a confirmed match — don't touch the
+          // scene until the user opts in. "Apply anyway" re-imports with the
+          // check skipped, so the same restore proceeds on their confirmation.
+          const why = match.reasons[0] ?? '';
+          deps.showToast(
+            `This session's scan couldn't be fully verified${why ? ` (${why})` : ''}. ` +
+              'Applying it may place its measurements on the wrong scan.',
+            { label: 'Apply anyway', onClick: () => void importSession(file, { skipScanConfirm: true }, deps) },
+          );
+          return;
+        }
+      }
+    }
+    const geo = haveCloud
+      ? rebaseSessionGeometry(session, deps.exportOrigin())
+      : {
+          measurements: session.measurements,
+          annotations: session.annotations,
+          views: session.views,
+          camera: session.camera,
+          clip: session.clip,
+          delta: [0, 0, 0] as const,
+        };
+    const rebased = geo.delta[0] !== 0 || geo.delta[1] !== 0 || geo.delta[2] !== 0;
+    // The scan could have been swapped in under us since we matched (this import
+    // routes ahead of the loading guard). Refuse to attach the session's state
+    // to a scan it was never matched against. (mirrors the 1723/1808 guard.)
+    if (
+      haveCloud &&
+      (deps.getActiveScanId() !== targetId ||
+        viewer.streamingCloud !== targetStreamingCloud ||
+        (targetId ? viewer.getCloud(targetId) : undefined) !== targetStaticCloud)
+    ) {
+      deps.showToast('Session not applied — the active scan changed while it was importing.');
+      return;
+    }
+    viewer.measure.loadMeasurements(geo.measurements);
+    viewer.annotate.loadAnnotations(geo.annotations);
+    // v7 — a view may carry a display bundle beyond its camera; hydrate it
+    // into the in-memory shape so restoring by name reapplies the lot. A
+    // v6 file's views have no bundle fields, so `buildViewState` returns
+    // undefined and they stay exactly the camera-only bookmarks they were.
+    deps.bookmarks.restore(
+      geo.views.map((v) => {
+        const { name, camera, ...state } = v;
+        return { name, pose: camera, state: buildViewState(state) };
+      }),
+    );
+    deps.setInspectorViews(deps.bookmarks.names());
+    deps.refreshMeasurePanel();
+    deps.refreshAnnotationPanel();
+
+    // Apply the optional GLOBAL state when present — through the SAME
+    // applyViewState path a named view restore uses (the extraction that
+    // replaced the old inline field-by-field block here). Each field is
+    // independently guarded so a partial file (e.g. a camera but no render
+    // settings) restores what's there without assuming the rest, and the
+    // camera is applied LAST so nothing re-frames after it. A v1 / v2 file
+    // has none of these — fall through to the existing behaviour.
+    deps.applyViewState({
+      render: session.render,
+      colorMode: session.colorMode,
+      classFilter: session.classFilter,
+      pointFilters: session.pointFilters,
+      clip: geo.clip,
+      camera: geo.camera,
+    });
+    if (
+      session.crs &&
+      session.crs.epsg != null &&
+      (session.crs.kind === 'projected' || session.crs.kind === 'geographic' || session.crs.kind === 'local')
+    ) {
+      // Restore the author's CRS override so a capsule round-trips without
+      // re-prompting — but NEVER over a scan that declares a DIFFERENT code.
+      // The scan-identity match already conflicts on differing codes; this
+      // guard covers the remaining hole, a scan whose declaration exists but
+      // was absent from the session summary. A file that states its own CRS is
+      // stronger evidence than a session written who-knows-where, so the
+      // declaration wins and the session's choice is dropped with a note.
+      const declared =
+        viewer.streamingCloud?.crs()?.epsg ??
+        (deps.getActiveScanId() ? viewer.getCloud(deps.getActiveScanId()!)?.metadata?.crs?.epsg : undefined);
+      if (declared != null && declared !== session.crs.epsg) {
+        deps.showToast(
+          `The session's CRS (EPSG:${session.crs.epsg}) was not applied — this scan declares EPSG:${declared}, and a file's own declaration wins.`,
+        );
+      } else {
+        deps.setCrsOverride({
+          override: { epsg: session.crs.epsg, kind: session.crs.kind },
+          detected: deps.getActiveScanId()
+            ? viewer.getCloud(deps.getActiveScanId()!)?.metadata?.crs ?? undefined
+            : undefined,
+          source: 'user-override',
+        });
+      }
+    }
+
+    // Honest disclosure: the session carries the saved analysis, not the scan
+    // itself (a point cloud can't travel in the file). If its scan isn't
+    // loaded, the restored measurements/annotations have nothing to sit on —
+    // say so and point the user at the file to drop, rather than restoring onto
+    // an empty scene silently.
+    const restored =
+      session.measurements.length + session.annotations.length + session.views.length;
+    const wantFile = session.scanSummary?.fileName;
+    // When the user reached here via "Apply anyway", record that the restore
+    // proceeded on an unverified scan match rather than a confirmed one.
+    const appliedNote = opts.skipScanConfirm ? ' Applied despite an unverified scan match.' : '';
+    // Disclosure when the session was captured in a different scan's frame and
+    // its geometry was shifted to line up with the loaded cloud — an honest
+    // note that a non-obvious transform happened, not a silent relocation.
+    const frameNote = rebased
+      ? ' Its measurements were realigned to the loaded scan’s origin.'
+      : '';
+    // Evidence Capsule: lead with the honesty roll-up when the shared session
+    // carries graded measurements — the recipient sees the trust picture, not
+    // just a count.
+    const evidence = summarizeMeasurementTrust(session.measurements.map((m) => m.trust));
+    const lead = evidence.total > 0 ? `Evidence restored — ${evidence.line}.` : null;
+    if (wantFile && !haveCloud) {
+      deps.showToast(lead ?? `Session restored — drop “${wantFile}” to view its scan.`,
+        lead ? { label: 'Need the scan', onClick: () => deps.showToast(`Drop “${wantFile}” to view this evidence on its scan.`) } : undefined);
+    } else if (lead) {
+      deps.showToast(`${lead}${frameNote}${appliedNote}`);
+    } else {
+      deps.showToast(
+        `Session restored — ${restored} item${restored === 1 ? '' : 's'} ` +
+          `(measurements, annotations, views).${frameNote}${appliedNote}`,
+      );
+    }
+  } catch (err) {
+    deps.setDropError(err instanceof Error ? err.message : 'Could not import the session');
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import { bootTour, type TourHandle } from './ui/onboarding/bootTour';
 import { buildMeasureConfidenceContext } from './app/measureConfidenceContext';
 import { findDuplicateIds } from './ui/actionRegistry';
 import { buildActionRegistry } from './app/actionDefinitions';
+import { importSession as runImportSession, type SessionIoDeps } from './app/sessionIo';
 import { WorkflowController, WORKFLOW_RECORDER_ENABLED } from './ui/WorkflowController';
 import type { WorkflowConfigPanel } from './ui/WorkflowConfigPanel';
 import { RecommendedViewChip } from './ui/RecommendedViewChip';
@@ -57,7 +58,6 @@ import {
 import { noteEdit, pickUndo, pickRedo, withSuppressed } from './ui/undoRouter';
 import { MeasurePanel } from './ui/MeasurePanel';
 import { aggregate as aggregateMeasurements } from './render/measure/measurementChains';
-import { summarizeMeasurementTrust } from './render/measure/measurementTrust';
 import { ICON_LASSO } from './render/measure/measureIcons';
 // Workflow presets (v0.4.5) — pure table + matcher; applied through the
 // Viewer's existing setters in the Inspector callback below.
@@ -109,7 +109,6 @@ import type { ClipBox } from './render/clip/clipBox';
 // Two-epoch change detection is loaded on demand (it pulls the terrain
 // ground-filter + rasteriser): see compareLoadedLayers' dynamic import.
 import { composeClassScopeBannerOntoBlob } from './export/ScanReportRenderer';
-import { isExportStale, staleExportReason } from './export/exportStaleness';
 import { footprintMetres } from './report/reportFootprint';
 import { planInstantAnswer } from './intelligence/instantAnswer';
 import { decodeFull } from './convert/decodeFull';
@@ -5270,217 +5269,32 @@ async function exportSession(): Promise<void> {
 }
 
 /**
- * Import an inspection session: restore measurements, annotations and views.
- * `skipScanConfirm` is set only by the "Apply anyway" action after a partial
- * scan-identity match, so the same restore re-runs past the confirmation gate.
+ * Session import — a thin caller over the extracted `src/app/sessionIo.ts`.
+ * Binds the shell's running state to the module's deps; the parse / verify /
+ * rebase / apply logic and the pure `ScanFacts` adapter live in that module.
  */
-async function importSession(file: File, opts: { skipScanConfirm?: boolean } = {}): Promise<void> {
-  try {
-    // The session path's imports are light (no three.js), so a session restore
-    // can finish before the lazily-imported Viewer chunk resolves — leaving
-    // `viewer` as its null sentinel. Await viewerLoaded so every `viewer.*`
-    // access below is safe (measure/annotate are built in the Viewer ctor, so
-    // no GPU backend is needed — just a non-null instance).
-    await viewerLoaded;
-    const { parseSession, rebaseSessionGeometry, matchSessionToScan } = await loadSession();
-    const session = parseSession(await file.text());
-    // If an older build wrote this session, a newer one may grade or label the
-    // scan differently — surface that so the user can re-save. Absent stamp
-    // (pre-v6 file) reads as "an earlier version".
-    if (isExportStale(session.software, __APP_VERSION__)) {
-      const note = staleExportReason(session.software, __APP_VERSION__);
-      if (note) showLassoToast(note);
-    }
-    // Session vertices are LOCAL to the origin of the scan they were captured
-    // against. Imported onto a DIFFERENT loaded cloud (a different floored
-    // origin), they must be rebased into that cloud's frame or they land
-    // displaced by the two origins' difference — and a later export would
-    // compound the error by adding the new origin. With no cloud loaded there
-    // is nothing to rebase against; keep the verbatim geometry (the missing-
-    // scan toast below already tells the user to drop the scan).
-    const haveCloud = viewer.clouds().length > 0 || viewer.hasStreamingCloud;
-    // Capture the scan this import matches against, re-checked before we attach
-    // state. A session restore routes ahead of the loading guard, so a scan
-    // swapped in mid-import must not inherit another scan's measurements.
-    const targetId = scans.activeId;
-    const targetStreamingCloud = viewer.streamingCloud;
-    const targetStaticCloud = targetId ? viewer.getCloud(targetId) : undefined;
-    // Guard the rebase: a session's geometry is local to the scan it was
-    // captured over, so realigning it onto the loaded cloud is only correct when
-    // that IS its scan. Compare the session's stored fingerprint (built the same
-    // way exportSession writes it) against the loaded scan. A clear conflict is
-    // refused rather than silently realigned onto the wrong scan; a partial
-    // match asks the user to confirm before anything is applied.
-    if (haveCloud) {
-      const streamingCloud = viewer.streamingCloud;
-      const staticCloud = scans.activeCloud() ?? undefined;
-      let loadedFacts: import('./io/session').ScanFacts | undefined;
-      if (streamingCloud) {
-        const b = streamingCloud.dataBounds();
-        loadedFacts = {
-          fileName: streamingCloud.name,
-          sourcePoints: streamingCloud.sourcePointCount,
-          width: b[3] - b[0],
-          depth: b[4] - b[1],
-          height: b[5] - b[2],
-          crs: streamingCloud.crs()?.name,
-          epsg: streamingCloud.crs()?.epsg,
-        };
-      } else if (staticCloud) {
-        const b = staticCloud.bounds();
-        loadedFacts = {
-          fileName: staticCloud.name,
-          sourcePoints: staticCloud.pointCount,
-          width: b.max[0] - b.min[0],
-          depth: b.max[1] - b.min[1],
-          height: b.max[2] - b.min[2],
-          crs: staticCloud.metadata?.crs?.name,
-          epsg: staticCloud.metadata?.crs?.epsg,
-        };
-      }
-      if (loadedFacts) {
-        const match = matchSessionToScan(session.scanSummary, loadedFacts);
-        if (match.verdict === 'conflict') {
-          const why = match.reasons[0] ?? 'its scan fingerprint does not match';
-          const want = session.scanSummary?.fileName;
-          showLassoToast(
-            `This session was captured over a different scan (${why}) — it was not applied. ` +
-              (want ? `Load “${want}” to restore it on its own scan.` : 'Load its source scan to restore it.'),
-          );
-          return;
-        }
-        if (match.verdict === 'partial' && !opts.skipScanConfirm) {
-          // Not a clear conflict, but not a confirmed match — don't touch the
-          // scene until the user opts in. "Apply anyway" re-imports with the
-          // check skipped, so the same restore proceeds on their confirmation.
-          const why = match.reasons[0] ?? '';
-          showLassoToast(
-            `This session's scan couldn't be fully verified${why ? ` (${why})` : ''}. ` +
-              'Applying it may place its measurements on the wrong scan.',
-            { label: 'Apply anyway', onClick: () => void importSession(file, { skipScanConfirm: true }) },
-          );
-          return;
-        }
-      }
-    }
-    const geo = haveCloud
-      ? rebaseSessionGeometry(session, exportGeoContext().origin)
-      : {
-          measurements: session.measurements,
-          annotations: session.annotations,
-          views: session.views,
-          camera: session.camera,
-          clip: session.clip,
-          delta: [0, 0, 0] as const,
-        };
-    const rebased = geo.delta[0] !== 0 || geo.delta[1] !== 0 || geo.delta[2] !== 0;
-    // The scan could have been swapped in under us since we matched (this import
-    // routes ahead of the loading guard). Refuse to attach the session's state
-    // to a scan it was never matched against. (mirrors the 1723/1808 guard.)
-    if (
-      haveCloud &&
-      (scans.activeId !== targetId ||
-        viewer.streamingCloud !== targetStreamingCloud ||
-        (targetId ? viewer.getCloud(targetId) : undefined) !== targetStaticCloud)
-    ) {
-      showLassoToast('Session not applied — the active scan changed while it was importing.');
-      return;
-    }
-    viewer.measure.loadMeasurements(geo.measurements);
-    viewer.annotate.loadAnnotations(geo.annotations);
-    // v7 — a view may carry a display bundle beyond its camera; hydrate it
-    // into the in-memory shape so restoring by name reapplies the lot. A
-    // v6 file's views have no bundle fields, so `buildViewState` returns
-    // undefined and they stay exactly the camera-only bookmarks they were.
-    bookmarks.restore(
-      geo.views.map((v) => {
-        const { name, camera, ...state } = v;
-        return { name, pose: camera, state: buildViewState(state) };
-      }),
-    );
-    inspector.setViews(bookmarks.names());
-    refreshMeasurePanel();
-    refreshAnnotationPanel();
+const sessionIoDeps: SessionIoDeps = {
+  viewerReady: viewerLoaded,
+  getViewer: () => viewer,
+  loadSession,
+  appVersion: __APP_VERSION__,
+  getActiveScanId: () => scans.activeId,
+  getActiveCloud: () => scans.activeCloud(),
+  exportOrigin: () => exportGeoContext().origin,
+  bookmarks,
+  setInspectorViews: (names) => inspector.setViews(names),
+  refreshMeasurePanel,
+  refreshAnnotationPanel,
+  applyViewState,
+  setCrsOverride: (args) => {
+    crsService.setOverride(args);
+  },
+  showToast: showLassoToast,
+  setDropError: (message) => dropZone.setError(message),
+};
 
-    // Apply the optional GLOBAL state when present — through the SAME
-    // applyViewState path a named view restore uses (the extraction that
-    // replaced the old inline field-by-field block here). Each field is
-    // independently guarded so a partial file (e.g. a camera but no render
-    // settings) restores what's there without assuming the rest, and the
-    // camera is applied LAST so nothing re-frames after it. A v1 / v2 file
-    // has none of these — fall through to the existing behaviour.
-    applyViewState({
-      render: session.render,
-      colorMode: session.colorMode,
-      classFilter: session.classFilter,
-      pointFilters: session.pointFilters,
-      clip: geo.clip,
-      camera: geo.camera,
-    });
-    if (
-      session.crs &&
-      session.crs.epsg != null &&
-      (session.crs.kind === 'projected' || session.crs.kind === 'geographic' || session.crs.kind === 'local')
-    ) {
-      // Restore the author's CRS override so a capsule round-trips without
-      // re-prompting — but NEVER over a scan that declares a DIFFERENT code.
-      // The scan-identity match already conflicts on differing codes; this
-      // guard covers the remaining hole, a scan whose declaration exists but
-      // was absent from the session summary. A file that states its own CRS is
-      // stronger evidence than a session written who-knows-where, so the
-      // declaration wins and the session's choice is dropped with a note.
-      const declared =
-        viewer.streamingCloud?.crs()?.epsg ??
-        (scans.activeId ? viewer.getCloud(scans.activeId)?.metadata?.crs?.epsg : undefined);
-      if (declared != null && declared !== session.crs.epsg) {
-        showLassoToast(
-          `The session's CRS (EPSG:${session.crs.epsg}) was not applied — this scan declares EPSG:${declared}, and a file's own declaration wins.`,
-        );
-      } else {
-        crsService.setOverride({
-          override: { epsg: session.crs.epsg, kind: session.crs.kind },
-          detected: scans.activeId ? viewer.getCloud(scans.activeId)?.metadata?.crs ?? undefined : undefined,
-          source: 'user-override',
-        });
-      }
-    }
-
-    // Honest disclosure: the session carries the saved analysis, not the scan
-    // itself (a point cloud can't travel in the file). If its scan isn't
-    // loaded, the restored measurements/annotations have nothing to sit on —
-    // say so and point the user at the file to drop, rather than restoring onto
-    // an empty scene silently.
-    const restored =
-      session.measurements.length + session.annotations.length + session.views.length;
-    const wantFile = session.scanSummary?.fileName;
-    // When the user reached here via "Apply anyway", record that the restore
-    // proceeded on an unverified scan match rather than a confirmed one.
-    const appliedNote = opts.skipScanConfirm ? ' Applied despite an unverified scan match.' : '';
-    // Disclosure when the session was captured in a different scan's frame and
-    // its geometry was shifted to line up with the loaded cloud — an honest
-    // note that a non-obvious transform happened, not a silent relocation.
-    const frameNote = rebased
-      ? ' Its measurements were realigned to the loaded scan’s origin.'
-      : '';
-    // Evidence Capsule: lead with the honesty roll-up when the shared session
-    // carries graded measurements — the recipient sees the trust picture, not
-    // just a count.
-    const evidence = summarizeMeasurementTrust(session.measurements.map((m) => m.trust));
-    const lead = evidence.total > 0 ? `Evidence restored — ${evidence.line}.` : null;
-    if (wantFile && !haveCloud) {
-      showLassoToast(lead ?? `Session restored — drop “${wantFile}” to view its scan.`,
-        lead ? { label: 'Need the scan', onClick: () => showLassoToast(`Drop “${wantFile}” to view this evidence on its scan.`) } : undefined);
-    } else if (lead) {
-      showLassoToast(`${lead}${frameNote}${appliedNote}`);
-    } else {
-      showLassoToast(
-        `Session restored — ${restored} item${restored === 1 ? '' : 's'} ` +
-          `(measurements, annotations, views).${frameNote}${appliedNote}`,
-      );
-    }
-  } catch (err) {
-    dropZone.setError(err instanceof Error ? err.message : 'Could not import the session');
-  }
+function importSession(file: File, opts: { skipScanConfirm?: boolean } = {}): Promise<void> {
+  return runImportSession(file, opts, sessionIoDeps);
 }
 
 /** Load a dropped or sampled File: parse, render, and populate the Inspector. */

--- a/tests/architectureMap.test.ts
+++ b/tests/architectureMap.test.ts
@@ -91,9 +91,9 @@ describe('architecture map stays in step with the tree', () => {
     // The floor is a sanity guard against the tables being deleted wholesale,
     // not a fixed size: each completed extraction moves its row out of the
     // pending table into "Done:" prose, so the count ratchets down over time
-    // (the render-loop extraction took it from 10 to 9).
+    // (the render-loop and importSession extractions took it from 10 to 8).
     const rows = text.split('\n').filter((l) => /^\|\s*`?[A-Za-z_]/.test(l) && /\|\s*[\d,]+\s*\|/.test(l));
-    expect(rows.length, 'the extraction tables have gone missing').toBeGreaterThanOrEqual(9);
+    expect(rows.length, 'the extraction tables have gone missing').toBeGreaterThanOrEqual(8);
 
     const lines = [
       ...readFileSync(root + 'src/main.ts', 'utf8').split('\n'),

--- a/tests/sessionIo.test.ts
+++ b/tests/sessionIo.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  importSession,
+  scanFactsFromStreaming,
+  scanFactsFromStatic,
+  type SessionIoDeps,
+  type SessionModule,
+} from '../src/app/sessionIo';
+import { serializeSession, parseSession, rebaseSessionGeometry, matchSessionToScan } from '../src/io/session';
+import type { InspectionSession, SessionScanSummary } from '../src/io/session';
+import type { Viewer } from '../src/render/Viewer';
+import type { Measurement, Vec3 } from '../src/render/measure/types';
+
+// The build version the deps advertise; sessions are stamped with the SAME
+// string so the stale-export disclosure stays quiet except where a test wants it.
+const CURRENT = '0.6.3';
+
+const p = (x: number, y: number, z: number): Vec3 => [x, y, z];
+
+// importSession only calls file.text(); a plain object is enough and avoids
+// depending on a Node `File` global.
+const asFile = (text: string): File => ({ text: async () => text }) as unknown as File;
+
+const realSessionModule: SessionModule = { parseSession, rebaseSessionGeometry, matchSessionToScan };
+
+interface StreamingOpts {
+  name: string;
+  sourcePointCount: number;
+  dataBounds: readonly [number, number, number, number, number, number];
+  crs?: { name?: string; epsg?: number } | null;
+}
+
+/**
+ * Build a SessionIoDeps wired to spies, plus the spies themselves. A `streaming`
+ * option supplies a fake streaming cloud (so `haveCloud` is true and the
+ * scan-identity match runs); with none, the scene is empty.
+ */
+function makeDeps(
+  over: {
+    streaming?: StreamingOpts;
+    origin?: readonly [number, number, number];
+    appVersion?: string;
+  } = {},
+) {
+  const loadMeasurements = vi.fn();
+  const loadAnnotations = vi.fn();
+  const restore = vi.fn();
+  const setInspectorViews = vi.fn();
+  const refreshMeasurePanel = vi.fn();
+  const refreshAnnotationPanel = vi.fn();
+  const applyViewState = vi.fn();
+  const setCrsOverride = vi.fn();
+  const showToast = vi.fn();
+  const setDropError = vi.fn();
+
+  const streamingCloud = over.streaming
+    ? {
+        name: over.streaming.name,
+        sourcePointCount: over.streaming.sourcePointCount,
+        dataBounds: () => over.streaming!.dataBounds,
+        crs: () => over.streaming!.crs ?? null,
+      }
+    : null;
+
+  const viewer = {
+    clouds: () => [] as string[],
+    hasStreamingCloud: over.streaming != null,
+    streamingCloud,
+    getCloud: () => undefined,
+    measure: { loadMeasurements },
+    annotate: { loadAnnotations },
+  };
+
+  const deps: SessionIoDeps = {
+    viewerReady: Promise.resolve(),
+    getViewer: () => viewer as unknown as Viewer,
+    loadSession: async () => realSessionModule,
+    appVersion: over.appVersion ?? CURRENT,
+    getActiveScanId: () => null,
+    getActiveCloud: () => null,
+    exportOrigin: () => over.origin ?? [0, 0, 0],
+    bookmarks: { restore, names: () => ['V1'] },
+    setInspectorViews,
+    refreshMeasurePanel,
+    refreshAnnotationPanel,
+    applyViewState,
+    setCrsOverride,
+    showToast,
+    setDropError,
+  };
+
+  return {
+    deps,
+    calls: {
+      loadMeasurements,
+      loadAnnotations,
+      restore,
+      setInspectorViews,
+      refreshMeasurePanel,
+      refreshAnnotationPanel,
+      applyViewState,
+      setCrsOverride,
+      showToast,
+      setDropError,
+    },
+  };
+}
+
+function sessionJson(
+  over: Partial<Omit<InspectionSession, 'app' | 'kind' | 'version'>> = {},
+): string {
+  const measurements: Measurement[] = [
+    { id: 'a', kind: 'distance', name: 'D1', points: [p(0, 0, 0), p(1, 0, 0)] },
+  ];
+  return serializeSession({
+    upAxis: 'z',
+    origin: [0, 0, 0],
+    unitSystem: 'metric',
+    views: [{ name: 'V1', camera: { position: p(1, 2, 3), target: p(4, 5, 6), mode: 'orbit' } }],
+    measurements,
+    annotations: [],
+    software: CURRENT,
+    ...over,
+  });
+}
+
+const summary = (over: Partial<SessionScanSummary> = {}): SessionScanSummary => ({
+  fileName: 'loaded.laz',
+  sourcePoints: 1000,
+  width: 10,
+  depth: 10,
+  height: 3,
+  ...over,
+});
+
+describe('scanFactsFromStreaming — pure cloud→fingerprint adapter', () => {
+  it('derives extent spans from dataBounds and copies name / points / CRS', () => {
+    const facts = scanFactsFromStreaming({
+      name: 'scan.laz',
+      sourcePointCount: 1000,
+      dataBounds: () => [0, 0, 0, 10, 20, 3],
+      crs: () => ({ name: 'UTM 13N', epsg: 32613 }),
+    });
+    expect(facts).toEqual({
+      fileName: 'scan.laz',
+      sourcePoints: 1000,
+      width: 10,
+      depth: 20,
+      height: 3,
+      crs: 'UTM 13N',
+      epsg: 32613,
+    });
+  });
+
+  it('leaves crs / epsg undefined when the source declares no CRS', () => {
+    const facts = scanFactsFromStreaming({
+      name: 'x',
+      sourcePointCount: 5,
+      dataBounds: () => [1, 2, 3, 4, 6, 9],
+      crs: () => null,
+    });
+    expect(facts).toMatchObject({ width: 3, depth: 4, height: 6 });
+    expect(facts.crs).toBeUndefined();
+    expect(facts.epsg).toBeUndefined();
+  });
+});
+
+describe('scanFactsFromStatic — pure cloud→fingerprint adapter', () => {
+  it('derives extent spans from bounds and reads CRS from header metadata', () => {
+    const facts = scanFactsFromStatic({
+      name: 'a.las',
+      pointCount: 42,
+      bounds: () => ({ min: [0, 0, 0], max: [5, 7, 2] }),
+      metadata: { crs: { name: 'NAD83', epsg: 26913 } },
+    });
+    expect(facts).toEqual({
+      fileName: 'a.las',
+      sourcePoints: 42,
+      width: 5,
+      depth: 7,
+      height: 2,
+      crs: 'NAD83',
+      epsg: 26913,
+    });
+  });
+
+  it('leaves crs / epsg undefined when metadata is absent', () => {
+    const facts = scanFactsFromStatic({
+      name: 'a',
+      pointCount: 1,
+      bounds: () => ({ min: [0, 0, 0], max: [1, 1, 1] }),
+    });
+    expect(facts.crs).toBeUndefined();
+    expect(facts.epsg).toBeUndefined();
+  });
+});
+
+describe('importSession — malformed / wrong-shape input routes to the drop zone', () => {
+  it('reports invalid JSON without touching the scene', async () => {
+    const { deps, calls } = makeDeps();
+    await importSession(asFile('not json{'), {}, deps);
+    expect(calls.setDropError).toHaveBeenCalledWith('This file is not valid JSON.');
+    expect(calls.loadMeasurements).not.toHaveBeenCalled();
+  });
+
+  it('rejects a file that is not an OpenLiDARViewer session', async () => {
+    const { deps, calls } = makeDeps();
+    await importSession(asFile(JSON.stringify({ app: 'Other', kind: 'x', version: 7 })), {}, deps);
+    expect(calls.setDropError).toHaveBeenCalledWith('This file is not an OpenLiDARViewer session.');
+  });
+
+  it('rejects an unsupported session version', async () => {
+    const { deps, calls } = makeDeps();
+    await importSession(
+      asFile(JSON.stringify({ app: 'OpenLiDARViewer', kind: 'measurement-session', version: 999 })),
+      {},
+      deps,
+    );
+    expect(calls.setDropError).toHaveBeenCalledWith('Unsupported session version: 999.');
+  });
+});
+
+describe('importSession — restore with no cloud loaded', () => {
+  it('applies the verbatim geometry and tells the user to drop the source scan', async () => {
+    const { deps, calls } = makeDeps();
+    await importSession(
+      asFile(sessionJson({ scanSummary: summary({ fileName: 'survey.las' }) })),
+      {},
+      deps,
+    );
+    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    expect(calls.loadMeasurements.mock.calls[0][0]).toHaveLength(1);
+    expect(calls.loadAnnotations).toHaveBeenCalledWith([]);
+    expect(calls.restore).toHaveBeenCalledTimes(1);
+    expect(calls.setInspectorViews).toHaveBeenCalledWith(['V1']);
+    expect(calls.applyViewState).toHaveBeenCalledTimes(1);
+    const msg = calls.showToast.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('survey.las');
+    expect(msg).toContain('drop');
+  });
+
+  it('summarises the restored item count when the session names no scan', async () => {
+    const { deps, calls } = makeDeps();
+    await importSession(asFile(sessionJson()), {}, deps);
+    // 1 measurement + 0 annotations + 1 view = 2 items.
+    expect(calls.showToast).toHaveBeenCalledWith(expect.stringContaining('Session restored — 2 items'));
+  });
+
+  it('discloses a stale producing version', async () => {
+    const { deps, calls } = makeDeps({ appVersion: '0.7.0' });
+    await importSession(asFile(sessionJson({ software: '0.6.0' })), {}, deps);
+    expect(calls.showToast).toHaveBeenCalledWith(expect.stringContaining('generated by v0.6.0'));
+  });
+});
+
+describe('importSession — scan-identity gate against a loaded cloud', () => {
+  const loadedStreaming: StreamingOpts = {
+    name: 'loaded.laz',
+    sourcePointCount: 1000,
+    dataBounds: [0, 0, 0, 10, 10, 3],
+  };
+
+  it('refuses a session captured over a different scan (extents conflict)', async () => {
+    const { deps, calls } = makeDeps({ streaming: loadedStreaming });
+    await importSession(
+      asFile(sessionJson({ scanSummary: summary({ width: 100, depth: 100 }) })),
+      {},
+      deps,
+    );
+    expect(calls.showToast).toHaveBeenCalledWith(expect.stringContaining('different scan'));
+    expect(calls.loadMeasurements).not.toHaveBeenCalled();
+  });
+
+  it('applies a strong match and discloses a geometry realignment', async () => {
+    // Extents match (strong verdict); the export origin differs from the
+    // session origin, so the rebase shifts geometry and the toast says so.
+    const { deps, calls } = makeDeps({ streaming: loadedStreaming, origin: [10, 0, 0] });
+    await importSession(
+      asFile(sessionJson({ origin: [0, 0, 0], scanSummary: summary() })),
+      {},
+      deps,
+    );
+    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    expect(calls.showToast).toHaveBeenCalledWith(expect.stringContaining('realigned'));
+  });
+
+  it('holds a partial match behind an "Apply anyway" confirmation, then applies on skip', async () => {
+    // Extents match tightly but the point count moved → partial, not strong.
+    const partialStreaming: StreamingOpts = { ...loadedStreaming, sourcePointCount: 2000 };
+    const { deps, calls } = makeDeps({ streaming: partialStreaming });
+    const file = asFile(sessionJson({ scanSummary: summary({ sourcePoints: 1000 }) }));
+
+    await importSession(file, {}, deps);
+    expect(calls.loadMeasurements).not.toHaveBeenCalled();
+    const confirm = calls.showToast.mock.calls.find((c) => c[1]?.label === 'Apply anyway');
+    expect(confirm).toBeTruthy();
+
+    // The confirmation re-runs the same restore with the check skipped.
+    await importSession(file, { skipScanConfirm: true }, deps);
+    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    expect(calls.showToast).toHaveBeenCalledWith(
+      expect.stringContaining('Applied despite an unverified scan match'),
+    );
+  });
+});


### PR DESCRIPTION
Lifts the ~208-line `importSession` orchestration out of `main.ts` into `src/app/sessionIo.ts`, following the `actionDefinitions` / `exportAdapter` deps pattern.

## What moved
- `importSession(file, opts, deps)` now lives in `src/app/sessionIo.ts`. It takes a `SessionIoDeps` object of ~16 accessors/setters (viewer, active scan, export origin, bookmarks, panels, `applyViewState`, CRS override, toast, drop-zone error, plus `loadSession` and `appVersion`). `main.ts` keeps a thin caller that binds those to its own state.
- The pure cloud-to-fingerprint step is extracted as exported `scanFactsFromStreaming` / `scanFactsFromStatic`, so the input the scan-identity matcher compares against is Node-testable without a Viewer.
- The parse/verify/rebase halves already lived in `src/io/session.ts` and are unchanged. Logic is relocated verbatim, only parameterised.

## Tests
`tests/sessionIo.test.ts` (13 cases): the two pure ScanFacts adapters (spans, CRS present/absent); malformed JSON, wrong-app and unsupported-version routing to the drop zone; no-cloud restore (verbatim apply + "drop the scan" disclosure, item-count summary, stale-version note); and the scan-identity gate against a loaded cloud (extents conflict refused, strong match applied with realignment note, partial match held behind "Apply anyway" then applied on skip).

## Ratchet + gates
- `main.ts` 6,976 -> 6,790. Baseline banked; `KNOWN_LIMITATIONS_v0.6.3.md` and `docs/architecture/architecture-map.md` counts updated and the `importSession` row marked done.
- Green: typecheck, lint:monolith-size, lint:release-truth, lint:main-deferral, lint:layer-boundaries, and all session suites (111) + sessionIo (13).

Scope: full extraction. No auto-merge.