### PR TITLE
Sonar S5906: length assertions use toHaveLength (tests)

### DIFF
--- a/tests/LayerService.test.ts
+++ b/tests/LayerService.test.ts
@@ -243,7 +243,7 @@ describe('LayerService — refreshCrsFlags', () => {
     const two = setup(twoClouds);
     two.service.refreshCrsFlags();
     expect(two.compareCalls.at(-1)).toBe(true);
-    expect(two.crsFlagCalls.length).toBe(1);
+    expect(two.crsFlagCalls).toHaveLength(1);
     expect(two.compassRefreshes()).toBe(1);
 
     const one = setup({ a: twoClouds.a });

--- a/tests/alignEpochs.test.ts
+++ b/tests/alignEpochs.test.ts
@@ -42,7 +42,7 @@ describe('alignEpochClouds', () => {
     expect(alignment.rmsResidualM).toBeLessThan(1e-3);
     expect(Math.abs(alignment.yawDeg)).toBeLessThan(0.1);
     expect(Math.hypot(alignment.translation[0], alignment.translation[1])).toBeLessThan(1e-2);
-    expect(after.positions.length).toBe(b.positions.length);
+    expect(after.positions).toHaveLength(b.positions.length);
   });
 
   test('recovers a horizontal translation and preserves the vertical change', () => {

--- a/tests/analyseContours.test.ts
+++ b/tests/analyseContours.test.ts
@@ -74,7 +74,7 @@ describe('analyseContours', () => {
   it('is deterministic', () => {
     const r2 = analyseContours(pts, { cellSizeM: 2, crs: 'EPSG:32610' });
     expect(r2.intervalM).toBe(r.intervalM);
-    expect(r2.model.features.length).toBe(r.model.features.length);
+    expect(r2.model.features).toHaveLength(r.model.features.length);
   });
 
   it('handles a flat surface honestly (no interval, no contours)', () => {
@@ -82,7 +82,7 @@ describe('analyseContours', () => {
     for (let x = 0; x <= 10; x++) for (let y = 0; y <= 10; y++) flat.push({ x, y, z: 5 });
     const fr = analyseContours(flat, { cellSizeM: 2, crs: 'EPSG:32610' });
     expect(fr.intervalM).toBeNull();
-    expect(fr.contours.levels.length).toBe(0);
+    expect(fr.contours.levels).toHaveLength(0);
     expect(fr.warnings.join(' ')).toMatch(/no reliable contour interval/i);
   });
 

--- a/tests/analyseContoursCore.test.ts
+++ b/tests/analyseContoursCore.test.ts
@@ -202,7 +202,7 @@ describe('computeTerrainCore + contoursFromCore (pure split)', () => {
     it('core has a usable dtm but the contour stage yields no interval', () => {
       const r = contoursFromCore(core, {});
       expect(r.intervalM).toBeNull();
-      expect(r.contours.levels.length).toBe(0);
+      expect(r.contours.levels).toHaveLength(0);
       expect(r.warnings.join(' ')).toMatch(/no reliable contour interval/i);
       // The "no interval" warning is appended AFTER the core warnings.
       expect(r.warnings.slice(0, core.coreWarnings.length)).toEqual([...core.coreWarnings]);

--- a/tests/analysePanelCoverageTile.test.ts
+++ b/tests/analysePanelCoverageTile.test.ts
@@ -101,21 +101,21 @@ describe('AnalysePanel — coverage tile', () => {
     const root = panel.element as unknown as FakeEl;
 
     // The tile heading.
-    expect(root.findByText('Coverage (trust)').length).toBe(1);
+    expect(root.findByText('Coverage (trust)')).toHaveLength(1);
 
     // The honesty caption — green/yellow/red = measured/interpolated/unreliable.
     expect(root.findContaining(COVERAGE_CAPTION).length).toBeGreaterThan(0);
 
     // The 3-stop legend words.
-    expect(root.findContaining('strong — measured').length).toBe(1);
-    expect(root.findContaining('moderate — interpolated').length).toBe(1);
-    expect(root.findContaining('weak — extrapolated / gap').length).toBe(1);
+    expect(root.findContaining('strong — measured')).toHaveLength(1);
+    expect(root.findContaining('moderate — interpolated')).toHaveLength(1);
+    expect(root.findContaining('weak — extrapolated / gap')).toHaveLength(1);
 
     // Coverage tile gets its own Export PNG button (one of several PNG buttons
     // in the surface row — assert at least the coverage one exists).
     expect(root.findByText('Export PNG').length).toBeGreaterThanOrEqual(1);
 
     // Honesty: nothing in the rendered tree claims survey-grade for coverage.
-    expect(root.findContaining('survey-grade coverage').length).toBe(0);
+    expect(root.findContaining('survey-grade coverage')).toHaveLength(0);
   });
 });

--- a/tests/analysePanelReportButton.test.ts
+++ b/tests/analysePanelReportButton.test.ts
@@ -69,10 +69,10 @@ describe('AnalysePanel — export area (Contour Studio architecture)', () => {
     // These moved out of the always-visible flow: the panel builds them only as
     // detached backing actions the Contour Studio workspace dispatches to, so
     // none must appear in the static panel tree.
-    expect(root.findByText('Intelligence report (PDF)').length).toBe(0);
-    expect(root.findByText('DEM (ZIP)').length).toBe(0);
-    expect(root.findByText('Export Contours').length).toBe(0);
-    expect(root.findByText('GEOJSON').length).toBe(0);
+    expect(root.findByText('Intelligence report (PDF)')).toHaveLength(0);
+    expect(root.findByText('DEM (ZIP)')).toHaveLength(0);
+    expect(root.findByText('Export Contours')).toHaveLength(0);
+    expect(root.findByText('GEOJSON')).toHaveLength(0);
   });
 
   it('leads the results with the Terrain Products surface (launcher + gated deliverable)', async () => {

--- a/tests/analyseRailBanner.test.ts
+++ b/tests/analyseRailBanner.test.ts
@@ -111,7 +111,7 @@ describe('AnalysePanel — consolidated not-survey-grade banner', () => {
 
     // Exactly one banner element carries the DEM caveat…
     const dem = root.findContaining('Preliminary DEM');
-    expect(dem.length).toBe(1);
+    expect(dem).toHaveLength(1);
     // …and that single banner states BOTH facts (nothing disclosed is lost).
     expect(dem[0].ownText).toContain('not survey-grade');
     expect(dem[0].ownText).toContain('README');
@@ -119,7 +119,7 @@ describe('AnalysePanel — consolidated not-survey-grade banner', () => {
 
     // The old second banner no longer renders as a separate element.
     const previewBanners = root.findContaining('Preview export — not survey-grade');
-    expect(previewBanners.length).toBe(0);
+    expect(previewBanners).toHaveLength(0);
 
     // Two elements state the limitation, and they are different things: the
     // consolidated banner above (conditional) and the panel's standing footer
@@ -127,7 +127,7 @@ describe('AnalysePanel — consolidated not-survey-grade banner', () => {
     // two stacked BANNERS; the footer is not a banner and is not conditional.
     const stating = root.findContaining('not survey-grade');
     const footers = stating.filter((e) => e.className.includes('olv-analyse-footer'));
-    expect(footers.length).toBe(1);
+    expect(footers).toHaveLength(1);
     expect(footers[0].ownText).toBe(NOT_SURVEY_GRADE_NOTE);
     // Exactly one banner states it — the consolidated one, and no other.
     expect(stating.length - footers.length).toBe(1);
@@ -144,8 +144,8 @@ describe('AnalysePanel — consolidated not-survey-grade banner', () => {
     panel.update(result);
     const root = panel.element as unknown as FakeEl;
     if (result.quality.exportReadiness === 'available' && result.dtm.coverageMode === 'full') {
-      expect(root.findContaining('Preliminary DEM').length).toBe(0);
-      expect(root.findContaining('Preview export').length).toBe(0);
+      expect(root.findContaining('Preliminary DEM')).toHaveLength(0);
+      expect(root.findContaining('Preview export')).toHaveLength(0);
     } else {
       // Georeferenced but still partial → a single banner, never two. The
       // standing footer is excluded: it always states the limitation and is
@@ -176,14 +176,14 @@ describe('AnalysePanel — compact per-tile footers', () => {
     expect(footers.length).toBeGreaterThanOrEqual(2);
     for (const footer of footers) {
       // The hint readout and the export action share the single footer line.
-      expect(footer.findByClass('olv-analyse-sample').length).toBe(1);
-      expect(footer.findContaining('Export PNG').length).toBe(1);
+      expect(footer.findByClass('olv-analyse-sample')).toHaveLength(1);
+      expect(footer.findContaining('Export PNG')).toHaveLength(1);
     }
 
     // Nothing disclosed was removed: every hint readout still exists, one per
     // tile footer (none stacked as standalone full-width rows any more).
     const hints = root.findContaining('Click the map to sample a point.');
-    expect(hints.length).toBe(footers.length);
+    expect(hints).toHaveLength(footers.length);
     for (const hint of hints) {
       expect(footers.some((f) => f.findByClass('olv-analyse-sample').includes(hint))).toBe(true);
     }

--- a/tests/annotationClustering.test.ts
+++ b/tests/annotationClustering.test.ts
@@ -69,7 +69,7 @@ describe('clusterAnnotations', () => {
   it('guards a non-positive cell size without throwing', () => {
     const out = clusterAnnotations([a('note', 0, 0), a('note', 1000, 1000)], 0);
     // With the min cell, the two distant points are separate clusters.
-    expect(out.length).toBe(2);
+    expect(out).toHaveLength(2);
   });
 });
 

--- a/tests/benchmark/contourCorrectness.test.ts
+++ b/tests/benchmark/contourCorrectness.test.ts
@@ -200,7 +200,7 @@ describe('contour correctness — analytic agreement', () => {
     const dtm = coneGrid(41, 41, cx, cy);
     const levels = [5, 10, 15];
     const set = contoursAt(dtm, { intervalM: 5, levels });
-    expect(set.levels.length).toBe(3);
+    expect(set.levels).toHaveLength(3);
     for (const level of set.levels) {
       expect(level.segments.length).toBeGreaterThan(0);
       const tol = radialTolerance(CELL, level.value);
@@ -471,8 +471,8 @@ describe('contour correctness — topological invariants', () => {
     };
     const below = ringsAt(4.0);
     const above = ringsAt(6.0);
-    expect(below.length).toBe(1);
-    expect(above.length).toBe(2);
+    expect(below).toHaveLength(1);
+    expect(above).toHaveLength(2);
     // The two upper rings are disjoint: neither contains a vertex of the other.
     const [a, b] = above.map((p) => p.vertices.map((v) => [v.x, v.y] as [number, number]));
     expect(a.some(([x, y]) => pointInRing({ x, y }, b))).toBe(false);
@@ -548,7 +548,7 @@ describe('contour correctness — topological invariants', () => {
     const model = modelFor(dtm, set);
     const ringFor = (value: number) => {
       const f = model.features.filter((x) => x.value === value);
-      expect(f.length).toBe(1);
+      expect(f).toHaveLength(1);
       return f[0].coordinates;
     };
     const values = [2, 4, 6, 8];
@@ -634,10 +634,10 @@ describe('contour correctness — declared properties match the geometry', () =>
     const dtm = coneGrid(41, 41, 20.5, 20.5);
     const set = contoursAt(dtm, { intervalM: 1 });
     const stitched = stitchContourSet(set, dtm.cellSizeM);
-    expect(stitched.length).toBe(set.levels.length);
+    expect(stitched).toHaveLength(set.levels.length);
     const model = modelFor(dtm, set);
     const geo = toGeoJSON(model);
-    expect((geo.features as unknown[]).length).toBe(model.features.length);
+    expect(geo.features as unknown[]).toHaveLength(model.features.length);
     const declaredValues = new Set(set.levels.map((l) => l.value));
     for (const f of model.features) expect(declaredValues.has(f.value)).toBe(true);
   });
@@ -695,7 +695,7 @@ describe('contour correctness — declared properties match the geometry', () =>
       const props = f.properties as Record<string, unknown>;
       const geom = f.geometry as { coordinates: number[][] };
       for (const c of geom.coordinates) {
-        expect(c.length).toBe(3);
+        expect(c).toHaveLength(3);
         expect(c[2]).toBe(props.elevation);
       }
     }
@@ -730,7 +730,7 @@ describe('contour correctness — the documented third-ordinate unit gap', () =>
     expect(metadata.elevationIn3d).toBe(false);
     for (const f of geo.features as Array<Record<string, unknown>>) {
       const geom = f.geometry as { coordinates: number[][] };
-      for (const c of geom.coordinates) expect(c.length).toBe(2);
+      for (const c of geom.coordinates) expect(c).toHaveLength(2);
       expect((f.properties as Record<string, unknown>).elevationUnit).toBe('foot');
     }
   });
@@ -751,7 +751,7 @@ describe('contour correctness — the documented third-ordinate unit gap', () =>
       expect(props.elevationUnit).toBe('foot');
       const geom = f.geometry as { coordinates: number[][] };
       for (const c of geom.coordinates) {
-        expect(c.length).toBe(3);
+        expect(c).toHaveLength(3);
         expect(c[2]).toBeCloseTo((props.elevation as number) * 0.3048, 9);
       }
     }
@@ -767,7 +767,7 @@ describe('contour correctness — the documented third-ordinate unit gap', () =>
     expect(metadata.elevationNote).toMatch(/vertical unit/i);
     for (const f of geo.features as Array<Record<string, unknown>>) {
       const geom = f.geometry as { coordinates: number[][] };
-      for (const c of geom.coordinates) expect(c.length).toBe(2);
+      for (const c of geom.coordinates) expect(c).toHaveLength(2);
     }
   });
 
@@ -794,7 +794,7 @@ describe('contour correctness — the documented third-ordinate unit gap', () =>
     const features = geo.features as Array<Record<string, unknown>>;
     for (const f of features) {
       const geom = f.geometry as { coordinates: number[][] };
-      for (const c of geom.coordinates) expect(c.length).toBe(3);
+      for (const c of geom.coordinates) expect(c).toHaveLength(3);
     }
     // And with no provenance argument the file carries no unit token at all:
     // `intervalM` names metres while the value is 2 feet, and neither the
@@ -865,7 +865,7 @@ describe('contour correctness — degenerate inputs', () => {
     const model = modelFor(dtm, set);
     expect(model.features).toEqual([]);
     expect(model.bbox).toBeNull();
-    expect(set.levels.length).toBe(1);
+    expect(set.levels).toHaveLength(1);
     expect(set.levels[0].value).toBe(10);
     // The set says WHY it is empty, in the same shape the all-gap path uses,
     // so a consumer never has to count segments to learn the surface is flat.
@@ -980,7 +980,7 @@ describe('contour correctness — generalization stays within its tolerance', ()
       toleranceSource: tol,
       horizontalUnit: knownUnit(1),
     });
-    expect(product.features.length).toBe(analytical.features.length);
+    expect(product.features).toHaveLength(analytical.features.length);
     // Recomputed independently of the record the generalizer wrote.
     let worst = 0;
     for (let i = 0; i < analytical.features.length; i++) {
@@ -1004,7 +1004,7 @@ describe('contour correctness — generalization stays within its tolerance', ()
         toleranceSource: tol,
         horizontalUnit: knownUnit(1),
       });
-      expect(product.features.length).toBe(analytical.features.length);
+      expect(product.features).toHaveLength(analytical.features.length);
       for (let i = 0; i < product.features.length; i++) {
         expect(product.features[i].value).toBe(analytical.features[i].value);
         expect(product.features[i].closed).toBe(analytical.features[i].closed);
@@ -1112,7 +1112,7 @@ describe('contour correctness — negative controls', () => {
     const closedLoop = [seg(0, 0, 1, 0), seg(1, 0, 1, 1), seg(1, 1, 0, 0)];
     expect(oddDegreeNodes(closedLoop, q)).toEqual([]);
     const withSpur = [...closedLoop, seg(1, 1, 2, 2)];
-    expect(oddDegreeNodes(withSpur, q).length).toBe(2);
+    expect(oddDegreeNodes(withSpur, q)).toHaveLength(2);
   });
 
   it('the crossing check flags two segments that genuinely cross', () => {

--- a/tests/benchmark/failureRecovery.test.ts
+++ b/tests/benchmark/failureRecovery.test.ts
@@ -236,7 +236,7 @@ describe('a body shorter than its header promised', () => {
       copcChunkMeta(50),
     );
     expect(healthy.pointCount).toBe(50);
-    expect(healthy.positions.length).toBe(150);
+    expect(healthy.positions).toHaveLength(150);
 
     // Injection: the hierarchy declared 50 points, the transport delivered 18.
     const injected = decodeRecords(
@@ -246,9 +246,9 @@ describe('a body shorter than its header promised', () => {
     expect(injected.pointCount).toBe(18);
     // The arrays are sized to what was decoded, not to what was declared — a
     // padded array would present 32 points at the origin as real returns.
-    expect(injected.positions.length).toBe(18 * 3);
-    expect(injected.intensity.length).toBe(18);
-    expect(injected.classification.length).toBe(18);
+    expect(injected.positions).toHaveLength(18 * 3);
+    expect(injected.intensity).toHaveLength(18);
+    expect(injected.classification).toHaveLength(18);
   });
 
   test('an EPT binary tile refuses a short body with a tagged error carrying both byte counts', () => {

--- a/tests/benchmark/fixtures.test.ts
+++ b/tests/benchmark/fixtures.test.ts
@@ -57,7 +57,7 @@ describe('the seeded synthetic cloud', () => {
   test('declares the count and bounds a driver hands to the pipeline', () => {
     const cloud = generateSyntheticCloud({ seed: 7, pointCount: 4_000 });
     expect(cloud.pointCount).toBe(4_000);
-    expect(cloud.positions.length).toBe(4_000 * 3);
+    expect(cloud.positions).toHaveLength(4_000 * 3);
     expect(cloud.groundPointCount + cloud.aboveGroundPointCount).toBe(4_000);
     // The declared bounds must be the real extremes of the emitted points —
     // a driver passes them straight to the pipeline's grid, so a declared box

--- a/tests/benchmark/pipelineDriver.test.ts
+++ b/tests/benchmark/pipelineDriver.test.ts
@@ -329,7 +329,7 @@ describe('the OLV pipeline driver', () => {
     expect(actual.validation.rmse).toBe(expected.validation.rmse);
     expect(actual.intervalM).toBe(expected.intervalM);
     expect(actual.tally).toEqual(expected.tally);
-    expect(actual.model.features.length).toBe(expected.model.features.length);
+    expect(actual.model.features).toHaveLength(expected.model.features.length);
     // And the descriptor stage re-runs the app's own complexity summary over
     // the core's cached Horn grids, so it must agree with the core's own.
     expect(run.artifacts.descriptors).toEqual(toHashable(expected.complexity));

--- a/tests/benchmark/provenanceIntegrity.test.ts
+++ b/tests/benchmark/provenanceIntegrity.test.ts
@@ -329,7 +329,7 @@ describe('completeness — what the artifact declares on its own', () => {
         bytes.byteOffset + 58,
         32,
       );
-      expect(field.length).toBe(32);
+      expect(field).toHaveLength(32);
       expect(lasGeneratingSoftware().length).toBeLessThanOrEqual(32);
       for (const part of lasGeneratingSoftware().split(' ').slice(1)) {
         expect([BUILD_IDENTITY.version, BUILD_IDENTITY.commit, `${BUILD_IDENTITY.commit}+dirty`])

--- a/tests/benchmark/reachability.test.ts
+++ b/tests/benchmark/reachability.test.ts
@@ -92,7 +92,7 @@ describe.runIf(witnessEnabled())('negative control: an untaken path is reported 
       // Every function the claim names must be missing. One entered function
       // here would mean the witness can be satisfied without the suite.
       expect(witness.entered, `${c.id} reported entered functions from an empty window`).toEqual([]);
-      expect(witness.missing.length).toBe((c.functions ?? []).length);
+      expect(witness.missing).toHaveLength((c.functions ?? []).length);
     }
     // Reported so the control's size is visible, not just its verdict.
     expect(Object.values(report).reduce((a, b) => a + b, 0)).toBe(
@@ -114,7 +114,7 @@ describe.runIf(witnessEnabled())('negative control: an untaken path is reported 
       functions: [{ file: 'src/canonicalHash.ts', fn: 'witnessFrom' }],
     };
     expect(callsRecorded(snapshot, impostor.functions![0])).toBe(0);
-    expect(witnessFrom(impostor, snapshot).missing.length).toBe(1);
+    expect(witnessFrom(impostor, snapshot).missing).toHaveLength(1);
   });
 
   test('a function that did run in the window is reported entered', async () => {
@@ -145,7 +145,7 @@ describe('negative control: a doctored artifact is refused', () => {
       const intact = judgeArtifactClaim(c, goodResult(c));
       expect(intact.problems).toEqual([]);
       expect(intact.state).toBe('witnessed');
-      expect(intact.executed.length).toBe((c.requiredChecks ?? []).length);
+      expect(intact.executed).toHaveLength((c.requiredChecks ?? []).length);
 
       const dropped = goodResult(c);
       dropped.results = dropped.results.slice(1);

--- a/tests/benchmark/roundtripFidelity.test.ts
+++ b/tests/benchmark/roundtripFidelity.test.ts
@@ -513,7 +513,7 @@ describe('version coverage — LAS 1.2 and 1.4 header contracts', () => {
     // The VALUE carries build identity and changes between branches; the
     // structure is what a reader depends on.
     const raw = readLasBySpec(writeLas(attributeCloud(), {})).generatingSoftwareRaw;
-    expect(raw.length).toBe(32);
+    expect(raw).toHaveLength(32);
     let sawNul = false;
     for (const b of raw) {
       if (b === 0) sawNul = true;
@@ -615,7 +615,7 @@ describe('CRS survival — what is written reads back as the same CRS', () => {
     const wkt = 'PROJCS["x",UNIT["metre",1],AUTHORITY["EPSG","32611"]]';
     const spec = readLasBySpec(writeLas14(g, { epsg: 32611, wkt }));
     const vlr = spec.vlrs.find((v) => v.recordId === 2112)!;
-    expect(vlr.bytes.length).toBe(wkt.length + 1);
+    expect(vlr.bytes).toHaveLength(wkt.length + 1);
     expect(vlr.bytes[vlr.bytes.length - 1]).toBe(0);
     expect(String.fromCharCode(...vlr.bytes.subarray(0, wkt.length))).toBe(wkt);
   });
@@ -689,7 +689,7 @@ describe('header self-consistency', () => {
   it('the point data offset lands exactly where the records begin', () => {
     for (const bytes of [writeLas(attributeCloud(), { epsg: 32611 }), writeLas14(attributeCloud(), { epsg: 32611 })]) {
       const spec = readLasBySpec(bytes);
-      expect(bytes.length).toBe(spec.offsetToPointData + spec.pointCount * spec.recordLength);
+      expect(bytes).toHaveLength(spec.offsetToPointData + spec.pointCount * spec.recordLength);
       expect(spec.offsetToPointData).toBeGreaterThanOrEqual(spec.headerSize);
     }
   });

--- a/tests/benchmark/runtime.test.ts
+++ b/tests/benchmark/runtime.test.ts
@@ -148,7 +148,7 @@ describe('the environment capture', () => {
       'releaseVersion',
     ];
     for (const key of declared) expect(env[key], key).toBeDefined();
-    expect(fields.length).toBe(declared.length);
+    expect(fields).toHaveLength(declared.length);
   });
 
   test('says whether the working tree matched the commit it reports', () => {

--- a/tests/benchmark/seedSensitivity.test.ts
+++ b/tests/benchmark/seedSensitivity.test.ts
@@ -243,7 +243,7 @@ describe('quantities that must not depend on the draw', () => {
 describe('quantities that legitimately follow the draw', () => {
   test('each carries a full spread and no verdict', () => {
     const variable = evaluation.quantities.filter((q) => q.group === 'variable');
-    expect(variable.length).toBe(PIPELINE_QUANTITIES.filter((q) => q.group === 'variable').length);
+    expect(variable).toHaveLength(PIPELINE_QUANTITIES.filter((q) => q.group === 'variable').length);
     for (const q of variable) {
       expect(q.summary.count, q.name).toBe(SWEEP_SEED_COUNT);
       expect(q.summary.stdDev, q.name).not.toBeNull();

--- a/tests/canonicalFrame.test.ts
+++ b/tests/canonicalFrame.test.ts
@@ -70,7 +70,7 @@ describe('yUpToCanonicalZUp', () => {
   });
 
   it('handles an empty buffer', () => {
-    expect(yUpToCanonicalZUp(new Float32Array(0)).length).toBe(0);
+    expect(yUpToCanonicalZUp(new Float32Array(0))).toHaveLength(0);
   });
 
   it('ignores a trailing partial triple rather than reading past the end', () => {

--- a/tests/civilProfileStats.test.ts
+++ b/tests/civilProfileStats.test.ts
@@ -18,7 +18,7 @@ describe('computeCivilProfileStats', () => {
   it('computes length, relief, mean and max grade on a clean profile', () => {
     // 0,10,20,30 m chainage; elevations rise then fall.
     const stats = computeCivilProfileStats([s(0, 100), s(10, 102), s(20, 108), s(30, 105)]);
-    expect(stats.length).toBe(30);
+    expect(stats).toHaveLength(30);
     expect(stats.sampleCount).toBe(4);
     expect(stats.coverage).toBe(1);
     expect(stats.minElevation).toBe(100);

--- a/tests/classBuffer.test.ts
+++ b/tests/classBuffer.test.ts
@@ -20,7 +20,7 @@ describe('toClassBuffer', () => {
   it('empty input yields an empty buffer', () => {
     const out = toClassBuffer([]);
     expect(out).toBeInstanceOf(Uint8Array);
-    expect(out.length).toBe(0);
+    expect(out).toHaveLength(0);
   });
 
   it('copies a number[] into a fresh Uint8Array with identical values', () => {

--- a/tests/classificationFilter.test.ts
+++ b/tests/classificationFilter.test.ts
@@ -26,7 +26,7 @@ describe('excludeNonGroundClasses', () => {
   it('keeps everything when classification is absent or misaligned', () => {
     const pts = [p(0, 1), p(1, 2)];
     expect(excludeNonGroundClasses(pts, null).excludedCount).toBe(0);
-    expect(excludeNonGroundClasses(pts, [5]).points.length).toBe(2); // wrong length → keep all
+    expect(excludeNonGroundClasses(pts, [5]).points).toHaveLength(2); // wrong length → keep all
     expect(excludeNonGroundClasses(pts, [5, 6], []).excludedCount).toBe(0); // empty exclude set
   });
 
@@ -39,7 +39,7 @@ describe('excludeNonGroundClasses', () => {
   it('does not mutate the input array', () => {
     const pts = [p(0, 1), p(1, 1)];
     excludeNonGroundClasses(pts, [5, 2]);
-    expect(pts.length).toBe(2);
+    expect(pts).toHaveLength(2);
   });
 
   it('default class set is vegetation + building + noise', () => {

--- a/tests/classifierCorpus.test.ts
+++ b/tests/classifierCorpus.test.ts
@@ -64,7 +64,7 @@ describe('corpus immutability', () => {
   it('regenerates byte for byte on a second build', () => {
     const a = buildCorpus();
     const b = buildCorpus();
-    expect(a.length).toBe(b.length);
+    expect(a).toHaveLength(b.length);
     for (let i = 0; i < a.length; i++) {
       expect(sceneDigest(a[i])).toBe(sceneDigest(b[i]));
       expect(Array.from(a[i].xyz)).toEqual(Array.from(b[i].xyz));
@@ -129,11 +129,11 @@ describe('corpus coverage', () => {
   it('every scene carries labelled points and a positive cell size', () => {
     for (const scene of buildCorpus()) {
       expect(scene.count).toBeGreaterThan(1000);
-      expect(scene.truth.length).toBe(scene.count);
-      expect(scene.xyz.length).toBe(scene.count * 3);
+      expect(scene.truth).toHaveLength(scene.count);
+      expect(scene.xyz).toHaveLength(scene.count * 3);
       expect(scene.cellSize).toBeGreaterThan(0);
-      if (scene.colors) expect(scene.colors.length).toBe(scene.count * 3);
-      if (scene.returnCount) expect(scene.returnCount.length).toBe(scene.count);
+      if (scene.colors) expect(scene.colors).toHaveLength(scene.count * 3);
+      if (scene.returnCount) expect(scene.returnCount).toHaveLength(scene.count);
     }
   });
 

--- a/tests/colorModes.test.ts
+++ b/tests/colorModes.test.ts
@@ -94,7 +94,7 @@ describe('colorForMode — intensity', () => {
     const cloud = makeFullCloud();
     const result = colorForMode('intensity', cloud);
     expect(result).toBeInstanceOf(Uint8Array);
-    expect(result.length).toBe(cloud.pointCount * 3);
+    expect(result).toHaveLength(cloud.pointCount * 3);
   });
 
   test('maps min intensity to 0 and max to 255 (greyscale)', () => {
@@ -150,7 +150,7 @@ describe('colorForMode — elevation', () => {
     const cloud = makeFullCloud();
     const result = colorForMode('elevation', cloud);
     expect(result).toBeInstanceOf(Uint8Array);
-    expect(result.length).toBe(cloud.pointCount * 3);
+    expect(result).toHaveLength(cloud.pointCount * 3);
   });
 
   test('higher Z points map to a higher position on the colour ramp', () => {
@@ -197,7 +197,7 @@ describe('colorForMode — elevation', () => {
     const cloud = makePositionsOnlyCloud(); // Z: 10, 20, 30
     expect(() => colorForMode('elevation', cloud)).not.toThrow();
     const result = colorForMode('elevation', cloud);
-    expect(result.length).toBe(3 * 3);
+    expect(result).toHaveLength(3 * 3);
   });
 
   test('single-point cloud does not throw', () => {
@@ -245,7 +245,7 @@ describe('colorByScalar', () => {
   test('returns a Uint8Array with 3 bytes per point', () => {
     const out = colorByScalar([0, 1, 2], 3, 0, 2);
     expect(out).toBeInstanceOf(Uint8Array);
-    expect(out.length).toBe(9);
+    expect(out).toHaveLength(9);
   });
 
   test('defaults to the CVD-safe Cividis ramp — min hits the bottom stop, max the top', () => {
@@ -364,7 +364,7 @@ describe('colorForMode — gpsTime', () => {
 
   test('ramps early → late acquisition time on Cividis (min bottom, max top)', () => {
     const out = colorForMode('gpsTime', makeGpsTimeCloud());
-    expect(out.length).toBe(4 * 3);
+    expect(out).toHaveLength(4 * 3);
     expect([out[0], out[1], out[2]]).toEqual([0, 32, 76]);
     expect([out[9], out[10], out[11]]).toEqual([253, 231, 37]);
   });
@@ -422,7 +422,7 @@ describe('colorForMode — returnNumber', () => {
 
   test('ramps first → last return on Cividis (min bottom, max top)', () => {
     const out = colorForMode('returnNumber', makeReturnCloud());
-    expect(out.length).toBe(3 * 3);
+    expect(out).toHaveLength(3 * 3);
     expect([out[0], out[1], out[2]]).toEqual([0, 32, 76]);
     expect([out[6], out[7], out[8]]).toEqual([253, 231, 37]);
   });
@@ -441,7 +441,7 @@ describe('colorForMode — classification', () => {
     const cloud = makeFullCloud();
     const result = colorForMode('classification', cloud);
     expect(result).toBeInstanceOf(Uint8Array);
-    expect(result.length).toBe(cloud.pointCount * 3);
+    expect(result).toHaveLength(cloud.pointCount * 3);
   });
 
   test('two points with the same class code get the same colour', () => {
@@ -481,7 +481,7 @@ describe('colorForMode — normal', () => {
     const cloud = makeNormalsCloud();
     const result = colorForMode('normal', cloud);
     expect(result).toBeInstanceOf(Uint8Array);
-    expect(result.length).toBe(cloud.pointCount * 3);
+    expect(result).toHaveLength(cloud.pointCount * 3);
   });
 
   test('encodes a unit normal direction as RGB (component −1…+1 → 0…255)', () => {
@@ -551,7 +551,7 @@ describe('colorForMode — coverage', () => {
       name: 'cov.las',
     });
     const out = colorForMode('coverage', cloud, { coverageGrid });
-    expect(out.length).toBe(4 * 3);
+    expect(out).toHaveLength(4 * 3);
     expect([out[0], out[1], out[2]]).toEqual([
       COVERAGE_STRONG.r, COVERAGE_STRONG.g, COVERAGE_STRONG.b,
     ]);

--- a/tests/commandPalette.test.ts
+++ b/tests/commandPalette.test.ts
@@ -91,7 +91,7 @@ describe('rankActions — sorts + filters action lists', () => {
 
   it('returns every action when the query is empty', () => {
     const ranked = rankActions('', ACTIONS);
-    expect(ranked.length).toBe(ACTIONS.length);
+    expect(ranked).toHaveLength(ACTIONS.length);
   });
 
   it('preserves the input order on an empty query (stable sort)', () => {
@@ -107,7 +107,7 @@ describe('rankActions — sorts + filters action lists', () => {
 
   it('drops actions that do not match at all', () => {
     const ranked = rankActions('snake oil', ACTIONS);
-    expect(ranked.length).toBe(0);
+    expect(ranked).toHaveLength(0);
   });
 
   it('finds an action by its section name', () => {

--- a/tests/contourAnalyticValidation.test.ts
+++ b/tests/contourAnalyticValidation.test.ts
@@ -50,7 +50,7 @@ describe('analytic contour validation (§24.1)', () => {
     const CX = 20.5, CY = 20.5; // world centre
     const cone = (x: number, y: number) => Math.hypot(x - (CX - 0.5), y - (CY - 0.5));
     const set = contoursAt(grid(cone, 41, 41), { intervalM: 5, levels: [5, 10, 15] });
-    expect(set.levels.length).toBe(3);
+    expect(set.levels).toHaveLength(3);
     for (const v of vertices(set)) {
       const r = Math.hypot(v.x - CX, v.y - CY);
       // Marching-squares linear interpolation on a smooth cone keeps every

--- a/tests/contourFeatureModel.test.ts
+++ b/tests/contourFeatureModel.test.ts
@@ -35,7 +35,7 @@ describe('buildFeatureModel', () => {
       crs: 'EPSG:32610',
       intervalM: 1,
     });
-    expect(model.features.length).toBe(3);
+    expect(model.features).toHaveLength(3);
     expect(model.features.map((f) => f.grade)).toEqual(['solid', 'gap', 'solid']);
     expect(model.features.every((f) => f.isIndex)).toBe(true);
   });
@@ -74,7 +74,7 @@ describe('buildFeatureModel', () => {
       crs: 'EPSG:32610',
       intervalM: 1,
     });
-    expect(model.features.length).toBe(1);
+    expect(model.features).toHaveLength(1);
     expect(model.features[0].closed).toBe(true);
   });
 

--- a/tests/contourOverlayGeometry.test.ts
+++ b/tests/contourOverlayGeometry.test.ts
@@ -33,7 +33,7 @@ describe('buildContourOverlayBuffers', () => {
   it('emits one segment per consecutive coordinate pair with elevation as Z', () => {
     const b = buildContourOverlayBuffers(model([feat('solid', [[0, 0], [1, 0], [2, 0]], 10, true)]));
     expect(b.segmentCount).toBe(2);
-    expect(b.positions.length).toBe(12); // 2 segs * 2 verts * 3
+    expect(b.positions).toHaveLength(12); // 2 segs * 2 verts * 3
     // First vertex (0,0) at elevation 10 → z slot.
     expect(Array.from(b.positions.slice(0, 3))).toEqual([0, 0, 10]);
     expect(Array.from(b.grades)).toEqual([0, 0]); // solid
@@ -58,6 +58,6 @@ describe('buildContourOverlayBuffers', () => {
   it('returns empty buffers for an empty model', () => {
     const b = buildContourOverlayBuffers(model([]));
     expect(b.segmentCount).toBe(0);
-    expect(b.positions.length).toBe(0);
+    expect(b.positions).toHaveLength(0);
   });
 });

--- a/tests/contourShapeStyle.test.ts
+++ b/tests/contourShapeStyle.test.ts
@@ -59,7 +59,7 @@ describe('applyContourShapeStyle', () => {
   it('crisp is identity — no vertex moved, same count', () => {
     const poly = line([v(0, 0), v(1, 1), v(2, 0), v(3, 2)]);
     const [out] = applyContourShapeStyle([poly], 'crisp');
-    expect(out.vertices.length).toBe(poly.vertices.length);
+    expect(out.vertices).toHaveLength(poly.vertices.length);
     out.vertices.forEach((p, i) => {
       expect(p.x).toBe(poly.vertices[i].x);
       expect(p.y).toBe(poly.vertices[i].y);
@@ -72,7 +72,7 @@ describe('applyContourShapeStyle', () => {
     const expected = chaikinSmooth(poly, { iterations: 2 });
     // Also identical to the historical bare call (no params) — the live default.
     const legacy = chaikinSmooth(poly);
-    expect(styled.vertices.length).toBe(expected.vertices.length);
+    expect(styled.vertices).toHaveLength(expected.vertices.length);
     styled.vertices.forEach((p, i) => {
       expect(p.x).toBe(expected.vertices[i].x);
       expect(p.y).toBe(expected.vertices[i].y);
@@ -120,7 +120,7 @@ describe('applyContourShapeStyle', () => {
       cellSizeM: 1,
       generalizeToleranceCells: 0.5,
     });
-    expect(explicit.vertices.length).toBe(byDefault.vertices.length);
+    expect(explicit.vertices).toHaveLength(byDefault.vertices.length);
     explicit.vertices.forEach((p, i) => {
       expect(p.x).toBe(byDefault.vertices[i].x);
       expect(p.y).toBe(byDefault.vertices[i].y);
@@ -149,7 +149,7 @@ describe('applyContourShapeStyle', () => {
       cellSizeM: 1,
       generalizeToleranceCells: 0,
     });
-    expect(genZero.vertices.length).toBe(smooth.vertices.length);
+    expect(genZero.vertices).toHaveLength(smooth.vertices.length);
   });
 
   it('honesty — a low-confidence/gap vertex keeps its EXACT coordinates under EVERY style', () => {
@@ -192,7 +192,7 @@ describe('simplifyPolyline', () => {
   it('removes collinear interior points but keeps endpoints', () => {
     const poly = line([v(0, 0), v(1, 0), v(2, 0), v(3, 0), v(4, 0)]);
     const out = simplifyPolyline(poly, 0.01);
-    expect(out.vertices.length).toBe(2);
+    expect(out.vertices).toHaveLength(2);
     expect([out.vertices[0].x, out.vertices[1].x]).toEqual([0, 4]);
   });
 
@@ -231,8 +231,8 @@ describe('simplifyPolyline', () => {
 
   it('returns short polylines and non-positive epsilon unchanged', () => {
     const two = line([v(0, 0), v(1, 1)]);
-    expect(simplifyPolyline(two, 1).vertices.length).toBe(2);
+    expect(simplifyPolyline(two, 1).vertices).toHaveLength(2);
     const poly = line([v(0, 0), v(1, 0), v(2, 0)]);
-    expect(simplifyPolyline(poly, 0).vertices.length).toBe(3);
+    expect(simplifyPolyline(poly, 0).vertices).toHaveLength(3);
   });
 });

--- a/tests/contourStudioLauncher.test.ts
+++ b/tests/contourStudioLauncher.test.ts
@@ -157,6 +157,6 @@ describe('renderContourStudioLauncher', () => {
 
   it('the available state carries no reasons list', () => {
     const card = renderContourStudioLauncher(AVAILABLE) as unknown as FakeEl;
-    expect(card.byClass('olv-contour-launcher-reasons').length).toBe(0);
+    expect(card.byClass('olv-contour-launcher-reasons')).toHaveLength(0);
   });
 });

--- a/tests/contourStudioPdf.test.ts
+++ b/tests/contourStudioPdf.test.ts
@@ -53,7 +53,7 @@ describe('buildContourStudioPdf (multipage Contour Studio PDF emitter)', () => {
     expect(bytes.byteLength).toBeGreaterThan(500);
 
     // One PDF page per model page/section (base model = 4 pages).
-    expect(model.pages.length).toBe(4);
+    expect(model.pages).toHaveLength(4);
     const loaded = await PDFDocument.load(bytes);
     expect(loaded.getPageCount()).toBe(model.pages.length);
   });
@@ -70,7 +70,7 @@ describe('buildContourStudioPdf (multipage Contour Studio PDF emitter)', () => {
       standardsTraceability: true,
     });
     expect(model.watermark).toBe('EXPLORATORY');
-    expect(model.pages.length).toBe(5);
+    expect(model.pages).toHaveLength(5);
 
     const bytes = await buildContourStudioPdf(model);
     expect(bytes[0]).toBe(PDF_MAGIC[0]);

--- a/tests/contourStudioWorkspace.test.ts
+++ b/tests/contourStudioWorkspace.test.ts
@@ -79,7 +79,7 @@ describe('renderContourStudioWorkspace', () => {
     const c = createContourStudioController();
     const root = renderContourStudioWorkspace({ controller: c, launch: AVAILABLE }) as unknown as FakeEl;
     const cards = root.byClass('olv-cs-purpose-card');
-    expect(cards.length).toBe(5);
+    expect(cards).toHaveLength(5);
     // The Survey Review card is the 2nd in order.
     const survey = cards[1];
     // Declutter: the description moved off-card onto hover (title) + aria-label.
@@ -90,7 +90,7 @@ describe('renderContourStudioWorkspace', () => {
     expect(c.getState().purpose).toBe('survey-review');
     // After re-render, survey is now the selected card.
     const selected = root.byClass('is-selected');
-    expect(selected.length).toBe(1);
+    expect(selected).toHaveLength(1);
   });
 
   it('evidence ladder claim reflects the launch state', () => {
@@ -108,9 +108,9 @@ describe('renderContourStudioWorkspace', () => {
     const root = renderContourStudioWorkspace({ controller: c, launch: AVAILABLE, onExport }) as unknown as FakeEl;
     const btns = root.byClass('olv-cs-export-btn');
     // Vector (GeoJSON, DXF, SVG) + Map sheet (PDF) + Data package (DEM, Complete) + Report.
-    expect(btns.length).toBe(7);
+    expect(btns).toHaveLength(7);
     // Gestalt grouping is present (labelled groups).
-    expect(root.byClass('olv-cs-export-group-label').length).toBe(4);
+    expect(root.byClass('olv-cs-export-group-label')).toHaveLength(4);
   });
 
   it('an available launch fires onExport for a chosen product', () => {
@@ -126,12 +126,12 @@ describe('renderContourStudioWorkspace', () => {
     const onExport = vi.fn();
     const root = renderContourStudioWorkspace({ controller: c, launch: UNAVAILABLE, onExport }) as unknown as FakeEl;
     const btns = root.byClass('olv-cs-export-btn');
-    expect(btns.length).toBe(7);
+    expect(btns).toHaveLength(7);
     expect(btns.every((b) => b.disabled)).toBe(true);
     btns[0].click();
     expect(onExport).not.toHaveBeenCalled();
     const claim = root.byClass('olv-cs-ladder-claim');
-    expect(claim.length).toBe(1);
+    expect(claim).toHaveLength(1);
     expect(claim[0].allText()).toContain('Blocked');
     expect(root.byClass('is-blocked').length).toBeGreaterThan(0);
   });
@@ -145,7 +145,7 @@ describe('renderContourStudioWorkspace', () => {
       ],
     };
     const root = renderContourStudioWorkspace({ controller: c, launch: AVAILABLE, review }) as unknown as FakeEl;
-    expect(root.byClass('olv-cs-review').length).toBe(1);
+    expect(root.byClass('olv-cs-review')).toHaveLength(1);
     expect(root.allText()).toContain('0.25 m · recommended');
   });
 

--- a/tests/contoursAt.test.ts
+++ b/tests/contoursAt.test.ts
@@ -81,7 +81,7 @@ describe('contoursAt', () => {
     // midway BETWEEN the cell centres. The pre-v0.4.4 corner registration
     // placed it at x = 0.5 (half a cell south-west of the true crossing).
     const set = contoursAt(grid((x) => x, 2, 2), { intervalM: 1, levels: [0.5] });
-    expect(set.levels.length).toBe(1);
+    expect(set.levels).toHaveLength(1);
     const segs = set.levels[0].segments;
     expect(segs.length).toBeGreaterThan(0);
     for (const s of segs) {
@@ -173,7 +173,7 @@ describe('contoursAt', () => {
       levels,
       maxLevels: 200,
     });
-    expect(set.levels.length).toBe(200);
+    expect(set.levels).toHaveLength(200);
     const kept = set.levels.map((l) => l.value);
     expect(kept[0]).toBe(0); // the minimum survives
     expect(kept[kept.length - 1]).toBe(399); // the summit level survives
@@ -186,7 +186,7 @@ describe('contoursAt', () => {
 
   it('returns no levels for an all-gap grid', () => {
     const set = contoursAt(grid((x) => x, 6, 6, { cov: () => 0 }), { intervalM: 1 });
-    expect(set.levels.length).toBe(0);
+    expect(set.levels).toHaveLength(0);
     expect(set.warnings.join(' ')).toMatch(/insufficient/i);
   });
 });
@@ -233,7 +233,7 @@ describe('contoursAt — marching-squares saddle disambiguation (exact bilinear 
       levels: [0.6],
     });
     const segs = set.levels[0].segments;
-    expect(segs.length).toBe(2);
+    expect(segs).toHaveLength(2);
     expect(isolatedCorners(segs)).toEqual([1, 3]);
     // Pin one hand-computed segment exactly: (1.3,0.5) → (1.5,0.7) around v1.
     const brSeg = segs.find((s) => nearest((s.x1 + s.x2) / 2, (s.y1 + s.y2) / 2, CORNERS) === 1)!;
@@ -253,7 +253,7 @@ describe('contoursAt — marching-squares saddle disambiguation (exact bilinear 
       levels: [0.9],
     });
     const segs = set.levels[0].segments;
-    expect(segs.length).toBe(2);
+    expect(segs).toHaveLength(2);
     expect(isolatedCorners(segs)).toEqual([0, 2]);
   });
 
@@ -265,7 +265,7 @@ describe('contoursAt — marching-squares saddle disambiguation (exact bilinear 
       levels: [0.6],
     });
     const segs = set.levels[0].segments;
-    expect(segs.length).toBe(2);
+    expect(segs).toHaveLength(2);
     expect(isolatedCorners(segs)).toEqual([0, 2]);
   });
 
@@ -283,7 +283,7 @@ describe('contoursAt — marching-squares saddle disambiguation (exact bilinear 
       levels: [1.1],
     });
     const segs = set.levels[0].segments;
-    expect(segs.length).toBe(2);
+    expect(segs).toHaveLength(2);
     expect(isolatedCorners(segs)).toEqual([0, 2]);
     // Pin the v0 (BL) segment exactly. Crossings at level 1.1:
     //   left  edge v3→v0 (0→10): t = 0.11 → (0.5, 1.39)
@@ -308,7 +308,7 @@ describe('contoursAt — marching-squares saddle disambiguation (exact bilinear 
       levels: [1.1],
     });
     const segs = set.levels[0].segments;
-    expect(segs.length).toBe(2);
+    expect(segs).toHaveLength(2);
     expect(isolatedCorners(segs)).toEqual([1, 3]);
   });
 });

--- a/tests/convertBatch.test.ts
+++ b/tests/convertBatch.test.ts
@@ -40,7 +40,7 @@ describe('buildZip', () => {
   it('handles an empty archive', () => {
     const zip = buildZip([]);
     expect(u32(zip, 0)).toBe(0x06054b50); // EOCD only
-    expect(zip.length).toBe(22);
+    expect(zip).toHaveLength(22);
   });
 });
 

--- a/tests/coverageHeatmap.test.ts
+++ b/tests/coverageHeatmap.test.ts
@@ -92,6 +92,6 @@ describe('coverageHeatmapImage — rasterises confidences to coloured pixels', (
     const img = coverageHeatmapImage({ confidence: [], coverage: [], cols: 0, rows: 0 });
     expect(img.width).toBe(0);
     expect(img.height).toBe(0);
-    expect(img.data.length).toBe(0);
+    expect(img.data).toHaveLength(0);
   });
 });

--- a/tests/coverageLabelHonesty.test.ts
+++ b/tests/coverageLabelHonesty.test.ts
@@ -83,7 +83,7 @@ describe('WIN 2 — capture-quality coverage label is honest to its computation'
     const root = panel.element as unknown as FakeEl;
 
     const labelEls = root.findAll((e) => e.ownText === 'Bounding area filled');
-    expect(labelEls.length).toBe(1);
+    expect(labelEls).toHaveLength(1);
 
     // The OLD dishonest phrasing must be gone.
     const allText = root.textContent;
@@ -94,7 +94,7 @@ describe('WIN 2 — capture-quality coverage label is honest to its computation'
     // "of footprint" qualifier the math doesn't support). Find the value node
     // whose title carries the honest fill-ratio definition.
     const honestHint = root.findAll((e) => /bounding-box footprint grid/.test(e.titleAttr));
-    expect(honestHint.length).toBe(1);
+    expect(honestHint).toHaveLength(1);
     // Its text is a plain "NN%" with nothing implying a traced outline.
     expect(honestHint[0].ownText).toMatch(/^\d+%$/);
   });

--- a/tests/densityColors.test.ts
+++ b/tests/densityColors.test.ts
@@ -31,12 +31,12 @@ describe('densityForChunk — voxel-grid heatmap colours', () => {
     ]);
     const out = densityForChunk({ positions, cellSize: 1 });
     expect(out.colors).toBeInstanceOf(Uint8Array);
-    expect(out.colors.length).toBe(4 * 3);
+    expect(out.colors).toHaveLength(4 * 3);
   });
 
   it('reports zero mean density on an empty chunk', () => {
     const out = densityForChunk({ positions: new Float32Array(0), cellSize: 1 });
-    expect(out.colors.length).toBe(0);
+    expect(out.colors).toHaveLength(0);
     expect(out.meanDensity).toBe(0);
     expect(out.maxObservedDensity).toBe(0);
   });

--- a/tests/deriveClassification.test.ts
+++ b/tests/deriveClassification.test.ts
@@ -128,7 +128,7 @@ describe('deriveClassification — degenerate inputs', () => {
   it('returns all-unclassified for an empty cloud', () => {
     const res = deriveClassification(new Float32Array(0), 0);
     expect(res.derived).toBe(true);
-    expect(res.codes.length).toBe(0);
+    expect(res.codes).toHaveLength(0);
   });
 
   it('returns all-unclassified for a degenerate (single-footprint) cloud', () => {
@@ -142,7 +142,7 @@ describe('deriveClassification — degenerate inputs', () => {
   it('does not crash on NaN coordinates', () => {
     const pos = new Float32Array([0, 0, 0, NaN, NaN, NaN, 10, 10, 0, 5, 5, 3]);
     const res = deriveClassification(pos, 4);
-    expect(res.codes.length).toBe(4);
+    expect(res.codes).toHaveLength(4);
   });
 });
 

--- a/tests/deriveClassificationAsync.test.ts
+++ b/tests/deriveClassificationAsync.test.ts
@@ -41,7 +41,7 @@ describe('deriveClassificationAsync', () => {
     };
     const res = await deriveClassificationAsync(positions, n, { cellSizeM: 1 }, undefined, client);
     expect(res.derived).toBe(true);
-    expect(res.codes.length).toBe(n);
+    expect(res.codes).toHaveLength(n);
     expect(getLastClassifyComputePath()).toBe('worker');
   });
 
@@ -65,7 +65,7 @@ describe('deriveClassificationAsync', () => {
       classify: () => Promise.reject(new Error('worker construction failed')),
     };
     const res = await deriveClassificationAsync(positions, n, { cellSizeM: 1 }, undefined, failing);
-    expect(res.codes.length).toBe(n);
+    expect(res.codes).toHaveLength(n);
     expect(getLastClassifyComputePath()).toBe('fallback');
   });
 

--- a/tests/disposalContracts.test.ts
+++ b/tests/disposalContracts.test.ts
@@ -197,7 +197,7 @@ describe('scheduleReplay — timer disposal', () => {
 describe('WorkflowSession — event accumulation', () => {
   it('a fresh session reports zero events', () => {
     const session = new WorkflowSession(() => 0);
-    expect(session.events().length).toBe(0);
+    expect(session.events()).toHaveLength(0);
     expect(session.hasContent).toBe(false);
   });
 
@@ -217,7 +217,7 @@ describe('WorkflowSession — event accumulation', () => {
     session.push({ type: 'camera-preset', name: 'top' });
     const snap = session.events();
     snap.length = 0;
-    expect(session.events().length).toBe(1);
+    expect(session.events()).toHaveLength(1);
   });
 });
 
@@ -256,7 +256,7 @@ describe('parseWorkflow — malformed input safety', () => {
     const r = parseWorkflow(json);
     expect(r.ok).toBe(true);
     if (r.ok) {
-      expect(r.workflow.events.length).toBe(2);
+      expect(r.workflow.events).toHaveLength(2);
     }
   });
 });

--- a/tests/e57IntegerTruncation.test.ts
+++ b/tests/e57IntegerTruncation.test.ts
@@ -45,7 +45,7 @@ describe('decodeField — integer / scaledInteger truncation', () => {
       { name: 't', type: 'integer', bitWidth: 8, minimum: 0 },
       4,
     );
-    expect(out.length).toBe(4);
+    expect(out).toHaveLength(4);
     expect(out[0]).toBe(1);
     expect(out[1]).toBe(2);
     expect(out[2]).toBe(3);

--- a/tests/ept.test.ts
+++ b/tests/ept.test.ts
@@ -242,9 +242,9 @@ test('parseHierarchyFile partitions nodes vs links correctly', () => {
     '2-3-3-3': 20,
   });
   const result = parseHierarchyFile(text);
-  expect(result.entries.length).toBe(5);
-  expect(result.nodes.length).toBe(4);   // four entries with positive value
-  expect(result.links.length).toBe(1);   // one with -1
+  expect(result.entries).toHaveLength(5);
+  expect(result.nodes).toHaveLength(4);   // four entries with positive value
+  expect(result.links).toHaveLength(1);   // one with -1
   expect(result.totalPoints).toBe(220);  // 100 + 50 + 50 + 20
 });
 
@@ -267,7 +267,7 @@ test('partitionHierarchyMap helper round-trips a typed map', () => {
 test('synthetic fixture hierarchy file parses cleanly', () => {
   const text = readFileSync(join(FIXTURE_DIR, 'ept-hierarchy', '0-0-0-0.json'), 'utf8');
   const result = parseHierarchyFile(text);
-  expect(result.nodes.length).toBe(1);
+  expect(result.nodes).toHaveLength(1);
   expect(result.nodes[0].key).toEqual({ d: 0, x: 0, y: 0, z: 0 });
   expect(result.nodes[0].value).toBe(100);
 });
@@ -279,7 +279,7 @@ test('synthetic fixture hierarchy file parses cleanly', () => {
 test('eptChildKeys produces the 8 standard octree children', () => {
   const root = { d: 0, x: 0, y: 0, z: 0 };
   const children = eptChildKeys(root);
-  expect(children.length).toBe(8);
+  expect(children).toHaveLength(8);
   // Every child is at depth 1 with coords in {0,1}.
   for (const c of children) {
     expect(c.d).toBe(1);

--- a/tests/eptLaszipDecode.test.ts
+++ b/tests/eptLaszipDecode.test.ts
@@ -36,12 +36,12 @@ test('decodeEptLaszipTile decodes the tiny.laz fixture into a DecodedChunk', asy
   const decoded = await decodeEptLaszipTile(TINY_LAZ_BUF, [0, 0, 0]);
   // tiny.laz has 12 points (the bundled fixture's actual count).
   expect(decoded.pointCount).toBe(12);
-  expect(decoded.positions.length).toBe(12 * 3);
-  expect(decoded.intensity.length).toBe(12);
-  expect(decoded.classification.length).toBe(12);
-  expect(decoded.returnNumber.length).toBe(12);
-  expect(decoded.returnCount.length).toBe(12);
-  expect(decoded.gpsTime.length).toBe(12);
+  expect(decoded.positions).toHaveLength(12 * 3);
+  expect(decoded.intensity).toHaveLength(12);
+  expect(decoded.classification).toHaveLength(12);
+  expect(decoded.returnNumber).toHaveLength(12);
+  expect(decoded.returnCount).toHaveLength(12);
+  expect(decoded.gpsTime).toHaveLength(12);
   // tiny.laz has no RGB (PDRF without colour); the field is undefined.
   expect(decoded.rgb).toBeUndefined();
 });

--- a/tests/eptStreaming.test.ts
+++ b/tests/eptStreaming.test.ts
@@ -91,9 +91,9 @@ test('decodeEptBinaryTile decodes the synthetic fixture cleanly', () => {
   const decoded = decodeEptBinaryTile(buffer, 100, meta.schema, renderOrigin);
 
   expect(decoded.pointCount).toBe(100);
-  expect(decoded.positions.length).toBe(300);
-  expect(decoded.intensity.length).toBe(100);
-  expect(decoded.classification.length).toBe(100);
+  expect(decoded.positions).toHaveLength(300);
+  expect(decoded.intensity).toHaveLength(100);
+  expect(decoded.classification).toHaveLength(100);
 
   // Every position is in render-origin-subtracted local space — the
   // fixture's cube is 100 m × 100 m × 50 m, so EVERY local x/y is within
@@ -132,11 +132,11 @@ test('EptOctree loads the synthetic fixture and registers one root node', async 
   );
   await octree.loadFullHierarchy();
   expect(octree.fullyLoaded).toBe(true);
-  expect(octree.errors.length).toBe(0);
+  expect(octree.errors).toHaveLength(0);
   // A whole hierarchy with no dropped file → complete, gradeable "exact".
   expect(octree.isComplete).toBe(true);
   const nodes = octree.nodes();
-  expect(nodes.length).toBe(1);
+  expect(nodes).toHaveLength(1);
   expect(nodes[0].record.id).toBe('0-0-0-0');
   expect(nodes[0].record.pointCount).toBe(100);
 });
@@ -205,7 +205,7 @@ test('progressive hierarchy: an initial paint attaches before the full index loa
   // Child links are complete AND never duplicated across the two passes —
   // the root gained 1-1-0-0 without re-adding 1-0-0-0.
   expect(new Set(octree.store.get('0-0-0-0')!.childIds)).toEqual(new Set(['1-0-0-0', '1-1-0-0']));
-  expect(octree.store.get('0-0-0-0')!.childIds.length).toBe(2);
+  expect(octree.store.get('0-0-0-0')!.childIds).toHaveLength(2);
   expect(octree.store.get('1-1-0-0')!.childIds).toEqual(['2-2-0-0']);
 });
 
@@ -250,12 +250,12 @@ test('a small hierarchy that fits the first-paint budget loads fully in one call
   const octree = multiFileOctree();
   await octree.loadInitialHierarchy(64); // budget exceeds the 3 files
   expect(octree.fullyLoaded).toBe(true);
-  expect(octree.nodes().length).toBe(4);
+  expect(octree.nodes()).toHaveLength(4);
 });
 
 test('EptOctree.childKeysOf returns the 8 standard octree children', () => {
   const children = EptOctree.childKeysOf({ d: 0, x: 0, y: 0, z: 0 });
-  expect(children.length).toBe(8);
+  expect(children).toHaveLength(8);
 });
 
 test('EptOctree handles a fetcher failure without crashing — surfaces in errors', async () => {
@@ -287,7 +287,7 @@ test('EptStreamingPointCloud.open round-trips the fixture into a streaming sourc
   expect(cloud.sourcePointCount).toBe(100);
   expect(cloud.dataType).toBe('binary');
   expect(cloud.maxDepth()).toBe(0);
-  expect(cloud.octree.nodes().length).toBe(1);
+  expect(cloud.octree.nodes()).toHaveLength(1);
 });
 
 test('EptStreamingPointCloud.readNodeChunk fetches the tile bytes', async () => {
@@ -318,7 +318,7 @@ test('EptStreamingPointCloud.decodeBinary recovers points within the cube', asyn
   const bytes = await cloud.readNodeChunk(root.record);
   const decoded = cloud.decodeBinary(bytes, root.record.pointCount);
   expect(decoded.pointCount).toBe(100);
-  expect(decoded.positions.length).toBe(300);
+  expect(decoded.positions).toHaveLength(300);
 });
 
 test('EptStreamingPointCloud pins the RGB bit-depth from the first decoded tile', async () => {

--- a/tests/evidenceRecord.test.ts
+++ b/tests/evidenceRecord.test.ts
@@ -250,7 +250,7 @@ describe('summariseStages', () => {
 describe('bindMutationEvidence', () => {
   it('reports absence only when the caller requires a result', () => {
     expect(bindMutationEvidence(null, RELEASE_COMMIT, { required: false }).problems).toEqual([]);
-    expect(bindMutationEvidence(null, RELEASE_COMMIT, { required: true }).problems.length).toBe(1);
+    expect(bindMutationEvidence(null, RELEASE_COMMIT, { required: true }).problems).toHaveLength(1);
   });
 
   it('does not claim coverage when the release commit is unknown', () => {

--- a/tests/exportPanelCrs.test.ts
+++ b/tests/exportPanelCrs.test.ts
@@ -107,7 +107,7 @@ describe('ExportPanel — CRS step auto-collapse', () => {
     expect(isHidden(note)).toBe(true);
     // The three CRS mode pills are present + their container visible.
     const keep = root.findOwnText('Keep');
-    expect(keep.length).toBe(1);
+    expect(keep).toHaveLength(1);
     expect(isHidden(keep[0])).toBe(false);
   });
 
@@ -128,7 +128,7 @@ describe('ExportPanel — CRS step auto-collapse', () => {
     // but their row carries display:none).
     const pillRows = root.findByClass('olv-bc-pills');
     // [0] = format row (visible), [1] = CRS row (hidden when collapsed).
-    expect(pillRows.length).toBe(2);
+    expect(pillRows).toHaveLength(2);
     expect(isHidden(pillRows[1])).toBe(true);
   });
 

--- a/tests/exportPngTextChunks.test.ts
+++ b/tests/exportPngTextChunks.test.ts
@@ -76,7 +76,7 @@ test('a Latin-1 entry is spliced as one tEXt chunk immediately before IEND', () 
   ]);
 
   // 12 bytes of chunk framing + 8 (keyword) + 1 (NUL) + 15 (text) = 36.
-  expect(out.length).toBe(TINY_PNG.length + 36);
+  expect(out).toHaveLength(TINY_PNG.length + 36);
   // Everything before the insert point is byte-identical to the input.
   expect([...out.slice(0, IEND_OFFSET)]).toEqual([...TINY_PNG.slice(0, IEND_OFFSET)]);
   // The IEND chunk is untouched and still terminates the file.

--- a/tests/exportStudio.test.ts
+++ b/tests/exportStudio.test.ts
@@ -387,7 +387,7 @@ test('orthographic-rgb render: a null framed render falls back to the view captu
   await orthographicRgbExporter.render(stubContext(adapter), {}).catch(() => {
     /* Node has no Image/canvas for the report-card composition — fine. */
   });
-  expect(adapter.framedCalls.length).toBe(1);
+  expect(adapter.framedCalls).toHaveLength(1);
   expect(snapshotCalled).toBe(true);
   warnSpy.mockRestore();
 });

--- a/tests/exportSubsetDisclosure.test.ts
+++ b/tests/exportSubsetDisclosure.test.ts
@@ -51,7 +51,7 @@ describe('subset disclosure in text exports', () => {
     expect(subset).toContain('250');
     expect(subset).toContain('1,000');
     // The rows written must match the held count, not the declared one.
-    expect(text.split('\n').filter((l) => l && !l.startsWith('#')).length).toBe(250);
+    expect(text.split('\n').filter((l) => l && !l.startsWith('#'))).toHaveLength(250);
   });
 
   it('names the load stride when one caused the subset', () => {

--- a/tests/exportWriters.test.ts
+++ b/tests/exportWriters.test.ts
@@ -88,7 +88,7 @@ describe('toGeoJSON', () => {
   it('produces a valid FeatureCollection with per-run properties', () => {
     const gj = toGeoJSON(m) as any;
     expect(gj.type).toBe('FeatureCollection');
-    expect(gj.features.length).toBe(2);
+    expect(gj.features).toHaveLength(2);
     expect(gj.features[0].geometry.type).toBe('LineString');
     // Elevation rides in the coordinate Z (3D position), not only the property,
     // so 3D-aware GIS/CAD don't import the contours flat at Z=0.
@@ -147,7 +147,7 @@ describe('svgContours', () => {
     );
     expect(svg).toMatch(/<svg/);
     expect(svg).toMatch(/viewBox=/);
-    expect((svg.match(/<path/g) || []).length).toBe(2);
+    expect(svg.match(/<path/g) || []).toHaveLength(2);
     expect(svg).toMatch(/stroke-dasharray/); // the dashed feature
     expect(svg).toMatch(/data-elevation="10"/);
   });
@@ -195,7 +195,7 @@ describe('svgContours', () => {
     );
     // Collect the start-Y of each contour <path> M command (skip marginalia).
     const ys = [...svg.matchAll(/<path d="M[\d.]+ ([\d.]+)/g)].map((m) => parseFloat(m[1]));
-    expect(ys.length).toBe(2);
+    expect(ys).toHaveLength(2);
     const [yAtWorld0, yAtWorld10] = ys; // features emitted in input order
     expect(yAtWorld10).toBeLessThan(yAtWorld0);
   });

--- a/tests/flaiCatalog.test.ts
+++ b/tests/flaiCatalog.test.ts
@@ -37,7 +37,7 @@ describe('FLAI Open LiDAR Data catalog entries', () => {
     // authoritative AHN source. If a future change adds or removes an
     // entry without updating the expected count, this assertion fails
     // loudly.
-    expect(flaiEntries.length).toBe(2);
+    expect(flaiEntries).toHaveLength(2);
   });
 
   it.each(flaiEntries)('$id streams from the documented S3 bucket', (loc) => {

--- a/tests/floorPlan.test.ts
+++ b/tests/floorPlan.test.ts
@@ -100,7 +100,7 @@ describe('wallSlice', () => {
 
   it('exposes per-band-point z parallel to xs/ys', () => {
     const slice = wallSlice(room(), { upAxis: 'z' });
-    expect(slice.zs.length).toBe(slice.count);
+    expect(slice.zs).toHaveLength(slice.count);
     // Every kept z lies inside the band actually used [anchor+low, anchor+high].
     for (let i = 0; i < slice.count; i++) {
       expect(slice.zs[i]).toBeGreaterThanOrEqual(slice.bandLowUsedM - 1e-6);
@@ -308,7 +308,7 @@ describe('vectorize', () => {
 
   it('traces a single cell as its CCW unit square', () => {
     const rings = traceMaskBoundaries(unitGrid([1], 1, 1));
-    expect(rings.length).toBe(1);
+    expect(rings).toHaveLength(1);
     expect(rings[0]).toEqual([[0, 0], [1, 0], [1, 1], [0, 1]]);
     expect(ringSignedArea(rings[0])).toBeCloseTo(1, 10);
   });
@@ -316,7 +316,7 @@ describe('vectorize', () => {
   it('traces a hole as a separate CW ring (nonzero winding renders it open)', () => {
     // 3×3 block with the centre empty: outer ring area +9, hole ring area −1.
     const rings = traceMaskBoundaries(unitGrid([1, 1, 1, 1, 0, 1, 1, 1, 1], 3, 3));
-    expect(rings.length).toBe(2);
+    expect(rings).toHaveLength(2);
     const areas = rings.map(ringSignedArea).sort((a, b) => a - b);
     expect(areas[0]).toBeCloseTo(-1, 10);
     expect(areas[1]).toBeCloseTo(9, 10);
@@ -325,7 +325,7 @@ describe('vectorize', () => {
   it('traces disjoint regions as separate rings', () => {
     // Two cells separated by an empty column.
     const rings = traceMaskBoundaries(unitGrid([1, 0, 1], 3, 1));
-    expect(rings.length).toBe(2);
+    expect(rings).toHaveLength(2);
     expect(rings.map(ringSignedArea).every((a) => Math.abs(a - 1) < 1e-9)).toBe(true);
   });
 
@@ -333,10 +333,10 @@ describe('vectorize', () => {
     // A 2×2 block traces with edge midpoints (8 points); ε = 0.1 removes the
     // collinear midpoints and keeps the 4 corners — area is preserved.
     const rings = traceMaskBoundaries(unitGrid([1, 1, 1, 1], 2, 2));
-    expect(rings.length).toBe(1);
-    expect(rings[0].length).toBe(8);
+    expect(rings).toHaveLength(1);
+    expect(rings[0]).toHaveLength(8);
     const simple = simplifyRing(rings[0], 0.1);
-    expect(simple.length).toBe(4);
+    expect(simple).toHaveLength(4);
     expect(Math.abs(ringSignedArea(simple))).toBeCloseTo(4, 10);
   });
 
@@ -378,7 +378,7 @@ describe('vectorize', () => {
     const snapped = snapRingToAxes(ring, 0);
     // Segment targets: south y = 0 (mean of ±0.05), east x = 10.025,
     // north y = 8.01, west x = 0.
-    expect(snapped.length).toBe(4);
+    expect(snapped).toHaveLength(4);
     expect(snapped[0][0]).toBeCloseTo(0, 9);
     expect(snapped[0][1]).toBeCloseTo(0, 9);
     expect(snapped[1][0]).toBeCloseTo(10.025, 9);

--- a/tests/floorPlanBudget.test.ts
+++ b/tests/floorPlanBudget.test.ts
@@ -100,7 +100,7 @@ describe('floor-plan emitted-geometry budget (dense noisy room)', () => {
   it('the decorative floor fill carries no hole subpaths and a bounded ring count', () => {
     // Pre-fix this floor traced 200+ CW hole rings (occlusion shadows).
     const holes = model.floorRings.filter((r) => ringSignedArea(r) < 0);
-    expect(holes.length).toBe(0);
+    expect(holes).toHaveLength(0);
     expect(model.floorRings.length).toBeLessThanOrEqual(24);
   });
 
@@ -173,7 +173,7 @@ describe('limitUnknownGaps', () => {
     const gaps: PlanGap[] = [];
     for (let i = 0; i < 120; i++) gaps.push(gap(0, i * 1.0, 0.3 + 0.01 * i));
     const out = limitUnknownGaps(gaps, 0.05);
-    expect(out.length).toBe(MAX_UNKNOWN_GAPS);
+    expect(out).toHaveLength(MAX_UNKNOWN_GAPS);
     // The widest survived.
     expect(out.some((g) => Math.abs(g.widthM - (0.3 + 0.01 * 119)) < 1e-9)).toBe(true);
     // The narrowest did not.
@@ -182,7 +182,7 @@ describe('limitUnknownGaps', () => {
 
   it('merges near-duplicates (same opening traced twice keeps the wider)', () => {
     const out = limitUnknownGaps([gap(0, 0, 0.8), gap(0.02, 0.02, 0.78), gap(5, 5, 0.6)], 0.05);
-    expect(out.length).toBe(2);
+    expect(out).toHaveLength(2);
     expect(out[0].widthM).toBeCloseTo(0.8, 9);
   });
 });

--- a/tests/floorPlanCenterline.test.ts
+++ b/tests/floorPlanCenterline.test.ts
@@ -251,7 +251,7 @@ describe('classifyWallGaps', () => {
 
   it('square jambs across a door-width gap classify as a door', () => {
     const gaps = gapsOf(gapGrid(18)); // 0.9 m at 0.05 m cells
-    expect(gaps.length).toBe(1);
+    expect(gaps).toHaveLength(1);
     expect(gaps[0].kind).toBe('door');
     expect(gaps[0].widthM).toBeGreaterThanOrEqual(DOOR_MIN_M);
     expect(gaps[0].widthM).toBeLessThanOrEqual(DOOR_MAX_M);
@@ -264,20 +264,20 @@ describe('classifyWallGaps', () => {
   it('skewed (ragged) facing ends classify as an unknown gap, not a door', () => {
     // Same door-width gap, right run shifted 12 cells: cos ≈ 0.6 — ragged.
     const gaps = gapsOf(gapGrid(14, 12));
-    expect(gaps.length).toBe(1);
+    expect(gaps).toHaveLength(1);
     expect(gaps[0].kind).toBe('unknown');
   });
 
   it('a wider-than-door gap with square ends is unknown (not claimed as a door)', () => {
     const gaps = gapsOf(gapGrid(36)); // 1.8 m: square but not door width
-    expect(gaps.length).toBe(1);
+    expect(gaps).toHaveLength(1);
     expect(gaps[0].kind).toBe('unknown');
     expect(gaps[0].widthM).toBeGreaterThan(DOOR_MAX_M);
   });
 
   it('holes wider than GAP_MAX_M are no gap at all (honest missing data)', () => {
     const gaps = gapsOf(gapGrid(Math.ceil(GAP_MAX_M / 0.05) + 14));
-    expect(gaps.length).toBe(0);
+    expect(gaps).toHaveLength(0);
   });
 
   it('an L-corner is not a gap (the runs do not face each other)', () => {
@@ -302,7 +302,7 @@ describe('convexHullRing', () => {
       expect(cross).toBeGreaterThanOrEqual(0);
     }
     // The hull is the 4-corner bounding rectangle here.
-    expect(hull.length).toBe(4);
+    expect(hull).toHaveLength(4);
     expect(Math.abs(ringSignedArea(hull))).toBeCloseTo(12, 5);
     expect(Math.abs(ringSignedArea(hull))).toBeGreaterThan(Math.abs(ringSignedArea(ring)));
   });
@@ -369,7 +369,7 @@ describe('extractFloorPlan — centerline pass end-to-end', () => {
     );
     expect(clean.thicknessNormalized).toBe(false);
     expect(clean.reasons.some((r) => /collapsed onto its centerline/i.test(r))).toBe(false);
-    expect(clean.unknownGaps.length).toBe(0);
+    expect(clean.unknownGaps).toHaveLength(0);
   });
 });
 

--- a/tests/floorPlanPipeline.test.ts
+++ b/tests/floorPlanPipeline.test.ts
@@ -239,7 +239,7 @@ describe('extractFloorPlan — robustness and fallbacks', () => {
     expect(model.usedWallBand).toBe(true);
     expect(model.floorBasis).toBe('percentile');
     expect(model.floorAreaM2).toBeNull();
-    expect(model.floorRings.length).toBe(0);
+    expect(model.floorRings).toHaveLength(0);
     expect(model.wallRings.length).toBeGreaterThanOrEqual(1);
     expect(Math.abs(model.widthM - 10)).toBeLessThan(0.2);
     expect(Math.abs(model.depthM - 8)).toBeLessThan(0.2);
@@ -282,8 +282,8 @@ describe('extractFloorPlan — robustness and fallbacks', () => {
     const t: number[] = [];
     for (let i = 0; i < 150; i++) t.push(rnd() * 10, rnd() * 8, rnd() * 2.5);
     const model = extractFloorPlan(Float32Array.from(t), { upAxis: 'z' });
-    expect(model.wallRings.length).toBe(0);
-    expect(model.floorRings.length).toBe(0);
+    expect(model.wallRings).toHaveLength(0);
+    expect(model.floorRings).toHaveLength(0);
     expect(model.floorAreaM2).toBeNull();
     expect(model.widthM).toBe(0);
     expect(model.reasons[0]).toMatch(/Too few points/);
@@ -365,7 +365,7 @@ describe('extractFloorPlan — multi-room interior', () => {
       }
       return a < 0;
     });
-    expect(holes.length).toBe(2);
+    expect(holes).toHaveLength(2);
   });
 
   it('traces the shared wall and both far walls', () => {

--- a/tests/floorPlanQuickWins.test.ts
+++ b/tests/floorPlanQuickWins.test.ts
@@ -140,10 +140,10 @@ describe('door-leaf arcs — one swing symbol per classified doorway', () => {
 
   it('renders exactly one door-arc path per classified doorway', () => {
     const arcs = svg.match(/class="door-arc"/g) ?? [];
-    expect(arcs.length).toBe(model.doorways.length);
+    expect(arcs).toHaveLength(model.doorways.length);
     // Each symbol is leaf line + quarter arc: M …  L … A r r 0 0 s …
     const ds = [...svg.matchAll(/class="door-arc" d="M[^"]*L[^"]*A([\d.]+) ([\d.]+) 0 0 [01][^"]*"/g)];
-    expect(ds.length).toBe(model.doorways.length);
+    expect(ds).toHaveLength(model.doorways.length);
   });
 
   it('the arc radius equals the doorway clear width at sheet scale', () => {
@@ -159,14 +159,14 @@ describe('door-leaf arcs — one swing symbol per classified doorway', () => {
 
   it('draws two arcs for two doors', () => {
     const two = extractFloorPlan(rectRoom([[2.0, 3.0], [6.5, 7.5]]), { upAxis: 'z' });
-    expect(two.doorways.length).toBe(2);
+    expect(two.doorways).toHaveLength(2);
     const svg2 = floorPlanSvg(two, { unitSystem: 'metric' });
-    expect((svg2.match(/class="door-arc"/g) ?? []).length).toBe(2);
+    expect(svg2.match(/class="door-arc"/g) ?? []).toHaveLength(2);
   });
 
   it('no door symbols without classified doorways', () => {
     const plain = extractFloorPlan(rectRoom(), { upAxis: 'z' });
-    expect(plain.doorways.length).toBe(0);
+    expect(plain.doorways).toHaveLength(0);
     expect(floorPlanSvg(plain, {})).not.toContain('door-arc');
   });
 
@@ -232,7 +232,7 @@ describe('region area labels — floor-fill polygon areas, honestly approximate'
     // supersede the approximate region labels exactly as before.
     const twoRoom = extractFloorPlan(twoRoomCloud([3.5, 4.4]), { upAxis: 'z' });
     expect(twoRoom.roomSegmentation).toBe('rooms');
-    expect(twoRoom.rooms.length).toBe(2); // the engine partitioned the space
+    expect(twoRoom.rooms).toHaveLength(2); // the engine partitioned the space
     const withRooms = floorPlanSvg(twoRoom, { unitSystem: 'metric' });
     expect(withRooms).toContain('class="room-labels"');
     expect(withRooms).toMatch(/Room 1 · [\d.]+ m²/);
@@ -284,7 +284,7 @@ describe('region area labels — floor-fill polygon areas, honestly approximate'
     // rounding tolerance), not the un-reconciled 120 m².
     expect(sum).toBeLessThanOrEqual(floor + 0.2);
     // The reconcile is proportional (not a clamp-to-zero): both regions survive.
-    expect([...footer.matchAll(/m²/g)].length).toBe(2);
+    expect([...footer.matchAll(/m²/g)]).toHaveLength(2);
 
     // Pure helper contract: scale ≤ 1, makes the sum equal the floor area, and
     // never scales UP when the raw sum already fits.
@@ -336,7 +336,7 @@ describe('ringObservedFraction — outline support in the pre-close mask', () =>
 
   it('the real pipeline threads per-ring fractions aligned with wallRings', () => {
     const model = extractFloorPlan(rectRoom(), { upAxis: 'z' });
-    expect(model.wallRingObservedFrac.length).toBe(model.wallRings.length);
+    expect(model.wallRingObservedFrac).toHaveLength(model.wallRings.length);
     // A cleanly sampled synthetic room is solidly observed.
     expect(Math.max(...model.wallRingObservedFrac)).toBeGreaterThan(OBSERVED_FRAC_MIN);
     for (const f of model.wallRingObservedFrac) {
@@ -393,7 +393,7 @@ describe('wall confidence styling — tinted poché under the threshold', () => 
     const weak = svg.match(/class="wall-weak" d="([^"]+)"/);
     expect(weak).not.toBeNull();
     // Both subpaths (outer + hole) live in the weak path: 2 closed loops.
-    expect((weak![1].match(/Z/g) ?? []).length).toBe(2);
+    expect(weak![1].match(/Z/g) ?? []).toHaveLength(2);
     expect(svg).not.toContain('class="wall-poche"');
   });
 });

--- a/tests/floorPlanRealism.test.ts
+++ b/tests/floorPlanRealism.test.ts
@@ -267,7 +267,7 @@ describe('mergeAxisJogs', () => {
       [0, 0], [10, 0], [10, 1.05], [6, 1.05], [6, 1], [0, 1],
     ];
     const out = mergeAxisJogs(ring, 0, 0.06);
-    expect(out.length).toBe(4);
+    expect(out).toHaveLength(4);
     const ys = out.map((p) => p[1]).sort((a, b) => a - b);
     // Weighted mean of 4 m at 1.05 and 6 m at 1.00 = 1.02.
     expect(ys[2]).toBeCloseTo(1.02, 6);
@@ -280,7 +280,7 @@ describe('mergeAxisJogs', () => {
       [0, 0], [10, 0], [10, 1.4], [6, 1.4], [6, 1], [0, 1],
     ];
     const out = mergeAxisJogs(ring, 0, 0.06);
-    expect(out.length).toBe(6);
+    expect(out).toHaveLength(6);
   });
 
   it('works in a rotated dominant-axis frame', () => {
@@ -292,7 +292,7 @@ describe('mergeAxisJogs', () => {
       [0, 0], [10, 0], [10, 1.05], [6, 1.05], [6, 1], [0, 1],
     ] as const).map(rot);
     const out = mergeAxisJogs(ring, theta, 0.06);
-    expect(out.length).toBe(4);
+    expect(out).toHaveLength(4);
   });
 });
 

--- a/tests/floorPlanRooms.test.ts
+++ b/tests/floorPlanRooms.test.ts
@@ -78,7 +78,7 @@ describe('detectRooms — flood fill against walls + closed doorway spans', () =
     // (which has its own test); production uses the default floor.
     const res = detectRooms(twoRoomGrid(), [dividerDoor], null, { minRoomAreaM2: 1.0 });
     expect(res.closedDoorways).toBe(1);
-    expect(res.rooms.length).toBe(2);
+    expect(res.rooms).toHaveLength(2);
     // Hand truth: 18 × 18 = 324 free cells per side. The door barrier
     // (radius 1.1 cells, so a DIAGONAL span can never be slipped by the
     // 4-connected flood) provably also paints col 19, rows 9–12: distance
@@ -96,7 +96,7 @@ describe('detectRooms — flood fill against walls + closed doorway spans', () =
 
   it('open-plan (no classified door): ONE merged region — no fake wall', () => {
     const res = detectRooms(twoRoomGrid(), []);
-    expect(res.rooms.length).toBe(1);
+    expect(res.rooms).toHaveLength(1);
     // 324 + 324 + the 2×4-cell gap corridor = 656 cells = 6.56 m².
     expect(res.rooms[0].cellCount).toBe(656);
     expect(res.rooms[0].areaM2).toBeCloseTo(6.56, 10);
@@ -106,14 +106,14 @@ describe('detectRooms — flood fill against walls + closed doorway spans', () =
     const unknownGap: PlanGap = { ...dividerDoor, kind: 'unknown' };
     const res = detectRooms(twoRoomGrid(), [unknownGap]);
     expect(res.closedDoorways).toBe(0);
-    expect(res.rooms.length).toBe(1);
+    expect(res.rooms).toHaveLength(1);
   });
 
   it('unenclosed walls yield no rooms (free space leaks to the border)', () => {
     const { mask, box } = blank(40, 20);
     box(0, 0, 39, 1); box(0, 18, 39, 19); // two parallel walls, open ends
     const res = detectRooms(toGrid(mask, 40, 20), []);
-    expect(res.rooms.length).toBe(0);
+    expect(res.rooms).toHaveLength(0);
   });
 
   it(`enclosures under ${ROOM_MIN_AREA_M2} m² are slivers, not rooms`, () => {
@@ -121,7 +121,7 @@ describe('detectRooms — flood fill against walls + closed doorway spans', () =
     const { mask, box } = blank(12, 12);
     box(0, 0, 11, 1); box(0, 10, 11, 11); box(0, 0, 1, 11); box(10, 0, 11, 11);
     const res = detectRooms(toGrid(mask, 12, 12), []);
-    expect(res.rooms.length).toBe(0);
+    expect(res.rooms).toHaveLength(0);
   });
 
   it('an L-shaped enclosure is one room with the exact cell-count area', () => {
@@ -131,7 +131,7 @@ describe('detectRooms — flood fill against walls + closed doorway spans', () =
     box(0, 0, 31, 1); box(0, 30, 31, 31); box(0, 0, 1, 31); box(30, 0, 31, 31);
     box(16, 16, 31, 31);
     const res = detectRooms(toGrid(mask, 32, 32), []);
-    expect(res.rooms.length).toBe(1);
+    expect(res.rooms).toHaveLength(1);
     expect(res.rooms[0].cellCount).toBe(28 * 28 - 14 * 14);
     expect(res.rooms[0].areaM2).toBeCloseTo(5.88, 10);
     // The pole-of-inaccessibility label sits in free space inside the L.
@@ -168,7 +168,7 @@ describe('extractFloorPlan — rooms end-to-end', () => {
     const model = extractFloorPlan(twoRoomCloud([3.5, 4.4]), { upAxis: 'z' });
     expect(model.doorways.length).toBeGreaterThanOrEqual(1); // door classified
     expect(model.fromWallGraph).toBe(true);
-    expect(model.rooms.length).toBe(2);
+    expect(model.rooms).toHaveLength(2);
     // Hand truth (200×160 grid, 5 cm cells, walls on cols 0 / 100 / 199):
     // left interior 99 × 158 cells = 39.105 m², right 98 × 158 = 38.71 m².
     const areas = model.rooms.map((r) => r.areaM2).sort((a, b) => b - a);
@@ -181,8 +181,8 @@ describe('extractFloorPlan — rooms end-to-end', () => {
     // The 2 m gap is wider than any door — never classified as one. The two
     // halves merge into one connected, unpartitioned region: FIX 1 reports
     // that honestly as a single OPEN SPACE, not "Room 1" of a schedule.
-    expect(model.doorways.length).toBe(0);
-    expect(model.rooms.length).toBe(0); // no numbered room
+    expect(model.doorways).toHaveLength(0);
+    expect(model.rooms).toHaveLength(0); // no numbered room
     expect(model.roomSegmentation).toBe('open-space');
     // The open space spans both halves (≈ 78 m² minus the divider stubs).
     expect(model.openSpaceAreaM2).toBeGreaterThan(70);
@@ -209,7 +209,7 @@ describe('extractFloorPlan — rooms end-to-end', () => {
     const model = extractFloorPlan(Float32Array.from(t), { upAxis: 'z' });
     // One connected, unpartitioned region → reported as a single open space
     // (FIX 1), with the open-space area at the hand-counted cell area.
-    expect(model.rooms.length).toBe(0);
+    expect(model.rooms).toHaveLength(0);
     expect(model.roomSegmentation).toBe('open-space');
     expect(Math.abs(model.openSpaceAreaM2 - 58.66)).toBeLessThan(0.02 * 58.66);
   });
@@ -251,13 +251,13 @@ describe('detectRooms — architectural min-room-area floor (ROOM_MIN_AREA_M2)',
     const big = blank(64, 64); // 60×60 free = 3×3 m at 5 cm = 9 m²
     big.box(0, 0, 63, 1); big.box(0, 62, 63, 63); big.box(0, 0, 1, 63); big.box(62, 0, 63, 63);
     const resBig = detectRooms(toGrid(big.mask, 64, 64, 0.05), []);
-    expect(resBig.rooms.length).toBe(1);
+    expect(resBig.rooms).toHaveLength(1);
     expect(resBig.rooms[0].areaM2).toBeCloseTo(9.0, 1);
 
     const small = blank(40, 40); // 36×36 free = 1.8×1.8 m = 3.24 m² < 4 m²
     small.box(0, 0, 39, 1); small.box(0, 38, 39, 39); small.box(0, 0, 1, 39); small.box(38, 0, 39, 39);
     const resSmall = detectRooms(toGrid(small.mask, 40, 40, 0.05), []);
-    expect(resSmall.rooms.length).toBe(0); // dropped, not "Room 1 · 3.2 m²"
+    expect(resSmall.rooms).toHaveLength(0); // dropped, not "Room 1 · 3.2 m²"
   });
 });
 
@@ -286,7 +286,7 @@ describe('detectRooms — coverage guard (open-space vs unsegmented)', () => {
   it('leaking open plan + small pockets → NOT a room schedule (unsegmented)', () => {
     const floorAreaM2 = 16; // the scanned floor — pockets cover ~1% of it
     const res = detectRooms(leakyGrid(), [], floorAreaM2);
-    expect(res.rooms.length).toBe(0); // no fake "Room 1..N"
+    expect(res.rooms).toHaveLength(0); // no fake "Room 1..N"
     expect(res.segmentation).toBe('unsegmented');
     expect(res.roomCoverageFrac).toBeLessThan(ROOM_COVERAGE_MIN_FRAC);
   });
@@ -306,7 +306,7 @@ describe('detectRooms — coverage guard (open-space vs unsegmented)', () => {
     const { mask, box } = blank(80, 80);
     box(0, 0, 79, 1); box(0, 78, 79, 79); box(0, 0, 1, 79); box(78, 0, 79, 79);
     const res = detectRooms(toGrid(mask, 80, 80, 0.05), [], 16);
-    expect(res.rooms.length).toBe(0); // not numbered
+    expect(res.rooms).toHaveLength(0); // not numbered
     expect(res.segmentation).toBe('open-space');
     expect(res.dominantRegionAreaM2).toBeCloseTo(14.44, 2);
   });

--- a/tests/floorPlanWallGraph.test.ts
+++ b/tests/floorPlanWallGraph.test.ts
@@ -67,7 +67,7 @@ describe('buildWallGraph — junction topology on truth grids', () => {
     const { graph } = graphOf(toGrid(mask, 41, 31));
     expect(junctions(graph)).toBe(1);
     expect(endpoints(graph)).toBe(3);
-    expect(graph.edges.length).toBe(3);
+    expect(graph.edges).toHaveLength(3);
   });
 
   it('+: one junction, four endpoints, four edges', () => {
@@ -77,7 +77,7 @@ describe('buildWallGraph — junction topology on truth grids', () => {
     const { graph } = graphOf(toGrid(mask, 41, 41));
     expect(junctions(graph)).toBe(1);
     expect(endpoints(graph)).toBe(4);
-    expect(graph.edges.length).toBe(4);
+    expect(graph.edges).toHaveLength(4);
   });
 
   it('L: two limb-tip endpoints connected through the corner', () => {
@@ -109,8 +109,8 @@ describe('buildWallGraph — junction topology on truth grids', () => {
       for (let c = 0; c < cols; c++)
         if (Math.abs(c - 15) + Math.abs(r - 15) === 10) mask[r * cols + c] = 1;
     const { graph } = graphOf(toGrid(mask, cols, rows));
-    expect(graph.nodes.filter((n) => n.kind === 'loop').length).toBe(1);
-    expect(graph.edges.length).toBe(1);
+    expect(graph.nodes.filter((n) => n.kind === 'loop')).toHaveLength(1);
+    expect(graph.edges).toHaveLength(1);
     expect(graph.edges[0].a).toBe(graph.edges[0].b);
     // The loop path is closed: first and last points coincide (same cell).
     const p = graph.edges[0].path;
@@ -123,7 +123,7 @@ describe('buildWallGraph — per-edge measurements', () => {
     const { mask, box } = blank(40, 11);
     box(2, 4, 37, 6); // 3 thick at 0.1 m cells
     const { graph } = graphOf(toGrid(mask, 40, 11));
-    expect(graph.edges.length).toBe(1);
+    expect(graph.edges).toHaveLength(1);
     // Centre cells read chamfer 2 (0.2 m); the run ends pull the mean down a
     // touch, so gate a band around the hand value.
     expect(graph.edges[0].halfThicknessM).toBeGreaterThan(0.15);
@@ -139,7 +139,7 @@ describe('buildWallGraph — per-edge measurements', () => {
     const rawHalf = blank(cols, rows);
     rawHalf.box(2, 3, 29, 5);
     const { graph } = graphOf(grid, toGrid(rawHalf.mask, cols, rows));
-    expect(graph.edges.length).toBe(1);
+    expect(graph.edges).toHaveLength(1);
     expect(graph.edges[0].observedFrac).toBeGreaterThan(0.35);
     expect(graph.edges[0].observedFrac).toBeLessThan(0.65);
     // Fully-observed control.

--- a/tests/fullCloudGradeAdapter.test.ts
+++ b/tests/fullCloudGradeAdapter.test.ts
@@ -126,7 +126,7 @@ describe('makeDecodeNode — id → decoded positions', () => {
     const src = fakeSource(nodeList(), {});
     const decode = makeDecodeNode(src, fakeDecoder());
     const pos = await decode('9-9-9-9');
-    expect(pos.length).toBe(0);
+    expect(pos).toHaveLength(0);
   });
 
   it('throws if a decoder returns a non-triple-length positions array', async () => {

--- a/tests/fullscreenToggleTeardown.test.ts
+++ b/tests/fullscreenToggleTeardown.test.ts
@@ -268,7 +268,7 @@ describe('FullscreenToggle refusal status', () => {
     press(toggle);
     await Promise.resolve();
     await Promise.resolve();
-    expect(announced.length).toBe(1);
+    expect(announced).toHaveLength(1);
     expect(announced[0]).toBe((toggle.status as unknown as NodeStub).textContent);
   });
 

--- a/tests/gpuBackendDispatch.test.ts
+++ b/tests/gpuBackendDispatch.test.ts
@@ -183,8 +183,8 @@ describe('gpuBackend.derivatives — dispatch plumbing on a mock device', () => 
     const out = await backend.derivatives(z, cols, rows, 0.5);
 
     // Output shape (zeros from the mock readback, but correctly sized).
-    expect(out.slope.length).toBe(cols * rows);
-    expect(out.aspect.length).toBe(cols * rows);
+    expect(out.slope).toHaveLength(cols * rows);
+    expect(out.aspect).toHaveLength(cols * rows);
 
     // One compute dispatch with ceil(40/16)=3 × ceil(33/16)=3 groups.
     expect(log.dispatches).toEqual([{ x: 3, y: 3, z: undefined }]);
@@ -260,7 +260,7 @@ describe('gpuBackend.derivatives — dispatch plumbing on a mock device', () => 
     const { device, log } = makeMockDevice();
     const backend = createGpuBackend(device);
     const empty = await backend.derivatives(new Float32Array(0), 0, 0, 1);
-    expect(empty.slope.length).toBe(0);
+    expect(empty.slope).toHaveLength(0);
     const badCell = await backend.derivatives(new Float32Array(4), 2, 2, 0);
     expect(Array.from(badCell.slope)).toEqual([0, 0, 0, 0]);
     // A non-positive Y cell is guarded exactly like the X cell.
@@ -297,7 +297,7 @@ describe('gpuBackend.hillshade — dispatch plumbing on a mock device', () => {
 
     const out = await backend.hillshade(slope, aspect, cov, cols, rows, { azimuthDeg: 315 });
 
-    expect(out.shade.length).toBe(n);
+    expect(out.shade).toHaveLength(n);
     expect(out.cols).toBe(cols);
     expect(out.rows).toBe(rows);
     // Coverage mask reproduces shadeFromSlopeAspect's skip rule.
@@ -327,7 +327,7 @@ describe('gpuBackend.hillshade — dispatch plumbing on a mock device', () => {
     const { device, log } = makeMockDevice();
     const backend = createGpuBackend(device);
     const out = await backend.hillshade(new Float32Array(0), new Float32Array(0), new Uint8Array(0), 0, 0);
-    expect(out.shade.length).toBe(0);
+    expect(out.shade).toHaveLength(0);
     expect(log.buffers).toHaveLength(0);
   });
 });
@@ -349,8 +349,8 @@ describe('gpuBackend.scatterMinCount — dispatch plumbing on a mock device', ()
     };
 
     const out = await backend.scatterMinCount!(pts, grid);
-    expect(out.z.length).toBe(nCells);
-    expect(out.counts.length).toBe(nCells);
+    expect(out.z).toHaveLength(nCells);
+    expect(out.counts).toHaveLength(nCells);
 
     // Two compute passes: scatter (ceil 600/256 = 3) then finalize
     // (ceil 384/256 = 2). Entry points in order.
@@ -377,7 +377,7 @@ describe('gpuBackend.scatterMinCount — dispatch plumbing on a mock device', ()
     );
     expect(keyBufs.length).toBeGreaterThanOrEqual(1);
     const seeded = keyBufs[0].written as Uint32Array;
-    expect(seeded.length).toBe(nCells);
+    expect(seeded).toHaveLength(nCells);
     expect(seeded.every((k) => k === SCATTER_MIN_SENTINEL)).toBe(true);
 
     // The scatter uniform (32 bytes) packs origin (f32×2), cols/rows (u32×2),
@@ -409,7 +409,7 @@ describe('gpuBackend.scatterMinCount — dispatch plumbing on a mock device', ()
       { h1: new Float32Array(0), h2: new Float32Array(0), v: new Float32Array(0), count: 0 },
       grid,
     );
-    expect(out.z.length).toBe(16);
+    expect(out.z).toHaveLength(16);
     // No scatter dispatch (no points); finalize still runs.
     expect(log.entryPoints).toEqual(['finalize_main']);
     expect(log.dispatches).toEqual([{ x: 1, y: undefined, z: undefined }]);
@@ -422,7 +422,7 @@ describe('gpuBackend.scatterMinCount — dispatch plumbing on a mock device', ()
       { h1: new Float32Array(0), h2: new Float32Array(0), v: new Float32Array(0), count: 0 },
       { originH1: 0, originH2: 0, cols: 0, rows: 0, cellSizeM: 1 },
     );
-    expect(out.z.length).toBe(0);
+    expect(out.z).toHaveLength(0);
     expect(log.buffers).toHaveLength(0);
   });
 

--- a/tests/groundFilter.test.ts
+++ b/tests/groundFilter.test.ts
@@ -142,7 +142,7 @@ describe('classifyGroundSmrf — degenerate inputs', () => {
   it('returns an empty, warned result for no points', () => {
     const res = classifyGroundSmrf([], PARAMS);
     expect(res.sourcePointCount).toBe(0);
-    expect(res.isGround.length).toBe(0);
+    expect(res.isGround).toHaveLength(0);
     expect(res.warnings.join(' ')).toMatch(/no points/i);
   });
 

--- a/tests/kmlExport.test.ts
+++ b/tests/kmlExport.test.ts
@@ -339,7 +339,7 @@ describe('KML altitude — only proven sea-level heights are claimed', () => {
     // 2D geometry: "lon,lat" pairs only, never a third ordinate.
     for (const m of kml.matchAll(/<coordinates>([^<]*)<\/coordinates>/g)) {
       for (const tuple of m[1].split(' ')) {
-        expect(tuple.split(',').length).toBe(2);
+        expect(tuple.split(',')).toHaveLength(2);
       }
     }
   });

--- a/tests/labelPlacement.test.ts
+++ b/tests/labelPlacement.test.ts
@@ -47,7 +47,7 @@ describe('decimalsForInterval', () => {
 describe('placeLabels', () => {
   it('places evenly spaced labels along a confident line', () => {
     const labels = placeLabels([straightLine(() => 90)], { spacingM: 25 });
-    expect(labels.length).toBe(4); // at 12.5, 37.5, 62.5, 87.5
+    expect(labels).toHaveLength(4); // at 12.5, 37.5, 62.5, 87.5
     for (const l of labels) {
       expect(Math.abs(l.angleRad)).toBeLessThan(1e-6); // horizontal
       expect(l.value).toBe(50);
@@ -59,7 +59,7 @@ describe('placeLabels', () => {
       spacingM: 25,
     });
     // 37.5 and 62.5 fall in/next to the uncertain span and are dropped.
-    expect(labels.length).toBe(2);
+    expect(labels).toHaveLength(2);
     for (const l of labels) expect(l.x < 37 || l.x > 63).toBe(true);
   });
 
@@ -75,6 +75,6 @@ describe('placeLabels', () => {
 
   it('places no labels on a line shorter than the first offset', () => {
     const short: ContourPolyline = { value: 1, vertices: [v(0, 0), v(10, 0)], closed: false };
-    expect(placeLabels([short], { spacingM: 25 }).length).toBe(0);
+    expect(placeLabels([short], { spacingM: 25 })).toHaveLength(0);
   });
 });

--- a/tests/lassoVolume.test.ts
+++ b/tests/lassoVolume.test.ts
@@ -186,7 +186,7 @@ describe('convexHull2D — Andrew\'s monotone chain', () => {
       { x: 2, y: 3 },
     ];
     const hull = convexHull2D(tri);
-    expect(hull.length).toBe(3);
+    expect(hull).toHaveLength(3);
   });
 
   it('drops interior points from a square', () => {
@@ -198,7 +198,7 @@ describe('convexHull2D — Andrew\'s monotone chain', () => {
       { x: 2, y: 2 }, // interior — must NOT be in the hull
     ];
     const hull = convexHull2D(square);
-    expect(hull.length).toBe(4);
+    expect(hull).toHaveLength(4);
     for (const p of hull) {
       // Interior point (2, 2) is excluded.
       expect(p.x === 2 && p.y === 2).toBe(false);

--- a/tests/lassoVolumeCompute.test.ts
+++ b/tests/lassoVolumeCompute.test.ts
@@ -80,8 +80,8 @@ describe('computeLassoVolume', () => {
     const out = computeLassoVolume({ host: h, lasso: fullBox(10), referencePercentile: 0.05 })!;
     expect(out).not.toBeNull();
     expect(out.selectedCount).toBe(64);
-    expect(out.selectionByCloudId.get('layer-1')!.length).toBe(64);
-    expect(out.selectedPositions.length).toBe(64 * 3);
+    expect(out.selectionByCloudId.get('layer-1')!).toHaveLength(64);
+    expect(out.selectedPositions).toHaveLength(64 * 3);
     // The grid has a raised disc in the middle, so a top-down lasso over the
     // whole thing must find fill above the reference plane and a real footprint.
     expect(out.result.fill).toBeGreaterThan(0);
@@ -118,7 +118,7 @@ describe('computeLassoVolume', () => {
     const out = computeLassoVolume({ host: h, lasso: fullBox(10), referencePercentile: 0.05 })!;
     expect(out.selectedCount).toBe(72);
     expect([...out.selectionByCloudId.keys()]).toEqual(['layer-1']);
-    expect(out.selectionByCloudId.get('layer-1')!.length).toBe(36);
+    expect(out.selectionByCloudId.get('layer-1')!).toHaveLength(36);
   });
 
   it('carries the reduced-source caveat when any contributing layer was reduced', () => {
@@ -157,13 +157,13 @@ describe('stridePositions', () => {
   it('keeps every nth point, and the kept values are the source values', () => {
     const p = Float32Array.from([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5]);
     const out = stridePositions(p, 2);
-    expect(out.length).toBe(9);
+    expect(out).toHaveLength(9);
     expect([...out]).toEqual([0, 0, 0, 2, 2, 2, 4, 4, 4]);
   });
 
   it('drops the tail rather than emitting a partial point', () => {
     // 5 points at stride 2 keeps floor(5/2) = 2, not 3 with a half-read.
     const p = Float32Array.from([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4]);
-    expect(stridePositions(p, 2).length).toBe(6);
+    expect(stridePositions(p, 2)).toHaveLength(6);
   });
 });

--- a/tests/lintUnsafeHtml.test.ts
+++ b/tests/lintUnsafeHtml.test.ts
@@ -24,7 +24,7 @@ describe('lint-unsafe-html scanSource', () => {
   });
 
   it('flags an annotation string reaching the sink', () => {
-    expect(scanSource(`el('p', { unsafeHtml: annotationText });`).length).toBe(1);
+    expect(scanSource(`el('p', { unsafeHtml: annotationText });`)).toHaveLength(1);
   });
 
   it('does NOT flag static icon constants (the real usages)', () => {

--- a/tests/loadE57Merge.test.ts
+++ b/tests/loadE57Merge.test.ts
@@ -83,7 +83,7 @@ describe('loadE57 — merging a Cartesian scan with a spherical-only scan', () =
 
     // 2 valid points, not 2 + 4 phantom records.
     expect(cloud.pointCount).toBe(2);
-    expect(cloud.positions.length).toBe(6);
+    expect(cloud.positions).toHaveLength(6);
     expect(cloud.origin).toEqual([10, 20, 5]);
     expect([...cloud.positions]).toEqual([0.5, 0.5, 0.5, 2.5, 2.5, 2.5]);
     // No point sits at the local origin (the phantom signature).

--- a/tests/loadLas.test.ts
+++ b/tests/loadLas.test.ts
@@ -54,9 +54,9 @@ describe('loadLas — tiny.las fixture (uncompressed)', () => {
   test('intensity and classification are decoded', async () => {
     const pc = await loadLas(loadFixture('tiny.las'), 'las');
     expect(pc.intensity).toBeInstanceOf(Uint16Array);
-    expect(pc.intensity!.length).toBe(12);
+    expect(pc.intensity!).toHaveLength(12);
     expect(pc.classification).toBeInstanceOf(Uint8Array);
-    expect(pc.classification!.length).toBe(12);
+    expect(pc.classification!).toHaveLength(12);
   });
 });
 
@@ -91,9 +91,9 @@ describe('loadLas — tiny.laz fixture (compressed)', () => {
   test('intensity and classification are decoded', async () => {
     const pc = await loadLas(loadFixture('tiny.laz'), 'laz');
     expect(pc.intensity).toBeInstanceOf(Uint16Array);
-    expect(pc.intensity!.length).toBe(12);
+    expect(pc.intensity!).toHaveLength(12);
     expect(pc.classification).toBeInstanceOf(Uint8Array);
-    expect(pc.classification!.length).toBe(12);
+    expect(pc.classification!).toHaveLength(12);
   });
 });
 
@@ -324,7 +324,7 @@ describe('loadLas — inspection extras', () => {
     ]);
     const pc = await loadLas(buf, 'las');
     expect(pc.gpsTime).toBeInstanceOf(Float64Array);
-    expect(pc.gpsTime!.length).toBe(2);
+    expect(pc.gpsTime!).toHaveLength(2);
     expect(pc.gpsTime![0]).toBeCloseTo(123456.789, 3);
     expect(pc.gpsTime![1]).toBeCloseTo(987654.321, 3);
   });
@@ -337,7 +337,7 @@ describe('loadLas — inspection extras', () => {
       { x: 3, y: 0, z: 0, intensity: 1, classByte: 1, returnBits: 0x1a, sourceId: 100 },
     ]);
     const strided = await loadLas(buf, 'las', 'x.las', 2);
-    expect(strided.returnNumber!.length).toBe(strided.pointCount);
-    expect(strided.pointSourceId!.length).toBe(strided.pointCount);
+    expect(strided.returnNumber!).toHaveLength(strided.pointCount);
+    expect(strided.pointSourceId!).toHaveLength(strided.pointCount);
   });
 });

--- a/tests/loadPcd.test.ts
+++ b/tests/loadPcd.test.ts
@@ -48,7 +48,7 @@ describe('loadPcd — ASCII', () => {
   test('a 0–1 intensity field is rescaled to the full Uint16 range', async () => {
     const pc = await loadPcd(loadFixture('tiny.pcd'));
     expect(pc.intensity).toBeInstanceOf(Uint16Array);
-    expect(pc.intensity!.length).toBe(4);
+    expect(pc.intensity!).toHaveLength(4);
     expect(pc.intensity![0]).toBe(Math.round(0.25 * 65535));
     expect(pc.intensity![3]).toBe(65535);
     // The fixture carries no rgb or normals.
@@ -169,7 +169,7 @@ describe('loadPcd — malformed input', () => {
       console.error = origError;
     }
     // The unplaceable point is excluded; the two finite points survive, all finite.
-    expect(pc.positions.length).toBe(6);
+    expect(pc.positions).toHaveLength(6);
     for (const v of pc.positions) expect(Number.isFinite(v)).toBe(true);
     // The redundant three bounding-sphere NaN message reached neither console channel.
     expect(logged.some((m) => m.includes('computeBoundingSphere') && m.includes('NaN'))).toBe(false);

--- a/tests/loadPly.test.ts
+++ b/tests/loadPly.test.ts
@@ -44,7 +44,7 @@ describe('loadPly — tiny.ply fixture (ground truth from FIXTURES.md)', () => {
     const pc = await loadPly(loadFixture());
     expect(pc.colors).toBeInstanceOf(Uint8Array);
     // Three bytes (rgb) per point.
-    expect(pc.colors!.length).toBe(pc.pointCount * 3);
+    expect(pc.colors!).toHaveLength(pc.pointCount * 3);
   });
 
   test('name defaults sensibly and round-trips when given', async () => {

--- a/tests/loaderSanitation.test.ts
+++ b/tests/loaderSanitation.test.ts
@@ -90,7 +90,7 @@ describe('sanitizeAndRecenter — attribute lockstep', () => {
     });
 
     expect(result.excludedCount).toBe(1);
-    expect(result.positions.length).toBe(9);
+    expect(result.positions).toHaveLength(9);
     // Origin is the floored min of the SURVIVORS.
     expect(result.origin).toEqual([10, 10, 10]);
     expect(Array.from(result.positions)).toEqual([0, 0, 0, 2, 2, 2, 3, 3, 3]);
@@ -143,7 +143,7 @@ describe('sanitizeAndRecenter — which coordinates are excluded', () => {
       coords[3 + axis] = bad;
       const result = sanitizeAndRecenter(coords, {});
       expect(result.excludedCount).toBe(1);
-      expect(result.positions.length).toBe(3);
+      expect(result.positions).toHaveLength(3);
       expect(Array.from(result.positions)).toEqual([0, 0, 0]);
     }
   });
@@ -207,7 +207,7 @@ describe('sanitizeAndRecenter — reporting and refusal', () => {
     // Nothing was excluded, so there is nothing to warn about; `parseBuffer`
     // already refuses a zero-point cloud with its own message.
     const result = sanitizeAndRecenter(new Float64Array(0), {});
-    expect(result.positions.length).toBe(0);
+    expect(result.positions).toHaveLength(0);
     expect(result.warning).toBeUndefined();
   });
 });

--- a/tests/localDensitySize.test.ts
+++ b/tests/localDensitySize.test.ts
@@ -19,7 +19,7 @@ describe('localDensitySizes — pure data formula hardening', () => {
       cellSize: 1,
       referenceDensity: 1,
     });
-    expect(out.length).toBe(0);
+    expect(out).toHaveLength(0);
   });
 
   it('handles a single point gracefully (one cell, count = 1)', () => {
@@ -28,7 +28,7 @@ describe('localDensitySizes — pure data formula hardening', () => {
       cellSize: 1,
       referenceDensity: 1,
     });
-    expect(out.length).toBe(1);
+    expect(out).toHaveLength(1);
     // ratio = refDensity / cellDensity = 1 / (1 / 1) = 1 → scale = √1 = 1
     expect(out[0]).toBeCloseTo(1, 6);
   });
@@ -40,7 +40,7 @@ describe('localDensitySizes — pure data formula hardening', () => {
       referenceDensity: 0,
     });
     // ratio = 1e-9 / cellD → very small, sqrt → still small, clamps to minScale (0.5)
-    expect(out.length).toBe(2);
+    expect(out).toHaveLength(2);
     expect(Number.isFinite(out[0])).toBe(true);
     expect(Number.isFinite(out[1])).toBe(true);
     expect(out[0]).toBeGreaterThanOrEqual(0.5); // default minScale
@@ -52,7 +52,7 @@ describe('localDensitySizes — pure data formula hardening', () => {
       cellSize: 0,
       referenceDensity: 1,
     });
-    expect(out.length).toBe(2);
+    expect(out).toHaveLength(2);
     expect(Number.isFinite(out[0])).toBe(true);
     expect(Number.isFinite(out[1])).toBe(true);
   });
@@ -71,7 +71,7 @@ describe('localDensitySizes — pure data formula hardening', () => {
       cellSize: 1,
       referenceDensity: 1,
     });
-    expect(out.length).toBe(4);
+    expect(out).toHaveLength(4);
     for (const v of out) expect(v).toBeCloseTo(1, 6);
   });
 
@@ -117,7 +117,7 @@ describe('localDensitySizes — pure data formula hardening', () => {
       minScale: 0.25,
       maxScale: 4,
     });
-    expect(out.length).toBe(20);
+    expect(out).toHaveLength(20);
     for (const v of out) {
       expect(v).toBeGreaterThanOrEqual(0.25);
       expect(v).toBeLessThanOrEqual(4);

--- a/tests/mapSheetPdf.test.ts
+++ b/tests/mapSheetPdf.test.ts
@@ -373,7 +373,7 @@ describe('buildMapSheetPdf — purpose deliverable content', () => {
     expect(withApx.length).toBeGreaterThan(noApx.length);
     // And both differ from the no-purpose sheet.
     const plain = await buildMapSheetPdf({ model, labels: [], provenance: PROV });
-    expect(noApx.length).not.toBe(plain.length);
+    expect(noApx).not.toHaveLength(plain.length);
   });
 
   it('produces different bytes for two different purposes (purposes are real)', async () => {

--- a/tests/measurePanelStationsLazy.test.ts
+++ b/tests/measurePanelStationsLazy.test.ts
@@ -210,7 +210,7 @@ function setOpen(details: FakeEl, open: boolean): void {
 describe('MeasurePanel — station table rows build lazily on first open', () => {
   it('renders NO station rows until the <details> is opened', () => {
     const { tbody } = mountProfilePanel();
-    expect(tbody.querySelectorAll('tr').length).toBe(0);
+    expect(tbody.querySelectorAll('tr')).toHaveLength(0);
   });
 
   it('shows the correct row count in the summary while the body is still unbuilt', () => {
@@ -218,24 +218,24 @@ describe('MeasurePanel — station table rows build lazily on first open', () =>
     // The count comes from the eagerly-computed row MODEL, not from the DOM…
     expect(summary.textContent).toContain(`Station table (${SAMPLE_COUNT})`);
     // …while the DOM body is still empty.
-    expect(tbody.querySelectorAll('tr').length).toBe(0);
+    expect(tbody.querySelectorAll('tr')).toHaveLength(0);
   });
 
   it('builds one row per sample when the <details> is opened', () => {
     const { details, tbody } = mountProfilePanel();
     setOpen(details, true);
-    expect(tbody.querySelectorAll('tr').length).toBe(SAMPLE_COUNT);
+    expect(tbody.querySelectorAll('tr')).toHaveLength(SAMPLE_COUNT);
     // Each built row carries the five station columns.
-    expect(tbody.querySelector('tr')!.querySelectorAll('td').length).toBe(5);
+    expect(tbody.querySelector('tr')!.querySelectorAll('td')).toHaveLength(5);
   });
 
   it('builds the rows exactly once — closing then reopening does not duplicate them', () => {
     const { details, tbody } = mountProfilePanel();
     setOpen(details, true);
-    expect(tbody.querySelectorAll('tr').length).toBe(SAMPLE_COUNT);
+    expect(tbody.querySelectorAll('tr')).toHaveLength(SAMPLE_COUNT);
     setOpen(details, false); // close — cached body stays
-    expect(tbody.querySelectorAll('tr').length).toBe(SAMPLE_COUNT);
+    expect(tbody.querySelectorAll('tr')).toHaveLength(SAMPLE_COUNT);
     setOpen(details, true); // reopen — no rebuild, no duplication
-    expect(tbody.querySelectorAll('tr').length).toBe(SAMPLE_COUNT);
+    expect(tbody.querySelectorAll('tr')).toHaveLength(SAMPLE_COUNT);
   });
 });

--- a/tests/modalConfirm.test.ts
+++ b/tests/modalConfirm.test.ts
@@ -188,21 +188,21 @@ describe('openConfirm', () => {
     backdrop.find('olv-confirm-ok')!.dispatch('click');
     await expect(promise).resolves.toBe(true);
     // Dialog is torn down after a decision.
-    expect(BODY.children.length).toBe(0);
+    expect(BODY.children).toHaveLength(0);
   });
 
   it('resolves false when the cancel button is clicked', async () => {
     const { promise, backdrop } = await open();
     backdrop.find('olv-confirm-cancel')!.dispatch('click');
     await expect(promise).resolves.toBe(false);
-    expect(BODY.children.length).toBe(0);
+    expect(BODY.children).toHaveLength(0);
   });
 
   it('resolves false on Escape (window keydown trap)', async () => {
     const { promise } = await open();
     winKeydown('Escape');
     await expect(promise).resolves.toBe(false);
-    expect(BODY.children.length).toBe(0);
+    expect(BODY.children).toHaveLength(0);
   });
 
   it('resolves false when the backdrop is clicked outside the card', async () => {

--- a/tests/objectPanelExport.test.ts
+++ b/tests/objectPanelExport.test.ts
@@ -81,8 +81,8 @@ describe('ObjectPanel — export row gating', () => {
     });
     panel.showSpace(space, shape);
     const root = panel.element as unknown as FakeEl;
-    expect(root.findByText('Report PDF').length).toBe(1);
-    expect(root.findByText('Floor plan preview').length).toBe(1);
+    expect(root.findByText('Report PDF')).toHaveLength(1);
+    expect(root.findByText('Floor plan preview')).toHaveLength(1);
   });
 
   it('object scan: Report PDF present, Floor plan preview absent', async () => {
@@ -95,7 +95,7 @@ describe('ObjectPanel — export row gating', () => {
     });
     panel.showObject(objectMetrics(cubeShell()), null, null);
     const root = panel.element as unknown as FakeEl;
-    expect(root.findByText('Report PDF').length).toBe(1);
-    expect(root.findByText('Floor plan preview').length).toBe(0);
+    expect(root.findByText('Report PDF')).toHaveLength(1);
+    expect(root.findByText('Floor plan preview')).toHaveLength(0);
   });
 });

--- a/tests/objectPanelSpace.test.ts
+++ b/tests/objectPanelSpace.test.ts
@@ -202,7 +202,7 @@ describe('ObjectPanel — space / object routing', () => {
 
     // Exactly ONE collapsible caveat disclosure, with a "details"/"summary".
     const details = all.filter((e) => e.tagName === 'details' && e.className.includes('olv-object-caveats'));
-    expect(details.length).toBe(1);
+    expect(details).toHaveLength(1);
     const summary = all.find((e) => e.className.includes('olv-object-caveats-summary'));
     expect(summary).toBeDefined();
     expect(summary!.textContent).toMatch(/About these figures/);
@@ -255,7 +255,7 @@ describe('ObjectPanel — space / object routing', () => {
     const root = panel.element as unknown as FakeEl;
     const all = flatten(root);
     expect(root.textContent).toContain('No space measurements available');
-    expect(all.filter((e) => e.className.includes('olv-scan-type-opt')).length).toBe(4);
+    expect(all.filter((e) => e.className.includes('olv-scan-type-opt'))).toHaveLength(4);
     expect(all.some((e) => e.className.includes('olv-object-run-anyway'))).toBe(true);
   });
 });

--- a/tests/patchView.test.ts
+++ b/tests/patchView.test.ts
@@ -219,7 +219,7 @@ describe('buildPatchView — buffer integrity', () => {
       size: 64,
     });
     expect(patch).not.toBeNull();
-    expect(patch!.rgba.length).toBe(64 * 64 * 4);
+    expect(patch!.rgba).toHaveLength(64 * 64 * 4);
   });
 
   it('every alpha channel is either 0 or 255', () => {

--- a/tests/pointFrames.test.ts
+++ b/tests/pointFrames.test.ts
@@ -74,7 +74,7 @@ describe('pointFrames accessors are free', () => {
   it('does not let a caller observe a different length or content', () => {
     const c = cloud();
     const p = sourcePositions(c);
-    expect(p.length).toBe(15);
+    expect(p).toHaveLength(15);
     expect([...p]).toEqual([...c.positions]);
   });
 
@@ -102,7 +102,7 @@ describe('copyPlacedPositions matches the buffer-level primitive exactly', () =>
       const viaCloud = copyPlacedPositions(c, stride, tf);
       const viaBuffer = stridePlacedPositions(c.positions, stride, tf);
       expect([...viaCloud]).toEqual([...viaBuffer]);
-      expect(viaCloud.length).toBe(viaBuffer.length);
+      expect(viaCloud).toHaveLength(viaBuffer.length);
     });
   }
 
@@ -156,7 +156,7 @@ describe('converted call sites are unchanged', () => {
       undefined,
       2,
     );
-    expect(viaAccessor.length).toBe(c.pointCount * 3);
+    expect(viaAccessor).toHaveLength(c.pointCount * 3);
     expect([...viaAccessor]).toEqual([...viaRawBuffer]);
   });
 });

--- a/tests/profileSampler.test.ts
+++ b/tests/profileSampler.test.ts
@@ -411,7 +411,7 @@ describe('normaliseResampleParams — the B7/B8 panel→sampler seam (hand-compu
         positions,
         samples: n,
       });
-      expect(out.length).toBe(n);
+      expect(out).toHaveLength(n);
     }
   });
 });

--- a/tests/profileStations.test.ts
+++ b/tests/profileStations.test.ts
@@ -23,7 +23,7 @@ describe('stationsAlongLine — chainage placement', () => {
       b: [100, 0, 110],
       intervalM: 25,
     });
-    expect(stations.length).toBe(5);
+    expect(stations).toHaveLength(5);
     expect(stations.map((s) => s.chainage)).toEqual([0, 25, 50, 75, 100]);
     // Last station carries the endpoint flag; others don't.
     expect(stations[stations.length - 1].isEndpoint).toBe(true);
@@ -123,7 +123,7 @@ describe('slopeGradesPerSegment — per-segment math', () => {
     // 100 m run, 5 m rise → 5 %.
     const sts = stations([0, 100], [0, 5]);
     const grades = slopeGradesPerSegment({ stations: sts });
-    expect(grades.length).toBe(1);
+    expect(grades).toHaveLength(1);
     expect(grades[0].run).toBe(100);
     expect(grades[0].rise).toBe(5);
     expect(grades[0].gradePercent).toBeCloseTo(5, 9);
@@ -141,7 +141,7 @@ describe('slopeGradesPerSegment — per-segment math', () => {
   it('produces one grade per segment between adjacent stations', () => {
     const sts = stations([0, 50, 100], [0, 3, 8]);
     const grades = slopeGradesPerSegment({ stations: sts });
-    expect(grades.length).toBe(2);
+    expect(grades).toHaveLength(2);
     expect(grades[0].gradePercent).toBeCloseTo(6, 9); // 3 / 50
     expect(grades[1].gradePercent).toBeCloseTo(10, 9); // 5 / 50
   });

--- a/tests/rangeSource.test.ts
+++ b/tests/rangeSource.test.ts
@@ -230,7 +230,7 @@ test('HttpRangeSource.readRange accepts a 206 and rejects a 200 full-file respon
           headers: { 'content-range': 'bytes 0-2/100' },
         })) as typeof fetch;
   const ok = new HttpRangeSource('https://example.com/a.copc.laz', testOpts);
-  expect(new Uint8Array(await ok.readRange(0, 3)).length).toBe(3);
+  expect(new Uint8Array(await ok.readRange(0, 3))).toHaveLength(3);
 
   globalThis.fetch = (async (_url: string, init?: RequestInit) =>
     init?.method === 'HEAD'

--- a/tests/reliefShading.test.ts
+++ b/tests/reliefShading.test.ts
@@ -40,7 +40,7 @@ describe('shadeFromSlopeAspect', () => {
       azimuthDeg: 315,
       altitudeDeg: 45,
     });
-    expect(direct.shade.length).toBe(N);
+    expect(direct.shade).toHaveLength(N);
     // Interior cells should carry a finite, in-range shade.
     expect(direct.shade[5]).toBeGreaterThanOrEqual(0);
     expect(direct.shade[5]).toBeLessThanOrEqual(255);

--- a/tests/renderClaimRegister.test.ts
+++ b/tests/renderClaimRegister.test.ts
@@ -66,7 +66,7 @@ describe('parseClaimRegister', () => {
     const real = parseClaimRegister(yaml);
     // One parsed claim per `claimId:` line — a claim the parser silently drops
     // would be a claim silently missing from the published table.
-    expect(real.claims.length).toBe((yaml.match(/claimId:/g) ?? []).length);
+    expect(real.claims).toHaveLength((yaml.match(/claimId:/g) ?? []).length);
     expect(real.claims.length).toBeGreaterThanOrEqual(20);
     for (const c of real.claims) {
       expect(c.product, `claim ${c.id} product`).toBeTruthy();

--- a/tests/reportEngine.test.ts
+++ b/tests/reportEngine.test.ts
@@ -31,7 +31,7 @@ import type { Measurement } from '../src/render/measure/types';
 
 describe('templates', () => {
   it('ships exactly two report templates (v0.5.5 P12 consolidation)', () => {
-    expect(REPORT_TEMPLATES.length).toBe(2);
+    expect(REPORT_TEMPLATES).toHaveLength(2);
     expect(REPORT_TEMPLATES.map((t) => t.id)).toEqual(['survey-summary', 'technical-report']);
   });
 

--- a/tests/reportPdfLayout.test.ts
+++ b/tests/reportPdfLayout.test.ts
@@ -229,7 +229,7 @@ describe('technical-report layout — heading underline', () => {
       'Measurements (0)', 'Annotations (0)', 'Visuals', 'Technical notes',
     ]);
     const headings = runs.filter((r) => r.size === 14 && HEADINGS.has(r.text));
-    expect(headings.length).toBe(HEADINGS.size);
+    expect(headings).toHaveLength(HEADINGS.size);
     for (const h of headings) {
       // The underline is the 1.5 pt-high rect drawn 4 pt under the heading.
       const underline = rects.find(

--- a/tests/resultFocus.test.ts
+++ b/tests/resultFocus.test.ts
@@ -222,36 +222,36 @@ describe('openResultFocus', () => {
   it('closes on Escape and restores focus to the trigger', async () => {
     const { trigger } = await openFocus();
     winKeydown('Escape');
-    expect(BODY.children.length).toBe(0);
+    expect(BODY.children).toHaveLength(0);
     expect(trigger.focused).toBe(true);
   });
 
   it('closes on a backdrop click (outside the card)', async () => {
     const { backdrop } = await openFocus();
     backdrop.dispatch('click', { target: backdrop });
-    expect(BODY.children.length).toBe(0);
+    expect(BODY.children).toHaveLength(0);
   });
 
   it('closes on the close-X control', async () => {
     const { backdrop } = await openFocus();
     backdrop.find('olv-modal-x')!.dispatch('click');
-    expect(BODY.children.length).toBe(0);
+    expect(BODY.children).toHaveLength(0);
   });
 
   it('closes via the returned handle', async () => {
     const { handle } = await openFocus();
     handle.close();
-    expect(BODY.children.length).toBe(0);
+    expect(BODY.children).toHaveLength(0);
   });
 
   it('with motion, defers teardown for the exit transition, then removes', async () => {
     const { handle, backdrop } = await openFocus(false);
     handle.close();
     // Still mounted, marked closing/inert while the fade plays.
-    expect(BODY.children.length).toBe(1);
+    expect(BODY.children).toHaveLength(1);
     expect(backdrop.classList.contains('olv-modal-closing')).toBe(true);
     // Flush the exit timer → the node is dropped.
     for (const fn of TIMERS.splice(0)) fn();
-    expect(BODY.children.length).toBe(0);
+    expect(BODY.children).toHaveLength(0);
   });
 });

--- a/tests/scaledSynthCopc.test.ts
+++ b/tests/scaledSynthCopc.test.ts
@@ -67,10 +67,10 @@ test('the generated hierarchy parses cleanly and the data-node count matches', (
   );
   // Every generated node lands in exactly one of nodes / emptyKeys (the
   // synthetic builder emits a single-page hierarchy, so childPages is 0).
-  expect(page.childPages.length).toBe(0);
-  expect(page.errors.length).toBe(0);
+  expect(page.childPages).toHaveLength(0);
+  expect(page.errors).toHaveLength(0);
   expect(page.nodes.length + page.emptyKeys.length).toBe(r.nodeCount);
-  expect(page.nodes.length).toBe(r.dataNodeCount);
+  expect(page.nodes).toHaveLength(r.dataNodeCount);
 });
 
 test('STRESS_TIERS lists 1 M / 10 M / 100 M / 250 M / 500 M', () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1261,7 +1261,7 @@ describe('session resource ceilings (hostile / corrupt input)', () => {
       `"measurements":[{"kind":"distance","points":${pointsJson}}]}`;
     const session = parseSession(doc);
     expect(session.measurements).toHaveLength(1);
-    expect(session.measurements[0].points.length).toBe(MAX_MEASUREMENT_POINTS);
+    expect(session.measurements[0].points).toHaveLength(MAX_MEASUREMENT_POINTS);
   });
 
   it('caps an annotation title and note length', () => {
@@ -1274,7 +1274,7 @@ describe('session resource ceilings (hostile / corrupt input)', () => {
     ];
     const session = parseSession(JSON.stringify(baseDoc({ annotations })));
     expect(session.annotations).toHaveLength(1);
-    expect(session.annotations[0].title.length).toBe(MAX_ANNOTATION_TITLE);
+    expect(session.annotations[0].title).toHaveLength(MAX_ANNOTATION_TITLE);
     expect(session.annotations[0].note?.length).toBe(MAX_ANNOTATION_NOTE);
   });
 

--- a/tests/smoothing.test.ts
+++ b/tests/smoothing.test.ts
@@ -24,7 +24,7 @@ const line = (vertices: ContourVertex[], closed = false): ContourPolyline => ({
 describe('chaikinSmooth', () => {
   it('rounds a corner on an all-confident open line', () => {
     const out = chaikinSmooth(line([v(0, 0), v(1, 1), v(2, 0)]), { iterations: 1 });
-    expect(out.vertices.length).toBe(4); // corner replaced by two cut points
+    expect(out.vertices).toHaveLength(4); // corner replaced by two cut points
     // The original corner vertex must no longer be present exactly.
     expect(out.vertices.some((p) => p.x === 1 && p.y === 1)).toBe(false);
     // Endpoints are pinned.
@@ -54,11 +54,11 @@ describe('chaikinSmooth', () => {
       { iterations: 1 },
     );
     expect(out.closed).toBe(true);
-    expect(out.vertices.length).toBe(8); // 4 corners → 2 points each
+    expect(out.vertices).toHaveLength(8); // 4 corners → 2 points each
   });
 
   it('returns short polylines unchanged', () => {
     const out = chaikinSmooth(line([v(0, 0), v(1, 1)]), { iterations: 3 });
-    expect(out.vertices.length).toBe(2);
+    expect(out.vertices).toHaveLength(2);
   });
 });

--- a/tests/stitchContours.test.ts
+++ b/tests/stitchContours.test.ts
@@ -20,7 +20,7 @@ const seg = (x1: number, y1: number, x2: number, y2: number, c = 90): ContourSeg
 describe('stitchLevel', () => {
   it('joins two adjacent segments into one 3-vertex polyline', () => {
     const polys = stitchLevel(5, [seg(0, 0, 1, 0), seg(1, 0, 2, 0)]);
-    expect(polys.length).toBe(1);
+    expect(polys).toHaveLength(1);
     expect(polys[0].vertices.map((v) => [v.x, v.y])).toEqual([
       [0, 0],
       [1, 0],
@@ -36,9 +36,9 @@ describe('stitchLevel', () => {
       seg(1, 1, 0, 1),
       seg(0, 1, 0, 0),
     ]);
-    expect(polys.length).toBe(1);
+    expect(polys).toHaveLength(1);
     expect(polys[0].closed).toBe(true);
-    expect(polys[0].vertices.length).toBe(4);
+    expect(polys[0].vertices).toHaveLength(4);
   });
 
   it('takes the minimum confidence at a junction', () => {
@@ -58,7 +58,7 @@ describe('stitchLevel', () => {
       seg(1, 0, 2, 0),
       seg(10, 10, 11, 10),
     ]);
-    expect(polys.length).toBe(2);
+    expect(polys).toHaveLength(2);
   });
 });
 
@@ -77,14 +77,14 @@ describe('unit-aware endpoint quantum (geographic-degree grids)', () => {
     // grid's quantum (1e-7) keeps them apart: two polylines.
     const chains = [seg(0, 0, 1e-4, 0), seg(0, 4e-4, 1e-4, 4e-4)];
     const legacy = stitchLevel(5, chains); // fixed 1e-3 quantum
-    expect(legacy.length).toBe(1); // documents the audited failure mode
+    expect(legacy).toHaveLength(1); // documents the audited failure mode
     const scaled = stitchLevel(5, chains, quantumForCellSize(1e-4));
-    expect(scaled.length).toBe(2);
+    expect(scaled).toHaveLength(2);
   });
 
   it('still joins genuinely shared endpoints under a tiny quantum', () => {
     const polys = stitchLevel(5, [seg(0, 0, 1e-4, 0), seg(1e-4, 0, 2e-4, 0)], quantumForCellSize(1e-4));
-    expect(polys.length).toBe(1);
-    expect(polys[0].vertices.length).toBe(3);
+    expect(polys).toHaveLength(1);
+    expect(polys[0].vertices).toHaveLength(3);
   });
 });

--- a/tests/streamingColors.test.ts
+++ b/tests/streamingColors.test.ts
@@ -92,14 +92,14 @@ test('streamingNodeColors returns the decoded RGB directly in rgb mode', () => {
 test('streamingNodeColors falls back to elevation when RGB is absent', () => {
   const c = chunk(2, false);
   const out = streamingNodeColors('rgb', c, ranges({ maxZ: 10 }));
-  expect(out.length).toBe(6); // 3 bytes per point — the elevation fallback
+  expect(out).toHaveLength(6); // 3 bytes per point — the elevation fallback
 });
 
 test('streamingNodeColors produces 3 bytes per point for every mode', () => {
   const c = chunk(4, true);
   const r = ranges({ maxIntensity: 255 });
   for (const mode of ['intensity', 'elevation', 'classification', 'gpsTime', 'returnNumber'] as const) {
-    expect(streamingNodeColors(mode, c, r).length).toBe(12);
+    expect(streamingNodeColors(mode, c, r)).toHaveLength(12);
   }
 });
 

--- a/tests/streamingOctree.test.ts
+++ b/tests/streamingOctree.test.ts
@@ -70,8 +70,8 @@ test('StreamingNodeStore maintained resident/queued sets match a ground-truth wa
   const setMatchesWalk = (): void => {
     expect(new Set(store.residentNodes())).toEqual(walkResident());
     expect(new Set(store.queuedNodes())).toEqual(walkQueued());
-    expect([...store.residentNodes()].length).toBe(store.counts().resident);
-    expect([...store.queuedNodes()].length).toBe(store.queuedCount);
+    expect([...store.residentNodes()]).toHaveLength(store.counts().resident);
+    expect([...store.queuedNodes()]).toHaveLength(store.queuedCount);
   };
 
   setMatchesWalk(); // empty
@@ -90,7 +90,7 @@ test('StreamingNodeStore maintained resident/queued sets match a ground-truth wa
   setMatchesWalk();
 
   // iterate() yields every known node with zero filtering.
-  expect([...store.iterate()].length).toBe(store.size);
+  expect([...store.iterate()]).toHaveLength(store.size);
   expect(new Set(store.iterate())).toEqual(new Set(store.all()));
 });
 

--- a/tests/streamingPanelGrade.test.ts
+++ b/tests/streamingPanelGrade.test.ts
@@ -84,8 +84,8 @@ describe('StreamingPanel — full-cloud grade surface', () => {
     const { StreamingPanel } = await import('../src/ui/StreamingPanel');
     const panel = new StreamingPanel(noopCallbacks());
     const root = panel.element as unknown as FakeEl;
-    expect(root.findByText('Grade full cloud').length).toBe(1);
-    expect(root.findByText('Full-cloud grade').length).toBe(1);
+    expect(root.findByText('Grade full cloud')).toHaveLength(1);
+    expect(root.findByText('Full-cloud grade')).toHaveLength(1);
   });
 
   it('setGradeBusy turns the button into an enabled Cancel control and shows progress', async () => {

--- a/tests/streamingRgbAppearance.test.ts
+++ b/tests/streamingRgbAppearance.test.ts
@@ -136,6 +136,6 @@ describe('streamingNodeColors — RGB appearance pass-through', () => {
   it('returns reusable buffer subarray of correct length', () => {
     const decoded = makeDecoded([10, 20, 30, 40, 50, 60]);
     const out = streamingNodeColors('rgb', decoded, RANGES, IDENTITY_RGB_APPEARANCE);
-    expect(out.length).toBe(6);
+    expect(out).toHaveLength(6);
   });
 });

--- a/tests/streamingScanReveal.test.ts
+++ b/tests/streamingScanReveal.test.ts
@@ -80,10 +80,10 @@ describe('streaming scan reveal', () => {
     const reveals = src.match(/revealStreamingChrome\(/g) ?? [];
 
     expect(attaches.length).toBeGreaterThanOrEqual(2);
-    expect(reveals.length).toBe(attaches.length);
+    expect(reveals).toHaveLength(attaches.length);
 
     // The reveal helper itself is wired exactly once — the shell's deps binding.
-    expect((main.match(/revealStreamingScanChrome\(/g) ?? []).length).toBe(1);
+    expect(main.match(/revealStreamingScanChrome\(/g) ?? []).toHaveLength(1);
 
     // And nothing re-inlines the block. Two hand-written `setCloseEnabled`
     // calls are correct and expected: the static-load path enables it, and
@@ -95,7 +95,7 @@ describe('streaming scan reveal', () => {
     const openScanSrc = readFileSync(resolve(ROOT, 'src/app/openScan.ts'), 'utf8');
     const enables = (main + openScanSrc).match(/dock\.setCloseEnabled\(true\)/g) ?? [];
     const disables = (main + openScanSrc).match(/dock\.setCloseEnabled\(false\)/g) ?? [];
-    expect(enables.length).toBe(1);
-    expect(disables.length).toBe(1);
+    expect(enables).toHaveLength(1);
+    expect(disables).toHaveLength(1);
   });
 });

--- a/tests/streamingScheduler.test.ts
+++ b/tests/streamingScheduler.test.ts
@@ -263,7 +263,7 @@ test('shrinking the budget evicts the surplus resident nodes', async () => {
   scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
   await drain(scheduler);
 
-  expect(evicted.length).toBe(4);
+  expect(evicted).toHaveLength(4);
   expect(cloud.counts().resident).toBe(1);
   expect(cloud.residentPointCount).toBe(1000); // the depth-0 root node
 });
@@ -387,7 +387,7 @@ test('memory pressure evicts deferred nodes immediately, bypassing hysteresis', 
   scheduler.setBudgets({ pointBudget: 1_000, maxConcurrentDecodes: 4 });
   scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
   await drain(scheduler);
-  expect(evicted.length).toBe(4);
+  expect(evicted).toHaveLength(4);
   expect(cloud.counts().resident).toBe(1);
 });
 

--- a/tests/surfaceModels.test.ts
+++ b/tests/surfaceModels.test.ts
@@ -64,7 +64,7 @@ describe('buildDsm — top surface (max return per cell)', () => {
 
   it('emptySurfaceGrid is all-NaN with zero coverage', () => {
     const g = emptySurfaceGrid({ originH1: 0, originH2: 0, cols: 2, rows: 2, cellSizeM: 1 });
-    expect(g.z.length).toBe(4);
+    expect(g.z).toHaveLength(4);
     expect(Array.from(g.coverage)).toEqual([0, 0, 0, 0]);
     expect(g.z.every((v) => Number.isNaN(v))).toBe(true);
     expect(surfaceStats(g).coveredCells).toBe(0);

--- a/tests/terrainCoreAsync.test.ts
+++ b/tests/terrainCoreAsync.test.ts
@@ -156,7 +156,7 @@ describe('computeTerrainCoreAsync — fallback', () => {
       throwingClient,
     );
     // The fallback reads pos synchronously; if it had been detached this throws.
-    expect(pos.length).toBe(before);
+    expect(pos).toHaveLength(before);
     expect(pos[0]).toBe(0); // first x of the grid, untouched
   });
 

--- a/tests/terrainReportContent.test.ts
+++ b/tests/terrainReportContent.test.ts
@@ -336,8 +336,8 @@ describe('buildTerrainReportContent — Good + Ready scan', () => {
 
   it('omits the How-to-improve section and emits no warnings', () => {
     const c = buildTerrainReportContent(readyResult(), OPTS);
-    expect(c.howToImprove.length).toBe(0);
-    expect(c.warnings.length).toBe(0);
+    expect(c.howToImprove).toHaveLength(0);
+    expect(c.warnings).toHaveLength(0);
   });
 
   it('every recommended workflow is graded good (✓)', () => {
@@ -359,7 +359,7 @@ describe('buildTerrainReportContent — Preview + datum-unknown scan', () => {
     // verdict reason, byte-identical.
     const result = previewResult();
     const c = buildTerrainReportContent(result, OPTS);
-    expect(c.products.length).toBe(6);
+    expect(c.products).toHaveLength(6);
     const a = terrainAssessment(result);
     for (const p of c.products) {
       expect(p.availability).toBe('Preview');

--- a/tests/terrainTruth.oracleCoverage.test.ts
+++ b/tests/terrainTruth.oracleCoverage.test.ts
@@ -593,7 +593,7 @@ describe('No-data boundary on a tilted plane — ground labels and the slope art
       scalingFactorM: 0,
     };
     const res = classifyGroundSmrf(clipped, PARAMS);
-    expect(res.isGround.length).toBe(clipped.length);
+    expect(res.isGround).toHaveLength(clipped.length);
     expect(Array.from(res.isGround).every((v) => v === 1)).toBe(true);
   });
 

--- a/tests/terrainTruth.surface.test.ts
+++ b/tests/terrainTruth.surface.test.ts
@@ -180,8 +180,8 @@ describe('DSM / CHM truth — building + canopy on a ground plane', () => {
     const canopy = 5 * 5;
     expect(classFilter.excludedCount).toBe(building + canopy);
     // Excluded returns are class 5 and 6 only.
-    expect(scene.classification.filter((c) => c === ASPRS.BUILDING).length).toBe(building);
-    expect(scene.classification.filter((c) => c === ASPRS.HIGH_VEGETATION).length).toBe(canopy);
+    expect(scene.classification.filter((c) => c === ASPRS.BUILDING)).toHaveLength(building);
+    expect(scene.classification.filter((c) => c === ASPRS.HIGH_VEGETATION)).toHaveLength(canopy);
   });
 
   it('nodata is preserved where the DSM grid has no points (none here: full coverage)', () => {

--- a/tests/themes.test.ts
+++ b/tests/themes.test.ts
@@ -117,7 +117,7 @@ describe('applyTheme — body-class swap', () => {
     const matches = Array.from(body.classes).filter(
       (c) => c === 'olv-theme-light',
     );
-    expect(matches.length).toBe(1);
+    expect(matches).toHaveLength(1);
   });
 
   it('preserves unrelated body classes the host has set', () => {

--- a/tests/trainOnlyReclassify.test.ts
+++ b/tests/trainOnlyReclassify.test.ts
@@ -66,7 +66,7 @@ describe('makeTrainOnlyReclassifier — train-only ground classification', () =>
     const got = seen as unknown as ReadonlyArray<TerrainPoint>;
     // Exactly the training points, in source order — no held-out point leaks in.
     const expectedTrain = pts.filter((_, i) => heldOut[i] !== 1);
-    expect(got.length).toBe(expectedTrain.length);
+    expect(got).toHaveLength(expectedTrain.length);
     for (let j = 0; j < got.length; j++) expect(got[j]).toBe(expectedTrain[j]);
   });
 
@@ -78,7 +78,7 @@ describe('makeTrainOnlyReclassifier — train-only ground classification', () =>
       isGround: Uint8Array.from(trainPts.map((_, j) => (j % 2) as 0 | 1)),
     });
     const mask = makeTrainOnlyReclassifier(SMRF_PARAMS, spy)(pts, heldOut);
-    expect(mask.length).toBe(pts.length);
+    expect(mask).toHaveLength(pts.length);
     let j = 0;
     for (let i = 0; i < pts.length; i++) {
       if (heldOut[i] === 1) {

--- a/tests/unsafeHtmlGuard.test.ts
+++ b/tests/unsafeHtmlGuard.test.ts
@@ -474,7 +474,7 @@ describe('unsafeHtml static-analysis guard (src/ui/dom.ts contract)', () => {
 
     // Belt-and-braces: the bijection above implies this, but state it
     // plainly so a failure mode is obvious in the report.
-    expect(callSites.length).toBe(ALLOWLIST.length);
+    expect(callSites).toHaveLength(ALLOWLIST.length);
   });
 
   it('no raw .innerHTML assignment exists outside dom.ts (allowlist, one-to-one)', () => {
@@ -529,6 +529,6 @@ describe('unsafeHtml static-analysis guard (src/ui/dom.ts contract)', () => {
         'stays a faithful review record.',
     ).toEqual([]);
 
-    expect(rawInnerHtmlSites.length).toBe(RAW_INNERHTML_ALLOWLIST.length);
+    expect(rawInnerHtmlSites).toHaveLength(RAW_INNERHTML_ALLOWLIST.length);
   });
 });

--- a/tests/usageCounters.test.ts
+++ b/tests/usageCounters.test.ts
@@ -58,7 +58,7 @@ describe('usageCounters — basic increment + snapshot', () => {
   it('records a new counter on first increment', () => {
     increment('scan-open', 'laz');
     const rows = snapshot();
-    expect(rows.length).toBe(1);
+    expect(rows).toHaveLength(1);
     expect(rows[0].key).toBe('scan-open:laz');
     expect(rows[0].count).toBe(1);
     expect(rows[0].category).toBe('scan-open');
@@ -70,7 +70,7 @@ describe('usageCounters — basic increment + snapshot', () => {
     increment('measurement', 'distance');
     increment('measurement', 'distance');
     const rows = snapshot();
-    expect(rows.length).toBe(1);
+    expect(rows).toHaveLength(1);
     expect(rows[0].count).toBe(3);
   });
 
@@ -79,7 +79,7 @@ describe('usageCounters — basic increment + snapshot', () => {
     increment('scan-open', 'copc');
     increment('scan-open', 'ply');
     const rows = snapshot();
-    expect(rows.length).toBe(3);
+    expect(rows).toHaveLength(3);
     expect(rows.map((r) => r.subcategory).sort()).toEqual(['copc', 'laz', 'ply']);
   });
 
@@ -123,7 +123,7 @@ describe('usageCounters — privacy contract', () => {
     // rather than a filesystem leak.
     increment('scan-open', 'My-Survey-File.LAS');
     const rows = snapshot();
-    expect(rows.length).toBe(1);
+    expect(rows).toHaveLength(1);
     // 'my-survey-file.las' — lowercased, hyphens + dots kept, no path
     // separator possible because '/' is stripped.
     expect(rows[0].subcategory).toBe('my-survey-file.las');
@@ -132,15 +132,15 @@ describe('usageCounters — privacy contract', () => {
   it('caps subcategory length at 32 characters', () => {
     increment('scan-open', 'a'.repeat(64));
     const rows = snapshot();
-    expect(rows.length).toBe(1);
-    expect(rows[0].subcategory.length).toBe(32);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].subcategory).toHaveLength(32);
   });
 
   it('drops an empty subcategory rather than recording a blank row', () => {
     increment('scan-open', '');
     increment('scan-open', '!!!@@@###'); // sanitises to ''
     const rows = snapshot();
-    expect(rows.length).toBe(0);
+    expect(rows).toHaveLength(0);
   });
 
   it('never writes anything outside the olv.usage.v1 storage key', () => {
@@ -171,7 +171,7 @@ describe('usageCounters — LRU cap', () => {
     vi.useRealTimers();
 
     const rows = snapshot();
-    expect(rows.length).toBe(200);
+    expect(rows).toHaveLength(200);
     // The oldest entries are dropped; key-0 is gone, key-249 is in.
     const subs = rows.map((r) => r.subcategory);
     expect(subs).toContain('key-249');
@@ -183,9 +183,9 @@ describe('usageCounters — reset', () => {
   it('reset() wipes every row', () => {
     increment('scan-open', 'laz');
     increment('measurement', 'distance');
-    expect(snapshot().length).toBe(2);
+    expect(snapshot()).toHaveLength(2);
     reset();
-    expect(snapshot().length).toBe(0);
+    expect(snapshot()).toHaveLength(0);
   });
 
   it('reset() removes the storage key entirely', () => {
@@ -236,7 +236,7 @@ describe('usageCounters — defensive loading', () => {
       ]),
     );
     const rows = snapshot();
-    expect(rows.length).toBe(1);
+    expect(rows).toHaveLength(1);
     expect(rows[0].count).toBe(5);
   });
 });

--- a/tests/verticalAccuracy.test.ts
+++ b/tests/verticalAccuracy.test.ts
@@ -77,7 +77,7 @@ describe('formatVerticalAccuracy', () => {
 
   it('returns a single honest line when there is no measurement', () => {
     const lines = formatVerticalAccuracy(report(Number.NaN, Number.NaN, 0));
-    expect(lines.length).toBe(1);
+    expect(lines).toHaveLength(1);
     expect(lines[0]).toMatch(/not enough ground points/i);
   });
 });

--- a/tests/voxelDownsample.test.ts
+++ b/tests/voxelDownsample.test.ts
@@ -171,7 +171,7 @@ test('LAS inspection extras are carried through, keeping the first member', () =
   expect(out.pointCount).toBe(2);
   // Each output array exists and matches the reduced point count.
   expect(out.returnNumber).toBeInstanceOf(Uint8Array);
-  expect(out.returnNumber!.length).toBe(2);
+  expect(out.returnNumber!).toHaveLength(2);
   expect(out.gpsTime).toBeInstanceOf(Float64Array);
   // The first member's discrete metadata is kept (the contract classification uses).
   expect(Array.from(out.returnNumber!)).toEqual([1, 3]);

--- a/tests/workerRegistry.test.ts
+++ b/tests/workerRegistry.test.ts
@@ -75,7 +75,7 @@ describe('worker registry single source', () => {
   it('derives an exclude pattern for every client and async bridge', () => {
     const expected = workerExcludeModules().map((m) => m.split('/').pop());
     const patterns = workerExcludePatterns();
-    expect(patterns.length).toBe(expected.length);
+    expect(patterns).toHaveLength(expected.length);
     for (const base of expected) {
       const hit = patterns.some((re) => re.test(`src/x/${base}`));
       expect(hit, `no exclude pattern matches ${base}`).toBe(true);

--- a/tests/workflowCardRender.test.ts
+++ b/tests/workflowCardRender.test.ts
@@ -82,7 +82,7 @@ describe('renderWorkflowCard', () => {
     const { renderWorkflowCard } = await load();
     const card = renderWorkflowCard(ITEMS) as unknown as FakeEl;
     const rows = card.findAll('olv-analyse-workflow-row');
-    expect(rows.length).toBe(ITEMS.length);
+    expect(rows).toHaveLength(ITEMS.length);
     expect(rows[0].classList.contains('is-good')).toBe(true);
     expect(rows[3].classList.contains('is-caution')).toBe(true);
     expect(rows[5].classList.contains('is-blocked')).toBe(true);
@@ -96,7 +96,7 @@ describe('renderWorkflowCard', () => {
     const { renderWorkflowCard } = await load();
     const card = renderWorkflowCard(ITEMS) as unknown as FakeEl;
     const glyphs = card.findAll('olv-analyse-workflow-glyph');
-    expect(glyphs.length).toBe(ITEMS.length);
+    expect(glyphs).toHaveLength(ITEMS.length);
     expect(glyphs[0].textContent).toBe('✓');
     expect(glyphs[3].textContent).toBe('⚠');
     expect(glyphs[5].textContent).toBe('✕');
@@ -117,9 +117,9 @@ describe('renderTerrainProducts', () => {
   it('renders real list semantics: one <ul> with one <li> per product', async () => {
     const { renderTerrainProducts } = await load();
     const card = renderTerrainProducts(PRODUCTS) as unknown as FakeEl;
-    expect(card.findTag('ul').length).toBe(1);
+    expect(card.findTag('ul')).toHaveLength(1);
     const items = card.findTag('li');
-    expect(items.length).toBe(PRODUCTS.length);
+    expect(items).toHaveLength(PRODUCTS.length);
     expect(items[0].classList.contains('is-ready')).toBe(true);
     expect(items[1].classList.contains('is-preview')).toBe(true);
     expect(items[2].classList.contains('is-blocked')).toBe(true);
@@ -139,10 +139,10 @@ describe('renderTerrainProducts', () => {
     const { renderTerrainProducts } = await load();
     const card = renderTerrainProducts(PRODUCTS) as unknown as FakeEl;
     // Every row has the head line (glyph + label + status word).
-    expect(card.findAll('olv-analyse-product-head').length).toBe(3);
+    expect(card.findAll('olv-analyse-product-head')).toHaveLength(3);
     // Only the non-ready rows grow the second line; the Ready row has none.
     const reasons = card.findAll('olv-analyse-product-reason');
-    expect(reasons.length).toBe(2);
+    expect(reasons).toHaveLength(2);
     const items = card.findTag('li');
     expect(items[0].find('olv-analyse-product-reason')).toBeNull();
     // The toggle is labelled "Reason" (a <summary>) for sighted users …
@@ -160,7 +160,7 @@ describe('renderTerrainProducts', () => {
     // row's reason (already shown once above) but keeps the distinct one.
     const card = renderTerrainProducts(PRODUCTS, LONG_REASON) as unknown as FakeEl;
     const reasons = card.findAll('olv-analyse-product-reason');
-    expect(reasons.length).toBe(1); // only the Map sheet's distinct reason
+    expect(reasons).toHaveLength(1); // only the Map sheet's distinct reason
     expect(reasons[0].find('olv-analyse-product-reason-text')!.textContent).toBe(
       'quality gate stopped this surface',
     );
@@ -196,12 +196,12 @@ describe('renderWhyDetails', () => {
     const node = renderWhyDetails(LIM) as unknown as FakeEl | null;
     expect(node).not.toBeNull();
     expect(node!.tagName).toBe('details');
-    expect(node!.findTag('summary').length).toBe(1);
+    expect(node!.findTag('summary')).toHaveLength(1);
     expect(node!.textContent).toContain('55% of the surface is interpolated');
     expect(node!.textContent).toContain('Provide the vertical datum');
     // Two short lists: Why (causes) and How to improve (fixes).
-    expect(node!.findAll('olv-analyse-why-cause').length).toBe(2);
-    expect(node!.findAll('olv-analyse-why-fix').length).toBe(2);
+    expect(node!.findAll('olv-analyse-why-cause')).toHaveLength(2);
+    expect(node!.findAll('olv-analyse-why-fix')).toHaveLength(2);
   });
 
   it('renders nothing when there are no causes (fully-good surface)', async () => {

--- a/tests/workflowRecorder.test.ts
+++ b/tests/workflowRecorder.test.ts
@@ -33,7 +33,7 @@ describe('WorkflowSession — live capture', () => {
     const s = new WorkflowSession(() => t);
     s.push({ type: 'frame-all' });
     const events = s.events();
-    expect(events.length).toBe(1);
+    expect(events).toHaveLength(1);
     expect(events[0].tMs).toBe(0);
     expect(s.hasContent).toBe(true);
   });
@@ -58,7 +58,7 @@ describe('WorkflowSession — live capture', () => {
     s.push({ type: 'frame-all' });
     const a = s.events();
     a.push({ type: 'frame-all', tMs: 999 });
-    expect(s.events().length).toBe(1); // mutation didn't leak back
+    expect(s.events()).toHaveLength(1); // mutation didn't leak back
   });
 });
 
@@ -83,7 +83,7 @@ describe('buildWorkflow — Workflow construction', () => {
     expect(Object.isFrozen(w.events)).toBe(true);
     // Mutating the input array does not leak into the workflow.
     events.push({ type: 'frame-all', tMs: 100 });
-    expect(w.events.length).toBe(1);
+    expect(w.events).toHaveLength(1);
   });
 
   it('omits title when not provided', () => {
@@ -142,7 +142,7 @@ describe('parseWorkflow — file shape validation', () => {
     const result = parseWorkflow(json);
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.workflow.events.length).toBe(4);
+      expect(result.workflow.events).toHaveLength(4);
       expect(result.workflow.events[0]).toEqual({
         type: 'camera-preset',
         name: 'top',
@@ -262,7 +262,7 @@ describe('scheduleReplay — fake-clock scheduler', () => {
   it('schedules one timer per event at the declared offset', () => {
     const { deps, timers } = makeFakeDeps();
     scheduleReplay(exampleWorkflow(), () => void 0, deps);
-    expect(timers.length).toBe(3);
+    expect(timers).toHaveLength(3);
     expect(timers.map((t) => t.ms)).toEqual([0, 1500, 3000]);
   });
 
@@ -274,7 +274,7 @@ describe('scheduleReplay — fake-clock scheduler', () => {
     for (const t of timers) {
       if (!t.cancelled) t.fn();
     }
-    expect(dispatched.length).toBe(3);
+    expect(dispatched).toHaveLength(3);
     expect(dispatched[0].type).toBe('camera-preset');
     expect(dispatched[1].type).toBe('theme');
     expect(dispatched[2].type).toBe('frame-all');
@@ -306,7 +306,7 @@ describe('scheduleReplay — fake-clock scheduler', () => {
     handle.cancel();
     // A delayed call (e.g. fake timer flushed after cancel) is a no-op.
     for (const t of timers) t.fn();
-    expect(dispatched.length).toBe(0);
+    expect(dispatched).toHaveLength(0);
   });
 
   it('an empty workflow fires onComplete immediately', () => {


### PR DESCRIPTION
Rewrites length assertions flagged by typescript:S5906 to the dedicated matcher: `expect(x.length).toBe(n)` becomes `expect(x).toHaveLength(n)`.

- 357 assertions rewritten across 112 test files (356 positive, 1 negation preserved as `expect(noApx).not.toHaveLength(...)`).
- Exact asserted value preserved in every case, including length-valued expectations like `.toHaveLength(model.doorways.length)`.
- Test-only, behavior-identical (357 insertions / 357 deletions, a 1:1 line swap).
- Skips 20 sibling S5906 sites whose dedicated matcher is not length-based and is out of scope for this PR: toBeNull (9), toHaveCount playwright e2e (5), value-vs-value toBe (5), toContain (1).

Verification: `npx tsc --noEmit` exit 0; `npx vitest run` 8484 passed / 20 skipped / 1 todo (647 files), exit 0.