### PR TITLE
Include annotations on the map sheet by default when the scan has them

### DIFF
--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -2302,7 +2302,12 @@ export class AnalysePanel {
     const annoCheck = document.createElement('input');
     annoCheck.type = 'checkbox';
     annoCheck.className = 'olv-modal-check';
-    annoCheck.checked = false;
+    // Default ON when the scan actually has annotations, so a map sheet includes
+    // them without the user hunting for the toggle — the reported "annotations
+    // missing from the map sheet" was this box sitting unchecked. A scan with no
+    // annotations keeps the clean, byte-reproducible sheet: the option is
+    // disabled there, so `!disabled` leaves it off and unchanged.
+    annoCheck.checked = !annoState.disabled;
     annoCheck.disabled = annoState.disabled;
 
     const editable = el('div', { className: 'olv-modal-grid' });


### PR DESCRIPTION
## The bug
The map-sheet export's **Include annotations** checkbox defaulted to *unchecked* even when the scan had placed annotations. So placing annotations, running Analyse, and exporting the map sheet produced **neither markers nor the description table** — `includeAnnotations` reached `buildMapSheetPdf` as `false` and the entire annotation layer was skipped.

Verified against an exported sheet: **no markers *and* no annotation table**, which is the `includeAnnotations=false` signature (an off-map projection would still draw the table with an "N off map" note).

## The fix
`annoCheck.checked = !annoState.disabled` — **default ON when annotations exist**. A scan with none keeps the option *disabled*, so the flag stays off and the sheet is byte-identical to the pre-annotation output (the reproducibility the opt-in protected, preserved where it matters). Users can still untick for a deliberately clean sheet.

## Verification
tsc 0 · map-sheet export-options + annotation-projection suites **57/57** · monolith-size + main-deferral green. (For a single local z-up scan the annotation frame and contour bbox coincide, so once the flag is on the markers land in-extent.)