### PR TITLE
Wire resident stickiness behind the LOD-freeze exemption (opt-in)

### DIFF
--- a/src/perf/devFlags.ts
+++ b/src/perf/devFlags.ts
@@ -91,6 +91,15 @@ export interface DevFlags {
    */
   decodePool: boolean;
   /**
+   * Resident-stickiness in the budget selection. OFF by default: absent the
+   * flag, selection is the plain greedy fill it has always been. `?stickiness=on`
+   * gives an already-resident, non-refining node a small score bonus so
+   * budget-boundary noise cannot bump it out and force an evict → re-decode →
+   * re-fade cycle. Like `decodePool`, this can only ever turn something ON, so a
+   * stray value can never move a session off the shipping default.
+   */
+  residentStickiness: boolean;
+  /**
    * Explicit decode worker count, or null for "not specified". Only 1-4 are
    * accepted; anything else, including garbage and out-of-range values, reads
    * as null. A value here also opts INTO the pool — asking for N workers and
@@ -119,6 +128,10 @@ export const DEV_FLAG_DEFAULTS: Readonly<DevFlags> = Object.freeze({
   // mount already made once.
   decodePool: false,
   decodeWorkers: null,
+  // Stickiness changes what stays on screen at the budget boundary, and flicker
+  // is not observable from Node, so it stays opt-in until a browser run on a
+  // real streamed cloud shows it settling the pulsing WITHOUT stalling refinement.
+  residentStickiness: false,
 });
 
 /** `legacy` (any case) selects the legacy implementation; all else = default. */
@@ -199,6 +212,7 @@ export function parseDevFlags(search: string | URLSearchParams): DevFlags {
     angularPrediction: parseOnOff(params.get('angularPrediction')),
     streamingCommitMode: parseCommitMode(params.get('streamingCommitMode')),
     decodePool: parseOptIn(params.get('decodePool')),
+    residentStickiness: parseOptIn(params.get('stickiness')),
     decodeWorkers: parseWorkerCount(params.get('decodeWorkers')),
   };
 }

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -228,6 +228,16 @@ export interface SchedulerOptions {
   /** Identifies this scan to the queue, for cancellation and staleness. */
   readonly datasetId?: string;
 
+  /**
+   * Resident-stickiness strength for the budget selection, 0..1. Absent or 0
+   * keeps the plain greedy fill, which is the shipping default; a positive
+   * value lets an already-resident node whose subtree has no finer candidate
+   * hold its slot against marginally-higher-scoring newcomers. The host reads
+   * the `?stickiness=on` dev flag and passes the value, so the scheduler itself
+   * stays free of flag lookups.
+   */
+  readonly stickyMargin?: number;
+
   /** Hysteresis window for eviction, ms. */
   evictDeferMs?: number;
   /**
@@ -279,6 +289,53 @@ function buildAncestorProtection(nodes: readonly StreamingNode[]): Set<string> {
     }
   }
   return set;
+}
+
+/** The ids currently resident, as a set the budget selection can test against. */
+function residentIdSet(store: { residentNodes(): IterableIterator<StreamingNode> }): Set<string> {
+  const ids = new Set<string>();
+  for (const node of store.residentNodes()) ids.add(node.record.id);
+  return ids;
+}
+
+/**
+ * The candidates that a FINER candidate sits underneath this tick.
+ *
+ * This is the exemption that keeps resident-stickiness from freezing LOD. A
+ * coarse node holding its slot is only harmless while nothing finer is waiting
+ * to replace it; the moment its own descendant is also a candidate, the coarse
+ * node IS the thing refinement is trying to displace, so it must compete on its
+ * raw score with no bonus.
+ *
+ * Computed from THIS tick's candidate list rather than the previous wanted set,
+ * because that is the question stickiness actually asks: "is a finer node
+ * competing for this budget right now?" A previous-tick answer would let a
+ * coarse node keep a bonus for one extra tick against the very child that had
+ * just become a candidate.
+ *
+ * Exported for its own test: an exemption that silently marked nothing would
+ * leave stickiness free to freeze LOD while every other test still passed.
+ */
+export function buildRefiningCandidateIds(
+  scored: readonly { readonly node: StreamingNode; readonly candidate: ScoredCandidate }[],
+): Set<string> {
+  // key -> candidate id, so an ancestor walk can ask "is this ancestor itself a
+  // candidate?" without rebuilding ids per level.
+  const idByKey = new Map<string, string>();
+  for (const s of scored) idByKey.set(voxelKeyString(s.node.record.key), s.candidate.id);
+  const refining = new Set<string>();
+  for (const s of scored) {
+    const key = s.node.record.key;
+    let { x, y, z } = key;
+    for (let d = key.depth - 1; d >= 0; d--) {
+      x >>= 1;
+      y >>= 1;
+      z >>= 1;
+      const ancestorId = idByKey.get(`${d}/${x}/${y}/${z}`);
+      if (ancestorId !== undefined) refining.add(ancestorId);
+    }
+  }
+  return refining;
 }
 
 /**
@@ -499,6 +556,14 @@ export class StreamingScheduler {
   private _lastSigStoreSize = -1;
   /** Last full rescore's wanted set (reused while the signature stays equal). */
   private _lastWanted: ReadonlySet<string> | null = null;
+  /**
+   * Resident-stickiness strength, read once from the dev flags. 0 disables the
+   * pass entirely and reproduces the plain greedy fill exactly, which is the
+   * shipping default. 0.15 is a fifteen-percent score bonus: enough to hold a
+   * slot against boundary noise, far too small to hold one against a genuinely
+   * closer or coarser-and-cheaper node.
+   */
+  private readonly _stickyMargin: number;
   /** Last full rescore's scored list (same lifecycle as `_lastWanted`). */
   private _lastScored: { node: StreamingNode; candidate: ScoredCandidate }[] | null = null;
   /** Tick index of the last full rescore — drives the periodic forced rescore. */
@@ -522,6 +587,7 @@ export class StreamingScheduler {
     this._maxConcurrent = budgets.maxConcurrentDecodes;
     this._effectiveMaxConcurrent = budgets.maxConcurrentDecodes;
     this._cache = new CompressedChunkCache(budgets.chunkCacheBytes);
+    this._stickyMargin = Math.max(0, Math.min(1, options.stickyMargin ?? 0));
     this._evictDeferMs = options.evictDeferMs ?? DEFAULT_EVICT_DEFER_MS;
     this._memoryPressureRatio =
       options.memoryPressureRatio ?? DEFAULT_MEMORY_PRESSURE_RATIO;
@@ -929,9 +995,25 @@ export class StreamingScheduler {
         1,
         Math.floor(this._pointBudget * this._fpsBudgetFactor),
       );
+      // Resident stickiness (opt-in). A node already on screen keeps a small
+      // bonus so score noise at the budget boundary cannot bump it out and pay
+      // an evict → re-decode → re-fade cycle for nothing. The exemption is what
+      // makes that safe: any candidate with a finer candidate beneath it is
+      // refinement's own target, so it competes on its raw score and LOD cannot
+      // freeze. Off by default; flicker is not observable from Node, so this
+      // stays behind `?stickiness=on` until a browser run on a streamed cloud
+      // shows it settling the pulsing without stalling refinement.
+      const sticky = this._stickyMargin > 0;
       const freshWanted = selectWithinBudget(
         freshScored.map((s) => s.candidate),
         fpsAdjustedBudget,
+        sticky
+          ? {
+              resident: residentIdSet(store),
+              refining: buildRefiningCandidateIds(freshScored),
+              stickyMargin: this._stickyMargin,
+            }
+          : {},
       );
       scored = freshScored;
       wanted = freshWanted;

--- a/src/render/streaming/streamingAttach.ts
+++ b/src/render/streaming/streamingAttach.ts
@@ -86,6 +86,13 @@ export interface StreamingHost {
  * fade in; mobile and the low-tier preset skip it to preserve frame-budget
  * headroom (hard add/remove). Pure so the gating is unit-tested without a GPU.
  */
+/**
+ * The stickiness bonus a resident, non-refining node keeps: fifteen percent of
+ * its score. Large enough to absorb the boundary noise that makes regions pulse,
+ * far too small to hold a slot against a genuinely closer or cheaper node.
+ */
+const RESIDENT_STICKY_MARGIN = 0.15;
+
 export function shouldFadeIn(isMobile: boolean, quality: StreamingQuality): boolean {
   return !isMobile && quality !== 'low';
 }
@@ -193,7 +200,13 @@ export async function buildStreamingSession(
       nodeReadyHook: () => host.streamingNodeReadyHook(),
     }),
     streamingBudgets(quality, isMobile),
-    commit.schedulerOptions(),
+    {
+      ...commit.schedulerOptions(),
+      // Opt-in resident stickiness. The flag lives here, with the other host
+      // flag reads, so the scheduler stays free of lookups; 0 keeps the plain
+      // greedy fill that ships today.
+      stickyMargin: readDevFlags().residentStickiness ? RESIDENT_STICKY_MARGIN : 0,
+    },
   );
   return { cloud, scheduler, renderer, decoder, benchmark, commit };
 }

