### PR TITLE
fix: smaller figures in the Analyse readiness + details

### DIFF
--- a/src/styles/86-dataset-intel-analyse.css
+++ b/src/styles/86-dataset-intel-analyse.css
@@ -409,7 +409,7 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
 .olv-analyse-ready-side { flex: 0 0 auto; display: flex; align-items: center; gap: var(--space-lg); }
 .olv-analyse-ready-figure { display: flex; align-items: baseline; gap: var(--space-2xs); }
 .olv-analyse-ready-value {
-  font-size: var(--text-2xl); font-weight: 600; line-height: 1;
+  font-size: var(--text-xl); font-weight: 600; line-height: 1;
   color: var(--text); font-variant-numeric: tabular-nums;
 }
 .olv-analyse-ready-figure.is-text .olv-analyse-ready-value { font-size: var(--text-lg); }

--- a/src/styles/92-terrain-verdict.css
+++ b/src/styles/92-terrain-verdict.css
@@ -363,7 +363,7 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
 
 .olv-analyse-score { margin-bottom: var(--space-xl); }
 .olv-analyse-score-head { display: flex; align-items: baseline; gap: var(--space-sm); margin-bottom: var(--space-md); }
-.olv-analyse-score-num { font-size: var(--text-3xl); font-weight: 700; line-height: 1; font-variant-numeric: tabular-nums; }
+.olv-analyse-score-num { font-size: var(--text-2xl); font-weight: 700; line-height: 1; font-variant-numeric: tabular-nums; }
 .olv-analyse-score-num.is-excellent { color: var(--rating-excellent); }
 .olv-analyse-score-num.is-good { color: var(--rating-good); }
 .olv-analyse-score-num.is-fair { color: var(--rating-moderate); }

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -6654,7 +6654,7 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
 .olv-analyse-ready-side { flex: 0 0 auto; display: flex; align-items: center; gap: var(--space-lg); }
 .olv-analyse-ready-figure { display: flex; align-items: baseline; gap: var(--space-2xs); }
 .olv-analyse-ready-value {
-  font-size: var(--text-2xl); font-weight: 600; line-height: 1;
+  font-size: var(--text-xl); font-weight: 600; line-height: 1;
   color: var(--text); font-variant-numeric: tabular-nums;
 }
 .olv-analyse-ready-figure.is-text .olv-analyse-ready-value { font-size: var(--text-lg); }
@@ -7516,7 +7516,7 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
 
 .olv-analyse-score { margin-bottom: var(--space-xl); }
 .olv-analyse-score-head { display: flex; align-items: baseline; gap: var(--space-sm); margin-bottom: var(--space-md); }
-.olv-analyse-score-num { font-size: var(--text-3xl); font-weight: 700; line-height: 1; font-variant-numeric: tabular-nums; }
+.olv-analyse-score-num { font-size: var(--text-2xl); font-weight: 700; line-height: 1; font-variant-numeric: tabular-nums; }
 .olv-analyse-score-num.is-excellent { color: var(--rating-excellent); }
 .olv-analyse-score-num.is-good { color: var(--rating-good); }
 .olv-analyse-score-num.is-fair { color: var(--rating-moderate); }


### PR DESCRIPTION
The composite score rendered at 28px (--text-3xl) and the readiness-card figures at 20px (--text-2xl), towering over the 11px body text, so the DTM & contour readiness and details sections read as oversized numbers.

This brings the composite to --text-2xl (20px) and the readiness figures to --text-xl (16px), for a gentler 20 / 16 / 11 hierarchy. The score stays the most prominent figure without dominating the panel. Verified live via computed font-size (composite 20px, readiness 16px); mono lint passes, build clean, no console errors.