### PR TITLE
Never grade a truncated COPC/EPT hierarchy as exact

### DIFF
--- a/src/render/streaming/EptOctree.ts
+++ b/src/render/streaming/EptOctree.ts
@@ -98,6 +98,21 @@ export class EptOctree implements StreamingOctreeView {
   }
 
   /**
+   * Whether the hierarchy index is KNOWN-COMPLETE: the walk terminated (see
+   * {@link fullyLoaded}) AND it dropped nothing. `fullyLoaded` alone only says
+   * the walk stopped — it is set true even when the walk stopped at the
+   * {@link MAX_HIERARCHY_FILES} ceiling, swallowed a sub-file fetch failure, or
+   * skipped a malformed file. Each of those pushes into {@link errors} and
+   * leaves subtrees out of the store. A completeness-sensitive consumer (the
+   * full-cloud grade's "exact" label) gates on THIS — never on `fullyLoaded`,
+   * which stays true for a half-loaded cloud. Mirrors `StreamingOctree` so COPC
+   * and EPT grade identically.
+   */
+  get isComplete(): boolean {
+    return this._fullyLoaded && this._errors.length === 0;
+  }
+
+  /**
    * Load the whole hierarchy up front, ingesting every node. Kept for callers
    * that want the complete index before rendering (small datasets, tests).
    */

--- a/src/render/streaming/StreamingOctree.ts
+++ b/src/render/streaming/StreamingOctree.ts
@@ -44,6 +44,21 @@ export class StreamingOctree {
     return this._fullyLoaded;
   }
 
+  /**
+   * Whether the hierarchy index is KNOWN-COMPLETE: the walk terminated (see
+   * {@link fullyLoaded}) AND it dropped nothing. `fullyLoaded` alone only says
+   * the breadth-first walk stopped — it is set true even when the walk stopped
+   * because it hit the {@link MAX_HIERARCHY_PAGES} ceiling, swallowed a page
+   * fetch failure, or skipped a malformed entry. Each of those pushes into
+   * {@link errors} and leaves whole subtrees out of the store, so a grade that
+   * decodes every node it can see still covers less than the file. Consumers
+   * that must not overclaim completeness (the full-cloud grade's "exact" label)
+   * gate on THIS, not on `fullyLoaded`.
+   */
+  get isComplete(): boolean {
+    return this._fullyLoaded && this._errors.length === 0;
+  }
+
   /** Every known node. */
   nodes(): StreamingNode[] {
     return this.store.all();

--- a/src/render/streaming/StreamingSource.ts
+++ b/src/render/streaming/StreamingSource.ts
@@ -38,13 +38,29 @@ import type { NodeCounts, StreamingNodeStore } from './StreamingNodeStore';
  * nominal typing).
  *
  * Both `StreamingOctree` (COPC) and `EptOctree` (EPT) implement this surface.
- * New streaming formats only need to expose these two members.
+ * New streaming formats expose these members.
  */
 export interface StreamingOctreeView {
   /** The shared node store — generic across formats. */
   readonly store: StreamingNodeStore;
   /** Every known node in the octree. */
   nodes(): StreamingNode[];
+  /**
+   * Whether the whole hierarchy index loaded with nothing dropped — no page/
+   * file ceiling hit, no swallowed fetch failure, no skipped malformed entry.
+   * false when any node is missing from the store, so a completeness-sensitive
+   * consumer can refuse to overclaim (the full-cloud grade's "exact" label).
+   * Distinct from a "walk finished" flag: a walk can finish having dropped
+   * subtrees, which is exactly the silent under-report the grade must not make.
+   */
+  readonly isComplete: boolean;
+  /**
+   * Hierarchy errors recorded while loading the index (a ceiling hit, a fetch
+   * failure, or a malformed entry). On the shared contract so a consumer can
+   * report HOW MANY regions were dropped instead of leaving the count
+   * write-only.
+   */
+  readonly errors: readonly string[];
 }
 
 /** The on-disk format a streaming source is backed by. */

--- a/src/render/streaming/fullCloudGrade.ts
+++ b/src/render/streaming/fullCloudGrade.ts
@@ -12,9 +12,19 @@
  *      unless its density is multiplied back up). Always ≥ 1 and finite.
  *
  *   2. A `scope` + human `label` + `note` that state whether the grade is EXACT
- *      (every node decoded) or ESTIMATED from a representative sample, with the
+ *      (every node decoded from a WHOLE hierarchy) or ESTIMATED, with the
  *      coverage fraction — so a full-cloud grade never implies a completeness it
  *      doesn't have.
