### PR TITLE
Route CPU elevation filter through each cloud's own origin (P3)

### DIFF
--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -68,13 +68,12 @@ import { buildExportAdapter } from './exportAdapter';
 import { buildColorLegend, type ColorLegend } from './colorLegend';
 import { resolveSceneOrigin } from '../io/coordinateBridge';
 import type { ClassVisibility } from './class/classVisibility';
-import { buildPointFilterAccept } from './pointFilterAccept';
+import { buildPointFilterAccept, elevWindowFieldsFor } from './pointFilterAccept';
 import { PHI_CONJUGATE } from './streaming/fadeDither';
 import type { PointFilterWindow } from './pointFilterAccept';
 import { elevationFilterUniform, type UpAxis } from './elevationFilterUniform';
 import { ElevationFilterGpu } from './elevationFilterGpu';
 import {
-  elevWindowFor,
   elevWindowForMaterial,
   type ElevFallback,
   type ElevLayer,
@@ -3212,7 +3211,7 @@ export class Viewer {
         entry.cloud.positions,
         entry.cloud.classification,
         entry.cloud.intensity,
-        this._currentFilterWindow(),
+        this._currentFilterWindow(this._elevLayerOf(entry.cloud)),
       ),
     });
     const buf = entry.cloud.classification;
@@ -3543,11 +3542,15 @@ export class Viewer {
     this._bumpRenderActivity();
   }
 
+  /** ONE cloud's own origin + up-axis — the facts that decide its conversion. */
+  private _elevLayerOf(cloud: PointCloud): ElevFallback {
+    const axis: UpAxis = isZUpFormat(cloud.sourceFormat) ? 2 : 1;
+    return { originAlongAxis: cloud.origin[axis], axis };
+  }
   /** Each static layer with the two facts that decide its own conversion. */
   private *_elevLayers(): Generator<ElevLayer<THREE.PointsNodeMaterial>> {
     for (const entry of this._clouds.values()) {
-      const axis: UpAxis = isZUpFormat(entry.cloud.sourceFormat) ? 2 : 1;
-      yield { material: entry.material, originAlongAxis: entry.cloud.origin[axis], axis };
+      yield { material: entry.material, ...this._elevLayerOf(entry.cloud) };
     }
   }
 