--- a/tests/devFlags.test.ts
+++ b/tests/devFlags.test.ts
@@ -31,6 +31,7 @@ describe('parseDevFlags — defaults', () => {
       streamingCommitMode: 'immediate',
       decodePool: false,
       decodeWorkers: null,
+      residentStickiness: false,
     });
   });
 
@@ -81,7 +82,17 @@ describe('parseDevFlags — the program §P0 flag set', () => {
       streamingCommitMode: 'immediate',
       decodePool: false,
       decodeWorkers: null,
+      residentStickiness: false,
     });
+  });
+
+  it('?stickiness=on opts into resident stickiness; every other input leaves it off', () => {
+    expect(parseDevFlags('?stickiness=on').residentStickiness).toBe(true);
+    expect(parseDevFlags('?stickiness=1').residentStickiness).toBe(true);
+    // Opt-in only: absence, garbage and an explicit "off" all keep the default.
+    expect(parseDevFlags('').residentStickiness).toBe(false);
+    expect(parseDevFlags('?stickiness=off').residentStickiness).toBe(false);
+    expect(parseDevFlags('?stickiness=maybe').residentStickiness).toBe(false);
   });
 
   it('?decodePool=on opts into pooled decoding; every other input leaves it off', () => {

--- a/tests/residentStickiness.test.ts
+++ b/tests/residentStickiness.test.ts
@@ -1,0 +1,144 @@
+/**
+ * residentStickiness.test.ts
+ *
+ * The admission-side anti-thrash pass, and the exemption that makes it safe.
+ *
+ * Resident stickiness gives an already-shown node a small score bonus so noise
+ * at the budget boundary cannot bump it out and pay an evict → re-decode →
+ * re-fade cycle for nothing. The danger is the failure mode that reverted an
+ * earlier attempt: if a coarse node can hold its slot against its OWN children,
+ * the scene stops refining. `buildRefiningCandidateIds` is the guard, and these
+ * tests exercise the guard, not just the bonus.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildRefiningCandidateIds } from '../src/render/streaming/StreamingScheduler';
+import { selectWithinBudget } from '../src/render/streaming/streamingBudget';
+import type { StreamingNode } from '../src/render/streaming/StreamingNode';
+import type { ScoredCandidate } from '../src/render/streaming/streamingBudget';
+
+/** A candidate at an octree key, with the shape the scheduler passes. */
+function cand(
+  depth: number, x: number, y: number, z: number, score: number, pointCount = 100,
+): { node: StreamingNode; candidate: ScoredCandidate } {
+  const id = `${depth}/${x}/${y}/${z}`;
+  return {
+    node: { record: { id, key: { depth, x, y, z }, pointCount } } as unknown as StreamingNode,
+    candidate: { id, pointCount, score },
+  };
+}
+
+describe('buildRefiningCandidateIds — the LOD-freeze guard', () => {
+  it('marks a parent whose CHILD is also a candidate', () => {
+    const scored = [cand(0, 0, 0, 0, 10), cand(1, 0, 0, 0, 9)];
+    const refining = buildRefiningCandidateIds(scored);
+    expect(refining.has('0/0/0/0')).toBe(true);   // the parent is being refined away
+    expect(refining.has('1/0/0/0')).toBe(false);  // the child is the refinement
+  });
+
+  it('marks EVERY ancestor in the chain, not just the immediate parent', () => {
+    const scored = [cand(0, 0, 0, 0, 10), cand(1, 0, 0, 0, 9), cand(2, 0, 0, 0, 8)];
+    const refining = buildRefiningCandidateIds(scored);
+    expect(refining.has('0/0/0/0')).toBe(true);
+    expect(refining.has('1/0/0/0')).toBe(true);
+    expect(refining.has('2/0/0/0')).toBe(false);
+  });
+
+  it('marks nothing when candidates are siblings with no descendant among them', () => {
+    const scored = [cand(1, 0, 0, 0, 10), cand(1, 1, 0, 0, 9), cand(1, 0, 1, 0, 8)];
+    expect(buildRefiningCandidateIds(scored).size).toBe(0);
+  });
+
+  it('does not mark a parent whose candidate descendant is in a DIFFERENT subtree', () => {
+    // 1/1/0/0 is not under 0/0/0/0's child path from 1/0/0/0's perspective; the
+    // only true ancestor chain is by bit-shift, so an unrelated deep node in
+    // another octant must not exempt a coarse node it does not refine.
+    const scored = [cand(1, 0, 0, 0, 10), cand(2, 2, 0, 0, 9)];
+    const refining = buildRefiningCandidateIds(scored);
+    // 2/2/0/0 shifts to 1/1/0/0, which is NOT a candidate, so nothing is marked.
+    expect(refining.size).toBe(0);
+  });
+
+  it('an empty candidate list marks nothing and does not throw', () => {
+    expect(buildRefiningCandidateIds([]).size).toBe(0);
+  });
+});
+
+describe('resident stickiness composed with the exemption', () => {
+  const budget = 100; // exactly one 100-point node fits
+
+  it('WITHOUT stickiness the marginally-higher newcomer always wins', () => {
+    const resident = new Set(['1/0/0/0']);
+    const picked = selectWithinBudget(
+      [{ id: '1/1/0/0', pointCount: 100, score: 1.05 }, { id: '1/0/0/0', pointCount: 100, score: 1.0 }],
+      budget,
+    );
+    expect(picked.has('1/1/0/0')).toBe(true);
+    expect(picked.has('1/0/0/0')).toBe(false);
+    expect(resident.size).toBe(1); // untouched: no stickiness was requested
+  });
+
+  it('WITH stickiness a resident node holds its slot against boundary noise', () => {
+    const picked = selectWithinBudget(
+      [{ id: '1/1/0/0', pointCount: 100, score: 1.05 }, { id: '1/0/0/0', pointCount: 100, score: 1.0 }],
+      budget,
+      { resident: new Set(['1/0/0/0']), refining: new Set(), stickyMargin: 0.15 },
+    );
+    // 1.0 x 1.15 = 1.15 > 1.05, so the node already on screen stays.
+    expect(picked.has('1/0/0/0')).toBe(true);
+    expect(picked.has('1/1/0/0')).toBe(false);
+  });
+
+  it('LOD IS NOT FROZEN: a resident parent loses to its own child despite the bonus', () => {
+    // This is the reverted failure mode, set up so ONLY the bonus could cause it:
+    // the child outranks the parent on raw score (1.05 > 1.00), but the parent
+    // would overtake it with stickiness (1.00 x 1.15 = 1.15 > 1.05). The
+    // exemption must strip that bonus because the child is right here.
+    const scored = [cand(0, 0, 0, 0, 1.0), cand(1, 0, 0, 0, 1.05)];
+    const refining = buildRefiningCandidateIds(scored);
+    const picked = selectWithinBudget(
+      scored.map((s) => s.candidate),
+      budget,
+      { resident: new Set(['0/0/0/0']), refining, stickyMargin: 0.15 },
+    );
+    expect(refining.has('0/0/0/0')).toBe(true); // the guard fired
+    expect(picked.has('1/0/0/0')).toBe(true);   // refinement proceeds
+    expect(picked.has('0/0/0/0')).toBe(false);
+
+    // And prove the bonus WOULD have frozen it, so the guard is load-bearing
+    // rather than incidental: same inputs, empty exemption set.
+    const frozen = selectWithinBudget(
+      scored.map((s) => s.candidate),
+      budget,
+      { resident: new Set(['0/0/0/0']), refining: new Set(), stickyMargin: 0.15 },
+    );
+    expect(frozen.has('0/0/0/0')).toBe(true);
+    expect(frozen.has('1/0/0/0')).toBe(false);
+  });
+
+  it('a resident node with no refinement beneath it still keeps its bonus', () => {
+    // Same shape as above, but the child is NOT a candidate this tick, so the
+    // parent is not refinement's target and stickiness legitimately applies.
+    const scored = [cand(0, 0, 0, 0, 1.0), cand(1, 5, 5, 5, 1.05)];
+    const refining = buildRefiningCandidateIds(scored);
+    expect(refining.size).toBe(0);
+    const picked = selectWithinBudget(
+      scored.map((s) => s.candidate),
+      budget,
+      { resident: new Set(['0/0/0/0']), refining, stickyMargin: 0.15 },
+    );
+    expect(picked.has('0/0/0/0')).toBe(true);
+  });
+
+  it('a margin of 0 reproduces the plain greedy fill exactly (the shipping default)', () => {
+    const candidates = [
+      { id: 'a', pointCount: 60, score: 1.05 },
+      { id: 'b', pointCount: 60, score: 1.0 },
+    ];
+    const plain = selectWithinBudget(candidates, budget);
+    const zeroMargin = selectWithinBudget(candidates, budget, {
+      resident: new Set(['b']), refining: new Set(), stickyMargin: 0,
+    });
+    expect([...zeroMargin]).toEqual([...plain]);
+  });
+});


### PR DESCRIPTION
`selectWithinBudget` carries a resident-stickiness pass the scheduler never fed, so it was inert.

`buildRefiningCandidateIds` supplies the exemption, computed from this tick's candidates. Any candidate with a finer candidate beneath it competes on its raw score with no bonus, so stickiness cannot freeze LOD. It is opt-in via `?stickiness=on` at 0.15, and the default is unchanged: a test pins that a zero margin reproduces the current selection exactly. The freeze test asserts both directions, so refinement proceeds with the exemption and stalls without it.

Flicker is not observable from Node, so the default stays off until a browser run on a streamed cloud. tsc clean, 65 streaming and flag tests, 1,974 in the unit shard.
