### PR TITLE
Fail closed on unknown CRS units at three metric surfaces

### DIFF
--- a/src/app/inspectorCardRefreshers.ts
+++ b/src/app/inspectorCardRefreshers.ts
@@ -11,6 +11,7 @@
 // thin factory that captures the inspector once. Call sites destructure the
 // returned object and otherwise behave exactly as before.
 import type { Inspector } from '../ui/Inspector';
+import { isLinearUnitKnown } from '../geo/CoordinateTypes';
 import { classify as classifyProvenance } from '../diagnostics/provenance';
 import {
   signalsForStaticCloud,
@@ -36,7 +37,7 @@ export interface InspectorCardRefreshers {
   refreshDatasetIntelligenceFromStaticCloud(cloud: {
     readonly pointCount: number;
     readonly declaredPointCount?: number;
-    readonly metadata?: { crs?: { linearUnitToMetres?: number; verticalUnitToMetres?: number } | null };
+    readonly metadata?: { crs?: { linearUnit?: string; linearUnitToMetres?: number; verticalUnitToMetres?: number } | null };
     bounds(): { min: [number, number, number]; max: [number, number, number] };
   }): void;
   /** Push a cheap Dataset Intelligence summary from a streaming cloud's header. */
@@ -48,7 +49,7 @@ export interface InspectorCardRefreshers {
         readonly max?: readonly [number, number, number] | number[];
       };
     };
-    crs?(): { linearUnitToMetres?: number; verticalUnitToMetres?: number } | null;
+    crs?(): { linearUnit?: string; linearUnitToMetres?: number; verticalUnitToMetres?: number } | null;
   }): void;
   /**
    * Fold a real analysed-point count from a finished terrain run into the
@@ -71,6 +72,35 @@ export interface InspectorCardRefreshers {
    * complexity) naturally resets the row.
    */
   noteTerrainComplexity(derived: DerivedComplexity | null): void;
+}
+
+/**
+ * The bounding-box volume in cubic METRES, or `undefined` when the CRS declares
+ * no usable linear unit. FAIL CLOSED: an unknown-unit CRS carries the inert
+ * placeholder `linearUnitToMetres: 1`, so converting with it would feed raw
+ * source-unit³ (feet³, degrees³) into the per-m³ density bucketing and mis-tier
+ * the scan — `classifyDensity` renders "—" for an absent volume, which is the
+ * honest state. Two axes are horizontal (×linear), one vertical (×vertical); the
+ * scalar factor mpu²·vmpu is order-independent. Shared by the static and
+ * streaming refreshers so the two paths can never diverge (see
+ * `tests/benchmark/unitIntegrity.test.ts`).
+ */
+function metresCubedBbox(
+  dx: number,
+  dy: number,
+  dz: number,
+  crs:
+    | { readonly linearUnit?: string; readonly linearUnitToMetres?: number; readonly verticalUnitToMetres?: number }
+    | null
+    | undefined,
+): number | undefined {
+  if (!isLinearUnitKnown(crs)) return undefined;
+  const mpu = crs?.linearUnitToMetres;
+  if (!Number.isFinite(mpu) || (mpu as number) <= 0) return undefined;
+  const vmpuRaw = crs?.verticalUnitToMetres ?? mpu;
+  if (!Number.isFinite(vmpuRaw) || (vmpuRaw as number) <= 0) return undefined;
+  const v = dx * dy * dz * (mpu as number) * (mpu as number) * (vmpuRaw as number);
+  return Number.isFinite(v) && v > 0 ? v : undefined;
 }
 
 /**
@@ -124,7 +154,7 @@ export function createInspectorCardRefreshers(
   function refreshDatasetIntelligenceFromStaticCloud(cloud: {
     readonly pointCount: number;
     readonly declaredPointCount?: number;
-    readonly metadata?: { crs?: { linearUnitToMetres?: number; verticalUnitToMetres?: number } | null };
+    readonly metadata?: { crs?: { linearUnit?: string; linearUnitToMetres?: number; verticalUnitToMetres?: number } | null };
     bounds(): { min: [number, number, number]; max: [number, number, number] };
   }): void {
     // A static summary supersedes any remembered streaming one.
@@ -138,9 +168,14 @@ export function createInspectorCardRefreshers(
       // a state-plane-FEET tile is otherwise ~35× under-dense and a genuine QL1
       // survey grades "sparse". Two axes are horizontal (×linear), one vertical
       // (×vertical); the scalar factor mpu²·vmpu is order-independent.
-      const mpu = cloud.metadata?.crs?.linearUnitToMetres ?? 1;
-      const vmpu = cloud.metadata?.crs?.verticalUnitToMetres ?? mpu;
-      const bboxVolume = dx * dy * dz * mpu * mpu * vmpu;
+      //
+      // FAIL CLOSED on the unit: a cubic-metre volume is only computed when the
+      // CRS declares a REAL linear unit. An unknown-unit CRS carries the inert
+      // placeholder factor 1, so multiplying by it would feed raw source-unit³
+      // (feet³, degrees³) into the per-m³ bucketing and mis-tier the density.
+      // When the unit is unconfirmed, `bboxVolume` is left undefined and
+      // `classifyDensity` renders "—" rather than a wrong tier.
+      const bboxVolume = metresCubedBbox(dx, dy, dz, cloud.metadata?.crs);
       // Density numerator is the file's declared total, back-scaled when the
       // loader strided for display — matching the Scan Report, not the smaller
       // in-memory sample that would under-report the tier.
@@ -148,7 +183,7 @@ export function createInspectorCardRefreshers(
       const n = declared !== undefined && declared > cloud.pointCount ? declared : cloud.pointCount;
       const summary: Parameters<Inspector['setDatasetIntelligence']>[0] = {
         pointCount: n,
-        bboxVolume: Number.isFinite(bboxVolume) && bboxVolume > 0 ? bboxVolume : undefined,
+        bboxVolume,
         coverageMeta: {
           coverage: 'full',
           sourcePointCount: n,
@@ -183,7 +218,7 @@ export function createInspectorCardRefreshers(
         readonly max?: readonly [number, number, number] | number[];
       };
     };
-    crs?(): { linearUnitToMetres?: number; verticalUnitToMetres?: number } | null;
+    crs?(): { linearUnit?: string; linearUnitToMetres?: number; verticalUnitToMetres?: number } | null;
   }): void {
     try {
       const sourcePoints = cloud.sourcePointCount;
@@ -197,12 +232,11 @@ export function createInspectorCardRefreshers(
         // Cubic METRES, for the same reason the static path above converts: a
         // state-plane-feet tile's header box is 35.31x larger in raw units, so
         // the per-m³ bucketing dropped a genuine QL1 survey a whole tier. The
-        // header carries source units; the CRS carries the factors.
-        const crs = cloud.crs?.() ?? null;
-        const mpu = crs?.linearUnitToMetres ?? 1;
-        const vmpu = crs?.verticalUnitToMetres ?? mpu;
-        const v = dx * dy * dz * mpu * mpu * vmpu;
-        if (Number.isFinite(v) && v > 0) bboxVolume = v;
+        // header carries source units; the CRS carries the factors. FAIL CLOSED
+        // on the unit exactly as the static path does — an unknown-unit CRS
+        // leaves `bboxVolume` undefined rather than feeding raw feet³ / degrees³
+        // into the per-m³ bucketing.
+        bboxVolume = metresCubedBbox(dx, dy, dz, cloud.crs?.() ?? null);
       }
       const summary = {
         pointCount: sourcePoints,

--- a/src/app/openStreaming.ts
+++ b/src/app/openStreaming.ts
@@ -410,6 +410,9 @@ export async function openStreamingCopc(
     // explicit format tag so the Scan Intelligence panel renders
     // "COPC LAZ · PDRF N" for COPC and "EPT · binary · N attrs" for EPT.
     format: 'copc',
+    // Carry the CRS so the spacing row states its unit honestly (metre / foot→m
+    // / source units / geographic) instead of unconditionally labelling "m".
+    crs: cloud.crs(),
   });
   deps.bookmarks.clear();
   deps.refreshViewsUI();
@@ -627,6 +630,9 @@ export async function handleRemoteEpt(
       nodeCount: cloud.octree.nodes().length,
       format: 'ept',
       schemaSummary,
+      // EPT's resolution row is a node budget (crs-independent), but carry the
+      // CRS anyway for shape parity with the COPC path.
+      crs: cloud.crs(),
     });
 
     // Was: body class + navBar only, which left the dock hidden — so an EPT

--- a/src/app/reportExport.ts
+++ b/src/app/reportExport.ts
@@ -29,6 +29,8 @@
  */
 
 import { footprintMetres } from '../report/reportFootprint';
