### PR TITLE
Replace regex WKT parsing with an AST parser (P1 #3)

### DIFF
--- a/src/io/crs.ts
+++ b/src/io/crs.ts
@@ -27,6 +27,15 @@
  * users that need WGS84 conversion can use a downstream tool (proj4, GDAL).
  */
 
+import {
+  collectWktNodes,
+  parseWkt,
+  wktChildNodes,
+  wktFirstNumber,
+  wktNodeName,
+  type WktNode,
+} from './wktParser';
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -244,28 +253,45 @@ export function parseCrsFromVlrs(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Best-effort WKT parser — extracts the top-level CRS name and any AUTHORITY
- * EPSG code, plus the linear unit from the first UNIT[...] clause. A full
- * WKT parser is intentionally out of scope; the regex-based path covers every
- * common LAS WKT (UTM zones, state plane, web mercator, WGS 84) which is
- * what research users actually ship.
+ * WKT → {@link CrsInfo}. Tokenises the WKT into a `KEYWORD["name", child, …]`
+ * AST (see {@link parseWkt}) and reads every field by STRUCTURE: the CRS name,
+ * horizontal EPSG (`AUTHORITY["EPSG",…]` / `ID["EPSG",…]` on the CRS node
+ * itself), linear unit + factor, geodetic datum, geographic-vs-projected kind,
+ * and the compound-CRS horizontal slice. Structure is what lets the code tell a
+ * CRS's own authority from one nested in a `UNIT` or `DATUM`, and keep a
+ * compound's vertical clauses out of the horizontal read — the two failure
+ * modes a flat regex cannot avoid.
+ *
+ * Resolution SEMANTICS are unchanged from the prior regex implementation: a
+ * projected CRS with no UNIT clause defaults to metre (the WKT default), an
+ * unrecognised linear-unit name resolves to `unknown` (fail-closed), and only
+ * the horizontal slice of a compound CRS decides name / EPSG / unit.
  */
 export function crsFromWkt(wkt: string): CrsInfo {
   // Trim wrapper whitespace + null terminators.
   const text = wkt.replace(/\0+$/, '').trim();
 
+  const root = parseWkt(text);
+  const nodes = root ? collectWktNodes(root) : [];
+
   // For a compound CRS (COMPD_CS / COMPOUNDCRS) the horizontal CRS and its
   // EPSG / unit live BEFORE the vertical block, so we analyse only the
   // horizontal slice for name / EPSG / unit. This stops the vertical CRS's
-  // EPSG and metre UNIT from being mistaken for the horizontal ones.
-  const vertKeyword = /\b(?:VERT_CS|VERTCRS|VERTICALCRS)\s*\[/i.exec(text);
-  const horizText = vertKeyword ? text.slice(0, vertKeyword.index) : text;
+  // EPSG and metre UNIT from being mistaken for the horizontal ones. The slice
+  // is every node that opens before the first vertical node — the structural
+  // equivalent of the old "text before the first VERT_CS keyword".
+  const verticalNode = nodes.find((n) => isVerticalKeyword(n.keyword));
+  const vertStart = verticalNode ? verticalNode.start : Infinity;
+  const horizNodes = nodes.filter((n) => n.start < vertStart);
 
-  // The CRS name is the first quoted string after a PROJCS / GEOGCS keyword
-  // (skipping the outer COMPD_CS name, which describes the whole compound).
-  const nameMatch = /(?:PROJCS|PROJCRS|GEOGCS|GEOGCRS)\s*\[\s*"([^"]+)"/i.exec(horizText)
-    ?? /^(?:COMPD_CS|COMPOUNDCRS)\s*\[\s*"([^"]+)"/i.exec(text);
-  const rawName = nameMatch ? nameMatch[1] : 'Unknown CRS';
+  // The CRS name is the first NAMED horizontal CRS node (PROJCS / GEOGCS /
+  // …); for a projected CRS that is the PROJCS, whose name wins over the nested
+  // base GEOGCS. A compound with no inner named CRS falls back to its own
+  // COMPD_CS name, which describes the whole compound.
+  const rawName =
+    firstName(horizNodes, isHorizontalCrsKeyword)
+    ?? (root && isCompoundKeyword(root.keyword) ? wktNodeName(root) : undefined)
+    ?? 'Unknown CRS';
 
   // Horizontal datum = the geographic base CRS's name (the GEOGCS / GEOGCRS /
   // BASEGEOGCRS node). For a projected CRS this is the nested base (e.g.
@@ -273,20 +299,23 @@ export function crsFromWkt(wkt: string): CrsInfo {
   // realization — "NAD83(2011)" stays distinct from "NAD83" (~1–2 m apart) — so
   // it is the precision-preserving source the resolver prefers over the generic
   // registry name.
-  const datumMatch = /\b(?:GEOGCS|GEOGCRS|BASEGEOGCRS)\s*\[\s*"([^"]+)"/i.exec(horizText);
-  const horizontalDatum = datumMatch ? datumMatch[1] : undefined;
+  const horizontalDatum = firstName(horizNodes, isGeodeticBaseKeyword);
 
-  // EPSG via the standard AUTHORITY clause. LAS WKT is permissive — we look
-  // for both AUTHORITY["EPSG","32612"] (WKT1) and ID["EPSG",32612] (WKT2).
-  // Restricted to the horizontal slice so a compound's vertical code can't win.
-  const epsg = extractEpsgFromWkt(horizText);
+  // EPSG via the standard AUTHORITY / ID clause on the CRS node itself. LAS WKT
+  // is permissive — AUTHORITY["EPSG","32612"] (WKT1) and ID["EPSG",32612]
+  // (WKT2) are both read. Anchored on the horizontal CRS node so a nested
+  // unit/datum authority, or a compound's vertical code, cannot win.
+  const horizCrsNode = horizNodes.find((n) => isHorizontalCrsKeyword(n.keyword));
+  const epsg = horizCrsNode ? epsgFromNodeChildren(horizCrsNode) : undefined;
 
   // Linear units. A projected WKT typically contains TWO UNIT clauses:
   // an angular one inside the nested GEOGCS (e.g. degrees), then the
   // projected linear one at the top level (metres / feet / etc.). We need
   // the LAST one in the horizontal slice for projected CRSs. For geographic
   // CRSs the unit is degrees and the "linear" field falls back to 'unknown'.
-  const isGeographic = !/\b(?:PROJCS|PROJCRS)/i.test(horizText) && /\b(?:GEOGCS|GEOGCRS)/i.test(horizText);
+  const isGeographic =
+    !horizNodes.some((n) => isProjectedKeyword(n.keyword)) &&
+    horizNodes.some((n) => isGeographicKeyword(n.keyword));
   let linearUnit: CrsLinearUnit = 'unknown';
   let linearUnitToMetres = 1;
   if (!isGeographic) {
@@ -294,17 +323,12 @@ export function crsFromWkt(wkt: string): CrsInfo {
     // its own UNIT (almost always metres); scanning the full text let that
     // vertical metre clause win over the horizontal one — e.g. a state-plane
     // CRS in US survey feet + NAVD88 metres parsed as metres.
-    const allUnits = [...horizText.matchAll(/\bUNIT\s*\[\s*"([^"]+)"\s*,\s*([0-9.eE+-]+)/g)];
-    // The projected linear unit is the LAST UNIT match in the horizontal
-    // slice (after the inner GEOGCS's angular UNIT). For non-compound WKT
-    // `horizText === text`, so this path is unchanged there.
-    const projectedUnit = allUnits[allUnits.length - 1];
+    const projectedUnit = lastLinearUnit(horizNodes);
     if (projectedUnit) {
-      const unitName = projectedUnit[1].toLowerCase();
-      const scale = Number(projectedUnit[2]);
+      const scale = projectedUnit.scale;
       if (Number.isFinite(scale) && scale > 0) {
         linearUnitToMetres = scale;
-        linearUnit = linearUnitFromNameOrScale(unitName, scale);
+        linearUnit = linearUnitFromNameOrScale(projectedUnit.name.toLowerCase(), scale);
       }
     } else {
       // No UNIT clause is rare on a projected CRS — default to metres.
@@ -317,7 +341,7 @@ export function crsFromWkt(wkt: string): CrsInfo {
   // VERT_CS. The name (e.g. "NAVD88") is the reliable signal; the EPSG is a
   // best-effort reverse lookup for the writer. The vertical block's own UNIT
   // (when present) gives the Z-axis unit, which can differ from the horizontal.
-  const vert = extractVerticalFromWkt(text);
+  const vert = verticalNode ? extractVerticalFromNode(verticalNode) : {};
 
   return {
     source: 'wkt',
@@ -335,44 +359,24 @@ export function crsFromWkt(wkt: string): CrsInfo {
   };
 }
 
-/** Extract the vertical-CRS name + best-effort EPSG + unit from a WKT string. */
-function extractVerticalFromWkt(
-  text: string,
+/** Extract the vertical-CRS name + best-effort EPSG + unit from a VERT_CS node. */
+function extractVerticalFromNode(
+  vert: WktNode,
 ): { epsg?: number; name?: string; unit?: CrsLinearUnit } {
-  const m = /\b(?:VERT_CS|VERTCRS|VERTICALCRS)\s*\[/i.exec(text);
-  if (!m) return {};
-  // Isolate the bracketed vertical block so a compound CRS's other authorities
-  // (the horizontal CRS, or the compound itself) can't be read as the vertical
-  // EPSG. The '[' is the last char of the match.
-  const block = bracketBlock(text, m.index + m[0].length - 1);
-  const nameMatch = /\[\s*"([^"]+)"/.exec(block);
-  const name = nameMatch ? nameMatch[1] : undefined;
+  const name = wktNodeName(vert);
   // A known datum name resolves to the vertical CRS code directly; otherwise
-  // fall back to an explicit EPSG authority inside the block (the LAST one is
-  // the vertical CRS's own, after any VERT_DATUM authority).
-  const epsg = (name ? verticalEpsgFromName(name) : undefined) ?? extractEpsgFromWkt(block);
-  // The vertical block's UNIT clause names the Z-axis unit (LAS WKT puts at most
+  // fall back to an explicit EPSG authority on the vertical node itself (its own
+  // AUTHORITY / ID, NOT a nested VERT_DATUM authority).
+  const epsg = (name ? verticalEpsgFromName(name) : undefined) ?? epsgFromNodeChildren(vert);
+  // The vertical node's UNIT child names the Z-axis unit (LAS WKT puts at most
   // one UNIT here). Mapped to our enum so elevation can convert by its own unit.
   let unit: CrsLinearUnit | undefined;
-  const unitMatches = [...block.matchAll(/\bUNIT\s*\[\s*"([^"]+)"\s*,\s*([0-9.eE+-]+)/g)];
-  const unitMatch = unitMatches[unitMatches.length - 1];
-  if (unitMatch) {
-    const scale = Number(unitMatch[2]);
-    if (Number.isFinite(scale) && scale > 0) unit = linearUnitFromNameOrScale(unitMatch[1].toLowerCase(), scale);
+  const unitClause = lastLinearUnit(collectWktNodes(vert));
+  if (unitClause) {
+    const scale = unitClause.scale;
+    if (Number.isFinite(scale) && scale > 0) unit = linearUnitFromNameOrScale(unitClause.name.toLowerCase(), scale);
   }
   return { name, epsg, unit };
-}
-
-/** Return the bracketed group that opens at/after `from` (matched depth-aware). */
-function bracketBlock(text: string, from: number): string {
-  let open = text[from] === '[' ? from : text.indexOf('[', from);
-  if (open < 0) return text.slice(from);
-  let depth = 0;
-  for (let j = open; j < text.length; j++) {
-    if (text[j] === '[') depth++;
-    else if (text[j] === ']' && --depth === 0) return text.slice(open, j + 1);
-  }
-  return text.slice(open);
 }
 
 /** Map a vertical-datum name to its EPSG code (the common geoids/datums). */
@@ -389,58 +393,105 @@ function verticalEpsgFromName(name: string): number | undefined {
   return undefined;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// AST field derivation — keyword predicates + node readers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The projected-CRS keywords (WKT1 `PROJCS`, WKT2 `PROJCRS`). */
+function isProjectedKeyword(k: string): boolean {
+  return k === 'PROJCS' || k === 'PROJCRS';
+}
+
+/** The geographic-CRS keywords (WKT1 `GEOGCS`, WKT2 `GEOGCRS`). */
+function isGeographicKeyword(k: string): boolean {
+  return k === 'GEOGCS' || k === 'GEOGCRS';
+}
+
+/** The vertical-CRS keywords (WKT1 `VERT_CS`, WKT2 `VERTCRS` / `VERTICALCRS`). */
+function isVerticalKeyword(k: string): boolean {
+  return k === 'VERT_CS' || k === 'VERTCRS' || k === 'VERTICALCRS';
+}
+
+/** The compound-CRS keywords (WKT1 `COMPD_CS`, WKT2 `COMPOUNDCRS`). */
+function isCompoundKeyword(k: string): boolean {
+  return k === 'COMPD_CS' || k === 'COMPOUNDCRS';
+}
+
+/** A horizontal CRS node — the one whose name and authority describe the frame. */
+function isHorizontalCrsKeyword(k: string): boolean {
+  return isProjectedKeyword(k) || isGeographicKeyword(k);
+}
+
 /**
- * Pull the first credible EPSG code from a WKT string. Looks for both WKT1
- * (`AUTHORITY["EPSG","32612"]`) and WKT2 (`ID["EPSG",32612]`) syntaxes.
- * Numerically constrained to the EPSG range (1024-32767, plus a generous
- * 32768-99999 for newer codes) so we don't latch onto a random integer.
+ * The geodetic BASE node whose name is the horizontal datum. For a projected
+ * CRS this is the nested `GEOGCS` / `BASEGEOGCRS`; for a geographic CRS it is
+ * the CRS node itself.
  */
-function extractEpsgFromWkt(text: string): number | undefined {
-  /*
-   * WKT carries many AUTHORITY/ID clauses — datum, spheroid, primem, axis and
-   * unit each have their own — and only the one on the OUTERMOST node names the
-   * CRS. Taking the last match in the EPSG range worked only because
-   * well-formed WKT happens to put the CRS's authority last; a PROJCS with no
-   * top-level authority (older / non-GDAL writers) then latched onto
-   * UNIT[...AUTHORITY["EPSG","9001"]] and reported the scan's CRS as EPSG:9001,
-   * a unit of measure presented as a coordinate system. Every nested code —
-   * 9001/9002/9003 (units), 6326/7030 (datum, spheroid) — sits inside that
-   * range, so no numeric filter can separate them.
-   *
-   * So match on STRUCTURE instead: track bracket depth and accept only a clause
-   * that is a direct child of the root node. When the root declares no
-   * authority, the honest answer is that the file names no code — not the
-   * nearest number that happens to look like one.
-   */
-  // Anchor on the CRS node itself rather than on the outermost bracket: a
-  // compound CRS wraps the horizontal CRS in COMPD_CS, so its authority sits one
-  // level deeper than a plain PROJCS's would.
-  const node = /\b(?:PROJCS|PROJCRS|GEOGCS|GEOGCRS|VERT_CS|VERTCRS|VERTICALCRS)\s*\[/i.exec(text);
+function isGeodeticBaseKeyword(k: string): boolean {
+  return isGeographicKeyword(k) || k === 'BASEGEOGCRS';
+}
 
-  /** Unclosed brackets before `index` — the nesting depth at that point. */
-  const depthAt = (index: number): number => {
-    let depth = 0;
-    for (let i = 0; i < index; i++) {
-      const c = text[i];
-      if (c === '[') depth++;
-      else if (c === ']') depth--;
-    }
-    return depth;
-  };
+/** The first node (document order) matching `pred` that carries a quoted name. */
+function firstName(candidates: readonly WktNode[], pred: (k: string) => boolean): string | undefined {
+  for (const n of candidates) {
+    if (!pred(n.keyword)) continue;
+    const name = wktNodeName(n);
+    if (name !== undefined) return name;
+  }
+  return undefined;
+}
 
-  // The node's own children sit one level inside it. With no keyword present the
-  // caller handed us a node's bracket block directly (the vertical path slices
-  // one out), so its children are already at depth 1.
-  const childDepth = node ? depthAt(node.index) + 1 : 1;
-
-  const clause = /(?:AUTHORITY|ID)\s*\[\s*"EPSG"\s*,\s*"?(\d+)"?\s*\]/gi;
+/**
+ * The EPSG code declared by a CRS node's OWN `AUTHORITY` / `ID` child — never a
+ * nested unit/datum/spheroid authority (those are grandchildren, not direct
+ * children). Both WKT1 `AUTHORITY["EPSG","32612"]` and WKT2 `ID["EPSG",32612]`
+ * are read. Constrained to the EPSG range (1024-99999) so a stray number can't
+ * pose as a code; the LAST qualifying child wins, matching well-formed WKT that
+ * places the CRS's own authority last.
+ */
+function epsgFromNodeChildren(node: WktNode): number | undefined {
   let found: number | undefined;
-  for (const m of text.matchAll(clause)) {
-    if (depthAt(m.index) !== childDepth) continue;
-    const n = Number(m[1]);
-    if (Number.isFinite(n) && n >= 1024 && n <= 99999) found = n;
+  for (const child of wktChildNodes(node)) {
+    if (child.keyword !== 'AUTHORITY' && child.keyword !== 'ID') continue;
+    if (wktNodeName(child)?.toUpperCase() !== 'EPSG') continue;
+    // The code is the clause's numeric argument. WKT1 quotes it ("32612"),
+    // WKT2 does not (32612); the AST carries the former as a string child and
+    // the latter as a number child, so read whichever is present.
+    const code = firstNumericArg(child);
+    if (code !== undefined && Number.isFinite(code) && code >= 1024 && code <= 99999) found = code;
   }
   return found;
+}
+
+/** The first numeric argument of a node — a number child, or a numeric string. */
+function firstNumericArg(node: WktNode): number | undefined {
+  for (const child of node.children) {
+    if (child.type === 'number') return child.value;
+    // Skip the leading name string ("EPSG"); a later numeric string is the code.
+    if (child.type === 'string' && /^\d+$/.test(child.value.trim())) return Number(child.value);
+  }
+  return undefined;
+}
+
+/**
+ * The LAST linear `UNIT` clause among `candidates` (document order), returning
+ * its name + scale. Only bare `UNIT` nodes count — WKT2's `LENGTHUNIT` /
+ * `ANGLEUNIT` are intentionally NOT read here, matching the prior parser's
+ * `\bUNIT\[` scan (which a `LENGTHUNIT` substring never satisfied). A node
+ * qualifies only when it has a quoted name and a numeric scale, exactly the
+ * `UNIT["name",<number>` shape the old regex required.
+ */
+function lastLinearUnit(candidates: readonly WktNode[]): { name: string; scale: number } | undefined {
+  let result: { name: string; scale: number } | undefined;
+  for (const n of candidates) {
+    if (n.keyword !== 'UNIT') continue;
+    const name = wktNodeName(n);
+    if (name === undefined) continue;
+    const scale = wktFirstNumber(n);
+    if (scale === undefined) continue;
+    result = { name, scale };
+  }
+  return result;
 }
 
 /**

--- a/src/io/wktParser.ts
+++ b/src/io/wktParser.ts
@@ -1,0 +1,267 @@
+/**
+ * wktParser.ts
+ *
+ * A small, dependency-free tokenizer + recursive parser for OGC WKT
+ * (Well-Known Text) coordinate-reference-system strings. It turns a WKT string
+ * into an AST of `KEYWORD["name", child, child, …]` nodes so callers can read
+ * fields by STRUCTURE (a node's keyword, its direct children, per-axis units)
+ * instead of by regex — which cannot tell a CRS's own `AUTHORITY` from one
+ * nested in a `UNIT` or `DATUM`, and bleeds a compound's vertical clauses into
+ * the horizontal read.
+ *
+ * Scope is deliberately narrow: recognise the WKT grammar's four token kinds
+ * (quoted string, number, bare keyword/identifier, bracketed node) and nest
+ * them. No semantics live here — `crs.ts` maps the AST to a `CrsInfo`. The
+ * parser NEVER throws: malformed input yields a best-effort tree (or `null`
+ * when no node can be found), so a broken VLR degrades to the same fallback a
+ * regex miss would, rather than crashing the loader.
+ *
+ * Both WKT1 (`PROJCS`, `AUTHORITY["EPSG","32612"]`) and WKT2 (`PROJCRS`,
+ * `ID["EPSG",32612]`, `BASEGEOGCRS`, `LENGTHUNIT`) shapes tokenise identically
+ * because the grammar is the same; only the keyword spellings differ, and
+ * keyword interpretation is the caller's job.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AST node shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A child of a WKT node — one of the grammar's value kinds:
+ *   • `node`    — a nested `KEYWORD[…]` (e.g. a `GEOGCS` inside a `PROJCS`)
+ *   • `string`  — a quoted string (`"WGS 84"`); this is how names arrive
+ *   • `number`  — a numeric literal (`0.9996`, `-111`, `298.257223563`)
+ *   • `keyword` — a bare unquoted identifier that is NOT followed by `[`
+ *                 (e.g. an axis direction `UP` / `NORTH`, or `NONE`)
+ */
+export type WktChild =
+  | { readonly type: 'node'; readonly node: WktNode }
+  | { readonly type: 'string'; readonly value: string }
+  | { readonly type: 'number'; readonly value: number }
+  | { readonly type: 'keyword'; readonly value: string };
+
+/** A parsed `KEYWORD[ … ]` clause. */
+export interface WktNode {
+  /** The clause keyword, UPPERCASED for case-insensitive matching (`'PROJCS'`). */
+  readonly keyword: string;
+  /**
+   * Source index of the keyword's first character. Gives every node a stable
+   * document-order position — used to reproduce the old parser's "everything
+   * before the first vertical keyword is the horizontal slice" rule exactly.
+   */
+  readonly start: number;
+  /** The clause's children, in source order. */
+  readonly children: readonly WktChild[];
+}
+
+/** Cap on nesting depth — real WKT nests < ~10 deep; this only guards against a
+ * pathological/malformed input blowing the stack. Content deeper than this is
+ * skipped rather than parsed. */
+const MAX_DEPTH = 64;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a WKT string into its root node, or `null` when the input contains no
+ * `KEYWORD[…]` node at all (empty, whitespace, or pure junk). Never throws.
+ */
+export function parseWkt(src: string): WktNode | null {
+  return parseTokens(tokenize(src));
+}
+
+/** Pre-order (document-order) list of every node in the tree, root first. */
+export function collectWktNodes(root: WktNode): WktNode[] {
+  const out: WktNode[] = [];
+  const visit = (n: WktNode): void => {
+    out.push(n);
+    for (const c of n.children) if (c.type === 'node') visit(c.node);
+  };
+  visit(root);
+  return out;
+}
+
+/** The node's direct child nodes (skipping scalar children), in source order. */
+export function wktChildNodes(node: WktNode): WktNode[] {
+  const out: WktNode[] = [];
+  for (const c of node.children) if (c.type === 'node') out.push(c.node);
+  return out;
+}
+
+/**
+ * The node's NAME: the first child, only when it is a quoted string. WKT places
+ * the name immediately after the opening bracket (`KEYWORD["name", …]`), so a
+ * node whose first child is not a string has no name — matching the old
+ * `KEYWORD\s*\[\s*"…"` regex, which required the quote right after the bracket.
+ */
+export function wktNodeName(node: WktNode): string | undefined {
+  const first = node.children[0];
+  return first && first.type === 'string' ? first.value : undefined;
+}
+
+/** The node's first numeric child, or `undefined` when it has none. */
+export function wktFirstNumber(node: WktNode): number | undefined {
+  for (const c of node.children) if (c.type === 'number') return c.value;
+  return undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tokenizer
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Tok =
+  | { readonly t: 'lb'; readonly i: number }
+  | { readonly t: 'rb'; readonly i: number }
+  | { readonly t: 'comma'; readonly i: number }
+  | { readonly t: 'string'; readonly v: string; readonly i: number }
+  | { readonly t: 'number'; readonly n: number; readonly i: number }
+  | { readonly t: 'ident'; readonly v: string; readonly i: number };
+
+function isDigit(ch: string): boolean {
+  return ch >= '0' && ch <= '9';
+}
+
+/** A number begins with a digit, or a sign/dot immediately followed by a digit. */
+function isNumberStart(src: string, i: number): boolean {
+  const ch = src[i];
+  if (isDigit(ch)) return true;
+  if (ch === '-' || ch === '+' || ch === '.') {
+    const d = src[i + 1];
+    return d !== undefined && isDigit(d);
+  }
+  return false;
+}
+
+/** Characters that may continue a numeric literal — mirrors the old scale
+ * regex's `[0-9.eE+-]+` so a token parses to the same `Number(…)`. */
+function isNumberChar(ch: string): boolean {
+  return isDigit(ch) || ch === '.' || ch === 'e' || ch === 'E' || ch === '+' || ch === '-';
+}
+
+function isIdentStart(ch: string): boolean {
+  return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch === '_';
+}
+
+function isIdentChar(ch: string): boolean {
+  return isIdentStart(ch) || isDigit(ch);
+}
+
+function tokenize(src: string): Tok[] {
+  const out: Tok[] = [];
+  const len = src.length;
+  let i = 0;
+  while (i < len) {
+    const ch = src[i];
+    // Whitespace.
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\f' || ch === '\v') {
+      i++;
+      continue;
+    }
+    if (ch === '[') { out.push({ t: 'lb', i }); i++; continue; }
+    if (ch === ']') { out.push({ t: 'rb', i }); i++; continue; }
+    if (ch === ',') { out.push({ t: 'comma', i }); i++; continue; }
+    if (ch === '"') {
+      // Quoted string — read to the next quote (or end). Matches the old
+      // `[^"]+` captures; WKT names never contain a literal quote.
+      const start = i + 1;
+      let j = start;
+      while (j < len && src[j] !== '"') j++;
+      out.push({ t: 'string', v: src.slice(start, j), i });
+      i = j < len ? j + 1 : j;
+      continue;
+    }
+    if (isNumberStart(src, i)) {
+      let j = i + 1;
+      while (j < len && isNumberChar(src[j])) j++;
+      out.push({ t: 'number', n: Number(src.slice(i, j)), i });
+      i = j;
+      continue;
+    }
+    if (isIdentStart(ch)) {
+      let j = i + 1;
+      while (j < len && isIdentChar(src[j])) j++;
+      out.push({ t: 'ident', v: src.slice(i, j), i });
+      i = j;
+      continue;
+    }
+    // Any other character (stray punctuation) — skip it rather than fail.
+    i++;
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parser
+// ─────────────────────────────────────────────────────────────────────────────
+
+function parseTokens(tokens: Tok[]): WktNode | null {
+  let pos = 0;
+
+  /** Consume a balanced bracket block starting at an `ident [` or a bare `[`. */
+  const skipBlock = (): void => {
+    if (tokens[pos]?.t === 'ident') pos++;
+    if (tokens[pos]?.t !== 'lb') {
+      if (pos < tokens.length) pos++;
+      return;
+    }
+    let depth = 0;
+    while (pos < tokens.length) {
+      const t = tokens[pos];
+      if (t.t === 'lb') depth++;
+      else if (t.t === 'rb') {
+        depth--;
+        if (depth === 0) { pos++; return; }
+      }
+      pos++;
+    }
+  };
+
+  /** Parse `IDENT [ child (, child)* ]` — assumes tokens[pos] is the keyword. */
+  const parseNode = (depth: number): WktNode | null => {
+    const idTok = tokens[pos];
+    if (!idTok || idTok.t !== 'ident') return null;
+    const lb = tokens[pos + 1];
+    if (!lb || lb.t !== 'lb') return null;
+
+    const keyword = idTok.v;
+    const start = idTok.i;
+    pos += 2; // consume the keyword and its opening bracket
+
+    const children: WktChild[] = [];
+    while (pos < tokens.length) {
+      const tk = tokens[pos];
+      if (tk.t === 'rb') { pos++; break; } // close this node
+      if (tk.t === 'comma') { pos++; continue; }
+      if (tk.t === 'string') { children.push({ type: 'string', value: tk.v }); pos++; continue; }
+      if (tk.t === 'number') { children.push({ type: 'number', value: tk.n }); pos++; continue; }
+      if (tk.t === 'lb') { skipBlock(); continue; } // stray bracket — skip its block
+      // ident: a nested node when followed by '[', otherwise a bare keyword token.
+      const nxt = tokens[pos + 1];
+      if (nxt && nxt.t === 'lb') {
+        if (depth < MAX_DEPTH) {
+          const child = parseNode(depth + 1);
+          if (child) children.push({ type: 'node', node: child });
+          else skipBlock();
+        } else {
+          skipBlock();
+        }
+      } else {
+        children.push({ type: 'keyword', value: tk.v });
+        pos++;
+      }
+    }
+
+    return { keyword: keyword.toUpperCase(), start, children };
+  };
+
+  // Find the first top-level `IDENT [` and parse it as the root.
+  while (pos < tokens.length) {
+    const tk = tokens[pos];
+    if (tk.t === 'ident' && tokens[pos + 1]?.t === 'lb') {
+      return parseNode(0);
+    }
+    pos++;
+  }
+  return null;
+}

--- a/tests/wktParser.test.ts
+++ b/tests/wktParser.test.ts
@@ -1,0 +1,236 @@
+/**
+ * wktParser.test.ts
+ *
+ * Table-driven tests for the WKT AST tokenizer/parser and the fields
+ * `crsFromWkt` derives from it. Two contracts:
+ *
+ *   1. The parser turns `KEYWORD["name", child, …]` WKT into a faithful tree —
+ *      quoted strings, numbers, bare keyword tokens (axis directions) and nested
+ *      nodes — for WKT1 and WKT2 shapes, and degrades (never throws) on junk.
+ *   2. `crsFromWkt` reads the SAME `CrsInfo` from that tree the regex parser did:
+ *      name / EPSG / linear unit / datum / compound horizontal slice, with the
+ *      no-UNIT→metre default and the unknown-unit→unknown fail-closed preserved.
+ *
+ * Pure Node — no DOM, no three.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { crsFromWkt } from '../src/io/crs';
+import {
+  collectWktNodes,
+  parseWkt,
+  wktChildNodes,
+  wktFirstNumber,
+  wktNodeName,
+  type WktNode,
+} from '../src/io/wktParser';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tokenizer / AST shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('parseWkt — AST node shape', () => {
+  it('parses a keyword, quoted name, number, and nested node', () => {
+    const root = parseWkt('UNIT["metre",1,AUTHORITY["EPSG","9001"]]');
+    expect(root).not.toBeNull();
+    expect(root!.keyword).toBe('UNIT');
+    expect(wktNodeName(root!)).toBe('metre');
+    expect(wktFirstNumber(root!)).toBe(1);
+    const auth = wktChildNodes(root!);
+    expect(auth).toHaveLength(1);
+    expect(auth[0].keyword).toBe('AUTHORITY');
+    expect(wktNodeName(auth[0])).toBe('EPSG');
+  });
+
+  it('uppercases keywords so matching is case-insensitive', () => {
+    const root = parseWkt('projcs["x",unit["metre",1]]');
+    expect(root!.keyword).toBe('PROJCS');
+    expect(wktChildNodes(root!)[0].keyword).toBe('UNIT');
+  });
+
+  it('keeps a bare identifier (axis direction) as a keyword child, not a node', () => {
+    const root = parseWkt('AXIS["Gravity-related height",UP]');
+    // The name is the quoted string; UP is a bare keyword token (no brackets).
+    expect(wktNodeName(root!)).toBe('Gravity-related height');
+    expect(wktChildNodes(root!)).toHaveLength(0); // UP is not a node
+    const kinds = root!.children.map((c) => c.type);
+    expect(kinds).toEqual(['string', 'keyword']);
+  });
+
+  it('reads signed and scientific numeric literals', () => {
+    const root = parseWkt('PARAMETER["central_meridian",-111]');
+    expect(wktFirstNumber(root!)).toBe(-111);
+    const sci = parseWkt('P["x",1.5e-7]');
+    expect(wktFirstNumber(sci!)).toBeCloseTo(1.5e-7, 12);
+  });
+
+  it('reads WKT2 unquoted authority codes (ID["EPSG",32612]) as numbers', () => {
+    const root = parseWkt('ID["EPSG",32612]');
+    expect(wktNodeName(root!)).toBe('EPSG');
+    expect(wktFirstNumber(root!)).toBe(32612);
+  });
+
+  it('collectWktNodes walks the whole tree in document order', () => {
+    const root = parseWkt('PROJCS["p",GEOGCS["g",DATUM["d"]],UNIT["metre",1]]');
+    const keywords = collectWktNodes(root!).map((n: WktNode) => n.keyword);
+    expect(keywords).toEqual(['PROJCS', 'GEOGCS', 'DATUM', 'UNIT']);
+  });
+
+  it('returns null when there is no node at all', () => {
+    expect(parseWkt('')).toBeNull();
+    expect(parseWkt('    ')).toBeNull();
+    expect(parseWkt('not wkt at all')).toBeNull();
+  });
+
+  it('degrades without throwing on an unterminated bracket', () => {
+    const root = parseWkt('PROJCS["Unterminated",GEOGCS["base"');
+    expect(root).not.toBeNull();
+    expect(root!.keyword).toBe('PROJCS');
+    expect(wktNodeName(root!)).toBe('Unterminated');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// crsFromWkt — table-driven field derivation
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NAD83_SP_CA_V_WKT =
+  'PROJCS["NAD83 / California zone 5 (ftUS)",GEOGCS["NAD83",' +
+  'DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101]],' +
+  'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],' +
+  'PROJECTION["Lambert_Conformal_Conic_2SP"],' +
+  'UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],' +
+  'AUTHORITY["EPSG","2229"]]';
+
+interface Case {
+  readonly title: string;
+  readonly wkt: string;
+  readonly epsg?: number;
+  readonly isGeographic: boolean;
+  readonly linearUnit: 'metre' | 'foot' | 'us-survey-foot' | 'unknown';
+  readonly nameContains?: string;
+  readonly horizontalDatum?: string;
+  readonly verticalEpsg?: number;
+  readonly verticalDatumContains?: string;
+  readonly verticalLinearUnit?: 'metre' | 'foot' | 'us-survey-foot' | 'unknown';
+}
+
+const cases: Case[] = [
+  {
+    title: 'WKT1 projected metre (UTM 12N)',
+    wkt: 'PROJCS["WGS 84 / UTM zone 12N",GEOGCS["WGS 84",DATUM["WGS_1984"],UNIT["degree",0.0174532925199433]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AUTHORITY["EPSG","32612"]]',
+    epsg: 32612, isGeographic: false, linearUnit: 'metre',
+    nameContains: 'WGS 84 / UTM zone 12N', horizontalDatum: 'WGS 84',
+  },
+  {
+    title: 'WKT1 projected US survey foot (state plane)',
+    wkt: NAD83_SP_CA_V_WKT,
+    epsg: 2229, isGeographic: false, linearUnit: 'us-survey-foot', horizontalDatum: 'NAD83',
+  },
+  {
+    title: 'WKT2 projected (PROJCRS + ID + BASEGEOGCRS + LENGTHUNIT)',
+    wkt: 'PROJCRS["WGS 84 / UTM zone 12N",BASEGEOGCRS["WGS 84",DATUM["World Geodetic System 1984"],ID["EPSG",4326]],CONVERSION["UTM zone 12N"],CS[Cartesian,2],AXIS["easting",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing",north,ORDER[2],LENGTHUNIT["metre",1]],ID["EPSG",32612]]',
+    // LENGTHUNIT is deliberately NOT read as a linear UNIT (parity with the old
+    // parser); with no bare UNIT clause a projected CRS defaults to metre.
+    epsg: 32612, isGeographic: false, linearUnit: 'metre',
+    nameContains: 'WGS 84 / UTM zone 12N', horizontalDatum: 'WGS 84',
+  },
+  {
+    title: 'geographic (WKT1 GEOGCS, degrees)',
+    wkt: 'GEOGCS["WGS 84",DATUM["WGS_1984"],UNIT["degree",0.0174532925199433],AUTHORITY["EPSG","4326"]]',
+    epsg: 4326, isGeographic: true, linearUnit: 'unknown', horizontalDatum: 'WGS 84',
+  },
+  {
+    title: 'nested base preserves datum realization (NAD83(2011))',
+    wkt: 'PROJCS["NAD83(2011) / UTM zone 12N",GEOGCS["NAD83(2011)",DATUM["NAD83_2011"]],UNIT["metre",1]]',
+    isGeographic: false, linearUnit: 'metre', horizontalDatum: 'NAD83(2011)',
+  },
+  {
+    title: 'compound: horizontal foot unit beats vertical metres',
+    wkt: 'COMPD_CS["NAD83 SP + NAVD88",' + NAD83_SP_CA_V_WKT +
+      ',VERT_CS["NAVD88 height",VERT_DATUM["North American Vertical Datum 1988",2005],' +
+      'UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Gravity-related height",UP],AUTHORITY["EPSG","5703"]]]',
+    epsg: 2229, isGeographic: false, linearUnit: 'us-survey-foot',
+    verticalEpsg: 5703, verticalDatumContains: 'NAVD88', verticalLinearUnit: 'metre',
+  },
+  {
+    title: 'compound: vertical survey-foot over a metre grid, read separately',
+    wkt: 'COMPD_CS["c",PROJCS["WGS 84 / UTM zone 12N",GEOGCS["WGS 84",DATUM["WGS_1984"],UNIT["degree",0.0174532925199433]],UNIT["metre",1],AUTHORITY["EPSG","32612"]],VERT_CS["NAVD88 height (ftUS)",VERT_DATUM["NAVD88",2005],UNIT["US survey foot",0.3048006096012192],AUTHORITY["EPSG","6360"]]]',
+    epsg: 32612, isGeographic: false, linearUnit: 'metre',
+    verticalDatumContains: 'NAVD88', verticalLinearUnit: 'us-survey-foot',
+  },
+  {
+    title: 'compound: explicit vertical EPSG with an unrecognised datum name',
+    wkt: 'COMPD_CS["x",PROJCS["NAD83 / UTM zone 11N",AUTHORITY["EPSG","26911"]],VERT_CS["Some local height datum",VERT_DATUM["Local",2005,AUTHORITY["EPSG","1234"]],UNIT["metre",1],AUTHORITY["EPSG","5703"]]]',
+    epsg: 26911, isGeographic: false, linearUnit: 'metre',
+    verticalEpsg: 5703, verticalDatumContains: 'Some local height datum',
+  },
+  {
+    title: 'standalone vertical CRS (no horizontal)',
+    wkt: 'VERT_CS["NAVD88 height",VERT_DATUM["NAVD88",2005],UNIT["metre",1],AUTHORITY["EPSG","5703"]]',
+    epsg: undefined, isGeographic: false, linearUnit: 'metre',
+    verticalEpsg: 5703, verticalDatumContains: 'NAVD88',
+  },
+  {
+    title: 'missing UNIT on a projected CRS defaults to metre',
+    wkt: 'PROJCS["Local grid",AUTHORITY["EPSG","0"]]',
+    // EPSG:0 is below the accepted range → no code claimed.
+    epsg: undefined, isGeographic: false, linearUnit: 'metre',
+  },
+  {
+    title: 'unknown unit NAME resolves to unknown (fail-closed), scale kept',
+    wkt: 'PROJCS["Local grid",UNIT["chain",20.1168],AUTHORITY["EPSG","0"]]',
+    epsg: undefined, isGeographic: false, linearUnit: 'unknown',
+  },
+  {
+    title: 'nested UNIT authority is not mistaken for the CRS code',
+    wkt: 'PROJCS["Custom Zone",GEOGCS["WGS 84",AUTHORITY["EPSG","4326"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]]]',
+    epsg: undefined, isGeographic: false, linearUnit: 'metre', horizontalDatum: 'WGS 84',
+  },
+];
+
+describe('crsFromWkt — table-driven shapes (parity with the regex parser)', () => {
+  for (const c of cases) {
+    it(c.title, () => {
+      const crs = crsFromWkt(c.wkt);
+      expect(crs.source).toBe('wkt');
+      expect(crs.epsg).toBe(c.epsg);
+      expect(crs.isGeographic).toBe(c.isGeographic);
+      expect(crs.linearUnit).toBe(c.linearUnit);
+      if (c.nameContains) expect(crs.name).toContain(c.nameContains);
+      if (c.horizontalDatum !== undefined) expect(crs.horizontalDatum).toBe(c.horizontalDatum);
+      if (c.verticalEpsg !== undefined) expect(crs.verticalEpsg).toBe(c.verticalEpsg);
+      if (c.verticalDatumContains) expect(crs.verticalDatum).toContain(c.verticalDatumContains);
+      if (c.verticalLinearUnit !== undefined) expect(crs.verticalLinearUnit).toBe(c.verticalLinearUnit);
+    });
+  }
+});
+
+describe('crsFromWkt — malformed input falls back like the regex parser did', () => {
+  it('empty / whitespace / junk → Unknown CRS, no code, metre default off (unknown)', () => {
+    for (const bad of ['', '   ', 'not wkt at all']) {
+      const crs = crsFromWkt(bad);
+      expect(crs.name).toBe('Unknown CRS');
+      expect(crs.epsg).toBeUndefined();
+      expect(crs.isGeographic).toBe(false);
+      // No PROJCS/GEOGCS recognised → not geographic; the projected branch with
+      // no UNIT defaults to metre, matching the prior parser exactly.
+      expect(crs.linearUnit).toBe('metre');
+    }
+  });
+
+  it('an unterminated PROJCS still yields its name and defaults', () => {
+    const crs = crsFromWkt('PROJCS["Unterminated",GEOGCS["base"');
+    expect(crs.name).toBe('Unterminated');
+    expect(crs.epsg).toBeUndefined();
+    expect(crs.isGeographic).toBe(false);
+    expect(crs.linearUnit).toBe('metre');
+    expect(crs.horizontalDatum).toBe('base');
+  });
+
+  it('trailing NUL terminators are trimmed before parsing', () => {
+    const crs = crsFromWkt('PROJCS["Zone",UNIT["metre",1],AUTHORITY["EPSG","32612"]]\0\0');
+    expect(crs.epsg).toBe(32612);
+    expect(crs.wkt?.endsWith(']')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Roadmap P1 #3: replace the regex-based field extraction in `crsFromWkt` with a proper WKT tokenizer + recursive AST parser, then derive the same `CrsInfo` fields from the tree.

`crsFromWkt` now parses WKT into a `KEYWORD["name", child, …]` AST (`src/io/wktParser.ts`, dependency-free) and reads every field by **structure**: CRS name, horizontal EPSG (`AUTHORITY["EPSG",…]` / `ID["EPSG",…]` on the CRS node itself), linear unit + factor, geodetic datum, `isGeographic`, and the compound-CRS horizontal slice.

This is **robustness, not a behaviour change**. Structure is what lets the parser tell a CRS's own authority from one nested in a `UNIT`/`DATUM`, and keep a compound's vertical clauses out of the horizontal read — the two failure modes a flat regex cannot avoid — without any cross-clause bleed.

## Semantics preserved (deliberate + tested)

- No-UNIT projected CRS → **metre** (the WKT default).
- Unrecognised linear-unit **name** → **`unknown`** (fail-closed); the declared scale is still kept.
- Compound CRS: only the **horizontal** slice decides name / EPSG / unit; the vertical block's EPSG and metre UNIT never leak in.
- WKT1 (`PROJCS`, `AUTHORITY`) and WKT2 (`PROJCRS`, `ID`, `BASEGEOGCRS`, `LENGTHUNIT`) both parse. `LENGTHUNIT`/`ANGLEUNIT` are intentionally **not** read as linear units — matching the prior `\bUNIT[` behaviour.
- Malformed input degrades to the same fallback as before; the parser never throws.

## How parity was proven

- A verbatim copy of the old regex parser was run beside the new one over a corpus of 34 WKT1/WKT2/compound/nested-base/standalone-vertical/malformed/lowercase/unterminated inputs — **identical `CrsInfo` for every input** (harness kept out of the tree).
- Every existing `crs*`/`wkt*` test passes unchanged: `crs.test.ts`, `crsFoundation.test.ts`, `crsValidation.test.ts`, `crsVerticalHardening.test.ts`, `las14WktConformance.test.ts`, `horizontalDatum.test.ts`, `eptCrs.test.ts`, `benchmark/failureRecovery.test.ts`.
- New `tests/wktParser.test.ts` adds table-driven parser + `crsFromWkt` tests (WKT1 + WKT2 shapes, compound, nested base, missing-UNIT→metre, unknown-unit→unknown, malformed → same fallback).

## Public API

`crsFromWkt` and all exported helpers keep their signatures — callers untouched.

## Gates

- `npx tsc --noEmit` → 0
- **FULL** `npx vitest run` → 0 (7750 passed, 20 skipped, 1 todo; 596 files)
- `lint-monolith-size` / `lint-layer-boundaries` / `lint-main-deferral` → 0
- `verify-archive-portability` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)