### PR TITLE
feat: consolidate exports into the Output panel (Output Center)

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,824 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,828 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -99,7 +99,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,824)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,828)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.5.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.5.md
@@ -4,7 +4,7 @@ This release sharpens classification, hardens the report and export surfaces aga
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,824 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and shared domain/application state is owned by AppContext/services, with the composition root retaining only explicitly bounded shell-local composition and lifecycle state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,828 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and shared domain/application state is owned by AppContext/services, with the composition root retaining only explicitly bounded shell-local composition and lifecycle state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## Building classification: the ground-support gate is evaluated on synthetic scenes only
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5824,
+      "lines": 5828,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/app/openScan.ts
+++ b/src/app/openScan.ts
@@ -38,6 +38,7 @@ import type { ClassScope } from '../render/class/classScope';
 import type { AnalysisRow } from '../analysis/ModuleApi';
 import type { Viewer } from '../render/Viewer';
 import type { Inspector } from '../ui/Inspector';
+import type { ExportPanel } from '../ui/ExportPanel';
 import type { ToolDock } from '../ui/toolDock';
 import type { NavBar } from '../ui/NavBar';
 import type { DebugOverlay } from '../ui/DebugOverlay';
@@ -133,6 +134,8 @@ export interface OpenScanDeps {
   layerIdentity: Pick<LayerIdentityService, 'bindOnLoad' | 'ensureStoresWired'>;
   /** The Inspector panel. */
   inspector: Inspector;
+  /** The Output panel — owns the image-export / report gating. */
+  exportPanel: Pick<ExportPanel, 'setImageExportEnabled' | 'setImageExportAvailability'>;
   /** Provenance / dataset-intelligence card refreshers. */
   inspectorCards: Pick<
     InspectorCardRefreshers,
@@ -436,11 +439,11 @@ export async function openScan(file: File, deps: OpenScanDeps): Promise<void> {
     // instead of waiting on the ~7 KB gzip fetch + parse. Pure fire-and-
     // forget; we don't await the result.
     try {
-      deps.inspector.setImageExportEnabled(true);
+      deps.exportPanel.setImageExportEnabled(true);
       // Per-mode gating — disable buttons whose mode the loaded cloud can't
       // satisfy (Normal map on a LAZ, etc.) so the user sees the constraint
       // before clicking rather than as a post-click error toast.
-      deps.inspector.setImageExportAvailability(viewer.availableImageExportModes());
+      deps.exportPanel.setImageExportAvailability(viewer.availableImageExportModes());
     } catch (err) {
       if (deps.debug) console.warn('[inspector] setImageExportEnabled threw', err);
     }

--- a/src/app/openStreaming.ts
+++ b/src/app/openStreaming.ts
@@ -41,6 +41,7 @@ import type { CrsInfo, CrsLinearUnit } from '../io/crs';
 import type { AnalysisRow } from '../analysis/ModuleApi';
 import type { Viewer } from '../render/Viewer';
 import type { Inspector } from '../ui/Inspector';
+import type { ExportPanel } from '../ui/ExportPanel';
 import type { Stage } from '../ui/Stage';
 import type { DropZone } from '../ui/DropZone';
 import type { StreamingPanel } from '../ui/StreamingPanel';
@@ -307,6 +308,7 @@ export interface OpenStreamingDeps {
   // ── View collaborators ──
   stage: Pick<Stage, 'hideEmptyState'>;
   inspector: Inspector;
+  exportPanel: Pick<ExportPanel, 'setImageExportEnabled' | 'setImageExportAvailability' | 'setStreamingMode'>;
   streamingPanel: Pick<StreamingPanel, 'setPhase' | 'show' | 'setColorModes' | 'setQuality' | 'setSummary'>;
   classLegendPanel: Pick<ClassLegendPanel, 'setClasses' | 'hide' | 'getVisibility'>;
   inspectorCards: Pick<
@@ -479,15 +481,16 @@ export async function openStreamingCopc(
   // the image-export buttons in the Inspector can light up. The streaming
   // path doesn't go through `inspector.addCloud`, so the gate has to flip
   // here too. Pre-warm the Studio chunk for the same reason as above.
-  deps.inspector.setImageExportEnabled(true);
+  deps.exportPanel.setImageExportEnabled(true);
   // Per-mode gating — streaming COPC / EPT rarely carry normals or
   // classification; disable the corresponding buttons at the source.
-  deps.inspector.setImageExportAvailability(viewer.availableImageExportModes());
+  deps.exportPanel.setImageExportAvailability(viewer.availableImageExportModes());
   // Switch the Inspector into streaming layout — hides Layers / Color by
   // / Point size / Rendering / Export (their streaming-equivalents are
   // in the StreamingPanel) and pins the panel to the lower-right so
   // both panels coexist on desktop.
   deps.inspector.setStreamingMode(true);
+  deps.exportPanel.setStreamingMode(true);
   try { deps.inspector.setDetail(cloud.sourcePointCount, cloud.sourcePointCount); }
   catch (err) { if (deps.debug) console.warn('[inspector] setDetail (streaming) threw', err); }
   deps.setLastStreamingReportCloud(cloud);
@@ -764,12 +767,13 @@ export async function handleRemoteEpt(
     );
     deps.streamingPanel.setQuality(deps.getStreamingQuality());
     deps.streamingPanel.setPhase('Streaming coarse geometry…');
-    deps.inspector.setImageExportEnabled(true);
+    deps.exportPanel.setImageExportEnabled(true);
     // Per-mode gating — EPT streams almost never carry normals.
-    deps.inspector.setImageExportAvailability(viewer.availableImageExportModes());
+    deps.exportPanel.setImageExportAvailability(viewer.availableImageExportModes());
     // Same streaming-mode layout the COPC path uses — hide Inspector's
     // static-cloud sections and populate the streaming Scan Report.
     deps.inspector.setStreamingMode(true);
+    deps.exportPanel.setStreamingMode(true);
     try { deps.inspector.setDetail(cloud.sourcePointCount, cloud.sourcePointCount); }
     catch (err) { if (deps.debug) console.warn('[inspector] setDetail (streaming) threw', err); }
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1267,113 +1267,6 @@ const inspector = new Inspector({
   onToggleLock: (id, locked) => viewer.setCloudLocked(id, locked),
   onCompareLayers: () => compareLoadedLayers(),
   onExportDifference: () => exportDifferenceRaster(),
-  onExport: (format) => {
-    const cloud = scans.activeCloud() ?? undefined;
-    if (!cloud) return;
-    // The exporter is a lazy chunk; fetched on first export of the session.
-    void loadExporters().then(({ exportCloud }) => {
-      downloadText(`${baseName(cloud.name)}.${format}`, exportCloud(cloud, format, crsService.context().isGeographic));
-    });
-  },
-  onExportImage: (mode) => {
-    // The Visual Export Studio ships in its own lazy chunk (`loadExportStudio`),
-    // pulled in by viewer.exportImage on the first invocation. The download
-    // triggers off the returned Blob; an unsupported-on-this-cloud rejection
-    // surfaces as a visible alert.
-    const sourceName = scans.activeId
-      ? viewer.getCloud(scans.activeId)?.name
-      : viewer.streamingCloud?.name;
-    const base = sourceName ? baseName(sourceName) : 'openlidarviewer';
-    // surface a precise per-mode progress string while the lazy
-    // Studio chunk loads and the export renders.
-    const modeLabel: Record<string, string> = {
-      'orthographic-rgb': 'orthographic RGB',
-      'height-map': 'height map',
-      intensity: 'intensity map',
-      classification: 'classification map',
-      depth: 'depth map',
-      normal: 'normal map',
-      contour: 'contour map',
-    };
-    const label = modeLabel[mode] ?? mode;
-    dropZone.setProgress(`Exporting ${label}…`);
-    viewer
-      // Thread the active class-scope stamp so a filtered export carries the
-      // "showing N of M classes" banner; empty when nothing is hidden.
-      .exportImage(mode, {}, currentClassScopeStamp())
-      .then(async (result) => {
-        // Georeferenced ortho path (v0.4.5, workplan C4): when the exporter
-        // returned world-file data (true top-down ortho frame + known world
-        // origin + CRS WKT), the download is one ZIP — PNG + `.pgw` + `.prj`
-        // — that QGIS/ArcGIS place directly. Every other export keeps the
-        // existing bare-PNG download and filename. Packaging failures fall
-        // back to the bare PNG rather than sinking an export that already
-        // rendered fine.
-        if (result.worldFile) {
-          try {
-            const { buildStudioPngPackage } = await loadPngWorldFile();
-            const wf = result.worldFile;
-            const pkg = buildStudioPngPackage({
-              basename: `${base}-${mode}`,
-              png: new Uint8Array(await result.blob.arrayBuffer()),
-              extent: wf.extent,
-              widthPx: wf.widthPx,
-              heightPx: wf.heightPx,
-              worldOrigin: wf.worldOrigin,
-              wkt: wf.wkt,
-            });
-            if (pkg) {
-              triggerDownload(new Blob([pkg.zip as BlobPart], { type: 'application/zip' }), pkg.filename);
-              recordUsage('export', mode);
-              dropZone.setProgress(null);
-              return;
-            }
-          } catch (err) {
-            console.warn('[image-export] world-file packaging failed — shipping bare PNG:', err);
-          }
-        }
-        triggerDownload(result.blob, `${base}-${mode}.png`);
-        recordUsage('export', mode);
-        dropZone.setProgress(null);
-      })
-      .catch((err: unknown) => {
-        recordUsage('error', 'export');
-        dropZone.setProgress(null);
-        // The orchestrator's explicit reason ("Classification export is
-        // unavailable — this cloud has no classification channel.") is the
-        // most actionable thing we can show, so it goes both to the console
-        // (for debugging) and to a non-blocking alert (so the user knows
-        // something happened and why). Replaces the alert with a
-        // Surface the failure through the shared toast UI rather than a
-        // modal alert — blocking the page on a generation failure is a UX
-        // regression we no longer accept.
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error('[image-export]', err);
-        dropZone.setError(`Image export failed: ${msg}`);
-      });
-  },
-  onExportReport: (templateId) => {
-    // Generate a PDF report from the live scan state + annotations +
-    // measurements. The whole `src/report/` module + pdf-lib (~150 KB)
-    // lives behind `loadReportEngine()`; first click downloads both. The
-    // report covers what the scan-report card already does on PNG
-    // exports, but as a multi-page PDF with the full Inspector context.
-    // The progress toast surfaces while the lazy module loads and the PDF
-    // renders; failures route through the same toast UI as every other
-    // export.
-    dropZone.setProgress('Generating report…');
-    generateReportPdf(templateId)
-      .then(() => {
-        recordUsage('report', templateId);
-        dropZone.setProgress(null);
-      })
-      .catch((err: unknown) => {
-        recordUsage('error', 'report');
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error('[report]', err);
-        dropZone.setError(`Report generation failed: ${msg}`);
-      });
-  },
   onSaveView: () => saveCurrentView(),
   onApplyView: (index) => applyView(index),
   onRenameView: (index, name) => {
@@ -2953,6 +2846,113 @@ const measurementExportActionDeps = (v: Viewer): MeasurementExportActionDeps => 
 });
 
 const exportPanel = new ExportPanel({
+  onExport: (format) => {
+    const cloud = scans.activeCloud() ?? undefined;
+    if (!cloud) return;
+    // The exporter is a lazy chunk; fetched on first export of the session.
+    void loadExporters().then(({ exportCloud }) => {
+      downloadText(`${baseName(cloud.name)}.${format}`, exportCloud(cloud, format, crsService.context().isGeographic));
+    });
+  },
+  onExportImage: (mode) => {
+    // The Visual Export Studio ships in its own lazy chunk (`loadExportStudio`),
+    // pulled in by viewer.exportImage on the first invocation. The download
+    // triggers off the returned Blob; an unsupported-on-this-cloud rejection
+    // surfaces as a visible alert.
+    const sourceName = scans.activeId
+      ? viewer.getCloud(scans.activeId)?.name
+      : viewer.streamingCloud?.name;
+    const base = sourceName ? baseName(sourceName) : 'openlidarviewer';
+    // surface a precise per-mode progress string while the lazy
+    // Studio chunk loads and the export renders.
+    const modeLabel: Record<string, string> = {
+      'orthographic-rgb': 'orthographic RGB',
+      'height-map': 'height map',
+      intensity: 'intensity map',
+      classification: 'classification map',
+      depth: 'depth map',
+      normal: 'normal map',
+      contour: 'contour map',
+    };
+    const label = modeLabel[mode] ?? mode;
+    dropZone.setProgress(`Exporting ${label}…`);
+    viewer
+      // Thread the active class-scope stamp so a filtered export carries the
+      // "showing N of M classes" banner; empty when nothing is hidden.
+      .exportImage(mode, {}, currentClassScopeStamp())
+      .then(async (result) => {
+        // Georeferenced ortho path (v0.4.5, workplan C4): when the exporter
+        // returned world-file data (true top-down ortho frame + known world
+        // origin + CRS WKT), the download is one ZIP — PNG + `.pgw` + `.prj`
+        // — that QGIS/ArcGIS place directly. Every other export keeps the
+        // existing bare-PNG download and filename. Packaging failures fall
+        // back to the bare PNG rather than sinking an export that already
+        // rendered fine.
+        if (result.worldFile) {
+          try {
+            const { buildStudioPngPackage } = await loadPngWorldFile();
+            const wf = result.worldFile;
+            const pkg = buildStudioPngPackage({
+              basename: `${base}-${mode}`,
+              png: new Uint8Array(await result.blob.arrayBuffer()),
+              extent: wf.extent,
+              widthPx: wf.widthPx,
+              heightPx: wf.heightPx,
+              worldOrigin: wf.worldOrigin,
+              wkt: wf.wkt,
+            });
+            if (pkg) {
+              triggerDownload(new Blob([pkg.zip as BlobPart], { type: 'application/zip' }), pkg.filename);
+              recordUsage('export', mode);
+              dropZone.setProgress(null);
+              return;
+            }
+          } catch (err) {
+            console.warn('[image-export] world-file packaging failed — shipping bare PNG:', err);
+          }
+        }
+        triggerDownload(result.blob, `${base}-${mode}.png`);
+        recordUsage('export', mode);
+        dropZone.setProgress(null);
+      })
+      .catch((err: unknown) => {
+        recordUsage('error', 'export');
+        dropZone.setProgress(null);
+        // The orchestrator's explicit reason ("Classification export is
+        // unavailable — this cloud has no classification channel.") is the
+        // most actionable thing we can show, so it goes both to the console
+        // (for debugging) and to a non-blocking alert (so the user knows
+        // something happened and why). Replaces the alert with a
+        // Surface the failure through the shared toast UI rather than a
+        // modal alert — blocking the page on a generation failure is a UX
+        // regression we no longer accept.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[image-export]', err);
+        dropZone.setError(`Image export failed: ${msg}`);
+      });
+  },
+  onExportReport: (templateId) => {
+    // Generate a PDF report from the live scan state + annotations +
+    // measurements. The whole `src/report/` module + pdf-lib (~150 KB)
+    // lives behind `loadReportEngine()`; first click downloads both. The
+    // report covers what the scan-report card already does on PNG
+    // exports, but as a multi-page PDF with the full Inspector context.
+    // The progress toast surfaces while the lazy module loads and the PDF
+    // renders; failures route through the same toast UI as every other
+    // export.
+    dropZone.setProgress('Generating report…');
+    generateReportPdf(templateId)
+      .then(() => {
+        recordUsage('report', templateId);
+        dropZone.setProgress(null);
+      })
+      .catch((err: unknown) => {
+        recordUsage('error', 'report');
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[report]', err);
+        dropZone.setError(`Report generation failed: ${msg}`);
+      });
+  },
   // Allocation-free summary for the live panel — NEVER snapshots the streaming
   // resident set (that ~150 MB materialization is deferred to the Export click
   // via getCloud below). Reads only scalar facts: resident count + colour/CRS
@@ -5020,6 +5020,7 @@ const openScanDeps: OpenScanDeps = {
   scans,
   layerIdentity: runtime.layerIdentity,
   inspector,
+  exportPanel,
   inspectorCards,
   crsCoordinator,
   dock,
@@ -5087,6 +5088,7 @@ const openStreamingDeps: OpenStreamingDeps = {
   dropZone,
   stage,
   inspector,
+  exportPanel,
   streamingPanel,
   classLegendPanel,
   inspectorCards,
@@ -5285,6 +5287,8 @@ function closeStreaming(): void {
   // and clear the streaming-mode positioning class.
   try { inspector.setStreamingMode(false); }
   catch (err) { if (debug) console.warn('[inspector] setStreamingMode(false) threw', err); }
+  try { exportPanel.setStreamingMode(false); }
+  catch (err) { if (debug) console.warn('[exportPanel] setStreamingMode(false) threw', err); }
   try { inspector.clearDatasetIntelligence(); }
   catch (err) { if (debug) console.warn('[inspector] clearDatasetIntelligence threw', err); }
   inspector.element.classList.remove('olv-hidden');
@@ -5591,7 +5595,7 @@ function resetToEmptyState(): void {
   // Visual Export Studio — no scan loaded, no source to render. The
   // buttons go back to disabled with their "load a scan first" hint so the
   // user can't fire an export against nothing.
-  inspector.setImageExportEnabled(false);
+  exportPanel.setImageExportEnabled(false);
   stage.showEmptyState();
   navBar.element.classList.add('olv-hidden');
   // Reset the NavBar mode to 'orbit'. The "Click the scan to look around"

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -27,6 +27,9 @@ import {
 import { sameExportTarget, EXPORT_SCAN_CHANGED_REFUSAL } from '../export/exportScanIdentity';
 import { clipCloud } from '../render/clip/clipCloud';
 import type { ClipBox } from '../render/clip/clipBox';
+import type { ExportFormat } from '../io/exporters';
+import type { ExportMode } from '../export/types';
+import { buildExportDeliverables, type ExportDeliverables } from './export/exportDeliverables';
 
 /**
  * Lightweight, allocation-free description of the exportable cloud, used to
@@ -152,10 +155,18 @@ export interface ExportPanelCallbacks {
    * "open a scan first" during the brief window before the first node lands.
    */
   isStreamingPending?: () => boolean;
+  /** Export the active cloud to a point-cloud file format (ply / obj / xyz / csv). */
+  onExport?: (format: ExportFormat) => void;
+  /** Render the live scan in one Visual Export Studio mode and download a PNG. */
+  onExportImage?: (mode: ExportMode) => void;
+  /** Generate a PDF report from the live scan using the named template. */
+  onExportReport?: (templateId: string) => void;
 }
 
 export class ExportPanel {
   readonly element: HTMLElement;
+  /** The moved deliverables (formats / image / report), or null when not wired. */
+  private readonly _deliverables: ExportDeliverables | null;
   private readonly _formatRow: HTMLElement;
   private readonly _crsLabel: HTMLElement;
   private readonly _crsRow: HTMLElement;
@@ -266,6 +277,21 @@ export class ExportPanel {
       this._products,
     );
 
+    // The Output Center's deliverables — point-cloud formats, image export, PDF
+    // report — moved here from the Inspector so every export lives in one place.
+    // Wired only when the host supplies the callbacks; the controller drives the
+    // load-time gating.
+    if (callbacks.onExport && callbacks.onExportImage && callbacks.onExportReport) {
+      this._deliverables = buildExportDeliverables({
+        onExport: callbacks.onExport,
+        onExportImage: callbacks.onExportImage,
+        onExportReport: callbacks.onExportReport,
+      });
+      body.append(this._deliverables.element);
+    } else {
+      this._deliverables = null;
+    }
+
     this.element.append(head, body);
     this.element.classList.add('olv-collapsed');
     this.setVisible(false);
@@ -282,6 +308,27 @@ export class ExportPanel {
 
   setVisible(on: boolean): void {
     this.element.style.display = on ? '' : 'none';
+  }
+
+  /** Enable or disable the image-export + report buttons as a group (see the deliverables). */
+  setImageExportEnabled(enabled: boolean): void {
+    this._deliverables?.setImageExportEnabled(enabled);
+  }
+
+  /** Per-mode availability override for the image-export buttons (see the deliverables). */
+  setImageExportAvailability(
+    availability: ReadonlyMap<ExportMode, { readonly available: boolean; readonly reason?: string }>,
+  ): void {
+    this._deliverables?.setImageExportAvailability(availability);
+  }
+
+  /**
+   * Hide the point-cloud file-format quick export while a streaming scan is
+   * active — a streaming cloud has no resident file to write those formats from.
+   * Image export and the PDF report stay available (they render the live view).
+   */
+  setStreamingMode(streaming: boolean): void {
+    if (this._deliverables) this._deliverables.formatSection.style.display = streaming ? 'none' : '';
   }
 
   /** Re-evaluate the full-resolution availability for the active cloud. */

--- a/src/ui/Inspector.ts
+++ b/src/ui/Inspector.ts
@@ -1,4 +1,5 @@
 import { el, formatCount } from './dom';
+import { collapsibleSection } from './collapsibleSection';
 import {
   compatibilityNote,
   type LayerCompatibility,
@@ -31,8 +32,6 @@ import {
 import { EDL_DEFAULTS, EDL_STRENGTH_RANGE } from '../render/edl';
 import type { EdlPresetId } from '../render/edlPresets';
 import type { SplatMode } from '../render/splatShader';
-import type { ExportFormat } from '../io/exporters';
-import type { ExportMode } from '../export/types';
 import {
   snapshot as snapshotUsage,
   reset as resetUsage,
@@ -42,18 +41,6 @@ import {
 import type { ProvenanceFingerprint, CaptureType } from '../diagnostics/provenance';
 import type { ResolvedCrs } from '../geo/CoordinateTypes';
 import { listCrsEntriesByRegion, getCrsEntry } from '../geo/CrsRegistry';
-// Direct subpath imports — NOT the `'../report'` barrel. The barrel
-// re-exports `generateReport` / `renderReportPdf`, which transitively
-// pull pdf-lib (~150 KB) into the static import graph and break the
-// lazy-chunk split for the entire report engine. `ReportTemplates.ts`
-// is a pure-data module with no pdf-lib dependency, so it's safe to
-// hold a static reference to.
-import {
-  REPORT_TEMPLATES,
-  DEFAULT_TEMPLATE_ID,
-  getReportTemplate,
-} from '../report/ReportTemplates';
-import type { ReportTemplateId } from '../report/types';
 // Workflow presets (v0.4.5) — pure table; the rail renders it, main.ts
 // applies it through the Viewer's existing setters.
 import {
@@ -123,21 +110,6 @@ export interface InspectorCallbacks {
   onCompareLayers?: () => void;
   /** Download the most recent comparison's signed difference as a georeferenced raster. */
   onExportDifference?: () => void;
-  /** Export the active cloud to a file format. */
-  onExport: (format: ExportFormat) => void;
-  /**
-   * Visual Export Studio — render the live scan in one of the four
-   * Studio modes (orthographic-rgb / height-map / intensity / classification)
-   * and download the result as a PNG. The Inspector surfaces a button per
-   * mode; main.ts owns the lazy import and the download wiring.
-   */
-  onExportImage: (mode: ExportMode) => void;
-  /**
-   * generate a PDF report from the live scan + annotations
-   * + measurements using the named template. main.ts lazy-loads the
-   * report engine + pdf-lib on first click.
-   */
-  onExportReport: (templateId: string) => void;
   /** Save the current camera viewpoint. */
   onSaveView: () => void;
   /** Fly to a saved viewpoint by index. */
@@ -226,73 +198,6 @@ const MODE_TITLES: Record<ColorMode, string> = {
     '(extrapolated/gap). Same buckets as Coverage. Approximate.',
 };
 
-const EXPORT_FORMATS: ExportFormat[] = ['ply', 'obj', 'xyz', 'csv'];
-
-/**
- * Visual Export Studio — the four PNG export modes the Inspector
- * exposes in the new "Image export" section. Each entry is `[mode, label,
- * title]` — the title doubles as the hover-hint for the disabled button when
- * the mode is unavailable on the loaded cloud.
- */
-// Honest button labels — user-reported confusion: "all reports show the
-// same export". Root cause was the misnamed "Ortho RGB" which captures
-// the CURRENT colour mode (not specifically RGB), so on a survey LAZ
-// being viewed in elevation mode it produced the same image as "Height
-// Map". Renamed to "View capture" so users know what they're getting:
-// a PNG of whatever they currently see. Tooltip is honest that it
-// preserves the active colour mode and isn't redundant with Height Map
-// only when the user is actively choosing RGB / intensity / class
-// before clicking.
-// Order matters — the specific colour-mode buttons come FIRST because
-// they reliably produce distinct images, then the generic "View capture"
-// comes LAST. The reordering is the design-audit "reduction filter"
-// applied: a user who clicks View capture without changing Color by
-// first will get the same image as Height map (current default for
-// survey LAZ). Placing the specific buttons first signals "to
-// differentiate, pick one of these" before falling through to the
-// generic capture.
-const IMAGE_EXPORT_BUTTONS: ReadonlyArray<{
-  readonly mode: ExportMode;
-  readonly label: string;
-  readonly title: string;
-}> = [
-  {
-    mode: 'height-map',
-    label: 'Height map',
-    title: 'Forces elevation colouring. Always distinct from view-capture-in-other-modes.',
-  },
-  {
-    mode: 'intensity',
-    label: 'Intensity',
-    title: 'Forces LiDAR-intensity colouring. Disabled on clouds without an intensity channel.',
-  },
-  {
-    mode: 'classification',
-    label: 'Class map',
-    title: 'Forces ASPRS-classification colouring. Disabled on clouds without a classification channel.',
-  },
-  {
-    mode: 'normal',
-    label: 'Normal map',
-    title:
-      'RGB-encodes per-point surface normals. Disabled on clouds without normals ' +
-      '(PCD / PTX / GLTF carry them; raw LiDAR rarely does).',
-  },
-  {
-    mode: 'orthographic-rgb',
-    label: 'View capture',
-    title:
-      'Captures the current on-screen view in whatever colour mode is active. ' +
-      'To get a distinct image, switch the Color by chip before clicking — ' +
-      'otherwise this matches Height Map when you are viewing in elevation. ' +
-      'Georeferenced scans (known CRS + world origin) instead download a ' +
-      'top-down ortho ZIP with .pgw/.prj sidecars that GIS tools place directly.',
-  },
-  // Depth Map + Contour Map intentionally absent — their previous
-  // implementations produced an elevation raster (same as Height Map)
-  // rather than true camera-relative depth or marching-squares contour
-  // lines. They will return once the proper implementations land.
-];
 
 /**
  * Visuals Studio — Visuals Studio state the Inspector keeps in sync
@@ -532,31 +437,6 @@ function buildRangeFilter(opts: {
   };
 }
 
-/**
- * A collapsible section using native `<details>` / `<summary>`. The
- * summary is styled to match the static `olv-section-label` so the
- * panel reads as a uniform list of sections — the only visual
- * difference is the disclosure caret. Default-closed for sections
- * the user opens occasionally (Detail, Provenance, Coordinate
- * system, Scan report, Saved views, every export group), which
- * reduces first-paint density by ~60% on the 232 px panel.
- */
-function collapsibleSection(
-  label: string,
-  body: HTMLElement,
-  opts: { readonly open?: boolean } = {},
-): HTMLDetailsElement {
-  const details = el('details', {
-    className: 'olv-section olv-section-collapsible',
-  }) as HTMLDetailsElement;
-  if (opts.open) details.open = true;
-  const summary = el('summary', {
-    className: 'olv-section-label olv-section-summary',
-    text: label,
-  });
-  details.append(summary, body);
-  return details;
-}
 
 /** A small on/off chip button; the active class reflects the on state. */
 function toggleChip(
@@ -576,8 +456,8 @@ function toggleChip(
 
 /**
  * The floating Inspector panel: the cloud layer list, the color-by chips, a
- * point-size slider, the Detail readout, the Scan Report, saved camera views,
- * and the export buttons.
+ * point-size slider, the Detail readout, the Scan Report, and saved camera
+ * views. The exports live in the Output panel.
  */
 export class Inspector {
   readonly element: HTMLElement;
@@ -689,7 +569,6 @@ export class Inspector {
   private readonly _layersSection!: HTMLElement;
   private readonly _colorBySection!: HTMLElement;
   private readonly _renderingSection!: HTMLElement;
-  private readonly _exportSection!: HTMLElement;
   private readonly _viewList = el('div', { className: 'olv-views' });
   /** Session-stats body — rebuilt lazily when the details section opens. */
   private readonly _sessionStatsBody: HTMLElement;
@@ -725,18 +604,6 @@ export class Inspector {
   private _compareBtn: HTMLButtonElement | null = null;
   private _compareResult: HTMLElement | null = null;
   private _diffBtn: HTMLButtonElement | null = null;
-  /**
-   * Visual Export Studio — the per-mode image-export buttons, kept
-   * by mode so {@link setImageExportEnabled} can disable them as a group
-   * when no cloud is loaded (preventing the "click → console error" gap)
-   * and per-mode when a specific channel is missing.
-   */
-  private readonly _imageExportButtons = new Map<ExportMode, HTMLButtonElement>();
-  /** The original tooltip for each image-export button — restored on enable. */
-  private readonly _imageExportTitles = new Map<ExportMode, string>();
-  /** the Report PDF button, gated like the image-export ones. */
-  private readonly _reportButton: HTMLButtonElement | null = null;
-  private readonly _reportSelect: HTMLSelectElement | null = null;
   // ── Rendering controls ──
   private readonly _pointSizeSlider: HTMLInputElement;
   private readonly _pointSizeValue: HTMLElement;
@@ -947,96 +814,6 @@ export class Inspector {
     });
     const views = el('div', {}, [saveView, this._viewList]);
 
-    // Export: one button per supported output format.
-    const exportButtons = EXPORT_FORMATS.map((format) => {
-      const button = el('button', {
-        className: 'olv-export-btn',
-        text: format.toUpperCase(),
-        title: `Export the cloud as ${format.toUpperCase()}`,
-      });
-      button.addEventListener('click', () => {
-        button.blur();
-        this._cb.onExport(format);
-      });
-      return button;
-    });
-    const exporter = el('div', { className: 'olv-export' }, exportButtons);
-
-    // Visual Export Studio — one button per export mode. The class
-    // matches the existing exporter row above so the CSS layout is shared.
-    // Buttons start disabled — `setImageExportEnabled()` flips them on once
-    // a scan is loaded so users can't fire an export with nothing to draw.
-    const imageExportButtons = IMAGE_EXPORT_BUTTONS.map(({ mode, label, title }) => {
-      const button = el('button', {
-        className: 'olv-export-btn',
-        text: label,
-        title,
-      });
-      button.disabled = true;
-      button.title = `${title} (load a scan first)`;
-      button.addEventListener('click', () => {
-        button.blur();
-        this._cb.onExportImage(mode);
-      });
-      this._imageExportButtons.set(mode, button);
-      this._imageExportTitles.set(mode, title);
-      return button;
-    });
-    // The image-export row carries 7 buttons — too many to fit in a single
-    // flex row inside the 232 px Inspector panel. The 2-column grid layout
-    // wraps cleanly into 4 rows (last row holds the seventh button).
-    const imageExporter = el('div', { className: 'olv-export-grid' }, imageExportButtons);
-
-    // PDF Report controls. A native <select> lets the user pick from the
-    // full template catalogue (`REPORT_TEMPLATES`) — the picker reads the
-    // current id off the select on click. The button stays single so the
-    // 232 px panel doesn't acquire a per-template button row.
-    const reportSelect = el('select', {
-      className: 'olv-report-select',
-      ariaLabel: 'PDF report template',
-    }) as HTMLSelectElement;
-    for (const t of REPORT_TEMPLATES) {
-      const option = el('option', { text: t.label, title: t.description });
-      option.value = t.id;
-      if (t.id === DEFAULT_TEMPLATE_ID) option.selected = true;
-      reportSelect.append(option);
-    }
-    // Mirror the button's empty-state disabled gate so the select and the
-    // button enable together once a scan loads.
-    reportSelect.disabled = true;
-    const reportButton = el('button', {
-      className: 'olv-export-btn',
-      text: 'Report PDF',
-      title: 'Generate a multi-page PDF report from the selected template.',
-    });
-    reportButton.disabled = true;
-    reportButton.title = `${reportButton.title} (load a scan first)`;
-    reportButton.addEventListener('click', () => {
-      reportButton.blur();
-      const templateId = reportSelect.value as ReportTemplateId;
-      // Defence-in-depth: the select is populated from REPORT_TEMPLATES, but
-      // a devtools-injected <option value="…"> or a future template rename
-      // could surface an unknown id. Surface a visible button-state flash
-      // so the click is observably acknowledged — silently bailing left the
-      // user wondering whether the click registered.
-      if (!getReportTemplate(templateId)) {
-        const original = reportButton.textContent;
-        reportButton.textContent = 'Unknown template';
-        reportButton.disabled = true;
-        window.setTimeout(() => {
-          reportButton.textContent = original;
-          reportButton.disabled = false;
-        }, 1500);
-        return;
-      }
-      this._cb.onExportReport(templateId);
-    });
-    this._reportButton = reportButton;
-    this._reportSelect = reportSelect;
-    const reportExporter = el('div', { className: 'olv-report-row' }, [
-      reportSelect,
-      reportButton,
-    ]);
 
     // The header carries the panel title and — on phones, where the panel is
     // a bottom sheet — a close control. The close handler stops propagation
@@ -1116,16 +893,15 @@ export class Inspector {
     // stay statically expanded because they're the user's per-frame
     // touch points. Everything below is collapsed by default — Detail
     // is informational, Provenance / Coordinate system / Scan report
-    // are loaded once and re-read on demand, Saved views starts empty,
-    // and the three export groups are each one-click destinations
-    // users go looking for. First-paint cognitive load drops by ~60%
-    // without removing any feature.
+    // are loaded once and re-read on demand, and Saved views starts
+    // empty. First-paint cognitive load drops by ~60% without removing
+    // any feature.
     // Per-section refs — captured so `setStreamingMode` can hide the
     // static-cloud-only sections during streaming (the StreamingPanel
     // owns the streaming-equivalents: streaming color modes, quality
     // control, saved views are mirrored there). The kept sections —
-    // Detail, Provenance, Coordinate system, Scan report, Image export,
-    // Report PDF — work uniformly against either source type.
+    // Detail, Provenance, Coordinate system, Scan report — work
+    // uniformly against either source type.
     this._layersSection = section('Layers', this._layers);
     // Height percentile-trim row, mounted inside "Color by" beneath the chip
     // rail and shown only while colouring BY elevation. It clips the top/bottom
@@ -1351,7 +1127,6 @@ export class Inspector {
     // "Rendering" section; it stays visible during streaming so point
     // thickness remains adjustable on a streaming COPC / EPT.
     this._renderingSection = collapsibleSection('Rendering', renderingBody);
-    this._exportSection = collapsibleSection('Export', exporter);
 
     // Dataset Intelligence — informational summary of the Terrain
     // Foundation outputs. Lives directly under the Scan Intelligence
@@ -1388,9 +1163,6 @@ export class Inspector {
       this._crsSection,
       collapsibleSection('Scan report', this._report),
       collapsibleSection('Saved views', views),
-      this._exportSection,
-      collapsibleSection('Image export', imageExporter),
-      collapsibleSection('Report PDF', reportExporter),
       sessionStats,
     ]);
     this._showReportPlaceholder();
@@ -1638,23 +1410,13 @@ export class Inspector {
   }
 
   /**
-   * Visual Export Studio — toggle the image-export buttons as a
-   * group. The Studio modes all require a loaded cloud (the height-map,
-   * intensity, and classification exporters' `isAvailable` gates on the
-   * cloud AABB), so the failure mode is hidden at the UI layer by disabling
-   * the buttons until `enabled === true`. Per-mode capability gating
-   * (intensity disabled on a PLY, classification disabled on PCD without
-   * a label channel) is handled inside each exporter's `isAvailable`.
-   */
-  /**
    * Streaming-mode toggle.
    *
-   * When `true`, hides the four static-cloud-only sections (Layers, Color by,
-   * Point size, Rendering) and the "Export" download section. Their
+   * When `true`, hides the static-cloud-only sections (Layers, Color by). Their
    * streaming-equivalents — color modes, quality control, resident-points
    * stats — live in the StreamingPanel; the Inspector retains Detail,
-   * Provenance, Coordinate system, Scan report, Saved views, Image export
-   * and Report PDF, which all work uniformly against a streaming source.
+   * Provenance, Coordinate system, Scan report and Saved views, which all work
+   * uniformly against a streaming source.
    *
    * When `false` (default), all sections are visible — the static load path
    * uses the full Inspector.
@@ -1667,7 +1429,6 @@ export class Inspector {
     const hidden = streaming ? 'none' : '';
     this._layersSection.style.display = hidden;
     this._colorBySection.style.display = hidden;
-    this._exportSection.style.display = hidden;
     // The Render-quality section (point size, point-size mode, EDL,
     // antialiasing) stays visible while streaming. Each control applies to the
     // resident streaming node materials and every newly-decoded node inherits
@@ -1703,59 +1464,6 @@ export class Inspector {
     this.sheetToggle.classList.toggle('olv-hidden', empty);
   }
 
-  setImageExportEnabled(enabled: boolean): void {
-    for (const [mode, button] of this._imageExportButtons) {
-      button.disabled = !enabled;
-      const baseTitle = this._imageExportTitles.get(mode) ?? '';
-      button.title = enabled ? baseTitle : `${baseTitle} (load a scan first)`;
-    }
-    // The Report PDF button + template picker share the same gate
-    // (a report against no cloud has nothing to summarise).
-    if (this._reportButton) {
-      this._reportButton.disabled = !enabled;
-      const base = 'Generate a multi-page PDF report from the selected template.';
-      this._reportButton.title = enabled ? base : `${base} (load a scan first)`;
-    }
-    if (this._reportSelect) {
-      this._reportSelect.disabled = !enabled;
-    }
-  }
-
-  /**
-   * Per-mode availability override for the Visual Export Studio buttons.
-   *
-   * Called by main after each load to disable buttons whose mode is not
-   * supported by the loaded cloud — Normal map on a LAZ, Intensity on a
-   * raw PLY, Class map on a PCD without a label channel. The button stays
-   * visible (so the user knows the feature exists) but is disabled with
-   * the unavailability reason in its tooltip. Without this, clicking
-   * Normal map on a LAZ produced an error toast at render time — a poor
-   * substitute for visibly-disabled affordance.
-   *
-   * Pre-conditions: a scan must already be loaded. Callers gate on
-   * {@link setImageExportEnabled}(true) first; this method then narrows
-   * the set of enabled buttons. A mode missing from the map is treated as
-   * enabled (forward-compatible: a new exporter without per-mode flags
-   * still works through `setImageExportEnabled(true)`).
-   */
-  setImageExportAvailability(
-    availability: ReadonlyMap<ExportMode, { readonly available: boolean; readonly reason?: string }>,
-  ): void {
-    for (const [mode, button] of this._imageExportButtons) {
-      const entry = availability.get(mode);
-      if (!entry) continue; // unknown mode → leave as-is
-      const baseTitle = this._imageExportTitles.get(mode) ?? '';
-      if (entry.available) {
-        button.disabled = false;
-        button.title = baseTitle;
-      } else {
-        button.disabled = true;
-        button.title = entry.reason
-          ? `${baseTitle} — ${entry.reason}`
-          : `${baseTitle} (unavailable on this cloud)`;
-      }
-    }
-  }
 
   /** Remove a cloud's layer row. */
   removeCloud(id: string): void {

--- a/src/ui/collapsibleSection.ts
+++ b/src/ui/collapsibleSection.ts
@@ -1,0 +1,26 @@
+/**
+ * collapsibleSection.ts
+ *
+ * A `<details>`-based collapsible section with a summary label. Shared by the
+ * Inspector and the Output panel's export deliverables, so the same disclosure
+ * idiom (and its CSS) is authored once.
+ */
+
+import { el } from './dom';
+
+export function collapsibleSection(
+  label: string,
+  body: HTMLElement,
+  opts: { readonly open?: boolean } = {},
+): HTMLDetailsElement {
+  const details = el('details', {
+    className: 'olv-section olv-section-collapsible',
+  }) as HTMLDetailsElement;
+  if (opts.open) details.open = true;
+  const summary = el('summary', {
+    className: 'olv-section-label olv-section-summary',
+    text: label,
+  });
+  details.append(summary, body);
+  return details;
+}

--- a/src/ui/export/exportDeliverables.ts
+++ b/src/ui/export/exportDeliverables.ts
@@ -1,0 +1,233 @@
+/**
+ * exportDeliverables.ts
+ *
+ * The three deliverable sections of the Output panel: point-cloud file formats,
+ * the Visual Export Studio (PNG image export), and the PDF report. These moved
+ * out of the Inspector so every export lives in one Output Center; the UX is
+ * unchanged (the same collapsible sections, the same buttons, the same gating),
+ * only the mount point differs.
+ *
+ * `main.ts` owns the lazy imports and the download wiring behind the three
+ * callbacks; this module owns the buttons, the template picker, and the
+ * empty-state gating that disables everything until a scan is loaded.
+ */
+
+import { el } from '../dom';
+import { collapsibleSection } from '../collapsibleSection';
+import type { ExportFormat } from '../../io/exporters';
+import type { ExportMode } from '../../export/types';
+// Direct subpath import — NOT the `'../../report'` barrel, which pulls pdf-lib
+// into the static graph. `ReportTemplates.ts` is a pure-data module.
+import {
+  REPORT_TEMPLATES,
+  DEFAULT_TEMPLATE_ID,
+  getReportTemplate,
+} from '../../report/ReportTemplates';
+import type { ReportTemplateId } from '../../report/types';
+
+/** The point-cloud file formats the quick exporter offers. */
+const EXPORT_FORMATS: ExportFormat[] = ['ply', 'obj', 'xyz', 'csv'];
+
+/**
+ * Visual Export Studio — the PNG export modes. Each entry is `mode / label /
+ * title`; the title doubles as the disabled-state hover hint. The specific
+ * colour-mode buttons come first because they reliably produce distinct images;
+ * the generic "View capture" comes last (it captures whatever colour mode is
+ * active, so it can match Height map when the user is already in elevation).
+ */
+const IMAGE_EXPORT_BUTTONS: ReadonlyArray<{
+  readonly mode: ExportMode;
+  readonly label: string;
+  readonly title: string;
+}> = [
+  {
+    mode: 'height-map',
+    label: 'Height map',
+    title: 'Forces elevation colouring. Always distinct from view-capture-in-other-modes.',
+  },
+  {
+    mode: 'intensity',
+    label: 'Intensity',
+    title: 'Forces LiDAR-intensity colouring. Disabled on clouds without an intensity channel.',
+  },
+  {
+    mode: 'classification',
+    label: 'Class map',
+    title: 'Forces ASPRS-classification colouring. Disabled on clouds without a classification channel.',
+  },
+  {
+    mode: 'normal',
+    label: 'Normal map',
+    title:
+      'RGB-encodes per-point surface normals. Disabled on clouds without normals ' +
+      '(PCD / PTX / GLTF carry them; raw LiDAR rarely does).',
+  },
+  {
+    mode: 'orthographic-rgb',
+    label: 'View capture',
+    title:
+      'Captures the current on-screen view in whatever colour mode is active. ' +
+      'To get a distinct image, switch the Color by chip before clicking — ' +
+      'otherwise this matches Height Map when you are viewing in elevation. ' +
+      'Georeferenced scans (known CRS + world origin) instead download a ' +
+      'top-down ortho ZIP with .pgw/.prj sidecars that GIS tools place directly.',
+  },
+];
+
+/** The callbacks the deliverables fire; main.ts owns the lazy engines behind them. */
+export interface ExportDeliverablesCallbacks {
+  /** Export the active cloud to a point-cloud file format. */
+  readonly onExport: (format: ExportFormat) => void;
+  /** Render the live scan in one Studio mode and download it as a PNG. */
+  readonly onExportImage: (mode: ExportMode) => void;
+  /** Generate a PDF report from the live scan using the named template. */
+  readonly onExportReport: (templateId: string) => void;
+}
+
+/** The mounted deliverables plus the gating controller the shell drives. */
+export interface ExportDeliverables {
+  /** The section element to place in the Output panel body. */
+  readonly element: HTMLElement;
+  /** The format-export section, shown only for a resolvable cloud (hidden while streaming-only). */
+  readonly formatSection: HTMLElement;
+  /**
+   * Enable or disable the image-export and report buttons as a group. A report
+   * or an image against no cloud has nothing to draw, so they gate together and
+   * start disabled.
+   */
+  setImageExportEnabled(enabled: boolean): void;
+  /**
+   * Per-mode availability override for the image-export buttons — disable the
+   * ones the loaded cloud cannot supply (Normal map on a LAZ, Intensity on a raw
+   * PLY) with the reason in the tooltip. Callers gate on
+   * {@link setImageExportEnabled}(true) first; a mode missing from the map is
+   * left as-is (a new exporter without per-mode flags still works).
+   */
+  setImageExportAvailability(
+    availability: ReadonlyMap<ExportMode, { readonly available: boolean; readonly reason?: string }>,
+  ): void;
+}
+
+/**
+ * Build the three export sections and their gating. Returns the element to mount
+ * and the controller the composition root drives on each scan load.
+ */
+export function buildExportDeliverables(cb: ExportDeliverablesCallbacks): ExportDeliverables {
+  const imageExportButtons = new Map<ExportMode, HTMLButtonElement>();
+  const imageExportTitles = new Map<ExportMode, string>();
+
+  // Point-cloud file formats — one button per supported output format.
+  const formatButtons = EXPORT_FORMATS.map((format) => {
+    const button = el('button', {
+      className: 'olv-export-btn',
+      text: format.toUpperCase(),
+      title: `Export the cloud as ${format.toUpperCase()}`,
+    });
+    button.addEventListener('click', () => {
+      button.blur();
+      cb.onExport(format);
+    });
+    return button;
+  });
+  const formatRow = el('div', { className: 'olv-export' }, formatButtons);
+  const formatSection = collapsibleSection('Export', formatRow);
+
+  // Visual Export Studio — one button per PNG mode. Start disabled so a user
+  // cannot fire an export with nothing to draw; the class matches the format
+  // row so the CSS layout is shared.
+  const imageButtons = IMAGE_EXPORT_BUTTONS.map(({ mode, label, title }) => {
+    const button = el('button', { className: 'olv-export-btn', text: label, title });
+    button.disabled = true;
+    button.title = `${title} (load a scan first)`;
+    button.addEventListener('click', () => {
+      button.blur();
+      cb.onExportImage(mode);
+    });
+    imageExportButtons.set(mode, button);
+    imageExportTitles.set(mode, title);
+    return button;
+  });
+  // The image row carries several buttons — too many for one flex row inside a
+  // narrow panel; the 2-column grid wraps cleanly.
+  const imageRow = el('div', { className: 'olv-export-grid' }, imageButtons);
+
+  // PDF report — a native <select> picks the template, a single button fires it.
+  const reportSelect = el('select', {
+    className: 'olv-report-select',
+    ariaLabel: 'PDF report template',
+  }) as HTMLSelectElement;
+  for (const t of REPORT_TEMPLATES) {
+    const option = el('option', { text: t.label, title: t.description });
+    option.value = t.id;
+    if (t.id === DEFAULT_TEMPLATE_ID) option.selected = true;
+    reportSelect.append(option);
+  }
+  reportSelect.disabled = true;
+  const reportButton = el('button', {
+    className: 'olv-export-btn',
+    text: 'Report PDF',
+    title: 'Generate a multi-page PDF report from the selected template.',
+  });
+  reportButton.disabled = true;
+  reportButton.title = `${reportButton.title} (load a scan first)`;
+  reportButton.addEventListener('click', () => {
+    reportButton.blur();
+    const templateId = reportSelect.value as ReportTemplateId;
+    // Defence-in-depth: the select is populated from REPORT_TEMPLATES, but a
+    // devtools-injected option or a future rename could surface an unknown id.
+    // Flash a visible button state so the click is observably acknowledged.
+    if (!getReportTemplate(templateId)) {
+      const original = reportButton.textContent;
+      reportButton.textContent = 'Unknown template';
+      reportButton.disabled = true;
+      window.setTimeout(() => {
+        reportButton.textContent = original;
+        reportButton.disabled = false;
+      }, 1500);
+      return;
+    }
+    cb.onExportReport(templateId);
+  });
+  const reportRow = el('div', { className: 'olv-report-row' }, [reportSelect, reportButton]);
+
+  const element = el('div', {}, [
+    formatSection,
+    collapsibleSection('Image export', imageRow),
+    collapsibleSection('Report PDF', reportRow),
+  ]);
+
+  const setImageExportEnabled = (enabled: boolean): void => {
+    for (const [mode, button] of imageExportButtons) {
+      button.disabled = !enabled;
+      const baseTitle = imageExportTitles.get(mode) ?? '';
+      button.title = enabled ? baseTitle : `${baseTitle} (load a scan first)`;
+    }
+    // The report button + picker share the same gate (a report against no cloud
+    // has nothing to summarise).
+    reportButton.disabled = !enabled;
+    const base = 'Generate a multi-page PDF report from the selected template.';
+    reportButton.title = enabled ? base : `${base} (load a scan first)`;
+    reportSelect.disabled = !enabled;
+  };
+
+  const setImageExportAvailability = (
+    availability: ReadonlyMap<ExportMode, { readonly available: boolean; readonly reason?: string }>,
+  ): void => {
+    for (const [mode, button] of imageExportButtons) {
+      const entry = availability.get(mode);
+      if (!entry) continue; // unknown mode → leave as-is
+      const baseTitle = imageExportTitles.get(mode) ?? '';
+      if (entry.available) {
+        button.disabled = false;
+        button.title = baseTitle;
+      } else {
+        button.disabled = true;
+        button.title = entry.reason
+          ? `${baseTitle} — ${entry.reason}`
+          : `${baseTitle} (unavailable on this cloud)`;
+      }
+    }
+  };
+
+  return { element, formatSection, setImageExportEnabled, setImageExportAvailability };
+}

--- a/tests/e2e/exportPanel.spec.ts
+++ b/tests/e2e/exportPanel.spec.ts
@@ -34,7 +34,9 @@ test('after a scan loads, the Export panel offers formats and exports a file', a
   // Pick XYZ (small text output) and export → a download fires.
   await panel.locator('.olv-bc-pill', { hasText: 'XYZ' }).click();
   const downloadPromise = page.waitForEvent('download');
-  await panel.locator('.olv-export-btn').click();
+  // The converter's own Export button (the deliverables moved here from the
+  // Inspector also carry `.olv-export-btn`, so target the converter class).
+  await panel.locator('.olv-bc-convert').click();
   const download = await downloadPromise;
   expect(download.suggestedFilename()).toMatch(/\.xyz$/);
 

--- a/tests/openScan.test.ts
+++ b/tests/openScan.test.ts
@@ -123,6 +123,7 @@ function makeDeps(over: { loading?: boolean } = {}) {
     scans: { setActive: vi.fn(), activeId: null } as unknown as OpenScanDeps['scans'],
     layerIdentity: { bindOnLoad: vi.fn(() => null), ensureStoresWired: vi.fn() },
     inspector: {} as unknown as OpenScanDeps['inspector'],
+    exportPanel: { setImageExportEnabled: () => {}, setImageExportAvailability: () => {}, setStreamingMode: () => {} } as unknown as OpenScanDeps['exportPanel'],
     inspectorCards: {} as unknown as OpenScanDeps['inspectorCards'],
     crsCoordinator: {} as unknown as OpenScanDeps['crsCoordinator'],
     dock: {} as unknown as OpenScanDeps['dock'],

--- a/tests/openStreaming.test.ts
+++ b/tests/openStreaming.test.ts
@@ -194,6 +194,7 @@ function makeDeps(
     },
     stage: { hideEmptyState: vi.fn() },
     inspector: {} as unknown as OpenStreamingDeps['inspector'],
+    exportPanel: { setImageExportEnabled: () => {}, setImageExportAvailability: () => {}, setStreamingMode: () => {} } as unknown as OpenStreamingDeps['exportPanel'],
     streamingPanel: {} as unknown as OpenStreamingDeps['streamingPanel'],
     classLegendPanel: {} as unknown as OpenStreamingDeps['classLegendPanel'],
     inspectorCards: {} as unknown as OpenStreamingDeps['inspectorCards'],
@@ -457,12 +458,15 @@ function makeCopcDeps(over: { openRejects?: boolean; attachRejects?: boolean; pr
     stage: { hideEmptyState: calls.hideEmptyState },
     inspector: {
       element: { classList: { remove: vi.fn() } },
-      setImageExportEnabled: vi.fn(),
-      setImageExportAvailability: vi.fn(),
       setStreamingMode: vi.fn(),
       setDetail: vi.fn(),
       setReport: vi.fn(),
     } as unknown as OpenStreamingDeps['inspector'],
+    exportPanel: {
+      setImageExportEnabled: vi.fn(),
+      setImageExportAvailability: vi.fn(),
+      setStreamingMode: vi.fn(),
+    } as unknown as OpenStreamingDeps['exportPanel'],
     streamingPanel: {
       setPhase: vi.fn(),
       show: vi.fn(),


### PR DESCRIPTION
The Inspector owned three export sections, the point-cloud file-format buttons, the Visual Export Studio image export, and the PDF report, while the Output panel owned the format converter, measurements, KML, and the integrity report. Two panels both about exporting, which the audit flagged as duplicated output surface.

This moves the three Inspector sections into the Output panel so every deliverable lives in one place. The UX is unchanged: the same collapsible sections, the same buttons, the same load-time gating; only the mount point differs. The relocation is a pure move, no redesign, so there is nothing new to review visually.

Structure:
- The three sections and their gating are extracted into src/ui/export/exportDeliverables.ts, which exposes the mounted element plus a controller (setImageExportEnabled, setImageExportAvailability). ExportPanel builds it and delegates.
- The shared collapsibleSection helper moves to src/ui/collapsibleSection.ts so both panels author the same disclosure idiom.
- The image-export and report callbacks move from the Inspector's callback set to ExportPanel's, and the gating is threaded to the open pipelines (openScan, openStreaming) through their deps.
- The point-format quick export hides while a streaming scan is active, matching the Inspector's old behaviour.
- Inspector loses roughly 200 lines and its report and export-type imports.

The export CSS classes were already global selectors, so no styles moved and the style fixture is unchanged. Verified: tsc clean, 93 unit tests pass, the export e2e suite passes, and a browser check confirms all three sections now render in the Output panel (with correct empty-state gating) and are gone from the Inspector. main.ts baseline moved 5824 to 5828 for the callback relocation and the deps wiring, with the architecture map and known-limitations counts updated.