### PR TITLE
Mechanical SonarCloud sweep across src/ (7-area consolidation)

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,876 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,874 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -98,7 +98,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,876)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,874)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,
@@ -165,7 +165,7 @@ no DOM, three.js or proj4 (`tests/scanFootprint.test.ts`); the serialiser is
 `buildFootprintKml` in the existing `src/export/kmlExport.ts`. `main.ts` keeps
 four thin delegates and the deps object.
 
-**`src/render/Viewer.ts` (6,376)** — the constructor and a handful of large
+**`src/render/Viewer.ts` (6,369)** — the constructor and a handful of large
 methods dominate:
 
 Spans below are the symbol's real extent, read from the TypeScript symbol graph

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.4.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.4.md
@@ -4,7 +4,7 @@ This release sharpens classification, hardens the report and export surfaces aga
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,876 lines and `src/render/Viewer.ts` is 6,376, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and the composition root stays free of module-level mutable application state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,874 lines and `src/render/Viewer.ts` is 6,369, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and the composition root stays free of module-level mutable application state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## Building classification: the ground-support gate is evaluated on synthetic scenes only
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5876,
+      "lines": 5874,
       "goal": 2500
     },
     "src/render/Viewer.ts": {
-      "lines": 6376,
+      "lines": 6369,
       "goal": 2000
     }
   }

--- a/src/analysis/modules/healthCheck.ts
+++ b/src/analysis/modules/healthCheck.ts
@@ -56,9 +56,8 @@ function computeMedianAndMAD(positions: Float32Array, pointCount: number): {
 function checkInvalidCoordinates(cloud: PointCloud): AnalysisRow {
   let invalidCount = 0;
   const pos = sourcePositions(cloud);
-  for (let i = 0; i < pos.length; i++) {
-    const v = pos[i];
-    if (!isFinite(v)) {
+  for (const v of pos) {
+    if (!Number.isFinite(v)) {
       invalidCount++;
     }
   }
@@ -186,7 +185,7 @@ const EMPTY_SLOT = -1;
  * close.
  */
 function sameValueZero(a: number, b: number): boolean {
-  return a === b || (a !== a && b !== b);
+  return a === b || (Number.isNaN(a) && Number.isNaN(b));
 }
 
 /**
@@ -200,7 +199,7 @@ function sameValueZero(a: number, b: number): boolean {
 function foldCoord(hash: number, v: number): number {
   let lo: number;
   let hi: number;
-  if (v !== v) {
+  if (Number.isNaN(v)) {
     // One bucket for every NaN, whatever its payload. Reading a NaN out of a
     // Float32Array yields the canonical quiet NaN on the engines we ship to, so
     // no test can currently distinguish this branch from falling through to the

--- a/src/analysis/modules/scanReport.ts
+++ b/src/analysis/modules/scanReport.ts
@@ -26,7 +26,7 @@ function rowWarn(label: string, value: string): AnalysisRow {
  * byte-identical to the legacy result.
  */
 function withScope(row: AnalysisRow, scope: ClassScope | undefined): AnalysisRow {
-  if (scope && scope.kind === 'subset') row.scope = scope;
+  if (scope?.kind === 'subset') row.scope = scope;
   return row;
 }
 
@@ -102,7 +102,7 @@ export const scanReport: AnalysisModule = {
     // density, coverage) to the visible classes. The set is masked to a byte
     // to match how classification is stored and counted elsewhere.
     const subset =
-      scope && scope.kind === 'subset' && cloud.classification !== undefined
+      scope?.kind === 'subset' && cloud.classification !== undefined
         ? new Set(scope.codes.map((c) => c & 0xff))
         : null;
     const cls = cloud.classification;
@@ -128,9 +128,12 @@ export const scanReport: AnalysisModule = {
         if (!isVisible(i)) continue;
         n++;
         const x = pos[i * 3], y = pos[i * 3 + 1], z = pos[i * 3 + 2];
-        if (x < minX) minX = x; if (x > maxX) maxX = x;
-        if (y < minY) minY = y; if (y > maxY) maxY = y;
-        if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+        if (x < minX) minX = x;
+        if (x > maxX) maxX = x;
+        if (y < minY) minY = y;
+        if (y > maxY) maxY = y;
+        if (z < minZ) minZ = z;
+        if (z > maxZ) maxZ = z;
       }
       if (n === 0) {
         // No visible points — every extent collapses to zero so the degenerate
@@ -184,9 +187,11 @@ export const scanReport: AnalysisModule = {
     const width = spanX * mpu;
     const depth = (zUp ? spanY : spanZ) * mpu;
     const height = (zUp ? spanZ : spanY) * vmpu;
-    rows.push(withScope(rowInfo('Width', `${width.toFixed(1)}${basis.lengthUnit}`), scope));
-    rows.push(withScope(rowInfo('Depth', `${depth.toFixed(1)}${basis.lengthUnit}`), scope));
-    rows.push(withScope(rowInfo('Height', `${height.toFixed(1)}${basis.lengthUnit}`), scope));
+    rows.push(
+      withScope(rowInfo('Width', `${width.toFixed(1)}${basis.lengthUnit}`), scope),
+      withScope(rowInfo('Depth', `${depth.toFixed(1)}${basis.lengthUnit}`), scope),
+      withScope(rowInfo('Height', `${height.toFixed(1)}${basis.lengthUnit}`), scope),
+    );
 
     const footprintArea = width * depth;
 
@@ -258,20 +263,19 @@ export const scanReport: AnalysisModule = {
             `${precision.worstCaseSpacing.toPrecision(3)} (source units) worst case — `
               + 'no linear unit declared, not graded',
           ),
+      {
+        label: 'Quantization basis',
+        value:
+          `Float32 positions, ${precision.governingAxis} axis, `
+          + `${precision.reach.toFixed(0)} source units from the local origin `
+          + `(${precision.localOrigin.map((n) => n.toFixed(0)).join(', ')})`,
+        status: 'info',
+        advanced: true,
+      },
+      // Attribute coverage.
+      rowInfo('RGB', cloud.colors !== undefined ? 'Yes' : 'No'),
+      rowInfo('Intensity', cloud.intensity !== undefined ? 'Yes' : 'No'),
     );
-    rows.push({
-      label: 'Quantization basis',
-      value:
-        `Float32 positions, ${precision.governingAxis} axis, `
-        + `${precision.reach.toFixed(0)} source units from the local origin `
-        + `(${precision.localOrigin.map((n) => n.toFixed(0)).join(', ')})`,
-      status: 'info',
-      advanced: true,
-    });
-
-    // Attribute coverage.
-    rows.push(rowInfo('RGB', cloud.colors !== undefined ? 'Yes' : 'No'));
-    rows.push(rowInfo('Intensity', cloud.intensity !== undefined ? 'Yes' : 'No'));
     // A cloud can carry the classification dimension while every point is still
     // unassigned (ASPRS 0 = never classified, 1 = unclassified). A bare "Yes"
     // there implies a classified cloud that isn't — so report the honest state.
@@ -348,8 +352,10 @@ export const scanReport: AnalysisModule = {
     const corner = (c: [number, number, number]): string =>
       `${(c[0] + origin[0]).toFixed(3)}, ${(c[1] + origin[1]).toFixed(3)}, ` +
       `${(c[2] + origin[2]).toFixed(3)}`;
-    rows.push({ label: 'Min corner', value: corner(bounds.min), status: 'info', advanced: true });
-    rows.push({ label: 'Max corner', value: corner(bounds.max), status: 'info', advanced: true });
+    rows.push(
+      { label: 'Min corner', value: corner(bounds.min), status: 'info', advanced: true },
+      { label: 'Max corner', value: corner(bounds.max), status: 'info', advanced: true },
+    );
 
     // The absolute corners carry an absolute Z, which asserts a vertical
     // reference the reader cannot recover from the number alone. State it,
@@ -374,6 +380,6 @@ export const scanReport: AnalysisModule = {
     // (v0.5.5 P12 — the separate "Classification Coverage" diagnostic row
     // merged into the main Classification row above.)
 
-    return scope && scope.kind === 'subset' ? { rows, scope } : { rows };
+    return scope?.kind === 'subset' ? { rows, scope } : { rows };
   },
 };

--- a/src/analysis/streamingExtentRows.ts
+++ b/src/analysis/streamingExtentRows.ts
@@ -75,8 +75,10 @@ export function streamingExtentRows(
     const spacing = Math.sqrt(footprintArea / sourcePointCount);
     const densityUnit = unitConfirmed ? ' pts/m²' : ' pts/unit²';
     const spacingUnit = unitConfirmed ? ' m' : ' (source units)';
-    rows.push({ label: 'Density', value: `${density.toFixed(1)}${densityUnit}`, scoped: true });
-    rows.push({ label: 'Spacing', value: `${spacing.toFixed(2)}${spacingUnit}`, scoped: true });
+    rows.push(
+      { label: 'Density', value: `${density.toFixed(1)}${densityUnit}`, scoped: true },
+      { label: 'Spacing', value: `${spacing.toFixed(2)}${spacingUnit}`, scoped: true },
+    );
   }
 
   return { unitConfirmed, rows };

--- a/src/app/actionDefinitions.ts
+++ b/src/app/actionDefinitions.ts
@@ -304,44 +304,42 @@ export function buildActionRegistry(deps: ActionRegistryDeps): Action[] {
   // v0.5.2 — verify a handed-over integrity report. Opens a file picker, reads
   // the JSON, recomputes its digest (the algorithm is self-described in the
   // file), and shows intact / modified. Ungated; the verifier loads on demand.
-  actions.push({
-    id: 'report.verify',
-    title: 'Verify integrity report…',
-    section: 'Export',
-    hint: 'Check a report JSON — confirm its digest still matches its contents.',
-    keywords: ['integrity', 'digest', 'tamper', 'check', 'sha', 'validate', 'verify'],
-    run: () => {
-      const input = el('input', { className: 'olv-hidden' });
-      input.type = 'file';
-      input.accept = '.json,application/json';
-      input.addEventListener('change', () => {
-        const file = input.files?.[0];
-        input.remove();
-        if (!file) return;
-        void loadReportVerifier().then(({ verifyAndShow }) => verifyAndShow(file));
-      });
-      document.body.append(input);
-      input.click();
-    },
-  });
-
-  // v0.5.3 — toggle the on-canvas compass (promoted to a default control). The
-  // choice persists; the widget loads lazily the first time it is shown.
-  actions.push({
-    id: 'view.compass',
-    title: 'Toggle compass',
-    section: 'View',
-    hint: 'Show or hide the on-canvas compass — north plus the standard-view snaps.',
-    keywords: ['compass', 'viewcube', 'north', 'rose', 'orientation', 'heading', 'gizmo'],
-    run: () => deps.compass.setEnabled(!deps.compass.isEnabled()),
-  });
-
-  // v7 sessions — named view states from the palette. Both handlers already
-  // live in this shell (the same saveCurrentView/applyView the panels call),
-  // so these entries add only sub-KB registry rows — no new code is dragged
-  // into the eager bundle. `keys: 'V'` advertises the binding that
-  // ui/shortcuts.ts actually fires; the registry `keys` field is display-only.
   actions.push(
+    {
+      id: 'report.verify',
+      title: 'Verify integrity report…',
+      section: 'Export',
+      hint: 'Check a report JSON — confirm its digest still matches its contents.',
+      keywords: ['integrity', 'digest', 'tamper', 'check', 'sha', 'validate', 'verify'],
+      run: () => {
+        const input = el('input', { className: 'olv-hidden' });
+        input.type = 'file';
+        input.accept = '.json,application/json';
+        input.addEventListener('change', () => {
+          const file = input.files?.[0];
+          input.remove();
+          if (!file) return;
+          void loadReportVerifier().then(({ verifyAndShow }) => verifyAndShow(file));
+        });
+        document.body.append(input);
+        input.click();
+      },
+    },
+    // v0.5.3 — toggle the on-canvas compass (promoted to a default control). The
+    // choice persists; the widget loads lazily the first time it is shown.
+    {
+      id: 'view.compass',
+      title: 'Toggle compass',
+      section: 'View',
+      hint: 'Show or hide the on-canvas compass — north plus the standard-view snaps.',
+      keywords: ['compass', 'viewcube', 'north', 'rose', 'orientation', 'heading', 'gizmo'],
+      run: () => deps.compass.setEnabled(!deps.compass.isEnabled()),
+    },
+    // v7 sessions — named view states from the palette. Both handlers already
+    // live in this shell (the same saveCurrentView/applyView the panels call),
+    // so these entries add only sub-KB registry rows — no new code is dragged
+    // into the eager bundle. `keys: 'V'` advertises the binding that
+    // ui/shortcuts.ts actually fires; the registry `keys` field is display-only.
     {
       id: 'view.save-state',
       title: 'Save view state',
@@ -373,32 +371,30 @@ export function buildActionRegistry(deps: ActionRegistryDeps): Action[] {
         deps.applyView(deps.bookmarks.count() - 1);
       },
     },
+    // v0.3.9 — Onboarding tour replay. Surfaces the tour from the
+    // command palette so users who skipped or dismissed can re-trigger
+    // it from one keystroke (Cmd-K → "tour").
+    {
+      id: 'tour.replay',
+      title: 'Replay onboarding tour',
+      section: 'Help',
+      hint: 'Walks through the main tools — about 30 seconds.',
+      keywords: ['onboarding', 'tour', 'help', 'tutorial', 'guide', 'walkthrough'],
+      run: () => deps.getTour()?.replay(),
+    },
+    // v0.3.9 — Keyboard shortcut sheet. Surfaces the sheet from the
+    // palette and lists its own binding (`?`) so users who discovered
+    // the palette via Cmd-K can find the sheet from the same surface.
+    {
+      id: 'help.shortcuts',
+      title: 'Show keyboard shortcuts',
+      section: 'Help',
+      keys: '?',
+      hint: 'Every action and key, grouped by section.',
+      keywords: ['shortcuts', 'keys', 'bindings', 'help', 'cheat', 'sheet'],
+      run: () => void deps.ensureShortcutSheet().then((sheet) => sheet.open()),
+    },
   );
-
-  // v0.3.9 — Onboarding tour replay. Surfaces the tour from the
-  // command palette so users who skipped or dismissed can re-trigger
-  // it from one keystroke (Cmd-K → "tour").
-  actions.push({
-    id: 'tour.replay',
-    title: 'Replay onboarding tour',
-    section: 'Help',
-    hint: 'Walks through the main tools — about 30 seconds.',
-    keywords: ['onboarding', 'tour', 'help', 'tutorial', 'guide', 'walkthrough'],
-    run: () => deps.getTour()?.replay(),
-  });
-
-  // v0.3.9 — Keyboard shortcut sheet. Surfaces the sheet from the
-  // palette and lists its own binding (`?`) so users who discovered
-  // the palette via Cmd-K can find the sheet from the same surface.
-  actions.push({
-    id: 'help.shortcuts',
-    title: 'Show keyboard shortcuts',
-    section: 'Help',
-    keys: '?',
-    hint: 'Every action and key, grouped by section.',
-    keywords: ['shortcuts', 'keys', 'bindings', 'help', 'cheat', 'sheet'],
-    run: () => void deps.ensureShortcutSheet().then((sheet) => sheet.open()),
-  });
 
   return actions;
 }

--- a/src/app/crsCoordinator.ts
+++ b/src/app/crsCoordinator.ts
@@ -164,9 +164,22 @@ export function createCrsCoordinator(deps: CrsCoordinatorDeps): CrsCoordinator {
     const vw = getViewer();
     const act = getActiveId();
     const sc = vw.streamingCloud;
-    const detected =
-      (sc ? sc.crs() : act ? vw.getCloud(act)?.metadata?.crs : undefined) ?? undefined;
-    const source: CrsSource = sc ? (sc.kind === 'ept' ? 'ept-srs' : 'copc-meta') : 'las-vlr';
+    let detected: CrsInfo | undefined;
+    if (sc) {
+      detected = sc.crs() ?? undefined;
+    } else if (act) {
+      detected = vw.getCloud(act)?.metadata?.crs ?? undefined;
+    } else {
+      detected = undefined;
+    }
+    let source: CrsSource;
+    if (!sc) {
+      source = 'las-vlr';
+    } else if (sc.kind === 'ept') {
+      source = 'ept-srs';
+    } else {
+      source = 'copc-meta';
+    }
     crsService.setOverride({ override, detected, source });
     if (!(override.epsg === null && override.kind === 'local')) {
       recordUsage('scan-open', `crs-override:${override.epsg ?? 'local'}`);

--- a/src/app/layerHealth.ts
+++ b/src/app/layerHealth.ts
@@ -218,51 +218,45 @@ export function buildLayerHealth(input: LayerHealthInput): LayerHealthRow[] {
     rows.push({ label: 'Coordinate system', value: `${input.crsName}${source}`, status: 'ok' });
   }
 
+  // One layer has nothing to combine WITH, so "eligible for combined
+  // results" overstates — the compatibility report says the same in its
+  // "cross-layer comparison does not apply" line. Keep the two agreeing.
+  let projectFrameRow: LayerHealthRow;
+  if (input.soleLayer ?? false) {
+    projectFrameRow = {
+      label: 'Project frame',
+      value: 'single layer — analysed on its own frame, nothing to combine',
+      status: 'info',
+    };
+  } else if (input.mounted) {
+    projectFrameRow = {
+      label: 'Project frame',
+      value: 'mounted — eligible for combined results',
+      status: 'ok',
+    };
+  } else {
+    projectFrameRow = {
+      label: 'Project frame',
+      value: 'not mounted — kept in its own frame, excluded from combined results',
+      status: 'info',
+    };
+  }
+
   rows.push(
     input.horizontalUnit === null
       ? { label: 'Horizontal unit', value: 'unknown', status: 'warn' }
       : { label: 'Horizontal unit', value: input.horizontalUnit, status: 'ok' },
-  );
-  // The vertical unit is its own declaration. Borrowing the horizontal one
-  // here would repeat, in words, the unit bug the precision gate exists to
-  // refuse in numbers.
-  rows.push(
+    // The vertical unit is its own declaration. Borrowing the horizontal one
+    // here would repeat, in words, the unit bug the precision gate exists to
+    // refuse in numbers.
     input.verticalUnit === null
       ? { label: 'Vertical unit', value: 'unknown', status: 'warn' }
       : { label: 'Vertical unit', value: input.verticalUnit, status: 'ok' },
-  );
-  rows.push(
     input.verticalDatum === null
       ? { label: 'Vertical datum', value: 'not established', status: 'warn' }
       : { label: 'Vertical datum', value: input.verticalDatum, status: 'ok' },
-  );
-
-  rows.push(compatibilityRow(input.compatibility, input.soleLayer ?? false));
-
-  rows.push(
-    (input.soleLayer ?? false)
-      // One layer has nothing to combine WITH, so "eligible for combined
-      // results" overstates — the compatibility report says the same in its
-      // "cross-layer comparison does not apply" line. Keep the two agreeing.
-      ? {
-          label: 'Project frame',
-          value: 'single layer — analysed on its own frame, nothing to combine',
-          status: 'info',
-        }
-      : input.mounted
-        ? {
-            label: 'Project frame',
-            value: 'mounted — eligible for combined results',
-            status: 'ok',
-          }
-        : {
-            label: 'Project frame',
-            value: 'not mounted — kept in its own frame, excluded from combined results',
-            status: 'info',
-          },
-  );
-
-  rows.push(
+    compatibilityRow(input.compatibility, input.soleLayer ?? false),
+    projectFrameRow,
     input.sourceOrigin === null
       ? { label: 'Source origin', value: 'not declared', status: 'info' }
       : {
@@ -271,9 +265,6 @@ export function buildLayerHealth(input: LayerHealthInput): LayerHealthRow[] {
           status: 'ok',
           mono: true,
         },
-  );
-
-  rows.push(
     input.frameOffset === null
       ? { label: 'Offset to project', value: 'none — not in a shared frame', status: 'info' }
       : {
@@ -287,9 +278,8 @@ export function buildLayerHealth(input: LayerHealthInput): LayerHealthRow[] {
   const identityPlacement =
     input.frameOffset === null ||
     (input.frameOffset[0] === 0 && input.frameOffset[1] === 0 && input.frameOffset[2] === 0);
-  rows.push(precisionRow(input.precisionMm, input.precisionBasis, identityPlacement));
-
   rows.push(
+    precisionRow(input.precisionMm, input.precisionBasis, identityPlacement),
     input.streaming
       ? {
           label: 'Loading',
@@ -357,12 +347,14 @@ export function buildCompatibilityReport(
     });
   }
 
-  const verdict =
-    allVerified && allDatumsKnown
-      ? 'These layers share one established reference, so plan and height results can be combined.'
-      : allHorizontal
-        ? 'These layers overlay in plan only; each keeps its own heights until a shared vertical reference is established.'
-        : 'Not every layer has an established frame, so combined results exclude the unproven ones.';
+  let verdict: string;
+  if (allVerified && allDatumsKnown) {
+    verdict = 'These layers share one established reference, so plan and height results can be combined.';
+  } else if (allHorizontal) {
+    verdict = 'These layers overlay in plan only; each keeps its own heights until a shared vertical reference is established.';
+  } else {
+    verdict = 'Not every layer has an established frame, so combined results exclude the unproven ones.';
+  }
 
   return { lines, verdict };
 }

--- a/src/app/sessionIo.ts
+++ b/src/app/sessionIo.ts
@@ -168,8 +168,14 @@ export function declaredSpatialFromStreaming(cloud: StreamingScanSource): Declar
  */
 export function declaredSpatialFromStatic(cloud: StaticScanCloud): DeclaredSpatialFacts {
   const crs = cloud.metadata?.crs;
+  let upAxis: 'y' | 'z' | undefined;
+  if (cloud.sourceFormat) {
+    upAxis = isZUpFormat(cloud.sourceFormat) ? 'z' : 'y';
+  } else {
+    upAxis = undefined;
+  }
   return {
-    upAxis: cloud.sourceFormat ? (isZUpFormat(cloud.sourceFormat) ? 'z' : 'y') : undefined,
+    upAxis,
     epsg: crs?.epsg,
     linearUnit: crs?.linearUnit,
   };
@@ -330,8 +336,9 @@ export async function importSession(
           // scene until the user opts in. "Apply anyway" re-imports with the
           // check skipped, so the same restore proceeds on their confirmation.
           const why = match.reasons[0] ?? '';
+          const whyDetail = why ? ` (${why})` : '';
           deps.showToast(
-            `This session's scan couldn't be fully verified${why ? ` (${why})` : ''}. ` +
+            `This session's scan couldn't be fully verified${whyDetail}. ` +
               'Applying it may place its measurements on the wrong scan.',
             { label: 'Apply anyway', onClick: () => void importSession(file, { skipScanConfirm: true }, deps) },
           );
@@ -425,8 +432,7 @@ export async function importSession(
     // author's CRS override so an Evidence Capsule round-trips without
     // re-prompting; a session that declared no usable CRS leaves the file's own.
     if (
-      session.crs &&
-      session.crs.epsg != null &&
+      session.crs?.epsg != null &&
       (session.crs.kind === 'projected' || session.crs.kind === 'geographic' || session.crs.kind === 'local')
     ) {
       deps.setCrsOverride({

--- a/src/app/staleChunkReload.ts
+++ b/src/app/staleChunkReload.ts
@@ -166,18 +166,22 @@ export function installStaleChunkRecovery(
       // lands back exactly where they were.
       if (typeof location !== 'undefined') location.reload();
     });
-  const storage =
-    opts.storage !== undefined
-      ? opts.storage
-      : typeof sessionStorage !== 'undefined'
-        ? sessionStorage
-        : null;
-  const eventTarget =
-    opts.eventTarget !== undefined
-      ? opts.eventTarget
-      : typeof window !== 'undefined'
-        ? (window as unknown as EventTargetLike)
-        : null;
+  let storage: StorageLike | null;
+  if (opts.storage !== undefined) {
+    storage = opts.storage;
+  } else if (typeof sessionStorage !== 'undefined') {
+    storage = sessionStorage;
+  } else {
+    storage = null;
+  }
+  let eventTarget: EventTargetLike | null;
+  if (opts.eventTarget !== undefined) {
+    eventTarget = opts.eventTarget;
+  } else if (typeof window !== 'undefined') {
+    eventTarget = window as unknown as EventTargetLike;
+  } else {
+    eventTarget = null;
+  }
   const onUnrecoverable = opts.onUnrecoverable;
   const log = opts.log ?? ((reason: string) => console.warn('[staleChunkReload]', reason));
 

--- a/src/app/terrainAnalysisRunner.ts
+++ b/src/app/terrainAnalysisRunner.ts
@@ -105,11 +105,14 @@ export function deriveCoreParams(
   // has to keep the raster self-consistent with the coordinates it is built
   // over. The metric claims downstream (densities, areas, volumes) are the ones
   // that gate on the context's `metricClaimsPermitted`.
-  const metresPerUnit = isGeographic
-    ? METRES_PER_DEGREE
-    : ctx.linearUnitToMetres > 0
-      ? ctx.linearUnitToMetres
-      : 1;
+  let metresPerUnit: number;
+  if (isGeographic) {
+    metresPerUnit = METRES_PER_DEGREE;
+  } else if (ctx.linearUnitToMetres > 0) {
+    metresPerUnit = ctx.linearUnitToMetres;
+  } else {
+    metresPerUnit = 1;
+  }
   const extent = Math.max(maxX - minX, maxY - minY, 1 / metresPerUnit);
   const cellSizeM = Math.max(0.25 / metresPerUnit, extent / 256);
   // Grid-centre latitude for the pipeline's cos φ east–west corrections.

--- a/src/canonicalHash.ts
+++ b/src/canonicalHash.ts
@@ -28,7 +28,9 @@
  * This comparator is for strings. Numeric arrays need `(a, b) => a - b`.
  */
 export function compareCodeUnits(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
 }
 
 /** Deterministic JSON with sorted object keys, so a fingerprint is stable. */
@@ -37,7 +39,8 @@ export function canonicalJson(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
   const obj = value as Record<string, unknown>;
   const keys = Object.keys(obj).sort(compareCodeUnits);
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`).join(',')}}`;
+  const entries = keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`);
+  return `{${entries.join(',')}}`;
 }
 
 /** FNV-1a 32-bit over a UTF-16 code-unit stream, as an 8-hex-digit string. */

--- a/src/convert/convertCloud.ts
+++ b/src/convert/convertCloud.ts
@@ -225,10 +225,14 @@ export function convertCloud(
     // source unit exactly like keep mode (stamping 9001 on a skipped reproject
     // mislabelled foot data as metres — v0.4.4 defect). Assigned tags leave the
     // unit implied by the EPSG. Vertical datum is preserved (no mode moves Z).
-    const linearUnitCode =
-      mode === 'reproject' && reprojectApplied ? 9001
-      : (mode === 'keep' || mode === 'reproject') && srcCrs ? unitToGeoTiff(srcCtx.linearUnit)
-      : null;
+    let linearUnitCode: number | null;
+    if (mode === 'reproject' && reprojectApplied) {
+      linearUnitCode = 9001;
+    } else if ((mode === 'keep' || mode === 'reproject') && srcCrs) {
+      linearUnitCode = unitToGeoTiff(srcCtx.linearUnit);
+    } else {
+      linearUnitCode = null;
+    }
     // Vertical unit: Z is untouched by every mode, so its unit is the SOURCE's
     // declared vertical unit — falling back to the source's horizontal family
     // (the GeoTIFF convention that vertical tracks the model's units), never

--- a/src/convert/writeLas.ts
+++ b/src/convert/writeLas.ts
@@ -145,7 +145,8 @@ export function composeGeneratingSoftware(
   id: Pick<BuildIdentity, 'version' | 'commit' | 'dirty'> = BUILD_IDENTITY,
 ): string {
   const hasCommit = id.commit.length > 0 && id.commit !== 'unknown';
-  const commit = hasCommit ? `${id.commit}${id.dirty ? '+dirty' : ''}` : null;
+  const dirtySuffix = id.dirty ? '+dirty' : '';
+  const commit = hasCommit ? `${id.commit}${dirtySuffix}` : null;
   const candidates = [
     commit ? `${PRODUCT_NAME} ${id.version} ${commit}` : null,
     `${PRODUCT_NAME} ${id.version}`,
@@ -236,8 +237,10 @@ function buildGeoKeys(opts: WriteLasOptions, geo: boolean): Array<[number, numbe
   const hasCrs = opts.epsg != null && Number.isFinite(opts.epsg) && opts.epsg > 0 && opts.epsg <= 65535;
   const geoKeys: Array<[number, number]> = [];
   if (hasCrs) {
-    geoKeys.push([1024, geo ? 2 : 1]); // GTModelType: geographic / projected
-    geoKeys.push([geo ? 2048 : 3072, opts.epsg as number]); // Geographic/ProjectedCSType
+    geoKeys.push(
+      [1024, geo ? 2 : 1], // GTModelType: geographic / projected
+      [geo ? 2048 : 3072, opts.epsg as number], // Geographic/ProjectedCSType
+    );
     if (!geo && opts.linearUnitCode != null && opts.linearUnitCode > 0) {
       geoKeys.push([3076, opts.linearUnitCode]); // ProjLinearUnits (metre/foot/US ft)
     }
@@ -298,10 +301,10 @@ const TEXT_AREA_DESCRIPTION_RECORD_ID = 3;
  */
 function asciiFold(s: string): string {
   return s
-    .replace(/[—–]/g, '-')
-    .replace(/≈/g, '~=')
-    .replace(/→/g, '->')
-    .replace(/[^\x00-\x7f]/g, '?');
+    .replaceAll(/[—–]/g, '-')
+    .replaceAll(/≈/g, '~=')
+    .replaceAll(/→/g, '->')
+    .replaceAll(/[^\x00-\x7f]/g, '?');
 }
 
 /**

--- a/src/convert/zipStore.ts
+++ b/src/convert/zipStore.ts
@@ -91,8 +91,8 @@ const CRC_TABLE = (() => {
 
 function crc32(bytes: Uint8Array): number {
   let c = 0xffffffff;
-  for (let i = 0; i < bytes.length; i++) {
-    c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  for (const b of bytes) {
+    c = CRC_TABLE[(c ^ b) & 0xff] ^ (c >>> 8);
   }
   return (c ^ 0xffffffff) >>> 0;
 }

--- a/src/diagnostics/provenance.ts
+++ b/src/diagnostics/provenance.ts
@@ -48,6 +48,9 @@ export type CaptureType =
   | 'spaceborne'        // GEDI, ICESat-2, CALIOP
   | 'unknown';
 
+/** The classifier's confidence in its verdict. */
+export type Confidence = 'low' | 'medium' | 'high';
+
 /**
  * A single literature-derived bound. Plain prose so the UI can render it
  * verbatim; each one names the source paper so the user (and a reviewer of
@@ -62,7 +65,7 @@ export interface AccuracyBound {
 /** The classifier's verdict for a loaded scan. */
 export interface ProvenanceFingerprint {
   readonly captureType: CaptureType;
-  readonly confidence: 'low' | 'medium' | 'high';
+  readonly confidence: Confidence;
   /** Short human-readable label, e.g. "iPhone / handheld LiDAR". */
   readonly label: string;
   /** Why the classifier picked this — surfaced in the UI under "Signals". */
@@ -469,7 +472,7 @@ function matchNumeric(signals: ScanSignals): ProvenanceFingerprint | null {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function phoneLidarFingerprint(
-  confidence: 'low' | 'medium' | 'high',
+  confidence: Confidence,
   signals: readonly string[],
 ): ProvenanceFingerprint {
   return {
@@ -509,7 +512,7 @@ function phoneLidarFingerprint(
 }
 
 function droneLidarFingerprint(
-  confidence: 'low' | 'medium' | 'high',
+  confidence: Confidence,
   signals: readonly string[],
 ): ProvenanceFingerprint {
   return {
@@ -539,7 +542,7 @@ function droneLidarFingerprint(
 }
 
 function terrestrialFingerprint(
-  confidence: 'low' | 'medium' | 'high',
+  confidence: Confidence,
   signals: readonly string[],
 ): ProvenanceFingerprint {
   return {
@@ -564,7 +567,7 @@ function terrestrialFingerprint(
 }
 
 function mobileSlamFingerprint(
-  confidence: 'low' | 'medium' | 'high',
+  confidence: Confidence,
   signals: readonly string[],
 ): ProvenanceFingerprint {
   return {
@@ -594,7 +597,7 @@ function mobileSlamFingerprint(
 }
 
 function aerialAlsFingerprint(
-  confidence: 'low' | 'medium' | 'high',
+  confidence: Confidence,
   signals: readonly string[],
 ): ProvenanceFingerprint {
   return {
@@ -632,7 +635,7 @@ function aerialAlsFingerprint(
 }
 
 function spaceborneFingerprint(
-  confidence: 'low' | 'medium' | 'high',
+  confidence: Confidence,
   signals: readonly string[],
 ): ProvenanceFingerprint {
   return {

--- a/src/export/BaseExportMode.ts
+++ b/src/export/BaseExportMode.ts
@@ -191,9 +191,11 @@ export function baseReportRows(
     const w = box[3] - box[0];
     const d = box[4] - box[1];
     const h = box[5] - box[2];
-    rows.push({ label: 'Width',  value: formatLinear(w, unit) });
-    rows.push({ label: 'Depth',  value: formatLinear(d, unit) });
-    rows.push({ label: 'Height', value: formatLinear(h, unit) });
+    rows.push(
+      { label: 'Width',  value: formatLinear(w, unit) },
+      { label: 'Depth',  value: formatLinear(d, unit) },
+      { label: 'Height', value: formatLinear(h, unit) },
+    );
     // Density — points per square unit on the XY footprint.
     if (w > 0 && d > 0) {
       const density = adapter.sourcePointCount() / (w * d);
@@ -204,30 +206,35 @@ export function baseReportRows(
   }
   // Capability summary — which channels the export can honour. Matches the
   // Scan Intelligence panel's RGB/Intensity/Classification rows.
-  rows.push({ label: 'RGB',           value: adapter.hasRgb() ? 'Yes' : 'No' });
-  rows.push({ label: 'Intensity',     value: adapter.hasIntensity() ? 'Yes' : 'No' });
+  rows.push(
+    { label: 'RGB',           value: adapter.hasRgb() ? 'Yes' : 'No' },
+    { label: 'Intensity',     value: adapter.hasIntensity() ? 'Yes' : 'No' },
+  );
   // Presence gates the classification RENDER; coverage is what a reader of the
   // report needs. An all-code-0 file has the channel and no classes, and a bare
   // "Yes" for it contradicted the Scan Report panel on the same scan. Fall back
   // to presence only when coverage genuinely cannot be counted — never invent a
   // percentage.
   const assigned = adapter.classificationAssignedFraction?.() ?? null;
-  rows.push({
-    label: 'Classification',
-    value: !adapter.hasClassification()
-      ? 'No'
-      : assigned === null
-        ? 'Yes'
-        : `Present, ${assigned > 0 ? 'classified' : 'unclassified'} ` +
-          `(${(assigned * 100).toFixed(1)} % coverage)`,
-  });
+  let classificationValue: string;
+  if (!adapter.hasClassification()) {
+    classificationValue = 'No';
+  } else if (assigned === null) {
+    classificationValue = 'Yes';
+  } else {
+    const classified = assigned > 0 ? 'classified' : 'unclassified';
+    classificationValue = `Present, ${classified} (${(assigned * 100).toFixed(1)} % coverage)`;
+  }
+  rows.push({ label: 'Classification', value: classificationValue });
   // CRS provenance, when the source file declares one. This
   // is the row that makes the export research-grade: an analyst reading the
   // PNG later knows the datum and the linear unit the dimensions are in.
   const crs = adapter.crsLabel();
   if (crs) {
-    rows.push({ label: 'CRS',   value: crs.name });
-    rows.push({ label: 'Units', value: crs.unit });
+    rows.push(
+      { label: 'CRS',   value: crs.name },
+      { label: 'Units', value: crs.unit },
+    );
   }
   // Capture-type row — auto-computed from the provenance classifier so
   // every exported image carries the same Research-Derived capture

--- a/src/export/OrthographicRgbExporter.ts
+++ b/src/export/OrthographicRgbExporter.ts
@@ -86,7 +86,7 @@ export function shouldExportGeoreferencedOrtho(
   if (!adapter.localBoundsAabb()) return false;
   if ((classScopeStamp ?? '').trim().length > 0) return false;
   const geo = adapter.georefContext?.() ?? null;
-  if (!geo || geo.worldOrigin == null) return false;
+  if (geo?.worldOrigin == null) return false;
   return geo.wkt != null && geo.wkt.trim().length > 0;
 }
 

--- a/src/export/contourExportPermit.ts
+++ b/src/export/contourExportPermit.ts
@@ -71,7 +71,7 @@ export interface ContourPermitContext {
    */
   readonly precision: PrecisionPermit | null;
   /** Injectable evidence lookup (defaults to the claim registry) — for tests. */
-  readonly evidenceStatusOf?: ExportDecisionContext['evidenceStatusOf'];
+  readonly evidenceStatusOf?: NonNullable<ExportDecisionContext['evidenceStatusOf']>;
 }
 
 /**

--- a/src/export/exportStaleness.ts
+++ b/src/export/exportStaleness.ts
@@ -26,7 +26,7 @@ export function parseVersion(version: string): readonly number[] {
     .replace(/^v/i, '')
     .split('.')
     .map((p) => {
-      const n = parseInt(p, 10);
+      const n = Number.parseInt(p, 10);
       return Number.isFinite(n) ? n : 0;
     });
 }

--- a/src/export/kmlExport.ts
+++ b/src/export/kmlExport.ts
@@ -159,11 +159,11 @@ export function kmlAltitudeMode(
 /** Escape text for XML content / attribute values (& < > " '). */
 function esc(s: string): string {
   return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
+    .replaceAll(/&/g, '&amp;')
+    .replaceAll(/</g, '&lt;')
+    .replaceAll(/>/g, '&gt;')
+    .replaceAll(/"/g, '&quot;')
+    .replaceAll(/'/g, '&apos;');
 }
 
 /**
@@ -243,10 +243,14 @@ function sourceElevationLine(input: KmlExportInput, sourceZ: number): string {
   // geometry that had correctly refused to carry an altitude at all. The
   // reader takes the number and its unit together, so an honest ordinate and
   // a guessed unit is not half right.
-  const unit =
-    f === undefined ? 'source vertical units (scale unknown)'
-    : Math.abs(f - 1) < 1e-9 ? 'metres'
-    : `source vertical units (1 unit = ${fmt(f)} m)`;
+  let unit: string;
+  if (f === undefined) {
+    unit = 'source vertical units (scale unknown)';
+  } else if (Math.abs(f - 1) < 1e-9) {
+    unit = 'metres';
+  } else {
+    unit = `source vertical units (1 unit = ${fmt(f)} m)`;
+  }
   const datum = input.verticalDatum?.trim() || 'undeclared';
   return `Source elevation: ${fmt(sourceZ)} ${unit}, vertical datum: ${datum}.`;
 }
@@ -456,7 +460,7 @@ export function buildFootprintKml(input: KmlFootprintInput): string {
     );
   }
   const first = ring[0];
-  const last = ring[ring.length - 1];
+  const last = ring.at(-1)!;
   if (first[0] !== last[0] || first[1] !== last[1]) {
     throw new ScanFootprintError(
       'The scan outline does not close: its last corner must repeat its first.',
@@ -465,6 +469,7 @@ export function buildFootprintKml(input: KmlFootprintInput): string {
   const crs = input.crsName ?? 'unknown CRS';
   const coords = ring.map(([lon, lat]) => coord([lon, lat, 0], false)).join(' ');
   const label = `${input.name} scan area`;
+  const rectLabel = `${label} (bounding rectangle)`;
   const lines = [
     'Bounding rectangle of the scanned area, reprojected to WGS84 longitude/latitude.',
     `Source CRS: ${crs}. Extent read from ${input.extentBasis}.`,
@@ -478,7 +483,7 @@ export function buildFootprintKml(input: KmlFootprintInput): string {
     `<name>${esc(label)}</name>`,
     description(lines),
     '<Placemark>',
-    `<name>${esc(`${label} (bounding rectangle)`)}</name>`,
+    `<name>${esc(rectLabel)}</name>`,
     description(lines),
     '<Polygon>',
     '<altitudeMode>clampToGround</altitudeMode>',

--- a/src/export/measurementExport.ts
+++ b/src/export/measurementExport.ts
@@ -254,7 +254,7 @@ function csvCell(v: string | number): string {
   const s = String(v);
   const neutralise = typeof v === 'string' && /^[=+\-@\t\r]/.test(s);
   const cell = neutralise ? `'${s}` : s;
-  return neutralise || /[",\n]/.test(cell) ? `"${cell.replace(/"/g, '""')}"` : cell;
+  return neutralise || /[",\n]/.test(cell) ? `"${cell.replaceAll(/"/g, '""')}"` : cell;
 }
 
 /** Serialise measurements to a CSV — one row per measurement, metres throughout. */

--- a/src/export/measurementReport.ts
+++ b/src/export/measurementReport.ts
@@ -85,7 +85,17 @@ export function measurementsToFindings(
       const k = Object.keys(metrics).find((key) => Number.isFinite(metrics[key]));
       if (k) {
         value = metrics[k];
-        unit = k.endsWith('_m2') ? 'm²' : k.endsWith('_m3') ? 'm³' : k.endsWith('_deg') ? '°' : k.endsWith('_pct') ? '%' : 'm';
+        if (k.endsWith('_m2')) {
+          unit = 'm²';
+        } else if (k.endsWith('_m3')) {
+          unit = 'm³';
+        } else if (k.endsWith('_deg')) {
+          unit = '°';
+        } else if (k.endsWith('_pct')) {
+          unit = '%';
+        } else {
+          unit = 'm';
+        }
       }
     }
     if (value === null) return; // an incomplete measurement contributes nothing

--- a/src/export/permitStamp.ts
+++ b/src/export/permitStamp.ts
@@ -21,7 +21,7 @@ import type { ExportPermitStamp } from '../terrain/export/exportProvenance';
  * has no runtime dependencies and never pulls the resolver into the eager bundle.
  */
 export function permitStamp(permit: ContourExportPermit | null): ExportPermitStamp | null {
-  if (!permit || !permit.ok) return null;
+  if (!permit?.ok) return null;
   const d = permit.decision;
   return {
     status: d.status,

--- a/src/export/pngTextChunks.ts
+++ b/src/export/pngTextChunks.ts
@@ -53,8 +53,8 @@ const CRC_TABLE = (() => {
 
 function crc32(bytes: Uint8Array): number {
   let c = 0xffffffff;
-  for (let i = 0; i < bytes.length; i++) {
-    c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  for (const b of bytes) {
+    c = CRC_TABLE[(c ^ b) & 0xff] ^ (c >>> 8);
   }
   return (c ^ 0xffffffff) >>> 0;
 }
@@ -77,7 +77,7 @@ function latin1Bytes(s: string): Uint8Array {
 /** Decode Latin-1 bytes back to a string (exact inverse of latin1Bytes). */
 function latin1String(bytes: Uint8Array): string {
   let out = '';
-  for (let i = 0; i < bytes.length; i++) out += String.fromCharCode(bytes[i]);
+  for (const b of bytes) out += String.fromCharCode(b);
   return out;
 }
 

--- a/src/export/verifyReport.ts
+++ b/src/export/verifyReport.ts
@@ -91,12 +91,16 @@ export function verifyReportFile(jsonText: string): VerifyReportResult {
   // Only SHA-256 is cryptographic. An FNV-1a digest is a forgeable checksum, so
   // a match is NOT proof of tamper-evidence — never report it as "intact".
   const cryptographic = algorithm === 'SHA-256';
+  let reason: string;
+  if (!valid) {
+    reason = 'Report has been modified, or the digest does not match its contents.';
+  } else if (cryptographic) {
+    reason = 'Report is intact — the SHA-256 digest matches its contents.';
+  } else {
+    reason = `The ${algorithm} checksum matches, but it is a fast non-cryptographic checksum an editor can forge — this does NOT prove the report was not altered. Treat it as unverified for tamper-evidence.`;
+  }
   return {
     recognised: true, valid, cryptographic, algorithm, software, classificationEpoch, findingsCount,
-    reason: !valid
-      ? 'Report has been modified, or the digest does not match its contents.'
-      : cryptographic
-        ? 'Report is intact — the SHA-256 digest matches its contents.'
-        : `The ${algorithm} checksum matches, but it is a fast non-cryptographic checksum an editor can forge — this does NOT prove the report was not altered. Treat it as unverified for tamper-evidence.`,
+    reason,
   };
 }

--- a/src/geo/CoordinateTypes.ts
+++ b/src/geo/CoordinateTypes.ts
@@ -156,7 +156,8 @@ export interface ResolvedCrs {
 export function isLinearUnitKnown(
   crs: { readonly linearUnit?: string } | null | undefined,
 ): boolean {
-  return crs != null && crs.linearUnit !== undefined && crs.linearUnit !== 'unknown';
+  const unit = crs?.linearUnit;
+  return unit !== undefined && unit !== 'unknown';
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -206,12 +207,14 @@ export function resolvedFromCrsInfo(
   const kind: CrsKind = info.isGeographic ? 'geographic' : 'projected';
   // Confidence: EPSG + WKT = high, EPSG OR a recognisable name = medium.
   // The CrsInfo always has a `name`, so the discriminator is EPSG.
-  const confidence: CrsConfidence =
-    typeof info.epsg === 'number' && info.wkt
-      ? 'high'
-      : typeof info.epsg === 'number' || info.name.startsWith('EPSG:')
-        ? 'medium'
-        : 'low';
+  let confidence: CrsConfidence;
+  if (typeof info.epsg === 'number' && info.wkt) {
+    confidence = 'high';
+  } else if (typeof info.epsg === 'number' || info.name.startsWith('EPSG:')) {
+    confidence = 'medium';
+  } else {
+    confidence = 'low';
+  }
   return {
     kind,
     name: info.name,

--- a/src/geo/CrsRegistry.ts
+++ b/src/geo/CrsRegistry.ts
@@ -307,7 +307,7 @@ export function resolveHorizontalDatum(
   epsg: number | undefined,
 ): string | undefined {
   const wkt = wktDatum?.trim();
-  return wkt ? wkt : registryDatumFor(epsg);
+  return wkt || registryDatumFor(epsg);
 }
 
 /**

--- a/src/geo/CrsService.ts
+++ b/src/geo/CrsService.ts
@@ -138,7 +138,7 @@ export class CrsService {
    * same object and cannot disagree with each other.
    */
   context(): SpatialContext {
-    if (this._context === null) this._context = spatialContextFrom(this._current);
+    this._context ??= spatialContextFrom(this._current);
     return this._context;
   }
 
@@ -340,6 +340,7 @@ export class CrsService {
       detected?.name && detected.epsg === override.epsg
         ? detected.name
         : (entry?.label ?? `EPSG:${override.epsg}`);
+    const fallbackLinearUnit = override.kind === 'geographic' ? 'unknown' : 'metre';
     return {
       kind: override.kind,
       name,
@@ -355,7 +356,7 @@ export class CrsService {
       linearUnit:
         detected?.epsg === override.epsg
           ? detected.linearUnit
-          : (entry?.linearUnit ?? (override.kind === 'geographic' ? 'unknown' : 'metre')),
+          : (entry?.linearUnit ?? fallbackLinearUnit),
       linearUnitToMetres:
         detected?.epsg === override.epsg
           ? detected.linearUnitToMetres

--- a/src/geo/SpatialContext.ts
+++ b/src/geo/SpatialContext.ts
@@ -213,12 +213,14 @@ export function spatialContextFrom(
   // needs-confirmation. A ResolvedCrs (identified by its `kind` discriminant,
   // which CrsInfo lacks) is already resolved and is used as-is; a CrsInfo is
   // bridged CrsInfo → ResolvedCrs via the canonical mapper.
-  const resolved =
-    crs == null
-      ? unknownCrs()
-      : 'kind' in crs
-        ? crs
-        : (resolvedFromCrsInfo(crs, FACADE_SOURCE) ?? unknownCrs());
+  let resolved: ResolvedCrs;
+  if (crs == null) {
+    resolved = unknownCrs();
+  } else if ('kind' in crs) {
+    resolved = crs;
+  } else {
+    resolved = resolvedFromCrsInfo(crs, FACADE_SOURCE) ?? unknownCrs();
+  }
 
   const verdict = validateCrsForMeasurement(resolved);
   const linearUnitKnown = isLinearUnitKnown(resolved);

--- a/src/geo/georefStatus.ts
+++ b/src/geo/georefStatus.ts
@@ -59,11 +59,14 @@ export function georefStatus(
   // A horizontally-georeferenced scan usually carries ABSOLUTE Z (e.g. 65–85 m),
   // so "relative" is wrong there — the datum is simply not declared. Reserve
   // "Relative heights" for the truly floating case (no horizontal reference).
-  const heightLabel = datumKnown
-    ? 'Real-world elevation'
-    : crsKnown
-      ? 'Datum not declared'
-      : 'Relative heights';
+  let heightLabel: string;
+  if (datumKnown) {
+    heightLabel = 'Real-world elevation';
+  } else if (crsKnown) {
+    heightLabel = 'Datum not declared';
+  } else {
+    heightLabel = 'Relative heights';
+  }
 
   let tone: GeorefTone;
   let headline: string;
@@ -85,14 +88,16 @@ export function georefStatus(
   // technical fact; a plain consequence sentence follows for everyone else.
   const crsPart = crsKnown ? `Position: ${names.crsName?.trim() || 'defined'}` : 'Position: none (no CRS)';
   const datumPart = datumKnown ? `Height: ${names.datumName?.trim() || 'defined'}` : 'Height: none (no vertical datum)';
-  const consequence =
-    crsKnown && datumKnown
-      ? 'Coordinates and heights are real-world values.'
-      : !crsKnown && !datumKnown
-        ? 'The scan can’t be placed on a map and its heights are relative only.'
-        : crsKnown
-          ? 'The scan is georeferenced horizontally, but its vertical datum isn’t declared — heights aren’t tied to a known reference.'
-          : 'Heights are referenced, but the scan can’t be placed on a map (no CRS).';
+  let consequence: string;
+  if (crsKnown && datumKnown) {
+    consequence = 'Coordinates and heights are real-world values.';
+  } else if (!crsKnown && !datumKnown) {
+    consequence = 'The scan can’t be placed on a map and its heights are relative only.';
+  } else if (crsKnown) {
+    consequence = 'The scan is georeferenced horizontally, but its vertical datum isn’t declared — heights aren’t tied to a known reference.';
+  } else {
+    consequence = 'Heights are referenced, but the scan can’t be placed on a map (no CRS).';
+  }
   const tooltip = `${crsPart} · ${datumPart}. ${consequence}`;
 
   return { tone, headline, positionKnown: crsKnown, heightKnown: datumKnown, positionLabel, heightLabel, tooltip };

--- a/src/geo/inMemoryPrecision.ts
+++ b/src/geo/inMemoryPrecision.ts
@@ -53,10 +53,10 @@ const U32 = new Uint32Array(F32.buffer);
  */
 export function float32Spacing(magnitude: number): number {
   const m = Math.abs(magnitude);
-  if (!Number.isFinite(m)) return NaN;
+  if (!Number.isFinite(m)) return Number.NaN;
   F32[0] = m;
   const stored = F32[0];
-  if (!Number.isFinite(stored)) return NaN; // overflowed the Float32 range
+  if (!Number.isFinite(stored)) return Number.NaN; // overflowed the Float32 range
   const bits = U32[0];
   U32[0] = bits + 1;
   const above = F32[0];

--- a/src/intelligence/scanStory.ts
+++ b/src/intelligence/scanStory.ts
@@ -214,14 +214,16 @@ export function buildExportHealth(i: ScanStoryInputs): ExportHealth {
   const rows: ExportHealthRow[] = [];
 
   // Scope — what slice of the cloud the figures describe.
-  const scope =
-    i.coverageMode === 'full'
-      ? { value: 'Full cloud', tier: 'good' as HealthTier }
-      : i.coverageMode === 'resident-only'
-        ? { value: 'Resident preview', tier: 'caution' as HealthTier }
-        : i.coverageMode === 'sampled'
-          ? { value: 'Sampled', tier: 'caution' as HealthTier }
-          : { value: 'Unknown', tier: 'info' as HealthTier };
+  let scope: { value: string; tier: HealthTier };
+  if (i.coverageMode === 'full') {
+    scope = { value: 'Full cloud', tier: 'good' };
+  } else if (i.coverageMode === 'resident-only') {
+    scope = { value: 'Resident preview', tier: 'caution' };
+  } else if (i.coverageMode === 'sampled') {
+    scope = { value: 'Sampled', tier: 'caution' };
+  } else {
+    scope = { value: 'Unknown', tier: 'info' };
+  }
   rows.push({ label: 'Scan scope', value: scope.value, tier: scope.tier });
 
   // Classification — source vs derived is the trust line the reviewer cares about.
@@ -238,20 +240,23 @@ export function buildExportHealth(i: ScanStoryInputs): ExportHealth {
   }
 
   // Georeferencing.
-  rows.push(
-    i.crsKnown === false
-      ? { label: 'Coordinate system', value: 'Unknown', tier: 'caution' }
-      : i.crsKnown === true
-        ? { label: 'Coordinate system', value: 'Known', tier: 'good' }
-        : { label: 'Coordinate system', value: '—', tier: 'info' },
-  );
-  rows.push(
-    i.datumKnown === false
-      ? { label: 'Vertical datum', value: 'Unknown', tier: 'caution' }
-      : i.datumKnown === true
-        ? { label: 'Vertical datum', value: 'Known', tier: 'good' }
-        : { label: 'Vertical datum', value: '—', tier: 'info' },
-  );
+  let crsRow: ExportHealthRow;
+  if (i.crsKnown === false) {
+    crsRow = { label: 'Coordinate system', value: 'Unknown', tier: 'caution' };
+  } else if (i.crsKnown === true) {
+    crsRow = { label: 'Coordinate system', value: 'Known', tier: 'good' };
+  } else {
+    crsRow = { label: 'Coordinate system', value: '—', tier: 'info' };
+  }
+  let datumRow: ExportHealthRow;
+  if (i.datumKnown === false) {
+    datumRow = { label: 'Vertical datum', value: 'Unknown', tier: 'caution' };
+  } else if (i.datumKnown === true) {
+    datumRow = { label: 'Vertical datum', value: 'Known', tier: 'good' };
+  } else {
+    datumRow = { label: 'Vertical datum', value: '—', tier: 'info' };
+  }
+  rows.push(crsRow, datumRow);
 
   // Density.
   if (i.density && i.density !== 'unknown') {
@@ -264,22 +269,26 @@ export function buildExportHealth(i: ScanStoryInputs): ExportHealth {
   }
 
   // Terrain-product readiness — the surface verdict in export terms.
-  const tprTier: HealthTier =
-    i.surfaceTier === 'Good'
-      ? 'good'
-      : i.surfaceTier === 'Blocked'
-        ? 'blocked'
-        : i.surfaceTier === undefined || i.surfaceTier === 'Unknown'
-          ? 'info'
-          : 'caution';
-  const tprValue =
-    i.surfaceTier === 'Good'
-      ? 'Export-ready'
-      : i.surfaceTier === 'Blocked'
-        ? 'Blocked'
-        : i.surfaceTier === undefined || i.surfaceTier === 'Unknown'
-          ? 'Not analysed'
-          : 'Preview only';
+  let tprTier: HealthTier;
+  if (i.surfaceTier === 'Good') {
+    tprTier = 'good';
+  } else if (i.surfaceTier === 'Blocked') {
+    tprTier = 'blocked';
+  } else if (i.surfaceTier === undefined || i.surfaceTier === 'Unknown') {
+    tprTier = 'info';
+  } else {
+    tprTier = 'caution';
+  }
+  let tprValue: string;
+  if (i.surfaceTier === 'Good') {
+    tprValue = 'Export-ready';
+  } else if (i.surfaceTier === 'Blocked') {
+    tprValue = 'Blocked';
+  } else if (i.surfaceTier === undefined || i.surfaceTier === 'Unknown') {
+    tprValue = 'Not analysed';
+  } else {
+    tprValue = 'Preview only';
+  }
   rows.push({ label: 'Terrain products', value: tprValue, tier: tprTier });
 
   // Actionable blockers — the caution/blocked rows phrased as a checklist.

--- a/src/io/copc/voxelKey.ts
+++ b/src/io/copc/voxelKey.ts
@@ -30,7 +30,7 @@ export function keyId(key: VoxelKey): string {
 export function keyFromId(id: string): VoxelKey | null {
   const parts = id.split('-');
   if (parts.length !== 4) return null;
-  const [depth, x, y, z] = parts.map((p) => Number(p));
+  const [depth, x, y, z] = parts.map(Number);
   const key = { depth, x, y, z };
   return isValidKey(key) ? key : null;
 }

--- a/src/io/crs.ts
+++ b/src/io/crs.ts
@@ -332,8 +332,8 @@ export function crsFromWkt(wkt: string): CrsInfo {
       }
     } else {
       // No UNIT clause is rare on a projected CRS — default to metres.
+      // linearUnitToMetres stays at its initial 1 (metre) on this path.
       linearUnit = 'metre';
-      linearUnitToMetres = 1;
     }
   }
 
@@ -679,10 +679,14 @@ export function crsFromGeoTiff(
   // to use its geographic citation, because there it does describe the CRS.
   const ownCitation = isGeographic ? citation : projectedCitation;
   const baseName = ownCitation ?? wellKnownCrsName(epsg) ?? (epsg ? `EPSG:${epsg}` : 'Unknown CRS');
-  const name =
-    epsg && !ownCitation && !wellKnownCrsName(epsg) ? `EPSG:${epsg}`
-    : epsg ? `${baseName} (EPSG:${epsg})`
-    : baseName;
+  let name: string;
+  if (epsg && !ownCitation && !wellKnownCrsName(epsg)) {
+    name = `EPSG:${epsg}`;
+  } else if (epsg) {
+    name = `${baseName} (EPSG:${epsg})`;
+  } else {
+    name = baseName;
+  }
 
   // Vertical datum: a real EPSG (verticalDatumLabel rejects the 0 / 32767
   // placeholders), else fall back to the citation text when present.

--- a/src/io/e57/schema.ts
+++ b/src/io/e57/schema.ts
@@ -303,7 +303,7 @@ const E57_CORE_NS = /^https?:\/\/(?:www\.)?astm\.org\/[^?#]*E57/i;
 /** Trimmed element text, or undefined when the element is missing / empty. */
 function declaredText(node: XmlNode | undefined): string | undefined {
   const t = node?.text.trim();
-  return t ? t : undefined;
+  return t || undefined;
 }
 
 /** Element text as a re-printed number, or undefined when missing / empty / NaN. */

--- a/src/io/ept/eptBinaryDecode.ts
+++ b/src/io/ept/eptBinaryDecode.ts
@@ -91,9 +91,11 @@ function readAttr(view: DataView, off: number, attr: AttrLayout): number {
   switch (attr.size) {
     case 1: return attr.type === 'signed'   ? view.getInt8(off)              : view.getUint8(off);
     case 2: return attr.type === 'signed'   ? view.getInt16(off,  true)      : view.getUint16(off,  true);
-    case 4: return attr.type === 'float'    ? view.getFloat32(off, true)
-          : attr.type === 'signed'         ? view.getInt32(off,   true)
-                                            : view.getUint32(off,  true);
+    case 4: {
+      if (attr.type === 'float') return view.getFloat32(off, true);
+      if (attr.type === 'signed') return view.getInt32(off, true);
+      return view.getUint32(off, true);
+    }
     case 8: {
       // Size 8 must branch on the declared type. The earlier code read every
       // 8-byte attribute as Float64, which reinterprets an int64/uint64's

--- a/src/io/ept/eptDetect.ts
+++ b/src/io/ept/eptDetect.ts
@@ -73,7 +73,7 @@ export function parseEptMetadata(text: string): EptDetection {
   if (typeof version !== 'string') {
     return { isEpt: false, reason: 'EPT manifest is missing a "version" string.' };
   }
-  if (!/^1\./.test(version)) {
+  if (!version.startsWith('1.')) {
     return {
       isEpt: false,
       reason: `Unsupported EPT version ${version} — only EPT 1.x is supported.`,

--- a/src/io/ept/eptUrlValidation.ts
+++ b/src/io/ept/eptUrlValidation.ts
@@ -11,13 +11,12 @@
  */
 
 import {
-  MAX_REMOTE_COPC_URL_LENGTH,
   validateRemoteCopcUrl,
   sanitizeUrlForDisplay,
 } from '../range/RangeSource';
 
 /** Maximum acceptable length of an EPT URL — same guard as the COPC entry. */
-export const MAX_REMOTE_EPT_URL_LENGTH = MAX_REMOTE_COPC_URL_LENGTH;
+export { MAX_REMOTE_COPC_URL_LENGTH as MAX_REMOTE_EPT_URL_LENGTH } from '../range/RangeSource';
 
 /**
  * Validate a remote EPT entry URL. The rules layer on top of

--- a/src/io/exporters.ts
+++ b/src/io/exporters.ts
@@ -47,8 +47,7 @@
  * point is dropped without an in-file note.
  */
 
-import type { PointCloud } from '../model/PointCloud';
-import type { SourceMetadata, DeclaredMetadataField } from '../model/PointCloud';
+import type { PointCloud, SourceMetadata, DeclaredMetadataField } from '../model/PointCloud';
 
 /** The export formats this module produces. */
 export type ExportFormat = 'xyz' | 'csv' | 'ply' | 'obj';
@@ -113,7 +112,14 @@ function subsetLine(cloud: PointCloud): string | null {
   const pct = (held / declared) * 100;
   // Two significant-ish digits: "12.3 %" for a typical cap, "0.4 %" for a
   // heavy stride, never "0.0 %" for something that did write points.
-  const share = pct >= 10 ? pct.toFixed(0) : pct >= 1 ? pct.toFixed(1) : pct.toFixed(2);
+  let share: string;
+  if (pct >= 10) {
+    share = pct.toFixed(0);
+  } else if (pct >= 1) {
+    share = pct.toFixed(1);
+  } else {
+    share = pct.toFixed(2);
+  }
   const stride = cloud.loadStride;
   const cause =
     stride !== undefined && stride > 1
@@ -243,9 +249,9 @@ export function toXyz(cloud: PointCloud, delimiter = ' '): string {
   // Length guards: a malformed cloud with a misaligned channel drops the
   // column rather than writing values from the wrong points.
   const intensity =
-    cloud.intensity && cloud.intensity.length === n ? cloud.intensity : undefined;
+    cloud.intensity?.length === n ? cloud.intensity : undefined;
   const classification =
-    cloud.classification && cloud.classification.length === n
+    cloud.classification?.length === n
       ? cloud.classification
       : undefined;
   const columns = [

--- a/src/io/formatInfo.ts
+++ b/src/io/formatInfo.ts
@@ -55,7 +55,7 @@ export function formatInfo(format: SourceFormat): FormatInfo {
 
 /** Whether a string names a registered, decodable format. */
 export function isRegisteredFormat(format: string): format is SourceFormat {
-  return Object.prototype.hasOwnProperty.call(FORMAT_INFO, format);
+  return Object.hasOwn(FORMAT_INFO, format);
 }
 
 /** Every registered format, for tests and diagnostics. */

--- a/src/io/heavy/lazChunkTable.ts
+++ b/src/io/heavy/lazChunkTable.ts
@@ -238,11 +238,14 @@ export async function readLazChunkTable(
   let firstPointIndex = 0;
   for (let i = 0; i < numChunks; i++) {
     const end = start + startDeltas[i];
-    const pointCount = countDeltas
-      ? countDeltas[i]
-      : i < numChunks - 1
-        ? vlr.chunkSize
-        : header.pointCount - vlr.chunkSize * (numChunks - 1);
+    let pointCount: number;
+    if (countDeltas) {
+      pointCount = countDeltas[i];
+    } else if (i < numChunks - 1) {
+      pointCount = vlr.chunkSize;
+    } else {
+      pointCount = header.pointCount - vlr.chunkSize * (numChunks - 1);
+    }
     if (startDeltas[i] <= 0) {
       return unsupported(`chunk ${i} has a non-positive byte length`);
     }

--- a/src/io/lasDecodeShared.ts
+++ b/src/io/lasDecodeShared.ts
@@ -36,7 +36,7 @@ const RECORD_GPS_TIME_EXT = 22;
 /** First point format index that uses the extended record layout. */
 export const FIRST_EXTENDED_FORMAT = 6;
 /** Legacy point formats (0-5) that carry a GPS-time field. */
-const LEGACY_GPS_FORMATS: readonly number[] = [1, 3, 4, 5];
+const LEGACY_GPS_FORMATS: ReadonlySet<number> = new Set([1, 3, 4, 5]);
 
 /**
  * Mask isolating the classification value within the LAS classification byte.
@@ -54,7 +54,7 @@ function classificationOffsetFor(pointFormat: number): number {
 
 function gpsTimeOffsetFor(header: LasHeader): number | null {
   const extended = header.pointFormat >= FIRST_EXTENDED_FORMAT;
-  if (!extended && !LEGACY_GPS_FORMATS.includes(header.pointFormat)) return null;
+  if (!extended && !LEGACY_GPS_FORMATS.has(header.pointFormat)) return null;
   const offset = extended ? RECORD_GPS_TIME_EXT : RECORD_GPS_TIME_LEGACY;
   return header.pointDataRecordLength >= offset + 8 ? offset : null;
 }
@@ -211,8 +211,8 @@ export function finalizeRawColors(raw: RawPoints): void {
   const src = raw.colors16;
   if (!src) return;
   let maxRgb = 0;
-  for (let i = 0; i < src.length; i++) {
-    if (src[i] > maxRgb) maxRgb = src[i];
+  for (const v of src) {
+    if (v > maxRgb) maxRgb = v;
   }
   const eightBit = maxRgb <= 255;
   const out = new Uint8Array(src.length);

--- a/src/io/loadE57.ts
+++ b/src/io/loadE57.ts
@@ -21,12 +21,16 @@ import { sanitizeAndRecenter } from './sanitizeCloud';
 
 /** Clamp a value into the 0–255 byte range. */
 function clampByte(v: number): number {
-  return v < 0 ? 0 : v > 255 ? 255 : Math.round(v);
+  if (v < 0) return 0;
+  if (v > 255) return 255;
+  return Math.round(v);
 }
 
 /** Clamp a value into the 0–65535 uint16 range. */
 function clampU16(v: number): number {
-  return v < 0 ? 0 : v > 65535 ? 65535 : Math.round(v);
+  if (v < 0) return 0;
+  if (v > 65535) return 65535;
+  return Math.round(v);
 }
 
 /**
@@ -48,7 +52,7 @@ function intensityScaleFor(scan: E57ScanData): number {
     return scan.intensityMax > 0 && scan.intensityMax <= 1 ? 65535 : 1;
   }
   let max = 0;
-  for (let i = 0; i < col.length; i++) if (col[i] > max) max = col[i];
+  for (const v of col) if (v > max) max = v;
   return max > 0 && max <= 1 ? 65535 : 1;
 }
 

--- a/src/io/loadFile.ts
+++ b/src/io/loadFile.ts
@@ -302,7 +302,7 @@ const defaultParseWorkerFactory: ParseWorkerFactory = () =>
 let parseWorkerFactory: ParseWorkerFactory = defaultParseWorkerFactory;
 
 function parseWorkerInstance(): Worker {
-  if (!sharedWorker) sharedWorker = parseWorkerFactory();
+  sharedWorker ??= parseWorkerFactory();
   return sharedWorker;
 }
 
@@ -413,7 +413,7 @@ export async function loadFile(
       const msg = event.data as WorkerReply;
       if (msg.type === 'progress') {
         // The first reply marks the buffer transfer + worker spin-up cost.
-        if (transferMs === undefined) transferMs = performance.now() - postedAt;
+        transferMs ??= performance.now() - postedAt;
         onProgress?.({ stage: msg.stage, detail: msg.detail, fraction: msg.fraction });
         return;
       }

--- a/src/io/loadGltf.ts
+++ b/src/io/loadGltf.ts
@@ -37,7 +37,7 @@ interface GltfPrimitive {
 /** Build the local transform of a node from either `matrix` or its TRS parts. */
 function localMatrix(node: GltfNode): Matrix4 {
   const m = new Matrix4();
-  if (node.matrix && node.matrix.length === 16) {
+  if (node.matrix?.length === 16) {
     // glTF matrices are column-major; three's `fromArray` reads column-major.
     m.fromArray(node.matrix);
     return m;
@@ -104,13 +104,15 @@ function collectNode(
       // vertex push accordingly. Without this scale, a float-typed
       // value of 0.5 becomes 0 when packed into `new Uint8Array(...)`
       // and most coloured mobile scans render near-black.
-      const colScale = colAttr
-        ? colAttr.value instanceof Float32Array || colAttr.value instanceof Float64Array
-          ? 255
-          : colAttr.value instanceof Uint16Array
-            ? 255 / 65535
-            : 1
-        : 1;
+      let colScale = 1;
+      if (colAttr) {
+        const cv = colAttr.value;
+        if (cv instanceof Float32Array || cv instanceof Float64Array) {
+          colScale = 255;
+        } else if (cv instanceof Uint16Array) {
+          colScale = 255 / 65535;
+        }
+      }
 
       for (let i = 0; i < vertexCount; i++) {
         // Apply the node's world transform so multi-node scans line up.

--- a/src/io/loadLas.ts
+++ b/src/io/loadLas.ts
@@ -42,7 +42,6 @@ import { makePrng, pickInBucket, STRIDE_SAMPLE_SEED } from './strideSample';
 import type { ProgressUpdate } from './loadProgress';
 import {
   allocRawPoints,
-  classificationMaskFor,
   decodeContext,
   decodeRecord,
   decodingUpdate,
@@ -51,7 +50,7 @@ import {
 } from './lasDecodeShared';
 
 // Re-export so external callers (analysis modules) keep their existing import path.
-export { classificationMaskFor };
+export { classificationMaskFor } from './lasDecodeShared';
 
 /**
  * Decode an uncompressed `.las` file. With `stride > 1` the records are split

--- a/src/io/loadObj.ts
+++ b/src/io/loadObj.ts
@@ -28,7 +28,7 @@ function readVertexRecords(text: string): Float64Array {
   const out: number[] = [];
   for (const raw of text.split('\n')) {
     const line = raw.trimStart();
-    if (line.length < 2 || line[0] !== 'v') continue;
+    if (line.length < 2 || !line.startsWith('v')) continue;
     const after = line[1];
     if (after !== ' ' && after !== '\t') continue; // vn / vt / vp records
     const tok = line.split(/\s+/);

--- a/src/io/loadPcd.ts
+++ b/src/io/loadPcd.ts
@@ -23,12 +23,16 @@ import { sanitizeAndRecenter, withLoadWarning } from './sanitizeCloud';
 
 /** Round and clamp a value into the 0–255 byte range. */
 function clampByte(v: number): number {
-  return v < 0 ? 0 : v > 255 ? 255 : Math.round(v);
+  if (v < 0) return 0;
+  if (v > 255) return 255;
+  return Math.round(v);
 }
 
 /** Round and clamp a value into the 0–65535 Uint16 range. */
 function clampU16(v: number): number {
-  return v < 0 ? 0 : v > 65535 ? 65535 : Math.round(v);
+  if (v < 0) return 0;
+  if (v > 65535) return 65535;
+  return Math.round(v);
 }
 
 /** The subset of PCD header facts the f64 position path needs. */
@@ -114,7 +118,7 @@ function parsePcdHeaderFacts(buffer: ArrayBuffer): PcdHeaderFacts | null {
   let height = 0;
   for (const raw of probe.slice(0, m.index).split(/\r?\n/)) {
     const line = raw.trim();
-    if (line === '' || line[0] === '#') continue;
+    if (line === '' || line.startsWith('#')) continue;
     const tok = line.split(/\s+/);
     const key = tok[0].toUpperCase();
     if (key === 'FIELDS') facts.fields = tok.slice(1).map((f) => f.toLowerCase());
@@ -295,7 +299,7 @@ export async function loadPcd(buffer: ArrayBuffer, name = 'cloud.pcd'): Promise<
   // with what PCDLoader decoded, PCDLoader's rows win.
   const reread = extractPcdPositionsF64(buffer);
   let global: Float64Array;
-  if (reread && reread.length === count * 3) {
+  if (reread?.length === count * 3) {
     global = reread;
   } else {
     global = new Float64Array(count * 3);

--- a/src/io/loadPly.ts
+++ b/src/io/loadPly.ts
@@ -45,7 +45,7 @@ function readAsciiVertices(
   if (header?.format !== 'ascii') return null;
   if (typeof header.headerLength !== 'number' || header.headerLength <= 0) return null;
   const vertex = header.elements?.[0];
-  if (!vertex || vertex.name !== 'vertex' || vertex.count !== expectedCount) return null;
+  if (vertex?.name !== 'vertex' || vertex?.count !== expectedCount) return null;
   const props = vertex.properties;
   if (props.some((p) => p.type === 'list')) return null;
   const xi = props.findIndex((p) => p.name === 'x');

--- a/src/io/loadPts.ts
+++ b/src/io/loadPts.ts
@@ -63,7 +63,7 @@ export async function loadPts(
     buffer,
     (raw) => {
       const line = raw.trim();
-      if (line === '' || line[0] === '#') return;
+      if (line === '' || line.startsWith('#')) return;
 
       const tok = tokenize(line);
       // The optional first line is a lone non-negative integer — the point
@@ -145,7 +145,7 @@ export async function loadPts(
     intensity = new Uint16Array(count);
     for (let p = 0; p < count; p++) {
       const v = Math.round((intensityVals[p] + offset) * scale);
-      intensity[p] = v < 0 ? 0 : v > 65535 ? 65535 : v;
+      intensity[p] = Math.max(0, Math.min(65535, v));
     }
   }
 
@@ -156,7 +156,7 @@ export async function loadPts(
     colors = new Uint8Array(count * 3);
     for (let k = 0; k < count * 3; k++) {
       const v = Math.round(normalized ? rgb[k] * 255 : rgb[k]);
-      colors[k] = v < 0 ? 0 : v > 255 ? 255 : v;
+      colors[k] = Math.max(0, Math.min(255, v));
     }
   }
 

--- a/src/io/loadPtx.ts
+++ b/src/io/loadPtx.ts
@@ -165,10 +165,8 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
           `and may not register with the rest of the cloud.`,
       );
     }
-    if (!scannerOrigin) {
-      // The transform's 4th row is the scanner's registered world position.
-      scannerOrigin = [m[3][0], m[3][1], m[3][2]];
-    }
+    // The transform's 4th row is the scanner's registered world position.
+    scannerOrigin ??= [m[3][0], m[3][1], m[3][2]];
     i += HEADER_LINES;
 
     const total = cols * rows;
@@ -195,7 +193,7 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
       const it = Number(tok[3]);
       intensityVals.push(Number.isFinite(it) ? it : 0);
 
-      if (hasColor === null) hasColor = tok.length >= 7;
+      hasColor ??= tok.length >= 7;
       if (hasColor) {
         rgb.push(Number(tok[4]) || 0, Number(tok[5]) || 0, Number(tok[6]) || 0);
       }
@@ -233,7 +231,7 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
   const intensity = new Uint16Array(count);
   for (let p = 0; p < count; p++) {
     const v = Math.round(intensityVals[p] * scale);
-    intensity[p] = v < 0 ? 0 : v > 65535 ? 65535 : v;
+    intensity[p] = Math.max(0, Math.min(65535, v));
   }
 
   // Colour — PTX RGB, when present, is 0–255 per channel.
@@ -242,7 +240,7 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
     colors = new Uint8Array(count * 3);
     for (let k = 0; k < count * 3; k++) {
       const v = Math.round(rgb[k]);
-      colors[k] = v < 0 ? 0 : v > 255 ? 255 : v;
+      colors[k] = Math.max(0, Math.min(255, v));
     }
   }
 

--- a/src/io/loadXyz.ts
+++ b/src/io/loadXyz.ts
@@ -48,7 +48,7 @@ export async function loadXyz(
     buffer,
     (raw) => {
       const line = raw.trim();
-      if (line === '' || line[0] === '#') return;
+      if (line === '' || line.startsWith('#')) return;
 
       const tok = tokenize(line);
       const x = Number(tok[0]);
@@ -57,13 +57,11 @@ export async function loadXyz(
       // A non-numeric line (e.g. a "x,y,z" header) is silently skipped.
       if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return;
 
-      if (hasColor === null) {
-        hasColor =
-          tok.length >= 6 &&
-          Number.isFinite(Number(tok[3])) &&
-          Number.isFinite(Number(tok[4])) &&
-          Number.isFinite(Number(tok[5]));
-      }
+      hasColor ??=
+        tok.length >= 6 &&
+        Number.isFinite(Number(tok[3])) &&
+        Number.isFinite(Number(tok[4])) &&
+        Number.isFinite(Number(tok[5]));
 
       xs.push(x);
       ys.push(y);

--- a/src/io/range/RangeSource.ts
+++ b/src/io/range/RangeSource.ts
@@ -174,8 +174,8 @@ export function isBlockedHost(hostname: string): boolean {
     const tail = mapped[1];
     const hex = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(tail);
     if (hex) {
-      const hi = parseInt(hex[1], 16);
-      const lo = parseInt(hex[2], 16);
+      const hi = Number.parseInt(hex[1], 16);
+      const lo = Number.parseInt(hex[2], 16);
       return isBlockedHost(`${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`);
     }
     return isBlockedHost(tail); // already-dotted mapped form
@@ -222,7 +222,7 @@ export function sanitizeUrlForDisplay(raw: string): string {
   } catch {
     // Best-effort textual scrub for inputs that won't parse — strip
     // the first `userinfo@` segment AND any query string.
-    const noUserInfo = raw.replace(/^([a-zA-Z][a-zA-Z0-9+.\-]*:\/\/)[^/@]*@/, '$1');
+    const noUserInfo = raw.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/@]*@/, '$1');
     return noUserInfo.replace(/\?.*$/, '?…');
   }
 }

--- a/src/io/session.ts
+++ b/src/io/session.ts
@@ -80,7 +80,7 @@ import type { WorkOwnership } from '../model/workOwnership';
 export const SESSION_VERSION = 8;
 
 /** Schema versions `parseSession` can read. */
-const SUPPORTED_VERSIONS: readonly number[] = [1, 2, 3, 4, 5, 6, 7, 8];
+const SUPPORTED_VERSIONS: ReadonlySet<number> = new Set([1, 2, 3, 4, 5, 6, 7, 8]);
 
 /** the render-style snapshot the v3 schema captures. */
 export interface SessionRenderSettings {
@@ -286,7 +286,7 @@ export interface InspectionSession {
   projectFrame?: SessionProjectFrame;
 }
 
-const KINDS: readonly MeasurementKind[] = [
+const KINDS: ReadonlySet<MeasurementKind> = new Set([
   'distance',
   'polyline',
   'area',
@@ -299,7 +299,7 @@ const KINDS: readonly MeasurementKind[] = [
   'profile',
   'box',
   'volume',
-];
+]);
 
 /**
  * Serialise a session to a pretty-printed JSON string (always the current
@@ -492,7 +492,7 @@ export function parseSession(text: string): InspectionSession {
   if (raw.app !== 'OpenLiDARViewer' || raw.kind !== 'measurement-session') {
     throw new Error('This file is not an OpenLiDARViewer session.');
   }
-  if (typeof raw.version !== 'number' || !SUPPORTED_VERSIONS.includes(raw.version)) {
+  if (typeof raw.version !== 'number' || !SUPPORTED_VERSIONS.has(raw.version)) {
     throw new Error(`Unsupported session version: ${String(raw.version)}.`);
   }
   const out: InspectionSession = {
@@ -982,7 +982,7 @@ export function detectSessionSpatialConflict(
 
 // --- validation helpers ----------------------------------------------------
 
-const CLIP_MODES: readonly ClipMode[] = ['keep-inside', 'keep-outside'];
+const CLIP_MODES: ReadonlySet<ClipMode> = new Set(['keep-inside', 'keep-outside']);
 
 /**
  * Parse a persisted clipping box, or `null` when malformed. Requires two finite
@@ -998,7 +998,7 @@ function parseClipBox(v: unknown): ClipBox | null {
     min: [b.min[0], b.min[1], b.min[2]],
     max: [b.max[0], b.max[1], b.max[2]],
   };
-  const mode: ClipMode = CLIP_MODES.includes(v.mode as ClipMode)
+  const mode: ClipMode = CLIP_MODES.has(v.mode as ClipMode)
     ? (v.mode as ClipMode)
     : 'keep-inside';
   return { box, mode, enabled: v.enabled === true };
@@ -1104,7 +1104,7 @@ function parseMeasurements(v: unknown): Measurement[] {
   for (const item of v.slice(0, MAX_SESSION_ITEMS)) {
     if (!isRecord(item)) continue;
     const kind = item.kind;
-    if (typeof kind !== 'string' || !KINDS.includes(kind as MeasurementKind)) continue;
+    if (typeof kind !== 'string' || !KINDS.has(kind as MeasurementKind)) continue;
     const k = kind as MeasurementKind;
     // Slice BEFORE filter/map so the cap bounds the WORK, not just the output —
     // a single measurement carrying tens of millions of points can't OOM the tab.
@@ -1173,7 +1173,7 @@ function parseProfileChart(v: unknown): ProfileChartSample[] | undefined {
     if (!isRecord(s)) continue;
     if (!isFiniteNum(s.distance)) continue;
     // JSON has no NaN literal — a gap serialises as null; restore it to NaN.
-    const height = isFiniteNum(s.height) ? s.height : NaN;
+    const height = isFiniteNum(s.height) ? s.height : Number.NaN;
     const sample: ProfileChartSample = { distance: s.distance, height };
     if (isFiniteNum(s.count)) sample.count = s.count;
     out.push(sample);
@@ -1181,7 +1181,7 @@ function parseProfileChart(v: unknown): ProfileChartSample[] | undefined {
   return out.length > 0 ? out : undefined;
 }
 
-const VOLUME_CONFIDENCE: readonly VolumeRecord['confidence'][] = ['high', 'medium', 'low'];
+const VOLUME_CONFIDENCE: ReadonlySet<VolumeRecord['confidence']> = new Set(['high', 'medium', 'low']);
 
 /**
  * Parse a persisted volume cut/fill record, or `undefined` when malformed. All
@@ -1196,14 +1196,17 @@ function parseVolumeRecord(v: unknown): VolumeRecord | undefined {
   // The field was renamed `density` → `densityNative` to stop calling a native
   // horizontal-unit² figure "points/m²". Older files carry `density`, which held
   // exactly the same native value, so migrating it across is lossless.
-  const densityNative = isFiniteNum(v.densityNative)
-    ? v.densityNative
-    : isFiniteNum(v.density)
-      ? v.density
-      : undefined;
+  let densityNative: number | undefined;
+  if (isFiniteNum(v.densityNative)) {
+    densityNative = v.densityNative;
+  } else if (isFiniteNum(v.density)) {
+    densityNative = v.density;
+  } else {
+    densityNative = undefined;
+  }
   if (densityNative === undefined) return undefined;
   if (typeof v.confidence !== 'string'
-    || !VOLUME_CONFIDENCE.includes(v.confidence as VolumeRecord['confidence'])) {
+    || !VOLUME_CONFIDENCE.has(v.confidence as VolumeRecord['confidence'])) {
     return undefined;
   }
   const record: VolumeRecord = {
@@ -1224,12 +1227,12 @@ function parseVolumeRecord(v: unknown): VolumeRecord | undefined {
   return record;
 }
 
-const TRUST_GRADES: readonly TrustGrade[] = ['green', 'yellow', 'red'];
+const TRUST_GRADES: ReadonlySet<TrustGrade> = new Set(['green', 'yellow', 'red']);
 
 /** Defensively parse a persisted measurement trust grade; null if malformed. */
 function parseMeasurementTrust(v: unknown): MeasurementTrust | undefined {
   if (!isRecord(v)) return undefined;
-  if (typeof v.grade !== 'string' || !TRUST_GRADES.includes(v.grade as TrustGrade)) return undefined;
+  if (typeof v.grade !== 'string' || !TRUST_GRADES.has(v.grade as TrustGrade)) return undefined;
   if (typeof v.caption !== 'string') return undefined;
   if (typeof v.presentable !== 'boolean') return undefined;
   const reasons = Array.isArray(v.reasons)

--- a/src/io/sessionFrame.ts
+++ b/src/io/sessionFrame.ts
@@ -98,7 +98,7 @@ export interface SessionFrameInput {
   readonly layers: readonly SessionFrameLayerInput[];
 }
 
-const AXES: readonly FrameUpAxis[] = ['x', 'y', 'z'];
+const AXES: ReadonlySet<FrameUpAxis> = new Set(['x', 'y', 'z']);
 
 /**
  * Cap on the number of layer records a project frame may declare. One record per
@@ -170,7 +170,7 @@ export function validateSessionProjectFrame(frame: unknown): string[] {
     if (typeof l.sourceName !== 'string') {
       reasons.push(`${named} has no source name`);
     }
-    if (typeof l.upAxis !== 'string' || !AXES.includes(l.upAxis as FrameUpAxis)) {
+    if (typeof l.upAxis !== 'string' || !AXES.has(l.upAxis as FrameUpAxis)) {
       reasons.push(`${named} declares up axis ${JSON.stringify(l.upAxis)}; expected "x", "y" or "z"`);
     }
     const sourceOrigin = l.sourceOrigin;

--- a/src/io/shareState.ts
+++ b/src/io/shareState.ts
@@ -56,12 +56,12 @@ function asCamera(v: unknown): SavedCameraState | null {
 
 /** Encode a string to URL-safe base64 (no `+`, `/`, or `=` padding). */
 function toBase64Url(text: string): string {
-  return btoa(text).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return btoa(text).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
 }
 
 /** Decode a URL-safe base64 string. */
 function fromBase64Url(encoded: string): string {
-  const padded = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = encoded.replaceAll('-', '+').replaceAll('_', '/');
   return atob(padded);
 }
 

--- a/src/io/sniffFormat.ts
+++ b/src/io/sniffFormat.ts
@@ -103,7 +103,7 @@ export function verticalAxisHintForSources(
 function readAscii(buffer: ArrayBuffer, count: number): string {
   const view = new Uint8Array(buffer, 0, Math.min(count, buffer.byteLength));
   let out = '';
-  for (let i = 0; i < view.length; i++) out += String.fromCharCode(view[i]);
+  for (const b of view) out += String.fromCharCode(b);
   return out;
 }
 

--- a/src/io/wktParser.ts
+++ b/src/io/wktParser.ts
@@ -97,7 +97,7 @@ export function wktChildNodes(node: WktNode): WktNode[] {
  */
 export function wktNodeName(node: WktNode): string | undefined {
   const first = node.children[0];
-  return first && first.type === 'string' ? first.value : undefined;
+  return first?.type === 'string' ? first.value : undefined;
 }
 
 /** The node's first numeric child, or `undefined` when it has none. */
@@ -220,9 +220,9 @@ function parseTokens(tokens: Tok[]): WktNode | null {
   /** Parse `IDENT [ child (, child)* ]` — assumes tokens[pos] is the keyword. */
   const parseNode = (depth: number): WktNode | null => {
     const idTok = tokens[pos];
-    if (!idTok || idTok.t !== 'ident') return null;
+    if (idTok?.t !== 'ident') return null;
     const lb = tokens[pos + 1];
-    if (!lb || lb.t !== 'lb') return null;
+    if (lb?.t !== 'lb') return null;
 
     const keyword = idTok.v;
     const start = idTok.i;
@@ -238,7 +238,7 @@ function parseTokens(tokens: Tok[]): WktNode | null {
       if (tk.t === 'lb') { skipBlock(); continue; } // stray bracket — skip its block
       // ident: a nested node when followed by '[', otherwise a bare keyword token.
       const nxt = tokens[pos + 1];
-      if (nxt && nxt.t === 'lb') {
+      if (nxt?.t === 'lb') {
         if (depth < MAX_DEPTH) {
           const child = parseNode(depth + 1);
           if (child) children.push({ type: 'node', node: child });

--- a/src/io/workerPool/DecodeWorkerPool.ts
+++ b/src/io/workerPool/DecodeWorkerPool.ts
@@ -511,7 +511,7 @@ export class DecodeWorkerPool<T> {
     // Free the worker only for the job it was actually running. A duplicate or
     // unknown request id must never release a slot that has since been given a
     // different job — that is how two live decodes would end up on one worker.
-    if (slot.job && slot.job.requestId === reply.requestId) slot.job = null;
+    if (slot.job?.requestId === reply.requestId) slot.job = null;
 
     const job = this._settle(reply.requestId);
     if (!job) {

--- a/src/io/workerPool/decodePoolSize.ts
+++ b/src/io/workerPool/decodePoolSize.ts
@@ -111,12 +111,14 @@ export function decodeWorkerPoolSize(input: DecodePoolSizeInput): number {
   }
 
   const cores = usableCores(input.hardwareConcurrency);
-  let workers =
-    cores === undefined
-      ? input.isMobile
-        ? UNKNOWN_CORES_MOBILE
-        : UNKNOWN_CORES_DESKTOP
-      : bandForCores(cores);
+  let workers: number;
+  if (cores !== undefined) {
+    workers = bandForCores(cores);
+  } else if (input.isMobile) {
+    workers = UNKNOWN_CORES_MOBILE;
+  } else {
+    workers = UNKNOWN_CORES_DESKTOP;
+  }
 
   if (input.isMobile) workers = Math.min(workers, DECODE_POOL_MOBILE_CAP);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -903,7 +903,9 @@ window.addEventListener('keydown', (e) => {
     const tag = target?.tagName;
     if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
     const k = e.key.toLowerCase();
-    const preset = k === 't' ? 'top' : k === 'o' ? 'oblique' : 'planar';
+    let preset: 'top' | 'oblique' | 'planar' = 'planar';
+    if (k === 't') preset = 'top';
+    else if (k === 'o') preset = 'oblique';
     const fired = viewer?.setCameraPreset(preset);
     // Mark the keystroke consumed so any later bare-key handler
     // (`bindShortcuts`) sees `defaultPrevented` and stays quiet.
@@ -1421,7 +1423,7 @@ const inspector = new Inspector({
     const id = scans.activeId;
     if (!id) return;
     const cloud = viewer.getCloud(id);
-    if (!cloud || !cloud.colors) return;
+    if (!cloud?.colors) return;
     void loadRgbAutoNormalize().then(({ rgbAutoNormalize }) => {
       if (scans.activeId !== id) return; // scan changed while we waited
       const suggestion = rgbAutoNormalize({ colorsU8: cloud.colors! });
@@ -1531,19 +1533,17 @@ let workflowConfigPanelLoading: Promise<WorkflowConfigPanel> | null = null;
 let pendingWorkflowConfig: Parameters<typeof workflowController.setConfig>[0] | undefined;
 function ensureWorkflowConfigPanel(): Promise<WorkflowConfigPanel> {
   if (workflowConfigPanel) return Promise.resolve(workflowConfigPanel);
-  if (!workflowConfigPanelLoading) {
-    workflowConfigPanelLoading = loadWorkflowConfigPanel().then(({ WorkflowConfigPanel }) => {
-      const panel = new WorkflowConfigPanel();
-      stage.overlay.append(panel.element);
-      panel.onChange((cfg) => {
-        workflowController.setConfig(cfg);
-        persistPrefs();
-      });
-      if (pendingWorkflowConfig !== undefined) panel.setConfig(pendingWorkflowConfig);
-      workflowConfigPanel = panel;
-      return panel;
+  workflowConfigPanelLoading ??= loadWorkflowConfigPanel().then(({ WorkflowConfigPanel }) => {
+    const panel = new WorkflowConfigPanel();
+    stage.overlay.append(panel.element);
+    panel.onChange((cfg) => {
+      workflowController.setConfig(cfg);
+      persistPrefs();
     });
-  }
+    if (pendingWorkflowConfig !== undefined) panel.setConfig(pendingWorkflowConfig);
+    workflowConfigPanel = panel;
+    return panel;
+  });
   return workflowConfigPanelLoading;
 }
 
@@ -1615,15 +1615,13 @@ let shortcutSheet: ShortcutSheet | null = null;
 let shortcutSheetLoading: Promise<ShortcutSheet> | null = null;
 function ensureShortcutSheet(): Promise<ShortcutSheet> {
   if (shortcutSheet) return Promise.resolve(shortcutSheet);
-  if (!shortcutSheetLoading) {
-    shortcutSheetLoading = loadShortcutSheet().then(({ ShortcutSheet }) => {
-      const sheet = new ShortcutSheet();
-      stage.overlay.append(sheet.element);
-      sheet.setActions(ACTION_REGISTRY);
-      shortcutSheet = sheet;
-      return sheet;
-    });
-  }
+  shortcutSheetLoading ??= loadShortcutSheet().then(({ ShortcutSheet }) => {
+    const sheet = new ShortcutSheet();
+    stage.overlay.append(sheet.element);
+    sheet.setActions(ACTION_REGISTRY);
+    shortcutSheet = sheet;
+    return sheet;
+  });
   return shortcutSheetLoading;
 }
 
@@ -1860,7 +1858,9 @@ function buildCurrentStoryInputs(): ScanStoryInputs {
       const crs = cloud.metadata?.crs as { name?: string; verticalDatum?: unknown } | undefined;
       metaCrsKnown = !!crs?.name;
       metaDatumKnown = !!crs?.verticalDatum;
-      classification = cloud.classificationIsDerived ? 'derived' : cloud.classification ? 'source' : 'none';
+      if (cloud.classificationIsDerived) classification = 'derived';
+      else if (cloud.classification) classification = 'source';
+      else classification = 'none';
     } else if (streaming) {
       // Tight data AABB, not the octree cube — the cube overstates footprint
       // area (and understates density) for a partial-footprint scan.
@@ -2473,20 +2473,18 @@ async function showReclassifyUi(): Promise<void> {
     return;
   }
   // Dedupe concurrent first-mounts so the panel is only ever created once.
-  if (!reclassifyUiLoading) {
-    reclassifyUiLoading = (async () => {
-      const { createReclassifyUi } = await loadReclassifyUi();
-      const ui = createReclassifyUi({
-        canvas: stage.canvas,
-        getViewer: () => viewer,
-        getActiveId: () => scans.activeId,
-        onToast: showLassoToast,
-        onAutoClassify: () => runDeriveClassification(),
-      });
-      classLegendPanel.element.after(ui.element);
-      reclassifyUi = ui;
-    })();
-  }
+  reclassifyUiLoading ??= (async () => {
+    const { createReclassifyUi } = await loadReclassifyUi();
+    const ui = createReclassifyUi({
+      canvas: stage.canvas,
+      getViewer: () => viewer,
+      getActiveId: () => scans.activeId,
+      onToast: showLassoToast,
+      onAutoClassify: () => runDeriveClassification(),
+    });
+    classLegendPanel.element.after(ui.element);
+    reclassifyUi = ui;
+  })();
   await reclassifyUiLoading;
   // Cast: TS can't see the async IIFE reassign the outer `let` across the await.
   (reclassifyUi as ReclassifyUi | null)?.setVisible(true);
@@ -2752,7 +2750,7 @@ function newObjectPanel(
   // Dimension / scale-bar units follow the live measurement unit system.
   onExportFloorPlan: async () => {
     const ctx = lastSpaceExport;
-    if (!ctx || ctx.spaceKind !== 'interior') return;
+    if (ctx?.spaceKind !== 'interior') return;
     const { extractFloorPlan, floorPlanSvg } = await loadFloorPlan();
     // Fresh dense gather: the 60 k routing snapshot is too sparse for wall
     // tracing (see FLOORPLAN_GATHER_POINTS).
@@ -2864,7 +2862,7 @@ const terrainRunner = createTerrainAnalysisRunner({
     // run that measured nothing (null summary/band) leaves the row honest.
     const cx = result.complexity;
     inspectorCards.noteTerrainComplexity(
-      cx && cx.band ? { bucket: cx.band, label: cx.bandLabel, detail: cx.detail } : null,
+      cx?.band ? { bucket: cx.band, label: cx.bandLabel, detail: cx.detail } : null,
     );
   },
 });
@@ -2982,15 +2980,14 @@ const exportPanel = new ExportPanel({
       const c = viewer?.getCloud(scans.activeId);
       if (!c) return null;
       const crs = c.metadata?.crs ?? null;
+      const declaredProvenance = c.classification != null ? 'source' : 'none';
       return {
         pointCount: c.pointCount,
         hasRgb: c.colors != null,
         hasGpsTime: c.gpsTime != null,
         crsName: crs?.name ?? null,
         hasWkt: crs?.wkt != null,
-        classProvenance: c.classificationIsDerived
-          ? 'derived'
-          : c.classification != null ? 'source' : 'none',
+        classProvenance: c.classificationIsDerived ? 'derived' : declaredProvenance,
       };
     }
     const sc = viewer?.streamingCloud;
@@ -3265,7 +3262,8 @@ function applyScanRoute(initial: boolean, settled = false): boolean {
   // never flips the session TO terrain (it only rescues interiors/objects
   // misread on a sparse frame), and `runTerrain` is true ONLY for the explicit
   // hatch / manual Terrain override — auto-detection never starts an analysis.
-  const detected: SpaceKind | null = shape ? (shape.nonTerrain ? shape.spaceKind : 'terrain') : null;
+  let detected: SpaceKind | null = null;
+  if (shape) detected = shape.nonTerrain ? shape.spaceKind : 'terrain';
   const plan = planScanRoute({
     detected,
     override: routing.typeOverride,
@@ -3321,7 +3319,7 @@ function applyScanRoute(initial: boolean, settled = false): boolean {
     const streamingCloud = viewer.streamingCloud;
     const hasRgb = streamingCloud
       ? streamingCloud.availableColorModes().includes('rgb')
-      : !!(activeCloud && activeCloud.colors && activeCloud.colors.length > 0);
+      : !!activeCloud?.colors?.length;
     // Compute REAL metrics for the EFFECTIVE type — when forced, the report
     // reflects what's actually there for that interpretation; nothing fabricated.
     // The active scan's context, so a foot-based CRS reports honest metre/feet
@@ -4452,7 +4450,7 @@ function prewarmForUrl(url: string): void {
     void loadStreamingPointCloud().catch(() => { _loadersPrewarmed = false; });
     void loadCopcWorkerClient()
       .then(({ CopcWorkerClient }) => {
-        if (!copcDecoder) copcDecoder = new CopcWorkerClient();
+        copcDecoder ??= new CopcWorkerClient();
       })
       .catch(() => { /* swallow — actual COPC open retries */ });
   }
@@ -4502,7 +4500,7 @@ function schedulePrewarm(): void {
     // painful one to debug or demo against.
     void loadCopcWorkerClient()
       .then(({ CopcWorkerClient }) => {
-        if (!copcDecoder) copcDecoder = new CopcWorkerClient();
+        copcDecoder ??= new CopcWorkerClient();
       })
       .catch(() => { /* swallow — actual COPC open retries */ });
     // Static LAS/LAZ loader sits in its own chunk too — pre-warm it for
@@ -4647,7 +4645,7 @@ function refreshMeasurePanel(): void {
   measurePanel.setVisible(viewer.measureMode || hasMeasurements);
   // Local-first counter, categorical (the kind) only — never coordinates or names.
   if (measurements.length > _lastMeasurementCount) {
-    const newest = measurements[measurements.length - 1];
+    const newest = measurements.at(-1);
     if (newest) recordUsage('measurement', newest.kind);
   }
   _lastMeasurementCount = measurements.length;
@@ -4896,9 +4894,9 @@ async function exportSession(): Promise<void> {
   // hence Z-up. Deriving origin/upAxis from the (absent) static cloud wrote
   // [0,0,0] + Y-up, so the session reopened displaced by the whole render origin
   // and mis-oriented.
-  const upAxis: 'y' | 'z' = cloud
-    ? isZUpFormat(cloud.sourceFormat) ? 'z' : 'y'
-    : viewer.streamingCloud ? 'z' : 'y';
+  let upAxis: 'y' | 'z';
+  if (cloud) upAxis = isZUpFormat(cloud.sourceFormat) ? 'z' : 'y';
+  else upAxis = viewer.streamingCloud ? 'z' : 'y';
 
   // populate the v3 fields so the .olvsession captures
   // the full working state, not just the inspection annotations. The
@@ -4981,7 +4979,7 @@ async function exportSession(): Promise<void> {
     // v7 — a view with a captured bundle serialises it per-view; a camera-only
     // view (e.g. restored from a v6 file) spreads nothing and keeps its exact
     // v6 byte-shape.
-    views: viewBookmarks.savedViews.map((v) => ({ name: v.name, camera: v.pose, ...(v.state ?? {}) })),
+    views: viewBookmarks.savedViews.map((v) => ({ name: v.name, camera: v.pose, ...v.state })),
     measurements: viewer.measure.getMeasurements(),
     annotations: viewer.annotate.getAnnotations(),
     camera: viewState.camera,

--- a/src/model/layerModel.ts
+++ b/src/model/layerModel.ts
@@ -147,9 +147,10 @@ export function detectCrsMismatch(layers: readonly LayerInfo[]): CrsMismatch {
 
   if (known.length < 2) {
     // Nothing to compare against — surface only an "unknown CRS" note if any.
+    const plural = unknown.length === 1 ? '' : 's';
     return empty(
       unknown.length > 0 && layers.length > 1
-        ? `${unknown.length} layer${unknown.length === 1 ? '' : 's'} without a declared CRS — can't check alignment.`
+        ? `${unknown.length} layer${plural} without a declared CRS — can't check alignment.`
         : '',
     );
   }

--- a/src/perf/frameTelemetry.ts
+++ b/src/perf/frameTelemetry.ts
@@ -209,13 +209,14 @@ export class FrameTelemetry {
     this._requestFrame =
       options.requestFrame ?? ((cb) => requestAnimationFrame(() => cb()));
     this._cancelFrame = options.cancelFrame ?? ((h) => cancelAnimationFrame(h));
-    this._observerCtor =
-      options.performanceObserver !== undefined
-        ? options.performanceObserver
-        : longTaskSupported()
-          ? ((globalThis as { PerformanceObserver?: LongTaskObserverCtor })
-              .PerformanceObserver ?? null)
-          : null;
+    if (options.performanceObserver !== undefined) {
+      this._observerCtor = options.performanceObserver;
+    } else if (longTaskSupported()) {
+      this._observerCtor =
+        (globalThis as { PerformanceObserver?: LongTaskObserverCtor }).PerformanceObserver ?? null;
+    } else {
+      this._observerCtor = null;
+    }
     this._dpr = options.devicePixelRatio ?? (() =>
       typeof devicePixelRatio === 'number' ? devicePixelRatio : 1);
     this._ringCapacity = options.ringCapacity ?? 240;

--- a/src/perf/metricsJson.ts
+++ b/src/perf/metricsJson.ts
@@ -73,7 +73,7 @@ function ms(v: number): number {
   return Math.round(v * 1000) / 1000;
 }
 
-const orNull = <T>(v: T | undefined): T | null => (v === undefined ? null : v);
+const orNull = <T>(v: T | undefined): T | null => v ?? null;
 
 /**
  * Build the metrics document as a plain object (exported for tests) —

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -74,7 +74,7 @@ const STORAGE_KEY = 'openlidarviewer.prefs.v1';
 
 /** Valid point-appearance modes (kept in sync with `SplatMode`). Inlined so the
  *  shell doesn't take a runtime dependency on the render layer. */
-const SPLAT_MODES: readonly SplatMode[] = ['classic', 'soft', 'inspection', 'gaussian'];
+const SPLAT_MODES: ReadonlySet<SplatMode> = new Set<SplatMode>(['classic', 'soft', 'inspection', 'gaussian']);
 
 /** Clamp a number into `[min, max]`. */
 function clamp(v: number, min: number, max: number): number {
@@ -111,7 +111,7 @@ export function parsePrefs(raw: string): Partial<ViewerPrefs> {
   // P13 — validate against the known modes inline (kept type-only on splatShader
   // so prefs never pulls the render layer into the shell chunk). Unknown values
   // are dropped, like every other malformed key here.
-  if (SPLAT_MODES.includes(o.splatMode as SplatMode)) out.splatMode = o.splatMode as SplatMode;
+  if (SPLAT_MODES.has(o.splatMode as SplatMode)) out.splatMode = o.splatMode as SplatMode;
   if (typeof o.antialiasing === 'boolean') out.antialiasing = o.antialiasing;
   if (o.unitSystem === 'metric' || o.unitSystem === 'imperial') {
     out.unitSystem = o.unitSystem;

--- a/src/render/InspectTool.ts
+++ b/src/render/InspectTool.ts
@@ -416,11 +416,13 @@ export class InspectTool {
     // doubled values into the geographic projection below.
     const split = splitPointCoords(info, this._coordContext.origin);
     const worldLabels = worldCoordLabels(this._coordContext.crs);
-    rows.push(coordGroupHeader(worldLabels.heading));
     // Geographic eastings/northings are degrees, not metres — use the
     // CRS-aware unit suffix so a lon/lat scan never reads "-122.4 m".
-    rows.push(infoRow(worldLabels.x, `${split.world.x}${worldLabels.xUnit}`));
-    rows.push(infoRow(worldLabels.y, `${split.world.y}${worldLabels.yUnit}`));
+    rows.push(
+      coordGroupHeader(worldLabels.heading),
+      infoRow(worldLabels.x, `${split.world.x}${worldLabels.xUnit}`),
+      infoRow(worldLabels.y, `${split.world.y}${worldLabels.yUnit}`),
+    );
     // Z / height row. The label is datum-aware via an explicit HeightValue: a
     // projected or geographic scan with no declared vertical datum reads
     // "Height (datum unknown)" instead of "Elevation" (which would assert a
@@ -441,10 +443,12 @@ export class InspectTool {
       // Local is the render-recentred point in the SAME source units as the
       // World group — so it must carry the same CRS-aware unit suffix, not a
       // hardcoded "m" that reads "152.400 m" beside World's "500.00 ft".
-      rows.push(coordGroupHeader('Local'));
-      rows.push(infoRow('X', `${split.local.x.toFixed(3)}${worldLabels.xUnit}`));
-      rows.push(infoRow('Y', `${split.local.y.toFixed(3)}${worldLabels.yUnit}`));
-      rows.push(infoRow('Z', `${split.local.z.toFixed(3)}${worldLabels.zUnit}`));
+      rows.push(
+        coordGroupHeader('Local'),
+        infoRow('X', `${split.local.x.toFixed(3)}${worldLabels.xUnit}`),
+        infoRow('Y', `${split.local.y.toFixed(3)}${worldLabels.yUnit}`),
+        infoRow('Z', `${split.local.z.toFixed(3)}${worldLabels.zUnit}`),
+      );
     }
 
     // ── Geographic coordinates — when CRS supports projection to WGS84 ────
@@ -469,7 +473,7 @@ export class InspectTool {
         lon = geo.value.lon;
         elev = geo.value.elevation;
       }
-    } else if (crs && crs.kind === 'geographic') {
+    } else if (crs?.kind === 'geographic') {
       // Source is already geographic — World row carried lon/lat
       // directly; reuse them for the UTM derivation.
       lat = split.world.y;
@@ -481,10 +485,12 @@ export class InspectTool {
       // Geographic group — render unless the World group already
       // carried it (i.e. the source CRS is geographic, in which case
       // the World row IS the lat/lon and we skip the redundancy).
-      if (!(crs && crs.kind === 'geographic')) {
-        rows.push(coordGroupHeader('Geographic (WGS 84)'));
-        rows.push(infoRow('Latitude', `${lat.toFixed(7)}°`));
-        rows.push(infoRow('Longitude', `${lon.toFixed(7)}°`));
+      if (!(crs?.kind === 'geographic')) {
+        rows.push(
+          coordGroupHeader('Geographic (WGS 84)'),
+          infoRow('Latitude', `${lat.toFixed(7)}°`),
+          infoRow('Longitude', `${lon.toFixed(7)}°`),
+        );
         if (typeof elev === 'number') {
           rows.push(infoRow('Elevation', `${elev.toFixed(3)} m`));
         }
@@ -498,16 +504,18 @@ export class InspectTool {
       // here instead of printing a coordinate from outside the system.
       const outsideUtm = utmLatitudeFailure(lat);
       if (outsideUtm) {
-        rows.push(coordGroupHeader('UTM'));
-        rows.push(infoRow('Grid', 'not defined at this latitude'));
-        rows.push(infoRow('Reason', outsideUtm));
+        rows.push(
+          coordGroupHeader('UTM'),
+          infoRow('Grid', 'not defined at this latitude'),
+          infoRow('Reason', outsideUtm),
+        );
       } else {
         const utm = latLonToUtm(lat, lon, elev);
         rows.push(
           coordGroupHeader(`UTM (zone ${utm.zone}${utm.hemisphere})`),
+          infoRow('Easting', `${utm.easting.toFixed(3)} m`),
+          infoRow('Northing', `${utm.northing.toFixed(3)} m`),
         );
-        rows.push(infoRow('Easting', `${utm.easting.toFixed(3)} m`));
-        rows.push(infoRow('Northing', `${utm.northing.toFixed(3)} m`));
         if (typeof utm.elevation === 'number') {
           rows.push(infoRow('Elevation', `${utm.elevation.toFixed(3)} m`));
         }
@@ -515,11 +523,13 @@ export class InspectTool {
     }
 
     // ── Existing attribute rows ────────────────────────────────────────────
-    rows.push(coordGroupHeader('Attributes'));
-    rows.push(infoRow('Distance', `${info.distance} m`));
-    rows.push(infoRow('Intensity', intensityText(info)));
-    rows.push(infoRow('Classification', classificationText(info)));
-    rows.push(infoRow('RGB', rgbText(info)));
+    rows.push(
+      coordGroupHeader('Attributes'),
+      infoRow('Distance', `${info.distance} m`),
+      infoRow('Intensity', intensityText(info)),
+      infoRow('Classification', classificationText(info)),
+      infoRow('RGB', rgbText(info)),
+    );
     // The LAS inspection extras get a row only when the cloud carries them —
     // a non-LAS scan shows no empty "Not available" clutter.
     const ret = returnText(info);
@@ -530,8 +540,10 @@ export class InspectTool {
     if (gps) rows.push(infoRow('GPS time', gps, gps));
     const normal = normalText(info);
     if (normal) rows.push(infoRow('Normal', normal, normal));
-    rows.push(infoRow('Layer', info.layer, info.layer));
-    rows.push(infoRow('Index', info.index.toLocaleString('en-US')));
+    rows.push(
+      infoRow('Layer', info.layer, info.layer),
+      infoRow('Index', info.index.toLocaleString('en-US')),
+    );
     // Refining-hint — "still refining" hint. Only present on streaming picks that
     // landed on a node coarser than the deepest currently-resident one.
     if (info.streamingRefining) {

--- a/src/render/NavController.ts
+++ b/src/render/NavController.ts
@@ -121,9 +121,9 @@ export class NavController {
   // ── Look orientation (walk / fly) ──────────────────────────────────────
   private _yaw = 0;
   private _pitch = 0;
-  private _worldUp = new THREE.Vector3(0, 1, 0);
-  private _refForward = new THREE.Vector3(0, 0, -1);
-  private _refRight = new THREE.Vector3(1, 0, 0);
+  private readonly _worldUp = new THREE.Vector3(0, 1, 0);
+  private readonly _refForward = new THREE.Vector3(0, 0, -1);
+  private readonly _refRight = new THREE.Vector3(1, 0, 0);
 
   // ── Movement state ─────────────────────────────────────────────────────
   private readonly _keys = {

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -212,9 +212,8 @@ import {
 } from './measure/classificationEditor';
 import { ClassEditHistory, recordEdit } from './measure/classEditHistory';
 import { ClassificationEpochs } from './measure/classificationEpoch';
-import type { PresetId, SkyPreset } from './inspectionPresets';
+import type { PresetId, SkyPreset, SkyPreset as SkyPresetId } from './inspectionPresets';
 import { applySkyPreset } from './skyPresetApply';
-import type { SkyPreset as SkyPresetId } from './inspectionPresets';
 import {
   applyRgbAppearance,
   IDENTITY_RGB_APPEARANCE,
@@ -1094,22 +1093,22 @@ export class Viewer {
   //    on the canvas / window; `dispose()` removes them. Storing the
   //    bound closures here (rather than the methods themselves) preserves
   //    the canvas reference each listener captures.
-  private _onCanvasDblClick!: (e: MouseEvent) => void;
-  private _onCanvasClick!: (e: MouseEvent) => void;
-  private _onCanvasPointerMove!: (e: PointerEvent) => void;
-  private _onCanvasPointerLeave!: () => void;
-  private _onWindowKeyDown!: (e: KeyboardEvent) => void;
+  private readonly _onCanvasDblClick!: (e: MouseEvent) => void;
+  private readonly _onCanvasClick!: (e: MouseEvent) => void;
+  private readonly _onCanvasPointerMove!: (e: PointerEvent) => void;
+  private readonly _onCanvasPointerLeave!: () => void;
+  private readonly _onWindowKeyDown!: (e: KeyboardEvent) => void;
   /**
    * Pauses the render loop while the tab is hidden; resumes when
    * the user comes back. Registered on `document.visibilitychange`.
    * Stored as a bound field so the symmetric `removeEventListener`
    * in `dispose()` actually matches.
    */
-  private _onVisibilityChange!: () => void;
+  private readonly _onVisibilityChange!: () => void;
   /** Touch-gesture pointer trackers. See `_initTouchGesture`. */
-  private _onCanvasPointerDown!: (e: PointerEvent) => void;
-  private _onCanvasPointerUp!: (e: PointerEvent) => void;
-  private _onCanvasPointerCancel!: (e: PointerEvent) => void;
+  private readonly _onCanvasPointerDown!: (e: PointerEvent) => void;
+  private readonly _onCanvasPointerUp!: (e: PointerEvent) => void;
+  private readonly _onCanvasPointerCancel!: (e: PointerEvent) => void;
   /** Active touch pointers, keyed by pointerId. */
   private readonly _touchTracker = new TouchTracker();
   /**
@@ -1342,7 +1341,7 @@ export class Viewer {
         const aligned = (
           c: ArrayLike<number> | null | undefined,
           pos: Float32Array,
-        ): ArrayLike<number> | undefined => (c && c.length === pos.length / 3 ? c : undefined);
+        ): ArrayLike<number> | undefined => (c?.length === pos.length / 3 ? c : undefined);
         // Only clouds the picker would place profile vertices on — visible and
         // unlocked — feed the sample, so a hidden or locked layer can't skew it.
         for (const { cloud, placement } of integrableClouds(this._clouds.values())) {
@@ -1453,12 +1452,10 @@ export class Viewer {
           up,
           positions,
         });
-        const confidence: 'high' | 'medium' | 'low' =
-          result.pointsInPolygon >= 1000
-            ? 'high'
-            : result.pointsInPolygon >= 100
-              ? 'medium'
-              : 'low';
+        let confidence: 'high' | 'medium' | 'low';
+        if (result.pointsInPolygon >= 1000) confidence = 'high';
+        else if (result.pointsInPolygon >= 100) confidence = 'medium';
+        else confidence = 'low';
         // Volume readout is "resident-only" whenever any streaming bytes
         // were in the walk and no fully-loaded static cloud sat beside
         // them — same rationale as the profile sampler.
@@ -2385,7 +2382,7 @@ export class Viewer {
       cls: ArrayLike<number> | null | undefined,
       pos: Float32Array,
     ): ArrayLike<number> | undefined =>
-      cls && cls.length === pos.length / 3 ? cls : undefined;
+      cls?.length === pos.length / 3 ? cls : undefined;
     // Match the picker: only visible, unlocked clouds contribute to the surface.
     for (const { cloud, placement } of integrableClouds(this._clouds.values())) {
       if (cloud.positions && cloud.positions.length > 0) {
@@ -3056,7 +3053,7 @@ export class Viewer {
    */
   swapClassification(id: string, fromClass: number, toClass: number): ClassEditResult {
     const entry = this._clouds.get(id);
-    if (!entry || !entry.cloud.classification) {
+    if (!entry?.cloud.classification) {
       return { changedCount: 0, pointCount: 0 };
     }
     const buf = entry.cloud.classification;
@@ -3099,7 +3096,7 @@ export class Viewer {
     up?: Vec3,
   ): ClassEditResult {
     const entry = this._clouds.get(id);
-    if (!entry || !entry.cloud.classification) {
+    if (!entry?.cloud.classification) {
       return { changedCount: 0, pointCount: 0 };
     }
     const buf = entry.cloud.classification;
@@ -3134,7 +3131,7 @@ export class Viewer {
     newClass: number,
   ): ClassEditResult {
     const entry = this._clouds.get(id);
-    if (!entry || !entry.cloud.classification || lasso.length < 3) {
+    if (!entry?.cloud.classification || lasso.length < 3) {
       return { changedCount: 0, pointCount: 0 };
     }
     const canvas = this._canvas;
@@ -3193,7 +3190,7 @@ export class Viewer {
   undoClassification(id: string): boolean {
     const entry = this._clouds.get(id);
     const h = this._classHistory.get(id);
-    if (!entry || !entry.cloud.classification || !h || !h.canUndo) return false;
+    if (!entry?.cloud.classification || !h?.canUndo) return false;
     h.undo(entry.cloud.classification);
     this._refreshClassificationColours(id);
     this._markClassificationEdited(id);
@@ -3208,7 +3205,7 @@ export class Viewer {
   redoClassification(id: string): boolean {
     const entry = this._clouds.get(id);
     const h = this._classHistory.get(id);
-    if (!entry || !entry.cloud.classification || !h || !h.canRedo) return false;
+    if (!entry?.cloud.classification || !h?.canRedo) return false;
     h.redo(entry.cloud.classification);
     this._refreshClassificationColours(id);
     this._markClassificationEdited(id);
@@ -3273,7 +3270,7 @@ export class Viewer {
     const existing = entry.mesh.geometry.getAttribute('aClass') as
       | THREE.InstancedBufferAttribute
       | undefined;
-    if (existing && existing.array.length === instanceCount) {
+    if (existing?.array.length === instanceCount) {
       const arr = existing.array as Float32Array;
       for (let i = 0; i < n; i++) arr[i] = codes[i];
       existing.needsUpdate = true;
@@ -3641,7 +3638,7 @@ export class Viewer {
    * report says whether the colour mode reached every layer: read `partial`
    * before telling the user the preset is active.
    */
-  applyPreset(id: PresetId | string): PresetApplication {
+  applyPreset(id: string): PresetApplication {
     const applied = applyInspectionPreset(this._presetApplyHost(), id);
     this._presetId = applied.presetId;
     return applied;
@@ -4209,11 +4206,9 @@ export class Viewer {
     this._toolPaused = paused;
     this._nav.setInputEnabled(paused);
     // Inspect owns its own cursor; measure / annotate use the crosshair.
-    this._canvas.style.cursor = paused
-      ? 'grab'
-      : this._toolMode === 'inspect'
-        ? ''
-        : 'crosshair';
+    if (paused) this._canvas.style.cursor = 'grab';
+    else if (this._toolMode === 'inspect') this._canvas.style.cursor = '';
+    else this._canvas.style.cursor = 'crosshair';
   }
 
   private _setToolMode(mode: ToolMode): void {
@@ -5783,7 +5778,6 @@ export class Viewer {
     // Resident-only pick invariant — pick from resident meshes only. Prune any orphan
     // sighting so the bug can't compound (and surface it in dev). The
     // resident, visible nodes are then handed to the pure selector below.
-    const eligibleMeshes: THREE.Mesh[] = [];
     const eligibleEntries: StreamingPickEntry[] = [];
     for (const [mesh, entry] of this._streamingPickData) {
       if (!this._streamingMeshes.has(mesh) || mesh.parent === null) {
@@ -5792,7 +5786,6 @@ export class Viewer {
         continue;
       }
       if (!mesh.visible) continue;
-      eligibleMeshes.push(mesh);
       eligibleEntries.push(entry);
     }
     if (eligibleEntries.length === 0) return null;

--- a/src/render/activeColorbar.ts
+++ b/src/render/activeColorbar.ts
@@ -99,7 +99,7 @@ export function buildActiveColorbarSpec(source: ActiveColorbarSource): ActiveCol
   // A poisoned (non-finite) or flat window cannot be labelled: a one-colour
   // bar says nothing, and NaN endpoints would render as garbage ticks.
   if (!Number.isFinite(range.min) || !Number.isFinite(range.max)) return null;
-  if (!(range.max > range.min)) return null;
+  if (range.max <= range.min) return null;
 
   const trim = source.trimPercent ?? 0;
   const windowNote = trim > 0 ? `p${trim}–p${100 - trim} window` : null;

--- a/src/render/adaptiveDpr.ts
+++ b/src/render/adaptiveDpr.ts
@@ -82,7 +82,7 @@ export function targetPixelRatio(input: DprInput): number {
 export function quantizeDpr(dpr: number, step: number = DPR_QUANT_STEP): number {
   const s = step > 0 && Number.isFinite(step) ? step : DPR_QUANT_STEP;
   const q = Math.round(dpr / s) * s;
-  return q < s ? s : q;
+  return Math.max(q, s);
 }
 
 /**

--- a/src/render/annotate/AnnotationOverlay.ts
+++ b/src/render/annotate/AnnotationOverlay.ts
@@ -180,7 +180,7 @@ export class AnnotationOverlay {
   private _createMarker(a: Annotation): Marker {
     const group = svgEl('g');
     group.setAttribute('class', `olv-anno-marker ${typeClass(a.type)}`);
-    group.setAttribute('data-aid', a.id);
+    group.dataset.aid = a.id;
 
     // Dark halo for readability over a dense, bright cloud, then the type disc.
     const halo = svgEl('circle');

--- a/src/render/class/classHistogram.ts
+++ b/src/render/class/classHistogram.ts
@@ -24,8 +24,8 @@ export function countClasses(
   buf: Uint8Array | Uint16Array | Float32Array,
 ): Map<number, number> {
   const counts = new Map<number, number>();
-  for (let i = 0; i < buf.length; i++) {
-    const code = Math.floor(buf[i]) & 0xff;
+  for (const value of buf) {
+    const code = Math.floor(value) & 0xff;
     counts.set(code, (counts.get(code) ?? 0) + 1);
   }
   return counts;

--- a/src/render/class/deriveClassification.ts
+++ b/src/render/class/deriveClassification.ts
@@ -445,7 +445,11 @@ export function classifierProcessingOp(result: DeriveClassificationResult): Proc
 }
 
 /** Clamp to [0, 1]. */
-const clamp01 = (v: number): number => (v < 0 ? 0 : v > 1 ? 1 : Number.isFinite(v) ? v : 0);
+const clamp01 = (v: number): number => {
+  if (v < 0) return 0;
+  if (v > 1) return 1;
+  return Number.isFinite(v) ? v : 0;
+};
 
 /** A finite-only min/max scan over the XY footprint and Z. */
 interface Bounds {
@@ -460,9 +464,12 @@ function computeBounds(positions: Float32Array, count: number): Bounds {
     const x = positions[i * 3], y = positions[i * 3 + 1], z = positions[i * 3 + 2];
     if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
     finite++;
-    if (x < minX) minX = x; if (x > maxX) maxX = x;
-    if (y < minY) minY = y; if (y > maxY) maxY = y;
-    if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z;
+    if (z > maxZ) maxZ = z;
   }
   return { minX, minY, maxX, maxY, minZ, maxZ, finite };
 }
@@ -503,7 +510,7 @@ function lineExtreme(
 ): void {
   let head = 0, tail = 0, next = 0;
   for (let i = 0; i < len; i++) {
-    const hi = i + r < len - 1 ? i + r : len - 1;
+    const hi = Math.min(i + r, len - 1);
     while (next <= hi) {
       const v = src[base + next * stride];
       while (tail > head) {
@@ -546,8 +553,8 @@ function morphOpen(src: Float32Array, W: number, H: number, r: number): Float32A
  */
 function fillHoles(grid: Float32Array, W: number, H: number): void {
   let holes = 0, sum = 0, finite = 0;
-  for (let i = 0; i < grid.length; i++) {
-    if (Number.isFinite(grid[i])) { sum += grid[i]; finite++; }
+  for (const value of grid) {
+    if (Number.isFinite(value)) { sum += value; finite++; }
     else holes++;
   }
   if (holes === 0) return;
@@ -611,7 +618,7 @@ export function rejectLowOutliers(
   H: number,
   gap: number,
 ): number {
-  if (!(gap > 0) || !Number.isFinite(gap)) return 0;
+  if (gap <= 0 || !Number.isFinite(gap)) return 0;
   // Snapshot so the pass is order-independent: a cell already rejected must not
   // change the median its neighbour is judged against.
   const snap = gridMin.slice();
@@ -672,12 +679,12 @@ export function deriveClassification(
   const emptyResult = (reason: string): DeriveClassificationResult => ({
     codes: new Uint8Array(count).fill(DERIVED_UNCLASSIFIED),
     counts: { [DERIVED_UNCLASSIFIED]: count },
-    cellSizeM: NaN,
+    cellSizeM: Number.NaN,
     gridWidth: 0,
     gridHeight: 0,
     derived: true,
     provenance: `Derived classification not computed (${reason}).`,
-    confidence: NaN,
+    confidence: Number.NaN,
     classConfidence: {},
     warnings: [`Classification not computed (${reason}).`],
     // The run produced nothing, but WHICH classifier declined still belongs in
@@ -693,7 +700,7 @@ export function deriveClassification(
     },
   });
 
-  if (count <= 0 || b.finite < 3 || !(b.maxX > b.minX) || !(b.maxY > b.minY)) {
+  if (count <= 0 || b.finite < 3 || b.maxX <= b.minX || b.maxY <= b.minY) {
     return emptyResult('insufficient or degenerate geometry');
   }
 
@@ -713,8 +720,8 @@ export function deriveClassification(
   //    alongside it, so the low-outlier rejection below has something real to
   //    fall back to rather than an interpolated guess.
   phase('Building ground surface');
-  const gridMin = new Float32Array(W * H).fill(NaN);
-  const gridMin2 = new Float32Array(W * H).fill(NaN);
+  const gridMin = new Float32Array(W * H).fill(Number.NaN);
+  const gridMin2 = new Float32Array(W * H).fill(Number.NaN);
   for (let i = 0; i < count; i++) {
     const x = positions[i * 3], y = positions[i * 3 + 1], z = positions[i * 3 + 2];
     if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
@@ -774,8 +781,10 @@ export function deriveClassification(
     const gx = (x - b.minX) / cell;
     const gy = (y - b.minY) / cell;
     let x0 = Math.floor(gx), y0 = Math.floor(gy);
-    if (x0 < 0) x0 = 0; if (x0 > W - 2) x0 = Math.max(0, W - 2);
-    if (y0 < 0) y0 = 0; if (y0 > H - 2) y0 = Math.max(0, H - 2);
+    if (x0 < 0) x0 = 0;
+    if (x0 > W - 2) x0 = Math.max(0, W - 2);
+    if (y0 < 0) y0 = 0;
+    if (y0 > H - 2) y0 = Math.max(0, H - 2);
     const x1 = Math.min(W - 1, x0 + 1), y1 = Math.min(H - 1, y0 + 1);
     const fx = Math.min(1, Math.max(0, gx - x0));
     const fy = Math.min(1, Math.max(0, gy - y0));
@@ -795,8 +804,10 @@ export function deriveClassification(
     const gx = (x - b.minX) / cell;
     const gy = (y - b.minY) / cell;
     let x0 = Math.floor(gx), y0 = Math.floor(gy);
-    if (x0 < 0) x0 = 0; if (x0 > W - 2) x0 = Math.max(0, W - 2);
-    if (y0 < 0) y0 = 0; if (y0 > H - 2) y0 = Math.max(0, H - 2);
+    if (x0 < 0) x0 = 0;
+    if (x0 > W - 2) x0 = Math.max(0, W - 2);
+    if (y0 < 0) y0 = 0;
+    if (y0 > H - 2) y0 = Math.max(0, H - 2);
     const x1 = Math.min(W - 1, x0 + 1), y1 = Math.min(H - 1, y0 + 1);
     return (
       measured[y0 * W + x0] + measured[y0 * W + x1] +
@@ -808,10 +819,10 @@ export function deriveClassification(
   for (let i = 0; i < count; i++) {
     const x = positions[i * 3], y = positions[i * 3 + 1], z = positions[i * 3 + 2];
     if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
-      hag[i] = NaN; continue;
+      hag[i] = Number.NaN; continue;
     }
     const h = z - dtmAt(x, y);
-    hag[i] = Number.isFinite(h) ? Math.max(0, h) : NaN;
+    hag[i] = Number.isFinite(h) ? Math.max(0, h) : Number.NaN;
   }
 
   // 5. Per-cell roughness of ABOVE-GROUND HAG (Welford mean/variance) — the
@@ -865,14 +876,11 @@ export function deriveClassification(
   // (3 = RGB, 4 = RGBA) is inferred from the buffer length; an unusable buffer
   // disables the cue rather than throwing.
   const colors = options.colors;
-  const colorStride =
-    colors && count > 0 && colors.length >= count * 3
-      ? colors.length % count === 0 && colors.length / count === 4
-        ? 4
-        : colors.length / count >= 3
-          ? 3
-          : 0
-      : 0;
+  let colorStride = 0;
+  if (colors && count > 0 && colors.length >= count * 3) {
+    if (colors.length % count === 0 && colors.length / count === 4) colorStride = 4;
+    else if (colors.length / count >= 3) colorStride = 3;
+  }
   const greenAt = (i: number): number => {
     const j = i * colorStride;
     const r = colors![j], g = colors![j + 1], bl = colors![j + 2];
@@ -959,7 +967,7 @@ export function deriveClassification(
   // fills only the unclassified holes — a scan that arrived with Ground keeps
   // it and gains vegetation / building around it.
   const existing = options.existingClassification;
-  const preserved = !!(existing && existing.length === count);
+  const preserved = !!(existing?.length === count);
   if (preserved) {
     for (let i = 0; i < count; i++) {
       const ex = existing![i];

--- a/src/render/clip/clipBox.ts
+++ b/src/render/clip/clipBox.ts
@@ -72,7 +72,8 @@ export function clipMaskArray(clip: ClipBox, positions: Float32Array): Uint8Arra
       x >= min[0] && x <= max[0] &&
       y >= min[1] && y <= max[1] &&
       z >= min[2] && z <= max[2];
-    mask[i] = (keepInside ? inside : !inside) ? 1 : 0;
+    const keep = keepInside ? inside : !inside;
+    mask[i] = keep ? 1 : 0;
   }
   return mask;
 }
@@ -86,11 +87,20 @@ export function countKept(clip: ClipBox, positions: Float32Array): number {
   let kept = 0;
   for (let i = 0; i < n; i++) {
     const x = positions[i * 3];
-    if (x < min[0] || x > max[0]) { if (!keepInside) kept++; continue; }
+    if (x < min[0] || x > max[0]) {
+      if (!keepInside) kept++;
+      continue;
+    }
     const y = positions[i * 3 + 1];
-    if (y < min[1] || y > max[1]) { if (!keepInside) kept++; continue; }
+    if (y < min[1] || y > max[1]) {
+      if (!keepInside) kept++;
+      continue;
+    }
     const z = positions[i * 3 + 2];
-    if (z < min[2] || z > max[2]) { if (!keepInside) kept++; continue; }
+    if (z < min[2] || z > max[2]) {
+      if (!keepInside) kept++;
+      continue;
+    }
     if (keepInside) kept++;
   }
   return kept;

--- a/src/render/clip/clipCloud.ts
+++ b/src/render/clip/clipCloud.ts
@@ -27,7 +27,7 @@ function filterChannel<T extends TypedArray>(
   if (!arr || pointCount <= 0) return undefined;
   const stride = (arr.length / pointCount) | 0;
   if (stride < 1) return undefined;
-  const Ctor = arr.constructor as { new (length: number): T };
+  const Ctor = arr.constructor as new (length: number) => T;
   const out = new Ctor(keep.length * stride);
   for (let j = 0; j < keep.length; j++) {
     const src = keep[j] * stride;

--- a/src/render/colorEncode.ts
+++ b/src/render/colorEncode.ts
@@ -46,7 +46,9 @@ export function srgbToLinearScalar(v: number): number {
  * inline copies that could drift from this seam.
  */
 export function linearToSrgbScalar(v: number): number {
-  const x = v < 0 ? 0 : v > 1 ? 1 : v;
+  let x = v;
+  if (v < 0) x = 0;
+  else if (v > 1) x = 1;
   return x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055;
 }
 

--- a/src/render/colorLegend.ts
+++ b/src/render/colorLegend.ts
@@ -151,11 +151,13 @@ export function buildColorLegend(host: ColorLegendHost): ColorLegend {
               max: range.max + cloud.sourceOrigin[upAxis],
             }
           : range;
+      let trimPercent = 0;
+      if (mode === 'elevation') trimPercent = host.heightPercentileTrim();
+      else if (mode === 'gpsTime') trimPercent = 5;
       return buildActiveColorbarSpec({
         mode,
         range: display,
-        trimPercent:
-          mode === 'elevation' ? host.heightPercentileTrim() : mode === 'gpsTime' ? 5 : 0,
+        trimPercent,
         elevationUnit: host.elevationUnitLabel(),
       });
     },

--- a/src/render/colorModes.ts
+++ b/src/render/colorModes.ts
@@ -269,7 +269,7 @@ function sampleRamp(
 
   // Find the two bracketing control points.
   let lo = ramp[0];
-  let hi = ramp[ramp.length - 1];
+  let hi = ramp.at(-1)!;
 
   for (let i = 0; i < ramp.length - 1; i++) {
     if (tc >= ramp[i][0] && tc <= ramp[i + 1][0]) {
@@ -454,7 +454,7 @@ function rampScalars(
     // data" black instead of feeding NaN through the ramp maths. (±Infinity
     // still flows through and clamps to a ramp endpoint, matching what the
     // pre-refactor elevation loop did.)
-    if (v !== v) continue;
+    if (Number.isNaN(v)) continue;
     const t = range === 0 ? 0 : (v - min) / range;
     const [r, g, b] = sampleRamp(t, palette);
     out[i * 3] = r;

--- a/src/render/colorbar.ts
+++ b/src/render/colorbar.ts
@@ -88,7 +88,11 @@ export function niceTicks(min: number, max: number, target = 5): number[] {
   const rawStep = span / Math.max(1, target);
   const mag = Math.pow(10, Math.floor(Math.log10(rawStep)));
   const norm = rawStep / mag;
-  const niceNorm = norm < 1.5 ? 1 : norm < 3 ? 2 : norm < 7 ? 5 : 10;
+  let niceNorm: number;
+  if (norm < 1.5) niceNorm = 1;
+  else if (norm < 3) niceNorm = 2;
+  else if (norm < 7) niceNorm = 5;
+  else niceNorm = 10;
   const step = niceNorm * mag;
   const first = Math.ceil(lo / step) * step;
   const ticks: number[] = [];
@@ -102,10 +106,10 @@ export function niceTicks(min: number, max: number, target = 5): number[] {
 /** XML-escape a text value for safe inclusion in the SVG. */
 function esc(s: string): string {
   return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
 }
 
 /**

--- a/src/render/densityColors.ts
+++ b/src/render/densityColors.ts
@@ -43,7 +43,7 @@ const DENSITY_RAMP: ReadonlyArray<readonly [number, number, number, number]> = [
 /** Sample the density ramp at `t` in [0, 1]. */
 function sampleRamp(t: number): [number, number, number] {
   if (t <= 0) return [DENSITY_RAMP[0][1], DENSITY_RAMP[0][2], DENSITY_RAMP[0][3]];
-  const last = DENSITY_RAMP[DENSITY_RAMP.length - 1];
+  const last = DENSITY_RAMP.at(-1)!;
   if (t >= 1) return [last[1], last[2], last[3]];
   for (let i = 1; i < DENSITY_RAMP.length; i++) {
     const upper = DENSITY_RAMP[i];

--- a/src/render/export/pngWorldFile.ts
+++ b/src/render/export/pngWorldFile.ts
@@ -64,7 +64,7 @@ export function buildWorldFileText(params: WorldFileParams): string | null {
   }
   const vals = [extent.minX, extent.minY, extent.maxX, extent.maxY];
   if (vals.some((v) => !Number.isFinite(v))) return null;
-  if (!(extent.maxX > extent.minX) || !(extent.maxY > extent.minY)) return null;
+  if (extent.maxX <= extent.minX || extent.maxY <= extent.minY) return null;
 
   const ox = params.worldOrigin?.x ?? 0;
   const oy = params.worldOrigin?.y ?? 0;
@@ -74,7 +74,7 @@ export function buildWorldFileText(params: WorldFileParams): string | null {
   const cx = ox + extent.minX + pixelW / 2;
   const cy = oy + extent.maxY - pixelH / 2;
   // One value per line, trailing newline — the format GDAL/QGIS write & read.
-  return [pixelW, 0, 0, -pixelH, cx, cy].map((v) => String(v)).join('\n') + '\n';
+  return [pixelW, 0, 0, -pixelH, cx, cy].map(String).join('\n') + '\n';
 }
 
 export interface StudioPngPackageParams extends WorldFileParams {

--- a/src/render/exportAdapter.ts
+++ b/src/render/exportAdapter.ts
@@ -342,7 +342,7 @@ export function buildExportAdapter(host: ExportAdapterHost): ExportSceneAdapter 
         } else if (worldOrigin.x !== o[0] || worldOrigin.y !== o[1]) {
           return null; // conflicting frames — honestly not georeferenceable
         }
-        if (wkt == null) wkt = cloud.metadata?.crs?.wkt ?? null;
+        wkt ??= cloud.metadata?.crs?.wkt ?? null;
       }
       return any ? { worldOrigin, wkt } : null;
     },

--- a/src/render/hillshadeColors.ts
+++ b/src/render/hillshadeColors.ts
@@ -144,7 +144,7 @@ export function hillshadeShading(input: HillshadeInput): Float32Array {
     const unz = nz / len;
     // Lambert shading: max(0, dot(normal, sun)).
     const dot = unx * sx + uny * sy + unz * sz;
-    const shade = dot > 0 ? dot : 0;
+    const shade = Math.max(0, dot);
     shadingCache.set(k, shade);
     out[i] = shade;
   }

--- a/src/render/inspectionPresets.ts
+++ b/src/render/inspectionPresets.ts
@@ -222,7 +222,7 @@ export function listPresets(): readonly InspectionPreset[] {
 }
 
 /** Look up a preset by id. Returns the default when the id is unknown. */
-export function getPreset(id: PresetId | string): InspectionPreset {
+export function getPreset(id: string): InspectionPreset {
   const known = (PRESETS as Record<string, InspectionPreset>)[id];
   return known ?? PRESETS[DEFAULT_PRESET_ID];
 }

--- a/src/render/measure/MeasureController.ts
+++ b/src/render/measure/MeasureController.ts
@@ -306,6 +306,9 @@ export interface MeasurementSummary {
   volumeResidentOnly?: boolean;
 }
 
+/** Snap targeting mode: off, to real returns only, or to measurement geometry. */
+export type SnapMode = 'off' | 'point' | 'geometry';
+
 export class MeasureController {
   /** The SVG overlay element — append to the stage overlay. */
   readonly overlay: SVGSVGElement;
@@ -318,7 +321,7 @@ export class MeasureController {
   private readonly _clearBtn: HTMLButtonElement;
   private readonly _unitsBtn: HTMLButtonElement;
   /** Finish-polygon button — shown only while a polygon draft is open. */
-  private _finishBtn: HTMLButtonElement | null = null;
+  private readonly _finishBtn: HTMLButtonElement | null = null;
   private readonly _kindButtons = new Map<MeasurementKind, HTMLButtonElement>();
   /**
    * The kind picker row container — exposed so the host can inject
@@ -326,7 +329,7 @@ export class MeasureController {
    * built-in measurement kinds without forking the controller.
    * Populated in the constructor.
    */
-  private _kindRow: HTMLElement | null = null;
+  private readonly _kindRow: HTMLElement | null = null;
   private _onChange: (() => void) | null = null;
   /** Called when the unit system changes — used to persist the preference. */
   private _onUnitChange: (() => void) | null = null;
@@ -445,7 +448,7 @@ export class MeasureController {
   // cloud on load; `_lastSnap` drives the disclosure in the hint. The camera +
   // canvas are cached each frame so the place handler can size the snap radius.
   private static readonly SNAP_RADIUS_PX = 14;
-  private _snapMode: 'off' | 'point' | 'geometry' = 'off';
+  private _snapMode: SnapMode = 'off';
   private _snapIndex: PointSnapIndex | null = null;
   private _lastSnap: SnapResult | null = null;
   // Whether the active scan has a known CRS with real-world units. Separate from
@@ -463,7 +466,7 @@ export class MeasureController {
   private _geographicCrs = false;
   private _lastCamera: THREE.PerspectiveCamera | null = null;
   private _lastCanvas: HTMLCanvasElement | null = null;
-  private _snapBtn: HTMLButtonElement | null = null;
+  private readonly _snapBtn: HTMLButtonElement | null = null;
   private readonly _counters: Record<MeasurementKind, number> = {
     distance: 0,
     polyline: 0,
@@ -970,8 +973,8 @@ export class MeasureController {
       const anchorBtn = anchorKind
         ? this._kindButtons.get(anchorKind) ?? null
         : null;
-      if (anchorBtn && anchorBtn.parentElement === this._kindRow) {
-        anchorBtn.insertAdjacentElement('afterend', btn);
+      if (anchorBtn?.parentElement === this._kindRow) {
+        anchorBtn.after(btn);
       } else {
         this._kindRow.append(btn);
       }
@@ -1018,7 +1021,7 @@ export class MeasureController {
   resampleProfile(id: string, params: ProfileResampleParams): boolean {
     if (!this._profileSampler) return false;
     const m = this._measurements.find((x) => x.id === id);
-    if (!m || m.kind !== 'profile' || m.points.length < 2) return false;
+    if (m?.kind !== 'profile' || m.points.length < 2) return false;
     // Clamp in METRES (the user's input space), then convert to render units
     // through the same B2 factor the summary boundary applies forward — the
     // exact inverse, so what the user typed is what the sampler walks. The
@@ -1200,7 +1203,7 @@ export class MeasureController {
       this._setHintText(`No point there — ${VERB_LOWER} directly on the scan`);
       return;
     }
-    if (!this._draft) this._draft = this._newDraft();
+    this._draft ??= this._newDraft();
     // Snap the placed vertex to a real return or to existing measurement
     // geometry before committing it. `_lastSnap` records what it landed on so
     // the hint can disclose it (a snap never implies a return that isn't one).
@@ -1223,12 +1226,12 @@ export class MeasureController {
   }
 
   /** The active snap mode. */
-  get snapMode(): 'off' | 'point' | 'geometry' {
+  get snapMode(): SnapMode {
     return this._snapMode;
   }
 
   /** Set the snap mode and re-label the toggle. */
-  setSnapMode(mode: 'off' | 'point' | 'geometry'): void {
+  setSnapMode(mode: SnapMode): void {
     this._snapMode = mode;
     if (mode === 'off') this._lastSnap = null;
     this._syncSnapBtn();
@@ -1236,15 +1239,19 @@ export class MeasureController {
   }
 
   private _cycleSnapMode(): void {
-    const next: 'off' | 'point' | 'geometry' =
-      this._snapMode === 'off' ? 'point' : this._snapMode === 'point' ? 'geometry' : 'off';
+    let next: SnapMode;
+    if (this._snapMode === 'off') next = 'point';
+    else if (this._snapMode === 'point') next = 'geometry';
+    else next = 'off';
     this.setSnapMode(next);
   }
 
   private _syncSnapBtn(): void {
     if (!this._snapBtn) return;
-    const label =
-      this._snapMode === 'off' ? 'Snap: Off' : this._snapMode === 'point' ? 'Snap: Point' : 'Snap: Geom';
+    let label: string;
+    if (this._snapMode === 'off') label = 'Snap: Off';
+    else if (this._snapMode === 'point') label = 'Snap: Point';
+    else label = 'Snap: Geom';
     const span = this._snapBtn.querySelector('.olv-mlabel');
     if (span) span.textContent = label;
     else this._snapBtn.textContent = label;
@@ -1303,14 +1310,11 @@ export class MeasureController {
   private _snapHintPrefix(): string {
     if (this._snapMode === 'off' || !this._lastSnap) return '';
     const k = this._lastSnap.kind;
-    const where =
-      k === 'point'
-        ? 'nearest point (measured return)'
-        : k === 'endpoint'
-          ? 'measurement vertex'
-          : k === 'midpoint'
-            ? 'segment midpoint'
-            : 'segment intersection';
+    let where: string;
+    if (k === 'point') where = 'nearest point (measured return)';
+    else if (k === 'endpoint') where = 'measurement vertex';
+    else if (k === 'midpoint') where = 'segment midpoint';
+    else where = 'segment intersection';
     return `Snapped to ${where} · `;
   }
 
@@ -1559,9 +1563,9 @@ export class MeasureController {
   /** A pointerdown on a vertex handle begins an edit drag. */
   private _handlePointerDown(e: PointerEvent): void {
     if (!this._active) return;
-    const target = e.target as Element | null;
-    const mid = target?.getAttribute('data-mid') ?? null;
-    const viAttr = target?.getAttribute('data-vi') ?? null;
+    const target = e.target as SVGElement | null;
+    const mid = target?.dataset.mid ?? null;
+    const viAttr = target?.dataset.vi ?? null;
     if (mid === null || viAttr === null) return;
     e.preventDefault();
     this._drag = { id: mid, vi: Number(viAttr) };
@@ -1853,7 +1857,7 @@ export class MeasureController {
         });
       }
       L.push({
-        anchor: pts[pts.length - 1],
+        anchor: pts.at(-1)!,
         text: this._fmtLen(r.total),
         primary: true,
       });
@@ -1873,48 +1877,58 @@ export class MeasureController {
       const [a, b] = pts;
       const elbow = elbowPoint(a, b, this._worldUp);
       const d = verticalDelta(a, b, this._worldUp);
-      E.push({ a, b: elbow, style: 'solid' });
-      E.push({ a: elbow, b, style: 'solid' });
-      L.push({
-        anchor: midpoint(elbow, b),
-        text: this._fmtVertical(Math.abs(d.vertical)),
-        primary: true,
-      });
-      L.push({
-        anchor: midpoint(a, elbow),
-        text: this._fmtLen(d.horizontal),
-        primary: false,
-      });
+      E.push(
+        { a, b: elbow, style: 'solid' },
+        { a: elbow, b, style: 'solid' },
+      );
+      L.push(
+        {
+          anchor: midpoint(elbow, b),
+          text: this._fmtVertical(Math.abs(d.vertical)),
+          primary: true,
+        },
+        {
+          anchor: midpoint(a, elbow),
+          text: this._fmtLen(d.horizontal),
+          primary: false,
+        },
+      );
       return;
     }
     if (m.kind === 'slope' && pts.length >= 2) {
       const [a, b] = pts;
       const elbow = elbowPoint(a, b, this._worldUp);
       const s = slopeBetween(a, b, this._worldUp);
-      E.push({ a, b, style: 'solid' });
-      E.push({ a, b: elbow, style: 'preview' });
-      E.push({ a: elbow, b, style: 'preview' });
-      L.push({
-        anchor: midpoint(a, b),
-        text: `${formatGrade(s.gradePercent)} · ${formatAngle(s.angleDeg)}`,
-        primary: true,
-      });
-      L.push({
-        anchor: midpoint(elbow, b),
-        text: this._fmtVertical(Math.abs(s.rise)),
-        primary: false,
-      });
-      L.push({
-        anchor: midpoint(a, elbow),
-        text: this._fmtLen(s.run),
-        primary: false,
-      });
+      E.push(
+        { a, b, style: 'solid' },
+        { a, b: elbow, style: 'preview' },
+        { a: elbow, b, style: 'preview' },
+      );
+      L.push(
+        {
+          anchor: midpoint(a, b),
+          text: `${formatGrade(s.gradePercent)} · ${formatAngle(s.angleDeg)}`,
+          primary: true,
+        },
+        {
+          anchor: midpoint(elbow, b),
+          text: this._fmtVertical(Math.abs(s.rise)),
+          primary: false,
+        },
+        {
+          anchor: midpoint(a, elbow),
+          text: this._fmtLen(s.run),
+          primary: false,
+        },
+      );
       return;
     }
     if (m.kind === 'angle' && pts.length >= 3) {
       const [a, vertex, c] = pts;
-      E.push({ a, b: vertex, style: 'solid' });
-      E.push({ a: vertex, b: c, style: 'solid' });
+      E.push(
+        { a, b: vertex, style: 'solid' },
+        { a: vertex, b: c, style: 'solid' },
+      );
       L.push({
         anchor: vertex,
         text: formatAngle(angleAtVertex(a, vertex, c)),
@@ -1930,30 +1944,34 @@ export class MeasureController {
       const [a, b] = pts;
       const elbow = elbowPoint(a, b, this._worldUp);
       const pm = profileMetrics(a, b, this._worldUp);
-      E.push({ a, b, style: 'solid' });
-      E.push({ a, b: elbow, style: 'preview' });
-      E.push({ a: elbow, b, style: 'preview' });
-      L.push({
-        anchor: midpoint(a, b),
-        text: formatProfileHeadline(
-          // Length ×horizontal factor; drop ×up-axis factor (compound CRS).
-          pm.length3d * this._unitToMetres,
-          pm.verticalDrop * this._effVertical(),
-          pm.gradePercent,
-          this._units,
-        ),
-        primary: true,
-      });
-      L.push({
-        anchor: midpoint(elbow, b),
-        text: this._fmtVertical(Math.abs(pm.verticalDrop)),
-        primary: false,
-      });
-      L.push({
-        anchor: midpoint(a, elbow),
-        text: this._fmtLen(pm.lengthHorizontal),
-        primary: false,
-      });
+      E.push(
+        { a, b, style: 'solid' },
+        { a, b: elbow, style: 'preview' },
+        { a: elbow, b, style: 'preview' },
+      );
+      L.push(
+        {
+          anchor: midpoint(a, b),
+          text: formatProfileHeadline(
+            // Length ×horizontal factor; drop ×up-axis factor (compound CRS).
+            pm.length3d * this._unitToMetres,
+            pm.verticalDrop * this._effVertical(),
+            pm.gradePercent,
+            this._units,
+          ),
+          primary: true,
+        },
+        {
+          anchor: midpoint(elbow, b),
+          text: this._fmtVertical(Math.abs(pm.verticalDrop)),
+          primary: false,
+        },
+        {
+          anchor: midpoint(a, elbow),
+          text: this._fmtLen(pm.lengthHorizontal),
+          primary: false,
+        },
+      );
       // Station markers on the cloud — small dim dots at evenly-spaced
       // chainages along the section line, so the profile's stations are visible
       // in 3D, not just on the chart. The endpoints already carry their own
@@ -2042,7 +2060,7 @@ export class MeasureController {
 
     const cur = this._cursor;
     if (!cur || pts.length === 0) return;
-    const last = pts[pts.length - 1];
+    const last = pts.at(-1)!;
 
     if (d.kind === 'distance') {
       E.push({ a: last, b: cur, style: 'preview' });
@@ -2097,8 +2115,10 @@ export class MeasureController {
     }
     if (d.kind === 'height') {
       const elbow = elbowPoint(pts[0], cur, this._worldUp);
-      E.push({ a: pts[0], b: elbow, style: 'preview' });
-      E.push({ a: elbow, b: cur, style: 'preview' });
+      E.push(
+        { a: pts[0], b: elbow, style: 'preview' },
+        { a: elbow, b: cur, style: 'preview' },
+      );
       L.push({
         anchor: midpoint(elbow, cur),
         text: this._fmtVertical(Math.abs(verticalDelta(pts[0], cur, this._worldUp).vertical)),
@@ -2109,9 +2129,11 @@ export class MeasureController {
     if (d.kind === 'slope') {
       const elbow = elbowPoint(pts[0], cur, this._worldUp);
       const s = slopeBetween(pts[0], cur, this._worldUp);
-      E.push({ a: pts[0], b: cur, style: 'preview' });
-      E.push({ a: pts[0], b: elbow, style: 'preview' });
-      E.push({ a: elbow, b: cur, style: 'preview' });
+      E.push(
+        { a: pts[0], b: cur, style: 'preview' },
+        { a: pts[0], b: elbow, style: 'preview' },
+        { a: elbow, b: cur, style: 'preview' },
+      );
       L.push({
         anchor: midpoint(pts[0], cur),
         text: `${formatGrade(s.gradePercent)} · ${formatAngle(s.angleDeg)}`,
@@ -2135,9 +2157,11 @@ export class MeasureController {
       // readout (length · Δh · grade).
       const elbow = elbowPoint(pts[0], cur, this._worldUp);
       const pm = profileMetrics(pts[0], cur, this._worldUp);
-      E.push({ a: pts[0], b: cur, style: 'preview' });
-      E.push({ a: pts[0], b: elbow, style: 'preview' });
-      E.push({ a: elbow, b: cur, style: 'preview' });
+      E.push(
+        { a: pts[0], b: cur, style: 'preview' },
+        { a: pts[0], b: elbow, style: 'preview' },
+        { a: elbow, b: cur, style: 'preview' },
+      );
       L.push({
         anchor: midpoint(pts[0], cur),
         text: formatProfileHeadline(

--- a/src/render/measure/MeasureOverlay.ts
+++ b/src/render/measure/MeasureOverlay.ts
@@ -198,34 +198,24 @@ export class MeasureOverlay {
           }),
         );
       }
-      kids.push(
-        svg('circle', {
-          cx: p.x,
-          cy: p.y,
-          r:
-            vx.role === 'pending'
-              ? 5
-              : vx.role === 'snap-target'
-                ? 5.5
-                : vx.role === 'station'
-                  ? 2.6
-                  : 4.2,
-          class:
-            vx.role === 'pending'
-              ? 'olv-measure-dot olv-measure-dot-pending'
-              : vx.role === 'snap-target'
-                ? 'olv-measure-dot olv-measure-dot-snap'
-                : vx.role === 'station'
-                  ? vx.active
-                    ? 'olv-measure-dot olv-measure-dot-station is-active'
-                    : 'olv-measure-dot olv-measure-dot-station'
-                  : 'olv-measure-dot',
-        }),
-      );
+      let dotRadius: number;
+      if (vx.role === 'pending') dotRadius = 5;
+      else if (vx.role === 'snap-target') dotRadius = 5.5;
+      else if (vx.role === 'station') dotRadius = 2.6;
+      else dotRadius = 4.2;
+      let dotClass: string;
+      if (vx.role === 'pending') dotClass = 'olv-measure-dot olv-measure-dot-pending';
+      else if (vx.role === 'snap-target') dotClass = 'olv-measure-dot olv-measure-dot-snap';
+      else if (vx.role === 'station') {
+        dotClass = vx.active
+          ? 'olv-measure-dot olv-measure-dot-station is-active'
+          : 'olv-measure-dot olv-measure-dot-station';
+      } else dotClass = 'olv-measure-dot';
+      kids.push(svg('circle', { cx: p.x, cy: p.y, r: dotRadius, class: dotClass }));
       if (vx.handle) {
         const hit = svg('circle', { cx: p.x, cy: p.y, r: 12, class: 'olv-m-handle' });
-        hit.setAttribute('data-mid', vx.handle.mid);
-        hit.setAttribute('data-vi', String(vx.handle.vi));
+        hit.dataset.mid = vx.handle.mid;
+        hit.dataset.vi = String(vx.handle.vi);
         kids.push(hit);
       }
     }

--- a/src/render/measure/auditLog.ts
+++ b/src/render/measure/auditLog.ts
@@ -156,7 +156,8 @@ export class AuditLog {
 
   /** The current chain head hash (or the genesis sentinel when empty). */
   get head(): string {
-    return this._entries.length === 0 ? GENESIS : this._entries[this._entries.length - 1].hash;
+    const last = this._entries.at(-1);
+    return last === undefined ? GENESIS : last.hash;
   }
 
   /** Deterministic, canonical serialization of the whole log for export. */

--- a/src/render/measure/classificationEditor.ts
+++ b/src/render/measure/classificationEditor.ts
@@ -86,8 +86,7 @@ export function applyIndexReclassify(
 ): ClassEditResult {
   const n = classification.length;
   let changed = 0;
-  for (let k = 0; k < indices.length; k++) {
-    const i = indices[k];
+  for (const i of indices) {
     if (i < 0 || i >= n) continue;
     if (classification[i] !== newClass) {
       classification[i] = newClass;

--- a/src/render/measure/format.ts
+++ b/src/render/measure/format.ts
@@ -153,7 +153,10 @@ export function formatProfileHeadline(
   const len = formatLength(length3d, system);
   const drop = formatLength(Math.abs(verticalDrop), system);
   const grade = formatGrade(gradePercent);
-  const sign = verticalDrop < 0 ? '−' : verticalDrop > 0 ? '+' : '';
+  let sign: string;
+  if (verticalDrop < 0) sign = '−';
+  else if (verticalDrop > 0) sign = '+';
+  else sign = '';
   return `${len}  · Δh ${sign}${drop}  · ${grade}`;
 }
 

--- a/src/render/measure/geometry.ts
+++ b/src/render/measure/geometry.ts
@@ -17,8 +17,12 @@ const EPSILON = 1e-9;
 
 // ── small vector helpers ────────────────────────────────────────────────────
 
-function sub(a: Vec3, b: Vec3): Vec3 {
-  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+function sub(minuend: Vec3, subtrahend: Vec3): Vec3 {
+  return [
+    minuend[0] - subtrahend[0],
+    minuend[1] - subtrahend[1],
+    minuend[2] - subtrahend[2],
+  ];
 }
 
 function dot(a: Vec3, b: Vec3): number {
@@ -367,6 +371,9 @@ export function boxFromCorners(a: Vec3, b: Vec3): BoxBounds {
  */
 const AXIS_EPS = 1e-6;
 
+/** The index of a coordinate axis: 0 = X, 1 = Y, 2 = Z. */
+export type AxisIndex = 0 | 1 | 2;
+
 /**
  * The index of the axis an up vector names — 0 = X, 1 = Y, 2 = Z.
  *
@@ -385,16 +392,22 @@ const AXIS_EPS = 1e-6;
  * it today: every write to the viewer's world-up is exactly (0, ±1, 0) or
  * (0, 0, ±1), chosen by source format.
  */
-export function upAxisIndex(up: Vec3): 0 | 1 | 2 {
+export function upAxisIndex(up: Vec3): AxisIndex {
   const ax = Math.abs(up[0]);
   const ay = Math.abs(up[1]);
   const az = Math.abs(up[2]);
   const len = Math.hypot(ax, ay, az);
-  const axis: 0 | 1 | 2 = ay > ax && ay >= az ? 1 : ax > ay && ax >= az ? 0 : 2;
+  let axis: AxisIndex;
+  if (ay > ax && ay >= az) axis = 1;
+  else if (ax > ay && ax >= az) axis = 0;
+  else axis = 2;
   // A zero or non-finite vector names no axis, and normalising it would divide
   // by zero — refuse before the ratio test rather than propagate a NaN.
   if (Number.isFinite(len) && len > 0) {
-    const dominant = axis === 0 ? ax : axis === 1 ? ay : az;
+    let dominant: number;
+    if (axis === 0) dominant = ax;
+    else if (axis === 1) dominant = ay;
+    else dominant = az;
     if (dominant / len >= 1 - AXIS_EPS) return axis;
   }
   throw new Error(
@@ -405,7 +418,7 @@ export function upAxisIndex(up: Vec3): 0 | 1 | 2 {
 }
 
 /** The two non-vertical axes, ascending, for a given up-axis. */
-function horizontalAxes(upAxis: 0 | 1 | 2): [0 | 1 | 2, 0 | 1 | 2] {
+function horizontalAxes(upAxis: AxisIndex): [AxisIndex, AxisIndex] {
   if (upAxis === 0) return [1, 2];
   if (upAxis === 1) return [0, 2];
   return [0, 1];

--- a/src/render/measure/lassoVolume.ts
+++ b/src/render/measure/lassoVolume.ts
@@ -119,8 +119,9 @@ export function filterSelectionToVisible(
   const { keepPoint, acceptIndex } = filters;
   if (!keepPoint && !acceptIndex) return indices;
   let w = 0;
-  for (let r = 0; r < indices.length; r++) {
-    const i = indices[r];
+  // Compaction in place: writes always land at index w <= the current read
+  // position, so the for-of never observes an overwritten element.
+  for (const i of indices) {
     if (
       keepPoint &&
       !keepPoint(positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2])
@@ -154,7 +155,7 @@ export function convexHull2D(points: ReadonlyArray<Vec2>): Vec2[] {
   // Lower hull.
   const lower: Vec2[] = [];
   for (const p of sorted) {
-    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) {
+    while (lower.length >= 2 && cross(lower.at(-2)!, lower.at(-1)!, p) <= 0) {
       lower.pop();
     }
     lower.push(p);
@@ -163,7 +164,7 @@ export function convexHull2D(points: ReadonlyArray<Vec2>): Vec2[] {
   const upper: Vec2[] = [];
   for (let i = sorted.length - 1; i >= 0; i--) {
     const p = sorted[i];
-    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) {
+    while (upper.length >= 2 && cross(upper.at(-2)!, upper.at(-1)!, p) <= 0) {
       upper.pop();
     }
     upper.push(p);

--- a/src/render/measure/mapSheetExportOptions.ts
+++ b/src/render/measure/mapSheetExportOptions.ts
@@ -61,7 +61,7 @@ export function ensurePdfExtension(name: string): string {
  * field is never blank.
  */
 export function defaultMapTitle(p: { title?: string | null; basename: string }): string {
-  if (p.title && p.title.trim()) return p.title.trim();
+  if (p.title?.trim()) return p.title.trim();
   const base = (p.basename ?? '').trim();
   return base ? `${base} — Contours` : 'Contours';
 }
@@ -86,7 +86,7 @@ export function defaultMapNotes(p: {
     p.intervalM != null && Number.isFinite(p.intervalM)
       ? `${p.intervalM}${verticalUnitSuffix(p.verticalUnitToMetres)}`
       : 'auto';
-  const crs = p.crs && p.crs.trim() ? p.crs.trim() : 'no CRS';
+  const crs = p.crs?.trim() ? p.crs.trim() : 'no CRS';
   return `Contours from ${base} · interval ${interval} · ${crs}`;
 }
 

--- a/src/render/measure/mapSheetPdf.ts
+++ b/src/render/measure/mapSheetPdf.ts
@@ -64,15 +64,14 @@ export function mapSheetEvidenceNote(claimId: string = MAP_SHEET_CLAIM): string 
  */
 export function mapSheetEvidenceLine(claimId: string = MAP_SHEET_CLAIM): string {
   const status = evidenceStatus(claimId);
-  return status === 'validated'
-    ? 'Evidence: validated export (meets required evidence level).'
-    : status === 'refused'
-      ? 'Evidence: export not permitted at current evidence level.'
-      : 'Evidence: exploratory export - below required evidence level.';
+  if (status === 'validated') return 'Evidence: validated export (meets required evidence level).';
+  if (status === 'refused') return 'Evidence: export not permitted at current evidence level.';
+  return 'Evidence: exploratory export - below required evidence level.';
 }
 
 export type SheetSize = 'letter' | 'a4' | 'a3';
 export type SheetOrientation = 'portrait' | 'landscape';
+export type SheetReadiness = 'ready' | 'previewOnly' | 'blocked';
 
 /**
  * Purpose-driven product facts a map sheet DOCUMENTS (v0.5.9 §6.2). When present
@@ -128,7 +127,7 @@ export interface MapSheetInput {
    */
   readonly linearUnit?: 'metre' | 'foot' | 'us-survey-foot' | 'unknown';
   readonly accuracy?: DemAccuracyStandards | null;
-  readonly readiness?: 'ready' | 'previewOnly' | 'blocked';
+  readonly readiness?: SheetReadiness;
   readonly title?: string;
   readonly preparedBy?: string;
   /** Free-text "Project / Notes" block printed under the identity column. */
@@ -241,7 +240,7 @@ export function contourDrawStyle(isIndex: boolean, grade: ContourFeature['grade'
  * without calling it survey-grade or a certification, and the preview state is
  * already negated.
  */
-export function readinessNote(readiness: 'ready' | 'previewOnly' | 'blocked'): string {
+export function readinessNote(readiness: SheetReadiness): string {
   return readiness === 'ready'
     ? 'Validated against held-out ground - not a survey certification.'
     : 'PREVIEW - not survey-grade until validated against control.';
@@ -267,8 +266,7 @@ export function wrapTextToWidth(
   const lines: string[] = [];
   let line = '';
   let truncated = false;
-  for (let w = 0; w < words.length; w++) {
-    const word = words[w];
+  for (const word of words) {
     const candidate = line ? `${line} ${word}` : word;
     if (fits(candidate)) {
       line = candidate;
@@ -473,14 +471,11 @@ function drawPurposeAppendix(
   // ── "This deliverable" settings box ────────────────────────────────────────
   const onOff = (b: boolean): string => (b ? 'on' : 'off');
   const yesNo = (b: boolean): string => (b ? 'yes' : 'no');
-  const geometry =
-    purpose.analytical && purpose.cartographic
-      ? 'analytical + cartographic'
-      : purpose.analytical
-        ? 'analytical (exact)'
-        : purpose.cartographic
-          ? 'cartographic'
-          : 'none';
+  let geometry: string;
+  if (purpose.analytical && purpose.cartographic) geometry = 'analytical + cartographic';
+  else if (purpose.analytical) geometry = 'analytical (exact)';
+  else if (purpose.cartographic) geometry = 'cartographic';
+  else geometry = 'none';
   const generalization =
     purpose.generalizeToleranceCells > 0
       ? `e = ${purpose.generalizeToleranceCells} x cell (Douglas-Peucker tolerance)`
@@ -837,10 +832,13 @@ function drawAnnotationTable(
   const headerBaseline = boxTop - 12;
   // Available vertical run from the header down to a margin above the scale bar.
   const avail = headerBaseline - (frame.y + 28);
-  const footNote =
-    offMapCount > 0
-      ? `${offMapCount} annotation${offMapCount === 1 ? '' : 's'} outside the map extent - listed, not plotted.`
-      : '';
+  let footNote: string;
+  if (offMapCount > 0) {
+    const plural = offMapCount === 1 ? '' : 's';
+    footNote = `${offMapCount} annotation${plural} outside the map extent - listed, not plotted.`;
+  } else {
+    footNote = '';
+  }
   const footLines = footNote ? 1 : 0;
   const noteRun = rowSz + 4;
   // Fit the row pitch: start roomy, shrink toward a floor so more rows fit before
@@ -986,12 +984,10 @@ function drawTitleBlock(
   const interval = prov?.contourIntervalM ?? input.model.intervalM;
   // World-unit→metres factor so the 1:N ratio stays a TRUE dimensionless ratio
   // on a foot CRS (the map is drawn in source units). 1 for metric / unknown.
-  const worldUnitToMetres =
-    input.linearUnit === 'foot'
-      ? 0.3048
-      : input.linearUnit === 'us-survey-foot'
-        ? 1200 / 3937
-        : 1;
+  let worldUnitToMetres: number;
+  if (input.linearUnit === 'foot') worldUnitToMetres = 0.3048;
+  else if (input.linearUnit === 'us-survey-foot') worldUnitToMetres = 1200 / 3937;
+  else worldUnitToMetres = 1;
   const scaleN =
     bbox && frame.w > 0
       ? Math.round(
@@ -1098,13 +1094,14 @@ function drawTitleBlock(
   // Export-readiness verdict — single-sourced from the unified provenance so the
   // sheet's readiness note can't disagree with the other exports. Maps the
   // provenance verdict (Ready / Preview / Blocked) onto the note vocabulary.
-  const readiness: 'ready' | 'previewOnly' | 'blocked' = prov
-    ? prov.exportReadiness === 'Ready'
-      ? 'ready'
-      : prov.exportReadiness === 'Blocked'
-        ? 'blocked'
-        : 'previewOnly'
-    : input.readiness ?? 'previewOnly';
+  let readiness: SheetReadiness;
+  if (prov) {
+    if (prov.exportReadiness === 'Ready') readiness = 'ready';
+    else if (prov.exportReadiness === 'Blocked') readiness = 'blocked';
+    else readiness = 'previewOnly';
+  } else {
+    readiness = input.readiness ?? 'previewOnly';
+  }
   // Export-readiness + evidence verdict, wrapped WITHIN the accuracy column
   // (rcx..rxr) so the honest PREVIEW / exploratory banner can never bleed into
   // the legend column. Both stay the SAME central-gate strings every other

--- a/src/render/measure/measureDerivations.ts
+++ b/src/render/measure/measureDerivations.ts
@@ -24,10 +24,10 @@ const MEDIUM_CONFIDENCE_POINTS = 100;
  */
 export function deriveVolumeRecord(result: VolumeResult, referenceZ: number): VolumeRecord {
   const inPoly = result.pointsInPolygon;
-  const confidence: 'high' | 'medium' | 'low' =
-    inPoly >= HIGH_CONFIDENCE_POINTS ? 'high'
-    : inPoly >= MEDIUM_CONFIDENCE_POINTS ? 'medium'
-    : 'low';
+  let confidence: 'high' | 'medium' | 'low';
+  if (inPoly >= HIGH_CONFIDENCE_POINTS) confidence = 'high';
+  else if (inPoly >= MEDIUM_CONFIDENCE_POINTS) confidence = 'medium';
+  else confidence = 'low';
   const record: VolumeRecord = {
     fill: result.fill,
     cut: result.cut,

--- a/src/render/measure/measurementTrust.ts
+++ b/src/render/measure/measurementTrust.ts
@@ -125,7 +125,10 @@ export function gradeMeasurement(input: MeasurementTrustInput): MeasurementTrust
     if (tier === 'void') worst = 'void';
   }
 
-  let grade: TrustGrade = worst === 'strong' ? 'green' : worst === 'weak' ? 'yellow' : 'red';
+  let grade: TrustGrade;
+  if (worst === 'strong') grade = 'green';
+  else if (worst === 'weak') grade = 'yellow';
+  else grade = 'red';
 
   // Endpoint reasoning.
   if (anyVoid) {
@@ -170,15 +173,12 @@ export function gradeMeasurement(input: MeasurementTrustInput): MeasurementTrust
   }
 
   const presentable = !anyVoid && !geographicRefusal && !verticalMismatchRefusal;
-  const caption = geographicRefusal
-    ? 'Unverified — degrees are not distances (geographic CRS)'
-    : verticalMismatchRefusal
-    ? 'Unverified — height unit differs from horizontal (compound CRS)'
-    : grade === 'green'
-      ? 'Verified — well supported by measured points'
-      : grade === 'yellow'
-        ? 'Caution — loosely supported or unverified scale'
-        : 'Unverified — an endpoint has no points to measure';
+  let caption: string;
+  if (geographicRefusal) caption = 'Unverified — degrees are not distances (geographic CRS)';
+  else if (verticalMismatchRefusal) caption = 'Unverified — height unit differs from horizontal (compound CRS)';
+  else if (grade === 'green') caption = 'Verified — well supported by measured points';
+  else if (grade === 'yellow') caption = 'Caution — loosely supported or unverified scale';
+  else caption = 'Unverified — an endpoint has no points to measure';
 
   return { grade, caption, reasons, presentable };
 }
@@ -216,9 +216,12 @@ export function summarizeMeasurementTrust(
   if (green) parts.push(`${green} verified`);
   if (yellow) parts.push(`${yellow} caution`);
   if (red) parts.push(`${red} unverified`);
-  const line =
-    total === 0
-      ? 'No graded measurements'
-      : `${total} measurement${total === 1 ? '' : 's'} — ${parts.join(', ')}`;
+  let line: string;
+  if (total === 0) {
+    line = 'No graded measurements';
+  } else {
+    const plural = total === 1 ? '' : 's';
+    line = `${total} measurement${plural} — ${parts.join(', ')}`;
+  }
   return { total, green, yellow, red, line };
 }

--- a/src/render/measure/profilePdf.ts
+++ b/src/render/measure/profilePdf.ts
@@ -154,7 +154,7 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
   // title rather than the raw filename; setLanguage tags the document language.
   // (A full tagged-structure tree is out of reach with this PDF library; these
   // are the honest, supported accessibility hooks — see ReportPdfRenderer.)
-  const pdfTitle = input.name && input.name.trim()
+  const pdfTitle = input.name?.trim()
     ? `Terrain Profile - ${input.name.trim()}`
     : 'Terrain Profile';
   doc.setTitle(pdfTitle, { showInWindowTitleBar: true });

--- a/src/render/measure/profileSampler.ts
+++ b/src/render/measure/profileSampler.ts
@@ -105,8 +105,12 @@ export function assembleProfileBuffers(
 function dot(a: Vec3, b: Vec3): number {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
-function sub(a: Vec3, b: Vec3): Vec3 {
-  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+function sub(minuend: Vec3, subtrahend: Vec3): Vec3 {
+  return [
+    minuend[0] - subtrahend[0],
+    minuend[1] - subtrahend[1],
+    minuend[2] - subtrahend[2],
+  ];
 }
 function length(v: Vec3): number {
   return Math.hypot(v[0], v[1], v[2]);
@@ -394,8 +398,7 @@ export function sampleProfile(input: SampleProfileInput): ProfileSample[] {
       ? horizontalLen * AUTO_CORRIDOR_FRACTION
       : Math.max(0, input.bandWidth);
   const bandSq = band * band;
-  const percentile =
-    input.groundPercentile == null ? DEFAULT_GROUND_PERCENTILE : input.groundPercentile;
+  const percentile = input.groundPercentile ?? DEFAULT_GROUND_PERCENTILE;
 
   const binStep = horizontalLen / (samples - 1);
 
@@ -411,10 +414,10 @@ export function sampleProfile(input: SampleProfileInput): ProfileSample[] {
   // Classification gate — drop vegetation / building / noise so they never
   // enter a corridor's elevation statistics. Only active when an aligned
   // classification channel was supplied.
-  const cls = input.classification && input.classification.length === n ? input.classification : null;
+  const cls = input.classification?.length === n ? input.classification : null;
   const drop = cls ? new Set(input.excludeClasses ?? NON_GROUND_CLASSES) : null;
   for (let i = 0; i < n; i++) {
-    if (drop && drop.has(cls![i])) continue;
+    if (drop?.has(cls![i])) continue;
     const px = positions[i * 3];
     const py = positions[i * 3 + 1];
     const pz = positions[i * 3 + 2];
@@ -492,7 +495,7 @@ export function summariseProfile(samples: readonly ProfileSample[]): ProfileSumm
     if (s.height > max) max = s.height;
   }
   if (hits === 0) {
-    return { minHeight: NaN, maxHeight: NaN, heightSpan: NaN, coverage: 0 };
+    return { minHeight: Number.NaN, maxHeight: Number.NaN, heightSpan: Number.NaN, coverage: 0 };
   }
   return {
     minHeight: min,

--- a/src/render/measure/profileStations.ts
+++ b/src/render/measure/profileStations.ts
@@ -260,10 +260,11 @@ function elevationAtChainage(
   samples: ReadonlyArray<ProfileChartSample>,
   chainage: number,
 ): number {
-  if (samples.length === 0) return Number.NaN;
+  const last = samples.at(-1);
+  if (last === undefined) return Number.NaN;
   if (chainage <= samples[0].distance) return samples[0].height;
-  if (chainage >= samples[samples.length - 1].distance) {
-    return samples[samples.length - 1].height;
+  if (chainage >= last.distance) {
+    return last.height;
   }
   // Linear search — samples are typically 32..256 long; binary
   // search would shave µs but adds branch complexity not worth it
@@ -286,5 +287,5 @@ function elevationAtChainage(
       return lo.height + t * (hi.height - lo.height);
     }
   }
-  return samples[samples.length - 1].height;
+  return last.height;
 }

--- a/src/render/measure/snap.ts
+++ b/src/render/measure/snap.ts
@@ -200,7 +200,7 @@ export function snapToNearestPoint(
   };
 
   // If cellSize is non-finite (<=1 point, no extent) just scan linearly.
-  if (!isFinite(cellSize)) {
+  if (!Number.isFinite(cellSize)) {
     for (let i = 0; i < index.count; i++) consider(i);
     return bestIndex < 0
       ? null
@@ -286,7 +286,7 @@ export function countPointsWithinRadius(
     if (dist2(positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2], query) <= r2) count++;
   };
 
-  if (!isFinite(cellSize)) {
+  if (!Number.isFinite(cellSize)) {
     for (let i = 0; i < index.count; i++) consider(i);
     return count;
   }
@@ -468,13 +468,14 @@ export function snapBest(
       best = c;
       continue;
     }
-    // Prefer a real point on a near-tie; otherwise strictly closer wins.
-    if (c.distance < best.distance - POINT_PREFERENCE_MARGIN) {
-      best = c;
-    } else if (
-      c.kind === 'point' &&
-      best.kind !== 'point' &&
-      c.distance <= best.distance + POINT_PREFERENCE_MARGIN
+    // Prefer a real point on a near-tie; otherwise strictly closer wins. Both
+    // conditions land on the same assignment: a strictly-closer candidate, or a
+    // real measured point that ties a constructed feature within the margin.
+    if (
+      c.distance < best.distance - POINT_PREFERENCE_MARGIN ||
+      (c.kind === 'point' &&
+        best.kind !== 'point' &&
+        c.distance <= best.distance + POINT_PREFERENCE_MARGIN)
     ) {
       best = c;
     }

--- a/src/render/measure/spaceReportPdf.ts
+++ b/src/render/measure/spaceReportPdf.ts
@@ -22,10 +22,7 @@
 import { PDFDocument, StandardFonts, rgb, type PDFFont, type PDFPage } from 'pdf-lib';
 import type { SpaceMetrics } from '../../terrain/spaceMetrics';
 import type { ObjectMetrics } from '../../terrain/objectMetrics';
-import {
-  buildSpaceReportContent,
-  type SpaceReportContent,
-} from '../../terrain/space/spaceReportLayout';
+import { buildSpaceReportContent } from '../../terrain/space/spaceReportLayout';
 import type { FloorPlanModel } from '../../terrain/space/floorplan/extractFloorPlan';
 import type { PlanUnitSystem } from '../../terrain/space/floorplan/floorPlanSvg';
 
@@ -130,7 +127,6 @@ export async function buildSpaceReportPdf(input: SpaceReportPdfInput): Promise<U
       y = drawWrapped(page, font, `- ${c}`, M, y, PW - 2 * M, 8.5, DIM);
       y -= 3;
     }
-    y -= 8;
   }
 
   // ── Provenance footer ──
@@ -351,4 +347,4 @@ function drawFloorPlan(
   });
 }
 
-export type { SpaceReportContent };
+export type { SpaceReportContent } from '../../terrain/space/spaceReportLayout';

--- a/src/render/measure/stockpileVolume.ts
+++ b/src/render/measure/stockpileVolume.ts
@@ -250,40 +250,38 @@ export function stockpileVolume(input: StockpileInput): StockpileVolumeResult {
   if (baseMode === 'explicit') {
     baseZ = input.base?.z ?? 0;
     baseUncertainty = 0;
+  } else if (insideHeights.length === 0) {
+    baseZ = 0;
+    baseUncertainty = 0;
   } else {
-    if (insideHeights.length === 0) {
-      baseZ = 0;
-      baseUncertainty = 0;
-    } else {
-      const sorted = Float64Array.from(insideHeights).sort();
-      baseZ = percentileSorted(sorted, basePct);
-      // Base-plane uncertainty has TWO parts, and the band is only honest if it
-      // carries both:
-      //
-      //   1. Random scatter — the std of the "ground band" (lowest 25% of inside
-      //      heights, the points sitting on the surrounding ground). How noisy
-      //      the apron is.
-      //   2. Systematic mis-fit — a single HORIZONTAL base under sloped or
-      //      uneven ground biases EVERY thickness the same direction, so it
-      //      cannot be averaged away by more points (a Type-B systematic term in
-      //      GUM language). Point scatter alone misses it. We bound it by how far
-      //      the representative ground level — the ground band's MEAN — sits
-      //      above the chosen low-percentile base: the amount the flat base is
-      //      systematically too low across the footprint. Flat ground ⇒ this gap
-      //      ≈ 0 and scatter governs; a sloped apron ⇒ it dominates, widening the
-      //      band honestly instead of reporting a confidently-narrow number.
-      //
-      // Take the larger of the two so the systematic term sets a floor the
-      // random term can never shrink below.
-      const groundCount = Math.max(1, Math.floor(sorted.length * 0.25));
-      const groundBand = sorted.subarray(0, groundCount);
-      const groundScatter = stdDev(groundBand);
-      let groundSum = 0;
-      for (let i = 0; i < groundBand.length; i++) groundSum += groundBand[i];
-      const groundMean = groundSum / groundBand.length;
-      const baseBias = Math.max(0, groundMean - baseZ);
-      baseUncertainty = Math.max(groundScatter, baseBias);
-    }
+    const sorted = Float64Array.from(insideHeights).sort();
+    baseZ = percentileSorted(sorted, basePct);
+    // Base-plane uncertainty has TWO parts, and the band is only honest if it
+    // carries both:
+    //
+    //   1. Random scatter — the std of the "ground band" (lowest 25% of inside
+    //      heights, the points sitting on the surrounding ground). How noisy
+    //      the apron is.
+    //   2. Systematic mis-fit — a single HORIZONTAL base under sloped or
+    //      uneven ground biases EVERY thickness the same direction, so it
+    //      cannot be averaged away by more points (a Type-B systematic term in
+    //      GUM language). Point scatter alone misses it. We bound it by how far
+    //      the representative ground level — the ground band's MEAN — sits
+    //      above the chosen low-percentile base: the amount the flat base is
+    //      systematically too low across the footprint. Flat ground ⇒ this gap
+    //      ≈ 0 and scatter governs; a sloped apron ⇒ it dominates, widening the
+    //      band honestly instead of reporting a confidently-narrow number.
+    //
+    // Take the larger of the two so the systematic term sets a floor the
+    // random term can never shrink below.
+    const groundCount = Math.max(1, Math.floor(sorted.length * 0.25));
+    const groundBand = sorted.subarray(0, groundCount);
+    const groundScatter = stdDev(groundBand);
+    let groundSum = 0;
+    for (const g of groundBand) groundSum += g;
+    const groundMean = groundSum / groundBand.length;
+    const baseBias = Math.max(0, groundMean - baseZ);
+    baseUncertainty = Math.max(groundScatter, baseBias);
   }
 
   // Reuse the existing estimator for fill/cut/area/density/validity.
@@ -425,11 +423,11 @@ function buildCaveats(
       `Base plane was inferred from the lowest ground points inside the footprint (±${baseUncertainty.toFixed(2)} m); set an explicit base if you have a surveyed datum.`,
     );
   }
-  out.push('Point-sample estimate over a horizontal base plane; not a triangulated surface-to-surface volume.');
   // Mirrors changeUncertainty's spatial-correlation caveat: the √N in the
   // sampling-error term assumes independent residuals, which scan noise
   // (scan lines, registration drift) routinely violates.
   out.push(
+    'Point-sample estimate over a horizontal base plane; not a triangulated surface-to-surface volume.',
     'Point-sampling noise is assumed spatially independent; the true error is larger if it is correlated.',
   );
   if (confidence === 'high') {

--- a/src/render/navPrefs.ts
+++ b/src/render/navPrefs.ts
@@ -48,7 +48,7 @@ export const DEFAULT_NAVIGATION_PREFERENCES: NavigationPreferences = {
 };
 
 /** The presets the panel offers (kept in sync with {@link NavigationPreset}). */
-const NAV_PRESETS: readonly NavigationPreset[] = ['default', 'recap', 'nira'];
+const NAV_PRESETS: ReadonlySet<NavigationPreset> = new Set(['default', 'recap', 'nira']);
 
 /**
  * The invert signs each preset selects. These sign combos are the ADJUSTABLE
@@ -83,7 +83,7 @@ export function parseNavigationPreferences(raw: unknown): NavigationPreferences 
   return {
     invertOrbitX: typeof o.invertOrbitX === 'boolean' ? o.invertOrbitX : d.invertOrbitX,
     invertOrbitY: typeof o.invertOrbitY === 'boolean' ? o.invertOrbitY : d.invertOrbitY,
-    preset: NAV_PRESETS.includes(o.preset as NavigationPreset)
+    preset: NAV_PRESETS.has(o.preset as NavigationPreset)
       ? (o.preset as NavigationPreset)
       : d.preset,
   };

--- a/src/render/patchView.ts
+++ b/src/render/patchView.ts
@@ -83,7 +83,9 @@ const DEFAULT_SIZE = 48;
 const DEFAULT_SPLAT_RADIUS = 1.5;
 
 function clamp(v: number, lo: number, hi: number): number {
-  return v < lo ? lo : v > hi ? hi : v;
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
 }
 
 function dot(a: Vec3, b: Vec3): number {

--- a/src/render/pixelProjection.ts
+++ b/src/render/pixelProjection.ts
@@ -32,7 +32,7 @@ export function projectedPixels(
   if (!(worldSize > 0) || !(viewportHeightCss > 0) || !(verticalFovRadians > 0)) return 0;
   const d = distance > 1e-6 ? distance : 1e-6;
   const denom = 2 * d * Math.tan(verticalFovRadians / 2);
-  if (!(denom > 0) || !Number.isFinite(denom)) return 0;
+  if (denom <= 0 || !Number.isFinite(denom)) return 0;
   return (worldSize * viewportHeightCss) / denom;
 }
 

--- a/src/render/presetApplication.ts
+++ b/src/render/presetApplication.ts
@@ -76,7 +76,7 @@ export interface PresetApplication {
  */
 export function applyInspectionPreset(
   host: PresetApplyHost,
-  id: PresetId | string,
+  id: string,
 ): PresetApplication {
   const preset = getPreset(id);
   host.setEdlEnabled(preset.edlEnabled);

--- a/src/render/refinementPhase.ts
+++ b/src/render/refinementPhase.ts
@@ -138,5 +138,7 @@ export function centerWeight(
   const dy = projY / wy;
   const d = Math.sqrt(dx * dx + dy * dy);
   const w = 1 - d;
-  return w < 0 ? 0 : w > 1 ? 1 : w;
+  if (w < 0) return 0;
+  if (w > 1) return 1;
+  return w;
 }

--- a/src/render/renderLoop.ts
+++ b/src/render/renderLoop.ts
@@ -204,7 +204,7 @@ export function runRenderFrame(host: RenderLoopHost): void {
       // Static clouds first; fall back to resident streaming nodes only when
       // the static pick misses — the COPC live probe.
       info = host.probePickStatic(ndc.x, ndc.y);
-      if (info === null) info = host.probePickStreaming(ndc.x, ndc.y);
+      info ??= host.probePickStreaming(ndc.x, ndc.y);
     }
     const client = host.pointerClient();
     host.updateProbe(info, client.x, client.y);

--- a/src/render/rgbAppearance.ts
+++ b/src/render/rgbAppearance.ts
@@ -184,7 +184,9 @@ function luminance(r: number, g: number, b: number): number {
 }
 
 function clamp01(v: number): number {
-  return v < 0 ? 0 : v > 1 ? 1 : v;
+  if (v < 0) return 0;
+  if (v > 1) return 1;
+  return v;
 }
 
 /**

--- a/src/render/scanCapability.ts
+++ b/src/render/scanCapability.ts
@@ -93,7 +93,7 @@ export interface ScanCapabilityInput {
   readonly hasNormals: boolean;
   readonly hasGpsTime: boolean;
   /** A resolved CRS makes the scan georeferenced; null/undefined = local frame. */
-  readonly crs?: unknown | null;
+  readonly crs?: unknown;
   readonly isMesh?: boolean;
   readonly hasTexture?: boolean;
   readonly extentMetres?: readonly [number, number, number];

--- a/src/render/snapshot.ts
+++ b/src/render/snapshot.ts
@@ -325,8 +325,10 @@ function drawInspectorInfoCard(
   if (info.pointSourceId !== undefined) {
     rows.push(['Point source', String(info.pointSourceId)]);
   }
-  rows.push(['Layer', info.layer]);
-  rows.push(['Index', info.index.toLocaleString('en-US')]);
+  rows.push(
+    ['Layer', info.layer],
+    ['Index', info.index.toLocaleString('en-US')],
+  );
 
   // Measure layout — the card width is driven by the widest row.
   const PAD = 14;

--- a/src/render/splatShader.ts
+++ b/src/render/splatShader.ts
@@ -156,7 +156,9 @@ export function gaussianSplatAlpha(
   const edge = Math.exp(-k); // raw(1), in (0, 1)
   const raw = Math.exp(-k * d * d); // raw(d)
   const a = (raw - edge) / (1 - edge);
-  return a <= 0 ? 0 : a >= 1 ? 1 : a;
+  if (a <= 0) return 0;
+  if (a >= 1) return 1;
+  return a;
 }
 
 /**

--- a/src/render/streaming/EptOctree.ts
+++ b/src/render/streaming/EptOctree.ts
@@ -155,7 +155,7 @@ export class EptOctree implements StreamingOctreeView {
    */
   private async _walkHierarchy(fileBudget: number, signal?: AbortSignal): Promise<void> {
     if (this._fullyLoaded) return;
-    if (this._frontier === null) this._frontier = [{ d: 0, x: 0, y: 0, z: 0 }];
+    this._frontier ??= [{ d: 0, x: 0, y: 0, z: 0 }];
     const cap = Math.min(fileBudget, MAX_HIERARCHY_FILES);
     const PER_WAVE_CONCURRENCY = 8;
 

--- a/src/render/streaming/EptStreamingPointCloud.ts
+++ b/src/render/streaming/EptStreamingPointCloud.ts
@@ -41,6 +41,7 @@ import type {
 } from '../../io/copc/copcChunkDecode';
 import type { NodeCounts } from './StreamingNodeStore';
 import type {
+  StreamingColorMode,
   StreamingSource,
   StreamingSourceKind,
 } from './StreamingSource';
@@ -181,7 +182,7 @@ export class EptStreamingPointCloud implements StreamingSource {
    * Red / Green / Blue attributes; elevation otherwise. Mirrors the
    * COPC implementation's contract.
    */
-  defaultColorMode(): 'rgb' | 'intensity' | 'elevation' | 'classification' | 'normal' {
+  defaultColorMode(): StreamingColorMode {
     return this._hasRgb() ? 'rgb' : 'elevation';
   }
 
@@ -190,8 +191,8 @@ export class EptStreamingPointCloud implements StreamingSource {
    * RGB requires Red/Green/Blue, Intensity needs Intensity, Classification
    * needs Classification. Elevation is always available (always have X/Y/Z).
    */
-  availableColorModes(): readonly ('rgb' | 'intensity' | 'elevation' | 'classification' | 'normal')[] {
-    const out: ('rgb' | 'intensity' | 'elevation' | 'classification' | 'normal')[] = [];
+  availableColorModes(): readonly StreamingColorMode[] {
+    const out: StreamingColorMode[] = [];
     if (this._hasRgb()) out.push('rgb');
     if (this._schemaHas('Intensity')) out.push('intensity');
     out.push('elevation');

--- a/src/render/streaming/StreamingPointCloud.ts
+++ b/src/render/streaming/StreamingPointCloud.ts
@@ -20,6 +20,7 @@ import type {
 import type { ChunkDecodeMetadata } from '../../io/copc/copcChunkDecode';
 import type { NodeCounts } from './StreamingNodeStore';
 import type {
+  StreamingColorMode,
   StreamingSource,
   StreamingSourceKind,
 } from './StreamingSource';
@@ -113,7 +114,7 @@ export class StreamingPointCloud implements StreamingSource {
    * format-agnostic default colour mode. COPC clouds use RGB when
    * the point format carries it (PDRF 7 / 8), elevation otherwise.
    */
-  defaultColorMode(): 'rgb' | 'intensity' | 'elevation' | 'classification' | 'normal' {
+  defaultColorMode(): StreamingColorMode {
     return this.metadata.header.hasRgb ? 'rgb' : 'elevation';
   }
 
@@ -122,8 +123,8 @@ export class StreamingPointCloud implements StreamingSource {
    * present; intensity / elevation / classification are always available
    * on COPC PDRF 6/7/8.
    */
-  availableColorModes(): readonly ('rgb' | 'intensity' | 'elevation' | 'classification' | 'normal')[] {
-    const out: ('rgb' | 'intensity' | 'elevation' | 'classification' | 'normal')[] = [];
+  availableColorModes(): readonly StreamingColorMode[] {
+    const out: StreamingColorMode[] = [];
     if (this.metadata.header.hasRgb) out.push('rgb');
     out.push('intensity', 'elevation', 'classification');
     return out;

--- a/src/render/streaming/StreamingRenderer.ts
+++ b/src/render/streaming/StreamingRenderer.ts
@@ -264,7 +264,7 @@ export class StreamingRenderer {
     const existing = this._meshes.get(node.record.id);
     if (existing) {
       const fade = this._fades.get(existing.mesh);
-      if (fade && fade.direction === 'out') {
+      if (fade?.direction === 'out') {
         // The node was evicted and is mid-fade-OUT, but its chunk arrived
         // again inside the fade window — it is current once more. Bailing here
         // (the old "already resident" guard) let the fade completion later

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -403,7 +403,7 @@ export class StreamingScheduler {
   private _pointBudget: number;
   private readonly _uploadQueue: GpuUploadQueue | undefined;
   private readonly _datasetId: string;
-  private _generationId = 0;
+  private readonly _generationId = 0;
   private _maxConcurrent: number;
   /**
    * Reused per-tick to avoid the spread-clone of `view.cameraPosition`
@@ -516,7 +516,7 @@ export class StreamingScheduler {
     this._memoryPressureRatio =
       options.memoryPressureRatio ?? DEFAULT_MEMORY_PRESSURE_RATIO;
     this._evictionHysteresis = resolveEvictionHysteresis({
-      ...(options.evictionHysteresis ?? {}),
+      ...options.evictionHysteresis,
       triggerRatio: this._memoryPressureRatio,
     });
     this._now = options.now ?? nowMs;
@@ -683,7 +683,7 @@ export class StreamingScheduler {
     // Hysteresis on the "stable" transition — we only resume full-detail
     // refinement after staying below the threshold for the settle window.
     if (this._velocitySmoothed <= VELOCITY_FAST_THRESHOLD) {
-      if (this._stableSinceTs === null) this._stableSinceTs = wallNow;
+      this._stableSinceTs ??= wallNow;
     } else {
       this._stableSinceTs = null;
     }
@@ -702,7 +702,7 @@ export class StreamingScheduler {
         ? this._cloud.octree.store.residentPointCount / this._pointBudget
         : 0;
     if (ratio > PRESSURE_HIGH_RATIO) {
-      if (this._pressureHighSinceTs === null) this._pressureHighSinceTs = wallNow;
+      this._pressureHighSinceTs ??= wallNow;
       this._pressureLowSinceTs = null;
       if (
         this._pressureDepthReduction === 0 &&
@@ -711,7 +711,7 @@ export class StreamingScheduler {
         this._pressureDepthReduction = PRESSURE_DEPTH_REDUCTION;
       }
     } else if (ratio < PRESSURE_LOW_RATIO) {
-      if (this._pressureLowSinceTs === null) this._pressureLowSinceTs = wallNow;
+      this._pressureLowSinceTs ??= wallNow;
       this._pressureHighSinceTs = null;
       if (
         this._pressureDepthReduction > 0 &&
@@ -746,7 +746,7 @@ export class StreamingScheduler {
     if (typeof frameMs === 'number' && frameMs > 0) {
       if (frameMs > FPS_PRESSURE_HIGH_MS) {
         // Sustained slow — start the low-fps timer.
-        if (this._fpsLowSinceTs === null) this._fpsLowSinceTs = wallNow;
+        this._fpsLowSinceTs ??= wallNow;
         this._fpsHighSinceTs = null;
         if (
           wallNow - this._fpsLowSinceTs >= FPS_PRESSURE_HIGH_HOLD_MS &&
@@ -761,7 +761,7 @@ export class StreamingScheduler {
         }
       } else if (frameMs < FPS_PRESSURE_LOW_MS) {
         // Sustained smooth — start the high-fps recovery timer.
-        if (this._fpsHighSinceTs === null) this._fpsHighSinceTs = wallNow;
+        this._fpsHighSinceTs ??= wallNow;
         this._fpsLowSinceTs = null;
         if (
           wallNow - this._fpsHighSinceTs >= FPS_PRESSURE_LOW_HOLD_MS &&
@@ -887,7 +887,7 @@ export class StreamingScheduler {
       wanted = freshWanted;
 
       // Cache the inputs and outputs for the next tick's fast-path check.
-      if (this._lastVP === null) this._lastVP = new Float64Array(16);
+      this._lastVP ??= new Float64Array(16);
       copyVp(view.viewProjection, this._lastVP);
       // Reuse the cached tuple instead of allocating a fresh one each rescore.
       if (this._lastSigCameraPos === null) {
@@ -958,7 +958,7 @@ export class StreamingScheduler {
     for (const [id, deadline] of this._deferredEvictAt) {
       if (nowTs < deadline) continue;
       const node = store.get(id);
-      if (!node || node.state !== 'resident') {
+      if (node?.state !== 'resident') {
         this._deferredEvictAt.delete(id);
         continue;
       }
@@ -1004,7 +1004,7 @@ export class StreamingScheduler {
       this._pointBudget,
     )) {
       const node = store.get(id);
-      if (!node || node.state !== 'resident') continue;
+      if (node?.state !== 'resident') continue;
       // Cache hysteresis (hysteresis): bump the compressed chunk so a quick
       // camera return finds it warm.
       this._cache.touch(id);
@@ -1063,7 +1063,7 @@ export class StreamingScheduler {
       });
       for (const id of plan.evict) {
         const node = store.get(id);
-        if (!node || node.state !== 'resident') {
+        if (node?.state !== 'resident') {
           this._deferredEvictAt.delete(id);
           continue;
         }
@@ -1146,7 +1146,7 @@ export class StreamingScheduler {
     const store = this._cloud.octree.store;
     for (const id of this._inFlight.keys()) {
       const node = store.get(id);
-      if (node && node.state === 'loading') store.setState(node, 'unloaded');
+      if (node?.state === 'loading') store.setState(node, 'unloaded');
     }
     for (const controller of this._inFlight.values()) controller.abort();
     this._inFlight.clear();
@@ -1273,7 +1273,7 @@ export class StreamingScheduler {
       this._queue.length > 0
     ) {
       const node = this._queue.shift();
-      if (!node || node.state !== 'queued') continue;
+      if (node?.state !== 'queued') continue;
       // Pressure gate — if accepting this decode would push the projected
       // resident count past the hysteresis cap, defer it. The next scheduler
       // `update()` tick (after eviction has had a chance to run) will

--- a/src/render/streaming/StreamingSource.ts
+++ b/src/render/streaming/StreamingSource.ts
@@ -21,14 +21,21 @@
  * Pure — no DOM, no three.js — entirely a type/contract module.
  */
 
-import type { Box6 } from '../../io/copc/copcTypes';
-import type {
-  ChunkDecodeMetadata,
-  DecodedChunk,
-} from '../../io/copc/copcChunkDecode';
-import type { StreamingNodeRecord } from '../../io/copc/copcTypes';
+import type { Box6, StreamingNodeRecord } from '../../io/copc/copcTypes';
+import type { ChunkDecodeMetadata } from '../../io/copc/copcChunkDecode';
 import type { StreamingNode } from './StreamingNode';
 import type { NodeCounts, StreamingNodeStore } from './StreamingNodeStore';
+
+/**
+ * The colour modes a streaming cloud can drive — shared by the source
+ * contract and its COPC / EPT implementations.
+ */
+export type StreamingColorMode =
+  | 'rgb'
+  | 'intensity'
+  | 'elevation'
+  | 'classification'
+  | 'normal';
 
 /**
  * The minimal public surface the scheduler / renderer / picking path read off
@@ -122,14 +129,14 @@ export interface StreamingSource {
    * Returned values match the runtime's `ColorMode` enum: 'rgb' when the
    * format carries colour, else 'elevation'.
    */
-  defaultColorMode(): 'rgb' | 'intensity' | 'elevation' | 'classification' | 'normal';
+  defaultColorMode(): StreamingColorMode;
   /**
    * The colour modes the cloud can actually drive. The Viewer surfaces
    * these to the Inspector's "Color by" chip row so a cloud that lacks
    * (say) classification doesn't show a Class chip that produces a blank
    * recolour.
    */
-  availableColorModes(): readonly ('rgb' | 'intensity' | 'elevation' | 'classification' | 'normal')[];
+  availableColorModes(): readonly StreamingColorMode[];
   /**
    * the source CRS, when the cloud carries projection metadata.
    * COPC clouds get this from the LAS VLRs the public-header parser walks
@@ -174,4 +181,4 @@ export interface StreamingSource {
 
 // Re-export `DecodedChunk` so consumers that import `StreamingSource` need
 // only one import for the decode-side type vocabulary.
-export type { DecodedChunk };
+export type { DecodedChunk } from '../../io/copc/copcChunkDecode';

--- a/src/render/streaming/evictionPolicy.ts
+++ b/src/render/streaming/evictionPolicy.ts
@@ -153,7 +153,7 @@ export interface EvictionPlanInput {
 export function resolveEvictionHysteresis(
   overrides: Partial<EvictionHysteresis> | undefined,
 ): EvictionHysteresis {
-  const merged = { ...DEFAULT_EVICTION_HYSTERESIS, ...(overrides ?? {}) };
+  const merged = { ...DEFAULT_EVICTION_HYSTERESIS, ...overrides };
   const triggerRatio = Math.max(1, finiteOr(merged.triggerRatio, DEFAULT_EVICTION_HYSTERESIS.triggerRatio));
   const requested = Math.max(0, finiteOr(merged.releaseRatio, DEFAULT_EVICTION_HYSTERESIS.releaseRatio));
   // Keep a real band between the two edges — 5 % of the trigger, or the whole
@@ -242,12 +242,15 @@ function byEvictionPriority(
 ): number {
   const ap = isDwellProtected(a, nowMs, minVisibleDwellMs) ? 1 : 0;
   const bp = isDwellProtected(b, nowMs, minVisibleDwellMs) ? 1 : 0;
+  let idOrder = 0;
+  if (a.id < b.id) idOrder = -1;
+  else if (a.id > b.id) idOrder = 1;
   return (
     evictionRank(b) - evictionRank(a) ||
     ap - bp ||
     b.depth - a.depth ||
     b.distance - a.distance ||
-    (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
+    idOrder
   );
 }
 

--- a/src/render/streaming/refinementReadiness.ts
+++ b/src/render/streaming/refinementReadiness.ts
@@ -161,7 +161,7 @@ export function evaluateRefinementReadiness(
   // Clamped for display safety only. A correct caller (counts over the wanted
   // set) cannot exceed 1; a caller that passed a global resident count can, and
   // the clamp keeps a progress bar sane without letting the excess vote below.
-  const fractionResident = raw > 1 ? 1 : raw;
+  const fractionResident = Math.min(1, raw);
   const outstanding =
     facts.inFlightCount + facts.queuedCount + facts.decodedPendingCount;
 

--- a/src/render/streaming/sampleGrade.ts
+++ b/src/render/streaming/sampleGrade.ts
@@ -158,9 +158,12 @@ export function gradeSampleDensity(
     const x = positions[i * 3], y = positions[i * 3 + 1], z = positions[i * 3 + 2];
     if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
     valid++;
-    if (x < minX) minX = x; if (x > maxX) maxX = x;
-    if (y < minY) minY = y; if (y > maxY) maxY = y;
-    if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z;
+    if (z > maxZ) maxZ = z;
   }
   const invalidPoints = n - valid;
   if (valid < 1 || !Number.isFinite(minX) || !Number.isFinite(maxX)) {
@@ -304,23 +307,20 @@ export function summarizeSampleGrade(grade: SampleGrade, unitConfirmed = true): 
   }
   // The tier word claims an absolute pts/m² band, so withhold it when the unit
   // is unconfirmed — the '—'/none case still reads '—'.
-  const tier = unitConfirmed
-    ? grade.bucketLabel
-    : grade.bucketBasis === 'none'
-      ? grade.bucketLabel
-      : 'units unknown';
+  let tier: string;
+  if (unitConfirmed) tier = grade.bucketLabel;
+  else if (grade.bucketBasis === 'none') tier = grade.bucketLabel;
+  else tier = 'units unknown';
   lines.push(`Density: ${tier}${densityFigure}`);
   if (grade.verticalSpanM > 0) {
     lines.push(`Vertical extent: ${grade.verticalSpanM.toFixed(1)} ${units.vertical}`);
   }
   if (grade.occupancyRatio != null) {
     const pct = Math.round(grade.occupancyRatio * 100);
-    const note =
-      grade.occupancyRatio >= 0.85
-        ? 'fills its footprint evenly'
-        : grade.occupancyRatio >= 0.5
-          ? 'partly hollow / irregular footprint'
-          : 'sparse or hollow footprint — bbox overstates coverage';
+    let note: string;
+    if (grade.occupancyRatio >= 0.85) note = 'fills its footprint evenly';
+    else if (grade.occupancyRatio >= 0.5) note = 'partly hollow / irregular footprint';
+    else note = 'sparse or hollow footprint — bbox overstates coverage';
     lines.push(`Coverage of bounding box: ${pct}% (${note})`);
   }
   if (grade.invalidPoints > 0) {

--- a/src/render/streaming/samplingPlan.ts
+++ b/src/render/streaming/samplingPlan.ts
@@ -86,7 +86,15 @@ export function buildSamplingPlan(
   const eligible = nodes
     .filter((n) => n.depth <= maxDepth)
     .slice()
-    .sort((a, b) => a.depth - b.depth || b.pointCount - a.pointCount || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    .sort((a, b) => {
+      const byDepth = a.depth - b.depth;
+      if (byDepth !== 0) return byDepth;
+      const byCount = b.pointCount - a.pointCount;
+      if (byCount !== 0) return byCount;
+      if (a.id < b.id) return -1;
+      if (a.id > b.id) return 1;
+      return 0;
+    });
 
   const nodeIds: string[] = [];
   let sampledPoints = 0;

--- a/src/render/streaming/streamingBenchmark.ts
+++ b/src/render/streaming/streamingBenchmark.ts
@@ -203,16 +203,12 @@ export class StreamingBenchmark {
 
   /** Mark the first rendered streaming node — once per session. */
   recordFirstPaint(): void {
-    if (this._firstPaintMs === undefined) {
-      this._firstPaintMs = this._elapsed();
-    }
+    this._firstPaintMs ??= this._elapsed();
   }
 
   /** Mark the moment the coarse view is fully resident — once per session. */
   recordCoarseStable(): void {
-    if (this._coarseStableMs === undefined) {
-      this._coarseStableMs = this._elapsed();
-    }
+    this._coarseStableMs ??= this._elapsed();
   }
 
   /**
@@ -451,12 +447,14 @@ export function formatStreamingBenchmark(result: StreamingBenchmarkResult): stri
         ` max=${a.max.toFixed(2).padStart(7)} ms`,
     );
   };
-  lines.push('streaming benchmark');
-  lines.push(`  first paint   ${ms(result.firstPaintMs)}`);
-  lines.push(`  coarse stable ${ms(result.timeToCoarseStableMs)}`);
-  lines.push(`  refined stable${ms(result.timeToRefinedStableMs)}`);
-  lines.push(`  network bytes ${mb(result.networkBytes)}`);
-  lines.push(`  decoded bytes ${mb(result.decodedBytes)}`);
+  lines.push(
+    'streaming benchmark',
+    `  first paint   ${ms(result.firstPaintMs)}`,
+    `  coarse stable ${ms(result.timeToCoarseStableMs)}`,
+    `  refined stable${ms(result.timeToRefinedStableMs)}`,
+    `  network bytes ${mb(result.networkBytes)}`,
+    `  decoded bytes ${mb(result.decodedBytes)}`,
+  );
   ag('scheduler', result.schedulerTickMs);
   ag('decode/chunk', result.decodeMsPerChunk);
   ag('frame', result.frameMs);

--- a/src/render/streaming/streamingColors.ts
+++ b/src/render/streaming/streamingColors.ts
@@ -156,7 +156,9 @@ export function streamingNodeColors(
       applyRgbAppearance(tmp.subarray(0, len), rgbAppearance);
       const out = _rgbWorkOut;
       for (let i = 0; i < len; i++) {
-        const v = tmp[i] <= 0 ? 0 : tmp[i] >= 1 ? 1 : tmp[i];
+        let v = tmp[i];
+        if (tmp[i] <= 0) v = 0;
+        else if (tmp[i] >= 1) v = 1;
         out[i] = Math.round(v * 255);
       }
       // The InstancedBufferAttribute upload copies the bytes — the

--- a/src/render/streaming/tierAdaptation.ts
+++ b/src/render/streaming/tierAdaptation.ts
@@ -103,7 +103,7 @@ export class TierAdaptation {
   recordFps(fps: number): DeviceTier {
     const now = this._now();
     if (fps < STEP_DOWN_FPS) {
-      if (this._belowSinceTs === null) this._belowSinceTs = now;
+      this._belowSinceTs ??= now;
       this._aboveSinceTs = null;
       if (now - this._belowSinceTs >= STEP_DOWN_HOLD_MS) {
         const next = tierStepDown(this._tier);
@@ -113,7 +113,7 @@ export class TierAdaptation {
         }
       }
     } else if (fps > STEP_UP_FPS) {
-      if (this._aboveSinceTs === null) this._aboveSinceTs = now;
+      this._aboveSinceTs ??= now;
       this._belowSinceTs = null;
       if (now - this._aboveSinceTs >= STEP_UP_HOLD_MS) {
         const next = tierStepUp(this._tier);

--- a/src/render/terrainStreamSample.ts
+++ b/src/render/terrainStreamSample.ts
@@ -79,9 +79,11 @@ export function sampleStridedTerrain(
   // rest, which makes the order a total function of the keys alone.
   const byKey = new Map<string, KeyedTerrainStreamBuffer>();
   for (const b of streamingBuffers) if (!byKey.has(b.key)) byKey.set(b.key, b);
-  const sortedStreaming = [...byKey.values()].sort((a, b) =>
-    a.key < b.key ? -1 : a.key > b.key ? 1 : 0,
-  );
+  const sortedStreaming = [...byKey.values()].sort((a, b) => {
+    if (a.key < b.key) return -1;
+    if (a.key > b.key) return 1;
+    return 0;
+  });
   const buffers: TerrainStreamBuffer[] = [...staticBuffers, ...sortedStreaming];
 
   const stride = Math.max(1, Math.ceil(totalPoints / maxPoints));
@@ -121,13 +123,13 @@ export function sampleStridedTerrain(
     }
   }
   if (oi === 0) return null;
+  let sampledClassification: Uint8Array | undefined;
+  if (classification) {
+    sampledClassification = oi === cap ? classification : classification.subarray(0, oi);
+  }
   return {
     positions: oi * 3 === positions.length ? positions : positions.subarray(0, oi * 3),
-    classification: classification
-      ? oi === cap
-        ? classification
-        : classification.subarray(0, oi)
-      : undefined,
+    classification: sampledClassification,
     sampled: stride > 1,
   };
 }

--- a/src/render/wheelDollyMath.ts
+++ b/src/render/wheelDollyMath.ts
@@ -61,7 +61,7 @@ export function normalizeWheelDeltaPx(
  */
 export function clampDollyVelocity(velocity: number, maxVelocity = Number.POSITIVE_INFINITY): number {
   if (!Number.isFinite(velocity)) return 0;
-  if (!(maxVelocity > 0) || !Number.isFinite(maxVelocity)) return velocity;
+  if (maxVelocity <= 0 || !Number.isFinite(maxVelocity)) return velocity;
   if (velocity > maxVelocity) return maxVelocity;
   if (velocity < -maxVelocity) return -maxVelocity;
   return velocity;

--- a/src/render/workflow/workflowConfig.ts
+++ b/src/render/workflow/workflowConfig.ts
@@ -93,7 +93,7 @@ export function chordFromEvent(e: ChordEventLike): string | null {
 export function matchesShortcut(e: ChordEventLike, chord: string): boolean {
   if (chord === '') return false;
   const tokens = chord.split('+');
-  const key = tokens[tokens.length - 1];
+  const key = tokens.at(-1)!;
   const wantMod = tokens.includes('mod');
   const wantAlt = tokens.includes('alt');
   const wantShift = tokens.includes('shift');
@@ -109,7 +109,7 @@ export function matchesShortcut(e: ChordEventLike, chord: string): boolean {
 export function formatShortcutLabel(chord: string, isMac: boolean): string {
   if (chord === '') return 'Off';
   const tokens = chord.split('+');
-  const key = tokens[tokens.length - 1];
+  const key = tokens.at(-1)!;
   const keyLabel = key.length === 1 ? key.toUpperCase() : key;
   if (isMac) {
     let s = '';

--- a/src/render/workflow/workflowRecorder.ts
+++ b/src/render/workflow/workflowRecorder.ts
@@ -299,7 +299,10 @@ export function scheduleReplay(
   // delay to 0 (instant replay).
   const speed = deps.speed;
   const instant = speed !== undefined && (!Number.isFinite(speed) || speed <= 0);
-  const scale = instant ? 0 : speed !== undefined && speed > 0 ? 1 / speed : 1;
+  let scale: number;
+  if (instant) scale = 0;
+  else if (speed !== undefined && speed > 0) scale = 1 / speed;
+  else scale = 1;
   for (const event of workflow.events) {
     const h = deps.setTimeout(() => {
       if (cancelled) return;

--- a/src/report/ReportBranding.ts
+++ b/src/report/ReportBranding.ts
@@ -44,9 +44,9 @@ function hexToRgb(hex: string): ParsedColor | null {
   }
   if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
   return {
-    r: parseInt(h.slice(0, 2), 16) / 255,
-    g: parseInt(h.slice(2, 4), 16) / 255,
-    b: parseInt(h.slice(4, 6), 16) / 255,
+    r: Number.parseInt(h.slice(0, 2), 16) / 255,
+    g: Number.parseInt(h.slice(2, 4), 16) / 255,
+    b: Number.parseInt(h.slice(4, 6), 16) / 255,
   };
 }
 
@@ -57,7 +57,7 @@ function hexToRgb(hex: string): ParsedColor | null {
 export function effectiveBranding(b?: ReportBranding): Required<Pick<ReportBranding, 'accentColor'>> & ReportBranding {
   return {
     accentColor: b?.accentColor ?? DEFAULT_ACCENT,
-    ...(b ?? {}),
+    ...b,
   };
 }
 

--- a/src/report/ReportFindings.ts
+++ b/src/report/ReportFindings.ts
@@ -210,21 +210,24 @@ export function buildInspectionSummary(
   const findings: ReportFinding[] = [];
 
   // 1. Coverage / scale.
-  findings.push({
-    label: 'Coverage',
-    value: formatArea(area),
-    detail: `${formatCount(metadata.sourcePointCount)} captured.`,
-    tier: 'info',
-  });
-
-  // 2. Point density — the one genuinely quantitative finding.
-  findings.push(densityFinding(metadata, qlApplies));
+  findings.push(
+    {
+      label: 'Coverage',
+      value: formatArea(area),
+      detail: `${formatCount(metadata.sourcePointCount)} captured.`,
+      tier: 'info',
+    },
+    // 2. Point density — the one genuinely quantitative finding.
+    densityFinding(metadata, qlApplies),
+  );
 
   // 3. Attribute channels.
   const channels: string[] = [];
-  channels.push(metadata.hasClassification ? 'classification' : 'no classification');
-  channels.push(metadata.hasIntensity ? 'intensity' : 'no intensity');
-  channels.push(metadata.hasRgb ? 'RGB' : 'no RGB');
+  channels.push(
+    metadata.hasClassification ? 'classification' : 'no classification',
+    metadata.hasIntensity ? 'intensity' : 'no intensity',
+    metadata.hasRgb ? 'RGB' : 'no RGB',
+  );
   findings.push({
     label: 'Attributes',
     value: channels.join(', '),

--- a/src/report/ReportMeasurementSection.ts
+++ b/src/report/ReportMeasurementSection.ts
@@ -94,7 +94,10 @@ function polyAreaHorizontal(points: readonly Vec3[]): number {
 function slopePercent(a: Vec3, b: Vec3): number {
   const dz = b[2] - a[2];
   const dxy = Math.sqrt((b[0] - a[0]) ** 2 + (b[1] - a[1]) ** 2);
-  if (dxy === 0) return dz === 0 ? 0 : dz > 0 ? Infinity : -Infinity;
+  if (dxy === 0) {
+    if (dz === 0) return 0;
+    return dz > 0 ? Infinity : -Infinity;
+  }
   return (dz / dxy) * 100;
 }
 
@@ -284,15 +287,19 @@ function buildProfileExtras(
     .map((s) => formatLinear(s.chainage * f, system))
     .join(' · ');
 
-  const slopeLine = Number.isFinite(summary.maxGradePercent)
-    ? `Max ${summary.maxGradePercent >= 0 ? '+' : ''}${summary.maxGradePercent.toFixed(2)}%, ` +
-      `Min ${summary.minGradePercent >= 0 ? '+' : ''}${summary.minGradePercent.toFixed(2)}%, ` +
-      `Avg ${summary.avgGradePercent >= 0 ? '+' : ''}${summary.avgGradePercent.toFixed(2)}%`
-    : `Slope summary unavailable — ${
-        samples
-          ? 'no finite samples along the section.'
-          : 'no point-cloud samples attached to this profile.'
-      }`;
+  const signPrefix = (v: number): string => (v >= 0 ? '+' : '');
+  let slopeLine: string;
+  if (Number.isFinite(summary.maxGradePercent)) {
+    slopeLine =
+      `Max ${signPrefix(summary.maxGradePercent)}${summary.maxGradePercent.toFixed(2)}%, ` +
+      `Min ${signPrefix(summary.minGradePercent)}${summary.minGradePercent.toFixed(2)}%, ` +
+      `Avg ${signPrefix(summary.avgGradePercent)}${summary.avgGradePercent.toFixed(2)}%`;
+  } else {
+    const reason = samples
+      ? 'no finite samples along the section.'
+      : 'no point-cloud samples attached to this profile.';
+    slopeLine = `Slope summary unavailable — ${reason}`;
+  }
 
   // The renderer self-normalises, so pass the finite samples straight through
   // (their absolute units are immaterial to the drawn shape).

--- a/src/report/ReportMetadataSection.ts
+++ b/src/report/ReportMetadataSection.ts
@@ -15,7 +15,7 @@ import type { ReportDatasetRow } from './types';
 /** What `buildDatasetSummary` needs to know about the scan. */
 export interface MetadataInputs {
   readonly fileName: string;
-  readonly format: 'COPC' | 'EPT' | 'LAS' | 'LAZ' | 'PLY' | 'E57' | 'PCD' | 'PTX' | 'PTS' | 'OBJ' | 'GLTF' | 'XYZ' | string;
+  readonly format: 'COPC' | 'EPT' | 'LAS' | 'LAZ' | 'PLY' | 'E57' | 'PCD' | 'PTX' | 'PTS' | 'OBJ' | 'GLTF' | 'XYZ' | (string & {});
   readonly sourcePointCount: number;
   /** Bounds in metres: width × depth × height. Pass NaN when unknown. */
   readonly width: number;
@@ -137,7 +137,7 @@ export function buildDatasetSummary(inputs: MetadataInputs): readonly ReportData
     const pct =
       Number.isFinite(total) && total > 0
         ? Math.min(100, Math.round((sr.points / total) * 100))
-        : NaN;
+        : Number.NaN;
     const nodePart =
       Number.isFinite(sr.totalNodes) && sr.totalNodes > 0
         ? ` · ${sr.nodes}/${sr.totalNodes} nodes`
@@ -155,11 +155,8 @@ export function buildDatasetSummary(inputs: MetadataInputs): readonly ReportData
   // confirmed unit (or the absent default) is byte-identical to before.
   const unitsUnconfirmed = inputs.extentUnitStatus === 'unknown';
   if (unitsUnconfirmed) {
-    rows.push({
-      label: 'Units',
-      value: 'Unconfirmed — extents in source units',
-    });
     rows.push(
+      { label: 'Units',  value: 'Unconfirmed — extents in source units' },
       { label: 'Width',  value: formatSourceUnits(inputs.width) },
       { label: 'Depth',  value: formatSourceUnits(inputs.depth) },
       { label: 'Height', value: formatSourceUnits(inputs.height) },
@@ -176,9 +173,11 @@ export function buildDatasetSummary(inputs: MetadataInputs): readonly ReportData
     // panel. Integer rounding printed 2.586 as "3", disagreeing with them.
     rows.push({ label: 'Density', value: `${inputs.density.toFixed(1)} pts/m²` });
   }
-  rows.push({ label: 'RGB',            value: inputs.hasRgb ? 'Yes' : 'No' });
-  rows.push({ label: 'Intensity',      value: inputs.hasIntensity ? 'Yes' : 'No' });
-  rows.push({ label: 'Classification', value: inputs.hasClassification ? 'Yes' : 'No' });
+  rows.push(
+    { label: 'RGB',            value: inputs.hasRgb ? 'Yes' : 'No' },
+    { label: 'Intensity',      value: inputs.hasIntensity ? 'Yes' : 'No' },
+    { label: 'Classification', value: inputs.hasClassification ? 'Yes' : 'No' },
+  );
   if (inputs.crsName) {
     rows.push({ label: 'CRS',   value: inputs.crsName });
   }

--- a/src/report/ReportPdfRenderer.ts
+++ b/src/report/ReportPdfRenderer.ts
@@ -1138,8 +1138,12 @@ async function renderAnnotations(
     // Label the coordinate FRAME so a render-local fallback is never presented
     // as a surveyed location. `world` names the CRS when the annotation carries
     // one; anything else is the scan's render-local anchor.
-    const frameLabel =
-      a.frame === 'world' ? (a.crs ? `world · ${a.crs}` : 'world') : 'render-local';
+    let frameLabel: string;
+    if (a.frame === 'world') {
+      frameLabel = a.crs ? `world · ${a.crs}` : 'world';
+    } else {
+      frameLabel = 'render-local';
+    }
     cursor = drawBodyLine(
       cursor,
       `Position (${frameLabel}): ${a.position.x.toFixed(3)}, ${a.position.y.toFixed(3)}, ${a.position.z.toFixed(3)}`,
@@ -1182,9 +1186,10 @@ async function renderMeasurements(
     // vertical space needed before drawing so a row never splits
     // across a page boundary.
     const extras = m.profileExtras;
-    const rowH = extras
-      ? 16 + 12 * 4 + (extras.coverageCaveat ? 12 : 0) + (extras.chart ? 68 : 0)
-      : 16;
+    let rowH = 16;
+    if (extras) {
+      rowH = 16 + 12 * 4 + (extras.coverageCaveat ? 12 : 0) + (extras.chart ? 68 : 0);
+    }
     cursor = ensureSpace(cursor, rowH, doc, accent, theme, organisation);
     cursor = drawLabelValueRow(cursor, `${m.kind} · ${m.name}`, m.value, body, bold, theme);
     if (extras) {

--- a/src/science/methodRegistry.ts
+++ b/src/science/methodRegistry.ts
@@ -198,7 +198,7 @@ export function method(id: string): MethodEntry | null {
 
 /** True when `id` names a registered method. */
 export function isMethodId(id: string): boolean {
-  return Object.prototype.hasOwnProperty.call(METHOD_REGISTRY, id);
+  return Object.hasOwn(METHOD_REGISTRY, id);
 }
 
 /**

--- a/src/style.css
+++ b/src/style.css
@@ -1123,7 +1123,7 @@ body.olv-theme-light .olv-empty::before {
   margin: var(--space-sm) 0 0; padding: var(--space-sm);
   background: var(--panel-2, rgba(255,255,255,0.04)); border-radius: var(--radius-sm, 6px);
   font-size: var(--text-xs); font-family: var(--mono); color: var(--text);
-  white-space: pre-wrap; word-break: break-word; line-height: 1.4;
+  white-space: pre-wrap; overflow-wrap: break-word; line-height: 1.4;
 }
 .olv-chips { display: flex; flex-wrap: wrap; gap: var(--space-sm); }
 .olv-color-by-body { display: flex; flex-direction: column; gap: var(--space-md); }
@@ -8179,7 +8179,7 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
 .olv-story-headline { font-size: 12.5px; opacity: 0.92; }
 .olv-story-row { display: grid; grid-template-columns: 116px 1fr; gap: 8px; align-items: baseline; }
 .olv-story-k { color: var(--muted, #8a8f98); font-size: 11px; }
-.olv-story-v { min-width: 0; word-break: break-word; }
+.olv-story-v { min-width: 0; overflow-wrap: break-word; }
 .olv-story-next {
   margin-top: 2px; padding-top: 7px; font-weight: 500;
   border-top: 0.5px solid color-mix(in srgb, currentColor 14%, transparent);

--- a/src/terrain/change/changeDetection.ts
+++ b/src/terrain/change/changeDetection.ts
@@ -162,7 +162,7 @@ export function detectChange(
       const bv = b.values[y * b.width + x];
       const oi = y * W + x;
       if (!Number.isFinite(av) || !Number.isFinite(bv)) {
-        diff[oi] = NaN;
+        diff[oi] = Number.NaN;
         classes[oi] = 0;
         continue;
       }

--- a/src/terrain/change/compareDtms.ts
+++ b/src/terrain/change/compareDtms.ts
@@ -266,8 +266,6 @@ export function summarizeChange(comparison: EpochComparison): string[] {
     `${(s.significantFraction * 100).toFixed(1)}% of comparable cells changed beyond the ` +
       `detection floor of ${comparison.levelOfDetectionM} m ` +
       `(${s.gained} gained, ${s.lost} lost, ${s.unchanged} unchanged).`,
-  );
-  lines.push(
     `Largest gain ${s.maxGainM.toFixed(2)} m, largest loss ${s.maxLossM.toFixed(2)} m; ` +
       `mean |Δ| ${s.meanAbsChangeM.toFixed(2)} m over ${s.comparable} comparable cells.`,
   );

--- a/src/terrain/change/compareEpochs.ts
+++ b/src/terrain/change/compareEpochs.ts
@@ -127,11 +127,14 @@ function sharedGrid(before: EpochCloud, after: EpochCloud): SharedGrid | null {
   // the same unit-aware rule as the analysis runner's deriveCoreParams. The
   // BEFORE epoch's units are the reference, matching compareDtms (an
   // inter-epoch unit mismatch is flagged by the comparison itself).
-  const metresPerUnit = before.isGeographic
-    ? METRES_PER_DEGREE
-    : before.linearUnitToMetres && before.linearUnitToMetres > 0
-      ? before.linearUnitToMetres
-      : 1;
+  let metresPerUnit: number;
+  if (before.isGeographic) {
+    metresPerUnit = METRES_PER_DEGREE;
+  } else if (before.linearUnitToMetres && before.linearUnitToMetres > 0) {
+    metresPerUnit = before.linearUnitToMetres;
+  } else {
+    metresPerUnit = 1;
+  }
   const extent = Math.max(maxX - minX, maxY - minY, 1 / metresPerUnit);
   const cellSizeM = Math.max(0.25 / metresPerUnit, extent / 256);
   return {

--- a/src/terrain/change/icpRegister.ts
+++ b/src/terrain/change/icpRegister.ts
@@ -201,7 +201,7 @@ export function icpRegister(
   }
 
   let prevRms = Infinity;
-  let rms = Infinity;
+  let rms: number;
   let iter = 0;
   let converged = false;
 

--- a/src/terrain/complexity/complexityEnvelope.ts
+++ b/src/terrain/complexity/complexityEnvelope.ts
@@ -89,7 +89,7 @@ export function deriveComplexityConfidence(support: ComplexitySupport): number {
       ? Math.min(1, meanWindowSupport)
       : 0;
   const c = Math.round(100 * validFraction * windowSupport);
-  return c < 0 ? 0 : c > 100 ? 100 : c;
+  return Math.min(100, Math.max(0, c));
 }
 
 /**

--- a/src/terrain/complexity/complexitySummary.ts
+++ b/src/terrain/complexity/complexitySummary.ts
@@ -210,12 +210,15 @@ export interface TerrainComplexitySummary {
 
 const fmtVrm = (v: number): string => (Number.isFinite(v) ? v.toFixed(4) : '—');
 const fmtZ = (v: number): string => (Number.isFinite(v) ? v.toFixed(2) : '—');
-const fmtGroundM = (v: number | null): string =>
-  v != null && Number.isFinite(v) ? `≈${v >= 10 ? Math.round(v).toString() : v.toFixed(1)} m` : 'ground size unknown';
+const fmtGroundM = (v: number | null): string => {
+  if (v == null || !Number.isFinite(v)) return 'ground size unknown';
+  const size = v >= 10 ? Math.round(v).toString() : v.toFixed(1);
+  return `≈${size} m`;
+};
 
 /** Z-unit label from the vertical unit scale (metres / US-or-intl feet / other). */
-function zUnit(verticalUnitToMetres: number | undefined): string {
-  const v = verticalUnitToMetres ?? 1;
+function zUnit(verticalUnitToMetres = 1): string {
+  const v = verticalUnitToMetres;
   if (!Number.isFinite(v) || v <= 0 || Math.abs(v - 1) < 1e-9) return 'm';
   if (Math.abs(v - 0.3048) < 5e-4) return 'ft';
   return 'z-units';
@@ -263,8 +266,7 @@ export function summariseTerrainComplexity(
   if (tpi.classes) {
     const counts = new Uint32Array(7);
     let classified = 0;
-    for (let i = 0; i < tpi.classes.length; i++) {
-      const c = tpi.classes[i];
+    for (const c of tpi.classes) {
       if (c === 0) continue;
       counts[c]++;
       classified++;

--- a/src/terrain/complexity/terrainPositionIndex.ts
+++ b/src/terrain/complexity/terrainPositionIndex.ts
@@ -149,7 +149,12 @@ export interface TpiSummary {
   readonly iqr: number;
 }
 
-const NO_SUMMARY: TpiSummary = { median: NaN, p25: NaN, p75: NaN, iqr: NaN };
+const NO_SUMMARY: TpiSummary = {
+  median: Number.NaN,
+  p25: Number.NaN,
+  p75: Number.NaN,
+  iqr: Number.NaN,
+};
 
 /**
  * Compute TPI, standardised TPI, and (when slope is supplied) the Weiss
@@ -163,8 +168,8 @@ export function computeTPI(
 ): TpiResult {
   const warnings: string[] = [];
   const n = cols > 0 && rows > 0 ? cols * rows : 0;
-  const tpi = new Float32Array(n).fill(NaN);
-  const stdTpi = new Float32Array(n).fill(NaN);
+  const tpi = new Float32Array(n).fill(Number.NaN);
+  const stdTpi = new Float32Array(n).fill(Number.NaN);
 
   let radius = params.radiusCells;
   if (!Number.isFinite(radius) || radius < 1) {
@@ -180,7 +185,7 @@ export function computeTPI(
 
   const valid = params.valid;
   const isValid = (i: number): boolean =>
-    (valid == null || valid[i] !== 0) && Number.isFinite(z[i]);
+    valid?.[i] !== 0 && Number.isFinite(z[i]);
 
   // Precompute the window offsets for the discrete circle (centre excluded).
   const rCeil = Math.ceil(radius);
@@ -302,8 +307,8 @@ function classify(stdTpi: number, slopeTan: number): number {
 function summarise(values: Float32Array, validCount: number): TpiSummary {
   if (validCount === 0) return NO_SUMMARY;
   const finite: number[] = [];
-  for (let i = 0; i < values.length; i++) {
-    if (Number.isFinite(values[i])) finite.push(values[i]);
+  for (const v of values) {
+    if (Number.isFinite(v)) finite.push(v);
   }
   finite.sort((a, b) => a - b);
   const p25 = quantileSorted(finite, 0.25);
@@ -329,8 +334,8 @@ function emptyResult(
     tpi,
     stdTpi,
     classes: slopeSupplied ? new Uint8Array(cellCount) : null,
-    mean: NaN,
-    stdev: NaN,
+    mean: Number.NaN,
+    stdev: Number.NaN,
     summary: NO_SUMMARY,
     validCellCount: 0,
     cellCount,

--- a/src/terrain/complexity/vectorRuggedness.ts
+++ b/src/terrain/complexity/vectorRuggedness.ts
@@ -97,7 +97,12 @@ export interface VrmSummary {
   readonly iqr: number;
 }
 
-const NO_SUMMARY: VrmSummary = { median: NaN, p25: NaN, p75: NaN, iqr: NaN };
+const NO_SUMMARY: VrmSummary = {
+  median: Number.NaN,
+  p25: Number.NaN,
+  p75: Number.NaN,
+  iqr: Number.NaN,
+};
 
 /**
  * Result of {@link computeVRM}. VRM is dimensionless, in [0, 1]. Carries
@@ -142,7 +147,7 @@ export function computeVRM(
 ): VrmResult {
   const warnings: string[] = [];
   const n = cols > 0 && rows > 0 ? cols * rows : 0;
-  const vrm = new Float32Array(n).fill(NaN);
+  const vrm = new Float32Array(n).fill(Number.NaN);
 
   let window = params.windowCells;
   if (!Number.isInteger(window) || window < 1 || window % 2 === 0) {
@@ -169,7 +174,7 @@ export function computeVRM(
   for (let i = 0; i < n; i++) {
     const m = slope[i];
     const a = aspect[i];
-    if ((valid != null && valid[i] === 0) || !Number.isFinite(m) || !Number.isFinite(a)) continue;
+    if (valid?.[i] === 0 || !Number.isFinite(m) || !Number.isFinite(a)) continue;
     const inv = 1 / Math.sqrt(1 + m * m); // cosθ
     const sinTheta = m * inv;
     nx[i] = sinTheta * Math.cos(a); // east
@@ -209,7 +214,7 @@ export function computeVRM(
       const resultant = Math.sqrt(sx * sx + sy * sy + sz * sz);
       // Unit vectors ⇒ R ≤ n; clamp float-error excursions to keep [0, 1].
       const v = 1 - resultant / count;
-      vrm[i] = v < 0 ? 0 : v > 1 ? 1 : v;
+      vrm[i] = Math.min(1, Math.max(0, v));
       validCellCount++;
     }
   }

--- a/src/terrain/contour/analyseContours.ts
+++ b/src/terrain/contour/analyseContours.ts
@@ -527,11 +527,14 @@ export function resolveGroundFilterParams(
   // plain cell size; a geographic frame's degree-valued cell would otherwise
   // starve the growth term by ~1/111,320, pinning the threshold at its base
   // and rejecting legitimate slope ground.
-  const horizToMetres = params.isGeographic
-    ? METRES_PER_DEGREE
-    : params.horizontalUnitToMetres && params.horizontalUnitToMetres > 0
-      ? params.horizontalUnitToMetres
-      : 1;
+  let horizToMetres: number;
+  if (params.isGeographic) {
+    horizToMetres = METRES_PER_DEGREE;
+  } else if (params.horizontalUnitToMetres && params.horizontalUnitToMetres > 0) {
+    horizToMetres = params.horizontalUnitToMetres;
+  } else {
+    horizToMetres = 1;
+  }
   const vertToMetres =
     params.verticalUnitToMetres && params.verticalUnitToMetres > 0
       ? params.verticalUnitToMetres
@@ -829,11 +832,14 @@ export function computeTerrainCore(
   // anisotropy in as √(cos φ): area = (cell·M·cos φ)·(cell·M) = (cell·M·√cos φ)²
   // exactly. Without it a 60°-latitude scan reports ~half the true pts/m² and
   // an unfairly failing USGS QL. cos φ = 1 (no-op) when latitude is unknown.
-  const horizUnitToMetres = params.isGeographic
-    ? METRES_PER_DEGREE * Math.sqrt(cosLatitude(params.latitudeDeg))
-    : params.horizontalUnitToMetres && params.horizontalUnitToMetres > 0
-      ? params.horizontalUnitToMetres
-      : 1;
+  let horizUnitToMetres: number;
+  if (params.isGeographic) {
+    horizUnitToMetres = METRES_PER_DEGREE * Math.sqrt(cosLatitude(params.latitudeDeg));
+  } else if (params.horizontalUnitToMetres && params.horizontalUnitToMetres > 0) {
+    horizUnitToMetres = params.horizontalUnitToMetres;
+  } else {
+    horizUnitToMetres = 1;
+  }
   const cellMetrics = computeCellMetrics(dtm, {
     horizontalUnitToMetres: horizUnitToMetres,
     // Stride honesty: scale per-cell counts back to the SCAN so the density —
@@ -932,7 +938,7 @@ export function computeTerrainCore(
   // non-finite neighbour was replaced by the centre.
   const synthesised = synthesisedNeighbourMask(dtm.z, dtm.cols, dtm.rows);
   let synthesisedCount = 0;
-  for (let i = 0; i < synthesised.length; i++) synthesisedCount += synthesised[i];
+  for (const flag of synthesised) synthesisedCount += flag;
   // Reported only when it is a material share of the grid — see
   // SYNTHESISED_WARN_FRACTION for why the threshold is not zero.
   if (synthesised.length > 0 && synthesisedCount / synthesised.length >= SYNTHESISED_WARN_FRACTION) {

--- a/src/terrain/contour/contourCopy.ts
+++ b/src/terrain/contour/contourCopy.ts
@@ -21,7 +21,6 @@
  */
 
 import { EVIDENCE_THRESHOLDS, type EvidenceGrade } from '../ground/cellConfidence';
-import { NOT_SURVEY_GRADE_NOTE } from '../export/exportNotes';
 import type { IntervalOption, IntervalGateResult } from './intervalGate';
 
 /** Plain-language names for the Analyse features. */
@@ -98,7 +97,7 @@ export const GRADE_MEANING: Record<EvidenceGrade, string> = {
  * {@link NOT_SURVEY_GRADE_NOTE} so the panel footer and the export writers
  * state the limitation in exactly one wording.
  */
-export const NOT_SURVEY_GRADE = NOT_SURVEY_GRADE_NOTE;
+export { NOT_SURVEY_GRADE_NOTE as NOT_SURVEY_GRADE } from '../export/exportNotes';
 
 /** A plain confidence word for a 0..100 number, aligned to the grade thresholds. */
 export function confidenceWord(confidence: number): 'high' | 'moderate' | 'low' {

--- a/src/terrain/contour/contourDownload.ts
+++ b/src/terrain/contour/contourDownload.ts
@@ -122,8 +122,16 @@ export function serializeContours(
   // Unit stamp for the human-facing formats. 'metre' is the standing default;
   // the abbreviation feeds the SVG's visible scale note.
   const linearUnit = opts.linearUnit ?? 'metre';
-  const unitLabel =
-    linearUnit === 'foot' ? 'ft' : linearUnit === 'us-survey-foot' ? 'ftUS' : linearUnit === 'unknown' ? 'unit' : 'm';
+  let unitLabel: string;
+  if (linearUnit === 'foot') {
+    unitLabel = 'ft';
+  } else if (linearUnit === 'us-survey-foot') {
+    unitLabel = 'ftUS';
+  } else if (linearUnit === 'unknown') {
+    unitLabel = 'unit';
+  } else {
+    unitLabel = 'm';
+  }
 
   let content: string;
   switch (format) {
@@ -160,7 +168,11 @@ export function serializeContours(
   // two files with the same extension in one folder is how the wrong frame
   // gets loaded.
   const code = format === 'geojson-native' ? epsgFromCrsLabel(exportModel.crs ?? '') : null;
-  const stem = format === 'geojson-native' ? `${basename}-native${code ? `-EPSG${code}` : ''}` : basename;
+  let stem = basename;
+  if (format === 'geojson-native') {
+    const epsgSuffix = code ? `-EPSG${code}` : '';
+    stem = `${basename}-native${epsgSuffix}`;
+  }
   return { filename: `${stem}.${EXT[format]}`, mime: MIME[format], content };
 }
 

--- a/src/terrain/contour/contoursAt.ts
+++ b/src/terrain/contour/contoursAt.ts
@@ -328,7 +328,7 @@ export function contoursAt(dtm: DtmGrid, params: ContoursAtParams): ContourSet {
     const zb = zc[bIdx];
     const denom = zb - za;
     const t = Math.abs(denom) < 1e-12 ? 0.5 : (v - za) / denom;
-    const tc = t < 0 ? 0 : t > 1 ? 1 : t;
+    const tc = Math.max(0, Math.min(1, t));
     return [p[aIdx][0] + tc * (p[bIdx][0] - p[aIdx][0]), p[aIdx][1] + tc * (p[bIdx][1] - p[aIdx][1])];
   };
 

--- a/src/terrain/contour/dxfContours.ts
+++ b/src/terrain/contour/dxfContours.ts
@@ -108,8 +108,7 @@ export function dxfContours(
 
   const out: string[] = [];
   const pair = (code: number, value: string | number) => {
-    out.push(String(code));
-    out.push(String(value));
+    out.push(String(code), String(value));
   };
 
   // Provenance comments (group code 999 — ignored by CAD readers) so the file is

--- a/src/terrain/contour/histogram.ts
+++ b/src/terrain/contour/histogram.ts
@@ -42,7 +42,7 @@ export function histogramBins(values: ArrayLike<number>, binCount: number): Hist
   const counts = new Array<number>(bins).fill(0);
 
   // Empty, or a degenerate single-value spread: everything in bin 0, width 0.
-  if (total === 0 || !(max > min)) {
+  if (total === 0 || max <= min) {
     if (total > 0) counts[0] = total;
     return {
       counts,

--- a/src/terrain/contour/hypsometric.ts
+++ b/src/terrain/contour/hypsometric.ts
@@ -53,7 +53,7 @@ export const DEFAULT_CANOPY_PALETTE: ReadonlyArray<ColorStop> = [
 
 function clamp01(t: number): number {
   if (!Number.isFinite(t)) return 0;
-  return t < 0 ? 0 : t > 1 ? 1 : t;
+  return Math.max(0, Math.min(1, t));
 }
 
 function lerpChannel(a: number, b: number, t: number): number {
@@ -77,7 +77,7 @@ export function hypsometricColor(
 
   const t = clamp01((value - minZ) / (maxZ - minZ));
   if (t <= palette[0].t) return palette[0].color;
-  const last = palette[palette.length - 1];
+  const last = palette.at(-1)!;
   if (t >= last.t) return last.color;
 
   for (let i = 1; i < palette.length; i++) {

--- a/src/terrain/contour/intervalGate.ts
+++ b/src/terrain/contour/intervalGate.ts
@@ -140,7 +140,7 @@ export function gateIntervals(params: IntervalGateParams): IntervalGateResult {
     }
   }
   if (recommendedM == null && supported.length > 0) {
-    recommendedM = supported[supported.length - 1];
+    recommendedM = supported.at(-1)!;
   }
 
   return { options, recommendedM, warnings };

--- a/src/terrain/contour/mapSheetLayout.ts
+++ b/src/terrain/contour/mapSheetLayout.ts
@@ -63,7 +63,16 @@ export function niceStep(span: number, target: number): number {
   const raw = span / Math.max(1, target);
   const mag = 10 ** Math.floor(Math.log10(raw));
   const norm = raw / mag;
-  const step = norm <= 1 ? 1 : norm <= 2 ? 2 : norm <= 5 ? 5 : 10;
+  let step: number;
+  if (norm <= 1) {
+    step = 1;
+  } else if (norm <= 2) {
+    step = 2;
+  } else if (norm <= 5) {
+    step = 5;
+  } else {
+    step = 10;
+  }
   return step * mag;
 }
 
@@ -72,7 +81,14 @@ export function niceRoundDown(x: number): number {
   if (!Number.isFinite(x) || x <= 0) return 0;
   const mag = 10 ** Math.floor(Math.log10(x));
   const norm = x / mag;
-  const v = norm >= 5 ? 5 : norm >= 2 ? 2 : 1;
+  let v: number;
+  if (norm >= 5) {
+    v = 5;
+  } else if (norm >= 2) {
+    v = 2;
+  } else {
+    v = 1;
+  }
   return v * mag;
 }
 

--- a/src/terrain/contour/smoothing.ts
+++ b/src/terrain/contour/smoothing.ts
@@ -77,13 +77,12 @@ function smoothOpen(
     const next = verts[i + 1];
     if (smoothable(prev) && smoothable(cur) && smoothable(next)) {
       // Cut the corner at `cur`: a point 1/4 toward prev and 1/4 toward next.
-      out.push(lerpVertex(cur, prev, 0.25));
-      out.push(lerpVertex(cur, next, 0.25));
+      out.push(lerpVertex(cur, prev, 0.25), lerpVertex(cur, next, 0.25));
     } else {
       out.push(cur); // preserve exactly — no fabrication near uncertainty
     }
   }
-  out.push(verts[verts.length - 1]);
+  out.push(verts.at(-1)!);
   return out;
 }
 
@@ -99,8 +98,7 @@ function smoothClosed(
     const cur = verts[i];
     const next = verts[(i + 1) % n];
     if (smoothable(prev) && smoothable(cur) && smoothable(next)) {
-      out.push(lerpVertex(cur, prev, 0.25));
-      out.push(lerpVertex(cur, next, 0.25));
+      out.push(lerpVertex(cur, prev, 0.25), lerpVertex(cur, next, 0.25));
     } else {
       out.push(cur);
     }

--- a/src/terrain/contour/stitchContours.ts
+++ b/src/terrain/contour/stitchContours.ts
@@ -134,7 +134,7 @@ export function stitchLevel(
         ny = sj.y1;
         tailKey = ka;
       }
-      mergeShared(vertices[vertices.length - 1], sj.confidence);
+      mergeShared(vertices.at(-1)!, sj.confidence);
       vertices.push({ x: nx, y: ny, confidence: sj.confidence, grade: sj.grade });
     }
 
@@ -164,7 +164,7 @@ export function stitchLevel(
     const closed =
       vertices.length > 3 &&
       keyOf(vertices[0].x, vertices[0].y) ===
-        keyOf(vertices[vertices.length - 1].x, vertices[vertices.length - 1].y);
+        keyOf(vertices.at(-1)!.x, vertices.at(-1)!.y);
     if (closed) vertices.pop(); // drop duplicate closing vertex
     polylines.push({ value, vertices, closed });
   }

--- a/src/terrain/contour/svgContours.ts
+++ b/src/terrain/contour/svgContours.ts
@@ -57,7 +57,7 @@ const MAP_TARGET_PX = 880;
 
 /** Escape the three XML-significant characters for safe text / `<metadata>`. */
 function xmlEscape(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return s.replaceAll(/&/g, '&amp;').replaceAll(/</g, '&lt;').replaceAll(/>/g, '&gt;');
 }
 
 function strokeStyle(f: ContourFeature, stroke: string, indexW: number, baseW: number): string {
@@ -77,7 +77,14 @@ function niceRound(v: number): number {
   if (!(v > 0)) return 1;
   const pow = Math.pow(10, Math.floor(Math.log10(v)));
   const f = v / pow;
-  const n = f >= 5 ? 5 : f >= 2 ? 2 : 1;
+  let n: number;
+  if (f >= 5) {
+    n = 5;
+  } else if (f >= 2) {
+    n = 2;
+  } else {
+    n = 1;
+  }
   return n * pow;
 }
 
@@ -99,9 +106,11 @@ function scaleBar(x: number, y: number, scale: number, worldW: number, unit: str
   const tick = (px: number, label: string): string =>
     `<text x="${px.toFixed(2)}" y="${(y - 3).toFixed(2)}" font-size="9" text-anchor="middle" ` +
     `fill="${stroke}" font-family="sans-serif">${label}</text>`;
-  parts.push(tick(x, '0'));
-  parts.push(tick(x + (D * scale) / 2, (D / 2).toFixed(dec)));
-  parts.push(tick(x + D * scale, `${D.toFixed(dec)} ${unit}`));
+  parts.push(
+    tick(x, '0'),
+    tick(x + (D * scale) / 2, (D / 2).toFixed(dec)),
+    tick(x + D * scale, `${D.toFixed(dec)} ${unit}`),
+  );
   return parts.join('');
 }
 
@@ -144,9 +153,11 @@ function titleLines(model: ContourFeatureModel, prov: ExportProvenance | undefin
     lines.push(`Contour interval ${model.intervalM.toFixed(intervalDec)} ${unit}`);
   }
   if (prov) {
-    lines.push(`Vertical datum: ${prov.datumKnown ? prov.verticalDatum : 'unknown'}`);
-    lines.push(`Horizontal CRS: ${prov.crsKnown ? prov.horizontalCrs : 'not georeferenced'}`);
-    if (prov.accuracy && prov.accuracy.rmseZM != null) {
+    lines.push(
+      `Vertical datum: ${prov.datumKnown ? prov.verticalDatum : 'unknown'}`,
+      `Horizontal CRS: ${prov.crsKnown ? prov.horizontalCrs : 'not georeferenced'}`,
+    );
+    if (prov.accuracy?.rmseZM != null) {
       // rmseZM is metre-denominated (the *M contract) whatever the sheet's
       // linear unit, and the provenance carries no unit factor to convert it
       // with — so stamp it 'm', matching the <metadata> block. Labelling a
@@ -154,8 +165,7 @@ function titleLines(model: ContourFeatureModel, prov: ExportProvenance | undefin
       // deliverable's accuracy 3.28×.
       lines.push(`Vertical RMSEz: ${prov.accuracy.rmseZM.toFixed(2)} m`);
     }
-    lines.push(`Surface quality: ${prov.surfaceQuality}`);
-    lines.push(prov.notSurveyGrade);
+    lines.push(`Surface quality: ${prov.surfaceQuality}`, prov.notSurveyGrade);
     if (prov.generated) lines.push(`Generated: ${prov.generated.slice(0, 10)}`);
   } else {
     lines.push(NOT_SURVEY_GRADE_NOTE);

--- a/src/terrain/contour/terrainAssessment.ts
+++ b/src/terrain/contour/terrainAssessment.ts
@@ -153,6 +153,20 @@ function describeCoverage(mode: string): { value: string; rating: SupportingMetr
   return { value: 'unknown', rating: 'unknown' };
 }
 
+/** Band a metric where a HIGHER value is better into good/fair/poor. NaN → 'poor'. */
+function bandHigh(v: number, goodMin: number, fairMin: number): SupportingMetric['rating'] {
+  if (v >= goodMin) return 'good';
+  if (v >= fairMin) return 'fair';
+  return 'poor';
+}
+
+/** Band a metric where a LOWER value is better into good/fair/poor. NaN → 'poor'. */
+function bandLow(v: number, goodMax: number, fairMax: number): SupportingMetric['rating'] {
+  if (v <= goodMax) return 'good';
+  if (v <= fairMax) return 'fair';
+  return 'poor';
+}
+
 /**
  * Collapse an analysis result into a single top-level assessment with TWO axes.
  *
@@ -194,7 +208,7 @@ export function terrainAssessment(result: AnalyseContoursResult): TerrainAssessm
   const emptyFrac = tally.empty / gridTotal;
   const edgeFrac = Number.isFinite(cm?.edgeRiskRatio) ? cm.edgeRiskRatio : 0;
   const density = Number.isFinite(cm?.meanDensity) ? cm.meanDensity : 0;
-  const groundRatio = Number.isFinite(q.groundPointRatio) ? q.groundPointRatio : NaN;
+  const groundRatio = Number.isFinite(q.groundPointRatio) ? q.groundPointRatio : Number.NaN;
   const crsKnown = crs != null;
   const datumKnown = datum != null;
   const rmse = acc?.rmseZM;
@@ -231,36 +245,22 @@ export function terrainAssessment(result: AnalyseContoursResult): TerrainAssessm
     {
       label: 'Ground density',
       value: density > 0 ? `${density.toFixed(1)} pts/m²` : 'unknown',
-      rating:
-        density <= 0
-          ? 'unknown'
-          : density >= 2
-            ? 'good'
-            : density >= LOW_DENSITY_PER_M2
-              ? 'fair'
-              : 'poor',
+      rating: density <= 0 ? 'unknown' : bandHigh(density, 2, LOW_DENSITY_PER_M2),
     },
     {
       label: 'DTM quality',
       value: scoreKnown ? `${score}/100` : 'unknown',
-      rating: !scoreKnown ? 'unknown' : score >= 70 ? 'good' : score >= 45 ? 'fair' : 'poor',
+      rating: !scoreKnown ? 'unknown' : bandHigh(score, 70, 45),
     },
     {
       label: 'Interpolation',
       value: coveredCells > 0 ? pctStr(interpFrac) : 'unknown',
-      rating:
-        coveredCells === 0
-          ? 'unknown'
-          : interpFrac <= 0.2
-            ? 'good'
-            : interpFrac <= HIGH_INTERP_FRACTION
-              ? 'fair'
-              : 'poor',
+      rating: coveredCells === 0 ? 'unknown' : bandLow(interpFrac, 0.2, HIGH_INTERP_FRACTION),
     },
     {
       label: 'Empty cells',
       value: pctStr(emptyFrac),
-      rating: emptyFrac <= 0.2 ? 'good' : emptyFrac <= HIGH_EMPTY_FRACTION ? 'fair' : 'poor',
+      rating: bandLow(emptyFrac, 0.2, HIGH_EMPTY_FRACTION),
     },
     {
       // cellMetrics.edgeRiskRatio — measured cells near the data boundary
@@ -269,18 +269,12 @@ export function terrainAssessment(result: AnalyseContoursResult): TerrainAssessm
       // sentence below words each truthfully.
       label: 'Edge risk',
       value: pctStr(edgeFrac),
-      rating: edgeFrac <= 0.05 ? 'good' : edgeFrac <= HIGH_EDGE_FRACTION ? 'fair' : 'poor',
+      rating: bandLow(edgeFrac, 0.05, HIGH_EDGE_FRACTION),
     },
     {
       label: 'Vertical RMSE',
       value: rmseKnown ? `${(rmse as number).toFixed(2)} m` : 'unknown',
-      rating: !rmseKnown
-        ? 'unknown'
-        : (rmse as number) <= 0.1
-          ? 'good'
-          : (rmse as number) <= 0.25
-            ? 'fair'
-            : 'poor',
+      rating: !rmseKnown ? 'unknown' : bandLow(rmse as number, 0.1, 0.25),
     },
     {
       label: 'CRS',
@@ -386,32 +380,39 @@ export function terrainAssessment(result: AnalyseContoursResult): TerrainAssessm
   // advertise georeferenced DEM export when export readiness actually allows it
   // (known CRS + datum); otherwise we point at measurement/inspection and the
   // export recommendation is carried separately by exportReason.
-  const bestFor =
-    status === 'Good'
-      ? exportReadiness === 'Ready'
+  let bestFor: string;
+  if (status === 'Good') {
+    bestFor =
+      exportReadiness === 'Ready'
         ? 'terrain products, DEM export, measurement and inspection'
-        : 'measurement, inspection and terrain analysis'
-      : status === 'Preview'
-        ? 'profile review, measurement and terrain inspection'
-        : status === 'Limited'
-          ? 'visual inspection only'
-          : 'reviewing the point cloud; this scan has no usable terrain surface';
+        : 'measurement, inspection and terrain analysis';
+  } else if (status === 'Preview') {
+    bestFor = 'profile review, measurement and terrain inspection';
+  } else if (status === 'Limited') {
+    bestFor = 'visual inspection only';
+  } else {
+    bestFor = 'reviewing the point cloud; this scan has no usable terrain surface';
+  }
 
-  const useCaution =
-    status === 'Good'
-      ? ''
-      : status === 'Preview'
-        ? 'terrain products are preliminary — validate independently before relying on them'
-        : status === 'Limited'
-          ? 'the surface is too incomplete for reliable terrain products'
-          : 'do not build terrain products from this scan';
+  let useCaution: string;
+  if (status === 'Good') {
+    useCaution = '';
+  } else if (status === 'Preview') {
+    useCaution = 'terrain products are preliminary — validate independently before relying on them';
+  } else if (status === 'Limited') {
+    useCaution = 'the surface is too incomplete for reliable terrain products';
+  } else {
+    useCaution = 'do not build terrain products from this scan';
+  }
 
-  const notRecommendedFor =
-    status === 'Good'
-      ? 'uses that legally require certified survey data'
-      : status === 'Preview'
-        ? 'outputs requiring independent validation'
-        : 'terrain products, DEM export, contour generation';
+  let notRecommendedFor: string;
+  if (status === 'Good') {
+    notRecommendedFor = 'uses that legally require certified survey data';
+  } else if (status === 'Preview') {
+    notRecommendedFor = 'outputs requiring independent validation';
+  } else {
+    notRecommendedFor = 'terrain products, DEM export, contour generation';
+  }
 
   return {
     status,

--- a/src/terrain/contour/terrainAssessment.ts
+++ b/src/terrain/contour/terrainAssessment.ts
@@ -154,14 +154,14 @@ function describeCoverage(mode: string): { value: string; rating: SupportingMetr
 }
 
 /** Band a metric where a HIGHER value is better into good/fair/poor. NaN → 'poor'. */
-function bandHigh(v: number, goodMin: number, fairMin: number): SupportingMetric['rating'] {
+export function bandHigh(v: number, goodMin: number, fairMin: number): SupportingMetric['rating'] {
   if (v >= goodMin) return 'good';
   if (v >= fairMin) return 'fair';
   return 'poor';
 }
 
 /** Band a metric where a LOWER value is better into good/fair/poor. NaN → 'poor'. */
-function bandLow(v: number, goodMax: number, fairMax: number): SupportingMetric['rating'] {
+export function bandLow(v: number, goodMax: number, fairMax: number): SupportingMetric['rating'] {
   if (v <= goodMax) return 'good';
   if (v <= fairMax) return 'fair';
   return 'poor';

--- a/src/terrain/contour/terrainReadiness.ts
+++ b/src/terrain/contour/terrainReadiness.ts
@@ -69,9 +69,9 @@ function tallyCoverage(coverage: Uint8Array): CoverageTally {
   let measured = 0;
   let interpolated = 0;
   let gap = 0;
-  for (let i = 0; i < coverage.length; i++) {
-    if (coverage[i] === 2) measured++;
-    else if (coverage[i] === 1) interpolated++;
+  for (const cell of coverage) {
+    if (cell === 2) measured++;
+    else if (cell === 1) interpolated++;
     else gap++;
   }
   return {
@@ -130,15 +130,19 @@ export function computeTerrainReadiness(
   if (groundRating !== 'unavailable' && measuredFrac < 0.5) {
     groundRating = demote(groundRating);
   }
+  let confidenceDetail: string;
+  if (!Number.isFinite(meanConf)) {
+    confidenceDetail = 'No ground surface could be built for this scan.';
+  } else if (calibrated && tol != null) {
+    confidenceDetail = `Calibrated to held-out error · ±${tol.toFixed(2)} m`;
+  } else {
+    confidenceDetail = 'Heuristic estimate — not enough held-out points to calibrate.';
+  }
   const groundConfidence: ReadinessIndicator = {
     label: 'Ground confidence',
     rating: groundRating,
     value: Number.isFinite(meanConf) ? pct(meanConf / 100) : '—',
-    detail: !Number.isFinite(meanConf)
-      ? 'No ground surface could be built for this scan.'
-      : calibrated && tol != null
-        ? `Calibrated to held-out error · ±${tol.toFixed(2)} m`
-        : 'Heuristic estimate — not enough held-out points to calibrate.',
+    detail: confidenceDetail,
   };
 
   // ── DTM quality ──────────────────────────────────────────────────────

--- a/src/terrain/contour/whyNotReasons.ts
+++ b/src/terrain/contour/whyNotReasons.ts
@@ -54,7 +54,7 @@ const LOW_GROUND_RATIO = 0.1;
 
 const pct = (frac: number): string => `${Math.round(frac * 100)}%`;
 const finite = (n: number | null | undefined): number =>
-  n != null && Number.isFinite(n) ? n : NaN;
+  n != null && Number.isFinite(n) ? n : Number.NaN;
 
 /**
  * Explain why an analysed surface sits short of fully-good, and how to improve

--- a/src/terrain/contourStudio/contourDeliverablePdfModel.ts
+++ b/src/terrain/contourStudio/contourDeliverablePdfModel.ts
@@ -83,10 +83,16 @@ export function buildContourPdfModel(input: ContourPdfInput): ContourPdfModel {
   ];
 
   // ── Page 1 — Contour map ────────────────────────────────────────────────
-  const geometryNote = input.geometry.cartographic
-    ? 'Cartographic (generalized) contours are shown for legibility.' +
-      (input.geometry.analyticalAvailable ? ' Exact analytical geometry is available in the GIS export.' : '')
-    : 'Analytical (exact) contours are shown.';
+  let geometryNote: string;
+  if (input.geometry.cartographic) {
+    const analyticalNote = input.geometry.analyticalAvailable
+      ? ' Exact analytical geometry is available in the GIS export.'
+      : '';
+    geometryNote =
+      'Cartographic (generalized) contours are shown for legibility.' + analyticalNote;
+  } else {
+    geometryNote = 'Analytical (exact) contours are shown.';
+  }
   const mapPage: ContourPdfPage = {
     title: 'Contour summary',
     lines: [
@@ -108,11 +114,12 @@ export function buildContourPdfModel(input: ContourPdfInput): ContourPdfModel {
   };
 
   // ── Page 3 — Validation ─────────────────────────────────────────────────
+  const rmseLine = input.validation.rmseM == null ? '—' : `${num(input.validation.rmseM)} m`;
   const validationPage: ContourPdfPage = {
     title: 'Validation',
     lines: [
       `Mode: ${input.validation.mode}`,
-      `RMSE: ${input.validation.rmseM == null ? '—' : `${num(input.validation.rmseM)} m`}`,
+      `RMSE: ${rmseLine}`,
       `Sample size: ${input.validation.sampleSize}`,
       `Independent checkpoints: ${input.validation.independentCheckpoints ? 'yes' : 'none provided'}`,
     ],

--- a/src/terrain/contourStudio/contourGeometryProduct.ts
+++ b/src/terrain/contourStudio/contourGeometryProduct.ts
@@ -131,7 +131,7 @@ export function cartographicProduct(
   // and the gaps between them are never merged.
 
   displacements.sort((a, b) => a - b);
-  const max = displacements.length ? displacements[displacements.length - 1] : 0;
+  const max = displacements.at(-1) ?? 0;
   const p95 = percentile(displacements, 0.95);
   const mean = displacements.length
     ? displacements.reduce((s, d) => s + d, 0) / displacements.length
@@ -171,7 +171,7 @@ function douglasPeucker(points: ReadonlyArray<Pt>, tol: number): Pt[] {
   let maxDist = -1;
   let idx = -1;
   const first = points[0];
-  const last = points[points.length - 1];
+  const last = points.at(-1)!;
   for (let i = 1; i < points.length - 1; i++) {
     const d = perpendicularDistance(points[i], first, last);
     if (d > maxDist) {

--- a/src/terrain/contourStudio/contourLabelEngine.ts
+++ b/src/terrain/contourStudio/contourLabelEngine.ts
@@ -216,7 +216,7 @@ export function placeContourLabels(
   features: readonly ContourFeature[],
   params: LabelEngineParams,
 ): { labels: PlacedLabel[]; audit: ContourLabelAudit } {
-  const fmt = params.formatValue ?? ((v: number) => String(v));
+  const fmt = params.formatValue ?? String;
   const placed: PlacedLabel[] = [];
   const placedBoxes: Box[] = [];
   let candidates = 0, suppressedByCollision = 0, suppressedByCurvature = 0;
@@ -226,9 +226,10 @@ export function placeContourLabels(
   const ordered = features
     .map((f, i) => ({ f, i, len: polylineLength(f.coordinates) }))
     .filter(({ f }) => !(params.indexOnly && !f.isIndex))
-    .sort((a, b) =>
-      a.f.isIndex !== b.f.isIndex ? (a.f.isIndex ? -1 : 1) : b.len - a.len || a.i - b.i,
-    );
+    .sort((a, b) => {
+      if (a.f.isIndex !== b.f.isIndex) return a.f.isIndex ? -1 : 1;
+      return b.len - a.len || a.i - b.i;
+    });
 
   for (const { f, len } of ordered) {
     if (params.maxLabels != null && placed.length >= params.maxLabels) break;

--- a/src/terrain/contourStudio/contourPackageManifest.ts
+++ b/src/terrain/contourStudio/contourPackageManifest.ts
@@ -201,8 +201,10 @@ export function buildContourPackageManifest(input: PackageInput): ContourPackage
     }
   }
   // README + checksums always present.
-  entries.push({ role: 'readme', filename: `${stem}_README.txt`, status: 'included' });
-  entries.push({ role: 'checksums', filename: 'SHA256SUMS', status: 'included' });
+  entries.push(
+    { role: 'readme', filename: `${stem}_README.txt`, status: 'included' },
+    { role: 'checksums', filename: 'SHA256SUMS', status: 'included' },
+  );
 
   const readme = buildReadme(stem, entries, input, exploratory);
   return { projectName: input.projectName, zipName: `${stem}_Contour_Deliverable.zip`, entries, readme, exploratory };

--- a/src/terrain/contourStudio/contourReviewSummary.ts
+++ b/src/terrain/contourStudio/contourReviewSummary.ts
@@ -97,13 +97,19 @@ export function buildContourReviewSummary(
   // estimate as a producer's survey classification. Unknown counts as derived:
   // silence must not be upgraded into a claim.
   const groundDerived = input.groundIsDerived !== false;
+  let sourceValue: string;
+  if (tally.measured === 0) sourceValue = 'No ground source';
+  else if (groundDerived) sourceValue = 'Derived ground (not from the source file)';
+  else sourceValue = 'Classified ground';
+  let sourceConfidence: ReviewRow['confidence'];
+  if (tally.measured === 0) sourceConfidence = 'low';
+  else if (groundDerived) sourceConfidence = 'medium';
+  else if (measuredFrac >= 0.5) sourceConfidence = 'high';
+  else sourceConfidence = 'medium';
   rows.push({
     key: 'source',
     label: 'Source',
-    value:
-      tally.measured === 0 ? 'No ground source'
-      : groundDerived ? 'Derived ground (not from the source file)'
-      : 'Classified ground',
+    value: sourceValue,
     rationale: [
       `${tally.measured.toLocaleString()} measured ground cells`,
       `${pct(covered / total)} of the grid is covered`,
@@ -113,11 +119,7 @@ export function buildContourReviewSummary(
     ],
     // Derived ground caps at medium however dense it is: density is not
     // provenance, and a confident-looking wrong surface is the failure mode.
-    confidence:
-      tally.measured === 0 ? 'low'
-      : groundDerived ? 'medium'
-      : measuredFrac >= 0.5 ? 'high'
-      : 'medium',
+    confidence: sourceConfidence,
   });
 
   // ── Grid ────────────────────────────────────────────────────────────────
@@ -187,6 +189,10 @@ export function buildContourReviewSummary(
     total,
   );
   const weakFrac = (tally.lowConfidence + tally.edgeRisk + tally.empty) / total;
+  let supportConfidence: ReviewRow['confidence'];
+  if (weakFrac < 0.1) supportConfidence = 'high';
+  else if (weakFrac < 0.3) supportConfidence = 'medium';
+  else supportConfidence = 'low';
   rows.push({
     key: 'support',
     label: 'Support',
@@ -200,7 +206,7 @@ export function buildContourReviewSummary(
     // Keyed off everything that is not strong. Keying it off `empty` alone
     // rated a mostly-low-confidence surface 'high' simply because no cell was
     // strictly void.
-    confidence: weakFrac < 0.1 ? 'high' : weakFrac < 0.3 ? 'medium' : 'low',
+    confidence: supportConfidence,
   });
 
   // ── Validation ────────────────────────────────────────────────────────────
@@ -226,12 +232,10 @@ export function buildContourReviewSummary(
   });
 
   // ── Evidence (from the launch state — the real claim) ─────────────────────
-  const evidenceValue =
-    input.launch.status === 'available'
-      ? 'Supported (internal validation only)'
-      : input.launch.status === 'exploratory'
-        ? 'Exploratory'
-        : 'Blocked';
+  let evidenceValue: string;
+  if (input.launch.status === 'available') evidenceValue = 'Supported (internal validation only)';
+  else if (input.launch.status === 'exploratory') evidenceValue = 'Exploratory';
+  else evidenceValue = 'Blocked';
   rows.push({
     key: 'evidence',
     label: 'Evidence',

--- a/src/terrain/contourStudio/contourStudioLaunchStateFromResult.ts
+++ b/src/terrain/contourStudio/contourStudioLaunchStateFromResult.ts
@@ -71,7 +71,7 @@ export function contourStudioPrerequisitesFromResult(
   ctx: LaunchFrameContext,
 ): ContourStudioPrerequisites {
   const tally = result.cellStatusTally;
-  const total = tally.total > 0 ? tally.total : 0;
+  const total = Math.max(0, tally.total);
   // Unsupported = empty cells over the whole grid. Conservative: unknown total
   // reads as fully unsupported so a degenerate grid can't look deliverable.
   const unsupportedFraction = total > 0 ? tally.empty / total : 1;

--- a/src/terrain/contourStudio/contourStudioState.ts
+++ b/src/terrain/contourStudio/contourStudioState.ts
@@ -197,7 +197,7 @@ function coerce(p: Partial<ContourStudioState>): ContourStudioState {
     appearance: { ...base.appearance, ...p.appearance },
     validation: { ...base.validation, ...p.validation },
     deliverable: { ...base.deliverable, ...p.deliverable },
-    overrides: { ...(p.overrides ?? {}) },
+    overrides: { ...p.overrides },
   };
 }
 

--- a/src/terrain/datasetIntelligence.ts
+++ b/src/terrain/datasetIntelligence.ts
@@ -248,16 +248,20 @@ export function classifyDensity(
   input: Pick<DatasetIntelligenceInput, 'pointCount' | 'bboxVolume' | 'residentDensity'>,
 ): DensityBucket {
   // Prefer the engine-measured value when present.
-  const candidate =
-    input.residentDensity !== undefined && Number.isFinite(input.residentDensity)
-      ? input.residentDensity
-      : input.pointCount !== undefined &&
-          input.bboxVolume !== undefined &&
-          Number.isFinite(input.pointCount) &&
-          Number.isFinite(input.bboxVolume) &&
-          input.bboxVolume > 0
-        ? input.pointCount / input.bboxVolume
-        : NaN;
+  let candidate: number;
+  if (input.residentDensity !== undefined && Number.isFinite(input.residentDensity)) {
+    candidate = input.residentDensity;
+  } else if (
+    input.pointCount !== undefined &&
+    input.bboxVolume !== undefined &&
+    Number.isFinite(input.pointCount) &&
+    Number.isFinite(input.bboxVolume) &&
+    input.bboxVolume > 0
+  ) {
+    candidate = input.pointCount / input.bboxVolume;
+  } else {
+    candidate = Number.NaN;
+  }
   if (!Number.isFinite(candidate) || candidate <= 0) return 'unknown';
   // Thresholds in points per cubic metre. The bands are deliberately
   // wide so a typical drone scan reads as Dense, a typical airborne
@@ -525,13 +529,13 @@ export function summariseDataset(input: DatasetIntelligenceInput): DatasetIntell
 /** Clamp into [0, 1]. */
 function clamp01(x: number): number {
   if (!Number.isFinite(x)) return 0;
-  return x < 0 ? 0 : x > 1 ? 1 : x;
+  return Math.min(1, Math.max(0, x));
 }
 
 /** Clamp into [lo, hi]. */
 function clamp(x: number, lo: number, hi: number): number {
   if (!Number.isFinite(x)) return lo;
-  return x < lo ? lo : x > hi ? hi : x;
+  return Math.min(hi, Math.max(lo, x));
 }
 
 /** Normalise a value to [0, 1] across [lo, hi]; 0 when missing. */

--- a/src/terrain/engine/dtmScatter.ts
+++ b/src/terrain/engine/dtmScatter.ts
@@ -160,7 +160,7 @@ export function scatterMinCountReference(
   grid: ScatterGrid,
 ): ScatterMinCount {
   const nCells = grid.cols * grid.rows;
-  const z = new Float32Array(nCells).fill(NaN);
+  const z = new Float32Array(nCells).fill(Number.NaN);
   const counts = new Uint32Array(nCells);
   const f32 = new Float32Array(1);
   const { h1, h2, v, count } = points;

--- a/src/terrain/engine/gpuBackend.ts
+++ b/src/terrain/engine/gpuBackend.ts
@@ -466,8 +466,16 @@ export function hornDerivativesF32Reference(
   // Per-axis denominators, mirroring the kernel's cellX / cellY uniforms.
   const denomX = fr(8 * fr(cellSizeM));
   const denomY = fr(8 * fr(cellSizeYM));
-  const clampR = (r: number): number => (r < 0 ? 0 : r >= rows ? rows - 1 : r);
-  const clampC = (c: number): number => (c < 0 ? 0 : c >= cols ? cols - 1 : c);
+  const clampR = (r: number): number => {
+    if (r < 0) return 0;
+    if (r >= rows) return rows - 1;
+    return r;
+  };
+  const clampC = (c: number): number => {
+    if (c < 0) return 0;
+    if (c >= cols) return cols - 1;
+    return c;
+  };
   const sample = (r: number, c: number, fallback: number): number => {
     const i = clampR(r) * cols + clampC(c);
     return valid[i] === 1 ? zClean[i] : fallback;

--- a/src/terrain/export/contourStudioPdf.ts
+++ b/src/terrain/export/contourStudioPdf.ts
@@ -53,7 +53,7 @@ function wrap(textStr: string, font: PDFFont, size: number, maxWidth: number): s
   for (const word of words) {
     const candidate = line ? `${line} ${word}` : word;
     if (fits(candidate)) { line = candidate; continue; }
-    if (line) { lines.push(line); line = ''; }
+    if (line) { lines.push(line); }
     if (fits(word)) { line = word; continue; }
     // A single word wider than the line: hard-cut it to what fits.
     let chunk = '';

--- a/src/terrain/export/demGeoTiff.ts
+++ b/src/terrain/export/demGeoTiff.ts
@@ -108,10 +108,15 @@ export function writeGeoTiff(input: DemGeoTiffInput): Uint8Array {
   // Header: [KeyDirectoryVersion=1, KeyRevision=1, MinorRevision=0, NumberOfKeys]
   const keys: number[] = [];
   // GTModelType (1024): 1=Projected, 2=Geographic, 32767=user-defined.
-  const modelType = epsg == null ? 32767 : input.isGeographic ? 2 : 1;
-  keys.push(1024, 0, 1, modelType);
-  // GTRasterType (1025): 1 = RasterPixelIsArea.
-  keys.push(1025, 0, 1, 1);
+  let modelType: number;
+  if (epsg == null) modelType = 32767;
+  else if (input.isGeographic) modelType = 2;
+  else modelType = 1;
+  keys.push(
+    1024, 0, 1, modelType,
+    // GTRasterType (1025): 1 = RasterPixelIsArea.
+    1025, 0, 1, 1,
+  );
   if (epsg != null) {
     if (input.isGeographic) keys.push(2048, 0, 1, epsg); // GeographicTypeGeoKey
     else keys.push(3072, 0, 1, epsg); // ProjectedCSTypeGeoKey

--- a/src/terrain/export/demPackage.ts
+++ b/src/terrain/export/demPackage.ts
@@ -222,9 +222,9 @@ export function buildDemReadme(opts: DemReadmeOptions): string {
 
   const cov = (() => {
     let measured = 0; let interp = 0; const total = dtm.coverage.length;
-    for (let i = 0; i < dtm.coverage.length; i++) {
-      if (dtm.coverage[i] === 2) measured++;
-      else if (dtm.coverage[i] === 1) interp++;
+    for (const c of dtm.coverage) {
+      if (c === 2) measured++;
+      else if (c === 1) interp++;
     }
     return { measured, interp, total };
   })();
@@ -283,12 +283,12 @@ export function buildDemReadme(opts: DemReadmeOptions): string {
     `Coverage mode`,
     `  ${coverageLabel(p.coverageMode)}`,
     ``,
+    `Quality gate`,
   );
 
   // Quality gate — the unified verdicts come from the provenance block below;
   // here we surface the gate's own per-axis REASON lists (surface + export
   // georeferencing) so a preview / blocked export explains itself in full.
-  lines.push(`Quality gate`);
   if (reasons.length) {
     lines.push(`  Surface reasons`);
     for (const r of reasons) lines.push(`    - ${r}`);
@@ -300,9 +300,7 @@ export function buildDemReadme(opts: DemReadmeOptions): string {
   if (!reasons.length && !exportReasons.length) {
     lines.push(`  (no gate reasons — see Export readiness in Provenance below)`);
   }
-  lines.push(``);
-
-  lines.push(`Warnings`);
+  lines.push(``, `Warnings`);
   if (warnings.length) {
     for (const w of warnings) lines.push(`  - ${w}`);
   } else {
@@ -317,9 +315,9 @@ export function buildDemReadme(opts: DemReadmeOptions): string {
   // it can't drift from what the other exports stamp.)
   const gp = result.generationParams;
   const interpStr = gp ? `${gp.interpolation} void fill` : 'unknown';
-  const despikeStr = gp
-    ? (gp.despike ? 'on (blunder-only outlier removal)' : 'off')
-    : 'unknown';
+  let despikeStr: string;
+  if (gp) despikeStr = gp.despike ? 'on (blunder-only outlier removal)' : 'off';
+  else despikeStr = 'unknown';
   const aggStr = gp ? gp.aggregation : 'unknown';
   lines.push(
     `Generation parameters`,
@@ -408,14 +406,16 @@ export function buildDemPackage(
       values: g.values, coverage: g.coverage,
       cols: dtm.cols, rows: dtm.rows, cellSize, xllCorner: xll, yllCorner: yll, noData: NO_DATA,
     };
-    entries.push({
-      name: `${basename}-${g.key}.asc`,
-      bytes: new TextEncoder().encode(writeAsciiGrid(common)),
-    });
-    entries.push({
-      name: `${basename}-${g.key}.tif`,
-      bytes: writeGeoTiff({ ...common, epsg, isGeographic, verticalEpsg: g.verticalEpsg, verticalUnitCode: g.verticalEpsg != null ? verticalUnitCode : null }),
-    });
+    entries.push(
+      {
+        name: `${basename}-${g.key}.asc`,
+        bytes: new TextEncoder().encode(writeAsciiGrid(common)),
+      },
+      {
+        name: `${basename}-${g.key}.tif`,
+        bytes: writeGeoTiff({ ...common, epsg, isGeographic, verticalEpsg: g.verticalEpsg, verticalUnitCode: g.verticalEpsg != null ? verticalUnitCode : null }),
+      },
+    );
   }
 
   if (options.wkt) {

--- a/src/terrain/export/exportProvenance.ts
+++ b/src/terrain/export/exportProvenance.ts
@@ -343,7 +343,7 @@ export function buildExportProvenance(
   // otherwise the whole block is null (never a fabricated zero).
   const acc = result.accuracyStandards ?? null;
   const accuracy: ExportProvenanceAccuracy | null =
-    acc && acc.rmseZM != null && Number.isFinite(acc.rmseZM)
+    acc?.rmseZM != null && Number.isFinite(acc.rmseZM)
       ? {
           rmseZM: acc.rmseZM,
           nvaM: acc.nvaM ?? null,
@@ -363,7 +363,7 @@ export function buildExportProvenance(
   // fields are a straight projection of the summary the core computed.
   const cx = result.complexity ?? null;
   const complexity: ExportProvenanceComplexity | null =
-    cx && cx.band != null
+    cx?.band != null
       ? {
           vrmMedian: cx.vrmMedian,
           vrmIqr: cx.vrmIqr,
@@ -609,6 +609,14 @@ function kv(key: string, value: string): string {
  * structured {@link provenanceJson} so every format agrees verbatim.
  */
 export function provenanceLines(p: ExportProvenance): string[] {
+  let contourIntervalValue: string;
+  if (p.contourIntervalM == null) {
+    contourIntervalValue = 'none';
+  } else if (p.contourIntervalUnit && p.contourIntervalUnit !== 'unknown') {
+    contourIntervalValue = `${p.contourIntervalM} ${p.contourIntervalUnit}`;
+  } else {
+    contourIntervalValue = `${p.contourIntervalM} (vertical unit unverified)`;
+  }
   const lines: string[] = [
     kv('Software', `${p.software} ${p.softwareVersion}`),
     kv('Build', p.build),
@@ -618,14 +626,7 @@ export function provenanceLines(p: ExportProvenance): string[] {
     kv('Horizontal CRS', p.horizontalCrs),
     kv('Vertical datum', p.verticalDatum),
     kv('Coverage', p.coverageMode),
-    kv(
-      'Contour interval',
-      p.contourIntervalM != null
-        ? p.contourIntervalUnit && p.contourIntervalUnit !== 'unknown'
-          ? `${p.contourIntervalM} ${p.contourIntervalUnit}`
-          : `${p.contourIntervalM} (vertical unit unverified)`
-        : 'none',
-    ),
+    kv('Contour interval', contourIntervalValue),
     kv('Contour style', p.contourStyleLabel),
     kv('Surface quality', p.surfaceQuality),
     // The "Tier — reason" formatting is the readiness engine's, so this stamp
@@ -688,8 +689,10 @@ export function provenanceLines(p: ExportProvenance): string[] {
   // The registered methods (id@version) that produced these figures, so a reader
   // can trace each number to the algorithm and revision behind it.
   const record = analysisRecordFromProvenance(p);
-  lines.push(kv('Methods', record.methods.map(methodTag).join(', ')));
-  lines.push(kv('Record', `schema ${record.schemaVersion} · ${record.contentHash}`));
+  lines.push(
+    kv('Methods', record.methods.map(methodTag).join(', ')),
+    kv('Record', `schema ${record.schemaVersion} · ${record.contentHash}`),
+  );
   // The verify-only processing manifest: op count + shortened chain head so a
   // reader can match this stamp against the full manifest in the JSON
   // metadata (or a session file) and confirm the record is intact. Twelve hex
@@ -701,9 +704,9 @@ export function provenanceLines(p: ExportProvenance): string[] {
       'Manifest',
       `schema ${manifest.schemaVersion} · ${manifest.head.slice(0, 12)} · ${manifest.ops.length} ops · verifiable`,
     ),
+    kv('Note', p.notSurveyGrade),
+    kv('Evidence', EVIDENCE_GATE_NOTE),
   );
-  lines.push(kv('Note', p.notSurveyGrade));
-  lines.push(kv('Evidence', EVIDENCE_GATE_NOTE));
   // The evidence-gate permit that authorised this file (§19). Absent only for a
   // non-gated path; a gated contour export always carries its decision here.
   if (p.exportPermit) {

--- a/src/terrain/export/sha256.ts
+++ b/src/terrain/export/sha256.ts
@@ -80,6 +80,6 @@ export function sha256Bytes(bytes: Uint8Array): Uint8Array {
 export function sha256Hex(bytes: Uint8Array): string {
   const d = sha256Bytes(bytes);
   let s = '';
-  for (let i = 0; i < d.length; i++) s += d[i].toString(16).padStart(2, '0');
+  for (const b of d) s += b.toString(16).padStart(2, '0');
   return s;
 }

--- a/src/terrain/export/terrainReportContent.ts
+++ b/src/terrain/export/terrainReportContent.ts
@@ -152,7 +152,9 @@ function fmtGenerated(iso: string): string {
 
 /** Map a workflow grade to its glyph mark. */
 function markFor(status: WorkflowItem['status']): TerrainReportWorkflow['mark'] {
-  return status === 'good' ? '✓' : status === 'caution' ? '⚠' : '✕';
+  if (status === 'good') return '✓';
+  if (status === 'caution') return '⚠';
+  return '✕';
 }
 
 /**
@@ -321,12 +323,11 @@ export function buildTerrainReportContent(
   // ── Quality Metrics ─────────────────────────────────────────────────────
   // ASPRS / USGS 3DEP vocabulary, honestly null-able: when the run measured no
   // RMSEz the whole block reads em-dash / unknown rather than a fabricated zero.
+  const qlFallback = acc && acc.qualityLevel !== 'unknown' ? acc.qualityLevel : DASH;
   const qlValue =
     hasAcc && provenance.accuracy && provenance.accuracy.usgsQualityLevel !== 'unknown'
       ? provenance.accuracy.usgsQualityLevel
-      : acc && acc.qualityLevel !== 'unknown'
-        ? acc.qualityLevel
-        : DASH;
+      : qlFallback;
   // Phase 4 honesty figures, single-sourced from the same result the panel
   // shows. ASCII only (the PDF renderer strips non-Latin1), so "<=" not "≤".
   const pctOf = (x: number): string => `${Math.round(x * 100)}%`;

--- a/src/terrain/ground/cellConfidence.ts
+++ b/src/terrain/ground/cellConfidence.ts
@@ -512,7 +512,7 @@ export function directionalSupport(
   if (directions === 1) return { directions: 1, oneSided: true };
   // Largest empty arc between consecutive hit directions (wrapping 360°).
   hitAngles.sort((a, b) => a - b);
-  let maxGap = 360 - hitAngles[hitAngles.length - 1] + hitAngles[0];
+  let maxGap = 360 - hitAngles.at(-1)! + hitAngles[0];
   for (let k = 1; k < hitAngles.length; k++) {
     const gap = hitAngles[k] - hitAngles[k - 1];
     if (gap > maxGap) maxGap = gap;
@@ -524,7 +524,7 @@ export function directionalSupport(
 /** Median of the positive (measured) counts; 0 when none are measured. */
 function medianMeasuredCount(counts: Uint32Array): number {
   const measured: number[] = [];
-  for (let i = 0; i < counts.length; i++) if (counts[i] > 0) measured.push(counts[i]);
+  for (const c of counts) if (c > 0) measured.push(c);
   if (measured.length === 0) return 0;
   measured.sort((a, b) => a - b);
   const mid = measured.length >> 1;

--- a/src/terrain/ground/classificationFilter.ts
+++ b/src/terrain/ground/classificationFilter.ts
@@ -42,7 +42,7 @@ export function excludeNonGroundClasses(
   classification: ReadonlyArray<number> | Uint8Array | null | undefined,
   excluded: ReadonlyArray<number> = NON_GROUND_CLASSES,
 ): ClassificationFilterResult {
-  if (!classification || classification.length !== points.length || excluded.length === 0) {
+  if (classification?.length !== points.length || excluded.length === 0) {
     return { points: points.slice(), excludedCount: 0, byClass: {} };
   }
   const drop = new Set(excluded);

--- a/src/terrain/ground/geodesicFill.ts
+++ b/src/terrain/ground/geodesicFill.ts
@@ -151,7 +151,7 @@ export function geodesicFill(
     for (let scol = 0; scol < cols; scol++) {
       const src = srow * cols + scol;
       if (hadData[src] === 1) continue; // measured — keep verbatim
-      if (!Number.isFinite(surface[src])) { out[src] = NaN; continue; } // unreachable gap
+      if (!Number.isFinite(surface[src])) { out[src] = Number.NaN; continue; } // unreachable gap
 
       const iter = src; // unique per void; stamps scratch arrays
       heapLen = 0;
@@ -186,8 +186,10 @@ export function geodesicFill(
           if (Math.abs(nr - srow) > maxRadius || Math.abs(nc - scol) > maxRadius) continue;
           const nb = nr * cols + nc;
           if (!Number.isFinite(surface[nb])) continue; // can't walk over unknown ground
-          const stepXY =
-            DR[k] !== 0 && DC[k] !== 0 ? cellDiag : DC[k] !== 0 ? cellX : cellY;
+          let stepXY: number;
+          if (DR[k] !== 0 && DC[k] !== 0) stepXY = cellDiag;
+          else if (DC[k] !== 0) stepXY = cellX;
+          else stepXY = cellY;
           const dz = (surface[nb] - surface[c]) * zScale;
           const nd = cost + Math.sqrt(stepXY * stepXY + dz * dz);
           if (seen[nb] !== iter || nd < dist[nb]) {

--- a/src/terrain/ground/groundFilter.ts
+++ b/src/terrain/ground/groundFilter.ts
@@ -275,7 +275,7 @@ export function classifyGroundSmrf(
   };
 
   // ── 2. minimum-elevation grid (optionally despiked) ───────────────
-  const minGrid = new Float32Array(nCells).fill(NaN);
+  const minGrid = new Float32Array(nCells).fill(Number.NaN);
   const hadData = new Uint8Array(nCells);
   if (floorPercentile <= 0) {
     // Fast path: strict per-cell minimum.
@@ -452,7 +452,7 @@ function windowExtreme(
   for (let row = 0; row < rows; row++) {
     const base = row * cols;
     for (let col = 0; col < cols; col++) {
-      let acc = NaN;
+      let acc = Number.NaN;
       const lo = Math.max(0, col - b);
       const hi = Math.min(cols - 1, col + b);
       for (let c = lo; c <= hi; c++) {
@@ -467,7 +467,7 @@ function windowExtreme(
   const out = new Float32Array(grid.length);
   for (let col = 0; col < cols; col++) {
     for (let row = 0; row < rows; row++) {
-      let acc = NaN;
+      let acc = Number.NaN;
       const lo = Math.max(0, row - b);
       const hi = Math.min(rows - 1, row + b);
       for (let r = lo; r <= hi; r++) {

--- a/src/terrain/ground/idwFill.ts
+++ b/src/terrain/ground/idwFill.ts
@@ -70,7 +70,7 @@ export function idwFill(
     }
   }
   if (!anyData) {
-    out.fill(NaN);
+    out.fill(Number.NaN);
     return out;
   }
 
@@ -118,7 +118,7 @@ export function idwFill(
         radius++;
       }
 
-      out[i] = wSum > 0 ? vSum / wSum : NaN;
+      out[i] = wSum > 0 ? vSum / wSum : Number.NaN;
     }
   }
   return out;

--- a/src/terrain/ground/rasterizeDtm.ts
+++ b/src/terrain/ground/rasterizeDtm.ts
@@ -170,7 +170,7 @@ export function rasterizeDtm(
 
   const { originH1, originH2, cols, rows, cellSizeM } = grid;
   const nCells = cols * rows;
-  const z = new Float32Array(nCells).fill(NaN);
+  const z = new Float32Array(nCells).fill(Number.NaN);
   const counts = new Uint32Array(nCells);
   const accum = new Float64Array(nCells); // sum for mean
   // Per-cell value lists, only allocated for list-needing modes. Sparse: a cell

--- a/src/terrain/ground/terrainDerivatives.ts
+++ b/src/terrain/ground/terrainDerivatives.ts
@@ -120,8 +120,16 @@ export function hornSlopeAspect(
   // left untouched. zScale 1 (metric, or Z already in metres) is a no-op.
   const zs = Number.isFinite(zScale) && zScale > 0 ? zScale : 1;
 
-  const clampR = (r: number): number => (r < 0 ? 0 : r >= rows ? rows - 1 : r);
-  const clampC = (c: number): number => (c < 0 ? 0 : c >= cols ? cols - 1 : c);
+  const clampR = (r: number): number => {
+    if (r < 0) return 0;
+    if (r >= rows) return rows - 1;
+    return r;
+  };
+  const clampC = (c: number): number => {
+    if (c < 0) return 0;
+    if (c >= cols) return cols - 1;
+    return c;
+  };
 
   /** In-grid read (indices clamped), preserving a non-finite value. */
   const raw = (r: number, c: number): number => z[clampR(r) * cols + clampC(c)];
@@ -290,7 +298,7 @@ export function countSynthesisedNeighbours(
 ): number {
   const mask = synthesisedNeighbourMask(z, cols, rows);
   let n = 0;
-  for (let i = 0; i < mask.length; i++) n += mask[i];
+  for (const m of mask) n += m;
   return n;
 }
 

--- a/src/terrain/objectMetrics.ts
+++ b/src/terrain/objectMetrics.ts
@@ -133,9 +133,12 @@ export function objectMetrics(
     if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
     sx.push(x); sy.push(y); sz.push(z);
     cx += x; cy += y; cz += z;
-    if (x < minX) minX = x; if (x > maxX) maxX = x;
-    if (y < minY) minY = y; if (y > maxY) maxY = y;
-    if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z;
+    if (z > maxZ) maxZ = z;
   }
   const m = sx.length;
   if (m < 4) return empty;
@@ -215,7 +218,7 @@ export function objectMetrics(
     bins[la2 * LON + lo2] = 1;
   }
   let hit = 0;
-  for (let i = 0; i < bins.length; i++) if (bins[i]) hit++;
+  for (const bin of bins) if (bin) hit++;
   const completenessPct = (100 * hit) / (LON * LAT);
 
   const { lengthM: L, widthM: W, heightM: H } = obb;

--- a/src/terrain/quality/cellMetrics.ts
+++ b/src/terrain/quality/cellMetrics.ts
@@ -188,11 +188,10 @@ export function computeCellMetrics(
   // True median: for an even count, average the two central values rather than
   // taking the lower-middle element (which biases the reported density low).
   const dn = densities.length;
-  const median = dn === 0
-    ? 0
-    : dn % 2 === 1
-      ? densities[(dn - 1) >> 1]
-      : (densities[dn / 2 - 1] + densities[dn / 2]) / 2;
+  let median: number;
+  if (dn === 0) median = 0;
+  else if (dn % 2 === 1) median = densities[(dn - 1) >> 1];
+  else median = (densities[dn / 2 - 1] + densities[dn / 2]) / 2;
 
   return {
     metrics: { pointDensity, localCompleteness, edgeDistanceCells },

--- a/src/terrain/quality/dtmCellStatus.ts
+++ b/src/terrain/quality/dtmCellStatus.ts
@@ -107,8 +107,8 @@ export function tallyCellStatus(statuses: Uint8Array): CellStatusTally {
   let empty = 0;
   let lowConfidence = 0;
   let edgeRisk = 0;
-  for (let i = 0; i < statuses.length; i++) {
-    switch (statuses[i]) {
+  for (const status of statuses) {
+    switch (status) {
       case CELL_STATUS_CODE.measured:
         measured++;
         break;

--- a/src/terrain/quality/dtmQualityGate.ts
+++ b/src/terrain/quality/dtmQualityGate.ts
@@ -236,5 +236,5 @@ export function evaluateDtmQuality(input: DtmQualityInput): DtmQualityReport {
 function joinReasons(parts: string[]): string {
   if (parts.length === 1) return parts[0];
   if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
-  return `${parts.slice(0, -1).join(', ')}, and ${parts[parts.length - 1]}`;
+  return `${parts.slice(0, -1).join(', ')}, and ${parts.at(-1)}`;
 }

--- a/src/terrain/quality/readinessEngine.ts
+++ b/src/terrain/quality/readinessEngine.ts
@@ -134,7 +134,7 @@ export function readinessLine(tier: ReadinessTier, reason: string): string {
 export function joinReasons(parts: string[]): string {
   if (parts.length === 1) return parts[0];
   if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
-  return `${parts.slice(0, -1).join(', ')}, and ${parts[parts.length - 1]}`;
+  return `${parts.slice(0, -1).join(', ')}, and ${parts.at(-1)}`;
 }
 
 /** Inspection-class rows grade off SURFACE QUALITY. */

--- a/src/terrain/quality/recommendGrid.ts
+++ b/src/terrain/quality/recommendGrid.ts
@@ -58,7 +58,7 @@ export interface GridRecommendation {
 /** Snap a raw value up to the smallest ladder member ≥ it (clamped to the ends). */
 function snapUp(raw: number, ladder: ReadonlyArray<number>): number {
   for (const v of ladder) if (raw <= v) return v;
-  return ladder[ladder.length - 1];
+  return ladder.at(-1)!;
 }
 
 /** Recommend a DTM grid cell size and contour interval. Deterministic. */
@@ -83,7 +83,7 @@ export function recommendGrid(input: GridRecommendationInput): GridRecommendatio
   const cellOptionsM = GRID_LADDER_M.filter(cellFits);
   let cellSizeM = densityCell;
   if (!cellFits(cellSizeM)) {
-    cellSizeM = cellOptionsM.length > 0 ? cellOptionsM[0] : GRID_LADDER_M[GRID_LADDER_M.length - 1];
+    cellSizeM = cellOptionsM.length > 0 ? cellOptionsM[0] : GRID_LADDER_M.at(-1)!;
     reasons.push(`Grid coarsened to ${cellSizeM} m so the ${Math.round(area)} m² extent fits in memory.`);
   } else if (Number.isFinite(spacing)) {
     reasons.push(

--- a/src/terrain/quality/scanFitness.ts
+++ b/src/terrain/quality/scanFitness.ts
@@ -155,20 +155,24 @@ function pct(frac: number): number {
 
 function georefDimension(inp: FitnessInputs): FitnessDimension {
   const gs = georefStatus(inp.crsKnown, inp.datumKnown, { crsName: inp.crsName, datumName: inp.datumName });
-  const tone: FitnessTone = gs.tone === 'anchored' ? 'ready' : gs.tone === 'partial' ? 'okay' : 'review';
+  let tone: FitnessTone;
+  if (gs.tone === 'anchored') tone = 'ready';
+  else if (gs.tone === 'partial') tone = 'okay';
+  else tone = 'review';
   return { key: 'georeferencing', label: 'Location & height', tone, summary: gs.headline };
 }
 
 function coverageDimension(f: number | null): FitnessDimension {
   if (f == null) return { key: 'coverage', label: 'Coverage', tone: 'review', summary: 'Coverage unknown.' };
-  const tone: FitnessTone = f >= COVERAGE_READY ? 'ready' : f >= COVERAGE_OKAY ? 'okay' : 'review';
+  let tone: FitnessTone;
+  if (f >= COVERAGE_READY) tone = 'ready';
+  else if (f >= COVERAGE_OKAY) tone = 'okay';
+  else tone = 'review';
   const measured = pct(f);
-  const summary =
-    tone === 'ready'
-      ? `${measured}% of the surface is measured ground — well covered.`
-      : tone === 'okay'
-        ? `${measured}% measured; the rest is interpolated between gaps.`
-        : `Only ${measured}% is measured ground — ${100 - measured}% is interpolated, so the surface is mostly inferred.`;
+  let summary: string;
+  if (tone === 'ready') summary = `${measured}% of the surface is measured ground — well covered.`;
+  else if (tone === 'okay') summary = `${measured}% measured; the rest is interpolated between gaps.`;
+  else summary = `Only ${measured}% is measured ground — ${100 - measured}% is interpolated, so the surface is mostly inferred.`;
   return { key: 'coverage', label: 'Coverage', tone, summary };
 }
 
@@ -185,14 +189,15 @@ function densityDimension(d: number | null, unitKnown: boolean): FitnessDimensio
       summary: 'Coordinate units are unverified — ground density can’t be graded in pts/m² until the source CRS is confirmed.',
     };
   }
-  const tone: FitnessTone = d >= QL1_DENSITY ? 'ready' : d >= QL2_DENSITY ? 'okay' : 'review';
+  let tone: FitnessTone;
+  if (d >= QL1_DENSITY) tone = 'ready';
+  else if (d >= QL2_DENSITY) tone = 'okay';
+  else tone = 'review';
   const v = d >= 100 ? Math.round(d) : Math.round(d * 10) / 10;
-  const summary =
-    tone === 'ready'
-      ? `${v} ground pts/m² — at or above ${QL1_DENSITY} pts/m² (the 3DEP QL1 density floor).`
-      : tone === 'okay'
-        ? `${v} ground pts/m² — at or above ${QL2_DENSITY} pts/m² (the 3DEP QL2 density floor).`
-        : `${v} ground pts/m² — below ${QL2_DENSITY} pts/m² (the 3DEP QL2 density floor).`;
+  let summary: string;
+  if (tone === 'ready') summary = `${v} ground pts/m² — at or above ${QL1_DENSITY} pts/m² (the 3DEP QL1 density floor).`;
+  else if (tone === 'okay') summary = `${v} ground pts/m² — at or above ${QL2_DENSITY} pts/m² (the 3DEP QL2 density floor).`;
+  else summary = `${v} ground pts/m² — below ${QL2_DENSITY} pts/m² (the 3DEP QL2 density floor).`;
   return { key: 'density', label: 'Ground detail', tone, summary };
 }
 
@@ -214,14 +219,15 @@ function accuracyDimension(rmse: number | null, unit: string, unitToMetres: numb
   // Bucket on the METRIC value; the thresholds are metres. The displayed value
   // stays in the file's unit.
   const rmseM = rmse * unitToMetres;
-  const tone: FitnessTone = rmseM <= RMSE_READY ? 'ready' : rmseM <= RMSE_OKAY ? 'okay' : 'review';
+  let tone: FitnessTone;
+  if (rmseM <= RMSE_READY) tone = 'ready';
+  else if (rmseM <= RMSE_OKAY) tone = 'okay';
+  else tone = 'review';
   const v = `±${rmse.toFixed(2)} ${unit}`;
-  const summary =
-    tone === 'ready'
-      ? `${v} vertical (held-out check) — tight.`
-      : tone === 'okay'
-        ? `${v} vertical (held-out check) — moderate.`
-        : `${v} vertical (held-out check) — loose.`;
+  let summary: string;
+  if (tone === 'ready') summary = `${v} vertical (held-out check) — tight.`;
+  else if (tone === 'okay') summary = `${v} vertical (held-out check) — moderate.`;
+  else summary = `${v} vertical (held-out check) — loose.`;
   return { key: 'accuracy', label: 'Vertical accuracy', tone, summary };
 }
 
@@ -234,14 +240,15 @@ function classificationDimension(unclassified: number | null, hasGround: boolean
       summary: 'No ground classification — ground was derived, not provided.',
     };
   }
-  const tone: FitnessTone = unclassified <= UNCLASSIFIED_OKAY ? 'ready' : unclassified < 0.5 ? 'okay' : 'review';
+  let tone: FitnessTone;
+  if (unclassified <= UNCLASSIFIED_OKAY) tone = 'ready';
+  else if (unclassified < 0.5) tone = 'okay';
+  else tone = 'review';
   const u = pct(unclassified);
-  const summary =
-    tone === 'ready'
-      ? `Classified ground present; ${u}% unclassified.`
-      : tone === 'okay'
-        ? `Partly classified — ${u}% of points are unclassified.`
-        : `${u}% unclassified — classification is incomplete.`;
+  let summary: string;
+  if (tone === 'ready') summary = `Classified ground present; ${u}% unclassified.`;
+  else if (tone === 'okay') summary = `Partly classified — ${u}% of points are unclassified.`;
+  else summary = `${u}% unclassified — classification is incomplete.`;
   return { key: 'classification', label: 'Classification', tone, summary };
 }
 

--- a/src/terrain/quality/terrainQualityScore.ts
+++ b/src/terrain/quality/terrainQualityScore.ts
@@ -60,7 +60,7 @@ const RMSE_HALF_M = 0.15;
 /** Returns-per-cell at which the density sub-score is 0.5. */
 const DENSITY_HALF_COUNT = 3;
 
-const clamp01 = (v: number): number => (v < 0 ? 0 : v > 1 ? 1 : v);
+const clamp01 = (v: number): number => Math.min(1, Math.max(0, v));
 
 function bandFor(score: number): QualityBand {
   if (score >= 80) return 'excellent';

--- a/src/terrain/quantile.ts
+++ b/src/terrain/quantile.ts
@@ -29,7 +29,7 @@ export function quantileSorted(sorted: ArrayLike<number>, p: number): number {
   const n = sorted.length;
   if (n === 0) return Number.NaN;
   if (n === 1) return sorted[0];
-  const frac = p < 0 ? 0 : p > 1 ? 1 : p;
+  const frac = Math.min(1, Math.max(0, p));
   const rank = frac * (n - 1);
   const lo = Math.floor(rank);
   const hi = Math.ceil(rank);

--- a/src/terrain/scanRoute.ts
+++ b/src/terrain/scanRoute.ts
@@ -144,12 +144,10 @@ export function planScanRoute(input: ScanRouteInput): ScanRoutePlan {
   // nothing to say, a NON-AUTO override still routes by itself (the user's
   // explicit choice must never strand them on a torn-down panel just because
   // the gather failed at click time).
-  const effective: SpaceKind | null =
-    detected !== null
-      ? resolveScanRoute(detected, override)
-      : override !== 'auto'
-        ? override
-        : null;
+  let effective: SpaceKind | null;
+  if (detected !== null) effective = resolveScanRoute(detected, override);
+  else if (override !== 'auto') effective = override;
+  else effective = null;
   if (!initial) {
     // Re-route only when the effective route genuinely changes — never thrash.
     if (effective === null || effective === lastVerdict) {

--- a/src/terrain/scanShape.ts
+++ b/src/terrain/scanShape.ts
@@ -283,9 +283,12 @@ function floorFieldForAxis(
     const b = i * 3;
     const h1 = positions[b + h1Off], h2 = positions[b + h2Off], v = positions[b + vOff];
     if (!Number.isFinite(h1) || !Number.isFinite(h2) || !Number.isFinite(v)) continue;
-    if (h1 < minH1) minH1 = h1; if (h1 > maxH1) maxH1 = h1;
-    if (h2 < minH2) minH2 = h2; if (h2 > maxH2) maxH2 = h2;
-    if (v < minV) minV = v; if (v > maxV) maxV = v;
+    if (h1 < minH1) minH1 = h1;
+    if (h1 > maxH1) maxH1 = h1;
+    if (h2 < minH2) minH2 = h2;
+    if (h2 > maxH2) maxH2 = h2;
+    if (v < minV) minV = v;
+    if (v > maxV) maxV = v;
   }
   const ex1 = Math.max(0, maxH1 - minH1);
   const ex2 = Math.max(0, maxH2 - minH2);
@@ -351,7 +354,8 @@ function enclosureForAxis(
   for (let i = 0; i < n; i += stride) {
     const v = positions[i * 3 + vOff];
     if (!Number.isFinite(v)) continue;
-    if (v < minV) minV = v; if (v > maxV) maxV = v;
+    if (v < minV) minV = v;
+    if (v > maxV) maxV = v;
   }
   const exV = Math.max(0, maxV - minV);
   if (exV <= 0) return { score: 0 };
@@ -398,9 +402,12 @@ function axisMetrics(
     const b = i * 3;
     const h1 = positions[b + h1Off], h2 = positions[b + h2Off], v = positions[b + vOff];
     if (!Number.isFinite(h1) || !Number.isFinite(h2) || !Number.isFinite(v)) continue;
-    if (h1 < minH1) minH1 = h1; if (h1 > maxH1) maxH1 = h1;
-    if (h2 < minH2) minH2 = h2; if (h2 > maxH2) maxH2 = h2;
-    if (v < minV) minV = v; if (v > maxV) maxV = v;
+    if (h1 < minH1) minH1 = h1;
+    if (h1 > maxH1) maxH1 = h1;
+    if (h2 < minH2) minH2 = h2;
+    if (h2 > maxH2) maxH2 = h2;
+    if (v < minV) minV = v;
+    if (v > maxV) maxV = v;
   }
   const ex1 = Math.max(0, maxH1 - minH1);
   const ex2 = Math.max(0, maxH2 - minH2);
@@ -466,9 +473,8 @@ export function classifyScanShape(
   const n = Math.floor(positions.length / 3);
   const gridN = Math.max(8, Math.floor(params.gridN ?? 64));
   const maxSamples = Math.max(100, Math.floor(params.maxSamples ?? 60000));
-  const classification = params.classification && params.classification.length === n
-    ? params.classification
-    : undefined;
+  const classification =
+    params.classification?.length === n ? params.classification : undefined;
 
   if (n < 8) {
     return {
@@ -580,14 +586,18 @@ export function classifyScanShape(
     // perimeter structure over a full floor) is the least certain but still
     // decisively non-terrain — it reports its own honest, lower confidence.
     const strongWalls = m.wallCoverage >= WALL_INTERIOR;
-    confidence = flatCeiling ? 0.9 : strongWalls ? 0.8 : 0.7;
-    reasons.unshift(
-      flatCeiling
-        ? `Floor + flat ceiling enclose ${Math.round(m.ceilingCoverage * 100)}% of the footprint — interior space.`
-        : strongWalls
-          ? `Floor + near-full-height walls (${Math.round(m.wallCoverage * 100)}% of cells) — interior space (ceiling partial).`
-          : `Full floor + partial perimeter walls / sparse ceiling (${Math.round(m.wallCoverage * 100)}% full-height, ${Math.round(m.ceilingCoverage * 100)}% overhead, ${Math.round(m.overhangFraction * 100)}% stacked) — open interior space (high or sparsely-scanned ceiling).`,
-    );
+    if (flatCeiling) confidence = 0.9;
+    else if (strongWalls) confidence = 0.8;
+    else confidence = 0.7;
+    let interiorReason: string;
+    if (flatCeiling) {
+      interiorReason = `Floor + flat ceiling enclose ${Math.round(m.ceilingCoverage * 100)}% of the footprint — interior space.`;
+    } else if (strongWalls) {
+      interiorReason = `Floor + near-full-height walls (${Math.round(m.wallCoverage * 100)}% of cells) — interior space (ceiling partial).`;
+    } else {
+      interiorReason = `Full floor + partial perimeter walls / sparse ceiling (${Math.round(m.wallCoverage * 100)}% full-height, ${Math.round(m.ceilingCoverage * 100)}% overhead, ${Math.round(m.overhangFraction * 100)}% stacked) — open interior space (high or sparsely-scanned ceiling).`;
+    }
+    reasons.unshift(interiorReason);
   } else {
     nonTerrain = false; spaceKind = 'terrain'; confidence = 0.85;
     reasons.unshift(`Flat, single-surface geometry along ${up} (aspect ${m.aspect.toFixed(2)}, ${Math.round(m.overhangFraction * 100)}% stacked, ${Math.round(m.wallCoverage * 100)}% full-height).`);

--- a/src/terrain/space/floorplan/centerline.ts
+++ b/src/terrain/space/floorplan/centerline.ts
@@ -133,9 +133,7 @@ export function skeletonize(mask: Uint8Array, cols: number, rows: number): Uint8
           if (a !== 1) continue;
           if (step === 0) {
             if (p2 * p4 * p6 !== 0 || p4 * p6 * p8 !== 0) continue;
-          } else {
-            if (p2 * p4 * p8 !== 0 || p2 * p6 * p8 !== 0) continue;
-          }
+          } else if (p2 * p4 * p8 !== 0 || p2 * p6 * p8 !== 0) continue;
           toClear.push(r * cols + c);
         }
       }
@@ -330,7 +328,7 @@ export function normalizeWallThickness(grid: OccupancyGrid): ThicknessNormalizat
   for (let i = 0; i < n; i++) {
     if (!mask[i]) continue;
     if (demotedComp[label[i]]) {
-      if (demotedMask === null) demotedMask = new Uint8Array(n);
+      demotedMask ??= new Uint8Array(n);
       demotedMask[i] = 1;
     } else if (!out[i]) {
       removedCells++;
@@ -506,9 +504,10 @@ export function classifyWallGaps(
       });
     }
   }
-  cands.sort((p, q) =>
-    p.kind !== q.kind ? (p.kind === 'door' ? -1 : 1) : p.widthM - q.widthM,
-  );
+  cands.sort((p, q) => {
+    if (p.kind !== q.kind) return p.kind === 'door' ? -1 : 1;
+    return p.widthM - q.widthM;
+  });
   const used = new Uint8Array(ends.length);
   const gaps: PlanGap[] = [];
   for (const cand of cands) {

--- a/src/terrain/space/floorplan/extractFloorPlan.ts
+++ b/src/terrain/space/floorplan/extractFloorPlan.ts
@@ -680,27 +680,32 @@ export function extractFloorPlan(
   // wall-evidence peak (vs the standard 0.7–1.8 m band) — an honest note that
   // the slice height was chosen from the data, not assumed.
   const bandAdapted = slice.bandBasis === 'adaptive';
-  reasons.push(
-    slice.usedWallBand
-      ? slice.floorBasis === 'histogram'
-        ? `Walls traced from the point slice ${slice.bandLowUsedM.toFixed(1)}–${slice.bandHighUsedM.toFixed(1)} m above the detected floor${bandAdapted ? ' (band re-centred on the densest wall-return height)' : ''}.`
-        : `No dominant floor plane — floor level estimated from the lowest dense returns; walls traced from the ${slice.bandLowUsedM.toFixed(1)}–${slice.bandHighUsedM.toFixed(1)} m slice above it${bandAdapted ? ' (band re-centred on the densest wall-return height)' : ''}.`
-      : 'No floor-anchored wall band could be cut — walls traced from the full-height point density instead.',
-  );
+  const adaptedNote = bandAdapted ? ' (band re-centred on the densest wall-return height)' : '';
+  let wallBandReason: string;
+  if (!slice.usedWallBand) {
+    wallBandReason = 'No floor-anchored wall band could be cut — walls traced from the full-height point density instead.';
+  } else if (slice.floorBasis === 'histogram') {
+    wallBandReason = `Walls traced from the point slice ${slice.bandLowUsedM.toFixed(1)}–${slice.bandHighUsedM.toFixed(1)} m above the detected floor${adaptedNote}.`;
+  } else {
+    wallBandReason = `No dominant floor plane — floor level estimated from the lowest dense returns; walls traced from the ${slice.bandLowUsedM.toFixed(1)}–${slice.bandHighUsedM.toFixed(1)} m slice above it${adaptedNote}.`;
+  }
+  reasons.push(wallBandReason);
   if (slice.clippedCount > 0) {
     reasons.push(
       `${slice.clippedCount.toLocaleString()} stray return(s) outside the dense footprint were excluded as outliers.`,
     );
   }
-  reasons.push(
-    snap.mode === 'off'
-      ? 'Axis snapping disabled (SNAP_MODE off) — wall directions left exactly as traced.'
-      : snap.forced && axes
-        ? 'Wall directions FORCED onto the strongest axis pair (SNAP_MODE strong) — the auto bimodal gates did not pass, so right angles may be assumed where the scan shows none.'
-        : axes
-          ? 'Wall directions snapped to the two dominant perpendicular axes (within ±7°).'
-          : 'Wall directions left as traced — no two dominant perpendicular directions found, so no right angles were assumed.',
-  );
+  let snapReason: string;
+  if (snap.mode === 'off') {
+    snapReason = 'Axis snapping disabled (SNAP_MODE off) — wall directions left exactly as traced.';
+  } else if (snap.forced && axes) {
+    snapReason = 'Wall directions FORCED onto the strongest axis pair (SNAP_MODE strong) — the auto bimodal gates did not pass, so right angles may be assumed where the scan shows none.';
+  } else if (axes) {
+    snapReason = 'Wall directions snapped to the two dominant perpendicular axes (within ±7°).';
+  } else {
+    snapReason = 'Wall directions left as traced — no two dominant perpendicular directions found, so no right angles were assumed.';
+  }
+  reasons.push(snapReason);
   if (thicknessNormalized) {
     reasons.push(
       `Echo-fattened wall mass (a wall scanned from both sides reads double) was collapsed onto its centerline at the measured ~${norm.medianThicknessM.toFixed(2)} m wall thickness (${removedM2.toFixed(1)} m² removed).`,
@@ -727,8 +732,10 @@ export function extractFloorPlan(
     );
   }
   if (rooms.length > 0) {
+    const doorwayNote =
+      roomsDet.closedDoorways > 0 ? ` and ${roomsDet.closedDoorways} closed doorway span(s)` : '';
     reasons.push(
-      `${rooms.length} room(s) segmented by flood fill bounded by the walls${roomsDet.closedDoorways > 0 ? ` and ${roomsDet.closedDoorways} closed doorway span(s)` : ''}; unknown gaps are never closed, so an unscanned divider merges its regions instead of fabricating a wall. Room areas are measured on the region mask.`,
+      `${rooms.length} room(s) segmented by flood fill bounded by the walls${doorwayNote}; unknown gaps are never closed, so an unscanned divider merges its regions instead of fabricating a wall. Room areas are measured on the region mask.`,
     );
   } else if (roomsDet.segmentation === 'open-space') {
     // HONESTY: one connected interior region dominates the floor — present it

--- a/src/terrain/space/floorplan/floorPlanConfidence.ts
+++ b/src/terrain/space/floorplan/floorPlanConfidence.ts
@@ -47,7 +47,9 @@ export interface FloorPlanConfidence {
 }
 
 function bandLabel(b: FloorPlanConfidenceBand): string {
-  return b === 'good' ? 'Good' : b === 'moderate' ? 'Moderate' : 'Low';
+  if (b === 'good') return 'Good';
+  if (b === 'moderate') return 'Moderate';
+  return 'Low';
 }
 
 /** Derive the presentation summary from a built floor-plan model. */
@@ -57,8 +59,16 @@ export function floorPlanConfidence(model: FloorPlanModel): FloorPlanConfidence 
   const weakWallPct = walls > 0 ? Math.round((100 * weakCount) / walls) : 100;
 
   // Trust band from the weak-wall share; no walls at all ⇒ low.
-  const band: FloorPlanConfidenceBand =
-    walls === 0 ? 'low' : weakWallPct <= 20 ? 'good' : weakWallPct <= 50 ? 'moderate' : 'low';
+  let band: FloorPlanConfidenceBand;
+  if (walls === 0) {
+    band = 'low';
+  } else if (weakWallPct <= 20) {
+    band = 'good';
+  } else if (weakWallPct <= 50) {
+    band = 'moderate';
+  } else {
+    band = 'low';
+  }
 
   let roomsLabel: string;
   let roomCount: number | null;

--- a/src/terrain/space/floorplan/floorPlanSvg.ts
+++ b/src/terrain/space/floorplan/floorPlanSvg.ts
@@ -104,11 +104,11 @@ export function regionAreaReconcileScale(
 /** XML-escape a string for safe insertion into SVG text / attributes. */
 export function escapeXml(s: string): string {
   return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+    .replaceAll(/&/g, '&amp;')
+    .replaceAll(/</g, '&lt;')
+    .replaceAll(/>/g, '&gt;')
+    .replaceAll(/"/g, '&quot;')
+    .replaceAll(/'/g, '&#39;');
 }
 
 /** Greedy word-wrap (the footer has no DOM to measure text with). */
@@ -356,15 +356,15 @@ export function floorPlanSvg(model: FloorPlanModel, opts: FloorPlanSvgOptions = 
   const parts: string[] = [];
   parts.push(
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${totalH}" width="${W}" height="${totalH}" font-family="Helvetica, Arial, sans-serif">`,
+    `<rect x="0" y="0" width="${W}" height="${totalH}" fill="#ffffff"/>`,
   );
-  parts.push(`<rect x="0" y="0" width="${W}" height="${totalH}" fill="#ffffff"/>`);
 
   // ── Title ──
   const title = escapeXml((opts.title ?? 'Floor plan preview').trim() || 'Floor plan preview');
-  parts.push(`<text x="${pad}" y="28" font-size="18" font-weight="bold" fill="${INK}">${title}</text>`);
   // Claim-accurate subtitle: "wall-graph reconstruction" only when the walls
   // really were re-extruded from the centerline graph; still a preview.
   parts.push(
+    `<text x="${pad}" y="28" font-size="18" font-weight="bold" fill="${INK}">${title}</text>`,
     `<text x="${pad}" y="46" font-size="11" fill="${DIM}">Floor Plan Preview — ${
       model.fromWallGraph ? 'wall-graph reconstruction' : 'approximate wall-trace sketch'
     } (top-down)</text>`,
@@ -478,11 +478,9 @@ export function floorPlanSvg(model: FloorPlanModel, opts: FloorPlanSvgOptions = 
     const dimLabelY = (dimY - 4).toFixed(1);
     const depthLabelX = (dimX - 4).toFixed(1);
     const depthLabelY = ((yT + yB) / 2).toFixed(1);
-    parts.push(`<g class="plan-dims"><path d="${dd.trim()}" fill="none" stroke="${INK}" stroke-width="0.55"/>`);
     parts.push(
+      `<g class="plan-dims"><path d="${dd.trim()}" fill="none" stroke="${INK}" stroke-width="0.55"/>`,
       `<text x="${((x0 + x1) / 2).toFixed(1)}" y="${dimLabelY}" font-size="10" text-anchor="middle" fill="${INK}">${escapeXml(lengthLabel(model.widthM, unitSystem))}</text>`,
-    );
-    parts.push(
       `<text x="${depthLabelX}" y="${depthLabelY}" font-size="10" text-anchor="middle" fill="${INK}" transform="rotate(-90 ${depthLabelX} ${depthLabelY})">${escapeXml(lengthLabel(model.depthM, unitSystem))}</text></g>`,
     );
     // ── Room labels: "Room N · 12.3 m²" at each segmented room's pole of
@@ -608,8 +606,8 @@ export function floorPlanSvg(model: FloorPlanModel, opts: FloorPlanSvgOptions = 
         const barPx = barM * scale;
         const bx = W - pad - barPx;
         const by = drawTop + drawH + 18;
-        parts.push(`<rect x="${bx.toFixed(1)}" y="${by.toFixed(1)}" width="${barPx.toFixed(1)}" height="6" fill="${INK}"/>`);
         parts.push(
+          `<rect x="${bx.toFixed(1)}" y="${by.toFixed(1)}" width="${barPx.toFixed(1)}" height="6" fill="${INK}"/>`,
           `<text x="${(bx + barPx).toFixed(1)}" y="${(by - 4).toFixed(1)}" font-size="10" text-anchor="end" fill="${INK}">${escapeXml(barText)}</text>`,
         );
       }
@@ -653,15 +651,17 @@ export function floorPlanSvg(model: FloorPlanModel, opts: FloorPlanSvgOptions = 
       model.floorAreaM2 != null
         ? `Floor area ${areaLabel(model.floorAreaM2, unitSystem)} (approx.)`
         : 'Floor area: not measured';
+    const overallTxt = `Overall ${lengthLabel(model.widthM, unitSystem)} x ${lengthLabel(model.depthM, unitSystem)}`;
+    const previewNote = `${dateTxt} · Floor plan preview — not for construction`;
     parts.push(
       `<g class="title-block">` +
         `<rect x="${tbX}" y="${tbY}" width="${tbW}" height="${tbH}" fill="#ffffff" stroke="${INK}" stroke-width="1"/>` +
         `<line x1="${tbX}" y1="${tbY + 21}" x2="${tbX + tbW}" y2="${tbY + 21}" stroke="${INK}" stroke-width="0.55"/>` +
         `<text x="${tbX + 8}" y="${tbY + 15}" font-size="11" font-weight="bold" fill="${INK}">${escapeXml(tbTitle)}</text>` +
-        `<text x="${tbX + 8}" y="${tbY + 34}" font-size="8.5" fill="${INK}">${escapeXml(`Overall ${lengthLabel(model.widthM, unitSystem)} x ${lengthLabel(model.depthM, unitSystem)}`)}</text>` +
+        `<text x="${tbX + 8}" y="${tbY + 34}" font-size="8.5" fill="${INK}">${escapeXml(overallTxt)}</text>` +
         `<text x="${tbX + 8}" y="${tbY + 46}" font-size="8.5" fill="${INK}">${escapeXml(areaTxt)}</text>` +
         `<text x="${tbX + 8}" y="${tbY + 58}" font-size="8.5" fill="${INK}">${escapeXml(scaleTxt)}</text>` +
-        `<text x="${tbX + 8}" y="${tbY + 70}" font-size="8.5" fill="${DIM}">${escapeXml(`${dateTxt} · Floor plan preview — not for construction`)}</text>` +
+        `<text x="${tbX + 8}" y="${tbY + 70}" font-size="8.5" fill="${DIM}">${escapeXml(previewNote)}</text>` +
         `</g>`,
     );
   }

--- a/src/terrain/space/floorplan/occupancyGrid.ts
+++ b/src/terrain/space/floorplan/occupancyGrid.ts
@@ -124,8 +124,8 @@ export function buildOccupancyMask(
       counts[r * cols + c]++;
     }
     let occupied = 0, total = 0;
-    for (let i = 0; i < counts.length; i++) {
-      if (counts[i] > 0) { occupied++; total += counts[i]; }
+    for (const cnt of counts) {
+      if (cnt > 0) { occupied++; total += cnt; }
     }
     if (occupied === 0) return null;
     return { counts, cols, rows, cellX, cellY, occupied, total };
@@ -183,8 +183,8 @@ export function buildCellHeightProfile(
 ): { zMin: Float32Array; zMax: Float32Array } {
   const { cols, rows, cellX, cellY, originX, originY } = grid;
   const n = cols * rows;
-  const zMin = new Float32Array(n).fill(NaN);
-  const zMax = new Float32Array(n).fill(NaN);
+  const zMin = new Float32Array(n).fill(Number.NaN);
+  const zMax = new Float32Array(n).fill(Number.NaN);
   for (let i = 0; i < count; i++) {
     let c = Math.floor((xs[i] - originX) / cellX);
     if (c < 0) c = 0; else if (c >= cols) c = cols - 1;
@@ -194,8 +194,13 @@ export function buildCellHeightProfile(
     const z = zs[i];
     // NaN-initialised cells: first hit seeds both bounds (NaN comparisons are
     // false, so an explicit empty test is needed).
-    if (Number.isNaN(zMin[k])) { zMin[k] = z; zMax[k] = z; }
-    else { if (z < zMin[k]) zMin[k] = z; if (z > zMax[k]) zMax[k] = z; }
+    if (Number.isNaN(zMin[k])) {
+      zMin[k] = z;
+      zMax[k] = z;
+    } else {
+      if (z < zMin[k]) zMin[k] = z;
+      if (z > zMax[k]) zMax[k] = z;
+    }
   }
   return { zMin, zMax };
 }
@@ -203,7 +208,7 @@ export function buildCellHeightProfile(
 /** Occupied area of the mask in m² (cells × exact cell area). */
 export function maskAreaM2(grid: OccupancyGrid): number {
   let occ = 0;
-  for (let i = 0; i < grid.mask.length; i++) if (grid.mask[i]) occ++;
+  for (const cell of grid.mask) if (cell) occ++;
   return occ * grid.cellX * grid.cellY;
 }
 

--- a/src/terrain/space/floorplan/regularize.ts
+++ b/src/terrain/space/floorplan/regularize.ts
@@ -258,14 +258,14 @@ export function convexHullRing(ring: Ring): Ring {
   ): number => (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
   const lower: Array<readonly [number, number]> = [];
   for (const p of pts) {
-    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0)
+    while (lower.length >= 2 && cross(lower.at(-2)!, lower.at(-1)!, p) <= 0)
       lower.pop();
     lower.push(p);
   }
   const upper: Array<readonly [number, number]> = [];
   for (let i = pts.length - 1; i >= 0; i--) {
     const p = pts[i];
-    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0)
+    while (upper.length >= 2 && cross(upper.at(-2)!, upper.at(-1)!, p) <= 0)
       upper.pop();
     upper.push(p);
   }
@@ -425,8 +425,14 @@ export function removeSpikes(ring: Ring, minLenM: number): Ring {
           const i1 = (i + 1) % n, i2 = (i + 2) % n;
           const next: Array<readonly [number, number]> = [];
           for (let k = 0; k < n; k++) {
-            if (k === i1) { if (nb) next.push(nb); continue; }
-            if (k === i2) { if (nc) next.push(nc); continue; }
+            if (k === i1) {
+              if (nb) next.push(nb);
+              continue;
+            }
+            if (k === i2) {
+              if (nc) next.push(nc);
+              continue;
+            }
             next.push(pts[k]);
           }
           pts = next;

--- a/src/terrain/space/floorplan/vectorize.ts
+++ b/src/terrain/space/floorplan/vectorize.ts
@@ -435,12 +435,12 @@ export function snapRingToAxes(ring: Ring, thetaRad: number, tolDeg = SNAP_TOL_D
 export function dedupeRing(ring: Ring, epsilon = 1e-9): Ring {
   const out: Array<readonly [number, number]> = [];
   for (const p of ring) {
-    const last = out[out.length - 1];
+    const last = out.at(-1);
     if (!last || Math.hypot(p[0] - last[0], p[1] - last[1]) > epsilon) out.push(p);
   }
   while (
     out.length > 1 &&
-    Math.hypot(out[0][0] - out[out.length - 1][0], out[0][1] - out[out.length - 1][1]) <= epsilon
+    Math.hypot(out[0][0] - out.at(-1)![0], out[0][1] - out.at(-1)![1]) <= epsilon
   ) {
     out.pop();
   }

--- a/src/terrain/space/floorplan/wallGraph.ts
+++ b/src/terrain/space/floorplan/wallGraph.ts
@@ -155,12 +155,22 @@ export function snapChainToAxes(
       // End segments next to a FIXED anchor take that vertex's coordinate as
       // their line (the anchor cannot move); free ends and interior segments
       // settle on the segment mean.
-      target[i] =
-        i === 0 && fixStart ? y1 : i === nSeg - 1 && fixEnd ? y2 : (y1 + y2) / 2;
+      if (i === 0 && fixStart) {
+        target[i] = y1;
+      } else if (i === nSeg - 1 && fixEnd) {
+        target[i] = y2;
+      } else {
+        target[i] = (y1 + y2) / 2;
+      }
     } else if (dV <= tol) {
       cls[i] = 'v';
-      target[i] =
-        i === 0 && fixStart ? x1 : i === nSeg - 1 && fixEnd ? x2 : (x1 + x2) / 2;
+      if (i === 0 && fixStart) {
+        target[i] = x1;
+      } else if (i === nSeg - 1 && fixEnd) {
+        target[i] = x2;
+      } else {
+        target[i] = (x1 + x2) / 2;
+      }
     } else {
       cls[i] = 'o';
       target[i] = 0;
@@ -191,7 +201,7 @@ export function snapChainToAxes(
   // Drop interior vertices the snap made (near-)duplicate.
   const dedup: Array<readonly [number, number]> = [out[0]];
   for (let i = 1; i < out.length; i++) {
-    const last = dedup[dedup.length - 1];
+    const last = dedup.at(-1)!;
     const isLast = i === out.length - 1;
     if (isLast || Math.hypot(out[i][0] - last[0], out[i][1] - last[1]) > 1e-9) dedup.push(out[i]);
   }
@@ -322,9 +332,9 @@ export function buildWallGraph(
     for (let steps = 0; steps < n && cur !== undefined && cur !== start; steps++) {
       visited[cur] = 1;
       cells.push(cur);
-      const nb = skelNeighbours(skeleton, cols, rows, cur).filter((k) => k !== prev && !visited[k]);
+      const nb = skelNeighbours(skeleton, cols, rows, cur).find((k) => k !== prev && !visited[k]);
       prev = cur;
-      cur = nb[0] ?? skelNeighbours(skeleton, cols, rows, prev).find((k) => k === start) ?? -1;
+      cur = nb ?? skelNeighbours(skeleton, cols, rows, prev).find((k) => k === start) ?? -1;
       if (cur === -1) break;
     }
     cells.push(start); // close the loop on its anchor
@@ -332,7 +342,7 @@ export function buildWallGraph(
   }
 
   // ── Per-edge attributes + straightening ──
-  const raw = opts.raw && opts.raw.cols === cols && opts.raw.rows === rows ? opts.raw : null;
+  const raw = opts.raw?.cols === cols && opts.raw?.rows === rows ? opts.raw : null;
   const observedAt = (i: number): boolean => {
     if (!raw) return true;
     const r = (i / cols) | 0;

--- a/src/terrain/space/floorplan/wallSlice.ts
+++ b/src/terrain/space/floorplan/wallSlice.ts
@@ -124,8 +124,11 @@ export interface WallSlice {
 }
 
 /** Same up-frame offset convention as spaceMetrics (vertical, horizontal1/2). */
-const upOffsets = (a: Axis): { v: number; h1: number; h2: number } =>
-  a === 'x' ? { v: 0, h1: 1, h2: 2 } : a === 'y' ? { v: 1, h1: 0, h2: 2 } : { v: 2, h1: 0, h2: 1 };
+const upOffsets = (a: Axis): { v: number; h1: number; h2: number } => {
+  if (a === 'x') return { v: 0, h1: 1, h2: 2 };
+  if (a === 'y') return { v: 1, h1: 0, h2: 2 };
+  return { v: 2, h1: 0, h2: 1 };
+};
 
 /** Histogram bins — matches spaceMetrics so both agree on the floor peak. */
 const HIST_BINS = 64;
@@ -384,7 +387,7 @@ export function denseFootprintBbox(
       if (r > kMaxR) kMaxR = r;
     }
   }
-  if (!(kMaxC >= kMinC) || !(kMaxR >= kMinR)) return null;
+  if (kMaxC < kMinC || kMaxR < kMinR) return null;
   // One-cell margin so border points straddling a kept cell's edge survive.
   return [
     minX + (kMinC - 1) * cellX,
@@ -521,8 +524,10 @@ export function wallSlice(
       const adapt = detectWallBand(V, anchor, bandHigh - bandLow, defaultCentreM);
       if (adapt) candidates.push({ bl: adapt.lowM, bh: adapt.highM, basis: 'adaptive' });
     }
-    candidates.push({ bl: bandLow, bh: bandHigh, basis: 'fixed' });
-    candidates.push({ bl: WIDE_BAND_LOW_M, bh: WIDE_BAND_HIGH_M, basis: 'fixed' });
+    candidates.push(
+      { bl: bandLow, bh: bandHigh, basis: 'fixed' },
+      { bl: WIDE_BAND_LOW_M, bh: WIDE_BAND_HIGH_M, basis: 'fixed' },
+    );
     for (const { bl, bh, basis } of candidates) {
       if (countInBand(anchor + bl, anchor + bh) >= MIN_BAND_POINTS) {
         lo = anchor + bl;

--- a/src/terrain/spaceMetrics.ts
+++ b/src/terrain/spaceMetrics.ts
@@ -153,8 +153,11 @@ const PARTIAL_STREAM_CAVEAT =
 const UNVERIFIED_UNIT_CAVEAT =
   'Coordinate units are unverified — dimensions, areas, volumes and densities assume metres. Confirm the source CRS before relying on the figures.';
 
-const upOffsets = (a: Axis): { v: number; h1: number; h2: number } =>
-  a === 'x' ? { v: 0, h1: 1, h2: 2 } : a === 'y' ? { v: 1, h1: 0, h2: 2 } : { v: 2, h1: 0, h2: 1 };
+const upOffsets = (a: Axis): { v: number; h1: number; h2: number } => {
+  if (a === 'x') return { v: 0, h1: 1, h2: 2 };
+  if (a === 'y') return { v: 1, h1: 0, h2: 2 };
+  return { v: 2, h1: 0, h2: 1 };
+};
 
 /** 2-D PCA on the horizontal projection → oriented footprint side lengths. */
 function orientedFootprint(h1: number[], h2: number[]): { major: number; minor: number } {
@@ -183,8 +186,10 @@ function orientedFootprint(h1: number[], h2: number[]): { major: number; minor: 
     const dx = h1[i] - cx, dy = h2[i] - cy;
     const p1 = dx * ax + dy * ay;
     const p2 = dx * bx + dy * by;
-    if (p1 < lo1) lo1 = p1; if (p1 > hi1) hi1 = p1;
-    if (p2 < lo2) lo2 = p2; if (p2 > hi2) hi2 = p2;
+    if (p1 < lo1) lo1 = p1;
+    if (p1 > hi1) hi1 = p1;
+    if (p2 < lo2) lo2 = p2;
+    if (p2 > hi2) hi2 = p2;
   }
   const r1 = Math.max(0, hi1 - lo1);
   const r2 = Math.max(0, hi2 - lo2);
@@ -223,7 +228,7 @@ function countStoreys(hist: Float64Array, binW: number, minV: number, total: num
   // Merge peaks closer than one storey, keeping the stronger.
   const merged: Array<{ level: number; count: number }> = [];
   for (const p of peaks) {
-    const last = merged[merged.length - 1];
+    const last = merged.at(-1);
     if (!last || p.level - last.level >= STOREY_SEP_M) merged.push({ ...p });
     else if (p.count > last.count) { last.level = p.level; last.count = p.count; }
   }
@@ -338,9 +343,12 @@ export function spaceMetrics(
 
   let minH1 = Infinity, maxH1 = -Infinity, minH2 = Infinity, maxH2 = -Infinity, minV = Infinity, maxV = -Infinity;
   for (let i = 0; i < V.length; i++) {
-    if (H1[i] < minH1) minH1 = H1[i]; if (H1[i] > maxH1) maxH1 = H1[i];
-    if (H2[i] < minH2) minH2 = H2[i]; if (H2[i] > maxH2) maxH2 = H2[i];
-    if (V[i] < minV) minV = V[i]; if (V[i] > maxV) maxV = V[i];
+    if (H1[i] < minH1) minH1 = H1[i];
+    if (H1[i] > maxH1) maxH1 = H1[i];
+    if (H2[i] < minH2) minH2 = H2[i];
+    if (H2[i] > maxH2) maxH2 = H2[i];
+    if (V[i] < minV) minV = V[i];
+    if (V[i] > maxV) maxV = V[i];
   }
   const m = V.length;
 
@@ -390,7 +398,7 @@ export function spaceMetrics(
     if (V[i] > zMax[idx]) zMax[idx] = V[i];
   }
   let occupied = 0;
-  for (let i = 0; i < occ.length; i++) if (occ[i]) occupied++;
+  for (const o of occ) if (o) occupied++;
   const floorAreaM2 = occupied * cellArea;
   const coveragePct = (100 * occupied) / (cols * rows);
 

--- a/src/terrain/surface/buildDsm.ts
+++ b/src/terrain/surface/buildDsm.ts
@@ -53,8 +53,7 @@ export function buildDsm(points: ReadonlyArray<TerrainPoint>, params: BuildDsmPa
   const coverage = new Uint8Array(n);
   const cell = cellSizeM > 0 ? cellSizeM : 1;
 
-  for (let i = 0; i < points.length; i++) {
-    const p = points[i];
+  for (const p of points) {
     const h1 = getH1(p);
     const h2 = getH2(p);
     const v = getV(p);

--- a/src/terrain/surface/coverageHeatmap.ts
+++ b/src/terrain/surface/coverageHeatmap.ts
@@ -25,7 +25,6 @@
  */
 
 import {
-  EVIDENCE_THRESHOLDS,
   gradeForConfidence,
   type EvidenceGrade,
 } from '../ground/cellConfidence';
@@ -166,4 +165,4 @@ export function coverageHeatmapImage(
 
 // Re-export the threshold object so a consumer can read the cutoffs without
 // reaching past the rasteriser into the confidence leaf.
-export { EVIDENCE_THRESHOLDS };
+export { EVIDENCE_THRESHOLDS } from '../ground/cellConfidence';

--- a/src/terrain/surface/hillshade.ts
+++ b/src/terrain/surface/hillshade.ts
@@ -133,8 +133,8 @@ export function computeMultiHillshade(
     const ss = Math.sin(slopeRad);
     let wsum = 0;
     let hsum = 0;
-    for (let k = 0; k < azRad.length; k++) {
-      const align = Math.cos(azRad[k] - asp); // -1..1
+    for (const az of azRad) {
+      const align = Math.cos(az - asp); // -1..1
       const w = 0.5 + 0.5 * Math.max(0, align); // favour the lit side
       const hs = cosZen * cs + sinZen * ss * align;
       hsum += w * Math.max(0, hs);

--- a/src/terrain/validate/calibrateConfidence.ts
+++ b/src/terrain/validate/calibrateConfidence.ts
@@ -190,7 +190,7 @@ function buildCurve(
   const remap = (rawConfidence: number): number => {
     const c = clamp(rawConfidence, 0, 100);
     if (c <= curve[0].rawConfidence) return curve[0].calibrated;
-    const last = curve[curve.length - 1];
+    const last = curve.at(-1)!;
     if (c >= last.rawConfidence) return last.calibrated;
     for (let i = 1; i < curve.length; i++) {
       const a = curve[i - 1];
@@ -334,7 +334,7 @@ export function applyConfidenceCalibration(
   // facts in the warning when the evaluation is available.
   const ev = calibration.evaluation;
   const evNote =
-    ev && ev.crossValidated
+    ev?.crossValidated
       ? `; quality assessed out-of-fold (${ev.folds}-fold cross-fit, ${ev.sampleSize} samples: reliability ${(ev.reliability * 100).toFixed(0)}%, Brier ${ev.brier.toFixed(3)})`
       : '';
   return {
@@ -363,7 +363,7 @@ function poolAdjacentViolators(
   const blocks: Array<{ x: number; y: number; w: number }> = [];
   for (const p of pts) {
     let cur = { x: p.x, y: p.y, w: p.w };
-    while (blocks.length > 0 && blocks[blocks.length - 1].y > cur.y) {
+    while (blocks.length > 0 && blocks.at(-1)!.y > cur.y) {
       const prev = blocks.pop() as { x: number; y: number; w: number };
       const w = prev.w + cur.w;
       cur = { x: cur.x, y: (prev.y * prev.w + cur.y * cur.w) / w, w };
@@ -375,5 +375,5 @@ function poolAdjacentViolators(
 
 function clamp(v: number, lo: number, hi: number): number {
   if (!Number.isFinite(v)) return lo;
-  return v < lo ? lo : v > hi ? hi : v;
+  return Math.min(hi, Math.max(lo, v));
 }

--- a/src/terrain/validate/dtmSurfaceModel.ts
+++ b/src/terrain/validate/dtmSurfaceModel.ts
@@ -101,8 +101,16 @@ export class DtmSurfaceModel implements SurfaceModel {
     const row0 = Math.floor(fy);
     const tx = fx - col0;
     const ty = fy - row0;
-    const clampCol = (c: number) => (c < 0 ? 0 : c >= cols ? cols - 1 : c);
-    const clampRow = (r: number) => (r < 0 ? 0 : r >= rows ? rows - 1 : r);
+    const clampCol = (c: number): number => {
+      if (c < 0) return 0;
+      if (c >= cols) return cols - 1;
+      return c;
+    };
+    const clampRow = (r: number): number => {
+      if (r < 0) return 0;
+      if (r >= rows) return rows - 1;
+      return r;
+    };
     const corners: ReadonlyArray<readonly [number, number, number]> = [
       [clampCol(col0), clampRow(row0), (1 - tx) * (1 - ty)],
       [clampCol(col0 + 1), clampRow(row0), tx * (1 - ty)],

--- a/src/terrain/validate/holdoutRmse.ts
+++ b/src/terrain/validate/holdoutRmse.ts
@@ -220,11 +220,11 @@ export function holdoutValidateDtm(
     } catch {
       newMask = null;
     }
-    if (!newMask || newMask.length !== points.length) {
+    if (newMask?.length !== points.length) {
       warnings.push(
         'reclassifyGround returned an invalid mask; falling back to full-cloud classification',
+        FULL_CLOUD_CLASSIFICATION_WARNING,
       );
-      warnings.push(FULL_CLOUD_CLASSIFICATION_WARNING);
     } else {
       const reTrain: TerrainPoint[] = [];
       for (let i = 0; i < points.length; i++) {
@@ -239,8 +239,8 @@ export function holdoutValidateDtm(
       if (reTrain.length === 0) {
         warnings.push(
           'train-only reclassification produced no ground points; falling back to full-cloud classification',
+          FULL_CLOUD_CLASSIFICATION_WARNING,
         );
-        warnings.push(FULL_CLOUD_CLASSIFICATION_WARNING);
       } else {
         fitTrain = reTrain;
         warnings.push(
@@ -353,8 +353,16 @@ export function holdoutValidateDtm(
   // renormalised over the covered corners, so a point near a data edge
   // still predicts from the corners that exist instead of snapping to
   // one cell. This removes grid-quantisation bias from the RMSE.
-  const clampCol = (c: number) => (c < 0 ? 0 : c >= cols ? cols - 1 : c);
-  const clampRow = (r: number) => (r < 0 ? 0 : r >= rows ? rows - 1 : r);
+  const clampCol = (c: number): number => {
+    if (c < 0) return 0;
+    if (c >= cols) return cols - 1;
+    return c;
+  };
+  const clampRow = (r: number): number => {
+    if (r < 0) return 0;
+    if (r >= rows) return rows - 1;
+    return r;
+  };
   for (const p of test) {
     const fx = (getH1(p) - minH1) / cellSizeM - 0.5;
     const fy = (getH2(p) - minH2) / cellSizeM - 0.5;

--- a/src/terrain/worker/terrainCoreWorkerClient.ts
+++ b/src/terrain/worker/terrainCoreWorkerClient.ts
@@ -130,7 +130,6 @@ export class TerrainCoreWorkerClient {
       // Strip classification from coreParams; it is carried as its own field so
       // the worker can re-attach it (avoids cloning it twice).
       const { classification: _drop, ...paramsNoClass } = coreParams;
-      void _drop;
       try {
         worker.postMessage(
           {

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -67,6 +67,8 @@ import {
   loadContourDownload,
   loadExportProvenance,
   loadContourDeliverableBuild,
+  loadContourStudioMount,
+  loadContourExportAdapter,
 } from '../lazyChunks';
 import { openModal, type ModalHandle } from './Modal';
 import type { SheetSize, SheetOrientation, MapSheetPurpose } from '../render/measure/mapSheetPdf';
@@ -102,7 +104,6 @@ import {
   renderWorkflowCard,
   renderWhyDetails,
 } from './workflowCardRender';
-import { loadContourStudioMount } from '../lazyChunks';
 import type {
   LaunchFrameContext,
   ContourStudioExportProduct,
@@ -119,7 +120,6 @@ import {
 } from '../export/exportScanIdentity';
 import type { ExportPermitStamp } from '../terrain/export/exportProvenance';
 import type { ContourExportAdapter, ContourExportHost } from './contourExportAdapter';
-import { loadContourExportAdapter } from '../lazyChunks';
 import type { SpaceKind } from '../terrain/scanShape';
 import type { ScanTypeOverride } from '../terrain/scanRoute';
 import type { DatasetIntelligence } from '../terrain/datasetIntelligence';
@@ -289,7 +289,7 @@ let lastNotes: string | null = null;
  *   "Not ready"    → { num: "Not ready", unit: "" }  (no leading digit)
  */
 export function splitReadinessValue(value: string): { num: string; unit: string } {
-  const m = value.match(/^(\d+(?:\.\d+)?)\s*(.*)$/);
+  const m = /^(\d+(?:\.\d+)?)\s*(.*)$/.exec(value);
   if (!m) return { num: value, unit: '' };
   return { num: m[1], unit: m[2].trim() };
 }
@@ -784,8 +784,14 @@ export class AnalysePanel {
     // a datum-less but clean scan reads "Surface quality: Good · Export
     // readiness: Preview — vertical datum unknown". Colour reuses the rating
     // tokens (good / moderate / blocked), never a new hardcoded colour.
-    const exportTier =
-      a.exportReadiness === 'Ready' ? 'good' : a.exportReadiness === 'Blocked' ? 'blocked' : 'preview';
+    let exportTier: 'good' | 'blocked' | 'preview';
+    if (a.exportReadiness === 'Ready') {
+      exportTier = 'good';
+    } else if (a.exportReadiness === 'Blocked') {
+      exportTier = 'blocked';
+    } else {
+      exportTier = 'preview';
+    }
     const exportLine = el('div', { className: `olv-analyse-assess-export is-${exportTier}` });
     exportLine.append(
       el('span', { className: 'olv-analyse-assess-export-label', text: 'Export readiness' }),
@@ -856,7 +862,7 @@ export class AnalysePanel {
     // `.olv-caveat` honesty treatment; nothing renders when the run
     // measured nothing (no fabricated band).
     const cx = this._result.complexity;
-    if (cx && cx.band) {
+    if (cx?.band) {
       const line = el('div', { className: 'olv-analyse-derived' });
       line.append(
         el('span', { className: 'olv-analyse-derived-label', text: 'Derived complexity' }),
@@ -1201,7 +1207,14 @@ export class AnalysePanel {
       } else {
         const conf = r.dtm.confidence[i];
         const grade = gradeForConfidence(conf);
-        const support = grade === 'solid' ? 'strong' : grade === 'dashed' ? 'moderate' : 'weak';
+        let support: 'strong' | 'moderate' | 'weak';
+        if (grade === 'solid') {
+          support = 'strong';
+        } else if (grade === 'dashed') {
+          support = 'moderate';
+        } else {
+          support = 'weak';
+        }
         const c = Number.isFinite(conf) ? Math.round(conf) : 0;
         readout.textContent = `Sample · ${support} support · confidence ${c}% (${confidenceWord(conf)})`;
         readout.classList.remove('is-empty');
@@ -1511,7 +1524,7 @@ export class AnalysePanel {
       const row = rows - 1 - displayRow; // undo the north-up flip
       const sample = sampleTerrain(r, col, row);
       readout.textContent = this._sampleReadoutText(sample);
-      readout.classList.toggle('is-empty', !sample || !sample.covered);
+      readout.classList.toggle('is-empty', !sample?.covered);
       // Drop the crosshair at the click point — percentages survive resize.
       crosshair.style.left = `${(fx * 100).toFixed(2)}%`;
       crosshair.style.top = `${(fy * 100).toFixed(2)}%`;
@@ -1651,7 +1664,7 @@ export class AnalysePanel {
     );
 
     const figure = el('div', {
-      className: `olv-analyse-ready-figure${num.match(/\d/) ? '' : ' is-text'}`,
+      className: `olv-analyse-ready-figure${/\d/.exec(num) ? '' : ' is-text'}`,
     });
     figure.append(el('span', { className: 'olv-analyse-ready-value', text: num }));
     if (unitText) figure.append(el('span', { className: 'olv-analyse-ready-unit', text: unitText }));
@@ -1715,10 +1728,17 @@ export class AnalysePanel {
     if (!this._result) return null;
     const a = terrainAssessment(this._result);
     const workflows = recommendedWorkflows(a, this._result.quality);
-    const products: StoryProduct[] = terrainProducts(a, workflows).map((p) => ({
-      label: p.label,
-      status: p.status === 'ready' ? 'Ready' : p.status === 'preview' ? 'Preview' : 'Blocked',
-    }));
+    const products: StoryProduct[] = terrainProducts(a, workflows).map((p) => {
+      let status: StoryProduct['status'];
+      if (p.status === 'ready') {
+        status = 'Ready';
+      } else if (p.status === 'preview') {
+        status = 'Preview';
+      } else {
+        status = 'Blocked';
+      }
+      return { label: p.label, status };
+    });
     const tier: FitnessTier =
       a.status === 'Good' || a.status === 'Preview' || a.status === 'Limited' || a.status === 'Blocked'
         ? a.status
@@ -1766,11 +1786,14 @@ export class AnalysePanel {
       reasonWhenAbsent: 'Not enough ground points to cross-validate.',
     });
     const cal = this._result?.confidenceOrdering;
-    const calText = cal?.assessable
-      ? cal.orderingConsistent
+    let calText: string;
+    if (cal?.assessable) {
+      calText = cal.orderingConsistent
         ? 'Confidence ordering is consistent with held-out error.'
-        : 'Warning: confidence does not track error here.'
-      : 'Confidence ordering not assessable on this scan.';
+        : 'Warning: confidence does not track error here.';
+    } else {
+      calText = 'Confidence ordering not assessable on this scan.';
+    }
     this._validationRow.append(
       this._hint(
         el('div', { className: 'olv-analyse-rmse', text: `Vertical RMSE: ${rmse.text}` }),
@@ -1966,7 +1989,7 @@ export class AnalysePanel {
     // This replaces the old ad-hoc `exportReadiness === 'blocked'` check with the
     // single authoritative gate, so no serialize path can bypass the registry.
     const permit = provenanceExtra?.permit ?? null;
-    if (!permit || !permit.ok) {
+    if (!permit?.ok) {
       // eslint-disable-next-line no-console
       console.warn(
         'OpenLiDARViewer: contour export refused — no granted evidence permit (§19).',
@@ -2191,9 +2214,7 @@ export class AnalysePanel {
             generalizeToleranceCells: intent.generalizeToleranceCells,
           })
         : this._result;
-      const [{ buildContourDeliverableFromResultAsync }] = await Promise.all([
-        loadContourDeliverableBuild(),
-      ]);
+      const { buildContourDeliverableFromResultAsync } = await loadContourDeliverableBuild();
       // Same re-verification as the vector exports: a scan opened during the
       // rebuild means this bundle is no longer the one the user is looking at.
       if (this._refuseForeignScanExport()) return;
@@ -2589,7 +2610,7 @@ export class AnalysePanel {
     // export can never inherit a stale purpose.
     const purpose = this._contourPdfPurpose;
     this._contourPdfPurpose = null;
-    if (!permit || !permit.ok) {
+    if (!permit?.ok) {
       // eslint-disable-next-line no-console
       console.warn('OpenLiDARViewer: map sheet export refused — no granted evidence permit (§19).');
       return;
@@ -2830,7 +2851,14 @@ export class AnalysePanel {
     const previewNoteApplies = e === 'previewOnly' && hasFeatures;
     const merged = demNoteApplies && previewNoteApplies;
     if (demNoteApplies) {
-      const verdict = exp === 'blocked' ? 'blocked' : exp === 'previewOnly' ? 'preview' : 'ready';
+      let verdict: 'blocked' | 'preview' | 'ready';
+      if (exp === 'blocked') {
+        verdict = 'blocked';
+      } else if (exp === 'previewOnly') {
+        verdict = 'preview';
+      } else {
+        verdict = 'ready';
+      }
       const georef = r.quality.exportReasons.length > 0 ? ` (${r.quality.exportReasons.join(', ')})` : '';
       this._demNote.textContent = merged
         ? `Preliminary DEM — coverage: ${coverageMode}; export readiness: ${verdict}${georef}. ` +

--- a/src/ui/BatchConverter.ts
+++ b/src/ui/BatchConverter.ts
@@ -41,7 +41,7 @@ export class BatchConverter {
   private readonly _formatNote: HTMLElement;
   private readonly _crsRow: HTMLElement;
 
-  private _files: BatchInput[] = [];
+  private readonly _files: BatchInput[] = [];
   // LAS 1.4 is the default: modern consumers all read it, and its extended
   // point formats keep the full 8-bit classification (1.2 clamps to 5 bits).
   // LAS 1.2 stays selectable for legacy-tool compatibility.
@@ -370,10 +370,11 @@ export class BatchConverter {
 
     const sum = summariseBatch(results);
     const header = el('div', { className: 'olv-bc-results-head' });
+    const failedNote = sum.failed ? `, ${sum.failed} failed` : '';
     header.append(
       el('span', {
         className: 'olv-bc-results-summary',
-        text: `${sum.ok} converted${sum.failed ? `, ${sum.failed} failed` : ''} · ${sum.points.toLocaleString()} points`,
+        text: `${sum.ok} converted${failedNote} · ${sum.points.toLocaleString()} points`,
       }),
     );
     if (this._produced.length > 1) {
@@ -432,7 +433,7 @@ export class BatchConverter {
 
 // ── small local helpers ─────────────────────────────────────────────────────
 function parseEpsg(v: string): number | null {
-  const n = parseInt(v, 10);
+  const n = Number.parseInt(v, 10);
   return Number.isInteger(n) && n > 0 ? n : null;
 }
 

--- a/src/ui/ClassLegendPanel.ts
+++ b/src/ui/ClassLegendPanel.ts
@@ -68,7 +68,7 @@ export class ClassLegendPanel {
   private _onPaletteChange: ClassPaletteChange | null = null;
 
   /** The colourblind-safe palette checkbox. */
-  private _cvToggle!: HTMLInputElement;
+  private readonly _cvToggle!: HTMLInputElement;
 
   /** The scrolling list of class rows. */
   private readonly _list: HTMLElement;

--- a/src/ui/ClipPanel.ts
+++ b/src/ui/ClipPanel.ts
@@ -172,7 +172,7 @@ export class ClipPanel {
     const input = el('input', { className: 'olv-bc-input olv-clip-num', type: 'number' }) as HTMLInputElement;
     input.step = 'any';
     input.addEventListener('input', () => {
-      const v = parseFloat(input.value);
+      const v = Number.parseFloat(input.value);
       if (Number.isFinite(v)) onChange(v);
     });
     return input;

--- a/src/ui/DebugOverlay.ts
+++ b/src/ui/DebugOverlay.ts
@@ -223,8 +223,8 @@ export class DebugOverlay {
     this.element = el('div', { className: 'olv-debug' }, [title, this._body]);
   }
 
-  private _title!: HTMLButtonElement;
-  private _body!: HTMLElement;
+  private readonly _title!: HTMLButtonElement;
+  private readonly _body!: HTMLElement;
   private _collapsed = false;
 
   /** Collapse to just the title bar, or expand back. */
@@ -317,8 +317,14 @@ export class DebugOverlay {
     } else {
       this._perf.textContent = '(collecting…)';
     }
-    const backendLabel =
-      backend === 'webgpu' ? 'WebGPU' : backend === 'webgl2' ? 'WebGL 2' : '—';
+    let backendLabel: string;
+    if (backend === 'webgpu') {
+      backendLabel = 'WebGPU';
+    } else if (backend === 'webgl2') {
+      backendLabel = 'WebGL 2';
+    } else {
+      backendLabel = '—';
+    }
 
     if (stats) {
       this._live.textContent = [

--- a/src/ui/DropZone.ts
+++ b/src/ui/DropZone.ts
@@ -160,8 +160,7 @@ export class DropZone {
       this.setProgress(null);
       return;
     }
-    this.toast.classList.remove('olv-toast-error');
-    this.toast.classList.remove('is-opening');
+    this.toast.classList.remove('olv-toast-error', 'is-opening');
     const text = lines.join('\n');
     this._text.textContent = text;
     this._srStatus.textContent = text;

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -52,15 +52,21 @@ export interface ExportCloudSummary {
 function cloudToSummary(cloud: PointCloud | null): ExportCloudSummary | null {
   if (!cloud) return null;
   const crs = cloud.metadata?.crs ?? null;
+  let classProvenance: ExportCloudSummary['classProvenance'];
+  if (cloud.classificationIsDerived) {
+    classProvenance = 'derived';
+  } else if (cloud.classification != null) {
+    classProvenance = 'source';
+  } else {
+    classProvenance = 'none';
+  }
   return {
     pointCount: cloud.pointCount,
     hasRgb: cloud.colors != null,
     hasGpsTime: cloud.gpsTime != null,
     crsName: crs?.name ?? null,
     hasWkt: crs?.wkt != null,
-    classProvenance: cloud.classificationIsDerived
-      ? 'derived'
-      : cloud.classification != null ? 'source' : 'none',
+    classProvenance,
   };
 }
 
@@ -433,7 +439,8 @@ export class ExportPanel {
     const s = buildExportSummary(input);
     const warn = s.warnings.find((w) => w.level === 'error') ?? s.warnings.find((w) => w.level === 'warn');
     this._summary.textContent = warn ? `${s.line} — ${warn.message}` : s.line;
-    this._summary.className = `olv-export-summary${warn ? ` is-${warn.level}` : ''}`;
+    const summaryModifier = warn ? ` is-${warn.level}` : '';
+    this._summary.className = `olv-export-summary${summaryModifier}`;
   }
 
   /**
@@ -494,13 +501,14 @@ export class ExportPanel {
       btn.setAttribute('data-testid', 'export-integrity-report');
       measureRow.append(btn);
     }
+    const measurePlural = count === 1 ? '' : 's';
     content.append(
       this._productGroup(
         'Measurements',
         measureRow,
         count === 0
           ? 'Place measurements, then export them as open vector formats.'
-          : `${count} measurement${count === 1 ? '' : 's'} ready to export.`,
+          : `${count} measurement${measurePlural} ready to export.`,
       ),
     );
 
@@ -738,7 +746,7 @@ export class ExportPanel {
       }
       // Respect an active clip: export only the points inside (or outside) the
       // box the user had set when they pressed Export (captured above).
-      const clipped = clip != null && clip.enabled;
+      const clipped = clip?.enabled;
       const cloud = clipped ? clipCloud(sourceCloud, clip) : sourceCloud;
       this._exportBtn.textContent = 'Exporting…';
       const { convertCloud } = await loadConvertEngine();
@@ -782,7 +790,7 @@ export class ExportPanel {
 }
 
 function parseEpsg(v: string): number | null {
-  const n = parseInt(v, 10);
+  const n = Number.parseInt(v, 10);
   return Number.isInteger(n) && n > 0 ? n : null;
 }
 

--- a/src/ui/Inspector.ts
+++ b/src/ui/Inspector.ts
@@ -29,6 +29,8 @@ import {
   type NavigationPreset,
 } from '../render/navPrefs';
 import { EDL_DEFAULTS, EDL_STRENGTH_RANGE } from '../render/edl';
+import type { EdlPresetId } from '../render/edlPresets';
+import type { SplatMode } from '../render/splatShader';
 import type { ExportFormat } from '../io/exporters';
 import type { ExportMode } from '../export/types';
 import {
@@ -59,6 +61,9 @@ import {
   type TerrainWorkflowPresetId,
 } from '../render/terrainWorkflowPresets';
 
+/** An EDL preset id, or `null` for "off". */
+type EdlPresetSelection = EdlPresetId | null;
+
 /** The render-quality state the Inspector's Rendering controls reflect. */
 export interface RenderingState {
   pointSize: number;
@@ -79,7 +84,7 @@ export interface RenderingState {
    * Rendering section. The viewer keeps the source of truth; the
    * Inspector mirrors it via `syncRendering`.
    */
-  splatMode: 'classic' | 'soft' | 'inspection' | 'gaussian';
+  splatMode: SplatMode;
 }
 
 export interface InspectorCallbacks {
@@ -164,14 +169,14 @@ export interface InspectorCallbacks {
    * preset change (session restore, public API call) reflects in the UI.
    */
   onRgbAppearancePreset: (id: string) => void;
-  onEdlPreset: (id: 'subtle' | 'balanced' | 'inspection' | null) => void;
+  onEdlPreset: (id: EdlPresetSelection) => void;
   onSkyPreset: (id: string) => void;
   /** Advanced (streaming COPC only) — white-balance sliders. */
   onWhiteBalance: (temperature: number, tint: number) => void;
   /** Advanced (streaming COPC only) — auto-balance button. */
   onAutoBalance: () => void;
   /** Rendering > Splat mode chip rail. */
-  onSplatMode: (id: 'classic' | 'soft' | 'inspection' | 'gaussian') => void;
+  onSplatMode: (id: SplatMode) => void;
   /**
    * Visuals Studio > Workflow chip rail (v0.4.5) — apply a terrain workflow
    * preset (Terrain / Construction / Mining / Forestry / Hydrology /
@@ -289,7 +294,7 @@ const IMAGE_EXPORT_BUTTONS: ReadonlyArray<{
  */
 export interface VisualsStudioState {
   readonly rgbAppearancePresetId: string | null;
-  readonly edlPresetId: 'subtle' | 'balanced' | 'inspection' | null;
+  readonly edlPresetId: EdlPresetSelection;
   readonly skyPresetId: string;
   /** Current white-balance temperature; only meaningful for streaming COPC. */
   readonly temperature: number;
@@ -315,7 +320,7 @@ const VISUALS_RGB_CHIPS: ReadonlyArray<{ id: string; label: string }> = [
 
 /** The four EDL chips (Off + three named presets). */
 const VISUALS_EDL_CHIPS: ReadonlyArray<{
-  id: 'subtle' | 'balanced' | 'inspection' | null;
+  id: EdlPresetSelection;
   label: string;
 }> = [
   { id: null, label: 'Off' },
@@ -343,7 +348,7 @@ const VISUALS_SKY_CHIPS: ReadonlyArray<{ id: string; label: string }> = [
  *     sprite falloff, NOT a trained 3D Gaussian Splat scene.
  */
 const VISUALS_SPLAT_CHIPS: ReadonlyArray<{
-  id: 'classic' | 'soft' | 'inspection' | 'gaussian';
+  id: SplatMode;
   label: string;
   /** Optional custom tooltip; falls back to a generated one when absent. */
   title?: string;
@@ -581,7 +586,7 @@ export class Inspector {
    * the listener is harmless — the sheet-open class is a no-op when the
    * panel isn't styled as a sheet.
    */
-  private _sheetHead!: HTMLElement;
+  private readonly _sheetHead!: HTMLElement;
   private readonly _cb: InspectorCallbacks;
   private readonly _layers = el('div', { className: 'olv-layers' });
   private readonly _chips = el('div', { className: 'olv-chips' });
@@ -608,7 +613,7 @@ export class Inspector {
    * so this details element is hidden via `_advancedVisible` until a
    * streaming cloud attaches. Stored so the host can flip visibility.
    */
-  private _wbAdvancedDetails: HTMLDetailsElement | null = null;
+  private readonly _wbAdvancedDetails: HTMLDetailsElement | null = null;
   private readonly _wbTemperatureSlider = (() => {
     const s = el('input', { type: 'range', className: 'olv-wb-slider' }) as HTMLInputElement;
     s.min = '-100';
@@ -651,17 +656,17 @@ export class Inspector {
   // Range filters (v0.5.6) — an elevation (world-unit height) filter and an
   // intensity (raw-unit) filter, both built from the shared `buildRangeFilter`
   // so the DOM, the active-state cue, and the seed/reset logic live once.
-  private _elevFilter!: RangeFilter;
-  private _intenFilter!: RangeFilter;
+  private readonly _elevFilter!: RangeFilter;
+  private readonly _intenFilter!: RangeFilter;
   private readonly _detail = el('div', { className: 'olv-detail' });
   private readonly _report = el('div', { className: 'olv-report' });
   // Captured section refs — `setStreamingMode` toggles their visibility so
   // the static-cloud-only sections drop out when a streaming COPC / EPT is
   // active and their streaming-equivalents in StreamingPanel take over.
-  private _layersSection!: HTMLElement;
-  private _colorBySection!: HTMLElement;
-  private _renderingSection!: HTMLElement;
-  private _exportSection!: HTMLElement;
+  private readonly _layersSection!: HTMLElement;
+  private readonly _colorBySection!: HTMLElement;
+  private readonly _renderingSection!: HTMLElement;
+  private readonly _exportSection!: HTMLElement;
   private readonly _viewList = el('div', { className: 'olv-views' });
   /** Session-stats body — rebuilt lazily when the details section opens. */
   private readonly _sessionStatsBody: HTMLElement;
@@ -687,7 +692,7 @@ export class Inspector {
   /** CRS section body — populated by setCrs(). */
   private readonly _crsBody: HTMLElement;
   /** The whole Coordinate-system collapsible — hidden for local-frame profiles. */
-  private _crsSection: HTMLElement | null = null;
+  private readonly _crsSection: HTMLElement | null = null;
   /** Caller registers this to react to user CRS overrides. */
   private _onCrsOverride: ((override: { epsg: number | null; kind: 'projected' | 'geographic' | 'local' }) => void) | null = null;
   private readonly _layerRows = new Map<string, HTMLElement>();
@@ -707,8 +712,8 @@ export class Inspector {
   /** The original tooltip for each image-export button — restored on enable. */
   private readonly _imageExportTitles = new Map<ExportMode, string>();
   /** the Report PDF button, gated like the image-export ones. */
-  private _reportButton: HTMLButtonElement | null = null;
-  private _reportSelect: HTMLSelectElement | null = null;
+  private readonly _reportButton: HTMLButtonElement | null = null;
+  private readonly _reportSelect: HTMLSelectElement | null = null;
   // ── Rendering controls ──
   private readonly _pointSizeSlider: HTMLInputElement;
   private readonly _pointSizeValue: HTMLElement;
@@ -1325,6 +1330,7 @@ export class Inspector {
     // paint — it simply is not there yet).
     this._layerHealthSlot = el('div');
 
+    this._crsSection = collapsibleSection('Coordinate system', this._crsBody);
     this.element = el('aside', { className: 'olv-inspector' }, [
       head,
       this._datasetIntelligence.element,
@@ -1347,7 +1353,7 @@ export class Inspector {
           this._provenanceBody,
         ]),
       ),
-      (this._crsSection = collapsibleSection('Coordinate system', this._crsBody)),
+      this._crsSection,
       collapsibleSection('Scan report', this._report),
       collapsibleSection('Saved views', views),
       this._exportSection,
@@ -1795,7 +1801,7 @@ export class Inspector {
     }
     for (const chip of this._visualsEdlRail.children) {
       const id = (chip as HTMLElement).dataset?.presetId;
-      const wanted = state.edlPresetId === null ? 'off' : state.edlPresetId;
+      const wanted = state.edlPresetId ?? 'off';
       chip.classList.toggle('olv-chip-active', id === wanted);
     }
     for (const chip of this._visualsSkyRail.children) {

--- a/src/ui/LassoVolumeTool.ts
+++ b/src/ui/LassoVolumeTool.ts
@@ -153,7 +153,7 @@ export class LassoVolumeTool {
     // Skip duplicate / near-duplicate samples — saves ~30% of the
     // path-d string growth on a slow drag and avoids the
     // `pointInPolygon2D` test repeating an identical vertex.
-    const last = this._points[this._points.length - 1];
+    const last = this._points.at(-1);
     if (last && Math.hypot(p.x - last.x, p.y - last.y) < 2) return;
     this._points.push(p);
     this._renderPath();

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -18,7 +18,7 @@ import { storageGet, storageSet } from './safeStorage';
 // lazyChunks.ts (excluded from the live source-transform) so its literal is
 // never scrambled. Importing the thunk pulls nothing heavy into the shell.
 import { loadProfilePdf } from '../lazyChunks';
-import type { MeasurementSummary } from '../render/measure/MeasureController';
+import type { MeasurementSummary, ProfileResampleParams } from '../render/measure/MeasureController';
 import {
   DIMENSION_LABEL,
   OPERATION_LABEL,
@@ -63,7 +63,6 @@ import {
   MIN_CORRIDOR_HALF_WIDTH_M,
   PROFILE_SAMPLE_COUNT_OPTIONS,
 } from '../render/measure/profileSampler';
-import type { ProfileResampleParams } from '../render/measure/MeasureController';
 
 /** Metres → feet — the same factor the chart's imperial labels use. */
 const FT_PER_M = 3.28084;
@@ -167,7 +166,16 @@ export function niceElevationTicks(min: number, max: number, target = 4): number
   const rawStep = span / Math.max(1, target);
   const mag = Math.pow(10, Math.floor(Math.log10(rawStep)));
   const norm = rawStep / mag;
-  const niceUnit = norm <= 1 ? 1 : norm <= 2 ? 2 : norm <= 5 ? 5 : 10;
+  let niceUnit: number;
+  if (norm <= 1) {
+    niceUnit = 1;
+  } else if (norm <= 2) {
+    niceUnit = 2;
+  } else if (norm <= 5) {
+    niceUnit = 5;
+  } else {
+    niceUnit = 10;
+  }
   const step = niceUnit * mag;
   // Crash guard (v0.4.5): a denormal-tiny span underflows `mag` to 0, which
   // makes `step` 0 — and a `v += 0` loop pushes ticks forever until the tab
@@ -966,12 +974,18 @@ export class MeasurePanel {
 
     const apply = (): void => {
       const rawCorr = corrInput.value.trim();
-      const corrVal = rawCorr === '' ? NaN : Number(rawCorr);
+      const corrVal = rawCorr === '' ? Number.NaN : Number(rawCorr);
       const cnt = Number(cntSelect.value);
       const pctVal = Number(pctInput.value);
+      // Empty input = keep auto; the controller clamps out-of-range values.
+      let corridorWidthM: number | null;
+      if (Number.isFinite(corrVal)) {
+        corridorWidthM = imperial ? corrVal / FT_PER_M : corrVal;
+      } else {
+        corridorWidthM = null;
+      }
       resample(s.id, {
-        // Empty input = keep auto; the controller clamps out-of-range values.
-        corridorWidthM: Number.isFinite(corrVal) ? (imperial ? corrVal / FT_PER_M : corrVal) : null,
+        corridorWidthM,
         groundPercentile: Number.isFinite(pctVal) ? pctVal : null,
         sampleCount: Number.isFinite(cnt) ? cnt : null,
       });
@@ -1146,7 +1160,14 @@ export class MeasurePanel {
     // value the data can't support.
     if (s.trust) {
       const t = s.trust;
-      const colour = t.grade === 'green' ? '#38b058' : t.grade === 'yellow' ? '#e8c440' : '#d64c40';
+      let colour: string;
+      if (t.grade === 'green') {
+        colour = '#38b058';
+      } else if (t.grade === 'yellow') {
+        colour = '#e8c440';
+      } else {
+        colour = '#d64c40';
+      }
       const badge = el('span', {
         className: `olv-mp-trust olv-mp-trust-${t.grade}`,
         text: '●',
@@ -1771,7 +1792,9 @@ function renderProfileChart(
   const elevDecimals = (() => {
     if (yTicks.length >= 2) {
       const st = Math.abs(yTicks[1] - yTicks[0]);
-      return st >= 1 ? 0 : st >= 0.1 ? 1 : 2;
+      if (st >= 1) return 0;
+      if (st >= 0.1) return 1;
+      return 2;
     }
     return 1;
   })();
@@ -1790,7 +1813,9 @@ function renderProfileChart(
   const elevDecimalsFt = (() => {
     if (yTicks.length >= 2) {
       const stepFt = Math.abs(yTicks[1] - yTicks[0]) * 3.28084;
-      return stepFt >= 1 ? 0 : stepFt >= 0.1 ? 1 : 2;
+      if (stepFt >= 1) return 0;
+      if (stepFt >= 0.1) return 1;
+      return 2;
     }
     return 1;
   })();
@@ -1901,7 +1926,14 @@ function renderProfileChart(
       const isLast = i === lastIdx;
       if (!isLast && i % labelStride !== 0) return '';
       if (!isLast && lastIdx - i < labelStride / 2) return '';
-      const tx = i === 0 ? '0' : isLast ? '-100%' : '-50%';
+      let tx: string;
+      if (i === 0) {
+        tx = '0';
+      } else if (isLast) {
+        tx = '-100%';
+      } else {
+        tx = '-50%';
+      }
       return `<span class="olv-mp-axis olv-mp-axis-x" style="left:${xPct(c).toFixed(2)}%;top:${xLabelTop}%;transform:translateX(${tx})">${formatChainage(c)}</span>`;
     })
     .join('');

--- a/src/ui/MobileSheet.ts
+++ b/src/ui/MobileSheet.ts
@@ -233,9 +233,9 @@ export class MobileSheet {
     this._syncDetent();
   }
 
-  private _handle!: HTMLButtonElement;
-  private _head!: HTMLElement;
-  private _body!: HTMLElement;
+  private readonly _handle!: HTMLButtonElement;
+  private readonly _head!: HTMLElement;
+  private readonly _body!: HTMLElement;
 
   /** The tabpanel container the host re-parents this tab's panels into. */
   slot(tab: MobileTab): HTMLElement {

--- a/src/ui/Modal.ts
+++ b/src/ui/Modal.ts
@@ -122,7 +122,7 @@ export function openModal(opts: ModalOptions): ModalHandle {
       return;
     }
     const first = items[0];
-    const last = items[items.length - 1];
+    const last = items.at(-1)!;
     const active = document.activeElement;
     if (e.shiftKey && (active === first || !dialog.contains(active))) {
       e.preventDefault();

--- a/src/ui/NavBar.ts
+++ b/src/ui/NavBar.ts
@@ -168,9 +168,9 @@ export class NavBar {
   private readonly _speed: HTMLElement;
   private readonly _modeButtons = new Map<NavMode, HTMLButtonElement>();
   /** The Pan (hand tool) pad — hidden when `?handPan=off` disables it. */
-  private _panBtn!: HTMLButtonElement;
+  private readonly _panBtn!: HTMLButtonElement;
   /** Legend chips that only make sense while the hand tool exists. */
-  private _panLegendItems: HTMLElement[] = [];
+  private readonly _panLegendItems: HTMLElement[] = [];
 
   private _mode: NavMode = 'orbit';
   private _locked = false;

--- a/src/ui/ObjectPanel.ts
+++ b/src/ui/ObjectPanel.ts
@@ -232,15 +232,23 @@ export class ObjectPanel {
     // —" caveat wins outright (the figures are provisional on a partial load);
     // else the certified-survey honesty line (present for interiors); else the
     // first reason as a fallback.
-    const partialIdx = reasons.findIndex((r) => /^Preliminary —/.test(r));
+    const partialIdx = reasons.findIndex((r) => r.startsWith('Preliminary —'));
     // An unverified-unit caveat is a whole-basis honesty flag (every metre figure
     // is an assumption), so it must be VISIBLE, not folded into the disclosure.
     // It outranks the standing "not a certified survey" line but yields to a
     // genuine partial-stream lead (provisional data trumps unit provenance).
-    const unitIdx = reasons.findIndex((r) => /^Coordinate units are unverified/.test(r));
+    const unitIdx = reasons.findIndex((r) => r.startsWith('Coordinate units are unverified'));
     const certIdx = reasons.findIndex((r) => /not a certified survey/i.test(r));
-    const leadIdx =
-      partialIdx >= 0 ? partialIdx : unitIdx >= 0 ? unitIdx : certIdx >= 0 ? certIdx : 0;
+    let leadIdx: number;
+    if (partialIdx >= 0) {
+      leadIdx = partialIdx;
+    } else if (unitIdx >= 0) {
+      leadIdx = unitIdx;
+    } else if (certIdx >= 0) {
+      leadIdx = certIdx;
+    } else {
+      leadIdx = 0;
+    }
     const lead = reasons[leadIdx];
     const rest = reasons.filter((_, i) => i !== leadIdx);
     const isPreliminary = leadIdx === partialIdx && partialIdx >= 0;
@@ -498,8 +506,8 @@ export class ObjectPanel {
     this._body.append(el('div', { className: 'olv-object-subhead', text: 'Planes' }));
     const p = space.planes;
     this._body.append(
-      this._row('Floor', p.floorPresent ? `Yes · ${areaMft(p.floorAreaM2 ?? NaN)}` : 'Not detected'),
-      this._row('Ceiling', p.ceilingPresent ? `Yes · ${areaMft(p.ceilingAreaM2 ?? NaN)}` : 'Not detected'),
+      this._row('Floor', p.floorPresent ? `Yes · ${areaMft(p.floorAreaM2 ?? Number.NaN)}` : 'Not detected'),
+      this._row('Ceiling', p.ceilingPresent ? `Yes · ${areaMft(p.ceilingAreaM2 ?? Number.NaN)}` : 'Not detected'),
       this._row('Walls', `${Math.round(p.wallCoveragePct)}% coverage · ~${p.dominantWallDirections} direction(s)`,
         'Share of perimeter spanning most of the height; approximate dominant-wall count.'),
     );
@@ -507,7 +515,7 @@ export class ObjectPanel {
     this._caveats(space.reasons);
     // Interior export row: Report PDF + the interior-only Floor plan preview.
     this._exportRow(true);
-    const why = shape && shape.reasons.length ? shape.reasons[0].replace(/\.$/, '') : 'interior space';
+    const why = shape?.reasons.length ? shape.reasons[0].replace(/\.$/, '') : 'interior space';
     this._body.append(el('div', {
       className: 'olv-object-note',
       text: `This looks like a ${why}. Terrain analysis — contours, slope, DTM — is for ground scans and would be misleading here.`,
@@ -555,7 +563,7 @@ export class ObjectPanel {
     }
     // Object export row: Report PDF only (no floor plan for objects).
     this._exportRow(false);
-    const why = shape && shape.reasons.length ? ` (${shape.reasons[0].replace(/\.$/, '')})` : '';
+    const why = shape?.reasons.length ? ` (${shape.reasons[0].replace(/\.$/, '')})` : '';
     this._body.append(el('div', {
       className: 'olv-object-note',
       text: `This looks like an object${why}. Terrain analysis — contours, slope, DTM — is for ground scans and would be misleading here.`,

--- a/src/ui/ShortcutSheet.ts
+++ b/src/ui/ShortcutSheet.ts
@@ -46,9 +46,9 @@ export function formatShortcutKeys(keys: string | undefined): string {
       .replace(/\bCmd\b/g, '⌘')
       .replace(/\bShift\b/g, '⇧')
       .replace(/\bAlt\b/g, '⌥')
-      .replace(/-/g, ' ');
+      .replaceAll('-', ' ');
   }
-  return keys.replace(/\bCmd\b/g, 'Ctrl').replace(/-/g, '+');
+  return keys.replace(/\bCmd\b/g, 'Ctrl').replaceAll('-', '+');
 }
 
 /**

--- a/src/ui/Stage.ts
+++ b/src/ui/Stage.ts
@@ -469,11 +469,12 @@ export class Stage {
       className: 'olv-empty-formats-summary',
       text: `Compatible data — ${SOURCE_FORMATS.length} file formats · COPC & EPT streaming`,
     });
+    const xyzAliases = XYZ_ALIAS_EXTENSIONS.map((e) => `.${e}`).join('/');
     const formatsFull = el('p', {
       className: 'olv-empty-formats-full',
       text:
         SOURCE_FORMATS.map((f) => `.${f}`).join(' · ') +
-        ` · ${XYZ_ALIAS_EXTENSIONS.map((e) => `.${e}`).join('/')} (read as .xyz)` +
+        ` · ${xyzAliases} (read as .xyz)` +
         ' · .copc.laz (streamed) · EPT via ept.json (streamed)',
     });
     formats.append(formatsSummary, formatsFull);
@@ -1029,11 +1030,9 @@ export class Stage {
             'streaming will resume when you reconnect.',
         }),
       );
-    } else {
+    } else if (this._statusBanner.classList.contains('olv-empty-status-offline')) {
       // Only auto-dismiss if the offline banner is the one currently shown.
-      if (this._statusBanner.classList.contains('olv-empty-status-offline')) {
-        this._hideStatusBanner();
-      }
+      this._hideStatusBanner();
     }
   }
 }

--- a/src/ui/StreamingPanel.ts
+++ b/src/ui/StreamingPanel.ts
@@ -11,8 +11,7 @@
  */
 
 import { clamp01 } from '../numeric';
-import { el } from './dom';
-import { formatCount } from './dom';
+import { el, formatCount } from './dom';
 import { formatByteSize as formatBytes } from '../io/formatByteSize';
 import type { ColorMode } from '../render/colorModes';
 import type { StreamingQuality } from '../render/streaming/streamingBudget';
@@ -468,9 +467,12 @@ export class StreamingPanel {
     const file = this._statRow('File', this._value(summary.fileName, summary.fileName));
     // format-aware Format row. COPC shows the LAS PDRF; EPT shows
     // the schema summary (when supplied) or just "EPT".
-    const formatText = summary.format === 'ept'
-      ? (summary.schemaSummary ? `EPT · ${summary.schemaSummary}` : 'EPT')
-      : `COPC LAZ · PDRF ${summary.pointFormat}`;
+    let formatText: string;
+    if (summary.format === 'ept') {
+      formatText = summary.schemaSummary ? `EPT · ${summary.schemaSummary}` : 'EPT';
+    } else {
+      formatText = `COPC LAZ · PDRF ${summary.pointFormat}`;
+    }
     this._summary.replaceChildren(
       file,
       this._statRow('Format', this._value(formatText)),

--- a/src/ui/ThemeToggle.ts
+++ b/src/ui/ThemeToggle.ts
@@ -138,6 +138,6 @@ export class ThemeToggle {
 function nextTheme(current: ThemeName): ThemeName {
   const i = THEME_ORDER.indexOf(current);
   // Unknown value (shouldn't happen) falls back to the start of the cycle.
-  const at = i < 0 ? 0 : i;
+  const at = Math.max(0, i);
   return THEME_ORDER[(at + 1) % THEME_ORDER.length];
 }

--- a/src/ui/WorkflowConfigPanel.ts
+++ b/src/ui/WorkflowConfigPanel.ts
@@ -45,7 +45,7 @@ export class WorkflowConfigPanel {
   private _capturingShortcut = false;
   private _shortcutBtn!: HTMLButtonElement;
   /** Re-render hooks keyed by control, run when the config changes externally. */
-  private _syncers: Array<() => void> = [];
+  private readonly _syncers: Array<() => void> = [];
 
   constructor() {
     const dismiss = el('button', {

--- a/src/ui/contourStudioWorkspace.ts
+++ b/src/ui/contourStudioWorkspace.ts
@@ -18,14 +18,13 @@
  */
 
 import type { ContourStudioController } from '../terrain/contourStudio/contourStudioController';
-import type { ContourStudioState } from '../terrain/contourStudio/contourStudioState';
+import type { ContourStudioState, ContourStudioPurpose } from '../terrain/contourStudio/contourStudioState';
 import type { ContourStudioLaunchState } from '../terrain/contourStudio/contourStudioLaunchState';
 import type { ContourReviewSummary } from '../terrain/contourStudio/contourReviewSummary';
 import {
   PURPOSE_META,
   type PurposeMeta,
 } from '../terrain/contourStudio/contourStudioPurpose';
-import type { ContourStudioPurpose } from '../terrain/contourStudio/contourStudioState';
 
 function el<K extends keyof HTMLElementTagNameMap>(
   tag: K,
@@ -98,7 +97,14 @@ const LADDER_GLYPH: Record<LadderState, string> = { met: '✓', warn: '!', block
 function ladderRows(launch: ContourStudioLaunchState): ReadonlyArray<{ label: string; state: LadderState }> {
   const status = launch.status;
   const base: LadderState = status === 'unavailable' ? 'blocked' : 'met';
-  const support: LadderState = status === 'available' ? 'met' : status === 'exploratory' ? 'warn' : 'blocked';
+  let support: LadderState;
+  if (status === 'available') {
+    support = 'met';
+  } else if (status === 'exploratory') {
+    support = 'warn';
+  } else {
+    support = 'blocked';
+  }
   const validation: LadderState = status === 'unavailable' ? 'blocked' : 'warn';
   return [
     { label: 'Source', state: base },
@@ -152,10 +158,16 @@ function renderPurposeCards(
 function renderSettingsSummary(state: ContourStudioState): HTMLElement {
   const wrap = el('div', { className: 'olv-cs-summary' });
   wrap.append(el('div', { className: 'olv-cs-section-head', text: 'This deliverable' }));
+  let labelsValue: string;
+  if (state.labels.enabled) {
+    labelsValue = state.labels.indexOnly ? 'index only' : 'on';
+  } else {
+    labelsValue = 'off';
+  }
   const rows: Array<[string, string]> = [
     ['Geometry', [state.contour.analytical ? 'analytical' : null, state.contour.cartographic ? 'cartographic' : null].filter(Boolean).join(' + ') || 'none'],
     ['Cartographic smoothing', state.surface.cartographicSmoothing ? 'on' : 'off'],
-    ['Labels', state.labels.enabled ? (state.labels.indexOnly ? 'index only' : 'on') : 'off'],
+    ['Labels', labelsValue],
     ['Validation appendix', state.validation.appendixRequired ? 'required' : 'optional'],
     ['Exploratory output', state.deliverable.allowExploratory ? 'allowed' : 'not for this purpose'],
   ];

--- a/src/ui/embedConfig.ts
+++ b/src/ui/embedConfig.ts
@@ -55,7 +55,7 @@ export function parseEmbedConfig(search: string): EmbedConfig {
   // `?autoload=sample:<id>` — only built-in samples are accepted.
   const autoload = params.get('autoload');
   const autoloadSample =
-    autoload && autoload.startsWith('sample:') ? autoload.slice('sample:'.length) : null;
+    autoload?.startsWith('sample:') ? autoload.slice('sample:'.length) : null;
 
   return {
     embed: flag(params, 'embed'),

--- a/src/ui/onboarding/TourOverlay.ts
+++ b/src/ui/onboarding/TourOverlay.ts
@@ -137,7 +137,7 @@ export class TourOverlay {
       );
       if (items.length === 0) return;
       const first = items[0];
-      const last = items[items.length - 1];
+      const last = items.at(-1)!;
       const active = document.activeElement;
       if (e.shiftKey && (active === first || !this._card.contains(active))) {
         e.preventDefault();

--- a/src/ui/onboarding/tourSteps.ts
+++ b/src/ui/onboarding/tourSteps.ts
@@ -136,6 +136,9 @@ export function splitEmphasis(body: string): BodySegment[] {
 /** Outcome of the user's interaction with the tour. */
 export type TourOutcome = 'completed' | 'skipped' | 'dismissed';
 
+/** Tour lifecycle: not yet started, running, or a terminal outcome. */
+export type TourState = 'pending' | 'running' | TourOutcome;
+
 /**
  * The persistence port. Default implementation uses `localStorage`;
  * tests inject a Map-backed fake.
@@ -184,7 +187,7 @@ export class TourSession {
   private readonly _steps: readonly TourStep[];
   private readonly _storage: TourStoragePort;
   private _index = 0;
-  private _state: 'pending' | 'running' | TourOutcome = 'pending';
+  private _state: TourState = 'pending';
   private readonly _listeners = new Set<(snap: TourSnapshot) => void>();
 
   constructor(
@@ -201,7 +204,7 @@ export class TourSession {
   }
 
   /** Current state — 'pending' before `start`, 'running' during, then the outcome. */
-  get state(): 'pending' | 'running' | TourOutcome {
+  get state(): TourState {
     return this._state;
   }
 
@@ -342,5 +345,5 @@ export interface TourSnapshot {
   readonly step: TourStep | null;
   readonly index: number;
   readonly total: number;
-  readonly state: 'pending' | 'running' | TourOutcome;
+  readonly state: TourState;
 }

--- a/src/ui/reportVerifier.ts
+++ b/src/ui/reportVerifier.ts
@@ -45,18 +45,34 @@ export function showReportVerification(result: VerifyReportResult): void {
   const ok = result.valid;
   const weak = ok && result.cryptographic === false;
   const status = document.createElement('div');
-  status.setAttribute(
-    'data-testid',
-    !ok ? 'report-verify-invalid' : weak ? 'report-verify-weak' : 'report-verify-valid',
-  );
-  status.textContent = !result.recognised
-    ? 'Not a report'
-    : !ok
-      ? 'Report has been modified'
-      : weak
-        ? 'Checksum matches — not tamper-proof'
-        : 'Report is intact';
-  const statusColor = !ok ? 'var(--rating-weak)' : weak ? 'var(--rating-good)' : 'var(--rating-excellent)';
+  let statusTestid: string;
+  if (!ok) {
+    statusTestid = 'report-verify-invalid';
+  } else if (weak) {
+    statusTestid = 'report-verify-weak';
+  } else {
+    statusTestid = 'report-verify-valid';
+  }
+  status.setAttribute('data-testid', statusTestid);
+  let statusText: string;
+  if (!result.recognised) {
+    statusText = 'Not a report';
+  } else if (!ok) {
+    statusText = 'Report has been modified';
+  } else if (weak) {
+    statusText = 'Checksum matches — not tamper-proof';
+  } else {
+    statusText = 'Report is intact';
+  }
+  status.textContent = statusText;
+  let statusColor: string;
+  if (!ok) {
+    statusColor = 'var(--rating-weak)';
+  } else if (weak) {
+    statusColor = 'var(--rating-good)';
+  } else {
+    statusColor = 'var(--rating-excellent)';
+  }
   status.style.cssText = `font:600 16px system-ui,sans-serif;color:${statusColor};`;
   card.append(status);
 

--- a/src/ui/scanTypeControl.ts
+++ b/src/ui/scanTypeControl.ts
@@ -142,7 +142,14 @@ export function createScanTypeControl(opts: ScanTypeControlOptions): ScanTypeCon
     // "(manual)" note), with Auto one click away to re-run detection.
     const detectedKind: SpaceKind | null = !manual ? effective : null;
     const committed = detectionCommitted === true && detectedKind !== null;
-    const selected: ScanTypeOverride = manual ? override : committed ? detectedKind! : 'auto';
+    let selected: ScanTypeOverride;
+    if (manual) {
+      selected = override;
+    } else if (committed) {
+      selected = detectedKind!;
+    } else {
+      selected = 'auto';
+    }
     let reasonText: string | null = null;
     for (const [value, btn] of buttons) {
       const active = value === selected;
@@ -181,17 +188,25 @@ export function createScanTypeControl(opts: ScanTypeControlOptions): ScanTypeCon
       // manual override (the override pill is the active one then).
       autoBtn.textContent =
         detectedKind !== null && !committed ? `Auto (${EFFECTIVE_LABEL[detectedKind]})` : 'Auto';
-      autoBtn.title = manual
-        ? `Auto-detection is overridden. Click to return to automatic (${eff}).`
-        : committed
-          ? `Detection settled on ${eff}. Click to re-run auto-detection.`
-          : `Auto-detected as ${eff}.`;
+      let autoTitle: string;
+      if (manual) {
+        autoTitle = `Auto-detection is overridden. Click to return to automatic (${eff}).`;
+      } else if (committed) {
+        autoTitle = `Detection settled on ${eff}. Click to re-run auto-detection.`;
+      } else {
+        autoTitle = `Auto-detected as ${eff}.`;
+      }
+      autoBtn.title = autoTitle;
     }
-    group.title = manual
-      ? `Treated as ${eff} — manual override of auto-detection.`
-      : committed
-        ? `Auto-detected as ${eff} — the detected type is selected. Pick a different type if it's wrong.`
-        : `Auto-detected as ${eff}. Pick a type here if it's wrong.`;
+    let groupTitle: string;
+    if (manual) {
+      groupTitle = `Treated as ${eff} — manual override of auto-detection.`;
+    } else if (committed) {
+      groupTitle = `Auto-detected as ${eff} — the detected type is selected. Pick a different type if it's wrong.`;
+    } else {
+      groupTitle = `Auto-detected as ${eff}. Pick a type here if it's wrong.`;
+    }
+    group.title = groupTitle;
   }
 
   set('auto', null);

--- a/src/validation/checkpointAccuracy.ts
+++ b/src/validation/checkpointAccuracy.ts
@@ -292,7 +292,7 @@ function statsOf(
     nmad,
     p90AbsResidual: quantileSorted(abs, 0.9),
     p95AbsResidual: quantileSorted(abs, 0.95),
-    maxAbsResidual: abs[abs.length - 1],
+    maxAbsResidual: abs.at(-1)!,
     biasCiLower: standardError === null ? null : bias - ciZ * standardError,
     biasCiUpper: standardError === null ? null : bias + ciZ * standardError,
     standardError,
@@ -434,7 +434,11 @@ export function checkpointAccuracy(
   // is what a deterministic record needs. Same rule as the benchmark artifact
   // ordering.
   const strata: StratumAccuracy[] = [...byStratum.keys()]
-    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    .sort((a, b) => {
+      if (a < b) return -1;
+      if (a > b) return 1;
+      return 0;
+    })
     .map((key) => {
       const bucket = byStratum.get(key)!;
       // A stratum below the floor is REPORTED as insufficient rather than

--- a/src/validation/classificationAgreement.ts
+++ b/src/validation/classificationAgreement.ts
@@ -182,10 +182,8 @@ export function classificationAgreement(
     if (t === 'ground') {
       if (p === 'ground') tp++;
       else fn++;
-    } else {
-      if (p === 'ground') fp++;
-      else tn++;
-    }
+    } else if (p === 'ground') fp++;
+    else tn++;
   }
 
   const evaluated = tp + fp + fn + tn;

--- a/src/validation/classifierCorpus.ts
+++ b/src/validation/classifierCorpus.ts
@@ -295,7 +295,8 @@ function buildScene(spec: SceneSpec): CorpusScene {
       const h = spec.vegMinH + rnd() * (spec.vegMaxH - spec.vegMinH);
       // Truth follows the SAME height bands the classifier uses, so a band
       // disagreement is a real disagreement and not a definition mismatch.
-      const truth = h < 2 ? TRUTH_LOW_VEG : h < 5 ? TRUTH_MED_VEG : TRUTH_HIGH_VEG;
+      const truthVeg = h < 5 ? TRUTH_MED_VEG : TRUTH_HIGH_VEG;
+      const truth = h < 2 ? TRUTH_LOW_VEG : truthVeg;
       // A canopy return is one of several from a pulse that kept going; a roof
       // return is not. Second return of two, so the cue reads `returnCount > 1`.
       add(a, x, y, surface(x, y) + h, GREEN, 2, 2, truth);
@@ -605,12 +606,14 @@ export function scoreScene(
     }
     const precision = tp + fp > 0 ? tp / (tp + fp) : null;
     const recall = tp + fn > 0 ? tp / (tp + fn) : null;
-    const f1 =
-      precision !== null && recall !== null && precision + recall > 0
-        ? (2 * precision * recall) / (precision + recall)
-        : precision !== null && recall !== null
-          ? 0
-          : null;
+    let f1: number | null;
+    if (precision !== null && recall !== null && precision + recall > 0) {
+      f1 = (2 * precision * recall) / (precision + recall);
+    } else if (precision !== null && recall !== null) {
+      f1 = 0;
+    } else {
+      f1 = null;
+    }
     byClass.push({
       code,
       support,
@@ -701,12 +704,14 @@ export function poolScores(scores: readonly SceneScore[]): SceneScore {
     const acc = byCode.get(code)!;
     const precision = acc.tp + acc.fp > 0 ? acc.tp / (acc.tp + acc.fp) : null;
     const recall = acc.tp + acc.fn > 0 ? acc.tp / (acc.tp + acc.fn) : null;
-    const f1 =
-      precision !== null && recall !== null && precision + recall > 0
-        ? (2 * precision * recall) / (precision + recall)
-        : precision !== null && recall !== null
-          ? 0
-          : null;
+    let f1: number | null;
+    if (precision !== null && recall !== null && precision + recall > 0) {
+      f1 = (2 * precision * recall) / (precision + recall);
+    } else if (precision !== null && recall !== null) {
+      f1 = 0;
+    } else {
+      f1 = null;
+    }
     return {
       code,
       support: acc.support,

--- a/src/validation/crossCheck.ts
+++ b/src/validation/crossCheck.ts
@@ -154,14 +154,19 @@ export function crossCheck(
   else if (withinTolFraction >= threshold) verdict = 'agree';
   else verdict = 'disagree';
 
-  const summary =
-    lengthMismatch && !allowPartial
-      ? `Grid length mismatch (${ours.length} vs ${reference.length}); not aligned — resample onto a common grid before comparing.`
-      : verdict === 'insufficient'
-      ? `Insufficient overlap: ${count} comparable cells (< ${minCells}).`
-      : `${verdict === 'agree' ? 'Agrees' : 'Disagrees'} with reference over ${count} cells: ` +
-        `max |Δ| ${maxAbsDiff.toPrecision(3)}, RMSE ${rmse.toPrecision(3)}, ` +
-        `${(withinTolFraction * 100).toFixed(1)}% within ±${tol} (bias ${meanDiff >= 0 ? '+' : ''}${meanDiff.toPrecision(3)}).`;
+  const agreeWord = verdict === 'agree' ? 'Agrees' : 'Disagrees';
+  const biasSign = meanDiff >= 0 ? '+' : '';
+  let summary: string;
+  if (lengthMismatch && !allowPartial) {
+    summary = `Grid length mismatch (${ours.length} vs ${reference.length}); not aligned — resample onto a common grid before comparing.`;
+  } else if (verdict === 'insufficient') {
+    summary = `Insufficient overlap: ${count} comparable cells (< ${minCells}).`;
+  } else {
+    summary =
+      `${agreeWord} with reference over ${count} cells: ` +
+      `max |Δ| ${maxAbsDiff.toPrecision(3)}, RMSE ${rmse.toPrecision(3)}, ` +
+      `${(withinTolFraction * 100).toFixed(1)}% within ±${tol} (bias ${biasSign}${meanDiff.toPrecision(3)}).`;
+  }
 
   return {
     verdict, count, skipped, maxAbsDiff, rmse, meanDiff,

--- a/src/validation/evidenceRegistry.ts
+++ b/src/validation/evidenceRegistry.ts
@@ -24,10 +24,10 @@ import { exportDecision, type ExportDecision } from './evidenceLevel';
 // The registry is GENERATED from docs/validation/claim-register.yaml by
 // scripts/generate-claim-registry.mjs (`npm run gen:claim-registry`), so it can
 // never be hand-mirrored out of sync. lint:claim-register fails on any drift.
-import { EVIDENCE_REGISTRY, type RegistryEntry } from './claimRegistry.generated';
+import { EVIDENCE_REGISTRY } from './claimRegistry.generated';
 
 export { EVIDENCE_REGISTRY };
-export type { RegistryEntry };
+export type { RegistryEntry } from './claimRegistry.generated';
 
 /**
  * Resolve the export decision for a product by its claim id. An unknown id is

--- a/src/validation/gridAgreement.ts
+++ b/src/validation/gridAgreement.ts
@@ -281,7 +281,7 @@ function statsOf(signed: readonly number[], tolerance: number): ErrorStats {
     abs.push(a);
   }
   const sortedSigned = [...signed].sort((x, y) => x - y);
-  const sortedAbs = abs.sort((x, y) => x - y);
+  const sortedAbs = abs.toSorted((x, y) => x - y);
   const median = quantileSorted(sortedSigned, 0.5);
   // NMAD = 1.4826 × median(|x − median(x)|). The constant makes it a consistent
   // estimator of the standard deviation under normality while staying resistant
@@ -298,7 +298,7 @@ function statsOf(signed: readonly number[], tolerance: number): ErrorStats {
     p90AbsError: quantileSorted(sortedAbs, 0.9),
     p95AbsError: quantileSorted(sortedAbs, 0.95),
     p99AbsError: quantileSorted(sortedAbs, 0.99),
-    maxAbsError: sortedAbs[sortedAbs.length - 1],
+    maxAbsError: sortedAbs.at(-1)!,
     withinToleranceFraction: within / n,
   };
 }

--- a/src/validation/spatialBootstrap.ts
+++ b/src/validation/spatialBootstrap.ts
@@ -154,7 +154,7 @@ function refuse(
 
 function mean(values: readonly number[]): number {
   let sum = 0;
-  for (let i = 0; i < values.length; i++) sum += values[i];
+  for (const v of values) sum += v;
   return sum / values.length;
 }
 
@@ -184,8 +184,8 @@ function quantileSorted(sorted: readonly number[], p: number): number {
 function standardDeviation(values: readonly number[]): number {
   const m = mean(values);
   let ss = 0;
-  for (let i = 0; i < values.length; i++) {
-    const d = values[i] - m;
+  for (const v of values) {
+    const d = v - m;
     ss += d * d;
   }
   return Math.sqrt(ss / (values.length - 1));
@@ -361,7 +361,7 @@ export function blockBootstrap(
     const pool: number[] = [];
     for (let d = 0; d < k; d++) {
       const block = groups[Math.floor(rng() * k)];
-      for (let i = 0; i < block.length; i++) pool.push(block[i]);
+      for (const v of block) pool.push(v);
     }
     const s = statistic(pool);
     if (!Number.isFinite(s)) {
@@ -508,7 +508,11 @@ export function leaveOneSiteOut(
   // reproducible. Comparing by code unit is fixed by the language spec, which
   // is what a deterministic record needs. Same rule as the benchmark artifact
   // ordering.
-  const siteIds = [...groups.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const siteIds = [...groups.keys()].sort((a, b) => {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+  });
   const perSite: SiteOmission[] = [];
   for (const siteId of siteIds) {
     const kept: number[] = [];

--- a/src/workers/workerRegistry.ts
+++ b/src/workers/workerRegistry.ts
@@ -84,7 +84,7 @@ export const WORKER_REGISTRY: readonly WorkerDeclaration[] = [
 
 /** Escape a string for safe embedding inside a `RegExp`. */
 function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 /** The basename (with extension) of a `src/...` module path. */

--- a/tests/terrainAssessmentBanding.test.ts
+++ b/tests/terrainAssessmentBanding.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { bandHigh, bandLow } from '../src/terrain/contour/terrainAssessment';
+
+// These two helpers replaced the assessment's inline good/fair/poor ternaries.
+// In the real flow every input is sanitised before it reaches them, so the NaN
+// case is a safety net rather than a reachable path; this pins it directly so a
+// later edit cannot drift the contract the ternaries had, where every NaN
+// comparison is false and the value falls through to poor.
+describe('terrainAssessment banding helpers', () => {
+  it('bandHigh (higher is better) bands at the thresholds, inclusive at good/fair', () => {
+    expect(bandHigh(70, 70, 45)).toBe('good');
+    expect(bandHigh(69.9, 70, 45)).toBe('fair');
+    expect(bandHigh(45, 70, 45)).toBe('fair');
+    expect(bandHigh(44.9, 70, 45)).toBe('poor');
+  });
+
+  it('bandLow (lower is better) bands at the thresholds, inclusive at good/fair', () => {
+    expect(bandLow(0.1, 0.1, 0.25)).toBe('good');
+    expect(bandLow(0.11, 0.1, 0.25)).toBe('fair');
+    expect(bandLow(0.25, 0.1, 0.25)).toBe('fair');
+    expect(bandLow(0.26, 0.1, 0.25)).toBe('poor');
+  });
+
+  it('bands NaN as poor in both directions, never good or fair', () => {
+    expect(bandHigh(Number.NaN, 70, 45)).toBe('poor');
+    expect(bandLow(Number.NaN, 0.1, 0.25)).toBe('poor');
+  });
+});


### PR DESCRIPTION
A mechanical SonarCloud maintainability sweep across `src/`, run as seven disjoint per-area passes (render, terrain, io, ui, export/report, and the rest) and consolidated here. It resolves about 750 issues and leaves the behaviour-sensitive ones alone.

## What changed
Behaviour-preserving rewrites: consecutive `.push()` calls merged, `NaN` to `Number.NaN`, `arr[len-1]` to `arr.at(-1)`, `Math.max`/`min` for clamps, `??=` for undefined guards, nested ternaries extracted to `if`/`else`, `readonly` on constructor-only fields, duplicate imports merged, and similar. 241 files, all under `src/`.

## What the sweep leaves unchanged
Nothing that could change a number or a byte is touched:
- `charCodeAt` in the hash, codec, and PDF paths (`codePointAt` would change the digest for non-BMP input);
- `Math.hypot` for released distances (it rounds differently from `sqrt(a*a+b*b)`);
- opposite-operator rewrites where an operand can be NaN (a fail-closed `!(x>0)` is not `x<=0` when `x` is NaN);
- optional chaining where the guard is a general falsy check rather than a null check;
- top-level-await conversions that would reorder the app entry's module init;
- 31 CSS "duplicate selector" flags, each an intentional additive or override split.

Those are covered instead by the repo's own `lint:int-truncation` and the test suite, and `S7767`, `S3776`, `S107` are de-scoped in SonarCloud.

Three SonarCloud reports were false positives, confirmed on inspection: an `S2234` "swapped argument" that was a correct `b - a` displacement (the helper's parameters were renamed), a push-merge that would have evaluated a checksum manifest before its input was complete (left split), and several `S4144`/`S1871` "duplicate" blocks that were intentional priority ladders or independent min/max updates.

## Verification
`tsc` clean; full `vitest` suite 8,584 passed / 0 failed; `lint:monolith-size`, `architecture-truth`, `int-truncation`, `layer-boundaries`, `release-truth` all green; production build clean. `main.ts` and `Viewer.ts` both shrank (5,874 and 6,369); the baseline and the two docs that cite it are re-banked to match.
