### PR TITLE
feat: unify planar ICP — registration model selects the live solver

### DIFF
--- a/src/registration/planarIcp.ts
+++ b/src/registration/planarIcp.ts
@@ -18,16 +18,9 @@
  * than two implementations.
  */
 
-import { icpRegister, applyIcp } from '../terrain/change/icpRegister';
-import type { IcpOptions, IcpResult, Vec3 } from '../terrain/change/icpRegister';
-
-export { icpRegister, applyIcp };
-export type { IcpOptions, IcpResult, Vec3 };
-
-/**
- * The planar-constrained (yaw + XY translation) ICP the registration model
- * selects for airborne same-area epochs. A registration-layer alias for
- * `icpRegister`; callers lock Z by zeroing the solved `translation[2]` so
- * genuine elevation change is not absorbed into the fit.
- */
-export const planarIcpRegister = icpRegister;
+// Direct `export … from` re-exports (no intermediate import) so this seam adds
+// no wrapper to maintain. `icpRegister as planarIcpRegister` is the registration
+// layer's alias for the same solver: callers lock Z by zeroing the solved
+// `translation[2]` so genuine elevation change is not absorbed into the fit.
+export { icpRegister, applyIcp, icpRegister as planarIcpRegister } from '../terrain/change/icpRegister';
+export type { IcpOptions, IcpResult, Vec3 } from '../terrain/change/icpRegister';

--- a/src/registration/planarIcp.ts
+++ b/src/registration/planarIcp.ts
@@ -1,0 +1,33 @@
+/**
+ * planarIcp.ts — the registration layer's canonical planar-constrained ICP.
+ *
+ * Two implementations of ICP grew up apart: the generic registration layer here
+ * (`rigidSolve`, `generalIcp` — full 6-DOF) and a planar, Z-locked solver under
+ * `terrain/change` that already ships wired to the "Compare elevation" epoch
+ * pipeline. `registrationModel` used to refuse the planar case with
+ * `PLANAR_ICP_NOT_IMPLEMENTED` on the grounds that "no planar-constrained solver
+ * exists under src/registration" — which was true only because the two trees
+ * never referenced each other, not because the solver was missing.
+ *
+ * This module is the single seam that resolves that split: it re-exports the
+ * existing, tested planar solver (`icpRegister` — a full 3-D translation plus a
+ * yaw about the world up axis, applied by callers with Z locked so a real
+ * vertical change is preserved) under the registration layer's vocabulary. The
+ * math is NOT duplicated or moved — the live change-detection path keeps calling
+ * the same function — so there is one planar solver with two import homes rather
+ * than two implementations.
+ */
+
+import { icpRegister, applyIcp } from '../terrain/change/icpRegister';
+import type { IcpOptions, IcpResult, Vec3 } from '../terrain/change/icpRegister';
+
+export { icpRegister, applyIcp };
+export type { IcpOptions, IcpResult, Vec3 };
+
+/**
+ * The planar-constrained (yaw + XY translation) ICP the registration model
+ * selects for airborne same-area epochs. A registration-layer alias for
+ * `icpRegister`; callers lock Z by zeroing the solved `translation[2]` so
+ * genuine elevation change is not absorbed into the fit.
+ */
+export const planarIcpRegister = icpRegister;

--- a/src/registration/registrationModel.ts
+++ b/src/registration/registrationModel.ts
@@ -11,7 +11,8 @@
  *    constrained to the horizontal plane (x, y, yaw) so it CANNOT absorb real
  *    elevation change — subsidence, uplift, erosion — into a vertical shift. A
  *    full 6-DOF fit would minimise residual by eating the very signal being
- *    measured.
+ *    measured. The solver lives at `./planarIcp` (a re-export of the tested
+ *    `terrain/change` planar `icpRegister`), so this case is allowed, not withheld.
  *  - FULL 6-DOF. Terrestrial or object scans with no shared frame — solve all
  *    six degrees of freedom.
  *
@@ -64,11 +65,11 @@ export function selectRegistrationModel(inp: RegistrationInputs): RegistrationDe
 
   // Airborne change-detection epochs WANT planar ICP (yaw + horizontal
   // translation, Z locked) so vertical change is preserved rather than absorbed
-  // into a Z shift. That solver is not implemented — no planar-constrained ICP
-  // exists under src/registration — so the model is named but registration is
-  // WITHHELD rather than run as full 6-DOF, which would defeat the purpose.
+  // into a Z shift. That solver exists — `src/registration/planarIcp` re-exports
+  // the tested planar `icpRegister` already wired to the epoch-compare pipeline —
+  // so the planar model is now selected and allowed rather than withheld.
   if (inp.capture === 'airborne' && inp.sameAreaEpochs) {
-    return { model: 'planar-icp', allowed: false, reasonCode: 'PLANAR_ICP_NOT_IMPLEMENTED', reason: 'Two airborne epochs of the same area need a planar-constrained ICP (yaw + XY, Z locked) to preserve vertical change; that solver is not yet implemented, so registration is withheld rather than run as full 6-DOF (which would absorb real elevation change into a Z shift).' };
+    return { model: 'planar-icp', allowed: true, reasonCode: 'PLANAR_ICP_AVAILABLE', reason: 'Two airborne epochs of the same area register with a planar-constrained ICP (yaw + XY, Z locked) so vertical change is preserved rather than absorbed into a Z shift.' };
   }
 
   // Terrestrial / object → full 6-DOF.

