### PR TITLE
Tighter terrain and measurement precision for v0.6.4

### DIFF
--- a/src/render/measure/format.ts
+++ b/src/render/measure/format.ts
@@ -4,13 +4,14 @@
  * Unit-aware formatting of measurement values for on-screen labels and the
  * Measurements panel. Pure — unit-tested in Node.
  *
- * The metric length format delegates to `navMath.formatDistance`, so the
- * distance tool's labels stay byte-identical to the original implementation
- * (no regression). The imperial branch and the area / angle / grade
- * formatters live here.
+ * Length and area readouts carry ADAPTIVE precision (see {@link displayDecimals}):
+ * the decimal count follows the value's magnitude so a sub-centimetre baseline
+ * keeps real digits (0.0020 m → "0.2000 cm", not "0.00 m") while a large span
+ * stays uncluttered (500.00 m, not 500.0000). The panel, the CSV and the PDF
+ * all read the same helpers here, so the precision policy cannot fork across
+ * surfaces. The imperial branch and the angle / grade formatters live here too.
  */
 
-import { formatDistance } from '../navMath';
 import type { UnitSystem } from './types';
 
 /**
@@ -75,16 +76,68 @@ function grouped(value: number, decimals: number): string {
   });
 }
 
+/**
+ * How many significant figures a length / area readout aims to show.
+ *
+ * The datasets now span sub-millimetre baselines (a 2 mm span) to kilometre
+ * corridors, and a fixed 2-decimal (centimetre) readout collapses the small
+ * end — 0.0020 m printed "0.00 m", a 50.009999 m GCP baseline printed "50.01 m"
+ * with the millimetre rounded away. Displaying a fixed number of SIGNIFICANT
+ * figures instead makes the decimal count follow the magnitude: small values
+ * gain decimals, large values shed them, so both ends read honestly.
+ */
+const DISPLAY_SIG_FIGS = 5;
+
+/**
+ * Decimal count for a display-unit value under the {@link DISPLAY_SIG_FIGS}
+ * policy, clamped to `[minDecimals, maxDecimals]`.
+ *
+ * `minDecimals` keeps a clean value looking familiar within its band (metres
+ * never drop below "0.00 m"); `maxDecimals` bounds the tail so a tiny value
+ * cannot demand an unreadable run of digits. Trailing zeros are KEPT — they
+ * are the visible signal that the reading carries that many significant
+ * figures (50.009999 m → "50.010 m", the millimetre place shown even though it
+ * rounds to zero). Pure and deterministic; the value passed is already in the
+ * unit that will be printed (centimetres, metres, km, m², …).
+ */
+function displayDecimals(
+  displayValue: number,
+  minDecimals: number,
+  maxDecimals: number,
+): number {
+  const abs = Math.abs(displayValue);
+  if (!(abs > 0) || !Number.isFinite(abs)) return minDecimals;
+  // leadingPlace: 0 for 1–9.99, 1 for 10–99.99, −1 for 0.1–0.99, …
+  const leadingPlace = Math.floor(Math.log10(abs));
+  const forSigFigs = DISPLAY_SIG_FIGS - 1 - leadingPlace;
+  return Math.min(maxDecimals, Math.max(minDecimals, forSigFigs));
+}
+
 /** Format a length given in metres for the active unit system. */
 export function formatLength(metres: number, system: UnitSystem): string {
   if (!Number.isFinite(metres)) return '—';
-  if (system === 'metric') return formatDistance(metres);
+  if (system === 'metric') {
+    const abs = Math.abs(metres);
+    // Band by magnitude (not sign): a signed reading — a downward delta, an
+    // elevation below the render origin — stays in the unit its size warrants.
+    if (abs < 1) {
+      const cm = metres * 100;
+      return `${cm.toFixed(displayDecimals(cm, 1, 4))} cm`;
+    }
+    if (abs < 1000) return `${metres.toFixed(displayDecimals(metres, 2, 4))} m`;
+    const km = metres / 1000;
+    return `${km.toFixed(displayDecimals(km, 3, 4))} km`;
+  }
 
   const feet = metres * FEET_PER_METRE;
   const abs = Math.abs(feet);
-  if (abs < 1) return `${(feet * 12).toFixed(1)} in`;
-  if (abs < FEET_PER_MILE) return `${feet.toFixed(2)} ft`;
-  return `${(feet / FEET_PER_MILE).toFixed(3)} mi`;
+  if (abs < 1) {
+    const inches = feet * 12;
+    return `${inches.toFixed(displayDecimals(inches, 1, 4))} in`;
+  }
+  if (abs < FEET_PER_MILE) return `${feet.toFixed(displayDecimals(feet, 2, 4))} ft`;
+  const miles = feet / FEET_PER_MILE;
+  return `${miles.toFixed(displayDecimals(miles, 3, 4))} mi`;
 }
 
 /**
@@ -107,13 +160,22 @@ export function formatElevation(metres: number, system: UnitSystem): string {
 /** Format an area given in square metres for the active unit system. */
 export function formatArea(squareMetres: number, system: UnitSystem): string {
   if (!Number.isFinite(squareMetres) || squareMetres < 0) return '—';
+  // A wider decimal ceiling than lengths: a small feature's area is the square
+  // of a small length, so a 5 mm baseline encloses ~2.5e-5 m² and needs the
+  // room to read as non-zero rather than collapsing to "0.00 m²".
   if (system === 'metric') {
-    if (squareMetres < 1e6) return `${grouped(squareMetres, 2)} m²`;
-    return `${grouped(squareMetres / 1e6, 3)} km²`;
+    if (squareMetres < 1e6) {
+      return `${grouped(squareMetres, displayDecimals(squareMetres, 2, 6))} m²`;
+    }
+    const sqKm = squareMetres / 1e6;
+    return `${grouped(sqKm, displayDecimals(sqKm, 3, 6))} km²`;
   }
   const squareFeet = squareMetres * SQFT_PER_SQM;
-  if (squareFeet < SQFT_PER_ACRE) return `${grouped(squareFeet, 1)} ft²`;
-  return `${grouped(squareFeet / SQFT_PER_ACRE, 3)} acre`;
+  if (squareFeet < SQFT_PER_ACRE) {
+    return `${grouped(squareFeet, displayDecimals(squareFeet, 1, 6))} ft²`;
+  }
+  const acres = squareFeet / SQFT_PER_ACRE;
+  return `${grouped(acres, displayDecimals(acres, 3, 6))} acre`;
 }
 
 /** Format an angle in degrees. Unit-system independent. */

