### PR TITLE
Refuse a session that redefines a scan's CRS/axis/unit on restore (P1 #5)

### DIFF
--- a/src/app/sessionIo.ts
+++ b/src/app/sessionIo.ts
@@ -25,12 +25,18 @@ import type { ViewStateBundle } from '../io/viewState';
 import { buildViewState } from '../io/viewState';
 import { isExportStale, staleExportReason } from '../export/exportStaleness';
 import { summarizeMeasurementTrust } from '../render/measure/measurementTrust';
+import { isZUpFormat } from '../io/sniffFormat';
+import type { SourceFormat } from '../io/sniffFormat';
+import type { CrsLinearUnit } from '../io/crs';
 import type {
+  DeclaredSpatialFacts,
   InspectionSession,
   RebasedSessionGeometry,
   ScanFacts,
   ScanMatch,
   SessionScanSummary,
+  SessionSpatialClaims,
+  SessionSpatialVerdict,
 } from '../io/session';
 
 /** The streaming-source slice `scanFactsFromStreaming` reads — a structural subset of {@link StreamingSource}. */
@@ -38,7 +44,10 @@ export interface StreamingScanSource {
   readonly name: string;
   readonly sourcePointCount: number;
   dataBounds(): readonly [number, number, number, number, number, number];
-  crs(): { readonly name?: string; readonly epsg?: number } | null | undefined;
+  crs():
+    | { readonly name?: string; readonly epsg?: number; readonly linearUnit?: CrsLinearUnit }
+    | null
+    | undefined;
 }
 
 /** The static-cloud slice `scanFactsFromStatic` reads — a structural subset of {@link PointCloud}. */
@@ -49,8 +58,12 @@ export interface StaticScanCloud {
     readonly min: readonly [number, number, number];
     readonly max: readonly [number, number, number];
   };
+  /** Source file format — drives the file's own up-axis (`isZUpFormat`). */
+  readonly sourceFormat?: SourceFormat;
   readonly metadata?: {
-    readonly crs?: { readonly name?: string; readonly epsg?: number } | null;
+    readonly crs?:
+      | { readonly name?: string; readonly epsg?: number; readonly linearUnit?: CrsLinearUnit }
+      | null;
   };
 }
 
@@ -92,7 +105,35 @@ export function scanFactsFromStatic(cloud: StaticScanCloud): ScanFacts {
   };
 }
 
