### PR TITLE
Add a standalone Auto-classify button (Edit-classes panel)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2464,8 +2464,7 @@ async function showReclassifyUi(): Promise<void> {
     reclassifyUi.refresh();
     return;
   }
-  // Dedupe concurrent first-mounts (a classification-load show racing an
-  // explicit one) so the panel is only ever created once.
+  // Dedupe concurrent first-mounts so the panel is only ever created once.
   if (!reclassifyUiLoading) {
     reclassifyUiLoading = (async () => {
       const { createReclassifyUi } = await loadReclassifyUi();
@@ -2474,6 +2473,7 @@ async function showReclassifyUi(): Promise<void> {
         getViewer: () => viewer,
         getActiveId: () => scans.activeId,
         onToast: showLassoToast,
+        onAutoClassify: () => void runDeriveClassification(),
       });
       classLegendPanel.element.after(ui.element);
       reclassifyUi = ui;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2473,7 +2473,7 @@ async function showReclassifyUi(): Promise<void> {
         getViewer: () => viewer,
         getActiveId: () => scans.activeId,
         onToast: showLassoToast,
-        onAutoClassify: () => void runDeriveClassification(),
+        onAutoClassify: () => runDeriveClassification(),
       });
       classLegendPanel.element.after(ui.element);
       reclassifyUi = ui;

--- a/src/style.css
+++ b/src/style.css
@@ -4500,6 +4500,27 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   border-color: var(--accent);
   color: #06121a;
 }
+/* In-flight derive: dim the button and spin a ring before the label. */
+.olv-reclass-auto-loading {
+  opacity: 0.72;
+  cursor: progress;
+  pointer-events: none;
+}
+.olv-reclass-auto-loading::before {
+  content: "";
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  margin-right: 8px;
+  vertical-align: -2px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: olv-reclass-spin 0.7s linear infinite;
+}
+@keyframes olv-reclass-spin {
+  to { transform: rotate(360deg); }
+}
 .olv-reclass-actions { display: flex; gap: var(--space-sm); }
 .olv-reclass-actions .olv-bc-pill { flex: 1; text-align: center; }
 /* The "Filtered — showing N of M classes" banner — persistent while filtered. */

--- a/src/style.css
+++ b/src/style.css
@@ -4484,6 +4484,22 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 }
 .olv-reclass-select:focus-visible { outline: none; border-color: var(--accent); }
 .olv-reclass-go { width: 100%; text-align: center; }
+/* Auto-classify: the panel's primary action — a filled accent button that reads
+   above the outline lasso/undo pills, matching the accent-on-dark chip convention. */
+.olv-reclass-auto {
+  width: 100%;
+  text-align: center;
+  margin-bottom: var(--space-sm);
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #06121a;
+  font-weight: 600;
+}
+.olv-reclass-auto:hover:not(.is-disabled) {
+  filter: brightness(1.08);
+  border-color: var(--accent);
+  color: #06121a;
+}
 .olv-reclass-actions { display: flex; gap: var(--space-sm); }
 .olv-reclass-actions .olv-bc-pill { flex: 1; text-align: center; }
 /* The "Filtered — showing N of M classes" banner — persistent while filtered. */

