### PR TITLE
fix: classifier parameters are physical, converted to source units at the boundary

### DIFF
--- a/docs/architecture/spatial-context-consumers.md
+++ b/docs/architecture/spatial-context-consumers.md
@@ -50,7 +50,7 @@ has re-opened the divergence this closes.
   `carrier` path must be free of the deprecated predicates listed below.
 - **Reads** — the context fields it now uses.
 
-## Inventory (13 consumers)
+## Inventory (14 consumers)
 
 | # | Consumer | Status | Routes through | Reads |
 |---|----------|--------|----------------|-------|
@@ -67,6 +67,7 @@ has re-opened the divergence this closes.
 | 11 | GeoJSON / KML / DXF export | migrated | `src/main.ts`, `src/app/kmlActions.ts`, `src/export/scanFootprint.ts` | `isGeographic`, `verticalDatum`, `verticalMetresPerUnit`, `upAxis` |
 | 12 | Measurement labels | migrated | `src/main.ts` | `linearUnitToMetres`, `linearUnitKnown`, `isGeographic`, `verticalMetresPerUnit` |
 | 13 | Elevation colorbars | migrated | `src/main.ts`, `src/app/terrainAnalysisRunner.ts` | `verticalMetresPerUnit`, `kind` |
+| 14 | Classification | migrated | `src/render/class/classifierCues.ts` | `linearUnitToMetres`, `verticalMetresPerUnit` |
 
 ## Deprecated predicates
 

--- a/src/geo/SpatialContext.ts
+++ b/src/geo/SpatialContext.ts
@@ -5,7 +5,7 @@
  * consumer that is about to make a metric claim — a distance in metres, an area
  * in m², a volume in m³, a density in pts/m², an elevation against a datum — can
  * read a single object instead of re-deriving unit, datum, axis and frame from
- * `metadata.crs` five different ways. The inventory tracks 13 consumers that
+ * `metadata.crs` five different ways. The inventory tracks 14 consumers that
  * each used to reach into a `CrsInfo` / `ResolvedCrs` and re-answer the same
  * questions (see docs/architecture/spatial-context-consumers.md, which
  * `scripts/lint-spatial-context.mjs` holds to the tree); the divergence between
