### PR TITLE
Terrain-aware contour generalization (opt-in, honesty-preserving)

### DIFF
--- a/src/app/terrainAnalysisRunner.ts
+++ b/src/app/terrainAnalysisRunner.ts
@@ -41,6 +41,7 @@ import type {
   TerrainCoreParams,
 } from '../terrain/contour/analyseContours';
 import type { ContourShapeStyle } from '../terrain/contour/contourShapeStyle';
+import type { ContourGeneralizeMode } from '../terrain/contour/terrainAwareTolerance';
 import {
   loadTerrainCoreCache,
   loadComputeTerrainCoreAsync,
@@ -450,6 +451,7 @@ export function createTerrainAnalysisRunner(
     intervalM: number;
     shapeStyle?: ContourShapeStyle;
     generalizeToleranceCells?: number;
+    generalizeMode?: ContourGeneralizeMode;
   }): Promise<AnalyseContoursResult> {
     const viewer = getViewer();
     const gathered = viewer.gatherTerrainPositions();
@@ -488,6 +490,7 @@ export function createTerrainAnalysisRunner(
       intervalM: opts.intervalM,
       shapeStyle: opts.shapeStyle,
       generalizeToleranceCells: opts.generalizeToleranceCells,
+      generalizeMode: opts.generalizeMode,
     });
   }
 

--- a/src/styles/97-contour-studio.css
+++ b/src/styles/97-contour-studio.css
@@ -136,8 +136,10 @@
 /* Purpose cards */
 /* Compact pills: the label alone; the full description is on hover (title
    attribute) so the picker stays tight instead of a wall of summary text. */
