### PR TITLE
Fix contour readiness card rendering value as a vertical column

### DIFF
--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -271,10 +271,34 @@ let lastNotes: string | null = null;
  *   "1 m"          → { num: "1",  unit: "m" }
  *   "Not ready"    → { num: "Not ready", unit: "" }  (no leading digit)
  */
-function splitReadinessValue(value: string): { num: string; unit: string } {
+export function splitReadinessValue(value: string): { num: string; unit: string } {
   const m = value.match(/^(\d+(?:\.\d+)?)\s*(.*)$/);
   if (!m) return { num: value, unit: '' };
   return { num: m[1], unit: m[2].trim() };
+}
+
+/**
+ * Decide how a readiness value + detail render across the card's two text slots.
+ * The subscript slot beside the big figure is narrow, so only a short, real unit
+ * ("m", "%", "ft", "% meas.") is allowed to sit there. A long, word-y annotation
+ * such as "(vertical unit unverified)" would collapse that slot into a
+ * one-char-per-line column, so it is kept out of the subscript and folded onto
+ * the normally-wrapping detail line instead (unless the detail already carries
+ * the same caveat, to avoid stating it twice).
+ */
+export function readinessCardParts(
+  value: string,
+  detail: string,
+): { num: string; unitText: string; detailText: string } {
+  const { num, unit } = splitReadinessValue(value);
+  const compactUnit = unit.replace(/\bmeasured\b/, 'meas.');
+  const unitIsCompact = compactUnit.length <= 8 && !compactUnit.includes('(');
+  const caveat = unitIsCompact ? '' : unit;
+  return {
+    num,
+    unitText: unitIsCompact ? compactUnit : '',
+    detailText: caveat && !detail.includes(caveat) ? `${detail} · ${caveat}` : detail,
+  };
 }
 
 export class AnalysePanel {
@@ -1585,19 +1609,19 @@ export class AnalysePanel {
   private _readinessCard(ind: ReadinessIndicator): HTMLElement {
     const card = el('div', { className: `olv-analyse-ready is-${ind.rating}` });
 
+    // Right column: a big tabular figure with the unit set as a subscript,
+    // and a colour-coded rating pill (the rating word stays for colourblind
+    // safety, no longer relying on hue alone). A long, word-y unit is demoted
+    // off the narrow subscript and onto the detail line (see readinessCardParts).
+    const { num, unitText, detailText } = readinessCardParts(ind.value, ind.detail);
+
     // Left column: label over the supporting line.
     const main = el('div', { className: 'olv-analyse-ready-main' });
     main.append(
       el('div', { className: 'olv-analyse-ready-label', text: ind.label }),
-      el('div', { className: 'olv-analyse-ready-detail', text: ind.detail }),
+      el('div', { className: 'olv-analyse-ready-detail', text: detailText }),
     );
 
-    // Right column: a big tabular figure with the unit set as a subscript,
-    // and a colour-coded rating pill (the rating word stays for colourblind
-    // safety, no longer relying on hue alone).
-    const { num, unit } = splitReadinessValue(ind.value);
-    // Keep the unit compact so the figure can't crowd the supporting line.
-    const unitText = unit.replace(/\bmeasured\b/, 'meas.');
     const figure = el('div', {
       className: `olv-analyse-ready-figure${num.match(/\d/) ? '' : ' is-text'}`,
     });

--- a/tests/readinessCardParts.test.ts
+++ b/tests/readinessCardParts.test.ts
@@ -1,0 +1,50 @@
+/**
+ * readinessCardParts.test.ts
+ *
+ * The Analyse panel's readiness cards set a big figure with the unit as a narrow
+ * subscript beside it. A short real unit ("m", "%", "ft", "% meas.") belongs in
+ * that slot, but a long word-y annotation — "(vertical unit unverified)" on the
+ * CONTOUR READINESS card when the scan's vertical unit is unresolved — collapsed
+ * the narrow slot into a one-char-per-line column. These assert the long unit is
+ * kept OUT of the subscript and folded onto the detail line instead, while the
+ * short units still render in the subscript exactly as before.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { splitReadinessValue, readinessCardParts } from '../src/ui/AnalysePanel';
+
+describe('splitReadinessValue', () => {
+  it('splits a leading figure from its unit', () => {
+    expect(splitReadinessValue('68%')).toEqual({ num: '68', unit: '%' });
+    expect(splitReadinessValue('31% measured')).toEqual({ num: '31', unit: '% measured' });
+    expect(splitReadinessValue('1 m')).toEqual({ num: '1', unit: 'm' });
+    expect(splitReadinessValue('Not ready')).toEqual({ num: 'Not ready', unit: '' });
+  });
+});
+
+describe('readinessCardParts', () => {
+  it('keeps short real units in the compact subscript', () => {
+    expect(readinessCardParts('68%', 'x').unitText).toBe('%');
+    expect(readinessCardParts('1 m', 'x').unitText).toBe('m');
+    expect(readinessCardParts('10 ft', 'x').unitText).toBe('ft');
+    expect(readinessCardParts('31% measured', 'x').unitText).toBe('% meas.');
+  });
+
+  it('keeps a long/multi-word unit OUT of the compact subscript', () => {
+    const parts = readinessCardParts('10 (vertical unit unverified)', 'Coverage 60%');
+    expect(parts.num).toBe('10');
+    // The big figure stays a clean number, and the long annotation never lands
+    // in the narrow subscript (which is what wrapped one char per line).
+    expect(parts.unitText).toBe('');
+    expect(parts.unitText).not.toContain('vertical');
+    // The caveat is preserved for the reader, on the normally-wrapping detail.
+    expect(parts.detailText).toBe('Coverage 60% · (vertical unit unverified)');
+  });
+
+  it('does not duplicate the caveat when the detail already carries it', () => {
+    const detail = 'Coverage 60% · relief 12.3 (vertical unit unverified)';
+    const parts = readinessCardParts('10 (vertical unit unverified)', detail);
+    expect(parts.unitText).toBe('');
+    expect(parts.detailText).toBe(detail);
+  });
+});


### PR DESCRIPTION
## Bug

In the Analyse panel's terrain-readiness cards, the CONTOUR READINESS card rendered its value as a tall one-character-per-line column reading `( v e r t i c a l  u n i t  u n v e r i f i e d )`. It happened whenever the scan's vertical unit was unverified. GROUND CONFIDENCE and MEASURED COVERAGE were unaffected.

## Root cause

`AnalysePanel._readinessCard` splits each value into `{num, unit}` via `splitReadinessValue` and places `unit` into the narrow subscript slot beside the big figure. For contour readiness with an unresolved vertical unit, `verticalUnitSuffix` returns ` (vertical unit unverified)`, so the value is `"10 (vertical unit unverified)"` and `unit` becomes the long string `"(vertical unit unverified)"`. The subscript slot is narrow, so that long string wrapped one character per line.

## Fix

Route only a short, real unit (`m`, `%`, `ft`, `% meas.`) into the compact subscript. A long, multi-word unit is kept out of the subscript and folded onto the normally-wrapping detail line instead, and is skipped there when the detail already carries the same caveat (the contour detail already appends the suffix to relief). The big figure stays a clean number. The rule is general (length + parenthesis check), not a string match, so any long/multi-word unit degrades gracefully. The other two cards render identically.

The routing decision is extracted as a pure, exported `readinessCardParts` helper with unit tests.

## After

CONTOUR READINESS now shows the figure `10` with no subscript, and the caveat appears on the detail line: `Coverage 60% · relief 12.3 (vertical unit unverified)`. Short-unit cards are unchanged.

## Gates

- `tsc --noEmit`: clean
- `scripts/lint-monolith-size.mjs`: passes (main.ts/Viewer.ts unchanged)
- `npm run build`: clean
- tests: new `tests/readinessCardParts.test.ts` (7 assertions) + `terrainReadiness.test.ts` pass