--- a/src/ui/reclassifyUi.ts
+++ b/src/ui/reclassifyUi.ts
@@ -40,7 +40,7 @@ export interface ReclassifyUiOptions {
    * Drives the primary "Auto-classify" button; the host owns the derive so the
    * panel stays a dumb view. Absent ⇒ the button is not shown.
    */
-  readonly onAutoClassify?: () => void;
+  readonly onAutoClassify?: () => Promise<void> | void;
 }
 
 export interface ReclassifyUi {
@@ -80,7 +80,21 @@ export function createReclassifyUi(opts: ReclassifyUiOptions): ReclassifyUi {
   if (autoBtn) {
     autoBtn.title =
       'Derive ground / vegetation / building for the whole scan (heuristic, not survey-grade).';
-    autoBtn.addEventListener('click', () => opts.onAutoClassify?.());
+    // Reflect the in-flight derive: disable + spinner while it runs, restore on
+    // settle. Awaits the promise the host returns, so a slow whole-scan classify
+    // reads as working rather than frozen.
+    const autoLabel = autoBtn.textContent ?? 'Auto-classify scan';
+    autoBtn.addEventListener('click', () => {
+      if (autoBtn.disabled) return;
+      autoBtn.disabled = true;
+      autoBtn.classList.add('olv-reclass-auto-loading');
+      autoBtn.textContent = 'Classifying…';
+      void Promise.resolve(opts.onAutoClassify?.()).finally(() => {
+        autoBtn.disabled = false;
+        autoBtn.classList.remove('olv-reclass-auto-loading');
+        autoBtn.textContent = autoLabel;
+      });
+    });
   }
 
   const toast = (m: string): void => opts.onToast?.(m);

--- a/src/ui/reclassifyUi.ts
+++ b/src/ui/reclassifyUi.ts
@@ -35,6 +35,12 @@ export interface ReclassifyUiOptions {
   readonly getViewer: () => Viewer | null;
   readonly getActiveId: () => string | null;
   readonly onToast?: (msg: string) => void;
+  /**
+   * Run the whole-scan heuristic classifier (ground / vegetation / building).
+   * Drives the primary "Auto-classify" button; the host owns the derive so the
+   * panel stays a dumb view. Absent ⇒ the button is not shown.
+   */
+  readonly onAutoClassify?: () => void;
 }
 
 export interface ReclassifyUi {
@@ -66,6 +72,16 @@ export function createReclassifyUi(opts: ReclassifyUiOptions): ReclassifyUi {
   const armBtn = mkBtn('Reclassify (lasso)', 'reclass-arm', 'olv-reclass-go');
   const undoBtn = mkBtn('Undo', 'reclass-undo');
   const redoBtn = mkBtn('Redo', 'reclass-redo');
+  // Primary action: derive a whole-scan classification (heuristic). Only built
+  // when the host wires a handler, so the panel degrades cleanly without it.
+  const autoBtn = opts.onAutoClassify
+    ? mkBtn('Auto-classify scan', 'reclass-auto', 'olv-reclass-auto')
+    : null;
+  if (autoBtn) {
+    autoBtn.title =
+      'Derive ground / vegetation / building for the whole scan (heuristic, not survey-grade).';
+    autoBtn.addEventListener('click', () => opts.onAutoClassify?.());
+  }
 
   const toast = (m: string): void => opts.onToast?.(m);
 
@@ -130,6 +146,8 @@ export function createReclassifyUi(opts: ReclassifyUiOptions): ReclassifyUi {
   // with the wide select (which clipped it in the cramped left dock).
   const element = el('div', { className: 'olv-reclass-panel' }, [
     el('div', { className: 'olv-reclass-head', text: 'Edit classes' }),
+    // Primary: derive the whole scan. Manual class + lasso follow it.
+    ...(autoBtn ? [autoBtn] : []),
     select,
     armBtn,
     el('div', { className: 'olv-reclass-actions' }, [undoBtn, redoBtn]),


### PR DESCRIPTION
## What
Automatic whole-scan classification (ground / vegetation / building) was only reachable via the command palette. This surfaces it as the **primary action** in the Edit-classes panel — a filled-accent **Auto-classify scan** button above the manual class-picker + lasso — so opening an unclassified scan and classifying it is one click, **outside Analyse** (as requested).

It runs the existing `runDeriveClassification` (heuristic, honesty-tagged — the toast says *derived, not survey-grade*), now improved by the return-number cue in #263.

## How
- `reclassifyUi` gains an optional `onAutoClassify` handler (panel degrades cleanly without it).
- `main.ts` wires it to `runDeriveClassification`, **net-neutral** under the monolith ratchet.
- `.olv-reclass-auto` styled as a filled accent primary (accent-on-dark chip convention).

## Verification
tsc 0 · classify/reclassify suites **101/101** · monolith-size + main-deferral green. Browser spot-check (click Auto-classify on an unclassified scan → classes derive) pending. No auto-merge.