### PR TITLE
Couple profile-station dots to chart/table hover

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2183,9 +2183,9 @@ const measurePanel = new MeasurePanel({
   // controller, which clamps the values, converts the metre corridor back to
   // render units, and emits a change so the panel re-renders with the values
   // that actually shaped the new chart.
-  onProfileResample: (id, params) => {
-    viewer.measure.resampleProfile(id, params);
-  },
+  onProfileResample: (id, params) => viewer.measure.resampleProfile(id, params),
+  // Profile-station hover → highlight the matching scene dot; repaint only when the dot changed.
+  onStationHover: (id, i) => { if (viewer.measure.setHoveredStation(id, i)) viewer.requestFrame(); },
 });
 
 // B2 (v0.4.5) — feed the measure stack the SAME render-units → metres seam

--- a/src/render/measure/MeasureController.ts
+++ b/src/render/measure/MeasureController.ts
@@ -73,7 +73,7 @@ import {
 // metres in `getSummaries` by the same module the panel/CSV/PDF read, so
 // labels and raw numerals can never drift apart.
 import { scaleProfileSamples } from './profileSummary';
-import { stationsAlongLine } from './profileStations';
+import { stationsAlongLine, type ProfileStation } from './profileStations';
 // B7/B8 (v0.4.5) — pure clamp + unit conversion for the resample path, read
 // from the sampler module so panel inputs, clamp and tests share one rule.
 // The encode/decode pair is the persistence seam: the user's last-applied
@@ -289,6 +289,15 @@ export interface MeasurementSummary {
   /** Profile only — the sampler's bare-earth percentile (dimensionless). */
   profileGroundPercentile?: number;
   /**
+   * Profile only — the cumulative chainages (in METRES, through the same B2
+   * factor the chart/table read) of the intermediate station dots drawn on the
+   * scene, in dot order. The panel uses these to couple a hovered chart tick or
+   * station-table row to the matching scene dot by nearest chainage: index `i`
+   * here is the same `i` the panel passes to `setHoveredStation`. Empty/absent
+   * for a degenerate or non-profile measurement.
+   */
+  profileStationChainages?: number[];
+  /**
    * Volume only — when true, the cut/fill record was sampled from
    * streaming resident nodes only. The panel surfaces a coverage caption
    * beneath the volume headline so the analyst understands the cubic
@@ -381,6 +390,15 @@ export class MeasureController {
   private _measurements: Measurement[] = [];
   /** The measurement currently being placed, if any. */
   private _draft: Measurement | null = null;
+  /**
+   * The one profile-station dot currently highlighted, as a pure
+   * `{ measurement id, dot index }` pair — never a DOM reference. Set by the
+   * panel when a profile-chart tick or station-table row is hovered, cleared on
+   * mouse-leave / panel re-render / panel close. A stale pair (a deleted
+   * measurement, or an index past the current dot count) simply matches nothing
+   * in `_appendMeasurement`, so it can never light the wrong dot.
+   */
+  private _activeStation: { id: string; index: number } | null = null;
   /** The active measurement kind new drafts are created as. */
   private _kind: MeasurementKind = 'distance';
   /** The live-preview point under the cursor, or null when off the cloud. */
@@ -862,9 +880,44 @@ export class MeasureController {
       profileCorridorWidthM:
         m.profileCorridorWidth != null ? m.profileCorridorWidth * f : undefined,
       profileGroundPercentile: m.profileGroundPercentile,
+      // Station-dot chainages in metres (× the same B2 factor as the samples),
+      // in dot order, so the panel can couple a hovered tick/row to the scene
+      // dot at the matching index. Only meaningful for profiles.
+      profileStationChainages:
+        m.kind === 'profile'
+          ? this._profileStations(m).map((s) => s.chainage * f)
+          : undefined,
       volumeResidentOnly: m.volumeResidentOnly,
       trust: m.trust,
     }));
