### PR TITLE
Prune vulnerable image-size transitive via texture-compressor stub

### DIFF
--- a/docs/project/DEPENDENCIES.md
+++ b/docs/project/DEPENDENCIES.md
@@ -117,6 +117,18 @@ The `vite` override is scoped to `vitepress` alone. The application builds on
 Vite 8.1.5 and is not affected by it. `npm run docs:build` passes on the
 overridden tree.
 
+## Stubbed to prune
+
+`texture-compressor` is replaced by a local empty stub through a
+`file:vendor-stubs/texture-compressor` override. It sits under
+`@loaders.gl/textures` on the encode path only, which shells out to `npx
+texture-compressor`. OLV decodes glTF and never encodes, so it never invokes
+that CLI, and there are zero references to it in the built `dist`. The real
+package pulls `image-size@0.7.5`, which carries CVE-2025-71329 and
+CVE-2025-71330 (HIGH, denial of service) with no fixed upstream version. The
+stub removes `image-size` and its own transitives (`argparse`, `sprintf-js`)
+from the installed tree rather than accepting an advisory with no available fix.
+
 ## Deferred upgrades
 
 Remaining open Dependabot bumps are major-version migrations that would

--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,10 +1576,6 @@
         "@loaders.gl/core": "~4.4.0"
       }
     },
-    "node_modules/@loaders.gl/textures/node_modules/texture-compressor": {
-      "resolved": "node_modules/@loaders.gl/textures/vendor-stubs/texture-compressor",
-      "link": true
-    },
     "node_modules/@loaders.gl/textures/vendor-stubs/texture-compressor": {},
     "node_modules/@loaders.gl/worker-utils": {
       "version": "4.4.3",
@@ -7321,6 +7317,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/texture-compressor": {
+      "resolved": "node_modules/@loaders.gl/textures/vendor-stubs/texture-compressor",
+      "link": true
     },
     "node_modules/three": {
       "version": "0.184.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,6 +1576,11 @@
         "@loaders.gl/core": "~4.4.0"
       }
     },
+    "node_modules/@loaders.gl/textures/node_modules/texture-compressor": {
+      "resolved": "node_modules/@loaders.gl/textures/vendor-stubs/texture-compressor",
+      "link": true
+    },
+    "node_modules/@loaders.gl/textures/vendor-stubs/texture-compressor": {},
     "node_modules/@loaders.gl/worker-utils": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.3.tgz",
@@ -3719,15 +3724,6 @@
         "arrow2csv": "bin/arrow2csv.js"
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/array-back": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
@@ -5181,18 +5177,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/image-size": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
-      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/inherits": {
@@ -7170,12 +7154,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -7342,19 +7320,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/texture-compressor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/texture-compressor/-/texture-compressor-1.0.2.tgz",
-      "integrity": "sha512-dStVgoaQ11mA5htJ+RzZ51ZxIZqNOgWKAIvtjLrW1AliQQLCmrDqNzQZ8Jh91YealQ95DXt4MEduLzJmbs6lig==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.10",
-        "image-size": "^0.7.4"
-      },
-      "bin": {
-        "texture-compressor": "bin/texture-compressor.js"
       }
     },
     "node_modules/three": {

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "qs": "^6.15.2",
     "vitepress": {
       "vite": "^6.4.3"
-    }
+    },
+    "texture-compressor": "file:vendor-stubs/texture-compressor"
   }
 }

--- a/sbom.json
+++ b/sbom.json
@@ -1800,8 +1800,7 @@
       "name": "texture-compressor",
       "version": "1.0.2",
       "bom-ref": "openlidarviewer@0.6.4|texture-compressor@1.0.2",
