### PR TITLE
Carry transform provenance on every reproject result (P1 #7)

### DIFF
--- a/src/convert/convertCloud.ts
+++ b/src/convert/convertCloud.ts
@@ -135,7 +135,11 @@ export function convertCloud(
     if (sourceEpsg == null) {
       return fail('Reproject needs a known source CRS. Assign the source EPSG, or pick Assign instead.');
     }
-    const r = reprojectGlobal(g, sourceEpsg, opts.targetEpsg);
+    // Pass the source CRS as a provenance hint so the result's
+    // TransformProvenance carries the realization-preserving datum name and the
+    // source coordinate epoch. Hints affect only the metadata, never the
+    // reprojected coordinates.
+    const r = reprojectGlobal(g, sourceEpsg, opts.targetEpsg, { sourceCrs: cloud.metadata?.crs ?? null });
     g = r.points;
     if (r.transformed && r.datumCaveat == null) {
       reprojectApplied = true;

--- a/src/convert/epsg.ts
+++ b/src/convert/epsg.ts
@@ -165,21 +165,23 @@ const WGS84_COINCIDENT: ReadonlySet<DatumFamily> = new Set([
   'GDA2020',
 ]);
 
-export function datumShiftCaveat(srcEpsg: number, dstEpsg: number): string | null {
+/**
+ * The three degenerate datum-shift classes our proj4 definitions cannot model
+ * faithfully. `null` means the pair is clean (same family, a pure projection
+ * change, or a conventionally-coincident cluster pair) OR unresolvable. This is
+ * the SINGLE classification both {@link datumShiftCaveat} (the human warning) and
+ * {@link datumShiftAccuracyMetres} (the machine-readable magnitude) read, so the
+ * two can never disagree about which pairs are degenerate.
+ */
+type DatumShiftClass = 'nad27-legless' | 'gda94-gda2020-identity' | 'nad83-wgs84-identity';
+
+function classifyDatumShift(srcEpsg: number, dstEpsg: number): DatumShiftClass | null {
   const a = epsgDatumFamily(srcEpsg);
   const b = epsgDatumFamily(dstEpsg);
   if (a == null || b == null || a === b) return null;
-  if (a === 'NAD27' || b === 'NAD27') {
-    return (
-      'NAD27 datum grids (NADCON/NTv2) are not bundled — the NAD27 leg of this ' +
-      'transform uses a coarse parametric shift; horizontal errors of 10 m or more are expected'
-    );
-  }
+  if (a === 'NAD27' || b === 'NAD27') return 'nad27-legless';
   if ((a === 'GDA94' && b === 'GDA2020') || (a === 'GDA2020' && b === 'GDA94')) {
-    return (
-      'GDA94 and GDA2020 are both defined as identity shifts to WGS84 here, so no real ' +
-      'datum shift was applied — the true GDA94→GDA2020 difference is ≈ 1.8 m (plate motion)'
-    );
+    return 'gda94-gda2020-identity';
   }
   // NAD83 is realised here as an identity shift to WGS84, but it is offset from
   // the WGS84-coincident cluster (modern WGS84 / ETRS89 / GDA2020) by ≈ 1–2 m
@@ -189,12 +191,62 @@ export function datumShiftCaveat(srcEpsg: number, dstEpsg: number): string | nul
     (a === 'NAD83' && WGS84_COINCIDENT.has(b)) ||
     (b === 'NAD83' && WGS84_COINCIDENT.has(a))
   ) {
-    return (
-      'NAD83 is applied here as an identity shift to the WGS84 datum family, but the two ' +
-      'differ by ≈ 1–2 m — no NAD83 datum grid was applied'
-    );
+    return 'nad83-wgs84-identity';
   }
   return null;
+}
+
+export function datumShiftCaveat(srcEpsg: number, dstEpsg: number): string | null {
+  switch (classifyDatumShift(srcEpsg, dstEpsg)) {
+    case 'nad27-legless':
+      return (
+        'NAD27 datum grids (NADCON/NTv2) are not bundled — the NAD27 leg of this ' +
+        'transform uses a coarse parametric shift; horizontal errors of 10 m or more are expected'
+      );
+    case 'gda94-gda2020-identity':
+      return (
+        'GDA94 and GDA2020 are both defined as identity shifts to WGS84 here, so no real ' +
+        'datum shift was applied — the true GDA94→GDA2020 difference is ≈ 1.8 m (plate motion)'
+      );
+    case 'nad83-wgs84-identity':
+      return (
+        'NAD83 is applied here as an identity shift to the WGS84 datum family, but the two ' +
+        'differ by ≈ 1–2 m — no NAD83 datum grid was applied'
+      );
+    default:
+      return null;
+  }
+}
+
+/**
+ * The estimated horizontal error, in METRES, that the DATUM leg of a src→dst
+ * transform introduces given our grid-less / identity proj4 definitions. It is
+ * the machine-readable companion to {@link datumShiftCaveat} — the SAME
+ * classification decides both — and reports the magnitude the caveat already
+ * states in prose, never a fabricated precision:
+ *
+ *   - NAD27 leg: 10 m — the stated floor ("10 m or more"); the true error grows
+ *     larger at datum edges / in Alaska, so this is a lower bound, not a claim.
+ *   - GDA94 ↔ GDA2020: 1.8 m — the plate-motion difference the identity omits.
+ *   - NAD83 ↔ the WGS84-coincident cluster: 2 m — the conservative top of the
+ *     "≈ 1–2 m" offset.
+ *
+ * Returns `null` when there is NO cross-datum leg to characterise (a same-family
+ * projection change, a conventionally-coincident cluster pair, or an
+ * unresolvable code): a projection-only transform is not assigned a survey
+ * figure, and an unknown datum is reported as unknown, never as zero.
+ */
+export function datumShiftAccuracyMetres(srcEpsg: number, dstEpsg: number): number | null {
+  switch (classifyDatumShift(srcEpsg, dstEpsg)) {
+    case 'nad27-legless':
+      return 10;
+    case 'gda94-gda2020-identity':
+      return 1.8;
+    case 'nad83-wgs84-identity':
+      return 2;
+    default:
+      return null;
+  }
 }
 
 /** A human label for an EPSG code (best-effort, for logs/UI). */

--- a/src/convert/reproject.ts
+++ b/src/convert/reproject.ts
@@ -12,6 +12,11 @@
 import proj4 from 'proj4';
 import type { GlobalPoints } from './globalPoints';
 import { epsgToProj4, datumShiftCaveat } from './epsg';
+import {
+  buildTransformProvenance,
+  type TransformCrsHints,
+  type TransformProvenance,
+} from './transformProvenance';
 
 export interface ReprojectResult {
   readonly points: GlobalPoints;
@@ -25,6 +30,15 @@ export interface ReprojectResult {
    * off. Always null when `transformed` is false (nothing moved).
    */
   readonly datumCaveat: string | null;
+  /**
+   * Provenance of the operation this result came from — which transform, its
+   * accuracy, the source/target datum + realization, and the source coordinate
+   * epoch (see {@link TransformProvenance}). Derived from the src/dst CRS, not
+   * from the coordinates, so it is present on EVERY outcome (transformed,
+   * skipped, or failed); a skipped/failed transform still discloses the
+   * operation that was attempted. Never affects a returned coordinate.
+   */
+  readonly provenance: TransformProvenance;
 }
 
 /**
@@ -32,22 +46,33 @@ export interface ReprojectResult {
  * points plus a human note. If either CRS can't be resolved to a proj4 def,
  * the points are returned untouched with an explanatory note so the caller
  * can downgrade to "assign" or surface a warning rather than corrupt data.
+ *
+ * `hints` is optional source/target `CrsInfo` used ONLY to enrich the result's
+ * {@link TransformProvenance} (realization-preserving datum name + source
+ * coordinate epoch). It never influences the projection math or any returned
+ * coordinate, so existing 3-argument callers behave exactly as before.
  */
 export function reprojectGlobal(
   g: GlobalPoints,
   srcEpsg: number,
   dstEpsg: number,
+  hints: TransformCrsHints = {},
 ): ReprojectResult {
+  // Provenance is a pure function of the src/dst CRS (+ optional hints), not of
+  // the coordinates or the transform's success, so derive it once and stamp it
+  // on every return path — a skipped/failed transform still discloses what was
+  // attempted.
+  const provenance = buildTransformProvenance(srcEpsg, dstEpsg, hints);
   if (srcEpsg === dstEpsg) {
-    return { points: g, transformed: false, note: 'source and target CRS are identical — no transform needed', datumCaveat: null };
+    return { points: g, transformed: false, note: 'source and target CRS are identical — no transform needed', datumCaveat: null, provenance };
   }
   const srcDef = epsgToProj4(srcEpsg);
   const dstDef = epsgToProj4(dstEpsg);
   if (!srcDef) {
-    return { points: g, transformed: false, note: `cannot resolve source EPSG:${srcEpsg} — coordinates left unchanged`, datumCaveat: null };
+    return { points: g, transformed: false, note: `cannot resolve source EPSG:${srcEpsg} — coordinates left unchanged`, datumCaveat: null, provenance };
   }
   if (!dstDef) {
-    return { points: g, transformed: false, note: `cannot resolve target EPSG:${dstEpsg} — coordinates left unchanged`, datumCaveat: null };
+    return { points: g, transformed: false, note: `cannot resolve target EPSG:${dstEpsg} — coordinates left unchanged`, datumCaveat: null, provenance };
   }
 
   try {
@@ -92,6 +117,7 @@ export function reprojectGlobal(
           `projection's valid area, or a non-finite source elevation) — ` +
           `coordinates left unchanged`,
         datumCaveat: null,
+        provenance,
       };
     }
     return {
@@ -101,6 +127,7 @@ export function reprojectGlobal(
       // Datum honesty: proj4 has now "succeeded", but for grid-less / identity
       // datum pairs that success is only the PROJECTION math — flag it.
       datumCaveat: datumShiftCaveat(srcEpsg, dstEpsg),
+      provenance,
     };
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
@@ -109,6 +136,7 @@ export function reprojectGlobal(
       transformed: false,
       note: `reprojection failed (${detail}) — coordinates left unchanged`,
       datumCaveat: null,
+      provenance,
     };
   }
 }

--- a/src/convert/transformProvenance.ts
+++ b/src/convert/transformProvenance.ts
@@ -1,0 +1,146 @@
+/**
+ * transformProvenance.ts — provenance for one coordinate transform.
+ *
+ * A reprojection RESULT is not just coordinates: it should be able to say WHICH
+ * operation produced it, the operation's accuracy, the source/target geodetic
+ * datum, the realization-preserving datum name (NAD83(2011) ≠ NAD83), and the
+ * coordinate epoch the source declared. {@link TransformProvenance} is that
+ * disclosure record, and {@link buildTransformProvenance} derives it for the
+ * primary reproject path (`reprojectGlobal`) from the source/target EPSG plus
+ * whatever `CrsInfo` the caller carries.
+ *
+ * Honesty contract (mirrors the rest of the CRS stack): every field is derived
+ * from a real signal or reported absent — a datum/realization we cannot resolve
+ * is OMITTED, an accuracy/epoch we do not know is `null`. Nothing is fabricated,
+ * and no reprojected coordinate depends on any of it — this is metadata about
+ * the transform, computed alongside it.
+ *
+ * Builds ON the existing datum-shift honesty rather than duplicating it: the
+ * operation label comes from {@link epsgLabel}, the datum family from
+ * {@link epsgDatumFamily}, the accuracy from {@link datumShiftAccuracyMetres}
+ * (the companion of the caveat `reprojectGlobal` already surfaces), the
+ * realization from the single-source-of-truth {@link resolveHorizontalDatum},
+ * and the epoch by reading the WKT AST the parser already produces.
+ *
+ * Pure data — no DOM, no proj4, no three.js.
+ */
+
+import type { CrsInfo } from '../io/crs';
+import { collectWktNodes, parseWkt, wktFirstNumber } from '../io/wktParser';
+import { epsgDatumFamily, epsgLabel, datumShiftAccuracyMetres } from './epsg';
+import { resolveHorizontalDatum } from '../geo/CrsRegistry';
+
+/**
+ * The provenance of one coordinate transform. Attached to every reproject
+ * result (see {@link reprojectGlobal}) and disclosable in an export's
+ * provenance. Absent values are honest: a datum/realization we cannot resolve is
+ * omitted; an accuracy/epoch we do not know is `null`. Never fabricated.
+ */
+export interface TransformProvenance {
+  /**
+   * Human-readable operation label — `"<source> → <target>"` from
+   * {@link epsgLabel}, or a "no transform" note when the two CRSs are identical.
+   * Always present.
+   */
+  readonly operation: string;
+  /**
+   * Estimated horizontal error of the DATUM leg in metres
+   * ({@link datumShiftAccuracyMetres}). `null` when there is no cross-datum leg
+   * to characterise (a projection-only change, a conventionally-coincident pair)
+   * or the datums are unresolvable — never a fabricated zero.
+   */
+  readonly accuracyMetres?: number | null;
+  /** Source geodetic datum FAMILY (e.g. 'NAD83', 'WGS84'); absent when unresolvable. */
+  readonly sourceDatum?: string;
+  /** Target geodetic datum FAMILY; absent when unresolvable. */
+  readonly targetDatum?: string;
+  /**
+   * Realization-preserving source datum NAME (e.g. 'NAD83(2011)', distinct from
+   * the 'NAD83' family). A WKT-declared datum wins over the registry generic;
+   * absent when neither source knows it.
+   */
+  readonly sourceRealization?: string;
+  /** Realization-preserving target datum NAME; absent when neither source knows it. */
+  readonly targetRealization?: string;
+  /**
+   * Coordinate epoch the SOURCE CRS declared (e.g. 2010.0), read from an
+   * `EPOCH[…]` / `COORDINATEEPOCH[…]` node in the source WKT. `null` when the
+   * source declares none — the common case for static-datum captures.
+   */
+  readonly coordinateEpoch?: number | null;
+}
+
+/** Source/target `CrsInfo`, when the caller has them, for realization + epoch. */
+export interface TransformCrsHints {
+  /** The source CRS — supplies its WKT-declared realization and coordinate epoch. */
+  readonly sourceCrs?: CrsInfo | null;
+  /** The target CRS — supplies its WKT-declared realization when one is known. */
+  readonly targetCrs?: CrsInfo | null;
+}
+
+/**
+ * Read the coordinate epoch a WKT declares, or `null` when it declares none.
+ *
+ * The coordinate epoch (WKT2 `EPOCH[2010.0]`, older `COORDINATEEPOCH`) is the
+ * epoch at which the coordinates are valid — distinct from a dynamic datum's
+ * `FRAMEEPOCH` (a datum property) and from `ANCHOREPOCH`, neither of which is
+ * matched here. Reads the AST the shared parser already produces; never throws.
+ */
+export function coordinateEpochFromWkt(wkt: string | undefined): number | null {
+  if (!wkt) return null;
+  const root = parseWkt(wkt);
+  if (!root) return null;
+  for (const node of collectWktNodes(root)) {
+    if (node.keyword !== 'EPOCH' && node.keyword !== 'COORDINATEEPOCH') continue;
+    const epoch = wktFirstNumber(node);
+    if (typeof epoch === 'number' && Number.isFinite(epoch)) return epoch;
+  }
+  return null;
+}
+
+/**
+ * Derive the {@link TransformProvenance} for a src→dst EPSG transform. Pure —
+ * given the same inputs it returns the same record, and it reads no state beyond
+ * its arguments.
+ *
+ *   - `operation`       ← {@link epsgLabel} of each code.
+ *   - `sourceDatum` /
+ *     `targetDatum`     ← {@link epsgDatumFamily} (omitted when unresolvable).
+ *   - `sourceRealization` /
+ *     `targetRealization` ← {@link resolveHorizontalDatum}: the WKT datum from the
+ *                          hint's `CrsInfo` when present (realization-preserving),
+ *                          else the curated registry generic by code, else omitted.
+ *   - `accuracyMetres`  ← {@link datumShiftAccuracyMetres} (`null` when there is
+ *                          no cross-datum leg or the datums are unknown).
+ *   - `coordinateEpoch` ← the SOURCE WKT's declared epoch (`null` when none).
+ */
+export function buildTransformProvenance(
+  srcEpsg: number,
+  dstEpsg: number,
+  hints: TransformCrsHints = {},
+): TransformProvenance {
+  const operation =
+    srcEpsg === dstEpsg
+      ? `no transform (identical CRS ${epsgLabel(srcEpsg)})`
+      : `${epsgLabel(srcEpsg)} → ${epsgLabel(dstEpsg)}`;
+
+  const sourceDatum = epsgDatumFamily(srcEpsg);
+  const targetDatum = epsgDatumFamily(dstEpsg);
+  const sourceRealization = resolveHorizontalDatum(hints.sourceCrs?.horizontalDatum, srcEpsg);
+  const targetRealization = resolveHorizontalDatum(hints.targetCrs?.horizontalDatum, dstEpsg);
+
+  return {
+    operation,
+    // number when the datum leg is a known degenerate case, else null (unknown
+    // or no cross-datum leg) — never fabricated.
+    accuracyMetres: datumShiftAccuracyMetres(srcEpsg, dstEpsg),
+    // The coordinate epoch belongs to the coordinates being moved — the SOURCE.
+    coordinateEpoch: coordinateEpochFromWkt(hints.sourceCrs?.wkt),
+    // Datum family + realization are OMITTED (not null) when unresolvable, so a
+    // consumer reads their absence as "not known" rather than a value.
+    ...(sourceDatum ? { sourceDatum } : {}),
+    ...(targetDatum ? { targetDatum } : {}),
+    ...(sourceRealization ? { sourceRealization } : {}),
+    ...(targetRealization ? { targetRealization } : {}),
+  };
+}

--- a/src/terrain/export/exportProvenance.ts
+++ b/src/terrain/export/exportProvenance.ts
@@ -66,6 +66,7 @@ export const SOFTWARE_NAME = 'OpenLiDARViewer';
  */
 import { NOT_SURVEY_GRADE_NOTE } from './exportNotes';
 import { verticalUnitLabel } from '../../units/units';
+import type { TransformProvenance } from '../../convert/transformProvenance';
 export { NOT_SURVEY_GRADE_NOTE };
 
 /**
@@ -244,6 +245,16 @@ export interface ExportProvenance {
    * §19: a contour file that carries no permit stamp was not gate-approved.
    */
   readonly exportPermit: ExportPermitStamp | null;
+  /**
+   * The coordinate transform this export's geometry was reprojected through, or
+   * `null` when the export path did not reproject (the common case — terrain
+   * products are built in the source CRS). Optional/disclosure metadata: it
+   * discloses WHICH operation moved the coordinates, its accuracy, the
+   * source/target datum + realization, and the source coordinate epoch (see
+   * {@link TransformProvenance}). Never a user-visible number — it changes no
+   * figure the export already stated.
+   */
+  readonly transform?: TransformProvenance | null;
 }
 
 /** Options for {@link buildExportProvenance}. */
@@ -279,6 +290,13 @@ export interface ExportProvenanceOptions {
    * which decision permitted it. Null / omitted for non-gated paths.
    */
   readonly exportPermit?: ExportPermitStamp | null;
+  /**
+   * The coordinate transform the exported geometry was reprojected through (from
+   * `reprojectGlobal`'s result). Supplied only by a path that actually
+   * reprojects; omitted/`null` otherwise, and the export then discloses no
+   * transform. Pure disclosure metadata — it never alters an exported figure.
+   */
+  readonly transform?: TransformProvenance | null;
 }
 
 /** Resolve the generation timestamp to an ISO string. */
@@ -403,6 +421,10 @@ export function buildExportProvenance(
     warnings: result.warnings ?? [],
     notSurveyGrade: NOT_SURVEY_GRADE_NOTE,
     exportPermit: opts.exportPermit ?? null,
+    // Disclosure metadata: present only when a reprojecting path supplied it,
+    // `null` otherwise — the terrain surface products build in the source CRS
+    // and reproject nothing, so this is `null` for them.
+    transform: opts.transform ?? null,
   };
 }
 
@@ -629,6 +651,28 @@ export function provenanceLines(p: ExportProvenance): string[] {
       p.pointDensityPerM2 != null ? `${p.pointDensityPerM2.toFixed(1)} pts/m²` : 'unknown',
     ),
   ];
+  // Coordinate-transform disclosure — present ONLY when the export path
+  // reprojected (p.transform set). Each line carries a real value: the operation
+  // always, the datum realization / epoch / accuracy only when known, so a
+  // reader never sees a fabricated figure. Absent entirely for the common
+  // build-in-source-CRS terrain export.
+  if (p.transform) {
+    const t = p.transform;
+    lines.push(kv('Transform operation', t.operation));
+    if (t.sourceRealization) lines.push(kv('Source realization', t.sourceRealization));
+    if (t.targetRealization) lines.push(kv('Target realization', t.targetRealization));
+    lines.push(
+      kv(
+        'Transform accuracy',
+        t.accuracyMetres != null
+          ? `≈ ${t.accuracyMetres} m (datum-shift estimate, not survey-grade)`
+          : 'not characterised (no cross-datum leg or unknown datums)',
+      ),
+    );
+    if (t.coordinateEpoch != null) {
+      lines.push(kv('Coordinate epoch', String(t.coordinateEpoch)));
+    }
+  }
   // Derived complexity (v0.5.4): metric, window/radius in cells AND ground
   // metres, Z units and the convention note — reproducible parameters, worded
   // identically to the panel/card (the texts are the same strings).
@@ -731,6 +775,25 @@ export function provenanceJson(p: ExportProvenance): Record<string, unknown> {
           label: p.exportPermit.label,
           watermark: p.exportPermit.watermark,
           caveats: [...p.exportPermit.caveats],
+        }
+      : null,
+    // The coordinate-transform disclosure (null when the path reprojected
+    // nothing). Copied field-by-field so the JSON owns its own object; absent
+    // datum/realization fields stay absent (never fabricated), and the
+    // accuracy/epoch are the honest `null` when unknown.
+    transform: p.transform
+      ? {
+          operation: p.transform.operation,
+          accuracyMetres: p.transform.accuracyMetres ?? null,
+          coordinateEpoch: p.transform.coordinateEpoch ?? null,
+          ...(p.transform.sourceDatum ? { sourceDatum: p.transform.sourceDatum } : {}),
+          ...(p.transform.targetDatum ? { targetDatum: p.transform.targetDatum } : {}),
+          ...(p.transform.sourceRealization
+            ? { sourceRealization: p.transform.sourceRealization }
+            : {}),
+          ...(p.transform.targetRealization
+            ? { targetRealization: p.transform.targetRealization }
+            : {}),
         }
       : null,
     // The canonical analysis record (PR3): the single structure every output can

--- a/tests/transformProvenance.test.ts
+++ b/tests/transformProvenance.test.ts
@@ -1,0 +1,271 @@
+/**
+ * transformProvenance.test.ts — provenance for a coordinate transform (P1 #7).
+ *
+ * A reprojection RESULT should be able to say which operation produced it, its
+ * accuracy, the source/target datum + realization, and the source coordinate
+ * epoch — derived from real signals, never fabricated. This pins:
+ *
+ *   1. buildTransformProvenance — table-driven over the four cases the roadmap
+ *      names: same-datum (no shift, epoch absent), a known-caveat datum shift
+ *      (accuracy + realization surfaced), a realization-distinct pair
+ *      (NAD83 vs NAD83(2011)), and an unknown pair (fields null / absent).
+ *   2. datumShiftAccuracyMetres is the machine-readable companion of the caveat:
+ *      the SAME pairs are flagged, and the magnitude matches the caveat prose.
+ *   3. coordinateEpochFromWkt reads the WKT EPOCH node, ignores FRAMEEPOCH.
+ *   4. reprojectGlobal stamps the provenance on every outcome without moving a
+ *      coordinate.
+ *   5. ExportProvenance discloses a supplied transform in both formatters, and
+ *      carries nothing when the path reprojected nothing (behaviour-preserving).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildTransformProvenance,
+  coordinateEpochFromWkt,
+  type TransformProvenance,
+} from '../src/convert/transformProvenance';
+import { datumShiftCaveat, datumShiftAccuracyMetres } from '../src/convert/epsg';
+import { reprojectGlobal } from '../src/convert/reproject';
+import { crsFromWkt, type CrsInfo } from '../src/io/crs';
+import {
+  buildExportProvenance,
+  provenanceLines,
+  provenanceJson,
+} from '../src/terrain/export/exportProvenance';
+import type { AnalyseContoursResult } from '../src/terrain/contour/analyseContours';
+
+function points(x: number, y: number, z = 0) {
+  return {
+    count: 1,
+    x: Float64Array.from([x]),
+    y: Float64Array.from([y]),
+    z: Float64Array.from([z]),
+  };
+}
+
+describe('buildTransformProvenance — table-driven derivation', () => {
+  it('same datum, projection-only change: no accuracy, no epoch, realization surfaced', () => {
+    // WGS84/UTM11N → WGS84 geographic — one datum family, so there is no
+    // cross-datum leg to characterise and no caveat pair.
+    const p = buildTransformProvenance(32611, 4326);
+    expect(p.operation).toBe('WGS 84 / UTM zone 11N → WGS 84 (geographic)');
+    expect(p.sourceDatum).toBe('WGS84');
+    expect(p.targetDatum).toBe('WGS84');
+    // Same family ⇒ no datum-shift figure (null, never a fabricated 0).
+    expect(p.accuracyMetres).toBeNull();
+    // No source WKT ⇒ epoch genuinely absent, reported null.
+    expect(p.coordinateEpoch).toBeNull();
+    // Realization filled from the curated registry generic.
+    expect(p.sourceRealization).toBe('WGS 84');
+    expect(p.targetRealization).toBe('WGS 84');
+  });
+
+  it('identical CRS: a "no transform" label, still honest metadata', () => {
+    const p = buildTransformProvenance(32611, 32611);
+    expect(p.operation).toMatch(/^no transform \(identical CRS /);
+    expect(p.accuracyMetres).toBeNull();
+    expect(p.coordinateEpoch).toBeNull();
+  });
+
+  it('known-caveat datum shift (NAD83 → WGS84): accuracy + both realizations surfaced', () => {
+    const p = buildTransformProvenance(26915, 32615); // NAD83/UTM15N → WGS84/UTM15N
+    expect(p.operation).toBe('NAD83 / UTM zone 15N → WGS 84 / UTM zone 15N');
+    expect(p.sourceDatum).toBe('NAD83');
+    expect(p.targetDatum).toBe('WGS84');
+    // Identity-to-WGS84 leg is ≈ 1–2 m; the machine-readable figure is the
+    // conservative top of that range, and it agrees with the caveat pair.
+    expect(p.accuracyMetres).toBe(2);
+    expect(datumShiftCaveat(26915, 32615)).not.toBeNull();
+    expect(p.sourceRealization).toBe('NAD83');
+    expect(p.targetRealization).toBe('WGS 84');
+  });
+
+  it('GDA94 → GDA2020: surfaces the 1.8 m plate-motion figure the caveat states', () => {
+    const p = buildTransformProvenance(28355, 7855);
+    expect(p.accuracyMetres).toBe(1.8);
+    expect(p.sourceDatum).toBe('GDA94');
+    expect(p.targetDatum).toBe('GDA2020');
+  });
+
+  it('realization-distinct pair: NAD83(2011) is kept apart from the NAD83 family', () => {
+    // A source WKT that declares the realization; the family is still NAD83.
+    const src: CrsInfo = crsFromWkt(
+      'PROJCS["NAD83(2011) / UTM zone 12N",GEOGCS["NAD83(2011)",DATUM["NAD83_2011"]],UNIT["metre",1]]',
+    );
+    expect(src.horizontalDatum).toBe('NAD83(2011)');
+    const p = buildTransformProvenance(26912, 32612, { sourceCrs: src });
+    // Realization preserves the WKT's specific frame …
+    expect(p.sourceRealization).toBe('NAD83(2011)');
+    // … while the coarse datum FAMILY stays the generic NAD83 the shift logic uses.
+    expect(p.sourceDatum).toBe('NAD83');
+    expect(p.sourceRealization).not.toBe(p.sourceDatum);
+    // The target has no WKT hint, so its realization comes from the registry.
+    expect(p.targetRealization).toBe('WGS 84');
+  });
+
+  it('unknown pair: datum + realization ABSENT, accuracy + epoch null — never fabricated', () => {
+    const p = buildTransformProvenance(999999, 4326);
+    expect(p.operation).toBe('EPSG:999999 → WGS 84 (geographic)');
+    // Unresolvable source ⇒ omit (not null) the datum + realization strings.
+    expect('sourceDatum' in p).toBe(false);
+    expect('sourceRealization' in p).toBe(false);
+    expect(p.accuracyMetres).toBeNull();
+    expect(p.coordinateEpoch).toBeNull();
+    // The resolvable target is still reported honestly.
+    expect(p.targetDatum).toBe('WGS84');
+    expect(p.targetRealization).toBe('WGS 84');
+  });
+
+  it('threads the source coordinate epoch from the source WKT', () => {
+    const src: CrsInfo = crsFromWkt(
+      'GEOGCS["WGS 84",DATUM["WGS_1984"]]',
+    );
+    const withEpoch: CrsInfo = { ...src, wkt: 'COORDINATEMETADATA[GEOGCRS["WGS 84 (G1762)",DATUM["x"]],EPOCH[2005.0]]' };
+    const p = buildTransformProvenance(4326, 32615, { sourceCrs: withEpoch });
+    expect(p.coordinateEpoch).toBe(2005.0);
+  });
+});
+
+describe('datumShiftAccuracyMetres — parity with the caveat, magnitude matches prose', () => {
+  const pairs: ReadonlyArray<[number, number]> = [
+    [26715, 26915], // NAD27 → NAD83 UTM 15
+    [4326, 4267], // WGS84 → NAD27
+    [28355, 7855], // GDA94 → GDA2020
+    [7844, 4283], // GDA2020 → GDA94
+    [26915, 32615], // NAD83 → WGS84
+    [4269, 4326], // NAD83 geo → WGS84
+    [32611, 4326], // WGS84 → WGS84 (clean)
+    [25831, 4326], // ETRS89 → WGS84 (coincident)
+    [26715, 4267], // NAD27 UTM → NAD27 geographic (same family)
+    [999999, 4326], // unknown
+  ];
+
+  it('a caveat exists exactly when an accuracy figure exists', () => {
+    for (const [a, b] of pairs) {
+      const hasCaveat = datumShiftCaveat(a, b) != null;
+      const hasAccuracy = datumShiftAccuracyMetres(a, b) != null;
+      expect(hasAccuracy).toBe(hasCaveat);
+    }
+  });
+
+  it('the concrete magnitudes match the figures the caveat prose asserts', () => {
+    expect(datumShiftAccuracyMetres(26715, 26915)).toBe(10); // "10 m or more"
+    expect(datumShiftAccuracyMetres(28355, 7855)).toBe(1.8); // "≈ 1.8 m"
+    expect(datumShiftAccuracyMetres(26915, 32615)).toBe(2); // top of "≈ 1–2 m"
+    expect(datumShiftAccuracyMetres(32611, 4326)).toBeNull(); // clean
+    expect(datumShiftAccuracyMetres(26715, 4267)).toBeNull(); // same family
+    expect(datumShiftAccuracyMetres(999999, 4326)).toBeNull(); // unknown
+  });
+});
+
+describe('coordinateEpochFromWkt', () => {
+  it('reads a WKT2 EPOCH node', () => {
+    expect(
+      coordinateEpochFromWkt('COORDINATEMETADATA[GEOGCRS["WGS 84 (G1762)",DATUM["x"]],EPOCH[2010.0]]'),
+    ).toBe(2010.0);
+  });
+
+  it('reads the older COORDINATEEPOCH spelling', () => {
+    expect(coordinateEpochFromWkt('GEOGCRS["x",DATUM["y"],COORDINATEEPOCH[2015.5]]')).toBe(2015.5);
+  });
+
+  it('ignores a dynamic-datum FRAMEEPOCH (a datum property, not the coordinate epoch)', () => {
+    expect(coordinateEpochFromWkt('GEODCRS["x",DYNAMIC[FRAMEEPOCH[2010.0]],DATUM["y"]]')).toBeNull();
+  });
+
+  it('returns null for a static CRS with no epoch, and for empty input', () => {
+    expect(coordinateEpochFromWkt('PROJCS["NAD83 / UTM zone 10N",GEOGCS["NAD83"],UNIT["metre",1]]')).toBeNull();
+    expect(coordinateEpochFromWkt(undefined)).toBeNull();
+    expect(coordinateEpochFromWkt('')).toBeNull();
+  });
+});
+
+describe('reprojectGlobal — the result carries provenance without moving a coordinate', () => {
+  it('a clean transform stamps the operation + datums', () => {
+    const r = reprojectGlobal(points(500000, 4000000), 32611, 4326);
+    expect(r.transformed).toBe(true);
+    expect(r.provenance.operation).toBe('WGS 84 / UTM zone 11N → WGS 84 (geographic)');
+    expect(r.provenance.sourceDatum).toBe('WGS84');
+    expect(r.provenance.accuracyMetres).toBeNull();
+  });
+
+  it('a degenerate-datum transform surfaces the accuracy figure alongside the caveat', () => {
+    const r = reprojectGlobal(points(500000, 6000000), 28355, 7855);
+    expect(r.datumCaveat).toMatch(/GDA94/);
+    expect(r.provenance.accuracyMetres).toBe(1.8);
+    expect(r.provenance.sourceDatum).toBe('GDA94');
+    expect(r.provenance.targetDatum).toBe('GDA2020');
+  });
+
+  it('a skipped (unresolvable) transform still discloses the attempted operation', () => {
+    const r = reprojectGlobal(points(0, 0), 999999, 4326);
+    expect(r.transformed).toBe(false);
+    expect(r.provenance.operation).toBe('EPSG:999999 → WGS 84 (geographic)');
+    expect(r.provenance.accuracyMetres).toBeNull();
+  });
+
+  it('the identical-CRS no-op carries the "no transform" provenance', () => {
+    const r = reprojectGlobal(points(1, 2, 3), 32611, 32611);
+    expect(r.transformed).toBe(false);
+    expect(r.provenance.operation).toMatch(/^no transform/);
+    // Coordinate untouched.
+    expect(r.points.x[0]).toBe(1);
+  });
+});
+
+describe('ExportProvenance — discloses a supplied transform, carries none otherwise', () => {
+  function readyResult(): AnalyseContoursResult {
+    return {
+      dtm: { crs: 'EPSG:32615', verticalDatum: 'EPSG:5703', coverageMode: 'full', meanConfidence: 82 },
+      intervalM: 1,
+      model: { crs: 'EPSG:32615', verticalDatum: 'EPSG:5703', intervalM: 1, contourStyle: 'smooth', coverageMode: 'full' },
+      accuracyStandards: {
+        rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, pointDensityPerM2: 4.2,
+        qualityLevel: 'QL2', qualityLevelReason: 'meets QL2.',
+      },
+      quality: {
+        readiness: 'ready', exportReadiness: 'available',
+        crsKnown: true, datumKnown: true, coverageMode: 'full', reasons: [], exportReasons: [],
+      },
+      qualityScore: { score: 85 },
+      cellMetrics: { meanDensity: 4.2, edgeRiskRatio: 0.02 },
+      cellStatusTally: { measured: 90, interpolated: 5, lowConfidence: 0, edgeRisk: 0, empty: 5, total: 100 },
+      generationParams: { interpolation: 'geodesic', contourStyle: 'smooth', smoothing: true, despike: true, aggregation: 'median' },
+      warnings: [],
+    } as unknown as AnalyseContoursResult;
+  }
+  const OPTS = { basename: 'site', generatedAt: '2026-06-05T00:00:00.000Z', softwareVersion: '9.9.9', metricVersion: 'v0.4.1', verticalUnitToMetres: 1 } as const;
+
+  const transform: TransformProvenance = buildTransformProvenance(26915, 32615);
+
+  it('when no transform is supplied the export discloses none (behaviour-preserving)', () => {
+    const p = buildExportProvenance(readyResult(), OPTS);
+    expect(p.transform ?? null).toBeNull();
+    const text = provenanceLines(p).join('\n');
+    expect(text).not.toMatch(/Transform operation/);
+    expect(provenanceJson(p).transform).toBeNull();
+    // The single-Manifest-line invariant other exporters rely on still holds.
+    expect(provenanceLines(p).filter((l) => l.startsWith('Manifest'))).toHaveLength(1);
+  });
+
+  it('a supplied transform is disclosed in both the lines and the JSON', () => {
+    const p = buildExportProvenance(readyResult(), { ...OPTS, transform });
+    const text = provenanceLines(p).join('\n');
+    expect(text).toMatch(/Transform operation\s+NAD83 \/ UTM zone 15N → WGS 84 \/ UTM zone 15N/);
+    expect(text).toMatch(/Source realization\s+NAD83/);
+    expect(text).toMatch(/Target realization\s+WGS 84/);
+    expect(text).toMatch(/Transform accuracy\s+≈ 2 m/);
+    const j = provenanceJson(p).transform as Record<string, unknown>;
+    expect(j.operation).toBe('NAD83 / UTM zone 15N → WGS 84 / UTM zone 15N');
+    expect(j.accuracyMetres).toBe(2);
+    expect(j.sourceRealization).toBe('NAD83');
+    expect(j.targetRealization).toBe('WGS 84');
+  });
+
+  it('every provenance line keeps the two-space key/value gutter, even with a transform', () => {
+    const p = buildExportProvenance(readyResult(), { ...OPTS, transform });
+    for (const line of provenanceLines(p)) {
+      expect(line).toMatch(/^\S.*?\s{2,}\S/);
+    }
+  });
+});


### PR DESCRIPTION
## What

Roadmap P1 #7: model datum realization and coordinate epoch, and carry operation provenance and accuracy on every transform result. A reprojection result is no longer just coordinates. It can now say which operation produced it, that operation's datum-shift accuracy, the source and target datum family plus its realization-preserving name, and the source coordinate epoch. Every field comes from a real signal or is reported absent; nothing is fabricated.

Bounded and additive. No reprojected coordinate or existing metric changes.

## Changes

- **New `TransformProvenance` + `buildTransformProvenance`** (`src/convert/transformProvenance.ts`). A pure builder for the primary reproject path:
  - `operation` from `epsgLabel`
  - `sourceDatum` / `targetDatum` (family) from `epsgDatumFamily`
  - `sourceRealization` / `targetRealization` from the single-source-of-truth `resolveHorizontalDatum` (a WKT-declared realization such as `NAD83(2011)` wins over the registry generic)
  - `accuracyMetres` from the new `datumShiftAccuracyMetres`
  - `coordinateEpoch` read from the source WKT AST (`EPOCH` / `COORDINATEEPOCH`, ignoring `FRAMEEPOCH`)
  - Unknown datum or realization is omitted; unknown accuracy or epoch is `null`.
- **`datumShiftAccuracyMetres`** added beside `datumShiftCaveat` in `epsg.ts`, both reading one shared classifier so the human caveat and the machine-readable magnitude cannot drift. The caveat strings are byte-for-byte unchanged.
- **`reprojectGlobal`** extends its result with a `provenance` field and accepts an optional `CrsInfo` hint used only for realization + epoch. Projection math and every returned coordinate are untouched; existing three-argument callers compile and behave as before. `convertCloud` passes the source CRS as a hint.
- **`ExportProvenance`** gains an optional `transform` field, disclosed in both `provenanceLines` and `provenanceJson` when a reprojecting path supplies it, and absent otherwise, so terrain surface exports (which build in the source CRS) are unchanged.

## Tests

Table-driven `tests/transformProvenance.test.ts`: same-datum projection change (no accuracy, no epoch), a known-caveat NAD83 to WGS84 shift (accuracy and both realizations surfaced), a realization-distinct NAD83 vs NAD83(2011) pair, and the unknown pair (datum and realization absent, accuracy and epoch null). Plus caveat/accuracy parity, epoch extraction, reproject-result stamping on every outcome, and the export-disclosure surfaces.

## Gates

- `tsc --noEmit`: 0
- Full `vitest run`: 0 (7784 passed, 20 skipped, 1 todo)
- `lint-monolith-size`: 0
- `lint-layer-boundaries`: 0
- `lint-main-deferral`: 0
- `verify-archive-portability`: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)