### PR TITLE
Add advanced-setup CodeQL to model the SSRF false positive (#40)

### DIFF
--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -1,0 +1,89 @@
+# CodeQL advanced setup
+
+This directory holds the CodeQL configuration for the advanced (workflow-driven)
+setup in [`../workflows/codeql.yml`](../workflows/codeql.yml). It replaces the
+repository's managed *default* CodeQL setup.
+
+## Why the switch
+
+Default setup analyses the code well, but it cannot read a configuration file,
+so there is no way to tell it about the remote loader's URL validator. The
+result is that `js/client-side-request-forgery` keeps flagging the same guarded
+`fetch` and re-raises the alert whenever the surrounding code is moved or
+renamed. Alert #40 is the current instance; #12 was the identical finding on the
+old `main.ts` and the maintainer already dismissed it. Advanced setup accepts
+[`codeql-config.yml`](./codeql-config.yml), which lets us handle that one rule
+deliberately instead of dismissing a fresh copy of it after every refactor.
+
+Everything else about the analysis is kept the same as default setup:
+
+- Languages: `actions` and `javascript-typescript` (default setup reports
+  `actions`, `javascript`, `javascript-typescript`, `typescript`; advanced setup
+  folds JS and TS into the single `javascript-typescript` identifier).
+- Suite: `security-extended` (default setup's "extended").
+- Triggers: push to `main`, pull requests into `main`, and a weekly schedule.
+
+## The one exclusion, and the alternative
+
+The config scopes out `js/client-side-request-forgery` by id, and nothing else.
+
+That rule flags a user-provided URL reaching `fetch`. In this client-only
+viewer, that happens in exactly two places, the remote EPT and remote COPC
+loaders in `src/main.ts`, and both send the URL through `validateRemoteEptUrl`
+/ `validateRemoteCopcUrl` first. Those reject non-`http(s)`, over-length,
+credentialed, and (via `isBlockedHost` in `src/io/range/RangeSource.ts`)
+loopback, RFC 1918, link-local, CGNAT, and cloud-metadata (`169.254.169.254`)
+hosts before any request is made. The finding is a false positive.
+
+The more precise fix would be a Models-as-Data barrier. CodeQL 2.25.2 and later
+do support `barrierModel` / `barrierGuardModel` for JavaScript, so this was the
+first thing evaluated. It does not fit here: those models anchor on a package or
+global type (`codeql/javascript-all`, or an npm package name such as `axios`),
+and our validator is a first-party local module with no package identity in the
+API graph. There is no dependable `type` to bind the barrier to, and no way to
+confirm a binding without running CodeQL. The scoped `query-filter` is the
+reliable mechanism instead. Because it is the only filter and it is an
+`exclude`, every other query stays active; the cost is that this single rule is
+off across the whole repository rather than only on those two functions, which
+is acceptable because those two functions are the app's only user-URL→`fetch`
+surface.
+
+## How to activate
+
+Advanced and default CodeQL setup cannot both run on a repository, so the
+maintainer has to turn default setup off before this workflow can analyse
+anything.
+
+1. Merge this PR. On its own, merging changes nothing about scanning yet.
+2. In the repository, go to **Settings → Code security → Code scanning →
+   CodeQL analysis**, open the **⋯** menu, and choose to **disable** default
+   setup (it switches to advanced).
+3. The `CodeQL` workflow then runs on the next push to `main` and on the
+   schedule. Re-running it against the commit that carried alert #40 clears the
+   alert, and the guarded pattern no longer re-flags.
+
+## What is verified, and what is not
+
+Verified locally, before opening the PR:
+
+- YAML parses and `actionlint` passes on the workflow.
+- Every action is pinned to a full commit SHA (`actions/checkout` reusing the
+  repo's existing pin; `github/codeql-action/init` and `.../analyze` at the
+  `v3.37.5` commit).
+- The language set and suite match the live default setup, read back from
+  `repos/Aurtechmx/openlidarviewer/code-scanning/default-setup`.
+- `js/client-side-request-forgery` is the exact, current query id in the CodeQL
+  JavaScript pack, so the filter is not a no-op.
+
+Needs CI and the activation above to confirm, since CodeQL cannot be run in this
+environment:
+
+- That the query-filter actually removes the finding on a real scan.
+- That the two-language advanced run reports the same coverage as default setup.
+
+One expected quirk: while default setup is still enabled, the CodeQL job on this
+PR (and on `main`) fails at the SARIF upload step with a "default setup is
+enabled" conflict. That is the platform refusing to accept results from two
+setups at once, not a fault in the workflow, and it clears the moment default
+setup is disabled. The workflow's YAML is validated independently by
+`actionlint` in the meantime.

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,39 @@
+# CodeQL configuration for the advanced setup in
+# ../workflows/codeql.yml. Read alongside ./README.md, which carries the full
+# rationale for the one exclusion below.
+name: "OpenLiDARViewer CodeQL config"
+
+# Reproduce default setup's coverage. Default setup on this repo runs the
+# "extended" query suite; security-extended is its advanced-setup name — the
+# standard code-scanning queries plus the extended security set. Nothing is
+# disabled, so this is a strict superset of the default query pack.
+queries:
+  - uses: security-extended
+
+# Scope out exactly one rule, by id, for the whole repository.
+#
+# js/client-side-request-forgery flags a user-provided URL reaching `fetch`.
+# In this client-only viewer that pattern exists in exactly two places — the
+# remote EPT and remote COPC loaders in src/main.ts — and both pass the URL
+# through validateRemoteEptUrl / validateRemoteCopcUrl before any fetch. Those
+# validators reject non-http(s), over-length, embedded-credential, and (via
+# isBlockedHost in src/io/range/RangeSource.ts) loopback / RFC1918 / link-local /
+# CGNAT / metadata (169.254.169.254) hosts. The finding is a false positive:
+# alert #40 is the current instance, #12 was the same pattern on the old
+# main.ts and was dismissed by the maintainer.
+#
+# Why a query-filter and not a Models-as-Data barrier: CodeQL >= 2.25.2 does
+# support barrierModel / barrierGuardModel for JavaScript, which would be the
+# more precise fix. But those models anchor on a package or global `type`
+# (e.g. codeql/javascript-all, or an npm package name like "axios"). Our guard
+# is a first-party local ES module with no package identity in the API graph,
+# so there is no reliable `type` to bind the barrier to — and it cannot be
+# verified without running CodeQL. A scoped, id-level exclusion is the reliable
+# mechanism: because this is the first (and only) filter and it is an `exclude`,
+# every other query stays included and active. The trade-off is breadth — the
+# rule is off repo-wide, not just on those two functions — which is acceptable
+# here precisely because those two functions are the app's only user-URL→fetch
+# surface. See README.md for the full write-up.
+query-filters:
+  - exclude:
+      id: js/client-side-request-forgery

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,73 @@
+# CodeQL — advanced setup.
+#
+# Replaces the repository's *default* CodeQL setup with an equivalent
+# advanced (workflow-driven) one. The only reason to make the switch is that
+# default setup cannot take a configuration file, so it has no way to model
+# the remote point-cloud loader's URL validator. That gap makes
+# `js/client-side-request-forgery` re-flag the guarded `fetch` in the two
+# remote-load paths every time the code moves (alert #40 today; #12 was the
+# same finding on the old main.ts, already dismissed by the maintainer).
+#
+# This workflow reproduces default setup exactly — same languages, same
+# extended suite, same weekly cadence — and adds ./.github/codeql/codeql-config.yml,
+# where the one false-positive rule is scoped out and every other query kept.
+# See .github/codeql/README.md for the rationale and the activation steps
+# (default setup must be turned off before this can run; the two cannot
+# coexist).
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, matching default setup's cadence so newly-shipped queries reach
+    # main even in a quiet week. Offset off the hour and off the other weekly
+    # jobs (Security audit 06:00, Scorecard 04:17) to spread runner load.
+    - cron: "26 3 * * 1"
+
+# Read-only by default. The analysis job widens its own grant below to the
+# least it needs to upload results; a job added later without its own block
+# inherits nothing but repository read.
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload SARIF to the code-scanning API.
+      security-events: write
+      # Check out the repository.
+      contents: read
+      # Read workflow run metadata (Actions analysis + status reporting).
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # The exact language set default setup analyses today. CodeQL folds
+        # javascript + typescript into the single `javascript-typescript`
+        # identifier in advanced setup; both are interpreted, so build-mode
+        # is `none` (no compile step).
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3.37.5
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3.37.5
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What this does

Moves CodeQL from **default setup** to an equivalent **advanced (workflow-driven) setup**, so the analysis can finally be configured. Default setup cannot take a config file, which is why `js/client-side-request-forgery` keeps re-flagging the guarded remote-load `fetch` every time that code moves. Alert **#40** is the current instance; **#12** was the same finding on the old `main.ts` and was already dismissed as a false positive.

Additive only: new `.github/workflows/codeql.yml` + `.github/codeql/*`. No `src/`, no other workflow, no docs touched.

## Files

- **`.github/workflows/codeql.yml`** — advanced-setup workflow that reproduces default setup: languages `actions` + `javascript-typescript`, `security-extended` suite, triggers on push to `main` + pull_request + weekly schedule, least-privilege permissions (`security-events: write`, `contents: read`, `actions: read`), all actions SHA-pinned, and a `config-file` reference.
- **`.github/codeql/codeql-config.yml`** — pulls in `security-extended` and scopes out the one false-positive rule.
- **`.github/codeql/README.md`** — rationale, mechanism trade-off, and activation steps.

## Mechanism: scoped query-filter (not a Models-as-Data barrier)

The config excludes exactly `js/client-side-request-forgery`, by id, and nothing else.

That rule flags a user-provided URL reaching `fetch`. In this client-only viewer that happens in exactly two places — the remote EPT and remote COPC loaders in `src/main.ts` — and both send the URL through `validateRemoteEptUrl` / `validateRemoteCopcUrl` first. Those reject non-`http(s)`, over-length, credentialed, and (via `isBlockedHost` in `src/io/range/RangeSource.ts`) loopback / RFC 1918 / link-local / CGNAT / metadata (`169.254.169.254`) hosts before any request is made.

**Why not the more precise barrier.** CodeQL >= 2.25.2 (the pinned bundle is newer) *does* support `barrierModel` / `barrierGuardModel` for JavaScript, and that was evaluated first. It does not fit here: those models anchor on a **package or global `type`** (`codeql/javascript-all`, or an npm name like `axios`), and our validator is a **first-party local ES module with no package identity in the API graph** — there is no dependable `type` to bind the barrier to, and no way to confirm a binding without running CodeQL. The id-level `query-filter` is the reliable mechanism instead. Because it is the only filter and it is an `exclude`, **every other query stays active**. The trade-off is breadth: this one rule is off repo-wide rather than only on those two functions, which is acceptable because those two functions are the app's only user-URL to `fetch` surface.

## Verified locally (before this PR)

- `actionlint` passes on the workflow; both YAML files parse cleanly (`js-yaml`).
- All three actions are pinned to full commit SHAs: `actions/checkout@3d3c42e5...` (reusing the repo's existing pin), and `github/codeql-action/init` + `.../analyze` at `e60ea984...` = **`v3.37.5`** (verified that tag dereferences to that commit, and that it is the current `v3` head).
- Languages + suite match the **live** default setup, read back from `code-scanning/default-setup` (`languages: actions, javascript, javascript-typescript, typescript`; `query_suite: extended`; `schedule: weekly`).
- `js/client-side-request-forgery` is the exact, current query id in the CodeQL JavaScript pack, so the filter is not a no-op.

## Needs CI / activation to confirm

CodeQL cannot be run in the authoring environment, so these are **not** verified here:

- That the query-filter removes the finding on a real scan.
- That the two-language advanced run reports the same coverage as default setup.

**Expected quirk on this PR:** while default setup is still enabled, the CodeQL job here (and on `main`) will **fail at the SARIF upload** with a "default setup is enabled" conflict — the platform refusing results from two setups at once, not a workflow fault. It clears the moment default setup is disabled. The workflow YAML is validated independently by `actionlint` in the meantime.

## Activation (maintainer, admin action — not done here)

Advanced and default CodeQL cannot both run, so:

1. Merge this PR (merging alone changes nothing about scanning yet).
2. **Settings -> Code security -> Code scanning -> CodeQL analysis** -> the **...** menu -> **disable** default setup (it switches to advanced).
3. The `CodeQL` workflow then runs on the next push to `main` and on the weekly schedule. Re-running against the commit that carried alert #40 clears it, and the guarded pattern no longer re-flags.

Not urgent; blocks nothing. Auto-merge intentionally left off for maintainer review.
