### PR TITLE
Pin generatedAt in the purpose byte-identity PDF test

### DIFF
--- a/tests/mapSheetPdf.test.ts
+++ b/tests/mapSheetPdf.test.ts
@@ -334,7 +334,15 @@ describe('buildMapSheetPdf — purpose deliverable content', () => {
   } as const;
 
   it('is byte-identical to the pre-purpose sheet when purpose is absent or null', async () => {
-    const base = { model, labels: [] as never[], provenance: PROV } as const;
+    // A fixed generatedAt: the sheet stamps the generation time to the minute,
+    // so two builds that straddle a boundary differ in bytes for a reason this
+    // test is not about.
+    const base = {
+      model,
+      labels: [] as never[],
+      provenance: PROV,
+      generatedAt: new Date(0),
+    } as const;
     const absent = await buildMapSheetPdf({ ...base });
     const nul = await buildMapSheetPdf({ ...base, purpose: null });
     expect(Buffer.from(nul).equals(Buffer.from(absent))).toBe(true);


### PR DESCRIPTION
`main` is red: `test (ui, 1/1)` fails on `tests/mapSheetPdf.test.ts > is byte-identical to the pre-purpose sheet when purpose is absent or null`.

**Cause.** The test builds two PDFs and compares bytes, but neither build pins `generatedAt`, so each stamps its own generation time. Two builds either side of a minute boundary differ in bytes for a reason the test is not about. This is timing, not a regression from the mobile change it surfaced on.

**Fix.** Pass `generatedAt: new Date(0)`, exactly as the annotation byte-identity test in the same file already does.

**Verification.** The suite passes 29/29 on five consecutive runs; typecheck clean. Risk: low, test-only. Rollback: revert the single commit.