### PR TITLE
Capture an export's inputs before its first await and verify them before writing

### DIFF
--- a/src/app/kmlActions.ts
+++ b/src/app/kmlActions.ts
@@ -131,7 +131,11 @@ export async function exportSiteKml(deps: KmlActionDeps): Promise<void> {
   const crs = deps.crsCurrent();
   const toLonLat = makeLocalToLonLat(crs, geo.origin);
   if (!toLonLat) return; // gated by siteKmlStatus; defensive no-op if reached
-  const { buildKml, KmlCoordinateError } = await deps.loadKmlExport();
+  // Every input is read BEFORE the serialiser import. The origin and CRS above
+  // were already captured pre-await while the features, up vector and unit scale
+  // were read after it, so a placement made (or a scan opened) during the import
+  // produced a file mixing one moment's frame with another's contents. One
+  // reading of the session, then the load.
   const input: KmlExportInput = {
     annotations: deps.annotations(),
     measurements: deps.measurements(),
@@ -157,6 +161,7 @@ export async function exportSiteKml(deps: KmlActionDeps): Promise<void> {
     notSurveyGradeNote: NOT_SURVEY_GRADE,
   };
   const stem = geo.name ? deps.baseName(geo.name) : 'site';
+  const { buildKml, KmlCoordinateError } = await deps.loadKmlExport();
   let text: string;
   try {
     text = buildKml(input);

--- a/src/export/exportScanIdentity.ts
+++ b/src/export/exportScanIdentity.ts
@@ -1,0 +1,66 @@
+/**
+ * exportScanIdentity.ts
+ *
+ * The identity check every export owes the user: the file that lands in
+ * Downloads has to describe the scan the export was asked for.
+ *
+ * An export is not instantaneous. A full-resolution re-decode runs off-thread
+ * for seconds, a contour regeneration rebuilds geometry, and even a "warm" lazy
+ * `import()` yields the event loop. Nothing is disabled while that happens, so
+ * the user can open another scan — or reclassify points — in the gap between
+ * "what am I exporting" and "write the bytes". Every input read AFTER that gap
+ * belongs to whatever is active now: the world origin, the CRS, the filename
+ * stem. Pair those with geometry captured before it and the file is internally
+ * inconsistent while reporting success.
+ *
+ * The codebase already answers this for async analysis: openScan.ts captures a
+ * target id before its first await and drops the result when `activeId` moved
+ * (openScan.ts:361), and terrainAnalysisRunner.ts re-checks the same id after
+ * every await (terrainAnalysisRunner.ts:333-335). This is that rule carried to
+ * the export boundary — capture the target before the first await, compare
+ * before writing, and refuse rather than ship a file whose provenance is a
+ * guess.
+ *
+ * KNOWN REACH: a streaming scan reports a null id, so swapping one streaming
+ * scan for another is invisible to this comparison. That is the same blind spot
+ * the runner's stale guard has, because both read the same shell identity;
+ * closing it means giving streaming scans a stable id in the shell, which is a
+ * change to the shell rather than to this rule.
+ *
+ * Pure data — the comparison plus the refusal wording. No DOM, no I/O.
+ */
+
+/**
+ * Whether two readings of "which scan is this" name the same target.
+ *
+ * A null id is a value, not "unknown" — the shell reports null for a streaming
+ * scan, and that is the identity the terrain runner's own guard compares. If
+ * null were treated as a wildcard the check would fail OPEN on exactly the path
+ * where a mismatch is hardest to see, so null matches only null.
+ */
+export function sameExportTarget(a: string | null, b: string | null): boolean {
+  return a === b;
+}
+
+/**
+ * Refusal for a point-cloud export whose scan was swapped mid-flight. Names the
+ * consequence (a file stamped with the wrong scan's frame) and the way forward,
+ * in the voice of the full-res classification refusal it sits next to.
+ */
+export const EXPORT_SCAN_CHANGED_REFUSAL =
+  'The active scan changed while this export was being prepared, so nothing was '
+  + 'written — the file would have carried one scan\'s points under another scan\'s '
+  + 'coordinate system and name. Select the scan you want and export again.';
+
+/**
+ * Refusal for a terrain deliverable built from an analysis that belongs to a
+ * scan which is no longer active. Distinct wording from the mid-export race
+ * above because this one is not a race at all: the result simply outlived its
+ * scan (an additive open never clears it), so the user needs to re-run rather
+ * than retry.
+ */
+export const TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL =
+  'This terrain analysis was computed on a different scan than the one now '
+  + 'active, so nothing was written — the contours, rasters and report would have '
+  + 'been stamped with the active scan\'s origin, coordinate system and name. '
+  + 'Re-run the analysis on this scan to export it.';

--- a/src/export/fullResClassGuard.ts
+++ b/src/export/fullResClassGuard.ts
@@ -53,6 +53,24 @@ export const FULL_RES_CLASS_EDITS_REFUSAL =
   'export them at display resolution, or untick "Include classification" to ' +
   'export the full scan without them.';
 
+/**
+ * The same refusal, for the case where the edits arrive DURING the export.
+ *
+ * The gate above is evaluated when the user presses Export, but a full-res
+ * export then spends seconds re-decoding the source off-thread with the
+ * reclassify tools still live. An edit made in that window passes the gate and
+ * is absent from the file, which is the exact outcome this module exists to
+ * refuse — so the decision is re-taken after the decode and, when it flips, the
+ * user is told why nothing was written rather than being handed a lossy file
+ * with a success message.
+ */
+export const FULL_RES_CLASS_EDITS_MID_EXPORT_REFUSAL =
+  'Points were reclassified while the full-resolution re-decode was running, so '
+  + 'nothing was written — the file would have carried the re-decoded classes and '
+  + 'silently dropped those edits. Untick "convert at full resolution" to export '
+  + 'them at display resolution, or untick "Include classification" to export the '
+  + 'full scan without them.';
+
 /** A full-res export decision: allowed, or refused with a reason. */
 export interface FullResClassExportDecision {
   readonly allowed: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2299,7 +2299,7 @@ function newAnalysePanel(
     // Same cached-core rebuild, generalised with the contour shape-style picker so
     // an export reflects the user's chosen interval AND line shape.
     buildResultForExport: (opts) => terrainRunner.buildResultForExport(opts),
-    getExportBasename: () => lastCloudName, getAnnotations: () => viewer.annotate.getAnnotations(),
+    getExportBasename: () => lastCloudName, getAnnotations: () => viewer.annotate.getAnnotations(), getActiveScanId: () => scans.activeId,
     // Terrain Intelligence Report (v0.4.5): hand the report the Inspector
     // card's CURRENT Dataset Intelligence summary so the PDF's bucket labels
     // are the card's own strings (null when the card is empty — the report
@@ -3015,9 +3015,8 @@ const exportPanel = new ExportPanel({
   // Pending = a streaming cloud is attached but its export frontier is still
   // empty. Read the allocation-free frontier count rather than materialising a
   // snapshot just to test it for null.
-  isStreamingPending: () =>
-    viewer?.streamingCloud != null && viewer.exportFrontierPointTotal() === 0,
-  getActiveClip: () => viewer.getClip(),
+  isStreamingPending: () => viewer?.streamingCloud != null && viewer.exportFrontierPointTotal() === 0,
+  getActiveClip: () => viewer.getClip(), getActiveScanId: () => scans.activeId,
   hasFullSource: () => scans.activeId != null && sourceFileById.has(scans.activeId),
   hasClassEdits: () => scans.activeId != null && (viewer?.canUndoClassification(scans.activeId) ?? false),
   // A streaming snapshot exports only resident points, so it is a reduced subset
@@ -3053,22 +3052,23 @@ const exportPanel = new ExportPanel({
     if (!viewer) return;
     const measurements = viewer.measure.getMeasurements();
     if (measurements.length === 0) return;
-    const { measurementsToGeoJSON, measurementsToCsv } = await loadMeasurementExport();
     // Measurement points are LOCAL (recentered); add the origin back to land them
     // in the source projected/local frame. `exportGeoContext` resolves the
     // origin for streaming scans too (renderOrigin) — a plain static-only read
     // would export at render-frame coordinates. Geographic reprojection
     // (→ lon/lat) is a later option — for now we emit in the scan's own frame.
+    // Resolved BEFORE the import below (as exportIntegrityReport already does),
+    // so the frame and the measurements come from one instant, not two.
     const geo = exportGeoContext();
-    const origin = geo.origin;
     const ctx: MeasurementExportContext = {
-      toOutput: (p) => [p[0] + origin[0], p[1] + origin[1], p[2] + origin[2]],
+      toOutput: (p) => [p[0] + geo.origin[0], p[1] + geo.origin[1], p[2] + geo.origin[2]],
       up: viewer.measure.worldUp,
       unitToMetres: viewer.measure.unitToMetres,
       verticalUnitToMetres: viewer.measure.verticalUnitToMetres,
       crsName: geo.crsName,
       geographic: false,
     };
+    const { measurementsToGeoJSON, measurementsToCsv } = await loadMeasurementExport();
     const text = format === 'geojson'
       ? measurementsToGeoJSON(measurements, ctx)
       : measurementsToCsv(measurements, ctx);

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -113,6 +113,10 @@ import type {
   ContourExportPermit,
 } from '../export/contourExportPermit';
 import { permitStamp } from '../export/permitStamp';
+import {
+  sameExportTarget,
+  TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL,
+} from '../export/exportScanIdentity';
 import type { ExportPermitStamp } from '../terrain/export/exportProvenance';
 import type { ContourExportAdapter, ContourExportHost } from './contourExportAdapter';
 import { loadContourExportAdapter } from '../lazyChunks';
@@ -159,6 +163,19 @@ export interface AnalysePanelCallbacks {
   }) => Promise<AnalyseContoursResult>;
   /** Optional basename for downloaded files (e.g. the scan name). */
   getExportBasename?: () => string;
+  /**
+   * The shell's active-scan id (null for a streaming scan). Stamped onto each
+   * result in {@link AnalysePanel.update} and compared again at export time.
+   *
+   * A terrain result is only cleared when the session resets, so opening a
+   * SECOND scan additively leaves the first scan's contours, DEM and report on
+   * screen while `getMapContext` / `getExportBasename` have already moved to the
+   * new scan. Exporting then writes A's geometry with B's world origin, CRS,
+   * linear unit and filename — no timing involved, it reproduces every time.
+   * With this wired the panel refuses instead. When omitted the panel cannot
+   * tell the two apart and behaves as before.
+   */
+  getActiveScanId?: () => string | null;
   /**
    * Switch the 3D viewer's colour mode to the colourblind-safe 'confidence'
    * trust overlay — the SAME per-cell confidence + strong/moderate/weak
@@ -315,6 +332,13 @@ export class AnalysePanel {
   private readonly _validationRow: HTMLElement;
   private readonly _body: HTMLElement;
   private _result: AnalyseContoursResult | null = null;
+  /**
+   * The scan `_result` was computed on, stamped when the result lands. The
+   * result outlives an additive scan open (only a session reset clears it), so
+   * this is what tells an export that the analysis on screen and the map context
+   * it would be stamped with come from two different scans.
+   */
+  private _resultScanId: string | null = null;
   /** The "Colour 3D by confidence" toggle button + its current on/off state, so
    *  its label always shows the way back to the original colour. */
   private _confidenceColorBtn?: HTMLButtonElement;
@@ -601,6 +625,10 @@ export class AnalysePanel {
   /** Re-render from a fresh analysis result (or clear when null). */
   update(result: AnalyseContoursResult | null): void {
     this._result = result;
+    // Bind the result to the scan it was computed on. The runner only lands a
+    // result while its own dataset guard still holds, so the active id here IS
+    // the id the analysis ran against.
+    this._resultScanId = result ? this._cb.getActiveScanId?.() ?? null : null;
     // Any update supersedes a pending staleness caveat: a fresh result was
     // computed against the edited classes, and a clear removes the result
     // the caveat was about.
@@ -1874,6 +1902,27 @@ export class AnalysePanel {
   }
 
   /**
+   * Refuse an export whose result belongs to a scan that is no longer active,
+   * and say so on the panel. Returns true when the caller must write nothing.
+   *
+   * Every terrain deliverable mixes the result (computed on one scan) with the
+   * host's live map context and basename (read from whatever is active now), so
+   * a result that outlived its scan would be published in the wrong frame under
+   * the wrong name. Refusing is deliberate over silently clearing the result:
+   * the analysis is the user's work and re-running it is their call, so the
+   * panel keeps it on screen and explains why it cannot be exported.
+   *
+   * Called at the head of every export path AND again after any regeneration
+   * await, since a scan can be opened while contours are being rebuilt.
+   */
+  private _refuseForeignScanExport(): boolean {
+    if (!this._result || !this._cb.getActiveScanId) return false;
+    if (sameExportTarget(this._resultScanId, this._cb.getActiveScanId())) return false;
+    this.setStaleNotice(TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL);
+    return true;
+  }
+
+  /**
    * Resolve the full analysis result to serialize for a contour export at the
    * panel's current shape style. Reuses the on-screen result when the style
    * already matches (no recompute); otherwise regenerates from the cached core at
@@ -1927,7 +1976,13 @@ export class AnalysePanel {
     if (!this._result || this._result.model.features.length === 0) {
       return;
     }
+    if (this._refuseForeignScanExport()) return;
+    // Both frame inputs are read HERE, before the regeneration await below: the
+    // rebuild can take seconds and the host's map context follows the ACTIVE
+    // scan, so reading it afterwards would georeference these contours with
+    // whatever scan the user opened meanwhile.
     const basename = this._cb.getExportBasename?.() ?? 'contours';
+    const mapCtx = this._cb.getMapContext?.();
     const label = btn?.textContent ?? '';
     if (btn) {
       btn.disabled = true;
@@ -1940,6 +1995,11 @@ export class AnalysePanel {
       const result = await this._resultForExport();
       const [{ serializeContours, triggerBrowserDownload }, { buildExportProvenance }] =
         await Promise.all([loadContourDownload(), loadExportProvenance()]);
+      // Re-verify after the regeneration: the captured context is the right one
+      // for `basename`/`mapCtx`, but a scan opened during the rebuild means the
+      // user is no longer looking at this analysis, and publishing it now would
+      // hand them a file for a scan they have moved on from.
+      if (this._refuseForeignScanExport()) return;
       const provenance = buildExportProvenance(result, {
         basename,
         generatedAt: new Date(),
@@ -1958,7 +2018,6 @@ export class AnalysePanel {
       // `worldOrigin` the DEM package and map sheet already use). When the host
       // can't supply one, serializeContours omits the CRS stamp rather than
       // georeferencing local coordinates.
-      const mapCtx = this._cb.getMapContext?.();
       const worldOrigin = mapCtx?.worldOrigin ?? null;
       triggerBrowserDownload(
         serializeContours(result.model, fmt, {
@@ -2057,13 +2116,16 @@ export class AnalysePanel {
   ): Promise<void> {
     const r = this._result;
     if (!r) return;
+    if (this._refuseForeignScanExport()) return;
     const label = btn.textContent ?? 'DEM (ZIP)';
     btn.disabled = true;
     btn.textContent = '…';
+    // Frame + name captured before the writer chunk loads, so the raster and its
+    // .prj / README describe the scan this result came from.
+    const ctx = this._cb.getMapContext?.() ?? {};
+    const basename = this._cb.getExportBasename?.() ?? 'terrain';
     try {
       const { buildDemPackage } = await loadDemPackage();
-      const ctx = this._cb.getMapContext?.() ?? {};
-      const basename = this._cb.getExportBasename?.() ?? 'terrain';
       const bytes = buildDemPackage(r, {
         worldOrigin: ctx.worldOrigin ?? null,
         basename,
@@ -2107,6 +2169,12 @@ export class AnalysePanel {
     intent: ContourExportIntent,
   ): Promise<void> {
     if (!permit.ok || !this._result) return;
+    if (this._refuseForeignScanExport()) return;
+    // Captured before the regeneration + writer awaits below (which are seconds
+    // of work), so the bundle's origin, unit and filename belong to the scan the
+    // contours were computed on.
+    const ctx = this._cb.getMapContext?.() ?? {};
+    const basename = this._cb.getExportBasename?.() ?? 'contours';
     try {
       // Regenerate the bundled geometry at the SELECTED PURPOSE's style + tolerance
       // (Survey Review = exact analytical; a cartographic purpose = generalized at
@@ -2126,8 +2194,9 @@ export class AnalysePanel {
       const [{ buildContourDeliverableFromResultAsync }] = await Promise.all([
         loadContourDeliverableBuild(),
       ]);
-      const ctx = this._cb.getMapContext?.() ?? {};
-      const basename = this._cb.getExportBasename?.() ?? 'contours';
+      // Same re-verification as the vector exports: a scan opened during the
+      // rebuild means this bundle is no longer the one the user is looking at.
+      if (this._refuseForeignScanExport()) return;
       const bytes = await buildContourDeliverableFromResultAsync(result, {
         decision: permit.decision,
         basename,
@@ -2171,13 +2240,16 @@ export class AnalysePanel {
   ): Promise<void> {
     const r = this._result;
     if (!r) return;
+    if (this._refuseForeignScanExport()) return;
     const label = btn.textContent ?? 'Intelligence report (PDF)';
     btn.disabled = true;
     btn.textContent = '…';
+    // Name + frame read before the pdf-lib chunk loads, so the report's header
+    // describes the scan its verdicts were computed on.
+    const basename = this._cb.getExportBasename?.() ?? 'terrain';
+    const mapCtx = this._cb.getMapContext?.() ?? {};
     try {
       const { buildTerrainReportPdf } = await loadTerrainReportPdf();
-      const basename = this._cb.getExportBasename?.() ?? 'terrain';
-      const mapCtx = this._cb.getMapContext?.() ?? {};
       // The renderer assembles the content from the SAME result the panel shows,
       // stamping the unified provenance via these options — so the report's
       // header / footer (CRS, datum, verdicts, accuracy, date) can never drift
@@ -2223,6 +2295,10 @@ export class AnalysePanel {
     // Same hard guard as the export itself — a blocked / empty result never
     // reaches the dialog.
     if (!r || r.model.features.length === 0 || r.quality.exportReadiness === 'blocked') return;
+    // Refuse before the dialog rather than after the user fills the title block:
+    // the pre-filled fields come from the ACTIVE scan while `r` came from
+    // another, so the sheet would document a scan it does not plot.
+    if (this._refuseForeignScanExport()) return;
 
     const ctx = this._cb.getMapContext?.() ?? {};
     const basename = this._cb.getExportBasename?.() ?? 'contours';
@@ -2518,25 +2594,31 @@ export class AnalysePanel {
       console.warn('OpenLiDARViewer: map sheet export refused — no granted evidence permit (§19).');
       return;
     }
-    const { buildMapSheetPdf } = await loadMapSheetPdf();
-    const { buildExportProvenance } = await loadExportProvenance();
+    // The dialog can sit open for minutes and its Export can regenerate the
+    // contours, so the scan is checked again here — right before the sheet is
+    // built — not only when the dialog was opened.
+    if (this._refuseForeignScanExport()) return;
     // Resolved linear unit so the sheet's scale bar + 1:N ratio honour a foot
     // CRS (the map is drawn in source units) instead of the metre default. Read
-    // the map context ONCE — it also supplies the scene up-axis the annotation
-    // markers are rotated by.
+    // the map context ONCE, before the pdf chunks load — it also supplies the
+    // scene up-axis the annotation markers are rotated by.
     const mapCtx = this._cb.getMapContext?.();
     const linearUnit = mapCtx?.linearUnit;
+    const sheetBasename = this._cb.getExportBasename?.() ?? undefined;
     // Annotation layer inputs, only gathered when the user opted in. The list is
     // read straight from the host (same order as the Annotations panel, so the
-    // marker index matches). The up-axis MUST be the gather's own — see the
-    // frame reasoning in annotationMapProjection.ts.
+    // marker index matches) — and read here, alongside the rest of the sheet's
+    // inputs, so the whole sheet comes from one instant. The up-axis MUST be the
+    // gather's own — see the frame reasoning in annotationMapProjection.ts.
     const annotations = opts.includeAnnotations ? this._cb.getAnnotations?.() ?? [] : [];
     const sceneUpAxis = mapCtx?.sceneUpAxis ?? 'z';
+    const { buildMapSheetPdf } = await loadMapSheetPdf();
+    const { buildExportProvenance } = await loadExportProvenance();
     // The unified provenance, derived from the SAME result the sheet plots, so
     // the title block's CRS / datum / style / accuracy / readiness / date can't
     // drift from the GeoJSON / DXF / SVG / DEM exports of this scan.
     const provenance = buildExportProvenance(result, {
-      basename: this._cb.getExportBasename?.() ?? undefined,
+      basename: sheetBasename,
       generatedAt: opts.generatedAt,
       softwareVersion: __APP_VERSION__,
       metricVersion: TERRAIN_METRIC_VERSION,

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -18,7 +18,11 @@ import { CONVERT_FORMATS, type ConvertFormat, type CrsMode, type ConvertOptions 
 import type { PointCloud } from '../model/PointCloud';
 import { gzipConvertedFile, gzipAvailable } from '../convert/gzip';
 import { buildExportSummary, type ExportSummaryInput } from '../export/exportSummary';
-import { evaluateFullResClassExport } from '../export/fullResClassGuard';
+import {
+  evaluateFullResClassExport,
+  FULL_RES_CLASS_EDITS_MID_EXPORT_REFUSAL,
+} from '../export/fullResClassGuard';
+import { sameExportTarget, EXPORT_SCAN_CHANGED_REFUSAL } from '../export/exportScanIdentity';
 import { clipCloud } from '../render/clip/clipCloud';
 import type { ClipBox } from '../render/clip/clipBox';
 
@@ -117,6 +121,15 @@ export interface ExportPanelCallbacks {
   scanFootprintStatus?: () => { ready: boolean; reason: string };
   /** The active clip box, if any — when enabled, the cloud export is restricted to it. */
   getActiveClip?: () => ClipBox | null;
+  /**
+   * Which scan the panel is exporting, as the shell's own active-scan id (null
+   * for a streaming scan). Read once before the export's first await and again
+   * before the bytes are written: a full-resolution re-decode takes seconds
+   * off-thread and nothing stops the user opening another scan meanwhile, which
+   * would otherwise write one scan's points under another's name and CRS. When
+   * omitted the panel cannot make that comparison and exports as before.
+   */
+  getActiveScanId?: () => string | null;
   /**
    * Whether a streaming scan is attached but has no resident points to export
    * yet. Lets the gate say "still streaming in" instead of the misleading
@@ -686,6 +699,13 @@ export class ExportPanel {
       return;
     }
 
+    // Snapshot the export's inputs BEFORE the first await. The clip box decides
+    // which points reach the file, and the user can drag or disable it while the
+    // decode runs — reading it afterwards would filter the export by a box that
+    // was never part of the request. `scanId` is the identity re-verified below.
+    const clip = this._cb.getActiveClip?.() ?? null;
+    const scanId = this._cb.getActiveScanId?.() ?? null;
+
     this._busy = true;
     this._exportBtn.disabled = true;
     this._exportBtn.textContent = useFull ? 'Re-decoding…' : 'Exporting…';
@@ -697,8 +717,27 @@ export class ExportPanel {
         this._setStatus('Could not read the source at full resolution.', 'error');
         return;
       }
-      // Respect an active clip: export only the points inside (or outside) the box.
-      const clip = this._cb.getActiveClip?.() ?? null;
+      // The decode is over — prove the export still describes what was asked for
+      // before any bytes are written. Nothing disables the scan list or the
+      // reclassify tools while a multi-second full-res decode runs off-thread, so
+      // both facts the gate above depends on can have moved underneath it. The
+      // class gate is re-taken rather than re-implemented: an edit made during the
+      // decode flips exactly the input it already reads.
+      if (!sameExportTarget(this._cb.getActiveScanId?.() ?? null, scanId)) {
+        this._setStatus(EXPORT_SCAN_CHANGED_REFUSAL, 'error');
+        return;
+      }
+      const classGateAfter = evaluateFullResClassExport({
+        fullRes: useFull,
+        includeClassification: this._includeClass,
+        hasClassEdits: this._cb.hasClassEdits?.() ?? false,
+      });
+      if (!classGateAfter.allowed) {
+        this._setStatus(FULL_RES_CLASS_EDITS_MID_EXPORT_REFUSAL, 'error');
+        return;
+      }
+      // Respect an active clip: export only the points inside (or outside) the
+      // box the user had set when they pressed Export (captured above).
       const clipped = clip != null && clip.enabled;
       const cloud = clipped ? clipCloud(sourceCloud, clip) : sourceCloud;
       this._exportBtn.textContent = 'Exporting…';

--- a/tests/analysePanelScanIdentity.test.ts
+++ b/tests/analysePanelScanIdentity.test.ts
@@ -1,0 +1,222 @@
+/**
+ * analysePanelScanIdentity.test.ts
+ *
+ * A terrain result is cleared only when the session resets. Opening a SECOND
+ * scan additively leaves the first scan's contours, DEM and report on screen
+ * while the host's map context and filename have already moved to the new scan —
+ * so an export written then carries A's geometry with B's world origin, CRS,
+ * linear unit and name. No race is involved: it reproduces every time.
+ *
+ * These tests pin the binding that stops it — the result remembers the scan it
+ * was computed on, and every export path refuses when that is no longer the
+ * active scan — and pin that the refusal is a refusal, not a silent clear: the
+ * user's analysis stays on screen with the reason shown.
+ *
+ * Driven with a REAL analysis result (same approach as
+ * analysePanelCoverageTile.test.ts) in the node environment via a DOM stub.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { analyseContours } from '../src/terrain/contour/analyseContours';
+import { TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL } from '../src/export/exportScanIdentity';
+import type { TerrainPoint } from '../src/terrain/TerrainContracts';
+import type { ContourExportPermit } from '../src/export/contourExportPermit';
+
+const hoisted = vi.hoisted(() => ({ downloads: [] as string[] }));
+
+vi.mock('../src/io/download', () => ({
+  triggerDownload: (_blob: unknown, filename: string) => { hoisted.downloads.push(filename); },
+  downloadBytes: (filename: string) => { hoisted.downloads.push(filename); },
+}));
+
+class FakeEl {
+  className = '';
+  title = '';
+  type = '';
+  disabled = false;
+  width = 0;
+  height = 0;
+  href = '';
+  download = '';
+  private _text = '';
+  readonly children: FakeEl[] = [];
+  readonly dataset: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly classList = {
+    add(): void { /* no-op */ },
+    remove(): void { /* no-op */ },
+    toggle(): void { /* no-op */ },
+  };
+  readonly tagName: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+  setAttribute(): void { /* no-op */ }
+  removeAttribute(): void { /* no-op */ }
+  getContext(): null { return null; }
+  getBoundingClientRect(): { width: number; height: number; left: number; top: number } {
+    return { width: 0, height: 0, left: 0, top: 0 };
+  }
+  set textContent(v: string) { this._text = v; }
+  get textContent(): string {
+    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
+  }
+  append(...kids: FakeEl[]): void { this.children.push(...kids.filter(Boolean)); }
+  replaceChildren(...kids: FakeEl[]): void { this.children.length = 0; this.children.push(...kids); }
+  addEventListener(): void { /* no-op */ }
+  blur(): void { /* no-op */ }
+  click(): void { /* no-op */ }
+  /** Every descendant carrying `cls` in its own className. */
+  findByClass(cls: string): FakeEl[] {
+    const out: FakeEl[] = [];
+    if (this.className.split(/\s+/).includes(cls)) out.push(this);
+    for (const c of this.children) out.push(...c.findByClass(cls));
+    return out;
+  }
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { document: unknown }).document = {
+    createElement: (tag: string) => new FakeEl(tag),
+    createElementNS: (_ns: string, tag: string) => new FakeEl(tag),
+  };
+  (globalThis as unknown as { requestAnimationFrame?: unknown }).requestAnimationFrame = undefined;
+});
+
+beforeEach(() => { hoisted.downloads.length = 0; });
+
+/** A small hill, enough for a real analysis with contours. */
+function hillScene(): TerrainPoint[] {
+  const pts: TerrainPoint[] = [];
+  for (let x = 0; x <= 30; x++) {
+    for (let y = 0; y <= 30; y++) {
+      const dx = x - 15;
+      const dy = y - 15;
+      pts.push({ x, y, z: 6 * Math.exp(-(dx * dx + dy * dy) / 200) });
+    }
+  }
+  return pts;
+}
+
+/** The private export surface these tests drive directly (no Studio mount). */
+interface ExportInternals {
+  _resultScanId: string | null;
+  _refuseForeignScanExport(): boolean;
+  _exportDemPackage(btn: unknown): Promise<void>;
+  _exportTerrainReport(btn: unknown): Promise<void>;
+  _exportContourFormat(fmt: string, btn?: unknown, extra?: unknown): Promise<void>;
+  _exportCompletePackage(permit: unknown, intent: unknown): Promise<void>;
+}
+
+/** A panel holding an analysis of scan A, plus the levers to move the session. */
+async function panelWithResultForScanA() {
+  const { AnalysePanel } = await import('../src/ui/AnalysePanel');
+  let activeId: string | null = 'scan-a';
+  let basename = 'scan-a';
+  /** Every map-context read, so a test can prove a refusal happened FIRST. */
+  const mapContextReads: string[] = [];
+  const panel = new AnalysePanel({
+    getActiveScanId: () => activeId,
+    getExportBasename: () => basename,
+    getMapContext: () => {
+      mapContextReads.push(basename);
+      return { worldOrigin: { x: 1, y: 2, z: 3 }, linearUnit: 'metre' as const };
+    },
+  });
+  panel.update(analyseContours(hillScene(), {
+    cellSizeM: 2,
+    crs: 'EPSG:32610',
+    verticalDatum: 'EPSG:5703',
+  }));
+  return {
+    panel,
+    internals: panel as unknown as ExportInternals,
+    root: panel.element as unknown as FakeEl,
+    mapContextReads,
+    /** The additive open of a second scan: active id + basename both move. */
+    openScanB: (): void => { activeId = 'scan-b'; basename = 'scan-b'; },
+    setActiveId: (id: string | null): void => { activeId = id; },
+  };
+}
+
+const grantedPermit = { ok: true, decision: {} } as unknown as ContourExportPermit;
+
+function noticeText(root: FakeEl): string {
+  return root.findByClass('olv-analyse-stale-notice')[0]?.textContent ?? '';
+}
+
+describe('AnalysePanel — a result belongs to the scan it was computed on', () => {
+  it('stamps the active scan onto the result when it lands', async () => {
+    const { internals } = await panelWithResultForScanA();
+    expect(internals._resultScanId).toBe('scan-a');
+  });
+
+  it('clears the stamp when the result is cleared', async () => {
+    const { panel, internals } = await panelWithResultForScanA();
+    panel.update(null);
+    expect(internals._resultScanId).toBe(null);
+  });
+
+  it('refuses the DEM package once another scan is active', async () => {
+    const { internals, root, mapContextReads, openScanB } = await panelWithResultForScanA();
+    mapContextReads.length = 0;
+    openScanB();
+    await internals._exportDemPackage(new FakeEl('button'));
+
+    expect(hoisted.downloads, 'a raster was written for the wrong scan').toEqual([]);
+    // Refused BEFORE the frame was read: had it been read, the .prj / README
+    // would already be describing scan B.
+    expect(mapContextReads).toEqual([]);
+    expect(noticeText(root)).toBe(TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL);
+  });
+
+  it('refuses the intelligence report once another scan is active', async () => {
+    const { internals, root, openScanB } = await panelWithResultForScanA();
+    openScanB();
+    await internals._exportTerrainReport(new FakeEl('button'));
+    expect(hoisted.downloads).toEqual([]);
+    expect(noticeText(root)).toBe(TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL);
+  });
+
+  it('refuses a contour vector export once another scan is active', async () => {
+    const { internals, root, mapContextReads, openScanB } = await panelWithResultForScanA();
+    mapContextReads.length = 0;
+    openScanB();
+    await internals._exportContourFormat('geojson', undefined, { permit: grantedPermit });
+    expect(hoisted.downloads).toEqual([]);
+    expect(mapContextReads).toEqual([]);
+    expect(noticeText(root)).toBe(TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL);
+  });
+
+  it('refuses the complete deliverable once another scan is active', async () => {
+    const { internals, root, openScanB } = await panelWithResultForScanA();
+    openScanB();
+    await internals._exportCompletePackage(grantedPermit, {
+      shapeStyle: 'analytical',
+      methodTag: 'analytical',
+      purpose: 'survey-review',
+    });
+    expect(hoisted.downloads).toEqual([]);
+    expect(noticeText(root)).toBe(TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL);
+  });
+
+  it('keeps the analysis on screen rather than discarding the user\'s work', async () => {
+    const { panel, internals, openScanB } = await panelWithResultForScanA();
+    openScanB();
+    await internals._exportDemPackage(new FakeEl('button'));
+    // Refuse, do not clear: re-running the analysis is the user's decision.
+    expect(panel.currentResult()).not.toBeNull();
+    expect(internals._resultScanId).toBe('scan-a');
+  });
+
+  it('allows the export while the originating scan is still active', async () => {
+    const { internals } = await panelWithResultForScanA();
+    expect(internals._refuseForeignScanExport()).toBe(false);
+  });
+
+  it('treats a streaming scan (null id) as a target of its own', async () => {
+    // null is a value, not a wildcard: a result computed while a streaming scan
+    // was active must not be exportable against a static scan that opened after.
+    const { internals, setActiveId } = await panelWithResultForScanA();
+    setActiveId(null);
+    expect(internals._refuseForeignScanExport()).toBe(true);
+  });
+});

--- a/tests/exportPanelSnapshotIntegrity.test.ts
+++ b/tests/exportPanelSnapshotIntegrity.test.ts
@@ -1,0 +1,275 @@
+/**
+ * exportPanelSnapshotIntegrity.test.ts
+ *
+ * A full-resolution export re-decodes the source file off-thread. That takes
+ * seconds, and nothing in the app is disabled while it runs — the user can
+ * reclassify points, drag the clip box, or open another scan in the gap between
+ * pressing Export and the bytes being written.
+ *
+ * These tests pin the two halves of the answer:
+ *
+ *   1. CAPTURE BEFORE THE AWAIT — the clip box that decides which points reach
+ *      the file is the one the user had set when they pressed Export.
+ *   2. VERIFY BEFORE THE WRITE — the classification gate and the active-scan
+ *      identity are re-checked after the decode, and a change refuses the export
+ *      instead of writing a file that silently omits the edits.
+ *
+ * The decode is simulated by mutating the panel's own callback state INSIDE the
+ * awaited `getFullCloud`, which is exactly when a real user's edit would land.
+ * Node environment via a recording DOM stub.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { PointCloud } from '../src/model/PointCloud';
+import type { ClipBox } from '../src/render/clip/clipBox';
+
+const hoisted = vi.hoisted(() => ({
+  /** Every cloud handed to the converter, so a test can see what was written. */
+  converted: [] as { pointCount: number }[],
+  /** Filenames that reached the browser download helper. */
+  downloads: [] as string[],
+}));
+
+vi.mock('../src/lazyChunks', () => ({
+  loadConvertEngine: async () => ({
+    convertCloud: (cloud: { pointCount: number }) => {
+      hoisted.converted.push(cloud);
+      return {
+        file: { filename: 'scan.las', bytes: new Uint8Array([0]), mime: 'application/octet-stream' },
+        report: { pointCount: cloud.pointCount, crsNote: 'CRS kept', log: [] },
+      };
+    },
+  }),
+}));
+
+vi.mock('../src/io/download', () => ({
+  downloadBytes: (filename: string) => { hoisted.downloads.push(filename); },
+  triggerDownload: () => { /* unused here */ },
+}));
+
+class FakeEl {
+  className = '';
+  title = '';
+  type = '';
+  href = '';
+  value = '';
+  placeholder = '';
+  inputMode = '';
+  checked = false;
+  disabled = false;
+  readonly style: Record<string, string> = {};
+  readonly dataset: Record<string, string> = {};
+  private _text = '';
+  readonly attrs: Record<string, string> = {};
+  readonly children: FakeEl[] = [];
+  private readonly _listeners: Record<string, (() => void)[]> = {};
+  readonly classList = {
+    _set: new Set<string>(),
+    add: (c: string): void => { this.classList._set.add(c); },
+    remove: (c: string): void => { this.classList._set.delete(c); },
+    toggle: (c: string, force?: boolean): void => {
+      const on = force ?? !this.classList._set.has(c);
+      if (on) this.classList._set.add(c);
+      else this.classList._set.delete(c);
+    },
+    contains: (c: string): boolean => this.classList._set.has(c),
+  };
+  readonly tagName: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+  set textContent(v: string) { this._text = v; }
+  get textContent(): string {
+    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
+  }
+  set innerHTML(_v: string) { /* icons only */ }
+  setAttribute(k: string, v: string): void { this.attrs[k] = v; }
+  removeAttribute(k: string): void { delete this.attrs[k]; }
+  append(...kids: FakeEl[]): void { this.children.push(...kids.filter(Boolean)); }
+  replaceChildren(...kids: FakeEl[]): void { this.children.length = 0; this.children.push(...kids); }
+  addEventListener(type: string, fn: () => void): void {
+    (this._listeners[type] ??= []).push(fn);
+  }
+  /** Fire every listener registered for `type` (the panel binds click/change). */
+  fire(type: string): void {
+    for (const fn of this._listeners[type] ?? []) fn();
+  }
+  findByClass(cls: string): FakeEl[] {
+    const out: FakeEl[] = [];
+    if (this.className.split(/\s+/).includes(cls)) out.push(this);
+    for (const c of this.children) out.push(...c.findByClass(cls));
+    return out;
+  }
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { document: unknown }).document = {
+    createElement: (tag: string) => new FakeEl(tag),
+  };
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.HTMLInputElement = class {};
+  g.HTMLAnchorElement = class {};
+});
+
+beforeEach(() => {
+  hoisted.converted.length = 0;
+  hoisted.downloads.length = 0;
+});
+
+/** Two points one unit apart on x, so a clip box can keep exactly one of them. */
+function twoPointCloud(name = 'scan.las'): PointCloud {
+  return new PointCloud({
+    positions: new Float32Array([0, 0, 0, 10, 0, 0]),
+    classification: new Uint8Array([2, 2]),
+    origin: [0, 0, 0],
+    sourceFormat: 'las',
+    name,
+  });
+}
+
+/** A clip that keeps only the point at the origin. */
+const keepsFirstPointOnly: ClipBox = {
+  box: { min: [-1, -1, -1], max: [1, 1, 1] },
+  mode: 'keep-inside',
+  enabled: true,
+};
+
+/**
+ * Tick the full-resolution checkbox the way a user does. The gzip row reuses the
+ * same class names, so the label text is what tells the two checkboxes apart.
+ */
+function enableFullRes(root: FakeEl): void {
+  const label = root
+    .findByClass('olv-export-fullres-label')
+    .find((l) => l.textContent.includes('Convert at full resolution'));
+  expect(label, 'full-resolution checkbox missing').toBeDefined();
+  const box = label!.children[0];
+  box.checked = true;
+  box.fire('change');
+}
+
+function statusText(root: FakeEl): string {
+  return root.findByClass('olv-export-status')[0]?.textContent ?? '';
+}
+
+/** Press Export and wait for the async export to settle. */
+async function pressExport(root: FakeEl): Promise<void> {
+  root.findByClass('olv-export-btn')[0].fire('click');
+  // Two macrotask turns: the decode promise, then the convert-engine import.
+  for (let i = 0; i < 4; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('ExportPanel — full-resolution export re-verifies before it writes', () => {
+  it('refuses when points are reclassified during the re-decode', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const cloud = twoPointCloud();
+    // No edits when Export is pressed — so the up-front gate ALLOWS this export.
+    // The edit lands mid-decode, which is the whole point: the display buffer now
+    // holds classes the re-decoded file cannot carry.
+    let hasClassEdits = false;
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => true,
+      isReduced: () => true,
+      getFullCloud: async () => {
+        hasClassEdits = true;
+        return cloud;
+      },
+      hasClassEdits: () => hasClassEdits,
+      getActiveScanId: () => 'scan-a',
+    });
+    const root = panel.element as unknown as FakeEl;
+    enableFullRes(root);
+    await pressExport(root);
+
+    expect(hoisted.downloads, 'a file was written despite the mid-export edit').toEqual([]);
+    expect(hoisted.converted).toEqual([]);
+    expect(statusText(root)).toMatch(/reclassified while the full-resolution re-decode was running/);
+    // The refusal names both lossless escapes, exactly like the up-front gate.
+    expect(statusText(root)).toMatch(/convert at full resolution/);
+    expect(statusText(root)).toMatch(/Include classification/);
+  });
+
+  it('refuses when the active scan changes during the re-decode', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const { EXPORT_SCAN_CHANGED_REFUSAL } = await import('../src/export/exportScanIdentity');
+    const cloud = twoPointCloud();
+    let activeId = 'scan-a';
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => true,
+      isReduced: () => true,
+      getFullCloud: async () => {
+        activeId = 'scan-b'; // the user opened another scan while we decoded
+        return cloud;
+      },
+      getActiveScanId: () => activeId,
+    });
+    const root = panel.element as unknown as FakeEl;
+    enableFullRes(root);
+    await pressExport(root);
+
+    expect(hoisted.downloads).toEqual([]);
+    expect(statusText(root)).toBe(EXPORT_SCAN_CHANGED_REFUSAL);
+  });
+
+  it('clips with the box captured BEFORE the decode, not the one set during it', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const cloud = twoPointCloud();
+    // Enabled when Export is pressed (keeps 1 of 2 points); cleared mid-decode.
+    // Reading the clip after the await would export both points — a file the
+    // user never asked for, in a session where the box was active at request time.
+    let clip: ClipBox | null = keepsFirstPointOnly;
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => true,
+      isReduced: () => true,
+      getFullCloud: async () => {
+        clip = null;
+        return cloud;
+      },
+      getActiveClip: () => clip,
+      getActiveScanId: () => 'scan-a',
+    });
+    const root = panel.element as unknown as FakeEl;
+    enableFullRes(root);
+    await pressExport(root);
+
+    expect(hoisted.downloads).toEqual(['scan.las']);
+    expect(hoisted.converted.length).toBe(1);
+    expect(hoisted.converted[0].pointCount, 'the post-await clip was used').toBe(1);
+    expect(statusText(root)).toMatch(/clipped to box/);
+  });
+
+  it('exports normally when nothing moved during the decode', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const cloud = twoPointCloud();
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => true,
+      isReduced: () => true,
+      getFullCloud: async () => cloud,
+      hasClassEdits: () => false,
+      getActiveScanId: () => 'scan-a',
+    });
+    const root = panel.element as unknown as FakeEl;
+    enableFullRes(root);
+    await pressExport(root);
+
+    expect(hoisted.downloads).toEqual(['scan.las']);
+    expect(hoisted.converted[0].pointCount).toBe(2);
+  });
+
+  it('still exports when the host supplies no scan identity (older wiring)', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const cloud = twoPointCloud();
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => false,
+      isReduced: () => false,
+      getFullCloud: async () => null,
+    });
+    const root = panel.element as unknown as FakeEl;
+    await pressExport(root);
+
+    expect(hoisted.downloads).toEqual(['scan.las']);
+  });
+});

