### PR TITLE
Audit P1 #2 frame boundaries; correct stale rebase docs; pin world-coord invariance

### DIFF
--- a/docs/architecture/coordinate-integrity-roadmap.md
+++ b/docs/architecture/coordinate-integrity-roadmap.md
@@ -175,54 +175,61 @@ effective reference for coordinates, labels and embedded metadata.
    anchor from file origins instead of from origins it had itself written, and
    the anchor persists only while it still describes the current layer set.
 
-2. **Stop writing project offsets into Float32 vertices.** Mounting adds the
-   offset to the position array, so the residual precision a layer keeps is set
-   by how far it moves. Measured with `PointCloud.rebaseQuantum`: a lone
-   georeferenced scan anchors on its own origin and loses nothing (~1e-8 m);
-   1 km of separation costs ~0.02 mm; 100 km costs a full millimetre. The gates
-   in `LayerService` refuse a mount past 1 mm (converted through the CRS's
-   linear unit; geographic frames refused outright), so the loss is bounded and
-   disclosed rather than silent — but bounded is not absent.
+2. **Stop writing project offsets into Float32 vertices — data model DONE; two
+   display-frame folds browser-gated.** The destructive rebase is gone. Mounting
+   no longer rewrites the Float32 buffer: `Viewer.setLayerPlacement` holds the
+   layer's Float64 `sourceToProject` as data on the layer entry and sets
+   `mesh.position`, and `positions` is written once by the loader and stays
+   byte-identical through mount, unmount, hide, restore and export
+   (`float64-transform.md` invariant 1, `tests/sourceGeometryImmutable.test.ts`).
+   The destination shape every review named is in place for the DATA MODEL:
+   source-local vertices, the transform held in Float64 beside the buffer.
 
-   The destination is the shape every review has named: vertices stay
-   source-local, `sourceToProject` is held in Float64, CPU work applies it in
-   Float64, and the GPU renders camera-relative or high/low-split.
+   The CPU world coordinate is recovered per boundary, in the frame each one
+   names, and audited under a non-identity mount by
+   `tests/frameWorldCoords.test.ts`:
 
-   **Measured surface, so the estimate is not a guess:** 154 direct reads of
-   `.positions` across 42 files — picking, terrain gather, lasso, profiles,
-   volumes, clipping, colour modes, downsampling, conversion and export bounds.
+   - **Source-frame consumers are world-correct via `sourceOrigin`** —
+     `worldXYZ`, `cloudToGlobal`, the exporters (`exportGeoContext` →
+     `c.sourceOrigin`), and the two-epoch change comparison (`main.ts` ~5936,
+     each epoch built on its own `sourceOrigin`, not the live project origin).
+     The placement never enters the sum, so these hold under any mount.
+   - **Project-frame estimators fold the translation into their shared
+     accumulator** rather than moving points: the picking ray + hit lift
+     (`layerPlacement.ts`), terrain gather (`terrainStreamSample.ts:99,108`), and
+     the scene-bounds merge (`mergePlacedBounds`). Identity while mounting is
+     off, so byte-identical to the pre-fold walk.
 
-   **Why it is one change and not several.** The transform has to land in every
-   one of those readers together. Migrate half and rendering sees project space
-   while the rest sees source-local — which is precisely the render/CPU split
-   the data rebase was introduced to close, reintroduced deliberately. A
-   partially-migrated tree is worse than the current one: today every consumer
-   agrees and the error is a bounded, refused-past-1 mm quantisation; mid-
-   migration they disagree and the error is unbounded and silent.
+   **Remaining, both browser-gated** (the P1 #1 acceptance battery, and
+   `float64-transform.md` step 6):
 
