### PR TITLE
Read one capture-type verdict on every surface

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -142,8 +142,12 @@ delegates that bind its running state to the deps.
 
 Done: `generateReportPdf` / `exportGeoContext` (~402 lines) — the report / geo-context
 export orchestration — now live in `src/app/reportExport.ts`, driven through a
-`ReportExportDeps` object of accessor functions closing over the shell's services,
-its resolved CRS and its mutable scan verdict rather than the Viewer class. The
+`ReportExportDeps` object of accessor functions closing over the shell's services
+and its resolved CRS rather than the Viewer class. The capture-type fingerprint
+comes from `src/diagnostics/captureProvenance.ts`, the one store the Inspector
+card, the report PDF and the image exports all read, so the three surfaces cannot
+state different capture types for the same scan; it also carries the user's
+capture-type override into the deliverables. The
 report engine (which pulls pdf-lib) is passed as a lazy loader so the module stays
 free of the boot graph. The pure decisions the extraction exposes are Node-tested —
 `effectiveCrsName` (the CRS-label honesty rule: only a projected / geographic CRS
@@ -151,7 +155,8 @@ names the export frame, so a post-override label can't confidently place an expo
 in the CRS the user rejected), `reportPointCount` (the file-scale honesty rule the
 PDF's Point Count follows, the same declared-total-over-strided-subset rule as the
 Layers chip's `layerChipCount`) and `isNonTerrainVerdict` (the capture-lens
-predicate that rules out an aerial density guess for a compact object / interior),
+predicate that rules out an aerial density guess for a compact object / interior,
+re-exported from `src/diagnostics/captureProvenance.ts`),
 alongside `exportGeoContext`'s static → streaming → zero frame resolution
 (`tests/reportExport.test.ts`). `main.ts` keeps thin `generateReportPdf` /
 `exportGeoContext` delegates that bind its running state to the deps.

--- a/docs/validation/test-evidence.json
+++ b/docs/validation/test-evidence.json
@@ -5,9 +5,9 @@
   "releaseChannel": "development",
   "releaseAuthoritative": false,
   "tag": null,
-  "commit": "4126af8ec4674b955ba3eee7760e8af57ef2f1ae",
+  "commit": "45c4e383de4633fb1468b9e64fa4a3173868c351",
   "repository": null,
-  "generatedAt": "2026-08-22T07:14:05.949Z",
+  "generatedAt": "2026-08-22T14:11:05.018Z",
   "nodeVersion": "v26.0.0",
   "npmVersion": "11.12.1",
   "platform": "darwin-arm64",
@@ -17,7 +17,7 @@
   "workflowSha": null,
   "gateExit": 0,
   "gateLog": "release/gate.log",
-  "gateLogSha256": "04867c0e393d2bb29bf35a91082e7e065e466b17d0a36c7341fda7b5c9a40924",
+  "gateLogSha256": "a59ef714b910c8b4f8c0c31f253695d2f9eb8e304063a4d0a514d80456435a7a",
   "stages": {
     "mutation": "not-executed"
   },
@@ -52,7 +52,7 @@
   },
   "buckets": {
     "unit": {
-      "passed": 6703,
+      "passed": 6713,
       "skipped": 29,
       "runs": 3
     },
@@ -78,11 +78,11 @@
     }
   },
   "total": {
-    "passed": 10761,
+    "passed": 10771,
     "skipped": 35
   },
   "bundle": {
-    "liveEntryKiB": 769,
+    "liveEntryKiB": 770,
     "ceilingKiB": 776
   },
   "packageLockSha256": "b1419471eee9b659377fa402ba40976e4bd3df7818a7dee0d578b045237aa79b",

--- a/src/app/inspectorCardRefreshers.ts
+++ b/src/app/inspectorCardRefreshers.ts
@@ -13,7 +13,7 @@
 // returned object and otherwise behave exactly as before.
 import type { Inspector } from '../ui/Inspector';
 import { isLinearUnitKnown } from '../geo/CoordinateTypes';
