### PR TITLE
Give streaming scans a stable shell id so the export guard catches swaps

### DIFF
--- a/src/app/ScanService.ts
+++ b/src/app/ScanService.ts
@@ -38,6 +38,21 @@ export interface ScanService {
   clearIf(id: string): void;
   /** The active cloud, or null when nothing is selected or it is gone. */
   activeCloud(): PointCloud | null;
+  /**
+   * The identity the export/terrain scan-identity guards compare: the active
+   * STATIC scan's `activeId`, or — when a streaming scan is open (`activeId` is
+   * null for streaming) — that streaming scan's stable shell id, or null when
+   * nothing identifiable is active.
+   *
+   * Deliberately SEPARATE from {@link activeId}, which keeps returning null for
+   * a streaming scan so no `activeId ? … : …` branch shifts. Only the export and
+   * terrain guards read this streaming-aware form, so they can tell one
+   * streaming scan from another where raw `activeId` could not — closing the
+   * blind spot where `sameExportTarget(null, null)` hid a streaming→streaming
+   * swap. Fails closed: a streaming scan now reports a concrete id, never a
+   * wildcard, and a genuinely unidentified state is still null.
+   */
+  activeExportTargetId(): string | null;
 }
 
 export function createScanService(deps: ScanServiceDeps): ScanService {
@@ -59,6 +74,14 @@ export function createScanService(deps: ScanServiceDeps): ScanService {
     activeCloud() {
       const id = scan.activeId;
       return id ? getViewer().getCloud(id) ?? null : null;
+    },
+    activeExportTargetId() {
+      // Static id wins when a static scan is selected (unchanged identity); a
+      // streaming scan leaves `activeId` null, so fall through to the streaming
+      // cloud's stable shell id. Same late-`getViewer()` assumption `activeCloud`
+      // relies on — only the export/terrain guards call this, well after the
+      // viewer is bound and a scan is open.
+      return scan.activeId ?? getViewer().streamingCloud?.id ?? null;
     },
   };
 }

