### PR TITLE
Scan eligible sources in place for the returns inside a corridor

### DIFF
--- a/src/render/measure/profileCorridor.ts
+++ b/src/render/measure/profileCorridor.ts
@@ -1,0 +1,130 @@
+/**
+ * profileCorridor.ts
+ *
+ * The corridor membership test for a profile section, as one definition.
+ *
+ * `sampleProfile` reduces the corridor to a per-bin percentile series; the
+ * section workbench keeps the individual returns instead. Both answer the
+ * same question first: is this point inside the corridor, and at what
+ * chainage. That question is answered here, so the two products cannot
+ * drift apart.
+ *
+ * The corridor is a capsule. Membership is the distance to the FINITE
+ * segment a -> b in the plane perpendicular to `up`: perpendicular distance
+ * between the endpoints, radial distance from the nearer endpoint once the
+ * chainage runs past either end. The boundary is inclusive, so a point at
+ * exactly `band` is inside.
+ *
+ * The arithmetic below is the sampler's per-point walk term for term,
+ * including the order of the multiplies and the early scalar reject, so the
+ * two agree by construction rather than by tolerance.
+ *
+ * The algebraically equivalent form `(chainage - nearest)^2 + lateral^2` is
+ * not interchangeable. Over 3.8e6 points placed within a few ulps of the
+ * boundary the two forms differ by up to 1.45e-14 relative and return
+ * opposite verdicts for 6.6e5 of them. Point positions are float32, whose
+ * spacing is far coarser than that band, so a disagreement needs a point to
+ * land inside it by chance; matching term for term removes the question
+ * instead of bounding how often it arises.
+ */
+import type { ProfileFrame } from './profileGeometry';
+
+/** Offsets into the scratch array {@link profileCorridorAccepts} writes. */
+export const PROFILE_HIT_CHAINAGE = 0;
+export const PROFILE_HIT_LATERAL = 1;
+export const PROFILE_HIT_HEIGHT = 2;
+/** Length of the scratch array a caller must supply. */
+export const PROFILE_HIT_STRIDE = 3;
+
+/**
+ * Resolve the corridor half-width the sampler would use for this section.
+ *
+ * A null or absent width takes the automatic fraction of the section's
+ * horizontal length; a supplied width is floored at zero. Mirrors the
+ * resolution inside `sampleProfile` so a section and its derived series
+ * never walk different corridors.
+ */
+export function resolveCorridorHalfWidth(
+  horizontalLength: number,
+  bandWidth: number | null | undefined,
+  autoFraction: number,
+): number {
+  return bandWidth == null ? horizontalLength * autoFraction : Math.max(0, bandWidth);
+}
+
+/**
+ * Test one point against the corridor, writing its chainage, signed lateral
+ * offset and height into `out` when it is accepted.
+ *
+ * `out` is caller-owned and reused across points, so a scan of millions of
+ * returns allocates nothing. Its contents are undefined when the result is
+ * false.
+ *
+ * Returns false for a point with any non-finite coordinate. An organized
+ * cloud marks invalid points NaN per the PCD spec, and no height can be read
+ * off such a point.
+ */
+export function profileCorridorAccepts(
+  frame: ProfileFrame,
+  band: number,
+  bandSq: number,
+  px: number,
+  py: number,
+  pz: number,
+  out: Float64Array,
+): boolean {
+  const u = frame.up;
+  const aH = frame.horizontalAnchor;
+  const hDir = frame.along;
+  const horizontalLen = frame.horizontalLength;
+
+  const height = px * u[0] + py * u[1] + pz * u[2];
+  const dx = px - u[0] * height - aH[0];
+  const dy = py - u[1] * height - aH[1];
+  const dz = pz - u[2] * height - aH[2];
+
+  const along = dx * hDir[0] + dy * hDir[1] + dz * hDir[2];
+  if (!Number.isFinite(along)) return false;
+  // Cheap scalar reject before the three multiplies below. A point whose
+  // chainage is further than `band` past either end is further than `band`
+  // from the segment, because |d| >= |along| for a projection.
+  if (along < -band || along > horizontalLen + band) return false;
+
+  const nearest = along < 0 ? 0 : along > horizontalLen ? horizontalLen : along;
+  const pdx = dx - hDir[0] * nearest;
+  const pdy = dy - hDir[1] * nearest;
+  const pdz = dz - hDir[2] * nearest;
+  const nearSq = pdx * pdx + pdy * pdy + pdz * pdz;
+  if (nearSq > bandSq) return false;
+
+  const lat = frame.lateral;
+  out[PROFILE_HIT_CHAINAGE] = along;
+  out[PROFILE_HIT_LATERAL] = dx * lat[0] + dy * lat[1] + dz * lat[2];
+  out[PROFILE_HIT_HEIGHT] = height;
+  return true;
+}
+
+/**
+ * The bin an accepted chainage falls in, for a series of `samples` stations.
+ *
+ * Clamped at both ends so the capsule caps report into the end bins, matching
+ * the sampler. Returns 0 when the section is horizontally degenerate.
+ */
+export function profileCorridorBin(
+  chainage: number,
+  horizontalLength: number,
+  samples: number,
+): number {
+  if (!(horizontalLength > 0) || samples < 2) return 0;
+  const binStep = horizontalLength / (samples - 1);
+  let binIndex = Math.round(chainage / binStep);
+  if (binIndex < 0) binIndex = 0;
+  if (binIndex > samples - 1) binIndex = samples - 1;
+  return binIndex;
+}
+
+/** Scratch array sized for {@link profileCorridorAccepts}. */
+export function createProfileHitScratch(): Float64Array {
+  return new Float64Array(PROFILE_HIT_STRIDE);
+}
+

