### PR TITLE
Panel polish: fit the session button, collapse derived-complexity detail

### DIFF
--- a/RELEASE_NOTES_v0.6.4.md
+++ b/RELEASE_NOTES_v0.6.4.md
@@ -59,7 +59,8 @@ A projected coordinate system whose linear unit cannot be confirmed used to flow
 - mobile landscape layout and controls are refined, and the mobile interface matches the hero console;
 - a colour mode is recommended on scan load;
 - navigation preferences can invert orbit X and Y with presets;
-- profile-station dots couple to chart and table hover.
+- profile-station dots couple to chart and table hover;
+- the side panels are tidied: the Measurements action button fits its row, the terrain-readiness detail and fitness notes collapse behind a disclosure, the panel scrollbars read as a slim panel-toned rail, and the left column aligns with the measure toolbar instead of opening a gap above it.
 
 ## Architecture
 

--- a/src/styles/72-panel-rails.css
+++ b/src/styles/72-panel-rails.css
@@ -260,15 +260,16 @@
   .olv-mp-stations-wrap,
   .olv-shortcuts-list {
     scrollbar-width: thin;
-    scrollbar-color: color-mix(in srgb, var(--hairline) 50%, var(--panel)) transparent;
+    scrollbar-color: color-mix(in srgb, var(--accent) 55%, var(--hairline)) transparent;
   }
 }
 
 /* Always-on thin themed scrollbar (not gated on classic mode) for the tall
    panels, so a macOS "always show scrollbars" setting — or any non-overlay
    platform — reads a slim accent bar rather than the chunky OS default. The
-   thumb mirrors the classic-mode style: hairline fill, inset with a transparent
-   border, accent on hover. Chromium/WebKit only; Firefox uses the block above. */
+   thumb mirrors the classic-mode style: accent-tinted fill, inset with a
+   transparent border, full accent on hover. Chromium/WebKit only; Firefox
+   uses the block above. */
 .olv-analyse-panel::-webkit-scrollbar,
 .olv-streaming-panel::-webkit-scrollbar,
 .olv-inspector::-webkit-scrollbar,
@@ -283,7 +284,7 @@
 .olv-streaming-panel::-webkit-scrollbar-thumb,
 .olv-inspector::-webkit-scrollbar-thumb,
 .olv-measure-panel::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--hairline) 50%, var(--panel)); border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 55%, var(--hairline)); border-radius: 999px;
   border: 2px solid transparent; background-clip: padding-box;
 }
 .olv-analyse-panel::-webkit-scrollbar-thumb:hover,

--- a/src/styles/72-panel-rails.css
+++ b/src/styles/72-panel-rails.css
@@ -260,7 +260,7 @@
   .olv-mp-stations-wrap,
   .olv-shortcuts-list {
     scrollbar-width: thin;
-    scrollbar-color: var(--hairline) transparent;
+    scrollbar-color: color-mix(in srgb, var(--hairline) 50%, var(--panel)) transparent;
   }
 }
 
@@ -283,7 +283,7 @@
 .olv-streaming-panel::-webkit-scrollbar-thumb,
 .olv-inspector::-webkit-scrollbar-thumb,
 .olv-measure-panel::-webkit-scrollbar-thumb {
-  background: var(--hairline); border-radius: 999px;
+  background: color-mix(in srgb, var(--hairline) 50%, var(--panel)); border-radius: 999px;
   border: 2px solid transparent; background-clip: padding-box;
 }
 .olv-analyse-panel::-webkit-scrollbar-thumb:hover,

--- a/src/styles/72-panel-rails.css
+++ b/src/styles/72-panel-rails.css
@@ -260,7 +260,7 @@
   .olv-mp-stations-wrap,
   .olv-shortcuts-list {
     scrollbar-width: thin;
-    scrollbar-color: var(--hairline-strong) transparent;
+    scrollbar-color: var(--hairline) transparent;
   }
 }
 
@@ -283,7 +283,7 @@
 .olv-streaming-panel::-webkit-scrollbar-thumb,
 .olv-inspector::-webkit-scrollbar-thumb,
 .olv-measure-panel::-webkit-scrollbar-thumb {
-  background: var(--hairline-strong); border-radius: 999px;
+  background: var(--hairline); border-radius: 999px;
   border: 2px solid transparent; background-clip: padding-box;
 }
 .olv-analyse-panel::-webkit-scrollbar-thumb:hover,