--- a/tests/kmlActionsSnapshot.test.ts
+++ b/tests/kmlActionsSnapshot.test.ts
@@ -1,0 +1,80 @@
+/**
+ * kmlActionsSnapshot.test.ts
+ *
+ * The site KML mixed two moments: the origin and CRS were read before the
+ * serialiser import, everything the file actually contains — annotations,
+ * measurements, saved views, the up vector and the unit scale — was read after
+ * it. A dynamic import is usually warm, but "usually warm" is not a guarantee,
+ * and the export has no reason to straddle it at all.
+ *
+ * This pins the ordering by resolving the import slowly and mutating the session
+ * while it resolves: the written file must hold what the session held when the
+ * export was requested, not a blend of both.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { exportSiteKml, type KmlActionDeps } from '../src/app/kmlActions';
+import type { KmlExportInput } from '../src/export/kmlExport';
+import type { ResolvedCrs } from '../src/geo/CoordinateTypes';
+import type { Measurement } from '../src/render/measure/types';
+
+/** A geographic frame, so the lon/lat mapper is a plain origin shift. */
+const GEOGRAPHIC: ResolvedCrs = {
+  kind: 'geographic',
+  name: 'WGS 84',
+  epsg: 4326,
+  linearUnit: 'degree',
+  linearUnitToMetres: 1,
+  source: 'wkt',
+  confidence: 'high',
+  userConfirmed: true,
+} as unknown as ResolvedCrs;
+
+function measurement(id: string): Measurement {
+  return { id, kind: 'distance', points: [[0, 0, 0], [1, 1, 1]] } as unknown as Measurement;
+}
+
+describe('exportSiteKml — one reading of the session, then the write', () => {
+  it('writes the measurements the session held when the export was requested', async () => {
+    // The session as it stands when the user presses Export.
+    let measurements: Measurement[] = [measurement('m1')];
+    let unitToMetres = 1;
+    let built: KmlExportInput | null = null;
+    const written: string[] = [];
+
+    const deps = {
+      hasViewer: () => true,
+      geo: () => ({ origin: [0, 0, 0] as [number, number, number], crsName: 'WGS 84', name: 'site.las' }),
+      crsCurrent: () => GEOGRAPHIC,
+      annotations: () => [],
+      measurements: () => measurements,
+      viewpoints: () => [],
+      worldUp: () => [0, 0, 1] as [number, number, number],
+      unitToMetres: () => unitToMetres,
+      scanExtent: () => null,
+      baseName: (n: string) => n.replace(/\.[^.]+$/, ''),
+      downloadText: (filename: string) => { written.push(filename); },
+      setError: () => { /* not expected here */ },
+      // The serialiser import, resolving a turn later — and the user keeps
+      // working while it does: a second measurement lands and the unit scale
+      // changes. Neither belongs in the file that was already requested.
+      loadKmlExport: async () => {
+        await new Promise((r) => setTimeout(r, 0));
+        measurements = [measurement('m1'), measurement('m2')];
+        unitToMetres = 1000;
+        return {
+          buildKml: (input: KmlExportInput) => { built = input; return '<kml/>'; },
+          KmlCoordinateError: class extends Error {},
+        };
+      },
+    } as unknown as KmlActionDeps;
+
+    await exportSiteKml(deps);
+
+    expect(written).toEqual(['site.kml']);
+    expect(built).not.toBeNull();
+    const input = built as unknown as KmlExportInput;
+    expect(input.measurements.map((m) => m.id)).toEqual(['m1']);
+    expect(input.unitToMetres).toBe(1);
+  });
+});


