### PR TITLE
Share one corridor membership test between the section and the sampler

### DIFF
--- a/src/render/measure/profileCorridor.ts
+++ b/src/render/measure/profileCorridor.ts
@@ -1,0 +1,130 @@
+/**
+ * profileCorridor.ts
+ *
+ * The corridor membership test for a profile section, as one definition.
+ *
+ * `sampleProfile` reduces the corridor to a per-bin percentile series; the
+ * section workbench keeps the individual returns instead. Both answer the
+ * same question first: is this point inside the corridor, and at what
+ * chainage. That question is answered here, so the two products cannot
+ * drift apart.
+ *
+ * The corridor is a capsule. Membership is the distance to the FINITE
+ * segment a -> b in the plane perpendicular to `up`: perpendicular distance
+ * between the endpoints, radial distance from the nearer endpoint once the
+ * chainage runs past either end. The boundary is inclusive, so a point at
+ * exactly `band` is inside.
+ *
+ * The arithmetic below is the sampler's per-point walk term for term,
+ * including the order of the multiplies and the early scalar reject, so the
+ * two agree by construction rather than by tolerance.
+ *
+ * The algebraically equivalent form `(chainage - nearest)^2 + lateral^2` is
+ * not interchangeable. Over 3.8e6 points placed within a few ulps of the
+ * boundary the two forms differ by up to 1.45e-14 relative and return
+ * opposite verdicts for 6.6e5 of them. Point positions are float32, whose
+ * spacing is far coarser than that band, so a disagreement needs a point to
+ * land inside it by chance; matching term for term removes the question
+ * instead of bounding how often it arises.
+ */
+import type { ProfileFrame } from './profileGeometry';
+
+/** Offsets into the scratch array {@link profileCorridorAccepts} writes. */
+export const PROFILE_HIT_CHAINAGE = 0;
+export const PROFILE_HIT_LATERAL = 1;
+export const PROFILE_HIT_HEIGHT = 2;
+/** Length of the scratch array a caller must supply. */
+export const PROFILE_HIT_STRIDE = 3;
+
+/**
+ * Resolve the corridor half-width the sampler would use for this section.
+ *
+ * A null or absent width takes the automatic fraction of the section's
+ * horizontal length; a supplied width is floored at zero. Mirrors the
+ * resolution inside `sampleProfile` so a section and its derived series
+ * never walk different corridors.
+ */
+export function resolveCorridorHalfWidth(
+  horizontalLength: number,
+  bandWidth: number | null | undefined,
+  autoFraction: number,
+): number {
+  return bandWidth == null ? horizontalLength * autoFraction : Math.max(0, bandWidth);
+}
+
+/**
+ * Test one point against the corridor, writing its chainage, signed lateral
+ * offset and height into `out` when it is accepted.
+ *
+ * `out` is caller-owned and reused across points, so a scan of millions of
+ * returns allocates nothing. Its contents are undefined when the result is
+ * false.
+ *
+ * Returns false for a point with any non-finite coordinate. An organized
+ * cloud marks invalid points NaN per the PCD spec, and no height can be read
+ * off such a point.
+ */
+export function profileCorridorAccepts(
+  frame: ProfileFrame,
+  band: number,
+  bandSq: number,
+  px: number,
+  py: number,
+  pz: number,
+  out: Float64Array,
+): boolean {
+  const u = frame.up;
+  const aH = frame.horizontalAnchor;
+  const hDir = frame.along;
+  const horizontalLen = frame.horizontalLength;
+
+  const height = px * u[0] + py * u[1] + pz * u[2];
+  const dx = px - u[0] * height - aH[0];
+  const dy = py - u[1] * height - aH[1];
+  const dz = pz - u[2] * height - aH[2];
+
+  const along = dx * hDir[0] + dy * hDir[1] + dz * hDir[2];
+  if (!Number.isFinite(along)) return false;
+  // Cheap scalar reject before the three multiplies below. A point whose
+  // chainage is further than `band` past either end is further than `band`
+  // from the segment, because |d| >= |along| for a projection.
+  if (along < -band || along > horizontalLen + band) return false;
+
+  const nearest = along < 0 ? 0 : along > horizontalLen ? horizontalLen : along;
+  const pdx = dx - hDir[0] * nearest;
+  const pdy = dy - hDir[1] * nearest;
+  const pdz = dz - hDir[2] * nearest;
+  const nearSq = pdx * pdx + pdy * pdy + pdz * pdz;
+  if (nearSq > bandSq) return false;
+
+  const lat = frame.lateral;
+  out[PROFILE_HIT_CHAINAGE] = along;
+  out[PROFILE_HIT_LATERAL] = dx * lat[0] + dy * lat[1] + dz * lat[2];
+  out[PROFILE_HIT_HEIGHT] = height;
+  return true;
+}
+
+/**
+ * The bin an accepted chainage falls in, for a series of `samples` stations.
+ *
+ * Clamped at both ends so the capsule caps report into the end bins, matching
+ * the sampler. Returns 0 when the section is horizontally degenerate.
+ */
+export function profileCorridorBin(
+  chainage: number,
+  horizontalLength: number,
+  samples: number,
+): number {
+  if (!(horizontalLength > 0) || samples < 2) return 0;
+  const binStep = horizontalLength / (samples - 1);
+  let binIndex = Math.round(chainage / binStep);
+  if (binIndex < 0) binIndex = 0;
+  if (binIndex > samples - 1) binIndex = samples - 1;
+  return binIndex;
+}
+
+/** Scratch array sized for {@link profileCorridorAccepts}. */
+export function createProfileHitScratch(): Float64Array {
+  return new Float64Array(PROFILE_HIT_STRIDE);
+}
+

