### PR TITLE
feat(annotate): inspection issue workflow on the annotation model

### DIFF
--- a/src/io/session.ts
+++ b/src/io/session.ts
@@ -26,6 +26,7 @@ import { MIN_POINTS } from '../render/measure/types';
 import type { MeasurementTrust, TrustGrade } from '../render/measure/measurementTrust';
 import type { Annotation, SavedCameraState, Vec3Object } from '../render/annotate/types';
 import { freshAnnotationId, isAnnotationType } from '../render/annotate/types';
+import { parseIssueDetails } from '../render/annotate/issueWorkflow';
 import type { ColorMode } from '../render/colorModes';
 import type { PointSizeMode } from '../render/pointStyle';
 import type { ResolvedCrs } from '../geo/CoordinateTypes';
@@ -71,6 +72,14 @@ import type { WorkOwnership } from '../model/workOwnership';
  * one origin, so saved work had no way to say which layer it belonged to,
  * which is why multi-layer mounting is disabled. v8 is the persistence half of
  * removing that block; the mount flag itself stays off (see `LayerService.ts`).
+ *
+ * The per-annotation inspection workflow (`annotation.issue` — severity,
+ * open/resolved status, observation date) is additive WITHIN v8 and carries no
+ * bump. It adds one optional field, changes the meaning of none, and is only
+ * emitted for annotations that have one, so a session with no issues keeps its
+ * byte-shape exactly; a reader that predates it ignores an unknown key and
+ * still gets every annotation. Bumping would instead make every file this app
+ * writes unreadable to a v8 reader for a field that reader never needed.
  *
  * Older v1..v7 files parse with no loss: the new optional fields just
  * read as undefined, and the Viewer falls back to its current state. A v7
@@ -1290,6 +1299,14 @@ function parseAnnotations(v: unknown): Annotation[] {
     if (typeof item.linkedMeasurementId === 'string') {
       annotation.linkedMeasurementId = item.linkedMeasurementId;
     }
+    // The inspection workflow (severity, open/resolved status, observation
+    // date). Additive and OPTIONAL, so it is read version-independently like
+    // `layerId` above: a file that carries the block gets it back whatever
+    // version it declares, and a file without one yields a plain annotation.
+    // Malformed contents degrade inside `parseIssueDetails` rather than
+    // failing the import; a block that is not an object is treated as absent.
+    const issue = parseIssueDetails(item.issue);
+    if (issue) annotation.issue = issue;
     out.push(annotation);
   }
   return out;

