### PR TITLE
Purpose-aware Contour Studio map-sheet PDF

### DIFF
--- a/src/render/measure/mapSheetPdf.ts
+++ b/src/render/measure/mapSheetPdf.ts
@@ -74,6 +74,36 @@ export function mapSheetEvidenceLine(claimId: string = MAP_SHEET_CLAIM): string 
 export type SheetSize = 'letter' | 'a4' | 'a3';
 export type SheetOrientation = 'portrait' | 'landscape';
 
+/**
+ * Purpose-driven product facts a map sheet DOCUMENTS (v0.5.9 §6.2). When present
+ * on {@link MapSheetInput}, the sheet gains a purpose line, a "This deliverable"
+ * settings box and (when {@link appendixRequired}) an internal-validation
+ * appendix — so two purposes produce visibly different sheets. These are
+ * PRESENTATION/product defaults only: nothing here raises an evidence level,
+ * hides a warning, or bypasses a gate (§6.3). Absent ⇒ the sheet is byte-for-byte
+ * the pre-purpose output.
+ */
+export interface MapSheetPurpose {
+  /** Human label ("Engineering Plan"). */
+  readonly label: string;
+  /** One-line purpose statement. */
+  readonly statement: string;
+  readonly analytical: boolean;
+  readonly cartographic: boolean;
+  readonly cartographicSmoothing: boolean;
+  /** Generalization tolerance (cells): ε = tolerance × cell. 0 = exact. */
+  readonly generalizeToleranceCells: number;
+  readonly indexEvery: number;
+  /** Only index contours are labelled on the map. */
+  readonly labelsIndexOnly: boolean;
+  readonly hillshade: boolean;
+  readonly hypsometricTint: boolean;
+  readonly allowExploratory: boolean;
+  readonly completePackage: boolean;
+  /** Draw the internal-validation appendix section. */
+  readonly appendixRequired: boolean;
+}
+
 export interface MapSheetInput {
   readonly model: ContourFeatureModel;
   readonly labels: ReadonlyArray<ContourLabel>;
@@ -135,6 +165,14 @@ export interface MapSheetInput {
    * 'z' (the survey formats a georeferenced sheet is built from).
    */
   readonly sceneUpAxis?: SceneUpAxis;
+  /**
+   * The active Contour Studio purpose + its deliverable facts. When present the
+   * sheet documents them (purpose line, settings box, optional validation
+   * appendix) and the on-map label mode honours {@link MapSheetPurpose.labelsIndexOnly}.
+   * Absent ⇒ the sheet is byte-for-byte the pre-purpose output (index-only
+   * labels), so non-Studio callers are unaffected.
+   */
+  readonly purpose?: MapSheetPurpose | null;
 }
 
 const SHEET_PT: Record<SheetSize, readonly [number, number]> = {
@@ -360,7 +398,133 @@ export async function buildMapSheetPdf(input: MapSheetInput): Promise<Uint8Array
   page.drawRectangle({ x: frame.x - 3, y: frame.y - 3, width: frame.w + 6, height: frame.h + 6, borderColor: FRAME, borderWidth: 0.4 });
   page.drawRectangle({ x: M - 4, y: M - 4, width: PW - 2 * M + 8, height: PH - 2 * M + 8, borderColor: FRAME, borderWidth: 0.6 });
 
+  // ── purpose (Contour Studio deliverable) ───────────────────────────────────
+  // Gated on the optional purpose facts: absent ⇒ nothing drawn and no page
+  // added, so a non-Studio sheet is byte-for-byte the pre-purpose output. When
+  // present, a compact purpose line sits in the empty bottom-left footer (mirror
+  // of the software credit on the right), and a dedicated appendix page carries
+  // the purpose statement, the "This deliverable" settings box and — when the
+  // purpose requires it — the internal-validation appendix.
+  const purpose = input.purpose;
+  if (purpose) {
+    text(`Deliverable - ${purpose.label}`, M, M - 9, 6, bold, DIM);
+    drawPurposeAppendix(doc, purpose, input, font, bold);
+  }
+
   return doc.save();
+}
+
+/**
+ * The purpose appendix page. Documents WHAT the chosen purpose applied so two
+ * purposes produce visibly different deliverables:
+ *   - a purpose header + the one-line purpose statement;
+ *   - a "This deliverable" settings box (geometry, generalization, labels,
+ *     appearance, packaging);
+ *   - when {@link MapSheetPurpose.appendixRequired}, an internal-validation
+ *     appendix.
+ *
+ * Honesty (§6.3): every string here records a PRESENTATION/product default or
+ * the sheet's EXISTING internal validation state. Nothing raises an evidence
+ * level, asserts survey certification, or changes a gate decision — the appendix
+ * even says so in words.
+ */
+function drawPurposeAppendix(
+  doc: PDFDocument,
+  purpose: MapSheetPurpose,
+  input: MapSheetInput,
+  font: PDFFont,
+  bold: PDFFont,
+): void {
+  const size = input.sheet ?? 'letter';
+  const orient = input.orientation ?? 'portrait';
+  let [PW, PH] = SHEET_PT[size];
+  if (orient === 'landscape') [PW, PH] = [PH, PW];
+  const page = doc.addPage([PW, PH]);
+  const M = 36;
+  const text = (s: string, x: number, y: number, sz: number, f: PDFFont = font, c = INK): void => {
+    page.drawText(safe(s), { x, y, size: sz, font: f, color: c });
+  };
+
+  // Outer neatline — the same finished-sheet convention as page 1.
+  page.drawRectangle({ x: M - 4, y: M - 4, width: PW - 2 * M + 8, height: PH - 2 * M + 8, borderColor: FRAME, borderWidth: 0.6 });
+
+  let y = PH - M - 20;
+  // ── header + purpose statement ─────────────────────────────────────────────
+  text(`Deliverable - ${purpose.label}`, M, y, 15, bold);
+  page.drawLine({ start: { x: M, y: y - 6 }, end: { x: PW - M, y: y - 6 }, thickness: 0.8, color: FRAME });
+  y -= 22;
+  const wrapW = PW - 2 * M;
+  const measure = (s: string, sz: number): number => font.widthOfTextAtSize(safe(s), sz);
+  for (const ln of wrapTextToWidth(purpose.statement, wrapW, 9, measure, 3)) {
+    text(ln, M, y, 9, font, DIM);
+    y -= 12;
+  }
+  y -= 14;
+
+  // ── "This deliverable" settings box ────────────────────────────────────────
+  const onOff = (b: boolean): string => (b ? 'on' : 'off');
+  const yesNo = (b: boolean): string => (b ? 'yes' : 'no');
+  const geometry =
+    purpose.analytical && purpose.cartographic
+      ? 'analytical + cartographic'
+      : purpose.analytical
+        ? 'analytical (exact)'
+        : purpose.cartographic
+          ? 'cartographic'
+          : 'none';
+  const generalization =
+    purpose.generalizeToleranceCells > 0
+      ? `e = ${purpose.generalizeToleranceCells} x cell (Douglas-Peucker tolerance)`
+      : 'exact - no generalization';
+  const settings: Array<[string, string]> = [
+    ['Geometry', geometry],
+    ['Cartographic smoothing', onOff(purpose.cartographicSmoothing)],
+    ['Generalization', generalization],
+    ['Contour index interval', `every ${purpose.indexEvery}`],
+    ['Labels', purpose.labelsIndexOnly ? 'index only' : 'all contours'],
+    ['Hillshade', `${onOff(purpose.hillshade)} (documented; raster not rendered on this sheet)`],
+    ['Hypsometric tint', `${onOff(purpose.hypsometricTint)} (documented; raster not rendered on this sheet)`],
+    ['Exploratory output allowed', yesNo(purpose.allowExploratory)],
+    ['Complete package', yesNo(purpose.completePackage)],
+  ];
+  const boxTop = y;
+  const rowH = 15;
+  const boxH = 24 + settings.length * rowH;
+  page.drawRectangle({ x: M, y: boxTop - boxH, width: PW - 2 * M, height: boxH, color: WHITE, borderColor: FRAME, borderWidth: 0.6 });
+  text('This deliverable', M + 10, boxTop - 16, 10, bold, SEPIA_INDEX);
+  page.drawLine({ start: { x: M + 10, y: boxTop - 20 }, end: { x: PW - M - 10, y: boxTop - 20 }, thickness: 0.5, color: FRAME });
+  let ry = boxTop - 36;
+  for (const [k, v] of settings) {
+    text(k, M + 12, ry, 8, bold, DIM);
+    text(v, M + 190, ry, 8, font, INK);
+    ry -= rowH;
+  }
+  y = boxTop - boxH - 20;
+
+  // ── internal-validation appendix (only when the purpose requires it) ───────
+  // HONESTY (§6.3): this records the sheet's INTERNAL validation state — the same
+  // evidence-ladder verdict every export of this scan carries. It is explicitly
+  // NOT a survey certification and it does NOT raise the evidence level.
+  if (purpose.appendixRequired) {
+    text('Validation appendix', M, y, 12, bold);
+    page.drawLine({ start: { x: M, y: y - 5 }, end: { x: PW - M, y: y - 5 }, thickness: 0.6, color: FRAME });
+    y -= 22;
+    const warn = rgb(0.6, 0.2, 0.1);
+    // Lead with the honesty disclaimer so it can never read as a certification.
+    const lines: Array<[string, ReturnType<typeof rgb>]> = [
+      ['This appendix records OpenLiDARViewer\'s INTERNAL validation state for this surface. It is NOT a survey certification and does NOT raise the evidence level of this deliverable.', warn],
+      [mapSheetEvidenceNote(), INK],
+      [mapSheetEvidenceLine(), evidenceStatus(MAP_SHEET_CLAIM) === 'validated' ? DIM : warn],
+      [readinessNote(input.readiness ?? 'previewOnly'), input.readiness === 'ready' ? INK : warn],
+    ];
+    for (const [ln, c] of lines) {
+      for (const w of wrapTextToWidth(ln, wrapW, 9, measure, 4)) {
+        text(w, M, y, 9, font, c);
+        y -= 12;
+      }
+      y -= 6;
+    }
+  }
 }
 
 /** Contours + graticule + scale bar + north arrow inside the map frame. */
@@ -476,7 +640,9 @@ function drawMap(
         labelHeight: (sz + 2) / t.scale,
         charWidth: 3.7 / t.scale,
         minFeatureLenForScale: extent * 0.04,
-        indexOnly: true,
+        // Honour the purpose's label mode: 'index only' (the default and the
+        // pre-purpose behaviour) or every contour when the purpose labels all.
+        indexOnly: input.purpose?.labelsIndexOnly ?? true,
         maxLabels: 60,
         // Repeat labels along each index contour (~every 28% of the map extent)
         // so a long line reads its height wherever the eye lands — the printed

--- a/src/terrain/contourStudio/contourExportIntent.ts
+++ b/src/terrain/contourStudio/contourExportIntent.ts
@@ -28,6 +28,43 @@
 
 import type { ContourStudioState } from './contourStudioState';
 import type { ContourShapeStyle } from '../contour/contourShapeStyle';
+import { PURPOSE_META } from './contourStudioPurpose';
+
+/**
+ * The purpose-driven product facts a deliverable renders on its sheet, so a
+ * map-sheet PDF (or any deliverable) can DOCUMENT the settings the chosen purpose
+ * applied — the geometry claim, generalization, labels, appearance and packaging.
+ * These are PRESENTATION/product defaults only: none of them raises an evidence
+ * level, hides a warning, or bypasses a gate.
+ */
+export interface ContourDeliverableFacts {
+  /** Human label of the purpose ("Engineering Plan"). */
+  readonly label: string;
+  /** One-line purpose statement (from PURPOSE_META.summary). */
+  readonly statement: string;
+  /** Exact analytical isolines are emitted. */
+  readonly analytical: boolean;
+  /** Generalized cartographic contours are emitted. */
+  readonly cartographic: boolean;
+  /** Cartographic smoothing is applied. */
+  readonly cartographicSmoothing: boolean;
+  /** Generalization tolerance (cells): ε = tolerance × cell. 0 = exact. */
+  readonly generalizeToleranceCells: number;
+  /** Every Nth contour is an index (bold) line. */
+  readonly indexEvery: number;
+  /** Only index contours are labelled. */
+  readonly labelsIndexOnly: boolean;
+  /** Hillshade appearance requested (raster documented, see mapSheetPdf). */
+  readonly hillshade: boolean;
+  /** Hypsometric tint requested (raster documented, see mapSheetPdf). */
+  readonly hypsometricTint: boolean;
+  /** Exploratory (watermarked) output may be produced for this purpose. */
+  readonly allowExploratory: boolean;
+  /** The complete deliverable package is part of this purpose. */
+  readonly completePackage: boolean;
+  /** The purpose demands the internal-validation appendix. */
+  readonly appendixRequired: boolean;
+}
 
 export interface ContourExportIntent {
   /** The purpose that produced this intent (stamped into provenance). */
@@ -50,6 +87,12 @@ export interface ContourExportIntent {
   readonly methodVersion: number;
   /** Human tag "id@version" for provenance and diagnostics. */
   readonly methodTag: string;
+  /**
+   * The purpose-driven product facts (label, statement, and the deliverable
+   * config). A deliverable renderer uses these to DOCUMENT what the chosen
+   * purpose applied — never to change any evidence/gate decision.
+   */
+  readonly deliverable: ContourDeliverableFacts;
 }
 
 /**
@@ -82,6 +125,7 @@ export function contourExportIntentFromState(state: ContourStudioState): Contour
   const methodId = exact ? 'olv.contour.analytical' : 'olv.contour.generalize';
   const methodVersion = 1;
 
+  const meta = PURPOSE_META[state.purpose];
   return {
     purpose: state.purpose,
     shapeStyle,
@@ -90,5 +134,22 @@ export function contourExportIntentFromState(state: ContourStudioState): Contour
     methodId,
     methodVersion,
     methodTag: `${methodId}@${methodVersion}`,
+    deliverable: {
+      label: meta.label,
+      statement: meta.summary,
+      analytical: state.contour.analytical,
+      cartographic: state.contour.cartographic,
+      cartographicSmoothing: state.surface.cartographicSmoothing,
+      // Report the tolerance actually in effect for the exported geometry: 0 on
+      // the exact path, else the state's per-purpose tolerance.
+      generalizeToleranceCells: exact ? 0 : tol,
+      indexEvery: state.contour.indexEvery,
+      labelsIndexOnly: state.labels.indexOnly,
+      hillshade: state.appearance.hillshade,
+      hypsometricTint: state.appearance.hypsometricTint,
+      allowExploratory: state.deliverable.allowExploratory,
+      completePackage: state.deliverable.completePackage,
+      appendixRequired: state.validation.appendixRequired,
+    },
   };
 }

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -69,7 +69,7 @@ import {
   loadContourDeliverableBuild,
 } from '../lazyChunks';
 import { openModal, type ModalHandle } from './Modal';
-import type { SheetSize, SheetOrientation } from '../render/measure/mapSheetPdf';
+import type { SheetSize, SheetOrientation, MapSheetPurpose } from '../render/measure/mapSheetPdf';
 import type { Annotation } from '../render/annotate/types';
 import {
   SHEET_OPTIONS,
@@ -348,6 +348,14 @@ export class AnalysePanel {
    * when it is null or not granted. Cleared after each PDF export attempt.
    */
   private _contourPdfPermit: ContourExportPermit | null = null;
+  /**
+   * The active purpose's deliverable facts for the pending map-sheet PDF. Stashed
+   * at Studio 'pdf' click time (alongside the permit) and read by
+   * `_buildAndDownloadMapPdf` so the sheet documents the chosen purpose. Null for
+   * any non-Studio export path, keeping that sheet byte-identical. Cleared after
+   * each attempt.
+   */
+  private _contourPdfPurpose: MapSheetPurpose | null = null;
   /** DEM raster export — gated only on a result existing, not the contour gate. */
   private _demButton!: HTMLButtonElement;
   /**
@@ -669,8 +677,12 @@ export class AnalysePanel {
               this._contourGeneralizeToleranceCells = generalizeToleranceCells;
             },
             exportVector: (fmt, opts) => this._exportContourFormat(fmt, undefined, opts),
-            openMapPdf: (permit) => {
+            openMapPdf: (permit, intent) => {
               this._contourPdfPermit = permit;
+              // Stash the purpose deliverable facts so the async map-sheet build
+              // documents the chosen purpose (presentation only; the permit is
+              // the sole gate). Field-compatible with MapSheetPurpose.
+              this._contourPdfPurpose = intent.deliverable;
               this._studioExportBtns.get('pdf')?.click();
             },
             exportDemPackage: (stamp) => this._exportDemPackage(this._demButton, stamp),
@@ -2473,6 +2485,10 @@ export class AnalysePanel {
     // and package paths so no PDF escapes the gate).
     const permit = this._contourPdfPermit;
     this._contourPdfPermit = null;
+    // Consume the stashed purpose (Studio path only); cleared so a later non-Studio
+    // export can never inherit a stale purpose.
+    const purpose = this._contourPdfPurpose;
+    this._contourPdfPurpose = null;
     if (!permit || !permit.ok) {
       // eslint-disable-next-line no-console
       console.warn('OpenLiDARViewer: map sheet export refused — no granted evidence permit (§19).');
@@ -2527,6 +2543,9 @@ export class AnalysePanel {
       includeAnnotations: opts.includeAnnotations,
       annotations,
       sceneUpAxis,
+      // Purpose deliverable facts (Studio path) so the sheet renders purpose-
+      // specific content. Null on any other path ⇒ byte-identical sheet.
+      purpose,
     });
     triggerDownload(
       new Blob([bytes as BlobPart], { type: 'application/pdf' }),

--- a/src/ui/contourExportAdapter.ts
+++ b/src/ui/contourExportAdapter.ts
@@ -46,8 +46,13 @@ export interface ContourExportHost {
     fmt: ContourVectorFormat,
     opts: { contourMethod?: string; deliverablePurpose?: string; permit: ContourExportPermit },
   ): Promise<void>;
-  /** Stash the granted permit for the async map-sheet dialog, then open it. */
-  openMapPdf(permit: ContourExportPermit): void;
+  /**
+   * Stash the granted permit + the live export intent for the async map-sheet
+   * dialog, then open it. The intent carries the purpose deliverable facts so the
+   * sheet documents the chosen purpose (presentation only — no gate/evidence
+   * effect).
+   */
+  openMapPdf(permit: ContourExportPermit, intent: ContourExportIntent): void;
   /**
    * Run the DEM raster package export, stamped with the evidence-gate permit the
    * adapter resolved (or null when unavailable). The DEM keeps its own internal
@@ -168,7 +173,7 @@ export class ContourExportAdapter {
 
     if (product === 'pdf') {
       // The dialog is the feedback — no busy spinner; stash the permit + open it.
-      this.host.openMapPdf(permit);
+      this.host.openMapPdf(permit, intent);
       return;
     }
     // geojson | dxf | svg → the gated vector exporter, stamped self-describing.

--- a/tests/contourExportAdapter.test.ts
+++ b/tests/contourExportAdapter.test.ts
@@ -52,6 +52,21 @@ const intent = (over: Partial<ContourExportIntent> = {}): ContourExportIntent =>
   methodId: 'olv.contour.analytical',
   methodVersion: 1,
   methodTag: 'olv.contour.analytical@1',
+  deliverable: {
+    label: 'Survey Review',
+    statement: 'Exact analytical geometry.',
+    analytical: true,
+    cartographic: false,
+    cartographicSmoothing: false,
+    generalizeToleranceCells: 0,
+    indexEvery: 5,
+    labelsIndexOnly: true,
+    hillshade: false,
+    hypsometricTint: false,
+    allowExploratory: false,
+    completePackage: false,
+    appendixRequired: true,
+  },
   ...over,
 });
 

--- a/tests/mapSheetPdf.test.ts
+++ b/tests/mapSheetPdf.test.ts
@@ -316,3 +316,43 @@ describe('readinessNote', () => {
     expect(readinessNote('previewOnly').toLowerCase()).toMatch(/not\s+survey-grade/);
   });
 });
+
+describe('buildMapSheetPdf — purpose deliverable content', () => {
+  const engineering = {
+    label: 'Engineering Plan', statement: 'Clear contours for planning.',
+    analytical: true, cartographic: true, cartographicSmoothing: true,
+    generalizeToleranceCells: 0.5, indexEvery: 5, labelsIndexOnly: false,
+    hillshade: false, hypsometricTint: false, allowExploratory: true,
+    completePackage: false, appendixRequired: false,
+  } as const;
+  const survey = {
+    label: 'Survey Review', statement: 'Exact analytical geometry; does not imply survey certification.',
+    analytical: true, cartographic: false, cartographicSmoothing: false,
+    generalizeToleranceCells: 0, indexEvery: 5, labelsIndexOnly: true,
+    hillshade: false, hypsometricTint: false, allowExploratory: false,
+    completePackage: false, appendixRequired: true,
+  } as const;
+
+  it('is byte-identical to the pre-purpose sheet when purpose is absent or null', async () => {
+    const base = { model, labels: [] as never[], provenance: PROV } as const;
+    const absent = await buildMapSheetPdf({ ...base });
+    const nul = await buildMapSheetPdf({ ...base, purpose: null });
+    expect(Buffer.from(nul).equals(Buffer.from(absent))).toBe(true);
+  });
+
+  it('adds a page (appendix) only when appendixRequired', async () => {
+    const noApx = await buildMapSheetPdf({ model, labels: [], provenance: PROV, purpose: engineering });
+    const withApx = await buildMapSheetPdf({ model, labels: [], provenance: PROV, purpose: survey });
+    // A required appendix means an extra page → measurably larger output.
+    expect(withApx.length).toBeGreaterThan(noApx.length);
+    // And both differ from the no-purpose sheet.
+    const plain = await buildMapSheetPdf({ model, labels: [], provenance: PROV });
+    expect(noApx.length).not.toBe(plain.length);
+  });
+
+  it('produces different bytes for two different purposes (purposes are real)', async () => {
+    const a = await buildMapSheetPdf({ model, labels: [], provenance: PROV, purpose: engineering });
+    const b = await buildMapSheetPdf({ model, labels: [], provenance: PROV, purpose: survey });
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(false);
+  });
+});


### PR DESCRIPTION
Each Contour Studio purpose now exports a different sheet: a deliverable line, a 'This deliverable' settings box (geometry/smoothing/generalization/labels/hillshade), and a validation appendix when the purpose requires it. Threaded on an optional `purpose` field so non-Studio callers stay byte-identical. Honesty preserved: the appendix records internal validation, not certification. Hillshade/tint documented, raster deferred. tsc + full vitest green.