--- a/src/app/kmlActions.ts
+++ b/src/app/kmlActions.ts
@@ -131,7 +131,11 @@ export async function exportSiteKml(deps: KmlActionDeps): Promise<void> {
   const crs = deps.crsCurrent();
   const toLonLat = makeLocalToLonLat(crs, geo.origin);
   if (!toLonLat) return; // gated by siteKmlStatus; defensive no-op if reached
-  const { buildKml, KmlCoordinateError } = await deps.loadKmlExport();
+  // Every input is read BEFORE the serialiser import. The origin and CRS above
+  // were already captured pre-await while the features, up vector and unit scale
+  // were read after it, so a placement made (or a scan opened) during the import
+  // produced a file mixing one moment's frame with another's contents. One
+  // reading of the session, then the load.
   const input: KmlExportInput = {
     annotations: deps.annotations(),
     measurements: deps.measurements(),
@@ -157,6 +161,7 @@ export async function exportSiteKml(deps: KmlActionDeps): Promise<void> {
     notSurveyGradeNote: NOT_SURVEY_GRADE,
   };
   const stem = geo.name ? deps.baseName(geo.name) : 'site';
+  const { buildKml, KmlCoordinateError } = await deps.loadKmlExport();
   let text: string;
   try {
     text = buildKml(input);

--- a/src/export/exportScanIdentity.ts
+++ b/src/export/exportScanIdentity.ts
@@ -1,0 +1,66 @@
+/**
+ * exportScanIdentity.ts
+ *
+ * The identity check every export owes the user: the file that lands in
+ * Downloads has to describe the scan the export was asked for.
+ *
+ * An export is not instantaneous. A full-resolution re-decode runs off-thread
+ * for seconds, a contour regeneration rebuilds geometry, and even a "warm" lazy
+ * `import()` yields the event loop. Nothing is disabled while that happens, so
+ * the user can open another scan — or reclassify points — in the gap between
+ * "what am I exporting" and "write the bytes". Every input read AFTER that gap
+ * belongs to whatever is active now: the world origin, the CRS, the filename
+ * stem. Pair those with geometry captured before it and the file is internally
+ * inconsistent while reporting success.
+ *
+ * The codebase already answers this for async analysis: openScan.ts captures a
+ * target id before its first await and drops the result when `activeId` moved
+ * (openScan.ts:361), and terrainAnalysisRunner.ts re-checks the same id after
+ * every await (terrainAnalysisRunner.ts:333-335). This is that rule carried to
+ * the export boundary — capture the target before the first await, compare
+ * before writing, and refuse rather than ship a file whose provenance is a
+ * guess.
+ *
+ * KNOWN REACH: a streaming scan reports a null id, so swapping one streaming
+ * scan for another is invisible to this comparison. That is the same blind spot
+ * the runner's stale guard has, because both read the same shell identity;
+ * closing it means giving streaming scans a stable id in the shell, which is a
+ * change to the shell rather than to this rule.
+ *
+ * Pure data — the comparison plus the refusal wording. No DOM, no I/O.
+ */
+
+/**
+ * Whether two readings of "which scan is this" name the same target.
+ *
+ * A null id is a value, not "unknown" — the shell reports null for a streaming
+ * scan, and that is the identity the terrain runner's own guard compares. If
+ * null were treated as a wildcard the check would fail OPEN on exactly the path
+ * where a mismatch is hardest to see, so null matches only null.
+ */
+export function sameExportTarget(a: string | null, b: string | null): boolean {
+  return a === b;
+}
+
+/**
+ * Refusal for a point-cloud export whose scan was swapped mid-flight. Names the
+ * consequence (a file stamped with the wrong scan's frame) and the way forward,
+ * in the voice of the full-res classification refusal it sits next to.
+ */
+export const EXPORT_SCAN_CHANGED_REFUSAL =
+  'The active scan changed while this export was being prepared, so nothing was '
+  + 'written — the file would have carried one scan\'s points under another scan\'s '
+  + 'coordinate system and name. Select the scan you want and export again.';
+
+/**
+ * Refusal for a terrain deliverable built from an analysis that belongs to a
+ * scan which is no longer active. Distinct wording from the mid-export race
+ * above because this one is not a race at all: the result simply outlived its
+ * scan (an additive open never clears it), so the user needs to re-run rather
+ * than retry.
+ */
+export const TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL =
+  'This terrain analysis was computed on a different scan than the one now '
+  + 'active, so nothing was written — the contours, rasters and report would have '
+  + 'been stamped with the active scan\'s origin, coordinate system and name. '
+  + 'Re-run the analysis on this scan to export it.';

--- a/src/export/fullResClassGuard.ts
+++ b/src/export/fullResClassGuard.ts
@@ -53,6 +53,24 @@ export const FULL_RES_CLASS_EDITS_REFUSAL =
   'export them at display resolution, or untick "Include classification" to ' +
   'export the full scan without them.';
 
+/**
+ * The same refusal, for the case where the edits arrive DURING the export.
+ *
+ * The gate above is evaluated when the user presses Export, but a full-res
+ * export then spends seconds re-decoding the source off-thread with the
+ * reclassify tools still live. An edit made in that window passes the gate and
+ * is absent from the file, which is the exact outcome this module exists to
+ * refuse — so the decision is re-taken after the decode and, when it flips, the
+ * user is told why nothing was written rather than being handed a lossy file
+ * with a success message.
+ */
+export const FULL_RES_CLASS_EDITS_MID_EXPORT_REFUSAL =
+  'Points were reclassified while the full-resolution re-decode was running, so '
+  + 'nothing was written — the file would have carried the re-decoded classes and '
+  + 'silently dropped those edits. Untick "convert at full resolution" to export '
+  + 'them at display resolution, or untick "Include classification" to export the '
+  + 'full scan without them.';
+
 /** A full-res export decision: allowed, or refused with a reason. */
 export interface FullResClassExportDecision {
   readonly allowed: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2299,7 +2299,7 @@ function newAnalysePanel(
     // Same cached-core rebuild, generalised with the contour shape-style picker so
     // an export reflects the user's chosen interval AND line shape.
     buildResultForExport: (opts) => terrainRunner.buildResultForExport(opts),
-    getExportBasename: () => lastCloudName, getAnnotations: () => viewer.annotate.getAnnotations(), getActiveScanId: () => scans.activeId,
+    getExportBasename: () => lastCloudName, getAnnotations: () => viewer.annotate.getAnnotations(), getActiveScanId: () => scans.activeExportTargetId(),
     // Terrain Intelligence Report (v0.4.5): hand the report the Inspector
     // card's CURRENT Dataset Intelligence summary so the PDF's bucket labels
     // are the card's own strings (null when the card is empty — the report
@@ -3016,7 +3016,7 @@ const exportPanel = new ExportPanel({
   // empty. Read the allocation-free frontier count rather than materialising a
   // snapshot just to test it for null.
   isStreamingPending: () => viewer?.streamingCloud != null && viewer.exportFrontierPointTotal() === 0,
-  getActiveClip: () => viewer.getClip(), getActiveScanId: () => scans.activeId,
+  getActiveClip: () => viewer.getClip(), getActiveScanId: () => scans.activeExportTargetId(),
   hasFullSource: () => scans.activeId != null && sourceFileById.has(scans.activeId),
   hasClassEdits: () => scans.activeId != null && (viewer?.canUndoClassification(scans.activeId) ?? false),
   // A streaming snapshot exports only resident points, so it is a reduced subset

--- a/src/main.ts
+++ b/src/main.ts
@@ -2299,7 +2299,7 @@ function newAnalysePanel(
     // Same cached-core rebuild, generalised with the contour shape-style picker so
     // an export reflects the user's chosen interval AND line shape.
     buildResultForExport: (opts) => terrainRunner.buildResultForExport(opts),
-    getExportBasename: () => lastCloudName, getAnnotations: () => viewer.annotate.getAnnotations(),
+    getExportBasename: () => lastCloudName, getAnnotations: () => viewer.annotate.getAnnotations(), getActiveScanId: () => scans.activeId,
     // Terrain Intelligence Report (v0.4.5): hand the report the Inspector
     // card's CURRENT Dataset Intelligence summary so the PDF's bucket labels
     // are the card's own strings (null when the card is empty — the report
@@ -3015,9 +3015,8 @@ const exportPanel = new ExportPanel({
   // Pending = a streaming cloud is attached but its export frontier is still
   // empty. Read the allocation-free frontier count rather than materialising a
   // snapshot just to test it for null.
-  isStreamingPending: () =>
-    viewer?.streamingCloud != null && viewer.exportFrontierPointTotal() === 0,
-  getActiveClip: () => viewer.getClip(),
+  isStreamingPending: () => viewer?.streamingCloud != null && viewer.exportFrontierPointTotal() === 0,
+  getActiveClip: () => viewer.getClip(), getActiveScanId: () => scans.activeId,
   hasFullSource: () => scans.activeId != null && sourceFileById.has(scans.activeId),
   hasClassEdits: () => scans.activeId != null && (viewer?.canUndoClassification(scans.activeId) ?? false),
   // A streaming snapshot exports only resident points, so it is a reduced subset
@@ -3053,22 +3052,23 @@ const exportPanel = new ExportPanel({
     if (!viewer) return;
     const measurements = viewer.measure.getMeasurements();
     if (measurements.length === 0) return;
-    const { measurementsToGeoJSON, measurementsToCsv } = await loadMeasurementExport();
     // Measurement points are LOCAL (recentered); add the origin back to land them
     // in the source projected/local frame. `exportGeoContext` resolves the
     // origin for streaming scans too (renderOrigin) — a plain static-only read
     // would export at render-frame coordinates. Geographic reprojection
     // (→ lon/lat) is a later option — for now we emit in the scan's own frame.
+    // Resolved BEFORE the import below (as exportIntegrityReport already does),
+    // so the frame and the measurements come from one instant, not two.
     const geo = exportGeoContext();
-    const origin = geo.origin;
     const ctx: MeasurementExportContext = {
-      toOutput: (p) => [p[0] + origin[0], p[1] + origin[1], p[2] + origin[2]],
+      toOutput: (p) => [p[0] + geo.origin[0], p[1] + geo.origin[1], p[2] + geo.origin[2]],
       up: viewer.measure.worldUp,
       unitToMetres: viewer.measure.unitToMetres,
       verticalUnitToMetres: viewer.measure.verticalUnitToMetres,
       crsName: geo.crsName,
       geographic: false,
     };
+    const { measurementsToGeoJSON, measurementsToCsv } = await loadMeasurementExport();
     const text = format === 'geojson'
       ? measurementsToGeoJSON(measurements, ctx)
       : measurementsToCsv(measurements, ctx);

--- a/src/render/streaming/EptStreamingPointCloud.ts
+++ b/src/render/streaming/EptStreamingPointCloud.ts
@@ -51,6 +51,7 @@ import { decodeEptBinaryTile } from '../../io/ept/eptBinaryDecode';
 import { EptOctree } from './EptOctree';
 import type { CrsInfo } from '../../io/crs';
 import { resolveEptCrs } from './eptCrs';
+import { nextStreamingScanId } from './streamingScanId';
 
 /**
  * Hierarchy files to load before a streaming EPT scan attaches. The root file
@@ -82,6 +83,8 @@ function pickRenderOriginFromCube(cube: Box6): [number, number, number] {
 
 export class EptStreamingPointCloud implements StreamingSource {
   readonly kind: StreamingSourceKind = 'ept';
+  /** Stable shell id for this streaming scan — see {@link StreamingSource.id}. */
+  readonly id: string = nextStreamingScanId();
   readonly name: string;
   readonly renderOrigin: [number, number, number];
   readonly octree: EptOctree;

--- a/src/render/streaming/StreamingPointCloud.ts
+++ b/src/render/streaming/StreamingPointCloud.ts
@@ -12,6 +12,7 @@
 import type { RangeSource } from '../../io/range/RangeSource';
 import { CopcSource } from '../../io/copc/CopcSource';
 import { StreamingOctree } from './StreamingOctree';
+import { nextStreamingScanId } from './streamingScanId';
 import type {
   CopcMetadata,
   Box6,
@@ -42,6 +43,8 @@ function pickRenderOrigin(
 export class StreamingPointCloud implements StreamingSource {
   /** Identifies this source as COPC-backed for the {@link StreamingSource} contract. */
   readonly kind: StreamingSourceKind = 'copc';
+  /** Stable shell id for this streaming scan — see {@link StreamingSource.id}. */
+  readonly id: string = nextStreamingScanId();
   readonly source: CopcSource;
   readonly octree: StreamingOctree;
   /** The render origin every node is recentred against (float64-stable). */

--- a/src/render/streaming/StreamingSource.ts
+++ b/src/render/streaming/StreamingSource.ts
@@ -65,6 +65,16 @@ export type StreamingSourceKind = 'copc' | 'ept';
 export interface StreamingSource {
   /** Which on-disk format is open. */
   readonly kind: StreamingSourceKind;
+  /**
+   * The scan's stable shell id — the streaming analogue of a static scan's
+   * `cloud_<n>` registry id. A static scan gets its id from the viewer's cloud
+   * registry; a streaming scan is never registered there, so it mints one at
+   * construction (see {@link nextStreamingScanId}). Non-null and distinct per
+   * session, so the export/terrain scan-identity guards can tell one streaming
+   * scan from another — a null here would let a streaming→streaming swap slip
+   * past a guard that treats null as "matches only null".
+   */
+  readonly id: string;
   /** Display name — the file or scan name surfaced in the UI. */
   readonly name: string;
   /** Render origin every node is recentred against (float64-stable). */

--- a/src/render/streaming/streamingScanId.ts
+++ b/src/render/streaming/streamingScanId.ts
@@ -1,0 +1,44 @@
+/**
+ * streamingScanId.ts — the stable shell id a streaming scan was missing.
+ *
+ * A static scan earns an identity the moment it enters the viewer's cloud
+ * registry: `addCloud` stamps it `cloud_<n>` from a per-load counter. A
+ * streaming scan never enters that registry — the scheduler streams it in
+ * place — so until now it had no id at all, and `scans.activeId` reported null
+ * for it. That null is what the export scan-identity guard compares, and
+ * `sameExportTarget(null, null)` is deliberately true (null matches only null),
+ * so swapping one streaming scan for another mid-export was invisible to the
+ * guard. Two different scans looked like the same target.
+ *
+ * This mints the missing identity: one non-null id per streaming session,
+ * assigned when the cloud is constructed and fixed for the cloud's lifetime.
+ *
+ * WHY MINTED, NOT DERIVED FROM THE SOURCE URL. A streaming scan is not always
+ * remote — a local COPC file opens through the same pipeline over a
+ * `LocalFileRangeSource` (main.ts), and a local file carries no stable URL /
+ * dataset key. Deriving the id from a URL would leave exactly those local scans
+ * back at a degenerate identity, and the guard must FAIL CLOSED: every streaming
+ * scan needs a concrete id so two of them never collide on a wildcard. A
+ * per-session mint is always present and always distinct, which is the property
+ * the swap check depends on. It also matches how a static scan behaves — a
+ * reopen yields a fresh `cloud_<n>`, so a reopened streaming scan yielding a
+ * fresh id keeps the two paths consistent rather than special-casing streaming.
+ *
+ * The namespace is prefixed so a streaming id can never equal a static
+ * `cloud_<n>` id; `sameExportTarget` compares by ===, so distinct namespaces
+ * make cross-type confusion impossible even if both were ever read together.
+ *
+ * Pure — a module-local counter and a string. No DOM, no three.js, no I/O.
+ */
+
+let counter = 0;
+
+/**
+ * Mint the next streaming-scan shell id. Monotonic within the session and
+ * prefixed out of the static `cloud_<n>` namespace, so every streaming cloud
+ * gets a distinct, non-null identity the export/terrain scan-identity guards can
+ * compare.
+ */
+export function nextStreamingScanId(): string {
+  return `streaming-scan_${++counter}`;
+}

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -113,6 +113,10 @@ import type {
   ContourExportPermit,
 } from '../export/contourExportPermit';
 import { permitStamp } from '../export/permitStamp';
+import {
+  sameExportTarget,
+  TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL,
+} from '../export/exportScanIdentity';
 import type { ExportPermitStamp } from '../terrain/export/exportProvenance';
 import type { ContourExportAdapter, ContourExportHost } from './contourExportAdapter';
 import { loadContourExportAdapter } from '../lazyChunks';
@@ -159,6 +163,19 @@ export interface AnalysePanelCallbacks {
   }) => Promise<AnalyseContoursResult>;
   /** Optional basename for downloaded files (e.g. the scan name). */
   getExportBasename?: () => string;
+  /**
+   * The shell's active-scan id (null for a streaming scan). Stamped onto each
+   * result in {@link AnalysePanel.update} and compared again at export time.
+   *
+   * A terrain result is only cleared when the session resets, so opening a
+   * SECOND scan additively leaves the first scan's contours, DEM and report on
+   * screen while `getMapContext` / `getExportBasename` have already moved to the
+   * new scan. Exporting then writes A's geometry with B's world origin, CRS,
+   * linear unit and filename — no timing involved, it reproduces every time.
+   * With this wired the panel refuses instead. When omitted the panel cannot
+   * tell the two apart and behaves as before.
+   */
+  getActiveScanId?: () => string | null;
   /**
    * Switch the 3D viewer's colour mode to the colourblind-safe 'confidence'
    * trust overlay — the SAME per-cell confidence + strong/moderate/weak
@@ -315,6 +332,13 @@ export class AnalysePanel {
   private readonly _validationRow: HTMLElement;
   private readonly _body: HTMLElement;
   private _result: AnalyseContoursResult | null = null;
+  /**
+   * The scan `_result` was computed on, stamped when the result lands. The
+   * result outlives an additive scan open (only a session reset clears it), so
+   * this is what tells an export that the analysis on screen and the map context
+   * it would be stamped with come from two different scans.
+   */
+  private _resultScanId: string | null = null;
   /** The "Colour 3D by confidence" toggle button + its current on/off state, so
    *  its label always shows the way back to the original colour. */
   private _confidenceColorBtn?: HTMLButtonElement;
@@ -601,6 +625,10 @@ export class AnalysePanel {
   /** Re-render from a fresh analysis result (or clear when null). */
   update(result: AnalyseContoursResult | null): void {
     this._result = result;
+    // Bind the result to the scan it was computed on. The runner only lands a
+    // result while its own dataset guard still holds, so the active id here IS
+    // the id the analysis ran against.
+    this._resultScanId = result ? this._cb.getActiveScanId?.() ?? null : null;
     // Any update supersedes a pending staleness caveat: a fresh result was
     // computed against the edited classes, and a clear removes the result
     // the caveat was about.
@@ -1874,6 +1902,27 @@ export class AnalysePanel {
   }
 
   /**
+   * Refuse an export whose result belongs to a scan that is no longer active,
+   * and say so on the panel. Returns true when the caller must write nothing.
+   *
+   * Every terrain deliverable mixes the result (computed on one scan) with the
+   * host's live map context and basename (read from whatever is active now), so
+   * a result that outlived its scan would be published in the wrong frame under
+   * the wrong name. Refusing is deliberate over silently clearing the result:
+   * the analysis is the user's work and re-running it is their call, so the
+   * panel keeps it on screen and explains why it cannot be exported.
+   *
+   * Called at the head of every export path AND again after any regeneration
+   * await, since a scan can be opened while contours are being rebuilt.
+   */
+  private _refuseForeignScanExport(): boolean {
+    if (!this._result || !this._cb.getActiveScanId) return false;
+    if (sameExportTarget(this._resultScanId, this._cb.getActiveScanId())) return false;
+    this.setStaleNotice(TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL);
+    return true;
+  }
+
+  /**
    * Resolve the full analysis result to serialize for a contour export at the
    * panel's current shape style. Reuses the on-screen result when the style
    * already matches (no recompute); otherwise regenerates from the cached core at
@@ -1927,7 +1976,13 @@ export class AnalysePanel {
     if (!this._result || this._result.model.features.length === 0) {
       return;
     }
+    if (this._refuseForeignScanExport()) return;
+    // Both frame inputs are read HERE, before the regeneration await below: the
+    // rebuild can take seconds and the host's map context follows the ACTIVE
+    // scan, so reading it afterwards would georeference these contours with
+    // whatever scan the user opened meanwhile.
     const basename = this._cb.getExportBasename?.() ?? 'contours';
+    const mapCtx = this._cb.getMapContext?.();
     const label = btn?.textContent ?? '';
     if (btn) {
       btn.disabled = true;
@@ -1940,6 +1995,11 @@ export class AnalysePanel {
       const result = await this._resultForExport();
       const [{ serializeContours, triggerBrowserDownload }, { buildExportProvenance }] =
         await Promise.all([loadContourDownload(), loadExportProvenance()]);
+      // Re-verify after the regeneration: the captured context is the right one
+      // for `basename`/`mapCtx`, but a scan opened during the rebuild means the
+      // user is no longer looking at this analysis, and publishing it now would
+      // hand them a file for a scan they have moved on from.
+      if (this._refuseForeignScanExport()) return;
       const provenance = buildExportProvenance(result, {
         basename,
         generatedAt: new Date(),
@@ -1958,7 +2018,6 @@ export class AnalysePanel {
       // `worldOrigin` the DEM package and map sheet already use). When the host
       // can't supply one, serializeContours omits the CRS stamp rather than
       // georeferencing local coordinates.
-      const mapCtx = this._cb.getMapContext?.();
       const worldOrigin = mapCtx?.worldOrigin ?? null;
       triggerBrowserDownload(
         serializeContours(result.model, fmt, {
@@ -2057,13 +2116,16 @@ export class AnalysePanel {
   ): Promise<void> {
     const r = this._result;
     if (!r) return;
+    if (this._refuseForeignScanExport()) return;
     const label = btn.textContent ?? 'DEM (ZIP)';
     btn.disabled = true;
     btn.textContent = '…';
+    // Frame + name captured before the writer chunk loads, so the raster and its
+    // .prj / README describe the scan this result came from.
+    const ctx = this._cb.getMapContext?.() ?? {};
+    const basename = this._cb.getExportBasename?.() ?? 'terrain';
     try {
       const { buildDemPackage } = await loadDemPackage();
-      const ctx = this._cb.getMapContext?.() ?? {};
-      const basename = this._cb.getExportBasename?.() ?? 'terrain';
       const bytes = buildDemPackage(r, {
         worldOrigin: ctx.worldOrigin ?? null,
         basename,
@@ -2107,6 +2169,12 @@ export class AnalysePanel {
     intent: ContourExportIntent,
   ): Promise<void> {
     if (!permit.ok || !this._result) return;
+    if (this._refuseForeignScanExport()) return;
+    // Captured before the regeneration + writer awaits below (which are seconds
+    // of work), so the bundle's origin, unit and filename belong to the scan the
+    // contours were computed on.
+    const ctx = this._cb.getMapContext?.() ?? {};
+    const basename = this._cb.getExportBasename?.() ?? 'contours';
     try {
       // Regenerate the bundled geometry at the SELECTED PURPOSE's style + tolerance
       // (Survey Review = exact analytical; a cartographic purpose = generalized at
@@ -2126,8 +2194,9 @@ export class AnalysePanel {
       const [{ buildContourDeliverableFromResultAsync }] = await Promise.all([
         loadContourDeliverableBuild(),
       ]);
-      const ctx = this._cb.getMapContext?.() ?? {};
-      const basename = this._cb.getExportBasename?.() ?? 'contours';
+      // Same re-verification as the vector exports: a scan opened during the
+      // rebuild means this bundle is no longer the one the user is looking at.
+      if (this._refuseForeignScanExport()) return;
       const bytes = await buildContourDeliverableFromResultAsync(result, {
         decision: permit.decision,
         basename,
@@ -2171,13 +2240,16 @@ export class AnalysePanel {
   ): Promise<void> {
     const r = this._result;
     if (!r) return;
+    if (this._refuseForeignScanExport()) return;
     const label = btn.textContent ?? 'Intelligence report (PDF)';
     btn.disabled = true;
     btn.textContent = '…';
+    // Name + frame read before the pdf-lib chunk loads, so the report's header
+    // describes the scan its verdicts were computed on.
+    const basename = this._cb.getExportBasename?.() ?? 'terrain';
+    const mapCtx = this._cb.getMapContext?.() ?? {};
     try {
       const { buildTerrainReportPdf } = await loadTerrainReportPdf();
-      const basename = this._cb.getExportBasename?.() ?? 'terrain';
-      const mapCtx = this._cb.getMapContext?.() ?? {};
       // The renderer assembles the content from the SAME result the panel shows,
       // stamping the unified provenance via these options — so the report's
       // header / footer (CRS, datum, verdicts, accuracy, date) can never drift
@@ -2223,6 +2295,10 @@ export class AnalysePanel {
     // Same hard guard as the export itself — a blocked / empty result never
     // reaches the dialog.
     if (!r || r.model.features.length === 0 || r.quality.exportReadiness === 'blocked') return;
+    // Refuse before the dialog rather than after the user fills the title block:
+    // the pre-filled fields come from the ACTIVE scan while `r` came from
+    // another, so the sheet would document a scan it does not plot.
+    if (this._refuseForeignScanExport()) return;
 
     const ctx = this._cb.getMapContext?.() ?? {};
     const basename = this._cb.getExportBasename?.() ?? 'contours';
@@ -2518,25 +2594,31 @@ export class AnalysePanel {
       console.warn('OpenLiDARViewer: map sheet export refused — no granted evidence permit (§19).');
       return;
     }
-    const { buildMapSheetPdf } = await loadMapSheetPdf();
-    const { buildExportProvenance } = await loadExportProvenance();
+    // The dialog can sit open for minutes and its Export can regenerate the
+    // contours, so the scan is checked again here — right before the sheet is
+    // built — not only when the dialog was opened.
+    if (this._refuseForeignScanExport()) return;
     // Resolved linear unit so the sheet's scale bar + 1:N ratio honour a foot
     // CRS (the map is drawn in source units) instead of the metre default. Read
-    // the map context ONCE — it also supplies the scene up-axis the annotation
-    // markers are rotated by.
+    // the map context ONCE, before the pdf chunks load — it also supplies the
+    // scene up-axis the annotation markers are rotated by.
     const mapCtx = this._cb.getMapContext?.();
     const linearUnit = mapCtx?.linearUnit;
+    const sheetBasename = this._cb.getExportBasename?.() ?? undefined;
     // Annotation layer inputs, only gathered when the user opted in. The list is
     // read straight from the host (same order as the Annotations panel, so the
-    // marker index matches). The up-axis MUST be the gather's own — see the
-    // frame reasoning in annotationMapProjection.ts.
+    // marker index matches) — and read here, alongside the rest of the sheet's
+    // inputs, so the whole sheet comes from one instant. The up-axis MUST be the
+    // gather's own — see the frame reasoning in annotationMapProjection.ts.
     const annotations = opts.includeAnnotations ? this._cb.getAnnotations?.() ?? [] : [];
     const sceneUpAxis = mapCtx?.sceneUpAxis ?? 'z';
+    const { buildMapSheetPdf } = await loadMapSheetPdf();
+    const { buildExportProvenance } = await loadExportProvenance();
     // The unified provenance, derived from the SAME result the sheet plots, so
     // the title block's CRS / datum / style / accuracy / readiness / date can't
     // drift from the GeoJSON / DXF / SVG / DEM exports of this scan.
     const provenance = buildExportProvenance(result, {
-      basename: this._cb.getExportBasename?.() ?? undefined,
+      basename: sheetBasename,
       generatedAt: opts.generatedAt,
       softwareVersion: __APP_VERSION__,
       metricVersion: TERRAIN_METRIC_VERSION,

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -18,7 +18,11 @@ import { CONVERT_FORMATS, type ConvertFormat, type CrsMode, type ConvertOptions 
 import type { PointCloud } from '../model/PointCloud';
 import { gzipConvertedFile, gzipAvailable } from '../convert/gzip';
 import { buildExportSummary, type ExportSummaryInput } from '../export/exportSummary';
-import { evaluateFullResClassExport } from '../export/fullResClassGuard';
+import {
+  evaluateFullResClassExport,
+  FULL_RES_CLASS_EDITS_MID_EXPORT_REFUSAL,
+} from '../export/fullResClassGuard';
+import { sameExportTarget, EXPORT_SCAN_CHANGED_REFUSAL } from '../export/exportScanIdentity';
 import { clipCloud } from '../render/clip/clipCloud';
 import type { ClipBox } from '../render/clip/clipBox';
 
@@ -117,6 +121,15 @@ export interface ExportPanelCallbacks {
   scanFootprintStatus?: () => { ready: boolean; reason: string };
   /** The active clip box, if any — when enabled, the cloud export is restricted to it. */
   getActiveClip?: () => ClipBox | null;
+  /**
+   * Which scan the panel is exporting, as the shell's own active-scan id (null
+   * for a streaming scan). Read once before the export's first await and again
+   * before the bytes are written: a full-resolution re-decode takes seconds
+   * off-thread and nothing stops the user opening another scan meanwhile, which
+   * would otherwise write one scan's points under another's name and CRS. When
+   * omitted the panel cannot make that comparison and exports as before.
+   */
+  getActiveScanId?: () => string | null;
   /**
    * Whether a streaming scan is attached but has no resident points to export
    * yet. Lets the gate say "still streaming in" instead of the misleading
@@ -686,6 +699,13 @@ export class ExportPanel {
       return;
     }
 
+    // Snapshot the export's inputs BEFORE the first await. The clip box decides
+    // which points reach the file, and the user can drag or disable it while the
+    // decode runs — reading it afterwards would filter the export by a box that
+    // was never part of the request. `scanId` is the identity re-verified below.
+    const clip = this._cb.getActiveClip?.() ?? null;
+    const scanId = this._cb.getActiveScanId?.() ?? null;
+
     this._busy = true;
     this._exportBtn.disabled = true;
     this._exportBtn.textContent = useFull ? 'Re-decoding…' : 'Exporting…';
@@ -697,8 +717,27 @@ export class ExportPanel {
         this._setStatus('Could not read the source at full resolution.', 'error');
         return;
       }
-      // Respect an active clip: export only the points inside (or outside) the box.
-      const clip = this._cb.getActiveClip?.() ?? null;
+      // The decode is over — prove the export still describes what was asked for
+      // before any bytes are written. Nothing disables the scan list or the
+      // reclassify tools while a multi-second full-res decode runs off-thread, so
+      // both facts the gate above depends on can have moved underneath it. The
+      // class gate is re-taken rather than re-implemented: an edit made during the
+      // decode flips exactly the input it already reads.
+      if (!sameExportTarget(this._cb.getActiveScanId?.() ?? null, scanId)) {
+        this._setStatus(EXPORT_SCAN_CHANGED_REFUSAL, 'error');
+        return;
+      }
+      const classGateAfter = evaluateFullResClassExport({
+        fullRes: useFull,
+        includeClassification: this._includeClass,
+        hasClassEdits: this._cb.hasClassEdits?.() ?? false,
+      });
+      if (!classGateAfter.allowed) {
+        this._setStatus(FULL_RES_CLASS_EDITS_MID_EXPORT_REFUSAL, 'error');
+        return;
+      }
+      // Respect an active clip: export only the points inside (or outside) the
+      // box the user had set when they pressed Export (captured above).
       const clipped = clip != null && clip.enabled;
       const cloud = clipped ? clipCloud(sourceCloud, clip) : sourceCloud;
       this._exportBtn.textContent = 'Exporting…';

--- a/tests/analysePanelScanIdentity.test.ts
+++ b/tests/analysePanelScanIdentity.test.ts
@@ -1,0 +1,222 @@
+/**
+ * analysePanelScanIdentity.test.ts
+ *
+ * A terrain result is cleared only when the session resets. Opening a SECOND
+ * scan additively leaves the first scan's contours, DEM and report on screen
+ * while the host's map context and filename have already moved to the new scan —
+ * so an export written then carries A's geometry with B's world origin, CRS,
+ * linear unit and name. No race is involved: it reproduces every time.
+ *
+ * These tests pin the binding that stops it — the result remembers the scan it
+ * was computed on, and every export path refuses when that is no longer the
+ * active scan — and pin that the refusal is a refusal, not a silent clear: the
+ * user's analysis stays on screen with the reason shown.
+ *
+ * Driven with a REAL analysis result (same approach as
+ * analysePanelCoverageTile.test.ts) in the node environment via a DOM stub.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { analyseContours } from '../src/terrain/contour/analyseContours';
+import { TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL } from '../src/export/exportScanIdentity';
+import type { TerrainPoint } from '../src/terrain/TerrainContracts';
+import type { ContourExportPermit } from '../src/export/contourExportPermit';
+
+const hoisted = vi.hoisted(() => ({ downloads: [] as string[] }));
+
+vi.mock('../src/io/download', () => ({
+  triggerDownload: (_blob: unknown, filename: string) => { hoisted.downloads.push(filename); },
+  downloadBytes: (filename: string) => { hoisted.downloads.push(filename); },
+}));
+
+class FakeEl {
+  className = '';
+  title = '';
+  type = '';
+  disabled = false;
+  width = 0;
+  height = 0;
+  href = '';
+  download = '';
+  private _text = '';
+  readonly children: FakeEl[] = [];
+  readonly dataset: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly classList = {
+    add(): void { /* no-op */ },
+    remove(): void { /* no-op */ },
+    toggle(): void { /* no-op */ },
+  };
+  readonly tagName: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+  setAttribute(): void { /* no-op */ }
+  removeAttribute(): void { /* no-op */ }
+  getContext(): null { return null; }
+  getBoundingClientRect(): { width: number; height: number; left: number; top: number } {
+    return { width: 0, height: 0, left: 0, top: 0 };
+  }
+  set textContent(v: string) { this._text = v; }
+  get textContent(): string {
+    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
+  }
+  append(...kids: FakeEl[]): void { this.children.push(...kids.filter(Boolean)); }
+  replaceChildren(...kids: FakeEl[]): void { this.children.length = 0; this.children.push(...kids); }
+  addEventListener(): void { /* no-op */ }
+  blur(): void { /* no-op */ }
+  click(): void { /* no-op */ }
+  /** Every descendant carrying `cls` in its own className. */
+  findByClass(cls: string): FakeEl[] {
+    const out: FakeEl[] = [];
+    if (this.className.split(/\s+/).includes(cls)) out.push(this);
+    for (const c of this.children) out.push(...c.findByClass(cls));
+    return out;
+  }
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { document: unknown }).document = {
+    createElement: (tag: string) => new FakeEl(tag),
+    createElementNS: (_ns: string, tag: string) => new FakeEl(tag),
+  };
+  (globalThis as unknown as { requestAnimationFrame?: unknown }).requestAnimationFrame = undefined;
+});
+
+beforeEach(() => { hoisted.downloads.length = 0; });
+
+/** A small hill, enough for a real analysis with contours. */
+function hillScene(): TerrainPoint[] {
+  const pts: TerrainPoint[] = [];
+  for (let x = 0; x <= 30; x++) {
+    for (let y = 0; y <= 30; y++) {
+      const dx = x - 15;
+      const dy = y - 15;
+      pts.push({ x, y, z: 6 * Math.exp(-(dx * dx + dy * dy) / 200) });
+    }
+  }
+  return pts;
+}
+
+/** The private export surface these tests drive directly (no Studio mount). */
+interface ExportInternals {
+  _resultScanId: string | null;
+  _refuseForeignScanExport(): boolean;
+  _exportDemPackage(btn: unknown): Promise<void>;
+  _exportTerrainReport(btn: unknown): Promise<void>;
+  _exportContourFormat(fmt: string, btn?: unknown, extra?: unknown): Promise<void>;
+  _exportCompletePackage(permit: unknown, intent: unknown): Promise<void>;
+}
+
+/** A panel holding an analysis of scan A, plus the levers to move the session. */
+async function panelWithResultForScanA() {
+  const { AnalysePanel } = await import('../src/ui/AnalysePanel');
+  let activeId: string | null = 'scan-a';
+  let basename = 'scan-a';
+  /** Every map-context read, so a test can prove a refusal happened FIRST. */
+  const mapContextReads: string[] = [];
+  const panel = new AnalysePanel({
+    getActiveScanId: () => activeId,
+    getExportBasename: () => basename,
+    getMapContext: () => {
+      mapContextReads.push(basename);
+      return { worldOrigin: { x: 1, y: 2, z: 3 }, linearUnit: 'metre' as const };
+    },
+  });
+  panel.update(analyseContours(hillScene(), {
+    cellSizeM: 2,
+    crs: 'EPSG:32610',
+    verticalDatum: 'EPSG:5703',
+  }));
+  return {
+    panel,
+    internals: panel as unknown as ExportInternals,
+    root: panel.element as unknown as FakeEl,
+    mapContextReads,
+    /** The additive open of a second scan: active id + basename both move. */
+    openScanB: (): void => { activeId = 'scan-b'; basename = 'scan-b'; },
+    setActiveId: (id: string | null): void => { activeId = id; },
+  };
+}
+
+const grantedPermit = { ok: true, decision: {} } as unknown as ContourExportPermit;
+
+function noticeText(root: FakeEl): string {
+  return root.findByClass('olv-analyse-stale-notice')[0]?.textContent ?? '';
+}
+
+describe('AnalysePanel — a result belongs to the scan it was computed on', () => {
+  it('stamps the active scan onto the result when it lands', async () => {
+    const { internals } = await panelWithResultForScanA();
+    expect(internals._resultScanId).toBe('scan-a');
+  });
+
+  it('clears the stamp when the result is cleared', async () => {
+    const { panel, internals } = await panelWithResultForScanA();
+    panel.update(null);
+    expect(internals._resultScanId).toBe(null);
+  });
+
+  it('refuses the DEM package once another scan is active', async () => {
+    const { internals, root, mapContextReads, openScanB } = await panelWithResultForScanA();
+    mapContextReads.length = 0;
+    openScanB();
+    await internals._exportDemPackage(new FakeEl('button'));
+
+    expect(hoisted.downloads, 'a raster was written for the wrong scan').toEqual([]);
+    // Refused BEFORE the frame was read: had it been read, the .prj / README
+    // would already be describing scan B.
+    expect(mapContextReads).toEqual([]);
+    expect(noticeText(root)).toBe(TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL);
+  });
+
+  it('refuses the intelligence report once another scan is active', async () => {
+    const { internals, root, openScanB } = await panelWithResultForScanA();
+    openScanB();
+    await internals._exportTerrainReport(new FakeEl('button'));
+    expect(hoisted.downloads).toEqual([]);
+    expect(noticeText(root)).toBe(TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL);
+  });
+
+  it('refuses a contour vector export once another scan is active', async () => {
+    const { internals, root, mapContextReads, openScanB } = await panelWithResultForScanA();
+    mapContextReads.length = 0;
+    openScanB();
+    await internals._exportContourFormat('geojson', undefined, { permit: grantedPermit });
+    expect(hoisted.downloads).toEqual([]);
+    expect(mapContextReads).toEqual([]);
+    expect(noticeText(root)).toBe(TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL);
+  });
+
+  it('refuses the complete deliverable once another scan is active', async () => {
+    const { internals, root, openScanB } = await panelWithResultForScanA();
+    openScanB();
+    await internals._exportCompletePackage(grantedPermit, {
+      shapeStyle: 'analytical',
+      methodTag: 'analytical',
+      purpose: 'survey-review',
+    });
+    expect(hoisted.downloads).toEqual([]);
+    expect(noticeText(root)).toBe(TERRAIN_RESULT_FOREIGN_SCAN_REFUSAL);
+  });
+
+  it('keeps the analysis on screen rather than discarding the user\'s work', async () => {
+    const { panel, internals, openScanB } = await panelWithResultForScanA();
+    openScanB();
+    await internals._exportDemPackage(new FakeEl('button'));
+    // Refuse, do not clear: re-running the analysis is the user's decision.
+    expect(panel.currentResult()).not.toBeNull();
+    expect(internals._resultScanId).toBe('scan-a');
+  });
+
+  it('allows the export while the originating scan is still active', async () => {
+    const { internals } = await panelWithResultForScanA();
+    expect(internals._refuseForeignScanExport()).toBe(false);
+  });
+
+  it('treats a streaming scan (null id) as a target of its own', async () => {
+    // null is a value, not a wildcard: a result computed while a streaming scan
+    // was active must not be exportable against a static scan that opened after.
+    const { internals, setActiveId } = await panelWithResultForScanA();
+    setActiveId(null);
+    expect(internals._refuseForeignScanExport()).toBe(true);
+  });
+});

--- a/tests/exportPanelSnapshotIntegrity.test.ts
+++ b/tests/exportPanelSnapshotIntegrity.test.ts
@@ -22,6 +22,10 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 import { PointCloud } from '../src/model/PointCloud';
 import type { ClipBox } from '../src/render/clip/clipBox';
+import { createScanService } from '../src/app/ScanService';
+import { createAppContext } from '../src/app/appContext';
+import type { StreamingSource } from '../src/render/streaming/StreamingSource';
+import type { Viewer } from '../src/render/Viewer';
 
 const hoisted = vi.hoisted(() => ({
   /** Every cloud handed to the converter, so a test can see what was written. */
@@ -209,6 +213,79 @@ describe('ExportPanel — full-resolution export re-verifies before it writes', 
 
     expect(hoisted.downloads).toEqual([]);
     expect(statusText(root)).toBe(EXPORT_SCAN_CHANGED_REFUSAL);
+  });
+
+  // ─── ROADMAP #19 — the streaming→streaming swap the guard used to miss ───
+  // A streaming scan leaves `scans.activeId` null, so BOTH scans in a swap used
+  // to read as null and `sameExportTarget(null, null)` passed the export. The
+  // shell now mints a stable id per streaming scan and surfaces it through
+  // `activeExportTargetId()`; these drive the panel through the REAL accessor so
+  // the whole read path (ScanService → viewer.streamingCloud.id) is under test.
+
+  /** A viewer stub exposing only the streaming cloud the service reads. */
+  function streamingViewer(current: () => StreamingSource | null): Viewer {
+    return {
+      getCloud: () => undefined,
+      get streamingCloud() {
+        return current();
+      },
+    } as unknown as Viewer;
+  }
+  const streamingScan = (id: string): StreamingSource => ({ id }) as unknown as StreamingSource;
+
+  it('refuses when one streaming scan is swapped for another during the re-decode', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const { EXPORT_SCAN_CHANGED_REFUSAL } = await import('../src/export/exportScanIdentity');
+    const cloud = twoPointCloud();
+    // Streaming throughout — activeId is never set, so the OLD wiring would have
+    // read null both before and after and written the file. The mint is what
+    // makes the swap visible.
+    let streaming: StreamingSource | null = streamingScan('streaming-scan_1');
+    const scans = createScanService({
+      getViewer: () => streamingViewer(() => streaming),
+      context: createAppContext(),
+    });
+    expect(scans.activeId, 'streaming leaves activeId null (safety pin)').toBeNull();
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => true,
+      isReduced: () => true,
+      getFullCloud: async () => {
+        streaming = streamingScan('streaming-scan_2'); // user opened another streaming scan
+        return cloud;
+      },
+      getActiveScanId: () => scans.activeExportTargetId(),
+    });
+    const root = panel.element as unknown as FakeEl;
+    enableFullRes(root);
+    await pressExport(root);
+
+    expect(hoisted.downloads, 'a file was written despite the streaming swap').toEqual([]);
+    expect(statusText(root)).toBe(EXPORT_SCAN_CHANGED_REFUSAL);
+  });
+
+  it('exports when the SAME streaming scan stays active through the re-decode (no false refusal)', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const cloud = twoPointCloud();
+    const streaming = streamingScan('streaming-scan_1');
+    const scans = createScanService({
+      getViewer: () => streamingViewer(() => streaming),
+      context: createAppContext(),
+    });
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => true,
+      isReduced: () => true,
+      getFullCloud: async () => cloud, // same streaming scan the whole time
+      hasClassEdits: () => false,
+      getActiveScanId: () => scans.activeExportTargetId(),
+    });
+    const root = panel.element as unknown as FakeEl;
+    enableFullRes(root);
+    await pressExport(root);
+
+    expect(hoisted.downloads).toEqual(['scan.las']);
+    expect(hoisted.converted[0].pointCount).toBe(2);
   });
 
   it('clips with the box captured BEFORE the decode, not the one set during it', async () => {

--- a/tests/exportPanelSnapshotIntegrity.test.ts
+++ b/tests/exportPanelSnapshotIntegrity.test.ts
@@ -1,0 +1,275 @@
+/**
+ * exportPanelSnapshotIntegrity.test.ts
+ *
+ * A full-resolution export re-decodes the source file off-thread. That takes
+ * seconds, and nothing in the app is disabled while it runs — the user can
+ * reclassify points, drag the clip box, or open another scan in the gap between
+ * pressing Export and the bytes being written.
+ *
+ * These tests pin the two halves of the answer:
+ *
+ *   1. CAPTURE BEFORE THE AWAIT — the clip box that decides which points reach
+ *      the file is the one the user had set when they pressed Export.
+ *   2. VERIFY BEFORE THE WRITE — the classification gate and the active-scan
+ *      identity are re-checked after the decode, and a change refuses the export
+ *      instead of writing a file that silently omits the edits.
+ *
+ * The decode is simulated by mutating the panel's own callback state INSIDE the
+ * awaited `getFullCloud`, which is exactly when a real user's edit would land.
+ * Node environment via a recording DOM stub.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { PointCloud } from '../src/model/PointCloud';
+import type { ClipBox } from '../src/render/clip/clipBox';
+
+const hoisted = vi.hoisted(() => ({
+  /** Every cloud handed to the converter, so a test can see what was written. */
+  converted: [] as { pointCount: number }[],
+  /** Filenames that reached the browser download helper. */
+  downloads: [] as string[],
+}));
+
+vi.mock('../src/lazyChunks', () => ({
+  loadConvertEngine: async () => ({
+    convertCloud: (cloud: { pointCount: number }) => {
+      hoisted.converted.push(cloud);
+      return {
+        file: { filename: 'scan.las', bytes: new Uint8Array([0]), mime: 'application/octet-stream' },
+        report: { pointCount: cloud.pointCount, crsNote: 'CRS kept', log: [] },
+      };
+    },
+  }),
+}));
+
+vi.mock('../src/io/download', () => ({
+  downloadBytes: (filename: string) => { hoisted.downloads.push(filename); },
+  triggerDownload: () => { /* unused here */ },
+}));
+
+class FakeEl {
+  className = '';
+  title = '';
+  type = '';
+  href = '';
+  value = '';
+  placeholder = '';
+  inputMode = '';
+  checked = false;
+  disabled = false;
+  readonly style: Record<string, string> = {};
+  readonly dataset: Record<string, string> = {};
+  private _text = '';
+  readonly attrs: Record<string, string> = {};
+  readonly children: FakeEl[] = [];
+  private readonly _listeners: Record<string, (() => void)[]> = {};
+  readonly classList = {
+    _set: new Set<string>(),
+    add: (c: string): void => { this.classList._set.add(c); },
+    remove: (c: string): void => { this.classList._set.delete(c); },
+    toggle: (c: string, force?: boolean): void => {
+      const on = force ?? !this.classList._set.has(c);
+      if (on) this.classList._set.add(c);
+      else this.classList._set.delete(c);
+    },
+    contains: (c: string): boolean => this.classList._set.has(c),
+  };
+  readonly tagName: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+  set textContent(v: string) { this._text = v; }
+  get textContent(): string {
+    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
+  }
+  set innerHTML(_v: string) { /* icons only */ }
+  setAttribute(k: string, v: string): void { this.attrs[k] = v; }
+  removeAttribute(k: string): void { delete this.attrs[k]; }
+  append(...kids: FakeEl[]): void { this.children.push(...kids.filter(Boolean)); }
+  replaceChildren(...kids: FakeEl[]): void { this.children.length = 0; this.children.push(...kids); }
+  addEventListener(type: string, fn: () => void): void {
+    (this._listeners[type] ??= []).push(fn);
+  }
+  /** Fire every listener registered for `type` (the panel binds click/change). */
+  fire(type: string): void {
+    for (const fn of this._listeners[type] ?? []) fn();
+  }
+  findByClass(cls: string): FakeEl[] {
+    const out: FakeEl[] = [];
+    if (this.className.split(/\s+/).includes(cls)) out.push(this);
+    for (const c of this.children) out.push(...c.findByClass(cls));
+    return out;
+  }
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { document: unknown }).document = {
+    createElement: (tag: string) => new FakeEl(tag),
+  };
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.HTMLInputElement = class {};
+  g.HTMLAnchorElement = class {};
+});
+
+beforeEach(() => {
+  hoisted.converted.length = 0;
+  hoisted.downloads.length = 0;
+});
+
+/** Two points one unit apart on x, so a clip box can keep exactly one of them. */
+function twoPointCloud(name = 'scan.las'): PointCloud {
+  return new PointCloud({
+    positions: new Float32Array([0, 0, 0, 10, 0, 0]),
+    classification: new Uint8Array([2, 2]),
+    origin: [0, 0, 0],
+    sourceFormat: 'las',
+    name,
+  });
+}
+
+/** A clip that keeps only the point at the origin. */
+const keepsFirstPointOnly: ClipBox = {
+  box: { min: [-1, -1, -1], max: [1, 1, 1] },
+  mode: 'keep-inside',
+  enabled: true,
+};
+
+/**
+ * Tick the full-resolution checkbox the way a user does. The gzip row reuses the
+ * same class names, so the label text is what tells the two checkboxes apart.
+ */
+function enableFullRes(root: FakeEl): void {
+  const label = root
+    .findByClass('olv-export-fullres-label')
+    .find((l) => l.textContent.includes('Convert at full resolution'));
+  expect(label, 'full-resolution checkbox missing').toBeDefined();
+  const box = label!.children[0];
+  box.checked = true;
+  box.fire('change');
+}
+
+function statusText(root: FakeEl): string {
+  return root.findByClass('olv-export-status')[0]?.textContent ?? '';
+}
+
+/** Press Export and wait for the async export to settle. */
+async function pressExport(root: FakeEl): Promise<void> {
+  root.findByClass('olv-export-btn')[0].fire('click');
+  // Two macrotask turns: the decode promise, then the convert-engine import.
+  for (let i = 0; i < 4; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('ExportPanel — full-resolution export re-verifies before it writes', () => {
+  it('refuses when points are reclassified during the re-decode', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const cloud = twoPointCloud();
+    // No edits when Export is pressed — so the up-front gate ALLOWS this export.
+    // The edit lands mid-decode, which is the whole point: the display buffer now
+    // holds classes the re-decoded file cannot carry.
+    let hasClassEdits = false;
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => true,
+      isReduced: () => true,
+      getFullCloud: async () => {
+        hasClassEdits = true;
+        return cloud;
+      },
+      hasClassEdits: () => hasClassEdits,
+      getActiveScanId: () => 'scan-a',
+    });
+    const root = panel.element as unknown as FakeEl;
+    enableFullRes(root);
+    await pressExport(root);
+
+    expect(hoisted.downloads, 'a file was written despite the mid-export edit').toEqual([]);
+    expect(hoisted.converted).toEqual([]);
+    expect(statusText(root)).toMatch(/reclassified while the full-resolution re-decode was running/);
+    // The refusal names both lossless escapes, exactly like the up-front gate.
+    expect(statusText(root)).toMatch(/convert at full resolution/);
+    expect(statusText(root)).toMatch(/Include classification/);
+  });
+
+  it('refuses when the active scan changes during the re-decode', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const { EXPORT_SCAN_CHANGED_REFUSAL } = await import('../src/export/exportScanIdentity');
+    const cloud = twoPointCloud();
+    let activeId = 'scan-a';
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => true,
+      isReduced: () => true,
+      getFullCloud: async () => {
+        activeId = 'scan-b'; // the user opened another scan while we decoded
+        return cloud;
+      },
+      getActiveScanId: () => activeId,
+    });
+    const root = panel.element as unknown as FakeEl;
+    enableFullRes(root);
+    await pressExport(root);
+
+    expect(hoisted.downloads).toEqual([]);
+    expect(statusText(root)).toBe(EXPORT_SCAN_CHANGED_REFUSAL);
+  });
+
+  it('clips with the box captured BEFORE the decode, not the one set during it', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const cloud = twoPointCloud();
+    // Enabled when Export is pressed (keeps 1 of 2 points); cleared mid-decode.
+    // Reading the clip after the await would export both points — a file the
+    // user never asked for, in a session where the box was active at request time.
+    let clip: ClipBox | null = keepsFirstPointOnly;
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => true,
+      isReduced: () => true,
+      getFullCloud: async () => {
+        clip = null;
+        return cloud;
+      },
+      getActiveClip: () => clip,
+      getActiveScanId: () => 'scan-a',
+    });
+    const root = panel.element as unknown as FakeEl;
+    enableFullRes(root);
+    await pressExport(root);
+
+    expect(hoisted.downloads).toEqual(['scan.las']);
+    expect(hoisted.converted.length).toBe(1);
+    expect(hoisted.converted[0].pointCount, 'the post-await clip was used').toBe(1);
+    expect(statusText(root)).toMatch(/clipped to box/);
+  });
+
+  it('exports normally when nothing moved during the decode', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const cloud = twoPointCloud();
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => true,
+      isReduced: () => true,
+      getFullCloud: async () => cloud,
+      hasClassEdits: () => false,
+      getActiveScanId: () => 'scan-a',
+    });
+    const root = panel.element as unknown as FakeEl;
+    enableFullRes(root);
+    await pressExport(root);
+
+    expect(hoisted.downloads).toEqual(['scan.las']);
+    expect(hoisted.converted[0].pointCount).toBe(2);
+  });
+
+  it('still exports when the host supplies no scan identity (older wiring)', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const cloud = twoPointCloud();
+    const panel = new ExportPanel({
+      getCloud: () => cloud,
+      hasFullSource: () => false,
+      isReduced: () => false,
+      getFullCloud: async () => null,
+    });
+    const root = panel.element as unknown as FakeEl;
+    await pressExport(root);
+
+    expect(hoisted.downloads).toEqual(['scan.las']);
+  });
+});