--- a/src/styles/72-panel-rails.css
+++ b/src/styles/72-panel-rails.css
@@ -253,6 +253,7 @@
   .olv-bc-dialog,
   .olv-wfc-card,
   .olv-left-panels,
+  .olv-analyse-panel,
   .olv-inspector,
   .olv-streaming-panel,
   .olv-catalog-results,
@@ -262,6 +263,39 @@
     scrollbar-color: var(--hairline-strong) transparent;
   }
 }
+
+/* Always-on thin themed scrollbar (not gated on classic mode) for the tall
+   panels, so a macOS "always show scrollbars" setting — or any non-overlay
+   platform — reads a slim accent bar rather than the chunky OS default. The
+   thumb mirrors the classic-mode style: hairline fill, inset with a transparent
+   border, accent on hover. Chromium/WebKit only; Firefox uses the block above. */
+.olv-analyse-panel::-webkit-scrollbar,
+.olv-streaming-panel::-webkit-scrollbar,
+.olv-inspector::-webkit-scrollbar,
+.olv-measure-panel::-webkit-scrollbar {
+  width: 7px; height: 7px;
+}
+.olv-analyse-panel::-webkit-scrollbar-track,
+.olv-streaming-panel::-webkit-scrollbar-track,
+.olv-inspector::-webkit-scrollbar-track,
+.olv-measure-panel::-webkit-scrollbar-track { background: transparent; }
+.olv-analyse-panel::-webkit-scrollbar-thumb,
+.olv-streaming-panel::-webkit-scrollbar-thumb,
+.olv-inspector::-webkit-scrollbar-thumb,
+.olv-measure-panel::-webkit-scrollbar-thumb {
+  background: var(--hairline-strong); border-radius: 999px;
+  border: 2px solid transparent; background-clip: padding-box;
+}
+.olv-analyse-panel::-webkit-scrollbar-thumb:hover,
+.olv-streaming-panel::-webkit-scrollbar-thumb:hover,
+.olv-inspector::-webkit-scrollbar-thumb:hover,
+.olv-measure-panel::-webkit-scrollbar-thumb:hover {
+  background: var(--accent); background-clip: padding-box;
+}
+.olv-analyse-panel::-webkit-scrollbar-corner,
+.olv-streaming-panel::-webkit-scrollbar-corner,
+.olv-inspector::-webkit-scrollbar-corner,
+.olv-measure-panel::-webkit-scrollbar-corner { background: transparent; }
 .olv-classic-scrollbars .olv-palette-list::-webkit-scrollbar,
 .olv-classic-scrollbars .olv-modal-body::-webkit-scrollbar,
 .olv-classic-scrollbars .olv-help-body::-webkit-scrollbar,

--- a/src/styles/72-panel-rails.css
+++ b/src/styles/72-panel-rails.css
@@ -276,10 +276,17 @@
 .olv-measure-panel::-webkit-scrollbar {
   width: 7px; height: 7px;
 }
+/* The outer column carries the whole stack, so its bar sits a touch wider
+   than the slim inner-panel bars while sharing their thumb colour. */
+.olv-left-panels::-webkit-scrollbar {
+  width: 11px; height: 11px;
+}
+.olv-left-panels::-webkit-scrollbar-track,
 .olv-analyse-panel::-webkit-scrollbar-track,
 .olv-streaming-panel::-webkit-scrollbar-track,
 .olv-inspector::-webkit-scrollbar-track,
 .olv-measure-panel::-webkit-scrollbar-track { background: transparent; }
+.olv-left-panels::-webkit-scrollbar-thumb,
 .olv-analyse-panel::-webkit-scrollbar-thumb,
 .olv-streaming-panel::-webkit-scrollbar-thumb,
 .olv-inspector::-webkit-scrollbar-thumb,
@@ -287,12 +294,14 @@
   background: color-mix(in srgb, var(--accent) 55%, var(--hairline)); border-radius: 999px;
   border: 2px solid transparent; background-clip: padding-box;
 }
+.olv-left-panels::-webkit-scrollbar-thumb:hover,
 .olv-analyse-panel::-webkit-scrollbar-thumb:hover,
 .olv-streaming-panel::-webkit-scrollbar-thumb:hover,
 .olv-inspector::-webkit-scrollbar-thumb:hover,
 .olv-measure-panel::-webkit-scrollbar-thumb:hover {
   background: var(--accent); background-clip: padding-box;
 }