-.olv-cs-purpose-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-.olv-cs-purpose-card {
+.olv-cs-purpose-grid,
+.olv-cs-genmode-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+.olv-cs-purpose-card,
+.olv-cs-genmode-card {
   display: flex;
   align-items: center;
   min-height: 30px;
@@ -149,14 +151,19 @@
   cursor: pointer;
   transition: border-color 0.15s ease, background 0.15s ease, transform 0.05s ease;
 }
-.olv-cs-purpose-card:hover { border-color: var(--hairline-strong); }
-.olv-cs-purpose-card:active { transform: translateY(1px); }
-.olv-cs-purpose-card.is-selected {
+.olv-cs-purpose-card:hover,
+.olv-cs-genmode-card:hover { border-color: var(--hairline-strong); }
+.olv-cs-purpose-card:active,
+.olv-cs-genmode-card:active { transform: translateY(1px); }
+.olv-cs-purpose-card.is-selected,
+.olv-cs-genmode-card.is-active {
   border-color: var(--accent);
   background: var(--accent-soft);
   box-shadow: 0 0 0 1px var(--accent) inset;
 }
-.olv-cs-purpose-label { display: block; font-size: var(--text-sm); font-weight: 620; color: var(--text); }
+.olv-cs-purpose-label,
+.olv-cs-genmode-label { display: block; font-size: var(--text-sm); font-weight: 620; color: var(--text); }
+.olv-cs-genmode { margin-top: 10px; }
 
 /* Review + settings summary — definition grids */
 .olv-cs-review-list, .olv-cs-summary-list {

--- a/src/terrain/contour/analyseContours.ts
+++ b/src/terrain/contour/analyseContours.ts
@@ -102,6 +102,7 @@ import {
   GENERALIZE_EPS_CELLS,
   type ContourShapeStyle,
 } from './contourShapeStyle';
+import type { ContourGeneralizeMode } from './terrainAwareTolerance';
 import { placeLabels, type ContourLabel } from './labelPlacement';
 import { computeVerticalAccuracy, type VerticalAccuracy } from '../validate/verticalAccuracy';
 import {
@@ -275,6 +276,12 @@ export interface IntervalContourParams {
    * never set it are byte-unchanged.
    */
   readonly generalizeToleranceCells?: number;
+  /**
+   * How the 'generalized' style distributes its tolerance across features:
+   * 'uniform' (default when omitted, byte-unchanged) or 'terrain-aware' (scaled
+   * DOWN per feature, never up). Ignored for every style but 'generalized'.
+   */
+  readonly generalizeMode?: ContourGeneralizeMode;
   /**
    * Legacy boolean toggle for smoothing. Honoured for back-compat when
    * `shapeStyle` is not given: `false` ⇒ `'crisp'`, otherwise the default
@@ -1325,6 +1332,7 @@ export function contoursFromCore(
     polylines: applyContourShapeStyle(level.polylines, shapeStyle, {
       cellSizeM,
       generalizeToleranceCells: intervalParams.generalizeToleranceCells,
+      generalizeMode: intervalParams.generalizeMode,
     }),
   }));
 

--- a/src/terrain/contour/contourShapeStyle.ts
+++ b/src/terrain/contour/contourShapeStyle.ts
@@ -36,6 +36,7 @@ import { unionProvBits } from './contourSegmentEvidence';
 import {
   terrainAwareToleranceFactor,
   type TerrainAwareFeatureShape,
+  type ContourGeneralizeMode,
 } from './terrainAwareTolerance';
 
 /** The contour shape presets the user can pick from. */
@@ -310,7 +311,7 @@ export interface ContourShapeStyleOptions {
    * line and the honesty-gated `simplifyPolyline` still protects gap and
    * low-confidence vertices. Only the 'generalized' style reads it.
    */
-  readonly generalizeMode?: 'uniform' | 'terrain-aware';
+  readonly generalizeMode?: ContourGeneralizeMode;
 }
 
 // Simplify epsilons as a fraction of the cell size. 'generalized' keeps the

--- a/src/terrain/contour/contourShapeStyle.ts
+++ b/src/terrain/contour/contourShapeStyle.ts
@@ -33,6 +33,10 @@ import { EVIDENCE_THRESHOLDS, gradeForConfidence } from '../ground/cellConfidenc
 import { chaikinSmooth } from './smoothing';
 import type { ContourPolyline, ContourVertex } from './stitchContours';
 import { unionProvBits } from './contourSegmentEvidence';
+import {
+  terrainAwareToleranceFactor,
+  type TerrainAwareFeatureShape,
+} from './terrainAwareTolerance';
 
 /** The contour shape presets the user can pick from. */
 export type ContourShapeStyle =
@@ -296,6 +300,17 @@ export interface ContourShapeStyleOptions {
    * `simplifyPolyline` returns the polyline unchanged for epsilon ≤ 0).
    */
   readonly generalizeToleranceCells?: number;
+  /**
+   * How the 'generalized' style distributes its simplification strength across
+   * features. 'uniform' (default, and the value when omitted) applies the same
+   * epsilon to every polyline — byte-identical to before this option existed.
+   * 'terrain-aware' scales the epsilon DOWN per feature from what it is
+   * (interpolated / low-confidence support and small closed summits are smoothed
+   * less), and NEVER up — so `generalizeToleranceCells × cell` still bounds every
+   * line and the honesty-gated `simplifyPolyline` still protects gap and
+   * low-confidence vertices. Only the 'generalized' style reads it.
+   */
+  readonly generalizeMode?: 'uniform' | 'terrain-aware';
 }
 
 // Simplify epsilons as a fraction of the cell size. 'generalized' keeps the
@@ -309,6 +324,36 @@ export interface ContourShapeStyleOptions {
 // may override it via {@link ContourShapeStyleOptions.generalizeToleranceCells}.
 export const GENERALIZE_EPS_CELLS = 0.5;
 const SEMI_GEOMETRIC_EPS_CELLS = 1.75;
+
+/**
+ * Reduce a polyline to the whole-feature evidence signals the terrain-aware
+ * tolerance policy reads: its WEAKEST grade (the most conservative — a single
+ * gap span grades the whole line 'gap'), the mean vertex confidence, closure,
+ * and planimetric length in source units. Pure.
+ */
+function polylineTerrainShape(poly: ContourPolyline): TerrainAwareFeatureShape {
+  const vs = poly.vertices;
+  let grade: 'solid' | 'dashed' | 'gap' = 'solid';
+  let confSum = 0;
+  let confN = 0;
+  let length = 0;
+  for (let i = 0; i < vs.length; i++) {
+    const v = vs[i];
+    if (v.grade === 'gap') grade = 'gap';
+    else if (v.grade === 'dashed' && grade !== 'gap') grade = 'dashed';
+    if (Number.isFinite(v.confidence)) {
+      confSum += v.confidence;
+      confN += 1;
+    }
+    if (i > 0) length += Math.hypot(v.x - vs[i - 1].x, v.y - vs[i - 1].y);
+  }
+  return {
+    grade,
+    meanConfidence: confN > 0 ? confSum / confN : NaN,
+    closed: poly.closed,
+    length,
+  };
+}
 
 /**
  * Apply a shape style to a list of raw stitched polylines, returning new
@@ -339,10 +384,28 @@ export function applyContourShapeStyle(
       return polylines.map((p) => chaikinSmooth(p, { iterations: 2 }));
     case 'rounded':
       return polylines.map((p) => chaikinSmooth(p, { iterations: 4 }));
-    case 'generalized':
-      return polylines.map((p) =>
-        chaikinSmooth(simplifyPolyline(p, generalizeEpsCells * cell), { iterations: 2 }),
-      );
+    case 'generalized': {
+      const base = generalizeEpsCells * cell;
+      // Terrain-aware: scale the epsilon DOWN per feature (interpolated /
+      // low-confidence / small-closed lines keep more of their shape). The
+      // `Math.min(1, …)` is the honesty clamp — terrain-awareness may only make
+      // a line MORE faithful than the uniform pass, never less, so the historical
+      // "at most `base`" ceiling still bounds every line and `simplifyPolyline`'s
+      // vertex protections are untouched. `longFeatureLen` / `smallRingLen` mirror
+      // the staged product pipeline's defaults (40× / 8× the base tolerance).
+      if (opts.generalizeMode === 'terrain-aware') {
+        const longFeatureLen = base * 40;
+        const smallRingLen = base * 8;
+        return polylines.map((p) => {
+          const factor = Math.min(
+            1,
+            terrainAwareToleranceFactor(polylineTerrainShape(p), { longFeatureLen, smallRingLen }),
+          );
+          return chaikinSmooth(simplifyPolyline(p, base * factor), { iterations: 2 });
+        });
+      }
+      return polylines.map((p) => chaikinSmooth(simplifyPolyline(p, base), { iterations: 2 }));
+    }
     case 'semi-geometric':
       return polylines.map((p) =>
         chaikinSmooth(simplifyPolyline(p, SEMI_GEOMETRIC_EPS_CELLS * cell), { iterations: 1 }),

--- a/src/terrain/contour/terrainAwareTolerance.ts
+++ b/src/terrain/contour/terrainAwareTolerance.ts
@@ -1,0 +1,58 @@
+/**
+ * terrainAwareTolerance.ts
+ *
+ * The single terrain-aware generalization policy (v0.5.9 spec §16.1/§16.2):
+ * scale a base simplification tolerance from what a contour feature IS —
+ *
+ *  - smooth LESS (smaller tolerance) where fidelity matters: interpolated or
+ *    low-confidence support, and small closed summits/depressions whose shape a
+ *    coarse tolerance would erase;
+ *  - smooth MORE (larger tolerance) where it is safe and helps legibility:
+ *    strongly-measured, long contours.
+ *
+ * Kept in the contour geometry layer so BOTH readers share one policy and it can
+ * never drift between them: the live honesty-gated shape styler
+ * (`contourShapeStyle.ts`) and the staged source-unit product pipeline
+ * (`contourStudio/contourAdaptiveGeneralize.ts`). This function only decides a
+ * multiplier; it never drops a vertex, so the honesty gates in each caller stay
+ * in force regardless of the value returned.
+ */
+
+/** The per-feature signals the terrain-aware tolerance policy reads. */
+export interface TerrainAwareFeatureShape {
+  /** Evidence grade of the feature as a whole (its weakest span wins). */
+  readonly grade: 'solid' | 'dashed' | 'gap';
+  /** Mean support confidence [0..100]; non-finite is treated as unknown. */
+  readonly meanConfidence: number;
+  readonly closed: boolean;
+  /** Planimetric length in the source (horizontal) unit. */
+  readonly length: number;
+}
+
+/**
+ * The terrain-aware tolerance multiplier. Deterministic, and always within a
+ * bounded band [0.25×, 2×] of the base so a single feature can never be wildly
+ * over- or under-generalized.
+ */
+export function terrainAwareToleranceFactor(
+  shape: TerrainAwareFeatureShape,
+  opts: { longFeatureLen: number; smallRingLen: number },
+): number {
+  let factor = 1;
+
+  // Support: smooth interpolated less, unsupported least (fidelity over polish).
+  if (shape.grade === 'dashed') factor *= 0.6;
+  else if (shape.grade === 'gap') factor *= 0.4;
+
+  // Low confidence → keep more of the original shape.
+  if (Number.isFinite(shape.meanConfidence) && shape.meanConfidence < 50) factor *= 0.7;
+
+  // Small closed summit/depression → preserve its (few) vertices.
+  if (shape.closed && shape.length <= opts.smallRingLen) factor *= 0.4;
+
+  // Long, strongly-measured contour → safe to generalize a little harder.
+  if (shape.grade === 'solid' && shape.length >= opts.longFeatureLen) factor *= 1.5;
+
+  // Bound the band.
+  return Math.max(0.25, Math.min(2, factor));
+}

--- a/src/terrain/contour/terrainAwareTolerance.ts
+++ b/src/terrain/contour/terrainAwareTolerance.ts
@@ -18,6 +18,14 @@
  * in force regardless of the value returned.
  */
 
+/**
+ * How the 'generalized' style distributes its simplification strength across
+ * features: 'uniform' (the same epsilon everywhere) or 'terrain-aware' (scaled
+ * DOWN per feature from what it is). The single named type both the geometry
+ * styler and the Contour Studio state/provenance share.
+ */
+export type ContourGeneralizeMode = 'uniform' | 'terrain-aware';
+
 /** The per-feature signals the terrain-aware tolerance policy reads. */
 export interface TerrainAwareFeatureShape {
   /** Evidence grade of the feature as a whole (its weakest span wins). */

--- a/src/terrain/contourStudio/contourAdaptiveGeneralize.ts
+++ b/src/terrain/contourStudio/contourAdaptiveGeneralize.ts
@@ -18,6 +18,7 @@
  */
 
 import type { ContourFeature } from '../contour/contourFeatureModel';
+import { terrainAwareToleranceFactor } from '../contour/terrainAwareTolerance';
 import {
   cartographicProduct,
   type ContourGeometryProduct,
@@ -46,33 +47,18 @@ function featureLength(f: ContourFeature): number {
 }
 
 /**
- * The per-feature tolerance multiplier (§16.1/§16.2). Deterministic, and always
- * within a bounded band [0.25×, 2×] of the base so a single feature can never
- * be wildly over- or under-generalized.
+ * The per-feature tolerance multiplier for a {@link ContourFeature} (the staged
+ * source-unit product path). Thin adapter over the shared
+ * {@link terrainAwareToleranceFactor} policy (see `../contour/terrainAwareTolerance`).
  */
 export function adaptiveToleranceFactor(
   f: ContourFeature,
   opts: { longFeatureLen: number; smallRingLen: number },
 ): number {
-  let factor = 1;
-
-  // Support: smooth interpolated less, unsupported least (fidelity over polish).
-  if (f.grade === 'dashed') factor *= 0.6;
-  else if (f.grade === 'gap') factor *= 0.4;
-
-  // Low confidence → keep more of the original shape.
-  if (Number.isFinite(f.meanConfidence) && f.meanConfidence < 50) factor *= 0.7;
-
-  const len = featureLength(f);
-
-  // Small closed summit/depression → preserve its (few) vertices.
-  if (f.closed && len <= opts.smallRingLen) factor *= 0.4;
-
-  // Long, strongly-measured contour → safe to generalize a little harder.
-  if (f.grade === 'solid' && len >= opts.longFeatureLen) factor *= 1.5;
-
-  // Bound the band.
-  return Math.max(0.25, Math.min(2, factor));
+  return terrainAwareToleranceFactor(
+    { grade: f.grade, meanConfidence: f.meanConfidence, closed: f.closed, length: featureLength(f) },
+    opts,
+  );
 }
 
 /**

--- a/src/terrain/contourStudio/contourExportIntent.ts
+++ b/src/terrain/contourStudio/contourExportIntent.ts
@@ -9,12 +9,13 @@
  *     it exports the CRISP geometry stamped `olv.contour.analytical@1`.
  *   - Presentation Map / Engineering Plan / Terrain Research apply cartographic
  *     generalization, so they export the GENERALIZED geometry (honesty-gated
- *     uniform-tolerance simplify + smooth — never the panel's on-screen default
- *     style) stamped `olv.contour.generalize@1`, each at its OWN per-purpose
- *     tolerance (`generalizeToleranceCells`). The stamp names the transformation
- *     the pipeline actually runs: a uniform Douglas–Peucker tolerance, NOT the
- *     terrain-adaptive module (`contourAdaptiveGeneralize`, which has no
- *     production caller). Stamping `terrain-adaptive` here would be an overclaim.
+ *     simplify + smooth — never the panel's on-screen default style), each at its
+ *     OWN per-purpose tolerance (`generalizeToleranceCells`). The stamp names the
+ *     transformation the pipeline actually runs: `olv.contour.generalize@1` for
+ *     the uniform Douglas–Peucker tolerance, or `olv.contour.generalize.terrain-adaptive@1`
+ *     when the surface's `generalizeMode` is 'terrain-aware' — the honesty-gated
+ *     styler then scales that tolerance DOWN per feature (never up), which is a
+ *     real production path, so the stamp is honest either way.
  *
  * The chosen `shapeStyle` + `generalizeToleranceCells` drive the host's
  * `buildResultForExport`, which regenerates the contour geometry at that style
@@ -28,6 +29,7 @@
 
 import type { ContourStudioState } from './contourStudioState';
 import type { ContourShapeStyle } from '../contour/contourShapeStyle';
+import type { ContourGeneralizeMode } from '../contour/terrainAwareTolerance';
 import { PURPOSE_META } from './contourStudioPurpose';
 
 /**
@@ -79,6 +81,12 @@ export interface ContourExportIntent {
    * stamped into provenance so each file names the tolerance it used.
    */
   readonly generalizeToleranceCells: number;
+  /**
+   * How the 'generalized' style distributes its tolerance across features. The
+   * export host passes it to `applyContourShapeStyle`, and it selects the method
+   * stamp. 'uniform' on the exact (crisp) path, since it generalizes nothing.
+   */
+  readonly generalizeMode: ContourGeneralizeMode;
   /** Whether only index (bold) contours are labelled. */
   readonly labelsIndexOnly: boolean;
   /** Stable method id of the geometry actually exported. */
@@ -117,12 +125,20 @@ export function contourExportIntentFromState(state: ContourStudioState): Contour
   // provenance string (the v0.5.9 "all purposes export the same file" bug).
   const shapeStyle: ContourShapeStyle = exact ? 'crisp' : 'generalized';
 
+  // The exact path generalizes nothing, so it always reports 'uniform'; only the
+  // generalized path honours the surface's chosen mode.
+  const generalizeMode: ContourGeneralizeMode = exact ? 'uniform' : state.surface.generalizeMode;
+
   // Honest method id: the crisp path is the exact analytical geometry; the
-  // generalized path is the shipped UNIFORM-tolerance Douglas–Peucker pass, so it
-  // is stamped `olv.contour.generalize` — NOT `terrain-adaptive`, which names a
-  // module (`contourAdaptiveGeneralize`) that has no production caller. The
-  // per-purpose tolerance is carried alongside so the stamp is fully specified.
-  const methodId = exact ? 'olv.contour.analytical' : 'olv.contour.generalize';
+  // generalized path is the uniform-tolerance Douglas–Peucker pass, stamped
+  // `olv.contour.generalize` — unless the surface selected terrain-aware, in
+  // which case the honesty-gated styler scales that tolerance per feature and the
+  // pass that actually runs is stamped `olv.contour.generalize.terrain-adaptive`.
+  const methodId = exact
+    ? 'olv.contour.analytical'
+    : generalizeMode === 'terrain-aware'
+      ? 'olv.contour.generalize.terrain-adaptive'
+      : 'olv.contour.generalize';
   const methodVersion = 1;
 
   const meta = PURPOSE_META[state.purpose];
@@ -130,6 +146,7 @@ export function contourExportIntentFromState(state: ContourStudioState): Contour
     purpose: state.purpose,
     shapeStyle,
     generalizeToleranceCells: exact ? 0 : tol,
+    generalizeMode,
     labelsIndexOnly: state.labels.indexOnly,
     methodId,
     methodVersion,

--- a/src/terrain/contourStudio/contourStudioPurpose.ts
+++ b/src/terrain/contourStudio/contourStudioPurpose.ts
@@ -109,6 +109,7 @@ export function purposeDefaults(purpose: ContourStudioPurpose): PurposeDefaults 
         surface: {
           cartographicSmoothing: true,
           generalizeToleranceCells: PURPOSE_GENERALIZE_TOLERANCE_CELLS['engineering-plan'],
+          generalizeMode: 'uniform',
         },
         contour: { analytical: true, cartographic: true, indexEvery: 5 },
         labels: { enabled: true, indexOnly: false },
@@ -129,6 +130,7 @@ export function purposeDefaults(purpose: ContourStudioPurpose): PurposeDefaults 
           cartographicSmoothing: false,
           // 0 → exact: the export uses the crisp analytical style, no generalize.
           generalizeToleranceCells: PURPOSE_GENERALIZE_TOLERANCE_CELLS['survey-review'],
+          generalizeMode: 'uniform',
         },
         contour: { analytical: true, cartographic: false, indexEvery: 5 },
         labels: { enabled: true, indexOnly: true },
@@ -150,6 +152,7 @@ export function purposeDefaults(purpose: ContourStudioPurpose): PurposeDefaults 
         surface: {
           cartographicSmoothing: true,
           generalizeToleranceCells: PURPOSE_GENERALIZE_TOLERANCE_CELLS['terrain-research'],
+          generalizeMode: 'uniform',
         },
         contour: { analytical: true, cartographic: true, indexEvery: 5 },
         labels: { enabled: true, indexOnly: false },
@@ -168,6 +171,7 @@ export function purposeDefaults(purpose: ContourStudioPurpose): PurposeDefaults 
         surface: {
           cartographicSmoothing: true,
           generalizeToleranceCells: PURPOSE_GENERALIZE_TOLERANCE_CELLS['presentation-map'],
+          generalizeMode: 'uniform',
         },
         contour: { analytical: false, cartographic: true, indexEvery: 5 },
         labels: { enabled: true, indexOnly: true },
@@ -199,6 +203,7 @@ export function purposeDefaults(purpose: ContourStudioPurpose): PurposeDefaults 
 const PURPOSE_OWNED_PATHS = [
   'surface.cartographicSmoothing',
   'surface.generalizeToleranceCells',
+  'surface.generalizeMode',
   'contour.analytical',
   'contour.cartographic',
   'contour.indexEvery',
@@ -248,15 +253,17 @@ export function applyPurpose(
 // ── tiny dotted-path get/set over the known settings groups ────────────────
 type SettingGroup = 'surface' | 'contour' | 'labels' | 'appearance' | 'validation' | 'deliverable';
 
-function getPath(state: ContourStudioState, path: string): boolean | number {
+type SettingValue = boolean | number | string;
+
+function getPath(state: ContourStudioState, path: string): SettingValue {
   const [group, key] = path.split('.') as [SettingGroup, string];
-  return (state[group] as unknown as Record<string, boolean | number>)[key];
+  return (state[group] as unknown as Record<string, SettingValue>)[key];
 }
 
 function setPath(
   state: ContourStudioState,
   path: string,
-  value: boolean | number,
+  value: SettingValue,
 ): ContourStudioState {
   const [group, key] = path.split('.') as [SettingGroup, string];
   return {

--- a/src/terrain/contourStudio/contourStudioReducer.ts
+++ b/src/terrain/contourStudio/contourStudioReducer.ts
@@ -16,11 +16,16 @@ import {
   type ContourStudioPurpose,
   type ContourStudioState,
 } from './contourStudioState';
+import type { ContourGeneralizeMode } from '../contour/terrainAwareTolerance';
 import { applyPurpose } from './contourStudioPurpose';
+
+/** The value a settable path can hold. */
+export type ContourSettingValue = boolean | number | ContourGeneralizeMode;
 
 /** A settable path into the state's presentation settings. */
 export type ContourSettingPath =
   | 'surface.cartographicSmoothing'
+  | 'surface.generalizeMode'
   | 'contour.analytical'
   | 'contour.cartographic'
   | 'contour.indexEvery'
@@ -38,7 +43,7 @@ export type ContourSettingPath =
 export type ContourStudioAction =
   | { readonly type: 'set-purpose'; readonly purpose: ContourStudioPurpose }
   | { readonly type: 'set-area'; readonly area: ContourArea }
-  | { readonly type: 'set-setting'; readonly path: ContourSettingPath; readonly value: boolean | number }
+  | { readonly type: 'set-setting'; readonly path: ContourSettingPath; readonly value: ContourSettingValue }
   | { readonly type: 'reset' };
 
 export function contourStudioReducer(
@@ -77,7 +82,7 @@ type SettingGroup =
 function setPath(
   state: ContourStudioState,
   path: ContourSettingPath,
-  value: boolean | number,
+  value: ContourSettingValue,
 ): ContourStudioState {
   const [group, key] = path.split('.') as [SettingGroup, string];
   return {

--- a/src/terrain/contourStudio/contourStudioState.ts
+++ b/src/terrain/contourStudio/contourStudioState.ts
@@ -17,6 +17,9 @@
  */
 
 import { canonicalJson, fnv1a } from '../../canonicalHash';
+import type { ContourGeneralizeMode } from '../contour/terrainAwareTolerance';
+
+export { type ContourGeneralizeMode };
 
 export const CONTOUR_STUDIO_SCHEMA = 1 as const;
 
@@ -56,6 +59,15 @@ export interface ContourSurfaceSettings {
    * purpose (preserved on user override) like `cartographicSmoothing`.
    */
   readonly generalizeToleranceCells: number;
+  /**
+   * How the generalized geometry distributes that tolerance across features:
+   * 'uniform' (default) applies it evenly; 'terrain-aware' scales it DOWN per
+   * feature so interpolated / low-confidence / small-closed forms keep more of
+   * their shape (never up, so the tolerance above stays the honest ceiling). The
+   * choice is stamped into export provenance. Owned by the purpose, preserved on
+   * user override.
+   */
+  readonly generalizeMode: ContourGeneralizeMode;
 }
 
 /** Which geometry products to emit + how often an index (bold) contour falls. */
@@ -131,6 +143,7 @@ export function baseContourStudioState(): ContourStudioState {
     surface: {
       cartographicSmoothing: true,
       generalizeToleranceCells: BASE_GENERALIZE_TOLERANCE_CELLS,
+      generalizeMode: 'uniform',
     },
     contour: { analytical: true, cartographic: true, indexEvery: 5 },
     labels: { enabled: true, indexOnly: false },

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -69,6 +69,7 @@ import {
   defaultContourShapeStyle,
   type ContourShapeStyle,
 } from '../terrain/contour/contourShapeStyle';
+import type { ContourGeneralizeMode } from '../terrain/contour/terrainAwareTolerance';
 import {
   loadMapSheetPdf,
   loadDemPackage,
@@ -169,6 +170,8 @@ export interface AnalysePanelCallbacks {
     shapeStyle: ContourShapeStyle;
     /** Per-purpose generalization tolerance (cells) for the 'generalized' style. */
     generalizeToleranceCells?: number;
+    /** Per-purpose generalization mode (uniform | terrain-aware). */
+    generalizeMode?: ContourGeneralizeMode;
   }) => Promise<AnalyseContoursResult>;
   /** Optional basename for downloaded files (e.g. the scan name). */
   getExportBasename?: () => string;
@@ -398,6 +401,13 @@ export class AnalysePanel {
    * "use the default tolerance" (the manual map-PDF style picker never sets it).
    */
   private _contourGeneralizeToleranceCells: number | undefined = undefined;
+  /**
+   * Per-purpose generalization mode adopted from the active Contour Studio export
+   * intent: 'uniform' or 'terrain-aware'. Threaded into `buildResultForExport`
+   * beside the tolerance. Undefined means "uniform" (the manual style picker
+   * never sets it, so its exports are byte-unchanged).
+   */
+  private _contourGeneralizeMode: ContourGeneralizeMode | undefined = undefined;
   /**
    * The §19 export permit for the pending map-sheet PDF. The map PDF export runs
    * asynchronously through a dialog, so the permit minted at click time is
@@ -733,9 +743,10 @@ export class AnalysePanel {
       .then(({ ContourExportAdapter }) => {
         if (!this._contourExportAdapter) {
           const host: ContourExportHost = {
-            setContourStyle: (style, generalizeToleranceCells) => {
+            setContourStyle: (style, generalizeToleranceCells, generalizeMode) => {
               this._contourStyle = style;
               this._contourGeneralizeToleranceCells = generalizeToleranceCells;
+              this._contourGeneralizeMode = generalizeMode;
             },
             exportVector: (fmt, opts) => this._exportContourFormat(fmt, undefined, opts),
             openMapPdf: (permit, intent) => {
@@ -2015,6 +2026,7 @@ export class AnalysePanel {
       intervalM: r.requestedIntervalM ?? r.model.intervalM,
       shapeStyle: style,
       generalizeToleranceCells: this._contourGeneralizeToleranceCells,
+      generalizeMode: this._contourGeneralizeMode,
     });
   }
 

--- a/src/ui/contourExportAdapter.ts
+++ b/src/ui/contourExportAdapter.ts
@@ -16,6 +16,7 @@
 
 import type { ContourStudioExportProduct, ContourExportIntent } from './contourStudioMount';
 import type { ContourShapeStyle } from '../terrain/contour/contourShapeStyle';
+import type { ContourGeneralizeMode } from '../terrain/contour/terrainAwareTolerance';
 import {
   resolveContourExportPermit,
   type ContourPermitProduct,
@@ -35,12 +36,17 @@ export type ContourVectorFormat = Extract<ContourStudioExportProduct, 'geojson' 
  */
 export interface ContourExportHost {
   /**
-   * Adopt the intent's geometry style + generalization tolerance so the export
-   * regenerates at them. `generalizeToleranceCells` (cells) tunes the
-   * 'generalized' style per purpose; omitted/undefined leaves the host at its
-   * default tolerance.
+   * Adopt the intent's geometry style + generalization tolerance + mode so the
+   * export regenerates at them. `generalizeToleranceCells` (cells) tunes the
+   * 'generalized' style per purpose; `generalizeMode` selects uniform vs
+   * terrain-aware distribution of that tolerance. Omitted/undefined leaves the
+   * host at its defaults.
    */
-  setContourStyle(style: ContourShapeStyle, generalizeToleranceCells?: number): void;
+  setContourStyle(
+    style: ContourShapeStyle,
+    generalizeToleranceCells?: number,
+    generalizeMode?: ContourGeneralizeMode,
+  ): void;
   /** Serialize + download one vector format with its granted permit + provenance. */
   exportVector(
     fmt: ContourVectorFormat,
@@ -97,7 +103,11 @@ export class ContourExportAdapter {
   ): void {
     // Make the purpose real: two purposes regenerate different geometry, each at
     // its own bounded generalization tolerance.
-    this.host.setContourStyle(intent.shapeStyle, intent.generalizeToleranceCells);
+    this.host.setContourStyle(
+      intent.shapeStyle,
+      intent.generalizeToleranceCells,
+      intent.generalizeMode,
+    );
 
     // DEM raster package: routed through the SAME resolver (DTM claim). A hard
     // block (no usable surface) refuses; otherwise it exports stamped with the

--- a/src/ui/contourStudioWorkspace.ts
+++ b/src/ui/contourStudioWorkspace.ts
@@ -19,6 +19,7 @@
 
 import type { ContourStudioController } from '../terrain/contourStudio/contourStudioController';
 import type { ContourStudioState, ContourStudioPurpose } from '../terrain/contourStudio/contourStudioState';
+import type { ContourGeneralizeMode } from '../terrain/contour/terrainAwareTolerance';
 import type { ContourStudioLaunchState } from '../terrain/contourStudio/contourStudioLaunchState';
 import type { ContourReviewSummary } from '../terrain/contourStudio/contourReviewSummary';
 import {
@@ -155,6 +156,48 @@ function renderPurposeCards(
   return wrap;
 }
 
+const GENERALIZE_MODES: ReadonlyArray<{
+  id: ContourGeneralizeMode;
+  label: string;
+  desc: string;
+}> = [
+  { id: 'uniform', label: 'Uniform', desc: 'One simplification strength for every contour.' },
+  {
+    id: 'terrain-aware',
+    label: 'Terrain-aware',
+    desc: 'Keeps interpolated, low-confidence and small closed forms sharper. Never simplifies a line harder than uniform.',
+  },
+];
+
+/**
+ * The Uniform / Terrain-aware generalization toggle. Reuses the purpose-card
+ * pill styling. Only the generalized geometry reads it, so the note says so; a
+ * survey (exact) export ignores it and stays stamped uniform.
+ */
+function renderGeneralizeMode(
+  state: ContourStudioState,
+  onPick: (mode: ContourGeneralizeMode) => void,
+): HTMLElement {
+  const wrap = el('div', { className: 'olv-cs-genmode' });
+  wrap.append(el('div', { className: 'olv-cs-section-head', text: 'Generalization' }));
+  const grid = el('div', { className: 'olv-cs-genmode-grid' });
+  for (const m of GENERALIZE_MODES) {
+    const on = state.surface.generalizeMode === m.id;
+    const card = el('button', {
+      className: `olv-cs-genmode-card${on ? ' is-active' : ''}`,
+    });
+    card.type = 'button';
+    card.setAttribute('aria-pressed', on ? 'true' : 'false');
+    card.title = m.desc;
+    card.setAttribute('aria-label', `${m.label}. ${m.desc}`);
+    card.append(el('span', { className: 'olv-cs-genmode-label', text: m.label }));
+    card.addEventListener('click', () => onPick(m.id));
+    grid.append(card);
+  }
+  wrap.append(grid);
+  return wrap;
+}
+
 function renderSettingsSummary(state: ContourStudioState): HTMLElement {
   const wrap = el('div', { className: 'olv-cs-summary' });
   wrap.append(el('div', { className: 'olv-cs-section-head', text: 'This deliverable' }));
@@ -167,6 +210,7 @@ function renderSettingsSummary(state: ContourStudioState): HTMLElement {
   const rows: Array<[string, string]> = [
     ['Geometry', [state.contour.analytical ? 'analytical' : null, state.contour.cartographic ? 'cartographic' : null].filter(Boolean).join(' + ') || 'none'],
     ['Cartographic smoothing', state.surface.cartographicSmoothing ? 'on' : 'off'],
+    ['Generalization', state.surface.generalizeMode === 'terrain-aware' ? 'terrain-aware' : 'uniform'],
     ['Labels', labelsValue],
     ['Validation appendix', state.validation.appendixRequired ? 'required' : 'optional'],
     ['Exploratory output', state.deliverable.allowExploratory ? 'allowed' : 'not for this purpose'],
@@ -281,6 +325,9 @@ export function renderContourStudioWorkspace(
     body.append(
       renderPurposeCards(state.purpose, (p) =>
         controller.dispatch({ type: 'set-purpose', purpose: p }),
+      ),
+      renderGeneralizeMode(state, (mode) =>
+        controller.dispatch({ type: 'set-setting', path: 'surface.generalizeMode', value: mode }),
       ),
     );
     if (review) body.append(renderReviewBar(review));

--- a/tests/contourExportAdapter.test.ts
+++ b/tests/contourExportAdapter.test.ts
@@ -48,6 +48,7 @@ const intent = (over: Partial<ContourExportIntent> = {}): ContourExportIntent =>
   purpose: 'Survey Review',
   shapeStyle: 'crisp',
   generalizeToleranceCells: 0,
+  generalizeMode: 'uniform',
   labelsIndexOnly: false,
   methodId: 'olv.contour.analytical',
   methodVersion: 1,

--- a/tests/contourExportIntent.test.ts
+++ b/tests/contourExportIntent.test.ts
@@ -28,18 +28,38 @@ describe('contourExportIntentFromState', () => {
   it('Presentation Map exports generalized cartographic geometry with the HONEST generalize method', () => {
     const intent = forPurpose('presentation-map');
     expect(intent.shapeStyle).toBe('generalized');
-    // Honesty: the shipped pass is a UNIFORM-tolerance simplify, so the stamp is
-    // `olv.contour.generalize` — NEVER `terrain-adaptive` (an unwired module).
+    // Every purpose defaults to the UNIFORM-tolerance simplify, so the stamp is
+    // `olv.contour.generalize`; terrain-adaptive is opt-in via generalizeMode.
     expect(intent.methodId).toBe('olv.contour.generalize');
     expect(intent.methodTag).toBe('olv.contour.generalize@1');
+    expect(intent.generalizeMode).toBe('uniform');
     expect(intent.generalizeToleranceCells).toBe(1.0); // strongest preset
     expect(intent.labelsIndexOnly).toBe(true); // presentation maps label index lines only
   });
 
-  it('no purpose is ever stamped with the unwired terrain-adaptive method', () => {
+  it('no purpose DEFAULTS to the terrain-adaptive method (it is opt-in)', () => {
     for (const p of ['engineering-plan', 'survey-review', 'terrain-research', 'presentation-map', 'custom'] as const) {
       expect(forPurpose(p).methodId).not.toBe('olv.contour.generalize.terrain-adaptive');
     }
+  });
+
+  it('terrain-aware generalize mode stamps the terrain-adaptive method on the generalized path', () => {
+    const base = applyPurpose(baseContourStudioState(), 'presentation-map');
+    const state = { ...base, surface: { ...base.surface, generalizeMode: 'terrain-aware' as const } };
+    const intent = contourExportIntentFromState(state);
+    expect(intent.shapeStyle).toBe('generalized');
+    expect(intent.generalizeMode).toBe('terrain-aware');
+    expect(intent.methodId).toBe('olv.contour.generalize.terrain-adaptive');
+    expect(intent.methodTag).toBe('olv.contour.generalize.terrain-adaptive@1');
+  });
+
+  it('terrain-aware on the EXACT (survey) path still reports uniform — it generalizes nothing', () => {
+    const base = applyPurpose(baseContourStudioState(), 'survey-review');
+    const state = { ...base, surface: { ...base.surface, generalizeMode: 'terrain-aware' as const } };
+    const intent = contourExportIntentFromState(state);
+    expect(intent.shapeStyle).toBe('crisp');
+    expect(intent.generalizeMode).toBe('uniform'); // exact path forces uniform
+    expect(intent.methodId).toBe('olv.contour.analytical');
   });
 
   it('each cartographic purpose carries its own bounded generalization tolerance', () => {

--- a/tests/contourShapeStyle.test.ts
+++ b/tests/contourShapeStyle.test.ts
@@ -237,3 +237,75 @@ describe('simplifyPolyline', () => {
     expect(simplifyPolyline(poly, 0).vertices).toHaveLength(3);
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Terrain-aware generalization: the 'generalized' style may scale its per-feature
+// epsilon DOWN (never up), so a weak / interpolated / small-closed line keeps more
+// of its shape while every honesty guarantee of the uniform pass stays in force.
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A zig-zag whose peaks deviate 0.8 in y. The two endpoints are dashed
+ * (conf 40) so the FEATURE grades 'dashed', but every interior peak is solid
+ * (conf 90) and thus freely simplifiable — the clean case where the per-feature
+ * factor changes the outcome without touching a protected vertex.
+ */
+function dashedGradedZigzag(): ContourPolyline {
+  const verts: ContourVertex[] = [];
+  for (let i = 0; i <= 10; i++) {
+    const y = i % 2 === 0 ? 0 : 0.8;
+    const conf = i === 0 || i === 10 ? 40 : 90;
+    verts.push(v(i, y, conf));
+  }
+  return line(verts);
+}
+
+describe('applyContourShapeStyle — terrain-aware generalization', () => {
+  const OPTS = { cellSizeM: 1, generalizeToleranceCells: 1 } as const;
+
+  it("uniform is the default: omitting generalizeMode equals mode 'uniform', byte-identical", () => {
+    const p = dashedGradedZigzag();
+    const def = applyContourShapeStyle([p], 'generalized', OPTS);
+    const uni = applyContourShapeStyle([p], 'generalized', { ...OPTS, generalizeMode: 'uniform' });
+    expect(uni).toEqual(def);
+  });
+
+  it('terrain-aware keeps a weak (dashed-graded) feature more faithfully than uniform', () => {
+    const p = dashedGradedZigzag();
+    const [uni] = applyContourShapeStyle([p], 'generalized', OPTS);
+    const [ta] = applyContourShapeStyle([p], 'generalized', {
+      ...OPTS,
+      generalizeMode: 'terrain-aware',
+    });
+    // Uniform (eps 1.0) drops the 0.8-high peaks; terrain-aware (dashed → ×0.6 →
+    // eps 0.6) keeps them, so it retains strictly more vertices.
+    expect(ta.vertices.length).toBeGreaterThan(uni.vertices.length);
+  });
+
+  it('terrain-aware is never LESS faithful than uniform (epsilon only ever shrinks)', () => {
+    const cases: ContourPolyline[] = [
+      wavyLine(),
+      dashedGradedZigzag(),
+      line([v(0, 0), v(1, 1), v(2, 0), v(3, 2)], true),
+    ];
+    for (const p of cases) {
+      const [uni] = applyContourShapeStyle([p], 'generalized', OPTS);
+      const [ta] = applyContourShapeStyle([p], 'generalized', {
+        ...OPTS,
+        generalizeMode: 'terrain-aware',
+      });
+      expect(ta.vertices.length).toBeGreaterThanOrEqual(uni.vertices.length);
+    }
+  });
+
+  it('terrain-aware keeps the honesty gate: a collinear gap vertex survives at its exact coordinate', () => {
+    // (2,0) is collinear and would be dropped by DP, but its conf 10 → gap grade
+    // makes it protected. It must remain under terrain-aware too.
+    const p = line([v(0, 0, 90), v(1, 0, 90), v(2, 0, 10), v(3, 0, 90), v(4, 0, 90)]);
+    const [ta] = applyContourShapeStyle([p], 'generalized', {
+      ...OPTS,
+      generalizeMode: 'terrain-aware',
+    });
+    expect(ta.vertices.some((w) => w.x === 2 && w.y === 0 && w.confidence === 10)).toBe(true);
+  });
+});

--- a/tests/contourStudioWorkspace.test.ts
+++ b/tests/contourStudioWorkspace.test.ts
@@ -93,6 +93,20 @@ describe('renderContourStudioWorkspace', () => {
     expect(selected).toHaveLength(1);
   });
 
+  it('renders the generalization toggle; clicking Terrain-aware dispatches set-setting', () => {
+    const c = createContourStudioController();
+    const root = renderContourStudioWorkspace({ controller: c, launch: AVAILABLE }) as unknown as FakeEl;
+    const modes = root.byClass('olv-cs-genmode-card');
+    expect(modes).toHaveLength(2);
+    expect(c.getState().surface.generalizeMode).toBe('uniform'); // default is opt-in uniform
+    // Order is Uniform, Terrain-aware.
+    modes[1].click();
+    expect(c.getState().surface.generalizeMode).toBe('terrain-aware');
+    // After re-render exactly one mode card is active, and it is not a purpose card.
+    expect(root.byClass('is-active')).toHaveLength(1);
+    expect(root.byClass('olv-cs-purpose-card')).toHaveLength(5);
+  });
+
   it('evidence ladder claim reflects the launch state', () => {
     const c = createContourStudioController();
     const avail = renderContourStudioWorkspace({ controller: c, launch: AVAILABLE }) as unknown as FakeEl;

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -8582,8 +8582,10 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
 /* Purpose cards */
 /* Compact pills: the label alone; the full description is on hover (title
    attribute) so the picker stays tight instead of a wall of summary text. */
-.olv-cs-purpose-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-.olv-cs-purpose-card {
+.olv-cs-purpose-grid,
+.olv-cs-genmode-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+.olv-cs-purpose-card,
+.olv-cs-genmode-card {
   display: flex;
   align-items: center;
   min-height: 30px;
@@ -8595,14 +8597,19 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
   cursor: pointer;
   transition: border-color 0.15s ease, background 0.15s ease, transform 0.05s ease;
 }
-.olv-cs-purpose-card:hover { border-color: var(--hairline-strong); }
-.olv-cs-purpose-card:active { transform: translateY(1px); }
-.olv-cs-purpose-card.is-selected {
+.olv-cs-purpose-card:hover,
+.olv-cs-genmode-card:hover { border-color: var(--hairline-strong); }
+.olv-cs-purpose-card:active,
+.olv-cs-genmode-card:active { transform: translateY(1px); }
+.olv-cs-purpose-card.is-selected,
+.olv-cs-genmode-card.is-active {
   border-color: var(--accent);
   background: var(--accent-soft);
   box-shadow: 0 0 0 1px var(--accent) inset;
 }
-.olv-cs-purpose-label { display: block; font-size: var(--text-sm); font-weight: 620; color: var(--text); }
+.olv-cs-purpose-label,
+.olv-cs-genmode-label { display: block; font-size: var(--text-sm); font-weight: 620; color: var(--text); }
+.olv-cs-genmode { margin-top: 10px; }
 
 /* Review + settings summary — definition grids */
 .olv-cs-review-list, .olv-cs-summary-list {


### PR DESCRIPTION
Turns on terrain-aware contour generalization as an opt-in Contour Studio mode. Terrain-aware scales the per-feature simplification tolerance DOWN from what a feature is (interpolated, low-confidence, and small closed forms are kept sharper), clamped so it can only ever make a line more faithful than the uniform pass, never exceed the one-cell honesty ceiling, and never drop a protected vertex.

## Design note

The staged `terrainAwareCartographicProduct` pipeline had no production caller, and the live export uses a separate honesty-gated styler (`simplifyPolyline`'s `protectedMask` plus Chaikin smoothing). Routing the live export through the protection-less product pipeline would have dropped both protections. Instead, terrain-aware is layered onto the live styler through one shared policy (`terrainAwareTolerance.ts`), so both paths read the same tolerance function and every honesty guarantee stays in force.

## Wiring

- `generalizeMode: 'uniform' | 'terrain-aware'` on `ContourStudioState.surface` (default uniform; additive so old serialized states coerce to uniform without a schema bump). Purpose-owned and override-preserved via a reducer `set-setting` path.
- `contourExportIntentFromState` stamps `olv.contour.generalize.terrain-adaptive@1` when terrain-aware is chosen on the generalized path, and forces `uniform` on the exact (crisp) path.
- Threaded intent → `setContourStyle` → AnalysePanel → `buildResultForExport` → `contoursFromCore` → `applyContourShapeStyle`.
- A Uniform / Terrain-aware toggle in the Contour Studio workspace.

## Verification

tsc clean. 359 tests pass across the contour, PDF, provenance, and workspace suites, including: uniform default byte-identical to before; terrain-aware keeps a weak feature more faithfully and never less faithful than uniform; a gap vertex is still protected under terrain-aware; the intent stamps terrain-adaptive on the generalized path and uniform on the exact path; the workspace toggle renders two mode cards, dispatches `set-setting`, and marks exactly one active.

Default is `uniform`, so every existing export stays byte-identical; terrain-aware is opt-in.