+import type { Footprint } from '../report/reportFootprint';
+import { isLinearUnitKnown } from '../geo/CoordinateTypes';
 import { isZUpFormat } from '../io/sniffFormat';
 import { increment as recordUsage } from '../diagnostics/usageCounters';
 import { classify as classifyProvenance } from '../diagnostics/provenance';
@@ -90,6 +92,35 @@ export function reportPointCount(
  */
 export function isNonTerrainVerdict(verdict: SpaceKind | null): boolean {
   return verdict === 'object' || verdict === 'interior';
+}
+
+/**
+ * The extent-carrying subset of {@link MetadataInputs}, mapped from a
+ * {@link Footprint}. A confirmed footprint carries metre extents + a pts·m⁻²
+ * density (byte-identical to the historical build). An unconfirmed footprint
+ * carries the RAW source-unit spans, a NaN density (so the density row / QL
+ * grading is omitted), and the `extentUnitStatus: 'unknown'` flag that makes the
+ * dataset summary print a "units unconfirmed — extents in source units" warning
+ * instead of a metre label.
+ */
+export function footprintToMetadataExtent(
+  fp: Footprint,
+): Pick<MetadataInputs, 'width' | 'depth' | 'height' | 'density' | 'extentUnitStatus'> {
+  if (fp.unitStatus === 'confirmed') {
+    return {
+      width: fp.widthMetres,
+      depth: fp.depthMetres,
+      height: fp.heightMetres,
+      density: fp.densityPerM2,
+    };
+  }
+  return {
+    width: fp.widthSourceUnits,
+    depth: fp.depthSourceUnits,
+    height: fp.heightSourceUnits,
+    density: Number.NaN,
+    extentUnitStatus: 'unknown',
+  };
 }
 
 /**
@@ -189,15 +220,21 @@ export async function generateReportPdf(templateId: string, deps: ReportExportDe
     const crs = streamingCloud.crs();
     // Footprint + density in metres / pts·m⁻², not raw CRS units (see
     // reportFootprint): a foot-CRS scan would otherwise overstate the headline
-    // area ~10.76× and be graded against the wrong USGS Quality Level.
-    const { width: wM, depth: dM, height: hM, density } = footprintMetres({
+    // area ~10.76× and be graded against the wrong USGS Quality Level. FAIL
+    // CLOSED on an unconfirmed unit: an unknown-unit CRS carries the inert
+    // placeholder factor, so `isLinearUnitKnown` gates whether the report may
+    // claim metres at all — otherwise the extents are emitted in source units
+    // with no density and a "units unconfirmed" warning row.
+    const fp = footprintMetres({
       extentX: b[3] - b[0], extentY: b[4] - b[1], extentZ: b[5] - b[2],
       pointCount: streamingCloud.sourcePointCount,
       linearUnitToMetres: crs?.linearUnitToMetres,
       verticalUnitToMetres: crs?.verticalUnitToMetres,
+      linearUnitKnown: isLinearUnitKnown(crs),
       // COPC and EPT are Z-up by spec.
       zUp: true,
     });
+    const ext = footprintToMetadataExtent(fp);
     const modes = streamingCloud.availableColorModes();
     // Streaming-preview accounting — how much of the cloud is resident at
     // export time. Surfaced as a "Loaded" row so the PDF discloses that a
@@ -208,7 +245,7 @@ export async function generateReportPdf(templateId: string, deps: ReportExportDe
       fileName: streamingCloud.name,
       format: streamingCloud.kind === 'ept' ? 'EPT' : 'COPC',
       sourcePointCount: streamingCloud.sourcePointCount,
-      width: wM, depth: dM, height: hM, density,
+      ...ext,
       hasRgb: modes.includes('rgb'),
       hasIntensity: modes.includes('intensity'),
       hasClassification: modes.includes('classification'),
@@ -233,21 +270,24 @@ export async function generateReportPdf(templateId: string, deps: ReportExportDe
     const crs = staticCloud.metadata?.crs;
     // Footprint + density in metres / pts·m⁻² (see reportFootprint): a foot-CRS
     // scan would otherwise overstate area ~10.76× and be graded against the
-    // wrong USGS Quality Level.
-    const { width: wM, depth: dM, height: hM, density } = footprintMetres({
+    // wrong USGS Quality Level. FAIL CLOSED on an unconfirmed unit — see the
+    // streaming path above.
+    const fp = footprintMetres({
       extentX: b.max[0] - b.min[0], extentY: b.max[1] - b.min[1], extentZ: b.max[2] - b.min[2],
       pointCount: fileN,
       linearUnitToMetres: crs?.linearUnitToMetres,
       verticalUnitToMetres: crs?.verticalUnitToMetres,
+      linearUnitKnown: isLinearUnitKnown(crs),
       // Mesh formats load Y-up, so the PDF reads the same axes as the
       // on-screen Scan Report rather than assuming Z.
       zUp: isZUpFormat(staticCloud.sourceFormat),
     });
+    const ext = footprintToMetadataExtent(fp);
     metadata = {
       fileName: staticCloud.name,
       format: staticCloud.sourceFormat.toUpperCase(),
       sourcePointCount: fileN,
-      width: wM, depth: dM, height: hM, density,
+      ...ext,
       hasRgb: !!staticCloud.colors,
       hasIntensity: !!staticCloud.intensity,
       hasClassification: !!staticCloud.classification,

--- a/src/io/session.ts
+++ b/src/io/session.ts
@@ -81,7 +81,15 @@ export interface SessionScanSummary {
   fileName: string;
   /** Source point count. */
   sourcePoints: number;
-  /** Source extents in metres: width × depth × height. */
+  /**
+   * Source extents in the scan's OWN CRS linear units (width × depth × height) —
+   * NOT metres. The writer stores the raw bounding-box spans (`b.max - b.min`)
+   * with no unit conversion, so a foot-CRS scan records feet here. The unit is
+   * disclosed by {@link crsUnit}; a metre value is never asserted. These raw
+   * spans are what `matchSessionToScan` compares (`extentRelDiff`), so the
+   * stored values must stay unconverted — this is a documentation correction
+   * only, not a value change.
+   */
   width: number;
   depth: number;
   height: number;

--- a/src/report/ReportFindings.ts
+++ b/src/report/ReportFindings.ts
@@ -109,8 +109,15 @@ function usgsQlApplies(provenance: ReportProvenanceFingerprint | undefined): boo
   return provenance.bounds.some((b) => /\bQL\b|USGS/i.test(b.label));
 }
 
