### PR TITLE
fix: SMRF ground tolerances are physical, converted per vertical unit (#2)

### DIFF
--- a/src/terrain/change/compareEpochs.ts
+++ b/src/terrain/change/compareEpochs.ts
@@ -166,12 +166,17 @@ function dtmOnGrid(cloud: EpochCloud, grid: SharedGrid): DtmGrid {
     : cloud.linearUnitToMetres && cloud.linearUnitToMetres > 0
       ? cloud.linearUnitToMetres
       : 1;
+  // The 0.5 m / 2.5 m SMRF tolerances are physical; convert to source vertical
+  // units so a foot frame keeps its physical ground tolerance (a geographic
+  // frame's z is already metric, so zPerMetre is 1 there).
+  const zPerMetre = 1 / vertToMetres;
   const gf = classifyGroundSmrf(points, {
     cellSizeM: grid.cellSizeM,
     cellSizeZUnits: grid.cellSizeM * (horizToMetres / vertToMetres),
     maxWindowCells: 8,
     slope: 0.2,
-    elevationThresholdM: 0.5,
+    elevationThresholdM: 0.5 * zPerMetre,
+    maxElevationThresholdM: 2.5 * zPerMetre,
     floorPercentile: 5,
     verticalAxis: 'z',
   });

--- a/src/terrain/change/compareEpochs.ts
+++ b/src/terrain/change/compareEpochs.ts
@@ -149,8 +149,26 @@ function sharedGrid(before: EpochCloud, after: EpochCloud): SharedGrid | null {
 /** Build one cloud's DTM on the shared world grid, matching the live analysis surface. */
 function dtmOnGrid(cloud: EpochCloud, grid: SharedGrid): DtmGrid {
   const points = boxPoints(cloud.positions, cloud.origin ?? ZERO);
+  // Match the analysis runner's unit-aware slope-growth run (deriveCoreParams):
+  // the SMRF threshold multiplies a rise/run slope by a horizontal run, so that
+  // run must share z's unit. A geographic frame's degree-valued cell would
+  // otherwise starve the growth term by ~1/111,320, pinning the threshold at
+  // its base and rejecting legitimate slope ground. cellSizeZUnits rescales the
+  // horizontal cell into z's unit; for a projected frame whose axes share one
+  // linear unit the ratio is 1 and the filter sees the plain cell size.
+  const horizToMetres = cloud.isGeographic
+    ? METRES_PER_DEGREE
+    : cloud.linearUnitToMetres && cloud.linearUnitToMetres > 0
+      ? cloud.linearUnitToMetres
+      : 1;
+  const vertToMetres = cloud.isGeographic
+    ? 1
+    : cloud.linearUnitToMetres && cloud.linearUnitToMetres > 0
+      ? cloud.linearUnitToMetres
+      : 1;
   const gf = classifyGroundSmrf(points, {
     cellSizeM: grid.cellSizeM,
+    cellSizeZUnits: grid.cellSizeM * (horizToMetres / vertToMetres),
     maxWindowCells: 8,
     slope: 0.2,
     elevationThresholdM: 0.5,

--- a/src/terrain/contour/analyseContours.ts
+++ b/src/terrain/contour/analyseContours.ts
@@ -626,13 +626,25 @@ export function resolveGroundFilterParams(
     params.verticalUnitToMetres && params.verticalUnitToMetres > 0
       ? params.verticalUnitToMetres
       : 1;
+  // The SMRF tolerances are physical constants (0.5 m base, 2.5 m cap; Pingel
+  // et al. 2013) but the filter compares them against source-unit Δz, so convert
+  // metres → source vertical units here. On a foot frame a 0.5 m base tolerance
+  // is 1.64 ft; left as 0.5 source-ft (0.15 m) it rejects real ground and warps
+  // the DTM for the same physical terrain. The ratio is exactly 1 for a metre
+  // frame, so metric clouds are unchanged.
+  const zPerMetre = 1 / vertToMetres;
   return {
     cellSizeM: params.cellSizeM,
     cellSizeZUnits: params.cellSizeM * (horizToMetres / vertToMetres),
     maxWindowCells: params.ground?.maxWindowCells ?? 8,
     slope: params.ground?.slope ?? 0.2,
-    elevationThresholdM: params.ground?.elevationThresholdM ?? 0.5,
-    scalingFactorM: params.ground?.scalingFactorM,
+    elevationThresholdM: (params.ground?.elevationThresholdM ?? 0.5) * zPerMetre,
+    maxElevationThresholdM:
+      (params.ground?.maxElevationThresholdM ?? 2.5) * zPerMetre,
+    scalingFactorM:
+      params.ground?.scalingFactorM != null
+        ? params.ground.scalingFactorM * zPerMetre
+        : undefined,
     // Despike by default in the pipeline (the leaf stays strict-min).
     floorPercentile: params.ground?.floorPercentile ?? 5,
     verticalAxis,

--- a/tests/compareEpochs.test.ts
+++ b/tests/compareEpochs.test.ts
@@ -165,10 +165,13 @@ describe('dtmOnGrid — geographic ground-filter unit parity', () => {
   // is wrongly rejected. The change path must reach the same ground coverage as
   // the metre frame — mirroring groundFilterUnitFrame for the two-epoch runner.
   function ridge(scale: number): Float32Array {
+    // 48×48 samples at 0.4 m spacing: a ~2.4 m ridge period (wider than the
+    // 8-cell SMRF window) over a small enough extent to grid quickly.
     const pts: number[] = [];
-    for (let i = 0; i <= 60; i++) {
-      for (let j = 0; j <= 60; j++) {
-        pts.push(i * scale, j * scale, 1.5 * Math.sin((i * Math.PI) / 3) * Math.cos((j * Math.PI) / 3));
+    for (let i = 0; i <= 48; i++) {
+      for (let j = 0; j <= 48; j++) {
+        const s = 0.4 * scale;
+        pts.push(i * s, j * s, 1.5 * Math.sin((i * Math.PI) / 3) * Math.cos((j * Math.PI) / 3));
       }
     }
     return new Float32Array(pts);
@@ -193,8 +196,8 @@ describe('dtmOnGrid — geographic ground-filter unit parity', () => {
     const geoFrac = measuredFraction(geo!.before.counts);
     expect(metreFrac).toBeGreaterThan(0.01);
     // The degree frame sees the identical surface, so it retains the same ground
-    // (parity ≈ 1.2× here). A starved growth term rejects ridge ground and drops
-    // this to ~0.45× — well under the 0.6× floor.
+    // (parity ≈ 1.0× here). A starved growth term rejects ridge ground and drops
+    // this to ~0.40× — well under the 0.6× floor.
     expect(geoFrac).toBeGreaterThan(metreFrac * 0.6);
   });
 });

--- a/tests/compareEpochs.test.ts
+++ b/tests/compareEpochs.test.ts
@@ -155,3 +155,46 @@ describe('compareEpochClouds', () => {
     expect(cmp!.coregistrationNotes.join(' ')).toContain('CRS differs');
   });
 });
+
+describe('dtmOnGrid — geographic ground-filter unit parity', () => {
+  // Rolling ridge terrain the morphological opening cannot reproduce exactly,
+  // so the SMRF slope-growth term actually bites (a bare plane opens to itself
+  // and hides the bug). In a geographic frame the horizontal cell is degrees
+  // while z is metric; without rescaling the run into z's unit the growth term
+  // is starved by ~1/111,320, the threshold stays at its base, and ridge ground
+  // is wrongly rejected. The change path must reach the same ground coverage as
+  // the metre frame — mirroring groundFilterUnitFrame for the two-epoch runner.
+  function ridge(scale: number): Float32Array {
+    const pts: number[] = [];
+    for (let i = 0; i <= 60; i++) {
+      for (let j = 0; j <= 60; j++) {
+        pts.push(i * scale, j * scale, 1.5 * Math.sin((i * Math.PI) / 3) * Math.cos((j * Math.PI) / 3));
+      }
+    }
+    return new Float32Array(pts);
+  }
+  /** Fraction of DTM cells that hold a measured ground return. */
+  function measuredFraction(counts: Uint32Array): number {
+    let m = 0;
+    for (const c of counts) if (c > 0) m++;
+    return m / counts.length;
+  }
+
+  it('retains as much ridge ground in a degree frame as in a metre frame', () => {
+    const metre = buildSharedEpochDtms({ positions: ridge(1) }, { positions: ridge(1) });
+    const K = METRES_PER_DEGREE;
+    const geo = buildSharedEpochDtms(
+      { positions: ridge(1 / K), isGeographic: true },
+      { positions: ridge(1 / K), isGeographic: true },
+    );
+    expect(metre).not.toBeNull();
+    expect(geo).not.toBeNull();
+    const metreFrac = measuredFraction(metre!.before.counts);
+    const geoFrac = measuredFraction(geo!.before.counts);
+    expect(metreFrac).toBeGreaterThan(0.01);
+    // The degree frame sees the identical surface, so it retains the same ground
+    // (parity ≈ 1.2× here). A starved growth term rejects ridge ground and drops
+    // this to ~0.45× — well under the 0.6× floor.
+    expect(geoFrac).toBeGreaterThan(metreFrac * 0.6);
+  });
+});

--- a/tests/contourIntervalUnits.test.ts
+++ b/tests/contourIntervalUnits.test.ts
@@ -1,14 +1,22 @@
 /**
- * contourIntervalUnits.test.ts — the contour interval gate must be unit-consistent.
+ * contourIntervalUnits.test.ts — the contour interval gate must consume RMSE in
+ * the interval's own (source) units.
  *
- * The gate's candidate intervals and elevation range/bounds are in the surface's
- * SOURCE vertical units (contours draw against `dtm.z` raw), but the hold-out
- * RMSE is in METRES. Feeding metre-RMSE into a source-unit comparison made the
- * "finer than 2×error" rule wrong for foot-based data. The fix expresses RMSE in
- * the interval's own units, so gating is entirely source-unit — which means the
- * recommended interval MUST be invariant to `verticalUnitToMetres` for identical
- * source geometry. This test pins that invariance (it fails on the metre-vs-source
- * mixing bug).
+ * The gate's candidate intervals are source-unit numbers (a foot-CRS surveyor
+ * wants 1 ft / 2 ft contours, not 0.5 m), but the hold-out RMSE arrives in
+ * METRES. Feeding it raw made the "finer than 2×error" rule compare feet against
+ * metres on foot data, offering contours finer than the surface can support. The
+ * fix expresses RMSE in the interval's own units (`rmse / verticalUnitToMetres`).
+ *
+ * The old form of this test pinned "same SOURCE numbers ⇒ same recommendation",
+ * which held only while the DTM was unit-blind. The SMRF ground tolerance is now
+ * a physical constant (0.5 m), so identical source numbers under different
+ * vertical units describe DIFFERENT physical terrain and no longer classify the
+ * same — see groundFilterUnitFrame. This test instead holds the PHYSICAL terrain
+ * fixed and checks that the RMSE gate implies a CONSISTENT physical error cutoff
+ * across unit frames: the finest supported PHYSICAL interval must agree to within
+ * the candidate grid's own granularity. Feeding metre-RMSE unconverted collapses
+ * the foot frame's cutoff by ~3.28× and breaks that agreement.
  */
 import { describe, it, expect } from 'vitest';
 import { analyseContours } from '../src/terrain/contour/analyseContours';
@@ -31,24 +39,54 @@ function withNoise(points: ReadonlyArray<TerrainPoint>, sigma: number, seed: num
   });
 }
 
-describe('contour interval gate — unit consistency', () => {
-  it('recommended interval is invariant to verticalUnitToMetres (gating is source-unit)', () => {
-    const pts = withNoise(gaussianHill({ amplitude: 6 }), 0.4, 12345);
-    const base = { cellSizeM: 2, crs: 'EPSG:32610', verticalDatum: 'EPSG:5703' } as const;
+const FOOT = 0.3048;
 
-    // Same SOURCE geometry; only the declared vertical scale differs.
-    const asMetre = analyseContours(pts, { ...base, verticalUnitToMetres: 1 });
-    const asFoot = analyseContours(pts, { ...base, verticalUnitToMetres: 0.3048 });
+/** Finest supported interval, expressed in PHYSICAL metres (source × vum). */
+function finestSupportedPhysicalM(
+  result: ReturnType<typeof analyseContours>,
+  vum: number,
+): number {
+  const supported = result.gate.options.filter((o) => o.supported).map((o) => o.intervalM);
+  expect(supported.length).toBeGreaterThan(0);
+  return Math.min(...supported) * vum;
+}
 
-    // The metre-scaled hold-out RMSE differs between the two (feet read smaller in
-    // metres), which is exactly what used to corrupt the gate — but the interval
-    // recommendation AND the per-interval supported flags must not move, because
-    // gating happens in the interval's own units.
-    expect(asFoot.gate.recommendedM).toBe(asMetre.gate.recommendedM);
-    const supported = (r: typeof asMetre): Array<[number, boolean]> =>
-      r.gate.options.map((o) => [o.intervalM, o.supported]);
-    expect(supported(asFoot)).toEqual(supported(asMetre));
-    // Sanity: the noise makes the error rule actually bite (not a trivial pass).
+describe('contour interval gate — RMSE unit consistency', () => {
+  it('implies a consistent physical error cutoff in metre and foot frames', () => {
+    // One physical surface (a 6 m hill with 0.4 m jitter), expressed once in
+    // metres and once in international feet — all coordinates and the cell size
+    // scaled by 1/0.3048 so the PHYSICAL terrain is identical.
+    const physical = withNoise(gaussianHill({ amplitude: 6 }), 0.4, 12345);
+    const asMetre = analyseContours(physical, {
+      cellSizeM: 2,
+      crs: 'EPSG:32610',
+      verticalDatum: 'EPSG:5703',
+      horizontalUnitToMetres: 1,
+      verticalUnitToMetres: 1,
+    });
+    const footPts = physical.map((p) => ({ x: p.x / FOOT, y: p.y / FOOT, z: p.z / FOOT }));
+    const asFoot = analyseContours(footPts, {
+      cellSizeM: 2 / FOOT,
+      crs: 'EPSG:2229',
+      verticalDatum: 'EPSG:6360',
+      horizontalUnitToMetres: FOOT,
+      verticalUnitToMetres: FOOT,
+    });
+
+    const metreCutoffM = finestSupportedPhysicalM(asMetre, 1);
+    const footCutoffM = finestSupportedPhysicalM(asFoot, FOOT);
+
+    // The candidate grid is [0.5,1,2,5,10] in each frame's own units, so the two
+    // frames sample the physical cutoff at DIFFERENT rungs — they can only agree
+    // to within one candidate step (≤ 2.5×). Feeding metre-RMSE unconverted
+    // shrinks the foot cutoff ~3.28× and pushes this ratio well past that.
+    const ratio = footCutoffM / metreCutoffM;
+    expect(ratio).toBeGreaterThan(0.4);
+    expect(ratio).toBeLessThan(2.5);
+
+    // Sanity: the noise makes the error rule actually bite in both frames (some
+    // fine intervals are rejected, not a trivial all-supported pass).
     expect(asMetre.gate.options.some((o) => !o.supported)).toBe(true);
+    expect(asFoot.gate.options.some((o) => !o.supported)).toBe(true);
   });
 });

--- a/tests/groundFilterUnitFrame.test.ts
+++ b/tests/groundFilterUnitFrame.test.ts
@@ -36,15 +36,22 @@ function slopeScene(scale: number): TerrainPoint[] {
   return points;
 }
 
+interface Frame {
+  readonly isGeographic?: boolean;
+  readonly horizontalUnitToMetres?: number;
+  readonly verticalUnitToMetres?: number;
+}
+
 /** Fraction of returns the pipeline-default SMRF pass calls ground. */
-function groundFraction(points: TerrainPoint[], cellSizeM: number, isGeographic: boolean): number {
+function groundFraction(points: TerrainPoint[], cellSizeM: number, frame: Frame): number {
+  const isGeographic = frame.isGeographic ?? false;
   const params = resolveGroundFilterParams(
     {
       cellSizeM,
       isGeographic,
       latitudeDeg: isGeographic ? 0 : null,
-      verticalUnitToMetres: 1,
-      horizontalUnitToMetres: 1,
+      verticalUnitToMetres: frame.verticalUnitToMetres ?? 1,
+      horizontalUnitToMetres: frame.horizontalUnitToMetres ?? 1,
     },
     'z',
   );
@@ -52,17 +59,62 @@ function groundFraction(points: TerrainPoint[], cellSizeM: number, isGeographic:
   return gf.sourcePointCount > 0 ? gf.groundPointCount / gf.sourcePointCount : Number.NaN;
 }
 
+/**
+ * A flat ground plane with deterministic vertical roughness of ±~0.35 m. Flat
+ * (slope 0) so the SMRF tolerance is the plain base term with no slope-growth: a
+ * return is ground when it sits within `elevationThresholdM` (0.5 m physical) of
+ * the opened surface. The roughness straddles the boundary between a correct
+ * 0.5 m tolerance and a mis-scaled 0.15 m one (0.5 read as source feet), so the
+ * two produce visibly different ground fractions.
+ */
+function roughFlatScene(scale: number, vScale: number): TerrainPoint[] {
+  const points: TerrainPoint[] = [];
+  for (let i = 0; i < 60; i++) {
+    for (let j = 0; j < 60; j++) {
+      const xM = i + 0.5;
+      const yM = j + 0.5;
+      const zM = 10 + 0.35 * Math.sin(i * 0.7) * Math.cos(j * 0.5);
+      points.push({ x: xM * scale, y: yM * scale, z: zM * vScale });
+    }
+  }
+  return points;
+}
+
+const FOOT = 0.3048;
+
 describe('classifyGroundSmrf — geographic (degree) frame parity', () => {
   it('classifies a metric-z planar slope identically in metre and degree frames', () => {
     // Same surface twice: projected metres, and EPSG:4326-style degrees
     // (x,y ÷ metres-per-degree) with z still in metres. One grid cell per
     // ground metre in both frames.
-    const metreFrac = groundFraction(slopeScene(1), 1, false);
-    const degreeFrac = groundFraction(slopeScene(1 / METRES_PER_DEGREE), 1 / METRES_PER_DEGREE, true);
+    const metreFrac = groundFraction(slopeScene(1), 1, { isGeographic: false });
+    const degreeFrac = groundFraction(slopeScene(1 / METRES_PER_DEGREE), 1 / METRES_PER_DEGREE, {
+      isGeographic: true,
+    });
 
     // A bare planar slope is all ground; the metre frame must say so.
     expect(metreFrac).toBeGreaterThan(0.99);
     // The degree frame sees the identical surface, so it must agree.
     expect(Math.abs(metreFrac - degreeFrac)).toBeLessThan(0.02);
+  });
+});
+
+describe('classifyGroundSmrf — vertical unit (foot) frame parity', () => {
+  it('classifies the same physical surface identically in metre and foot frames', () => {
+    // Identical physical terrain, expressed once in metres and once in
+    // international feet (x, y, z all ÷ 0.3048). The 0.5 m base tolerance must
+    // convert to 1.64 ft so the foot frame keeps the same rough ground the metre
+    // frame does; left unconverted it would be 0.5 ft (0.15 m) and reject the
+    // +0.35 m bumps.
+    const metreFrac = groundFraction(roughFlatScene(1, 1), 1, { verticalUnitToMetres: 1 });
+    const footFrac = groundFraction(roughFlatScene(1 / FOOT, 1 / FOOT), 1 / FOOT, {
+      horizontalUnitToMetres: FOOT,
+      verticalUnitToMetres: FOOT,
+    });
+
+    // The rough flat plane is essentially all ground under a 0.5 m tolerance.
+    expect(metreFrac).toBeGreaterThan(0.95);
+    // The foot frame sees the identical surface, so it must agree.
+    expect(Math.abs(metreFrac - footFrac)).toBeLessThan(0.02);
   });
 });


### PR DESCRIPTION
The SMRF ground filter's 0.5 m base and 2.5 m cap (Pingel et al. 2013) are physical constants, but the filter compares them against source-unit Δz. A foot-vertical frame therefore classified ground with a 0.5 ft (0.15 m) tolerance and produced a warped DTM for the same physical terrain. A geographic frame separately starved the slope-growth run.

Two seams now convert at the boundary. `resolveGroundFilterParams` (contour path) and `compareEpochs.dtmOnGrid` (change path) convert `elevationThresholdM` and `maxElevationThresholdM` to source vertical units (times 1/verticalUnitToMetres). The ratio is 1 for a metre or geographic (metric-z) frame, so those are unchanged. `dtmOnGrid` also passes `cellSizeZUnits = cellSizeM * horizToMetres/vertToMetres`, matching the analysis runner, so a geographic frame's degree cell no longer starves the growth term (it rejected about 55% of ridge ground before).

Tests. `groundFilterUnitFrame` gains a foot-frame physical-invariance case. `compareEpochs` gains a geographic ridge-ground parity case. `contourIntervalUnits` is reframed to assert a consistent physical error cutoff across unit frames, and I confirmed it still fails when the metre-to-source RMSE conversion is removed. Full suite green.
