### PR TITLE
Extract handleFile → src/app/openScan.ts behind a structural deps object

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.3.md
+++ b/KNOWN_LIMITATIONS_v0.6.3.md
@@ -6,7 +6,7 @@ Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 6,790 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 6,507 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 6,790 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 6,507 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -98,7 +98,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (6,790)** — the largest blocks, which are the extraction
+**`src/main.ts` (6,507)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,
@@ -107,7 +107,6 @@ called with a 19-member deps object. The candidates that remain:
 | Block | ~Lines | Extraction target |
 |---|---:|---|
 | `seedStreamingFilterExtents` | 338 | streaming panel wiring module |
-| `handleFile` | 336 | `src/app/openScan.ts` *(planned)* — the open/load pipeline |
 | `syncInspectorVisuals` | 266 | inspector wiring module |
 | `applyScanRoute` | 233 | joins `ScanRouteService` |
 | `handleRemoteEpt` / `openStreamingCopc` | 406 | `src/app/openStreaming.ts` *(planned)* |
@@ -118,6 +117,15 @@ Done: `importSession` (~208 lines) now lives in `src/app/sessionIo.ts`, called w
 cloud→fingerprint adapter (`scanFactsFromStreaming` / `scanFactsFromStatic`) is
 exported and Node-tested, and the parse/verify/rebase halves it leans on already
 lived in `src/io/session.ts`; `main.ts` keeps a thin caller (`tests/sessionIo.test.ts`).
