### PR TITLE
Read streaming ancestry from parent identity, not octree keys

### DIFF
--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -86,7 +86,6 @@ import {
   type GpuDeviceLike,
 } from './gpuErrorLedger';
 import { computeExportFrontier, type FrontierNode } from './streaming/exportFrontier';
-import { keyFromId } from '../io/copc/voxelKey';
 import { intensityFilterUniform } from './intensityFilterUniform';
 import { isZUpFormat, sceneUpAxisPolicy } from '../io/sniffFormat';
 import { classifyScanShape } from '../terrain/scanShape';
@@ -3655,17 +3654,18 @@ export class Viewer {
     if (!s) return [];
     const entries = s.renderer.residentFrontierEntries();
     if (entries.length === 0) return [];
-    const frontierNodes: FrontierNode[] = [];
-    for (const e of entries) {
-      const key = keyFromId(e.id);
-      if (key) frontierNodes.push({ id: e.id, key, fadingOut: e.fadingOut });
-    }
-    const keep = computeExportFrontier(frontierNodes);
-    // An unparseable id can't be reasoned about; keep it rather than silently
-    // dropping its points. Parseable ids obey the frontier keep-set.
-    const parseable = new Set(frontierNodes.map((n) => n.id));
+    const store = s.cloud.octree.store;
+    const frontierNodes: FrontierNode[] = entries.map((e) => ({
+      id: e.id,
+      fadingOut: e.fadingOut,
+    }));
+    const parentOf = (id: string): string | undefined => store.get(id)?.record.parentId;
+    const keep = computeExportFrontier(frontierNodes, parentOf);
+    // A node the hierarchy no longer holds can't be reasoned about; keep it
+    // rather than silently dropping its points. A node it does hold obeys the
+    // frontier keep-set.
     return entries
-      .filter((e) => (parseable.has(e.id) ? keep.has(e.id) : true))
+      .filter((e) => (store.has(e.id) ? keep.has(e.id) : true))
       .map((e) => e.decoded);
   }
 

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -12,7 +12,12 @@
  * with a synthetic COPC and a fake decoder.
  */
 
-import type { Box6, VoxelKey } from '../../io/copc/copcTypes';
+import type { Box6 } from '../../io/copc/copcTypes';
+import {
+  forEachAncestorId,
+  parentLookupFromStore,
+  type ParentLookup,
+} from './streamingHierarchy';
 import { GpuUploadQueue } from '../gpuUploadQueue';
 import type { ChunkDecoder, DecodedChunk } from '../../io/copc/copcChunkDecode';
 import type { StreamingSource } from './StreamingSource';
@@ -256,37 +261,26 @@ export interface SchedulerOptions {
   now?: () => number;
 }
 
-/** Compact key for an ancestor-protection set — `${depth}/${x}/${y}/${z}`. */
-function voxelKeyString(k: VoxelKey): string {
-  return `${k.depth}/${k.x}/${k.y}/${k.z}`;
-}
-
 /**
- * The compact key of a voxel's parent, or `null` for the root. Children at
- * depth d collapse to their parent at depth d-1 by right-shifting each axis
- * coordinate — the COPC hierarchy is a regular octree.
+ * Build the set of *ancestor ids* of every resident node. A node whose own id
+ * appears in this set is a parent of at least one resident node, and it is
+ * protected from eviction until its descendants leave too.
+ *
+ * Ancestry comes from each record's `parentId`, not from shifting its voxel
+ * key. The two agree exactly on a regular octree, which is what COPC, EPT and
+ * the OLV tile store are; the difference is that a hierarchy which is not an
+ * octree still answers. The one behavioural distinction is that the key walk
+ * climbed to depth 0 through cells that may hold no node, while this one stops
+ * where the hierarchy stops. Only ids of nodes that exist are ever tested
+ * against the set, so the phantom entries the key walk added were never read.
  */
