### PR TITLE
Say what limits a tool and what would lift it

### DIFF
--- a/docs/architecture/spatial-context-consumers.md
+++ b/docs/architecture/spatial-context-consumers.md
@@ -50,7 +50,7 @@ has re-opened the divergence this closes.
   `carrier` path must be free of the deprecated predicates listed below.
 - **Reads** — the context fields it now uses.
 
-## Inventory (15 consumers)
+## Inventory (16 consumers)
 
 | # | Consumer | Status | Routes through | Reads |
 |---|----------|--------|----------------|-------|
@@ -69,6 +69,7 @@ has re-opened the divergence this closes.
 | 13 | Elevation colorbars | migrated | `src/main.ts`, `src/app/terrainAnalysisRunner.ts` | `verticalMetresPerUnit`, `kind` |
 | 14 | Classification | migrated | `src/render/class/classifierCues.ts` | `linearUnitToMetres`, `verticalMetresPerUnit` |
 | 15 | Streaming scan-report extents | migrated | `src/analysis/streamingExtentRows.ts` | `linearUnitKnown`, `linearUnitToMetres`, `verticalMetresPerUnit` |
+| 16 | Tool preflight | migrated | `src/process/toolPreflight.ts` | `metricClaimsPermitted`, `verticalReferenceKnown`, `crsName` |
 
 ## Deprecated predicates
 

--- a/src/geo/SpatialContext.ts
+++ b/src/geo/SpatialContext.ts
@@ -5,7 +5,7 @@
  * consumer that is about to make a metric claim — a distance in metres, an area
  * in m², a volume in m³, a density in pts/m², an elevation against a datum — can
  * read a single object instead of re-deriving unit, datum, axis and frame from
- * `metadata.crs` five different ways. The inventory tracks 15 consumers that
+ * `metadata.crs` five different ways. The inventory tracks 16 consumers that
  * each used to reach into a `CrsInfo` / `ResolvedCrs` and re-answer the same
  * questions (see docs/architecture/spatial-context-consumers.md, which
  * `scripts/lint-spatial-context.mjs` holds to the tree); the divergence between