+
+Done: `handleFile` (~336 lines) — the open/load pipeline — now lives in
+`src/app/openScan.ts` as `openScan(file, deps)`, driven through an `OpenScanDeps`
+object of accessor functions closing over the shell's services rather than the
+Viewer class. The two genuinely pure decisions it made are extracted and
+Node-tested — `layerChipCount` (the file-total vs strided-display count the Layers
+chip shows) and `shouldResetSavedWork` (fresh-project vs additive open) — alongside
+the three-way router's session / COPC / static dispatch (`tests/openScan.test.ts`).
+`main.ts` keeps a thin `handleFile` delegate that binds its running state to the deps.
 
 **`src/render/Viewer.ts` (6,419)** — the constructor and a handful of large
 methods dominate:

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 6790,
+      "lines": 6507,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/app/openScan.ts
+++ b/src/app/openScan.ts
@@ -1,0 +1,512 @@
+/**
+ * openScan.ts — the open/load pipeline lifted out of main.ts.
+ *
+ * `openScan` is the SINGLE router every file entering the app passes through
+ * (drop zone, Open picker, Measurements Import, sampled catalog loads). It
+ * splits three ways: an `.olvsession` is a saved analysis, not a scan, so it
+ * routes to the session loader; a COPC file takes the streaming pipeline; every
+ * other format takes the static loader, then the whole post-load orchestration
+ * runs — attach the cloud, reveal the dock / nav, and populate the Inspector.
+ *
+ * The two genuinely pure decisions the pipeline makes are extracted as
+ * {@link layerChipCount} and {@link shouldResetSavedWork} so they are
+ * Node-testable without a Viewer or the DOM. Everything else is imperative view
+ * orchestration, driven through a structural {@link OpenScanDeps} of accessor
+ * functions closing over the shell's services rather than the Viewer class —
+ * the same seam `sessionIo` and the render hosts use. `main.ts` keeps a thin
+ * `handleFile` delegate that binds its running state to these deps. Part of the
+ * v0.6 decomposition (see `docs/architecture/architecture-map.md`).
+ */
+
+import { isSessionFile } from '../io/sessionFile';
+import { detectCopc } from '../io/copc/copcDetect';
+import { formatProgress } from '../io/loadProgress';
+import { describeLoadError } from '../io/loadErrors';
+import { formatTelemetry } from '../io/loadTelemetry';
+import { buildBenchmarkResult, formatBenchmarkResult } from '../io/benchmark';
+import { LoadCancelledError } from '../io/loadFile';
+import { defaultMode, availableModes } from '../render/colorModes';
+import { increment as recordUsage } from '../diagnostics/usageCounters';
+
+import type { LoadResult, LoadCallbacks, LoadOptions } from '../io/loadFile';
+import type { ColorMode } from '../render/colorModes';
+import type { PointCloud } from '../model/PointCloud';
+import type { ShareState } from '../io/shareState';
+import type { ClassScope } from '../render/class/classScope';
+import type { AnalysisRow } from '../analysis/ModuleApi';
+import type { Viewer } from '../render/Viewer';
+import type { Inspector } from '../ui/Inspector';
+import type { ToolDock } from '../ui/toolDock';
+import type { NavBar } from '../ui/NavBar';
+import type { DebugOverlay } from '../ui/DebugOverlay';
+import type { DropZone } from '../ui/DropZone';
+import type { Stage } from '../ui/Stage';
+import type { ScanService } from './ScanService';
+import type { LayerService } from './LayerService';
+import type { InspectorCardRefreshers } from './inspectorCardRefreshers';
+import type { CrsCoordinator } from './crsCoordinator';
+import type { ViewBookmarksService } from './viewBookmarks';
+
+/**
+ * The Layers chip names the FILE, so it shows the file total (the same count
+ * DETAIL renders as "loaded / total"), not the strided display subset — kept
+ * consistent with the Scan Report's file-scale Point Count. Use the header /
+ * source total only when it is present AND larger than the display cloud (a
+ * budget-capped load); otherwise the display count already is the file count.
+ */
+export function layerChipCount(
+  originalPointCount: number | undefined,
+  displayPointCount: number,
+): number {
+  return originalPointCount && originalPointCount > displayPointCount
+    ? originalPointCount
+    : displayPointCount;
+}
+
+/**
+ * A fresh project resets saved work; an additive open keeps the layer that is
+ * still on screen. True only when this is the first (or only) loaded cloud —
+ * `tests/additiveOpenKeepsWork.test.ts` pins the additive side of this.
+ */
+export function shouldResetSavedWork(loadedCloudCount: number): boolean {
+  return loadedCloudCount <= 1;
+}
+
+/**
+ * The running-app seam `openScan` writes through. Accessors are functions, not
+ * snapshots, so the lazily-bound Viewer and the mutable load flags are read at
+ * call time — exactly as the inline version read the shell's module-level
+ * `let`s. The two heavy runtime actions (the static source load, the COPC
+ * stream open) are passed in so this module stays free of the loader / boot
+ * graph and the decision logic above can be tested without them.
+ */
+export interface OpenScanDeps {
+  /** Resolves once the lazily-loaded Viewer chunk is in place — awaited before any `getViewer()`. */
+  readonly viewerReady: Promise<unknown>;
+  /** The live Viewer (a late-bound `let` in the shell). */
+  getViewer: () => Viewer;
+  /** Route an `.olvsession` to the session loader (the shell's `importSession`). */
+  importSession: (file: File) => Promise<void>;
+  /** True while a load is in flight — the one-load-at-a-time guard. */
+  isLoading: () => boolean;
+  /** Claim / release the load flag. Claimed synchronously; released in `finally`. */
+  setLoading: (loading: boolean) => void;
+  /** Fire a toast, optionally with one action button. */
+  showToast: (
+    message: string,
+    action?: { readonly label: string; readonly onClick: () => void },
+  ) => void;
+  /** The drop-zone status surface. */
+  dropZone: Pick<
+    DropZone,
+    'setOpening' | 'setCancelHandler' | 'setProgress' | 'setPreload' | 'setError'
+  >;
+  /** Open a local COPC file through the streaming pipeline (wraps the range source + `openStreamingCopc`). */
+  openLocalCopc: (file: File, signal: AbortSignal) => Promise<void>;
+  /** Load a dropped / opened file through the static loader (wraps `new LocalFileSource(file).load(...)`). */
+  loadLocalSource: (
+    file: File,
+    callbacks: LoadCallbacks,
+    options: LoadOptions,
+  ) => Promise<LoadResult>;
+  /** The device's safe render budget (`deviceCapsValue.renderBudget`). */
+  readonly renderBudget: number;
+  /** Phone-class device — tighter budget + touch hints. */
+  isPhone: () => boolean;
+  /** Reported device memory in GB, or undefined when the browser withholds it. */
+  deviceMemoryGB: () => number | undefined;
+  /** Hide the empty-state placeholder once a scan renders. */
+  stage: Pick<Stage, 'hideEmptyState'>;
+  /** Tear down any open streaming scan (a static load replaces it; a failed streaming open tidies up). */
+  closeStreaming: () => void;
+  /** Active-scan selection + lookup. */
+  scans: Pick<ScanService, 'setActive' | 'activeId'>;
+  /** The Inspector panel. */
+  inspector: Inspector;
+  /** Provenance / dataset-intelligence card refreshers. */
+  inspectorCards: Pick<
+    InspectorCardRefreshers,
+    'refreshProvenance' | 'refreshDatasetIntelligenceFromStaticCloud'
+  >;
+  /** CRS detection for the freshly loaded static cloud. */
+  crsCoordinator: Pick<CrsCoordinator, 'refreshCrsForStaticCloud'>;
+  /** The tool dock. */
+  dock: ToolDock;
+  /** The navigation bar. */
+  navBar: NavBar;
+  /** Saved-view store — cleared only on a fresh project. */
+  bookmarks: Pick<ViewBookmarksService, 'clear'>;
+  /** CRS-mismatch flag refresh across layers. */
+  layerService: Pick<LayerService, 'refreshCrsFlags'>;
+  /** Record the per-layer visibility intent for a freshly attached cloud. */
+  setLayerVisible: (id: string, visible: boolean) => void;
+  /** Retain the source File so the Export panel can offer a full-resolution re-decode. */
+  rememberSourceFile: (id: string, file: File) => void;
+  /** Retain whether the display cloud was reduced from the source. */
+  rememberReduced: (id: string, reduced: boolean) => void;
+  /** Re-render the annotations panel from the viewer's store. */
+  refreshAnnotationPanel: () => void;
+  /** Record the active colour mode chosen for this load (the shell's `currentColorMode`). */
+  setCurrentColorMode: (mode: ColorMode) => void;
+  /** Lazily import the display-profile card applier. */
+  loadApplyDisplayProfile: () => Promise<{
+    applyDisplayProfile: (cloud: PointCloud, target: Inspector) => void;
+  }>;
+  /** Run the analysis modules over a cloud for the Scan Report. */
+  runModules: (cloud: PointCloud, scope?: ClassScope) => AnalysisRow[];
+  /** Derive the active class scope for the report. */
+  currentClassScope: (cloud: PointCloud) => ClassScope;
+  /** Pre-warm the lazy Visual Export Studio chunk. */
+  prewarmExportStudio: () => void;
+  /** A share link's pending view state, if this page opened via one. */
+  getPendingShareState: () => ShareState | null;
+  /** Consume the pending share state so it applies at most once. */
+  clearPendingShareState: () => void;
+  /** Restore a shared view onto the freshly loaded scan. */
+  applyShareState: (state: ShareState, cloud: PointCloud) => void;
+  /** Embedded / minimal-UI mode — suppresses the project + instant-answer cards. */
+  readonly bareMode: boolean;
+  /** Show the post-load project summary card. */
+  showProjectCard: (cloud: PointCloud, originalPointCount: number) => void;
+  /** Reveal the Analyse panel for the loaded scan. */
+  revealAnalysePanel: (name: string) => void;
+  /** Surface the instant analysis-on-drop entry point. */
+  showInstantAnswer: (name: string) => void;
+  /** Repopulate the classification legend from the cloud's per-point class buffer. */
+  refreshClassLegend: (classification?: ArrayLike<number>) => void;
+  /** `?debug=1` — console diagnostics + overlay telemetry. */
+  readonly debug: boolean;
+  /** `?benchmark=1` — emit a benchmark result on load. */
+  readonly benchmark: boolean;
+  /** The developer diagnostics overlay, or null when it hasn't loaded. */
+  getDebugOverlay: () => Pick<DebugOverlay, 'setTelemetry' | 'setBenchmark'> | null;
+}
+
+/** Load a dropped or sampled File: parse, render, and populate the Inspector. */
+export async function openScan(file: File, deps: OpenScanDeps): Promise<void> {
+  // SINGLE ROUTER for every file that enters the app (drop zone, Open picker,
+  // Measurements Import). An `.olvsession` is a saved analysis, not a scan, so
+  // it goes to the one session loader — never the cloud worker — and every
+  // entry point therefore opens sessions the same way. A session restore is
+  // cheap (read + apply state) and safe to run even mid-load, so it routes
+  // ahead of the cloud-loading guard.
+  if (isSessionFile(file.name)) {
+    await deps.importSession(file);
+    return;
+  }
+  // One load at a time. The shared parse worker decodes a single file; a
+  // second load started mid-flight would hijack the first one's worker. The
+  // in-progress load carries a Cancel control if the user wants to switch.
+  if (deps.isLoading()) {
+    deps.showToast('Already loading — cancel the current load first.');
+    return;
+  }
+  // Claim the flag SYNCHRONOUSLY — the `await viewerReady` below yields to
+  // the event loop, and a second drop in that window used to pass the
+  // `loading` guard too (TOCTOU). The `finally` below is the only reset.
+  deps.setLoading(true);
+  const controller = new AbortController();
+  // Blue blinking "Opening …" — the prominent first feedback, matching the
+  // catalog status vocabulary so device and public-dataset loads read the same.
+  // The load's staged progress (decoding / uploading / rendering) supersedes it.
+  deps.dropZone.setOpening(`Opening ${file.name}…`);
+  deps.dropZone.setCancelHandler(() => controller.abort());
+  try {
+    // ensure the lazy-loaded Viewer is ready before touching it.
+    await deps.viewerReady;
+    const viewer = deps.getViewer();
+    // COPC files take the streaming pipeline, not the static loader. The
+    // range-source module is part of the lazy COPC chunk.
+    const headSlice = await file.slice(0, 4096).arrayBuffer();
+    if (detectCopc(headSlice).isCopc) {
+      await deps.openLocalCopc(file, controller.signal);
+      return;
+    }
+    // Phones get a tighter point budget — limited GPU memory and fill-rate.
+    // The dropped file is wrapped in a LocalFileSource — the source
+    // abstraction; v0.3 streaming sources slot in beside it.
+    const result = await deps.loadLocalSource(
+      file,
+      {
+        onProgress: (u) => deps.dropZone.setProgress(formatProgress(u), u.fraction),
+        onPreload: (lines) => deps.dropZone.setPreload(lines),
+      },
+      {
+        // The point budget is the device's safe render budget — full on a
+        // capable machine, reduced on a weak one to keep the GPU stable.
+        budget: deps.renderBudget,
+        isMobile: deps.isPhone(),
+        deviceMemoryGB: deps.deviceMemoryGB(),
+        signal: controller.signal,
+      },
+    );
+    await viewer.ready;
+
+    // NB: static layers are ADDITIVE — dropping/opening a second scan keeps the
+    // first as a separate layer (the LAYERS panel lists each with its own ✕ to
+    // free it). We deliberately do NOT clear prior static clouds here: an
+    // earlier "free the previous scan on re-open" optimisation mistook the
+    // retained layer for a leak and silently broke multi-scan loading. GPU for
+    // multiple layers is intended; the user releases a layer via its ✕, which
+    // routes through removeCloud() and frees the same buffers. (Streaming opens
+    // remain exclusive and still call clearOpenStaticLayers below.)
+
+    deps.dropZone.setProgress(formatProgress({ stage: 'uploading' }));
+    deps.stage.hideEmptyState();
+    // A static load replaces any open streaming scan — but only now that the
+    // file parsed. A failed or cancelled parse above must leave the current
+    // scene intact rather than clearing it for a scan that never arrived.
+    if (controller.signal.aborted) throw new LoadCancelledError();
+    if (viewer.hasStreamingCloud) deps.closeStreaming();
+    const uploadStartedAt = performance.now();
+    const id = viewer.addCloud(result.cloud);
+    const gpuUploadMs = performance.now() - uploadStartedAt;
+    deps.scans.setActive(id);
+    // A freshly opened scan has no terrain analysis yet — drop any prior grid so
+    // the Coverage colour chip starts disabled until this scan is analysed.
+    viewer.setCoverageGrid(null);
+    deps.inspector.setCoverageAvailable(false);
+    // Retain the source file + whether the display cloud was reduced, so the
+    // Export panel can offer a full-resolution re-decode.
+    deps.rememberSourceFile(id, file);
+    deps.rememberReduced(id, result.downsampled);
+    // Local-first counter — categorical source format only; never the file name.
+    try { recordUsage('scan-open', result.cloud.sourceFormat); }
+    catch (err) { if (deps.debug) console.warn('[usage] recordUsage threw', err); }
+    // Provenance fingerprint — pure metadata classification, surfaced in
+    // the Inspector's "Provenance" section. Wrapped because a malformed
+    // input shape would have aborted the rest of the post-load setup
+    // (including the navBar reveal further down).
+    try { deps.inspectorCards.refreshProvenance(result.cloud); }
+    catch (err) { if (deps.debug) console.warn('[provenance] refreshProvenance threw', err); }
+    // CRS — detected from the loaded cloud's metadata, merged with any
+    // persisted user override. Wrapped because a malformed cloud
+    // shape shouldn't break the rest of the load.
+    try { deps.crsCoordinator.refreshCrsForStaticCloud(result.cloud); }
+    catch (err) { if (deps.debug) console.warn('[crs] refreshCrsForStaticCloud threw', err); }
+
+    deps.dropZone.setProgress(formatProgress({ stage: 'rendering' }));
+    const renderStartedAt = performance.now();
+    // A freshly opened scan starts in the orbit overview, then glides in.
+    viewer.setMode('orbit');
+    viewer.frameAll();
+    const firstRenderMs = performance.now() - renderStartedAt;
+
+    const mode = defaultMode(result.cloud);
+    deps.setCurrentColorMode(mode);
+    viewer.setColorMode(id, mode);
+
+    // ── CRITICAL UI REVEAL — runs BEFORE any inspector / module setup ────
+    // The dock backend indicator + NavBar (Orbit/Walk/Fly mode switcher
+    // + speed slider) must reveal even if a downstream inspector call
+    // throws. Without this ordering, a failure in `runModules` or
+    // `inspector.setReport` left the user with a rendered scan they
+    // couldn't navigate around, and the backend indicator stuck at
+    // "initialising…". Critical reveal first, decorations second.
+    deps.dock.setBackend(viewer.activeBackend());
+    // v0.3.6 design-audit fix: reveal the dock at attach. It stays hidden
+    // through the empty state so eight dimmed tools don't clutter the
+    // primary CTA on mobile.
+    deps.dock.setEmpty(false);
+    deps.inspector.setEmpty(false);
+    deps.dock.setMeasureEnabled(true);
+    deps.dock.setInspectEnabled(true);
+    deps.dock.setProbeEnabled(true);
+    deps.dock.setAnnotateEnabled(true);
+    deps.dock.setCloseEnabled(true);
+    deps.navBar.element.classList.remove('olv-hidden');
+    deps.navBar.setMode('orbit');
+    deps.navBar.flashHelp();
+    document.body.classList.add('olv-has-scan');
+    if (deps.isPhone()) deps.navBar.flashTouchHint();
+
+    // Only a fresh project resets saved work; an additive open keeps the layer
+    // that is still on screen. tests/additiveOpenKeepsWork.test.ts pins this.
+    if (shouldResetSavedWork(viewer.clouds().length)) { deps.bookmarks.clear(); viewer.annotate.clear(); }
+    deps.refreshAnnotationPanel();
+
+    // ── Inspector setup — wrapped in defensive try/catches so a single
+    //    failing analysis module or inspector call can't abort the rest.
+    //    Each isolated block restores its own slice; the navigation
+    //    above remains usable even if every block below fails.
+    try {
+      // The Layers chip names the FILE, so it shows the file total (the same
+      // count DETAIL renders as "loaded / total"), not the strided display
+      // subset — consistent with the Scan Report's file-scale Point Count.
+      const layerCount = layerChipCount(result.originalPointCount, result.cloud.pointCount);
+      deps.inspector.addCloud(id, result.cloud.name, layerCount, result.cloud.metadata?.crs?.name ?? null);
+      deps.setLayerVisible(id, true);
+      deps.layerService.refreshCrsFlags();
+      deps.inspector.setColorModes(availableModes(result.cloud), mode);
+      deps.inspector.setDetail(result.cloud.pointCount, result.originalPointCount);
+      deps.inspector.setElevationExtent(viewer.elevationExtent());
+      deps.inspector.setIntensityExtent(viewer.intensityExtent());
+      deps.inspectorCards.refreshDatasetIntelligenceFromStaticCloud(result.cloud);
+      // v0.5.7 capability-driven card: derive the display profile from the
+      // loaded scan and surface the declared-by-the-file provenance (E57 olv:
+      // block, headline) + hide the CRS section for local-frame scans. Loaded
+      // lazily (via lazyChunks) so displayProfile + scanCapability stay out of
+      // the eager startup shell / index bundle budget. Additive; a no-op on the
+      // geo path.
+      {
+        const profileCloud = result.cloud;
+        const targetId = id;
+        void deps.loadApplyDisplayProfile()
+          .then(({ applyDisplayProfile }) => {
+            if (deps.scans.activeId !== targetId) return; // scan changed while we waited
+            applyDisplayProfile(profileCloud, deps.inspector);
+          })
+          // The card is additive and no-op on absence; a chunk-load or
+          // derivation failure must not surface as an unhandled rejection (the
+          // enclosing try/catch is synchronous and won't catch this promise).
+          .catch((err) => {
+            if (deps.debug) console.warn('[inspector] display-profile card threw', err);
+          });
+      }
+    } catch (err) {
+      if (deps.debug) console.warn('[inspector] cloud + details setup threw', err);
+    }
+    // Scan Report — deferred off the attach path (v0.5.3). The health-check
+    // module walks EVERY point several times (duplicate-point set, median/MAD
+    // sorts, outlier + finite scans): ~3 s of the attach long-task on a
+    // multi-million-point cloud, blocking first paint and first input after
+    // "rendering…" clears. Run it when the main thread goes idle instead —
+    // the report card fills in a beat later, navigation is live immediately.
+    // The cloud-id guard drops the stale result if the user swapped scans
+    // before idle arrived (the memoised module re-runs cheaply on re-open).
+    {
+      const reportForId = id;
+      const fillReport = (): void => {
+        if (deps.scans.activeId !== reportForId) return; // scan changed while we waited
+        try {
+          deps.inspector.setReport(deps.runModules(result.cloud, deps.currentClassScope(result.cloud)));
+        } catch (err) {
+          if (deps.debug) console.warn('[inspector] runModules + setReport threw', err);
+        }
+      };
+      type RIC = (cb: () => void, opts?: { timeout?: number }) => number;
+      const rIC = (window as unknown as { requestIdleCallback?: RIC }).requestIdleCallback;
+      if (typeof rIC === 'function') rIC(fillReport, { timeout: 1500 });
+      else setTimeout(fillReport, 200);
+    }
+    try {
+      deps.inspector.setViews([]);
+    } catch (err) {
+      if (deps.debug) console.warn('[inspector] setViews threw', err);
+    }
+    // Visual Export Studio — a scan is now loaded; turn on the image-
+    // export buttons so the user can capture it. Pre-warm the lazy Studio
+    // chunk in the background so the first export click feels instant
+    // instead of waiting on the ~7 KB gzip fetch + parse. Pure fire-and-
+    // forget; we don't await the result.
+    try {
+      deps.inspector.setImageExportEnabled(true);
+      // Per-mode gating — disable buttons whose mode the loaded cloud can't
+      // satisfy (Normal map on a LAZ, etc.) so the user sees the constraint
+      // before clicking rather than as a post-click error toast.
+      deps.inspector.setImageExportAvailability(viewer.availableImageExportModes());
+    } catch (err) {
+      if (deps.debug) console.warn('[inspector] setImageExportEnabled threw', err);
+    }
+    deps.prewarmExportStudio();
+
+    // A share link, if one opened this page, restores its view onto this scan.
+    const pending = deps.getPendingShareState();
+    if (pending) {
+      try {
+        deps.applyShareState(pending, result.cloud);
+      } catch (err) {
+        if (deps.debug) console.warn('[share] applyShareState threw', err);
+      }
+      deps.clearPendingShareState();
+    }
+
+    // The render-quality controls reflect the viewer's state — EDL defaults
+    // depend on the GPU backend, known only once `viewer.ready` resolved.
+    try {
+      deps.inspector.syncRendering({
+        pointSize: viewer.pointSize,
+        edlEnabled: viewer.edlEnabled,
+        edlStrength: viewer.edlStrength,
+        pointSizeMode: viewer.pointSizeMode,
+        antialiasing: viewer.antialiasing,
+        twoFingerTwistEnabled: viewer.twoFingerTwistEnabled,
+    splatMode: viewer.splatMode,
+      });
+    } catch (err) {
+      if (deps.debug) console.warn('[inspector] syncRendering threw', err);
+    }
+
+    if (!deps.bareMode) deps.showProjectCard(result.cloud, result.originalPointCount);
+
+    // Reveal the Analyse panel now there's a scan to analyse. v0.4.0.
+    deps.revealAnalysePanel(result.cloud.name);
+
+    // Instant analysis-on-drop — surface the most relevant analysis one click
+    // away (terrain / volume / floor plan / before-after), nothing uploaded.
+    // Skipped in bare/embedded mode, which has no panels to drive.
+    if (!deps.bareMode) deps.showInstantAnswer(result.cloud.name);
+
+    // Classification legend (v0.4.1) — populate from the cloud's per-point
+    // class buffer when present, then show. A scan with no classification
+    // channel renders the panel's empty state. DISPLAY-ONLY; the all-visible
+    // default mask is applied so nothing is hidden on load.
+    try {
+      deps.refreshClassLegend(result.cloud.classification);
+    } catch (err) {
+      if (deps.debug) console.warn('[class-legend] refresh threw', err);
+    }
+
+    // Developer diagnostics — the merged telemetry feeds the debug console
+    // block, the performance overlay, and (under ?benchmark=1) a benchmark.
+    if ((deps.debug || deps.benchmark) && result.telemetry) {
+      const telemetry = { ...result.telemetry, gpuUploadMs, firstRenderMs };
+      if (deps.debug) {
+        console.log(
+          '%cOpenLiDARViewer — load telemetry',
+          'font-weight:600;color:#22dcff',
+          '\n' + formatTelemetry(telemetry),
+        );
+      }
+      deps.getDebugOverlay()?.setTelemetry(telemetry);
+      if (deps.benchmark) {
+        const text = formatBenchmarkResult(
+          buildBenchmarkResult(
+            result.cloud.name,
+            result.cloud.sourceFormat,
+            result.cloud.pointCount,
+            telemetry,
+            // Surface the header-declared point count when the source had
+            // one, so the benchmark output disambiguates "4M of 100M (4 %)"
+            // from "4M of 4M (100 %)" — a budget-capped load shouldn't
+            // read identically to a full one.
+            result.cloud.declaredPointCount,
+          ),
+        );
+        console.log(
+          '%cOpenLiDARViewer — benchmark',
+          'font-weight:600;color:#22dcff',
+          '\n' + text,
+        );
+        deps.getDebugOverlay()?.setBenchmark('benchmark\n' + text);
+      }
+    }
+    deps.dropZone.setCancelHandler(null);
+    deps.dropZone.setProgress(null);
+  } catch (err) {
+    deps.dropZone.setCancelHandler(null);
+    if (err instanceof LoadCancelledError) {
+      // A cancelled load is a quiet no-op — no error toast, nothing was added.
+      deps.dropZone.setProgress(null);
+    } else {
+      // The toast shows a clear, categorised message; the raw error still
+      // reaches the console for developers under ?debug=1.
+      if (deps.debug) console.error('OpenLiDARViewer — load error', err);
+      deps.dropZone.setError(describeLoadError(err));
+      // A streaming open that failed mid-flight leaves no scan — tidy up.
+      deps.closeStreaming();
+    }
+  } finally {
+    deps.setLoading(false);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ import { buildMeasureConfidenceContext } from './app/measureConfidenceContext';
 import { findDuplicateIds } from './ui/actionRegistry';
 import { buildActionRegistry } from './app/actionDefinitions';
 import { importSession as runImportSession, type SessionIoDeps } from './app/sessionIo';
+import { openScan, type OpenScanDeps } from './app/openScan';
 import { WorkflowController, WORKFLOW_RECORDER_ENABLED } from './ui/WorkflowController';
 import type { WorkflowConfigPanel } from './ui/WorkflowConfigPanel';
 import { RecommendedViewChip } from './ui/RecommendedViewChip';
@@ -124,9 +125,6 @@ import { parseEmbedConfig } from './ui/embedConfig';
 // non-iframe page load (the dominant traffic pattern).
 import { encodeShareState, decodeShareState } from './io/shareState';
 import type { ShareState } from './io/shareState';
-import { formatProgress } from './io/loadProgress';
-import { formatTelemetry } from './io/loadTelemetry';
-import { buildBenchmarkResult, formatBenchmarkResult } from './io/benchmark';
 // The diagnostics runtime (DebugOverlay + streamingBenchmark + the
 // instrumented range source) loads only when `?debug=1` or `?benchmark=1`
 // is set — see `loadDiagnostics()` below. The types stay reachable for the
@@ -143,7 +141,6 @@ import { isZUpFormat } from './io/sniffFormat';
 // Only the tiny file-router predicate is eager; the (large) serializer/parser
 // is dynamically imported in exportSession/importSession so it stays off the
 // initial bundle.
-import { isSessionFile } from './io/sessionFile';
 // The view-state seam is eager but weightless: pure capture/apply
 // orchestration with type-only imports (no session parser, no three.js), so
 // saveCurrentView/applyView can run synchronously from a keystroke while the
@@ -166,11 +163,6 @@ import {
 } from './render/colorModes';
 import type { ColorMode } from './render/colorModes';
 import type { PointCloud } from './model/PointCloud';
-// `detectCopc` is a tiny leaf — kept static so `handleFile` can branch on it
-// synchronously. The rest of the COPC + streaming subsystem is dynamically
-// imported (in `openStreamingCopc` and `handleRemoteCopc`), so it lands in a
-// lazy chunk fetched only when a COPC scan is actually opened.
-import { detectCopc } from './io/copc/copcDetect';
 import { validateRemoteCopcUrl } from './io/range/RangeSource';
 import type { RangeSource } from './io/range/RangeSource';
 import type { CopcWorkerClient } from './io/copc/worker/copcWorkerClient';
@@ -5297,339 +5289,64 @@ function importSession(file: File, opts: { skipScanConfirm?: boolean } = {}): Pr
   return runImportSession(file, opts, sessionIoDeps);
 }
 
+/**
+ * Open/load pipeline — a thin caller over the extracted `src/app/openScan.ts`.
+ * Binds the shell's running state to the module's deps; the three-way router
+ * (session / COPC / static), the post-load orchestration and the pure
+ * `layerChipCount` / `shouldResetSavedWork` decisions live in that module.
+ */
+const openScanDeps: OpenScanDeps = {
+  viewerReady: viewerLoaded,
+  getViewer: () => viewer,
+  importSession,
+  isLoading: () => loading,
+  setLoading: (v) => { loading = v; },
+  showToast: showLassoToast,
+  dropZone,
+  openLocalCopc: async (fileToOpen, signal) => {
+    const { LocalFileRangeSource } = await loadLocalFileRangeSource();
+    await openStreamingCopc(new LocalFileRangeSource(fileToOpen), fileToOpen.name, signal);
+  },
+  loadLocalSource: (fileToLoad, callbacks, options) =>
+    new LocalFileSource(fileToLoad).load(callbacks, options),
+  renderBudget: deviceCapsValue.renderBudget,
+  isPhone,
+  deviceMemoryGB,
+  stage,
+  closeStreaming,
+  scans,
+  inspector,
+  inspectorCards,
+  crsCoordinator,
+  dock,
+  navBar,
+  bookmarks,
+  layerService,
+  setLayerVisible: (id, visible) => { layerVisible.set(id, visible); },
+  rememberSourceFile: (id, sourceFile) => { sourceFileById.set(id, sourceFile); },
+  rememberReduced: (id, reduced) => { reducedById.set(id, reduced); },
+  refreshAnnotationPanel,
+  setCurrentColorMode: (mode) => { currentColorMode = mode; },
+  loadApplyDisplayProfile,
+  runModules,
+  currentClassScope,
+  prewarmExportStudio: () => { void prewarmExportStudio(); },
+  getPendingShareState: () => pendingShareState,
+  clearPendingShareState: () => { pendingShareState = null; },
+  applyShareState,
+  bareMode,
+  showProjectCard,
+  revealAnalysePanel,
+  showInstantAnswer,
+  refreshClassLegend,
+  debug,
+  benchmark,
+  getDebugOverlay: () => debugOverlay,
+};
+
 /** Load a dropped or sampled File: parse, render, and populate the Inspector. */
-async function handleFile(file: File): Promise<void> {
-  // SINGLE ROUTER for every file that enters the app (drop zone, Open picker,
-  // Measurements Import). An `.olvsession` is a saved analysis, not a scan, so
-  // it goes to the one session loader — never the cloud worker — and every
-  // entry point therefore opens sessions the same way. A session restore is
-  // cheap (read + apply state) and safe to run even mid-load, so it routes
-  // ahead of the cloud-loading guard.
-  if (isSessionFile(file.name)) {
-    await importSession(file);
-    return;
-  }
-  // One load at a time. The shared parse worker decodes a single file; a
-  // second load started mid-flight would hijack the first one's worker. The
-  // in-progress load carries a Cancel control if the user wants to switch.
-  if (loading) {
-    showLassoToast('Already loading — cancel the current load first.');
-    return;
-  }
-  // Claim the flag SYNCHRONOUSLY — the `await viewerLoaded` below yields to
-  // the event loop, and a second drop in that window used to pass the
-  // `loading` guard too (TOCTOU). The `finally` below is the only reset.
-  loading = true;
-  const controller = new AbortController();
-  // Blue blinking "Opening …" — the prominent first feedback, matching the
-  // catalog status vocabulary so device and public-dataset loads read the same.
-  // The load's staged progress (decoding / uploading / rendering) supersedes it.
-  dropZone.setOpening(`Opening ${file.name}…`);
-  dropZone.setCancelHandler(() => controller.abort());
-  try {
-    // ensure the lazy-loaded Viewer is ready before touching it.
-    await viewerLoaded;
-    // COPC files take the streaming pipeline, not the static loader. The
-    // range-source module is part of the lazy COPC chunk.
-    const headSlice = await file.slice(0, 4096).arrayBuffer();
-    if (detectCopc(headSlice).isCopc) {
-      const { LocalFileRangeSource } = await loadLocalFileRangeSource();
-      await openStreamingCopc(
-        new LocalFileRangeSource(file),
-        file.name,
-        controller.signal,
-      );
-      return;
-    }
-    // Phones get a tighter point budget — limited GPU memory and fill-rate.
-    // The dropped file is wrapped in a LocalFileSource — the source
-    // abstraction; v0.3 streaming sources slot in beside it.
-    const source = new LocalFileSource(file);
-    const result = await source.load(
-      {
-        onProgress: (u) => dropZone.setProgress(formatProgress(u), u.fraction),
-        onPreload: (lines) => dropZone.setPreload(lines),
-      },
-      {
-        // The point budget is the device's safe render budget — full on a
-        // capable machine, reduced on a weak one to keep the GPU stable.
-        budget: deviceCapsValue.renderBudget,
-        isMobile: isPhone(),
-        deviceMemoryGB: deviceMemoryGB(),
-        signal: controller.signal,
-      },
-    );
-    await viewer.ready;
-
-    // NB: static layers are ADDITIVE — dropping/opening a second scan keeps the
-    // first as a separate layer (the LAYERS panel lists each with its own ✕ to
-    // free it). We deliberately do NOT clear prior static clouds here: an
-    // earlier "free the previous scan on re-open" optimisation mistook the
-    // retained layer for a leak and silently broke multi-scan loading. GPU for
-    // multiple layers is intended; the user releases a layer via its ✕, which
-    // routes through removeCloud() and frees the same buffers. (Streaming opens
-    // remain exclusive and still call clearOpenStaticLayers below.)
-
-    dropZone.setProgress(formatProgress({ stage: 'uploading' }));
-    stage.hideEmptyState();
-    // A static load replaces any open streaming scan — but only now that the
-    // file parsed. A failed or cancelled parse above must leave the current
-    // scene intact rather than clearing it for a scan that never arrived.
-    if (controller.signal.aborted) throw new LoadCancelledError();
-    if (viewer.hasStreamingCloud) closeStreaming();
-    const uploadStartedAt = performance.now();
-    const id = viewer.addCloud(result.cloud);
-    const gpuUploadMs = performance.now() - uploadStartedAt;
-    scans.setActive(id);
-    // A freshly opened scan has no terrain analysis yet — drop any prior grid so
-    // the Coverage colour chip starts disabled until this scan is analysed.
-    viewer.setCoverageGrid(null);
-    inspector.setCoverageAvailable(false);
-    // Retain the source file + whether the display cloud was reduced, so the
-    // Export panel can offer a full-resolution re-decode.
-    sourceFileById.set(id, file);
-    reducedById.set(id, result.downsampled);
-    // Local-first counter — categorical source format only; never the file name.
-    try { recordUsage('scan-open', result.cloud.sourceFormat); }
-    catch (err) { if (debug) console.warn('[usage] recordUsage threw', err); }
-    // Provenance fingerprint — pure metadata classification, surfaced in
-    // the Inspector's "Provenance" section. Wrapped because a malformed
-    // input shape would have aborted the rest of the post-load setup
-    // (including the navBar reveal further down).
-    try { inspectorCards.refreshProvenance(result.cloud); }
-    catch (err) { if (debug) console.warn('[provenance] refreshProvenance threw', err); }
-    // CRS — detected from the loaded cloud's metadata, merged with any
-    // persisted user override. Wrapped because a malformed cloud
-    // shape shouldn't break the rest of the load.
-    try { crsCoordinator.refreshCrsForStaticCloud(result.cloud); }
-    catch (err) { if (debug) console.warn('[crs] refreshCrsForStaticCloud threw', err); }
-
-    dropZone.setProgress(formatProgress({ stage: 'rendering' }));
-    const renderStartedAt = performance.now();
-    // A freshly opened scan starts in the orbit overview, then glides in.
-    viewer.setMode('orbit');
-    viewer.frameAll();
-    const firstRenderMs = performance.now() - renderStartedAt;
-
-    const mode = defaultMode(result.cloud);
-    currentColorMode = mode;
-    viewer.setColorMode(id, mode);
-
-    // ── CRITICAL UI REVEAL — runs BEFORE any inspector / module setup ────
-    // The dock backend indicator + NavBar (Orbit/Walk/Fly mode switcher
-    // + speed slider) must reveal even if a downstream inspector call
-    // throws. Without this ordering, a failure in `runModules` or
-    // `inspector.setReport` left the user with a rendered scan they
-    // couldn't navigate around, and the backend indicator stuck at
-    // "initialising…". Critical reveal first, decorations second.
-    dock.setBackend(viewer.activeBackend());
-    // v0.3.6 design-audit fix: reveal the dock at attach. It stays hidden
-    // through the empty state so eight dimmed tools don't clutter the
-    // primary CTA on mobile.
-    dock.setEmpty(false);
-    inspector.setEmpty(false);
-    dock.setMeasureEnabled(true);
-    dock.setInspectEnabled(true);
-    dock.setProbeEnabled(true);
-    dock.setAnnotateEnabled(true);
-    dock.setCloseEnabled(true);
-    navBar.element.classList.remove('olv-hidden');
-    navBar.setMode('orbit');
-    navBar.flashHelp();
-    document.body.classList.add('olv-has-scan');
-    if (isPhone()) navBar.flashTouchHint();
-
-    // Only a fresh project resets saved work; an additive open keeps the layer
-    // that is still on screen. tests/additiveOpenKeepsWork.test.ts pins this.
-    if (viewer.clouds().length <= 1) { bookmarks.clear(); viewer.annotate.clear(); }
-    refreshAnnotationPanel();
-
-    // ── Inspector setup — wrapped in defensive try/catches so a single
-    //    failing analysis module or inspector call can't abort the rest.
-    //    Each isolated block restores its own slice; the navigation
-    //    above remains usable even if every block below fails.
-    try {
-      // The Layers chip names the FILE, so it shows the file total (the same
-      // count DETAIL renders as "loaded / total"), not the strided display
-      // subset — consistent with the Scan Report's file-scale Point Count.
-      const layerCount =
-        result.originalPointCount && result.originalPointCount > result.cloud.pointCount
-          ? result.originalPointCount
-          : result.cloud.pointCount;
-      inspector.addCloud(id, result.cloud.name, layerCount, result.cloud.metadata?.crs?.name ?? null);
-      layerVisible.set(id, true);
-      layerService.refreshCrsFlags();
-      inspector.setColorModes(availableModes(result.cloud), mode);
-      inspector.setDetail(result.cloud.pointCount, result.originalPointCount);
-      inspector.setElevationExtent(viewer.elevationExtent());
-      inspector.setIntensityExtent(viewer.intensityExtent());
-      inspectorCards.refreshDatasetIntelligenceFromStaticCloud(result.cloud);
-      // v0.5.7 capability-driven card: derive the display profile from the
-      // loaded scan and surface the declared-by-the-file provenance (E57 olv:
-      // block, headline) + hide the CRS section for local-frame scans. Loaded
-      // lazily (via lazyChunks) so displayProfile + scanCapability stay out of
-      // the eager startup shell / index bundle budget. Additive; a no-op on the
-      // geo path.
-      {
-        const profileCloud = result.cloud;
-        const targetId = id;
-        void loadApplyDisplayProfile()
-          .then(({ applyDisplayProfile }) => {
-            if (scans.activeId !== targetId) return; // scan changed while we waited
-            applyDisplayProfile(profileCloud, inspector);
-          })
-          // The card is additive and no-op on absence; a chunk-load or
-          // derivation failure must not surface as an unhandled rejection (the
-          // enclosing try/catch is synchronous and won't catch this promise).
-          .catch((err) => {
-            if (debug) console.warn('[inspector] display-profile card threw', err);
-          });
-      }
-    } catch (err) {
-      if (debug) console.warn('[inspector] cloud + details setup threw', err);
-    }
-    // Scan Report — deferred off the attach path (v0.5.3). The health-check
-    // module walks EVERY point several times (duplicate-point set, median/MAD
-    // sorts, outlier + finite scans): ~3 s of the attach long-task on a
-    // multi-million-point cloud, blocking first paint and first input after
-    // "rendering…" clears. Run it when the main thread goes idle instead —
-    // the report card fills in a beat later, navigation is live immediately.
-    // The cloud-id guard drops the stale result if the user swapped scans
-    // before idle arrived (the memoised module re-runs cheaply on re-open).
-    {
-      const reportForId = id;
-      const fillReport = (): void => {
-        if (scans.activeId !== reportForId) return; // scan changed while we waited
-        try {
-          inspector.setReport(runModules(result.cloud, currentClassScope(result.cloud)));
-        } catch (err) {
-          if (debug) console.warn('[inspector] runModules + setReport threw', err);
-        }
-      };
-      type RIC = (cb: () => void, opts?: { timeout?: number }) => number;
-      const rIC = (window as unknown as { requestIdleCallback?: RIC }).requestIdleCallback;
-      if (typeof rIC === 'function') rIC(fillReport, { timeout: 1500 });
-      else setTimeout(fillReport, 200);
-    }
-    try {
-      inspector.setViews([]);
-    } catch (err) {
-      if (debug) console.warn('[inspector] setViews threw', err);
-    }
-    // Visual Export Studio — a scan is now loaded; turn on the image-
-    // export buttons so the user can capture it. Pre-warm the lazy Studio
-    // chunk in the background so the first export click feels instant
-    // instead of waiting on the ~7 KB gzip fetch + parse. Pure fire-and-
-    // forget; we don't await the result.
-    try {
-      inspector.setImageExportEnabled(true);
-      // Per-mode gating — disable buttons whose mode the loaded cloud can't
-      // satisfy (Normal map on a LAZ, etc.) so the user sees the constraint
-      // before clicking rather than as a post-click error toast.
-      inspector.setImageExportAvailability(viewer.availableImageExportModes());
-    } catch (err) {
-      if (debug) console.warn('[inspector] setImageExportEnabled threw', err);
-    }
-    void prewarmExportStudio();
-
-    // A share link, if one opened this page, restores its view onto this scan.
-    if (pendingShareState) {
-      try {
-        applyShareState(pendingShareState, result.cloud);
-      } catch (err) {
-        if (debug) console.warn('[share] applyShareState threw', err);
-      }
-      pendingShareState = null;
-    }
-
-    // The render-quality controls reflect the viewer's state — EDL defaults
-    // depend on the GPU backend, known only once `viewer.ready` resolved.
-    try {
-      inspector.syncRendering({
-        pointSize: viewer.pointSize,
-        edlEnabled: viewer.edlEnabled,
-        edlStrength: viewer.edlStrength,
-        pointSizeMode: viewer.pointSizeMode,
-        antialiasing: viewer.antialiasing,
-        twoFingerTwistEnabled: viewer.twoFingerTwistEnabled,
-    splatMode: viewer.splatMode,
-      });
-    } catch (err) {
-      if (debug) console.warn('[inspector] syncRendering threw', err);
-    }
-
-    if (!bareMode) showProjectCard(result.cloud, result.originalPointCount);
-
-    // Reveal the Analyse panel now there's a scan to analyse. v0.4.0.
-    revealAnalysePanel(result.cloud.name);
-
-    // Instant analysis-on-drop — surface the most relevant analysis one click
-    // away (terrain / volume / floor plan / before-after), nothing uploaded.
-    // Skipped in bare/embedded mode, which has no panels to drive.
-    if (!bareMode) showInstantAnswer(result.cloud.name);
-
-    // Classification legend (v0.4.1) — populate from the cloud's per-point
-    // class buffer when present, then show. A scan with no classification
-    // channel renders the panel's empty state. DISPLAY-ONLY; the all-visible
-    // default mask is applied so nothing is hidden on load.
-    try {
-      refreshClassLegend(result.cloud.classification);
-    } catch (err) {
-      if (debug) console.warn('[class-legend] refresh threw', err);
-    }
-
-    // Developer diagnostics — the merged telemetry feeds the debug console
-    // block, the performance overlay, and (under ?benchmark=1) a benchmark.
-    if ((debug || benchmark) && result.telemetry) {
-      const telemetry = { ...result.telemetry, gpuUploadMs, firstRenderMs };
-      if (debug) {
-        console.log(
-          '%cOpenLiDARViewer — load telemetry',
-          'font-weight:600;color:#22dcff',
-          '\n' + formatTelemetry(telemetry),
-        );
-      }
-      debugOverlay?.setTelemetry(telemetry);
-      if (benchmark) {
-        const text = formatBenchmarkResult(
-          buildBenchmarkResult(
-            result.cloud.name,
-            result.cloud.sourceFormat,
-            result.cloud.pointCount,
-            telemetry,
-            // Surface the header-declared point count when the source had
-            // one, so the benchmark output disambiguates "4M of 100M (4 %)"
-            // from "4M of 4M (100 %)" — a budget-capped load shouldn't
-            // read identically to a full one.
-            result.cloud.declaredPointCount,
-          ),
-        );
-        console.log(
-          '%cOpenLiDARViewer — benchmark',
-          'font-weight:600;color:#22dcff',
-          '\n' + text,
-        );
-        debugOverlay?.setBenchmark('benchmark\n' + text);
-      }
-    }
-    dropZone.setCancelHandler(null);
-    dropZone.setProgress(null);
-  } catch (err) {
-    dropZone.setCancelHandler(null);
-    if (err instanceof LoadCancelledError) {
-      // A cancelled load is a quiet no-op — no error toast, nothing was added.
-      dropZone.setProgress(null);
-    } else {
-      // The toast shows a clear, categorised message; the raw error still
-      // reaches the console for developers under ?debug=1.
-      if (debug) console.error('OpenLiDARViewer — load error', err);
-      dropZone.setError(describeLoadError(err));
-      // A streaming open that failed mid-flight leaves no scan — tidy up.
-      closeStreaming();
-    }
-  } finally {
-    loading = false;
-  }
+function handleFile(file: File): Promise<void> {
+  return openScan(file, openScanDeps);
 }
 
 /**

--- a/tests/additiveOpenKeepsWork.test.ts
+++ b/tests/additiveOpenKeepsWork.test.ts
@@ -14,9 +14,10 @@
  * identical at the point of the clear. Until annotations carry a layer, the
  * honest rule is to reset only when there is nothing to preserve.
  *
- * Two assertions here. The first models the rule, so a reader can see what it
- * decides. The second reads main.ts, because that is where the rule lives and
- * the file cannot be imported in Node.
+ * Two assertions here. The first exercises the rule directly — the load-pipeline
+ * extraction (`src/app/openScan.ts`) exports it as the pure `shouldResetSavedWork`,
+ * so a reader can see what it decides. The second reads `src/app/openScan.ts`,
+ * because that is where the rule now lives and the shell cannot be imported in Node.
  */
 
 import { readFileSync } from 'node:fs';
@@ -24,9 +25,11 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { shouldResetSavedWork } from '../src/app/openScan';
+
 /** The decision the load path makes, with nothing else attached. */
 function resetsSavedWork(cloudCountAfterAdd: number): boolean {
-  return cloudCountAfterAdd <= 1;
+  return shouldResetSavedWork(cloudCountAfterAdd);
 }
 
 describe('an additive open keeps saved work', () => {
@@ -52,16 +55,17 @@ describe('an additive open keeps saved work', () => {
 });
 
 describe('the load path applies that rule', () => {
-  const mainSource = readFileSync(join(__dirname, '../src/main.ts'), 'utf8');
+  const loadSource = readFileSync(join(__dirname, '../src/app/openScan.ts'), 'utf8');
 
   it('gates the bookmark and annotation reset on the cloud count', () => {
     // Matching the guard rather than the bare calls: an unguarded
     // `bookmarks.clear()` on this path is the defect, so the test has to see
-    // the condition, not just the presence of a clear.
+    // the condition, not just the presence of a clear. The gate is the pure
+    // `shouldResetSavedWork(viewer.clouds().length)` after the extraction.
     const guarded =
-      /if \(viewer\.clouds\(\)\.length <= 1\) \{[^}]*bookmarks\.clear\(\);[^}]*viewer\.annotate\.clear\(\);[^}]*\}/;
+      /if \(shouldResetSavedWork\(viewer\.clouds\(\)\.length\)\) \{[^}]*bookmarks\.clear\(\);[^}]*viewer\.annotate\.clear\(\);[^}]*\}/;
     expect(
-      guarded.test(mainSource),
+      guarded.test(loadSource),
       'The reset must stay gated on there being at most one cloud. An ' +
         'unconditional clear here destroys saved viewpoints for a layer that ' +
         'is still on screen, with no undo.',
@@ -74,11 +78,11 @@ describe('the load path applies that rule', () => {
     // Anchored forward from the additive marker: `refreshAnnotationPanel();`
     // also appears earlier in the file, so an unanchored indexOf produced an
     // empty slice and the assertion below passed against nothing.
-    const start = mainSource.indexOf('static layers are ADDITIVE');
-    const end = mainSource.indexOf('refreshAnnotationPanel();', start);
+    const start = loadSource.indexOf('static layers are ADDITIVE');
+    const end = loadSource.indexOf('refreshAnnotationPanel();', start);
     expect(start).toBeGreaterThan(0);
     expect(end).toBeGreaterThan(start);
-    const loadPath = mainSource.slice(start, end);
+    const loadPath = loadSource.slice(start, end);
     expect(loadPath).not.toContain('clearMeasurements');
   });
 });

--- a/tests/architectureMap.test.ts
+++ b/tests/architectureMap.test.ts
@@ -91,9 +91,10 @@ describe('architecture map stays in step with the tree', () => {
     // The floor is a sanity guard against the tables being deleted wholesale,
     // not a fixed size: each completed extraction moves its row out of the
     // pending table into "Done:" prose, so the count ratchets down over time
-    // (the render-loop and importSession extractions took it from 10 to 8).
+    // (the render-loop and importSession extractions took it from 10 to 8, and
+    // the openScan extraction took it to 7).
     const rows = text.split('\n').filter((l) => /^\|\s*`?[A-Za-z_]/.test(l) && /\|\s*[\d,]+\s*\|/.test(l));
-    expect(rows.length, 'the extraction tables have gone missing').toBeGreaterThanOrEqual(8);
+    expect(rows.length, 'the extraction tables have gone missing').toBeGreaterThanOrEqual(7);
 
     const lines = [
       ...readFileSync(root + 'src/main.ts', 'utf8').split('\n'),

--- a/tests/openScan.test.ts
+++ b/tests/openScan.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  openScan,
+  layerChipCount,
+  shouldResetSavedWork,
+  type OpenScanDeps,
+} from '../src/app/openScan';
+import { COPC_DETECT_MIN_BYTES } from '../src/io/copc/copcDetect';
+import type { Viewer } from '../src/render/Viewer';
+import type { ClassScope } from '../src/render/class/classScope';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The two pure decisions the extraction exposes — the only load-pipeline logic
+// that can be decided without a Viewer, a canvas or the DOM.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('layerChipCount — the file-total vs display-subset decision', () => {
+  it('shows the source total when the display cloud was budget-reduced below it', () => {
+    // A 100M-point file rendered at a 4M budget: the Layers chip names the file.
+    expect(layerChipCount(100_000_000, 4_000_000)).toBe(100_000_000);
+  });
+
+  it('shows the display count when the load was NOT reduced (original === display)', () => {
+    expect(layerChipCount(4_000_000, 4_000_000)).toBe(4_000_000);
+  });
+
+  it('shows the display count when the source total is unknown (undefined)', () => {
+    // No header-declared total — the display count is the only number we have.
+    expect(layerChipCount(undefined, 2_500_000)).toBe(2_500_000);
+  });
+
+  it('never shows a source total smaller than the display count', () => {
+    // Defensive: a smaller "original" is not a reduction, so it must not win.
+    expect(layerChipCount(1_000, 4_000)).toBe(4_000);
+  });
+
+  it('treats a zero source total as absent', () => {
+    expect(layerChipCount(0, 4_000)).toBe(4_000);
+  });
+});
+
+describe('shouldResetSavedWork — fresh project vs additive open', () => {
+  it('resets on the first loaded cloud', () => {
+    expect(shouldResetSavedWork(1)).toBe(true);
+  });
+
+  it('resets defensively when the scene is somehow empty', () => {
+    expect(shouldResetSavedWork(0)).toBe(true);
+  });
+
+  it('keeps saved work when a second cloud is added (additive open)', () => {
+    expect(shouldResetSavedWork(2)).toBe(false);
+    expect(shouldResetSavedWork(5)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The three-way router — session / COPC / static — the decidable dispatch.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A minimal File stand-in: `openScan` reads only `.name` and `.slice(...).arrayBuffer()`. */
+function fakeFile(name: string, head?: ArrayBuffer): File {
+  return {
+    name,
+    slice: () => ({ arrayBuffer: async () => head ?? new ArrayBuffer(0) }),
+  } as unknown as File;
+}
+
+/** A 589-byte COPC head: "LASF" magic, a "copc" info VLR at 377, record id 1 at 393. */
+function copcHead(): ArrayBuffer {
+  const buf = new ArrayBuffer(COPC_DETECT_MIN_BYTES);
+  const u8 = new Uint8Array(buf);
+  u8[0] = 0x4c; u8[1] = 0x41; u8[2] = 0x53; u8[3] = 0x46; // LASF
+  u8[377] = 0x63; u8[378] = 0x6f; u8[379] = 0x70; u8[380] = 0x63; // copc
+  new DataView(buf).setUint16(393, 1, true); // COPC info VLR record id
+  return buf;
+}
+
+/**
+ * Build an OpenScanDeps wired to spies. `loadLocalSource` rejects by default so
+ * the static route stops at the loader without needing a real cloud / GPU — the
+ * routing and the loading-flag lifecycle are what these tests observe. A
+ * `loading` override starts the one-load-at-a-time guard closed.
+ */
+function makeDeps(over: { loading?: boolean } = {}) {
+  let loading = over.loading ?? false;
+  const calls = {
+    importSession: vi.fn(async () => {}),
+    isLoading: vi.fn(() => loading),
+    setLoading: vi.fn((v: boolean) => { loading = v; }),
+    showToast: vi.fn(),
+    setOpening: vi.fn(),
+    setCancelHandler: vi.fn(),
+    setProgress: vi.fn(),
+    setPreload: vi.fn(),
+    setError: vi.fn(),
+    openLocalCopc: vi.fn(async () => {}),
+    loadLocalSource: vi.fn(async () => { throw new Error('loader not exercised in this test'); }),
+    closeStreaming: vi.fn(),
+  };
+
+  const deps: OpenScanDeps = {
+    viewerReady: Promise.resolve(),
+    getViewer: () => ({}) as unknown as Viewer,
+    importSession: calls.importSession,
+    isLoading: calls.isLoading,
+    setLoading: calls.setLoading,
+    showToast: calls.showToast,
+    dropZone: {
+      setOpening: calls.setOpening,
+      setCancelHandler: calls.setCancelHandler,
+      setProgress: calls.setProgress,
+      setPreload: calls.setPreload,
+      setError: calls.setError,
+    },
+    openLocalCopc: calls.openLocalCopc,
+    loadLocalSource: calls.loadLocalSource,
+    renderBudget: 1_000_000,
+    isPhone: () => false,
+    deviceMemoryGB: () => 8,
+    stage: { hideEmptyState: vi.fn() },
+    closeStreaming: calls.closeStreaming,
+    scans: { setActive: vi.fn(), activeId: null } as unknown as OpenScanDeps['scans'],
+    inspector: {} as unknown as OpenScanDeps['inspector'],
+    inspectorCards: {} as unknown as OpenScanDeps['inspectorCards'],
+    crsCoordinator: {} as unknown as OpenScanDeps['crsCoordinator'],
+    dock: {} as unknown as OpenScanDeps['dock'],
+    navBar: {} as unknown as OpenScanDeps['navBar'],
+    bookmarks: { clear: vi.fn() },
+    layerService: { refreshCrsFlags: vi.fn() },
+    setLayerVisible: vi.fn(),
+    rememberSourceFile: vi.fn(),
+    rememberReduced: vi.fn(),
+    refreshAnnotationPanel: vi.fn(),
+    setCurrentColorMode: vi.fn(),
+    loadApplyDisplayProfile: vi.fn(async () => ({ applyDisplayProfile: vi.fn() })),
+    runModules: vi.fn(() => []),
+    currentClassScope: vi.fn(() => ({}) as unknown as ClassScope),
+    prewarmExportStudio: vi.fn(),
+    getPendingShareState: () => null,
+    clearPendingShareState: vi.fn(),
+    applyShareState: vi.fn(),
+    bareMode: false,
+    showProjectCard: vi.fn(),
+    revealAnalysePanel: vi.fn(),
+    showInstantAnswer: vi.fn(),
+    refreshClassLegend: vi.fn(),
+    debug: false,
+    benchmark: false,
+    getDebugOverlay: () => null,
+  };
+
+  return { deps, calls };
+}
+
+describe('openScan — the file router', () => {
+  it('routes an .olvsession to the session loader, never the cloud worker', async () => {
+    const { deps, calls } = makeDeps();
+    await openScan(fakeFile('survey.olvsession'), deps);
+    expect(calls.importSession).toHaveBeenCalledTimes(1);
+    // A session restore routes AHEAD of the loading guard and touches no loader.
+    expect(calls.isLoading).not.toHaveBeenCalled();
+    expect(calls.setLoading).not.toHaveBeenCalled();
+    expect(calls.loadLocalSource).not.toHaveBeenCalled();
+    expect(calls.openLocalCopc).not.toHaveBeenCalled();
+  });
+
+  it('refuses a second load while one is in flight, without starting anything', async () => {
+    const { deps, calls } = makeDeps({ loading: true });
+    await openScan(fakeFile('scan.laz'), deps);
+    expect(calls.showToast).toHaveBeenCalledWith(
+      expect.stringContaining('Already loading'),
+    );
+    expect(calls.importSession).not.toHaveBeenCalled();
+    expect(calls.loadLocalSource).not.toHaveBeenCalled();
+    expect(calls.setLoading).not.toHaveBeenCalled(); // never claimed the flag
+  });
+
+  it('routes a COPC file to the streaming pipeline, not the static loader', async () => {
+    const { deps, calls } = makeDeps();
+    await openScan(fakeFile('cloud.copc.laz', copcHead()), deps);
+    expect(calls.openLocalCopc).toHaveBeenCalledTimes(1);
+    expect(calls.loadLocalSource).not.toHaveBeenCalled();
+    // The flag is claimed and released around the streaming open.
+    expect(calls.setLoading).toHaveBeenNthCalledWith(1, true);
+    expect(calls.setLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it('routes a non-COPC file to the static loader and reports a loader failure honestly', async () => {
+    const { deps, calls } = makeDeps();
+    await openScan(fakeFile('scan.las', new ArrayBuffer(0)), deps);
+    expect(calls.loadLocalSource).toHaveBeenCalledTimes(1);
+    expect(calls.openLocalCopc).not.toHaveBeenCalled();
+    // A failed load surfaces on the drop zone, tidies any half-open stream,
+    // and always releases the loading flag in `finally`.
+    expect(calls.setError).toHaveBeenCalledTimes(1);
+    expect(calls.closeStreaming).toHaveBeenCalledTimes(1);
+    expect(calls.setLoading).toHaveBeenNthCalledWith(1, true);
+    expect(calls.setLoading).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/tests/streamingScanReveal.test.ts
+++ b/tests/streamingScanReveal.test.ts
@@ -78,9 +78,13 @@ describe('streaming scan reveal', () => {
     // And nothing re-inlines the block. Two hand-written `setCloseEnabled`
     // calls are correct and expected: the static-load path enables it, and
     // `closeScan` disables it on the way back to the empty state. A third
-    // means a streaming path drifted back out of the shared reveal.
-    const enables = main.match(/dock\.setCloseEnabled\(true\)/g) ?? [];
-    const disables = main.match(/dock\.setCloseEnabled\(false\)/g) ?? [];
+    // means a streaming path drifted back out of the shared reveal. The
+    // static-load enable moved to the extracted open/load pipeline
+    // (`src/app/openScan.ts`), so the enable is counted across both files while
+    // the disable stays in the shell's `closeScan`.
+    const openScanSrc = readFileSync(resolve(ROOT, 'src/app/openScan.ts'), 'utf8');
+    const enables = (main + openScanSrc).match(/dock\.setCloseEnabled\(true\)/g) ?? [];
+    const disables = (main + openScanSrc).match(/dock\.setCloseEnabled\(false\)/g) ?? [];
     expect(enables.length).toBe(1);
     expect(disables.length).toBe(1);
   });

--- a/tests/viewState.test.ts
+++ b/tests/viewState.test.ts
@@ -129,8 +129,12 @@ describe('main.ts scan-lifecycle reset sites still clear saved views', () => {
     // mutation onto the `viewBookmarks` service, so each reset now calls
     // `bookmarks.clear()`. The "views AND counter, together" guarantee is atomic
     // in the service's clear() (see tests/viewBookmarks.test.ts) rather than
-    // duplicated across three inline field pairs.
-    const src = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8');
+    // duplicated across three inline field pairs. The new-static-scan reset now
+    // lives in the extracted open/load pipeline (`src/app/openScan.ts`), so the
+    // three sites span both the shell and that module.
+    const src =
+      readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8') +
+      readFileSync(new URL('../src/app/openScan.ts', import.meta.url), 'utf8');
     const resets = src.match(/bookmarks\.clear\(\)/g) ?? [];
     expect(resets.length).toBeGreaterThanOrEqual(3);
     // And no reset site pokes the cluster fields directly any more.


### PR DESCRIPTION
## What

Extracts the open/load pipeline (`handleFile`, ~336 lines) out of the `src/main.ts` monolith into `src/app/openScan.ts` as `openScan(file, deps)`, following the exact idiom already used for `importSession` (`sessionIo.ts`), `buildActionRegistry` (`actionDefinitions.ts`) and the render hosts (`renderLoop.ts` / `snapshot.ts`).

`openScan` is driven through a structural `OpenScanDeps` object — accessor functions closing over the shell's services, **not** the Viewer class. `main.ts` keeps a thin `handleFile` delegate that binds its running state (the `loading` / `currentColorMode` / `pendingShareState` module lets, the `getViewer()` seam, the panel/dock/inspector services) to those deps. **No behaviour change.**

## Pure decisions, now Node-tested

The extraction exposes the two genuinely pure decisions the pipeline made; both are exported and covered in `tests/openScan.test.ts`:

- `layerChipCount(originalPointCount, displayPointCount)` — the file-total vs strided-display count the Layers chip shows (the "loaded / total" distinction).
- `shouldResetSavedWork(loadedCloudCount)` — fresh-project reset vs additive-open keep.

The same test file also pins the three-way **session / COPC / static** router (session routes ahead of the loading guard; the one-load-at-a-time guard; COPC → streaming; non-COPC → static loader with honest error surfacing).

## main.ts shrinks

`6,790 → 6,507` lines. The monolith-size baseline is re-banked to the lower count (shrink only). `Viewer.ts` untouched.

## Truth records

- `docs/architecture/architecture-map.md`: `handleFile`'s `*(planned)*` table row moves into "Done" prose; the `src/main.ts` totals updated.
- `tests/architectureMap.test.ts`: pending-extraction floor guard ratchets `8 → 7` (one row left the table), exactly as prior extractions did.
- `KNOWN_LIMITATIONS_v0.6.3.md`: restates the current line count (kept in step with the ratchet baseline, enforced by `lint:release-truth`).
- Three source-shape guard tests (`additiveOpenKeepsWork`, `viewState`, `streamingScanReveal`) now read the pipeline at its new home; `additiveOpenKeepsWork` exercises the real exported `shouldResetSavedWork` directly.

## Gates (all green)

| Gate | Exit |
|---|---|
| `tsc --noEmit` | 0 |
| `vitest run` (7691 passed) | 0 |
| `lint-monolith-size` | 0 |
| `lint-layer-boundaries` | 0 |
| `lint-main-deferral` | 0 |
| `verify-archive-portability` | 0 |
| deterministic e2e (`--project=deterministic`, 162 passed / 4 skipped) | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)