### PR TITLE
Bound the geodesic void fill by the work it will cost

### DIFF
--- a/src/terrain/ground/cellConfidence.ts
+++ b/src/terrain/ground/cellConfidence.ts
@@ -39,7 +39,7 @@ import type { TerrainCoverageMode } from '../TerrainContracts';
 import type { DemRaster } from './rasterizeDtm';
 import { inpaintNearest } from './groundFilter';
 import { idwFill } from './idwFill';
-import { geodesicFill } from './geodesicFill';
+import { geodesicFillWithReport, GEODESIC_NODE_BUDGET } from './geodesicFill';
 import { hornSlope } from './terrainDerivatives';
 import { horizontalCellMetresXY } from './horizontalScale';
 
@@ -209,6 +209,13 @@ export interface CellConfidenceParams {
    */
   readonly interpolation?: 'idw' | 'geodesic';
   /**
+   * Ceiling on the geodesic pass's search steps, defaulting to
+   * {@link GEODESIC_NODE_BUDGET}. Above it the whole grid keeps the Euclidean
+   * prefill and a warning says so. A caller willing to wait longer for a better
+   * surface across large data gaps raises it; one on a slow device lowers it.
+   */
+  readonly geodesicNodeBudget?: number;
+  /**
    * DTM hardening — extrapolation guard. An interpolated cell whose
    * supporting data lies only on one side is an *extrapolation*, not an
    * interpolation, and is the least trustworthy filled surface: there is no
@@ -293,17 +300,34 @@ export function buildDtmGrid(raster: DemRaster, params: CellConfidenceParams = {
   );
 
   const nearest = inpaintNearest(raster.z, hadData, cols, rows);
-  const idw =
-    params.interpolation === 'geodesic'
-      ? geodesicFill(raster.z, hadData, cols, rows, {
-          // The geodesic cost adds a horizontal step to a vertical rise, so
-          // both must be metres. Passing the raw cell size collapsed the cost
-          // to vertical-only on a degree grid (~1e-5 beside metre heights).
-          cellMetresX: cellM.x,
-          cellMetresY: cellM.y,
-          verticalUnitToMetres: params.verticalUnitToMetres,
-        })
-      : idwFill(raster.z, hadData, cols, rows, {});
+  let idw: Float32Array;
+  if (params.interpolation === 'geodesic') {
+    const filled = geodesicFillWithReport(raster.z, hadData, cols, rows, {
+      // The geodesic cost adds a horizontal step to a vertical rise, so
+      // both must be metres. Passing the raw cell size collapsed the cost
+      // to vertical-only on a degree grid (~1e-5 beside metre heights).
+      cellMetresX: cellM.x,
+      cellMetresY: cellM.y,
+      verticalUnitToMetres: params.verticalUnitToMetres,
+      nodeBudget: params.geodesicNodeBudget,
+    });
+    idw = filled.z;
+    if (filled.report.abandoned) {
+      // The grid's voids are large enough that walking them would have cost
+      // more than the pass allows, so every void carries the Euclidean fill.
+      // Said here because the method name promises geodesic distance, and a
+      // report that names a method the run did not use is the overclaim.
+      warnings.push(
+        `void fill fell back to Euclidean IDW — the geodesic pass over ` +
+          `${filled.report.voids.toLocaleString('en-US')} void cells was projected ` +
+          `to cost ${Math.round(filled.report.projectedNodes / 1e6).toLocaleString('en-US')}M ` +
+          `search steps, above the ${Math.round((params.geodesicNodeBudget ?? GEODESIC_NODE_BUDGET) / 1e6)}M ceiling; ` +
+          `heights across data gaps are less reliable than a geodesic fill would give`,
+      );
+    }
+  } else {
+    idw = idwFill(raster.z, hadData, cols, rows, {});
+  }
 
   // Distance-to-data in cells (multi-source BFS, 8-connectivity).
   const interpDistanceCells = distanceToData(hadData, cols, rows);

--- a/src/terrain/ground/cellConfidence.ts
+++ b/src/terrain/ground/cellConfidence.ts
@@ -317,11 +317,20 @@ export function buildDtmGrid(raster: DemRaster, params: CellConfidenceParams = {
       // more than the pass allows, so every void carries the Euclidean fill.
       // Said here because the method name promises geodesic distance, and a
       // report that names a method the run did not use is the overclaim.
+      const ceilingM = Math.round(
+        (params.geodesicNodeBudget ?? GEODESIC_NODE_BUDGET) / 1e6,
+      );
+      // The two stops need different words. Only the projection can say the
+      // cost was estimated above the ceiling; the ceiling itself fires when the
+      // estimate was below it and the real pass ran out.
+      const cause =
+        filled.report.stoppedBy === 'projection'
+          ? `was projected to cost ${Math.round(filled.report.projectedNodes / 1e6).toLocaleString('en-US')}M ` +
+            `search steps, above the ${ceilingM}M ceiling`
+          : `reached the ${ceilingM}M search-step ceiling before it finished`;
       warnings.push(
         `void fill fell back to Euclidean IDW — the geodesic pass over ` +
-          `${filled.report.voids.toLocaleString('en-US')} void cells was projected ` +
-          `to cost ${Math.round(filled.report.projectedNodes / 1e6).toLocaleString('en-US')}M ` +
-          `search steps, above the ${Math.round((params.geodesicNodeBudget ?? GEODESIC_NODE_BUDGET) / 1e6)}M ceiling; ` +
+          `${filled.report.voids.toLocaleString('en-US')} void cells ${cause}; ` +
           `heights across data gaps are less reliable than a geodesic fill would give`,
       );
     }

--- a/src/terrain/ground/cellConfidence.ts
+++ b/src/terrain/ground/cellConfidence.ts
@@ -317,6 +317,15 @@ export function buildDtmGrid(raster: DemRaster, params: CellConfidenceParams = {
       // more than the pass allows, so every void carries the Euclidean fill.
       // Said here because the method name promises geodesic distance, and a
       // report that names a method the run did not use is the overclaim.
+      //
+      // The size of the loss is measured, not cited. `geodesicFillAccuracy`
+      // fills analytic surfaces both ways and compares against known truth: a
+      // void beside a softened scarp is 20% closer to truth under the geodesic
+      // fill, a void away from any contrast is unchanged, and on the flank of a
+      // symmetric ridge the geodesic fill is 10% WORSE, because crossing a
+      // crest whose far side sits at the same height costs nothing while the
+      // rise in the path cost still biases the estimate downhill. So the
+      // wording names the condition rather than claiming a general loss.
       const ceilingM = Math.round(
         (params.geodesicNodeBudget ?? GEODESIC_NODE_BUDGET) / 1e6,
       );
@@ -331,7 +340,9 @@ export function buildDtmGrid(raster: DemRaster, params: CellConfidenceParams = {
       warnings.push(
         `void fill fell back to Euclidean IDW — the geodesic pass over ` +
           `${filled.report.voids.toLocaleString('en-US')} void cells ${cause}; ` +
-          `heights across data gaps are less reliable than a geodesic fill would give`,
+          `heights in gaps beside a break in slope are the ones affected, ` +
+          `by around 20% of their error on a synthetic scarp, and gaps away ` +
+          `from one are unchanged`,
       );
     }
   } else {

--- a/src/terrain/ground/geodesicFill.ts
+++ b/src/terrain/ground/geodesicFill.ts
@@ -67,6 +67,14 @@ export interface GeodesicParams {
    * enough to reach the real ceiling.
    */
   readonly nodeBudget?: number;
+  /**
+   * Voids sampled to project the cost. Default {@link GEODESIC_PROBE_VOIDS}.
+   *
+   * Exposed because the sample size sets the order voids are solved in, and a
+   * fill whose answer depended on that order would be a defect the default
+   * alone could not reveal.
+   */
+  readonly probeVoids?: number;
 }
 
 /**
@@ -301,7 +309,8 @@ export function geodesicFillWithReport(
   // spreads the sample across the grid, where the expensive voids are: one
   // inside a large gap has to expand most of its window before it collects
   // kNearest measured cells, and one beside a measured cell does not.
-  const probeStride = Math.max(1, Math.ceil(voids.length / GEODESIC_PROBE_VOIDS));
+  const probeVoids = Math.max(1, Math.floor(positiveOr(params.probeVoids, GEODESIC_PROBE_VOIDS)));
+  const probeStride = Math.max(1, Math.ceil(voids.length / probeVoids));
   let probed = 0;
   for (let i = 0; i < voids.length; i += probeStride) { solve(voids[i]); probed++; }
   const projectedNodes = Math.round((pops / probed) * voids.length);

--- a/src/terrain/ground/geodesicFill.ts
+++ b/src/terrain/ground/geodesicFill.ts
@@ -32,9 +32,22 @@
  * nearest" would no longer follow cell-ring order. Deliberately out of scope
  * here; the pass-2 unit bug it sat behind is the one being fixed.
  *
- * Honesty is unchanged: this only produces better interpolated HEIGHTS. Which
- * cells count as measured / interpolated / gap, and their confidence, is still
- * decided in cellConfidence.ts. No DOM, no I/O.
+ * The 13-17% figure is Duan et al.'s, on their data with their code, and it is
+ * not evidence about this implementation. `geodesicFillAccuracy.test.ts`
+ * measures this one against analytic surfaces where the truth is known at every
+ * cell, and the answer is conditional. A void whose neighbourhood reaches
+ * across an elevation CONTRAST is 20% closer to truth beside a softened scarp
+ * and 25% closer beside a hard one. A void with no contrast to cross is
+ * unchanged. On the flank of a SYMMETRIC ridge the geodesic fill is 10% worse,
+ * because the far side of a symmetric crest sits at the same height as the near
+ * side, so crossing it costs nothing while the rise in the path cost still
+ * biases the estimate downhill. A symmetric ridge is the case that looks like a
+ * barrier and is not one.
+ *
+ * Honesty is unchanged: this only produces better interpolated HEIGHTS, and
+ * only where the paragraph above says so. Which cells count as measured /
+ * interpolated / gap, and their confidence, is still decided in
+ * cellConfidence.ts. No DOM, no I/O.
  */
 
 import { idwFill } from './idwFill';

