### PR TITLE
Correct three stale comments in profileSampler

### DIFF
--- a/src/render/measure/profileSampler.ts
+++ b/src/render/measure/profileSampler.ts
@@ -14,9 +14,10 @@
  *     `samples` (≥ 2). Each sample's height is a robust statistic of the
  *     cloud points inside that bin's corridor, measured along `up`.
  *
- *   - The sampler walks the line in screen-perpendicular world-XY bins;
- *     each bin collects EVERY cloud point within `bandWidth` of the line
- *     and reduces them to one elevation with a percentile estimator (see
+ *   - Bins are laid out at equal chainage steps along the section line, and
+ *     each bin's corridor is evaluated in the plane perpendicular to `up`.
+ *     A bin collects EVERY cloud point within `bandWidth` of the segment and
+ *     reduces them to one elevation with a percentile estimator (see
  *     below). If a bin sees no points, the height is `NaN` — the consumer
  *     renders that gap as a discontinuity, never an interpolation.
  *
@@ -347,9 +348,9 @@ function percentileSorted(sorted: Float64Array, count: number, p: number): numbe
  *
  * Algorithm: for each cloud point, project it onto the horizontal line,
  * compute its distance to the SEGMENT (perpendicular between the endpoints,
- * radial past either end), and (if within `bandWidth`) update the bin's
- * nearest-point record. After the linear pass, walk the bins and emit
- * `(distance, nearestHeight)` for each.
+ * radial past either end), and (if within `bandWidth`) add its elevation to
+ * the bin its chainage falls in. After the linear pass, walk the bins and
+ * emit `(distance, percentileHeight)` for each.
  */
 export function sampleProfile(input: SampleProfileInput): ProfileSample[] {
   const samples = Math.max(MIN_SAMPLES, Math.min(MAX_SAMPLES, input.samples | 0));

--- a/src/render/measure/profileSampler.ts
+++ b/src/render/measure/profileSampler.ts
@@ -45,7 +45,8 @@
  *
  * The cost model is a single linear pass to bin the points, O(N), then a
  * per-bin sort, O(Σ b log b). For a 1 M-point cloud and 64 bins that is
- * tens of ms. The Measurements panel samples asynchronously.
+ * tens of ms. The walk is synchronous on the caller's thread, and it runs
+ * once per profile commit or resample, never per rendered frame.
  *
  * Streaming clouds sample only the resident points. This matches the live
  * inspector contract — what the user sees on screen is what gets sampled.


### PR DESCRIPTION
Three comments in `profileSampler.ts` described behaviour the module no longer has.

The header said bins are "screen-perpendicular world-XY". Bins are laid out at equal chainage steps along the section, and each bin's corridor is evaluated in the plane perpendicular to `up`. Membership is measured to the segment rather than to the line, so a point past an end is held to its distance from the endpoint.

The cost paragraph said the Measurements panel samples asynchronously. The walk is synchronous on the caller's thread, bound to a profile commit or resample rather than to the render loop.

`sampleProfile`'s algorithm note still described updating a nearest-point record and emitting `nearestHeight`, which the percentile reduction replaced. Comments only, one file, no executable change.
