### PR TITLE
Repoint release pipeline to docs/releases/ and refresh reviewer docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           cp "release/test-evidence-v${V}.json" release/payload/
           cp release/production-audit.json release/payload/
           cp sbom.json release/payload/
-          cp "RELEASE_NOTES_v${V}.md" release/payload/
+          cp "docs/releases/RELEASE_NOTES_v${V}.md" release/payload/
           ls -la release/payload
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -1,6 +1,6 @@
 # Reproducibility
 
-This page is the single entry point for reproducing OpenLiDARViewer's build, tests, and reported analysis figures. It stitches together the pieces that also live in `README.md`, `REVIEWER_QUICKSTART.md`, and `docs/benchmarks.md`. The exact figures reported for the current release, each tied to the command that regenerates it, are in [REPRODUCIBILITY_v0.6.1.md](docs/releases/REPRODUCIBILITY_v0.6.1.md).
+This page is the single entry point for reproducing OpenLiDARViewer's build, tests, and reported analysis figures. It stitches together the pieces that also live in `README.md`, `REVIEWER_QUICKSTART.md`, and `docs/benchmarks.md`. The exact figures reported for the current release, each tied to the command that regenerates it, are in [REPRODUCIBILITY_v0.6.4.md](docs/releases/REPRODUCIBILITY_v0.6.4.md).
 
 ## Environment
 
@@ -25,7 +25,7 @@ npm ci
 | Regenerate analysis/benchmark figures | `npm run repro` |
 | Package source + deploy archives | `npm run package` |
 
-The authoritative deterministic gate is `npm run test:release` (typecheck, lints, all test buckets, both builds, bundle budget, plus plain and live-obfuscated smoke). The broader browser matrix that a device varies — the full end-to-end suite and the mobile responsive job — runs in CI (`.github/workflows/ci.yml`), not in `test:release`. The remaining physical-device coverage gaps for a tagged release are recorded in `RELEASE_NOTES_v0.6.1.md`.
+The authoritative deterministic gate is `npm run test:release` (typecheck, lints, all test buckets, both builds, bundle budget, plus plain and live-obfuscated smoke). The broader browser matrix that a device varies — the full end-to-end suite and the mobile responsive job — runs in CI (`.github/workflows/ci.yml`), not in `test:release`. The remaining physical-device coverage gaps for a tagged release are recorded in `docs/releases/RELEASE_NOTES_v0.6.4.md`.
 
 ### End-to-end browsers
 

--- a/REVIEWER_QUICKSTART.md
+++ b/REVIEWER_QUICKSTART.md
@@ -52,7 +52,7 @@ Everything happens on your machine; no data leaves the browser.
 ## Verifying a published release
 
 ```bash
-git checkout v0.6.1
+git checkout v0.6.4
 nvm use && npm ci
 npm run gate
 ```

--- a/docs/project/DEPENDENCIES.md
+++ b/docs/project/DEPENDENCIES.md
@@ -19,12 +19,12 @@ unaffected.
 
 | Field | Value |
 |---|---|
-| Release line | v0.6.1 |
+| Release line | v0.6.4 |
 | Baseline date (UTC) | 2026-07-25 |
 | Canonical Node | 22.17.1 (`.nvmrc`) |
 | Canonical npm | 10.9.2 (`package.json` `packageManager`) |
 | `package-lock` lockfileVersion | 3 |
-| SBOM | CycloneDX 1.6, root `openlidarviewer@0.6.1`, 59 components |
+| SBOM | CycloneDX 1.6, root `openlidarviewer@0.6.4`, 59 components |
 
 The CycloneDX bill of materials for the production dependency set is in
 [sbom.json](../../sbom.json). Licences are credited in
@@ -45,7 +45,7 @@ These ship in the deploy archive.
 | @loaders.gl/ply | ^4.4.2 | 4.4.3 | MIT |
 | laz-perf | ^0.0.7 | 0.0.7 | Apache-2.0 |
 | pdf-lib | ^1.17.1 | 1.17.1 | MIT |