+.olv-left-panels::-webkit-scrollbar-corner,
 .olv-analyse-panel::-webkit-scrollbar-corner,
 .olv-streaming-panel::-webkit-scrollbar-corner,
 .olv-inspector::-webkit-scrollbar-corner,

--- a/src/styles/72-panel-rails.css
+++ b/src/styles/72-panel-rails.css
@@ -260,7 +260,7 @@
   .olv-mp-stations-wrap,
   .olv-shortcuts-list {
     scrollbar-width: thin;
-    scrollbar-color: color-mix(in srgb, var(--accent) 55%, var(--hairline)) transparent;
+    scrollbar-color: color-mix(in srgb, var(--accent) 44%, var(--panel)) transparent;
   }
 }
 
@@ -279,7 +279,7 @@
 /* The outer column carries the whole stack, so its bar sits a touch wider
    than the slim inner-panel bars while sharing their thumb colour. */
 .olv-left-panels::-webkit-scrollbar {
-  width: 11px; height: 11px;
+  width: 9px; height: 9px;
 }
 .olv-left-panels::-webkit-scrollbar-track,
 .olv-analyse-panel::-webkit-scrollbar-track,
@@ -291,7 +291,7 @@
 .olv-streaming-panel::-webkit-scrollbar-thumb,
 .olv-inspector::-webkit-scrollbar-thumb,
 .olv-measure-panel::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--accent) 55%, var(--hairline)); border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 44%, var(--panel)); border-radius: 999px;
   border: 2px solid transparent; background-clip: padding-box;
 }
 .olv-left-panels::-webkit-scrollbar-thumb:hover,

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -19,6 +19,9 @@
   position: relative;
   min-width: 222px; max-width: 760px;
   resize: horizontal; overflow: auto;
+  /* Reserve the scrollbar's track so an always-on (macOS) vertical scrollbar
+     doesn't eat into the content width and clip the right edge of a reading. */
+  scrollbar-gutter: stable;
   background: var(--panel); border: 0.5px solid var(--hairline);
   border-radius: var(--radius-lg); padding: var(--space-xl);
 }

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -544,6 +544,9 @@
 .olv-mp-confidence {
   font-size: var(--text-xs); color: var(--text-faint);
   text-align: right; line-height: 1.35; cursor: help;
+  /* Wrap to a second line instead of clipping at the panel edge when the label
+     ("Viewer measurement · datum resolved") is wider than a narrow panel. */
+  white-space: normal; overflow-wrap: anywhere;
 }
 .olv-mp-confidence-approximate { color: var(--warn, #e0a030); }
 .olv-mp-confidence-unavailable { color: var(--text-faint); font-style: italic; }

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -560,7 +560,7 @@
   border-top: 0.5px solid var(--hairline);
 }
 .olv-mp-action {
-  flex: 1; font-size: var(--text-xs); color: var(--text-dim);
+  flex: 1; min-width: 0; font-size: var(--text-xs); color: var(--text-dim);
   background: rgba(255, 255, 255, 0.04);
   border: 0.5px solid var(--hairline);
   border-radius: var(--radius-sm); padding: var(--space-sm);

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -100,7 +100,7 @@
  * like "5.46 m × 11.53 m × 14.13 m · 889.54 m³" overflowed the box). */
 .olv-mp-row { display: flex; align-items: flex-start; gap: var(--space-sm); min-width: 0; }
 /* Profile measurements stack the headline row over a compact chart strip. */
-.olv-mp-row-stack { display: flex; flex-direction: column; gap: var(--space-xs); }
+.olv-mp-row-stack { display: flex; flex-direction: column; gap: var(--space-xs); min-width: 0; }
 /* Profile chart strip beneath a profile row. v0.3.10
  * #402: bumped from 36 px → 140 px so the curve is actually readable,
  * and made the box resizable along the vertical axis so an analyst

--- a/src/styles/89-data-fitness.css
+++ b/src/styles/89-data-fitness.css
@@ -37,6 +37,20 @@
   padding-left: var(--space-md); position: relative;
 }
 .olv-fit-caveat::before { content: '⚠'; position: absolute; left: 0; }
+/* Caveats collapsed behind a "Notes" disclosure — they restate the checklist in
+   longer form, so they stay one tap away instead of stacking under it. */
+.olv-fit-caveats { margin-top: var(--space-2xs); display: flex; flex-direction: column; gap: var(--space-2xs); }
+.olv-fit-caveats-summary {
+  cursor: pointer; list-style: none; user-select: none;
+  font-size: var(--text-2xs); font-weight: 500; color: var(--text-faint);
+  padding: var(--space-2xs) 0;
+}
+.olv-fit-caveats-summary::-webkit-details-marker { display: none; }
+.olv-fit-caveats-summary::before {
+  content: '▸'; display: inline-block; margin-right: var(--space-2xs);
+  font-size: 0.85em; transition: transform 0.12s ease;
+}
+.olv-fit-caveats[open] > .olv-fit-caveats-summary::before { transform: rotate(90deg); }
 
 /* Recommended grid / interval. */
 .olv-analyse-recommend-box { display: flex; flex-direction: column; gap: var(--space-2xs); margin: var(--space-sm) 0; }

--- a/src/styles/92-terrain-verdict.css
+++ b/src/styles/92-terrain-verdict.css
@@ -106,17 +106,23 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
    Descriptive (never a good/bad colour); the density caveat below it reuses
    the .olv-caveat honesty primitive. */
 .olv-analyse-derived {
-  display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-xs);
   margin-top: var(--space-sm); padding-top: var(--space-sm);
   border-top: 0.5px solid var(--hairline);
 }
 .olv-analyse-derived-label {
+  cursor: pointer; list-style: none; user-select: none;
   font-family: var(--mono); font-size: var(--text-2xs); font-weight: 500;
   text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-faint);
 }
