### PR TITLE
feat(model): group loaded layers behind stable group ids

### DIFF
--- a/src/model/layerGroups.ts
+++ b/src/model/layerGroups.ts
@@ -1,0 +1,478 @@
+/**
+ * layerGroups.ts — organising loaded layers into named, collapsible groups.
+ *
+ * A survey flown as two passes of three strips arrives in the Layers panel as
+ * six flat rows, and every operation on "the second flight" is the same click
+ * repeated three times. This module is the container that makes such a set
+ * addressable: a named group with a stable id, a member list, and a collapsed
+ * flag.
+ *
+ * What it is deliberately NOT is a second layer store. A group holds ids and
+ * nothing else — no visibility, no opacity, no lock, no CRS, no position in the
+ * scene. All of that already lives in `AppContext.layers`, the viewer, and
+ * `LayerService`, and duplicating any of it here would create two answers to
+ * one question. So "hide this group" is not a flag that can drift out of step
+ * with the six layers under it; it is a one-shot OPERATION whose result is a
+ * list of member ids for the caller to push through `LayerService.setVisible`.
+ * Solo is the same shape, which is why nothing here remembers a soloed group.
+ *
+ * Membership is EXCLUSIVE: a layer belongs to at most one group. That makes
+ * {@link LayerGroupStore.groupOf} a function rather than a list, and gives
+ * "show only this group" one unambiguous answer. Adding a layer to a second
+ * group MOVES it out of the first. Overlapping membership would let two groups
+ * issue contradictory visibility plans for the same layer, and nothing in the
+ * workflow needs a layer to be in two flights at once.
+ *
+ * A group never proves a layer exists. The store holds ids the app handed it,
+ * and the app closes scans without asking, so every function that emits ids
+ * takes the LIVE id set and intersects with it. A closed scan can still be
+ * listed as a member and will not appear in a visibility plan, a solo plan, an
+ * appearance plan, or the tree. {@link LayerGroupStore.reconcile} is how those
+ * stale entries are dropped for good, on the same cadence
+ * `LayerService.refreshCrsFlags` already reconciles the project frame.
+ *
+ * Pure: no DOM, no three.js, no viewer, no imports at all. This is the model
+ * only — the panel that renders a group, and the session that persists one, are
+ * later steps that consume it.
+ */
+
+/**
+ * A named, collapsible set of layer ids.
+ *
+ * Identity is {@link id} — never the name (two flights are routinely both
+ * called "Flight 2") and never the position in the list (a re-ordered or
+ * re-created list would rename every group under it, which is the index-as-id
+ * defect this repository has already paid for once).
+ */
+export interface LayerGroup {
+  /** Stable, generated identity. */
+  readonly id: string;
+  /** Display label. Mutable, non-blank, and not required to be unique. */
+  readonly name: string;
+  /**
+   * Member layer ids in the order they joined. May still name a layer the
+   * scene has closed; see {@link LayerGroupStore.reconcile}.
+   */
+  readonly memberIds: readonly string[];
+  /** Whether the panel should draw the group folded shut. */
+  readonly collapsed: boolean;
+}
+
+/** Session-local counter behind the no-WebCrypto fallback. */
+let fallbackGroupCounter = 0;
+
+/**
+ * Mint a fresh group id.
+ *
+ * Random where WebCrypto offers it, monotonic time plus a counter otherwise.
+ * Either way it is derived from neither the group's name nor its position, so
+ * renaming a group or reordering the list cannot change which group an id
+ * refers to. Never a secret — a group id is an internal handle.
+ */
+export function newGroupId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c && typeof c.randomUUID === 'function') return `group_${c.randomUUID()}`;
+  return `group_${Date.now().toString(36)}_${(fallbackGroupCounter++).toString(36)}`;
+}
+
+export interface LayerGroupStoreOptions {
+  /** Override the id generator (tests inject a deterministic counter). */
+  readonly generateId?: () => string;
+}
+
+/** Internal mutable record; {@link LayerGroup} is the snapshot handed out. */
+interface MutableGroup {
+  name: string;
+  readonly memberIds: string[];
+  collapsed: boolean;
+}
+
+/** One node of the Layers panel's ordered tree. */
+export type LayerTreeNode =
+  | {
+      readonly kind: 'group';
+      readonly group: LayerGroup;
+      /** The group's members that are actually loaded, in join order. */
+      readonly memberIds: readonly string[];
+    }
+  | { readonly kind: 'layer'; readonly layerId: string };
+
+/**
+ * The groups of one session, keyed by group id and held in creation order.
+ *
+ * Holds group records and membership. Nothing else: no layer state passes
+ * through here, and no method returns a layer's visibility, appearance, or
+ * order — those are read from, and written to, the services that own them.
+ */
+export class LayerGroupStore {
+  private readonly _byId = new Map<string, MutableGroup>();
+  /**
+   * layer id → owning group id. The exclusivity index, kept in step with the
+   * member arrays by {@link _detach} and {@link addMember}; every membership
+   * change must touch both or `groupOf` starts disagreeing with `membersOf`.
+   */
+  private readonly _owner = new Map<string, string>();
+  private readonly _gen: () => string;
+
+  constructor(options: LayerGroupStoreOptions = {}) {
+    this._gen = options.generateId ?? newGroupId;
+  }
+
+  /**
+   * Create a group, optionally seeded with members. Each seed is MOVED out of
+   * whatever group already held it.
+   *
+   * A blank name throws rather than being accepted, because a group is created
+   * from a control that always supplies a default label — a blank one reaching
+   * here is a caller bug, not a user action, and a nameless row in the panel
+   * cannot be told apart from its neighbours. (A blank RENAME is a user action
+   * and is merely refused; see {@link rename}.)
+   */
+  create(name: string, memberIds: readonly string[] = []): LayerGroup {
+    const label = name.trim();
+    if (label === '') {
+      throw new Error('LayerGroupStore.create: a group needs a non-blank name.');
+    }
+    const id = this._mintId();
+    this._byId.set(id, { name: label, memberIds: [], collapsed: false });
+    for (const layerId of memberIds) this.addMember(id, layerId);
+    return this._snapshot(id)!;
+  }
+
+  /**
+   * Relabel a group. The trimmed name must be non-blank and need not be unique
+   * — identity is the id, so two groups may legitimately both be "Flight 2".
+   * Returns null (leaving the group untouched) for an unknown id or a blank
+   * name.
+   */
+  rename(groupId: string, name: string): LayerGroup | null {
+    const group = this._byId.get(groupId);
+    if (!group) return null;
+    const label = name.trim();
+    if (label === '') return null;
+    group.name = label;
+    return this._snapshot(groupId);
+  }
+
+  /** Fold or unfold the group in the panel. */
+  setCollapsed(groupId: string, collapsed: boolean): LayerGroup | null {
+    const group = this._byId.get(groupId);
+    if (!group) return null;
+    group.collapsed = collapsed;
+    return this._snapshot(groupId);
+  }
+
+  /**
+   * Delete the group. Its members become ungrouped and stay loaded: a container
+   * disappearing must not take the scans inside it out of the scene.
+   */
+  delete(groupId: string): boolean {
+    const group = this._byId.get(groupId);
+    if (!group) return false;
+    for (const layerId of group.memberIds) {
+      if (this._owner.get(layerId) === groupId) this._owner.delete(layerId);
+    }
+    return this._byId.delete(groupId);
+  }
+
+  /**
+   * Put a layer in a group, moving it out of any group that already held it
+   * (membership is exclusive). Re-adding a layer to the group it is already in
+   * is a no-op that keeps its position, so a double click cannot duplicate a
+   * row or send a member to the bottom of its own list.
+   */
+  addMember(groupId: string, layerId: string): LayerGroup | null {
+    const group = this._byId.get(groupId);
+    if (!group) return null;
+    const previous = this._owner.get(layerId);
+    if (previous === groupId) return this._snapshot(groupId);
+    if (previous !== undefined) this._detach(previous, layerId);
+    group.memberIds.push(layerId);
+    this._owner.set(layerId, groupId);
+    return this._snapshot(groupId);
+  }
+
+  /**
+   * Take a layer out of a group; it becomes ungrouped and stays loaded. False
+   * when that group does not hold that layer.
+   */
+  removeMember(groupId: string, layerId: string): boolean {
+    if (this._owner.get(layerId) !== groupId) return false;
+    this._detach(groupId, layerId);
+    return true;
+  }
+
+  /** Drop one closed layer from whatever group held it. False when ungrouped. */
+  forgetLayer(layerId: string): boolean {
+    const owner = this._owner.get(layerId);
+    if (owner === undefined) return false;
+    this._detach(owner, layerId);
+    return true;
+  }
+
+  /**
+   * Drop every member id absent from `liveLayerIds`.
+   *
+   * Empty groups are KEPT. A group whose last scan was closed is still the
+   * container the user made, and deleting it on a routine reconcile would
+   * destroy it as a side effect of removing a layer. The cost is that a scan
+   * closed and reopened does not rejoin its old group by itself; that is a
+   * deliberate trade, and the read paths never resurrect a dead id in the
+   * meantime because they all intersect with the live set anyway.
+   */
+  reconcile(liveLayerIds: Iterable<string>): void {
+    const live = new Set(liveLayerIds);
+    for (const [groupId, group] of this._byId) {
+      for (let i = group.memberIds.length - 1; i >= 0; i--) {
+        const layerId = group.memberIds[i];
+        if (live.has(layerId)) continue;
+        group.memberIds.splice(i, 1);
+        if (this._owner.get(layerId) === groupId) this._owner.delete(layerId);
+      }
+    }
+  }
+
+  /** The group with this id, or null. */
+  get(groupId: string): LayerGroup | null {
+    return this._snapshot(groupId);
+  }
+
+  has(groupId: string): boolean {
+    return this._byId.has(groupId);
+  }
+
+  /** Every group, in creation order. */
+  groups(): LayerGroup[] {
+    const out: LayerGroup[] = [];
+    for (const groupId of this._byId.keys()) out.push(this._snapshot(groupId)!);
+    return out;
+  }
+
+  /** The group holding this layer, or null when it is ungrouped. */
+  groupOf(layerId: string): LayerGroup | null {
+    const groupId = this._owner.get(layerId);
+    return groupId === undefined ? null : this._snapshot(groupId);
+  }
+
+  /**
+   * A group's recorded members, in join order. May include layers the scene has
+   * closed — use {@link liveMembersOf} for anything that acts on them.
+   */
+  membersOf(groupId: string): readonly string[] {
+    const group = this._byId.get(groupId);
+    return group ? [...group.memberIds] : [];
+  }
+
+  /**
+   * A group's members that are actually loaded, in join order. Join order
+   * rather than scene order so a group's rows keep the arrangement the user
+   * built as other scans come and go.
+   */
+  liveMembersOf(groupId: string, allLayerIds: readonly string[]): readonly string[] {
+    const group = this._byId.get(groupId);
+    if (!group) return [];
+    const live = new Set(allLayerIds);
+    return group.memberIds.filter((layerId) => live.has(layerId));
+  }
+
+  /**
+   * Loaded layers in no group, in scene order. Grouping is opt-in, so this is
+   * the path by which an ungrouped layer stays reachable — it is never implied
+   * by absence from some default group, because there is no default group.
+   */
+  ungrouped(allLayerIds: readonly string[]): readonly string[] {
+    return allLayerIds.filter((layerId) => !this._owner.has(layerId));
+  }
+
+  /**
+   * The panel's ordered tree: every group in creation order, then every
+   * ungrouped layer in scene order.
+   *
+   * Built FROM `allLayerIds`, which is what makes the two invariants
+   * structural rather than remembered: each loaded layer appears exactly once,
+   * and a closed layer appears nowhere, whether or not {@link reconcile} has
+   * run yet.
+   */
+  tree(allLayerIds: readonly string[]): readonly LayerTreeNode[] {
+    const nodes: LayerTreeNode[] = [];
+    for (const groupId of this._byId.keys()) {
+      nodes.push({
+        kind: 'group',
+        group: this._snapshot(groupId)!,
+        memberIds: this.liveMembersOf(groupId, allLayerIds),
+      });
+    }
+    for (const layerId of this.ungrouped(allLayerIds)) {
+      nodes.push({ kind: 'layer', layerId });
+    }
+    return nodes;
+  }
+
+  /** Detach a layer from a group, keeping the member array and the index in step. */
+  private _detach(groupId: string, layerId: string): void {
+    const group = this._byId.get(groupId);
+    if (group) {
+      const at = group.memberIds.indexOf(layerId);
+      if (at >= 0) group.memberIds.splice(at, 1);
+    }
+    if (this._owner.get(layerId) === groupId) this._owner.delete(layerId);
+  }
+
+  /**
+   * A free group id. The generator is allowed to repeat — a test injects a
+   * counter, and a session import will one day hand back ids minted in another
+   * run — and handing out a live id would silently merge two groups into one.
+   */
+  private _mintId(): string {
+    let id = this._gen();
+    for (let attempt = 0; this._byId.has(id); attempt++) {
+      if (attempt >= 64) {
+        throw new Error('LayerGroupStore: the id generator produced no free id.');
+      }
+      id = this._gen();
+    }
+    return id;
+  }
+
+  private _snapshot(groupId: string): LayerGroup | null {
+    const group = this._byId.get(groupId);
+    if (!group) return null;
+    return {
+      id: groupId,
+      name: group.name,
+      memberIds: [...group.memberIds],
+      collapsed: group.collapsed,
+    };
+  }
+}
+
+/**
+ * What a group's visibility control should read.
+ *
+ * `empty` is a distinct state, not a synonym for `none`. A group with no loaded
+ * member has nothing hidden; reporting it as `none` would draw an unchecked box
+ * that invites a click which does nothing. The same distinction the CRS model
+ * makes between "can't compare" and "matches".
+ */
+export type GroupVisibility = 'all' | 'none' | 'mixed' | 'empty';
+
+/**
+ * Fold a group's members down to one visibility state.
+ *
+ * `layerVisibility` is the app's existing per-layer intent map
+ * (`AppContext.layers.visible`), read here and never written. A member absent
+ * from it is a layer the scene no longer holds and is ignored, so a group that
+ * outlived its scans reports `empty` rather than inheriting the state of ghosts.
+ */
+export function groupVisibilityIntent(
+  group: LayerGroup,
+  layerVisibility: ReadonlyMap<string, boolean>,
+): GroupVisibility {
+  let shown = 0;
+  let hidden = 0;
+  for (const layerId of group.memberIds) {
+    const visible = layerVisibility.get(layerId);
+    if (visible === undefined) continue;
+    if (visible) shown++;
+    else hidden++;
+  }
+  if (shown + hidden === 0) return 'empty';
+  if (hidden === 0) return 'all';
+  if (shown === 0) return 'none';
+  return 'mixed';
+}
+
+/** The layers to show and to hide when a group is isolated. */
+export interface GroupSoloPlan {
+  readonly visible: readonly string[];
+  readonly hidden: readonly string[];
+}
+
+/**
+ * Plan "show only this group" as a partition of the loaded layers.
+ *
+ * A plan, not a stored flag: the caller applies it through the visibility path
+ * it already owns, so there is no group-solo state to fall out of step with the
+ * layers. Both lists are built from `allLayerIds`, so a member the scene has
+ * closed can never be handed back as something to show.
+ *
+ * Null when the group has no loaded member. Isolating an empty group would hide
+ * every layer and leave a blank viewport with nothing on screen to explain it,
+ * so the operation refuses and the caller can disable the control instead.
+ */
+export function soloGroupIntent(
+  group: LayerGroup,
+  allLayerIds: readonly string[],
+): GroupSoloPlan | null {
+  const members = new Set(group.memberIds);
+  const visible: string[] = [];
+  const hidden: string[] = [];
+  for (const layerId of allLayerIds) {
+    if (members.has(layerId)) visible.push(layerId);
+    else hidden.push(layerId);
+  }
+  return visible.length === 0 ? null : { visible, hidden };
+}
+
+/**
+ * How an appearance property behaves across several layers.
+ *
+ * `per-layer` — the value stands on its own for each layer: opacity, point
+ * size, a picking lock. Applying it to six layers is six independent edits and
+ * is always safe.
+ *
+ * `cross-layer` — the value only reads correctly when the layers share a
+ * spatial frame: an elevation ramp over one height range, a single colour scale
+ * spanning the set. Pushing one of those onto layers that are not all mounted
+ * in the project frame yields a legend that claims to describe the group and
+ * describes only part of it, which is the same failure the viewer's shared
+ * elevation range already refuses to compute.
+ */
+export type AppearanceScope = 'per-layer' | 'cross-layer';
+
+/** The one fact a bulk appearance decision needs about a loaded member. */
+export interface GroupMemberFrame {
+  readonly id: string;
+  /** True when the layer is mounted in the project's shared spatial frame. */
+  readonly inSharedFrame: boolean;
+}
+
+/** Which members a bulk appearance edit may touch, and why the rest were left. */
+export interface BulkAppearancePlan {
+  readonly applyTo: readonly string[];
+  /** Live members held back. Empty when the edit runs across the whole group. */
+  readonly withheld: readonly string[];
+  /** Plain-language reason, empty when nothing was withheld. */
+  readonly reason: string;
+}
+
+/**
+ * Decide which members of a group a bulk appearance edit may be applied to.
+ *
+ * `members` carries the loaded layers and their frame state; anything in the
+ * group but not in `members` is a closed scan and is dropped, so a bulk edit
+ * can never be aimed at a layer that is gone.
+ *
+ * A `cross-layer` edit is all-or-nothing. Applying it to the in-frame subset
+ * would be worse than refusing: the control says "the group", and the result
+ * would silently mean "the part of the group that happened to qualify".
+ */
+export function bulkAppearanceIntent(
+  group: LayerGroup,
+  members: readonly GroupMemberFrame[],
+  scope: AppearanceScope,
+): BulkAppearancePlan {
+  const inGroup = new Set(group.memberIds);
+  const live = members.filter((member) => inGroup.has(member.id));
+  const ids = live.map((member) => member.id);
+  if (scope === 'per-layer') return { applyTo: ids, withheld: [], reason: '' };
+  const outside = live.filter((member) => !member.inSharedFrame);
+  if (outside.length === 0) return { applyTo: ids, withheld: [], reason: '' };
+  return {
+    applyTo: [],
+    withheld: ids,
+    reason:
+      `${outside.length} of ${ids.length} layers in "${group.name}" are not in the ` +
+      "project's shared frame, so one value across the group would not describe them.",
+  };
+}

