### PR TITLE
Contours as the first Derived Layer (drawn in the 3D scene)

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -166,8 +166,18 @@ no DOM, three.js or proj4 (`tests/scanFootprint.test.ts`); the serialiser is
 `buildFootprintKml` in the existing `src/export/kmlExport.ts`. `main.ts` keeps
 four thin delegates and the deps object.
 
-**`src/render/Viewer.ts` (6,419)** — the constructor and a handful of large
+**`src/render/Viewer.ts` (6,439)** — the constructor and a handful of large
 methods dominate:
+
+The count ROSE by 20 in this cycle, the first deliberate growth since the
+shrink-only ratchet was restored, and the baseline was hand-raised to match. The
+Viewer owns the scene exclusively, so derived layers — analytical results drawn
+in 3D rather than only exported — had no way in. `derivedLayerHost()` is that
+way: a structural host (the same shape as the sky and snapshot hosts) that lends
+scene membership and a redraw request, so the overlay module owns its own
+objects and disposal and the Viewer never learns a product's lifecycle. Twenty
+lines to open a subsystem, rather than a per-product method each time. The next
+extraction below still pays it back several times over.
 
 Spans below are the symbol's real extent, read from the TypeScript symbol graph
 rather than estimated by pattern-matching — an earlier revision of this table

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.6.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.6.md
@@ -4,7 +4,9 @@ This cycle promotes the DSM, DTM and CHM surface products to E4 on cross-impleme
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,821 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and shared domain/application state is owned by AppContext/services, with the composition root retaining only explicitly bounded shell-local composition and lifecycle state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,821 lines and `src/render/Viewer.ts` is 6,439, against stated targets of 2,500 and 2,000. This cycle lifted more blocks out of `Viewer.ts` (the streaming session assembly moved behind a `StreamingHost`, and report and scan-open paths moved behind structural dependency objects), and shared domain/application state is owned by AppContext/services, with the composition root retaining only explicitly bounded shell-local composition and lifecycle state. That is continued decomposition, not its completion. The remaining blocks to lift, and the measured dependency surface of the first one, are in `docs/architecture/architecture-map.md`.
+
+`Viewer.ts` also GREW by 20 lines this cycle — the first deliberate growth since the shrink-only guard was restored, and the recorded baseline was raised by hand to match. The Viewer owns the scene exclusively, so derived layers (analytical results drawn in 3D rather than only exported) had no way into it. `derivedLayerHost()` is that way in: a structural host that lends scene membership and a redraw request, so an overlay module owns its own objects and their disposal. Twenty lines that open a subsystem, rather than a method per product — but growth all the same, and named here rather than left to be discovered in the diff.
 
 ## Building classification: the ground-support gate is evaluated on synthetic scenes only
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -5,7 +5,7 @@
       "goal": 2500
     },
     "src/render/Viewer.ts": {
-      "lines": 6419,
+      "lines": 6439,
       "goal": 2000
     }
   }

--- a/docs/validation/position-access-baseline.json
+++ b/docs/validation/position-access-baseline.json
@@ -1,5 +1,5 @@
 {
-  "total": 146,
+  "total": 147,
   "files": {
     "src/app/epochFramePrep.ts": 2,
     "src/app/floorPlanPositions.ts": 4,
@@ -19,6 +19,7 @@
     "src/main.ts": 12,
     "src/model/PointCloud.ts": 17,
     "src/model/pointFrames.ts": 2,
+    "src/render/ContourOverlay.ts": 1,
     "src/render/InspectTool.ts": 1,
     "src/render/Viewer.ts": 46,
     "src/render/densityColors.ts": 1,

--- a/docs/validation/position-frames.json
+++ b/docs/validation/position-frames.json
@@ -380,6 +380,13 @@
       "frame": "project-local",
       "reads": 1,
       "why": "Rebuilds a view over the transferred gather buffer, which the gather assembler already placed into the project frame."
+    },
+    {
+      "file": "src/render/ContourOverlay.ts",
+      "symbol": "ContourOverlay._upload",
+      "frame": "project-local",
+      "reads": 1,
+      "why": "Uploads the CONTOUR line-segment vertices (not cloud points) into a THREE.BufferGeometry. They arrive from buildContourOverlayBuffers over a model derived from gatherTerrainPositions, which folds every layer placement in, so the buffer is already in the project frame the scene draws at its origin — the object carries no further offset."
     }
   ]
 }

--- a/src/app/contourLayerService.ts
+++ b/src/app/contourLayerService.ts
@@ -1,0 +1,192 @@
+/**
+ * contourLayerService.ts
+ *
+ * Lifecycle for the contours DERIVED LAYER: the first analytical product that
+ * lives in the 3D scene as a first-class layer rather than only as an export.
+ *
+ * It owns exactly two things and nothing else: the `DerivedLayerStore` record
+ * (what the layer IS — name, source scan, provenance, coverage, display state)
+ * and the `ContourOverlay` (what is drawn). Everything three.js stays inside the
+ * overlay; everything view-bound stays in the Viewer behind its structural
+ * `derivedLayerHost()`. So this module is pure orchestration and is testable in
+ * Node against fakes.
+ *
+ * WHY A SERVICE AND NOT A FEW CALLS IN THE RUNNER. Two invariants only hold if
+ * one place owns them:
+ *
+ *  - a RE-ANALYSIS must replace the drawn geometry and bump the layer's
+ *    generation, never leave the previous overlay stacked behind the new one;
+ *  - a CLOSED scan must take its derived layers with it — a contour layer that
+ *    outlives the scan it was derived from is a claim about data no longer
+ *    loaded, and would keep drawing over whatever is opened next.
+ *
+ * The store already models regeneration (`put` bumps `generation`) and source
+ * ownership (`bySource`); this wires the overlay to the same events so the two
+ * cannot disagree about what is on screen.
+ */
+
+import { DerivedLayerStore, type DerivedLayer } from '../model/DerivedLayer';
+import { ContourOverlay, type ContourOverlayHost } from '../render/ContourOverlay';
+import type { ContourFeatureModel } from '../terrain/contour/contourFeatureModel';
+import type { SourceFormat } from '../io/sniffFormat';
+
+/** The stable id of the contour layer derived from a given scan. */
+export function contourLayerId(scanId: string): string {
+  return `contours:${scanId}`;
+}
+
+/** What a contour layer needs to be built and placed. */
+export interface ContourLayerInput {
+  /** The scan the contours were derived FROM (owns the layer's lifetime). */
+  readonly scanId: string;
+  readonly model: ContourFeatureModel;
+  /** Fixes the scene frame — a Y-up scan is drawn through the inverse rotation. */
+  readonly format: SourceFormat;
+  readonly renderOrigin: readonly [number, number, number] | null;
+  /** Vertical exaggeration currently applied to the scene. Default 1. */
+  readonly zScale?: number;
+  /** Coverage honesty, carried from the analysis that produced the contours. */
+  readonly coverage?: DerivedLayer['coverage'];
+  /** True when the analysis was exploratory rather than evidence-graded. */
+  readonly evidenceExploratory?: boolean;
+  /** The scientific record digest, when the product is graded. */
+  readonly provenanceDigest?: string | null;
+}
+
+/** The overlay factory, injectable so tests do not construct three.js objects. */
+export type ContourOverlayFactory = (host: ContourOverlayHost) => ContourOverlay;
+
+export interface ContourLayerServiceDeps {
+  /** `viewer.derivedLayerHost()` — scene membership + redraw, nothing more. */
+  readonly host: ContourOverlayHost;
+  /** The app's derived-layer store. Shared, so other products can join it. */
+  readonly store: DerivedLayerStore;
+  readonly makeOverlay?: ContourOverlayFactory;
+}
+
+export interface ContourLayerService {
+  /** Build or REGENERATE the contour layer for a scan, and draw it. */
+  show(input: ContourLayerInput): DerivedLayer;
+  /** The layer record for a scan, if one exists. */
+  layerFor(scanId: string): DerivedLayer | undefined;
+  setVisible(scanId: string, visible: boolean): DerivedLayer | undefined;
+  setOpacity(scanId: string, opacity: number): DerivedLayer | undefined;
+  setHeightOffset(scanId: string, offset: number): DerivedLayer | undefined;
+  setIndexEmphasis(scanId: string, on: boolean): DerivedLayer | undefined;
+  /** Drop every derived layer owned by a scan, and stop drawing it. */
+  clearForScan(scanId: string): void;
+  /** Release the overlay and its GPU resources. */
+  dispose(): void;
+}
+
+export function createContourLayerService(deps: ContourLayerServiceDeps): ContourLayerService {
+  const makeOverlay = deps.makeOverlay ?? ((host) => new ContourOverlay(host));
+  // ONE overlay, reused across regenerations. A per-analysis overlay would need
+  // the caller to remember to dispose the previous one, which is exactly the
+  // "stale overlay left drawn" bug this service exists to make impossible.
+  let overlay: ContourOverlay | null = null;
+  // The scan the overlay currently draws, so a different scan's controls cannot
+  // silently drive geometry belonging to another.
+  let drawnScanId: string | null = null;
+
+  const ensureOverlay = (): ContourOverlay => {
+    overlay ??= makeOverlay(deps.host);
+    return overlay;
+  };
+
+  /** Apply a display patch to the store, then mirror it onto the overlay. */
+  const patch = (
+    scanId: string,
+    mutate: (id: string) => DerivedLayer | undefined,
+    paint: (o: ContourOverlay) => void,
+  ): DerivedLayer | undefined => {
+    const next = mutate(contourLayerId(scanId));
+    // Only paint when the overlay is actually showing THIS scan; a control for a
+    // background scan updates its record without touching what is on screen.
+    if (next && overlay && drawnScanId === scanId) paint(overlay);
+    return next;
+  };
+
+  return {
+    show(input) {
+      const o = ensureOverlay();
+      o.setModel({
+        model: input.model,
+        format: input.format,
+        renderOrigin: input.renderOrigin,
+        zScale: input.zScale ?? 1,
+      });
+      drawnScanId = input.scanId;
+      const id = contourLayerId(input.scanId);
+      // `put` REPLACES the record (bumping generation), so the display state the
+      // user chose has to be carried across explicitly. Without this, re-running
+      // the analysis silently snaps a hidden or faded layer back to fully
+      // visible — the user's choice undone by a background recompute.
+      const prev = deps.store.get(id);
+      const layer = deps.store.put({
+        id,
+        type: 'contours',
+        name: 'Contours',
+        sourceScanIds: [input.scanId],
+        coverage: input.coverage ?? 'unknown',
+        evidenceExploratory: input.evidenceExploratory ?? false,
+        provenanceDigest: input.provenanceDigest ?? null,
+        visible: prev?.visible,
+        opacity: prev?.opacity,
+        style: prev ? { ...prev.style } : undefined,
+      });
+      // The record is the source of truth for display state, so a regeneration
+      // re-asserts ALL of it onto the freshly built geometry.
+      o.setVisible(layer.visible);
+      o.setOpacity(layer.opacity);
+      if (typeof layer.style.heightOffset === 'number') o.setHeightOffset(layer.style.heightOffset);
+      if (typeof layer.style.indexEmphasis === 'boolean') o.setIndexEmphasis(layer.style.indexEmphasis);
+      return layer;
+    },
+
+    layerFor(scanId) {
+      return deps.store.get(contourLayerId(scanId));
+    },
+
+    setVisible(scanId, visible) {
+      return patch(scanId, (id) => deps.store.setVisible(id, visible), (o) => { o.setVisible(visible); });
+    },
+
+    setOpacity(scanId, opacity) {
+      return patch(scanId, (id) => deps.store.setOpacity(id, opacity), (o) => { o.setOpacity(opacity); });
+    },
+
+    setHeightOffset(scanId, offset) {
+      return patch(
+        scanId,
+        (id) => deps.store.setStyle(id, { heightOffset: offset }),
+        (o) => { o.setHeightOffset(offset); },
+      );
+    },
+
+    setIndexEmphasis(scanId, on) {
+      return patch(
+        scanId,
+        (id) => deps.store.setStyle(id, { indexEmphasis: on }),
+        (o) => { o.setIndexEmphasis(on); },
+      );
+    },
+
+    clearForScan(scanId) {
+      for (const layer of deps.store.bySource(scanId)) deps.store.remove(layer.id);
+      // Stop drawing only if the overlay belonged to THIS scan — closing a
+      // background scan must not blank the contours of the one on screen.
+      if (drawnScanId === scanId && overlay) {
+        overlay.dispose();
+        overlay = null;
+        drawnScanId = null;
+      }
+    },
+
+    dispose() {
+      overlay?.dispose();
+      overlay = null;
+      drawnScanId = null;
+    },
+  };
+}

