### PR TITLE
Check that the release gate survives the published source shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
       # is not the one the SBOM, the audit, and the evidence describe.
       - name: Lockfile is unchanged by a clean install
         run: git diff --exit-code -- package-lock.json
+      # The gate has to be runnable from what people actually download. A stage
+      # that reads an export-ignored file passes here and dies for them, which
+      # is not something a test can catch: every test runs in the tree that has
+      # the file. This reconstructs `git archive` output and runs the gate lints
+      # inside it.
+      - name: Release gate survives the published source shape
+        run: npm run verify:archive-gate
       - name: Typecheck
         run: npm run typecheck
       - name: Main-deferral lint (no top-level viewer.* deref outside viewerLoaded)

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "lint:positions-reads": "node scripts/lint-positions-reads.mjs",
     "lint:monolith-size": "node scripts/lint-monolith-size.mjs",
     "lint:architecture-truth": "node scripts/lint-architecture-truth.mjs",
+    "verify:archive-gate": "node scripts/verify-archive-gate.mjs",
     "lint:claims-language": "node scripts/lint-claims-language.mjs",
     "lint:archive-vocab": "node scripts/lint-archive-vocab.mjs",
     "lint:csp-html": "node scripts/lint-csp-html.mjs",

--- a/scripts/verify-archive-gate.mjs
+++ b/scripts/verify-archive-gate.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * verify-archive-gate.mjs — can the published source actually run its own gate?
+ *
+ * The release gate runs from a full checkout, but what users download is
+ * `git archive` output: the tree minus everything `.gitattributes` marks
+ * `export-ignore`. Those are different trees, and a gate stage that reads a
+ * file living only in the first one passes for us and dies for them.
+ *
+ * That is not hypothetical. `lint:architecture-truth` cross-checked a claim in
+ * an export-ignored planning document with an unguarded read, so the whole
+ * release gate threw ENOENT before the tests or the build ran — for anyone
+ * outside this repository, and only for them. A test could not catch it: every
+ * test ran in the tree that had the file.
+ *
+ * So this check reconstructs the published shape and runs every gate lint
+ * inside it. A stage that cannot survive there is reported as a defect in the
+ * gate, not in the archive.
+ *
+ * Two failure kinds, deliberately distinguished:
+ *   • CRASHED  — an uncaught exception (ENOENT, TypeError). Always a defect:
+ *                the stage assumed a file or shape the published tree lacks.
+ *   • FAILED   — a controlled non-zero exit. The stage ran and reported a
+ *                verdict, which is legitimate behaviour for the checks that
+ *                genuinely need repository context (listed below).
+ *
+ * Run: node scripts/verify-archive-gate.mjs
+ */
+
+import { execFileSync, execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Gate stages that read git history or the working copy by design, so they
+ * cannot run inside an extracted archive. Each is named with its reason: an
+ * entry here is a claim that the stage is repository-only, not a way to quiet
+ * a stage that broke.
+ */
+const REPO_ONLY = new Map([
+  ['lint:no-tracked-ignored', 'compares the git index against .gitignore'],
+  ['lint:release-sync', 'diffs the publish tree against its source of truth'],
+  ['lint:sbom', 'resolves the installed dependency tree'],
+]);
+
+/** The lint stages of `test:release:execute`, in gate order. */
+function gateLints() {
+  const pkg = JSON.parse(execSync('git show HEAD:package.json', { cwd: ROOT, encoding: 'utf8' }));
+  const chain = pkg.scripts['test:release:execute'] ?? '';
+  return chain
+    .split('&&')
+    .map((s) => s.trim())
+    .filter((s) => s.startsWith('npm run lint:'))
+    .map((s) => s.replace(/^npm run\s+/, '').split(/\s+/)[0]);
+}
+
+const stages = gateLints();
+if (stages.length === 0) {
+  console.error('verify-archive-gate FAILED\n\n  • found no lint stages in test:release:execute.');
+  process.exit(1);
+}
+
+const work = mkdtempSync(join(tmpdir(), 'olv-archive-gate-'));
+const tree = join(work, 'tree');
+let crashed = [];
+let failed = [];
+let passed = 0;
+
+try {
+  // The published shape: HEAD with every export-ignore rule applied.
+  execSync(`mkdir -p "${tree}" && git archive --format=tar HEAD | tar -x -C "${tree}"`, {
+    cwd: ROOT,
+    stdio: 'pipe',
+  });
+
+  // The lints are plain Node ESM; a few import dev dependencies. Borrowing the
+  // installed tree keeps this check about missing SOURCE, not missing packages.
+  const mods = resolve(ROOT, 'node_modules');
+  if (existsSync(mods) && !existsSync(join(tree, 'node_modules'))) {
+    symlinkSync(mods, join(tree, 'node_modules'), 'dir');
+  }
+
+  const pkg = JSON.parse(execSync('git show HEAD:package.json', { cwd: ROOT, encoding: 'utf8' }));
+
+  for (const stage of stages) {
+    if (REPO_ONLY.has(stage)) continue;
+    const cmd = pkg.scripts[stage];
+    if (!cmd) {
+      crashed.push([stage, `no such script: ${stage}`]);
+      continue;
+    }
+    try {
+      execFileSync('sh', ['-c', cmd], { cwd: tree, stdio: 'pipe', encoding: 'utf8' });
+      passed += 1;
+    } catch (err) {
+      const text = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+      // An uncaught throw prints a stack; a lint that ran prints its own
+      // verdict. The distinction is the whole point of this check.
+      const isCrash = /^\s*(?:node:internal|\w*Error:)/m.test(text) || /\bat .+:\d+:\d+/.test(text);
+      // Report the line that names the cause, not whichever line came first —
+      // a stack begins with its own frame header ("node:fs:436"), which tells
+      // the reader nothing about which file was missing.
+      const lines = text.split('\n').map((l) => l.trim()).filter(Boolean);
+      const why =
+        lines.find((l) => /(?:ENOENT|no such file|required file is missing)/i.test(l)) ??
+        lines.find((l) => /^\w*Error:/.test(l)) ??
+        lines.find((l) => /FAILED|•/.test(l)) ??
+        lines[0] ??
+        `exit ${err.status}`;
+      (isCrash ? crashed : failed).push([stage, why]);
+    }
+  }
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}
+
+if (crashed.length > 0) {
+  console.error('verify-archive-gate FAILED\n');
+  for (const [stage, why] of crashed) console.error(`  • ${stage} crashed in the published tree: ${why}`);
+  console.error(
+    '\nThese stages run from a full checkout and die from `git archive` output.\n' +
+      'Guard the read, or stop the gate depending on a file that ships nowhere.',
+  );
+  process.exit(1);
+}
+
+if (failed.length > 0) {
+  console.error('verify-archive-gate FAILED\n');
+  for (const [stage, why] of failed) console.error(`  • ${stage} reported a failure in the published tree: ${why}`);
+  process.exit(1);
+}
+
+console.log(
+  `verify-archive-gate OK — ${passed} gate lints run against the published tree; ` +
+    `${REPO_ONLY.size} skipped as repository-only.`,
+);
+for (const [stage, why] of REPO_ONLY) console.log(`    (skipped) ${stage} — ${why}`);


### PR DESCRIPTION
Re-lands a guard that was written and verified alongside #304 but **never reached main** — the commit was pushed after auto-merge had already squashed and deleted that branch, so it was orphaned. Recovered intact from the reflog (`80b3e74`) and cherry-picked onto current main.

## Why this exists

#304 fixed a real P0: `lint:architecture-truth` read an `export-ignore`d document with an unguarded `readFileSync`, so the **entire release gate died with an uncaught ENOENT when run from the published source archive**. It passed for us and failed for anyone who downloaded the source.

No test could catch that — every test runs in the tree that has the file. The fix removed the symptom; this removes the class.

## What it does

`verify:archive-gate` reconstructs what people actually download (`git archive` output, every export-ignore rule applied) and runs the gate lints inside it. It distinguishes:

- **CRASHED** — an uncaught exception (ENOENT, TypeError). Always a defect: the stage assumed a file or shape the published tree lacks.
- **FAILED** — a controlled non-zero exit. The stage ran and reported a verdict, which is legitimate.

Three stages are declared repository-only, each with its reason (they read git history or the installed dependency tree by design). An entry in that list is a claim about a stage, not a way to quiet one that broke.

Wired into the `verify` job, which is already a `ci-green` blocking dependency.

## Verified both directions

| Tree | Result |
|---|---|
| Main with the unguarded read (pre-#304) | `lint:architecture-truth crashed in the published tree: Error: ENOENT … float64-frame-migration-plan.md` → exit 1 |
| Current main (9159101) | **19 gate lints run against the published tree, 3 skipped as repository-only → exit 0** |

Re-verified against current main after #299/#300/#303/#305 landed, not just against the tree it was written on.