### PR TITLE
Name the basis each coverage figure is measured against

### DIFF
--- a/docs/releases/RELEASE_NOTES_v0.6.6.md
+++ b/docs/releases/RELEASE_NOTES_v0.6.6.md
@@ -22,7 +22,10 @@ OpenLiDARViewer remains browser-native and local-first: local files stay on the 
 - the EPT and 3D Tiles parsers are strict at their format boundary rather than failing open, and the declared-bounds oracle reads the file's pages instead of raw bytes;
 - pointer lock delivered every mouse event to the canvas, so the navigation dock stopped receiving clicks and no mode could be reached with the mouse once walk or fly began; a click while locked now returns the cursor;
 - the live probe ran a pick across every point of every visible cloud on each pointer-move frame in walk and fly, and during both custom drags, because only an OrbitControls drag sets the flag its gate reads;
-- provenance reads the file's own declarations ahead of a density guess, and the phone-LiDAR density band is bounded above, so a tripod station carrying dense returns is not reported as a phone.
+- provenance reads the file's own declarations ahead of a density guess, and the phone-LiDAR density band is bounded above, so a tripod station carrying dense returns is not reported as a phone;
+- the terrain report printed one figure as "43% of the surface is interpolated" and another as "Interpolated 37%" for the same run. Both are right and they answer different questions, one over the covered surface and one over the whole grid, so the table now carries both and names the basis of each. The map sheet already did this for its own figure, "63% interpolated (by length)";
+- "Ground visibility" labelled a categorical bucket in one section of the terrain report and the classifier's ground share of all returns in another, printing a dash for one and a percentage for the other. The second reads "Ground returns (of all returns)";
+- the map sheet stamps the contour style from the export's provenance, and without provenance it fell back to the style the view holds now, which need not be the style that geometry was produced with. One sheet read Generalized while the terrain report for the same run recorded Smooth. The fallback says where its value came from.
 
 ## Section profile corrections
 

--- a/docs/releases/RELEASE_NOTES_v0.6.6.md
+++ b/docs/releases/RELEASE_NOTES_v0.6.6.md
@@ -1,10 +1,10 @@
 # OpenLiDARViewer v0.6.6
 
-v0.6.6 is a feature and evidence release. Twelve products now carry independent cross-implementation evidence against v0.6.5's five, and the E57 reader is checked point for point against PDAL. The seven added are `E57-INGEST`, `MEAS-PROFILE`, `DSM`, `DTM`, `CHM`, `TPI` and `VRM`. Around that, the workspace gained a Work mode for the scene-work tools and an Output panel that consolidates exports. Layer groups arrived in the Layers panel, annotations gained an inspection issue workflow, and one Speed to Quality control now covers display and streaming. A long run of unit-correctness fixes runs underneath all of it, and those are listed first because several of them changed reported numbers.
+v0.6.6 is a feature and evidence release with a substantial correctness pass underneath. Twelve registered claims now carry E4 cross-implementation evidence, against v0.6.5's five. The seven added are `E57-INGEST`, `MEAS-PROFILE`, `DSM`, `DTM`, `CHM`, `TPI` and `VRM`. On the public E57 validation scan, cartesian coordinates, surface normals and colour are checked point for point against PDAL; intensity is outside that comparison. Around that, the workspace gained a Work mode for the scene-work tools and an Output panel that consolidates exports. Layer groups arrived in the Layers panel, annotations gained an inspection issue workflow, and one Speed to Quality control now covers display and streaming. A long run of unit-correctness fixes runs underneath all of it, and those are listed first because several of them changed reported numbers.
 
 OpenLiDARViewer remains browser-native and local-first: local files stay on the user's device, and no account is required.
 
-## Corrected calculations and declarations
+## Corrected calculations and behaviour
 
 - the USGS 3DEP Quality Level table read a QL3 density floor of 0.25 pts/m² where the published floor is 0.5, so a survey between the two was awarded QL3 at half the required density; the other three levels were already correct, and datasets in that band now read below-QL3;
 - WKT2 `LENGTHUNIT` is parsed for linear and vertical units;
@@ -21,8 +21,9 @@ OpenLiDARViewer remains browser-native and local-first: local files stay on the 
 - an unsupported E57 major version is refused, and every section offset is bounded by the declared physical length;
 - the EPT and 3D Tiles parsers are strict at their format boundary rather than failing open, and the declared-bounds oracle reads the file's pages instead of raw bytes;
 - pointer lock delivered every mouse event to the canvas, so the navigation dock stopped receiving clicks and no mode could be reached with the mouse once walk or fly began; a click while locked now returns the cursor;
