### PR TITLE
Keep the natural colour after auto-classify

### DIFF
--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -3246,11 +3246,10 @@ export class Viewer {
     // class-mask multiply folded into the size node. Without this the legend
     // could colour the derived classes but not hide them.
     this._attachClassAttribute(entry, codes);
-    if (entry.mode === 'classification') {
-      this._refreshClassificationColours(id);
-    } else {
-      this.setColorMode(id, 'classification');
-    }
+    // Keep the current colour mode (RGB/natural) after a derive, like a cloud
+    // loaded WITH classification: the class-filter wiring above hides classes
+    // without recolouring. Only refresh when already showing class colours.
+    if (entry.mode === 'classification') this._refreshClassificationColours(id);
     this._bumpRenderActivity();
     return true;
   }


### PR DESCRIPTION
`applyDerivedClassification` force-switched to classification colours; a cloud loaded WITH classification keeps its RGB. Match that — the class-filter wiring is already colour-independent, so hiding a class filters in any mode. Auto-classify now keeps the natural colour; the colour picker still offers Class. Net -1 line in Viewer.ts.