### PR TITLE
refactor: route streamingExtentRows through SpatialContext

### DIFF
--- a/docs/architecture/spatial-context-consumers.md
+++ b/docs/architecture/spatial-context-consumers.md
@@ -50,7 +50,7 @@ has re-opened the divergence this closes.
   `carrier` path must be free of the deprecated predicates listed below.
 - **Reads** — the context fields it now uses.
 
-## Inventory (14 consumers)
+## Inventory (15 consumers)
 
 | # | Consumer | Status | Routes through | Reads |
 |---|----------|--------|----------------|-------|
@@ -68,6 +68,7 @@ has re-opened the divergence this closes.
 | 12 | Measurement labels | migrated | `src/main.ts` | `linearUnitToMetres`, `linearUnitKnown`, `isGeographic`, `verticalMetresPerUnit` |
 | 13 | Elevation colorbars | migrated | `src/main.ts`, `src/app/terrainAnalysisRunner.ts` | `verticalMetresPerUnit`, `kind` |
 | 14 | Classification | migrated | `src/render/class/classifierCues.ts` | `linearUnitToMetres`, `verticalMetresPerUnit` |
+| 15 | Streaming scan-report extents | migrated | `src/analysis/streamingExtentRows.ts` | `linearUnitKnown`, `linearUnitToMetres`, `verticalMetresPerUnit` |
 
 ## Deprecated predicates
 
@@ -108,13 +109,9 @@ factor would answer a question the file already answered wrongly.
 
 ## Seams inside routed consumers that still derive
 
-Every row above is routed. Three seams inside those consumers still hold their
+Every row above is routed. Two seams inside those consumers still hold their
 own derivation, and they are named here rather than hidden:
 
-- **`src/analysis/streamingExtentRows.ts`** takes a structural CRS subset rather
-  than a context, so the streaming Scan Report's extent rows still call
-  `isLinearUnitKnown` directly. Its signature is exercised by six existing test
-  call sites; changing it is a separate, mechanical change.
 - **`src/main.ts`'s contour-export `linearUnit`** still reads
   `crsService.current()?.linearUnit`, because "no scan open yet" and "a scan
   whose CRS is unknown" are two different answers there and the context

