### PR TITLE
Extract generateReportPdf + exportGeoContext → src/app/reportExport.ts behind a structural deps object

### DIFF
--- a/KNOWN_LIMITATIONS_v0.6.3.md
+++ b/KNOWN_LIMITATIONS_v0.6.3.md
@@ -6,7 +6,7 @@ Four v0.6.1 statements or outputs are corrected in `docs/release/ERRATUM_v0.6.2.
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 6,125 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,927 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root is finished (no module-level mutable application state remains in `main.ts`) and the architecture is written down with a drift check, but that is the scaffolding for the decomposition, not the decomposition. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## The shared project frame is carried, not applied
 

--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 6,125 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,927 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -98,7 +98,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (6,125)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,927)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,
@@ -109,7 +109,6 @@ called with a 19-member deps object. The candidates that remain:
 | `seedStreamingFilterExtents` | 338 | streaming panel wiring module |
 | `syncInspectorVisuals` | 266 | inspector wiring module |
 | `applyScanRoute` | 233 | joins `ScanRouteService` |
-| `generateReportPdf` / `exportGeoContext` | 402 | export/report wiring module |
 
 Done: `importSession` (~208 lines) now lives in `src/app/sessionIo.ts`, called with a
 `SessionIoDeps` object of ~16 accessors the shell binds to its own state. The pure
@@ -139,6 +138,22 @@ URL-validation gate, and the honest error surfacing (`tests/openStreaming.test.t
 The SSRF URL validation (`validateRemoteEptUrl` / `validateRemoteCopcUrl`) is
 preserved exactly. `main.ts` keeps thin `openStreamingCopc` / `handleRemoteEpt`
 delegates that bind its running state to the deps.
