### PR TITLE
fix(io): make the 3D Tiles parsers strict at their format boundary

### DIFF
--- a/src/io/tiles3d/pnts.ts
+++ b/src/io/tiles3d/pnts.ts
@@ -12,6 +12,8 @@
 
 const HEADER_BYTES = 28;
 const MAGIC = 0x73746e70; // 'pnts' little-endian
+/** The only PNTS version this decoder claims to read. */
+const SUPPORTED_VERSION = 1;
 
 export interface PntsTile {
   readonly version: number;
@@ -39,17 +41,27 @@ export function parsePnts(buffer: ArrayBuffer): PntsTile {
     throw new Error('PNTS: bad magic — not a pnts tile.');
   }
   const version = view.getUint32(4, true);
+  if (version !== SUPPORTED_VERSION) {
+    throw new Error(`PNTS: version ${version} is not supported, only ${SUPPORTED_VERSION}.`);
+  }
   const byteLength = view.getUint32(8, true);
   if (byteLength > buffer.byteLength) {
     throw new Error('PNTS: declared byteLength exceeds the buffer.');
   }
+  if (byteLength < HEADER_BYTES) {
+    throw new Error('PNTS: declared byteLength is shorter than the header.');
+  }
+  // The DECLARED tile length is the parse boundary, not the buffer. A tile
+  // concatenated with trailing bytes would otherwise let a feature table or a
+  // POSITION range run past its own tile and read whatever followed it.
+  const limit = byteLength;
   const ftJsonLen = view.getUint32(12, true);
   const ftBinLen = view.getUint32(16, true);
 
   const ftJsonStart = HEADER_BYTES;
   const ftBinStart = ftJsonStart + ftJsonLen;
-  if (ftBinStart + ftBinLen > buffer.byteLength) {
-    throw new Error('PNTS: feature table extends past the buffer.');
+  if (ftBinStart + ftBinLen > limit) {
+    throw new Error('PNTS: feature table extends past the declared tile length.');
   }
 
   const ftJsonText = new TextDecoder().decode(new Uint8Array(buffer, ftJsonStart, ftJsonLen));
@@ -65,17 +77,29 @@ export function parsePnts(buffer: ArrayBuffer): PntsTile {
   if (!ft.POSITION || typeof ft.POSITION.byteOffset !== 'number') {
     throw new Error('PNTS: feature table has no float32 POSITION.');
   }
+  // A byteOffset is an index into the feature-table binary, so it is a
+  // non-negative whole number. Fractional or negative values reach DataView
+  // construction and fail there, far from the tile that carried them.
+  if (!Number.isSafeInteger(ft.POSITION.byteOffset) || ft.POSITION.byteOffset < 0) {
+    throw new Error('PNTS: POSITION.byteOffset is not a non-negative whole number.');
+  }
 
   const rtc = ft.RTC_CENTER;
   const rtcCenter: [number, number, number] | null =
-    Array.isArray(rtc) && rtc.length === 3 && rtc.every((n) => typeof n === 'number')
+    Array.isArray(rtc) && rtc.length === 3 && rtc.every((n) => typeof n === 'number' && Number.isFinite(n))
       ? [rtc[0], rtc[1], rtc[2]]
       : null;
 
   const posOffset = ftBinStart + ft.POSITION.byteOffset;
   const need = pointsLength * 3 * 4;
-  if (posOffset + need > buffer.byteLength) {
-    throw new Error('PNTS: POSITION array extends past the buffer.');
+  // Guard the product itself: a POINTS_LENGTH near the safe-integer ceiling
+  // makes `need` lose precision, and the range check below would then compare
+  // an approximation.
+  if (!Number.isSafeInteger(need)) {
+    throw new Error(`PNTS: POINTS_LENGTH ${pointsLength} is too large to address.`);
+  }
+  if (posOffset + need > limit) {
+    throw new Error('PNTS: POSITION array extends past the declared tile length.');
   }
   // Copy (POSITION.byteOffset need not be 4-aligned within the buffer, and a
   // Float32Array view requires alignment).

--- a/src/io/tiles3d/tileset.ts
+++ b/src/io/tiles3d/tileset.ts
@@ -48,17 +48,48 @@ interface RawTile {
   implicitTiling?: unknown;
 }
 
+/** Component counts the spec fixes for each bounding-volume form. */
+const BOUNDING_VOLUME_LENGTH = { box: 12, region: 6, sphere: 4 } as const;
+
 function boundingVolume(raw: Record<string, unknown> | undefined): BoundingVolume {
   if (!raw) throw new Error('3D Tiles: a tile has no boundingVolume.');
-  const num = (v: unknown): number[] | undefined =>
-    Array.isArray(v) && v.every((n) => typeof n === 'number') ? (v as number[]) : undefined;
-  const box = num(raw.box);
-  const region = num(raw.region);
-  const sphere = num(raw.sphere);
+  // Each form has a fixed length and every component must be a real number.
+  // `parseTileset` also accepts an already-parsed object, and an object can
+  // carry NaN where JSON text cannot, so finiteness is checked rather than
+  // assumed from the source.
+  const num = (v: unknown, kind: keyof typeof BOUNDING_VOLUME_LENGTH): number[] | undefined => {
+    if (v === undefined) return undefined;
+    const want = BOUNDING_VOLUME_LENGTH[kind];
+    if (!Array.isArray(v) || v.length !== want) {
+      throw new Error(`3D Tiles: boundingVolume.${kind} must have ${want} components.`);
+    }
+    if (!v.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+      throw new Error(`3D Tiles: boundingVolume.${kind} has a non-finite component.`);
+    }
+    return v as number[];
+  };
+  const box = num(raw.box, 'box');
+  const region = num(raw.region, 'region');
+  const sphere = num(raw.sphere, 'sphere');
   if (!box && !region && !sphere) {
     throw new Error('3D Tiles: boundingVolume must be one of box, region, or sphere.');
   }
+  if (sphere && sphere[3] < 0) {
+    throw new Error('3D Tiles: boundingVolume.sphere has a negative radius.');
+  }
   return { ...(box && { box }), ...(region && { region }), ...(sphere && { sphere }) };
+}
+
+/** A 3D Tiles transform is a column-major 4x4 of real numbers, or absent. */
+function tileTransform(v: unknown): readonly number[] | null {
+  if (v === undefined || v === null) return null;
+  if (!Array.isArray(v) || v.length !== 16) {
+    throw new Error('3D Tiles: a tile transform must have 16 components.');
+  }
+  if (!v.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+    throw new Error('3D Tiles: a tile transform has a non-finite component.');
+  }
+  return v as number[];
 }
 
 function parseTile(raw: RawTile, inheritedRefine: Refine): Tile {
@@ -68,15 +99,28 @@ function parseTile(raw: RawTile, inheritedRefine: Refine): Tile {
   if (typeof raw.geometricError !== 'number' || !Number.isFinite(raw.geometricError)) {
     throw new Error('3D Tiles: a tile has no finite geometricError.');
   }
+  // Geometric error is a distance, so a negative one describes nothing.
+  if (raw.geometricError < 0) {
+    throw new Error(`3D Tiles: a tile has a negative geometricError (${raw.geometricError}).`);
+  }
   const refineRaw = (raw.refine ?? '').toUpperCase();
   const refine: Refine = refineRaw === 'ADD' || refineRaw === 'REPLACE' ? refineRaw : inheritedRefine;
-  const contentUri = raw.content?.uri ?? raw.content?.url ?? null;
+  // TypeScript types content.uri as a string, but the runtime accepts whatever
+  // the document held. A non-string here would flow out as a URI and be fetched.
+  const rawUri = raw.content?.uri ?? raw.content?.url;
+  if (rawUri !== undefined && (typeof rawUri !== 'string' || rawUri.length === 0)) {
+    throw new Error('3D Tiles: a tile content URI is not a non-empty string.');
+  }
+  const contentUri = rawUri ?? null;
+  if (raw.children !== undefined && !Array.isArray(raw.children)) {
+    throw new Error('3D Tiles: a tile children field is not an array.');
+  }
   const children = (raw.children ?? []).map((c) => parseTile(c, refine));
   return {
     boundingVolume: boundingVolume(raw.boundingVolume),
     geometricError: raw.geometricError,
     refine,
-    transform: Array.isArray(raw.transform) ? raw.transform : null,
+    transform: tileTransform(raw.transform),
     contentUri,
     children,
   };
@@ -95,6 +139,9 @@ export function parseTileset(input: string | object): Tileset {
   }
   if (typeof doc.geometricError !== 'number' || !Number.isFinite(doc.geometricError)) {
     throw new Error('3D Tiles: tileset.json has no finite geometricError.');
+  }
+  if (doc.geometricError < 0) {
+    throw new Error(`3D Tiles: tileset.json has a negative geometricError (${doc.geometricError}).`);
   }
   if (!doc.root) throw new Error('3D Tiles: tileset.json has no root tile.');
   // The root must declare its own refine; children inherit it when they omit one.

--- a/tests/tiles3dMalformed.test.ts
+++ b/tests/tiles3dMalformed.test.ts
@@ -1,0 +1,130 @@
+/**
+ * tiles3dMalformed.test.ts — what the 3D Tiles parsers must refuse.
+ *
+ * Neither parser is user-facing in v0.6.6, so nothing routes untrusted bytes
+ * into them yet. That is exactly when a format boundary is cheap to make
+ * strict: `parseTileset` also accepts an already-parsed object, which can carry
+ * NaN where JSON text cannot, and a PNTS tile declares its own length that the
+ * decoder should honour instead of reading to the end of whatever buffer it was
+ * handed. Every case below was accepted before this suite existed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import { parsePnts } from '../src/io/tiles3d/pnts';
+
+const tileset = (over: Record<string, unknown> = {}, rootOver: Record<string, unknown> = {}) => ({
+  asset: { version: '1.0' },
+  geometricError: 100,
+  root: {
+    boundingVolume: { box: [0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 5] },
+    geometricError: 10,
+    refine: 'REPLACE',
+    ...rootOver,
+  },
+  ...over,
+});
+
+describe('tileset.json perimeter', () => {
+  it('accepts the well-formed baseline', () => {
+    expect(parseTileset(tileset()).root.refine).toBe('REPLACE');
+  });
+
+  it('refuses a bounding volume of the wrong length', () => {
+    expect(() => parseTileset(tileset({}, { boundingVolume: { box: [1, 2, 3] } }))).toThrow(/12 components/);
+    expect(() => parseTileset(tileset({}, { boundingVolume: { region: [1, 2, 3] } }))).toThrow(/6 components/);
+    expect(() => parseTileset(tileset({}, { boundingVolume: { sphere: [1, 2, 3, 4, 5] } }))).toThrow(/4 components/);
+  });
+
+  it('refuses a non-finite bounding-volume component', () => {
+    const box = [0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, Number.NaN];
+    expect(() => parseTileset(tileset({}, { boundingVolume: { box } }))).toThrow(/non-finite/);
+  });
+
+  it('refuses a negative sphere radius and a negative geometric error', () => {
+    expect(() => parseTileset(tileset({}, { boundingVolume: { sphere: [0, 0, 0, -1] } }))).toThrow(/negative radius/);
+    expect(() => parseTileset(tileset({}, { geometricError: -1 }))).toThrow(/negative geometricError/);
+    expect(() => parseTileset(tileset({ geometricError: -1 }))).toThrow(/negative geometricError/);
+  });
+
+  it('refuses a transform that is not a 4x4 of real numbers', () => {
+    expect(() => parseTileset(tileset({}, { transform: [1, 2, 3] }))).toThrow(/16 components/);
+    const sixteen = Array.from({ length: 16 }, (_, i) => (i === 15 ? Number.POSITIVE_INFINITY : 0));
+    expect(() => parseTileset(tileset({}, { transform: sixteen }))).toThrow(/non-finite/);
+  });
+
+  it('refuses a content URI that is not a non-empty string', () => {
+    expect(() => parseTileset(tileset({}, { content: { uri: 123 } }))).toThrow(/not a non-empty string/);
+    expect(() => parseTileset(tileset({}, { content: { uri: '' } }))).toThrow(/not a non-empty string/);
+  });
+
+  it('refuses a children field that is not an array', () => {
+    expect(() => parseTileset(tileset({}, { children: { nope: true } }))).toThrow(/not an array/);
+  });
+});
+
+/** Build a PNTS tile. `declaredLength` defaults to the real byte length. */
+function pnts(opts: {
+  version?: number;
+  pointsLength?: number;
+  positionByteOffset?: number;
+  declaredLength?: number;
+  trailing?: number;
+  rtc?: unknown;
+} = {}): ArrayBuffer {
+  const pointsLength = opts.pointsLength ?? 2;
+  const ftJson: Record<string, unknown> = {
+    POINTS_LENGTH: pointsLength,
+    POSITION: { byteOffset: opts.positionByteOffset ?? 0 },
+  };
+  if (opts.rtc !== undefined) ftJson.RTC_CENTER = opts.rtc;
+  let json = JSON.stringify(ftJson);
+  while (json.length % 4 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const binBytes = pointsLength * 3 * 4;
+  const tileBytes = 28 + jsonBytes.length + binBytes;
+  const total = tileBytes + (opts.trailing ?? 0);
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, 0x73746e70, true);
+  view.setUint32(4, opts.version ?? 1, true);
+  // The declared length is the TILE, not the buffer: trailing bytes are
+  // whatever followed it in a concatenated stream.
+  view.setUint32(8, opts.declaredLength ?? tileBytes, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, binBytes, true);
+  new Uint8Array(buf).set(jsonBytes, 28);
+  return buf;
+}
+
+describe('PNTS perimeter', () => {
+  it('accepts the well-formed baseline', () => {
+    expect(parsePnts(pnts()).pointsLength).toBe(2);
+  });
+
+  it('refuses a version it does not claim to read', () => {
+    expect(() => parsePnts(pnts({ version: 2 }))).toThrow(/version 2 is not supported/);
+  });
+
+  it('treats the declared tile length as the boundary, not the buffer', () => {
+    // 64 trailing bytes follow the tile. POSITION starts 4 bytes into the
+    // feature-table binary, so its 24 bytes run 4 past the tile and into them.
+    // The buffer can satisfy that read; the tile cannot.
+    const withTrailing = pnts({ trailing: 64, positionByteOffset: 4 });
+    expect(() => parsePnts(withTrailing)).toThrow(/past the declared tile length/);
+    // Without the trailing bytes the buffer would have refused it anyway, so
+    // the case above is the one that needs the declared length to be enforced.
+    expect(parsePnts(pnts()).pointsLength).toBe(2);
+  });
+
+  it('refuses a fractional or negative POSITION.byteOffset', () => {
+    expect(() => parsePnts(pnts({ positionByteOffset: 1.5 }))).toThrow(/non-negative whole number/);
+    expect(() => parsePnts(pnts({ positionByteOffset: -4 }))).toThrow(/non-negative whole number/);
+  });
+
+  it('ignores a non-finite RTC_CENTER rather than carrying NaN into placement', () => {
+    const tile = parsePnts(pnts({ rtc: [1, 2, Number.NaN] }));
+    expect(tile.rtcCenter).toBeNull();
+    expect(parsePnts(pnts({ rtc: [1, 2, 3] })).rtcCenter).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
Neither parser is user-facing yet, which is when a format boundary is cheapest to make strict.

`tileset.json` accepted a bounding volume of any length with non-finite components, a negative geometric error, a transform that was not a 4x4, a content URI that was not a string, and a children field that was not an array. `parseTileset` also takes an already-parsed object, which can carry `NaN` where JSON text cannot.

PNTS read a version it does not support, checked ranges against the buffer rather than the tile's own declared length, so trailing bytes in a concatenated stream could satisfy a malformed POSITION range, and took `POSITION.byteOffset` without requiring a non-negative whole number.

`tests/tiles3dMalformed.test.ts` covers each case.
