### PR TITLE
Process Studio foundation: ProcessService + scan-facts + QA checks

### DIFF
--- a/src/classification/classificationEvidence.ts
+++ b/src/classification/classificationEvidence.ts
@@ -1,0 +1,88 @@
+/**
+ * classificationEvidence.ts — the per-point / per-component evidence record for
+ * a classification decision (Phase 3).
+ *
+ * Every derived class carries WHY it was assigned and how much to trust it: the
+ * class, where it came from (producer / derived / manual), a support score, the
+ * method version, greppable reason codes, and honesty flags. The support score
+ * is a bounded heuristic in [0,1] — deliberately NOT called a calibrated
+ * probability, because it is not one. Producer classes are trusted and preserved;
+ * only DERIVED points with weak support are candidates for review-isolation.
+ *
+ * Pure data model + helpers. No side effects.
+ */
+
+export type ClassSource = 'producer' | 'derived' | 'manual';
+
+export interface EvidenceFlags {
+  /** Support below the review threshold. */
+  readonly lowSupport: boolean;
+  /** Support sits within a narrow band of the decision threshold. */
+  readonly nearThreshold: boolean;
+  /** A competing class scored comparably — the assignment is contested. */
+  readonly conflicting: boolean;
+}
+
+export interface ClassificationEvidence {
+  /** ASPRS class code assigned. */
+  readonly classCode: number;
+  readonly source: ClassSource;
+  /** Bounded heuristic support in [0,1]. NOT a calibrated probability. */
+  readonly support: number;
+  /** Version of the method that produced this decision. */
+  readonly methodVersion: string;
+  /** Greppable UPPER_SNAKE reasons the class was chosen. */
+  readonly reasonCodes: readonly string[];
+  readonly flags: EvidenceFlags;
+}
+
+/** Support at or below this is treated as weak (review candidate). */
+export const LOW_SUPPORT_THRESHOLD = 0.5;
+/** Half-width of the band around a threshold that counts as "near". */
+export const NEAR_THRESHOLD_BAND = 0.1;
+
+export interface EvidenceInput {
+  readonly classCode: number;
+  readonly source: ClassSource;
+  readonly support: number;
+  readonly methodVersion: string;
+  readonly reasonCodes?: readonly string[];
+  /** The decision threshold the support was compared against, if any. */
+  readonly decisionThreshold?: number;
+  /** Best competing class support, if a competitor was evaluated. */
+  readonly runnerUpSupport?: number;
+}
+
+/** Build an evidence record, deriving the honesty flags from the inputs. */
+export function buildEvidence(input: EvidenceInput): ClassificationEvidence {
+  const support = clamp01(input.support);
+  const lowSupport = support <= LOW_SUPPORT_THRESHOLD;
+  const nearThreshold = input.decisionThreshold !== undefined
+    && Math.abs(support - clamp01(input.decisionThreshold)) <= NEAR_THRESHOLD_BAND;
+  const conflicting = input.runnerUpSupport !== undefined
+    && clamp01(input.runnerUpSupport) >= support - NEAR_THRESHOLD_BAND;
+  return {
+    classCode: input.classCode,
+    source: input.source,
+    support,
+    methodVersion: input.methodVersion,
+    reasonCodes: input.reasonCodes ?? [],
+    flags: { lowSupport, nearThreshold, conflicting },
+  };
+}
+
+/**
+ * Whether a point should be isolated for review. Only DERIVED points qualify —
+ * producer and manual classes are trusted and preserved. A derived point is a
+ * review candidate when its support is weak, it sits near the threshold, or a
+ * competing class scored comparably.
+ */
+export function isReviewUncertain(e: ClassificationEvidence): boolean {
+  if (e.source !== 'derived') return false;
+  return e.flags.lowSupport || e.flags.nearThreshold || e.flags.conflicting;
+}
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 0;
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}

--- a/src/classification/geometryDescriptors.ts
+++ b/src/classification/geometryDescriptors.ts
@@ -1,0 +1,89 @@
+/**
+ * geometryDescriptors.ts — multi-scale geometric descriptors from a point
+ * neighbourhood's covariance eigenvalues.
+ *
+ * For a neighbourhood, form the 3×3 covariance of the mean-centred points, take
+ * its eigenvalues l0 ≥ l1 ≥ l2 (normalised so e_i = l_i / Σl), and derive the
+ * standard shape features: linearity, planarity, sphericity (scattering),
+ * omnivariance, anisotropy, eigenentropy, surface variation (curvature), and
+ * verticality (from the smallest-eigenvalue eigenvector, the surface normal).
+ * These are the cues Classification 2.0 reasons over — a wire is linear, a roof
+ * is planar-and-horizontal, a wall is planar-and-vertical, foliage is scattered.
+ *
+ * Pure and deterministic. Descriptors are DERIVED, never a class label — the
+ * classifier decides; this only measures shape. Returns null for a neighbourhood
+ * too small to have a shape (< 3 points).
+ */
+
+import { symEig3, type SymEig3 } from '../math/symEig3';
+
+export interface GeoDescriptors {
+  readonly linearity: number;
+  readonly planarity: number;
+  readonly sphericity: number;
+  readonly omnivariance: number;
+  readonly anisotropy: number;
+  readonly eigenentropy: number;
+  /** l2 / (l0+l1+l2) — low on a clean surface, high on rough/scattered points. */
+  readonly surfaceVariation: number;
+  /** 1 − |n·ẑ|: ~0 for a horizontal surface (normal up), ~1 for a vertical one. */
+  readonly verticality: number;
+  readonly neighborCount: number;
+}
+
+/** Mean-centred covariance eigen-decomposition of a neighbourhood, or null. */
+export function covarianceEigen(
+  positions: Float32Array | ReadonlyArray<number>,
+  ids: ReadonlyArray<number>,
+): SymEig3 | null {
+  const n = ids.length;
+  if (n < 3) return null;
+  let mx = 0, my = 0, mz = 0;
+  for (const i of ids) { mx += positions[i * 3]; my += positions[i * 3 + 1]; mz += positions[i * 3 + 2]; }
+  mx /= n; my /= n; mz /= n;
+  let cxx = 0, cxy = 0, cxz = 0, cyy = 0, cyz = 0, czz = 0;
+  for (const i of ids) {
+    const dx = positions[i * 3] - mx, dy = positions[i * 3 + 1] - my, dz = positions[i * 3 + 2] - mz;
+    cxx += dx * dx; cxy += dx * dy; cxz += dx * dz; cyy += dy * dy; cyz += dy * dz; czz += dz * dz;
+  }
+  const inv = 1 / n;
+  return symEig3(cxx * inv, cxy * inv, cxz * inv, cyy * inv, cyz * inv, czz * inv);
+}
+
+/** Derive the shape features from an eigen-decomposition. */
+export function descriptorsFromEigen(eig: SymEig3, neighborCount: number): GeoDescriptors {
+  const [l0, l1, l2] = eig.values.map((v) => Math.max(0, v)) as [number, number, number];
+  const sum = l0 + l1 + l2;
+  if (sum <= 0) {
+    return { linearity: 0, planarity: 0, sphericity: 0, omnivariance: 0, anisotropy: 0, eigenentropy: 0, surfaceVariation: 0, verticality: 0, neighborCount };
+  }
+  const e0 = l0 / sum, e1 = l1 / sum, e2 = l2 / sum;
+  const denom = e0 > 0 ? e0 : 1;
+  const ent = -(safeEntropy(e0) + safeEntropy(e1) + safeEntropy(e2));
+  // Normal = eigenvector of the SMALLEST eigenvalue (index 2, values sorted desc).
+  const nz = Math.abs(eig.vectors[2][2]);
+  return {
+    linearity: (e0 - e1) / denom,
+    planarity: (e1 - e2) / denom,
+    sphericity: e2 / denom,
+    omnivariance: Math.cbrt(e0 * e1 * e2),
+    anisotropy: (e0 - e2) / denom,
+    eigenentropy: ent,
+    surfaceVariation: e2, // e2 = l2/Σl since e's sum to 1
+    verticality: 1 - Math.min(1, nz),
+    neighborCount,
+  };
+}
+
+/** Descriptors for one neighbourhood (positions + neighbour ids), or null. */
+export function descriptorsForNeighborhood(
+  positions: Float32Array | ReadonlyArray<number>,
+  ids: ReadonlyArray<number>,
+): GeoDescriptors | null {
+  const eig = covarianceEigen(positions, ids);
+  return eig ? descriptorsFromEigen(eig, ids.length) : null;
+}
+
+function safeEntropy(e: number): number {
+  return e > 0 ? e * Math.log(e) : 0;
+}

