### PR TITLE
Fix 9 duplicate font-variant-numeric declarations (Sonar reliability)

### DIFF
--- a/src/styles/30-empty-state.css
+++ b/src/styles/30-empty-state.css
@@ -157,7 +157,6 @@ body.olv-theme-light .olv-empty::before {
   font-variant-numeric: tabular-nums;
   font-size: var(--text-2xs);
   color: var(--text-faint);
-  font-variant-numeric: tabular-nums;
 }
 .olv-rail-label { font-size: var(--text-xs); }
 .olv-rail-step-active { color: var(--text-dim); }

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -154,7 +154,6 @@
   inset: 2px 4px;
   pointer-events: none;
   font-variant-numeric: tabular-nums;
-  font-variant-numeric: tabular-nums;
   letter-spacing: 0.01em;
 }
 .olv-mp-axis {
@@ -320,7 +319,7 @@
 }
 .olv-mp-summary-value {
   margin: 0; font-variant-numeric: tabular-nums; font-size: var(--text-2xs);
-  font-variant-numeric: tabular-nums; color: var(--text-dim);
+  color: var(--text-dim);
   overflow-wrap: anywhere;
 }
 
@@ -363,7 +362,6 @@
   cursor: pointer;
   font-variant-numeric: tabular-nums;
   font-size: var(--text-2xs);
-  font-variant-numeric: tabular-nums;
   color: var(--text-faint);
   padding: var(--space-2xs) 0;
   list-style: none;
@@ -401,7 +399,6 @@
   width: 76px;
   font-variant-numeric: tabular-nums;
   font-size: var(--text-2xs);
-  font-variant-numeric: tabular-nums;
   color: var(--text-dim);
   background: rgba(255, 255, 255, 0.04);
   border: 0.5px solid var(--hairline);
@@ -452,7 +449,7 @@
 .olv-mp-stations-table {
   width: 100%; border-collapse: collapse;
   font-variant-numeric: tabular-nums; font-size: var(--text-2xs);
-  font-variant-numeric: tabular-nums; color: var(--text-dim);
+  color: var(--text-dim);
 }
 .olv-mp-stations-th {
   text-align: left; font-weight: 500; color: var(--text-faint);

--- a/src/styles/76-classification.css
+++ b/src/styles/76-classification.css
@@ -107,7 +107,6 @@
 .olv-cl-count {
   flex-shrink: 0; font-size: 11px; font-variant-numeric: tabular-nums;
   color: var(--text-dim); text-align: right;
-  font-variant-numeric: tabular-nums;
 }
 .olv-cl-solo {
   flex-shrink: 0; font-size: 10px; color: var(--text-faint);

--- a/src/styles/80-modal-system.css
+++ b/src/styles/80-modal-system.css
@@ -144,7 +144,7 @@
 }
 .olv-rf-stat-value {
   margin: 0; font-variant-numeric: tabular-nums; font-size: var(--text-md);
-  color: var(--text); font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
+  color: var(--text); overflow-wrap: anywhere;
 }
 /* Station table — reuses the in-panel scroll wrap + sticky header, with room to
    read more rows at once than the 220px dock cap allows. */

--- a/src/styles/98-layer-health.css
+++ b/src/styles/98-layer-health.css
@@ -72,7 +72,6 @@
 }
 .olv-layerhealth-row-value.is-mono {
   font-variant-numeric: tabular-nums;
-  font-variant-numeric: tabular-nums;
 }
 /* Quiet status dot before the value: ok = established (green),
  * warn = doubt gating something (amber), info = neutral fact (grey). */

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -789,7 +789,6 @@ body.olv-theme-light .olv-empty::before {
   font-variant-numeric: tabular-nums;
   font-size: var(--text-2xs);
   color: var(--text-faint);
-  font-variant-numeric: tabular-nums;
 }
 .olv-rail-label { font-size: var(--text-xs); }
 .olv-rail-step-active { color: var(--text-dim); }
@@ -4371,7 +4370,6 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   inset: 2px 4px;
   pointer-events: none;
   font-variant-numeric: tabular-nums;
-  font-variant-numeric: tabular-nums;
   letter-spacing: 0.01em;
 }
 .olv-mp-axis {
@@ -4537,7 +4535,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 }
 .olv-mp-summary-value {
   margin: 0; font-variant-numeric: tabular-nums; font-size: var(--text-2xs);
-  font-variant-numeric: tabular-nums; color: var(--text-dim);
+  color: var(--text-dim);
   overflow-wrap: anywhere;
 }
 
@@ -4580,7 +4578,6 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   cursor: pointer;
   font-variant-numeric: tabular-nums;
   font-size: var(--text-2xs);
-  font-variant-numeric: tabular-nums;
   color: var(--text-faint);
   padding: var(--space-2xs) 0;
   list-style: none;
@@ -4618,7 +4615,6 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   width: 76px;
   font-variant-numeric: tabular-nums;
   font-size: var(--text-2xs);
-  font-variant-numeric: tabular-nums;
   color: var(--text-dim);
   background: rgba(255, 255, 255, 0.04);
   border: 0.5px solid var(--hairline);
@@ -4669,7 +4665,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-mp-stations-table {
   width: 100%; border-collapse: collapse;
   font-variant-numeric: tabular-nums; font-size: var(--text-2xs);
-  font-variant-numeric: tabular-nums; color: var(--text-dim);
+  color: var(--text-dim);
 }
 .olv-mp-stations-th {
   text-align: left; font-weight: 500; color: var(--text-faint);
@@ -4908,7 +4904,6 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-cl-count {
   flex-shrink: 0; font-size: 11px; font-variant-numeric: tabular-nums;
   color: var(--text-dim); text-align: right;
-  font-variant-numeric: tabular-nums;
 }
 .olv-cl-solo {
   flex-shrink: 0; font-size: 10px; color: var(--text-faint);
@@ -5679,7 +5674,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 }
 .olv-rf-stat-value {
   margin: 0; font-variant-numeric: tabular-nums; font-size: var(--text-md);
-  color: var(--text); font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
+  color: var(--text); overflow-wrap: anywhere;
 }
 /* Station table — reuses the in-panel scroll wrap + sticky header, with room to
    read more rows at once than the 220px dock cap allows. */
@@ -8810,7 +8805,6 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
   color: var(--text); text-align: right; overflow-wrap: anywhere;
 }
 .olv-layerhealth-row-value.is-mono {
-  font-variant-numeric: tabular-nums;
   font-variant-numeric: tabular-nums;
 }
 /* Quiet status dot before the value: ok = established (green),


### PR DESCRIPTION
Removes the redundant second `font-variant-numeric: tabular-nums` declaration SonarCloud flagged as reliability bugs across five style files (30-empty-state, 74-inspector-profile ×5, 76-classification, 80-modal-system, 98-layer-health). Each block declared the property twice with the same value, so the kept value is identical and nothing renders differently.

Verified locally: a block-level scan of `src/styles/` reports no same-value duplicate declarations remain; the other different-value fallbacks (e.g. `max-height: 92vh; max-height: min(92dvh, 92vh)`) are intentional and untouched.