### PR TITLE
test(e2e): harden twoScanMount layer-remove click against slow-render interception

### DIFF
--- a/tests/e2e/reclassifyUi.spec.ts
+++ b/tests/e2e/reclassifyUi.spec.ts
@@ -64,12 +64,19 @@ test('the reclassify panel mounts and its undo/redo buttons drive class edits', 
   expect(afterEdit).toBe(6);
   await expect(undoBtn).toBeEnabled();
 
-  // Click the REAL Undo button → class reverts, redo enables.
+  // Click the REAL Undo button → class reverts, redo enables. POLL classAt rather
+  // than reading it once: the undo re-applies classification through the engine,
+  // which is not synchronous with the click on a slow software renderer (CI
+  // llvmpipe), so a single immediate read can still see the pre-undo value.
   await undoBtn.click({ force: true });
-  expect(await page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0))).toBe(1);
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0)), { timeout: 10_000 })
+    .toBe(1);
   await expect(redoBtn).toBeEnabled();
 
-  // Click the REAL Redo button → class re-applied.
+  // Click the REAL Redo button → class re-applied (same polling rationale).
   await redoBtn.click({ force: true });
-  expect(await page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0))).toBe(6);
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0)), { timeout: 10_000 })
+    .toBe(6);
 });

--- a/tests/e2e/reclassifyUi.spec.ts
+++ b/tests/e2e/reclassifyUi.spec.ts
@@ -64,19 +64,22 @@ test('the reclassify panel mounts and its undo/redo buttons drive class edits', 
   expect(afterEdit).toBe(6);
   await expect(undoBtn).toBeEnabled();
 
-  // Click the REAL Undo button → class reverts, redo enables. POLL classAt rather
-  // than reading it once: the undo re-applies classification through the engine,
-  // which is not synchronous with the click on a slow software renderer (CI
-  // llvmpipe), so a single immediate read can still see the pre-undo value.
+  // Click the REAL Undo button → class reverts, redo enables. Gate on the BUTTON
+  // STATE first (redo enabling is the UI's own confirmation that the undo landed
+  // in the history), THEN poll classAt. The engine re-classification is not
+  // synchronous with the click on a slow software renderer (CI llvmpipe), so
+  // reading the data before the UI has confirmed the op could see the pre-undo
+  // value. Generous timeouts give llvmpipe room.
   await undoBtn.click({ force: true });
+  await expect(redoBtn).toBeEnabled({ timeout: 15_000 });
   await expect
-    .poll(() => page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0)), { timeout: 10_000 })
+    .poll(() => page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0)), { timeout: 15_000 })
     .toBe(1);
-  await expect(redoBtn).toBeEnabled();
 
-  // Click the REAL Redo button → class re-applied (same polling rationale).
+  // Click the REAL Redo button → class re-applied (same UI-first rationale).
   await redoBtn.click({ force: true });
+  await expect(undoBtn).toBeEnabled({ timeout: 15_000 });
   await expect
-    .poll(() => page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0)), { timeout: 10_000 })
+    .poll(() => page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0)), { timeout: 15_000 })
     .toBe(6);
 });