-      "author": "Tim van Scherpenzeel",
-      "description": "CLI tool for texture compression using ASTC, ETC, PVRTC and S3TC in a KTX container.",
+      "description": "Local empty stub for the encode-only texture-compressor CLI, which OLV never invokes. Replaces the registry package via a file: override to drop its vulnerable image-size transitive (CVE-2025-71329/71330).",
       "licenses": [
         {
           "license": {
@@ -1811,19 +1810,6 @@
         }
       ],
       "purl": "pkg:npm/texture-compressor@1.0.2",
-      "externalReferences": [
-        {
-          "url": "https://registry.npmjs.org/texture-compressor/-/texture-compressor-1.0.2.tgz",
-          "type": "distribution",
-          "hashes": [
-            {
-              "alg": "SHA-512",
-              "content": "752b55828690d75980e61b49f91cd9e75671219a8d3a058a008bed8cbad6d409624102c29ab0ea373419f0987dd5879a950f790d7b7830476e2f32666ecea58a"
-            }
-          ],
-          "comment": "as detected from npm-ls property \"resolved\" and property \"integrity\""
-        }
-      ],
       "properties": [
         {
           "name": "cdx:npm:package:path",
@@ -2294,107 +2280,6 @@
     },
     {
       "type": "library",
-      "name": "argparse",
-      "version": "1.0.10",
-      "bom-ref": "openlidarviewer@0.6.4|argparse@1.0.10",
-      "description": "Very powerful CLI arguments parser. Native port of argparse - python's options parsing library",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/argparse@1.0.10",
-      "externalReferences": [
-        {
-          "url": "git+https://github.com/nodeca/argparse.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \"repository.url\""
-        },
-        {
-          "url": "https://github.com/nodeca/argparse#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \"homepage\""
-        },
-        {
-          "url": "https://github.com/nodeca/argparse/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \"bugs.url\""
-        },
-        {
-          "url": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "type": "distribution",
-          "hashes": [
-            {
-              "alg": "SHA-512",
-              "content": "a39468cbab4d1b848bfc53a408037a4738e26a4652db944b605adc32db49a9b75df015ab9c0f9f1b3e7b88de4f6f4ea9bc11af979810d01e3c74996c957be84e"
-            }
-          ],
-          "comment": "as detected from npm-ls property \"resolved\" and property \"integrity\""
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:npm:package:path",
-          "value": "node_modules/argparse"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "image-size",
-      "version": "0.7.5",
-      "bom-ref": "openlidarviewer@0.6.4|image-size@0.7.5",
-      "author": "netroy",
-      "description": "get dimensions of any image file",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/image-size@0.7.5",
-      "externalReferences": [
-        {
-          "url": "git+https://github.com/image-size/image-size.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \"repository.url\""
-        },
-        {
-          "url": "https://github.com/image-size/image-size#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \"homepage\""
-        },
-        {
-          "url": "https://github.com/image-size/image-size/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \"bugs.url\""
-        },
-        {
-          "url": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
-          "type": "distribution",
-          "hashes": [
-            {
-              "alg": "SHA-512",
-              "content": "1e2caffa65c77c510fecbcd42ff96583d470171c58fa8f4ddc954b21e1b913b88520501a971bd153d519b6105d6031159f31cc8239ca24f3e96b2e4159fd60f6"
-            }
-          ],
-          "comment": "as detected from npm-ls property \"resolved\" and property \"integrity\""
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:npm:package:path",
-          "value": "node_modules/image-size"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "undici-types",
       "version": "7.18.2",
       "bom-ref": "openlidarviewer@0.6.4|undici-types@7.18.2",
@@ -2745,57 +2630,6 @@
         {
           "name": "cdx:npm:package:path",
           "value": "node_modules/table-layout"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "sprintf-js",
-      "version": "1.0.3",
-      "bom-ref": "openlidarviewer@0.6.4|sprintf-js@1.0.3",
-      "author": "Alexandru Marasteanu",
-      "description": "JavaScript sprintf implementation",
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/sprintf-js@1.0.3",
-      "externalReferences": [
-        {
-          "url": "git+https://github.com/alexei/sprintf.js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \"repository.url\""
-        },
-        {
-          "url": "https://github.com/alexei/sprintf.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \"homepage\""
-        },
-        {
-          "url": "https://github.com/alexei/sprintf.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \"bugs.url\""
-        },
-        {
-          "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "type": "distribution",
-          "hashes": [
-            {
-              "alg": "SHA-512",
-              "content": "0fd70f824bcb955deddc8ccbd03d182ef180f40864e0f72f57051b3747521abd5a3f436bb780049d351bb86beab840b4980eb81aab757f38ab951b3989b5f1f2"
-            }
-          ],
-          "comment": "as detected from npm-ls property \"resolved\" and property \"integrity\""
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:npm:package:path",
-          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -3375,11 +3209,7 @@
       "ref": "openlidarviewer@0.6.4|ktx-parse@0.7.1"
     },
     {
-      "ref": "openlidarviewer@0.6.4|texture-compressor@1.0.2",
-      "dependsOn": [
-        "openlidarviewer@0.6.4|argparse@1.0.10",
-        "openlidarviewer@0.6.4|image-size@0.7.5"
-      ]
+      "ref": "openlidarviewer@0.6.4|texture-compressor@1.0.2"
     },
     {
       "ref": "openlidarviewer@0.6.4|@swc/helpers@0.5.23",
@@ -3427,15 +3257,6 @@
       "ref": "openlidarviewer@0.6.4|tslib@2.8.1"
     },
     {
-      "ref": "openlidarviewer@0.6.4|argparse@1.0.10",
-      "dependsOn": [
-        "openlidarviewer@0.6.4|sprintf-js@1.0.3"
-      ]
-    },
-    {
-      "ref": "openlidarviewer@0.6.4|image-size@0.7.5"
-    },
-    {
       "ref": "openlidarviewer@0.6.4|undici-types@7.18.2"
     },
     {
@@ -3462,9 +3283,6 @@
         "openlidarviewer@0.6.4|array-back@6.2.3",
         "openlidarviewer@0.6.4|wordwrapjs@5.1.1"
       ]
-    },
-    {
-      "ref": "openlidarviewer@0.6.4|sprintf-js@1.0.3"
     },
     {
       "ref": "openlidarviewer@0.6.4|chalk@4.1.2",

--- a/vendor-stubs/texture-compressor/package.json
+++ b/vendor-stubs/texture-compressor/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "texture-compressor",
+  "version": "1.0.2",
+  "description": "Local empty stub. @loaders.gl/textures' encode path shells out to `npx texture-compressor`; OLV only decodes glTF and never invokes it. The real package pulls image-size@0.7.5 (CVE-2025-71329/71330, no upstream fix). Stubbing removes that vulnerable transitive.",
+  "license": "MIT",
+  "private": true
+}


### PR DESCRIPTION
## What

Removes `image-size@0.7.5` from the installed dependency tree by stubbing out the encode-only `texture-compressor` package.

## Why

`image-size@0.7.5` carries **CVE-2025-71329** and **CVE-2025-71330** (HIGH, denial of service) with no fixed upstream version (`fixAvailable: false`). It enters the tree only as a transitive of `texture-compressor`, which sits under `@loaders.gl/textures` on the **encode** path and shells out to `npx texture-compressor`.

Reachability finding: OLV only **decodes** glTF and never encodes, so it never invokes that CLI. There are **0 references** to it in the built `dist`.

## How

- Add `vendor-stubs/texture-compressor/` as a local empty stub package.
- Add a `file:vendor-stubs/texture-compressor` entry to root `overrides`.
- Regenerate `package-lock.json`. `npm ls image-size` now resolves empty; `argparse` and `sprintf-js` (its own transitives) also leave the tree.

This **removes** the vulnerable dependency rather than accepting an advisory with no available fix.

## Honesty / bookkeeping

- `sbom.json`: dropped the `image-size`, `argparse`, `sprintf-js` components and their dependency-graph entries; marked `texture-compressor` as a local file stub (registry URL/hash removed).
- `docs/project/DEPENDENCIES.md`: added a "Stubbed to prune" note.

## Verification (offline)

`tsc --noEmit`, `npm run build`, `check:deps`, `lint:sbom`, `lint:release-sync`, `lint:release-truth`, `lint:evidence`, and `lint-monolith-size` all pass. Production dependency set stays at 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)