### PR TITLE
docs: state the ProcessService / export-permit relationship honestly

### DIFF
--- a/src/process/ProcessService.ts
+++ b/src/process/ProcessService.ts
@@ -2,11 +2,21 @@
  * ProcessService.ts — the single source of product eligibility (Phase 1).
  *
  * The capability maths already live in `processCapabilities.evaluateCapabilities`
- * (pure). This is the thin, stateless surface the shell and the exporters both
- * read, so eligibility is decided in exactly one place: no button re-derives
- * "can I export a DTM?" on its own. It composes the fail-closed scan-facts
- * normaliser with the evaluator and exposes per-product lookups plus a readiness
- * roll-up. No live objects, no side effects.
+ * (pure). This is the thin, stateless surface the shell and the Process Studio
+ * panel read for a product's coarse readiness (ready / review / blocked). It
+ * composes the fail-closed scan-facts normaliser with the evaluator and exposes
+ * per-product lookups plus a readiness roll-up. No live objects, no side effects.
+ *
+ * SCOPE. This is the readiness MODEL, not the export enforcement point. The file
+ * exporters enforce `src/export/contourExportPermit.ts` — a finer, independent
+ * decision that also reads launch state, evidence grade, and the precision
+ * permit, and that intentionally allows a `cartographic-only` exploratory export
+ * where this service reports `review`. The unforgeable {@link ProcessService.authorize}
+ * / {@link ProcessService.runIfAuthorized} seam models a strict "produce only
+ * when ready" policy; no product uses it in production yet, because every OLV
+ * product supports a legitimate exploratory / review path that a hard ready-only
+ * gate would wrongly block. Making one authorization backbone for both the
+ * readiness model and the export permit is deferred design work.
  */
 
 import type { ProcessPlan, ProductCapability, ProductId, Readiness, ScanFacts } from './ProcessPlan';

--- a/src/ui/ProcessStudioPanel.ts
+++ b/src/ui/ProcessStudioPanel.ts
@@ -5,8 +5,19 @@
  * stages that apply, each product's eligibility (ready / review / blocked with a
  * reason), and the independent QA checks (pass / review / block). It reads the
  * pure Phase-1/2 services — `ProcessService`, `processStages`, `qaChecks` — and
- * renders them; it decides nothing itself, so the panel and the exporters can
- * never disagree about what is eligible.
+ * renders them; it decides nothing itself.
+ *
+ * It shows `ProcessService`'s coarse readiness (ready / review / blocked). That
+ * is NOT the same gate the file exporters enforce: a contour or DEM export is
+ * permitted by `src/export/contourExportPermit.ts`, a finer decision that also
+ * reads launch state, the evidence grade, and the in-memory precision permit,
+ * and that deliberately allows a `cartographic-only` exploratory export where
+ * `ProcessService` reports `review`. So the panel and an exporter CAN show
+ * different verdicts for the same product, and that is by design — the panel
+ * describes whether a metric-grade product is READY, the permit decides whether
+ * a specific file (graded or exploratory) may be written. They are not yet a
+ * single authorization backbone; unifying them is deferred work, not a claim
+ * this panel makes.
  *
  * DISPLAY ONLY, in the same vocabulary as ClassLegendPanel / MeasurePanel: a
  * `readonly element`, `el(...)`-built DOM, and `mount()/show()/hide()/update()`.


### PR DESCRIPTION
The audit flagged that ProcessStudioPanel claims the panel and the exporters can never disagree about eligibility, while the authorize / runIfAuthorized seam has zero production consumers. Investigating why: the file exporters enforce a separate, finer gate (contourExportPermit) that reads launch state, evidence grade, and the precision permit, and that intentionally allows a cartographic-only exploratory export where ProcessService reports review. So the two CAN disagree, and that is by design — every OLV product (DTM, DSM, contours, classify) supports a legitimate exploratory / review path, which is exactly why a hard ready-only gate like runIfAuthorized fits none of them and has no consumer.

This corrects the misleading comments in ProcessStudioPanel and ProcessService to describe the real model: ProcessService is the coarse readiness model the shell and the panel read; contourExportPermit is the export enforcement point; unifying them into one authorization backbone is deferred design work rather than a claim the code makes today. No behaviour change — forcing the unification would regress exploratory exports, so it is intentionally not done here. tsc, process tests, and the truth lints pass.