-- the live probe ran a pick across every point of every visible cloud on each pointer-move frame in walk and fly, and during both custom drags, because only an OrbitControls drag sets the flag its gate reads;
+- the live probe ran a pick across every point of every visible cloud on each pointer-move frame in walk and fly, and during both custom drags, because only an OrbitControls drag set the flag its gate reads. NavController now reports every way the camera is being driven, so the gate suspends the pick through all four;
 - provenance reads the file's own declarations ahead of a density guess, and the phone-LiDAR density band is bounded above, so a tripod station carrying dense returns is not reported as a phone;
+- every deployed terrain analysis ended by reloading the page. Five `import()` calls sat in modules the live source transform rewrites, so their specifiers became string-array lookups, their chunks were never emitted, and the browser fetched `/model/DerivedLayer` and got a 404. Vite raised `vite:preloadError`, the stale-chunk handler treated it as a swept-away deploy and reloaded, and a finished run looked like a crash back to the start screen. The five are routed through the module the transform excludes, and the release lint that guards this now parses every transformed module rather than matching lines in one file, so a relative runtime dynamic import cannot reach a deployed build again;
 - the terrain report printed one figure as "43% of the surface is interpolated" and another as "Interpolated 37%" for the same run. Both are right and they answer different questions, one over the covered surface and one over the whole grid, so the table now carries both and names the basis of each. The map sheet already did this for its own figure, "63% interpolated (by length)";
 - "Ground visibility" labelled a categorical bucket in one section of the terrain report and the classifier's ground share of all returns in another, printing a dash for one and a percentage for the other. The second reads "Ground returns (of all returns)";
 - the map sheet stamps the contour style from the export's provenance, and without provenance it fell back to the style the view holds now, which need not be the style that geometry was produced with. One sheet read Generalized while the terrain report for the same run recorded Smooth. The fallback says where its value came from.
@@ -55,16 +56,21 @@ The performance control is display and streaming only. It drives the streaming p
 ## Reading more data
 
 - Krovák (EPSG:5514) ingest and iPhone PDRF7 reading;
-- footprint reprojection for any proj4-defined projected CRS rather than UTM alone;
-- parsers for 3D Tiles `tileset.json` and PNTS;
-- a local out-of-core read planner, and a cross-CRS project placement planner;
-- tie-point rigid registration with control-network validation, and a single planar ICP solver the registration model now selects directly instead of refusing the planar case.
+- footprint reprojection for any proj4-defined projected CRS rather than UTM alone.
 
 The Krovák definition uses a seven-parameter Bursa-Wolf shift. It agrees with authoritative PROJ to about 5 cm on the surveyed reference points, where the naive three-parameter shift is roughly 10 m out.
 
+### Foundations added for a later release, not reachable in v0.6.6
+
+Each of these is implemented and tested, and nothing in the running application passes through it. They are listed so the source is not mistaken for dead code, and they are not features of this release.
+
+- parsers for 3D Tiles `tileset.json` and PNTS;
+- a local out-of-core read planner, and a cross-CRS project placement planner;
+- tie-point rigid registration with control-network validation, and a single planar ICP solver the registration model selects directly instead of refusing the planar case.
+
 ## Also in this release
 
-Several items below are foundations: implemented and tested, but not yet reached by the normal loading or analysis routes. They are `ProductExecutorRegistry`, the feature-extraction service, the 3D Tiles and PNTS parsers, the out-of-core read planner, the cross-CRS placement planner, and the registration model. Nothing in the running application passes through them in this release, so treat them as groundwork rather than as behaviour you can exercise.
+Two more foundations appear below, alongside those listed under Reading more data: `ProductExecutorRegistry` and the feature-extraction service. Nothing in the running application passes through either, so treat them as groundwork rather than as behaviour you can exercise.
 
 - a project-wide elevation colour scale, opt-in, applied per frame, so two scans in one project can share a range instead of each stretching its own;
 - classifier v3: a structural-verticality cue and a wall-rescue pass;
