### PR TITLE
Restore the coverage floor and pin the map-sheet PDF date at the source

### DIFF
--- a/src/render/measure/mapSheetPdf.ts
+++ b/src/render/measure/mapSheetPdf.ts
@@ -357,6 +357,15 @@ export async function buildMapSheetPdf(input: MapSheetInput): Promise<Uint8Array
   doc.setTitle(input.title ?? 'Contour Map', { showInWindowTitleBar: true });
   doc.setLanguage('en-US');
   doc.setAuthor('OpenLiDARViewer');
+  // Pin the document's Info-dictionary dates. pdf-lib defaults CreationDate and
+  // ModDate to the wall clock at `create()`, so two otherwise-identical sheets
+  // built either side of a second boundary embed different timestamps and cease
+  // to be byte-identical — a real determinism hole the visible `generatedAt`
+  // stamp (title block) never covered. Sourcing both from the same generatedAt
+  // makes a build with a fixed date reproducible and matches the printed stamp.
+  const stamp = input.generatedAt ?? new Date();
+  doc.setCreationDate(stamp);
+  doc.setModificationDate(stamp);
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
 

--- a/tests/axisGetters.test.ts
+++ b/tests/axisGetters.test.ts
@@ -1,0 +1,32 @@
+/**
+ * axisGetters — the one place H1/H2/V projection is defined, so the ground
+ * filter, DTM rasteriser, DSM builder and hold-out validation cannot drift on
+ * which source axis is "up". Both conventions are exercised: 'z'-up (the
+ * common case) and 'y'-up (glTF/Three-style sources), because the vertical
+ * choice swaps which of y/z is horizontal and which is height.
+ */
+import { describe, it, expect } from 'vitest';
+import { axisGetters } from '../src/terrain/ground/axisGetters';
+import type { TerrainPoint } from '../src/terrain/TerrainContracts';
+
+const P: TerrainPoint = { x: 1, y: 2, z: 3 };
+
+describe('axisGetters', () => {
+  it("'z'-up keeps y horizontal and z vertical", () => {
+    const g = axisGetters('z');
+    expect(g.getH1(P)).toBe(1);
+    expect(g.getH2(P)).toBe(2);
+    expect(g.getV(P)).toBe(3);
+  });
+
+  it("'y'-up swaps: z becomes the second horizontal, y becomes height", () => {
+    const g = axisGetters('y');
+    expect(g.getH1(P)).toBe(1);
+    expect(g.getH2(P)).toBe(3);
+    expect(g.getV(P)).toBe(2);
+  });
+
+  it('H1 is the x axis under either convention', () => {
+    expect(axisGetters('z').getH1(P)).toBe(axisGetters('y').getH1(P));
+  });
+});

--- a/tests/layerCompatibility.test.ts
+++ b/tests/layerCompatibility.test.ts
@@ -17,6 +17,7 @@ import {
   classifyLayerCompatibility,
   participatesInSharedAnalysis,
   alignsVertically,
+  compatibilityNote,
   type CompatibilityInput,
 } from '../src/model/layerCompatibility';
 
@@ -218,5 +219,25 @@ describe('vertical reference identity', () => {
   it('an unrecognised name still matches itself', () => {
     const s = at([withVertical('a', 'Site benchmark A'), withVertical('b', 'Site benchmark A')]);
     expect(s('a')).toBe('verified');
+  });
+});
+
+describe('compatibilityNote', () => {
+  it('gives a distinct, non-empty sentence for each state', () => {
+    const states = ['verified', 'horizontal-only', 'unknown', 'incompatible'] as const;
+    const notes = states.map(compatibilityNote);
+    for (const n of notes) expect(n.length).toBeGreaterThan(0);
+    expect(new Set(notes).size).toBe(states.length);
+  });
+
+  it('only the verified state omits the "excluded from combined results" caveat', () => {
+    expect(compatibilityNote('verified')).not.toMatch(/excluded from combined/i);
+    for (const c of ['horizontal-only', 'unknown', 'incompatible'] as const) {
+      expect(compatibilityNote(c)).toMatch(/excluded from combined/i);
+    }
+  });
+
+  it('horizontal-only names the X/Y-only placement that defines it', () => {
+    expect(compatibilityNote('horizontal-only')).toMatch(/X\/Y only/);
   });
 });

