### PR TITLE
Bound remote range reads in bytes and time (#309 Goal 3)

### DIFF
--- a/src/io/range/HttpRangeSource.ts
+++ b/src/io/range/HttpRangeSource.ts
@@ -23,6 +23,7 @@
 
 import type { RangeSource, RangeSourceKind } from './RangeSource';
 import { RangeReadError, clampRange, sanitizeUrlForDisplay } from './RangeSource';
+import { readExactlyBounded } from './boundedRead';
 
 /** Per-attempt timeout for one HTTP request, in milliseconds. */
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
@@ -208,15 +209,15 @@ export class HttpRangeSource implements RangeSource {
     // returning the wrong bytes.
     const contentRange = response.headers.get('content-range');
     const expected = end - offset + 1;
+    // Both success paths stream the body through a bounded reader: it refuses a
+    // declared length above the request before reading a byte, stops and
+    // cancels on the chunk that would cross the ceiling, and races an idle /
+    // whole-body clock so a host that sends headers and then trickles (or
+    // stalls) can't hang the read. A too-short body is rejected the same as
+    // before. When Content-Range is absent the exact-length check IS the only
+    // integrity guard, so it stays; when present, it still bounds the read.
     if (contentRange === null) {
-      const body = await response.arrayBuffer();
-      if (body.byteLength !== expected) {
-        throw new RangeReadError(
-          'content-mismatch',
-          `Server returned a 206 without Content-Range and a body length ${body.byteLength} that didn't match the requested ${expected} bytes.`,
-        );
-      }
-      return body;
+      return readExactlyBounded(response, expected, { signal });
     }
     if (!isContentRangeMatch(contentRange, offset, end)) {
       throw new RangeReadError(
@@ -224,7 +225,7 @@ export class HttpRangeSource implements RangeSource {
         `Server returned a 206 with mismatched Content-Range "${contentRange}" for ${offset}-${end}.`,
       );
     }
-    return response.arrayBuffer();
+    return readExactlyBounded(response, expected, { signal });
   }
 
   /**
@@ -256,9 +257,18 @@ export class HttpRangeSource implements RangeSource {
         `Probe returned an unexpected status ${response.status}`,
       );
     }
-    // Drain the one-byte body so the connection can be reused. Skipping
-    // this can leave the response in a half-read state on some runtimes.
-    void response.arrayBuffer().catch(() => undefined);
+    // Tear the one-byte probe body down without reading it. `arrayBuffer()`
+    // here would materialise whatever the server actually sent — a host that
+    // answers a `bytes=0-0` probe with a huge body would be read in full into a
+    // buffer nobody looks at. Cancelling the stream releases the connection
+    // and refuses that body outright. Guarded for runtimes / test stand-ins
+    // whose Response has no streaming body.
+    const probeBody = response.body as ReadableStream<Uint8Array> | null | undefined;
+    if (probeBody && typeof probeBody.cancel === 'function') {
+      void probeBody.cancel().catch(() => undefined);
+    } else {
+      void response.arrayBuffer().catch(() => undefined);
+    }
     const total = parseContentRangeTotal(response.headers.get('content-range'));
     if (total !== null && total > 0) {
       this._size = total;

--- a/src/io/range/boundedRead.ts
+++ b/src/io/range/boundedRead.ts
@@ -1,0 +1,480 @@
+/**
+ * boundedRead.ts
+ *
+ * Bounded body readers for untrusted remote responses.
+ *
+ * Every remote read in this codebase used to be `await response.arrayBuffer()`
+ * followed — if at all — by a length check. That is read-then-validate: the
+ * body is already fully materialised in memory before anyone asks whether it
+ * was the right size. A host that answers a 3 KB range request with a 4 GB
+ * body wins that exchange; the tab dies before the check runs. The `bytes=0-0`
+ * probe was worse still, because it discarded the promise (`void
+ * response.arrayBuffer()`) and so read an unbounded body into a buffer nobody
+ * would ever look at, before anything at all was known about the object.
+ *
+ * These helpers invert the order: consult the declared length, then stream the
+ * body through `ReadableStreamDefaultReader` and stop the moment it exceeds
+ * what was asked for, cancelling the body so the transfer is torn down rather
+ * than drained. Nothing materially larger than the caller's ceiling is ever
+ * allocated.
+ *
+ * `response.body` is absent on some runtimes and on the hand-rolled Response
+ * stand-ins used in tests. That degrades to `arrayBuffer()` plus the same
+ * validation — read-then-validate again, but only where streaming genuinely
+ * isn't available, and still with a pre-read `Content-Length` refusal in front
+ * of it.
+ *
+ * A BYTE ceiling alone is not a bound. A server that returns headers promptly
+ * and then never sends a body sits under every byte limit forever, and so does
+ * one trickling a byte a minute. Bounding size without bounding time turns a
+ * hostile host into a hang, which in the manifest path wedged the app's
+ * `loading` flag until a page reload. So every chunk read RACES the caller's
+ * abort and two clocks — an idle timeout (silence between chunks) and a
+ * whole-body ceiling (the trickle) — rather than checking a flag before an
+ * unbounded await, where a body that goes quiet never reaches the check again.
+ *
+ * Pure — no DOM, no three.js. Uses only `Response` and web streams, both of
+ * which exist on the main thread and in workers.
+ */
+
+import { RangeReadError } from './RangeSource';
+
+/**
+ * Default silence budget between two chunks, in ms.
+ *
+ * Matches the per-request header timeout the transports already use: 20 s of a
+ * connection saying nothing at all is the same evidence of a dead host either
+ * side of the response headers.
+ */
+export const DEFAULT_IDLE_TIMEOUT_MS = 20_000;
+
+/**
+ * Default ceiling on consuming ONE body, in ms.
+ *
+ * Deliberately far above the idle budget. A total deadline as tight as the
+ * header deadline would fail a large tile on a slow-but-healthy mobile link —
+ * trading a rare hostile-host hang for a common legitimate failure. Five
+ * minutes is past any real read (a 128 MiB tile at 500 KB/s is four) while
+ * still terminating a byte-a-minute trickle that the idle budget alone would
+ * let run forever.
+ */
+export const DEFAULT_TOTAL_TIMEOUT_MS = 300_000;
+
+/** Timing and cancellation for one bounded body read. */
+export interface BoundedReadOptions {
+  /**
+   * Aborts the read.
+   *
+   * The transports pass the SAME composed signal the `fetch` was issued with,
+   * still wired to the caller's cancel and the request deadline, so aborting
+   * it errors the underlying body stream rather than leaving a dangling read.
+   * That wiring is the fix for a subtler half of the same bug: the transports
+   * used to tear the listener down as soon as the headers arrived, after which
+   * neither the deadline nor the user's Cancel could reach the body at all.
+   */
+  readonly signal?: AbortSignal;
+  /**
+   * The deadline half of `signal`, when the caller composed one.
+   *
+   * Both a user cancel and an expired request deadline arrive here as the same
+   * event — the composed signal aborting — but they are not the same thing to
+   * a person. A cancel should surface as a cancel (the app shows nothing; the
+   * user already knows) and an expired deadline should surface as an error
+   * naming a server that stopped responding. Handing the deadline's own signal
+   * in is what lets the read tell them apart instead of reporting every
+   * stalled host as something the user did.
+   */
+  readonly timeoutSignal?: AbortSignal;
+  /** Silence budget between chunks. Default {@link DEFAULT_IDLE_TIMEOUT_MS}. */
+  readonly idleTimeoutMs?: number;
+  /** Whole-body ceiling. Default {@link DEFAULT_TOTAL_TIMEOUT_MS}. */
+  readonly totalTimeoutMs?: number;
+}
+
+/** Why a bounded read failed. */
+export type BoundedReadReason = 'too-large' | 'stalled';
+
+/**
+ * A remote body that blew past the caller's byte ceiling, arrived short, or
+ * stopped arriving. Distinct from {@link RangeReadError} because the non-range
+ * callers (the EPT transport, the EPT manifest) have no range semantics to
+ * report — they have a limit and a resource name.
+ */
+export class BoundedReadError extends Error {
+  /** The ceiling that was exceeded, in bytes. */
+  readonly limitBytes: number;
+  /** What was being read — "EPT hierarchy file", "EPT manifest", … */
+  readonly what: string;
+  /** Size failure or time failure. */
+  readonly reason: BoundedReadReason;
+  constructor(
+    what: string,
+    limitBytes: number,
+    message: string,
+    reason: BoundedReadReason = 'too-large',
+  ) {
+    super(message);
+    this.name = 'BoundedReadError';
+    this.what = what;
+    this.limitBytes = limitBytes;
+    this.reason = reason;
+  }
+}
+
+/** The abort shape a cancelled `fetch` produces, so callers classify it alike. */
+function abortError(): Error {
+  return new DOMException('The read was aborted.', 'AbortError');
+}
+
+/**
+ * Read ONE chunk, racing the reader against the caller's abort and the two
+ * clocks.
+ *
+ * The ordering matters and is the whole point. Polling `signal.aborted` before
+ * `await reader.read()` bounds nothing: the check happens, then control leaves
+ * for an await that may never return, and the check is never reached again.
+ * Racing puts the timer and the abort listener on the same footing as the read
+ * itself, so whichever settles first wins.
+ *
+ * When a clock or the abort wins, the underlying `read()` is left pending. The
+ * caller cancels the reader on its error path, which settles it.
+ */
+function readChunkRacing(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal: AbortSignal | undefined,
+  timeoutSignal: AbortSignal | undefined,
+  idleTimeoutMs: number,
+  totalTimeoutMs: number,
+  msLeftOfTotal: () => number,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const settle = (act: () => void): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      act();
+    };
+    // An abort that the caller's deadline caused is a stalled server, not a
+    // cancel — the transports arm the request deadline through the body now,
+    // so it is the deadline, not the idle timer, that usually wins that race.
+    const abortReason = (): Error =>
+      timeoutSignal?.aborted
+        ? new BoundedReadStall(
+            'the request deadline expired while the body was still arriving',
+            'total',
+          )
+        : abortError();
+    function onAbort(): void {
+      settle(() => reject(abortReason()));
+    }
+    if (signal?.aborted) {
+      settle(() => reject(abortReason()));
+      return;
+    }
+    const totalLeft = msLeftOfTotal();
+    // Whichever clock expires first governs this chunk. `totalLeft` shrinks
+    // across chunks, so a trickle eventually gets a zero budget even though
+    // every individual gap stayed under the idle limit.
+    const budget = Math.max(0, Math.min(idleTimeoutMs, totalLeft));
+    // Which clock we were actually waiting on, decided up front: if the total
+    // budget is what capped this chunk, expiry means the whole body ran out of
+    // time, not that this one gap was too long.
+    const cappedByTotal = totalLeft <= idleTimeoutMs;
+    timer = setTimeout(() => {
+      settle(() =>
+        reject(
+          cappedByTotal
+            ? new BoundedReadStall(
+                `body did not finish within ${totalTimeoutMs} ms`,
+                'total',
+              )
+            : new BoundedReadStall(`body sent nothing for ${idleTimeoutMs} ms`, 'idle'),
+        ),
+      );
+    }, budget);
+    signal?.addEventListener('abort', onAbort, { once: true });
+    reader.read().then(
+      (result) => settle(() => resolve(result)),
+      (err) => settle(() => reject(err)),
+    );
+  });
+}
+
+/** Internal marker for a body that stopped arriving; translated per caller. */
+class BoundedReadStall extends Error {
+  readonly kind: 'idle' | 'total';
+  constructor(message: string, kind: 'idle' | 'total') {
+    super(message);
+    this.name = 'BoundedReadStall';
+    this.kind = kind;
+  }
+}
+
+/**
+ * The body length the response declares, or `null` when it declares nothing
+ * usable.
+ *
+ * `Content-Length` is only trustworthy as an upper bound when the body is not
+ * re-encoded in transit: with `Content-Encoding: gzip` the header counts
+ * compressed bytes while `arrayBuffer()` yields decompressed ones, so a
+ * perfectly honest server would look like it under-reported. We therefore
+ * return `null` for any non-identity encoding rather than reason about a
+ * number that doesn't describe what we're about to receive.
+ */
+function declaredBodyLength(response: Response): number | null {
+  const encoding = response.headers.get('content-encoding');
+  if (encoding !== null && encoding.trim().toLowerCase() !== 'identity') return null;
+  const raw = response.headers.get('content-length');
+  if (raw === null) return null;
+  const n = Number(raw.trim());
+  if (!Number.isSafeInteger(n) || n < 0) return null;
+  return n;
+}
+
+/** Cancel a body reader without letting the cancellation mask the real error. */
+async function cancelQuietly(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<void> {
+  try {
+    await reader.cancel();
+  } catch {
+    // A body that is already errored or closed rejects `cancel()`. We are on
+    // an error path either way; the original failure is the one worth raising.
+  }
+}
+
+/**
+ * Tear down a body we have decided not to read at all.
+ *
+ * The declared-length refusals below happen before a single chunk is
+ * consumed, and an un-cancelled body holds the connection open until the
+ * whole transfer arrives — which is precisely the transfer we just refused.
+ */
+async function discardBody(response: Response): Promise<void> {
+  const body = response.body as ReadableStream<Uint8Array> | null | undefined;
+  if (!body || typeof body.cancel !== 'function') return;
+  try {
+    await body.cancel();
+  } catch {
+    // Already consumed, errored, or locked. Nothing left to release.
+  }
+}
+
+/** Resolve the timing options once and start the whole-body clock. */
+function startClock(options: BoundedReadOptions): {
+  idleTimeoutMs: number;
+  totalTimeoutMs: number;
+  msLeftOfTotal: () => number;
+} {
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+  const totalTimeoutMs = options.totalTimeoutMs ?? DEFAULT_TOTAL_TIMEOUT_MS;
+  const startedAt = Date.now();
+  return {
+    idleTimeoutMs,
+    totalTimeoutMs,
+    msLeftOfTotal: () => totalTimeoutMs - (Date.now() - startedAt),
+  };
+}
+
+/** True when the response exposes a real streaming body we can read in chunks. */
+function streamableBody(
+  response: Response,
+): ReadableStream<Uint8Array> | null {
+  const body = response.body as ReadableStream<Uint8Array> | null | undefined;
+  if (!body || typeof body.getReader !== 'function') return null;
+  return body;
+}
+
+/**
+ * Read exactly `expectedBytes` from a response body, refusing anything longer
+ * or shorter.
+ *
+ * This is the range-read shape: the caller asked for a precise span and the
+ * only acceptable answer is that span. Overflow is detected on the chunk that
+ * crosses the line — the read stops there and cancels — so a hostile or broken
+ * server cannot force an allocation beyond one chunk past the ceiling. Short
+ * bodies are rejected too: a truncated range silently decoded is exactly the
+ * "wrong number rather than a crash" failure the threat model puts first.
+ */
+export async function readExactlyBounded(
+  response: Response,
+  expectedBytes: number,
+  options: BoundedReadOptions = {},
+): Promise<ArrayBuffer> {
+  if (!Number.isSafeInteger(expectedBytes) || expectedBytes < 0) {
+    throw new RangeReadError(
+      'out-of-range',
+      `Refusing to read a body of ${expectedBytes} bytes — not a valid length.`,
+    );
+  }
+  const declared = declaredBodyLength(response);
+  if (declared !== null && declared > expectedBytes) {
+    // Refuse before reading a single byte. This is the whole point of the
+    // helper: the server has already told us it intends to send too much.
+    await discardBody(response);
+    throw new RangeReadError(
+      'content-mismatch',
+      `Server declared a ${declared}-byte body for a ${expectedBytes}-byte request.`,
+    );
+  }
+  const body = streamableBody(response);
+  if (body === null) {
+    // No streaming body available (older runtime, or a test stand-in). The
+    // `Content-Length` refusal above is the only pre-read guard we get here.
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength !== expectedBytes) {
+      throw new RangeReadError(
+        'content-mismatch',
+        `Server returned ${buffer.byteLength} bytes for a ${expectedBytes}-byte request.`,
+      );
+    }
+    return buffer;
+  }
+  const out = new Uint8Array(expectedBytes);
+  let filled = 0;
+  const reader = body.getReader();
+  const clock = startClock(options);
+  try {
+    for (;;) {
+      const { done, value } = await readChunkRacing(
+        reader,
+        options.signal,
+        options.timeoutSignal,
+        clock.idleTimeoutMs,
+        clock.totalTimeoutMs,
+        clock.msLeftOfTotal,
+      );
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      if (filled + value.byteLength > expectedBytes) {
+        throw new RangeReadError(
+          'content-mismatch',
+          `Server returned more than the requested ${expectedBytes} bytes.`,
+        );
+      }
+      out.set(value, filled);
+      filled += value.byteLength;
+    }
+  } catch (err) {
+    await cancelQuietly(reader);
+    if (err instanceof BoundedReadStall) {
+      throw new RangeReadError(
+        'timeout',
+        `Range read stalled — ${err.message}. The server sent headers but stopped sending data.`,
+      );
+    }
+    throw err;
+  }
+  if (filled !== expectedBytes) {
+    throw new RangeReadError(
+      'content-mismatch',
+      `Server returned ${filled} bytes for a ${expectedBytes}-byte request.`,
+    );
+  }
+  return out.buffer;
+}
+
+/**
+ * Read a body of unknown length, refusing anything above `maxBytes`.
+ *
+ * This is the manifest / hierarchy / tile shape: we don't know the size in
+ * advance, only that a legitimate one is far below the ceiling. Everything
+ * else matches {@link readExactlyBounded} — declared-length refusal first,
+ * then a streaming read that stops and cancels on the chunk that crosses the
+ * limit.
+ */
+export async function readAtMostBounded(
+  response: Response,
+  maxBytes: number,
+  what: string,
+  options: BoundedReadOptions = {},
+): Promise<Uint8Array> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    throw new BoundedReadError(
+      what,
+      maxBytes,
+      `Refusing to read ${what} with a ${maxBytes}-byte ceiling — not a valid limit.`,
+    );
+  }
+  const declared = declaredBodyLength(response);
+  if (declared !== null && declared > maxBytes) {
+    await discardBody(response);
+    throw new BoundedReadError(
+      what,
+      maxBytes,
+      `${what} declares ${declared} bytes, above the ${maxBytes}-byte limit.`,
+    );
+  }
+  const body = streamableBody(response);
+  if (body === null) {
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > maxBytes) {
+      throw new BoundedReadError(
+        what,
+        maxBytes,
+        `${what} is ${buffer.byteLength} bytes, above the ${maxBytes}-byte limit.`,
+      );
+    }
+    return new Uint8Array(buffer);
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const reader = body.getReader();
+  const clock = startClock(options);
+  try {
+    for (;;) {
+      const { done, value } = await readChunkRacing(
+        reader,
+        options.signal,
+        options.timeoutSignal,
+        clock.idleTimeoutMs,
+        clock.totalTimeoutMs,
+        clock.msLeftOfTotal,
+      );
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      if (total + value.byteLength > maxBytes) {
+        throw new BoundedReadError(
+          what,
+          maxBytes,
+          `${what} exceeds the ${maxBytes}-byte limit — refusing to read further.`,
+        );
+      }
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  } catch (err) {
+    await cancelQuietly(reader);
+    if (err instanceof BoundedReadStall) {
+      throw new BoundedReadError(
+        what,
+        maxBytes,
+        `${what} stalled — ${err.message}. The server sent headers but stopped sending data.`,
+        'stalled',
+      );
+    }
+    throw err;
+  }
+  if (chunks.length === 1) return chunks[0];
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, at);
+    at += chunk.byteLength;
+  }
+  return out;
+}
+
+/** {@link readAtMostBounded}, decoded as UTF-8. For JSON documents. */
+export async function readTextAtMost(
+  response: Response,
+  maxBytes: number,
+  what: string,
+  options: BoundedReadOptions = {},
+): Promise<string> {
+  const bytes = await readAtMostBounded(response, maxBytes, what, options);
+  return new TextDecoder('utf-8').decode(bytes);
+}

