### PR TITLE
Disable multi-layer mount pending per-layer frame fixes; guard the flag

### DIFF
--- a/scripts/lint-release-truth.mjs
+++ b/scripts/lint-release-truth.mjs
@@ -50,6 +50,7 @@ export function collectReleaseTruthProblems(read) {
 
   const KNOWN = `KNOWN_LIMITATIONS_v${version}.md`;
   const VALREPORT = `VALIDATION_REPORT_v${version}.md`;
+  const RELEASE_NOTES = `RELEASE_NOTES_v${version}.md`;
   const ARCHMAP = 'docs/architecture/architecture-map.md';
   const CLAIMS = 'docs/validation/claim-register.yaml';
   const EVTEST = 'tests/evidenceRegistry.test.ts';
@@ -239,6 +240,55 @@ export function collectReleaseTruthProblems(read) {
       ];
       for (const [label, re] of required) {
         if (!re.test(text)) problems.push(`${RELEASE_ASSETS} does not document the "${label}" release asset.`);
+      }
+    }
+  }
+
+  // ── 8. The shipped mount flag agrees with the current truth docs ──────────
+  // PR #238 flipped MULTI_LAYER_MOUNT_ENABLED on AFTER v0.6.3 tagged, while all
+  // three truth docs still say multi-layer mounting is disabled — a live
+  // contradiction the mount wording above never saw, because rule 2 only
+  // matched alpha/beta/rc phrasing. Assert the shipped flag and the docs
+  // describe the same state, in both directions.
+  {
+    const svc = read('src/app/LayerService.ts');
+    if (svc == null) {
+      problems.push('src/app/LayerService.ts unreadable — cannot verify the mount flag.');
+    } else {
+      const flagMatch = svc.match(/export const MULTI_LAYER_MOUNT_ENABLED\s*=\s*(true|false)\s*;/);
+      if (!flagMatch) {
+        problems.push('src/app/LayerService.ts has no "export const MULTI_LAYER_MOUNT_ENABLED = true|false;" declaration to check.');
+      } else {
+        const mountEnabled = flagMatch[1] === 'true';
+        // A doc asserting mounting is OFF. Bounded by sentence/line so the span
+        // stays within one claim.
+        const MOUNT_DISABLED_CLAIM =
+          /(?:multi-layer mount\w*|mounting)[^.\n]*\b(?:disabled|remains disabled)\b|MULTI_LAYER_MOUNT_ENABLED\s*=\s*false/i;
+        // A doc asserting mounting is ON. Requires "is" so "Turning mounting on
+        // waits …" and "mounting is off" do not read as an enabled claim.
+        const MOUNT_ENABLED_CLAIM =
+          /(?:multi-layer mount\w*|mounting)\s+is(?:\s+now)?\s+(?:enabled|on)\b|MULTI_LAYER_MOUNT_ENABLED\s*=\s*true/i;
+        for (const doc of [KNOWN, VALREPORT, RELEASE_NOTES]) {
+          const text = read(doc);
+          if (text == null) continue;
+          if (mountEnabled) {
+            const m = MOUNT_DISABLED_CLAIM.exec(text);
+            if (m) {
+              problems.push(
+                `${doc} says "${m[0]}", but src/app/LayerService.ts ships ` +
+                  `MULTI_LAYER_MOUNT_ENABLED = true. Re-disable the flag or correct the doc.`,
+              );
+            }
+          } else {
+            const m = MOUNT_ENABLED_CLAIM.exec(text);
+            if (m) {
+              problems.push(
+                `${doc} says "${m[0]}", but src/app/LayerService.ts ships ` +
+                  `MULTI_LAYER_MOUNT_ENABLED = false. Enable the flag or correct the doc.`,
+              );
+            }
+          }
+        }
       }
     }
   }

