### PR TITLE
Disclose that full-resolution export drops in-session class edits

### DIFF
--- a/src/export/exportSummary.ts
+++ b/src/export/exportSummary.ts
@@ -49,6 +49,12 @@ export interface ExportSummaryInput {
   readonly viewDecimated?: boolean;
   /** User ticked "convert at full resolution". */
   readonly fullRes?: boolean;
+  /**
+   * The active cloud carries in-session classification edits (manual reclassify)
+   * that live only in the display-resolution buffer. A full-resolution export
+   * re-decodes the original file and would silently drop them.
+   */
+  readonly hasClassEdits?: boolean;
   /** User ticked "Compress (.gz)" — gzip the LAS output (LAS formats only). */
   readonly gzip?: boolean;
 }
@@ -196,6 +202,14 @@ export function buildExportSummary(input: ExportSummaryInput): ExportSummary {
       message:
         'This writes the DERIVED (heuristic) classification — not survey-grade. ' +
         'Validate it before anyone relies on it, or omit it below.',
+    });
+  }
+  if (input.fullRes && includeClass && input.hasClassEdits) {
+    warnings.push({
+      level: 'warn',
+      message:
+        'Full-resolution export re-decodes the original file — your in-session ' +
+        'classification edits will NOT be included. Untick full resolution to keep them.',
     });
   }
   if (includeClass && provenance !== 'none' && input.format === 'las') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2965,9 +2965,9 @@ const exportPanel = new ExportPanel({
     viewer?.streamingCloud != null && viewer.exportFrontierPointTotal() === 0,
   getActiveClip: () => viewer.getClip(),
   hasFullSource: () => scans.activeId != null && sourceFileById.has(scans.activeId),
-  // A streaming snapshot exports only the resident (streamed-in) points, so it
-  // is a reduced subset whenever the whole cloud hasn't landed yet — flag it so
-  // the export status says "reduced view" and never reads as the full survey.
+  hasClassEdits: () => scans.activeId != null && (viewer?.canUndoClassification(scans.activeId) ?? false),
+  // A streaming snapshot exports only resident points, so it is a reduced subset
+  // until the whole cloud lands — flagged so the status reads "reduced view".
   isReduced: () => {
     if (scans.activeId != null) return reducedById.get(scans.activeId) === true;
     // `viewer` is null until the lazy Viewer chunk resolves, and ExportPanel's

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -74,6 +74,13 @@ export interface ExportPanelCallbacks {
   isReduced: () => boolean;
   /** Re-decode the original file at full resolution. Only call when `hasFullSource()`. */
   getFullCloud: () => Promise<PointCloud | null>;
+  /**
+   * Whether the active cloud has in-session classification edits (manual
+   * reclassify) that live only in the display-resolution buffer. Drives the
+   * full-resolution disclosure — a full-res export re-decodes the original file
+   * and drops them.
+   */
+  hasClassEdits?: () => boolean;
   /** Count of placed measurements — drives the Products lane's enablement. */
   measurementCount?: () => number;
   /** Export the placed measurements to an open format (GeoJSON / CSV). */
@@ -387,6 +394,7 @@ export class ExportPanel {
       includeClassification: this._includeClass,
       viewDecimated: this._cb.isReduced(),
       fullRes: this._fullRes,
+      hasClassEdits: this._cb.hasClassEdits?.() ?? false,
       gzip: this._gzip,
     };
     const s = buildExportSummary(input);

--- a/tests/exportSummary.test.ts
+++ b/tests/exportSummary.test.ts
@@ -160,3 +160,33 @@ describe('buildExportSummary — CRS label + line', () => {
     expect(s.line).toContain('·');
   });
 });
+
+describe('buildExportSummary — full-res drops in-session class edits', () => {
+  const dropRe = /class(ification)? edits will NOT/i;
+
+  it('warns when a full-res export would drop in-session class edits', () => {
+    expect(
+      warns({ ...base, fullRes: true, hasClassEdits: true, includeClassification: true }),
+    ).toEqual(
+      expect.arrayContaining([expect.stringMatching(/warn:.*edits will NOT be included/i)]),
+    );
+  });
+
+  it('no warning without class edits', () => {
+    expect(warns({ ...base, fullRes: true, hasClassEdits: false })).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(dropRe)]),
+    );
+  });
+
+  it('no warning at display resolution (edits are kept)', () => {
+    expect(warns({ ...base, fullRes: false, hasClassEdits: true })).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(dropRe)]),
+    );
+  });
+
+  it('no warning when classification is omitted from the export', () => {
+    expect(
+      warns({ ...base, fullRes: true, hasClassEdits: true, includeClassification: false }),
+    ).not.toEqual(expect.arrayContaining([expect.stringMatching(dropRe)]));
+  });
+});


### PR DESCRIPTION
## The bug (found by the UX & Navigation sweep)
Manual classification editing (lasso reclassify + undo) is shipped and wired. But **full-resolution export silently drops the edits**: `main.ts` `getFullCloud` → `decodeFull` re-decodes the original file, discarding the in-memory class edits. A user reclassifies points, exports at full res, and their work vanishes with no warning.

## Why disclosure, not remap
Re-applying display-res edits onto the re-decoded full cloud needs a stable per-point source-index map, which doesn't exist today — a naive remap would silently **mis-paint** classes (a worse, data-integrity failure). So the fail-closed, honest fix is to **disclose** the drop.

## The change
`buildExportSummary` emits a warning when `fullRes + includeClassification + hasClassEdits`, shown in the existing export summary line. `ExportPanel` threads `hasClassEdits`; `main.ts` computes it from `viewer.canUndoClassification`. Four unit tests pin the condition.

## Verification
tsc 0 · export/classification suites **620/620** · monolith-size **net-neutral** · main-deferral green.

**Follow-ups:** (1) actually carry edits into full-res export (needs a source-index map); (2) browser spot-check — reclassify → tick full-res → confirm the warning shows.

No auto-merge — user-facing behavior change.