+
+Done: `generateReportPdf` / `exportGeoContext` (~402 lines) — the report / geo-context
+export orchestration — now live in `src/app/reportExport.ts`, driven through a
+`ReportExportDeps` object of accessor functions closing over the shell's services,
+its resolved CRS and its mutable scan verdict rather than the Viewer class. The
+report engine (which pulls pdf-lib) is passed as a lazy loader so the module stays
+free of the boot graph. The pure decisions the extraction exposes are Node-tested —
+`effectiveCrsName` (the CRS-label honesty rule: only a projected / geographic CRS
+names the export frame, so a post-override label can't confidently place an export
+in the CRS the user rejected), `reportPointCount` (the file-scale honesty rule the
+PDF's Point Count follows, the same declared-total-over-strided-subset rule as the
+Layers chip's `layerChipCount`) and `isNonTerrainVerdict` (the capture-lens
+predicate that rules out an aerial density guess for a compact object / interior),
+alongside `exportGeoContext`'s static → streaming → zero frame resolution
+(`tests/reportExport.test.ts`). `main.ts` keeps thin `generateReportPdf` /
+`exportGeoContext` delegates that bind its running state to the deps.
 
 **`src/render/Viewer.ts` (6,419)** — the constructor and a handful of large
 methods dominate:

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 6125,
+      "lines": 5927,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/app/reportExport.ts
+++ b/src/app/reportExport.ts
@@ -1,0 +1,361 @@
+/**
+ * reportExport.ts — the report / geo-context export orchestration lifted out of
+ * main.ts.
+ *
+ * Two functions live here: {@link generateReportPdf}, which assembles and renders
+ * the multi-page PDF report from the live scan state (metadata, annotations,
+ * measurements, unit system + provenance fingerprint), and {@link exportGeoContext},
+ * which resolves the origin + CRS + name for the ACTIVE scan — static OR streaming
+ * — so the Products-lane exporters (measurements / integrity report / KML) place
+ * local points back into the source frame. Both read the same active-scan seam and
+ * the same resolved CRS the rest of the shell uses.
+ *
+ * The genuinely pure decisions the extraction exposes are free functions so they
+ * are Node-testable without a Viewer, the report engine or the DOM:
+ * {@link effectiveCrsName} (the CRS-label honesty rule — only a projected /
+ * geographic CRS names the frame, so a post-override label can't confidently place
+ * an export in the CRS the user rejected), {@link reportPointCount} (the file-scale
+ * honesty rule the PDF's Point Count follows — the declared total over the strided
+ * display subset, the same rule as the Layers chip's `layerChipCount`) and
+ * {@link isNonTerrainVerdict} (the capture-lens predicate that rules out an aerial
+ * density guess for a compact object / interior). Everything else is imperative
+ * orchestration, driven through a structural {@link ReportExportDeps} of accessor
+ * functions closing over the shell's services and its mutable scan verdict rather
+ * than the Viewer class — the same seam `openScan` and `openStreaming` use. The
+ * heavy report engine (which pulls pdf-lib) is passed in as a lazy loader so this
+ * module stays free of the boot graph. `main.ts` keeps thin `generateReportPdf` /
+ * `exportGeoContext` delegates that bind its running state to these deps. Part of
+ * the v0.6 decomposition (see `docs/architecture/architecture-map.md`).
+ */
+
+import { footprintMetres } from '../report/reportFootprint';
+import { isZUpFormat } from '../io/sniffFormat';
+import { increment as recordUsage } from '../diagnostics/usageCounters';
+import { classify as classifyProvenance } from '../diagnostics/provenance';
+import { signalsForStaticCloud, signalsForStreamingCloud } from '../diagnostics/provenanceSignals';
+import { triggerDownload } from '../io/download';
+
+import type { MetadataInputs, ReportProvenanceFingerprint } from '../report';
+import type { ResolvedCrs } from '../geo/CoordinateTypes';
+import type { SpaceKind } from '../terrain/scanShape';
+import type { Viewer } from '../render/Viewer';
+import type { DropZone } from '../ui/DropZone';
+import type { ScanService } from './ScanService';
+import type { loadReportEngine } from '../lazyChunks';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure decisions the extraction exposes — decidable without a Viewer, the report
+// engine or the DOM, so `tests/reportExport.test.ts` pins each one directly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The CRS label to STAMP on an export, or undefined for none. Only a projected or
+ * geographic CRS names the frame the coordinates live in; a local-coordinate (or
+ * absent) CRS yields undefined so nothing false is stamped.
+ *
+ * The label must come from the RESOLVED CRS — the same one every conversion, unit
+ * factor and validation gate uses — not from the raw source metadata. After a user
+ * override (the picker exists precisely because files declare wrong CRSs), the
+ * source label names the CRS the user rejected: a KML whose coordinates were
+ * converted under the override then carried metadata naming the old CRS would place
+ * confidently in the wrong frame — worse than no label. The raw source name stays
+ * available on the cloud for provenance.
+ */
+export function effectiveCrsName(crs: ResolvedCrs | null): string | undefined {
+  return crs && (crs.kind === 'projected' || crs.kind === 'geographic')
+    ? crs.name
+    : undefined;
+}
+
+/**
+ * The FILE-scale point count the PDF's "Point Count" reports. The loader strides
+ * huge clouds for display, so the in-memory `pointCount` is the rendered subset —
+ * the client PDF must describe the FILE, so use the declared total (and the density
+ * that follows from it) when striding reduced the in-memory count. Mirrors the
+ * Layers chip's `layerChipCount` and the Scan Report panel; the two must agree.
+ */
+export function reportPointCount(
+  declaredPointCount: number | undefined,
+  renderedPointCount: number,
+): number {
+  return declaredPointCount !== undefined && declaredPointCount > renderedPointCount
+    ? declaredPointCount
+    : renderedPointCount;
+}
+
+/**
+ * True for a compact object / interior scan — the capture-lens verdict that rules
+ * out an aerial density guess in the provenance fingerprint (v0.5.7). A temple is
+ * not drone LiDAR just because its density resembles a UAV survey.
+ */
+export function isNonTerrainVerdict(verdict: SpaceKind | null): boolean {
+  return verdict === 'object' || verdict === 'interior';
+}
+
+/**
+ * Origin + CRS + name for the ACTIVE scan, static OR streaming — the frame the
+ * Products-lane exporters place local points back into.
+ */
+export interface GeoExportContext {
+  origin: readonly [number, number, number];
+  crsName: string | undefined;
+  name: string | null;
+}
+
+/**
+ * The running-app seam the report / geo-context exports write through. Accessors
+ * are functions, not snapshots, so the lazily-bound Viewer, the resolved CRS and
+ * the mutable scan verdict are read at call time — exactly as the inline versions
+ * read the shell's `viewer` / `crsService` / `lastScanVerdict`. The report engine
+ * (which pulls pdf-lib) is passed as a lazy loader so this module stays free of the
+ * boot graph and the pure decisions above can be tested without it.
+ */
+export interface ReportExportDeps {
+  /** Resolves once the lazily-loaded Viewer chunk is in place — awaited before any `getViewer()`. */
+  readonly viewerReady: Promise<unknown>;
+  /** The live Viewer (a late-bound `let` in the shell). */
+  getViewer: () => Viewer;
+  /** Active-scan selection + lookup. */
+  scans: Pick<ScanService, 'activeId' | 'activeCloud'>;
+  /** The resolved CRS for the active scan (the shell's `crsService.current()`), or null. */
+  crsCurrent: () => ResolvedCrs | null;
+  /** The shape router's latest verdict for the active scan (the shell's `lastScanVerdict`). */
+  lastScanVerdict: () => SpaceKind | null;
+  /** The current class-scope stamp — disclosed on the PDF when a filter narrows the view. */
+  classScopeStamp: () => string;
+  /** A file name without its extension (the shell's `baseName`). */
+  baseName: (name: string) => string;
+  /** Lazily import the report engine (pdf-lib + the pure builders). */
+  loadReportEngine: typeof loadReportEngine;
+  /** The drop-zone status surface — carries a partial-render warning. */
+  dropZone: Pick<DropZone, 'setError'>;
+  /** `?debug=1` — console diagnostics for the wrapped, defensive blocks. */
+  readonly debug: boolean;
+}
+
+/**
+ * Origin + CRS + name for the ACTIVE scan, static OR streaming. The Products-
+ * lane exporters (measurements / integrity report / KML) place local points
+ * back into the source frame by adding the cloud origin — but streaming clouds
+ * aren't tracked by `scans.activeId`, so reading only the static cloud left them
+ * exporting at RENDER-frame coordinates (off by the whole `renderOrigin`) with
+ * no CRS. This resolves the origin from the streaming source's `renderOrigin`
+ * when no static cloud is active.
+ */
+export function exportGeoContext(deps: ReportExportDeps): GeoExportContext {
+  const viewer = deps.getViewer();
+  // The label comes from the RESOLVED CRS, the same rule every export path uses.
+  const crsName = effectiveCrsName(deps.crsCurrent());
+  if (deps.scans.activeId) {
+    const c = viewer.getCloud(deps.scans.activeId);
+    // SOURCE frame (float64-transform.md step 2): sessions save + import here.
+    if (c) return { origin: c.sourceOrigin, crsName: crsName ?? c.metadata?.crs?.name, name: c.name };
+  }
+  const sc = viewer.streamingCloud;
+  if (sc) return { origin: sc.renderOrigin, crsName: crsName ?? sc.crs()?.name ?? undefined, name: sc.name };
+  return { origin: [0, 0, 0], crsName: undefined, name: null };
+}
+
+/**
+ * Assemble + render a PDF report from the live state.
+ * Lazy-loads the report engine (which pulls pdf-lib) on first call.
+ * Returns a Promise so the caller can surface errors via toast/alert.
+ *
+ * Pulls the active streaming OR static cloud's metadata, the current
+ * annotations + measurements + unit system, and assembles a
+ * `ReportInputs`. Visuals + technical notes are queued for a UI-coupled
+ * follow-up (the user will pre-render image exports + type notes via a
+ * follow-on Studio-panel dialog). The engineering-
+ * inspection template renders cleanly without visuals.
+ */
+export async function generateReportPdf(templateId: string, deps: ReportExportDeps): Promise<void> {
+  // the report flow needs the Viewer state; ensure it's loaded.
+  await deps.viewerReady;
+  const viewer = deps.getViewer();
+  const report = await deps.loadReportEngine();
+  const streamingCloud = viewer.streamingCloud;
+  const staticCloud = deps.scans.activeCloud() ?? undefined;
+  if (!streamingCloud && !staticCloud) {
+    throw new Error('Load a scan first.');
+  }
+
+  // Build the MetadataInputs the composer + dataset-summary section need.
+  let metadata: MetadataInputs;
+  let exportFileStem: string;
+  if (streamingCloud) {
+    // `dataBounds` (tight data AABB), NOT `localBounds` (the octree cube): the
+    // cube inflates height ~7× and, for a partial footprint, deflates density.
+    const b = streamingCloud.dataBounds();
+    const crs = streamingCloud.crs();
+    // Footprint + density in metres / pts·m⁻², not raw CRS units (see
+    // reportFootprint): a foot-CRS scan would otherwise overstate the headline
+    // area ~10.76× and be graded against the wrong USGS Quality Level.
+    const { width: wM, depth: dM, height: hM, density } = footprintMetres({
+      extentX: b[3] - b[0], extentY: b[4] - b[1], extentZ: b[5] - b[2],
+      pointCount: streamingCloud.sourcePointCount,
+      linearUnitToMetres: crs?.linearUnitToMetres,
+      verticalUnitToMetres: crs?.verticalUnitToMetres,
+      // COPC and EPT are Z-up by spec.
+      zUp: true,
+    });
+    const modes = streamingCloud.availableColorModes();
+    // Streaming-preview accounting — how much of the cloud is resident at
+    // export time. Surfaced as a "Loaded" row so the PDF discloses that a
+    // mid-stream report describes the full cloud but inspected only the
+    // resident subset. counts().known is the total known node count.
+    const nodeCounts = streamingCloud.counts();
+    metadata = {
+      fileName: streamingCloud.name,
+      format: streamingCloud.kind === 'ept' ? 'EPT' : 'COPC',
+      sourcePointCount: streamingCloud.sourcePointCount,
+      width: wM, depth: dM, height: hM, density,
+      hasRgb: modes.includes('rgb'),
+      hasIntensity: modes.includes('intensity'),
+      hasClassification: modes.includes('classification'),
+      streamingResident: {
+        points: streamingCloud.residentPointCount,
+        nodes: nodeCounts.resident,
+        totalNodes: nodeCounts.known,
+      },
+      ...(crs ? { crsName: crs.name, crsUnit: crs.linearUnit } : {}),
+      // Class-filter honesty — when a filter narrows the live view, disclose
+      // it so the PDF's full-cloud figures aren't read as filter-scoped.
+      ...(deps.classScopeStamp() ? { classScopeNote: deps.classScopeStamp() } : {}),
+    };
+    exportFileStem = deps.baseName(streamingCloud.name);
+  } else if (staticCloud) {
+    const b = staticCloud.bounds();
+    // File-scale honesty: the loader strides huge clouds for display, so
+    // `pointCount` is the rendered subset. The client PDF must describe the
+    // FILE — use the declared total (and the density that follows from it) when
+    // striding reduced the in-memory count, matching the Scan Report panel.
+    const fileN = reportPointCount(staticCloud.declaredPointCount, staticCloud.pointCount);
+    const crs = staticCloud.metadata?.crs;
+    // Footprint + density in metres / pts·m⁻² (see reportFootprint): a foot-CRS
+    // scan would otherwise overstate area ~10.76× and be graded against the
+    // wrong USGS Quality Level.
+    const { width: wM, depth: dM, height: hM, density } = footprintMetres({
+      extentX: b.max[0] - b.min[0], extentY: b.max[1] - b.min[1], extentZ: b.max[2] - b.min[2],
+      pointCount: fileN,
+      linearUnitToMetres: crs?.linearUnitToMetres,
+      verticalUnitToMetres: crs?.verticalUnitToMetres,
+      // Mesh formats load Y-up, so the PDF reads the same axes as the
+      // on-screen Scan Report rather than assuming Z.
+      zUp: isZUpFormat(staticCloud.sourceFormat),
+    });
+    metadata = {
+      fileName: staticCloud.name,
+      format: staticCloud.sourceFormat.toUpperCase(),
+      sourcePointCount: fileN,
+      width: wM, depth: dM, height: hM, density,
+      hasRgb: !!staticCloud.colors,
+      hasIntensity: !!staticCloud.intensity,
+      hasClassification: !!staticCloud.classification,
+      ...(crs ? { crsName: crs.name, crsUnit: crs.linearUnit } : {}),
+      // Class-filter honesty — when a filter narrows the live view, disclose
+      // it so the PDF's full-cloud figures aren't read as filter-scoped.
+      ...(deps.classScopeStamp() ? { classScopeNote: deps.classScopeStamp() } : {}),
+    };
+    exportFileStem = deps.baseName(staticCloud.name);
+  } else {
+    throw new Error('Load a scan first.');
+  }
+
+  // Derive the cover title from the actual template so each template
+  // produces a distinct, recognisable PDF. The user-reported bug — "all
+  // reports show the same export" — was driven by a hardcoded
+  // `title: 'Scan Report'` that made the cover identical across every
+  // template choice. Pulling `label` off `getReportTemplate(templateId)`
+  // gives "Survey Summary" or "Technical Report" as appropriate. The
+  // dataset name moves into the subtitle so both axes (template type,
+  // source scan) are surfaced on the cover.
+  //
+  // v0.5.5 P12 — legacy ids (engineering-inspection, qa-validation,
+  // terrain-review, technical-documentation, scan-acceptance) normalise
+  // to the nearest current template, so an id carried in old UI state or
+  // an external caller keeps working; the export filename follows the
+  // NORMALISED id.
+  const validatedTemplateId =
+    report.normalizeReportTemplateId(templateId) ?? report.DEFAULT_TEMPLATE_ID;
+  const template = report.getReportTemplate(validatedTemplateId);
+  const coverTitle = template?.label ?? 'Scan Report';
+  // Compute the same provenance fingerprint the Inspector's Provenance
+  // section already shows, and feed it to the report. Templates that
+  // include the `provenance` section get a real capture-type +
+  // confidence + cited accuracy bounds — auto-computed, varies per
+  // scan, gives every export per-template differentiation without
+  // requiring the user to take measurements or annotate first.
+  //
+  // Wrapped because a malformed cloud shape shouldn't sink the whole
+  // PDF — the section gracefully renders "No provenance fingerprint
+  // available" when the fingerprint is undefined.
+  let provenanceFp: ReportProvenanceFingerprint | undefined;
+  try {
+    const activeCloud = deps.scans.activeCloud();
+    const streamingCloud = viewer.streamingCloud;
+    // The shape router's verdict rules out an aerial density guess for a
+    // compact object / interior (v0.5.7 capture lens) — a temple is not drone
+    // LiDAR just because its density resembles a UAV survey.
+    const isNonTerrain = isNonTerrainVerdict(deps.lastScanVerdict());
+    if (activeCloud) {
+      const f = classifyProvenance({ ...signalsForStaticCloud(activeCloud as never), isNonTerrain });
+      provenanceFp = {
+        label: f.label,
+        confidence: f.confidence,
+        signals: f.signals,
+        bounds: f.bounds.map((b) => ({ label: b.label, value: b.value, source: b.source })),
+        disclaimer: f.disclaimer,
+      };
+    } else if (streamingCloud) {
+      const f = classifyProvenance({ ...signalsForStreamingCloud(streamingCloud as never), isNonTerrain });
+      provenanceFp = {
+        label: f.label,
+        confidence: f.confidence,
+        signals: f.signals,
+        bounds: f.bounds.map((b) => ({ label: b.label, value: b.value, source: b.source })),
+        disclaimer: f.disclaimer,
+      };
+    }
+  } catch (err) {
+    if (deps.debug) console.warn('[report] classifyProvenance threw', err);
+  }
+  const inputs = report.composeReportInputs({
+    templateId: validatedTemplateId,
+    title: coverTitle,
+    subtitle: metadata.fileName,
+    metadata,
+    visuals: [],          // user-pre-rendered Studio exports
+    annotations: viewer.annotate.getAnnotations(),
+    measurements: viewer.measure.getMeasurements(),
+    unitSystem: viewer.measure.unitSystem,
+    // Render-units → metres, the SAME factor the live measure readouts apply
+    // (B2, v0.4.5) — so the report PDF's measurement values agree with the
+    // panel to the digit on foot-based CRSs.
+    unitToMetres: viewer.measure.unitToMetres,
+    provenance: provenanceFp,
+    // The file's own declared source metadata (E57 today) — verbatim,
+    // rendered by the report's "Declared source metadata" section under the
+    // "declared by the file, not verified" disclosure. Undefined (streaming
+    // sources, metadata-less files) omits the section entirely.
+    sourceMetadata: staticCloud?.metadata?.sourceMetadata,
+  });
+
+  const result = await report.generateReport(inputs);
+  // The download filename now mirrors the template choice so the
+  // user's Downloads folder distinguishes a Survey Summary from an
+  // Engineering Inspection at a glance.
+  triggerDownload(result.blob, `${exportFileStem}-${validatedTemplateId}.pdf`);
+  // Per-section render failures are caught by the engine's isolation pass
+  // and surfaced as a `failedSections` list — the PDF still ships but
+  // misses those sections. Tell the user so they're not surprised by a
+  // partial deliverable, and record it for local diagnostics so the
+  // partial-PDF mode is visible in the session-stats panel.
+  if (result.failedSections.length > 0) {
+    recordUsage('error', 'report:partial');
+    const list = result.failedSections.join(', ');
+    deps.dropZone.setError(
+      `Report rendered without these sections: ${list}. ` +
+        'Check for unusual characters in the affected inputs and try again.',
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,12 @@ import {
   linkAbortSignals,
   type OpenStreamingDeps,
 } from './app/openStreaming';
+import {
+  generateReportPdf as runGenerateReportPdf,
+  exportGeoContext as runExportGeoContext,
+  type GeoExportContext,
+  type ReportExportDeps,
+} from './app/reportExport';
 import { WorkflowController, WORKFLOW_RECORDER_ENABLED } from './ui/WorkflowController';
 import type { WorkflowConfigPanel } from './ui/WorkflowConfigPanel';
 import { RecommendedViewChip } from './ui/RecommendedViewChip';
@@ -118,7 +124,6 @@ import type { ClipBox } from './render/clip/clipBox';
 // Two-epoch change detection is loaded on demand (it pulls the terrain
 // ground-filter + rasteriser): see compareLoadedLayers' dynamic import.
 import { composeClassScopeBannerOntoBlob } from './export/ScanReportRenderer';
-import { footprintMetres } from './report/reportFootprint';
 import { planInstantAnswer } from './intelligence/instantAnswer';
 import { decodeFull } from './convert/decodeFull';
 import { HelpOverlay } from './ui/HelpOverlay';
@@ -232,14 +237,9 @@ import {
   isSuppressed as usageIsSuppressed,
 } from './diagnostics/usageCounters';
 import {
-  classify as classifyProvenance,
   fingerprintFor as provenanceFor,
   type CaptureType,
 } from './diagnostics/provenance';
-import {
-  signalsForStaticCloud,
-  signalsForStreamingCloud,
-} from './diagnostics/provenanceSignals';
 // CatalogPanel renders the empty-state "verified public LiDAR" picker.
 // The picker carries a curated dropdown of direct EPT URLs (each probed
 // at build time) and routes the selected URL into the existing streaming
@@ -2903,39 +2903,14 @@ function streamingExportCloud(): PointCloud | null {
 }
 
 /**
- * Origin + CRS + name for the ACTIVE scan, static OR streaming. The Products-
- * lane exporters (measurements / integrity report / KML) place local points
- * back into the source frame by adding the cloud origin — but streaming clouds
- * aren't tracked by `scans.activeId`, so reading only the static cloud left them
- * exporting at RENDER-frame coordinates (off by the whole `renderOrigin`) with
- * no CRS. This resolves the origin from the streaming source's `renderOrigin`
- * when no static cloud is active.
+ * Origin + CRS + name for the ACTIVE scan, static OR streaming — a thin caller
+ * over the extracted `src/app/reportExport.ts`. The origin-resolution rule (static
+ * `sourceOrigin`, else streaming `renderOrigin`, else zero) and the CRS-label
+ * honesty rule (`effectiveCrsName`) live in that module; here we bind the shell's
+ * running state through `reportExportDeps`.
  */
-function exportGeoContext(): {
-  origin: readonly [number, number, number];
-  crsName: string | undefined; name: string | null;
-} {
-  // The label must come from the RESOLVED CRS — the same one every conversion,
-  // unit factor and validation gate uses — not from the raw source metadata.
-  // After a user override (the picker exists precisely because files declare
-  // wrong CRSs), the source label names the CRS the user rejected: a KML whose
-  // coordinates were converted under the override then carried metadata naming
-  // the old CRS, which places confidently in the wrong frame — worse than no
-  // label. The raw source name stays available on the cloud for provenance.
-  const effectiveCrsName = (): string | undefined => {
-    const cur = crsService.current();
-    return cur && (cur.kind === 'projected' || cur.kind === 'geographic')
-      ? cur.name
-      : undefined;
-  };
-  if (scans.activeId) {
-    const c = viewer.getCloud(scans.activeId);
-    // SOURCE frame (float64-transform.md step 2): sessions save + import here.
-    if (c) return { origin: c.sourceOrigin, crsName: effectiveCrsName() ?? c.metadata?.crs?.name, name: c.name };
-  }
-  const sc = viewer.streamingCloud;
-  if (sc) return { origin: sc.renderOrigin, crsName: effectiveCrsName() ?? sc.crs()?.name ?? undefined, name: sc.name };
-  return { origin: [0, 0, 0], crsName: undefined, name: null };
+function exportGeoContext(): GeoExportContext {
+  return runExportGeoContext(reportExportDeps);
 }
 
 const exportPanel = new ExportPanel({
@@ -4593,209 +4568,15 @@ function schedulePrewarm(): void {
 }
 
 /**
- * Assemble + render a PDF report from the live state.
- * Lazy-loads the report engine (which pulls pdf-lib) on first call.
- * Returns a Promise so the caller can surface errors via toast/alert.
- *
- * Pulls the active streaming OR static cloud's metadata, the current
- * annotations + measurements + unit system, and assembles a
- * `ReportInputs`. Visuals + technical notes are queued for a UI-coupled
- * follow-up (the user will pre-render image exports + type notes via a
- * follow-on Studio-panel dialog). The engineering-
- * inspection template renders cleanly without visuals.
+ * Assemble + render a PDF report from the live state — a thin caller over the
+ * extracted `src/app/reportExport.ts`. The metadata assembly, provenance
+ * fingerprint, template normalisation and download live in that module, along with
+ * the pure `reportPointCount` (file-scale honesty) and `isNonTerrainVerdict`
+ * (capture lens) decisions; here we bind the shell's running state through
+ * `reportExportDeps`.
  */
-async function generateReportPdf(templateId: string): Promise<void> {
-  // the report flow needs the Viewer state; ensure it's loaded.
-  await viewerLoaded;
-  const report = await loadReportEngine();
-  const streamingCloud = viewer.streamingCloud;
-  const staticCloud = scans.activeCloud() ?? undefined;
-  if (!streamingCloud && !staticCloud) {
-    throw new Error('Load a scan first.');
-  }
-
-  // Build the MetadataInputs the composer + dataset-summary section need.
-  let metadata: import('./report').MetadataInputs;
-  let exportFileStem: string;
-  if (streamingCloud) {
-    // `dataBounds` (tight data AABB), NOT `localBounds` (the octree cube): the
-    // cube inflates height ~7× and, for a partial footprint, deflates density.
-    const b = streamingCloud.dataBounds();
-    const crs = streamingCloud.crs();
-    // Footprint + density in metres / pts·m⁻², not raw CRS units (see
-    // reportFootprint): a foot-CRS scan would otherwise overstate the headline
-    // area ~10.76× and be graded against the wrong USGS Quality Level.
-    const { width: wM, depth: dM, height: hM, density } = footprintMetres({
-      extentX: b[3] - b[0], extentY: b[4] - b[1], extentZ: b[5] - b[2],
-      pointCount: streamingCloud.sourcePointCount,
-      linearUnitToMetres: crs?.linearUnitToMetres,
-      verticalUnitToMetres: crs?.verticalUnitToMetres,
-      // COPC and EPT are Z-up by spec.
-      zUp: true,
-    });
-    const modes = streamingCloud.availableColorModes();
-    // Streaming-preview accounting — how much of the cloud is resident at
-    // export time. Surfaced as a "Loaded" row so the PDF discloses that a
-    // mid-stream report describes the full cloud but inspected only the
-    // resident subset. counts().known is the total known node count.
-    const nodeCounts = streamingCloud.counts();
-    metadata = {
-      fileName: streamingCloud.name,
-      format: streamingCloud.kind === 'ept' ? 'EPT' : 'COPC',
-      sourcePointCount: streamingCloud.sourcePointCount,
-      width: wM, depth: dM, height: hM, density,
-      hasRgb: modes.includes('rgb'),
-      hasIntensity: modes.includes('intensity'),
-      hasClassification: modes.includes('classification'),
-      streamingResident: {
-        points: streamingCloud.residentPointCount,
-        nodes: nodeCounts.resident,
-        totalNodes: nodeCounts.known,
-      },
-      ...(crs ? { crsName: crs.name, crsUnit: crs.linearUnit } : {}),
-      // Class-filter honesty — when a filter narrows the live view, disclose
-      // it so the PDF's full-cloud figures aren't read as filter-scoped.
-      ...(currentClassScopeStamp() ? { classScopeNote: currentClassScopeStamp() } : {}),
-    };
-    exportFileStem = baseName(streamingCloud.name);
-  } else if (staticCloud) {
-    const b = staticCloud.bounds();
-    // File-scale honesty: the loader strides huge clouds for display, so
-    // `pointCount` is the rendered subset. The client PDF must describe the
-    // FILE — use the declared total (and the density that follows from it) when
-    // striding reduced the in-memory count, matching the Scan Report panel.
-    const fileN =
-      staticCloud.declaredPointCount !== undefined && staticCloud.declaredPointCount > staticCloud.pointCount
-        ? staticCloud.declaredPointCount
-        : staticCloud.pointCount;
-    const crs = staticCloud.metadata?.crs;
-    // Footprint + density in metres / pts·m⁻² (see reportFootprint): a foot-CRS
-    // scan would otherwise overstate area ~10.76× and be graded against the
-    // wrong USGS Quality Level.
-    const { width: wM, depth: dM, height: hM, density } = footprintMetres({
-      extentX: b.max[0] - b.min[0], extentY: b.max[1] - b.min[1], extentZ: b.max[2] - b.min[2],
-      pointCount: fileN,
-      linearUnitToMetres: crs?.linearUnitToMetres,
-      verticalUnitToMetres: crs?.verticalUnitToMetres,
-      // Mesh formats load Y-up, so the PDF reads the same axes as the
-      // on-screen Scan Report rather than assuming Z.
-      zUp: isZUpFormat(staticCloud.sourceFormat),
-    });
-    metadata = {
-      fileName: staticCloud.name,
-      format: staticCloud.sourceFormat.toUpperCase(),
-      sourcePointCount: fileN,
-      width: wM, depth: dM, height: hM, density,
-      hasRgb: !!staticCloud.colors,
-      hasIntensity: !!staticCloud.intensity,
-      hasClassification: !!staticCloud.classification,
-      ...(crs ? { crsName: crs.name, crsUnit: crs.linearUnit } : {}),
-      // Class-filter honesty — when a filter narrows the live view, disclose
-      // it so the PDF's full-cloud figures aren't read as filter-scoped.
-      ...(currentClassScopeStamp() ? { classScopeNote: currentClassScopeStamp() } : {}),
-    };
-    exportFileStem = baseName(staticCloud.name);
-  } else {
-    throw new Error('Load a scan first.');
-  }
-
-  // Derive the cover title from the actual template so each template
-  // produces a distinct, recognisable PDF. The user-reported bug — "all
-  // reports show the same export" — was driven by a hardcoded
-  // `title: 'Scan Report'` that made the cover identical across every
-  // template choice. Pulling `label` off `getReportTemplate(templateId)`
-  // gives "Survey Summary" or "Technical Report" as appropriate. The
-  // dataset name moves into the subtitle so both axes (template type,
-  // source scan) are surfaced on the cover.
-  //
-  // v0.5.5 P12 — legacy ids (engineering-inspection, qa-validation,
-  // terrain-review, technical-documentation, scan-acceptance) normalise
-  // to the nearest current template, so an id carried in old UI state or
-  // an external caller keeps working; the export filename follows the
-  // NORMALISED id.
-  const validatedTemplateId =
-    report.normalizeReportTemplateId(templateId) ?? report.DEFAULT_TEMPLATE_ID;
-  const template = report.getReportTemplate(validatedTemplateId);
-  const coverTitle = template?.label ?? 'Scan Report';
-  // Compute the same provenance fingerprint the Inspector's Provenance
-  // section already shows, and feed it to the report. Templates that
-  // include the `provenance` section get a real capture-type +
-  // confidence + cited accuracy bounds — auto-computed, varies per
-  // scan, gives every export per-template differentiation without
-  // requiring the user to take measurements or annotate first.
-  //
-  // Wrapped because a malformed cloud shape shouldn't sink the whole
-  // PDF — the section gracefully renders "No provenance fingerprint
-  // available" when the fingerprint is undefined.
-  let provenanceFp: import('./report').ReportProvenanceFingerprint | undefined;
-  try {
-    const activeCloud = scans.activeCloud();
-    const streamingCloud = viewer.streamingCloud;
-    // The shape router's verdict rules out an aerial density guess for a
-    // compact object / interior (v0.5.7 capture lens) — a temple is not drone
-    // LiDAR just because its density resembles a UAV survey.
-    const isNonTerrain = lastScanVerdict === 'object' || lastScanVerdict === 'interior';
-    if (activeCloud) {
-      const f = classifyProvenance({ ...signalsForStaticCloud(activeCloud as never), isNonTerrain });
-      provenanceFp = {
-        label: f.label,
-        confidence: f.confidence,
-        signals: f.signals,
-        bounds: f.bounds.map((b) => ({ label: b.label, value: b.value, source: b.source })),
-        disclaimer: f.disclaimer,
-      };
-    } else if (streamingCloud) {
-      const f = classifyProvenance({ ...signalsForStreamingCloud(streamingCloud as never), isNonTerrain });
-      provenanceFp = {
-        label: f.label,
-        confidence: f.confidence,
-        signals: f.signals,
-        bounds: f.bounds.map((b) => ({ label: b.label, value: b.value, source: b.source })),
-        disclaimer: f.disclaimer,
-      };
-    }
-  } catch (err) {
-    if (debug) console.warn('[report] classifyProvenance threw', err);
-  }
-  const inputs = report.composeReportInputs({
-    templateId: validatedTemplateId,
-    title: coverTitle,
-    subtitle: metadata.fileName,
-    metadata,
-    visuals: [],          // user-pre-rendered Studio exports
-    annotations: viewer.annotate.getAnnotations(),
-    measurements: viewer.measure.getMeasurements(),
-    unitSystem: viewer.measure.unitSystem,
-    // Render-units → metres, the SAME factor the live measure readouts apply
-    // (B2, v0.4.5) — so the report PDF's measurement values agree with the
-    // panel to the digit on foot-based CRSs.
-    unitToMetres: viewer.measure.unitToMetres,
-    provenance: provenanceFp,
-    // The file's own declared source metadata (E57 today) — verbatim,
-    // rendered by the report's "Declared source metadata" section under the
-    // "declared by the file, not verified" disclosure. Undefined (streaming
-    // sources, metadata-less files) omits the section entirely.
-    sourceMetadata: staticCloud?.metadata?.sourceMetadata,
-  });
-
-  const result = await report.generateReport(inputs);
-  // The download filename now mirrors the template choice so the
-  // user's Downloads folder distinguishes a Survey Summary from an
-  // Engineering Inspection at a glance.
-  triggerDownload(result.blob, `${exportFileStem}-${validatedTemplateId}.pdf`);
-  // Per-section render failures are caught by the engine's isolation pass
-  // and surfaced as a `failedSections` list — the PDF still ships but
-  // misses those sections. Tell the user so they're not surprised by a
-  // partial deliverable, and record it for local diagnostics so the
-  // partial-PDF mode is visible in the session-stats panel.
-  if (result.failedSections.length > 0) {
-    recordUsage('error', 'report:partial');
-    const list = result.failedSections.join(', ');
-    dropZone.setError(
-      `Report rendered without these sections: ${list}. ` +
-        'Check for unusual characters in the affected inputs and try again.',
-    );
-  }
+function generateReportPdf(templateId: string): Promise<void> {
+  return runGenerateReportPdf(templateId, reportExportDeps);
 }
 
 
@@ -5409,6 +5190,27 @@ const openStreamingDeps: OpenStreamingDeps = {
   hideReclassifyUi,
   syncInspectClassScope,
   runStreamingModules,
+};
+
+/**
+ * Report / geo-context export — thin callers over the extracted
+ * `src/app/reportExport.ts`. `reportExportDeps` binds the shell's running state
+ * (the lazy Viewer, the active-scan seam, the resolved CRS, the scan verdict and
+ * the class-scope stamp) to the module's accessors; the PDF assembly and the
+ * origin/CRS resolution, plus the pure `effectiveCrsName` / `reportPointCount` /
+ * `isNonTerrainVerdict` decisions, live in that module.
+ */
+const reportExportDeps: ReportExportDeps = {
+  viewerReady: viewerLoaded,
+  getViewer: () => viewer,
+  scans,
+  crsCurrent: () => crsService.current(),
+  lastScanVerdict: () => lastScanVerdict,
+  classScopeStamp: currentClassScopeStamp,
+  baseName,
+  loadReportEngine,
+  dropZone,
+  debug,
 };
 
 /**

--- a/tests/architectureMap.test.ts
+++ b/tests/architectureMap.test.ts
@@ -92,9 +92,10 @@ describe('architecture map stays in step with the tree', () => {
     // not a fixed size: each completed extraction moves its row out of the
     // pending table into "Done:" prose, so the count ratchets down over time
     // (the render-loop and importSession extractions took it from 10 to 8, the
-    // openScan extraction took it to 7, and the openStreaming extraction to 6).
+    // openScan extraction took it to 7, the openStreaming extraction to 6, and the
+    // reportExport extraction to 5).
     const rows = text.split('\n').filter((l) => /^\|\s*`?[A-Za-z_]/.test(l) && /\|\s*[\d,]+\s*\|/.test(l));
-    expect(rows.length, 'the extraction tables have gone missing').toBeGreaterThanOrEqual(6);
+    expect(rows.length, 'the extraction tables have gone missing').toBeGreaterThanOrEqual(5);
 
     const lines = [
       ...readFileSync(root + 'src/main.ts', 'utf8').split('\n'),

--- a/tests/reportExport.test.ts
+++ b/tests/reportExport.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import {
+  effectiveCrsName,
+  reportPointCount,
+  isNonTerrainVerdict,
+  exportGeoContext,
+  type ReportExportDeps,
+} from '../src/app/reportExport';
+import type { ResolvedCrs } from '../src/geo/CoordinateTypes';
+import type { Viewer } from '../src/render/Viewer';
+import type { SpaceKind } from '../src/terrain/scanShape';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The pure decisions the extraction exposes — the only report/export logic that
+// can be decided without a Viewer, the report engine or the DOM.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// A minimal ResolvedCrs with just the two fields `effectiveCrsName` reads.
+const crs = (kind: ResolvedCrs['kind'], name: string): ResolvedCrs =>
+  ({ kind, name } as ResolvedCrs);
+
+describe('effectiveCrsName — the CRS-label honesty rule', () => {
+  it('names the frame for a projected CRS', () => {
+    expect(effectiveCrsName(crs('projected', 'NAD83 / UTM zone 15N'))).toBe(
+      'NAD83 / UTM zone 15N',
+    );
+  });
+
+  it('names the frame for a geographic CRS', () => {
+    expect(effectiveCrsName(crs('geographic', 'WGS 84'))).toBe('WGS 84');
+  });
+
+  it('stamps nothing for a local-coordinate CRS (no real frame to name)', () => {
+    // A local scan has no georeferenced frame — stamping a name would be false.
+    expect(effectiveCrsName(crs('local', 'Local coordinates (no CRS)'))).toBeUndefined();
+  });
+
+  it('stamps nothing for an unknown-kind CRS', () => {
+    expect(effectiveCrsName(crs('unknown', 'EPSG:0'))).toBeUndefined();
+  });
+
+  it('stamps nothing when there is no resolved CRS at all', () => {
+    expect(effectiveCrsName(null)).toBeUndefined();
+  });
+});
+
+describe('reportPointCount — the file-scale honesty rule', () => {
+  it('reports the declared file total when striding reduced the in-memory subset', () => {
+    // A 100M-point file rendered at a 4M display budget: the PDF describes the FILE.
+    expect(reportPointCount(100_000_000, 4_000_000)).toBe(100_000_000);
+  });
+
+  it('reports the rendered count when the load was not strided (declared === rendered)', () => {
+    expect(reportPointCount(4_000_000, 4_000_000)).toBe(4_000_000);
+  });
+
+  it('reports the rendered count when no total was declared (undefined)', () => {
+    expect(reportPointCount(undefined, 2_500_000)).toBe(2_500_000);
+  });
+
+  it('never reports a declared total smaller than the rendered count', () => {
+    // A smaller "declared" is not a reduction, so it must not win over what loaded.
+    expect(reportPointCount(1_000, 4_000)).toBe(4_000);
+  });
+
+  it('treats a declared total equal to zero as present but not larger, so rendered wins', () => {
+    expect(reportPointCount(0, 4_000)).toBe(4_000);
+  });
+});
+
+describe('isNonTerrainVerdict — the capture-lens predicate', () => {
+  it('is true for a compact object scan', () => {
+    expect(isNonTerrainVerdict('object')).toBe(true);
+  });
+
+  it('is true for an interior scan', () => {
+    expect(isNonTerrainVerdict('interior')).toBe(true);
+  });
+
+  it('is false for a terrain scan (aerial density guess allowed)', () => {
+    expect(isNonTerrainVerdict('terrain')).toBe(false);
+  });
+
+  it('is false when no verdict has been reached yet', () => {
+    expect(isNonTerrainVerdict(null)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// exportGeoContext — the origin/CRS/name resolution routing (static → streaming
+// → none). Reads only accessors, so it is exercisable with a stubbed deps object.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type StaticCloud = {
+  sourceOrigin: readonly [number, number, number];
+  name: string;
+  metadata?: { crs?: { name?: string } };
+};
+type StreamingCloud = {
+  renderOrigin: readonly [number, number, number];
+  name: string;
+  crs: () => { name?: string } | null;
+};
+
+/** Assemble a deps stub with only the members exportGeoContext reads. */
+function makeDeps(opts: {
+  activeId: string | null;
+  cloud?: StaticCloud;
+  streaming?: StreamingCloud;
+  resolvedCrs?: ResolvedCrs | null;
+}): ReportExportDeps {
+  const viewer = {
+    getCloud: (_id: string) => opts.cloud ?? null,
+    get streamingCloud() {
+      return opts.streaming ?? null;
+    },
+  } as unknown as Viewer;
+  return {
+    getViewer: () => viewer,
+    scans: { activeId: opts.activeId, activeCloud: () => null },
+    crsCurrent: () => opts.resolvedCrs ?? null,
+  } as unknown as ReportExportDeps;
+}
+
+describe('exportGeoContext — active-scan frame resolution', () => {
+  it('resolves the STATIC cloud source frame when a scan is active', () => {
+    const geo = exportGeoContext(
+      makeDeps({
+        activeId: 'a',
+        cloud: { sourceOrigin: [10, 20, 30], name: 'site.las', metadata: { crs: { name: 'EPSG:26915' } } },
+        resolvedCrs: crs('projected', 'NAD83 / UTM zone 15N'),
+      }),
+    );
+    expect(geo.origin).toEqual([10, 20, 30]);
+    // The RESOLVED label wins over the raw source metadata name.
+    expect(geo.crsName).toBe('NAD83 / UTM zone 15N');
+    expect(geo.name).toBe('site.las');
+  });
+
+  it('falls back to the static cloud source metadata name when the resolved CRS is local', () => {
+    const geo = exportGeoContext(
+      makeDeps({
+        activeId: 'a',
+        cloud: { sourceOrigin: [1, 2, 3], name: 'scan.las', metadata: { crs: { name: 'declared-in-file' } } },
+        resolvedCrs: crs('local', 'Local coordinates (no CRS)'),
+      }),
+    );
+    // effectiveCrsName is undefined for a local CRS, so the source metadata name shows.
+    expect(geo.crsName).toBe('declared-in-file');
+  });
+
+  it('resolves the STREAMING renderOrigin when no static cloud is active', () => {
+    const geo = exportGeoContext(
+      makeDeps({
+        activeId: null,
+        streaming: { renderOrigin: [100, 200, 300], name: 'remote.copc.laz', crs: () => ({ name: 'EPSG:6339' }) },
+        resolvedCrs: crs('projected', 'NAD83(2011) / UTM zone 12N'),
+      }),
+    );
+    expect(geo.origin).toEqual([100, 200, 300]);
+    expect(geo.crsName).toBe('NAD83(2011) / UTM zone 12N');
+    expect(geo.name).toBe('remote.copc.laz');
+  });
+
+  it('returns the zero frame with no CRS or name when nothing is loaded', () => {
+    const geo = exportGeoContext(makeDeps({ activeId: null }));
+    expect(geo.origin).toEqual([0, 0, 0]);
+    expect(geo.crsName).toBeUndefined();
+    expect(geo.name).toBeNull();
+  });
+});
+
+// Exhaustiveness guard: if a new SpaceKind is added, this array must be updated,
+// which forces a reviewer to decide whether it counts as non-terrain.
+const ALL_VERDICTS: SpaceKind[] = ['interior', 'object', 'terrain'];
+describe('isNonTerrainVerdict covers every SpaceKind', () => {
+  it('classifies each known verdict without throwing', () => {
+    for (const v of ALL_VERDICTS) expect(typeof isNonTerrainVerdict(v)).toBe('boolean');
+  });
+});

--- a/tests/reportExport.test.ts
+++ b/tests/reportExport.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import {
   effectiveCrsName,
   reportPointCount,
   isNonTerrainVerdict,
   exportGeoContext,
+  generateReportPdf,
   type ReportExportDeps,
 } from '../src/app/reportExport';
 import type { ResolvedCrs } from '../src/geo/CoordinateTypes';
@@ -176,5 +177,180 @@ const ALL_VERDICTS: SpaceKind[] = ['interior', 'object', 'terrain'];
 describe('isNonTerrainVerdict covers every SpaceKind', () => {
   it('classifies each known verdict without throwing', () => {
     for (const v of ALL_VERDICTS) expect(typeof isNonTerrainVerdict(v)).toBe('boolean');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generateReportPdf — the wiring body, exercised through a fake ReportExportDeps
+// (a stub report engine + fake viewer / scans) the same way the openScan /
+// openStreaming siblings cover their delegate bodies. Covers the static + the
+// streaming metadata builds, the provenance fingerprint, the partial-render
+// warning, the no-scan guard and an engine failure.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// generateReportPdf ends by triggering a browser download; the node test env has
+// no DOM, so stub the two globals `triggerDownload` touches. Fake timers keep the
+// helper's deferred URL-revoke from firing after the stubs are torn down.
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('document', {
+    createElement: () => ({ href: '', download: '', click() {}, remove() {} }),
+    body: { appendChild() {} },
+  });
+  const u = globalThis.URL as unknown as Record<string, unknown>;
+  u.createObjectURL = () => 'blob:reportexport-test';
+  u.revokeObjectURL = () => {};
+});
+afterAll(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  const u = globalThis.URL as unknown as Record<string, unknown>;
+  delete u.createObjectURL;
+  delete u.revokeObjectURL;
+});
+
+// A static cloud whose declared total exceeds the strided display count (file-scale
+// honesty), with a metre CRS + declared source metadata + one colour channel.
+const staticCloud = {
+  name: 'survey.las',
+  sourceFormat: 'las',
+  declaredPointCount: 2000,
+  pointCount: 1000,
+  bounds: () => ({ min: [0, 0, 0], max: [30, 20, 5] }),
+  colors: new Float32Array(3),
+  intensity: null,
+  classification: null,
+  metadata: {
+    crs: { name: 'NAD83 / UTM zone 15N', linearUnit: 'metre', linearUnitToMetres: 1, verticalUnitToMetres: 1 },
+    sourceMetadata: { fields: [{ label: 'Scanner', value: 'Faro' }] },
+  },
+};
+
+// A streaming COPC cloud with a resident subset smaller than the source total.
+const streamingCloud = {
+  name: 'remote.copc.laz',
+  kind: 'copc' as const,
+  dataBounds: () => [0, 0, 0, 30, 20, 5],
+  crs: () => ({ name: 'EPSG:6339', linearUnit: 'metre', linearUnitToMetres: 1, verticalUnitToMetres: 1 }),
+  availableColorModes: () => ['rgb', 'intensity', 'classification'],
+  sourcePointCount: 5000,
+  residentPointCount: 1200,
+  counts: () => ({ resident: 12, known: 40 }),
+};
+
+type ReportInputs = { templateId: string; subtitle: string; metadata: Record<string, unknown> };
+
+/** Assemble a fake deps + a recording report-engine stub for generateReportPdf. */
+function makeReportDeps(opts: {
+  staticCloud?: typeof staticCloud;
+  streamingCloud?: typeof streamingCloud;
+  classScopeStamp?: string;
+  verdict?: SpaceKind | null;
+  failedSections?: string[];
+  generateReject?: boolean;
+  normalizeToNull?: boolean;
+}) {
+  const setError = vi.fn();
+  const composeReportInputs = vi.fn((x: ReportInputs) => x);
+  const generateReport = vi.fn(async () => {
+    if (opts.generateReject) throw new Error('pdf-lib exploded');
+    return { blob: new Blob(['%PDF-1.7']), failedSections: opts.failedSections ?? [] };
+  });
+  const reportStub = {
+    normalizeReportTemplateId: (id: string) => (opts.normalizeToNull ? null : id),
+    DEFAULT_TEMPLATE_ID: 'engineering-inspection',
+    getReportTemplate: (id: string) => ({ label: `Template ${id}` }),
+    composeReportInputs,
+    generateReport,
+  };
+  const viewer = {
+    get streamingCloud() {
+      return opts.streamingCloud ?? null;
+    },
+    annotate: { getAnnotations: () => [] },
+    measure: { getMeasurements: () => [], unitSystem: 'metric', unitToMetres: 1 },
+  } as unknown as Viewer;
+  const deps = {
+    viewerReady: Promise.resolve(),
+    getViewer: () => viewer,
+    scans: {
+      activeId: opts.staticCloud ? 'a' : null,
+      activeCloud: () => opts.staticCloud ?? null,
+    },
+    crsCurrent: () => null,
+    lastScanVerdict: () => opts.verdict ?? null,
+    classScopeStamp: () => opts.classScopeStamp ?? '',
+    baseName: (n: string) => n.replace(/\.[^.]+$/, ''),
+    loadReportEngine: vi.fn(async () => reportStub),
+    dropZone: { setError },
+    debug: false,
+  } as unknown as ReportExportDeps;
+  return { deps, setError, composeReportInputs, generateReport };
+}
+
+describe('generateReportPdf — the report assembly body', () => {
+  it('assembles a static-cloud report at file scale and hands it to the engine', async () => {
+    const { deps, composeReportInputs, generateReport, setError } = makeReportDeps({
+      staticCloud,
+      classScopeStamp: 'ground only',
+      verdict: 'terrain',
+    });
+    await generateReportPdf('survey-summary', deps);
+    expect(composeReportInputs).toHaveBeenCalledTimes(1);
+    const inputs = composeReportInputs.mock.calls[0]![0] as ReportInputs;
+    // File-scale honesty: the declared 2000, not the strided 1000, reaches the PDF.
+    expect(inputs.metadata.sourcePointCount).toBe(2000);
+    expect(inputs.metadata.format).toBe('LAS');
+    // A non-empty class-scope stamp is disclosed on the metadata.
+    expect(inputs.metadata.classScopeNote).toBe('ground only');
+    expect(inputs.subtitle).toBe('survey.las');
+    // A terrain verdict is provenance-classified without throwing.
+    expect(inputs.metadata).toBeDefined();
+    expect(generateReport).toHaveBeenCalledTimes(1);
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('assembles a streaming-cloud report from the resident preview', async () => {
+    const { deps, composeReportInputs } = makeReportDeps({
+      streamingCloud,
+      classScopeStamp: '',
+      verdict: 'object',
+    });
+    await generateReportPdf('technical-report', deps);
+    const inputs = composeReportInputs.mock.calls[0]![0] as ReportInputs;
+    expect(inputs.metadata.format).toBe('COPC');
+    expect(inputs.metadata.sourcePointCount).toBe(5000);
+    expect((inputs.metadata.streamingResident as { points: number }).points).toBe(1200);
+    // An empty stamp discloses no class-scope note.
+    expect(inputs.metadata.classScopeNote).toBeUndefined();
+  });
+
+  it('falls back to the default template id when the requested id is unknown', async () => {
+    const { deps, composeReportInputs } = makeReportDeps({ staticCloud, normalizeToNull: true });
+    await generateReportPdf('bogus-id', deps);
+    const inputs = composeReportInputs.mock.calls[0]![0] as ReportInputs;
+    expect(inputs.templateId).toBe('engineering-inspection');
+  });
+
+  it('warns via the drop zone when the engine drops sections but still ships the PDF', async () => {
+    const { deps, setError, generateReport } = makeReportDeps({
+      staticCloud,
+      failedSections: ['visuals', 'notes'],
+    });
+    await generateReportPdf('survey-summary', deps);
+    expect(generateReport).toHaveBeenCalledTimes(1);
+    expect(setError).toHaveBeenCalledTimes(1);
+    expect(setError.mock.calls[0]![0]).toContain('visuals, notes');
+  });
+
+  it('throws "Load a scan first." when neither a static nor a streaming cloud is present', async () => {
+    const { deps, setError } = makeReportDeps({});
+    await expect(generateReportPdf('survey-summary', deps)).rejects.toThrow('Load a scan first.');
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('propagates a report-engine failure to the caller', async () => {
+    const { deps } = makeReportDeps({ staticCloud, generateReject: true });
+    await expect(generateReportPdf('survey-summary', deps)).rejects.toThrow('pdf-lib exploded');
   });
 });


### PR DESCRIPTION
## What

Lifts the report / geo-context export orchestration out of the `src/main.ts` monolith into a new `src/app/reportExport.ts`, continuing the v0.6 P5 decomposition. Follows the exact idiom of the two just-merged siblings — `openScan` (#242) and `openStreaming` (#244): the two functions become free functions taking a structural `ReportExportDeps` object of accessor functions that close over the shell's services (not the `Viewer` class), and `main.ts` keeps thin delegates that bind its running state.

**No behaviour change.** Function bodies are transcribed verbatim; the only substitutions are shell references → deps accessors and three inline decisions → named pure helpers.

## `ReportExportDeps`
`viewerReady`, `getViewer`, `scans` (`activeId` / `activeCloud`), `crsCurrent`, `lastScanVerdict`, `classScopeStamp`, `baseName`, `loadReportEngine`, `dropZone` (`setError`), `debug`. The report engine (pulls pdf-lib) is passed as a lazy loader so the module stays out of the boot graph.

## Pure decisions Node-tested (`tests/reportExport.test.ts`)
- **`effectiveCrsName`** — the CRS-label honesty rule (only a projected/geographic CRS names the export frame, so a post-override label can't confidently place an export in the CRS the user rejected).
- **`reportPointCount`** — the file-scale honesty rule the PDF's Point Count follows (declared total over strided display subset, mirroring the Layers chip's `layerChipCount`).
- **`isNonTerrainVerdict`** — the capture-lens predicate that rules out an aerial density guess for a compact object / interior.
- plus `exportGeoContext`'s static → streaming → zero frame resolution.

## main.ts shrinks
`6,125 → 5,927` lines. The monolith-size baseline is banked to the lower count (legitimate shrink). Truth records follow: the architecture-map row moves out of the pending table into "Done" prose with the new count, the `architectureMap.test.ts` pending-row floor drops `6 → 5` (as #242/#244 did), and `KNOWN_LIMITATIONS_v0.6.3.md`'s stated count is kept in step.

## Gates (all green)
`tsc` 0 · `vitest run` 0 (7819 passed) · `lint:monolith-size` 0 · `lint:layer-boundaries` 0 · `lint:main-deferral` 0 · `lint:release-truth` 0 · `verify-archive-portability` 0 (only pre-existing soft warnings) · deterministic e2e green (162 passed; `reportVerify` / `exportPanel` / `integrityReport` / `smoke` / `viewer` all pass — one E57-decode timing flake cleared on isolated re-run).

`src/render/Viewer.ts` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)