--- a/src/render/annotate/issueWorkflow.ts
+++ b/src/render/annotate/issueWorkflow.ts
@@ -1,0 +1,294 @@
+/**
+ * issueWorkflow.ts
+ *
+ * The inspection-issue workflow layered over the annotation model.
+ *
+ * An issue IS an annotation: the same stable id, the same local/world anchor,
+ * the same saved camera view (`cameraState`), the same linked measurement
+ * (`linkedMeasurementId`), and the same free text (`note`) carrying the
+ * description. What an issue adds is the {@link IssueDetails} block — a
+ * severity, an open/resolved status, and the date the condition was observed —
+ * held in the optional `Annotation.issue` field. An annotation without that
+ * block is a plain annotation, and every helper here treats it as one.
+ *
+ * The `type: 'issue'` CATEGORY and the workflow block are two different
+ * statements. `AnnotationType` drives marker styling and predates this
+ * workflow, so saved work can hold `type: 'issue'` annotations that were never
+ * triaged. Those stay plain annotations: {@link isIssueAnnotation} asks for the
+ * block, never for the category, so nothing already saved acquires a severity
+ * or a status it was never given. Attaching the workflow does set the category
+ * (see {@link attachIssue}), so the marker matches the workflow from then on.
+ *
+ * Identity is the annotation's `id` throughout. Nothing here indexes by list
+ * position, and the sort below breaks ties on `id` rather than on input order,
+ * so a re-sorted or re-imported list ranks identically.
+ *
+ * Pure data: no DOM, no three.js, unit-tested in Node alongside the session
+ * serializer.
+ */
+
+import type { Annotation } from './types';
+
+/**
+ * How bad the observed condition is, ASCENDING. The array order is the ranking
+ * (see {@link issueSeverityRank}); read it, do not restate it.
+ */
+export const ISSUE_SEVERITIES = ['low', 'medium', 'high', 'critical'] as const;
+
+/** One of the four inspection severities. */
+export type IssueSeverity = (typeof ISSUE_SEVERITIES)[number];
+
+/**
+ * Where the issue stands. Deliberately two states: multi-user comments,
+ * assignment and any server-side workflow are out of scope, so there is no
+ * "in progress" that nothing can advance and nobody owns.
+ */
+export const ISSUE_STATUSES = ['open', 'resolved'] as const;
+
+/** Open or resolved. */
+export type IssueStatus = (typeof ISSUE_STATUSES)[number];
+
+/**
+ * Severity substituted when a stored value is missing or unrecognised.
+ *
+ * Mid-rank on purpose. A corrupt file must not silently bury what may have
+ * been a critical finding below every asserted `low`, and it must not
+ * manufacture urgency the inspector never recorded either.
+ */
+export const FALLBACK_ISSUE_SEVERITY: IssueSeverity = 'medium';
+
+/**
+ * Status substituted when a stored value is missing or unrecognised.
+ *
+ * Fail-closed: an issue whose status cannot be read is NOT claimed resolved.
+ * A stray open issue costs a second look; a fabricated resolution closes a
+ * defect that was never fixed.
+ */
+export const FALLBACK_ISSUE_STATUS: IssueStatus = 'open';
+
+/** The inspection workflow carried by an annotation that is an issue. */
+export interface IssueDetails {
+  /** How bad the observed condition is. */
+  severity: IssueSeverity;
+  /** Open or resolved. */
+  status: IssueStatus;
+  /**
+   * When the condition was observed, epoch milliseconds. Distinct from the
+   * annotation's `createdAt`: a finding is routinely logged in the office days
+   * after the site visit, and a report dates the observation, not the typing.
+   * Absent when no date was recorded.
+   */
+  observedAt?: number;
+}
+
+/** The fields a caller supplies to attach the workflow; the rest are filled. */
+export interface IssueInput {
+  severity: IssueSeverity;
+  /** Defaults to `open`. */
+  status?: IssueStatus;
+  observedAt?: number;
+}
+
+/** An annotation that carries the workflow block. */
+export type IssueAnnotation = Annotation & { issue: IssueDetails };
+
+/** Per-severity counts, one entry per severity, zeros included. */
+export type IssueSeverityCounts = Record<IssueSeverity, number>;
+
+/** A roll-up of the issues in an annotation list. */
+export interface IssueSummary {
+  /** Annotations carrying the workflow block. Non-issues are not counted. */
+  total: number;
+  open: number;
+  resolved: number;
+  /** Counts of the OPEN issues per severity; every severity key is present. */
+  openBySeverity: IssueSeverityCounts;
+  /**
+   * Severity of the most severe OPEN issue. Absent when nothing is open, which
+   * a caller must not read as `low` — "nothing outstanding" and "the worst
+   * outstanding thing is minor" are different reports.
+   */
+  highestOpenSeverity?: IssueSeverity;
+}
+
+/** Type guard for a valid {@link IssueSeverity}. */
+export function isIssueSeverity(v: unknown): v is IssueSeverity {
+  return v === 'low' || v === 'medium' || v === 'high' || v === 'critical';
+}
+
+/** Type guard for a valid {@link IssueStatus}. */
+export function isIssueStatus(v: unknown): v is IssueStatus {
+  return v === 'open' || v === 'resolved';
+}
+
+/**
+ * Rank of a severity: 0 for `low` through 3 for `critical`, so a higher number
+ * is a worse condition. Derived from {@link ISSUE_SEVERITIES} so the order is
+ * stated once.
+ */
+export function issueSeverityRank(s: IssueSeverity): number {
+  return ISSUE_SEVERITIES.indexOf(s);
+}
+
+/**
+ * Compare two severities ASCENDING, the `Array.prototype.sort` convention:
+ * negative when `a` is less severe than `b`, zero when equal. Sort a roster
+ * worst-first by passing the arguments the other way round, as
+ * {@link sortIssuesBySeverity} does.
+ */
+export function compareIssueSeverity(a: IssueSeverity, b: IssueSeverity): number {
+  return issueSeverityRank(a) - issueSeverityRank(b);
+}
+
+/**
+ * Whether an annotation carries the inspection workflow. A `type: 'issue'`
+ * annotation with no block is a plain annotation and returns false.
+ */
+export function isIssueAnnotation(a: Annotation): a is IssueAnnotation {
+  return a.issue !== undefined;
+}
+
+/** Whether an annotation is an issue AND still open. */
+export function isOpenIssue(a: Annotation): boolean {
+  return isIssueAnnotation(a) && a.issue.status === 'open';
+}
+
+/** Whether an annotation is an issue AND resolved. */
+export function isResolvedIssue(a: Annotation): boolean {
+  return isIssueAnnotation(a) && a.issue.status === 'resolved';
+}
+
+/**
+ * Every issue in `list` with the given status, in input order. Annotations
+ * that are not issues match NEITHER status and are dropped from both results,
+ * so `open.length + resolved.length` counts issues, not annotations.
+ */
+export function filterIssuesByStatus(
+  list: readonly Annotation[],
+  status: IssueStatus,
+): IssueAnnotation[] {
+  return list.filter((a): a is IssueAnnotation => isIssueAnnotation(a) && a.issue.status === status);
+}
+
+/** Every issue in `list`, in input order. */
+export function issueAnnotations(list: readonly Annotation[]): IssueAnnotation[] {
+  return list.filter(isIssueAnnotation);
+}
+
+/**
+ * The issues in `list`, worst first. Ties break on the observation date
+ * (oldest first, falling back to `createdAt` when undated) and then on the
+ * stable `id`, so the ranking never depends on where an annotation sat in the
+ * input array. Non-issues are dropped. The input is not mutated.
+ */
+export function sortIssuesBySeverity(list: readonly Annotation[]): IssueAnnotation[] {
+  return issueAnnotations(list).sort((a, b) => {
+    const bySeverity = compareIssueSeverity(b.issue.severity, a.issue.severity);
+    if (bySeverity !== 0) return bySeverity;
+    const byDate = (a.issue.observedAt ?? a.createdAt) - (b.issue.observedAt ?? b.createdAt);
+    if (byDate !== 0) return byDate;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+/** A zeroed count for every severity — the starting point of a roll-up. */
+function zeroSeverityCounts(): IssueSeverityCounts {
+  return { low: 0, medium: 0, high: 0, critical: 0 };
+}
+
+/**
+ * Count the issues in an annotation list. Plain annotations contribute to
+ * nothing, so `total` is the number of issues and not the length of `list`.
+ */
+export function summarizeIssues(list: readonly Annotation[]): IssueSummary {
+  const openBySeverity = zeroSeverityCounts();
+  let total = 0;
+  let open = 0;
+  let resolved = 0;
+  let highest: IssueSeverity | undefined;
+  for (const a of list) {
+    if (!isIssueAnnotation(a)) continue;
+    total += 1;
+    if (a.issue.status === 'resolved') {
+      resolved += 1;
+      continue;
+    }
+    open += 1;
+    openBySeverity[a.issue.severity] += 1;
+    if (highest === undefined || compareIssueSeverity(a.issue.severity, highest) > 0) {
+      highest = a.issue.severity;
+    }
+  }
+  const summary: IssueSummary = { total, open, resolved, openBySeverity };
+  if (highest !== undefined) summary.highestOpenSeverity = highest;
+  return summary;
+}
+
+/** Normalise caller- or file-supplied workflow fields into a stored block. */
+function normalizeIssueDetails(severity: unknown, status: unknown, observedAt: unknown) {
+  const details: IssueDetails = {
+    severity: isIssueSeverity(severity) ? severity : FALLBACK_ISSUE_SEVERITY,
+    status: isIssueStatus(status) ? status : FALLBACK_ISSUE_STATUS,
+  };
+  // A non-finite or non-numeric date is no date. Keeping a NaN here would put
+  // an unorderable value into the tiebreak in `sortIssuesBySeverity`.
+  if (typeof observedAt === 'number' && Number.isFinite(observedAt)) {
+    details.observedAt = observedAt;
+  }
+  return details;
+}
+
+/**
+ * Attach (or replace) the inspection workflow on an annotation, returning a
+ * NEW annotation with a refreshed `updatedAt`; the original is never mutated,
+ * matching `editAnnotation`. The category is set to `issue` so the marker
+ * agrees with the workflow. Everything else about the annotation — id, anchor,
+ * note, camera view, linked measurement, ownership — is carried through
+ * untouched, because an issue is an annotation with more said about it.
+ */
+export function attachIssue(
+  a: Annotation,
+  input: IssueInput,
+  now: number = Date.now(),
+): IssueAnnotation {
+  return {
+    ...a,
+    type: 'issue',
+    updatedAt: now,
+    issue: normalizeIssueDetails(input.severity, input.status, input.observedAt),
+  };
+}
+
+/**
+ * Move an issue between open and resolved, returning a NEW annotation with a
+ * refreshed `updatedAt`.
+ *
+ * An annotation that is not an issue, and an issue already in `status`, are
+ * both returned AS THE SAME OBJECT: there is no workflow step to record, so
+ * there is no edit to timestamp. Callers can test that by identity.
+ */
+export function setIssueStatus(
+  a: Annotation,
+  status: IssueStatus,
+  now: number = Date.now(),
+): Annotation {
+  if (!isIssueAnnotation(a)) return a;
+  if (a.issue.status === status) return a;
+  return { ...a, updatedAt: now, issue: { ...a.issue, status } };
+}
+
+/**
+ * Read a persisted workflow block defensively.
+ *
+ * Returns undefined when the field is absent or is not an object, which is how
+ * an annotation saved before this workflow existed stays a plain annotation.
+ * When the block IS there, an unrecognised severity or status degrades to the
+ * documented fallback rather than throwing or dropping the whole block: losing
+ * the block would demote a real finding to an untracked note, which is a worse
+ * failure than a mid-rank severity on a corrupt record.
+ */
+export function parseIssueDetails(v: unknown): IssueDetails | undefined {
+  if (v === null || typeof v !== 'object' || Array.isArray(v)) return undefined;
+  const raw = v as Record<string, unknown>;
+  return normalizeIssueDetails(raw.severity, raw.status, raw.observedAt);
+}

--- a/src/render/annotate/types.ts
+++ b/src/render/annotate/types.ts
@@ -13,6 +13,7 @@
 
 import type { NavMode } from '../NavController';
 import type { WorkOwnership } from '../../model/workOwnership';
+import type { IssueDetails } from './issueWorkflow';
 
 /** The four annotation categories — each drives a distinct marker style. */
 export type AnnotationType = 'note' | 'info' | 'warning' | 'issue';
@@ -104,6 +105,19 @@ export interface Annotation {
   cameraState?: SavedCameraState;
   /** Optional link to a measurement by its id. */
   linkedMeasurementId?: string;
+  /**
+   * Inspection workflow, when this annotation is an ISSUE: severity, an
+   * open/resolved status, and the date the condition was observed. See
+   * `annotate/issueWorkflow.ts`, which owns the vocabulary and the helpers.
+   *
+   * Optional, and its absence is meaningful: an annotation saved before this
+   * workflow existed carries no block and stays a plain annotation, including
+   * one already categorised `type: 'issue'`. The category drives marker
+   * styling; this block is what says the annotation is being tracked. Nothing
+   * infers one from the other, so no saved annotation gains a severity or a
+   * status it was never given.
+   */
+  issue?: IssueDetails;
 }
 
 /** Type guard for a valid {@link AnnotationType}. */

--- a/tests/issueWorkflow.test.ts
+++ b/tests/issueWorkflow.test.ts
@@ -1,0 +1,506 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ISSUE_SEVERITIES,
+  ISSUE_STATUSES,
+  FALLBACK_ISSUE_SEVERITY,
+  FALLBACK_ISSUE_STATUS,
+  attachIssue,
+  compareIssueSeverity,
+  filterIssuesByStatus,
+  isIssueAnnotation,
+  isIssueSeverity,
+  isIssueStatus,
+  isOpenIssue,
+  isResolvedIssue,
+  issueSeverityRank,
+  parseIssueDetails,
+  setIssueStatus,
+  sortIssuesBySeverity,
+  summarizeIssues,
+} from '../src/render/annotate/issueWorkflow';
+import type { IssueSeverity } from '../src/render/annotate/issueWorkflow';
+import { createAnnotation, editAnnotation } from '../src/render/annotate/types';
+import type { Annotation } from '../src/render/annotate/types';
+import { serializeSession, parseSession, SESSION_VERSION } from '../src/io/session';
+import type { InspectionSession } from '../src/io/session';
+
+/** A plain annotation with a fixed id, so tests never lean on list position. */
+function plain(id: string, over: Partial<Annotation> = {}): Annotation {
+  return {
+    id,
+    title: `Annotation ${id}`,
+    type: 'note',
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    localPosition: { x: 0, y: 0, z: 0 },
+    ...over,
+  };
+}
+
+/** An issue with a chosen severity/status, built through the public helper. */
+function issue(
+  id: string,
+  severity: IssueSeverity,
+  status: 'open' | 'resolved' = 'open',
+  over: Partial<Annotation> = {},
+): Annotation {
+  return attachIssue(plain(id, over), { severity, status }, 2_000);
+}
+
+/** A session envelope carrying whatever annotations a test wants to persist. */
+function sessionWith(annotations: Annotation[]): Omit<InspectionSession, 'app' | 'kind' | 'version'> {
+  return {
+    upAxis: 'z',
+    origin: [0, 0, 0],
+    unitSystem: 'metric',
+    views: [],
+    measurements: [],
+    annotations,
+  };
+}
+
+describe('severity ordering', () => {
+  /**
+   * Catches a scale that is not a scale: a rank table that skips or duplicates
+   * a value, a `critical` that does not outrank `high`, or a comparator whose
+   * sign is inverted so a worst-first roster silently lists the least severe
+   * finding at the top of an inspection report.
+   */
+  it('ranks the four severities strictly ascending, low through critical', () => {
+    expect(ISSUE_SEVERITIES).toEqual(['low', 'medium', 'high', 'critical']);
+    expect(issueSeverityRank('critical')).toBeGreaterThan(issueSeverityRank('high'));
+    expect(issueSeverityRank('high')).toBeGreaterThan(issueSeverityRank('medium'));
+    expect(issueSeverityRank('medium')).toBeGreaterThan(issueSeverityRank('low'));
+    // Ranks are distinct, so no two severities collapse into one bucket.
+    expect(new Set(ISSUE_SEVERITIES.map(issueSeverityRank)).size).toBe(4);
+  });
+
+  /**
+   * Catches a comparator that is not a total order — an incomparable pair, a
+   * non-antisymmetric result, or an intransitive chain — any of which makes a
+   * sorted issue list depend on the engine's sort implementation.
+   */
+  it('compares as a total order over every pair', () => {
+    for (const a of ISSUE_SEVERITIES) {
+      for (const b of ISSUE_SEVERITIES) {
+        const ab = compareIssueSeverity(a, b);
+        const ba = compareIssueSeverity(b, a);
+        expect(Number.isFinite(ab)).toBe(true);
+        // Antisymmetry: exactly one of a<b, a=b, a>b. Summed rather than
+        // negated because `Math.sign(0)` is +0 and `-Math.sign(0)` is -0.
+        expect(Math.sign(ab) + Math.sign(ba)).toBe(0);
+        expect(ab === 0).toBe(a === b);
+        for (const c of ISSUE_SEVERITIES) {
+          // Transitivity: a < b and b < c implies a < c.
+          if (ab < 0 && compareIssueSeverity(b, c) < 0) {
+            expect(compareIssueSeverity(a, c)).toBeLessThan(0);
+          }
+        }
+      }
+    }
+  });
+
+  /**
+   * Catches a roster ordered by insertion order rather than by severity, and a
+   * tiebreak that reads array position, which would reorder the same issues
+   * after a session reload.
+   */
+  it('sorts issues worst first, breaking ties on the stable id', () => {
+    const list = [
+      issue('b', 'low'),
+      issue('a', 'critical'),
+      issue('d', 'medium'),
+      issue('c', 'critical'),
+      plain('z'),
+    ];
+    expect(sortIssuesBySeverity(list).map((a) => a.id)).toEqual(['a', 'c', 'd', 'b']);
+    // The same set in a different input order ranks identically.
+    const shuffled = [list[4], list[3], list[2], list[1], list[0]];
+    expect(sortIssuesBySeverity(shuffled).map((a) => a.id)).toEqual(['a', 'c', 'd', 'b']);
+  });
+
+  /**
+   * Catches a sort that reorders the caller's array in place, which would make
+   * a read-only roster view silently rewrite the controller's annotation list.
+   */
+  it('does not mutate the list it was given', () => {
+    const list = [issue('b', 'low'), issue('a', 'critical')];
+    sortIssuesBySeverity(list);
+    expect(list.map((a) => a.id)).toEqual(['b', 'a']);
+  });
+});
+
+describe('a plain annotation is not an issue', () => {
+  /**
+   * Catches the whole backward-compatibility failure: work saved before this
+   * workflow existed being read as an issue, and in particular a `type:'issue'`
+   * annotation from an older session acquiring a severity and an open status
+   * nobody ever recorded for it.
+   */
+  it('treats an annotation with no workflow block as a plain annotation', () => {
+    const note = plain('n1');
+    const legacyIssueCategory = plain('n2', { type: 'issue' });
+    for (const a of [note, legacyIssueCategory]) {
+      expect(a.issue).toBeUndefined();
+      expect(isIssueAnnotation(a)).toBe(false);
+      expect(isOpenIssue(a)).toBe(false);
+      expect(isResolvedIssue(a)).toBe(false);
+    }
+    expect(summarizeIssues([note, legacyIssueCategory])).toEqual({
+      total: 0,
+      open: 0,
+      resolved: 0,
+      openBySeverity: { low: 0, medium: 0, high: 0, critical: 0 },
+    });
+    expect(sortIssuesBySeverity([note, legacyIssueCategory])).toEqual([]);
+  });
+
+  /**
+   * Catches a status change that invents a workflow on an annotation that has
+   * none, turning every note in the list into a tracked issue.
+   */
+  it('leaves a non-issue untouched when a status change is requested', () => {
+    const note = plain('n1');
+    const after = setIssueStatus(note, 'resolved', 9_000);
+    expect(after).toBe(note);
+    expect(after.issue).toBeUndefined();
+    expect(after.updatedAt).toBe(1_000);
+  });
+
+  /**
+   * Catches the plain-annotation edit path regressing: editing a note must not
+   * gain a workflow block, and editing an issue must not drop the one it has.
+   */
+  it('keeps editAnnotation free of workflow side effects in both directions', () => {
+    const renamedNote = editAnnotation(plain('n1'), { title: 'Renamed' }, 3_000);
+    expect(renamedNote.issue).toBeUndefined();
+    expect(isIssueAnnotation(renamedNote)).toBe(false);
+
+    const renamedIssue = editAnnotation(issue('i1', 'high'), { title: 'Renamed' }, 3_000);
+    expect(renamedIssue.issue).toEqual({ severity: 'high', status: 'open' });
+  });
+});
+
+describe('attaching and advancing the workflow', () => {
+  /**
+   * Catches an issue being modelled as a replacement for an annotation rather
+   * than an extension of one: a lost id, a lost anchor, a lost camera view, or
+   * a lost measurement link would each break "jump to this finding".
+   */
+  it('keeps the annotation identity and payload when the workflow is attached', () => {
+    const base = createAnnotation(
+      {
+        title: 'Spalled concrete',
+        note: 'Delamination on the north face',
+        type: 'warning',
+        localPosition: { x: 4, y: 5, z: 6 },
+        linkedMeasurementId: 'm-7',
+        cameraState: { position: [1, 2, 3], target: [4, 5, 6] },
+      },
+      1_000,
+    );
+    const tracked = attachIssue(base, { severity: 'high', observedAt: 500 }, 7_000);
+    expect(tracked.id).toBe(base.id);
+    expect(tracked.title).toBe('Spalled concrete');
+    expect(tracked.note).toBe('Delamination on the north face');
+    expect(tracked.localPosition).toEqual({ x: 4, y: 5, z: 6 });
+    expect(tracked.linkedMeasurementId).toBe('m-7');
+    expect(tracked.cameraState).toEqual({ position: [1, 2, 3], target: [4, 5, 6] });
+    expect(tracked.createdAt).toBe(1_000);
+    expect(tracked.updatedAt).toBe(7_000);
+    // The category follows the workflow so the marker matches.
+    expect(tracked.type).toBe('issue');
+    expect(tracked.issue).toEqual({ severity: 'high', status: 'open', observedAt: 500 });
+    // The original is untouched, as with every other annotation edit.
+    expect(base.issue).toBeUndefined();
+    expect(base.type).toBe('warning');
+  });
+
+  /**
+   * Catches an observation date defaulting to "now" or to the creation time,
+   * which would date a report by when it was typed rather than by when the
+   * condition was seen.
+   */
+  it('omits the observation date when none was supplied', () => {
+    const tracked = attachIssue(plain('i1'), { severity: 'low' }, 7_000);
+    expect(tracked.issue.observedAt).toBeUndefined();
+    expect('observedAt' in tracked.issue).toBe(false);
+  });
+
+  /**
+   * Catches a resolve step that does not record an edit time, and a redundant
+   * one that bumps the edit time with no workflow change behind it.
+   */
+  it('records a real status change and no-ops an identical one', () => {
+    const open = issue('i1', 'critical');
+    const resolved = setIssueStatus(open, 'resolved', 9_000);
+    expect(resolved.issue?.status).toBe('resolved');
+    expect(resolved.issue?.severity).toBe('critical');
+    expect(resolved.updatedAt).toBe(9_000);
+    expect(open.issue?.status).toBe('open'); // the original is untouched
+
+    expect(setIssueStatus(resolved, 'resolved', 11_000)).toBe(resolved);
+    expect(setIssueStatus(open, 'open', 11_000)).toBe(open);
+  });
+});
+
+describe('open / resolved filtering and counts', () => {
+  const list: Annotation[] = [
+    plain('n1'),
+    plain('n2', { type: 'issue' }), // legacy category, no workflow
+    issue('i-open-low', 'low'),
+    issue('i-open-critical', 'critical'),
+    issue('i-open-high', 'high'),
+    issue('i-done-high', 'high', 'resolved'),
+  ];
+
+  /**
+   * Catches a filter that leaks non-issues into either bucket. A `type:'issue'`
+   * note with no workflow appearing under "open" would inflate an outstanding
+   * defect count with untriaged annotations.
+   */
+  it('splits issues by status and excludes annotations that are not issues', () => {
+    expect(filterIssuesByStatus(list, 'open').map((a) => a.id)).toEqual([
+      'i-open-low',
+      'i-open-critical',
+      'i-open-high',
+    ]);
+    expect(filterIssuesByStatus(list, 'resolved').map((a) => a.id)).toEqual(['i-done-high']);
+    // The two buckets partition the issues exactly, with nothing else in them.
+    expect(
+      filterIssuesByStatus(list, 'open').length + filterIssuesByStatus(list, 'resolved').length,
+    ).toBe(4);
+    expect(list.filter(isIssueAnnotation)).toHaveLength(4);
+  });
+
+  /**
+   * Catches a roll-up counting annotations instead of issues, per-severity
+   * buckets that include resolved work, and a missing severity key that would
+   * make a badge read `undefined` instead of zero.
+   */
+  it('rolls the list up into issue counts, not annotation counts', () => {
+    expect(summarizeIssues(list)).toEqual({
+      total: 4,
+      open: 3,
+      resolved: 1,
+      openBySeverity: { low: 1, medium: 0, high: 1, critical: 1 },
+      highestOpenSeverity: 'critical',
+    });
+  });
+
+  /**
+   * Catches "nothing outstanding" being reported as a low-severity finding,
+   * which would light up a status badge on a clean inspection.
+   */
+  it('reports no highest severity when nothing is open', () => {
+    const summary = summarizeIssues([plain('n1'), issue('i1', 'critical', 'resolved')]);
+    expect(summary.open).toBe(0);
+    expect(summary.resolved).toBe(1);
+    expect(summary.highestOpenSeverity).toBeUndefined();
+    expect(summarizeIssues([]).highestOpenSeverity).toBeUndefined();
+  });
+
+  /**
+   * Catches a "worst open" that tracks the last one seen, the first one seen,
+   * or a resolved issue, rather than the most severe outstanding one.
+   */
+  it('takes the highest OPEN severity regardless of position or resolved work', () => {
+    expect(
+      summarizeIssues([issue('a', 'critical'), issue('b', 'low')]).highestOpenSeverity,
+    ).toBe('critical');
+    expect(
+      summarizeIssues([issue('a', 'low'), issue('b', 'critical')]).highestOpenSeverity,
+    ).toBe('critical');
+    expect(
+      summarizeIssues([issue('a', 'medium'), issue('b', 'critical', 'resolved')])
+        .highestOpenSeverity,
+    ).toBe('medium');
+  });
+});
+
+describe('reading a persisted workflow block', () => {
+  /**
+   * Catches a parser that throws, or that drops a real finding, on a value it
+   * does not recognise — a file hand-edited to `severity: "blocker"` must not
+   * take the whole session down or quietly delete the issue.
+   */
+  it('degrades an unknown severity to the mid-rank fallback without throwing', () => {
+    const parsed = parseIssueDetails({ severity: 'blocker', status: 'open' });
+    expect(parsed).toEqual({ severity: FALLBACK_ISSUE_SEVERITY, status: 'open' });
+    expect(isIssueSeverity(FALLBACK_ISSUE_SEVERITY)).toBe(true);
+    // Mid-rank: neither below every asserted severity nor above every one.
+    expect(issueSeverityRank(FALLBACK_ISSUE_SEVERITY)).toBeGreaterThan(issueSeverityRank('low'));
+    expect(issueSeverityRank(FALLBACK_ISSUE_SEVERITY)).toBeLessThan(issueSeverityRank('critical'));
+  });
+
+  /**
+   * Catches a fail-OPEN status default: an unreadable status being treated as
+   * resolved would close a defect that was never fixed.
+   */
+  it('degrades an unknown status to open, never to resolved', () => {
+    expect(FALLBACK_ISSUE_STATUS).toBe('open');
+    expect(parseIssueDetails({ severity: 'high', status: 'wontfix' })?.status).toBe('open');
+    expect(parseIssueDetails({ severity: 'high' })?.status).toBe('open');
+    expect(parseIssueDetails({})).toEqual({ severity: FALLBACK_ISSUE_SEVERITY, status: 'open' });
+    expect(isIssueStatus(FALLBACK_ISSUE_STATUS)).toBe(true);
+    expect(ISSUE_STATUSES).toEqual(['open', 'resolved']);
+  });
+
+  /**
+   * Catches an absent block being materialised into an issue, which is the
+   * legacy-session failure seen from the file side.
+   */
+  it('returns nothing for an absent or non-object block', () => {
+    for (const v of [undefined, null, 'open', 42, true, ['high'], NaN]) {
+      expect(parseIssueDetails(v)).toBeUndefined();
+    }
+  });
+
+  /**
+   * Catches a NaN or Infinity observation date surviving into the model, where
+   * it would poison the date tiebreak in the severity sort.
+   */
+  it('drops a non-finite or non-numeric observation date', () => {
+    for (const v of [Number.NaN, Number.POSITIVE_INFINITY, '2026-08-19', null, {}]) {
+      expect(parseIssueDetails({ severity: 'low', status: 'open', observedAt: v })?.observedAt)
+        .toBeUndefined();
+    }
+    expect(parseIssueDetails({ severity: 'low', status: 'open', observedAt: 0 })?.observedAt).toBe(0);
+  });
+
+  /**
+   * Catches a hostile severity value reaching the rank table and producing a
+   * comparator result of NaN, which would scramble the sorted roster.
+   */
+  it('keeps the sort well defined after a degraded parse', () => {
+    const degraded = parseIssueDetails({ severity: { evil: true } });
+    const a: Annotation = { ...plain('a'), issue: degraded };
+    const b = issue('b', 'critical');
+    expect(sortIssuesBySeverity([a, b]).map((x) => x.id)).toEqual(['b', 'a']);
+  });
+});
+
+describe('session round trip', () => {
+  /**
+   * Catches the workflow being written but not read back, or read back with a
+   * changed severity/status/date — an inspection whose findings reset to
+   * "open, medium, undated" every time the file is reopened.
+   */
+  it('preserves severity, status and observation date across save and load', () => {
+    const tracked = attachIssue(
+      plain('i1', { title: 'Corroded bracket', note: 'Section loss at the base' }),
+      { severity: 'critical', status: 'resolved', observedAt: 1_712_000_000_000 },
+      2_000,
+    );
+    const back = parseSession(serializeSession(sessionWith([tracked])));
+    expect(back.version).toBe(SESSION_VERSION);
+    expect(back.annotations).toHaveLength(1);
+    const [read] = back.annotations;
+    expect(read.id).toBe('i1');
+    expect(read.title).toBe('Corroded bracket');
+    expect(read.note).toBe('Section loss at the base');
+    expect(read.issue).toEqual({
+      severity: 'critical',
+      status: 'resolved',
+      observedAt: 1_712_000_000_000,
+    });
+    expect(isIssueAnnotation(read)).toBe(true);
+    expect(isResolvedIssue(read)).toBe(true);
+  });
+
+  /**
+   * Catches a schema-version bump smuggled in with an additive optional field,
+   * which would make every file this build writes unreadable to the readers
+   * already in the field.
+   */
+  it('stays on the existing schema version and keeps a plain session byte-identical', () => {
+    expect(SESSION_VERSION).toBe(8);
+    const notes = sessionWith([plain('n1'), plain('n2', { type: 'issue' })]);
+    const json = serializeSession(notes);
+    const doc = JSON.parse(json) as { version: number; annotations: Record<string, unknown>[] };
+    expect(doc.version).toBe(8);
+    // No annotation without a workflow gains an `issue` key on the way out.
+    for (const a of doc.annotations) expect('issue' in a).toBe(false);
+    expect(serializeSession(notes)).toBe(json);
+  });
+
+  /**
+   * Catches the legacy-file path from end to end: a session written before the
+   * workflow existed must load as plain annotations, including its `issue`
+   * CATEGORY rows, and must not report outstanding findings.
+   */
+  it('loads a pre-workflow session as plain annotations', () => {
+    const legacy = JSON.stringify({
+      app: 'OpenLiDARViewer',
+      kind: 'measurement-session',
+      version: 2,
+      upAxis: 'z',
+      origin: [0, 0, 0],
+      unitSystem: 'metric',
+      views: [],
+      measurements: [],
+      annotations: [
+        {
+          id: 'old1',
+          title: 'Cracked panel',
+          type: 'issue',
+          createdAt: 1,
+          updatedAt: 1,
+          localPosition: { x: 1, y: 2, z: 3 },
+        },
+      ],
+    });
+    const back = parseSession(legacy);
+    expect(back.annotations).toHaveLength(1);
+    expect(back.annotations[0].type).toBe('issue');
+    expect(back.annotations[0].issue).toBeUndefined();
+    expect(isIssueAnnotation(back.annotations[0])).toBe(false);
+    expect(summarizeIssues(back.annotations).total).toBe(0);
+  });
+
+  /**
+   * Catches a malformed persisted block failing the whole import, and catches
+   * it degrading to something a reader would present as resolved.
+   */
+  it('imports a corrupt workflow block as an open issue rather than failing', () => {
+    const corrupt = JSON.stringify({
+      app: 'OpenLiDARViewer',
+      kind: 'measurement-session',
+      version: 8,
+      upAxis: 'z',
+      origin: [0, 0, 0],
+      unitSystem: 'metric',
+      views: [],
+      measurements: [],
+      annotations: [
+        {
+          id: 'bad1',
+          title: 'Unreadable',
+          type: 'issue',
+          createdAt: 1,
+          updatedAt: 1,
+          localPosition: { x: 0, y: 0, z: 0 },
+          issue: { severity: 'catastrophic', status: 'archived', observedAt: 'yesterday' },
+        },
+        {
+          id: 'bad2',
+          title: 'Block is a string',
+          type: 'note',
+          createdAt: 1,
+          updatedAt: 1,
+          localPosition: { x: 0, y: 0, z: 0 },
+          issue: 'critical',
+        },
+      ],
+    });
+    const back = parseSession(corrupt);
+    expect(back.annotations.map((a) => a.id)).toEqual(['bad1', 'bad2']);
+    expect(back.annotations[0].issue).toEqual({
+      severity: FALLBACK_ISSUE_SEVERITY,
+      status: 'open',
+    });
+    // A block that is not an object is absent, not an issue with defaults.
+    expect(back.annotations[1].issue).toBeUndefined();
+    expect(summarizeIssues(back.annotations)).toMatchObject({ total: 1, open: 1, resolved: 0 });
+  });
+});


### PR DESCRIPTION
An annotation can now carry an optional `issue` block: severity (low, medium, high, critical), an open/resolved status, and the date the condition was observed. Description, linked measurement and saved camera view stay on the existing `note`, `linkedMeasurementId` and `cameraState`.

`annotate/issueWorkflow.ts` holds the vocabulary and the helpers: severity ranking, a worst-first sort that breaks ties on the stable id, an open/resolved filter, a roll-up count, attach and status transitions, and a defensive reader. An unrecognised severity degrades to mid-rank, an unrecognised status to open, so a corrupt file cannot report a defect as fixed.

An annotation without the block stays a plain annotation, including one already categorised `type: 'issue'`. The session schema stays at v8: the field is optional, read version-independently and written only when set.

Model only, no UI.
