### PR TITLE
fix: snap Analyse figures to the type-scale tokens

### DIFF
--- a/src/styles/86-dataset-intel-analyse.css
+++ b/src/styles/86-dataset-intel-analyse.css
@@ -409,7 +409,7 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
 .olv-analyse-ready-side { flex: 0 0 auto; display: flex; align-items: center; gap: var(--space-lg); }
 .olv-analyse-ready-figure { display: flex; align-items: baseline; gap: var(--space-2xs); }
 .olv-analyse-ready-value {
-  font-size: 22px; font-weight: 600; line-height: 1;
+  font-size: var(--text-2xl); font-weight: 600; line-height: 1;
   color: var(--text); font-variant-numeric: tabular-nums;
 }
 .olv-analyse-ready-figure.is-text .olv-analyse-ready-value { font-size: var(--text-lg); }

--- a/src/styles/92-terrain-verdict.css
+++ b/src/styles/92-terrain-verdict.css
@@ -398,7 +398,7 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
 .olv-analyse-legend-bar { height: 6px; border-radius: var(--radius-xs); border: 0.5px solid var(--hairline); }
 .olv-analyse-legend-ticks {
   display: flex; justify-content: space-between;
-  font-size: 9px; color: var(--text-faint);
+  font-size: var(--text-2xs); color: var(--text-faint); font-variant-numeric: tabular-nums;
 }
 /* Discrete 3-stop coverage legend (green/yellow/red = strong/moderate/weak). */
 .olv-analyse-coverage-legend { display: flex; flex-direction: column; gap: var(--space-2xs); }

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -6654,7 +6654,7 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
 .olv-analyse-ready-side { flex: 0 0 auto; display: flex; align-items: center; gap: var(--space-lg); }
 .olv-analyse-ready-figure { display: flex; align-items: baseline; gap: var(--space-2xs); }
 .olv-analyse-ready-value {
-  font-size: 22px; font-weight: 600; line-height: 1;
+  font-size: var(--text-2xl); font-weight: 600; line-height: 1;
   color: var(--text); font-variant-numeric: tabular-nums;
 }
 .olv-analyse-ready-figure.is-text .olv-analyse-ready-value { font-size: var(--text-lg); }
@@ -7551,7 +7551,7 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
 .olv-analyse-legend-bar { height: 6px; border-radius: var(--radius-xs); border: 0.5px solid var(--hairline); }
 .olv-analyse-legend-ticks {
   display: flex; justify-content: space-between;
-  font-size: 9px; color: var(--text-faint);
+  font-size: var(--text-2xs); color: var(--text-faint); font-variant-numeric: tabular-nums;
 }
 /* Discrete 3-stop coverage legend (green/yellow/red = strong/moderate/weak). */
 .olv-analyse-coverage-legend { display: flex; flex-direction: column; gap: var(--space-2xs); }


### PR DESCRIPTION
A typography-scale pass on the Analyse panel. Two sizes were off the token scale (10 / 11 / 12 / 13 / 14 / 16 / 20 / 28): the readiness-card figures were a hardcoded 22px, and the legend tick labels were 9px, below the scale floor.

Snap the readiness value to --text-2xl (20px), one clean step below the composite score at --text-3xl (28px), and the legend ticks to --text-2xs (10px) with tabular numerics. The panel now reads as one coherent scale: 28 display, 20 secondary figure, 11 body, 10 micro-label. Verified in a running build via computed font-size. The rest of the skill's audit already passed — the labels are letterspaced and the copy uses en-dashes for ranges and the real multiplication sign for dimensions.