### PR TITLE
test(io): decode a real multi-station E57 and its poses

### DIFF
--- a/docs/validation/claim-register.yaml
+++ b/docs/validation/claim-register.yaml
@@ -210,7 +210,7 @@ claims:
     units: [metres, source-units]
     crsDatum: "The file declares no coordinate metadata; coordinates are read in the file's own local frame."
     assumptions: ["the reference reader implements the same standard independently", "both readers consume the CompressedVector in file order"]
-    failureModes: ["scanner-native writers, not represented by this file", "multi-scan registration and pose composition, which the return-index file does not carry"]
+    failureModes: ["scanner-native writers, not represented by this file", "whether a multi-station pose is CORRECT, since no file here carries independent registration truth"]
     exportAllowed: true
     userLabel: "Cross-implementation validated E57 decode"
     softwareStatus: shipping

--- a/tests/e57DeclaredBounds.test.ts
+++ b/tests/e57DeclaredBounds.test.ts
@@ -190,3 +190,65 @@ withPump3('E57 multiple returns (libE57 pumpARowColumnIndex3ReturnIndex)', () =>
     for (const step of steps) expect(step).toBeCloseTo(0.1, 5);
   });
 });
+
+/**
+ * Multiple registered scans. 50 MB, so read from `OLV_E57_PUMP_MULTI`.
+ *
+ * What this can and cannot say is worth being exact about. The file carries no
+ * independent registration truth, so nothing here shows the poses are RIGHT.
+ * What it shows is that a real vendor multi-station file decodes: five scans,
+ * four carrying a pose, every quaternion already a unit quaternion needing no
+ * repair, and the composition arithmetic reversible. `e57Pose.test.ts` covers
+ * the repair policy on synthetic quaternions; this covers a real one.
+ *
+ * Each scan is stored in its own scanner-centred frame, which is why the raw
+ * centroids all sit near the origin and applying the poses moves them apart
+ * rather than together. Station spread is not misalignment.
+ */
+const PUMP_MULTI = process.env.OLV_E57_PUMP_MULTI ?? '';
+const withMulti = PUMP_MULTI && existsSync(PUMP_MULTI) ? describe : describe.skip;
+
+withMulti('E57 multiple registered scans (libE57 Pump)', () => {
+  it('reads every station and its pose without needing to repair one', () => {
+    const r = parseE57(bufferOf(PUMP_MULTI));
+    expect(r.scans).toHaveLength(5);
+    const posed = r.scans.filter((s) => s.pose !== null);
+    expect(posed.length, 'stations carrying a pose').toBe(4);
+    for (const s of posed) {
+      // readPose normalises a non-unit quaternion and warns. A real writer's
+      // file should give it nothing to do.
+      expect(Math.hypot(...s.pose!.rotation), `${s.name} rotation is a unit quaternion`).toBeCloseTo(1, 9);
+      expect(s.pose!.translation).toHaveLength(3);
+      for (const t of s.pose!.translation) expect(Number.isFinite(t)).toBe(true);
+    }
+    const warnings = (r as unknown as { warnings?: unknown[] }).warnings ?? [];
+    expect(warnings, 'no pose repair was needed').toEqual([]);
+  }, 180_000);
+
+  it('composes a pose reversibly, so the transform is a rigid motion', () => {
+    const r = parseE57(bufferOf(PUMP_MULTI));
+    const s = r.scans.find((x) => x.pose !== null)!;
+    const [w, x, y, z] = s.pose!.rotation;
+    const t = s.pose!.translation;
+    const rotate = (q: readonly number[], v: readonly number[]): [number, number, number] => {
+      const [qw, qx, qy, qz] = q;
+      const tx = 2 * (qy * v[2] - qz * v[1]);
+      const ty = 2 * (qz * v[0] - qx * v[2]);
+      const tz = 2 * (qx * v[1] - qy * v[0]);
+      return [
+        v[0] + qw * tx + (qy * tz - qz * ty),
+        v[1] + qw * ty + (qz * tx - qx * tz),
+        v[2] + qw * tz + (qx * ty - qy * tx),
+      ];
+    };
+    const c = s.columns;
+    const step = Math.max(1, Math.floor(s.recordCount / 500));
+    for (let i = 0; i < s.recordCount; i += step) {
+      const p = [c.cartesianX[i], c.cartesianY[i], c.cartesianZ[i]] as const;
+      const fwd = rotate([w, x, y, z], p).map((v, k) => v + t[k]);
+      // The conjugate undoes the rotation; a rigid motion loses nothing.
+      const back = rotate([w, -x, -y, -z], fwd.map((v, k) => v - t[k]));
+      for (let k = 0; k < 3; k++) expect(back[k]).toBeCloseTo(p[k], 6);
+    }
+  }, 180_000);
+});

--- a/validation/datasets/dataset-register.yaml
+++ b/validation/datasets/dataset-register.yaml
@@ -955,6 +955,39 @@ datasets:
     controlPointIds: []
     checkpointIds: []
 
+  - datasetId: OLV-DS-043-LIBE57-PUMP-MULTISCAN
+    title: "libE57 Pump, five registered stations each carrying a pose"
+    sourceUrl: http://libe57.org/data.html
+    landingPage: http://libe57.org/data.html
+    licence: libE57-test-data
+    licenceUrl: http://libe57.org/data.html
+    redistribution: permitted
+    acquisitionDate: 2026-08-20
+    sourceSha256: 5b582e9247979a29ac7cccb6afa942e632d84f91867130f094fa488629e3c124
+    sourceBytes: 52496384
+    format: e57
+    pointCount: 2879
+    sensorType: tls
+    capturePlatform: tripod
+    captureDate: unknown
+    horizontalCrs: local-metric-grid
+    verticalCrs: local-metric-grid
+    horizontalUnits: metre
+    verticalUnits: metre
+    nominalDensity: not-recorded
+    terrainClasses: [not-applicable]
+    landCoverClasses: [not-applicable]
+    containsIndependentCheckpoints: false
+    checkpointSource: not-applicable
+    checkpointUseRestriction: not-applicable
+    dataOwner: "Carnahan-Proctor and Cross, Inc. (copyright 2008), published by the libE57 project"
+    citation: "libE57 E57 Example/Test Data, Pump.e57. http://libe57.org/data.html"
+    knownLimitations: "Carries no independent registration truth, so it fixes decode behaviour for multi-station poses and says nothing about whether those poses are correct. Each scan is stored in its own scanner-centred frame. Not vendored at 50 MB; read from OLV_E57_PUMP_MULTI."
+    storage: acquired
+    localPath: not-vendored
+    controlPointIds: []
+    checkpointIds: []
+
   # ── Committed section-profile set (MEAS-PROFILE corridor cross-check) ──────
   - datasetId: OLV-DS-023-ANALYTIC-PROFILE-RAMP
     title: "Analytic corridor transect, 257 stations at 1 m with a cross-line elevation ramp"


### PR DESCRIPTION
`e57Pose.test.ts` covers the quaternion repair policy on synthetic values. Nothing exercised a real vendor file with registered stations.

The libE57 Pump carries five scans, four with a pose. Every quaternion is already a unit quaternion, so `readPose` has nothing to repair and emits no warning, and the composition arithmetic round-trips through the conjugate.

The file carries no independent registration truth, so nothing here shows the poses are correct. The claim's failure mode now says that instead of saying multi-scan is untested. Each scan sits in its own scanner-centred frame, so applying the poses moves the stations apart rather than together.

50 MB, read from `OLV_E57_PUMP_MULTI`, registered as OLV-DS-043.
