### PR TITLE
fix: Clip panel is reachable on mobile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3835,7 +3835,7 @@ void viewerLoaded.then(() => {
       mobileSheet.slot('layers').append(dataEls.layers, dataEls.layerHealth);
       const layersPanels: HTMLElement[] = [classLegendPanel.element, processStudio.panel.element];
       if (measureMount.panel) layersPanels.push(measureMount.panel.element);
-      layersPanels.push(annotationPanel.element, exportPanel.element);
+      layersPanels.push(clipPanel.element, annotationPanel.element, exportPanel.element);
       mobileSheet.slot('layers').append(...layersPanels);
       // Drop the desktop collapsed state so mobile users don't see a nested
       // collapsed header inside the sheet's own collapse chrome.


### PR DESCRIPTION
Audit finding #2.

The desktop layout mounts Clip under the Data workspace, but the mobile bottom sheet only reparents the layer, class, process, measure, annotation, and export panels into its slots. It never moves clipPanel.element, and it then hides the desktop workspace (leftPanels) where Clip lives. So on a phone Clip was present in application state but sat inside a hidden container, unreachable.

The fix reparents Clip into the sheet's Layers slot alongside the other scene tools (Measure and Annotate already live there), matching their exact reparenting pattern. The desktop layout already restores Clip through layoutDesktop, so a rotate or resize back to desktop is unaffected. One-line, net-neutral to the monolith baseline.

The fuller mobile information architecture (a View / Data / Analyse / Output sheet, with Clip as a contextual tool) is a separate, larger item (audit #9). This PR makes Clip reachable now.

Verification: full suite green (9412). The reparenting mirrors the working Measure and Annotate paths; the on-screen result is best confirmed at a mobile width with a scan open.