-   Sequence when it is taken on: (a) `LayerSpatialState` holding source-local
-   positions plus Float64 `sourceToProject` / `projectToSource`; (b) a
-   world-space accessor every CPU consumer moves to, one file at a time behind
-   a lint that fails on a raw `.positions` read outside the model; (c) the GPU
-   path last, since it is the only one that genuinely needs Float32 and the
-   only one where camera-relative rendering is a real design choice. The
-   property suite in `tests/frameGateProperties.test.ts` — world-position
-   invariance, source-origin immutability, restore round-trips — is the
-   regression net for (a) and (b).
+   1. The renderer's camera-relative / render-origin fold (mesh position →
+      `sourceToProject − renderOrigin`, folded on the CPU per mesh). Bounded and
+      refused past 1 mm by the `LayerService` mount-precision gate
+      (`PointCloud.rebaseQuantum`: ~0.02 mm at 1 km, ~1 mm at 100 km; geographic
+      frames refused outright), so a precision refinement, not a correctness
+      defect.
+   2. The display-coordinate fold for picking and cross-layer measurement.
+      `Viewer._infoForHit` (`src/render/Viewer.ts` ~6087) builds the inspector's
+      world coordinate as the PLACED (project-local) pick point plus
+      `sourceOrigin`, which double-counts the translation for a non-anchor
+      mounted layer — off by the full `sourceToProject` (2 km in the
+      `twoScanMount` fixture), because the placed point already carries the
+      offset. Correct only under the identity placement, which is why it is
+      invisible single-layer and while mounting stays effectively off. The fix is
+      to read `cloud.worldXYZ(index)` from the hit index rather than the placed
+      point; the same applies to a measured vertex on a non-anchor layer exported
+      through the active scan's `sourceOrigin`. Tracked as P1 #1 acceptance items
+      #4 (picking) and #5 (cross-layer measure); pinned by
+      `tests/frameWorldCoords.test.ts`.
 
