### PR TITLE
Pin remote object identity across a range-read load (#309 Goal 2)

### DIFF
--- a/src/app/remoteSourceNaming.ts
+++ b/src/app/remoteSourceNaming.ts
@@ -77,6 +77,10 @@ export function describeRemoteCopcError(err: unknown, url: string): string {
     if (err.code === 'server-error') {
       return `${err.message} The host returned a server-side error — wait a moment and try again.`;
     }
+    if (err.code === 'resource-changed') {
+      // The message already says what happened and what to do; nothing to add.
+      return err.message;
+    }
     return err.message;
   }
   const detail = err instanceof Error ? err.message : 'unknown error';

--- a/src/io/range/HttpRangeSource.ts
+++ b/src/io/range/HttpRangeSource.ts
@@ -13,9 +13,16 @@
  * backoff retries on transient transport failures (retry-with-backoff), (b) hard
  * per-attempt request timeouts (per-attempt timeout), (c) `Content-Range` validation on
  * 206 responses (Content-Range validation), (d) a `Range: bytes=0-0` GET fallback when HEAD
- * is unusable (ranged-GET fallback). The new behaviour is fully dependency-injected for
+ * is unusable (ranged-GET fallback), and (e) OBJECT-IDENTITY PINNING: a load is
+ * dozens of range reads over seconds to minutes, so a file re-uploaded partway
+ * through would splice two versions into one decode. The object's validators
+ * (ETag / Last-Modified) and total size are pinned at probe time; every read
+ * sends `If-Match` when a strong ETag is held and is re-checked against the pin,
+ * failing with the non-retryable `resource-changed` code on any mismatch or a
+ * `412`. `If-Match` downgrades once if it trips a CORS preflight, keeping the
+ * client-side check. The new behaviour is fully dependency-injected for
  * deterministic tests — pass a fake `fetchImpl`, `now`, and `random` and
- * exercise the retry / timeout / mismatch paths exactly.
+ * exercise the retry / timeout / mismatch / identity paths exactly.
  *
  * Pure of three.js; uses `fetch`, which is available on both the main thread
  * and in workers.
@@ -32,6 +39,12 @@ const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_RETRY_BASE_MS = 250;
 /** HTTP statuses we DO retry on (transient transport faults). */
 const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+/** The server's answer to our `If-Match`: the object is no longer the one we pinned. */
+const PRECONDITION_FAILED = 412;
+/** Shown when a mid-load object change is detected. Not retryable — the bytes
+ *  already decoded belong to a version that no longer exists. */
+const RESOURCE_CHANGED_MESSAGE =
+  'The file on the server changed while it was loading. Reload to read the current version.';
 
 /** Tunables for {@link HttpRangeSource}. Defaulted, injected for unit tests. */
 export interface HttpRangeSourceOptions {
@@ -62,6 +75,33 @@ export class HttpRangeSource implements RangeSource {
   private readonly _random: () => number;
   private readonly _sleep: (ms: number) => Promise<void>;
   private _size: number | undefined;
+  // ── Object identity, pinned at probe time (a COPC/EPT load is dozens of
+  // range reads over seconds to minutes; a file re-uploaded partway through
+  // splices two versions into one decode, which is silent where a crash is
+  // not). Pin the object's validators once and re-check every response. ──
+  /** The `ETag` pinned at probe time, verbatim (quotes and any `W/` kept). */
+  private _etag: string | null = null;
+  /**
+   * Whether {@link _etag} is a STRONG validator. `If-Match` is defined for
+   * strong comparison, so a weak `W/"…"` tag must not be sent as a
+   * precondition; it is still kept to compare against what comes back.
+   */
+  private _etagIsStrong = false;
+  /** The `Last-Modified` pinned at probe time — the weaker fallback validator. */
+  private _lastModified: string | null = null;
+  /**
+   * Send `If-Match` on range reads. Starts on when a strong ETag is held and
+   * downgrades at most once: `If-Match` is not a CORS-safelisted request
+   * header, so a bucket whose CORS lists `Range` explicitly (not `*`) fails
+   * the preflight for it and the browser reports an opaque transport error.
+   * Refusing such a dataset would trade a rare correctness hazard for a common
+   * outage, so the first conditional read that dies at the transport layer
+   * before any conditional read has succeeded drops to unconditional reads —
+   * every response is still checked against the pinned validators.
+   */
+  private _useConditionalRead = true;
+  /** True once a conditional read has actually reached a response. */
+  private _conditionalReadProven = false;
 
   constructor(url: string, options: HttpRangeSourceOptions = {}) {
     this._url = url;
@@ -112,6 +152,9 @@ export class HttpRangeSource implements RangeSource {
           `Server returned ${head.status} for ${sanitizeUrlForDisplay(this._url)}`,
         );
       }
+      // Pin the object's validators from the first successful response; every
+      // later read is checked against them.
+      this._pinIdentity(head);
       const acceptRanges = head.headers.get('accept-ranges');
       if (acceptRanges === 'none') {
         // Server explicitly declares it doesn't support ranges.
@@ -179,10 +222,14 @@ export class HttpRangeSource implements RangeSource {
     if (clamped === 0) return new ArrayBuffer(0);
 
     const end = offset + clamped - 1;
-    const response = await this._fetchWithRetryAndTimeout(
-      { headers: { Range: `bytes=${offset}-${end}` } },
-      signal,
-    );
+    const response = await this._fetchRangeWithIdentity(offset, end, signal);
+    // The server evaluated our `If-Match` and says the object is no longer the
+    // one we pinned. Distinct from every transport code: the read cannot be
+    // retried into correctness, because the bytes already decoded belong to a
+    // version that no longer exists.
+    if (response.status === PRECONDITION_FAILED) {
+      throw new RangeReadError('resource-changed', RESOURCE_CHANGED_MESSAGE);
+    }
     // 206 Partial Content is the expected success. A 200 means the server
     // ignored the Range header and is sending the whole file — that defeats
     // streaming, so it is treated as range-unsupported rather than accepted.
@@ -209,6 +256,9 @@ export class HttpRangeSource implements RangeSource {
     const contentRange = response.headers.get('content-range');
     const expected = end - offset + 1;
     if (contentRange === null) {
+      // No Content-Range to read a total from, so identity rests on the
+      // validators (ETag / Last-Modified) alone here.
+      this._assertSameObject(response, null);
       const body = await response.arrayBuffer();
       if (body.byteLength !== expected) {
         throw new RangeReadError(
@@ -224,6 +274,10 @@ export class HttpRangeSource implements RangeSource {
         `Server returned a 206 with mismatched Content-Range "${contentRange}" for ${offset}-${end}.`,
       );
     }
+    // The Content-Range total is the object's size on this response; a
+    // re-uploaded file of a different size is caught here even if it kept its
+    // validators or the server exposes none.
+    this._assertSameObject(response, parseContentRangeTotal(contentRange));
     return response.arrayBuffer();
   }
 
@@ -256,6 +310,9 @@ export class HttpRangeSource implements RangeSource {
         `Probe returned an unexpected status ${response.status}`,
       );
     }
+    // Pin the object's validators when HEAD was skipped and this ranged GET is
+    // the first successful response.
+    this._pinIdentity(response);
     // Drain the one-byte body so the connection can be reused. Skipping
     // this can leave the response in a half-read state on some runtimes.
     void response.arrayBuffer().catch(() => undefined);
@@ -277,6 +334,85 @@ export class HttpRangeSource implements RangeSource {
       'The server confirmed range support but didn\'t expose the file size. ' +
         'If you control the bucket, add Content-Length and Content-Range to its CORS ExposeHeaders.',
     );
+  }
+
+  /**
+   * Record the object's validators from the first response that carries them.
+   * Later responses are CHECKED against these, never allowed to overwrite them
+   * — a pin that follows the server around is not a pin.
+   */
+  private _pinIdentity(response: Response): void {
+    if (this._etag === null) {
+      const etag = response.headers.get('etag');
+      if (etag !== null && etag.trim() !== '') {
+        this._etag = etag.trim();
+        this._etagIsStrong = !/^W\//i.test(this._etag);
+      }
+    }
+    if (this._lastModified === null) {
+      const lastModified = response.headers.get('last-modified');
+      if (lastModified !== null && lastModified.trim() !== '') {
+        this._lastModified = lastModified.trim();
+      }
+    }
+  }
+
+  /**
+   * Fail the read if this response describes a different object than the one
+   * pinned at probe time. Each check is skipped when either side is absent —
+   * the graceful degradation for a host that stops exposing a validator — so a
+   * present-but-changed signal is what fires, never a missing one.
+   */
+  private _assertSameObject(response: Response, total: number | null): void {
+    const etag = response.headers.get('etag')?.trim();
+    if (this._etag !== null && etag !== undefined && etag !== '' && etag !== this._etag) {
+      throw new RangeReadError('resource-changed', RESOURCE_CHANGED_MESSAGE);
+    }
+    const lastModified = response.headers.get('last-modified')?.trim();
+    if (this._lastModified !== null && lastModified !== undefined && lastModified !== '' && lastModified !== this._lastModified) {
+      throw new RangeReadError('resource-changed', RESOURCE_CHANGED_MESSAGE);
+    }
+    // The total from Content-Range is the identity signal every compliant range
+    // server sends, exposed cross-origin with no extra CORS header beyond the
+    // Content-Range already read. A re-uploaded object of a different size is
+    // caught here even when it kept its ETag.
+    if (total !== null && this._size !== undefined && total !== this._size) {
+      throw new RangeReadError('resource-changed', RESOURCE_CHANGED_MESSAGE);
+    }
+  }
+
+  /**
+   * Issue the range request, sending `If-Match` when a strong ETag is pinned,
+   * and downgrading to unconditional reads once if that trips a CORS preflight
+   * — see {@link _useConditionalRead}. Either way the response is still checked
+   * against the pinned validators by {@link _assertSameObject}.
+   */
+  private async _fetchRangeWithIdentity(
+    offset: number,
+    end: number,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    const conditional =
+      this._useConditionalRead && this._etag !== null && this._etagIsStrong;
+    const headers: Record<string, string> = { Range: `bytes=${offset}-${end}` };
+    if (conditional) headers['If-Match'] = this._etag as string;
+    try {
+      const response = await this._fetchWithRetryAndTimeout({ headers }, signal);
+      if (conditional) this._conditionalReadProven = true;
+      return response;
+    } catch (err) {
+      const preflightSuspect =
+        conditional &&
+        !this._conditionalReadProven &&
+        err instanceof RangeReadError &&
+        err.code === 'transport';
+      if (!preflightSuspect) throw err;
+      this._useConditionalRead = false;
+      return this._fetchWithRetryAndTimeout(
+        { headers: { Range: `bytes=${offset}-${end}` } },
+        signal,
+      );
+    }
   }
 
   /**

--- a/src/io/range/RangeSource.ts
+++ b/src/io/range/RangeSource.ts
@@ -49,6 +49,12 @@ export type RangeReadErrorCode =
   | 'range-unsupported'
   | 'timeout'
   | 'content-mismatch'
+  // The remote object changed under a load in progress: a later response
+  // carries a different validator (ETag / Last-Modified) or total size than the
+  // one pinned at probe time, or the server failed our `If-Match`. Distinct
+  // from a transport fault because the read cannot be retried into correctness
+  // — the bytes already decoded belong to a version that no longer exists.
+  | 'resource-changed'
   | 'server-error';
 
 /** A typed range-read failure. */

--- a/tests/remoteObjectIdentity.test.ts
+++ b/tests/remoteObjectIdentity.test.ts
@@ -1,0 +1,152 @@
+/**
+ * remoteObjectIdentity.test.ts
+ *
+ * A COPC/EPT load is dozens of range reads over seconds to minutes. If the
+ * object is re-uploaded partway through, the reads before and after splice two
+ * versions into one decode — silent where a crash is not. HttpRangeSource pins
+ * the object's validators (ETag / Last-Modified / total size) at probe time and
+ * re-checks every read: a changed validator, a changed total, or a 412 from our
+ * `If-Match` fails the read with the non-retryable `resource-changed` code.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { HttpRangeSource } from '../src/io/range/HttpRangeSource';
+import { RangeReadError } from '../src/io/range/RangeSource';
+
+const opts = { maxRetries: 0, sleep: async () => {} } as const;
+const URL = 'https://example.com/a.copc.laz';
+
+/** A HEAD response advertising range support, a size, and the given validators. */
+function head(headers: Record<string, string>): Response {
+  return new Response(null, {
+    status: 200,
+    headers: { 'accept-ranges': 'bytes', 'content-length': '1000', ...headers },
+  });
+}
+
+/** A 206 range response for [0,3] with the given headers. */
+function range206(headers: Record<string, string>): Response {
+  return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
+    status: 206,
+    headers: { 'content-range': 'bytes 0-3/1000', ...headers },
+  });
+}
+
+async function readErr(src: HttpRangeSource): Promise<RangeReadError> {
+  try {
+    await src.readRange(0, 4);
+  } catch (e) {
+    return e as RangeReadError;
+  }
+  throw new Error('expected readRange to throw');
+}
+
+describe('remote object identity pinning', () => {
+  it('reads normally when the object is unchanged', async () => {
+    const src = new HttpRangeSource(URL, {
+      ...opts,
+      fetchImpl: (async (_u: string, init?: RequestInit) =>
+        init?.method === 'HEAD'
+          ? head({ etag: '"v1"' })
+          : range206({ etag: '"v1"' })) as unknown as typeof fetch,
+    });
+    const buf = await src.readRange(0, 4);
+    expect(buf.byteLength).toBe(4);
+  });
+
+  it('fails with resource-changed when the ETag changes mid-load', async () => {
+    const src = new HttpRangeSource(URL, {
+      ...opts,
+      fetchImpl: (async (_u: string, init?: RequestInit) =>
+        init?.method === 'HEAD'
+          ? head({ etag: 'W/"v1"' }) // weak, so no If-Match; client-side check still runs
+          : range206({ etag: 'W/"v2"' })) as unknown as typeof fetch,
+    });
+    expect((await readErr(src)).code).toBe('resource-changed');
+  });
+
+  it('fails with resource-changed when the Content-Range total changes', async () => {
+    const src = new HttpRangeSource(URL, {
+      ...opts,
+      fetchImpl: (async (_u: string, init?: RequestInit) =>
+        init?.method === 'HEAD'
+          ? head({}) // size 1000 pinned from content-length
+          : new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
+              status: 206,
+              headers: { 'content-range': 'bytes 0-3/2048' }, // re-uploaded, bigger
+            })) as unknown as typeof fetch,
+    });
+    expect((await readErr(src)).code).toBe('resource-changed');
+  });
+
+  it('fails with resource-changed when the Last-Modified changes (no ETag)', async () => {
+    const src = new HttpRangeSource(URL, {
+      ...opts,
+      fetchImpl: (async (_u: string, init?: RequestInit) =>
+        init?.method === 'HEAD'
+          ? head({ 'last-modified': 'Wed, 01 Jan 2025 00:00:00 GMT' })
+          : range206({ 'last-modified': 'Thu, 02 Jan 2025 00:00:00 GMT' })) as unknown as typeof fetch,
+    });
+    expect((await readErr(src)).code).toBe('resource-changed');
+  });
+
+  it('fails with resource-changed on a 412 Precondition Failed', async () => {
+    const src = new HttpRangeSource(URL, {
+      ...opts,
+      fetchImpl: (async (_u: string, init?: RequestInit) =>
+        init?.method === 'HEAD'
+          ? head({ etag: '"v1"' })
+          : new Response(null, { status: 412 })) as unknown as typeof fetch,
+    });
+    expect((await readErr(src)).code).toBe('resource-changed');
+  });
+
+  it('sends If-Match with a strong ETag and reads when the server accepts it', async () => {
+    let sentIfMatch: string | null = null;
+    const src = new HttpRangeSource(URL, {
+      ...opts,
+      fetchImpl: (async (_u: string, init?: RequestInit) => {
+        if (init?.method === 'HEAD') return head({ etag: '"strong-v1"' });
+        sentIfMatch = new Headers(init?.headers).get('if-match');
+        return range206({ etag: '"strong-v1"' });
+      }) as unknown as typeof fetch,
+    });
+    await src.readRange(0, 4);
+    expect(sentIfMatch).toBe('"strong-v1"');
+  });
+
+  it('does not send If-Match for a weak ETag', async () => {
+    let sentIfMatch: string | null = 'unset';
+    const src = new HttpRangeSource(URL, {
+      ...opts,
+      fetchImpl: (async (_u: string, init?: RequestInit) => {
+        if (init?.method === 'HEAD') return head({ etag: 'W/"weak-v1"' });
+        sentIfMatch = new Headers(init?.headers).get('if-match');
+        return range206({ etag: 'W/"weak-v1"' });
+      }) as unknown as typeof fetch,
+    });
+    await src.readRange(0, 4);
+    expect(sentIfMatch).toBeNull();
+  });
+
+  it('downgrades to unconditional reads when If-Match trips a transport error, then succeeds', async () => {
+    // A CORS preflight rejecting If-Match surfaces as an opaque transport
+    // error. The first conditional read downgrades once; the retry omits
+    // If-Match and succeeds, and the client-side validator check still runs.
+    const ifMatchSeen: Array<string | null> = [];
+    const src = new HttpRangeSource(URL, {
+      ...opts,
+      fetchImpl: (async (_u: string, init?: RequestInit) => {
+        if (init?.method === 'HEAD') return head({ etag: '"strong-v1"' });
+        const im = new Headers(init?.headers).get('if-match');
+        ifMatchSeen.push(im);
+        if (im !== null) throw new TypeError('Failed to fetch'); // preflight rejection
+        return range206({ etag: '"strong-v1"' });
+      }) as unknown as typeof fetch,
+    });
+    const buf = await src.readRange(0, 4);
+    expect(buf.byteLength).toBe(4);
+    expect(ifMatchSeen[0]).toBe('"strong-v1"'); // tried conditional
+    expect(ifMatchSeen[ifMatchSeen.length - 1]).toBeNull(); // then unconditional
+  });
+});


### PR DESCRIPTION
Final security slice of the deferred #309 (after #341 URL-scrub and #343 bounded reads). Rebuilt on fresh main — the #309 branch is ~14k lines stale, and its identity pinning was bundled with a `TimedResponse` refactor; this lands the identity core independently against main's read path.

## The hazard
A COPC/EPT load is dozens of range reads over seconds to minutes. If the object is re-uploaded partway through, the reads before and after **splice two versions into one decode** — silent where a crash is not. Main discarded the `Content-Range` total and never pinned validators, so a re-upload went unnoticed.

## The fix
`HttpRangeSource` pins the object's **ETag**, **Last-Modified** and **total size** at probe time (from HEAD, or the ranged-GET probe when HEAD is skipped), then re-checks every read:
- sends **`If-Match`** when a strong ETag is held (weak `W/` tags are kept for comparison but never sent as a precondition), so a `412 Precondition Failed` fails the read;
- **client-side re-check** on every 206 — a changed ETag, a changed Last-Modified, or a changed `Content-Range` total fails the read;
- all of it via a new non-retryable **`resource-changed`** code (the bytes already decoded belong to a version that no longer exists, so a retry can't help).

**Graceful degradation:** `If-Match` isn't CORS-safelisted, so a bucket that lists `Range` explicitly (not `*`) fails the preflight with an opaque transport error. The first conditional read that dies that way **downgrades once** to unconditional reads — the client-side validator check still runs. Each identity check is skipped when either side is absent, so a host that exposes no validators isn't blocked.

## Tests
`tests/remoteObjectIdentity.test.ts` (8): unchanged read; ETag / Last-Modified / total change each → resource-changed; 412 → resource-changed; If-Match sent for strong / not for weak; preflight downgrade then success.

## Gates
tsc; existing range suite 34/34; new 8/8; full suite 8639 passed; arch-truth / main-deferral / monolith / layer-boundaries green. No monolith growth. Independent of #343 (uses main's arrayBuffer read path) — whichever merges second rebases cleanly.

Completes #309.