### PR TITLE
chore: lower the position-access baseline

### DIFF
--- a/docs/validation/position-access-baseline.json
+++ b/docs/validation/position-access-baseline.json
@@ -1,5 +1,5 @@
 {
-  "total": 148,
+  "total": 146,
   "files": {
     "src/app/epochFramePrep.ts": 2,
     "src/app/floorPlanPositions.ts": 4,
@@ -20,7 +20,7 @@
     "src/model/PointCloud.ts": 17,
     "src/model/pointFrames.ts": 2,
     "src/render/InspectTool.ts": 1,
-    "src/render/Viewer.ts": 48,
+    "src/render/Viewer.ts": 46,
     "src/render/densityColors.ts": 1,
     "src/render/elevationRange.ts": 2,
     "src/render/hillshadeColors.ts": 1,

--- a/docs/validation/position-frames.json
+++ b/docs/validation/position-frames.json
@@ -332,7 +332,7 @@
         "source-local",
         "render-local"
       ],
-      "reads": 27,
+      "reads": 25,
       "why": "The sampler callbacks registered here (profile, cut/fill volume, inspector patch) collect buffers from both sources: static layers contribute source-local buffers WITH their placement alongside, resident streaming nodes contribute render-local ones. Neither is lifted here; the assemblers fold placement as they copy."
     },
     {


### PR DESCRIPTION
The position-access ratchet reported two fewer direct frame reads than the recorded baseline and one stale allowlist entry. This runs `--update` to bank the reduction and prune the stale entry, so the guard tracks the real surface. No source change; baseline + frames JSON only.