+.olv-analyse-derived-label::-webkit-details-marker { display: none; }
+.olv-analyse-derived-label::before {
+  content: '▸'; display: inline-block; margin-right: var(--space-2xs);
+  font-size: 0.85em; transition: transform 0.12s ease;
+}
+.olv-analyse-derived[open] > .olv-analyse-derived-label::before { transform: rotate(90deg); }
 .olv-analyse-derived-value {
   font-size: var(--text-xs); color: var(--text-dim); overflow-wrap: anywhere;
-  font-variant-numeric: tabular-nums;
+  font-variant-numeric: tabular-nums; margin-top: var(--space-xs);
 }
 .olv-analyse-derived-caveat { margin-top: var(--space-xs); }
 

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -863,21 +863,24 @@ export class AnalysePanel {
     // measured nothing (no fabricated band).
     const cx = this._result.complexity;
     if (cx?.band) {
-      const line = el('div', { className: 'olv-analyse-derived' });
-      line.append(
-        el('span', { className: 'olv-analyse-derived-label', text: 'Derived complexity' }),
-        el('span', {
+      // Collapsed by default: the VRM/TPI detail and its cited reliability
+      // caveat are deep metrics, kept one tap away so the assessment reads at
+      // a glance instead of ending in a wall of statistics.
+      const details = el('details', { className: 'olv-analyse-derived' });
+      details.append(
+        el('summary', { className: 'olv-analyse-derived-label', text: 'Derived complexity' }),
+        el('div', {
           className: 'olv-analyse-derived-value',
           text: `${cx.bandLabel} — ${cx.detail}`,
         }),
       );
-      this._assessmentRow.append(line);
       const caveat = cx.warnings.find((w) => w.includes('reliability threshold'));
       if (caveat) {
-        this._assessmentRow.append(
+        details.append(
           el('div', { className: 'olv-caveat olv-analyse-derived-caveat', text: caveat }),
         );
       }
+      this._assessmentRow.append(details);
     }
   }
 

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -2780,8 +2780,21 @@ export class AnalysePanel {
     }
     this._fitnessRow.append(grid);
 
-    for (const c of f.caveats) {
-      this._fitnessRow.append(el('div', { className: 'olv-fit-caveat', text: c }));
+    if (f.caveats.length > 0) {
+      // Collapsed by default: the caveats restate the checklist dimensions above
+      // in longer form, so they sit behind one disclosure instead of stacking a
+      // wall of repeated text under the list.
+      const notes = el('details', { className: 'olv-fit-caveats' });
+      notes.append(
+        el('summary', {
+          className: 'olv-fit-caveats-summary',
+          text: `Notes (${f.caveats.length})`,
+        }),
+      );
+      for (const c of f.caveats) {
+        notes.append(el('div', { className: 'olv-fit-caveat', text: c }));
+      }
+      this._fitnessRow.append(notes);
     }
   }
 

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -413,7 +413,7 @@ export class MeasurePanel {
     });
     const importBtn = el('button', {
       className: 'olv-mp-action',
-      text: 'Open session',
+      text: 'Open',
       title:
         'Open a saved .olvsession — restores measurements, annotations, views, ' +
         'camera, render + colour settings. You can also just drag the ' +

--- a/src/ui/panelChrome.ts
+++ b/src/ui/panelChrome.ts
@@ -24,20 +24,39 @@ import { applyClassicScrollbarClass } from './classicScrollbars';
  * the observer fires with a zero box when the toolbar hides and the column
  * snaps back up. No-ops (keeping the static layout) where ResizeObserver
  * is unavailable.
+ *
+ * The push-down only applies when the centred toolbar actually overlaps the
+ * column horizontally. On a wide viewport the toolbar clears the far-left
+ * column entirely, so pushing the panels down just opens dead space above
+ * them; there the column stays at the shared 56px band and its top lines up
+ * with the toolbar's. Overlap depends on viewport width (the centred bar
+ * slides as the window resizes without its own box changing), so a window
+ * resize listener recomputes alongside the ResizeObserver.
  */
 export function wireMeasureBarClearance(bar: HTMLElement, column: HTMLElement): void {
-  if (typeof ResizeObserver === 'undefined') return;
-  try {
-    const ro = new ResizeObserver(() => {
-      const h = bar.offsetHeight; // 0 while .olv-hidden (display: none)
-      // 8px = the column's own --space-md gap, so toolbar → first panel
-      // reads with the same rhythm as panel → panel.
-      column.style.setProperty('--olv-measure-bar-clear', h > 0 ? `${h + 8}px` : '0px');
-    });
-    ro.observe(bar);
-  } catch {
-    /* Static layout fallback — only ancient engines, overlap is cosmetic. */
+  const update = (): void => {
+    const h = bar.offsetHeight; // 0 while .olv-hidden (display: none)
+    if (h <= 0) { column.style.setProperty('--olv-measure-bar-clear', '0px'); return; }
+    const b = bar.getBoundingClientRect();
+    const c = column.getBoundingClientRect();
+    // Only clear vertically when the toolbar and column boxes actually meet
+    // horizontally; the 8px slack matches the column's --space-md gap.
+    const overlaps = b.left < c.right + 8 && b.right > c.left;
+    // 8px = the column's own --space-md gap, so toolbar → first panel reads
+    // with the same rhythm as panel → panel.
+    column.style.setProperty('--olv-measure-bar-clear', overlaps ? `${h + 8}px` : '0px');
+  };
+  if (typeof ResizeObserver !== 'undefined') {
+    try {
+      const ro = new ResizeObserver(update);
+      ro.observe(bar);
+      ro.observe(column);
+    } catch {
+      /* Static layout fallback — only ancient engines, overlap is cosmetic. */
+    }
   }
+  if (typeof window !== 'undefined') window.addEventListener('resize', update);
+  update();
 }
 
 /**

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -3908,7 +3908,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   .olv-mp-stations-wrap,
   .olv-shortcuts-list {
     scrollbar-width: thin;
-    scrollbar-color: var(--hairline) transparent;
+    scrollbar-color: color-mix(in srgb, var(--hairline) 50%, var(--panel)) transparent;
   }
 }
 
@@ -3931,7 +3931,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-streaming-panel::-webkit-scrollbar-thumb,
 .olv-inspector::-webkit-scrollbar-thumb,
 .olv-measure-panel::-webkit-scrollbar-thumb {
-  background: var(--hairline); border-radius: 999px;
+  background: color-mix(in srgb, var(--hairline) 50%, var(--panel)); border-radius: 999px;
   border: 2px solid transparent; background-clip: padding-box;
 }
 .olv-analyse-panel::-webkit-scrollbar-thumb:hover,

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -4133,7 +4133,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
  * like "5.46 m × 11.53 m × 14.13 m · 889.54 m³" overflowed the box). */
 .olv-mp-row { display: flex; align-items: flex-start; gap: var(--space-sm); min-width: 0; }
 /* Profile measurements stack the headline row over a compact chart strip. */
-.olv-mp-row-stack { display: flex; flex-direction: column; gap: var(--space-xs); }
+.olv-mp-row-stack { display: flex; flex-direction: column; gap: var(--space-xs); min-width: 0; }
 /* Profile chart strip beneath a profile row. v0.3.10
  * #402: bumped from 36 px → 140 px so the curve is actually readable,
  * and made the box resizable along the vertical axis so an analyst

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -3924,10 +3924,17 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-measure-panel::-webkit-scrollbar {
   width: 7px; height: 7px;
 }
+/* The outer column carries the whole stack, so its bar sits a touch wider
+   than the slim inner-panel bars while sharing their thumb colour. */
+.olv-left-panels::-webkit-scrollbar {
+  width: 11px; height: 11px;
+}
+.olv-left-panels::-webkit-scrollbar-track,
 .olv-analyse-panel::-webkit-scrollbar-track,
 .olv-streaming-panel::-webkit-scrollbar-track,
 .olv-inspector::-webkit-scrollbar-track,
 .olv-measure-panel::-webkit-scrollbar-track { background: transparent; }
+.olv-left-panels::-webkit-scrollbar-thumb,
 .olv-analyse-panel::-webkit-scrollbar-thumb,
 .olv-streaming-panel::-webkit-scrollbar-thumb,
 .olv-inspector::-webkit-scrollbar-thumb,
@@ -3935,12 +3942,14 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   background: color-mix(in srgb, var(--accent) 55%, var(--hairline)); border-radius: 999px;
   border: 2px solid transparent; background-clip: padding-box;
 }
+.olv-left-panels::-webkit-scrollbar-thumb:hover,
 .olv-analyse-panel::-webkit-scrollbar-thumb:hover,
 .olv-streaming-panel::-webkit-scrollbar-thumb:hover,
 .olv-inspector::-webkit-scrollbar-thumb:hover,
 .olv-measure-panel::-webkit-scrollbar-thumb:hover {
   background: var(--accent); background-clip: padding-box;
 }
+.olv-left-panels::-webkit-scrollbar-corner,
 .olv-analyse-panel::-webkit-scrollbar-corner,
 .olv-streaming-panel::-webkit-scrollbar-corner,
 .olv-inspector::-webkit-scrollbar-corner,

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -3908,7 +3908,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   .olv-mp-stations-wrap,
   .olv-shortcuts-list {
     scrollbar-width: thin;
-    scrollbar-color: color-mix(in srgb, var(--accent) 55%, var(--hairline)) transparent;
+    scrollbar-color: color-mix(in srgb, var(--accent) 44%, var(--panel)) transparent;
   }
 }
 
@@ -3927,7 +3927,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 /* The outer column carries the whole stack, so its bar sits a touch wider
    than the slim inner-panel bars while sharing their thumb colour. */
 .olv-left-panels::-webkit-scrollbar {
-  width: 11px; height: 11px;
+  width: 9px; height: 9px;
 }
 .olv-left-panels::-webkit-scrollbar-track,
 .olv-analyse-panel::-webkit-scrollbar-track,
@@ -3939,7 +3939,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-streaming-panel::-webkit-scrollbar-thumb,
 .olv-inspector::-webkit-scrollbar-thumb,
 .olv-measure-panel::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--accent) 55%, var(--hairline)); border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 44%, var(--panel)); border-radius: 999px;
   border: 2px solid transparent; background-clip: padding-box;
 }
 .olv-left-panels::-webkit-scrollbar-thumb:hover,

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -3908,15 +3908,16 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   .olv-mp-stations-wrap,
   .olv-shortcuts-list {
     scrollbar-width: thin;
-    scrollbar-color: color-mix(in srgb, var(--hairline) 50%, var(--panel)) transparent;
+    scrollbar-color: color-mix(in srgb, var(--accent) 55%, var(--hairline)) transparent;
   }
 }
 
 /* Always-on thin themed scrollbar (not gated on classic mode) for the tall
    panels, so a macOS "always show scrollbars" setting — or any non-overlay
    platform — reads a slim accent bar rather than the chunky OS default. The
-   thumb mirrors the classic-mode style: hairline fill, inset with a transparent
-   border, accent on hover. Chromium/WebKit only; Firefox uses the block above. */
+   thumb mirrors the classic-mode style: accent-tinted fill, inset with a
+   transparent border, full accent on hover. Chromium/WebKit only; Firefox
+   uses the block above. */
 .olv-analyse-panel::-webkit-scrollbar,
 .olv-streaming-panel::-webkit-scrollbar,
 .olv-inspector::-webkit-scrollbar,
