### PR TITLE
Fix stale battery unit-test reference

### DIFF
--- a/scripts/publication-battery.mjs
+++ b/scripts/publication-battery.mjs
@@ -24,7 +24,7 @@
  *
  * Not a vitest suite: it spawns npm scripts, several of which are themselves
  * vitest runs. Its pure parts are unit-covered from vitest in
- * `tests/benchmark/publicationBattery.test.ts`.
+ * `tests/benchmark/cleanClone.test.ts`.
  */
 import { spawnSync } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';


### PR DESCRIPTION
## What

The `scripts/publication-battery.mjs` header comment pointed its unit-coverage claim at `tests/benchmark/publicationBattery.test.ts`, a file that does not exist. The pure-part coverage (registry composition, tier subsetting, verdict logic, summary rendering) actually lives in `tests/benchmark/cleanClone.test.ts`. Comment now points there.

## Why

Verification pass over the publication-validation program. All 10 intended suites are wired into the `SUITES` registry and reachable through the umbrella; the `verify` tier resolves to every registered suite and `quick` is a strict subset. The only defect found was this broken reference in the file whose whole job is honest bookkeeping.

## Verification

- `npm run benchmark:publication:quick` — 8/8 passed, verdict PASS, exit 0
- `npm run benchmark:backends` — passed (backend-equivalence, the suite `quick` omits)
- all 10 `validation:*:verify` committed-record checkers — exit 0
- `npx vitest run tests/benchmark/cleanClone.test.ts` — 21/21 passed
- `npm run typecheck` — 0 errors

No tolerance weakened, no suite added or removed. Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)