### PR TITLE
chore(ci): exclude the main.ts composition root from coverage measurement

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -36,3 +36,8 @@ ignore:
   - "scripts/**"
   - "docs-site/**"
   - "**/*.d.ts"
+  # The composition root: wiring only, decomposed under a shrink-only ratchet
+  # (docs/architecture/architecture-map.md). Its logic lives in testable modules;
+  # a coverage percentage over the wiring says nothing about whether the software
+  # works, and each new binding here otherwise drops patch coverage on unrelated PRs.
+  - "src/main.ts"


### PR DESCRIPTION
The advisory Codecov `coverage` check goes red whenever a PR adds a wiring line to `main.ts` (seen on #373/#374/#375). main.ts is the composition root — wiring only, decomposed under a shrink-only ratchet, its logic extracted into testable modules — so a coverage number over it says nothing about correctness. Excludes `src/main.ts` from the Codecov measurement, alongside the `tests/`/`scripts/` exclusions already present. Coverage is already `informational` (non-blocking); the release gate's mandatory coverage stage is unaffected.