### PR TITLE
Add an independent reference for the profile corridor end caps

### DIFF
--- a/scripts/make-profile-fixture.mjs
+++ b/scripts/make-profile-fixture.mjs
@@ -27,6 +27,11 @@
  *                        The other two fixtures keep their beyond-the-end
  *                        returns far enough out that both rules agree.
  *
+ *   profile-endcap.csv   eight probes, one per decisive end-cap case, two of
+ *                        them EXACTLY on a threshold. Compared point by point
+ *                        rather than through a percentile, so the verdict it
+ *                        carries is membership itself.
+ *
  *   profile-scatter.csv  an oblique section line, irregular corridor
  *                        populations including single-point and empty stations,
  *                        classified vegetation / building / noise returns above
@@ -48,6 +53,7 @@ import {
   CAPS_A, CAPS_B, CAPS_SAMPLES, CAPS_BAND, CAPS_BIN_STEP,
   CAPS_T_START, CAPS_T_STEP, CAPS_T_COUNT, CAPS_CROSS,
   CAPS_DECOY_T, CAPS_DECOY_LIFT, CAPS_REJECT_LIFT, CAPS_PROBES, capsGround,
+  ENDCAP_BAND, ENDCAP_PROBES, ENDCAP_Z, endcapDistance,
   EXCLUDED_CLASSES,
 } from './profile-fixture-params.mjs';
 
@@ -258,6 +264,41 @@ function writeCaps() {
   return { path, points: lines.length - 1 };
 }
 
+
+// ── ENDCAP ──────────────────────────────────────────────────────────────────
+
+/**
+ * Eight probes, one per decisive case, carrying an `id` column so a per-point
+ * verdict can be joined back to the case it answers. Two of them sit EXACTLY on
+ * a threshold, so unlike the other fixtures this one does not hold its points
+ * clear of the boundary; that is the whole measurement.
+ *
+ * Each probe's declared verdict is checked here against `endcapDistance`, an
+ * expression written from the definition rather than from the sampler, and the
+ * coordinates are checked for Float32 exactness so neither side reads a
+ * rounded number on a case decided by equality.
+ */
+export function endcapRows() {
+  return ENDCAP_PROBES.map((probe) => {
+    const d = endcapDistance(probe);
+    if (probe.admitted !== d <= ENDCAP_BAND) {
+      throw new Error(`endcap probe ${probe.id} is ${d} from the segment; admitted is declared ${probe.admitted}`);
+    }
+    for (const [name, v] of [['x', probe.x], ['y', probe.y], ['z', ENDCAP_Z]]) {
+      if (Math.fround(v) !== v) throw new Error(`endcap probe ${probe.id}: ${name} = ${v} is not exact in Float32`);
+    }
+    return [probe.id, probe.x, probe.y, ENDCAP_Z];
+  });
+}
+
+function writeEndcap() {
+  const lines = ['id,x,y,z'];
+  for (const [id, x, y, z] of endcapRows()) lines.push(`${id},${f(x)},${f(y)},${f(z)}`);
+  const path = resolve(OUT_DIR, 'profile-endcap.csv');
+  writeFileSync(path, `${lines.join('\n')}\n`);
+  return { path, points: lines.length - 1 };
+}
+
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
@@ -265,8 +306,10 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
   const ramp = writeRamp();
   const scatter = writeScatter();
   const caps = writeCaps();
+  const endcap = writeEndcap();
   console.log(`profile fixtures written`);
   console.log(`  ${ramp.path}  ${ramp.points} points, ${RAMP_SAMPLES} stations, corridor ±${RAMP_BAND} m`);
   console.log(`  ${scatter.path}  ${scatter.points} points, ${SCATTER_SAMPLES} stations, corridor ±${SCATTER_BAND} m`);
   console.log(`  ${caps.path}  ${caps.points} points, ${CAPS_SAMPLES} stations, corridor ±${CAPS_BAND} m`);
+  console.log(`  ${endcap.path}  ${endcap.points} probes, corridor ±${ENDCAP_BAND} m`);
 }

--- a/scripts/profile-fixture-params.d.mts
+++ b/scripts/profile-fixture-params.d.mts
@@ -42,3 +42,20 @@ export const CAPS_REJECT_LIFT: number;
 export const capsGround: (s: number) => number;
 export const CAPS_PROBES: Array<[number, number, boolean]>;
 export const capsExpected: (i: number, p: number) => number;
+
+export interface EndcapProbe {
+  id: string;
+  caseNo: number;
+  x: number;
+  y: number;
+  admitted: boolean;
+}
+export const ENDCAP_A: number[];
+export const ENDCAP_B: number[];
+export const ENDCAP_SAMPLES: number;
+export const ENDCAP_BAND: number;
+export const ENDCAP_BIN_STEP: number;
+export const ENDCAP_Z: number;
+export const ENDCAP_PROBES: EndcapProbe[];
+export const endcapDistance: (probe: { x: number; y: number }) => number;
+export const endcapRectangle: (probe: { x: number; y: number }) => boolean;