--- a/src/analysis/streamingExtentRows.ts
+++ b/src/analysis/streamingExtentRows.ts
@@ -1,5 +1,5 @@
-import type { CrsLinearUnit } from '../io/crs';
-import { isLinearUnitKnown } from '../geo/CoordinateTypes';
+import type { SpatialContext } from '../geo/SpatialContext';
+import { verticalMetresPerUnit } from '../geo/SpatialContext';
 
 /** One extent/density/spacing row the streaming Scan-report emits. */
 export interface ExtentRowSpec {
@@ -23,12 +23,6 @@ export interface StreamingExtentResult {
   readonly rows: readonly ExtentRowSpec[];
 }
 
-type ExtentCrs = {
-  readonly linearUnit?: CrsLinearUnit;
-  readonly linearUnitToMetres?: number;
-  readonly verticalUnitToMetres?: number;
-} | null;
-
 /**
  * Build the Width / Depth / Height / Density / Spacing rows for the streaming
  * Scan-report, FAILING CLOSED on an unconfirmed linear unit.
@@ -37,26 +31,30 @@ type ExtentCrs = {
  * and a CRS-less cloud resolves the same way. Multiplying a source span by
  * that factor and stamping "m" silently reports non-metre data as metres — a
  * state-plane-FEET COPC would over-report extent ~3.28× mislabelled as metres.
- * So metres are only claimed when the CRS declares a real linear unit
- * (`crsInfo != null && crsInfo.linearUnit !== 'unknown'`), the same gate the
- * measure tool (`setCrsKnown`) and the lasso (`densityUnitKnown`) already
- * apply. When the unit is unconfirmed the metre factor is dropped, the raw
- * source span is shown, and the "m" / "pts/m²" claim is withheld.
+ * So metres are only claimed when the frame declares a real linear unit
+ * (`ctx.linearUnitKnown`), the same gate the measure tool (`setCrsKnown`) and
+ * the lasso (`densityUnitKnown`) already apply. When the unit is unconfirmed
+ * the metre factor is dropped, the raw source span is shown, and the "m" /
+ * "pts/m²" claim is withheld. The frame comes in as a {@link SpatialContext}
+ * rather than a raw CRS subset, so the unit gate and the metre factors are read
+ * from the one resolved model instead of a hand-rolled predicate.
  *
  * COPC/EPT are Z-up by spec, so the horizontal footprint is X·Y and height is
- * Z; the vertical span uses the vertical unit when the CRS declares one.
+ * Z; the vertical span uses the vertical unit when the frame declares one,
+ * falling back to the horizontal factor (the GeoTIFF `'horizontal'` policy,
+ * matching the prior `verticalUnitToMetres ?? mpu`).
  */
 export function streamingExtentRows(
   header: { readonly min: readonly [number, number, number]; readonly max: readonly [number, number, number] },
-  crsInfo: ExtentCrs,
+  ctx: SpatialContext,
   sourcePointCount: number,
 ): StreamingExtentResult {
-  const unitConfirmed = isLinearUnitKnown(crsInfo);
+  const unitConfirmed = ctx.linearUnitKnown;
 
   // Apply the metre factor ONLY when the unit is real. Otherwise the span stays
   // in raw source units (factor 1) and is not labelled "m".
-  const mpu = unitConfirmed ? (crsInfo?.linearUnitToMetres ?? 1) : 1;
-  const vmpu = unitConfirmed ? (crsInfo?.verticalUnitToMetres ?? mpu) : 1;
+  const mpu = unitConfirmed ? ctx.linearUnitToMetres : 1;
+  const vmpu = unitConfirmed ? (verticalMetresPerUnit(ctx, 'horizontal') ?? mpu) : 1;
 
   const w = (header.max[0] - header.min[0]) * mpu;
   const d = (header.max[1] - header.min[1]) * mpu;

--- a/src/geo/SpatialContext.ts
+++ b/src/geo/SpatialContext.ts
@@ -5,7 +5,7 @@
  * consumer that is about to make a metric claim — a distance in metres, an area
  * in m², a volume in m³, a density in pts/m², an elevation against a datum — can
  * read a single object instead of re-deriving unit, datum, axis and frame from
- * `metadata.crs` five different ways. The inventory tracks 14 consumers that
+ * `metadata.crs` five different ways. The inventory tracks 15 consumers that
  * each used to reach into a `CrsInfo` / `ResolvedCrs` and re-answer the same
  * questions (see docs/architecture/spatial-context-consumers.md, which
  * `scripts/lint-spatial-context.mjs` holds to the tree); the divergence between
@@ -195,7 +195,7 @@ export interface SpatialContextPlacement {
  * project-frame placement. A `null` / `undefined` CRS fails closed: the context
  * resolves to `unknown`, and `metricClaimsPermitted` is `false`.
  *
- * Accepting both inputs is what lets all 14 consumers route through this one
+ * Accepting both inputs is what lets all 15 consumers route through this one
  * façade without hand-building anything: a `CrsInfo` is bridged through the
  * canonical `resolvedFromCrsInfo` mapper, while a `ResolvedCrs` — which already
  * carries the resolved `kind` (including `local` / `unknown`, which a `CrsInfo`

--- a/src/main.ts
+++ b/src/main.ts
@@ -4322,8 +4322,8 @@ function runStreamingModules(cloud: {
     // metres. `streamingExtentRows` FAILS CLOSED on an unconfirmed unit
     // (placeholder `linearUnitToMetres: 1`): it drops the "m"/"pts/m²" claim
     // rather than stamping metres onto non-metre data — as measure/lasso do.
-    const crsInfo = cloud.crs?.() ?? null;
-    const ext = streamingExtentRows(header, crsInfo, cloud.sourcePointCount);
+    // Reads the active scan's resolved frame (`crsService.context()`).
+    const ext = streamingExtentRows(header, crsService.context(), cloud.sourcePointCount);
     if (!ext.unitConfirmed) {
       rows.push({
         label: 'Units',

--- a/tests/streamingExtentRows.test.ts
+++ b/tests/streamingExtentRows.test.ts
@@ -11,16 +11,33 @@
  * declares a real linear unit, matching the measure tool and lasso.
  */
 import { streamingExtentRows } from '../src/analysis/streamingExtentRows';
+import { spatialContextFrom } from '../src/geo/SpatialContext';
+import type { CrsInfo } from '../src/io/crs';
 
 const header = {
   min: [0, 0, 0] as const,
   max: [1000, 1000, 100] as const,
 };
 
+/**
+ * Build a resolved SpatialContext from a minimal CRS override — the function
+ * now takes the resolved frame, not a raw CRS subset, so the unit gate is read
+ * from `ctx.linearUnitKnown` rather than a hand-rolled predicate.
+ */
+function ctx(o: Partial<CrsInfo>) {
+  return spatialContextFrom({
+    source: 'epsg',
+    name: 'EPSG:32610',
+    linearUnit: 'metre',
+    linearUnitToMetres: 1,
+    ...o,
+  } as CrsInfo);
+}
+
 test('metre CRS: converts and labels "m" / "pts/m²" (byte-identical to before)', () => {
   const { unitConfirmed, rows } = streamingExtentRows(
     header,
-    { linearUnit: 'metre', linearUnitToMetres: 1 },
+    ctx({ linearUnit: 'metre', linearUnitToMetres: 1 }),
     1_000_000,
   );
   expect(unitConfirmed).toBe(true);
@@ -35,7 +52,7 @@ test('metre CRS: converts and labels "m" / "pts/m²" (byte-identical to before)'
 test('foot CRS: applies the 0.3048 factor before stamping metres', () => {
   const { unitConfirmed, rows } = streamingExtentRows(
     header,
-    { linearUnit: 'foot', linearUnitToMetres: 0.3048, verticalUnitToMetres: 0.3048 },
+    ctx({ linearUnit: 'foot', linearUnitToMetres: 0.3048, verticalUnitToMetres: 0.3048 }),
     1_000_000,
   );
   expect(unitConfirmed).toBe(true);
@@ -49,7 +66,7 @@ test('unknown-unit CRS: does NOT claim metres despite the placeholder factor', (
   const { unitConfirmed, rows } = streamingExtentRows(
     header,
     // The leak shape: unknown unit, inert factor 1.
-    { linearUnit: 'unknown', linearUnitToMetres: 1 },
+    ctx({ linearUnit: 'unknown', linearUnitToMetres: 1, name: 'local' }),
     1_000_000,
   );
   expect(unitConfirmed).toBe(false);
@@ -65,7 +82,7 @@ test('unknown-unit CRS: does NOT claim metres despite the placeholder factor', (
 });
 
 test('no CRS resolved (null): fails closed exactly like unknown', () => {
-  const { unitConfirmed, rows } = streamingExtentRows(header, null, 1_000_000);
+  const { unitConfirmed, rows } = streamingExtentRows(header, spatialContextFrom(null), 1_000_000);
   expect(unitConfirmed).toBe(false);
   const byLabel = Object.fromEntries(rows.map((r) => [r.label, r.value]));
   expect(byLabel.Width).toBe('1000.0 (source units)');
@@ -73,13 +90,13 @@ test('no CRS resolved (null): fails closed exactly like unknown', () => {
 });
 
 test('density & spacing rows carry the class-scope flag; extents do not', () => {
-  const { rows } = streamingExtentRows(header, { linearUnit: 'metre', linearUnitToMetres: 1 }, 1_000_000);
+  const { rows } = streamingExtentRows(header, ctx({ linearUnit: 'metre', linearUnitToMetres: 1 }), 1_000_000);
   const scoped = new Set(rows.filter((r) => r.scoped).map((r) => r.label));
   expect(scoped).toEqual(new Set(['Density', 'Spacing']));
 });
 
 test('degenerate footprint: emits extents only, no density/spacing', () => {
   const flat = { min: [0, 0, 0] as const, max: [0, 100, 100] as const };
-  const { rows } = streamingExtentRows(flat, { linearUnit: 'metre', linearUnitToMetres: 1 }, 1000);
+  const { rows } = streamingExtentRows(flat, ctx({ linearUnit: 'metre', linearUnitToMetres: 1 }), 1000);
   expect(rows.map((r) => r.label)).toEqual(['Width', 'Depth', 'Height']);
 });


### PR DESCRIPTION
Closes the last named still-deriving seam in the SpatialContext consumer inventory.

The streaming Scan-report extent block (`streamingExtentRows`) took a raw CRS subset and called `isLinearUnitKnown` directly. It now takes the resolved `SpatialContext`: `ctx.linearUnitKnown` for the fail-closed metre gate, and `verticalMetresPerUnit(ctx, 'horizontal')` for the vertical factor — exactly the prior `verticalUnitToMetres ?? mpu` GeoTIFF fallback. The `main.ts` caller passes `crsService.context()` (the authoritative resolved frame the space report and classifier already use) rather than the raw `cloud.crs()` subset, which also honors a CRS override.

Behaviour is byte-identical — the six extent-row tests pass unchanged: metre → 1000.0 m, foot → 304.8 m (not 1000 m), unknown and null fail closed to source units. The consumer inventory moves it from a seam to migrated consumer 15; `main.ts` stays net-zero. tsc, lint:spatial-context, architecture-truth, release-truth, monolith-size all green.