### PR TITLE
Group the annotation panel into per-category sections when the list is long

### DIFF
--- a/src/render/annotate/annotationClustering.ts
+++ b/src/render/annotate/annotationClustering.ts
@@ -57,6 +57,28 @@ export function summariseAnnotationCategories(
   return { total: items.length, byType, ordered };
 }
 
+/**
+ * Partition annotations into per-category buckets in display
+ * ({@link ANNOTATION_TYPES}) order, dropping empty categories. Input order is
+ * preserved WITHIN each bucket, so a caller that has already sorted its items
+ * keeps that order inside every group. Generic over anything carrying a `type`,
+ * so it serves both the full {@link Annotation} and the panel's summaries.
+ */
+export function groupByCategory<T extends { readonly type: AnnotationType }>(
+  items: readonly T[],
+): ReadonlyArray<{ readonly type: AnnotationType; readonly items: readonly T[] }> {
+  const buckets = new Map<AnnotationType, T[]>();
+  for (const it of items) {
+    const bucket = buckets.get(it.type);
+    if (bucket) bucket.push(it);
+    else buckets.set(it.type, [it]);
+  }
+  return ANNOTATION_TYPES.filter((t) => buckets.has(t)).map((t) => ({
+    type: t,
+    items: buckets.get(t)!,
+  }));
+}
+
 /** One spatial cluster of nearby annotations. */
 export interface AnnotationCluster {
   /** Mean of the members' local positions. */

--- a/src/style.css
+++ b/src/style.css
@@ -5006,6 +5006,29 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   background: var(--accent-soft); border-radius: var(--radius-xs); padding: 1px var(--space-sm);
 }
 .olv-ap-time { font-size: var(--text-2xs); color: var(--text-faint); flex-shrink: 0; }
