### PR TITLE
Process Studio capability evaluator (v0.6.5 Phase 1)

### DIFF
--- a/src/process/ProcessPlan.ts
+++ b/src/process/ProcessPlan.ts
@@ -1,0 +1,95 @@
+/**
+ * ProcessPlan.ts — the pure capability model for Process Studio (v0.6.5).
+ *
+ * A ProcessPlan answers one question a user actually has: "what can I safely
+ * produce from this data?" It is a plain-data description — no DOM, no I/O, no
+ * three.js — so the UI, the exporters, and the tests all read the SAME
+ * eligibility verdicts. The rule this enforces is that eligibility lives in one
+ * place ({@link evaluateCapabilities}), never re-derived inside a button.
+ *
+ * Every product is `ready`, `review`, or `blocked` with an explicit,
+ * greppable reason code. The vocabulary deliberately fails closed: when a fact
+ * needed for a metric product is unknown (an unconfirmed linear unit, a
+ * differing vertical reference, resident-only streaming coverage), the product
+ * is withheld or flagged, never silently produced. This mirrors the honesty
+ * contract the terrain and export surfaces already hold in v0.6.4.
+ *
+ * Phase 1 defines the model and a first set of rules. Later phases add products
+ * (semantic classes, registration, features) by extending the enum and the
+ * evaluator, not by adding parallel eligibility logic elsewhere.
+ */
+
+import type { CrsInfo } from '../io/crs';
+
+/** How ready a derivable product is, given the loaded data. */
+export type Readiness = 'ready' | 'review' | 'blocked';
+
+/** How much of a scan the operation can actually see. */
+export type Coverage = 'full' | 'sampled' | 'resident-only';
+
+/** Whether a scan carries classification, and how completely. */
+export type ClassPresence = 'none' | 'partial' | 'full';
+
+/** The products the capability model reasons about in Phase 1. */
+export type ProductId =
+  | 'classify-gaps'
+  | 'dtm'
+  | 'dsm'
+  | 'contours'
+  | 'building-footprints'
+  | 'cross-epoch-change'
+  | 'volume-cut-fill';
+
+/**
+ * A plain-data snapshot of ONE loaded scan — the facts the evaluator needs.
+ * Assembled by the shell from existing scan-report / streaming signals; kept
+ * free of live objects so the evaluator stays pure and worker-safe.
+ */
+export interface ScanFacts {
+  /** Static (whole file resident) or streaming (COPC/EPT). */
+  readonly kind: 'static' | 'streaming';
+  /** How much of the scan the operation can read — drives coverage honesty. */
+  readonly coverage: Coverage;
+  /** Detected CRS, or null when none is recoverable. */
+  readonly crs: CrsInfo | null;
+  /** Total points in the source (not the resident count). */
+  readonly pointCount: number;
+  readonly hasRgb: boolean;
+  readonly hasIntensity: boolean;
+  readonly hasGpsTime: boolean;
+  readonly hasReturnNumber: boolean;
+  readonly hasPointSourceId: boolean;
+  /** Classification presence, from the producer or a prior derive. */
+  readonly classification: ClassPresence;
+  /** True when class 2 (ground) is present and trustworthy. */
+  readonly groundClassified: boolean;
+  /** True when class 6 (building) points are present. */
+  readonly hasBuildingClass: boolean;
+  /** Median point spacing in metres, when measurable. */
+  readonly medianSpacing?: number;
+}
+
+/** Everything the evaluator reasons over: the loaded scans and their relation. */
+export interface ProcessInputs {
+  readonly scans: readonly ScanFacts[];
+  /**
+   * For a two-scan comparison: whether the two share a proven-compatible
+   * spatial frame. `undefined` means not yet determined (→ review, not ready).
+   */
+  readonly projectFrameCompatible?: boolean;
+}
+
+/** One product's verdict, with a stable reason code and a human sentence. */
+export interface ProductCapability {
+  readonly product: ProductId;
+  readonly readiness: Readiness;
+  /** Stable UPPER_SNAKE slug — greppable, safe to switch on. */
+  readonly reasonCode: string;
+  /** One human sentence explaining the verdict. */
+  readonly reason: string;
+}
+
+/** The capability model for the current dataset(s). */
+export interface ProcessPlan {
+  readonly products: readonly ProductCapability[];
+}