+  }
+
+  /**
+   * Highlight a single profile-station dot on the scene, or clear the
+   * highlight. `index` indexes the intermediate station dots of measurement
+   * `id`, in the same order as `MeasurementSummary.profileStationChainages` —
+   * the panel resolves a hovered chart tick / table row to that index and calls
+   * this. Passing a null id or index (or an out-of-range index) clears the
+   * highlight; a stale pair simply matches no dot next frame.
+   *
+   * Returns `true` only when the active dot actually changed, so the host can
+   * skip a redraw request on a redundant hover event. The controller does not
+   * own the render loop — the caller pairs a `true` result with its own
+   * `requestFrame()`; the next rendered frame reprojects the overlay and the
+   * `is-active` class appears or clears.
+   */
+  setHoveredStation(id: string | null, index: number | null): boolean {
+    const next =
+      id != null && index != null && Number.isInteger(index) && index >= 0
+        ? { id, index }
+        : null;
+    const cur = this._activeStation;
+    const same =
+      (cur === null && next === null) ||
+      (cur !== null && next !== null && cur.id === next.id && cur.index === next.index);
+    if (same) return false;
+    this._activeStation = next;
+    return true;
   }
 
   /** Register a callback fired whenever the completed-measurement list changes. */
@@ -1735,6 +1788,22 @@ export class MeasureController {
     }
   }
 