-/** Footprint area in m² from width × depth, or NaN when either is unknown. */
+/**
+ * Footprint area in m² from width × depth, or NaN when the area is not a
+ * confirmed metric quantity. FAILS CLOSED on an unconfirmed linear unit: when
+ * the CRS declares no real unit, `width`/`depth` are raw source-unit spans, so
+ * multiplying them would yield a source-unit² figure the report must NOT present
+ * as m² — the coverage finding reads "unknown extent" instead.
+ */
 function footprintAreaM2(metadata: MetadataInputs): number {
+  if (metadata.extentUnitStatus === 'unknown') return Number.NaN;
   const { width, depth } = metadata;
   if (!Number.isFinite(width) || !Number.isFinite(depth)) return Number.NaN;
   return width * depth;

--- a/src/report/ReportMetadataSection.ts
+++ b/src/report/ReportMetadataSection.ts
@@ -30,6 +30,18 @@ export interface MetadataInputs {
   readonly crsName?: string;
   readonly crsUnit?: string;
   /**
+   * Whether the extent figures above are in confirmed metres. Absent (or
+   * `'confirmed'`) means `width`/`depth`/`height` are metres and `density` is
+   * pts·m⁻² — the summary is byte-identical to the pre-feature output. When
+   * `'unknown'`, the CRS declares no real linear unit: `width`/`depth`/`height`
+   * are RAW SOURCE-UNIT spans and `density` is NaN, so the summary prints the
+   * extents with a "source units" suffix, omits the density row, and adds a
+   * visible "units unconfirmed" warning rather than stamping metres on feet /
+   * degrees. Set by `footprintToMetadataExtent` behind the `isLinearUnitKnown`
+   * gate.
+   */
+  readonly extentUnitStatus?: 'confirmed' | 'unknown';
+  /**
    * Active class-filter scope stamp — e.g. `"Ground + Building · 2 of 5
    * classes"`. Present ONLY while a class filter narrows the live view at
    * export time. When set, the dataset-summary table prepends an honesty row
@@ -66,6 +78,16 @@ function formatMetres(m: number): string {
   if (m >= 10) return `${m.toFixed(1)} m`;
   if (m >= 1) return `${m.toFixed(2)} m`;
   return `${(m * 100).toFixed(1)} cm`;
+}
+
+/**
+ * Format a raw source-unit extent — used when the CRS declares no real linear
+ * unit. No km/m/cm scaling and no "m" label: the magnitude's unit is unknown,
+ * so the value is shown verbatim with an explicit "(source units)" suffix.
+ */
+function formatSourceUnits(n: number): string {
+  if (!Number.isFinite(n)) return 'unknown';
+  return `${n.toFixed(1)} (source units)`;
 }
 
 /** Pretty-format an integer point count with locale separators. */
@@ -126,11 +148,29 @@ export function buildDatasetSummary(inputs: MetadataInputs): readonly ReportData
       value: `${formatCompactCount(sr.points)} of ${formatCompactCount(total)} pts${pctPart} — streaming preview`,
     });
   }
