### PR TITLE
Route the display-tier consumers (inspector, scan report) through SpatialContext (P2 #1, #2)

### DIFF
--- a/src/analysis/modules/scanReport.ts
+++ b/src/analysis/modules/scanReport.ts
@@ -1,10 +1,10 @@
 import type { AnalysisModule, AnalysisResult, AnalysisRow, RunOptions } from '../ModuleApi';
 import type { PointCloud } from '../../model/PointCloud';
 import type { ClassScope } from '../../render/class/classScope';
-import type { CrsLinearUnit } from '../../io/crs';
-import { isLinearUnitKnown } from '../../geo/CoordinateTypes';
+import type { SpatialContext } from '../../geo/SpatialContext';
+import { spatialContextFrom } from '../../geo/SpatialContext';
 import { isZUpFormat } from '../../io/sniffFormat';
-import { heightLabel, verticalReferenceFromDatum } from '../../geo/height';
+import { heightLabel } from '../../geo/height';
 
 function rowInfo(label: string, value: string): AnalysisRow {
   return { label, value, status: 'info' };
@@ -29,13 +29,6 @@ function formatLength(metres: number): string {
   return metres < 1 ? `${(metres * 100).toFixed(1)} cm` : `${metres.toFixed(2)} m`;
 }
 
-/** The minimal CRS shape the unit basis reads — a subset of `CrsInfo`. */
-type UnitCrs = {
-  readonly linearUnit?: CrsLinearUnit;
-  readonly linearUnitToMetres?: number;
-  readonly verticalUnitToMetres?: number;
-} | null | undefined;
-
 /** Source→metre factors and unit labels for the extent block. */
 export interface ScanReportUnitBasis {
   /** Whether the CRS declares a real, resolved linear unit (metres claimable). */
@@ -58,17 +51,24 @@ export interface ScanReportUnitBasis {
  * unknown-unit CRS carries the inert placeholder `linearUnitToMetres: 1`, and
  * a CRS-less cloud resolves the same way — multiplying a source span by that 1
  * and stamping "m" would report non-metre data (feet, or even degrees for a
- * geographic CRS) as metres. So metres are claimed only when
- * `crs != null && crs.linearUnit !== 'unknown'`, the same canonical gate the
- * streaming report (`streamingExtentRows`), the space report (`spaceMetrics`),
- * the measure tool and the lasso already apply. When the unit is unconfirmed
- * the factor stays 1, the raw source span is shown, and the "m" / "pts/m²"
- * claim is withheld.
+ * geographic CRS) as metres. So metres are claimed only when the one
+ * {@link SpatialContext} says the linear unit is real — `ctx.linearUnitKnown` —
+ * the same canonical gate the streaming report (`streamingExtentRows`), the
+ * space report (`spaceMetrics`), the measure tool and the lasso already apply
+ * (each is `isLinearUnitKnown`, which the façade wraps). When the unit is
+ * unconfirmed the factor stays 1, the raw source span is shown, and the "m" /
+ * "pts/m²" claim is withheld.
+ *
+ * NOTE: the gate is `linearUnitKnown`, NOT `metricClaimsPermitted`. The two agree
+ * on every well-formed CRS but diverge on a corrupt `linearUnit: 'metre'` with a
+ * non-finite `linearUnitToMetres`, where the ladder blocks the metric headline
+ * yet the unit name is still "known"; the report's fail-closed rule keys off the
+ * declared unit, so preserving the prior behaviour means reading `linearUnitKnown`.
  */
-export function scanReportUnitBasis(crs: UnitCrs): ScanReportUnitBasis {
-  const unitKnown = isLinearUnitKnown(crs);
-  const mpu = unitKnown ? (crs?.linearUnitToMetres ?? 1) : 1;
-  const vmpu = unitKnown ? (crs?.verticalUnitToMetres ?? mpu) : 1;
+export function scanReportUnitBasis(ctx: SpatialContext): ScanReportUnitBasis {
+  const unitKnown = ctx.linearUnitKnown;
+  const mpu = unitKnown ? ctx.linearUnitToMetres : 1;
+  const vmpu = unitKnown ? (ctx.verticalUnitToMetres ?? mpu) : 1;
   return {
     unitKnown,
     mpu,
@@ -161,7 +161,11 @@ export const scanReport: AnalysisModule = {
     // would report non-metre data — feet, or even degrees for a geographic CRS —
     // as metres. When unconfirmed, the factor stays 1, the raw source span is
     // shown, and the "m" / "pts/m²" claim is withheld (matches #218/#220).
-    const basis = scanReportUnitBasis(cloud.metadata?.crs);
+    // Build the one SpatialContext for this report and hand it down, rather than
+    // letting the extent block and the vertical-reference row each re-read the
+    // CRS: both the unit gate and the datum classification now come from `ctx`.
+    const ctx = spatialContextFrom(cloud.metadata?.crs);
+    const basis = scanReportUnitBasis(ctx);
     const { mpu, vmpu } = basis;
     // Footprint and height are axis-aware. LAS-family (and COPC/EPT) are Z-up
     // by spec, so the ground footprint is X·Y and height is Z. Mesh formats
@@ -287,16 +291,14 @@ export const scanReport: AnalysisModule = {
     // than letting the corner Z pass as a sea-level elevation, mirroring the
     // Inspector's datum-honest Z label (#229) via the same classifier. Shown
     // only when the file carried a CRS: a scan with none has purely local
-    // corners and no datum to name.
-    const crs = meta?.crs;
-    if (crs) {
-      const reference = verticalReferenceFromDatum({
-        verticalEpsg: crs.verticalEpsg,
-        verticalDatum: crs.verticalDatum,
-      });
+    // corners and no datum to name. The datum → reference classification is read
+    // from the same `ctx` as the extent block (behaviour-identical to the prior
+    // direct `verticalReferenceFromDatum` call over these same datum fields), so
+    // the report and the inspector can never disagree about what a datum means.
+    if (meta?.crs) {
       rows.push({
         label: 'Vertical reference',
-        value: heightLabel(reference),
+        value: heightLabel(ctx.verticalReference),
         status: 'info',
         advanced: true,
       });

--- a/src/geo/SpatialContext.ts
+++ b/src/geo/SpatialContext.ts
@@ -34,7 +34,7 @@
  */
 
 import type { CrsInfo, CrsLinearUnit } from '../io/crs';
-import type { CrsKind, CrsSource } from './CoordinateTypes';
+import type { CrsKind, CrsSource, ResolvedCrs } from './CoordinateTypes';
 import { isLinearUnitKnown, resolvedFromCrsInfo, unknownCrs } from './CoordinateTypes';
 import type { CrsValidity, CrsValiditySeverity } from './CrsValidation';
 import { validateCrsForMeasurement } from './CrsValidation';
@@ -155,22 +155,36 @@ export interface SpatialContextPlacement {
 }
 
 /**
- * Build a {@link SpatialContext} from the existing {@link CrsInfo} (the shape
- * `src/io/crs.ts` extracts) plus optional project-frame placement. A `null` /
- * `undefined` CRS fails closed: the context resolves to `unknown`, and
- * `metricClaimsPermitted` is `false`.
+ * Build a {@link SpatialContext} from either the raw {@link CrsInfo} (the shape
+ * `src/io/crs.ts` extracts) or an already-resolved {@link ResolvedCrs} (the shape
+ * most consumers hold, e.g. the inspector's coordinate context), plus optional
+ * project-frame placement. A `null` / `undefined` CRS fails closed: the context
+ * resolves to `unknown`, and `metricClaimsPermitted` is `false`.
+ *
+ * Accepting both inputs is what lets the ~13 consumers route through this one
+ * façade without hand-building anything: a `CrsInfo` is bridged through the
+ * canonical `resolvedFromCrsInfo` mapper, while a `ResolvedCrs` — which already
+ * carries the resolved `kind` (including `local` / `unknown`, which a `CrsInfo`
+ * cannot express) — is used directly rather than round-tripped and re-derived.
  *
  * This is a pure fan-out over already-merged predicates — it introduces no new
  * unit, datum, or validity logic of its own.
  */
 export function spatialContextFrom(
-  crs: CrsInfo | null | undefined,
+  crs: CrsInfo | ResolvedCrs | null | undefined,
   frame?: ProjectSpatialFrame,
   placement: SpatialContextPlacement = {},
 ): SpatialContext {
-  // Bridge CrsInfo → ResolvedCrs via the canonical mapper; a missing CRS is the
-  // explicit unknown case, which the ladder classifies as needs-confirmation.
-  const resolved = crs ? (resolvedFromCrsInfo(crs, FACADE_SOURCE) ?? unknownCrs()) : unknownCrs();
+  // A missing CRS is the explicit unknown case, which the ladder classifies as
+  // needs-confirmation. A ResolvedCrs (identified by its `kind` discriminant,
+  // which CrsInfo lacks) is already resolved and is used as-is; a CrsInfo is
+  // bridged CrsInfo → ResolvedCrs via the canonical mapper.
+  const resolved =
+    crs == null
+      ? unknownCrs()
+      : 'kind' in crs
+        ? crs
+        : (resolvedFromCrsInfo(crs, FACADE_SOURCE) ?? unknownCrs());
 
   const verdict = validateCrsForMeasurement(resolved);
   const linearUnitKnown = isLinearUnitKnown(resolved);

--- a/src/render/pointInfo.ts
+++ b/src/render/pointInfo.ts
@@ -14,8 +14,8 @@ import {
   type VerticalReference,
   heightLabel,
   makeHeight,
-  verticalReferenceFromDatum,
 } from '../geo/height';
+import { spatialContextFrom } from '../geo/SpatialContext';
 import { UNIT_FACTORS } from '../units/units';
 
 /**
@@ -95,12 +95,20 @@ function verticalAxisSuffix(verticalUnitToMetres: number | undefined, fallback: 
 
 /** Build the World-group labels + units for a resolved CRS (or undefined). */
 export function worldCoordLabels(crs: ResolvedCrs | undefined): WorldCoordLabels {
+  // The unit/kind decisions come from the one SpatialContext façade instead of
+  // being re-read off `crs` here — so the inspector, the scan report, and every
+  // other consumer read the SAME horizontal-unit and vertical-scale facts. The
+  // façade uses a ResolvedCrs directly, so `ctx.kind`, `ctx.linearUnit`,
+  // `ctx.verticalUnitToMetres`, and `ctx.crsName` are byte-identical to the
+  // `crs.*` fields this used to read (and `undefined` resolves to `kind:
+  // 'unknown'`, matching the old `!crs` guard).
+  const ctx = spatialContextFrom(crs);
   // No CRS, local, or unknown: the coordinates are in the file's own units,
   // whose scale we do NOT know — assert no unit rather than fabricate metres.
-  if (!crs || crs.kind === 'local' || crs.kind === 'unknown') {
+  if (ctx.kind === 'local' || ctx.kind === 'unknown') {
     return { heading: 'World', x: 'X', y: 'Y', z: 'Z', xUnit: '', yUnit: '', zUnit: '' };
   }
-  if (crs.kind === 'geographic') {
+  if (ctx.kind === 'geographic') {
     return {
       heading: 'World (geographic)',
       x: 'Longitude',
@@ -110,7 +118,7 @@ export function worldCoordLabels(crs: ResolvedCrs | undefined): WorldCoordLabels
       yUnit: '°',
       // Elevation is metres by the geographic convention, UNLESS the file
       // declared a distinct (e.g. foot) vertical unit — then honour that.
-      zUnit: verticalAxisSuffix(crs.verticalUnitToMetres, ' m'),
+      zUnit: verticalAxisSuffix(ctx.verticalUnitToMetres, ' m'),
     };
   }
   // Projected: the axis unit is the CRS's own linear unit, so a foot-based CRS
@@ -118,15 +126,15 @@ export function worldCoordLabels(crs: ResolvedCrs | undefined): WorldCoordLabels
   // horizontal linear unit by default, but a CRS with a DISTINCT declared
   // vertical unit (e.g. metre easting/northing over a foot height) now reports
   // the elevation in its own unit rather than inheriting the horizontal one.
-  const suffix = linearAxisSuffix(crs.linearUnit);
+  const suffix = linearAxisSuffix(ctx.linearUnit);
   return {
-    heading: `World (${crs.name})`,
+    heading: `World (${ctx.crsName})`,
     x: 'Easting',
     y: 'Northing',
     z: 'Elevation',
     xUnit: suffix,
     yUnit: suffix,
-    zUnit: verticalAxisSuffix(crs.verticalUnitToMetres, suffix),
+    zUnit: verticalAxisSuffix(ctx.verticalUnitToMetres, suffix),
   };
 }
 
@@ -138,12 +146,17 @@ export function worldCoordLabels(crs: ResolvedCrs | undefined): WorldCoordLabels
  * `'unknown'` when none is declared — never upgraded to a datum it never had).
  */
 export function pointVerticalReference(crs: ResolvedCrs | undefined): VerticalReference {
+  // Frame classes first: 'local' and 'unknown' are properties of the coordinate
+  // frame, not of a datum, so they are decided here — the façade never returns
+  // 'local' (per height.ts) and would flatten a local frame to 'unknown'.
   if (!crs || crs.kind === 'unknown') return 'unknown';
   if (crs.kind === 'local') return 'local';
-  return verticalReferenceFromDatum({
-    verticalEpsg: crs.verticalEpsg,
-    verticalDatum: crs.verticalDatum,
-  });
+  // Datum → reference now reads the single SpatialContext definition instead of a
+  // second direct `verticalReferenceFromDatum` call. Behaviour-identical: the
+  // façade computes `verticalReference` as exactly
+  // `verticalReferenceFromDatum({ verticalEpsg, verticalDatum })` over these same
+  // fields, so the inspector and the façade can never disagree about a datum.
+  return spatialContextFrom(crs).verticalReference;
 }
 
 /**
@@ -153,7 +166,14 @@ export function pointVerticalReference(crs: ResolvedCrs | undefined): VerticalRe
  * inspector carry a typed height end to end instead of a bare "elevation" number.
  */
 export function pointHeight(z: number, crs: ResolvedCrs | undefined): HeightValue {
-  return makeHeight(z, pointVerticalReference(crs), crs?.verticalUnitToMetres);
+  // Reference from the frame-aware helper; vertical scale from the same façade
+  // (`ctx.verticalUnitToMetres === crs?.verticalUnitToMetres`, so this is a pure
+  // re-route, not a behaviour change).
+  return makeHeight(
+    z,
+    pointVerticalReference(crs),
+    spatialContextFrom(crs).verticalUnitToMetres,
+  );
 }
 
 /**

--- a/tests/pointInfo.test.ts
+++ b/tests/pointInfo.test.ts
@@ -10,8 +10,17 @@ import {
   normalText,
   pointInfoCopyText,
   pointInfoJson,
+  worldCoordLabels,
+  pointVerticalReference,
+  pointHeight,
+  heightRowLabel,
 } from '../src/render/pointInfo';
 import type { RawPointInfo } from '../src/render/pointInfo';
+import type { CrsInfo } from '../src/io/crs';
+import type { ResolvedCrs } from '../src/geo/CoordinateTypes';
+import { resolvedFromCrsInfo, localCrs, unknownCrs } from '../src/geo/CoordinateTypes';
+import { verticalReferenceFromDatum } from '../src/geo/height';
+import { spatialContextFrom } from '../src/geo/SpatialContext';
 
 /** A raw picked point with every attribute present (origin at zero). */
 function fullRaw(): RawPointInfo {
@@ -317,5 +326,118 @@ describe('makePointInfo — geographic horizontal precision', () => {
   it('shows the defect scale without the flag: the 7th decimal is destroyed', () => {
     const info = makePointInfo(raw());
     expect(info.x).toBe(-111.045); // ~40 m of longitude gone at this latitude
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// CRS-derived display facts routed through SpatialContext (P2 coordinate-integrity)
+//
+// worldCoordLabels / pointVerticalReference / pointHeight now read their
+// unit-suffix and datum-reference decisions off `spatialContextFrom(crs)` rather
+// than re-deriving them inline. These tests pin the routed path across the
+// unit × vertical-datum × frame matrix AND assert it is byte-identical to the
+// prior inline derivation (verticalReferenceFromDatum over the same fields).
+// ────────────────────────────────────────────────────────────────────────────
+
+/** A projected/geographic ResolvedCrs from a CrsInfo (the inspector's shape). */
+function resolved(over: Partial<CrsInfo>): ResolvedCrs {
+  const info: CrsInfo = {
+    source: 'wkt',
+    name: 'Matrix CRS',
+    linearUnit: 'metre',
+    linearUnitToMetres: 1,
+    isGeographic: false,
+    ...over,
+  };
+  const r = resolvedFromCrsInfo(info, 'las-vlr');
+  if (!r) throw new Error('resolvedFromCrsInfo returned null for a defined CrsInfo');
+  return r;
+}
+
+const US_SURVEY_FOOT = 1200 / 3937;
+
+describe('worldCoordLabels — unit suffixes routed through the façade', () => {
+  it.each([
+    { name: 'undefined CRS', crs: undefined, xUnit: '', yUnit: '', zUnit: '', heading: 'World' },
+    { name: 'local frame', crs: localCrs(), xUnit: '', yUnit: '', zUnit: '', heading: 'World' },
+    { name: 'unknown CRS', crs: unknownCrs(), xUnit: '', yUnit: '', zUnit: '', heading: 'World' },
+    { name: 'projected metre', crs: resolved({ linearUnit: 'metre', linearUnitToMetres: 1 }), xUnit: ' m', yUnit: ' m', zUnit: ' m', heading: 'World (Matrix CRS)' },
+    { name: 'projected intl-foot', crs: resolved({ linearUnit: 'foot', linearUnitToMetres: 0.3048 }), xUnit: ' ft', yUnit: ' ft', zUnit: ' ft', heading: 'World (Matrix CRS)' },
+    { name: 'projected us-survey-foot', crs: resolved({ linearUnit: 'us-survey-foot', linearUnitToMetres: US_SURVEY_FOOT }), xUnit: ' ft', yUnit: ' ft', zUnit: ' ft', heading: 'World (Matrix CRS)' },
+    { name: 'projected unknown-unit → no fabricated metres', crs: resolved({ linearUnit: 'unknown', linearUnitToMetres: 1 }), xUnit: '', yUnit: '', zUnit: '', heading: 'World (Matrix CRS)' },
+    { name: 'geographic → degrees, elevation metres', crs: resolved({ linearUnit: 'unknown', linearUnitToMetres: 1, isGeographic: true }), xUnit: '°', yUnit: '°', zUnit: ' m', heading: 'World (geographic)' },
+  ])('$name', ({ crs, xUnit, yUnit, zUnit, heading }) => {
+    const labels = worldCoordLabels(crs);
+    expect(labels.xUnit).toBe(xUnit);
+    expect(labels.yUnit).toBe(yUnit);
+    expect(labels.zUnit).toBe(zUnit);
+    expect(labels.heading).toBe(heading);
+  });
+
+  it('honours a DISTINCT declared vertical unit on the Z axis (metre grid, foot height)', () => {
+    const metreGridFootHeight = resolved({ linearUnit: 'metre', linearUnitToMetres: 1, verticalUnitToMetres: 0.3048 });
+    expect(worldCoordLabels(metreGridFootHeight).xUnit).toBe(' m');
+    expect(worldCoordLabels(metreGridFootHeight).zUnit).toBe(' ft');
+    // Geographic base with a declared foot height → degrees horizontal, feet Z.
+    const geoFootHeight = resolved({ isGeographic: true, linearUnit: 'unknown', linearUnitToMetres: 1, verticalUnitToMetres: 0.3048 });
+    expect(worldCoordLabels(geoFootHeight).xUnit).toBe('°');
+    expect(worldCoordLabels(geoFootHeight).zUnit).toBe(' ft');
+  });
+});
+
+describe('pointVerticalReference — datum reference routed through the façade', () => {
+  // Frame classes are decided in the consumer (the façade never returns 'local').
+  it('undefined / unknown → unknown; local → local', () => {
+    expect(pointVerticalReference(undefined)).toBe('unknown');
+    expect(pointVerticalReference(unknownCrs())).toBe('unknown');
+    expect(pointVerticalReference(localCrs())).toBe('local');
+  });
+
+  const datumCells: { name: string; over: Partial<CrsInfo>; expected: string }[] = [
+    { name: 'orthometric (NAVD88, EPSG:5703)', over: { verticalEpsg: 5703, verticalDatum: 'NAVD88' }, expected: 'orthometric' },
+    { name: 'ellipsoidal (EPSG:4979)', over: { isGeographic: true, linearUnit: 'unknown', verticalEpsg: 4979, verticalDatum: 'EPSG:4979' }, expected: 'ellipsoidal' },
+    { name: 'no declared datum → unknown', over: {}, expected: 'unknown' },
+    { name: 'present-but-unrecognised datum → unknown', over: { verticalDatum: 'Some local vertical' }, expected: 'unknown' },
+  ];
+
+  it.each(datumCells)('$name', ({ over, expected }) => {
+    const crs = resolved(over);
+    expect(pointVerticalReference(crs)).toBe(expected);
+    // Byte-identical to the prior inline derivation …
+    expect(pointVerticalReference(crs)).toBe(
+      verticalReferenceFromDatum({ verticalEpsg: crs.verticalEpsg, verticalDatum: crs.verticalDatum }),
+    );
+    // … and to the single façade field the consumer now reads.
+    expect(pointVerticalReference(crs)).toBe(spatialContextFrom(crs).verticalReference);
+  });
+});
+
+describe('pointHeight — reference + vertical scale routed through the façade', () => {
+  it('carries the frame-aware reference and the CRS vertical scale', () => {
+    const metreGridFootHeight = resolved({ linearUnit: 'metre', verticalEpsg: 5703, verticalDatum: 'NAVD88', verticalUnitToMetres: 0.3048 });
+    const h = pointHeight(100, metreGridFootHeight);
+    expect(h.reference).toBe('orthometric');
+    expect(h.metresPerUnit).toBe(0.3048);
+    expect(h.value).toBe(100);
+  });
+
+  it('an undeclared vertical scale stays undefined (never read as metres)', () => {
+    expect(pointHeight(5, resolved({ linearUnit: 'metre' })).metresPerUnit).toBeUndefined();
+    expect(pointHeight(5, undefined).metresPerUnit).toBeUndefined();
+    expect(pointHeight(5, undefined).reference).toBe('unknown');
+    expect(pointHeight(5, localCrs()).reference).toBe('local');
+  });
+});
+
+describe('heightRowLabel — datum-honest Z label via the routed reference', () => {
+  it.each([
+    { name: 'undefined → neutral Z', crs: undefined, label: 'Z' },
+    { name: 'local → neutral Z', crs: localCrs(), label: 'Z' },
+    { name: 'unknown → neutral Z', crs: unknownCrs(), label: 'Z' },
+    { name: 'orthometric → Elevation', crs: resolved({ verticalEpsg: 5703, verticalDatum: 'NAVD88' }), label: 'Elevation' },
+    { name: 'ellipsoidal → Ellipsoidal height', crs: resolved({ isGeographic: true, linearUnit: 'unknown', verticalEpsg: 4979 }), label: 'Ellipsoidal height' },
+    { name: 'no datum → Height (datum unknown)', crs: resolved({ linearUnit: 'metre' }), label: 'Height (datum unknown)' },
+  ])('$name', ({ crs, label }) => {
+    expect(heightRowLabel(crs)).toBe(label);
   });
 });

--- a/tests/scanReportUnits.test.ts
+++ b/tests/scanReportUnits.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect, test } from 'vitest';
 import { scanReport, scanReportUnitBasis } from '../src/analysis/modules/scanReport';
 import { PointCloud } from '../src/model/PointCloud';
 import type { CrsInfo } from '../src/io/crs';
+import { spatialContextFrom } from '../src/geo/SpatialContext';
 
 function rowByLabel(result: ReturnType<typeof scanReport.run>, label: string) {
   const row = result.rows.find((r) => r.label === label);
@@ -22,9 +23,29 @@ function rowByLabel(result: ReturnType<typeof scanReport.run>, label: string) {
   return row;
 }
 
-describe('scanReportUnitBasis — fail-closed unit gate', () => {
+/** Wrap a CrsInfo (or its absence) through the façade the basis now reads. */
+const basisFor = (crs: CrsInfo | null | undefined) =>
+  scanReportUnitBasis(spatialContextFrom(crs));
+
+/** A CrsInfo for `unit`, projected unless flagged geographic. */
+const crsWith = (
+  linearUnit: CrsInfo['linearUnit'],
+  linearUnitToMetres: number,
+  over: Partial<CrsInfo> = {},
+): CrsInfo => ({
+  source: 'wkt',
+  name: `${linearUnit} CRS`,
+  linearUnit,
+  linearUnitToMetres,
+  isGeographic: false,
+  ...over,
+});
+
+const US_SURVEY_FOOT = 1200 / 3937;
+
+describe('scanReportUnitBasis — fail-closed unit gate (routed via spatialContextFrom)', () => {
   test('metre CRS: confirmed, factor 1, "m" / "pts/m²"', () => {
-    const b = scanReportUnitBasis({ linearUnit: 'metre', linearUnitToMetres: 1 });
+    const b = basisFor(crsWith('metre', 1));
     expect(b.unitKnown).toBe(true);
     expect(b.mpu).toBe(1);
     expect(b.vmpu).toBe(1);
@@ -33,7 +54,7 @@ describe('scanReportUnitBasis — fail-closed unit gate', () => {
   });
 
   test('foot CRS: confirmed, applies the 0.3048 factor', () => {
-    const b = scanReportUnitBasis({ linearUnit: 'foot', linearUnitToMetres: 0.3048 });
+    const b = basisFor(crsWith('foot', 0.3048));
     expect(b.unitKnown).toBe(true);
     expect(b.mpu).toBeCloseTo(0.3048, 6);
     expect(b.vmpu).toBeCloseTo(0.3048, 6); // vertical falls back to the horizontal factor
@@ -41,7 +62,7 @@ describe('scanReportUnitBasis — fail-closed unit gate', () => {
   });
 
   test('unknown-unit CRS: fails closed to source units despite the placeholder factor', () => {
-    const b = scanReportUnitBasis({ linearUnit: 'unknown', linearUnitToMetres: 1 });
+    const b = basisFor(crsWith('unknown', 1));
     expect(b.unitKnown).toBe(false);
     expect(b.mpu).toBe(1);
     expect(b.vmpu).toBe(1);
@@ -51,11 +72,41 @@ describe('scanReportUnitBasis — fail-closed unit gate', () => {
 
   test('CRS-less (null / undefined): fails closed exactly like unknown', () => {
     for (const crs of [null, undefined]) {
-      const b = scanReportUnitBasis(crs);
+      const b = basisFor(crs);
       expect(b.unitKnown).toBe(false);
       expect(b.mpu).toBe(1);
       expect(b.lengthUnit).toBe(' (source units)');
     }
+  });
+
+  // The routed gate keys off `ctx.linearUnitKnown` across the full unit matrix.
+  // Each cell is the same verdict the pre-routing `isLinearUnitKnown(crs)` gate
+  // produced, proving the swap is behaviour-identical rather than a new rule.
+  it.each([
+    { name: 'metre', crs: crsWith('metre', 1), unitKnown: true, mpu: 1 },
+    { name: 'intl-foot', crs: crsWith('foot', 0.3048), unitKnown: true, mpu: 0.3048 },
+    { name: 'us-survey-foot', crs: crsWith('us-survey-foot', US_SURVEY_FOOT), unitKnown: true, mpu: US_SURVEY_FOOT },
+    { name: 'unknown-unit (projected)', crs: crsWith('unknown', 1), unitKnown: false, mpu: 1 },
+    { name: 'geographic (degrees)', crs: crsWith('unknown', 1, { isGeographic: true, name: 'WGS 84' }), unitKnown: false, mpu: 1 },
+  ])('unit matrix — $name', ({ crs, unitKnown, mpu }) => {
+    const b = basisFor(crs);
+    expect(b.unitKnown).toBe(unitKnown);
+    expect(b.mpu).toBeCloseTo(mpu, 9);
+    expect(b.lengthUnit).toBe(unitKnown ? ' m' : ' (source units)');
+    expect(b.densityUnit).toBe(unitKnown ? ' pts/m²' : ' pts/unit²');
+  });
+
+  // The gate is `linearUnitKnown`, NOT `metricClaimsPermitted`: a corrupt metre
+  // CRS whose factor is non-finite has a KNOWN unit name (so the report still
+  // treats it as unit-confirmed, exactly as the old `isLinearUnitKnown` gate did)
+  // even though the measurement ladder would block a metric headline. Routing to
+  // `metricClaimsPermitted` here would silently flip this cell — this test pins
+  // the behaviour-preserving choice.
+  test('corrupt metre CRS (non-finite factor) stays unit-confirmed, like the old gate', () => {
+    const ctx = spatialContextFrom(crsWith('metre', 0));
+    expect(ctx.metricClaimsPermitted).toBe(false); // ladder blocks it…
+    expect(ctx.linearUnitKnown).toBe(true); // …but the unit name is still known
+    expect(scanReportUnitBasis(ctx).unitKnown).toBe(true); // report keys off the unit name
   });
 });
 

--- a/tests/spatialContext.test.ts
+++ b/tests/spatialContext.test.ts
@@ -23,6 +23,7 @@ import type { VerticalReference } from '../src/geo/height';
 import type { SpatialUpAxis } from '../src/geo/SpatialContext';
 import { spatialContextFrom } from '../src/geo/SpatialContext';
 import { createProjectFrame, layerTransform } from '../src/geo/ProjectSpatialFrame';
+import { resolvedFromCrsInfo, localCrs, unknownCrs } from '../src/geo/CoordinateTypes';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Matrix dimensions
@@ -284,5 +285,67 @@ describe('spatialContextFrom — project-frame placement', () => {
     expect(ctx.inProjectFrame).toBe(false);
     expect(ctx.projectFrame).toBeUndefined();
     expect(ctx.sourceToProject).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ResolvedCrs input — the shape most consumers (e.g. the inspector) actually
+// hold. The façade accepts it directly so those consumers can route without
+// hand-building a CrsInfo. A ResolvedCrs must yield the same context a CrsInfo
+// with the equivalent fields would, AND it can express `kind` a CrsInfo cannot
+// ('local' / 'unknown').
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('spatialContextFrom — accepts a ResolvedCrs directly', () => {
+  it('a resolved projected CRS yields the same context as its CrsInfo', () => {
+    const info: CrsInfo = {
+      source: 'wkt',
+      name: 'NAD83 / UTM 12N + NAVD88',
+      epsg: 32000,
+      linearUnit: 'foot',
+      linearUnitToMetres: 0.3048,
+      isGeographic: false,
+      verticalEpsg: 5703,
+      verticalDatum: 'NAVD88',
+      verticalUnitToMetres: 0.3048,
+    };
+    const resolved = resolvedFromCrsInfo(info, 'las-vlr');
+    expect(resolved).not.toBeNull();
+    const fromInfo = spatialContextFrom(info);
+    const fromResolved = spatialContextFrom(resolved);
+
+    for (const key of [
+      'kind', 'isGeographic', 'linearUnit', 'linearUnitToMetres', 'linearUnitKnown',
+      'verticalReference', 'verticalDatum', 'verticalEpsg', 'verticalUnitToMetres',
+      'metricValidity', 'metricClaimsPermitted',
+    ] as const) {
+      expect(fromResolved[key]).toEqual(fromInfo[key]);
+    }
+    expect(fromResolved.metricClaimsPermitted).toBe(true);
+    expect(fromResolved.verticalReference).toBe('orthometric');
+  });
+
+  it('honours a resolved kind a CrsInfo cannot express (local / unknown)', () => {
+    const local = spatialContextFrom(localCrs());
+    expect(local.kind).toBe('local');
+    expect(local.linearUnitKnown).toBe(false);
+    expect(local.metricClaimsPermitted).toBe(false);
+    // The ladder classifies a local frame as safe-explicit-local, not projected.
+    expect(local.metricValidity).toBe('safe-explicit-local');
+
+    const unknown = spatialContextFrom(unknownCrs());
+    expect(unknown.kind).toBe('unknown');
+    expect(unknown.metricClaimsPermitted).toBe(false);
+  });
+
+  it('a resolved geographic CRS fails the gate closed', () => {
+    const geo = resolvedFromCrsInfo(
+      { source: 'wkt', name: 'WGS 84', linearUnit: 'unknown', linearUnitToMetres: 1, isGeographic: true },
+      'las-vlr',
+    );
+    const ctx = spatialContextFrom(geo);
+    expect(ctx.isGeographic).toBe(true);
+    expect(ctx.metricValidity).toBe('requires-projection');
+    expect(ctx.metricClaimsPermitted).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Roadmap item **P2 (coordinate-integrity), routing phase A**: route the two display-tier consumers through the merged `SpatialContext` façade so they stop re-deriving unit/datum facts inline. Each is a pure refactor — no behavior change.

Routed **only** these two consumer modules. `main.ts` and `Viewer.ts` are untouched (the up-axis feed for point inspection lives at `main.ts:5160` and was left alone). The other 11 consumers in the inventory are the follow-up. The roadmap doc is unchanged.

## Consumer 1 — Point inspection (`src/render/pointInfo.ts`)

`pointVerticalReference` — datum → reference:

```
- return verticalReferenceFromDatum({ verticalEpsg: crs.verticalEpsg, verticalDatum: crs.verticalDatum });
+ return spatialContextFrom(crs).verticalReference;   // 'local' / 'unknown' frame classes still decided above
```

`worldCoordLabels` — unit-suffix / kind decisions now read `ctx.kind` / `ctx.linearUnit` / `ctx.verticalUnitToMetres` / `ctx.crsName` (was `crs.kind` / `crs.linearUnit` / `crs.verticalUnitToMetres` / `crs.name`). `pointHeight` reads `ctx.verticalUnitToMetres`. `heightRowLabel` already delegates to the routed `pointVerticalReference`.

## Consumer 2 — Scan report (`src/analysis/modules/scanReport.ts`)

Unit gate (in `scanReportUnitBasis`):

```
- const unitKnown = isLinearUnitKnown(crs);
+ const unitKnown = ctx.linearUnitKnown;
```

Vertical-reference row:

```
- const reference = verticalReferenceFromDatum({ verticalEpsg: crs.verticalEpsg, verticalDatum: crs.verticalDatum });
- rows.push({ label: 'Vertical reference', value: heightLabel(reference), ... });
+ rows.push({ label: 'Vertical reference', value: heightLabel(ctx.verticalReference), ... });   // still guarded by `if (meta?.crs)`
```

One context is built per report in `run()` and handed down (the roadmap's "build once, hand down").

**Gate choice — `linearUnitKnown`, not `metricClaimsPermitted`.** The two agree on every well-formed CRS but diverge on a corrupt `linearUnit:'metre'` with a non-finite `linearUnitToMetres`: the ladder blocks the metric headline while the unit name is still "known". The report's fail-closed rule keys off the declared unit, so `linearUnitKnown` is the behavior-preserving read. A test pins this.

## Enabler — `spatialContextFrom` accepts a `ResolvedCrs`

Point inspection holds a `ResolvedCrs`, not a `CrsInfo`, so `spatialContextFrom(crs)` was widened to accept `CrsInfo | ResolvedCrs` (discriminated by the `kind` field, which `CrsInfo` lacks). A `ResolvedCrs` is used as-is; a `CrsInfo` is bridged through `resolvedFromCrsInfo` exactly as before. This is additive — existing `CrsInfo` callers and the 30-cell matrix test are unchanged — and it is the honest alternative to hand-building a `CrsInfo` inside the consumer (which the façade doc forbids). It is also the enabler every other `ResolvedCrs`-holding consumer in the inventory will reuse.

## How behavior-identity is proven

Tests extended across the unit × vertical-datum × frame matrix:

- **pointInfo.test.ts**: new coverage for `worldCoordLabels` / `pointVerticalReference` / `pointHeight` / `heightRowLabel` (these had none). Cells: metre / intl-foot / us-survey-foot / unknown-unit / geographic × orthometric / ellipsoidal / no-datum × local / unknown / undefined. Each asserts the routed result equals `verticalReferenceFromDatum(...)` over the same fields AND `spatialContextFrom(crs).verticalReference`.
- **scanReportUnits.test.ts**: the 4 helper tests re-expressed against `spatialContextFrom(...)` (all assertions kept), plus a unit-matrix `it.each` and the non-finite-factor guard for the `linearUnitKnown` vs `metricClaimsPermitted` choice.
- **scanReport.test.ts / spatialContext.test.ts**: existing module-level and matrix tests still pass unchanged (behavior-identity at the module level); added a `ResolvedCrs`-input block proving it yields the same context a `CrsInfo` would.

No test was weakened.

## Gates (all green)

| gate | exit |
|------|------|
| `npx tsc --noEmit` | 0 |
| `npx vitest run` | 0 (7710 passed, 20 skipped, 1 todo) |
| `node scripts/lint-monolith-size.mjs` | 0 |
| `node scripts/lint-layer-boundaries.mjs` | 0 |
| `node scripts/lint-main-deferral.mjs` | 0 |
| `node scripts/verify-archive-portability.mjs` | 0 (14 passed, 0 failed; 127 pre-existing doc-reference warnings, none from these files) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)