### PR TITLE
Emit the classifier worker chunk in the obfuscated build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,13 @@ function liveSourceTransformPlugin() {
       /eptLaszipWorkerClient\.ts/,
       /terrainCoreWorkerClient\.ts/,
       /computeTerrainCoreAsync\.ts/,
+      // The classifier mirrors the terrain-core pair above: the client holds
+      // `new Worker(new URL('./deriveClassificationWorker.ts', …))` and the async
+      // bridge holds `import('./deriveClassificationWorkerClient')`. Obfuscating
+      // either scrambles the specifier, so the worker chunk never emits and the
+      // dynamic import 404s at runtime (`vite:preloadError` → a full reload).
+      /deriveClassificationWorkerClient\.ts/,
+      /deriveClassificationAsync\.ts/,
       /lazyChunks\.ts/,
       /parseBuffer\.ts/,
       /loaderRegistry\.ts/,
@@ -276,11 +283,13 @@ function chunkEmissionGuard() {
     'copcWorker',
     'eptLaszipWorker',
     'terrainCoreWorker',
+    'deriveClassificationWorker',
     // Dynamic imports living inside OTHER excluded modules (not lazyChunks.ts):
     // `computeTerrainCoreAsync.ts` lazy-imports the terrain worker client;
     // `loadLas.ts` lazy-imports `lazDecode` (laz-perf JS + embedded WASM) so
     // uncompressed `.las` files never download the decompressor.
     'terrainCoreWorkerClient',
+    'deriveClassificationWorkerClient',
     'lazDecode',
     // Vendor chunks pinned via manualChunks. The presence of these
     // chunks proves the manualChunks rule is still active — losing them


### PR DESCRIPTION
## Problem

In the obfuscated packaged build, clicking **Auto-classify scan** reloaded the whole app back to the landing page and dropped the loaded scan.

Root cause: the classifier worker was never registered in the two hand-maintained lists in `vite.config.ts` that every other worker uses —

- the obfuscator `exclude` (so `new Worker(new URL('./deriveClassificationWorker.ts', import.meta.url))` stays statically analysable), and
- the chunk-emission pin list.

Obfuscating `deriveClassificationWorkerClient` scrambled the worker specifier, so the `deriveClassificationWorker` chunk never emitted. At runtime the dynamic import 404'd, Vite fired `vite:preloadError`, and stale-chunk recovery called `location.reload()` — the reload users saw. `deriveClassificationAsync`'s main-thread fallback can't prevent it, because the reload is triggered by the global preload-error event, not by the caught rejection.

This only reproduces in the obfuscated `--mode live` build (the packaged deploy), not in dev or the plain build.

## Fix

Register the classifier trio mirroring the existing terrain-core trio (`computeTerrainCoreAsync` → `terrainCoreWorkerClient` → `terrainCoreWorker`):

- obfuscator `exclude`: `deriveClassificationWorkerClient.ts`, `deriveClassificationAsync.ts`
- emission pins: `deriveClassificationWorker`, `deriveClassificationWorkerClient`

## Verification

`build:live` (the obfuscated pipeline) now emits `deriveClassificationWorker-*.js` with its `onmessage`/`postMessage` intact, and the client chunk references it. The chunk-emission guard fails the build if either chunk regresses, so this stays covered.