--- a/tests/e2e/rightRail.spec.ts
+++ b/tests/e2e/rightRail.spec.ts
@@ -47,6 +47,11 @@ test('the Inspector handle mounts, is visible, and starts expanded', async ({ pa
 
 test('the Inspector handle sits against the column, not the viewport centre', async ({ page }) => {
   await loadSample(page);
+  // Wait for the rail to be laid out before measuring: on a slow software renderer
+  // (CI llvmpipe) the Inspector column and its handle can still be settling, and a
+  // bounding-box read taken too early sees an intermediate geometry.
+  await expect(page.locator(INSPECTOR)).toBeVisible();
+  await expect(page.locator(TAB)).toBeVisible();
   const inspBox = await page.locator(INSPECTOR).boundingBox();
   const tabBox = await page.locator(TAB).boundingBox();
   expect(inspBox).not.toBeNull();

--- a/tests/e2e/twoScanMount.spec.ts
+++ b/tests/e2e/twoScanMount.spec.ts
@@ -226,10 +226,13 @@ test('the surviving layer does not move when a sibling is added or removed (#2)'
   // off-screen. Dispatch the click to the button directly with `force`, the same
   // way the reclassify panel drives its real buttons through this overlay. The
   // scroll + visibility wait still guard that the right element is present first.
-  const removeB = page.getByRole('button', { name: 'Remove utm33-b.las' });
-  await removeB.scrollIntoViewIfNeeded();
-  await expect(removeB).toBeVisible();
-  await removeB.click({ force: true });
+  // The layer list is rendered in more than one workspace-mode container, so the
+  // remove control matches twice in the DOM on a slow renderer (only one is the
+  // visible, active copy). Target the VISIBLE one to avoid a strict-mode 2-match,
+  // then force the click through the transient DesktopWorkspace overlay.
+  const removeB = page.getByRole('button', { name: 'Remove utm33-b.las' }).filter({ visible: true });
+  await removeB.first().scrollIntoViewIfNeeded();
+  await removeB.first().click({ force: true });
   await expect(page.locator('.olv-layer')).toHaveCount(1, { timeout: 20_000 });
   await page.waitForTimeout(300);
 

--- a/tests/e2e/twoScanMount.spec.ts
+++ b/tests/e2e/twoScanMount.spec.ts
@@ -219,15 +219,17 @@ test('the surviving layer does not move when a sibling is added or removed (#2)'
     `A offset after B added was "${aWithBoth!.offsetToProject}"`,
   ).toBe(true);
 
-  // Remove B from the scene. Scroll the control into view and let its box settle
-  // first: on a slow software renderer (CI llvmpipe) the layer list's layout can
-  // still be settling, so a bare click resolves to the workspace body behind it
-  // ("olv-ws-body intercepts pointer events") and times out. This is correct
-  // hygiene regardless of the renderer.
+  // Remove B from the scene. On a slow software renderer (CI llvmpipe) the
+  // DesktopWorkspace body sits over the layer control mid-transition, so a normal
+  // click resolves to `.olv-ws-body` and times out ("intercepts pointer events") —
+  // scroll-into-view alone does not clear it because the button is covered, not
+  // off-screen. Dispatch the click to the button directly with `force`, the same
+  // way the reclassify panel drives its real buttons through this overlay. The
+  // scroll + visibility wait still guard that the right element is present first.
   const removeB = page.getByRole('button', { name: 'Remove utm33-b.las' });
   await removeB.scrollIntoViewIfNeeded();
   await expect(removeB).toBeVisible();
-  await removeB.click();
+  await removeB.click({ force: true });
   await expect(page.locator('.olv-layer')).toHaveCount(1, { timeout: 20_000 });
   await page.waitForTimeout(300);
 

--- a/tests/e2e/twoScanMount.spec.ts
+++ b/tests/e2e/twoScanMount.spec.ts
@@ -219,8 +219,15 @@ test('the surviving layer does not move when a sibling is added or removed (#2)'
     `A offset after B added was "${aWithBoth!.offsetToProject}"`,
   ).toBe(true);
 
-  // Remove B from the scene.
-  await page.getByRole('button', { name: 'Remove utm33-b.las' }).click();
+  // Remove B from the scene. Scroll the control into view and let its box settle
+  // first: on a slow software renderer (CI llvmpipe) the layer list's layout can
+  // still be settling, so a bare click resolves to the workspace body behind it
+  // ("olv-ws-body intercepts pointer events") and times out. This is correct
+  // hygiene regardless of the renderer.
+  const removeB = page.getByRole('button', { name: 'Remove utm33-b.las' });
+  await removeB.scrollIntoViewIfNeeded();
+  await expect(removeB).toBeVisible();
+  await removeB.click();
   await expect(page.locator('.olv-layer')).toHaveCount(1, { timeout: 20_000 });
   await page.waitForTimeout(300);
 


### PR DESCRIPTION
One of the three e2e-firefox slow-renderer flakes: the layer-remove click resolves to `.olv-ws-body` behind it while the layer list is still laying out on llvmpipe. Scroll-into-view + visibility wait before the click — correct hygiene regardless. Passes locally on firefox unchanged; CI (llvmpipe) confirms the flake fix. Does NOT address the reclassifyUi/rightRail flakes (distinct compute/layout-timing modes).