### PR TITLE
fix: consistent fonts in the Analyse Details section

### DIFF
--- a/src/styles/86-dataset-intel-analyse.css
+++ b/src/styles/86-dataset-intel-analyse.css
@@ -409,12 +409,12 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
 .olv-analyse-ready-side { flex: 0 0 auto; display: flex; align-items: center; gap: var(--space-lg); }
 .olv-analyse-ready-figure { display: flex; align-items: baseline; gap: var(--space-2xs); }
 .olv-analyse-ready-value {
-  font-family: var(--mono); font-size: 22px; font-weight: 600; line-height: 1;
+  font-size: 22px; font-weight: 600; line-height: 1;
   color: var(--text); font-variant-numeric: tabular-nums;
 }
 .olv-analyse-ready-figure.is-text .olv-analyse-ready-value { font-size: var(--text-lg); }
 .olv-analyse-ready-unit {
-  font-family: var(--mono); font-size: var(--text-xs); color: var(--text-dim);
+  font-size: var(--text-xs); color: var(--text-dim);
 }
 /* Rating pill — capitalised word on a tinted ground keyed to the rating. */
 .olv-analyse-ready-rating {
@@ -481,7 +481,7 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
 }
 
 .olv-analyse-validation { font-size: var(--text-xs); color: var(--text-dim); margin-bottom: var(--space-sm); }
-.olv-analyse-rmse { font-family: var(--mono); }
+.olv-analyse-rmse { font-variant-numeric: tabular-nums; }
 .olv-analyse-caption { font-size: var(--text-xs); color: var(--text-dim); margin-bottom: var(--space-md); overflow-wrap: anywhere; }
 
 /* Export buttons. */

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -6654,12 +6654,12 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
 .olv-analyse-ready-side { flex: 0 0 auto; display: flex; align-items: center; gap: var(--space-lg); }
 .olv-analyse-ready-figure { display: flex; align-items: baseline; gap: var(--space-2xs); }
 .olv-analyse-ready-value {
-  font-family: var(--mono); font-size: 22px; font-weight: 600; line-height: 1;
+  font-size: 22px; font-weight: 600; line-height: 1;
   color: var(--text); font-variant-numeric: tabular-nums;
 }
 .olv-analyse-ready-figure.is-text .olv-analyse-ready-value { font-size: var(--text-lg); }
 .olv-analyse-ready-unit {
-  font-family: var(--mono); font-size: var(--text-xs); color: var(--text-dim);
+  font-size: var(--text-xs); color: var(--text-dim);
 }
 /* Rating pill — capitalised word on a tinted ground keyed to the rating. */
 .olv-analyse-ready-rating {
@@ -6726,7 +6726,7 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
 }
 
 .olv-analyse-validation { font-size: var(--text-xs); color: var(--text-dim); margin-bottom: var(--space-sm); }
-.olv-analyse-rmse { font-family: var(--mono); }
+.olv-analyse-rmse { font-variant-numeric: tabular-nums; }
 .olv-analyse-caption { font-size: var(--text-xs); color: var(--text-dim); margin-bottom: var(--space-md); overflow-wrap: anywhere; }
 
 /* Export buttons. */


### PR DESCRIPTION
The Details section mixed two fonts for its figures: the composite score used the sans UI font with tabular numerics, while the readiness-card values (44%, 35%, 10) and the Vertical RMSE line used the monospace family. Two headline numbers side by side in different fonts read as a mismatch.

This drops the mono family from .olv-analyse-ready-value, .olv-analyse-ready-unit, and .olv-analyse-rmse, keeping font-variant-numeric: tabular-nums so the digits still align. The figures now match the composite score. The small uppercase micro-labels (section eyebrows, status tags) keep their deliberate mono instrument-label treatment, which is a self-consistent system across the terrain verdict.

CSS only; the style-partition fixture is regenerated and its test passes.