### PR TITLE
Build the static scan fingerprint from the source point count, not the display sample

### DIFF
--- a/src/app/openScan.ts
+++ b/src/app/openScan.ts
@@ -186,26 +186,36 @@ export interface OpenScanDeps {
 /** Load a dropped or sampled File: parse, render, and populate the Inspector. */
 export async function openScan(file: File, deps: OpenScanDeps): Promise<void> {
   // SINGLE ROUTER for every file that enters the app (drop zone, Open picker,
-  // Measurements Import). An `.olvsession` is a saved analysis, not a scan, so
-  // it goes to the one session loader — never the cloud worker — and every
-  // entry point therefore opens sessions the same way. A session restore is
-  // cheap (read + apply state) and safe to run even mid-load, so it routes
-  // ahead of the cloud-loading guard.
-  if (isSessionFile(file.name)) {
-    await deps.importSession(file);
-    return;
-  }
-  // One load at a time. The shared parse worker decodes a single file; a
-  // second load started mid-flight would hijack the first one's worker. The
-  // in-progress load carries a Cancel control if the user wants to switch.
+  // Measurements Import). It splits three ways: an `.olvsession` is a saved
+  // analysis (→ the one session loader), a COPC file streams, everything else
+  // takes the static loader. The one-load-at-a-time guard below now covers ALL
+  // three — including the session reroute, which used to run AHEAD of it.
+  //
+  // One load at a time. The shared parse worker decodes a single file; a second
+  // load started mid-flight would hijack the first one's worker. The session
+  // reroute sits under this guard too: an embed `load-file` is wrapped as a File
+  // whose NAME the host controls (main.ts), so a `x.olvsession` name could
+  // otherwise reach the session loader unthrottled and stack repeated restores.
   if (deps.isLoading()) {
     deps.showToast('Already loading — cancel the current load first.');
     return;
   }
-  // Claim the flag SYNCHRONOUSLY — the `await viewerReady` below yields to
-  // the event loop, and a second drop in that window used to pass the
-  // `loading` guard too (TOCTOU). The `finally` below is the only reset.
+  // Claim the flag SYNCHRONOUSLY — the `await`s below yield to the event loop,
+  // and a second drop in that window used to pass the `loading` guard too
+  // (TOCTOU). Every return path from here on releases it.
   deps.setLoading(true);
+  // An `.olvsession` is a saved analysis, not a scan: route it to the one
+  // session loader (never the cloud worker) and release the flag in its own
+  // finally — the session path has no cancel / progress affordance, so it does
+  // not share the cloud path's dropzone setup below.
+  if (isSessionFile(file.name)) {
+    try {
+      await deps.importSession(file);
+    } finally {
+      deps.setLoading(false);
+    }
+    return;
+  }
   const controller = new AbortController();
   // Blue blinking "Opening …" — the prominent first feedback, matching the
   // catalog status vocabulary so device and public-dataset loads read the same.

--- a/src/app/sessionIo.ts
+++ b/src/app/sessionIo.ts
@@ -39,6 +39,17 @@ import type {
   SessionSpatialVerdict,
 } from '../io/session';
 
+/**
+ * Whole-file byte ceiling for a `.olvsession`, checked on the File's size BEFORE
+ * it is read. A shared session is untrusted input, and `parseSession` runs
+ * `JSON.parse` over the entire text — an unbounded file can exhaust memory
+ * before the parser's per-dimension caps ever apply (and before the try/catch
+ * can surface it). An inspection session is analysis metadata, not the scan, so
+ * even a rich Evidence Capsule is a few MB; 256 MB is far above any real session
+ * while bounding the parse. Over-limit is rejected onto the drop zone.
+ */
+export const MAX_SESSION_BYTES = 256 * 1024 * 1024;
+
 /** The streaming-source slice `scanFactsFromStreaming` reads — a structural subset of {@link StreamingSource}. */
 export interface StreamingScanSource {
   readonly name: string;
@@ -216,6 +227,16 @@ export async function importSession(
   deps: SessionIoDeps,
 ): Promise<void> {
   try {
+    // A shared `.olvsession` is untrusted; reject an over-large file up front,
+    // before it is read, so `JSON.parse` of the whole text can't exhaust memory.
+    // This is the whole-file ceiling; the parser's per-dimension caps (item
+    // counts, per-measurement points) bound the rest once the JSON is in hand.
+    if (file.size > MAX_SESSION_BYTES) {
+      throw new Error(
+        `This session file is too large (${Math.round(file.size / (1024 * 1024))} MB; ` +
+          `limit ${Math.round(MAX_SESSION_BYTES / (1024 * 1024))} MB).`,
+      );
+    }
     // The session path's imports are light (no three.js), so a session restore
     // can finish before the lazily-imported Viewer chunk resolves — leaving
     // `viewer` as its null sentinel. Await viewerReady so every `viewer.*`
@@ -286,6 +307,31 @@ export async function importSession(
           return;
         }
       }
+      // Roadmap P1 #5 — validate the session's spatial FRAME here, in the SAME
+      // preflight as the scan-identity match and BEFORE any state is attached. A
+      // session whose extents match the scan (so `matchSessionToScan` returned
+      // strong/partial, not conflict) can still declare a divergent up-axis, unit
+      // or CRS — a Z-up survey re-exported Y-up keeps identical extents. Rebasing
+      // geometry is TRANSLATION only, never rotation or rescale, so attaching a
+      // session under the wrong frame lands every measurement silently wrong.
+      // Detect the conflict against the FILE's own declaration and refuse the
+      // whole restore, exactly as the identity `conflict` verdict does above,
+      // rather than mutating the scene and disclosing after the fact. (The
+      // "Apply anyway" path overrides identity CONFIDENCE only; a spatial-frame
+      // conflict is a harder, different failure and is never waved through.)
+      const declaredSpatial = declaredSpatialForActiveScan(viewer, deps);
+      const spatial = detectSessionSpatialConflict(
+        { upAxis: session.upAxis, epsg: session.crs?.epsg, linearUnit: session.crs?.linearUnit },
+        declaredSpatial,
+      );
+      if (spatial.hasConflict) {
+        const why = spatial.conflicts.map((c) => c.reason).join('; ');
+        deps.showToast(
+          `This session's spatial metadata conflicts with this scan (${why}) — it was not applied. ` +
+            `The scan's own frame is kept; load the session on its own scan to restore it.`,
+        );
+        return;
+      }
     }
     const geo = haveCloud
       ? rebaseSessionGeometry(session, deps.exportOrigin())
@@ -341,36 +387,17 @@ export async function importSession(
       clip: geo.clip,
       camera: geo.camera,
     });
-    // Roadmap P1 #5 — the session's stored spatial metadata must never silently
-    // redefine the loaded scan's own frame. Compare the session's CRS code,
-    // up-axis and linear unit against what the FILE declares; any divergence is a
-    // conflict, not a disclosure. On a conflict we keep the file's declaration
-    // and refuse the session's spatial claim (disclosing it), rather than
-    // reinterpreting the scan's coordinates. The scan-identity gate already
-    // refuses a mismatched EPSG summary; this covers the rest — a differing
-    // up-axis or unit, and a scan whose declaration exists but was absent from
-    // the session's summary. With no cloud loaded the file declares nothing, so
-    // nothing can conflict and the session's CRS (if any) still round-trips.
-    const declaredSpatial: DeclaredSpatialFacts = haveCloud
-      ? declaredSpatialForActiveScan(viewer, deps)
-      : {};
-    const spatial = detectSessionSpatialConflict(
-      { upAxis: session.upAxis, epsg: session.crs?.epsg, linearUnit: session.crs?.linearUnit },
-      declaredSpatial,
-    );
-    if (spatial.hasConflict) {
-      const why = spatial.conflicts.map((c) => c.reason).join('; ');
-      deps.showToast(
-        `The session's spatial metadata conflicts with this scan (${why}) — ` +
-          `the scan's own declaration is kept and the session's was not applied.`,
-      );
-    } else if (
+    // Roadmap P1 #5 — the spatial FRAME was already validated in the preflight
+    // above (a divergent up-axis / unit / CRS refuses the whole restore before
+    // any state is attached), so reaching here means the session's frame agrees
+    // with the file's, or no cloud is loaded for it to disagree with. Restore the
+    // author's CRS override so an Evidence Capsule round-trips without
+    // re-prompting; a session that declared no usable CRS leaves the file's own.
+    if (
       session.crs &&
       session.crs.epsg != null &&
       (session.crs.kind === 'projected' || session.crs.kind === 'geographic' || session.crs.kind === 'local')
     ) {
-      // No conflict — restore the author's CRS override so a capsule round-trips
-      // without re-prompting.
       deps.setCrsOverride({
         override: { epsg: session.crs.epsg, kind: session.crs.kind },
         detected: deps.getActiveScanId()

--- a/src/app/sessionIo.ts
+++ b/src/app/sessionIo.ts
@@ -65,6 +65,15 @@ export interface StreamingScanSource {
 export interface StaticScanCloud {
   readonly name: string;
   readonly pointCount: number;
+  /**
+   * Source-truth counts, preferred over the display-sampled `pointCount` for
+   * identity. `declaredPointCount` is the file header's own total;
+   * `decodedPointCount` is what the decoder read before any voxel downsample.
+   * Both survive stride / downsample (see PointCloud), so a fingerprint built
+   * from them does not shift with a device's point budget.
+   */
+  readonly declaredPointCount?: number;
+  readonly decodedPointCount?: number;
   bounds(): {
     readonly min: readonly [number, number, number];
     readonly max: readonly [number, number, number];
@@ -100,14 +109,36 @@ export function scanFactsFromStreaming(cloud: StreamingScanSource): ScanFacts {
 
 /**
  * Build the loaded-scan fingerprint from a static cloud. Pure counterpart to
- * {@link scanFactsFromStreaming}: extent spans from `bounds()`, point count and
- * CRS from the cloud's own header metadata.
+ * {@link scanFactsFromStreaming}: point count from the source header, CRS from
+ * the cloud's own header metadata, extent spans from `bounds()`.
+ *
+ * The point count is SOURCE truth, not the display sample. The held
+ * `pointCount` is whatever survived this device's decode stride and voxel
+ * downsample, so reading it here made a scan's identity change with the point
+ * budget — the same file fingerprinted differently on mobile vs desktop, and a
+ * valid session failed to match across devices. The streaming sibling already
+ * reads `sourcePointCount` for exactly this reason; the static analog is the
+ * header's declared total, falling to the pre-downsample decode count, then the
+ * held count (the header count on top of the `decodedPointCount ?? pointCount`
+ * ladder the Health Check uses). Both source-truth fields survive stride /
+ * downsample (see PointCloud), so the fingerprint no longer moves with the
+ * device.
+ *
+ * Extents (`width`/`depth`/`height`) are the residual: they still come from the
+ * DECIMATED `bounds()`. A source/header extent is not reachable here — the
+ * LAS/LAZ header min/max are read at load (`lasHeader.ts`) but consumed for the
+ * origin and never persisted onto the cloud or its metadata, and threading a
+ * header extent through every loader is out of scope for this change. So the
+ * spans stay decimation-sensitive (stride / voxel sampling rarely lands on the
+ * exact extremes) and an exact-match consumer must compare them with a
+ * tolerance, never equality — as {@link matchSessionToScan} already does (its
+ * 1 %/5 % extent bands). Only the count above is source-stable.
  */
 export function scanFactsFromStatic(cloud: StaticScanCloud): ScanFacts {
   const b = cloud.bounds();
   return {
     fileName: cloud.name,
-    sourcePoints: cloud.pointCount,
+    sourcePoints: cloud.declaredPointCount ?? cloud.decodedPointCount ?? cloud.pointCount,
     width: b.max[0] - b.min[0],
     depth: b.max[1] - b.min[1],
     height: b.max[2] - b.min[2],

--- a/src/io/session.ts
+++ b/src/io/session.ts
@@ -437,6 +437,48 @@ function parseUpAxis(raw: unknown): 'y' | 'z' {
   );
 }
 
+// --- session resource ceilings ---------------------------------------------
+// A shared, corrupt or hostile `.olvsession` is untrusted input. These cap the
+// dimensions an over-large file can blow up on; each is far beyond any real
+// session and truncates/rejects BEFORE the value reaches app state. (The whole-
+// file byte ceiling is enforced one layer up, in `app/sessionIo.ts`, on the
+// File's size before this parser ever reads it.)
+
+/** Hard cap on parsed list lengths (views, measurements, chart samples, annotations) — a hostile/corrupt file can't hang the tab. */
+export const MAX_SESSION_ITEMS = 100_000;
+
+/**
+ * Cap on a SINGLE measurement's vertex list. A real measurement holds at most a
+ * few thousand hand-placed / traced vertices, so a million is orders beyond any
+ * legitimate one while still bounding the per-measurement heap: one hostile
+ * entry carrying tens of millions of points would otherwise OOM the tab — an
+ * allocation the `importSession` try/catch can't catch, because the tab dies
+ * first.
+ */
+export const MAX_MEASUREMENT_POINTS = 1_000_000;
+
+/** Cap on an annotation title's length — a multi-MB string is a DoS, not a label. */
+export const MAX_ANNOTATION_TITLE = 512;
+/** Cap on an annotation note's length — generous for a paragraph, bounded against abuse. */
+export const MAX_ANNOTATION_NOTE = 8_192;
+
+/**
+ * Cap on the opaque `processingManifest`'s serialized size. The slot is passed
+ * through verbatim (never validated), so a size bound is the only guard on it; a
+ * real manifest is a few KB of provenance, so 4 MB is far above any legitimate
+ * one while rejecting a slot inflated to exhaust memory.
+ */
+export const MAX_MANIFEST_BYTES = 4 * 1024 * 1024;
+
+/** True when the opaque manifest serialises within the byte cap; a non-serialisable or over-cap value is rejected (dropped, treated as absent). */
+function withinManifestByteCap(manifest: unknown): boolean {
+  try {
+    return JSON.stringify(manifest).length <= MAX_MANIFEST_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 export function parseSession(text: string): InspectionSession {
   let raw: unknown;
   try {
@@ -496,7 +538,12 @@ export function parseSession(text: string): InspectionSession {
   // passthrough until the processing-manifest workstream defines its shape).
   // Deliberately version-independent on read so a file that carries one is
   // never stripped by a round-trip.
-  if (raw.processingManifest != null) out.processingManifest = raw.processingManifest;
+  // Opaque passthrough (never validated), so the one guard on this untrusted
+  // slot is its serialized SIZE — an over-cap manifest is dropped (treated as
+  // absent) rather than carried, verbatim, into app state.
+  if (raw.processingManifest != null && withinManifestByteCap(raw.processingManifest)) {
+    out.processingManifest = raw.processingManifest;
+  }
   // Stable layer identity — additive within v7, version-independent on read so a
   // file that carries it is never stripped by a round trip. A non-string is
   // ignored (treated as absent) rather than throwing.
@@ -1024,7 +1071,9 @@ function parseCameraState(v: unknown): SavedCameraState {
 function parseViews(v: unknown): SavedView[] {
   if (!Array.isArray(v)) return [];
   const out: SavedView[] = [];
-  v.forEach((item, i) => {
+  // Cap the count, matching the three sibling parsers below — a hostile file
+  // can't hang the tab by declaring an unbounded number of views.
+  v.slice(0, MAX_SESSION_ITEMS).forEach((item, i) => {
     if (!isRecord(item)) return;
     const name =
       typeof item.name === 'string' && item.name.trim().length > 0
@@ -1049,9 +1098,6 @@ function parseViews(v: unknown): SavedView[] {
   return out;
 }
 
-/** Hard cap on parsed list lengths — a hostile/corrupt file can't hang the tab. */
-const MAX_SESSION_ITEMS = 100_000;
-
 function parseMeasurements(v: unknown): Measurement[] {
   if (!Array.isArray(v)) return [];
   const out: Measurement[] = [];
@@ -1060,8 +1106,10 @@ function parseMeasurements(v: unknown): Measurement[] {
     const kind = item.kind;
     if (typeof kind !== 'string' || !KINDS.includes(kind as MeasurementKind)) continue;
     const k = kind as MeasurementKind;
+    // Slice BEFORE filter/map so the cap bounds the WORK, not just the output —
+    // a single measurement carrying tens of millions of points can't OOM the tab.
     const points = Array.isArray(item.points)
-      ? item.points.filter(isVec3).map((p): Vec3 => [p[0], p[1], p[2]])
+      ? item.points.slice(0, MAX_MEASUREMENT_POINTS).filter(isVec3).map((p): Vec3 => [p[0], p[1], p[2]])
       : [];
     if (points.length < MIN_POINTS[k]) continue;
     const m: Measurement = {
@@ -1208,13 +1256,19 @@ function parseAnnotations(v: unknown): Annotation[] {
     const updated = isFiniteNumber(item.updatedAt) ? item.updatedAt : created;
     const annotation: Annotation = {
       id: typeof item.id === 'string' && item.id.length > 0 ? item.id : freshAnnotationId(),
-      title: typeof item.title === 'string' && item.title.length > 0 ? item.title : 'Annotation',
+      // Cap the length — a title is a label, not a payload; a multi-MB string is abuse.
+      title:
+        typeof item.title === 'string' && item.title.length > 0
+          ? item.title.slice(0, MAX_ANNOTATION_TITLE)
+          : 'Annotation',
       type: isAnnotationType(item.type) ? item.type : 'note',
       createdAt: created,
       updatedAt: updated,
       localPosition: local,
     };
-    if (typeof item.note === 'string' && item.note.length > 0) annotation.note = item.note;
+    if (typeof item.note === 'string' && item.note.length > 0) {
+      annotation.note = item.note.slice(0, MAX_ANNOTATION_NOTE);
+    }
     const world = parseVec3Object(item.worldPosition);
     if (world) annotation.worldPosition = world;
     // The owning layer + CRS label — the world frame's provenance, kept so a

--- a/src/io/sessionFrame.ts
+++ b/src/io/sessionFrame.ts
@@ -100,6 +100,14 @@ export interface SessionFrameInput {
 
 const AXES: readonly FrameUpAxis[] = ['x', 'y', 'z'];
 
+/**
+ * Cap on the number of layer records a project frame may declare. One record per
+ * loaded layer, so a real project has a handful; 10k is far beyond any genuine
+ * frame while bounding how much a hostile file can make the validator allocate
+ * and walk. Over-cap is refused, like any other self-inconsistent frame.
+ */
+export const MAX_FRAME_LAYERS = 10_000;
+
 function isFiniteNumber(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v);
 }
@@ -133,7 +141,12 @@ export function validateSessionProjectFrame(frame: unknown): string[] {
     reasons.push('the frame declares no layers');
     return reasons;
   }
-
+  // Refuse an unbounded layer count up front, before the per-layer walk below —
+  // a hostile frame can't make the validator chew through millions of records.
+  if (layers.length > MAX_FRAME_LAYERS) {
+    reasons.push(`the frame declares ${layers.length} layers, above the ${MAX_FRAME_LAYERS} cap`);
+    return reasons;
+  }
   const seen = new Set<string>();
   layers.forEach((entry, i) => {
     const where = `layer ${i + 1}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4926,7 +4926,7 @@ async function exportSession(): Promise<void> {
     const b = cloud.bounds();
     scanSummary = {
       fileName: cloud.name,
-      sourcePoints: cloud.pointCount,
+      sourcePoints: cloud.declaredPointCount ?? cloud.decodedPointCount ?? cloud.pointCount,
       width: b.max[0] - b.min[0],
       depth: b.max[1] - b.min[1],
       height: b.max[2] - b.min[2],

--- a/src/ui/embedBridge.ts
+++ b/src/ui/embedBridge.ts
@@ -22,6 +22,16 @@ import type { SavedCameraState } from '../render/annotate/types';
 /** The tag identifying messages this viewer sends. */
 const SOURCE = 'openlidarviewer';
 
+/**
+ * Byte ceiling on an embed `load-file` buffer. The host pushes the whole file in
+ * one `postMessage`, which structured-clones (copies) the ArrayBuffer into this
+ * frame before the loader ever sees it, so an unbounded `byteLength` is a claim
+ * this frame is made to allocate. 2 GiB is past any practical postMessage
+ * transfer while rejecting an absurd allocation up front rather than in the
+ * decoder. An over-limit buffer is dropped exactly like a malformed one.
+ */
+export const MAX_EMBED_FILE_BYTES = 2 * 1024 * 1024 * 1024;
+
 /** A validated inbound command — the discriminated result of one message. */
 export type EmbedCommand =
   | { kind: 'load-file'; buffer: ArrayBuffer; name: string }
@@ -69,7 +79,11 @@ export function interpretEmbedMessage(data: unknown): EmbedCommand | null {
   if (!isRecord(data)) return null;
   switch (data.type) {
     case 'load-file':
-      return data.buffer instanceof ArrayBuffer && typeof data.name === 'string'
+      // The buffer is host-supplied and copied into this frame whole; cap its
+      // byteLength so an absurd size is dropped here, not in the decoder.
+      return data.buffer instanceof ArrayBuffer &&
+        data.buffer.byteLength <= MAX_EMBED_FILE_BYTES &&
+        typeof data.name === 'string'
         ? { kind: 'load-file', buffer: data.buffer, name: data.name }
         : null;
     case 'jump-camera': {
@@ -183,8 +197,14 @@ export function startEmbedBridge(
 
   const onMessage = (event: MessageEvent): void => {
     // Only the actual embedding parent may drive the viewer — never a sibling
-    // iframe, an opener, or a popup that postMessages into this window.
-    if (window.parent !== window && event.source !== window.parent) return;
+    // iframe, an opener, or a popup that postMessages into this window. The
+    // source check runs UNCONDITIONALLY: at top level `window.parent === window`,
+    // so this accepts only a message from the window itself and drops an opener
+    // (which is a DIFFERENT window). Guarding it behind `window.parent !== window`
+    // — as this once did — skipped the check entirely at top level and let an
+    // opener that did `window.open('…?embed=1')` then postMessage drive the app.
+    // A genuine iframe embed is unaffected: `event.source === window.parent` still.
+    if (event.source !== window.parent) return;
     if (allow && allow.length > 0 && !allow.includes(event.origin)) return;
     const command = interpretEmbedMessage(event.data);
     if (!command) return;

--- a/tests/embedBridge.test.ts
+++ b/tests/embedBridge.test.ts
@@ -1,4 +1,21 @@
-import { interpretEmbedMessage } from '../src/ui/embedBridge';
+import { afterEach, describe, expect, it, test, vi } from 'vitest';
+import {
+  interpretEmbedMessage,
+  startEmbedBridge,
+  MAX_EMBED_FILE_BYTES,
+  type EmbedBridgeHandlers,
+} from '../src/ui/embedBridge';
+
+/**
+ * A real (tiny) ArrayBuffer whose reported `byteLength` is shadowed to `size`.
+ * Lets a test assert the byte cap without allocating gigabytes — an own data
+ * property shadows the ArrayBuffer.prototype.byteLength accessor on read.
+ */
+function bufferOfSize(size: number): ArrayBuffer {
+  const buf = new ArrayBuffer(8);
+  Object.defineProperty(buf, 'byteLength', { value: size, configurable: true });
+  return buf;
+}
 
 test('a valid jump-camera message is interpreted', () => {
   const cmd = interpretEmbedMessage({
@@ -57,10 +74,139 @@ test('load-file requires an ArrayBuffer and a name', () => {
     .toBeNull();
 });
 
+test('load-file rejects a buffer over the byte cap', () => {
+  const buffer = bufferOfSize(MAX_EMBED_FILE_BYTES + 1);
+  expect(interpretEmbedMessage({ type: 'load-file', buffer, name: 'a.las' })).toBeNull();
+});
+
+test('load-file accepts a buffer exactly at the byte cap', () => {
+  const buffer = bufferOfSize(MAX_EMBED_FILE_BYTES);
+  expect(interpretEmbedMessage({ type: 'load-file', buffer, name: 'a.las' }))
+    .toEqual({ kind: 'load-file', buffer, name: 'a.las' });
+});
+
 test('unrecognised, malformed, and non-object messages are rejected', () => {
   expect(interpretEmbedMessage({ type: 'delete-everything' })).toBeNull();
   expect(interpretEmbedMessage({ type: 'jump-camera' })).toBeNull();
   expect(interpretEmbedMessage(null)).toBeNull();
   expect(interpretEmbedMessage('jump-camera')).toBeNull();
   expect(interpretEmbedMessage(undefined)).toBeNull();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// startEmbedBridge — the browser glue's source gate. These exercise the source
+// check itself (previously only the pure interpreter was tested), and pin the
+// difference between a real embedding parent and an opener at top level.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeHandlers() {
+  const calls = {
+    onLoadFile: vi.fn(),
+    onJumpCamera: vi.fn(),
+    onToggleLayer: vi.fn(),
+    onFocusAnnotation: vi.fn(),
+  };
+  return { handlers: calls as unknown as EmbedBridgeHandlers, calls };
+}
+
+/**
+ * Install a fake `window` for one startEmbedBridge run and capture its 'message'
+ * listener. `topLevel: true` makes `window.parent === window` (a page opened
+ * directly — the situation an opener/popup exploits); `topLevel: false` gives a
+ * DISTINCT parent object (a genuine iframe embed).
+ */
+function withWindow(topLevel: boolean) {
+  let listener: ((e: MessageEvent) => void) | null = null;
+  const win: Record<string, unknown> = {
+    addEventListener: (type: string, cb: (e: MessageEvent) => void) => {
+      if (type === 'message') listener = cb;
+    },
+    removeEventListener: vi.fn(),
+    postMessage: vi.fn(),
+  };
+  const parent = topLevel ? win : { postMessage: vi.fn() };
+  win.parent = parent;
+  (globalThis as { window?: unknown }).window = win;
+  return {
+    parent,
+    dispatch: (e: { source: unknown; origin: string; data: unknown }) =>
+      listener?.(e as unknown as MessageEvent),
+  };
+}
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+});
+
+describe('startEmbedBridge — only the true embedding parent may drive the viewer', () => {
+  it('DROPS a message from an opener at top level (window.parent === window)', () => {
+    // A page opened directly (window.parent === window). An opener that did
+    // `window.open('…?embed=1')` then postMessage is NOT the parent — the old
+    // guard skipped its source check here and processed the command anyway.
+    const { handlers, calls } = makeHandlers();
+    const env = withWindow(true);
+    const dispose = startEmbedBridge(handlers);
+    env.dispatch({
+      source: { id: 'opener-window' },
+      origin: 'https://attacker.example',
+      data: { type: 'toggle-layer', id: 'cloud_0', visible: false },
+    });
+    expect(calls.onToggleLayer).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it('ACCEPTS a command from the genuine embedding parent (iframe case unaffected)', () => {
+    const { handlers, calls } = makeHandlers();
+    const env = withWindow(false);
+    const dispose = startEmbedBridge(handlers);
+    env.dispatch({
+      source: env.parent,
+      origin: 'https://host.example',
+      data: { type: 'toggle-layer', id: 'cloud_0', visible: true },
+    });
+    expect(calls.onToggleLayer).toHaveBeenCalledWith('cloud_0', true);
+    dispose();
+  });
+
+  it('DROPS a top-level self/opener message even when it is well-formed', () => {
+    // Defence in depth: at top level the only accepted source is the window
+    // itself; a foreign source with a perfectly valid jump-camera is still gone.
+    const { handlers, calls } = makeHandlers();
+    const env = withWindow(true);
+    const dispose = startEmbedBridge(handlers);
+    env.dispatch({
+      source: { id: 'popup' },
+      origin: 'https://attacker.example',
+      data: { type: 'jump-camera', camera: { position: [1, 2, 3], target: [0, 0, 0] } },
+    });
+    expect(calls.onJumpCamera).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it('DROPS an oversized load-file even from the genuine parent (byte cap)', () => {
+    const { handlers, calls } = makeHandlers();
+    const env = withWindow(false);
+    const dispose = startEmbedBridge(handlers);
+    env.dispatch({
+      source: env.parent,
+      origin: 'https://host.example',
+      data: { type: 'load-file', name: 'x.las', buffer: bufferOfSize(MAX_EMBED_FILE_BYTES + 1) },
+    });
+    expect(calls.onLoadFile).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it('accepts a within-limit load-file from the genuine parent', () => {
+    const { handlers, calls } = makeHandlers();
+    const env = withWindow(false);
+    const dispose = startEmbedBridge(handlers);
+    const buffer = new ArrayBuffer(8);
+    env.dispatch({
+      source: env.parent,
+      origin: 'https://host.example',
+      data: { type: 'load-file', name: 'x.las', buffer },
+    });
+    expect(calls.onLoadFile).toHaveBeenCalledWith(buffer, 'x.las');
+    dispose();
+  });
 });

--- a/tests/openScan.test.ts
+++ b/tests/openScan.test.ts
@@ -154,15 +154,28 @@ function makeDeps(over: { loading?: boolean } = {}) {
 }
 
 describe('openScan — the file router', () => {
-  it('routes an .olvsession to the session loader, never the cloud worker', async () => {
+  it('routes an .olvsession to the session loader UNDER the load guard, never the cloud worker', async () => {
     const { deps, calls } = makeDeps();
     await openScan(fakeFile('survey.olvsession'), deps);
     expect(calls.importSession).toHaveBeenCalledTimes(1);
-    // A session restore routes AHEAD of the loading guard and touches no loader.
-    expect(calls.isLoading).not.toHaveBeenCalled();
-    expect(calls.setLoading).not.toHaveBeenCalled();
+    // FIX C: the session reroute now runs UNDER the one-load-at-a-time guard.
+    // An embed `load-file` is wrapped as a File whose NAME the host controls, so
+    // a `x.olvsession` name reaching the session loader unthrottled could stack
+    // repeated restores. It still touches no cloud loader, and it claims then
+    // releases the flag around the restore.
+    expect(calls.isLoading).toHaveBeenCalled();
+    expect(calls.setLoading).toHaveBeenNthCalledWith(1, true);
+    expect(calls.setLoading).toHaveBeenLastCalledWith(false);
     expect(calls.loadLocalSource).not.toHaveBeenCalled();
     expect(calls.openLocalCopc).not.toHaveBeenCalled();
+  });
+
+  it('refuses a second .olvsession while a load is in flight (no stacking)', async () => {
+    const { deps, calls } = makeDeps({ loading: true });
+    await openScan(fakeFile('survey.olvsession'), deps);
+    expect(calls.showToast).toHaveBeenCalledWith(expect.stringContaining('Already loading'));
+    expect(calls.importSession).not.toHaveBeenCalled();
+    expect(calls.setLoading).not.toHaveBeenCalled(); // guard rejects before claiming the flag
   });
 
   it('refuses a second load while one is in flight, without starting anything', async () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { serializeSession, parseSession, SESSION_VERSION, isSessionFile, SESSION_EXTENSION, matchSessionToScan } from '../src/io/session';
+import {
+  serializeSession,
+  parseSession,
+  SESSION_VERSION,
+  isSessionFile,
+  SESSION_EXTENSION,
+  matchSessionToScan,
+  MAX_SESSION_ITEMS,
+  MAX_MEASUREMENT_POINTS,
+  MAX_ANNOTATION_TITLE,
+  MAX_ANNOTATION_NOTE,
+  MAX_MANIFEST_BYTES,
+} from '../src/io/session';
 import type { InspectionSession, SavedView } from '../src/io/session';
 import {
   buildProcessingManifest,
@@ -1214,5 +1226,67 @@ describe('matchSessionToScan — a differing EPSG code caps the verdict', () => 
     const m = matchSessionToScan({ ...base, crs: 'A' }, { ...base, crs: 'B' });
     expect(m.verdict).toBe('strong');
     expect(m.reasons.join(' ')).toContain('CRS label differs');
+  });
+});
+
+describe('session resource ceilings (hostile / corrupt input)', () => {
+  const baseDoc = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+    app: 'OpenLiDARViewer',
+    kind: 'measurement-session',
+    version: SESSION_VERSION,
+    upAxis: 'z',
+    origin: [0, 0, 0],
+    unitSystem: 'metric',
+    views: [],
+    measurements: [],
+    annotations: [],
+    ...over,
+  });
+
+  it('truncates parseViews at MAX_SESSION_ITEMS (the sibling-parser cap it was missing)', () => {
+    const views = new Array(MAX_SESSION_ITEMS + 5).fill({});
+    const session = parseSession(JSON.stringify(baseDoc({ views })));
+    expect(session.views).toHaveLength(MAX_SESSION_ITEMS);
+  });
+
+  it('caps the vertex list of a single measurement at MAX_MEASUREMENT_POINTS', () => {
+    // Built as a raw JSON string so the over-cap array is one string allocation,
+    // not a materialised JS array on the test side. All points are valid vec3s,
+    // so the result is truncated to exactly the cap.
+    const n = MAX_MEASUREMENT_POINTS + 3;
+    const pointsJson = '[' + '[0,0,0],'.repeat(n - 1) + '[0,0,0]]';
+    const doc =
+      `{"app":"OpenLiDARViewer","kind":"measurement-session","version":${SESSION_VERSION},` +
+      '"upAxis":"z","origin":[0,0,0],"unitSystem":"metric","views":[],"annotations":[],' +
+      `"measurements":[{"kind":"distance","points":${pointsJson}}]}`;
+    const session = parseSession(doc);
+    expect(session.measurements).toHaveLength(1);
+    expect(session.measurements[0].points.length).toBe(MAX_MEASUREMENT_POINTS);
+  });
+
+  it('caps an annotation title and note length', () => {
+    const annotations = [
+      {
+        localPosition: { x: 0, y: 0, z: 0 },
+        title: 'T'.repeat(MAX_ANNOTATION_TITLE + 100),
+        note: 'N'.repeat(MAX_ANNOTATION_NOTE + 100),
+      },
+    ];
+    const session = parseSession(JSON.stringify(baseDoc({ annotations })));
+    expect(session.annotations).toHaveLength(1);
+    expect(session.annotations[0].title.length).toBe(MAX_ANNOTATION_TITLE);
+    expect(session.annotations[0].note?.length).toBe(MAX_ANNOTATION_NOTE);
+  });
+
+  it('drops a processingManifest whose serialized size exceeds the cap', () => {
+    const bigManifest = { note: 'x'.repeat(MAX_MANIFEST_BYTES + 100) };
+    const session = parseSession(JSON.stringify(baseDoc({ processingManifest: bigManifest })));
+    expect(session.processingManifest).toBeUndefined();
+  });
+
+  it('keeps a normal-sized processingManifest (the cap never rejects a legitimate one)', () => {
+    const manifest = { schema: 'olv@1', steps: [{ op: 'crop' }] };
+    const session = parseSession(JSON.stringify(baseDoc({ processingManifest: manifest })));
+    expect(session.processingManifest).toEqual(manifest);
   });
 });

--- a/tests/sessionIo.test.ts
+++ b/tests/sessionIo.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_SESSION_BYTES,
   type SessionIoDeps,
   type SessionModule,
+  type StaticScanCloud,
 } from '../src/app/sessionIo';
 import {
   serializeSession,
@@ -227,6 +228,79 @@ describe('scanFactsFromStatic — pure cloud→fingerprint adapter', () => {
     });
     expect(facts.crs).toBeUndefined();
     expect(facts.epsg).toBeUndefined();
+  });
+
+  // Identity must be SOURCE-stable: the same file loaded at a different point
+  // budget / decode stride on another device has to fingerprint identically.
+  // `pointCount` (and the `bounds()` taken over the held sample) are the
+  // device-variant fields; `declaredPointCount` is the header's own total and
+  // survives stride / voxel downsample. These two fixtures are the SAME source
+  // file and differ ONLY in the display-sampled fields.
+  const HEADER_COUNT = 1_000_000;
+  const denseLoad: StaticScanCloud = {
+    name: 'survey.las',
+    pointCount: 500_000, // ~stride 2 under a desktop budget
+    declaredPointCount: HEADER_COUNT,
+    decodedPointCount: 500_000,
+    // more points held → the sampled AABB reaches closer to the true extremes
+    bounds: () => ({ min: [0, 0, 0], max: [99.8, 49.9, 12.4] }),
+  };
+  const sparseLoad: StaticScanCloud = {
+    name: 'survey.las',
+    pointCount: 100_000, // ~stride 10 under a mobile budget
+    declaredPointCount: HEADER_COUNT,
+    decodedPointCount: 100_000,
+    // fewer points held → the sampled extremes fall short of the true extent
+    bounds: () => ({ min: [0, 0, 0], max: [99.1, 49.4, 12.1] }),
+  };
+
+  it('fingerprints the same source identically across load stride / point budget', () => {
+    const dense = scanFactsFromStatic(denseLoad);
+    const sparse = scanFactsFromStatic(sparseLoad);
+    // Source truth from the header, not the held sample — so it does NOT move
+    // with the device budget. (Matches the streaming sibling's sourcePointCount.)
+    expect(dense.sourcePoints).toBe(HEADER_COUNT);
+    expect(sparse.sourcePoints).toBe(HEADER_COUNT);
+    expect(dense.sourcePoints).toBe(sparse.sourcePoints);
+  });
+
+  it('prefers the pre-downsample decode count when the header count is absent', () => {
+    // A format that carries no declared header total (e.g. PLY) still exposes
+    // what the decoder read before voxel downsample — better than the reduced
+    // held count. Ladder: declaredPointCount ?? decodedPointCount ?? pointCount.
+    const facts = scanFactsFromStatic({
+      name: 'mesh.ply',
+      pointCount: 40_000, // held after voxel downsample
+      decodedPointCount: 90_000, // survived the downsample
+      bounds: () => ({ min: [0, 0, 0], max: [1, 1, 1] }),
+    });
+    expect(facts.sourcePoints).toBe(90_000);
+  });
+
+  it('falls back to the held point count when no source count is known, without throwing', () => {
+    const facts = scanFactsFromStatic({
+      name: 'bare',
+      pointCount: 7,
+      bounds: () => ({ min: [0, 0, 0], max: [1, 1, 1] }),
+    });
+    expect(facts.sourcePoints).toBe(7);
+  });
+
+  it('leaves width/depth/height on the DECIMATED bounds — a documented residual', () => {
+    // A source/header extent is NOT reachable here: the LAS/LAZ header min/max
+    // are read at load but consumed for the origin and never persisted onto the
+    // cloud, and adding that plumbing across every loader is out of scope. So
+    // extents still track the display sample and legitimately differ across
+    // devices — pinned here so a future exact-match fingerprint compares extents
+    // with a tolerance (as matchSessionToScan does), never equality, while the
+    // count stays source-stable.
+    const dense = scanFactsFromStatic(denseLoad);
+    const sparse = scanFactsFromStatic(sparseLoad);
+    expect(dense.width).not.toBe(sparse.width);
+    expect(dense.depth).not.toBe(sparse.depth);
+    expect(dense.height).not.toBe(sparse.height);
+    // ...even though the count is identical for the two loads.
+    expect(dense.sourcePoints).toBe(sparse.sourcePoints);
   });
 });
 

--- a/tests/sessionIo.test.ts
+++ b/tests/sessionIo.test.ts
@@ -3,6 +3,7 @@ import {
   importSession,
   scanFactsFromStreaming,
   scanFactsFromStatic,
+  MAX_SESSION_BYTES,
   type SessionIoDeps,
   type SessionModule,
 } from '../src/app/sessionIo';
@@ -365,16 +366,20 @@ describe('importSession — per-scan spatial-metadata guard (roadmap P1 #5)', ()
   });
   const strongSummary = () => summary({ width: 10, depth: 10, height: 3, sourcePoints: 1000 });
 
-  it('refuses the session CRS when the file declares a DIFFERENT EPSG (no silent adopt)', async () => {
+  it('REFUSES the whole restore when the file declares a DIFFERENT EPSG (no geometry under the wrong frame)', async () => {
     const { deps, calls } = makeDeps({ streaming: strongStreaming({ epsg: 32614 }) });
     await importSession(
       asFile(sessionJson({ crs: resolvedCrs({ epsg: 32613 }), scanSummary: strongSummary() })),
       {},
       deps,
     );
-    // Geometry still restores — the scan IS a spatial match — but the session's
-    // CRS claim is refused and disclosed, not applied.
-    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    // FIX A: a hard spatial conflict is validated in the preflight now, BEFORE
+    // any mutation, so nothing is attached (measurements included) — it is not
+    // restored-then-disclosed. The scan-identity gate saw a strong extents match
+    // (the summary carried no EPSG); the resolved CRS-code divergence is the
+    // conflict, and it refuses rather than realigning geometry onto the wrong
+    // frame — the same stance the identity gate takes on a differing summary EPSG.
+    expect(calls.loadMeasurements).not.toHaveBeenCalled();
     expect(calls.setCrsOverride).not.toHaveBeenCalled();
     const warn = calls.showToast.mock.calls.map((c) => c[0] as string).find((m) => /conflicts with this scan/.test(m));
     expect(warn).toBeTruthy();
@@ -402,22 +407,31 @@ describe('importSession — per-scan spatial-metadata guard (roadmap P1 #5)', ()
     expect(calls.showToast.mock.calls.every((c) => !/conflicts with this scan/.test(c[0] as string))).toBe(true);
   });
 
-  it('refuses the session CRS on a UNIT mismatch even when the EPSG agrees', async () => {
+  it('REFUSES the restore on a UNIT mismatch even when the EPSG agrees', async () => {
     const { deps, calls } = makeDeps({ streaming: strongStreaming({ epsg: 32613, linearUnit: 'metre' }) });
     await importSession(
       asFile(sessionJson({ crs: resolvedCrs({ epsg: 32613, linearUnit: 'foot', linearUnitToMetres: 0.3048 }), scanSummary: strongSummary() })),
       {},
       deps,
     );
+    // A metre-vs-foot unit divergence silently rescales every distance, and the
+    // rebase only translates (never rescales), so the geometry can't be made
+    // right — FIX A refuses before attaching it.
+    expect(calls.loadMeasurements).not.toHaveBeenCalled();
     expect(calls.setCrsOverride).not.toHaveBeenCalled();
     const warn = calls.showToast.mock.calls.map((c) => c[0] as string).find((m) => /conflicts with this scan/.test(m));
     expect(warn).toMatch(/linear unit/);
     expect(warn).toMatch(/foot/);
   });
 
-  it('flags an up-axis mismatch against the file’s detected axis', async () => {
-    // A Y-up mesh format (GLB) loaded; the session was captured Z-up. Extents
-    // match so the identity gate passes; the axis divergence is the conflict.
+  it('REFUSES a Z-up session dropped onto a Y-up scan — no measurements under the wrong frame', async () => {
+    // The headline FIX A case. A Y-up mesh format (GLB) is loaded; the session
+    // was captured Z-up. Extents match so the identity gate returns strong, so
+    // the OLD code rebased and attached the measurements, then fired a toast that
+    // under-disclosed (the geometry was already applied). A Z-up→Y-up frame needs
+    // a ROTATION to line up, but the rebase only ever translates — so every
+    // attached measurement lands silently wrong. FIX A validates the axis in the
+    // preflight and refuses the whole restore before any state is touched.
     const { deps, calls } = makeDeps({
       static: {
         name: 'loaded.glb',
@@ -432,12 +446,32 @@ describe('importSession — per-scan spatial-metadata guard (roadmap P1 #5)', ()
       {},
       deps,
     );
-    // Geometry restores; the axis conflict is surfaced, not silently adopted.
-    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    // Nothing spatial is attached — not measurements, not annotations, not views.
+    expect(calls.loadMeasurements).not.toHaveBeenCalled();
+    expect(calls.loadAnnotations).not.toHaveBeenCalled();
+    expect(calls.applyViewState).not.toHaveBeenCalled();
     const warn = calls.showToast.mock.calls.map((c) => c[0] as string).find((m) => /conflicts with this scan/.test(m));
     expect(warn).toBeTruthy();
     expect(warn).toMatch(/up-axis/);
     expect(warn).toMatch(/Y-up/);
+  });
+
+  it('regression guard — a fully matching session (axis, unit, CRS all agree) STILL restores everything', async () => {
+    // The clean-restore path FIX A must leave byte-for-byte intact: no conflict,
+    // so the preflight falls through and every piece of state is committed and
+    // the CRS override round-trips, exactly as before.
+    const { deps, calls } = makeDeps({ streaming: strongStreaming({ epsg: 32613, linearUnit: 'metre' }) });
+    await importSession(
+      asFile(sessionJson({ upAxis: 'z', crs: resolvedCrs({ epsg: 32613, linearUnit: 'metre' }), scanSummary: strongSummary() })),
+      {},
+      deps,
+    );
+    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    expect(calls.loadAnnotations).toHaveBeenCalledTimes(1);
+    expect(calls.restore).toHaveBeenCalledTimes(1);
+    expect(calls.applyViewState).toHaveBeenCalledTimes(1);
+    expect(calls.setCrsOverride).toHaveBeenCalledTimes(1);
+    expect(calls.showToast.mock.calls.every((c) => !/conflicts with this scan/.test(c[0] as string))).toBe(true);
   });
 
   it('restores cleanly when the file’s axis AGREES with the session', async () => {
@@ -454,5 +488,26 @@ describe('importSession — per-scan spatial-metadata guard (roadmap P1 #5)', ()
     await importSession(asFile(sessionJson({ upAxis: 'z', scanSummary: strongSummary() })), {}, deps);
     expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
     expect(calls.showToast.mock.calls.every((c) => !/conflicts with this scan/.test(c[0] as string))).toBe(true);
+  });
+});
+
+describe('importSession — whole-file byte ceiling (OOM hardening)', () => {
+  it('rejects an over-size session file before reading or mutating anything', async () => {
+    const { deps, calls } = makeDeps();
+    const text = vi.fn(async () => sessionJson());
+    const overSize = { size: MAX_SESSION_BYTES + 1, text } as unknown as File;
+    await importSession(overSize, {}, deps);
+    expect(calls.setDropError).toHaveBeenCalledWith(expect.stringContaining('too large'));
+    expect(calls.loadMeasurements).not.toHaveBeenCalled();
+    // Rejected on size alone — the file's bytes are never even read.
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it('reads a file whose size is under the ceiling (regression guard)', async () => {
+    const { deps, calls } = makeDeps();
+    const okFile = { size: 1024, text: async () => sessionJson() } as unknown as File;
+    await importSession(okFile, {}, deps);
+    expect(calls.loadMeasurements).toHaveBeenCalledTimes(1);
+    expect(calls.setDropError).not.toHaveBeenCalled();
   });
 });

--- a/tests/sessionProjectFrame.test.ts
+++ b/tests/sessionProjectFrame.test.ts
@@ -24,6 +24,7 @@ import {
   frameAnchorLayerId,
   withoutFrameLayer,
   withFrameLayerOrder,
+  MAX_FRAME_LAYERS,
 } from '../src/io/sessionFrame';
 import type { SessionLayerRecord, SessionProjectFrame } from '../src/io/sessionFrame';
 import type { ResolvedCrs } from '../src/geo/CoordinateTypes';
@@ -446,5 +447,25 @@ describe('sessionFrame: parse and serialize agree', () => {
       'sourceToProject',
       'upAxis',
     ]);
+  });
+});
+
+describe('validateSessionProjectFrame — layer-count ceiling (hostile input)', () => {
+  it('refuses a frame that declares more than MAX_FRAME_LAYERS layers', () => {
+    const layer = {
+      layerId: 'L',
+      sourceFingerprint: 'f',
+      sourceName: 'n',
+      sourceOrigin: [0, 0, 0],
+      sourceToProject: [0, 0, 0],
+      upAxis: 'z',
+    };
+    const frame = { projectOrigin: [0, 0, 0], layers: new Array(MAX_FRAME_LAYERS + 1).fill(layer) };
+    const reasons = validateSessionProjectFrame(frame);
+    // The count check fires up front and returns early — so the cap reason is
+    // present (the per-layer duplicate-id walk never runs).
+    expect(reasons.some((r) => r.includes('above the') && r.includes(String(MAX_FRAME_LAYERS)))).toBe(true);
+    // And the strict reader refuses it, like any other inconsistent frame.
+    expect(() => parseSessionProjectFrame(frame)).toThrow(/inconsistent/i);
   });
 });

--- a/tests/sessionScanIdentity.test.ts
+++ b/tests/sessionScanIdentity.test.ts
@@ -12,11 +12,14 @@ import { describe, test, expect } from 'vitest';
 import {
   matchSessionToScan,
   detectSessionSpatialConflict,
+  serializeSession,
+  parseSession,
   type ScanFacts,
   type DeclaredSpatialFacts,
   type SessionSpatialClaims,
 } from '../src/io/session';
 import type { SessionScanSummary } from '../src/io/session';
+import { scanFactsFromStatic, type StaticScanCloud } from '../src/app/sessionIo';
 
 const SCAN_A: SessionScanSummary = {
   fileName: 'site-a.laz',
@@ -175,5 +178,96 @@ describe('detectSessionSpatialConflict', () => {
       file({ epsg: 32614, upAxis: 'y', linearUnit: 'foot' }),
     );
     expect(v.conflicts.map((c) => c.field)).toEqual(['crs', 'axis', 'unit']);
+  });
+});
+
+/**
+ * The WRITER side of the same identity fact, round-tripped. `exportSession`
+ * (main.ts) builds its `scanSummary` inline from the active cloud and is only
+ * reachable through the app entry's viewer / DOM wiring, so it is not
+ * unit-addressable here. The behaviour under test is its field rule: the exported
+ * summary must store the SOURCE point count — `declaredPointCount ??
+ * decodedPointCount ?? pointCount`, the SAME ladder the reader's
+ * `scanFactsFromStatic` uses — so a session exported under one device's point
+ * budget reimports strongly under another's. Pinned here at the serialize /
+ * parse + match layer; the one-line writer change in main.ts (the static
+ * `scanSummary.sourcePoints`) is what makes the real export emit it.
+ */
+describe('session round-trip — the exported scan count is source-stable across devices', () => {
+  // The SAME source file loaded at two very different budgets. Its header count
+  // is device-independent; the held `pointCount` is not. Extents are held equal
+  // so the point count is the only variable — the field the writer change fixes.
+  const HEADER = 4_000_000;
+  const bounds = () => ({ min: [0, 0, 0] as const, max: [120, 80, 25] as const });
+  const crsMeta = { crs: { name: 'NAD83 / UTM 13N', epsg: 26913 } };
+  const exportDeviceCloud: StaticScanCloud = {
+    name: 'site-a.laz',
+    pointCount: 250_000, // heavily strided + voxel-downsampled on the export device
+    declaredPointCount: HEADER,
+    decodedPointCount: 250_000,
+    bounds,
+    metadata: crsMeta,
+  };
+  const reimportDeviceCloud: StaticScanCloud = {
+    name: 'site-a.laz',
+    pointCount: 3_900_000, // near-full load on a larger device
+    declaredPointCount: HEADER,
+    decodedPointCount: 3_900_000,
+    bounds,
+    metadata: crsMeta,
+  };
+
+  // The summary the fixed writer emits for the static branch: `sourcePoints` via
+  // the source-stable ladder (mirrored through the reader's shared rule), every
+  // other field exactly as exportSession builds it.
+  const exported = scanFactsFromStatic(exportDeviceCloud);
+  const exportedSummary: SessionScanSummary = {
+    fileName: exported.fileName!,
+    sourcePoints: exported.sourcePoints!,
+    width: exported.width!,
+    depth: exported.depth!,
+    height: exported.height!,
+    ...(exported.crs ? { crs: exported.crs } : {}),
+    ...(exported.epsg != null ? { epsg: exported.epsg } : {}),
+  };
+
+  const roundTrip = (summary: SessionScanSummary): SessionScanSummary | undefined =>
+    parseSession(
+      serializeSession({
+        upAxis: 'z',
+        origin: [0, 0, 0],
+        unitSystem: 'imperial',
+        views: [],
+        measurements: [],
+        annotations: [],
+        scanSummary: summary,
+      }),
+    ).scanSummary;
+
+  test('the serialized scanSummary stores the DECLARED header count, not the strided display sample', () => {
+    const back = roundTrip(exportedSummary);
+    expect(back?.sourcePoints).toBe(HEADER);
+    // The pre-fix writer stored the decimated held count; that value is gone.
+    expect(back?.sourcePoints).not.toBe(exportDeviceCloud.pointCount);
+  });
+
+  test('a strided export reimports STRONGLY on a fuller device', () => {
+    const back = roundTrip(exportedSummary);
+    const reimport = scanFactsFromStatic(reimportDeviceCloud);
+    expect(matchSessionToScan(back, reimport).verdict).toBe('strong');
+  });
+
+  test('the pre-fix decimated count would downgrade that reimport to partial — the instability removed', () => {
+    // What the writer stored BEFORE main.ts aligned to the ladder: the held
+    // count (250k), against a 3.9M-point reimport of the same file.
+    const preFix: SessionScanSummary = {
+      ...exportedSummary,
+      sourcePoints: exportDeviceCloud.pointCount,
+    };
+    const back = roundTrip(preFix);
+    const reimport = scanFactsFromStatic(reimportDeviceCloud);
+    const m = matchSessionToScan(back, reimport);
+    expect(m.verdict).toBe('partial');
+    expect(m.reasons.some((r) => /point count differs/.test(r))).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Two builders turned a scan's identity facts into device-dependent values. `scanFactsFromStatic` (the session read path) and the inline `scanSummary` builder in `main.ts` `exportSession` (the write path) both read the held `pointCount` and the `bounds()` taken over the in-memory positions. Both shrink with a device's decode stride and voxel downsample, so the same source file produced different identity facts on mobile vs desktop, or under any smaller point budget. A session could then fail to match its own scan across devices, and the identity was never stable. That instability is the blocker for the layer-identity model, which exact-matches on these facts.

Both static builders were the outliers. The streaming paths already read `sourcePointCount` (source truth).

## Change

- Reader (`src/app/sessionIo.ts`, `scanFactsFromStatic`): `sourcePoints` now reads `cloud.declaredPointCount ?? cloud.decodedPointCount ?? cloud.pointCount`. Header total preferred, then the pre-downsample decode count, then the held count. `StaticScanCloud` gains the two optional readonly fields it now reads; `PointCloud` already exposes them.
- Writer (`src/main.ts`, `exportSession`): the static-cloud `scanSummary.sourcePoints` now uses the same ladder, so an exported session stores the source count that a reimport computes. One expression, no line delta, so the `lint:monolith-size` ratchet stays at main.ts 5876.

`ScanFacts` / `SessionScanSummary` shapes and every other field are unchanged.

## Extents: documented residual, not fixed

`width` / `depth` / `height` still come from the decimated `bounds()` on both sides. I checked whether a source extent was reachable. The LAS/LAZ header does carry min/max XYZ (`src/io/lasHeader.ts`) and it is read at load, but it is consumed to compute the origin and never persisted onto the cloud or its `metadata` (`lasMetadata` keeps only sensor / software / date / CRS). Reaching a source extent would mean new plumbing through every loader, larger than the count fix and out of scope here.

So the spans stay decimation-sensitive, stated in the function comment and pinned by a test. A future exact-match fingerprint must compare extents with a tolerance rather than equality, which is what `matchSessionToScan` already does with its 1% / 5% bands. Only the count is source-stable.

## Round-trip is now symmetric

This started as a reader-only change, on the premise that `scanFactsFromStatic` was the single shared builder for both the read path and the writer. It is not: the writer in `main.ts` `exportSession` is a separate inline builder. Left half-fixed, that made the session round-trip asymmetric. A large strided cloud exported the decimated count but reimported the source count, downgrading a would-be strong match to a partial, i.e. a confirm prompt on every cross-device reopen. Both sides now use the same ladder, so the round-trip is symmetric and session identity is source-stable, not just layer identity.

`exportSession` is module-local to the app entry and only reachable through viewer / DOM wiring, so it is not unit-addressable. Its field rule is pinned at the nearest testable layer: a serialize / parse round-trip asserting the stored count is the declared header count, plus a match test showing a strided export now reimports strongly on a fuller device where the decimated count downgraded to partial.

## Tests (red-green)

Reader (`tests/sessionIo.test.ts`):
- Same source at two point budgets (identical `declaredPointCount`, different held `pointCount` and `bounds`) yields the same `sourcePoints`. Proven to fail before the change.
- Header count absent falls to the decode count; neither present falls to the held count without throwing.
- Extents pinned as decimation-sensitive (they differ across the two loads) while the count stays identical.

Writer round-trip (`tests/sessionScanIdentity.test.ts`):
- A serialized session stores the declared header count, not the strided display sample.
- A strided export reimports strongly on a fuller device, where the pre-fix decimated count downgraded the same reimport to partial.

## Stacking

Stacks on #316 (`fix/session-embed-input-hardening`), which already modified `sessionIo.ts`; this branch is cut from #316 to avoid a same-file conflict. Merge after #316.

## Verify

- `npx tsc --noEmit`: clean
- `npx vitest run tests/session*.test.ts tests/sessionIo*.test.ts`: 211 passed
- `lint:monolith-size` (main.ts 5876), `lint:archive-vocab`, `lint:layer-boundaries`: all OK
- full `npx vitest run`: 8472 passed, 20 skipped, 1 todo, 0 failures
