### PR TITLE
Harden workflowRecorder download handler against a teardown race (fixes flaky e2e-webkit)

### DIFF
--- a/tests/e2e/workflowRecorder.spec.ts
+++ b/tests/e2e/workflowRecorder.spec.ts
@@ -127,8 +127,16 @@ test.describe('workflow recorder — capture into a live session', () => {
     // Stop the recording. The download is intercepted by Playwright;
     // we just confirm the page didn't throw at any point.
     page.on('download', async (d) => {
-      // Acknowledge the download so the browser doesn't hang on it.
-      await d.cancel();
+      // Acknowledge the download so the browser doesn't hang on it. The event can
+      // arrive during teardown, after the context has already closed, where
+      // cancel() rejects with "browser has been closed" — swallow that late
+      // rejection so it can't crash the worker (the test's own assertions have
+      // run by then).
+      try {
+        await d.cancel();
+      } catch {
+        /* context already closing — nothing left to cancel */
+      }
     });
     await pressRecordToggle(page);
     expect(errors).toEqual([]);


### PR DESCRIPTION
## The flake
`tests/e2e/workflowRecorder.spec.ts:131` registers `page.on('download', d => d.cancel())`. When the download event fires **during teardown** (context already closed), `await d.cancel()` rejects with `download.cancel: Target page, context or browser has been closed`, crashing the worker — even though **158 passed, 0 assertions failed**. This is the intermittent `e2e-webkit` red blocking otherwise-green PRs (surfaced on #255, a doc-only change).

## The fix
Wrap `d.cancel()` in try/catch — the test's assertions have already run by the time a teardown-time download event fires, so a failed cancel on a closing context is harmless. **Test-only**, no source change.

_Note: the separate firefox `rightRail.spec.ts:49` flake auto-recovers on retry (`1 flaky`, job passes) and is not addressed here._