### PR TITLE
Honest units and stable identity for feature candidates

### DIFF
--- a/src/features/FeatureExtractionService.ts
+++ b/src/features/FeatureExtractionService.ts
@@ -30,6 +30,7 @@
 
 import { extractBuildingFootprints, type BuildingPoint, type FootprintGrid } from './buildingFootprints';
 import { fitConductor, type Vec3 } from './conductors';
+import type { Pt2 } from './footprintTrace';
 import {
   sourceUnits,
   toMetresIfKnown,
@@ -54,6 +55,12 @@ export interface BuildingCandidate extends CandidateBase {
   /** The same area in m², or null when the source unit is not known. */
   readonly areaM2: number | null;
   readonly cellCount: number;
+  /**
+   * The traced outer boundary, in the source frame the points arrived in (first
+   * vertex not repeated). This is what a reviewer SEES and what a GeoJSON export
+   * writes — a bounding box would be a rectangle, not a building.
+   */
+  readonly ring: readonly Pt2[];
   /** Source-unit centroid + bounds, in the frame the points arrived in. */
   readonly centroid: readonly [number, number];
   readonly bounds: readonly [number, number, number, number];
@@ -122,6 +129,7 @@ export function extractBuildingCandidates(
       // once would under-report by the unit factor.
       areaM2: unit.known ? areaSource * unit.metresPerUnit * unit.metresPerUnit : null,
       cellCount: f.cellCount,
+      ring: f.ring,
       centroid: [f.centroidX, f.centroidY],
       bounds: [f.minX, f.minY, f.maxX, f.maxY],
     };

--- a/src/features/FeatureExtractionService.ts
+++ b/src/features/FeatureExtractionService.ts
@@ -1,73 +1,173 @@
 /**
  * FeatureExtractionService.ts — a callable entry over the feature cores.
  *
- * `extractBuildingFootprints` and `fitConductor` are complete, tested pure cores
- * with no caller outside their tests. This service is the product-side entry:
- * it runs them and returns DERIVED CANDIDATES — not "detected buildings" — in a
- * uniform, review-ready shape (stable id, area/span, confidence marked derived)
- * so a candidate-review UI or a DerivedLayer can consume one thing. The evidence
+ * `extractBuildingFootprints` and `fitConductor` are complete, tested pure cores.
+ * This service is the product-side entry: it runs them and returns DERIVED
+ * CANDIDATES — not "detected buildings" — in a uniform, review-ready shape so a
+ * candidate-review UI or a DerivedLayer can consume one thing. The evidence
  * language stays deliberately weak: these are candidates until a reviewer or
- * stronger evidence promotes them. Pure: geometry in, candidates out.
+ * stronger evidence promotes them.
+ *
+ * TWO CONTRACTS THIS LAYER OWNS, both load-bearing:
+ *
+ * 1. UNITS. The cores measure in whatever unit their input carries — the grid's
+ *    cell size and the point coordinates are SOURCE units, not metres (the
+ *    terrain pipeline's own `cellSizeM` is likewise source units: it is
+ *    `0.25 / metresPerUnit`). A field called `areaM2` fed from a foot or degree
+ *    CRS would therefore be a number labelled m² that is not m². So a candidate
+ *    always carries its SOURCE-unit measure, and the metric twin is present only
+ *    when the linear unit is KNOWN — `null` otherwise, never a guess. This is the
+ *    same fail-closed rule the rest of the metric surface follows.
+ *
+ * 2. IDENTITY. A candidate's id is derived from its own GEOMETRY (a quantised
+ *    position), not from its index in a sorted list. An index is not stable: a
+ *    re-run whose areas shift by a hair reorders the list, and a reviewer who
+ *    accepted "building-3" would find that id now naming a different building.
+ *    A geometry-derived id keeps naming the same thing across re-runs.
+ *
+ * Pure: geometry in, candidates out.
  */
 
 import { extractBuildingFootprints, type BuildingPoint, type FootprintGrid } from './buildingFootprints';
 import { fitConductor, type Vec3 } from './conductors';
+import {
+  sourceUnits,
+  toMetresIfKnown,
+  raw,
+  type LinearUnitScale,
+} from '../units/units';
 
-export interface BuildingCandidate {
+/** Shared by every candidate kind: what it is, and how far to trust it. */
+interface CandidateBase {
   readonly id: string;
-  readonly kind: 'building';
+  /**
+   * Deliberately weak. A candidate is a DERIVED proposal, never a detection —
+   * promotion is a reviewer's act or a stronger evidence source's.
+   */
   readonly confidence: 'derived';
-  readonly areaM2: number;
+}
+
+export interface BuildingCandidate extends CandidateBase {
+  readonly kind: 'building';
+  /** Footprint area in the SOURCE horizontal unit, squared. Always present. */
+  readonly areaSource: number;
+  /** The same area in m², or null when the source unit is not known. */
+  readonly areaM2: number | null;
   readonly cellCount: number;
+  /** Source-unit centroid + bounds, in the frame the points arrived in. */
   readonly centroid: readonly [number, number];
   readonly bounds: readonly [number, number, number, number];
 }
 
-export interface ConductorCandidate {
-  readonly id: string;
+export interface ConductorCandidate extends CandidateBase {
   readonly kind: 'conductor';
-  readonly confidence: 'derived';
   readonly linearity: number;
-  readonly spanM: number;
-  readonly sagM: number;
-  readonly residualRms: number;
+  /** Along-span length in SOURCE units. Always present. */
+  readonly spanSource: number;
+  /** The same span in metres, or null when the source unit is not known. */
+  readonly spanM: number | null;
+  /** Sag in SOURCE units, and its metric twin when the unit is known. */
+  readonly sagSource: number;
+  readonly sagM: number | null;
+  /** Fit residual RMS in SOURCE units, and its metric twin when known. */
+  readonly residualRmsSource: number;
+  readonly residualRmsM: number | null;
   readonly pointCount: number;
 }
 
-/** Extract building footprint candidates from occupied ground-plane points. */
+/**
+ * Quantise a coordinate pair into a stable identity token.
+ *
+ * The quantum is a fraction of the grid cell, so two runs that place the same
+ * feature within a fraction of a cell agree on its id, while two genuinely
+ * different features a cell apart never collide.
+ */
+function positionToken(x: number, y: number, quantum: number): string {
+  const q = Number.isFinite(quantum) && quantum > 0 ? quantum : 1;
+  const qx = Math.round(x / q);
+  const qy = Math.round(y / q);
+  return `${qx}_${qy}`;
+}
+
+/**
+ * Extract building footprint candidates from occupied ground-plane points.
+ *
+ * `unit` converts the SOURCE horizontal unit to metres; pass `unknownUnit()`
+ * when the file declares none, and every metric field comes back null rather
+ * than pretending the source unit was metres.
+ */
 export function extractBuildingCandidates(
   points: readonly BuildingPoint[],
   grid: FootprintGrid,
+  unit: LinearUnitScale,
 ): BuildingCandidate[] {
-  return extractBuildingFootprints(points, grid).map((f, i) => ({
-    id: `building-${i + 1}`,
-    kind: 'building',
-    confidence: 'derived',
-    areaM2: f.areaM2,
-    cellCount: f.cellCount,
-    centroid: [f.centroidX, f.centroidY],
-    bounds: [f.minX, f.minY, f.maxX, f.maxY],
-  }));
+  // Half a cell: fine enough that two distinct footprints never share a token,
+  // coarse enough that a re-run's sub-cell centroid drift keeps the same id.
+  const quantum = grid.cellSizeM / 2;
+  const seen = new Map<string, number>();
+  return extractBuildingFootprints(points, grid).map((f) => {
+    const token = positionToken(f.centroidX, f.centroidY, quantum);
+    // A collision is possible in principle (two centroids inside one quantum);
+    // suffix rather than overwrite, so two candidates can never share an id.
+    const n = (seen.get(token) ?? 0) + 1;
+    seen.set(token, n);
+    const id = n === 1 ? `building-${token}` : `building-${token}-${n}`;
+    const areaSource = f.areaM2; // core value: cells x cell^2, in SOURCE units^2
+    return {
+      id,
+      kind: 'building',
+      confidence: 'derived',
+      areaSource,
+      // Area is a SQUARE measure, so the scale applies twice — converting it
+      // once would under-report by the unit factor.
+      areaM2: unit.known ? areaSource * unit.metresPerUnit * unit.metresPerUnit : null,
+      cellCount: f.cellCount,
+      centroid: [f.centroidX, f.centroidY],
+      bounds: [f.minX, f.minY, f.maxX, f.maxY],
+    };
+  });
 }
 
 /**
  * Fit a single conductor candidate to a set of points, or null when the points
  * are not linear enough to be a conductor span (the core's own gate).
+ *
+ * The id is derived from the span's own midpoint, so re-running over the same
+ * span keeps the same candidate rather than minting a fresh one.
  */
 export function extractConductorCandidate(
   points: readonly Vec3[],
+  unit: LinearUnitScale,
   minLinearity = 0.9,
 ): ConductorCandidate | null {
   const fit = fitConductor(points, minLinearity);
   if (!fit.ok) return null;
+  const toM = (v: number): number | null => {
+    const m = toMetresIfKnown(sourceUnits(v), unit);
+    return m === null ? null : raw(m);
+  };
+  // Identity from the span's midpoint, quantised by a fraction of its own
+  // length — scale-free, so it works for a 10 m span and a 400 m one alike.
+  let cx = 0;
+  let cy = 0;
+  for (const p of points) {
+    cx += p[0];
+    cy += p[1];
+  }
+  cx /= points.length;
+  cy /= points.length;
+  const token = positionToken(cx, cy, fit.spanM / 8 || 1);
   return {
-    id: 'conductor-1',
+    id: `conductor-${token}`,
     kind: 'conductor',
     confidence: 'derived',
     linearity: fit.linearity,
-    spanM: fit.spanM,
-    sagM: fit.sagM,
-    residualRms: fit.residualRms,
+    spanSource: fit.spanM,
+    spanM: toM(fit.spanM),
+    sagSource: fit.sagM,
+    sagM: toM(fit.sagM),
+    residualRmsSource: fit.residualRms,
+    residualRmsM: toM(fit.residualRms),
     pointCount: fit.n,
   };
 }

--- a/src/features/buildingFootprints.ts
+++ b/src/features/buildingFootprints.ts
@@ -16,6 +16,8 @@
  * area. Pure and deterministic.
  */
 
+import { traceOccupancyBoundary, type Pt2 } from './footprintTrace';
+
 export interface FootprintGrid {
   readonly originX: number;
   readonly originY: number;
@@ -27,6 +29,16 @@ export interface FootprintGrid {
 }
 
 export interface Footprint {
+  /**
+   * The footprint's traced outer boundary, in the same world coordinates as the
+   * centroid and bounds (first vertex NOT repeated).
+   *
+   * Carried because a bounding box is not a building: it is the only geometry
+   * that can be DRAWN as a candidate or written to GeoJSON, and both consumers
+   * would otherwise have to re-derive it from cells this function discards.
+   * Empty only for a degenerate component the tracer cannot close.
+   */
+  readonly ring: readonly Pt2[];
   readonly cellCount: number;
   readonly areaM2: number;
   readonly centroidX: number;
@@ -113,8 +125,10 @@ export function extractBuildingFootprints(points: readonly BuildingPoint[], grid
       if (ly < minY) minY = ly;
       if (ly + cell > maxY) maxY = ly + cell;
     }
+    // Trace the block's outline once, here, where the cells still exist.
+    const ring = traceOccupancyBoundary(cells, cell, grid.originX, grid.originY);
     footprints.push({
-      cellCount: cells.length, areaM2,
+      ring, cellCount: cells.length, areaM2,
       centroidX: sx / cells.length, centroidY: sy / cells.length,
       minX, minY, maxX, maxY,
     });

--- a/src/features/candidateReview.ts
+++ b/src/features/candidateReview.ts
@@ -1,0 +1,126 @@
+/**
+ * candidateReview.ts — the review state over extracted candidates.
+ *
+ * Extraction proposes; a person disposes. A candidate is a DERIVED proposal, so
+ * the product's job is to make each one reviewable — accept it, reject it, or
+ * leave it pending — and to make those judgments outlive the extraction that
+ * produced them.
+ *
+ * WHY THIS IS KEYED BY CANDIDATE ID, AND WHY THAT ID HAD TO BE FIXED FIRST.
+ * Re-running extraction (a re-analysis, a parameter tweak, more points arriving)
+ * produces a FRESH list. If a decision were held by list position, the second run
+ * would silently reassign every judgment: the building the reviewer accepted as
+ * #3 becomes #4, and the accept lands on a different building. Because ids are
+ * now derived from a candidate's own geometry, a decision re-attaches to the
+ * thing it was made about. That is the whole reason the identity fix preceded
+ * this module.
+ *
+ * A decision for a candidate that a later run does NOT produce is KEPT, not
+ * discarded: extraction output moves with its inputs, and a reviewer who
+ * rejected something should not have to reject it again when it reappears.
+ *
+ * Pure: no DOM, no I/O, no clock. Every method is deterministic.
+ */
+
+/** Where a candidate stands with its reviewer. */
+export type CandidateStatus = 'review' | 'accepted' | 'rejected';
+
+/** The default for anything nobody has judged yet. */
+export const DEFAULT_STATUS: CandidateStatus = 'review';
+
+/** A candidate paired with the reviewer's standing decision about it. */
+export interface ReviewedCandidate<T extends { readonly id: string }> {
+  readonly candidate: T;
+  readonly status: CandidateStatus;
+}
+
+/** How a review set stands, for a header or a gate. */
+export interface ReviewSummary {
+  readonly total: number;
+  readonly accepted: number;
+  readonly rejected: number;
+  readonly pending: number;
+  /** True when nothing is left in `review` — every candidate has been judged. */
+  readonly complete: boolean;
+}
+
+/**
+ * A pure store of review decisions keyed by candidate id. Only non-default
+ * decisions are stored, so an untouched set costs nothing and `statusOf`
+ * answers `'review'` for anything unknown.
+ */
+export class CandidateReviewStore {
+  private readonly _byId = new Map<string, CandidateStatus>();
+
+  /** The standing decision for an id; `'review'` when nobody has judged it. */
+  statusOf(id: string): CandidateStatus {
+    return this._byId.get(id) ?? DEFAULT_STATUS;
+  }
+
+  accept(id: string): CandidateStatus {
+    return this._set(id, 'accepted');
+  }
+
+  reject(id: string): CandidateStatus {
+    return this._set(id, 'rejected');
+  }
+
+  /** Return a candidate to the pending state, forgetting the decision. */
+  reset(id: string): CandidateStatus {
+    this._byId.delete(id);
+    return DEFAULT_STATUS;
+  }
+
+  /** Every recorded decision, for persistence. Pending candidates are absent. */
+  decisions(): ReadonlyMap<string, CandidateStatus> {
+    return new Map(this._byId);
+  }
+
+  /** Reload recorded decisions (e.g. from a restored session). Replaces all. */
+  restore(decisions: Iterable<readonly [string, CandidateStatus]>): void {
+    this._byId.clear();
+    for (const [id, status] of decisions) {
+      // Never store the default: it is the absence of a decision, and storing it
+      // would make an untouched candidate indistinguishable from a reset one.
+      if (status !== DEFAULT_STATUS) this._byId.set(id, status);
+    }
+  }
+
+  /** Drop every decision. */
+  clear(): void {
+    this._byId.clear();
+  }
+
+  /**
+   * Join the standing decisions onto a FRESH extraction, in the extraction's own
+   * order. This is the call a re-run makes: candidates are new objects, the
+   * judgments are the store's, and they meet by id.
+   */
+  apply<T extends { readonly id: string }>(candidates: readonly T[]): ReviewedCandidate<T>[] {
+    return candidates.map((candidate) => ({ candidate, status: this.statusOf(candidate.id) }));
+  }
+
+  /** Only the candidates a reviewer has accepted — what a deliverable ships. */
+  accepted<T extends { readonly id: string }>(candidates: readonly T[]): T[] {
+    return candidates.filter((c) => this.statusOf(c.id) === 'accepted');
+  }
+
+  /** Counts over a candidate set, for a header or an export gate. */
+  summarise<T extends { readonly id: string }>(candidates: readonly T[]): ReviewSummary {
+    let accepted = 0;
+    let rejected = 0;
+    for (const c of candidates) {
+      const s = this.statusOf(c.id);
+      if (s === 'accepted') accepted++;
+      else if (s === 'rejected') rejected++;
+    }
+    const total = candidates.length;
+    const pending = total - accepted - rejected;
+    return { total, accepted, rejected, pending, complete: pending === 0 };
+  }
+
+  private _set(id: string, status: CandidateStatus): CandidateStatus {
+    this._byId.set(id, status);
+    return status;
+  }
+}

--- a/tests/candidateReview.test.ts
+++ b/tests/candidateReview.test.ts
@@ -1,0 +1,174 @@
+/**
+ * candidateReview.test.ts
+ *
+ * The review state over extracted candidates. The load-bearing property is that
+ * a judgment SURVIVES a re-extraction and re-attaches to the thing it was made
+ * about — which only works because candidate ids are derived from geometry
+ * rather than list position. The re-run tests below are what would have failed
+ * under the old index-based ids, so they pin the pair together.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CandidateReviewStore,
+  DEFAULT_STATUS,
+  type CandidateStatus,
+} from '../src/features/candidateReview';
+import { extractBuildingCandidates } from '../src/features/FeatureExtractionService';
+import type { BuildingPoint } from '../src/features/buildingFootprints';
+import { knownUnit } from '../src/units/units';
+
+const METRE = knownUnit(1);
+const GRID = { originX: 0, originY: 0, cellSizeM: 1, minPointsPerCell: 1, minAreaM2: 4 };
+
+function block(ox = 0, oy = 0, n = 10): BuildingPoint[] {
+  const pts: BuildingPoint[] = [];
+  for (let x = 0; x < n; x++) for (let y = 0; y < n; y++) pts.push({ x: ox + x, y: oy + y });
+  return pts;
+}
+const idc = (id: string) => ({ id });
+
+describe('CandidateReviewStore — decisions', () => {
+  it('everything starts pending, and an unknown id is pending too', () => {
+    const s = new CandidateReviewStore();
+    expect(s.statusOf('nobody')).toBe(DEFAULT_STATUS);
+    expect(DEFAULT_STATUS).toBe('review');
+  });
+
+  it('accept and reject are recorded and readable', () => {
+    const s = new CandidateReviewStore();
+    expect(s.accept('a')).toBe('accepted');
+    expect(s.reject('b')).toBe('rejected');
+    expect(s.statusOf('a')).toBe('accepted');
+    expect(s.statusOf('b')).toBe('rejected');
+  });
+
+  it('reset returns a candidate to pending and forgets the decision', () => {
+    const s = new CandidateReviewStore();
+    s.accept('a');
+    expect(s.reset('a')).toBe('review');
+    expect(s.statusOf('a')).toBe('review');
+    expect(s.decisions().has('a')).toBe(false);
+  });
+
+  it('a decision can be changed', () => {
+    const s = new CandidateReviewStore();
+    s.accept('a');
+    s.reject('a');
+    expect(s.statusOf('a')).toBe('rejected');
+  });
+
+  it('only real decisions are stored — pending is the absence of one', () => {
+    const s = new CandidateReviewStore();
+    s.accept('a');
+    expect([...s.decisions().keys()]).toEqual(['a']);
+  });
+});
+
+describe('CandidateReviewStore — joining onto a candidate set', () => {
+  const cands = [idc('x'), idc('y'), idc('z')];
+
+  it('apply pairs each candidate with its standing decision, in extraction order', () => {
+    const s = new CandidateReviewStore();
+    s.accept('y');
+    const rows = s.apply(cands);
+    expect(rows.map((r) => r.candidate.id)).toEqual(['x', 'y', 'z']);
+    expect(rows.map((r) => r.status)).toEqual(['review', 'accepted', 'review']);
+  });
+
+  it('accepted() is what a deliverable would ship', () => {
+    const s = new CandidateReviewStore();
+    s.accept('x');
+    s.reject('y');
+    expect(s.accepted(cands).map((c) => c.id)).toEqual(['x']);
+  });
+
+  it('summarise counts the set and reports completeness', () => {
+    const s = new CandidateReviewStore();
+    expect(s.summarise(cands)).toEqual({
+      total: 3, accepted: 0, rejected: 0, pending: 3, complete: false,
+    });
+    s.accept('x'); s.reject('y'); s.accept('z');
+    expect(s.summarise(cands)).toEqual({
+      total: 3, accepted: 2, rejected: 1, pending: 0, complete: true,
+    });
+  });
+
+  it('summarise ignores decisions about candidates outside the set', () => {
+    const s = new CandidateReviewStore();
+    s.accept('not-in-this-set');
+    expect(s.summarise(cands).accepted).toBe(0);
+    expect(s.summarise(cands).pending).toBe(3);
+  });
+});
+
+describe('CandidateReviewStore — surviving a re-extraction', () => {
+  it('a judgment re-attaches to the SAME building after a re-run', () => {
+    const s = new CandidateReviewStore();
+    const first = extractBuildingCandidates(block(), GRID, METRE);
+    s.accept(first[0].id);
+
+    // Re-run over the same data: fresh objects, same geometry.
+    const second = extractBuildingCandidates(block(), GRID, METRE);
+    expect(second[0]).not.toBe(first[0]);
+    expect(s.statusOf(second[0].id)).toBe('accepted');
+  });
+
+  it('a judgment follows its own building when a larger one REORDERS the list', () => {
+    // This is the case index-based ids got wrong: the accept would slide onto
+    // whichever building happened to take the old position.
+    const s = new CandidateReviewStore();
+    const small = block(0, 0, 6);
+    const before = extractBuildingCandidates(small, GRID, METRE);
+    s.accept(before[0].id);
+
+    const after = extractBuildingCandidates([...small, ...block(40, 40, 14)], GRID, METRE);
+    expect(after[0].areaSource).toBeGreaterThan(after[1].areaSource); // reordered
+    const rows = s.apply(after);
+    const acceptedIds = rows.filter((r) => r.status === 'accepted').map((r) => r.candidate.id);
+    // Exactly one accept, and it is still the SMALL building.
+    expect(acceptedIds).toEqual([before[0].id]);
+    // The newly-appeared larger building is untouched.
+    expect(rows.find((r) => r.candidate.id !== before[0].id)!.status).toBe('review');
+  });
+
+  it('a decision is KEPT for a candidate a later run does not produce', () => {
+    const s = new CandidateReviewStore();
+    const seen = extractBuildingCandidates(block(), GRID, METRE);
+    s.reject(seen[0].id);
+    // A run that finds nothing must not erase the judgment...
+    expect(s.summarise([]).total).toBe(0);
+    // ...so when the candidate reappears it is still rejected.
+    const again = extractBuildingCandidates(block(), GRID, METRE);
+    expect(s.statusOf(again[0].id)).toBe('rejected');
+  });
+});
+
+describe('CandidateReviewStore — persistence', () => {
+  it('decisions round-trip through restore', () => {
+    const s = new CandidateReviewStore();
+    s.accept('a'); s.reject('b');
+    const saved = [...s.decisions()];
+
+    const restored = new CandidateReviewStore();
+    restored.restore(saved);
+    expect(restored.statusOf('a')).toBe('accepted');
+    expect(restored.statusOf('b')).toBe('rejected');
+  });
+
+  it('restore REPLACES, and never stores a pending entry', () => {
+    const s = new CandidateReviewStore();
+    s.accept('old');
+    s.restore([['new', 'accepted'], ['idle', DEFAULT_STATUS as CandidateStatus]]);
+    expect(s.statusOf('old')).toBe('review'); // replaced, not merged
+    expect(s.statusOf('new')).toBe('accepted');
+    expect(s.decisions().has('idle')).toBe(false); // pending is not a decision
+  });
+
+  it('clear drops everything', () => {
+    const s = new CandidateReviewStore();
+    s.accept('a');
+    s.clear();
+    expect(s.decisions().size).toBe(0);
+  });
+});

--- a/tests/featureExtractionService.test.ts
+++ b/tests/featureExtractionService.test.ts
@@ -19,6 +19,7 @@ import {
 import type { BuildingPoint } from '../src/features/buildingFootprints';
 import type { Vec3 } from '../src/features/conductors';
 import { knownUnit, unknownUnit } from '../src/units/units';
+import { footprintsToGeoJson } from '../src/features/footprintGeoJson';
 
 const METRE = knownUnit(1);
 const FOOT = knownUnit(0.3048);
@@ -138,5 +139,53 @@ describe('FeatureExtractionService — stable identity', () => {
     const a = extractConductorCandidate(span(), METRE)!;
     const b = extractConductorCandidate(span(), METRE)!;
     expect(b.id).toBe(a.id);
+  });
+});
+
+describe('FeatureExtractionService — the traced ring', () => {
+  it('carries a real outline, not a bounding box', () => {
+    // An L-shaped block: a rectangle would have 4 corners and cover the notch,
+    // so a ring that is genuinely traced must have more vertices than that.
+    const pts: BuildingPoint[] = [];
+    for (let x = 0; x < 10; x++) for (let y = 0; y < 4; y++) pts.push({ x, y });
+    for (let x = 0; x < 4; x++) for (let y = 4; y < 10; y++) pts.push({ x, y });
+    const [b] = extractBuildingCandidates(pts, GRID, METRE);
+    expect(b.ring.length).toBeGreaterThan(4);
+  });
+
+  it('the ring closes, stays inside the bounds, and is not repeated at the end', () => {
+    const [b] = extractBuildingCandidates(block(), GRID, METRE);
+    expect(b.ring.length).toBeGreaterThanOrEqual(3);
+    const [minX, minY, maxX, maxY] = b.bounds;
+    for (const p of b.ring) {
+      expect(p.x).toBeGreaterThanOrEqual(minX);
+      expect(p.x).toBeLessThanOrEqual(maxX);
+      expect(p.y).toBeGreaterThanOrEqual(minY);
+      expect(p.y).toBeLessThanOrEqual(maxY);
+    }
+    // First vertex is NOT repeated as the last (the documented convention).
+    const first = b.ring[0];
+    const last = b.ring[b.ring.length - 1];
+    expect(first.x === last.x && first.y === last.y).toBe(false);
+  });
+
+  it('feeds the GeoJSON writer, which previously had no ring to consume', () => {
+    const cands = extractBuildingCandidates(block(), GRID, METRE);
+    const fc = footprintsToGeoJson(
+      cands.map((c) => ({
+        ring: c.ring,
+        areaM2: c.areaM2 ?? c.areaSource,
+        centroidX: c.centroid[0],
+        centroidY: c.centroid[1],
+        id: c.id,
+      })),
+      { crs: 'EPSG:32610' },
+    );
+    expect(fc.features).toHaveLength(1);
+    const geom = fc.features[0].geometry as { type: string; coordinates: number[][][] };
+    expect(geom.type).toBe('Polygon');
+    // RFC 7946: the writer closes the ring on output.
+    const out = geom.coordinates[0];
+    expect(out[0]).toEqual(out[out.length - 1]);
   });
 });

--- a/tests/featureExtractionService.test.ts
+++ b/tests/featureExtractionService.test.ts
@@ -1,3 +1,16 @@
+/**
+ * featureExtractionService.test.ts
+ *
+ * The product-side entry over the feature cores. Beyond "does it extract", the
+ * two contracts this layer exists to own are pinned here:
+ *
+ *  - UNITS: the cores measure in the SOURCE unit, so a metric field is emitted
+ *    only when the unit is KNOWN, and area converts by the scale SQUARED.
+ *  - IDENTITY: a candidate id is derived from its geometry, so it survives a
+ *    re-run whose ordering shifts — an index-based id would rename a building
+ *    the reviewer had already accepted.
+ */
+
 import { describe, it, expect } from 'vitest';
 import {
   extractBuildingCandidates,
@@ -5,38 +18,125 @@ import {
 } from '../src/features/FeatureExtractionService';
 import type { BuildingPoint } from '../src/features/buildingFootprints';
 import type { Vec3 } from '../src/features/conductors';
+import { knownUnit, unknownUnit } from '../src/units/units';
 
-describe('FeatureExtractionService', () => {
+const METRE = knownUnit(1);
+const FOOT = knownUnit(0.3048);
+
+/** A solid 10x10 block of building points. */
+function block(ox = 0, oy = 0, n = 10): BuildingPoint[] {
+  const pts: BuildingPoint[] = [];
+  for (let x = 0; x < n; x++) for (let y = 0; y < n; y++) pts.push({ x: ox + x, y: oy + y });
+  return pts;
+}
+const GRID = { originX: 0, originY: 0, cellSizeM: 1, minPointsPerCell: 1, minAreaM2: 4 };
+
+/** A near-straight span with a slight sag. */
+function span(len = 40): Vec3[] {
+  const pts: Vec3[] = [];
+  for (let i = 0; i < len; i++) pts.push([i, 0, 10 - 0.001 * i * (len - i)]);
+  return pts;
+}
+
+describe('FeatureExtractionService — extraction', () => {
   it('turns a dense occupied block into a derived building candidate', () => {
-    const pts: BuildingPoint[] = [];
-    for (let x = 0; x < 10; x++) for (let y = 0; y < 10; y++) pts.push({ x, y });
-    const cands = extractBuildingCandidates(pts, { originX: 0, originY: 0, cellSizeM: 1, minPointsPerCell: 1, minAreaM2: 4 });
+    const cands = extractBuildingCandidates(block(), GRID, METRE);
     expect(cands.length).toBe(1);
-    expect(cands[0].id).toBe('building-1');
     expect(cands[0].kind).toBe('building');
     expect(cands[0].confidence).toBe('derived');
-    expect(cands[0].areaM2).toBeGreaterThan(0);
+    expect(cands[0].areaSource).toBeGreaterThan(0);
     expect(cands[0].bounds).toHaveLength(4);
   });
 
   it('returns no candidates for empty input', () => {
-    expect(extractBuildingCandidates([], { originX: 0, originY: 0, cellSizeM: 1 })).toEqual([]);
+    expect(extractBuildingCandidates([], GRID, METRE)).toEqual([]);
   });
 
   it('fits a straight span as a conductor candidate', () => {
-    const pts: Vec3[] = [];
-    for (let i = 0; i < 40; i++) pts.push([i, 0, 10 - 0.001 * i * (40 - i)]); // slight sag
-    const c = extractConductorCandidate(pts);
+    const c = extractConductorCandidate(span(), METRE);
     expect(c).not.toBeNull();
     expect(c!.kind).toBe('conductor');
     expect(c!.linearity).toBeGreaterThan(0.9);
-    expect(c!.spanM).toBeGreaterThan(30);
-    expect(c!.sagM).toBeGreaterThan(0);
+    expect(c!.spanSource).toBeGreaterThan(30);
+    expect(c!.sagSource).toBeGreaterThan(0);
   });
 
   it('rejects a non-linear blob as not a conductor', () => {
     const pts: Vec3[] = [];
     for (let x = 0; x < 6; x++) for (let y = 0; y < 6; y++) pts.push([x, y, 0]);
-    expect(extractConductorCandidate(pts)).toBeNull();
+    expect(extractConductorCandidate(pts, METRE)).toBeNull();
+  });
+});
+
+describe('FeatureExtractionService — unit honesty', () => {
+  it('an UNKNOWN unit yields no metric claim at all, never a metres guess', () => {
+    const b = extractBuildingCandidates(block(), GRID, unknownUnit())[0];
+    expect(b.areaSource).toBeGreaterThan(0); // the source measure still stands
+    expect(b.areaM2).toBeNull();
+
+    const c = extractConductorCandidate(span(), unknownUnit())!;
+    expect(c.spanSource).toBeGreaterThan(30);
+    expect(c.spanM).toBeNull();
+    expect(c.sagM).toBeNull();
+    expect(c.residualRmsM).toBeNull();
+  });
+
+  it('AREA converts by the scale SQUARED — a foot grid is not a metre grid', () => {
+    const inFeet = extractBuildingCandidates(block(), GRID, FOOT)[0];
+    const inMetres = extractBuildingCandidates(block(), GRID, METRE)[0];
+    // Same source area (the cores never saw a unit)...
+    expect(inFeet.areaSource).toBeCloseTo(inMetres.areaSource, 9);
+    // ...but the metric twin differs by the scale squared, not the scale.
+    expect(inFeet.areaM2).toBeCloseTo(inFeet.areaSource * 0.3048 * 0.3048, 9);
+    // A once-converted area would be ~3.3x too large — pin that it is not.
+    expect(inFeet.areaM2).toBeLessThan(inFeet.areaSource * 0.3048);
+  });
+
+  it('LENGTH converts by the scale once (span, sag and residual alike)', () => {
+    const c = extractConductorCandidate(span(), FOOT)!;
+    expect(c.spanM).toBeCloseTo(c.spanSource * 0.3048, 9);
+    expect(c.sagM).toBeCloseTo(c.sagSource * 0.3048, 9);
+    expect(c.residualRmsM).toBeCloseTo(c.residualRmsSource * 0.3048, 9);
+  });
+
+  it('a metre unit leaves the numbers unchanged', () => {
+    const b = extractBuildingCandidates(block(), GRID, METRE)[0];
+    expect(b.areaM2).toBeCloseTo(b.areaSource, 9);
+  });
+});
+
+describe('FeatureExtractionService — stable identity', () => {
+  it('the same geometry keeps the same id across re-runs', () => {
+    const a = extractBuildingCandidates(block(), GRID, METRE)[0];
+    const b = extractBuildingCandidates(block(), GRID, METRE)[0];
+    expect(b.id).toBe(a.id);
+  });
+
+  it('an id follows its OWN building when another appears and reorders the list', () => {
+    // One small building first; then add a LARGER one, which sorts ahead of it.
+    const small = block(0, 0, 6);
+    const before = extractBuildingCandidates(small, GRID, METRE);
+    expect(before).toHaveLength(1);
+    const smallId = before[0].id;
+
+    const big = block(40, 40, 14);
+    const after = extractBuildingCandidates([...small, ...big], GRID, METRE);
+    expect(after.length).toBe(2);
+    // The larger building sorts first, so an index-based id would have renamed
+    // the small one. Its geometry-derived id must be untouched.
+    expect(after[0].areaSource).toBeGreaterThan(after[1].areaSource);
+    expect(after.map((c) => c.id)).toContain(smallId);
+  });
+
+  it('distinct buildings never share an id', () => {
+    const cands = extractBuildingCandidates([...block(0, 0, 6), ...block(40, 40, 6)], GRID, METRE);
+    expect(cands).toHaveLength(2);
+    expect(new Set(cands.map((c) => c.id)).size).toBe(2);
+  });
+
+  it('a conductor id is stable for the same span', () => {
+    const a = extractConductorCandidate(span(), METRE)!;
+    const b = extractConductorCandidate(span(), METRE)!;
+    expect(b.id).toBe(a.id);
   });
 });


### PR DESCRIPTION
Two contracts the candidate workflow depends on, plus the geometry it draws from.

The feature cores measure in source units, and so does the grid cell (`cellSizeM` is `0.25 / metresPerUnit`), so `areaM2`, `spanM` and `sagM` were metric labels on non-metric numbers on any foot or degree CRS. A candidate now carries its source measure always, and the metric twin only when the unit is known. Area converts by the scale squared.

Ids were the index in an area-sorted list, so a re-run that reordered the list renamed candidates. They now derive from the centroid, and `CandidateReviewStore` keys decisions by id, so an accept survives re-extraction.

Footprints carried bounds but no outline, so nothing could draw one. The traced ring now travels on the footprint.

**API change:** `areaM2` becomes `areaSource` plus a nullable `areaM2`.