--- a/tests/layerGroups.test.ts
+++ b/tests/layerGroups.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LayerGroupStore,
+  bulkAppearanceIntent,
+  groupVisibilityIntent,
+  newGroupId,
+  soloGroupIntent,
+  type LayerGroup,
+} from '../src/model/layerGroups';
+
+/** A store whose ids are deterministic, so assertions can name them. */
+function store(): LayerGroupStore {
+  let n = 0;
+  return new LayerGroupStore({ generateId: () => `g${++n}` });
+}
+
+/** A group value built without a store, for the pure intent functions. */
+function group(memberIds: readonly string[], name = 'Flight 1'): LayerGroup {
+  return { id: 'g1', name, memberIds, collapsed: false };
+}
+
+describe('group identity', () => {
+  /**
+   * Catches identity taken from the name or the list position. Two flights are
+   * routinely both called "Flight 2", and a renamed or re-ordered group must
+   * still be the same group — the index-as-id defect that renamed things on
+   * every re-run.
+   */
+  it('keeps ids stable across rename, reorder and duplicate names', () => {
+    const s = store();
+    const first = s.create('Flight 1');
+    const second = s.create('Flight 1');
+    expect(first.id).not.toBe(second.id);
+    expect(s.groups().map((g) => g.name)).toEqual(['Flight 1', 'Flight 1']);
+
+    expect(s.rename(first.id, 'Morning pass')!.id).toBe(first.id);
+    expect(s.get(first.id)!.name).toBe('Morning pass');
+    // Deleting the group ABOVE must not shift what the surviving id refers to.
+    s.delete(first.id);
+    expect(s.groups()).toHaveLength(1);
+    expect(s.get(second.id)!.name).toBe('Flight 1');
+  });
+
+  /**
+   * Catches an id generator whose collisions merge two groups into one record.
+   * A session import will one day replay ids minted in another run.
+   */
+  it('never hands out an id that is already in use', () => {
+    let n = 0;
+    // Repeats 'dup' once before moving on.
+    const ids = ['dup', 'dup', 'fresh'];
+    const s = new LayerGroupStore({ generateId: () => ids[n++] });
+    const a = s.create('A');
+    const b = s.create('B');
+    expect(a.id).toBe('dup');
+    expect(b.id).toBe('fresh');
+    expect(s.groups()).toHaveLength(2);
+  });
+
+  /** Catches an id derived from the group's name or its ordinal. */
+  it('mints ids that carry no name or position', () => {
+    const id = newGroupId();
+    expect(id.startsWith('group_')).toBe(true);
+    expect(newGroupId()).not.toBe(id);
+  });
+
+  /**
+   * Catches a blank label reaching the panel. A create call always comes from a
+   * control with a default label, so a blank one is a caller bug and throws; a
+   * blank rename is a user clearing a text field and is merely refused, leaving
+   * the previous name standing.
+   */
+  it('refuses blank names, and trims the rest', () => {
+    const s = store();
+    expect(() => s.create('   ')).toThrow(/non-blank name/);
+    const g = s.create('  Flight 2  ');
+    expect(g.name).toBe('Flight 2');
+    expect(s.rename(g.id, '  ')).toBeNull();
+    expect(s.get(g.id)!.name).toBe('Flight 2');
+    expect(s.rename('no-such-group', 'x')).toBeNull();
+  });
+});
+
+describe('exclusive membership', () => {
+  /**
+   * Catches a layer left in two groups at once. Overlapping membership lets two
+   * groups issue contradictory visibility plans for the same layer, and makes
+   * `groupOf` a lie.
+   */
+  it('moves a layer out of its old group when it joins a second', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c1', 'c2']);
+    const b = s.create('Flight 2', ['c3']);
+
+    s.addMember(b.id, 'c2');
+    expect(s.membersOf(a.id)).toEqual(['c1']);
+    expect(s.membersOf(b.id)).toEqual(['c3', 'c2']);
+    expect(s.groupOf('c2')!.id).toBe(b.id);
+  });
+
+  /**
+   * Catches a duplicated row, and catches a re-add that quietly sends a member
+   * to the bottom of its own group. Both surface as a double click reordering
+   * or doubling the panel.
+   */
+  it('re-adding a member is a no-op that keeps its position', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c1', 'c2', 'c3']);
+    s.addMember(a.id, 'c1');
+    expect(s.membersOf(a.id)).toEqual(['c1', 'c2', 'c3']);
+    // A repeated seed in the constructor list is the same case.
+    const b = s.create('Flight 2', ['c9', 'c9']);
+    expect(s.membersOf(b.id)).toEqual(['c9']);
+  });
+
+  /**
+   * Catches the member array and the owner index falling out of step — the
+   * failure where `membersOf` still lists a layer that `groupOf` says is
+   * ungrouped, so the panel draws it twice or not at all.
+   */
+  it('keeps membersOf and groupOf agreeing through every membership change', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c1', 'c2']);
+    const b = s.create('Flight 2');
+
+    expect(s.removeMember(a.id, 'c1')).toBe(true);
+    expect(s.groupOf('c1')).toBeNull();
+    expect(s.membersOf(a.id)).toEqual(['c2']);
+    // Removing from the wrong group changes nothing.
+    expect(s.removeMember(b.id, 'c2')).toBe(false);
+    expect(s.groupOf('c2')!.id).toBe(a.id);
+
+    expect(s.forgetLayer('c2')).toBe(true);
+    expect(s.groupOf('c2')).toBeNull();
+    expect(s.membersOf(a.id)).toEqual([]);
+    expect(s.forgetLayer('c2')).toBe(false);
+
+    expect(s.addMember('no-such-group', 'c1')).toBeNull();
+    expect(s.groupOf('c1')).toBeNull();
+  });
+
+  /**
+   * Catches a group delete that takes the loaded scans with it. Deleting a
+   * container is an organisational act; the layers stay in the scene and become
+   * ungrouped.
+   */
+  it('deleting a group ungroups its members rather than losing them', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c1', 'c2']);
+    expect(s.delete(a.id)).toBe(true);
+    expect(s.delete(a.id)).toBe(false);
+    expect(s.groupOf('c1')).toBeNull();
+    expect(s.ungrouped(['c1', 'c2'])).toEqual(['c1', 'c2']);
+    expect(s.tree(['c1', 'c2'])).toEqual([
+      { kind: 'layer', layerId: 'c1' },
+      { kind: 'layer', layerId: 'c2' },
+    ]);
+  });
+
+  /** Catches a collapsed flag that does not round-trip, or leaks into membership. */
+  it('collapses and expands without touching membership', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c1']);
+    expect(a.collapsed).toBe(false);
+    expect(s.setCollapsed(a.id, true)!.collapsed).toBe(true);
+    expect(s.get(a.id)!.memberIds).toEqual(['c1']);
+    expect(s.setCollapsed(a.id, false)!.collapsed).toBe(false);
+    expect(s.setCollapsed('no-such-group', true)).toBeNull();
+  });
+
+  /**
+   * Catches a snapshot that hands out the store's own array. A caller mutating
+   * what it got back would rewrite membership through a read method.
+   */
+  it('hands out copies, so a caller cannot edit membership through a read', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c1']);
+    (s.get(a.id)!.memberIds as string[]).push('c2');
+    (s.membersOf(a.id) as string[]).push('c3');
+    expect(s.membersOf(a.id)).toEqual(['c1']);
+  });
+});
+
+describe('layers the scene has closed', () => {
+  /**
+   * Catches a group resurrecting a dead id: the layer is gone from the viewer,
+   * but a group operation still names it and the caller tries to show, hide or
+   * restyle something that no longer exists.
+   */
+  it('never emits a member the live layer set does not contain', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c1', 'c2', 'c3']);
+    const live = ['c1', 'c3', 'c9'];
+
+    // Recorded membership still knows about c2 until reconcile runs.
+    expect(s.membersOf(a.id)).toEqual(['c1', 'c2', 'c3']);
+    // Everything that acts on layers has already dropped it.
+    expect(s.liveMembersOf(a.id, live)).toEqual(['c1', 'c3']);
+    expect(soloGroupIntent(s.get(a.id)!, live)!.visible).toEqual(['c1', 'c3']);
+    expect(
+      bulkAppearanceIntent(
+        s.get(a.id)!,
+        live.map((id) => ({ id, inSharedFrame: true })),
+        'per-layer',
+      ).applyTo,
+    ).toEqual(['c1', 'c3']);
+    for (const node of s.tree(live)) {
+      if (node.kind === 'group') expect(node.memberIds).not.toContain('c2');
+    }
+  });
+
+  /**
+   * Catches a reconcile that either keeps ghosts or deletes the container. An
+   * emptied group is still the group the user made; removing its last layer
+   * must not delete it as a side effect.
+   */
+  it('reconcile drops closed members and keeps the emptied group', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c1', 'c2']);
+    const b = s.create('Flight 2', ['c3']);
+
+    s.reconcile(['c1']);
+    expect(s.membersOf(a.id)).toEqual(['c1']);
+    expect(s.membersOf(b.id)).toEqual([]);
+    expect(s.has(b.id)).toBe(true);
+    expect(s.groupOf('c3')).toBeNull();
+    // c3 can be regrouped afterwards, which a stale owner index would refuse.
+    expect(s.addMember(a.id, 'c3')!.memberIds).toEqual(['c1', 'c3']);
+  });
+
+  /**
+   * Catches a group that inherits the state of layers that are gone: with every
+   * member closed the answer is `empty`, not `all` (a checked box promising
+   * six visible scans) and not `none`.
+   */
+  it('a group whose members all closed reports empty, and refuses solo', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c1', 'c2']);
+    const g = s.get(a.id)!;
+    expect(groupVisibilityIntent(g, new Map())).toBe('empty');
+    expect(soloGroupIntent(g, ['c7', 'c8'])).toBeNull();
+  });
+});
+
+describe('ungrouped layers stay reachable', () => {
+  /**
+   * Catches the defect that makes grouping destructive: a layer in no group
+   * disappearing from the panel, because the tree was built from the groups
+   * instead of from the loaded layers.
+   */
+  it('every loaded layer appears exactly once in the tree', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c2', 'c4']);
+    s.create('Flight 2', ['c5']);
+    const live = ['c1', 'c2', 'c3', 'c4', 'c5'];
+
+    const nodes = s.tree(live);
+    const seen: string[] = [];
+    for (const node of nodes) {
+      if (node.kind === 'group') seen.push(...node.memberIds);
+      else seen.push(node.layerId);
+    }
+    expect(seen.slice().sort()).toEqual(live.slice().sort());
+    expect(new Set(seen).size).toBe(seen.length);
+
+    // Groups in creation order first, then the ungrouped layers in scene order.
+    expect(nodes.map((n) => (n.kind === 'group' ? n.group.name : n.layerId))).toEqual([
+      'Flight 1',
+      'Flight 2',
+      'c1',
+      'c3',
+    ]);
+    expect(s.ungrouped(live)).toEqual(['c1', 'c3']);
+    expect(s.groupOf('c1')).toBeNull();
+    expect(s.groupOf('c4')!.id).toBe(a.id);
+  });
+
+  /**
+   * Catches a tree whose group rows re-order themselves as unrelated scans load
+   * and close. Members keep the order the user built them in.
+   */
+  it('keeps members in join order, not scene order', () => {
+    const s = store();
+    const a = s.create('Flight 1', ['c4', 'c2']);
+    expect(s.liveMembersOf(a.id, ['c1', 'c2', 'c3', 'c4'])).toEqual(['c4', 'c2']);
+    expect(s.liveMembersOf('no-such-group', ['c1'])).toEqual([]);
+  });
+
+  /** Catches a tree that invents rows when nothing is loaded at all. */
+  it('an empty scene yields a group node with no members and no layer rows', () => {
+    const s = store();
+    s.create('Flight 1', ['c1']);
+    expect(s.tree([])).toEqual([
+      { kind: 'group', group: expect.objectContaining({ name: 'Flight 1' }), memberIds: [] },
+    ]);
+  });
+});
+
+describe('group visibility as an operation over member ids', () => {
+  /**
+   * Catches the whole class of bug a duplicate group-level visibility flag
+   * would introduce: the flag says "shown" while a member underneath it is
+   * hidden. The state is derived from the layers every time, so `mixed` is
+   * reported instead of a stale `all`.
+   */
+  it('reports all, none and mixed from the per-layer intent map', () => {
+    const visible = new Map([
+      ['c1', true],
+      ['c2', true],
+      ['c3', false],
+    ]);
+    expect(groupVisibilityIntent(group(['c1', 'c2']), visible)).toBe('all');
+    expect(groupVisibilityIntent(group(['c3']), visible)).toBe('none');
+    expect(groupVisibilityIntent(group(['c1', 'c3']), visible)).toBe('mixed');
+    expect(groupVisibilityIntent(group([]), visible)).toBe('empty');
+  });
+
+  /**
+   * Catches a fold that counts closed layers. One hidden member out of three
+   * must read `mixed`; a member the map has never heard of must not tip it
+   * either way.
+   */
+  it('ignores members the visibility map does not know about', () => {
+    const visible = new Map([
+      ['c1', true],
+      ['c2', true],
+    ]);
+    expect(groupVisibilityIntent(group(['c1', 'c2', 'gone']), visible)).toBe('all');
+    expect(groupVisibilityIntent(group(['gone']), visible)).toBe('empty');
+  });
+
+  /**
+   * Catches a solo that leaks a layer: the plan must partition the loaded set,
+   * so no layer is left out of both lists and quietly keeps its old state while
+   * the rest of the scene is isolated.
+   */
+  it('solo partitions the loaded layers into show and hide', () => {
+    const live = ['c1', 'c2', 'c3', 'c4'];
+    const plan = soloGroupIntent(group(['c2', 'c4']), live)!;
+    expect(plan.visible).toEqual(['c2', 'c4']);
+    expect(plan.hidden).toEqual(['c1', 'c3']);
+    expect([...plan.visible, ...plan.hidden].slice().sort()).toEqual(live.slice().sort());
+  });
+
+  /**
+   * Catches the blank-viewport defect: isolating a group with nothing loaded in
+   * it would hide every layer, leaving nothing on screen to explain why.
+   */
+  it('refuses to isolate a group with no loaded member', () => {
+    expect(soloGroupIntent(group([]), ['c1', 'c2'])).toBeNull();
+    expect(soloGroupIntent(group(['c9']), ['c1', 'c2'])).toBeNull();
+    // A single loaded member is enough to isolate on.
+    expect(soloGroupIntent(group(['c9', 'c1']), ['c1', 'c2'])!.visible).toEqual(['c1']);
+  });
+});
+
+describe('bulk appearance safety', () => {
+  /**
+   * Catches a bulk edit that refuses work it could safely do. Opacity, point
+   * size and a picking lock mean the same thing on each layer independently, so
+   * a group-wide edit is just several independent edits.
+   */
+  it('applies a per-layer property to every loaded member', () => {
+    const members = [
+      { id: 'c1', inSharedFrame: true },
+      { id: 'c2', inSharedFrame: false },
+      { id: 'c3', inSharedFrame: false },
+    ];
+    const plan = bulkAppearanceIntent(group(['c1', 'c2']), members, 'per-layer');
+    expect(plan.applyTo).toEqual(['c1', 'c2']);
+    expect(plan.withheld).toEqual([]);
+    expect(plan.reason).toBe('');
+  });
+
+  /**
+   * Catches a group-wide elevation ramp or colour scale spanning layers that do
+   * not share a frame — a legend that claims to describe the group while the
+   * heights under it sit on unrelated origins.
+   */
+  it('refuses a cross-layer property when a member is outside the shared frame', () => {
+    const members = [
+      { id: 'c1', inSharedFrame: true },
+      { id: 'c2', inSharedFrame: false },
+    ];
+    const plan = bulkAppearanceIntent(group(['c1', 'c2']), members, 'cross-layer');
+    expect(plan.applyTo).toEqual([]);
+    expect(plan.withheld).toEqual(['c1', 'c2']);
+    expect(plan.reason).toContain('1 of 2');
+    expect(plan.reason).toContain('Flight 1');
+  });
+
+  /**
+   * Catches a partial cross-layer apply. Styling only the qualifying half is
+   * worse than refusing: the control says "the group" and the result would mean
+   * "whichever members happened to qualify", with nothing saying so.
+   */
+  it('a cross-layer refusal is all-or-nothing, never the qualifying subset', () => {
+    const members = [
+      { id: 'c1', inSharedFrame: true },
+      { id: 'c2', inSharedFrame: true },
+      { id: 'c3', inSharedFrame: false },
+    ];
+    const plan = bulkAppearanceIntent(group(['c1', 'c2', 'c3']), members, 'cross-layer');
+    expect(plan.applyTo).toEqual([]);
+    expect(plan.withheld).toEqual(['c1', 'c2', 'c3']);
+  });
+
+  /**
+   * Catches a frame check that reads the whole scene instead of the group. A
+   * layer outside the frame and outside the group must not block the group's
+   * own edit.
+   */
+  it('judges only the group, and allows a wholly in-frame group', () => {
+    const members = [
+      { id: 'c1', inSharedFrame: true },
+      { id: 'c2', inSharedFrame: true },
+      { id: 'c3', inSharedFrame: false },
+    ];
+    const plan = bulkAppearanceIntent(group(['c1', 'c2']), members, 'cross-layer');
+    expect(plan.applyTo).toEqual(['c1', 'c2']);
+    expect(plan.reason).toBe('');
+  });
+});


### PR DESCRIPTION
A group references existing LayerService ids and holds no layer state.

`LayerGroupStore` covers create, rename, add and remove member, delete, collapse, and lookup by group or by layer. Membership is exclusive, so adding a layer to a second group moves it out of the first. Group ids are generated, never a list position.

Visibility and solo are operations, not flags. `groupVisibilityIntent` folds the per-layer intent map into all, none, mixed or empty. `soloGroupIntent` partitions the loaded layers, returning null when the group has nothing loaded. `bulkAppearanceIntent` refuses a cross-layer property unless every member shares the project frame.

Every id-emitting function intersects with the live layer set, so a closed scan never reappears. `reconcile` prunes the record and keeps the emptied group.

Model only. No UI and no session persistence.