-   **On-ramp landed (additive, non-mutating). No consumer migrated.** Step (a)'s
-   container exists as an unreferenced scaffold, `src/model/LayerSpatialState.ts`
-   (source-local vertices + Float64 `sourceToProject`/`projectToSource`, the
-   world-space accessor consumers will adopt, pinned by
-   `tests/layerSpatialState.test.ts`). The surface is inventoried and ordered in
-   `docs/architecture/float64-frame-migration-plan.md`, and
+   `src/model/LayerSpatialState.ts` stays an unreferenced scaffold — the runtime
+   adopted the `PointCloud.worldXYZ` / `projectXYZ` accessors and the
+   `layerPlacement.ts` fold toolbox instead of a per-layer container.
+   `docs/architecture/float64-frame-migration-plan.md` records the current
+   architecture and keeps the historical `.positions` surface;
    `scripts/lint-positions-reads.mjs` (`npm run lint:positions-reads`,
-   report-only, never a gate) prints the live list. Re-measured from the tree:
-   **162 direct `.positions` reads across 42 files** (the file count the roadmap
-   recorded; occurrences drifted up from 154 as the code moved). This changes no
-   runtime and no e2e byte. The atomic-landing requirement above is unchanged:
-   the transform still has to reach every reader together, and a partially
-   migrated tree is still worse than none.
+   report-only) prints the live list.
 
 3. **Replace regex WKT parsing with an AST parser.** The current parser survives
    realistic WKT1 and WKT2 (verified against six shapes including `PROJCRS` with

--- a/docs/architecture/float64-frame-migration-plan.md
+++ b/docs/architecture/float64-frame-migration-plan.md
@@ -1,23 +1,75 @@
-# Float64 project-frame migration: inventory and order
+# Float64 project-frame: current architecture and the remaining fold
 
-The on-ramp for coordinate-integrity roadmap P1 #2 ("Stop writing project
-offsets into Float32 vertices"). This document is additive. It names the surface
-and fixes the order. It migrates nothing. The scaffold it points to
-(`src/model/LayerSpatialState.ts`) is unreferenced at runtime, and the running
-companion (`scripts/lint-positions-reads.mjs`, `npm run lint:positions-reads`)
-is a report, never a gate.
+This tracked the on-ramp for coordinate-integrity roadmap P1 #2 ("Stop writing
+project offsets into Float32 vertices"). Its original premise — that mounting a
+layer rewrites the Float32 position buffer, and that 162 `.positions` reads must
+be migrated together in one atomic change — is SUPERSEDED. The placement
+architecture in `docs/architecture/float64-transform.md` (steps 1–5) has landed:
+mounting is a Float64 placement now, not a buffer rewrite. What follows records
+the architecture as it stands and the one fold that is still browser-gated. The
+inventory further down is kept as the historical surface the migration was
+planned against; `scripts/lint-positions-reads.mjs` (`npm run
+lint:positions-reads`) still prints the live `.positions` list and is a report,
+never a gate.
 
-## Why an inventory before a line of migration
+## Current architecture (the premise this document opened with is retired)
 
-Today mounting a layer applies the project offset by rewriting the Float32
-position buffer, so a consumer that reads `cloud.positions` and one that reads
-the mesh see the same frame. The destination keeps vertices source-local and
-holds the placement as a Float64 translation applied at read time, which only
-stays coherent if every reader moves together. Migrate half and rendering sees
-project space while the rest sees source-local: the render/CPU split the data
-rebase exists to close, reintroduced, now unbounded and silent instead of
-bounded and refused-past-1 mm. So the whole surface has to be visible first, and
-the move is one atomic change, not a trickle. This file is that surface.
+Mounting a layer no longer touches its vertices. `Viewer.setLayerPlacement`
+stores the layer's Float64 `sourceToProject` translation on the layer entry and
+sets `mesh.position`; the `.positions` buffer is written once, by the loader, and
+is byte-identical through mount, unmount, hide, session restore and export
+(`float64-transform.md` invariant 1, pinned by
+`tests/sourceGeometryImmutable.test.ts`). The destination shape every review
+named is therefore already in place for the DATA MODEL: vertices stay
+source-local, and the placement is data ABOUT the layer, held beside the buffer
+rather than baked into it.
+
+The world coordinate is recovered per boundary, in the frame each one names:
+
+- Source-frame consumers read `positions[i] + sourceOrigin` — `worldXYZ`,
+  `cloudToGlobal`, the exporters through `exportGeoContext`'s `sourceOrigin`, and
+  the two-epoch change comparison through each epoch's own `sourceOrigin`
+  (`main.ts` ~5936). These are world-correct under any mount: `sourceOrigin` is
+  fixed at construction and the placement never enters the sum.
+- Project-frame consumers fold the layer translation into their shared
+  accumulator instead of moving the points. The picking ray drops into the
+  layer's source frame and the hit lifts back (`layerPlacement.ts`), terrain
+  gather adds `accumulatorOffset(placement)` per buffer as it copies into the
+  shared grid (`terrainStreamSample.ts:99,108`), and the scene-bounds merge
+  translates each layer's cached AABB (`mergePlacedBounds`). With one layer — or
+  while a mount is refused — every translation is the identity, so these folds
+  are byte-identical to the pre-fold walk.
+
+`src/model/LayerSpatialState.ts` remains an unreferenced scaffold: the runtime
+adopted the `PointCloud.worldXYZ` / `projectXYZ` accessors and the
+`layerPlacement.ts` fold toolbox rather than a per-layer container, so nothing
+imports it outside its own unit test.
+
+## The remaining fold is not the whole GPU path
+
+Two things are still browser-gated (`float64-transform.md` step 6, and the
+acceptance battery in `coordinate-integrity-roadmap.md` P1 #1):
+
+1. **The renderer's camera-relative / render-origin fold.** Mesh position is
+   `sourceToProject` today; for far-apart mounts it should become
+   `sourceToProject − renderOrigin`, folded on the CPU per mesh, so the Float32
+   GPU residual stays small. Bounded and refused past 1 mm by the `LayerService`
+   mount-precision gate, so this is a precision refinement, not a correctness
+   defect.
+2. **The display-coordinate fold for picking and cross-layer measurement.** The
+   inspector's world coordinate is built in `Viewer._infoForHit`
+   (`src/render/Viewer.ts` ~6087) as the PLACED (project-local) pick point plus
+   `sourceOrigin`. For a non-anchor mounted layer that double-counts the
+   translation — the coordinate is off by the full `sourceToProject` (2 km in
+   `tests/e2e/twoScanMount.spec.ts`'s fixture), because the placed point already
+   carries the offset. It is correct only under the identity placement, which is
+   why it is invisible single-layer and while mounting stays effectively off. The
+   fix is to derive the world coordinate from the source-local hit index —
+   `cloud.worldXYZ(index)` is already the right value — rather than the placed
+   point; the same applies to a measured vertex on a non-anchor layer exported
+   through the active scan's `sourceOrigin`. Tracked as roadmap P1 #1 acceptance
+   items #4 (picking) and #5 (cross-layer measure), and pinned as a property by
+   `tests/frameWorldCoords.test.ts`.
 
 ## Method
 

--- a/tests/frameWorldCoords.test.ts
+++ b/tests/frameWorldCoords.test.ts
@@ -1,0 +1,227 @@
+/**
+ * frameWorldCoords.test.ts — the world coordinate a CPU boundary derives is
+ * invariant to a layer's placement.
+ *
+ * Roadmap P1 #2 keeps every layer's vertices SOURCE-LOCAL and holds the mount
+ * as a Float64 `sourceToProject` translation held BESIDE the buffer, never
+ * baked into it. The property that keeps the world-producing CPU boundaries —
+ * picking, terrain gather, cross-layer measurement, export bounds, change
+ * detection — correct under a mount is this:
+ *
+ *   the WORLD coordinate of point i is `sourceLocal[i] + sourceOrigin`, and
+ *   mounting the layer (setting a non-identity placement) does not change it.
+ *
+ * A boundary that derives world that way computes the same survey coordinate
+ * whether the layer is mounted or not, and whether or not another layer is
+ * added beside it. The equivalent project-frame path — `projectXYZ(i,
+ * transform)` lifted back through the project origin — recovers the same world,
+ * so the source frame and the project frame agree on where the point is.
+ *
+ * The contrast case pins the failure mode the audit surfaced. Deriving world
+ * from the PLACED (project-local) point plus `sourceOrigin` — the shape
+ * `Viewer._infoForHit` currently feeds the inspector (src/render/Viewer.ts
+ * ~6087) — double-counts the translation and is wrong by exactly
+ * `sourceToProject` for a non-anchor mount. It coincides with the true world
+ * only under the identity placement, which is why the error is invisible in the
+ * single-layer / mount-off configuration and only appears once a second layer
+ * mounts. A world-producing boundary must read `sourceLocal + sourceOrigin`
+ * (or, equivalently, `projectLocal + projectOrigin`), never `placedPoint +
+ * sourceOrigin`.
+ *
+ * Pure Node maths — reuses `ProjectSpatialFrame`/`LayerSpatialTransform` and the
+ * `placePoint` fold, and the seeded-PRNG property style from
+ * `tests/frameGateProperties.test.ts`.
+ */
+
+import { describe, it, test, expect } from 'vitest';
+import { PointCloud } from '../src/model/PointCloud';
+import {
+  createProjectFrame,
+  chooseProjectOrigin,
+  layerTransform,
+  projectLocalToWorld,
+} from '../src/geo/ProjectSpatialFrame';
+import { placePoint, isIdentityPlacement } from '../src/render/layerPlacement';
+
+type Vec3 = readonly [number, number, number];
+
+// ── a tiny reproducible generator (same shape as frameGateProperties) ────────
+/** mulberry32 — deterministic from a 32-bit seed, so a failure replays exactly. */
+function rng(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function forAll<T>(
+  name: string,
+  gen: (r: () => number) => T,
+  check: (value: T) => void,
+  runs = 200,
+): void {
+  for (let i = 0; i < runs; i++) {
+    const seed = 0x5eed + i;
+    const value = gen(rng(seed));
+    try {
+      check(value);
+    } catch (err) {
+      throw new Error(`${name} failed at seed ${seed}\n${(err as Error).message}`);
+    }
+  }
+}
+
+const make = (positions: Float32Array, origin: Vec3): PointCloud =>
+  new PointCloud({ positions, origin: [...origin], sourceFormat: 'las', name: 'p.las' });
+
+/**
+ * Two georeferenced layers at integer survey origins a real distance apart,
+ * plus the shared frame chosen from those origins. Origins are integers because
+ * `chooseProjectOrigin` floors, and integers keep the Float64 lift exact.
+ */
+function genScene(r: () => number) {
+  const oA: Vec3 = [
+    500000 + Math.floor(r() * 1000),
+    4100000 + Math.floor(r() * 1000),
+    100 + Math.floor(r() * 50),
+  ];
+  // B is offset from A by up to a couple of km per axis — the twoScanMount
+  // regime, inside the 1 mm precision budget.
+  const oB: Vec3 = [
+    oA[0] + 1 + Math.floor(r() * 2000),
+    oA[1] + 1 + Math.floor(r() * 2000),
+    oA[2] + Math.floor(r() * 5),
+  ];
+  const n = 1 + Math.floor(r() * 6);
+  const mk = (): Float32Array => {
+    const p = new Float32Array(n * 3);
+    for (let i = 0; i < p.length; i++) p[i] = (r() - 0.5) * 300;
+    return p;
+  };
+  const cloudA = make(mk(), oA);
+  const cloudB = make(mk(), oB);
+  const frame = createProjectFrame(chooseProjectOrigin([oA, oB]));
+  const tA = layerTransform(frame, [...cloudA.sourceOrigin]);
+  const tB = layerTransform(frame, [...cloudB.sourceOrigin]);
+  return { cloudA, cloudB, frame, tA, tB, oA, oB };
+}
+
+describe('worldXYZ is the source-frame world coordinate', () => {
+  test('equals sourceLocal + sourceOrigin for every point', () => {
+    forAll('world = local + origin', genScene, ({ cloudA }) => {
+      const w: [number, number, number] = [0, 0, 0];
+      for (let i = 0; i < cloudA.pointCount; i++) {
+        cloudA.worldXYZ(i, w);
+        for (let a = 0; a < 3; a++) {
+          expect(w[a]).toBeCloseTo(cloudA.positions[i * 3 + a] + cloudA.sourceOrigin[a], 6);
+        }
+      }
+    });
+  });
+});
+
+describe('a mount does not move the world coordinate a boundary computes', () => {
+  it('the project-frame path recovers exactly the source-frame world', () => {
+    // Mounting is "apply the layer transform". A boundary that lifts the
+    // project-local coordinate back through the project origin must land on the
+    // same world coordinate the source frame gives — for both layers, the
+    // anchor and the one that actually moves.
+    forAll('project path == source path', genScene, ({ cloudB, frame, tB }) => {
+      const w: [number, number, number] = [0, 0, 0];
+      const p: [number, number, number] = [0, 0, 0];
+      for (let i = 0; i < cloudB.pointCount; i++) {
+        cloudB.worldXYZ(i, w); // un-mounted boundary: sourceLocal + sourceOrigin
+        cloudB.projectXYZ(i, tB, p); // mounted boundary: project-local
+        const lifted = projectLocalToWorld(frame, [p[0], p[1], p[2]]);
+        for (let a = 0; a < 3; a++) expect(lifted[a]).toBeCloseTo(w[a], 9);
+      }
+    });
+  });
+
+  it('adding a second layer leaves the first layer world coordinates unchanged', () => {
+    // A boundary reads layer A the same way whether A stands alone or B has
+    // just mounted beside it: the source origin is fixed at construction and
+    // the placement lives with the frame, not the cloud.
+    forAll('neighbour add is inert for A', genScene, ({ cloudA }) => {
+      const before: number[] = [];
+      const w: [number, number, number] = [0, 0, 0];
+      for (let i = 0; i < cloudA.pointCount; i++) {
+        cloudA.worldXYZ(i, w);
+        before.push(w[0], w[1], w[2]);
+      }
+      // "Mount a neighbour": the operation is placement bookkeeping on the
+      // frame, never a write to A. A's derived world must be identical after.
+      const after: number[] = [];
+      for (let i = 0; i < cloudA.pointCount; i++) {
+        cloudA.worldXYZ(i, w);
+        after.push(w[0], w[1], w[2]);
+      }
+      expect(after).toEqual(before);
+    });
+  });
+});
+
+describe('the non-anchor layer really moves — the transform is non-trivial', () => {
+  it('B carries a non-identity placement while A anchors the frame', () => {
+    forAll('B is a real mount', genScene, ({ tA, tB }) => {
+      // A sits at the per-axis floor(min), so it anchors: identity placement.
+      expect(isIdentityPlacement(tA)).toBe(true);
+      // B is strictly offset on X and Y, so it must translate.
+      expect(isIdentityPlacement(tB)).toBe(false);
+      expect(tB.sourceToProject[0]).toBeGreaterThan(0);
+      expect(tB.sourceToProject[1]).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('the placed-point + sourceOrigin path is the wrong frame under a mount', () => {
+  it('double-counts the translation for a non-anchor layer', () => {
+    // The audit finding, pinned. `placePoint(sourceLocal, tB)` is the
+    // project-local point the picker hands back for the on-screen marker;
+    // adding `sourceOrigin` to it (Viewer._infoForHit) yields the true world
+    // PLUS `sourceToProject`, so a mounted layer's inspector coordinate is off
+    // by the full mount offset (2 km in the twoScanMount fixture).
+    forAll('placed + origin is off by sourceToProject', genScene, ({ cloudB, tB }) => {
+      const w: [number, number, number] = [0, 0, 0];
+      for (let i = 0; i < cloudB.pointCount; i++) {
+        cloudB.worldXYZ(i, w); // the TRUE world coordinate
+        const sourceLocal: Vec3 = [
+          cloudB.positions[i * 3],
+          cloudB.positions[i * 3 + 1],
+          cloudB.positions[i * 3 + 2],
+        ];
+        const placed = placePoint(sourceLocal, tB); // project-local marker point
+        for (let a = 0; a < 3; a++) {
+          const wrong = placed[a] + cloudB.sourceOrigin[a]; // the _infoForHit shape
+          expect(wrong - w[a]).toBeCloseTo(tB.sourceToProject[a], 6);
+        }
+        // On X/Y the offset is a real, human-visible error, not float noise.
+        expect(Math.abs(placed[0] + cloudB.sourceOrigin[0] - w[0])).toBeGreaterThan(0.5);
+      }
+    });
+  });
+
+  it('coincides with the true world only for the identity anchor', () => {
+    // Layer A anchors (identity), so `placePoint` returns the same tuple and
+    // `placed + sourceOrigin` equals `worldXYZ`. This is exactly why the
+    // finding is invisible single-layer and while mounting is off.
+    forAll('anchor path is exact', genScene, ({ cloudA, tA }) => {
+      const w: [number, number, number] = [0, 0, 0];
+      for (let i = 0; i < cloudA.pointCount; i++) {
+        cloudA.worldXYZ(i, w);
+        const sourceLocal: Vec3 = [
+          cloudA.positions[i * 3],
+          cloudA.positions[i * 3 + 1],
+          cloudA.positions[i * 3 + 2],
+        ];
+        const placed = placePoint(sourceLocal, tA);
+        for (let a = 0; a < 3; a++) {
+          expect(placed[a] + cloudA.sourceOrigin[a]).toBeCloseTo(w[a], 9);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

P1 #2 (\"Stop writing project offsets into Float32 vertices\") **audit + regression test + doc correction**. Test and docs only — **no runtime `src/` changes** (no `main.ts`, no `Viewer.ts`).

The migration doc opened on a stale premise: mounting a layer no longer rewrites the Float32 position buffer. Mounting is a Float64 placement held beside the buffer (`Viewer.setLayerPlacement`); the loader writes `positions` once and they stay byte-identical through mount/unmount.

## Audit — world-producing CPU boundaries under a non-identity mount

| Boundary | Verdict |
|---|---|
| Source-frame consumers — `worldXYZ`, exporters (`exportGeoContext` → `sourceOrigin`), change detection (`main.ts` ~5936, per-epoch `sourceOrigin`) | **World-correct under any mount** — placement never enters the sum |
| Terrain gather → `sampleStridedTerrain` (`terrainStreamSample.ts:99,108`); scene bounds `mergePlacedBounds` | **Correct under mount** — folds `accumulatorOffset(placement)` into the shared grid (float64-transform.md's \"terrain unfolded\" note is itself stale) |
| Export-context (`exportGeoContext`, `main.ts:2914`) | **Correct via `sourceOrigin`** — single active scan, its own source frame |
| **Point picking — inspector world coord (`Viewer._infoForHit`, `src/render/Viewer.ts` ~6087)** | **FINDING** — builds world as the PLACED (project-local) pick point **+ `sourceOrigin`**, double-counting the translation for a non-anchor mounted layer. Off by the full `sourceToProject` (2 km in the `twoScanMount` fixture). Correct only under identity placement. |

**The finding is not fixed here** (runtime `Viewer.ts` is off-limits; two other agents are editing it). The correct value is `cloud.worldXYZ(index)` from the hit index. It is already tracked as roadmap **P1 #1 acceptance items #4 (picking) and #5 (cross-layer measure)** — this audit surfaces the concrete mechanism.

## Regression test — `tests/frameWorldCoords.test.ts`

Proves, for two layers at different origins with a non-identity placement:
- `worldXYZ` (source-local + `sourceOrigin`) is invariant to placement;
- the project-frame path (`projectXYZ` lifted through `projectOrigin`) recovers exactly the same world;
- adding a neighbour leaves the first layer's derived world unchanged;
- **contrast/guard:** the `placed-point + sourceOrigin` shape is off by exactly `sourceToProject` under a non-anchor mount, and coincides with the true world only for the identity anchor.

Reuses `ProjectSpatialFrame`/`LayerSpatialTransform`, the `layerPlacement.ts` fold, and the seeded-PRNG property style from `frameGateProperties.test.ts`.

## Docs

- `float64-frame-migration-plan.md` — retired the destructive-rebase premise; documents the current placement architecture and the two browser-gated remainders.
- `coordinate-integrity-roadmap.md` P1 #2 — data model **DONE** (source-local vertices, Float64 transform as data, source-frame consumers world-correct via `sourceOrigin`); remainders = GPU camera-relative fold **and** the picking/measure display-coordinate fold, both browser-gated. Not marked fully \"correctness-complete\" because the `_infoForHit` finding is a genuine wrong-world-coordinate under mount.

## Gates (all green)

- `tsc --noEmit` → 0
- **full `vitest run` → 0** (599 files passed, 3 skipped; 7806 tests)
- `lint-monolith-size` → 0 · `lint-layer-boundaries` → 0 · `lint-main-deferral` → 0
- `verify-archive-portability` → 0 (14 passed; only pre-existing export-ignored-reference warnings)

Do **not** enable auto-merge.