--- a/tests/kmlActionsSnapshot.test.ts
+++ b/tests/kmlActionsSnapshot.test.ts
@@ -1,0 +1,80 @@
+/**
+ * kmlActionsSnapshot.test.ts
+ *
+ * The site KML mixed two moments: the origin and CRS were read before the
+ * serialiser import, everything the file actually contains — annotations,
+ * measurements, saved views, the up vector and the unit scale — was read after
+ * it. A dynamic import is usually warm, but "usually warm" is not a guarantee,
+ * and the export has no reason to straddle it at all.
+ *
+ * This pins the ordering by resolving the import slowly and mutating the session
+ * while it resolves: the written file must hold what the session held when the
+ * export was requested, not a blend of both.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { exportSiteKml, type KmlActionDeps } from '../src/app/kmlActions';
+import type { KmlExportInput } from '../src/export/kmlExport';
+import type { ResolvedCrs } from '../src/geo/CoordinateTypes';
+import type { Measurement } from '../src/render/measure/types';
+
+/** A geographic frame, so the lon/lat mapper is a plain origin shift. */
+const GEOGRAPHIC: ResolvedCrs = {
+  kind: 'geographic',
+  name: 'WGS 84',
+  epsg: 4326,
+  linearUnit: 'degree',
+  linearUnitToMetres: 1,
+  source: 'wkt',
+  confidence: 'high',
+  userConfirmed: true,
+} as unknown as ResolvedCrs;
+
+function measurement(id: string): Measurement {
+  return { id, kind: 'distance', points: [[0, 0, 0], [1, 1, 1]] } as unknown as Measurement;
+}
+
+describe('exportSiteKml — one reading of the session, then the write', () => {
+  it('writes the measurements the session held when the export was requested', async () => {
+    // The session as it stands when the user presses Export.
+    let measurements: Measurement[] = [measurement('m1')];
+    let unitToMetres = 1;
+    let built: KmlExportInput | null = null;
+    const written: string[] = [];
+
+    const deps = {
+      hasViewer: () => true,
+      geo: () => ({ origin: [0, 0, 0] as [number, number, number], crsName: 'WGS 84', name: 'site.las' }),
+      crsCurrent: () => GEOGRAPHIC,
+      annotations: () => [],
+      measurements: () => measurements,
+      viewpoints: () => [],
+      worldUp: () => [0, 0, 1] as [number, number, number],
+      unitToMetres: () => unitToMetres,
+      scanExtent: () => null,
+      baseName: (n: string) => n.replace(/\.[^.]+$/, ''),
+      downloadText: (filename: string) => { written.push(filename); },
+      setError: () => { /* not expected here */ },
+      // The serialiser import, resolving a turn later — and the user keeps
+      // working while it does: a second measurement lands and the unit scale
+      // changes. Neither belongs in the file that was already requested.
+      loadKmlExport: async () => {
+        await new Promise((r) => setTimeout(r, 0));
+        measurements = [measurement('m1'), measurement('m2')];
+        unitToMetres = 1000;
+        return {
+          buildKml: (input: KmlExportInput) => { built = input; return '<kml/>'; },
+          KmlCoordinateError: class extends Error {},
+        };
+      },
+    } as unknown as KmlActionDeps;
+
+    await exportSiteKml(deps);
+
+    expect(written).toEqual(['site.kml']);
+    expect(built).not.toBeNull();
+    const input = built as unknown as KmlExportInput;
+    expect(input.measurements.map((m) => m.id)).toEqual(['m1']);
+    expect(input.unitToMetres).toBe(1);
+  });
+});

