### PR TITLE
Surface the scan-area / Site KML lane without a measurement tool

### DIFF
--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -457,7 +457,16 @@ export class ExportPanel {
    */
   private _renderProducts(): void {
     this._products.replaceChildren();
-    if (!this._cb.exportMeasurements) return;
+    // The Products section carries two independent lanes: the measurement
+    // deliverables (which need the measure surface wired) and the map outlines
+    // (the Site KML and the Scan-area polygon). The scan-area polygon is derived
+    // from the loaded cloud's footprint, so it does not depend on a measurement
+    // ever being placed — nor on the measurement export being wired. Render the
+    // section whenever EITHER lane has a host callback, so the always-available
+    // scan-area control surfaces even when no measurement tool is in play.
+    const hasMeasureLane = Boolean(this._cb.exportMeasurements);
+    const hasMapLane = Boolean(this._cb.exportKml || this._cb.exportScanFootprint);
+    if (!hasMeasureLane && !hasMapLane) return;
     // Defensive: this runs during construction, before the host's lazy viewer
     // resolves. A callback that throws (e.g. dereferencing a not-yet-ready
     // viewer) must degrade to 0, never take down panel/app init.
@@ -483,34 +492,36 @@ export class ExportPanel {
       applyOpen();
     });
 
-    const measureRow = el('div', { className: 'olv-export-product-actions' });
-    ([['geojson', 'GeoJSON'], ['csv', 'CSV']] as const).forEach(([fmt, label]) => {
-      measureRow.append(
-        this._productButton(label, count > 0, () => this._cb.exportMeasurements?.(fmt)),
+    if (hasMeasureLane) {
+      const measureRow = el('div', { className: 'olv-export-product-actions' });
+      ([['geojson', 'GeoJSON'], ['csv', 'CSV']] as const).forEach(([fmt, label]) => {
+        measureRow.append(
+          this._productButton(label, count > 0, () => this._cb.exportMeasurements?.(fmt)),
+        );
+      });
+      // Tamper-evident integrity report (JSON) — the same measurements, stamped
+      // with provenance + a verifiable content digest (catches accidental/casual
+      // edits; not a cryptographic signature). The honest deliverable.
+      if (this._cb.exportIntegrityReport) {
+        const btn = this._productButton(
+          'Integrity report',
+          count > 0,
+          () => this._cb.exportIntegrityReport?.(),
+        );
+        btn.setAttribute('data-testid', 'export-integrity-report');
+        measureRow.append(btn);
+      }
+      const measurePlural = count === 1 ? '' : 's';
+      content.append(
+        this._productGroup(
+          'Measurements',
+          measureRow,
+          count === 0
+            ? 'Place measurements, then export them as open vector formats.'
+            : `${count} measurement${measurePlural} ready to export.`,
+        ),
       );
-    });
-    // Tamper-evident integrity report (JSON) — the same measurements, stamped
-    // with provenance + a verifiable content digest (catches accidental/casual
-    // edits; not a cryptographic signature). The honest deliverable.
-    if (this._cb.exportIntegrityReport) {
-      const btn = this._productButton(
-        'Integrity report',
-        count > 0,
-        () => this._cb.exportIntegrityReport?.(),
-      );
-      btn.setAttribute('data-testid', 'export-integrity-report');
-      measureRow.append(btn);
     }
-    const measurePlural = count === 1 ? '' : 's';
-    content.append(
-      this._productGroup(
-        'Measurements',
-        measureRow,
-        count === 0
-          ? 'Place measurements, then export them as open vector formats.'
-          : `${count} measurement${measurePlural} ready to export.`,
-      ),
-    );
 
     // The map lane: everything that lands in Google Earth / QGIS as lon/lat.
     // Each entry is offered only when the host wires it, and each carries its

--- a/tests/exportPanelCrs.test.ts
+++ b/tests/exportPanelCrs.test.ts
@@ -260,5 +260,53 @@ describe('ExportPanel: Products section', () => {
   });
 });
 
+/**
+ * The scan-area polygon is derived from the loaded cloud's footprint, so it does
+ * not depend on any measurement having been placed — nor on the measurement
+ * export feature being wired at all. It is an always-available map control, so
+ * the Google Earth lane must render it even when the host wires no measurement
+ * callbacks (no `exportMeasurements`).
+ */
+describe('ExportPanel: scan-area export is independent of the measure surface', () => {
+  const noMeasure = {
+    getCloud: () => null,
+    hasFullSource: () => false,
+    isReduced: () => false,
+    getFullCloud: async () => null,
+    // Deliberately NO exportMeasurements / measurementCount.
+  };
+
+  it('offers the scan-area polygon with no measurement callbacks wired', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const panel = new ExportPanel({
+      ...noMeasure,
+      exportScanFootprint: () => { /* no-op */ },
+      scanFootprintStatus: () => ({ ready: true, reason: '' }),
+    });
+    const root = panel.element as unknown as FakeEl;
+    const btn = root.findOwnText('Scan area (KML polygon)')[0];
+    expect(btn, 'scan-area button should render without a measure surface').toBeDefined();
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('offers the site KML with no measurement callbacks wired', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const panel = new ExportPanel({
+      ...noMeasure,
+      exportKml: () => { /* no-op */ },
+      kmlStatus: () => ({ ready: true, reason: '' }),
+    });
+    const root = panel.element as unknown as FakeEl;
+    expect(root.findOwnText('Site KML')[0]).toBeDefined();
+  });
+
+  it('renders no Products section at all when nothing is wired', async () => {
+    const { ExportPanel } = await import('../src/ui/ExportPanel');
+    const panel = new ExportPanel({ ...noMeasure });
+    const root = panel.element as unknown as FakeEl;
+    expect(root.findByClass('olv-export-products-head')).toHaveLength(0);
+  });
+});
+
 // silence "unused" for the shared helper while keeping it available for edits.
 void makePanel;


### PR DESCRIPTION
The Products section only rendered when the measurement export lane was wired, so the scan-area polygon and Site KML — derived from the loaded cloud's footprint, independent of any placed measurement — stayed hidden unless a measure tool was active. Split the section into two independent lanes and render it whenever either lane has a host callback, so the map outlines are always reachable. Adds ExportPanel CRS coverage for the map lane.