-| proj4 | ^2.20.8 | 2.20.9 | MIT |
+| proj4 | ^2.21.0 | 2.21.0 | MIT |
 | three | ^0.184.0 | 0.184.0 | MIT |
 
 ## Direct development dependencies

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.4.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.4.md
@@ -54,7 +54,7 @@ Unchanged from prior releases: the viewer does not reproject between coordinate 
 
 ## Axis and compound-unit handling is correct but not yet uniform
 
-There is still no single explicit model spanning up-axis, horizontal unit, vertical unit and CRS, so an unusual combination is more likely to be silently plausible than loudly refused. A box measurement is stored as axis-aligned min/max corners and throws on a genuinely tilted up vector rather than reporting the extent along the nearest axis. No scan the viewer sets can currently trigger that, so the refusal guards the contract rather than gating a feature. A single explicit spatial model is a stable-v0.6 requirement.
+An explicit model spanning up-axis, horizontal unit, vertical unit and CRS now exists as `SpatialContext` (`src/geo/SpatialContext.ts`), but not every metric path consumes it yet, so an unusual combination can still be silently plausible where a caller reads the raw fields instead of the model. A box measurement is stored as axis-aligned min/max corners and throws on a genuinely tilted up vector rather than reporting the extent along the nearest axis. No scan the viewer sets can currently trigger that, so the refusal guards the contract rather than gating a feature. Full adoption of `SpatialContext` across every metric path is a stable-v0.6 requirement.
 
 ## Compatibility fallback verified against a forced configuration, not every device
 

--- a/scripts/lib/releaseDocs.mjs
+++ b/scripts/lib/releaseDocs.mjs
@@ -1,0 +1,33 @@
+/**
+ * releaseDocs.mjs — the one place that knows where a release's versioned
+ * documents live.
+ *
+ * The four truth documents (release notes, known limitations, validation
+ * report, reproducibility) moved from the repository root under
+ * `docs/releases/` in the v0.6.4 cycle. Several scripts built these paths by
+ * hand, so the move broke each one silently: the tag-time ref check reported a
+ * missing document, the evidence lint fell back to a different file, and the
+ * release workflow copied a path that no longer existed. Deriving the paths
+ * from one function keeps them from drifting apart again.
+ */
+
+/** Directory the versioned release documents live in, relative to repo root. */
+export const RELEASE_DOCS_DIR = 'docs/releases';
+
+/**
+ * The four versioned truth documents for a release, as repo-root-relative
+ * paths. `version` is the bare semver, e.g. "0.6.4".
+ */
+export function releaseDocsFor(version) {
+  return {
+    releaseNotes: `${RELEASE_DOCS_DIR}/RELEASE_NOTES_v${version}.md`,
+    knownLimitations: `${RELEASE_DOCS_DIR}/KNOWN_LIMITATIONS_v${version}.md`,
+    validationReport: `${RELEASE_DOCS_DIR}/VALIDATION_REPORT_v${version}.md`,
+    reproducibility: `${RELEASE_DOCS_DIR}/REPRODUCIBILITY_v${version}.md`,
+  };
+}
+
+/** The same four paths as an array, in a stable order. */
+export function releaseDocPaths(version) {
+  return Object.values(releaseDocsFor(version));
+}

