### PR TITLE
Budget the heavy capability chunks (Viewer, lazDecode, EPT/COPC workers)

### DIFF
--- a/scripts/check-bundle-budget.mjs
+++ b/scripts/check-bundle-budget.mjs
@@ -32,6 +32,14 @@ const BUDGETS = [
   { prefix: 'index', maxKiB: 720, warnKiB: 680 },   // live ~669 KiB after v0.6 P1 (AnalysePanel + ObjectPanel lazy-mounted on scan-load, was 792). Hard ceiling lowered 800→720 to lock in the win and fail a regression well before the old 800; warn at 680 flags creep early. The lazy panels ride their own AnalysePanel-*/ObjectPanel-* chunks — verified by the shell-leak fingerprint guard.
   { prefix: 'vendor-three-webgpu', maxKiB: 1100 },  // live ~978 KiB
   { prefix: 'vendor-pdf', maxKiB: 512 },            // live ~410 KiB
+  // Heavy capability chunks, lazy-loaded on the feature that needs them. Each
+  // gets its own ceiling so a single capability cannot bloat unnoticed under the
+  // "unbudgeted chunks never fail" rule above (R5: a budget line per heavy
+  // capability). Sized ~12-15 % over the current live (obfuscated) size.
+  { prefix: 'Viewer', maxKiB: 740, warnKiB: 710 },          // live ~657 KiB — render core (three binding, tools, streaming attach)
+  { prefix: 'lazDecode', maxKiB: 700, warnKiB: 670 },       // live ~613 KiB across 2 files — laz-perf WASM + decode glue
+  { prefix: 'eptLaszipWorker', maxKiB: 395, warnKiB: 380 }, // live ~343 KiB — EPT laszip streaming worker
+  { prefix: 'copcWorker', maxKiB: 385, warnKiB: 370 },      // live ~334 KiB — COPC streaming worker
 ];
 
 function listJs() {


### PR DESCRIPTION
## What
Only `index` + the two vendor chunks had bundle-budget ceilings; everything else fell under the script's *"unbudgeted chunks never fail"* rule, so a heavy capability chunk could bloat unnoticed. This adds ceilings for the largest unbudgeted lazy chunks, sized ~12–15% over their current **live/obfuscated** size:

| Chunk | Live | Ceiling (warn) |
|---|---|---|
| `Viewer` | 657 KiB | 740 (710) |
| `lazDecode` | 613 KiB | 700 (670) |
| `eptLaszipWorker` | 343 KiB | 395 (380) |
| `copcWorker` | 334 KiB | 385 (370) |

Closes the R5 *"a budget line per heavy capability"* modernization item.

## Verification
`node scripts/check-bundle-budget.mjs` on the live build → all **7 budgets pass, exit 0**. Script-only change, no runtime effect.

_Note: `index` sits at 699/720 KiB (97%, pre-existing WARN) — separate creep, not touched here._