### PR TITLE
Record why the reliability-mistagged Sonar rules are ignored

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -68,13 +68,47 @@ sonar.test.exclusions=tests/fixtures/**
 # the release gate) already vets every one over src/, telling a safe wrap apart
 # from a value that could exceed 2^31, so S7767 here is a blunt duplicate of a
 # check the repo already runs, more precisely.
-sonar.issue.ignore.multicriteria=e1,e2,e3
+#
+# The four rules below (e4-e7) arrived with a 2025 Quality Profile update that
+# tagged them with a RELIABILITY impact and flagged pre-existing, intentional
+# code as new-code reliability issues. None is a defect this codebase can act on:
+#
+#   S7758 (Unicode-aware string methods) fires on charCodeAt/fromCharCode in the
+#   LAS, PNG, PLY, PTX, E57 and PDF byte parsers, where a code unit is a byte on
+#   purpose (a `& 0x7f` ASCII fold, an `=== 13` test for a carriage return).
+#   codePointAt/fromCodePoint would be wrong for byte-level I/O.
+#
+#   S7781 (prefer replaceAll) and S7773 (prefer Number.NaN) are modernization
+#   nits: the current forms are correct and exercised by the test suite. They are
+#   mis-tagged as reliability, not defects.
+#
+#   S8786 (regex non-linear backtracking) fires on anchored single-quantifier
+#   patterns such as /=+$/ and /\.+$/ over bounded parsed tokens (a base64
+#   string, a hostname, a NUL-terminated WKT), which cannot backtrack
+#   catastrophically. JavaScript has no possessive quantifier or atomic group to
+#   satisfy the rule, so the only "fix" is rewriting a safe regex as a loop,
+#   trading a clear expression for a more error-prone one. e8 is the JavaScript
+#   analyser's key for the same rule (public/sw.js).
+#
+# The genuine bug in this batch, css:S4656 (a property declared twice), was FIXED
+# in the stylesheets rather than ignored.
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S3776
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
 sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S107
 sonar.issue.ignore.multicriteria.e2.resourceKey=**/*
 sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S7767
 sonar.issue.ignore.multicriteria.e3.resourceKey=**/*
+sonar.issue.ignore.multicriteria.e4.ruleKey=typescript:S7758
+sonar.issue.ignore.multicriteria.e4.resourceKey=**/*
+sonar.issue.ignore.multicriteria.e5.ruleKey=typescript:S7781
+sonar.issue.ignore.multicriteria.e5.resourceKey=**/*
+sonar.issue.ignore.multicriteria.e6.ruleKey=typescript:S7773
+sonar.issue.ignore.multicriteria.e6.resourceKey=**/*
+sonar.issue.ignore.multicriteria.e7.ruleKey=typescript:S8786
+sonar.issue.ignore.multicriteria.e7.resourceKey=**/*
+sonar.issue.ignore.multicriteria.e8.ruleKey=javascript:S8786
+sonar.issue.ignore.multicriteria.e8.resourceKey=**/*
 
 # Coverage is produced by the same run Codecov consumes, so both read one
 # measurement rather than two that can disagree.


### PR DESCRIPTION
A 2025 Quality Profile update gave four rules a RELIABILITY impact and flagged pre-existing, intentional code as new-code reliability issues. This lands the reasoning in version control, where a reader can check it against the code.

## The numbers, checked today

74 reliability issues are open, and their composition matches that account exactly:

| Rule | Open |
|---|---:|
| typescript:S7758 | 35 |
| typescript:S7781 | 16 |
| typescript:S8786 | 12 |
| typescript:S7773 | 10 |
| javascript:S8786 | 1 |

The nine genuine bugs in the original set were `css:S4656` duplicate declarations. Those were real, were fixed in #434, and are now **zero open**.

## Why the remaining four are not actionable

- **S7758** (Unicode-aware string methods) fires on `charCodeAt`/`fromCharCode` in the LAS, PNG, PLY, PTX, E57 and PDF byte parsers, where a code unit is a byte on purpose (an ASCII fold, a carriage-return test). The suggested replacement is wrong for byte-level I/O.
- **S7781** (`replaceAll`) and **S7773** (`Number.NaN`) are modernization nits. The current forms are correct and exercised by the suite; they are mis-tagged as reliability rather than being defects.
- **S8786** (regex backtracking) fires on anchored single-quantifier patterns over bounded parsed tokens, which cannot backtrack catastrophically. JavaScript has no possessive quantifier or atomic group to satisfy it, so the only "fix" trades a clear expression for a loop that is easier to get wrong.

## What this does not do

This project uses SonarCloud **automatic analysis**, so the enforced ignore list is the one in the project's Analysis Scope settings. This file is the version-controlled record of that decision, not the mechanism. Reaching a green reliability rating still needs the same five entries mirrored in the SonarCloud UI, which requires project-owner access.

One file, no source change.
