### PR TITLE
Plan mode remembers the scene it replaced

### DIFF
--- a/src/render/camera/planView.ts
+++ b/src/render/camera/planView.ts
@@ -1,0 +1,137 @@
+/**
+ * planView.ts — entering and leaving a 2D-style plan workflow.
+ *
+ * Plan View is not a second viewer. It is three things the camera can already
+ * do, held together and remembered: look straight down, drop the perspective,
+ * and put the primary drag on the hand tool so a drag pans instead of orbiting.
+ * `Viewer.setStandardView('top')`, `Viewer.setOrthographic(true)` and
+ * `NavController.setMode('pan')` each already exist and are each already
+ * reachable from the navigation bar.
+ *
+ * What did not exist is the memory. A user who turns plan off wants the scene
+ * they had, not the defaults: the projection they were using and the navigation
+ * mode they were in. So this module owns the capture and the restore, and
+ * nothing else.
+ *
+ * It performs no camera work. It answers a question, and the answer is a list of
+ * intents the caller executes against the Viewer. That keeps the decision pure
+ * and testable in Node, and keeps the camera mathematics in the one place that
+ * already owns it. A planner that recomputed a pose here would be a second
+ * opinion about where the camera goes.
+ *
+ * Pure — no DOM, no three.js.
+ */
+
+import type { NavMode } from '../NavController';
+import type { StandardView } from './cameraPresets';
+
+/** The one thing a caller does with this module's output. */
+export type PlanViewIntent =
+  | { readonly kind: 'standardView'; readonly view: StandardView }
+  | { readonly kind: 'orthographic'; readonly on: boolean }
+  | { readonly kind: 'navMode'; readonly mode: NavMode };
+
+/** What plan mode captured on the way in, so leaving can put it back. */
+export interface PlanViewRestore {
+  readonly mode: NavMode;
+  readonly orthographic: boolean;
+}
+
+/** Whether plan mode is on, and what it owes the scene when it turns off. */
+export interface PlanViewState {
+  readonly active: boolean;
+  /** Null whenever `active` is false. Never read on the way in. */
+  readonly restore: PlanViewRestore | null;
+}
+
+/** The scene facts the planner reads. */
+export interface PlanViewContext {
+  readonly mode: NavMode;
+  readonly orthographic: boolean;
+  /**
+   * False when the hand tool is unavailable (the `?handPan=off` dev flag).
+   * `NavController.setMode` refuses `'pan'` in that case and returns silently,
+   * so asking for it anyway would leave plan mode in orbit while claiming to be
+   * pan-navigated. Plan still enters; it just keeps orbit and says so.
+   */
+  readonly handPanAvailable: boolean;
+}
+
+/** A fresh, inactive state. */
+export const PLAN_VIEW_OFF: PlanViewState = { active: false, restore: null };
+
+/** The result of a transition: the new state, and what to execute. */
+export interface PlanViewTransition {
+  readonly state: PlanViewState;
+  readonly intents: readonly PlanViewIntent[];
+}
+
+/**
+ * Enter plan mode from `ctx`.
+ *
+ * Captures the mode and projection FIRST, so the restore describes the scene as
+ * the user left it rather than as plan mode rewrote it. Entering while already
+ * active is a no-op that keeps the original capture: re-entering must not
+ * overwrite the memory with plan mode's own top-down orthographic state, which
+ * would strand the user there.
+ */
+export function enterPlanView(state: PlanViewState, ctx: PlanViewContext): PlanViewTransition {
+  if (state.active) return { state, intents: [] };
+
+  const intents: PlanViewIntent[] = [
+    { kind: 'standardView', view: 'top' },
+    { kind: 'orthographic', on: true },
+  ];
+  // Only ask for the mode the controller can actually honour.
+  if (ctx.handPanAvailable && ctx.mode !== 'pan') {
+    intents.push({ kind: 'navMode', mode: 'pan' });
+  }
+
+  return {
+    state: {
+      active: true,
+      restore: { mode: ctx.mode, orthographic: ctx.orthographic },
+    },
+    intents,
+  };
+}
+
+/**
+ * Leave plan mode, restoring what was captured.
+ *
+ * Only what actually changed is emitted, so leaving a scene that was already
+ * orthographic does not flip the projection, and leaving from a session that
+ * started in pan does not switch the mode. Leaving when inactive is a no-op.
+ *
+ * The camera is returned to an iso pose rather than left looking straight down.
+ * A user turning plan off is asking for the 3D view back, and top-down with
+ * perspective restored is neither the plan they had nor the scene they wanted.
+ */
+export function leavePlanView(state: PlanViewState): PlanViewTransition {
+  if (!state.active || !state.restore) return { state: PLAN_VIEW_OFF, intents: [] };
+
+  const { mode, orthographic } = state.restore;
+  const intents: PlanViewIntent[] = [];
+  if (!orthographic) intents.push({ kind: 'orthographic', on: false });
+  intents.push({ kind: 'standardView', view: 'front' });
+  if (mode !== 'pan') intents.push({ kind: 'navMode', mode });
+
+  return { state: PLAN_VIEW_OFF, intents };
+}
+
+/** Enter when off, leave when on. */
+export function togglePlanView(state: PlanViewState, ctx: PlanViewContext): PlanViewTransition {
+  return state.active ? leavePlanView(state) : enterPlanView(state, ctx);
+}
+
+/**
+ * Whether a scene fact drifting out from under plan mode should drop it.
+ *
+ * Plan mode is a claim about how the scene is set up, so it must not keep
+ * claiming that after the user changes the projection or the view by hand. The
+ * navigation mode is deliberately NOT part of this: panning is what plan mode is
+ * for, and a user switching to orbit for one look has not left plan.
+ */
+export function planViewSurvives(orthographicStillOn: boolean, viewStillTop: boolean): boolean {
+  return orthographicStillOn && viewStillTop;
+}

