### PR TITLE
Unify report readout precision; state a fact in the notes

### DIFF
--- a/RELEASE_NOTES_v0.6.4.md
+++ b/RELEASE_NOTES_v0.6.4.md
@@ -67,7 +67,7 @@ The two monoliths continue to shrink. Streaming session assembly moved behind a 
 
 ## Scientific evidence
 
-- the derived classifier is frozen against an evaluation corpus, and the ground-recall collapse is diagnosed rather than hidden;
+- the derived classifier is frozen against an evaluation corpus, and the ground-recall collapse is diagnosed and disclosed;
 - cross-implementation CRS reference fixtures (PROJ and pyproj) are on file, and a synthetic evaluation covers the building ground-support gate;
 - the non-redistributable E57 fixture is replaced with a generated synthetic one;
 - an acquired dataset's recorded hash is checkable;

--- a/src/render/measure/format.ts
+++ b/src/render/measure/format.ts
@@ -100,7 +100,7 @@ const DISPLAY_SIG_FIGS = 5;
  * rounds to zero). Pure and deterministic; the value passed is already in the
  * unit that will be printed (centimetres, metres, km, m², …).
  */
-function displayDecimals(
+export function displayDecimals(
   displayValue: number,
   minDecimals: number,
   maxDecimals: number,

--- a/src/report/ReportMeasurementSection.ts
+++ b/src/report/ReportMeasurementSection.ts
@@ -27,7 +27,7 @@ import {
 // polygon reads the same units in the PDF report as on the overlay — the same
 // surface that produced it. Length and volume keep this module's own
 // cm/ha-free report conventions; only area was drifting (acre vs sq ft).
-import { formatArea } from '../render/measure/format';
+import { formatArea, displayDecimals } from '../render/measure/format';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Inline math
@@ -122,14 +122,24 @@ function formatLinear(metres: number, system: UnitSystem): string {
   // `formatVolume` two functions down already returned an em dash for the same
   // input.
   if (!Number.isFinite(metres)) return '—';
+  // Adaptive precision through the shared measure policy, so a report length
+  // carries the same significant figures the panel and CSV do — a sub-centimetre
+  // separation no longer rounds to `0.00`.
   if (system === 'imperial') {
     const ft = metres * 3.28084;
-    if (ft >= 5280) return `${(ft / 5280).toFixed(2)} mi`;
-    return `${ft.toFixed(2)} ft`;
+    if (ft >= 5280) {
+      const mi = ft / 5280;
+      return `${mi.toFixed(displayDecimals(mi, 3, 4))} mi`;
+    }
+    return `${ft.toFixed(displayDecimals(ft, 2, 4))} ft`;
   }
-  if (metres >= 1000) return `${(metres / 1000).toFixed(2)} km`;
-  if (metres >= 1) return `${metres.toFixed(2)} m`;
-  return `${(metres * 100).toFixed(1)} cm`;
+  if (metres >= 1000) {
+    const km = metres / 1000;
+    return `${km.toFixed(displayDecimals(km, 3, 4))} km`;
+  }
+  if (metres >= 1) return `${metres.toFixed(displayDecimals(metres, 2, 4))} m`;
+  const cm = metres * 100;
+  return `${cm.toFixed(displayDecimals(cm, 1, 4))} cm`;
 }
 
 /**
@@ -143,9 +153,9 @@ function formatVolume(cubicMetres: number, system: UnitSystem): string {
   if (!Number.isFinite(cubicMetres)) return '—';
   if (system === 'imperial') {
     const cuYd = cubicMetres * 1.30795;
-    return `${cuYd.toFixed(2)} yd³`;
+    return `${cuYd.toFixed(displayDecimals(cuYd, 2, 4))} yd³`;
   }
-  return `${cubicMetres.toFixed(2)} m³`;
+  return `${cubicMetres.toFixed(displayDecimals(cubicMetres, 2, 4))} m³`;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/benchmark/failureRecovery.test.ts
+++ b/tests/benchmark/failureRecovery.test.ts
@@ -956,14 +956,14 @@ describe('what the measurement report prints when the geometry is degenerate', (
       [measurement('distance', [[0, 0, 0], [3, 4, 0]])],
       'metric',
     );
-    expect(rows[0].value).toBe('5.00 m');
+    expect(rows[0].value).toBe('5.0000 m');
     // A foot-CRS scan converts exactly once at this boundary.
     const feet = buildMeasurementRows(
       [measurement('distance', [[0, 0, 0], [3, 4, 0]])],
       'metric',
       0.3048,
     );
-    expect(feet[0].value).toBe('1.52 m');
+    expect(feet[0].value).toBe('1.5240 m');
   });
 
   test('a measurement with too few vertices refuses rather than reporting a zero', () => {
@@ -1053,6 +1053,6 @@ describe('what the measurement report prints when the geometry is degenerate', (
         ],
         'metric',
       ).map((r) => r.value),
-    ).toEqual(['50.0 cm', '5.00 m', '5.00 km']);
+    ).toEqual(['50.000 cm', '5.0000 m', '5.0000 km']);
   });
 });

--- a/tests/reportEngine.test.ts
+++ b/tests/reportEngine.test.ts
@@ -462,9 +462,9 @@ describe('buildMeasurementRows', () => {
 
   it('formats metric values correctly', () => {
     const rows = buildMeasurementRows(measurements, 'metric');
-    expect(rows[0].value).toBe('10.00 m');
+    expect(rows[0].value).toBe('10.000 m');
     expect(rows[1].value).toBe('100.00 m²');
-    expect(rows[2].value).toBe('3.00 m');
+    expect(rows[2].value).toBe('3.0000 m');
   });
 
   it('formats imperial values correctly', () => {
@@ -498,10 +498,10 @@ describe('buildMeasurementRows', () => {
   describe('unitToMetres factor', () => {
     const FT = 0.3048; // international foot → metres
 
-    it('scales lengths ×f: a 10 ft span reads 3.05 m, not 10 m', () => {
+    it('scales lengths ×f: a 10 ft span reads 3.0480 m, not 10 m', () => {
       const rows = buildMeasurementRows(measurements, 'metric', FT);
-      expect(rows[0].value).toBe('3.05 m'); // 10 ft × 0.3048
-      expect(rows[2].value).toBe('91.4 cm'); // 3 ft height
+      expect(rows[0].value).toBe('3.0480 m'); // 10 ft × 0.3048
+      expect(rows[2].value).toBe('91.440 cm'); // 3 ft height
     });
 
     it('scales areas ×f²: a 10×10 ft footprint reads 9.2903 m²', () => {
@@ -510,9 +510,9 @@ describe('buildMeasurementRows', () => {
       expect(rows[1].value).toBe('9.2903 m²');
     });
 
-    it('round-trips imperial: a 10 ft span on a foot CRS reads 10.00 ft', () => {
+    it('round-trips imperial: a 10 ft span on a foot CRS reads 10.000 ft', () => {
       const rows = buildMeasurementRows(measurements, 'imperial', FT);
-      expect(rows[0].value).toBe('10.00 ft');
+      expect(rows[0].value).toBe('10.000 ft');
     });
 
     it('scales volumes ×f³ (box and cut/fill)', () => {
@@ -537,9 +537,9 @@ describe('buildMeasurementRows', () => {
       ];
       const rows = buildMeasurementRows(vols, 'metric', FT);
       // 24 cu render-units × 0.3048³ = 0.679604… m³
-      expect(rows[0].value).toBe('0.68 m³');
+      expect(rows[0].value).toBe('0.6796 m³');
       expect(rows[1].value).toContain('9.2903 m²'); // footprint ×f²
-      expect(rows[1].value).toContain('+0.68 m³ fill'); // fill ×f³
+      expect(rows[1].value).toContain('+0.6796 m³ fill'); // fill ×f³
     });
 
     it('leaves ratios (slope / angle) unscaled', () => {


### PR DESCRIPTION
Two of the three non-blocking QualityRevision suggestions from the v0.6.4 pre-publish review.

- **Report formatter precision.** `ReportMeasurementSection` formatted lengths and volumes to two decimals while report areas already routed through the shared adaptive five-significant-figure policy, so a sub-centimetre length rounded to `0.00` in the deliverable PDF. `displayDecimals` is now exported from the measure formatter and applied to the report's length and volume bands, so the PDF, panel and CSV carry the same significant figures. Unit banding is unchanged; only the decimal count adapts.
- **Release note wording.** One line reworded from "diagnosed rather than hidden" to "diagnosed and disclosed" (states the software behaviour, not the authoring choice).

Assertions in `reportEngine.test.ts` and `failureRecovery.test.ts` updated to the adaptive values. Full suite green (8631), tsc clean, prose gate passes.

The third suggestion — registering the DTM/contour cross-checks into `src/validation/crossCheck.ts` and the claim register — is left for v0.6.5: it needs a bundled reference fixture and changes the formal E4 tally, which is out of scope for the v0.6.4 tag. The validation report already labels it a follow-up.