### PR TITLE
Let a streaming source say its point total is unknown

### DIFF
--- a/src/analysis/streamingExtentRows.ts
+++ b/src/analysis/streamingExtentRows.ts
@@ -47,7 +47,7 @@ export interface StreamingExtentResult {
 export function streamingExtentRows(
   header: { readonly min: readonly [number, number, number]; readonly max: readonly [number, number, number] },
   ctx: SpatialContext,
-  sourcePointCount: number,
+  sourcePointCount: number | null,
 ): StreamingExtentResult {
   const unitConfirmed = ctx.linearUnitKnown;
 
@@ -68,7 +68,9 @@ export function streamingExtentRows(
   ];
 
   const footprintArea = w * d;
-  if (footprintArea > 0 && sourcePointCount > 0) {
+  // A source that cannot state its total has no nominal density or spacing.
+  // Absent rows, not zeroed ones: a density of zero reads as a measurement.
+  if (footprintArea > 0 && sourcePointCount !== null && sourcePointCount > 0) {
     const density = sourcePointCount / footprintArea;
     const spacing = Math.sqrt(footprintArea / sourcePointCount);
     const densityUnit = unitConfirmed ? ' pts/m²' : ' pts/unit²';

--- a/src/app/processStudioMount.ts
+++ b/src/app/processStudioMount.ts
@@ -201,7 +201,7 @@ export function createProcessStudio(deps: ProcessStudioDeps): MountedProcessStud
  */
 export interface StudioViewer {
   /** The mounted streaming source, or null for a static / empty scene. */
-  readonly streamingCloud: { readonly sourcePointCount: number } | null;
+  readonly streamingCloud: { readonly sourcePointCount: number | null } | null;
   /** Every loaded static layer's id. */
   clouds(): readonly string[];
   getCloud(id: string):

--- a/src/app/sessionIo.ts
+++ b/src/app/sessionIo.ts
@@ -59,7 +59,7 @@ export const MAX_SESSION_BYTES = 256 * 1024 * 1024;
 /** The streaming-source slice `scanFactsFromStreaming` reads — a structural subset of {@link StreamingSource}. */
 export interface StreamingScanSource {
   readonly name: string;
-  readonly sourcePointCount: number;
+  readonly sourcePointCount: number | null;
   dataBounds(): readonly [number, number, number, number, number, number];
   crs():
     | { readonly name?: string; readonly epsg?: number; readonly linearUnit?: CrsLinearUnit }
@@ -104,7 +104,9 @@ export function scanFactsFromStreaming(cloud: StreamingScanSource): ScanFacts {
   const crs = cloud.crs();
   return {
     fileName: cloud.name,
-    sourcePoints: cloud.sourcePointCount,
+    // `sourcePoints` is optional in the session schema, so an unknown total
+    // is an absent field rather than a stored zero.
+    sourcePoints: cloud.sourcePointCount ?? undefined,
     width: b[3] - b[0],
     depth: b[4] - b[1],
     height: b[5] - b[2],

--- a/src/diagnostics/provenanceSignals.ts
+++ b/src/diagnostics/provenanceSignals.ts
@@ -268,6 +268,10 @@ export function signalsForStreamingCloud(cloud: StreamingCloudShape): ScanSignal
   }
   return {
     sourceFormat: cloud.kind,
+    // Unknown collapses to 0 here, which is safe only because every reader of
+    // `pointCount` gates on `> 0` or `> 1_000_000`: an unknown total makes no
+    // claim, exactly as a genuinely empty source makes none. The density above
+    // is left undefined rather than zeroed for the same reason.
     pointCount: cloud.sourcePointCount ?? 0,
     extent,
     densityPerSqM: density,

--- a/src/export/BaseExportMode.ts
+++ b/src/export/BaseExportMode.ts
@@ -192,7 +192,12 @@ export function baseReportRows(
   const unit = linearUnitOf(adapter.crsLabel()?.unit);
   const uLabel = linearUnitLabel(unit);
   const rows: ScanReportRow[] = [
-    { label: 'Points', value: formatInt(adapter.sourcePointCount()) },
+    {
+      label: 'Points',
+      value: adapter.sourcePointCount() === null
+        ? 'Unknown'
+        : formatInt(adapter.sourcePointCount() as number),
+    },
   ];
   // Extent/density use the TIGHT data AABB (streaming's octree cube inflates
   // height ~7× and deflates density); falls back to the passed AABB.
@@ -207,8 +212,11 @@ export function baseReportRows(
       { label: 'Height', value: formatLinear(h, unit) },
     );
     // Density — points per square unit on the XY footprint.
-    if (w > 0 && d > 0) {
-      const density = adapter.sourcePointCount() / (w * d);
+    const total = adapter.sourcePointCount();
+    // No total, no density. A stamped "0.0 pts/m²" reads as a measurement of an
+    // empty scan rather than as an unanswered question.
+    if (w > 0 && d > 0 && total !== null) {
+      const density = total / (w * d);
       // One decimal, matching the Scan Report panel (`toFixed(0)` rounded
       // 2.586 pts/m² up to "3", disagreeing with the panel's "2.6").
       rows.push({ label: 'Density', value: `${density.toFixed(1)} pts/${uLabel}²` });

--- a/src/export/types.ts
+++ b/src/export/types.ts
@@ -174,7 +174,7 @@ export interface ExportSceneAdapter {
    * not the GPU-resident count). For streaming COPC, this is the full source
    * cloud's point total.
    */
-  sourcePointCount(): number;
+  sourcePointCount(): number | null;
   /** Currently displayed point count (resident on GPU). */
   residentPointCount(): number;
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1782,7 +1782,7 @@ function buildCurrentStoryInputs(): ScanStoryInputs {
       // area (and understates density) for a partial-footprint scan.
       const lb = streaming.dataBounds();
       areaM2 = footprintAreaM2(lb[3] - lb[0], lb[4] - lb[1], areaCrs);
-      pointCount = streaming.sourcePointCount;
+      pointCount = streaming.sourcePointCount ?? undefined;
       const sCrs = streaming.crs();
       metaCrsKnown = !!sCrs?.name;
       // Read the datum from the streamed source's own CRS (COPC VLRs / EPT srs)
@@ -2995,7 +2995,7 @@ const exportPanel = new ExportPanel({
     // cloud, so nothing is a reduced view yet. (An explicit `viewer == null`
     // check would trip TS2367 since `viewer` is typed non-null via a cast.)
     const sc = viewer?.streamingCloud;
-    return sc != null && sc.residentPointCount < sc.sourcePointCount;
+    return sc != null && (sc.sourcePointCount === null || sc.residentPointCount < sc.sourcePointCount);
   },
   getFullCloud: async () => {
     const f = scans.activeId ? sourceFileById.get(scans.activeId) : null;
@@ -4729,8 +4729,8 @@ async function exportSession(): Promise<void> {
       const exportFileName = streamingCloud?.name ?? (cloud ? cloud.name : null);
 
       let scanSummary: import('./io/session').SessionScanSummary | undefined;
-      if (streamingCloud) {
-        // Tight data AABB, not the octree cube — see the dataBounds() note above.
+      if (streamingCloud && streamingCloud.sourcePointCount !== null) {
+        // Tight data AABB, not the octree cube. No summary without a source total.
         const b = streamingCloud.dataBounds();
         const crs = streamingCloud.crs();
         scanSummary = {

--- a/src/perf/metricsJson.ts
+++ b/src/perf/metricsJson.ts
@@ -42,7 +42,8 @@ export interface MetricsStreamingInput {
   loadingNodes: number;
   residentNodes: number;
   displayedPoints: number;
-  sourcePoints: number;
+  /** Total in the source, or null when the source cannot state one. */
+  sourcePoints: number | null;
   cacheBytes: number;
   decodedBytes?: number;
   gpuBytes: number;

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -2213,7 +2213,7 @@ export class Viewer {
     const w = b[3] - b[0];
     const d = b[4] - b[1];
     const footprint = Math.max(1, w * d);
-    this._currentDensityPtsPerM2 = cloud.sourcePointCount / footprint;
+    this._currentDensityPtsPerM2 = (cloud.sourcePointCount ?? 0) / footprint;
   }
 
   /**
@@ -3653,7 +3653,7 @@ export class Viewer {
       origin: s.cloud.renderOrigin,
       name: s.cloud.name,
       sourceFormat: 'laz', // COPC and EPT both decode LAZ point records
-      sourcePointCount: s.cloud.sourcePointCount,
+      sourcePointCount: s.cloud.sourcePointCount ?? undefined,
       ...(crs ? { metadata: { crs } } : {}),
     });
   }
@@ -4631,7 +4631,7 @@ export class Viewer {
     if (this._streaming) {
       const resident = this._streaming.cloud.residentPointCount;
       displayedPoints += resident;
-      totalPoints += this._streaming.cloud.sourcePointCount;
+      totalPoints += this._streaming.cloud.sourcePointCount ?? resident;
       gpuBytesEstimate += estimateGpuBytes(resident);
     }
 

--- a/src/render/exportAdapter.ts
+++ b/src/render/exportAdapter.ts
@@ -377,7 +377,7 @@ export function buildExportAdapter(host: ExportAdapterHost): ExportSceneAdapter 
       const first = visible[0]!.cloud.name;
       return visible.length === 1 ? first : `${first} + ${visible.length - 1} more`;
     },
-    sourcePointCount(): number {
+    sourcePointCount(): number | null {
       const streaming = host.streaming();
       if (streaming) return streaming.cloud.sourcePointCount;
       // The file's declared total, back-scaled when the loader strided a huge

--- a/src/render/streaming/StreamingSource.ts
+++ b/src/render/streaming/StreamingSource.ts
@@ -133,8 +133,22 @@ export interface StreamingSource {
   readonly renderOrigin: [number, number, number];
   /** The runtime octree — nodes, state, scoring inputs. */
   readonly octree: StreamingOctreeView;
-  /** Total points in the source — not the displayed (resident) count. */
-  readonly sourcePointCount: number;
+  /**
+   * Total points in the source, or `null` when the source cannot say.
+   *
+   * COPC reads it from the LAS header and EPT from `ept.json`, so both always
+   * know. A 3D Tiles tileset generally does not: the hierarchy names content
+   * URIs, not point totals, and the only way to a total is fetching every tile,
+   * which is the one thing a streaming source must not do to open.
+   *
+   * Null is not zero, and the difference is the whole reason this is nullable.
+   * Zero is a real answer meaning an empty source; null means the question has
+   * no answer yet. A consumer that coerces one to the other reports an empty
+   * scan, a density of zero, or a capture type inferred from a density that was
+   * never measured. {@link residentPointCount} stays a number, because what is
+   * on the GPU is always known.
+   */
+  readonly sourcePointCount: number | null;
   /** Points currently uploaded to the GPU. */
   readonly residentPointCount: number;
 

--- a/src/report/ReportFindings.ts
+++ b/src/report/ReportFindings.ts
@@ -205,7 +205,11 @@ export function buildInspectionSummary(
 
   // Headline: capture type (if classified) + scale.
   const captureLabel = provenance?.label ?? 'Point cloud';
-  const headline = `${captureLabel} — ${formatArea(area)}, ${formatCount(metadata.sourcePointCount)}.`;
+  const totalText =
+    metadata.sourcePointCount === null
+      ? 'point count unknown from source metadata'
+      : formatCount(metadata.sourcePointCount);
+  const headline = `${captureLabel} — ${formatArea(area)}, ${totalText}.`;
 
   const findings: ReportFinding[] = [];
 
@@ -214,7 +218,10 @@ export function buildInspectionSummary(
     {
       label: 'Coverage',
       value: formatArea(area),
-      detail: `${formatCount(metadata.sourcePointCount)} captured.`,
+      detail:
+        metadata.sourcePointCount === null
+          ? 'Point count unknown from source metadata.'
+          : `${formatCount(metadata.sourcePointCount)} captured.`,
       tier: 'info',
     },
     // 2. Point density — the one genuinely quantitative finding.

--- a/src/report/ReportMetadataSection.ts
+++ b/src/report/ReportMetadataSection.ts
@@ -16,7 +16,7 @@ import type { ReportDatasetRow } from './types';
 export interface MetadataInputs {
   readonly fileName: string;
   readonly format: 'COPC' | 'EPT' | 'LAS' | 'LAZ' | 'PLY' | 'E57' | 'PCD' | 'PTX' | 'PTS' | 'OBJ' | 'GLTF' | 'XYZ' | (string & {});
-  readonly sourcePointCount: number;
+  readonly sourcePointCount: number | null;
   /** Bounds in metres: width × depth × height. Pass NaN when unknown. */
   readonly width: number;
   readonly depth: number;
@@ -124,7 +124,14 @@ export function buildDatasetSummary(inputs: MetadataInputs): readonly ReportData
   rows.push(
     { label: 'File',   value: inputs.fileName },
     { label: 'Format', value: inputs.format },
-    { label: 'Points', value: formatInt(inputs.sourcePointCount) },
+    {
+      label: 'Points',
+      // Unknown, not zero: a source that cannot state its total has not
+      // stated that it is empty.
+      value: inputs.sourcePointCount === null
+        ? 'Unknown from source metadata'
+        : formatInt(inputs.sourcePointCount),
+    },
   );
   // Streaming-preview disclosure — for a COPC / EPT scan exported mid-stream,
   // surface how much of the cloud is actually resident. Reads directly below
@@ -135,7 +142,7 @@ export function buildDatasetSummary(inputs: MetadataInputs): readonly ReportData
   if (sr && Number.isFinite(sr.points) && sr.points > 0) {
     const total = inputs.sourcePointCount;
     const pct =
-      Number.isFinite(total) && total > 0
+      total !== null && Number.isFinite(total) && total > 0
         ? Math.min(100, Math.round((sr.points / total) * 100))
         : Number.NaN;
     const nodePart =
@@ -145,7 +152,10 @@ export function buildDatasetSummary(inputs: MetadataInputs): readonly ReportData
     const pctPart = Number.isFinite(pct) ? ` (${pct}%${nodePart})` : '';
     rows.push({
       label: 'Loaded',
-      value: `${formatCompactCount(sr.points)} of ${formatCompactCount(total)} pts${pctPart} — streaming preview`,
+      value:
+        total === null
+          ? `${formatCompactCount(sr.points)} resident, source total unknown — streaming preview`
+          : `${formatCompactCount(sr.points)} of ${formatCompactCount(total)} pts${pctPart} — streaming preview`,
     });
   }
   // FAIL CLOSED on an unconfirmed linear unit. When the CRS declares no real

--- a/src/report/reportFootprint.ts
+++ b/src/report/reportFootprint.ts
@@ -19,7 +19,7 @@ export interface FootprintInput {
   readonly extentY: number;
   readonly extentZ: number;
   /** Total point count the density should reflect (file-scale, not strided). */
-  readonly pointCount: number;
+  readonly pointCount: number | null;
   /** Horizontal CRS unit → metres (1 for a metre CRS, ~0.3048 for feet). */
   readonly linearUnitToMetres?: number;
   /** Vertical unit → metres, when the source declares one distinct from horizontal. */
@@ -125,6 +125,8 @@ export function footprintMetres(input: FootprintInput): Footprint {
   const depthMetres = spanDepth * uH;
   const heightMetres = spanHeight * uV;
   const densityPerM2 =
-    widthMetres > 0 && depthMetres > 0 ? input.pointCount / (widthMetres * depthMetres) : Number.NaN;
+    widthMetres > 0 && depthMetres > 0 && input.pointCount !== null
+      ? input.pointCount / (widthMetres * depthMetres)
+      : Number.NaN;
   return { unitStatus: 'confirmed', widthMetres, depthMetres, heightMetres, densityPerM2 };
 }

--- a/src/ui/DebugOverlay.ts
+++ b/src/ui/DebugOverlay.ts
@@ -29,7 +29,8 @@ export interface StreamingDebugStats {
   loadingNodes: number;
   residentNodes: number;
   displayedPoints: number;
-  sourcePoints: number;
+  /** Total in the source, or null when the source cannot state one. */
+  sourcePoints: number | null;
   /** Compressed-cache LRU current bytes. */
   cacheBytes: number;
   /**
@@ -352,7 +353,9 @@ export class DebugOverlay {
         `nodes         ${streaming.residentNodes} resident / ${streaming.knownNodes} known`,
         `visible       ${streaming.visibleNodes}`,
         `queue         ${streaming.queuedNodes} queued / ${streaming.loadingNodes} decoding`,
-        `points        ${formatInt(streaming.displayedPoints)} / ${formatInt(streaming.sourcePoints)}`,
+        `points        ${formatInt(streaming.displayedPoints)} / ${
+          streaming.sourcePoints === null ? '?' : formatInt(streaming.sourcePoints)
+        }`,
       ];
       // Memory accounting — three-tier memory readout. Compressed (LRU bytes + cache
       // outcomes); decoded (CPU-side, sized from the decoded attribute set);

--- a/src/ui/StreamingPanel.ts
+++ b/src/ui/StreamingPanel.ts
@@ -39,7 +39,8 @@ export interface StreamingStatus {
   loadedNodes: number;
   knownNodes: number;
   displayedPoints: number;
-  sourcePoints: number;
+  /** Total in the source, or null when the source cannot state one. */
+  sourcePoints: number | null;
   cacheBytes: number;
 }
 
@@ -55,7 +56,8 @@ export interface StreamingStatus {
 export interface StreamingScanSummary {
   fileName: string;
   pointFormat: number;
-  sourcePoints: number;
+  /** Total in the source, or null when the source cannot state one. */
+  sourcePoints: number | null;
   width: number;
   depth: number;
   height: number;
@@ -230,9 +232,9 @@ export function streamingProgress(status: StreamingStatus): StreamingProgress {
     fraction,
     determinate,
     nodesLabel: `${status.loadedNodes} / ${determinate ? known : '?'} nodes resident`,
-    pointsLabel: `${pointsMillions(status.displayedPoints)} / ${pointsMillions(
-      status.sourcePoints,
-    )} pts`,
+    pointsLabel: `${pointsMillions(status.displayedPoints)} / ${
+      status.sourcePoints === null ? '?' : pointsMillions(status.sourcePoints)
+    } pts`,
   };
 }
 
@@ -467,7 +469,11 @@ export class StreamingPanel {
     this._summary.replaceChildren(
       file,
       this._statRow('Format', this._value(formatText)),
-      this._statRow('Source', this._value(`${formatCount(summary.sourcePoints)} points`)),
+      this._statRow('Source', this._value(
+        summary.sourcePoints === null
+          ? 'Unknown from source metadata'
+          : `${formatCount(summary.sourcePoints)} points`,
+      )),
       this._statRow(
         'Extent',
         this._value(
@@ -569,9 +575,9 @@ export class StreamingPanel {
   /** Update the live status numbers + the determinate progress treatment. */
   setStatus(status: StreamingStatus): void {
     this._nodes.textContent = `${status.loadedNodes} / ${status.knownNodes}`;
-    this._points.textContent = `${formatCount(status.displayedPoints)} / ${formatCount(
-      status.sourcePoints,
-    )}`;
+    this._points.textContent = `${formatCount(status.displayedPoints)} / ${
+      status.sourcePoints === null ? 'Unknown' : formatCount(status.sourcePoints)
+    }`;
     this._cache.textContent = formatBytes(status.cacheBytes);
     this._updateProgress(status);
   }

--- a/tests/streamingLegacyEquivalence.test.ts
+++ b/tests/streamingLegacyEquivalence.test.ts
@@ -151,7 +151,14 @@ interface FixtureRecord {
   fixture: string;
   sourceKind: string;
   nodeCount: number;
-  sourcePoints: number;
+  /**
+   * Null where the source cannot say. COPC reads its total from the LAS header
+   * and EPT from `ept.json`, so both always know; a 3D Tiles tileset names
+   * content URIs rather than point totals. Recording null rather than zero is
+   * the whole point of the nullable type: zero is a real answer meaning an
+   * empty source.
+   */
+  sourcePoints: number | null;
   hierarchyComplete: boolean;
   budgets: { pointBudget: number; maxConcurrentDecodes: number; chunkCacheBytes: number };
   /** Local cube half-span the camera path was scaled by. */
@@ -611,8 +618,14 @@ describe('streaming scheduler baseline', () => {
 
     for (const f of doc.fixtures) {
       // The budget bit: the source is bigger than the budget, and no tick ever
-      // wanted the whole hierarchy.
-      expect(f.sourcePoints).toBeGreaterThan(f.budgets.pointBudget);
+      // wanted the whole hierarchy. A source that cannot state its total is
+      // asserted as unknown rather than coerced to a number, because coercing
+      // is the defect this nullable type exists to prevent.
+      if (f.sourcePoints === null) {
+        expect(f.sourceKind, 'only a source that cannot count reports null').toBe('tiles');
+      } else {
+        expect(f.sourcePoints).toBeGreaterThan(f.budgets.pointBudget);
+      }
       expect(Math.max(...f.trace.map((t) => t.wantedIds.length))).toBeLessThan(f.nodeCount);
       // Ancestry is present and read: a protected set formed, and the tree is
       // deeper than one level.

--- a/tests/unknownSourceTotal.test.ts
+++ b/tests/unknownSourceTotal.test.ts
@@ -1,0 +1,180 @@
+/**
+ * unknownSourceTotal.test.ts
+ *
+ * A streaming source whose total point count is unknown, across every surface
+ * that states one.
+ *
+ * `StreamingSource.sourcePointCount` was a number, which is correct for COPC
+ * and EPT: both read the total from a header. A 3D Tiles tileset names content
+ * URIs and not point totals, and the only route to a total is fetching every
+ * tile, which is precisely what a streaming source must not do to open. The
+ * field is therefore `number | null`.
+ *
+ * Null is not zero. Zero is a real answer meaning an empty source; null means
+ * the question has no answer yet, and a surface that coerces one to the other
+ * reports an empty scan, a density of zero, or a capture type inferred from a
+ * density nothing measured. These tests are the coercion check: every assertion
+ * below is that some surface said "unknown" or said nothing, rather than
+ * printing a figure it does not have.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { streamingExtentRows } from '../src/analysis/streamingExtentRows';
+import { footprintMetres } from '../src/report/reportFootprint';
+import { buildDatasetSummary, type MetadataInputs } from '../src/report/ReportMetadataSection';
+import { streamingProgress } from '../src/ui/StreamingPanel';
+import { signalsForStreamingCloud } from '../src/diagnostics/provenanceSignals';
+import type { SpatialContext } from '../src/geo/SpatialContext';
+
+const HEADER = {
+  min: [0, 0, 0] as readonly [number, number, number],
+  max: [100, 200, 10] as readonly [number, number, number],
+};
+
+const METRIC_CONTEXT = {
+  linearUnitKnown: true,
+  linearUnitToMetres: 1,
+  verticalUnitToMetres: 1,
+} as unknown as SpatialContext;
+
+describe('streaming extent rows', () => {
+  it('drops density and spacing when the source has no total', () => {
+    const { rows } = streamingExtentRows(HEADER, METRIC_CONTEXT, null);
+    expect(rows.map((r: { label: string }) => r.label)).toEqual(['Width', 'Depth', 'Height']);
+  });
+
+  it('still states the extent, which does not depend on a count', () => {
+    const { rows } = streamingExtentRows(HEADER, METRIC_CONTEXT, null);
+    expect(rows.find((r: { label: string; value: string }) => r.label === 'Width')?.value).toBe('100.0 m');
+  });
+
+  it('reports density as usual for a source that knows its total', () => {
+    const { rows } = streamingExtentRows(HEADER, METRIC_CONTEXT, 200_000);
+    expect(rows.map((r: { label: string }) => r.label)).toContain('Density');
+    expect(rows.find((r: { label: string; value: string }) => r.label === 'Density')?.value).toBe('10.0 pts/m²');
+  });
+
+  it('is not the same as a source that reports zero points', () => {
+    // Zero is a real answer, and it also yields no density, but through the
+    // count rather than through its absence. The two must not be conflated in
+    // the source type even where the row set happens to match.
+    const zero = streamingExtentRows(HEADER, METRIC_CONTEXT, 0);
+    const unknown = streamingExtentRows(HEADER, METRIC_CONTEXT, null);
+    expect(zero.rows.map((r: { label: string }) => r.label)).toEqual(unknown.rows.map((r: { label: string }) => r.label));
+  });
+});
+
+describe('report footprint', () => {
+  it('yields no density figure without a total', () => {
+    const fp = footprintMetres({
+      extentX: 100, extentY: 200, extentZ: 10,
+      pointCount: null,
+      linearUnitToMetres: 1, verticalUnitToMetres: 1, linearUnitKnown: true, zUp: true,
+    });
+    expect(fp.unitStatus).toBe('confirmed');
+    if (fp.unitStatus !== 'confirmed') throw new Error('expected a confirmed unit');
+    expect(Number.isNaN(fp.densityPerM2)).toBe(true);
+  });
+
+  it('yields one when the total is known', () => {
+    const fp = footprintMetres({
+      extentX: 100, extentY: 200, extentZ: 10,
+      pointCount: 200_000,
+      linearUnitToMetres: 1, verticalUnitToMetres: 1, linearUnitKnown: true, zUp: true,
+    });
+    if (fp.unitStatus !== 'confirmed') throw new Error('expected a confirmed unit');
+    expect(fp.densityPerM2).toBeCloseTo(10, 9);
+  });
+});
+
+describe('report metadata', () => {
+  const base: MetadataInputs = {
+    fileName: 'tileset.json',
+    format: '3D Tiles',
+    sourcePointCount: null,
+    width: 100, depth: 200, height: 10,
+    density: Number.NaN,
+    hasRgb: true, hasIntensity: false, hasClassification: false,
+  };
+
+  it('prints Unknown rather than a zero for Points', () => {
+    const rows = buildDatasetSummary(base);
+    const points = rows.find((r: { label: string; value: string }) => r.label === 'Points');
+    expect(points?.value).toMatch(/Unknown/);
+    expect(points?.value).not.toMatch(/^0$/);
+  });
+
+  it('prints the figure when there is one', () => {
+    const rows = buildDatasetSummary({ ...base, sourcePointCount: 1_234_567 });
+    expect(rows.find((r: { label: string; value: string }) => r.label === 'Points')?.value).not.toMatch(/Unknown/);
+  });
+
+  it('states residency without a percentage of an unknown total', () => {
+    const rows = buildDatasetSummary({
+      ...base,
+      streamingResident: { points: 1_000_000, nodes: 12, totalNodes: 40 },
+    });
+    const loaded = rows.find((r: { label: string; value: string }) => r.label === 'Loaded');
+    expect(loaded?.value).toMatch(/source total unknown/);
+    expect(loaded?.value).not.toMatch(/%/);
+  });
+
+  it('gives the percentage when the total is known', () => {
+    const rows = buildDatasetSummary({
+      ...base,
+      sourcePointCount: 4_000_000,
+      streamingResident: { points: 1_000_000, nodes: 12, totalNodes: 40 },
+    });
+    expect(rows.find((r: { label: string; value: string }) => r.label === 'Loaded')?.value).toMatch(/25%/);
+  });
+});
+
+describe('streaming panel progress', () => {
+  const status = {
+    loadedNodes: 12, knownNodes: 40,
+    displayedPoints: 1_000_000, sourcePoints: null,
+    cacheBytes: 0,
+  };
+
+  it('shows a question mark for the total rather than 0.0M', () => {
+    const p = streamingProgress(status);
+    expect(p.pointsLabel).toBe('1.0M / ? pts');
+  });
+
+  it('keeps the resident figure visible, which is always known', () => {
+    expect(streamingProgress(status).pointsLabel).toMatch(/^1\.0M/);
+  });
+
+  it('still drives the node progress bar, which does not need a point total', () => {
+    const p = streamingProgress(status);
+    expect(p.determinate).toBe(true);
+    expect(p.fraction).toBeCloseTo(12 / 40, 9);
+  });
+});
+
+describe('provenance signals', () => {
+  const cloud = {
+    kind: '3dtiles',
+    sourcePointCount: null,
+    dataBounds: () => [0, 0, 0, 100, 200, 10] as const,
+    crs: () => null,
+  };
+
+  it('computes no density from a total the source never gave', () => {
+    const signals = signalsForStreamingCloud(cloud as never);
+    expect(signals.densityPerSqM).toBeUndefined();
+  });
+
+  it('makes no point-count claim, so no capture type can be inferred from one', () => {
+    // Every reader of `pointCount` gates on `> 0`, so an unknown total makes no
+    // claim. The assertion is that it did not arrive as a plausible figure.
+    const signals = signalsForStreamingCloud(cloud as never);
+    expect(signals.pointCount).toBe(0);
+    expect(signals.pointCount).not.toBeGreaterThan(0);
+  });
+
+  it('still reports the extent, which comes from the bounds and not the count', () => {
+    const signals = signalsForStreamingCloud(cloud as never);
+    expect(signals.extent?.[0]).toBeCloseTo(100, 9);
+  });
+});


### PR DESCRIPTION
`StreamingSource.sourcePointCount` was a required number. That is right for COPC and EPT, which read the total from a LAS header and from `ept.json`. A 3D Tiles tileset names content URIs and geometric errors, not point totals, and the only route to a total is fetching every tile, which is the one thing a streaming source must not do to open.

The field is `number | null`, and the distinction is the whole point. Zero is a real answer meaning an empty source; null means the question has no answer yet. A surface that coerces one to the other reports an empty scan, a density of zero, or a capture type inferred from a density that nothing measured, and each of those reads as a measurement rather than as a gap.

Every consumer decides explicitly:

| surface | with an unknown total |
|---|---|
| Inspector extent rows | Width, Depth, Height stated; Density and Spacing absent |
| Streaming panel | `1.0M / ? pts`, and `Unknown` in the status row |
| Report metadata | `Unknown from source metadata`, and no percentage on the Loaded row |
| Report findings | "point count unknown from source metadata" in place of a figure |
| Exported image card | `Unknown` for Points, no Density row |
| Report footprint | density stays NaN, which the report already handles |
| Session | no scan summary written, rather than a stored zero |
| Process Studio | already returns `number | null` and passes it through |
| Provenance signals | no density, and the count guards already treat 0 as no claim |
| Debug overlay and metrics JSON | `?` and null respectively |
| Viewer scene totals | the resident count, which is the part that is known |

The resident count stays a number everywhere, because what is on the GPU is always known, and it stays visible on every surface above. No format ships an unknown total today, so every figure this produces is unchanged, and `tests/unknownSourceTotal.test.ts` drives the surfaces against a null total directly rather than waiting for a source that produces one. The suite also asserts that a known total still produces the density, the percentage and the figure it always did, so the branch that matters today is pinned alongside the one that does not.

Gates: typecheck, `lint:architecture-truth`, `lint:monolith-size`, `lint:module-graph`, `lint:release-truth`, `lint:inline-imports`, `lint:layer-boundaries`, `lint:spatial-context`, `test:unit` (6,765 passed), `test:export` (842 passed) and `test:ui` (657 passed). Both monolith line counts and every ratchet baseline are unchanged.