--- a/tests/layerPlacement.test.ts
+++ b/tests/layerPlacement.test.ts
@@ -13,6 +13,7 @@ import {
   rayOriginToLayer,
   accumulatorOffset,
   mergePlacedBounds,
+  placeBufferInto,
 } from '../src/render/layerPlacement';
 import {
   createProjectFrame,
@@ -108,5 +109,31 @@ describe('mergePlacedBounds', () => {
   it('returns null for nothing visible', () => {
     expect(mergePlacedBounds([])).toBeNull();
     expect(mergePlacedBounds([], null)).toBeNull();
+  });
+});
+
+describe('placeBufferInto', () => {
+  it('the identity copies positions verbatim and returns the advanced offset', () => {
+    const src = new Float32Array([1, 2, 3, 4, 5, 6]);
+    const dest = new Float32Array(6);
+    const next = placeBufferInto(dest, 0, src, IDENTITY);
+    expect(Array.from(dest)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(next).toBe(6);
+  });
+
+  it('a real placement folds the translation into every point', () => {
+    const [dx, dy, dz] = accumulatorOffset(OFFSET);
+    const src = new Float32Array([0, 0, 0, 10, 20, 30]);
+    const dest = new Float32Array(6);
+    placeBufferInto(dest, 0, src, OFFSET);
+    expect(Array.from(dest)).toEqual([dx, dy, dz, 10 + dx, 20 + dy, 30 + dz]);
+  });
+
+  it('writes at a non-zero destination offset without touching earlier slots', () => {
+    const src = new Float32Array([7, 8, 9]);
+    const dest = new Float32Array([1, 1, 1, 0, 0, 0]);
+    const next = placeBufferInto(dest, 3, src, IDENTITY);
+    expect(Array.from(dest)).toEqual([1, 1, 1, 7, 8, 9]);
+    expect(next).toBe(6);
   });
 });

--- a/tests/mapSheetPdf.test.ts
+++ b/tests/mapSheetPdf.test.ts
@@ -237,6 +237,24 @@ describe('buildMapSheetPdf', () => {
     expect(Buffer.from(off).equals(Buffer.from(absent))).toBe(true);
   });
 
+  it('sources the document date from generatedAt, so a fixed date is byte-reproducible', async () => {
+    // Guards the pdf-lib Info-dictionary dates (CreationDate/ModDate), which
+    // default to the wall clock at build time. Two builds either side of a
+    // second boundary used to differ there even with a fixed visible stamp.
+    const base = { model, labels: [] as never[], crs: model.crs, sheet: 'letter' as const };
+    const a1 = await buildMapSheetPdf({ ...base, generatedAt: new Date(0) });
+    const a2 = await buildMapSheetPdf({ ...base, generatedAt: new Date(0) });
+    expect(Buffer.from(a1).equals(Buffer.from(a2))).toBe(true);
+
+    // Two instants in the SAME minute but different seconds: the visible stamp
+    // (minute precision) is identical, so the only thing that can move the bytes
+    // is the document date being pinned to generatedAt. Without the pin both
+    // builds would take the wall clock and land in the same second — equal bytes.
+    const atSecond00 = await buildMapSheetPdf({ ...base, generatedAt: new Date(0) });
+    const atSecond30 = await buildMapSheetPdf({ ...base, generatedAt: new Date(30_000) });
+    expect(Buffer.from(atSecond00).equals(Buffer.from(atSecond30))).toBe(false);
+  });
+
   it('draws additional content when annotations are included', async () => {
     const base = { model, labels: [], crs: model.crs, verticalDatum: model.verticalDatum, sheet: 'letter' as const };
     const plain = await buildMapSheetPdf({ ...base });

--- a/tests/numerics.test.ts
+++ b/tests/numerics.test.ts
@@ -100,3 +100,20 @@ describe('neumaierSum / NeumaierSum', () => {
     expect(neumaierSum([])).toBe(0);
   });
 });
+
+describe('WelfordStats sample vs population spread', () => {
+  it('sampleStd uses the n-1 divisor, so it exceeds populationStd', () => {
+    const w = new WelfordStats();
+    for (const x of [2, 4, 4, 4, 5, 5, 7, 9]) w.push(x);
+    // Deviations from the mean of 5 sum to 32 in square; n = 8.
+    expect(w.populationStd).toBeCloseTo(2, 12); // sqrt(32/8)
+    expect(w.sampleStd).toBeCloseTo(Math.sqrt(32 / 7), 12); // sqrt(32/7)
+    expect(w.sampleStd).toBeGreaterThan(w.populationStd);
+  });
+
+  it('a single sample has zero sample spread rather than dividing by zero', () => {
+    const w = new WelfordStats();
+    w.push(42);
+    expect(w.sampleStd).toBe(0);
+  });
+});


### PR DESCRIPTION
The `coverage` check on main HEAD (the #301 merge) is red — it is the only failing check. The v0.6.4 feature merges dropped v8 coverage to **85.88% functions / 87.99% statements** on the Linux runner, under the 86% / 88% floors. Those same thresholds gate a **mandatory stage in the release gate** (`scripts/gate.sh`), so this also blocks cutting the v0.6.4 tag — it is not cosmetic.

## What this does

**1. Restores the coverage floor with real tests (not padding).** Five genuinely-untested pure functions had slipped below the line:
- `axisGetters` — only the `'z'`-up branch was exercised; the `'y'`-up arrows were uncovered
- `WelfordStats.sampleStd` — no test read the sample (n−1) spread
- `compatibilityNote` — the 4-state note strings
- `placeBufferInto` — both the identity and the additive fold
- the sample-vs-population spread path

Result: **functions 86.3%** (1437/1665), **statements 88.13%** (14504/16457) — clear of both floors with margin, and stable on the Linux basis (the +5 functions run on every platform).

**2. Fixes the real map-sheet PDF determinism hole at the source.** #301 pinned `generatedAt` per-test, but that only fixes the *visible* collar stamp — pdf-lib defaults the document `CreationDate`/`ModDate` to the wall clock at `create()`, so two byte-identity builds crossing a *second* boundary still differed. That flake tripped a byte-identity assertion during the coverage run. The builder now sources both Info-dict dates from the same `generatedAt`, so a fixed date is byte-reproducible and the metadata matches the printed stamp. A regression test guards it deterministically (two instants in one minute, different seconds: identical stamp, bytes differing only because the date is now pinned).

## Verification
- `tsc --noEmit`: clean
- Full suite under coverage: **8000 passed / 3 skipped**, `vitest` **exit 0** (thresholds met)
- `mapSheetPdf.test.ts`: **8/8 consecutive deterministic passes**
- `lint:archive-vocab`, `lint:position-access`, `lint:architecture-truth`: pass