-/** The three pure session functions `importSession` resolves lazily (from `../io/session`). */
+/**
+ * The FILE's own spatial declaration from a streaming source — the source of
+ * truth a restored session may not silently redefine (roadmap P1 #5). CRS code
+ * and linear unit come off the source's `crs()`. Up-axis is intentionally left
+ * unknown: COPC/EPT streaming sources don't surface a source format through the
+ * `StreamingSource` seam, and they are z-up by construction, so there is nothing
+ * to conflict against — the CRS and unit checks still run.
+ */
+export function declaredSpatialFromStreaming(cloud: StreamingScanSource): DeclaredSpatialFacts {
+  const crs = cloud.crs();
+  return { epsg: crs?.epsg, linearUnit: crs?.linearUnit };
+}
+
+/**
+ * The FILE's own spatial declaration from a static cloud. Up-axis comes from the
+ * source format the same way the renderer and session exporter derive it
+ * (`isZUpFormat`), so the three can never disagree; CRS code and linear unit come
+ * off the header metadata.
+ */
+export function declaredSpatialFromStatic(cloud: StaticScanCloud): DeclaredSpatialFacts {
+  const crs = cloud.metadata?.crs;
+  return {
+    upAxis: cloud.sourceFormat ? (isZUpFormat(cloud.sourceFormat) ? 'z' : 'y') : undefined,
+    epsg: crs?.epsg,
+    linearUnit: crs?.linearUnit,
+  };
+}
+
+/** The pure session functions `importSession` resolves lazily (from `../io/session`). */
 export interface SessionModule {
   parseSession: (text: string) => InspectionSession;
   rebaseSessionGeometry: (
@@ -100,6 +141,10 @@ export interface SessionModule {
     cloudOrigin: readonly [number, number, number],
   ) => RebasedSessionGeometry;
   matchSessionToScan: (summary: SessionScanSummary | undefined, loaded: ScanFacts) => ScanMatch;
+  detectSessionSpatialConflict: (
+    claims: SessionSpatialClaims,
+    declared: DeclaredSpatialFacts,
+  ) => SessionSpatialVerdict;
 }
 
 /**
@@ -145,6 +190,22 @@ export interface SessionIoDeps {
 }
 
 /**
+ * The FILE's declared spatial frame for whatever scan is active right now —
+ * streaming source first, else the active static cloud, else an empty
+ * declaration. Mirrors the streaming/static split the scan-identity match uses,
+ * so the spatial-conflict guard reads exactly the scan the geometry is being
+ * attached to.
+ */
+function declaredSpatialForActiveScan(viewer: Viewer, deps: SessionIoDeps): DeclaredSpatialFacts {
+  const streaming = viewer.streamingCloud;
+  if (streaming) return declaredSpatialFromStreaming(streaming);
+  const id = deps.getActiveScanId();
+  const staticCloud = id ? viewer.getCloud(id) : undefined;
+  if (staticCloud) return declaredSpatialFromStatic(staticCloud);
+  return {};
+}
+
+/**
  * Import an inspection session: restore measurements, annotations and views.
  * `skipScanConfirm` is set only by the "Apply anyway" action after a partial
  * scan-identity match, so the same restore re-runs past the confirmation gate.
@@ -162,7 +223,8 @@ export async function importSession(
     // no GPU backend is needed — just a non-null instance).
     await deps.viewerReady;
     const viewer = deps.getViewer();
-    const { parseSession, rebaseSessionGeometry, matchSessionToScan } = await deps.loadSession();
+    const { parseSession, rebaseSessionGeometry, matchSessionToScan, detectSessionSpatialConflict } =
+      await deps.loadSession();
     const session = parseSession(await file.text());
     // If an older build wrote this session, a newer one may grade or label the
     // scan differently — surface that so the user can re-save. Absent stamp
@@ -279,34 +341,43 @@ export async function importSession(
       clip: geo.clip,
       camera: geo.camera,
     });
-    if (
+    // Roadmap P1 #5 — the session's stored spatial metadata must never silently
+    // redefine the loaded scan's own frame. Compare the session's CRS code,
+    // up-axis and linear unit against what the FILE declares; any divergence is a
+    // conflict, not a disclosure. On a conflict we keep the file's declaration
+    // and refuse the session's spatial claim (disclosing it), rather than
+    // reinterpreting the scan's coordinates. The scan-identity gate already
+    // refuses a mismatched EPSG summary; this covers the rest — a differing
+    // up-axis or unit, and a scan whose declaration exists but was absent from
+    // the session's summary. With no cloud loaded the file declares nothing, so
+    // nothing can conflict and the session's CRS (if any) still round-trips.
+    const declaredSpatial: DeclaredSpatialFacts = haveCloud
+      ? declaredSpatialForActiveScan(viewer, deps)
+      : {};
+    const spatial = detectSessionSpatialConflict(
+      { upAxis: session.upAxis, epsg: session.crs?.epsg, linearUnit: session.crs?.linearUnit },
+      declaredSpatial,
+    );
+    if (spatial.hasConflict) {
+      const why = spatial.conflicts.map((c) => c.reason).join('; ');
+      deps.showToast(
+        `The session's spatial metadata conflicts with this scan (${why}) — ` +
+          `the scan's own declaration is kept and the session's was not applied.`,
+      );
+    } else if (
       session.crs &&
       session.crs.epsg != null &&
       (session.crs.kind === 'projected' || session.crs.kind === 'geographic' || session.crs.kind === 'local')
     ) {
-      // Restore the author's CRS override so a capsule round-trips without
-      // re-prompting — but NEVER over a scan that declares a DIFFERENT code.
-      // The scan-identity match already conflicts on differing codes; this
-      // guard covers the remaining hole, a scan whose declaration exists but
-      // was absent from the session summary. A file that states its own CRS is
-      // stronger evidence than a session written who-knows-where, so the
-      // declaration wins and the session's choice is dropped with a note.
-      const declared =
-        viewer.streamingCloud?.crs()?.epsg ??
-        (deps.getActiveScanId() ? viewer.getCloud(deps.getActiveScanId()!)?.metadata?.crs?.epsg : undefined);
-      if (declared != null && declared !== session.crs.epsg) {
-        deps.showToast(
-          `The session's CRS (EPSG:${session.crs.epsg}) was not applied — this scan declares EPSG:${declared}, and a file's own declaration wins.`,
-        );
-      } else {
-        deps.setCrsOverride({
-          override: { epsg: session.crs.epsg, kind: session.crs.kind },
-          detected: deps.getActiveScanId()
-            ? viewer.getCloud(deps.getActiveScanId()!)?.metadata?.crs ?? undefined
-            : undefined,
-          source: 'user-override',
-        });
-      }
+      // No conflict — restore the author's CRS override so a capsule round-trips
+      // without re-prompting.
+      deps.setCrsOverride({
+        override: { epsg: session.crs.epsg, kind: session.crs.kind },
+        detected: deps.getActiveScanId()
+          ? viewer.getCloud(deps.getActiveScanId()!)?.metadata?.crs ?? undefined
+          : undefined,
+        source: 'user-override',
+      });
     }
 
     // Honest disclosure: the session carries the saved analysis, not the scan

--- a/src/io/session.ts
+++ b/src/io/session.ts
@@ -29,6 +29,7 @@ import { freshAnnotationId, isAnnotationType } from '../render/annotate/types';
 import type { ColorMode } from '../render/colorModes';
 import type { PointSizeMode } from '../render/pointStyle';
 import type { ResolvedCrs } from '../geo/CoordinateTypes';
+import type { CrsLinearUnit } from './crs';
 import type { BoxBounds } from '../render/measure/geometry';
 import type { ClipBox, ClipMode } from '../render/clip/clipBox';
 
@@ -659,6 +660,131 @@ export function matchSessionToScan(
   // consistent with the same scan, not proof of it.
   if (rel > 0.01) reasons.unshift(`scan extents differ by ${(rel * 100).toFixed(1)}%`);
   return { verdict: 'partial', reasons };
+}
+
+// --- per-scan spatial-metadata guard (roadmap P1 #5) ------------------------
+
+/**
+ * The session's own spatial claims, distilled into a scan-independent bundle so
+ * the conflict check reads one shape whatever the session's provenance. `upAxis`
+ * is always present (top-level, parsed fail-closed by {@link parseUpAxis}); the
+ * CRS code and linear unit come from the session's resolved CRS when it carried
+ * one.
+ */
+export interface SessionSpatialClaims {
+  /** Vertical axis the session was captured in. */
+  readonly upAxis: 'y' | 'z';
+  /** Horizontal EPSG the session declares, when it carried a resolved CRS. */
+  readonly epsg?: number;
+  /** Linear unit the session's CRS declares; `'unknown'`/absent ⇒ no unit claim. */
+  readonly linearUnit?: CrsLinearUnit;
+}
+
+/**
+ * What the freshly-loaded FILE declares about its own frame — the source of
+ * truth a session may not silently redefine. Every field is optional because a
+ * file may declare none of them; when it does, that field simply can't conflict
+ * and the session's value is free to fill the gap.
+ */
+export interface DeclaredSpatialFacts {
+  /** The file's detected up-axis; `'unknown'`/absent ⇒ the file makes no axis claim. */
+  readonly upAxis?: 'y' | 'z' | 'unknown';
+  /** The file's horizontal EPSG, when it declares one. */
+  readonly epsg?: number;
+  /** The file's linear unit; `'unknown'`/absent ⇒ the file makes no unit claim. */
+  readonly linearUnit?: CrsLinearUnit;
+}
+
+/** Which spatial claim a {@link SpatialClaimConflict} concerns. */
+export type SpatialClaimField = 'crs' | 'axis' | 'unit';
+
+/** One proven divergence between the session's spatial claim and the file's. */
+export interface SpatialClaimConflict {
+  readonly field: SpatialClaimField;
+  /** Human-readable evidence, phrased so the file reads as the authority. */
+  readonly reason: string;
+}
+
+/** The verdict of {@link detectSessionSpatialConflict}. */
+export interface SessionSpatialVerdict {
+  /** True when the session's spatial metadata contradicts the file's own declaration. */
+  readonly hasConflict: boolean;
+  /** Every proven contradiction, most-load-bearing (CRS) first; empty on a clean match. */
+  readonly conflicts: readonly SpatialClaimConflict[];
+}
+
+/** A linear unit that positively names a real metric length (not the inert placeholder). */
+function isKnownLinearUnit(u: CrsLinearUnit | undefined): u is Exclude<CrsLinearUnit, 'unknown'> {
+  return u != null && u !== 'unknown';
+}
+
+/**
+ * Compare a session's stored spatial metadata (CRS identity, up-axis, linear
+ * unit) against what the freshly-loaded FILE declares, and report every field
+ * where they contradict — roadmap P1 #5's fail-closed gate.
+ *
+ * The rule is asymmetric on purpose: the FILE's own declaration is the source of
+ * truth, so a session may only SUPPLY spatial metadata the file leaves blank, it
+ * may never REDEFINE metadata the file already carries. A conflict is therefore
+ * raised only when BOTH sides positively declare a value AND those values differ
+ * (for the axis, when the file names a real axis that differs). When the file
+ * declares nothing — no EPSG, an `'unknown'` axis, an `'unknown'` unit — there is
+ * no conflict and the session's value fills the gap, exactly as before.
+ *
+ * The caller (session restore) treats any conflict as a refusal of the session's
+ * spatial claim, not a silent adoption of it: it keeps the file's declaration and
+ * discloses the disagreement, mirroring how the scan-identity gate refuses a
+ * differing EPSG rather than realigning onto it.
+ *
+ * Pure — no DOM, no cloud objects — so it is fully unit-tested in Node.
+ */
+export function detectSessionSpatialConflict(
+  claims: SessionSpatialClaims,
+  declared: DeclaredSpatialFacts,
+): SessionSpatialVerdict {
+  const conflicts: SpatialClaimConflict[] = [];
+
+  // CRS — canonical EPSG codes: a difference means the coordinates' MEANING
+  // differs, so no matching extents make adopting the session's frame honest.
+  if (
+    isFiniteNumber(claims.epsg) &&
+    isFiniteNumber(declared.epsg) &&
+    claims.epsg !== declared.epsg
+  ) {
+    conflicts.push({
+      field: 'crs',
+      reason: `the session's CRS (EPSG:${claims.epsg}) disagrees with the scan's declared EPSG:${declared.epsg}`,
+    });
+  }
+
+  // Axis — only when the FILE names a real axis (never on an unknown/undetected
+  // one). A differing up-axis reinterprets which component of every restored
+  // vertex is elevation, so it can't be adopted silently.
+  if (
+    (declared.upAxis === 'y' || declared.upAxis === 'z') &&
+    declared.upAxis !== claims.upAxis
+  ) {
+    conflicts.push({
+      field: 'axis',
+      reason: `the session's up-axis (${claims.upAxis.toUpperCase()}) disagrees with the scan's ${declared.upAxis.toUpperCase()}-up frame`,
+    });
+  }
+
+  // Unit — only when BOTH sides name a KNOWN unit (an unknown unit is the
+  // fail-closed "no claim", never a conflict). Metre vs foot silently rescales
+  // every distance, so the file's unit wins.
+  if (
+    isKnownLinearUnit(claims.linearUnit) &&
+    isKnownLinearUnit(declared.linearUnit) &&
+    claims.linearUnit !== declared.linearUnit
+  ) {
+    conflicts.push({
+      field: 'unit',
+      reason: `the session's linear unit (${claims.linearUnit}) disagrees with the scan's ${declared.linearUnit}`,
+    });
+  }
+
+  return { hasConflict: conflicts.length > 0, conflicts };
 }
 
 // --- validation helpers ----------------------------------------------------

--- a/tests/sessionIo.test.ts
+++ b/tests/sessionIo.test.ts
@@ -6,8 +6,15 @@ import {
   type SessionIoDeps,
   type SessionModule,
 } from '../src/app/sessionIo';
-import { serializeSession, parseSession, rebaseSessionGeometry, matchSessionToScan } from '../src/io/session';
+import {
+  serializeSession,
+  parseSession,
+  rebaseSessionGeometry,
+  matchSessionToScan,
+  detectSessionSpatialConflict,
+} from '../src/io/session';
 import type { InspectionSession, SessionScanSummary } from '../src/io/session';
+import type { ResolvedCrs } from '../src/geo/CoordinateTypes';
 import type { Viewer } from '../src/render/Viewer';
 import type { Measurement, Vec3 } from '../src/render/measure/types';
 
@@ -21,13 +28,29 @@ const p = (x: number, y: number, z: number): Vec3 => [x, y, z];
 // depending on a Node `File` global.
 const asFile = (text: string): File => ({ text: async () => text }) as unknown as File;
 
-const realSessionModule: SessionModule = { parseSession, rebaseSessionGeometry, matchSessionToScan };
+const realSessionModule: SessionModule = {
+  parseSession,
+  rebaseSessionGeometry,
+  matchSessionToScan,
+  detectSessionSpatialConflict,
+};
+
+type LinearUnit = 'metre' | 'foot' | 'us-survey-foot' | 'unknown';
 
 interface StreamingOpts {
   name: string;
   sourcePointCount: number;
   dataBounds: readonly [number, number, number, number, number, number];
-  crs?: { name?: string; epsg?: number } | null;
+  crs?: { name?: string; epsg?: number; linearUnit?: LinearUnit } | null;
+}
+
+interface StaticOpts {
+  name: string;
+  scanId: string;
+  pointCount: number;
+  bounds: { min: readonly [number, number, number]; max: readonly [number, number, number] };
+  sourceFormat: string;
+  crs?: { name?: string; epsg?: number; linearUnit?: LinearUnit } | null;
 }
 
 /**
@@ -38,6 +61,7 @@ interface StreamingOpts {
 function makeDeps(
   over: {
     streaming?: StreamingOpts;
+    static?: StaticOpts;
     origin?: readonly [number, number, number];
     appVersion?: string;
   } = {},
@@ -62,11 +86,21 @@ function makeDeps(
       }
     : null;
 
+  const staticCloud = over.static
+    ? {
+        name: over.static.name,
+        pointCount: over.static.pointCount,
+        bounds: () => over.static!.bounds,
+        sourceFormat: over.static.sourceFormat,
+        metadata: { crs: over.static.crs ?? null },
+      }
+    : null;
+
   const viewer = {
-    clouds: () => [] as string[],
+    clouds: () => (over.static ? [over.static.scanId] : ([] as string[])),
     hasStreamingCloud: over.streaming != null,
     streamingCloud,
-    getCloud: () => undefined,
+    getCloud: (id: string) => (over.static && id === over.static.scanId ? staticCloud : undefined),
     measure: { loadMeasurements },
     annotate: { loadAnnotations },
   };
@@ -76,8 +110,8 @@ function makeDeps(
     getViewer: () => viewer as unknown as Viewer,
     loadSession: async () => realSessionModule,
     appVersion: over.appVersion ?? CURRENT,
-    getActiveScanId: () => null,
-    getActiveCloud: () => null,
+    getActiveScanId: () => over.static?.scanId ?? null,
+    getActiveCloud: () => (staticCloud as unknown as import('../src/model/PointCloud').PointCloud | null),
     exportOrigin: () => over.origin ?? [0, 0, 0],
     bookmarks: { restore, names: () => ['V1'] },
     setInspectorViews,
@@ -301,5 +335,124 @@ describe('importSession — scan-identity gate against a loaded cloud', () => {
     expect(calls.showToast).toHaveBeenCalledWith(
       expect.stringContaining('Applied despite an unverified scan match'),
     );
+  });
+});
+
+describe('importSession — per-scan spatial-metadata guard (roadmap P1 #5)', () => {
+  // A resolved CRS the session carries; the serializer/parser round-trips it and
+  // the restore tries to re-apply it as the author's override.
+  const resolvedCrs = (over: Partial<ResolvedCrs> = {}): ResolvedCrs => ({
+    kind: 'projected',
+    name: 'NAD83 / UTM 13N',
+    epsg: 32613,
+    linearUnit: 'metre',
+    linearUnitToMetres: 1,
+    source: 'las-vlr',
+    confidence: 'high',
+    userConfirmed: true,
+    ...over,
+  });
+
+  // Extents match SCAN_A so the scan-identity gate returns a STRONG verdict and
+  // the restore reaches the spatial-metadata block. The summary carries NO epsg,
+  // so the identity gate can't conflict on CRS — that is precisely the hole this
+  // guard closes: a scan whose CRS declaration exists but wasn't in the summary.
+  const strongStreaming = (crs?: { epsg?: number; linearUnit?: LinearUnit }): StreamingOpts => ({
+    name: 'loaded.laz',
+    sourcePointCount: 1000,
+    dataBounds: [0, 0, 0, 10, 10, 3],
+    crs: crs ?? null,
+  });
+  const strongSummary = () => summary({ width: 10, depth: 10, height: 3, sourcePoints: 1000 });
+
+  it('refuses the session CRS when the file declares a DIFFERENT EPSG (no silent adopt)', async () => {
+    const { deps, calls } = makeDeps({ streaming: strongStreaming({ epsg: 32614 }) });
+    await importSession(
+      asFile(sessionJson({ crs: resolvedCrs({ epsg: 32613 }), scanSummary: strongSummary() })),
+      {},
+      deps,
+    );
+    // Geometry still restores — the scan IS a spatial match — but the session's
+    // CRS claim is refused and disclosed, not applied.
+    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    expect(calls.setCrsOverride).not.toHaveBeenCalled();
+    const warn = calls.showToast.mock.calls.map((c) => c[0] as string).find((m) => /conflicts with this scan/.test(m));
+    expect(warn).toBeTruthy();
+    expect(warn).toMatch(/EPSG:32613/);
+    expect(warn).toMatch(/EPSG:32614/);
+  });
+
+  it('applies the session CRS when it AGREES with the file', async () => {
+    const { deps, calls } = makeDeps({ streaming: strongStreaming({ epsg: 32613 }) });
+    await importSession(
+      asFile(sessionJson({ crs: resolvedCrs({ epsg: 32613 }), scanSummary: strongSummary() })),
+      {},
+      deps,
+    );
+    expect(calls.setCrsOverride).toHaveBeenCalledTimes(1);
+    expect(calls.setCrsOverride.mock.calls[0][0].override).toMatchObject({ epsg: 32613 });
+    expect(calls.showToast.mock.calls.every((c) => !/conflicts with this scan/.test(c[0] as string))).toBe(true);
+  });
+
+  it('keeps the file’s CRS when the session declares none — no override, no conflict', async () => {
+    const { deps, calls } = makeDeps({ streaming: strongStreaming({ epsg: 32613 }) });
+    await importSession(asFile(sessionJson({ scanSummary: strongSummary() })), {}, deps);
+    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    expect(calls.setCrsOverride).not.toHaveBeenCalled();
+    expect(calls.showToast.mock.calls.every((c) => !/conflicts with this scan/.test(c[0] as string))).toBe(true);
+  });
+
+  it('refuses the session CRS on a UNIT mismatch even when the EPSG agrees', async () => {
+    const { deps, calls } = makeDeps({ streaming: strongStreaming({ epsg: 32613, linearUnit: 'metre' }) });
+    await importSession(
+      asFile(sessionJson({ crs: resolvedCrs({ epsg: 32613, linearUnit: 'foot', linearUnitToMetres: 0.3048 }), scanSummary: strongSummary() })),
+      {},
+      deps,
+    );
+    expect(calls.setCrsOverride).not.toHaveBeenCalled();
+    const warn = calls.showToast.mock.calls.map((c) => c[0] as string).find((m) => /conflicts with this scan/.test(m));
+    expect(warn).toMatch(/linear unit/);
+    expect(warn).toMatch(/foot/);
+  });
+
+  it('flags an up-axis mismatch against the file’s detected axis', async () => {
+    // A Y-up mesh format (GLB) loaded; the session was captured Z-up. Extents
+    // match so the identity gate passes; the axis divergence is the conflict.
+    const { deps, calls } = makeDeps({
+      static: {
+        name: 'loaded.glb',
+        scanId: 'scan-1',
+        pointCount: 1000,
+        bounds: { min: [0, 0, 0], max: [10, 10, 3] },
+        sourceFormat: 'glb',
+      },
+    });
+    await importSession(
+      asFile(sessionJson({ upAxis: 'z', scanSummary: strongSummary() })),
+      {},
+      deps,
+    );
+    // Geometry restores; the axis conflict is surfaced, not silently adopted.
+    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    const warn = calls.showToast.mock.calls.map((c) => c[0] as string).find((m) => /conflicts with this scan/.test(m));
+    expect(warn).toBeTruthy();
+    expect(warn).toMatch(/up-axis/);
+    expect(warn).toMatch(/Y-up/);
+  });
+
+  it('restores cleanly when the file’s axis AGREES with the session', async () => {
+    // A Z-up survey format (LAS); session Z-up — no axis conflict.
+    const { deps, calls } = makeDeps({
+      static: {
+        name: 'loaded.las',
+        scanId: 'scan-1',
+        pointCount: 1000,
+        bounds: { min: [0, 0, 0], max: [10, 10, 3] },
+        sourceFormat: 'las',
+      },
+    });
+    await importSession(asFile(sessionJson({ upAxis: 'z', scanSummary: strongSummary() })), {}, deps);
+    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    expect(calls.showToast.mock.calls.every((c) => !/conflicts with this scan/.test(c[0] as string))).toBe(true);
   });
 });

--- a/tests/sessionScanIdentity.test.ts
+++ b/tests/sessionScanIdentity.test.ts
@@ -9,7 +9,13 @@
  */
 
 import { describe, test, expect } from 'vitest';
-import { matchSessionToScan, type ScanFacts } from '../src/io/session';
+import {
+  matchSessionToScan,
+  detectSessionSpatialConflict,
+  type ScanFacts,
+  type DeclaredSpatialFacts,
+  type SessionSpatialClaims,
+} from '../src/io/session';
 import type { SessionScanSummary } from '../src/io/session';
 
 const SCAN_A: SessionScanSummary = {
@@ -85,5 +91,89 @@ describe('matchSessionToScan', () => {
     const m = matchSessionToScan(undefined, loaded());
     expect(m.verdict).toBe('partial');
     expect(m.reasons[0]).toMatch(/no scan fingerprint/);
+  });
+});
+
+/**
+ * `detectSessionSpatialConflict` is the per-scan spatial-metadata gate (roadmap
+ * P1 #5): the FILE's own declaration is the source of truth, so a session may
+ * SUPPLY metadata the file omits but may never REDEFINE metadata the file
+ * carries. A conflict is raised only when both sides positively declare a value
+ * (a real axis for the axis field) and they differ.
+ */
+describe('detectSessionSpatialConflict', () => {
+  const claims = (over: Partial<SessionSpatialClaims> = {}): SessionSpatialClaims => ({
+    upAxis: 'z',
+    epsg: 32613,
+    linearUnit: 'metre',
+    ...over,
+  });
+  const file = (over: Partial<DeclaredSpatialFacts> = {}): DeclaredSpatialFacts => ({
+    upAxis: 'z',
+    epsg: 32613,
+    linearUnit: 'metre',
+    ...over,
+  });
+
+  test('fully-agreeing metadata has no conflict', () => {
+    const v = detectSessionSpatialConflict(claims(), file());
+    expect(v.hasConflict).toBe(false);
+    expect(v.conflicts).toEqual([]);
+  });
+
+  test('a differing EPSG is a CRS conflict, not a silent adoption', () => {
+    const v = detectSessionSpatialConflict(claims({ epsg: 32613 }), file({ epsg: 32614 }));
+    expect(v.hasConflict).toBe(true);
+    expect(v.conflicts.map((c) => c.field)).toContain('crs');
+    expect(v.conflicts.find((c) => c.field === 'crs')!.reason).toMatch(/EPSG:32613.*EPSG:32614/);
+  });
+
+  test('a differing up-axis is an axis conflict', () => {
+    const v = detectSessionSpatialConflict(claims({ upAxis: 'z' }), file({ upAxis: 'y' }));
+    expect(v.conflicts.map((c) => c.field)).toEqual(['axis']);
+    expect(v.conflicts[0].reason).toMatch(/up-axis \(Z\).*Y-up/);
+  });
+
+  test('a differing linear unit is a unit conflict', () => {
+    const v = detectSessionSpatialConflict(
+      claims({ linearUnit: 'foot' }),
+      file({ linearUnit: 'metre' }),
+    );
+    expect(v.conflicts.map((c) => c.field)).toEqual(['unit']);
+    expect(v.conflicts[0].reason).toMatch(/foot.*metre/);
+  });
+
+  test('the file declaring NOTHING lets the session fill the gap — no conflict', () => {
+    // File has no EPSG, an unknown axis, and an unknown unit; the session's
+    // values are free to stand.
+    const v = detectSessionSpatialConflict(
+      claims({ epsg: 32613, linearUnit: 'foot' }),
+      { upAxis: 'unknown', epsg: undefined, linearUnit: 'unknown' },
+    );
+    expect(v.hasConflict).toBe(false);
+  });
+
+  test('the session declaring nothing beyond its axis cannot conflict on CRS/unit', () => {
+    const v = detectSessionSpatialConflict(
+      { upAxis: 'z', epsg: undefined, linearUnit: undefined },
+      file({ epsg: 32613, linearUnit: 'metre' }),
+    );
+    expect(v.hasConflict).toBe(false);
+  });
+
+  test('an unknown-unit file never conflicts on unit (fail-closed = no claim)', () => {
+    const v = detectSessionSpatialConflict(
+      claims({ linearUnit: 'foot' }),
+      file({ linearUnit: 'unknown' }),
+    );
+    expect(v.conflicts.some((c) => c.field === 'unit')).toBe(false);
+  });
+
+  test('multiple divergences are all reported, CRS first', () => {
+    const v = detectSessionSpatialConflict(
+      claims({ epsg: 32613, upAxis: 'z', linearUnit: 'metre' }),
+      file({ epsg: 32614, upAxis: 'y', linearUnit: 'foot' }),
+    );
+    expect(v.conflicts.map((c) => c.field)).toEqual(['crs', 'axis', 'unit']);
   });
 });