--- a/src/classification/spatialHash3d.ts
+++ b/src/classification/spatialHash3d.ts
@@ -1,0 +1,71 @@
+/**
+ * spatialHash3d.ts — a uniform-grid spatial hash for radius neighbourhood
+ * queries over a point cloud.
+ *
+ * Bins points into cubic cells of a chosen side length; a radius query then
+ * visits only the 3×3×3 block of cells around the query point instead of the
+ * whole cloud. Built once, queried many times — the neighbourhood primitive the
+ * multi-scale geometry descriptors (and, later, registration) share. Pure and
+ * deterministic: identical points in, identical bins out, no RNG. Worker-safe.
+ */
+
+export class SpatialHash3d {
+  private readonly _inv: number;
+  private readonly _bins = new Map<string, number[]>();
+  private readonly _x: Float32Array | ReadonlyArray<number>;
+  private readonly _y: Float32Array | ReadonlyArray<number>;
+  private readonly _z: Float32Array | ReadonlyArray<number>;
+
+  /**
+   * @param positions Interleaved xyz (length 3N).
+   * @param cellSize  Cube side length. Should be ≥ the largest query radius for
+   *                  the 3×3×3 block to cover the full sphere; must be > 0.
+   */
+  constructor(positions: Float32Array | ReadonlyArray<number>, cellSize: number) {
+    if (!(cellSize > 0)) throw new Error(`SpatialHash3d: cellSize must be > 0, got ${cellSize}`);
+    this._inv = 1 / cellSize;
+    // Store a positions view; index into it by point id.
+    this._x = positions;
+    this._y = positions;
+    this._z = positions;
+    const n = Math.floor(positions.length / 3);
+    for (let i = 0; i < n; i++) {
+      const key = this._key(positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2]);
+      const list = this._bins.get(key);
+      if (list) list.push(i);
+      else this._bins.set(key, [i]);
+    }
+  }
+
+  private _key(x: number, y: number, z: number): string {
+    return `${Math.floor(x * this._inv)}:${Math.floor(y * this._inv)}:${Math.floor(z * this._inv)}`;
+  }
+
+  /** Point ids within `radius` of (x,y,z), including any point exactly at it. */
+  queryRadius(x: number, y: number, z: number, radius: number): number[] {
+    const r2 = radius * radius;
+    const cx = Math.floor(x * this._inv), cy = Math.floor(y * this._inv), cz = Math.floor(z * this._inv);
+    // Cells the sphere can touch (ceil so a radius > cellSize still covers).
+    const span = Math.max(1, Math.ceil(radius * this._inv));
+    const out: number[] = [];
+    for (let dx = -span; dx <= span; dx++) {
+      for (let dy = -span; dy <= span; dy++) {
+        for (let dz = -span; dz <= span; dz++) {
+          const list = this._bins.get(`${cx + dx}:${cy + dy}:${cz + dz}`);
+          if (!list) continue;
+          for (const i of list) {
+            const px = this._x[i * 3], py = this._y[i * 3 + 1], pz = this._z[i * 3 + 2];
+            const ex = px - x, ey = py - y, ez = pz - z;
+            if (ex * ex + ey * ey + ez * ez <= r2) out.push(i);
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  /** Number of occupied cells — diagnostic. */
+  get cellCount(): number {
+    return this._bins.size;
+  }
+}

--- a/src/math/symEig3.ts
+++ b/src/math/symEig3.ts
@@ -1,0 +1,73 @@
+/**
+ * symEig3.ts — eigen-decomposition of a symmetric 3×3 matrix.
+ *
+ * Returns eigenvalues sorted DESCENDING (l0 ≥ l1 ≥ l2) with their unit
+ * eigenvectors, the form point-cloud geometry descriptors need (the smallest
+ * eigenvalue's vector is the surface normal; the ratios of the three are the
+ * shape features). Classic cyclic Jacobi rotations — robust and exact for the
+ * symmetric 3×3 case, no external solver. Pure and allocation-light.
+ */
+
+export interface SymEig3 {
+  /** Eigenvalues, sorted descending: [l0 ≥ l1 ≥ l2]. */
+  readonly values: [number, number, number];
+  /** Unit eigenvectors aligned with `values` (vectors[i] ↔ values[i]). */
+  readonly vectors: [[number, number, number], [number, number, number], [number, number, number]];
+}
+
+/**
+ * Decompose a symmetric matrix given by its upper triangle
+ * (axx, axy, axz, ayy, ayz, azz). The lower triangle is taken as the mirror.
+ */
+export function symEig3(axx: number, axy: number, axz: number, ayy: number, ayz: number, azz: number): SymEig3 {
+  // Working symmetric matrix and accumulated rotation (columns = eigenvectors).
+  const m = [
+    [axx, axy, axz],
+    [axy, ayy, ayz],
+    [axz, ayz, azz],
+  ];
+  const v = [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+  ];
+  for (let iter = 0; iter < 64; iter++) {
+    // Largest off-diagonal magnitude.
+    let p = 0, q = 1, max = Math.abs(m[0][1]);
+    if (Math.abs(m[0][2]) > max) { max = Math.abs(m[0][2]); p = 0; q = 2; }
+    if (Math.abs(m[1][2]) > max) { max = Math.abs(m[1][2]); p = 1; q = 2; }
+    if (max < 1e-14) break;
+    const phi = 0.5 * Math.atan2(2 * m[p][q], m[q][q] - m[p][p]);
+    const c = Math.cos(phi), s = Math.sin(phi);
+    for (let k = 0; k < 3; k++) {
+      const mkp = m[k][p], mkq = m[k][q];
+      m[k][p] = c * mkp - s * mkq;
+      m[k][q] = s * mkp + c * mkq;
+    }
+    for (let k = 0; k < 3; k++) {
+      const mpk = m[p][k], mqk = m[q][k];
+      m[p][k] = c * mpk - s * mqk;
+      m[q][k] = s * mpk + c * mqk;
+    }
+    for (let k = 0; k < 3; k++) {
+      const vkp = v[k][p], vkq = v[k][q];
+      v[k][p] = c * vkp - s * vkq;
+      v[k][q] = s * vkp + c * vkq;
+    }
+  }
+  // Eigenvalues on the diagonal; columns of v are eigenvectors.
+  const eig = [
+    { val: m[0][0], vec: [v[0][0], v[1][0], v[2][0]] as [number, number, number] },
+    { val: m[1][1], vec: [v[0][1], v[1][1], v[2][1]] as [number, number, number] },
+    { val: m[2][2], vec: [v[0][2], v[1][2], v[2][2]] as [number, number, number] },
+  ];
+  eig.sort((a, b) => b.val - a.val); // descending
+  const unit = (u: [number, number, number]): [number, number, number] => {
+    const n = Math.hypot(u[0], u[1], u[2]) || 1;
+    return [u[0] / n, u[1] / n, u[2] / n];
+  };
+  return {
+    values: [eig[0].val, eig[1].val, eig[2].val],
+    vectors: [unit(eig[0].vec), unit(eig[1].vec), unit(eig[2].vec)],
+  };
+}

--- a/src/process/ProcessService.ts
+++ b/src/process/ProcessService.ts
@@ -1,0 +1,71 @@
+/**
+ * ProcessService.ts — the single source of product eligibility (Phase 1).
+ *
+ * The capability maths already live in `processCapabilities.evaluateCapabilities`
+ * (pure). This is the thin, stateless surface the shell and the exporters both
+ * read, so eligibility is decided in exactly one place: no button re-derives
+ * "can I export a DTM?" on its own. It composes the fail-closed scan-facts
+ * normaliser with the evaluator and exposes per-product lookups plus a readiness
+ * roll-up. No live objects, no side effects.
+ */
+
+import type { ProcessPlan, ProductCapability, ProductId, Readiness, ScanFacts } from './ProcessPlan';
+import { evaluateCapabilities, capabilityFor } from './processCapabilities';
+import { deriveScanFacts, type RawScanSignals } from './scanFacts';
+
+export interface ProcessReadinessSummary {
+  readonly ready: number;
+  readonly review: number;
+  readonly blocked: number;
+  /** True when at least one product is ready to export as a validated artifact. */
+  readonly anyReady: boolean;
+}
+
+export class ProcessService {
+  private readonly _plan: ProcessPlan;
+
+  private constructor(plan: ProcessPlan) {
+    this._plan = plan;
+  }
+
+  /** Build from already-normalised scan facts (e.g. tests, worker payloads). */
+  static fromFacts(scans: readonly ScanFacts[], projectFrameCompatible?: boolean): ProcessService {
+    return new ProcessService(evaluateCapabilities({ scans, projectFrameCompatible }));
+  }
+
+  /** Build from loose shell signals; each is normalised fail-closed first. */
+  static fromSignals(raw: readonly RawScanSignals[], projectFrameCompatible?: boolean): ProcessService {
+    return ProcessService.fromFacts(raw.map(deriveScanFacts), projectFrameCompatible);
+  }
+
+  /** The full capability plan. */
+  get plan(): ProcessPlan {
+    return this._plan;
+  }
+
+  /** One product's capability, or undefined if the model does not carry it. */
+  capability(product: ProductId): ProductCapability | undefined {
+    return capabilityFor(this._plan, product);
+  }
+
+  /** A product's readiness, defaulting to `blocked` for an unknown product. */
+  readiness(product: ProductId): Readiness {
+    return this.capability(product)?.readiness ?? 'blocked';
+  }
+
+  /** True only when the product is `ready` — the gate an exporter should use. */
+  isReady(product: ProductId): boolean {
+    return this.readiness(product) === 'ready';
+  }
+
+  /** Count products by readiness. */
+  summary(): ProcessReadinessSummary {
+    let ready = 0, review = 0, blocked = 0;
+    for (const p of this._plan.products) {
+      if (p.readiness === 'ready') ready++;
+      else if (p.readiness === 'review') review++;
+      else blocked++;
+    }
+    return { ready, review, blocked, anyReady: ready > 0 };
+  }
+}

--- a/src/process/processStages.ts
+++ b/src/process/processStages.ts
@@ -1,0 +1,67 @@
+/**
+ * processStages.ts — the adaptive Process Studio stage model (Phase 1).
+ *
+ * The Process Studio shows only the stages that matter for the loaded data:
+ * Prepare → Classify → Surface → Align → Extract → Validate/Export. This pure
+ * function decides which stages are relevant from the capability plan and scan
+ * facts, so the shell renders the adaptive flow without re-deriving eligibility.
+ * No UI, no side effects — the shell reads this.
+ */
+
+import type { ProcessInputs } from './ProcessPlan';
+import { evaluateCapabilities, capabilityFor } from './processCapabilities';
+
+export type StageId = 'prepare' | 'classify' | 'surface' | 'align' | 'extract' | 'validate-export';
+
+export interface Stage {
+  readonly id: StageId;
+  readonly title: string;
+  readonly relevant: boolean;
+  /** One sentence on why this stage is shown or skipped. */
+  readonly reason: string;
+}
+
+/**
+ * Compute the adaptive stage list for the current inputs. Prepare and
+ * Validate/Export are always relevant (every dataset is prepared and every run
+ * ends at validation/export); the middle stages appear only when the data can
+ * actually use them.
+ */
+export function adaptiveStages(inputs: ProcessInputs): Stage[] {
+  const plan = evaluateCapabilities(inputs);
+  const scans = inputs.scans;
+  const one = scans[0];
+  const notBlocked = (p: Parameters<typeof capabilityFor>[1]): boolean =>
+    (capabilityFor(plan, p)?.readiness ?? 'blocked') !== 'blocked';
+
+  const classifyRelevant = one !== undefined && one.classification !== 'full';
+  const surfaceRelevant = notBlocked('dtm') || notBlocked('dsm') || notBlocked('contours');
+  const alignRelevant = scans.length >= 2;
+  const extractRelevant = notBlocked('building-footprints');
+
+  return [
+    { id: 'prepare', title: 'Prepare', relevant: true, reason: 'Every dataset is inspected and prepared first.' },
+    {
+      id: 'classify', title: 'Classify', relevant: classifyRelevant,
+      reason: classifyRelevant ? 'Classification is missing or partial; gaps can be classified.' : 'The cloud is already fully classified.',
+    },
+    {
+      id: 'surface', title: 'Surface', relevant: surfaceRelevant,
+      reason: surfaceRelevant ? 'A terrain surface (DTM/DSM/contours) is buildable.' : 'No terrain surface is available for this data.',
+    },
+    {
+      id: 'align', title: 'Align', relevant: alignRelevant,
+      reason: alignRelevant ? `${scans.length} scans loaded; alignment applies.` : 'A single scan needs no alignment.',
+    },
+    {
+      id: 'extract', title: 'Extract', relevant: extractRelevant,
+      reason: extractRelevant ? 'Structure extraction (e.g. building footprints) is available.' : 'No feature-extraction product is currently available.',
+    },
+    { id: 'validate-export', title: 'Validate / Export', relevant: true, reason: 'Every run ends at validation and export.' },
+  ];
+}
+
+/** Only the stages worth showing. */
+export function relevantStages(inputs: ProcessInputs): Stage[] {
+  return adaptiveStages(inputs).filter((s) => s.relevant);
+}

--- a/src/process/scanFacts.ts
+++ b/src/process/scanFacts.ts
@@ -1,0 +1,71 @@
+/**
+ * scanFacts.ts — normalise loose scan signals into the ScanFacts the capability
+ * evaluator reasons over, fail-closed.
+ *
+ * The shell assembles scan facts from several existing sources (scan report,
+ * CRS resolver, streaming coverage, classification presence), each of which may
+ * be missing or not-yet-known. This is the one place that turns those loose
+ * signals into a clean ScanFacts, and it defaults every unknown to the SAFE
+ * side: an unknown CRS is null (not assumed metre), an unknown streaming
+ * coverage is resident-only (not full), ground is trusted only when
+ * classification actually carries it. So a fact the shell failed to supply can
+ * only make the capability model MORE conservative, never falsely enable a
+ * product. Pure and worker-safe — no live objects.
+ */
+
+import type { CrsInfo } from '../io/crs';
+import type { ScanFacts, Coverage, ClassPresence } from './ProcessPlan';
+
+/** Loose, possibly-incomplete signals from the shell. Every field is optional. */
+export interface RawScanSignals {
+  readonly kind?: 'static' | 'streaming';
+  readonly coverage?: Coverage;
+  readonly crs?: CrsInfo | null;
+  readonly pointCount?: number;
+  readonly hasRgb?: boolean;
+  readonly hasIntensity?: boolean;
+  readonly hasGpsTime?: boolean;
+  readonly hasReturnNumber?: boolean;
+  readonly hasPointSourceId?: boolean;
+  readonly classification?: ClassPresence;
+  readonly groundClassified?: boolean;
+  readonly hasBuildingClass?: boolean;
+  readonly medianSpacing?: number;
+}
+
+/**
+ * Turn loose signals into ScanFacts with fail-closed defaults.
+ *
+ * - `kind` defaults to `static` (a whole-file cloud).
+ * - `coverage`: a static cloud is `full`; a streaming cloud whose coverage the
+ *   shell did not report is `resident-only` (the honest floor — we cannot claim
+ *   to have seen more than the resident set). An explicit coverage is kept.
+ * - `crs` defaults to null — an unknown CRS is never assumed to be anything.
+ * - feature flags default to false; `classification` defaults to `none`.
+ * - `groundClassified` is true only when it is explicitly true AND some
+ *   classification is present, so "trusted ground" can never sit on an
+ *   unclassified cloud.
+ */
+export function deriveScanFacts(raw: RawScanSignals): ScanFacts {
+  const kind = raw.kind ?? 'static';
+  const coverage: Coverage = raw.coverage ?? (kind === 'streaming' ? 'resident-only' : 'full');
+  const classification: ClassPresence = raw.classification ?? 'none';
+  const groundClassified = raw.groundClassified === true && classification !== 'none';
+  const facts: ScanFacts = {
+    kind,
+    coverage,
+    crs: raw.crs ?? null,
+    pointCount: Number.isFinite(raw.pointCount) ? Math.max(0, raw.pointCount as number) : 0,
+    hasRgb: raw.hasRgb === true,
+    hasIntensity: raw.hasIntensity === true,
+    hasGpsTime: raw.hasGpsTime === true,
+    hasReturnNumber: raw.hasReturnNumber === true,
+    hasPointSourceId: raw.hasPointSourceId === true,
+    classification,
+    groundClassified,
+    hasBuildingClass: raw.hasBuildingClass === true,
+  };
+  return raw.medianSpacing !== undefined && Number.isFinite(raw.medianSpacing)
+    ? { ...facts, medianSpacing: raw.medianSpacing }
+    : facts;
+}

--- a/src/qa/QaService.ts
+++ b/src/qa/QaService.ts
@@ -1,0 +1,68 @@
+/**
+ * QaService.ts — product-specific QA gating (Phase 2).
+ *
+ * Wraps the independent `runQaChecks` diagnostics and answers, per product,
+ * whether QA permits it — reading only the checks that actually bear on that
+ * product. The point is independence: a failed terrain-readiness check must NOT
+ * block an unrelated classification export, and vice versa. There is still no
+ * global score; `gateFor` names the specific checks that block a given product.
+ * Pure and side-effect-free.
+ */
+
+import type { ScanFacts, ProductId } from '../process/ProcessPlan';
+import { runQaChecks, worstStatus, type QaCheck, type QaStatus } from './qaChecks';
+
+/** Which QA check ids bear on each product. Absent products depend on the base set. */
+const BASE_CHECKS = ['FILE_INTEGRITY', 'SPATIAL_REFERENCE'] as const;
+const PRODUCT_CHECKS: Partial<Record<ProductId, readonly string[]>> = {
+  'classify-gaps': ['FILE_INTEGRITY', 'CLOUD_QUALITY'], // classification does not need a CRS or ground
+  dtm: ['FILE_INTEGRITY', 'SPATIAL_REFERENCE', 'COVERAGE', 'TERRAIN_READINESS'],
+  dsm: ['FILE_INTEGRITY', 'SPATIAL_REFERENCE', 'COVERAGE'],
+  contours: ['FILE_INTEGRITY', 'SPATIAL_REFERENCE', 'COVERAGE', 'TERRAIN_READINESS'],
+  'building-footprints': ['FILE_INTEGRITY', 'SPATIAL_REFERENCE', 'CLASSIFICATION'],
+  'cross-epoch-change': ['FILE_INTEGRITY', 'SPATIAL_REFERENCE', 'COVERAGE'],
+  'volume-cut-fill': ['FILE_INTEGRITY', 'SPATIAL_REFERENCE', 'COVERAGE'],
+};
+
+export interface ProductQaGate {
+  readonly product: ProductId;
+  /** True when no relevant check BLOCKS the product (review is allowed). */
+  readonly allowed: boolean;
+  /** The relevant checks, and specifically those blocking it. */
+  readonly relevant: readonly QaCheck[];
+  readonly blocking: readonly QaCheck[];
+}
+
+export class QaService {
+  private readonly _checks: QaCheck[];
+
+  private constructor(checks: QaCheck[]) {
+    this._checks = checks;
+  }
+
+  static forFacts(facts: ScanFacts): QaService {
+    return new QaService(runQaChecks(facts));
+  }
+
+  /** All independent checks, in stable order. */
+  checks(): readonly QaCheck[] {
+    return this._checks;
+  }
+
+  /** Severity headline across all checks — a banner signal, not a score. */
+  worst(): QaStatus {
+    return worstStatus(this._checks);
+  }
+
+  /**
+   * QA's verdict for one product, over ONLY the checks that bear on it. A block
+   * on an unrelated axis (e.g. terrain readiness for a classification export)
+   * never appears here, so products fail independently.
+   */
+  gateFor(product: ProductId): ProductQaGate {
+    const ids = PRODUCT_CHECKS[product] ?? BASE_CHECKS;
+    const relevant = this._checks.filter((c) => ids.includes(c.id));
+    const blocking = relevant.filter((c) => c.status === 'block');
+    return { product, allowed: blocking.length === 0, relevant, blocking };
+  }
+}

--- a/src/qa/qaChecks.ts
+++ b/src/qa/qaChecks.ts
@@ -1,0 +1,113 @@
+/**
+ * qaChecks.ts — independent quality checks (Phase 2 foundation).
+ *
+ * A set of INDEPENDENT diagnostics over a loaded scan, each returning its own
+ * PASS / REVIEW / BLOCK verdict with a reason. Deliberately NO single global
+ * "quality score": a failed spatial-reference check must not drag down an
+ * unrelated cloud-quality check, and collapsing them into one number hides which
+ * property is actually wrong. Each check reads the same fail-closed ScanFacts the
+ * capability model reads, so QA and eligibility can never disagree about the raw
+ * facts. Diagnostics, not evidence claims — pure and side-effect-free.
+ */
+
+import type { ScanFacts } from '../process/ProcessPlan';
+import { isLinearUnitKnown } from '../geo/CoordinateTypes';
+
+export type QaStatus = 'pass' | 'review' | 'block';
+
+export interface QaCheck {
+  /** Stable UPPER_SNAKE id — greppable. */
+  readonly id: string;
+  /** Short human label. */
+  readonly label: string;
+  readonly status: QaStatus;
+  /** One sentence: what was checked and why it landed here. */
+  readonly reason: string;
+}
+
+/** File integrity: is there actually any point data to work with? */
+function fileIntegrity(f: ScanFacts): QaCheck {
+  if (f.pointCount <= 0) {
+    return { id: 'FILE_INTEGRITY', label: 'File integrity', status: 'block', reason: 'No points are present in the scan.' };
+  }
+  return { id: 'FILE_INTEGRITY', label: 'File integrity', status: 'pass', reason: `${f.pointCount.toLocaleString()} points present.` };
+}
+
+/** Spatial reference: is the horizontal unit known? Unknown blocks metric work. */
+function spatialReference(f: ScanFacts): QaCheck {
+  if (isLinearUnitKnown(f.crs)) {
+    return { id: 'SPATIAL_REFERENCE', label: 'Spatial reference', status: 'pass', reason: 'A coordinate reference with a known linear unit is present.' };
+  }
+  return {
+    id: 'SPATIAL_REFERENCE', label: 'Spatial reference', status: 'block',
+    reason: 'No coordinate reference with a known linear unit — metric products are blocked until it is set.',
+  };
+}
+
+/** Cloud quality: is the point spacing measured and reasonable? */
+function cloudQuality(f: ScanFacts): QaCheck {
+  if (f.medianSpacing === undefined || !Number.isFinite(f.medianSpacing)) {
+    return { id: 'CLOUD_QUALITY', label: 'Cloud quality', status: 'review', reason: 'Point spacing has not been measured yet.' };
+  }
+  if (f.medianSpacing <= 0) {
+    return { id: 'CLOUD_QUALITY', label: 'Cloud quality', status: 'review', reason: 'Measured point spacing is not positive; treat density as unverified.' };
+  }
+  return { id: 'CLOUD_QUALITY', label: 'Cloud quality', status: 'pass', reason: `Median point spacing ~${f.medianSpacing.toFixed(2)} m.` };
+}
+
+/** Coverage honesty: a resident-only streaming view is not the whole cloud. */
+function coverage(f: ScanFacts): QaCheck {
+  if (f.coverage === 'full') {
+    return { id: 'COVERAGE', label: 'Coverage', status: 'pass', reason: 'The whole cloud is available to the operation.' };
+  }
+  if (f.coverage === 'sampled') {
+    return { id: 'COVERAGE', label: 'Coverage', status: 'review', reason: 'Only a sampled subset is available; whole-dataset products are limited.' };
+  }
+  return { id: 'COVERAGE', label: 'Coverage', status: 'review', reason: 'Only the resident set is available; whole-dataset products cannot be produced from this view.' };
+}
+
+/** Classification: is any producer/derived classification present? */
+function classification(f: ScanFacts): QaCheck {
+  if (f.classification === 'none') {
+    return { id: 'CLASSIFICATION', label: 'Classification', status: 'review', reason: 'No classification is present; classify before class-dependent products.' };
+  }
+  if (f.classification === 'partial') {
+    return { id: 'CLASSIFICATION', label: 'Classification', status: 'review', reason: 'Classification is partial; some class-dependent products may be incomplete.' };
+  }
+  return { id: 'CLASSIFICATION', label: 'Classification', status: 'pass', reason: 'A full classification is present.' };
+}
+
+/** Terrain readiness: is there trustworthy ground for a bare-earth surface? */
+function terrainReadiness(f: ScanFacts): QaCheck {
+  if (f.groundClassified) {
+    return { id: 'TERRAIN_READINESS', label: 'Terrain readiness', status: 'pass', reason: 'Trusted ground (class 2) is present for a bare-earth surface.' };
+  }
+  return { id: 'TERRAIN_READINESS', label: 'Terrain readiness', status: 'review', reason: 'No trusted ground; a DTM would need ground to be derived first.' };
+}
+
+/**
+ * Run every independent check over one scan. Order is stable and each check is
+ * self-contained; the caller renders them side by side, never as a single score.
+ */
+export function runQaChecks(f: ScanFacts): QaCheck[] {
+  return [
+    fileIntegrity(f),
+    spatialReference(f),
+    cloudQuality(f),
+    coverage(f),
+    classification(f),
+    terrainReadiness(f),
+  ];
+}
+
+/**
+ * The most severe status across a set of checks — block beats review beats pass.
+ * This is a SEVERITY roll-up for a headline banner, explicitly NOT a quality
+ * score: it tells the reader whether anything needs attention, and the checks
+ * themselves say what.
+ */
+export function worstStatus(checks: readonly QaCheck[]): QaStatus {
+  if (checks.some((c) => c.status === 'block')) return 'block';
+  if (checks.some((c) => c.status === 'review')) return 'review';
+  return 'pass';
+}

--- a/tests/classificationEvidence.test.ts
+++ b/tests/classificationEvidence.test.ts
@@ -1,0 +1,37 @@
+/**
+ * classificationEvidence.test.ts — the per-point evidence record + review rule.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildEvidence, isReviewUncertain } from '../src/classification/classificationEvidence';
+
+describe('buildEvidence', () => {
+  it('clamps support to [0,1] and carries reason codes', () => {
+    expect(buildEvidence({ classCode: 2, source: 'derived', support: 1.7, methodVersion: 'v1' }).support).toBe(1);
+    expect(buildEvidence({ classCode: 2, source: 'derived', support: -3, methodVersion: 'v1' }).support).toBe(0);
+    const e = buildEvidence({ classCode: 6, source: 'derived', support: 0.8, methodVersion: 'v1', reasonCodes: ['PLANAR_HORIZONTAL'] });
+    expect(e.reasonCodes).toEqual(['PLANAR_HORIZONTAL']);
+  });
+
+  it('flags low support, near-threshold and conflicting decisions', () => {
+    const low = buildEvidence({ classCode: 5, source: 'derived', support: 0.3, methodVersion: 'v1' });
+    expect(low.flags.lowSupport).toBe(true);
+    const near = buildEvidence({ classCode: 5, source: 'derived', support: 0.55, methodVersion: 'v1', decisionThreshold: 0.5 });
+    expect(near.flags.nearThreshold).toBe(true);
+    const conflict = buildEvidence({ classCode: 5, source: 'derived', support: 0.6, methodVersion: 'v1', runnerUpSupport: 0.58 });
+    expect(conflict.flags.conflicting).toBe(true);
+  });
+});
+
+describe('isReviewUncertain — only weak DERIVED points are isolated', () => {
+  it('a strong derived point is not flagged for review', () => {
+    expect(isReviewUncertain(buildEvidence({ classCode: 6, source: 'derived', support: 0.95, methodVersion: 'v1' }))).toBe(false);
+  });
+  it('a weak derived point is flagged', () => {
+    expect(isReviewUncertain(buildEvidence({ classCode: 6, source: 'derived', support: 0.2, methodVersion: 'v1' }))).toBe(true);
+  });
+  it('producer and manual classes are trusted and never review-isolated, even at low support', () => {
+    expect(isReviewUncertain(buildEvidence({ classCode: 2, source: 'producer', support: 0.1, methodVersion: 'v1' }))).toBe(false);
+    expect(isReviewUncertain(buildEvidence({ classCode: 2, source: 'manual', support: 0.1, methodVersion: 'v1' }))).toBe(false);
+  });
+});

--- a/tests/geometryDescriptors.test.ts
+++ b/tests/geometryDescriptors.test.ts
@@ -1,0 +1,71 @@
+/**
+ * geometryDescriptors.test.ts — shape descriptors validated on canonical shapes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { descriptorsForNeighborhood } from '../src/classification/geometryDescriptors';
+import { SpatialHash3d } from '../src/classification/spatialHash3d';
+
+function flat(pts: Array<[number, number, number]>): Float32Array {
+  const a = new Float32Array(pts.length * 3);
+  pts.forEach((p, i) => { a[i * 3] = p[0]; a[i * 3 + 1] = p[1]; a[i * 3 + 2] = p[2]; });
+  return a;
+}
+const ids = (n: number): number[] => Array.from({ length: n }, (_, i) => i);
+
+describe('canonical shapes produce the expected descriptor signatures', () => {
+  it('a collinear set is linear (linearity high, planarity/sphericity low)', () => {
+    const pts = flat(Array.from({ length: 21 }, (_, i) => [i * 0.1, 0, 0] as [number, number, number]));
+    const d = descriptorsForNeighborhood(pts, ids(21))!;
+    expect(d.linearity).toBeGreaterThan(0.98);
+    expect(d.planarity).toBeLessThan(0.05);
+    expect(d.sphericity).toBeLessThan(0.05);
+  });
+
+  it('a horizontal plane is planar with LOW verticality (normal points up)', () => {
+    const pts: Array<[number, number, number]> = [];
+    for (let x = 0; x < 7; x++) for (let y = 0; y < 7; y++) pts.push([x, y, 0]);
+    const d = descriptorsForNeighborhood(flat(pts), ids(pts.length))!;
+    expect(d.planarity).toBeGreaterThan(0.9);
+    expect(d.linearity).toBeLessThan(0.1);
+    expect(d.verticality).toBeLessThan(0.05); // roof-like
+  });
+
+  it('a vertical plane is planar with HIGH verticality (normal is horizontal)', () => {
+    const pts: Array<[number, number, number]> = [];
+    for (let x = 0; x < 7; x++) for (let z = 0; z < 7; z++) pts.push([x, 0, z]); // x-z plane, normal ±y
+    const d = descriptorsForNeighborhood(flat(pts), ids(pts.length))!;
+    expect(d.planarity).toBeGreaterThan(0.9);
+    expect(d.verticality).toBeGreaterThan(0.95); // wall-like
+  });
+
+  it('an isotropic blob is spherical (sphericity high, linearity/planarity low)', () => {
+    const pts: Array<[number, number, number]> = [];
+    for (let x = -2; x <= 2; x++) for (let y = -2; y <= 2; y++) for (let z = -2; z <= 2; z++) pts.push([x, y, z]);
+    const d = descriptorsForNeighborhood(flat(pts), ids(pts.length))!;
+    expect(d.sphericity).toBeGreaterThan(0.5);
+    expect(d.linearity).toBeLessThan(0.2);
+    expect(d.planarity).toBeLessThan(0.2);
+  });
+
+  it('returns null for a degenerate (<3 point) neighbourhood', () => {
+    expect(descriptorsForNeighborhood(flat([[0, 0, 0], [1, 1, 1]]), [0, 1])).toBeNull();
+  });
+
+  it('feeds off the spatial hash: descriptors on a wire vs a roof neighbourhood differ as expected', () => {
+    // A horizontal wire (linear) and a roof patch (planar) in one cloud.
+    const wire: Array<[number, number, number]> = Array.from({ length: 15 }, (_, i) => [i * 0.2, 50, 10]);
+    const roof: Array<[number, number, number]> = [];
+    for (let x = 0; x < 6; x++) for (let y = 0; y < 6; y++) roof.push([x * 0.2, y * 0.2, 3]);
+    const all = flat([...wire, ...roof]);
+    const hash = new SpatialHash3d(all, 1.0);
+    // A point on the wire.
+    const wIds = hash.queryRadius(wire[7][0], wire[7][1], wire[7][2], 1.0);
+    const wD = descriptorsForNeighborhood(all, wIds)!;
+    expect(wD.linearity).toBeGreaterThan(wD.planarity);
+    // A point on the roof.
+    const rIds = hash.queryRadius(roof[18][0], roof[18][1], roof[18][2], 1.0);
+    const rD = descriptorsForNeighborhood(all, rIds)!;
+    expect(rD.planarity).toBeGreaterThan(rD.linearity);
+  });
+});

--- a/tests/processService.test.ts
+++ b/tests/processService.test.ts
@@ -1,0 +1,44 @@
+/**
+ * processService.test.ts — the single eligibility surface over the evaluator.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ProcessService } from '../src/process/ProcessService';
+import type { CrsInfo } from '../src/io/crs';
+import type { ScanFacts } from '../src/process/ProcessPlan';
+
+function crs(o: Partial<CrsInfo> = {}): CrsInfo {
+  return { source: 'epsg', linearUnit: 'metre', linearUnitToMetres: 1, ...o } as CrsInfo;
+}
+const healthy: ScanFacts = {
+  kind: 'static', coverage: 'full', crs: crs(), pointCount: 1_000_000,
+  hasRgb: true, hasIntensity: true, hasGpsTime: true, hasReturnNumber: true, hasPointSourceId: false,
+  classification: 'full', groundClassified: true, hasBuildingClass: true, medianSpacing: 0.2,
+};
+
+describe('ProcessService', () => {
+  it('agrees with the underlying evaluator and gates exporters through isReady', () => {
+    const svc = ProcessService.fromFacts([healthy]);
+    expect(svc.isReady('dtm')).toBe(true);
+    expect(svc.readiness('contours')).toBe('ready');
+  });
+
+  it('an unknown product reads blocked, never accidentally ready', () => {
+    const svc = ProcessService.fromFacts([healthy]);
+    // A product id the model does not carry defaults to blocked.
+    expect(svc.readiness('not-a-real-product' as never)).toBe('blocked');
+    expect(svc.isReady('not-a-real-product' as never)).toBe(false);
+  });
+
+  it('fromSignals normalises fail-closed, so a missing CRS blocks metric products', () => {
+    // No crs supplied → deriveScanFacts nulls it → contours (metric) blocked.
+    const svc = ProcessService.fromSignals([{ pointCount: 1000, classification: 'full', groundClassified: true }]);
+    expect(svc.readiness('contours')).toBe('blocked');
+  });
+
+  it('summary counts products by readiness', () => {
+    const s = ProcessService.fromFacts([healthy]).summary();
+    expect(s.ready + s.review + s.blocked).toBeGreaterThan(0);
+    expect(s.anyReady).toBe(true);
+  });
+});

--- a/tests/processStages.test.ts
+++ b/tests/processStages.test.ts
@@ -1,0 +1,50 @@
+/**
+ * processStages.test.ts — the adaptive Process Studio stage model.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { adaptiveStages, relevantStages } from '../src/process/processStages';
+import type { CrsInfo } from '../src/io/crs';
+import type { ScanFacts } from '../src/process/ProcessPlan';
+
+function crs(o: Partial<CrsInfo> = {}): CrsInfo {
+  return { source: 'epsg', linearUnit: 'metre', linearUnitToMetres: 1, ...o } as CrsInfo;
+}
+function scan(o: Partial<ScanFacts> = {}): ScanFacts {
+  return {
+    kind: 'static', coverage: 'full', crs: crs(), pointCount: 1_000_000,
+    hasRgb: true, hasIntensity: true, hasGpsTime: true, hasReturnNumber: true, hasPointSourceId: false,
+    classification: 'full', groundClassified: true, hasBuildingClass: true, medianSpacing: 0.2, ...o,
+  };
+}
+const stage = (stages: ReturnType<typeof adaptiveStages>, id: string) => stages.find((s) => s.id === id)!;
+
+describe('adaptiveStages', () => {
+  it('always shows Prepare and Validate/Export', () => {
+    const s = adaptiveStages({ scans: [scan()] });
+    expect(stage(s, 'prepare').relevant).toBe(true);
+    expect(stage(s, 'validate-export').relevant).toBe(true);
+  });
+
+  it('skips Classify when the cloud is already fully classified, shows it when partial', () => {
+    expect(stage(adaptiveStages({ scans: [scan({ classification: 'full' })] }), 'classify').relevant).toBe(false);
+    expect(stage(adaptiveStages({ scans: [scan({ classification: 'partial' })] }), 'classify').relevant).toBe(true);
+    expect(stage(adaptiveStages({ scans: [scan({ classification: 'none' })] }), 'classify').relevant).toBe(true);
+  });
+
+  it('shows Align only for two or more scans', () => {
+    expect(stage(adaptiveStages({ scans: [scan()] }), 'align').relevant).toBe(false);
+    expect(stage(adaptiveStages({ scans: [scan(), scan()] }), 'align').relevant).toBe(true);
+  });
+
+  it('skips Surface when no terrain product is possible (resident-only streaming)', () => {
+    const residentOnly = scan({ kind: 'streaming', coverage: 'resident-only' });
+    expect(stage(adaptiveStages({ scans: [residentOnly] }), 'surface').relevant).toBe(false);
+  });
+
+  it('relevantStages returns only the shown stages', () => {
+    const shown = relevantStages({ scans: [scan({ classification: 'full' })] });
+    expect(shown.every((s) => s.relevant)).toBe(true);
+    expect(shown.find((s) => s.id === 'classify')).toBeUndefined(); // fully classified → hidden
+  });
+});

--- a/tests/qaChecks.test.ts
+++ b/tests/qaChecks.test.ts
@@ -1,0 +1,55 @@
+/**
+ * qaChecks.test.ts — independent QA diagnostics, no fake global score.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runQaChecks, worstStatus, type QaCheck } from '../src/qa/qaChecks';
+import type { CrsInfo } from '../src/io/crs';
+import type { ScanFacts } from '../src/process/ProcessPlan';
+
+function crs(o: Partial<CrsInfo> = {}): CrsInfo {
+  return { source: 'epsg', linearUnit: 'metre', linearUnitToMetres: 1, ...o } as CrsInfo;
+}
+function facts(o: Partial<ScanFacts> = {}): ScanFacts {
+  return {
+    kind: 'static', coverage: 'full', crs: crs(), pointCount: 1_000_000,
+    hasRgb: true, hasIntensity: true, hasGpsTime: true, hasReturnNumber: true, hasPointSourceId: false,
+    classification: 'full', groundClassified: true, hasBuildingClass: true, medianSpacing: 0.2, ...o,
+  };
+}
+const byId = (checks: QaCheck[], id: string): QaCheck => checks.find((c) => c.id === id)!;
+
+describe('runQaChecks', () => {
+  it('a healthy scan passes every check', () => {
+    const checks = runQaChecks(facts());
+    expect(checks.every((c) => c.status === 'pass')).toBe(true);
+    expect(worstStatus(checks)).toBe('pass');
+  });
+
+  it('an empty cloud blocks file integrity but leaves other checks independent', () => {
+    const checks = runQaChecks(facts({ pointCount: 0 }));
+    expect(byId(checks, 'FILE_INTEGRITY').status).toBe('block');
+    // Independence: the spatial reference is still fine and reports pass on its own.
+    expect(byId(checks, 'SPATIAL_REFERENCE').status).toBe('pass');
+    expect(worstStatus(checks)).toBe('block');
+  });
+
+  it('a missing CRS blocks only the spatial-reference check (fail closed)', () => {
+    const checks = runQaChecks(facts({ crs: null }));
+    expect(byId(checks, 'SPATIAL_REFERENCE').status).toBe('block');
+    expect(byId(checks, 'FILE_INTEGRITY').status).toBe('pass');
+  });
+
+  it('resident-only coverage and no ground each review, not block, on their own axes', () => {
+    const checks = runQaChecks(facts({ kind: 'streaming', coverage: 'resident-only', groundClassified: false, classification: 'none' }));
+    expect(byId(checks, 'COVERAGE').status).toBe('review');
+    expect(byId(checks, 'TERRAIN_READINESS').status).toBe('review');
+    expect(byId(checks, 'CLASSIFICATION').status).toBe('review');
+    expect(worstStatus(checks)).toBe('review'); // nothing blocked, but attention needed
+  });
+
+  it('worstStatus is a severity roll-up (block beats review beats pass), not an average', () => {
+    expect(worstStatus([{ id: 'a', label: 'a', status: 'pass', reason: '' }, { id: 'b', label: 'b', status: 'block', reason: '' }])).toBe('block');
+    expect(worstStatus([{ id: 'a', label: 'a', status: 'pass', reason: '' }, { id: 'b', label: 'b', status: 'review', reason: '' }])).toBe('review');
+  });
+});

--- a/tests/qaService.test.ts
+++ b/tests/qaService.test.ts
@@ -1,0 +1,56 @@
+/**
+ * qaService.test.ts — product-specific QA gating stays independent per product.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { QaService } from '../src/qa/QaService';
+import type { CrsInfo } from '../src/io/crs';
+import type { ScanFacts } from '../src/process/ProcessPlan';
+
+function crs(o: Partial<CrsInfo> = {}): CrsInfo {
+  return { source: 'epsg', linearUnit: 'metre', linearUnitToMetres: 1, ...o } as CrsInfo;
+}
+function facts(o: Partial<ScanFacts> = {}): ScanFacts {
+  return {
+    kind: 'static', coverage: 'full', crs: crs(), pointCount: 1_000_000,
+    hasRgb: true, hasIntensity: true, hasGpsTime: true, hasReturnNumber: true, hasPointSourceId: false,
+    classification: 'full', groundClassified: true, hasBuildingClass: true, medianSpacing: 0.2, ...o,
+  };
+}
+
+describe('QaService.gateFor — products fail independently', () => {
+  it('a failed terrain-readiness check does NOT block a classification export', () => {
+    // No trusted ground → TERRAIN_READINESS reviews, but classification is fine.
+    const svc = QaService.forFacts(facts({ groundClassified: false, classification: 'full' }));
+    const dtm = svc.gateFor('dtm');
+    const classify = svc.gateFor('classify-gaps');
+    // Terrain readiness only reviews (not block), so dtm is allowed but flagged;
+    // classification does not even consider terrain readiness.
+    expect(classify.relevant.some((c) => c.id === 'TERRAIN_READINESS')).toBe(false);
+    expect(classify.allowed).toBe(true);
+    expect(dtm.relevant.some((c) => c.id === 'TERRAIN_READINESS')).toBe(true);
+  });
+
+  it('a missing CRS blocks metric products but not gap-classification', () => {
+    const svc = QaService.forFacts(facts({ crs: null }));
+    expect(svc.gateFor('contours').allowed).toBe(false); // spatial reference blocks
+    expect(svc.gateFor('contours').blocking.some((c) => c.id === 'SPATIAL_REFERENCE')).toBe(true);
+    // classify-gaps does not depend on the CRS.
+    expect(svc.gateFor('classify-gaps').allowed).toBe(true);
+  });
+
+  it('an empty cloud blocks every product (file integrity is in every base set)', () => {
+    const svc = QaService.forFacts(facts({ pointCount: 0 }));
+    expect(svc.gateFor('dtm').allowed).toBe(false);
+    expect(svc.gateFor('classify-gaps').allowed).toBe(false);
+    expect(svc.worst()).toBe('block');
+  });
+
+  it('a healthy scan allows all products', () => {
+    const svc = QaService.forFacts(facts());
+    for (const p of ['dtm', 'contours', 'building-footprints', 'classify-gaps'] as const) {
+      expect(svc.gateFor(p).allowed).toBe(true);
+    }
+    expect(svc.worst()).toBe('pass');
+  });
+});

--- a/tests/scanFacts.test.ts
+++ b/tests/scanFacts.test.ts
@@ -1,0 +1,45 @@
+/**
+ * scanFacts.test.ts — the fail-closed scan-facts normaliser.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveScanFacts } from '../src/process/scanFacts';
+
+describe('deriveScanFacts — unknowns default to the safe side', () => {
+  it('an empty signal set yields a conservative static, no-CRS, unclassified scan', () => {
+    const f = deriveScanFacts({});
+    expect(f.kind).toBe('static');
+    expect(f.coverage).toBe('full'); // static clouds are whole-file
+    expect(f.crs).toBeNull(); // never assume a CRS
+    expect(f.pointCount).toBe(0);
+    expect(f.classification).toBe('none');
+    expect(f.groundClassified).toBe(false);
+    expect(f.hasBuildingClass).toBe(false);
+    expect(f.medianSpacing).toBeUndefined();
+  });
+
+  it('a streaming scan with no coverage signal is resident-only, not full', () => {
+    expect(deriveScanFacts({ kind: 'streaming' }).coverage).toBe('resident-only');
+    // An explicit coverage is kept.
+    expect(deriveScanFacts({ kind: 'streaming', coverage: 'full' }).coverage).toBe('full');
+  });
+
+  it('ground can never be trusted on an unclassified cloud', () => {
+    // groundClassified true but classification none → forced false.
+    expect(deriveScanFacts({ groundClassified: true }).groundClassified).toBe(false);
+    // With classification present, it stands.
+    expect(deriveScanFacts({ groundClassified: true, classification: 'full' }).groundClassified).toBe(true);
+  });
+
+  it('a negative or non-finite point count clamps to 0', () => {
+    expect(deriveScanFacts({ pointCount: -5 }).pointCount).toBe(0);
+    expect(deriveScanFacts({ pointCount: NaN }).pointCount).toBe(0);
+    expect(deriveScanFacts({ pointCount: 1000 }).pointCount).toBe(1000);
+  });
+
+  it('feature flags are false unless explicitly true', () => {
+    const f = deriveScanFacts({ hasRgb: undefined, hasIntensity: true });
+    expect(f.hasRgb).toBe(false);
+    expect(f.hasIntensity).toBe(true);
+  });
+});

--- a/tests/spatialHash3d.test.ts
+++ b/tests/spatialHash3d.test.ts
@@ -1,0 +1,54 @@
+/**
+ * spatialHash3d.test.ts — the uniform-grid neighbourhood index.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SpatialHash3d } from '../src/classification/spatialHash3d';
+
+/** N points on a regular 1 m lattice in [0,g)^3. */
+function lattice(g: number): Float32Array {
+  const pts: number[] = [];
+  for (let x = 0; x < g; x++) for (let y = 0; y < g; y++) for (let z = 0; z < g; z++) pts.push(x, y, z);
+  return new Float32Array(pts);
+}
+
+describe('SpatialHash3d', () => {
+  it('radius query matches a brute-force scan exactly', () => {
+    const pos = lattice(10);
+    const n = pos.length / 3;
+    const hash = new SpatialHash3d(pos, 2.0);
+    const qx = 4, qy = 5, qz = 6, r = 2.5;
+    const got = new Set(hash.queryRadius(qx, qy, qz, r));
+    const brute = new Set<number>();
+    for (let i = 0; i < n; i++) {
+      const dx = pos[i * 3] - qx, dy = pos[i * 3 + 1] - qy, dz = pos[i * 3 + 2] - qz;
+      if (dx * dx + dy * dy + dz * dz <= r * r) brute.add(i);
+    }
+    expect(got).toEqual(brute);
+    expect(got.size).toBeGreaterThan(0);
+  });
+
+  it('includes the point exactly at the query location', () => {
+    const pos = lattice(5);
+    const hash = new SpatialHash3d(pos, 1.0);
+    expect(hash.queryRadius(2, 2, 2, 0.1)).toContain((2 * 5 + 2) * 5 + 2);
+  });
+
+  it('handles a radius larger than the cell size (ceil span covers the sphere)', () => {
+    const pos = lattice(12);
+    const n = pos.length / 3;
+    const hash = new SpatialHash3d(pos, 1.0); // cell smaller than radius
+    const r = 3.5;
+    const got = new Set(hash.queryRadius(6, 6, 6, r));
+    let brute = 0;
+    for (let i = 0; i < n; i++) {
+      const dx = pos[i * 3] - 6, dy = pos[i * 3 + 1] - 6, dz = pos[i * 3 + 2] - 6;
+      if (dx * dx + dy * dy + dz * dz <= r * r) brute++;
+    }
+    expect(got.size).toBe(brute);
+  });
+
+  it('rejects a non-positive cell size', () => {
+    expect(() => new SpatialHash3d(new Float32Array([0, 0, 0]), 0)).toThrow();
+  });
+});

--- a/tests/symEig3.test.ts
+++ b/tests/symEig3.test.ts
@@ -1,0 +1,45 @@
+/**
+ * symEig3.test.ts — the symmetric 3×3 eigensolver.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { symEig3 } from '../src/math/symEig3';
+
+describe('symEig3', () => {
+  it('diagonalises a diagonal matrix, sorted descending', () => {
+    const e = symEig3(1, 0, 0, 5, 0, 3); // eigenvalues 5,3,1
+    expect(e.values[0]).toBeCloseTo(5, 9);
+    expect(e.values[1]).toBeCloseTo(3, 9);
+    expect(e.values[2]).toBeCloseTo(1, 9);
+  });
+
+  it('recovers eigenvalues of a known symmetric matrix (trace + det invariants)', () => {
+    // [[2,1,0],[1,2,0],[0,0,3]] → eigenvalues 3,3,1.
+    const e = symEig3(2, 1, 0, 2, 0, 3);
+    const vals = [...e.values].sort((a, b) => b - a);
+    expect(vals[0]).toBeCloseTo(3, 6);
+    expect(vals[1]).toBeCloseTo(3, 6);
+    expect(vals[2]).toBeCloseTo(1, 6);
+    // Trace and determinant are preserved.
+    expect(e.values[0] + e.values[1] + e.values[2]).toBeCloseTo(7, 6);
+  });
+
+  it('returns unit eigenvectors that actually satisfy A v = λ v', () => {
+    const axx = 4, axy = 1, axz = 0.5, ayy = 3, ayz = 0.2, azz = 2;
+    const e = symEig3(axx, axy, axz, ayy, ayz, azz);
+    for (let k = 0; k < 3; k++) {
+      const v = e.vectors[k], lam = e.values[k];
+      // A v
+      const av = [
+        axx * v[0] + axy * v[1] + axz * v[2],
+        axy * v[0] + ayy * v[1] + ayz * v[2],
+        axz * v[0] + ayz * v[1] + azz * v[2],
+      ];
+      expect(av[0]).toBeCloseTo(lam * v[0], 5);
+      expect(av[1]).toBeCloseTo(lam * v[1], 5);
+      expect(av[2]).toBeCloseTo(lam * v[2], 5);
+      // Unit length.
+      expect(Math.hypot(v[0], v[1], v[2])).toBeCloseTo(1, 6);
+    }
+  });
+});


### PR DESCRIPTION
Phase 1/2 pure services — the eligibility + QA layer the Process Studio vision reads, built services-first (no UI yet, so the production bundle is unchanged at 324.86 kB).

- `scanFacts.deriveScanFacts` — fail-closed normaliser (unknown CRS null, unknown streaming coverage resident-only, ground trusted only when classification carries it).
- `ProcessService` — the single source of product eligibility over the existing pure evaluator; one `isReady` gate for exporters and UI.
- `qa/qaChecks` — independent PASS/REVIEW/BLOCK diagnostics, no fake global score.

14 unit tests; tsc + main-deferral lint clean.