### PR TITLE
Extract handleRemoteEpt + openStreamingCopc → src/app/openStreaming.ts behind a structural deps object

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.3.md
+++ b/KNOWN_LIMITATIONS_v0.6.3.md
@@ -6,7 +6,7 @@ Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 6,507 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 6,125 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 6,507 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 6,125 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -98,7 +98,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (6,507)** — the largest blocks, which are the extraction
+**`src/main.ts` (6,125)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,
@@ -109,7 +109,6 @@ called with a 19-member deps object. The candidates that remain:
 | `seedStreamingFilterExtents` | 338 | streaming panel wiring module |
 | `syncInspectorVisuals` | 266 | inspector wiring module |
 | `applyScanRoute` | 233 | joins `ScanRouteService` |
-| `handleRemoteEpt` / `openStreamingCopc` | 406 | `src/app/openStreaming.ts` *(planned)* |
 | `generateReportPdf` / `exportGeoContext` | 402 | export/report wiring module |
 
 Done: `importSession` (~208 lines) now lives in `src/app/sessionIo.ts`, called with a
@@ -126,6 +125,20 @@ Node-tested — `layerChipCount` (the file-total vs strided-display count the La
 chip shows) and `shouldResetSavedWork` (fresh-project vs additive open) — alongside
 the three-way router's session / COPC / static dispatch (`tests/openScan.test.ts`).
 `main.ts` keeps a thin `handleFile` delegate that binds its running state to the deps.
