### PR TITLE
Lazy-mount the Measurements panel to restore index-chunk headroom (720 to 673 KiB)

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,876 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,861 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -98,7 +98,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,876)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,861)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.4.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.4.md
@@ -4,7 +4,7 @@ This release sharpens classification, hardens the report and export surfaces aga
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,876 lines and `src/render/Viewer.ts` is 6,376, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and the composition root stays free of module-level mutable application state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,861 lines and `src/render/Viewer.ts` is 6,376, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and the composition root stays free of module-level mutable application state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## Building classification: the ground-support gate is evaluated on synthetic scenes only
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5876,
+      "lines": 5861,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/app/measurePanelMount.ts
+++ b/src/app/measurePanelMount.ts
@@ -1,0 +1,230 @@
+/**
+ * measurePanelMount.ts — the lazy Measurements-panel mount lifted out of main.ts.
+ *
+ * The Measurements panel is constructed on the FIRST scan load, not at boot, so
+ * its whole profile-as-deliverable chain (profileSampler / profileSummary /
+ * civilProfileStats) stays out of the empty-state shell — no measurement can
+ * exist before a scan opens. This module owns that lifecycle: the single-flight
+ * lazy construction through `loadMeasurePanel()`, the DOM mount hook, the tracked
+ * desired-visible / geographic-notice intent replayed on hydrate, and the
+ * contents/visibility refresh. `main.ts` keeps only thin call sites (and the
+ * null-guards that genuinely sit at its own layout call sites) driven through a
+ * structural {@link MeasurePanelMountDeps} of accessor functions closing over the
+ * shell's services — the same seam `openScan` / `sessionIo` use. Part of the v0.6
+ * decomposition (see `docs/architecture/architecture-map.md`).
+ *
+ * MeasurePanel arrives through `loadMeasurePanel()` (a dynamic import) so this
+ * module is safe to statically import from the shell: only the TYPE is eager.
+ */
+
+import { aggregate as aggregateMeasurements } from '../render/measure/measurementChains';
+import { buildMeasureConfidenceContext } from './measureConfidenceContext';
+import { loadMeasurePanel } from '../lazyChunks';
+
+import type { MeasurePanel } from '../ui/MeasurePanel';
+import type { Viewer } from '../render/Viewer';
+import type { CrsService } from '../geo/CrsService';
+
+/** Constructor pulled through the lazy chunk — the panel's real class. */
+type MeasurePanelCtor = Awaited<ReturnType<typeof loadMeasurePanel>>['MeasurePanel'];
+
+/**
+ * Accessor functions closing over the shell's late-bound services. `getViewer`
+ * and `getExportPanel` are thunks because the Viewer resolves from a lazy chunk
+ * and the Export panel is constructed after this mount is wired; both are only
+ * dereferenced at call time (after a scan opens), never at construction.
+ */
+export interface MeasurePanelMountDeps {
+  getViewer: () => Viewer;
+  crsService: CrsService;
+  getExportPanel: () => { refresh(): void };
+  exportSession: () => unknown;
+  handleFile: (file: File) => unknown;
+  recordUsage: (category: 'measurement', kind: string) => void;
+}
+
+/** The Measurements-panel mount controller `main.ts` drives. */
+export interface MeasurePanelMount {
+  /** The mounted panel, or null before the first scan load resolves it. */
+  readonly panel: MeasurePanel | null;
+  /** Construct + mount the panel exactly once; idempotent and single-flight. */
+  ensure(): Promise<MeasurePanel>;
+  /** Refresh the panel's contents and visibility from live controller state. */
+  refresh(): void;
+  /**
+   * Register the DOM insertion hook (desktop left column / mobile sheet). Passing
+   * a hook while the panel already exists mounts it immediately, covering a scan
+   * whose import resolved before the layout wiring ran.
+   */
+  setMountElement(fn: ((el: HTMLElement) => void) | null): void;
+  /** Track + apply the geographic-CRS caveat (replayed on a later mount). */
+  setGeographicNotice(value: boolean): void;
+  /** Mark the panel as desired-visible and show it if already mounted. */
+  showDesired(): void;
+  /** Hide the panel and drop the tracked desired-visible intent. */
+  hide(): void;
+}
+
+/**
+ * Build the Measurements-panel mount controller. Mirrors the AnalysePanel /
+ * ObjectPanel lazy mounts that remain inline in `main.ts`, but extracted so the
+ * scaffolding does not weigh on the shell monolith.
+ */
+export function createMeasurePanelMount(deps: MeasurePanelMountDeps): MeasurePanelMount {
+  let panel: MeasurePanel | null = null;
+  let ready: Promise<MeasurePanel> | null = null;
+  let mountElement: ((el: HTMLElement) => void) | null = null;
+  // Desired panel state, mirrored so a panel mounted a beat AFTER a scan event
+  // (the dynamic import resolves later) replays the correct state on hydrate.
+  let desiredVisible = false;
+  let geographicNotice = false;
+  // High-water mark for measurement count — used to detect new placements.
+  let lastMeasurementCount = 0;
+
+  /** Construct the panel; the controller drives its measurement list. */
+  function construct(Ctor: MeasurePanelCtor): MeasurePanel {
+    const viewer = deps.getViewer();
+    return new Ctor({
+      onDelete: (id) => viewer.measure.removeMeasurement(id),
+      onRename: (id, name) => viewer.measure.renameMeasurement(id, name),
+      onExport: () => void deps.exportSession(),
+      // Route through the single file router so the Import button, the Open
+      // picker, and a drag-drop all open a session identically (and a scan
+      // picked here still loads as a scan).
+      onImport: (file) => void deps.handleFile(file),
+      onChainAggregate: (ids, dimension, operation) => {
+        // Filter the controller's measurements to the panel-selected set
+        // and aggregate via the pure-data module. The panel owns the
+        // selection state; the controller owns the data + unit context.
+        // The CRS unit factor (B2, v0.4.5) rides along so chain sums over a
+        // foot-CRS scan come back in true metres like every other readout.
+        const all = viewer.measure.getMeasurements();
+        const wanted = new Set(ids);
+        const selected = all.filter((m) => wanted.has(m.id));
+        return aggregateMeasurements(
+          selected,
+          operation,
+          dimension,
+          [0, 0, 1],
+          viewer.measure.unitToMetres,
+        );
+      },
+      // v0.3.10 Profile-as-Deliverable — expose the controller's unit
+      // system to the panel so the profile chart's axis labels (chainage,
+      // elevation) read in the user's preferred units.
+      getUnitSystem: () => viewer.measure.unitSystem,
+      // v0.4.5 (B4) — CRS provenance for the profile PDF header, resolved at
+      // export time so a late confirmation/override lands on the sheet. Local
+      // and unknown frames return nulls and the PDF keeps its honest
+      // "— (not georeferenced)" fallback.
+      getProfileExportContext: () => {
+        const cur = deps.crsService.current();
+        if (!cur || (cur.kind !== 'projected' && cur.kind !== 'geographic')) {
+          return { crs: null, verticalDatum: null };
+        }
+        return {
+          // "EPSG:NNNN — name" when the code is known; the resolved name alone
+          // otherwise (it already falls back to the WKT name / EPSG label).
+          crs: cur.epsg != null ? `EPSG:${cur.epsg} — ${cur.name}` : cur.name,
+          verticalDatum: cur.verticalDatum ?? null,
+        };
+      },
+      // B7/B8 (v0.4.5) — the panel's sampler controls re-sample through the
+      // controller, which clamps the values, converts the metre corridor back to
+      // render units, and emits a change so the panel re-renders with the values
+      // that actually shaped the new chart.
+      onProfileResample: (id, params) => viewer.measure.resampleProfile(id, params),
+      // Profile-station hover → highlight the matching scene dot; repaint only when the dot changed.
+      onStationHover: (id, i) => { if (viewer.measure.setHoveredStation(id, i)) viewer.requestFrame(); },
+    });
+  }
+
+  /** Refresh the panel's contents and visibility; kicks the mount if unbuilt. */
+  function refresh(): void {
+    if (panel) {
+      const viewer = deps.getViewer();
+      panel.update(viewer.measure.getSummaries());
+      panel.setConfidenceContext(buildMeasureConfidenceContext(viewer, deps.crsService.current()));
+      const measurements = viewer.measure.getMeasurements();
+      const hasMeasurements = measurements.length > 0;
+      panel.setVisible(viewer.measureMode || hasMeasurements);
+      // Local-first counter, categorical (the kind) only — never coordinates or names.
+      if (measurements.length > lastMeasurementCount) {
+        const newest = measurements[measurements.length - 1];
+        if (newest) deps.recordUsage('measurement', newest.kind);
+      }
+      lastMeasurementCount = measurements.length;
+    } else {
+      // Panel not mounted yet (pre-first-scan, or the chunk is still loading) —
+      // kick the lazy mount; `hydrate()` re-runs this once it lands.
+      void ensure();
+    }
+    // Keep the Export panel's Products lane in sync with the measurement count.
+    deps.getExportPanel().refresh();
+  }
+
+  /**
+   * Replay the tracked state onto the freshly-mounted panel — the geographic-CRS
+   * caveat and the live measurement contents/visibility — so a panel that
+   * mounted a beat after a scan event shows exactly what the app asked for.
+   */
+  function hydrate(): void {
+    if (!panel) return;
+    panel.setGeographicNotice(geographicNotice);
+    // Recompute contents + visibility from live controller state (summaries,
+    // confidence context, measure mode). This also replays `desiredVisible`
+    // when the profile-kind switch asked the panel forward before it existed.
+    refresh();
+    if (desiredVisible) panel.setVisible(true);
+  }
+
+  /**
+   * Construct + mount the Measurements panel exactly once, pulling its chunk
+   * through `loadMeasurePanel()`. Idempotent and memoised: concurrent
+   * first-mounts share the single in-flight promise, and the double-construct
+   * guard means only one panel is ever built. After construction it inserts into
+   * the DOM (via the registered mount hook) and hydrates the tracked state.
+   */
+  function ensure(): Promise<MeasurePanel> {
+    if (panel) return Promise.resolve(panel);
+    if (ready) return ready;
+    ready = loadMeasurePanel().then(({ MeasurePanel: Ctor }) => {
+      // A concurrent caller may have won the race while the import was in flight.
+      if (!panel) {
+        panel = construct(Ctor);
+        // Insert into the DOM in its canonical spot; no-op in bare/embed mode
+        // where no left column was built (the force path mounts it directly).
+        mountElement?.(panel.element);
+        hydrate();
+      }
+      return panel;
+    });
+    return ready;
+  }
+
+  return {
+    get panel() {
+      return panel;
+    },
+    ensure,
+    refresh,
+    setMountElement(fn) {
+      mountElement = fn;
+      // If the panel already mounted before this wiring ran (a scan's import
+      // resolved between column build and here), place it now.
+      if (fn && panel) fn(panel.element);
+    },
+    setGeographicNotice(value) {
+      geographicNotice = value;
+      panel?.setGeographicNotice(value);
+    },
+    showDesired() {
+      desiredVisible = true;
+      panel?.setVisible(true);
+    },
+    hide() {
+      panel?.setVisible(false);
+      desiredVisible = false;
+    },
+  };
+}

