### PR TITLE
Mark ground-filter object cells instead of lowering the surface

### DIFF
--- a/src/terrain/ground/groundFilter.ts
+++ b/src/terrain/ground/groundFilter.ts
@@ -26,19 +26,43 @@
  *      a spring-metaphor inpaint; nearest-finite is a deterministic,
  *      dependency-free stand-in that is honest about being simpler).
  *   3. Progressive morphological opening — open the surface with a flat
- *      square structuring element of growing radius; at each radius a
- *      cell is cut to the opened height when the drop exceeds a
- *      slope-scaled threshold `dh = elevationThresholdM + slope · b ·
- *      cellSize` (the cell run in z's unit — see
+ *      structuring element of growing radius and compare the drop
+ *      against a slope-scaled threshold `dh = elevationThresholdM +
+ *      slope · b · cellSize` (the cell run in z's unit — see
  *      `GroundFilterParams.cellSizeZUnits`). This is the heart shared by
  *      SMRF and Zhang's PMF.
  *   4. Point classification — a return is ground when it sits within a
  *      slope-scaled tolerance of the final opened surface beneath it.
  *
- *   It does NOT (yet) implement SMRF's net-cutting refinement pass or
- *   its image-processing-grade inpaint. Those are accuracy refinements,
- *   not correctness gaps; they belong in a later cycle and would be
- *   documented when they land. Until then the docstring tells the truth.
+ *   TWO OPENING RULES, AND WHY BOTH ARE HERE. `openingMode` selects
+ *   between them and defaults to `'cut-surface'`, the rule this filter
+ *   has always run and the one every committed terrain product was
+ *   measured under. It carries a single work surface through the window
+ *   ladder and writes a cell down whenever the drop exceeds `dh`, so
+ *   radius `b + 1` opens a surface radius `b` already lowered and the
+ *   drops compound. On ground that genuinely falls away across the
+ *   ladder that compounding cuts bare earth: measured against
+ *   `filters.smrf` over the committed study scenes it marks 1599 of 2500
+ *   cells on the rolling scene where the published rule marks 218.
+ *
+ *   `'object-mask'` is the rule as published (Pingel, Clarke & McBride
+ *   2013) and as implemented in PDAL's `filters.smrf`. The surface is
+ *   never written down; each radius opens the original, the drop is
+ *   measured against the previous radius' opening, the result is a
+ *   sticky object mask, and the masked cells are interpolated from their
+ *   nearest unmasked neighbours before any point is classified.
+ *   `structuringElement` selects the element shape independently and
+ *   defaults to `'square'`; `'diamond'` is the L1 element the published
+ *   filter uses. `tests/groundFilterPdalAgreement.test.ts` carries the
+ *   measured agreement for the combination the study runs.
+ *
+ *   It does NOT implement SMRF's net-cutting refinement pass, its
+ *   low-point pre-pass, or its image-processing-grade inpaint (the
+ *   object-cell refill here is the same nearest-finite flood fill used
+ *   for empty cells, where the published filter interpolates from k
+ *   neighbours). The missing low-point pass is why a scene carrying
+ *   gross below-ground blunders is not helped by `'object-mask'` alone;
+ *   `floorPercentile` is this filter's separate answer to that.
  *
  *   LOW-OUTLIER DESPIKE. A gross below-ground blunder (multipath, water
  *   returns, sensor noise) can seed a false low surface, and grayscale
@@ -67,6 +91,50 @@ import type { TerrainPoint, TerrainCoverageMode } from '../TerrainContracts';
 
 /** Which axis is the vertical (elevation) axis in the source frame. */
 export type VerticalAxis = 'z' | 'y';
+
+/**
+ * How the progressive morphological opening decides which cells carry
+ * above-ground objects.
+ *
+ * `'cut-surface'` — the original OpenLiDARViewer behaviour. One work surface is
+ * carried through the window ladder and a cell is written down to the opened
+ * height whenever the drop exceeds the threshold, so radius `b + 1` opens a
+ * surface that radius `b` already lowered.
+ *
+ * `'object-mask'` — the behaviour published as SMRF (Pingel, Clarke & McBride
+ * 2013) and implemented in PDAL's `filters.smrf`. The minimum-elevation surface
+ * is never written down. Each radius opens the ORIGINAL surface, the drop is
+ * measured against the PREVIOUS radius' opening rather than against a lowered
+ * surface, and the outcome is a sticky per-cell object mask. Cells the mask
+ * marks are then interpolated from their nearest unmarked neighbours before any
+ * point is classified, so a cell that held a building contributes the
+ * surrounding bare earth instead of the roof-minus-window height.
+ *
+ * The difference is not cosmetic. Under `'cut-surface'` a cell on curved ground
+ * accumulates one drop per radius, so a scene whose ground genuinely falls away
+ * over 16 cells is cut as though it held structure. See
+ * `tests/groundFilterPdalAgreement.test.ts` for the measured size of that.
+ */
+export type GroundOpeningMode = 'cut-surface' | 'object-mask';
+
+/**
+ * Shape of the flat structuring element the progressive opening uses.
+ *
+ * `'square'` (default) — the 8-connected box OpenLiDARViewer has always used. It
+ * is separable, so a radius-`b` pass costs two 1-D sweeps.
+ *
+ * `'diamond'` — the 4-connected L1 element PDAL's `filters.smrf` uses
+ * (`erodeDiamond` / `dilateDiamond`). A radius-`b` diamond covers
+ * `2b² + 2b + 1` cells against the box's `(2b + 1)²`, so a gross below-ground
+ * blunder propagates through the erosion ladder far more slowly. On a scene
+ * carrying such blunders the box lets a handful of pits swallow the whole grid
+ * by the time the ladder reaches radius 16; the diamond does not.
+ *
+ * Both are decomposable, so eroding by radius 1 `b` times equals eroding by
+ * radius `b` for either shape, which is what makes the progressive ladder exact
+ * rather than an approximation.
+ */
+export type GroundStructuringElement = 'square' | 'diamond';
 
 /** Tunable parameters for {@link classifyGroundSmrf}. */
 export interface GroundFilterParams {
@@ -132,6 +200,18 @@ export interface GroundFilterParams {
   readonly floorPercentile?: number;
   /** Vertical axis of the source frame. Defaults to `'z'`. */
   readonly verticalAxis?: VerticalAxis;
+  /**
+   * Which progressive-opening rule to run. Defaults to `'cut-surface'`, the
+   * behaviour every committed terrain product was measured under. See
+   * {@link GroundOpeningMode}.
+   */
+  readonly openingMode?: GroundOpeningMode;
+  /**
+   * Structuring-element shape for the opening. Defaults to `'square'`, the
+   * shape every committed terrain product was measured under. See
+   * {@link GroundStructuringElement}.
+   */
+  readonly structuringElement?: GroundStructuringElement;
 }
 
 /** Result of {@link classifyGroundSmrf}. */
@@ -149,6 +229,18 @@ export interface GroundFilterResult {
   readonly groundSurface: Float32Array;
   /** `1` where the cell held at least one source point, else `0`. */
   readonly hadData: Uint8Array;
+  /**
+   * `1` where the progressive opening judged the cell to hold an above-ground
+   * object, else `0`. Row-major like {@link groundSurface}.
+   *
+   * Both opening modes report it, so the two are directly comparable: under
+   * `'object-mask'` it is the mask the ladder accumulated, and under
+   * `'cut-surface'` it is the set of cells the ladder wrote down. All zeroes on
+   * the trusted-classification path, which runs no opening.
+   */
+  readonly objectCells: Uint8Array;
+  /** How many cells {@link objectCells} marks. */
+  readonly objectCellCount: number;
   /** Grid width in cells. */
   readonly cols: number;
   /** Grid height in cells. */
@@ -230,6 +322,18 @@ export function classifyGroundSmrf(
   let floorPercentile = params.floorPercentile ?? 0;
   if (!Number.isFinite(floorPercentile) || floorPercentile < 0) floorPercentile = 0;
   if (floorPercentile > 50) floorPercentile = 50;
+  // An unrecognised mode falls back to the shipped one WITH a warning rather
+  // than silently picking a rule the caller did not ask for.
+  let openingMode: GroundOpeningMode = params.openingMode ?? 'cut-surface';
+  if (openingMode !== 'cut-surface' && openingMode !== 'object-mask') {
+    warnings.push(`openingMode invalid (${String(openingMode)}); using cut-surface`);
+    openingMode = 'cut-surface';
+  }
+  let structuringElement: GroundStructuringElement = params.structuringElement ?? 'square';
+  if (structuringElement !== 'square' && structuringElement !== 'diamond') {
+    warnings.push(`structuringElement invalid (${String(structuringElement)}); using square`);
+    structuringElement = 'square';
+  }
 
   const sourcePointCount = points.length;
   if (sourcePointCount === 0) {
@@ -318,21 +422,80 @@ export function classifyGroundSmrf(
   const surface = inpaintNearest(minGrid, hadData, cols, rows);
 
   // ── 4. progressive morphological opening ──────────────────────────
-  // Work surface is mutated each window radius; a cell is cut down to
-  // the opened height when the drop exceeds the slope-scaled threshold.
-  let work = surface.slice();
-  for (let b = 1; b <= maxWindowCells; b++) {
-    const opened = morphOpen(work, cols, rows, b);
-    // Cap the slope-scaled threshold so a large window on steep ground can't
-    // grow the tolerance high enough to admit low objects (SMRF hard cap).
-    // The growth term takes the z-unit cell run: slope · run compares against
-    // a Δz, so a degree-valued run would pin dh at the base threshold.
-    const dh = Math.min(maxElevationThresholdM, elevationThresholdM + slope * b * cellSizeZUnits);
-    for (let i = 0; i < nCells; i++) {
-      if (work[i] - opened[i] > dh) work[i] = opened[i];
+  // The threshold at radius `b`, shared by both modes. Capped so a large window
+  // on steep ground can't grow the tolerance high enough to admit low objects
+  // (SMRF hard cap). The growth term takes the z-unit cell run: slope · run
+  // compares against a Δz, so a degree-valued run would pin dh at the base.
+  const thresholdAt = (b: number): number =>
+    Math.min(maxElevationThresholdM, elevationThresholdM + slope * b * cellSizeZUnits);
+
+  const objectCells = new Uint8Array(nCells);
+  let groundSurface: Float32Array;
+
+  if (openingMode === 'object-mask') {
+    // Published SMRF. The surface is never written down, so the drop a cell can
+    // show at radius `b` is the drop from radius `b - 1`'s opening and not the
+    // sum of every drop the ladder has taken so far. `prevSurface` starts at the
+    // minimum-elevation surface and advances to each opening in turn.
+    //
+    // The erosion is progressive: radius `b`'s erosion is radius `b - 1`'s
+    // eroded one more cell. A flat square structuring element decomposes, so
+    // eroding by radius 1 `b` times is exactly eroding the ORIGINAL surface by
+    // radius `b` — which is the point, since the original is what stays intact.
+    let prevSurface = surface;
+    let erosion = surface;
+    for (let b = 1; b <= maxWindowCells; b++) {
+      erosion = erodeBy(erosion, cols, rows, 1, structuringElement);
+      const opened = dilateBy(erosion, cols, rows, b, structuringElement);
+      const dh = thresholdAt(b);
+      for (let i = 0; i < nCells; i++) {
+        if (prevSurface[i] - opened[i] > dh) objectCells[i] = 1;
+      }
+      prevSurface = opened;
     }
+    // Object cells hold a height nobody surveyed as bare earth, so they are
+    // dropped and refilled from the nearest cell the mask left standing rather
+    // than kept at their opened value. `inpaintNearest` is the same
+    // nearest-finite flood fill step 3 uses for cells that held no return; the
+    // published filter's `knnfill` differs in interpolating from k neighbours,
+    // which is an accuracy refinement over the same idea.
+    let objectFree = 0;
+    const keep = new Uint8Array(nCells);
+    for (let i = 0; i < nCells; i++) {
+      if (objectCells[i] === 0) {
+        keep[i] = 1;
+        objectFree++;
+      }
+    }
+    if (objectFree === 0) {
+      // Every cell marked. There is no bare earth left to interpolate FROM, and
+      // a flood fill would return zeros, so the surface is left as measured and
+      // the caller is told the scene carried no unmarked cell.
+      warnings.push('progressive opening marked every cell as object; ground surface left un-interpolated');
+      groundSurface = surface.slice();
+    } else {
+      groundSurface = inpaintNearest(surface, keep, cols, rows);
+    }
+  } else {
+    // Original behaviour. Work surface is mutated each window radius; a cell is
+    // cut down to the opened height when the drop exceeds the threshold, and
+    // radius b + 1 then opens the surface radius b already lowered.
+    const work = surface.slice();
+    for (let b = 1; b <= maxWindowCells; b++) {
+      const opened = morphOpen(work, cols, rows, b, structuringElement);
+      const dh = thresholdAt(b);
+      for (let i = 0; i < nCells; i++) {
+        if (work[i] - opened[i] > dh) {
+          work[i] = opened[i];
+          objectCells[i] = 1;
+        }
+      }
+    }
+    groundSurface = work;
   }
-  const groundSurface = work;
+
+  let objectCellCount = 0;
+  for (let i = 0; i < nCells; i++) objectCellCount += objectCells[i];
 
   // ── 5. classify points against the opened surface ─────────────────
   const slopeGrid = surfaceSlope(groundSurface, cols, rows, cellSizeZUnits);
@@ -359,6 +522,8 @@ export function classifyGroundSmrf(
     isGround,
     groundSurface,
     hadData,
+    objectCells,
+    objectCellCount,
     cols,
     rows,
     cellSizeM,
@@ -464,6 +629,9 @@ export function groundFromTrustedClassification(
     isGround,
     groundSurface,
     hadData,
+    // No opening runs on this path, so no cell is judged to hold an object.
+    objectCells: new Uint8Array(nCells),
+    objectCellCount: 0,
     cols,
     rows,
     cellSizeM,
@@ -538,9 +706,76 @@ export function morphOpen(
   cols: number,
   rows: number,
   b: number,
+  se: GroundStructuringElement = 'square',
 ): Float32Array {
-  const eroded = windowExtreme(grid, cols, rows, b, 'min');
-  return windowExtreme(eroded, cols, rows, b, 'max');
+  const eroded = erodeBy(grid, cols, rows, b, se);
+  return dilateBy(eroded, cols, rows, b, se);
+}
+
+/** Erosion by a flat radius-`b` element of the given shape. */
+function erodeBy(
+  grid: Float32Array,
+  cols: number,
+  rows: number,
+  b: number,
+  se: GroundStructuringElement,
+): Float32Array {
+  return se === 'diamond'
+    ? diamondExtreme(grid, cols, rows, b, 'min')
+    : windowExtreme(grid, cols, rows, b, 'min');
+}
+
+/** Dilation by a flat radius-`b` element of the given shape. */
+function dilateBy(
+  grid: Float32Array,
+  cols: number,
+  rows: number,
+  b: number,
+  se: GroundStructuringElement,
+): Float32Array {
+  return se === 'diamond'
+    ? diamondExtreme(grid, cols, rows, b, 'max')
+    : windowExtreme(grid, cols, rows, b, 'max');
+}
+
+/**
+ * Radius-`b` L1 (diamond) min/max, applied as `b` radius-1 passes. The diamond
+ * is decomposable, so the repeated pass IS the radius-`b` element and not an
+ * approximation of it. There is no separable form, which is why this costs `b`
+ * sweeps where the box costs two. NaN is ignored, matching
+ * {@link windowExtreme}.
+ */
+function diamondExtreme(
+  grid: Float32Array,
+  cols: number,
+  rows: number,
+  b: number,
+  mode: 'min' | 'max',
+): Float32Array {
+  const pick = mode === 'min' ? Math.min : Math.max;
+  let cur = grid;
+  for (let pass = 0; pass < b; pass++) {
+    const next = new Float32Array(grid.length);
+    for (let row = 0; row < rows; row++) {
+      for (let col = 0; col < cols; col++) {
+        const i = row * cols + col;
+        let acc = cur[i];
+        if (col > 0) acc = merge(acc, cur[i - 1], pick);
+        if (col < cols - 1) acc = merge(acc, cur[i + 1], pick);
+        if (row > 0) acc = merge(acc, cur[i - cols], pick);
+        if (row < rows - 1) acc = merge(acc, cur[i + cols], pick);
+        next[i] = acc;
+      }
+    }
+    cur = next;
+  }
+  return cur;
+}
+
+/** Fold one neighbour into an accumulator, skipping non-finite values. */
+function merge(acc: number, val: number, pick: (a: number, b: number) => number): number {
+  if (!Number.isFinite(val)) return acc;
+  return Number.isFinite(acc) ? pick(acc, val) : val;
 }
 
 /** Separable 1-D windowed min/max over a flat square radius-`b` window. */
@@ -628,6 +863,8 @@ function emptyResult(cellSizeM: number, warnings: string[]): GroundFilterResult 
     isGround: new Uint8Array(0),
     groundSurface: new Float32Array(0),
     hadData: new Uint8Array(0),
+    objectCells: new Uint8Array(0),
+    objectCellCount: 0,
     cols: 0,
     rows: 0,
     cellSizeM,

--- a/tests/groundFilter.test.ts
+++ b/tests/groundFilter.test.ts
@@ -226,3 +226,152 @@ describe('surfaceSlope', () => {
     expect(surfaceSlope(step, cols, rows, 1)[2]).toBeGreaterThan(0);
   });
 });
+
+describe('opening mode', () => {
+  /**
+   * Ground that genuinely falls away across the window ladder, with no object on
+   * it at all. Every return is bare earth, so any cell either mode marks is a
+   * false object. 61x61 cells so the radius ladder has room to run.
+   */
+  function slopingScene(maxWindowCells: number): {
+    points: TerrainPoint[];
+    params: GroundFilterParams;
+  } {
+    const points: TerrainPoint[] = [];
+    const n = 61;
+    for (let iy = 0; iy < n; iy++) {
+      for (let ix = 0; ix < n; ix++) {
+        // Curvature in both axes, the same rolling form the PDAL study scenes
+        // use, so no straight-line fit hides it and every return is bare earth.
+        const z =
+          100 +
+          3 * Math.sin((2 * Math.PI * ix) / 25) * Math.cos((2 * Math.PI * iy) / 31) +
+          0.02 * ix;
+        points.push({ x: ix, y: iy, z });
+      }
+    }
+    return {
+      points,
+      params: {
+        cellSizeM: 1,
+        maxWindowCells,
+        slope: 0.15,
+        elevationThresholdM: 0.5,
+        scalingFactorM: 0,
+        maxElevationThresholdM: Infinity,
+      },
+    };
+  }
+
+  it('defaults to cut-surface, so an omitted mode changes nothing', () => {
+    const { points, params } = slopingScene(8);
+    const implicit = classifyGroundSmrf(points, params);
+    const explicit = classifyGroundSmrf(points, { ...params, openingMode: 'cut-surface' });
+    expect(Array.from(implicit.isGround)).toEqual(Array.from(explicit.isGround));
+    expect(Array.from(implicit.groundSurface)).toEqual(Array.from(explicit.groundSurface));
+    expect(implicit.objectCellCount).toBe(explicit.objectCellCount);
+  });
+
+  it('defaults to a square structuring element', () => {
+    const { points, params } = slopingScene(8);
+    const implicit = classifyGroundSmrf(points, params);
+    const explicit = classifyGroundSmrf(points, { ...params, structuringElement: 'square' });
+    expect(Array.from(implicit.groundSurface)).toEqual(Array.from(explicit.groundSurface));
+  });
+
+  it('object-mask marks far fewer cells than cut-surface on object-free curved ground', () => {
+    // Every return here is bare earth. cut-surface re-opens a surface it already
+    // lowered, so the drops compound and the ladder cuts ground that never held
+    // anything; object-mask measures each radius against the previous opening.
+    const { points, params } = slopingScene(12);
+    const cut = classifyGroundSmrf(points, { ...params, openingMode: 'cut-surface' });
+    const mask = classifyGroundSmrf(points, { ...params, openingMode: 'object-mask' });
+    expect(cut.objectCellCount).toBeGreaterThan(10 * (mask.objectCellCount + 1));
+    // and the classification follows. Not every return: object-mask still marks
+    // a handful of cells where the rolling surface turns fastest, so the claim
+    // is that it recovers nearly all of this ground, not all of it.
+    expect(mask.groundPointCount).toBeGreaterThan(cut.groundPointCount);
+    expect(mask.groundPointCount / points.length).toBeGreaterThan(0.99);
+    expect(cut.groundPointCount / points.length).toBeLessThan(0.9);
+  });
+
+  it('object-mask still finds a building, and refills its cells from the ground around it', () => {
+    const points: TerrainPoint[] = [];
+    const n = 41;
+    for (let iy = 0; iy < n; iy++) {
+      for (let ix = 0; ix < n; ix++) {
+        const roofed = ix >= 18 && ix <= 22 && iy >= 18 && iy <= 22;
+        // Roofed cells carry ONLY the roof return: the ground under them is occluded.
+        points.push({ x: ix, y: iy, z: roofed ? 8 : 0 });
+      }
+    }
+    const params: GroundFilterParams = {
+      cellSizeM: 1,
+      maxWindowCells: 10,
+      slope: 0.15,
+      elevationThresholdM: 0.5,
+      scalingFactorM: 0,
+      maxElevationThresholdM: Infinity,
+      openingMode: 'object-mask',
+    };
+    const r = classifyGroundSmrf(points, params);
+    const centre = 20 * r.cols + 20;
+    expect(r.objectCells[centre]).toBe(1);
+    // Interpolated back to the surrounding bare earth, not left at roof height.
+    expect(r.groundSurface[centre]).toBeCloseTo(0, 5);
+    // and the roof returns are not ground.
+    let roofGround = 0;
+    for (let i = 0; i < points.length; i++) if (points[i].z === 8 && r.isGround[i] === 1) roofGround++;
+    expect(roofGround).toBe(0);
+  });
+
+  it('reports objectCells consistently with the surface the cut-surface mode wrote', () => {
+    const { points, params } = slopingScene(6);
+    const r = classifyGroundSmrf(points, { ...params, openingMode: 'cut-surface' });
+    let marked = 0;
+    for (let i = 0; i < r.objectCells.length; i++) marked += r.objectCells[i];
+    expect(marked).toBe(r.objectCellCount);
+    expect(r.objectCells.length).toBe(r.cols * r.rows);
+  });
+
+  it('falls back with a warning on an unrecognised mode or element', () => {
+    const { points, params } = slopingScene(4);
+    const bad = classifyGroundSmrf(points, {
+      ...params,
+      openingMode: 'nonsense' as unknown as 'cut-surface',
+      structuringElement: 'hexagon' as unknown as 'square',
+    });
+    const good = classifyGroundSmrf(points, params);
+    expect(bad.warnings.some((w) => w.includes('openingMode invalid'))).toBe(true);
+    expect(bad.warnings.some((w) => w.includes('structuringElement invalid'))).toBe(true);
+    expect(Array.from(bad.groundSurface)).toEqual(Array.from(good.groundSurface));
+  });
+});
+
+describe('diamond structuring element', () => {
+  it('reaches fewer cells than the box, so a pit spreads less far', () => {
+    const cols = 15;
+    const rows = 15;
+    const grid = new Float32Array(cols * rows).fill(0);
+    grid[7 * cols + 7] = 9;
+    grid[3 * cols + 11] = -4;
+    const diamond = morphOpen(grid, cols, rows, 3, 'diamond');
+    const square = morphOpen(grid, cols, rows, 3, 'square');
+    expect(diamond[7 * cols + 7]).toBeCloseTo(0, 5); // spike removed by both
+    let diamondBelow = 0;
+    let squareBelow = 0;
+    for (let i = 0; i < grid.length; i++) {
+      if (diamond[i] < -0.001) diamondBelow++;
+      if (square[i] < -0.001) squareBelow++;
+    }
+    expect(diamondBelow).toBeLessThan(squareBelow);
+  });
+
+  it('removes an isolated spike like the square element', () => {
+    const cols = 7;
+    const rows = 7;
+    const grid = new Float32Array(cols * rows).fill(2);
+    grid[3 * cols + 3] = 20;
+    expect(morphOpen(grid, cols, rows, 1, 'diamond')[3 * cols + 3]).toBeCloseTo(2, 5);
+  });
+});


### PR DESCRIPTION
`GROUND-FILTER` sits at E3 with a registered study at `partial`: 0.607 and 0.773 agreement with PDAL `filters.smrf` on the rolling and ridge scenes against a 0.99 gate frozen before the run, and 0.822 pooled. The published refusal says agreement "holds on low-relief terrain but falls on steep terrain", which reads as a terrain problem. It is not. It is a code problem, and this locates it.

Object cells marked per 2500-cell scene, against a published-style mask: planar 200 against 200, rolling 1599 against 218, ridge 893 against 200. OLV over-cuts by roughly 8x on curved ground and not at all on planar, which is exactly why planar scenes agree perfectly and curved ones collapse.

`groundFilter.ts:332` wrote `work[i] = opened[i]` conditionally, so the surface was lowered in place and fed back into the next iteration's opening, while uncut cells kept their original height and accumulated a full-window drop against a threshold that grows linearly. PDAL's `SMRFilter.cpp` never lowers the surface: it accumulates an object mask, then sets those cells to NaN and interpolates before the provisional DEM is used.

Two corrections to the brief this was written from, both found by checking rather than accepting it. Progressive erosion is not an independent defect: the square structuring element is decomposable, so eroding by 1 `b` times equals eroding by `b`, and it matters only because the surface was being mutated. And there is a fourth difference the brief missed, visible in its own quoted source: PDAL calls `erodeDiamond` / `dilateDiamond`, an L1 element covering `2b²+2b+1` cells against the box's `(2b+1)²`. That is the published element shape, not a parameter.

Results over five committed scenes, the study's parameter set, as agreement with PDAL / balanced accuracy against generator truth / object cells per 2500:

| scene | shipped | object-mask, square | object-mask, diamond | PDAL bal.acc |
|---|---|---|---|---|
| plane | 1.0000 / 1.0000 / 200 | 1.0000 / 1.0000 / 200 | 1.0000 / 1.0000 / 200 | 1.0000 |
| rolling | 0.6070 / 0.6927 / 1599 | 0.9055 / 0.9864 / 218 | 0.9039 / 0.9880 / 204 | 0.9300 |
| ridge | 0.7734 / 0.8461 / 893 | 0.9723 / 1.0000 / 200 | 0.9723 / 1.0000 / 200 | 0.9832 |
| lowblunders | 0.7399 / 0.4923 | 0.7399 / 0.4923 | 0.9586 / 0.6370 | 0.6501 |
| gap | 1.0000 / 1.0000 | 1.0000 / 1.0000 | 1.0000 / 1.0000 | 1.0000 |
| pooled | 0.8221 / 0.8039 | 0.9227 / 0.8947 | 0.9666 / 0.9242 | 0.9117 |

The over-cut closes onto the published counts exactly: rolling 1599 to 218, ridge 893 to 200, planar unmoved.

Two results here are not wins, and they matter more than the headline. The low-blunder scene is untouched by the object mask, bit-identical. By radius 16 a square erosion spreads each of its 30 pits across 33x33 cells, so every cell is marked object and the 29 unmarked cells *are* the blunders, so the refill interpolates from them. That needs SMRF's `Low` pre-pass, which this filter does not have. The diamond helps there only because pits propagate more slowly, not because the defect is addressed, and PDAL itself reaches only 0.6501 on that scene.

And the residual disagreement flips sign. Before, OLV was restrictive (4382 only-PDAL-ground on rolling). After, it is slightly permissive (1047 only-ours, 7 only-PDAL). Against the generator's labels the new path beats PDAL on both curved scenes and pooled, 0.9242 against 0.9117, so the remaining gap to 0.99 is substantially PDAL cutting real ground near buildings rather than OLV missing it. No parameter was changed to reach that.

Both parameters default off and nothing downstream moves. `git status` is clean after the full suite, which regenerates the ground-filter results files into the working tree; `groundFilterPdalAgreement` still prints exactly `82.207 %` pooled with identical per-scene figures. A default flip would move DTM, CHM, contours, VRM and TPI, invalidating committed cross-checks whose numbers were measured under the current rule, for a path that reaches 0.9666 against a 0.99 gate and is still below PDAL on its worst scene. `GroundOpeningMode` and `GroundStructuringElement` are separate rather than one bundled flag so the two gains can be attributed independently.

The shipped column reproduces `results-ground-filter.json` to all printed digits, so the harness is sound, and an independently written standalone reimplementation reproduced the object-mask column exactly, so the in-module version is not self-confirming. The interpolator reuses the existing `inpaintNearest` rather than adding one; it uses a single nearest neighbour where PDAL uses `knnfill`, and how much of the residual that costs is unmeasured.

Not implemented and not measured: SMRF's `Low` and net-cell pre-passes, non-projected frames, other cell sizes and window ladders, real survey data, and the diamond's cost on production grids (it is roughly 8x the morphology work of the square at radius 16).

Gates: typecheck, `lint:architecture-truth`, `lint:module-graph`, `lint:layer-boundaries`, `lint:release-truth`, `lint:claim-register`, `validation:ground-metrics:verify`, `validation:study:verify`, and every test bucket. No claim, evidence level, tolerance or study manifest is touched.
