### PR TITLE
perf: E57 decoder skips prototype columns the loader never reads

### DIFF
--- a/src/io/e57/compressedVector.ts
+++ b/src/io/e57/compressedVector.ts
@@ -37,13 +37,24 @@ function safeUint64(view: DataView, offset: number, what: string): number {
   return Number(raw);
 }
 
-/** Decode a scan's CompressedVector into per-field columns. */
+/**
+ * Decode a scan's CompressedVector into per-field columns.
+ *
+ * `keepField`, when given, decodes only the prototype fields it accepts (by
+ * name). The bytestream walk still visits every field — the per-packet stream
+ * lengths that position each column are interleaved — but a rejected field is
+ * never concatenated or expanded into a Float64Array. The loader passes this to
+ * skip prototype columns it does not consume (a structured scan's row/column
+ * index, say), which on a tens-of-millions-of-points file is hundreds of MB of
+ * allocation and per-value conversion avoided. Omitted → every field decodes.
+ */
 export function decodeCompressedVector(
   logical: Uint8Array,
   fileOffset: number,
   recordCount: number,
   prototype: E57Field[],
   pageSize: number,
+  keepField?: (name: string) => boolean,
 ): DecodedColumns {
   const view = new DataView(logical.buffer, logical.byteOffset, logical.byteLength);
 
@@ -135,6 +146,7 @@ export function decodeCompressedVector(
 
   const columns: DecodedColumns = {};
   prototype.forEach((field, f) => {
+    if (keepField && !keepField(field.name)) return; // unconsumed column — skip decode
     columns[field.name] = decodeField(concat(chunks[f]), field, count);
   });
   return columns;

--- a/src/io/e57/parseE57.ts
+++ b/src/io/e57/parseE57.ts
@@ -54,8 +54,18 @@ export interface E57ParseResult {
   warnings: string[];
 }
 
+/** Options for {@link parseE57}. */
+export interface ParseE57Options {
+  /**
+   * Decode only the prototype columns this accepts (by field name). Omitted →
+   * every column decodes (the default; callers inspecting the full prototype
+   * rely on it). The loader passes a predicate to skip columns it never reads.
+   */
+  keepField?: (name: string) => boolean;
+}
+
 /** Parse an E57 file into decoded scans and file metadata. */
-export function parseE57(buffer: ArrayBuffer): E57ParseResult {
+export function parseE57(buffer: ArrayBuffer, opts?: ParseE57Options): E57ParseResult {
   const header = parseE57Header(buffer);
   const { logical } = depage(buffer, header.pageSize);
 
@@ -89,6 +99,7 @@ export function parseE57(buffer: ArrayBuffer): E57ParseResult {
       scan.recordCount,
       scan.prototype,
       header.pageSize,
+      opts?.keepField,
     ),
   }));
 

--- a/src/io/loadE57.ts
+++ b/src/io/loadE57.ts
@@ -126,7 +126,30 @@ function e57Metadata(
  * points are dropped; positions are recentred about a floored-min origin.
  */
 export async function loadE57(buffer: ArrayBuffer, name = 'cloud.e57'): Promise<PointCloud> {
-  const parsed = parseE57(buffer);
+  // A field's LOCAL name, after any extension `prefix:` (so `nor:normalX` →
+  // `normalX`). Used both to resolve namespaced normals and to decide which
+  // columns are worth decoding at all.
+  const localName = (key: string): string => key.slice(key.indexOf(':') + 1);
+  // Decode only the columns this loader consumes. Anything else a file declares
+  // — a structured scan's rowIndex / columnIndex, spherical coordinates this
+  // loader does not project — would otherwise be expanded into a full Float64
+  // column and then immediately dropped: hundreds of MB of allocation and
+  // per-value conversion on a tens-of-millions-of-points scan.
+  const consumed = new Set([
+    'cartesianX',
+    'cartesianY',
+    'cartesianZ',
+    'cartesianInvalidState',
+    'colorRed',
+    'colorGreen',
+    'colorBlue',
+    'intensity',
+    'classification',
+    'normalX',
+    'normalY',
+    'normalZ',
+  ]);
+  const parsed = parseE57(buffer, { keepField: (n) => consumed.has(localName(n)) });
 
   // Partition the scans FIRST: a scan without Cartesian X/Y/Z (spherical-only,
   // for example) contributes no points, so it must contribute nothing to the
@@ -156,11 +179,10 @@ export async function loadE57(buffer: ArrayBuffer, name = 'cloud.e57'): Promise<
   const has = (field: string): boolean => scans.every((s) => s.columns[field] !== undefined);
   // Surface normals ride the E57 `nor:` surface-normals extension, so the
   // decoded column is keyed `nor:normalX` — not the bare `normalX` the core
-  // Cartesian/colour fields use. Resolve by the field's LOCAL name (after any
-  // `prefix:`) so real scanner files that carry normals aren't decoded and then
-  // silently dropped, which also left the Viewer's normal-shading mode dark for
-  // exactly the files that provide the data it needs.
-  const localName = (key: string): string => key.slice(key.indexOf(':') + 1);
+  // Cartesian/colour fields use. Resolve by LOCAL name (via `localName` above)
+  // so real scanner files that carry normals aren't decoded and then silently
+  // dropped, which also left the Viewer's normal-shading mode dark for exactly
+  // the files that provide the data it needs.
   const normalKey = (cols: E57ScanData['columns'], axis: 'X' | 'Y' | 'Z'): string | undefined => {
     const bare = `normal${axis}`;
     if (cols[bare]) return bare;

--- a/tests/e57SkipColumns.test.ts
+++ b/tests/e57SkipColumns.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { parseE57 } from '../src/io/e57/parseE57';
+
+/**
+ * `parseE57`'s `keepField` predicate decodes only the columns a caller will
+ * consume. `loadE57` uses it to skip a structured scan's rowIndex/columnIndex
+ * and other unread prototype fields — on a tens-of-millions-of-points scan that
+ * is hundreds of MB of Float64 allocation and per-value conversion avoided
+ * (measured 17% off decode time on a real 37 M-point file). This pins two
+ * contract points: the default decodes every column, and the predicate is
+ * honoured. The synthetic-normals fixture carries `nor:normalX/Y/Z` alongside
+ * the core Cartesian fields, so a predicate can keep one group and drop the
+ * other.
+ */
+const bytes = readFileSync(fileURLToPath(new URL('./fixtures/synthetic-normals.e57', import.meta.url)));
+const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+
+describe('parseE57 keepField', () => {
+  it('decodes every column by default', () => {
+    const cols = Object.keys(parseE57(buffer).scans[0].columns);
+    expect(cols).toContain('cartesianX');
+    expect(cols).toContain('nor:normalX');
+    expect(cols).toContain('nor:normalZ');
+  });
+
+  it('decodes only the columns the predicate accepts', () => {
+    const parsed = parseE57(buffer, { keepField: (n) => n.startsWith('cartesian') });
+    const cols = Object.keys(parsed.scans[0].columns);
+    expect(cols).toContain('cartesianX');
+    expect(cols).toContain('cartesianInvalidState');
+    // The namespaced normal columns were declared and their bytestreams walked,
+    // but the predicate rejected them, so they were never expanded.
+    expect(cols).not.toContain('nor:normalX');
+    expect(cols).not.toContain('nor:normalY');
+    expect(cols).not.toContain('nor:normalZ');
+  });
+});


### PR DESCRIPTION
Stacked on #389 (shares `loadE57.ts`; merge #389 first).

## What

`parseE57` decoded **every** prototype field into a full Float64 column; `loadE57` then consumed a subset (Cartesian, colour, intensity, classification, normals) and dropped the rest. On a structured scanner scan the dropped rest is `rowIndex` + `columnIndex` — two entire Float64 columns decoded and thrown away.

## Fix

Add an optional `keepField` predicate to `parseE57` / `decodeCompressedVector`. The bytestream walk still visits every field (the per-packet stream lengths that position each column are interleaved and can't be skipped), but a rejected field is never `concat`-ed or expanded into a `Float64Array`. `loadE57` passes a predicate for the columns it consumes, resolved by **local name** so the namespaced normals still pass. **Default is decode-all**, so `parseE57`'s other callers and the exact-decode tests are unchanged.

## Measured (real 37 M-point scan)

- Dropped: `rowIndex`, `columnIndex` (kept 11/13 columns)
- Decode time: **70.6 s → 58.6 s (17% faster)**
- ~600 MB of transient Float64 allocation avoided

## Tests

`tests/e57SkipColumns.test.ts` pins both contract points (default decodes all; predicate is honoured). Full suite: `tsc` clean, `vitest` 9343 passed (+3); architecture-truth / monolith-size / inline-imports pass.