--- a/src/terrain/ground/geodesicFill.ts
+++ b/src/terrain/ground/geodesicFill.ts
@@ -61,6 +61,51 @@ export interface GeodesicParams {
    * unit; a foot-vertical grid measured against metre steps overstates the climb.
    */
   readonly verticalUnitToMetres?: number;
+  /**
+   * Heap pops the whole fill may spend. Default {@link GEODESIC_NODE_BUDGET}.
+   * Exposed so a test can drive the abandon path without building a grid large
+   * enough to reach the real ceiling.
+   */
+  readonly nodeBudget?: number;
+}
+
+/**
+ * Heap pops the whole fill may spend before it abandons the geodesic pass.
+ *
+ * `maxRadiusCells` bounds the work for ONE void, and nothing bounded the total.
+ * A scan of scattered single-cell voids is cheap because each Dijkstra finds
+ * its twelve measured cells within a step or two, and a scan with large
+ * contiguous gaps is not: every void inside a blob has to expand most of its
+ * radius-24 window first. The only thing separating the two cases is void
+ * shape, which no existing cap looked at.
+ *
+ * Measured, at roughly 8 million pops per second:
+ *
+ *   2000x2000, 35% scattered voids     28M pops     2.2 s
+ *   500x500, 32-cell void tiles        35M pops     4.4 s
+ *   1000x1000, 32-cell void tiles     137M pops    17.1 s
+ *   1500x1500, 64-cell void tiles     629M pops    82.7 s
+ *
+ * Sixty million sits above every scattered case and above the smallest blobby
+ * one, and below the grids that run for a minute or more. A device slower than
+ * the one measured spends longer at the same budget, so the ceiling is a bound
+ * on work rather than a promise about seconds.
+ */
+export const GEODESIC_NODE_BUDGET = 60_000_000;
+
+/** Voids sampled to project the cost of the whole pass. */
+export const GEODESIC_PROBE_VOIDS = 2_000;
+
+/** What the fill actually did, so a caller can say which method built a cell. */
+export interface GeodesicFillReport {
+  /** Void cells the pass was asked to fill. */
+  readonly voids: number;
+  /** True when the projected cost exceeded the budget and no void got a geodesic value. */
+  readonly abandoned: boolean;
+  /** Heap pops spent, including the probe. */
+  readonly nodesExpanded: number;
+  /** Pops the projection expected for the whole grid, from the probe. */
+  readonly projectedNodes: number;
 }
 
 /** Positive-and-finite guard, or the fallback. Never a silent 0 step. */