@@ -3931,7 +3932,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-streaming-panel::-webkit-scrollbar-thumb,
 .olv-inspector::-webkit-scrollbar-thumb,
 .olv-measure-panel::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--hairline) 50%, var(--panel)); border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 55%, var(--hairline)); border-radius: 999px;
   border: 2px solid transparent; background-clip: padding-box;
 }
 .olv-analyse-panel::-webkit-scrollbar-thumb:hover,

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -3901,6 +3901,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   .olv-bc-dialog,
   .olv-wfc-card,
   .olv-left-panels,
+  .olv-analyse-panel,
   .olv-inspector,
   .olv-streaming-panel,
   .olv-catalog-results,
@@ -3910,6 +3911,39 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
     scrollbar-color: var(--hairline-strong) transparent;
   }
 }
+
+/* Always-on thin themed scrollbar (not gated on classic mode) for the tall
+   panels, so a macOS "always show scrollbars" setting — or any non-overlay
+   platform — reads a slim accent bar rather than the chunky OS default. The
+   thumb mirrors the classic-mode style: hairline fill, inset with a transparent
+   border, accent on hover. Chromium/WebKit only; Firefox uses the block above. */
+.olv-analyse-panel::-webkit-scrollbar,
+.olv-streaming-panel::-webkit-scrollbar,
+.olv-inspector::-webkit-scrollbar,
+.olv-measure-panel::-webkit-scrollbar {
+  width: 7px; height: 7px;
+}
+.olv-analyse-panel::-webkit-scrollbar-track,
+.olv-streaming-panel::-webkit-scrollbar-track,
+.olv-inspector::-webkit-scrollbar-track,
+.olv-measure-panel::-webkit-scrollbar-track { background: transparent; }
+.olv-analyse-panel::-webkit-scrollbar-thumb,
+.olv-streaming-panel::-webkit-scrollbar-thumb,
+.olv-inspector::-webkit-scrollbar-thumb,
+.olv-measure-panel::-webkit-scrollbar-thumb {
+  background: var(--hairline-strong); border-radius: 999px;
+  border: 2px solid transparent; background-clip: padding-box;
+}
+.olv-analyse-panel::-webkit-scrollbar-thumb:hover,
+.olv-streaming-panel::-webkit-scrollbar-thumb:hover,
+.olv-inspector::-webkit-scrollbar-thumb:hover,
+.olv-measure-panel::-webkit-scrollbar-thumb:hover {
+  background: var(--accent); background-clip: padding-box;
+}
+.olv-analyse-panel::-webkit-scrollbar-corner,
+.olv-streaming-panel::-webkit-scrollbar-corner,
+.olv-inspector::-webkit-scrollbar-corner,
+.olv-measure-panel::-webkit-scrollbar-corner { background: transparent; }
 .olv-classic-scrollbars .olv-palette-list::-webkit-scrollbar,
 .olv-classic-scrollbars .olv-modal-body::-webkit-scrollbar,
 .olv-classic-scrollbars .olv-help-body::-webkit-scrollbar,