--- a/tests/streamingScanIdentity.test.ts
+++ b/tests/streamingScanIdentity.test.ts
@@ -1,0 +1,140 @@
+/**
+ * streamingScanIdentity.test.ts
+ *
+ * ROADMAP #19 — a streaming scan used to report a null shell id, and the export
+ * scan-identity guard treats `sameExportTarget(null, null)` as "same target"
+ * (null matches only null, deliberately). So swapping one streaming scan for
+ * another mid-export was invisible: two different scans looked identical to the
+ * guard. These tests pin the fix at two levels:
+ *
+ *   1. The mint — every streaming cloud now carries a non-null, per-session id
+ *      that is distinct between scans and stable for one scan (the foundation
+ *      the guard stands on).
+ *   2. The read path — `ScanService.activeExportTargetId()` surfaces that id to
+ *      the guard WITHOUT changing `activeId`, which stays null for streaming so
+ *      no `activeId ? … : …` branch shifts (Option A's safety pin).
+ *
+ * The end-to-end proof that the ExportPanel now REFUSES a streaming→streaming
+ * swap lives in exportPanelSnapshotIntegrity.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
+import { nextStreamingScanId } from '../src/render/streaming/streamingScanId';
+import type { StreamingSource } from '../src/render/streaming/StreamingSource';
+import { sameExportTarget } from '../src/export/exportScanIdentity';
+import { createScanService } from '../src/app/ScanService';
+import { createAppContext } from '../src/app/appContext';
+import type { Viewer } from '../src/render/Viewer';
+import { buildSyntheticCopc } from './fixtures/copc/synthCopc';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+
+async function openStreaming(name: string): Promise<StreamingPointCloud> {
+  const fixture = buildSyntheticCopc({
+    center: [0, 0, 0],
+    halfsize: 128,
+    nodes: [{ key: [0, 0, 0, 0], pointCount: 100 }],
+  });
+  return StreamingPointCloud.open(new ArrayBufferRangeSource(fixture.buffer), name);
+}
+
+describe('streaming scan id — the mint', () => {
+  it('gives two different streaming scans different, non-null ids', async () => {
+    const a = await openStreaming('a.copc.laz');
+    const b = await openStreaming('b.copc.laz');
+    expect(a.id).toBeTruthy();
+    expect(b.id).toBeTruthy();
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('reports the same id for the same scan on every read (stable per instance)', async () => {
+    const a = await openStreaming('a.copc.laz');
+    expect(a.id).toBe(a.id);
+  });
+
+  it('mints outside the static cloud_<n> namespace', () => {
+    // A static scan is `cloud_<n>`; a streaming id must never collide with one,
+    // because the guard compares by === and both could be read as an export
+    // target. Distinct prefixes make cross-type confusion impossible.
+    expect(nextStreamingScanId()).toMatch(/^streaming-scan_/);
+    expect(nextStreamingScanId()).not.toMatch(/^cloud_/);
+  });
+
+  it('the guard distinguishes two streaming scans and matches one to itself', async () => {
+    const a = await openStreaming('a.copc.laz');
+    const b = await openStreaming('b.copc.laz');
+    // The red the fix removes: before the mint, both scans reported null and the
+    // guard read them as the SAME target — a swap slipped through.
+    expect(sameExportTarget(null, null)).toBe(true);
+    // Green: distinct ids make a swap visible, and a scan still matches itself.
+    expect(sameExportTarget(a.id, b.id)).toBe(false);
+    expect(sameExportTarget(a.id, a.id)).toBe(true);
+  });
+});
+
+/** A viewer exposing only the two members the service reads. */
+function viewerStub(streaming: () => StreamingSource | null): Viewer {
+  return {
+    getCloud: () => undefined,
+    get streamingCloud() {
+      return streaming();
+    },
+  } as unknown as Viewer;
+}
+
+/** A minimal streaming cloud carrying just the id the guard reads. */
+function streamingWithId(id: string): StreamingSource {
+  return { id } as unknown as StreamingSource;
+}
+
+describe('ScanService.activeExportTargetId — the read path', () => {
+  it('returns the static activeId when a static scan is selected, and activeId is unchanged', () => {
+    const svc = createScanService({ getViewer: () => viewerStub(() => null), context: createAppContext() });
+    svc.setActive('cloud_3');
+    expect(svc.activeExportTargetId()).toBe('cloud_3');
+    expect(svc.activeId).toBe('cloud_3');
+  });
+
+  it('returns the streaming id when a streaming scan is active — while activeId stays null (safety pin)', () => {
+    // A streaming scan never calls setActive, so activeId is null; the export
+    // target must still be identifiable. This is the whole point of Option A:
+    // activeId keeps returning null (no branch shifts), the guard reads the id.
+    const svc = createScanService({
+      getViewer: () => viewerStub(() => streamingWithId('streaming-scan_7')),
+      context: createAppContext(),
+    });
+    expect(svc.activeId).toBeNull();
+    expect(svc.activeExportTargetId()).toBe('streaming-scan_7');
+  });
+
+  it('distinguishes a streaming→streaming swap', () => {
+    let current: StreamingSource | null = streamingWithId('streaming-scan_1');
+    const svc = createScanService({ getViewer: () => viewerStub(() => current), context: createAppContext() });
+    const before = svc.activeExportTargetId();
+    current = streamingWithId('streaming-scan_2'); // user opened another streaming scan
+    const after = svc.activeExportTargetId();
+    expect(sameExportTarget(before, after)).toBe(false);
+  });
+
+  it('reports the same target for the same streaming scan (no false refusal)', () => {
+    const cloud = streamingWithId('streaming-scan_9');
+    const svc = createScanService({ getViewer: () => viewerStub(() => cloud), context: createAppContext() });
+    expect(sameExportTarget(svc.activeExportTargetId(), svc.activeExportTargetId())).toBe(true);
+  });
+
+  it('is null when nothing identifiable is active (fail closed, not a wildcard)', () => {
+    const svc = createScanService({ getViewer: () => viewerStub(() => null), context: createAppContext() });
+    expect(svc.activeExportTargetId()).toBeNull();
+  });
+
+  it('prefers the static id when a static scan is selected even if a streaming cloud lingers', () => {
+    // Defensive: activeId is the authoritative selection; a stale streaming
+    // reference must not override an explicitly selected static scan.
+    const svc = createScanService({
+      getViewer: () => viewerStub(() => streamingWithId('streaming-scan_5')),
+      context: createAppContext(),
+    });
+    svc.setActive('cloud_2');
+    expect(svc.activeExportTargetId()).toBe('cloud_2');
+  });
+});

