### PR TITLE
Retire two stale privacy claims that suppressed a real measurement

### DIFF
--- a/validation/control-network/README.md
+++ b/validation/control-network/README.md
@@ -28,7 +28,10 @@ multi-layer mount cannot place them). The targets are the bridge:
   `OLV_CONTROL_NETWORK_DIR` holds `*_vertices.txt` target files, every pair of
   frames sharing ≥ 3 targets is checked for distance invariance (via OLV's
   `geometry.distance`) and frame-to-frame registration residual. The surveyed
-  coordinates are private, so nothing is committed and CI skips this.
+  coordinates are public, CC BY 4.0, and registered as
+  `OLV-DS-061-MURCIA-TIEPOINTS` (Zenodo 10.5281/zenodo.11518223); they arrive
+  with the point clouds they belong to, which are not vendored, so CI skips
+  this leg.
 
 ## Real-data result
 

--- a/validation/e57-fidelity/README.md
+++ b/validation/e57-fidelity/README.md
@@ -10,13 +10,16 @@ reconstruct the same world-space geometry. This leg checks that invariant.
 - `tests/e57LasCrossFormat.test.ts` — the committed, CI-runnable guard. It reads
   the project's own `synthetic-normals.e57` fixture through the E57 path, writes
   the same six points to LAS with the real LAS writer, reads them back through
-  the LAS path, and asserts the two agree within the LAS quantisation scale. No
-  private data; runs in CI on every change.
+  the LAS path, and asserts the two agree within the LAS quantisation scale.
+  Committed fixture; runs in CI on every change.
 - `tests/e57LasFidelityExternal.test.ts` — the real-data leg. It runs only when
   `OLV_E57_FIDELITY_DIR` points at a directory of paired `<stem>.e57` /
   `<stem>.las` exports, decoding each pair and comparing point count, bounds, and
-  centroid. The raw files are private and multi-gigabyte, so nothing is committed
-  and CI skips it; the synthetic guard covers the same invariant at fixture scale.
+  centroid. The raw files are public, CC BY 4.0, and registered as
+  `OLV-DS-057-MURCIA-SCAN01` through `OLV-DS-060-TERRENO-SCAN02` (Zenodo
+  10.5281/zenodo.11518223). They run to 1.3 GB each, so they are not vendored
+  and CI skips this leg; the synthetic guard covers the same invariant at
+  fixture scale.
 
 ## Why this is not circular
 


### PR DESCRIPTION

`validation/e57-fidelity/README.md` and `validation/control-network/README.md`
described their real-data legs as running on private files. Those files are the
University of Alicante terrestrial scans, Zenodo 11518223, CC BY 4.0, now
registered as OLV-DS-051 through 055. Identity was confirmed by SHA-256 against
the register.

The consequence was not cosmetic. A measurement that exists and can be cited was
recorded as uncitable, so the E57 to LAS fidelity result and the control-network
registration residual both sat behind a label that was wrong. The READMEs now
name the DOI and the dataset ids, and give file size rather than access as the
reason CI skips those legs.

Both files were verified by SHA-256 against the dataset register: `3c95bae9…` is `Terreno_2023_Scan01.e57`, `83af8dda…` is `Murcia_2015_Scan01.e57`, `70234ee1…` is `Murcia_2015_Scan01.las`.

Gates: typecheck, `lint:release-truth`, `lint:architecture-truth`, `lint:doc-links` (283 paths across 43 documents resolve).