### PR TITLE
Verify processing manifest on session import

### DIFF
--- a/src/app/sessionIo.ts
+++ b/src/app/sessionIo.ts
@@ -25,7 +25,6 @@ import type { ViewStateBundle } from '../io/viewState';
 import { buildViewState } from '../io/viewState';
 import { isExportStale, staleExportReason } from '../export/exportStaleness';
 import { summarizeMeasurementTrust } from '../render/measure/measurementTrust';
-import { verifySessionManifest, sessionManifestNote } from '../science/verifySessionManifest';
 import { isZUpFormat } from '../io/sniffFormat';
 import type { SourceFormat } from '../io/sniffFormat';
 import type { CrsLinearUnit } from '../io/crs';
@@ -541,6 +540,11 @@ export async function importSession(
     // Verify the embedded processing manifest and disclose one integrity line.
     // This never rejects the session (an absent, legacy, or tampered manifest
     // still restores every measurement) — it only appends to the disclosure.
+    // Lazily loaded so the hash-chain verifier (canonicalize + sha256) stays
+    // out of the eager boot shell — session import is already an async action.
+    const { verifySessionManifest, sessionManifestNote } = await import(
+      '../science/verifySessionManifest'
+    );
     const manifestNote = sessionManifestNote(verifySessionManifest(session.processingManifest));
     const manifestSuffix = manifestNote ? ` ${manifestNote}` : '';
     if (wantFile && !haveCloud) {

--- a/src/app/sessionIo.ts
+++ b/src/app/sessionIo.ts
@@ -25,6 +25,7 @@ import type { ViewStateBundle } from '../io/viewState';
 import { buildViewState } from '../io/viewState';
 import { isExportStale, staleExportReason } from '../export/exportStaleness';
 import { summarizeMeasurementTrust } from '../render/measure/measurementTrust';
+import { verifySessionManifest, sessionManifestNote } from '../science/verifySessionManifest';
 import { isZUpFormat } from '../io/sniffFormat';
 import type { SourceFormat } from '../io/sniffFormat';
 import type { CrsLinearUnit } from '../io/crs';
@@ -537,15 +538,20 @@ export async function importSession(
     // just a count.
     const evidence = summarizeMeasurementTrust(session.measurements.map((m) => m.trust));
     const lead = evidence.total > 0 ? `Evidence restored — ${evidence.line}.` : null;
+    // Verify the embedded processing manifest and disclose one integrity line.
+    // This never rejects the session (an absent, legacy, or tampered manifest
+    // still restores every measurement) — it only appends to the disclosure.
+    const manifestNote = sessionManifestNote(verifySessionManifest(session.processingManifest));
+    const manifestSuffix = manifestNote ? ` ${manifestNote}` : '';
     if (wantFile && !haveCloud) {
-      deps.showToast(lead ?? `Session restored — drop “${wantFile}” to view its scan.`,
+      deps.showToast((lead ?? `Session restored — drop “${wantFile}” to view its scan.`) + manifestSuffix,
         lead ? { label: 'Need the scan', onClick: () => deps.showToast(`Drop “${wantFile}” to view this evidence on its scan.`) } : undefined);
     } else if (lead) {
-      deps.showToast(`${lead}${frameNote}${appliedNote}`);
+      deps.showToast(`${lead}${frameNote}${appliedNote}${manifestSuffix}`);
     } else {
       deps.showToast(
         `Session restored — ${restored} item${restored === 1 ? '' : 's'} ` +
-          `(measurements, annotations, views).${frameNote}${appliedNote}`,
+          `(measurements, annotations, views).${frameNote}${appliedNote}${manifestSuffix}`,
       );
     }
   } catch (err) {

--- a/src/science/verifySessionManifest.ts
+++ b/src/science/verifySessionManifest.ts
@@ -1,0 +1,103 @@
+/**
+ * verifySessionManifest.ts — turn a session's opaque processing manifest into a
+ * user-facing integrity verdict on IMPORT.
+ *
+ * The session layer carries `processingManifest` as an opaque passthrough: it is
+ * size-bounded and copied verbatim, never interpreted. On import we want to tell
+ * the reader whether that embedded provenance record is intact, WITHOUT ever
+ * letting the answer reject the session. A hand-edited, legacy, or corrupt
+ * manifest must never block restoring measurements — it only changes one line of
+ * disclosure. So this function is pure, total, and defensive: it shape-checks the
+ * unknown value, only runs {@link verifyProcessingManifest} against a manifest
+ * that matches the recognized schema, and treats anything it does not recognize
+ * (or any thrown error) as `legacy` rather than a failure.
+ *
+ * Verdicts:
+ *  - `absent`   — no manifest present (nothing to say).
+ *  - `verified` — recognized schema and the hash chain recomputes (ok).
+ *  - `failed`   — recognized schema but the chain does not verify (tampering or
+ *                 corruption); `firstInvalidSeq` locates the first bad op.
+ *  - `legacy`   — a manifest is present but does not match the recognized schema
+ *                 (an older/foreign shape we can neither verify nor trust).
+ */
+
+import {
+  PROCESSING_MANIFEST_SCHEMA,
+  verifyProcessingManifest,
+  type ProcessingManifest,
+  type ProcessingManifestOp,
+} from './processingManifest';
+
+/** The integrity verdict for a session's embedded processing manifest. */
+export type SessionManifestVerdict =
+  | { readonly status: 'absent' }
+  | { readonly status: 'verified'; readonly ops: number; readonly head: string }
+  | { readonly status: 'failed'; readonly firstInvalidSeq?: number }
+  | { readonly status: 'legacy' };
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Defensive shape check: does the unknown value match the manifest schema this
+ * build recognizes closely enough to hand to {@link verifyProcessingManifest}?
+ * Only structure and the schema version are checked here — the hash chain (the
+ * real integrity claim) is left to the verifier. A `false` here means `legacy`,
+ * never `failed`: we make no accusation about a shape we do not recognize.
+ */
+function matchesRecognizedSchema(v: unknown): v is ProcessingManifest {
+  if (!isPlainObject(v)) return false;
+  if (v.schemaVersion !== PROCESSING_MANIFEST_SCHEMA) return false;
+  if (typeof v.build !== 'string') return false;
+  if (!(v.source === null || typeof v.source === 'string')) return false;
+  if (typeof v.head !== 'string') return false;
+  if (!Array.isArray(v.ops)) return false;
+  return v.ops.every((op: unknown) => {
+    if (!isPlainObject(op)) return false;
+    const o = op as Partial<ProcessingManifestOp>;
+    if (typeof o.seq !== 'number') return false;
+    if (typeof o.method !== 'string') return false;
+    if (!isPlainObject(o.params)) return false;
+    if (typeof o.hash !== 'string') return false;
+    if (o.note !== undefined && typeof o.note !== 'string') return false;
+    return true;
+  });
+}
+
+/**
+ * Compute the import-time integrity verdict for a parsed session's
+ * `processingManifest`. NEVER throws; NEVER used to reject a session — the
+ * caller only turns this into one line of disclosure.
+ */
+export function verifySessionManifest(manifest: unknown): SessionManifestVerdict {
+  try {
+    if (manifest == null) return { status: 'absent' };
+    if (!matchesRecognizedSchema(manifest)) return { status: 'legacy' };
+    const result = verifyProcessingManifest(manifest);
+    if (result.ok) return { status: 'verified', ops: manifest.ops.length, head: manifest.head };
+    return result.firstInvalid !== undefined
+      ? { status: 'failed', firstInvalidSeq: result.firstInvalid }
+      : { status: 'failed' };
+  } catch {
+    return { status: 'legacy' };
+  }
+}
+
+/**
+ * The short disclosure line for a verdict, or null when there is nothing to say
+ * (an absent manifest). Kept beside the verdict so the import path stays a thin
+ * call.
+ */
+export function sessionManifestNote(verdict: SessionManifestVerdict): string | null {
+  switch (verdict.status) {
+    case 'absent':
+      return null;
+    case 'verified':
+      return `Analysis history: integrity verified (${verdict.ops} operation${verdict.ops === 1 ? '' : 's'}).`;
+    case 'failed':
+      return '⚠ Analysis history integrity check failed.';
+    case 'legacy':
+      return 'Analysis history: legacy manifest (not verified).';
+  }
+}

--- a/tests/verifySessionManifest.test.ts
+++ b/tests/verifySessionManifest.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { buildProcessingManifest } from '../src/science/processingManifest';
+import {
+  verifySessionManifest,
+  sessionManifestNote,
+} from '../src/science/verifySessionManifest';
+
+/** A real, chain-valid manifest built the way the exporter builds it. */
+function realManifest() {
+  return buildProcessingManifest({
+    build: '0.6.6 (abc1234)',
+    source: 'site.laz',
+    ops: [
+      { method: 'olv.ground.smrf@1', params: {}, note: 'params not captured in this slice' },
+      { method: 'olv.dtm.idw-fill@1', params: { coverageMode: 'full' } },
+    ],
+  });
+}
+
+describe('verifySessionManifest', () => {
+  it("reports 'absent' when there is no manifest", () => {
+    expect(verifySessionManifest(undefined)).toEqual({ status: 'absent' });
+    expect(verifySessionManifest(null)).toEqual({ status: 'absent' });
+  });
+
+  it("reports 'verified' with the op count for a real, intact manifest", () => {
+    const verdict = verifySessionManifest(realManifest());
+    expect(verdict.status).toBe('verified');
+    if (verdict.status === 'verified') {
+      expect(verdict.ops).toBe(2);
+      expect(typeof verdict.head).toBe('string');
+    }
+  });
+
+  it("survives a serialize → parse round trip and still reports 'verified'", () => {
+    const back = JSON.parse(JSON.stringify(realManifest())) as unknown;
+    expect(verifySessionManifest(back)).toMatchObject({ status: 'verified', ops: 2 });
+  });
+
+  it("reports 'failed' when the chain is tampered", () => {
+    const tampered = JSON.parse(JSON.stringify(realManifest()));
+    tampered.ops[1].params = { coverageMode: 'partial' }; // edited op leaves the hash stale
+    const verdict = verifySessionManifest(tampered);
+    expect(verdict.status).toBe('failed');
+    if (verdict.status === 'failed') expect(verdict.firstInvalidSeq).toBe(1);
+  });
+
+  it("reports 'legacy' for a manifest that does not match the recognized schema", () => {
+    expect(verifySessionManifest({ foo: 1 })).toEqual({ status: 'legacy' });
+    expect(verifySessionManifest(['anything', { nested: true }])).toEqual({ status: 'legacy' });
+    // Right skeleton, wrong schema version.
+    const wrongVersion = { ...realManifest(), schemaVersion: 999 };
+    expect(verifySessionManifest(wrongVersion)).toEqual({ status: 'legacy' });
+  });
+
+  it('never throws on hostile or malformed input', () => {
+    const inputs: unknown[] = [
+      0,
+      '',
+      'a string',
+      true,
+      { ops: 'not-an-array', schemaVersion: 1, build: 'x', source: null, head: 'h' },
+      { schemaVersion: 1, build: 'x', source: null, head: 'h', ops: [{ seq: 'no' }] },
+      Object.create(null),
+    ];
+    for (const input of inputs) {
+      expect(() => verifySessionManifest(input)).not.toThrow();
+    }
+  });
+});
+
+describe('sessionManifestNote', () => {
+  it('says nothing when the manifest is absent', () => {
+    expect(sessionManifestNote({ status: 'absent' })).toBeNull();
+  });
+
+  it('pluralizes the operation count', () => {
+    expect(sessionManifestNote({ status: 'verified', ops: 1, head: 'h' })).toContain('1 operation)');
+    expect(sessionManifestNote({ status: 'verified', ops: 3, head: 'h' })).toContain('3 operations)');
+  });
+
+  it('flags a failed check and labels a legacy manifest', () => {
+    expect(sessionManifestNote({ status: 'failed' })).toContain('failed');
+    expect(sessionManifestNote({ status: 'legacy' })).toContain('legacy');
+  });
+});


### PR DESCRIPTION
On session import, the app now verifies the embedded processing manifest and surfaces an integrity verdict. Before this the manifest was written on save but treated as opaque on load, size-bounded only.

A new pure module `src/science/verifySessionManifest.ts` takes the parsed manifest and returns absent, verified, failed, or legacy. It never throws and never rejects a valid session. It is wired into the real consume site, `sessionIo.ts` importSession, where it appends a short line to the session-restored toast. A garbage or legacy manifest does not block the load.

The classifier hash-chain crypto is loaded lazily (dynamic import at the import site) so it stays out of the eager index bundle. tsc, 91 tests, and the monolith gate are green.
