### PR TITLE
Scope the exported image's capture row to the pixels it shows

### DIFF
--- a/src/app/inspectorCardRefreshers.ts
+++ b/src/app/inspectorCardRefreshers.ts
@@ -25,11 +25,20 @@ import {
 import type { StreamingSourceKind } from '../render/streaming/StreamingSource';
 
 export interface InspectorCardRefreshers {
-  /** Record a freshly attached static cloud as the scan the provenance store describes. */
-  refreshProvenance(cloud: {
-    readonly sourceFormat: string;
-    readonly pointCount: number;
-  }): void;
+  /**
+   * Record a freshly attached static cloud as the scan the provenance store
+   * describes, owned by the layer id it was added under. The id is what lets a
+   * scene-scoped surface tell whether the stored verdict belongs to the layer
+   * it is describing, since static layers are additive and only the newest open
+   * becomes the active scan.
+   */
+  refreshProvenance(
+    cloud: {
+      readonly sourceFormat: string;
+      readonly pointCount: number;
+    },
+    layerId: string,
+  ): void;
   /** Record a freshly attached streaming cloud as the scan the provenance store describes. */
   refreshProvenanceFromStreaming(cloud: {
     readonly kind: StreamingSourceKind;
@@ -148,18 +157,23 @@ export function createInspectorCardRefreshers(
     else inspector.clearProvenance();
   });
 
-  function refreshProvenance(cloud: {
-    readonly sourceFormat: string;
-    readonly pointCount: number;
-  }): void {
-    captureProvenance.setScan(signalsForStaticCloud(cloud as never));
+  function refreshProvenance(
+    cloud: {
+      readonly sourceFormat: string;
+      readonly pointCount: number;
+    },
+    layerId: string,
+  ): void {
+    captureProvenance.setScan({ layerId, signals: signalsForStaticCloud(cloud as never) });
   }
 
   function refreshProvenanceFromStreaming(cloud: {
     readonly kind: StreamingSourceKind;
     readonly sourcePointCount?: number;
   }): void {
-    captureProvenance.setScan(signalsForStreamingCloud(cloud as never));
+    // A streaming open closes the static layers, so the streaming source is the
+    // whole scene and carries no static layer id.
+    captureProvenance.setScan({ layerId: null, signals: signalsForStreamingCloud(cloud as never) });
   }
 
   /**

--- a/src/app/openScan.ts
+++ b/src/app/openScan.ts
@@ -335,7 +335,7 @@ export async function openScan(file: File, deps: OpenScanDeps): Promise<void> {
     // the Inspector's "Provenance" section. Wrapped because a malformed
     // input shape would have aborted the rest of the post-load setup
     // (including the navBar reveal further down).
-    try { deps.inspectorCards.refreshProvenance(result.cloud); }
+    try { deps.inspectorCards.refreshProvenance(result.cloud, id); }
     catch (err) { if (deps.debug) console.warn('[provenance] refreshProvenance threw', err); }
     // CRS — detected from the loaded cloud's metadata, merged with any
     // persisted user override. Wrapped because a malformed cloud

--- a/src/diagnostics/captureProvenance.ts
+++ b/src/diagnostics/captureProvenance.ts
@@ -24,8 +24,14 @@
  * This store holds the inputs and derives the verdict on read, so the three
  * surfaces state one answer:
  *
- *   - `setScan` records the scan's signals, and drops the previous scan's
- *     verdict and override so neither leaks across a load;
+ *   - `setScan` records the scan's signals AND the layer they were read from,
+ *     and drops the previous scan's verdict and override so neither leaks
+ *     across a load;
+ *   - `ownedBy` answers whether the stored scan is a given layer, and `clearIf`
+ *     drops the store when that layer goes. Static layers are additive
+ *     (`app/openScan.ts`) and the newest open becomes the active scan, so the
+ *     store can describe a layer that is hidden or no longer in the scene. A
+ *     scene-scoped surface asks `ownedBy` before it states the verdict;
  *   - `setVerdict` records the shape router's decision whenever it changes;
  *   - `setOverride` records the user's capture-type pick, which is part of the
  *     shared verdict and therefore reaches the PDF and the exported images
@@ -59,13 +65,31 @@ export function isNonTerrainVerdict(verdict: SpaceKind | null): boolean {
   return verdict === 'object' || verdict === 'interior';
 }
 
+/**
+ * The scan the store describes: its classifier signals plus the identity of the
+ * source they were read from. `layerId` is the static layer's id, or `null` for
+ * a streaming source, which has no static layer id and is the whole scene while
+ * it is open.
+ */
+export interface CaptureProvenanceScan {
+  readonly layerId: string | null;
+  readonly signals: ScanSignals;
+}
+
 /** The shared capture-type verdict for the active scan. */
 export interface CaptureProvenanceStore {
   /**
-   * Record the signals for the scan now loaded, or `null` for none. Resets the
-   * shape verdict and any user override, which describe the scan being replaced.
+   * Record the scan now loaded, or `null` for none. Resets the shape verdict
+   * and any user override, which describe the scan being replaced.
    */
-  setScan(signals: ScanSignals | null): void;
+  setScan(scan: CaptureProvenanceScan | null): void;
+  /**
+   * Whether the stored scan is `layerId` (`null` for the streaming source).
+   * False whenever no scan is stored, so an empty store owns nothing.
+   */
+  ownedBy(layerId: string | null): boolean;
+  /** Drop the scan, the verdict and the override when `layerId` owns them. */
+  clearIf(layerId: string): void;
   /** Record the shape router's latest verdict for the active scan. */
   setVerdict(verdict: SpaceKind | null): void;
   /** The shape router's latest verdict for the active scan. */
@@ -94,7 +118,7 @@ function key(f: ProvenanceFingerprint | null): string {
 
 /** An isolated store. The application uses the shared {@link captureProvenance}. */
 export function createCaptureProvenance(): CaptureProvenanceStore {
-  let signals: ScanSignals | null = null;
+  let scan: CaptureProvenanceScan | null = null;
   let verdict: SpaceKind | null = null;
   let override: CaptureType | null = null;
   let listener: ((f: ProvenanceFingerprint | null) => void) | null = null;
@@ -102,8 +126,19 @@ export function createCaptureProvenance(): CaptureProvenanceStore {
 
   function fingerprint(): ProvenanceFingerprint | null {
     if (override) return fingerprintFor(override);
-    if (!signals) return null;
-    return classify({ ...signals, isNonTerrain: isNonTerrainVerdict(verdict) });
+    if (!scan) return null;
+    return classify({ ...scan.signals, isNonTerrain: isNonTerrainVerdict(verdict) });
+  }
+
+  function clearAll(): void {
+    scan = null;
+    verdict = null;
+    override = null;
+    // Unconditional, unlike the mutators: closing a scan restores the panel's
+    // placeholder even when the store was already empty, and resetting
+    // `lastKey` lets the next scan notify from a clean slate.
+    lastKey = '';
+    listener?.(null);
   }
 
   function notify(): void {
@@ -116,10 +151,14 @@ export function createCaptureProvenance(): CaptureProvenanceStore {
 
   return {
     setScan(next) {
-      signals = next;
+      scan = next;
       verdict = null;
       override = null;
       notify();
+    },
+    ownedBy: (layerId) => scan !== null && scan.layerId === layerId,
+    clearIf(layerId) {
+      if (scan !== null && scan.layerId === layerId) clearAll();
     },
     setVerdict(next) {
       verdict = next;
@@ -135,16 +174,7 @@ export function createCaptureProvenance(): CaptureProvenanceStore {
     onChange(fn) {
       listener = fn;
     },
-    clear() {
-      signals = null;
-      verdict = null;
-      override = null;
-      // Unconditional, unlike the mutators: closing a scan restores the panel's
-      // placeholder even when the store was already empty, and resetting
-      // `lastKey` lets the next scan notify from a clean slate.
-      lastKey = '';
-      listener?.(null);
-    },
+    clear: clearAll,
   };
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5416,7 +5416,6 @@ function resetToEmptyState(): void {
   // Cancel any pending scan-type re-route + reset its state so a timer can't
   // fire against the now-closed scan, and the next open routes from scratch.
   routing.cancelScheduled();
-  captureProvenance.setVerdict(null);
   routing.reset();
   streamingSettledRouted = false;
   settleAttempts = 0;
@@ -5594,6 +5593,7 @@ function removeCloud(id: string): void {
   layerVisible.delete(id);
   if (layers.solo === id) layers.solo = null;
   scans.clearIf(id);
+  captureProvenance.clearIf(id);
   if (viewer.clouds().length === 0) resetToEmptyState();
   else {
     layerService.refreshCrsFlags();

--- a/src/render/exportAdapter.ts
+++ b/src/render/exportAdapter.ts
@@ -435,14 +435,35 @@ export function buildExportAdapter(host: ExportAdapterHost): ExportSceneAdapter 
       // showing, read from the shared store rather than re-classified here.
       // Re-classifying from the cloud alone dropped both the shape router's
       // verdict and the user's capture-type override, so an exported image could
-      // stamp a capture type the panel and the PDF both contradicted. Wrapped
-      // because a throw must not sink the export: null is a clean no-op in the
-      // renderer and renders as no Capture row.
+      // stamp a capture type the panel and the PDF both contradicted.
+      //
+      // The store describes the ACTIVE scan; this row describes the pixels. The
+      // two diverge because static layers are additive and the newest open
+      // becomes active: hiding the active layer, or removing it while an older
+      // one stays, leaves the store describing a scan the image does not show.
+      // So the row is emitted only when the scene has exactly one visible source
+      // AND the store describes that source. Several visible sources, a hidden
+      // owner, or a removed owner all emit nothing, which renders as no Capture
+      // row (the same path a null fingerprint takes). Per-source capture rows
+      // are a separate feature; this returns to the file's own rule that scene
+      // questions are answered over the visible entries.
+      //
+      // Wrapped because a throw must not sink the export.
       try {
+        const streamingSource = host.streaming();
+        const visible = [...host.clouds()].filter(([, c]) => c.visible);
+        if (streamingSource) {
+          // A streaming open closes the static layers, so a static layer still
+          // visible beside the streaming source is a second source. The
+          // streaming source itself owns the store under a null layer id.
+          if (visible.length > 0 || !captureProvenance.ownedBy(null)) return null;
+        } else if (visible.length !== 1 || !captureProvenance.ownedBy(visible[0]![0])) {
+          return null;
+        }
         const f = captureProvenance.fingerprint();
         if (f) return { label: f.label, confidence: f.confidence };
       } catch {
-        /* defensive — null falls back to "no Capture row" */
+        /* defensive: null falls back to "no Capture row" */
       }
       return null;
     },

--- a/src/terrain/export/terrainReportContent.ts
+++ b/src/terrain/export/terrainReportContent.ts
@@ -312,7 +312,7 @@ export function buildTerrainReportContent(
       { label: 'Interpolated (of grid)', value: fmtPct(q?.interpolatedCellRatio) },
       { label: 'Empty (of grid)', value: fmtPct(q?.emptyCellRatio) },
       {
-        label: 'Interpolated (of measured surface)',
+        label: 'Interpolated (of covered surface)',
         value: fmtPct(q?.interpolatedOfSurfaceRatio),
       },
       { label: 'Edge risk', value: fmtPct(q?.edgeRiskRatio) },

--- a/tests/captureProvenanceSingleSource.test.ts
+++ b/tests/captureProvenanceSingleSource.test.ts
@@ -23,6 +23,11 @@
  * Inspector through `createInspectorCardRefreshers`, the PDF through
  * `generateReportPdf` with a recording report-engine stub, and the exported
  * image's scan-report card through `buildExportAdapter().captureLabel()`.
+ *
+ * One store, two scopes. The Inspector and the PDF describe the active scan;
+ * the exported image describes the visible scene. The last describe block below
+ * covers the scenes where those differ, which the single-source cases cannot
+ * reach because they load one layer at a time.
  */
 
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
@@ -139,18 +144,35 @@ async function reportProvenance(cloud: typeof templeCloud) {
   return inputs.provenance;
 }
 
+/** A static layer in the exported scene: its id, its cloud, and whether it renders. */
+interface SceneLayer {
+  readonly id: string;
+  readonly cloud: typeof templeCloud;
+  readonly visible?: boolean;
+}
+
 /**
- * The scan-report card stamped into an exported image. The host carries the same
- * cloud the panel and the report describe, so a surface that classifies the cloud
+ * The scan-report card stamped into an exported image, over a scene of static
+ * layers plus an optional streaming source. Each layer carries the id the
+ * provenance store records as the owner, so a case can hide the owning layer,
+ * remove it, or leave two layers visible at once. The host carries the same
+ * clouds the panel and the report describe, so a surface that classifies a cloud
  * itself has everything it needs to produce its own answer.
  */
-function exportedImageCapture(cloud: typeof templeCloud | null = null) {
+function exportedImageCapture(
+  layers: readonly SceneLayer[] = [],
+  streamingCloud: { readonly kind: string; readonly sourcePointCount?: number } | null = null,
+) {
   const entries = new Map(
-    cloud ? [['a', { cloud, mode: 'rgb', visible: true, placement: null }]] : [],
+    layers.map((l) => [
+      l.id,
+      { cloud: l.cloud, mode: 'rgb', visible: l.visible ?? true, placement: null },
+    ]),
   );
   const host = {
     clouds: () => entries,
-    streaming: () => null,
+    streaming: () =>
+      streamingCloud ? { cloud: streamingCloud, renderer: { colorMode: 'rgb' } } : null,
     setColorMode: vi.fn(),
     setStreamingColorMode: vi.fn(),
     setVisible: vi.fn(),
@@ -162,6 +184,9 @@ function exportedImageCapture(cloud: typeof templeCloud | null = null) {
   return buildExportAdapter(host).captureLabel?.() ?? null;
 }
 
+/** The one-layer scene: layer `id` is loaded, visible, and owns the store. */
+const onlyLayer = (id: string, cloud: typeof templeCloud): SceneLayer[] => [{ id, cloud }];
+
 beforeEach(() => {
   captureProvenance.clear();
 });
@@ -170,12 +195,12 @@ describe('capture type: one verdict, every surface', () => {
   it('states ground-based on all three surfaces for a compact object', async () => {
     const p = panel();
     // Open order: the panel refreshes first, the shape router decides after.
-    p.cards.refreshProvenance(templeCloud);
+    p.cards.refreshProvenance(templeCloud, 'a');
     expect(p.label()).toBe('Drone-mounted LiDAR (UAV ALS)');
     captureProvenance.setVerdict('object');
 
     const report = await reportProvenance(templeCloud);
-    const image = exportedImageCapture(templeCloud);
+    const image = exportedImageCapture(onlyLayer('a', templeCloud));
 
     expect(p.label()).toBe('Ground-based scan — capture method not determined');
     expect(report?.label).toBe(p.label());
@@ -189,11 +214,11 @@ describe('capture type: one verdict, every surface', () => {
 
   it('states ground-based on all three surfaces for an interior', async () => {
     const p = panel();
-    p.cards.refreshProvenance(templeCloud);
+    p.cards.refreshProvenance(templeCloud, 'a');
     captureProvenance.setVerdict('interior');
 
     const report = await reportProvenance(templeCloud);
-    const image = exportedImageCapture(templeCloud);
+    const image = exportedImageCapture(onlyLayer('a', templeCloud));
 
     expect(p.label()).toBe('Ground-based scan — capture method not determined');
     expect(report?.label).toBe(p.label());
@@ -202,11 +227,11 @@ describe('capture type: one verdict, every surface', () => {
 
   it('keeps the aerial verdict on all three surfaces for a terrain scan', async () => {
     const p = panel();
-    p.cards.refreshProvenance(terrainCloud);
+    p.cards.refreshProvenance(terrainCloud, 'a');
     captureProvenance.setVerdict('terrain');
 
     const report = await reportProvenance(terrainCloud);
-    const image = exportedImageCapture(terrainCloud);
+    const image = exportedImageCapture(onlyLayer('a', terrainCloud));
 
     // The same density band as the temple, so this is the control that the
     // shape guard is applied by verdict rather than to every scan.
@@ -218,7 +243,7 @@ describe('capture type: one verdict, every surface', () => {
 
   it('follows a verdict that lands after the panel already rendered', () => {
     const p = panel();
-    p.cards.refreshProvenance(templeCloud);
+    p.cards.refreshProvenance(templeCloud, 'a');
     const atOpen = p.label();
     captureProvenance.setVerdict('object');
     expect(atOpen).toBe('Drone-mounted LiDAR (UAV ALS)');
@@ -227,7 +252,7 @@ describe('capture type: one verdict, every surface', () => {
 
   it('follows a streaming re-route that changes the verdict mid-session', () => {
     const p = panel();
-    p.cards.refreshProvenance(templeCloud);
+    p.cards.refreshProvenance(templeCloud, 'a');
     captureProvenance.setVerdict('terrain');
     expect(p.label()).toBe('Drone-mounted LiDAR (UAV ALS)');
     captureProvenance.setVerdict('object');
@@ -238,12 +263,12 @@ describe('capture type: one verdict, every surface', () => {
 describe('capture type: a user override reaches the deliverables', () => {
   it('carries the override into the report PDF and the exported image', async () => {
     const p = panel();
-    p.cards.refreshProvenance(templeCloud);
+    p.cards.refreshProvenance(templeCloud, 'a');
     captureProvenance.setVerdict('object');
     captureProvenance.setOverride('terrestrial');
 
     const report = await reportProvenance(templeCloud);
-    const image = exportedImageCapture(templeCloud);
+    const image = exportedImageCapture(onlyLayer('a', templeCloud));
 
     expect(p.label()).toBe('Terrestrial Laser Scan (TLS)');
     expect(report?.label).toBe(p.label());
@@ -251,38 +276,127 @@ describe('capture type: a user override reaches the deliverables', () => {
     expect(report?.signals).toContain('User-overridden capture type');
   });
 
-  it('drops the override when the next scan opens', () => {
+  it('drops the override when the next scan opens, and rebinds the owner', () => {
     const p = panel();
-    p.cards.refreshProvenance(templeCloud);
+    p.cards.refreshProvenance(templeCloud, 'a');
     captureProvenance.setOverride('spaceborne');
     expect(p.label()).toBe('Spaceborne LiDAR');
-    p.cards.refreshProvenance(terrainCloud);
+    p.cards.refreshProvenance(terrainCloud, 'b');
     expect(captureProvenance.override()).toBeNull();
     expect(p.label()).toBe('Drone-mounted LiDAR (UAV ALS)');
+    // The store now describes layer 'b', so an image of 'b' carries the new
+    // verdict and an image of 'a' carries none.
+    expect(exportedImageCapture(onlyLayer('b', terrainCloud))?.label).toBe(p.label());
+    expect(exportedImageCapture(onlyLayer('a', templeCloud))).toBeNull();
   });
 
   it('drops the previous scan verdict when the next scan opens', () => {
     const p = panel();
-    p.cards.refreshProvenance(templeCloud);
+    p.cards.refreshProvenance(templeCloud, 'a');
     captureProvenance.setVerdict('object');
-    p.cards.refreshProvenance(terrainCloud);
+    p.cards.refreshProvenance(terrainCloud, 'b');
     expect(captureProvenance.verdict()).toBeNull();
     expect(p.label()).toBe('Drone-mounted LiDAR (UAV ALS)');
+    expect(exportedImageCapture(onlyLayer('a', templeCloud))).toBeNull();
+  });
+});
+
+/**
+ * Scope. The Inspector card and the report PDF describe the ACTIVE scan, which
+ * is what they are for. The exported image describes the PIXELS, and
+ * `exportAdapter` answers every other scene question (capabilities, counts,
+ * bounds) over `visibleEntries()` for that reason.
+ *
+ * The two scopes come apart because static layers are additive
+ * (`app/openScan.ts`) and the newest open becomes the active scan. Load a
+ * terrain scan, then a temple: the store describes the temple. Hide the temple
+ * and the image shows only terrain pixels while the store still answers
+ * "ground-based". Remove the temple with its layer close control and the store
+ * describes a scan that is no longer in the scene at all.
+ *
+ * The cases below drive scenes the single-source cases above cannot reach: two
+ * layers, one of them hidden, and a layer removed. The rule under test is
+ * conservative on purpose. Exactly one visible source that owns the stored
+ * verdict states the capture type; anything else states nothing, which renders
+ * as no Capture row. A per-source capture row is a separate feature.
+ */
+describe('capture type: the exported image is scene scoped', () => {
+  /** Terrain opens first as layer 'a', the temple second as layer 'b' and active. */
+  function twoLayerSession() {
+    const p = panel();
+    p.cards.refreshProvenance(terrainCloud, 'a');
+    p.cards.refreshProvenance(templeCloud, 'b');
+    captureProvenance.setVerdict('object');
+    return p;
+  }
+
+  it('states nothing when the owning scan is hidden and an older scan shows', () => {
+    const p = twoLayerSession();
+    const image = exportedImageCapture([
+      { id: 'a', cloud: terrainCloud },
+      { id: 'b', cloud: templeCloud, visible: false },
+    ]);
+    // The panel keeps describing the active scan, which is correct for it.
+    expect(p.label()).toBe('Ground-based scan — capture method not determined');
+    // The image carries only terrain pixels, so it must not stamp the temple's
+    // capture type.
+    expect(image).toBeNull();
+  });
+
+  it('states nothing when two static scans are both visible', () => {
+    const p = twoLayerSession();
+    const image = exportedImageCapture([
+      { id: 'a', cloud: terrainCloud },
+      { id: 'b', cloud: templeCloud },
+    ]);
+    expect(p.label()).toBe('Ground-based scan — capture method not determined');
+    expect(image).toBeNull();
+  });
+
+  it('drops a removed scan from every surface at once', () => {
+    const p = twoLayerSession();
+    expect(p.label()).toBe('Ground-based scan — capture method not determined');
+    // The layer close control: `removeCloud` clears the store for the layer it
+    // frees, so the freed scan cannot keep describing the session.
+    captureProvenance.clearIf('b');
+    expect(captureProvenance.fingerprint()).toBeNull();
+    expect(p.label()).toBeNull();
+    expect(exportedImageCapture(onlyLayer('a', terrainCloud))).toBeNull();
+  });
+
+  it('keeps the verdict when a layer that does not own it is removed', () => {
+    const p = twoLayerSession();
+    captureProvenance.clearIf('a');
+    expect(p.label()).toBe('Ground-based scan — capture method not determined');
+    expect(exportedImageCapture(onlyLayer('b', templeCloud))?.label).toBe(p.label());
+  });
+
+  it('states the capture type for a streaming source, which is the whole scene', () => {
+    const p = panel();
+    const streamingCloud = {
+      kind: 'copc' as const,
+      name: 'tile.copc.laz',
+      sourcePointCount: 8_000_000,
+    };
+    p.cards.refreshProvenanceFromStreaming(streamingCloud);
+    const image = exportedImageCapture([], streamingCloud);
+    expect(p.label()).not.toBeNull();
+    expect(image?.label).toBe(p.label());
   });
 });
 
 describe('capture type: no scan states nothing', () => {
   it('reports no fingerprint to any surface before a scan opens', () => {
     expect(captureProvenance.fingerprint()).toBeNull();
-    expect(exportedImageCapture(templeCloud)).toBeNull();
+    expect(exportedImageCapture(onlyLayer('a', templeCloud))).toBeNull();
   });
 
   it('clears every surface when the scan closes', () => {
     const p = panel();
-    p.cards.refreshProvenance(templeCloud);
+    p.cards.refreshProvenance(templeCloud, 'a');
     expect(p.label()).not.toBeNull();
     captureProvenance.clear();
     expect(p.label()).toBeNull();
-    expect(exportedImageCapture(templeCloud)).toBeNull();
+    expect(exportedImageCapture(onlyLayer('a', templeCloud))).toBeNull();
   });
 });

--- a/tests/terrainReportContent.test.ts
+++ b/tests/terrainReportContent.test.ts
@@ -492,7 +492,7 @@ describe('buildTerrainReportContent — §19 permit stamp in provenance', () => 
       const rows = coverage(r)?.rows ?? [];
       const label = (l: string) => rows.find((x) => x.label === l)?.value;
       expect(label('Interpolated (of grid)')).toBe('37%');
-      expect(label('Interpolated (of measured surface)')).toBe('43%');
+      expect(label('Interpolated (of covered surface)')).toBe('43%');
       // No bare "Interpolated" survives, which is what made the two look like
       // one contradictory figure.
       expect(rows.some((x) => x.label === 'Interpolated')).toBe(false);


### PR DESCRIPTION
The shared capture store describes the active scan, and the image export was
reading it directly. Static layers are additive and the newest open becomes
active, so hiding the active layer, or removing it while an older one stays,
left the exported image stamping a capture type for pixels it does not show.
The export adapter's own rule is that scene questions are answered over the
visible entries.

The store now records which layer owns the verdict. The image emits a capture
row only when the scene has exactly one visible source and the store describes
that source; several visible sources, a hidden owner or a removed owner emit
nothing, which renders as no row. Removing a layer clears the verdict it owned.

A coverage row also read "of measured surface" where the denominator is the
covered surface.
