### PR TITLE
Derive the LAZ count floor from the point record length

### DIFF
--- a/src/io/copc/copcChunkDecompress.ts
+++ b/src/io/copc/copcChunkDecompress.ts
@@ -20,7 +20,10 @@
 
 import type { createLazPerf } from 'laz-perf';
 import { LoadError } from '../loadErrors';
-import { validateDeclaredPointCount } from '../validateCount';
+import {
+  validateDeclaredPointCount,
+  compressedBytesPerPointFloor,
+} from '../validateCount';
 import type { ChunkDecodeMetadata } from './copcChunkDecode';
 
 /** The instantiated laz-perf WASM module. */
@@ -51,12 +54,12 @@ export function decompressChunk(
   meta: ChunkDecodeMetadata,
 ): Uint8Array {
   // Allocation guard — bound the node's declared count by its compressed
-  // bytes (1 byte/point is far below any genuine LAZ stream) and by the
-  // practical node ceiling BEFORE sizing the output buffer below.
+  // bytes, at a floor derived from the record length rather than a flat byte,
+  // and by the practical node ceiling BEFORE sizing the output buffer below.
   const pointCount = validateDeclaredPointCount(
     meta.pointCount,
     chunk.byteLength,
-    1,
+    compressedBytesPerPointFloor(meta.pointRecordLength),
     'COPC node',
   );
   if (pointCount > MAX_NODE_POINTS) {

--- a/src/io/ept/eptLaszipDecode.ts
+++ b/src/io/ept/eptLaszipDecode.ts
@@ -41,7 +41,10 @@
 
 import { parseLasHeader } from '../lasHeader';
 import { getLazPerf } from '../loadLas';
-import { validateDeclaredPointCount } from '../validateCount';
+import {
+  validateDeclaredPointCount,
+  compressedBytesPerPointFloor,
+} from '../validateCount';
 import { assertFiniteNodeTransform, assertFinitePositions } from '../streamingFiniteGuard';
 import type { DecodedChunk } from '../copc/copcChunkDecode';
 
@@ -193,12 +196,12 @@ export function decodeEptLaszipTileWith(
   const ctx = buildContext(buffer);
   // Bound the per-tile declared count by the tile's own bytes BEFORE the
   // seven typed-array allocations below. EPT tiles arrive from remote
-  // URLs; 1 byte/point compressed is far below any genuine LAZ stream,
-  // so this only trips on a header lying by orders of magnitude.
+  // URLs, and the floor comes from the record length, so this only trips
+  // on a header lying by orders of magnitude.
   const n = validateDeclaredPointCount(
     ctx.pointCount,
     buffer.byteLength,
-    1,
+    compressedBytesPerPointFloor(ctx.recordLength),
     'EPT laszip tile',
   );
   // Fail before decoding a whole tile when its transform is outright non-finite

--- a/src/io/lazDecode.ts
+++ b/src/io/lazDecode.ts
@@ -32,7 +32,10 @@ import { LAZ_PERF_WASM_BASE64 } from './lazPerfWasm';
 import type { LasHeader } from './lasHeader';
 import type { ProgressUpdate } from './loadProgress';
 import { makePrng, pickInBucket, STRIDE_SAMPLE_SEED } from './strideSample';
-import { validateDeclaredPointCount } from './validateCount';
+import {
+  validateDeclaredPointCount,
+  compressedBytesPerPointFloor,
+} from './validateCount';
 import {
   allocRawPoints,
   decodeContext,
@@ -41,16 +44,6 @@ import {
   finalizeRawColors,
   type RawPoints,
 } from './lasDecodeShared';
-
-/**
- * Conservative floor on compressed bytes per LAZ point. Real-world LAZ
- * compresses ~30-byte records to roughly 2–5 bytes; 1 byte/point is far
- * below anything a genuine file produces, so the bound only trips on a
- * header lying about its count by orders of magnitude (the case that
- * matters — a remote file declaring 10^12 points would otherwise drive
- * a multi-terabyte allocation in `allocRawPoints` below).
- */
-const MIN_COMPRESSED_BYTES_PER_POINT = 1;
 
 /** Decode the embedded base64 laz-perf WASM into bytes for `createLazPerf`. */
 function lazPerfWasmBinary(): Uint8Array {
@@ -112,7 +105,7 @@ export async function decodeLaz(
   const pointCount = validateDeclaredPointCount(
     header.pointCount,
     buffer.byteLength,
-    MIN_COMPRESSED_BYTES_PER_POINT,
+    compressedBytesPerPointFloor(header.pointDataRecordLength),
     'LAZ file',
   );
   const step = Math.max(1, Math.floor(stride));

--- a/src/io/validateCount.ts
+++ b/src/io/validateCount.ts
@@ -51,13 +51,26 @@ export const MIN_BYTES_PER_POINT_FLOOR = 0.01;
 /**
  * Compression ratio above which a LAZ stream is treated as impossible.
  *
- * A committed 120,000-point PDRF 7 fixture compresses 14.8x, and published
- * ratios for airborne survey data sit between 5x and 20x. Degenerate content
- * goes far higher: a node whose points share one classification, one intensity
- * and a near-constant coordinate delta feeds the arithmetic coder almost no
- * entropy, and a bare-earth node on a plane can pass 30x without being
- * malformed in any way. Fifty leaves that headroom while keeping the allocation
- * this guard exists to bound at roughly what it was.
+ * A judgement, not a measurement, and worth saying so. The one figure available
+ * here is a committed 120,000-point PDRF 7 fixture at 14.8x, which is a single
+ * synthetic file. `laz-perf` ships a decoder only, so nothing in this tree can
+ * compress content and report what ratio LAZ actually reaches; settling the
+ * number would take a corpus of real files measured with an encoder.
+ *
+ * What the choice IS grounded in is the bound it leaves behind. This guard is a
+ * sanity check against a header lying by orders of magnitude, not a memory
+ * guarantee: the real ceilings are the per-node point cap and the preflight
+ * memory plan. At one byte per point the output arrays a header could force
+ * ranged from 19x the input bytes for PDRF 0 to 33x for PDRF 3, varying by
+ * format for no reason anyone chose. At `recordLength / 50` the multiple is
+ * 45x to 49x for every format. That is looser, by 1.4x to 2.5x depending on
+ * format, and it is uniform, and it buys back a class of legitimate
+ * high-compression LAZ the flat byte refused.
+ *
+ * Degenerate content is where that matters: a node whose points share one
+ * classification, one intensity and a near-constant coordinate delta feeds the
+ * arithmetic coder almost no entropy, and a bare-earth node on a plane can pass
+ * 30x without being malformed in any way.
  */
 export const MAX_LAZ_COMPRESSION_RATIO = 50;
 

--- a/src/io/validateCount.ts
+++ b/src/io/validateCount.ts
@@ -13,13 +13,20 @@
  * hold could plausibly decompress to.
  *
  * The bound is deliberately loose — `minBytesPerPoint` is a conservative
- * floor (callers pass 1 byte/point for compressed streams), because the
- * goal is blocking absurd allocations, not byte-exact validation. A real
- * file is never within orders of magnitude of the limit; a header lying
- * about its count by 1000x is. Mirrors the silent clamp `loadLas.ts`
- * applies to uncompressed records, but throws instead of clamping:
+ * floor, because the goal is blocking absurd allocations, not byte-exact
+ * validation. A real file is never within orders of magnitude of the limit; a
+ * header lying about its count by 1000x is. Mirrors the silent clamp
+ * `loadLas.ts` applies to uncompressed records, but throws instead of clamping:
  * a compressed stream whose header wildly disagrees with its payload
  * cannot be partially trusted the way fixed-length records can.
+ *
+ * For a LAZ stream the floor comes from {@link compressedBytesPerPointFloor},
+ * which derives it from the point record length rather than fixing it at one
+ * byte. One byte per point is a different compression ratio for every point
+ * format: 20x for PDRF 0's twenty-byte record and 36x for PDRF 7's thirty-six,
+ * so the guard was strictest on exactly the formats that carry least. Deriving
+ * the floor from the record makes the admitted ratio the same everywhere and
+ * keeps the allocation bound where it was.
  *
  * Throws the typed {@link LoadError} (`malformed-file`) so the toast
  * explains the failure clearly. The message also contains the word
@@ -33,6 +40,41 @@
 import { LoadError } from './loadErrors';
 
 /**
+ * Smallest floor the guard will use, whatever a caller passes.
+ *
+ * A zero or negative floor makes the bound vacuous, which is the one thing this
+ * guard must never be. A hundredth of a byte per point still refuses a header
+ * claiming a trillion points behind a kilobyte.
+ */
+export const MIN_BYTES_PER_POINT_FLOOR = 0.01;
+
+/**
+ * Compression ratio above which a LAZ stream is treated as impossible.
+ *
+ * A committed 120,000-point PDRF 7 fixture compresses 14.8x, and published
+ * ratios for airborne survey data sit between 5x and 20x. Degenerate content
+ * goes far higher: a node whose points share one classification, one intensity
+ * and a near-constant coordinate delta feeds the arithmetic coder almost no
+ * entropy, and a bare-earth node on a plane can pass 30x without being
+ * malformed in any way. Fifty leaves that headroom while keeping the allocation
+ * this guard exists to bound at roughly what it was.
+ */
+export const MAX_LAZ_COMPRESSION_RATIO = 50;
+
+/**
+ * The bytes-per-point floor for a LAZ stream of the given record length.
+ *
+ * Callers pass the uncompressed point record length from the LAS header, so the
+ * floor scales with what a point actually carries.
+ */
+export function compressedBytesPerPointFloor(pointRecordLength: number): number {
+  if (!Number.isFinite(pointRecordLength) || pointRecordLength <= 0) {
+    return MIN_BYTES_PER_POINT_FLOOR;
+  }
+  return pointRecordLength / MAX_LAZ_COMPRESSION_RATIO;
+}
+
+/**
  * Validate a header-declared point/record count against the bytes that
  * actually back it. Returns the count unchanged when plausible; throws
  * a `malformed-file` {@link LoadError} when the count is not a safe
@@ -41,9 +83,10 @@ import { LoadError } from './loadErrors';
  *
  * @param declared        The count the file's header claims.
  * @param bytesAvailable  The bytes actually present (compressed or raw).
- * @param minBytesPerPoint Conservative floor on bytes consumed per point.
- *                         Clamped to at least 1 — a 0 floor would make the
- *                         bound vacuous.
+ * @param minBytesPerPoint Conservative floor on bytes consumed per point. May
+ *                         be fractional for a compressed stream; clamped to
+ *                         {@link MIN_BYTES_PER_POINT_FLOOR}, because a zero or
+ *                         negative floor would make the bound vacuous.
  * @param context         Loader name for the error message ("LAZ",
  *                        "COPC node", "E57 CompressedVector", …).
  */
@@ -62,14 +105,16 @@ export function validateDeclaredPointCount(
       `malformed ${context}: invalid declared point count (${declared}).`,
     );
   }
-  const floor = Math.max(1, minBytesPerPoint);
+  const floor = Number.isFinite(minBytesPerPoint)
+    ? Math.max(MIN_BYTES_PER_POINT_FLOOR, minBytesPerPoint)
+    : MIN_BYTES_PER_POINT_FLOOR;
   const plausibleMax = Math.floor(Math.max(0, bytesAvailable) / floor);
   if (declared > plausibleMax) {
     throw new LoadError(
       'malformed-file',
       `malformed ${context}: header declares ${declared.toLocaleString('en-US')} points, ` +
         `but only ${bytesAvailable.toLocaleString('en-US')} bytes are available ` +
-        `(at least ${floor} byte(s) per point expected).`,
+        `(at least ${floor.toFixed(2)} byte(s) per point expected).`,
     );
   }
   return declared;

--- a/src/io/validateCount.ts
+++ b/src/io/validateCount.ts
@@ -62,6 +62,18 @@ export const MIN_BYTES_PER_POINT_FLOOR = 0.01;
 export const MAX_LAZ_COMPRESSION_RATIO = 50;
 
 /**
+ * Floor used when a record length is missing or nonsense.
+ *
+ * One byte per point, which is what every LAZ caller passed before the floor
+ * was derived from the record. A header can declare a zero record length,
+ * nothing upstream rejects it, and falling back to
+ * {@link MIN_BYTES_PER_POINT_FLOOR} there would leave the guard a hundred times
+ * weaker than the flat byte it replaced, on exactly the malformed input it
+ * exists for. This change must never be looser than what it replaced.
+ */
+export const UNKNOWN_RECORD_BYTES_PER_POINT = 1;
+
+/**
  * The bytes-per-point floor for a LAZ stream of the given record length.
  *
  * Callers pass the uncompressed point record length from the LAS header, so the
@@ -69,7 +81,7 @@ export const MAX_LAZ_COMPRESSION_RATIO = 50;
  */
 export function compressedBytesPerPointFloor(pointRecordLength: number): number {
   if (!Number.isFinite(pointRecordLength) || pointRecordLength <= 0) {
-    return MIN_BYTES_PER_POINT_FLOOR;
+    return UNKNOWN_RECORD_BYTES_PER_POINT;
   }
   return pointRecordLength / MAX_LAZ_COMPRESSION_RATIO;
 }

--- a/tests/validateCount.test.ts
+++ b/tests/validateCount.test.ts
@@ -19,6 +19,7 @@ import {
   compressedBytesPerPointFloor,
   MIN_BYTES_PER_POINT_FLOOR,
   MAX_LAZ_COMPRESSION_RATIO,
+  UNKNOWN_RECORD_BYTES_PER_POINT,
 } from '../src/io/validateCount';
 import { LoadError } from '../src/io/loadErrors';
 
@@ -37,10 +38,25 @@ describe('compressedBytesPerPointFloor', () => {
     }
   });
 
-  it('falls back to the hard floor for a missing or nonsense record length', () => {
+  it('falls back to one byte per point for a missing or nonsense record length', () => {
+    // Not to MIN_BYTES_PER_POINT_FLOOR. A header can declare a zero record
+    // length and nothing upstream rejects it, so falling back to a hundredth of
+    // a byte would leave the guard a hundred times weaker than the flat byte it
+    // replaced, on precisely the malformed input it exists for.
     for (const bad of [0, -30, Number.NaN, Number.POSITIVE_INFINITY]) {
-      expect(compressedBytesPerPointFloor(bad)).toBe(MIN_BYTES_PER_POINT_FLOOR);
+      expect(compressedBytesPerPointFloor(bad)).toBe(UNKNOWN_RECORD_BYTES_PER_POINT);
+      expect(compressedBytesPerPointFloor(bad)).toBeGreaterThan(MIN_BYTES_PER_POINT_FLOOR);
     }
+  });
+
+  it('is never looser than the flat byte it replaced, for a malformed header', () => {
+    // 10^9 points behind a kilobyte, with the record length a malformed file
+    // declared as zero.
+    const floor = compressedBytesPerPointFloor(0);
+    expect(() => validateDeclaredPointCount(1e9, 1024, floor, 'COPC node'))
+      .toThrow(LoadError);
+    expect(() => validateDeclaredPointCount(1025, 1024, floor, 'COPC node'))
+      .toThrow(LoadError);
   });
 });
 

--- a/tests/validateCount.test.ts
+++ b/tests/validateCount.test.ts
@@ -1,0 +1,111 @@
+/**
+ * validateCount.test.ts
+ *
+ * The allocation guard's floor, and the false rejection it used to carry.
+ *
+ * The guard bounds a header-declared count by the bytes that back it, which is
+ * what stops a remote file claiming 10^12 points from driving a multi-terabyte
+ * allocation. The floor it used was one byte per point for every LAZ stream,
+ * and that is not one rule: a twenty-byte PDRF 0 record was refused above 20x
+ * compression while a thirty-six-byte PDRF 7 record was allowed to 36x. LAZ
+ * reaches those ratios on content that is uniform rather than malformed, so the
+ * guard could refuse a valid file, and it was strictest on the formats carrying
+ * least per point.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateDeclaredPointCount,
+  compressedBytesPerPointFloor,
+  MIN_BYTES_PER_POINT_FLOOR,
+  MAX_LAZ_COMPRESSION_RATIO,
+} from '../src/io/validateCount';
+import { LoadError } from '../src/io/loadErrors';
+
+describe('compressedBytesPerPointFloor', () => {
+  it('admits the same compression ratio for every point format', () => {
+    for (const recordLength of [20, 26, 28, 30, 34, 36]) {
+      const floor = compressedBytesPerPointFloor(recordLength);
+      expect(recordLength / floor).toBeCloseTo(MAX_LAZ_COMPRESSION_RATIO, 9);
+    }
+  });
+
+  it('is below one byte per point for every LAS record format', () => {
+    // The whole point: the flat one-byte floor sat above these.
+    for (const recordLength of [20, 28, 30, 36]) {
+      expect(compressedBytesPerPointFloor(recordLength)).toBeLessThan(1);
+    }
+  });
+
+  it('falls back to the hard floor for a missing or nonsense record length', () => {
+    for (const bad of [0, -30, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(compressedBytesPerPointFloor(bad)).toBe(MIN_BYTES_PER_POINT_FLOOR);
+    }
+  });
+});
+
+describe('validateDeclaredPointCount with a fractional floor', () => {
+  it('accepts a node compressed past the old one-byte floor', () => {
+    // 50,000 PDRF 6 points in 40 KB is 0.8 bytes per point, a 37.5x ratio. A
+    // node whose points share a classification, an intensity and a
+    // near-constant coordinate delta feeds the coder almost no entropy and gets
+    // there without being malformed.
+    const floor = compressedBytesPerPointFloor(30);
+    expect(validateDeclaredPointCount(50_000, 40_000, floor, 'COPC node')).toBe(50_000);
+    // The same call at the floor that shipped before.
+    expect(() => validateDeclaredPointCount(50_000, 40_000, 1, 'COPC node'))
+      .toThrow(LoadError);
+  });
+
+  it('refuses a ratio past the ceiling, so the window is bounded not removed', () => {
+    // 60x on a thirty-byte record. The change widens the admitted ratio from
+    // 30x to 50x; it does not admit anything at all.
+    const floor = compressedBytesPerPointFloor(30);
+    expect(() => validateDeclaredPointCount(50_000, 25_000, floor, 'COPC node'))
+      .toThrow(LoadError);
+  });
+
+  it('still refuses a header lying by orders of magnitude', () => {
+    const floor = compressedBytesPerPointFloor(30);
+    expect(() => validateDeclaredPointCount(1e12, 4096, floor, 'COPC node'))
+      .toThrow(/malformed COPC node/);
+    expect(() => validateDeclaredPointCount(1e9, 1024, floor, 'LAZ file'))
+      .toThrow(LoadError);
+  });
+
+  it('holds the bound at the exact boundary the floor sets', () => {
+    const floor = compressedBytesPerPointFloor(30); // 0.6 bytes per point
+    const bytes = 6_000;
+    const most = Math.floor(bytes / floor); // 10,000
+    expect(validateDeclaredPointCount(most, bytes, floor, 'LAZ file')).toBe(most);
+    expect(() => validateDeclaredPointCount(most + 1, bytes, floor, 'LAZ file'))
+      .toThrow(LoadError);
+  });
+
+  it('never lets a caller make the bound vacuous', () => {
+    // A zero or negative floor would admit any count at all, which is the one
+    // thing this guard must not do.
+    for (const bad of [0, -1, Number.NaN]) {
+      expect(() => validateDeclaredPointCount(1e12, 1024, bad, 'LAZ file'))
+        .toThrow(LoadError);
+    }
+  });
+
+  it('names the floor it applied, so the message is checkable', () => {
+    let message = '';
+    try {
+      validateDeclaredPointCount(1e9, 1024, compressedBytesPerPointFloor(30), 'LAZ file');
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toMatch(/0\.60 byte\(s\) per point/);
+    expect(message).toMatch(/malformed LAZ file/);
+  });
+
+  it('keeps refusing a count that is not a safe non-negative integer', () => {
+    for (const bad of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 53]) {
+      expect(() => validateDeclaredPointCount(bad, 20_000, 0.6, 'LAZ file'))
+        .toThrow(/invalid declared point count/);
+    }
+  });
+});

--- a/tests/validateCount.test.ts
+++ b/tests/validateCount.test.ts
@@ -125,3 +125,57 @@ describe('validateDeclaredPointCount with a fractional floor', () => {
     }
   });
 });
+
+describe('the allocation bound the ratio leaves behind', () => {
+  /**
+   * `MAX_LAZ_COMPRESSION_RATIO` is a judgement, so the property it was chosen
+   * for is pinned instead of the number. The guard's job is bounding what a
+   * lying header can allocate, and the point of deriving the floor from the
+   * record length is that the bound stops varying by point format.
+   *
+   * Bytes per point are `allocRawPoints`: positions Float32x3, intensity
+   * Uint16, classification, return number and return count Uint8, point source
+   * id Uint16, plus GPS time Float64 and 16-bit colour where the format carries
+   * them.
+   */
+  const FORMATS: readonly { name: string; recordLength: number; perPoint: number }[] = [
+    { name: 'PDRF 0', recordLength: 20, perPoint: 19 },
+    { name: 'PDRF 1', recordLength: 28, perPoint: 27 },
+    { name: 'PDRF 2', recordLength: 26, perPoint: 25 },
+    { name: 'PDRF 3', recordLength: 34, perPoint: 33 },
+    { name: 'PDRF 6', recordLength: 30, perPoint: 27 },
+    { name: 'PDRF 7', recordLength: 36, perPoint: 33 },
+  ];
+
+  /** Output bytes a header can force, as a multiple of the bytes backing it. */
+  function allocationMultiple(recordLength: number, perPoint: number): number {
+    return perPoint / compressedBytesPerPointFloor(recordLength);
+  }
+
+  it('admits the same multiple of the input bytes for every point format', () => {
+    // The flat byte gave 19x for PDRF 0 and 33x for PDRF 3, which is the same
+    // inconsistency as the compression ratio seen from the allocation side.
+    const multiples = FORMATS.map((f) => allocationMultiple(f.recordLength, f.perPoint));
+    const spread = Math.max(...multiples) / Math.min(...multiples);
+    expect(spread).toBeLessThan(1.15);
+  });
+
+  it('stays inside fifty times the bytes that back it', () => {
+    for (const f of FORMATS) {
+      expect(allocationMultiple(f.recordLength, f.perPoint)).toBeLessThan(50);
+    }
+  });
+
+  it('is looser than the flat byte it replaced, by under three times', () => {
+    // Stated rather than hidden. The guard is a sanity check against a header
+    // lying by orders of magnitude, not a memory guarantee, so trading this
+    // much of an already 19x to 33x bound to stop refusing legitimate files is
+    // the deliberate part of the change.
+    for (const f of FORMATS) {
+      const before = f.perPoint / 1;
+      const after = allocationMultiple(f.recordLength, f.perPoint);
+      expect(after).toBeGreaterThan(before);
+      expect(after / before).toBeLessThan(3);
+    }
+  });
+});


### PR DESCRIPTION
`validateDeclaredPointCount` bounds a header-declared count by the bytes backing it, which is what stops a remote file claiming 10^12 points from driving a multi-terabyte allocation before a record is decoded. Its floor for compressed streams was one byte per point, clamped so a caller could not go lower.

That flat byte is a different compression ratio for every point format: PDRF 0 carries a twenty-byte record, so one byte per point refuses anything past 20x, while PDRF 7 carries thirty-six and the same floor allows 36x. The guard was therefore strictest on exactly the formats that carry least per point.

LAZ reaches those ratios without being malformed. A node whose points share one classification, one intensity and a near-constant coordinate delta feeds the arithmetic coder almost no entropy, and a bare-earth node on a plane can pass 30x.

`compressedBytesPerPointFloor(recordLength)` returns `recordLength / 50`, so every format is admitted to the same ceiling. The three LAZ call sites (`lazDecode`, `copcChunkDecompress`, `eptLaszipDecode`) each pass their own record length; E57's `compressedVector` is a different format and keeps its own floor. A header can declare a zero record length and nothing upstream rejects it, so that case falls back to one byte per point rather than to `MIN_BYTES_PER_POINT_FLOOR`, which would have left the guard a hundred times weaker than what it replaced on precisely the malformed input it exists for.

**On the 50.** It is a judgement, and the first version of this description defended it with published LAZ ratios of 5x to 20x, asserted from memory with no source. Nothing here can check that: `laz-perf` ships a decoder only, so this tree cannot compress content and report what ratio LAZ actually reaches, and settling the number would take a corpus of real files measured with an encoder. The one real figure available is a single committed fixture at 14.8x.

What the choice is grounded in instead is the bound it leaves behind. This guard is a sanity check against a header lying by orders of magnitude, not a memory guarantee; the per-node point cap and the preflight memory plan are the real ceilings. At one byte per point the output arrays a lying header could force ranged from 19x the input bytes for PDRF 0 to 33x for PDRF 3, varying by format for no reason anyone chose. At `recordLength / 50` it is 45x to 49x for every format. That is **looser, by 1.4x to 2.5x**. The first version of this description called it roughly unchanged, which was wrong. It is also uniform, and it buys back a class of legitimate high-compression LAZ the flat byte refused. Tests pin the uniformity and the ceiling rather than the constant, so a future change to the ratio has to keep the property it was chosen for.

The window is widened, not removed: 60x on a thirty-byte record is still refused, `MIN_BYTES_PER_POINT_FLOOR` keeps a caller from making the bound vacuous with a zero or negative floor, and the message names the floor it applied so a rejection is checkable.

Gates: typecheck, `lint:architecture-truth`, `lint:module-graph`, `lint:layer-boundaries`, `lint:release-truth`, `lint:inline-imports`, `test:unit` (6,763 passed) and `test:slow` (806 passed).