--- a/src/process/processCapabilities.ts
+++ b/src/process/processCapabilities.ts
@@ -1,0 +1,186 @@
+/**
+ * processCapabilities.ts — the single eligibility evaluator (v0.6.5 Phase 1).
+ *
+ * {@link evaluateCapabilities} turns a plain-data {@link ProcessInputs} into a
+ * {@link ProcessPlan}. It is the ONE place product eligibility is decided; the
+ * Process Studio UI and every exporter read its verdicts rather than re-deriving
+ * their own, so a product can never be offered in one surface and refused in
+ * another.
+ *
+ * Fail-closed is the rule. A metric product (contours, footprint area, volume)
+ * needs a confirmed linear unit and, for cross-epoch work, a shared vertical
+ * reference. When those are missing the product is `blocked` or `review`, never
+ * `ready`. Coverage honesty carries through too: a resident-only streaming scan
+ * cannot back a full-dataset product, so those degrade to `review`.
+ *
+ * Pure — no DOM, no I/O, no three.js. Reuses the v0.6.4 unit guard
+ * ({@link isLinearUnitKnown}) so "unit known" means exactly what it means
+ * everywhere else.
+ */
+
+import type {
+  ProcessInputs,
+  ProcessPlan,
+  ProductCapability,
+  ProductId,
+  ScanFacts,
+} from './ProcessPlan';
+import { isLinearUnitKnown } from '../geo/CoordinateTypes';
+
+/** Build one capability verdict. */
+function cap(
+  product: ProductId,
+  readiness: ProductCapability['readiness'],
+  reasonCode: string,
+  reason: string,
+): ProductCapability {
+  return { product, readiness, reasonCode, reason };
+}
+
+/** True when the scan can back a full-dataset product (not resident-only). */
+function isFullCoverage(scan: ScanFacts): boolean {
+  return scan.coverage === 'full';
+}
+
+/**
+ * Two scans share a usable vertical reference when both declare a vertical
+ * datum and the two agree. A missing or mismatched vertical reference fails
+ * closed — cross-epoch height math on incompatible references is exactly the
+ * silent wrong number the model exists to prevent.
+ */
+function sharedVerticalReference(a: ScanFacts, b: ScanFacts): boolean {
+  const va = a.crs?.verticalDatum;
+  const vb = b.crs?.verticalDatum;
+  return va != null && vb != null && va === vb;
+}
+
+/** Classification of unclassified points — geometry-driven, no CRS needed. */
+function classifyGaps(scan: ScanFacts): ProductCapability {
+  const p: ProductId = 'classify-gaps';
+  if (scan.pointCount <= 0) {
+    return cap(p, 'blocked', 'NO_POINTS', 'The scan has no points to classify.');
+  }
+  if (scan.classification === 'full') {
+    return cap(p, 'review', 'ALREADY_CLASSIFIED', 'Every point already carries a class; reclassifying would overwrite producer values, so it is an explicit action rather than a default.');
+  }
+  if (!isFullCoverage(scan)) {
+    return cap(p, 'review', 'PARTIAL_COVERAGE', 'Only resident or sampled points are available, so classification would cover part of the scan; it is labelled as such.');
+  }
+  return cap(p, 'ready', 'GAPS_CLASSIFIABLE', 'Unclassified points can be classified from geometry while producer classes are preserved.');
+}
+
+/** Bare-earth DTM — needs ground and full coverage; unit gates georeferenced use. */
+function dtm(scan: ScanFacts): ProductCapability {
+  const p: ProductId = 'dtm';
+  if (scan.pointCount <= 0) {
+    return cap(p, 'blocked', 'NO_POINTS', 'The scan has no points to grid.');
+  }
+  if (!isFullCoverage(scan)) {
+    return cap(p, 'blocked', 'RESIDENT_ONLY', 'A surface needs the whole dataset; a resident-only streaming view cannot back a DTM.');
+  }
+  if (!isLinearUnitKnown(scan.crs)) {
+    return cap(p, 'review', 'UNIT_UNKNOWN', 'The linear unit is unconfirmed, so the surface can be built for inspection but its georeferenced export is withheld.');
+  }
+  if (!scan.groundClassified) {
+    return cap(p, 'review', 'GROUND_DERIVED', 'No trusted ground class is present, so ground is derived by the filter; the surface carries lower confidence than one built from classified ground.');
+  }
+  return cap(p, 'ready', 'GROUND_TRUSTED', 'Trusted ground points and a known unit support a bare-earth DTM.');
+}
+
+/** Upper-surface DSM — needs full coverage; no ground requirement. */
+function dsm(scan: ScanFacts): ProductCapability {
+  const p: ProductId = 'dsm';
+  if (scan.pointCount <= 0) {
+    return cap(p, 'blocked', 'NO_POINTS', 'The scan has no points to grid.');
+  }
+  if (!isFullCoverage(scan)) {
+    return cap(p, 'blocked', 'RESIDENT_ONLY', 'A surface needs the whole dataset; a resident-only streaming view cannot back a DSM.');
+  }
+  if (!isLinearUnitKnown(scan.crs)) {
+    return cap(p, 'review', 'UNIT_UNKNOWN', 'The linear unit is unconfirmed, so the surface can be built for inspection but its georeferenced export is withheld.');
+  }
+  return cap(p, 'ready', 'SURFACE_READY', 'The upper surface can be gridded from all returns.');
+}
+
+/** Contours — a metric product; a confirmed unit is required, not optional. */
+function contours(scan: ScanFacts, dtmVerdict: ProductCapability): ProductCapability {
+  const p: ProductId = 'contours';
+  if (dtmVerdict.readiness === 'blocked') {
+    return cap(p, 'blocked', 'NO_DTM', 'Contours derive from a DTM, which is not available for this scan.');
+  }
+  if (!isLinearUnitKnown(scan.crs)) {
+    return cap(p, 'blocked', 'UNIT_UNKNOWN', 'A contour interval is a metric distance, so an unconfirmed linear unit blocks contours rather than guessing metres.');
+  }
+  if (dtmVerdict.readiness === 'review') {
+    return cap(p, 'review', 'DTM_REVIEW', 'The underlying DTM is for review, so its contours carry the same caveat.');
+  }
+  return cap(p, 'ready', 'DTM_READY', 'A trusted DTM and a known unit support evidence-graded contours.');
+}
+
+/** Building footprints — need building points and a known unit (area is metric). */
+function buildingFootprints(scan: ScanFacts): ProductCapability {
+  const p: ProductId = 'building-footprints';
+  if (!isLinearUnitKnown(scan.crs)) {
+    return cap(p, 'blocked', 'UNIT_UNKNOWN', 'Footprint area is a metric quantity, so an unconfirmed linear unit blocks extraction.');
+  }
+  if (!isFullCoverage(scan)) {
+    return cap(p, 'blocked', 'RESIDENT_ONLY', 'Footprints need every building return; a resident-only streaming view cannot back them.');
+  }
+  if (scan.hasBuildingClass) {
+    return cap(p, 'ready', 'BUILDING_CLASS_PRESENT', 'Building-class points support footprint extraction.');
+  }
+  if (scan.classification === 'none') {
+    return cap(p, 'review', 'NEEDS_CLASSIFICATION', 'No building class is present; classifying first would supply the candidates, so extraction is offered for review.');
+  }
+  return cap(p, 'review', 'NO_BUILDING_CLASS', 'The scan is classified but carries no building class, so any footprints come from derived candidates and need review.');
+}
+
+/**
+ * A two-scan product (change raster or volume) — needs exactly two scans, a
+ * compatible frame, and a shared vertical reference. Reused by both cross-epoch
+ * change and cut/fill volume, which share the same eligibility.
+ */
+function twoScanProduct(product: ProductId, inputs: ProcessInputs, noun: string): ProductCapability {
+  const [a, b] = inputs.scans;
+  if (inputs.scans.length !== 2 || a == null || b == null) {
+    return cap(product, 'blocked', 'NEED_TWO_SCANS', `${noun} needs exactly two loaded scans.`);
+  }
+  if (!isLinearUnitKnown(a.crs) || !isLinearUnitKnown(b.crs)) {
+    return cap(product, 'blocked', 'UNIT_UNKNOWN', `${noun} is a metric product, so an unconfirmed linear unit on either scan blocks it.`);
+  }
+  if (!sharedVerticalReference(a, b)) {
+    return cap(product, 'blocked', 'VERTICAL_REF_DIFFERS', `${noun} compares heights, so a missing or differing vertical reference between the two scans blocks it.`);
+  }
+  if (inputs.projectFrameCompatible !== true) {
+    return cap(product, 'review', 'FRAME_UNPROVEN', `The two scans' spatial frames are not yet proven compatible, so ${noun.toLowerCase()} is offered for review pending alignment.`);
+  }
+  return cap(product, 'ready', 'COMPATIBLE', `Two scans in a compatible frame with a shared vertical reference support ${noun.toLowerCase()}.`);
+}
+
+/**
+ * Evaluate what the loaded dataset(s) can safely produce. The single source of
+ * product eligibility for Process Studio and every exporter.
+ */
+export function evaluateCapabilities(inputs: ProcessInputs): ProcessPlan {
+  const products: ProductCapability[] = [];
+  const primary = inputs.scans[0];
+
+  if (primary != null) {
+    const dtmVerdict = dtm(primary);
+    products.push(classifyGaps(primary));
+    products.push(dtmVerdict);
+    products.push(dsm(primary));
+    products.push(contours(primary, dtmVerdict));
+    products.push(buildingFootprints(primary));
+  }
+
+  products.push(twoScanProduct('cross-epoch-change', inputs, 'Cross-epoch change'));
+  products.push(twoScanProduct('volume-cut-fill', inputs, 'Cut/fill volume'));
+
+  return { products };
+}
+
+/** Convenience: look up one product's verdict in a plan. */
+export function capabilityFor(plan: ProcessPlan, product: ProductId): ProductCapability | undefined {
+  return plan.products.find((c) => c.product === product);
+}