-function parentKeyString(k: VoxelKey): string | null {
-  if (k.depth === 0) return null;
-  return `${k.depth - 1}/${k.x >> 1}/${k.y >> 1}/${k.z >> 1}`;
-}
-
-/**
- * Build the set of *ancestor* keys of every resident node. A node whose own
- * key appears in this set is a parent of at least one resident node, and
- * it protects it from eviction until its descendants leave too.
- */
-function buildAncestorProtection(nodes: readonly StreamingNode[]): Set<string> {
+function buildAncestorProtection(
+  nodes: readonly StreamingNode[],
+  parentOf: ParentLookup,
+): Set<string> {
   const set = new Set<string>();
   for (const n of nodes) {
-    let { x, y, z } = n.record.key;
-    const depth = n.record.key.depth;
-    for (let d = depth - 1; d >= 0; d--) {
-      x >>= 1;
-      y >>= 1;
-      z >>= 1;
-      set.add(`${d}/${x}/${y}/${z}`);
-    }
+    forEachAncestorId(n.record.id, parentOf, (ancestorId) => set.add(ancestorId));
   }
   return set;
 }
@@ -318,22 +312,17 @@ function residentIdSet(store: { residentNodes(): IterableIterator<StreamingNode>
  */
 export function buildRefiningCandidateIds(
   scored: readonly { readonly node: StreamingNode; readonly candidate: ScoredCandidate }[],
+  parentOf: ParentLookup,
 ): Set<string> {
-  // key -> candidate id, so an ancestor walk can ask "is this ancestor itself a
-  // candidate?" without rebuilding ids per level.
-  const idByKey = new Map<string, string>();
-  for (const s of scored) idByKey.set(voxelKeyString(s.node.record.key), s.candidate.id);
+  // The candidate ids, so an ancestor walk can ask "is this ancestor itself a
+  // candidate?" without rescanning the list per level.
+  const candidateIds = new Set<string>();
+  for (const s of scored) candidateIds.add(s.candidate.id);
   const refining = new Set<string>();
   for (const s of scored) {
-    const key = s.node.record.key;
-    let { x, y, z } = key;
-    for (let d = key.depth - 1; d >= 0; d--) {
-      x >>= 1;
-      y >>= 1;
-      z >>= 1;
-      const ancestorId = idByKey.get(`${d}/${x}/${y}/${z}`);
-      if (ancestorId !== undefined) refining.add(ancestorId);
-    }
+    forEachAncestorId(s.node.record.id, parentOf, (ancestorId) => {
+      if (candidateIds.has(ancestorId)) refining.add(ancestorId);
+    });
   }
   return refining;
 }
@@ -344,22 +333,20 @@ export function buildRefiningCandidateIds(
  * these "still-wanted" siblings gets one extra window of grace, on the bet
  * that a flicker-orbit pulling one sibling will likely pull the others next.
  */
-function buildWantedParentKeys(
+function buildWantedParentIds(
   wanted: ReadonlySet<string>,
   cloud: StreamingSource,
 ): Set<string> {
   const set = new Set<string>();
   for (const id of wanted) {
-    const node = cloud.octree.store.get(id);
-    if (!node) continue;
-    const pk = parentKeyString(node.record.key);
-    if (pk !== null) set.add(pk);
+    const parentId = cloud.octree.store.get(id)?.record.parentId;
+    if (parentId !== undefined) set.add(parentId);
   }
   return set;
 }
 
 /**
- * The keys of every node that has finer detail arriving inside its subtree.
+ * The ids of every node that has finer detail arriving inside its subtree.
  *
  * A resident node is "refined away" when the level below it is on its way in:
  * either it has itself left the wanted set while a finer descendant stayed in
@@ -377,21 +364,22 @@ function buildWantedParentKeys(
  * the flag it is handed, and an ancestor walk that silently marked nothing
  * would leave the exemption inert while every unit test still passed.
  */
-export function buildRefinedAwayKeys(
+export function buildRefinedAwayIds(
   wanted: ReadonlySet<string>,
   cloud: StreamingSource,
 ): Set<string> {
   const store = cloud.octree.store;
-  // The wanted nodes, resolved once, plus their keys — the ancestor walk below
-  // needs to ask "is this ancestor itself wanted?" and a key set answers that
-  // without rebuilding an id per level.
+  const parentOf = parentLookupFromStore(store);
+  // The wanted nodes, resolved once. The ancestor walk below asks "is this
+  // ancestor itself wanted?", and only a wanted id that resolves to a node can
+  // ever be an ancestor, so the resolved ids are the set to test against.
   const wantedNodes: StreamingNode[] = [];
-  const wantedKeys = new Set<string>();
+  const wantedResolved = new Set<string>();
   for (const id of wanted) {
     const node = store.get(id);
     if (!node) continue;
     wantedNodes.push(node);
-    wantedKeys.add(voxelKeyString(node.record.key));
+    wantedResolved.add(node.record.id);
   }
 
   const set = new Set<string>();
@@ -400,14 +388,9 @@ export function buildRefinedAwayKeys(
     // those ancestors are what is holding the budget it needs. One that has
     // already arrived supersedes only the ancestors the selector has dropped.
     const pending = node.state !== 'resident';
-    let { x, y, z } = node.record.key;
-    for (let d = node.record.key.depth - 1; d >= 0; d--) {
-      x >>= 1;
-      y >>= 1;
-      z >>= 1;
-      const key = `${d}/${x}/${y}/${z}`;
-      if (pending || !wantedKeys.has(key)) set.add(key);
-    }
+    forEachAncestorId(node.record.id, parentOf, (ancestorId) => {
+      if (pending || !wantedResolved.has(ancestorId)) set.add(ancestorId);
+    });
   }
   return set;
 }
@@ -1010,7 +993,7 @@ export class StreamingScheduler {
         sticky
           ? {
               resident: residentIdSet(store),
-              refining: buildRefiningCandidateIds(freshScored),
+              refining: buildRefiningCandidateIds(freshScored, parentLookupFromStore(store)),
               stickyMargin: this._stickyMargin,
             }
           : {},
@@ -1053,10 +1036,10 @@ export class StreamingScheduler {
     // shares one consistent timestamp.
     const nowTs = wallNow;
     const residents = store.resident();
-    const protection = buildAncestorProtection(residents);
+    const protection = buildAncestorProtection(residents, parentLookupFromStore(store));
     // Sibling-retention bonus. Children of a wanted parent get a
     // retention bonus over orphan deferred nodes.
-    const wantedParentKeys = buildWantedParentKeys(wanted, this._cloud);
+    const wantedParentIds = buildWantedParentIds(wanted, this._cloud);
 
     for (const node of residents) {
       const id = node.record.id;
@@ -1094,7 +1077,7 @@ export class StreamingScheduler {
         this._deferredEvictAt.delete(id);
         continue;
       }
-      if (protection.has(voxelKeyString(node.record.key))) {
+      if (protection.has(node.record.id)) {
         // Parent of a resident — reschedule one window. The child eviction
         // on a later tick frees the parent for eviction *then*.
         //
@@ -1108,8 +1091,8 @@ export class StreamingScheduler {
         this._deferredEvictAt.set(id, nowTs + this._evictDeferMs);
         continue;
       }
-      const parentKey = parentKeyString(node.record.key);
-      if (parentKey !== null && wantedParentKeys.has(parentKey)) {
+      const parentId = node.record.parentId;
+      if (parentId !== undefined && wantedParentIds.has(parentId)) {
         // Sibling still wanted — keep it warm for one more window.
         this._deferredEvictAt.set(id, nowTs + this._evictDeferMs);
         continue;
@@ -1168,7 +1151,7 @@ export class StreamingScheduler {
       // The one input that costs a walk of the wanted set. Built here rather
       // than per tick, because this branch is the only reader and it is cold:
       // a settled camera inside the hysteresis band never pays for it.
-      const refinedAwayKeys = buildRefinedAwayKeys(wanted, this._cloud);
+      const refinedAwayIds = buildRefinedAwayIds(wanted, this._cloud);
       const candidates: EvictionCandidate[] = [];
       for (const node of store.residentNodes()) {
         const centre = boxCentre(this._localBoundsFor(node));
@@ -1182,7 +1165,7 @@ export class StreamingScheduler {
           // which is the same answer, because the camera has not moved.
           visible: node.score > 0,
           wanted: wanted.has(node.record.id),
-          supersededByFiner: refinedAwayKeys.has(voxelKeyString(node.record.key)),
+          supersededByFiner: refinedAwayIds.has(node.record.id),
           residentSinceMs: node.residentSinceMs,
         });
       }

--- a/src/render/streaming/exportFrontier.ts
+++ b/src/render/streaming/exportFrontier.ts
@@ -6,48 +6,73 @@
  * incoming children can both be resident, so a naive snapshot concatenates
  * overlapping LOD samples of the same region — the coarse parent points and the
  * finer child points together. This module computes the frontier to keep before
- * the snapshot is built: for each octree path keep the deepest resident node and
- * drop any ancestor that has a resident descendant, and exclude nodes that are
- * fading out (they are on their way off screen).
+ * the snapshot is built: for each hierarchy path keep the deepest resident node
+ * and drop any ancestor that has a resident descendant, and exclude nodes that
+ * are fading out (they are on their way off screen).
  *
  * The result is an antichain of the resident set — no kept node is an ancestor
  * of another kept node — so each region is represented once, at its finest
  * resident level, with no double sampling.
  *
- * Pure: octree-key math only (no DOM, no three.js, no GPU), so the frontier is
- * verifiable without a device. The renderer supplies `{ id, key, fadingOut }`
- * for each resident node; the caller keeps only the returned ids.
+ * Ancestry arrives as explicit parent identity rather than octree-key
+ * arithmetic, so a hierarchy that is not a regular octree answers the same
+ * question. A resident node's parent is frequently not itself resident, so the
+ * caller supplies a lookup over the whole hierarchy, not just the nodes passed
+ * in.
  *
- * Trade-off, stated explicitly: a parent is dropped when it has ANY resident
- * descendant, even if only some of its eight octants are covered by resident
- * children. In the streaming model children of a node load as a group and a
- * fully-refined parent is evicted (and thus fading out), so partial-coverage
+ * Pure: identity math only (no DOM, no three.js, no GPU), so the frontier is
+ * verifiable without a device. The renderer supplies `{ id, fadingOut }` for
+ * each resident node; the caller keeps only the returned ids.
+ *
+ * Trade-off, stated explicitly: a REPLACE parent is dropped when it has ANY
+ * resident descendant, even if only some of its children are covered by
+ * resident nodes. In the streaming model children of a node load as a group and
+ * a fully-refined parent is evicted (and thus fading out), so partial-coverage
  * parents are transient; dropping them removes duplicate coarse points rather
  * than creating gaps in the steady state. The alternative — keeping partially
  * covered parents — would reintroduce the very overlap this frontier exists to
  * remove.
+ *
+ * That trade-off is only sound where a child REPLACES its parent, which is what
+ * COPC, EPT and the OLV tile store all do. Under additive refinement a parent
+ * and its children are both part of the represented surface, so an additive
+ * node is never dropped for having a descendant. The mode travels with each
+ * node rather than with the source, because one hierarchy may mix the two.
  */
 
-import type { VoxelKey } from '../../io/copc/copcTypes';
-import { keyId, parentKey } from '../../io/copc/voxelKey';
+import type { ParentLookup } from './streamingHierarchy';
+import { forEachAncestorId } from './streamingHierarchy';
+
+/**
+ * How a node's children relate to it.
+ *
+ * `'replace'` — the children are a finer representation of the same region, so
+ * the parent is redundant once they are resident.
+ * `'add'` — the children are extra detail alongside the parent, so both belong
+ * in the snapshot.
+ */
+export type FrontierRefine = 'replace' | 'add';
 
 /** A resident node as the frontier needs it. */
 export interface FrontierNode {
-  /** The `"depth-x-y-z"` id (the resident map key). */
+  /** The node id (the resident map key). */
   readonly id: string;
-  /** The octree key, for ancestor/descendant reasoning. */
-  readonly key: VoxelKey;
   /** True while the node is animating out during a cross-fade. */
   readonly fadingOut?: boolean;
+  /** Defaults to `'replace'`, which is what every format shipped today uses. */
+  readonly refine?: FrontierRefine;
 }
 
 /**
  * Compute the set of node ids to keep for the export snapshot.
  *
- * A node is kept when it is not fading out AND no other non-fading resident node
- * is a strict descendant of it. Fading-out nodes are excluded entirely.
+ * A node is kept when it is not fading out AND it is not a replacing ancestor
+ * of another non-fading resident node.
  */
-export function computeExportFrontier(nodes: readonly FrontierNode[]): Set<string> {
+export function computeExportFrontier(
+  nodes: readonly FrontierNode[],
+  parentOf: ParentLookup,
+): Set<string> {
   // Candidates: everything not on its way out. A fading-out node is leaving the
   // scene, so it should not contribute to a stable export.
   const candidates = nodes.filter((n) => n.fadingOut !== true);
@@ -57,16 +82,13 @@ export function computeExportFrontier(nodes: readonly FrontierNode[]): Set<strin
   // ancestor to drop. Climbing to the root is O(depth) per node.
   const ancestorsOfResident = new Set<string>();
   for (const node of candidates) {
-    let parent = parentKey(node.key);
-    while (parent) {
-      ancestorsOfResident.add(keyId(parent));
-      parent = parentKey(parent);
-    }
+    forEachAncestorId(node.id, parentOf, (ancestorId) => ancestorsOfResident.add(ancestorId));
   }
 
   const keep = new Set<string>();
   for (const node of candidates) {
-    if (!ancestorsOfResident.has(node.id)) keep.add(node.id);
+    if (node.refine === 'add') keep.add(node.id);
+    else if (!ancestorsOfResident.has(node.id)) keep.add(node.id);
   }
   return keep;
 }

--- a/src/render/streaming/streamingHierarchy.ts
+++ b/src/render/streaming/streamingHierarchy.ts
@@ -60,8 +60,8 @@ export function forEachAncestorId(
 /**
  * A {@link ParentLookup} backed by a streaming node store.
  *
- * Kept here rather than inlined at each call site so the scheduler holds one
- * closure per tick instead of one per walk.
+ * Kept here rather than inlined at each call site so a caller holds one closure
+ * for a whole pass over the nodes instead of one per walk.
  */
 export function parentLookupFromStore(store: {
   get(id: string): { readonly record: { readonly parentId?: string } } | undefined;

--- a/src/render/streaming/streamingHierarchy.ts
+++ b/src/render/streaming/streamingHierarchy.ts
@@ -1,0 +1,70 @@
+/**
+ * streamingHierarchy.ts
+ *
+ * Ancestry over explicit parent identity, for every streaming format.
+ *
+ * The scheduler used to reconstruct a node's ancestors by right-shifting its
+ * `VoxelKey` axes, which is exact for a regular octree and meaningless for any
+ * hierarchy that is not one. COPC, EPT and the OLV tile store already record
+ * `parentId` on every node record and link `childIds` on the runtime node, so
+ * the relationship the scheduler needs is present without deriving it from
+ * coordinates. This module is that walk.
+ *
+ * The walk is allocation-free per node: no set, no array, no closure state
+ * beyond the two locals below. The scheduler runs it over every candidate and
+ * every resident node on a tick, so anything it allocates is allocated
+ * thousands of times a second.
+ *
+ * A malformed hierarchy can name a parent that is its own descendant. The step
+ * ceiling below terminates such a walk. It is a backstop against hostile or
+ * corrupt input, not a limit on how deep a real hierarchy may be: COPC and EPT
+ * octrees bottom out around depth 20, and the ceiling sits an order of
+ * magnitude above that.
+ *
+ * Pure — no DOM, no three.js, no I/O.
+ */
+
+/** A node's parent id, or `undefined` at a root or for an unknown node. */
+export type ParentLookup = (id: string) => string | undefined;
+
+/**
+ * Steps a single ancestor walk may take before it stops.
+ *
+ * Reached only by a cycle or by a hierarchy deeper than any format OLV reads.
+ * A walk that hits it stops early rather than throwing: the sets these walks
+ * build are protection and refinement hints, and the safe answer for a
+ * hierarchy this deep is to protect fewer nodes, never to fail a frame.
+ */
+export const MAX_ANCESTOR_STEPS = 256;
+
+/**
+ * Visit every ancestor id of `id`, nearest parent first, up to the root.
+ *
+ * The node itself is not visited. Stops at the first id with no recorded
+ * parent, which is how a partially loaded hierarchy terminates: an EPT page
+ * that has not arrived yet leaves its subtree unreachable, and the walk ends
+ * there rather than inventing the ids above it.
+ */
+export function forEachAncestorId(
+  id: string,
+  parentOf: ParentLookup,
+  visit: (ancestorId: string) => void,
+): void {
+  let current = parentOf(id);
+  for (let steps = 0; current !== undefined && steps < MAX_ANCESTOR_STEPS; steps++) {
+    visit(current);
+    current = parentOf(current);
+  }
+}
+
+/**
+ * A {@link ParentLookup} backed by a streaming node store.
+ *
+ * Kept here rather than inlined at each call site so the scheduler holds one
+ * closure per tick instead of one per walk.
+ */
+export function parentLookupFromStore(store: {
+  get(id: string): { readonly record: { readonly parentId?: string } } | undefined;
+}): ParentLookup {
+  return (id) => store.get(id)?.record.parentId;
+}

--- a/tests/exportFrontier.test.ts
+++ b/tests/exportFrontier.test.ts
@@ -2,10 +2,16 @@
  * exportFrontier.test.ts
  *
  * Pins the deterministic export frontier (v0.5.7 Gate 5): keep the deepest
- * resident node per octree path, drop ancestors that have a resident descendant,
- * and exclude fading-out nodes — so a resident-snapshot export never carries
- * overlapping LOD samples of the same region. Also covers the `keyFromId`
- * parser the wiring uses to turn a resident map id back into a key.
+ * resident node per hierarchy path, drop ancestors that have a resident
+ * descendant, and exclude fading-out nodes — so a resident-snapshot export never
+ * carries overlapping LOD samples of the same region. Also covers the
+ * `keyFromId` parser, which the octree formats still use to name their nodes.
+ *
+ * Every octree case below is unchanged from when the frontier derived ancestry
+ * by shifting a `VoxelKey`. It now takes an explicit parent lookup instead, and
+ * these are the fixtures that prove the two agree: the lookup here IS the octree
+ * shift, so any keep-set that moved would be a regression rather than a
+ * generalization.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -14,25 +20,31 @@ import { keyId, keyFromId } from '../src/io/copc/voxelKey';
 import type { VoxelKey } from '../src/io/copc/copcTypes';
 
 function node(depth: number, x: number, y: number, z: number, fadingOut = false): FrontierNode {
-  const key: VoxelKey = { depth, x, y, z };
-  return { id: keyId(key), key, fadingOut };
+  return { id: keyId({ depth, x, y, z }), fadingOut };
+}
+
+/** The octree parent of an id, which is what the frontier used to derive itself. */
+function octreeParentOf(id: string): string | undefined {
+  const k = keyFromId(id);
+  if (!k || k.depth === 0) return undefined;
+  return keyId({ depth: k.depth - 1, x: k.x >> 1, y: k.y >> 1, z: k.z >> 1 });
 }
 
 describe('computeExportFrontier', () => {
   it('keeps a lone resident node', () => {
-    const keep = computeExportFrontier([node(0, 0, 0, 0)]);
+    const keep = computeExportFrontier([node(0, 0, 0, 0)], octreeParentOf);
     expect([...keep]).toEqual(['0-0-0-0']);
   });
 
   it('drops a parent when one child is resident, keeping the child', () => {
     // root (0-0-0-0) and its first child (1-0-0-0) both resident.
-    const keep = computeExportFrontier([node(0, 0, 0, 0), node(1, 0, 0, 0)]);
+    const keep = computeExportFrontier([node(0, 0, 0, 0), node(1, 0, 0, 0)], octreeParentOf);
     expect(keep.has('1-0-0-0')).toBe(true);
     expect(keep.has('0-0-0-0')).toBe(false);
   });
 
   it('keeps both siblings when the parent is not resident', () => {
-    const keep = computeExportFrontier([node(1, 0, 0, 0), node(1, 1, 0, 0)]);
+    const keep = computeExportFrontier([node(1, 0, 0, 0), node(1, 1, 0, 0)], octreeParentOf);
     expect([...keep].sort()).toEqual(['1-0-0-0', '1-1-0-0']);
   });
 
@@ -41,12 +53,12 @@ describe('computeExportFrontier', () => {
       node(0, 0, 0, 0),
       node(1, 0, 0, 0),
       node(2, 0, 0, 0),
-    ]);
+    ], octreeParentOf);
     expect([...keep]).toEqual(['2-0-0-0']);
   });
 
   it('excludes a fading-out node entirely', () => {
-    const keep = computeExportFrontier([node(2, 3, 1, 0, /* fadingOut */ true)]);
+    const keep = computeExportFrontier([node(2, 3, 1, 0, /* fadingOut */ true)], octreeParentOf);
     expect(keep.size).toBe(0);
   });
 
@@ -56,7 +68,7 @@ describe('computeExportFrontier', () => {
       node(0, 0, 0, 0, /* fadingOut */ true),
       node(1, 0, 0, 0),
       node(1, 1, 0, 0),
-    ]);
+    ], octreeParentOf);
     expect([...keep].sort()).toEqual(['1-0-0-0', '1-1-0-0']);
     expect(keep.has('0-0-0-0')).toBe(false);
   });
@@ -66,7 +78,7 @@ describe('computeExportFrontier', () => {
     const keep = computeExportFrontier([
       node(0, 0, 0, 0),
       node(1, 0, 0, 0, /* fadingOut */ true),
-    ]);
+    ], octreeParentOf);
     expect([...keep]).toEqual(['0-0-0-0']);
   });
 
@@ -75,7 +87,7 @@ describe('computeExportFrontier', () => {
       node(1, 0, 0, 0),
       node(3, 7, 7, 7),
       node(2, 2, 1, 0),
-    ]);
+    ], octreeParentOf);
     expect(keep.size).toBe(3);
   });
 
@@ -86,7 +98,7 @@ describe('computeExportFrontier', () => {
       node(1, 1, 1, 1),
       node(2, 0, 0, 0),
       node(2, 2, 2, 2),
-    ]);
+    ], octreeParentOf);
     const kept = [...keep].map((id) => keyFromId(id)!);
     for (const a of kept) {
       for (const b of kept) {
@@ -116,5 +128,88 @@ describe('keyFromId', () => {
     expect(keyFromId('a-b-c-d')).toBeNull();
     expect(keyFromId('1--1-0-0')).toBeNull();
     expect(keyFromId('0-0-0-0')).toEqual({ depth: 0, x: 0, y: 0, z: 0 });
+  });
+});
+
+describe('computeExportFrontier over a hierarchy that is not an octree', () => {
+  /**
+   * The irregular tree the 3D Tiles adapter produces: mixed child counts, mixed
+   * depths, ids that carry no coordinate at all.
+   *
+   *   root
+   *    ├─ A ─ A1
+   *    ├─ B ─ B1, B2, B3
+   *    └─ C
+   */
+  const PARENTS: Record<string, string | undefined> = {
+    root: undefined,
+    A: 'root', A1: 'A',
+    B: 'root', B1: 'B', B2: 'B', B3: 'B',
+    C: 'root',
+  };
+  const parentOf = (id: string): string | undefined => PARENTS[id];
+
+  it('drops an ancestor with a resident descendant and keeps unrefined siblings', () => {
+    const keep = computeExportFrontier(
+      [{ id: 'root' }, { id: 'A' }, { id: 'A1' }, { id: 'C' }],
+      parentOf,
+    );
+    expect([...keep].sort()).toEqual(['A1', 'C']);
+  });
+
+  it('keeps every child of a node with three children', () => {
+    const keep = computeExportFrontier(
+      [{ id: 'B' }, { id: 'B1' }, { id: 'B2' }, { id: 'B3' }],
+      parentOf,
+    );
+    expect([...keep].sort()).toEqual(['B1', 'B2', 'B3']);
+  });
+
+  it('keeps a node whose parent is not in the hierarchy at all', () => {
+    const keep = computeExportFrontier([{ id: 'orphan' }], () => undefined);
+    expect([...keep]).toEqual(['orphan']);
+  });
+});
+
+describe('computeExportFrontier under additive refinement', () => {
+  const parentOf = (id: string): string | undefined =>
+    ({ child: 'parent', grandchild: 'child' })[id];
+
+  it('keeps an additive parent alongside its resident child', () => {
+    const keep = computeExportFrontier(
+      [{ id: 'parent', refine: 'add' }, { id: 'child' }],
+      parentOf,
+    );
+    expect([...keep].sort()).toEqual(['child', 'parent']);
+  });
+
+  it('still drops a replacing parent, so the default is unchanged', () => {
+    const keep = computeExportFrontier(
+      [{ id: 'parent', refine: 'replace' }, { id: 'child' }],
+      parentOf,
+    );
+    expect([...keep]).toEqual(['child']);
+  });
+
+  it('an additive node still drops its own replacing ancestor', () => {
+    // `child` is additive, so it is kept; it is also a descendant of `parent`,
+    // which replaces, so `parent` goes.
+    const keep = computeExportFrontier(
+      [{ id: 'parent' }, { id: 'child', refine: 'add' }, { id: 'grandchild' }],
+      parentOf,
+    );
+    expect([...keep].sort()).toEqual(['child', 'grandchild']);
+  });
+});
+
+describe('computeExportFrontier on a malformed hierarchy', () => {
+  it('terminates on a parent cycle rather than hanging', () => {
+    // A names B as its parent and B names A. A real tileset cannot produce
+    // this; a hostile or corrupt one can.
+    const parentOf = (id: string): string | undefined => (id === 'A' ? 'B' : 'A');
+    const keep = computeExportFrontier([{ id: 'A' }, { id: 'B' }], parentOf);
+    // Each is an ancestor of the other, so neither survives. The property under
+    // test is that the call returns.
+    expect(keep.size).toBe(0);
   });
 });

--- a/tests/residentStickiness.test.ts
+++ b/tests/residentStickiness.test.ts
@@ -17,6 +17,18 @@ import { selectWithinBudget } from '../src/render/streaming/streamingBudget';
 import type { StreamingNode } from '../src/render/streaming/StreamingNode';
 import type { ScoredCandidate } from '../src/render/streaming/streamingBudget';
 
+/**
+ * The octree parent of a `depth/x/y/z` id — the relationship the scheduler used
+ * to derive by shifting the key, supplied explicitly now that it reads ancestry
+ * from parent identity. Every expectation below is unchanged, which is what
+ * makes these the fixtures that prove the two agree on an octree.
+ */
+function octreeParentOf(id: string): string | undefined {
+  const [depth, x, y, z] = id.split('/').map(Number);
+  if (depth === 0) return undefined;
+  return `${depth - 1}/${x >> 1}/${y >> 1}/${z >> 1}`;
+}
+
 /** A candidate at an octree key, with the shape the scheduler passes. */
 function cand(
   depth: number, x: number, y: number, z: number, score: number, pointCount = 100,
@@ -31,14 +43,14 @@ function cand(
 describe('buildRefiningCandidateIds — the LOD-freeze guard', () => {
   it('marks a parent whose CHILD is also a candidate', () => {
     const scored = [cand(0, 0, 0, 0, 10), cand(1, 0, 0, 0, 9)];
-    const refining = buildRefiningCandidateIds(scored);
+    const refining = buildRefiningCandidateIds(scored, octreeParentOf);
     expect(refining.has('0/0/0/0')).toBe(true);   // the parent is being refined away
     expect(refining.has('1/0/0/0')).toBe(false);  // the child is the refinement
   });
 
   it('marks EVERY ancestor in the chain, not just the immediate parent', () => {
     const scored = [cand(0, 0, 0, 0, 10), cand(1, 0, 0, 0, 9), cand(2, 0, 0, 0, 8)];
-    const refining = buildRefiningCandidateIds(scored);
+    const refining = buildRefiningCandidateIds(scored, octreeParentOf);
     expect(refining.has('0/0/0/0')).toBe(true);
     expect(refining.has('1/0/0/0')).toBe(true);
     expect(refining.has('2/0/0/0')).toBe(false);
@@ -46,7 +58,7 @@ describe('buildRefiningCandidateIds — the LOD-freeze guard', () => {
 
   it('marks nothing when candidates are siblings with no descendant among them', () => {
     const scored = [cand(1, 0, 0, 0, 10), cand(1, 1, 0, 0, 9), cand(1, 0, 1, 0, 8)];
-    expect(buildRefiningCandidateIds(scored).size).toBe(0);
+    expect(buildRefiningCandidateIds(scored, octreeParentOf).size).toBe(0);
   });
 
   it('does not mark a parent whose candidate descendant is in a DIFFERENT subtree', () => {
@@ -54,13 +66,13 @@ describe('buildRefiningCandidateIds — the LOD-freeze guard', () => {
     // only true ancestor chain is by bit-shift, so an unrelated deep node in
     // another octant must not exempt a coarse node it does not refine.
     const scored = [cand(1, 0, 0, 0, 10), cand(2, 2, 0, 0, 9)];
-    const refining = buildRefiningCandidateIds(scored);
+    const refining = buildRefiningCandidateIds(scored, octreeParentOf);
     // 2/2/0/0 shifts to 1/1/0/0, which is NOT a candidate, so nothing is marked.
     expect(refining.size).toBe(0);
   });
 
   it('an empty candidate list marks nothing and does not throw', () => {
-    expect(buildRefiningCandidateIds([]).size).toBe(0);
+    expect(buildRefiningCandidateIds([], octreeParentOf).size).toBe(0);
   });
 });
 
@@ -95,7 +107,7 @@ describe('resident stickiness composed with the exemption', () => {
     // would overtake it with stickiness (1.00 x 1.15 = 1.15 > 1.05). The
     // exemption must strip that bonus because the child is right here.
     const scored = [cand(0, 0, 0, 0, 1.0), cand(1, 0, 0, 0, 1.05)];
-    const refining = buildRefiningCandidateIds(scored);
+    const refining = buildRefiningCandidateIds(scored, octreeParentOf);
     const picked = selectWithinBudget(
       scored.map((s) => s.candidate),
       budget,
@@ -120,7 +132,7 @@ describe('resident stickiness composed with the exemption', () => {
     // Same shape as above, but the child is NOT a candidate this tick, so the
     // parent is not refinement's target and stickiness legitimately applies.
     const scored = [cand(0, 0, 0, 0, 1.0), cand(1, 5, 5, 5, 1.05)];
-    const refining = buildRefiningCandidateIds(scored);
+    const refining = buildRefiningCandidateIds(scored, octreeParentOf);
     expect(refining.size).toBe(0);
     const picked = selectWithinBudget(
       scored.map((s) => s.candidate),

--- a/tests/streamingEvictionHysteresis.test.ts
+++ b/tests/streamingEvictionHysteresis.test.ts
@@ -17,7 +17,7 @@
 import { describe, test, expect } from 'vitest';
 import {
   StreamingScheduler,
-  buildRefinedAwayKeys,
+  buildRefinedAwayIds,
 } from '../src/render/streaming/StreamingScheduler';
 import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
 import { streamingBudgets } from '../src/render/streaming/streamingBudget';
@@ -121,7 +121,7 @@ const VIEW_B = windowViewProjection(CAM_B, HALF * 0.47);
 
 // --- The seam: does the scheduler actually compute the refined-away flag? ----
 
-describe('buildRefinedAwayKeys marks the nodes finer detail is arriving under', () => {
+describe('buildRefinedAwayIds marks the nodes finer detail is arriving under', () => {
   test('marks every ancestor of a wanted node that has not arrived yet', async () => {
     const cloud = await openTwoRegionCloud();
     const store = cloud.octree.store;
@@ -133,11 +133,11 @@ describe('buildRefinedAwayKeys marks the nodes finer detail is arriving under', 
       expect(node).toBeDefined();
       store.setState(node as StreamingNode, 'resident', 400);
     }
-    const keys = buildRefinedAwayKeys(wanted, cloud);
-    expect(keys.has('0/0/0/0')).toBe(true);
-    expect(keys.has('1/0/0/0')).toBe(true);
+    const ids = buildRefinedAwayIds(wanted, cloud);
+    expect(ids.has('0-0-0-0')).toBe(true);
+    expect(ids.has('1-0-0-0')).toBe(true);
     // Region B is untouched — nothing is arriving under it.
-    expect(keys.has('1/1/0/0')).toBe(false);
+    expect(ids.has('1-1-0-0')).toBe(false);
   });
 
   test('marks nothing once every wanted node has arrived', async () => {
@@ -150,7 +150,7 @@ describe('buildRefinedAwayKeys marks the nodes finer detail is arriving under', 
     }
     // Fully refined and fully resident: no node is being replaced, so the
     // exemption must not fire and hysteresis holds normally.
-    expect(buildRefinedAwayKeys(wanted, cloud).size).toBe(0);
+    expect(buildRefinedAwayIds(wanted, cloud).size).toBe(0);
   });
 
   test('marks an ancestor the selector dropped while a finer node stayed', async () => {
@@ -163,11 +163,11 @@ describe('buildRefinedAwayKeys marks the nodes finer detail is arriving under', 
     for (const id of ['0-0-0-0', '1-0-0-0', '2-0-0-0']) {
       store.setState(store.get(id) as StreamingNode, 'resident', 400);
     }
-    const keys = buildRefinedAwayKeys(wanted, cloud);
-    expect(keys.has('1/0/0/0')).toBe(true);
+    const ids = buildRefinedAwayIds(wanted, cloud);
+    expect(ids.has('1-0-0-0')).toBe(true);
     // The root is still wanted and its wanted descendant has arrived, so it is
     // not being replaced by anything.
-    expect(keys.has('0/0/0/0')).toBe(false);
+    expect(ids.has('0-0-0-0')).toBe(false);
   });
 });
 

--- a/tests/streamingHierarchyGeneric.test.ts
+++ b/tests/streamingHierarchyGeneric.test.ts
@@ -1,0 +1,352 @@
+/**
+ * streamingHierarchyGeneric.test.ts
+ *
+ * The scheduler reads ancestry from each node's recorded `parentId` instead of
+ * shifting its `VoxelKey`. Every hierarchy OLV streams today is a regular
+ * octree, so the two answers must be identical; a hierarchy that is not an
+ * octree has no key to shift, which is why the change was made.
+ *
+ * This file is both halves of that claim. The first suite runs the octree-key
+ * walk the scheduler used to perform, side by side with the shipped one, over
+ * real COPC hierarchies, and asserts the sets match exactly. The second builds
+ * an irregular tree with ids that carry no coordinate and shows the same
+ * helpers answer over it.
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  buildRefinedAwayIds,
+  buildRefiningCandidateIds,
+} from '../src/render/streaming/StreamingScheduler';
+import {
+  forEachAncestorId,
+  parentLookupFromStore,
+  MAX_ANCESTOR_STEPS,
+} from '../src/render/streaming/streamingHierarchy';
+import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
+import { StreamingNodeStore } from '../src/render/streaming/StreamingNodeStore';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import { buildSyntheticCopc } from './fixtures/copc/synthCopc';
+import type { StreamingNode } from '../src/render/streaming/StreamingNode';
+import type { StreamingSource } from '../src/render/streaming/StreamingSource';
+import type { VoxelKey, Box6 } from '../src/io/copc/copcTypes';
+
+// --- The reference implementation: the walk that shipped through v0.6.6 ------
+
+/** `${depth}/${x}/${y}/${z}` — the key namespace the scheduler used to use. */
+function voxelKeyString(k: VoxelKey): string {
+  return `${k.depth}/${k.x}/${k.y}/${k.z}`;
+}
+
+/** Ancestor KEYS of every node, by right-shifting each axis. */
+function legacyAncestorProtection(nodes: readonly StreamingNode[]): Set<string> {
+  const set = new Set<string>();
+  for (const n of nodes) {
+    let { x, y, z } = n.record.key;
+    for (let d = n.record.key.depth - 1; d >= 0; d--) {
+      x >>= 1; y >>= 1; z >>= 1;
+      set.add(`${d}/${x}/${y}/${z}`);
+    }
+  }
+  return set;
+}
+
+/** Candidate ids that a finer candidate sits underneath, by key shift. */
+function legacyRefiningCandidateIds(
+  scored: readonly { readonly node: StreamingNode; readonly candidate: { id: string } }[],
+): Set<string> {
+  const idByKey = new Map<string, string>();
+  for (const s of scored) idByKey.set(voxelKeyString(s.node.record.key), s.candidate.id);
+  const refining = new Set<string>();
+  for (const s of scored) {
+    let { x, y, z } = s.node.record.key;
+    for (let d = s.node.record.key.depth - 1; d >= 0; d--) {
+      x >>= 1; y >>= 1; z >>= 1;
+      const ancestorId = idByKey.get(`${d}/${x}/${y}/${z}`);
+      if (ancestorId !== undefined) refining.add(ancestorId);
+    }
+  }
+  return refining;
+}
+
+/** Refined-away KEYS, by key shift. */
+function legacyRefinedAwayKeys(
+  wanted: ReadonlySet<string>,
+  store: { get(id: string): StreamingNode | undefined },
+): Set<string> {
+  const wantedNodes: StreamingNode[] = [];
+  const wantedKeys = new Set<string>();
+  for (const id of wanted) {
+    const node = store.get(id);
+    if (!node) continue;
+    wantedNodes.push(node);
+    wantedKeys.add(voxelKeyString(node.record.key));
+  }
+  const set = new Set<string>();
+  for (const node of wantedNodes) {
+    const pending = node.state !== 'resident';
+    let { x, y, z } = node.record.key;
+    for (let d = node.record.key.depth - 1; d >= 0; d--) {
+      x >>= 1; y >>= 1; z >>= 1;
+      const key = `${d}/${x}/${y}/${z}`;
+      if (pending || !wantedKeys.has(key)) set.add(key);
+    }
+  }
+  return set;
+}
+
+/**
+ * A key set and an id set name the same nodes when, restricted to nodes the
+ * hierarchy actually holds, they agree.
+ *
+ * The restriction is the one real difference between the two walks and it is
+ * unobservable: the key walk climbed to depth 0 through cells that may hold no
+ * node, and every consumer only ever tests the id or key of a node that exists.
+ */
+function sameNodes(
+  keySet: ReadonlySet<string>,
+  idSet: ReadonlySet<string>,
+  nodes: readonly StreamingNode[],
+): void {
+  const viaKeys = nodes
+    .filter((n) => keySet.has(voxelKeyString(n.record.key)))
+    .map((n) => n.record.id)
+    .sort();
+  const viaIds = nodes.filter((n) => idSet.has(n.record.id)).map((n) => n.record.id).sort();
+  expect(viaIds).toEqual(viaKeys);
+}
+
+// --- Fixtures ----------------------------------------------------------------
+
+const HALF = 128;
+
+/** A full three-level octree: every node of depth 0-2 under one root. */
+async function openDenseCloud(): Promise<StreamingPointCloud> {
+  const nodes: { key: [number, number, number, number]; pointCount: number }[] = [
+    { key: [0, 0, 0, 0], pointCount: 400 },
+  ];
+  for (let x = 0; x < 2; x++)
+    for (let y = 0; y < 2; y++)
+      for (let z = 0; z < 2; z++) nodes.push({ key: [1, x, y, z], pointCount: 300 });
+  for (let x = 0; x < 4; x++)
+    for (let y = 0; y < 2; y++) nodes.push({ key: [2, x, y, 0], pointCount: 200 });
+  const fixture = buildSyntheticCopc({ center: [0, 0, 0], halfsize: HALF, nodes });
+  return StreamingPointCloud.open(new ArrayBufferRangeSource(fixture.buffer), 'dense.copc.laz');
+}
+
+/** A sparse, lopsided octree: one deep branch, one shallow, one unrefined. */
+async function openSparseCloud(): Promise<StreamingPointCloud> {
+  const fixture = buildSyntheticCopc({
+    center: [0, 0, 0],
+    halfsize: HALF,
+    nodes: [
+      { key: [0, 0, 0, 0], pointCount: 400 },
+      { key: [1, 0, 0, 0], pointCount: 400 },
+      { key: [2, 0, 0, 0], pointCount: 400 },
+      { key: [3, 0, 0, 0], pointCount: 400 },
+      { key: [3, 1, 0, 0], pointCount: 400 },
+      { key: [1, 1, 1, 1], pointCount: 400 },
+      { key: [2, 3, 3, 3], pointCount: 400 },
+      { key: [1, 0, 1, 0], pointCount: 400 },
+    ],
+  });
+  return StreamingPointCloud.open(new ArrayBufferRangeSource(fixture.buffer), 'sparse.copc.laz');
+}
+
+/** Every non-empty subset of `items`, capped so the suite stays quick. */
+function subsets<T>(items: readonly T[], limit: number): T[][] {
+  const out: T[][] = [];
+  const total = 1 << items.length;
+  for (let mask = 1; mask < total && out.length < limit; mask++) {
+    const pick: T[] = [];
+    for (let i = 0; i < items.length; i++) if (mask & (1 << i)) pick.push(items[i]);
+    out.push(pick);
+  }
+  return out;
+}
+
+// --- Suite 1: the octree formats answer exactly as they did ------------------
+
+describe('generic ancestry agrees with the octree-key walk it replaced', () => {
+  for (const [label, open] of [
+    ['a dense three-level octree', openDenseCloud],
+    ['a sparse lopsided octree', openSparseCloud],
+  ] as const) {
+    test(`ancestor protection over every resident subset of ${label}`, async () => {
+      const cloud = await open();
+      const all = cloud.octree.store.all();
+      const parentOf = parentLookupFromStore(cloud.octree.store);
+      for (const residents of subsets(all, 400)) {
+        const legacy = legacyAncestorProtection(residents);
+        const generic = new Set<string>();
+        for (const n of residents) {
+          forEachAncestorId(n.record.id, parentOf, (id) => generic.add(id));
+        }
+        sameNodes(legacy, generic, all);
+      }
+    });
+
+    test(`refining-candidate marks over every candidate subset of ${label}`, async () => {
+      const cloud = await open();
+      const all = cloud.octree.store.all();
+      const parentOf = parentLookupFromStore(cloud.octree.store);
+      for (const pick of subsets(all, 400)) {
+        const scored = pick.map((node) => ({ node, candidate: { id: node.record.id, pointCount: 100, score: 1 } }));
+        expect([...buildRefiningCandidateIds(scored, parentOf)].sort())
+          .toEqual([...legacyRefiningCandidateIds(scored)].sort());
+      }
+    });
+
+    test(`refined-away marks over every wanted subset of ${label}`, async () => {
+      const cloud = await open();
+      const store = cloud.octree.store;
+      const all = store.all();
+      // Half the nodes resident, so both the pending and the arrived branch run.
+      for (let i = 0; i < all.length; i += 2) store.setState(all[i], 'resident', 100);
+      for (const pick of subsets(all, 400)) {
+        const wanted = new Set(pick.map((n) => n.record.id));
+        const generic = buildRefinedAwayIds(wanted, cloud as unknown as StreamingSource);
+        sameNodes(legacyRefinedAwayKeys(wanted, store), generic, all);
+      }
+    });
+
+    test(`wanted-parent marks over every wanted subset of ${label}`, async () => {
+      const cloud = await open();
+      const store = cloud.octree.store;
+      const all = store.all();
+      for (const pick of subsets(all, 400)) {
+        const legacy = new Set<string>();
+        for (const n of pick) {
+          const k = n.record.key;
+          if (k.depth > 0) legacy.add(`${k.depth - 1}/${k.x >> 1}/${k.y >> 1}/${k.z >> 1}`);
+        }
+        const generic = new Set<string>();
+        for (const n of pick) {
+          const parentId = store.get(n.record.id)?.record.parentId;
+          if (parentId !== undefined) generic.add(parentId);
+        }
+        sameNodes(legacy, generic, all);
+      }
+    });
+  }
+});
+
+// --- Suite 2: a hierarchy with no coordinates at all -------------------------
+
+/**
+ * The irregular tree a 3D Tiles adapter produces — mixed child counts, mixed
+ * depths, ids that are opaque strings.
+ *
+ *   root
+ *    ├─ A ─ A1
+ *    ├─ B ─ B1, B2, B3
+ *    └─ C
+ */
+const IRREGULAR: readonly (readonly [string, string | undefined])[] = [
+  ['root', undefined],
+  ['A', 'root'], ['A1', 'A'],
+  ['B', 'root'], ['B1', 'B'], ['B2', 'B'], ['B3', 'B'],
+  ['C', 'root'],
+];
+
+function irregularStore(): StreamingNodeStore {
+  const store = new StreamingNodeStore();
+  const bounds: Box6 = [0, 0, 0, 1, 1, 1];
+  for (const [id, parentId] of IRREGULAR) {
+    store.add({
+      id,
+      // The key is format-specific and meaningless here; nothing reads it.
+      key: { depth: 0, x: 0, y: 0, z: 0 },
+      bounds,
+      pointCount: 100,
+      byteOffset: 0,
+      byteSize: 0,
+      spacing: 1,
+      parentId,
+    });
+  }
+  return store;
+}
+
+describe('ancestry over a hierarchy that is not an octree', () => {
+  test('walks the recorded chain, nearest parent first', () => {
+    const parentOf = parentLookupFromStore(irregularStore());
+    const seen: string[] = [];
+    forEachAncestorId('B2', parentOf, (id) => seen.push(id));
+    expect(seen).toEqual(['B', 'root']);
+  });
+
+  test('a root has no ancestors', () => {
+    const parentOf = parentLookupFromStore(irregularStore());
+    const seen: string[] = [];
+    forEachAncestorId('root', parentOf, (id) => seen.push(id));
+    expect(seen).toEqual([]);
+  });
+
+  test('marks a candidate parent whose child is also a candidate, at any arity', () => {
+    const store = irregularStore();
+    const parentOf = parentLookupFromStore(store);
+    const scored = ['root', 'B', 'B1', 'B3', 'C'].map((id) => ({
+      node: store.get(id) as StreamingNode,
+      candidate: { id, pointCount: 100, score: 1 },
+    }));
+    const refining = buildRefiningCandidateIds(scored, parentOf);
+    // `root` is refined by B and C; `B` is refined by B1 and B3.
+    expect([...refining].sort()).toEqual(['B', 'root']);
+  });
+
+  test('does not mark a candidate whose descendants are in another branch', () => {
+    const store = irregularStore();
+    const parentOf = parentLookupFromStore(store);
+    const scored = ['A', 'B1'].map((id) => ({
+      node: store.get(id) as StreamingNode,
+      candidate: { id, pointCount: 100, score: 1 },
+    }));
+    // B1's chain is B then root; neither A nor B is refined by the other.
+    expect(buildRefiningCandidateIds(scored, parentOf).size).toBe(0);
+  });
+
+  test('refined-away marks the ancestors of a wanted node still on its way in', () => {
+    const store = irregularStore();
+    for (const id of ['root', 'B']) store.setState(store.get(id) as StreamingNode, 'resident', 100);
+    const cloud = { octree: { store } } as unknown as StreamingSource;
+    const ids = buildRefinedAwayIds(new Set(['root', 'B', 'B2']), cloud);
+    expect(ids.has('root')).toBe(true);
+    expect(ids.has('B')).toBe(true);
+    expect(ids.has('A')).toBe(false);
+  });
+});
+
+// --- Suite 3: malformed input ------------------------------------------------
+
+describe('a malformed hierarchy cannot spin the walk', () => {
+  test('a two-node parent cycle stops at the step ceiling', () => {
+    const parentOf = (id: string): string | undefined => (id === 'A' ? 'B' : 'A');
+    let steps = 0;
+    forEachAncestorId('A', parentOf, () => { steps++; });
+    expect(steps).toBe(MAX_ANCESTOR_STEPS);
+  });
+
+  test('a node naming itself as its parent stops too', () => {
+    let steps = 0;
+    forEachAncestorId('self', () => 'self', () => { steps++; });
+    expect(steps).toBe(MAX_ANCESTOR_STEPS);
+  });
+
+  test('a chain into a node the store does not hold ends there', () => {
+    const store = new StreamingNodeStore();
+    store.add({
+      id: 'orphan',
+      key: { depth: 1, x: 0, y: 0, z: 0 },
+      bounds: [0, 0, 0, 1, 1, 1],
+      pointCount: 1,
+      byteOffset: 0,
+      byteSize: 0,
+      spacing: 1,
+      parentId: 'never-loaded',
+    });
+    const seen: string[] = [];
+    forEachAncestorId('orphan', parentLookupFromStore(store), (id) => seen.push(id));
+    expect(seen).toEqual(['never-loaded']);
+  });
+});


### PR DESCRIPTION
Ancestor reasoning in the streaming scheduler ran on octree key arithmetic: a node's parent came from right-shifting each axis of its `VoxelKey`. That is exact for COPC, EPT and the OLV tile store, and undefined for a hierarchy that is not a regular octree. Every one of those formats already records `parentId` on each node and links `childIds` on the runtime node, so the relationship was present without deriving it from coordinates. Ancestor protection, the refining-candidate marks, the sibling-retention bonus and the refined-away marks now walk that chain through the node store.

`exportFrontier` takes a parent lookup rather than parsing a resident id back into a key. It also reads a per-node refinement mode, so an additive parent is kept while a replacing one is still dropped once a descendant is resident.

`tests/streamingHierarchyGeneric.test.ts` runs the previous key walk beside the current one over a dense three-level and a sparse lopsided COPC hierarchy, across every node subset up to 400 per fixture, and asserts the two name the same nodes. Truncating the walk to one step fails seven of those tests. An irregular tree with opaque ids covers the shape a key cannot express, and a parent cycle terminates at a step ceiling.

Not in scope: `StreamingNodeRecord` stays in `src/io/copc/copcTypes.ts`, and `VoxelKey` stays required on it, because depth still drives LOD scoring.

Gates: typecheck, `lint:inline-imports`, `lint:module-graph`, `lint:monolith-size`, `lint:architecture-truth`, `lint:release-truth`, `lint:spatial-context`, `lint:layer-boundaries`, `test:build`, `test:unit` (6,749 passed) and `test:export` (849 passed). Viewer.ts line count and both ratchet baselines are unchanged.
