### PR TITLE
feat: add the Work workspace mode for the scene-work tools

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2056,10 +2056,10 @@ const dock = new ToolDock({
   onFrameAll: () => viewer.frameAll(),
   onSnapshot: () => void saveSnapshot(),
   onShare: () => void copyShareLink(),
-  onMeasureToggle: () => { const on = !viewer.measureMode; viewer.setMeasureMode(on); if (on) showWorkspaceMode?.('data'); },
+  onMeasureToggle: () => { const on = !viewer.measureMode; viewer.setMeasureMode(on); if (on) showWorkspaceMode?.('work'); },
   onInspectToggle: () => viewer.setInspectMode(!viewer.inspectMode),
   onProbeToggle: () => viewer.setProbeMode(!viewer.probeMode),
-  onAnnotateToggle: () => { const on = !viewer.annotateMode; viewer.setAnnotateMode(on); if (on) showWorkspaceMode?.('data'); },
+  onAnnotateToggle: () => { const on = !viewer.annotateMode; viewer.setAnnotateMode(on); if (on) showWorkspaceMode?.('work'); },
   onAnalyseToggle: () => {
     // Re-open (or hide) the terrain analysis panel. If an object scan had
     // demoted it behind the Object panel, opening Analyse takes over —
@@ -3935,8 +3935,8 @@ void viewerLoaded.then(() => {
           slot.append(el);
         }
       } else {
-        // Data mode — measure sits under the class legend with annotations, clip.
-        workspace.mountInMode('data', el);
+        // Work mode — measure sits with annotations and clip, the scene-work tools.
+        workspace.mountInMode('work', el);
       }
     });
     // If either panel already mounted before this wiring ran (possible only if a

--- a/src/ui/workspace/DesktopWorkspace.ts
+++ b/src/ui/workspace/DesktopWorkspace.ts
@@ -31,16 +31,22 @@
 import { el } from '../dom';
 
 /** The semantic workspace modes, in display order. */
-export type WorkspaceMode = 'data' | 'analyse' | 'output';
+export type WorkspaceMode = 'data' | 'work' | 'analyse' | 'output';
 
 interface ModeDef {
   readonly id: WorkspaceMode;
   readonly label: string;
 }
 
-/** The tab order — Data (layers, classes, scene-work tools) → Analyse → Output. */
+/**
+ * The tab order — Data (layers, classes) → Work (the scene-work tools:
+ * measurement, annotation, clip) → Analyse → Output. Splitting Work out of Data
+ * keeps Data about what the scan IS and Work about what you DO to it, so neither
+ * tab carries the other's clutter.
+ */
 const MODES: readonly ModeDef[] = [
   { id: 'data', label: 'Data' },
+  { id: 'work', label: 'Work' },
   { id: 'analyse', label: 'Analyse' },
   { id: 'output', label: 'Output' },
 ];
@@ -182,12 +188,11 @@ export class DesktopWorkspace {
   layoutDesktop(p: WorkspacePanels): void {
     this.mountInMode('data', p.dataLayers);
     this.mountInMode('data', p.dataLayerHealth);
-    // Data also carries the classification panel and, beneath it, the scene-work
-    // tools (measurements, annotations, clip).
     this.mountInMode('data', p.classLegend);
-    if (p.measure) this.mountInMode('data', p.measure);
-    this.mountInMode('data', p.annotation);
-    this.mountInMode('data', p.clip);
+    // Work carries the scene-work tools: measurement, annotation, clip.
+    if (p.measure) this.mountInMode('work', p.measure);
+    this.mountInMode('work', p.annotation);
+    this.mountInMode('work', p.clip);
     this.mountInMode('analyse', p.processStudio);
     if (p.analyse) this.mountInMode('analyse', p.analyse);
     if (p.object) this.mountInMode('analyse', p.object);

--- a/tests/desktopWorkspace.test.ts
+++ b/tests/desktopWorkspace.test.ts
@@ -1,8 +1,8 @@
 /**
  * desktopWorkspace.test.ts
  *
- * The desktop left-rail workspace shell: a three-way Data · Analyse ·
- * Output tablist over three mode-host slots the host re-parents panels into.
+ * The desktop left-rail workspace shell: a four-way Data · Work · Analyse ·
+ * Output tablist over four mode-host slots the host re-parents panels into.
  * Runs in the node environment through the same recording DOM stub the other
  * UI tests use, asserting on state, ARIA, node identity and persistence rather
  * than pixels.
@@ -113,9 +113,9 @@ describe('DesktopWorkspace', () => {
   it('renders a three-tab tablist over three mode panels wired by aria-controls', async () => {
     const { root } = await make();
     const tabs = root.findAll((e) => e.attrs['role'] === 'tab');
-    expect(tabs.map((t) => t.dataset.mode)).toEqual(['data', 'analyse', 'output']);
+    expect(tabs.map((t) => t.dataset.mode)).toEqual(['data', 'work', 'analyse', 'output']);
     const panels = root.findAll((e) => e.attrs['role'] === 'tabpanel');
-    expect(panels.map((p) => p.dataset.mode)).toEqual(['data', 'analyse', 'output']);
+    expect(panels.map((p) => p.dataset.mode)).toEqual(['data', 'work', 'analyse', 'output']);
     for (const t of tabs) {
       expect(t.attrs['aria-controls']).toBe(`olv-ws-mode-${t.dataset.mode}`);
     }
@@ -195,8 +195,8 @@ describe('DesktopWorkspace', () => {
   it('ArrowRight moves the active mode and focuses the next tab', async () => {
     const { ws, tab } = await make();
     tab('data').fire('keydown', { key: 'ArrowRight', preventDefault: () => {} });
-    expect(ws.getMode()).toBe('analyse');
-    expect(tab('analyse').focused).toBe(true);
+    expect(ws.getMode()).toBe('work');
+    expect(tab('work').focused).toBe(true);
   });
 
   it('exposes a callable dispose()', async () => {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -37,7 +37,7 @@ import { fileURLToPath } from 'node:url';
  */
 export async function showWorkspaceMode(
   page: Page,
-  mode: 'data' | 'analyse' | 'output',
+  mode: 'data' | 'work' | 'analyse' | 'output',
 ): Promise<void> {
   const tab = page.locator(`.olv-ws-tab[data-mode="${mode}"]`);
   if (await tab.count()) await tab.click();

--- a/tests/e2e/measure.spec.ts
+++ b/tests/e2e/measure.spec.ts
@@ -149,12 +149,12 @@ test(
       .locator('.olv-scan-type-opt', { hasText: /^Object$/ })
       .evaluate((el: HTMLElement) => el.click());
 
-    // In the v0.6.5 workspace the Object panel lives in the Analyse mode while
-    // Measurements lives in Data (under the class legend), so they no longer
-    // share one column. The enduring guard is that the Measurements panel refuses
-    // to be flex-shrunk within its own column, keeping its natural height rather
-    // than collapsing to its ~25px header.
-    await showWorkspaceMode(page, 'data');
+    // The Object panel lives in Analyse while Measurements lives in Work (with
+    // annotation and clip), so they no longer share one column. The enduring
+    // guard is that the Measurements panel refuses to be flex-shrunk within its
+    // own column, keeping its natural height rather than collapsing to its ~25px
+    // header.
+    await showWorkspaceMode(page, 'work');
     const flexShrink = await page
       .locator('.olv-measure-panel')
       .evaluate((el) => getComputedStyle(el).flexShrink);


### PR DESCRIPTION
The desktop left rail had three modes, Data / Analyse / Output, and Data carried both what the scan is (layers, layer health, classification) and the tools you run on it (measurement, annotation, clip). The WorkspaceMode type comment already described a four-mode Data / Work / Analyse / Output rail, so the intent was in the tree but the mode was never built.

This adds the Work mode and moves measurement, annotation, and clip into it. Data now holds only the scan's own layers and classes; Work holds the scene-work tools. The measure and annotate tool toggles reveal Work instead of Data, and the lazy measure panel mounts into Work. Analyse (Process Studio, contextual editors) and Output (exports) are unchanged.

The tab strip CSS is data-driven, so the fourth tab needs no style change, and the mobile sheet uses its own tab system and is untouched. Tests: the workspace tab/panel order asserts the four modes and arrow-key navigation steps Data to Work; the measure e2e reaches the Measurements panel through the Work tab. Full unit, build, bundle, and truth-lint sweep green.