### PR TITLE
DRY the linear-unit-known gate, and fail closed on a missing CRS in epoch compare

### DIFF
--- a/src/analysis/modules/scanReport.ts
+++ b/src/analysis/modules/scanReport.ts
@@ -2,6 +2,7 @@ import type { AnalysisModule, AnalysisResult, AnalysisRow, RunOptions } from '..
 import type { PointCloud } from '../../model/PointCloud';
 import type { ClassScope } from '../../render/class/classScope';
 import type { CrsLinearUnit } from '../../io/crs';
+import { isLinearUnitKnown } from '../../geo/CoordinateTypes';
 import { isZUpFormat } from '../../io/sniffFormat';
 
 function rowInfo(label: string, value: string): AnalysisRow {
@@ -64,8 +65,7 @@ export interface ScanReportUnitBasis {
  * claim is withheld.
  */
 export function scanReportUnitBasis(crs: UnitCrs): ScanReportUnitBasis {
-  const unitKnown =
-    crs != null && crs.linearUnit !== undefined && crs.linearUnit !== 'unknown';
+  const unitKnown = isLinearUnitKnown(crs);
   const mpu = unitKnown ? (crs?.linearUnitToMetres ?? 1) : 1;
   const vmpu = unitKnown ? (crs?.verticalUnitToMetres ?? mpu) : 1;
   return {

--- a/src/analysis/streamingExtentRows.ts
+++ b/src/analysis/streamingExtentRows.ts
@@ -1,4 +1,5 @@
 import type { CrsLinearUnit } from '../io/crs';
+import { isLinearUnitKnown } from '../geo/CoordinateTypes';
 
 /** One extent/density/spacing row the streaming Scan-report emits. */
 export interface ExtentRowSpec {
@@ -50,8 +51,7 @@ export function streamingExtentRows(
   crsInfo: ExtentCrs,
   sourcePointCount: number,
 ): StreamingExtentResult {
-  const unitConfirmed =
-    crsInfo != null && crsInfo.linearUnit !== undefined && crsInfo.linearUnit !== 'unknown';
+  const unitConfirmed = isLinearUnitKnown(crsInfo);
 
   // Apply the metre factor ONLY when the unit is real. Otherwise the span stays
   // in raw source units (factor 1) and is not labelled "m".

--- a/src/app/LayerService.ts
+++ b/src/app/LayerService.ts
@@ -26,6 +26,7 @@ import {
   type LayerCompatibility,
 } from '../model/layerCompatibility';
 import { loadLayerHealth } from '../lazyChunks';
+import { isLinearUnitKnown } from '../geo/CoordinateTypes';
 import type { AppContext } from './appContext';
 import type { ProjectFrameService, ProjectFrameLayer } from './projectFrame';
 
@@ -357,7 +358,7 @@ export function createLayerService(deps: LayerServiceDeps): LayerService {
             crsName: info.crsName ?? null,
             crsSource: (crs as { source?: string } | null)?.source ?? null,
             horizontalUnit:
-              crs && crs.linearUnit && crs.linearUnit !== 'unknown' ? crs.linearUnit : null,
+              crs && isLinearUnitKnown(crs) ? crs.linearUnit : null,
             verticalUnit: null, // no declared vertical unit NAME exists; never reverse-map the factor
             verticalDatum: info.verticalDatum ?? null,
             compatibility: lastCompatibility.get(info.id) ?? null,

--- a/src/geo/CoordinateTypes.ts
+++ b/src/geo/CoordinateTypes.ts
@@ -136,6 +136,30 @@ export interface ResolvedCrs {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Unit-integrity predicate — the single fail-closed gate
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Whether a CRS declares a REAL linear unit — the canonical fail-closed gate
+ * every metric-claiming seam shares (measure tool, lasso density, streaming and
+ * scan reports, full-cloud grade, epoch compare). A metre / foot / us-survey-
+ * foot CRS is known; a null/undefined CRS, one carrying `linearUnit: 'unknown'`
+ * (the inert `linearUnitToMetres: 1` placeholder), or one with no `linearUnit`
+ * field at all is NOT — so the caller withholds the "m" / "pts/m²" claim rather
+ * than stamping raw source units as metres. The `!== undefined` arm keeps a
+ * missing unit on the fail-closed side, matching the streaming-extent / scan-
+ * report gates whose CRS type leaves `linearUnit` optional.
+ *
+ * Structurally typed so every CRS shape (ResolvedCrs, CrsInfo, metadata.crs)
+ * passes without a cast. Pure — no DOM, no proj4, no three.
+ */
+export function isLinearUnitKnown(
+  crs: { readonly linearUnit?: string } | null | undefined,
+): boolean {
+  return crs != null && crs.linearUnit !== undefined && crs.linearUnit !== 'unknown';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Point shapes — every coordinate the platform talks about
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/intelligence/scanStory.ts
+++ b/src/intelligence/scanStory.ts
@@ -29,6 +29,7 @@ import type {
   GroundVisibilityBucket,
   CoverageBucket,
 } from '../terrain/datasetIntelligence';
+import { isLinearUnitKnown } from '../geo/CoordinateTypes';
 
 /** Surface-quality / fitness tier, mirroring terrainAssessment's axis. */
 export type FitnessTier = 'Good' | 'Preview' | 'Limited' | 'Blocked' | 'Unknown';
@@ -122,7 +123,7 @@ export function footprintAreaM2(
   spanY: number,
   crs: { readonly linearUnit: string; readonly linearUnitToMetres?: number } | null | undefined,
 ): number | undefined {
-  if (!crs || crs.linearUnit === 'unknown') return undefined;
+  if (!crs || !isLinearUnitKnown(crs)) return undefined;
   const toM = crs.linearUnitToMetres ?? 1;
   const area = spanX * spanY * toM * toM;
   return Number.isFinite(area) && area > 0 ? area : undefined;

--- a/src/main.ts
+++ b/src/main.ts
@@ -6625,7 +6625,7 @@ function compareLoadedLayers(): void {
       const span = horizontalSpanXY(a.positions, a.sourceOrigin);
       const spanUnitToM = a.metadata?.crs?.linearUnitToMetres ?? 1;
       const { after: alignedAfter, alignment } = alignEpochClouds(beforeCloud, afterCloud, {
-        maxResidualM: span > 0 ? span * 0.1 * spanUnitToM : undefined, horizontalUnitKnown: a.metadata?.crs?.linearUnit !== 'unknown' && b.metadata?.crs?.linearUnit !== 'unknown', // both KNOWN ⇒ summarizeAlignment reports the shift/residual in metres; 'unknown' withholds the metre figures (geographic frames are refused before the fit)
+        maxResidualM: span > 0 ? span * 0.1 * spanUnitToM : undefined, horizontalUnitKnown: isLinearUnitKnown(a.metadata?.crs) && isLinearUnitKnown(b.metadata?.crs), // both units KNOWN ⇒ summarizeAlignment reports the shift/residual in metres; a missing CRS or 'unknown' unit withholds the metre figures (geographic frames are refused before the fit)
       });
       const dtms = buildSharedEpochDtms(beforeCloud, alignedAfter);
       if (!dtms) {
@@ -6642,7 +6642,7 @@ function compareLoadedLayers(): void {
         horizontalUnitToMetres: a.metadata?.crs?.linearUnitToMetres,
         verticalUnitToMetres: a.metadata?.crs?.verticalUnitToMetres,
         isGeographic: a.metadata?.crs?.isGeographic === true || b.metadata?.crs?.isGeographic === true,
-        horizontalUnitKnown: a.metadata?.crs?.linearUnit !== 'unknown' && b.metadata?.crs?.linearUnit !== 'unknown', // KNOWN in both epochs ⇒ compareDtms fails closed instead of leaking source units as metres ('unknown' = placeholder factor 1; geographic frames go via isGeographic)
+        horizontalUnitKnown: isLinearUnitKnown(a.metadata?.crs) && isLinearUnitKnown(b.metadata?.crs), // KNOWN in both epochs ⇒ compareDtms fails closed instead of leaking source units as metres (a missing CRS or 'unknown' unit = placeholder factor 1; geographic frames go via isGeographic)
       });
       const header = `${baseName(a.name)} (before) → ${baseName(b.name)} (after)`;
       inspector.setCompareResult([header, summarizeAlignment(alignment), ...summarizeChange(cmp)]);

--- a/src/main.ts
+++ b/src/main.ts
@@ -254,6 +254,7 @@ import { CatalogPanel } from './ui/CatalogPanel';
 import type { CrsInfo, CrsLinearUnit } from './io/crs';
 import { streamingExtentRows } from './analysis/streamingExtentRows';
 import { CrsService } from './geo/CrsService';
+import { isLinearUnitKnown } from './geo/CoordinateTypes';
 // Shared vertical-unit labeller (already eager via terrainAnalysisRunner) —
 // feeds the colorbar legend's elevation unit from the resolved CRS.
 import { verticalUnitLabel } from './units/units';
@@ -559,7 +560,7 @@ const lassoVolumeTool = new LassoVolumeTool(stage.canvas, {
     // Whether that factor is real or an assumed 1: an unknown CRS still yields
     // lin = 1 for display, but its points/m² density is then an assumption, so
     // the stockpile grade must not claim it.
-    const densityUnitKnown = crsForLasso != null && crsForLasso.linearUnit !== 'unknown';
+    const densityUnitKnown = isLinearUnitKnown(crsForLasso);
     const vert = crsForLasso?.verticalUnitToMetres ?? lin;
     const out = viewer.computeLassoVolume(lasso, 0.05, lin, densityUnitKnown, vert);
     if (out === null) {
@@ -2217,7 +2218,7 @@ void viewerLoaded.then(() => {
     // A CRS is "known" for the measurement trust grade when one resolved with a
     // real linear unit. Distinct from the unit factor: a metric (UTM) survey has
     // factor 1 yet a fully-known CRS, so the factor alone can't certify scale.
-    viewer.measure.setCrsKnown(resolved != null && resolved.linearUnit !== 'unknown');
+    viewer.measure.setCrsKnown(isLinearUnitKnown(resolved));
     // A GEOGRAPHIC (degree) CRS can't be repaired by any scalar factor —
     // X/Y are degrees, Z is linear. The controller refuses the affected
     // trust grades + captions the hint; the panel shows the persistent
@@ -2228,14 +2229,13 @@ void viewerLoaded.then(() => {
     // Colorbar legend — the elevation unit comes from the SAME resolved CRS
     // (overrides included), through the same vertical-unit rule the terrain
     // runner uses: an explicit vertical unit wins, else the horizontal
-    // linear unit WHEN KNOWN. An unknown CRS reports factor 1 as a
-    // pass-through, so gate on `linearUnit !== 'unknown'` — otherwise
-    // unknown units would masquerade as metres on the legend. `verticalUnitLabel`
+    // linear unit WHEN KNOWN. An unknown CRS reports factor 1 as a pass-through,
+    // so gate via `isLinearUnitKnown` — else units masquerade as metres. `verticalUnitLabel`
     // returns 'units' for odd factors; that is not a unit, so it maps to
     // null and the legend shows bare numbers (honesty rule).
     const vToM =
       resolved?.verticalUnitToMetres ??
-      (resolved && resolved.linearUnit !== 'unknown' ? resolved.linearUnitToMetres : null);
+      (resolved && isLinearUnitKnown(resolved) ? resolved.linearUnitToMetres : null);
     const vLabel = vToM != null ? verticalUnitLabel(vToM) : 'units';
     viewer.setElevationUnit(vLabel === 'units' ? null : vLabel);
   });
@@ -2396,7 +2396,7 @@ function newAnalysePanel(
         // and the Analyse panel's readiness / recommend / map-sheet notes, read this.
         verticalUnitToMetres:
           cur?.verticalUnitToMetres ??
-          (cur && cur.linearUnit !== 'unknown' ? cur.linearUnitToMetres : undefined),
+          (cur && isLinearUnitKnown(cur) ? cur.linearUnitToMetres : undefined),
       };
     },
   });
@@ -3399,7 +3399,7 @@ function applyScanRoute(initial: boolean, settled = false): boolean {
       upAxis: shape.up,
       spaceKind: effective === 'interior' ? 'interior' : 'object',
       unitToMetres,
-      unitKnown: (crsService.current()?.linearUnit ?? 'unknown') !== 'unknown',
+      unitKnown: isLinearUnitKnown(crsService.current()),
       hasRgb,
       sourcePointCount: gathered.totalPoints,
       // A still-streaming cloud is measured on its resident subset only — lead

--- a/src/render/streaming/runFullCloudGradeAction.ts
+++ b/src/render/streaming/runFullCloudGradeAction.ts
@@ -20,6 +20,7 @@ import type { Viewer } from '../Viewer';
 import type { StreamingPanel } from '../../ui/StreamingPanel';
 import { gradeFullCloud } from './fullCloudGradeAdapter';
 import { gradeSampleDensity, summarizeSampleGrade } from './sampleGrade';
+import { isLinearUnitKnown } from '../../geo/CoordinateTypes';
 
 /**
  * Decode + grade the active streaming cloud's full extent and render the result
@@ -51,7 +52,7 @@ export async function runFullCloudGrade(deps: {
   // otherwise the factor stays 1 and the summary labels the figures per source
   // unit (see summarizeSampleGrade's unitConfirmed argument).
   const crs = source.crs();
-  const unitConfirmed = crs != null && crs.linearUnit !== 'unknown';
+  const unitConfirmed = isLinearUnitKnown(crs);
   const metresPerUnit = unitConfirmed ? (crs?.linearUnitToMetres ?? 1) : 1;
   // Z gets the vertical unit when the CRS declares one separately (e.g. NAVD88
   // feet over a metre grid); otherwise it follows the horizontal factor.

--- a/tests/unitKnown.test.ts
+++ b/tests/unitKnown.test.ts
@@ -39,4 +39,22 @@ describe('isLinearUnitKnown', () => {
     expect(isLinearUnitKnown(footCrs)).toBe(true);
     expect(isLinearUnitKnown(unknownWithFactor)).toBe(false);
   });
+
+  it('the two-epoch compare gate fails closed when EITHER epoch lacks a known unit', () => {
+    // Regression for the epoch-compare wiring (compareLoadedLayers in main.ts):
+    // `horizontalUnitKnown` is `isLinearUnitKnown(a) && isLinearUnitKnown(b)`.
+    // The earlier inline form `a.linearUnit !== 'unknown' && b...` read a MISSING
+    // CRS (null metadata, the default for a plain PLY/PCD/XYZ) as unit-known —
+    // fail-OPEN — so cut/fill volume and Δz/LoD printed in metres from a
+    // placeholder factor of 1 while the real unit was unknown.
+    const metre = { linearUnit: 'metre' };
+    const bothKnown = (a: unknown, b: unknown) =>
+      isLinearUnitKnown(a as { linearUnit?: string } | null) &&
+      isLinearUnitKnown(b as { linearUnit?: string } | null);
+    expect(bothKnown(metre, metre)).toBe(true);
+    expect(bothKnown(metre, null)).toBe(false); // after-epoch has no CRS
+    expect(bothKnown(null, metre)).toBe(false); // before-epoch has no CRS
+    expect(bothKnown(metre, { linearUnit: 'unknown' })).toBe(false);
+    expect(bothKnown(null, null)).toBe(false);
+  });
 });

--- a/tests/unitKnown.test.ts
+++ b/tests/unitKnown.test.ts
@@ -1,0 +1,42 @@
+/**
+ * unitKnown.test.ts
+ *
+ * The single fail-closed unit-integrity predicate, `isLinearUnitKnown`, that the
+ * measure tool, lasso density, streaming / scan reports, full-cloud grade and
+ * epoch-compare seams all share (PRs #217–227). Metres are claimable ONLY when
+ * the CRS declares a real linear unit; everything else — no CRS, the inert
+ * `linearUnit: 'unknown'` placeholder, or no `linearUnit` field at all — fails
+ * closed so raw source units are never stamped as metres.
+ */
+import { isLinearUnitKnown } from '../src/geo/CoordinateTypes';
+
+describe('isLinearUnitKnown', () => {
+  it('is true for the known linear units', () => {
+    expect(isLinearUnitKnown({ linearUnit: 'metre' })).toBe(true);
+    expect(isLinearUnitKnown({ linearUnit: 'foot' })).toBe(true);
+    expect(isLinearUnitKnown({ linearUnit: 'us-survey-foot' })).toBe(true);
+  });
+
+  it("is false for the 'unknown' placeholder unit", () => {
+    expect(isLinearUnitKnown({ linearUnit: 'unknown' })).toBe(false);
+  });
+
+  it('is false for a null or undefined CRS', () => {
+    expect(isLinearUnitKnown(null)).toBe(false);
+    expect(isLinearUnitKnown(undefined)).toBe(false);
+  });
+
+  it('is false when the CRS carries no linearUnit field', () => {
+    expect(isLinearUnitKnown({})).toBe(false);
+  });
+
+  it('accepts richer CRS shapes structurally, no cast (ResolvedCrs / CrsInfo)', () => {
+    // Passed as typed variables, mirroring real callers: extra fields are fine
+    // structurally, and the placeholder-factor 1 does not make an unknown unit
+    // "known".
+    const footCrs = { linearUnit: 'foot', linearUnitToMetres: 0.3048 };
+    const unknownWithFactor = { linearUnit: 'unknown', linearUnitToMetres: 1 };
+    expect(isLinearUnitKnown(footCrs)).toBe(true);
+    expect(isLinearUnitKnown(unknownWithFactor)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Two related changes to the fail-closed unit-integrity gate.

**1. DRY the predicate (no behaviour change).** Add `isLinearUnitKnown(crs)` to `src/geo/CoordinateTypes.ts` (co-located with the CRS types, no UI/three imports):

```ts
export function isLinearUnitKnown(
  crs: { readonly linearUnit?: string } | null | undefined,
): boolean {
  return crs != null && crs.linearUnit !== undefined && crs.linearUnit !== 'unknown';
}
```

Route 10 fail-closed unit gates through it — `main.ts` (5), `streamingExtentRows`, `scanReport`, `scanStory`, `LayerService`, `runFullCloudGradeAction`. Pure predicate swap; the `!== undefined` arm preserves the two optional-`linearUnit` sites (`streamingExtentRows`, `scanReport`) exactly.

**2. Close the epoch-compare fail-OPEN (behaviour change, strictly safer).** `main.ts:6628/6645` computed `horizontalUnitKnown` as `a.metadata?.crs?.linearUnit !== 'unknown' && b...` with **no null guard**. Since `metadata.crs` is `CrsInfo | null`, a **missing** CRS made `undefined !== 'unknown'` → `true` — fail-open. `compareLoadedLayers` accepts any two loaded clouds with no CRS preflight, so two CRS-less clouds (plain PLY/PCD/XYZ — the default for non-georeferenced data) reached it and got cut/fill volume + Δz/LoD reported in **metres** from a placeholder factor of 1, while the real unit was unknown. Both sites now go through `isLinearUnitKnown`, which returns `false` for a null/undefined CRS, so a missing or `'unknown'` unit in either epoch withholds the metre figures. Two known-unit epochs are unaffected.

## Tests / gates
- `tests/unitKnown.test.ts` — the predicate (known → true; `'unknown'`/null/undefined/missing-field → false) **plus a two-epoch regression case** pinning the missing-CRS fail-closed behaviour.
- `tsc --noEmit` 0 errors; `lint:monolith-size` OK (`main.ts` 6790, baseline held); `lint:layer-boundaries` + `lint:main-deferral` clean.
- Full `vitest run` green on the branch before the fail-open fix; targeted re-run after it: 112/112 across unitKnown, compareDtms, alignEpochs, streamingExtentRows, scanReport, scanStory.

## Note
The behaviour change (part 2) is browser-observable only via the two-epoch compare on CRS-less fixtures; it is covered here at the pure-predicate level. No auto-merge.