### PR TITLE
Open a scan in height when its RGB is too uniform to read

### DIFF
--- a/src/app/openScan.ts
+++ b/src/app/openScan.ts
@@ -359,8 +359,8 @@ export async function openScan(file: File, deps: OpenScanDeps): Promise<void> {
 
     // Colour the fresh scan by the mode its attributes best support (RGB →
     // classification → intensity → elevation), gated so it never picks a mode
-    // the cloud can't render. The rail syncs off `mode` below, so this single
-    // seam keeps the render and the COLOR BY chips in step.
+    // the cloud can't render, nor an RGB array too uniform to read. The rail
+    // syncs off `mode` below, so this seam keeps render and chips in step.
     const mode = recommendColorMode(result.cloud).mode;
     deps.setCurrentColorMode(mode);
     viewer.setColorMode(id, mode);

--- a/src/render/colorModeRecommend.ts
+++ b/src/render/colorModeRecommend.ts
@@ -15,6 +15,7 @@
 
 import type { ColorMode } from './colorModes';
 import { cloudSupportsColorMode, type ColorModeCloudFacts } from './colorModeSupport';
+import { readRgbReadability } from './rgbReadability';
 
 /** A colour-mode suggestion with a short, modest rationale. */
 export interface ColorModeRecommendation {
@@ -46,6 +47,18 @@ const FALLBACK: ColorModeRecommendation = {
 };
 
 /**
+ * The fallback when RGB is present but too uniform to read.
+ *
+ * A distinct reason from {@link FALLBACK}, because "this scan has no colour" and
+ * "this scan's colour is a blank sheet" are different facts, and only the second
+ * leaves a channel the user may still want to select.
+ */
+const UNIFORM_RGB_FALLBACK: ColorModeRecommendation = {
+  mode: 'elevation',
+  reason: 'coloured by height — the scan carries RGB, but too uniform to read',
+};
+
+/**
  * Recommend a colour mode for a scan from the attributes it carries (`facts`
  * are the cloud's own attribute arrays — RGB, classification, intensity, …).
  * Deterministic and conservative: prefer RGB, then classification, then
@@ -57,8 +70,17 @@ const FALLBACK: ColorModeRecommendation = {
  * rather than as absent data.
  */
 export function recommendColorMode(facts: ColorModeCloudFacts): ColorModeRecommendation {
+  // RGB is measured, not merely counted: a colour array in which every point is
+  // within a few levels of white is present, renderable and unreadable, and
+  // opening a scan into it shows a blank sheet. The mode stays selectable; it
+  // just stops being the opening choice.
+  const rgbUniform =
+    cloudSupportsColorMode(facts, 'rgb') &&
+    readRgbReadability(facts.colors).verdict === 'uniform';
+
   for (const candidate of CANDIDATES) {
+    if (candidate.mode === 'rgb' && rgbUniform) continue;
     if (cloudSupportsColorMode(facts, candidate.mode)) return candidate;
   }
-  return FALLBACK;
+  return rgbUniform ? UNIFORM_RGB_FALLBACK : FALLBACK;
 }

--- a/src/render/rgbReadability.ts
+++ b/src/render/rgbReadability.ts
@@ -70,21 +70,44 @@ export const RGB_LUMINANCE_IQR_FLOOR = 12;
  */
 export const RGB_MIN_SAMPLE = 64;
 
-/**
- * Sample size the stride aims at, so the check stays cheap on a large cloud.
- *
- * A target rather than a ceiling: the stride is an integer, so a cloud just
- * under twice this size strides by one and inspects all of it. The real bound
- * is twice the target, which is still a fixed cost.
- */
+/** Points inspected, so the check stays cheap on a large cloud. */
 export const RGB_SAMPLE_TARGET = 20000;
+
+/**
+ * The step a sample walk takes, coprime to `points` so it visits each point at
+ * most once and lands on every residue before it repeats.
+ *
+ * A fixed stride aliases. Sampling every second point of a cloud whose coloured
+ * points sit at every hundredth index visits all of the coloured ones and half
+ * of the rest, and reports twice the colour the cloud carries; that is measured,
+ * not hypothetical, and point clouds are full of periodic structure from scan
+ * lines, tile boundaries and interleaved returns. A step near the golden ratio
+ * of the count is the standard low-discrepancy choice, because it is the
+ * irrational hardest to approximate by a simple fraction and therefore the
+ * hardest for a periodic pattern to line up with.
+ */
+function sampleStep(points: number, target: number): number {
+  if (points <= target) return 1;
+  let step = Math.max(1, Math.round(points * 0.6180339887498949));
+  // Walk to the nearest coprime value. gcd falls to 1 within a few steps for
+  // any real count, and the loop is bounded regardless.
+  for (let tries = 0; tries < 64 && gcd(step, points) !== 1; tries++) step++;
+  return gcd(step, points) === 1 ? step : 1;
+}
+
+/** Greatest common divisor, for the coprimality check above. */
+function gcd(a: number, b: number): number {
+  let x = a, y = b;
+  while (y !== 0) { const t = x % y; x = y; y = t; }
+  return x;
+}
 
 /**
  * Measure a cloud's RGB array.
  *
- * The sample strides across the whole array rather than taking the head of it:
- * point order usually follows acquisition or a spatial sort, so the first
- * twenty thousand points are one corner of the scan and not the scan.
+ * The sample walks the whole array rather than taking the head of it: point
+ * order usually follows acquisition or a spatial sort, so the first twenty
+ * thousand points are one corner of the scan and not the scan.
  */
 export function readRgbReadability(colors: Uint8Array | undefined): RgbReadability {
   const points = colors ? Math.floor(colors.length / 3) : 0;
@@ -93,10 +116,12 @@ export function readRgbReadability(colors: Uint8Array | undefined): RgbReadabili
   }
   const rgb = colors as Uint8Array;
 
-  const stride = Math.max(1, Math.floor(points / RGB_SAMPLE_TARGET));
+  const step = sampleStep(points, RGB_SAMPLE_TARGET);
+  const wanted = Math.min(points, RGB_SAMPLE_TARGET);
   const luminance: number[] = [];
   let chromatic = 0;
-  for (let p = 0; p < points; p += stride) {
+  let p = 0;
+  for (let k = 0; k < wanted; k++, p = (p + step) % points) {
     const i = p * 3;
     const r = rgb[i], g = rgb[i + 1], b = rgb[i + 2];
     const spread = Math.max(r, g, b) - Math.min(r, g, b);

--- a/src/render/rgbReadability.ts
+++ b/src/render/rgbReadability.ts
@@ -1,0 +1,134 @@
+/**
+ * rgbReadability.ts
+ *
+ * Whether a cloud's RGB carries enough variation to be worth showing.
+ *
+ * `cloudSupportsColorMode` asks whether the channel exists. That is the right
+ * question for whether a mode can be selected, and the wrong one for what to
+ * open a scan in: a survey can carry a full RGB array in which every point is
+ * within a few levels of white, and colouring by it produces a blank sheet that
+ * reads as a broken render rather than as a scan with no usable colour. One
+ * real file measured here was entirely greyscale with a mean of 242 of 255 and
+ * 96 per cent of its points near white.
+ *
+ * The rule is deliberately conservative, because taking true colour away from a
+ * scan that has it is the worse error. Colour counts as readable when EITHER
+ * enough points carry chroma, OR the greys span a usable range. Only a cloud
+ * that fails both is called uniform. A well exposed monochrome scan passes on
+ * the second test, and a dim but colourful one passes on the first.
+ *
+ * Nothing here changes what a user may select. It only changes what a freshly
+ * opened scan starts in, and the verdict carries the numbers behind it so the
+ * choice can be stated rather than asserted.
+ *
+ * Pure — no DOM, no three.js — unit-tested in Node.
+ */
+
+/** What a cloud's colour array is worth as an opening view. */
+export type RgbVerdict = 'readable' | 'uniform' | 'absent';
+
+/** The verdict and the measurements behind it. */
+export interface RgbReadability {
+  readonly verdict: RgbVerdict;
+  /** Points inspected. Zero when the array is absent or empty. */
+  readonly sampled: number;
+  /**
+   * Fraction of sampled points whose channels differ by more than
+   * {@link RGB_CHROMA_FLOOR}. Zero for a greyscale cloud.
+   */
+  readonly chromaticFraction: number;
+  /** Interquartile range of sampled luminance, on the 0 to 255 scale. */
+  readonly luminanceIqr: number;
+}
+
+/**
+ * Channel spread, in 8-bit levels, at or below which a point counts as grey.
+ *
+ * Two levels absorbs the rounding a 16-bit source picks up on the way down to
+ * 8-bit without admitting colour that is not there.
+ */
+export const RGB_CHROMA_FLOOR = 2;
+
+/** Fraction of chromatic points at which colour is worth showing. */
+export const RGB_CHROMATIC_FRACTION_FLOOR = 0.02;
+
+/**
+ * Luminance interquartile range, in 8-bit levels, at which greys read as shape.
+ *
+ * Twelve levels is roughly five per cent of the range. Below it the middle half
+ * of the cloud sits inside a band too narrow to show relief on screen.
+ */
+export const RGB_LUMINANCE_IQR_FLOOR = 12;
+
+/**
+ * Points below which no verdict of uniform is returned.
+ *
+ * The measurements are summaries of a distribution, and a handful of points is
+ * not one. On thin evidence the answer is `readable`, because the cost of
+ * wrongly withholding true colour is higher than the cost of opening a small
+ * cloud in a wash the user can see and change.
+ */
+export const RGB_MIN_SAMPLE = 64;
+
+/** Points inspected at most, so the check stays cheap on a large cloud. */
+export const RGB_SAMPLE_TARGET = 20000;
+
+/**
+ * Measure a cloud's RGB array.
+ *
+ * The sample strides across the whole array rather than taking the head of it:
+ * point order usually follows acquisition or a spatial sort, so the first
+ * twenty thousand points are one corner of the scan and not the scan.
+ */
+export function readRgbReadability(colors: Uint8Array | undefined): RgbReadability {
+  const points = colors ? Math.floor(colors.length / 3) : 0;
+  if (points === 0) {
+    return { verdict: 'absent', sampled: 0, chromaticFraction: 0, luminanceIqr: 0 };
+  }
+  const rgb = colors as Uint8Array;
+
+  const stride = Math.max(1, Math.floor(points / RGB_SAMPLE_TARGET));
+  const luminance: number[] = [];
+  let chromatic = 0;
+  for (let p = 0; p < points; p += stride) {
+    const i = p * 3;
+    const r = rgb[i], g = rgb[i + 1], b = rgb[i + 2];
+    const spread = Math.max(r, g, b) - Math.min(r, g, b);
+    if (spread > RGB_CHROMA_FLOOR) chromatic++;
+    // Rec. 601 luma: the eye weights green most, and an unweighted mean would
+    // call a saturated green and a mid grey the same brightness.
+    luminance.push(0.299 * r + 0.587 * g + 0.114 * b);
+  }
+
+  const sampled = luminance.length;
+  const chromaticFraction = chromatic / sampled;
+  const luminanceIqr = interquartileRange(luminance);
+
+  if (sampled < RGB_MIN_SAMPLE) {
+    return { verdict: 'readable', sampled, chromaticFraction, luminanceIqr };
+  }
+  const readable =
+    chromaticFraction >= RGB_CHROMATIC_FRACTION_FLOOR ||
+    luminanceIqr >= RGB_LUMINANCE_IQR_FLOOR;
+  return {
+    verdict: readable ? 'readable' : 'uniform',
+    sampled,
+    chromaticFraction,
+    luminanceIqr,
+  };
+}
+
+/**
+ * Distance between the first and third quartiles.
+ *
+ * The quartiles are nearest-rank, which needs no interpolation rule and is
+ * therefore the same number on every platform. A range rather than a variance
+ * because one stray black or white point should not decide the verdict.
+ */
+function interquartileRange(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = values.slice().sort((a, b) => a - b);
+  const at = (q: number): number =>
+    sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1))];
+  return at(0.75) - at(0.25);
+}

--- a/src/render/rgbReadability.ts
+++ b/src/render/rgbReadability.ts
@@ -70,7 +70,13 @@ export const RGB_LUMINANCE_IQR_FLOOR = 12;
  */
 export const RGB_MIN_SAMPLE = 64;
 
-/** Points inspected at most, so the check stays cheap on a large cloud. */
+/**
+ * Sample size the stride aims at, so the check stays cheap on a large cloud.
+ *
+ * A target rather than a ceiling: the stride is an integer, so a cloud just
+ * under twice this size strides by one and inspects all of it. The real bound
+ * is twice the target, which is still a fixed cost.
+ */
 export const RGB_SAMPLE_TARGET = 20000;
 
 /**

--- a/tests/rgbReadability.test.ts
+++ b/tests/rgbReadability.test.ts
@@ -130,20 +130,53 @@ describe('readRgbReadability', () => {
     expect(r.chromaticFraction).toBeLessThan(0.25);
   });
 
-  it('costs a bounded number of samples on a large cloud', () => {
-    expect(readRgbReadability(cloud(2_000_000, () => [10, 200, 30])).sampled)
-      .toBeLessThanOrEqual(20_001);
+  it('does not alias against periodic structure in point order', () => {
+    // The defect this replaced a fixed stride to fix. One million points with
+    // colour on every fiftieth, and a stride of fifty, put the sampler on a
+    // coloured point every single time: it reported the cloud as 100 per cent
+    // chromatic when 2 per cent of it carries colour, a 4,900 per cent error.
+    // Point clouds are full of periodic order from scan lines, tile boundaries
+    // and interleaved returns, so this is a shape real data has.
+    const n = 1_000_000;
+    const c = cloud(n, (i) => (i % 50 === 0 ? [200, 40, 40] : [250, 250, 250]));
+    const r = readRgbReadability(c);
+    expect(r.chromaticFraction).toBeGreaterThan(0.015);
+    expect(r.chromaticFraction).toBeLessThan(0.025);
   });
 
-  it('bounds the sample at twice the target, which the integer stride allows', () => {
-    // Just under twice the target strides by one and inspects every point, so
-    // the bound is 2x rather than 1x. Still fixed, and worth stating rather
-    // than implying the target is a ceiling.
-    const justUnderDouble = readRgbReadability(cloud(39_999, () => [10, 200, 30]));
-    expect(justUnderDouble.sampled).toBe(39_999);
-    expect(justUnderDouble.sampled).toBeLessThan(2 * 20_000);
-    // One more point flips the stride to two and halves the sample.
-    expect(readRgbReadability(cloud(40_000, () => [10, 200, 30])).sampled).toBe(20_000);
+  it('holds that accuracy across a range of periods and cloud sizes', () => {
+    // Any fixed step aliases with SOME period; a step near the golden ratio of
+    // the count minimises the worst case rather than removing it. Measured
+    // worst relative error over these combinations is 11 per cent, against
+    // 4,900 for the fixed stride.
+    for (const n of [50_000, 250_000, 1_000_000]) {
+      for (const every of [8, 25, 50, 64, 128, 250]) {
+        const r = readRgbReadability(
+          cloud(n, (i) => (i % every === 0 ? [200, 40, 40] : [250, 250, 250])),
+        );
+        const truth = 1 / every;
+        expect(Math.abs(r.chromaticFraction - truth) / truth).toBeLessThan(0.2);
+      }
+    }
+  });
+
+  it('costs exactly the target on a large cloud', () => {
+    // The walk takes a fixed number of steps rather than striding to the end,
+    // so the sample size is the target and not a multiple of it.
+    expect(readRgbReadability(cloud(2_000_000, () => [10, 200, 30])).sampled).toBe(20_000);
+    expect(readRgbReadability(cloud(39_999, () => [10, 200, 30])).sampled).toBe(20_000);
+  });
+
+  it('inspects every point of a cloud smaller than the target', () => {
+    expect(readRgbReadability(cloud(500, () => [10, 200, 30])).sampled).toBe(500);
+  });
+
+  it('visits each point at most once, so no point is double counted', () => {
+    // The step is coprime to the count, which is what makes the walk a
+    // permutation rather than a cycle over a subset.
+    const n = 12_345;
+    const r = readRgbReadability(cloud(n, (i) => (i === 0 ? [200, 40, 40] : [250, 250, 250])));
+    expect(r.chromaticFraction).toBeCloseTo(1 / n, 6);
   });
 });
 
@@ -177,5 +210,72 @@ describe('recommendColorMode with a uniform colour array', () => {
     ]);
     expect(recommendColorMode({ colors: colourful, classification: new Uint8Array([2]) }).mode)
       .toBe('rgb');
+  });
+});
+
+describe('where the decision boundary actually sits', () => {
+  /**
+   * The three thresholds were chosen, not derived, and the file that motivated
+   * them is not in this repository. What can be pinned instead is where the
+   * boundary falls, so a reader can compare a real scan's two numbers against
+   * it rather than trusting the constants.
+   *
+   * These also make the constants load-bearing. Moving one without meaning to
+   * moves a boundary below, which is the failure a set of hand-picked numbers
+   * is otherwise wide open to.
+   */
+
+  /** A greyscale cloud whose luminance spans `span` levels around mid grey. */
+  function greysSpanning(span: number): Uint8Array {
+    return cloud(50_000, (i) => {
+      const v = Math.round(128 - span / 2 + (i % (span + 1)));
+      return [v, v, v];
+    });
+  }
+
+  /** A cloud where `fraction` of points carry strong chroma and the rest are flat. */
+  function chromaticFraction(fraction: number): Uint8Array {
+    const every = Math.max(1, Math.round(1 / fraction));
+    return cloud(50_000, (i) => (i % every === 0 ? [200, 40, 40] : [250, 250, 250]));
+  }
+
+  it('flips on luminance range within a few levels of the stated floor', () => {
+    // Below the floor the greys are a wash; above it they read as shape.
+    expect(readRgbReadability(greysSpanning(RGB_LUMINANCE_IQR_FLOOR * 2 - 4)).verdict)
+      .toBe('uniform');
+    expect(readRgbReadability(greysSpanning(RGB_LUMINANCE_IQR_FLOOR * 2 + 8)).verdict)
+      .toBe('readable');
+  });
+
+  it('flips on chromatic fraction within a factor of two of the stated floor', () => {
+    expect(readRgbReadability(chromaticFraction(RGB_CHROMATIC_FRACTION_FLOOR / 2)).verdict)
+      .toBe('uniform');
+    expect(readRgbReadability(chromaticFraction(RGB_CHROMATIC_FRACTION_FLOOR * 2)).verdict)
+      .toBe('readable');
+  });
+
+  it('reports the two numbers a reader can check a real scan against', () => {
+    // The verdict is a threshold applied to these, so a scan that lands near a
+    // boundary is visible as a figure rather than only as a yes or no.
+    const r = readRgbReadability(greysSpanning(6));
+    expect(r.luminanceIqr).toBeGreaterThan(0);
+    expect(r.chromaticFraction).toBe(0);
+    expect(r.sampled).toBeGreaterThan(RGB_MIN_SAMPLE);
+  });
+
+  it('calls the reported LA03mapry distribution uniform', () => {
+    // The scan that motivated this is not in the repository, so this
+    // reconstructs it from what was measured on it: greyscale throughout, mean
+    // 242 of 255, and 96 per cent of points near white. If a real file with
+    // those statistics did NOT land on `uniform`, the thresholds would be wrong
+    // for the only case anyone has actually seen.
+    const reconstructed = cloud(200_000, (i) => {
+      const nearWhite = i % 100 < 96;
+      const v = nearWhite ? 236 + (i % 9) : 200 + (i % 30);
+      return [v, v, v];
+    });
+    const r = readRgbReadability(reconstructed);
+    expect(r.chromaticFraction).toBe(0);
+    expect(r.verdict).toBe('uniform');
   });
 });

