### PR TITLE
fix: streaming panel does not read ready with decoded-pending nodes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5335,7 +5335,7 @@ function startStreamingStatusPolling(): void {
     });
     if (counts.resident === 0) {
       streamingPanel.setPhase('Streaming coarse geometry…');
-    } else if (counts.loading > 0 || counts.queued > 0) {
+    } else if (counts.loading > 0 || counts.queued > 0 || counts.decoded > 0) {
       streamingPanel.setPhase('Refining visible detail…');
     } else {
       streamingPanel.setPhase('Streaming ready');

--- a/src/render/streaming/StreamingNodeStore.ts
+++ b/src/render/streaming/StreamingNodeStore.ts
@@ -20,6 +20,13 @@ export interface NodeCounts {
   loading: number;
   resident: number;
   error: number;
+  /**
+   * Nodes decoded but NOT yet committed to the renderer (awaiting a metered GPU
+   * upload). Non-zero means work is still landing, so a "ready" verdict that
+   * checks only queued/loading would fire too early. Not folded into resident:
+   * resident means drawn, decoded means decoded-and-waiting.
+   */
+  decoded: number;
 }
 
 /** Owns every known node and keeps resident-point accounting exact. */
@@ -222,6 +229,7 @@ export class StreamingNodeStore {
       loading: this._loadingCount,
       resident: this._resident.size,
       error: this._errorCount,
+      decoded: this._decoded.size,
     };
   }
 }

--- a/tests/streamingNodeStoreCounts.test.ts
+++ b/tests/streamingNodeStoreCounts.test.ts
@@ -25,14 +25,15 @@ function rec(id: string): StreamingNodeRecord {
 
 /** Ground-truth walk — what the old O(n) implementation returned. */
 function walk(store: StreamingNodeStore) {
-  let queued = 0, loading = 0, resident = 0, error = 0;
+  let queued = 0, loading = 0, resident = 0, error = 0, decoded = 0;
   for (const n of store.all()) {
     if (n.state === 'queued') queued++;
     else if (n.state === 'loading') loading++;
     else if (n.state === 'resident') resident++;
     else if (n.state === 'error') error++;
+    else if (n.state === 'decoded') decoded++;
   }
-  return { known: store.size, queued, loading, resident, error };
+  return { known: store.size, queued, loading, resident, error, decoded };
 }
 
 describe('StreamingNodeStore.counts() — O(1) counters track a ground-truth walk', () => {
@@ -79,8 +80,21 @@ describe('StreamingNodeStore.counts() — O(1) counters track a ground-truth wal
     expect(store.counts().known).toBe(3);
   });
 
+  it('counts decoded-pending nodes and clears them on commit', () => {
+    const store = new StreamingNodeStore();
+    const a = store.add(rec('a'));
+    store.setState(a, 'loading');
+    store.setState(a, 'decoded', 100);
+    expect(store.counts()).toEqual(walk(store));
+    // decoded-pending is its own bucket: not loading, not yet resident.
+    expect(store.counts()).toMatchObject({ decoded: 1, loading: 0, resident: 0 });
+    // Committing to the renderer moves it to resident and clears decoded.
+    store.setState(a, 'resident', 100);
+    expect(store.counts()).toMatchObject({ decoded: 0, resident: 1 });
+  });
+
   it('starts at all-zero for a fresh store', () => {
     const store = new StreamingNodeStore();
-    expect(store.counts()).toEqual({ known: 0, queued: 0, loading: 0, resident: 0, error: 0 });
+    expect(store.counts()).toEqual({ known: 0, queued: 0, loading: 0, resident: 0, error: 0, decoded: 0 });
   });
 });

--- a/tests/streamingOctree.test.ts
+++ b/tests/streamingOctree.test.ts
@@ -53,7 +53,7 @@ test('StreamingNodeStore.counts and setError report lifecycle state', () => {
   store.setState(a, 'queued');
   store.setError(b, 'decode failed');
   const counts = store.counts();
-  expect(counts).toEqual({ known: 2, queued: 1, loading: 0, resident: 0, error: 1 });
+  expect(counts).toEqual({ known: 2, queued: 1, loading: 0, resident: 0, error: 1, decoded: 0 });
   expect(b.error).toBe('decode failed');
 });
 


### PR DESCRIPTION
The honest-label half of audit #3.

The streaming panel derives its phase from cloud.counts(), which reported known, queued, loading, resident, and error, but not the decoded-pending state. With metered GPU commits a node can be fully fetched and decoded and still waiting for its upload, so with queued and loading both zero the panel showed 'Streaming ready' while points were still landing, and the progress bar had already latched to 100 percent.

The store already maintains a _decoded set (used by decodedPending()), so counts() now reports its size in O(1) as a new decoded field. The panel ready gate requires resident greater than zero and queued, loading, and decoded all zero, so a slow commit stays on 'Refining visible detail' until the last node is actually on screen.

Verification: a new store test pins that a decoded node is counted in its own bucket and clears to resident on commit. The three tests that assert the exact counts() shape were updated. Full suite green (9413).

Scope: this is the panel-truth half. The render-loop still steps DPR refinement from elapsed time (coverageComplete and centralRefined are msSinceSettle thresholds), and the tested refinementReadiness engine is still unwired there. That flip changes on-screen sharpening and needs verification against a live stream, so it is a separate follow-up rather than folded in here.