--- a/tests/profileCorridor.test.ts
+++ b/tests/profileCorridor.test.ts
@@ -1,0 +1,235 @@
+/**
+ * profileCorridor.test.ts
+ *
+ * The section extractor and the derived sampler must accept exactly the same
+ * returns. These tests hold the two against each other on clouds built to
+ * land points on and beside the capsule boundary, under several `up` axes.
+ *
+ * Agreement is asserted per bin and exactly. A single point resolving to a
+ * different bin, or accepted by one side and not the other, fails.
+ */
+import { describe, it, expect } from 'vitest';
+import { sampleProfile, AUTO_CORRIDOR_FRACTION } from '../src/render/measure/profileSampler';
+import { buildProfileFrame } from '../src/render/measure/profileGeometry';
+import {
+  profileCorridorAccepts,
+  profileCorridorBin,
+  resolveCorridorHalfWidth,
+  createProfileHitScratch,
+  PROFILE_HIT_CHAINAGE,
+  PROFILE_HIT_LATERAL,
+  PROFILE_HIT_HEIGHT,
+} from '../src/render/measure/profileCorridor';
+import type { Vec3 } from '../src/render/navMath';
+
+/**
+ * Golden-ratio low-discrepancy sequence. Deterministic, and unlike a fixed
+ * stride it does not align with any structure in the generated cloud.
+ */
+function lowDiscrepancy(i: number): number {
+  return (i * 0.6180339887498949) % 1;
+}
+
+/** Per-bin accepted counts, computed through the shared corridor predicate. */
+function countsViaPredicate(
+  positions: Float32Array,
+  a: Vec3,
+  b: Vec3,
+  up: Vec3,
+  bandWidth: number | null,
+  samples: number,
+): number[] {
+  const frame = buildProfileFrame(a, b, up);
+  const band = resolveCorridorHalfWidth(frame.horizontalLength, bandWidth, AUTO_CORRIDOR_FRACTION);
+  const bandSq = band * band;
+  const scratch = createProfileHitScratch();
+  const counts: number[] = new Array<number>(samples).fill(0);
+  const n = positions.length / 3;
+  for (let i = 0; i < n; i++) {
+    const ok = profileCorridorAccepts(
+      frame,
+      band,
+      bandSq,
+      positions[i * 3],
+      positions[i * 3 + 1],
+      positions[i * 3 + 2],
+      scratch,
+    );
+    if (!ok) continue;
+    const bin = profileCorridorBin(
+      scratch[PROFILE_HIT_CHAINAGE],
+      frame.horizontalLength,
+      samples,
+    );
+    counts[bin]++;
+  }
+  return counts;
+}
+
+/** Per-bin accepted counts as reported by the derived sampler. */
+function countsViaSampler(
+  positions: Float32Array,
+  a: Vec3,
+  b: Vec3,
+  up: Vec3,
+  bandWidth: number | null,
+  samples: number,
+): number[] {
+  // `count` is optional on ProfileSample for pre-v0.4.5 series, and
+  // `sampleProfile` always emits it. Coercing a missing one to 0 would let
+  // this comparison agree with an extractor that found nothing, so a missing
+  // count is an error here rather than a default.
+  return sampleProfile({ positions, a, b, up, bandWidth, samples }).map((s) => {
+    if (s.count === undefined) throw new Error('sampleProfile omitted a bin count');
+    return s.count;
+  });
+}
+
+/**
+ * A cloud whose points cluster on the corridor boundary.
+ *
+ * Half the points are placed at a lateral offset drawn from a set that
+ * includes exactly `band`, one ulp inside and one ulp outside, so the
+ * inclusive-boundary rule is exercised rather than assumed. The rest scatter
+ * across and beyond both end caps, including the diagonal corner region that
+ * separates a capsule from a bounding rectangle.
+ */
+function boundaryCloud(
+  count: number,
+  band: number,
+  a: Vec3,
+  b: Vec3,
+  up: Vec3,
+): Float32Array {
+  const out = new Float32Array(count * 3);
+  const offsets = [
+    band,
+    band * (1 + 2 * Number.EPSILON),
+    band * (1 - 2 * Number.EPSILON),
+    band * 0.5,
+    band * 1.5,
+    0,
+  ];
+  // Generate in the section's own frame so the cloud is boundary-dense for
+  // this exact a/b/up rather than for a canonical one.
+  const frame = buildProfileFrame(a, b, up);
+  const length = frame.horizontalLength;
+  const along = frame.along;
+  const lat = frame.lateral;
+  const u = frame.up;
+  const anchor = frame.horizontalAnchor;
+  for (let i = 0; i < count; i++) {
+    // Chainage sweeps past both caps so the radial cap region is populated.
+    const s = lowDiscrepancy(i) * (length + 4 * band) - 2 * band;
+    const d = offsets[i % offsets.length] * (i % 2 === 0 ? 1 : -1);
+    const h = lowDiscrepancy(i * 7 + 3) * 20;
+    out[i * 3] = anchor[0] + along[0] * s + lat[0] * d + u[0] * h;
+    out[i * 3 + 1] = anchor[1] + along[1] * s + lat[1] * d + u[1] * h;
+    out[i * 3 + 2] = anchor[2] + along[2] * s + lat[2] * d + u[2] * h;
+  }
+  return out;
+}
+
+const CASES: { name: string; up: Vec3; a: Vec3; b: Vec3 }[] = [
+  { name: 'Z-up, axis aligned', up: [0, 0, 1], a: [0, 0, 0], b: [100, 0, 0] },
+  { name: 'Z-up, oblique section', up: [0, 0, 1], a: [-13, 7, 2], b: [61, 44, 9] },
+  { name: 'Y-up', up: [0, 1, 0], a: [0, 0, 0], b: [80, 5, 30] },
+  { name: 'X-up', up: [1, 0, 0], a: [3, -2, 0], b: [4, 55, 40] },
+  {
+    name: 'oblique up',
+    up: [0.3, 0.5, 0.8119], // normalised inside buildProfileFrame
+    a: [1, 2, 3],
+    b: [70, 40, 25],
+  },
+];
+
+describe('profile corridor predicate agrees with the derived sampler', () => {
+  for (const c of CASES) {
+    for (const samples of [32, 64, 512]) {
+      it(`${c.name}, ${samples} stations, explicit band`, () => {
+        const band = 2.5;
+        const cloud = boundaryCloud(4000, band, c.a, c.b, c.up);
+        const viaPredicate = countsViaPredicate(cloud, c.a, c.b, c.up, band, samples);
+        const viaSampler = countsViaSampler(cloud, c.a, c.b, c.up, band, samples);
+        expect(viaPredicate).toEqual(viaSampler);
+        // A vacuous pass would be two all-zero arrays; require real coverage.
+        const total = viaSampler.reduce((x, y) => x + y, 0);
+        expect(total).toBeGreaterThan(200);
+      });
+    }
+
+    it(`${c.name}, automatic corridor width`, () => {
+      const cloud = boundaryCloud(4000, 5, c.a, c.b, c.up);
+      const viaPredicate = countsViaPredicate(cloud, c.a, c.b, c.up, null, 64);
+      const viaSampler = countsViaSampler(cloud, c.a, c.b, c.up, null, 64);
+      expect(viaPredicate).toEqual(viaSampler);
+      expect(viaSampler.reduce((x, y) => x + y, 0)).toBeGreaterThan(200);
+    });
+  }
+});
+
+describe('profile corridor edge behaviour', () => {
+  const up: Vec3 = [0, 0, 1];
+  const a: Vec3 = [0, 0, 0];
+  const b: Vec3 = [10, 0, 0];
+  const frame = buildProfileFrame(a, b, up);
+  const band = 1;
+  const scratch = createProfileHitScratch();
+
+  const accepts = (x: number, y: number, z: number): boolean =>
+    profileCorridorAccepts(frame, band, band * band, x, y, z, scratch);
+
+  it('accepts a point exactly on the lateral boundary', () => {
+    expect(accepts(5, 1, 0)).toBe(true);
+  });
+
+  it('rejects a point outside the lateral boundary', () => {
+    expect(accepts(5, 1.0000001, 0)).toBe(false);
+  });
+
+  it('closes the ends with a cap rather than a square corner', () => {
+    // Diagonal corner: inside a bounding rectangle of half-width 1 extended
+    // to the endpoint, outside a capsule because its radial distance from the
+    // endpoint is sqrt(2) * 0.9 > 1.
+    expect(accepts(-0.9, 0.9, 0)).toBe(false);
+    // Same chainage, on the section axis: inside the cap.
+    expect(accepts(-0.9, 0, 0)).toBe(true);
+  });
+
+  it('rejects a point beyond the far cap', () => {
+    expect(accepts(11.0000001, 0, 0)).toBe(false);
+    expect(accepts(11, 0, 0)).toBe(true);
+  });
+
+  it('rejects non-finite coordinates', () => {
+    expect(accepts(Number.NaN, 0, 0)).toBe(false);
+    expect(accepts(5, Number.POSITIVE_INFINITY, 0)).toBe(false);
+  });
+
+  it('signs the lateral offset by side, and reports chainage along the line', () => {
+    // frame.lateral is up x along. For up = +Z and along = +X that is +Y, so
+    // a point at +Y sits on the positive side. A sign flip or a swap with
+    // chainage would mirror the section, which the counts alone cannot see.
+    expect(accepts(3, 0.5, 0)).toBe(true);
+    expect(scratch[PROFILE_HIT_LATERAL]).toBeCloseTo(0.5, 12);
+    expect(scratch[PROFILE_HIT_CHAINAGE]).toBeCloseTo(3, 12);
+
+    expect(accepts(3, -0.5, 0)).toBe(true);
+    expect(scratch[PROFILE_HIT_LATERAL]).toBeCloseTo(-0.5, 12);
+    expect(scratch[PROFILE_HIT_CHAINAGE]).toBeCloseTo(3, 12);
+
+    // Under a reversed section the same physical point takes the other side.
+    const rev = buildProfileFrame(b, a, up);
+    expect(profileCorridorAccepts(rev, band, band * band, 3, 0.5, 0, scratch)).toBe(true);
+    expect(scratch[PROFILE_HIT_LATERAL]).toBeCloseTo(-0.5, 12);
+    expect(scratch[PROFILE_HIT_CHAINAGE]).toBeCloseTo(7, 12);
+  });
+
+  it('reports height along up, not z, under a Y-up frame', () => {
+    const yUp: Vec3 = [0, 1, 0];
+    const yFrame = buildProfileFrame([0, 0, 0], [10, 0, 0], yUp);
+    const ok = profileCorridorAccepts(yFrame, 1, 1, 5, 42, 0.5, scratch);
+    expect(ok).toBe(true);
+    expect(scratch[PROFILE_HIT_HEIGHT]).toBeCloseTo(42, 12);
+  });
+});


### PR DESCRIPTION
`sampleProfile` reduces a profile corridor to a per-bin percentile. The section workbench keeps the individual returns. `profileCorridorAccepts` answers the membership question both ask.

The corridor is a capsule: distance to the finite segment in the plane perpendicular to `up`, boundary inclusive. The predicate reproduces the sampler's arithmetic term for term. The algebraically equal `(chainage - nearest)^2 + lateral^2` returns the opposite verdict within 1.45e-14 of the boundary.

Chainage, signed lateral offset and height go into a caller-owned scratch array, so a scan allocates nothing per point.

Tests compare per-bin accepted counts against `sampleProfile` across five up axes and both corridor-width modes. `sampleProfile` is unchanged, so no claim or evidence level moves.