@@ -5840,9 +5843,9 @@ export class Viewer {
     // Viewer's mesh-lifecycle plumbing.
     // Thread each node's class + intensity so the pick can obey the class,
     // elevation, and intensity filters (positions drive the elevation test).
-    // The per-node accept factory is passed only when SOME filter is active, so
-    // the all-visible hot path compares exactly as before (no per-point call).
-    const filterWindow = this._currentFilterWindow();
+    // The accept factory is passed only when SOME filter is active (hot path
+    // unchanged); streaming nodes share the streaming renderOrigin = primary layer.
+    const filterWindow = this._currentFilterWindow(this._primaryElevLayer());
     const anyFilter =
       filterWindow.classActive || filterWindow.elevActive || filterWindow.intenActive;
     const pick = selectStreamingPick(
@@ -5902,22 +5905,19 @@ export class Viewer {
   /**
    * Snapshot the active filter windows (class + elevation + intensity) in the
    * same spaces the GPU uniforms use, so a CPU accept predicate built from it
-   * rejects exactly the points the shader collapses to zero size. Read once per
-   * pick and shared across every candidate buffer.
+   * rejects exactly the points the shader collapses to zero size. Built for the
+   * given `layer`, so each cloud's elevation converts with ITS own origin/axis.
    */
-  private _currentFilterWindow(): PointFilterWindow {
-    // Pick resolves elevation against the PRIMARY cloud only, so with layers at
-    // different origins the GPU clips each correctly but pick and screen can
-    // disagree on a secondary layer. Stage C (docs/gate2-per-cloud-filter-plan.md).
-    const p = this._primaryElevLayer();
-    const primary = elevWindowFor(this._elevFilterWorld, p.originAlongAxis, p.axis);
+  private _currentFilterWindow(layer: ElevFallback): PointFilterWindow {
+    // Elevation converts with the PASSED layer's origin (class/intensity are origin-free).
+    const e = elevWindowFieldsFor(this._elevFilterWorld, layer.originAlongAxis, layer.axis);
     return {
       classActive: this._classFiltered,
       classMask: this._classMaskUniform.array as ArrayLike<number>,
       elevActive: this._elevGpu.isActive(),
-      elevAxisIdx: primary.axisIsZ === 1 ? 2 : 1,
-      elevMin: primary.min,
-      elevMax: primary.max,
+      elevAxisIdx: e.elevAxisIdx,
+      elevMin: e.elevMin,
+      elevMax: e.elevMax,
       intenActive: this._intenFilterEnabled.value !== 0,
       intenMin: this._intenFilterMin.value as number,
       intenMax: this._intenFilterMax.value as number,
@@ -5952,10 +5952,10 @@ export class Viewer {
 
     let best: { cloud: PointCloud; index: number; point: THREE.Vector3 } | null = null;
     let bestScore = Infinity;
-    const filterWindow = this._currentFilterWindow();
     for (const entry of this._clouds.values()) {
       const { mesh, cloud, locked, placement } = entry;
       if (!mesh.visible || locked) continue;
+      const filterWindow = this._currentFilterWindow(this._elevLayerOf(cloud)); // per-cloud origin
       // Placement fold (float64-transform.md step 3): the ray drops into the
       // layer's source frame, the pick runs over the raw positions unchanged,
       // and the hit lifts back. Identity returns the same tuples — a no-op.

--- a/src/render/pointFilterAccept.ts
+++ b/src/render/pointFilterAccept.ts
@@ -13,6 +13,8 @@
  */
 
 import { classVisibleAt } from './class/classMaskUniform';
+import { elevWindowFor } from './elevationWindowResolver';
+import type { UpAxis } from './elevationFilterUniform';
 
 /**
  * A snapshot of the active filter windows, in the SAME spaces the GPU uniforms
@@ -74,4 +76,32 @@ export function buildPointFilterAccept(
     }
     return true;
   };
+}
+
+/** The elevation portion of a {@link PointFilterWindow}, in one cloud's attribute space. */
+export interface ElevWindowFields {
+  /** Index into an interleaved xyz triple for the up axis: 2 = Z-up, 1 = Y-up. */
+  readonly elevAxisIdx: 1 | 2;
+  readonly elevMin: number;
+  readonly elevMax: number;
+}
+
+/**
+ * Convert a world-space elevation window into ONE cloud's attribute space using
+ * THAT cloud's origin and up-axis — the exact per-cloud conversion the GPU takes
+ * (`elevationWindowResolver.elevWindowFor`), so a CPU pick / lasso edit and the
+ * shader clip the same true height on EVERY layer, not just the primary one.
+ * Positions are stored origin-shifted, so a window converted with cloud A's
+ * origin tests cloud B (recentred elsewhere) at the wrong height — this is the
+ * seam that stops that. Reuses the resolver; it never forks a second convention.
+ * Off (`world === undefined`) still returns finite bounds (never consulted, since
+ * the caller gates on `elevActive`), matching the resolver and the shader.
+ */
+export function elevWindowFieldsFor(
+  world: readonly [number, number] | undefined,
+  originAlongAxis: number,
+  axis: UpAxis,
+): ElevWindowFields {
+  const w = elevWindowFor(world, originAlongAxis, axis);
+  return { elevAxisIdx: w.axisIsZ === 1 ? 2 : 1, elevMin: w.min, elevMax: w.max };
 }

--- a/tests/pointFilterAccept.test.ts
+++ b/tests/pointFilterAccept.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildPointFilterAccept } from '../src/render/pointFilterAccept';
+import { buildPointFilterAccept, elevWindowFieldsFor } from '../src/render/pointFilterAccept';
 import type { PointFilterWindow } from '../src/render/pointFilterAccept';
 
 /** A 256-entry all-visible class mask, optionally hiding some codes. */
@@ -146,5 +146,61 @@ describe('buildPointFilterAccept — per-cloud windows (Gate 2 Stage B contract)
     const zUpAcceptWrongAxis = buildPointFilterAccept(zUpPos, null, null,
       win({ elevActive: true, elevAxisIdx: 1, elevMin: 0, elevMax: 10 }));
     expect(zUpAcceptWrongAxis!(0)).toBe(false); // reads y=999, outside the window
+  });
+});
+
+describe('elevWindowFieldsFor — CPU world→attribute conversion (per-cloud)', () => {
+  // This pins the seam the Viewer's CPU pick / lasso path now goes through
+  // (`_currentFilterWindow(layer)`), mirroring elevationWindowResolver.test.ts's
+  // two-different-origins case but for the CPU accept path. The block above
+  // proves the PREDICATE honours two already-different windows; this proves the
+  // Viewer derives those two windows from ONE world range per cloud, closing the
+  // gap where a single primary-origin window was reused for every cloud.
+
+  it('subtracts the cloud origin along the up-axis (attr = world - origin), matching the resolver', () => {
+    // Same fixture as the resolver test: Cloud A, Z origin 195, world [198, 202].
+    expect(elevWindowFieldsFor([198, 202], 195, 2)).toEqual({ elevAxisIdx: 2, elevMin: 3, elevMax: 7 });
+  });
+
+  it('maps the up-axis to the position component: Z-up -> 2, Y-up -> 1', () => {
+    expect(elevWindowFieldsFor([10, 20], 0, 2).elevAxisIdx).toBe(2);
+    expect(elevWindowFieldsFor([10, 20], 0, 1).elevAxisIdx).toBe(1);
+  });
+
+  it('still returns finite bounds when the filter is off (undefined range)', () => {
+    // The accept predicate gates on `elevActive`, so an off window is never
+    // consulted — but it must be a real window, never NaN, matching the resolver.
+    const w = elevWindowFieldsFor(undefined, 195, 2);
+    expect(Number.isFinite(w.elevMin)).toBe(true);
+    expect(Number.isFinite(w.elevMax)).toBe(true);
+  });
+
+  it('gives two clouds at different origins two windows that accept the SAME true-height point', () => {
+    // The core CPU-path guarantee. gate2-origin-a: Z origin 195; gate2-origin-b:
+    // Z origin 150. ONE world window [198, 202] must convert per cloud, so a real
+    // point at true world Z=200 (stored origin-shifted: 5 in A, 50 in B) is
+    // accepted by BOTH — the whole point of routing each cloud through its own
+    // origin instead of the primary's.
+    const world: [number, number] = [198, 202];
+    const a = elevWindowFieldsFor(world, 195, 2);
+    const b = elevWindowFieldsFor(world, 150, 2);
+    expect(a).toEqual({ elevAxisIdx: 2, elevMin: 3, elevMax: 7 });
+    expect(b).toEqual({ elevAxisIdx: 2, elevMin: 48, elevMax: 52 });
+    expect(a.elevMin).not.toBe(b.elevMin);
+
+    const posA = new Float32Array([0, 0, 200 - 195]); // 5
+    const posB = new Float32Array([0, 0, 200 - 150]); // 50
+    const base = { classActive: false, classMask: null, intenActive: false, intenMin: 0, intenMax: 0 } as const;
+    expect(buildPointFilterAccept(posA, null, null, { ...base, elevActive: true, ...a })!(0)).toBe(true);
+    expect(buildPointFilterAccept(posB, null, null, { ...base, elevActive: true, ...b })!(0)).toBe(true);
+
+    // The Stage-A CPU bug this fix closes: cloud B's point tested against cloud
+    // A's window (one shared/primary origin) is wrongly rejected — 50 ∉ [3, 7].
+    expect(buildPointFilterAccept(posB, null, null, { ...base, elevActive: true, ...a })!(0)).toBe(false);
+  });
+
+  it('reads the correct component for a Z-up cloud beside a Y-up cloud from one world window', () => {
+    expect(elevWindowFieldsFor([12, 17], 10, 2).elevAxisIdx).toBe(2); // survey, Z-up
+    expect(elevWindowFieldsFor([12, 17], 10, 1).elevAxisIdx).toBe(1); // phone, Y-up
   });
 });


### PR DESCRIPTION
## What

Closes the **CPU** side of the per-cloud elevation-filter gap (roadmap P3). The GPU/shader path already converts a world-space elevation window into each cloud's own attribute space via `elevationWindowResolver`; the CPU pick / lasso / point-info path did not.

## The gap (file:line)

`Viewer._currentFilterWindow()` resolved the elevation window **once** against the PRIMARY cloud's origin/up-axis (`src/render/Viewer.ts`, old line 5912-5913, `const p = this._primaryElevLayer()`) and reused that single window for every cloud. Its own comment admitted it: *"Pick resolves elevation against the PRIMARY cloud only ... pick and screen can disagree on a secondary layer. Stage C."*

Because positions are stored origin-shifted, a layer recentred on a different origin was tested against the wrong true height. Two consumers were affected:

- **Static multi-cloud pick** (`_pickDetailed`): one window built before the loop, applied to every static cloud.
- **Lasso reclassify** (`applyLassoReclassify`): primary-origin window applied to a specific `entry.cloud` — a **permanent edit** at the wrong height.

The streaming pick (`_pickStreamingDetailed`) was already correct: every streaming node shares the streaming cloud's `renderOrigin` = primary.

## The fix

- New pure helper `elevWindowFieldsFor(world, originAlongAxis, axis)` in `src/render/pointFilterAccept.ts` (the CPU module), which **reuses** the resolver's `elevWindowFor` — no second convention.
- `_currentFilterWindow(layer)` now takes the target layer and converts elevation for it. Class + intensity are origin-independent and unchanged.
- New `_elevLayerOf(cloud)` gives one cloud's `{originAlongAxis, axis}`; `_elevLayers()` reuses it.
- Static pick resolves the window **per candidate cloud** inside the loop; lasso passes `entry.cloud`'s layer; streaming passes the primary layer explicitly.

## Shader path unchanged

`elevationFilterGpu.ts`, `elevationWindowResolver.ts`, and the constructor's `setWindowResolver` wiring are untouched. `Viewer.ts` stays within its shrink ratchet (6419).

## Test

Adds a regression block to `tests/pointFilterAccept.test.ts` mirroring `elevationWindowResolver.test.ts`'s two-different-origins case, but for the CPU path: one world window `[198,202]` converts to two different attribute windows (origins 195 vs 150), the same true-height point (world Z=200) is accepted by **both** clouds' predicates, and the shared-origin window wrongly rejects one — the exact false negative the fix prevents.

## Gates

| gate | exit |
|---|---|
| `tsc --noEmit` | 0 |
| `vitest run` (7684 passed) | 0 |
| `lint-monolith-size` | 0 |
| `lint-layer-boundaries` | 0 |
| `lint-main-deferral` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)