@@ -84,10 +129,37 @@ export function geodesicFill(
   rows: number,
   params: GeodesicParams = {},
 ): Float32Array {
+  return geodesicFillWithReport(z, hadData, cols, rows, params).z;
+}
+
+/**
+ * {@link geodesicFill}, plus what it did.
+ *
+ * The pass is costed before it is committed to. A strided sample of voids is
+ * solved first and its pops per void projected over the whole void set; if the
+ * projection exceeds the budget the geodesic values are discarded and every
+ * void keeps its Euclidean prefill. All or nothing, deliberately: a surface
+ * built by one interpolant in the north and another in the south is harder to
+ * defend than one built throughout by the weaker of the two and labelled as
+ * such, and the seam between them would be visible in the contours.
+ *
+ * The sample strides through the voids in index order, so it spans the grid and
+ * the same grid always yields the same answer.
+ */
+export function geodesicFillWithReport(
+  z: Float32Array,
+  hadData: Uint8Array,
+  cols: number,
+  rows: number,
+  params: GeodesicParams = {},
+): { z: Float32Array; report: GeodesicFillReport } {
   const n = cols * rows;
   const out = new Float32Array(n);
   out.set(z);
-  if (n === 0) return out;
+  const empty: GeodesicFillReport = {
+    voids: 0, abandoned: false, nodesExpanded: 0, projectedNodes: 0,
+  };
+  if (n === 0) return { z: out, report: empty };
 
   const power = Number.isFinite(params.power) && (params.power as number) > 0 ? (params.power as number) : 2;
   const kNearest = Math.max(1, Math.floor(params.kNearest ?? 12));
@@ -147,60 +219,99 @@ export function geodesicFill(
     return top;
   };
 
-  for (let srow = 0; srow < rows; srow++) {
-    for (let scol = 0; scol < cols; scol++) {
-      const src = srow * cols + scol;
-      if (hadData[src] === 1) continue; // measured — keep verbatim
-      if (!Number.isFinite(surface[src])) { out[src] = Number.NaN; continue; } // unreachable gap
+  // Pops spent so far, the unit the budget is denominated in.
+  let pops = 0;
 
-      const iter = src; // unique per void; stamps scratch arrays
-      heapLen = 0;
-      dist[src] = 0; seen[src] = iter;
-      heapPush(0, src);
+  /** Solve one void by geodesic-distance IDW, writing `out[src]`. */
+  const solve = (src: number): void => {
+    const srow = (src / cols) | 0;
+    const scol = src - srow * cols;
+    const iter = src; // unique per void; stamps scratch arrays
+    heapLen = 0;
+    dist[src] = 0; seen[src] = iter;
+    heapPush(0, src);
 
-      let wSum = 0;
-      let vSum = 0;
-      let collected = 0;
+    let wSum = 0;
+    let vSum = 0;
+    let collected = 0;
 
-      while (heapLen > 0 && collected < kNearest) {
-        const c = heapPop();
-        const cost = dist[c];
-        if (hadData[c] === 1) {
-          // Nearest measured cell by geodesic cost — absorb into the blend and
-          // do not expand through it. Skip a stale duplicate pop so each measured
-          // cell contributes exactly once (its first, lowest-cost pop).
-          if (absorbed[c] === iter) continue;
-          absorbed[c] = iter;
-          const w = 1 / Math.pow(cost, power);
-          wSum += w; vSum += w * z[c];
-          collected++;
-          continue;
-        }
-        const cr = (c / cols) | 0;
-        const cc = c - cr * cols;
-        for (let k = 0; k < 8; k++) {
-          const nr = cr + DR[k];
-          const nc = cc + DC[k];
-          if (nr < 0 || nr >= rows || nc < 0 || nc >= cols) continue;
-          // Stay within the window around the source so the search is bounded.
-          if (Math.abs(nr - srow) > maxRadius || Math.abs(nc - scol) > maxRadius) continue;
-          const nb = nr * cols + nc;
-          if (!Number.isFinite(surface[nb])) continue; // can't walk over unknown ground
-          let stepXY: number;
-          if (DR[k] !== 0 && DC[k] !== 0) stepXY = cellDiag;
-          else if (DC[k] !== 0) stepXY = cellX;
-          else stepXY = cellY;
-          const dz = (surface[nb] - surface[c]) * zScale;
-          const nd = cost + Math.sqrt(stepXY * stepXY + dz * dz);
-          if (seen[nb] !== iter || nd < dist[nb]) {
-            dist[nb] = nd; seen[nb] = iter;
-            heapPush(nd, nb);
-          }
+    while (heapLen > 0 && collected < kNearest) {
+      const c = heapPop();
+      pops++;
+      const cost = dist[c];
+      if (hadData[c] === 1) {
+        // Nearest measured cell by geodesic cost — absorb into the blend and
+        // do not expand through it. Skip a stale duplicate pop so each measured
+        // cell contributes exactly once (its first, lowest-cost pop).
+        if (absorbed[c] === iter) continue;
+        absorbed[c] = iter;
+        const w = 1 / Math.pow(cost, power);
+        wSum += w; vSum += w * z[c];
+        collected++;
+        continue;
+      }
+      const cr = (c / cols) | 0;
+      const cc = c - cr * cols;
+      for (let k = 0; k < 8; k++) {
+        const nr = cr + DR[k];
+        const nc = cc + DC[k];
+        if (nr < 0 || nr >= rows || nc < 0 || nc >= cols) continue;
+        // Stay within the window around the source so the search is bounded.
+        if (Math.abs(nr - srow) > maxRadius || Math.abs(nc - scol) > maxRadius) continue;
+        const nb = nr * cols + nc;
+        if (!Number.isFinite(surface[nb])) continue; // can't walk over unknown ground
+        let stepXY: number;
+        if (DR[k] !== 0 && DC[k] !== 0) stepXY = cellDiag;
+        else if (DC[k] !== 0) stepXY = cellX;
+        else stepXY = cellY;
+        const dz = (surface[nb] - surface[c]) * zScale;
+        const nd = cost + Math.sqrt(stepXY * stepXY + dz * dz);
+        if (seen[nb] !== iter || nd < dist[nb]) {
+          dist[nb] = nd; seen[nb] = iter;
+          heapPush(nd, nb);
         }
       }
-
-      out[src] = wSum > 0 ? vSum / wSum : surface[src];
     }
+
+    out[src] = wSum > 0 ? vSum / wSum : surface[src];
+  };
+
+  // The voids to fill, in index order. A cell the prefill could not reach has
+  // no provisional height to walk from, so it stays NaN and the caller decides.
+  const voids: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (hadData[i] === 1) continue; // measured — keep verbatim
+    if (!Number.isFinite(surface[i])) { out[i] = Number.NaN; continue; } // unreachable gap
+    voids.push(i);
   }
-  return out;
+  if (voids.length === 0) return { z: out, report: empty };
+
+  // Probe: solve a strided sample, then project its pops per void over the
+  // whole set. Striding through the void list rather than taking its head
+  // spreads the sample across the grid, where the expensive voids are: one
+  // inside a large gap has to expand most of its window before it collects
+  // kNearest measured cells, and one beside a measured cell does not.
+  const probeStride = Math.max(1, Math.ceil(voids.length / GEODESIC_PROBE_VOIDS));
+  let probed = 0;
+  for (let i = 0; i < voids.length; i += probeStride) { solve(voids[i]); probed++; }
+  const projectedNodes = Math.round((pops / probed) * voids.length);
+
+  const nodeBudget = positiveOr(params.nodeBudget, GEODESIC_NODE_BUDGET);
+  if (projectedNodes > nodeBudget) {
+    // Discard the probe's geodesic values so the whole grid is one interpolant.
+    for (const src of voids) out[src] = surface[src];
+    return {
+      z: out,
+      report: { voids: voids.length, abandoned: true, nodesExpanded: pops, projectedNodes },
+    };
+  }
+
+  for (let i = 0; i < voids.length; i++) {
+    if (i % probeStride === 0) continue; // solved by the probe
+    solve(voids[i]);
+  }
+  return {
+    z: out,
+    report: { voids: voids.length, abandoned: false, nodesExpanded: pops, projectedNodes },
+  };
 }

--- a/src/terrain/ground/geodesicFill.ts
+++ b/src/terrain/ground/geodesicFill.ts
@@ -79,17 +79,18 @@ export interface GeodesicParams {
  * radius-24 window first. The only thing separating the two cases is void
  * shape, which no existing cap looked at.
  *
- * Measured, at roughly 8 million pops per second:
+ * Pops are the unit because they are the reproducible measurement: the same
+ * grid yields the same count on every run and every machine, while the seconds
+ * below moved 40% between two runs on one loaded laptop.
  *
- *   2000x2000, 35% scattered voids     28M pops     2.2 s
- *   500x500, 32-cell void tiles        35M pops     4.4 s
- *   1000x1000, 32-cell void tiles     137M pops    17.1 s
- *   1500x1500, 64-cell void tiles     629M pops    82.7 s
+ *   2000x2000, 35% scattered voids     28M pops     2.3 to 2.8 s
+ *   500x500, 32-cell void tiles        35M pops     6.1 s
+ *   1000x1000, 32-cell void tiles     137M pops    23.5 to 23.8 s
+ *   1500x1500, 64-cell void tiles     629M pops    83 s
  *
  * Sixty million sits above every scattered case and above the smallest blobby
- * one, and below the grids that run for a minute or more. A device slower than
- * the one measured spends longer at the same budget, so the ceiling is a bound
- * on work rather than a promise about seconds.
+ * one, and below the grids that run for tens of seconds. What it bounds is
+ * work; how long that work takes is the device's business.
  */
 export const GEODESIC_NODE_BUDGET = 60_000_000;
 
@@ -100,8 +101,17 @@ export const GEODESIC_PROBE_VOIDS = 2_000;
 export interface GeodesicFillReport {
   /** Void cells the pass was asked to fill. */
   readonly voids: number;
-  /** True when the projected cost exceeded the budget and no void got a geodesic value. */
+  /** True when the pass was given up and no void got a geodesic value. */
   readonly abandoned: boolean;
+  /**
+   * Which check gave the pass up.
+   *
+   * `'projection'` means it never started, because the probe's estimate was
+   * already above the ceiling. `'ceiling'` means it started and ran out, which
+   * happens when the estimate was low. The two need different words in a
+   * report: only the first can say the cost was projected above the ceiling.
+   */
+  readonly stoppedBy: 'projection' | 'ceiling' | null;
   /** Heap pops spent, including the probe. */
   readonly nodesExpanded: number;
   /** Pops the projection expected for the whole grid, from the probe. */
@@ -157,7 +167,7 @@ export function geodesicFillWithReport(
   const out = new Float32Array(n);
   out.set(z);
   const empty: GeodesicFillReport = {
-    voids: 0, abandoned: false, nodesExpanded: 0, projectedNodes: 0,
+    voids: 0, abandoned: false, stoppedBy: null, nodesExpanded: 0, projectedNodes: 0,
   };
   if (n === 0) return { z: out, report: empty };
 
@@ -302,16 +312,38 @@ export function geodesicFillWithReport(
     for (const src of voids) out[src] = surface[src];
     return {
       z: out,
-      report: { voids: voids.length, abandoned: true, nodesExpanded: pops, projectedNodes },
+      report: {
+        voids: voids.length, abandoned: true, stoppedBy: 'projection',
+        nodesExpanded: pops, projectedNodes,
+      },
     };
   }
 
   for (let i = 0; i < voids.length; i++) {
     if (i % probeStride === 0) continue; // solved by the probe
     solve(voids[i]);
+    // The projection decides whether to start; this decides whether to finish.
+    // Cost per void varies by two orders of magnitude between a void beside
+    // measured ground and one deep inside a gap, and a strided sample of that
+    // distribution can be well out: measured across 24 void morphologies the
+    // median error is 0.5% and the worst is 36%. Without this the ceiling would
+    // bound a projection rather than the work, which is not what it is for.
+    if (pops > nodeBudget) {
+      for (const src of voids) out[src] = surface[src];
+      return {
+        z: out,
+        report: {
+          voids: voids.length, abandoned: true, stoppedBy: 'ceiling',
+          nodesExpanded: pops, projectedNodes,
+        },
+      };
+    }
   }
   return {
     z: out,
-    report: { voids: voids.length, abandoned: false, nodesExpanded: pops, projectedNodes },
+    report: {
+      voids: voids.length, abandoned: false, stoppedBy: null,
+      nodesExpanded: pops, projectedNodes,
+    },
   };
 }

--- a/tests/cellConfidence.test.ts
+++ b/tests/cellConfidence.test.ts
@@ -407,6 +407,9 @@ describe('buildDtmGrid geodesic cost ceiling', () => {
     expect(warning).toBeDefined();
     expect(warning).toMatch(/void cells/);
     expect(warning).toMatch(/ceiling/);
+    // A ceiling of one stops the pass before it starts, so the wording is the
+    // projection's, which is the only one entitled to quote a projected cost.
+    expect(warning).toMatch(/was projected to cost/);
   });
 
   it('says nothing when the pass fits inside the ceiling', () => {

--- a/tests/cellConfidence.test.ts
+++ b/tests/cellConfidence.test.ts
@@ -382,3 +382,53 @@ describe('buildDtmGrid vertical unit propagation', () => {
     expect(buildDtmGrid(nonEmpty(), params).verticalUnitToMetres).toBe(empty.verticalUnitToMetres);
   });
 });
+
+describe('buildDtmGrid geodesic cost ceiling', () => {
+  /** A 24x24 grid of alternating 4-cell measured and void tiles. */
+  function tiled(): { z: number[]; counts: number[]; cols: number; rows: number } {
+    const cols = 24, rows = 24;
+    const z: number[] = [], counts: number[] = [];
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const isVoid = ((((r / 4) | 0) + ((c / 4) | 0)) % 2) === 1;
+        z.push(isVoid ? Number.NaN : 10 + r * 0.5 + c * 0.25);
+        counts.push(isVoid ? 0 : 8);
+      }
+    }
+    return { z, counts, cols, rows };
+  }
+
+  it('says so in the warnings when it falls back to Euclidean IDW', () => {
+    const g = buildDtmGrid(raster(tiled()), {
+      interpolation: 'geodesic',
+      geodesicNodeBudget: 1,
+    });
+    const warning = g.warnings.find((w) => w.includes('Euclidean IDW'));
+    expect(warning).toBeDefined();
+    expect(warning).toMatch(/void cells/);
+    expect(warning).toMatch(/ceiling/);
+  });
+
+  it('says nothing when the pass fits inside the ceiling', () => {
+    const g = buildDtmGrid(raster(tiled()), { interpolation: 'geodesic' });
+    expect(g.warnings.some((w) => w.includes('Euclidean IDW'))).toBe(false);
+  });
+
+  it('says nothing when the caller never asked for a geodesic fill', () => {
+    const g = buildDtmGrid(raster(tiled()), {
+      interpolation: 'idw',
+      geodesicNodeBudget: 1,
+    });
+    expect(g.warnings.some((w) => w.includes('Euclidean IDW'))).toBe(false);
+  });
+
+  it('still produces a height for every void it can reach after falling back', () => {
+    const g = buildDtmGrid(raster(tiled()), {
+      interpolation: 'geodesic',
+      geodesicNodeBudget: 1,
+    });
+    let heights = 0;
+    for (let i = 0; i < g.z.length; i++) if (g.coverage[i] > 0) heights++;
+    expect(heights).toBeGreaterThan(g.cols * g.rows * 0.5);
+  });
+});

--- a/tests/geodesicFill.test.ts
+++ b/tests/geodesicFill.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { geodesicFill } from '../src/terrain/ground/geodesicFill';
+import {
+  geodesicFill,
+  geodesicFillWithReport,
+  GEODESIC_PROBE_VOIDS,
+} from '../src/terrain/ground/geodesicFill';
 import { idwFill } from '../src/terrain/ground/idwFill';
 
 describe('geodesicFill', () => {
@@ -90,5 +94,110 @@ describe('geodesicFill', () => {
       2, 1, {},
     );
     expect(empty.every((v) => Number.isNaN(v))).toBe(true);
+  });
+});
+
+/**
+ * A grid of alternating measured and void tiles, the shape that makes the pass
+ * expensive: a void in the middle of a tile has to expand most of its search
+ * window before it reaches twelve measured cells, while a void beside measured
+ * ground reaches them in a step.
+ */
+function tiledGrid(cols: number, rows: number, tile: number): {
+  z: Float32Array; had: Uint8Array;
+} {
+  const n = cols * rows;
+  const z = new Float32Array(n);
+  const had = new Uint8Array(n).fill(1);
+  for (let i = 0; i < n; i++) {
+    const r = (i / cols) | 0, c = i - r * cols;
+    z[i] = 40 * Math.sin(c / 60) + 25 * Math.cos(r / 45);
+    if ((((r / tile) | 0) + ((c / tile) | 0)) % 2 === 1) { had[i] = 0; z[i] = Number.NaN; }
+  }
+  return { z, had };
+}
+
+describe('geodesicFill cost bound', () => {
+  it('reports what it spent and what it projected', () => {
+    const { z, had } = tiledGrid(64, 64, 8);
+    const { report } = geodesicFillWithReport(z, had, 64, 64, { cellMetresX: 1 });
+    expect(report.voids).toBeGreaterThan(0);
+    expect(report.abandoned).toBe(false);
+    expect(report.nodesExpanded).toBeGreaterThan(0);
+    expect(report.projectedNodes).toBeGreaterThan(0);
+  });
+
+  it('projects the whole pass to within a few per cent of what it costs', () => {
+    // The projection is the decision, so a probe that misread the grid would
+    // abandon a cheap pass or run an expensive one.
+    const { z, had } = tiledGrid(160, 160, 16);
+    const { report } = geodesicFillWithReport(z, had, 160, 160, {
+      cellMetresX: 1, nodeBudget: 1e15,
+    });
+    const ratio = report.projectedNodes / report.nodesExpanded;
+    expect(ratio).toBeGreaterThan(0.9);
+    expect(ratio).toBeLessThan(1.1);
+  });
+
+  it('abandons the geodesic pass when the projection exceeds the budget', () => {
+    const { z, had } = tiledGrid(96, 96, 12);
+    const { report } = geodesicFillWithReport(z, had, 96, 96, {
+      cellMetresX: 1, nodeBudget: 1,
+    });
+    expect(report.abandoned).toBe(true);
+    expect(report.projectedNodes).toBeGreaterThan(1);
+  });
+
+  it('leaves every void at the Euclidean prefill when it abandons', () => {
+    // All or nothing: the probe's geodesic values are discarded so the surface
+    // is one interpolant throughout, not geodesic in the cells sampled first.
+    const { z, had } = tiledGrid(96, 96, 12);
+    const { z: out } = geodesicFillWithReport(z, had, 96, 96, {
+      cellMetresX: 1, nodeBudget: 1,
+    });
+    const euclidean = idwFill(z, had, 96, 96, { power: 2, kNearest: 12, maxRadiusCells: 24 });
+    for (let i = 0; i < out.length; i++) {
+      if (had[i] === 1) continue;
+      if (!Number.isFinite(euclidean[i])) continue;
+      expect(out[i]).toBe(euclidean[i]);
+    }
+  });
+
+  it('keeps measured cells verbatim on the abandoned path too', () => {
+    const { z, had } = tiledGrid(96, 96, 12);
+    const { z: out } = geodesicFillWithReport(z, had, 96, 96, {
+      cellMetresX: 1, nodeBudget: 1,
+    });
+    for (let i = 0; i < out.length; i++) if (had[i] === 1) expect(out[i]).toBe(z[i]);
+  });
+
+  it('gives the same answer every run, probe included', () => {
+    const a = tiledGrid(80, 80, 10);
+    const b = tiledGrid(80, 80, 10);
+    const ra = geodesicFillWithReport(a.z, a.had, 80, 80, { cellMetresX: 1 });
+    const rb = geodesicFillWithReport(b.z, b.had, 80, 80, { cellMetresX: 1 });
+    expect([...rb.z]).toEqual([...ra.z]);
+    expect(rb.report).toEqual(ra.report);
+  });
+
+  it('solves every void exactly once, so the probe is not repeated work', () => {
+    // A void solved twice would double the pops for no change in the answer.
+    const { z, had } = tiledGrid(40, 40, 5);
+    const strided = geodesicFillWithReport(z, had, 40, 40, { cellMetresX: 1 });
+    const unstrided = geodesicFillWithReport(z, had, 40, 40, {
+      cellMetresX: 1,
+      // One probe void, so nearly every void is solved in the second loop.
+      nodeBudget: 1e15,
+    });
+    expect([...strided.z]).toEqual([...unstrided.z]);
+    expect(strided.report.voids).toBeLessThanOrEqual(GEODESIC_PROBE_VOIDS * 1000);
+  });
+
+  it('is unchanged for a grid small enough that the probe covers it', () => {
+    // Under GEODESIC_PROBE_VOIDS voids the stride is 1 and the probe solves
+    // everything, which must still equal what the plain entry point returns.
+    const { z, had } = tiledGrid(30, 30, 6);
+    const viaReport = geodesicFillWithReport(z, had, 30, 30, { cellMetresX: 1 }).z;
+    expect([...geodesicFill(z, had, 30, 30, { cellMetresX: 1 })]).toEqual([...viaReport]);
   });
 });

--- a/tests/geodesicFill.test.ts
+++ b/tests/geodesicFill.test.ts
@@ -123,6 +123,7 @@ describe('geodesicFill cost bound', () => {
     const { report } = geodesicFillWithReport(z, had, 64, 64, { cellMetresX: 1 });
     expect(report.voids).toBeGreaterThan(0);
     expect(report.abandoned).toBe(false);
+    expect(report.stoppedBy).toBeNull();
     expect(report.nodesExpanded).toBeGreaterThan(0);
     expect(report.projectedNodes).toBeGreaterThan(0);
   });
@@ -145,6 +146,7 @@ describe('geodesicFill cost bound', () => {
       cellMetresX: 1, nodeBudget: 1,
     });
     expect(report.abandoned).toBe(true);
+    expect(report.stoppedBy).toBe('projection');
     expect(report.projectedNodes).toBeGreaterThan(1);
   });
 
