### PR TITLE
Add the section viewport transform and true vertical exaggeration

### DIFF
--- a/src/render/measure/profileViewTransform.ts
+++ b/src/render/measure/profileViewTransform.ts
@@ -1,0 +1,268 @@
+/**
+ * profileViewTransform.ts
+ *
+ * The viewport transform for a 2D profile cross-section: data space
+ * (chainage, height) to screen space and back, fit, pan, zoom about a
+ * cursor, and vertical exaggeration.
+ *
+ * Pure. No DOM, no canvas, no renderer. Everything here is a value.
+ *
+ * Vertical exaggeration is a ratio between two physical scales, so it can
+ * only be stated when both axes can be expressed in the same physical unit.
+ * A profile's horizontal and vertical units can differ, and either can be
+ * unknown. When one is unknown the view still works, and the ratio is
+ * reported as null rather than as 1.
+ */
+
+/** Metres per data unit on each axis. Null where the scale is unknown. */
+export interface ProfileUnitContext {
+  readonly horizontalToMetres: number | null;
+  readonly verticalToMetres: number | null;
+}
+
+/** The drawable area, in CSS pixels, and the backing store ratio. */
+export interface ProfileViewport {
+  readonly width: number;
+  readonly height: number;
+  readonly devicePixelRatio: number;
+}
+
+/** Data-space extent to be shown. */
+export interface ProfileDataBounds {
+  readonly minChainage: number;
+  readonly maxChainage: number;
+  readonly minHeight: number;
+  readonly maxHeight: number;
+}
+
+/**
+ * `fit` scales each axis independently to the viewport and claims no ratio.
+ * `ve` holds a true vertical exaggeration and requires both unit scales.
+ */
+export type ProfileScaleMode =
+  | { readonly kind: 'fit' }
+  | { readonly kind: 've'; readonly ratio: number };
+
+/** A resolved view: what sits at the centre, and the scale of each axis. */
+export interface ProfileView {
+  readonly centreChainage: number;
+  readonly centreHeight: number;
+  /** CSS pixels per chainage unit. Always > 0. */
+  readonly pxPerChainage: number;
+  /** CSS pixels per height unit. Always > 0. */
+  readonly pxPerHeight: number;
+}
+
+/**
+ * The smallest span a degenerate axis is given.
+ *
+ * A section whose returns share one height has a zero height span, and
+ * dividing the viewport by it yields infinity. One unit of span puts such a
+ * section on a readable axis instead of an empty one.
+ */
+export const MIN_DATA_SPAN = 1e-6;
+
+/** Scale change per zoom step. */
+export const ZOOM_STEP = 1.2;
+
+const MIN_PX_PER_UNIT = 1e-12;
+const MAX_PX_PER_UNIT = 1e12;
+
+function finite(v: number): boolean {
+  return Number.isFinite(v);
+}
+
+function clampScale(v: number): number {
+  if (!finite(v) || v <= 0) return MIN_PX_PER_UNIT;
+  return Math.min(MAX_PX_PER_UNIT, Math.max(MIN_PX_PER_UNIT, v));
+}
+
+function spanOf(min: number, max: number): number {
+  const s = max - min;
+  if (!finite(s) || s <= MIN_DATA_SPAN) return MIN_DATA_SPAN;
+  return s;
+}
+
+/** True when a true vertical exaggeration can be stated for these units. */
+export function canStateExaggeration(units: ProfileUnitContext): boolean {
+  const h = units.horizontalToMetres;
+  const v = units.verticalToMetres;
+  return h != null && v != null && finite(h) && finite(v) && h > 0 && v > 0;
+}
+
+/**
+ * The view's vertical exaggeration, or null when it cannot be stated.
+ *
+ * Pixels per metre on each axis is the axis scale divided by the metres in
+ * one of its data units. The exaggeration is the vertical figure over the
+ * horizontal one.
+ */
+export function viewExaggeration(
+  view: ProfileView,
+  units: ProfileUnitContext,
+): number | null {
+  if (!canStateExaggeration(units)) return null;
+  const h = units.horizontalToMetres!;
+  const v = units.verticalToMetres!;
+  const pxPerMetreX = view.pxPerChainage / h;
+  const pxPerMetreY = view.pxPerHeight / v;
+  if (!finite(pxPerMetreX) || pxPerMetreX <= 0) return null;
+  const ratio = pxPerMetreY / pxPerMetreX;
+  return finite(ratio) ? ratio : null;
+}
+
+/**
+ * Fit `bounds` into `viewport`.
+ *
+ * Under `fit` each axis takes the viewport independently. Under `ve` both
+ * axes take one base scale chosen so the whole extent still fits, so holding
+ * a ratio never crops an extreme.
+ *
+ * Returns null when the mode asks for an exaggeration the units cannot
+ * support, so a caller must handle that rather than receive a view whose
+ * ratio is a fiction.
+ */
+export function fitProfileView(
+  bounds: ProfileDataBounds,
+  viewport: ProfileViewport,
+  mode: ProfileScaleMode,
+  units: ProfileUnitContext,
+): ProfileView | null {
+  const w = finite(viewport.width) && viewport.width > 0 ? viewport.width : 1;
+  const hgt = finite(viewport.height) && viewport.height > 0 ? viewport.height : 1;
+
+  const minC = finite(bounds.minChainage) ? bounds.minChainage : 0;
+  const maxC = finite(bounds.maxChainage) ? bounds.maxChainage : 0;
+  const minH = finite(bounds.minHeight) ? bounds.minHeight : 0;
+  const maxH = finite(bounds.maxHeight) ? bounds.maxHeight : 0;
+
+  const spanC = spanOf(minC, maxC);
+  const spanH = spanOf(minH, maxH);
+  const centreChainage = (minC + maxC) / 2;
+  const centreHeight = (minH + maxH) / 2;
+
+  if (mode.kind === 'fit') {
+    return {
+      centreChainage,
+      centreHeight,
+      pxPerChainage: clampScale(w / spanC),
+      pxPerHeight: clampScale(hgt / spanH),
+    };
+  }
+
+  if (!canStateExaggeration(units)) return null;
+  const ratio = mode.ratio;
+  if (!finite(ratio) || ratio <= 0) return null;
+  const mPerC = units.horizontalToMetres!;
+  const mPerH = units.verticalToMetres!;
+
+  // pxPerHeight = ratio * pxPerChainage * mPerH / mPerC, so a vertical fit
+  // implies a horizontal scale. Taking the smaller of that and the
+  // horizontal fit keeps both extents inside the viewport.
+  const fromWidth = w / spanC;
+  const fromHeight = ((hgt / spanH) * mPerC) / (ratio * mPerH);
+  const pxPerChainage = clampScale(Math.min(fromWidth, fromHeight));
+  const pxPerHeight = clampScale((ratio * pxPerChainage * mPerH) / mPerC);
+  return { centreChainage, centreHeight, pxPerChainage, pxPerHeight };
+}
+
+/**
+ * Data to screen, in CSS pixels from the top left of the drawable area.
+ *
+ * Height increases upward on screen, so the vertical term is negated.
+ */
+export function profileDataToScreen(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  chainage: number,
+  height: number,
+  out: Float64Array,
+): void {
+  out[0] = viewport.width / 2 + (chainage - view.centreChainage) * view.pxPerChainage;
+  out[1] = viewport.height / 2 - (height - view.centreHeight) * view.pxPerHeight;
+}
+
+/** Screen to data. The inverse of {@link profileDataToScreen}. */
+export function profileScreenToData(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  sx: number,
+  sy: number,
+  out: Float64Array,
+): void {
+  out[0] = view.centreChainage + (sx - viewport.width / 2) / view.pxPerChainage;
+  out[1] = view.centreHeight - (sy - viewport.height / 2) / view.pxPerHeight;
+}
+
+/** Move the view by a screen-space delta. */
+export function panProfileView(
+  view: ProfileView,
+  dxPx: number,
+  dyPx: number,
+): ProfileView {
+  const dx = finite(dxPx) ? dxPx : 0;
+  const dy = finite(dyPx) ? dyPx : 0;
+  return {
+    ...view,
+    centreChainage: view.centreChainage - dx / view.pxPerChainage,
+    centreHeight: view.centreHeight + dy / view.pxPerHeight,
+  };
+}
+
+/**
+ * Zoom about a screen anchor, keeping the data under that anchor fixed.
+ *
+ * Under `fit` both axes scale together, which preserves the aspect the fit
+ * produced. Under `ve` both axes scale together as well, which is what keeps
+ * the exaggeration constant through a zoom.
+ */
+export function zoomProfileViewAt(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  anchorX: number,
+  anchorY: number,
+  factor: number,
+): ProfileView {
+  if (!finite(factor) || factor <= 0) return view;
+  const ax = finite(anchorX) ? anchorX : viewport.width / 2;
+  const ay = finite(anchorY) ? anchorY : viewport.height / 2;
+
+  const before = new Float64Array(2);
+  profileScreenToData(view, viewport, ax, ay, before);
+  const next: ProfileView = {
+    ...view,
+    pxPerChainage: clampScale(view.pxPerChainage * factor),
+    pxPerHeight: clampScale(view.pxPerHeight * factor),
+  };
+  const after = new Float64Array(2);
+  profileScreenToData(next, viewport, ax, ay, after);
+  return {
+    ...next,
+    centreChainage: next.centreChainage + (before[0]! - after[0]!),
+    centreHeight: next.centreHeight + (before[1]! - after[1]!),
+  };
+}
+
+/** Scale a CSS-pixel measure to the canvas backing store. */
+export function toDevicePixels(viewport: ProfileViewport, cssPx: number): number {
+  const dpr =
+    finite(viewport.devicePixelRatio) && viewport.devicePixelRatio > 0
+      ? viewport.devicePixelRatio
+      : 1;
+  return cssPx * dpr;
+}
+
+/** The data-space rectangle the viewport currently shows. */
+export function profileVisibleBounds(
+  view: ProfileView,
+  viewport: ProfileViewport,
+): ProfileDataBounds {
+  const halfC = viewport.width / 2 / view.pxPerChainage;
+  const halfH = viewport.height / 2 / view.pxPerHeight;
+  return {
+    minChainage: view.centreChainage - halfC,
+    maxChainage: view.centreChainage + halfC,
+    minHeight: view.centreHeight - halfH,
+    maxHeight: view.centreHeight + halfH,
+  };
+}