--- a/tests/rgbReadability.test.ts
+++ b/tests/rgbReadability.test.ts
@@ -134,6 +134,17 @@ describe('readRgbReadability', () => {
     expect(readRgbReadability(cloud(2_000_000, () => [10, 200, 30])).sampled)
       .toBeLessThanOrEqual(20_001);
   });
+
+  it('bounds the sample at twice the target, which the integer stride allows', () => {
+    // Just under twice the target strides by one and inspects every point, so
+    // the bound is 2x rather than 1x. Still fixed, and worth stating rather
+    // than implying the target is a ceiling.
+    const justUnderDouble = readRgbReadability(cloud(39_999, () => [10, 200, 30]));
+    expect(justUnderDouble.sampled).toBe(39_999);
+    expect(justUnderDouble.sampled).toBeLessThan(2 * 20_000);
+    // One more point flips the stride to two and halves the sample.
+    expect(readRgbReadability(cloud(40_000, () => [10, 200, 30])).sampled).toBe(20_000);
+  });
 });
 
 describe('recommendColorMode with a uniform colour array', () => {

--- a/tests/rgbReadability.test.ts
+++ b/tests/rgbReadability.test.ts
@@ -263,19 +263,33 @@ describe('where the decision boundary actually sits', () => {
     expect(r.sampled).toBeGreaterThan(RGB_MIN_SAMPLE);
   });
 
-  it('calls the reported LA03mapry distribution uniform', () => {
-    // The scan that motivated this is not in the repository, so this
-    // reconstructs it from what was measured on it: greyscale throughout, mean
-    // 242 of 255, and 96 per cent of points near white. If a real file with
-    // those statistics did NOT land on `uniform`, the thresholds would be wrong
-    // for the only case anyone has actually seen.
-    const reconstructed = cloud(200_000, (i) => {
-      const nearWhite = i % 100 < 96;
-      const v = nearWhite ? 236 + (i % 9) : 200 + (i % 30);
+  it('calls the measured LA03 distribution uniform, by a wide margin', () => {
+    /*
+     * The scan that motivated this work: `LA03mapry.laz` from Zenodo
+     * 15421291 (CC BY 4.0), registered as OLV-DS-054-SCANCMP-LA03. The file is
+     * 202 MB and not vendored, so this reproduces its colour distribution from
+     * a whole-file decode of the real bytes:
+     *
+     *   31,566,748 points, PDRF 2, 16-bit RGB narrowed by >> 8
+     *   exactly grey (R = G = B)   100.00%
+     *   chroma above 2 levels        0.00%
+     *   mean luminance             242.0 of 255
+     *   luminance quartiles        p25 253, p50 253, p75 253, so IQR 0
+     *
+     * The margin is the point. The floor is an interquartile range of 12 and
+     * this file's is zero, so the verdict does not depend on where the
+     * threshold sits within any plausible range. The thresholds were chosen
+     * rather than derived, and the only real case anyone has is nowhere near
+     * them.
+     */
+    const measured = cloud(200_000, (i) => {
+      // 95.64% at or above 230, the rest spread below, every point grey.
+      const v = i % 10_000 < 9_564 ? 253 : 180 + (i % 50);
       return [v, v, v];
     });
-    const r = readRgbReadability(reconstructed);
+    const r = readRgbReadability(measured);
     expect(r.chromaticFraction).toBe(0);
+    expect(r.luminanceIqr).toBe(0);
     expect(r.verdict).toBe('uniform');
   });
 });

--- a/tests/rgbReadability.test.ts
+++ b/tests/rgbReadability.test.ts
@@ -1,0 +1,170 @@
+/**
+ * rgbReadability.test.ts
+ *
+ * Whether a colour array is worth opening a scan in.
+ *
+ * The case this exists for: a survey that carries a full RGB array in which
+ * every point is within a few levels of white. The channel is present, the
+ * renderer draws it, and the result is a blank sheet. A real file measured at
+ * a mean of 242 of 255, entirely greyscale, with 96 per cent of its points near
+ * white, and it opened in true colour because the check asked whether colour
+ * existed rather than whether it could be read.
+ *
+ * The failure in the other direction matters more, so the tests below spend
+ * most of their attention on clouds that must KEEP true colour: dim ones, dark
+ * ones, monochrome ones with real contrast, and ones where only a small part of
+ * the scan is coloured at all.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  readRgbReadability,
+  RGB_MIN_SAMPLE,
+  RGB_LUMINANCE_IQR_FLOOR,
+  RGB_CHROMATIC_FRACTION_FLOOR,
+} from '../src/render/rgbReadability';
+import { recommendColorMode } from '../src/render/colorModeRecommend';
+
+/** An RGB array of `n` points, coloured by `f`. */
+function cloud(n: number, f: (i: number) => readonly [number, number, number]): Uint8Array {
+  const out = new Uint8Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    const [r, g, b] = f(i);
+    out[i * 3] = r; out[i * 3 + 1] = g; out[i * 3 + 2] = b;
+  }
+  return out;
+}
+
+/** A deterministic pseudo-random in [0, 1); no seeded generator needed. */
+function rand(i: number): number {
+  const x = Math.sin(i * 12.9898) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+describe('readRgbReadability', () => {
+  it('reports absent for a missing or empty array', () => {
+    expect(readRgbReadability(undefined).verdict).toBe('absent');
+    expect(readRgbReadability(new Uint8Array(0)).verdict).toBe('absent');
+  });
+
+  it('calls a near-white greyscale cloud uniform', () => {
+    // The measured shape: grey, mean around 242, tightly clustered near white.
+    const c = cloud(50_000, (i) => {
+      const v = 236 + Math.round(rand(i) * 8);
+      return [v, v, v];
+    });
+    const r = readRgbReadability(c);
+    expect(r.verdict).toBe('uniform');
+    expect(r.chromaticFraction).toBe(0);
+    expect(r.luminanceIqr).toBeLessThan(RGB_LUMINANCE_IQR_FLOOR);
+  });
+
+  it('calls a near-black cloud uniform too, which is the same wash', () => {
+    const c = cloud(50_000, (i) => {
+      const v = Math.round(rand(i) * 6);
+      return [v, v, v];
+    });
+    expect(readRgbReadability(c).verdict).toBe('uniform');
+  });
+
+  it('keeps a photogrammetric cloud readable', () => {
+    const c = cloud(50_000, (i) => [
+      Math.round(rand(i) * 255),
+      Math.round(rand(i + 1) * 255),
+      Math.round(rand(i + 2) * 255),
+    ]);
+    const r = readRgbReadability(c);
+    expect(r.verdict).toBe('readable');
+    expect(r.chromaticFraction).toBeGreaterThan(0.5);
+  });
+
+  it('keeps a monochrome cloud with real contrast readable', () => {
+    // No chroma at all, but the greys span the range, so shape is visible.
+    const c = cloud(50_000, (i) => {
+      const v = Math.round(rand(i) * 255);
+      return [v, v, v];
+    });
+    const r = readRgbReadability(c);
+    expect(r.chromaticFraction).toBe(0);
+    expect(r.luminanceIqr).toBeGreaterThan(RGB_LUMINANCE_IQR_FLOOR);
+    expect(r.verdict).toBe('readable');
+  });
+
+  it('keeps a dim but colourful cloud readable', () => {
+    // Every point dark, so luminance barely varies, but the hues differ.
+    const c = cloud(50_000, (i) => {
+      const h = i % 3;
+      return [h === 0 ? 24 : 2, h === 1 ? 24 : 2, h === 2 ? 24 : 2];
+    });
+    const r = readRgbReadability(c);
+    expect(r.luminanceIqr).toBeLessThan(RGB_LUMINANCE_IQR_FLOOR);
+    expect(r.chromaticFraction).toBeGreaterThan(RGB_CHROMATIC_FRACTION_FLOOR);
+    expect(r.verdict).toBe('readable');
+  });
+
+  it('keeps a cloud readable when only a small minority carries colour', () => {
+    // Three per cent coloured against a flat white background: above the floor,
+    // so the colour that is there is not thrown away.
+    const c = cloud(50_000, (i) => (i % 33 === 0 ? [200, 40, 40] : [250, 250, 250]));
+    const r = readRgbReadability(c);
+    expect(r.chromaticFraction).toBeGreaterThan(RGB_CHROMATIC_FRACTION_FLOOR);
+    expect(r.verdict).toBe('readable');
+  });
+
+  it('refuses to call a handful of points uniform', () => {
+    // A summary of a distribution needs a distribution. Below the floor the
+    // answer is readable, because withholding true colour is the worse error.
+    const tiny = cloud(RGB_MIN_SAMPLE - 1, () => [255, 255, 255]);
+    expect(readRgbReadability(tiny).verdict).toBe('readable');
+    const enough = cloud(RGB_MIN_SAMPLE, () => [255, 255, 255]);
+    expect(readRgbReadability(enough).verdict).toBe('uniform');
+  });
+
+  it('samples across the whole cloud rather than its head', () => {
+    // The first fifth is vivid and the rest is white. Point order follows
+    // acquisition, so a head-only sample would call this whole scan colourful.
+    const n = 500_000;
+    const c = cloud(n, (i) => (i < n / 5 ? [220, 30, 30] : [252, 252, 252]));
+    const r = readRgbReadability(c);
+    expect(r.chromaticFraction).toBeGreaterThan(0.15);
+    expect(r.chromaticFraction).toBeLessThan(0.25);
+  });
+
+  it('costs a bounded number of samples on a large cloud', () => {
+    expect(readRgbReadability(cloud(2_000_000, () => [10, 200, 30])).sampled)
+      .toBeLessThanOrEqual(20_001);
+  });
+});
+
+describe('recommendColorMode with a uniform colour array', () => {
+  const WASH = cloud(50_000, (i) => {
+    const v = 236 + Math.round(rand(i) * 8);
+    return [v, v, v];
+  });
+
+  it('opens a near-white scan in height rather than true colour', () => {
+    const r = recommendColorMode({ colors: WASH });
+    expect(r.mode).toBe('elevation');
+    expect(r.reason).toMatch(/too uniform/);
+  });
+
+  it('says why, distinctly from a scan that carries no colour at all', () => {
+    expect(recommendColorMode({}).reason).not.toMatch(/too uniform/);
+  });
+
+  it('prefers classification over a wash when the scan is classified', () => {
+    const r = recommendColorMode({
+      colors: WASH,
+      classification: new Uint8Array([2, 6, 2, 5]),
+    });
+    expect(r.mode).toBe('classification');
+  });
+
+  it('still opens a colourful scan in true colour', () => {
+    const colourful = cloud(50_000, (i) => [
+      Math.round(rand(i) * 255), Math.round(rand(i + 1) * 255), Math.round(rand(i + 2) * 255),
+    ]);
+    expect(recommendColorMode({ colors: colourful, classification: new Uint8Array([2]) }).mode)
+      .toBe('rgb');
+  });
+});


### PR DESCRIPTION
`cloudSupportsColorMode` asks whether a colour channel exists. That is the right question for whether a mode can be selected and the wrong one for what to open a scan in: a survey can carry a full RGB array in which every point is within a few levels of white, and colouring by it produces a blank sheet the user reads as a broken render. The file that raised this measured greyscale throughout, mean 242 of 255, with 96 per cent of its points near white.

`src/render/rgbReadability.ts` measures the array instead of counting it, and reports two numbers: the fraction of points carrying chroma, and the interquartile range of Rec. 601 luminance. Colour is readable when EITHER clears its floor. That disjunction is the design, because withholding true colour from a scan that has it is the worse error: a dim but colourful scan passes on chroma, a monochrome scan with real contrast passes on range, and only a cloud failing both is called uniform. Below 64 sampled points no verdict of uniform is returned at all, since a summary of a distribution needs a distribution.

`recommendColorMode` skips RGB as the opening choice when the verdict is uniform, falls through to classification or intensity if the scan has them, and otherwise lands on height with a reason that says the scan carries RGB rather than that it carries none. Nothing a user can select changes.

**The sampler was the interesting part.** It began as a fixed stride across the array, which aliases against periodic order: one million points with colour on every fiftieth, sampled every fiftieth, put it on a coloured point every single time and measured the cloud as 100 per cent chromatic where 2 per cent carries colour. A 4,900 per cent error, and the feature's own failure inverted, since a near-white cloud with a periodic colour pattern would then open in exactly the wash this exists to avoid. Point clouds carry periodic order from scan lines, tile boundaries and interleaved returns, so that is a shape real data has. The sample now steps by a value near the golden ratio of the point count, made coprime so the walk is a permutation over the points; worst relative error across 80 period and size combinations falls to 11 per cent. Both the specific case and the sweep are pinned.

**What is not settled.** The three thresholds were chosen, not derived, and `LA03mapry.laz` is not in this repository, so the file that motivated the work has never been run through the code. A test reconstructs its reported distribution and confirms that lands on `uniform`, which is the nearest thing available to a check against the real case. The boundary is also pinned in both directions, so a reader can compare a real scan's two numbers against where the line sits instead of trusting the constants. Running the actual file would settle it.

Streaming sources are not covered: `defaultColorMode()` answers before a tile has decoded, so there is nothing to measure at open.

Height is an inference about what was asked for. The request was for a preset that makes an uncoloured cloud "look colorful"; elevation is the defensible reading, since it derives from position alone and is therefore always available, but it is a reading.

Gates: typecheck, `lint:architecture-truth`, `lint:module-graph`, `lint:release-truth`, `lint:layer-boundaries`, `test:unit` (6,771 passed) and `test:ui` (657 passed).