--- a/src/terrain/contour/analyseContours.ts
+++ b/src/terrain/contour/analyseContours.ts
@@ -39,7 +39,9 @@
 import type { TerrainPoint } from '../TerrainContracts';
 import {
   classifyGroundSmrf,
+  groundFromTrustedClassification,
   type GroundFilterParams,
+  type GroundFilterResult,
   type VerticalAxis,
 } from '../ground/groundFilter';
 import { rasterizeDtm, type DtmAggregation } from '../ground/rasterizeDtm';
@@ -168,6 +170,27 @@ export interface TerrainCoreParams {
    * The DSM (top surface, for above-ground height) still uses the full cloud.
    */
   readonly classification?: ReadonlyArray<number> | Uint8Array;
+  /**
+   * Trust an authoritative ground classification instead of re-deriving one
+   * with SMRF. When the caller already carries a usable ASPRS class-2 (ground)
+   * set — a survey-delivered bare-earth cloud, or the lasso editor's ground
+   * assignment — the DTM should be rasterised straight from those points, so
+   * every ground node is a MEASURED cell and steep-slope ground SMRF's
+   * progressive opening would drop stays exact. Interpreted as:
+   *   - `true`  — force trust: use the class-2 points as the ground set and
+   *               skip SMRF (falls back to SMRF with a warning if no class-2
+   *               points are present).
+   *   - `false` — never trust: always run SMRF (the historical behaviour).
+   *   - omitted — AUTO: trust only when a class-2 set of sufficient size is
+   *               present AND every ground candidate (after dropping
+   *               vegetation/building/noise) is class-2, i.e. the cloud is
+   *               fully ground-classified. This keeps mixed clouds (some
+   *               unclassified ground) on the SMRF path, so unclassified
+   *               ground is never silently dropped.
+   * The RAW-cloud path (no `classification`) is byte-unchanged: with no
+   * classification there is no class-2 set, so auto never engages.
+   */
+  readonly trustGroundClassification?: boolean;
   /** ASPRS classes to exclude before ground filtering. Default veg/building/noise. */
   readonly excludeClasses?: ReadonlyArray<number>;
   /** Hold-out PRNG seed for reproducible validation. Default 1. */
@@ -506,6 +529,70 @@ function normalisePoints(input: TerrainPointInput): ReadonlyArray<TerrainPoint> 
   return input instanceof Float32Array ? positionsToPoints(input) : input;
 }
 