+
+Done: `handleRemoteEpt` / `openStreamingCopc` (~406 lines) — the remote / streaming
+open pipeline — now live in `src/app/openStreaming.ts`, driven through an
+`OpenStreamingDeps` object of accessor functions closing over the shell's services
+and its mutable streaming-session state (the load flag, the COPC / EPT decode
+workers, the benchmark collector, the quality preset) rather than the Viewer class.
+The pure decisions the extraction exposes are Node-tested — `isEptUrl` (the
+COPC-vs-EPT routing predicate the shell's URL router dispatches on), `isAbortError`
+(the user-cancel classifier both remote handlers surface through) and
+`linkAbortSignals` — alongside the guarded remote-open paths: the one-load guard, the
+URL-validation gate, and the honest error surfacing (`tests/openStreaming.test.ts`).
+The SSRF URL validation (`validateRemoteEptUrl` / `validateRemoteCopcUrl`) is
+preserved exactly. `main.ts` keeps thin `openStreamingCopc` / `handleRemoteEpt`
+delegates that bind its running state to the deps.
 
 **`src/render/Viewer.ts` (6,419)** — the constructor and a handful of large
 methods dominate:

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 6507,
+      "lines": 6125,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/app/openStreaming.ts
+++ b/src/app/openStreaming.ts
@@ -1,0 +1,663 @@
+/**
+ * openStreaming.ts — the remote / streaming open pipeline lifted out of main.ts.
+ *
+ * Two functions live here: {@link openStreamingCopc}, which opens a COPC scan
+ * from any range-readable source (a local file or a remote HTTP URL) through the
+ * streaming pipeline, and {@link handleRemoteEpt}, which opens a remote EPT
+ * dataset by its `ept.json` URL. Both read the metadata / hierarchy, attach the
+ * streaming cloud to the viewer, and reveal the streaming chrome; the format
+ * difference stops at attach — the scheduler / renderer / picking path never
+ * sees it.
+ *
+ * The genuinely pure decisions the pipeline makes are extracted as free
+ * functions so they are Node-testable without a Viewer, the network or the DOM:
+ * {@link isEptUrl} (the COPC-vs-EPT routing predicate the shell's URL router
+ * dispatches on), {@link isAbortError} (the user-cancel classifier both remote
+ * handlers surface through) and {@link linkAbortSignals} (composing an outer
+ * Cancel with a load's own controller). Everything else is imperative view
+ * orchestration, driven through a structural {@link OpenStreamingDeps} of
+ * accessor functions closing over the shell's services and its mutable
+ * streaming-session state rather than the Viewer class — the same seam
+ * `openScan` and `sessionIo` use. The heavy runtime actions (the lazy COPC /
+ * EPT / diagnostics chunks) are passed in so this module stays free of the boot
+ * graph. `main.ts` keeps thin `openStreamingCopc` / `handleRemoteEpt` delegates
+ * that bind its running state to these deps. Part of the v0.6 decomposition
+ * (see `docs/architecture/architecture-map.md`).
+ */
+
+import { LoadCancelledError } from '../io/loadFile';
+import { describeLoadError } from '../io/loadErrors';
+import { increment as recordUsage } from '../diagnostics/usageCounters';
+import { remoteCopcName, remoteEptName } from './remoteSourceNaming';
+
+import type { RangeSource } from '../io/range/RangeSource';
+import type { StreamingQuality } from '../render/streaming/streamingBudget';
+import type { StreamingBenchmark } from '../render/streaming/streamingBenchmark';
+import type { CopcWorkerClient } from '../io/copc/worker/copcWorkerClient';
+import type { EptLaszipWorkerClient } from '../io/ept/worker/eptLaszipWorkerClient';
+import type { CrsInfo, CrsLinearUnit } from '../io/crs';
+import type { AnalysisRow } from '../analysis/ModuleApi';
+import type { Viewer } from '../render/Viewer';
+import type { Inspector } from '../ui/Inspector';
+import type { Stage } from '../ui/Stage';
+import type { DropZone } from '../ui/DropZone';
+import type { StreamingPanel } from '../ui/StreamingPanel';
+import type { ClassLegendPanel } from '../ui/ClassLegendPanel';
+import type { InspectorCardRefreshers } from './inspectorCardRefreshers';
+import type { CrsCoordinator } from './crsCoordinator';
+import type { ViewBookmarksService } from './viewBookmarks';
+import type {
+  loadStreamingPointCloud,
+  loadCopcWorkerClient,
+  loadStreamingColors,
+  loadEptLaszipWorkerClient,
+  loadEpt,
+} from '../lazyChunks';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure decisions the extraction exposes — decidable without a Viewer, the
+// network or the DOM, so `tests/openStreaming.test.ts` pins each one directly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * True when `url` is an EPT entry point (an `ept.json`), so the shell's URL
+ * router hands it to {@link handleRemoteEpt} instead of the COPC path. The check
+ * is URL-pattern only — fast, no network, no schema fetch — mirroring
+ * `detectEptUrl` in `eptDetect.ts` so the routing decision is synchronous and
+ * does not depend on the EPT lazy chunk loading. A malformed URL that `new URL`
+ * cannot parse still gets a raw-string test, so it routes deterministically
+ * rather than throwing.
+ */
+export function isEptUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    return /(?:^|\/)ept\.json$/i.test(u.pathname);
+  } catch {
+    return /(?:^|\/)ept\.json(?:\?|#|$)/i.test(url);
+  }
+}
+
+/**
+ * True when `err` is a user-initiated abort, in any of the shapes a cancel can
+ * surface as on the remote-open path:
+ *
+ *  - the platform's DOMException named `AbortError` (a fetch aborted directly by
+ *    the linked signal), or
+ *  - `RangeReadError` with code `'aborted'` — `HttpRangeSource` wraps the
+ *    platform abort in its typed error before it reaches us.
+ *
+ * The Stage URL-field Cancel aborts the linked signal while a fetch or range
+ * probe is in flight; neither rejection is our `LoadCancelledError`, so cancel
+ * handling must recognise all three shapes.
+ */
+export function isAbortError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { name?: unknown; code?: unknown };
+  if (e.name === 'AbortError') return true;
+  return e.name === 'RangeReadError' && e.code === 'aborted';
+}
+
+/**
+ * Wire an optional outer abort signal (the Stage URL field's Cancel button) into
+ * a load's own AbortController (the progress toast's Cancel) so EITHER cancel
+ * aborts the in-flight fetches. Returns a cleanup that detaches the listener —
+ * call it on every exit path so a long-lived outer signal can't accumulate
+ * listeners across loads. (Mirrors the private `composeSignals` discipline
+ * inside `HttpRangeSource`.)
+ */
+export function linkAbortSignals(
+  outer: AbortSignal | undefined,
+  controller: AbortController,
+): () => void {
+  if (!outer) return () => {};
+  if (outer.aborted) {
+    controller.abort();
+    return () => {};
+  }
+  const onAbort = (): void => controller.abort();
+  outer.addEventListener('abort', onAbort, { once: true });
+  return () => outer.removeEventListener('abort', onAbort);
+}
+
+/**
+ * The streaming Scan Report's input — the structural cloud shape
+ * `runStreamingModules` reads. Kept identical to the shell's own parameter type
+ * so the COPC source (a `StreamingPointCloud`) and the EPT path's hand-built
+ * report cloud both satisfy it, and `lastStreamingReportCloud` round-trips.
+ */
+export type StreamingReportInput = {
+  readonly kind: 'copc' | 'ept';
+  readonly name: string;
+  readonly sourcePointCount: number;
+  readonly localBounds?: () => readonly [number, number, number, number, number, number];
+  readonly metadata?: {
+    readonly header?: {
+      min: readonly [number, number, number];
+      max: readonly [number, number, number];
+      pointDataRecordFormat?: number;
+    };
+    readonly info?: { spacing?: number };
+    readonly captureSensor?: string;
+    readonly sourceSoftware?: string;
+  };
+  readonly crs?: () => { readonly linearUnit?: CrsLinearUnit; readonly linearUnitToMetres?: number; readonly verticalUnitToMetres?: number } | null;
+  readonly maxDepth?: () => number;
+  readonly octree?: { nodes: () => readonly unknown[] };
+};
+
+/**
+ * The running-app seam the streaming opens write through. Accessors are
+ * functions, not snapshots, so the lazily-bound Viewer, the mutable load flag
+ * and the streaming-session state (`streamingBenchmark`, the decode workers, the
+ * quality preset) are read at call time — exactly as the inline versions read
+ * the shell's module-level `let`s. That session state is shared with code that
+ * stays in the shell (`closeStreaming`, the status poll, the render-loop
+ * sample), so it moves behind get/set accessors rather than into this module.
+ * The heavy runtime actions (the lazy COPC / EPT / diagnostics chunks) are
+ * passed in so this module stays free of the loader / boot graph.
+ */
+export interface OpenStreamingDeps {
+  // ── Lazy runtime chunks (each an `import()` split point in lazyChunks.ts) ──
+  loadStreamingPointCloud: typeof loadStreamingPointCloud;
+  loadCopcWorkerClient: typeof loadCopcWorkerClient;
+  loadStreamingColors: typeof loadStreamingColors;
+  loadEptLaszipWorkerClient: typeof loadEptLaszipWorkerClient;
+  loadEpt: typeof loadEpt;
+  /** The `?benchmark=1` / `?debug=1` diagnostics runtime — only the two members these opens construct. */
+  loadDiagnostics: () => Promise<{
+    StreamingBenchmark: new () => StreamingBenchmark;
+    InstrumentedRangeSource: new (inner: RangeSource, onBytes: (bytes: number) => void) => RangeSource;
+  }>;
+
+  /** Resolves once the lazily-loaded Viewer chunk is in place — awaited before any `getViewer()`. */
+  readonly viewerReady: Promise<unknown>;
+  /** The live Viewer (a late-bound `let` in the shell). */
+  getViewer: () => Viewer;
+
+  // ── One-load-at-a-time guard (the shell's `loading` flag) ──
+  isLoading: () => boolean;
+  setLoading: (loading: boolean) => void;
+
+  // ── Streaming-session state shared with the shell — read/written at call
+  //    time through accessors so both sides see one value ──
+  getStreamingBenchmark: () => StreamingBenchmark | null;
+  setStreamingBenchmark: (benchmark: StreamingBenchmark | null) => void;
+  setCoarseStableFired: (fired: boolean) => void;
+  getCopcDecoder: () => CopcWorkerClient | null;
+  setCopcDecoder: (decoder: CopcWorkerClient) => void;
+  getEptLaszipDecoder: () => EptLaszipWorkerClient | null;
+  setEptLaszipDecoder: (decoder: EptLaszipWorkerClient) => void;
+  getStreamingQuality: () => StreamingQuality;
+  setLastStreamingReportCloud: (cloud: StreamingReportInput) => void;
+
+  // ── URL flags ──
+  readonly debug: boolean;
+  readonly benchmark: boolean;
+
+  // ── Toast + drop-zone status surface ──
+  showToast: (message: string) => void;
+  dropZone: Pick<DropZone, 'setError' | 'setOpening' | 'setCancelHandler' | 'setProgress'>;
+
+  // ── View collaborators ──
+  stage: Pick<Stage, 'hideEmptyState'>;
+  inspector: Inspector;
+  streamingPanel: Pick<StreamingPanel, 'setPhase' | 'show' | 'setColorModes' | 'setQuality' | 'setSummary'>;
+  classLegendPanel: Pick<ClassLegendPanel, 'setClasses' | 'hide' | 'getVisibility'>;
+  inspectorCards: Pick<
+    InspectorCardRefreshers,
+    'refreshProvenanceFromStreaming' | 'refreshDatasetIntelligenceFromStreamingCloud'
+  >;
+  crsCoordinator: Pick<CrsCoordinator, 'refreshCrsForStreamingCloud'>;
+  bookmarks: Pick<ViewBookmarksService, 'clear'>;
+
+  /** Phone-class device — tighter streaming budget + touch hints. */
+  isPhone: () => boolean;
+
+  // ── Session lifecycle helpers that stay in the shell ──
+  /** Tear down any open streaming scan (a failed open tidies up; a replacement supersedes). */
+  closeStreaming: () => void;
+  /** Free the open static layers — a streaming scan is exclusive. */
+  clearOpenStaticLayers: () => void;
+  /** Start the ~4 Hz streaming-status poll that drives the panel. */
+  startStreamingStatusPolling: () => void;
+  /** Reveal the scan-dependent chrome (dock, inspector, nav bar, `olv-has-scan`) for a streaming cloud. */
+  revealStreamingChrome: () => void;
+  /** Reveal the Analyse panel for the streaming scan. */
+  revealAnalysePanel: (name: string, settled?: boolean) => void;
+  /** Pre-warm the lazy Visual Export Studio chunk. */
+  prewarmExportStudio: () => void;
+  /** Fire the streaming + format chunk pre-warm for a URL open. */
+  prewarmForUrl: (url: string) => void;
+  /** Repopulate the saved-views list after a fresh streaming open. */
+  refreshViewsUI: () => void;
+  /** Hide the reclassify UI for the new streaming scan. */
+  hideReclassifyUi: () => void;
+  /** Clear any prior scan's inspector copy/JSON class-scope stamp. */
+  syncInspectClassScope: () => void;
+  /** Run the streaming analysis modules for the Scan Report. */
+  runStreamingModules: (cloud: StreamingReportInput, classFilterActive?: boolean) => AnalysisRow[];
+}
+
+/**
+ * Open a COPC scan from any range-readable source — a local file or a remote
+ * HTTP URL — through the streaming pipeline: read the metadata and hierarchy,
+ * attach the streaming cloud to the viewer, and show the streaming panel.
+ * Point data then streams in progressively, driven by the camera.
+ */
+export async function openStreamingCopc(
+  range: RangeSource,
+  displayName: string,
+  signal: AbortSignal,
+  deps: OpenStreamingDeps,
+): Promise<void> {
+  // Race the lazy COPC + streaming chunks against `viewer.ready` so a
+  // user who opens a scan during the first ~half-second of page load
+  // (a common demo path) doesn't see chunk-fetch and GPU init run
+  // serially. By the time `viewer.ready` resolves the chunks are
+  // usually cached too — `await chunksPromise` below typically
+  // resolves immediately. On a cold start, the parallelism saves
+  // roughly the smaller of the two latencies (often 100-300 ms).
+  const chunksPromise = Promise.all([
+    deps.loadStreamingPointCloud(),
+    deps.loadCopcWorkerClient(),
+    deps.loadStreamingColors(),
+  ]);
+
+  // Show the streaming panel as soon as we know we're on the COPC branch —
+  // before `await viewer.ready`, which on cold WebGPU runners can sit for
+  // 10–18 s compiling shaders. The panel reads "Loading metadata…" while
+  // the viewer warms up, so the user gets immediate confirmation that the
+  // file was recognised as COPC instead of staring at the empty state.
+  deps.streamingPanel.setPhase('Loading metadata…');
+  deps.streamingPanel.show();
+
+  const viewer = deps.getViewer();
+  await viewer.ready;
+  // Inspector stays visible during streaming — it carries the sections
+  // that work uniformly against either source type (Scan report,
+  // Provenance, Coordinate system, Image export, Report PDF). The
+  // static-only sections are hidden via `setStreamingMode(true)` when
+  // the streaming cloud finishes attaching; until then the Inspector
+  // shows its empty placeholders, which is fine.
+  deps.inspector.element.classList.remove('olv-hidden');
+  deps.dropZone.setProgress('Reading COPC hierarchy…');
+
+  // The streaming benchmark collector is created when either `?benchmark=1`
+  // (which adds a session report on close) or `?debug=1` (which surfaces the
+  // live thrash / scheduler-histogram readout in the overlay) is set. Off by
+  // default — no overhead in normal sessions. The diagnostics chunk loads
+  // lazily on first need; cached afterwards.
+  if (deps.benchmark || deps.debug) {
+    const d = await deps.loadDiagnostics();
+    deps.setStreamingBenchmark(new d.StreamingBenchmark());
+    deps.setCoarseStableFired(false);
+    range = new d.InstrumentedRangeSource(range, (n) => {
+      deps.getStreamingBenchmark()?.recordNetworkBytes(n);
+    });
+  }
+
+  // Await the hoisted chunk fetches; if `viewer.ready` was the slow
+  // path (cold WebGPU init) this is a no-op.
+  const [{ StreamingPointCloud }, { CopcWorkerClient }, streamingColors] =
+    await chunksPromise;
+
+  const cloud = await StreamingPointCloud.open(range, displayName, signal);
+  if (signal.aborted) throw new LoadCancelledError();
+
+  let copcDecoder = deps.getCopcDecoder();
+  if (!copcDecoder) {
+    copcDecoder = new CopcWorkerClient();
+    deps.setCopcDecoder(copcDecoder);
+  }
+  // Wire the per-chunk decode timing hook only when a benchmark is collecting;
+  // clearing it on close keeps a non-benchmark session free of any callback.
+  copcDecoder.onDecodeMs = deps.getStreamingBenchmark()
+    ? (ms) => deps.getStreamingBenchmark()?.recordDecodeMs(ms)
+    : undefined;
+
+  deps.stage.hideEmptyState();
+  // Local-first counter — categorical only ('copc' or 'ept'); never the URL.
+  recordUsage('scan-open', cloud.kind === 'ept' ? 'ept' : 'copc');
+  // Provenance fingerprint for streaming clouds — fed with the cloud's
+  // declared point count + extent so the classifier has signal even though
+  // the resident set is small. Wrapped because a malformed cloud shape
+  // shouldn't break the rest of the streaming load (CRS, attach, color
+  // modes, navBar reveal).
+  try { deps.inspectorCards.refreshProvenanceFromStreaming(cloud); }
+  catch (err) { if (deps.debug) console.warn('[provenance] refreshProvenanceFromStreaming threw', err); }
+  // CRS for streaming clouds — same merge rule as the static path.
+  try {
+    deps.crsCoordinator.refreshCrsForStreamingCloud(cloud as unknown as {
+      readonly name: string;
+      readonly kind: 'copc' | 'ept';
+      crs(): CrsInfo | undefined;
+    });
+  } catch (err) {
+    if (deps.debug) console.warn('[crs] refreshCrsForStreamingCloud threw', err);
+  }
+  // A streaming scan is exclusive — clear open static layers at the last
+  // moment, after the source opened above and just before its replacement
+  // attaches, so a failed open left the current scene intact. The abort check
+  // at the open still guards this; nothing yields between it and here.
+  deps.clearOpenStaticLayers();
+  await viewer.attachStreamingCloud(
+    cloud,
+    copcDecoder,
+    deps.getStreamingQuality(),
+    deps.isPhone(),
+    deps.getStreamingBenchmark(),
+  );
+  // attachStreamingCloud takes no signal; if the user cancelled while it ran,
+  // drop the fresh cloud so a cancel adds nothing rather than half-attaching.
+  if (signal.aborted) { deps.closeStreaming(); throw new LoadCancelledError(); }
+  viewer.setMode('orbit');
+  viewer.frameAll();
+
+  deps.streamingPanel.setColorModes(
+    streamingColors.availableStreamingModes(cloud.metadata),
+    streamingColors.defaultStreamingMode(cloud.metadata),
+  );
+  deps.streamingPanel.setQuality(deps.getStreamingQuality());
+  deps.streamingPanel.setPhase('Streaming coarse geometry…');
+  // Classification legend (v0.4.1) — reset to empty for the new streaming scan.
+  // The legend is seeded + revealed lazily by `viewer.onStreamingNodeClasses`
+  // as nodes carrying classification become resident, and refines as deeper
+  // nodes stream in. A streaming source without a classification channel simply
+  // never seeds the legend, so it stays hidden.
+  deps.classLegendPanel.setClasses(new Map());
+  deps.classLegendPanel.hide();
+  deps.hideReclassifyUi();
+  // Clear any prior filtered scan's inspector copy/JSON scope stamp.
+  deps.syncInspectClassScope();
+  // Visual Export Studio — a streaming COPC cloud is now attached;
+  // the image-export buttons in the Inspector can light up. The streaming
+  // path doesn't go through `inspector.addCloud`, so the gate has to flip
+  // here too. Pre-warm the Studio chunk for the same reason as above.
+  deps.inspector.setImageExportEnabled(true);
+  // Per-mode gating — streaming COPC / EPT rarely carry normals or
+  // classification; disable the corresponding buttons at the source.
+  deps.inspector.setImageExportAvailability(viewer.availableImageExportModes());
+  // Switch the Inspector into streaming layout — hides Layers / Color by
+  // / Point size / Rendering / Export (their streaming-equivalents are
+  // in the StreamingPanel) and pins the panel to the lower-right so
+  // both panels coexist on desktop.
+  deps.inspector.setStreamingMode(true);
+  try { deps.inspector.setDetail(cloud.sourcePointCount, cloud.sourcePointCount); }
+  catch (err) { if (deps.debug) console.warn('[inspector] setDetail (streaming) threw', err); }
+  deps.setLastStreamingReportCloud(cloud);
+  try { deps.inspector.setReport(deps.runStreamingModules(cloud, deps.classLegendPanel.getVisibility().isFiltered())); }
+  catch (err) { if (deps.debug) console.warn('[inspector] setReport (streaming) threw', err); }
+  try {
+    deps.inspectorCards.refreshDatasetIntelligenceFromStreamingCloud(cloud);
+  } catch (err) {
+    if (deps.debug) console.warn('[inspector] dataset intel (streaming) threw', err);
+  }
+  deps.prewarmExportStudio();
+
+  // The metadata-driven scan summary, and a fresh saved-views list.
+  const header = cloud.metadata.header;
+  deps.revealAnalysePanel(cloud.name, false); // streaming COPC also gets the terrain tools
+  deps.streamingPanel.setSummary({
+    fileName: cloud.name,
+    pointFormat: header.pointDataRecordFormat,
+    sourcePoints: cloud.sourcePointCount,
+    width: header.max[0] - header.min[0],
+    depth: header.max[1] - header.min[1],
+    height: header.max[2] - header.min[2],
+    spacing: cloud.metadata.info.spacing,
+    octreeDepth: cloud.maxDepth(),
+    nodeCount: cloud.octree.nodes().length,
+    // explicit format tag so the Scan Intelligence panel renders
+    // "COPC LAZ · PDRF N" for COPC and "EPT · binary · N attrs" for EPT.
+    format: 'copc',
+  });
+  deps.bookmarks.clear();
+  deps.refreshViewsUI();
+
+  deps.revealStreamingChrome();
+
+  deps.startStreamingStatusPolling();
+  deps.dropZone.setProgress(null);
+}
+
+/**
+ * open a remote EPT dataset by its `ept.json` URL. Mirrors the
+ * `handleRemoteCopc` flow:
+ *   1. Validate the URL.
+ *   2. Fetch + parse + validate `ept.json` (typed failure paths surface
+ *      as user-readable error messages, same as COPC's malformed-file
+ *      path).
+ *   3. Open an `EptStreamingPointCloud` against an HTTP-backed transport.
+ *   4. Hand it to the same `viewer.attachStreamingCloud` the COPC flow
+ *      uses — the scheduler / renderer / picking path don't see the
+ *      format difference.
+ */
+export async function handleRemoteEpt(
+  url: string,
+  signal: AbortSignal | undefined,
+  deps: OpenStreamingDeps,
+): Promise<void> {
+  if (deps.isLoading()) {
+    deps.showToast('Already loading — cancel the current load first.');
+    return;
+  }
+  // Claim the flag SYNCHRONOUSLY. Every await below yields to the event
+  // loop, and a second open started in that window used to pass the
+  // `loading` guard too (TOCTOU). The `finally` below is the only reset.
+  deps.setLoading(true);
+  const controller = new AbortController();
+  // Compose the Stage URL-field Cancel (outer signal) with the progress
+  // toast's Cancel (this controller): either abort cancels the load.
+  const unlinkAbort = linkAbortSignals(signal, controller);
+  // Fire the streaming + EPT chunk pre-warm immediately. Each dynamic
+  // import is one HTTP fetch + parse; running them in parallel with
+  // the manifest GET below cuts cold-start by 200–700 ms.
+  deps.prewarmForUrl(url);
+  // Declared outside the try so the catch can use the module's error
+  // classifier when the module loaded, and a plain classifier when the
+  // chunk fetch itself was the failure.
+  let eptUrlMod: Awaited<ReturnType<OpenStreamingDeps['loadEpt']>> | null = null;
+  try {
+    // URL validation is pure — run it before awaiting the lazy Viewer so a
+    // malformed URL always surfaces an error toast, even if the Viewer chunk
+    // hasn't loaded yet or the GPU backend can't initialise.
+    eptUrlMod = await deps.loadEpt();
+    const check = eptUrlMod.validateRemoteEptUrl(url);
+    if (!check.ok) {
+      deps.dropZone.setError(`${check.reason} Enter the full https://…/ept.json URL.`);
+      return;
+    }
+    // The actual streaming open touches viewer state — defer until the lazy
+    // Viewer chunk is up.
+    await deps.viewerReady;
+    const viewer = deps.getViewer();
+    // Blue blinking "Opening …" first, consistent with the COPC + device paths;
+    // the manifest read + node streaming supersede it with staged progress.
+    deps.dropZone.setOpening(`Opening ${remoteCopcName(url)}…`);
+    deps.dropZone.setCancelHandler(() => controller.abort());
+    const { parseEptMetadata, EptStreamingPointCloud, EptChunkDecoder } = eptUrlMod;
+
+    // Fetch the manifest. We use plain `fetch` rather than the HttpRangeSource:
+    // ept.json is a small JSON document, not a range-served binary. It gets the
+    // same per-request TIMEOUT as the hardened hierarchy/tile transport (20 s),
+    // so a stalled manifest aborts instead of hanging until the user cancels;
+    // the timeout is composed with the outer load-cancel signal. Single attempt
+    // (no retry) — a failed manifest surfaces an error and the user re-opens.
+    const MANIFEST_TIMEOUT_MS = 20_000;
+    const manifestTimeout = new AbortController();
+    const manifestTimer = setTimeout(() => manifestTimeout.abort(), MANIFEST_TIMEOUT_MS);
+    const onOuterAbort = () => manifestTimeout.abort();
+    controller.signal.addEventListener('abort', onOuterAbort, { once: true });
+    const manifestResponse = await fetch(url, { signal: manifestTimeout.signal }).finally(() => {
+      clearTimeout(manifestTimer);
+      controller.signal.removeEventListener('abort', onOuterAbort);
+    });
+    if (!manifestResponse.ok) {
+      throw new Error(
+        `EPT manifest fetch failed (${manifestResponse.status} ${manifestResponse.statusText}).`,
+      );
+    }
+    const manifestText = await manifestResponse.text();
+    const detection = parseEptMetadata(manifestText);
+    if (!detection.isEpt) {
+      throw new Error(`Not a valid EPT manifest — ${detection.reason}`);
+    }
+
+    await viewer.ready;
+    deps.streamingPanel.setPhase('Building hierarchy…');
+    deps.streamingPanel.show();
+    // Inspector stays visible during streaming — same rationale as the
+    // COPC path. Streaming-only sections drop out via setStreamingMode
+    // once the cloud finishes attaching.
+    deps.inspector.element.classList.remove('olv-hidden');
+
+    // Compute the dataset base URL by stripping the ept.json filename;
+    // the source uses it to build hierarchy + tile URLs.
+    const baseUrl = url.replace(/ept\.json(?:\?.*)?(?:#.*)?$/i, '');
+    // The base URL drops the manifest's query, so re-attach the auth query
+    // (e.g. an Azure SAS / CDN `?token=…`) to every derived hierarchy + tile
+    // request — otherwise a signed dataset validates, loads ept.json, then
+    // 401/403s on the first hierarchy fetch. (A per-object presigned signature
+    // bound to ept.json alone still can't authorise the hierarchy — that stays
+    // an honest hierarchy-fetch error.)
+    const eptSearch = eptUrlMod.eptUrlSearch(url);
+
+    // hardened EPT transport: retry-with-backoff (3 retries),
+    // per-attempt timeout (20 s), abort discipline composed with the outer
+    // load-cancel signal. Mirrors the discipline `HttpRangeSource` brings
+    // to the COPC path. Typed error messages flow through to
+    // `describeRemoteEptError` for the user-facing classifier.
+    const transport = eptUrlMod.createEptTransport();
+
+    const cloud = await EptStreamingPointCloud.open(
+      detection.metadata,
+      baseUrl,
+      remoteEptName(url),
+      transport,
+      controller.signal,
+      eptSearch,
+    );
+    if (controller.signal.aborted) throw new LoadCancelledError();
+
+    deps.stage.hideEmptyState();
+
+    // Laszip tiles are CPU-heavy (laz-perf decompress + coordinate transform);
+    // decode them off the main thread in a dedicated worker, created lazily and
+    // reused for the session like the COPC decode worker. The binary path stays
+    // in-process (microsecond decodes) so it never pays the worker round-trip.
+    if (cloud.dataType === 'laszip' && !deps.getEptLaszipDecoder()) {
+      const { EptLaszipWorkerClient } = await deps.loadEptLaszipWorkerClient();
+      deps.setEptLaszipDecoder(new EptLaszipWorkerClient());
+    }
+    const decoder = new EptChunkDecoder(
+      cloud,
+      cloud.dataType === 'laszip' ? deps.getEptLaszipDecoder() : null,
+    );
+    // A streaming scan is exclusive — replace any prior streaming/static scene
+    // at the last moment, after the EPT source opened and the decoder is ready,
+    // so a failed or cancelled step above left the current scene intact.
+    if (controller.signal.aborted) throw new LoadCancelledError();
+    if (viewer.hasStreamingCloud) deps.closeStreaming();
+    deps.clearOpenStaticLayers();
+    await viewer.attachStreamingCloud(
+      cloud,
+      decoder,
+      deps.getStreamingQuality(),
+      deps.isPhone(),
+      null,
+    );
+    // attachStreamingCloud takes no signal; if the user cancelled while it ran,
+    // drop the fresh cloud so a cancel adds nothing rather than half-attaching.
+    if (controller.signal.aborted) { deps.closeStreaming(); throw new LoadCancelledError(); }
+    viewer.setMode('orbit');
+    viewer.frameAll();
+
+    deps.streamingPanel.setColorModes(
+      // The interface returns a readonly array; the panel accepts a mutable
+      // ColorMode[], so we materialise a copy.
+      [...cloud.availableColorModes()],
+      cloud.defaultColorMode(),
+    );
+    deps.streamingPanel.setQuality(deps.getStreamingQuality());
+    deps.streamingPanel.setPhase('Streaming coarse geometry…');
+    deps.inspector.setImageExportEnabled(true);
+    // Per-mode gating — EPT streams almost never carry normals.
+    deps.inspector.setImageExportAvailability(viewer.availableImageExportModes());
+    // Same streaming-mode layout the COPC path uses — hide Inspector's
+    // static-cloud sections and populate the streaming Scan Report.
+    deps.inspector.setStreamingMode(true);
+    try { deps.inspector.setDetail(cloud.sourcePointCount, cloud.sourcePointCount); }
+    catch (err) { if (deps.debug) console.warn('[inspector] setDetail (streaming) threw', err); }
+    try {
+      // Shape-adapt the EPT cloud's metadata for the streaming-report
+      // synthesizer. EPT's bounds live on `detection.metadata.bounds`;
+      // EPT has no first-class spacing/maxDepth fields (the writer's
+      // `span` is the points-per-tile analogue), so those rows are
+      // omitted on EPT streams.
+      const b = detection.metadata.bounds.conforming;
+      const eptReportCloud = {
+        kind: 'ept' as const,
+        name: cloud.name,
+        sourcePointCount: cloud.sourcePointCount,
+        metadata: {
+          header: { min: [b[0], b[1], b[2]] as [number, number, number], max: [b[3], b[4], b[5]] as [number, number, number] },
+        },
+      };
+      deps.setLastStreamingReportCloud(eptReportCloud);
+      deps.inspector.setReport(
+        deps.runStreamingModules(eptReportCloud, deps.classLegendPanel.getVisibility().isFiltered()),
+      );
+    } catch (err) { if (deps.debug) console.warn('[inspector] setReport (streaming) threw', err); }
+    deps.prewarmExportStudio();
+
+    // The metadata-driven scan summary — same shape the COPC path fills,
+    // adapted for EPT's metadata layout.
+    const b = detection.metadata.bounds.conforming;
+    const schemaSummary = `${detection.metadata.dataType} · ${detection.metadata.schema.length} attrs`;
+    deps.revealAnalysePanel(cloud.name, false); // streaming EPT also gets the terrain tools
+    deps.streamingPanel.setSummary({
+      fileName: cloud.name,
+      pointFormat: -1,                 // EPT has no LAS PDRF; sentinel
+      sourcePoints: cloud.sourcePointCount,
+      width: b[3] - b[0],
+      depth: b[4] - b[1],
+      height: b[5] - b[2],
+      spacing: detection.metadata.span,
+      octreeDepth: cloud.maxDepth(),
+      nodeCount: cloud.octree.nodes().length,
+      format: 'ept',
+      schemaSummary,
+    });
+
+    // Was: body class + navBar only, which left the dock hidden — so an EPT
+    // scan loaded with no measure, inspect, probe, annotate or close.
+    deps.revealStreamingChrome();
+    deps.startStreamingStatusPolling();
+    deps.dropZone.setCancelHandler(null);
+    deps.dropZone.setProgress(null);
+  } catch (err) {
+    deps.dropZone.setCancelHandler(null);
+    // A user-initiated cancel surfaces two ways: our own LoadCancelledError,
+    // or a DOMException named `AbortError` when the Stage URL-field Cancel
+    // aborts the linked signal mid-fetch. Both mean "the user changed their
+    // mind" — neither is an error to report or count.
+    if (err instanceof LoadCancelledError || isAbortError(err)) {
+      deps.dropZone.setProgress(null);
+    } else {
+      if (deps.debug) console.error('OpenLiDARViewer — remote EPT error', err);
+      recordUsage('error', 'load');
+      // classified error messages, matching the COPC
+      // remote-UX polish. `describeRemoteEptError` distinguishes CORS,
+      // 404, 5xx, hierarchy vs. tile fetch, and transport failures.
+      // Fall back to the generic classifier when the EPT chunk itself
+      // failed to load (so `eptUrlMod` never arrived).
+      deps.dropZone.setError(
+        eptUrlMod ? eptUrlMod.describeRemoteEptError(err, url) : describeLoadError(err),
+      );
+      deps.closeStreaming();
+    }
+  } finally {
+    unlinkAbort();
+    deps.setLoading(false);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,14 @@ import { findDuplicateIds } from './ui/actionRegistry';
 import { buildActionRegistry } from './app/actionDefinitions';
 import { importSession as runImportSession, type SessionIoDeps } from './app/sessionIo';
 import { openScan, type OpenScanDeps } from './app/openScan';
+import {
+  openStreamingCopc as runOpenStreamingCopc,
+  handleRemoteEpt as runHandleRemoteEpt,
+  isEptUrl,
+  isAbortError,
+  linkAbortSignals,
+  type OpenStreamingDeps,
+} from './app/openStreaming';
 import { WorkflowController, WORKFLOW_RECORDER_ENABLED } from './ui/WorkflowController';
 import type { WorkflowConfigPanel } from './ui/WorkflowConfigPanel';
 import { RecommendedViewChip } from './ui/RecommendedViewChip';
@@ -116,7 +124,6 @@ import { decodeFull } from './convert/decodeFull';
 import { HelpOverlay } from './ui/HelpOverlay';
 import { bindShortcuts } from './ui/shortcuts';
 import { LoadCancelledError } from './io/loadFile';
-import { describeLoadError } from './io/loadErrors';
 import { LocalFileSource } from './io/LocalFileSource';
 import { deviceCaps } from './render/deviceProfile';
 import { parseEmbedConfig } from './ui/embedConfig';
@@ -243,7 +250,7 @@ import { CatalogPanel } from './ui/CatalogPanel';
 // CRS detection + override — feeds the Inspector's Coordinate System
 // section. Static clouds carry `metadata.crs` (CrsInfo from src/io/crs);
 // streaming clouds expose `.crs()` returning the same shape.
-import type { CrsInfo, CrsLinearUnit } from './io/crs';
+import type { CrsLinearUnit } from './io/crs';
 import { streamingExtentRows } from './analysis/streamingExtentRows';
 import { CrsService } from './geo/CrsService';
 import { isLinearUnitKnown } from './geo/CoordinateTypes';
@@ -253,7 +260,7 @@ import { verticalUnitLabel } from './units/units';
 import { createInspectorCardRefreshers } from './app/inspectorCardRefreshers';
 import { installStaleChunkRecovery } from './app/staleChunkReload';
 import { createCrsCoordinator } from './app/crsCoordinator';
-import { remoteEptName, remoteCopcName, describeRemoteCopcError } from './app/remoteSourceNaming';
+import { remoteCopcName, describeRemoteCopcError } from './app/remoteSourceNaming';
 import { deriveVolumeRecord, horizontalSpanXY } from './render/measure/measureDerivations';
 import { serviceWorkerUrl } from './app/swUrl';
 import { createTerrainAnalysisRunner } from './app/terrainAnalysisRunner';
@@ -5350,181 +5357,72 @@ function handleFile(file: File): Promise<void> {
 }
 
 /**
- * Open a COPC scan from any range-readable source — a local file or a remote
- * HTTP URL — through the streaming pipeline: read the metadata and hierarchy,
- * attach the streaming cloud to the viewer, and show the streaming panel.
- * Point data then streams in progressively, driven by the camera.
+ * Remote / streaming opens — thin callers over the extracted
+ * `src/app/openStreaming.ts`. `openStreamingDeps` binds the shell's running
+ * state (the load flag, the streaming-session decode workers / benchmark, the
+ * quality preset) and its view collaborators to the module's accessors; the
+ * COPC + EPT open pipelines, and the pure `isEptUrl` / `isAbortError` /
+ * `linkAbortSignals` decisions, live in that module.
  */
-async function openStreamingCopc(
+const openStreamingDeps: OpenStreamingDeps = {
+  loadStreamingPointCloud,
+  loadCopcWorkerClient,
+  loadStreamingColors,
+  loadEptLaszipWorkerClient,
+  loadEpt,
+  loadDiagnostics,
+  viewerReady: viewerLoaded,
+  getViewer: () => viewer,
+  isLoading: () => loading,
+  setLoading: (v) => { loading = v; },
+  getStreamingBenchmark: () => streamingBenchmark,
+  setStreamingBenchmark: (b) => { streamingBenchmark = b; },
+  setCoarseStableFired: (v) => { coarseStableFired = v; },
+  getCopcDecoder: () => copcDecoder,
+  setCopcDecoder: (d) => { copcDecoder = d; },
+  getEptLaszipDecoder: () => eptLaszipDecoder,
+  setEptLaszipDecoder: (d) => { eptLaszipDecoder = d; },
+  getStreamingQuality: () => streamingQuality,
+  setLastStreamingReportCloud: (c) => { lastStreamingReportCloud = c; },
+  debug,
+  benchmark,
+  showToast: showLassoToast,
+  dropZone,
+  stage,
+  inspector,
+  streamingPanel,
+  classLegendPanel,
+  inspectorCards,
+  crsCoordinator,
+  bookmarks,
+  isPhone,
+  closeStreaming,
+  clearOpenStaticLayers,
+  startStreamingStatusPolling,
+  revealStreamingChrome: () => revealStreamingScanChrome({
+    dock, inspector, navBar, backend: viewer.activeBackend(), body: document.body,
+  }),
+  revealAnalysePanel,
+  prewarmExportStudio: () => { void prewarmExportStudio(); },
+  prewarmForUrl,
+  refreshViewsUI,
+  hideReclassifyUi,
+  syncInspectClassScope,
+  runStreamingModules,
+};
+
+/**
+ * Open a COPC scan from any range-readable source — a local file or a remote
+ * HTTP URL — through the streaming pipeline. A thin caller over
+ * `src/app/openStreaming.ts`; the local-file and remote-COPC paths both route
+ * here so the metadata read / attach / reveal happens in one place.
+ */
+function openStreamingCopc(
   range: RangeSource,
   displayName: string,
   signal: AbortSignal,
 ): Promise<void> {
-  // Race the lazy COPC + streaming chunks against `viewer.ready` so a
-  // user who opens a scan during the first ~half-second of page load
-  // (a common demo path) doesn't see chunk-fetch and GPU init run
-  // serially. By the time `viewer.ready` resolves the chunks are
-  // usually cached too — `await chunksPromise` below typically
-  // resolves immediately. On a cold start, the parallelism saves
-  // roughly the smaller of the two latencies (often 100-300 ms).
-  const chunksPromise = Promise.all([
-    loadStreamingPointCloud(),
-    loadCopcWorkerClient(),
-    loadStreamingColors(),
-  ]);
-
-  // Show the streaming panel as soon as we know we're on the COPC branch —
-  // before `await viewer.ready`, which on cold WebGPU runners can sit for
-  // 10–18 s compiling shaders. The panel reads "Loading metadata…" while
-  // the viewer warms up, so the user gets immediate confirmation that the
-  // file was recognised as COPC instead of staring at the empty state.
-  streamingPanel.setPhase('Loading metadata…');
-  streamingPanel.show();
-
-  await viewer.ready;
-  // Inspector stays visible during streaming — it carries the sections
-  // that work uniformly against either source type (Scan report,
-  // Provenance, Coordinate system, Image export, Report PDF). The
-  // static-only sections are hidden via `setStreamingMode(true)` when
-  // the streaming cloud finishes attaching; until then the Inspector
-  // shows its empty placeholders, which is fine.
-  inspector.element.classList.remove('olv-hidden');
-  dropZone.setProgress('Reading COPC hierarchy…');
-
-  // The streaming benchmark collector is created when either `?benchmark=1`
-  // (which adds a session report on close) or `?debug=1` (which surfaces the
-  // live thrash / scheduler-histogram readout in the overlay) is set. Off by
-  // default — no overhead in normal sessions. The diagnostics chunk loads
-  // lazily on first need; cached afterwards.
-  if (benchmark || debug) {
-    const d = await loadDiagnostics();
-    streamingBenchmark = new d.StreamingBenchmark();
-    coarseStableFired = false;
-    range = new d.InstrumentedRangeSource(range, (n) => {
-      streamingBenchmark?.recordNetworkBytes(n);
-    });
-  }
-
-  // Await the hoisted chunk fetches; if `viewer.ready` was the slow
-  // path (cold WebGPU init) this is a no-op.
-  const [{ StreamingPointCloud }, { CopcWorkerClient }, streamingColors] =
-    await chunksPromise;
-
-  const cloud = await StreamingPointCloud.open(range, displayName, signal);
-  if (signal.aborted) throw new LoadCancelledError();
-
-  if (!copcDecoder) copcDecoder = new CopcWorkerClient();
-  // Wire the per-chunk decode timing hook only when a benchmark is collecting;
-  // clearing it on close keeps a non-benchmark session free of any callback.
-  copcDecoder.onDecodeMs = streamingBenchmark
-    ? (ms) => streamingBenchmark?.recordDecodeMs(ms)
-    : undefined;
-
-  stage.hideEmptyState();
-  // Local-first counter — categorical only ('copc' or 'ept'); never the URL.
-  recordUsage('scan-open', cloud.kind === 'ept' ? 'ept' : 'copc');
-  // Provenance fingerprint for streaming clouds — fed with the cloud's
-  // declared point count + extent so the classifier has signal even though
-  // the resident set is small. Wrapped because a malformed cloud shape
-  // shouldn't break the rest of the streaming load (CRS, attach, color
-  // modes, navBar reveal).
-  try { inspectorCards.refreshProvenanceFromStreaming(cloud); }
-  catch (err) { if (debug) console.warn('[provenance] refreshProvenanceFromStreaming threw', err); }
-  // CRS for streaming clouds — same merge rule as the static path.
-  try {
-    crsCoordinator.refreshCrsForStreamingCloud(cloud as unknown as {
-      readonly name: string;
-      readonly kind: 'copc' | 'ept';
-      crs(): CrsInfo | undefined;
-    });
-  } catch (err) {
-    if (debug) console.warn('[crs] refreshCrsForStreamingCloud threw', err);
-  }
-  // A streaming scan is exclusive — clear open static layers at the last
-  // moment, after the source opened above and just before its replacement
-  // attaches, so a failed open left the current scene intact. The abort check
-  // at the open still guards this; nothing yields between it and here.
-  clearOpenStaticLayers();
-  await viewer.attachStreamingCloud(
-    cloud,
-    copcDecoder,
-    streamingQuality,
-    isPhone(),
-    streamingBenchmark,
-  );
-  // attachStreamingCloud takes no signal; if the user cancelled while it ran,
-  // drop the fresh cloud so a cancel adds nothing rather than half-attaching.
-  if (signal.aborted) { closeStreaming(); throw new LoadCancelledError(); }
-  viewer.setMode('orbit');
-  viewer.frameAll();
-
-  streamingPanel.setColorModes(
-    streamingColors.availableStreamingModes(cloud.metadata),
-    streamingColors.defaultStreamingMode(cloud.metadata),
-  );
-  streamingPanel.setQuality(streamingQuality);
-  streamingPanel.setPhase('Streaming coarse geometry…');
-  // Classification legend (v0.4.1) — reset to empty for the new streaming scan.
-  // The legend is seeded + revealed lazily by `viewer.onStreamingNodeClasses`
-  // as nodes carrying classification become resident, and refines as deeper
-  // nodes stream in. A streaming source without a classification channel simply
-  // never seeds the legend, so it stays hidden.
-  classLegendPanel.setClasses(new Map());
-  classLegendPanel.hide();
-  hideReclassifyUi();
-  // Clear any prior filtered scan's inspector copy/JSON scope stamp.
-  syncInspectClassScope();
-  // Visual Export Studio — a streaming COPC cloud is now attached;
-  // the image-export buttons in the Inspector can light up. The streaming
-  // path doesn't go through `inspector.addCloud`, so the gate has to flip
-  // here too. Pre-warm the Studio chunk for the same reason as above.
-  inspector.setImageExportEnabled(true);
-  // Per-mode gating — streaming COPC / EPT rarely carry normals or
-  // classification; disable the corresponding buttons at the source.
-  inspector.setImageExportAvailability(viewer.availableImageExportModes());
-  // Switch the Inspector into streaming layout — hides Layers / Color by
-  // / Point size / Rendering / Export (their streaming-equivalents are
-  // in the StreamingPanel) and pins the panel to the lower-right so
-  // both panels coexist on desktop.
-  inspector.setStreamingMode(true);
-  try { inspector.setDetail(cloud.sourcePointCount, cloud.sourcePointCount); }
-  catch (err) { if (debug) console.warn('[inspector] setDetail (streaming) threw', err); }
-  lastStreamingReportCloud = cloud;
-  try { inspector.setReport(runStreamingModules(cloud, classLegendPanel.getVisibility().isFiltered())); }
-  catch (err) { if (debug) console.warn('[inspector] setReport (streaming) threw', err); }
-  try {
-    inspectorCards.refreshDatasetIntelligenceFromStreamingCloud(cloud);
-  } catch (err) {
-    if (debug) console.warn('[inspector] dataset intel (streaming) threw', err);
-  }
-  void prewarmExportStudio();
-
-  // The metadata-driven scan summary, and a fresh saved-views list.
-  const header = cloud.metadata.header;
-  revealAnalysePanel(cloud.name, false); // streaming COPC also gets the terrain tools
-  streamingPanel.setSummary({
-    fileName: cloud.name,
-    pointFormat: header.pointDataRecordFormat,
-    sourcePoints: cloud.sourcePointCount,
-    width: header.max[0] - header.min[0],
-    depth: header.max[1] - header.min[1],
-    height: header.max[2] - header.min[2],
-    spacing: cloud.metadata.info.spacing,
-    octreeDepth: cloud.maxDepth(),
-    nodeCount: cloud.octree.nodes().length,
-    // explicit format tag so the Scan Intelligence panel renders
-    // "COPC LAZ · PDRF N" for COPC and "EPT · binary · N attrs" for EPT.
-    format: 'copc',
-  });
-  bookmarks.clear();
-  refreshViewsUI();
-
-  revealStreamingScanChrome({
-    dock, inspector, navBar, backend: viewer.activeBackend(), body: document.body,
-  });
-
-  startStreamingStatusPolling();
-  dropZone.setProgress(null);
+  return runOpenStreamingCopc(range, displayName, signal, openStreamingDeps);
 }
 
 /**
@@ -5536,301 +5434,21 @@ async function openStreamingCopc(
  * Tiles support in a future format here is a one-line addition.
  */
 async function handleRemoteUrl(url: string, signal?: AbortSignal): Promise<void> {
-  // EPT detection is URL-pattern only — fast, no network, no schema fetch.
-  // The check is inlined here (mirroring `detectEptUrl` in `eptDetect.ts`)
-  // so the routing decision is synchronous and doesn't depend on the EPT
-  // lazy chunk loading — a malformed URL still surfaces an error toast even
-  // when the EPT or Viewer chunks aren't reachable.
-  let isEpt = false;
-  try {
-    const u = new URL(url);
-    isEpt = /(?:^|\/)ept\.json$/i.test(u.pathname);
-  } catch {
-    isEpt = /(?:^|\/)ept\.json(?:\?|#|$)/i.test(url);
-  }
-  if (isEpt) return handleRemoteEpt(url, signal);
+  // EPT detection is URL-pattern only — fast, no network, no schema fetch, so
+  // the routing decision is synchronous and doesn't depend on the EPT lazy
+  // chunk loading (a malformed URL still surfaces an error toast even when the
+  // EPT or Viewer chunks aren't reachable). `isEptUrl` lives beside the handler.
+  if (isEptUrl(url)) return handleRemoteEpt(url, signal);
   return handleRemoteCopc(url, signal);
 }
 
 /**
- * Wire an optional outer abort signal (the Stage URL field's Cancel
- * button) into a load's own AbortController (the progress toast's Cancel)
- * so EITHER cancel aborts the in-flight fetches. Returns a cleanup that
- * detaches the listener — call it on every exit path so a long-lived
- * outer signal can't accumulate listeners across loads. (Mirrors the
- * private `composeSignals` discipline inside `HttpRangeSource`.)
+ * Open a remote EPT dataset by its `ept.json` URL — a thin caller over
+ * `src/app/openStreaming.ts`, which owns the manifest fetch / validate / attach
+ * pipeline and binds the shell's running state through `openStreamingDeps`.
  */
-/**
- * True when `err` is a user-initiated abort, in any of the shapes a cancel
- * can surface as on the remote-open path:
- *
- *  - the platform's DOMException named `AbortError` (a fetch aborted
- *    directly by the linked signal), or
- *  - `RangeReadError` with code `'aborted'` — `HttpRangeSource` wraps the
- *    platform abort in its typed error before it reaches us.
- *
- * The Stage URL-field Cancel aborts the linked signal while a fetch or
- * range probe is in flight; neither rejection is our LoadCancelledError,
- * so cancel handling must recognise all three shapes.
- */
-function isAbortError(err: unknown): boolean {
-  if (typeof err !== 'object' || err === null) return false;
-  const e = err as { name?: unknown; code?: unknown };
-  if (e.name === 'AbortError') return true;
-  return e.name === 'RangeReadError' && e.code === 'aborted';
-}
-
-function linkAbortSignals(
-  outer: AbortSignal | undefined,
-  controller: AbortController,
-): () => void {
-  if (!outer) return () => {};
-  if (outer.aborted) {
-    controller.abort();
-    return () => {};
-  }
-  const onAbort = (): void => controller.abort();
-  outer.addEventListener('abort', onAbort, { once: true });
-  return () => outer.removeEventListener('abort', onAbort);
-}
-
-/**
- * open a remote EPT dataset by its `ept.json` URL. Mirrors the
- * `handleRemoteCopc` flow:
- *   1. Validate the URL.
- *   2. Fetch + parse + validate `ept.json` (typed failure paths surface
- *      as user-readable error messages, same as COPC's malformed-file
- *      path).
- *   3. Open an `EptStreamingPointCloud` against an HTTP-backed transport.
- *   4. Hand it to the same `viewer.attachStreamingCloud` the COPC flow
- *      uses — the scheduler / renderer / picking path don't see the
- *      format difference.
- */
-async function handleRemoteEpt(url: string, signal?: AbortSignal): Promise<void> {
-  if (loading) {
-    showLassoToast('Already loading — cancel the current load first.');
-    return;
-  }
-  // Claim the flag SYNCHRONOUSLY. Every await below yields to the event
-  // loop, and a second open started in that window used to pass the
-  // `loading` guard too (TOCTOU). The `finally` below is the only reset.
-  loading = true;
-  const controller = new AbortController();
-  // Compose the Stage URL-field Cancel (outer signal) with the progress
-  // toast's Cancel (this controller): either abort cancels the load.
-  const unlinkAbort = linkAbortSignals(signal, controller);
-  // Fire the streaming + EPT chunk pre-warm immediately. Each dynamic
-  // import is one HTTP fetch + parse; running them in parallel with
-  // the manifest GET below cuts cold-start by 200–700 ms.
-  prewarmForUrl(url);
-  // Declared outside the try so the catch can use the module's error
-  // classifier when the module loaded, and a plain classifier when the
-  // chunk fetch itself was the failure.
-  let eptUrlMod: Awaited<ReturnType<typeof loadEpt>> | null = null;
-  try {
-    // URL validation is pure — run it before awaiting the lazy Viewer so a
-    // malformed URL always surfaces an error toast, even if the Viewer chunk
-    // hasn't loaded yet or the GPU backend can't initialise.
-    eptUrlMod = await loadEpt();
-    const check = eptUrlMod.validateRemoteEptUrl(url);
-    if (!check.ok) {
-      dropZone.setError(`${check.reason} Enter the full https://…/ept.json URL.`);
-      return;
-    }
-    // The actual streaming open touches viewer state — defer until the lazy
-    // Viewer chunk is up.
-    await viewerLoaded;
-    // Blue blinking "Opening …" first, consistent with the COPC + device paths;
-    // the manifest read + node streaming supersede it with staged progress.
-    dropZone.setOpening(`Opening ${remoteCopcName(url)}…`);
-    dropZone.setCancelHandler(() => controller.abort());
-    const { parseEptMetadata, EptStreamingPointCloud, EptChunkDecoder } = eptUrlMod;
-
-    // Fetch the manifest. We use plain `fetch` rather than the HttpRangeSource:
-    // ept.json is a small JSON document, not a range-served binary. It gets the
-    // same per-request TIMEOUT as the hardened hierarchy/tile transport (20 s),
-    // so a stalled manifest aborts instead of hanging until the user cancels;
-    // the timeout is composed with the outer load-cancel signal. Single attempt
-    // (no retry) — a failed manifest surfaces an error and the user re-opens.
-    const MANIFEST_TIMEOUT_MS = 20_000;
-    const manifestTimeout = new AbortController();
-    const manifestTimer = setTimeout(() => manifestTimeout.abort(), MANIFEST_TIMEOUT_MS);
-    const onOuterAbort = () => manifestTimeout.abort();
-    controller.signal.addEventListener('abort', onOuterAbort, { once: true });
-    const manifestResponse = await fetch(url, { signal: manifestTimeout.signal }).finally(() => {
-      clearTimeout(manifestTimer);
-      controller.signal.removeEventListener('abort', onOuterAbort);
-    });
-    if (!manifestResponse.ok) {
-      throw new Error(
-        `EPT manifest fetch failed (${manifestResponse.status} ${manifestResponse.statusText}).`,
-      );
-    }
-    const manifestText = await manifestResponse.text();
-    const detection = parseEptMetadata(manifestText);
-    if (!detection.isEpt) {
-      throw new Error(`Not a valid EPT manifest — ${detection.reason}`);
-    }
-
-    await viewer.ready;
-    streamingPanel.setPhase('Building hierarchy…');
-    streamingPanel.show();
-    // Inspector stays visible during streaming — same rationale as the
-    // COPC path. Streaming-only sections drop out via setStreamingMode
-    // once the cloud finishes attaching.
-    inspector.element.classList.remove('olv-hidden');
-
-    // Compute the dataset base URL by stripping the ept.json filename;
-    // the source uses it to build hierarchy + tile URLs.
-    const baseUrl = url.replace(/ept\.json(?:\?.*)?(?:#.*)?$/i, '');
-    // The base URL drops the manifest's query, so re-attach the auth query
-    // (e.g. an Azure SAS / CDN `?token=…`) to every derived hierarchy + tile
-    // request — otherwise a signed dataset validates, loads ept.json, then
-    // 401/403s on the first hierarchy fetch. (A per-object presigned signature
-    // bound to ept.json alone still can't authorise the hierarchy — that stays
-    // an honest hierarchy-fetch error.)
-    const eptSearch = eptUrlMod.eptUrlSearch(url);
-
-    // hardened EPT transport: retry-with-backoff (3 retries),
-    // per-attempt timeout (20 s), abort discipline composed with the outer
-    // load-cancel signal. Mirrors the discipline `HttpRangeSource` brings
-    // to the COPC path. Typed error messages flow through to
-    // `describeRemoteEptError` for the user-facing classifier.
-    const transport = eptUrlMod.createEptTransport();
-
-    const cloud = await EptStreamingPointCloud.open(
-      detection.metadata,
-      baseUrl,
-      remoteEptName(url),
-      transport,
-      controller.signal,
-      eptSearch,
-    );
-    if (controller.signal.aborted) throw new LoadCancelledError();
-
-    stage.hideEmptyState();
-
-    // Laszip tiles are CPU-heavy (laz-perf decompress + coordinate transform);
-    // decode them off the main thread in a dedicated worker, created lazily and
-    // reused for the session like the COPC decode worker. The binary path stays
-    // in-process (microsecond decodes) so it never pays the worker round-trip.
-    if (cloud.dataType === 'laszip' && !eptLaszipDecoder) {
-      const { EptLaszipWorkerClient } = await loadEptLaszipWorkerClient();
-      eptLaszipDecoder = new EptLaszipWorkerClient();
-    }
-    const decoder = new EptChunkDecoder(
-      cloud,
-      cloud.dataType === 'laszip' ? eptLaszipDecoder : null,
-    );
-    // A streaming scan is exclusive — replace any prior streaming/static scene
-    // at the last moment, after the EPT source opened and the decoder is ready,
-    // so a failed or cancelled step above left the current scene intact.
-    if (controller.signal.aborted) throw new LoadCancelledError();
-    if (viewer.hasStreamingCloud) closeStreaming();
-    clearOpenStaticLayers();
-    await viewer.attachStreamingCloud(
-      cloud,
-      decoder,
-      streamingQuality,
-      isPhone(),
-      null,
-    );
-    // attachStreamingCloud takes no signal; if the user cancelled while it ran,
-    // drop the fresh cloud so a cancel adds nothing rather than half-attaching.
-    if (controller.signal.aborted) { closeStreaming(); throw new LoadCancelledError(); }
-    viewer.setMode('orbit');
-    viewer.frameAll();
-
-    streamingPanel.setColorModes(
-      // The interface returns a readonly array; the panel accepts a mutable
-      // ColorMode[], so we materialise a copy.
-      [...cloud.availableColorModes()],
-      cloud.defaultColorMode(),
-    );
-    streamingPanel.setQuality(streamingQuality);
-    streamingPanel.setPhase('Streaming coarse geometry…');
-    inspector.setImageExportEnabled(true);
-    // Per-mode gating — EPT streams almost never carry normals.
-    inspector.setImageExportAvailability(viewer.availableImageExportModes());
-    // Same streaming-mode layout the COPC path uses — hide Inspector's
-    // static-cloud sections and populate the streaming Scan Report.
-    inspector.setStreamingMode(true);
-    try { inspector.setDetail(cloud.sourcePointCount, cloud.sourcePointCount); }
-    catch (err) { if (debug) console.warn('[inspector] setDetail (streaming) threw', err); }
-    try {
-      // Shape-adapt the EPT cloud's metadata for the streaming-report
-      // synthesizer. EPT's bounds live on `detection.metadata.bounds`;
-      // EPT has no first-class spacing/maxDepth fields (the writer's
-      // `span` is the points-per-tile analogue), so those rows are
-      // omitted on EPT streams.
-      const b = detection.metadata.bounds.conforming;
-      const eptReportCloud = {
-        kind: 'ept' as const,
-        name: cloud.name,
-        sourcePointCount: cloud.sourcePointCount,
-        metadata: {
-          header: { min: [b[0], b[1], b[2]] as [number, number, number], max: [b[3], b[4], b[5]] as [number, number, number] },
-        },
-      };
-      lastStreamingReportCloud = eptReportCloud;
-      inspector.setReport(
-        runStreamingModules(eptReportCloud, classLegendPanel.getVisibility().isFiltered()),
-      );
-    } catch (err) { if (debug) console.warn('[inspector] setReport (streaming) threw', err); }
-    void prewarmExportStudio();
-
-    // The metadata-driven scan summary — same shape the COPC path fills,
-    // adapted for EPT's metadata layout.
-    const b = detection.metadata.bounds.conforming;
-    const schemaSummary = `${detection.metadata.dataType} · ${detection.metadata.schema.length} attrs`;
-    revealAnalysePanel(cloud.name, false); // streaming EPT also gets the terrain tools
-    streamingPanel.setSummary({
-      fileName: cloud.name,
-      pointFormat: -1,                 // EPT has no LAS PDRF; sentinel
-      sourcePoints: cloud.sourcePointCount,
-      width: b[3] - b[0],
-      depth: b[4] - b[1],
-      height: b[5] - b[2],
-      spacing: detection.metadata.span,
-      octreeDepth: cloud.maxDepth(),
-      nodeCount: cloud.octree.nodes().length,
-      format: 'ept',
-      schemaSummary,
-    });
-
-    // Was: body class + navBar only, which left the dock hidden — so an EPT
-    // scan loaded with no measure, inspect, probe, annotate or close.
-    revealStreamingScanChrome({
-      dock, inspector, navBar, backend: viewer.activeBackend(), body: document.body,
-    });
-    startStreamingStatusPolling();
-    dropZone.setCancelHandler(null);
-    dropZone.setProgress(null);
-  } catch (err) {
-    dropZone.setCancelHandler(null);
-    // A user-initiated cancel surfaces two ways: our own LoadCancelledError,
-    // or a DOMException named `AbortError` when the Stage URL-field Cancel
-    // aborts the linked signal mid-fetch. Both mean "the user changed their
-    // mind" — neither is an error to report or count.
-    if (err instanceof LoadCancelledError || isAbortError(err)) {
-      dropZone.setProgress(null);
-    } else {
-      if (debug) console.error('OpenLiDARViewer — remote EPT error', err);
-      recordUsage('error', 'load');
-      // classified error messages, matching the COPC
-      // remote-UX polish. `describeRemoteEptError` distinguishes CORS,
-      // 404, 5xx, hierarchy vs. tile fetch, and transport failures.
-      // Fall back to the generic classifier when the EPT chunk itself
-      // failed to load (so `eptUrlMod` never arrived).
-      dropZone.setError(
-        eptUrlMod ? eptUrlMod.describeRemoteEptError(err, url) : describeLoadError(err),
-      );
-      closeStreaming();
-    }
-  } finally {
-    unlinkAbort();
-    loading = false;
-  }
+function handleRemoteEpt(url: string, signal?: AbortSignal): Promise<void> {
+  return runHandleRemoteEpt(url, signal, openStreamingDeps);
 }
 
 

--- a/tests/architectureMap.test.ts
+++ b/tests/architectureMap.test.ts
@@ -91,10 +91,10 @@ describe('architecture map stays in step with the tree', () => {
     // The floor is a sanity guard against the tables being deleted wholesale,
     // not a fixed size: each completed extraction moves its row out of the
     // pending table into "Done:" prose, so the count ratchets down over time
-    // (the render-loop and importSession extractions took it from 10 to 8, and
-    // the openScan extraction took it to 7).
+    // (the render-loop and importSession extractions took it from 10 to 8, the
+    // openScan extraction took it to 7, and the openStreaming extraction to 6).
     const rows = text.split('\n').filter((l) => /^\|\s*`?[A-Za-z_]/.test(l) && /\|\s*[\d,]+\s*\|/.test(l));
-    expect(rows.length, 'the extraction tables have gone missing').toBeGreaterThanOrEqual(7);
+    expect(rows.length, 'the extraction tables have gone missing').toBeGreaterThanOrEqual(6);
 
     const lines = [
       ...readFileSync(root + 'src/main.ts', 'utf8').split('\n'),

--- a/tests/openStreaming.test.ts
+++ b/tests/openStreaming.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isEptUrl,
+  isAbortError,
+  linkAbortSignals,
+  handleRemoteEpt,
+  type OpenStreamingDeps,
+} from '../src/app/openStreaming';
+import type { Viewer } from '../src/render/Viewer';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The pure decisions the extraction exposes — the only remote-open logic that
+// can be decided without a Viewer, the network or the DOM.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('isEptUrl — the COPC-vs-EPT routing predicate', () => {
+  it('routes a plain ept.json entry point to EPT', () => {
+    expect(isEptUrl('https://example.com/data/ept.json')).toBe(true);
+  });
+
+  it('routes an ept.json carrying an auth query or fragment to EPT', () => {
+    // A signed dataset appends `?token=…`; a fragment can trail the path.
+    expect(isEptUrl('https://example.com/data/ept.json?token=abc')).toBe(true);
+    expect(isEptUrl('https://example.com/data/ept.json#frag')).toBe(true);
+  });
+
+  it('is case-insensitive on the filename', () => {
+    expect(isEptUrl('https://example.com/EPT.JSON')).toBe(true);
+  });
+
+  it('routes a COPC file (and anything not ending in ept.json) to COPC', () => {
+    expect(isEptUrl('https://example.com/data/scan.copc.laz')).toBe(false);
+    // A path that merely contains the string but does not end in it stays COPC.
+    expect(isEptUrl('https://example.com/ept.json.bak')).toBe(false);
+  });
+
+  it('falls back to a raw-string test when the URL will not parse, never throwing', () => {
+    // `new URL('ept.json')` throws (no base); the raw fallback still routes it.
+    expect(isEptUrl('ept.json')).toBe(true);
+    expect(isEptUrl('%%% not a url %%%')).toBe(false);
+  });
+});
+
+describe('isAbortError — the user-cancel classifier both remote handlers surface through', () => {
+  it('recognises the platform AbortError (a fetch aborted by the linked signal)', () => {
+    expect(isAbortError({ name: 'AbortError' })).toBe(true);
+  });
+
+  it("recognises HttpRangeSource's typed RangeReadError with code 'aborted'", () => {
+    expect(isAbortError({ name: 'RangeReadError', code: 'aborted' })).toBe(true);
+  });
+
+  it('does NOT treat a non-abort RangeReadError as a cancel', () => {
+    expect(isAbortError({ name: 'RangeReadError', code: 'timeout' })).toBe(false);
+  });
+
+  it('does NOT treat an ordinary error, or a non-object, as a cancel', () => {
+    expect(isAbortError(new Error('boom'))).toBe(false);
+    expect(isAbortError(null)).toBe(false);
+    expect(isAbortError('AbortError')).toBe(false);
+    expect(isAbortError(undefined)).toBe(false);
+  });
+});
+
+describe('linkAbortSignals — composing an outer Cancel with a load controller', () => {
+  it('is a no-op when there is no outer signal', () => {
+    const controller = new AbortController();
+    const unlink = linkAbortSignals(undefined, controller);
+    expect(controller.signal.aborted).toBe(false);
+    expect(() => unlink()).not.toThrow();
+  });
+
+  it('aborts the controller immediately when the outer signal is already aborted', () => {
+    const outer = AbortSignal.abort();
+    const controller = new AbortController();
+    linkAbortSignals(outer, controller);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('aborts the controller when the outer signal fires later, and stops after unlink', () => {
+    const outer = new AbortController();
+    const controller = new AbortController();
+    const unlink = linkAbortSignals(outer.signal, controller);
+    expect(controller.signal.aborted).toBe(false);
+    outer.abort();
+    expect(controller.signal.aborted).toBe(true);
+
+    // After unlink, a fresh controller no longer tracks the (already-fired)
+    // outer — the listener was detached.
+    const later = new AbortController();
+    const unlink2 = linkAbortSignals(new AbortController().signal, later);
+    unlink();
+    unlink2();
+    expect(later.signal.aborted).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// handleRemoteEpt — the guarded remote-open decisions, driven through fakes:
+// the one-load-at-a-time guard, the pure URL-validation gate, and the honest
+// error surfacing when the pipeline throws.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build an OpenStreamingDeps wired to spies. Only the members these guarded
+ * paths reach need real behaviour; the streaming-attach collaborators are cast
+ * stubs because no test here gets past the validation / chunk-load gate. A
+ * `validate` override drives the pure URL gate; `loadEptRejects` simulates the
+ * EPT chunk failing to load so the catch's error surfacing runs.
+ */
+function makeDeps(
+  over: { loading?: boolean; validate?: { ok: boolean; reason?: string }; loadEptRejects?: boolean } = {},
+) {
+  let loading = over.loading ?? false;
+  const validateRemoteEptUrl = vi.fn((_url: string) => over.validate ?? { ok: true });
+  const describeRemoteEptError = vi.fn((_err: unknown, _url: string) => 'classified EPT error');
+  const calls = {
+    isLoading: vi.fn(() => loading),
+    setLoading: vi.fn((v: boolean) => { loading = v; }),
+    showToast: vi.fn(),
+    setError: vi.fn(),
+    setOpening: vi.fn(),
+    setCancelHandler: vi.fn(),
+    setProgress: vi.fn(),
+    prewarmForUrl: vi.fn(),
+    getViewer: vi.fn(() => ({}) as unknown as Viewer),
+    closeStreaming: vi.fn(),
+    validateRemoteEptUrl,
+    describeRemoteEptError,
+    loadEpt: vi.fn(async () => {
+      if (over.loadEptRejects) throw new Error('EPT chunk failed to load');
+      return { validateRemoteEptUrl, describeRemoteEptError };
+    }),
+  };
+
+  const stub = <K extends keyof OpenStreamingDeps>(): OpenStreamingDeps[K] =>
+    vi.fn() as unknown as OpenStreamingDeps[K];
+
+  const deps: OpenStreamingDeps = {
+    loadStreamingPointCloud: stub<'loadStreamingPointCloud'>(),
+    loadCopcWorkerClient: stub<'loadCopcWorkerClient'>(),
+    loadStreamingColors: stub<'loadStreamingColors'>(),
+    loadEptLaszipWorkerClient: stub<'loadEptLaszipWorkerClient'>(),
+    loadEpt: calls.loadEpt as unknown as OpenStreamingDeps['loadEpt'],
+    loadDiagnostics: stub<'loadDiagnostics'>(),
+    viewerReady: Promise.resolve(),
+    getViewer: calls.getViewer,
+    isLoading: calls.isLoading,
+    setLoading: calls.setLoading,
+    getStreamingBenchmark: () => null,
+    setStreamingBenchmark: vi.fn(),
+    setCoarseStableFired: vi.fn(),
+    getCopcDecoder: () => null,
+    setCopcDecoder: vi.fn(),
+    getEptLaszipDecoder: () => null,
+    setEptLaszipDecoder: vi.fn(),
+    getStreamingQuality: () => 'balanced',
+    setLastStreamingReportCloud: vi.fn(),
+    debug: false,
+    benchmark: false,
+    showToast: calls.showToast,
+    dropZone: {
+      setError: calls.setError,
+      setOpening: calls.setOpening,
+      setCancelHandler: calls.setCancelHandler,
+      setProgress: calls.setProgress,
+    },
+    stage: { hideEmptyState: vi.fn() },
+    inspector: {} as unknown as OpenStreamingDeps['inspector'],
+    streamingPanel: {} as unknown as OpenStreamingDeps['streamingPanel'],
+    classLegendPanel: {} as unknown as OpenStreamingDeps['classLegendPanel'],
+    inspectorCards: {} as unknown as OpenStreamingDeps['inspectorCards'],
+    crsCoordinator: {} as unknown as OpenStreamingDeps['crsCoordinator'],
+    bookmarks: { clear: vi.fn() },
+    isPhone: () => false,
+    closeStreaming: calls.closeStreaming,
+    clearOpenStaticLayers: vi.fn(),
+    startStreamingStatusPolling: vi.fn(),
+    revealStreamingChrome: vi.fn(),
+    revealAnalysePanel: vi.fn(),
+    prewarmExportStudio: vi.fn(),
+    prewarmForUrl: calls.prewarmForUrl,
+    refreshViewsUI: vi.fn(),
+    hideReclassifyUi: vi.fn(),
+    syncInspectClassScope: vi.fn(),
+    runStreamingModules: vi.fn(() => []),
+  };
+
+  return { deps, calls };
+}
+
+describe('handleRemoteEpt — the guarded remote-open decisions', () => {
+  it('refuses a second open while one is in flight, without claiming the flag', async () => {
+    const { deps, calls } = makeDeps({ loading: true });
+    await handleRemoteEpt('https://example.com/ept.json', undefined, deps);
+    expect(calls.showToast).toHaveBeenCalledWith(expect.stringContaining('Already loading'));
+    // Never even loaded the EPT chunk, and never claimed the load flag.
+    expect(calls.loadEpt).not.toHaveBeenCalled();
+    expect(calls.setLoading).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a validation failure on the drop zone and never touches the viewer', async () => {
+    const { deps, calls } = makeDeps({ validate: { ok: false, reason: 'That is not an http(s) URL.' } });
+    await handleRemoteEpt('ftp://nope/ept.json', undefined, deps);
+    // The pure gate ran and its reason reached the user, with the ept.json hint.
+    expect(calls.validateRemoteEptUrl).toHaveBeenCalledTimes(1);
+    expect(calls.setError).toHaveBeenCalledWith(
+      expect.stringContaining('That is not an http(s) URL.'),
+    );
+    expect(calls.setError.mock.calls[0][0]).toContain('ept.json');
+    // Gated before any viewer / attach work.
+    expect(calls.getViewer).not.toHaveBeenCalled();
+    expect(calls.closeStreaming).not.toHaveBeenCalled();
+    // The flag was claimed synchronously and always released in `finally`.
+    expect(calls.setLoading).toHaveBeenNthCalledWith(1, true);
+    expect(calls.setLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it('claims the flag and proceeds past the guard for a valid, unclaimed open', async () => {
+    const { deps, calls } = makeDeps({ validate: { ok: true }, loadEptRejects: true });
+    await handleRemoteEpt('https://example.com/ept.json', undefined, deps);
+    // Valid URL ⇒ the guard let it through: the flag is claimed and the EPT
+    // chunk pre-warm + load both fire.
+    expect(calls.setLoading).toHaveBeenNthCalledWith(1, true);
+    expect(calls.prewarmForUrl).toHaveBeenCalledTimes(1);
+    expect(calls.loadEpt).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a chunk-load failure honestly, tidies up, and releases the flag', async () => {
+    // The EPT chunk itself fails to load, so `eptUrlMod` never arrives and the
+    // catch falls back to the generic classifier — the honest error path.
+    const { deps, calls } = makeDeps({ validate: { ok: true }, loadEptRejects: true });
+    await handleRemoteEpt('https://example.com/ept.json', undefined, deps);
+    expect(calls.setError).toHaveBeenCalledTimes(1);
+    // A failed open leaves no scan — the stream is torn down.
+    expect(calls.closeStreaming).toHaveBeenCalledTimes(1);
+    // And the one-load flag is always released.
+    expect(calls.setLoading).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/tests/streamingScanReveal.test.ts
+++ b/tests/streamingScanReveal.test.ts
@@ -63,17 +63,27 @@ describe('streaming scan reveal', () => {
     expect(c.calls).toContain('body.add(olv-has-scan)');
   });
 
-  it('is called by every streaming attach path in main.ts', () => {
+  it('is called by every streaming attach path', () => {
+    // v0.6 decomposition: both streaming attach paths (COPC + EPT) moved out of
+    // the shell into `src/app/openStreaming.ts`, where each attach is followed
+    // by the shared reveal — now indirected through the deps as
+    // `revealStreamingChrome()`, which `main.ts` binds to the single
+    // `revealStreamingScanChrome(...)` call. Scan both files.
     const main = readFileSync(resolve(ROOT, 'src/main.ts'), 'utf8');
+    const openStreaming = readFileSync(resolve(ROOT, 'src/app/openStreaming.ts'), 'utf8');
+    const src = main + openStreaming;
 
     // Both streaming formats go through `viewer.attachStreamingCloud`. Counting
     // the reveal against the attaches is what makes a new format fail here
     // instead of shipping a scan with no dock.
-    const attaches = main.match(/viewer\.attachStreamingCloud\(/g) ?? [];
-    const reveals = main.match(/revealStreamingScanChrome\(/g) ?? [];
+    const attaches = src.match(/viewer\.attachStreamingCloud\(/g) ?? [];
+    const reveals = src.match(/revealStreamingChrome\(/g) ?? [];
 
     expect(attaches.length).toBeGreaterThanOrEqual(2);
     expect(reveals.length).toBe(attaches.length);
+
+    // The reveal helper itself is wired exactly once — the shell's deps binding.
+    expect((main.match(/revealStreamingScanChrome\(/g) ?? []).length).toBe(1);
 
     // And nothing re-inlines the block. Two hand-written `setCloseEnabled`
     // calls are correct and expected: the static-load path enables it, and

--- a/tests/viewState.test.ts
+++ b/tests/viewState.test.ts
@@ -130,11 +130,13 @@ describe('main.ts scan-lifecycle reset sites still clear saved views', () => {
     // `bookmarks.clear()`. The "views AND counter, together" guarantee is atomic
     // in the service's clear() (see tests/viewBookmarks.test.ts) rather than
     // duplicated across three inline field pairs. The new-static-scan reset now
-    // lives in the extracted open/load pipeline (`src/app/openScan.ts`), so the
-    // three sites span both the shell and that module.
+    // lives in the extracted open/load pipeline (`src/app/openScan.ts`) and the
+    // streaming-open reset in `src/app/openStreaming.ts`, so the three sites span
+    // the shell (close-to-empty) and those two modules.
     const src =
       readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8') +
-      readFileSync(new URL('../src/app/openScan.ts', import.meta.url), 'utf8');
+      readFileSync(new URL('../src/app/openScan.ts', import.meta.url), 'utf8') +
+      readFileSync(new URL('../src/app/openStreaming.ts', import.meta.url), 'utf8');
     const resets = src.match(/bookmarks\.clear\(\)/g) ?? [];
     expect(resets.length).toBeGreaterThanOrEqual(3);
     // And no reset site pokes the cluster fields directly any more.


### PR DESCRIPTION
## What

Roadmap item P5 / architecture-map decomposition: lift the remote / streaming open pipeline (~406 lines) out of the `src/main.ts` monolith into `src/app/openStreaming.ts`, following the exact template `src/app/openScan.ts` set in #242.

`openStreamingCopc` (open a COPC scan from any range source — local file or remote URL) and `handleRemoteEpt` (open a remote EPT dataset by its `ept.json` URL) now take a structural `OpenStreamingDeps` object of accessor functions that close over the shell's services and its mutable streaming-session state (the load flag, the COPC/EPT decode workers, the benchmark collector, the quality preset) rather than the `Viewer` class. `main.ts` keeps thin `openStreamingCopc` / `handleRemoteEpt` delegates that bind running state to the deps; `handleRemoteCopc` and the URL router `handleRemoteUrl` stay in the shell and call the delegates as before.

## Pure logic Node-tested (`tests/openStreaming.test.ts`, 16 cases)

- `isEptUrl` — the COPC-vs-EPT routing predicate the URL router dispatches on (lifted out of `handleRemoteUrl`).
- `isAbortError` — the user-cancel classifier both remote handlers surface through.
- `linkAbortSignals` — composing an outer Cancel with a load's own controller.
- `handleRemoteEpt` guarded paths via fakes: the one-load-at-a-time guard, the URL-validation gate, and honest error surfacing (setError + closeStreaming + flag release).

## No behavior change

- The SSRF URL validation (`validateRemoteEptUrl` / `validateRemoteCopcUrl` / `isBlockedHost`) is preserved exactly — the gating call and its message are byte-identical; the validators themselves were not touched.
- `main.ts`: 6,507 → 6,125 lines. Monolith-size baseline re-banked (shrink only). `Viewer.ts` unchanged.
- Truth records updated in the same change: `architecture-map.md` (planned row → Done prose, main.ts total), `KNOWN_LIMITATIONS_v0.6.3.md` (count), and the architecture-map drift-test floor (7 → 6). Two source-shape guards (`streamingScanReveal`, `viewState`) now scan the new module, the same way #242 extended them for `openScan.ts`.

## Gates (all green, exit 0)

- `tsc --noEmit`
- `vitest run` — 7712 passed / 20 skipped
- `lint:monolith-size`, `lint:layer-boundaries`, `lint:main-deferral`, `lint:release-truth`
- `verify-archive-portability` — 14 passed, 0 failed
- e2e `--project=deterministic` — 162 passed, 4 skipped (autzen COPC fixture not on disk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)