--- a/tests/streamingSource.test.ts
+++ b/tests/streamingSource.test.ts
@@ -99,6 +99,7 @@ test('the scheduler accepts any StreamingSource conforming object — EPT will p
 
   const stub: StreamingSource = {
     kind: 'ept', // pretending to be an EPT source
+    id: 'stub-streaming-scan',
     name: 'stub.ept',
     renderOrigin: realCloud.renderOrigin,
     octree: realCloud.octree,


### PR DESCRIPTION
Closes the blind spot #308's export scan-identity guard documented: a streaming scan reported a **null** shell id, and `sameExportTarget(null, null)` is deliberately `true`, so swapping one streaming scan for another mid-export slipped past the guard (and the terrain stale-guard, which reads the same identity).

Stacks on #308 (which added the guard) — merge after it.

## The fix — Option A (additive, `activeId` semantics untouched)
- `src/render/streaming/streamingScanId.ts` (new) mints one non-null id per streaming session, in a namespace that can't collide with a static `cloud_<n>` id (`sameExportTarget` compares by `===`).
- `StreamingSource` carries `readonly id`; COPC + EPT streaming clouds mint it at construction.
- `ScanService.activeExportTargetId()` (new accessor) returns the static `activeId`, else the streaming cloud's id, else null. **`activeId` itself is unchanged** — it still returns null for streaming, so none of the ~69 `activeId` consumers (or the dozen `activeId ? … : …` branches) shift behavior. Only the export/terrain guards read the streaming-aware form. This was the low-risk requirement: fix the guard without touching the meaning of a value the whole shell depends on.
- Fails closed: a streaming scan reports a concrete id, never a wildcard.

## Verification
The implementing agent stalled (API watchdog) mid RED-proof — it had temporarily reverted the accessor to demonstrate the tests catch a swap, and stopped before restoring the fix. I restored it and re-verified the full branch:
- `npx tsc --noEmit` — clean
- Streaming-id + export-identity tests — 17 passed (the two swap-detection tests were the RED proof; green with the fix restored)
- **Full suite — 8475 passed, 0 failed** (651 files); `verify:freeze-claims`/`Image is not defined` stdout are known fixtures, not failures (exit 0)
- `lint:monolith-size` (main.ts 5875, ≤ baseline), `lint:architecture-truth`, `lint:layer-boundaries`, `lint:archive-vocab` — all pass

## Tests
Two different streaming scans → different targets → a swap is refused; the same streaming scan → same target (no false refusal); a static scan is unaffected; and a safety-pin test that `activeId` still returns null for streaming.