+/** ASPRS classification code for bare-earth ground returns. */
+const ASPRS_GROUND_CLASS = 2;
+
+/**
+ * Minimum class-2 points for AUTO trust to engage — enough to hold-out
+ * cross-validate (which needs ≥ 4 ground returns to split). Below this the
+ * classification is too sparse to be the authoritative surface, so the SMRF
+ * path runs. `trustGroundClassification: true` bypasses this floor.
+ */
+const AUTO_TRUST_MIN_GROUND_POINTS = 4;
+
+/** Resolved trust decision + the class-2 ground point set it will use. */
+interface GroundTrustDecision {
+  /** True when the DTM should be built from the class-2 set, skipping SMRF. */
+  readonly trust: boolean;
+  /** The ASPRS class-2 (ground) points, index-selected from the input. */
+  readonly groundPoints: TerrainPoint[];
+  /** True when trust was explicitly requested but no class-2 points exist. */
+  readonly requestedButUnavailable: boolean;
+}
+
+/**
+ * Decide whether to trust an existing ground classification (see
+ * {@link TerrainCoreParams.trustGroundClassification}) and, when so, select the
+ * class-2 point set to rasterise the DTM from.
+ *
+ * `keptCandidateCount` is the number of points that survive
+ * {@link excludeNonGroundClasses} (the 0/1/2/9 ground candidates). AUTO trust
+ * requires EVERY candidate to be class-2, so a cloud with unclassified ground
+ * stays on the SMRF path and nothing is silently dropped.
+ */
+function resolveGroundTrust(
+  points: ReadonlyArray<TerrainPoint>,
+  classification: ReadonlyArray<number> | Uint8Array | undefined,
+  keptCandidateCount: number,
+  explicit: boolean | undefined,
+): GroundTrustDecision {
+  const aligned = classification != null && classification.length === points.length;
+  const groundPoints: TerrainPoint[] = [];
+  if (aligned) {
+    for (let i = 0; i < points.length; i++) {
+      if (classification![i] === ASPRS_GROUND_CLASS) groundPoints.push(points[i]);
+    }
+  }
+  const class2Count = groundPoints.length;
+
+  if (explicit === false) {
+    return { trust: false, groundPoints: [], requestedButUnavailable: false };
+  }
+  if (explicit === true) {
+    if (class2Count >= 1) return { trust: true, groundPoints, requestedButUnavailable: false };
+    return { trust: false, groundPoints: [], requestedButUnavailable: true };
+  }
+  // AUTO: a class-2 set of sufficient size, and the classification is
+  // authoritative (every ground candidate is class-2).
+  const auto =
+    class2Count >= AUTO_TRUST_MIN_GROUND_POINTS && class2Count === keptCandidateCount;
+  return {
+    trust: auto,
+    groundPoints: auto ? groundPoints : [],
+    requestedButUnavailable: false,
+  };
+}
+
 /**
  * Resolve the ground-filter parameters the core actually runs with (caller
  * overrides + pipeline defaults). Exported as the SINGLE source of truth for
@@ -591,7 +678,7 @@ export function computeTerrainCore(
   // or rooftops. The full cloud is still used for the DSM further down, so
   // above-ground height keeps measuring those very returns.
   const classFilter = excludeNonGroundClasses(points, params.classification, params.excludeClasses);
-  const groundPts = classFilter.points;
+  let groundPts: ReadonlyArray<TerrainPoint> = classFilter.points;
   if (classFilter.excludedCount > 0) {
     warnings.push(
       `Excluded ${classFilter.excludedCount} classified vegetation/building/noise return(s) before ground filtering.`,
@@ -602,9 +689,56 @@ export function computeTerrainCore(
   // resolveGroundFilterParams) and shared with the hold-out validation's
   // train-only reclassifier below, so the per-split classification can never
   // drift from the pass that produced the delivered surface.
+  //
+  // When a usable ground classification is present (auto) — or the caller
+  // forces it — TRUST the ASPRS class-2 set as the surface and skip the SMRF
+  // re-derivation: the DTM is then rasterised straight from measured ground
+  // returns, so steep-slope ground SMRF's progressive opening would discard
+  // stays exact. `reclassifyForHoldout` follows the same decision so the
+  // hold-out validates the surface the user actually receives.
   const groundParams = resolveGroundFilterParams(params, verticalAxis);
-  const gf = classifyGroundSmrf(groundPts, groundParams);
-  warnings.push(...gf.warnings);
+  const trust = resolveGroundTrust(
+    points,
+    params.classification,
+    groundPts.length,
+    params.trustGroundClassification,
+  );
+  if (trust.requestedButUnavailable) {
+    warnings.push(
+      'trustGroundClassification was requested but no ASPRS class 2 (ground) ' +
+        'points are present; falling back to the SMRF ground filter.',
+    );
+  }
+  let groundPtsForSurface: ReadonlyArray<TerrainPoint>;
+  let gf: GroundFilterResult;
+  let reclassifyForHoldout:
+    | ((points: ReadonlyArray<TerrainPoint>, isHeldOut: Uint8Array) => Uint8Array | ReadonlyArray<number>)
+    | undefined;
+  if (trust.trust) {
+    groundPtsForSurface = trust.groundPoints;
+    gf = groundFromTrustedClassification(groundPtsForSurface, {
+      cellSizeM: params.cellSizeM,
+      verticalAxis,
+    });
+    warnings.push(...gf.warnings);
+    warnings.push(
+      `Trusted ${gf.groundPointCount} ASPRS class 2 (ground) point(s) as the DTM ` +
+        'surface; SMRF ground re-derivation skipped (every ground node is a measured cell).',
+    );
+    // The class-2 set is authoritative and independent of the hold-out split,
+    // so a withheld point never helped decide its own ground membership — the
+    // classification leak the SMRF path removes with a re-run simply does not
+    // exist here. Feed the validator an all-ground mask (it excludes held-out
+    // points from the fit itself), so it validates the delivered surface.
+    reclassifyForHoldout = (pts) => new Uint8Array(pts.length).fill(1);
+  } else {
+    groundPtsForSurface = groundPts;
+    gf = classifyGroundSmrf(groundPtsForSurface, groundParams);
+    warnings.push(...gf.warnings);
+    reclassifyForHoldout = makeTrainOnlyReclassifier(groundParams);
+  }
+  // Every stage below that consumed `groundPts` reads the resolved surface set.
+  groundPts = groundPtsForSurface;
 
   // 2) DTM raster aligned to the filter grid + 3) per-cell confidence.
   // The live surface aggregates each cell by MEDIAN (the robustness upgrade over
@@ -627,14 +761,17 @@ export function computeTerrainCore(
   // geodesic void fill + extrapolation-guarded confidence — all through the
   // ONE shared raster→grid constructor, so the hold-out validation below
   // provably builds the SAME kind of surface (it calls the same function).
-  // The despike pass is part of every generation run; the README derives its
-  // provenance from this fact, not a mirrored constant.
-  const despikeApplied = true;
+  // The despike pass is part of every generation run EXCEPT the trusted-
+  // classification path: there the ground returns are authoritative, so a
+  // steep survey node must not be void-filled as a spike. The README derives
+  // its provenance from this fact, not a mirrored constant.
+  const despikeApplied = !trust.trust;
   const built = buildSurfaceFromRaster(raster, {
     crs,
     horizontalEpsg: params.horizontalEpsg,
     verticalDatum,
     verticalEpsg: params.verticalEpsg,
+    despike: despikeApplied,
     isGeographic: params.isGeographic,
     // WORLD grid-centre latitude for the confidence roughness slope's cos φ
     // E–W correction (the grid's own originH2 is render-recentred, ≈ 0).
@@ -671,8 +808,10 @@ export function computeTerrainCore(
     seed: params.holdoutSeed ?? 1,
     verticalAxis,
     // Validate the SAME surface the user gets: same per-cell aggregation as the
-    // live DTM above (median), so the RMSE isn't measuring a different surface.
+    // live DTM above (median) AND the same despike decision (off when trusting
+    // the classification), so the RMSE isn't measuring a different surface.
     aggregation,
+    despike: despikeApplied,
     isGeographic: params.isGeographic,
     latitudeDeg: params.latitudeDeg,
     verticalUnitToMetres: params.verticalUnitToMetres,
@@ -685,8 +824,10 @@ export function computeTerrainCore(
     // Cost: the hold-out is a single deterministic split, so this is exactly
     // ONE extra SMRF pass over the training share of the analysed cloud
     // (already capped by the gather stride) — ground-filter cost ≤ 2× per
-    // run, never K passes.
-    reclassifyGround: makeTrainOnlyReclassifier(groundParams),
+    // run, never K passes. On the trusted-classification path this is instead
+    // an all-ground mask (no SMRF), so the hold-out validates the exact class-2
+    // surface the user receives.
+    reclassifyGround: reclassifyForHoldout,
   });
   const confidenceOrdering = checkConfidenceOrdering(validation);
   const accuracy = computeVerticalAccuracy(validation);

--- a/src/terrain/ground/groundFilter.ts
+++ b/src/terrain/ground/groundFilter.ts
@@ -372,6 +372,111 @@ export function classifyGroundSmrf(
   };
 }
 
+/**
+ * Build a {@link GroundFilterResult} that TRUSTS an authoritative ground
+ * classification instead of re-deriving one with SMRF. Every finite point in
+ * `points` is treated as ground (the caller has already selected the ASPRS
+ * class-2 subset), so `isGround` is all-ones over the finite returns and the
+ * DTM rasterised from it is a measured cell wherever a ground return exists —
+ * SMRF's progressive opening can no longer discard steep-slope ground it
+ * mistook for structure.
+ *
+ * The grid geometry (origin / cols / rows) and the provisional `groundSurface`
+ * (min-elevation grid + nearest-finite inpaint) are computed EXACTLY as
+ * {@link classifyGroundSmrf} would, so this result is a drop-in substitute for
+ * the SMRF one; only the classification decision differs. The morphological
+ * opening and slope-scaled point test are skipped — that is the whole point.
+ *
+ * Deterministic. Degenerate inputs (empty / all non-finite) return the same
+ * honest empty result the SMRF path does.
+ */
+export function groundFromTrustedClassification(
+  points: ReadonlyArray<TerrainPoint>,
+  params: { readonly cellSizeM: number; readonly verticalAxis?: VerticalAxis },
+): GroundFilterResult {
+  const warnings: string[] = [];
+  const vertical: VerticalAxis = params.verticalAxis ?? 'z';
+  const cellSizeM = finitePositive(params.cellSizeM, 1, 'cellSizeM', warnings);
+
+  const sourcePointCount = points.length;
+  if (sourcePointCount === 0) {
+    warnings.push('no points — nothing to classify');
+    return emptyResult(cellSizeM, warnings);
+  }
+
+  // Bounds over the finite returns (identical rule to classifyGroundSmrf).
+  let minH1 = Infinity;
+  let minH2 = Infinity;
+  let maxH1 = -Infinity;
+  let maxH2 = -Infinity;
+  let analyzed = 0;
+  for (const p of points) {
+    const [h1, h2, v] = axes(p, vertical);
+    if (!Number.isFinite(h1) || !Number.isFinite(h2) || !Number.isFinite(v)) continue;
+    analyzed++;
+    if (h1 < minH1) minH1 = h1;
+    if (h2 < minH2) minH2 = h2;
+    if (h1 > maxH1) maxH1 = h1;
+    if (h2 > maxH2) maxH2 = h2;
+  }
+  if (analyzed === 0) {
+    warnings.push('all points non-finite — nothing to classify');
+    return emptyResult(cellSizeM, warnings);
+  }
+  if (analyzed < sourcePointCount) {
+    warnings.push(`${sourcePointCount - analyzed} non-finite points skipped`);
+  }
+
+  const cols = Math.max(1, Math.floor((maxH1 - minH1) / cellSizeM) + 1);
+  const rows = Math.max(1, Math.floor((maxH2 - minH2) / cellSizeM) + 1);
+  const nCells = cols * rows;
+
+  const cellOf = (h1: number, h2: number): number => {
+    let col = Math.floor((h1 - minH1) / cellSizeM);
+    let row = Math.floor((h2 - minH2) / cellSizeM);
+    if (col < 0) col = 0;
+    else if (col >= cols) col = cols - 1;
+    if (row < 0) row = 0;
+    else if (row >= rows) row = rows - 1;
+    return row * cols + col;
+  };
+
+  // Minimum-elevation grid + provisional surface, so the returned result
+  // carries a valid bare-earth surface like the SMRF path (used for provenance,
+  // never for the delivered DTM, which rasterizeDtm builds from the points).
+  const minGrid = new Float32Array(nCells).fill(Number.NaN);
+  const hadData = new Uint8Array(nCells);
+  const isGround = new Uint8Array(sourcePointCount);
+  let groundPointCount = 0;
+  for (let pi = 0; pi < sourcePointCount; pi++) {
+    const [h1, h2, v] = axes(points[pi], vertical);
+    if (!Number.isFinite(h1) || !Number.isFinite(h2) || !Number.isFinite(v)) continue;
+    // Every finite classified-ground return is ground — no morphological test.
+    isGround[pi] = 1;
+    groundPointCount++;
+    const c = cellOf(h1, h2);
+    if (hadData[c] === 0 || v < minGrid[c]) minGrid[c] = v;
+    hadData[c] = 1;
+  }
+  const groundSurface = inpaintNearest(minGrid, hadData, cols, rows);
+
+  return {
+    isGround,
+    groundSurface,
+    hadData,
+    cols,
+    rows,
+    cellSizeM,
+    originH1: minH1,
+    originH2: minH2,
+    coverage: 'full' as TerrainCoverageMode,
+    sourcePointCount,
+    analyzedPointCount: analyzed,
+    groundPointCount,
+    warnings,
+  };
+}
+
 // ── morphology helpers (exported for unit testing) ──────────────────
 
 /**

--- a/src/terrain/ground/surfaceFromRaster.ts
+++ b/src/terrain/ground/surfaceFromRaster.ts
@@ -62,6 +62,16 @@ export interface SurfaceFromRasterParams {
   readonly verticalUnitToMetres?: number;
   /** Density (returns/cell) earning full confidence; default = scene median. */
   readonly targetCount?: number;
