### PR TITLE
Thread the height vertical-reference through the measure gate and scan report (P1 #6)

### DIFF
--- a/src/analysis/modules/scanReport.ts
+++ b/src/analysis/modules/scanReport.ts
@@ -3,6 +3,7 @@ import type { PointCloud } from '../../model/PointCloud';
 import type { ClassScope } from '../../render/class/classScope';
 import type { CrsLinearUnit } from '../../io/crs';
 import { isZUpFormat } from '../../io/sniffFormat';
+import { heightLabel, verticalReferenceFromDatum } from '../../geo/height';
 
 function rowInfo(label: string, value: string): AnalysisRow {
   return { label, value, status: 'info' };
@@ -278,6 +279,28 @@ export const scanReport: AnalysisModule = {
       `${(c[2] + origin[2]).toFixed(3)}`;
     rows.push({ label: 'Min corner', value: corner(bounds.min), status: 'info', advanced: true });
     rows.push({ label: 'Max corner', value: corner(bounds.max), status: 'info', advanced: true });
+
+    // The absolute corners carry an absolute Z, which asserts a vertical
+    // reference the reader cannot recover from the number alone. State it,
+    // honestly (roadmap P1 #6): a georeferenced scan whose file declares no —
+    // or an unrecognised — vertical datum reads "Height (datum unknown)" rather
+    // than letting the corner Z pass as a sea-level elevation, mirroring the
+    // Inspector's datum-honest Z label (#229) via the same classifier. Shown
+    // only when the file carried a CRS: a scan with none has purely local
+    // corners and no datum to name.
+    const crs = meta?.crs;
+    if (crs) {
+      const reference = verticalReferenceFromDatum({
+        verticalEpsg: crs.verticalEpsg,
+        verticalDatum: crs.verticalDatum,
+      });
+      rows.push({
+        label: 'Vertical reference',
+        value: heightLabel(reference),
+        status: 'info',
+        advanced: true,
+      });
+    }
 
     // (v0.5.5 P12 — the separate "Classification Coverage" diagnostic row
     // merged into the main Classification row above.)

--- a/src/app/measureConfidenceContext.ts
+++ b/src/app/measureConfidenceContext.ts
@@ -4,6 +4,7 @@
  * call and the fail-closed choices are documented here, next to the types
  * they feed (src/render/measure/measureConfidence.ts).
  */
+import { verticalReferenceFromDatum } from '../geo/height';
 import type { MeasureSceneContext } from '../render/measure/measureConfidence';
 
 export function buildMeasureConfidenceContext(
@@ -13,13 +14,33 @@ export function buildMeasureConfidenceContext(
     /** Loaded static clouds. */
     clouds(): ReadonlyArray<unknown>;
   },
-  resolvedCrs: { readonly verticalDatum?: string | null } | null | undefined,
+  resolvedCrs:
+    | {
+        readonly verticalEpsg?: number | null;
+        readonly verticalDatum?: string | null;
+      }
+    | null
+    | undefined,
 ): MeasureSceneContext {
+  // Roadmap P1 #6: a height/volume measurement is only "datum resolved" when
+  // the vertical reference is actually KNOWN — not merely when a datum STRING
+  // is present. `verticalReferenceFromDatum` fails closed on a datum that is
+  // undeclared OR present-but-unrecognised (both → 'unknown'), and admits a
+  // recognised ellipsoidal / orthometric / depth reference. The old
+  // `verticalDatum != null` check upgraded an unclassifiable datum string to
+  // "known", so a height measured over a reference we cannot name still read
+  // "verified · datum resolved" — the same over-claim #229 removed from the
+  // Inspector's Z label. This reuses that module's classifier, so the measure
+  // tool and the Inspector never disagree about what a datum is.
+  const reference = verticalReferenceFromDatum({
+    verticalEpsg: resolvedCrs?.verticalEpsg ?? undefined,
+    verticalDatum: resolvedCrs?.verticalDatum ?? undefined,
+  });
   return {
     datumResolved: viewer.measure.datumResolved,
     // Fail-closed: a multi-layer scene reads as an unproven combined context
     // until the compatibility ladder upgrades it (layerContextOf).
     layers: viewer.clouds().length <= 1 ? 'single' : 'mixed',
-    verticalReferenceKnown: (resolvedCrs?.verticalDatum ?? null) !== null,
+    verticalReferenceKnown: reference !== 'unknown',
   };
 }

--- a/tests/measureConfidenceContext.test.ts
+++ b/tests/measureConfidenceContext.test.ts
@@ -1,0 +1,99 @@
+/**
+ * measureConfidenceContext.test.ts
+ *
+ * `buildMeasureConfidenceContext` is the one seam that turns the live CRS into
+ * the measure tool's `verticalReferenceKnown` fact — the flag that decides
+ * whether a HEIGHT / VOLUME measurement reads "verified · datum resolved" or
+ * carries the "vertical reference unknown" caveat. Roadmap P1 #6 routes it
+ * through `verticalReferenceFromDatum` (the same classifier #229 gave the
+ * Inspector), so a datum that is undeclared OR present-but-unrecognised fails
+ * closed instead of quietly certifying a height it cannot name.
+ *
+ * Pure data in, pure data out, so it is unit-tested here against a minimal
+ * viewer stub rather than the live app.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildMeasureConfidenceContext } from '../src/app/measureConfidenceContext';
+import { confidenceForKind } from '../src/render/measure/measureConfidence';
+
+/** A minimal viewer stub: only the two facts the builder reads. */
+function viewer(datumResolved: boolean, cloudCount = 1) {
+  return {
+    measure: { datumResolved },
+    clouds: () => new Array(cloudCount).fill(null) as ReadonlyArray<unknown>,
+  };
+}
+
+describe('buildMeasureConfidenceContext — verticalReferenceKnown', () => {
+  it('is false when the scene has no CRS at all', () => {
+    expect(buildMeasureConfidenceContext(viewer(true), null).verticalReferenceKnown).toBe(false);
+    expect(buildMeasureConfidenceContext(viewer(true), undefined).verticalReferenceKnown).toBe(
+      false,
+    );
+  });
+
+  it('is false when the CRS declares no vertical datum', () => {
+    const ctx = buildMeasureConfidenceContext(viewer(true), { verticalDatum: null });
+    expect(ctx.verticalReferenceKnown).toBe(false);
+  });
+
+  it('is false for a present-but-UNRECOGNISED datum string (the fix — was true)', () => {
+    // Before P1 #6 the coarse `verticalDatum != null` check upgraded any
+    // non-null string to "known"; an unclassifiable datum must fail closed.
+    const ctx = buildMeasureConfidenceContext(viewer(true), {
+      verticalDatum: 'Local Mine Grid vertical',
+    });
+    expect(ctx.verticalReferenceKnown).toBe(false);
+  });
+
+  it('is true for a recognised orthometric datum name (NAVD88)', () => {
+    const ctx = buildMeasureConfidenceContext(viewer(true), { verticalDatum: 'NAVD88' });
+    expect(ctx.verticalReferenceKnown).toBe(true);
+  });
+
+  it('is true for a recognised vertical EPSG code (5703 = NAVD88)', () => {
+    const ctx = buildMeasureConfidenceContext(viewer(true), { verticalEpsg: 5703 });
+    expect(ctx.verticalReferenceKnown).toBe(true);
+  });
+
+  it('is true for a recognised ellipsoidal reference (WGS 84 3D, EPSG:4979)', () => {
+    // An ellipsoidal height IS a known reference — the height is well-defined
+    // even though it is not a sea-level elevation.
+    const ctx = buildMeasureConfidenceContext(viewer(true), { verticalEpsg: 4979 });
+    expect(ctx.verticalReferenceKnown).toBe(true);
+  });
+
+  it('is false for an unrecognised vertical EPSG code', () => {
+    const ctx = buildMeasureConfidenceContext(viewer(true), { verticalEpsg: 9999 });
+    expect(ctx.verticalReferenceKnown).toBe(false);
+  });
+});
+
+describe('buildMeasureConfidenceContext — datum / layer wiring', () => {
+  it('passes the controller datum-resolved fact through', () => {
+    expect(buildMeasureConfidenceContext(viewer(true), null).datumResolved).toBe(true);
+    expect(buildMeasureConfidenceContext(viewer(false), null).datumResolved).toBe(false);
+  });
+
+  it('reads a single/zero-cloud scene as `single` and a multi-cloud scene as `mixed`', () => {
+    expect(buildMeasureConfidenceContext(viewer(true, 1), null).layers).toBe('single');
+    expect(buildMeasureConfidenceContext(viewer(true, 0), null).layers).toBe('single');
+    expect(buildMeasureConfidenceContext(viewer(true, 2), null).layers).toBe('mixed');
+  });
+});
+
+describe('buildMeasureConfidenceContext — end-to-end confidence of a height measurement', () => {
+  it('a height over an unknown vertical reference reads approximate, and names why', () => {
+    const scene = buildMeasureConfidenceContext(viewer(true), { verticalDatum: 'Some unmapped datum' });
+    const c = confidenceForKind('height', scene);
+    expect(c.level).toBe('approximate');
+    if (c.level === 'approximate') expect(c.reason).toContain('vertical reference unknown');
+  });
+
+  it('a height over a recognised datum, single layer, resolved, reads verified', () => {
+    const scene = buildMeasureConfidenceContext(viewer(true), { verticalEpsg: 5703 });
+    const c = confidenceForKind('height', scene);
+    expect(c.level).toBe('verified');
+  });
+});

--- a/tests/scanReport.test.ts
+++ b/tests/scanReport.test.ts
@@ -265,4 +265,80 @@ describe('scanReport module', () => {
       expect(parseFloat(v)).toBeCloseTo(30.5, 0);
     });
   });
+
+  describe('vertical reference of the absolute corners (roadmap P1 #6)', () => {
+    // The advanced "Min/Max corner" rows are absolute georeferenced Z, so the
+    // report must state what that Z is measured from — not let it pass as a
+    // sea-level elevation. Mirrors the Inspector's datum-honest Z label (#229).
+    const positions = new Float32Array([0, 0, 0, 2, 0, 0, 0, 2, 0, 2, 2, 1]);
+    const cloudWith = (crs: Record<string, unknown> | undefined) =>
+      new PointCloud({
+        positions,
+        origin: [0, 0, 0],
+        sourceFormat: 'las',
+        name: 'vref',
+        ...(crs ? { metadata: { crs: crs as never } } : {}),
+      });
+
+    test('a georeferenced scan with NO declared vertical datum reads "Height (datum unknown)"', () => {
+      const cloud = cloudWith({
+        source: 'wkt',
+        name: 'WGS 84 / UTM zone 12N',
+        linearUnit: 'metre',
+        linearUnitToMetres: 1,
+        isGeographic: false,
+      });
+      expect(rowByLabel(scanReport.run(cloud), 'Vertical reference').value).toBe(
+        'Height (datum unknown)',
+      );
+    });
+
+    test('a recognised orthometric datum (NAVD88, EPSG:5703) reads "Elevation"', () => {
+      const cloud = cloudWith({
+        source: 'wkt',
+        name: 'NAD83 / UTM 12N + NAVD88 height',
+        linearUnit: 'metre',
+        linearUnitToMetres: 1,
+        isGeographic: false,
+        verticalEpsg: 5703,
+        verticalDatum: 'NAVD88',
+      });
+      expect(rowByLabel(scanReport.run(cloud), 'Vertical reference').value).toBe('Elevation');
+    });
+
+    test('WGS 84 3D (EPSG:4979) reads "Ellipsoidal height", not "Elevation"', () => {
+      const cloud = cloudWith({
+        source: 'epsg',
+        name: 'WGS 84 (3D)',
+        linearUnit: 'metre',
+        linearUnitToMetres: 1,
+        isGeographic: true,
+        verticalEpsg: 4979,
+      });
+      expect(rowByLabel(scanReport.run(cloud), 'Vertical reference').value).toBe(
+        'Ellipsoidal height',
+      );
+    });
+
+    test('a present-but-unrecognised vertical datum still reads "Height (datum unknown)"', () => {
+      const cloud = cloudWith({
+        source: 'wkt',
+        name: 'Some projected CRS',
+        linearUnit: 'metre',
+        linearUnitToMetres: 1,
+        isGeographic: false,
+        verticalDatum: 'Mine local vertical',
+      });
+      expect(rowByLabel(scanReport.run(cloud), 'Vertical reference').value).toBe(
+        'Height (datum unknown)',
+      );
+    });
+
+    test('a scan with NO CRS omits the row entirely (its corners are purely local)', () => {
+      const cloud = cloudWith(undefined);
+      expect(
+        scanReport.run(cloud).rows.find((r) => r.label === 'Vertical reference'),
+      ).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## What

Continues coordinate-integrity roadmap **P1 #6**, after #229 threaded the explicit `HeightValue` / `verticalReferenceFromDatum` type through the Inspector. This routes two more absolute-height consumers through the same `src/geo/height.ts` classifier, so a vertical datum that is **undeclared or present-but-unrecognised** fails closed instead of implying a sea-level elevation.

No parallel type: both consumers reuse `verticalReferenceFromDatum` / `heightLabel` from `src/geo/height.ts`.

## Consumers threaded

- **`src/app/measureConfidenceContext.ts`** — the measure tool's vertical-reference trust gate. `verticalReferenceKnown` was `verticalDatum != null`, which upgraded any non-null datum string (including one we can't classify) to "known", so a height/volume measurement over an unnameable reference still read *"verified · datum resolved"*. It now gates on `verticalReferenceFromDatum(...) !== 'unknown'` (reading `verticalEpsg` too). An unrecognised/undeclared datum now carries the *"vertical reference unknown"* caveat; a recognised ellipsoidal / orthometric / depth reference still reads known. `main.ts` already passes the full resolved CRS, so its call site is unchanged (no monolith growth).

- **`src/analysis/modules/scanReport.ts`** — the advanced *Min/Max corner* rows print an absolute georeferenced Z. Adds a **"Vertical reference"** row naming what that Z is measured from (*"Elevation"* / *"Ellipsoidal height"* / *"Height (datum unknown)"*), so the corner Z is not read as a sea-level elevation. Shown only when the file carried a CRS.

## Real mislabel fixed

The `measureConfidenceContext` change fixes a genuine over-claim: a scan whose vertical datum is present-but-unrecognised (or an ellipsoidal WGS 84 3D height labelled as a plain elevation elsewhere) previously certified a height measurement as datum-resolved. It now fails closed, matching the honesty #229 gave the Inspector.

## Tests

- New `tests/measureConfidenceContext.test.ts`: known datum reads normally; undeclared / unrecognised / unrecognised-EPSG datums read honestly; ellipsoidal is a known reference; end-to-end a height measurement over an unknown reference reads *approximate* and names why.
- Extended `tests/scanReport.test.ts`: NAVD88 → "Elevation", WGS 84 3D → "Ellipsoidal height", no/unrecognised datum → "Height (datum unknown)", no-CRS scan omits the row.

## Gates (all pass)

| gate | exit |
|---|---|
| `npx tsc --noEmit` | 0 |
| `npx vitest run` | 0 (7569 passed, 19 skipped, 1 todo) |
| `node scripts/lint-monolith-size.mjs` | 0 |
| `node scripts/lint-layer-boundaries.mjs` | 0 |
| `node scripts/lint-main-deferral.mjs` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)