### PR TITLE
feat: drive refinement DPR from wanted-set readiness, not a clock

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -166,7 +166,7 @@ no DOM, three.js or proj4 (`tests/scanFootprint.test.ts`); the serialiser is
 `buildFootprintKml` in the existing `src/export/kmlExport.ts`. `main.ts` keeps
 four thin delegates and the deps object.
 
-**`src/render/Viewer.ts` (6,395)** — the constructor and a handful of large
+**`src/render/Viewer.ts` (6,419)** — the constructor and a handful of large
 methods dominate:
 
 Spans below are the symbol's real extent, read from the TypeScript symbol graph

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.5.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.5.md
@@ -4,7 +4,7 @@ This release sharpens classification, hardens the report and export surfaces aga
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,824 lines and `src/render/Viewer.ts` is 6,395, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and shared domain/application state is owned by AppContext/services, with the composition root retaining only explicitly bounded shell-local composition and lifecycle state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,824 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and shared domain/application state is owned by AppContext/services, with the composition root retaining only explicitly bounded shell-local composition and lifecycle state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## Building classification: the ground-support gate is evaluated on synthetic scenes only
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -5,7 +5,7 @@
       "goal": 2500
     },
     "src/render/Viewer.ts": {
-      "lines": 6395,
+      "lines": 6419,
       "goal": 2000
     }
   }

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -113,6 +113,8 @@ import {
   phaseDprScale,
   type RefinementPhase,
 } from './refinementPhase';
+import { evaluateRefinementReadiness } from './streaming/refinementReadiness';
+import type { RefinementReadiness } from './streaming/refinementReadiness';
 import { readDevFlags } from '../perf/devFlags';
 import { POINT_STYLE_DEFAULTS } from './pointStyle';
 import type { PointSizeMode } from './pointStyle';