### PR DESCRIPTION
No export path captured a scan identity or a snapshot before its first `await`, and none re-verified anything before triggering the download. The stale-guard idiom this repo already relies on for async analysis — `src/app/openScan.ts:361` (`if (deps.scans.activeId !== targetId) return;`) and `src/app/terrainAnalysisRunner.ts:333-335` — had never been carried to the export boundary, even though `exportIntegrityReport` (`src/main.ts:3082-3083`) already follows it by hand. This extends that idiom; it does not introduce a parallel mechanism, and there is no `ExportTransaction` framework.

## 1. Full-resolution export could bypass the classification safety gate

**Evidence.** `src/ui/ExportPanel.ts` evaluated `hasClassEdits` once, at click time (old line ~682), then awaited `getFullCloud()` (~695) — `decodeFull` → `decodeFullViaWorker`, a multi-second off-thread decode during which the UI stays fully live. Nothing disables the reclassify tools while it runs. The download fired at ~718 with no revalidation, so an edit made during the decode produced a file that silently omitted it and a status line that said the export succeeded — the exact outcome `src/export/fullResClassGuard.ts` was written to refuse.

The clip box had the same shape of problem: `getActiveClip()` was read *after* the await (~701), so a box dragged or cleared mid-decode filtered an export nobody requested that way.

