### PR TITLE
Add PDF accessibility metadata to the five remaining emitters

### DIFF
--- a/src/render/measure/mapSheetPdf.ts
+++ b/src/render/measure/mapSheetPdf.ts
@@ -311,6 +311,14 @@ function safe(s: string): string {
 /** Build the map-sheet PDF and return its bytes. */
 export async function buildMapSheetPdf(input: MapSheetInput): Promise<Uint8Array> {
   const doc = await PDFDocument.create();
+  // Accessibility metadata. `showInWindowTitleBar` sets the ViewerPreferences
+  // DisplayDocTitle flag so a screen reader / PDF viewer announces the sheet
+  // title rather than the raw filename; setLanguage tags the document language.
+  // (A full tagged-structure tree is out of reach with this PDF library; these
+  // are the honest, supported accessibility hooks — see ReportPdfRenderer.)
+  doc.setTitle(input.title ?? 'Contour Map', { showInWindowTitleBar: true });
+  doc.setLanguage('en-US');
+  doc.setAuthor('OpenLiDARViewer');
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
 

--- a/src/render/measure/profilePdf.ts
+++ b/src/render/measure/profilePdf.ts
@@ -149,6 +149,17 @@ function scaleRatio(groundM: number, paperPt: number): number {
 /** Build the profile PDF and return its bytes. */
 export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Array> {
   const doc = await PDFDocument.create();
+  // Accessibility metadata. `showInWindowTitleBar` sets the ViewerPreferences
+  // DisplayDocTitle flag so a screen reader / PDF viewer announces the sheet
+  // title rather than the raw filename; setLanguage tags the document language.
+  // (A full tagged-structure tree is out of reach with this PDF library; these
+  // are the honest, supported accessibility hooks — see ReportPdfRenderer.)
+  const pdfTitle = input.name && input.name.trim()
+    ? `Terrain Profile - ${input.name.trim()}`
+    : 'Terrain Profile';
+  doc.setTitle(pdfTitle, { showInWindowTitleBar: true });
+  doc.setLanguage('en-US');
+  doc.setAuthor('OpenLiDARViewer');
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
   const mono = await doc.embedFont(StandardFonts.Courier);

--- a/src/render/measure/spaceReportPdf.ts
+++ b/src/render/measure/spaceReportPdf.ts
@@ -68,6 +68,14 @@ function safe(s: string): string {
 export async function buildSpaceReportPdf(input: SpaceReportPdfInput): Promise<Uint8Array> {
   const content = buildSpaceReportContent(input);
   const doc = await PDFDocument.create();
+  // Accessibility metadata. `showInWindowTitleBar` sets the ViewerPreferences
+  // DisplayDocTitle flag so a screen reader / PDF viewer announces the report
+  // title rather than the raw filename; setLanguage tags the document language.
+  // (A full tagged-structure tree is out of reach with this PDF library; these
+  // are the honest, supported accessibility hooks — see ReportPdfRenderer.)
+  doc.setTitle(content.title, { showInWindowTitleBar: true });
+  doc.setLanguage('en-US');
+  doc.setAuthor('OpenLiDARViewer');
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
 

--- a/src/render/measure/terrainReportPdf.ts
+++ b/src/render/measure/terrainReportPdf.ts
@@ -92,6 +92,14 @@ export async function buildTerrainReportPdf(
   const content = isContent(input) ? input : buildTerrainReportContent(input, opts);
 
   const doc = await PDFDocument.create();
+  // Accessibility metadata. `showInWindowTitleBar` sets the ViewerPreferences
+  // DisplayDocTitle flag so a screen reader / PDF viewer announces the report
+  // title rather than the raw filename; setLanguage tags the document language.
+  // (A full tagged-structure tree is out of reach with this PDF library; these
+  // are the honest, supported accessibility hooks — see ReportPdfRenderer.)
+  doc.setTitle(content.title, { showInWindowTitleBar: true });
+  doc.setLanguage('en-US');
+  doc.setAuthor('OpenLiDARViewer');
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
 

--- a/src/terrain/export/contourStudioPdf.ts
+++ b/src/terrain/export/contourStudioPdf.ts
@@ -88,6 +88,16 @@ function drawWatermark(page: PDFPage, font: PDFFont, mark: string): void {
  */
 export async function buildContourStudioPdf(model: ContourPdfModel): Promise<Uint8Array> {
   const doc = await PDFDocument.create();
+  // Accessibility metadata. `showInWindowTitleBar` sets the ViewerPreferences
+  // DisplayDocTitle flag so a screen reader / PDF viewer announces the
+  // deliverable title rather than the raw filename; setLanguage tags the
+  // document language. (A full tagged-structure tree is out of reach with this
+  // PDF library; these are the honest, supported accessibility hooks — see
+  // ReportPdfRenderer.)
+  const pdfTitle = model.titleBlock[0]?.trim() || 'Contour Studio Deliverable';
+  doc.setTitle(pdfTitle, { showInWindowTitleBar: true });
+  doc.setLanguage('en-US');
+  doc.setAuthor('OpenLiDARViewer');
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
 


### PR DESCRIPTION
## What

Adds the same three accessibility metadata hooks the `ReportPdfRenderer` exemplar already sets (`src/report/ReportPdfRenderer.ts:106-115`) to the five PDF emitters that set none, immediately after each `PDFDocument.create()`:

- `setTitle(<descriptive per-document title>, { showInWindowTitleBar: true })` — sets the ViewerPreferences `DisplayDocTitle` flag so a screen reader / PDF viewer announces the document title rather than the raw filename
- `setLanguage('en-US')` — tags the document language for correct pronunciation
- `setAuthor('OpenLiDARViewer')`

Emitters changed:

| File | Title source |
| --- | --- |
| `src/render/measure/mapSheetPdf.ts` | `input.title ?? 'Contour Map'` |
| `src/render/measure/terrainReportPdf.ts` | `content.title` |
| `src/render/measure/spaceReportPdf.ts` | `content.title` |
| `src/render/measure/profilePdf.ts` | `Terrain Profile - <name>` (fallback `Terrain Profile`) |
| `src/terrain/export/contourStudioPdf.ts` | `model.titleBlock[0]` (fallback `Contour Studio Deliverable`) |

No tagged struct tree is built (out of reach with pdf-lib, as the exemplar notes) — these are the honest, supported accessibility hooks only.

## Determinism / tests

`setTitle`/`setLanguage`/`setAuthor` are deterministic and add no timestamp, so output stays stable. The existing PDF tests assert the `%PDF-` header, `byteLength` thresholds, and parsed text-show operators — none of which metadata (Info dict / Catalog) affects. No test fixtures needed regeneration.

## Verification

- `npx tsc --noEmit` → 0 errors
- `npx vitest run` (full suite) → 7844 passed, 20 skipped, 1 todo, 0 failed
- `node scripts/lint-monolith-size.mjs` → exit 0
- `node scripts/lint-main-deferral.mjs` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)