### PR TITLE
Say where saved camera views actually live

### DIFF
--- a/src/ui/StreamingPanel.ts
+++ b/src/ui/StreamingPanel.ts
@@ -2,9 +2,12 @@
  * StreamingPanel.ts
  *
  * The user-facing panel for a streaming COPC scan: a metadata scan summary,
- * the live load phase and status (nodes, points, cache), the streaming
- * controls (colour, quality, pause/resume, clear cache), and saved camera
- * views.
+ * the live load phase and status (nodes, points, cache), and the streaming
+ * controls (colour, quality, pause/resume, clear cache, full-cloud grade).
+ *
+ * Saved camera views are NOT here. No panel renders them: they are reached
+ * through the command palette, whose actions in `src/app/actionDefinitions.ts`
+ * are the only surface the bookmark store has.
  *
  * It is calm by design — a few clear sections, no technical noise. The deep
  * counters belong to the `?debug=1` overlay, not here.


### PR DESCRIPTION
The StreamingPanel docstring listed saved camera views among the surfaces the panel provides. It exposes six callbacks and none is a saved view.

No panel renders them at all. The bookmark store in `app/viewBookmarks.ts` is reached only through the command-palette actions in `app/actionDefinitions.ts`, and no file under `src/ui/` references it. The docstring now says that, so the next person planning work against this panel starts from where the capability actually lives.

`lint:release-truth` catches this class of drift on release documents. It does not cover module docstrings.
