### PR TITLE
fix: classification needs a known unit to be ready, not review

### DIFF
--- a/src/process/processCapabilities.ts
+++ b/src/process/processCapabilities.ts
@@ -93,7 +93,16 @@ function compareVerticalReference(a: ScanFacts, b: ScanFacts): VerticalReference
   return { ok: true };
 }
 
-/** Classification of unclassified points — geometry-driven, no CRS needed. */
+/**
+ * Classification of unclassified points. The classifier is geometry-driven but
+ * its thresholds are PHYSICAL (a 20 m object size, a 1 m structural
+ * neighbourhood, 0.5/2/5 m height bands), so a known source unit is needed to
+ * normalize them. With the unit unconfirmed the classifier falls back to a
+ * factor of 1, treating one source unit as one metre, and the same physical
+ * geometry expressed in feet or metres can classify differently. Classification
+ * for inspection is still allowed; the confirmed-unit result is what a graded
+ * product needs.
+ */
 function classifyGaps(scan: ScanFacts): ProductCapability {
   const p: ProductId = 'classify-gaps';
   if (scan.pointCount <= 0) {
@@ -104,6 +113,9 @@ function classifyGaps(scan: ScanFacts): ProductCapability {
   }
   if (!isFullCoverage(scan)) {
     return cap(p, 'review', 'PARTIAL_COVERAGE', 'Only resident or sampled points are available, so classification would cover part of the scan; it is labelled as such.');
+  }
+  if (!isLinearUnitKnown(scan.crs)) {
+    return cap(p, 'review', 'UNIT_UNKNOWN', 'Classification can be derived for inspection, but its physical neighbourhood and height thresholds cannot be normalized until the source unit is confirmed, so the same geometry in another unit may classify differently.');
   }
   return cap(p, 'ready', 'GAPS_CLASSIFIABLE', 'Unclassified points can be classified from geometry while producer classes are preserved.');
 }

--- a/tests/processCapabilities.test.ts
+++ b/tests/processCapabilities.test.ts
@@ -63,6 +63,16 @@ describe('classify-gaps', () => {
   it('blocked with no points', () => {
     expect(verdict([scan({ pointCount: 0 })], 'classify-gaps').readiness).toBe('blocked');
   });
+  it('review when the linear unit is unknown (physical thresholds cannot be normalized)', () => {
+    const v = verdict([scan({ crs: crs({ linearUnit: 'unknown' }) })], 'classify-gaps');
+    expect(v.readiness).toBe('review');
+    expect(v.reasonCode).toBe('UNIT_UNKNOWN');
+  });
+  it('review when the CRS is missing entirely (fail closed, not assumed metre)', () => {
+    const v = verdict([scan({ crs: null })], 'classify-gaps');
+    expect(v.readiness).toBe('review');
+    expect(v.reasonCode).toBe('UNIT_UNKNOWN');
+  });
 });
 
 describe('dtm — fail closed on unit and coverage', () => {


### PR DESCRIPTION
classifyGaps reported ready whether or not the linear unit was known, and the capability comment said classification is geometry-driven with no CRS needed. That was true before the classifier carried physical parameters. It now normalizes a 20 m object size, a 1 m structural neighbourhood, and 0.5/2/5 m height bands against the source unit, and falls back to a factor of 1 when the unit is unknown, so a foot cloud with unidentified units can classify differently from the same geometry in metres.

The capability now gates on the linear unit the way dtm and dsm already do: an unknown or missing unit is review with reason UNIT_UNKNOWN, and the reason states that classification for inspection is allowed but the physical neighbourhood and height thresholds cannot be normalized until the unit is confirmed. A known unit still reads ready. Two new tests cover the unknown-unit and missing-CRS paths.