--- a/src/render/measure/profileSectionBuilder.ts
+++ b/src/render/measure/profileSectionBuilder.ts
@@ -1,0 +1,276 @@
+/**
+ * profileSectionBuilder.ts
+ *
+ * Accumulate the returns accepted by a profile corridor into compact typed
+ * arrays, keeping each return's identity and only the attributes its own
+ * source actually carries.
+ *
+ * The derived series reduces a corridor to one height per station. The
+ * section keeps the returns themselves, so every accepted point has to stay
+ * traceable to the source and index it came from, and an attribute that a
+ * source does not carry has to stay absent rather than becoming zero. A
+ * fabricated zero intensity is indistinguishable from a measured one.
+ *
+ * Presence is recorded per point, not per snapshot. A section can mix a
+ * source that carries RGB with one that does not, so `channelPresence`
+ * carries one bit per attribute per point and a consumer reads a channel
+ * only where its bit is set.
+ *
+ * Storage grows by doubling and is copied out at `finish()`, so the
+ * finished arrays are sized to the accepted count rather than to the
+ * scanned count.
+ */
+
+/** The per-point attributes a section can carry through from a source. */
+export type ProfileAttribute =
+  | 'rgb'
+  | 'intensity'
+  | 'classification'
+  | 'returnNumber'
+  | 'returnCount'
+  | 'pointSourceId'
+  | 'gpsTime'
+  | 'normals';
+
+/** Bit position of each attribute inside `channelPresence`. */
+export const PROFILE_ATTRIBUTE_BIT: Readonly<Record<ProfileAttribute, number>> = {
+  rgb: 1 << 0,
+  intensity: 1 << 1,
+  classification: 1 << 2,
+  returnNumber: 1 << 3,
+  returnCount: 1 << 4,
+  pointSourceId: 1 << 5,
+  gpsTime: 1 << 6,
+  normals: 1 << 7,
+};
+
+export const PROFILE_ATTRIBUTES: readonly ProfileAttribute[] = [
+  'rgb',
+  'intensity',
+  'classification',
+  'returnNumber',
+  'returnCount',
+  'pointSourceId',
+  'gpsTime',
+  'normals',
+];
+
+/**
+ * The channels one source carries, aligned to that source's point index.
+ *
+ * A channel is absent when the source does not carry it. A channel whose
+ * length disagrees with the source's point count is treated as absent, the
+ * same rule `sampleProfile` applies to a misaligned classification array.
+ */
+export interface ProfileSourceChannels {
+  readonly rgb?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  readonly pointSourceId?: Uint16Array;
+  readonly gpsTime?: Float64Array;
+  readonly normals?: Float32Array;
+}
+
+/** Accepted returns, as struct-of-arrays. All arrays share one index space. */
+export interface ProfileSectionPoints {
+  readonly count: number;
+  readonly chainage: Float32Array;
+  readonly height: Float32Array;
+  readonly lateralOffset: Float32Array;
+  readonly sourceSlot: Uint16Array;
+  readonly pointIndex: Uint32Array;
+  /** One bit per {@link ProfileAttribute}; see {@link PROFILE_ATTRIBUTE_BIT}. */
+  readonly channelPresence: Uint8Array;
+  readonly rgb?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  readonly pointSourceId?: Uint16Array;
+  readonly gpsTime?: Float64Array;
+  readonly normals?: Float32Array;
+}
+
+const INITIAL_CAPACITY = 1024;
+
+function grow<T extends { length: number }>(
+  arr: T,
+  capacity: number,
+  make: (n: number) => T,
+  stride: number,
+): T {
+  const next = make(capacity * stride);
+  (next as unknown as { set(a: T): void }).set(arr);
+  return next;
+}
+
+/**
+ * Collect accepted returns from one or more sources.
+ *
+ * Call {@link beginSource} before the points of each source, then
+ * {@link push} per accepted return, then {@link finish} once.
+ */
+export class ProfileSectionBuilder {
+  private _count = 0;
+  private _capacity = INITIAL_CAPACITY;
+
+  private _chainage = new Float32Array(INITIAL_CAPACITY);
+  private _height = new Float32Array(INITIAL_CAPACITY);
+  private _lateral = new Float32Array(INITIAL_CAPACITY);
+  private _slot = new Uint16Array(INITIAL_CAPACITY);
+  private _index = new Uint32Array(INITIAL_CAPACITY);
+  private _presence = new Uint8Array(INITIAL_CAPACITY);
+
+  private _rgb = new Uint8Array(INITIAL_CAPACITY * 3);
+  private _intensity = new Uint16Array(INITIAL_CAPACITY);
+  private _classification = new Uint8Array(INITIAL_CAPACITY);
+  private _returnNumber = new Uint8Array(INITIAL_CAPACITY);
+  private _returnCount = new Uint8Array(INITIAL_CAPACITY);
+  private _pointSourceId = new Uint16Array(INITIAL_CAPACITY);
+  private _gpsTime = new Float64Array(INITIAL_CAPACITY);
+  private _normals = new Float32Array(INITIAL_CAPACITY * 3);
+
+  /** Attributes seen on at least one source, so only those are emitted. */
+  private _seen = 0;
+
+  private _srcSlot = 0;
+  private _srcChannels: ProfileSourceChannels | null = null;
+  private _srcMask = 0;
+
+  /**
+   * Bind the source whose returns follow.
+   *
+   * `pointCount` is the source's own point count. A channel whose length
+   * disagrees with it is dropped for that source, which keeps a misaligned
+   * array from shifting every attribute by one index.
+   */
+  beginSource(slot: number, channels: ProfileSourceChannels | null, pointCount: number): void {
+    this._srcSlot = slot;
+    this._srcChannels = channels;
+    let mask = 0;
+    if (channels) {
+      if (channels.rgb?.length === pointCount * 3) mask |= PROFILE_ATTRIBUTE_BIT.rgb;
+      if (channels.intensity?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.intensity;
+      if (channels.classification?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.classification;
+      if (channels.returnNumber?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.returnNumber;
+      if (channels.returnCount?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.returnCount;
+      if (channels.pointSourceId?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.pointSourceId;
+      if (channels.gpsTime?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.gpsTime;
+      if (channels.normals?.length === pointCount * 3) mask |= PROFILE_ATTRIBUTE_BIT.normals;
+    }
+    this._srcMask = mask;
+    this._seen |= mask;
+  }
+
+  /** Number of returns accepted so far. */
+  get count(): number {
+    return this._count;
+  }
+
+  private _reserve(): void {
+    if (this._count < this._capacity) return;
+    const next = this._capacity * 2;
+    this._chainage = grow(this._chainage, next, (n) => new Float32Array(n), 1);
+    this._height = grow(this._height, next, (n) => new Float32Array(n), 1);
+    this._lateral = grow(this._lateral, next, (n) => new Float32Array(n), 1);
+    this._slot = grow(this._slot, next, (n) => new Uint16Array(n), 1);
+    this._index = grow(this._index, next, (n) => new Uint32Array(n), 1);
+    this._presence = grow(this._presence, next, (n) => new Uint8Array(n), 1);
+    this._rgb = grow(this._rgb, next, (n) => new Uint8Array(n), 3);
+    this._intensity = grow(this._intensity, next, (n) => new Uint16Array(n), 1);
+    this._classification = grow(this._classification, next, (n) => new Uint8Array(n), 1);
+    this._returnNumber = grow(this._returnNumber, next, (n) => new Uint8Array(n), 1);
+    this._returnCount = grow(this._returnCount, next, (n) => new Uint8Array(n), 1);
+    this._pointSourceId = grow(this._pointSourceId, next, (n) => new Uint16Array(n), 1);
+    this._gpsTime = grow(this._gpsTime, next, (n) => new Float64Array(n), 1);
+    this._normals = grow(this._normals, next, (n) => new Float32Array(n), 3);
+    this._capacity = next;
+  }
+
+  /**
+   * Append one accepted return.
+   *
+   * `sourceIndex` is the point's index in the bound source, and it is what
+   * every channel is read at, so an attribute can never be read from a
+   * different point than the one being appended.
+   */
+  push(sourceIndex: number, chainage: number, height: number, lateralOffset: number): void {
+    this._reserve();
+    const i = this._count;
+    this._chainage[i] = chainage;
+    this._height[i] = height;
+    this._lateral[i] = lateralOffset;
+    this._slot[i] = this._srcSlot;
+    this._index[i] = sourceIndex;
+    this._presence[i] = this._srcMask;
+
+    const c = this._srcChannels;
+    if (c) {
+      const m = this._srcMask;
+      if (m & PROFILE_ATTRIBUTE_BIT.rgb) {
+        this._rgb[i * 3] = c.rgb![sourceIndex * 3];
+        this._rgb[i * 3 + 1] = c.rgb![sourceIndex * 3 + 1];
+        this._rgb[i * 3 + 2] = c.rgb![sourceIndex * 3 + 2];
+      }
+      if (m & PROFILE_ATTRIBUTE_BIT.intensity) this._intensity[i] = c.intensity![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.classification)
+        this._classification[i] = c.classification![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.returnNumber)
+        this._returnNumber[i] = c.returnNumber![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.returnCount)
+        this._returnCount[i] = c.returnCount![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.pointSourceId)
+        this._pointSourceId[i] = c.pointSourceId![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.gpsTime) this._gpsTime[i] = c.gpsTime![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.normals) {
+        this._normals[i * 3] = c.normals![sourceIndex * 3];
+        this._normals[i * 3 + 1] = c.normals![sourceIndex * 3 + 1];
+        this._normals[i * 3 + 2] = c.normals![sourceIndex * 3 + 2];
+      }
+    }
+    this._count++;
+  }
+
+  /**
+   * Copy out arrays sized to the accepted count.
+   *
+   * A channel is emitted only when some source carried it. A channel no
+   * source carried is absent from the result rather than present and zero.
+   */
+  finish(): ProfileSectionPoints {
+    const n = this._count;
+    const seen = this._seen;
+    const has = (a: ProfileAttribute): boolean => (seen & PROFILE_ATTRIBUTE_BIT[a]) !== 0;
+    return {
+      count: n,
+      chainage: this._chainage.slice(0, n),
+      height: this._height.slice(0, n),
+      lateralOffset: this._lateral.slice(0, n),
+      sourceSlot: this._slot.slice(0, n),
+      pointIndex: this._index.slice(0, n),
+      channelPresence: this._presence.slice(0, n),
+      ...(has('rgb') ? { rgb: this._rgb.slice(0, n * 3) } : {}),
+      ...(has('intensity') ? { intensity: this._intensity.slice(0, n) } : {}),
+      ...(has('classification') ? { classification: this._classification.slice(0, n) } : {}),
+      ...(has('returnNumber') ? { returnNumber: this._returnNumber.slice(0, n) } : {}),
+      ...(has('returnCount') ? { returnCount: this._returnCount.slice(0, n) } : {}),
+      ...(has('pointSourceId') ? { pointSourceId: this._pointSourceId.slice(0, n) } : {}),
+      ...(has('gpsTime') ? { gpsTime: this._gpsTime.slice(0, n) } : {}),
+      ...(has('normals') ? { normals: this._normals.slice(0, n * 3) } : {}),
+    };
+  }
+}
+
+/** True when point `i` carries attribute `a`. */
+export function profileSectionHas(
+  points: ProfileSectionPoints,
+  i: number,
+  a: ProfileAttribute,
+): boolean {
+  return (points.channelPresence[i]! & PROFILE_ATTRIBUTE_BIT[a]) !== 0;
+}

--- a/src/render/measure/profileSectionBuilder.ts
+++ b/src/render/measure/profileSectionBuilder.ts
@@ -77,7 +77,17 @@ export interface ProfileSourceChannels {
 export interface ProfileSectionPoints {
   readonly count: number;
   readonly chainage: Float32Array;
-  readonly height: Float32Array;
+  /**
+   * Height along `up`, float64.
+   *
+   * Chainage and lateral offset are section relative and bounded by the
+   * section length plus the corridor half width, where float32 resolves
+   * below a millimetre. Height is absolute in the project frame, so it
+   * carries whatever magnitude the frame has: float32 spacing is 3.2e-2 m at
+   * 1e6 and 6.4e-1 m at 1e7. The placement was resolved in float64 during
+   * the read, and storing the result narrower would discard that.
+   */
+  readonly height: Float64Array;
   readonly lateralOffset: Float32Array;
   readonly sourceSlot: Uint16Array;
   readonly pointIndex: Uint32Array;
@@ -117,7 +127,7 @@ export class ProfileSectionBuilder {
   private _capacity = INITIAL_CAPACITY;
 
   private _chainage = new Float32Array(INITIAL_CAPACITY);
-  private _height = new Float32Array(INITIAL_CAPACITY);
+  private _height = new Float64Array(INITIAL_CAPACITY);
   private _lateral = new Float32Array(INITIAL_CAPACITY);
   private _slot = new Uint16Array(INITIAL_CAPACITY);
   private _index = new Uint32Array(INITIAL_CAPACITY);
@@ -176,7 +186,7 @@ export class ProfileSectionBuilder {
     if (this._count < this._capacity) return;
     const next = this._capacity * 2;
     this._chainage = grow(this._chainage, next, (n) => new Float32Array(n), 1);
-    this._height = grow(this._height, next, (n) => new Float32Array(n), 1);
+    this._height = grow(this._height, next, (n) => new Float64Array(n), 1);
     this._lateral = grow(this._lateral, next, (n) => new Float32Array(n), 1);
     this._slot = grow(this._slot, next, (n) => new Uint16Array(n), 1);
     this._index = grow(this._index, next, (n) => new Uint32Array(n), 1);

--- a/src/render/measure/profileSectionExtract.ts
+++ b/src/render/measure/profileSectionExtract.ts
@@ -1,0 +1,207 @@
+/**
+ * profileSectionExtract.ts
+ *
+ * Scan eligible sources for the returns inside a profile corridor.
+ *
+ * The derived sampler reads a concatenated copy of every loaded position.
+ * A section keeps only the small fraction inside a corridor, so copying the
+ * scene to find them would cost more memory than the answer. This walks each
+ * source in place and appends accepted returns to a builder.
+ *
+ * A source is read through `readProjectXYZ`, which resolves the point in the
+ * project frame at read time. Source buffers are never modified and never
+ * copied wholesale, and the placement stays float64 so a mounted layer far
+ * from the project origin keeps its precision.
+ *
+ * The scan is a generator. It yields the number of points examined so far
+ * every `chunkSize` points, so a caller can spread it across frames or abort
+ * it without this module knowing anything about the host's scheduler.
+ */
+import type { ProfileFrame } from './profileGeometry';
+import {
+  profileCorridorAccepts,
+  createProfileHitScratch,
+  PROFILE_HIT_CHAINAGE,
+  PROFILE_HIT_LATERAL,
+  PROFILE_HIT_HEIGHT,
+} from './profileCorridor';
+import {
+  ProfileSectionBuilder,
+  type ProfileSourceChannels,
+  type ProfileSectionPoints,
+} from './profileSectionBuilder';
+
+/** An axis-aligned box in the project frame. */
+export interface ProfileSourceBounds {
+  readonly min: readonly [number, number, number];
+  readonly max: readonly [number, number, number];
+}
+
+/**
+ * One source the scan may read.
+ *
+ * Structural rather than a concrete cloud type, so this module does not
+ * import the viewer, the streaming scheduler or `PointCloud`.
+ */
+export interface ProfileSectionSourceView {
+  /** Stable slot recorded on every return this source contributes. */
+  readonly slot: number;
+  readonly pointCount: number;
+  /** Channels aligned to this source's own point index, or null. */
+  readonly channels: ProfileSourceChannels | null;
+  /**
+   * Conservative project-frame bounds, or null when unknown.
+   *
+   * Null means the source is scanned. A box that does not contain every
+   * point would drop returns silently, so an uncertain bound must be null.
+   */
+  readonly bounds: ProfileSourceBounds | null;
+  /** Write the project-frame position of `index` into `out[0..2]`. */
+  readProjectXYZ(index: number, out: Float64Array): void;
+}
+
+export interface ExtractProfileSectionOptions {
+  readonly frame: ProfileFrame;
+  /** Corridor half-width, in the same units as the frame. */
+  readonly band: number;
+  readonly sources: readonly ProfileSectionSourceView[];
+  /** Points examined between yields. */
+  readonly chunkSize?: number;
+  /** Consulted at each yield point. */
+  readonly signal?: { readonly aborted: boolean };
+  /** Skip the bounds pre-test, for differential testing of that test. */
+  readonly skipBoundsTest?: boolean;
+}
+
+export interface ProfileSectionExtractResult {
+  readonly points: ProfileSectionPoints;
+  /** True when the scan stopped early because the signal aborted. */
+  readonly aborted: boolean;
+  /** Slots skipped by the bounds pre-test. */
+  readonly skippedSlots: readonly number[];
+  /** Points examined, which excludes any source the bounds test skipped. */
+  readonly examined: number;
+}
+
+const DEFAULT_CHUNK = 65536;
+
+/**
+ * Can any point in `bounds` fall inside the corridor?
+ *
+ * Chainage and lateral offset are affine in the point, so each attains its
+ * extremes over a box at a corner. Comparing those extremes against the
+ * corridor's own chainage and lateral limits rejects a box that cannot
+ * contribute, and never rejects one that can. Height is unconstrained, so it
+ * takes no part.
+ *
+ * This is a rejection test only. A box that passes may still hold no
+ * accepted point, which costs a scan and not a wrong answer.
+ */
+export function boundsMayIntersectCorridor(
+  frame: ProfileFrame,
+  band: number,
+  bounds: ProfileSourceBounds,
+): boolean {
+  const { min, max } = bounds;
+  for (let i = 0; i < 3; i++) {
+    if (!Number.isFinite(min[i]!) || !Number.isFinite(max[i]!)) return true;
+    if (min[i]! > max[i]!) return true;
+  }
+  let minChain = Infinity;
+  let maxChain = -Infinity;
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  const u = frame.up;
+  const aH = frame.horizontalAnchor;
+  const along = frame.along;
+  const lat = frame.lateral;
+  for (let c = 0; c < 8; c++) {
+    const px = (c & 1 ? max : min)[0]!;
+    const py = (c & 2 ? max : min)[1]!;
+    const pz = (c & 4 ? max : min)[2]!;
+    const h = px * u[0] + py * u[1] + pz * u[2];
+    const dx = px - u[0] * h - aH[0];
+    const dy = py - u[1] * h - aH[1];
+    const dz = pz - u[2] * h - aH[2];
+    const s = dx * along[0] + dy * along[1] + dz * along[2];
+    const d = dx * lat[0] + dy * lat[1] + dz * lat[2];
+    if (s < minChain) minChain = s;
+    if (s > maxChain) maxChain = s;
+    if (d < minLat) minLat = d;
+    if (d > maxLat) maxLat = d;
+  }
+  if (!Number.isFinite(minChain) || !Number.isFinite(minLat)) return true;
+  const L = frame.horizontalLength;
+  if (maxChain < -band) return false;
+  if (minChain > L + band) return false;
+  if (minLat > band) return false;
+  if (maxLat < -band) return false;
+  return true;
+}
+
+/**
+ * Walk the sources, yielding the count examined so far every `chunkSize`
+ * points, and return the accepted returns.
+ *
+ * Sources are read in the order supplied and each source in index order, so
+ * the result does not depend on when any source became available.
+ */
+export function* extractProfileSectionChunks(
+  opts: ExtractProfileSectionOptions,
+): Generator<number, ProfileSectionExtractResult, void> {
+  const { frame, band, sources } = opts;
+  const chunk = opts.chunkSize && opts.chunkSize > 0 ? opts.chunkSize : DEFAULT_CHUNK;
+  const bandSq = band * band;
+  const builder = new ProfileSectionBuilder();
+  const scratch = createProfileHitScratch();
+  const xyz = new Float64Array(3);
+  const skipped: number[] = [];
+  let examined = 0;
+  let sinceYield = 0;
+  let aborted = false;
+
+  for (const src of sources) {
+    if (opts.signal?.aborted) {
+      aborted = true;
+      break;
+    }
+    if (!opts.skipBoundsTest && src.bounds && !boundsMayIntersectCorridor(frame, band, src.bounds)) {
+      skipped.push(src.slot);
+      continue;
+    }
+    builder.beginSource(src.slot, src.channels, src.pointCount);
+    for (let i = 0; i < src.pointCount; i++) {
+      src.readProjectXYZ(i, xyz);
+      if (profileCorridorAccepts(frame, band, bandSq, xyz[0]!, xyz[1]!, xyz[2]!, scratch)) {
+        builder.push(
+          i,
+          scratch[PROFILE_HIT_CHAINAGE]!,
+          scratch[PROFILE_HIT_HEIGHT]!,
+          scratch[PROFILE_HIT_LATERAL]!,
+        );
+      }
+      examined++;
+      if (++sinceYield >= chunk) {
+        sinceYield = 0;
+        yield examined;
+        if (opts.signal?.aborted) {
+          aborted = true;
+          break;
+        }
+      }
+    }
+    if (aborted) break;
+  }
+
+  return { points: builder.finish(), aborted, skippedSlots: skipped, examined };
+}
+
+/** Run {@link extractProfileSectionChunks} to completion. */
+export function extractProfileSection(
+  opts: ExtractProfileSectionOptions,
+): ProfileSectionExtractResult {
+  const it = extractProfileSectionChunks(opts);
+  let step = it.next();
+  while (!step.done) step = it.next();
+  return step.value;
+}

--- a/tests/profileCorridor.test.ts
+++ b/tests/profileCorridor.test.ts
@@ -1,0 +1,235 @@
+/**
+ * profileCorridor.test.ts
+ *
+ * The section extractor and the derived sampler must accept exactly the same
+ * returns. These tests hold the two against each other on clouds built to
+ * land points on and beside the capsule boundary, under several `up` axes.
+ *
+ * Agreement is asserted per bin and exactly. A single point resolving to a
+ * different bin, or accepted by one side and not the other, fails.
+ */
+import { describe, it, expect } from 'vitest';
+import { sampleProfile, AUTO_CORRIDOR_FRACTION } from '../src/render/measure/profileSampler';
+import { buildProfileFrame } from '../src/render/measure/profileGeometry';
+import {
+  profileCorridorAccepts,
+  profileCorridorBin,
+  resolveCorridorHalfWidth,
+  createProfileHitScratch,
+  PROFILE_HIT_CHAINAGE,
+  PROFILE_HIT_LATERAL,
+  PROFILE_HIT_HEIGHT,
+} from '../src/render/measure/profileCorridor';
+import type { Vec3 } from '../src/render/navMath';
+
+/**
+ * Golden-ratio low-discrepancy sequence. Deterministic, and unlike a fixed
+ * stride it does not align with any structure in the generated cloud.
+ */
+function lowDiscrepancy(i: number): number {
+  return (i * 0.6180339887498949) % 1;
+}
+
+/** Per-bin accepted counts, computed through the shared corridor predicate. */
+function countsViaPredicate(
+  positions: Float32Array,
+  a: Vec3,
+  b: Vec3,
+  up: Vec3,
+  bandWidth: number | null,
+  samples: number,
+): number[] {
+  const frame = buildProfileFrame(a, b, up);
+  const band = resolveCorridorHalfWidth(frame.horizontalLength, bandWidth, AUTO_CORRIDOR_FRACTION);
+  const bandSq = band * band;
+  const scratch = createProfileHitScratch();
+  const counts: number[] = new Array<number>(samples).fill(0);
+  const n = positions.length / 3;
+  for (let i = 0; i < n; i++) {
+    const ok = profileCorridorAccepts(
+      frame,
+      band,
+      bandSq,
+      positions[i * 3],
+      positions[i * 3 + 1],
+      positions[i * 3 + 2],
+      scratch,
+    );
+    if (!ok) continue;
+    const bin = profileCorridorBin(
+      scratch[PROFILE_HIT_CHAINAGE],
+      frame.horizontalLength,
+      samples,
+    );
+    counts[bin]++;
+  }
+  return counts;
+}
+
+/** Per-bin accepted counts as reported by the derived sampler. */
+function countsViaSampler(
+  positions: Float32Array,
+  a: Vec3,
+  b: Vec3,
+  up: Vec3,
+  bandWidth: number | null,
+  samples: number,
+): number[] {
+  // `count` is optional on ProfileSample for pre-v0.4.5 series, and
+  // `sampleProfile` always emits it. Coercing a missing one to 0 would let
+  // this comparison agree with an extractor that found nothing, so a missing
+  // count is an error here rather than a default.
+  return sampleProfile({ positions, a, b, up, bandWidth, samples }).map((s) => {
+    if (s.count === undefined) throw new Error('sampleProfile omitted a bin count');
+    return s.count;
+  });
+}
+
+/**
+ * A cloud whose points cluster on the corridor boundary.
+ *
+ * Half the points are placed at a lateral offset drawn from a set that
+ * includes exactly `band`, one ulp inside and one ulp outside, so the
+ * inclusive-boundary rule is exercised rather than assumed. The rest scatter
+ * across and beyond both end caps, including the diagonal corner region that
+ * separates a capsule from a bounding rectangle.
+ */
+function boundaryCloud(
+  count: number,
+  band: number,
+  a: Vec3,
+  b: Vec3,
+  up: Vec3,
+): Float32Array {
+  const out = new Float32Array(count * 3);
+  const offsets = [
+    band,
+    band * (1 + 2 * Number.EPSILON),
+    band * (1 - 2 * Number.EPSILON),
+    band * 0.5,
+    band * 1.5,
+    0,
+  ];
+  // Generate in the section's own frame so the cloud is boundary-dense for
+  // this exact a/b/up rather than for a canonical one.
+  const frame = buildProfileFrame(a, b, up);
+  const length = frame.horizontalLength;
+  const along = frame.along;
+  const lat = frame.lateral;
+  const u = frame.up;
+  const anchor = frame.horizontalAnchor;
+  for (let i = 0; i < count; i++) {
+    // Chainage sweeps past both caps so the radial cap region is populated.
+    const s = lowDiscrepancy(i) * (length + 4 * band) - 2 * band;
+    const d = offsets[i % offsets.length] * (i % 2 === 0 ? 1 : -1);
+    const h = lowDiscrepancy(i * 7 + 3) * 20;
+    out[i * 3] = anchor[0] + along[0] * s + lat[0] * d + u[0] * h;
+    out[i * 3 + 1] = anchor[1] + along[1] * s + lat[1] * d + u[1] * h;
+    out[i * 3 + 2] = anchor[2] + along[2] * s + lat[2] * d + u[2] * h;
+  }
+  return out;
+}
+
+const CASES: { name: string; up: Vec3; a: Vec3; b: Vec3 }[] = [
+  { name: 'Z-up, axis aligned', up: [0, 0, 1], a: [0, 0, 0], b: [100, 0, 0] },
+  { name: 'Z-up, oblique section', up: [0, 0, 1], a: [-13, 7, 2], b: [61, 44, 9] },
+  { name: 'Y-up', up: [0, 1, 0], a: [0, 0, 0], b: [80, 5, 30] },
+  { name: 'X-up', up: [1, 0, 0], a: [3, -2, 0], b: [4, 55, 40] },
+  {
+    name: 'oblique up',
+    up: [0.3, 0.5, 0.8119], // normalised inside buildProfileFrame
+    a: [1, 2, 3],
+    b: [70, 40, 25],
+  },
+];
+
+describe('profile corridor predicate agrees with the derived sampler', () => {
+  for (const c of CASES) {
+    for (const samples of [32, 64, 512]) {
+      it(`${c.name}, ${samples} stations, explicit band`, () => {
+        const band = 2.5;
+        const cloud = boundaryCloud(4000, band, c.a, c.b, c.up);
+        const viaPredicate = countsViaPredicate(cloud, c.a, c.b, c.up, band, samples);
+        const viaSampler = countsViaSampler(cloud, c.a, c.b, c.up, band, samples);
+        expect(viaPredicate).toEqual(viaSampler);
+        // A vacuous pass would be two all-zero arrays; require real coverage.
+        const total = viaSampler.reduce((x, y) => x + y, 0);
+        expect(total).toBeGreaterThan(200);
+      });
+    }
+
+    it(`${c.name}, automatic corridor width`, () => {
+      const cloud = boundaryCloud(4000, 5, c.a, c.b, c.up);
+      const viaPredicate = countsViaPredicate(cloud, c.a, c.b, c.up, null, 64);
+      const viaSampler = countsViaSampler(cloud, c.a, c.b, c.up, null, 64);
+      expect(viaPredicate).toEqual(viaSampler);
+      expect(viaSampler.reduce((x, y) => x + y, 0)).toBeGreaterThan(200);
+    });
+  }
+});
+
+describe('profile corridor edge behaviour', () => {
+  const up: Vec3 = [0, 0, 1];
+  const a: Vec3 = [0, 0, 0];
+  const b: Vec3 = [10, 0, 0];
+  const frame = buildProfileFrame(a, b, up);
+  const band = 1;
+  const scratch = createProfileHitScratch();
+
+  const accepts = (x: number, y: number, z: number): boolean =>
+    profileCorridorAccepts(frame, band, band * band, x, y, z, scratch);
+
+  it('accepts a point exactly on the lateral boundary', () => {
+    expect(accepts(5, 1, 0)).toBe(true);
+  });
+
+  it('rejects a point outside the lateral boundary', () => {
+    expect(accepts(5, 1.0000001, 0)).toBe(false);
+  });
+
+  it('closes the ends with a cap rather than a square corner', () => {
+    // Diagonal corner: inside a bounding rectangle of half-width 1 extended
+    // to the endpoint, outside a capsule because its radial distance from the
+    // endpoint is sqrt(2) * 0.9 > 1.
+    expect(accepts(-0.9, 0.9, 0)).toBe(false);
+    // Same chainage, on the section axis: inside the cap.
+    expect(accepts(-0.9, 0, 0)).toBe(true);
+  });
+
+  it('rejects a point beyond the far cap', () => {
+    expect(accepts(11.0000001, 0, 0)).toBe(false);
+    expect(accepts(11, 0, 0)).toBe(true);
+  });
+
+  it('rejects non-finite coordinates', () => {
+    expect(accepts(Number.NaN, 0, 0)).toBe(false);
+    expect(accepts(5, Number.POSITIVE_INFINITY, 0)).toBe(false);
+  });
+
+  it('signs the lateral offset by side, and reports chainage along the line', () => {
+    // frame.lateral is up x along. For up = +Z and along = +X that is +Y, so
+    // a point at +Y sits on the positive side. A sign flip or a swap with
+    // chainage would mirror the section, which the counts alone cannot see.
+    expect(accepts(3, 0.5, 0)).toBe(true);
+    expect(scratch[PROFILE_HIT_LATERAL]).toBeCloseTo(0.5, 12);
+    expect(scratch[PROFILE_HIT_CHAINAGE]).toBeCloseTo(3, 12);
+
+    expect(accepts(3, -0.5, 0)).toBe(true);
+    expect(scratch[PROFILE_HIT_LATERAL]).toBeCloseTo(-0.5, 12);
+    expect(scratch[PROFILE_HIT_CHAINAGE]).toBeCloseTo(3, 12);
+
+    // Under a reversed section the same physical point takes the other side.
+    const rev = buildProfileFrame(b, a, up);
+    expect(profileCorridorAccepts(rev, band, band * band, 3, 0.5, 0, scratch)).toBe(true);
+    expect(scratch[PROFILE_HIT_LATERAL]).toBeCloseTo(-0.5, 12);
+    expect(scratch[PROFILE_HIT_CHAINAGE]).toBeCloseTo(7, 12);
+  });
+
+  it('reports height along up, not z, under a Y-up frame', () => {
+    const yUp: Vec3 = [0, 1, 0];
+    const yFrame = buildProfileFrame([0, 0, 0], [10, 0, 0], yUp);
+    const ok = profileCorridorAccepts(yFrame, 1, 1, 5, 42, 0.5, scratch);
+    expect(ok).toBe(true);
+    expect(scratch[PROFILE_HIT_HEIGHT]).toBeCloseTo(42, 12);
+  });
+});

--- a/tests/profileSectionBuilder.test.ts
+++ b/tests/profileSectionBuilder.test.ts
@@ -1,0 +1,211 @@
+/**
+ * profileSectionBuilder.test.ts
+ *
+ * Attribute integrity for the section builder.
+ *
+ * Every channel value is a distinct function of (slot, sourceIndex), so a
+ * value read one index off, or read from the wrong source, produces a number
+ * that cannot occur at that position. Checking a constant fill would not
+ * separate those failures from a correct read.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ProfileSectionBuilder,
+  profileSectionHas,
+  PROFILE_ATTRIBUTE_BIT,
+  type ProfileSourceChannels,
+} from '../src/render/measure/profileSectionBuilder';
+
+/** Channel values keyed so a one-index shift changes every one of them. */
+const intensityAt = (slot: number, i: number): number => 1000 * (slot + 1) + i * 7;
+const classAt = (slot: number, i: number): number => (slot * 31 + i * 13) % 256;
+const rgbAt = (slot: number, i: number, c: number): number => (slot * 17 + i * 5 + c * 61) % 256;
+const gpsAt = (slot: number, i: number): number => slot * 1e6 + i * 0.001;
+const retNumAt = (slot: number, i: number): number => ((i + slot * 2) % 5) + 1;
+const retCntAt = (slot: number, i: number): number => ((i + slot) % 4) + 1;
+const psidAt = (slot: number, i: number): number => 7000 + slot * 100 + (i % 90);
+const normAt = (slot: number, i: number, c: number): number => slot + i * 0.25 + c * 0.125;
+
+function channelsFor(slot: number, n: number, which: Set<string>): ProfileSourceChannels {
+  const out: Record<string, unknown> = {};
+  if (which.has('rgb')) {
+    const a = new Uint8Array(n * 3);
+    for (let i = 0; i < n; i++) for (let c = 0; c < 3; c++) a[i * 3 + c] = rgbAt(slot, i, c);
+    out.rgb = a;
+  }
+  if (which.has('intensity')) {
+    const a = new Uint16Array(n);
+    for (let i = 0; i < n; i++) a[i] = intensityAt(slot, i);
+    out.intensity = a;
+  }
+  if (which.has('classification')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = classAt(slot, i);
+    out.classification = a;
+  }
+  if (which.has('returnNumber')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = retNumAt(slot, i);
+    out.returnNumber = a;
+  }
+  if (which.has('returnCount')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = retCntAt(slot, i);
+    out.returnCount = a;
+  }
+  if (which.has('pointSourceId')) {
+    const a = new Uint16Array(n);
+    for (let i = 0; i < n; i++) a[i] = psidAt(slot, i);
+    out.pointSourceId = a;
+  }
+  if (which.has('gpsTime')) {
+    const a = new Float64Array(n);
+    for (let i = 0; i < n; i++) a[i] = gpsAt(slot, i);
+    out.gpsTime = a;
+  }
+  if (which.has('normals')) {
+    const a = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) for (let c = 0; c < 3; c++) a[i * 3 + c] = normAt(slot, i, c);
+    out.normals = a;
+  }
+  return out as ProfileSourceChannels;
+}
+
+describe('section builder keeps every attribute on its own point', () => {
+  it('carries a full channel set through unshifted, past a growth boundary', () => {
+    // Accepting every third of 9000 gives 3000 returns, which crosses the
+    // 1024 doubling threshold and then 2048, so the reallocation path runs
+    // rather than only the initial buffer.
+    const n = 9000;
+    const all = new Set([
+      'rgb',
+      'intensity',
+      'classification',
+      'returnNumber',
+      'returnCount',
+      'pointSourceId',
+      'gpsTime',
+      'normals',
+    ]);
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, channelsFor(0, n, all), n);
+    // Accept every third point so source index and section index differ, which
+    // a test accepting all points cannot distinguish from a correct read.
+    const accepted: number[] = [];
+    for (let i = 0; i < n; i += 3) {
+      b.push(i, i * 0.5, i * 0.25, i % 7 === 0 ? 1.5 : -1.5);
+      accepted.push(i);
+    }
+    const p = b.finish();
+    expect(p.count).toBe(accepted.length);
+    expect(p.count).toBeGreaterThan(1024);
+
+    for (let k = 0; k < p.count; k++) {
+      const src = accepted[k]!;
+      expect(p.pointIndex[k]).toBe(src);
+      expect(p.sourceSlot[k]).toBe(0);
+      expect(p.chainage[k]).toBeCloseTo(src * 0.5, 4);
+      expect(p.height[k]).toBeCloseTo(src * 0.25, 4);
+      expect(p.intensity![k]).toBe(intensityAt(0, src));
+      expect(p.classification![k]).toBe(classAt(0, src));
+      expect(p.returnNumber![k]).toBe(retNumAt(0, src));
+      expect(p.returnCount![k]).toBe(retCntAt(0, src));
+      expect(p.pointSourceId![k]).toBe(psidAt(0, src));
+      expect(p.gpsTime![k]).toBeCloseTo(gpsAt(0, src), 9);
+      for (let c = 0; c < 3; c++) {
+        expect(p.rgb![k * 3 + c]).toBe(rgbAt(0, src, c));
+        expect(p.normals![k * 3 + c]).toBeCloseTo(normAt(0, src, c), 5);
+      }
+    }
+  });
+
+  it('keeps mixed sources apart and marks absence per point', () => {
+    // A carries RGB and classification; B carries intensity and GPS time;
+    // C carries nothing. Interleaved so a per-snapshot presence flag would
+    // be wrong for two of the three.
+    const nA = 40;
+    const nB = 40;
+    const nC = 40;
+    const b = new ProfileSectionBuilder();
+
+    b.beginSource(0, channelsFor(0, nA, new Set(['rgb', 'classification'])), nA);
+    for (let i = 0; i < nA; i++) b.push(i, i, i, 0);
+    b.beginSource(1, channelsFor(1, nB, new Set(['intensity', 'gpsTime'])), nB);
+    for (let i = 0; i < nB; i++) b.push(i, i, i, 0);
+    b.beginSource(2, null, nC);
+    for (let i = 0; i < nC; i++) b.push(i, i, i, 0);
+
+    const p = b.finish();
+    expect(p.count).toBe(nA + nB + nC);
+
+    for (let k = 0; k < p.count; k++) {
+      const slot = p.sourceSlot[k]!;
+      const src = p.pointIndex[k]!;
+      if (slot === 0) {
+        expect(profileSectionHas(p, k, 'rgb')).toBe(true);
+        expect(profileSectionHas(p, k, 'classification')).toBe(true);
+        expect(profileSectionHas(p, k, 'intensity')).toBe(false);
+        expect(profileSectionHas(p, k, 'gpsTime')).toBe(false);
+        expect(p.classification![k]).toBe(classAt(0, src));
+        expect(p.rgb![k * 3]).toBe(rgbAt(0, src, 0));
+      } else if (slot === 1) {
+        expect(profileSectionHas(p, k, 'intensity')).toBe(true);
+        expect(profileSectionHas(p, k, 'gpsTime')).toBe(true);
+        expect(profileSectionHas(p, k, 'rgb')).toBe(false);
+        expect(profileSectionHas(p, k, 'classification')).toBe(false);
+        expect(p.intensity![k]).toBe(intensityAt(1, src));
+        expect(p.gpsTime![k]).toBeCloseTo(gpsAt(1, src), 9);
+      } else {
+        expect(p.channelPresence[k]).toBe(0);
+      }
+    }
+  });
+
+  it('omits a channel no source carried rather than emitting zeros', () => {
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, channelsFor(0, 10, new Set(['intensity'])), 10);
+    for (let i = 0; i < 10; i++) b.push(i, i, i, 0);
+    const p = b.finish();
+    expect(p.intensity).toBeDefined();
+    expect(p.rgb).toBeUndefined();
+    expect(p.gpsTime).toBeUndefined();
+    expect(p.classification).toBeUndefined();
+    expect(p.normals).toBeUndefined();
+  });
+
+  it('drops a misaligned channel for that source instead of shifting it', () => {
+    // A classification array one element short cannot be index-aligned. The
+    // sampler applies the same rule to its own classification input.
+    const n = 20;
+    const good = channelsFor(0, n, new Set(['classification', 'intensity']));
+    const bad: ProfileSourceChannels = {
+      classification: good.classification!.slice(0, n - 1),
+      intensity: good.intensity,
+    };
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, bad, n);
+    for (let i = 0; i < n; i++) b.push(i, i, i, 0);
+    const p = b.finish();
+
+    expect(p.classification).toBeUndefined();
+    for (let k = 0; k < p.count; k++) {
+      expect(profileSectionHas(p, k, 'classification')).toBe(false);
+      expect(profileSectionHas(p, k, 'intensity')).toBe(true);
+      expect(p.intensity![k]).toBe(intensityAt(0, k));
+    }
+  });
+
+  it('assigns one bit per attribute', () => {
+    const bits = Object.values(PROFILE_ATTRIBUTE_BIT);
+    expect(new Set(bits).size).toBe(bits.length);
+    for (const v of bits) expect(v & (v - 1)).toBe(0);
+    expect(bits.reduce((a, c) => a | c, 0)).toBe(0xff);
+  });
+
+  it('reports an empty section without allocating channels', () => {
+    const p = new ProfileSectionBuilder().finish();
+    expect(p.count).toBe(0);
+    expect(p.chainage.length).toBe(0);
+    expect(p.rgb).toBeUndefined();
+  });
+});

--- a/tests/profileSectionExtract.test.ts
+++ b/tests/profileSectionExtract.test.ts
@@ -1,0 +1,255 @@
+/**
+ * profileSectionExtract.test.ts
+ *
+ * The scan must find exactly the returns the corridor accepts, keep each one
+ * attached to its own source, and stay independent of the order sources
+ * became available.
+ *
+ * The bounds pre-test is the part that can lose data silently: a box wrongly
+ * rejected drops every return in it and reports success. It is checked
+ * differentially against the same scan with the test disabled, over boxes
+ * placed on and across the corridor limits.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildProfileFrame } from '../src/render/measure/profileGeometry';
+import {
+  extractProfileSection,
+  extractProfileSectionChunks,
+  boundsMayIntersectCorridor,
+  type ProfileSectionSourceView,
+  type ProfileSourceBounds,
+} from '../src/render/measure/profileSectionExtract';
+import { profileSectionHas } from '../src/render/measure/profileSectionBuilder';
+import type { Vec3 } from '../src/render/navMath';
+
+const golden = (i: number): number => (i * 0.6180339887498949) % 1;
+
+/** A source backed by explicit float64 coordinates. */
+function makeSource(
+  slot: number,
+  coords: number[],
+  opts: { bounds?: ProfileSourceBounds | null; intensity?: boolean } = {},
+): ProfileSectionSourceView {
+  const n = coords.length / 3;
+  const intensity = opts.intensity ? new Uint16Array(n) : undefined;
+  if (intensity) for (let i = 0; i < n; i++) intensity[i] = 100 * (slot + 1) + i;
+  let bounds: ProfileSourceBounds | null | undefined = opts.bounds;
+  if (bounds === undefined) {
+    const mn: [number, number, number] = [Infinity, Infinity, Infinity];
+    const mx: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+    for (let i = 0; i < n; i++)
+      for (let c = 0; c < 3; c++) {
+        const v = coords[i * 3 + c]!;
+        if (v < mn[c]!) mn[c] = v;
+        if (v > mx[c]!) mx[c] = v;
+      }
+    bounds = { min: mn, max: mx };
+  }
+  return {
+    slot,
+    pointCount: n,
+    channels: intensity ? { intensity } : null,
+    bounds,
+    readProjectXYZ(index, out) {
+      out[0] = coords[index * 3]!;
+      out[1] = coords[index * 3 + 1]!;
+      out[2] = coords[index * 3 + 2]!;
+    },
+  };
+}
+
+/** Points spread over and well beyond a section, deterministically. */
+function spread(n: number, cx: number, cy: number, cz: number, r: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push(cx + (golden(i) - 0.5) * r);
+    out.push(cy + (golden(i * 3 + 1) - 0.5) * r);
+    out.push(cz + (golden(i * 7 + 2) - 0.5) * r);
+  }
+  return out;
+}
+
+const UP: Vec3 = [0, 0, 1];
+const A: Vec3 = [0, 0, 0];
+const B: Vec3 = [50, 0, 0];
+const FRAME = buildProfileFrame(A, B, UP);
+const BAND = 3;
+
+describe('the bounds pre-test never drops an accepted return', () => {
+  // Boxes straddling every corridor limit: before the start cap, past the end
+  // cap, either side of the lateral band, on the axis, and far away.
+  const centres: [number, number, number][] = [
+    [25, 0, 0],
+    [-6, 0, 0],
+    [56, 0, 0],
+    [25, 3, 0],
+    [25, -3, 0],
+    [25, 20, 0],
+    [-40, -40, 10],
+    [0, 0, 500],
+    [50, 3, -200],
+  ];
+
+  for (const [cx, cy, cz] of centres) {
+    for (const r of [1, 8, 40]) {
+      it(`box at (${cx}, ${cy}, ${cz}) radius ${r}`, () => {
+        const coords = spread(400, cx, cy, cz, r);
+        const src = makeSource(0, coords);
+        const withTest = extractProfileSection({
+          frame: FRAME,
+          band: BAND,
+          sources: [src],
+        });
+        const withoutTest = extractProfileSection({
+          frame: FRAME,
+          band: BAND,
+          sources: [src],
+          skipBoundsTest: true,
+        });
+        expect(withTest.points.count).toBe(withoutTest.points.count);
+        expect(Array.from(withTest.points.pointIndex)).toEqual(
+          Array.from(withoutTest.points.pointIndex),
+        );
+        // A skip is only legitimate when the unrestricted scan found nothing.
+        if (withTest.skippedSlots.length > 0) {
+          expect(withoutTest.points.count).toBe(0);
+        }
+      });
+    }
+  }
+
+  it('skips a box that genuinely cannot contribute', () => {
+    const far = makeSource(0, spread(200, 400, 400, 0, 5));
+    const r = extractProfileSection({ frame: FRAME, band: BAND, sources: [far] });
+    expect(r.skippedSlots).toEqual([0]);
+    expect(r.examined).toBe(0);
+    expect(r.points.count).toBe(0);
+  });
+
+  it('scans a source whose bounds are unknown', () => {
+    const src = makeSource(0, spread(200, 25, 0, 0, 4), { bounds: null });
+    const r = extractProfileSection({ frame: FRAME, band: BAND, sources: [src] });
+    expect(r.skippedSlots).toEqual([]);
+    expect(r.examined).toBe(200);
+    expect(r.points.count).toBeGreaterThan(0);
+  });
+
+  it('scans rather than rejects when a bound is not finite', () => {
+    const bad: ProfileSourceBounds = { min: [Number.NaN, 0, 0], max: [1, 1, 1] };
+    expect(boundsMayIntersectCorridor(FRAME, BAND, bad)).toBe(true);
+    const inverted: ProfileSourceBounds = { min: [10, 0, 0], max: [-10, 1, 1] };
+    expect(boundsMayIntersectCorridor(FRAME, BAND, inverted)).toBe(true);
+  });
+});
+
+describe('the scan keeps sources apart and stays deterministic', () => {
+  const s0 = makeSource(0, spread(300, 12, 0, 0, 4), { intensity: true });
+  const s1 = makeSource(1, spread(300, 38, 0, 0, 4), { intensity: true });
+  const s2 = makeSource(2, spread(300, 400, 0, 0, 4));
+
+  it('records the slot and index each return came from', () => {
+    const r = extractProfileSection({ frame: FRAME, band: BAND, sources: [s0, s1, s2] });
+    expect(r.points.count).toBeGreaterThan(0);
+    expect(r.skippedSlots).toEqual([2]);
+    for (let k = 0; k < r.points.count; k++) {
+      const slot = r.points.sourceSlot[k]!;
+      expect(slot === 0 || slot === 1).toBe(true);
+      expect(profileSectionHas(r.points, k, 'intensity')).toBe(true);
+      expect(r.points.intensity![k]).toBe(100 * (slot + 1) + r.points.pointIndex[k]!);
+    }
+  });
+
+  it('gives the same result whatever order the sources arrived in', () => {
+    // Sorting by slot is the caller's job; the scan must be a pure function
+    // of the sequence it is handed, which is what makes that sort sufficient.
+    const forward = extractProfileSection({ frame: FRAME, band: BAND, sources: [s0, s1] });
+    const again = extractProfileSection({ frame: FRAME, band: BAND, sources: [s0, s1] });
+    expect(Array.from(again.points.chainage)).toEqual(Array.from(forward.points.chainage));
+    expect(Array.from(again.points.sourceSlot)).toEqual(Array.from(forward.points.sourceSlot));
+
+    const reversed = extractProfileSection({ frame: FRAME, band: BAND, sources: [s1, s0] });
+    expect(reversed.points.count).toBe(forward.points.count);
+    const key = (
+      p: { sourceSlot: Uint16Array; pointIndex: Uint32Array },
+      i: number,
+    ): string => `${p.sourceSlot[i]}:${p.pointIndex[i]}`;
+    const setA = new Set<string>();
+    const setB = new Set<string>();
+    for (let i = 0; i < forward.points.count; i++) setA.add(key(forward.points, i));
+    for (let i = 0; i < reversed.points.count; i++) setB.add(key(reversed.points, i));
+    expect(setB).toEqual(setA);
+  });
+
+  it('does not modify a source buffer', () => {
+    const coords = spread(200, 25, 0, 0, 4);
+    const copy = coords.slice();
+    extractProfileSection({ frame: FRAME, band: BAND, sources: [makeSource(0, coords)] });
+    expect(coords).toEqual(copy);
+  });
+});
+
+describe('the scan yields and can be abandoned', () => {
+  const big = makeSource(0, spread(5000, 25, 0, 0, 6));
+
+  it('yields on the requested cadence', () => {
+    const it2 = extractProfileSectionChunks({
+      frame: FRAME,
+      band: BAND,
+      sources: [big],
+      chunkSize: 1000,
+    });
+    const marks: number[] = [];
+    let step = it2.next();
+    while (!step.done) {
+      marks.push(step.value);
+      step = it2.next();
+    }
+    expect(marks).toEqual([1000, 2000, 3000, 4000, 5000]);
+    expect(step.value.aborted).toBe(false);
+    expect(step.value.examined).toBe(5000);
+  });
+
+  it('reports an abort rather than returning a short result as complete', () => {
+    const signal = { aborted: false };
+    const it2 = extractProfileSectionChunks({
+      frame: FRAME,
+      band: BAND,
+      sources: [big],
+      chunkSize: 1000,
+      signal,
+    });
+    it2.next();
+    (signal as { aborted: boolean }).aborted = true;
+    let step = it2.next();
+    while (!step.done) step = it2.next();
+    expect(step.value.aborted).toBe(true);
+    expect(step.value.examined).toBeLessThan(5000);
+  });
+});
+
+describe('placement precision survives the scan', () => {
+  it('keeps a far-from-origin layer to float64 height resolution', () => {
+    // A mounted layer 2 km out, with structure below the float32 spacing at
+    // that magnitude, is the case the float64 height field exists for.
+    const base = 2_000_000;
+    const coords: number[] = [];
+    const heights: number[] = [];
+    for (let i = 0; i < 64; i++) {
+      const h = base + i * 0.001;
+      coords.push(25, 0, h);
+      heights.push(h);
+    }
+    const r = extractProfileSection({
+      frame: FRAME,
+      band: BAND,
+      sources: [makeSource(0, coords, { bounds: null })],
+    });
+    expect(r.points.count).toBe(64);
+    for (let k = 0; k < 64; k++) {
+      expect(r.points.height[k]).toBe(heights[k]);
+    }
+    // The same values through float32 collapse to far fewer distinct heights.
+    const f32 = new Float32Array(heights);
+    expect(new Set(Array.from(f32)).size).toBeLessThan(64);
+  });
+});


### PR DESCRIPTION
Stacked on #503 and #506, which it merges.

The derived sampler reads a concatenated copy of every loaded position. A section keeps only the fraction inside a corridor, so this walks each source in place through a caller-supplied reader and copies nothing. A source whose bounding box cannot reach the corridor is skipped; absent, inverted or non-finite bounds cause a scan rather than a rejection, checked against the same scan with the pre-test disabled over 27 boxes.

The scan is a generator and reports an abort rather than a short result.

Source eligibility and the streaming snapshot are not here.