--- a/scripts/lint-evidence.mjs
+++ b/scripts/lint-evidence.mjs
@@ -19,6 +19,7 @@ import { spawnSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { requireBinaryOnPath } from './lib/binaryOnPath.mjs';
+import { releaseDocsFor } from './lib/releaseDocs.mjs';
 
 const GIT = requireBinaryOnPath('git');
 
@@ -150,12 +151,16 @@ for (const k of ['liveEntryKiB', 'ceilingKiB']) {
 // version from package.json ties the list to what actually ships, and the
 // zero-documents guard below turns a vacuous pass into a failure.
 const VERSION = JSON.parse(read('package.json')).version;
+// The four versioned truth documents live under docs/releases/; the paths come
+// from one helper so this list cannot silently point at the repo root, where
+// existsSync → continue would let the guard pass while parsing nothing.
+const releaseDocs = releaseDocsFor(VERSION);
 const DOCS = [
-  `REPRODUCIBILITY_v${VERSION}.md`,
-  `VALIDATION_REPORT_v${VERSION}.md`,
+  releaseDocs.reproducibility,
+  releaseDocs.validationReport,
   `READINESS_REPORT_v${VERSION}.md`,
-  `KNOWN_LIMITATIONS_v${VERSION}.md`,
-  `RELEASE_NOTES_v${VERSION}.md`,
+  releaseDocs.knownLimitations,
+  releaseDocs.releaseNotes,
   'ARTIFACT_EVALUATION.md',
 ];
 if (DOCS.every((d) => !existsSync(resolve(ROOT, d)))) {

--- a/scripts/lint-release-sync.mjs
+++ b/scripts/lint-release-sync.mjs
@@ -287,6 +287,10 @@ const REFERRERS = [
   'docs/project/AI_ASSISTANCE.md',
   'ARTIFACT_EVALUATION.md',
   'docs-site/reproducibility/validation-report.md',
+  // The unversioned reproducibility entry point points at the current
+  // release's evidence file; it drifted to v0.6.1 after the docs moved under
+  // docs/releases/, and nothing noticed because the old link still resolved.
+  'REPRODUCIBILITY.md',
 ];
 for (const file of REFERRERS) {
   let text;
@@ -310,6 +314,23 @@ for (const file of REFERRERS) {
           `the link still resolves, so it silently sends a reviewer to the wrong release's evidence.`,
       );
     }
+  }
+}
+
+// 8b. The reviewer quickstart tells a reader which tag to check out. It carried
+// `git checkout v0.6.1` after the release moved to v0.6.4 — a stale instruction
+// that lands a reviewer on the wrong release, and one nothing checked because
+// it names a tag, not a versioned filename. Require the checkout tag to be the
+// current release.
+if (existsSync(resolve(ROOT, 'REVIEWER_QUICKSTART.md'))) {
+  const quickstart = read('REVIEWER_QUICKSTART.md');
+  const checkout = /git checkout v([0-9][0-9A-Za-z.\-]*)/.exec(quickstart);
+  if (!checkout) {
+    problems.push('REVIEWER_QUICKSTART.md has no "git checkout vX.Y.Z" line to check.');
+  } else if (checkout[1] !== version) {
+    problems.push(
+      `REVIEWER_QUICKSTART.md says "git checkout v${checkout[1]}", expected v${version} — it sends a reviewer to the wrong release.`,
+    );
   }
 }
 

--- a/scripts/validate-release-ref.mjs
+++ b/scripts/validate-release-ref.mjs
@@ -20,6 +20,7 @@ import { execFileSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { requireBinaryOnPath } from './lib/binaryOnPath.mjs';
+import { releaseDocPaths } from './lib/releaseDocs.mjs';
 
 // Spawned programs are resolved to an absolute path by reading PATH, so the
 // path that runs is a value this script can name rather than whatever the OS
@@ -92,14 +93,10 @@ export function validateReleaseRef({ env = {}, git = {}, files = {}, requireTag 
     } catch { problems.push('sbom.json is not valid JSON'); }
   }
 
-  // 5. Every document a reader is promised for this release.
-  for (const name of [
-    `RELEASE_NOTES_v${version}.md`,
-    `KNOWN_LIMITATIONS_v${version}.md`,
-    `VALIDATION_REPORT_v${version}.md`,
-    `REPRODUCIBILITY_v${version}.md`,
-  ]) {
-    if (read(name) === null) problems.push(`${name} is missing`);
+  // 5. Every document a reader is promised for this release. These live under
+  // docs/releases/; the paths come from one helper so they cannot drift.
+  for (const path of releaseDocPaths(version)) {
+    if (read(path) === null) problems.push(`${path} is missing`);
   }
 
   return { ok: problems.length === 0, problems, version, expectedTag };

--- a/tests/evidenceReleasePathLint.test.ts
+++ b/tests/evidenceReleasePathLint.test.ts
@@ -1,0 +1,52 @@
+/**
+ * evidenceReleasePathLint.test.ts — proves scripts/lint-evidence.mjs actually
+ * parses the versioned release documents under docs/releases/.
+ *
+ * The four truth documents moved from the repository root to docs/releases/ in
+ * the v0.6.4 cycle. lint-evidence still built root paths, so a wrong test count
+ * inside a real release document was invisible: the path did not exist, the
+ * loop's `existsSync → continue` skipped it, and the guard fell back to a
+ * different file. This writes a false bucket total into the real release
+ * document and requires the lint to refuse it, so the path can never silently
+ * drift back to the root.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+// @ts-expect-error — plain .mjs helper, no types
+import { releaseDocsFor } from '../scripts/lib/releaseDocs.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const VERSION = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')).version as string;
+const evidence = JSON.parse(readFileSync(resolve(ROOT, 'docs/validation/test-evidence.json'), 'utf8'));
+
+const runLint = () =>
+  spawnSync('node', ['scripts/lint-evidence.mjs'], { cwd: ROOT, encoding: 'utf8' });
+
+describe('lint:evidence release-doc path', () => {
+  it('passes on the real, correct tree', () => {
+    expect(runLint().status).toBe(0);
+  });
+
+  it('refuses a false bucket total written into a real release document', () => {
+    // The validation report is one of the four versioned docs under docs/releases/.
+    const doc = releaseDocsFor(VERSION).validationReport as string;
+    const abs = resolve(ROOT, doc);
+    const original = readFileSync(abs, 'utf8');
+    // A bucket count that cannot be the real one (real unit passed is thousands).
+    const bucket = Object.keys(evidence.buckets)[0];
+    try {
+      writeFileSync(abs, `${original}\n${bucket} 1 passed\n`);
+      const r = runLint();
+      expect(r.status).not.toBe(0);
+      expect(r.stderr + r.stdout).toContain(doc);
+    } finally {
+      writeFileSync(abs, original);
+    }
+    // The tree is restored, so a follow-up run is green again.
+    expect(runLint().status).toBe(0);
+  });
+});

--- a/tests/validateReleaseRef.test.ts
+++ b/tests/validateReleaseRef.test.ts
@@ -18,10 +18,10 @@ function files(over: Record<string, string | null> = {}) {
     'package-lock.json': JSON.stringify({ version: VERSION, packages: { '': { version: VERSION } } }),
     'CITATION.cff': `version: ${VERSION}\n`,
     'sbom.json': JSON.stringify({ metadata: { component: { version: VERSION } } }),
-    [`RELEASE_NOTES_v${VERSION}.md`]: 'notes',
-    [`KNOWN_LIMITATIONS_v${VERSION}.md`]: 'limits',
-    [`VALIDATION_REPORT_v${VERSION}.md`]: 'validation',
-    [`REPRODUCIBILITY_v${VERSION}.md`]: 'repro',
+    [`docs/releases/RELEASE_NOTES_v${VERSION}.md`]: 'notes',
+    [`docs/releases/KNOWN_LIMITATIONS_v${VERSION}.md`]: 'limits',
+    [`docs/releases/VALIDATION_REPORT_v${VERSION}.md`]: 'validation',
+    [`docs/releases/REPRODUCIBILITY_v${VERSION}.md`]: 'repro',
     ...over,
   };
   return { read: (p: string) => (p in base ? base[p] : null) };
@@ -82,10 +82,10 @@ describe('validateReleaseRef', () => {
 
   it('refuses when a promised evidence document is missing', () => {
     for (const doc of [
-      `RELEASE_NOTES_v${VERSION}.md`,
-      `KNOWN_LIMITATIONS_v${VERSION}.md`,
-      `VALIDATION_REPORT_v${VERSION}.md`,
-      `REPRODUCIBILITY_v${VERSION}.md`,
+      `docs/releases/RELEASE_NOTES_v${VERSION}.md`,
+      `docs/releases/KNOWN_LIMITATIONS_v${VERSION}.md`,
+      `docs/releases/VALIDATION_REPORT_v${VERSION}.md`,
+      `docs/releases/REPRODUCIBILITY_v${VERSION}.md`,
     ]) {
       const r = run({ files: files({ [doc]: null }) });
       expect(r.problems.some((p) => p.includes(doc))).toBe(true);


### PR DESCRIPTION
The versioned release documents moved under `docs/releases/` in the root-cleanup + v0.6.4 bump. Several release-time scripts still built repo-root paths and broke silently (they run only at tag time or fail open), and three reviewer-facing docs kept v0.6.1 references. An external audit verified these; per-PR CI did not catch them.

## Release-pipeline path regressions fixed
- **scripts/validate-release-ref.mjs** — looked for the four versioned docs at repo root, so the tag gate would report them missing. Now resolves them under `docs/releases/`.
- **.github/workflows/release.yml** — the source copy `cp "RELEASE_NOTES_v${V}.md"` (line 127) pointed at a path that no longer exists. Now `docs/releases/RELEASE_NOTES_v${V}.md`. The other two references read from the flat payload / staged dir and are correct as-is.
- **scripts/lint-evidence.mjs** — built root paths for the four docs, so `existsSync → continue` skipped every real release doc and the guard fell back to `ARTIFACT_EVALUATION.md`. Test-count drift inside the actual release docs was invisible. Now parses `docs/releases/`.
- **scripts/lib/releaseDocs.mjs** — new shared helper `releaseDocsFor(version)` / `releaseDocPaths(version)`, used by validate-release-ref and lint-evidence so the paths cannot drift apart again.

## lint:evidence false-count proof
Appended `unit 1 passed` to `docs/releases/VALIDATION_REPORT_v0.6.4.md` and ran `npm run lint:evidence`:

Before fix: PASS (fell back to ARTIFACT_EVALUATION.md; drift invisible).
After fix: FAIL —
```
docs/releases/VALIDATION_REPORT_v0.6.4.md: "unit 1" — the unit bucket ran 4,726 passed.
```
Line removed; lint:evidence green again.

## Regression test
`tests/evidenceReleasePathLint.test.ts` writes a false bucket total into the real release doc and asserts lint:evidence exits non-zero and names the doc, then restores the tree. `tests/validateReleaseRef.test.ts` updated to the docs/releases/ paths.

## Doc-truth fixes
- **docs/project/DEPENDENCIES.md** — release line v0.6.4, SBOM root `openlidarviewer@0.6.4`, proj4 `^2.21.0 / 2.21.0` (verified against package.json / lock / sbom.json).
- **REPRODUCIBILITY.md** — current-release references repointed to the v0.6.4 docs under docs/releases/.
- **REVIEWER_QUICKSTART.md** — `git checkout v0.6.4`.
- **docs/releases/KNOWN_LIMITATIONS_v0.6.4.md** — corrected "no single explicit model" to reflect that `SpatialContext` (src/geo/SpatialContext.ts) exists but adoption across every metric path is incomplete.
- **scripts/lint-release-sync.mjs** — REPRODUCIBILITY.md added to the evidence-referrer scan, and a check that REVIEWER_QUICKSTART's `git checkout vX.Y.Z` names the current release, so a future stale v-reference fails CI.

## Gates (offline)
tsc --noEmit, build, lint:release-sync, lint:release-truth, lint:evidence, lint:monolith-size, lint:doc-links all pass. validate-release-ref now finds the four docs (only "working tree not clean" remained pre-commit). New + updated tests: 22 passed.

This unblocks the exact-tag v0.6.4 release workflow.
