### PR TITLE
v0.6.6 release truth: record the contour generalization mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 
 ## [0.6.6] - 2026-08-17
 
+### Added
+
+- An opt-in terrain-aware mode for cartographic contour generalization. Where the shipped pass applies one simplification tolerance to every line, terrain-aware scales that tolerance per feature from what the feature is: interpolated or low-confidence support, and small closed summits and depressions, keep more of their shape, while long strongly-measured lines generalize at the full tolerance. The per-feature factor is clamped so it can only ever make a line more faithful than the uniform pass, so the chosen tolerance remains the bound on every line, and the honesty-gated simplifier still refuses to drop a gap or low-confidence vertex under either mode. Exports record which pass ran, `olv.contour.generalize.terrain-adaptive@1` or `olv.contour.generalize@1`. Uniform stays the default, so contour geometry is unchanged for every existing purpose unless the mode is selected.
+
 ### Changed
 
 - The DSM, DTM and CHM surface products reach `E4_CROSS_IMPLEMENTATION_VALIDATED`. The DSM and DTM grids were each recomputed and compared against a committed PDAL 2.10.2 `writers.gdal` reference over three seeded synthetic clouds, agreeing over 7,500 cells to a maximum difference under 4×10⁻⁶ m within a 0.05 m registered tolerance (studies `DSM-PDAL-WRITERS-GDAL-CELL-CENTRED` and `DTM-PDAL-WRITERS-GDAL-CELL-CENTRED`); the CHM (clamped DSM minus DTM) agreed with the PDAL max grid minus the PDAL min grid over 7,500 cells to under 8×10⁻⁶ m within a 0.1 m registered tolerance (study `CHM-PDAL-WRITERS-GDAL-DIFFERENCE`). The check covers the cell gridding: the reference radius is below half a cell, so it does not exercise ground classification (`GROUND-FILTER` stays partial) or real-terrain void interpolation, and the DTM's required bar remains E5.
 - The `TPI` and `VRM` terrain descriptors reach `E4_CROSS_IMPLEMENTATION_VALIDATED`, splitting the former combined `VRM-TPI` claim. Each is checked three ways against an independent tool AND the closed form on an analytic fixture designed to control the confound: `TPI` against gdaldem 3.13.1 over 3364 interior cells to under 9×10⁻⁷ within a 1×10⁻⁵ tolerance, on a low-amplitude quadratic (so the reference's float32 mean accumulation stays below tolerance); `VRM` (Sappington et al. 2007) against SAGA 7.8.2 over 3136 interior cells within a 1×10⁻⁴ tolerance, on a smooth tilted quadratic (so Horn's normal and SAGA's estimator converge), reproducing the closed-form Sappington VRM to under 1×10⁻⁹ (studies `TPI-GDALDEM-ANALYTIC` and `VRM-SAGA-ANALYTIC`). Ten products are now at E4.
-- The terrain and measurement algorithms are inherited from v0.6.5 unchanged.
+- The terrain and measurement algorithms are inherited from v0.6.5 unchanged, apart from the opt-in contour generalization mode above, which is off by default.
 
 ## [0.6.5] - 2026-08-14
 

--- a/docs-site/releases/v0.6.6.md
+++ b/docs-site/releases/v0.6.6.md
@@ -11,6 +11,9 @@ The check covers the cell gridding: the reference radius is below half a cell, s
 it does not exercise ground classification (`GROUND-FILTER` stays partial) or
 real-terrain void interpolation, and the DTM's required bar for field validation
 stays at E5. The terrain and measurement algorithms are inherited from v0.6.5
-unchanged.
+unchanged, apart from an opt-in terrain-aware contour generalization mode that
+simplifies interpolated, low-confidence and small closed contours less than the
+uniform pass, and never more. Uniform stays the default, so contour geometry is
+unchanged unless the mode is selected.
 
 Full notes: [RELEASE_NOTES_v0.6.6.md](https://github.com/Aurtechmx/openlidarviewer/blob/main/docs/releases/RELEASE_NOTES_v0.6.6.md)

--- a/docs/releases/RELEASE_NOTES_v0.6.6.md
+++ b/docs/releases/RELEASE_NOTES_v0.6.6.md
@@ -1,6 +1,6 @@
 # OpenLiDARViewer v0.6.6
 
-v0.6.6 is a focused evidence release. It promotes the DSM, DTM and CHM surface products to independent cross-implementation evidence and carries the v0.6.5 application forward unchanged. The measured figures in this document come from the release-mode gate run at the tagged commit.
+v0.6.6 is a focused evidence release. It promotes the DSM, DTM and CHM surface products to independent cross-implementation evidence, and adds one opt-in cartographic option that leaves every default output unchanged. The measured figures in this document come from the release-mode gate run at the tagged commit.
 
 OpenLiDARViewer remains browser-native and local-first: local files stay on the user's device, and no account is required.
 
@@ -16,13 +16,21 @@ Ten products are now at E4: `SLOPE-RASTER`, `ASPECT-RASTER`, `HILLSHADE`, `CONTO
 
 The cross-check isolates the cell gridding. The reference radius is 0.45 m, below half a cell, so each cell reduces to the returns at its centre and the two implementations take the maximum or minimum over the same point set. It therefore measures the gridding arithmetic, not a divergent neighbourhood search. The DTM clouds are bare-earth by construction, so it does not exercise ground classification. `GROUND-FILTER` stays at E3 in this release, because its agreement with PDAL's `filters.smrf` holds on low-relief terrain and falls on steep and complex terrain. Void interpolation on real terrain is not exercised, and the DTM's required bar for field validation stays at E5. None of this is survey-grade accuracy or a field campaign.
 
+## Terrain-aware contour generalization, opt-in
+
+Cartographic contour purposes simplify their geometry at a bounded tolerance, expressed as a fraction of the grid cell. That tolerance has always applied evenly to every line, which spends the same amount of give on a long confidently-measured contour and on a small summit ring whose shape a coarse tolerance would erase.
+
+A terrain-aware mode is now offered beside the uniform one. It scales the tolerance per feature from the feature's own evidence: interpolated and low-confidence support, and small closed summits and depressions, are simplified less, while long strongly-measured lines are simplified at the full tolerance. The per-feature factor is clamped so that it can only ever make a line more faithful than the uniform pass, which keeps the chosen tolerance as the bound on every line in the set. The simplifier underneath is unchanged and still refuses to drop a vertex that sits on a gap or below the confidence floor, so neither mode can straighten an interpolated run into a confident-looking line.
+
+Exports record which pass produced their geometry, `olv.contour.generalize.terrain-adaptive@1` or `olv.contour.generalize@1`, alongside the tolerance in effect. Uniform remains the default for every purpose, so contour geometry is byte-identical to v0.6.5 unless the mode is selected.
+
 ## Known limitations
 
-The complete list is in `KNOWN_LIMITATIONS_v0.6.6.md`. It carries the v0.6.5 limits forward, with the evidence-ceiling section updated for the three newly promoted surface products and the scope those cross-checks reach. Multi-layer mounting stays enabled with its one outstanding precision refinement, the residual streaming flicker at the point-budget boundary is unchanged, and there is still no cross-CRS reprojection into a common viewer frame.
+The complete list is in `KNOWN_LIMITATIONS_v0.6.6.md`. It carries the v0.6.5 limits forward, with the evidence-ceiling section updated for the three newly promoted surface products and the scope those cross-checks reach. Terrain-aware generalization is a cartographic option and carries no evidence claim of its own: it changes how a line is drawn, never what the surface says. Multi-layer mounting stays enabled with its one outstanding precision refinement, the residual streaming flicker at the point-budget boundary is unchanged, and there is still no cross-CRS reprojection into a common viewer frame.
 
 ## Compatibility
 
-Unchanged from v0.6.5. Modern Chromium browsers use WebGPU, with WebGL 2 fallback in Firefox and Safari, and existing sessions remain compatible. Session files are unaffected.
+Unchanged from v0.6.5. Modern Chromium browsers use WebGPU, with WebGL 2 fallback in Firefox and Safari, and existing sessions remain compatible. Session files are unaffected: a session saved before this release loads with generalization in its uniform default.
 
 ## Verifying this release
 


### PR DESCRIPTION
The v0.6.6 documents said the application, and the terrain and measurement algorithms, were carried forward from v0.6.5 unchanged. That stopped being true when the opt-in terrain-aware contour generalization merged in #435, so the release currently describes something other than what it contains.

Three public documents carried the claim and are corrected together: `RELEASE_NOTES_v0.6.6.md`, `CHANGELOG.md`, and the `docs-site` release page.

## What the documents now say

Each records the mode and its bound: what it scales and from which evidence (interpolated and low-confidence support, and small closed summits and depressions, are simplified less; long strongly-measured lines at the full tolerance), that the per-feature factor is clamped so a line can only ever become *more* faithful than the uniform pass, and that the honesty-gated simplifier underneath is unchanged and still refuses to drop a gap or low-confidence vertex under either mode.

Exports record which pass produced their geometry, so the method stamp is named rather than implied.

Uniform stays the default, so contour geometry is byte-identical to v0.6.5 unless the mode is selected. That is stated plainly instead of left to be inferred, and the compatibility section says what happens to a session saved before this release.

The known-limitations line notes that terrain-aware generalization carries no evidence claim of its own: it changes how a line is drawn, never what the surface says.

## Verification

`release-truth`, `release-sync`, `claim-prose-sync`, `claims-language` and `claim-register` all green. The added prose passes the repo's AI-writing gate. 21 doc-truth tests and 2,039 unit tests pass.

Docs only, no source change.
