### PR TITLE
Give the E57 report poll the budget the attach already has

### DIFF
--- a/docs/validation/test-evidence.json
+++ b/docs/validation/test-evidence.json
@@ -5,9 +5,9 @@
   "releaseChannel": "development",
   "releaseAuthoritative": false,
   "tag": null,
-  "commit": "cd850e22b74234e4a806248628110e33a8cdc90f",
+  "commit": "97bc0d76b9b84784bdc797d6a87decc4b3ae7282",
   "repository": null,
-  "generatedAt": "2026-08-19T23:49:34.433Z",
+  "generatedAt": "2026-08-20T07:10:06.022Z",
   "nodeVersion": "v26.0.0",
   "npmVersion": "11.12.1",
   "platform": "darwin-arm64",
@@ -17,7 +17,7 @@
   "workflowSha": null,
   "gateExit": 0,
   "gateLog": "release/gate.log",
-  "gateLogSha256": "f959266936c97d2a883880b3c697e77a0c87d54ef21664118c42a675d58c9a54",
+  "gateLogSha256": "5917bbfcaf5a4cd4e26737904c04bcda586d7b9a11de3dc619af99206c30920c",
   "stages": {
     "staticGate": "passed",
     "mutation": "not-executed"
@@ -53,7 +53,7 @@
   },
   "buckets": {
     "unit": {
-      "passed": 5839,
+      "passed": 5974,
       "skipped": 22,
       "runs": 3
     },
@@ -63,12 +63,12 @@
       "runs": 1
     },
     "terrain": {
-      "passed": 1600,
+      "passed": 1608,
       "skipped": 0,
       "runs": 2
     },
     "ui": {
-      "passed": 557,
+      "passed": 563,
       "skipped": 0,
       "runs": 1
     },
@@ -79,11 +79,11 @@
     }
   },
   "total": {
-    "passed": 9605,
+    "passed": 9754,
     "skipped": 22
   },
   "bundle": {
-    "liveEntryKiB": 743,
+    "liveEntryKiB": 736,
     "ceilingKiB": 744
   },
   "packageLockSha256": "56be9b578b4ab7fba32abd1ad84e0c80d0990548ef8aaae5a980c850e46b58ef",

--- a/tests/e2e/viewer.spec.ts
+++ b/tests/e2e/viewer.spec.ts
@@ -69,8 +69,14 @@ test('opens a dropped E57 scan', async ({ page }) => {
 
   await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
   await expect(page.locator('.olv-layer')).toHaveCount(1);
+  // The report rows are analysis-module output, so they land AFTER the attach
+  // the line above waits on, on the same heaviest-decode path this test already
+  // calls `test.slow()` for. A 5 s budget here was the tightest in the test and
+  // sat on its slowest step, which is how a loaded runner failed it twice in one
+  // run while every other job on the same commit passed. Matched to the budget
+  // the attach already gets.
   await expect
-    .poll(() => page.locator('.olv-report-row').count(), { timeout: 5_000 })
+    .poll(() => page.locator('.olv-report-row').count(), { timeout: 20_000 })
     .toBeGreaterThan(0);
 });
 


### PR DESCRIPTION
`opens a dropped E57 scan` polls for the scan report with a 5 s budget. That was the tightest assertion in the test and it sits on the slowest step: report rows are analysis-module output, so they land after the attach the previous line waits on, on the heaviest decode path the test already calls `test.slow()` for.

A loaded runner failed it twice in one run and again on a rerun, on a commit whose only change was a comment inside a doc block. Every other job on that commit passed, and the same spec passed on a PR that touched real code.

The poll now gets the 20 s the attach already has. Nothing else changes.
