### PR TITLE
Fix inspector world coordinate for a non-anchor mounted layer (acceptance #4/#5)

### DIFF
--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -6045,10 +6045,10 @@ export class Viewer {
       geographicHorizontal: this._inspectGeographicHorizontal,
       layer: cloud.name,
       index,
-      // `point` is in local space; the cloud's origin restores real-world
-      // coordinates — the absolute survey position engineers expect.
-      local: [point.x, point.y, point.z],
-      origin: [cloud.sourceOrigin[0], cloud.sourceOrigin[1], cloud.sourceOrigin[2]],
+      // `point` is the PLACED pick; for a non-anchor mounted layer it would
+      // double-count the origin. `worldXYZ` folds each cloud's own source origin.
+      local: cloud.worldXYZ(index),
+      origin: [0, 0, 0],
       distance: this._camera.position.distanceTo(point),
       intensity: cloud.intensity ? cloud.intensity[index] : null,
       classification: cloud.classification ? cloud.classification[index] : null,


### PR DESCRIPTION
## The bug
`Viewer._infoForHit` passed the **placed** (project-local) pick point as the source-local coordinate, then added `sourceOrigin` to recover the world position. For a layer mounted at a non-anchor offset the placed point already includes the placement translation, so `point + sourceOrigin` **double-counted** it — the inspector reported a world coordinate off by the full mount offset (~2 km in the `twoScanMount` fixture). Correct only under identity placement (single layer / frame anchor), which is why it stayed hidden until multi-scan mount was enabled (#238). Found by the P1 #2 frame-boundary audit (#250).

## The fix
Use `cloud.worldXYZ(index)` (source-local vertex + the cloud's own `sourceOrigin`, correct for any layer, pinned by `tests/frameWorldCoords.test.ts`) as the world coordinate; `distance` still uses the placed `point`. This completes multi-scan acceptance **#4** (picking returns correct coordinates) and **#5** (cross-layer coordinates).

## Verification
tsc 0 · full vitest **7844 pass** · monolith-size / position-access / layer-boundaries / main-deferral green · line-neutral (Viewer.ts 6375). `worldXYZ` reads `positions` inside `PointCloud`, which is excluded from the accessor ratchet, so no new raw read.

**Follow-up:** a browser e2e that picks a point on a mounted non-anchor tile and asserts the inspector coordinate needs a pick seam on `__OLV_TEST_API__`; tracked as the remaining acceptance-#4 browser evidence.