### PR TITLE
fix: Project card sizes are physical and up-axis aware

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,825 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,824 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -99,7 +99,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,825)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,824)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.5.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.5.md
@@ -4,7 +4,7 @@ This release sharpens classification, hardens the report and export surfaces aga
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,825 lines and `src/render/Viewer.ts` is 6,395, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and shared domain/application state is owned by AppContext/services, with the composition root retaining only explicitly bounded shell-local composition and lifecycle state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,824 lines and `src/render/Viewer.ts` is 6,395, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and shared domain/application state is owned by AppContext/services, with the composition root retaining only explicitly bounded shell-local composition and lifecycle state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## Building classification: the ground-support gate is evaluated on synthetic scenes only
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5825,
+      "lines": 5824,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,7 @@ import {
 import { WorkflowController, WORKFLOW_RECORDER_ENABLED } from './ui/WorkflowController';
 import type { WorkflowConfigPanel } from './ui/WorkflowConfigPanel';
 import { RecommendedViewChip } from './ui/RecommendedViewChip';
-import { recommendCameraPreset, flatnessFromBounds } from './render/camera/recommendView';
+import { recommendCameraPreset, flatnessFromBounds, describeProjectSize } from './render/camera/recommendView';
 import type { WorkflowEvent } from './render/workflow/workflowRecorder';
 import { matchesShortcut } from './render/workflow/workflowConfig';
 import { LassoVolumeTool } from './ui/LassoVolumeTool';
@@ -5434,14 +5434,13 @@ function stopStreamingStatusPolling(): void {
 /** Reveal the "Project ready" summary card for a freshly opened scan. */
 function showProjectCard(cloud: PointCloud, totalCount: number): void {
   const b = cloud.bounds();
+  const c = crsService.context();
   projectCard.show({
     name: cloud.name,
     format: cloud.sourceFormat,
     shownCount: cloud.pointCount,
     totalCount,
-    width: b.max[0] - b.min[0],
-    depth: b.max[1] - b.min[1],
-    height: b.max[2] - b.min[2],
+    ...describeProjectSize(b.min, b.max, { upAxis: c.upAxis, linearUnitKnown: c.linearUnitKnown, linearUnitToMetres: c.linearUnitToMetres, verticalUnitToMetres: verticalMetresPerUnit(c, 'horizontal') ?? undefined }),
     hasRgb: cloud.colors !== undefined,
     hasIntensity: cloud.intensity !== undefined,
     hasClassification: cloud.classification !== undefined,

--- a/src/render/camera/recommendView.ts
+++ b/src/render/camera/recommendView.ts
@@ -68,3 +68,49 @@ export function flatnessFromBounds(
   if (height <= 0) return FLAT_RATIO; // flat-as-a-sheet → plan view
   return horizontal / height;
 }
+
+/** A scan's extents for the Project card. */
+export interface ProjectSize {
+  /** Extents in {@link sizeUnit}, ordered width, depth, height. */
+  readonly width: number;
+  readonly depth: number;
+  readonly height: number;
+  readonly sizeUnit: 'm' | 'source units';
+  /** Largest extent in physical metres, or null when the linear scale is unresolved. */
+  readonly maxPhysicalDimM: number | null;
+}
+
+/**
+ * The scan's extents for the Project card, in physical metres when the CRS
+ * resolves a linear unit and in raw source units otherwise (labelled as such, so
+ * a foot cloud is never shown as metres). The up-axis picks which extent is
+ * height, so a Y-up scan reports its vertical extent as height rather than a
+ * horizontal axis. `maxPhysicalDimM` is null when the scale is unknown, so a
+ * caller does not map an unknown-unit size onto metre navigation thresholds.
+ */
+export function describeProjectSize(
+  min: readonly [number, number, number],
+  max: readonly [number, number, number],
+  frame: {
+    readonly upAxis: 'z' | 'y' | 'unknown';
+    readonly linearUnitKnown: boolean;
+    readonly linearUnitToMetres: number;
+    readonly verticalUnitToMetres?: number;
+  },
+): ProjectSize {
+  const ext = [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
+  const upIdx = frame.upAxis === 'y' ? 1 : 2; // 'z' | 'unknown' -> Z
+  const [hA, hB] = [0, 1, 2].filter((i) => i !== upIdx);
+  const rawW = ext[hA];
+  const rawD = ext[hB];
+  const rawH = ext[upIdx];
+  if (!frame.linearUnitKnown || !(frame.linearUnitToMetres > 0)) {
+    return { width: rawW, depth: rawD, height: rawH, sizeUnit: 'source units', maxPhysicalDimM: null };
+  }
+  const hz = frame.linearUnitToMetres;
+  const vt = frame.verticalUnitToMetres && frame.verticalUnitToMetres > 0 ? frame.verticalUnitToMetres : hz;
+  const width = rawW * hz;
+  const depth = rawD * hz;
+  const height = rawH * vt;
+  return { width, depth, height, sizeUnit: 'm', maxPhysicalDimM: Math.max(width, depth, height) };
+}

--- a/src/ui/ProjectCard.ts
+++ b/src/ui/ProjectCard.ts
@@ -8,10 +8,14 @@ export interface ProjectInfo {
   shownCount: number;
   /** Points decoded from the file (before downsampling). */
   totalCount: number;
-  /** Bounding-box extents in metres. */
+  /** Bounding-box extents in {@link sizeUnit}, ordered width, depth, height. */
   width: number;
   depth: number;
   height: number;
+  /** 'm' when the CRS resolves a linear unit, else 'source units'. */
+  sizeUnit: 'm' | 'source units';
+  /** Largest extent in physical metres, or null when the scale is unresolved. */
+  maxPhysicalDimM: number | null;
   hasRgb: boolean;
   hasIntensity: boolean;
   hasClassification: boolean;
@@ -20,11 +24,15 @@ export interface ProjectInfo {
 /** How long the card lingers before fading out on its own. */
 const DISMISS_MS = 7000;
 
-/** A suggested navigation mode, derived from the scan's physical size. */
-function suggestMode(info: ProjectInfo): string {
-  const maxDim = Math.max(info.width, info.depth, info.height);
-  if (maxDim > 150) return 'Fly — large outdoor scan';
-  if (maxDim > 15) return 'Walk — building / interior scale';
+/**
+ * A suggested navigation mode from the scan's PHYSICAL size (metres). Only shown
+ * when the size is physical: an unknown-unit scan cannot be mapped onto these
+ * metre thresholds without risking a wrong recommendation, so the caller omits
+ * the row in that case.
+ */
+function suggestMode(maxDimM: number): string {
+  if (maxDimM > 150) return 'Fly — large outdoor scan';
+  if (maxDimM > 15) return 'Walk — building / interior scale';
   return 'Orbit — object scale';
 }
 
@@ -84,9 +92,9 @@ export class ProjectCard {
       el('div', { className: 'olv-pc-grid' }, [
         row('Format', info.format.toUpperCase()),
         row('Points', points),
-        row('Size', `${info.width.toFixed(1)} × ${info.depth.toFixed(1)} × ${info.height.toFixed(1)} m`),
+        row('Size', `${info.width.toFixed(1)} × ${info.depth.toFixed(1)} × ${info.height.toFixed(1)} ${info.sizeUnit}`),
         row('Attributes', attrs.length ? attrs.join(', ') : 'positions only'),
-        row('Suggested', suggestMode(info)),
+        ...(info.maxPhysicalDimM != null ? [row('Suggested', suggestMode(info.maxPhysicalDimM))] : []),
         row('Performance', performance(info.totalCount)),
       ]),
       el('div', { className: 'olv-pc-countdown' }),

--- a/tests/projectSize.test.ts
+++ b/tests/projectSize.test.ts
@@ -1,0 +1,78 @@
+/**
+ * projectSize.test.ts
+ *
+ * The Project card shows a scan's extents. They must read in physical metres
+ * only when the CRS resolves a linear unit, in raw source units otherwise (never
+ * a false 'm'), and the height must follow the source up-axis so a Y-up scan
+ * does not report a horizontal axis as its height. `maxPhysicalDimM` is null when
+ * the scale is unknown, so the card omits the metre-threshold navigation hint
+ * rather than guessing.
+ */
+import { describe, it, expect } from 'vitest';
+import { describeProjectSize } from '../src/render/camera/recommendView';
+
+const MIN: [number, number, number] = [0, 0, 0];
+// X extent 300, Y extent 200, Z extent 25.
+const MAX: [number, number, number] = [300, 200, 25];
+const FOOT = 0.3048;
+
+describe('describeProjectSize', () => {
+  it('metres pass through, Z is height, and maxPhysicalDimM is the largest', () => {
+    const s = describeProjectSize(MIN, MAX, {
+      upAxis: 'z',
+      linearUnitKnown: true,
+      linearUnitToMetres: 1,
+      verticalUnitToMetres: 1,
+    });
+    expect([s.width, s.depth]).toEqual([300, 200]); // horizontal X, Y
+    expect(s.height).toBe(25); // Z
+    expect(s.sizeUnit).toBe('m');
+    expect(s.maxPhysicalDimM).toBe(300);
+  });
+
+  it('a foot cloud reports physical metres, not the raw foot numbers', () => {
+    const s = describeProjectSize(MIN, MAX, {
+      upAxis: 'z',
+      linearUnitKnown: true,
+      linearUnitToMetres: FOOT,
+      verticalUnitToMetres: FOOT,
+    });
+    expect(s.width).toBeCloseTo(300 * FOOT, 6);
+    expect(s.height).toBeCloseTo(25 * FOOT, 6);
+    expect(s.sizeUnit).toBe('m');
+    expect(s.maxPhysicalDimM).toBeCloseTo(300 * FOOT, 6);
+  });
+
+  it('a Y-up scan takes its height from the Y extent', () => {
+    const s = describeProjectSize(MIN, MAX, {
+      upAxis: 'y',
+      linearUnitKnown: true,
+      linearUnitToMetres: 1,
+      verticalUnitToMetres: 1,
+    });
+    expect(s.height).toBe(200); // Y is up
+    expect([s.width, s.depth]).toEqual([300, 25]); // horizontal X, Z
+  });
+
+  it('an unknown linear unit reports source units and no metre navigation hint', () => {
+    const s = describeProjectSize(MIN, MAX, {
+      upAxis: 'z',
+      linearUnitKnown: false,
+      linearUnitToMetres: 1,
+    });
+    expect(s.width).toBe(300); // raw
+    expect(s.sizeUnit).toBe('source units');
+    expect(s.maxPhysicalDimM).toBeNull();
+  });
+
+  it('a compound frame scales horizontal and vertical separately', () => {
+    const s = describeProjectSize(MIN, MAX, {
+      upAxis: 'z',
+      linearUnitKnown: true,
+      linearUnitToMetres: 1, // metre horizontal
+      verticalUnitToMetres: FOOT, // foot vertical
+    });
+    expect(s.width).toBe(300); // horizontal unchanged
+    expect(s.height).toBeCloseTo(25 * FOOT, 6); // vertical scaled
+  });
+});


### PR DESCRIPTION
Audit finding #7.

The Project-ready card rendered the raw bounding-box extents as metres and picked axis 2 as height. A foot cloud showed feet labelled as metres (300 x 200 x 25 m when the numbers are feet), a Y-up scan reported a horizontal axis as its height, and the size-based Fly/Walk/Orbit hint ran on those wrong numbers, so a unit error could flip the recommendation.

describeProjectSize restates the extents in physical metres when the CRS resolves a linear unit (horizontal by linearUnitToMetres, vertical by verticalUnitToMetres) and in raw source units otherwise, labelled 'source units' rather than a false 'm'. The up-axis chooses which extent is height, so a Y-up scan reports its vertical extent. maxPhysicalDimM is null when the scale is unresolved, so the card omits the navigation hint instead of mapping an unknown-unit size onto metre thresholds. showProjectCard passes the resolved CRS context through, and main.ts stays net-neutral.

A new projectSize test covers metre pass-through, foot conversion, the Y-up height axis, the unknown-unit fallback, and a compound frame. Full suite green (9417).

Note: the audit also flags recommendView's own flatnessFromBounds as Z-up-assuming. That is a ratio and is used for the separate camera-preset chip, which is a follow-up; this PR fixes the card's false-metres and wrong-height display.