@@ -195,7 +195,7 @@ export interface SpatialContextPlacement {
  * project-frame placement. A `null` / `undefined` CRS fails closed: the context
  * resolves to `unknown`, and `metricClaimsPermitted` is `false`.
  *
- * Accepting both inputs is what lets all 15 consumers route through this one
+ * Accepting both inputs is what lets all 16 consumers route through this one
  * façade without hand-building anything: a `CrsInfo` is bridged through the
  * canonical `resolvedFromCrsInfo` mapper, while a `ResolvedCrs` — which already
  * carries the resolved `kind` (including `local` / `unknown`, which a `CrsInfo`

--- a/src/process/toolPreflight.ts
+++ b/src/process/toolPreflight.ts
@@ -1,0 +1,478 @@
+/**
+ * toolPreflight.ts — what limits a tool, and the shortest way to lift it.
+ *
+ * A disabled control says nothing. It does not name the condition that limits
+ * it, and it does not say what would change the answer, so the user is left to
+ * guess between "my data is wrong", "I picked the wrong layer" and "the app is
+ * still loading". This module turns that silence into plain data: for one tool,
+ * a status in the {@link Readiness} vocabulary, the conditions that produced it,
+ * and the corrective actions that would clear them.
+ *
+ * IT DECIDES NOTHING ITSELF. Every verdict is read from the service that already
+ * owns it:
+ *
+ *   • whether a metric claim is permitted  ← {@link SpatialContext.metricClaimsPermitted}
+ *   • whether the layers share a reference ← `layerContextOf` + `measureConfidence`
+ *   • what a derived product may produce   ← `ProcessService` / `evaluateCapabilities`
+ *   • how much of a scan is readable       ← the normalised {@link ScanFacts.coverage}
+ *
+ * A second opinion about units or coverage assembled here would be the exact
+ * defect the rest of the tree guards against, so this file contains no unit
+ * arithmetic, no datum comparison and no coverage estimation. What it adds is
+ * the mapping from an established verdict to a named condition and a corrective
+ * action — and nothing else.
+ *
+ * Fail-closed, like the services it reads. A fact that cannot be established
+ * degrades the status; it is never guessed. An omitted layer-compatibility set
+ * over several scans reads as unproven, an omitted scene datum reads as
+ * unresolved, and a tool with no capability verdict is blocked.
+ *
+ * DOMAIN-ORIENTED, not UI-specific: no DOM, no three.js, and a remediation names
+ * an ACTION, not a button. Pure and Node-testable.
+ */
+
+import type { SpatialContext } from '../geo/SpatialContext';
+import type { LayerCompatibility } from '../model/layerCompatibility';
+import type { MeasureSceneContext } from '../render/measure/measureConfidence';
+import { confidenceForKind, layerContextOf } from '../render/measure/measureConfidence';
+import type { MeasurementKind } from '../render/measure/types';
+import type { Coverage, ProductId, Readiness, ScanFacts } from './ProcessPlan';
+import { ProcessService } from './ProcessService';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Vocabulary
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * How limited a tool is. Deliberately the SAME three words the capability model
+ * uses ({@link Readiness}), aliased rather than redeclared so the two can never
+ * drift into a parallel vocabulary.
+ */
+export type PreflightStatus = Readiness;
+
+/** The tools a user can reach that this model reasons about. */
+export type ToolId =
+  | 'measure-distance'
+  | 'measure-area'
+  | 'measure-height'
+  | 'measure-volume'
+  | 'classify'
+  | 'terrain-dtm'
+  | 'terrain-dsm'
+  | 'contours'
+  | 'building-footprints'
+  | 'cross-epoch-change'
+  | 'cut-fill-volume';
+
+/**
+ * A corrective action, named as a DOMAIN intent. It says what would change the
+ * answer, not which control does it, so a panel, a command palette and a test
+ * can each bind it their own way.
+ */
+export type PreflightActionId =
+  /** Confirm the coordinate system so the physical unit is established. */
+  | 'set-coordinate-system'
+  /** Proceed with the figure labelled exploratory rather than metric. */
+  | 'continue-exploratory'
+  /** Reduce the scene to the active layer, so one proven frame is in play. */
+  | 'solo-active-layer'
+  /** Look at what each layer declares about its horizontal/vertical reference. */
+  | 'inspect-layer-crs'
+  /** Wait until the streaming set covers everything currently visible. */
+  | 'await-full-coverage'
+  /** Proceed over the points that are resident now, scoped to them. */
+  | 'continue-resident-only'
+  /** Load the second epoch a comparison needs. */
+  | 'load-second-scan'
+  /** Prove the two scans' frames compatible before comparing them. */
+  | 'align-scans'
+  /** Derive the classes a class-dependent product needs. */
+  | 'classify-scan';
+
+/** One condition that limits the tool, with a stable greppable code. */
+export interface PreflightReason {
+  /** Stable UPPER_SNAKE slug — safe to switch on, safe to grep for. */
+  readonly code: string;
+  /** One sentence naming the condition. */
+  readonly message: string;
+}
+
+/** One corrective action offered against the reasons above. */
+export interface PreflightRemediation {
+  readonly label: string;
+  readonly action: PreflightActionId;
+}
+
+/**
+ * The preflight verdict for one tool. `reasons` is empty exactly when nothing
+ * limits the tool, and `remediations` is empty when there is nothing to offer —
+ * so a `ready` preflight carries neither.
+ */
+export interface ToolPreflight {
+  readonly tool: ToolId;
+  readonly status: PreflightStatus;
+  readonly reasons: readonly PreflightReason[];
+  readonly remediations: readonly PreflightRemediation[];
+}
+
+/**
+ * Everything the preflight reads. Each field is the OUTPUT of a service that
+ * already established it; nothing here is a raw signal this module interprets
+ * for itself.
+ */
+export interface PreflightInput {
+  /**
+   * The loaded scans, already normalised fail-closed by `deriveScanFacts`. The
+   * capability verdicts are evaluated from these, and `coverage` is read from
+   * them (never estimated here).
+   */
+  readonly scans: readonly ScanFacts[];
+  /** The frame description for the active scan — the single unit authority. */
+  readonly spatial: SpatialContext;
+  /**
+   * What each visible layer has proven about its frame, from
+   * `classifyLayerCompatibility`. Omitted over more than one scan reads as
+   * unproven, which is the fail-closed answer, never "compatible".
+   */
+  readonly layerCompatibility?: readonly LayerCompatibility[];
+  /** Whether the scene resolved a shared origin datum. Omitted ⇒ unresolved. */
+  readonly datumResolved?: boolean;
+  /** Whether two scans are in a proven-compatible frame; omitted ⇒ unproven. */
+  readonly projectFrameCompatible?: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tool bindings
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Which authority answers for a tool. */
+type ToolBinding =
+  /** An interactive measurement: the measure-confidence + unit authorities. */
+  | { readonly family: 'measure'; readonly kind: MeasurementKind }
+  /** A derived product: the process capability model answers in full. */
+  | { readonly family: 'product'; readonly product: ProductId };
+
+/**
+ * Every tool bound to the authority that answers for it. A full `Record` on
+ * purpose: adding a `ToolId` without binding it fails to compile, so a tool can
+ * never reach the model with no authority behind it.
+ */
+const TOOL_BINDING: Readonly<Record<ToolId, ToolBinding>> = {
+  'measure-distance': { family: 'measure', kind: 'distance' },
+  'measure-area': { family: 'measure', kind: 'area' },
+  'measure-height': { family: 'measure', kind: 'height' },
+  'measure-volume': { family: 'measure', kind: 'volume' },
+  classify: { family: 'product', product: 'classify-gaps' },
+  'terrain-dtm': { family: 'product', product: 'dtm' },
+  'terrain-dsm': { family: 'product', product: 'dsm' },
+  contours: { family: 'product', product: 'contours' },
+  'building-footprints': { family: 'product', product: 'building-footprints' },
+  'cross-epoch-change': { family: 'product', product: 'cross-epoch-change' },
+  'cut-fill-volume': { family: 'product', product: 'volume-cut-fill' },
+};
+
+/** Every tool the model reasons about, in declaration order. */
+export const ALL_TOOLS: readonly ToolId[] = Object.keys(TOOL_BINDING) as ToolId[];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Remediation catalogue
+// ─────────────────────────────────────────────────────────────────────────────
+
+const REMEDIATION: Readonly<Record<PreflightActionId, PreflightRemediation>> = {
+  'set-coordinate-system': { label: 'Set the coordinate system', action: 'set-coordinate-system' },
+  'continue-exploratory': { label: 'Continue, labelled exploratory', action: 'continue-exploratory' },
+  'solo-active-layer': { label: 'Show the active layer on its own', action: 'solo-active-layer' },
+  'inspect-layer-crs': { label: 'Inspect each layer’s coordinate reference', action: 'inspect-layer-crs' },
+  'await-full-coverage': { label: 'Wait for full visible coverage', action: 'await-full-coverage' },
+  'continue-resident-only': { label: 'Continue on the resident points', action: 'continue-resident-only' },
+  'load-second-scan': { label: 'Load a second scan', action: 'load-second-scan' },
+  'align-scans': { label: 'Align the two scans', action: 'align-scans' },
+  'classify-scan': { label: 'Classify the scan first', action: 'classify-scan' },
+};
+
+/**
+ * Actions that let the user proceed with the limitation stated rather than
+ * removing it. They are only honest when the tool can actually run, so a
+ * `blocked` preflight drops them and offers corrective actions alone.
+ */
+const PERMISSIVE: ReadonlySet<PreflightActionId> = new Set([
+  'continue-exploratory',
+  'continue-resident-only',
+]);
+
+/**
+ * The corrective actions for each reason code the capability model emits. A code
+ * with no entry has no action this model can honestly offer (an empty scan, an
+ * already-complete classification), and that is stated by offering none rather
+ * than by inventing a step.
+ */
+const ACTIONS_BY_PRODUCT_CODE: Readonly<Record<string, readonly PreflightActionId[]>> = {
+  UNIT_UNKNOWN: ['set-coordinate-system', 'continue-exploratory'],
+  RESIDENT_ONLY: ['await-full-coverage', 'continue-resident-only'],
+  PARTIAL_COVERAGE: ['await-full-coverage', 'continue-resident-only'],
+  RESIDENT_OVERLAP_ONLY: ['await-full-coverage', 'continue-resident-only'],
+  VERTICAL_REF_DIFFERS: ['solo-active-layer', 'inspect-layer-crs'],
+  VERTICAL_UNIT_CONFLICT: ['solo-active-layer', 'inspect-layer-crs'],
+  FRAME_UNPROVEN: ['align-scans', 'inspect-layer-crs'],
+  NEED_TWO_SCANS: ['load-second-scan'],
+  NEEDS_CLASSIFICATION: ['classify-scan'],
+  NO_BUILDING_CLASS: ['classify-scan'],
+  GROUND_DERIVED: ['classify-scan', 'continue-exploratory'],
+  DTM_REVIEW: ['continue-exploratory'],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Assembly
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A reason plus the actions it justifies, before de-duplication. */
+interface CandidateReason {
+  readonly status: PreflightStatus;
+  readonly code: string;
+  readonly message: string;
+  readonly actions: readonly PreflightActionId[];
+}
+
+const STATUS_RANK: Readonly<Record<PreflightStatus, number>> = {
+  ready: 0,
+  review: 1,
+  blocked: 2,
+};
+
+/** The more limiting of two statuses — a tool is as limited as its worst condition. */
+function worse(a: PreflightStatus, b: PreflightStatus): PreflightStatus {
+  return STATUS_RANK[b] > STATUS_RANK[a] ? b : a;
+}
+
+/**
+ * Collapse the candidate reasons into one verdict: the worst status, every
+ * reason in the order it was established, and the actions de-duplicated so a
+ * condition named twice does not offer the same step twice.
+ */
+function assemble(tool: ToolId, candidates: readonly CandidateReason[]): ToolPreflight {
+  let status: PreflightStatus = 'ready';
+  for (const c of candidates) status = worse(status, c.status);
+
+  const seen = new Set<PreflightActionId>();
+  const remediations: PreflightRemediation[] = [];
+  for (const c of candidates) {
+    for (const action of c.actions) {
+      if (status === 'blocked' && PERMISSIVE.has(action)) continue;
+      if (seen.has(action)) continue;
+      seen.add(action);
+      remediations.push(REMEDIATION[action]);
+    }
+  }
+
+  return {
+    tool,
+    status,
+    reasons: candidates.map((c) => ({ code: c.code, message: c.message })),
+    remediations,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prepared authorities
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The services, built once so a batch preflight evaluates them a single time. */
+interface PreparedAuthorities {
+  readonly service: ProcessService;
+  readonly scene: MeasureSceneContext;
+}
+
+/**
+ * Build the authorities this input describes. The layer context is derived by
+ * `layerContextOf`, never by counting here; an absent compatibility set is
+ * filled with `unknown` per scan so a multi-scan scene reads as unproven — the
+ * same fail-closed default the live measure wiring uses.
+ */
+function prepare(ctx: PreflightInput): PreparedAuthorities {
+  const states: readonly LayerCompatibility[] =
+    ctx.layerCompatibility ?? ctx.scans.map((): LayerCompatibility => 'unknown');
+  return {
+    service: ProcessService.fromFacts(ctx.scans, ctx.projectFrameCompatible),
+    scene: {
+      datumResolved: ctx.datumResolved === true,
+      layers: layerContextOf(states),
+      verticalReferenceKnown: ctx.spatial.verticalReferenceKnown,
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Coverage
+// ─────────────────────────────────────────────────────────────────────────────
+
+const COVERAGE_RANK: Readonly<Record<Coverage, number>> = {
+  full: 0,
+  sampled: 1,
+  'resident-only': 2,
+};
+
+/**
+ * The least complete coverage among the loaded scans, or `null` when every scan
+ * is fully readable. Reads the normalised `ScanFacts.coverage` — the fact
+ * `deriveScanFacts` already settled fail-closed — and ranks it; it estimates
+ * nothing about what a streaming source has actually delivered.
+ */
+function coverageShortfall(scans: readonly ScanFacts[]): Coverage | null {
+  let worstCoverage: Coverage = 'full';
+  for (const s of scans) {
+    if (COVERAGE_RANK[s.coverage] > COVERAGE_RANK[worstCoverage]) worstCoverage = s.coverage;
+  }
+  return worstCoverage === 'full' ? null : worstCoverage;
+}
+
+/** The coverage condition for an interactive tool, or `null` when there is none. */
+function coverageReason(scans: readonly ScanFacts[]): CandidateReason | null {
+  const shortfall = coverageShortfall(scans);
+  if (shortfall === null) return null;
+  return shortfall === 'resident-only'
+    ? {
+        status: 'review',
+        code: 'STREAMING_RESIDENT_ONLY',
+        message:
+          'The streaming source is still refining: only the resident points can be read, so the figure describes that subset rather than everything in view.',
+        actions: ['await-full-coverage', 'continue-resident-only'],
+      }
+    : {
+        status: 'review',
+        code: 'SAMPLED_COVERAGE',
+        message:
+          'Only a sample of the scan can be read, so the figure describes that sample rather than the whole scan.',
+        actions: ['await-full-coverage', 'continue-resident-only'],
+      };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The two families
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * An interactive measurement. Three authorities answer, and each contributes at
+ * most one condition: the spatial context on whether a metric claim is
+ * permitted, `measureConfidence` on whether the visible layers share a proven
+ * reference, and the normalised coverage on whether the data is still refining.
+ */
+function preflightMeasure(
+  tool: ToolId,
+  kind: MeasurementKind,
+  ctx: PreflightInput,
+  prepared: PreparedAuthorities,
+): ToolPreflight {
+  if (ctx.scans.length === 0) {
+    return assemble(tool, [
+      {
+        status: 'blocked',
+        code: 'NO_SCAN_LOADED',
+        message: 'No scan is loaded, so there is nothing to measure.',
+        actions: [],
+      },
+    ]);
+  }
+
+  const candidates: CandidateReason[] = [];
+
+  // 1. Physical unit. The context's own gate, read whole — a figure without a
+  //    confirmed unit is exploratory, and volume is the clearest case.
+  if (!ctx.spatial.metricClaimsPermitted) {
+    candidates.push({
+      status: 'review',
+      code: 'UNIT_UNRESOLVED',
+      message: `The physical unit is not confirmed for “${ctx.spatial.crsName}”, so this figure stays exploratory rather than a metric claim.`,
+      actions: ['set-coordinate-system', 'continue-exploratory'],
+    });
+  }
+
+  // 2. Shared reference across the visible layers, from the measure-confidence
+  //    ladder. `unavailable` is a refusal (no combined figure has a meaning);
+  //    `approximate` names whichever facts stayed unproven, in its own words.
+  const confidence = confidenceForKind(kind, prepared.scene);
+  if (confidence.level === 'unavailable') {
+    candidates.push({
+      status: 'blocked',
+      code: 'NO_SHARED_REFERENCE',
+      message: `The visible layers do not share a proven reference: ${confidence.reason}.`,
+      actions: ['solo-active-layer', 'inspect-layer-crs'],
+    });
+  } else if (confidence.level === 'approximate') {
+    candidates.push({
+      status: 'review',
+      code: 'SHARED_REFERENCE_UNPROVEN',
+      message: `The shared reference is not established: ${confidence.reason}.`,
+      actions: ['solo-active-layer', 'inspect-layer-crs'],
+    });
+  }
+
+  // 3. Coverage.
+  const coverage = coverageReason(ctx.scans);
+  if (coverage !== null) candidates.push(coverage);
+
+  return assemble(tool, candidates);
+}
+
+/**
+ * A derived product. The capability model already weighs unit, coverage, ground
+ * trust, vertical reference and frame compatibility for exactly these products,
+ * so its verdict is taken WHOLE — status, code and sentence — and this function
+ * only attaches the corrective actions the code implies. Re-deciding any part of
+ * it here would be the second opinion the model exists to prevent.
+ */
+function preflightProduct(
+  tool: ToolId,
+  product: ProductId,
+  prepared: PreparedAuthorities,
+): ToolPreflight {
+  const capability = prepared.service.capability(product);
+  if (capability == null) {
+    return assemble(tool, [
+      {
+        status: 'blocked',
+        code: 'NO_SCAN_LOADED',
+        message: 'No scan is loaded, so the capability model has no verdict for this product.',
+        actions: [],
+      },
+    ]);
+  }
+  if (capability.readiness === 'ready') return assemble(tool, []);
+  return assemble(tool, [
+    {
+      status: capability.readiness,
+      code: capability.reasonCode,
+      message: capability.reason,
+      actions: ACTIONS_BY_PRODUCT_CODE[capability.reasonCode] ?? [],
+    },
+  ]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entry points
+// ─────────────────────────────────────────────────────────────────────────────
+
+function preflightWith(
+  tool: ToolId,
+  ctx: PreflightInput,
+  prepared: PreparedAuthorities,
+): ToolPreflight {
+  const binding = TOOL_BINDING[tool];
+  return binding.family === 'measure'
+    ? preflightMeasure(tool, binding.kind, ctx, prepared)
+    : preflightProduct(tool, binding.product, prepared);
+}
+
+/** What limits one tool right now, and what would lift it. */
+export function preflightFor(tool: ToolId, ctx: PreflightInput): ToolPreflight {
+  return preflightWith(tool, ctx, prepare(ctx));
+}
+
+/**
+ * The preflight for every tool, evaluating the shared authorities once. Use this
+ * when a surface needs the whole set; the per-tool answers are identical to
+ * {@link preflightFor}.
+ */
+export function preflightAll(ctx: PreflightInput): readonly ToolPreflight[] {
+  const prepared = prepare(ctx);
+  return ALL_TOOLS.map((tool) => preflightWith(tool, ctx, prepared));
+}

--- a/tests/toolPreflight.test.ts
+++ b/tests/toolPreflight.test.ts
@@ -1,0 +1,318 @@
+/**
+ * toolPreflight.test.ts
+ *
+ * The preflight model has one job: when a tool is limited, say which condition
+ * limits it and what would lift it. These tests pin the four conditions the
+ * v0.6.6 interaction brief names — an unresolved physical unit, no proven shared
+ * vertical reference across the visible layers, streaming data still refining,
+ * and a classification prerequisite that needs a confirmed physical scale — plus
+ * the state where nothing limits the tool at all.
+ *
+ * They also pin the property that makes the model safe to build a UI on: every
+ * verdict comes from the service that already owns it (SpatialContext for the
+ * unit, measureConfidence for the shared reference, the capability model for
+ * derived products), so a status can never be more permissive than the authority
+ * behind it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CrsInfo } from '../src/io/crs';
+import { spatialContextFrom } from '../src/geo/SpatialContext';
+import type { ScanFacts } from '../src/process/ProcessPlan';
+import {
+  ALL_TOOLS,
+  preflightAll,
+  preflightFor,
+  type PreflightInput,
+  type ToolPreflight,
+} from '../src/process/toolPreflight';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A projected metre CRS with an orthometric vertical datum — nothing unknown. */
+function fullyKnownCrs(overrides: Partial<CrsInfo> = {}): CrsInfo {
+  return {
+    source: 'epsg',
+    name: 'WGS 84 / UTM zone 12N',
+    epsg: 32612,
+    linearUnit: 'metre',
+    linearUnitToMetres: 1,
+    isGeographic: false,
+    verticalEpsg: 5703,
+    verticalDatum: 'NAVD88',
+    verticalUnitToMetres: 1,
+    ...overrides,
+  } as CrsInfo;
+}
+
+function scan(overrides: Partial<ScanFacts> = {}): ScanFacts {
+  return {
+    kind: 'static',
+    coverage: 'full',
+    crs: fullyKnownCrs(),
+    pointCount: 1_000_000,
+    hasRgb: true,
+    hasIntensity: true,
+    hasGpsTime: true,
+    hasReturnNumber: true,
+    hasPointSourceId: false,
+    classification: 'full',
+    classificationProvenance: 'producer',
+    groundClassified: true,
+    hasBuildingClass: true,
+    medianSpacing: 0.2,
+    ...overrides,
+  };
+}
+
+/** The state where every fact is established: one scan, known frame, datum held. */
+function readyInput(overrides: Partial<PreflightInput> = {}): PreflightInput {
+  return {
+    scans: [scan()],
+    spatial: spatialContextFrom(fullyKnownCrs()),
+    layerCompatibility: ['verified'],
+    datumResolved: true,
+    ...overrides,
+  };
+}
+
+const codes = (p: ToolPreflight): readonly string[] => p.reasons.map((r) => r.code);
+const actions = (p: ToolPreflight): readonly string[] => p.remediations.map((r) => r.action);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Unresolved physical unit
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('unresolved physical unit', () => {
+  /** No CRS at all: the context refuses metric claims, so a volume is exploratory. */
+  const unitless: PreflightInput = readyInput({
+    scans: [scan({ crs: null })],
+    spatial: spatialContextFrom(null),
+  });
+
+  it('holds a volume at exploratory rather than presenting it as a metric figure', () => {
+    const p = preflightFor('measure-volume', unitless);
+    expect(p.status).toBe('review');
+    expect(codes(p)).toContain('UNIT_UNRESOLVED');
+  });
+
+  it('offers setting the coordinate system, or continuing exploratory', () => {
+    const p = preflightFor('measure-volume', unitless);
+    expect(actions(p)).toContain('set-coordinate-system');
+    expect(actions(p)).toContain('continue-exploratory');
+  });
+
+  it('names the condition on every metric measurement, not just volume', () => {
+    for (const tool of ['measure-distance', 'measure-area', 'measure-height'] as const) {
+      expect(codes(preflightFor(tool, unitless))).toContain('UNIT_UNRESOLVED');
+    }
+  });
+
+  it('reads the verdict from the spatial context, not from a private unit test', () => {
+    // The context is the authority: while it permits metric claims, no preflight
+    // may report an unresolved unit, whatever else is true of the scan.
+    const permitted = readyInput();
+    expect(permitted.spatial.metricClaimsPermitted).toBe(true);
+    for (const tool of ALL_TOOLS) {
+      expect(codes(preflightFor(tool, permitted))).not.toContain('UNIT_UNRESOLVED');
+    }
+  });
+
+  it('blocks a metric product outright where the capability model does', () => {
+    // Footprint AREA cannot be exploratory: the capability model blocks it on an
+    // unconfirmed unit, and the preflight carries that verdict rather than
+    // softening it — so the permissive action is withheld too.
+    const p = preflightFor('building-footprints', unitless);
+    expect(p.status).toBe('blocked');
+    expect(codes(p)).toContain('UNIT_UNKNOWN');
+    expect(actions(p)).toEqual(['set-coordinate-system']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. No proven shared vertical reference across the visible layers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('no proven shared reference across visible layers', () => {
+  /** Two layers, one proven to be in a different frame. */
+  const incomparable: PreflightInput = readyInput({
+    scans: [scan(), scan()],
+    layerCompatibility: ['verified', 'incompatible'],
+  });
+
+  it('refuses a height across layers that are in incomparable frames', () => {
+    const p = preflightFor('measure-height', incomparable);
+    expect(p.status).toBe('blocked');
+    expect(codes(p)).toContain('NO_SHARED_REFERENCE');
+  });
+
+  it('offers soloing the active layer or inspecting each layer CRS', () => {
+    const p = preflightFor('measure-height', incomparable);
+    expect(actions(p)).toEqual(['solo-active-layer', 'inspect-layer-crs']);
+  });
+
+  it('never offers "continue" once the reference is refused', () => {
+    const p = preflightFor('measure-volume', incomparable);
+    expect(p.status).toBe('blocked');
+    expect(actions(p)).not.toContain('continue-exploratory');
+    expect(actions(p)).not.toContain('continue-resident-only');
+  });
+
+  it('degrades to review, not ready, when the layer set is merely unproven', () => {
+    // No compatibility set supplied over two scans: unproven, which is a caveat
+    // rather than a refusal.
+    const unproven = readyInput({ scans: [scan(), scan()], layerCompatibility: undefined });
+    const p = preflightFor('measure-height', unproven);
+    expect(p.status).toBe('review');
+    expect(codes(p)).toContain('SHARED_REFERENCE_UNPROVEN');
+  });
+
+  it('blocks cross-epoch change when the two scans declare different vertical datums', () => {
+    const differing = readyInput({
+      scans: [
+        scan(),
+        scan({ crs: fullyKnownCrs({ verticalEpsg: 3855, verticalDatum: 'EGM2008 height' }) }),
+      ],
+      layerCompatibility: ['verified', 'horizontal-only'],
+      projectFrameCompatible: true,
+    });
+    const p = preflightFor('cross-epoch-change', differing);
+    expect(p.status).toBe('blocked');
+    expect(codes(p)).toContain('VERTICAL_REF_DIFFERS');
+    expect(actions(p)).toEqual(['solo-active-layer', 'inspect-layer-crs']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Streaming data still refining — resident-only coverage
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('streaming data still refining', () => {
+  const streaming: PreflightInput = readyInput({
+    scans: [scan({ kind: 'streaming', coverage: 'resident-only' })],
+  });
+
+  it('marks a measurement as scoped to the resident points', () => {
+    const p = preflightFor('measure-distance', streaming);
+    expect(p.status).toBe('review');
+    expect(codes(p)).toContain('STREAMING_RESIDENT_ONLY');
+  });
+
+  it('offers waiting for full visible coverage, or continuing resident-only', () => {
+    const p = preflightFor('measure-distance', streaming);
+    expect(actions(p)).toEqual(['await-full-coverage', 'continue-resident-only']);
+  });
+
+  it('carries the capability model verdict for a derived surface', () => {
+    const p = preflightFor('terrain-dtm', streaming);
+    expect(p.status).toBe('review');
+    expect(codes(p)).toContain('RESIDENT_ONLY');
+    expect(actions(p)).toContain('await-full-coverage');
+  });
+
+  it('does not raise the condition once coverage is full', () => {
+    const p = preflightFor('measure-distance', readyInput());
+    expect(codes(p)).not.toContain('STREAMING_RESIDENT_ONLY');
+  });
+
+  it('distinguishes a sampled read from a resident-only one', () => {
+    const sampled = readyInput({ scans: [scan({ coverage: 'sampled' })] });
+    expect(codes(preflightFor('measure-area', sampled))).toContain('SAMPLED_COVERAGE');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Classification prerequisites needing a confirmed physical scale
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('classification prerequisites', () => {
+  it('holds classification at review while the physical scale is unconfirmed', () => {
+    const unitless = readyInput({
+      scans: [scan({ crs: null, classification: 'none', classificationProvenance: 'none' })],
+      spatial: spatialContextFrom(null),
+    });
+    const p = preflightFor('classify', unitless);
+    expect(p.status).toBe('review');
+    expect(codes(p)).toContain('UNIT_UNKNOWN');
+    expect(actions(p)).toEqual(['set-coordinate-system', 'continue-exploratory']);
+  });
+
+  it('asks for classification first where a product needs the classes', () => {
+    const unclassified = readyInput({
+      scans: [
+        scan({
+          classification: 'none',
+          classificationProvenance: 'none',
+          groundClassified: false,
+          hasBuildingClass: false,
+        }),
+      ],
+    });
+    const p = preflightFor('building-footprints', unclassified);
+    expect(p.status).toBe('review');
+    expect(codes(p)).toContain('NEEDS_CLASSIFICATION');
+    expect(actions(p)).toContain('classify-scan');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Nothing limits the tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('the fully ready state', () => {
+  it('names no condition and offers no remediation', () => {
+    const p = preflightFor('measure-distance', readyInput());
+    expect(p.status).toBe('ready');
+    expect(p.reasons).toEqual([]);
+    expect(p.remediations).toEqual([]);
+  });
+
+  it('reaches ready for a height and for a derived surface too', () => {
+    for (const tool of ['measure-height', 'measure-volume', 'terrain-dtm', 'terrain-dsm'] as const) {
+      const p = preflightFor(tool, readyInput());
+      expect(p.status).toBe('ready');
+      expect(p.reasons).toEqual([]);
+    }
+  });
+
+  it('blocks every measurement when no scan is loaded', () => {
+    const empty: PreflightInput = {
+      scans: [],
+      spatial: spatialContextFrom(fullyKnownCrs()),
+      datumResolved: true,
+    };
+    const p = preflightFor('measure-area', empty);
+    expect(p.status).toBe('blocked');
+    expect(codes(p)).toEqual(['NO_SCAN_LOADED']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Model shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('model shape', () => {
+  it('answers for every tool, and the batch answers match the single answers', () => {
+    const ctx = readyInput({ scans: [scan({ coverage: 'resident-only', kind: 'streaming' })] });
+    const all = preflightAll(ctx);
+    expect(all.map((p) => p.tool)).toEqual([...ALL_TOOLS]);
+    for (const p of all) {
+      expect(preflightFor(p.tool, ctx)).toEqual(p);
+    }
+  });
+
+  it('never offers a remediation without a reason behind it', () => {
+    for (const ctx of [
+      readyInput(),
+      readyInput({ scans: [scan({ crs: null })], spatial: spatialContextFrom(null) }),
+      readyInput({ scans: [], layerCompatibility: [] }),
+    ]) {
+      for (const p of preflightAll(ctx)) {
+        if (p.reasons.length === 0) expect(p.remediations).toEqual([]);
+        if (p.status === 'ready') expect(p.reasons).toEqual([]);
+      }
+    }
+  });
+});


### PR DESCRIPTION
`src/process/toolPreflight.ts` answers, for one tool, which condition limits it and which action would change the answer. Status uses the existing `ready` / `review` / `blocked` vocabulary.

Nothing is decided in the new file. The unit verdict is read from `SpatialContext.metricClaimsPermitted`, the shared-reference verdict from `layerContextOf` plus `measureConfidence`, and each derived product carries its `ProcessService` capability whole. Coverage comes from the normalised `ScanFacts.coverage`. A fact that cannot be established degrades the status instead of being guessed.

Reasons carry a greppable code. Remediations name a domain action such as `set-coordinate-system` or `solo-active-layer`, not a control, so no UI shape is assumed. A blocked tool drops the "continue anyway" options.

This is the model only. Nothing consumes it yet.

22 tests in `tests/toolPreflight.test.ts`.