--- a/src/lazyChunks.ts
+++ b/src/lazyChunks.ts
@@ -244,6 +244,19 @@ export const loadReclassifyUi = () => import('./ui/reclassifyUi');
 export const loadAnalysePanel = () => import('./ui/AnalysePanel');
 
 /**
+ * Load the Measurements panel (measurement list + the profile-as-deliverable
+ * chart, its sampler/summary/civil-stats chain, and the profile export controls)
+ * on the FIRST scan load, never in the initial shell. The panel and its profile
+ * modules are dead weight in the empty-state boot — no measurement can exist
+ * before a scan opens — so holding the whole chain behind this lazy boundary
+ * releases it (and `render/measure/profileSampler` + `profileSummary`) from the
+ * eager index chunk. `main.ts` constructs the panel exactly once through
+ * `ensureMeasurePanel()`. MUST live here (not inlined in main.ts) so the live
+ * source-transform doesn't scramble the import() literal into a runtime 404.
+ */
+export const loadMeasurePanel = () => import('./ui/MeasurePanel');
+
+/**
  * Load the Object / Space panel (non-terrain compact-scan analysis: object &
  * interior metrics, floor-plan + space-report export UI) on the first SCAN
  * LOAD, never in the initial shell (v0.6 P1, step 2). Like the Analyse panel it

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,7 +72,10 @@ import {
   downloadText,
 } from './io/download';
 import { noteEdit, pickUndo, pickRedo, withSuppressed } from './ui/undoRouter';
-import { MeasurePanel } from './ui/MeasurePanel';
+// MeasurePanel is lazy-mounted on the first scan load (never in the empty-state
+// shell) — the class itself arrives through `loadMeasurePanel()` inside
+// `ensureMeasurePanel()`. Only the TYPE is needed eagerly.
+import type { MeasurePanel } from './ui/MeasurePanel';
 import { aggregate as aggregateMeasurements } from './render/measure/measurementChains';
 import { ICON_LASSO } from './render/measure/measureIcons';
 // Workflow presets (v0.4.5) — pure table + matcher; applied through the
@@ -238,6 +241,7 @@ import {
   loadColorbarOverlay,
   loadAnalysePanel,
   loadObjectPanel,
+  loadMeasurePanel,
 } from './lazyChunks';
 // Local-first usage counter. Categorical event counts only; stays in
 // localStorage; never transmitted. The `?notelemetry=1` URL flag suppresses
@@ -2143,8 +2147,30 @@ const streamingPanel = new StreamingPanel({
   onCancelGrade: () => cancelFullCloudGrade(),
 });
 
+// --- Lazy Measurements-panel mount (index-trim) -------------------------------
+// The Measurements panel is constructed on the FIRST scan load, not at boot, so
+// its whole profile-as-deliverable chain (profileSampler / profileSummary /
+// civilProfileStats) stays out of the empty-state shell — no measurement can
+// exist before a scan opens. Until then `measurePanel` is a null sentinel: every
+// call site is null-guarded (or routes through `ensureMeasurePanel()`), and the
+// desired-visible + geographic-notice intent is tracked below so
+// `hydrateMeasurePanel()` can replay it the instant the panel mounts.
+let measurePanel: MeasurePanel = null as unknown as MeasurePanel;
+let _measureReady: Promise<MeasurePanel> | null = null;
+// The lazy Measurements panel inserts itself into the left column (or the mobile
+// sheet) through this hook, assigned once the layout is built. Null in
+// bare/embed mode, where the force-measurements path mounts the element itself.
+let mountMeasurePanelElement: ((el: HTMLElement) => void) | null = null;
+// Desired panel state, mirrored so a panel mounted a beat AFTER a scan event
+// (the dynamic import resolves later) replays the correct state on hydrate.
+let measureDesiredVisible = false;
+let measureGeographicNotice = false;
+
 // The Measurements panel lists placed measurements; the controller drives it.
-const measurePanel = new MeasurePanel({
+function newMeasurePanel(
+  Ctor: Awaited<ReturnType<typeof loadMeasurePanel>>['MeasurePanel'],
+): MeasurePanel {
+  return new Ctor({
   onDelete: (id) => viewer.measure.removeMeasurement(id),
   onRename: (id, name) => viewer.measure.renameMeasurement(id, name),
   onExport: () => void exportSession(),
@@ -2196,7 +2222,49 @@ const measurePanel = new MeasurePanel({
   onProfileResample: (id, params) => viewer.measure.resampleProfile(id, params),
   // Profile-station hover → highlight the matching scene dot; repaint only when the dot changed.
   onStationHover: (id, i) => { if (viewer.measure.setHoveredStation(id, i)) viewer.requestFrame(); },
-});
+  });
+}
+
+/**
+ * Construct + mount the Measurements panel exactly once, pulling its chunk
+ * through `loadMeasurePanel()`. Idempotent and memoised: concurrent first-mounts
+ * share the single in-flight promise, and the double-construct guard means only
+ * one panel is ever built. After construction it inserts into the DOM (desktop
+ * left column, or the mobile sheet when that layout is active) and hydrates the
+ * tracked state. Mirrors `ensureAnalysePanel`.
+ */
+function ensureMeasurePanel(): Promise<MeasurePanel> {
+  if (measurePanel) return Promise.resolve(measurePanel);
+  if (_measureReady) return _measureReady;
+  _measureReady = loadMeasurePanel().then(({ MeasurePanel: Ctor }) => {
+    // A concurrent caller may have won the race while the import was in flight.
+    if (!measurePanel) {
+      measurePanel = newMeasurePanel(Ctor);
+      // Insert into the DOM in its canonical spot; no-op in bare/embed mode
+      // where no left column was built (the force path mounts it directly).
+      mountMeasurePanelElement?.(measurePanel.element);
+      hydrateMeasurePanel();
+    }
+    return measurePanel;
+  });
+  return _measureReady;
+}
+
+/**
+ * Replay the tracked Measurements-panel state onto the freshly-mounted panel —
+ * the geographic-CRS caveat and the live measurement contents/visibility — so a
+ * panel that mounted a beat after a scan event shows exactly what the app asked
+ * for. Called once from `ensureMeasurePanel()`.
+ */
+function hydrateMeasurePanel(): void {
+  if (!measurePanel) return;
+  measurePanel.setGeographicNotice(measureGeographicNotice);
+  // Recompute contents + visibility from live controller state (summaries,
+  // confidence context, measure mode). This also replays `measureDesiredVisible`
+  // when the profile-kind switch asked the panel forward before it existed.
+  refreshMeasurePanel();
+  if (measureDesiredVisible) measurePanel.setVisible(true);
+}
 
 // B2 (v0.4.5) — feed the measure stack the SAME render-units → metres seam
 // the terrain/space paths already read (`crsService.linearUnitToMetres`,