--- a/tests/planarIcpReexport.test.ts
+++ b/tests/planarIcpReexport.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { icpRegister as sourceIcp } from '../src/terrain/change/icpRegister';
+import { icpRegister, planarIcpRegister, applyIcp } from '../src/registration/planarIcp';
+
+/**
+ * The registration layer's planar-ICP seam is a re-export of the ONE tested
+ * planar solver in terrain/change, not a second implementation. This pins that:
+ * the canonical registration entry is byte-identical to the live solver, so
+ * `registrationModel`'s "planar ICP is available at ./planarIcp" claim is true
+ * and there is no divergent copy to drift. The solver's numerical behaviour is
+ * covered by the terrain/change ICP tests.
+ */
+describe('src/registration/planarIcp seam', () => {
+  it('re-exports the live terrain/change planar solver (same function, no copy)', () => {
+    expect(icpRegister).toBe(sourceIcp);
+    expect(planarIcpRegister).toBe(sourceIcp);
+    expect(typeof applyIcp).toBe('function');
+  });
+});

--- a/tests/registrationModel.test.ts
+++ b/tests/registrationModel.test.ts
@@ -16,14 +16,14 @@ describe('selectRegistrationModel', () => {
     expect(d.reasonCode).toBe('PROVEN_FRAME_MOUNT');
   });
 
-  it('airborne same-area epochs → PLANAR ICP recommended but WITHHELD (solver not implemented)', () => {
+  it('airborne same-area epochs → PLANAR ICP selected and allowed (solver exists)', () => {
     const d = selectRegistrationModel({ ...base, capture: 'airborne', sameAreaEpochs: true });
-    // The model is named (planar ICP is the right method) but not authorized,
-    // because no planar-constrained solver exists — running full 6-DOF instead
-    // would absorb vertical change, so registration is withheld.
+    // The planar (yaw + XY, Z-locked) solver exists at src/registration/planarIcp
+    // (a re-export of the tested terrain/change icpRegister already wired to the
+    // epoch-compare pipeline), so the planar model is selected AND authorised.
     expect(d.model).toBe('planar-icp');
-    expect(d.allowed).toBe(false);
-    expect(d.reasonCode).toBe('PLANAR_ICP_NOT_IMPLEMENTED');
+    expect(d.allowed).toBe(true);
+    expect(d.reasonCode).toBe('PLANAR_ICP_AVAILABLE');
   });
 
   it('a full 6-DOF fit is NOT chosen for airborne epochs — the key change-detection guard', () => {

--- a/tests/supportIntegrityHardening.test.ts
+++ b/tests/supportIntegrityHardening.test.ts
@@ -94,13 +94,15 @@ describe('#9 rigidSolve refuses ill-posed correspondence sets', () => {
   });
 });
 
-describe('#10 planar-icp is recommended but not authorized (no solver)', () => {
-  it('withholds airborne-epoch registration rather than run 6-DOF', () => {
+describe('#10 planar-icp is selected and authorised (solver exists), never 6-DOF', () => {
+  it('registers airborne epochs with the planar solver rather than full 6-DOF', () => {
     const d = selectRegistrationModel({
       crsCompatible: false, originsKnown: false, capture: 'airborne', sameAreaEpochs: true,
     } as Parameters<typeof selectRegistrationModel>[0]);
     expect(d.model).toBe('planar-icp');
-    expect(d.allowed).toBe(false);
-    expect(d.reasonCode).toBe('PLANAR_ICP_NOT_IMPLEMENTED');
+    expect(d.allowed).toBe(true);
+    expect(d.reasonCode).toBe('PLANAR_ICP_AVAILABLE');
+    // The change-detection guard still holds: never full 6-DOF for airborne epochs.
+    expect(d.model).not.toBe('full-6dof');
   });
 });


### PR DESCRIPTION
Slice 1 of the validated v0.6.6 program. Resolves a real architectural contradiction surfaced by the baseline review.

## The contradiction

`registrationModel.selectRegistrationModel` refused airborne same-area epochs with `PLANAR_ICP_NOT_IMPLEMENTED`, on the grounds that "no planar-constrained solver exists under `src/registration`." But a tested planar (yaw + XY, **Z-locked**) ICP already ships in `src/terrain/change/icpRegister.ts` and runs live behind the Inspector "Compare elevation" epoch pipeline (`alignEpochs` zeroes the solved Z translation so real vertical change is preserved). The two ICP trees — the dormant generic `src/registration/*` and the live planar `terrain/change` one — simply never referenced each other.

## Change

- `src/registration/planarIcp.ts` — a re-export of that one solver under the registration layer's vocabulary. **No math is moved or duplicated**; the live change-detection path keeps calling the same `icpRegister`, so there is one solver with two import homes rather than two implementations.
- `registrationModel` airborne-epoch case → `allowed: true` / `PLANAR_ICP_AVAILABLE`, doc + comment corrected.

## Guard preserved

The change-detection invariant — never full 6-DOF for airborne epochs (which would absorb elevation change into the fit) — still holds and is re-asserted in the tests.

## Gate

`tsc` clean; `vitest` full suite green; `tests/planarIcpReexport.test.ts` pins the seam is the identical function (no divergent copy); layer-boundaries / architecture-truth / inline-imports pass. No product call site changes behaviour yet (the model had none) — this makes the model honest and gives a Registration Studio one canonical planar entry to consume.