### PR TITLE
Keep section returns traceable to their own source and index

### DIFF
--- a/src/render/measure/profileSectionBuilder.ts
+++ b/src/render/measure/profileSectionBuilder.ts
@@ -1,0 +1,276 @@
+/**
+ * profileSectionBuilder.ts
+ *
+ * Accumulate the returns accepted by a profile corridor into compact typed
+ * arrays, keeping each return's identity and only the attributes its own
+ * source actually carries.
+ *
+ * The derived series reduces a corridor to one height per station. The
+ * section keeps the returns themselves, so every accepted point has to stay
+ * traceable to the source and index it came from, and an attribute that a
+ * source does not carry has to stay absent rather than becoming zero. A
+ * fabricated zero intensity is indistinguishable from a measured one.
+ *
+ * Presence is recorded per point, not per snapshot. A section can mix a
+ * source that carries RGB with one that does not, so `channelPresence`
+ * carries one bit per attribute per point and a consumer reads a channel
+ * only where its bit is set.
+ *
+ * Storage grows by doubling and is copied out at `finish()`, so the
+ * finished arrays are sized to the accepted count rather than to the
+ * scanned count.
+ */
+
+/** The per-point attributes a section can carry through from a source. */
+export type ProfileAttribute =
+  | 'rgb'
+  | 'intensity'
+  | 'classification'
+  | 'returnNumber'
+  | 'returnCount'
+  | 'pointSourceId'
+  | 'gpsTime'
+  | 'normals';
+
+/** Bit position of each attribute inside `channelPresence`. */
+export const PROFILE_ATTRIBUTE_BIT: Readonly<Record<ProfileAttribute, number>> = {
+  rgb: 1 << 0,
+  intensity: 1 << 1,
+  classification: 1 << 2,
+  returnNumber: 1 << 3,
+  returnCount: 1 << 4,
+  pointSourceId: 1 << 5,
+  gpsTime: 1 << 6,
+  normals: 1 << 7,
+};
+
+export const PROFILE_ATTRIBUTES: readonly ProfileAttribute[] = [
+  'rgb',
+  'intensity',
+  'classification',
+  'returnNumber',
+  'returnCount',
+  'pointSourceId',
+  'gpsTime',
+  'normals',
+];
+
+/**
+ * The channels one source carries, aligned to that source's point index.
+ *
+ * A channel is absent when the source does not carry it. A channel whose
+ * length disagrees with the source's point count is treated as absent, the
+ * same rule `sampleProfile` applies to a misaligned classification array.
+ */
+export interface ProfileSourceChannels {
+  readonly rgb?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  readonly pointSourceId?: Uint16Array;
+  readonly gpsTime?: Float64Array;
+  readonly normals?: Float32Array;
+}
+
+/** Accepted returns, as struct-of-arrays. All arrays share one index space. */
+export interface ProfileSectionPoints {
+  readonly count: number;
+  readonly chainage: Float32Array;
+  readonly height: Float32Array;
+  readonly lateralOffset: Float32Array;
+  readonly sourceSlot: Uint16Array;
+  readonly pointIndex: Uint32Array;
+  /** One bit per {@link ProfileAttribute}; see {@link PROFILE_ATTRIBUTE_BIT}. */
+  readonly channelPresence: Uint8Array;
+  readonly rgb?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  readonly pointSourceId?: Uint16Array;
+  readonly gpsTime?: Float64Array;
+  readonly normals?: Float32Array;
+}
+
+const INITIAL_CAPACITY = 1024;
+
+function grow<T extends { length: number }>(
+  arr: T,
+  capacity: number,
+  make: (n: number) => T,
+  stride: number,
+): T {
+  const next = make(capacity * stride);
+  (next as unknown as { set(a: T): void }).set(arr);
+  return next;
+}
+
+/**
+ * Collect accepted returns from one or more sources.
+ *
+ * Call {@link beginSource} before the points of each source, then
+ * {@link push} per accepted return, then {@link finish} once.
+ */
+export class ProfileSectionBuilder {
+  private _count = 0;
+  private _capacity = INITIAL_CAPACITY;
+
+  private _chainage = new Float32Array(INITIAL_CAPACITY);
+  private _height = new Float32Array(INITIAL_CAPACITY);
+  private _lateral = new Float32Array(INITIAL_CAPACITY);
+  private _slot = new Uint16Array(INITIAL_CAPACITY);
+  private _index = new Uint32Array(INITIAL_CAPACITY);
+  private _presence = new Uint8Array(INITIAL_CAPACITY);
+
+  private _rgb = new Uint8Array(INITIAL_CAPACITY * 3);
+  private _intensity = new Uint16Array(INITIAL_CAPACITY);
+  private _classification = new Uint8Array(INITIAL_CAPACITY);
+  private _returnNumber = new Uint8Array(INITIAL_CAPACITY);
+  private _returnCount = new Uint8Array(INITIAL_CAPACITY);
+  private _pointSourceId = new Uint16Array(INITIAL_CAPACITY);
+  private _gpsTime = new Float64Array(INITIAL_CAPACITY);
+  private _normals = new Float32Array(INITIAL_CAPACITY * 3);
+
+  /** Attributes seen on at least one source, so only those are emitted. */
+  private _seen = 0;
+
+  private _srcSlot = 0;
+  private _srcChannels: ProfileSourceChannels | null = null;
+  private _srcMask = 0;
+
+  /**
+   * Bind the source whose returns follow.
+   *
+   * `pointCount` is the source's own point count. A channel whose length
+   * disagrees with it is dropped for that source, which keeps a misaligned
+   * array from shifting every attribute by one index.
+   */
+  beginSource(slot: number, channels: ProfileSourceChannels | null, pointCount: number): void {
+    this._srcSlot = slot;
+    this._srcChannels = channels;
+    let mask = 0;
+    if (channels) {
+      if (channels.rgb?.length === pointCount * 3) mask |= PROFILE_ATTRIBUTE_BIT.rgb;
+      if (channels.intensity?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.intensity;
+      if (channels.classification?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.classification;
+      if (channels.returnNumber?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.returnNumber;
+      if (channels.returnCount?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.returnCount;
+      if (channels.pointSourceId?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.pointSourceId;
+      if (channels.gpsTime?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.gpsTime;
+      if (channels.normals?.length === pointCount * 3) mask |= PROFILE_ATTRIBUTE_BIT.normals;
+    }
+    this._srcMask = mask;
+    this._seen |= mask;
+  }
+
+  /** Number of returns accepted so far. */
+  get count(): number {
+    return this._count;
+  }
+
+  private _reserve(): void {
+    if (this._count < this._capacity) return;
+    const next = this._capacity * 2;
+    this._chainage = grow(this._chainage, next, (n) => new Float32Array(n), 1);
+    this._height = grow(this._height, next, (n) => new Float32Array(n), 1);
+    this._lateral = grow(this._lateral, next, (n) => new Float32Array(n), 1);
+    this._slot = grow(this._slot, next, (n) => new Uint16Array(n), 1);
+    this._index = grow(this._index, next, (n) => new Uint32Array(n), 1);
+    this._presence = grow(this._presence, next, (n) => new Uint8Array(n), 1);
+    this._rgb = grow(this._rgb, next, (n) => new Uint8Array(n), 3);
+    this._intensity = grow(this._intensity, next, (n) => new Uint16Array(n), 1);
+    this._classification = grow(this._classification, next, (n) => new Uint8Array(n), 1);
+    this._returnNumber = grow(this._returnNumber, next, (n) => new Uint8Array(n), 1);
+    this._returnCount = grow(this._returnCount, next, (n) => new Uint8Array(n), 1);
+    this._pointSourceId = grow(this._pointSourceId, next, (n) => new Uint16Array(n), 1);
+    this._gpsTime = grow(this._gpsTime, next, (n) => new Float64Array(n), 1);
+    this._normals = grow(this._normals, next, (n) => new Float32Array(n), 3);
+    this._capacity = next;
+  }
+
+  /**
+   * Append one accepted return.
+   *
+   * `sourceIndex` is the point's index in the bound source, and it is what
+   * every channel is read at, so an attribute can never be read from a
+   * different point than the one being appended.
+   */
+  push(sourceIndex: number, chainage: number, height: number, lateralOffset: number): void {
+    this._reserve();
+    const i = this._count;
+    this._chainage[i] = chainage;
+    this._height[i] = height;
+    this._lateral[i] = lateralOffset;
+    this._slot[i] = this._srcSlot;
+    this._index[i] = sourceIndex;
+    this._presence[i] = this._srcMask;
+
+    const c = this._srcChannels;
+    if (c) {
+      const m = this._srcMask;
+      if (m & PROFILE_ATTRIBUTE_BIT.rgb) {
+        this._rgb[i * 3] = c.rgb![sourceIndex * 3];
+        this._rgb[i * 3 + 1] = c.rgb![sourceIndex * 3 + 1];
+        this._rgb[i * 3 + 2] = c.rgb![sourceIndex * 3 + 2];
+      }
+      if (m & PROFILE_ATTRIBUTE_BIT.intensity) this._intensity[i] = c.intensity![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.classification)
+        this._classification[i] = c.classification![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.returnNumber)
+        this._returnNumber[i] = c.returnNumber![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.returnCount)
+        this._returnCount[i] = c.returnCount![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.pointSourceId)
+        this._pointSourceId[i] = c.pointSourceId![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.gpsTime) this._gpsTime[i] = c.gpsTime![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.normals) {
+        this._normals[i * 3] = c.normals![sourceIndex * 3];
+        this._normals[i * 3 + 1] = c.normals![sourceIndex * 3 + 1];
+        this._normals[i * 3 + 2] = c.normals![sourceIndex * 3 + 2];
+      }
+    }
+    this._count++;
+  }
+
+  /**
+   * Copy out arrays sized to the accepted count.
+   *
+   * A channel is emitted only when some source carried it. A channel no
+   * source carried is absent from the result rather than present and zero.
+   */
+  finish(): ProfileSectionPoints {
+    const n = this._count;
+    const seen = this._seen;
+    const has = (a: ProfileAttribute): boolean => (seen & PROFILE_ATTRIBUTE_BIT[a]) !== 0;
+    return {
+      count: n,
+      chainage: this._chainage.slice(0, n),
+      height: this._height.slice(0, n),
+      lateralOffset: this._lateral.slice(0, n),
+      sourceSlot: this._slot.slice(0, n),
+      pointIndex: this._index.slice(0, n),
+      channelPresence: this._presence.slice(0, n),
+      ...(has('rgb') ? { rgb: this._rgb.slice(0, n * 3) } : {}),
+      ...(has('intensity') ? { intensity: this._intensity.slice(0, n) } : {}),
+      ...(has('classification') ? { classification: this._classification.slice(0, n) } : {}),
+      ...(has('returnNumber') ? { returnNumber: this._returnNumber.slice(0, n) } : {}),
+      ...(has('returnCount') ? { returnCount: this._returnCount.slice(0, n) } : {}),
+      ...(has('pointSourceId') ? { pointSourceId: this._pointSourceId.slice(0, n) } : {}),
+      ...(has('gpsTime') ? { gpsTime: this._gpsTime.slice(0, n) } : {}),
+      ...(has('normals') ? { normals: this._normals.slice(0, n * 3) } : {}),
+    };
+  }
+}
+
+/** True when point `i` carries attribute `a`. */
+export function profileSectionHas(
+  points: ProfileSectionPoints,
+  i: number,
+  a: ProfileAttribute,
+): boolean {
+  return (points.channelPresence[i]! & PROFILE_ATTRIBUTE_BIT[a]) !== 0;
+}

--- a/src/render/measure/profileSectionBuilder.ts
+++ b/src/render/measure/profileSectionBuilder.ts
@@ -77,7 +77,17 @@ export interface ProfileSourceChannels {
 export interface ProfileSectionPoints {
   readonly count: number;
   readonly chainage: Float32Array;
-  readonly height: Float32Array;
+  /**
+   * Height along `up`, float64.
+   *
+   * Chainage and lateral offset are section relative and bounded by the
+   * section length plus the corridor half width, where float32 resolves
+   * below a millimetre. Height is absolute in the project frame, so it
+   * carries whatever magnitude the frame has: float32 spacing is 3.2e-2 m at
+   * 1e6 and 6.4e-1 m at 1e7. The placement was resolved in float64 during
+   * the read, and storing the result narrower would discard that.
+   */
+  readonly height: Float64Array;
   readonly lateralOffset: Float32Array;
   readonly sourceSlot: Uint16Array;
   readonly pointIndex: Uint32Array;
@@ -117,7 +127,7 @@ export class ProfileSectionBuilder {
   private _capacity = INITIAL_CAPACITY;
 
   private _chainage = new Float32Array(INITIAL_CAPACITY);
-  private _height = new Float32Array(INITIAL_CAPACITY);
+  private _height = new Float64Array(INITIAL_CAPACITY);
   private _lateral = new Float32Array(INITIAL_CAPACITY);
   private _slot = new Uint16Array(INITIAL_CAPACITY);
   private _index = new Uint32Array(INITIAL_CAPACITY);
@@ -176,7 +186,7 @@ export class ProfileSectionBuilder {
     if (this._count < this._capacity) return;
     const next = this._capacity * 2;
     this._chainage = grow(this._chainage, next, (n) => new Float32Array(n), 1);
-    this._height = grow(this._height, next, (n) => new Float32Array(n), 1);
+    this._height = grow(this._height, next, (n) => new Float64Array(n), 1);
     this._lateral = grow(this._lateral, next, (n) => new Float32Array(n), 1);
     this._slot = grow(this._slot, next, (n) => new Uint16Array(n), 1);
     this._index = grow(this._index, next, (n) => new Uint32Array(n), 1);

--- a/tests/profileSectionBuilder.test.ts
+++ b/tests/profileSectionBuilder.test.ts
@@ -1,0 +1,211 @@
+/**
+ * profileSectionBuilder.test.ts
+ *
+ * Attribute integrity for the section builder.
+ *
+ * Every channel value is a distinct function of (slot, sourceIndex), so a
+ * value read one index off, or read from the wrong source, produces a number
+ * that cannot occur at that position. Checking a constant fill would not
+ * separate those failures from a correct read.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ProfileSectionBuilder,
+  profileSectionHas,
+  PROFILE_ATTRIBUTE_BIT,
+  type ProfileSourceChannels,
+} from '../src/render/measure/profileSectionBuilder';
+
+/** Channel values keyed so a one-index shift changes every one of them. */
+const intensityAt = (slot: number, i: number): number => 1000 * (slot + 1) + i * 7;
+const classAt = (slot: number, i: number): number => (slot * 31 + i * 13) % 256;
+const rgbAt = (slot: number, i: number, c: number): number => (slot * 17 + i * 5 + c * 61) % 256;
+const gpsAt = (slot: number, i: number): number => slot * 1e6 + i * 0.001;
+const retNumAt = (slot: number, i: number): number => ((i + slot * 2) % 5) + 1;
+const retCntAt = (slot: number, i: number): number => ((i + slot) % 4) + 1;
+const psidAt = (slot: number, i: number): number => 7000 + slot * 100 + (i % 90);
+const normAt = (slot: number, i: number, c: number): number => slot + i * 0.25 + c * 0.125;
+
+function channelsFor(slot: number, n: number, which: Set<string>): ProfileSourceChannels {
+  const out: Record<string, unknown> = {};
+  if (which.has('rgb')) {
+    const a = new Uint8Array(n * 3);
+    for (let i = 0; i < n; i++) for (let c = 0; c < 3; c++) a[i * 3 + c] = rgbAt(slot, i, c);
+    out.rgb = a;
+  }
+  if (which.has('intensity')) {
+    const a = new Uint16Array(n);
+    for (let i = 0; i < n; i++) a[i] = intensityAt(slot, i);
+    out.intensity = a;
+  }
+  if (which.has('classification')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = classAt(slot, i);
+    out.classification = a;
+  }
+  if (which.has('returnNumber')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = retNumAt(slot, i);
+    out.returnNumber = a;
+  }
+  if (which.has('returnCount')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = retCntAt(slot, i);
+    out.returnCount = a;
+  }
+  if (which.has('pointSourceId')) {
+    const a = new Uint16Array(n);
+    for (let i = 0; i < n; i++) a[i] = psidAt(slot, i);
+    out.pointSourceId = a;
+  }
+  if (which.has('gpsTime')) {
+    const a = new Float64Array(n);
+    for (let i = 0; i < n; i++) a[i] = gpsAt(slot, i);
+    out.gpsTime = a;
+  }
+  if (which.has('normals')) {
+    const a = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) for (let c = 0; c < 3; c++) a[i * 3 + c] = normAt(slot, i, c);
+    out.normals = a;
+  }
+  return out as ProfileSourceChannels;
+}
+
+describe('section builder keeps every attribute on its own point', () => {
+  it('carries a full channel set through unshifted, past a growth boundary', () => {
+    // Accepting every third of 9000 gives 3000 returns, which crosses the
+    // 1024 doubling threshold and then 2048, so the reallocation path runs
+    // rather than only the initial buffer.
+    const n = 9000;
+    const all = new Set([
+      'rgb',
+      'intensity',
+      'classification',
+      'returnNumber',
+      'returnCount',
+      'pointSourceId',
+      'gpsTime',
+      'normals',
+    ]);
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, channelsFor(0, n, all), n);
+    // Accept every third point so source index and section index differ, which
+    // a test accepting all points cannot distinguish from a correct read.
+    const accepted: number[] = [];
+    for (let i = 0; i < n; i += 3) {
+      b.push(i, i * 0.5, i * 0.25, i % 7 === 0 ? 1.5 : -1.5);
+      accepted.push(i);
+    }
+    const p = b.finish();
+    expect(p.count).toBe(accepted.length);
+    expect(p.count).toBeGreaterThan(1024);
+
+    for (let k = 0; k < p.count; k++) {
+      const src = accepted[k]!;
+      expect(p.pointIndex[k]).toBe(src);
+      expect(p.sourceSlot[k]).toBe(0);
+      expect(p.chainage[k]).toBeCloseTo(src * 0.5, 4);
+      expect(p.height[k]).toBeCloseTo(src * 0.25, 4);
+      expect(p.intensity![k]).toBe(intensityAt(0, src));
+      expect(p.classification![k]).toBe(classAt(0, src));
+      expect(p.returnNumber![k]).toBe(retNumAt(0, src));
+      expect(p.returnCount![k]).toBe(retCntAt(0, src));
+      expect(p.pointSourceId![k]).toBe(psidAt(0, src));
+      expect(p.gpsTime![k]).toBeCloseTo(gpsAt(0, src), 9);
+      for (let c = 0; c < 3; c++) {
+        expect(p.rgb![k * 3 + c]).toBe(rgbAt(0, src, c));
+        expect(p.normals![k * 3 + c]).toBeCloseTo(normAt(0, src, c), 5);
+      }
+    }
+  });
+
+  it('keeps mixed sources apart and marks absence per point', () => {
+    // A carries RGB and classification; B carries intensity and GPS time;
+    // C carries nothing. Interleaved so a per-snapshot presence flag would
+    // be wrong for two of the three.
+    const nA = 40;
+    const nB = 40;
+    const nC = 40;
+    const b = new ProfileSectionBuilder();
+
+    b.beginSource(0, channelsFor(0, nA, new Set(['rgb', 'classification'])), nA);
+    for (let i = 0; i < nA; i++) b.push(i, i, i, 0);
+    b.beginSource(1, channelsFor(1, nB, new Set(['intensity', 'gpsTime'])), nB);
+    for (let i = 0; i < nB; i++) b.push(i, i, i, 0);
+    b.beginSource(2, null, nC);
+    for (let i = 0; i < nC; i++) b.push(i, i, i, 0);
+
+    const p = b.finish();
+    expect(p.count).toBe(nA + nB + nC);
+
+    for (let k = 0; k < p.count; k++) {
+      const slot = p.sourceSlot[k]!;
+      const src = p.pointIndex[k]!;
+      if (slot === 0) {
+        expect(profileSectionHas(p, k, 'rgb')).toBe(true);
+        expect(profileSectionHas(p, k, 'classification')).toBe(true);
+        expect(profileSectionHas(p, k, 'intensity')).toBe(false);
+        expect(profileSectionHas(p, k, 'gpsTime')).toBe(false);
+        expect(p.classification![k]).toBe(classAt(0, src));
+        expect(p.rgb![k * 3]).toBe(rgbAt(0, src, 0));
+      } else if (slot === 1) {
+        expect(profileSectionHas(p, k, 'intensity')).toBe(true);
+        expect(profileSectionHas(p, k, 'gpsTime')).toBe(true);
+        expect(profileSectionHas(p, k, 'rgb')).toBe(false);
+        expect(profileSectionHas(p, k, 'classification')).toBe(false);
+        expect(p.intensity![k]).toBe(intensityAt(1, src));
+        expect(p.gpsTime![k]).toBeCloseTo(gpsAt(1, src), 9);
+      } else {
+        expect(p.channelPresence[k]).toBe(0);
+      }
+    }
+  });
+
+  it('omits a channel no source carried rather than emitting zeros', () => {
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, channelsFor(0, 10, new Set(['intensity'])), 10);
+    for (let i = 0; i < 10; i++) b.push(i, i, i, 0);
+    const p = b.finish();
+    expect(p.intensity).toBeDefined();
+    expect(p.rgb).toBeUndefined();
+    expect(p.gpsTime).toBeUndefined();
+    expect(p.classification).toBeUndefined();
+    expect(p.normals).toBeUndefined();
+  });
+
+  it('drops a misaligned channel for that source instead of shifting it', () => {
+    // A classification array one element short cannot be index-aligned. The
+    // sampler applies the same rule to its own classification input.
+    const n = 20;
+    const good = channelsFor(0, n, new Set(['classification', 'intensity']));
+    const bad: ProfileSourceChannels = {
+      classification: good.classification!.slice(0, n - 1),
+      intensity: good.intensity,
+    };
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, bad, n);
+    for (let i = 0; i < n; i++) b.push(i, i, i, 0);
+    const p = b.finish();
+
+    expect(p.classification).toBeUndefined();
+    for (let k = 0; k < p.count; k++) {
+      expect(profileSectionHas(p, k, 'classification')).toBe(false);
+      expect(profileSectionHas(p, k, 'intensity')).toBe(true);
+      expect(p.intensity![k]).toBe(intensityAt(0, k));
+    }
+  });
+
+  it('assigns one bit per attribute', () => {
+    const bits = Object.values(PROFILE_ATTRIBUTE_BIT);
+    expect(new Set(bits).size).toBe(bits.length);
+    for (const v of bits) expect(v & (v - 1)).toBe(0);
+    expect(bits.reduce((a, c) => a | c, 0)).toBe(0xff);
+  });
+
+  it('reports an empty section without allocating channels', () => {
+    const p = new ProfileSectionBuilder().finish();
+    expect(p.count).toBe(0);
+    expect(p.chainage.length).toBe(0);
+    expect(p.rgb).toBeUndefined();
+  });
+});


### PR DESCRIPTION
A profile section keeps individual corridor returns where the derived series keeps one height per station, so each return stays traceable to the source and index it came from.

`ProfileSectionBuilder` accumulates accepted returns into typed arrays sized to the accepted count, carrying slot, source point index, chainage, signed lateral offset and height, plus only the attributes each source supplies.

Presence is per point. A section can mix a source carrying RGB with one carrying intensity, so `channelPresence` holds one bit per attribute per point, and a channel no source supplied is absent rather than present and zero. A channel whose length disagrees with its source's point count is dropped for that source.

Height is float64: it is absolute in the project frame, where float32 spacing reaches 3.2e-2 m at 1e6.