--- a/tests/processCapabilities.test.ts
+++ b/tests/processCapabilities.test.ts
@@ -1,0 +1,183 @@
+/**
+ * processCapabilities.test.ts
+ *
+ * The Phase 1 capability evaluator is the single source of product eligibility,
+ * so these tests pin every ready / review / blocked path and, above all, the
+ * fail-closed rules: an unconfirmed linear unit blocks metric products, a
+ * differing vertical reference blocks cross-epoch height math, and resident-only
+ * streaming coverage cannot back a full-dataset product.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CrsInfo } from '../src/io/crs';
+import type { ScanFacts, ProductId } from '../src/process/ProcessPlan';
+import { evaluateCapabilities, capabilityFor } from '../src/process/processCapabilities';
+
+function crs(overrides: Partial<CrsInfo> = {}): CrsInfo {
+  return {
+    source: 'epsg',
+    linearUnit: 'metre',
+    linearUnitToMetres: 1,
+    ...overrides,
+  } as CrsInfo;
+}
+
+function scan(overrides: Partial<ScanFacts> = {}): ScanFacts {
+  return {
+    kind: 'static',
+    coverage: 'full',
+    crs: crs(),
+    pointCount: 1_000_000,
+    hasRgb: true,
+    hasIntensity: true,
+    hasGpsTime: true,
+    hasReturnNumber: true,
+    hasPointSourceId: false,
+    classification: 'none',
+    groundClassified: false,
+    hasBuildingClass: false,
+    medianSpacing: 0.2,
+    ...overrides,
+  };
+}
+
+function verdict(scans: ScanFacts[], product: ProductId, projectFrameCompatible?: boolean) {
+  const plan = evaluateCapabilities({ scans, projectFrameCompatible });
+  return capabilityFor(plan, product)!;
+}
+
+describe('classify-gaps', () => {
+  it('ready on an unclassified full scan', () => {
+    expect(verdict([scan()], 'classify-gaps').readiness).toBe('ready');
+  });
+  it('review when already fully classified (preserve producer classes)', () => {
+    const v = verdict([scan({ classification: 'full' })], 'classify-gaps');
+    expect(v.readiness).toBe('review');
+    expect(v.reasonCode).toBe('ALREADY_CLASSIFIED');
+  });
+  it('review on resident-only streaming coverage', () => {
+    const v = verdict([scan({ kind: 'streaming', coverage: 'resident-only' })], 'classify-gaps');
+    expect(v.readiness).toBe('review');
+    expect(v.reasonCode).toBe('PARTIAL_COVERAGE');
+  });
+  it('blocked with no points', () => {
+    expect(verdict([scan({ pointCount: 0 })], 'classify-gaps').readiness).toBe('blocked');
+  });
+});
+
+describe('dtm — fail closed on unit and coverage', () => {
+  it('ready with trusted ground and a known unit', () => {
+    expect(verdict([scan({ groundClassified: true })], 'dtm').readiness).toBe('ready');
+  });
+  it('review when ground must be derived', () => {
+    const v = verdict([scan({ groundClassified: false })], 'dtm');
+    expect(v.readiness).toBe('review');
+    expect(v.reasonCode).toBe('GROUND_DERIVED');
+  });
+  it('review when the linear unit is unknown', () => {
+    const v = verdict([scan({ groundClassified: true, crs: crs({ linearUnit: 'unknown' }) })], 'dtm');
+    expect(v.readiness).toBe('review');
+    expect(v.reasonCode).toBe('UNIT_UNKNOWN');
+  });
+  it('review when the CRS is missing entirely (fail closed, not assumed metre)', () => {
+    const v = verdict([scan({ groundClassified: true, crs: null })], 'dtm');
+    expect(v.readiness).toBe('review');
+    expect(v.reasonCode).toBe('UNIT_UNKNOWN');
+  });
+  it('blocked on resident-only streaming', () => {
+    const v = verdict([scan({ kind: 'streaming', coverage: 'resident-only' })], 'dtm');
+    expect(v.readiness).toBe('blocked');
+    expect(v.reasonCode).toBe('RESIDENT_ONLY');
+  });
+});
+
+describe('contours — a metric product blocks on unknown unit', () => {
+  it('ready over a trusted DTM with a known unit', () => {
+    expect(verdict([scan({ groundClassified: true })], 'contours').readiness).toBe('ready');
+  });
+  it('blocked when the unit is unknown, even though a surface could be drawn', () => {
+    const v = verdict([scan({ groundClassified: true, crs: crs({ linearUnit: 'unknown' }) })], 'contours');
+    expect(v.readiness).toBe('blocked');
+    expect(v.reasonCode).toBe('UNIT_UNKNOWN');
+  });
+  it('review when the DTM itself is only for review', () => {
+    expect(verdict([scan({ groundClassified: false })], 'contours').readiness).toBe('review');
+  });
+  it('blocked when no DTM is possible (resident-only)', () => {
+    const v = verdict([scan({ kind: 'streaming', coverage: 'resident-only' })], 'contours');
+    expect(v.readiness).toBe('blocked');
+    expect(v.reasonCode).toBe('NO_DTM');
+  });
+});
+
+describe('building-footprints', () => {
+  it('ready with building-class points and a known unit', () => {
+    expect(verdict([scan({ hasBuildingClass: true, classification: 'full' })], 'building-footprints').readiness).toBe('ready');
+  });
+  it('blocked when the unit is unknown (area is metric)', () => {
+    const v = verdict([scan({ hasBuildingClass: true, crs: crs({ linearUnit: 'unknown' }) })], 'building-footprints');
+    expect(v.readiness).toBe('blocked');
+    expect(v.reasonCode).toBe('UNIT_UNKNOWN');
+  });
+  it('review when unclassified (classify first)', () => {
+    const v = verdict([scan({ classification: 'none' })], 'building-footprints');
+    expect(v.readiness).toBe('review');
+    expect(v.reasonCode).toBe('NEEDS_CLASSIFICATION');
+  });
+});
+
+describe('cross-epoch change & volume — two-scan fail-closed rules', () => {
+  const epochA = scan({ crs: crs({ verticalDatum: 'NAVD88' }), groundClassified: true });
+  const epochB = scan({ crs: crs({ verticalDatum: 'NAVD88' }), groundClassified: true });
+
+  it('blocked with a single scan', () => {
+    expect(verdict([epochA], 'cross-epoch-change').readiness).toBe('blocked');
+    expect(verdict([epochA], 'volume-cut-fill').reasonCode).toBe('NEED_TWO_SCANS');
+  });
+
+  it('blocked when vertical references differ', () => {
+    const other = scan({ crs: crs({ verticalDatum: 'EGM2008' }), groundClassified: true });
+    const v = verdict([epochA, other], 'volume-cut-fill', true);
+    expect(v.readiness).toBe('blocked');
+    expect(v.reasonCode).toBe('VERTICAL_REF_DIFFERS');
+  });
+
+  it('blocked when either vertical reference is missing (fail closed)', () => {
+    const noVert = scan({ crs: crs(), groundClassified: true }); // no verticalDatum
+    const v = verdict([epochA, noVert], 'cross-epoch-change', true);
+    expect(v.readiness).toBe('blocked');
+    expect(v.reasonCode).toBe('VERTICAL_REF_DIFFERS');
+  });
+
+  it('review when the frame compatibility is not yet proven', () => {
+    const v = verdict([epochA, epochB], 'cross-epoch-change', undefined);
+    expect(v.readiness).toBe('review');
+    expect(v.reasonCode).toBe('FRAME_UNPROVEN');
+  });
+
+  it('ready with two compatible scans sharing a vertical reference', () => {
+    expect(verdict([epochA, epochB], 'volume-cut-fill', true).readiness).toBe('ready');
+  });
+
+  it('blocked when a unit is unknown on either scan', () => {
+    const noUnit = scan({ crs: crs({ linearUnit: 'unknown', verticalDatum: 'NAVD88' }), groundClassified: true });
+    const v = verdict([epochA, noUnit], 'volume-cut-fill', true);
+    expect(v.readiness).toBe('blocked');
+    expect(v.reasonCode).toBe('UNIT_UNKNOWN');
+  });
+});
+
+describe('plan shape', () => {
+  it('is empty of single-scan products when no scans are loaded, and blocks two-scan ones', () => {
+    const plan = evaluateCapabilities({ scans: [] });
+    expect(capabilityFor(plan, 'dtm')).toBeUndefined();
+    expect(capabilityFor(plan, 'cross-epoch-change')!.readiness).toBe('blocked');
+  });
+  it('every reason code is UPPER_SNAKE and every product carries a reason sentence', () => {
+    const plan = evaluateCapabilities({ scans: [scan()], projectFrameCompatible: false });
+    for (const c of plan.products) {
+      expect(c.reasonCode).toMatch(/^[A-Z][A-Z0-9_]*$/);
+      expect(c.reason.length).toBeGreaterThan(10);
+    }
+  });
+});


### PR DESCRIPTION
First slice of the v0.6.5 Process Studio roadmap: the **pure capability model**, services-first per the plan (no UI yet).

## What this is
`evaluateCapabilities(ProcessInputs): ProcessPlan` — the single place product eligibility is decided. Each product is `ready | review | blocked` with a stable UPPER_SNAKE reason code and a human sentence. The UI and every exporter will read these verdicts instead of re-deriving their own, so a product can never be offered in one surface and refused in another.

## Products modelled (Phase 1)
classify-gaps, dtm, dsm, contours, building-footprints, cross-epoch-change, volume-cut-fill.

## Honesty, reusing v0.6.4 primitives
- Unknown/absent linear unit → metric products (contours, footprint area, volume) **blocked**, via the existing `isLinearUnitKnown` guard (same meaning as everywhere else).
- Missing or differing vertical datum between two scans → cross-epoch height math **blocked** (the roadmap's canonical "Cross-epoch volume — BLOCKED: vertical reference differs").
- Resident-only streaming coverage → full-dataset products **blocked**; partial coverage → **review**. Carries v0.6.4's coverage honesty into the capability layer.
- Already-classified scan → classify-gaps is **review**, not a silent overwrite (preserves producer classes).

## Purity & tests
No DOM/I/O/three.js — worker-safe. `tests/processCapabilities.test.ts`: 24 cases across every ready/review/blocked path and each fail-closed rule.

## Gates
tsc clean; 24/24 new tests; arch-truth, main-deferral, monolith, layer-boundaries, evidence, claim-register all green. No `main.ts`/`Viewer.ts` growth (new module under `src/process/`).

Roadmap: `_private/ROADMAP_v0.6.5.md` Phase 1. No scientific claim yet (pure routing), so no claim-register entry — those come with the algorithms in Phases 3+.