--- a/tests/planView.test.ts
+++ b/tests/planView.test.ts
@@ -1,0 +1,154 @@
+/**
+ * planView.test.ts — what plan mode remembers, and what it puts back.
+ *
+ * The camera work behind Plan View already existed: a top standard view, the
+ * orthographic toggle, and a pan navigation mode that hands the primary drag to
+ * the hand tool. Composing them is easy. The part that goes wrong is the memory.
+ *
+ * Two failures these tests exist to catch. Capturing the scene AFTER plan mode
+ * has rewritten it stores plan's own top-down orthographic state as the thing to
+ * restore, so leaving strands the user exactly where they were trying to leave.
+ * And re-entering while already active overwrites a good capture with that same
+ * useless one, which is the same strand reached by a double click.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  enterPlanView,
+  leavePlanView,
+  togglePlanView,
+  planViewSurvives,
+  PLAN_VIEW_OFF,
+  type PlanViewContext,
+  type PlanViewIntent,
+} from '../src/render/camera/planView';
+
+/** A scene the user is working in: perspective, orbiting, hand tool available. */
+function scene(over: Partial<PlanViewContext> = {}): PlanViewContext {
+  return { mode: 'orbit', orthographic: false, handPanAvailable: true, ...over };
+}
+
+/** The intents as a comparable shape. */
+const kinds = (intents: readonly PlanViewIntent[]): string[] => intents.map((i) => i.kind);
+
+describe('entering plan mode', () => {
+  it('asks for top down, parallel projection and the hand tool', () => {
+    const { state, intents } = enterPlanView(PLAN_VIEW_OFF, scene());
+    expect(state.active).toBe(true);
+    expect(intents).toEqual([
+      { kind: 'standardView', view: 'top' },
+      { kind: 'orthographic', on: true },
+      { kind: 'navMode', mode: 'pan' },
+    ]);
+  });
+
+  it('captures the scene as the user left it, not as plan rewrote it', () => {
+    const { state } = enterPlanView(PLAN_VIEW_OFF, scene({ mode: 'fly', orthographic: false }));
+    // Capturing after the intents ran would store pan + orthographic here, and
+    // leaving would then put the user back into the view they just left.
+    expect(state.restore).toEqual({ mode: 'fly', orthographic: false });
+  });
+
+  it('does not ask for a mode the controller would refuse', () => {
+    // `NavController.setMode('pan')` returns silently when the hand tool is off,
+    // so requesting it would leave plan mode orbiting while claiming otherwise.
+    const { intents } = enterPlanView(PLAN_VIEW_OFF, scene({ handPanAvailable: false }));
+    expect(kinds(intents)).not.toContain('navMode');
+    expect(kinds(intents)).toEqual(['standardView', 'orthographic']);
+  });
+
+  it('does not ask for pan when the scene is already panning', () => {
+    const { intents } = enterPlanView(PLAN_VIEW_OFF, scene({ mode: 'pan' }));
+    expect(kinds(intents)).not.toContain('navMode');
+  });
+
+  it('keeps the original capture when entering twice', () => {
+    const first = enterPlanView(PLAN_VIEW_OFF, scene({ mode: 'walk', orthographic: false }));
+    // A second enter, with the scene now reading as plan mode set it up.
+    const second = enterPlanView(first.state, scene({ mode: 'pan', orthographic: true }));
+    expect(second.intents).toEqual([]);
+    expect(second.state.restore).toEqual({ mode: 'walk', orthographic: false });
+  });
+});
+
+describe('leaving plan mode', () => {
+  it('restores the projection and the mode it captured', () => {
+    const entered = enterPlanView(PLAN_VIEW_OFF, scene({ mode: 'fly' }));
+    const { state, intents } = leavePlanView(entered.state);
+    expect(state).toEqual(PLAN_VIEW_OFF);
+    expect(intents).toEqual([
+      { kind: 'orthographic', on: false },
+      { kind: 'standardView', view: 'front' },
+      { kind: 'navMode', mode: 'fly' },
+    ]);
+  });
+
+  it('leaves the projection alone when it was already orthographic', () => {
+    const entered = enterPlanView(PLAN_VIEW_OFF, scene({ orthographic: true }));
+    const { intents } = leavePlanView(entered.state);
+    // Flipping it off here would change a setting the user chose themselves.
+    expect(intents.find((i) => i.kind === 'orthographic')).toBeUndefined();
+  });
+
+  it('leaves the mode alone when the scene was already panning', () => {
+    const entered = enterPlanView(PLAN_VIEW_OFF, scene({ mode: 'pan' }));
+    const { intents } = leavePlanView(entered.state);
+    expect(kinds(intents)).not.toContain('navMode');
+  });
+
+  it('returns to a 3D pose rather than staying overhead', () => {
+    const entered = enterPlanView(PLAN_VIEW_OFF, scene());
+    const view = leavePlanView(entered.state).intents.find((i) => i.kind === 'standardView');
+    expect(view).toBeDefined();
+    // Top with perspective restored is neither the plan the user had nor the
+    // scene they asked to get back.
+    expect(view).not.toEqual({ kind: 'standardView', view: 'top' });
+  });
+
+  it('is a no-op when plan mode is already off', () => {
+    const { state, intents } = leavePlanView(PLAN_VIEW_OFF);
+    expect(state).toEqual(PLAN_VIEW_OFF);
+    expect(intents).toEqual([]);
+  });
+});
+
+describe('a full round trip', () => {
+  it('returns every captured fact to where it started', () => {
+    for (const ctx of [
+      scene({ mode: 'orbit', orthographic: false }),
+      scene({ mode: 'walk', orthographic: true }),
+      scene({ mode: 'fly', orthographic: false }),
+      scene({ mode: 'pan', orthographic: true }),
+    ]) {
+      const entered = enterPlanView(PLAN_VIEW_OFF, ctx);
+      const left = leavePlanView(entered.state);
+
+      // Whatever the scene started as, the restore either names it or the
+      // absence of an intent means it never changed.
+      const orthoIntent = left.intents.find((i) => i.kind === 'orthographic');
+      const finalOrtho = orthoIntent ? (orthoIntent as { on: boolean }).on : true;
+      expect(finalOrtho).toBe(ctx.orthographic);
+
+      const modeIntent = left.intents.find((i) => i.kind === 'navMode');
+      const finalMode = modeIntent ? (modeIntent as { mode: string }).mode : 'pan';
+      expect(finalMode).toBe(ctx.mode);
+
+      expect(left.state).toEqual(PLAN_VIEW_OFF);
+    }
+  });
+
+  it('toggles in and back out', () => {
+    const on = togglePlanView(PLAN_VIEW_OFF, scene());
+    expect(on.state.active).toBe(true);
+    const off = togglePlanView(on.state, scene({ mode: 'pan', orthographic: true }));
+    expect(off.state.active).toBe(false);
+  });
+});
+
+describe('when the scene drifts out from under plan mode', () => {
+  it('drops the claim once the projection or the view changes by hand', () => {
+    expect(planViewSurvives(true, true)).toBe(true);
+    expect(planViewSurvives(false, true)).toBe(false);
+    expect(planViewSurvives(true, false)).toBe(false);
+  });
+});


### PR DESCRIPTION
Plan View composes three things the camera already does: `setStandardView('top')`, `setOrthographic(true)`, and the `pan` navigation mode, which already hands the primary drag to the hand tool.

What did not exist is the memory. `planView` captures the navigation mode and the projection before the composition rewrites them, so leaving restores the scene the user had. Re-entering keeps the original capture; a second enter would otherwise store plan's own top-down orthographic state and strand the user there. It emits only what actually changed, so leaving a scene that was already orthographic does not flip the projection.

It answers with intents rather than driving the camera, so pose mathematics stays where it already lives. 13 tests; three mutations red-checked.

Model only, no consumer yet. Wiring needs `main.ts` lines the ratchet has none of.
