### PR TITLE
Fix flaky mapSheetPdf byte-identity test (fixed generatedAt)

### DIFF
--- a/tests/mapSheetPdf.test.ts
+++ b/tests/mapSheetPdf.test.ts
@@ -227,7 +227,11 @@ describe('buildMapSheetPdf', () => {
   });
 
   it('is byte-identical whether the annotation flag is OFF or absent', async () => {
-    const base = { model, labels: [], crs: model.crs, verticalDatum: model.verticalDatum, sheet: 'letter' as const };
+    // A fixed generatedAt: the sheet stamps the generation time (minute
+    // precision) when none is passed (`?? new Date()`), so two back-to-back
+    // builds that straddle a minute boundary on a slow runner differ — a real
+    // flake that has nothing to do with the annotation flag this test pins.
+    const base = { model, labels: [], crs: model.crs, verticalDatum: model.verticalDatum, sheet: 'letter' as const, generatedAt: new Date(0) };
     const absent = await buildMapSheetPdf({ ...base });
     const off = await buildMapSheetPdf({ ...base, includeAnnotations: false, annotations: [anno('1', 25, 60)], sceneUpAxis: 'z' });
     expect(Buffer.from(off).equals(Buffer.from(absent))).toBe(true);


### PR DESCRIPTION
The `is byte-identical whether the annotation flag is OFF or absent` test built two PDFs with no `generatedAt`, so each stamped the wall clock (minute precision, `?? new Date()`). Two back-to-back builds that straddle a minute boundary on a slow CI runner produce different bytes — a real flake unrelated to the annotation flag the test pins (it blocked #241, whose code never touches mapSheetPdf). Passing a fixed `generatedAt: new Date(0)` makes both builds stamp the same time. tsc 0; mapSheetPdf 26/26.