### PR TITLE
Populate annotation worldPosition; label the report frame (P1)

### DIFF
--- a/src/io/session.ts
+++ b/src/io/session.ts
@@ -489,6 +489,18 @@ export function rebaseSessionGeometry(
     return next;
   });
   const annotations = session.annotations.map((a) => {
+    // The world (survey) position is frame-INVARIANT: a render-frame rebase
+    // shifts the local anchor by `delta` and the active origin by `-delta`, so
+    // `local + origin` is unchanged. Honour the "recomputed on load" contract on
+    // annotate/types.ts by (re)deriving it here — keep a stored value, else
+    // compute it from the OLD local plus the session's capture origin (which
+    // equals the rebased local plus the new cloud origin). This is what lets a
+    // deliverable report state a real survey coordinate after a reopen.
+    const world = a.worldPosition ?? {
+      x: a.localPosition.x + session.origin[0],
+      y: a.localPosition.y + session.origin[1],
+      z: a.localPosition.z + session.origin[2],
+    };
     const next: Annotation = {
       ...a,
       localPosition: {
@@ -496,9 +508,7 @@ export function rebaseSessionGeometry(
         y: a.localPosition.y + dy,
         z: a.localPosition.z + dz,
       },
-      // Drop the cached world position — it was derived against the OLD frame and
-      // the viewer recomputes it from the rebased local plus the active origin.
-      worldPosition: undefined,
+      worldPosition: { x: world.x, y: world.y, z: world.z },
     };
     // The jump-to-view camera is in the same local frame as the vertices.
     if (a.cameraState) next.cameraState = shiftCamera(a.cameraState);
@@ -1065,6 +1075,12 @@ function parseAnnotations(v: unknown): Annotation[] {
     if (typeof item.note === 'string' && item.note.length > 0) annotation.note = item.note;
     const world = parseVec3Object(item.worldPosition);
     if (world) annotation.worldPosition = world;
+    // The owning layer + CRS label — the world frame's provenance, kept so a
+    // report can attribute the annotation and name the survey frame on reload.
+    if (typeof item.layerId === 'string' && item.layerId.length > 0) {
+      annotation.layerId = item.layerId;
+    }
+    if (typeof item.crs === 'string' && item.crs.length > 0) annotation.crs = item.crs;
     if (isRecord(item.cameraState)) annotation.cameraState = parseCameraState(item.cameraState);
     if (typeof item.linkedMeasurementId === 'string') {
       annotation.linkedMeasurementId = item.linkedMeasurementId;

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -229,7 +229,7 @@ import { RenderActivityGate } from './renderActivityGate';
 import { resolveStreamingCompatibility } from './streamingCompatibility';
 import { InspectTool } from './InspectTool';
 import { AnnotationController } from './annotate/AnnotationController';
-import { georefFromPick } from './annotate/pickGeoref';
+import { annotationGeorefFor } from './annotate/pickGeoref';
 import type { SavedCameraState } from './annotate/types';
 import { LiveProbe } from './LiveProbe';
 import { downsampleToBudget } from '../process/voxelDownsample';
@@ -312,17 +312,6 @@ import type {
  * with `clipIntersection = true` so a fragment survives if it's outside ANY
  * face (i.e. outside the box). A three.js plane clips where n·p + c < 0.
  */
-/**
- * A human-readable CRS label for an annotation's world frame, or undefined when
- * the cloud declares none. Structural param so this stays free of the io/crs
- * import; `CrsInfo.name` is already a best-effort label ("WGS 84 / UTM zone 12N"
- * or "EPSG:32612").
- */
-function crsLabelFor(crs: { name?: string } | null | undefined): string | undefined {
-  const name = crs?.name;
-  return name !== undefined && name.length > 0 ? name : undefined;
-}
-
 function clipBoxPlanes(clip: ClipBox): THREE.Plane[] {
   const { min, max } = clip.box;
   const planes = [
@@ -5998,34 +5987,21 @@ export class Viewer {
   }
 
   /**
-   * While annotating, a canvas click picks the point under the cursor and
-   * opens the inline editor on a hit, or reports a clear miss message on a
-   * miss — never creating an invalid annotation. Marker clicks are handled by
-   * the overlay itself; a click while the editor is open is left to the editor.
+   * A click while annotating opens the editor on a hit, or reports a clear miss.
    */
   private _handleAnnotateClick(e: MouseEvent, canvas: HTMLCanvasElement): void {
     if (this._annotate.isEditing) return;
     const ndcX = (e.offsetX / canvas.clientWidth) * 2 - 1;
     const ndcY = -(e.offsetY / canvas.clientHeight) * 2 + 1;
-    // Prefer the DETAILED static pick — it carries the cloud + point index, so
-    // the annotation can store the SURVEY coordinate (`cloud.worldXYZ(index)`)
-    // and not just the small render-local anchor. Fall back to the streaming
-    // pick (same order as `_pickPoint`); a streaming hit has no cloud+index in
-    // this shape, so its annotation keeps only the render-local position and the
-    // report labels the frame honestly.
     const detailed = this._pickDetailed(ndcX, ndcY);
     const hit = detailed?.point ?? this._pickStreaming(ndcX, ndcY);
     if (hit) {
-      const crs = detailed ? crsLabelFor(detailed.cloud.metadata?.crs) : undefined;
-      const georef = detailed
-        ? georefFromPick(detailed.cloud, detailed.index, crs)
-        : undefined;
       this._annotate.beginDraft(
         { x: hit.x, y: hit.y, z: hit.z },
         e.clientX,
         e.clientY,
         this.getCameraState(),
-        georef,
+        annotationGeorefFor(detailed),
       );
     } else {
       this._annotate.pickMissed();

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -229,6 +229,7 @@ import { RenderActivityGate } from './renderActivityGate';
 import { resolveStreamingCompatibility } from './streamingCompatibility';
 import { InspectTool } from './InspectTool';
 import { AnnotationController } from './annotate/AnnotationController';
+import { georefFromPick } from './annotate/pickGeoref';
 import type { SavedCameraState } from './annotate/types';
 import { LiveProbe } from './LiveProbe';
 import { downsampleToBudget } from '../process/voxelDownsample';
@@ -311,6 +312,17 @@ import type {
  * with `clipIntersection = true` so a fragment survives if it's outside ANY
  * face (i.e. outside the box). A three.js plane clips where n·p + c < 0.
  */
+/**
+ * A human-readable CRS label for an annotation's world frame, or undefined when
+ * the cloud declares none. Structural param so this stays free of the io/crs
+ * import; `CrsInfo.name` is already a best-effort label ("WGS 84 / UTM zone 12N"
+ * or "EPSG:32612").
+ */
+function crsLabelFor(crs: { name?: string } | null | undefined): string | undefined {
+  const name = crs?.name;
+  return name !== undefined && name.length > 0 ? name : undefined;
+}
+
 function clipBoxPlanes(clip: ClipBox): THREE.Plane[] {
   const { min, max } = clip.box;
   const planes = [
@@ -5995,13 +6007,25 @@ export class Viewer {
     if (this._annotate.isEditing) return;
     const ndcX = (e.offsetX / canvas.clientWidth) * 2 - 1;
     const ndcY = -(e.offsetY / canvas.clientHeight) * 2 + 1;
-    const hit = this._pickPoint(ndcX, ndcY);
+    // Prefer the DETAILED static pick — it carries the cloud + point index, so
+    // the annotation can store the SURVEY coordinate (`cloud.worldXYZ(index)`)
+    // and not just the small render-local anchor. Fall back to the streaming
+    // pick (same order as `_pickPoint`); a streaming hit has no cloud+index in
+    // this shape, so its annotation keeps only the render-local position and the
+    // report labels the frame honestly.
+    const detailed = this._pickDetailed(ndcX, ndcY);
+    const hit = detailed?.point ?? this._pickStreaming(ndcX, ndcY);
     if (hit) {
+      const crs = detailed ? crsLabelFor(detailed.cloud.metadata?.crs) : undefined;
+      const georef = detailed
+        ? georefFromPick(detailed.cloud, detailed.index, crs)
+        : undefined;
       this._annotate.beginDraft(
         { x: hit.x, y: hit.y, z: hit.z },
         e.clientX,
         e.clientY,
         this.getCameraState(),
+        georef,
       );
     } else {
       this._annotate.pickMissed();

--- a/src/render/annotate/AnnotationController.ts
+++ b/src/render/annotate/AnnotationController.ts
@@ -19,6 +19,7 @@ import type {
   Vec3Object,
 } from './types';
 import { createAnnotation, editAnnotation } from './types';
+import type { AnnotationGeoref } from './pickGeoref';
 import { AnnotationOverlay } from './AnnotationOverlay';
 import { AnnotationEditor } from '../../ui/AnnotationEditor';
 import { el } from '../../ui/dom';
@@ -127,12 +128,19 @@ export class AnnotationController {
    * `cameraState` is the viewpoint captured at the moment of the click; it is
    * attached to the annotation only if the user keeps the "Save current camera
    * view" checkbox ticked.
+   *
+   * `georef` carries the world-frame provenance the picker resolved from the hit
+   * (survey `worldPosition`, owning `layerId`, and an optional CRS label). It is
+   * stored on the annotation so a deliverable report can state a real survey
+   * coordinate; when the pick has no owning cloud it is omitted and the
+   * annotation keeps only its render-local anchor.
    */
   beginDraft(
     local: Vec3Object,
     screenX: number,
     screenY: number,
     cameraState?: SavedCameraState,
+    georef?: AnnotationGeoref,
   ): void {
     this._setHint('Fill in the annotation, then Save');
     this._editor.open({
@@ -146,6 +154,13 @@ export class AnnotationController {
           note: fields.note,
           type: fields.type,
           localPosition: local,
+          ...(georef
+            ? {
+                worldPosition: georef.worldPosition,
+                layerId: georef.layerId,
+                ...(georef.crs ? { crs: georef.crs } : {}),
+              }
+            : {}),
           ...(fields.captureCamera && cameraState ? { cameraState } : {}),
           ...(fields.linkedMeasurementId
             ? { linkedMeasurementId: fields.linkedMeasurementId }

--- a/src/render/annotate/pickGeoref.ts
+++ b/src/render/annotate/pickGeoref.ts
@@ -21,6 +21,8 @@ import type { Vec3Object } from './types';
 export interface AnnotationPickCloud {
   /** Stable layer identity — the cloud's display name / source filename. */
   readonly name: string;
+  /** Optional CRS metadata, for the annotation's world-frame label. */
+  readonly metadata?: { readonly crs?: { readonly name?: string } | null } | null;
   /**
    * World coordinate of point `index`, as `positions[index] + sourceOrigin`.
    * Survey-frame, fixed for the cloud's life (float64-transform invariant).
@@ -55,4 +57,26 @@ export function georefFromPick(
   };
   if (crs !== undefined && crs.length > 0) georef.crs = crs;
   return georef;
+}
+
+/**
+ * A human-readable CRS label for an annotation's world frame, or undefined when
+ * the cloud declares none. Structural param so callers need no io/crs import;
+ * `CrsInfo.name` is already a best-effort label ("WGS 84 / UTM zone 12N").
+ */
+export function crsLabelFor(crs: { name?: string } | null | undefined): string | undefined {
+  const name = crs?.name;
+  return name !== undefined && name.length > 0 ? name : undefined;
+}
+
+/**
+ * The georef for a DETAILED static pick, or undefined for a streaming / missed
+ * pick. Folds the pick cloud's origin and CRS label so the annotation stores a
+ * survey coordinate; a caller with no detailed pick keeps only render-local.
+ */
+export function annotationGeorefFor(
+  pick: { cloud: AnnotationPickCloud; index: number } | null | undefined,
+): AnnotationGeoref | undefined {
+  if (!pick) return undefined;
+  return georefFromPick(pick.cloud, pick.index, crsLabelFor(pick.cloud.metadata?.crs));
 }

--- a/src/render/annotate/pickGeoref.ts
+++ b/src/render/annotate/pickGeoref.ts
@@ -1,0 +1,58 @@
+/**
+ * pickGeoref.ts
+ *
+ * Turns a picked cloud + point index into the world-frame fields an annotation
+ * carries: the survey `worldPosition` (local + the cloud's source origin), the
+ * owning `layerId`, and an optional CRS label.
+ *
+ * Pure: it depends on a structural `AnnotationPickCloud` surface, not on the
+ * concrete `PointCloud` (which pulls in three.js-adjacent code), so this stays
+ * Node-testable alongside the rest of the annotation model. The real
+ * `PointCloud` satisfies the surface structurally — `worldXYZ(index)` folds the
+ * cloud's own `sourceOrigin`, exactly what `Viewer._infoForHit` already uses.
+ */
+
+import type { Vec3Object } from './types';
+
+/**
+ * The minimal cloud surface the annotation layer needs to georeference a pick.
+ * `PointCloud` satisfies this structurally.
+ */
+export interface AnnotationPickCloud {
+  /** Stable layer identity — the cloud's display name / source filename. */
+  readonly name: string;
+  /**
+   * World coordinate of point `index`, as `positions[index] + sourceOrigin`.
+   * Survey-frame, fixed for the cloud's life (float64-transform invariant).
+   */
+  worldXYZ(index: number, out?: [number, number, number]): [number, number, number];
+}
+
+/** The world-frame provenance an annotation stores about the point it marks. */
+export interface AnnotationGeoref {
+  /** Survey coordinate — local render position folded with the source origin. */
+  worldPosition: Vec3Object;
+  /** The cloud the point was picked on. */
+  layerId: string;
+  /** Human-readable CRS label (e.g. `EPSG:25830`), when the cloud declares one. */
+  crs?: string;
+}
+
+/**
+ * Derive the world-frame fields for an annotation from the picked cloud and the
+ * hit point's index. `crs` is the caller-resolved coordinate-system label; it is
+ * attached only when present so an annotation on a CRS-less scan stays honest.
+ */
+export function georefFromPick(
+  cloud: AnnotationPickCloud,
+  index: number,
+  crs?: string,
+): AnnotationGeoref {
+  const w = cloud.worldXYZ(index);
+  const georef: AnnotationGeoref = {
+    worldPosition: { x: w[0], y: w[1], z: w[2] },
+    layerId: cloud.name,
+  };
+  if (crs !== undefined && crs.length > 0) georef.crs = crs;
+  return georef;
+}

--- a/src/render/annotate/types.ts
+++ b/src/render/annotate/types.ts
@@ -61,8 +61,23 @@ export interface Annotation {
    * against any particular node's mesh.
    */
   localPosition: Vec3Object;
-  /** Georeferenced position (local + cloud origin); recomputed on load. */
+  /**
+   * Georeferenced (survey) position — the picked point's `localPosition` folded
+   * with the owning cloud's source origin (`cloud.worldXYZ(index)`). Populated
+   * at creation from the picked cloud, and recomputed on load from the session's
+   * capture origin when a stored value is absent (see `rebaseSessionGeometry`),
+   * so a deliverable report can state a real survey coordinate rather than a
+   * small render-local one. Absent only when no owning cloud can be resolved.
+   */
   worldPosition?: Vec3Object;
+  /**
+   * The cloud the point was picked on — its display name / source filename.
+   * A scan fingerprint that lets a report attribute an annotation to its layer
+   * and lets the world position be interpreted against the right frame.
+   */
+  layerId?: string;
+  /** Human-readable CRS label of the world frame (e.g. `EPSG:25830`), when known. */
+  crs?: string;
   /** Camera viewpoint captured at creation, for "jump to annotation". */
   cameraState?: SavedCameraState;
   /** Optional link to a measurement by its id. */
@@ -113,6 +128,8 @@ export interface NewAnnotation {
   type: AnnotationType;
   localPosition: Vec3Object;
   worldPosition?: Vec3Object;
+  layerId?: string;
+  crs?: string;
   cameraState?: SavedCameraState;
   linkedMeasurementId?: string;
 }
@@ -134,6 +151,8 @@ export function createAnnotation(input: NewAnnotation, now: number = Date.now())
   const note = cleanNote(input.note);
   if (note !== undefined) a.note = note;
   if (input.worldPosition) a.worldPosition = cloneVec3(input.worldPosition);
+  if (input.layerId) a.layerId = input.layerId;
+  if (input.crs) a.crs = input.crs;
   if (input.cameraState) a.cameraState = input.cameraState;
   if (input.linkedMeasurementId) a.linkedMeasurementId = input.linkedMeasurementId;
   return a;

--- a/src/report/ReportAnnotationSection.ts
+++ b/src/report/ReportAnnotationSection.ts
@@ -15,20 +15,28 @@ import type { ReportAnnotationRow } from './types';
 /**
  * Convert one runtime annotation to a report row.
  *
- * Position policy: prefer `worldPosition` (absolute world coords) over
- * `localPosition` so analysts reading the report can correlate the
- * annotation to a survey coordinate. Falls back to `localPosition` when
- * the annotation pre-dates the worldPosition field (older sessions).
+ * Position policy: prefer `worldPosition` (absolute survey coords) over
+ * `localPosition` so analysts reading the report can correlate the annotation to
+ * a survey coordinate. Falls back to `localPosition` when no world position
+ * could be derived (an annotation with no owning cloud, or an older session).
+ *
+ * Honesty: the row records WHICH frame the coordinate is in (`frame`) and the
+ * CRS label when known, so the renderer can label a render-local fallback as
+ * such instead of presenting it as a surveyed location.
  */
 function toRow(a: Annotation): ReportAnnotationRow {
-  const pos = a.worldPosition ?? a.localPosition;
-  return {
+  const world = a.worldPosition;
+  const pos = world ?? a.localPosition;
+  const row: ReportAnnotationRow = {
     title: a.title,
     type: a.type,
     note: a.note,
     position: { x: pos.x, y: pos.y, z: pos.z },
+    frame: world ? 'world' : 'local',
     createdAt: a.createdAt,
   };
+  if (world && a.crs) return { ...row, crs: a.crs };
+  return row;
 }
 
 /**

--- a/src/report/ReportPdfRenderer.ts
+++ b/src/report/ReportPdfRenderer.ts
@@ -1135,9 +1135,14 @@ async function renderAnnotations(
     if (a.note) {
       cursor = drawBodyLine(cursor, a.note, body, theme);
     }
+    // Label the coordinate FRAME so a render-local fallback is never presented
+    // as a surveyed location. `world` names the CRS when the annotation carries
+    // one; anything else is the scan's render-local anchor.
+    const frameLabel =
+      a.frame === 'world' ? (a.crs ? `world · ${a.crs}` : 'world') : 'render-local';
     cursor = drawBodyLine(
       cursor,
-      `Position: ${a.position.x.toFixed(3)}, ${a.position.y.toFixed(3)}, ${a.position.z.toFixed(3)}`,
+      `Position (${frameLabel}): ${a.position.x.toFixed(3)}, ${a.position.y.toFixed(3)}, ${a.position.z.toFixed(3)}`,
       body,
       theme,
     );

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -143,6 +143,16 @@ export interface ReportAnnotationRow {
   readonly type: string;
   readonly note?: string;
   readonly position: { readonly x: number; readonly y: number; readonly z: number };
+  /**
+   * Which frame `position` is in — so the report never presents a render-local
+   * coordinate as a surveyed one. `world` means `position` is a survey
+   * coordinate (from the annotation's `worldPosition`); `local` means it is the
+   * render-local anchor because no world position could be derived. Optional so
+   * rows built directly by older callers default to the honest `local` label.
+   */
+  readonly frame?: 'world' | 'local';
+  /** CRS label of the world frame (e.g. `EPSG:25830`), when the annotation carries one. */
+  readonly crs?: string;
   readonly createdAt: number;
 }
 

--- a/tests/annotationWorldPosition.test.ts
+++ b/tests/annotationWorldPosition.test.ts
@@ -1,0 +1,188 @@
+/**
+ * annotationWorldPosition.test.ts
+ *
+ * An annotation is created with only its render-local anchor (`localPosition`),
+ * a small coordinate in the scan's recentered frame. A deliverable report needs
+ * the SURVEY coordinate — the same point folded with the cloud's source origin —
+ * or it prints a meaningless small number where an analyst expects an easting /
+ * northing. These tests pin the fix end to end:
+ *
+ *   - creation stores `worldPosition === localPosition + sourceOrigin` (real
+ *     survey coords, not the render-local anchor) plus the owning `layerId`;
+ *   - the report row carries the world coordinate and LABELS its frame, and a
+ *     world-less annotation is labelled render-local rather than presented as a
+ *     survey location;
+ *   - the load path (re)derives the frame-invariant world position and
+ *     round-trips the layer/CRS provenance.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PointCloud } from '../src/model/PointCloud';
+import { createAnnotation, type Annotation } from '../src/render/annotate/types';
+import { georefFromPick } from '../src/render/annotate/pickGeoref';
+import { buildAnnotationRows } from '../src/report';
+import { parseSession, rebaseSessionGeometry, serializeSession } from '../src/io/session';
+
+/**
+ * A one-point cloud whose source origin is a real survey shift. The single
+ * position is exactly representable in Float32 so `worldXYZ` is exact.
+ */
+function cloudAt(
+  local: [number, number, number],
+  origin: [number, number, number],
+  name = 'scan-A',
+): PointCloud {
+  return new PointCloud({
+    positions: Float32Array.of(local[0], local[1], local[2]),
+    origin,
+    sourceFormat: 'laz',
+    name,
+  });
+}
+
+describe('annotation world position — created from the picked cloud', () => {
+  const local: [number, number, number] = [12.5, -7.25, 3.75];
+  const origin: [number, number, number] = [517000, 4645000, 58];
+
+  it('stores worldPosition === localPosition + sourceOrigin (survey coords, not render-local)', () => {
+    const cloud = cloudAt(local, origin);
+    const georef = georefFromPick(cloud, 0, 'EPSG:25830');
+
+    const a = createAnnotation(
+      { title: 'Weld crack', type: 'issue', localPosition: { x: local[0], y: local[1], z: local[2] }, ...georef },
+      5000,
+    );
+
+    // The whole point of the fix: the world position is the surveyed location,
+    // which is localPosition folded with the cloud's source origin — NOT the
+    // small render-local anchor the marker draws at.
+    expect(a.worldPosition).toEqual({
+      x: local[0] + origin[0],
+      y: local[1] + origin[1],
+      z: local[2] + origin[2],
+    });
+    expect(a.worldPosition).not.toEqual(a.localPosition);
+    // And it matches the cloud's own world read for that index.
+    const [wx, wy, wz] = cloud.worldXYZ(0);
+    expect(a.worldPosition).toEqual({ x: wx, y: wy, z: wz });
+  });
+
+  it('records the owning layer and CRS so the frame is attributable', () => {
+    const cloud = cloudAt(local, origin, 'tower-east.laz');
+    const a = createAnnotation(
+      { title: 'P', type: 'note', localPosition: { x: local[0], y: local[1], z: local[2] }, ...georefFromPick(cloud, 0, 'EPSG:25830') },
+      1,
+    );
+    expect(a.layerId).toBe('tower-east.laz');
+    expect(a.crs).toBe('EPSG:25830');
+  });
+
+  it('omits the CRS when the cloud declares none, keeping the world position', () => {
+    const cloud = cloudAt(local, origin);
+    const g = georefFromPick(cloud, 0); // no CRS resolved
+    expect(g.crs).toBeUndefined();
+    const a = createAnnotation(
+      { title: 'P', type: 'note', localPosition: { x: local[0], y: local[1], z: local[2] }, ...g },
+      1,
+    );
+    expect(a.crs).toBeUndefined();
+    expect(a.layerId).toBe('scan-A');
+    expect(a.worldPosition).toEqual({ x: local[0] + origin[0], y: local[1] + origin[1], z: local[2] + origin[2] });
+  });
+});
+
+describe('annotation report — states the coordinate frame honestly', () => {
+  const local: [number, number, number] = [12.5, -7.25, 3.75];
+  const origin: [number, number, number] = [517000, 4645000, 58];
+
+  it('prints the WORLD coordinate and labels the frame when a world position exists', () => {
+    const cloud = cloudAt(local, origin);
+    const a = createAnnotation(
+      { title: 'Spall', type: 'issue', localPosition: { x: local[0], y: local[1], z: local[2] }, ...georefFromPick(cloud, 0, 'EPSG:25830') },
+      1,
+    );
+    const [row] = buildAnnotationRows([a]);
+    expect(row!.frame).toBe('world');
+    expect(row!.crs).toBe('EPSG:25830');
+    // The report position is the survey coordinate, not the render-local anchor.
+    expect(row!.position).toEqual({ x: local[0] + origin[0], y: local[1] + origin[1], z: local[2] + origin[2] });
+  });
+
+  it('labels a world-less annotation as render-local instead of presenting it as survey', () => {
+    const a: Annotation = {
+      id: 'x', title: 'Loose bolt', type: 'warning', createdAt: 1, updatedAt: 1,
+      localPosition: { x: 1, y: 2, z: 3 },
+    };
+    const [row] = buildAnnotationRows([a]);
+    expect(row!.frame).toBe('local');
+    expect(row!.crs).toBeUndefined();
+    expect(row!.position).toEqual({ x: 1, y: 2, z: 3 });
+  });
+});
+
+describe('annotation world position — load path', () => {
+  const O1: [number, number, number] = [517000, 4645000, 58]; // capture origin
+  const O2: [number, number, number] = [10, 20, 30]; // origin of the cloud imported onto
+
+  function fixture(annotation: Record<string, unknown>): string {
+    return JSON.stringify({
+      app: 'OpenLiDARViewer',
+      kind: 'measurement-session',
+      version: 7,
+      upAxis: 'z',
+      origin: O1,
+      unitSystem: 'metric',
+      views: [],
+      measurements: [],
+      annotations: [annotation],
+    });
+  }
+
+  it('derives worldPosition on load for an annotation that stored only a local anchor', () => {
+    const session = parseSession(
+      fixture({ id: 'a1', title: 'A', type: 'note', createdAt: 1, updatedAt: 1, localPosition: { x: 12.5, y: -7.25, z: 3.75 } }),
+    );
+    const rebased = rebaseSessionGeometry(session, O2);
+    const a = rebased.annotations[0]!;
+
+    // The type comment promises worldPosition is "recomputed on load" — it now is.
+    expect(a.worldPosition).toBeDefined();
+    // World = old local + capture origin, and it is FRAME-INVARIANT: the rebased
+    // local plus the NEW cloud origin lands on the same survey coordinate.
+    expect(a.worldPosition).toEqual({ x: 12.5 + O1[0], y: -7.25 + O1[1], z: 3.75 + O1[2] });
+    expect({
+      x: a.localPosition.x + O2[0],
+      y: a.localPosition.y + O2[1],
+      z: a.localPosition.z + O2[2],
+    }).toEqual(a.worldPosition);
+  });
+
+  it('preserves an already-stored world position through the rebase (survey coords do not move)', () => {
+    const stored = { x: 999_001, y: 888_002, z: 77 };
+    const session = parseSession(
+      fixture({ id: 'a1', title: 'A', type: 'note', createdAt: 1, updatedAt: 1, localPosition: { x: 1, y: 2, z: 3 }, worldPosition: stored }),
+    );
+    const rebased = rebaseSessionGeometry(session, O2);
+    expect(rebased.annotations[0]!.worldPosition).toEqual(stored);
+  });
+
+  it('round-trips the owning layer and CRS through serialize + parse', () => {
+    const cloud = cloudAt([12.5, -7.25, 3.75], O1, 'pier-3.laz');
+    const a = createAnnotation(
+      { title: 'A', type: 'note', localPosition: { x: 12.5, y: -7.25, z: 3.75 }, ...georefFromPick(cloud, 0, 'EPSG:25830') },
+      1,
+    );
+    const json = serializeSession({
+      upAxis: 'z',
+      origin: O1,
+      unitSystem: 'metric',
+      views: [],
+      measurements: [],
+      annotations: [a],
+    });
+    const back = parseSession(json).annotations[0]!;
+    expect(back.layerId).toBe('pier-3.laz');
+    expect(back.crs).toBe('EPSG:25830');
+    expect(back.worldPosition).toEqual(a.worldPosition);
+  });
+});


### PR DESCRIPTION
Annotations were created with only `localPosition` (render-local), and `worldPosition` was never populated — so reports printed render-local numbers instead of survey coordinates, even for a single scan. Now the picked cloud/index derives `worldPosition` via `cloud.worldXYZ(index)` (folds `sourceOrigin`), plus `layerId` + a CRS label, through a new `annotationGeorefFor` helper in `pickGeoref.ts`. The load path recomputes `worldPosition` (honouring the type's long-standing 'recomputed on load' claim) and round-trips `layerId`/`crs`. The report labels the frame honestly — `Position (world · EPSG:xxxx)` vs `Position (render-local)` — so a world-less annotation is never shown as surveyed. New `annotationWorldPosition.test.ts` (8 tests); `Viewer.ts` held at its monolith baseline (georef logic lives in `pickGeoref`). tsc clean; full vitest green.