--- a/src/app/LayerService.ts
+++ b/src/app/LayerService.ts
@@ -76,25 +76,24 @@ export const REBASE_QUANTUM_BUDGET_M = 0.001;
 /**
  * Whether layers are physically rebased onto a shared project origin.
  *
- * ON since the mount became non-destructive. It is a Float64 placement
- * transform (`Viewer.setLayerPlacement`), not a rewrite of the position array:
- * the source vertices never move, rendering places the mesh by its transform,
- * each layer's CPU work reads its own source-local frame (per-cloud origin),
- * and combined estimators run only across `verified` layers. The precision
- * gate above still refuses a placement it cannot represent, and an unaligned
- * or foreign-CRS layer carries no placement and stays in its own frame, so
- * `mounted: false` still makes the combined estimators refuse rather than
- * average unlike frames.
+ * DISABLED pending the multi-layer per-layer-frame fixes. The mount mechanism
+ * is a Float64 placement transform (`Viewer.setLayerPlacement`), not a rewrite
+ * of the position array: the source vertices never move, rendering places the
+ * mesh by its transform, each layer's CPU work reads its own source-local frame
+ * (per-cloud origin), and combined estimators run only across `verified`
+ * layers. But a non-anchor mounted layer still corrupts data — lasso reclassify
+ * edits the wrong points, and session and measurement export write the wrong
+ * coordinates — because those paths do not yet read each layer's own frame.
+ * Until that per-layer-frame model lands, mounting stays off, which keeps the
+ * three v0.6.3 truth docs accurate and the corruption unreachable.
  *
- * The remaining Float64 work — holding `sourceToProject` beside source-local
- * vertices for every `.positions` consumer — is coordinate-integrity roadmap
- * P1 item 2. It does not gate this: the placement folds at the render, bounds,
- * picking and elevation-window boundaries the mount actually crosses, which is
- * what the two-layer placement e2e (`gate2-origin-a` / `gate2-origin-b`)
- * confirms. Single-layer work is unaffected: a lone layer's placement is the
- * identity.
+ * The precision gate above still refuses a placement it cannot represent, and
+ * an unaligned or foreign-CRS layer carries no placement and stays in its own
+ * frame, so `mounted: false` still makes the combined estimators refuse rather
+ * than average unlike frames. Single-layer work is unaffected: a lone layer's
+ * placement is the identity.
  */
-export const MULTI_LAYER_MOUNT_ENABLED = true;
+export const MULTI_LAYER_MOUNT_ENABLED = false;
 
 /**
  * What a mount would cost this layer, expressed in metres — or null when that

--- a/tests/e2e/twoScanMount.spec.ts
+++ b/tests/e2e/twoScanMount.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { GlobalPoints } from '../../src/convert/globalPoints';
 
 /**
@@ -116,6 +118,22 @@ function parseCoords(text: string): [number, number, number] | null {
   if (!nums || nums.length < 3) return null;
   return [Number(nums[0]), Number(nums[1]), Number(nums[2])];
 }
+
+// Multi-layer mount is disabled pending the per-layer frame fixes (v0.6.4).
+// This spec is browser evidence that the mount produces a shared frame, so it
+// only applies while the mount is on. The flag is read from source rather than
+// imported from LayerService (which pulls lazyChunks + Vite-define globals the
+// Playwright transform does not provide); the gate re-arms itself when the flag
+// returns to true.
+const MULTI_LAYER_MOUNT_ENABLED = /MULTI_LAYER_MOUNT_ENABLED\s*=\s*true\b/.test(
+  readFileSync(resolve(process.cwd(), 'src/app/LayerService.ts'), 'utf8'),
+);
+test.beforeEach(() => {
+  test.skip(
+    !MULTI_LAYER_MOUNT_ENABLED,
+    'multi-layer mount disabled pending per-layer frame fixes (v0.6.4)',
+  );
+});
 
 test('two georeferenced tiles mount into one frame at their real separation', async ({ page }) => {
   const errors: string[] = [];

--- a/tests/releaseTruthLint.test.ts
+++ b/tests/releaseTruthLint.test.ts
@@ -101,4 +101,24 @@ describe('lint:release-truth', () => {
     const problems = problemsFor(withOverride(RELEASE_ASSETS, doc));
     expect(problems.some((p) => p.includes('sbom.json'))).toBe(true);
   });
+
+  const SERVICE = 'src/app/LayerService.ts';
+
+  it('fails when the mount flag is ON while the docs say mounting is disabled', () => {
+    // The real docs state mounting is disabled; flip only the shipped flag to
+    // true to reproduce the post-tag PR #238 contradiction.
+    const svc = realRead(SERVICE)!.replace(
+      'MULTI_LAYER_MOUNT_ENABLED = false',
+      'MULTI_LAYER_MOUNT_ENABLED = true',
+    );
+    const problems = problemsFor(withOverride(SERVICE, svc));
+    expect(problems.some((p) => p.includes('MULTI_LAYER_MOUNT_ENABLED = true'))).toBe(true);
+  });
+
+  it('fails when the mount flag is OFF while a doc claims mounting is enabled', () => {
+    // Keep the real (disabled) flag; make one truth doc claim mounting is on.
+    const doc = realRead(KNOWN)! + '\n\nMulti-layer mounting is enabled in this release.\n';
+    const problems = problemsFor(withOverride(KNOWN, doc));
+    expect(problems.some((p) => p.includes('MULTI_LAYER_MOUNT_ENABLED = false'))).toBe(true);
+  });
 });


### PR DESCRIPTION
Interim safety: reverts `MULTI_LAYER_MOUNT_ENABLED` to `false`. The mount shipped enabled (#238) but a non-anchor mounted layer corrupts data (lasso reclassify edits the wrong points; session + measurement export write wrong coordinates) — those P0 fixes are the next cycle. Disabling makes the corruption unreachable and the v0.6.3 truth docs accurate. Also adds release-truth rule #8 so the flag and the truth docs can never disagree again. tsc clean; releaseTruthLint 12/12; lint:release-truth OK. **Held for review — this changes shipped behavior.**