**Remedy.** The clip and the active-scan id are captured before the first await. After the decode and before any bytes exist, the scan identity is compared and the class gate is *re-taken* (same function, same inputs — an edit during the decode flips exactly the input it already reads). Either mismatch aborts with a refusal in the voice of the existing one: `FULL_RES_CLASS_EDITS_MID_EXPORT_REFUSAL` names the consequence and both lossless escapes; `EXPORT_SCAN_CHANGED_REFUSAL` covers the swapped scan.

## 2. A stale terrain result exported against a different scan — deterministic, not a race

**Evidence.** In `src/ui/AnalysePanel.ts`, `_result` was cleared only by `analysePanel.update(null)` inside `resetToEmptyState()` (`src/main.ts:5542`, reached on scan *close* only). An additive scan open never clears it, while `getMapContext` (`src/main.ts:2352`) and `getExportBasename` (`src/main.ts:2302`) read live shell state. So: analyse Scan A → open Scan B additively → export, and A's contours / DEM / report are written with B's world origin, CRS, linear unit and filename stem.

**This one needs no timing at all.** It reproduces every time. The terrain runner's stale guard only stops a *new* result landing on the wrong scan; it does nothing about a result already on screen.

**Remedy.** A result is now stamped with the scan it was computed on when it lands in `update()`, and every export path — vector contours, DEM package, complete deliverable, intelligence report, map-sheet PDF (at dialog open *and* again before the sheet is built) — refuses when that scan is no longer active. Paths with a regeneration await re-check afterwards too. Refusing is deliberate over silently clearing: the analysis is the user's work, so it stays on screen with `TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL` shown on the existing caveat line.

