### PR TITLE
Stop granting a precision permit from a collapsed bounding box

### DIFF
--- a/src/app/scanPrecision.ts
+++ b/src/app/scanPrecision.ts
@@ -17,6 +17,30 @@
  * centre for a streaming one. Re-deriving `floor(min)` here would model the
  * streaming case wrong (its residuals straddle zero) and silently under-report.
  *
+ * WHEN THE DECLARED BOX IS NOT A BOX. `dataBounds()` is the LAS header's
+ * min/max, and real files ship that field zeroed: two public LAS 1.4 datasets
+ * in the corpus declare min = max = 0 on every axis while carrying 15.2 M and
+ * 9.6 M points (confirmed against the same files with WhiteboxTools
+ * `lidar_info`, so it is the file's claim and not a parse). Read straight, that
+ * box breaks this reader in both directions. On a georeferenced source it puts
+ * the whole extent one render origin away from zero, so the reach reads as the
+ * UTM northing (4,644,804 measured) and a good dataset is refused. On a
+ * local-frame source it collapses to the origin, so the reach reads 0, the
+ * worst-case step reads 1.4e-45 m, and a permit is GRANTED from no evidence at
+ * all. The second is the one that matters: this permit exists to refuse work
+ * the numbers cannot support.
+ *
+ * So a box is read only when it is readable (finite corners, some span on some
+ * axis). A streaming source that fails that test falls back to `localBounds()`,
+ * the octree root cube, which is a containment guarantee rather than a claim:
+ * every point is inside it by construction, COPC refuses a non-positive
+ * half-size at header parse (`io/copc/copcHeader.ts`), and it is already the
+ * box the scene is framed in. The reach it yields is an upper bound on the real
+ * one, so the resulting figure can over-report the step and never under-report
+ * it. When neither box is readable the frame is INDETERMINATE and the permit is
+ * refused outright, because substituting a number there would be the same
+ * fabrication in a quieter form.
+ *
  * No DOM, no three.js. The two cloud shapes are structural, so this is unit
  * tested against plain objects rather than a mounted viewer.
  */
@@ -27,7 +51,13 @@ import {
   resolvePrecisionPermit,
   type InMemoryPrecision,
   type PrecisionPermit,
+  type PrecisionPermitRefused,
 } from '../geo/inMemoryPrecision';
+
+/** An axis-aligned box as `[minX, minY, minZ, maxX, maxY, maxZ]`. */
+type Box6 = readonly [number, number, number, number, number, number];
+
+type Vec3 = readonly [number, number, number];
 
 /** The part of a static `PointCloud` this reader needs. */
 export interface PrecisionStaticCloud {
@@ -38,7 +68,14 @@ export interface PrecisionStaticCloud {
 /** The part of a `StreamingSource` this reader needs. */
 export interface PrecisionStreamingCloud {
   readonly renderOrigin: readonly [number, number, number];
-  dataBounds(): readonly [number, number, number, number, number, number];
+  dataBounds(): Box6;
+  /**
+   * The octree root cube, origin-shifted exactly as `dataBounds()` is. Read
+   * ONLY when the declared data box is unreadable, as the containment bound
+   * described in the module header; it over-reports the reach on the short
+   * axes, so it is never the first choice.
+   */
+  localBounds?: () => Box6;
 }
 
 /** The unit facts, in the shape both `CrsInfo` and `ResolvedCrs` already carry. */
@@ -60,14 +97,19 @@ export interface ScanPrecisionInputs {
 }
 
 /**
- * The in-memory quantization of the active scan, or `null` when nothing is
- * loaded. `null` is "no scan", not "no error" — a caller must not read it as a
- * pass.
+ * The in-memory quantization of the active scan, or `null` when there is no
+ * frame to measure: nothing loaded, or a loaded scan whose declared boxes are
+ * all unreadable. `null` is "no figure", not "no error" — a caller must not
+ * read it as a pass, and a caller that needs the gate must read
+ * {@link scanPrecisionPermit}, which refuses the second case explicitly.
  */
 export function scanPrecision(inputs: ScanPrecisionInputs): InMemoryPrecision | null {
-  const frame = localFrameOf(inputs);
-  if (!frame) return null;
+  const resolved = resolveLocalFrame(inputs);
+  return resolved.kind === 'frame' ? precisionOfFrame(resolved.frame, inputs) : null;
+}
 
+/** The estimate for an already-resolved frame. */
+function precisionOfFrame(frame: LocalFrame, inputs: ScanPrecisionInputs): InMemoryPrecision {
   // The linear unit gate is the canonical one every metric surface uses, so a
   // CRS carrying the inert placeholder `linearUnitToMetres: 1` for an unknown
   // unit yields no metre figure here either.
@@ -93,39 +135,105 @@ export function scanPrecision(inputs: ScanPrecisionInputs): InMemoryPrecision | 
  * Mint the precision permit for the active scan, or `null` when nothing is
  * loaded. A caller that holds `null` has no scan to gate and must decide on
  * its own grounds; a caller that holds a permit must honour `ok === false`.
+ *
+ * A loaded scan whose boxes are all unreadable returns a REFUSED permit, not
+ * `null`: `null` is read downstream as "no precision term" and passes
+ * (`export/exportManifest.ts` blocks only on `precision.ok === false`), so
+ * handing it back for an unmeasurable frame would reopen the hole this reader
+ * closes.
  */
 export function scanPrecisionPermit(inputs: ScanPrecisionInputs): PrecisionPermit | null {
-  const precision = scanPrecision(inputs);
-  if (!precision) return null;
+  const resolved = resolveLocalFrame(inputs);
+  if (resolved.kind === 'absent') return null;
+  if (resolved.kind === 'indeterminate') return indeterminateFramePermit(resolved.origin);
   return resolvePrecisionPermit(
-    precision,
+    precisionOfFrame(resolved.frame, inputs),
     inputs.budgetMetres !== undefined ? { budgetMetres: inputs.budgetMetres } : {},
   );
 }
 
-type LocalFrame = [
-  readonly [number, number, number],
-  readonly [number, number, number],
-  readonly [number, number, number],
-];
+type LocalFrame = [Vec3, Vec3, Vec3];
+
+/**
+ * What reading the loaded shape produced: a frame to measure, a loaded scan
+ * with no readable box, or nothing loaded at all. The last two are separate
+ * answers because only one of them is a refusal.
+ */
+type FrameResolution =
+  | { readonly kind: 'frame'; readonly frame: LocalFrame }
+  | { readonly kind: 'indeterminate'; readonly origin: Vec3 }
+  | { readonly kind: 'absent' };
+
+/**
+ * Whether a declared box can be read as an extent at all: every corner finite,
+ * and some span on at least one axis.
+ *
+ * "At least one axis" rather than "all three" on purpose. A dataset can be flat
+ * in Z and still have a real extent, and its frame is measurable; what is not
+ * measurable is a box that is a single point, which no cloud with points in it
+ * can honestly declare.
+ */
+function isReadableBox(b: Box6): boolean {
+  for (let i = 0; i < 6; i++) {
+    if (!Number.isFinite(b[i])) return false;
+  }
+  return b[3] > b[0] || b[4] > b[1] || b[5] > b[2];
+}
+
+const frameOf = (origin: Vec3, b: Box6): FrameResolution => ({
+  kind: 'frame',
+  frame: [origin, [b[0], b[1], b[2]], [b[3], b[4], b[5]]],
+});
 
 /** The origin and the LOCAL extent the loaded shape actually holds. */
-function localFrameOf(inputs: ScanPrecisionInputs): LocalFrame | null {
+function resolveLocalFrame(inputs: ScanPrecisionInputs): FrameResolution {
   const cloud = inputs.cloud;
   if (cloud) {
     const b = cloud.bounds();
     const o = cloud.sourceOrigin;
-    return [[o[0], o[1], o[2]], b.min, b.max];
+    const origin: Vec3 = [o[0], o[1], o[2]];
+    const box: Box6 = [b.min[0], b.min[1], b.min[2], b.max[0], b.max[1], b.max[2]];
+    // A static cloud's bounds are scanned off the decoded positions, so there
+    // is no second box to fall back to: an unreadable one means the buffer
+    // itself holds no extent.
+    return isReadableBox(box) ? frameOf(origin, box) : { kind: 'indeterminate', origin };
   }
   const streaming = inputs.streaming;
   if (streaming) {
-    const b = streaming.dataBounds();
     const o = streaming.renderOrigin;
-    return [
-      [o[0], o[1], o[2]],
-      [b[0], b[1], b[2]],
-      [b[3], b[4], b[5]],
-    ];
+    const origin: Vec3 = [o[0], o[1], o[2]];
+    const data = streaming.dataBounds();
+    if (isReadableBox(data)) return frameOf(origin, data);
+    const cube = streaming.localBounds?.();
+    if (cube && isReadableBox(cube)) return frameOf(origin, cube);
+    return { kind: 'indeterminate', origin };
   }
-  return null;
+  return { kind: 'absent' };
+}
+
+/**
+ * The refusal for a scan whose frame cannot be established.
+ *
+ * The estimate is carried so the refusal still says which origin it was reading
+ * from, and it is built WITHOUT a unit basis: there is no extent to convert, so
+ * no metre figure is minted for one and the grade resolves to `unknown`. The
+ * reasons name the file field at fault, because the remedy is to the file.
+ */
+function indeterminateFramePermit(origin: Vec3): PrecisionPermitRefused {
+  const precision = estimateInMemoryPrecision({
+    extent: { min: origin, max: origin },
+    strategy: { kind: 'shared-origin', origin },
+  });
+  return {
+    ok: false,
+    precision,
+    reasons: [
+      'This scan declares no extent: its bounding box collapses to a single point, '
+      + 'so there is no distance from the local origin to put through the Float32 step.',
+      'A precision figure taken from that box would describe the declared box rather '
+      + 'than the data, so no permit is issued for it.',
+      'Check the declared bounding box in the file header (WhiteboxTools `lidar_info` '
+      + 'and PDAL `info` both report it), rewrite it from the point records, and re-run.',
+    ],
+  };
 }

--- a/tests/precisionExportRefusal.test.ts
+++ b/tests/precisionExportRefusal.test.ts
@@ -72,6 +72,26 @@ describe('precision refusal — coverage of the deliverable set', () => {
     expect(resolveExportDecision('contour.pdf', ctx({ precision: null })).status).toBe('validated');
   });
 
+  it('blocks every deliverable when the scan declares no measurable extent', () => {
+    // A streaming source whose declared data box collapses to a point and that
+    // offers no octree cube to fall back on. Before the frame check this minted
+    // a granted permit (reach 0, a 1.4e-45 m step, grade `fine`), so a terrain
+    // report could be stamped from a frame that was never established.
+    const permit = scanPrecisionPermit({
+      streaming: {
+        renderOrigin: [0, 0, 0],
+        dataBounds: () => [0, 0, 0, 0, 0, 0],
+      },
+      crs: METRE,
+    });
+    expect(permit).not.toBeNull();
+    expect(permit!.ok).toBe(false);
+    for (const reg of SCIENTIFIC_EXPORTERS) {
+      const decision = resolveExportDecision(reg.exporterId, ctx({ precision: permit }));
+      expect(decision.status, reg.exporterId).toBe('blocked');
+    }
+  });
+
   it('reports the launch failure first when both a launch and precision block', () => {
     // "There is no usable surface" answers the question more fundamentally than
     // "the surface would be too coarse", so it must not be masked.

--- a/tests/scanPrecisionPolicy.test.ts
+++ b/tests/scanPrecisionPolicy.test.ts
@@ -114,3 +114,135 @@ describe('scanPrecisionPermit — the gate the deliverables read', () => {
     expect(scanPrecisionPermit({ ...inputs, budgetMetres: 0.001 })!.ok).toBe(false);
   });
 });
+
+/**
+ * A COPC/EPT source whose LAS header declares min = max = 0 on every axis while
+ * the file carries millions of points. Real files do this: two public LAS 1.4
+ * datasets in the corpus ship that header, cross-checked with WhiteboxTools
+ * `lidar_info`. `dataBounds()` is the header box shifted by the render origin,
+ * so it collapses to the single point `-renderOrigin`; `localBounds()` is the
+ * octree root cube, which the COPC header parser refuses unless its half-size
+ * is positive.
+ */
+function degenerateHeaderStreaming(
+  renderOrigin: [number, number, number],
+  cubeHalfSpan: number,
+) {
+  const [rx, ry, rz] = renderOrigin;
+  return {
+    renderOrigin,
+    dataBounds: () => [-rx, -ry, -rz, -rx, -ry, -rz] as const,
+    // The cube is centred on the render origin (which IS its floored centre),
+    // so in local space it straddles zero.
+    localBounds: () =>
+      [
+        -cubeHalfSpan,
+        -cubeHalfSpan,
+        -cubeHalfSpan,
+        cubeHalfSpan,
+        cubeHalfSpan,
+        cubeHalfSpan,
+      ] as const,
+  };
+}
+
+describe('scanPrecision — a declared box that is not a box', () => {
+  it('never reads a collapsed data box as a zero reach', () => {
+    // The fabrication case: a LOCAL-frame source, where the collapsed box lands
+    // exactly on the origin. Read straight it reports reach 0 and a 1.4e-45 m
+    // step, which grades `fine` and grants a permit from no evidence at all.
+    const p = scanPrecision({
+      streaming: degenerateHeaderStreaming([0, 0, 0], 1_000),
+      crs: METRE,
+    })!;
+    expect(p.reach).toBe(1_000);
+    expect(p.metres!.worstCaseSpacing).toBe(float32Spacing(1_000));
+  });
+
+  it('refuses a local-frame scan whose octree cube is over budget', () => {
+    const permit = scanPrecisionPermit({
+      streaming: degenerateHeaderStreaming([0, 0, 0], 400_000),
+      crs: METRE,
+    })!;
+    expect(permit.ok).toBe(false);
+  });
+
+  it('never reads a collapsed data box as the whole render origin', () => {
+    // The false-refusal case: a GEOREFERENCED source, where the collapsed box
+    // lands one render origin away from zero. Read straight it reports the UTM
+    // northing as the reach (4,644,804), grades `unusable`, and blocks terrain
+    // analysis on a dataset that is fine.
+    const p = scanPrecision({
+      streaming: degenerateHeaderStreaming([600_000, 4_644_804, 61], 1_000),
+      crs: METRE,
+    })!;
+    expect(p.reach).toBe(1_000);
+    expect(p.grade).toBe('fine');
+    expect(scanPrecisionPermit({
+      streaming: degenerateHeaderStreaming([600_000, 4_644_804, 61], 1_000),
+      crs: METRE,
+    })!.ok).toBe(true);
+  });
+
+  it('falls back to the cube when the data box carries a non-finite corner', () => {
+    const source = {
+      renderOrigin: [0, 0, 0] as [number, number, number],
+      dataBounds: () => [-500, -500, Number.NaN, 500, 500, Number.NaN] as const,
+      localBounds: () => [-1_000, -1_000, -1_000, 1_000, 1_000, 1_000] as const,
+    };
+    const p = scanPrecision({ streaming: source, crs: METRE })!;
+    expect(p.reach).toBe(1_000);
+    expect(Number.isFinite(p.metres!.worstCaseSpacing)).toBe(true);
+  });
+
+  it('still prefers the tight data box whenever it is readable', () => {
+    // The cube over-reports the reach on the short axes, so it must stay the
+    // fallback and never become the default.
+    const p = scanPrecision({
+      streaming: {
+        ...streamingCloud([600_000, 4_500_000, 100], 20_000),
+        localBounds: () => [-400_000, -400_000, -400_000, 400_000, 400_000, 400_000] as const,
+      },
+      crs: METRE,
+    })!;
+    expect(p.reach).toBe(20_000);
+  });
+
+  it('refuses, rather than grades, when no box on the scan is readable', () => {
+    const inputs = {
+      streaming: { renderOrigin: [0, 0, 0] as [number, number, number], dataBounds: () => [0, 0, 0, 0, 0, 0] as const },
+      crs: METRE,
+    };
+    // No figure to report, and the refusal invents no metre step for one.
+    expect(scanPrecision(inputs)).toBeNull();
+    const permit = scanPrecisionPermit(inputs)!;
+    expect(permit.ok).toBe(false);
+    if (permit.ok) return;
+    expect(permit.precision.metres).toBeNull();
+    expect(permit.precision.grade).toBe('unknown');
+    expect(permit.reasons.join(' ').toLowerCase()).toContain('bounding box');
+  });
+
+  it('refuses a static cloud whose scanned bounds hold no extent', () => {
+    const permit = scanPrecisionPermit({
+      cloud: {
+        sourceOrigin: [500_000, 4_500_000, 0],
+        bounds: () => ({ min: [0, 0, 0] as [number, number, number], max: [0, 0, 0] as [number, number, number] }),
+      },
+      crs: METRE,
+    })!;
+    expect(permit.ok).toBe(false);
+  });
+
+  it('separates "no scan" from "a scan with no measurable frame"', () => {
+    // `null` passes downstream (exportManifest blocks only on ok === false), so
+    // an unmeasurable scan must never come back as `null`.
+    expect(scanPrecisionPermit({ crs: METRE })).toBeNull();
+    const unmeasurable = scanPrecisionPermit({
+      streaming: { renderOrigin: [0, 0, 0], dataBounds: () => [0, 0, 0, 0, 0, 0] as const },
+      crs: METRE,
+    });
+    expect(unmeasurable).not.toBeNull();
+    expect(unmeasurable!.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
`scanPrecision` built the Float32 precision frame from the streaming source's `dataBounds()`, which derives from the LAS header's declared min and max. Some real files declare a collapsed box: min equal to max on every axis while carrying millions of points. Two public files do exactly this, the 2021 pair of Zenodo [8113105](https://doi.org/10.5281/zenodo.8113105), at 15,166,707 and 9,597,830 points. WhiteboxTools `lidar_info` reads the same zero box, so it is a property of the files rather than of OLV's parser.

On such a file the permit was wrong in both directions, measured against the repo's own modules:

| source frame | reach | worst-case step | grade | `permit.ok` |
|---|---:|---:|---|---|
| georeferenced | 4,644,804 | 0.5 m | `unusable` | **false** |
| local | 0 | 1.4e-45 m | `fine` | **true** |

The second is the reason this is a defect and not an inconvenience. A permit whose entire purpose is refusing work the numbers cannot support granted one from no evidence, reporting a worst-case step 30 orders of magnitude below float spacing, and stamped it into the terrain report's provenance footer as `exportPermit`. The first blocked terrain analysis on a sound dataset while advising the user to load it as COPC, at a file that already was COPC.

Frame resolution now has three answers rather than two: a declared box is read only when all six corners are finite and it spans at least one axis; a streaming source failing that falls back to `localBounds()`, the COPC info-VLR octree cube; and when neither is readable the permit is explicitly refused with `metres: null` and grade `unknown`.

The cube fallback is a bound, not a substitute. Every point lies inside it by construction, `copcHeader.ts:141` already refuses a non-positive half-size, and it is the box the scene is framed in, so the reach it yields can only over-report the step and never under-report it. One rule therefore fixes both directions.

Returning `null` for the unmeasurable case would have looked equivalent and was not: `exportManifest.ts:139` blocks only on `precision.ok === false`, so a null would have passed the gate one layer up and reopened the hole. A non-finite corner previously produced a NaN step, which `resolvePrecisionPermit` also grants on; that is handled at the frame level rather than by changing a policy module other callers share.

Not fixed here, deliberately: `loadLas.ts` trusts `header.min` for the origin, so a collapsed header costs Float32 precision on a georeferenced file (measured worst-case error 3.05e-05 m from a real minimum against 0.25 m from a zeroed one). That degrades data and then discloses it, because `PointCloud.bounds()` scans decoded positions and the permit correctly refuses. The honest fix needs a real minimum before decode, which touches the decoder, the strided path and the pooled worker path. Separate change.

Nine of the new tests are load-bearing, verified by disabling the readability check and confirming failure: eight fail, twenty-seven pass restored. One of them is load-bearing against the wrong fix, failing if the fallback is preferred ahead of a readable data box.

Gates: typecheck, `lint:architecture-truth`, `lint:module-graph`, `lint:release-truth`, `lint:layer-boundaries`, `lint:inline-imports`, `test:unit` (6,758 passed), `test:export` (842) and `test:terrain` (1,753). Neither monolith was touched.