--- a/scripts/profile-fixture-params.mjs
+++ b/scripts/profile-fixture-params.mjs
@@ -191,3 +191,80 @@ export const CAPS_PROBES = [
 export const capsExpected = (i, p) =>
   capsGround(i * CAPS_BIN_STEP)
   + CAPS_CROSS * (CAPS_T_START + CAPS_T_STEP * (p / 100) * (CAPS_T_COUNT - 1));
+
+// ── ENDCAP: one probe per decisive case, membership only ────────────────────
+//
+// CAPS answers "does the corridor close with a half-disc" through the p25 of
+// two stations. It cannot answer what happens ON the threshold: every one of
+// its probes is held at least 0.125 m clear of the cap boundary, and the
+// MEAS-PROFILE-OGR-R-CORRIDOR study lists the exact-boundary tie-break in its
+// own scope.unsupported. This fixture is the membership-level reference for
+// that gap: eight probes, each decisive for one case, compared point by point
+// rather than through a percentile.
+//
+// The band is 2.5 m so a 3-4-5 triangle scaled by 1/2 lands a probe EXACTLY on
+// the cap boundary: 1.5² + 2² = 6.25 = 2.5². All three legs are dyadic and the
+// squares and their sum are exact in Float32 and in double, so the boundary
+// case is a true tie and not a value that happens to round onto one side. The
+// sampler compares squared distance against squared band, SpatiaLite compares
+// the distance itself against the band; on this probe both comparisons see
+// equality, which is what makes the tie-break observable at all.
+
+/** Section line, local render space. Axis-aligned, so chainage is x. */
+export const ENDCAP_A = [0, 0, 0];
+export const ENDCAP_B = [32, 0, 0];
+/** 33 stations over 32 m = a 1 m bin step. */
+export const ENDCAP_SAMPLES = 33;
+/** Corridor half-width, metres. 2.5 makes the 1.5/2/2.5 boundary probe exact. */
+export const ENDCAP_BAND = 2.5;
+/** Bin step, metres. Exact: 32 / 32. */
+export const ENDCAP_BIN_STEP = (ENDCAP_B[0] - ENDCAP_A[0]) / (ENDCAP_SAMPLES - 1);
+/** Elevation every probe carries. Membership is the measurement, not height. */
+export const ENDCAP_Z = 10;
+
+/**
+ * The eight probes, one per decisive case. `x` and `y` are absolute, in the
+ * same local frame as the section line, so nothing has to be reconstructed from
+ * a chainage convention. `admitted` is the HAND-DERIVED verdict for a corridor
+ * whose membership is "distance to the finite segment <= band". It is written
+ * here and asserted against exact arithmetic by scripts/make-profile-fixture.mjs
+ * before a byte is written.
+ *
+ * `caseNo` is the case number in the end-cap reference. `rectangle` is what a
+ * corridor with square ends would say about the same probe, which is what makes
+ * case 3 the discriminating one: it is the only probe the two rules disagree
+ * about while sitting nowhere near either threshold, so its verdict reports
+ * which shape the implementation has rather than how it rounds.
+ *
+ * Every coordinate is a multiple of 1/32 and under 40 in magnitude, so it is
+ * exact in the Float32Array the sampler reads and in the double the reference
+ * tools work in.
+ */
+export const ENDCAP_PROBES = [
+  { id: 'c1-start-cap-inside', caseNo: 1, x: -1, y: 0.5, admitted: true },
+  { id: 'c2-start-cap-boundary', caseNo: 2, x: -1.5, y: 2, admitted: true },
+  { id: 'c3-square-corner', caseNo: 3, x: -2.5, y: 2.5, admitted: false },
+  { id: 'c4-start-cap-outside', caseNo: 4, x: -1.5, y: 2.03125, admitted: false },
+  { id: 'c5a-end-cap-inside', caseNo: 5, x: 33, y: -0.5, admitted: true },
+  { id: 'c5b-end-cap-outside', caseNo: 5, x: 33.5, y: -2.03125, admitted: false },
+  { id: 'c6-body-inside', caseNo: 6, x: 16, y: 2.46875, admitted: true },
+  { id: 'c7-body-boundary', caseNo: 7, x: 16, y: 2.5, admitted: true },
+];
+
+/**
+ * Horizontal distance from a probe to the nearest point ON the segment: the
+ * perpendicular offset between the endpoints, the radius to the endpoint past
+ * either end. This is the definition the `admitted` flags are checked against,
+ * and it is deliberately not the sampler's expression.
+ */
+export const endcapDistance = ({ x, y }) => {
+  const len = ENDCAP_B[0] - ENDCAP_A[0];
+  const s = x < 0 ? 0 : x > len ? len : x;
+  return Math.hypot(x - s, y);
+};
+
+/** The rectangle rule, for the same probe: square ends, band past either end. */
+export const endcapRectangle = ({ x, y }) =>
+  Math.abs(y) <= ENDCAP_BAND
+  && x >= -ENDCAP_BAND
+  && x <= ENDCAP_B[0] - ENDCAP_A[0] + ENDCAP_BAND;

--- a/scripts/run-profile-endcap-reference.mjs
+++ b/scripts/run-profile-endcap-reference.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/**
+ * run-profile-endcap-reference.mjs: the independent side of the end-cap
+ * MEMBERSHIP reference.
+ *
+ * WHAT THIS ANSWERS THAT THE OTHER RUNS DO NOT. scripts/run-profile-reference.mjs
+ * compares reduced series: a percentile per station. A percentile can only show
+ * a membership rule indirectly, through a value that moves when a point leaks
+ * in, and it cannot show anything at all about a point sitting exactly on the
+ * threshold, because both fixtures hold every point clear of one. The
+ * MEAS-PROFILE-OGR-R-CORRIDOR study says so in its own scope.unsupported. This
+ * run asks the membership question directly, probe by probe.
+ *
+ * WHAT MAKES IT A CROSS-IMPLEMENTATION REFERENCE. The distance is SpatiaLite's
+ * ST_Distance against a two-point LINESTRING, which is GEOS point-to-segment
+ * geometry with no connection to this project. This script computes no distance
+ * and no verdict of its own; it runs ogrinfo, copies what came back, and records
+ * what ran.
+ *
+ * THREE COLUMNS, NOT ONE.
+ *   dist      ST_Distance itself, printed at full precision. The verdict is a
+ *             comparison, and a comparison written on this side would be this
+ *             repository's opinion; the distance is the reference's.
+ *   capsule   ST_Distance <= band, the corridor the sampler documents.
+ *   rect      ST_Intersects against an explicit POLYGON with square ends, the
+ *             rule the capsule has to be distinguished FROM. Case 3 is the probe
+ *             the two disagree about, so this column is what turns "the shapes
+ *             differ" into something the reference states rather than this file.
+ *
+ * A SEPARATE RECORD. reference-runs-profile.json is a listed artifact of the
+ * MEAS-PROFILE-OGR-R-CORRIDOR study with its own sha256, and
+ * reference-runs-profile-caps.json belongs to the supplementary caps run. This
+ * writes a third file so neither of those moves.
+ *
+ * NOTHING IS INFERRED. A failing stage is recorded with its exit code and its
+ * stderr and no output file is written.
+ *
+ * Usage: node scripts/run-profile-endcap-reference.mjs
+ */
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, existsSync, rmSync, realpathSync } from 'node:fs';
+import { resolve, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { platform, arch } from 'node:process';
+import { binaryOnPath } from './lib/binaryOnPath.mjs';
+import { ENDCAP_A, ENDCAP_B, ENDCAP_BAND } from './profile-fixture-params.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DIR = resolve(ROOT, 'validation/cross-implementation/profile');
+const rel = (abs) => relative(ROOT, abs).split('\\').join('/');
+
+const OGRINFO = 'ogrinfo';
+const LAYER = 'profile-endcap';
+const FIXTURE = resolve(DIR, 'profile-endcap.csv');
+const OUTPUT = resolve(DIR, 'profile-endcap__membership.csv');
+const RECORD = resolve(DIR, 'reference-runs-profile-endcap.json');
+
+function run(cmd, args) {
+  const r = spawnSync(cmd, args, { encoding: 'utf8', cwd: ROOT });
+  return {
+    code: r.status === null ? -1 : r.status,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? String(r.error?.message ?? ''),
+  };
+}
+
+const resolvedPathOf = (name) => {
+  const found = binaryOnPath(name);
+  if (found === null) return `unavailable: ${name} not on PATH`;
+  try { return realpathSync(found); } catch { return `unavailable: ${name}`; }
+};
+
+const version = (cmd, args) => run(cmd, args).stdout.split('\n')[0].trim() || 'unavailable';
+
+const line = `LINESTRING(${ENDCAP_A[0]} ${ENDCAP_A[1]},${ENDCAP_B[0]} ${ENDCAP_B[1]})`;
+/** The square-ended corridor: half-width band, extended band past either end. */
+const rectRing = [
+  [ENDCAP_A[0] - ENDCAP_BAND, -ENDCAP_BAND],
+  [ENDCAP_B[0] + ENDCAP_BAND, -ENDCAP_BAND],
+  [ENDCAP_B[0] + ENDCAP_BAND, ENDCAP_BAND],
+  [ENDCAP_A[0] - ENDCAP_BAND, ENDCAP_BAND],
+  [ENDCAP_A[0] - ENDCAP_BAND, -ENDCAP_BAND],
+];
+const rect = `POLYGON((${rectRing.map(([x, y]) => `${x} ${y}`).join(',')}))`;
+
+/**
+ * The membership query. Every value below is interpolated into SQL text,
+ * because ogrinfo's -sql takes a statement and not bind parameters. They all
+ * come from the frozen constants in profile-fixture-params.mjs and this script
+ * reads neither argv nor env, so nothing outside the repository reaches here.
+ * These assertions keep that true.
+ */
+function membershipSql() {
+  if (typeof ENDCAP_BAND !== 'number' || !Number.isFinite(ENDCAP_BAND)) {
+    throw new TypeError(`membershipSql: band must be a finite number, got ${String(ENDCAP_BAND)}`);
+  }
+  if (!/^[A-Za-z0-9_-]+$/.test(LAYER)) {
+    throw new TypeError(`membershipSql: layer name is not a bare identifier: ${LAYER}`);
+  }
+  if (!/^LINESTRING\(-?[\d.]+ -?[\d.]+,-?[\d.]+ -?[\d.]+\)$/.test(line)) {
+    throw new TypeError(`membershipSql: line is not a two-point WKT LINESTRING: ${line}`);
+  }
+  if (!/^POLYGON\(\((-?[\d.]+ -?[\d.]+,){4}-?[\d.]+ -?[\d.]+\)\)$/.test(rect)) {
+    throw new TypeError(`membershipSql: rect is not a five-vertex WKT POLYGON: ${rect}`);
+  }
+  const pt = 'MakePoint(CAST(x AS REAL), CAST(y AS REAL))';
+  const seg = `GeomFromText('${line}')`;
+  const box = `GeomFromText('${rect}')`;
+  const d = `ST_Distance(${seg}, ${pt})`;
+  return (
+    `SELECT id AS id, ${d} AS dist, `
+    + `CASE WHEN ${d} <= ${ENDCAP_BAND} THEN 1 ELSE 0 END AS capsule, `
+    + `CASE WHEN ST_Intersects(${box}, ${pt}) THEN 1 ELSE 0 END AS rect, `
+    + `CASE WHEN ${d} = ${ENDCAP_BAND} THEN 1 ELSE 0 END AS onBoundary `
+    + `FROM "${LAYER}"`
+  );
+}
+
+/**
+ * ogrinfo prints a feature block per row. Reading it back into a CSV here is a
+ * transcription, not a computation: `dist` is copied as the literal text
+ * ogrinfo printed, so nothing in this repository reformats a reference number.
+ */
+function parseFeatures(stdout) {
+  const rows = [];
+  let current = null;
+  for (const raw of stdout.split('\n')) {
+    if (/^OGRFeature/.test(raw)) {
+      if (current) rows.push(current);
+      current = {};
+      continue;
+    }
+    const m = /^\s{2}(\w+) \([^)]+\) = (.*)$/.exec(raw);
+    if (m && current) current[m[1]] = m[2].trim();
+  }
+  if (current) rows.push(current);
+  return rows;
+}
+
+const record = { generatedBy: 'scripts/run-profile-endcap-reference.mjs', runs: {} };
+
+if (!existsSync(FIXTURE)) {
+  record.runs.endcap = {
+    status: 'unavailable',
+    detail: `${rel(FIXTURE)} is missing; run scripts/make-profile-fixture.mjs`,
+  };
+} else {
+  const sql = membershipSql();
+  if (existsSync(OUTPUT)) rmSync(OUTPUT);
+  // -q drops the layer banner; the feature blocks carry every value at the
+  // precision ogrinfo prints them, which is what gets copied through.
+  const args = ['-q', '-dialect', 'SQLITE', '-sql', sql, rel(FIXTURE)];
+  const ogr = run(OGRINFO, args);
+  const rows = ogr.code === 0 ? parseFeatures(ogr.stdout) : [];
+  if (ogr.code !== 0 || rows.length === 0) {
+    record.runs.endcap = {
+      status: 'failed',
+      stage: 'ogrinfo',
+      exitCode: ogr.code,
+      stderr: ogr.stderr.trim() || null,
+    };
+    process.exitCode = 1;
+  } else {
+    const header = 'id,dist,capsule,rect,onBoundary';
+    const lines = [header];
+    for (const r of rows) lines.push([r.id, r.dist, r.capsule, r.rect, r.onBoundary].join(','));
+    writeFileSync(OUTPUT, `${lines.join('\n')}\n`);
+    record.runs.endcap = {
+      status: 'ok',
+      membershipSql: sql,
+      membershipCommandLine: `${OGRINFO} ${args.join(' ')}`,
+      membershipOutput: rel(OUTPUT),
+      probes: rows.length,
+      band: ENDCAP_BAND,
+      exitCodes: { ogrinfo: ogr.code },
+      stderr: ogr.stderr.trim() || null,
+    };
+  }
+}
+
+record.geometry = {
+  tool: 'GDAL/OGR SQLite dialect with SpatiaLite',
+  gdal: version(OGRINFO, ['--version']),
+  spatialite: run(OGRINFO, ['-q', '-dialect', 'SQLITE', '-sql', 'SELECT spatialite_version()', rel(FIXTURE)])
+    .stdout.split('=').pop().trim() || 'unavailable',
+  resolvedPath: resolvedPathOf(OGRINFO),
+  functions: ['ST_Distance', 'ST_Intersects', 'MakePoint', 'GeomFromText'],
+};
+record.containerPinning = 'not-executed';
+record.containerPinningNote =
+  'No containerised GDAL was used; the resolved executable path, the reported version and the exact command line stand in for an image digest.';
+record.platform = `${platform}-${arch}`;
+record.node = process.version;
+
+writeFileSync(RECORD, `${JSON.stringify(record, null, 2)}\n`);
+console.log(`endcap: ${record.runs.endcap.status}`);
+console.log(`record written to ${rel(RECORD)}`);