@@ -4577,6 +4611,9 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-mp-confidence {
   font-size: var(--text-xs); color: var(--text-faint);
   text-align: right; line-height: 1.35; cursor: help;
+  /* Wrap to a second line instead of clipping at the panel edge when the label
+     ("Viewer measurement · datum resolved") is wider than a narrow panel. */
+  white-space: normal; overflow-wrap: anywhere;
 }
 .olv-mp-confidence-approximate { color: var(--warn, #e0a030); }
 .olv-mp-confidence-unavailable { color: var(--text-faint); font-style: italic; }

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -3908,7 +3908,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   .olv-mp-stations-wrap,
   .olv-shortcuts-list {
     scrollbar-width: thin;
-    scrollbar-color: var(--hairline-strong) transparent;
+    scrollbar-color: var(--hairline) transparent;
   }
 }
 
@@ -3931,7 +3931,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-streaming-panel::-webkit-scrollbar-thumb,
 .olv-inspector::-webkit-scrollbar-thumb,
 .olv-measure-panel::-webkit-scrollbar-thumb {
-  background: var(--hairline-strong); border-radius: 999px;
+  background: var(--hairline); border-radius: 999px;
   border: 2px solid transparent; background-clip: padding-box;
 }
 .olv-analyse-panel::-webkit-scrollbar-thumb:hover,
@@ -4086,6 +4086,9 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   position: relative;
   min-width: 222px; max-width: 760px;
   resize: horizontal; overflow: auto;
+  /* Reserve the scrollbar's track so an always-on (macOS) vertical scrollbar
+     doesn't eat into the content width and clip the right edge of a reading. */
+  scrollbar-gutter: stable;
   background: var(--panel); border: 0.5px solid var(--hairline);
   border-radius: var(--radius-lg); padding: var(--space-xl);
 }