--- a/tests/boundedRead.test.ts
+++ b/tests/boundedRead.test.ts
@@ -40,7 +40,9 @@ function streamingResponse(
 
 /** A Response with no streaming body — exercises the arrayBuffer fallback. */
 function bufferResponse(bytes: Uint8Array, headers: Record<string, string> = {}): Response {
-  const r = new Response(bytes, { headers });
+  // `bytes.slice().buffer` is a fresh, exactly-sized ArrayBuffer — a BodyInit
+  // the Response type accepts, where a bare Uint8Array view is not.
+  const r = new Response(bytes.slice().buffer, { headers });
   Object.defineProperty(r, 'body', { value: null });
   return r;
 }

--- a/tests/boundedRead.test.ts
+++ b/tests/boundedRead.test.ts
@@ -1,0 +1,138 @@
+/**
+ * boundedRead.test.ts
+ *
+ * The bounded body readers invert read-then-validate into validate-then-read:
+ * a declared length above the ceiling is refused before a byte is consumed, a
+ * streamed body that crosses the ceiling stops and cancels on the offending
+ * chunk, a short body is rejected, and a body that goes silent is bounded by an
+ * idle clock rather than hanging. These tests pin each of those, plus the
+ * arrayBuffer fallback for runtimes without a streaming body.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  readExactlyBounded,
+  readAtMostBounded,
+  readTextAtMost,
+  BoundedReadError,
+} from '../src/io/range/boundedRead';
+import { RangeReadError } from '../src/io/range/RangeSource';
+
+/** A Response whose body streams the given chunks, with optional per-chunk gaps. */
+function streamingResponse(
+  chunks: Uint8Array[],
+  headers: Record<string, string> = {},
+  gapMs = 0,
+): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const next = chunks.shift();
+      if (next === undefined) {
+        controller.close();
+        return;
+      }
+      if (gapMs > 0) await new Promise((r) => setTimeout(r, gapMs));
+      controller.enqueue(next);
+    },
+  });
+  return new Response(stream, { headers });
+}
+
+/** A Response with no streaming body — exercises the arrayBuffer fallback. */
+function bufferResponse(bytes: Uint8Array, headers: Record<string, string> = {}): Response {
+  const r = new Response(bytes, { headers });
+  Object.defineProperty(r, 'body', { value: null });
+  return r;
+}
+
+const bytes = (n: number, fill = 1): Uint8Array => new Uint8Array(n).fill(fill);
+
+describe('readExactlyBounded', () => {
+  it('returns the buffer when the streamed body is exactly the requested size', async () => {
+    const out = await readExactlyBounded(streamingResponse([bytes(4), bytes(4)]), 8);
+    expect(out.byteLength).toBe(8);
+  });
+
+  it('refuses before reading when Content-Length declares more than requested', async () => {
+    const resp = streamingResponse([bytes(8)], { 'content-length': '999999' });
+    await expect(readExactlyBounded(resp, 8)).rejects.toMatchObject({
+      name: 'RangeReadError',
+      code: 'content-mismatch',
+    });
+  });
+
+  it('stops and rejects on the chunk that overflows the ceiling', async () => {
+    // No Content-Length, so the overflow is caught mid-stream, not up front.
+    const resp = streamingResponse([bytes(4), bytes(4), bytes(4)]);
+    await expect(readExactlyBounded(resp, 8)).rejects.toMatchObject({ code: 'content-mismatch' });
+  });
+
+  it('rejects a body shorter than requested', async () => {
+    await expect(readExactlyBounded(streamingResponse([bytes(4)]), 8)).rejects.toMatchObject({
+      code: 'content-mismatch',
+    });
+  });
+
+  it('rejects a negative/invalid expected length', async () => {
+    await expect(readExactlyBounded(streamingResponse([]), -1)).rejects.toBeInstanceOf(RangeReadError);
+  });
+
+  it('ignores Content-Length under a non-identity encoding (compressed length lies)', async () => {
+    // gzip: declared length counts compressed bytes, so it must NOT gate the read.
+    const resp = streamingResponse([bytes(8)], {
+      'content-length': '3',
+      'content-encoding': 'gzip',
+    });
+    const out = await readExactlyBounded(resp, 8);
+    expect(out.byteLength).toBe(8);
+  });
+
+  it('bounds a silent body with the idle clock instead of hanging', async () => {
+    // A body that never enqueues: the idle timer must fire.
+    const never = new Response(new ReadableStream<Uint8Array>({ pull() { /* never enqueues */ } }));
+    await expect(
+      readExactlyBounded(never, 8, { idleTimeoutMs: 30, totalTimeoutMs: 1000 }),
+    ).rejects.toMatchObject({ code: 'timeout' });
+  });
+
+  it('falls back to arrayBuffer when there is no streaming body, still checking exact length', async () => {
+    await expect(readExactlyBounded(bufferResponse(bytes(4)), 8)).rejects.toMatchObject({
+      code: 'content-mismatch',
+    });
+    const ok = await readExactlyBounded(bufferResponse(bytes(8)), 8);
+    expect(ok.byteLength).toBe(8);
+  });
+});
+
+describe('readAtMostBounded', () => {
+  it('returns a body under the ceiling', async () => {
+    const out = await readAtMostBounded(streamingResponse([bytes(10)]), 100, 'EPT manifest');
+    expect(out.byteLength).toBe(10);
+  });
+
+  it('refuses before reading when the declared length exceeds the ceiling', async () => {
+    const resp = streamingResponse([bytes(10)], { 'content-length': '10000' });
+    await expect(readAtMostBounded(resp, 100, 'EPT manifest')).rejects.toBeInstanceOf(BoundedReadError);
+  });
+
+  it('stops and rejects on the streamed chunk that crosses the ceiling', async () => {
+    const resp = streamingResponse([bytes(60), bytes(60)]);
+    await expect(readAtMostBounded(resp, 100, 'EPT tile')).rejects.toMatchObject({
+      name: 'BoundedReadError',
+      limitBytes: 100,
+      what: 'EPT tile',
+    });
+  });
+
+  it('rejects an invalid ceiling', async () => {
+    await expect(readAtMostBounded(streamingResponse([]), 0, 'x')).rejects.toBeInstanceOf(BoundedReadError);
+  });
+});
+
+describe('readTextAtMost', () => {
+  it('decodes a bounded body as UTF-8', async () => {
+    const payload = new TextEncoder().encode('{"ept":"json"}');
+    const out = await readTextAtMost(streamingResponse([payload]), 1000, 'EPT manifest');
+    expect(out).toBe('{"ept":"json"}');
+  });
+});