@@ -199,5 +201,87 @@ describe('geodesicFill cost bound', () => {
     const { z, had } = tiledGrid(30, 30, 6);
     const viaReport = geodesicFillWithReport(z, had, 30, 30, { cellMetresX: 1 }).z;
     expect([...geodesicFill(z, had, 30, 30, { cellMetresX: 1 })]).toEqual([...viaReport]);
+  });
+});
+
+describe('geodesicFill runtime backstop', () => {
+  /**
+   * One contiguous gap covering the right of the grid. This is the shape the
+   * probe reads worst: cost per void spans two orders of magnitude between the
+   * gap edge and its interior, and a strided sample of that distribution comes
+   * out low. Measured across 24 void morphologies the median projection error
+   * is 0.5% and the worst is 36%, and every case that misses badly has this
+   * shape. It is therefore the only fixture in which the BACKSTOP, rather than
+   * the projection, is what stops the pass.
+   */
+  function oneGap(cols: number, rows: number, frac: number): {
+    z: Float32Array; had: Uint8Array;
+  } {
+    const n = cols * rows;
+    const z = new Float32Array(n);
+    const had = new Uint8Array(n).fill(1);
+    for (let i = 0; i < n; i++) {
+      const r = (i / cols) | 0, c = i - r * cols;
+      z[i] = 40 * Math.sin(c / 17) + 25 * Math.cos(r / 13);
+      if (c > cols * frac) { had[i] = 0; z[i] = Number.NaN; }
+    }
+    return { z, had };
+  }
+
+  const COLS = 200, ROWS = 200;
+  const grid = oneGap(COLS, ROWS, 0.6);
+  const uncapped = geodesicFillWithReport(grid.z, grid.had, COLS, ROWS, {
+    cellMetresX: 1, nodeBudget: 1e15,
+  });
+
+  it('under-estimates on this fixture, which is what the backstop is for', () => {
+    // If the projection ever became exact here the tests below would pass
+    // through the projection's own abandon path and stop testing anything.
+    expect(uncapped.report.projectedNodes).toBeLessThan(uncapped.report.nodesExpanded);
+  });
+
+  it('stops at the ceiling when the projection said the pass would fit', () => {
+    // Above the projection, below the real cost: the pass starts, and only the
+    // backstop can end it.
+    const budget = Math.floor(
+      (uncapped.report.projectedNodes + uncapped.report.nodesExpanded) / 2,
+    );
+    expect(budget).toBeGreaterThan(uncapped.report.projectedNodes);
+    expect(budget).toBeLessThan(uncapped.report.nodesExpanded);
+    const capped = geodesicFillWithReport(grid.z, grid.had, COLS, ROWS, {
+      cellMetresX: 1, nodeBudget: budget,
+    });
+    expect(capped.report.abandoned).toBe(true);
+    expect(capped.report.stoppedBy).toBe('ceiling');
+    expect(capped.report.nodesExpanded).toBeLessThan(uncapped.report.nodesExpanded);
+  });
+
+  it('leaves the Euclidean prefill everywhere when it fires', () => {
+    const budget = Math.floor(
+      (uncapped.report.projectedNodes + uncapped.report.nodesExpanded) / 2,
+    );
+    const capped = geodesicFillWithReport(grid.z, grid.had, COLS, ROWS, {
+      cellMetresX: 1, nodeBudget: budget,
+    });
+    // Not a partly geodesic surface: the fallback covers every void, so the
+    // grid is one interpolant and carries no seam.
+    const euclidean = geodesicFillWithReport(grid.z, grid.had, COLS, ROWS, {
+      cellMetresX: 1, nodeBudget: 1,
+    }).z;
+    expect([...capped.z]).toEqual([...euclidean]);
+  });
+
+  it('overshoots by at most one void search, not by the rest of the grid', () => {
+    const budget = Math.floor(
+      (uncapped.report.projectedNodes + uncapped.report.nodesExpanded) / 2,
+    );
+    const capped = geodesicFillWithReport(grid.z, grid.had, COLS, ROWS, {
+      cellMetresX: 1, nodeBudget: budget,
+    });
+    // The check runs between voids, so the search in flight is the overshoot.
+    // One void expands at most its whole window, each cell pushed a bounded
+    // number of times.
+    const oneVoidCeiling = (2 * 24 + 1) ** 2 * 8;
+    expect(capped.report.nodesExpanded).toBeLessThanOrEqual(budget + oneVoidCeiling);
   });
 });