+ *
+ * "Exact" needs TWO independent facts, because the sampling plan can only ever
+ * see the nodes the octree actually LOADED. `plan.exhaustive` means "the sample
+ * covered every loaded node"; it says nothing about a hierarchy that stopped
+ * short at its page ceiling, swallowed a page-fetch failure, or skipped a
+ * malformed entry — all of which leave subtrees out of the store while the walk
+ * still reports "finished". So the caller threads the octree's own completeness
+ * ({@link OctreeCompleteness}) in, and a grade is labelled exact ONLY when the
+ * sample was exhaustive AND the hierarchy was whole. A truncated cloud is graded
+ * over the part that loaded and SAID SO — never labelled "exact" over a subset.
  *
  * Pure data: no DOM, no three.js, no I/O. Deterministic.
  */
@@ -51,8 +61,41 @@ export interface FullCloudGradeCoverage {
   readonly note: string;
 }
 
+/**
+ * The source octree's completeness, threaded into the coverage decision. The
+ * {@link SamplingPlan} is derived from the LOADED nodes only, so it cannot tell
+ * a whole hierarchy from one that stopped short — this carries that fact from
+ * the octree (`StreamingOctree` / `EptOctree`) to the honesty layer. A grade may
+ * be labelled "exact" ONLY when `complete` is true.
+ */
+export interface OctreeCompleteness {
+  /** false when the hierarchy dropped a node — a page/file ceiling, a fetch failure, or a malformed entry. */
+  readonly complete: boolean;
+  /** How many hierarchy load errors were recorded — surfaced so the count isn't write-only. */
+  readonly errorCount: number;
+}
+
+/** The default when no completeness is supplied: a pure-plan caller grading a whole tree. */
+const COMPLETE: OctreeCompleteness = { complete: true, errorCount: 0 };
+
 const SAMPLED_NOTE =
   'Graded from a representative octree sample — density and coverage are estimated for the whole cloud, not measured exhaustively.';
