### PR TITLE
Name the scan-report card after what its figures cover

### DIFF
--- a/src/render/exportAdapter.ts
+++ b/src/render/exportAdapter.ts
@@ -366,8 +366,16 @@ export function buildExportAdapter(host: ExportAdapterHost): ExportSceneAdapter 
     sourceName(): string {
       const streaming = host.streaming();
       if (streaming) return streaming.cloud.name;
-      const first = visibleEntries()[0];
-      return first?.cloud.name ?? 'scan';
+      // Every other figure on the scan-report card is answered over the visible
+      // entries: Points sums them, the extent is their union, the CRS is the
+      // first that declares one. The name was the exception, and named only the
+      // first visible layer, so a card covering three scans read as a card
+      // about one of them. Naming the count alongside it keeps the name useful
+      // for identification while saying the figures cover more.
+      const visible = visibleEntries();
+      if (visible.length === 0) return 'scan';
+      const first = visible[0]!.cloud.name;
+      return visible.length === 1 ? first : `${first} + ${visible.length - 1} more`;
     },
     sourcePointCount(): number {
       const streaming = host.streaming();

--- a/tests/exportAdapter.test.ts
+++ b/tests/exportAdapter.test.ts
@@ -484,3 +484,58 @@ describe('export adapter — excludeUnsupported (pass-7 #3)', () => {
     expect(a.excludeUnsupported('classification')).toEqual([]);
   });
 });
+
+describe('the scan-report card names what its figures cover', () => {
+  /**
+   * Every other figure on the card is answered over the visible entries: Points
+   * sums them, the extent is their union, the CRS is the first that declares
+   * one. The name was the exception and reported only the first visible layer,
+   * so a card whose Points and extent covered three scans read as a card about
+   * one of them.
+   */
+  /** An adapter over the given visible/hidden named layers. */
+  function named(entries: readonly { id: string; name: string; visible?: boolean }[]) {
+    return buildExportAdapter(
+      host({
+        clouds: () =>
+          new Map(entries.map((e) => [e.id, cloud({ name: e.name, visible: e.visible ?? true })])),
+      }),
+    );
+  }
+
+  it('names the layer when one is visible', () => {
+    expect(named([{ id: 'a', name: 'north.las' }]).sourceName()).toBe('north.las');
+  });
+
+  it('says how many more when several are visible', () => {
+    const adapter = named([
+      { id: 'a', name: 'north.las' },
+      { id: 'b', name: 'south.las' },
+      { id: 'c', name: 'east.las' },
+    ]);
+    expect(adapter.sourceName()).toBe('north.las + 2 more');
+  });
+
+  it('counts only the visible layers, which is what the figures cover', () => {
+    const adapter = named([
+      { id: 'a', name: 'north.las' },
+      { id: 'b', name: 'south.las', visible: false },
+    ]);
+    expect(adapter.sourceName()).toBe('north.las');
+  });
+
+  it('agrees with the point total, which sums the same set', () => {
+    // The two answers describe one scene, so a card that names one layer beside
+    // a total for three is the defect this pins.
+    const adapter = named([
+      { id: 'a', name: 'north.las' },
+      { id: 'b', name: 'south.las' },
+    ]);
+    expect(adapter.sourceName()).toMatch(/\+ 1 more$/);
+    expect(adapter.sourcePointCount()).toBe(200);
+  });
+
+  it('falls back to a placeholder with nothing visible', () => {
+    expect(named([]).sourceName()).toBe('scan');
+  });
+});


### PR DESCRIPTION
The scan-report card stamped into an exported image answers every figure over the visible layers. `sourcePointCount()` sums them, `localBoundsAabb()` unions them, `crsLabel()` takes the first that declares one, and `captureLabel()` refuses to answer unless it can answer for the whole visible set.

`sourceName()` was the exception. It returned the first visible layer's name, so a card whose Points and extent covered three scans read as a card about one of them, and the reader had no way to tell from the card which it was.

It now returns `north.las + 2 more` when several layers are visible, and the layer's own name when one is. A streaming source closes the static layers and is the whole scene, so that path is untouched. The name feeds only the card's display text, not the download filename.

This came out of looking at per-layer capture provenance, which is the item that motivated it. That one is not here, and the reason is worth recording: a fingerprint for a layer other than the active one has no shape verdict of its own, because the shape router runs once per scene against the active scan. Classifying a non-active layer from its signals alone drops the capture lens, and `tests/captureProvenanceSingleSource.test.ts` shows exactly what that costs, labelling a temple as drone LiDAR on the density its signals carry. A real per-layer verdict needs `classifyScanShape` run per layer, which reads positions in the open path against a shrink-only ratchet and duplicates what the router already does for the active scan. Worth doing deliberately rather than alongside this.

Gates: typecheck, `lint:architecture-truth`, `lint:module-graph`, `lint:release-truth`, `lint:layer-boundaries`, `test:export` (847 passed) and `test:ui` (657 passed).
