### PR TITLE
Give every streaming source an explicit source-to-render frame

### DIFF
--- a/docs/coordinate-precision.md
+++ b/docs/coordinate-precision.md
@@ -43,6 +43,32 @@ the largest residual is 10,000 m — well within Float32's sub-mm sweet spot.
 - **Invariant:** `world = local + origin` is exact to within Float32
   precision of the local residual.
 
+#### The frame behind that invariant
+
+The addition above is one case of a general conversion, and every streaming
+source now carries it explicitly as a `SpatialFrame`
+(`src/geo/frame/spatialFrame.ts`). COPC, EPT and the OLV tile store build a
+`translated-cartesian` frame from their own `renderOrigin`, so their arithmetic
+is unchanged and `frame.isTranslationOnly` is true.
+
+An offset is not enough for a source whose coordinates are geocentric. On a
+globe the source +Z is the polar axis, not up, so a scene drawn without rotating
+into a tangent frame is wrong about which way is down, and a Float32 buffer
+holding a coordinate near the Earth's radius has lost the millimetre before the
+first frame is drawn. `createLocalEnuFrame` covers that case: it subtracts the
+anchor in Float64, then rotates into east-north-up, so render up is `[0, 0, 1]`
+and the residual reaching Float32 is metre-scale.
+
+Nothing ships on the rotating path yet, because no format OLV reads today
+declares a geocentric frame. A consumer that still performs `local + origin`
+directly should test `frame.isTranslationOnly` and refuse rather than report a
+coordinate that a rotation would have moved by hundreds of metres.
+
+Note what the frame will not do: decide that a source is geocentric. A tileset
+whose coordinates sit near the Earth's radius may be EPSG:4978, or a local
+model that happens to be large, and the numbers do not separate the two. The
+frame is built from a declaration, never from the magnitude of a coordinate.
+
 ### 3. Camera/view space (Float32 on the GPU)
 
 Three.js's standard space. Camera position + projection matrices operate