@@ -2159,6 +2161,16 @@ export class Viewer {
   /** The streaming scheduler, or null — for the streaming panel and diagnostics. */
   get streamingScheduler(): StreamingScheduler | null {
     return this._streaming?.scheduler ?? null;
+  }
+
+  /**
+   * Wanted-set refinement readiness for the active streaming session, or null
+   * when nothing is streaming. Drives the DPR phase machine and lets the panel
+   * read the same verdict the renderer acts on, not a divergent guess.
+   */
+  refinementReadiness(): RefinementReadiness | null {
+    const scheduler = this._streaming?.scheduler;
+    return scheduler ? evaluateRefinementReadiness(scheduler.readinessFacts()) : null;
   }
 
   /**
@@ -6240,18 +6252,30 @@ export class Viewer {
 
     let target: number;
     if (this._refinementPhasesEnabled) {
-      // P6 — track settle time and step DPR by discrete refinement phase. The
-      // coverage / central-refinement readiness are time proxies here until the
-      // P4 scheduler emits real signals; the phase machine itself is exact.
+      // P6 — step DPR by discrete refinement phase. With a streaming scheduler
+      // active the coverage / central-refine signals come from the WANTED-SET
+      // readiness verdict, so full resolution is reached only when the requested
+      // nodes are resident, not after a fixed time over a half-loaded cloud.
+      // Without a verdict (static cloud, or before the first cull) the
+      // elapsed-time proxy stands in; there is nothing to wait on there.
       if (moving) this._settledAtMs = 0;
       else if (this._settledAtMs === 0) this._settledAtMs = nowMs;
       const msSinceSettle = moving ? 0 : nowMs - this._settledAtMs;
+      const readiness = this.refinementReadiness();
+      const coverageComplete =
+        readiness && readiness.phase !== 'unknown'
+          ? readiness.phase === 'settling' || readiness.phase === 'settled'
+          : msSinceSettle >= SETTLE_MS;
+      const centralRefined =
+        readiness && readiness.phase !== 'unknown'
+          ? readiness.phase === 'settled'
+          : msSinceSettle >= PHASE_CENTER_PROXY_MS;
       this._phase = nextRefinementPhase(this._phase, {
         moving,
         msSinceSettle,
         settleMs: SETTLE_MS,
-        coverageComplete: msSinceSettle >= SETTLE_MS,
-        centralRefined: msSinceSettle >= PHASE_CENTER_PROXY_MS,
+        coverageComplete,
+        centralRefined,
       });
       target = Math.max(floor, maxDpr * phaseDprScale(this._phase));
       if (this._phase === 'moving' && angularSpeed > 0) {

--- a/src/render/refinementPhase.ts
+++ b/src/render/refinementPhase.ts
@@ -58,18 +58,14 @@ export interface PhaseInput {
  * cannot skip coverage. Monotonic while parked: it never steps backward without
  * motion.
  *
- * What this function does NOT guarantee, despite an earlier version of this
- * comment saying it does: that phases advance on anything other than elapsed
- * time. This is a pure function of its inputs, and `coverageComplete` and
- * `centralRefined` are declared above as accepting a proxy. The only production
- * caller supplies both as exactly that — `Viewer.ts` passes
- * `msSinceSettle >= SETTLE_MS` and `msSinceSettle >= PHASE_CENTER_PROXY_MS` —
- * so as shipped the machine is driven by a clock and by nothing else.
- *
- * The claim was not wrong about the contract, it was wrong about the system: a
- * signal-shaped parameter fed a timer. `refinementReadiness.ts` derives the two
- * signals from scheduler state and is what makes the original sentence true.
- * Until its output reaches this call site, read the phases as timing.
+ * This is a pure function of its inputs; `coverageComplete` and `centralRefined`
+ * are readiness signals the caller supplies. With a streaming scheduler active,
+ * `Viewer.ts` derives both from the wanted-set verdict in
+ * `refinementReadiness.ts` (`settling`/`settled` → coverage/central), so the
+ * machine advances on data that is actually resident. Only when no verdict
+ * exists — a static cloud with nothing to stream, or before the first cull —
+ * does the Viewer fall back to `msSinceSettle` proxies, where there is no
+ * outstanding data for a signal to describe.
  */
 export function nextRefinementPhase(current: RefinementPhase, input: PhaseInput): RefinementPhase {
   if (input.moving) return 'moving';

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -32,6 +32,7 @@ import {
   selectLapsedEvictions,
 } from './evictionPolicy';
 import type { EvictionCandidate, EvictionHysteresis } from './evictionPolicy';
+import type { SchedulerReadinessFacts } from './refinementReadiness';
 
 /** Renderer-facing callbacks the scheduler drives. */
 export interface SchedulerCallbacks {
@@ -637,6 +638,46 @@ export class StreamingScheduler {
       pressureDepthReduction: this._pressureDepthReduction,
       fpsBudgetFactor: this._fpsBudgetFactor,
       fullRescoreCount: this._fullRescoreCount,
+    };
+  }
+
+  /**
+   * Node-state counts over the LAST rescore's wanted set — the facts
+   * {@link evaluateRefinementReadiness} turns into a readiness verdict. Measured
+   * over the wanted set, not globally, so a node held resident by eviction
+   * hysteresis after leaving the view cannot vote readiness for the view. Before
+   * the first cull the wanted set is null and every count is 0, which the
+   * evaluator reads as `'unknown'` (its refusal rule), never `'settled'`.
+   */
+  readinessFacts(): SchedulerReadinessFacts {
+    const store = this._cloud.octree.store;
+    const wanted = this._lastWanted;
+    let residentCount = 0;
+    let inFlightCount = 0;
+    let queuedCount = 0;
+    let decodedPendingCount = 0;
+    let failedCount = 0;
+    if (wanted) {
+      for (const id of wanted) {
+        const node = store.get(id);
+        if (!node) continue;
+        switch (node.state) {
+          case 'resident': residentCount++; break;
+          case 'loading': inFlightCount++; break;
+          case 'queued': queuedCount++; break;
+          case 'decoded': decodedPendingCount++; break;
+          case 'error': failedCount++; break;
+          default: break; // 'unloaded' — not yet requested, counts against the denominator
+        }
+      }
+    }
+    return {
+      wantedCount: wanted ? wanted.size : 0,
+      residentCount,
+      inFlightCount,
+      queuedCount,
+      decodedPendingCount,
+      failedCount,
     };
   }
 

--- a/src/render/streaming/refinementReadiness.ts
+++ b/src/render/streaming/refinementReadiness.ts
@@ -36,11 +36,13 @@
  * Pure and deterministic: no timers, no DOM, no three.js, no scheduler import.
  * The same facts always produce the same verdict, so it is unit-tested in Node.
  *
- * STATUS: the pure half only. Nothing constructs `SchedulerReadinessFacts` from
- * a live `StreamingScheduler` yet, and the Viewer still feeds the phase machine
- * its time proxies. A tested leaf module with no production caller is not a
- * shipped behaviour change — this file is explicitly the former until the
- * scheduler emits these counts and the Viewer reads them.
+ * WIRING: `StreamingScheduler.readinessFacts()` builds `SchedulerReadinessFacts`
+ * from the live wanted set, and `Viewer.refinementReadiness()` evaluates it. The
+ * Viewer's DPR phase machine reads that verdict — `settling`/`settled` drive
+ * coverage and central-refine — so full resolution is reached only when the
+ * requested nodes are resident, not after a fixed elapsed time. The time proxy
+ * remains only as the fallback for a static cloud or the pre-first-cull window,
+ * where there is no wanted set to be ready about.
  */
 
 /**

--- a/tests/streamingScheduler.test.ts
+++ b/tests/streamingScheduler.test.ts
@@ -10,6 +10,7 @@ import {
   selectWithinBudget,
 } from '../src/render/streaming/streamingBudget';
 import { StreamingScheduler } from '../src/render/streaming/StreamingScheduler';
+import { evaluateRefinementReadiness } from '../src/render/streaming/refinementReadiness';
 import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
 import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
 import { buildSyntheticCopc } from './fixtures/copc/synthCopc';
@@ -994,4 +995,52 @@ test('nodes ingested AFTER scheduler construction still stream (late hierarchy)'
   await drain(scheduler);
   expect(ready.map((n) => n.record.id)).toContain('3-0-0-0');
   expect(cloud.counts().resident).toBe(6);
+});
+
+test('readinessFacts reports unknown before the first cull and settled once the wanted set is resident', async () => {
+  const cloud = await openCloud();
+  const scheduler = new StreamingScheduler(
+    cloud,
+    fakeDecoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    streamingBudgets('balanced', false),
+  );
+
+  // Before any update the wanted set is null: no denominator, no verdict.
+  const before = scheduler.readinessFacts();
+  expect(before.wantedCount).toBe(0);
+  expect(evaluateRefinementReadiness(before).phase).toBe('unknown');
+
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  // Every wanted node is resident, nothing outstanding, no failures → settled.
+  const after = scheduler.readinessFacts();
+  expect(after.wantedCount).toBeGreaterThan(0);
+  expect(after.residentCount).toBe(after.wantedCount);
+  expect(after.inFlightCount + after.queuedCount + after.decodedPendingCount).toBe(0);
+  const verdict = evaluateRefinementReadiness(after);
+  expect(verdict.phase).toBe('settled');
+  if (verdict.phase === 'settled') expect(verdict.fractionResident).toBe(1);
+});
+
+test('readinessFacts counts are measured over the wanted set, not globally', async () => {
+  const cloud = await openCloud();
+  const scheduler = new StreamingScheduler(
+    cloud,
+    fakeDecoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    streamingBudgets('balanced', false),
+  );
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  // The wanted count never exceeds the nodes the hierarchy has revealed, and the
+  // per-state buckets sum to no more than the wanted count (a node outside the
+  // wanted set cannot inflate any bucket).
+  const f = scheduler.readinessFacts();
+  const bucketed =
+    f.residentCount + f.inFlightCount + f.queuedCount + f.decodedPendingCount + f.failedCount;
+  expect(f.wantedCount).toBeLessThanOrEqual(cloud.counts().known);
+  expect(bucketed).toBeLessThanOrEqual(f.wantedCount);
 });


### PR DESCRIPTION
The refinement phase machine stepped device pixel ratio up to full resolution after a fixed time since the camera settled. On a streaming cloud that means a sharp, full-detail frame can paint over a half-loaded scene while the network is still delivering nodes, and a sharp frame reads as complete.

refinementReadiness.ts already derived an honest verdict from scheduler counts, but nothing produced the facts and the Viewer still fed the phase machine elapsed-time proxies. This wires it end to end:

- StreamingScheduler.readinessFacts() counts node states over the last wanted set (resident, in-flight, queued, decoded-pending, failed). Measured over the wanted set, not globally, so a node held resident by eviction hysteresis after leaving the view cannot vote readiness for the view.
- Viewer.refinementReadiness() evaluates those facts and is exposed for the panel to read the same verdict the renderer acts on.
- The DPR phase machine now takes coverageComplete and centralRefined from the verdict: settling or settled gives coverage, settled gives central-refine. Full resolution is reached only when the requested nodes are resident.

The elapsed-time proxy remains as the fallback for a static cloud with nothing to stream and for the window before the first cull, where there is no wanted set to be ready about, so non-streaming behaviour is unchanged.

Tests: readinessFacts reports unknown before the first cull and settled once the wanted set is resident, and its buckets stay bounded by the wanted count. Viewer.ts baseline moved 6395 to 6419 for the getter and wiring, with the architecture map and known-limitations counts updated to match. The stale STATUS comments that called the module unwired are corrected.