### PR TITLE
docs(collab): citation + research-collaboration invitation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -99,6 +99,16 @@ access their task needs, reviewed again when their role changes. Branch
 protection applies to everyone: pull requests, passing checks, resolved
 conversations, and linear history are required, with no direct pushes to `main`.
 
+## Scientific contributions
+
+Not every contribution is code. Independent reproduction, a surveyed-checkpoint
+dataset, a cross-check against ArcGIS or PDAL, or a careful read of a validation
+report all help, and they feed the evidence record the releases depend on.
+[docs/collaboration/RESEARCH_COLLABORATION.md](../docs/collaboration/RESEARCH_COLLABORATION.md)
+explains what is useful and what we can offer in return. Open an issue or a
+discussion to start, or email <info@aurtech.mx> for data you cannot post
+publicly.
+
 ## A note on honesty
 
 Do not describe a format, feature, or accuracy level as supported unless the

--- a/README.md
+++ b/README.md
@@ -406,6 +406,12 @@ OpenLiDARViewer stands on a lot of open work, and we're grateful for it.
 
 **Standards & formats:** ASPRS (LAS/LAZ), the Khronos Group (glTF/GLB), ASTM (E57), and OGC / IOGP-EPSG (coordinate systems). Particular thanks to **Howard Butler** and **Hobu, Inc.**, whose work on laz-perf, COPC, and Entwine this viewer relies on.
 
+## Citation & research collaboration
+
+OpenLiDARViewer is MIT-licensed so its code and methods stay open. The licence lets you use, change, and redistribute the software, and it says nothing about citation. Citation is a separate request: if the software, its validation framework, algorithms, or documentation helped your research, software, thesis, or commercial work, please cite it. GitHub's "Cite this repository" button reads [CITATION.cff](CITATION.cff) and gives you the current reference, including BibTeX.
+
+Being cited is the minimum; working together is the better outcome. Independent reproduction, new surveyed-checkpoint datasets, terrain and contour cross-checks against a reference tool, and method comparisons feed the evidence record directly, and a result that holds or fails on your data tells us more than one that only holds on ours. If you have a dataset or a study in mind, open an issue or a discussion. The specifics, and what we can offer in return, are in [docs/collaboration/RESEARCH_COLLABORATION.md](docs/collaboration/RESEARCH_COLLABORATION.md).
+
 ## License
 
 MIT. See [LICENSE](LICENSE). If you use OpenLiDARViewer in research, a [CITATION.cff](CITATION.cff) is included. Developed by Aurtech ([aurtech.mx](https://aurtech.mx)).

--- a/docs/collaboration/RESEARCH_COLLABORATION.md
+++ b/docs/collaboration/RESEARCH_COLLABORATION.md
@@ -1,0 +1,51 @@
+# Research collaboration
+
+OpenLiDARViewer ships with an evidence record attached to it: released numbers
+are meant to be reproducible, and the validation legs are public. That record
+gets stronger when people outside the project test it.
+
+This page is for anyone who wants to do that, and for anyone whose own work
+could fold into it.
+
+## Ways to contribute scientifically
+
+- Reproduce a result. Run the offline suite from a clean clone
+  ([REVIEWER_QUICKSTART.md](../../REVIEWER_QUICKSTART.md)) and say where your
+  numbers differ from the reported ones. A mismatch is worth more than a match.
+- Bring a dataset. Surveyed checkpoints, field-measured terrain, or a public
+  cloud with a declared coordinate system let the tool be tested against ground
+  truth instead of against itself. Only send data you are free to redistribute.
+- Cross-check a method. Compare a DTM/DSM, contours, slope, or a measurement
+  against ArcGIS, CloudCompare, PDAL, or GDAL, and report both the agreement and
+  the disagreement.
+- Review the methodology. Read the validation reports and the method notes and
+  say what is under-specified, unconvincing, or wrong.
+
+Studies that test the viewer outside the data and assumptions the core project
+already used are the most useful of all. A result that holds only on our own
+fixtures tells us less than one that holds, or fails, on yours. If that means
+the reported figure moves, so be it; a corrected number is the point.
+
+## What we can offer in return
+
+Independent validation that gets folded in is credited to whoever did it, and
+cited in the evidence record. If you are writing the work up, a co-authored
+validation note is on the table rather than having the same result sit in two
+disconnected places. None of this is an obligation. It is how we would rather
+work, and it costs you nothing to ask.
+
+## How to start
+
+Open an issue or a discussion on
+[GitHub](https://github.com/Aurtechmx/openlidarviewer), describing what you want
+to test and what data you have. Email <info@aurtech.mx> first for anything you
+would rather not post publicly.
+
+## Citing the work
+
+Use the **Cite this repository** button on the repository page, which reads
+[CITATION.cff](../../CITATION.cff) and gives you the current reference, including
+BibTeX. Cite the software version and its DOI when you use the tool. Once the
+OpenLiDARViewer paper is published it will carry its own reference for the
+methodology, and `CITATION.cff` will point to it; until then the software
+citation covers both.


### PR DESCRIPTION
Adds the citation and research-collaboration framing requested before publication, in the repo's existing voice. MIT stays the governing licence; citation is presented as a request, not a licence restriction.

## What's here
- **README** — new `Citation & research collaboration` section before License: how to cite (GitHub's Cite-this-repository button over CITATION.cff), and an open invitation to reproduce, bring datasets, cross-check methods, and collaborate.
- **docs/collaboration/RESEARCH_COLLABORATION.md** — the specifics: reproduction, surveyed-checkpoint datasets, method cross-checks vs ArcGIS/CloudCompare/PDAL/GDAL, methodology review, plus what we offer back (credit in the evidence record, co-authored validation notes). Points at the eventual paper reference once published.
- **.github/CONTRIBUTING.md** — a `Scientific contributions` section noting non-code contributions and linking the collaboration doc.

## Notes
- `CITATION.cff` is left unchanged here. The version bump and the `preferred-citation` → paper DOI belong to the release PR / post-publication, to avoid colliding with `release/v0.6.5`.
- All three files pass the repo prose gate (`node _private/check-ai-writing.mjs`): no AI-writing tells.