### PR TITLE
test(io): read an E57 carrying an unknown vendor extension

### DIFF
--- a/docs/validation/claim-register.yaml
+++ b/docs/validation/claim-register.yaml
@@ -224,8 +224,9 @@ claims:
         - "Intensity, excluded because PDAL scales it by 65535/(max-min) without subtracting the minimum, so a tolerance would measure that transform rather than either reader."
         - "Any writer other than the one that produced this file (CloudCompare 2.12.4 via E57Format 2.3.0). One file is one profile, not the format."
         - "Scanner-native acquisition metadata. This file is a re-export and carries no sensor vendor, model, serial or acquisition time."
-      - "Multi-scan registration. The libE57 return-index file is one structured scan, so pose composition across stations stays untested."
-        - "Scaled-integer cartesian encodings, where the declared per-field limits ARE decode parameters."
+        - "Whether a multi-station pose is CORRECT. The libE57 Pump decodes five registered stations and every quaternion is already a unit quaternion, but the file carries no independent registration truth."
+        - "Spherical coordinate storage, which none of the files held here uses."
+        - "Extension SEMANTICS. An unknown vendor namespace is carried through with its prefix intact and refused nothing (libE57 openpitmine, Riegl rlms), but no meaning is assigned to an extension field."
 
   - claimId: MEAS-HEIGHT
     product: Height / vertical measurement

--- a/tests/e57DeclaredBounds.test.ts
+++ b/tests/e57DeclaredBounds.test.ts
@@ -252,3 +252,68 @@ withMulti('E57 multiple registered scans (libE57 Pump)', () => {
     }
   }, 180_000);
 });
+
+/**
+ * An unknown vendor extension. 587 MB, so read from `OLV_E57_OPENPITMINE`.
+ *
+ * The corpus publishes this file so readers can show they cope with data they
+ * were never told about: it declares the Riegl `rlms` namespace and carries
+ * two fields inside it. The failure this guards against is a reader that
+ * treats an unrecognised prefix as corruption and refuses the file, or worse,
+ * reads the extension columns as if they were part of the standard prototype
+ * and shifts every subsequent field.
+ *
+ * OLV keeps the prefix on the column name rather than dropping or flattening
+ * it, so an extension field stays distinguishable from a standard one.
+ */
+const OPENPIT = process.env.OLV_E57_OPENPITMINE ?? '';
+const withExtension = OPENPIT && existsSync(OPENPIT) ? describe : describe.skip;
+
+withExtension('E57 unknown vendor extension (libE57 openpitmine, Riegl rlms)', () => {
+  it('reads the file, keeps the extension namespaced, and does not warn', () => {
+    const r = parseE57(bufferOf(OPENPIT));
+    expect(r.scans.length, 'every station decodes').toBeGreaterThan(1);
+    const s = r.scans[0];
+    const columns = Object.keys(s.columns);
+
+    // The standard prototype survives alongside the extension.
+    for (const need of ['cartesianX', 'cartesianY', 'cartesianZ']) {
+      expect(columns, `${need} still present`).toContain(need);
+    }
+    // The extension fields keep their prefix, so nothing mistakes them for
+    // standard attributes.
+    const extension = columns.filter((c) => c.startsWith('rlms:'));
+    expect(extension.length, 'rlms fields are carried, not dropped').toBeGreaterThan(0);
+    for (const c of extension) expect(c).toMatch(/^rlms:[a-zA-Z]+$/);
+
+    // An unknown extension is not a defect, so it must not raise one.
+    const warnings = (r as unknown as { warnings?: unknown[] }).warnings ?? [];
+    expect(warnings, 'an unrecognised namespace is not a warning').toEqual([]);
+  }, 300_000);
+
+  it('decodes coordinates that did not shift by an extension field width', () => {
+    // Reading the rlms columns as part of the standard prototype would slide
+    // every later field along the record and put coordinates somewhere else
+    // entirely. The declared extent catches that.
+    const buf = bufferOf(OPENPIT);
+    const declared = declaredExtent(buf);
+    const s = parseE57(buf).scans[0];
+    if (declared) {
+      for (const [axis, col] of [
+        ['x', s.columns.cartesianX],
+        ['y', s.columns.cartesianY],
+        ['z', s.columns.cartesianZ],
+      ] as const) {
+        const [lo, hi] = extent(col);
+        expect(lo, `${axis} minimum vs ${declared.source}`).toBeGreaterThanOrEqual(declared[axis][0] - 1e-3);
+        expect(hi, `${axis} maximum vs ${declared.source}`).toBeLessThanOrEqual(declared[axis][1] + 1e-3);
+      }
+    }
+    // Whether or not the file declares an extent, the values must be real.
+    let nonFinite = 0;
+    for (let i = 0; i < s.recordCount; i += 997) {
+      if (!Number.isFinite(s.columns.cartesianX[i])) nonFinite++;
+    }
+    expect(nonFinite, 'sampled coordinates are finite').toBe(0);
+  }, 300_000);
+});