--- a/tests/geodesicFill.test.ts
+++ b/tests/geodesicFill.test.ts
@@ -285,3 +285,34 @@ describe('geodesicFill runtime backstop', () => {
     expect(capped.report.nodesExpanded).toBeLessThanOrEqual(budget + oneVoidCeiling);
   });
 });
+
+describe('geodesicFill is independent of the order voids are solved in', () => {
+  /**
+   * The probe solves a strided sample before the rest, so the visit order now
+   * depends on the sample size. Each void reads the prefilled surface and
+   * writes only its own cell, so the order cannot matter, and this is the
+   * assertion that keeps it that way: a future change that let one void's
+   * result feed another would show up here and nowhere else.
+   */
+  it('gives the same surface at every probe size', () => {
+    const { z, had } = tiledGrid(70, 70, 7);
+    const reference = geodesicFillWithReport(z, had, 70, 70, {
+      cellMetresX: 1.3, cellMetresY: 0.7, verticalUnitToMetres: 1.1, probeVoids: 1,
+    });
+    for (const probeVoids of [2, 3, 17, 200, 5000]) {
+      const other = geodesicFillWithReport(z, had, 70, 70, {
+        cellMetresX: 1.3, cellMetresY: 0.7, verticalUnitToMetres: 1.1, probeVoids,
+      });
+      expect([...other.z]).toEqual([...reference.z]);
+      expect(other.report.nodesExpanded).toBe(reference.report.nodesExpanded);
+    }
+  });
+
+  it('gives the same surface when the probe covers every void', () => {
+    // Stride 1: the probe solves everything and the second loop does nothing.
+    const { z, had } = tiledGrid(50, 50, 5);
+    const strided = geodesicFillWithReport(z, had, 50, 50, { cellMetresX: 1, probeVoids: 9 });
+    const whole = geodesicFillWithReport(z, had, 50, 50, { cellMetresX: 1, probeVoids: 1e6 });
+    expect([...whole.z]).toEqual([...strided.z]);
+  });
+});