+
+/**
+ * The caveat for a grade over an INCOMPLETE hierarchy — some of the file never
+ * loaded, so the figures cover only the part that did. Distinct from
+ * {@link SAMPLED_NOTE}: sampling is a deliberate budget choice over a whole
+ * cloud; this is a shortfall in the cloud itself, and it names the recorded
+ * error count so the otherwise write-only `octree.errors` reaches the user.
+ */
+function incompleteNote(sampledPoints: number, errorCount: number): string {
+  const base =
+    `This scan's point hierarchy did not fully load, so the grade covers only the ` +
+    `${formatPointCount(sampledPoints)} points that were read — a partial figure, not the whole file.`;
+  if (errorCount <= 0) return base;
+  const noun = errorCount === 1 ? 'load error was' : 'load errors were';
+  return `${base} ${errorCount} ${noun} recorded.`;
+}
 
 /** Format the coverage percent, collapsing a tiny-but-nonzero fraction to "<1%". */
 function percentLabel(fraction: number, rounded: number): string {
@@ -62,15 +105,32 @@ function percentLabel(fraction: number, rounded: number): string {
 
 /**
  * Derive the honest coverage + density-scale facts for a full-cloud grade from
- * its sampling plan. Defensive against an empty/degenerate plan (returns a
- * scale of 1 and a "no points" label rather than a NaN/Infinity).
+ * its sampling plan and the source octree's {@link OctreeCompleteness}.
+ * Defensive against an empty/degenerate plan (returns a scale of 1 and a "no
+ * points" label rather than a NaN/Infinity).
+ *
+ * `completeness` defaults to complete, so a pure-plan caller that is grading a
+ * whole tree (and the existing tests) keeps the plain exhaustive/sampled
+ * behaviour; the live grade passes the real octree state.
  */
-export function fullCloudGradeCoverage(plan: SamplingPlan): FullCloudGradeCoverage {
+export function fullCloudGradeCoverage(
+  plan: SamplingPlan,
+  completeness: OctreeCompleteness = COMPLETE,
+): FullCloudGradeCoverage {
   const sampledPoints = Math.max(0, plan.sampledPoints);
   const totalPoints = Math.max(0, plan.totalPoints);
   const fraction = totalPoints > 0 ? Math.min(1, sampledPoints / totalPoints) : 0;
   const coveragePercent = Math.round(fraction * 100);
-  const scope: GradeScope = plan.exhaustive ? 'exhaustive' : 'sampled';
+
+  // EXACT demands two independent facts: the sample covered every node the
+  // octree HOLDS (`plan.exhaustive`), and the octree HOLDS every node the file
+  // has (`completeness.complete`). The planner only ever sees loaded nodes, so
+  // `plan.exhaustive` on its own means "sampled everything we loaded" — it is
+  // blind to a hierarchy that stopped at the page ceiling, swallowed a fetch
+  // failure, or skipped a malformed entry. Labelling that "exact" is the silent
+  // under-report this guards against; a partial hierarchy is 'sampled', never
+  // exhaustive.
+  const scope: GradeScope = plan.exhaustive && completeness.complete ? 'exhaustive' : 'sampled';
 
   // Back-scale density from sample → whole cloud. Floored at 1 and guarded
   // against a zero/degenerate sample so a grade can never read 0/NaN/Infinity.
@@ -87,6 +147,13 @@ export function fullCloudGradeCoverage(plan: SamplingPlan): FullCloudGradeCovera
   } else if (scope === 'exhaustive') {
     label = `all ${formatPointCount(totalPoints)} points (exact)`;
     note = '';
+  } else if (!completeness.complete) {
+    // Incomplete hierarchy: report only what loaded and say why. The
+    // percentage-of-total wording is deliberately withheld — the denominator we
+    // have (loaded-node sum) is not the file's true count, so a "% of total"
+    // here would itself be a quiet fabrication.
+    label = `${formatPointCount(sampledPoints)} points graded (partial)`;
+    note = incompleteNote(sampledPoints, completeness.errorCount);
   } else {
     label = `${formatPointCount(sampledPoints)} of ${formatPointCount(totalPoints)} points (${percentLabel(fraction, coveragePercent)}, sampled)`;
     note = SAMPLED_NOTE;

--- a/src/render/streaming/fullCloudGradeAdapter.ts
+++ b/src/render/streaming/fullCloudGradeAdapter.ts
@@ -48,6 +48,14 @@ export interface GradeNodeSource {
     nodes(): StreamingNode[];
     /** Lookup a runtime node by its deterministic id. */
     readonly store: { get(id: string): StreamingNode | undefined };
+    /**
+     * Whether the hierarchy loaded whole. Gates the grade's "exact" claim:
+     * `nodes()` returns only the LOADED nodes, so a grade that sampled every one
+     * of them is still not exhaustive over the file when this is false.
+     */
+    readonly isComplete: boolean;
+    /** Hierarchy load errors — read so the dropped-region count reaches the grade note. */
+    readonly errors: readonly string[];
   };
   readNodeChunk(record: StreamingNodeRecord, signal?: AbortSignal): Promise<ArrayBuffer>;
   decodeMeta(record: StreamingNodeRecord): ChunkDecodeMetadata;
@@ -140,5 +148,14 @@ export function gradeFullCloud<G>(args: {
     options,
     signal,
     onProgress,
+    // The whole point of grading the FULL cloud is the completeness claim, so
+    // carry the octree's own truth: `nodes()` above is only what loaded, and a
+    // sample of it is "exact" over the file solely when the hierarchy is whole.
+    // `errors.length` rides along so a partial grade can name how many regions
+    // were dropped instead of leaving that count write-only.
+    completeness: {
+      complete: source.octree.isComplete,
+      errorCount: source.octree.errors.length,
+    },
   });
 }

--- a/src/render/streaming/fullCloudGradeRunner.ts
+++ b/src/render/streaming/fullCloudGradeRunner.ts
@@ -21,7 +21,11 @@
  */
 
 import { buildSamplingPlan, type SampleNode, type SamplingPlanOptions } from './samplingPlan';
-import { fullCloudGradeCoverage, type FullCloudGradeCoverage } from './fullCloudGrade';
+import {
+  fullCloudGradeCoverage,
+  type FullCloudGradeCoverage,
+  type OctreeCompleteness,
+} from './fullCloudGrade';
 
 /** Decode one node's points into local-space XYZ triples. Live = range read + worker. */
 export type DecodeNodeFn = (nodeId: string, signal?: AbortSignal) => Promise<Float32Array>;
@@ -73,11 +77,18 @@ export async function runFullCloudGrade<G>(args: {
    * is skipped by an abort.
    */
   readonly onProgress?: (progress: GradeProgress) => void;
+  /**
+   * The source octree's completeness, forwarded to {@link fullCloudGradeCoverage}
+   * so a grade over a truncated hierarchy is never labelled "exact". Omitted by
+   * pure-plan callers (tests grading an explicit node list) → treated as
+   * complete, preserving the exhaustive/sampled behaviour for whole octrees.
+   */
+  readonly completeness?: OctreeCompleteness;
 }): Promise<FullCloudGradeRun<G>> {
-  const { nodes, decodeNode, grade, options, signal, onProgress } = args;
+  const { nodes, decodeNode, grade, options, signal, onProgress, completeness } = args;
 
   const plan = buildSamplingPlan(nodes, options);
-  const coverage = fullCloudGradeCoverage(plan);
+  const coverage = fullCloudGradeCoverage(plan, completeness);
 
   // Decode each selected node in plan order, copying its points STRAIGHT into one
   // pre-sized buffer and dropping the chunk reference immediately — so the sample

--- a/tests/eptStreaming.test.ts
+++ b/tests/eptStreaming.test.ts
@@ -133,6 +133,8 @@ test('EptOctree loads the synthetic fixture and registers one root node', async 
   await octree.loadFullHierarchy();
   expect(octree.fullyLoaded).toBe(true);
   expect(octree.errors.length).toBe(0);
+  // A whole hierarchy with no dropped file → complete, gradeable "exact".
+  expect(octree.isComplete).toBe(true);
   const nodes = octree.nodes();
   expect(nodes.length).toBe(1);
   expect(nodes[0].record.id).toBe('0-0-0-0');
@@ -184,6 +186,9 @@ test('progressive hierarchy: an initial paint attaches before the full index loa
   // Budget of one file: the root only.
   await octree.loadInitialHierarchy(1);
   expect(octree.fullyLoaded).toBe(false); // more to fetch in the background
+  // Mid-deepening the index is not whole yet, so a grade taken now must not
+  // claim exact — even though no error has occurred.
+  expect(octree.isComplete).toBe(false);
   const idsAfterInitial = octree.nodes().map((n) => n.record.id).sort();
   expect(idsAfterInitial).toEqual(['0-0-0-0', '1-0-0-0']);
   // The nodes that DID land already carry correct child links.
@@ -192,6 +197,8 @@ test('progressive hierarchy: an initial paint attaches before the full index loa
   // Continue to completion — nodes arrive and refine.
   await octree.continueHierarchy();
   expect(octree.fullyLoaded).toBe(true);
+  // Deepened to completion with no dropped file → now complete.
+  expect(octree.isComplete).toBe(true);
   expect(octree.nodes().map((n) => n.record.id).sort()).toEqual([
     '0-0-0-0', '1-0-0-0', '1-1-0-0', '2-2-0-0',
   ]);
@@ -234,6 +241,9 @@ test('the walk terminates when sub-file fetches fail — no retry loop', async (
   expect(octree.fullyLoaded).toBe(true);
   expect(octree.nodes().map((n) => n.record.id).sort()).toEqual(['0-0-0-0', '1-0-0-0']);
   expect(octree.errors.some((e) => /network down/.test(e))).toBe(true);
+  // EPT mirror of the COPC swallowed-fetch case: the walk finished but a sub-file
+  // was dropped, so the octree is NOT complete and a grade must not claim exact.
+  expect(octree.isComplete).toBe(false);
 });
 
 test('a small hierarchy that fits the first-paint budget loads fully in one call', async () => {
@@ -256,6 +266,7 @@ test('EptOctree handles a fetcher failure without crashing — surfaces in error
   expect(octree.fullyLoaded).toBe(true);
   expect(octree.errors.length).toBeGreaterThan(0);
   expect(octree.errors[0]).toMatch(/network down/);
+  expect(octree.isComplete).toBe(false);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/fullCloudGrade.test.ts
+++ b/tests/fullCloudGrade.test.ts
@@ -75,3 +75,66 @@ describe('fullCloudGradeCoverage', () => {
     expect(cov.sampledPoints * cov.samplePointScale).toBeCloseTo(cov.totalPoints, 5);
   });
 });
+
+describe('fullCloudGradeCoverage — completeness gating (a short hierarchy is never "exact")', () => {
+  // Every case below feeds a plan whose sample IS exhaustive over the loaded
+  // nodes (`plan.exhaustive === true`). Before the fix that alone printed "all N
+  // points (exact)". Completeness now decides whether that claim is honest.
+  const wholeTreePlan = () =>
+    buildSamplingPlan(nodes([[0, 500_000], [1, 1_300_000]]), { maxPoints: 10_000_000 });
+
+  it('a genuinely complete hierarchy within budget is STILL exact (the regression that matters most)', () => {
+    const plan = wholeTreePlan();
+    expect(plan.exhaustive).toBe(true);
+    const cov = fullCloudGradeCoverage(plan, { complete: true, errorCount: 0 });
+    expect(cov.scope).toBe('exhaustive');
+    expect(cov.label).toBe('all 1.8M points (exact)');
+    expect(cov.note).toBe('');
+  });
+
+  it('a hierarchy that hit the page/file ceiling is NOT exact', () => {
+    const plan = wholeTreePlan();
+    expect(plan.exhaustive).toBe(true); // the loaded nodes all fit the budget
+    const cov = fullCloudGradeCoverage(plan, { complete: false, errorCount: 1 });
+    expect(cov.scope).not.toBe('exhaustive');
+    expect(cov.label).not.toMatch(/exact/);
+    expect(cov.label).toMatch(/partial/i);
+  });
+
+  it('a swallowed page-fetch failure is NOT exact and states the reason + error count', () => {
+    const cov = fullCloudGradeCoverage(wholeTreePlan(), { complete: false, errorCount: 2 });
+    expect(cov.scope).toBe('sampled');
+    expect(cov.label).not.toMatch(/exact/);
+    expect(cov.note).toMatch(/did not fully load/i);
+    expect(cov.note).toMatch(/2 load errors were recorded/);
+  });
+
+  it('recorded parse errors are NOT exact', () => {
+    const cov = fullCloudGradeCoverage(wholeTreePlan(), { complete: false, errorCount: 5 });
+    expect(cov.scope).not.toBe('exhaustive');
+    expect(cov.label).not.toMatch(/exact/);
+  });
+
+  it('incompleteness with no recorded error count still downgrades, and omits the count clause', () => {
+    // EPT mid-deepening: the walk has not finished (fullyLoaded false), no error
+    // yet → complete:false, errorCount:0. Still not exact, and the note reads
+    // cleanly without a "0 errors" clause.
+    const cov = fullCloudGradeCoverage(wholeTreePlan(), { complete: false, errorCount: 0 });
+    expect(cov.scope).not.toBe('exhaustive');
+    expect(cov.label).not.toMatch(/exact/);
+    expect(cov.note).toMatch(/did not fully load/i);
+    expect(cov.note).not.toMatch(/load error/);
+  });
+
+  it('completeness does not FORCE exact: a whole tree still over budget stays sampled', () => {
+    const plan = buildSamplingPlan(
+      nodes([[0, 500_000], [1, 1_500_000], [2, 8_000_000]]),
+      { maxPoints: 2_000_000 },
+    );
+    expect(plan.exhaustive).toBe(false);
+    const cov = fullCloudGradeCoverage(plan, { complete: true, errorCount: 0 });
+    expect(cov.scope).toBe('sampled'); // driven by the budget, not completeness
+    expect(cov.label).toMatch(/sampled/);
+    expect(cov.note).toMatch(/representative octree sample/i);
+  });
+});

--- a/tests/fullCloudGradeAdapter.test.ts
+++ b/tests/fullCloudGradeAdapter.test.ts
@@ -52,6 +52,10 @@ function fakeSource(
   nodes: StreamingNode[],
   markers: Record<string, number>,
   hooks: { onRead?: (id: string, signal?: AbortSignal) => void } = {},
+  // Completeness of the source octree. Defaults to a WHOLE hierarchy so the
+  // existing exhaustive/sampled tests are unaffected; the truncation test sets
+  // it false to prove the grade never claims exact over a short hierarchy.
+  completeness: { isComplete?: boolean; errors?: readonly string[] } = {},
 ): GradeNodeSource {
   const byId = new Map(nodes.map((n) => [n.record.id, n]));
   // Reverse-lookup a record's id from the marker we'll stash, so readNodeChunk
@@ -60,6 +64,8 @@ function fakeSource(
     octree: {
       nodes: () => nodes,
       store: { get: (id: string) => byId.get(id) },
+      isComplete: completeness.isComplete ?? true,
+      errors: completeness.errors ?? [],
     },
     readNodeChunk: async (rec: StreamingNodeRecord, signal?: AbortSignal): Promise<ArrayBuffer> => {
       hooks.onRead?.(rec.id, signal);
@@ -227,5 +233,29 @@ describe('gradeFullCloud — one-call composition + progress', () => {
         signal: controller.signal,
       }),
     ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('never labels an INCOMPLETE octree exact — even when every LOADED node fits the budget', async () => {
+    // The defect end-to-end: a hierarchy that dropped a subtree (a swallowed
+    // page-fetch failure here) still returns its loaded nodes, so the sampling
+    // plan is exhaustive OVER THOSE and the old path printed "all N points
+    // (exact)". `octree.nodes()` — not `fullyLoaded` — is what the grade reads,
+    // so completeness must ride in separately and downgrade the claim.
+    const src = fakeSource(nodeList(), { '0-0-0-0': 1, '1-0-0-0': 2, '1-1-0-0': 3 }, {}, {
+      isComplete: false,
+      errors: ['failed to load hierarchy page at 4096: network down'],
+    });
+    const run = await gradeFullCloud({
+      source: src,
+      decoder: fakeDecoder(),
+      grade: (pos) => pos.length / 3,
+      options: { maxPoints: 10_000 }, // budget covers every loaded node
+    });
+    expect(run.coverage.scope).toBe('sampled');
+    expect(run.coverage.label).not.toMatch(/exact/);
+    expect(run.coverage.label).toMatch(/partial/i);
+    // The reason and the (previously write-only) error count reach the user.
+    expect(run.coverage.note).toMatch(/did not fully load/i);
+    expect(run.coverage.note).toMatch(/1 load error/);
   });
 });

--- a/tests/fullCloudGradeRunner.test.ts
+++ b/tests/fullCloudGradeRunner.test.ts
@@ -160,4 +160,31 @@ describe('runFullCloudGrade — orchestration', () => {
     ).rejects.toMatchObject({ name: 'AbortError' });
     expect(decode).not.toHaveBeenCalled();
   });
+
+  it('forwards octree completeness: an incomplete hierarchy is never labelled exact', async () => {
+    // Budget covers all 300 points → plan.exhaustive is true → the old path said
+    // "exact". A false `completeness` (a truncated hierarchy) must override that.
+    const out = await runFullCloudGrade({
+      nodes: nodes(),
+      decodeNode: markerDecode({ '0-0-0-0': 1, '1-0-0-0': 2, '1-1-0-0': 3 }),
+      grade: (_pos, scale) => scale,
+      options: { maxPoints: 10_000 },
+      completeness: { complete: false, errorCount: 1 },
+    });
+    expect(out.coverage.scope).toBe('sampled');
+    expect(out.coverage.label).not.toMatch(/exact/);
+    expect(out.coverage.note).toMatch(/did not fully load/i);
+  });
+
+  it('a complete hierarchy within budget keeps the exact label (no false downgrade)', async () => {
+    const out = await runFullCloudGrade({
+      nodes: nodes(),
+      decodeNode: markerDecode({ '0-0-0-0': 1, '1-0-0-0': 2, '1-1-0-0': 3 }),
+      grade: (_pos, scale) => scale,
+      options: { maxPoints: 10_000 },
+      completeness: { complete: true, errorCount: 0 },
+    });
+    expect(out.coverage.scope).toBe('exhaustive');
+    expect(out.coverage.label).toMatch(/exact/);
+  });
 });

--- a/tests/streamingOctree.test.ts
+++ b/tests/streamingOctree.test.ts
@@ -2,6 +2,7 @@ import { StreamingNodeStore } from '../src/render/streaming/StreamingNodeStore';
 import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
 import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
 import { buildSyntheticCopc } from './fixtures/copc/synthCopc';
+import type { SynthKey, SynthPage } from './fixtures/copc/synthCopc';
 import type { StreamingNodeRecord } from '../src/io/copc/copcTypes';
 
 function record(id: string, pointCount: number): StreamingNodeRecord {
@@ -113,6 +114,8 @@ test('StreamingPointCloud.open ingests a single-page hierarchy', async () => {
   expect(cloud.maxDepth()).toBe(1);
   expect(cloud.localBounds()).toEqual([-128, -128, -128, 128, 128, 128]);
   expect(cloud.octree.errors).toEqual([]);
+  // A clean walk with no dropped page is genuinely complete → gradeable "exact".
+  expect(cloud.octree.isComplete).toBe(true);
 });
 
 test('StreamingOctree loads child pages and resolves parent/child links', async () => {
@@ -147,4 +150,127 @@ test('StreamingOctree loads child pages and resolves parent/child links', async 
     '1-1-0-0',
   ]);
   expect(cloud.octree.rootNodes()).toHaveLength(1);
+  // Every page loaded and parsed → complete.
+  expect(cloud.octree.isComplete).toBe(true);
+});
+
+// --- StreamingOctree completeness (walk-finished ≠ fully-loaded) -------------
+//
+// `fullyLoaded` goes true whenever the breadth-first walk STOPS — including when
+// it stops short. Each test below drives one way a COPC hierarchy loads short
+// and pins that `isComplete` reports it (so the full-cloud grade can refuse to
+// call a partial cloud "exact"). The grade reads `octree.nodes()`, which returns
+// only the surviving nodes, so nothing downstream would otherwise notice.
+
+/**
+ * Wraps a RangeSource and rejects any read at or beyond `failFrom`. The COPC
+ * root hierarchy page is read at `rootHierOffset` (below the threshold), so it
+ * succeeds; a CHILD page — laid out immediately after the root in the fixture's
+ * pages blob — is read at `rootHierOffset + rootHierSize` and fails, modelling a
+ * transient range-read failure on a child page during a normal open.
+ */
+class FailFromRange {
+  private readonly inner: ArrayBufferRangeSource;
+  private readonly failFrom: number;
+  constructor(inner: ArrayBufferRangeSource, failFrom: number) {
+    this.inner = inner;
+    this.failFrom = failFrom;
+  }
+  id(): string {
+    return this.inner.id();
+  }
+  kind(): ReturnType<ArrayBufferRangeSource['kind']> {
+    return this.inner.kind();
+  }
+  size(): Promise<number> {
+    return this.inner.size();
+  }
+  readRange(offset: number, length: number, signal?: AbortSignal): Promise<ArrayBuffer> {
+    if (offset >= this.failFrom) {
+      return Promise.reject(new Error(`range read failed at ${offset}`));
+    }
+    return this.inner.readRange(offset, length, signal);
+  }
+}
+
+test('StreamingOctree: a swallowed child-page fetch failure loads short → NOT complete', async () => {
+  const fixture = buildSyntheticCopc({
+    pages: [
+      { pageKey: [0, 0, 0, 0], nodes: [{ key: [0, 0, 0, 0], pointCount: 2000 }], childPages: [1] },
+      {
+        pageKey: [1, 0, 0, 0],
+        nodes: [
+          { key: [1, 0, 0, 0], pointCount: 800 },
+          { key: [1, 1, 0, 0], pointCount: 600 },
+        ],
+      },
+    ],
+  });
+  const range = new FailFromRange(
+    new ArrayBufferRangeSource(fixture.buffer),
+    fixture.rootHierOffset + fixture.rootHierSize, // the child page's offset
+  );
+  const cloud = await StreamingPointCloud.open(range, 'partial.copc.laz');
+
+  // The walk still reports "finished" and the root survived — the exact trap the
+  // grade fell into: nodes() looks healthy.
+  expect(cloud.octree.fullyLoaded).toBe(true);
+  expect(cloud.octree.nodes().map((n) => n.record.id)).toEqual(['0-0-0-0']);
+  // But a page was dropped and recorded, so it is NOT complete.
+  expect(cloud.octree.errors.some((e) => /failed to load hierarchy page/.test(e))).toBe(true);
+  expect(cloud.octree.isComplete).toBe(false);
+});
+
+test('StreamingOctree: a malformed hierarchy entry is skipped → NOT complete', async () => {
+  // `bad-hierarchy-entry` corrupts the root page's data entry (dropped as
+  // malformed) while the child-page reference stays valid, so the child nodes
+  // load but the root node is missing — a real partial parse.
+  const fixture = buildSyntheticCopc({
+    pages: [
+      { pageKey: [0, 0, 0, 0], nodes: [{ key: [0, 0, 0, 0], pointCount: 2000 }], childPages: [1] },
+      {
+        pageKey: [1, 0, 0, 0],
+        nodes: [
+          { key: [1, 0, 0, 0], pointCount: 800 },
+          { key: [1, 1, 0, 0], pointCount: 600 },
+        ],
+      },
+    ],
+    corrupt: 'bad-hierarchy-entry',
+  });
+  const cloud = await StreamingPointCloud.open(
+    new ArrayBufferRangeSource(fixture.buffer),
+    'corrupt.copc.laz',
+  );
+  expect(cloud.octree.fullyLoaded).toBe(true);
+  expect(cloud.octree.errors.length).toBeGreaterThan(0);
+  expect(cloud.octree.isComplete).toBe(false);
+});
+
+test('StreamingOctree: hitting the hierarchy-page ceiling loads short → NOT complete', async () => {
+  // A fan-out wide enough to trip the MAX_HIERARCHY_PAGES ceiling: the root
+  // references more child pages than the cap allows, so the walk stops with a
+  // ceiling error and never loads the tail. Pins that the documented 4096-page
+  // cap makes the octree incomplete rather than silently truncating "exact".
+  // Comfortably above the documented MAX_HIERARCHY_PAGES (4096) so the walk trips
+  // the cap regardless of the exact off-by-one at the boundary.
+  const FANOUT = 4200;
+  const childPages: number[] = [];
+  const pages: SynthPage[] = [{ pageKey: [0, 0, 0, 0], nodes: [], childPages }];
+  for (let i = 1; i <= FANOUT; i++) {
+    // Spread children across depth-1 octants deterministically; the exact keys
+    // don't matter, only that there are more PAGES (distinct offsets) than the
+    // ceiling admits.
+    const key: SynthKey = [1, i % 2, (i >> 1) % 2, (i >> 2) % 2];
+    pages.push({ pageKey: key, nodes: [{ key, pointCount: 10 }], childPages: [] });
+    childPages.push(i);
+  }
+  const fixture = buildSyntheticCopc({ pages });
+  const cloud = await StreamingPointCloud.open(
+    new ArrayBufferRangeSource(fixture.buffer),
+    'ceiling.copc.laz',
+  );
+  expect(cloud.octree.fullyLoaded).toBe(true);
+  expect(cloud.octree.errors.some((e) => /exceeded .* pages/.test(e))).toBe(true);
+  expect(cloud.octree.isComplete).toBe(false);
 });


### PR DESCRIPTION
## The defect

The full-cloud grade could label a silently-truncated scan `all N points (exact)` with N below the file's true count, then back-scale its density, vertical, and occupancy figures onto that reduced set. A wrong number, no crash: the exact failure `docs/threat-model.md` names as the top risk.

A COPC/EPT hierarchy can finish loading short in three ways, and all three still end with the octree's `fullyLoaded` flag set true:

- **Page ceiling.** `StreamingOctree.ts` pushes `hierarchy exceeded 4096 pages — stopped` into `_errors`, empties the frontier, and falls through to `_fullyLoaded = true`.
- **Swallowed fetch failure.** A failed child-page read is caught, recorded in `_errors`, and skipped with `continue`; its descendants are never enqueued. This is reachable in normal operation on a transient range-read failure.
- **Malformed entry.** `parseHierarchyPage` collects each bad entry into `errors` and skips it, so the walk completes "normally" with nodes missing.

`EptOctree` has the same shape (ceiling / fetch failure / parse failure all record an error and still set `_fullyLoaded = true`).

Two consequences followed:

1. `octree.errors` was **write-only**. Grepping the non-test tree, the only reference outside the producer was the unused getter. Nothing read it.
2. The grade asserted "exact" over the partial cloud. `sampleNodesFromSource` enumerates `octree.nodes()`; `buildSamplingPlan` sets `exhaustive = nodeIds.length === nodes.length`; `fullCloudGradeCoverage` turned that into `scope: 'exhaustive'` and the label `all N points (exact)`. Nothing consulted completeness.

### The danger is `octree.nodes()`, not `fullyLoaded`

The audit that surfaced this named `fullyLoaded` as the variable to fix. That is not where the grade goes wrong. `runFullCloudGradeAction` never reads `fullyLoaded` at all — the grade is built from `octree.nodes()`, which returns only the nodes that *loaded*. `plan.exhaustive` therefore means "the sample covered every node we hold", which is silently true for a hierarchy that dropped whole subtrees. `fullyLoaded` being true after a short load is the *cause* of the missing nodes; the leak into the label runs through `nodes()` and `plan.exhaustive`. So the fix does not gate on `fullyLoaded` (that would also break EPT background deepening, which legitimately relies on it); it adds a separate completeness signal and gates the label on that.

## The fix

**A completeness signal on the octree, distinct from "walk finished".** `StreamingOctree` and `EptOctree` gain `isComplete = fullyLoaded && errors.length === 0`. `fullyLoaded` keeps its exact meaning (the walk terminated), so `EptStreamingPointCloud`'s background-deepening decision is untouched. Because every one of the three short-load modes records into `errors`, that one predicate covers all of them. Both octrees implement it identically, and it is declared on the shared `StreamingOctreeView` contract alongside `errors`.

**The label gates on completeness.** `fullCloudGradeCoverage(plan, completeness)` labels a grade `exhaustive`/exact only when the sample was exhaustive *and* the hierarchy was whole. An incomplete cloud is still graded — a partial grade is useful — but it is labelled `N points graded (partial)` and carries a note that says the hierarchy did not fully load and how many load errors were recorded. That routes the previously write-only `errors` count to the user through the existing grade note; no new panel. The completeness is threaded octree → adapter → runner → coverage, so `fullCloudGrade.ts` stays the single place that decides the honesty label.

**No node-sum vs. header cross-check.** The task flagged this as optional and risky: COPC carries decimated overview copies at coarse levels, so summing all node point counts overcounts the file's true count. Asserting `nodeSum === sourcePointCount` would false-positive on healthy clouds. The completeness signal (ceiling / fetch failure / parse error) is unambiguous and is what the fix relies on. Called out here so a later reader does not "helpfully" add the cross-check.

## The legitimate exact case still labels exact

A fully-loaded hierarchy with no ceiling, no fetch failure, and no errors that fits the sampling budget is genuinely exhaustive over the whole file, and it still reports `all N points (exact)` with an empty note. This is the regression that mattered most to guard, and it is pinned by tests in both `fullCloudGrade.test.ts` and the COPC/EPT octree suites.

## Tests (red-green)

Each new assertion was confirmed to fail against the pre-fix behaviour and pass after. Reverting just the two behavioural cores (the coverage gate and the `isComplete` getters, signatures kept so everything still compiles) turned exactly the 11 new completeness assertions red while all 47 pre-existing tests in those files stayed green:

- ceiling / swallowed fetch failure / parse error → grade label is not "exact" (coverage layer, with the reason and error count present)
- a genuinely complete within-budget hierarchy → still "exact" (over-rejection guard)
- COPC octree: child-page fetch failure, malformed entry, and page ceiling each yield `isComplete === false` while `fullyLoaded === true`
- EPT octree: sub-file fetch failure and a partial mid-deepening index yield `isComplete === false`; a whole load yields `true`
- adapter and runner carry completeness end to end

## Verification

```
npx tsc --noEmit                         # clean
npx vitest run (full suite)              # 8460 passed, 20 skipped, 1 todo, 0 failed
npm run lint:monolith-size --silent      # OK (main.ts / Viewer.ts untouched)
npm run lint:archive-vocab --silent      # OK
npm run lint:layer-boundaries --silent   # OK (changed files stay pure science/core)
```

Scope is the streaming/COPC grade path and its tests only; no loaders, E57, or transport touched.
