### PR TITLE
Automatic classification: return-number cue (multi-return => vegetation)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -91,6 +91,7 @@ import type { ReclassifyUi } from './ui/reclassifyUi';
 import { countClasses } from './render/class/classHistogram';
 import { toClassBuffer } from './render/class/classBuffer';
 import { deriveClassificationAsync } from './render/class/deriveClassificationAsync';
+import { classifierCues } from './render/class/classifierCues';
 import {
   classificationCoverage,
   type DeriveClassificationOptions,
@@ -1693,8 +1694,7 @@ async function runDeriveClassification(): Promise<void> {
   }
   // RGB (when present) sharpens vegetation on photogrammetry, where geometry
   // alone is noisy — a green, locally-smooth canopy isn't mistaken for a roof.
-  const deriveOptions: DeriveClassificationOptions =
-    cloud.colors && cloud.colors.length > 0 ? { colors: cloud.colors } : {};
+  const deriveOptions = classifierCues(cloud);
 
   classifyRunning = true;
   showLassoToast('Classify · deriving ground / vegetation / building…');
@@ -1780,7 +1780,7 @@ async function runFillUnclassified(): Promise<void> {
   // Preserve the producer classes; RGB (when present) sharpens the filled gaps.
   const deriveOptions: DeriveClassificationOptions = {
     existingClassification: cloud.classification,
-    ...(cloud.colors && cloud.colors.length > 0 ? { colors: cloud.colors } : {}),
+    ...classifierCues(cloud),
   };
 
   classifyRunning = true;

--- a/src/render/class/classifierCues.ts
+++ b/src/render/class/classifierCues.ts
@@ -1,0 +1,40 @@
+/**
+ * src/render/class/classifierCues.ts
+ *
+ * Assemble the OPTIONAL per-point cues {@link deriveClassification} can consume
+ * from a cloud — RGB (greenness) and LAS return number/count (multi-return ⇒
+ * vegetation). Each is included only when it is actually present, so a bare XYZ
+ * cloud degrades to geometry-only. Pure: no mutation, no DOM. Kept out of
+ * main.ts so both the "Classify (derive)" and "Fill unclassified" call sites
+ * share one honest assembly, and so it is unit-testable.
+ */
+
+import type { DeriveClassificationOptions } from './deriveClassification';
+
+/** The cloud attributes the classifier can optionally consume. */
+export interface ClassifierCueSource {
+  readonly colors?: Uint8Array | Uint16Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+}
+
+/**
+ * Build the cue subset of {@link DeriveClassificationOptions} present on `cloud`.
+ * Returns `{}` for a bare XYZ cloud. Return number + count are included only as a
+ * PAIR — the multi-return cue needs both, so one without the other is dropped.
+ */
+export function classifierCues(cloud: ClassifierCueSource): DeriveClassificationOptions {
+  const hasColors = !!(cloud.colors && cloud.colors.length > 0);
+  const hasReturns = !!(
+    cloud.returnNumber &&
+    cloud.returnCount &&
+    cloud.returnNumber.length > 0 &&
+    cloud.returnCount.length > 0
+  );
+  return {
+    ...(hasColors ? { colors: cloud.colors } : {}),
+    ...(hasReturns
+      ? { returnNumber: cloud.returnNumber, returnCount: cloud.returnCount }
+      : {}),
+  };
+}

--- a/src/render/class/deriveClassification.ts
+++ b/src/render/class/deriveClassification.ts
@@ -135,6 +135,20 @@ export interface DeriveClassificationOptions {
    */
   readonly minGroundSupport?: number;
   /**
+   * Optional per-point LAS return number and total returns-per-pulse (same point
+   * order as `positions`). When BOTH are present, a TALL point from a
+   * MULTI-return pulse (`returnCount > 1`) is read as vegetation rather than a
+   * building: a solid roof reflects the whole pulse in a single return, so
+   * multiple returns mean the pulse penetrated a canopy. This is the strongest
+   * aerial veg-vs-structure cue and supplements the geometry + greenness the same
+   * way — it only rescues a tall SMOOTH patch from being mis-filed as a roof,
+   * never inventing vegetation where the geometry says ground. Either array
+   * absent or mis-sized ⇒ the cue is off and the result is byte-identical to the
+   * geometry(+colour)-only path.
+   */
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  /**
    * Optional producer classification to PRESERVE (same point order). Any point
    * whose existing code is a real producer class — anything other than
    * 0 (Created, never classified) or 1 (Unclassified) — keeps that code
@@ -520,6 +534,18 @@ export function deriveClassification(
   };
   const useGreen = colorStride >= 3;
 
+  // Optional return-number cue. A TALL point from a MULTI-return pulse
+  // (returnCount > 1) penetrated a canopy — a solid roof reflects the whole pulse
+  // in ONE return — so it reads as vegetation, not a building. The strongest
+  // aerial veg-vs-structure signal; supplements geometry + greenness the same
+  // way. Both arrays required and count-length; otherwise the cue is off.
+  const retNum = options.returnNumber;
+  const retCount = options.returnCount;
+  const useReturns = !!(
+    retNum && retCount && retNum.length >= count && retCount.length >= count
+  );
+  const vegByReturn = (i: number): boolean => retCount![i] > 1;
+
   // 6. Rule classification + per-point ground support.
   phase('Classifying');
   const codes = new Uint8Array(count);
@@ -554,7 +580,10 @@ export function deriveClassification(
         // photogrammetry, canopy is often locally smooth and would otherwise be
         // mistaken for a roof. Green ⇒ fall through to the vegetation bands.
         const green = useGreen && greenAt(i) >= o.vegGreennessMin;
-        if (planar && h >= o.buildingMinHagM && !green) {
+        // A multi-return pulse penetrated foliage — a solid roof would not. So a
+        // tall smooth patch that is multi-return is canopy, not a building.
+        const vegReturn = useReturns && vegByReturn(i);
+        if (planar && h >= o.buildingMinHagM && !green && !vegReturn) {
           code = DERIVED_BUILDING;
         } else if (h < o.lowVegBandM) {
           code = DERIVED_LOW_VEG;
@@ -641,6 +670,7 @@ export function deriveClassification(
 
   const modeNotes: string[] = [];
   if (useGreen) modeNotes.push('RGB vegetation index');
+  if (useReturns) modeNotes.push('multi-return vegetation cue');
   if (preserved) modeNotes.push('producer classes preserved (gaps only)');
   const modeSuffix = modeNotes.length > 0 ? ` (${modeNotes.join('; ')})` : '';
 

--- a/tests/classifierCues.test.ts
+++ b/tests/classifierCues.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { classifierCues } from '../src/render/class/classifierCues';
+
+describe('classifierCues', () => {
+  const colors = new Uint8Array([1, 2, 3]);
+  const returnNumber = new Uint8Array([1, 1]);
+  const returnCount = new Uint8Array([2, 1]);
+
+  it('a bare XYZ cloud yields no cues', () => {
+    expect(classifierCues({})).toEqual({});
+  });
+
+  it('includes colours when present', () => {
+    expect(classifierCues({ colors })).toEqual({ colors });
+  });
+
+  it('includes return number + count only as a pair', () => {
+    expect(classifierCues({ returnNumber, returnCount })).toEqual({ returnNumber, returnCount });
+  });
+
+  it('drops a lone return array — the cue needs both', () => {
+    expect(classifierCues({ returnNumber })).toEqual({});
+    expect(classifierCues({ returnCount })).toEqual({});
+  });
+
+  it('combines colours and returns', () => {
+    expect(classifierCues({ colors, returnNumber, returnCount })).toEqual({
+      colors,
+      returnNumber,
+      returnCount,
+    });
+  });
+
+  it('treats empty arrays as absent', () => {
+    expect(classifierCues({ colors: new Uint8Array(0) })).toEqual({});
+    expect(
+      classifierCues({ returnNumber: new Uint8Array(0), returnCount: new Uint8Array(0) }),
+    ).toEqual({});
+  });
+});

--- a/tests/deriveClassification.test.ts
+++ b/tests/deriveClassification.test.ts
@@ -372,3 +372,50 @@ describe('deriveClassification — void-aware confidence', () => {
     expect(res.confidence).toBeGreaterThan(0.5);
   });
 });
+
+describe('deriveClassification — multi-return vegetation cue', () => {
+  const scene = buildScene();
+  const n = scene.count;
+  const baseline = deriveClassification(scene.positions, n, { cellSizeM: 1 });
+
+  it('a multi-return smooth roof reads as vegetation, not a building', () => {
+    // Baseline (no return data): the smooth roof classifies as a building.
+    expect(frac(scene.buildingIdx, baseline.codes, DERIVED_BUILDING)).toBeGreaterThan(0.7);
+    // Mark every pulse as multi-return (returnCount = 2): a solid roof reflects
+    // the whole pulse in ONE return, so multi-return means the pulse penetrated
+    // foliage — the roof points now fall through to the vegetation bands.
+    const returnNumber = new Uint8Array(n).fill(1);
+    const returnCount = new Uint8Array(n).fill(2);
+    const res = deriveClassification(scene.positions, n, { cellSizeM: 1, returnNumber, returnCount });
+    const roofAsVeg =
+      frac(scene.buildingIdx, res.codes, DERIVED_HIGH_VEG) +
+      frac(scene.buildingIdx, res.codes, DERIVED_MED_VEG) +
+      frac(scene.buildingIdx, res.codes, DERIVED_LOW_VEG);
+    expect(roofAsVeg).toBeGreaterThan(0.7);
+    expect(frac(scene.buildingIdx, res.codes, DERIVED_BUILDING)).toBeLessThan(0.1);
+    // The cue only touches TALL points — ground below the band stays Ground.
+    expect(frac(scene.groundIdx, res.codes, DERIVED_GROUND)).toBeGreaterThan(0.9);
+    // Provenance discloses that return data informed the classification.
+    expect(res.provenance).toContain('multi-return');
+  });
+
+  it('single-return keeps the smooth roof a building (cue fires only on multi-return)', () => {
+    const returnNumber = new Uint8Array(n).fill(1);
+    const returnCount = new Uint8Array(n).fill(1);
+    const res = deriveClassification(scene.positions, n, { cellSizeM: 1, returnNumber, returnCount });
+    expect(frac(scene.buildingIdx, res.codes, DERIVED_BUILDING)).toBeGreaterThan(0.7);
+  });
+
+  it('needs BOTH return arrays — returnCount alone leaves the cue off', () => {
+    const returnCount = new Uint8Array(n).fill(2); // no returnNumber
+    const res = deriveClassification(scene.positions, n, { cellSizeM: 1, returnCount });
+    expect(frac(scene.buildingIdx, res.codes, DERIVED_BUILDING)).toBeGreaterThan(0.7);
+    expect(res.provenance).not.toContain('multi-return');
+  });
+
+  it('absent return data is byte-identical to the geometry-only path', () => {
+    const res = deriveClassification(scene.positions, n, { cellSizeM: 1 });
+    expect(Array.from(res.codes)).toEqual(Array.from(baseline.codes));
+    expect(res.provenance).not.toContain('multi-return');
+  });
+});


### PR DESCRIPTION
## What
The heuristic classifier was geometry(+RGB)-only; its documented failure mode is a tall **smooth** patch mis-filed as a building (real canopy, walls). This adds the canonical aerial discriminator: a tall point from a **multi-return** pulse (`returnCount > 1`) penetrated foliage — a solid roof reflects the whole pulse in one return — so it reads as vegetation, not a building. Same escape-hatch shape as the existing greenness cue: it only rescues a tall smooth patch from `building`, never invents vegetation where geometry says ground.

## How
- `deriveClassification`: optional `returnNumber`/`returnCount`; cue fires only when **both** present + count-length, else **byte-identical** to before. Provenance discloses `multi-return vegetation cue`.
- New pure `classifierCues.ts` assembles the optional cues a cloud carries (colours + returns); replaces the inline colour ternary at both classify sites in `main.ts` — **net-neutral** under the monolith ratchet.
- Worker structured-clones `options`, so returns thread across the boundary with **no worker/client change**; `returnNumber`/`returnCount` already resident on `PointCloud` — no loader work.

## Honesty / provenance
Clean-room from primary literature (canopy penetration / multiple echoes); no third-party code consulted. Result stays tagged `derived`, confidence-rated, never survey-grade.

## Verification
tsc 0 · **49 classifier tests** (multi-return roof→veg, single-return roof→building, one-array-only/absent→cue off, worker+async threading) · monolith-size + main-deferral green.

Follow-ups (this session): a standalone **Auto-classify** button (outside Analyse); the intensity + noise/water tiers. No auto-merge.