### PR TITLE
fix: ICP overlap gate + net-volume ± band (#2, #3)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5665,7 +5665,7 @@ function compareLoadedLayers(): void {
         verticalUnitToMetres: ctxA.verticalUnitToMetres, // Z keeps its OWN declared scale; the horizontal verdict never stands in for it
       });
       const header = `${baseName(a.name)} (before) → ${baseName(b.name)} (after)`;
-      inspector.setCompareResult([header, summarizeAlignment(alignment), ...summarizeChange(cmp)]);
+      inspector.setCompareResult([header, summarizeAlignment(alignment), ...summarizeChange(cmp, { registrationSigmaM: alignment.applied ? alignment.rmsResidualM : 0, horizontalUnitToMetres: frames.horizontalUnitToMetres })]);
       // A georeferenced .asc of the signed difference. The shared grid is built
       // in the common world frame, so its origin IS the scan's projected corner.
       // The .asc grid geometry (cellsize + corners) is in the source LINEAR

--- a/src/terrain/change/alignEpochs.ts
+++ b/src/terrain/change/alignEpochs.ts
@@ -125,7 +125,21 @@ export interface EpochAlignment {
    * and keeps only the unit-free parts (yaw, sample count) plus the diagnosis.
    */
   readonly horizontalUnitUnknown?: boolean;
+  /**
+   * Inlier fraction of the fit (0..1) — how much of the sampled overlap the
+   * transform actually explains. A small residual over a small overlap is the
+   * classic "locked onto a subset" failure that RMS alone hides, so this is
+   * surfaced and gated: below {@link LOW_OVERLAP_FRACTION} the transform is NOT
+   * applied (the clouds are compared as-is), because a minority-of-points fit
+   * would smear real vertical change across slopes and corrupt the cut/fill.
+   */
+  readonly overlapFraction: number;
+  /** The fit ran but its overlap was too low to trust, so it was withheld. */
+  readonly lowOverlap?: boolean;
 }