-  rows.push(
-    { label: 'Width',  value: formatMetres(inputs.width) },
-    { label: 'Depth',  value: formatMetres(inputs.depth) },
-    { label: 'Height', value: formatMetres(inputs.height) },
-  );
+  // FAIL CLOSED on an unconfirmed linear unit. When the CRS declares no real
+  // linear unit the extents are raw source-unit spans, not metres — a warning
+  // row discloses that, the extents carry a "(source units)" suffix instead of
+  // "m", and the density row is omitted (density is NaN, caught below). A
+  // confirmed unit (or the absent default) is byte-identical to before.
+  const unitsUnconfirmed = inputs.extentUnitStatus === 'unknown';
+  if (unitsUnconfirmed) {
+    rows.push({
+      label: 'Units',
+      value: 'Unconfirmed — extents in source units',
+    });
+    rows.push(
+      { label: 'Width',  value: formatSourceUnits(inputs.width) },
+      { label: 'Depth',  value: formatSourceUnits(inputs.depth) },
+      { label: 'Height', value: formatSourceUnits(inputs.height) },
+    );
+  } else {
+    rows.push(
+      { label: 'Width',  value: formatMetres(inputs.width) },
+      { label: 'Depth',  value: formatMetres(inputs.depth) },
+      { label: 'Height', value: formatMetres(inputs.height) },
+    );
+  }
   if (Number.isFinite(inputs.density) && inputs.density > 0) {
     // One decimal — same as the Inspection-summary finding and the on-screen
     // panel. Integer rounding printed 2.586 as "3", disagreeing with them.
@@ -142,7 +182,9 @@ export function buildDatasetSummary(inputs: MetadataInputs): readonly ReportData
   if (inputs.crsName) {
     rows.push({ label: 'CRS',   value: inputs.crsName });
   }
-  if (inputs.crsUnit) {
+  // The dedicated "Units — Unconfirmed …" warning above already states the unit
+  // status, so skip the redundant `crsUnit` row (which would read "unknown").
+  if (!unitsUnconfirmed && inputs.crsUnit) {
     rows.push({ label: 'Units', value: inputs.crsUnit });
   }
   return rows;

--- a/src/report/reportFootprint.ts
+++ b/src/report/reportFootprint.ts
@@ -25,6 +25,17 @@ export interface FootprintInput {
   /** Vertical unit → metres, when the source declares one distinct from horizontal. */
   readonly verticalUnitToMetres?: number;
   /**
+   * Whether the source CRS declares a REAL linear unit — the fail-closed gate
+   * (`isLinearUnitKnown` at the call site). `false` when the CRS is absent or
+   * carries `linearUnit: 'unknown'` (the inert `linearUnitToMetres: 1`
+   * placeholder). When `false` the footprint is returned in RAW SOURCE UNITS
+   * with no metre / pts·m⁻² claim — multiplying a source span by the placeholder
+   * 1 and stamping "m" would report feet (or degrees) as metres. Matches the
+   * on-screen Scan Report (`scanReportUnitBasis`) and streaming report
+   * (`streamingExtentRows`) gates.
+   */
+  readonly linearUnitKnown: boolean;
+  /**
    * Whether the source frame is Z-up. LAS-family, COPC and EPT are Z-up by
    * spec; PLY, OBJ and glTF load in their native Y-up frame, where Y carries
    * height and Z carries ground depth. Defaults to `true`, so a caller that
@@ -40,32 +51,80 @@ export interface FootprintInput {
   readonly zUp?: boolean;
 }
 
-export interface FootprintMetres {
+/**
+ * A footprint whose CRS declares a real linear unit: extents in metres and a
+ * density in pts·m⁻² the report may print with its "m" / "pts/m²" suffixes.
+ */
+export interface FootprintConfirmed {
+  readonly unitStatus: 'confirmed';
   /** Width (X) in metres. */
-  readonly width: number;
-  /** Depth (Y) in metres. */
-  readonly depth: number;
-  /** Height (Z) in metres. */
-  readonly height: number;
+  readonly widthMetres: number;
+  /** Depth in metres. */
+  readonly depthMetres: number;
+  /** Height in metres. */
+  readonly heightMetres: number;
   /** Footprint density in pts·m⁻² on the XY footprint; NaN when extent is degenerate. */
-  readonly density: number;
+  readonly densityPerM2: number;
 }
 
 /**
- * Project a raw bounding-box extent into metres + pts·m⁻². A missing or
- * non-finite unit factor falls back to 1 (treat the source as metres) so a
- * unit-less cloud degrades to today's behaviour rather than NaN.
+ * A footprint whose CRS does NOT declare a real linear unit. The spans are the
+ * RAW source-unit extents; there is no metre value and no density, because
+ * converting an unknown unit to metres (or grading pts·m⁻²) would assert a
+ * conversion nobody performed. The report renders these with a "source units"
+ * label and an explicit "units unconfirmed" warning instead of "m" / "pts/m²".
  */
-export function footprintMetres(input: FootprintInput): FootprintMetres {
-  const uH = Number.isFinite(input.linearUnitToMetres) ? (input.linearUnitToMetres as number) : 1;
-  const uV = Number.isFinite(input.verticalUnitToMetres) ? (input.verticalUnitToMetres as number) : uH;
+export interface FootprintUnknownUnit {
+  readonly unitStatus: 'unknown';
+  /** Width (X) span in raw source units. */
+  readonly widthSourceUnits: number;
+  /** Depth span in raw source units. */
+  readonly depthSourceUnits: number;
+  /** Height span in raw source units. */
+  readonly heightSourceUnits: number;
+}
+
+/** Discriminated on {@link FootprintConfirmed.unitStatus} vs {@link FootprintUnknownUnit.unitStatus}. */
+export type Footprint = FootprintConfirmed | FootprintUnknownUnit;
+
+/**
+ * Project a raw bounding-box extent into a footprint, FAILING CLOSED on an
+ * unconfirmed linear unit.
+ *
+ * When `linearUnitKnown` is true the extents are converted to metres with the
+ * declared unit factors and a pts·m⁻² density is computed — the historical,
+ * byte-identical behaviour for a real CRS. When it is false the CRS carries no
+ * usable linear unit (absent, or the `linearUnit: 'unknown'` placeholder whose
+ * `linearUnitToMetres` is the inert 1), so the raw source-unit spans are
+ * returned with NO metre value and NO density: stamping "m" / "pts/m²" on a
+ * source span would report feet (or degrees) as metres. This mirrors the gate
+ * the on-screen Scan Report (`scanReportUnitBasis`) and the streaming Scan
+ * Report (`streamingExtentRows`) already apply.
+ */
+export function footprintMetres(input: FootprintInput): Footprint {
   // Width is X in both conventions. The other two swap: Z-up puts depth in Y
   // and height in Z, Y-up puts height in Y and depth in Z. The vertical factor
   // follows the height, never the slot.
   const zUp = input.zUp ?? true;
-  const width = input.extentX * uH;
-  const depth = (zUp ? input.extentY : input.extentZ) * uH;
-  const height = (zUp ? input.extentZ : input.extentY) * uV;
-  const density = width > 0 && depth > 0 ? input.pointCount / (width * depth) : Number.NaN;
-  return { width, depth, height, density };
+  const spanWidth = input.extentX;
+  const spanDepth = zUp ? input.extentY : input.extentZ;
+  const spanHeight = zUp ? input.extentZ : input.extentY;
+
+  if (!input.linearUnitKnown) {
+    return {
+      unitStatus: 'unknown',
+      widthSourceUnits: spanWidth,
+      depthSourceUnits: spanDepth,
+      heightSourceUnits: spanHeight,
+    };
+  }
+
+  const uH = Number.isFinite(input.linearUnitToMetres) ? (input.linearUnitToMetres as number) : 1;
+  const uV = Number.isFinite(input.verticalUnitToMetres) ? (input.verticalUnitToMetres as number) : uH;
+  const widthMetres = spanWidth * uH;
+  const depthMetres = spanDepth * uH;
+  const heightMetres = spanHeight * uV;
+  const densityPerM2 =
+    widthMetres > 0 && depthMetres > 0 ? input.pointCount / (widthMetres * depthMetres) : Number.NaN;
+  return { unitStatus: 'confirmed', widthMetres, depthMetres, heightMetres, densityPerM2 };
 }

--- a/src/ui/StreamingPanel.ts
+++ b/src/ui/StreamingPanel.ts
@@ -16,6 +16,21 @@ import { formatCount } from './dom';
 import { formatByteSize as formatBytes } from '../io/formatByteSize';
 import type { ColorMode } from '../render/colorModes';
 import type { StreamingQuality } from '../render/streaming/streamingBudget';
+import type { CrsLinearUnit } from '../io/crs';
+
+/**
+ * The CRS facts the spacing row needs to state its unit honestly — a structural
+ * subset of `CrsInfo`, so `cloud.crs()` (which returns a full `CrsInfo`) is
+ * assignable without coupling the panel to the loader's shape.
+ */
+export interface SpacingCrs {
+  /** Horizontal linear unit. `'unknown'` / absent ⇒ spacing shown in source units. */
+  readonly linearUnit?: CrsLinearUnit;
+  /** Linear unit → metres factor (1 metre, ~0.3048 foot). Used to convert feet to m. */
+  readonly linearUnitToMetres?: number;
+  /** Geographic (degrees) CRS — a linear spacing is undefined. */
+  readonly isGeographic?: boolean;
+}
 
 /** Live status numbers for the panel. */
 export interface StreamingStatus {
@@ -49,6 +64,13 @@ export interface StreamingScanSummary {
   format?: 'copc' | 'ept';
   /** EPT-only: schema summary string for the Format row. */
   schemaSummary?: string;
+  /**
+   * Source CRS, when known — carried so the COPC `spacing` row can state its
+   * unit honestly (metre / foot→m / source units / geographic) instead of
+   * unconditionally labelling the CRS-unit distance "m". Absent ⇒ the unit is
+   * unconfirmed and the spacing is shown in source units.
+   */
+  crs?: SpacingCrs | null;
 }
 
 /** Callbacks the panel raises. */
@@ -98,17 +120,26 @@ function formatDim(n: number): string {
 /**
  * Label + value for the resolution row of the scan summary.
  *
- * COPC's metadata `spacing` is a METRIC root-node point spacing (CRS units —
- * metres for the usual projected scans), so it reads as "1.20 m". EPT's `span`
- * is a DIMENSIONLESS points-per-tile budget (the octree resolution analogue),
- * NOT a distance — feeding it into the same bare "Spacing" row read as "128 m"
- * of spacing, a label-vs-value drift. EPT therefore gets its own "Node budget"
- * label and a "pts/node" value so the number is never mistaken for a distance.
+ * COPC's metadata `spacing` is a METRIC root-node point spacing in the dataset's
+ * CRS units. EPT's `span` is a DIMENSIONLESS points-per-tile budget (the octree
+ * resolution analogue), NOT a distance — feeding it into the same bare "Spacing"
+ * row read as "128 m" of spacing, a label-vs-value drift. EPT therefore gets its
+ * own "Node budget" label and a "pts/node" value so the number is never mistaken
+ * for a distance.
+ *
+ * The COPC spacing FAILS CLOSED on its unit, the same gate the rest of the
+ * platform applies: it is only labelled "m" when the CRS declares a metre unit;
+ * a foot CRS is converted to metres, a geographic CRS has no linear spacing at
+ * all, and an unknown / absent unit is shown in raw source units rather than
+ * stamped "m". Previously the value was unconditionally suffixed " m", so a
+ * state-plane-FEET COPC read ~3.28× too large mislabelled as metres.
+ *
  * Pure + DOM-free so the decision is unit-tested without standing up the panel.
  */
 export function spacingRowFor(
   format: 'copc' | 'ept' | undefined,
   spacing: number,
+  crs?: SpacingCrs | null,
 ): { readonly label: string; readonly value: string; readonly title: string } {
   if (format === 'ept') {
     return {
@@ -117,10 +148,39 @@ export function spacingRowFor(
       title: 'EPT octree resolution — target points per node, not a metric spacing.',
     };
   }
+  // COPC: spacing is a root-node point spacing in the dataset's CRS units.
+  if (crs?.isGeographic) {
+    // Degrees of longitude are not a linear distance; a "spacing in metres"
+    // would be latitude-dependent and is not defined here.
+    return {
+      label: 'Spacing',
+      value: '— (geographic CRS)',
+      title: 'Spacing is not a linear distance for a geographic (degrees) CRS.',
+    };
+  }
+  if (crs?.linearUnit === 'metre') {
+    return {
+      label: 'Spacing',
+      value: `${spacing.toFixed(2)} m`,
+      title: 'Root-node point spacing in metres.',
+    };
+  }
+  if (crs?.linearUnit === 'foot' || crs?.linearUnit === 'us-survey-foot') {
+    // Spacing is in feet; convert to metres so the number is comparable.
+    const factor = crs.linearUnitToMetres;
+    const metres = Number.isFinite(factor) ? spacing * (factor as number) : spacing;
+    return {
+      label: 'Spacing',
+      value: `${metres.toFixed(2)} m`,
+      title: 'Root-node point spacing, converted from the source foot unit to metres.',
+    };
+  }
+  // Unknown / absent linear unit — fail closed: show the raw source figure and
+  // do NOT claim metres.
   return {
     label: 'Spacing',
-    value: `${spacing.toFixed(2)} m`,
-    title: 'Root-node point spacing in the dataset’s CRS units.',
+    value: `${spacing.toFixed(2)} (source units)`,
+    title: 'Linear unit unconfirmed — spacing shown in the source CRS units, not metres.',
   };
 }
 
@@ -425,7 +485,7 @@ export class StreamingPanel {
       // budget. `spacingRowFor` labels + units each correctly so neither is
       // misread (see its doc-comment for the label-vs-value drift it fixes).
       (() => {
-        const r = spacingRowFor(summary.format, summary.spacing);
+        const r = spacingRowFor(summary.format, summary.spacing, summary.crs);
         return this._statRow(r.label, this._value(r.value, r.title));
       })(),
       this._statRow(

--- a/tests/benchmark/unitIntegrity.test.ts
+++ b/tests/benchmark/unitIntegrity.test.ts
@@ -722,6 +722,7 @@ describe('unit integrity: axis convention', () => {
       pointCount: POINTS,
       linearUnitToMetres: 1,
       verticalUnitToMetres: 1,
+      linearUnitKnown: true,
       zUp: true,
     });
     const yUp = footprintMetres({
@@ -731,12 +732,16 @@ describe('unit integrity: axis convention', () => {
       pointCount: POINTS,
       linearUnitToMetres: 1,
       verticalUnitToMetres: 1,
+      linearUnitKnown: true,
       zUp: false,
     });
-    expect(Math.abs(yUp.width - zUp.width)).toBeLessThan(LENGTH_METRES_TOL);
-    expect(Math.abs(yUp.depth - zUp.depth)).toBeLessThan(LENGTH_METRES_TOL);
-    expect(Math.abs(yUp.height - zUp.height)).toBeLessThan(LENGTH_METRES_TOL);
-    expect(relDiff(yUp.density, zUp.density)).toBeLessThan(DENSITY_RELATIVE_TOL);
+    if (zUp.unitStatus !== 'confirmed' || yUp.unitStatus !== 'confirmed') {
+      throw new Error('expected confirmed footprints');
+    }
+    expect(Math.abs(yUp.widthMetres - zUp.widthMetres)).toBeLessThan(LENGTH_METRES_TOL);
+    expect(Math.abs(yUp.depthMetres - zUp.depthMetres)).toBeLessThan(LENGTH_METRES_TOL);
+    expect(Math.abs(yUp.heightMetres - zUp.heightMetres)).toBeLessThan(LENGTH_METRES_TOL);
+    expect(relDiff(yUp.densityPerM2, zUp.densityPerM2)).toBeLessThan(DENSITY_RELATIVE_TOL);
   });
 
   /**
@@ -753,11 +758,13 @@ describe('unit integrity: axis convention', () => {
       pointCount: POINTS,
       linearUnitToMetres: 1,
       verticalUnitToMetres: M_PER_FT,
+      linearUnitKnown: true,
       zUp: false,
     });
-    expect(Math.abs(yUp.height - Y_UP_EXTENTS.y * M_PER_FT)).toBeLessThan(LENGTH_METRES_TOL);
-    expect(Math.abs(yUp.depth - Y_UP_EXTENTS.z)).toBeLessThan(LENGTH_METRES_TOL);
-    expect(relDiff(yUp.density, POINTS / (Y_UP_EXTENTS.x * Y_UP_EXTENTS.z))).toBeLessThan(
+    if (yUp.unitStatus !== 'confirmed') throw new Error('expected confirmed footprint');
+    expect(Math.abs(yUp.heightMetres - Y_UP_EXTENTS.y * M_PER_FT)).toBeLessThan(LENGTH_METRES_TOL);
+    expect(Math.abs(yUp.depthMetres - Y_UP_EXTENTS.z)).toBeLessThan(LENGTH_METRES_TOL);
+    expect(relDiff(yUp.densityPerM2, POINTS / (Y_UP_EXTENTS.x * Y_UP_EXTENTS.z))).toBeLessThan(
       DENSITY_RELATIVE_TOL,
     );
   });
@@ -774,11 +781,13 @@ describe('unit integrity: axis convention', () => {
       pointCount: POINTS,
       linearUnitToMetres: M_PER_FT,
       verticalUnitToMetres: M_PER_FT,
+      linearUnitKnown: true,
       zUp: true,
     });
-    expect(Math.abs(f.width - 30 * M_PER_FT)).toBeLessThan(LENGTH_METRES_TOL);
-    expect(Math.abs(f.depth - 40 * M_PER_FT)).toBeLessThan(LENGTH_METRES_TOL);
-    expect(Math.abs(f.height - 8 * M_PER_FT)).toBeLessThan(LENGTH_METRES_TOL);
+    if (f.unitStatus !== 'confirmed') throw new Error('expected confirmed footprint');
+    expect(Math.abs(f.widthMetres - 30 * M_PER_FT)).toBeLessThan(LENGTH_METRES_TOL);
+    expect(Math.abs(f.depthMetres - 40 * M_PER_FT)).toBeLessThan(LENGTH_METRES_TOL);
+    expect(Math.abs(f.heightMetres - 8 * M_PER_FT)).toBeLessThan(LENGTH_METRES_TOL);
   });
 
   /**
@@ -880,7 +889,10 @@ describe('unit integrity: cross-path agreement', () => {
    * classifier agreeing proves nothing if one caller feeds it raw feet.
    */
   test('the static and streaming refreshers agree on the density tier for one foot-CRS box', () => {
-    const crs = { linearUnitToMetres: M_PER_FT, verticalUnitToMetres: M_PER_FT };
+    // A real foot CRS declares its linear unit; the refreshers now fail closed
+    // on an unknown unit, so the fixture must name it (an under-specified crs
+    // with only a factor is treated as unconfirmed and yields no bboxVolume).
+    const crs = { linearUnit: 'foot' as const, linearUnitToMetres: M_PER_FT, verticalUnitToMetres: M_PER_FT };
     // A 100 x 100 x 20 m box, expressed in feet.
     const minFt: [number, number, number] = [0, 0, 0];
     const maxFt: [number, number, number] = [100 / M_PER_FT, 100 / M_PER_FT, 20 / M_PER_FT];

--- a/tests/reportFootprint.test.ts
+++ b/tests/reportFootprint.test.ts
@@ -1,7 +1,9 @@
 /**
- * reportFootprint.test.ts — the raw-extent → metres/pts·m⁻² conversion the
- * report metadata is contracted to carry. Guards the foot-CRS bug: area must
- * not be printed ~10.76× too large, and density must be graded in pts·m⁻².
+ * reportFootprint.test.ts — the raw-extent → footprint conversion the report
+ * metadata is contracted to carry. Guards the foot-CRS bug: area must not be
+ * printed ~10.76× too large, and density must be graded in pts·m⁻². Also guards
+ * the fail-closed contract: an unconfirmed linear unit yields raw source-unit
+ * spans with NO metre value and NO density, never a source span stamped "m".
  */
 
 import { describe, it, expect } from 'vitest';
@@ -9,50 +11,93 @@ import { footprintMetres } from '../src/report/reportFootprint';
 
 const FT = 0.3048; // US/international foot → metre
 
-describe('footprintMetres', () => {
+describe('footprintMetres — confirmed unit', () => {
   it('passes a metre CRS through unchanged (factor 1)', () => {
     const f = footprintMetres({
       extentX: 100, extentY: 50, extentZ: 20, pointCount: 5000,
-      linearUnitToMetres: 1,
+      linearUnitToMetres: 1, linearUnitKnown: true,
     });
-    expect(f.width).toBeCloseTo(100, 6);
-    expect(f.depth).toBeCloseTo(50, 6);
-    expect(f.height).toBeCloseTo(20, 6);
-    expect(f.density).toBeCloseTo(5000 / (100 * 50), 6); // 1 pt/m²
+    expect(f.unitStatus).toBe('confirmed');
+    if (f.unitStatus !== 'confirmed') throw new Error('unreachable');
+    expect(f.widthMetres).toBeCloseTo(100, 6);
+    expect(f.depthMetres).toBeCloseTo(50, 6);
+    expect(f.heightMetres).toBeCloseTo(20, 6);
+    expect(f.densityPerM2).toBeCloseTo(5000 / (100 * 50), 6); // 1 pt/m²
   });
 
   it('converts a foot CRS to metres and pts·m⁻²', () => {
     // 100 ft × 50 ft footprint. In metres: 30.48 × 15.24 = 464.5 m² (NOT 5000).
     const f = footprintMetres({
       extentX: 100, extentY: 50, extentZ: 20, pointCount: 5000,
-      linearUnitToMetres: FT,
+      linearUnitToMetres: FT, linearUnitKnown: true,
     });
-    expect(f.width).toBeCloseTo(30.48, 4);
-    expect(f.depth).toBeCloseTo(15.24, 4);
-    expect(f.height).toBeCloseTo(20 * FT, 4);
+    if (f.unitStatus !== 'confirmed') throw new Error('expected confirmed');
+    expect(f.widthMetres).toBeCloseTo(30.48, 4);
+    expect(f.depthMetres).toBeCloseTo(15.24, 4);
+    expect(f.heightMetres).toBeCloseTo(20 * FT, 4);
     // Density in pts/m² is the raw pts/ft² scaled up by 1/0.3048² ≈ 10.76.
     const area_m2 = 100 * FT * (50 * FT);
-    expect(f.density).toBeCloseTo(5000 / area_m2, 6);
-    expect(f.density / (5000 / (100 * 50))).toBeCloseTo(1 / (FT * FT), 4); // ~10.76×
+    expect(f.densityPerM2).toBeCloseTo(5000 / area_m2, 6);
+    expect(f.densityPerM2 / (5000 / (100 * 50))).toBeCloseTo(1 / (FT * FT), 4); // ~10.76×
   });
 
   it('honours a distinct vertical unit for height only', () => {
     const f = footprintMetres({
       extentX: 100, extentY: 50, extentZ: 10, pointCount: 1,
       linearUnitToMetres: FT, verticalUnitToMetres: 1, // height already in metres
+      linearUnitKnown: true,
     });
-    expect(f.width).toBeCloseTo(30.48, 4); // horizontal still feet→m
-    expect(f.height).toBeCloseTo(10, 6);   // vertical untouched
-  });
-
-  it('falls back to factor 1 when the unit is missing (unit-less cloud)', () => {
-    const f = footprintMetres({ extentX: 10, extentY: 10, extentZ: 2, pointCount: 400 });
-    expect(f.width).toBeCloseTo(10, 6);
-    expect(f.density).toBeCloseTo(4, 6);
+    if (f.unitStatus !== 'confirmed') throw new Error('expected confirmed');
+    expect(f.widthMetres).toBeCloseTo(30.48, 4); // horizontal still feet→m
+    expect(f.heightMetres).toBeCloseTo(10, 6);   // vertical untouched
   });
 
   it('returns NaN density for a degenerate (zero-extent) footprint', () => {
-    const f = footprintMetres({ extentX: 0, extentY: 50, extentZ: 5, pointCount: 100, linearUnitToMetres: 1 });
-    expect(Number.isNaN(f.density)).toBe(true);
+    const f = footprintMetres({
+      extentX: 0, extentY: 50, extentZ: 5, pointCount: 100,
+      linearUnitToMetres: 1, linearUnitKnown: true,
+    });
+    if (f.unitStatus !== 'confirmed') throw new Error('expected confirmed');
+    expect(Number.isNaN(f.densityPerM2)).toBe(true);
+  });
+});
+
+describe('footprintMetres — fail closed on an unconfirmed unit', () => {
+  it('emits raw source-unit spans with NO metre value and NO density', () => {
+    // The old fail-OPEN behaviour multiplied by the placeholder factor 1 and
+    // stamped "m" on a unit-less cloud. It must now report source units.
+    const f = footprintMetres({
+      extentX: 10, extentY: 8, extentZ: 2, pointCount: 400,
+      linearUnitKnown: false,
+    });
+    expect(f.unitStatus).toBe('unknown');
+    if (f.unitStatus !== 'unknown') throw new Error('unreachable');
+    expect(f.widthSourceUnits).toBeCloseTo(10, 6);
+    expect(f.depthSourceUnits).toBeCloseTo(8, 6);
+    expect(f.heightSourceUnits).toBeCloseTo(2, 6);
+    // There is no density and no metre field on the unknown shape.
+    expect('densityPerM2' in f).toBe(false);
+    expect('widthMetres' in f).toBe(false);
+  });
+
+  it('ignores any unit factor present when the unit is not confirmed', () => {
+    // A placeholder linearUnitToMetres must not sneak a conversion in.
+    const f = footprintMetres({
+      extentX: 100, extentY: 50, extentZ: 20, pointCount: 5000,
+      linearUnitToMetres: 1, linearUnitKnown: false,
+    });
+    if (f.unitStatus !== 'unknown') throw new Error('expected unknown');
+    expect(f.widthSourceUnits).toBe(100); // raw span, not "×1 metres"
+  });
+
+  it('honours the up axis for the source-unit spans (Y-up depth/height swap)', () => {
+    const f = footprintMetres({
+      extentX: 30, extentY: 8, extentZ: 40, pointCount: 1,
+      linearUnitKnown: false, zUp: false, // Y carries height, Z carries depth
+    });
+    if (f.unitStatus !== 'unknown') throw new Error('expected unknown');
+    expect(f.widthSourceUnits).toBe(30);
+    expect(f.depthSourceUnits).toBe(40); // Z is depth when Y-up
+    expect(f.heightSourceUnits).toBe(8); // Y is height when Y-up
   });
 });

--- a/tests/reportMetadataUnits.test.ts
+++ b/tests/reportMetadataUnits.test.ts
@@ -1,0 +1,102 @@
+/**
+ * reportMetadataUnits.test.ts
+ *
+ * The report's dataset summary and inspection findings FAIL CLOSED on an
+ * unconfirmed linear unit. When the CRS declares no real linear unit the PDF
+ * must NOT present source-unit spans as metres or grade a source-unit² area /
+ * density: the extents read "(source units)", the density row is omitted, a
+ * "units unconfirmed" warning appears, and the coverage finding reads "unknown
+ * extent". A confirmed unit is byte-identical to the pre-feature output.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildDatasetSummary, type MetadataInputs } from '../src/report/ReportMetadataSection';
+import { buildInspectionSummary } from '../src/report/ReportFindings';
+
+const CONFIRMED: MetadataInputs = {
+  fileName: 'survey.las',
+  format: 'LAS',
+  sourcePointCount: 5000,
+  width: 30,
+  depth: 20,
+  height: 5,
+  density: 8.33,
+  hasRgb: true,
+  hasIntensity: false,
+  hasClassification: true,
+  crsName: 'NAD83 / UTM zone 15N',
+  crsUnit: 'metre',
+};
+
+// The same physical scan whose CRS carries no real linear unit: the spans are
+// raw source units, the density is NaN, and the discriminant is set.
+const UNCONFIRMED: MetadataInputs = {
+  ...CONFIRMED,
+  width: 100,
+  depth: 60,
+  height: 15,
+  density: Number.NaN,
+  extentUnitStatus: 'unknown',
+  crsUnit: 'unknown',
+};
+
+const rowMap = (inputs: MetadataInputs): Map<string, string> => {
+  const rows = buildDatasetSummary(inputs);
+  const m = new Map<string, string>();
+  for (const r of rows) m.set(r.label, r.value); // last wins; labels here are unique
+  return m;
+};
+
+describe('buildDatasetSummary — confirmed unit (unchanged)', () => {
+  it('prints metre extents, a pts/m² density, and the CRS unit', () => {
+    const m = rowMap(CONFIRMED);
+    expect(m.get('Width')).toBe('30.0 m');
+    expect(m.get('Density')).toBe('8.3 pts/m²');
+    expect(m.get('Units')).toBe('metre');
+  });
+});
+
+describe('buildDatasetSummary — fail closed on an unconfirmed unit', () => {
+  it('labels the extents as source units, never metres', () => {
+    const m = rowMap(UNCONFIRMED);
+    expect(m.get('Width')).toBe('100.0 (source units)');
+    expect(m.get('Depth')).toBe('60.0 (source units)');
+    expect(m.get('Height')).toBe('15.0 (source units)');
+    for (const label of ['Width', 'Depth', 'Height']) {
+      expect(m.get(label)).not.toMatch(/\bm\b|km|cm/);
+    }
+  });
+
+  it('omits the density row (no pts/m² on an unknown unit)', () => {
+    const rows = buildDatasetSummary(UNCONFIRMED);
+    expect(rows.some((r) => r.label === 'Density')).toBe(false);
+  });
+
+  it('adds a visible units-unconfirmed warning and no redundant crsUnit row', () => {
+    const rows = buildDatasetSummary(UNCONFIRMED);
+    const units = rows.filter((r) => r.label === 'Units');
+    expect(units).toHaveLength(1); // the warning replaces the crsUnit row
+    expect(units[0]!.value).toMatch(/unconfirmed/i);
+    expect(units[0]!.value).toMatch(/source units/i);
+  });
+
+  it('still reports the CRS name (georeference is not the unit)', () => {
+    expect(rowMap(UNCONFIRMED).get('CRS')).toBe('NAD83 / UTM zone 15N');
+  });
+});
+
+describe('buildInspectionSummary — fail closed on an unconfirmed unit', () => {
+  it('reports unknown extent rather than a source-unit² area as m²', () => {
+    const s = buildInspectionSummary(UNCONFIRMED);
+    const coverage = s.findings.find((f) => f.label === 'Coverage');
+    expect(coverage?.value).toBe('unknown extent');
+    expect(s.headline).toMatch(/unknown extent/);
+  });
+
+  it('reports density as unknown and draws no density bar', () => {
+    const s = buildInspectionSummary(UNCONFIRMED);
+    const d = s.findings.find((f) => f.label === 'Point density (all returns)');
+    expect(d?.value).toBe('—');
+    expect(s.densityBar).toBeUndefined();
+  });
+});

--- a/tests/streamingSpacingLabel.test.ts
+++ b/tests/streamingSpacingLabel.test.ts
@@ -3,25 +3,64 @@
  *
  * Label-vs-value regression for the streaming-scan summary's resolution row.
  *
- * COPC metadata `spacing` is a METRIC root-node point spacing (CRS units), so
- * the panel must render it as a distance ("1.20 m"). EPT metadata `span` is a
- * DIMENSIONLESS points-per-tile budget (the octree resolution analogue) that
- * was fed into the SAME bare "Spacing" row, where it read as "128 m" of
- * spacing — a label-vs-value drift. `spacingRowFor` now labels + units each
- * source correctly: a metric "Spacing" for COPC, a "Node budget" in pts/node
- * for EPT.
+ * COPC metadata `spacing` is a METRIC root-node point spacing in the dataset's
+ * CRS units, so the panel must render it as a distance — but only when the CRS
+ * confirms the unit. A metre CRS reads "1.20 m"; a foot CRS is converted to
+ * metres; a geographic CRS has no linear spacing; and an unknown / absent unit
+ * FAILS CLOSED to source units rather than being stamped "m" (a state-plane-FEET
+ * COPC otherwise read ~3.28× too large mislabelled as metres). EPT metadata
+ * `span` is a DIMENSIONLESS points-per-tile budget — labelled "Node budget" in
+ * pts/node so the number is never mistaken for a distance.
  */
 import { spacingRowFor } from '../src/ui/StreamingPanel';
 
-test('COPC: spacing renders as a metric distance under the "Spacing" label', () => {
-  const r = spacingRowFor('copc', 1.2);
+const METRE = { linearUnit: 'metre' as const, linearUnitToMetres: 1, isGeographic: false };
+const FOOT = { linearUnit: 'foot' as const, linearUnitToMetres: 0.3048, isGeographic: false };
+const US_FOOT = { linearUnit: 'us-survey-foot' as const, linearUnitToMetres: 1200 / 3937, isGeographic: false };
+const GEOGRAPHIC = { linearUnit: 'unknown' as const, isGeographic: true };
+const UNKNOWN = { linearUnit: 'unknown' as const, linearUnitToMetres: 1, isGeographic: false };
+
+test('COPC + metre CRS: spacing renders as a metric distance under "Spacing"', () => {
+  const r = spacingRowFor('copc', 1.2, METRE);
   expect(r.label).toBe('Spacing');
   expect(r.value).toBe('1.20 m');
-  expect(r.title).toMatch(/CRS/);
+});
+
+test('COPC + foot CRS: spacing is converted from feet to metres', () => {
+  // 4 ft root spacing ≈ 1.22 m — not "4.00 m".
+  const r = spacingRowFor('copc', 4, FOOT);
+  expect(r.label).toBe('Spacing');
+  expect(r.value).toBe(`${(4 * 0.3048).toFixed(2)} m`);
+  expect(r.value).toBe('1.22 m');
+});
+
+test('COPC + US-survey-foot CRS: also converted to metres', () => {
+  const r = spacingRowFor('copc', 4, US_FOOT);
+  expect(r.value).toBe(`${(4 * (1200 / 3937)).toFixed(2)} m`);
+});
+
+test('COPC + geographic CRS: no linear spacing (degrees are not a distance)', () => {
+  const r = spacingRowFor('copc', 0.00001, GEOGRAPHIC);
+  expect(r.label).toBe('Spacing');
+  expect(r.value).not.toMatch(/\bm\b/);
+  expect(r.value).toMatch(/geographic/i);
+});
+
+test('COPC + unknown unit: FAILS CLOSED to source units, never "m"', () => {
+  const r = spacingRowFor('copc', 1.2, UNKNOWN);
+  expect(r.value).toBe('1.20 (source units)');
+  expect(r.value).not.toMatch(/\bm\b/);
+  expect(r.title).toMatch(/unconfirmed/i);
+});
+
+test('COPC + no CRS at all: FAILS CLOSED to source units', () => {
+  const r = spacingRowFor('copc', 1.2);
+  expect(r.value).toBe('1.20 (source units)');
+  expect(r.value).not.toMatch(/\bm\b/);
 });
 
 test('EPT: span renders as a points-per-node budget, NOT a metric spacing', () => {
-  const r = spacingRowFor('ept', 128);
+  const r = spacingRowFor('ept', 128, METRE);
   // Crucially NOT labelled "Spacing" and NOT suffixed " m".
   expect(r.label).toBe('Node budget');
   expect(r.value).toBe('~128 pts/node');
@@ -35,8 +74,7 @@ test('EPT: a large span never reads as a huge metre distance', () => {
   expect(r.label).not.toBe('Spacing');
 });
 
-test('undefined format falls back to the metric COPC presentation', () => {
-  const r = spacingRowFor(undefined, 0.5);
-  expect(r.label).toBe('Spacing');
-  expect(r.value).toBe('0.50 m');
+test('undefined format is treated as COPC and still gates on the unit', () => {
+  expect(spacingRowFor(undefined, 0.5, METRE).value).toBe('0.50 m');
+  expect(spacingRowFor(undefined, 0.5, UNKNOWN).value).toBe('0.50 (source units)');
 });


### PR DESCRIPTION
Extends the existing `isLinearUnitKnown`/`SpatialContext` fail-closed program to three surfaces it had missed. **PDF footprint** (`reportFootprint`): returns a confirmed|unknown union; when unknown, emits source-unit extents, omits m / pts·m² / density grading, adds a warning row. **COPC spacing** (`StreamingPanel`): unit-aware label instead of unconditional ` m`. **Dataset Intelligence volume** (`inspectorCardRefreshers`): grades density only when horizontal + vertical units are confirmed, else `—`. **Session summary**: corrects a "metres" doc comment to source-unit extents (no value change). `main.ts` untouched. tsc clean; full vitest 7858 passed.