### PR TITLE
Invert the vertical orbit by default

### DIFF
--- a/docs/releases/RELEASE_NOTES_v0.6.6.md
+++ b/docs/releases/RELEASE_NOTES_v0.6.6.md
@@ -49,6 +49,7 @@ Z-up station positions move by at most 6.8e-13 and station counts are unchanged.
 - an inspection issue workflow on annotations, carrying a severity, an open or resolved status and an observation date, with an issue list ordered worst first and a roll-up of what is still open;
 - one Speed to Quality performance control with an Auto position and an Advanced disclosure that keeps every underlying knob individually settable;
 - a top-down orthographic Plan view, reachable from the navigation bar and the command palette, which restores the scene you left rather than the one it drew;
+- vertical orbit is inverted by default, so dragging down raises the viewpoint. The Nira preset selects no inversion on either axis, and a stored preference of either sign is kept;
 - tool preflight in Process Studio: a blocked or review-only tool states the condition that limits it and offers the shortest action that lifts it, and the measurement tools gained a readiness surface they did not have.
 
 The performance control is display and streaming only. It drives the streaming preset, the resident point budget, concurrent decodes, the device-pixel-ratio ceiling, Eye Dome Lighting and antialiasing. It does not touch the static load budget, which voxel-reduces the decoded cloud that terrain analysis reads, along with measurement and export, so no slider position can change a measured number, a terrain product or a reported claim. The panel says so where the control is.

--- a/src/render/navPrefs.ts
+++ b/src/render/navPrefs.ts
@@ -22,11 +22,15 @@
  * A named starting point for the invert signs. The invert flags are the source
  * of truth for behaviour; a preset is just a convenience that sets them.
  *
- *  - **default** — OLV's shipped convention (no inversion).
- *  - **recap** — Autodesk ReCap-style: vertical orbit inverted. This is the
- *    common "feels inverted vs CAD" case a validator hits.
- *  - **nira** — Nira is a browser point-cloud viewer whose orbit already
- *    matches OLV's convention, so it maps to no inversion too.
+ *  - **default** — OLV's shipped convention: vertical orbit inverted,
+ *    horizontal not. Dragging down raises the viewpoint, which is what
+ *    Autodesk ReCap does and what most people reaching for this app expect.
+ *  - **recap** — Autodesk ReCap-style. It now selects the same signs as
+ *    `default`, and is kept as a name a user can recognise rather than merged
+ *    away, because the two answer different questions: one is what OLV ships,
+ *    the other is what ReCap does.
+ *  - **nira** — Nira is a browser point-cloud viewer that inverts neither
+ *    axis, so it is the preset to pick for no inversion at all.
  */
 export type NavigationPreset = 'default' | 'recap' | 'nira';
 
@@ -40,10 +44,16 @@ export interface NavigationPreferences {
   preset: NavigationPreset;
 }
 
-/** The shipped defaults — no inversion, default preset. */
+/**
+ * The shipped defaults: vertical orbit inverted, horizontal not.
+ *
+ * `parseNavigationPreferences` falls back to these field by field, so a user
+ * who has never touched the setting gets the inverted vertical axis, while a
+ * stored preference of either sign is preserved exactly as written.
+ */
 export const DEFAULT_NAVIGATION_PREFERENCES: NavigationPreferences = {
   invertOrbitX: false,
-  invertOrbitY: false,
+  invertOrbitY: true,
   preset: 'default',
 };
 