## 3. Ordering fixes on the remaining paths (latent)

Fixed by ordering, not machinery — in each case the only await was a warm dynamic `import()`:

- `src/main.ts` `exportMeasurements` — `exportGeoContext()` (origin / CRS / name) now resolves before `loadMeasurementExport()`, matching `exportIntegrityReport`.
- `src/app/kmlActions.ts` `exportSiteKml` — annotations, measurements, viewpoints, worldUp and unitToMetres were read *after* `loadKmlExport()` while origin and CRS were read before it. All inputs are now read first, then the serialiser loads.
- `src/ui/AnalysePanel.ts` contour export, DEM package, complete deliverable, intelligence report and map sheet — basename and map context captured before the long regeneration / writer awaits.

## Tests

- `tests/exportPanelSnapshotIntegrity.test.ts` — export aborts when classification edits land inside the awaited `getFullCloud` stub; aborts when the active scan changes there; the clip used is the one captured before the await; two control cases still export. Verified red before the fix (3 of 5 fail, the 2 controls pass).
- `tests/analysePanelScanIdentity.test.ts` — an A-derived result refuses to export once B is active, across DEM / report / contour / complete-deliverable, and the refusal happens *before* the map context is read (proving no frame mixing). Also pins that the result is kept, not cleared, and that a null (streaming) id is a target of its own. Verified red before the fix (5 of 9 fail).
- `tests/kmlActionsSnapshot.test.ts` — the KML holds the session as it stood when the export was requested, with the serialiser import resolving a turn later and the session mutating meanwhile. Verified red before the fix.