--- a/validation/datasets/dataset-register.yaml
+++ b/validation/datasets/dataset-register.yaml
@@ -988,6 +988,39 @@ datasets:
     controlPointIds: []
     checkpointIds: []
 
+  - datasetId: OLV-DS-044-LIBE57-OPENPITMINE-RLMS
+    title: "libE57 openpitmine, multi-station Riegl scan carrying the rlms vendor extension"
+    sourceUrl: http://libe57.org/data.html
+    landingPage: http://libe57.org/data.html
+    licence: libE57-test-data
+    licenceUrl: http://libe57.org/data.html
+    redistribution: permitted
+    acquisitionDate: 2026-08-20
+    sourceSha256: 4b0e3ce2398d958ac9bbc0e94ded34472d785cf3797be61101960aa1f3014b55
+    sourceBytes: 616108032
+    format: e57
+    pointCount: 4438419
+    sensorType: tls
+    capturePlatform: tripod
+    captureDate: 2011-06-13
+    horizontalCrs: local-metric-grid
+    verticalCrs: local-metric-grid
+    horizontalUnits: metre
+    verticalUnits: metre
+    nominalDensity: not-recorded
+    terrainClasses: [open-pit-mine]
+    landCoverClasses: [bare-rock]
+    containsIndependentCheckpoints: false
+    checkpointSource: not-applicable
+    checkpointUseRestriction: not-applicable
+    dataOwner: "Riegl LMS GmbH (copyright 2011), published by the libE57 project"
+    citation: "libE57 E57 Example/Test Data, openpitmine.e57. http://libe57.org/data.html"
+    knownLimitations: "Held for its declared rlms extension namespace and its station count, not for terrain accuracy: it carries no survey control and no independent registration truth. The pointCount recorded is the first station only. Not vendored at 587 MB; read from OLV_E57_OPENPITMINE."
+    storage: acquired
+    localPath: not-vendored
+    controlPointIds: []
+    checkpointIds: []
+
   # ── Committed section-profile set (MEAS-PROFILE corridor cross-check) ──────
   - datasetId: OLV-DS-023-ANALYTIC-PROFILE-RAMP
     title: "Analytic corridor transect, 257 stations at 1 m with a cross-line elevation ramp"


### PR DESCRIPTION
The corpus publishes `openpitmine` so readers can show they cope with data they were never told about: it declares the Riegl `rlms` namespace and carries two fields inside it, across ten posed stations.

OLV keeps the prefix on the column name, so `rlms:amplitude` and `rlms:reflectance` stay distinguishable from standard attributes, the standard prototype survives alongside them, and an unrecognised namespace raises no warning. The second check guards the failure that would matter: reading extension columns as part of the standard prototype slides every later field along the record.

The claim's unsupported list said multi-scan and scaled-integer encodings were untested. Both are covered now, so it names what is actually untested instead. One entry was also indented two spaces short of its siblings.

587 MB, read from `OLV_E57_OPENPITMINE`, registered as OLV-DS-044.