### PR DESCRIPTION
Second security slice of the deferred #309 (after #341's URL-scrub). Rebuilt on fresh main — the #309 branch is ~14k lines stale, but `boundedRead.ts` is a pure, self-contained module (depends only on `RangeReadError`), so it ports faithfully.

## The hole
Every remote range read was **read-then-validate**: `response.arrayBuffer()` materialised the whole body before anyone checked its length. A host answering a small range request with a huge body wins that exchange — the tab dies before the length check runs. The `bytes=0-0` size probe was worse: it `void`-discarded the promise and read an **unbounded** body into a buffer nobody looks at.

## The fix
`boundedRead.ts` inverts the order:
- refuses a declared `Content-Length` above the request **before reading a byte** (and ignores it under a non-identity `Content-Encoding`, where the compressed length would lie);
- streams the body through a reader and **stops + cancels on the chunk that would cross the ceiling** — never more than one chunk past the limit is allocated;
- races an **idle clock** (silence between chunks) and a **whole-body clock** (the trickle) so a host that sends headers then stalls can't hang the read;
- rejects a **short** body too (a truncated range silently decoded is the "wrong number rather than a crash" failure the threat model puts first);
- falls back to `arrayBuffer()` + the same exact-length check on runtimes without a streaming body.

`HttpRangeSource` routes both 206 success paths through `readExactlyBounded(response, expected, { signal })` (exact size known from the range, so no ceiling-guessing) and **cancels** the probe body instead of draining it.

## Scope
This bounds the **COPC / HTTP range** path, where the expected size is exact and unambiguous. The EPT-transport `readAtMost` bounding (which needs per-resource ceilings) and #309 Goal 2 (ETag/Last-Modified object-identity pinning) remain as focused follow-ups.

## Gates
tsc clean; new `boundedRead.test.ts` 13/13 (exact/at-most/text, declared-length refusal, streamed-overflow, short-body, idle-stall, arrayBuffer fallback); full suite 8644 passed; arch-truth / main-deferral / monolith / layer-boundaries green. No monolith growth.