@@ -81,7 +87,7 @@ The DSM (top surface, max return per cell) and the DTM (bare-earth grid, min ret
 
 The canopy height model (`CHM`) is promoted alongside them. CHM is DSM minus DTM, clamped at zero, and with both parents at E4 it was compared against the PDAL max grid minus the PDAL min grid on the same structure clouds, agreeing over 7,500 cells to a maximum difference under 8×10⁻⁶ m, within a 0.1 m registered tolerance (study `CHM-PDAL-WRITERS-GDAL-DIFFERENCE`, test `tests/chmCrossCheck.test.ts`).
 
-Twelve products are now at E4: `SLOPE-RASTER`, `ASPECT-RASTER`, `HILLSHADE`, `CONTOURS` and `MEAS-AREA` against GDAL, `DSM`, `DTM` and `CHM` against PDAL, the terrain descriptors `TPI` (against gdaldem 3.13.1) and `VRM` (against SAGA 7.8.2), each also checked against the closed form on a controlled analytic fixture, and two more promoted in this release.
+Twelve registered claims are now at E4: `SLOPE-RASTER`, `ASPECT-RASTER`, `HILLSHADE`, `CONTOURS` and `MEAS-AREA` against GDAL, `DSM`, `DTM` and `CHM` against PDAL, the terrain descriptors `TPI` (against gdaldem 3.13.1) and `VRM` (against SAGA 7.8.2), each also checked against the closed form on a controlled analytic fixture, and two more promoted in this release.
 
 `MEAS-PROFILE`, the corridor section profile, reaches its required level. No single tool exposes a corridor percentile over a point cloud, so the reference is assembled from two: OGR/SpatiaLite 5.1.0 places every point on the section line and R 4.4.1 `quantile(type = 7)` reduces each station. Over 751 stations the largest difference is 3.6e-15 m, against a 1e-6 m tolerance registered before the reference existed. Per-station corridor counts match exactly, and the four deliberately empty stations read as gaps on both sides. Both fixtures are synthetic and hold every point clear of a bin boundary and of the corridor edge, so the tie-breaking there is untested and none of this is accuracy against a surveyed section.
 
@@ -119,7 +125,7 @@ The complete list is in `KNOWN_LIMITATIONS_v0.6.6.md`. It carries the v0.6.5 lim
 
 ## Compatibility
 
-Unchanged from v0.6.5. Modern Chromium browsers use WebGPU, with WebGL 2 fallback in Firefox and Safari, and existing sessions remain compatible. Session files are unaffected: a session saved before this release loads with generalization in its uniform default.
+Unchanged from v0.6.5. Modern Chromium browsers prefer WebGPU where the platform and adapter provide it and fall back to WebGL 2 otherwise; Firefox and Safari take the WebGL 2 path. Existing sessions remain compatible. Session files are unaffected: a session saved before this release loads with generalization in its uniform default.
 
 ## Verifying this release
 

--- a/docs/validation/test-evidence.json
+++ b/docs/validation/test-evidence.json
@@ -5,9 +5,9 @@
   "releaseChannel": "development",
   "releaseAuthoritative": false,
   "tag": null,
-  "commit": "3dcfbbb8c94b6dfea0bf96439cd1b05987faedfd",
+  "commit": "4126af8ec4674b955ba3eee7760e8af57ef2f1ae",
   "repository": null,
-  "generatedAt": "2026-08-22T06:07:51.998Z",
+  "generatedAt": "2026-08-22T07:14:05.949Z",
   "nodeVersion": "v26.0.0",
   "npmVersion": "11.12.1",
   "platform": "darwin-arm64",
@@ -17,7 +17,7 @@
   "workflowSha": null,
   "gateExit": 0,
   "gateLog": "release/gate.log",
-  "gateLogSha256": "61dcfd06908ff42b2152a55deb883cc7f0bbd7420e336e6f5af67faf056b8083",
+  "gateLogSha256": "04867c0e393d2bb29bf35a91082e7e065e466b17d0a36c7341fda7b5c9a40924",
   "stages": {
     "mutation": "not-executed"
   },

--- a/docs/validation/test-evidence.json
+++ b/docs/validation/test-evidence.json
@@ -5,9 +5,9 @@
   "releaseChannel": "development",
   "releaseAuthoritative": false,
   "tag": null,
-  "commit": "7e3e1132991218a3c43290a07f62f8927611c7d8",
+  "commit": "3dcfbbb8c94b6dfea0bf96439cd1b05987faedfd",
   "repository": null,
-  "generatedAt": "2026-08-22T03:16:34.603Z",
+  "generatedAt": "2026-08-22T06:07:51.998Z",
   "nodeVersion": "v26.0.0",
   "npmVersion": "11.12.1",
   "platform": "darwin-arm64",
@@ -17,7 +17,7 @@
   "workflowSha": null,
   "gateExit": 0,
   "gateLog": "release/gate.log",
-  "gateLogSha256": "06b2a2751ae1c9fceb51e3326c8cd4a88e5fd6fa101756b3c7708b5b075ed88f",
+  "gateLogSha256": "61dcfd06908ff42b2152a55deb883cc7f0bbd7420e336e6f5af67faf056b8083",
   "stages": {
     "mutation": "not-executed"
   },
@@ -62,7 +62,7 @@
       "runs": 1
     },
     "terrain": {
-      "passed": 1750,
+      "passed": 1753,
       "skipped": 0,
       "runs": 2
     },