@@ -53,8 +63,8 @@ const NAV_PRESETS: ReadonlySet<NavigationPreset> = new Set(['default', 'recap', 
 /**
  * The invert signs each preset selects. These sign combos are the ADJUSTABLE
  * product choice — the one place to retune what "ReCap" or "Nira" should feel
- * like without touching the handler. `recap` inverts the vertical axis only;
- * `default` and `nira` match OLV's current convention.
+ * like without touching the handler. `default` and `recap` both invert the
+ * vertical axis only; `nira` inverts neither.
  */
 export function navPresetSigns(
   preset: NavigationPreset,
@@ -66,7 +76,7 @@ export function navPresetSigns(
       return { invertOrbitX: false, invertOrbitY: false };
     case 'default':
     default:
-      return { invertOrbitX: false, invertOrbitY: false };
+      return { invertOrbitX: false, invertOrbitY: true };
   }
 }
 

--- a/tests/navPrefsWiring.test.ts
+++ b/tests/navPrefsWiring.test.ts
@@ -49,9 +49,12 @@ describe('navPrefsWiring external toggles', () => {
 
   it('toggling the same axis twice returns to the original state', () => {
     const f = fakes();
+    const start = navigationPrefs().invertOrbitY;
     toggleNavInvert('y', f.viewer, f.inspector, f.persist);
     const back = toggleNavInvert('y', f.viewer, f.inspector, f.persist);
-    expect(back.invertOrbitY).toBe(false);
+    // Asserted against where it started rather than a literal, so the round
+    // trip is what is pinned and not the shipped default's current value.
+    expect(back.invertOrbitY).toBe(start);
   });
 
   it('resetNavPrefs restores the shipped defaults and notifies all surfaces', () => {

--- a/tests/navigationPreferences.test.ts
+++ b/tests/navigationPreferences.test.ts
@@ -18,10 +18,12 @@ describe('parseNavigationPreferences', () => {
     }
   });
 
-  test('an empty object yields the all-false / default-preset defaults', () => {
+  test('an empty object yields the shipped defaults', () => {
+    // Vertical inverted, horizontal not: what a user who has never opened the
+    // setting gets.
     expect(parseNavigationPreferences({})).toEqual({
       invertOrbitX: false,
-      invertOrbitY: false,
+      invertOrbitY: true,
       preset: 'default',
     });
   });
@@ -39,10 +41,12 @@ describe('parseNavigationPreferences', () => {
     ).toEqual({ invertOrbitX: false, invertOrbitY: true, preset: 'nira' });
   });
 
-  test('a malformed boolean becomes false, not true', () => {
+  test('a malformed boolean falls back to that field default, not to false', () => {
+    // Both values are the wrong type, so each takes its own default rather than
+    // a blanket false: X defaults false, Y defaults true.
     expect(parseNavigationPreferences({ invertOrbitX: 1, invertOrbitY: 'true' })).toEqual({
       invertOrbitX: false,
-      invertOrbitY: false,
+      invertOrbitY: true,
       preset: 'default',
     });
   });
@@ -66,15 +70,21 @@ describe('parseNavigationPreferences', () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe('navPresetSigns', () => {
-  test('default maps to no inversion', () => {
-    expect(navPresetSigns('default')).toEqual({ invertOrbitX: false, invertOrbitY: false });
+  test('default inverts the vertical orbit, matching the shipped preferences', () => {
+    // The preset named default has to agree with DEFAULT_NAVIGATION_PREFERENCES,
+    // or selecting it would undo the shipped behaviour.
+    expect(navPresetSigns('default')).toEqual({ invertOrbitX: false, invertOrbitY: true });
+    expect(navPresetSigns('default')).toEqual({
+      invertOrbitX: DEFAULT_NAVIGATION_PREFERENCES.invertOrbitX,
+      invertOrbitY: DEFAULT_NAVIGATION_PREFERENCES.invertOrbitY,
+    });
   });
 
   test('recap inverts the vertical orbit only', () => {
     expect(navPresetSigns('recap')).toEqual({ invertOrbitX: false, invertOrbitY: true });
   });
 
-  test('nira matches the current convention (no inversion)', () => {
+  test('nira inverts neither axis, so it is the no-inversion preset', () => {
     expect(navPresetSigns('nira')).toEqual({ invertOrbitX: false, invertOrbitY: false });
   });
 });


### PR DESCRIPTION
Vertical orbit now inverts by default, so dragging down raises the viewpoint,
which is what Autodesk ReCap does.

The preset named default moves with it. A preset that undoes the shipped
behaviour is the one thing it must not do, so default and recap now select the
same signs and nira becomes the no-inversion choice.

parseNavigationPreferences falls back field by field, so a stored preference of
either sign is preserved and only a user who has never opened the setting sees
the change.

Two tests stated the old value in their names as well as their bodies, and one
pinned a literal where it meant a round trip; that one now asserts against
where it started, so it holds if this default ever moves again.