+  /**
+   * The intermediate station dots of a profile measurement, in dot order —
+   * the single source both the scene dots (`_appendMeasurement`) and the
+   * panel-coupling chainages (`getSummaries`) read, so the two can never
+   * disagree on how many stations exist or where they sit. The endpoints carry
+   * their own vertices, so they are dropped (`slice(1, -1)`). Empty for a
+   * non-profile or horizontally-degenerate measurement.
+   */
+  private _profileStations(m: Measurement): ProfileStation[] {
+    if (m.kind !== 'profile' || m.points.length < 2) return [];
+    const [a, b] = m.points;
+    const horizontal = Math.hypot(b[0] - a[0], b[1] - a[1]);
+    if (horizontal <= 0) return [];
+    return stationsAlongLine({ a, b, intervalM: horizontal / 7 }).slice(1, -1);
+  }
+
   private _buildModel(): OverlayModel {
     const vertices: OverlayVertex[] = [];
     const edges: OverlayEdge[] = [];
@@ -1888,14 +1957,16 @@ export class MeasureController {
       // Station markers on the cloud — small dim dots at evenly-spaced
       // chainages along the section line, so the profile's stations are visible
       // in 3D, not just on the chart. The endpoints already carry their own
-      // vertices, so only the intermediate stations are drawn.
-      const horizontal = Math.hypot(b[0] - a[0], b[1] - a[1]);
-      if (horizontal > 0) {
-        const stations = stationsAlongLine({ a, b, intervalM: horizontal / 7 });
-        for (const s of stations.slice(1, -1)) {
-          V.push({ p: s.position, role: 'station' });
-        }
-      }
+      // vertices, so only the intermediate stations are drawn. The one dot whose
+      // (measurement, index) matches `_activeStation` brightens (`is-active`) —
+      // the scene half of the chart/table hover coupling.
+      this._profileStations(m).forEach((s, idx) => {
+        V.push({
+          p: s.position,
+          role: 'station',
+          active: this._activeStation?.id === m.id && this._activeStation.index === idx,
+        });
+      });
     }
     if (m.kind === 'volume' && pts.length >= MIN_POINTS.volume) {
       // Volume renders as the same closed polygon idiom as `area` — the

--- a/src/render/measure/MeasureOverlay.ts
+++ b/src/render/measure/MeasureOverlay.ts
@@ -36,6 +36,7 @@ const SNAPSHOT_CSS = [
   '.olv-measure-dot-pending{fill:none;stroke:#00b2ff;stroke-width:2.2}',
   '.olv-measure-dot-snap{fill:#00f0ff;stroke:#0a0e1a;stroke-width:1.65}',
   '.olv-measure-dot-station{fill:rgba(0,178,255,0.55);stroke:#0a0e1a;stroke-width:1}',
+  '.olv-measure-dot-station.is-active{fill:rgba(0,178,255,0.98);stroke:#0a0e1a;stroke-width:1.4}',
   '.olv-measure-snap-ring{fill:none;stroke:#00f0ff;stroke-width:1.4;stroke-dasharray:3 3;opacity:0.85}',
   '.olv-m-fill{fill:rgba(0,178,255,0.14);stroke:#00b2ff;stroke-width:1.45;stroke-dasharray:5 4}',
   '.olv-m-leader{stroke:rgba(0,178,255,0.5);stroke-width:1.1}',
@@ -59,6 +60,13 @@ export interface OverlayVertex {
   role: 'normal' | 'pending' | 'snap-target' | 'station';
   /** When set, this vertex is a draggable edit handle. */
   handle?: { mid: string; vi: number };
+  /**
+   * `station` role only — the profile-station marker currently coupled to a
+   * hovered chart tick / station-table row. Brightens the otherwise-dim dot
+   * via an `is-active` class. A pure display flag set by the controller from
+   * its single active-station index; the renderer never owns the state.
+   */
+  active?: boolean;
 }
 
 /** A line segment between two world points. */
@@ -208,7 +216,9 @@ export class MeasureOverlay {
               : vx.role === 'snap-target'
                 ? 'olv-measure-dot olv-measure-dot-snap'
                 : vx.role === 'station'
-                  ? 'olv-measure-dot olv-measure-dot-station'
+                  ? vx.active
+                    ? 'olv-measure-dot olv-measure-dot-station is-active'
+                    : 'olv-measure-dot olv-measure-dot-station'
                   : 'olv-measure-dot',
         }),
       );

--- a/src/style.css
+++ b/src/style.css
@@ -2548,6 +2548,20 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-measure-dot-snap {
   fill: var(--cyan, #00f0ff); stroke: #0a0e1a; stroke-width: 1.65;
 }
+/*
+ * Profile-station markers — the small dim dots at evenly-spaced chainages
+ * along a profile section line. Dim by default so they sit quietly under the
+ * measurement's own vertices; `.is-active` brightens the ONE dot coupled to a
+ * hovered profile-chart tick or station-table row. The dim base mirrors the
+ * inline `SNAPSHOT_CSS` in MeasureOverlay.ts so the live overlay and the
+ * screenshot export read identically — keep the two in sync.
+ */
+.olv-measure-dot-station {
+  fill: rgba(0, 178, 255, 0.55); stroke: #0a0e1a; stroke-width: 1;
+}
+.olv-measure-dot-station.is-active {
+  fill: rgba(0, 178, 255, 0.98); stroke: #0a0e1a; stroke-width: 1.4;
+}
 .olv-measure-snap-ring {
   fill: none;
   stroke: var(--cyan, #00f0ff);

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -272,6 +272,56 @@ export interface MeasurePanelCallbacks {
    * sampler controls are simply not rendered.
    */
   onProfileResample?: (id: string, params: ProfileResampleParams) => void;
+  /**
+   * Highlight (or clear) one scene profile-station dot as the reader hovers a
+   * profile-chart tick or station-table row. `stationIndex` indexes the dots of
+   * measurement `id` in `MeasurementSummary.profileStationChainages` order;
+   * `null` (with either argument) clears the highlight. Purely a display
+   * coupling — the host forwards it to the controller and requests a frame.
+   * Optional: without it the profile panel renders exactly as before, inert.
+   */
+  onStationHover?: (id: string | null, stationIndex: number | null) => void;
+}
+
+/**
+ * Coupling passed into the profile builders so a hovered chart tick / table
+ * row can brighten the matching scene dot. `stationChainages` are the scene
+ * dots' chainages (metres, dot order); `notify(i)` reports the resolved dot
+ * index (or null on leave) up to the panel's `onStationHover`.
+ */
+interface StationHoverCoupling {
+  readonly stationChainages: readonly number[];
+  readonly notify: (stationIndex: number | null) => void;
+}
+
+/** The scene dot whose chainage is nearest `target` (metres). Callers guard emptiness. */
+function nearestStationIndex(stationChainages: readonly number[], target: number): number {
+  let best = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < stationChainages.length; i++) {
+    const d = Math.abs(stationChainages[i] - target);
+    if (d < bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  }
+  return best;
+}
+
+/**
+ * Attach a symmetric hover coupling to one element: pointer-enter reports
+ * `stationIndex`, pointer-leave clears it. `mouseenter`/`mouseleave` don't
+ * bubble, so a leave always pairs with its own enter and the highlight can't
+ * get stuck when the pointer crosses between adjacent targets. The nodes are
+ * discarded whole on the next `_renderList`, taking these listeners with them.
+ */
+function bindStationHover(
+  node: EventTarget,
+  stationIndex: number,
+  coupling: StationHoverCoupling,
+): void {
+  node.addEventListener('mouseenter', () => coupling.notify(stationIndex));
+  node.addEventListener('mouseleave', () => coupling.notify(null));
 }
 
 export class MeasurePanel {
@@ -666,6 +716,10 @@ export class MeasurePanel {
 
   /** Show or hide the panel. */
   setVisible(visible: boolean): void {
+    // Hiding the panel can strand a station hover (no `mouseleave` fires on a
+    // now-hidden row), which would leave a scene dot lit; clear it on the way
+    // out. The host no-ops when nothing was highlighted.
+    if (!visible) this._cb.onStationHover?.(null, null);
     this.element.classList.toggle('olv-hidden', !visible);
   }
 
@@ -1018,6 +1072,11 @@ export class MeasurePanel {
 
   /** Internal — rebuild the list DOM from `_summaries`. */
   private _renderList(): void {
+    // Drop any live station-hover highlight BEFORE the old chart/table nodes are
+    // replaced: their `mouseleave` will never fire once detached, so without
+    // this an in-flight hover would leave a scene dot lit indefinitely. The
+    // host no-ops (and skips the frame) when nothing was highlighted.
+    this._cb.onStationHover?.(null, null);
     // Disconnect any ResizeObservers attached to the old chart
     // nodes BEFORE we drop those nodes on the floor. Otherwise
     // the observers keep their callbacks (and the chart elements
@@ -1132,7 +1191,17 @@ export class MeasurePanel {
         ? storedVex
         : 1;
       const system = this._cb.getUnitSystem ? this._cb.getUnitSystem() : 'metric';
-      const chart = renderProfileChart(s.profileChart, vex, system);
+      // Hover coupling: a chart tick or table row highlights the scene dot at
+      // the nearest chainage. Built once and shared by the chart and the table
+      // so both speak the same dot index. Absent (inert) when the host wired no
+      // `onStationHover`, or the profile has no intermediate station dots.
+      const onStationHover = this._cb.onStationHover;
+      const stationChainages = s.profileStationChainages ?? [];
+      const stationCoupling: StationHoverCoupling | undefined =
+        onStationHover && stationChainages.length > 0
+          ? { stationChainages, notify: (i) => onStationHover(s.id, i) }
+          : undefined;
+      const chart = renderProfileChart(s.profileChart, vex, system, stationCoupling);
       // The chart is where the eye lands, so it carries the primary "expand"
       // affordance: click (or Enter / Space) anywhere on it to open the whole
       // result in the shared focus surface. An always-visible corner badge marks
@@ -1333,6 +1402,8 @@ export class MeasurePanel {
         unitLabel,
         s.name,
         heightHeader,
+        stationCoupling,
+        s.profileChart.map((sample) => sample.distance),
       );
       const stationDetails = el('details', { className: 'olv-mp-stations' }, [
         el('summary', {
@@ -1530,6 +1601,8 @@ function buildStationTable(
   unitLabel: string,
   name: string,
   heightHeader = 'Elevation',
+  coupling?: StationHoverCoupling,
+  rowChainages?: readonly number[],
 ): { table: HTMLElement; build: () => void } {
   const headerCells = [
     'Station',
@@ -1544,23 +1617,31 @@ function buildStationTable(
   });
   const tbody = el('tbody');
   let built = false;
+  // Couple rows to scene dots only when the host wired the hover callback AND
+  // the per-row chainages are available to resolve each row to its nearest dot.
+  const couple = coupling && coupling.stationChainages.length > 0 ? coupling : undefined;
   const build = (): void => {
     if (built) return;
     built = true;
-    for (const r of stationRows) {
+    stationRows.forEach((r, i) => {
       // '' is an honest gap (blank in the CSV); the table shows an em dash so a
       // gap reads as "no data", not an empty cell.
       const dash = (v: string): string => (v === '' ? '—' : v);
-      tbody.append(
-        el('tr', {}, [
-          el('td', { className: 'olv-mp-stations-td', text: r.station }),
-          el('td', { className: 'olv-mp-stations-td', text: dash(r.chainage) }),
-          el('td', { className: 'olv-mp-stations-td', text: dash(r.elevation) }),
-          el('td', { className: 'olv-mp-stations-td', text: dash(r.points) }),
-          el('td', { className: 'olv-mp-stations-td', text: dash(r.grade) }),
-        ]),
-      );
-    }
+      const tr = el('tr', {}, [
+        el('td', { className: 'olv-mp-stations-td', text: r.station }),
+        el('td', { className: 'olv-mp-stations-td', text: dash(r.chainage) }),
+        el('td', { className: 'olv-mp-stations-td', text: dash(r.elevation) }),
+        el('td', { className: 'olv-mp-stations-td', text: dash(r.points) }),
+        el('td', { className: 'olv-mp-stations-td', text: dash(r.grade) }),
+      ]);
+      const chainage = rowChainages?.[i];
+      if (couple && chainage !== undefined && Number.isFinite(chainage)) {
+        const si = nearestStationIndex(couple.stationChainages, chainage);
+        tr.dataset.si = String(si);
+        bindStationHover(tr, si, couple);
+      }
+      tbody.append(tr);
+    });
   };
   const table = el(
     'table',
@@ -1574,6 +1655,7 @@ function renderProfileChart(
   samples: readonly { distance: number; height: number }[],
   vex: number,
   system: 'metric' | 'imperial',
+  coupling?: StationHoverCoupling,
 ): HTMLElement {
   // viewBox proportioned to the (taller-than-wide) chart box so that
   // `preserveAspectRatio="none"` barely distorts the text — the prior
@@ -1778,8 +1860,29 @@ function renderProfileChart(
     `<rect x="${plotLeft}" y="${plotTop}" width="${plotW}" height="${plotH}"/>` +
     `</clipPath></defs>`;
 
+  // Station hover coupling (optional): one transparent hit-zone per visible
+  // station tick, tiled to the midpoints of its neighbours so every x in the
+  // plot maps to exactly one tick. Each zone's `data-si` is the SCENE dot
+  // nearest that tick's chainage, so hovering the chart brightens the matching
+  // 3D marker. Zones stop at `plotBottom`, clear of the X labels and the native
+  // resize grip below. Rendered last so they sit above the grid/path for
+  // pointer-events; visually invisible (transparent fill).
+  let hitParts = '';
+  if (coupling && coupling.stationChainages.length > 0 && stations.length > 0) {
+    const tickX = stations.map((c) => plotLeft + (c / xSpan) * plotW);
+    hitParts = stations
+      .map((c, i) => {
+        const cx = tickX[i];
+        const left = i === 0 ? plotLeft : (tickX[i - 1] + cx) / 2;
+        const right = i === stations.length - 1 ? plotRight : (cx + tickX[i + 1]) / 2;
+        const si = nearestStationIndex(coupling.stationChainages, c);
+        return `<rect class="olv-mp-chart-hit" data-si="${si}" x="${left.toFixed(2)}" y="${plotTop}" width="${Math.max(0, right - left).toFixed(2)}" height="${plotH}" fill="transparent" pointer-events="all"/>`;
+      })
+      .join('');
+  }
+
   const svg = `<svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    ${clipDef}${minorGridParts}${majorGridParts}${yGridParts}${yAxisRules}${stationCaps}<g clip-path="url(#${clipId})">${pathParts}</g>
+    ${clipDef}${minorGridParts}${majorGridParts}${yGridParts}${yAxisRules}${stationCaps}<g clip-path="url(#${clipId})">${pathParts}</g>${hitParts}
   </svg>`;
 
   // ── HTML overlay: every numeral, in the brand mono with tabular figures,
@@ -1822,5 +1925,13 @@ function renderProfileChart(
     `${samples.length} samples · Δh ${formatLength(trueSpan, system)} · ` +
     `station interval ${formatChainage(stationInterval)} · vertical ${vexLabel} · ` +
     `drag bottom-right to resize`;
-  return el('div', { className: 'olv-mp-chart', unsafeHtml: svg + overlay, title });
+  const chartEl = el('div', { className: 'olv-mp-chart', unsafeHtml: svg + overlay, title });
+  if (hitParts) {
+    // The zones live in the just-assigned innerHTML; bind each to its `data-si`.
+    for (const hit of Array.from(chartEl.querySelectorAll('.olv-mp-chart-hit'))) {
+      const si = Number(hit.getAttribute('data-si'));
+      if (Number.isInteger(si) && si >= 0) bindStationHover(hit, si, coupling!);
+    }
+  }
+  return chartEl;
 }

--- a/tests/measurePanelStationHover.test.ts
+++ b/tests/measurePanelStationHover.test.ts
@@ -1,0 +1,259 @@
+/**
+ * measurePanelStationHover.test.ts
+ *
+ * The profile panel couples its station-table rows to the scene's profile-
+ * station dots: hovering a row asks the host to brighten the dot at the nearest
+ * chainage (`onStationHover(id, index)`), and leaving the row clears it
+ * (`onStationHover(id, null)`). The coupling is a PURE INDEX — the panel never
+ * touches the scene; it only reports which dot index the reader is pointing at.
+ *
+ * These tests pin, at the DOM level via the same recording stub the other panel
+ * tests use:
+ *   - a table row reports the dot whose chainage is nearest the row's sample,
+ *     and tags itself with that index (`data-si`);
+ *   - enter/leave are symmetric (leave always reports null);
+ *   - the highlight can't leak: a list re-render OR hiding the panel clears it,
+ *     because a detached/hidden row's `mouseleave` never fires;
+ *   - with no `onStationHover` wired (or no station dots) the rows stay inert.
+ *
+ * The profile CHART's hover zones live in `innerHTML` markup the node stub does
+ * not parse, so they are verified in the browser, not here.
+ */
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { MeasurePanel } from '../src/ui/MeasurePanel';
+import type { MeasurementSummary } from '../src/render/measure/MeasureController';
+import type { ProfileChartSample } from '../src/render/measure/types';
+
+type Handler = (e: unknown) => void;
+
+/** A recording DOM node covering only the surface MeasurePanel touches. */
+class FakeEl {
+  readonly tagName: string;
+  private _classes = new Set<string>();
+  textContent = '';
+  title = '';
+  value = '';
+  innerHTML = '';
+  open = false;
+  readonly dataset: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly children: FakeEl[] = [];
+  parent: FakeEl | null = null;
+  private readonly attrs = new Map<string, string>();
+  private readonly handlers = new Map<string, Handler[]>();
+  clientHeight = 0;
+  offsetWidth = 0;
+
+  constructor(tag: string) {
+    this.tagName = tag.toLowerCase();
+  }
+
+  set className(v: string) {
+    this._classes = new Set(String(v).split(/\s+/).filter(Boolean));
+  }
+  get className(): string {
+    return [...this._classes].join(' ');
+  }
+  get classList() {
+    const classes = this._classes;
+    return {
+      add: (c: string): void => void classes.add(c),
+      remove: (c: string): void => void classes.delete(c),
+      contains: (c: string): boolean => classes.has(c),
+      toggle: (c: string, force?: boolean): boolean => {
+        const want = force === undefined ? !classes.has(c) : force;
+        if (want) classes.add(c);
+        else classes.delete(c);
+        return want;
+      },
+    };
+  }
+
+  get lastElementChild(): FakeEl | null {
+    for (let i = this.children.length - 1; i >= 0; i--) {
+      if (this.children[i].tagName !== '#text') return this.children[i];
+    }
+    return null;
+  }
+
+  private _adopt(kid: unknown): FakeEl {
+    if (kid instanceof FakeEl) {
+      kid.parent = this;
+      return kid;
+    }
+    const t = new FakeEl('#text');
+    t.textContent = String(kid);
+    t.parent = this;
+    return t;
+  }
+  append(...kids: unknown[]): void {
+    for (const k of kids) this.children.push(this._adopt(k));
+  }
+  replaceChildren(...kids: unknown[]): void {
+    this.children.length = 0;
+    for (const k of kids) this.children.push(this._adopt(k));
+  }
+
+  setAttribute(n: string, v: string): void {
+    this.attrs.set(n, v);
+  }
+  getAttribute(n: string): string | null {
+    return this.attrs.get(n) ?? null;
+  }
+
+  addEventListener(type: string, fn: Handler): void {
+    const a = this.handlers.get(type) ?? [];
+    a.push(fn);
+    this.handlers.set(type, a);
+  }
+  removeEventListener(): void {
+    /* not exercised */
+  }
+  dispatchEvent(evt: { type: string }): boolean {
+    for (const fn of this.handlers.get(evt.type) ?? []) fn(evt);
+    return true;
+  }
+  focus(): void {}
+  blur(): void {}
+
+  /** `tag`, `.class`, or `tag.class` — the only selector shapes this panel uses. */
+  private _matches(sel: string): boolean {
+    const parts = sel.split('.');
+    const tag = parts[0];
+    if (tag && this.tagName !== tag.toLowerCase()) return false;
+    for (const c of parts.slice(1)) if (!this._classes.has(c)) return false;
+    return true;
+  }
+  querySelector(sel: string): FakeEl | null {
+    for (const c of this.children) {
+      if (c._matches(sel)) return c;
+      const deep = c.querySelector(sel);
+      if (deep) return deep;
+    }
+    return null;
+  }
+  querySelectorAll(sel: string): FakeEl[] {
+    const out: FakeEl[] = [];
+    const walk = (n: FakeEl): void => {
+      for (const c of n.children) {
+        if (c._matches(sel)) out.push(c);
+        walk(c);
+      }
+    };
+    walk(this);
+    return out;
+  }
+}
+
+/** No-op observer so the panel's resize-persistence path never warns or fires. */
+class FakeResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+beforeAll(() => {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.document = { createElement: (tag: string) => new FakeEl(tag) };
+  g.HTMLInputElement = class HTMLInputElement {};
+  g.HTMLAnchorElement = class HTMLAnchorElement {};
+  g.ResizeObserver = FakeResizeObserver;
+});
+
+const SAMPLE_COUNT = 10;
+/** Three scene dots at these chainages (metres), in dot order. */
+const STATION_CHAINAGES = [30, 60, 90];
+
+/** A profile summary with a dense sample series and a fixed station-dot set. */
+function profileSummary(withChainages = true): MeasurementSummary {
+  const profileChart: ProfileChartSample[] = [];
+  for (let i = 0; i < SAMPLE_COUNT; i++) {
+    // distances 0,10,20,…,90 — one lands exactly on each station chainage.
+    profileChart.push({ distance: i * 10, height: 100 + Math.sin(i / 3) * 4, count: 12 });
+  }
+  return {
+    id: 'p1',
+    kind: 'profile',
+    name: 'Section A',
+    value: '250.00 m',
+    profileChart,
+    profileStationChainages: withChainages ? [...STATION_CHAINAGES] : [],
+  };
+}
+
+interface Mounted {
+  panel: MeasurePanel;
+  onStationHover: ReturnType<typeof vi.fn>;
+  rows: () => FakeEl[];
+}
+
+/** Mount a profile panel and open the station table so its rows exist. */
+function mountOpened(withChainages = true, withCallback = true): Mounted {
+  const onStationHover = vi.fn();
+  const panel = new MeasurePanel({
+    onDelete: () => {},
+    onRename: () => {},
+    onExport: () => {},
+    onImport: () => {},
+    getUnitSystem: () => 'metric',
+    ...(withCallback ? { onStationHover } : {}),
+  });
+  panel.update([profileSummary(withChainages)]);
+  const root = panel.element as unknown as FakeEl;
+  const details = root.querySelector('details.olv-mp-stations')!;
+  details.open = true;
+  details.dispatchEvent({ type: 'toggle' }); // builds the rows
+  const tbody = details.querySelector('tbody')!;
+  return { panel, onStationHover, rows: () => tbody.querySelectorAll('tr') };
+}
+
+describe('MeasurePanel — station-table rows couple to scene dots by nearest chainage', () => {
+  it('tags each row with the nearest dot index', () => {
+    const { rows } = mountOpened();
+    // distance = i*10; nearest of [30,60,90].
+    const expected = [0, 0, 0, 0, 0, 1, 1, 1, 2, 2]; // i=0..9
+    const got = rows().map((r) => Number(r.dataset.si));
+    expect(got).toEqual(expected);
+  });
+
+  it('reports the dot index on enter and clears it on leave (symmetric)', () => {
+    const { rows, onStationHover } = mountOpened();
+    const row60 = rows()[6]; // distance 60 → dot index 1
+    onStationHover.mockClear();
+    row60.dispatchEvent({ type: 'mouseenter' });
+    expect(onStationHover).toHaveBeenLastCalledWith('p1', 1);
+    row60.dispatchEvent({ type: 'mouseleave' });
+    expect(onStationHover).toHaveBeenLastCalledWith('p1', null);
+  });
+
+  it('clears a live highlight when the list re-renders (detached row never leaves)', () => {
+    const { panel, rows, onStationHover } = mountOpened();
+    rows()[3].dispatchEvent({ type: 'mouseenter' }); // highlight is live
+    onStationHover.mockClear();
+    panel.update([profileSummary()]); // rebuild drops the hovered row
+    expect(onStationHover).toHaveBeenCalledWith(null, null);
+  });
+
+  it('clears a live highlight when the panel is hidden', () => {
+    const { panel, rows, onStationHover } = mountOpened();
+    rows()[8].dispatchEvent({ type: 'mouseenter' });
+    onStationHover.mockClear();
+    panel.setVisible(false);
+    expect(onStationHover).toHaveBeenCalledWith(null, null);
+  });
+
+  it('stays inert when the host wired no onStationHover', () => {
+    const { rows } = mountOpened(true, false);
+    // No coupling → no data-si tags at all.
+    expect(rows().every((r) => r.dataset.si === undefined)).toBe(true);
+  });
+
+  it('stays inert when the profile has no station dots', () => {
+    const { rows, onStationHover } = mountOpened(false, true);
+    expect(rows().every((r) => r.dataset.si === undefined)).toBe(true);
+    onStationHover.mockClear();
+    rows()[4].dispatchEvent({ type: 'mouseenter' });
+    expect(onStationHover).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Adds a hover highlight to the **existing** profile-station markers (the dim dots along a profile section line). Hovering a profile-chart tick or a station-table row brightens the matching scene dot; leaving clears it. No new 3D geometry — this is a highlight-state coupling on the markers already drawn.

## How

The coupling is a single active-station index owned by `MeasureController`:

- **`MeasureController`** — `_activeStation` (`{id, index}`, never a DOM ref); `setHoveredStation(id, index)` returns whether the highlighted dot actually changed (so the host skips a redraw on redundant hover events); `_profileStations(m)` is the one source both the scene dots (`_appendMeasurement`) and the new `MeasurementSummary.profileStationChainages` (metres, dot order) read, so the two can't disagree on how many stations exist or where they sit. A stale index (deleted measurement / out-of-range) simply matches no dot, so it can never light the wrong one.
- **`MeasureOverlay`** — `OverlayVertex.active` adds an `is-active` class to the matching station dot.
- **`style.css`** — adds the dim `.olv-measure-dot-station` base (it previously lived **only** in the `SNAPSHOT_CSS` mirror, so live dots never dimmed) plus `.olv-measure-dot-station.is-active`; the `is-active` rule is mirrored into `SNAPSHOT_CSS` so the live overlay and the screenshot export read identically.
- **`MeasurePanel`** — chart ticks and station-table rows resolve to the nearest scene dot by chainage and report it through a new `onStationHover` callback. Enter/leave are symmetric; the highlight is cleared on list re-render (`_renderList`) and on panel hide (`setVisible(false)`) so a detached/hidden row that never fires `mouseleave` can't strand a lit dot.
- **`main.ts`** — forwards `onStationHover` to `setHoveredStation` and calls `requestFrame()` only when the dot changed. Kept net-neutral so the monolith ratchet stays green.

## Design note

The chart ticks (`autoStationInterval`), the table rows (one per sample), and the scene dots (`stationsAlongLine`, interval = horizontal/7) are three independent station sets, so the coupling maps a hovered tick/row to the **nearest** scene dot by chainage. The stored coupling is a pure index; chainages are compared in metres on both sides.

## Verification

- `npx tsc --noEmit` -> 0 errors
- `npx vitest run` -> **exit 0**, 7850 passed / 20 skipped / 1 todo (602 files). Includes the new `tests/measurePanelStationHover.test.ts` (row->dot mapping, symmetric enter/leave, both leak-clears, inert no-callback/no-dots paths). The `verify:freeze-claims` console lines are about another change's `validation/.../S1.study.json` and are unrelated to this branch (that test passes at exit 0 in isolation).
- `node scripts/lint-monolith-size.mjs` -> exit 0 (`main.ts` at baseline)
- `node scripts/lint-main-deferral.mjs` -> exit 0

## Still pending

**Browser verification** on both GPU backends: confirm hovering a chart tick / table row brightens the matching scene dot (and that the dim->brighten reads correctly live). Not exercised here — the chart's hover zones live in `innerHTML` markup the node test stub does not parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