--- a/tests/geodesicFillAccuracy.test.ts
+++ b/tests/geodesicFillAccuracy.test.ts
@@ -1,0 +1,150 @@
+/**
+ * geodesicFillAccuracy.test.ts
+ *
+ * Does the geodesic void fill produce better heights than the Euclidean prefill
+ * it refines, in THIS implementation?
+ *
+ * The question was worth asking because nothing here answered it. The method is
+ * cited to Duan, Ge & He (2025), who report a 13 to 17 per cent RMSE reduction
+ * on their data with their code, and `geodesicFill.test.ts` shows the two
+ * methods differ in the expected direction on a 3x3 fixture without knowing
+ * which of them is right. A user-facing warning said heights were less reliable
+ * after a fallback to Euclidean, which is an accuracy claim resting on someone
+ * else's measurement of someone else's implementation.
+ *
+ * These surfaces are analytic, so the truth is known at every cell and RMSE is
+ * against the real surface rather than against held-out samples. That is the
+ * measurement's strength and its limit: closed-form landforms are not scans,
+ * and nothing here is evidence about field accuracy. It is enough to say which
+ * of two interpolants is closer to a known answer, and that is all it says.
+ *
+ * The result is conditional, and the condition is the point. A void whose
+ * neighbourhood reaches across an elevation CONTRAST is where the method wins,
+ * and it wins by a wide margin. Where there is no contrast to cross it loses a
+ * few per cent, because adding the rise to the path cost makes uphill
+ * neighbours expensive and biases the estimate downhill. A symmetric ridge is
+ * the case that looks like a barrier and is not one: crossing the crest costs
+ * nothing when the far side sits at the same height as the near side.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { geodesicFill } from '../src/terrain/ground/geodesicFill';
+import { idwFill } from '../src/terrain/ground/idwFill';
+
+const COLS = 120, ROWS = 120;
+const MID = COLS / 2;
+
+/** A scarp: a low bench west, a plateau 50 m higher east, over `ramp` cells. */
+const scarp = (ramp: number) => (c: number, r: number): number => {
+  const t = Math.max(0, Math.min(1, (c - (MID - ramp / 2)) / ramp));
+  return 10 + 50 * t + 0.02 * r;
+};
+/** A symmetric ridge: it looks like a barrier, and crossing it is free. */
+const ridge = (c: number, r: number): number => 60 - 1.8 * Math.abs(c - MID) + 0.03 * r;
+/** No barrier at all. */
+const plane = (c: number, r: number): number => 10 + 0.25 * c + 0.11 * r;
+
+interface Grid { truth: Float64Array; z: Float32Array; had: Uint8Array }
+
+/** Circular voids of `radius` centred at each of `centres`. */
+function build(
+  surface: (c: number, r: number) => number,
+  centres: readonly (readonly [number, number])[],
+  radius: number,
+): Grid {
+  const n = COLS * ROWS;
+  const truth = new Float64Array(n);
+  const z = new Float32Array(n);
+  const had = new Uint8Array(n).fill(1);
+  for (let i = 0; i < n; i++) {
+    const r = (i / COLS) | 0, c = i - r * COLS;
+    truth[i] = surface(c, r);
+    z[i] = truth[i];
+  }
+  for (const [cx, cy] of centres) {
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        if ((c - cx) ** 2 + (r - cy) ** 2 <= radius * radius) {
+          const i = r * COLS + c;
+          had[i] = 0; z[i] = Number.NaN;
+        }
+      }
+    }
+  }
+  return { truth, z, had };
+}
+
+/** RMSE over the void cells only, against the analytic surface. */
+function voidRmse(filled: Float32Array, g: Grid): number {
+  let s = 0, n = 0;
+  for (let i = 0; i < filled.length; i++) {
+    if (g.had[i] === 1 || !Number.isFinite(filled[i])) continue;
+    s += (filled[i] - g.truth[i]) ** 2; n++;
+  }
+  return n ? Math.sqrt(s / n) : Number.NaN;
+}
+
+/** Percentage change in RMSE from Euclidean to geodesic; negative is better. */
+function change(g: Grid): number {
+  const e = idwFill(g.z, g.had, COLS, ROWS, { power: 2, kNearest: 12, maxRadiusCells: 24 });
+  const geo = geodesicFill(g.z, g.had, COLS, ROWS, {
+    cellMetresX: 1, cellMetresY: 1, verticalUnitToMetres: 1,
+  });
+  const re = voidRmse(e, g), rg = voidRmse(geo, g);
+  return ((rg - re) / re) * 100;
+}
+
+const LOW_BENCH: readonly (readonly [number, number])[] = [
+  [MID - 12, 30], [MID - 12, 60], [MID - 12, 90],
+];
+const FAR_AWAY: readonly (readonly [number, number])[] = [[18, 30], [20, 62], [19, 92]];
+
+describe('geodesic fill against a known surface', () => {
+  it('is closer to truth for a void beside a hard scarp', () => {
+    // A void on the low bench, near enough that a Euclidean neighbourhood
+    // reaches over a 50 m step. This is the failure the method exists for.
+    // Measured: RMSE 6.13 m Euclidean against 4.58 m geodesic, 25% closer.
+    const pct = change(build(scarp(1), [[MID - 10, 30], [MID - 10, 60], [MID - 10, 90]], 9));
+    expect(pct).toBeLessThan(-15);
+  });
+
+  it('is closer to truth for a void beside a softened break in slope', () => {
+    // A real break in slope is not a cliff. Over an eight-cell ramp the gain is
+    // smaller: 3.75 m against 3.02 m, 20% closer, which is the range the cited
+    // paper reports on its own data. The cliff above is the ceiling of the
+    // effect, not its typical size.
+    const pct = change(build(scarp(8), LOW_BENCH, 9));
+    expect(pct).toBeLessThan(-10);
+    expect(pct).toBeGreaterThan(-40);
+  });
+
+  it('changes nothing for a void far from any contrast', () => {
+    const pct = change(build(scarp(8), FAR_AWAY, 9));
+    expect(Math.abs(pct)).toBeLessThan(2);
+  });
+
+  it('changes nothing on a plane, where there is nothing to walk around', () => {
+    const pct = change(build(plane, [[MID, 30], [30, 60], [90, 90]], 9));
+    expect(Math.abs(pct)).toBeLessThan(2);
+  });
+
+  it('is slightly WORSE on the flank of a symmetric ridge', () => {
+    // The finding that makes the gain conditional rather than general. A
+    // symmetric crest looks like a barrier and is not one: the far side sits at
+    // the same height as the near side, so crossing it costs nothing, and the
+    // rise in the path cost only biases the estimate downhill. Recorded because
+    // a claim that the method is uniformly better would be false, and because a
+    // future change that erased this would be changing the method's behaviour
+    // on ordinary terrain without anyone noticing.
+    // Measured: 2.89 m Euclidean against 3.18 m geodesic, 10% worse.
+    const pct = change(build(ridge, [[MID - 7, 30], [MID - 7, 60], [MID - 7, 90]], 6));
+    expect(pct).toBeGreaterThan(0);
+    expect(pct).toBeLessThan(20);
+  });
+
+  it('costs less the larger the void, as the neighbourhood stops reaching over', () => {
+    const near = change(build(ridge, [[MID - 7, 30], [MID - 7, 60], [MID - 7, 90]], 6));
+    const far = change(build(ridge, [[MID - 16, 30], [MID - 16, 62], [MID - 16, 94]], 14));
+    expect(far).toBeLessThan(near);
+  });
+});