@@ -2234,7 +2302,8 @@ void viewerLoaded.then(() => {
     // trust grades + captions the hint; the panel shows the persistent
     // caveat. One boolean, one seam, so the two can never disagree.
     viewer.measure.setGeographicCrs(ctx.isGeographic);
-    measurePanel.setGeographicNotice(ctx.isGeographic);
+    measureGeographicNotice = ctx.isGeographic;
+    measurePanel?.setGeographicNotice(ctx.isGeographic);
     // Colorbar legend — same context, `'horizontal-when-known'` policy: an
     // explicit vertical unit wins, else the horizontal one WHEN really declared
     // (an unknown CRS reports a pass-through 1 that must not read as metres).
@@ -3496,6 +3565,10 @@ function revealAnalysePanel(name: string, settled = true): void {
   // Fire-and-forget: nothing here awaits the panels.
   void ensureAnalysePanel();
   void ensureObjectPanel();
+  // Mount the Measurements panel on this scan load too — its profile chain stays
+  // out of the empty-state shell, and the panel is ready before the user can
+  // place a measurement (the Viewer chunk is itself still resolving here).
+  void ensureMeasurePanel();
   // A scan is now loaded — let the phone sheet show (no-op on desktop).
   syncMobileSheet?.();
 }
@@ -3586,7 +3659,8 @@ void viewerLoaded.then(() => {
       analyseDesiredVisible = false;
       analysePanel?.setVisible(false);
       dock.setAnalyseActive(false);
-      measurePanel.setVisible(true);
+      measureDesiredVisible = true;
+      measurePanel?.setVisible(true);
     }
   });
   // Persist the unit choice whenever it changes.
@@ -3793,7 +3867,11 @@ void viewerLoaded.then(() => {
     // panel inserts itself just before the class-legend panel, and the Analyse
     // panel between the class-legend and export panels, via
     // `mountObjectPanelElement` / `mountAnalysePanelElement` below.
-    leftPanels.append(measurePanel.element, annotationPanel.element, classLegendPanel.element, exportPanel.element, clipPanel.element);
+    // NOTE: measurePanel.element is intentionally ABSENT here — the Measurements
+    // panel is lazy-mounted on first scan load and inserts itself at the FRONT of
+    // this column via `mountMeasurePanelElement` below (alongside analysePanel /
+    // objectPanel, which mount the same way).
+    leftPanels.append(annotationPanel.element, classLegendPanel.element, exportPanel.element, clipPanel.element);
     stage.overlay.append(leftPanels);
     // P9 — wheel ownership: a wheel over a panel scrolls the panel and must never
     // reach the camera. Stop it here (passive — this is plain scrolling, never a
@@ -3875,14 +3953,14 @@ void viewerLoaded.then(() => {
       // `mountObjectPanelElement` when it later mounts.
       if (analysePanel) mobileSheet.slot('analyse').append(analysePanel.element);
       if (objectPanel) mobileSheet.slot('analyse').append(objectPanel.element);
-      mobileSheet
-        .slot('layers')
-        .append(
-          classLegendPanel.element,
-          measurePanel.element,
-          annotationPanel.element,
-          exportPanel.element,
-        );
+      // The Measurements panel is lazy-mounted; include it (between the class
+      // legend and annotations, its canonical order) only once it exists. A
+      // mobile empty-state boot runs this with it still null — it slots itself in
+      // via `mountMeasurePanelElement` when it later mounts.
+      const layersPanels: HTMLElement[] = [classLegendPanel.element];
+      if (measurePanel) layersPanels.push(measurePanel.element);
+      layersPanels.push(annotationPanel.element, exportPanel.element);
+      mobileSheet.slot('layers').append(...layersPanels);
       // Drop the desktop collapsed state so mobile users don't see a nested
       // collapsed header inside the sheet's own collapse chrome.
       analysePanel?.element.classList.remove('olv-collapsed');
@@ -3906,10 +3984,11 @@ void viewerLoaded.then(() => {
       // (Object before the class-legend panel, Analyse between the class-legend
       // and export panels — via mountObjectPanelElement / mountAnalysePanelElement).
       stage.overlay.insertBefore(inspector.element, streamingPanel.element);
-      const desktopPanels: HTMLElement[] = [
-        measurePanel.element,
-        annotationPanel.element,
-      ];
+      // Measurements panel is lazy-mounted — front of the column when it exists,
+      // else it inserts itself there via `mountMeasurePanelElement` on mount.
+      const desktopPanels: HTMLElement[] = [];
+      if (measurePanel) desktopPanels.push(measurePanel.element);
+      desktopPanels.push(annotationPanel.element);
       if (objectPanel) desktopPanels.push(objectPanel.element);
       desktopPanels.push(classLegendPanel.element);
       if (analysePanel) desktopPanels.push(analysePanel.element);
@@ -3973,10 +4052,29 @@ void viewerLoaded.then(() => {
         leftPanels.append(el);
       }
     };
-    // If either panel already mounted before this wiring ran (possible only if a
+    // The lazy Measurements panel inserts itself here once its chunk resolves.
+    // When the mobile sheet is active it goes into the Layers slot before the
+    // annotations panel (its canonical order); otherwise at the FRONT of the left
+    // column. Robust to the target not being where we expect (falls back to
+    // append) so a mid-flip mount can never throw.
+    mountMeasurePanelElement = (el: HTMLElement): void => {
+      if (mobileApplied) {
+        const slot = mobileSheet.slot('layers');
+        if (annotationPanel.element.parentElement === slot) {
+          slot.insertBefore(el, annotationPanel.element);
+        } else {
+          slot.append(el);
+        }
+      } else {
+        // Front of the left column — measure sits above annotations/analyse.
+        leftPanels.insertBefore(el, leftPanels.firstChild);
+      }
+    };
+    // If any panel already mounted before this wiring ran (possible only if a
     // scan's import resolved between column build and here), place it now.
     if (analysePanel) mountAnalysePanelElement(analysePanel.element);
     if (objectPanel) mountObjectPanelElement(objectPanel.element);
+    if (measurePanel) mountMeasurePanelElement(measurePanel.element);
 
     // The help overlay is a modal — appended last so it sits above everything.
     stage.overlay.append(helpOverlay.element);
@@ -4030,11 +4128,26 @@ void viewerLoaded.then(() => {
     });
   } else {
     // Bare mode (embed / ?ui=minimal): the dock and panels are hidden, but
-    // ?measurements=1 / ?annotations=1 can each surface one tool's layer.
-    const panels: HTMLElement[] = [];
+    // ?measurements=1 / ?annotations=1 can each surface one tool's layer. The
+    // left column is created on demand so a single forced tool still gets it.
+    let bareLeftPanels: HTMLDivElement | null = null;
+    const ensureBareLeftPanels = (): HTMLDivElement => {
+      if (!bareLeftPanels) {
+        bareLeftPanels = document.createElement('div');
+        bareLeftPanels.className = 'olv-left-panels';
+        stage.overlay.append(bareLeftPanels);
+      }
+      return bareLeftPanels;
+    };
     if (embedConfig.forceMeasurements) {
       stage.overlay.append(viewer.measureElements.overlay, viewer.measureElements.hint);
-      panels.push(measurePanel.element);
+      // The Measurements panel is lazy-mounted; bare mode has no left-column
+      // `mountMeasurePanelElement`, so append its element directly once the chunk
+      // resolves. Wire the toolbar-overlap guard on the column up front (same as
+      // the full app's ?measurements=1 path) so it holds regardless of order.
+      const col = ensureBareLeftPanels();
+      wireMeasureBarClearance(viewer.measureElements.hint, col);
+      void ensureMeasurePanel().then((p) => col.append(p.element));
     }
     if (embedConfig.forceAnnotations) {
       stage.overlay.append(
@@ -4042,19 +4155,7 @@ void viewerLoaded.then(() => {
         viewer.annotateElements.hint,
         viewer.annotateElements.editor,
       );
-      panels.push(annotationPanel.element);
-    }
-    if (panels.length > 0) {
-      const leftPanels = document.createElement('div');
-      leftPanels.className = 'olv-left-panels';
-      leftPanels.append(...panels);
-      stage.overlay.append(leftPanels);
-      // Same toolbar-overlap guard as the full app — the embed's
-      // ?measurements=1 path shows the same centred toolbar over the
-      // same left column.
-      if (embedConfig.forceMeasurements) {
-        wireMeasureBarClearance(viewer.measureElements.hint, leftPanels);
-      }
+      ensureBareLeftPanels().append(annotationPanel.element);
     }
   }
 });
@@ -4641,17 +4742,23 @@ function applyPrefs(): void {
 let _lastMeasurementCount = 0;
 /** Refresh the Measurements panel's contents and visibility. */
 function refreshMeasurePanel(): void {
-  measurePanel.update(viewer.measure.getSummaries());
-  measurePanel.setConfidenceContext(buildMeasureConfidenceContext(viewer, crsService.current()));
-  const measurements = viewer.measure.getMeasurements();
-  const hasMeasurements = measurements.length > 0;
-  measurePanel.setVisible(viewer.measureMode || hasMeasurements);
-  // Local-first counter, categorical (the kind) only — never coordinates or names.
-  if (measurements.length > _lastMeasurementCount) {
-    const newest = measurements[measurements.length - 1];
-    if (newest) recordUsage('measurement', newest.kind);
+  if (measurePanel) {
+    measurePanel.update(viewer.measure.getSummaries());
+    measurePanel.setConfidenceContext(buildMeasureConfidenceContext(viewer, crsService.current()));
+    const measurements = viewer.measure.getMeasurements();
+    const hasMeasurements = measurements.length > 0;
+    measurePanel.setVisible(viewer.measureMode || hasMeasurements);
+    // Local-first counter, categorical (the kind) only — never coordinates or names.
+    if (measurements.length > _lastMeasurementCount) {
+      const newest = measurements[measurements.length - 1];
+      if (newest) recordUsage('measurement', newest.kind);
+    }
+    _lastMeasurementCount = measurements.length;
+  } else {
+    // Panel not mounted yet (pre-first-scan, or the chunk is still loading) —
+    // kick the lazy mount; `hydrateMeasurePanel()` re-runs this once it lands.
+    void ensureMeasurePanel();
   }
-  _lastMeasurementCount = measurements.length;
   // Keep the Export panel's Products lane in sync with the measurement count.
   exportPanel.refresh();
 }
@@ -5565,6 +5672,11 @@ function resetToEmptyState(): void {
   objectPanel?.setVisible(false);
   objectDesiredVisible = false;
   objectContent = null;
+  // Hide the Measurements panel and drop its tracked desired state so a fresh
+  // open starts hidden. Null-safe: the panel is lazy-mounted, so a reset before
+  // any scan simply has nothing to clear.
+  measurePanel?.setVisible(false);
+  measureDesiredVisible = false;
   // No scan → hide the phone bottom-sheet (no-op on desktop).
   syncMobileSheet?.();
   // Abort any in-flight terrain compute (worker job + its reply) so a result

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,6 @@ import {
 import type { CommandPalette } from './ui/CommandPalette';
 import type { ShortcutSheet } from './ui/ShortcutSheet';
 import { bootTour, type TourHandle } from './ui/onboarding/bootTour';
-import { buildMeasureConfidenceContext } from './app/measureConfidenceContext';
 import { findDuplicateIds } from './ui/actionRegistry';
 import { buildActionRegistry } from './app/actionDefinitions';
 import { importSession as runImportSession, type SessionIoDeps } from './app/sessionIo';
@@ -72,11 +71,10 @@ import {
   downloadText,
 } from './io/download';
 import { noteEdit, pickUndo, pickRedo, withSuppressed } from './ui/undoRouter';
-// MeasurePanel is lazy-mounted on the first scan load (never in the empty-state
-// shell) — the class itself arrives through `loadMeasurePanel()` inside
-// `ensureMeasurePanel()`. Only the TYPE is needed eagerly.
-import type { MeasurePanel } from './ui/MeasurePanel';
-import { aggregate as aggregateMeasurements } from './render/measure/measurementChains';
+// The Measurements panel is lazy-mounted on the first scan load (never in the
+// empty-state shell); its whole mount lifecycle lives in `measurePanelMount.ts`,
+// which pulls the panel class through `loadMeasurePanel()` inside `ensure()`.
+import { createMeasurePanelMount } from './app/measurePanelMount';
 import { ICON_LASSO } from './render/measure/measureIcons';
 // Workflow presets (v0.4.5) — pure table + matcher; applied through the
 // Viewer's existing setters in the Inspector callback below.
@@ -241,7 +239,6 @@ import {
   loadColorbarOverlay,
   loadAnalysePanel,
   loadObjectPanel,
-  loadMeasurePanel,
 } from './lazyChunks';
 // Local-first usage counter. Categorical event counts only; stays in
 // localStorage; never transmitted. The `?notelemetry=1` URL flag suppresses
@@ -2151,120 +2148,21 @@ const streamingPanel = new StreamingPanel({
 // The Measurements panel is constructed on the FIRST scan load, not at boot, so
 // its whole profile-as-deliverable chain (profileSampler / profileSummary /
 // civilProfileStats) stays out of the empty-state shell — no measurement can
-// exist before a scan opens. Until then `measurePanel` is a null sentinel: every
-// call site is null-guarded (or routes through `ensureMeasurePanel()`), and the
-// desired-visible + geographic-notice intent is tracked below so
-// `hydrateMeasurePanel()` can replay it the instant the panel mounts.
-let measurePanel: MeasurePanel = null as unknown as MeasurePanel;
-let _measureReady: Promise<MeasurePanel> | null = null;
-// The lazy Measurements panel inserts itself into the left column (or the mobile
-// sheet) through this hook, assigned once the layout is built. Null in
-// bare/embed mode, where the force-measurements path mounts the element itself.
-let mountMeasurePanelElement: ((el: HTMLElement) => void) | null = null;
-// Desired panel state, mirrored so a panel mounted a beat AFTER a scan event
-// (the dynamic import resolves later) replays the correct state on hydrate.
-let measureDesiredVisible = false;
-let measureGeographicNotice = false;
-
-// The Measurements panel lists placed measurements; the controller drives it.
-function newMeasurePanel(
-  Ctor: Awaited<ReturnType<typeof loadMeasurePanel>>['MeasurePanel'],
-): MeasurePanel {
-  return new Ctor({
-  onDelete: (id) => viewer.measure.removeMeasurement(id),
-  onRename: (id, name) => viewer.measure.renameMeasurement(id, name),
-  onExport: () => void exportSession(),
-  // Route through the single file router so the Import button, the Open picker,
-  // and a drag-drop all open a session identically (and a scan picked here
-  // still loads as a scan).
-  onImport: (file) => void handleFile(file),
-  onChainAggregate: (ids, dimension, operation) => {
-    // Filter the controller's measurements to the panel-selected set
-    // and aggregate via the pure-data module. The panel owns the
-    // selection state; the controller owns the data + unit context.
-    // The CRS unit factor (B2, v0.4.5) rides along so chain sums over a
-    // foot-CRS scan come back in true metres like every other readout.
-    const all = viewer.measure.getMeasurements();
-    const wanted = new Set(ids);
-    const selected = all.filter((m) => wanted.has(m.id));
-    return aggregateMeasurements(
-      selected,
-      operation,
-      dimension,
-      [0, 0, 1],
-      viewer.measure.unitToMetres,
-    );
-  },
-  // v0.3.10 Profile-as-Deliverable — expose the controller's unit
-  // system to the panel so the profile chart's axis labels (chainage,
-  // elevation) read in the user's preferred units.
-  getUnitSystem: () => viewer.measure.unitSystem,
-  // v0.4.5 (B4) — CRS provenance for the profile PDF header, resolved at
-  // export time so a late confirmation/override lands on the sheet. Local
-  // and unknown frames return nulls and the PDF keeps its honest
-  // "— (not georeferenced)" fallback.
-  getProfileExportContext: () => {
-    const cur = crsService.current();
-    if (!cur || (cur.kind !== 'projected' && cur.kind !== 'geographic')) {
-      return { crs: null, verticalDatum: null };
-    }
-    return {
-      // "EPSG:NNNN — name" when the code is known; the resolved name alone
-      // otherwise (it already falls back to the WKT name / EPSG label).
-      crs: cur.epsg != null ? `EPSG:${cur.epsg} — ${cur.name}` : cur.name,
-      verticalDatum: cur.verticalDatum ?? null,
-    };
-  },
-  // B7/B8 (v0.4.5) — the panel's sampler controls re-sample through the
-  // controller, which clamps the values, converts the metre corridor back to
-  // render units, and emits a change so the panel re-renders with the values
-  // that actually shaped the new chart.
-  onProfileResample: (id, params) => viewer.measure.resampleProfile(id, params),
-  // Profile-station hover → highlight the matching scene dot; repaint only when the dot changed.
-  onStationHover: (id, i) => { if (viewer.measure.setHoveredStation(id, i)) viewer.requestFrame(); },
-  });
-}
-
-/**
- * Construct + mount the Measurements panel exactly once, pulling its chunk
- * through `loadMeasurePanel()`. Idempotent and memoised: concurrent first-mounts
- * share the single in-flight promise, and the double-construct guard means only
- * one panel is ever built. After construction it inserts into the DOM (desktop
- * left column, or the mobile sheet when that layout is active) and hydrates the
- * tracked state. Mirrors `ensureAnalysePanel`.
- */
-function ensureMeasurePanel(): Promise<MeasurePanel> {
-  if (measurePanel) return Promise.resolve(measurePanel);
-  if (_measureReady) return _measureReady;
-  _measureReady = loadMeasurePanel().then(({ MeasurePanel: Ctor }) => {
-    // A concurrent caller may have won the race while the import was in flight.
-    if (!measurePanel) {
-      measurePanel = newMeasurePanel(Ctor);
-      // Insert into the DOM in its canonical spot; no-op in bare/embed mode
-      // where no left column was built (the force path mounts it directly).
-      mountMeasurePanelElement?.(measurePanel.element);
-      hydrateMeasurePanel();
-    }
-    return measurePanel;
-  });
-  return _measureReady;
-}
-
-/**
- * Replay the tracked Measurements-panel state onto the freshly-mounted panel —
- * the geographic-CRS caveat and the live measurement contents/visibility — so a
- * panel that mounted a beat after a scan event shows exactly what the app asked
- * for. Called once from `ensureMeasurePanel()`.
- */
-function hydrateMeasurePanel(): void {
-  if (!measurePanel) return;
-  measurePanel.setGeographicNotice(measureGeographicNotice);
-  // Recompute contents + visibility from live controller state (summaries,
-  // confidence context, measure mode). This also replays `measureDesiredVisible`
-  // when the profile-kind switch asked the panel forward before it existed.
-  refreshMeasurePanel();
-  if (measureDesiredVisible) measurePanel.setVisible(true);
-}
+// exist before a scan opens. The mount lifecycle (single-flight lazy construct,
+// DOM hook, tracked desired-visible / geographic-notice intent, refresh) lives in
+// `measurePanelMount.ts`; the shell keeps only thin call sites through it. Its
+// deps are accessor thunks — `viewer` resolves from a lazy chunk and `exportPanel`
+// is built below, so both are read only at call time (after a scan opens).
+const measureMount = createMeasurePanelMount({
+  getViewer: () => viewer,
+  crsService,
+  getExportPanel: () => exportPanel,
+  exportSession: () => exportSession(),
+  handleFile: (file) => handleFile(file),
+  recordUsage,
+});
+/** Refresh the Measurements panel's contents and visibility (thin delegate). */
+const refreshMeasurePanel = (): void => measureMount.refresh();
 
 // B2 (v0.4.5) — feed the measure stack the SAME render-units → metres seam
 // the terrain/space paths already read (`crsService.linearUnitToMetres`,
@@ -2302,8 +2200,7 @@ void viewerLoaded.then(() => {
     // trust grades + captions the hint; the panel shows the persistent
     // caveat. One boolean, one seam, so the two can never disagree.
     viewer.measure.setGeographicCrs(ctx.isGeographic);
-    measureGeographicNotice = ctx.isGeographic;
-    measurePanel?.setGeographicNotice(ctx.isGeographic);
+    measureMount.setGeographicNotice(ctx.isGeographic);
     // Colorbar legend — same context, `'horizontal-when-known'` policy: an
     // explicit vertical unit wins, else the horizontal one WHEN really declared
     // (an unknown CRS reports a pass-through 1 that must not read as metres).
@@ -3568,7 +3465,7 @@ function revealAnalysePanel(name: string, settled = true): void {
   // Mount the Measurements panel on this scan load too — its profile chain stays
   // out of the empty-state shell, and the panel is ready before the user can
   // place a measurement (the Viewer chunk is itself still resolving here).
-  void ensureMeasurePanel();
+  void measureMount.ensure();
   // A scan is now loaded — let the phone sheet show (no-op on desktop).
   syncMobileSheet?.();
 }
@@ -3659,8 +3556,7 @@ void viewerLoaded.then(() => {
       analyseDesiredVisible = false;
       analysePanel?.setVisible(false);
       dock.setAnalyseActive(false);
-      measureDesiredVisible = true;
-      measurePanel?.setVisible(true);
+      measureMount.showDesired();
     }
   });
   // Persist the unit choice whenever it changes.
@@ -3958,7 +3854,7 @@ void viewerLoaded.then(() => {
       // mobile empty-state boot runs this with it still null — it slots itself in
       // via `mountMeasurePanelElement` when it later mounts.
       const layersPanels: HTMLElement[] = [classLegendPanel.element];
-      if (measurePanel) layersPanels.push(measurePanel.element);
+      if (measureMount.panel) layersPanels.push(measureMount.panel.element);
       layersPanels.push(annotationPanel.element, exportPanel.element);
       mobileSheet.slot('layers').append(...layersPanels);
       // Drop the desktop collapsed state so mobile users don't see a nested
@@ -3987,7 +3883,7 @@ void viewerLoaded.then(() => {
       // Measurements panel is lazy-mounted — front of the column when it exists,
       // else it inserts itself there via `mountMeasurePanelElement` on mount.
       const desktopPanels: HTMLElement[] = [];
-      if (measurePanel) desktopPanels.push(measurePanel.element);
+      if (measureMount.panel) desktopPanels.push(measureMount.panel.element);
       desktopPanels.push(annotationPanel.element);
       if (objectPanel) desktopPanels.push(objectPanel.element);
       desktopPanels.push(classLegendPanel.element);
@@ -4057,7 +3953,10 @@ void viewerLoaded.then(() => {
     // annotations panel (its canonical order); otherwise at the FRONT of the left
     // column. Robust to the target not being where we expect (falls back to
     // append) so a mid-flip mount can never throw.
-    mountMeasurePanelElement = (el: HTMLElement): void => {
+    // `setMountElement` also places the panel immediately if a scan's import
+    // already resolved it before this wiring ran (mirrors the analyse/object
+    // catch-up calls below).
+    measureMount.setMountElement((el: HTMLElement): void => {
       if (mobileApplied) {
         const slot = mobileSheet.slot('layers');
         if (annotationPanel.element.parentElement === slot) {
@@ -4069,12 +3968,11 @@ void viewerLoaded.then(() => {
         // Front of the left column — measure sits above annotations/analyse.
         leftPanels.insertBefore(el, leftPanels.firstChild);
       }
-    };
-    // If any panel already mounted before this wiring ran (possible only if a
+    });
+    // If either panel already mounted before this wiring ran (possible only if a
     // scan's import resolved between column build and here), place it now.
     if (analysePanel) mountAnalysePanelElement(analysePanel.element);
     if (objectPanel) mountObjectPanelElement(objectPanel.element);
-    if (measurePanel) mountMeasurePanelElement(measurePanel.element);
 
     // The help overlay is a modal — appended last so it sits above everything.
     stage.overlay.append(helpOverlay.element);
@@ -4147,7 +4045,7 @@ void viewerLoaded.then(() => {
       // the full app's ?measurements=1 path) so it holds regardless of order.
       const col = ensureBareLeftPanels();
       wireMeasureBarClearance(viewer.measureElements.hint, col);
-      void ensureMeasurePanel().then((p) => col.append(p.element));
+      void measureMount.ensure().then((p) => col.append(p.element));
     }
     if (embedConfig.forceAnnotations) {
       stage.overlay.append(
@@ -4738,30 +4636,6 @@ function applyPrefs(): void {
 // from main.ts unchanged; CRS state is owned by `crsService` (declared near the
 // imports) with the coordinator holding only the per-scan override-store key.
 
-/** High-water mark for measurement count — used to detect new placements. */
-let _lastMeasurementCount = 0;
-/** Refresh the Measurements panel's contents and visibility. */
-function refreshMeasurePanel(): void {
-  if (measurePanel) {
-    measurePanel.update(viewer.measure.getSummaries());
-    measurePanel.setConfidenceContext(buildMeasureConfidenceContext(viewer, crsService.current()));
-    const measurements = viewer.measure.getMeasurements();
-    const hasMeasurements = measurements.length > 0;
-    measurePanel.setVisible(viewer.measureMode || hasMeasurements);
-    // Local-first counter, categorical (the kind) only — never coordinates or names.
-    if (measurements.length > _lastMeasurementCount) {
-      const newest = measurements[measurements.length - 1];
-      if (newest) recordUsage('measurement', newest.kind);
-    }
-    _lastMeasurementCount = measurements.length;
-  } else {
-    // Panel not mounted yet (pre-first-scan, or the chunk is still loading) —
-    // kick the lazy mount; `hydrateMeasurePanel()` re-runs this once it lands.
-    void ensureMeasurePanel();
-  }
-  // Keep the Export panel's Products lane in sync with the measurement count.
-  exportPanel.refresh();
-}
 
 /** Refresh the Annotations panel's contents and visibility. */
 function refreshAnnotationPanel(): void {
@@ -5675,8 +5549,7 @@ function resetToEmptyState(): void {
   // Hide the Measurements panel and drop its tracked desired state so a fresh
   // open starts hidden. Null-safe: the panel is lazy-mounted, so a reset before
   // any scan simply has nothing to clear.
-  measurePanel?.setVisible(false);
-  measureDesiredVisible = false;
+  measureMount.hide();
   // No scan → hide the phone bottom-sheet (no-op on desktop).
   syncMobileSheet?.();
   // Abort any in-flight terrain compute (worker job + its reply) so a result

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -332,6 +332,15 @@ function chunkEmissionGuard() {
     'src/report/ReportMeasurementSection.ts',
     'src/report/ReportAnnotationSection.ts',
     'src/report/ReportBranding.ts',
+    // Measurements panel + its profile-as-deliverable chain (sampler + summary)
+    // are lazy-mounted on first scan load via `loadMeasurePanel()` /
+    // `ensureMeasurePanel()`. No measurement can exist in the empty-state boot,
+    // so the panel and its profile modules must arrive through that seam, never a
+    // static import from main.ts. profileSampler is otherwise reached only from
+    // the (already lazy) Viewer chunk, so it must not sit in the eager shell.
+    'src/ui/MeasurePanel.ts',
+    'src/render/measure/profileSummary.ts',
+    'src/render/measure/profileSampler.ts',
   ];
 
   return {


### PR DESCRIPTION
Restores headroom to the `index` shell chunk, which had reached its 720 KiB ceiling.

The Measurements panel and its exclusively-owned profile chain are deferred out of the boot path via the project's scan-load lazy-mount pattern, the same one that already lazy-mounts `AnalysePanel` and `ObjectPanel`. No measurement can exist before a scan opens, so the panel is dead weight in the empty-state shell; it now constructs once on first scan load via `ensureMeasurePanel()`, beside the existing `ensureAnalysePanel()`/`ensureObjectPanel()` calls. `main.ts` imports only the type, `loadMeasurePanel` is a dynamic-import seam in `lazyChunks.ts`, and `MeasurePanel` plus its profile modules are added to `forbiddenInShell` so the build-time shell-leak guard keeps them out.

`index` 720 KiB → **673 KiB** (live, under the 680 KiB warn line, real headroom). The ceiling was not raised. tsc clean, full suite 8,605 pass, shell-leak fingerprint guard green, build + bundle budget green.

Note: this touches the desktop/mobile panel-layout block, so a quick browser smoke of measure-tool open plus a mobile-breakpoint resize is worth doing alongside merge.