+/* Category section header for the grouped (long) annotation list. A left rule in
+   the category's colour groups the rows beneath it; the count sits at the right. */
+.olv-ap-group {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin: var(--space-sm) 0 var(--space-2xs);
+  padding: 0 var(--space-xs) var(--space-2xs) var(--space-sm);
+  border-bottom: 1px solid var(--border-faint, rgba(255, 255, 255, 0.08));
+  border-left: 2px solid var(--text-faint);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+.olv-ap-group:first-child { margin-top: 0; }
+.olv-ap-group-count { font-variant-numeric: tabular-nums; opacity: 0.85; }
+.olv-ap-group.olv-anno-note { border-left-color: #5b9bd5; }
+.olv-ap-group.olv-anno-info { border-left-color: #22dcff; }
+.olv-ap-group.olv-anno-warning { border-left-color: var(--rating-good); }
+.olv-ap-group.olv-anno-issue { border-left-color: var(--rating-weak); }
 .olv-ap-edit {
   font-size: var(--text-2xs); color: var(--text-dim); font-family: var(--font);
   background: none; border: 0.5px solid var(--hairline);

--- a/src/ui/AnnotationPanel.ts
+++ b/src/ui/AnnotationPanel.ts
@@ -9,7 +9,7 @@
 import { el } from './dom';
 import type { AnnotationSummary } from '../render/annotate/AnnotationController';
 import type { AnnotationType } from '../render/annotate/types';
-import { describeAnnotationGroups } from '../render/annotate/annotationClustering';
+import { describeAnnotationGroups, groupByCategory } from '../render/annotate/annotationClustering';
 
 /** How the annotation list is ordered. */
 export type AnnotationSort = 'created' | 'updated' | 'type' | 'title';
@@ -37,6 +37,17 @@ const SORT_OPTIONS: { value: AnnotationSort; label: string }[] = [
 
 /** Type order for the "Type" sort — most actionable first. */
 const TYPE_RANK: Record<AnnotationType, number> = { issue: 0, warning: 1, info: 2, note: 3 };
+
+/** Capitalised section labels for the grouped (long) list. */
+const CATEGORY_LABEL: Record<AnnotationType, string> = {
+  issue: 'Issues',
+  warning: 'Warnings',
+  info: 'Info',
+  note: 'Notes',
+};
+
+/** Above this many rows the list splits into per-category sections. */
+const GROUP_THRESHOLD = 8;
 
 /** A short relative time, e.g. "just now", "4m ago", "2h ago", "3d ago". */
 function relativeTime(ts: number, now: number = Date.now()): string {
@@ -189,7 +200,31 @@ export class AnnotationPanel {
       return;
     }
     const sorted = sortSummaries(filtered, this._sort);
-    this._list.replaceChildren(...sorted.map((s) => this._row(s)));
+    // A short list reads fine flat; a long one splits into per-category sections
+    // (severity-first) so a dense roster is navigable instead of a wall of rows.
+    // Search + sort still apply — grouping partitions the already-filtered,
+    // already-sorted list and keeps each row's order within its section.
+    if (sorted.length > GROUP_THRESHOLD) {
+      const groups = [...groupByCategory(sorted)].sort(
+        (x, y) => TYPE_RANK[x.type] - TYPE_RANK[y.type],
+      );
+      const nodes: HTMLElement[] = [];
+      for (const g of groups) {
+        nodes.push(this._groupHeader(g.type, g.items.length));
+        for (const s of g.items) nodes.push(this._row(s));
+      }
+      this._list.replaceChildren(...nodes);
+    } else {
+      this._list.replaceChildren(...sorted.map((s) => this._row(s)));
+    }
+  }
+
+  /** A category section header for the grouped (long) list. */
+  private _groupHeader(type: AnnotationType, count: number): HTMLElement {
+    return el('div', { className: `olv-ap-group olv-anno-${type}` }, [
+      el('span', { className: 'olv-ap-group-label', text: CATEGORY_LABEL[type] }),
+      el('span', { className: 'olv-ap-group-count', text: String(count) }),
+    ]);
   }
 
   /** Whether a summary matches the current search query (title / note / type). */

--- a/tests/annotationClustering.test.ts
+++ b/tests/annotationClustering.test.ts
@@ -4,6 +4,7 @@ import {
   clusterAnnotations,
   suggestCellSize,
   describeAnnotationGroups,
+  groupByCategory,
   type ClusterableAnnotation,
 } from '../src/render/annotate/annotationClustering';
 import type { AnnotationType } from '../src/render/annotate/types';
@@ -94,6 +95,26 @@ describe('describeAnnotationGroups', () => {
 
   it('uses singular nouns for a single annotation', () => {
     expect(describeAnnotationGroups([a('issue', 0, 0)])).toBe('1 annotation');
+  });
+});
+
+describe('groupByCategory', () => {
+  it('partitions into non-empty buckets in display order, preserving within-group order', () => {
+    const items = [
+      a('issue', 1, 0), a('note', 2, 0), a('issue', 3, 0), a('warning', 4, 0), a('note', 5, 0),
+    ];
+    const groups = groupByCategory(items);
+    // Display order note, info, warning, issue — info is absent, so dropped.
+    expect(groups.map((g) => g.type)).toEqual(['note', 'warning', 'issue']);
+    // Input order is kept inside each bucket (notes captured at x 2 then 5).
+    expect(groups[0].items.map((i) => i.localPosition.x)).toEqual([2, 5]);
+    expect(groups[2].items.map((i) => i.localPosition.x)).toEqual([1, 3]);
+    // Every item lands in exactly one bucket.
+    expect(groups.reduce((n, g) => n + g.items.length, 0)).toBe(items.length);
+  });
+
+  it('returns an empty array for no items', () => {
+    expect(groupByCategory([])).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What
The pure grouping module (`annotationClustering.ts`) was shipped + tested but only fed a one-line summary; the panel rendered a **flat list** even for a dense roster. This makes a long list navigable.

- New pure, generic `groupByCategory()` — partitions in `ANNOTATION_TYPES` order, drops empty categories, **preserves within-group order** (so the caller's sort survives).
- Once the filtered+sorted list exceeds `GROUP_THRESHOLD` (8), the panel renders **severity-first** sections (Issues → Warnings → Info → Notes) with a coloured left rule + per-section count. Below the threshold: unchanged flat list.
- **Search + sort still apply** — grouping partitions the already-filtered, already-sorted list.

## Verification
tsc 0 · annotation suites **41/41** (2 new `groupByCategory` cases) · monolith-size + main-deferral green.

**Follow-ups:** browser spot-check (place 9+ mixed-type annotations → see grouped sections + confirm search/sort coherence); optional grouped PDF block in `ReportPdfRenderer` (the same helper serves it). No auto-merge.