## Verification (run on this branch)

```
npx tsc --noEmit                                  # clean, exit 0
npx vitest run tests/exportPanel*.test.ts \
  tests/kmlActions*.test.ts tests/analysePanel*.test.ts   # 6 files, 27 tests passed
npm run lint:monolith-size                        # OK — main.ts 5876 (baseline 5876), Viewer.ts 6376
npm run lint:archive-vocab                        # OK
npm run lint:layer-boundaries                     # OK — 137 files
npx vitest run                                    # 637 passed | 3 skipped (640 files)
                                                  # 8300 passed | 20 skipped | 1 todo (8321 tests)
```

Full suite green with no failures — the known-flaky `terrainRunnerDensityWiring` / `terrainCoreCache` timeouts did not fire on either of the two full runs. `main.ts` came out net-neutral against the shrink-only ratchet.

## Notes

- No new runtime dependencies. One new pure module, `src/export/exportScanIdentity.ts` (comparison + refusal wording, no DOM, no I/O), shared by both panels.
- `src/io/range/*`, `src/io/ept/*` and `src/app/openStreaming.ts` are untouched.
- Stated limit, documented in the new module: a streaming scan reports a null id, so swapping one streaming scan for another is invisible to this comparison — the same blind spot the terrain runner's guard has, since both read the same shell identity. Closing it means giving streaming scans a stable id in the shell.
