### PR TITLE
Evidence model: accuracy validation-envelope + shared-solution confounder

### DIFF
--- a/src/validation/accuracyEnvelope.ts
+++ b/src/validation/accuracyEnvelope.ts
@@ -1,0 +1,117 @@
+/**
+ * accuracyEnvelope.ts — an absolute-accuracy figure is only valid inside the
+ * conditions it was measured in, and only as independent as its reference.
+ *
+ * A surveyed-checkpoint result (e.g. "DTM vertical RMSE 2.8 cm") is measured on
+ * one biome, one relief band, one sensor class, under one vertical-datum
+ * situation. Presenting that number for a scan outside those conditions is
+ * overgeneralisation. This module carries the VALIDATION ENVELOPE with each
+ * accuracy claim and answers, fail-closed, whether a given scan is covered:
+ * an unknown scan fact, or a scan outside the envelope, gets no survey-grade
+ * figure — the same discipline OLV already applies to unknown units and
+ * coverage, extended to accuracy provenance.
+ *
+ * It also carries a CONFOUNDER: when the checkpoint truth and the gridded points
+ * come from the same upstream solution (e.g. one photogrammetric bundle), the
+ * comparison is not fully independent and the evidence level is capped below the
+ * external tier. Pure and deterministic; no runtime dependency.
+ */
+
+import { type EvidenceLevel, evidenceRank } from './evidenceLevel';
+
+export type Biome = 'coastal-marsh' | 'bare-dune' | 'forest' | 'urban' | 'riparian' | 'slope' | 'plain' | 'unknown';
+export type ReliefBand = 'flat' | 'low' | 'moderate' | 'steep' | 'unknown';
+export type SensorClass = 'airborne-lidar' | 'uav-lidar' | 'uav-photogrammetry' | 'terrestrial-lidar' | 'unknown';
+/** How the scan's vertical datum relates to the checkpoint/reference datum. */
+export type DatumMatch = 'matched' | 'reconciled' | 'unreconciled' | 'unknown';
+
+/** The conditions an absolute-accuracy figure was actually validated under. */
+export interface ValidationEnvelope {
+  readonly biomes: readonly Biome[];
+  readonly reliefBands: readonly ReliefBand[];
+  readonly sensorClasses: readonly SensorClass[];
+  /** The weakest datum-match handling the validation covered. */
+  readonly datumMatch: DatumMatch;
+}
+
+/** The facts about the scan a figure is being requested for. */
+export interface ScanContext {
+  readonly biome: Biome;
+  readonly reliefBand: ReliefBand;
+  readonly sensorClass: SensorClass;
+  readonly datumMatch: DatumMatch;
+}
+
+/** An absolute-accuracy claim, scoped to the envelope it was measured in. */
+export interface AccuracyClaim {
+  readonly id: string;
+  readonly rmseM: number;
+  readonly n: number;
+  readonly envelope: ValidationEnvelope;
+  /**
+   * True when the checkpoint truth and the gridded points share an upstream
+   * solution (the same photogrammetric bundle, the same lidar adjustment), so
+   * the comparison leans toward self-consistency rather than full independence.
+   */
+  readonly sharedSolutionWithReference: boolean;
+}
+
+/** Datum-match strength ordering: matched > reconciled > unreconciled ≈ unknown. */
+const DATUM_RANK: Record<DatumMatch, number> = { matched: 3, reconciled: 2, unreconciled: 1, unknown: 0 };
+function datumAtLeast(scan: DatumMatch, required: DatumMatch): boolean {
+  return DATUM_RANK[scan] >= DATUM_RANK[required];
+}
+
+/**
+ * Whether a scan falls inside the envelope a claim was validated in. Fail-closed:
+ * any unknown scan fact, or a datum situation weaker than the validation's, means
+ * NOT covered.
+ */
+export function isWithinEnvelope(env: ValidationEnvelope, scan: ScanContext): boolean {
+  if (scan.biome === 'unknown' || scan.reliefBand === 'unknown' || scan.sensorClass === 'unknown' || scan.datumMatch === 'unknown') {
+    return false;
+  }
+  if (!datumAtLeast(scan.datumMatch, env.datumMatch)) return false;
+  return env.biomes.includes(scan.biome)
+    && env.reliefBands.includes(scan.reliefBand)
+    && env.sensorClasses.includes(scan.sensorClass);
+}
+
+export interface AccuracyDecision {
+  /** May a survey-grade accuracy figure be presented for this scan? */
+  readonly allowed: boolean;
+  readonly rmseM?: number;
+  readonly reason: string;
+  /** Greppable UPPER_SNAKE code. */
+  readonly reasonCode: string;
+}
+
+/**
+ * Fail-closed accuracy display: return the figure ONLY when the scan is inside
+ * the claim's validated envelope; otherwise refuse with a reason. A refusal is
+ * not "no accuracy" — it is "this scan was not validated", which the UI states
+ * rather than showing a number that does not apply.
+ */
+export function accuracyFigureFor(scan: ScanContext, claim: AccuracyClaim): AccuracyDecision {
+  if (!isWithinEnvelope(claim.envelope, scan)) {
+    return {
+      allowed: false,
+      reason: 'This scan is outside the conditions the accuracy figure was validated under (biome / relief / sensor / datum), so no survey-grade figure is shown.',
+      reasonCode: 'OUTSIDE_ENVELOPE',
+    };
+  }
+  return { allowed: true, rmseM: claim.rmseM, reason: `Within the validated envelope (N=${claim.n}).`, reasonCode: 'WITHIN_ENVELOPE' };
+}
+
+/**
+ * Cap a checkpoint leg's evidence level for the shared-solution confounder: a
+ * comparison whose truth shares an upstream solution with the gridded points is
+ * not externally independent, so it cannot reach the external tier — it holds at
+ * the cross-implementation tier. A claim without the confounder is unchanged.
+ */
+export function confounderCappedLevel(nominal: EvidenceLevel, claim: AccuracyClaim): EvidenceLevel {
+  if (claim.sharedSolutionWithReference && evidenceRank(nominal) >= evidenceRank('E5_EXTERNALLY_VALIDATED')) {
+    return 'E4_CROSS_IMPLEMENTATION_VALIDATED';
+  }
+  return nominal;
+}