@@ -6650,6 +6653,20 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
   padding-left: var(--space-md); position: relative;
 }
 .olv-fit-caveat::before { content: '⚠'; position: absolute; left: 0; }
+/* Caveats collapsed behind a "Notes" disclosure — they restate the checklist in
+   longer form, so they stay one tap away instead of stacking under it. */
+.olv-fit-caveats { margin-top: var(--space-2xs); display: flex; flex-direction: column; gap: var(--space-2xs); }
+.olv-fit-caveats-summary {
+  cursor: pointer; list-style: none; user-select: none;
+  font-size: var(--text-2xs); font-weight: 500; color: var(--text-faint);
+  padding: var(--space-2xs) 0;
+}
+.olv-fit-caveats-summary::-webkit-details-marker { display: none; }
+.olv-fit-caveats-summary::before {
+  content: '▸'; display: inline-block; margin-right: var(--space-2xs);
+  font-size: 0.85em; transition: transform 0.12s ease;
+}
+.olv-fit-caveats[open] > .olv-fit-caveats-summary::before { transform: rotate(90deg); }
 
 /* Recommended grid / interval. */
 .olv-analyse-recommend-box { display: flex; flex-direction: column; gap: var(--space-2xs); margin: var(--space-sm) 0; }

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -4593,7 +4593,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   border-top: 0.5px solid var(--hairline);
 }
 .olv-mp-action {
-  flex: 1; font-size: var(--text-xs); color: var(--text-dim);
+  flex: 1; min-width: 0; font-size: var(--text-xs); color: var(--text-dim);
   background: rgba(255, 255, 255, 0.04);
   border: 0.5px solid var(--hairline);
   border-radius: var(--radius-sm); padding: var(--space-sm);
@@ -7025,17 +7025,23 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
    Descriptive (never a good/bad colour); the density caveat below it reuses
    the .olv-caveat honesty primitive. */
 .olv-analyse-derived {
-  display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-xs);
   margin-top: var(--space-sm); padding-top: var(--space-sm);
   border-top: 0.5px solid var(--hairline);
 }
 .olv-analyse-derived-label {
+  cursor: pointer; list-style: none; user-select: none;
   font-family: var(--mono); font-size: var(--text-2xs); font-weight: 500;
   text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-faint);
 }