+  /**
+   * Run the blunder-only despike pass before building the surface. Default
+   * `true` (the historical behaviour). Set `false` when the ground returns are
+   * an AUTHORITATIVE classification the caller trusts (see
+   * `analyseContours` `trustGroundClassification`): the despike's 6σ-MAD test
+   * misreads legitimately-steep survey ground — escarpment and ridge nodes —
+   * as spikes and void-fills them, so trusting the classification means keeping
+   * every measured ground cell exactly as delivered.
+   */
+  readonly despike?: boolean;
 }
 
 export interface SurfaceFromRasterResult {
@@ -93,34 +103,38 @@ export function buildSurfaceFromRaster(
   // neighbours) so they don't warp the surface; the builder re-fills them by
   // interpolation. Real outliers only — smooth terrain loses nothing.
   let workingRaster = raster;
-  const hadData0 = new Uint8Array(raster.counts.length);
-  let measuredCellCount = 0;
-  for (let i = 0; i < hadData0.length; i++) {
-    if (raster.counts[i] > 0) { hadData0[i] = 1; measuredCellCount++; }
-  }
-  // `raster.z` is in native source vertical units and LIVE_DESPIKE's floor is
-  // metres, so the factor has to travel with it — otherwise 30 cm reads as
-  // 30 source units and a foot-vertical scan loses real sub-30 cm features.
-  const despiked = removeSpikes(raster.z, hadData0, raster.cols, raster.rows, {
-    ...LIVE_DESPIKE,
-    verticalUnitToMetres: params.verticalUnitToMetres,
-  });
-  // Safety cap: if "outliers" exceed 2% of measured cells the data is noisy,
-  // not spiky — removing that much would distort the surface, so leave it.
-  const removalCap = Math.max(4, Math.ceil(measuredCellCount * 0.02));
   let despikedCellCount = 0;
   let cappedOutlierCount = 0;
-  if (despiked.removed > 0 && despiked.removed <= removalCap) {
-    const counts2 = raster.counts.slice();
-    let filled = 0;
-    for (let i = 0; i < counts2.length; i++) {
-      if (despiked.hadData[i] === 0) counts2[i] = 0;
-      if (counts2[i] > 0) filled++;
+  // Skip the despike entirely when the caller trusts an authoritative ground
+  // classification — steep survey ground must not be void-filled as a "spike".
+  if (params.despike !== false) {
+    const hadData0 = new Uint8Array(raster.counts.length);
+    let measuredCellCount = 0;
+    for (let i = 0; i < hadData0.length; i++) {
+      if (raster.counts[i] > 0) { hadData0[i] = 1; measuredCellCount++; }
     }
-    workingRaster = { ...raster, z: despiked.z, counts: counts2, filledCellCount: filled };
-    despikedCellCount = despiked.removed;
-  } else if (despiked.removed > removalCap) {
-    cappedOutlierCount = despiked.removed;
+    // `raster.z` is in native source vertical units and LIVE_DESPIKE's floor is
+    // metres, so the factor has to travel with it — otherwise 30 cm reads as
+    // 30 source units and a foot-vertical scan loses real sub-30 cm features.
+    const despiked = removeSpikes(raster.z, hadData0, raster.cols, raster.rows, {
+      ...LIVE_DESPIKE,
+      verticalUnitToMetres: params.verticalUnitToMetres,
+    });
+    // Safety cap: if "outliers" exceed 2% of measured cells the data is noisy,
+    // not spiky — removing that much would distort the surface, so leave it.
+    const removalCap = Math.max(4, Math.ceil(measuredCellCount * 0.02));
+    if (despiked.removed > 0 && despiked.removed <= removalCap) {
+      const counts2 = raster.counts.slice();
+      let filled = 0;
+      for (let i = 0; i < counts2.length; i++) {
+        if (despiked.hadData[i] === 0) counts2[i] = 0;
+        if (counts2[i] > 0) filled++;
+      }
+      workingRaster = { ...raster, z: despiked.z, counts: counts2, filledCellCount: filled };
+      despikedCellCount = despiked.removed;
+    } else if (despiked.removed > removalCap) {
+      cappedOutlierCount = despiked.removed;
+    }
   }
 
   const dtm = buildDtmGrid(workingRaster, {

--- a/src/terrain/validate/holdoutRmse.ts
+++ b/src/terrain/validate/holdoutRmse.ts
@@ -60,6 +60,13 @@ export interface HoldoutParams {
   readonly cellSizeM: number;
   /** Per-cell aggregation for the DTM. Default `mean`. */
   readonly aggregation?: DtmAggregation;
+  /**
+   * Run the blunder-only despike when rebuilding the train surface. Default
+   * `true`. Set `false` to match a delivered surface built from a trusted
+   * ground classification (despike disabled), so the validated surface is the
+   * one the user receives rather than a despiked variant.
+   */
+  readonly despike?: boolean;
   /** Vertical axis of the source frame. Default `'z'`. */
   readonly verticalAxis?: VerticalAxis;
   /** Density (returns/cell) earning full confidence; default = scene median. */
@@ -283,6 +290,7 @@ export function holdoutValidateDtm(
   });
   const { dtm } = buildSurfaceFromRaster(raster, {
     targetCount: params.targetCount,
+    despike: params.despike,
     isGeographic: params.isGeographic,
     latitudeDeg: params.latitudeDeg,
     horizontalUnitToMetres: params.horizontalUnitToMetres,

--- a/tests/measureFormat.test.ts
+++ b/tests/measureFormat.test.ts
@@ -6,7 +6,6 @@ import {
   formatGrade,
   formatBearing,
 } from '../src/render/measure/format';
-import { formatDistance } from '../src/render/navMath';
 
 describe('formatBearing', () => {
   it('zero-pads whole-degree azimuths to three digits', () => {
@@ -22,22 +21,33 @@ describe('formatBearing', () => {
 });
 
 describe('formatLength', () => {
-  it('metric matches the v0.1.0 distance formatter', () => {
-    for (const m of [0.25, 0.5, 5, 42.7, 1500]) {
-      expect(formatLength(m, 'metric')).toBe(formatDistance(m));
-    }
+  it('metric uses cm / m / km bands with adaptive (5-sig-fig) precision', () => {
+    expect(formatLength(0.5, 'metric')).toBe('50.000 cm');
+    expect(formatLength(5, 'metric')).toBe('5.0000 m');
+    expect(formatLength(1500, 'metric')).toBe('1.5000 km');
   });
 
-  it('metric uses cm / m / km bands', () => {
-    expect(formatLength(0.5, 'metric')).toBe('50.0 cm');
-    expect(formatLength(5, 'metric')).toBe('5.00 m');
-    expect(formatLength(1500, 'metric')).toBe('1.500 km');
+  it('imperial uses in / ft / mi bands with adaptive (5-sig-fig) precision', () => {
+    expect(formatLength(0.1, 'imperial')).toBe('3.9370 in');
+    expect(formatLength(1, 'imperial')).toBe('3.2808 ft');
+    expect(formatLength(2000, 'imperial')).toBe('1.2427 mi');
   });
 
-  it('imperial uses in / ft / mi bands', () => {
-    expect(formatLength(0.1, 'imperial')).toBe('3.9 in');
-    expect(formatLength(1, 'imperial')).toBe('3.28 ft');
-    expect(formatLength(2000, 'imperial')).toBe('1.243 mi');
+  it('keeps sub-centimetre and sub-millimetre baselines readable, not "0.00 m"', () => {
+    // 2 mm — the smallest horizontal baseline in the precision datasets. The old
+    // 2-decimal metre readout printed "0.00 m"; the cm band now shows the digits.
+    expect(formatLength(0.002, 'metric')).toBe('0.2000 cm');
+    // A single step of the 0.5 mm vertical staircase — still non-zero, distinct
+    // from a 1.0 mm ("0.1000 cm") or 1.5 mm ("0.1500 cm") step.
+    expect(formatLength(0.0005, 'metric')).toBe('0.0500 cm');
+    // A GCP baseline with millimetre-significant truth: the millimetre place is
+    // shown instead of being rounded away to "50.01 m".
+    expect(formatLength(50.009999, 'metric')).toBe('50.010 m');
+  });
+
+  it('sheds decimals as magnitude grows so large spans stay readable', () => {
+    expect(formatLength(500, 'metric')).toBe('500.00 m');
+    expect(formatLength(1289.968, 'metric')).toBe('1.2900 km');
   });
 
   it('returns a dash for a non-finite length', () => {
@@ -47,14 +57,20 @@ describe('formatLength', () => {
 });
 
 describe('formatArea', () => {
-  it('metric uses m² then km²', () => {
+  it('metric uses m² then km² with adaptive (5-sig-fig) precision', () => {
     expect(formatArea(100, 'metric')).toBe('100.00 m²');
-    expect(formatArea(2_000_000, 'metric')).toBe('2.000 km²');
+    expect(formatArea(2_000_000, 'metric')).toBe('2.0000 km²');
   });
 
-  it('imperial uses ft² then acres', () => {
+  it('imperial uses ft² then acres with adaptive (5-sig-fig) precision', () => {
     expect(formatArea(100, 'imperial')).toBe('1,076.4 ft²');
-    expect(formatArea(5000, 'imperial')).toBe('1.236 acre');
+    expect(formatArea(5000, 'imperial')).toBe('1.2355 acre');
+  });
+
+  it('keeps a tiny feature area non-zero instead of collapsing to "0.00 m²"', () => {
+    // A 5 mm baseline encloses ~2.5e-5 m²; the wider decimal ceiling reads it.
+    expect(formatArea(0.000025, 'metric')).toBe('0.000025 m²');
+    expect(formatArea(0.000004, 'metric')).toBe('0.000004 m²');
   });
 
   it('returns a dash for an invalid area', () => {
@@ -104,10 +120,10 @@ const US_SURVEY_FOOT = 1200 / 3937; // 0.30480060960121924 m
 
 describe('formatLengthRender (B2 foot-CRS fixture)', () => {
   it('labels a 10 sft span correctly in both unit systems', () => {
-    // 3.0480060960121924 m → "3.05 m"; NOT the pre-B2 "10.00 m".
-    expect(formatLengthRender(10, US_SURVEY_FOOT, 'metric')).toBe('3.05 m');
-    // 10.00002 ft → "10.00 ft" — the span reads back as the feet it is.
-    expect(formatLengthRender(10, US_SURVEY_FOOT, 'imperial')).toBe('10.00 ft');
+    // 3.0480060960121924 m → "3.0480 m" (5 sig figs); NOT the pre-B2 "10.00 m".
+    expect(formatLengthRender(10, US_SURVEY_FOOT, 'metric')).toBe('3.0480 m');
+    // 10.00002 ft → "10.000 ft" — the span reads back as the feet it is.
+    expect(formatLengthRender(10, US_SURVEY_FOOT, 'imperial')).toBe('10.000 ft');
   });
 
   it('factor 1 is a byte-identical passthrough (metric/local scans)', () => {
@@ -116,16 +132,16 @@ describe('formatLengthRender (B2 foot-CRS fixture)', () => {
   });
 
   it('invalid factors fall back to 1, never multiply by garbage', () => {
-    expect(formatLengthRender(10, Number.NaN, 'metric')).toBe('10.00 m');
-    expect(formatLengthRender(10, 0, 'metric')).toBe('10.00 m');
-    expect(formatLengthRender(10, -2, 'metric')).toBe('10.00 m');
+    expect(formatLengthRender(10, Number.NaN, 'metric')).toBe('10.000 m');
+    expect(formatLengthRender(10, 0, 'metric')).toBe('10.000 m');
+    expect(formatLengthRender(10, -2, 'metric')).toBe('10.000 m');
   });
 });
 
 describe('formatAreaRender (B2: areas scale by the factor squared)', () => {
   it('1000 sft² = 92.90 m² = 1,000.0 ft²', () => {
-    // 1000 × (1200/3937)² = 92.90341161327482 m².
-    expect(formatAreaRender(1000, US_SURVEY_FOOT, 'metric')).toBe('92.90 m²');
+    // 1000 × (1200/3937)² = 92.90341161327482 m² → "92.903 m²" (5 sig figs).
+    expect(formatAreaRender(1000, US_SURVEY_FOOT, 'metric')).toBe('92.903 m²');
     // 92.903411… m² × 10.76391042 ft²/m² = 1000.004000004 ft².
     expect(formatAreaRender(1000, US_SURVEY_FOOT, 'imperial')).toBe('1,000.0 ft²');
   });

--- a/tests/measureVerticalUnit.test.ts
+++ b/tests/measureVerticalUnit.test.ts
@@ -20,10 +20,11 @@ const strong = { snappedToPoint: true, pointsWithinRadius: 40 } as const;
 
 describe('measurement vertical unit (compound CRS)', () => {
   it('a height reads through the VERTICAL factor, not the horizontal one', () => {
-    // Δz of 10 render units on a foot-height CRS is 10 ft ≈ 3.05 m.
-    expect(formatLengthRender(10, 0.3048, 'metric')).toBe('3.05 m');
+    // Δz of 10 render units on a foot-height CRS is 10 ft = 3.048 m.
+    // Adaptive precision (5 sig figs) prints "3.0480 m", not the old "3.05 m".
+    expect(formatLengthRender(10, 0.3048, 'metric')).toBe('3.0480 m');
     // The pre-fix path multiplied by the horizontal factor (1) — 3.28× too large.
-    expect(formatLengthRender(10, 1, 'metric')).toBe('10.00 m');
+    expect(formatLengthRender(10, 1, 'metric')).toBe('10.000 m');
   });
 
   it('box volume scales linear²·vertical on a mixed-unit CRS', () => {

--- a/tests/profilePdf.test.ts
+++ b/tests/profilePdf.test.ts
@@ -103,7 +103,7 @@ describe('provenance metadata (v0.4.5, B4)', () => {
     const text = drawnPdfText(bytes);
     expect(text).toContain('EPSG:2225'); // header line + summary row
     expect(text).toContain('NAVD88');
-    expect(text).toContain('12.50 m'); // the real corridor, not "auto"
+    expect(text).toContain('12.500 m'); // the real corridor, not "auto" (5 sig figs)
     expect(text).toContain('ground p25'); // header provenance line
     expect(text).not.toContain('auto (5% of length)');
     expect(text).not.toContain('not georeferenced');
@@ -132,10 +132,10 @@ describe('unit system (v0.4.5, B9) — the sheet honours the active toggle end-t
     // Chainage gridline labels use US 100-ft stationing: the ramp spans
     // 30 m = 98.43 ft → nice interval 10 ft → second gridline at "0+10.00".
     expect(text).toContain('0+10.00');
-    // Summary: length 30 m = 98.4252 ft → "98.43 ft" via formatLength; the
-    // corridor 12.5 m = 41.0105 ft → "41.01 ft".
-    expect(text).toContain('98.43 ft');
-    expect(text).toContain('41.01 ft');
+    // Summary: length 30 m = 98.4252 ft → "98.425 ft" via formatLength (5 sig
+    // figs); the corridor 12.5 m = 41.0105 ft → "41.010 ft".
+    expect(text).toContain('98.425 ft');
+    expect(text).toContain('41.010 ft');
     // Station table: header names the unit; elevations convert per station
     // (station 0 sits at exactly 100 m = 328.0840 ft → "328.08").
     expect(text).toContain('elevation (ft)');

--- a/tests/profileSummary.test.ts
+++ b/tests/profileSummary.test.ts
@@ -132,8 +132,9 @@ describe('profileSummaryRows', () => {
   it('metric rows carry the hand-computed values', () => {
     const rows = profileSummaryRows(computeProfileSummary(FIXTURE), 'metric');
     const byLabel = new Map(rows.map((r) => [r.label, r.value]));
-    expect(byLabel.get('Length')).toBe('50.00 m');
-    expect(byLabel.get('Elevation gain / loss')).toBe('+2.00 m / −2.00 m');
+    // Length is a distance → adaptive 5-sig-fig precision ("50.000 m").
+    expect(byLabel.get('Length')).toBe('50.000 m');
+    expect(byLabel.get('Elevation gain / loss')).toBe('+2.0000 m / −2.0000 m');
     expect(byLabel.get('Avg grade')).toBe('6.00%');
     expect(byLabel.get('Max grade')).toBe('20.00%');
     expect(byLabel.get('Steepest section')).toBe('0+000.00 → 0+010.00 (20.00%)');

--- a/tests/reportEngine.test.ts
+++ b/tests/reportEngine.test.ts
@@ -504,9 +504,10 @@ describe('buildMeasurementRows', () => {
       expect(rows[2].value).toBe('91.4 cm'); // 3 ft height
     });
 
-    it('scales areas ×f²: a 10×10 ft footprint reads 9.29 m²', () => {
+    it('scales areas ×f²: a 10×10 ft footprint reads 9.2903 m²', () => {
       const rows = buildMeasurementRows(measurements, 'metric', FT);
-      expect(rows[1].value).toBe('9.29 m²'); // 100 sq ft × 0.3048²
+      // 100 sq ft × 0.3048² = 9.290304 m² → adaptive 5-sig-fig "9.2903 m²".
+      expect(rows[1].value).toBe('9.2903 m²');
     });
 
     it('round-trips imperial: a 10 ft span on a foot CRS reads 10.00 ft', () => {
@@ -537,7 +538,7 @@ describe('buildMeasurementRows', () => {
       const rows = buildMeasurementRows(vols, 'metric', FT);
       // 24 cu render-units × 0.3048³ = 0.679604… m³
       expect(rows[0].value).toBe('0.68 m³');
-      expect(rows[1].value).toContain('9.29 m²'); // footprint ×f²
+      expect(rows[1].value).toContain('9.2903 m²'); // footprint ×f²
       expect(rows[1].value).toContain('+0.68 m³ fill'); // fill ×f³
     });
 


### PR DESCRIPTION
Two precision improvements, each verified against an analytic synthetic reference dataset (generated by A Urias) whose exact truth is known.

## Trust an authoritative ground classification
When a cloud is already fully classified as bare-earth ground (every ground candidate is ASPRS class 2), the DTM is now rasterised directly from those points and the SMRF ground re-derivation is skipped, along with the blunder despike that treats steep survey ground as spikes. Both stages were dropping legitimately steep ground and interpolating across it.

On a 160,801-node bare-earth reference grid, the delivered DTM goes from 0.267 m node RMSE with 2,742 interpolated cells to the Float32 storage floor (about 1.6e-6 m) with every cell measured. A ravine contour the interpolated surface had bridged into one loop now resolves as two, matching the reference.

The behaviour auto-engages only when the cloud is fully ground-classified. A raw cloud, or one with unclassified ground, stays on the SMRF path, so nothing is silently dropped and the existing behaviour is unchanged. A `trustGroundClassification` parameter allows forcing or disabling it.

## Adaptive measurement readout precision
The metric and imperial readout formatted to two decimals, which rendered a 2 mm distance as 0.00 m and dropped the millimetre place from survey-grade values. It now formats to five significant figures with a per-band decimal clamp, at the single boundary the panel, CSV and PDF all read. A 0.0020 m distance shows 0.2000 cm, 50.009999 m shows 50.010 m, and large values stay readable.

## Verification
- tsc clean; full suite 8631 passed, 0 failures.
- Raw-cloud terrain path unchanged (existing PDAL-agreement and terrain-truth tests still within tolerance).
- The claims above are matches against analytic synthetic truth. They measure formula correctness, not field accuracy, and assert no product-to-product comparison.

Follow-up left out of scope: `ReportMeasurementSection.ts` carries its own inline length and volume formatter that still rounds to two decimals, so deliverable-report areas now inherit the adaptive precision while its lengths do not.