--- a/scripts/run-profile-endcap-reference.mjs
+++ b/scripts/run-profile-endcap-reference.mjs
@@ -146,7 +146,9 @@ if (!existsSync(FIXTURE)) {
   };
 } else {
   const sql = membershipSql();
-  if (existsSync(OUTPUT)) rmSync(OUTPUT);
+  // force: a stale output is removed without first asking whether it is
+  // there, so nothing can create the file between the question and the answer.
+  rmSync(OUTPUT, { force: true });
   // -q drops the layer banner; the feature blocks carry every value at the
   // precision ogrinfo prints them, which is what gets copied through.
   const args = ['-q', '-dialect', 'SQLITE', '-sql', sql, rel(FIXTURE)];

--- a/tests/profileEndcapMembership.test.ts
+++ b/tests/profileEndcapMembership.test.ts
@@ -1,0 +1,226 @@
+/**
+ * profileEndcapMembership.test.ts: the corridor's SHAPE at the ends, one probe
+ * per decisive case, against an independent implementation.
+ *
+ * WHAT THIS ADDS OVER profileCapsCrossCheck. That file compares reduced series:
+ * a p25 per station, which reports a membership rule only through a value that
+ * moves when a point leaks in. It cannot say anything about a point sitting
+ * exactly ON the threshold, because every one of its probes is held 0.125 m
+ * clear of the cap boundary, and MEAS-PROFILE-OGR-R-CORRIDOR lists that
+ * tie-break in its own scope.unsupported. This file asks membership directly and
+ * puts two probes exactly on the threshold.
+ *
+ * THREE VERDICTS PER PROBE, AND THEY MUST ALL AGREE.
+ *   hand-derived  ENDCAP_PROBES.admitted, checked against `endcapDistance`,
+ *                 an expression written from the definition of distance to a
+ *                 finite segment and not from the sampler.
+ *   candidate     whether sampleProfile's corridor counts the probe.
+ *   reference     SpatiaLite's ST_Distance <= band, from
+ *                 profile-endcap__membership.csv.
+ *
+ * WHY CASE 3 IS THE DISCRIMINATING ONE. Every probe here lies inside a corridor
+ * with square ends, so the rectangle rule admits all eight and cannot be the
+ * source of any agreement. The square corner is the probe the two shapes
+ * disagree about while sitting nowhere near either threshold: 3.5355 m from the
+ * segment against a 2.5 m band, and exactly on the rectangle's corner. A
+ * verdict on it reports which shape the implementation has, not how it rounds.
+ *
+ * Skips the reference legs rather than failing when the OGR output is absent;
+ * GDAL is not a project dependency.
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { sampleProfile } from '../src/render/measure/profileSampler';
+import type { Vec3 } from '../src/render/navMath';
+import {
+  ENDCAP_A, ENDCAP_B, ENDCAP_BAND, ENDCAP_SAMPLES, ENDCAP_Z,
+  ENDCAP_PROBES, endcapDistance, endcapRectangle, UP,
+} from '../scripts/profile-fixture-params.mjs';
+
+const DIR = resolve(__dirname, '../validation/cross-implementation/profile');
+const CLOUD = resolve(DIR, 'profile-endcap.csv');
+const REF = resolve(DIR, 'profile-endcap__membership.csv');
+const RUNS = resolve(DIR, 'reference-runs-profile-endcap.json');
+
+const PROBES = ENDCAP_PROBES;
+
+const vec3 = (v: number[]): Vec3 => [v[0], v[1], v[2]];
+
+/**
+ * The candidate's verdict, read behaviourally: a cloud holding this one point,
+ * sampled with the fixture's parameters. The corridor counts it or it does not,
+ * and nothing here reimplements the test that decides which.
+ */
+function sampled(x: number, y: number): boolean {
+  const out = sampleProfile({
+    a: vec3(ENDCAP_A),
+    b: vec3(ENDCAP_B),
+    up: vec3(UP),
+    positions: new Float32Array([x, y, ENDCAP_Z]),
+    samples: ENDCAP_SAMPLES,
+    bandWidth: ENDCAP_BAND,
+  });
+  const total = out.reduce((n, s) => n + (s.count ?? 0), 0);
+  expect(total, `a single probe cannot be counted ${total} times`).toBeLessThanOrEqual(1);
+  return total === 1;
+}
+
+/** The neighbouring Float32, outward or inward. One ulp, in the type the sampler reads. */
+function nextFloat32(v: number, dir: 1 | -1): number {
+  const buf = new ArrayBuffer(4);
+  const f = new Float32Array(buf);
+  const i = new Int32Array(buf);
+  f[0] = Math.fround(v);
+  i[0] += v >= 0 ? dir : -dir;
+  return f[0];
+}
+
+interface ReferenceRow {
+  dist: number;
+  capsule: boolean;
+  rect: boolean;
+  onBoundary: boolean;
+}
+
+function readReference(path: string): Map<string, ReferenceRow> {
+  const lines = readFileSync(path, 'utf8').trim().split('\n');
+  expect(lines[0], `${path}: unexpected header`).toBe('id,dist,capsule,rect,onBoundary');
+  const rows = new Map<string, ReferenceRow>();
+  for (const raw of lines.slice(1)) {
+    const [id, dist, capsule, rect, onBoundary] = raw.split(',');
+    rows.set(id, {
+      dist: Number(dist),
+      capsule: capsule === '1',
+      rect: rect === '1',
+      onBoundary: onBoundary === '1',
+    });
+  }
+  return rows;
+}
+
+const withReference = existsSync(REF) ? it : it.skip;
+/** The two probes placed exactly on a threshold, by construction. */
+const BOUNDARY_IDS = ['c2-start-cap-boundary', 'c7-body-boundary'];
+
+describe('section profile corridor: end-cap membership', () => {
+  it('covers all seven cases with probes whose fixture rows are exact', () => {
+    expect(new Set(PROBES.map((p) => p.caseNo))).toEqual(new Set([1, 2, 3, 4, 5, 6, 7]));
+    const rows = readFileSync(CLOUD, 'utf8').trim().split('\n');
+    expect(rows[0]).toBe('id,x,y,z');
+    expect(rows).toHaveLength(PROBES.length + 1);
+    for (const [i, probe] of PROBES.entries()) {
+      // The committed bytes are the probe, not a rounded copy of it.
+      expect(rows[i + 1]).toBe(`${probe.id},${probe.x},${probe.y},${ENDCAP_Z}`);
+      expect(Math.fround(probe.x)).toBe(probe.x);
+      expect(Math.fround(probe.y)).toBe(probe.y);
+    }
+  });
+
+  it('derives each verdict from the definition, not from the sampler', () => {
+    for (const probe of PROBES) {
+      const d = endcapDistance(probe);
+      expect(probe.admitted, `${probe.id} is ${d} m from the segment`).toBe(d <= ENDCAP_BAND);
+    }
+    // Exactly two probes sit on the threshold; the rest are decided by a margin
+    // twelve orders of magnitude above double-precision projection differences.
+    const onBoundary = PROBES.filter((p) => endcapDistance(p) === ENDCAP_BAND);
+    expect(onBoundary.map((p) => p.id)).toEqual(BOUNDARY_IDS);
+    for (const probe of PROBES) {
+      if (BOUNDARY_IDS.includes(probe.id)) continue;
+      expect(Math.abs(endcapDistance(probe) - ENDCAP_BAND), `${probe.id} margin`).toBeGreaterThan(0.02);
+    }
+  });
+
+  it('case 3 is the probe that discriminates a capsule from a rectangle', () => {
+    // Every probe is inside the square-ended corridor, so agreement anywhere
+    // else in this file cannot be coming from the rectangle rule.
+    for (const probe of PROBES) expect(endcapRectangle(probe), `${probe.id} rectangle`).toBe(true);
+    const corner = PROBES.find((p) => p.caseNo === 3)!;
+    expect(corner.admitted).toBe(false);
+    // Its offset and its chainage past the end are both exactly the band, so a
+    // rectangle admits it on both axes, while the segment distance is band·√2.
+    expect(Math.abs(corner.y)).toBe(ENDCAP_BAND);
+    expect(Math.abs(corner.x - ENDCAP_A[0])).toBe(ENDCAP_BAND);
+    expect(endcapDistance(corner)).toBeCloseTo(ENDCAP_BAND * Math.SQRT2, 12);
+    // Cases 4 and 5b say what the rejection is measured from: both sit inside
+    // the square-ended rule on both axes and are still rejected, because the
+    // radius to the endpoint is what exceeds the band.
+    for (const id of ['c4-start-cap-outside', 'c5b-end-cap-outside']) {
+      const p = PROBES.find((q) => q.id === id)!;
+      expect(Math.abs(p.y), `${id} offset`).toBeLessThan(ENDCAP_BAND);
+      expect(endcapRectangle(p), `${id} rectangle`).toBe(true);
+      expect(p.admitted, `${id} capsule`).toBe(false);
+    }
+  });
+
+  it('the sampler agrees with the hand-derived verdict on all seven cases', () => {
+    for (const probe of PROBES) {
+      expect(sampled(probe.x, probe.y), `${probe.id} (case ${probe.caseNo})`).toBe(probe.admitted);
+    }
+  });
+
+  it('breaks the exact-boundary tie inclusively, at the cap and at the band', () => {
+    for (const id of BOUNDARY_IDS) {
+      const probe = PROBES.find((p) => p.id === id)!;
+      // Admitted at the threshold, and one Float32 ulp further out is rejected:
+      // the probe is ON the boundary and the admission is the equality branch,
+      // not a value that landed just inside.
+      expect(sampled(probe.x, probe.y), `${id} on the boundary`).toBe(true);
+      const out = nextFloat32(probe.y, 1);
+      expect(out, `${id}: the ulp step must move y`).not.toBe(probe.y);
+      expect(sampled(probe.x, out), `${id} one ulp outward`).toBe(false);
+      expect(sampled(probe.x, nextFloat32(probe.y, -1)), `${id} one ulp inward`).toBe(true);
+    }
+  });
+
+  withReference('agrees with the OGR/SpatiaLite verdict on all seven cases', () => {
+    const ref = readReference(REF);
+    expect(ref.size, 'reference probe count').toBe(PROBES.length);
+    for (const probe of PROBES) {
+      const row = ref.get(probe.id);
+      expect(row, `reference has no row for ${probe.id}`).toBeDefined();
+      const label = `${probe.id} (case ${probe.caseNo}), ST_Distance ${row!.dist}`;
+      expect(row!.capsule, `${label}: reference vs hand-derived`).toBe(probe.admitted);
+      expect(sampled(probe.x, probe.y), `${label}: sampler vs reference`).toBe(row!.capsule);
+      // Distances agree to the last bit the reference printed.
+      expect(row!.dist).toBeCloseTo(endcapDistance(probe), 12);
+    }
+  });
+
+  withReference('the reference puts the two tie cases exactly on the threshold', () => {
+    const ref = readReference(REF);
+    for (const [id, row] of ref) {
+      const onBoundary = BOUNDARY_IDS.includes(id);
+      // ST_Distance returned the band itself, not a neighbouring double. Without
+      // this the inclusive verdict below would be a rounding accident.
+      expect(row.onBoundary, `${id}: ST_Distance = band`).toBe(onBoundary);
+      if (onBoundary) {
+        expect(row.dist).toBe(ENDCAP_BAND);
+        expect(row.capsule, `${id}: reference admits at equality`).toBe(true);
+      }
+    }
+  });
+
+  withReference('the reference states the rectangle rule itself', () => {
+    const ref = readReference(REF);
+    // The reference admits every probe under the square-ended rule and rejects
+    // three under the segment rule, so the disagreement is the reference's
+    // finding and not an assertion written on this side.
+    for (const [id, row] of ref) expect(row.rect, `${id} rectangle`).toBe(true);
+    expect([...ref].filter(([, r]) => !r.capsule).map(([id]) => id))
+      .toEqual(['c3-square-corner', 'c4-start-cap-outside', 'c5b-end-cap-outside']);
+  });
+
+  withReference('records what produced the reference, separately from the study', () => {
+    const runs = JSON.parse(readFileSync(RUNS, 'utf8')) as {
+      runs: Record<string, { status: string; membershipSql?: string; band?: number }>;
+    };
+    expect(runs.runs.endcap.status).toBe('ok');
+    expect(runs.runs.endcap.band).toBe(ENDCAP_BAND);
+    // The corridor rule the reference applied, in its own words.
+    expect(runs.runs.endcap.membershipSql).toContain(
+      `ST_Distance(GeomFromText('LINESTRING(0 0,32 0)'), MakePoint(CAST(x AS REAL), CAST(y AS REAL))) <= 2.5`,
+    );
+  });
+});

--- a/validation/cross-implementation/profile/README.md
+++ b/validation/cross-implementation/profile/README.md
@@ -30,12 +30,22 @@ repository. Chainage and distance come from OGR's SpatiaLite functions
   MEAS-PROFILE-OGR-R-CORRIDOR study, whose two fixtures place their
   beyond-the-end returns far enough out that both rules reject them, which that
   study records in its own `scope.unsupported`.
+- `profile-endcap.csv` holds eight probes, one per decisive case of the
+  corridor's shape at the ends, all at one elevation because the measurement
+  here is membership rather than height. `profile-caps.csv` answers the shape
+  question through the p25 of two stations and holds every probe at least
+  0.125 m clear of the cap boundary; this fixture answers it point by point and
+  puts two probes EXACTLY on a threshold, one on the start cap and one on the
+  lateral band. The band is 2.5 m so that 1.5² + 2² = 6.25 = 2.5² lands the cap
+  probe on the boundary with no rounding on either side. The seven cases are
+  tabulated below. This fixture is SUPPLEMENTARY: it belongs to no study and
+  promotes nothing.
 - `profile-scatter.csv` — an oblique line, irregular corridor populations
   including single-point and empty stations, classified vegetation, building and
   noise returns above the ground, and ground returns outside the corridor. No
   closed form applies here; this is the fixture the external reference is for.
 
-All three are written by `scripts/make-profile-fixture.mjs`. The parameters, and why
+All four are written by `scripts/make-profile-fixture.mjs`. The parameters, and why
 each was chosen, are in `scripts/profile-fixture-params.mjs`.
 
 ## References
@@ -50,16 +60,66 @@ each was chosen, are in `scripts/profile-fixture-params.mjs`.
   series: station, corridor count, and one column per percentile.
 - `profile-caps__corridor.csv`, `profile-caps__profile.csv` — the same two
   stages over the end-cap fixture.
+- `profile-endcap__membership.csv` holds one row per probe, carrying SpatiaLite's
+  `ST_Distance` to the section segment at the precision ogrinfo printed it, the
+  `ST_Distance <= band` verdict, an `ST_Intersects` verdict against an explicit
+  square-ended POLYGON, and whether the distance came back exactly equal to the
+  band. The distance is what the reference contributes; the comparison is
+  reported next to it rather than in place of it.
 
 Exact commands, tool versions and resolved paths are in
 `reference-runs-profile.json`, written by `scripts/run-profile-reference.mjs`.
 The end-cap run records to `reference-runs-profile-caps.json` instead, because
 `reference-runs-profile.json` is an artifact of the study record below and is
 listed there with its sha256; a third run folded into it would change a file
-that record is checked against.
+that record is checked against. The membership run records to a third file,
+`reference-runs-profile-endcap.json`, written by
+`scripts/run-profile-endcap-reference.mjs`, for the same reason.
+
+## The seven end-cap cases
+
+`sampleProfile` admits a point when its distance to the FINITE segment is within
+the band, so the corridor is a capsule: a rectangle between the endpoints closed
+by a half-disc of radius `band` at each end. The eight probes in
+`profile-endcap.csv` are the cases that pin that shape down, on a 32 m section
+with a 2.5 m band.
+
+| Case | Probe | Position | In the corridor |
+| --- | --- | --- | --- |
+| 1 | `c1-start-cap-inside` | (−1, 0.5) | yes, 1.118 m from the start endpoint |
+| 2 | `c2-start-cap-boundary` | (−1.5, 2) | yes, exactly 2.5 m from the start endpoint |
+| 3 | `c3-square-corner` | (−2.5, 2.5) | no, 3.536 m from the segment |
+| 4 | `c4-start-cap-outside` | (−1.5, 2.03125) | no, 2.525 m from the start endpoint |
+| 5 | `c5a-end-cap-inside`, `c5b-end-cap-outside` | (33, −0.5), (33.5, −2.03125) | yes, then no; cases 1 and 4 mirrored to the end cap |
+| 6 | `c6-body-inside` | (16, 2.46875) | yes, 2.469 m from the line |
+| 7 | `c7-body-boundary` | (16, 2.5) | yes, exactly 2.5 m from the line |
+
+Case 3 is the discriminating one. All eight probes lie inside a corridor with
+square ends, which the reference states for itself in the `rect` column, so no
+agreement anywhere in this set can be coming from the rectangle rule. The square
+corner sits at exactly the band on both axes, which a square-ended corridor
+admits on both, and 2.5·√2 = 3.536 m from the segment, which the capsule
+rejects. It is also 1.036 m clear of the capsule's own boundary, so its verdict
+reports which shape the implementation has rather than how it rounds. Cases 4
+and 5b say what the rejection is measured from: each sits at a cross-line offset
+of 2.03125 m and a chainage 1.5 m past its end, both comfortably inside the
+square-ended rule, and each is rejected because its distance to the ENDPOINT is
+2.525 m. With cases 1, 2 and 5a admitted, that fixes the end of the corridor as
+a circle centred on the endpoint and not any straight cut.
+
+Cases 2 and 7 are the tie. Both sit exactly on a threshold, so each
+implementation's verdict is decided by whether its comparison is inclusive.
+`sampleProfile` rejects on `nearSq > bandSq`, a strict comparison of squared
+distance against squared band, so equality is admitted. The reference query is
+`ST_Distance(...) <= band`, so equality is admitted there too. Neither side is
+relying on a value that landed just inside: `ST_Distance` returns the band
+itself, which the `onBoundary` column records, and moving either probe one
+Float32 ulp outward flips the sampler to reject, which
+`tests/profileEndcapMembership.test.ts` runs.
 
 The comparison is `tests/profileCrossCheck.test.ts`, with the end caps in
-`tests/profileCapsCrossCheck.test.ts`; the study record is
+`tests/profileCapsCrossCheck.test.ts` and the seven membership cases in
+`tests/profileEndcapMembership.test.ts`; the study record is
 `validation/cross-implementation/studies/MEAS-PROFILE-OGR-R-CORRIDOR.study.json`
 and the protocol it runs under is
 `validation/protocols/PROTO-PROFILE-OGR-R-CORRIDOR.protocol.json`.

--- a/validation/cross-implementation/profile/profile-endcap.csv
+++ b/validation/cross-implementation/profile/profile-endcap.csv
@@ -1,0 +1,9 @@
+id,x,y,z
+c1-start-cap-inside,-1,0.5,10
+c2-start-cap-boundary,-1.5,2,10
+c3-square-corner,-2.5,2.5,10
+c4-start-cap-outside,-1.5,2.03125,10
+c5a-end-cap-inside,33,-0.5,10
+c5b-end-cap-outside,33.5,-2.03125,10
+c6-body-inside,16,2.46875,10
+c7-body-boundary,16,2.5,10

--- a/validation/cross-implementation/profile/profile-endcap__membership.csv
+++ b/validation/cross-implementation/profile/profile-endcap__membership.csv
@@ -1,0 +1,9 @@
+id,dist,capsule,rect,onBoundary
+c1-start-cap-inside,1.11803398874989,1,1,0
+c2-start-cap-boundary,2.5,1,1,1
+c3-square-corner,3.53553390593274,0,1,0
+c4-start-cap-outside,2.52506961537697,0,1,0
+c5a-end-cap-inside,1.11803398874989,1,1,0
+c5b-end-cap-outside,2.52506961537697,0,1,0
+c6-body-inside,2.46875,1,1,0
+c7-body-boundary,2.5,1,1,1

--- a/validation/cross-implementation/profile/reference-runs-profile-endcap.json
+++ b/validation/cross-implementation/profile/reference-runs-profile-endcap.json
@@ -1,0 +1,33 @@
+{
+  "generatedBy": "scripts/run-profile-endcap-reference.mjs",
+  "runs": {
+    "endcap": {
+      "status": "ok",
+      "membershipSql": "SELECT id AS id, ST_Distance(GeomFromText('LINESTRING(0 0,32 0)'), MakePoint(CAST(x AS REAL), CAST(y AS REAL))) AS dist, CASE WHEN ST_Distance(GeomFromText('LINESTRING(0 0,32 0)'), MakePoint(CAST(x AS REAL), CAST(y AS REAL))) <= 2.5 THEN 1 ELSE 0 END AS capsule, CASE WHEN ST_Intersects(GeomFromText('POLYGON((-2.5 -2.5,34.5 -2.5,34.5 2.5,-2.5 2.5,-2.5 -2.5))'), MakePoint(CAST(x AS REAL), CAST(y AS REAL))) THEN 1 ELSE 0 END AS rect, CASE WHEN ST_Distance(GeomFromText('LINESTRING(0 0,32 0)'), MakePoint(CAST(x AS REAL), CAST(y AS REAL))) = 2.5 THEN 1 ELSE 0 END AS onBoundary FROM \"profile-endcap\"",
+      "membershipCommandLine": "ogrinfo -q -dialect SQLITE -sql SELECT id AS id, ST_Distance(GeomFromText('LINESTRING(0 0,32 0)'), MakePoint(CAST(x AS REAL), CAST(y AS REAL))) AS dist, CASE WHEN ST_Distance(GeomFromText('LINESTRING(0 0,32 0)'), MakePoint(CAST(x AS REAL), CAST(y AS REAL))) <= 2.5 THEN 1 ELSE 0 END AS capsule, CASE WHEN ST_Intersects(GeomFromText('POLYGON((-2.5 -2.5,34.5 -2.5,34.5 2.5,-2.5 2.5,-2.5 -2.5))'), MakePoint(CAST(x AS REAL), CAST(y AS REAL))) THEN 1 ELSE 0 END AS rect, CASE WHEN ST_Distance(GeomFromText('LINESTRING(0 0,32 0)'), MakePoint(CAST(x AS REAL), CAST(y AS REAL))) = 2.5 THEN 1 ELSE 0 END AS onBoundary FROM \"profile-endcap\" validation/cross-implementation/profile/profile-endcap.csv",
+      "membershipOutput": "validation/cross-implementation/profile/profile-endcap__membership.csv",
+      "probes": 8,
+      "band": 2.5,
+      "exitCodes": {
+        "ogrinfo": 0
+      },
+      "stderr": null
+    }
+  },
+  "geometry": {
+    "tool": "GDAL/OGR SQLite dialect with SpatiaLite",
+    "gdal": "GDAL 3.13.3 \"Iowa City\", released 2026/08/13",
+    "spatialite": "5.1.0",
+    "resolvedPath": "/opt/homebrew/Cellar/gdal/3.13.3/bin/ogrinfo",
+    "functions": [
+      "ST_Distance",
+      "ST_Intersects",
+      "MakePoint",
+      "GeomFromText"
+    ]
+  },
+  "containerPinning": "not-executed",
+  "containerPinningNote": "No containerised GDAL was used; the resolved executable path, the reported version and the exact command line stand in for an image digest.",
+  "platform": "darwin-arm64",
+  "node": "v26.7.0"
+}


### PR DESCRIPTION
The profile corridor's end-cap semantics had no reference outside OLV's own tests.

Eight probes on a 32 m section at a 2.5 m band, resolved through OGR/SpatiaLite `ST_Distance` against the finite LineString. The seven cases agree with the sampler and with a hand-derived verdict.

A square-ended corridor admits all eight probes, so the fixture separates the two shapes rather than confirming either. The corner probe sits inside that rectangle on both axes and 3.54 m from the segment. Both boundary probes use a halved 3-4-5 triple, so the tie is exact rather than rounded, and both implementations admit it.

New fixture, reference record and test. No study, protocol, claim or tolerance edited. GDAL 3.13.3, SpatiaLite 5.1.0.