-import { classify as classifyProvenance } from '../diagnostics/provenance';
+import { captureProvenance } from '../diagnostics/captureProvenance';
 import {
   signalsForStaticCloud,
   signalsForStreamingCloud,
@@ -25,12 +25,12 @@ import {
 import type { StreamingSourceKind } from '../render/streaming/StreamingSource';
 
 export interface InspectorCardRefreshers {
-  /** Refresh the Inspector's provenance panel from a freshly attached static cloud. */
+  /** Record a freshly attached static cloud as the scan the provenance store describes. */
   refreshProvenance(cloud: {
     readonly sourceFormat: string;
     readonly pointCount: number;
   }): void;
-  /** Refresh the Inspector's provenance panel from a freshly attached streaming cloud. */
+  /** Record a freshly attached streaming cloud as the scan the provenance store describes. */
   refreshProvenanceFromStreaming(cloud: {
     readonly kind: StreamingSourceKind;
     readonly sourcePointCount?: number;
@@ -137,22 +137,29 @@ export function createInspectorCardRefreshers(
   // every attach-time refresh, so derived numbers never survive a scan swap.
   let lastSummary: Parameters<Inspector['setDatasetIntelligence']>[0] | null = null;
 
+  // The panel renders whatever the shared store says, including a verdict that
+  // arrives after the refresher below already ran: the shape router only decides
+  // in `revealAnalysePanel`, which both open paths call after their provenance
+  // refresh, and a streaming re-route or a manual "Treat as" pick moves it again
+  // later in the session. Pushing from here keeps the card in step with the
+  // report PDF and the exported images, which read the same store.
+  captureProvenance.onChange((f) => {
+    if (f) inspector.setProvenance(f);
+    else inspector.clearProvenance();
+  });
+
   function refreshProvenance(cloud: {
     readonly sourceFormat: string;
     readonly pointCount: number;
   }): void {
-    const signals = signalsForStaticCloud(cloud as never);
-    const f = classifyProvenance(signals);
-    inspector.setProvenance(f);
+    captureProvenance.setScan(signalsForStaticCloud(cloud as never));
   }
 
   function refreshProvenanceFromStreaming(cloud: {
     readonly kind: StreamingSourceKind;
     readonly sourcePointCount?: number;
   }): void {
-    const signals = signalsForStreamingCloud(cloud as never);
-    const f = classifyProvenance(signals);
-    inspector.setProvenance(f);
+    captureProvenance.setScan(signalsForStreamingCloud(cloud as never));
   }
 
   /**

--- a/src/app/reportExport.ts
+++ b/src/app/reportExport.ts
@@ -18,14 +18,17 @@
  * honesty rule the PDF's Point Count follows — the declared total over the strided
  * display subset, the same rule as the Layers chip's `layerChipCount`) and
  * {@link isNonTerrainVerdict} (the capture-lens predicate that rules out an aerial
- * density guess for a compact object / interior). Everything else is imperative
- * orchestration, driven through a structural {@link ReportExportDeps} of accessor
- * functions closing over the shell's services and its mutable scan verdict rather
- * than the Viewer class — the same seam `openScan` and `openStreaming` use. The
- * heavy report engine (which pulls pdf-lib) is passed in as a lazy loader so this
- * module stays free of the boot graph. `main.ts` keeps thin `generateReportPdf` /
- * `exportGeoContext` delegates that bind its running state to these deps. Part of
- * the v0.6 decomposition (see `docs/architecture/architecture-map.md`).
+ * density guess for a compact object / interior, re-exported from
+ * `diagnostics/captureProvenance`). Everything else is imperative orchestration,
+ * driven through a structural {@link ReportExportDeps} of accessor functions
+ * closing over the shell's services rather than the Viewer class — the same seam
+ * `openScan` and `openStreaming` use. The heavy report engine (pdf-lib) is passed
+ * in as a lazy loader so this module stays free of the boot graph, and the capture
+ * fingerprint is read from the shared `diagnostics/captureProvenance` store so the
+ * PDF cannot state a capture type the Inspector contradicts. `main.ts` keeps thin
+ * `generateReportPdf` / `exportGeoContext` delegates that bind its running state
+ * to these deps. Part of the v0.6 decomposition
+ * (see `docs/architecture/architecture-map.md`).
  */
 
 import { footprintMetres } from '../report/reportFootprint';
@@ -33,13 +36,11 @@ import type { Footprint } from '../report/reportFootprint';
 import { spatialContextFrom } from '../geo/SpatialContext';
 import { isZUpFormat } from '../io/sniffFormat';
 import { increment as recordUsage } from '../diagnostics/usageCounters';
-import { classify as classifyProvenance } from '../diagnostics/provenance';
-import { signalsForStaticCloud, signalsForStreamingCloud } from '../diagnostics/provenanceSignals';
+import { captureProvenance, isNonTerrainVerdict } from '../diagnostics/captureProvenance';
 import { triggerDownload } from '../io/download';
 
 import type { MetadataInputs, ReportProvenanceFingerprint } from '../report';
 import type { ResolvedCrs } from '../geo/CoordinateTypes';
-import type { SpaceKind } from '../terrain/scanShape';
 import type { Viewer } from '../render/Viewer';
 import type { DropZone } from '../ui/DropZone';
 import type { ScanService } from './ScanService';
@@ -87,13 +88,11 @@ export function reportPointCount(
 }
 
 /**
- * True for a compact object / interior scan — the capture-lens verdict that rules
- * out an aerial density guess in the provenance fingerprint (v0.5.7). A temple is
- * not drone LiDAR just because its density resembles a UAV survey.
+ * Re-exported from `diagnostics/captureProvenance`, which owns the shared capture
+ * verdict and applies this predicate to it. Kept on this module's surface because
+ * the capture lens is one of the pure decisions the report extraction exposes.
  */
-export function isNonTerrainVerdict(verdict: SpaceKind | null): boolean {
-  return verdict === 'object' || verdict === 'interior';
-}
+export { isNonTerrainVerdict };
 
 /**
  * The extent-carrying subset of {@link MetadataInputs}, mapped from a
@@ -136,9 +135,10 @@ export interface GeoExportContext {
 
 /**
  * The running-app seam the report / geo-context exports write through. Accessors
- * are functions, not snapshots, so the lazily-bound Viewer, the resolved CRS and
- * the mutable scan verdict are read at call time — exactly as the inline versions
- * read the shell's `viewer` / `crsService` / `lastScanVerdict`. The report engine
+ * are functions, not snapshots, so the lazily-bound Viewer and the resolved CRS
+ * are read at call time — exactly as the inline versions read the shell's
+ * `viewer` / `crsService`. The capture fingerprint comes from the shared
+ * `diagnostics/captureProvenance` store instead of a dep. The report engine
  * (which pulls pdf-lib) is passed as a lazy loader so this module stays free of the
  * boot graph and the pure decisions above can be tested without it.
  */
@@ -151,8 +151,6 @@ export interface ReportExportDeps {
   scans: Pick<ScanService, 'activeId' | 'activeCloud'>;
   /** The resolved CRS for the active scan (the shell's `crsService.current()`), or null. */
   crsCurrent: () => ResolvedCrs | null;
-  /** The shape router's latest verdict for the active scan (the shell's `lastScanVerdict`). */
-  lastScanVerdict: () => SpaceKind | null;
   /** The current class-scope stamp — disclosed on the PDF when a filter narrows the view. */
   classScopeStamp: () => string;
   /** A file name without its extension (the shell's `baseName`). */
@@ -345,35 +343,20 @@ export async function generateReportPdf(templateId: string, deps: ReportExportDe
     report.normalizeReportTemplateId(templateId) ?? report.DEFAULT_TEMPLATE_ID;
   const template = report.getReportTemplate(validatedTemplateId);
   const coverTitle = template?.label ?? 'Scan Report';
-  // Compute the same provenance fingerprint the Inspector's Provenance
-  // section already shows, and feed it to the report. Templates that
-  // include the `provenance` section get a real capture-type +
-  // confidence + cited accuracy bounds — auto-computed, varies per
-  // scan, gives every export per-template differentiation without
-  // requiring the user to take measurements or annotate first.
+  // The capture-type fingerprint the Inspector's Provenance card is showing,
+  // read from the shared store rather than re-classified here. Re-classifying
+  // let the PDF and the panel state opposite capture types for the same scan:
+  // only this site passed the shape router's verdict, so a compact object read
+  // "Ground-based scan" here and "Drone-mounted LiDAR" in the panel. The store
+  // also carries the user's capture-type override, so a corrected type reaches
+  // the deliverable instead of stopping at the panel.
   //
-  // Wrapped because a malformed cloud shape shouldn't sink the whole
-  // PDF — the section gracefully renders "No provenance fingerprint
-  // available" when the fingerprint is undefined.
+  // Wrapped because a throw must not sink the whole PDF. The section renders
+  // "No provenance fingerprint available" when the fingerprint is undefined.
   let provenanceFp: ReportProvenanceFingerprint | undefined;
   try {
-    const activeCloud = deps.scans.activeCloud();
-    const streamingCloud = viewer.streamingCloud;
-    // The shape router's verdict rules out an aerial density guess for a
-    // compact object / interior (v0.5.7 capture lens) — a temple is not drone
-    // LiDAR just because its density resembles a UAV survey.
-    const isNonTerrain = isNonTerrainVerdict(deps.lastScanVerdict());
-    if (activeCloud) {
-      const f = classifyProvenance({ ...signalsForStaticCloud(activeCloud as never), isNonTerrain });
-      provenanceFp = {
-        label: f.label,
-        confidence: f.confidence,
-        signals: f.signals,
-        bounds: f.bounds.map((b) => ({ label: b.label, value: b.value, source: b.source })),
-        disclaimer: f.disclaimer,
-      };
-    } else if (streamingCloud) {
-      const f = classifyProvenance({ ...signalsForStreamingCloud(streamingCloud as never), isNonTerrain });
+    const f = captureProvenance.fingerprint();
+    if (f) {
       provenanceFp = {
         label: f.label,
         confidence: f.confidence,
@@ -383,7 +366,7 @@ export async function generateReportPdf(templateId: string, deps: ReportExportDe
       };
     }
   } catch (err) {
-    if (deps.debug) console.warn('[report] classifyProvenance threw', err);
+    if (deps.debug) console.warn('[report] captureProvenance.fingerprint threw', err);
   }
   const inputs = report.composeReportInputs({
     templateId: validatedTemplateId,

--- a/src/diagnostics/captureProvenance.ts
+++ b/src/diagnostics/captureProvenance.ts
@@ -1,0 +1,155 @@
+/**
+ * captureProvenance.ts
+ *
+ * The one capture-type verdict every surface reads.
+ *
+ * `provenance.classify` was called at three sites with three different argument
+ * lists: the Inspector's Provenance card (`app/inspectorCardRefreshers.ts`), the
+ * technical-report PDF (`app/reportExport.ts`) and the scan-report card stamped
+ * into every exported image (`render/exportAdapter.ts`). Only the report passed
+ * `isNonTerrain`, so one scan produced two opposite answers at the same moment:
+ * the panel read "Drone-mounted LiDAR (UAV ALS), medium confidence" while the
+ * PDF exported from the same session read "Ground-based scan, capture method not
+ * determined" with the shape-router signal that ruled airborne out.
+ *
+ * The shape verdict also lands AFTER the panel refreshes. `openScan.ts` calls
+ * `refreshProvenance` (line 338) then `revealAnalysePanel` (line 515);
+ * `openStreaming.ts` calls `refreshProvenanceFromStreaming` (line 189) then
+ * `revealAnalysePanel` (line 509 for COPC, line 806 for EPT).
+ * `revealAnalysePanel` is what runs `applyScanRoute`, which produces the
+ * verdict. A surface that classifies once at open time therefore cannot see the
+ * verdict at all, and a streaming re-route or a manual "Treat as" pick moves it
+ * again later in the session.
+ *
+ * This store holds the inputs and derives the verdict on read, so the three
+ * surfaces state one answer:
+ *
+ *   - `setScan` records the scan's signals, and drops the previous scan's
+ *     verdict and override so neither leaks across a load;
+ *   - `setVerdict` records the shape router's decision whenever it changes;
+ *   - `setOverride` records the user's capture-type pick, which is part of the
+ *     shared verdict and therefore reaches the PDF and the exported images
+ *     rather than only the panel;
+ *   - `fingerprint` composes all three through `classify`;
+ *   - `onChange` pushes each new verdict into the Inspector, so the panel
+ *     follows a verdict that lands after it first rendered.
+ *
+ * One instance per document, exported as {@link captureProvenance}. The three
+ * surfaces sit in `src/app`, `src/render` and the `src/main.ts` wiring with no
+ * shared construction seam between them, and a per-surface instance is the
+ * defect this module closes. `createCaptureProvenance` is exported so tests get
+ * an isolated store.
+ */
+
+import {
+  classify,
+  fingerprintFor,
+  type CaptureType,
+  type ProvenanceFingerprint,
+  type ScanSignals,
+} from './provenance';
+import type { SpaceKind } from '../terrain/scanShape';
+
+/**
+ * True for a compact object / interior scan. This is the capture-lens verdict
+ * that rules out an aerial density guess in the provenance fingerprint (v0.5.7):
+ * a temple is not drone LiDAR just because its density resembles a UAV survey.
+ */
+export function isNonTerrainVerdict(verdict: SpaceKind | null): boolean {
+  return verdict === 'object' || verdict === 'interior';
+}
+
+/** The shared capture-type verdict for the active scan. */
+export interface CaptureProvenanceStore {
+  /**
+   * Record the signals for the scan now loaded, or `null` for none. Resets the
+   * shape verdict and any user override, which describe the scan being replaced.
+   */
+  setScan(signals: ScanSignals | null): void;
+  /** Record the shape router's latest verdict for the active scan. */
+  setVerdict(verdict: SpaceKind | null): void;
+  /** The shape router's latest verdict for the active scan. */
+  verdict(): SpaceKind | null;
+  /** Record the user's capture-type pick, or `null` to return to the classifier. */
+  setOverride(type: CaptureType | null): void;
+  /** The user's capture-type pick, or `null` when the classifier decides. */
+  override(): CaptureType | null;
+  /** The verdict every surface states, or `null` when no scan is loaded. */
+  fingerprint(): ProvenanceFingerprint | null;
+  /**
+   * Run `fn` with each new verdict, replacing any previous listener. One slot:
+   * the Inspector is the only surface that has to be pushed to, because the
+   * report and the image exports read `fingerprint()` when they build.
+   */
+  onChange(fn: ((f: ProvenanceFingerprint | null) => void) | null): void;
+  /** Drop the scan, the verdict and the override. A closed scan states nothing. */
+  clear(): void;
+}
+
+/** A cheap equality key, so an unchanged verdict does not re-render the panel. */
+function key(f: ProvenanceFingerprint | null): string {
+  if (!f) return '';
+  return `${f.captureType}|${f.confidence}|${f.label}|${f.signals.join(' ')}`;
+}
+
+/** An isolated store. The application uses the shared {@link captureProvenance}. */
+export function createCaptureProvenance(): CaptureProvenanceStore {
+  let signals: ScanSignals | null = null;
+  let verdict: SpaceKind | null = null;
+  let override: CaptureType | null = null;
+  let listener: ((f: ProvenanceFingerprint | null) => void) | null = null;
+  let lastKey = '';
+
+  function fingerprint(): ProvenanceFingerprint | null {
+    if (override) return fingerprintFor(override);
+    if (!signals) return null;
+    return classify({ ...signals, isNonTerrain: isNonTerrainVerdict(verdict) });
+  }
+
+  function notify(): void {
+    const f = fingerprint();
+    const k = key(f);
+    if (k === lastKey) return;
+    lastKey = k;
+    listener?.(f);
+  }
+
+  return {
+    setScan(next) {
+      signals = next;
+      verdict = null;
+      override = null;
+      notify();
+    },
+    setVerdict(next) {
+      verdict = next;
+      notify();
+    },
+    verdict: () => verdict,
+    setOverride(type) {
+      override = type;
+      notify();
+    },
+    override: () => override,
+    fingerprint,
+    onChange(fn) {
+      listener = fn;
+    },
+    clear() {
+      signals = null;
+      verdict = null;
+      override = null;
+      // Unconditional, unlike the mutators: closing a scan restores the panel's
+      // placeholder even when the store was already empty, and resetting
+      // `lastKey` lets the next scan notify from a clean slate.
+      lastKey = '';
+      listener?.(null);
+    },
+  };
+}
+
+/**
+ * The shared store the Inspector, the report PDF and the image exports all read.
+ * Module-scoped so the three of them cannot hold separate copies.
+ */
+export const captureProvenance: CaptureProvenanceStore = createCaptureProvenance();

--- a/src/main.ts
+++ b/src/main.ts
@@ -253,10 +253,8 @@ import {
   increment as recordUsage,
   isSuppressed as usageIsSuppressed,
 } from './diagnostics/usageCounters';
-import {
-  fingerprintFor as provenanceFor,
-  type CaptureType,
-} from './diagnostics/provenance';
+import { captureProvenance } from './diagnostics/captureProvenance';
+import type { CaptureType } from './diagnostics/provenance';
 // CatalogPanel renders the empty-state "verified public LiDAR" picker.
 // The picker carries a curated dropdown of direct EPT URLs (each probed
 // at build time) and routes the selected URL into the existing streaming
@@ -1003,7 +1001,7 @@ let _lastInstantScanLabel: string | undefined;
 function showInstantAnswer(scanLabel: string): void {
   const answer = planInstantAnswer({
     cloudCount: viewer.clouds().length,
-    scanShape: lastScanVerdict,
+    scanShape: captureProvenance.verdict(),
     scanLabel,
     priorScanLabel: _lastInstantScanLabel,
   });
@@ -3059,12 +3057,14 @@ const clipPanel = new ClipPanel({
 });
 
 // ── Scan-type routing state ─────────────────────────────────────────────────
+// The verdict itself lives in `captureProvenance`, which composes it with the
+// scan's metadata signals into the one capture-type fingerprint the Inspector,
+// the PDF report and the image exports all state.
 // `revealAnalysePanel` runs once at open, when a streaming cloud may have only
 // a sparse coarse level resident — a misread is likely. `applyScanRoute` is
 // re-run as the cloud fills in (debounced, growth-gated) and only flips panels
 // when the verdict actually changes, so it never thrashes. Once the user forces
 // a panel ("Run terrain anyway" / Analyse toggle) `routing.overridden` pins it.
-let lastScanVerdict: SpaceKind | null = null;
 let lastRouteResident = 0;
 /** Re-route only after the resident cloud grows by this factor (cheap gate). */
 const SCAN_REROUTE_GROWTH = 1.4;
@@ -3202,7 +3202,7 @@ function applyScanRoute(initial: boolean, settled = false): boolean {
     detected,
     override: routing.typeOverride,
     initial,
-    lastVerdict: lastScanVerdict,
+    lastVerdict: captureProvenance.verdict(),
     pinned: routing.overridden,
     settled,
   });
@@ -3240,7 +3240,7 @@ function applyScanRoute(initial: boolean, settled = false): boolean {
     return oneShotSpent;
   }
   const effective = plan.effective;
-  lastScanVerdict = effective;
+  captureProvenance.setVerdict(effective);
 
   const isNonTerrain = plan.showObjectPanel;
   if (isNonTerrain && shape && gathered) {
@@ -3418,7 +3418,7 @@ function revealAnalysePanel(name: string, settled = true): void {
   lastSettleResident = -1;
   lastSettleUndecided = false;
   scanDetectionCommitted = false;
-  lastScanVerdict = null;
+  captureProvenance.setVerdict(null);
   lastRouteResident = viewer.residentPointTotal();
   // `settled` = the geometry is fully loaded at open time (every static path).
   // Streaming callers pass false: their open-time verdict runs on a sparse
@@ -3535,12 +3535,12 @@ void viewerLoaded.then(() => {
     noteEdit('annotation');
   });
 
-  // Provenance override — when the user picks a capture type from the
-  // dropdown in the Inspector's Provenance section, rebuild the
-  // fingerprint for that explicit type. The signals row records that
-  // it's a user override so the surfacing stays honest.
+  // Provenance override: when the user picks a capture type from the dropdown
+  // in the Inspector's Provenance section, record it on the shared store. The
+  // panel re-renders through the store's listener, and the report PDF and the
+  // image exports read the same override, so a correction reaches every surface.
   inspector.setOnProvenanceOverride((type: CaptureType) => {
-    inspector.setProvenance(provenanceFor(type));
+    captureProvenance.setOverride(type);
   });
   // CRS override picker — persists to localStorage via CrsOverrideStore,
   // re-resolves against the active scan, and refreshes the Inspector
@@ -4971,9 +4971,10 @@ const openStreamingDeps: OpenStreamingDeps = {
 /**
  * Report / geo-context export — thin callers over the extracted
  * `src/app/reportExport.ts`. `reportExportDeps` binds the shell's running state
- * (the lazy Viewer, the active-scan seam, the resolved CRS, the scan verdict and
- * the class-scope stamp) to the module's accessors; the PDF assembly and the
- * origin/CRS resolution, plus the pure `effectiveCrsName` / `reportPointCount` /
+ * (the lazy Viewer, the active-scan seam, the resolved CRS and the class-scope
+ * stamp) to the module's accessors, and the capture fingerprint comes from the
+ * shared `captureProvenance` store. The PDF assembly and the origin/CRS
+ * resolution, plus the pure `effectiveCrsName` / `reportPointCount` /
  * `isNonTerrainVerdict` decisions, live in that module.
  */
 const reportExportDeps: ReportExportDeps = {
@@ -4981,7 +4982,6 @@ const reportExportDeps: ReportExportDeps = {
   getViewer: () => viewer,
   scans,
   crsCurrent: () => crsService.current(),
-  lastScanVerdict: () => lastScanVerdict,
   classScopeStamp: currentClassScopeStamp,
   baseName,
   loadReportEngine,
@@ -5416,7 +5416,7 @@ function resetToEmptyState(): void {
   // Cancel any pending scan-type re-route + reset its state so a timer can't
   // fire against the now-closed scan, and the next open routes from scratch.
   routing.cancelScheduled();
-  lastScanVerdict = null;
+  captureProvenance.setVerdict(null);
   routing.reset();
   streamingSettledRouted = false;
   settleAttempts = 0;
@@ -5438,7 +5438,7 @@ function resetToEmptyState(): void {
   dock.setEmpty(true);
   inspector.setEmpty(true);
   inspector.clear();
-  inspector.clearProvenance();
+  captureProvenance.clear();
   // `crsService.clear()` broadcasts `null` to the inspector via its
   // subscription, which restores the CRS placeholder.
   crsCoordinator.clearDatasetKey();

--- a/src/render/exportAdapter.ts
+++ b/src/render/exportAdapter.ts
@@ -27,14 +27,10 @@ import type { LayerSpatialTransform } from '../geo/ProjectSpatialFrame';
 import { placeAabb } from './layerPlacement';
 import type { ExportSceneAdapter, FigureViewContext, ExportColorModeSnapshot } from '../export/types';
 import { linearUnitLabel } from '../io/crs';
-// Provenance classifier for `captureLabel` — surfaces capture-type + confidence
-// into every exported image's scan-report card. Same path the Inspector and the
-// PDF report use.
-import { classify as classifyProvenance } from '../diagnostics/provenance';
-import {
-  signalsForStaticCloud,
-  signalsForStreamingCloud,
-} from '../diagnostics/provenanceSignals';
+// The shared capture verdict for `captureLabel`. It surfaces capture-type plus
+// confidence into every exported image's scan-report card, from the same store
+// the Inspector card and the PDF report read.
+import { captureProvenance } from '../diagnostics/captureProvenance';
 import { classificationCoverage } from './class/classificationCoverage';
 
 /**
@@ -435,26 +431,16 @@ export function buildExportAdapter(host: ExportAdapterHost): ExportSceneAdapter 
       return null;
     },
     captureLabel(): { label: string; confidence: 'low' | 'medium' | 'high' } | null {
-      // Compute the same provenance fingerprint the Inspector + PDF
-      // Provenance section surface. Auto-computed, varies per scan;
-      // exporters get it via `baseReportRows` without any per-mode
-      // code. Wrapped because a malformed cloud shape shouldn't sink
-      // the export — null is a clean no-op in the renderer.
+      // The verdict the Inspector card and the PDF Provenance section are
+      // showing, read from the shared store rather than re-classified here.
+      // Re-classifying from the cloud alone dropped both the shape router's
+      // verdict and the user's capture-type override, so an exported image could
+      // stamp a capture type the panel and the PDF both contradicted. Wrapped
+      // because a throw must not sink the export: null is a clean no-op in the
+      // renderer and renders as no Capture row.
       try {
-        const streaming = host.streaming();
-        if (streaming) {
-          const f = classifyProvenance(
-            signalsForStreamingCloud(streaming.cloud as never),
-          );
-          return { label: f.label, confidence: f.confidence };
-        }
-        const first = visibleEntries()[0];
-        if (first) {
-          const f = classifyProvenance(
-            signalsForStaticCloud(first.cloud as never),
-          );
-          return { label: f.label, confidence: f.confidence };
-        }
+        const f = captureProvenance.fingerprint();
+        if (f) return { label: f.label, confidence: f.confidence };
       } catch {
         /* defensive — null falls back to "no Capture row" */
       }

--- a/src/report/ReportAssetComposer.ts
+++ b/src/report/ReportAssetComposer.ts
@@ -71,9 +71,9 @@ export interface ComposeReportInputs {
    * Provenance fingerprint from the classifier. When supplied AND the
    * selected template includes the `provenance` section, the PDF
    * renders a capture-type label + confidence badge + signals list +
-   * literature-cited accuracy bounds. Auto-computed by main.ts via
-   * `classifyProvenance(signalsFor…(cloud))` — the report module never
-   * sees the diagnostics types.
+   * literature-cited accuracy bounds. Read from the shared
+   * `diagnostics/captureProvenance` store by `app/reportExport.ts`, so the
+   * report module never sees the diagnostics types.
    */
   readonly provenance?: ReportProvenanceFingerprint;
   /**

--- a/tests/captureProvenanceSingleSource.test.ts
+++ b/tests/captureProvenanceSingleSource.test.ts
@@ -1,0 +1,288 @@
+/**
+ * captureProvenanceSingleSource.test.ts
+ *
+ * One capture type per scan, stated identically by every surface that states one.
+ *
+ * `provenance.classify` was called at three sites with three different argument
+ * lists. `app/inspectorCardRefreshers.ts` and `render/exportAdapter.ts` passed
+ * the scan signals alone; `app/reportExport.ts` passed the signals plus
+ * `isNonTerrain` from the shape router. On a compact object or interior the
+ * router rules airborne out, so the Inspector reported "Drone-mounted LiDAR (UAV
+ * ALS)" while the technical report PDF exported from the same session reported
+ * "Ground-based scan, capture method not determined".
+ *
+ * Ordering made a per-site argument insufficient on its own. Both open paths
+ * refresh the panel before the verdict exists: `openScan.ts` calls
+ * `refreshProvenance` (line 338) then `revealAnalysePanel` (line 515), and
+ * `openStreaming.ts` calls `refreshProvenanceFromStreaming` (line 189) then
+ * `revealAnalysePanel` (line 509 for COPC, line 806 for EPT).
+ * `revealAnalysePanel` runs `applyScanRoute`, which is where the verdict is
+ * produced. The cases below drive the surfaces in that order.
+ *
+ * The three surfaces are driven through their production entry points: the
+ * Inspector through `createInspectorCardRefreshers`, the PDF through
+ * `generateReportPdf` with a recording report-engine stub, and the exported
+ * image's scan-report card through `buildExportAdapter().captureLabel()`.
+ */
+
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+import { captureProvenance } from '../src/diagnostics/captureProvenance';
+import { createInspectorCardRefreshers } from '../src/app/inspectorCardRefreshers';
+import { generateReportPdf, type ReportExportDeps } from '../src/app/reportExport';
+import { buildExportAdapter, type ExportAdapterHost } from '../src/render/exportAdapter';
+import type { Inspector } from '../src/ui/Inspector';
+import type { Viewer } from '../src/render/Viewer';
+import type { ProvenanceFingerprint } from '../src/diagnostics/provenance';
+
+// generateReportPdf ends by triggering a browser download; the node test env has
+// no DOM, so stub the two globals `triggerDownload` touches. Fake timers keep the
+// helper's deferred URL-revoke from firing after the stubs are torn down.
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('document', {
+    createElement: () => ({ href: '', download: '', click() {}, remove() {} }),
+    body: { appendChild() {} },
+  });
+  const u = globalThis.URL as unknown as Record<string, unknown>;
+  u.createObjectURL = () => 'blob:capture-provenance-test';
+  u.revokeObjectURL = () => {};
+});
+afterAll(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  const u = globalThis.URL as unknown as Record<string, unknown>;
+  delete u.createObjectURL;
+  delete u.revokeObjectURL;
+});
+
+// ── the two scans ───────────────────────────────────────────────────────────
+
+/**
+ * A temple: 80 x 60 m footprint (4 800 m²) carrying 960 000 points, so
+ * 200 pts/m² over a footprint above the 2 000 m² mapping-scale bound. That is
+ * the UAV band in `matchNumeric`, which is why density alone calls it drone.
+ * The shape router calls the same scan a compact object.
+ */
+const templeCloud = {
+  name: 'temple.las',
+  sourceFormat: 'las',
+  pointCount: 960_000,
+  declaredPointCount: 960_000,
+  bounds: () => ({ min: [0, 0, 0], max: [80, 60, 25] }),
+  colors: null,
+  intensity: null,
+  classification: null,
+  metadata: {
+    crs: { name: 'EPSG:32614', linearUnit: 'metre', linearUnitToMetres: 1, verticalUnitToMetres: 1 },
+  },
+};
+
+/**
+ * An open survey with the SAME density signature: 200 x 200 m (40 000 m²) at
+ * 8 000 000 points is also 200 pts/m². Only the shape verdict separates it from
+ * the temple, which is what makes it the control for "the fix did not simply
+ * force every scan to ground-based".
+ */
+const terrainCloud = {
+  ...templeCloud,
+  name: 'survey.las',
+  pointCount: 8_000_000,
+  declaredPointCount: 8_000_000,
+  bounds: () => ({ min: [0, 0, 0], max: [200, 200, 40] }),
+};
+
+// ── the three surfaces ──────────────────────────────────────────────────────
+
+/** The Inspector's Provenance card: the last fingerprint pushed to the panel. */
+function panel() {
+  let last: ProvenanceFingerprint | null = null;
+  const inspector = {
+    setProvenance: (f: ProvenanceFingerprint) => { last = f; },
+    clearProvenance: () => { last = null; },
+    setDatasetIntelligence: vi.fn(),
+    clearDatasetIntelligence: vi.fn(),
+  } as unknown as Inspector;
+  const cards = createInspectorCardRefreshers(inspector);
+  return { cards, label: () => last?.label ?? null, confidence: () => last?.confidence ?? null };
+}
+
+/** The technical report PDF: the provenance block handed to the report engine. */
+async function reportProvenance(cloud: typeof templeCloud) {
+  const composeReportInputs = vi.fn((x: Record<string, unknown>) => x);
+  const reportStub = {
+    normalizeReportTemplateId: (id: string) => id,
+    DEFAULT_TEMPLATE_ID: 'technical-report',
+    getReportTemplate: (id: string) => ({ label: `Template ${id}` }),
+    composeReportInputs,
+    generateReport: async () => ({ blob: new Blob(['%PDF-1.7']), failedSections: [] }),
+  };
+  const viewer = {
+    get streamingCloud() { return null; },
+    annotate: { getAnnotations: () => [] },
+    measure: { getMeasurements: () => [], unitSystem: 'metric', unitToMetres: 1 },
+  } as unknown as Viewer;
+  const deps = {
+    viewerReady: Promise.resolve(),
+    getViewer: () => viewer,
+    scans: { activeId: 'a', activeCloud: () => cloud },
+    crsCurrent: () => null,
+    classScopeStamp: () => '',
+    baseName: (n: string) => n.replace(/\.[^.]+$/, ''),
+    loadReportEngine: vi.fn(async () => reportStub),
+    dropZone: { setError: vi.fn() },
+    debug: false,
+  } as unknown as ReportExportDeps;
+  await generateReportPdf('technical-report', deps);
+  const inputs = composeReportInputs.mock.calls[0]![0] as {
+    provenance?: { label: string; confidence: string; signals: readonly string[] };
+  };
+  return inputs.provenance;
+}
+
+/**
+ * The scan-report card stamped into an exported image. The host carries the same
+ * cloud the panel and the report describe, so a surface that classifies the cloud
+ * itself has everything it needs to produce its own answer.
+ */
+function exportedImageCapture(cloud: typeof templeCloud | null = null) {
+  const entries = new Map(
+    cloud ? [['a', { cloud, mode: 'rgb', visible: true, placement: null }]] : [],
+  );
+  const host = {
+    clouds: () => entries,
+    streaming: () => null,
+    setColorMode: vi.fn(),
+    setStreamingColorMode: vi.fn(),
+    setVisible: vi.fn(),
+    snapshot: vi.fn(async () => new Blob()),
+    renderFramedTopDown: vi.fn(async () => null),
+    renderFigure: vi.fn(async () => null),
+    figureViewContext: vi.fn(),
+  } as unknown as ExportAdapterHost;
+  return buildExportAdapter(host).captureLabel?.() ?? null;
+}
+
+beforeEach(() => {
+  captureProvenance.clear();
+});
+
+describe('capture type: one verdict, every surface', () => {
+  it('states ground-based on all three surfaces for a compact object', async () => {
+    const p = panel();
+    // Open order: the panel refreshes first, the shape router decides after.
+    p.cards.refreshProvenance(templeCloud);
+    expect(p.label()).toBe('Drone-mounted LiDAR (UAV ALS)');
+    captureProvenance.setVerdict('object');
+
+    const report = await reportProvenance(templeCloud);
+    const image = exportedImageCapture(templeCloud);
+
+    expect(p.label()).toBe('Ground-based scan — capture method not determined');
+    expect(report?.label).toBe(p.label());
+    expect(image?.label).toBe(p.label());
+    expect(report?.confidence).toBe(p.confidence());
+    expect(image?.confidence).toBe(p.confidence());
+    expect(report?.signals).toContain(
+      'Shape reads as a compact object / interior — airborne capture ruled out by geometry.',
+    );
+  });
+
+  it('states ground-based on all three surfaces for an interior', async () => {
+    const p = panel();
+    p.cards.refreshProvenance(templeCloud);
+    captureProvenance.setVerdict('interior');
+
+    const report = await reportProvenance(templeCloud);
+    const image = exportedImageCapture(templeCloud);
+
+    expect(p.label()).toBe('Ground-based scan — capture method not determined');
+    expect(report?.label).toBe(p.label());
+    expect(image?.label).toBe(p.label());
+  });
+
+  it('keeps the aerial verdict on all three surfaces for a terrain scan', async () => {
+    const p = panel();
+    p.cards.refreshProvenance(terrainCloud);
+    captureProvenance.setVerdict('terrain');
+
+    const report = await reportProvenance(terrainCloud);
+    const image = exportedImageCapture(terrainCloud);
+
+    // The same density band as the temple, so this is the control that the
+    // shape guard is applied by verdict rather than to every scan.
+    expect(p.label()).toBe('Drone-mounted LiDAR (UAV ALS)');
+    expect(report?.label).toBe(p.label());
+    expect(image?.label).toBe(p.label());
+    expect(report?.confidence).toBe('medium');
+  });
+
+  it('follows a verdict that lands after the panel already rendered', () => {
+    const p = panel();
+    p.cards.refreshProvenance(templeCloud);
+    const atOpen = p.label();
+    captureProvenance.setVerdict('object');
+    expect(atOpen).toBe('Drone-mounted LiDAR (UAV ALS)');
+    expect(p.label()).toBe('Ground-based scan — capture method not determined');
+  });
+
+  it('follows a streaming re-route that changes the verdict mid-session', () => {
+    const p = panel();
+    p.cards.refreshProvenance(templeCloud);
+    captureProvenance.setVerdict('terrain');
+    expect(p.label()).toBe('Drone-mounted LiDAR (UAV ALS)');
+    captureProvenance.setVerdict('object');
+    expect(p.label()).toBe('Ground-based scan — capture method not determined');
+  });
+});
+
+describe('capture type: a user override reaches the deliverables', () => {
+  it('carries the override into the report PDF and the exported image', async () => {
+    const p = panel();
+    p.cards.refreshProvenance(templeCloud);
+    captureProvenance.setVerdict('object');
+    captureProvenance.setOverride('terrestrial');
+
+    const report = await reportProvenance(templeCloud);
+    const image = exportedImageCapture(templeCloud);
+
+    expect(p.label()).toBe('Terrestrial Laser Scan (TLS)');
+    expect(report?.label).toBe(p.label());
+    expect(image?.label).toBe(p.label());
+    expect(report?.signals).toContain('User-overridden capture type');
+  });
+
+  it('drops the override when the next scan opens', () => {
+    const p = panel();
+    p.cards.refreshProvenance(templeCloud);
+    captureProvenance.setOverride('spaceborne');
+    expect(p.label()).toBe('Spaceborne LiDAR');
+    p.cards.refreshProvenance(terrainCloud);
+    expect(captureProvenance.override()).toBeNull();
+    expect(p.label()).toBe('Drone-mounted LiDAR (UAV ALS)');
+  });
+
+  it('drops the previous scan verdict when the next scan opens', () => {
+    const p = panel();
+    p.cards.refreshProvenance(templeCloud);
+    captureProvenance.setVerdict('object');
+    p.cards.refreshProvenance(terrainCloud);
+    expect(captureProvenance.verdict()).toBeNull();
+    expect(p.label()).toBe('Drone-mounted LiDAR (UAV ALS)');
+  });
+});
+
+describe('capture type: no scan states nothing', () => {
+  it('reports no fingerprint to any surface before a scan opens', () => {
+    expect(captureProvenance.fingerprint()).toBeNull();
+    expect(exportedImageCapture(templeCloud)).toBeNull();
+  });
+
+  it('clears every surface when the scan closes', () => {
+    const p = panel();
+    p.cards.refreshProvenance(templeCloud);
+    expect(p.label()).not.toBeNull();
+    captureProvenance.clear();
+    expect(p.label()).toBeNull();
+    expect(exportedImageCapture(templeCloud)).toBeNull();
+  });
+});

--- a/tests/reportExport.test.ts
+++ b/tests/reportExport.test.ts
@@ -247,7 +247,6 @@ function makeReportDeps(opts: {
   staticCloud?: typeof staticCloud;
   streamingCloud?: typeof streamingCloud;
   classScopeStamp?: string;
-  verdict?: SpaceKind | null;
   failedSections?: string[];
   generateReject?: boolean;
   normalizeToNull?: boolean;
@@ -280,7 +279,6 @@ function makeReportDeps(opts: {
       activeCloud: () => opts.staticCloud ?? null,
     },
     crsCurrent: () => null,
-    lastScanVerdict: () => opts.verdict ?? null,
     classScopeStamp: () => opts.classScopeStamp ?? '',
     baseName: (n: string) => n.replace(/\.[^.]+$/, ''),
     loadReportEngine: vi.fn(async () => reportStub),
@@ -295,7 +293,6 @@ describe('generateReportPdf — the report assembly body', () => {
     const { deps, composeReportInputs, generateReport, setError } = makeReportDeps({
       staticCloud,
       classScopeStamp: 'ground only',
-      verdict: 'terrain',
     });
     await generateReportPdf('survey-summary', deps);
     expect(composeReportInputs).toHaveBeenCalledTimes(1);
@@ -306,7 +303,6 @@ describe('generateReportPdf — the report assembly body', () => {
     // A non-empty class-scope stamp is disclosed on the metadata.
     expect(inputs.metadata.classScopeNote).toBe('ground only');
     expect(inputs.subtitle).toBe('survey.las');
-    // A terrain verdict is provenance-classified without throwing.
     expect(inputs.metadata).toBeDefined();
     expect(generateReport).toHaveBeenCalledTimes(1);
     expect(setError).not.toHaveBeenCalled();
@@ -316,7 +312,6 @@ describe('generateReportPdf — the report assembly body', () => {
     const { deps, composeReportInputs } = makeReportDeps({
       streamingCloud,
       classScopeStamp: '',
-      verdict: 'object',
     });
     await generateReportPdf('technical-report', deps);
     const inputs = composeReportInputs.mock.calls[0]![0] as ReportInputs;


### PR DESCRIPTION
The Inspector reported one capture type and the exported report reported another
for the same scan in the same session. `classifyProvenance` ran at three sites
with different inputs, and only the report saw the shape router's verdict, so a
compact object or interior read as ground-based in the PDF and as drone LiDAR on
screen.

The verdict is not available when the panel refreshes: it is produced by
`revealAnalysePanel`, which runs after both open paths, and it moves again on
re-route and on a scan-type override. Passing it as an argument could not have
worked. A store in `src/diagnostics` now holds the signals, the verdict and the
user override and derives the fingerprint on read; the panel, the report and the
export adapter all read it.

A user override also never reached the exported PDF or image. It does now.