+.olv-analyse-derived-label::-webkit-details-marker { display: none; }
+.olv-analyse-derived-label::before {
+  content: '▸'; display: inline-block; margin-right: var(--space-2xs);
+  font-size: 0.85em; transition: transform 0.12s ease;
+}
+.olv-analyse-derived[open] > .olv-analyse-derived-label::before { transform: rotate(90deg); }
 .olv-analyse-derived-value {
   font-size: var(--text-xs); color: var(--text-dim); overflow-wrap: anywhere;
-  font-variant-numeric: tabular-nums;
+  font-variant-numeric: tabular-nums; margin-top: var(--space-xs);
 }
 .olv-analyse-derived-caveat { margin-top: var(--space-xs); }
 


### PR DESCRIPTION
Two v0.6.4 UI-density fixes.

- **Measurements footer button clipped.** The three footer buttons are `flex: 1` with no `min-width: 0`, so the longest label ("Open session") could not shrink and overflowed the panel's right edge — most visibly at the 218px minimum width. Shortened the label to "Open" (matching the single-word "Chain"/"Export") and added `min-width: 0`, so the row always fits.
- **Terrain-readiness panel ended in a wall of statistics.** The Derived-complexity block (a VRM/TPI paragraph plus a cited reliability threshold) rendered expanded by default. It now sits behind a collapsed `Derived complexity` disclosure, reusing the panel's existing `▸` expander styling, so the assessment reads at a glance and the deep metrics are one tap away.

Golden CSS fixture regenerated. Full suite green (8631), tsc clean, build clean, monolith gate OK. Visual should be eyeballed in the test build; the button fix is deterministic and the disclosure mirrors the existing pattern.