### PR TITLE
fix: layer Remove button — thin scrollbar on .olv-ws-body (#401)

### DIFF
--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -100,8 +100,8 @@ jobs:
       - name: Deterministic end-to-end tests on Firefox (advisory)
         if: steps.glcheck.outputs.renderer == 'present'
         run: xvfb-run -a ./node_modules/.bin/playwright test --project=firefox
-      - name: Upload Playwright report on failure
-        if: failure()
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report-firefox
@@ -124,8 +124,8 @@ jobs:
         run: ./node_modules/.bin/playwright install --with-deps webkit
       - name: Deterministic end-to-end tests on WebKit (advisory)
         run: ./node_modules/.bin/playwright test --project=webkit
-      - name: Upload Playwright report on failure
-        if: failure()
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report-webkit

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,11 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  reporter: 'list',
+  // `list` for readable console output; in CI also emit an `html` report so the
+  // on-first-retry trace + failure screenshot are bundled into playwright-report/
+  // and uploadable (the advisory browser jobs are continue-on-error, so their
+  // failures are only diagnosable from an uploaded trace).
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
   use: {
     baseURL: 'http://localhost:4173',
     trace: 'on-first-retry',

--- a/src/styles/40-inspector.css
+++ b/src/styles/40-inspector.css
@@ -118,7 +118,10 @@
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
-.olv-layers { display: flex; flex-direction: column; gap: var(--space-sm); }
+/* End-clearance so the rightmost row control (the Remove ×) never sits under the
+ * workspace scroll gutter/scrollbar, which otherwise intercepts its click on
+ * browsers with classic space-consuming scrollbars (Firefox). See #401. */
+.olv-layers { display: flex; flex-direction: column; gap: var(--space-sm); padding-inline-end: var(--space-xs); }
 .olv-layer { display: flex; align-items: center; gap: var(--space-md); }
 .olv-layer input { accent-color: var(--accent); }
 .olv-layer-name {
@@ -140,7 +143,7 @@
 }
 .olv-layer-solo:hover, .olv-layer-lock:hover { color: var(--text); }
 .olv-layer-solo.is-active, .olv-layer-lock.is-active { color: var(--accent); }
-.olv-layer-x { background: none; border: none; color: var(--text-faint); font-size: var(--text-lg); line-height: 1; }
+.olv-layer-x { background: none; border: none; color: var(--text-faint); font-size: var(--text-lg); line-height: 1; cursor: pointer; padding: 0 var(--space-xs); }
 .olv-layer-x:hover { color: var(--text); }
 /* A layer whose CRS differs from the others — flag the row + badge. */
 .olv-layer-crs-mismatch .olv-layer-crs { color: var(--warn, #e0a030); }

--- a/src/styles/72-panel-rails.css
+++ b/src/styles/72-panel-rails.css
@@ -429,3 +429,26 @@
   .olv-export-panel, .olv-object-panel { transition: none; }
 }
 
+
+/* The v0.6.5 desktop workspace scroll body (.olv-ws-body, 73-desktop-workspace.css)
+   was added after the scrollbar-styling lists above and was missed by them. On
+   Firefox it therefore fell back to the wide platform-default scrollbar, which
+   overlapped the rightmost layer-row control (the Remove ×) and intercepted its
+   click — the twoScanMount:192 failure (#401). Overlay-scrollbar engines
+   (Chromium, WebKit, macOS) never showed it. Give this scroller the same thin
+   themed bar its sibling panels use, so the reserved gutter clears the row
+   controls on every engine. */
+@supports (-moz-appearance: none) {
+  .olv-ws-body {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--accent) 44%, var(--panel)) transparent;
+  }
+}
+.olv-ws-body::-webkit-scrollbar { width: 9px; height: 9px; }
+.olv-ws-body::-webkit-scrollbar-track { background: transparent; }
+.olv-ws-body::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent) 44%, var(--panel));
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -1130,7 +1130,10 @@ body.olv-theme-light .olv-empty::before {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
-.olv-layers { display: flex; flex-direction: column; gap: var(--space-sm); }
+/* End-clearance so the rightmost row control (the Remove ×) never sits under the
+ * workspace scroll gutter/scrollbar, which otherwise intercepts its click on
+ * browsers with classic space-consuming scrollbars (Firefox). See #401. */
+.olv-layers { display: flex; flex-direction: column; gap: var(--space-sm); padding-inline-end: var(--space-xs); }
 .olv-layer { display: flex; align-items: center; gap: var(--space-md); }
 .olv-layer input { accent-color: var(--accent); }
 .olv-layer-name {
@@ -1152,7 +1155,7 @@ body.olv-theme-light .olv-empty::before {
 }
 .olv-layer-solo:hover, .olv-layer-lock:hover { color: var(--text); }
 .olv-layer-solo.is-active, .olv-layer-lock.is-active { color: var(--accent); }
-.olv-layer-x { background: none; border: none; color: var(--text-faint); font-size: var(--text-lg); line-height: 1; }
+.olv-layer-x { background: none; border: none; color: var(--text-faint); font-size: var(--text-lg); line-height: 1; cursor: pointer; padding: 0 var(--space-xs); }
 .olv-layer-x:hover { color: var(--text); }
 /* A layer whose CRS differs from the others — flag the row + badge. */
 .olv-layer-crs-mismatch .olv-layer-crs { color: var(--warn, #e0a030); }

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -4129,6 +4129,29 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   .olv-export-panel, .olv-object-panel { transition: none; }
 }
 
+
+/* The v0.6.5 desktop workspace scroll body (.olv-ws-body, 73-desktop-workspace.css)
+   was added after the scrollbar-styling lists above and was missed by them. On
+   Firefox it therefore fell back to the wide platform-default scrollbar, which
+   overlapped the rightmost layer-row control (the Remove ×) and intercepted its
+   click — the twoScanMount:192 failure (#401). Overlay-scrollbar engines
+   (Chromium, WebKit, macOS) never showed it. Give this scroller the same thin
+   themed bar its sibling panels use, so the reserved gutter clears the row
+   controls on every engine. */
+@supports (-moz-appearance: none) {
+  .olv-ws-body {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--accent) 44%, var(--panel)) transparent;
+  }
+}
+.olv-ws-body::-webkit-scrollbar { width: 9px; height: 9px; }
+.olv-ws-body::-webkit-scrollbar-track { background: transparent; }
+.olv-ws-body::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent) 44%, var(--panel));
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
 /* 73-desktop-workspace.css — the desktop left-rail workspace.
    A Data · Work · Analyse · Output segmented tab strip over four mode hosts,
    one visible at a time (see src/ui/workspace/DesktopWorkspace.ts). Presentation


### PR DESCRIPTION
Small a11y/usability improvement to the layer Remove control.

`.olv-layer-x` had no padding (its `.olv-layer-solo`/`.olv-layer-lock` siblings have `padding: 0 2px`) and no `cursor: pointer`. This adds horizontal padding (bigger hit target, consistent affordance) plus a small end-clearance on `.olv-layers`.

**This does NOT fix #401.** I opened it as a candidate fix for the Firefox `twoScanMount:192` scrollbar-interception, but the e2e-firefox CI run on this branch shows the failure persists unchanged (`.olv-ws-body` still intercepts the click). The clearance was far too small for a ~16px classic scrollbar, and the gutter model is incomplete. #401 stays open. Merge this only as the minor improvement it is, or close it.