--- a/tests/profileViewTransform.test.ts
+++ b/tests/profileViewTransform.test.ts
@@ -1,0 +1,299 @@
+/**
+ * profileViewTransform.test.ts
+ *
+ * The section viewport transform, its inverse, and vertical exaggeration.
+ *
+ * Exaggeration is asserted in physical terms: the pixels a metre occupies
+ * vertically over the pixels a metre occupies horizontally. Asserting the
+ * ratio of the two axis scales instead would pass even when the axes are in
+ * different units, which is the case the ratio exists to get right.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  fitProfileView,
+  profileDataToScreen,
+  profileScreenToData,
+  panProfileView,
+  zoomProfileViewAt,
+  viewExaggeration,
+  canStateExaggeration,
+  profileVisibleBounds,
+  toDevicePixels,
+  MIN_DATA_SPAN,
+  type ProfileViewport,
+  type ProfileDataBounds,
+  type ProfileUnitContext,
+  type ProfileView,
+} from '../src/render/measure/profileViewTransform';
+
+const VP: ProfileViewport = { width: 800, height: 300, devicePixelRatio: 2 };
+const BOUNDS: ProfileDataBounds = {
+  minChainage: 0,
+  maxChainage: 200,
+  minHeight: 120,
+  maxHeight: 150,
+};
+const METRES: ProfileUnitContext = { horizontalToMetres: 1, verticalToMetres: 1 };
+const FEET_H: ProfileUnitContext = { horizontalToMetres: 0.3048, verticalToMetres: 1 };
+const UNKNOWN_V: ProfileUnitContext = { horizontalToMetres: 1, verticalToMetres: null };
+
+const s = new Float64Array(2);
+const d = new Float64Array(2);
+
+/** Pixels a physical metre occupies on each axis. */
+function pxPerMetre(view: ProfileView, u: ProfileUnitContext): [number, number] {
+  return [view.pxPerChainage / u.horizontalToMetres!, view.pxPerHeight / u.verticalToMetres!];
+}
+
+describe('fit', () => {
+  it('puts the data extent in the viewport and centres it', () => {
+    const v = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    expect(v.centreChainage).toBe(100);
+    expect(v.centreHeight).toBe(135);
+    profileDataToScreen(v, VP, 0, 150, s);
+    expect(s[0]).toBeCloseTo(0, 9);
+    expect(s[1]).toBeCloseTo(0, 9);
+    profileDataToScreen(v, VP, 200, 120, s);
+    expect(s[0]).toBeCloseTo(800, 9);
+    expect(s[1]).toBeCloseTo(300, 9);
+  });
+
+  it('scales the axes independently and claims no ratio', () => {
+    const v = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    expect(v.pxPerChainage).toBeCloseTo(4, 9);
+    expect(v.pxPerHeight).toBeCloseTo(10, 9);
+  });
+});
+
+describe('round trip', () => {
+  const v = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+  it('returns the same data point through screen space', () => {
+    for (let i = 0; i < 500; i++) {
+      const g = (i * 0.6180339887498949) % 1;
+      const c = BOUNDS.minChainage + g * 200;
+      const h = BOUNDS.minHeight + ((i * 7 * 0.6180339887498949) % 1) * 30;
+      profileDataToScreen(v, VP, c, h, s);
+      profileScreenToData(v, VP, s[0]!, s[1]!, d);
+      expect(d[0]).toBeCloseTo(c, 9);
+      expect(d[1]).toBeCloseTo(h, 9);
+    }
+  });
+
+  it('maps height upward on screen', () => {
+    profileDataToScreen(v, VP, 100, 140, s);
+    const high = s[1]!;
+    profileDataToScreen(v, VP, 100, 130, s);
+    expect(s[1]!).toBeGreaterThan(high);
+  });
+});
+
+describe('pan and zoom', () => {
+  const base = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+
+  it('pans by exactly the screen delta', () => {
+    const p = panProfileView(base, 40, -25);
+    profileDataToScreen(base, VP, 100, 135, s);
+    const before = [s[0]!, s[1]!];
+    profileDataToScreen(p, VP, 100, 135, s);
+    expect(s[0]! - before[0]!).toBeCloseTo(40, 9);
+    expect(s[1]! - before[1]!).toBeCloseTo(-25, 9);
+  });
+
+  it('holds the data under the cursor fixed while zooming', () => {
+    for (const [ax, ay] of [
+      [0, 0],
+      [800, 300],
+      [137, 42],
+      [400, 150],
+    ]) {
+      profileScreenToData(base, VP, ax!, ay!, d);
+      const anchored = [d[0]!, d[1]!];
+      let v = base;
+      for (let i = 0; i < 6; i++) v = zoomProfileViewAt(v, VP, ax!, ay!, 1.2);
+      profileScreenToData(v, VP, ax!, ay!, d);
+      expect(d[0]).toBeCloseTo(anchored[0]!, 6);
+      expect(d[1]).toBeCloseTo(anchored[1]!, 6);
+    }
+  });
+
+  it('zooming out then in returns the original scale', () => {
+    let v = zoomProfileViewAt(base, VP, 300, 100, 1.2);
+    v = zoomProfileViewAt(v, VP, 300, 100, 1 / 1.2);
+    expect(v.pxPerChainage).toBeCloseTo(base.pxPerChainage, 9);
+    expect(v.pxPerHeight).toBeCloseTo(base.pxPerHeight, 9);
+    expect(v.centreChainage).toBeCloseTo(base.centreChainage, 6);
+  });
+
+  it('ignores a non-finite or non-positive zoom factor', () => {
+    expect(zoomProfileViewAt(base, VP, 100, 100, Number.NaN)).toBe(base);
+    expect(zoomProfileViewAt(base, VP, 100, 100, 0)).toBe(base);
+    expect(zoomProfileViewAt(base, VP, 100, 100, -2)).toBe(base);
+  });
+});
+
+describe('true vertical exaggeration', () => {
+  for (const ratio of [1, 2, 5, 10]) {
+    it(`VE ${ratio}x gives a metre ${ratio}x the pixels vertically`, () => {
+      const v = fitProfileView(BOUNDS, VP, { kind: 've', ratio }, METRES)!;
+      const [mx, my] = pxPerMetre(v, METRES);
+      expect(my / mx).toBeCloseTo(ratio, 9);
+      expect(viewExaggeration(v, METRES)).toBeCloseTo(ratio, 9);
+    });
+
+    it(`VE ${ratio}x holds when the axes are in different units`, () => {
+      // Chainage in feet, height in metres. Comparing the two axis scales
+      // directly would be wrong by 1/0.3048 here.
+      const v = fitProfileView(BOUNDS, VP, { kind: 've', ratio }, FEET_H)!;
+      const [mx, my] = pxPerMetre(v, FEET_H);
+      expect(my / mx).toBeCloseTo(ratio, 9);
+      expect(viewExaggeration(v, FEET_H)).toBeCloseTo(ratio, 9);
+      // The raw axis-scale ratio is a different number, so the test above is
+      // not measuring the same thing twice.
+      expect(v.pxPerHeight / v.pxPerChainage).not.toBeCloseTo(ratio, 3);
+    });
+  }
+
+  it('contains the whole extent rather than cropping to hold the ratio', () => {
+    for (const ratio of [1, 2, 5, 10]) {
+      const v = fitProfileView(BOUNDS, VP, { kind: 've', ratio }, METRES)!;
+      const vis = profileVisibleBounds(v, VP);
+      expect(vis.minChainage).toBeLessThanOrEqual(BOUNDS.minChainage + 1e-9);
+      expect(vis.maxChainage).toBeGreaterThanOrEqual(BOUNDS.maxChainage - 1e-9);
+      expect(vis.minHeight).toBeLessThanOrEqual(BOUNDS.minHeight + 1e-9);
+      expect(vis.maxHeight).toBeGreaterThanOrEqual(BOUNDS.maxHeight - 1e-9);
+    }
+  });
+
+  it('survives a zoom', () => {
+    let v = fitProfileView(BOUNDS, VP, { kind: 've', ratio: 5 }, METRES)!;
+    for (let i = 0; i < 5; i++) v = zoomProfileViewAt(v, VP, 250, 90, 1.2);
+    expect(viewExaggeration(v, METRES)).toBeCloseTo(5, 9);
+  });
+
+  it('refuses a ratio when a unit scale is unknown', () => {
+    expect(canStateExaggeration(UNKNOWN_V)).toBe(false);
+    expect(fitProfileView(BOUNDS, VP, { kind: 've', ratio: 2 }, UNKNOWN_V)).toBeNull();
+    const fit = fitProfileView(BOUNDS, VP, { kind: 'fit' }, UNKNOWN_V)!;
+    expect(viewExaggeration(fit, UNKNOWN_V)).toBeNull();
+  });
+
+  it('refuses a ratio that is not a positive number', () => {
+    for (const r of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(fitProfileView(BOUNDS, VP, { kind: 've', ratio: r }, METRES)).toBeNull();
+    }
+  });
+
+  it('refuses a unit scale that is zero or negative', () => {
+    expect(canStateExaggeration({ horizontalToMetres: 0, verticalToMetres: 1 })).toBe(false);
+    expect(canStateExaggeration({ horizontalToMetres: 1, verticalToMetres: -1 })).toBe(false);
+  });
+});
+
+describe('degenerate and hostile input', () => {
+  it('handles a flat section without dividing by zero', () => {
+    const flat: ProfileDataBounds = {
+      minChainage: 0,
+      maxChainage: 200,
+      minHeight: 137.5,
+      maxHeight: 137.5,
+    };
+    const v = fitProfileView(flat, VP, { kind: 'fit' }, METRES)!;
+    expect(Number.isFinite(v.pxPerHeight)).toBe(true);
+    expect(v.pxPerHeight).toBeGreaterThan(0);
+    expect(v.centreHeight).toBe(137.5);
+    profileDataToScreen(v, VP, 100, 137.5, s);
+    expect(Number.isFinite(s[0]!)).toBe(true);
+    expect(Number.isFinite(s[1]!)).toBe(true);
+  });
+
+  it('handles a single-point section on both axes', () => {
+    const pt: ProfileDataBounds = {
+      minChainage: 42,
+      maxChainage: 42,
+      minHeight: 7,
+      maxHeight: 7,
+    };
+    const v = fitProfileView(pt, VP, { kind: 'fit' }, METRES)!;
+    expect(Number.isFinite(v.pxPerChainage)).toBe(true);
+    expect(Number.isFinite(v.pxPerHeight)).toBe(true);
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+  });
+
+  it('keeps a huge chainage span finite', () => {
+    const huge: ProfileDataBounds = {
+      minChainage: -1e15,
+      maxChainage: 1e15,
+      minHeight: 0,
+      maxHeight: 1e12,
+    };
+    const v = fitProfileView(huge, VP, { kind: 'fit' }, METRES)!;
+    expect(Number.isFinite(v.pxPerChainage)).toBe(true);
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+    profileDataToScreen(v, VP, 0, 0, s);
+    expect(Number.isFinite(s[0]!)).toBe(true);
+    expect(Number.isFinite(s[1]!)).toBe(true);
+  });
+
+  it('produces a finite view from non-finite bounds', () => {
+    const bad: ProfileDataBounds = {
+      minChainage: Number.NaN,
+      maxChainage: Number.POSITIVE_INFINITY,
+      minHeight: Number.NEGATIVE_INFINITY,
+      maxHeight: Number.NaN,
+    };
+    const v = fitProfileView(bad, VP, { kind: 'fit' }, METRES)!;
+    for (const n of [v.centreChainage, v.centreHeight, v.pxPerChainage, v.pxPerHeight]) {
+      expect(Number.isFinite(n)).toBe(true);
+    }
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+  });
+
+  it('produces a finite view from a zero-sized viewport', () => {
+    const v = fitProfileView(BOUNDS, { width: 0, height: 0, devicePixelRatio: 1 }, { kind: 'fit' }, METRES)!;
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+    expect(Number.isFinite(v.pxPerHeight)).toBe(true);
+  });
+
+  it('ignores a non-finite pan delta', () => {
+    const base = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    const p = panProfileView(base, Number.NaN, Number.POSITIVE_INFINITY);
+    expect(p.centreChainage).toBe(base.centreChainage);
+    expect(p.centreHeight).toBe(base.centreHeight);
+  });
+
+  it('gives a degenerate axis the documented minimum span', () => {
+    const flat: ProfileDataBounds = {
+      minChainage: 5,
+      maxChainage: 5,
+      minHeight: 0,
+      maxHeight: 10,
+    };
+    const v = fitProfileView(flat, VP, { kind: 'fit' }, METRES)!;
+    expect(v.pxPerChainage).toBeCloseTo(VP.width / MIN_DATA_SPAN, 0);
+  });
+});
+
+describe('device pixels', () => {
+  it('scales by the backing ratio', () => {
+    expect(toDevicePixels(VP, 10)).toBe(20);
+  });
+  it('falls back to 1 for a bad ratio', () => {
+    expect(toDevicePixels({ width: 10, height: 10, devicePixelRatio: 0 }, 10)).toBe(10);
+    expect(toDevicePixels({ width: 10, height: 10, devicePixelRatio: Number.NaN }, 10)).toBe(10);
+  });
+});
+
+describe('resize', () => {
+  it('keeps the centre and rescales the fit', () => {
+    const small = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    const wide = fitProfileView(
+      BOUNDS,
+      { width: 1600, height: 300, devicePixelRatio: 2 },
+      { kind: 'fit' },
+      METRES,
+    )!;
+    expect(wide.centreChainage).toBe(small.centreChainage);
+    expect(wide.pxPerChainage).toBeCloseTo(small.pxPerChainage * 2, 9);
+    expect(wide.pxPerHeight).toBeCloseTo(small.pxPerHeight, 9);
+  });
+});


### PR DESCRIPTION
Data space to screen and back, fit, pan, and zoom about a cursor for the 2D cross-section. Pure values, no DOM.

Vertical exaggeration is pixels per metre vertically over pixels per metre horizontally, so each axis converts through its own unit first. The raw ratio of the two axis scales is a different number when the units differ.

An unknown unit scale reports null rather than 1, and a fit asked for a ratio it cannot state returns null. A fit holding a ratio contains the whole extent rather than cropping to it.

Degenerate spans take a floor, so a flat section scales without dividing by zero.
