### PR TITLE
feat: slim the StreamingPanel — saved views move to the Inspector

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,828 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,821 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -99,7 +99,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,828)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,821)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.5.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.5.md
@@ -4,7 +4,7 @@ This release sharpens classification, hardens the report and export surfaces aga
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,828 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and shared domain/application state is owned by AppContext/services, with the composition root retaining only explicitly bounded shell-local composition and lifecycle state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,821 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and shared domain/application state is owned by AppContext/services, with the composition root retaining only explicitly bounded shell-local composition and lifecycle state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
 
 ## Building classification: the ground-support gate is evaluated on synthetic scenes only
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5828,
+      "lines": 5821,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2028,9 +2028,6 @@ const streamingPanel = new StreamingPanel({
     else viewer.resumeStreaming();
   },
   onClearCache: () => viewer.clearStreamingCache(),
-  onSaveView: () => saveCurrentView(),
-  onApplyView: (index) => applyView(index),
-  onDeleteView: (index) => deleteView(index),
   onGradeFullCloud: () => void runFullCloudGradeAction(),
   onCancelGrade: () => cancelFullCloudGrade(),
 });
@@ -4763,8 +4760,10 @@ function saveCurrentView(): void {
 /** Push the saved-view names to whichever panel is currently shown. */
 function refreshViewsUI(): void {
   const names = bookmarks.names();
-  if (viewer.hasStreamingCloud) streamingPanel.setViews(names);
-  else inspector.setViews(names);
+  // Saved views live in the Inspector for both static and streaming scans — the
+  // Inspector's Saved-views section stays visible in streaming mode, so there is
+  // one list (with rename + delete) rather than a second copy in the stream panel.
+  inspector.setViews(names);
 }
 
 /** Glide the camera to a saved view — and (v7) restore its display state. */
@@ -4781,12 +4780,6 @@ function applyView(index: number): void {
   // Full restore through the one apply path; the pose rides as the bundle's
   // camera so the orchestrator applies it LAST.
   applyViewState({ ...view.state, camera: view.pose });
-}
-
-/** Delete a saved view and refresh the list. */
-function deleteView(index: number): void {
-  bookmarks.remove(index);
-  refreshViewsUI();
 }
 
 /**

--- a/src/styles/45-dock-and-panels.css
+++ b/src/styles/45-dock-and-panels.css
@@ -182,22 +182,6 @@
   color: var(--text-dim); font-family: var(--mono);
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.olv-streaming-views { display: flex; flex-direction: column; gap: var(--space-xs); }
-.olv-streaming-empty { font-size: var(--text-xs); color: var(--text-faint); }
-.olv-streaming-view { display: flex; gap: var(--space-xs); }
-.olv-streaming-view-name {
-  flex: 1; min-width: 0; text-align: left; font-size: var(--text-xs); color: var(--text-dim);
-  background: rgba(255, 255, 255, 0.04);
-  border: 0.5px solid var(--hairline); border-radius: var(--radius-sm); padding: var(--space-sm) var(--space-md);
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.olv-streaming-view-name:hover { color: var(--text); border-color: var(--accent); }
-.olv-streaming-view-del {
-  flex: none; width: 26px; font-size: var(--text-md); color: var(--text-faint);
-  background: rgba(255, 255, 255, 0.04);
-  border: 0.5px solid var(--hairline); border-radius: var(--radius-sm);
-}
-.olv-streaming-view-del:hover { color: #ff9a9a; border-color: rgba(255, 120, 120, 0.55); }
 /*
  * StreamingPanel section eyebrow — matches .olv-section-label so
  * Inspector and Streaming, sharing the same 232 px right column,
@@ -210,10 +194,9 @@
 .olv-streaming-chips { display: flex; flex-wrap: wrap; gap: var(--space-xs); }
 .olv-streaming-actions { display: flex; gap: var(--space-sm); margin-top: var(--space-xl); }
 /*
- * The destructive actions row (Clear cache) gets extra top margin so
- * it visually segregates from the constructive Save view + Pause
- * pair above it (Gestalt common region — destructive deserves its
- * own region, not just a colour cue).
+ * The destructive actions row (Clear cache) gets extra top margin so it
+ * visually segregates from the Pause control above it (Gestalt common
+ * region — destructive deserves its own region, not just a colour cue).
  */
 .olv-streaming-actions + .olv-streaming-actions { margin-top: var(--space-2xl); }
 .olv-streaming-btn {

--- a/src/styles/70-measurement-panels.css
+++ b/src/styles/70-measurement-panels.css
@@ -90,10 +90,9 @@
 /*
  * Save (primary action) — aligned with the rest of the app's primary
  * vocabulary: cyan text on accent-soft fill, NOT solid-cyan. This is
- * the same treatment used by .olv-measure-done, .olv-inspect-copy and
- * .olv-streaming-view-save, so a user who learned "this is the primary
- * action" anywhere in the app reads it the same way here (Gestalt
- * similarity).
+ * the same treatment used by .olv-measure-done and .olv-inspect-copy, so a
+ * user who learned "this is the primary action" anywhere in the app reads it
+ * the same way here (Gestalt similarity).
  */
 .olv-anno-editor-save {
   font-size: var(--text-xs); padding: var(--space-sm) var(--space-xl); cursor: pointer; border-radius: var(--radius-sm);

--- a/src/styles/72-panel-rails.css
+++ b/src/styles/72-panel-rails.css
@@ -114,32 +114,11 @@
 @media (max-width: 767px), (max-height: 500px) and (pointer: coarse) { .olv-rail-tab { display: none; } }
 
 /* ── Right rail — one-tap collapse for the right column ──────────────────────
-   Mirror of the left rail. A single grabber slides BOTH right panels (the
-   Streaming/COPC card and the Inspector) out to the screen's right edge. The
-   two panels are separate absolutely-positioned elements, so the collapse
-   transform is applied to each; the grabber is a handle growing out of the
-   column's left (canvas-facing) edge. Desktop only — the mobile sheet owns
-   small screens. Motion/opacity are scoped to desktop so the mobile bottom
-   sheet's own transforms are never touched. */
-@media (min-width: 768px) {
-  .olv-inspector,
-  .olv-streaming-panel {
-    transition: transform 420ms var(--ease-spring), opacity 260ms var(--ease-standard);
-  }
-  /* Collapsed — slide the panel fully past the right edge (its own width plus
-     the 14px inset and a small margin), GPU transform only, no reflow.
-     `animation: none` releases the `olv-rise-in` entrance animation's hold: it
-     runs with fill-mode `both`, so its held end-state would otherwise pin the
-     Inspector's transform/opacity and override this rule (the Streaming card has
-     no such animation, which is why only it collapsed before). */
-  .olv-inspector.olv-right-collapsed,
-  .olv-streaming-panel.olv-right-collapsed {
-    animation: none;
-    transform: translateX(calc(100% + var(--space-lg, 16px)));
-    opacity: 0;
-    pointer-events: none;
-  }
-}
+   A single grabber slides the whole right rail out to the screen's right edge.
+   The rail collapse lives on the `.olv-right-rail` wrapper (both the Streaming
+   card and the Inspector move together inside it) in `40-inspector.css`; the
+   grabber styling below is a handle growing out of the column's left
+   (canvas-facing) edge. Desktop only — the mobile sheet owns small screens. */
 /* The grabber — a handle growing out of the right column's LEFT edge: flush to
    the edge, right corners squared, right border merged into the column (−1px
    overlap hides the shared hairline), only the outer (left) corners rounded.
@@ -191,12 +170,6 @@
 .olv-right-rail-tab svg { width: 14px; height: 14px; transition: transform 300ms var(--ease-spring); }
 .olv-right-rail-tab[aria-expanded="false"] svg { transform: rotate(180deg); }
 @media (prefers-reduced-motion: reduce) {
-  .olv-inspector, .olv-streaming-panel { transition: none; }
-  /* No slide under reduced motion, but still release the entrance animation so
-     the collapse's opacity:0 / pointer-events:none actually take (the panel
-     fades out in place instead of staying a dead, visible layer). */
-  .olv-inspector.olv-right-collapsed,
-  .olv-streaming-panel.olv-right-collapsed { animation: none; transform: none; }
   .olv-right-rail-tab, .olv-right-rail-tab svg { transition: none; }
 }
 @media (max-width: 767px), (max-height: 500px) and (pointer: coarse) { .olv-right-rail-tab { display: none; } }

--- a/src/ui/StreamingPanel.ts
+++ b/src/ui/StreamingPanel.ts
@@ -78,9 +78,6 @@ export interface StreamingPanelCallbacks {
   onQuality(quality: StreamingQuality): void;
   onPauseToggle(paused: boolean): void;
   onClearCache(): void;
-  onSaveView(): void;
-  onApplyView(index: number): void;
-  onDeleteView(index: number): void;
   /** Run the full-cloud grade (decode a representative octree sample + grade it). */
   onGradeFullCloud(): void;
   /** Cancel a full-cloud grade that is currently running. */
@@ -258,7 +255,6 @@ export class StreamingPanel {
   private readonly _cache: HTMLElement;
   private readonly _modeRow: HTMLElement;
   private readonly _qualityRow: HTMLElement;
-  private readonly _views: HTMLElement;
   private readonly _pause: HTMLButtonElement;
   // Full-cloud grade: a button that decodes a representative octree
   // sample across the whole cloud and grades it, plus a result/status area.
@@ -300,8 +296,6 @@ export class StreamingPanel {
     this._cache = el('span', { className: 'olv-streaming-stat', text: '—' });
     this._modeRow = el('div', { className: 'olv-streaming-chips' });
     this._qualityRow = el('div', { className: 'olv-streaming-chips' });
-    this._views = el('div', { className: 'olv-streaming-views' });
-
     for (const quality of QUALITIES) {
       const chip = el('button', {
         className: 'olv-chip',
@@ -313,9 +307,6 @@ export class StreamingPanel {
       });
       this._qualityRow.append(chip);
     }
-
-    const saveView = el('button', { className: 'olv-streaming-btn', text: 'Save view' });
-    saveView.addEventListener('click', () => this._callbacks.onSaveView());
 
     this._pause = el('button', { className: 'olv-streaming-btn', text: 'Pause' });
     this._pause.addEventListener('click', () => {
@@ -399,12 +390,9 @@ export class StreamingPanel {
       el('div', { className: 'olv-streaming-label', text: 'Full-cloud grade' }),
       el('div', { className: 'olv-streaming-actions' }, [this._gradeBtn]),
       this._gradeResult,
-      el('div', { className: 'olv-streaming-label', text: 'Saved views' }),
-      this._views,
-      el('div', { className: 'olv-streaming-actions' }, [saveView, this._pause]),
+      el('div', { className: 'olv-streaming-actions' }, [this._pause]),
       el('div', { className: 'olv-streaming-actions' }, [clearCache]),
     ]);
-    this.setViews([]);
   }
 
   /** Show the panel. */
@@ -608,29 +596,6 @@ export class StreamingPanel {
       this._progressFill.style.width = '0%';
       this._progressTrack.removeAttribute('aria-valuenow');
     }
-  }
-
-  /** Populate the saved-views list. */
-  setViews(names: string[]): void {
-    if (names.length === 0) {
-      this._views.replaceChildren(
-        el('div', { className: 'olv-streaming-empty', text: 'No saved views yet' }),
-      );
-      return;
-    }
-    this._views.replaceChildren(
-      ...names.map((name, index) => {
-        const apply = el('button', { className: 'olv-streaming-view-name', text: name });
-        apply.addEventListener('click', () => this._callbacks.onApplyView(index));
-        const del = el('button', {
-          className: 'olv-streaming-view-del',
-          text: '×',
-          ariaLabel: `Delete ${name}`,
-        });
-        del.addEventListener('click', () => this._callbacks.onDeleteView(index));
-        return el('div', { className: 'olv-streaming-view' }, [apply, del]);
-      }),
-    );
   }
 
   private _statRow(label: string, value: HTMLElement): HTMLElement {

--- a/tests/e2e/streaming.spec.ts
+++ b/tests/e2e/streaming.spec.ts
@@ -107,10 +107,13 @@ test('opens a real COPC file and streams it progressively', async ({ page }) => 
   await expect(panel).toContainText('COPC LAZ');
   await expect(panel).toContainText(/PDRF [678]/);
 
-  // Saving a camera view adds it to the streaming panel's list.
-  await expect(panel).toContainText('No saved views yet');
-  await panel.locator('.olv-streaming-btn', { hasText: 'Save view' }).click();
-  await expect(panel.locator('.olv-streaming-view-name')).toHaveText('View 1');
+  // Saving a camera view adds it to the Inspector's Saved views. The streaming
+  // panel no longer carries its own list — saved views (with rename + delete)
+  // live in the Inspector for both static and streaming scans.
+  const inspector = page.locator('.olv-inspector');
+  await inspector.locator('summary', { hasText: 'Saved views' }).click();
+  await inspector.locator('.olv-view-save').click();
+  await expect(inspector.locator('.olv-view-name').first()).toHaveValue('View 1');
 });
 
 test('inspects a per-point readout on a streaming COPC node', async ({ page }) => {

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -1685,22 +1685,6 @@ body.olv-theme-light .olv-empty::before {
   color: var(--text-dim); font-family: var(--mono);
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.olv-streaming-views { display: flex; flex-direction: column; gap: var(--space-xs); }
-.olv-streaming-empty { font-size: var(--text-xs); color: var(--text-faint); }
-.olv-streaming-view { display: flex; gap: var(--space-xs); }
-.olv-streaming-view-name {
-  flex: 1; min-width: 0; text-align: left; font-size: var(--text-xs); color: var(--text-dim);
-  background: rgba(255, 255, 255, 0.04);
-  border: 0.5px solid var(--hairline); border-radius: var(--radius-sm); padding: var(--space-sm) var(--space-md);
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.olv-streaming-view-name:hover { color: var(--text); border-color: var(--accent); }
-.olv-streaming-view-del {
-  flex: none; width: 26px; font-size: var(--text-md); color: var(--text-faint);
-  background: rgba(255, 255, 255, 0.04);
-  border: 0.5px solid var(--hairline); border-radius: var(--radius-sm);
-}
-.olv-streaming-view-del:hover { color: #ff9a9a; border-color: rgba(255, 120, 120, 0.55); }
 /*
  * StreamingPanel section eyebrow — matches .olv-section-label so
  * Inspector and Streaming, sharing the same 232 px right column,
@@ -1713,10 +1697,9 @@ body.olv-theme-light .olv-empty::before {
 .olv-streaming-chips { display: flex; flex-wrap: wrap; gap: var(--space-xs); }
 .olv-streaming-actions { display: flex; gap: var(--space-sm); margin-top: var(--space-xl); }
 /*
- * The destructive actions row (Clear cache) gets extra top margin so
- * it visually segregates from the constructive Save view + Pause
- * pair above it (Gestalt common region — destructive deserves its
- * own region, not just a colour cue).
+ * The destructive actions row (Clear cache) gets extra top margin so it
+ * visually segregates from the Pause control above it (Gestalt common
+ * region — destructive deserves its own region, not just a colour cue).
  */
 .olv-streaming-actions + .olv-streaming-actions { margin-top: var(--space-2xl); }
 .olv-streaming-btn {
@@ -3458,10 +3441,9 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 /*
  * Save (primary action) — aligned with the rest of the app's primary
  * vocabulary: cyan text on accent-soft fill, NOT solid-cyan. This is
- * the same treatment used by .olv-measure-done, .olv-inspect-copy and
- * .olv-streaming-view-save, so a user who learned "this is the primary
- * action" anywhere in the app reads it the same way here (Gestalt
- * similarity).
+ * the same treatment used by .olv-measure-done and .olv-inspect-copy, so a
+ * user who learned "this is the primary action" anywhere in the app reads it
+ * the same way here (Gestalt similarity).
  */
 .olv-anno-editor-save {
   font-size: var(--text-xs); padding: var(--space-sm) var(--space-xl); cursor: pointer; border-radius: var(--radius-sm);
@@ -3815,32 +3797,11 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 @media (max-width: 767px), (max-height: 500px) and (pointer: coarse) { .olv-rail-tab { display: none; } }
 
 /* ── Right rail — one-tap collapse for the right column ──────────────────────
-   Mirror of the left rail. A single grabber slides BOTH right panels (the
-   Streaming/COPC card and the Inspector) out to the screen's right edge. The
-   two panels are separate absolutely-positioned elements, so the collapse
-   transform is applied to each; the grabber is a handle growing out of the
-   column's left (canvas-facing) edge. Desktop only — the mobile sheet owns
-   small screens. Motion/opacity are scoped to desktop so the mobile bottom
-   sheet's own transforms are never touched. */
-@media (min-width: 768px) {
-  .olv-inspector,
-  .olv-streaming-panel {
-    transition: transform 420ms var(--ease-spring), opacity 260ms var(--ease-standard);
-  }
-  /* Collapsed — slide the panel fully past the right edge (its own width plus
-     the 14px inset and a small margin), GPU transform only, no reflow.
-     `animation: none` releases the `olv-rise-in` entrance animation's hold: it
-     runs with fill-mode `both`, so its held end-state would otherwise pin the
-     Inspector's transform/opacity and override this rule (the Streaming card has
-     no such animation, which is why only it collapsed before). */
-  .olv-inspector.olv-right-collapsed,
-  .olv-streaming-panel.olv-right-collapsed {
-    animation: none;
-    transform: translateX(calc(100% + var(--space-lg, 16px)));
-    opacity: 0;
-    pointer-events: none;
-  }
-}
+   A single grabber slides the whole right rail out to the screen's right edge.
+   The rail collapse lives on the `.olv-right-rail` wrapper (both the Streaming
+   card and the Inspector move together inside it) in `40-inspector.css`; the
+   grabber styling below is a handle growing out of the column's left
+   (canvas-facing) edge. Desktop only — the mobile sheet owns small screens. */
 /* The grabber — a handle growing out of the right column's LEFT edge: flush to
    the edge, right corners squared, right border merged into the column (−1px
    overlap hides the shared hairline), only the outer (left) corners rounded.
@@ -3892,12 +3853,6 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-right-rail-tab svg { width: 14px; height: 14px; transition: transform 300ms var(--ease-spring); }
 .olv-right-rail-tab[aria-expanded="false"] svg { transform: rotate(180deg); }
 @media (prefers-reduced-motion: reduce) {
-  .olv-inspector, .olv-streaming-panel { transition: none; }
-  /* No slide under reduced motion, but still release the entrance animation so
-     the collapse's opacity:0 / pointer-events:none actually take (the panel
-     fades out in place instead of staying a dead, visible layer). */
-  .olv-inspector.olv-right-collapsed,
-  .olv-streaming-panel.olv-right-collapsed { animation: none; transform: none; }
   .olv-right-rail-tab, .olv-right-rail-tab svg { transition: none; }
 }
 @media (max-width: 767px), (max-height: 500px) and (pointer: coarse) { .olv-right-rail-tab { display: none; } }

--- a/tests/streamingPanelGrade.test.ts
+++ b/tests/streamingPanelGrade.test.ts
@@ -74,8 +74,7 @@ beforeAll(() => {
 function noopCallbacks() {
   return {
     onColorMode() {}, onQuality() {}, onPauseToggle() {}, onClearCache() {},
-    onSaveView() {}, onApplyView() {}, onDeleteView() {}, onGradeFullCloud() {},
-    onCancelGrade() {},
+    onGradeFullCloud() {}, onCancelGrade() {},
   };
 }
 


### PR DESCRIPTION
The StreamingPanel carried its own saved-views list and Save-view button, duplicating what the Inspector already owns. The Inspector's Saved-views section stays visible during streaming, so the two were redundant, and the streaming copy lacked rename.

This routes saved views to the Inspector for both static and streaming scans and removes the StreamingPanel's list, Save-view button, setViews method, and the onSaveView / onApplyView / onDeleteView callbacks. The panel now shows streaming status and controls only: Scan, Streaming, Colour, Quality, Full-cloud grade, Pause, Clear cache.

Colour stays in the StreamingPanel on purpose. The Inspector's Color-by section is hidden while streaming, so the streaming Colour is the only colour control there; moving it would need a separate streaming-colour integration and is out of scope here.

Also removes dead right-rail collapse CSS. The collapse moved to the .olv-right-rail wrapper (40-inspector.css), so the per-panel .olv-inspector.olv-right-collapsed / .olv-streaming-panel.olv-right-collapsed rules never matched; the stale comment and the reduced-motion variant go with them. The style fixture is regenerated.

Verified: tsc clean, unit and style-contract tests pass, build and bundle clean, and a browser check confirms the StreamingPanel no longer has the saved-views list or Save button while the Inspector still owns them. main.ts drops 7 lines, baseline ratcheted 5828 to 5821 with the doc counts updated. The autzen streaming save-view e2e is rewritten to the Inspector flow (CI-only, skipped without the fixture).