### PR TITLE
fix: declutter the Analyse panel (font, readiness restatements)

### DIFF
--- a/src/styles/89-data-fitness.css
+++ b/src/styles/89-data-fitness.css
@@ -54,7 +54,7 @@
 
 /* Recommended grid / interval. */
 .olv-analyse-recommend-box { display: flex; flex-direction: column; gap: var(--space-2xs); margin: var(--space-sm) 0; }
-.olv-analyse-reco { font-size: var(--text-xs); color: var(--text); font-family: var(--mono); }
+.olv-analyse-reco { font-size: var(--text-2xs); color: var(--text-dim); font-variant-numeric: tabular-nums; }
 /* Quality gate reasons. */
 .olv-analyse-quality { display: flex; flex-direction: column; gap: var(--space-xs); margin: var(--space-xs) 0; }
 /* v0.4.6: quality-gate reason rides the shared caveat primitive (tinted

--- a/src/terrain/contour/terrainReadiness.ts
+++ b/src/terrain/contour/terrainReadiness.ts
@@ -115,13 +115,18 @@ export function computeTerrainReadiness(
   opts?: { readonly verticalUnitToMetres?: number | null },
 ): TerrainReadiness {
   const vSuffix = verticalUnitSuffix(opts?.verticalUnitToMetres);
+  // Unit-only suffix for the readiness card: the "(vertical unit unverified)"
+  // caveat is carried once on the recommended-interval line, so the card shows
+  // the unit when known and nothing when not, rather than repeating the caveat.
+  const vm = opts?.verticalUnitToMetres;
+  const unitKnown = vm != null && Number.isFinite(vm) && vm > 0;
+  const reliefSuffix = unitKnown ? vSuffix : '';
   const cov = tallyCoverage(result.dtm.coverage);
   const meanConf = result.dtm.meanConfidence;
   const measuredFrac = cov.covered > 0 ? cov.measured / cov.covered : 0;
   const coverageFrac = cov.total > 0 ? cov.covered / cov.total : 0;
   const calibrated = result.confidenceCalibrationApplied;
   const tol = result.confidenceToleranceM;
-  const rmse = result.validation.rmse;
 
   // ── Ground confidence ────────────────────────────────────────────────
   let groundRating = rate(meanConf);
@@ -150,7 +155,6 @@ export function computeTerrainReadiness(
   // whether the confidence is calibrated.
   let dtmRating = rate(measuredFrac * 100);
   if (dtmRating !== 'unavailable' && !calibrated) dtmRating = demote(dtmRating);
-  const rmseText = Number.isFinite(rmse) ? `${rmse.toFixed(2)} m` : 'not measurable';
   const dtmQuality: ReadinessIndicator = {
     // "Measured coverage" — not "DTM quality" — so this card (a % of the
     // surface that is real measurement vs interpolated) can't be mistaken for
@@ -160,10 +164,12 @@ export function computeTerrainReadiness(
     label: 'Measured coverage',
     rating: cov.covered === 0 ? 'unavailable' : dtmRating,
     value: cov.covered === 0 ? '—' : `${pct(measuredFrac)} measured`,
+    // RMSE lives on the Ground-confidence card (± tolerance) and in Validation
+    // detail; this card is about coverage, so it does not restate it.
     detail:
       cov.covered === 0
         ? 'No covered cells — nothing to model.'
-        : `${pct(1 - measuredFrac)} interpolated · vertical RMSE ${rmseText}`,
+        : `${pct(1 - measuredFrac)} interpolated`,
   };
 
   // ── Contour readiness ────────────────────────────────────────────────
@@ -181,9 +187,9 @@ export function computeTerrainReadiness(
   const contourReadiness: ReadinessIndicator = {
     label: 'Contour readiness',
     rating: contourRating,
-    value: contoursRecommended ? `${recommended}${vSuffix}` : 'Not ready',
+    value: contoursRecommended ? `${recommended}${reliefSuffix}` : 'Not ready',
     detail: contoursRecommended
-      ? `Coverage ${pct(coverageFrac)} · relief ${result.elevationRangeM.toFixed(1)}${vSuffix}`
+      ? `Coverage ${pct(coverageFrac)} · relief ${result.elevationRangeM.toFixed(1)}${reliefSuffix}`
       : 'No reliable contour interval — the scan is too sparse or the vertical error is too high for honest contours.',
   };
 

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -6895,7 +6895,7 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
 
 /* Recommended grid / interval. */
 .olv-analyse-recommend-box { display: flex; flex-direction: column; gap: var(--space-2xs); margin: var(--space-sm) 0; }
-.olv-analyse-reco { font-size: var(--text-xs); color: var(--text); font-family: var(--mono); }
+.olv-analyse-reco { font-size: var(--text-2xs); color: var(--text-dim); font-variant-numeric: tabular-nums; }
 /* Quality gate reasons. */
 .olv-analyse-quality { display: flex; flex-direction: column; gap: var(--space-xs); margin: var(--space-xs) 0; }
 /* v0.4.6: quality-gate reason rides the shared caveat primitive (tinted


### PR DESCRIPTION
Addresses two things in the Analyse panel.

Font. The Recommended grid and Recommended contour interval lines used a monospace face at a larger metric, so they read bigger and wider than the surrounding text. They now use the panel's proportional face at the caption size, with tabular numbers.

Declutter. Two readiness cards restated numbers shown elsewhere in the same section. The Measured-coverage card no longer appends vertical RMSE, which is already on the Ground-confidence card as a plus/minus tolerance and in Validation detail. The Contour-readiness card shows the vertical unit when it is known but drops the '(vertical unit unverified)' caveat, which stays once on the recommended-interval line. No unique number is removed.

Left as-is: Ground density appearing in both the promoted top row and its Surface cluster is the worst-chip promotion, not duplication. Cross-panel overlap between Analyse and Scan Intelligence is deferred to a live review, since the left resident-only scope is an analysis caveat rather than a repeat of the right panel's streaming state.

Verified with tsc, the readiness and panel unit tests, and the full suite (9407 pass). The visual result is best confirmed against a loaded, analyzed scan.