### PR TITLE
Compact the Contour Studio purpose picker; descriptions on hover

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -7978,12 +7978,14 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
 }
 
 /* Purpose cards */
-.olv-cs-purpose-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+/* Compact pills: the label alone; the full description is on hover (title
+   attribute) so the picker stays tight instead of a wall of summary text. */
+.olv-cs-purpose-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
 .olv-cs-purpose-card {
   display: flex;
-  flex-direction: column;
-  gap: 3px;
-  padding: 10px 12px;
+  align-items: center;
+  min-height: 30px;
+  padding: 6px 10px;
   text-align: left;
   background: var(--panel-recessive);
   border: 1px solid var(--hairline);
@@ -7998,8 +8000,7 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
   background: var(--accent-soft);
   box-shadow: 0 0 0 1px var(--accent) inset;
 }
-.olv-cs-purpose-label { display: block; font-size: var(--text-md); font-weight: 620; color: var(--text); }
-.olv-cs-purpose-summary { display: block; font-size: var(--text-xs); line-height: 1.4; color: var(--text-faint); }
+.olv-cs-purpose-label { display: block; font-size: var(--text-sm); font-weight: 620; color: var(--text); }
 
 /* Review + settings summary — definition grids */
 .olv-cs-review-list, .olv-cs-summary-list {

--- a/src/ui/contourStudioWorkspace.ts
+++ b/src/ui/contourStudioWorkspace.ts
@@ -137,7 +137,11 @@ function renderPurposeCards(
     card.type = 'button';
     card.setAttribute('aria-pressed', id === current ? 'true' : 'false');
     card.append(el('span', { className: 'olv-cs-purpose-label', text: meta.label }));
-    card.append(el('span', { className: 'olv-cs-purpose-summary', text: meta.summary }));
+    // The summary moves to hover (native tooltip) + the a11y label, matching the
+    // review bar's title-attribute pattern. Keeps each card a compact pill so the
+    // purpose picker stops crowding the panel.
+    card.title = meta.summary;
+    card.setAttribute('aria-label', `${meta.label}. ${meta.summary}`);
     card.addEventListener('click', () => onPick(id));
     grid.append(card);
   }

--- a/tests/contourStudioWorkspace.test.ts
+++ b/tests/contourStudioWorkspace.test.ts
@@ -11,11 +11,13 @@ import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { createContourStudioController } from '../src/terrain/contourStudio/contourStudioController';
 import { renderContourStudioWorkspace } from '../src/ui/contourStudioWorkspace';
 import type { ContourStudioLaunchState } from '../src/terrain/contourStudio/contourStudioLaunchState';
+import { PURPOSE_META } from '../src/terrain/contourStudio/contourStudioPurpose';
 
 class FakeEl {
   readonly tagName: string;
   className = '';
   textContent = '';
+  title = '';
   type = '';
   disabled = false;
   readonly children: FakeEl[] = [];
@@ -80,6 +82,10 @@ describe('renderContourStudioWorkspace', () => {
     expect(cards.length).toBe(5);
     // The Survey Review card is the 2nd in order.
     const survey = cards[1];
+    // Declutter: the description moved off-card onto hover (title) + aria-label.
+    const meta = PURPOSE_META['survey-review'];
+    expect(survey.title).toBe(meta.summary);
+    expect(survey.getAttribute('aria-label')).toBe(`${meta.label}. ${meta.summary}`);
     survey.click();
     expect(c.getState().purpose).toBe('survey-review');
     // After re-render, survey is now the selected card.


### PR DESCRIPTION
The purpose cards showed an always-visible summary under each label, crowding the panel. Keep the label as a compact pill and move the description to the card's title (hover) + aria-label, matching the review bar's title-attribute pattern. tsc + 9/9 tests green.