### PR TITLE
fix: streaming panel data values use the sans UI font

### DIFF
--- a/src/styles/45-dock-and-panels.css
+++ b/src/styles/45-dock-and-panels.css
@@ -171,7 +171,7 @@
 .olv-stream-prog-readout {
   display: flex; justify-content: space-between; gap: var(--space-md);
   margin-top: var(--space-sm);
-  font-size: var(--text-xs); font-family: var(--mono); color: var(--text-dim);
+  font-size: var(--text-xs); color: var(--text-dim); font-variant-numeric: tabular-nums;
 }
 .olv-streaming-rows { display: flex; flex-direction: column; gap: var(--space-xs); }
 .olv-streaming-row {
@@ -179,7 +179,7 @@
 }
 .olv-streaming-key { color: var(--text-faint); flex: none; }
 .olv-streaming-stat {
-  color: var(--text-dim); font-family: var(--mono);
+  color: var(--text-dim); font-variant-numeric: tabular-nums;
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 /*

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -1674,7 +1674,7 @@ body.olv-theme-light .olv-empty::before {
 .olv-stream-prog-readout {
   display: flex; justify-content: space-between; gap: var(--space-md);
   margin-top: var(--space-sm);
-  font-size: var(--text-xs); font-family: var(--mono); color: var(--text-dim);
+  font-size: var(--text-xs); color: var(--text-dim); font-variant-numeric: tabular-nums;
 }
 .olv-streaming-rows { display: flex; flex-direction: column; gap: var(--space-xs); }
 .olv-streaming-row {
@@ -1682,7 +1682,7 @@ body.olv-theme-light .olv-empty::before {
 }
 .olv-streaming-key { color: var(--text-faint); flex: none; }
 .olv-streaming-stat {
-  color: var(--text-dim); font-family: var(--mono);
+  color: var(--text-dim); font-variant-numeric: tabular-nums;
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 /*


### PR DESCRIPTION
After analyzing a terrain, the right-side Streaming COPC panel rendered its scan and streaming stats (file name, format, extent, spacing, node/point counts, cache) in the monospace family, so it read as a different font from the sans Analyse panel next to it.

This drops the monospace from the streaming stat and progress-readout values and keeps font-variant-numeric: tabular-nums so the counts still line up. The Streaming and Scan Intelligence panels now match the Analyse panel's font. Verified in a running build: the streaming panel has zero monospace elements, values resolve to the sans body font, numbers stay aligned, no console errors.

Scope note: the Inspector's own scan-report / detail readouts keep their monospace. That is a separate, app-wide data convention (also used by the class legend and coordinate readouts); changing it was the broader option and is intentionally not included here.