### PR TITLE
Stop the architecture-truth gate from failing on the published source archive

### DIFF
--- a/scripts/lint-architecture-truth.mjs
+++ b/scripts/lint-architecture-truth.mjs
@@ -25,10 +25,27 @@ import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const read = (rel) => readFileSync(resolve(ROOT, rel), 'utf8');
+/**
+ * Read a tracked file, turning a missing one into a stated lint failure rather
+ * than an uncaught ENOENT. A stack trace from inside a release stage reads as a
+ * broken toolchain; "required document is missing" reads as what it is, and
+ * names the file the gate expected.
+ */
+const read = (rel) => {
+  try {
+    return readFileSync(resolve(ROOT, rel), 'utf8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      throw new Error(`required file is missing: ${rel}`);
+    }
+    throw err;
+  }
+};
 const countLines = (rel) => read(rel).split('\n').length;
 
 const problems = [];
+/** Checks deliberately not performed (absent optional documents). */
+const notes = [];
 const facts = [];
 const fact = (name, value) => {
   facts.push(`${name} = ${value}`);
@@ -158,9 +175,19 @@ const fact = (name, value) => {
   fact('positions reads', reads);
   fact('positions read files', files.size);
 
+  // This plan is `export-ignore`d (.gitattributes), so it is present in the
+  // repository and ABSENT from the published source archive. Reading it
+  // unguarded made the whole release gate ENOENT when run from that archive —
+  // the gate passed for us and failed for anyone who downloaded the source.
+  // A cross-check against a document that ships nowhere is a repo-only check:
+  // skip it when the document is absent, and say so rather than passing
+  // silently. Fact 7 below already guards its document this way.
   const PLAN = 'docs/architecture/float64-frame-migration-plan.md';
-  const planText = read(PLAN);
-  const claim = planText.match(/([\d,]+)\s+direct\s+`?\.positions`?\s+reads\s+across\s+(\d+)\s+files/i);
+  const planText = existsSync(resolve(ROOT, PLAN)) ? read(PLAN) : null;
+  if (planText === null) {
+    notes.push(`${PLAN} is not present (export-ignored); its position-read claim was not cross-checked.`);
+  }
+  const claim = planText?.match(/([\d,]+)\s+direct\s+`?\.positions`?\s+reads\s+across\s+(\d+)\s+files/i);
   if (claim) {
     const statedReads = Number(claim[1].replace(/,/g, ''));
     const statedFiles = Number(claim[2]);
@@ -216,6 +243,9 @@ if (problems.length > 0) {
 
 console.log(`lint:architecture-truth OK — ${facts.length} facts checked against the docs.`);
 console.log(facts.map((f) => `    ${f}`).join('\n'));
+// Printed on the passing path too: a check that did not run is not a check that
+// passed, and the difference is invisible unless it is stated.
+for (const n of notes) console.log(`    (skipped) ${n}`);
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 function walk(dir, exclude) {


### PR DESCRIPTION
Found by an external review of the v0.6.4 source archive, and confirmed here.

## The defect

`scripts/lint-architecture-truth.mjs` read `docs/architecture/float64-frame-migration-plan.md` **unguarded**. That document is `export-ignore`d in `.gitattributes:46` — deliberately present in the repo and **absent from the published source archive**.

`lint:architecture-truth` is part of `test:release:execute`. So from the shipped archive the entire release gate died with an uncaught `ENOENT` **before the tests or the build ran**. It passed for us and failed for anyone who downloaded the source — the gate was structurally unable to verify the artifact it ships with.

The same script's Fact 7 already guards its document with `existsSync`; Fact 5 did not. That inconsistency was the bug.

## The fix

- Guard the read. When the document is absent, **skip that cross-check** instead of inventing a verdict from a file that ships nowhere — it is a repo-only check by construction.
- **Report the skip on the passing path.** A check that did not run is not a check that passed, and the difference is otherwise invisible.
- Missing files now raise `required file is missing: <path>` rather than a raw ENOENT stack, so an genuinely absent tracked document reads as a lint result, not a broken toolchain.

## Verification

| Tree | Before | After |
|---|---|---|
| Full repository | passes | passes — all facts checked (162 reads / 43 files) |
| `git archive` output (published shape) | **ENOENT, gate dead** | passes, states the skipped check |

Reproduced the archive case directly by extracting `git archive origin/main` into a clean directory and running the lint there.

## Not fixed here

The review also notes the enforced ratchet reports 179 reads / 44 files while this scanner reports 162 / 43. That is a real inconsistency between two scanners with different scopes, worth reconciling separately — it does not block the gate.