### PR TITLE
fix: camera flatness reads height off the up axis

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5450,7 +5450,7 @@ function showProjectCard(cloud: PointCloud, totalCount: number): void {
   const rec = recommendCameraPreset({
     hasRgb: cloud.colors !== undefined,
     hasClassification: cloud.classification !== undefined,
-    flatness: flatnessFromBounds(b.min, b.max),
+    flatness: flatnessFromBounds(b.min, b.max, c.upAxis),
   });
   recommendedViewChip.show(rec, () => viewer.setCameraPreset(rec.preset));
 }

--- a/src/render/camera/recommendView.ts
+++ b/src/render/camera/recommendView.ts
@@ -59,11 +59,15 @@ export function recommendCameraPreset(input: ViewRecommendationInput): ViewRecom
 export function flatnessFromBounds(
   min: readonly [number, number, number],
   max: readonly [number, number, number],
+  upAxis: 'z' | 'y' | 'unknown' = 'z',
 ): number {
-  const width = Math.abs(max[0] - min[0]);
-  const depth = Math.abs(max[1] - min[1]);
-  const height = Math.abs(max[2] - min[2]);
-  const horizontal = Math.max(width, depth);
+  // The height axis is the up axis; the other two are horizontal. A Y-up scan
+  // whose height was read off Z would get an inverted ratio and the wrong
+  // recommended view.
+  const upIdx = upAxis === 'y' ? 1 : 2; // 'z' | 'unknown' -> Z
+  const [hA, hB] = [0, 1, 2].filter((i) => i !== upIdx);
+  const horizontal = Math.max(Math.abs(max[hA] - min[hA]), Math.abs(max[hB] - min[hB]));
+  const height = Math.abs(max[upIdx] - min[upIdx]);
   if (horizontal <= 0) return 1;
   if (height <= 0) return FLAT_RATIO; // flat-as-a-sheet → plan view
   return horizontal / height;

--- a/tests/recommendView.test.ts
+++ b/tests/recommendView.test.ts
@@ -42,4 +42,13 @@ describe('flatnessFromBounds', () => {
     expect(flatnessFromBounds([0, 0, 0], [100, 100, 0])).toBeGreaterThanOrEqual(6);
     expect(flatnessFromBounds([5, 5, 5], [5, 5, 5])).toBe(1);
   });
+
+  it('reads height off the up axis, so a Y-up wide-shallow tile is still flat', () => {
+    // Same wide-shallow tile with its 50-unit shallow extent on Y (Y-up). Read
+    // Z-up it would look like a 1000x50 wall (ratio 1); with upAxis='y' the
+    // shallow Y is the height and the ratio is 20.
+    expect(flatnessFromBounds([0, 0, 0], [1000, 50, 1000], 'y')).toBeCloseTo(20, 5);
+    // Default (Z-up) on the same box treats Z as height → not flat.
+    expect(flatnessFromBounds([0, 0, 0], [1000, 50, 1000])).toBeCloseTo(1, 5);
+  });
 });


### PR DESCRIPTION
flatnessFromBounds picked the Z extent as height regardless of the scan's up axis. A Y-up cloud had its vertical extent treated as horizontal, so a wide, shallow tile read as a tall wall and drew a perspective recommendation instead of the plan view. The function now takes the up axis and selects the height extent from it, matching describeProjectSize in the same file. The parameter defaults to Z, so every existing caller and test behaves as before; the one production call site passes the resolved context up axis.

Covered by a new recommendView test: the same wide-shallow box reads as flat under upAxis 'y' and as a cube under the Z default.