--- a/tests/accuracyEnvelope.test.ts
+++ b/tests/accuracyEnvelope.test.ts
@@ -1,0 +1,82 @@
+/**
+ * accuracyEnvelope.test.ts — an accuracy figure only shows inside its validated
+ * envelope, and the shared-solution confounder caps its evidence level.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isWithinEnvelope, accuracyFigureFor, confounderCappedLevel,
+  type AccuracyClaim, type ScanContext,
+} from '../src/validation/accuracyEnvelope';
+
+// The Marsh Island result: measured on coastal salt marsh, flat relief, UAS
+// photogrammetry, matched vertical datum — and the ground shares the Metashape
+// solution with the reference, so it carries the shared-solution confounder.
+const MARSH: AccuracyClaim = {
+  id: 'DTM-VERTICAL-ABSOLUTE/marsh-island',
+  rmseM: 0.028,
+  n: 101,
+  envelope: {
+    biomes: ['coastal-marsh'],
+    reliefBands: ['flat'],
+    sensorClasses: ['uav-photogrammetry'],
+    datumMatch: 'matched',
+  },
+  sharedSolutionWithReference: true,
+};
+
+const marshLikeScan: ScanContext = { biome: 'coastal-marsh', reliefBand: 'flat', sensorClass: 'uav-photogrammetry', datumMatch: 'matched' };
+
+describe('accuracy figures only transfer inside the validated envelope', () => {
+  it('shows the figure for a scan matching the validated conditions', () => {
+    expect(isWithinEnvelope(MARSH.envelope, marshLikeScan)).toBe(true);
+    const d = accuracyFigureFor(marshLikeScan, MARSH);
+    expect(d.allowed).toBe(true);
+    expect(d.rmseM).toBe(0.028);
+  });
+
+  it('refuses the figure for a different biome (steep forest) — no overgeneralisation', () => {
+    const forest: ScanContext = { biome: 'forest', reliefBand: 'steep', sensorClass: 'airborne-lidar', datumMatch: 'matched' };
+    expect(isWithinEnvelope(MARSH.envelope, forest)).toBe(false);
+    const d = accuracyFigureFor(forest, MARSH);
+    expect(d.allowed).toBe(false);
+    expect(d.reasonCode).toBe('OUTSIDE_ENVELOPE');
+    expect(d.rmseM).toBeUndefined();
+  });
+
+  it('refuses when relief differs even if biome/sensor match (flat validation, steep scan)', () => {
+    const steep: ScanContext = { ...marshLikeScan, reliefBand: 'steep' };
+    expect(accuracyFigureFor(steep, MARSH).allowed).toBe(false);
+  });
+
+  it('fails closed on any unknown scan fact', () => {
+    for (const bad of [
+      { ...marshLikeScan, biome: 'unknown' as const },
+      { ...marshLikeScan, reliefBand: 'unknown' as const },
+      { ...marshLikeScan, sensorClass: 'unknown' as const },
+      { ...marshLikeScan, datumMatch: 'unknown' as const },
+    ]) {
+      expect(accuracyFigureFor(bad, MARSH).allowed).toBe(false);
+    }
+  });
+
+  it('refuses when the scan datum is weaker than the validation (matched-validated, unreconciled scan)', () => {
+    const weakDatum: ScanContext = { ...marshLikeScan, datumMatch: 'unreconciled' };
+    expect(isWithinEnvelope(MARSH.envelope, weakDatum)).toBe(false);
+  });
+});
+
+describe('shared-solution confounder caps the evidence level', () => {
+  it('a shared-solution checkpoint leg cannot reach the external tier — held at cross-implementation', () => {
+    expect(confounderCappedLevel('E5_EXTERNALLY_VALIDATED', MARSH)).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+  });
+
+  it('a genuinely independent checkpoint leg is not capped', () => {
+    const independent: AccuracyClaim = { ...MARSH, sharedSolutionWithReference: false };
+    expect(confounderCappedLevel('E5_EXTERNALLY_VALIDATED', independent)).toBe('E5_EXTERNALLY_VALIDATED');
+  });
+
+  it('the cap never RAISES a level (a lower nominal stays where it is)', () => {
+    expect(confounderCappedLevel('E3_SYNTHETICALLY_VALIDATED', MARSH)).toBe('E3_SYNTHETICALLY_VALIDATED');
+  });
+});


### PR DESCRIPTION
An absolute-accuracy figure (e.g. a DTM vertical RMSE) is measured on one biome, relief band, sensor class and vertical-datum situation. This carries that **validation envelope** with each accuracy claim and shows a survey-grade figure ONLY when the scan is inside it — failing closed on any unknown scan fact or a weaker datum-match, the same discipline OLV applies to unknown units and coverage.

It also carries the **shared-solution confounder**: a checkpoint leg whose truth shares an upstream solution with the gridded points (e.g. one photogrammetric bundle) is not externally independent and is capped below the external tier at cross-implementation.

Pure, validation-only (bundle unchanged). 8 unit tests. Encodes the scientific-critical-thinking findings (single-biome indirectness, shared-solution confounder) as a permanent fail-closed property.