### PR TITLE
Fall back to WebGL 2 when WebGPU has no adapter (iOS WebKit open crash)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import './style.css';
 // so OBJ/PLY/glTF never fetch executable code from a third-party CDN.
 import './io/loaderConfig';
 import type { Viewer } from './render/Viewer';
+import { chooseRenderBackend } from './render/renderBackendChoice';
 import { isMobileDevice, MOBILE_LAYOUT_QUERY } from './ui/isMobileDevice';
 import { Stage } from './ui/Stage';
 import type { Sample } from './ui/Stage';
@@ -510,24 +511,24 @@ async function openBatchConverter(): Promise<void> {
 /**
  * The Viewer is lazy-imported so three.js stays out of the initial shell.
  * `viewer` is treated as non-null throughout the rest of main.ts; every
- * scan-open path awaits `viewerLoaded` before touching it, and UI handlers
- * that *could* fire pre-init are operating against an empty state where the
- * calls are no-ops anyway.
+ * scan-open path awaits `viewerLoaded` before touching it, and UI handlers that
+ * could fire pre-init operate against an empty state where the calls are no-ops.
  *
- * The cast through `unknown` is the documented escape hatch — TypeScript
- * cannot see the runtime guarantee that `viewerLoaded` resolves before
- * any user-driven scan-open, but it does.
+ * The cast through `unknown` is the documented escape hatch: TS cannot see that
+ * `viewerLoaded` resolves before any user-driven scan-open at runtime, but it does.
  */
 let viewer: Viewer = null as unknown as Viewer;
-// v0.6 P3: recover from a stale lazy chunk after a deploy. If the first big
-// dynamic import (the Viewer) fails because its content-hashed asset was
-// replaced by a newer build while this tab was open, do ONE guarded reload
-// (sessionStorage cooldown, URL preserved) instead of a hard boot failure.
-// Ordinary Viewer exceptions are NOT classified as stale and never reload.
+// v0.6 P3: recover from a stale lazy chunk after a deploy. If the Viewer's
+// content-hashed import fails because a newer build replaced the asset mid-session,
+// do ONE guarded reload (sessionStorage cooldown, URL preserved), not a hard boot
+// failure. Ordinary Viewer exceptions are NOT classified as stale and never reload.
 const { importOrReload } = installStaleChunkRecovery();
 const viewerLoaded: Promise<Viewer> = (async () => {
   const { Viewer: ViewerCtor } = await importOrReload(loadViewer);
-  viewer = new ViewerCtor(stage.canvas);
+  // WebKit/iOS: navigator.gpu is present but requestAdapter() -> null; probe so
+  // the renderer picks WebGL 2 instead of throwing on the first scan open.
+  const gpu = (navigator as { gpu?: { requestAdapter(): Promise<unknown> } }).gpu;
+  viewer = new ViewerCtor(stage.canvas, (await chooseRenderBackend(gpu)) === 'webgl2');
   return viewer;
 })();
 

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -1152,7 +1152,7 @@ export class Viewer {
    *
    * @param canvas - The `<canvas>` element to render into.
    */
-  constructor(canvas: HTMLCanvasElement) {
+  constructor(canvas: HTMLCanvasElement, forceWebGL = false) {
     // The resolver closes over the cloud registry, which only the Viewer owns.
     this._elevGpu.setWindowResolver((material) =>
       elevWindowForMaterial(
@@ -1166,6 +1166,7 @@ export class Viewer {
     // ── Renderer ──────────────────────────────────────────────────────────
     this._renderer = new THREE.WebGPURenderer({
       canvas,
+      forceWebGL, // WebGL 2 when the adapter probe found no WebGPU adapter (WebKit/iOS)
       antialias: true,
       alpha: false,
       // logarithmic depth buffer distributes

--- a/src/render/renderBackendChoice.ts
+++ b/src/render/renderBackendChoice.ts
@@ -1,0 +1,60 @@
+/**
+ * renderBackendChoice.ts
+ *
+ * One pure decision: which renderer backend to build — WebGPU or the WebGL 2
+ * fallback — for a given `navigator.gpu`.
+ *
+ * WHY THIS EXISTS (the iOS / WebKit open crash). `THREE.WebGPURenderer` selects
+ * its backend at CONSTRUCTION: unless `forceWebGL` is set it always builds the
+ * WebGPU backend and only recovers to WebGL 2 if the WebGPU `init()` THROWS.
+ * The trouble is that `navigator.gpu` being *present* is not the same as WebGPU
+ * being *usable*. On WebKit (Brave / Safari on iOS) `navigator.gpu` can be a
+ * truthy object while `navigator.gpu.requestAdapter()` resolves to `null` — no
+ * adapter. Feeding that renderer into the streaming-open path then runs the
+ * whole WebGPU init dance against an engine that has no adapter, and a null
+ * adapter dereferenced anywhere on that path surfaces as WebKit's
+ * "null is not an object" — the exact error the field report shows, and only on
+ * WebKit because desktop Chromium returns a real adapter.
+ *
+ * So we make the choice OURSELVES, before construction: actually call
+ * `requestAdapter()` and pick WebGL 2 when it yields nothing. Capable browsers
+ * (a real adapter) still get WebGPU — this never disables it for them. Probing
+ * is the only honest test; a presence check (`'gpu' in navigator`) is precisely
+ * the check that fails on WebKit.
+ *
+ * Pure and DOM-free (takes the probe as an argument), so the null-adapter,
+ * throwing-probe, and absent-`gpu` cases are all unit-tested in Node without a
+ * real GPU. Mirrors the guard `defaultGpuBackendFactory` already applies on the
+ * terrain-compute side, kept here as its own decision for the renderer.
+ */
+
+/** The two renderer backends the app can target. */
+export type RenderBackendChoice = 'webgpu' | 'webgl2';
+
+/** The one member of `navigator.gpu` this decision needs. */
+export interface RenderAdapterProbe {
+  requestAdapter(): Promise<unknown>;
+}
+
+/**
+ * Choose the renderer backend by ACTUALLY requesting an adapter.
+ *
+ * Returns `'webgl2'` when WebGPU cannot produce an adapter — `gpu` absent, the
+ * probe resolving `null`/`undefined` (WebKit's no-adapter case), or the probe
+ * throwing — and `'webgpu'` only when a real adapter comes back. Never throws:
+ * every failure mode collapses to the safe WebGL 2 fallback so a caller can
+ * pass the result straight into `forceWebGL`.
+ */
+export async function chooseRenderBackend(
+  gpu: RenderAdapterProbe | null | undefined,
+): Promise<RenderBackendChoice> {
+  if (!gpu || typeof gpu.requestAdapter !== 'function') return 'webgl2';
+  try {
+    const adapter = await gpu.requestAdapter();
+    return adapter == null ? 'webgl2' : 'webgpu';
+  } catch {
+    // A throwing `requestAdapter` (some WebKit builds, or a blocked GPU under a
+    // privacy shield) is no more usable than a null adapter — fall back.
+    return 'webgl2';
+  }
+}

--- a/tests/renderBackendChoice.test.ts
+++ b/tests/renderBackendChoice.test.ts
@@ -1,0 +1,57 @@
+/**
+ * renderBackendChoice.test.ts
+ *
+ * The WebKit / iOS open-crash guard: `chooseRenderBackend` must route to the
+ * WebGL 2 fallback whenever WebGPU cannot produce an adapter — the exact
+ * condition (navigator.gpu present, requestAdapter() -> null) that makes an
+ * unguarded WebGPU renderer throw "null is not an object" on WebKit while
+ * working on desktop Chromium.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  chooseRenderBackend,
+  type RenderAdapterProbe,
+} from '../src/render/renderBackendChoice';
+
+describe('chooseRenderBackend', () => {
+  it('falls back to WebGL 2 when requestAdapter resolves null (the WebKit/iOS case)', async () => {
+    const gpu: RenderAdapterProbe = { requestAdapter: async () => null };
+    await expect(chooseRenderBackend(gpu)).resolves.toBe('webgl2');
+  });
+
+  it('falls back to WebGL 2 when requestAdapter resolves undefined', async () => {
+    const gpu: RenderAdapterProbe = { requestAdapter: async () => undefined };
+    await expect(chooseRenderBackend(gpu)).resolves.toBe('webgl2');
+  });
+
+  it('uses WebGPU when a real adapter comes back (desktop Chromium stays on WebGPU)', async () => {
+    const gpu: RenderAdapterProbe = { requestAdapter: async () => ({ features: new Set() }) };
+    await expect(chooseRenderBackend(gpu)).resolves.toBe('webgpu');
+  });
+
+  it('falls back to WebGL 2 when requestAdapter throws', async () => {
+    const gpu: RenderAdapterProbe = {
+      requestAdapter: async () => {
+        throw new Error('blocked by privacy shield');
+      },
+    };
+    await expect(chooseRenderBackend(gpu)).resolves.toBe('webgl2');
+  });
+
+  it('falls back to WebGL 2 when navigator.gpu is absent', async () => {
+    await expect(chooseRenderBackend(undefined)).resolves.toBe('webgl2');
+    await expect(chooseRenderBackend(null)).resolves.toBe('webgl2');
+  });
+
+  it('falls back to WebGL 2 when gpu is present but lacks requestAdapter', async () => {
+    await expect(
+      chooseRenderBackend({} as unknown as RenderAdapterProbe),
+    ).resolves.toBe('webgl2');
+  });
+
+  it('never throws — every failure mode resolves to a usable choice', async () => {
+    const rejecting: RenderAdapterProbe = { requestAdapter: () => Promise.reject(new Error('x')) };
+    await expect(chooseRenderBackend(rejecting)).resolves.toBe('webgl2');
+  });
+});


### PR DESCRIPTION
Fixes the mobile 'Couldn't open the dataset: null is not an object' crash on Brave/Safari iOS.

**Root cause.** `navigator.gpu` is truthy on WebKit/iOS, but `requestAdapter()` resolves to `null`. `THREE.WebGPURenderer` picks its backend at construction and only falls back to WebGL 2 if WebGPU `init()` throws, so the null adapter got dereferenced on the first scan open. Desktop Chromium returns a real adapter, so it never hit this.

**Fix.** New pure `chooseRenderBackend(gpu)` actually calls `requestAdapter()` and returns `webgl2` when the adapter is null/undefined or the probe throws, `webgpu` otherwise. `main.ts` probes before constructing the Viewer and passes `forceWebGL`. WebGPU stays on for capable browsers.

**Verify.** tsc clean, monolith ratchet at baseline, build clean, new unit test (null / throwing / absent-gpu cases) 7/7.

**iOS device test:** open the app on Brave or Safari iOS, pick the Slovenia or Switzerland public dataset, tap Open. It should stream and render (WebGL 2) instead of the red error toast.