--- a/scripts/lint-layer-boundaries.mjs
+++ b/scripts/lint-layer-boundaries.mjs
@@ -44,7 +44,7 @@ import { fileURLToPath } from 'node:url';
 // to exist), so the lint would print success having read zero files. A gate
 // that passes vacuously is worse than one that fails, hence fileURLToPath.
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
-const LAYERS = ['src/terrain', 'src/validation', 'src/analysis', 'src/science', 'src/geo/context'];
+const LAYERS = ['src/terrain', 'src/validation', 'src/analysis', 'src/science', 'src/geo/context', 'src/geo/frame'];
 
 /** A specifier that reaches into the UI layer or pulls in three.js. */
 function isBanned(spec) {

--- a/src/geo/frame/spatialFrame.ts
+++ b/src/geo/frame/spatialFrame.ts
@@ -1,0 +1,202 @@
+/**
+ * spatialFrame.ts
+ *
+ * The conversion between the coordinates a source carries and the coordinates
+ * the renderer draws.
+ *
+ * Every streaming source today recentres its points on one `renderOrigin` and
+ * consumers recover a source coordinate by adding it back. That is exact for a
+ * LAS-derived cloud in a projected CRS, where local visual up is the source's
+ * own +Z and no rotation is involved. It is not sufficient for a source in a
+ * geocentric frame: on a globe, +Z is the polar axis, not up, and a scene drawn
+ * without rotating into a tangent frame is lying about which way is down.
+ *
+ * A frame is therefore a rotation and a translation, not an offset. Two
+ * implementations cover what OLV reads:
+ *
+ *   translated-cartesian  render = source − renderOrigin
+ *   local-enu             render = R · (source − anchor), R an ECEF-to-ENU basis
+ *
+ * The translated frame is a distinct implementation rather than the general one
+ * with an identity rotation, so the arithmetic every existing consumer performs
+ * is unchanged rather than merely equal to within rounding.
+ *
+ * WHAT THIS MODULE WILL NOT DO. It will not decide that a source is geocentric.
+ * A tileset whose coordinates sit near the Earth's radius may be in EPSG:4978,
+ * or it may be a local Cartesian model that happens to be large, and nothing in
+ * the numbers separates the two. The frame is built from a declaration made
+ * elsewhere; guessing it here would put a false CRS into every report that
+ * reads the frame back.
+ *
+ * All arithmetic is Float64. Narrowing to Float32 belongs after the recentring
+ * and the rotation, at the GPU buffer, and nowhere before it: a metre-scale
+ * residual survives Float32 to well under a millimetre, and an ECEF coordinate
+ * does not survive it at all.
+ *
+ * Pure — no DOM, no three.js, no proj4, no I/O.
+ */
+
+/** A point or vector in a Cartesian frame, Float64. */
+export type Vec3 = readonly [number, number, number];
+
+/** A freshly allocated triple, so a caller can never alias a frame's state. */
+export type Vec3Out = [number, number, number];
+
+/** Which conversion a frame performs. */
+export type SpatialFrameKind = 'translated-cartesian' | 'local-enu';
+
+/**
+ * The conversion between source and render coordinates.
+ *
+ * Points carry the translation; vectors do not. A displacement, a normal or a
+ * bounding-box half-extent must go through the vector methods, or it picks up
+ * the anchor and lands somewhere near the centre of the Earth.
+ */
+export interface SpatialFrame {
+  readonly kind: SpatialFrameKind;
+  /**
+   * The source coordinate that maps to render zero.
+   *
+   * For a translated frame this is the offset every consumer already adds back,
+   * which is why the field keeps that name. For an ENU frame it is the tangent
+   * point, and adding it to a render coordinate does NOT recover the source:
+   * use {@link renderToSourcePoint}.
+   */
+  readonly renderOrigin: Vec3;
+
+  sourceToRenderPoint(p: Vec3): Vec3Out;
+  renderToSourcePoint(p: Vec3): Vec3Out;
+  sourceVectorToRender(v: Vec3): Vec3Out;
+  renderVectorToSource(v: Vec3): Vec3Out;
+
+  /** Up in render space, unit length. */
+  renderWorldUp(): Vec3Out;
+
+  /**
+   * True when a source coordinate is `render + renderOrigin`.
+   *
+   * A consumer that still performs that addition directly can ask, and refuse
+   * rather than produce a coordinate that is wrong by the radius of the Earth.
+   */
+  readonly isTranslationOnly: boolean;
+}
+
+// ── Translated Cartesian ─────────────────────────────────────────────────────
+
+/**
+ * A frame that only recentres: `render = source − renderOrigin`.
+ *
+ * `up` is the source's own up axis in source coordinates, and because the frame
+ * does not rotate it is also up in render space. LAS-derived sources are Z-up;
+ * a Y-up model format passes `[0, 1, 0]`.
+ */
+export function createTranslatedFrame(
+  renderOrigin: Vec3,
+  up: Vec3 = [0, 0, 1],
+): SpatialFrame {
+  const o0 = renderOrigin[0], o1 = renderOrigin[1], o2 = renderOrigin[2];
+  const u = normalize(up);
+  return {
+    kind: 'translated-cartesian',
+    renderOrigin: [o0, o1, o2],
+    isTranslationOnly: true,
+    sourceToRenderPoint: (p) => [p[0] - o0, p[1] - o1, p[2] - o2],
+    renderToSourcePoint: (p) => [p[0] + o0, p[1] + o1, p[2] + o2],
+    sourceVectorToRender: (v) => [v[0], v[1], v[2]],
+    renderVectorToSource: (v) => [v[0], v[1], v[2]],
+    renderWorldUp: () => [u[0], u[1], u[2]],
+  };
+}
+
+// ── Local ENU about an ECEF anchor ───────────────────────────────────────────
+
+/** WGS84 semi-major axis, metres. */
+export const WGS84_A = 6378137.0;
+/** WGS84 inverse flattening. */
+export const WGS84_INV_F = 298.257223563;
+
+/**
+ * Geodetic latitude and longitude of an ECEF position, in radians.
+ *
+ * Bowring's closed form. Height is not returned because the ENU basis does not
+ * need it: the rotation is fixed by the surface normal direction alone.
+ *
+ * Exported for its own test. A latitude that is wrong by a degree still yields
+ * an orthonormal rotation, so every round-trip assertion would pass while the
+ * scene sat visibly tilted.
+ */
+export function ecefToGeodeticAngles(p: Vec3): { lat: number; lon: number } {
+  const a = WGS84_A;
+  const f = 1 / WGS84_INV_F;
+  const b = a * (1 - f);
+  const e2 = f * (2 - f);
+  const ep2 = (a * a - b * b) / (b * b);
+  const [x, y, z] = p;
+  const r = Math.hypot(x, y);
+  const lon = Math.atan2(y, x);
+  // On the polar axis the parametric latitude is ±90° and `r` is zero, which
+  // atan2 resolves without a divide.
+  const theta = Math.atan2(z * a, r * b);
+  const st = Math.sin(theta), ct = Math.cos(theta);
+  const lat = Math.atan2(z + ep2 * b * st * st * st, r - e2 * a * ct * ct * ct);
+  return { lat, lon };
+}
+
+/**
+ * A local east-north-up frame tangent to the ellipsoid beneath `anchor`.
+ *
+ * Render X is east, Y is north, Z is up, so render world-up is `[0, 0, 1]` and
+ * the rest of the viewer needs no globe-specific case.
+ *
+ * The anchor is subtracted before the rotation, in Float64, so the multiply
+ * only ever sees a residual: a value of a few kilometres rather than the six
+ * thousand kilometres an ECEF coordinate carries. Rotating first and
+ * subtracting after would lose roughly the low six digits of every coordinate.
+ */
+export function createLocalEnuFrame(anchor: Vec3): SpatialFrame {
+  const { lat, lon } = ecefToGeodeticAngles(anchor);
+  const sLat = Math.sin(lat), cLat = Math.cos(lat);
+  const sLon = Math.sin(lon), cLon = Math.cos(lon);
+
+  // Rows of R: east, north, up, each a unit vector in ECEF.
+  const ex = -sLon,        ey = cLon,         ez = 0;
+  const nx = -sLat * cLon, ny = -sLat * sLon, nz = cLat;
+  const ux = cLat * cLon,  uy = cLat * sLon,  uz = sLat;
+
+  const a0 = anchor[0], a1 = anchor[1], a2 = anchor[2];
+
+  const rotate = (x: number, y: number, z: number): Vec3Out => [
+    ex * x + ey * y + ez * z,
+    nx * x + ny * y + nz * z,
+    ux * x + uy * y + uz * z,
+  ];
+  // R is orthonormal, so the inverse is the transpose: columns become rows.
+  const unrotate = (e: number, n: number, u: number): Vec3Out => [
+    ex * e + nx * n + ux * u,
+    ey * e + ny * n + uy * u,
+    ez * e + nz * n + uz * u,
+  ];
+
+  return {
+    kind: 'local-enu',
+    renderOrigin: [a0, a1, a2],
+    isTranslationOnly: false,
+    sourceToRenderPoint: (p) => rotate(p[0] - a0, p[1] - a1, p[2] - a2),
+    renderToSourcePoint: (p) => {
+      const v = unrotate(p[0], p[1], p[2]);
+      return [v[0] + a0, v[1] + a1, v[2] + a2];
+    },
+    sourceVectorToRender: (v) => rotate(v[0], v[1], v[2]),
+    renderVectorToSource: (v) => unrotate(v[0], v[1], v[2]),
+    renderWorldUp: () => [0, 0, 1],
+  };
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Unit vector, or `[0, 0, 1]` for a zero-length input. */
+function normalize(v: Vec3): Vec3Out {
+  const len = Math.hypot(v[0], v[1], v[2]);
+  if (!(len > 0) || !Number.isFinite(len)) return [0, 0, 1];
+  return [v[0] / len, v[1] / len, v[2] / len];
+}

--- a/src/io/heavy/OlvTileSource.ts
+++ b/src/io/heavy/OlvTileSource.ts
@@ -41,6 +41,7 @@ import type {
   StreamingSource,
 } from '../../render/streaming/StreamingSource';
 import type { TileStoreReader } from './tileStore';
+import { createTranslatedFrame, type SpatialFrame } from '../../geo/frame/spatialFrame';
 
 /**
  * Node ids carry a one-character prefix because the root's octant path is the
@@ -194,6 +195,12 @@ export class OlvTileSource implements StreamingSource {
   readonly name: string;
   /** The recentring origin the build stored — world = local + this. */
   readonly renderOrigin: [number, number, number];
+  /**
+   * The source-to-render conversion. A recentring with no rotation: this format
+   * is LAS-derived and Z-up, so render up is the source's own +Z.
+   */
+  readonly frame: SpatialFrame;
+
   readonly octree: OlvTileOctree;
 
   private readonly _store: TileStoreReader;
@@ -210,6 +217,7 @@ export class OlvTileSource implements StreamingSource {
     this._close = options.close;
     const o = options.store.manifest.origin;
     this.renderOrigin = [o[0], o[1], o[2]];
+    this.frame = createTranslatedFrame(this.renderOrigin);
     this.octree = new OlvTileOctree(options.store);
   }
 

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -2173,9 +2173,9 @@ export class Viewer {
 
   /** Configure navigation and clip planes for a streaming cloud's extent. */
   private _configureForStreaming(cloud: StreamingSource): void {
-    // COPC + EPT are both LAS-derived (EPT writes binary tiles via LAS
-    // conventions) — always Z-up.
-    this._worldUp.set(0, 0, 1);
+    // Render up comes from the source's frame. COPC, EPT and the tile store
+    // are LAS-derived and report Z; a rotating frame reports its tangent up.
+    this._worldUp.fromArray(cloud.frame.renderWorldUp());
     this._nav.setWorldUp(this._worldUp);
 
     const b = cloud.localBounds();

--- a/src/render/streaming/EptStreamingPointCloud.ts
+++ b/src/render/streaming/EptStreamingPointCloud.ts
@@ -53,6 +53,7 @@ import { EptOctree } from './EptOctree';
 import { nextStreamingScanId } from './streamingScanId';
 import type { CrsInfo } from '../../io/crs';
 import { resolveEptCrs } from './eptCrs';
+import { createTranslatedFrame, type SpatialFrame } from '../../geo/frame/spatialFrame';
 
 /**
  * Hierarchy files to load before a streaming EPT scan attaches. The root file
@@ -109,6 +110,12 @@ export class EptStreamingPointCloud implements StreamingSource {
   readonly kind: StreamingSourceKind = 'ept';
   readonly name: string;
   readonly renderOrigin: [number, number, number];
+  /**
+   * The source-to-render conversion. A recentring with no rotation: this format
+   * is LAS-derived and Z-up, so render up is the source's own +Z.
+   */
+  readonly frame: SpatialFrame;
+
   readonly octree: EptOctree;
   readonly metadata: EptMetadata;
   /** Dataset base URL — every tile + hierarchy URL builds from this. */
@@ -148,6 +155,7 @@ export class EptStreamingPointCloud implements StreamingSource {
     this.baseUrl = baseUrl;
     this.name = name;
     this.renderOrigin = renderOrigin;
+    this.frame = createTranslatedFrame(renderOrigin);
     this.octree = octree;
     this._transport = transport;
     this._search = search;

--- a/src/render/streaming/StreamingPointCloud.ts
+++ b/src/render/streaming/StreamingPointCloud.ts
@@ -25,6 +25,7 @@ import type {
   StreamingSource,
   StreamingSourceKind,
 } from './StreamingSource';
+import { createTranslatedFrame, type SpatialFrame } from '../../geo/frame/spatialFrame';
 
 /** The render origin — the floored octree-cube centre, shared by every node. */
 function pickRenderOrigin(
@@ -50,6 +51,12 @@ export class StreamingPointCloud implements StreamingSource {
   readonly octree: StreamingOctree;
   /** The render origin every node is recentred against (float64-stable). */
   readonly renderOrigin: [number, number, number];
+  /**
+   * The source-to-render conversion. A recentring with no rotation: this format
+   * is LAS-derived and Z-up, so render up is the source's own +Z.
+   */
+  readonly frame: SpatialFrame;
+
   /** The display name — the file name. */
   readonly name: string;
   /** File-level RGB bit-depth, captured from the first decoded RGB chunk; see
@@ -65,6 +72,7 @@ export class StreamingPointCloud implements StreamingSource {
     this.source = source;
     this.octree = octree;
     this.renderOrigin = renderOrigin;
+    this.frame = createTranslatedFrame(renderOrigin);
     this.name = name;
   }
 

--- a/src/render/streaming/StreamingSource.ts
+++ b/src/render/streaming/StreamingSource.ts
@@ -22,6 +22,7 @@
  */
 
 import type { Box6, StreamingNodeRecord } from '../../io/copc/copcTypes';
+import type { SpatialFrame } from '../../geo/frame/spatialFrame';
 import type { ChunkDecodeMetadata } from '../../io/copc/copcChunkDecode';
 import type { StreamingNode } from './StreamingNode';
 import type { NodeCounts, StreamingNodeStore } from './StreamingNodeStore';
@@ -131,6 +132,18 @@ export interface StreamingSource {
   readonly name: string;
   /** Render origin every node is recentred against (float64-stable). */
   readonly renderOrigin: [number, number, number];
+  /**
+   * How a source coordinate becomes a render coordinate, and back.
+   *
+   * Every format streamed today recentres and does not rotate, so this is a
+   * translated-cartesian frame built on {@link renderOrigin} and the two agree
+   * exactly. A consumer that reconstructs a source coordinate should go through
+   * the frame rather than adding the origin, because a source in a geocentric
+   * frame needs a rotation that no offset can express, and the frame is where
+   * that arrives. `frame.isTranslationOnly` is how a caller that cannot yet do
+   * so refuses rather than reporting a coordinate off by hundreds of metres.
+   */
+  readonly frame: SpatialFrame;
   /** The runtime octree — nodes, state, scoring inputs. */
   readonly octree: StreamingOctreeView;
   /**

--- a/tests/eptStreaming.test.ts
+++ b/tests/eptStreaming.test.ts
@@ -311,6 +311,16 @@ test('EptStreamingPointCloud.open round-trips the fixture into a streaming sourc
   );
   expect(cloud.kind).toBe('ept');
   expect(cloud.name).toBe('ept-tiny');
+  // The frame and the render origin must describe the same conversion; a
+  // consumer reconstructs a source coordinate through one or the other.
+  expect(cloud.frame.isTranslationOnly).toBe(true);
+  expect(cloud.frame.renderOrigin).toEqual([...cloud.renderOrigin]);
+  expect(cloud.frame.renderToSourcePoint([1.5, -2.25, 30.125])).toEqual([
+    1.5 + cloud.renderOrigin[0],
+    -2.25 + cloud.renderOrigin[1],
+    30.125 + cloud.renderOrigin[2],
+  ]);
+  expect(cloud.frame.renderWorldUp()).toEqual([0, 0, 1]);
   expect(cloud.sourcePointCount).toBe(100);
   expect(cloud.dataType).toBe('binary');
   expect(cloud.maxDepth()).toBe(0);

--- a/tests/olvTileSource.test.ts
+++ b/tests/olvTileSource.test.ts
@@ -108,6 +108,18 @@ function makeSource(reader: TileStoreReader, tiles: TileBytesReader) {
 }
 
 describe('OlvTileSource', () => {
+  it('reports a frame that agrees with its render origin', async () => {
+    const { reader, tiles } = await buildReader(2000);
+    const source = makeSource(reader, tiles);
+    const o = source.renderOrigin;
+    expect(source.frame.isTranslationOnly).toBe(true);
+    expect(source.frame.renderOrigin).toEqual([o[0], o[1], o[2]]);
+    expect(source.frame.renderWorldUp()).toEqual([0, 0, 1]);
+    expect(source.frame.renderToSourcePoint([1.5, -2.25, 30.125]))
+      .toEqual([1.5 + o[0], -2.25 + o[1], 30.125 + o[2]]);
+    expect(source.frame.sourceToRenderPoint([o[0], o[1], o[2]])).toEqual([0, 0, 0]);
+  });
+
   it('presents the stored pyramid as a streaming octree', async () => {
     const { reader, tiles, pointCount } = await buildReader(5000);
     const source = makeSource(reader, tiles);

--- a/tests/spatialFrame.test.ts
+++ b/tests/spatialFrame.test.ts
@@ -1,0 +1,238 @@
+/**
+ * spatialFrame.test.ts
+ *
+ * The source-to-render conversion, in both forms OLV needs.
+ *
+ * The translated frame must be arithmetically identical to the `p ± origin` its
+ * consumers perform today, not merely close: a frame that rounded differently
+ * would move every measured coordinate in the app by a rounding step for no
+ * reason a reader could see. The ENU frame must place east, north and up where
+ * the ellipsoid puts them, must round-trip a geocentric coordinate back to
+ * itself, and must keep millimetre spacing that a Float32 cast at the wrong
+ * point in the chain destroys.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createTranslatedFrame,
+  createLocalEnuFrame,
+  ecefToGeodeticAngles,
+  WGS84_A,
+  WGS84_INV_F,
+  type Vec3,
+} from '../src/geo/frame/spatialFrame';
+
+const D2R = Math.PI / 180;
+
+/** Geodetic to ECEF, the independent direction, so a round trip is not circular. */
+function geodeticToEcef(latDeg: number, lonDeg: number, height: number): Vec3 {
+  const f = 1 / WGS84_INV_F;
+  const e2 = f * (2 - f);
+  const lat = latDeg * D2R, lon = lonDeg * D2R;
+  const s = Math.sin(lat), c = Math.cos(lat);
+  const n = WGS84_A / Math.sqrt(1 - e2 * s * s);
+  return [
+    (n + height) * c * Math.cos(lon),
+    (n + height) * c * Math.sin(lon),
+    (n * (1 - e2) + height) * s,
+  ];
+}
+
+function dot(a: Vec3, b: Vec3): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+describe('translated-cartesian frame', () => {
+  const ORIGIN: Vec3 = [512345, 4207891, 137];
+
+  it('produces exactly what adding and subtracting the origin produces', () => {
+    const frame = createTranslatedFrame(ORIGIN);
+    for (const p of [
+      [512345.001, 4207891.002, 137.003],
+      [0, 0, 0],
+      [-1e6, 7.5e6, -412.25],
+      [512345 + 1e-7, 4207891 - 1e-7, 137],
+    ] as Vec3[]) {
+      expect(frame.sourceToRenderPoint(p)).toEqual([
+        p[0] - ORIGIN[0], p[1] - ORIGIN[1], p[2] - ORIGIN[2],
+      ]);
+      expect(frame.renderToSourcePoint(p)).toEqual([
+        p[0] + ORIGIN[0], p[1] + ORIGIN[1], p[2] + ORIGIN[2],
+      ]);
+    }
+  });
+
+  it('round-trips a source coordinate to the same double', () => {
+    const frame = createTranslatedFrame(ORIGIN);
+    const p: Vec3 = [512345.123456789, 4207891.987654321, 137.5];
+    expect(frame.renderToSourcePoint(frame.sourceToRenderPoint(p))).toEqual([...p]);
+  });
+
+  it('leaves a vector alone, so a normal picks up no translation', () => {
+    const frame = createTranslatedFrame(ORIGIN);
+    expect(frame.sourceVectorToRender([0, 0, 1])).toEqual([0, 0, 1]);
+    expect(frame.renderVectorToSource([3, -4, 12])).toEqual([3, -4, 12]);
+  });
+
+  it('reports Z-up by default and the axis it was given otherwise', () => {
+    expect(createTranslatedFrame(ORIGIN).renderWorldUp()).toEqual([0, 0, 1]);
+    expect(createTranslatedFrame(ORIGIN, [0, 1, 0]).renderWorldUp()).toEqual([0, 1, 0]);
+    expect(createTranslatedFrame(ORIGIN, [0, 0, 5]).renderWorldUp()).toEqual([0, 0, 1]);
+  });
+
+  it('falls back to Z-up rather than emitting NaN for a degenerate axis', () => {
+    expect(createTranslatedFrame(ORIGIN, [0, 0, 0]).renderWorldUp()).toEqual([0, 0, 1]);
+    expect(createTranslatedFrame(ORIGIN, [NaN, 0, 1]).renderWorldUp()).toEqual([0, 0, 1]);
+  });
+
+  it('says it is translation only, so a direct adder may keep adding', () => {
+    expect(createTranslatedFrame(ORIGIN).isTranslationOnly).toBe(true);
+  });
+});
+
+describe('ecefToGeodeticAngles', () => {
+  const CASES: readonly (readonly [number, number, number])[] = [
+    [0, 0, 0],
+    [0, 180, 0],
+    [45.5, -122.6, 60],
+    [-33.87, 151.21, 25],
+    [78.22, 15.65, 400],
+    [89.999, 0, 0],
+    [-89.999, 90, 0],
+    [51.4778, -0.0015, 45.2],
+  ];
+
+  it('recovers the latitude and longitude a position was built from', () => {
+    for (const [lat, lon, h] of CASES) {
+      const got = ecefToGeodeticAngles(geodeticToEcef(lat, lon, h));
+      expect(got.lat / D2R).toBeCloseTo(lat, 9);
+      // Longitude at ±180 wraps; compare through the unit circle.
+      expect(Math.cos(got.lon)).toBeCloseTo(Math.cos(lon * D2R), 12);
+      expect(Math.sin(got.lon)).toBeCloseTo(Math.sin(lon * D2R), 12);
+    }
+  });
+
+  it('resolves the pole without dividing by zero', () => {
+    const north = ecefToGeodeticAngles([0, 0, 6356752.314245]);
+    expect(north.lat / D2R).toBeCloseTo(90, 9);
+    expect(Number.isFinite(north.lon)).toBe(true);
+  });
+});
+
+describe('local ENU frame', () => {
+  it('puts the anchor at render zero', () => {
+    const anchor = geodeticToEcef(45.5, -122.6, 60);
+    const frame = createLocalEnuFrame(anchor);
+    const r = frame.sourceToRenderPoint(anchor);
+    expect(Math.hypot(r[0], r[1], r[2])).toBeLessThan(1e-9);
+  });
+
+  it('reports render up as local +Z', () => {
+    expect(createLocalEnuFrame(geodeticToEcef(45.5, -122.6, 60)).renderWorldUp())
+      .toEqual([0, 0, 1]);
+  });
+
+  it('maps a metre of geodetic height onto render +Z alone', () => {
+    for (const [lat, lon] of [[0, 0], [45.5, -122.6], [-33.87, 151.21], [78.22, 15.65]]) {
+      const frame = createLocalEnuFrame(geodeticToEcef(lat, lon, 0));
+      const up = frame.sourceToRenderPoint(geodeticToEcef(lat, lon, 1));
+      expect(up[0]).toBeCloseTo(0, 6);
+      expect(up[1]).toBeCloseTo(0, 6);
+      expect(up[2]).toBeCloseTo(1, 6);
+    }
+  });
+
+  it('sends north toward render +Y and east toward render +X', () => {
+    const lat = 45.5, lon = -122.6;
+    const frame = createLocalEnuFrame(geodeticToEcef(lat, lon, 0));
+    // A hundred metres of latitude is about 0.0009 degrees; the exact figure
+    // does not matter, only which render axis it lands on.
+    const north = frame.sourceToRenderPoint(geodeticToEcef(lat + 0.0009, lon, 0));
+    expect(north[1]).toBeGreaterThan(90);
+    expect(Math.abs(north[0])).toBeLessThan(1);
+
+    const east = frame.sourceToRenderPoint(geodeticToEcef(lat, lon + 0.0009, 0));
+    expect(east[0]).toBeGreaterThan(60);
+    expect(Math.abs(east[1])).toBeLessThan(1);
+  });
+
+  it('keeps an orthonormal basis, so distances and angles survive', () => {
+    const frame = createLocalEnuFrame(geodeticToEcef(-33.87, 151.21, 25));
+    const e = frame.renderVectorToSource([1, 0, 0]);
+    const n = frame.renderVectorToSource([0, 1, 0]);
+    const u = frame.renderVectorToSource([0, 0, 1]);
+    for (const v of [e, n, u]) expect(Math.hypot(...v)).toBeCloseTo(1, 12);
+    expect(dot(e, n)).toBeCloseTo(0, 12);
+    expect(dot(e, u)).toBeCloseTo(0, 12);
+    expect(dot(n, u)).toBeCloseTo(0, 12);
+  });
+
+  it('preserves the distance between two source points', () => {
+    const frame = createLocalEnuFrame(geodeticToEcef(45.5, -122.6, 60));
+    const a = geodeticToEcef(45.5001, -122.6002, 61);
+    const b = geodeticToEcef(45.5004, -122.5997, 78);
+    const sourceD = Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+    const ra = frame.sourceToRenderPoint(a), rb = frame.sourceToRenderPoint(b);
+    const renderD = Math.hypot(ra[0] - rb[0], ra[1] - rb[1], ra[2] - rb[2]);
+    expect(renderD).toBeCloseTo(sourceD, 9);
+  });
+
+  it('round-trips a geocentric coordinate back to within a nanometre', () => {
+    const frame = createLocalEnuFrame(geodeticToEcef(45.5, -122.6, 60));
+    for (const [dLat, dLon, dH] of [[0, 0, 0], [0.01, -0.01, 120], [-0.004, 0.02, -30]]) {
+      const p = geodeticToEcef(45.5 + dLat, -122.6 + dLon, 60 + dH);
+      const back = frame.renderToSourcePoint(frame.sourceToRenderPoint(p));
+      for (let i = 0; i < 3; i++) expect(Math.abs(back[i] - p[i])).toBeLessThan(1e-9);
+    }
+  });
+
+  it('carries a vector without the anchor, so a normal stays a direction', () => {
+    const frame = createLocalEnuFrame(geodeticToEcef(45.5, -122.6, 60));
+    const v = frame.sourceVectorToRender([1, 0, 0]);
+    expect(Math.hypot(...v)).toBeCloseTo(1, 12);
+    expect(frame.renderVectorToSource(v)[0]).toBeCloseTo(1, 12);
+  });
+
+  it('says it is not translation only, so a direct adder must not add', () => {
+    const anchor = geodeticToEcef(45.5, -122.6, 60);
+    const frame = createLocalEnuFrame(anchor);
+    expect(frame.isTranslationOnly).toBe(false);
+    // What the naive addition costs: the rotation is skipped, so the error is
+    // the arc between the two frames over the offset from the anchor. A point
+    // 1.5 km away lands roughly 950 m from where it belongs, and the gap grows
+    // with the offset rather than staying a fixed bias.
+    const p = geodeticToEcef(45.51, -122.61, 70);
+    const render = frame.sourceToRenderPoint(p);
+    const naive = [
+      render[0] + anchor[0], render[1] + anchor[1], render[2] + anchor[2],
+    ];
+    const offset = Math.hypot(
+      p[0] - anchor[0], p[1] - anchor[1], p[2] - anchor[2],
+    );
+    expect(offset).toBeGreaterThan(1000);
+    expect(Math.hypot(naive[0] - p[0], naive[1] - p[1], naive[2] - p[2]))
+      .toBeGreaterThan(500);
+  });
+});
+
+describe('where Float32 may enter', () => {
+  const anchor = geodeticToEcef(45.5, -122.6, 60);
+
+  it('keeps millimetre spacing when the cast follows the recentring', () => {
+    const frame = createLocalEnuFrame(anchor);
+    const a = frame.sourceToRenderPoint(anchor);
+    const b = frame.sourceToRenderPoint([anchor[0], anchor[1], anchor[2] + 0.001]);
+    const f = new Float32Array([...a, ...b]);
+    const dz = Math.hypot(f[3] - f[0], f[4] - f[1], f[5] - f[2]);
+    expect(dz).toBeCloseTo(0.001, 6);
+  });
+
+  it('loses that spacing entirely when the cast precedes it', () => {
+    // The same millimetre, narrowed while the coordinate is still geocentric.
+    const f = new Float32Array([
+      anchor[0], anchor[1], anchor[2],
+      anchor[0], anchor[1], anchor[2] + 0.001,
+    ]);
+    expect(Math.hypot(f[3] - f[0], f[4] - f[1], f[5] - f[2])).toBe(0);
+  });
+});

--- a/tests/streamingSource.test.ts
+++ b/tests/streamingSource.test.ts
@@ -102,6 +102,7 @@ test('the scheduler accepts any StreamingSource conforming object — EPT will p
     kind: 'ept', // pretending to be an EPT source
     name: 'stub.ept',
     renderOrigin: realCloud.renderOrigin,
+    frame: realCloud.frame,
     octree: realCloud.octree,
     sourcePointCount: realCloud.sourcePointCount,
     get residentPointCount(): number { return realCloud.residentPointCount; },
@@ -129,4 +130,39 @@ test('the scheduler accepts any StreamingSource conforming object — EPT will p
   );
   expect(scheduler).toBeDefined();
   scheduler.stop();
+});
+
+/**
+ * The frame and the render origin must describe the same conversion. Every
+ * consumer that reconstructs a source coordinate does it one way or the other,
+ * and a disagreement would put two different answers in the same report.
+ */
+function assertFrameMatchesOrigin(source: {
+  readonly renderOrigin: readonly [number, number, number];
+  readonly frame: import('../src/geo/frame/spatialFrame').SpatialFrame;
+}): void {
+  const o = source.renderOrigin;
+  expect(source.frame.kind).toBe('translated-cartesian');
+  expect(source.frame.isTranslationOnly).toBe(true);
+  expect(source.frame.renderOrigin).toEqual([o[0], o[1], o[2]]);
+  expect(source.frame.renderWorldUp()).toEqual([0, 0, 1]);
+  for (const p of [[0, 0, 0], [1.5, -2.25, 30.125], [1e6, -1e6, 0]] as const) {
+    expect(source.frame.renderToSourcePoint(p))
+      .toEqual([p[0] + o[0], p[1] + o[1], p[2] + o[2]]);
+    expect(source.frame.sourceToRenderPoint(p))
+      .toEqual([p[0] - o[0], p[1] - o[1], p[2] - o[2]]);
+  }
+}
+
+test('a COPC source reports a frame that agrees with its render origin', async () => {
+  const fixture = buildSyntheticCopc({
+    center: [512345, 4207891, 137],
+    halfsize: 128,
+    nodes: [{ key: [0, 0, 0, 0], pointCount: 100 }],
+  });
+  const cloud = await StreamingPointCloud.open(
+    new ArrayBufferRangeSource(fixture.buffer),
+    'frame.copc.laz',
+  );
+  assertFrameMatchesOrigin(cloud);
 });


### PR DESCRIPTION
`StreamingSource` exposed a `renderOrigin` and consumers recovered a source coordinate by adding it back. Exact for a LAS-derived cloud in a projected CRS, and unable to express a geocentric source: on a globe the source +Z is the polar axis rather than up, so a scene drawn without rotating into a tangent frame is wrong about which way is down, and a coordinate near the Earth's radius has lost the millimetre before Float32 receives it.

`src/geo/frame/spatialFrame.ts` holds both conversions behind one interface. A `translated-cartesian` frame does `render = source − renderOrigin` and reports `isTranslationOnly`, so a consumer that still adds the origin directly can ask before doing it. `createLocalEnuFrame` subtracts the anchor in Float64 and then rotates into east-north-up, which puts render up at `[0, 0, 1]` and leaves a metre-scale residual for the GPU.

COPC, EPT and the OLV tile store each build a translated frame from their existing origin. It is a separate implementation rather than the general one with an identity rotation, so their arithmetic is unchanged rather than equal to within rounding, and each format has a test asserting the frame and the origin give the same answer for the same point. `Viewer._configureForStreaming` reads render up off the frame instead of setting Z for every streaming source, which is the assumption that made the hardcode wrong for anything that is not LAS-derived. The two paths agree today and the code no longer says they must.

Nothing runs on the rotating path yet, because no format OLV reads declares a geocentric frame. The module will not infer one either: a tileset near the Earth's radius may be EPSG:4978 or a large local model, and the numbers do not separate them. A guess here would put a false CRS into every report that reads the frame back, which is worse than the frame refusing to answer.

`src/geo/frame` is added to `lint:layer-boundaries`, and the scanned count goes 149 to 150.

Gates: typecheck, `lint:architecture-truth`, `lint:monolith-size`, `lint:module-graph`, `lint:release-truth`, `lint:inline-imports`, `lint:spatial-context`, `lint:layer-boundaries`, `lint:worker-registry`, `test:build`, `test:unit` (6,769 passed) and `test:export` (842 passed). Viewer.ts line count and both ratchet baselines are unchanged.