### PR DESCRIPTION
`geodesicFill` bounds one void's Dijkstra with `maxRadiusCells` and bounded nothing about the total. The two cases are far apart and only void shape separates them: a scattered single-cell void reaches its twelve measured cells in a step or two, while a void in the middle of a large gap expands most of its radius-24 window before it reaches any.

Pops are the unit throughout, because they are the reproducible measurement. The same grid yields the same count on every run; the seconds beside them moved 40% between two runs on one loaded laptop, so they are indicative and the ceiling is not denominated in them.

| grid | voids | pops | seconds |
|---|---:|---:|---:|
| 2000x2000, 35% scattered | 1,432,414 | 28M | 2.3 to 2.8 |
| 500x500, 32-cell void tiles | 124,928 | 35M | 6.1 |
| 1000x1000, 32-cell void tiles | 499,712 | 137M | 23.5 to 23.8 |
| 1500x1500, 64-cell void tiles | 1,046,592 | 629M | 83 |

Two checks, and they answer different questions. `geodesicFillWithReport` solves a strided sample first and projects its pops per void over the whole set, which decides whether the pass starts. Then it checks its spend between voids, which decides whether it finishes. The second exists because the first is an estimate over a heavy-tailed distribution: across 24 void morphologies the median projection error is 0.5% and the worst is 36%, on a grid with one large contiguous gap where cheap edge voids outnumber expensive interior ones. Without the runtime check the ceiling would bound an estimate rather than the work, and the overshoot would be the rest of the grid rather than the one search in flight.