### PR DESCRIPTION
## What

Session restore compares the session's stored spatial metadata (CRS identity/EPSG, up-axis, linear unit) against what the freshly-loaded file declares, and treats a divergence as a conflict rather than silently adopting the session's value. Roadmap item P1 #5 in `docs/architecture/coordinate-integrity-roadmap.md`.

## Why

A restored `.olvsession` carries the scan's up-axis, resolved CRS, and linear unit. The restore path trusted those over the loaded file. When they disagreed — session says Z-up but the file is Y-up, session says EPSG:32613 but the file declares 32614, session says feet but the file is metres — the file's own declaration was replaced and the scan's coordinates reinterpreted with no warning. The previous inline guard only caught the EPSG case.

## How

- `detectSessionSpatialConflict` (pure, `src/io/session.ts`) compares the session's claims against the file's declared facts and returns every field that conflicts. The rule is asymmetric: the file's declaration wins, so a session may supply metadata the file omits but never redefine metadata the file carries. A conflict fires only when both sides positively declare a value (a real axis for the axis field) and they differ; an unknown/absent value on the file side is "no claim," never a conflict.
- `src/app/sessionIo.ts` builds the file's declared frame from the active scan (`declaredSpatialFromStreaming` / `declaredSpatialFromStatic`, the up-axis derived via `isZUpFormat` exactly as the renderer and exporter do it), runs the check, and on any conflict keeps the file's declaration, skips the session's CRS override, and discloses the disagreement. This subsumes the old EPSG-only inline guard and extends it to axis and unit.
- Matching or metadata-free sessions round-trip exactly as before.

`src/main.ts` and `src/render/Viewer.ts` are untouched. `loadSession` already returns the whole `io/session` module, so the new pure function reaches the restore path with no wiring change.

## Tests

- `detectSessionSpatialConflict` matrix in `tests/sessionScanIdentity.test.ts`: full match; a differing EPSG; a differing up-axis; a differing unit; the file declaring nothing (session fills the gap); the session declaring nothing; an unknown-unit file; and all three diverging at once.
- `importSession` integration in `tests/sessionIo.test.ts`: a differing EPSG is refused and disclosed (override not applied); an agreeing EPSG is applied; a session with no CRS keeps the file's; a unit mismatch with an agreeing EPSG is refused; a Y-up file against a Z-up session is flagged; an agreeing axis restores cleanly.

## Gates

`tsc --noEmit`, full `vitest run` (7741 passed), monolith-size, layer-boundaries, and main-deferral all pass. `verify-archive-portability` fails only on `archive-self-verification`, which fetches an external USGS S3 dataset that this environment cannot reach; the other 13 checks pass and the failure is unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)