@@ -195,7 +195,7 @@ export interface SpatialContextPlacement {
  * project-frame placement. A `null` / `undefined` CRS fails closed: the context
  * resolves to `unknown`, and `metricClaimsPermitted` is `false`.
  *
- * Accepting both inputs is what lets all 13 consumers route through this one
+ * Accepting both inputs is what lets all 14 consumers route through this one
  * façade without hand-building anything: a `CrsInfo` is bridged through the
  * canonical `resolvedFromCrsInfo` mapper, while a `ResolvedCrs` — which already
  * carries the resolved `kind` (including `local` / `unknown`, which a `CrsInfo`

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,7 +94,7 @@ import type { ReclassifyUi } from './ui/reclassifyUi';
 import { countClasses } from './render/class/classHistogram';
 import { toClassBuffer } from './render/class/classBuffer';
 import { deriveClassificationAsync } from './render/class/deriveClassificationAsync';
-import { classifierCues } from './render/class/classifierCues';
+import { classifierOptions } from './render/class/classifierCues';
 import { classificationCoverage } from './render/class/classificationCoverage';
 import type { DeriveClassificationOptions } from './render/class/deriveClassification';
 import { footprintAreaM2, type ScanStoryInputs } from './intelligence/scanStory';
@@ -1728,7 +1728,7 @@ async function runDeriveClassification(): Promise<void> {
   }
   // RGB (when present) sharpens vegetation on photogrammetry, where geometry
   // alone is noisy — a green, locally-smooth canopy isn't mistaken for a roof.
-  const deriveOptions = classifierCues(cloud);
+  const deriveOptions = classifierOptions(cloud, crsService.context());
 
   classifyRunning = true;
   showLassoToast('Classify · deriving ground / vegetation / building…');
@@ -1815,7 +1815,7 @@ async function runFillUnclassified(): Promise<void> {
   // Preserve the producer classes; RGB (when present) sharpens the filled gaps.
   const deriveOptions: DeriveClassificationOptions = {
     existingClassification: cloud.classification,
-    ...classifierCues(cloud),
+    ...classifierOptions(cloud, crsService.context()),
   };
 
   classifyRunning = true;

--- a/src/render/class/classifierCues.ts
+++ b/src/render/class/classifierCues.ts
@@ -10,6 +10,8 @@
  */
 
 import type { DeriveClassificationOptions } from './deriveClassification';
+import { classifierParamsForFrame } from './deriveClassification';
+import { verticalMetresPerUnit, type SpatialContext } from '../../geo/SpatialContext';
 
 /** The cloud attributes the classifier can optionally consume. */
 export interface ClassifierCueSource {
@@ -42,5 +44,26 @@ export function classifierCues(
     // A colour-only cue: pointless without RGB, so only surfaced when colours
     // are present and the caller opted in (see DeriveClassificationOptions).
     ...(hasColors && opts?.lowVegByGreenness ? { lowVegByGreenness: true } : {}),
+  };
+}
+
+/**
+ * The full classifier options for a cloud in its resolved CRS frame: the optional
+ * cues plus the physical (metre) parameters restated in the cloud's SOURCE units
+ * (see {@link classifierParamsForFrame}). Production MUST pass this so a foot or
+ * mixed-unit cloud classifies the same physical terrain as a metre one; passing
+ * the bare cues would run the metre defaults against foot coordinates.
+ */
+export function classifierOptions(
+  cloud: ClassifierCueSource,
+  ctx: SpatialContext,
+  opts?: { readonly lowVegByGreenness?: boolean },
+): DeriveClassificationOptions {
+  return {
+    ...classifierCues(cloud, opts),
+    ...classifierParamsForFrame({
+      linearUnitToMetres: ctx.linearUnitToMetres,
+      verticalUnitToMetres: verticalMetresPerUnit(ctx, 'horizontal') ?? ctx.linearUnitToMetres,
+    }),
   };
 }

--- a/src/render/class/classifierCues.ts
+++ b/src/render/class/classifierCues.ts
@@ -10,7 +10,7 @@
  */
 
 import type { DeriveClassificationOptions } from './deriveClassification';
-import { classifierParamsForFrame } from './deriveClassification';
+import { classifierParamsForFrame } from './classifierFrame';
 import { verticalMetresPerUnit, type SpatialContext } from '../../geo/SpatialContext';
 
 /** The cloud attributes the classifier can optionally consume. */

--- a/src/render/class/classifierFrame.ts
+++ b/src/render/class/classifierFrame.ts
@@ -1,0 +1,87 @@
+/**
+ * classifierFrame.ts
+ *
+ * The classifier's frozen physical (metre) parameter preset and the helper that
+ * restates it in a cloud's SOURCE units. This is a LIGHT leaf: it holds the
+ * preset numbers and a pure conversion function, and imports only TYPES from
+ * `deriveClassification`. The eager classify path (`classifierCues`) imports
+ * `classifierParamsForFrame` from here, so the heavy classifier core stays out
+ * of the boot bundle.
+ *
+ * `deriveClassification` imports `V2_PARAMS` / `CURRENT_PARAMS` back from here,
+ * so there is one source of truth for the numbers and the preset digest cannot
+ * drift from what the conversion scales.
+ */
+
+import type { ClassifierParams, DeriveClassificationOptions } from './deriveClassification';
+
+// v2's frozen numeric params (13 fields). Held verbatim by preset 2 so its
+// digest never moves; v3 extends this rather than mutating it.
+export const V2_PARAMS = Object.freeze({
+  vegGreennessMin: 0.06,
+  minGroundSupport: 0.5,
+  buildingMinSupport: 0.66,
+  maxObjectSizeM: 20,
+  elevThresholdM: 0.3,
+  slope: 0.15,
+  groundBandM: 0.5,
+  lowVegBandM: 2,
+  medVegBandM: 5,
+  buildingRoughnessMaxM: 1.5,
+  buildingMinHagM: 2.5,
+  maxGridDim: 768,
+  despikeNeighbourFactor: 1,
+});
+
+// v3 = v2 + the structural-verticality rescue's one spatial parameter. The
+// `satisfies` check still runs, so a missing/typo'd parameter is a compile error.
+export const CURRENT_PARAMS = Object.freeze({
+  ...V2_PARAMS,
+  structuralNeighborRadiusM: 1.0,
+  structuralVerticalityMin: 0.85,
+}) satisfies ClassifierParams;
+
+/** The source-unit frame a cloud's coordinates live in. */
+export interface ClassifierFrame {
+  /** Metres per source horizontal unit (~0.3048 for feet). Default 1. */
+  readonly linearUnitToMetres?: number | null;
+  /** Metres per source vertical unit. Default = the horizontal factor. */
+  readonly verticalUnitToMetres?: number | null;
+}
+
+/**
+ * Restate the classifier's physical (metre) parameters in the cloud's SOURCE
+ * units, so the same physical terrain classifies the same whether its
+ * coordinates arrive in metres, feet, or a mix. Horizontal lengths
+ * (`maxObjectSizeM`, `structuralNeighborRadiusM`) divide by the horizontal
+ * factor; vertical lengths (`elevThresholdM`, the HAG bands, roughness,
+ * `buildingMinHagM`) divide by the vertical factor; `slope` is a rise/run ratio,
+ * so it scales by their quotient (1 when both axes share a unit). Dimensionless
+ * parameters (support fractions, greenness, grid-cell cap, despike multiple)
+ * pass through untouched. `cellSizeM` is NOT here: the classifier derives it
+ * from the point spacing, already in source units.
+ *
+ * The production classify path MUST apply this before {@link deriveClassification};
+ * the corpus does the per-scene equivalent (`scaleLengthParams`). A frame of all
+ * 1s returns the metre defaults unchanged.
+ */
+export function classifierParamsForFrame(frame: ClassifierFrame): Partial<DeriveClassificationOptions> {
+  const lin =
+    frame.linearUnitToMetres && frame.linearUnitToMetres > 0 ? frame.linearUnitToMetres : 1;
+  const vert =
+    frame.verticalUnitToMetres && frame.verticalUnitToMetres > 0 ? frame.verticalUnitToMetres : lin;
+  const p = CURRENT_PARAMS;
+  return {
+    // Carried so the auto cell-size clamp stays physical (see chooseCellSize).
+    linearUnitToMetres: lin,
+    maxObjectSizeM: p.maxObjectSizeM / lin,
+    structuralNeighborRadiusM: p.structuralNeighborRadiusM / lin,
+    elevThresholdM: p.elevThresholdM / vert,
+    groundBandM: p.groundBandM / vert,
+    lowVegBandM: p.lowVegBandM / vert,
+    medVegBandM: p.medVegBandM / vert,
+    buildingRoughnessMaxM: p.buildingRoughnessMaxM / vert,
+    buildingMinHagM: p.buildingMinHagM / vert,
+    slope: p.slope * (lin / vert),
+  };
+}

--- a/src/render/class/deriveClassification.ts
+++ b/src/render/class/deriveClassification.ts
@@ -62,6 +62,9 @@ export const DERIVED_UNCLASSIFIED = 1;
 // shell can import it without pulling this classifier core (and its descriptor
 // deps) into the index bundle. Re-exported here for existing importers.
 export { classificationCoverage } from './classificationCoverage';
+import { V2_PARAMS, CURRENT_PARAMS } from './classifierFrame';
+export { classifierParamsForFrame } from './classifierFrame';
+export type { ClassifierFrame } from './classifierFrame';
 
 /** Tunable parameters; every field has a literature-anchored default. */
 export interface DeriveClassificationOptions {
@@ -322,32 +325,6 @@ export interface ClassifierPreset {
  * preset table holds for {@link CLASSIFIER_VERSION}, so the published record and
  * the running defaults are the same object and cannot drift.
  */
-// v2's frozen numeric params (13 fields). Held verbatim by preset 2 so its
-// digest never moves; v3 extends this rather than mutating it.
-const V2_PARAMS = Object.freeze({
-  vegGreennessMin: 0.06,
-  minGroundSupport: 0.5,
-  buildingMinSupport: 0.66,
-  maxObjectSizeM: 20,
-  elevThresholdM: 0.3,
-  slope: 0.15,
-  groundBandM: 0.5,
-  lowVegBandM: 2,
-  medVegBandM: 5,
-  buildingRoughnessMaxM: 1.5,
-  buildingMinHagM: 2.5,
-  maxGridDim: 768,
-  despikeNeighbourFactor: 1,
-});
-
-// v3 = v2 + the structural-verticality rescue's one spatial parameter. The
-// `satisfies` check still runs, so a missing/typo'd parameter is a compile error.
-const CURRENT_PARAMS = Object.freeze({
-  ...V2_PARAMS,
-  structuralNeighborRadiusM: 1.0,
-  structuralVerticalityMin: 0.85,
-}) satisfies ClassifierParams;
-
 /**
  * Every published preset, by version. Entries are APPEND-ONLY: an existing one
  * is a record of what shipped, and editing it in place is the move the freeze
@@ -491,50 +468,6 @@ export function classifierProcessingOp(result: DeriveClassificationResult): Proc
   };
 }
 
-/** The source-unit frame a cloud's coordinates live in. */
-export interface ClassifierFrame {
-  /** Metres per source horizontal unit (~0.3048 for feet). Default 1. */
-  readonly linearUnitToMetres?: number | null;
-  /** Metres per source vertical unit. Default = the horizontal factor. */
-  readonly verticalUnitToMetres?: number | null;
-}
-
-/**
- * Restate the classifier's physical (metre) parameters in the cloud's SOURCE
- * units, so the same physical terrain classifies the same whether its
- * coordinates arrive in metres, feet, or a mix. Horizontal lengths
- * (`maxObjectSizeM`, `structuralNeighborRadiusM`) divide by the horizontal
- * factor; vertical lengths (`elevThresholdM`, the HAG bands, roughness,
- * `buildingMinHagM`) divide by the vertical factor; `slope` is a rise/run ratio,
- * so it scales by their quotient (1 when both axes share a unit). Dimensionless
- * parameters (support fractions, greenness, grid-cell cap, despike multiple)
- * pass through untouched. `cellSizeM` is NOT here: the classifier derives it
- * from the point spacing, already in source units.
- *
- * The production classify path MUST apply this before {@link deriveClassification};
- * the corpus does the per-scene equivalent (`scaleLengthParams`). A frame of all
- * 1s returns the metre defaults unchanged.
- */
-export function classifierParamsForFrame(frame: ClassifierFrame): Partial<DeriveClassificationOptions> {
-  const lin =
-    frame.linearUnitToMetres && frame.linearUnitToMetres > 0 ? frame.linearUnitToMetres : 1;
-  const vert =
-    frame.verticalUnitToMetres && frame.verticalUnitToMetres > 0 ? frame.verticalUnitToMetres : lin;
-  const p = CURRENT_PARAMS;
-  return {
-    // Carried so the auto cell-size clamp stays physical (see chooseCellSize).
-    linearUnitToMetres: lin,
-    maxObjectSizeM: p.maxObjectSizeM / lin,
-    structuralNeighborRadiusM: p.structuralNeighborRadiusM / lin,
-    elevThresholdM: p.elevThresholdM / vert,
-    groundBandM: p.groundBandM / vert,
-    lowVegBandM: p.lowVegBandM / vert,
-    medVegBandM: p.medVegBandM / vert,
-    buildingRoughnessMaxM: p.buildingRoughnessMaxM / vert,
-    buildingMinHagM: p.buildingMinHagM / vert,
-    slope: p.slope * (lin / vert),
-  };
-}
 
 /** Clamp to [0, 1]. */
 const clamp01 = (v: number): number => {

--- a/src/render/class/deriveClassification.ts
+++ b/src/render/class/deriveClassification.ts
@@ -98,6 +98,11 @@ export interface DeriveClassificationOptions {
    * smooth low mounds aren't promoted to structures.
    */
   readonly buildingMinHagM?: number;
+  /**
+   * v3 wall rescue: neighbourhood radius (source units) for the eigen-descriptor
+   * re-examination of a tall vegetation-classified point. See ClassifierParams.
+   */
+  readonly structuralNeighborRadiusM?: number;
   /** Hard cap on either grid dimension; cellSize grows to respect it. */
   readonly maxGridDim?: number;
   /**
@@ -195,6 +200,14 @@ export interface DeriveClassificationOptions {
    * gets vegetation / building filled in around it. Absent ⇒ derive every point.
    */
   readonly existingClassification?: Uint8Array;
+  /**
+   * Metres per source horizontal unit. Only the AUTO cell-size path uses it: the
+   * fallback grid clamp (0.5..5 m) is physical, so on a foot cloud it becomes
+   * 0.5..5 m worth of feet rather than 0.5..5 ft, keeping the derived grid the
+   * same physical size a metre cloud gets. An explicit `cellSizeM` bypasses this.
+   * Default 1 (metres, unchanged).
+   */
+  readonly linearUnitToMetres?: number;
 }
 
 /** Per-class counts plus the run's honest provenance. */
@@ -478,6 +491,51 @@ export function classifierProcessingOp(result: DeriveClassificationResult): Proc
   };
 }
 
+/** The source-unit frame a cloud's coordinates live in. */
+export interface ClassifierFrame {
+  /** Metres per source horizontal unit (~0.3048 for feet). Default 1. */
+  readonly linearUnitToMetres?: number | null;
+  /** Metres per source vertical unit. Default = the horizontal factor. */
+  readonly verticalUnitToMetres?: number | null;
+}
+
+/**
+ * Restate the classifier's physical (metre) parameters in the cloud's SOURCE
+ * units, so the same physical terrain classifies the same whether its
+ * coordinates arrive in metres, feet, or a mix. Horizontal lengths
+ * (`maxObjectSizeM`, `structuralNeighborRadiusM`) divide by the horizontal
+ * factor; vertical lengths (`elevThresholdM`, the HAG bands, roughness,
+ * `buildingMinHagM`) divide by the vertical factor; `slope` is a rise/run ratio,
+ * so it scales by their quotient (1 when both axes share a unit). Dimensionless
+ * parameters (support fractions, greenness, grid-cell cap, despike multiple)
+ * pass through untouched. `cellSizeM` is NOT here: the classifier derives it
+ * from the point spacing, already in source units.
+ *
+ * The production classify path MUST apply this before {@link deriveClassification};
+ * the corpus does the per-scene equivalent (`scaleLengthParams`). A frame of all
+ * 1s returns the metre defaults unchanged.
+ */
+export function classifierParamsForFrame(frame: ClassifierFrame): Partial<DeriveClassificationOptions> {
+  const lin =
+    frame.linearUnitToMetres && frame.linearUnitToMetres > 0 ? frame.linearUnitToMetres : 1;
+  const vert =
+    frame.verticalUnitToMetres && frame.verticalUnitToMetres > 0 ? frame.verticalUnitToMetres : lin;
+  const p = CURRENT_PARAMS;
+  return {
+    // Carried so the auto cell-size clamp stays physical (see chooseCellSize).
+    linearUnitToMetres: lin,
+    maxObjectSizeM: p.maxObjectSizeM / lin,
+    structuralNeighborRadiusM: p.structuralNeighborRadiusM / lin,
+    elevThresholdM: p.elevThresholdM / vert,
+    groundBandM: p.groundBandM / vert,
+    lowVegBandM: p.lowVegBandM / vert,
+    medVegBandM: p.medVegBandM / vert,
+    buildingRoughnessMaxM: p.buildingRoughnessMaxM / vert,
+    buildingMinHagM: p.buildingMinHagM / vert,
+    slope: p.slope * (lin / vert),
+  };
+}
+
 /** Clamp to [0, 1]. */
 const clamp01 = (v: number): number => {
   if (v < 0) return 0;
@@ -517,7 +575,11 @@ function chooseCellSize(b: Bounds, count: number, opt: DeriveClassificationOptio
   let cell = opt.cellSizeM;
   if (cell === undefined || !Number.isFinite(cell) || cell <= 0) {
     const spacing = area > 0 && count > 0 ? Math.sqrt(area / count) : 1;
-    cell = Math.min(5, Math.max(0.5, spacing * 2.5));
+    // The 0.5..5 m clamp is physical, so restate it in source units — otherwise a
+    // foot cloud clamps at 0.5..5 ft and derives a different-size grid than the
+    // equivalent metre cloud, changing the classification.
+    const lin = opt.linearUnitToMetres && opt.linearUnitToMetres > 0 ? opt.linearUnitToMetres : 1;
+    cell = Math.min(5 / lin, Math.max(0.5 / lin, spacing * 2.5));
   }
   // Grow the cell until both grid dimensions fit the cap.
   const fits = (c: number): boolean =>

--- a/src/validation/classifierCorpus.ts
+++ b/src/validation/classifierCorpus.ts
@@ -478,6 +478,9 @@ export const LENGTH_PARAM_KEYS: readonly string[] = Object.freeze([
   'medVegBandM',
   'buildingRoughnessMaxM',
   'buildingMinHagM',
+  // v3: the structural wall-rescue radius is a length, so a foot scene must scale
+  // it like the rest, or the metre/foot equivalence would not cover the rescue.
+  'structuralNeighborRadiusM',
 ]);
 
 /**

--- a/tests/classifierUnitFrame.test.ts
+++ b/tests/classifierUnitFrame.test.ts
@@ -1,0 +1,95 @@
+/**
+ * classifierUnitFrame.test.ts
+ *
+ * The classifier's parameters are physical metres, but it runs on raw source
+ * coordinates. A caller must restate the parameters in the cloud's source units
+ * before running, or a foot cloud classifies with a 0.5 ft ground band and a
+ * 1 ft wall-rescue radius instead of 0.5 m and 1 m. `classifierParamsForFrame`
+ * is that boundary converter, and the production classify path applies it via
+ * `classifierOptions`. This pins the conversion and the end-to-end equivalence:
+ * the same physical terrain classifies the same whether its coordinates are in
+ * metres or feet.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  classifierParamsForFrame,
+  deriveClassification,
+  CLASSIFIER_PRESET,
+  DERIVED_GROUND,
+  DERIVED_BUILDING,
+} from '../src/render/class/deriveClassification';
+
+const FOOT = 0.3048;
+const P = CLASSIFIER_PRESET.params;
+
+describe('classifierParamsForFrame — unit conversion', () => {
+  it('a unit frame returns the metre defaults unchanged', () => {
+    const out = classifierParamsForFrame({ linearUnitToMetres: 1, verticalUnitToMetres: 1 });
+    expect(out.maxObjectSizeM).toBeCloseTo(P.maxObjectSizeM, 12);
+    expect(out.groundBandM).toBeCloseTo(P.groundBandM, 12);
+    expect(out.structuralNeighborRadiusM).toBeCloseTo(P.structuralNeighborRadiusM, 12);
+    expect(out.slope).toBeCloseTo(P.slope, 12);
+  });
+
+  it('a foot frame divides every length by the foot factor, slope unchanged', () => {
+    const out = classifierParamsForFrame({ linearUnitToMetres: FOOT, verticalUnitToMetres: FOOT });
+    // Horizontal.
+    expect(out.maxObjectSizeM).toBeCloseTo(P.maxObjectSizeM / FOOT, 9);
+    expect(out.structuralNeighborRadiusM).toBeCloseTo(P.structuralNeighborRadiusM / FOOT, 9);
+    // Vertical.
+    expect(out.groundBandM).toBeCloseTo(P.groundBandM / FOOT, 9);
+    expect(out.buildingMinHagM).toBeCloseTo(P.buildingMinHagM / FOOT, 9);
+    // Slope is a rise/run ratio; both axes share the foot, so it is unchanged.
+    expect(out.slope).toBeCloseTo(P.slope, 12);
+  });
+
+  it('a compound frame scales horizontal and vertical separately and adjusts slope', () => {
+    // Metre horizontal, foot vertical.
+    const out = classifierParamsForFrame({ linearUnitToMetres: 1, verticalUnitToMetres: FOOT });
+    expect(out.maxObjectSizeM).toBeCloseTo(P.maxObjectSizeM, 12); // horizontal unchanged
+    expect(out.groundBandM).toBeCloseTo(P.groundBandM / FOOT, 9); // vertical scaled
+    expect(out.slope).toBeCloseTo(P.slope * (1 / FOOT), 9); // ratio scaled
+  });
+
+  it('a missing or zero factor falls back to 1 (metre defaults, no NaN)', () => {
+    const out = classifierParamsForFrame({ linearUnitToMetres: null, verticalUnitToMetres: 0 });
+    expect(out.groundBandM).toBeCloseTo(P.groundBandM, 12);
+    expect(Number.isFinite(out.slope as number)).toBe(true);
+  });
+});
+
+/**
+ * A ground plane with a raised smooth block (a building). 60x60 m at 1 m
+ * spacing, block 12x12 m raised 6 m. Deterministic, no RNG.
+ */
+function scene(scale: number): Float32Array {
+  const pts: number[] = [];
+  for (let i = 0; i <= 60; i++) {
+    for (let j = 0; j <= 60; j++) {
+      const inBlock = i >= 24 && i <= 36 && j >= 24 && j <= 36;
+      const z = inBlock ? 6 : 0;
+      pts.push(i * scale, j * scale, z * scale);
+    }
+  }
+  return new Float32Array(pts);
+}
+
+describe('deriveClassification — metre / foot physical equivalence', () => {
+  it('classifies the same physical terrain identically in metres and feet', () => {
+    const metre = new Float32Array(scene(1));
+    const n = metre.length / 3;
+    const foot = new Float32Array(scene(1 / FOOT));
+
+    const metreRes = deriveClassification(metre, n, {});
+    const footRes = deriveClassification(foot, n, {
+      ...classifierParamsForFrame({ linearUnitToMetres: FOOT, verticalUnitToMetres: FOOT }),
+    });
+
+    // The block is a building and the plane is ground in both frames.
+    expect(metreRes.counts[DERIVED_BUILDING]).toBeGreaterThan(0);
+    expect(metreRes.counts[DERIVED_GROUND]).toBeGreaterThan(0);
+    // Same physical scene, so the per-code totals match point-for-point.
+    expect(footRes.counts[DERIVED_BUILDING]).toBe(metreRes.counts[DERIVED_BUILDING]);
+    expect(footRes.counts[DERIVED_GROUND]).toBe(metreRes.counts[DERIVED_GROUND]);
+  });
+});


### PR DESCRIPTION
Finding #1 from the latest audit, and a regression from the v3 wall rescue I shipped in #411.

deriveClassification's parameters are named in metres (maxObjectSizeM, groundBandM, structuralNeighborRadiusM, and the vertical bands) but it runs on the cloud's raw source coordinates, and the production classify path passed only the cue flags with no unit conversion. A foot cloud therefore classified with a 0.5 ft ground band and a 1 ft wall-rescue radius instead of 0.5 m and 1 m, which changes the result. My v3 structuralNeighborRadiusM was also missing from the corpus scaled keys, so the metre/foot equivalence test did not cover the wall rescue at all. The corpus passed only because it scales the parameters per scene, which the comment there notes is exactly what a foot-cloud caller must do. Production did not.

Fix:

- classifierParamsForFrame restates the physical parameters in the cloud's source units. Horizontal lengths (maxObjectSize, structuralNeighborRadius) divide by linearUnitToMetres, vertical lengths (elevThreshold, HAG bands, roughness, buildingMinHag) by verticalUnitToMetres, and slope, a rise/run ratio, by their quotient. A unit frame returns the metre defaults unchanged.
- classifierOptions merges that with the cues, and both production classify sites use it (main.ts stays net-neutral).
- The auto cell-size clamp (0.5..5 m) is now stated in source units, so a foot cloud derives the same physical grid a metre cloud does. This was a second unit dependency the equivalence test surfaced.
- structuralNeighborRadiusM joins LENGTH_PARAM_KEYS, closing the v3 corpus-coverage gap.

Verification: a new classifierUnitFrame test pins the conversion (horizontal, vertical, compound, fallback) and an end-to-end equivalence where the same physical terrain classifies point-for-point identically in metres and feet. The corpus units-metre and units-foot scenes now sit at an identical 0.9898 macro-F1, the corpus digest and freeze are unchanged, and the full suite is green (9412 pass).

Not in scope: the audit also suggests renaming the internal parameters to ...XYUnits / ...ZUnits and adding an international-foot plus explicit walls scene to the corpus. Both are worthwhile follow-ups; this PR fixes the production correctness bug and the coverage gap first.