Above `GEODESIC_NODE_BUDGET`, 60M pops, every void keeps its Euclidean prefill. All or nothing, deliberately: stopping partway would leave a surface built by one interpolant in the north and another in the south, with a seam visible in the contours.

**How much the fallback costs, measured rather than cited.** The warning first said heights would be "less reliable", which is an accuracy claim, and the only support for it was Duan et al. (2025) reporting 13 to 17 per cent RMSE reduction on their data with their code. `geodesicFillAccuracy.test.ts` fills analytic surfaces both ways and compares against truth known at every cell. The result is conditional, and the condition turned out to be the whole story:

| surface | geodesic vs Euclidean RMSE |
|---|---:|
| void beside a hard scarp | 25% closer |
| void beside a softened break in slope | 20% closer |
| void far from any contrast | unchanged |
| tilted plane | unchanged |
| flank of a symmetric ridge | **10% worse** |

A symmetric crest is the case that looks like a barrier and is not one: the far side sits at the same height as the near side, so crossing it costs nothing while the rise in the path cost still biases the estimate downhill. The warning now names the condition instead of claiming a general loss, and the module doc says the 13-to-17 figure is someone else's measurement of someone else's implementation.

These are closed-form landforms, not scans, so this is evidence about which of two interpolants is closer to a known answer and nothing about field accuracy. No claim's evidence level moves.

`geodesicNodeBudget` and `probeVoids` are parameters, so a caller willing to wait can raise the ceiling, and the sample size the visit order depends on is testable.

`geodesicFill` keeps its signature and delegates. Its output is byte-identical to the pre-change implementation across seven grids spanning scattered and blocky voids at probe strides from 2 to 10, checked against the old code directly. Disabling the runtime check fails three tests; injecting an order-dependent term fails two more.

Gates: typecheck, `lint:architecture-truth`, `lint:module-graph`, `lint:layer-boundaries`, `lint:release-truth`, `test:unit` (6,769 passed, the bucket `geodesicFill.test.ts` and `geodesicFillAccuracy.test.ts` run in), `test:terrain` (1,757 passed) and `test:slow` (806 passed).