@@ -78,7 +78,7 @@
     }
   },
   "total": {
-    "passed": 10758,
+    "passed": 10761,
     "skipped": 35
   },
   "bundle": {

--- a/src/render/measure/mapSheetPdf.ts
+++ b/src/render/measure/mapSheetPdf.ts
@@ -1065,9 +1065,16 @@ function drawTitleBlock(
     ? `${Math.round(interpFraction * 100)}% interpolated (by length)`
     : 'Interpolated fraction — not measured (no contours)';
   text(interpLine, mxx, topY - 88, 6.5, font, DIM);
-  // Honest stamp of the shape style applied to the plotted contours (sourced
-  // from the unified provenance when present, so it matches every other export).
-  const styleLabel = prov ? prov.contourStyleLabel : contourShapeStyleLabel(input.model.contourStyle);
+  // Honest stamp of the shape style applied to the plotted contours, sourced
+  // from the unified provenance so it matches every other export of the same
+  // run. Without provenance the only style available is the one the view holds
+  // now, which is not necessarily the one this geometry was produced with: a
+  // sheet plotting cartographic contours read "Generalized" while the terrain
+  // report for the same run recorded "Smooth". The fallback therefore says
+  // where its value came from rather than presenting it as the recorded style.
+  const styleLabel = prov
+    ? prov.contourStyleLabel
+    : `${contourShapeStyleLabel(input.model.contourStyle)} (current view, not recorded)`;
   text(`Contour style: ${styleLabel}`, mxx, topY - 99, 6.5, font, DIM);
 
   // Right column — accuracy + readiness + provenance.

--- a/src/terrain/export/terrainReportContent.ts
+++ b/src/terrain/export/terrainReportContent.ts
@@ -302,12 +302,25 @@ export function buildTerrainReportContent(
     title: 'Coverage Analysis',
     rows: [
       { label: 'Coverage mode', value: provenance.coverageMode },
-      { label: 'Measured', value: fmtPct(q?.measuredCellRatio) },
-      { label: 'Interpolated', value: fmtPct(q?.interpolatedCellRatio) },
-      { label: 'Empty', value: fmtPct(q?.emptyCellRatio) },
+      // These three are shares of the WHOLE grid and sum to 100%. The verdict
+      // and the gate reasons quote interpolatedOfSurfaceRatio instead, which
+      // excludes empty cells, so both bases appear here and each says which one
+      // it is. dtmQualityGate documents that the two are not interchangeable,
+      // and a reader comparing an unlabelled 37% against an unlabelled 43%
+      // cannot tell that they are different questions.
+      { label: 'Measured (of grid)', value: fmtPct(q?.measuredCellRatio) },
+      { label: 'Interpolated (of grid)', value: fmtPct(q?.interpolatedCellRatio) },
+      { label: 'Empty (of grid)', value: fmtPct(q?.emptyCellRatio) },
+      {
+        label: 'Interpolated (of measured surface)',
+        value: fmtPct(q?.interpolatedOfSurfaceRatio),
+      },
       { label: 'Edge risk', value: fmtPct(q?.edgeRiskRatio) },
       {
-        label: 'Ground visibility',
+        // Not the same quantity as the "Ground visibility" bucket in Dataset
+        // Statistics, which is a categorical read. This is the classifier's
+        // ground share of all returns.
+        label: 'Ground returns (of all returns)',
         value: fmtPct(q?.groundPointRatio),
       },
       {

--- a/tests/terrainReportContent.test.ts
+++ b/tests/terrainReportContent.test.ts
@@ -483,10 +483,12 @@ describe('buildTerrainReportContent — §19 permit stamp in provenance', () => 
       buildTerrainReportContent(r, OPTS).sections.find((s) => s.title === 'Coverage Analysis');
 
     it('separates the grid share from the covered-surface share', () => {
-      const r = readyResult();
+      const base = readyResult();
       // Distinct on purpose: with empty cells present the two never agree.
-      r.quality.interpolatedCellRatio = 0.37;
-      r.quality.interpolatedOfSurfaceRatio = 0.43;
+      const r = {
+        ...base,
+        quality: { ...base.quality, interpolatedCellRatio: 0.37, interpolatedOfSurfaceRatio: 0.43 },
+      } as ReturnType<typeof readyResult>;
       const rows = coverage(r)?.rows ?? [];
       const label = (l: string) => rows.find((x) => x.label === l)?.value;
       expect(label('Interpolated (of grid)')).toBe('37%');

--- a/tests/terrainReportContent.test.ts
+++ b/tests/terrainReportContent.test.ts
@@ -467,4 +467,47 @@ describe('buildTerrainReportContent — §19 permit stamp in provenance', () => 
     expect(c.provenance.exportPermit).toBeNull();
     expect(c.provenanceLines.some((l) => /Export permit/.test(l))).toBe(false);
   });
+
+  /**
+   * Reported from a real 151M-point survey: the verdict said 43% of the surface
+   * was interpolated while the Coverage table said 37%, and both said only
+   * "interpolated". The two are different questions, one over the whole grid
+   * and one over the covered surface, and dtmQualityGate documents that they
+   * are not interchangeable. A reader could not reconcile the numbers because
+   * neither carried its basis. The same report used one label, "Ground
+   * visibility", for a categorical bucket and for the classifier's ground
+   * share, printing "-" for one and a percentage for the other.
+   */
+  describe('coverage figures name the basis they are measured against', () => {
+    const coverage = (r: ReturnType<typeof readyResult>) =>
+      buildTerrainReportContent(r, OPTS).sections.find((s) => s.title === 'Coverage Analysis');
+
+    it('separates the grid share from the covered-surface share', () => {
+      const r = readyResult();
+      // Distinct on purpose: with empty cells present the two never agree.
+      r.quality.interpolatedCellRatio = 0.37;
+      r.quality.interpolatedOfSurfaceRatio = 0.43;
+      const rows = coverage(r)?.rows ?? [];
+      const label = (l: string) => rows.find((x) => x.label === l)?.value;
+      expect(label('Interpolated (of grid)')).toBe('37%');
+      expect(label('Interpolated (of measured surface)')).toBe('43%');
+      // No bare "Interpolated" survives, which is what made the two look like
+      // one contradictory figure.
+      expect(rows.some((x) => x.label === 'Interpolated')).toBe(false);
+    });
+
+    it('states the basis of every share that sums over the grid', () => {
+      const rows = coverage(readyResult())?.rows ?? [];
+      for (const l of ['Measured (of grid)', 'Empty (of grid)']) {
+        expect(rows.some((x) => x.label === l)).toBe(true);
+      }
+    });
+
+    it('does not reuse the Ground visibility label for the ground return share', () => {
+      const c = buildTerrainReportContent(readyResult(), OPTS);
+      const cov = c.sections.find((s) => s.title === 'Coverage Analysis');
+      expect(cov?.rows.some((x) => x.label === 'Ground returns (of all returns)')).toBe(true);
+      expect(cov?.rows.some((x) => x.label === 'Ground visibility')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Testing a 151M-point survey against the v0.6.6 candidate turned up three label
defects in the exported terrain deliverables. Every figure was correct; the
labels made two of them unreadable.

The report printed "43% of the surface is interpolated" in the verdict and
"Interpolated 37%" in the table for the same run. Both are right and they answer
different questions, one over the covered surface and one over the whole grid.
`dtmQualityGate` documents that the two are not interchangeable. The table now
carries both and names the basis of each, matching the map sheet's existing
"63% interpolated (by length)".

"Ground visibility" labelled a categorical bucket in one section and the
classifier's ground share in another. The map's contour-style stamp fell back to
the style the view holds when an export carried no provenance.