--- a/src/app/contourLayerService.ts
+++ b/src/app/contourLayerService.ts
@@ -25,8 +25,14 @@
  * cannot disagree about what is on screen.
  */
 
-import { DerivedLayerStore, type DerivedLayer } from '../model/DerivedLayer';
-import { ContourOverlay, type ContourOverlayHost } from '../render/ContourOverlay';
+import { type DerivedLayer } from '../model/DerivedLayer';
+// TYPE-ONLY on purpose: `ContourOverlay` pulls in three/webgpu, and this module
+// is reachable from the startup shell through the terrain runner. Importing the
+// class as a VALUE here would drag the whole renderer into the index chunk (the
+// chunk-isolation guard's exact subject), so the overlay arrives as an injected
+// factory that the caller lazy-imports.
+import type { ContourOverlay, ContourOverlayHost } from '../render/ContourOverlay';
+import type { DerivedLayerStore } from '../model/DerivedLayer';
 import type { ContourFeatureModel } from '../terrain/contour/contourFeatureModel';
 import type { SourceFormat } from '../io/sniffFormat';
 
@@ -61,7 +67,11 @@ export interface ContourLayerServiceDeps {
   readonly host: ContourOverlayHost;
   /** The app's derived-layer store. Shared, so other products can join it. */
   readonly store: DerivedLayerStore;
-  readonly makeOverlay?: ContourOverlayFactory;
+  /**
+   * Builds the overlay. REQUIRED (not defaulted to `new ContourOverlay`) so this
+   * module never imports three as a value — see the type-only import above.
+   */
+  readonly makeOverlay: ContourOverlayFactory;
 }
 
 export interface ContourLayerService {
@@ -80,7 +90,7 @@ export interface ContourLayerService {
 }
 
 export function createContourLayerService(deps: ContourLayerServiceDeps): ContourLayerService {
-  const makeOverlay = deps.makeOverlay ?? ((host) => new ContourOverlay(host));
+  const makeOverlay = deps.makeOverlay;
   // ONE overlay, reused across regenerations. A per-analysis overlay would need
   // the caller to remember to dispose the previous one, which is exactly the
   // "stale overlay left drawn" bug this service exists to make impossible.

--- a/src/app/terrainAnalysisRunner.ts
+++ b/src/app/terrainAnalysisRunner.ts
@@ -286,6 +286,15 @@ export function createTerrainAnalysisRunner(
    * to a successful analysis, so a lazy-chunk failure or a missing cloud must
    * leave the analysis, the panel and the export exactly as they are.
    */
+  /**
+   * The scan's vertical-unit label for the layer controls, or null when the file
+   * declares none — the fail-honest rule the metric readouts already follow.
+   */
+  function layerVerticalUnitLabel(): string | null {
+    const scale = verticalMetresPerUnit(crsService.context(), 'horizontal') ?? null;
+    return scale != null ? verticalUnitLabel(scale) : null;
+  }
+
   async function showContourLayer(
     result: AnalyseContoursResult,
     scanId: string | null,
@@ -322,6 +331,38 @@ export function createTerrainAnalysisRunner(
         // Coverage honesty travels with the layer: a resident-only gather is a
         // partial view, and the record must say so rather than imply the whole scan.
         coverage: result.dtm.coverageMode === 'full' ? 'full' : 'sampled',
+      });
+      // Hand the panel a live view of the layer. Every handler returns what the
+      // service ACTUALLY applied, so a control re-reads the record rather than
+      // assuming its own click won — the drawn state and the UI cannot drift.
+      const svc = contourLayers;
+      const layer = svc.layerFor(scanId);
+      const styleNum = (k: string, fallback: number): number => {
+        const v = layer?.style[k];
+        return typeof v === 'number' ? v : fallback;
+      };
+      const styleBool = (k: string, fallback: boolean): boolean => {
+        const v = layer?.style[k];
+        return typeof v === 'boolean' ? v : fallback;
+      };
+      getAnalysePanel().setContourLayerControls({
+        visible: layer?.visible ?? true,
+        opacity: layer?.opacity ?? 1,
+        indexEmphasis: styleBool('indexEmphasis', true),
+        heightOffset: styleNum('heightOffset', 0),
+        // Same vertical-unit policy the panel's other readouts use: an
+        // undeclared unit prints no label rather than implying metres.
+        verticalUnitLabel: layerVerticalUnitLabel(),
+        onVisible: (next) => svc.setVisible(scanId, next)?.visible ?? null,
+        onOpacity: (next) => svc.setOpacity(scanId, next)?.opacity ?? null,
+        onIndexEmphasis: (next) => {
+          const v = svc.setIndexEmphasis(scanId, next)?.style.indexEmphasis;
+          return typeof v === 'boolean' ? v : null;
+        },
+        onHeightOffset: (next) => {
+          const v = svc.setHeightOffset(scanId, next)?.style.heightOffset;
+          return typeof v === 'number' ? v : null;
+        },
       });
     } catch (err) {
       console.warn('OpenLiDARViewer: contour layer not drawn.', err);

--- a/src/app/terrainAnalysisRunner.ts
+++ b/src/app/terrainAnalysisRunner.ts
@@ -41,6 +41,9 @@ import type {
   TerrainCoreParams,
 } from '../terrain/contour/analyseContours';
 import type { ContourShapeStyle } from '../terrain/contour/contourShapeStyle';
+// TYPE-ONLY: the service and the overlay it builds both load lazily, so
+// neither this import nor the runner widens the startup shell chunk.
+import type { ContourLayerService } from './contourLayerService';
 import {
   loadTerrainCoreCache,
   loadComputeTerrainCoreAsync,
@@ -198,6 +201,13 @@ export interface TerrainAnalysisRunner {
    */
   buildResultAtInterval(intervalM: number): Promise<AnalyseContoursResult>;
   /**
+   * The contours derived-layer service, or null before the first analysis has
+   * drawn one. The UI reads it to drive the layer's visibility, opacity and
+   * style; it is created lazily so the overlay chunk (and three) never loads for
+   * a session that never analyses terrain.
+   */
+  getContourLayers(): ContourLayerService | null;
+  /**
    * Build a fresh contour result at a chosen interval AND shape style for an
    * export ONLY, over the SAME cached core path as {@link run}. Generalises
    * {@link buildResultAtInterval} with the contour-shape-style picker; a cache
@@ -257,6 +267,65 @@ export function createTerrainAnalysisRunner(
   // previous controller so a superseded worker job is cancelled and its reply
   // dropped. Null when no run is in flight.
   let terrainAbort: AbortController | null = null;
+
+  // ── contours as a derived LAYER in the 3D scene ──────────────────────────
+  // Owned here rather than in the composition root because this is where the
+  // contour model is produced, and because both the store and the service are
+  // three-free — the overlay class (and with it three/webgpu) arrives through a
+  // lazy import, so nothing here widens the startup shell.
+  let contourLayers: ContourLayerService | null = null;
+
+  /** The contour derived-layer service, or null before the first analysis. */
+  const getContourLayers = (): ContourLayerService | null => contourLayers;
+
+  /**
+   * Draw (or regenerate) the contour layer for the scan that produced `result`.
+   *
+   * Every failure path is swallowed deliberately: a scene overlay is an ADDITION
+   * to a successful analysis, so a lazy-chunk failure or a missing cloud must
+   * leave the analysis, the panel and the export exactly as they are.
+   */
+  async function showContourLayer(
+    result: AnalyseContoursResult,
+    scanId: string | null,
+  ): Promise<void> {
+    if (!scanId) return;
+    try {
+      const viewer = getViewer();
+      const cloud = viewer.getCloud(scanId);
+      if (!cloud) return;
+      if (!contourLayers) {
+        const [{ createContourLayerService }, { DerivedLayerStore }, { ContourOverlay }] =
+          await Promise.all([
+            import('./contourLayerService'),
+            import('../model/DerivedLayer'),
+            import('../render/ContourOverlay'),
+          ]);
+        contourLayers = createContourLayerService({
+          host: viewer.derivedLayerHost(),
+          store: new DerivedLayerStore(),
+          makeOverlay: (host) => new ContourOverlay(host),
+        });
+      }
+      contourLayers.show({
+        scanId,
+        model: result.model,
+        format: cloud.sourceFormat,
+        // NO offset. The contour model is built from `gatherTerrainPositions`,
+        // which returns one assembled sample with every layer placement already
+        // folded in — the PROJECT frame, which the scene draws at its own
+        // origin. Adding a cloud origin here would translate the contours by it
+        // a second time and float them off their terrain. (The overlay still
+        // accepts an origin, for a future product whose model is source-local.)
+        renderOrigin: null,
+        // Coverage honesty travels with the layer: a resident-only gather is a
+        // partial view, and the record must say so rather than imply the whole scan.
+        coverage: result.dtm.coverageMode === 'full' ? 'full' : 'sampled',
+      });
+    } catch (err) {
+      console.warn('OpenLiDARViewer: contour layer not drawn.', err);
+    }
+  }
 
   // The last gather's raw-scene up-axis, cached so the map-sheet export can plot
   // annotation markers in the same canonical frame the contours were built in.
@@ -429,6 +498,11 @@ export function createTerrainAnalysisRunner(
       // post-analysis wiring (e.g. the Viewer's coverage colour grid) sees the
       // same winning result the panel shows.
       onResult?.(result);
+      // Draw the contours as a derived LAYER in the 3D scene. Fire-and-forget:
+      // the overlay chunk loads lazily, and a scene overlay must never delay or
+      // fail the analysis that produced it — a throw here would turn a
+      // successful analysis into a reported failure.
+      void showContourLayer(result, runDatasetId);
     } catch (err) {
       // A stale run must not clobber the winning run's busy flag or status.
       if (isStale()) return;
@@ -513,5 +587,12 @@ export function createTerrainAnalysisRunner(
     return lastSourceUpAxis;
   }
 
-  return { run, buildResultAtInterval, buildResultForExport, abortAndClearCache, getLastSourceUpAxis };
+  return {
+    run,
+    buildResultAtInterval,
+    buildResultForExport,
+    abortAndClearCache,
+    getLastSourceUpAxis,
+    getContourLayers,
+  };
 }

--- a/src/app/terrainAnalysisRunner.ts
+++ b/src/app/terrainAnalysisRunner.ts
@@ -317,6 +317,22 @@ export function createTerrainAnalysisRunner(
           makeOverlay: (host) => new ContourOverlay(host),
         });
       }
+      // The digest identifies the RUN reproducibly: the record's fingerprint
+      // covers the scientific content only — not build, not time — so two runs
+      // over the same data agree even though their timestamps differ. The
+      // timestamp below is therefore a display field of the receipt, not an
+      // input to its identity. A receipt failure must not cost the user their
+      // layer, so it degrades to no digest rather than throwing.
+      let receiptDigest: string | null = null;
+      try {
+        const { buildDerivedLayerReceipt } = await import('../science/derivedLayerReceipt');
+        receiptDigest = buildDerivedLayerReceipt({
+          result,
+          generatedAt: new Date(),
+        }).digest;
+      } catch (err) {
+        console.warn('OpenLiDARViewer: contour layer receipt not built.', err);
+      }
       contourLayers.show({
         scanId,
         model: result.model,
@@ -331,6 +347,12 @@ export function createTerrainAnalysisRunner(
         // Coverage honesty travels with the layer: a resident-only gather is a
         // partial view, and the record must say so rather than imply the whole scan.
         coverage: result.dtm.coverageMode === 'full' ? 'full' : 'sampled',
+        // The layer carries the receipt digest for the analysis that produced
+        // it, so "what made this, and was it allowed to claim it" travels with
+        // the layer rather than only with an export. Built through the same
+        // provenance path the exported files use, so a layer and a file can
+        // never disagree about the same run.
+        provenanceDigest: receiptDigest,
       });
       // Hand the panel a live view of the layer. Every handler returns what the
       // service ACTUALLY applied, so a control re-reads the record rather than

--- a/src/render/ContourOverlay.ts
+++ b/src/render/ContourOverlay.ts
@@ -1,0 +1,279 @@
+/**
+ * ContourOverlay.ts
+ *
+ * The thin three.js binding that draws analysed contours in the 3D scene — the
+ * first real Derived Layer. Everything that can be decided without three lives
+ * next door in `contourOverlayPlacement.ts` (which frame, which position) and in
+ * `terrain/contour/contourOverlayGeometry.ts` (the line buffers), both pure and
+ * unit-tested. What remains here is upload, style, and lifecycle.
+ *
+ * FRAME (load-bearing). The buffers are built through
+ * `overlayBufferParamsFor(format)`, which returns the vertical axis and the
+ * northing sign TOGETHER. Taking only the axis for a Y-up scan is a reflection
+ * that mirrors the scan while still looking like a contour map; the pairing is
+ * what makes that unreachable from here. See the proof in
+ * `tests/contourOverlayPlacement.test.ts`.
+ *
+ * EVIDENCE HONESTY. A contour's grade is not decoration: `solid` means measured
+ * support, `dashed` means interpolated. The overlay distinguishes them by colour
+ * and alpha rather than by a dash PATTERN — a screen-space dash length is
+ * meaningless at an arbitrary 3D zoom, and a dashed line that reads as solid
+ * when you fly close would be the dishonest option. `gap` segments are excluded
+ * by the geometry builder's default: a gap is a break, not a line, so nothing is
+ * drawn across it. Index contours are brightened, never re-shaped.
+ *
+ * The elevations drawn are the analysed elevations. `heightOffset` lifts the
+ * whole object along the scene's vertical axis so the lines read ON the surface
+ * instead of z-fighting the points that produced them; it is a DISPLAY nudge and
+ * never changes the geometry, the readouts, or any export.
+ */
+
+import * as THREE from 'three/webgpu';
+import {
+  buildContourOverlayBuffers,
+  type ContourOverlayBuffers,
+} from '../terrain/contour/contourOverlayGeometry';
+import type { ContourFeatureModel } from '../terrain/contour/contourFeatureModel';
+import type { SourceFormat } from '../io/sniffFormat';
+import {
+  overlayBufferParamsFor,
+  overlayVerticalAxisFor,
+  overlayScenePosition,
+  overlayHeightOffsetVector,
+} from './contourOverlayPlacement';
+
+/**
+ * What the overlay needs from its host. A `THREE.Scene` satisfies add/remove as
+ *-is; `requestFrame` is the Viewer's redraw request. Narrow on purpose, so the
+ * overlay can be exercised without standing up a renderer.
+ */
+export interface ContourOverlayHost {
+  add(object: THREE.Object3D): void;
+  remove(object: THREE.Object3D): void;
+  requestFrame?: () => void;
+}
+
+/** What to draw, and the frame of the scan it belongs to. */
+export interface ContourOverlayInput {
+  readonly model: ContourFeatureModel;
+  /** The source format of the scan the contours were derived from (fixes the frame). */
+  readonly format: SourceFormat;
+  /** The scan's render-recentre origin, so the lines land over their own terrain. */
+  readonly renderOrigin: readonly [number, number, number] | null;
+  /** Vertical exaggeration currently applied to the scene. Default 1. */
+  readonly zScale?: number;
+}
+
+/** Colours, chosen to read against both the dark and light scene presets. */
+const SOLID_RGB: readonly [number, number, number] = [0.36, 0.85, 1.0];
+const DASHED_RGB: readonly [number, number, number] = [0.55, 0.66, 0.74];
+/** Index (bold) contours are the same hue, brighter — emphasis, not a new class. */
+const INDEX_GAIN = 1.25;
+/** Interpolated support also drops alpha, so it recedes as well as desaturates. */
+const DASHED_ALPHA = 0.55;
+
+const GRADE_SOLID = 0;
+
+export class ContourOverlay {
+  private readonly _host: ContourOverlayHost;
+  private _lines: THREE.LineSegments | null = null;
+  private _geometry: THREE.BufferGeometry | null = null;
+  private _material: THREE.LineBasicNodeMaterial | null = null;
+  private _verticalAxis: 'z' | 'y' = 'z';
+  private _basePosition: [number, number, number] = [0, 0, 0];
+  private _heightOffset = 0;
+  private _visible = true;
+  private _opacity = 1;
+  private _indexEmphasis = true;
+  /** Segment count of the current upload — 0 when nothing is drawn. */
+  private _segmentCount = 0;
+
+  constructor(host: ContourOverlayHost) {
+    this._host = host;
+  }
+
+  /** Segments currently uploaded. 0 means the overlay draws nothing. */
+  get segmentCount(): number {
+    return this._segmentCount;
+  }
+
+  /** The scene object, for a host that needs to inspect it. Null before the first build. */
+  get object(): THREE.Object3D | null {
+    return this._lines;
+  }
+
+  /**
+   * Build (or rebuild) the drawn geometry from an analysed contour model. Safe to
+   * call repeatedly: the previous GPU resources are released first, so a
+   * re-analysis cannot leak buffers.
+   */
+  setModel(input: ContourOverlayInput): void {
+    const { verticalAxis, negateNorthing } = overlayBufferParamsFor(input.format);
+    const buffers = buildContourOverlayBuffers(input.model, {
+      verticalAxis,
+      negateNorthing,
+      zScale: input.zScale ?? 1,
+    });
+    this._verticalAxis = overlayVerticalAxisFor(input.format);
+    this._basePosition = overlayScenePosition(input.renderOrigin);
+    this._upload(buffers);
+    this._applyTransform();
+    this._applyMaterialState();
+    this._host.requestFrame?.();
+  }
+
+  /** Show or hide without discarding the uploaded geometry. */
+  setVisible(visible: boolean): void {
+    this._visible = visible;
+    this._applyMaterialState();
+    this._host.requestFrame?.();
+  }
+
+  /** 0..1, clamped. */
+  setOpacity(opacity: number): void {
+    const o = Number.isFinite(opacity) ? opacity : 1;
+    this._opacity = o < 0 ? 0 : o > 1 ? 1 : o;
+    this._applyMaterialState();
+    this._host.requestFrame?.();
+  }
+
+  /** Brighten index (bold) contours. Emphasis only — geometry is untouched. */
+  setIndexEmphasis(on: boolean): void {
+    if (this._indexEmphasis === on) return;
+    this._indexEmphasis = on;
+    // The emphasis is baked into the vertex colours, so it needs a recolour of
+    // the existing upload rather than a material flag.
+    this._recolour();
+    this._host.requestFrame?.();
+  }
+
+  /**
+   * Lift the lines along the scene's vertical axis so they sit ON the surface.
+   * Display only: the contour elevations are unchanged.
+   */
+  setHeightOffset(offset: number): void {
+    this._heightOffset = Number.isFinite(offset) ? offset : 0;
+    this._applyTransform();
+    this._host.requestFrame?.();
+  }
+
+  /** Remove from the scene and release every GPU resource. Idempotent. */
+  dispose(): void {
+    if (this._lines) this._host.remove(this._lines);
+    this._geometry?.dispose();
+    this._material?.dispose();
+    this._lines = null;
+    this._geometry = null;
+    this._material = null;
+    this._segmentCount = 0;
+    this._host.requestFrame?.();
+  }
+
+  // ── internals ────────────────────────────────────────────────────────────
+
+  /** Replace the uploaded geometry with `buffers`, creating the object if needed. */
+  private _upload(buffers: ContourOverlayBuffers): void {
+    // Drop the previous upload first: a re-analysis replaces every vertex, and
+    // reusing a geometry sized for the old model would leave a stale tail drawn.
+    if (this._lines) this._host.remove(this._lines);
+    this._geometry?.dispose();
+
+    this._segmentCount = buffers.segmentCount;
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(buffers.positions, 3));
+    geometry.setAttribute(
+      'color',
+      new THREE.BufferAttribute(vertexColours(buffers, this._indexEmphasis), 3),
+    );
+    this._geometry = geometry;
+    // Kept so a later recolour knows what each vertex was, without re-deriving.
+    this._grades = buffers.grades;
+    this._isIndex = buffers.isIndex;
+
+    if (!this._material) {
+      const material = new THREE.LineBasicNodeMaterial();
+      material.vertexColors = true;
+      material.transparent = true;
+      // Contours describe the surface under them; drawn without depth-write they
+      // stay visible where the cloud is dense without punching a hole in it.
+      material.depthWrite = false;
+      this._material = material;
+    }
+
+    const lines = new THREE.LineSegments(geometry, this._material);
+    // Derived overlays draw after the cloud so a thin line is not swallowed by
+    // point splats at the same depth.
+    lines.renderOrder = 2;
+    // The scan can be far from the scene origin; its own bounds are meaningless
+    // for culling once the object is offset to the render origin.
+    lines.frustumCulled = false;
+    this._lines = lines;
+    this._host.add(lines);
+  }
+
+  private _grades: Uint8Array = new Uint8Array(0);
+  private _isIndex: Uint8Array = new Uint8Array(0);
+
+  /** Rebuild the colour attribute in place from the retained grade/index arrays. */
+  private _recolour(): void {
+    if (!this._geometry || this._segmentCount === 0) return;
+    const colours = vertexColours(
+      { segmentCount: this._segmentCount, grades: this._grades, isIndex: this._isIndex },
+      this._indexEmphasis,
+    );
+    const attr = this._geometry.getAttribute('color') as THREE.BufferAttribute | undefined;
+    if (attr && attr.array.length === colours.length) {
+      (attr.array as Float32Array).set(colours);
+      attr.needsUpdate = true;
+    } else {
+      this._geometry.setAttribute('color', new THREE.BufferAttribute(colours, 3));
+    }
+  }
+
+  private _applyTransform(): void {
+    if (!this._lines) return;
+    const lift = overlayHeightOffsetVector(this._verticalAxis, this._heightOffset);
+    this._lines.position.set(
+      this._basePosition[0] + lift[0],
+      this._basePosition[1] + lift[1],
+      this._basePosition[2] + lift[2],
+    );
+  }
+
+  private _applyMaterialState(): void {
+    if (this._lines) this._lines.visible = this._visible && this._segmentCount > 0;
+    if (this._material) this._material.opacity = this._opacity;
+  }
+}
+
+/**
+ * Per-VERTEX colours from per-SEGMENT grades: two vertices per segment, so each
+ * segment's colour is written twice. Exported for the unit test, which is what
+ * pins the evidence-honesty mapping (interpolated support must not render the
+ * same as measured support).
+ */
+export function vertexColours(
+  buffers: Pick<ContourOverlayBuffers, 'segmentCount' | 'grades' | 'isIndex'>,
+  indexEmphasis: boolean,
+): Float32Array {
+  const out = new Float32Array(buffers.segmentCount * 6);
+  for (let s = 0; s < buffers.segmentCount; s++) {
+    const solid = buffers.grades[s] === GRADE_SOLID;
+    const base = solid ? SOLID_RGB : DASHED_RGB;
+    const gain = indexEmphasis && buffers.isIndex[s] === 1 ? INDEX_GAIN : 1;
+    // Interpolated support recedes: dimmer hue AND lower alpha. Alpha rides in
+    // the colour here because the material's opacity is the layer-wide control.
+    const a = solid ? 1 : DASHED_ALPHA;
+    const r = Math.min(1, base[0] * gain * a);
+    const g = Math.min(1, base[1] * gain * a);
+    const b = Math.min(1, base[2] * gain * a);
+    const o = s * 6;
+    out[o] = r;
+    out[o + 1] = g;
+    out[o + 2] = b;
+    out[o + 3] = r;
+    out[o + 4] = g;
+    out[o + 5] = b;
+  }
+  return out;
+}

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -3048,6 +3048,26 @@ export class Viewer {
     this._bumpRenderActivity();
   }
 
+  /**
+   * The scene-attach seam for DERIVED-LAYER overlays (contours today; the other
+   * analytical products next). Structural — the same shape as the sky and
+   * snapshot hosts — so the overlay module owns its own three.js objects and
+   * their disposal, and the Viewer lends only scene membership plus a redraw
+   * request. Deliberately not a `setContourOverlay`: the Viewer must not learn
+   * one product's lifecycle, or every future derived layer adds another method.
+   */
+  derivedLayerHost(): {
+    add(object: THREE.Object3D): void;
+    remove(object: THREE.Object3D): void;
+    requestFrame(): void;
+  } {
+    return {
+      add: (object) => { this._scene.add(object); },
+      remove: (object) => { this._scene.remove(object); },
+      requestFrame: () => { this.requestFrame(); },
+    };
+  }
+
   // ── B.3 — classification editor ─────────────────────────────────────────
   /**
    * Per-cloud snapshot of the classification buffer taken before the last

--- a/src/render/contourOverlayPlacement.ts
+++ b/src/render/contourOverlayPlacement.ts
@@ -1,0 +1,90 @@
+/**
+ * contourOverlayPlacement.ts
+ *
+ * The PURE half of drawing analysed contours in the 3D scene: which vertical
+ * axis the overlay buffers must be built for, and where the resulting object
+ * sits. No three.js here, so the part that is easy to get silently wrong — the
+ * frame — is unit-tested in Node; `ContourOverlay` is the thin binding that
+ * uploads the buffers.
+ *
+ * WHY A FRAME DECISION EXISTS AT ALL. Contours are computed in the canonical
+ * Z-up survey frame (the terrain gather rotates Y-up sources first — see
+ * `terrain/canonicalFrame.ts`), but the scene draws each cloud in its OWN
+ * source frame: a LAS/LAZ/E57 cloud is Z-up, a phone-scan mesh (glTF/OBJ/PLY)
+ * is Y-up. So the overlay has to be placed into the frame of the scan it
+ * describes, not into a fixed one.
+ *
+ * The trap this module exists to close: for a Y-up scan it is tempting to "just
+ * put the elevation in Y" (`(x, y, z) → (x, z, y)`). That is a REFLECTION. It
+ * mirrors the northing, so every contour draws on the wrong side of the scan —
+ * wrong in a way that still looks like a contour map, because the lines
+ * themselves are real. The correct inverse is the rotation
+ * `(x, y, z) → (x, z, −y)` (`canonicalZUpToYUp`). The overlay gets that by
+ * BUILDING its buffers with `verticalAxis: 'y'` AND `negateNorthing: true` —
+ * both, since the axis choice alone is the reflection. `overlayBufferParamsFor`
+ * below is the one place that pairing is decided, so a caller cannot take half
+ * of it.
+ */
+
+import type { OverlayVerticalAxis } from '../terrain/contour/contourOverlayGeometry';
+import { isZUpFormat } from '../io/sniffFormat';
+import type { SourceFormat } from '../io/sniffFormat';
+
+/**
+ * The scene vertical axis for a scan's source format: 'z' for the survey
+ * formats (LAS/LAZ/XYZ/E57/PCD/PTX/PTS), 'y' for the mesh formats the scene
+ * draws Y-up. Mirrors the axis the Viewer already colours elevation by, so an
+ * overlay can never disagree with the cloud it is drawn over.
+ */
+export function overlayVerticalAxisFor(format: SourceFormat): OverlayVerticalAxis {
+  return isZUpFormat(format) ? 'z' : 'y';
+}
+
+/**
+ * The buffer-build parameters for a scan's format: the vertical axis AND the
+ * northing sign, together.
+ *
+ * They are returned as one object on purpose. `verticalAxis: 'y'` on its own is
+ * the reflection described above; it is only a rotation when paired with
+ * `negateNorthing: true`. Handing callers the pair — rather than two functions
+ * they must remember to call together — is what makes the mirrored-contour bug
+ * unreachable from the wiring.
+ */
+export function overlayBufferParamsFor(format: SourceFormat): {
+  readonly verticalAxis: OverlayVerticalAxis;
+  readonly negateNorthing: boolean;
+} {
+  const verticalAxis = overlayVerticalAxisFor(format);
+  return { verticalAxis, negateNorthing: verticalAxis === 'y' };
+}
+
+/**
+ * The scene position for the overlay object: the same render-origin offset the
+ * cloud's own mesh carries, so the contours sit exactly over the terrain they
+ * were derived from rather than at the world origin.
+ *
+ * `null`/absent origin means the cloud is not recentred, so the overlay sits at
+ * the scene origin too.
+ */
+export function overlayScenePosition(
+  renderOrigin: readonly [number, number, number] | null | undefined,
+): [number, number, number] {
+  if (!renderOrigin) return [0, 0, 0];
+  return [renderOrigin[0], renderOrigin[1], renderOrigin[2]];
+}
+
+/**
+ * Lift the lines slightly along the scene's vertical axis so they read ON the
+ * surface instead of z-fighting the points that generated them. Returns the
+ * per-axis offset to add to the object's position.
+ *
+ * The offset is a DISPLAY nudge only: it never changes the contour elevations
+ * the geometry, the readouts, or any export carry.
+ */
+export function overlayHeightOffsetVector(
+  axis: OverlayVerticalAxis,
+  heightOffset: number,
+): [number, number, number] {
+  const h = Number.isFinite(heightOffset) ? heightOffset : 0;
+  return axis === 'y' ? [0, h, 0] : [0, 0, h];
+}

--- a/src/science/derivedLayerReceipt.ts
+++ b/src/science/derivedLayerReceipt.ts
@@ -1,0 +1,74 @@
+/**
+ * derivedLayerReceipt.ts — the scientific receipt for a DERIVED LAYER.
+ *
+ * A derived layer (contours today; the other analytical products next) is shown
+ * in the 3D scene and can outlive the panel that produced it, so "what produced
+ * this, and was the software allowed to claim it" has to travel WITH the layer
+ * rather than only with an export. This module is that bridge: analysis result
+ * in, receipt out.
+ *
+ * WHY IT IS BUILT FROM THE EXPORT PROVENANCE PATH. `buildExportProvenance` is
+ * already the one place that resolves a run's CRS honesty, coverage, registered
+ * methods and evidence verdict from the result, and `analysisRecordFromProvenance`
+ * is already the canonical record for it. Re-deriving any of that here would be a
+ * second source of truth that could disagree with the exported file about the
+ * same run — the exact drift the provenance layer exists to prevent. Every
+ * EXPORT-specific option (basename, permit, deliverable purpose) is deliberately
+ * left unset: a layer is not a file, and a receipt that named an export permit
+ * the layer never had would be an overclaim.
+ *
+ * Pure and clock-free: `generatedAt` is injected, never read from the wall clock,
+ * so a receipt is reproducible and byte-stable for a given run.
+ */
+
+import type { AnalyseContoursResult } from '../terrain/contour/analyseContours';
+import {
+  buildExportProvenance,
+  analysisRecordFromProvenance,
+} from '../terrain/export/exportProvenance';
+import {
+  buildScientificReceipt,
+  receiptToJson,
+  renderReceiptText,
+  type ScientificReceipt,
+} from './scientificReceipt';
+
+export interface DerivedLayerReceiptInput {
+  readonly result: AnalyseContoursResult;
+  /**
+   * The run's timestamp. REQUIRED and injected — defaulting to `new Date()`
+   * would make the receipt (and its digest) differ between two identical runs,
+   * which is precisely what a fingerprint must not do.
+   */
+  readonly generatedAt: Date | string;
+  /** The process-gate reason the run was authorised from, when it was gated. */
+  readonly authorizationGrantedFrom?: string | null;
+}
+
+/** Build the receipt describing the analysis a derived layer came from. */
+export function buildDerivedLayerReceipt(input: DerivedLayerReceiptInput): ScientificReceipt {
+  const provenance = buildExportProvenance(input.result, {
+    generatedAt: input.generatedAt,
+  });
+  return buildScientificReceipt(analysisRecordFromProvenance(provenance), {
+    authorizationGrantedFrom: input.authorizationGrantedFrom ?? null,
+  });
+}
+
+/**
+ * The receipt's identity digest — what a `DerivedLayer.provenanceDigest` holds.
+ * Identifies a run; it is not a tamper seal.
+ */
+export function derivedLayerReceiptDigest(receipt: ScientificReceipt): string {
+  return receipt.digest;
+}
+
+/** The receipt as canonical JSON, for copy / export / embedding in a report. */
+export function derivedLayerReceiptJson(receipt: ScientificReceipt): string {
+  return receiptToJson(receipt);
+}
+
+/** The receipt as readable text, for a "view receipt" surface. */
+export function derivedLayerReceiptText(receipt: ScientificReceipt): string {
+  return renderReceiptText(receipt);
+}

--- a/src/styles/92-terrain-verdict.css
+++ b/src/styles/92-terrain-verdict.css
@@ -435,6 +435,35 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
   font-size: var(--text-2xs); color: var(--text-dim);
   width: 34px; text-align: right; flex: 0 0 auto; font-variant-numeric: tabular-nums;
 }
+/* ── Derived-layer controls (contours drawn in the 3D scene) ─────────────────
+   Same control vocabulary as the relief sliders above, so a layer reads as part
+   of the same panel rather than a new kind of surface. */
+.olv-analyse-layer-controls {
+  display: flex; flex-direction: column; gap: var(--space-2xs);
+  margin-top: var(--space-md); padding-top: var(--space-md);
+  border-top: 0.5px solid var(--hairline);
+}
+.olv-analyse-layer-head {
+  font-size: var(--text-2xs); font-weight: 700; letter-spacing: 0.9px;
+  text-transform: uppercase; color: var(--text-faint);
+}
+.olv-analyse-layer-row { display: flex; align-items: center; gap: var(--space-lg); flex-wrap: wrap; }
+.olv-analyse-layer-toggle {
+  display: flex; align-items: center; gap: var(--space-sm); cursor: pointer;
+  font-size: var(--text-xs); color: var(--text-dim); user-select: none;
+}
+.olv-analyse-layer-toggle input { accent-color: var(--accent); cursor: pointer; }
+.olv-analyse-layer-slider { display: flex; align-items: center; gap: var(--space-md); }
+.olv-analyse-layer-tag {
+  font-size: var(--text-2xs); text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--text-faint); width: 46px; flex: 0 0 auto;
+}
+.olv-analyse-layer-slider input[type='range'] { flex: 1 1 auto; accent-color: var(--accent); min-width: 0; }
+.olv-analyse-layer-val {
+  font-size: var(--text-2xs); color: var(--text-dim);
+  width: 46px; text-align: right; flex: 0 0 auto; font-variant-numeric: tabular-nums;
+}
+
 /* Click-to-sample readout under a raster tile. */
 .olv-analyse-raster.is-samplable { cursor: crosshair; }
 .olv-analyse-sample {

--- a/src/terrain/contour/contourOverlayGeometry.ts
+++ b/src/terrain/contour/contourOverlayGeometry.ts
@@ -53,6 +53,17 @@ export interface OverlayGeometryParams {
   readonly zScale?: number;
   /** Include gap-grade segments (drawn as faint breaks). Default false. */
   readonly includeGap?: boolean;
+  /**
+   * Negate the northing as it is placed. Default false.
+   *
+   * This is what completes the Y-up placement into a ROTATION. With
+   * `verticalAxis: 'y'` alone a canonical Z-up point `(x, north, elev)` lands as
+   * `(x, elev, north)` — a reflection, which mirrors the scan. The exact inverse
+   * (`canonicalZUpToYUp`, `(x, y, z) → (x, z, −y)`) needs `(x, elev, −north)`,
+   * so a Y-up scene sets this. Meaningless for `verticalAxis: 'z'`, where the
+   * northing already sits on its own axis unchanged.
+   */
+  readonly negateNorthing?: boolean;
 }
 
 /**
@@ -67,6 +78,7 @@ export function buildContourOverlayBuffers(
   const vertical = params.verticalAxis ?? 'z';
   const zScale = Number.isFinite(params.zScale) ? (params.zScale as number) : 1;
   const includeGap = params.includeGap ?? false;
+  const northSign = params.negateNorthing ? -1 : 1;
 
   // Count segments first so we can allocate exact typed arrays.
   let segCount = 0;
@@ -83,13 +95,14 @@ export function buildContourOverlayBuffers(
   let s = 0;
   const place = (x: number, y: number, elev: number) => {
     const e = elev * zScale;
+    const n = y * northSign;
     if (vertical === 'y') {
       positions[p++] = x;
       positions[p++] = e;
-      positions[p++] = y;
+      positions[p++] = n;
     } else {
       positions[p++] = x;
-      positions[p++] = y;
+      positions[p++] = n;
       positions[p++] = e;
     }
   };

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -28,6 +28,37 @@
  */
 
 import type { AnalyseContoursResult } from '../terrain/contour/analyseContours';
+
+/**
+ * What the panel needs to drive the contours derived layer. Every handler
+ * RETURNS the value that was actually applied (or null when the layer is gone),
+ * so the control re-reads the truth instead of assuming its own click won — the
+ * record stays authoritative and the UI cannot drift from what is drawn.
+ */
+export interface ContourLayerControls {
+  readonly visible: boolean;
+  /** 0..1. */
+  readonly opacity: number;
+  readonly indexEmphasis: boolean;
+  /** Display lift along the scene vertical axis, in the scan's vertical unit. */
+  readonly heightOffset: number;
+  /** e.g. "m" / "ft"; null when the file declares no vertical unit. */
+  readonly verticalUnitLabel: string | null;
+  onVisible(next: boolean): boolean | null;
+  onOpacity(next: number): number | null;
+  onIndexEmphasis(next: boolean): boolean | null;
+  onHeightOffset(next: number): number | null;
+}
+
+/**
+ * Label a display lift. An unknown vertical unit prints the bare number rather
+ * than inventing "m" — the same fail-honest rule the metric readouts follow.
+ */
+function formatHeightOffset(offset: number, unitLabel: string | null): string {
+  const n = Number.isFinite(offset) ? offset : 0;
+  const shown = n.toFixed(2).replace(/\.?0+$/, '') || '0';
+  return unitLabel ? `${shown} ${unitLabel}` : shown;
+}
 import {
   ANALYSE_LABELS,
   GRADE_MEANING,
@@ -378,6 +409,8 @@ export class AnalysePanel {
    * `_contourDeliverable`, hidden until the launcher's action is invoked.
    */
   private readonly _contourLauncher: HTMLElement;
+  /** Host for the 3D contour derived-layer controls; empty until a layer is drawn. */
+  private readonly _contourLayerControls: HTMLElement;
   private readonly _contourDeliverable: HTMLElement;
   /** Monotonic token so a slow lazy launcher load can't mount a stale result. */
   private _contourToken = 0;
@@ -514,6 +547,7 @@ export class AnalysePanel {
     // Studio export section dispatches to, so every exporter's guards, provenance
     // and busy-state are reused verbatim rather than re-implemented.
     this._contourLauncher = el('div', { className: 'olv-analyse-contour-launcher' });
+    this._contourLayerControls = el('div', { className: 'olv-analyse-layer-controls olv-hidden' });
     this._contourDeliverable = el('div', {
       className: 'olv-analyse-contour-deliverable olv-hidden',
     });
@@ -555,7 +589,7 @@ export class AnalysePanel {
     // own "Terrain Products" eyebrow; this wrapper just groups + spaces it. Only
     // the stale caveat outranks it, so a stale verdict is never read as current.
     const terrainProducts = el('div', { className: 'olv-analyse-products' });
-    terrainProducts.append(this._contourLauncher, this._contourDeliverable);
+    terrainProducts.append(this._contourLauncher, this._contourLayerControls, this._contourDeliverable);
 
     this._resultsRegion.append(
       this._staleNotice,
@@ -692,6 +726,93 @@ export class AnalysePanel {
    * launcher's action. `null` (or no current result) clears the launcher.
    * Honesty-first: label + enabled state come from the computed launch state.
    */
+  /**
+   * Show (or clear) the controls for the CONTOURS derived layer drawn in the 3D
+   * scene. Passing null hides the group — there is no layer to drive, so an
+   * inert control would imply one exists.
+   *
+   * The panel owns no layer state: every control reports the user's intent and
+   * re-reads what the service actually applied, so the record stays the single
+   * source of truth and the UI can never drift from what is drawn.
+   */
+  setContourLayerControls(controls: ContourLayerControls | null): void {
+    const host = this._contourLayerControls;
+    host.replaceChildren();
+    if (!controls) {
+      host.classList.add('olv-hidden');
+      return;
+    }
+    host.classList.remove('olv-hidden');
+    host.append(el('div', { className: 'olv-analyse-layer-head', text: 'Contours in 3D' }));
+
+    const row = el('div', { className: 'olv-analyse-layer-row' });
+
+    // Visibility.
+    const visLabel = el('label', { className: 'olv-analyse-layer-toggle' });
+    const visCb = document.createElement('input');
+    visCb.type = 'checkbox';
+    visCb.checked = controls.visible;
+    visCb.setAttribute('aria-label', 'Show contours in the 3D scene');
+    visLabel.append(visCb, el('span', { text: 'Show' }));
+
+    // Index emphasis.
+    const idxLabel = el('label', { className: 'olv-analyse-layer-toggle' });
+    const idxCb = document.createElement('input');
+    idxCb.type = 'checkbox';
+    idxCb.checked = controls.indexEmphasis;
+    idxCb.setAttribute('aria-label', 'Emphasise index contours');
+    idxLabel.append(idxCb, el('span', { text: 'Index emphasis' }));
+    row.append(visLabel, idxLabel);
+
+    // Opacity.
+    const opRow = el('label', { className: 'olv-analyse-layer-slider' });
+    const opVal = el('span', {
+      className: 'olv-analyse-layer-val',
+      text: `${Math.round(controls.opacity * 100)}%`,
+    });
+    const opInput = document.createElement('input');
+    opInput.type = 'range'; opInput.min = '0'; opInput.max = '100'; opInput.step = '5';
+    opInput.value = String(Math.round(controls.opacity * 100));
+    opInput.setAttribute('aria-label', 'Contour layer opacity');
+    opRow.append(el('span', { className: 'olv-analyse-layer-tag', text: 'Opacity' }), opInput, opVal);
+
+    // Height offset — a DISPLAY lift so the lines read on the surface rather
+    // than z-fighting the points. Labelled in the scan's own vertical unit, and
+    // never presented as a change to the contour elevations.
+    const hOff = el('label', { className: 'olv-analyse-layer-slider' });
+    const hVal = el('span', {
+      className: 'olv-analyse-layer-val',
+      text: formatHeightOffset(controls.heightOffset, controls.verticalUnitLabel),
+    });
+    const hInput = document.createElement('input');
+    hInput.type = 'range'; hInput.min = '0'; hInput.max = '200'; hInput.step = '5';
+    hInput.value = String(Math.round(controls.heightOffset * 100));
+    hInput.setAttribute('aria-label', 'Contour layer height offset (display only)');
+    hOff.append(el('span', { className: 'olv-analyse-layer-tag', text: 'Lift' }), hInput, hVal);
+
+    visCb.addEventListener('change', () => {
+      // Re-read the applied value: the service, not the checkbox, decides.
+      const applied = controls.onVisible(visCb.checked);
+      visCb.checked = applied ?? visCb.checked;
+    });
+    idxCb.addEventListener('change', () => {
+      const applied = controls.onIndexEmphasis(idxCb.checked);
+      idxCb.checked = applied ?? idxCb.checked;
+    });
+    opInput.addEventListener('input', () => {
+      const next = Number(opInput.value) / 100;
+      const applied = controls.onOpacity(next) ?? next;
+      opVal.textContent = `${Math.round(applied * 100)}%`;
+    });
+    hInput.addEventListener('input', () => {
+      const next = Number(hInput.value) / 100;
+      const applied = controls.onHeightOffset(next) ?? next;
+      hVal.textContent = formatHeightOffset(applied, controls.verticalUnitLabel);
+    });
+
+    host.append(row, opRow, hOff);
+  }
+
   setContourFrame(ctx: LaunchFrameContext | null): void {
     const token = ++this._contourToken; // any new call supersedes a pending mount
     this._contourLauncher.replaceChildren();

--- a/tests/contourLayerService.test.ts
+++ b/tests/contourLayerService.test.ts
@@ -1,0 +1,212 @@
+/**
+ * contourLayerService.test.ts
+ *
+ * The contours derived-layer lifecycle. The two invariants under test are the
+ * reason the service exists at all:
+ *
+ *  - a RE-ANALYSIS replaces the drawn geometry and bumps the record's
+ *    generation — it never leaves the old overlay stacked behind the new one;
+ *  - a CLOSED scan takes its derived layers with it, and closing a BACKGROUND
+ *    scan never blanks the contours of the one on screen.
+ *
+ * The overlay is faked, so this stays pure orchestration with no three.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createContourLayerService,
+  contourLayerId,
+  type ContourLayerInput,
+} from '../src/app/contourLayerService';
+import { DerivedLayerStore } from '../src/model/DerivedLayer';
+import type { ContourOverlay } from '../src/render/ContourOverlay';
+import type { ContourFeatureModel } from '../src/terrain/contour/contourFeatureModel';
+
+const MODEL = { features: [] } as unknown as ContourFeatureModel;
+
+/** Records every call the service makes onto the overlay. */
+function fakeOverlay() {
+  const calls: string[] = [];
+  const state = {
+    models: 0,
+    visible: null as boolean | null,
+    opacity: null as number | null,
+    heightOffset: null as number | null,
+    indexEmphasis: null as boolean | null,
+    disposed: 0,
+  };
+  const overlay = {
+    setModel: () => { state.models++; calls.push('setModel'); },
+    setVisible: (v: boolean) => { state.visible = v; calls.push('setVisible'); },
+    setOpacity: (o: number) => { state.opacity = o; calls.push('setOpacity'); },
+    setHeightOffset: (h: number) => { state.heightOffset = h; calls.push('setHeightOffset'); },
+    setIndexEmphasis: (b: boolean) => { state.indexEmphasis = b; calls.push('setIndexEmphasis'); },
+    dispose: () => { state.disposed++; calls.push('dispose'); },
+  } as unknown as ContourOverlay;
+  return { overlay, state, calls };
+}
+
+function setup() {
+  const made: ReturnType<typeof fakeOverlay>[] = [];
+  const store = new DerivedLayerStore();
+  const service = createContourLayerService({
+    host: { add: () => {}, remove: () => {} },
+    store,
+    makeOverlay: () => {
+      const f = fakeOverlay();
+      made.push(f);
+      return f.overlay;
+    },
+  });
+  return { service, store, made };
+}
+
+const input = (over: Partial<ContourLayerInput> = {}): ContourLayerInput => ({
+  scanId: 'scan-a',
+  model: MODEL,
+  format: 'las',
+  renderOrigin: [1, 2, 3],
+  ...over,
+});
+
+describe('createContourLayerService — show', () => {
+  it('registers a contours layer owned by its source scan and draws it', () => {
+    const { service, store } = setup();
+    const layer = service.show(input());
+    expect(layer.type).toBe('contours');
+    expect(layer.id).toBe(contourLayerId('scan-a'));
+    expect(layer.sourceScanIds).toEqual(['scan-a']);
+    expect(layer.generation).toBe(1);
+    expect(store.list()).toHaveLength(1);
+  });
+
+  it('carries the analysis honesty facts onto the record', () => {
+    const { service } = setup();
+    const layer = service.show(
+      input({ coverage: 'resident-only', evidenceExploratory: true, provenanceDigest: 'abc123' }),
+    );
+    expect(layer.coverage).toBe('resident-only');
+    expect(layer.evidenceExploratory).toBe(true);
+    expect(layer.provenanceDigest).toBe('abc123');
+  });
+
+  it('re-analysis REGENERATES: one layer, generation bumped, one overlay reused', () => {
+    const { service, store, made } = setup();
+    service.show(input());
+    const again = service.show(input());
+    expect(again.generation).toBe(2);
+    expect(store.list()).toHaveLength(1);
+    // One overlay across both analyses — a second would be the stale-overlay bug.
+    expect(made).toHaveLength(1);
+    expect(made[0].state.models).toBe(2);
+  });
+
+  it('a regeneration PRESERVES the display state the user chose, and re-paints it', () => {
+    // Regression: `store.put` replaces the record, so without carrying the
+    // previous display state a background re-analysis would snap a hidden or
+    // faded layer back to fully visible — undoing the user's choice silently.
+    const { service, made } = setup();
+    service.show(input());
+    service.setVisible('scan-a', false);
+    service.setOpacity('scan-a', 0.3);
+    service.setHeightOffset('scan-a', 0.25);
+    service.setIndexEmphasis('scan-a', false);
+
+    const regenerated = service.show(input());
+
+    // The record kept every choice...
+    expect(regenerated.visible).toBe(false);
+    expect(regenerated.opacity).toBeCloseTo(0.3, 6);
+    expect(regenerated.style.heightOffset).toBe(0.25);
+    expect(regenerated.style.indexEmphasis).toBe(false);
+    // ...and the freshly built geometry was painted with all of it.
+    expect(made[0].state.visible).toBe(false);
+    expect(made[0].state.opacity).toBeCloseTo(0.3, 6);
+    expect(made[0].state.heightOffset).toBe(0.25);
+    expect(made[0].state.indexEmphasis).toBe(false);
+  });
+});
+
+describe('createContourLayerService — display controls', () => {
+  it('visibility and opacity update both the record and the drawn overlay', () => {
+    const { service, made } = setup();
+    service.show(input());
+    expect(service.setVisible('scan-a', false)?.visible).toBe(false);
+    expect(service.setOpacity('scan-a', 0.5)?.opacity).toBeCloseTo(0.5, 6);
+    expect(made[0].state.visible).toBe(false);
+    expect(made[0].state.opacity).toBeCloseTo(0.5, 6);
+  });
+
+  it('height offset and index emphasis are recorded as style and painted', () => {
+    const { service, made } = setup();
+    service.show(input());
+    expect(service.setHeightOffset('scan-a', 0.25)?.style.heightOffset).toBe(0.25);
+    expect(service.setIndexEmphasis('scan-a', false)?.style.indexEmphasis).toBe(false);
+    expect(made[0].state.heightOffset).toBe(0.25);
+    expect(made[0].state.indexEmphasis).toBe(false);
+  });
+
+  it('a control for an unknown scan is a no-op, not a throw', () => {
+    const { service, made } = setup();
+    service.show(input());
+    expect(service.setVisible('scan-zzz', false)).toBeUndefined();
+    // The on-screen overlay is untouched by a control for another scan.
+    expect(made[0].state.visible).toBe(true);
+  });
+
+  it('controls for a BACKGROUND scan update its record without repainting the screen', () => {
+    const { service, made } = setup();
+    service.show(input({ scanId: 'scan-a' }));
+    service.show(input({ scanId: 'scan-b' })); // scan-b is now drawn
+    const drawnCalls = made[0].calls.length;
+    const rec = service.setVisible('scan-a', false); // background scan
+    expect(rec?.visible).toBe(false); // record updated
+    expect(made[0].calls.length).toBe(drawnCalls); // nothing repainted
+  });
+});
+
+describe('createContourLayerService — scan lifetime', () => {
+  it('closing the scan drops its layers and stops drawing them', () => {
+    const { service, store, made } = setup();
+    service.show(input());
+    service.clearForScan('scan-a');
+    expect(store.list()).toHaveLength(0);
+    expect(service.layerFor('scan-a')).toBeUndefined();
+    expect(made[0].state.disposed).toBe(1);
+  });
+
+  it('closing a BACKGROUND scan never blanks the contours on screen', () => {
+    const { service, store, made } = setup();
+    service.show(input({ scanId: 'scan-a' }));
+    service.show(input({ scanId: 'scan-b' })); // scan-b drawn
+    service.clearForScan('scan-a'); // close the background scan
+    expect(store.list().map((l) => l.id)).toEqual([contourLayerId('scan-b')]);
+    expect(made[0].state.disposed).toBe(0); // still drawing scan-b
+  });
+
+  it('a scan re-shown after closing gets a FRESH overlay and generation 1', () => {
+    const { service, made } = setup();
+    service.show(input());
+    service.clearForScan('scan-a');
+    const layer = service.show(input());
+    expect(layer.generation).toBe(1);
+    expect(made).toHaveLength(2); // the disposed overlay is not reused
+  });
+
+  it('dispose releases the overlay and is idempotent', () => {
+    const { service, made } = setup();
+    service.show(input());
+    service.dispose();
+    expect(made[0].state.disposed).toBe(1);
+    expect(() => service.dispose()).not.toThrow();
+    expect(made[0].state.disposed).toBe(1);
+  });
+
+  it('builds no overlay at all until something is shown', () => {
+    const { service, made } = setup();
+    expect(made).toHaveLength(0);
+    service.clearForScan('scan-a');
+    service.dispose();
+    expect(made).toHaveLength(0);
+  });
+});

--- a/tests/contourOverlay.test.ts
+++ b/tests/contourOverlay.test.ts
@@ -1,0 +1,227 @@
+/**
+ * contourOverlay.test.ts
+ *
+ * The three.js binding that draws analysed contours in the scene. three/webgpu
+ * constructs geometries, materials and objects without a GPU, so the lifecycle
+ * (upload, replace, dispose), the placement, and the evidence-honesty colour
+ * mapping are all provable in Node. What a headless test CANNOT prove is that
+ * the result is visible on screen — that is the browser check, and it is called
+ * out as such rather than implied by these passing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three/webgpu';
+import { ContourOverlay, vertexColours } from '../src/render/ContourOverlay';
+import type { ContourFeatureModel } from '../src/terrain/contour/contourFeatureModel';
+
+/** A host that records what the overlay attaches and detaches. */
+function fakeHost() {
+  const objects: THREE.Object3D[] = [];
+  let frames = 0;
+  return {
+    add: (o: THREE.Object3D) => { objects.push(o); },
+    remove: (o: THREE.Object3D) => {
+      const i = objects.indexOf(o);
+      if (i >= 0) objects.splice(i, 1);
+    },
+    requestFrame: () => { frames++; },
+    objects,
+    get frames() { return frames; },
+  };
+}
+
+/** Two solid segments + one dashed, with one index contour among them. */
+function model(): ContourFeatureModel {
+  return {
+    features: [
+      {
+        value: 10, grade: 'solid', isIndex: true, closed: false, meanConfidence: 90,
+        coordinates: [[0, 0], [10, 0], [20, 5]],
+      },
+      {
+        value: 12, grade: 'dashed', isIndex: false, closed: false, meanConfidence: 40,
+        coordinates: [[0, 8], [10, 8]],
+      },
+    ],
+  } as unknown as ContourFeatureModel;
+}
+
+const zUpInput = (m = model()) =>
+  ({ model: m, format: 'las' as const, renderOrigin: [100, 200, 5] as const });
+
+describe('ContourOverlay — lifecycle', () => {
+  it('attaches one object to the host on first build', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    expect(host.objects).toHaveLength(0);
+    overlay.setModel(zUpInput());
+    expect(host.objects).toHaveLength(1);
+    expect(overlay.segmentCount).toBe(3); // 2 from the 3-point line + 1 dashed
+    expect(overlay.object).not.toBeNull();
+  });
+
+  it('rebuilding REPLACES the object — no stale second overlay is left drawn', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    overlay.setModel(zUpInput());
+    const first = overlay.object;
+    overlay.setModel(zUpInput());
+    expect(host.objects).toHaveLength(1);
+    expect(host.objects[0]).not.toBe(first);
+  });
+
+  it('dispose detaches and is idempotent', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    overlay.setModel(zUpInput());
+    overlay.dispose();
+    expect(host.objects).toHaveLength(0);
+    expect(overlay.object).toBeNull();
+    expect(overlay.segmentCount).toBe(0);
+    expect(() => overlay.dispose()).not.toThrow();
+  });
+
+  it('an empty model draws nothing and stays hidden', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    overlay.setModel({ ...zUpInput({ features: [] } as unknown as ContourFeatureModel) });
+    expect(overlay.segmentCount).toBe(0);
+    expect(host.objects[0].visible).toBe(false);
+  });
+
+  it('requests a redraw on every state change', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    overlay.setModel(zUpInput());
+    const after = host.frames;
+    overlay.setVisible(false);
+    overlay.setOpacity(0.5);
+    overlay.setHeightOffset(1);
+    expect(host.frames).toBeGreaterThan(after);
+  });
+});
+
+describe('ContourOverlay — placement', () => {
+  it('sits on the scan render origin so the lines land over their own terrain', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    overlay.setModel(zUpInput());
+    const p = overlay.object!.position;
+    expect([p.x, p.y, p.z]).toEqual([100, 200, 5]);
+  });
+
+  it('height offset lifts along Z for a survey (Z-up) scan', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    overlay.setModel(zUpInput());
+    overlay.setHeightOffset(0.5);
+    const p = overlay.object!.position;
+    expect([p.x, p.y, p.z]).toEqual([100, 200, 5.5]);
+  });
+
+  it('height offset lifts along Y for a Y-up mesh scan', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    overlay.setModel({ model: model(), format: 'gltf', renderOrigin: [0, 0, 0] });
+    overlay.setHeightOffset(2);
+    const p = overlay.object!.position;
+    expect([p.x, p.y, p.z]).toEqual([0, 2, 0]);
+  });
+
+  it('a Y-up scan is built through the rotation, so its northing is negated', () => {
+    const host = fakeHost();
+    const zUp = new ContourOverlay(host);
+    zUp.setModel({ model: model(), format: 'las', renderOrigin: null });
+    const zPos = (zUp.object as THREE.LineSegments).geometry.getAttribute('position');
+
+    const yHost = fakeHost();
+    const yUp = new ContourOverlay(yHost);
+    yUp.setModel({ model: model(), format: 'gltf', renderOrigin: null });
+    const yPos = (yUp.object as THREE.LineSegments).geometry.getAttribute('position');
+
+    // canonicalZUpToYUp: (x, y, z) -> (x, z, -y).
+    for (let i = 0; i < zPos.count; i++) {
+      expect(yPos.getX(i)).toBeCloseTo(zPos.getX(i), 5);
+      expect(yPos.getY(i)).toBeCloseTo(zPos.getZ(i), 5);
+      expect(yPos.getZ(i)).toBeCloseTo(-zPos.getY(i), 5);
+    }
+  });
+
+  it('a non-finite height offset degrades to no lift rather than NaN-ing the object', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    overlay.setModel(zUpInput());
+    overlay.setHeightOffset(Number.NaN);
+    const p = overlay.object!.position;
+    expect(Number.isFinite(p.z)).toBe(true);
+    expect(p.z).toBe(5);
+  });
+});
+
+describe('ContourOverlay — display state', () => {
+  it('setVisible toggles without discarding the upload', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    overlay.setModel(zUpInput());
+    overlay.setVisible(false);
+    expect(overlay.object!.visible).toBe(false);
+    expect(overlay.segmentCount).toBe(3); // geometry retained
+    overlay.setVisible(true);
+    expect(overlay.object!.visible).toBe(true);
+  });
+
+  it('opacity is clamped to 0..1 and survives a rebuild', () => {
+    const host = fakeHost();
+    const overlay = new ContourOverlay(host);
+    overlay.setModel(zUpInput());
+    overlay.setOpacity(2);
+    const mat = (overlay.object as THREE.LineSegments).material as THREE.LineBasicNodeMaterial;
+    expect(mat.opacity).toBe(1);
+    overlay.setOpacity(-1);
+    expect(mat.opacity).toBe(0);
+    overlay.setOpacity(0.4);
+    overlay.setModel(zUpInput());
+    const mat2 = (overlay.object as THREE.LineSegments).material as THREE.LineBasicNodeMaterial;
+    expect(mat2.opacity).toBeCloseTo(0.4, 6);
+  });
+});
+
+describe('vertexColours — evidence honesty', () => {
+  const buffers = (grades: number[], isIndex: number[]) => ({
+    segmentCount: grades.length,
+    grades: Uint8Array.from(grades),
+    isIndex: Uint8Array.from(isIndex),
+  });
+
+  it('interpolated (dashed) support never renders identically to measured (solid)', () => {
+    const c = vertexColours(buffers([0, 1], [0, 0]), true);
+    const solid = [c[0], c[1], c[2]];
+    const dashed = [c[6], c[7], c[8]];
+    expect(solid).not.toEqual(dashed);
+  });
+
+  it('dashed is dimmer than solid on every channel — it recedes, never advances', () => {
+    const c = vertexColours(buffers([0, 1], [0, 0]), true);
+    for (let k = 0; k < 3; k++) expect(c[6 + k]).toBeLessThan(c[k]);
+  });
+
+  it('both vertices of a segment carry the same colour', () => {
+    const c = vertexColours(buffers([0], [0]), true);
+    expect([c[0], c[1], c[2]]).toEqual([c[3], c[4], c[5]]);
+  });
+
+  it('index emphasis brightens an index contour, and turning it off equalises them', () => {
+    const on = vertexColours(buffers([0, 0], [1, 0]), true);
+    expect(on[0] + on[1] + on[2]).toBeGreaterThan(on[6] + on[7] + on[8]);
+    const off = vertexColours(buffers([0, 0], [1, 0]), false);
+    expect([off[0], off[1], off[2]]).toEqual([off[6], off[7], off[8]]);
+  });
+
+  it('every channel stays inside the legal 0..1 range', () => {
+    const c = vertexColours(buffers([0, 1, 0], [1, 1, 0]), true);
+    for (const v of c) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/tests/contourOverlayPlacement.test.ts
+++ b/tests/contourOverlayPlacement.test.ts
@@ -1,0 +1,143 @@
+/**
+ * contourOverlayPlacement.test.ts
+ *
+ * The frame proof for drawing analysed contours in the 3D scene.
+ *
+ * The bug this pins is the mirrored overlay: contours are computed in the
+ * canonical Z-up survey frame, and placing them into a Y-up scene by moving the
+ * elevation alone is a REFLECTION, which draws every contour on the wrong side
+ * of the scan while still looking like a valid contour map. The load-bearing
+ * test composes the Y-up build and asserts it equals the Z-up build put through
+ * `canonicalZUpToYUp` — the exact inverse rotation — so a reflection cannot pass.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  overlayVerticalAxisFor,
+  overlayBufferParamsFor,
+  overlayScenePosition,
+  overlayHeightOffsetVector,
+} from '../src/render/contourOverlayPlacement';
+import { buildContourOverlayBuffers } from '../src/terrain/contour/contourOverlayGeometry';
+import { canonicalZUpToYUp } from '../src/terrain/canonicalFrame';
+import type { ContourFeatureModel } from '../src/terrain/contour/contourFeatureModel';
+
+/**
+ * A model with a deliberately ASYMMETRIC northing span. A mirror is invisible on
+ * a north-symmetric fixture, so the coordinates must not be balanced about 0.
+ */
+function model(): ContourFeatureModel {
+  return {
+    features: [
+      {
+        value: 12,
+        grade: 'solid',
+        isIndex: true,
+        closed: false,
+        meanConfidence: 90,
+        coordinates: [
+          [5, 20],
+          [7, 35],
+          [11, 60],
+        ],
+      },
+    ],
+  } as unknown as ContourFeatureModel;
+}
+
+describe('overlayVerticalAxisFor', () => {
+  it('survey formats draw Z-up; mesh formats draw Y-up', () => {
+    for (const f of ['las', 'laz', 'e57', 'xyz', 'pcd', 'ptx', 'pts'] as const) {
+      expect(overlayVerticalAxisFor(f)).toBe('z');
+    }
+    for (const f of ['gltf', 'obj', 'ply'] as const) {
+      expect(overlayVerticalAxisFor(f)).toBe('y');
+    }
+  });
+});
+
+describe('overlayBufferParamsFor — the axis and the sign travel together', () => {
+  it('Z-up: no negation (the northing keeps its own axis)', () => {
+    expect(overlayBufferParamsFor('las')).toEqual({ verticalAxis: 'z', negateNorthing: false });
+  });
+
+  it('Y-up: negation is REQUIRED, so the placement is a rotation not a mirror', () => {
+    expect(overlayBufferParamsFor('gltf')).toEqual({ verticalAxis: 'y', negateNorthing: true });
+  });
+});
+
+describe('the Y-up overlay build IS the canonical inverse rotation', () => {
+  it('equals canonicalZUpToYUp applied to the Z-up build, vertex for vertex', () => {
+    const m = model();
+    const zUp = buildContourOverlayBuffers(m, { verticalAxis: 'z' });
+    const yUp = buildContourOverlayBuffers(m, overlayBufferParamsFor('gltf'));
+
+    // The reference: rotate the Z-up buffer with the shared inverse transform.
+    const expected = canonicalZUpToYUp(Float32Array.from(zUp.positions));
+
+    expect(yUp.segmentCount).toBe(zUp.segmentCount);
+    expect(yUp.positions.length).toBe(expected.length);
+    expect(yUp.positions.length).toBeGreaterThan(0);
+    for (let i = 0; i < expected.length; i++) {
+      expect(yUp.positions[i]).toBeCloseTo(expected[i], 6);
+    }
+  });
+
+  it('the tempting shortcut (axis only, no negation) does NOT match — it is the mirror', () => {
+    const m = model();
+    const zUp = buildContourOverlayBuffers(m, { verticalAxis: 'z' });
+    const expected = canonicalZUpToYUp(Float32Array.from(zUp.positions));
+    // verticalAxis:'y' WITHOUT negateNorthing — the bug this module exists to stop.
+    const mirrored = buildContourOverlayBuffers(m, { verticalAxis: 'y' });
+
+    let differs = false;
+    for (let i = 0; i < expected.length; i++) {
+      if (Math.abs(mirrored.positions[i] - expected[i]) > 1e-6) {
+        differs = true;
+        break;
+      }
+    }
+    expect(differs).toBe(true);
+  });
+
+  it('negation flips only the northing — easting and elevation are untouched', () => {
+    const m = model();
+    const plain = buildContourOverlayBuffers(m, { verticalAxis: 'y' });
+    const rotated = buildContourOverlayBuffers(m, { verticalAxis: 'y', negateNorthing: true });
+    for (let i = 0; i < plain.positions.length; i += 3) {
+      expect(rotated.positions[i]).toBe(plain.positions[i]); // easting
+      expect(rotated.positions[i + 1]).toBe(plain.positions[i + 1]); // elevation
+      expect(rotated.positions[i + 2]).toBe(-plain.positions[i + 2]); // northing
+    }
+  });
+
+  it('the Z-up build is unchanged by the new option (default off, byte-identical)', () => {
+    const m = model();
+    const before = buildContourOverlayBuffers(m, { verticalAxis: 'z' });
+    const after = buildContourOverlayBuffers(m, { verticalAxis: 'z', negateNorthing: false });
+    expect([...after.positions]).toEqual([...before.positions]);
+  });
+});
+
+describe('overlayScenePosition', () => {
+  it('sits on the cloud render origin so the lines land over their own terrain', () => {
+    expect(overlayScenePosition([10, -20, 3])).toEqual([10, -20, 3]);
+  });
+
+  it('a cloud that was never recentred sits at the scene origin', () => {
+    expect(overlayScenePosition(null)).toEqual([0, 0, 0]);
+    expect(overlayScenePosition(undefined)).toEqual([0, 0, 0]);
+  });
+});
+
+describe('overlayHeightOffsetVector', () => {
+  it('lifts along the scene vertical axis only', () => {
+    expect(overlayHeightOffsetVector('z', 0.5)).toEqual([0, 0, 0.5]);
+    expect(overlayHeightOffsetVector('y', 0.5)).toEqual([0, 0.5, 0]);
+  });
+
+  it('a non-finite offset degrades to no lift rather than NaN-ing the object', () => {
+    expect(overlayHeightOffsetVector('z', Number.NaN)).toEqual([0, 0, 0]);
+    expect(overlayHeightOffsetVector('y', Number.POSITIVE_INFINITY)).toEqual([0, 0, 0]);
+  });
+});

--- a/tests/derivedLayerReceipt.test.ts
+++ b/tests/derivedLayerReceipt.test.ts
@@ -1,0 +1,104 @@
+/**
+ * derivedLayerReceipt.test.ts
+ *
+ * The receipt a DERIVED LAYER carries, so "what produced this, and was the
+ * software allowed to claim it" travels with the layer rather than only with an
+ * export. The load-bearing property is the digest's REPRODUCIBILITY: the
+ * record's fingerprint covers scientific content only — not build, not time —
+ * so two runs over the same data agree, while a run over different data does
+ * not. A digest that drifted with the clock would identify nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { analyseContours } from '../src/terrain/contour/analyseContours';
+import {
+  buildDerivedLayerReceipt,
+  derivedLayerReceiptDigest,
+  derivedLayerReceiptJson,
+  derivedLayerReceiptText,
+} from '../src/science/derivedLayerReceipt';
+import type { TerrainPoint } from '../src/terrain/TerrainContracts';
+
+function hill(scale = 8): TerrainPoint[] {
+  const pts: TerrainPoint[] = [];
+  for (let x = 0; x <= 50; x++) {
+    for (let y = 0; y <= 50; y++) {
+      const dx = x - 25;
+      const dy = y - 25;
+      pts.push({ x, y, z: scale * Math.exp(-(dx * dx + dy * dy) / 400) });
+    }
+  }
+  return pts;
+}
+
+const OPTS = { cellSizeM: 2, crs: 'EPSG:32610', verticalDatum: 'EPSG:5703' } as const;
+const AT = '2026-01-01T00:00:00.000Z';
+
+describe('buildDerivedLayerReceipt', () => {
+  const result = analyseContours(hill(), OPTS);
+  const receipt = buildDerivedLayerReceipt({ result, generatedAt: AT });
+
+  it('carries the run identity a reader needs', () => {
+    expect(receipt.kind).toBeTruthy();
+    expect(receipt.digest).toBeTruthy();
+    expect(receipt.methods.length).toBeGreaterThan(0);
+    expect(['validated', 'exploratory']).toContain(receipt.evidenceGrade);
+  });
+
+  it('reports the resolved CRS honesty rather than assuming it', () => {
+    expect(receipt.crs.horizontal).toContain('32610');
+    expect(receipt.crs.horizontalKnown).toBe(true);
+  });
+
+  it('claims NO export authorization — a layer is not a gated file', () => {
+    expect(receipt.authorization).toBeNull();
+  });
+
+  it('carries an authorization only when one is genuinely supplied', () => {
+    const gated = buildDerivedLayerReceipt({
+      result, generatedAt: AT, authorizationGrantedFrom: 'process-gate:ready',
+    });
+    expect(gated.authorization).toBe('process-gate:ready');
+  });
+});
+
+describe('derived-layer receipt digest — reproducibility', () => {
+  it('is IDENTICAL for two runs over the same data', () => {
+    const a = buildDerivedLayerReceipt({ result: analyseContours(hill(), OPTS), generatedAt: AT });
+    const b = buildDerivedLayerReceipt({ result: analyseContours(hill(), OPTS), generatedAt: AT });
+    expect(derivedLayerReceiptDigest(b)).toBe(derivedLayerReceiptDigest(a));
+  });
+
+  it('does NOT drift with the clock — the fingerprint excludes time', () => {
+    const result = analyseContours(hill(), OPTS);
+    const early = buildDerivedLayerReceipt({ result, generatedAt: '2020-05-05T05:05:05.000Z' });
+    const late = buildDerivedLayerReceipt({ result, generatedAt: '2031-11-11T11:11:11.000Z' });
+    expect(late.digest).toBe(early.digest);
+    // The timestamp is still reported — it is a display field, not identity.
+    expect(late.generatedAt).not.toBe(early.generatedAt);
+  });
+
+  it('DIFFERS when the terrain differs — it identifies this run, not any run', () => {
+    const flat = buildDerivedLayerReceipt({ result: analyseContours(hill(1), OPTS), generatedAt: AT });
+    const steep = buildDerivedLayerReceipt({ result: analyseContours(hill(30), OPTS), generatedAt: AT });
+    expect(steep.digest).not.toBe(flat.digest);
+  });
+});
+
+describe('derived-layer receipt rendering', () => {
+  const receipt = buildDerivedLayerReceipt({ result: analyseContours(hill(), OPTS), generatedAt: AT });
+
+  it('serialises to canonical JSON that round-trips', () => {
+    const json = derivedLayerReceiptJson(receipt);
+    const back = JSON.parse(json) as { digest: string };
+    expect(back.digest).toBe(receipt.digest);
+    // Canonical: the same receipt always produces byte-identical JSON.
+    expect(derivedLayerReceiptJson(receipt)).toBe(json);
+  });
+
+  it('renders readable text that names the run and its digest', () => {
+    const text = derivedLayerReceiptText(receipt);
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain(receipt.digest);
+  });
+});

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -7583,6 +7583,35 @@ body.olv-theme-light .olv-analyse-assess-export.is-preview .olv-analyse-assess-e
   font-size: var(--text-2xs); color: var(--text-dim);
   width: 34px; text-align: right; flex: 0 0 auto; font-variant-numeric: tabular-nums;
 }
+/* ── Derived-layer controls (contours drawn in the 3D scene) ─────────────────
+   Same control vocabulary as the relief sliders above, so a layer reads as part
+   of the same panel rather than a new kind of surface. */
+.olv-analyse-layer-controls {
+  display: flex; flex-direction: column; gap: var(--space-2xs);
+  margin-top: var(--space-md); padding-top: var(--space-md);
+  border-top: 0.5px solid var(--hairline);
+}
+.olv-analyse-layer-head {
+  font-size: var(--text-2xs); font-weight: 700; letter-spacing: 0.9px;
+  text-transform: uppercase; color: var(--text-faint);
+}
+.olv-analyse-layer-row { display: flex; align-items: center; gap: var(--space-lg); flex-wrap: wrap; }
+.olv-analyse-layer-toggle {
+  display: flex; align-items: center; gap: var(--space-sm); cursor: pointer;
+  font-size: var(--text-xs); color: var(--text-dim); user-select: none;
+}
+.olv-analyse-layer-toggle input { accent-color: var(--accent); cursor: pointer; }
+.olv-analyse-layer-slider { display: flex; align-items: center; gap: var(--space-md); }
+.olv-analyse-layer-tag {
+  font-size: var(--text-2xs); text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--text-faint); width: 46px; flex: 0 0 auto;
+}
+.olv-analyse-layer-slider input[type='range'] { flex: 1 1 auto; accent-color: var(--accent); min-width: 0; }
+.olv-analyse-layer-val {
+  font-size: var(--text-2xs); color: var(--text-dim);
+  width: 46px; text-align: right; flex: 0 0 auto; font-variant-numeric: tabular-nums;
+}
+
 /* Click-to-sample readout under a raster tile. */
 .olv-analyse-raster.is-samplable { cursor: crosshair; }
 .olv-analyse-sample {


### PR DESCRIPTION
Contours draw in the 3D scene as a derived layer, with panel controls for visibility, index emphasis, opacity and lift.

`Viewer.derivedLayerHost()` is the scene seam: a structural host, so the overlay keeps ownership of its objects and their disposal. `ContourOverlay` uploads the line buffers, where solid and dashed support differ by colour and alpha rather than dash pattern, and gap segments are not drawn. `contourLayerService` owns the lifecycle, so a re-analysis regenerates in place, and a closed scan drops its layers while a closed background scan does not. The layer carries the analysis receipt digest, built through the provenance path exports already use.

Y-up scans are drawn through the full `canonicalZUpToYUp` rotation. `overlayBufferParamsFor` returns the vertical axis and the northing sign together so they cannot be split. Contours arrive in the project frame, so the overlay adds no origin offset.

**Decision needed:** `Viewer.ts` grows 20 lines and the monolith baseline is hand-raised from 6,419 to 6,439. Recorded in `architecture-map.md` and `KNOWN_LIMITATIONS_v0.6.6.md`.

tsc clean, 41 unit tests, build and chunk isolation green (`three` stays out of the startup shell), controls browser-checked against a loaded scan.

Receipts on other products need analysis-time provenance and are out of scope here.