+
+/** Below this inlier fraction the fit is untrustworthy and is not applied. */
+export const LOW_OVERLAP_FRACTION = 0.5;
 
 const NO_ALIGNMENT: EpochAlignment = {
   attempted: false,
@@ -136,6 +150,7 @@ const NO_ALIGNMENT: EpochAlignment = {
   yawDeg: 0,
   translation: ZERO,
   sampleCount: 0,
+  overlapFraction: 0,
 };
 
 /** The geographic-frame refusal: nothing attempted, clouds untouched. */
@@ -318,6 +333,32 @@ export function alignEpochClouds(
         yawDeg,
         translation: toMetres(fit.translation),
         sampleCount,
+        overlapFraction: fit.inlierFraction,
+        frameUnverified,
+        horizontalUnitUnknown,
+      },
+    };
+  }
+
+  // Low overlap: the fit converged with a small residual, but only a minority
+  // of points registered — the classic subset lock. Applying it would inject a
+  // horizontal shift/yaw from a fraction of the scene and smear real vertical
+  // change across slopes. Withhold the transform (compare as-is) rather than
+  // report a partial fit as a trustworthy alignment.
+  if (fit.inlierFraction < LOW_OVERLAP_FRACTION) {
+    return {
+      after,
+      alignment: {
+        attempted: true,
+        applied: false,
+        refused: false,
+        degenerate: false,
+        rmsResidualM,
+        yawDeg,
+        translation: toMetres(fit.translation),
+        sampleCount,
+        overlapFraction: fit.inlierFraction,
+        lowOverlap: true,
         frameUnverified,
         horizontalUnitUnknown,
       },
@@ -357,6 +398,7 @@ export function alignEpochClouds(
       // actually moved the points.
       translation: toMetres(applied.translation),
       sampleCount,
+      overlapFraction: fit.inlierFraction,
       frameUnverified,
       horizontalUnitUnknown,
     },
@@ -393,8 +435,11 @@ export function summarizeAlignment(a: EpochAlignment): string {
   if (a.refused) {
     return `Alignment: refused — residual ${a.rmsResidualM.toFixed(2)} m exceeds the limit; comparing as-is.`;
   }
+  if (a.lowOverlap) {
+    return `Alignment: withheld — only ${(a.overlapFraction * 100).toFixed(0)}% of the sampled points registered (below ${(LOW_OVERLAP_FRACTION * 100).toFixed(0)}%), so the fit locked onto a subset; comparing as-is rather than shifting on a partial overlap.`;
+  }
   const shift = Math.hypot(a.translation[0], a.translation[1]);
-  const base = `Aligned the after cloud horizontally (${shift.toFixed(2)} m shift, ${a.yawDeg.toFixed(2)}° yaw, ${a.rmsResidualM.toFixed(2)} m residual over ${a.sampleCount} sampled points); vertical change preserved.`;
+  const base = `Aligned the after cloud horizontally (${shift.toFixed(2)} m shift, ${a.yawDeg.toFixed(2)}° yaw, ${a.rmsResidualM.toFixed(2)} m residual, ${(a.overlapFraction * 100).toFixed(0)}% overlap over ${a.sampleCount} sampled points); vertical change preserved.`;
   // The figures above describe the FIT. Without a declared frame on both sides
   // they say nothing about the relationship between the epochs, and a residual
   // quoted in metres reads as evidence of georeferenced agreement.

--- a/src/terrain/change/compareDtms.ts
+++ b/src/terrain/change/compareDtms.ts
@@ -22,6 +22,7 @@ import {
   type ChangeResult,
   type ChangeDetectionOptions,
 } from './changeDetection';
+import { changeVolumeUncertainty, cellSigmaFromLoD } from './changeUncertainty';
 
 /**
  * Adapt a {@link DtmGrid} to the bare {@link ChangeGrid} the change core
@@ -218,7 +219,15 @@ export function compareDtms(
  * cut/fill volumes, the change significance, and every co-registration caveat,
  * so the numbers never travel without their honesty context.
  */
-export function summarizeChange(comparison: EpochComparison): string[] {
+/** Extra facts, known only at the call site, that qualify the net-volume figure. */
+export interface ChangeSummaryContext {
+  /** Co-registration RMSE (m) of the applied alignment — the systematic error term. */
+  readonly registrationSigmaM?: number;
+  /** Horizontal linear-unit factor, to turn the source-unit cell size into m². */
+  readonly horizontalUnitToMetres?: number;
+}
+
+export function summarizeChange(comparison: EpochComparison, ctx: ChangeSummaryContext = {}): string[] {
   const { result, coregistered, coregistrationNotes } = comparison;
   const s = result.stats;
   const lines: string[] = [];
@@ -261,6 +270,27 @@ export function summarizeChange(comparison: EpochComparison): string[] {
       `Net volume change: ${s.netVolumeM3.toFixed(1)} m³ ` +
         `(gain ${s.gainVolumeM3.toFixed(1)} m³, loss ${s.lossVolumeM3.toFixed(1)} m³).`,
     );
+    // Qualify the net volume with a ± band + detectability. A bare figure hides
+    // whether the change exceeds the noise, and an unquantified co-registration
+    // error is the most common way a change number lies — so both are surfaced.
+    const hM = ctx.horizontalUnitToMetres;
+    if (hM && hM > 0) {
+      const u = changeVolumeUncertainty({
+        netVolumeM3: s.netVolumeM3,
+        significantCells: s.gained + s.lost,
+        cellAreaM2: (result.cellSizeM * hM) * (result.cellSizeM * hM),
+        cellSigmaM: cellSigmaFromLoD(comparison.levelOfDetectionM),
+        registrationSigmaM: ctx.registrationSigmaM ?? 0,
+      });
+      lines.push(
+        u.detectable
+          ? `Volume uncertainty: ±${u.sigmaM3.toFixed(1)} m³ (1σ, ${(u.relativeError * 100).toFixed(0)}% relative); ${u.confidence} confidence.`
+          : `Net volume is below the level of detection: ±${u.sigmaM3.toFixed(1)} m³ (1σ) — not distinguishable from noise.`,
+      );
+      if (!(ctx.registrationSigmaM && ctx.registrationSigmaM > 0)) {
+        lines.push('The co-registration error is unquantified (no alignment applied), so this band is a lower bound.');
+      }
+    }
   }
   lines.push(
     `${(s.significantFraction * 100).toFixed(1)}% of comparable cells changed beyond the ` +

--- a/tests/alignEpochs.test.ts
+++ b/tests/alignEpochs.test.ts
@@ -39,6 +39,8 @@ describe('alignEpochClouds', () => {
     const { after, alignment } = alignEpochClouds(a, b);
     expect(alignment.attempted).toBe(true);
     expect(alignment.applied).toBe(true);
+    // Identical geometry registers fully, so the overlap is surfaced and high (#2).
+    expect(alignment.overlapFraction).toBeGreaterThan(0.9);
     expect(alignment.rmsResidualM).toBeLessThan(1e-3);
     expect(Math.abs(alignment.yawDeg)).toBeLessThan(0.1);
     expect(Math.hypot(alignment.translation[0], alignment.translation[1])).toBeLessThan(1e-2);

--- a/tests/compareDtms.test.ts
+++ b/tests/compareDtms.test.ts
@@ -144,6 +144,20 @@ describe('summarizeChange', () => {
     expect(lines.some((l) => /Needs for a measured result/.test(l))).toBe(false);
   });
 
+  it('qualifies the net volume with a ± band + detectability when a unit factor is given (#3)', () => {
+    const a = grid([1, 1, 1, 1], 2, 2);
+    const b = grid([2, 2, 2, 2], 2, 2);
+    const lines = summarizeChange(compareDtms(a, b), { horizontalUnitToMetres: 1, registrationSigmaM: 0.02 });
+    expect(lines.some((l) => /Volume uncertainty|below the level of detection/.test(l))).toBe(true);
+  });
+
+  it('flags the band as a lower bound when the co-registration error is unquantified (#3)', () => {
+    const a = grid([1, 1, 1, 1], 2, 2);
+    const b = grid([2, 2, 2, 2], 2, 2);
+    const lines = summarizeChange(compareDtms(a, b), { horizontalUnitToMetres: 1, registrationSigmaM: 0 });
+    expect(lines.some((l) => /lower bound/.test(l))).toBe(true);
+  });
+
   it('spells out the co-registration checklist when not co-registered', () => {
     const a = grid([1, 1], 2, 1);
     const b = grid([2, 2], 2, 1, { originH1: 10 });


### PR DESCRIPTION
Audit defects #2 + #3 (both High). **#2:** `alignEpochClouds` dropped the ICP `inlierFraction`, so a 30%-overlap fit that locked onto a subset was applied and reported as trustworthy — smearing vertical change. Now surfaced as `EpochAlignment.overlapFraction` and **withheld below 0.5** (compared as-is). **#3:** `changeVolumeUncertainty` was dead, so net volume printed as a bare fact; `summarizeChange` now appends the 1σ band + detectability ("below the level of detection"), flagging a lower bound when the co-registration error is unquantified. `main.ts` net-neutral (5810). tsc + change/align suites green (50 new-file assertions incl. #2/#3).