### PR TITLE
Draw section returns to canvas with a gap-aware station overlay

### DIFF
--- a/src/render/measure/profileSectionBuilder.ts
+++ b/src/render/measure/profileSectionBuilder.ts
@@ -1,0 +1,276 @@
+/**
+ * profileSectionBuilder.ts
+ *
+ * Accumulate the returns accepted by a profile corridor into compact typed
+ * arrays, keeping each return's identity and only the attributes its own
+ * source actually carries.
+ *
+ * The derived series reduces a corridor to one height per station. The
+ * section keeps the returns themselves, so every accepted point has to stay
+ * traceable to the source and index it came from, and an attribute that a
+ * source does not carry has to stay absent rather than becoming zero. A
+ * fabricated zero intensity is indistinguishable from a measured one.
+ *
+ * Presence is recorded per point, not per snapshot. A section can mix a
+ * source that carries RGB with one that does not, so `channelPresence`
+ * carries one bit per attribute per point and a consumer reads a channel
+ * only where its bit is set.
+ *
+ * Storage grows by doubling and is copied out at `finish()`, so the
+ * finished arrays are sized to the accepted count rather than to the
+ * scanned count.
+ */
+
+/** The per-point attributes a section can carry through from a source. */
+export type ProfileAttribute =
+  | 'rgb'
+  | 'intensity'
+  | 'classification'
+  | 'returnNumber'
+  | 'returnCount'
+  | 'pointSourceId'
+  | 'gpsTime'
+  | 'normals';
+
+/** Bit position of each attribute inside `channelPresence`. */
+export const PROFILE_ATTRIBUTE_BIT: Readonly<Record<ProfileAttribute, number>> = {
+  rgb: 1 << 0,
+  intensity: 1 << 1,
+  classification: 1 << 2,
+  returnNumber: 1 << 3,
+  returnCount: 1 << 4,
+  pointSourceId: 1 << 5,
+  gpsTime: 1 << 6,
+  normals: 1 << 7,
+};
+
+export const PROFILE_ATTRIBUTES: readonly ProfileAttribute[] = [
+  'rgb',
+  'intensity',
+  'classification',
+  'returnNumber',
+  'returnCount',
+  'pointSourceId',
+  'gpsTime',
+  'normals',
+];
+
+/**
+ * The channels one source carries, aligned to that source's point index.
+ *
+ * A channel is absent when the source does not carry it. A channel whose
+ * length disagrees with the source's point count is treated as absent, the
+ * same rule `sampleProfile` applies to a misaligned classification array.
+ */
+export interface ProfileSourceChannels {
+  readonly rgb?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  readonly pointSourceId?: Uint16Array;
+  readonly gpsTime?: Float64Array;
+  readonly normals?: Float32Array;
+}
+
+/** Accepted returns, as struct-of-arrays. All arrays share one index space. */
+export interface ProfileSectionPoints {
+  readonly count: number;
+  readonly chainage: Float32Array;
+  readonly height: Float32Array;
+  readonly lateralOffset: Float32Array;
+  readonly sourceSlot: Uint16Array;
+  readonly pointIndex: Uint32Array;
+  /** One bit per {@link ProfileAttribute}; see {@link PROFILE_ATTRIBUTE_BIT}. */
+  readonly channelPresence: Uint8Array;
+  readonly rgb?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  readonly pointSourceId?: Uint16Array;
+  readonly gpsTime?: Float64Array;
+  readonly normals?: Float32Array;
+}
+
+const INITIAL_CAPACITY = 1024;
+
+function grow<T extends { length: number }>(
+  arr: T,
+  capacity: number,
+  make: (n: number) => T,
+  stride: number,
+): T {
+  const next = make(capacity * stride);
+  (next as unknown as { set(a: T): void }).set(arr);
+  return next;
+}
+
+/**
+ * Collect accepted returns from one or more sources.
+ *
+ * Call {@link beginSource} before the points of each source, then
+ * {@link push} per accepted return, then {@link finish} once.
+ */
+export class ProfileSectionBuilder {
+  private _count = 0;
+  private _capacity = INITIAL_CAPACITY;
+
+  private _chainage = new Float32Array(INITIAL_CAPACITY);
+  private _height = new Float32Array(INITIAL_CAPACITY);
+  private _lateral = new Float32Array(INITIAL_CAPACITY);
+  private _slot = new Uint16Array(INITIAL_CAPACITY);
+  private _index = new Uint32Array(INITIAL_CAPACITY);
+  private _presence = new Uint8Array(INITIAL_CAPACITY);
+
+  private _rgb = new Uint8Array(INITIAL_CAPACITY * 3);
+  private _intensity = new Uint16Array(INITIAL_CAPACITY);
+  private _classification = new Uint8Array(INITIAL_CAPACITY);
+  private _returnNumber = new Uint8Array(INITIAL_CAPACITY);
+  private _returnCount = new Uint8Array(INITIAL_CAPACITY);
+  private _pointSourceId = new Uint16Array(INITIAL_CAPACITY);
+  private _gpsTime = new Float64Array(INITIAL_CAPACITY);
+  private _normals = new Float32Array(INITIAL_CAPACITY * 3);
+
+  /** Attributes seen on at least one source, so only those are emitted. */
+  private _seen = 0;
+
+  private _srcSlot = 0;
+  private _srcChannels: ProfileSourceChannels | null = null;
+  private _srcMask = 0;
+
+  /**
+   * Bind the source whose returns follow.
+   *
+   * `pointCount` is the source's own point count. A channel whose length
+   * disagrees with it is dropped for that source, which keeps a misaligned
+   * array from shifting every attribute by one index.
+   */
+  beginSource(slot: number, channels: ProfileSourceChannels | null, pointCount: number): void {
+    this._srcSlot = slot;
+    this._srcChannels = channels;
+    let mask = 0;
+    if (channels) {
+      if (channels.rgb?.length === pointCount * 3) mask |= PROFILE_ATTRIBUTE_BIT.rgb;
+      if (channels.intensity?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.intensity;
+      if (channels.classification?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.classification;
+      if (channels.returnNumber?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.returnNumber;
+      if (channels.returnCount?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.returnCount;
+      if (channels.pointSourceId?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.pointSourceId;
+      if (channels.gpsTime?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.gpsTime;
+      if (channels.normals?.length === pointCount * 3) mask |= PROFILE_ATTRIBUTE_BIT.normals;
+    }
+    this._srcMask = mask;
+    this._seen |= mask;
+  }
+
+  /** Number of returns accepted so far. */
+  get count(): number {
+    return this._count;
+  }
+
+  private _reserve(): void {
+    if (this._count < this._capacity) return;
+    const next = this._capacity * 2;
+    this._chainage = grow(this._chainage, next, (n) => new Float32Array(n), 1);
+    this._height = grow(this._height, next, (n) => new Float32Array(n), 1);
+    this._lateral = grow(this._lateral, next, (n) => new Float32Array(n), 1);
+    this._slot = grow(this._slot, next, (n) => new Uint16Array(n), 1);
+    this._index = grow(this._index, next, (n) => new Uint32Array(n), 1);
+    this._presence = grow(this._presence, next, (n) => new Uint8Array(n), 1);
+    this._rgb = grow(this._rgb, next, (n) => new Uint8Array(n), 3);
+    this._intensity = grow(this._intensity, next, (n) => new Uint16Array(n), 1);
+    this._classification = grow(this._classification, next, (n) => new Uint8Array(n), 1);
+    this._returnNumber = grow(this._returnNumber, next, (n) => new Uint8Array(n), 1);
+    this._returnCount = grow(this._returnCount, next, (n) => new Uint8Array(n), 1);
+    this._pointSourceId = grow(this._pointSourceId, next, (n) => new Uint16Array(n), 1);
+    this._gpsTime = grow(this._gpsTime, next, (n) => new Float64Array(n), 1);
+    this._normals = grow(this._normals, next, (n) => new Float32Array(n), 3);
+    this._capacity = next;
+  }
+
+  /**
+   * Append one accepted return.
+   *
+   * `sourceIndex` is the point's index in the bound source, and it is what
+   * every channel is read at, so an attribute can never be read from a
+   * different point than the one being appended.
+   */
+  push(sourceIndex: number, chainage: number, height: number, lateralOffset: number): void {
+    this._reserve();
+    const i = this._count;
+    this._chainage[i] = chainage;
+    this._height[i] = height;
+    this._lateral[i] = lateralOffset;
+    this._slot[i] = this._srcSlot;
+    this._index[i] = sourceIndex;
+    this._presence[i] = this._srcMask;
+
+    const c = this._srcChannels;
+    if (c) {
+      const m = this._srcMask;
+      if (m & PROFILE_ATTRIBUTE_BIT.rgb) {
+        this._rgb[i * 3] = c.rgb![sourceIndex * 3];
+        this._rgb[i * 3 + 1] = c.rgb![sourceIndex * 3 + 1];
+        this._rgb[i * 3 + 2] = c.rgb![sourceIndex * 3 + 2];
+      }
+      if (m & PROFILE_ATTRIBUTE_BIT.intensity) this._intensity[i] = c.intensity![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.classification)
+        this._classification[i] = c.classification![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.returnNumber)
+        this._returnNumber[i] = c.returnNumber![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.returnCount)
+        this._returnCount[i] = c.returnCount![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.pointSourceId)
+        this._pointSourceId[i] = c.pointSourceId![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.gpsTime) this._gpsTime[i] = c.gpsTime![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.normals) {
+        this._normals[i * 3] = c.normals![sourceIndex * 3];
+        this._normals[i * 3 + 1] = c.normals![sourceIndex * 3 + 1];
+        this._normals[i * 3 + 2] = c.normals![sourceIndex * 3 + 2];
+      }
+    }
+    this._count++;
+  }
+
+  /**
+   * Copy out arrays sized to the accepted count.
+   *
+   * A channel is emitted only when some source carried it. A channel no
+   * source carried is absent from the result rather than present and zero.
+   */
+  finish(): ProfileSectionPoints {
+    const n = this._count;
+    const seen = this._seen;
+    const has = (a: ProfileAttribute): boolean => (seen & PROFILE_ATTRIBUTE_BIT[a]) !== 0;
+    return {
+      count: n,
+      chainage: this._chainage.slice(0, n),
+      height: this._height.slice(0, n),
+      lateralOffset: this._lateral.slice(0, n),
+      sourceSlot: this._slot.slice(0, n),
+      pointIndex: this._index.slice(0, n),
+      channelPresence: this._presence.slice(0, n),
+      ...(has('rgb') ? { rgb: this._rgb.slice(0, n * 3) } : {}),
+      ...(has('intensity') ? { intensity: this._intensity.slice(0, n) } : {}),
+      ...(has('classification') ? { classification: this._classification.slice(0, n) } : {}),
+      ...(has('returnNumber') ? { returnNumber: this._returnNumber.slice(0, n) } : {}),
+      ...(has('returnCount') ? { returnCount: this._returnCount.slice(0, n) } : {}),
+      ...(has('pointSourceId') ? { pointSourceId: this._pointSourceId.slice(0, n) } : {}),
+      ...(has('gpsTime') ? { gpsTime: this._gpsTime.slice(0, n) } : {}),
+      ...(has('normals') ? { normals: this._normals.slice(0, n * 3) } : {}),
+    };
+  }
+}
+
+/** True when point `i` carries attribute `a`. */
+export function profileSectionHas(
+  points: ProfileSectionPoints,
+  i: number,
+  a: ProfileAttribute,
+): boolean {
+  return (points.channelPresence[i]! & PROFILE_ATTRIBUTE_BIT[a]) !== 0;
+}

--- a/src/render/measure/profileSectionBuilder.ts
+++ b/src/render/measure/profileSectionBuilder.ts
@@ -77,7 +77,17 @@ export interface ProfileSourceChannels {
 export interface ProfileSectionPoints {
   readonly count: number;
   readonly chainage: Float32Array;
-  readonly height: Float32Array;
+  /**
+   * Height along `up`, float64.
+   *
+   * Chainage and lateral offset are section relative and bounded by the
+   * section length plus the corridor half width, where float32 resolves
+   * below a millimetre. Height is absolute in the project frame, so it
+   * carries whatever magnitude the frame has: float32 spacing is 3.2e-2 m at
+   * 1e6 and 6.4e-1 m at 1e7. The placement was resolved in float64 during
+   * the read, and storing the result narrower would discard that.
+   */
+  readonly height: Float64Array;
   readonly lateralOffset: Float32Array;
   readonly sourceSlot: Uint16Array;
   readonly pointIndex: Uint32Array;
@@ -117,7 +127,7 @@ export class ProfileSectionBuilder {
   private _capacity = INITIAL_CAPACITY;
 
   private _chainage = new Float32Array(INITIAL_CAPACITY);
-  private _height = new Float32Array(INITIAL_CAPACITY);
+  private _height = new Float64Array(INITIAL_CAPACITY);
   private _lateral = new Float32Array(INITIAL_CAPACITY);
   private _slot = new Uint16Array(INITIAL_CAPACITY);
   private _index = new Uint32Array(INITIAL_CAPACITY);
@@ -176,7 +186,7 @@ export class ProfileSectionBuilder {
     if (this._count < this._capacity) return;
     const next = this._capacity * 2;
     this._chainage = grow(this._chainage, next, (n) => new Float32Array(n), 1);
-    this._height = grow(this._height, next, (n) => new Float32Array(n), 1);
+    this._height = grow(this._height, next, (n) => new Float64Array(n), 1);
     this._lateral = grow(this._lateral, next, (n) => new Float32Array(n), 1);
     this._slot = grow(this._slot, next, (n) => new Uint16Array(n), 1);
     this._index = grow(this._index, next, (n) => new Uint32Array(n), 1);

--- a/src/render/measure/profileSectionRenderer.ts
+++ b/src/render/measure/profileSectionRenderer.ts
@@ -1,0 +1,368 @@
+/**
+ * profileSectionRenderer.ts
+ *
+ * Draw a profile cross-section onto a 2D canvas: one splat per observed
+ * return, then the derived station series over the top.
+ *
+ * Two layers with different standing. The returns are measurements; the
+ * station series is a reduction of them, one height per bin. The reduction
+ * is useful to read a grade off, but it is not evidence, so it is drawn
+ * after the returns, thinner, and at an alpha this module caps. A viewer
+ * that lets a derived line sit over its own evidence at full weight invites
+ * the line to be read as the data.
+ *
+ * Colour is not decided here. The caller passes a `Uint8Array` of RGB
+ * triplets, one per drawn index, so whatever the colour mode resolved (class
+ * palette, intensity ramp, source RGB, flat) is what reaches the canvas. A
+ * renderer that reached for `classification` itself would silently override
+ * the mode the user chose.
+ *
+ * No DOM is touched. The context is a structural interface, so a real
+ * `CanvasRenderingContext2D` satisfies it and a recording double can be
+ * substituted in a Node test.
+ *
+ * WHY BATCHED `fillRect` AND NOT `ImageData` / `putImageData`
+ *
+ *   `putImageData` costs one pass over the backing store per frame no matter
+ *   how many points are drawn: a 1600 x 600 CSS plot at DPR 2 is 3200 x 1200
+ *   device pixels, 3.84 M pixels, 15.4 MB of RGBA that has to be composed in
+ *   JS and uploaded whole. A section corridor is not that large. The corridor
+ *   is a band a few metres wide around one line, so a realistic accepted
+ *   count is 1e3 to 1e5 returns, and the visible index list is smaller again
+ *   once the caller decimates. At 1e5 splats, `fillRect` does 1e5 small
+ *   rectangle fills against 3.84 M pixels of per-pixel bookkeeping, and the
+ *   rectangles win by more than an order of magnitude.
+ *
+ *   `putImageData` also ignores the canvas transform, `globalAlpha`, and any
+ *   clip, and it replaces rather than composites. Every one of those would
+ *   have to be reimplemented by hand: the DPR scale, the splat radius (a
+ *   splat wider than one pixel is a manual rasterisation), and the blend of
+ *   overlapping returns. Each reimplementation is a place for the plot to
+ *   disagree with the transform the rest of the profile uses.
+ *
+ *   The crossover is when drawn points approach the device-pixel count. A
+ *   section that dense is already unreadable as splats and wants a density
+ *   raster instead, which is a different product, not a faster path for this
+ *   one.
+ *
+ * Per-point cost is kept to the fill itself: `fillStyle` is assigned only
+ * when the triplet differs from the previous point's, and the CSS colour
+ * strings are memoised per packed triplet, so a section coloured by class
+ * pays a handful of style changes rather than one per return.
+ */
+
+import type { ProfileSectionPoints } from './profileSectionBuilder';
+import type { ProfileSample } from './profileSampler';
+import type { ProfileView, ProfileViewport } from './profileViewTransform';
+import { profileDataToScreen, toDevicePixels } from './profileViewTransform';
+
+/**
+ * The 2D drawing operations this renderer uses, and nothing more.
+ *
+ * `fillStyle` and `strokeStyle` carry the DOM's own union so a real
+ * `CanvasRenderingContext2D` is assignable; this module only ever writes
+ * strings to them.
+ */
+export interface ProfileRenderingContext {
+  fillStyle: string | CanvasGradient | CanvasPattern;
+  strokeStyle: string | CanvasGradient | CanvasPattern;
+  lineWidth: number;
+  globalAlpha: number;
+  setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void;
+  clearRect(x: number, y: number, w: number, h: number): void;
+  fillRect(x: number, y: number, w: number, h: number): void;
+  beginPath(): void;
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  stroke(): void;
+}
+
+/**
+ * The canvas the renderer owns.
+ *
+ * `setBackingSize` takes DEVICE pixels. Sizing the backing store is separated
+ * from drawing because assigning a canvas's width or height clears it, so it
+ * has to happen only when the size actually changed.
+ */
+export interface ProfileSurface {
+  readonly ctx: ProfileRenderingContext;
+  setBackingSize(deviceWidth: number, deviceHeight: number): void;
+}
+
+/**
+ * Schedules one callback for the next frame.
+ *
+ * Passed in rather than reaching for `requestAnimationFrame` so a test can
+ * drive the coalescing synchronously, and so a headless or worker host can
+ * supply its own clock.
+ */
+export type ProfileFrameScheduler = (draw: () => void) => void;
+
+/** What to draw. Every array is caller owned and is only read. */
+export interface ProfileSectionScene {
+  readonly points: ProfileSectionPoints;
+  /** Indices into `points` to draw, in draw order. */
+  readonly indices: Uint32Array;
+  /** RGB triplets, one per entry of `indices`, NOT one per point index. */
+  readonly colours: Uint8Array;
+  /** The derived station series, or null to draw returns alone. */
+  readonly stations?: readonly ProfileSample[] | null;
+}
+
+/** Splat and station weights, in CSS pixels. */
+export interface ProfileSectionStyle {
+  /** Side of the square splat, CSS pixels. */
+  readonly pointSizePx: number;
+  readonly pointAlpha: number;
+  /** Station line width, CSS pixels. */
+  readonly stationWidthPx: number;
+  /** CSS colour of the station line. The caller owns it. */
+  readonly stationColour: string;
+  readonly stationAlpha: number;
+}
+
+/** A complete frame: what, seen how, at what weight. */
+export interface ProfileSectionFrame {
+  readonly scene: ProfileSectionScene;
+  readonly view: ProfileView;
+  readonly viewport: ProfileViewport;
+  readonly style: ProfileSectionStyle;
+}
+
+/**
+ * The most opaque the derived station line may be drawn.
+ *
+ * Clamped rather than trusted, because the layer ordering alone does not stop
+ * a caller from handing in an opaque station line that hides the returns it
+ * was derived from.
+ */
+export const MAX_STATION_ALPHA = 0.7;
+
+/** Largest splat side accepted, CSS pixels. Beyond this the plot is blocks. */
+const MAX_POINT_SIZE_PX = 64;
+
+function finite(v: number): boolean {
+  return Number.isFinite(v);
+}
+
+function clampAlpha(v: number, max: number): number {
+  if (!finite(v)) return max;
+  return Math.min(max, Math.max(0, v));
+}
+
+/** Device pixels per CSS pixel, with the same fallback the transform uses. */
+function effectiveDpr(viewport: ProfileViewport): number {
+  const d = viewport.devicePixelRatio;
+  return finite(d) && d > 0 ? d : 1;
+}
+
+function positiveOr(v: number, fallback: number, max: number): number {
+  if (!finite(v) || v <= 0) return fallback;
+  return Math.min(max, v);
+}
+
+/** `rgb(r, g, b)` for a triplet, memoised on the packed 24-bit key. */
+class ColourCache {
+  private readonly cache = new Map<number, string>();
+
+  get(r: number, g: number, b: number): string {
+    const key = (r << 16) | (g << 8) | b;
+    let css = this.cache.get(key);
+    if (css === undefined) {
+      css = `rgb(${r}, ${g}, ${b})`;
+      this.cache.set(key, css);
+    }
+    return css;
+  }
+}
+
+/**
+ * Coalescing Canvas 2D renderer for one profile cross-section.
+ *
+ * `requestRender` marks the view dirty and asks the scheduler for a frame;
+ * further requests before that frame fires are absorbed. `renderNow` draws
+ * immediately and is what the scheduled callback ends up calling, so a host
+ * that needs a synchronous draw (an export, a test) can call it directly.
+ */
+export class ProfileSectionRenderer {
+  private readonly surface: ProfileSurface;
+  private readonly schedule: ProfileFrameScheduler;
+  private readonly colours = new ColourCache();
+  private readonly scratch = new Float64Array(2);
+
+  private frame: ProfileSectionFrame | null = null;
+  private scheduled = false;
+  private backingWidth = -1;
+  private backingHeight = -1;
+  private draws = 0;
+
+  constructor(surface: ProfileSurface, schedule: ProfileFrameScheduler) {
+    this.surface = surface;
+    this.schedule = schedule;
+  }
+
+  /** Replace the frame. Does not draw; the caller invalidates explicitly. */
+  setFrame(frame: ProfileSectionFrame): void {
+    this.frame = frame;
+  }
+
+  /** True while a scheduled frame is still outstanding. */
+  get pending(): boolean {
+    return this.scheduled;
+  }
+
+  /** How many times {@link renderNow} has drawn. */
+  get drawCount(): number {
+    return this.draws;
+  }
+
+  /**
+   * Mark dirty and ask for one frame.
+   *
+   * Several invalidations inside one frame produce one draw. The flag is
+   * cleared before the draw runs, so an invalidation raised DURING a draw
+   * schedules the next frame instead of being swallowed.
+   */
+  requestRender(): void {
+    if (this.scheduled) return;
+    this.scheduled = true;
+    this.schedule(() => {
+      this.scheduled = false;
+      this.renderNow();
+    });
+  }
+
+  /** Draw the current frame immediately. */
+  renderNow(): void {
+    const frame = this.frame;
+    if (frame === null) return;
+    const { scene, view, viewport, style } = frame;
+    const ctx = this.surface.ctx;
+    const dpr = effectiveDpr(viewport);
+
+    const cssWidth = positiveOr(viewport.width, 1, Number.MAX_SAFE_INTEGER);
+    const cssHeight = positiveOr(viewport.height, 1, Number.MAX_SAFE_INTEGER);
+
+    // The backing store is device pixels; everything below is CSS pixels
+    // because the transform carries the ratio. Resizing clears the canvas, so
+    // it is applied only on a real change.
+    const deviceWidth = Math.max(1, Math.round(toDevicePixels(viewport, cssWidth)));
+    const deviceHeight = Math.max(1, Math.round(toDevicePixels(viewport, cssHeight)));
+    if (deviceWidth !== this.backingWidth || deviceHeight !== this.backingHeight) {
+      this.surface.setBackingSize(deviceWidth, deviceHeight);
+      this.backingWidth = deviceWidth;
+      this.backingHeight = deviceHeight;
+    }
+
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+    this.drawReturns(ctx, scene, view, viewport, style);
+    // Derived after observed, always.
+    this.drawStations(ctx, scene, view, viewport, style);
+
+    ctx.globalAlpha = 1;
+    this.draws++;
+  }
+
+  /**
+   * One square splat per drawn index.
+   *
+   * The loop is bounded by the shorter of the index list and the colour
+   * array, so a colour array that disagrees with the index list truncates
+   * rather than reading past its end or pairing an index with a triplet that
+   * was never supplied for it. `colours` is indexed by POSITION in `indices`,
+   * so index `indices[k]` always takes triplet `k`.
+   */
+  private drawReturns(
+    ctx: ProfileRenderingContext,
+    scene: ProfileSectionScene,
+    view: ProfileView,
+    viewport: ProfileViewport,
+    style: ProfileSectionStyle,
+  ): void {
+    const { points, indices, colours } = scene;
+    const drawable = Math.min(indices.length, Math.floor(colours.length / 3));
+    if (drawable <= 0) return;
+
+    const size = positiveOr(style.pointSizePx, 1, MAX_POINT_SIZE_PX);
+    const half = size / 2;
+    ctx.globalAlpha = clampAlpha(style.pointAlpha, 1);
+
+    const out = this.scratch;
+    let lastCss = '';
+    for (let k = 0; k < drawable; k++) {
+      const i = indices[k]!;
+      if (i >= points.count) continue;
+      profileDataToScreen(view, viewport, points.chainage[i]!, points.height[i]!, out);
+      const x = out[0]!;
+      const y = out[1]!;
+      // A non-finite coordinate, whether from a non-finite return or from a
+      // non-finite view scale, is skipped. The loop is a counted for, so no
+      // input can make it run longer than the index list.
+      if (!finite(x) || !finite(y)) continue;
+      const css = this.colours.get(colours[k * 3]!, colours[k * 3 + 1]!, colours[k * 3 + 2]!);
+      if (css !== lastCss) {
+        ctx.fillStyle = css;
+        lastCss = css;
+      }
+      ctx.fillRect(x - half, y - half, size, size);
+    }
+  }
+
+  /**
+   * The derived station series, as straight segments between adjacent
+   * samples, broken at every gap.
+   *
+   * A `NaN` height means the bin saw no returns. Joining across it would draw
+   * a segment through ground nothing was measured on, and that segment would
+   * be indistinguishable from measured ground. So a gap ends the current run
+   * and the next finite sample starts a new one; the two are never joined.
+   *
+   * A run of one sample is left unstroked: a straight segment needs two ends,
+   * and an isolated station has no segment to draw.
+   */
+  private drawStations(
+    ctx: ProfileRenderingContext,
+    scene: ProfileSectionScene,
+    view: ProfileView,
+    viewport: ProfileViewport,
+    style: ProfileSectionStyle,
+  ): void {
+    const stations = scene.stations;
+    if (stations == null || stations.length === 0) return;
+
+    ctx.globalAlpha = clampAlpha(style.stationAlpha, MAX_STATION_ALPHA);
+    ctx.strokeStyle = style.stationColour;
+    ctx.lineWidth = positiveOr(style.stationWidthPx, 1, MAX_POINT_SIZE_PX);
+
+    const out = this.scratch;
+    let run = 0;
+    for (let s = 0; s < stations.length; s++) {
+      const sample = stations[s]!;
+      const d = sample.distance;
+      const h = sample.height;
+      if (!finite(d) || !finite(h)) {
+        if (run >= 2) ctx.stroke();
+        run = 0;
+        continue;
+      }
+      profileDataToScreen(view, viewport, d, h, out);
+      const x = out[0]!;
+      const y = out[1]!;
+      if (!finite(x) || !finite(y)) {
+        if (run >= 2) ctx.stroke();
+        run = 0;
+        continue;
+      }
+      if (run === 0) {
+        ctx.beginPath();
+        ctx.moveTo(x, y);
+      } else {
+        ctx.lineTo(x, y);
+      }
+      run++;
+    }
+    if (run >= 2) ctx.stroke();
+  }
+}

--- a/src/render/measure/profileViewTransform.ts
+++ b/src/render/measure/profileViewTransform.ts
@@ -1,0 +1,268 @@
+/**
+ * profileViewTransform.ts
+ *
+ * The viewport transform for a 2D profile cross-section: data space
+ * (chainage, height) to screen space and back, fit, pan, zoom about a
+ * cursor, and vertical exaggeration.
+ *
+ * Pure. No DOM, no canvas, no renderer. Everything here is a value.
+ *
+ * Vertical exaggeration is a ratio between two physical scales, so it can
+ * only be stated when both axes can be expressed in the same physical unit.
+ * A profile's horizontal and vertical units can differ, and either can be
+ * unknown. When one is unknown the view still works, and the ratio is
+ * reported as null rather than as 1.
+ */
+
+/** Metres per data unit on each axis. Null where the scale is unknown. */
+export interface ProfileUnitContext {
+  readonly horizontalToMetres: number | null;
+  readonly verticalToMetres: number | null;
+}
+
+/** The drawable area, in CSS pixels, and the backing store ratio. */
+export interface ProfileViewport {
+  readonly width: number;
+  readonly height: number;
+  readonly devicePixelRatio: number;
+}
+
+/** Data-space extent to be shown. */
+export interface ProfileDataBounds {
+  readonly minChainage: number;
+  readonly maxChainage: number;
+  readonly minHeight: number;
+  readonly maxHeight: number;
+}
+
+/**
+ * `fit` scales each axis independently to the viewport and claims no ratio.
+ * `ve` holds a true vertical exaggeration and requires both unit scales.
+ */
+export type ProfileScaleMode =
+  | { readonly kind: 'fit' }
+  | { readonly kind: 've'; readonly ratio: number };
+
+/** A resolved view: what sits at the centre, and the scale of each axis. */
+export interface ProfileView {
+  readonly centreChainage: number;
+  readonly centreHeight: number;
+  /** CSS pixels per chainage unit. Always > 0. */
+  readonly pxPerChainage: number;
+  /** CSS pixels per height unit. Always > 0. */
+  readonly pxPerHeight: number;
+}
+
+/**
+ * The smallest span a degenerate axis is given.
+ *
+ * A section whose returns share one height has a zero height span, and
+ * dividing the viewport by it yields infinity. One unit of span puts such a
+ * section on a readable axis instead of an empty one.
+ */
+export const MIN_DATA_SPAN = 1e-6;
+
+/** Scale change per zoom step. */
+export const ZOOM_STEP = 1.2;
+
+const MIN_PX_PER_UNIT = 1e-12;
+const MAX_PX_PER_UNIT = 1e12;
+
+function finite(v: number): boolean {
+  return Number.isFinite(v);
+}
+
+function clampScale(v: number): number {
+  if (!finite(v) || v <= 0) return MIN_PX_PER_UNIT;
+  return Math.min(MAX_PX_PER_UNIT, Math.max(MIN_PX_PER_UNIT, v));
+}
+
+function spanOf(min: number, max: number): number {
+  const s = max - min;
+  if (!finite(s) || s <= MIN_DATA_SPAN) return MIN_DATA_SPAN;
+  return s;
+}
+
+/** True when a true vertical exaggeration can be stated for these units. */
+export function canStateExaggeration(units: ProfileUnitContext): boolean {
+  const h = units.horizontalToMetres;
+  const v = units.verticalToMetres;
+  return h != null && v != null && finite(h) && finite(v) && h > 0 && v > 0;
+}
+
+/**
+ * The view's vertical exaggeration, or null when it cannot be stated.
+ *
+ * Pixels per metre on each axis is the axis scale divided by the metres in
+ * one of its data units. The exaggeration is the vertical figure over the
+ * horizontal one.
+ */
+export function viewExaggeration(
+  view: ProfileView,
+  units: ProfileUnitContext,
+): number | null {
+  if (!canStateExaggeration(units)) return null;
+  const h = units.horizontalToMetres!;
+  const v = units.verticalToMetres!;
+  const pxPerMetreX = view.pxPerChainage / h;
+  const pxPerMetreY = view.pxPerHeight / v;
+  if (!finite(pxPerMetreX) || pxPerMetreX <= 0) return null;
+  const ratio = pxPerMetreY / pxPerMetreX;
+  return finite(ratio) ? ratio : null;
+}
+
+/**
+ * Fit `bounds` into `viewport`.
+ *
+ * Under `fit` each axis takes the viewport independently. Under `ve` both
+ * axes take one base scale chosen so the whole extent still fits, so holding
+ * a ratio never crops an extreme.
+ *
+ * Returns null when the mode asks for an exaggeration the units cannot
+ * support, so a caller must handle that rather than receive a view whose
+ * ratio is a fiction.
+ */
+export function fitProfileView(
+  bounds: ProfileDataBounds,
+  viewport: ProfileViewport,
+  mode: ProfileScaleMode,
+  units: ProfileUnitContext,
+): ProfileView | null {
+  const w = finite(viewport.width) && viewport.width > 0 ? viewport.width : 1;
+  const hgt = finite(viewport.height) && viewport.height > 0 ? viewport.height : 1;
+
+  const minC = finite(bounds.minChainage) ? bounds.minChainage : 0;
+  const maxC = finite(bounds.maxChainage) ? bounds.maxChainage : 0;
+  const minH = finite(bounds.minHeight) ? bounds.minHeight : 0;
+  const maxH = finite(bounds.maxHeight) ? bounds.maxHeight : 0;
+
+  const spanC = spanOf(minC, maxC);
+  const spanH = spanOf(minH, maxH);
+  const centreChainage = (minC + maxC) / 2;
+  const centreHeight = (minH + maxH) / 2;
+
+  if (mode.kind === 'fit') {
+    return {
+      centreChainage,
+      centreHeight,
+      pxPerChainage: clampScale(w / spanC),
+      pxPerHeight: clampScale(hgt / spanH),
+    };
+  }
+
+  if (!canStateExaggeration(units)) return null;
+  const ratio = mode.ratio;
+  if (!finite(ratio) || ratio <= 0) return null;
+  const mPerC = units.horizontalToMetres!;
+  const mPerH = units.verticalToMetres!;
+
+  // pxPerHeight = ratio * pxPerChainage * mPerH / mPerC, so a vertical fit
+  // implies a horizontal scale. Taking the smaller of that and the
+  // horizontal fit keeps both extents inside the viewport.
+  const fromWidth = w / spanC;
+  const fromHeight = ((hgt / spanH) * mPerC) / (ratio * mPerH);
+  const pxPerChainage = clampScale(Math.min(fromWidth, fromHeight));
+  const pxPerHeight = clampScale((ratio * pxPerChainage * mPerH) / mPerC);
+  return { centreChainage, centreHeight, pxPerChainage, pxPerHeight };
+}
+
+/**
+ * Data to screen, in CSS pixels from the top left of the drawable area.
+ *
+ * Height increases upward on screen, so the vertical term is negated.
+ */
+export function profileDataToScreen(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  chainage: number,
+  height: number,
+  out: Float64Array,
+): void {
+  out[0] = viewport.width / 2 + (chainage - view.centreChainage) * view.pxPerChainage;
+  out[1] = viewport.height / 2 - (height - view.centreHeight) * view.pxPerHeight;
+}
+
+/** Screen to data. The inverse of {@link profileDataToScreen}. */
+export function profileScreenToData(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  sx: number,
+  sy: number,
+  out: Float64Array,
+): void {
+  out[0] = view.centreChainage + (sx - viewport.width / 2) / view.pxPerChainage;
+  out[1] = view.centreHeight - (sy - viewport.height / 2) / view.pxPerHeight;
+}
+
+/** Move the view by a screen-space delta. */
+export function panProfileView(
+  view: ProfileView,
+  dxPx: number,
+  dyPx: number,
+): ProfileView {
+  const dx = finite(dxPx) ? dxPx : 0;
+  const dy = finite(dyPx) ? dyPx : 0;
+  return {
+    ...view,
+    centreChainage: view.centreChainage - dx / view.pxPerChainage,
+    centreHeight: view.centreHeight + dy / view.pxPerHeight,
+  };
+}
+
+/**
+ * Zoom about a screen anchor, keeping the data under that anchor fixed.
+ *
+ * Under `fit` both axes scale together, which preserves the aspect the fit
+ * produced. Under `ve` both axes scale together as well, which is what keeps
+ * the exaggeration constant through a zoom.
+ */
+export function zoomProfileViewAt(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  anchorX: number,
+  anchorY: number,
+  factor: number,
+): ProfileView {
+  if (!finite(factor) || factor <= 0) return view;
+  const ax = finite(anchorX) ? anchorX : viewport.width / 2;
+  const ay = finite(anchorY) ? anchorY : viewport.height / 2;
+
+  const before = new Float64Array(2);
+  profileScreenToData(view, viewport, ax, ay, before);
+  const next: ProfileView = {
+    ...view,
+    pxPerChainage: clampScale(view.pxPerChainage * factor),
+    pxPerHeight: clampScale(view.pxPerHeight * factor),
+  };
+  const after = new Float64Array(2);
+  profileScreenToData(next, viewport, ax, ay, after);
+  return {
+    ...next,
+    centreChainage: next.centreChainage + (before[0]! - after[0]!),
+    centreHeight: next.centreHeight + (before[1]! - after[1]!),
+  };
+}
+
+/** Scale a CSS-pixel measure to the canvas backing store. */
+export function toDevicePixels(viewport: ProfileViewport, cssPx: number): number {
+  const dpr =
+    finite(viewport.devicePixelRatio) && viewport.devicePixelRatio > 0
+      ? viewport.devicePixelRatio
+      : 1;
+  return cssPx * dpr;
+}
+
+/** The data-space rectangle the viewport currently shows. */
+export function profileVisibleBounds(
+  view: ProfileView,
+  viewport: ProfileViewport,
+): ProfileDataBounds {
+  const halfC = viewport.width / 2 / view.pxPerChainage;
+  const halfH = viewport.height / 2 / view.pxPerHeight;
+  return {
+    minChainage: view.centreChainage - halfC,
+    maxChainage: view.centreChainage + halfC,
+    minHeight: view.centreHeight - halfH,
+    maxHeight: view.centreHeight + halfH,
+  };
+}

--- a/tests/profileSectionBuilder.test.ts
+++ b/tests/profileSectionBuilder.test.ts
@@ -1,0 +1,211 @@
+/**
+ * profileSectionBuilder.test.ts
+ *
+ * Attribute integrity for the section builder.
+ *
+ * Every channel value is a distinct function of (slot, sourceIndex), so a
+ * value read one index off, or read from the wrong source, produces a number
+ * that cannot occur at that position. Checking a constant fill would not
+ * separate those failures from a correct read.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ProfileSectionBuilder,
+  profileSectionHas,
+  PROFILE_ATTRIBUTE_BIT,
+  type ProfileSourceChannels,
+} from '../src/render/measure/profileSectionBuilder';
+
+/** Channel values keyed so a one-index shift changes every one of them. */
+const intensityAt = (slot: number, i: number): number => 1000 * (slot + 1) + i * 7;
+const classAt = (slot: number, i: number): number => (slot * 31 + i * 13) % 256;
+const rgbAt = (slot: number, i: number, c: number): number => (slot * 17 + i * 5 + c * 61) % 256;
+const gpsAt = (slot: number, i: number): number => slot * 1e6 + i * 0.001;
+const retNumAt = (slot: number, i: number): number => ((i + slot * 2) % 5) + 1;
+const retCntAt = (slot: number, i: number): number => ((i + slot) % 4) + 1;
+const psidAt = (slot: number, i: number): number => 7000 + slot * 100 + (i % 90);
+const normAt = (slot: number, i: number, c: number): number => slot + i * 0.25 + c * 0.125;
+
+function channelsFor(slot: number, n: number, which: Set<string>): ProfileSourceChannels {
+  const out: Record<string, unknown> = {};
+  if (which.has('rgb')) {
+    const a = new Uint8Array(n * 3);
+    for (let i = 0; i < n; i++) for (let c = 0; c < 3; c++) a[i * 3 + c] = rgbAt(slot, i, c);
+    out.rgb = a;
+  }
+  if (which.has('intensity')) {
+    const a = new Uint16Array(n);
+    for (let i = 0; i < n; i++) a[i] = intensityAt(slot, i);
+    out.intensity = a;
+  }
+  if (which.has('classification')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = classAt(slot, i);
+    out.classification = a;
+  }
+  if (which.has('returnNumber')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = retNumAt(slot, i);
+    out.returnNumber = a;
+  }
+  if (which.has('returnCount')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = retCntAt(slot, i);
+    out.returnCount = a;
+  }
+  if (which.has('pointSourceId')) {
+    const a = new Uint16Array(n);
+    for (let i = 0; i < n; i++) a[i] = psidAt(slot, i);
+    out.pointSourceId = a;
+  }
+  if (which.has('gpsTime')) {
+    const a = new Float64Array(n);
+    for (let i = 0; i < n; i++) a[i] = gpsAt(slot, i);
+    out.gpsTime = a;
+  }
+  if (which.has('normals')) {
+    const a = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) for (let c = 0; c < 3; c++) a[i * 3 + c] = normAt(slot, i, c);
+    out.normals = a;
+  }
+  return out as ProfileSourceChannels;
+}
+
+describe('section builder keeps every attribute on its own point', () => {
+  it('carries a full channel set through unshifted, past a growth boundary', () => {
+    // Accepting every third of 9000 gives 3000 returns, which crosses the
+    // 1024 doubling threshold and then 2048, so the reallocation path runs
+    // rather than only the initial buffer.
+    const n = 9000;
+    const all = new Set([
+      'rgb',
+      'intensity',
+      'classification',
+      'returnNumber',
+      'returnCount',
+      'pointSourceId',
+      'gpsTime',
+      'normals',
+    ]);
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, channelsFor(0, n, all), n);
+    // Accept every third point so source index and section index differ, which
+    // a test accepting all points cannot distinguish from a correct read.
+    const accepted: number[] = [];
+    for (let i = 0; i < n; i += 3) {
+      b.push(i, i * 0.5, i * 0.25, i % 7 === 0 ? 1.5 : -1.5);
+      accepted.push(i);
+    }
+    const p = b.finish();
+    expect(p.count).toBe(accepted.length);
+    expect(p.count).toBeGreaterThan(1024);
+
+    for (let k = 0; k < p.count; k++) {
+      const src = accepted[k]!;
+      expect(p.pointIndex[k]).toBe(src);
+      expect(p.sourceSlot[k]).toBe(0);
+      expect(p.chainage[k]).toBeCloseTo(src * 0.5, 4);
+      expect(p.height[k]).toBeCloseTo(src * 0.25, 4);
+      expect(p.intensity![k]).toBe(intensityAt(0, src));
+      expect(p.classification![k]).toBe(classAt(0, src));
+      expect(p.returnNumber![k]).toBe(retNumAt(0, src));
+      expect(p.returnCount![k]).toBe(retCntAt(0, src));
+      expect(p.pointSourceId![k]).toBe(psidAt(0, src));
+      expect(p.gpsTime![k]).toBeCloseTo(gpsAt(0, src), 9);
+      for (let c = 0; c < 3; c++) {
+        expect(p.rgb![k * 3 + c]).toBe(rgbAt(0, src, c));
+        expect(p.normals![k * 3 + c]).toBeCloseTo(normAt(0, src, c), 5);
+      }
+    }
+  });
+
+  it('keeps mixed sources apart and marks absence per point', () => {
+    // A carries RGB and classification; B carries intensity and GPS time;
+    // C carries nothing. Interleaved so a per-snapshot presence flag would
+    // be wrong for two of the three.
+    const nA = 40;
+    const nB = 40;
+    const nC = 40;
+    const b = new ProfileSectionBuilder();
+
+    b.beginSource(0, channelsFor(0, nA, new Set(['rgb', 'classification'])), nA);
+    for (let i = 0; i < nA; i++) b.push(i, i, i, 0);
+    b.beginSource(1, channelsFor(1, nB, new Set(['intensity', 'gpsTime'])), nB);
+    for (let i = 0; i < nB; i++) b.push(i, i, i, 0);
+    b.beginSource(2, null, nC);
+    for (let i = 0; i < nC; i++) b.push(i, i, i, 0);
+
+    const p = b.finish();
+    expect(p.count).toBe(nA + nB + nC);
+
+    for (let k = 0; k < p.count; k++) {
+      const slot = p.sourceSlot[k]!;
+      const src = p.pointIndex[k]!;
+      if (slot === 0) {
+        expect(profileSectionHas(p, k, 'rgb')).toBe(true);
+        expect(profileSectionHas(p, k, 'classification')).toBe(true);
+        expect(profileSectionHas(p, k, 'intensity')).toBe(false);
+        expect(profileSectionHas(p, k, 'gpsTime')).toBe(false);
+        expect(p.classification![k]).toBe(classAt(0, src));
+        expect(p.rgb![k * 3]).toBe(rgbAt(0, src, 0));
+      } else if (slot === 1) {
+        expect(profileSectionHas(p, k, 'intensity')).toBe(true);
+        expect(profileSectionHas(p, k, 'gpsTime')).toBe(true);
+        expect(profileSectionHas(p, k, 'rgb')).toBe(false);
+        expect(profileSectionHas(p, k, 'classification')).toBe(false);
+        expect(p.intensity![k]).toBe(intensityAt(1, src));
+        expect(p.gpsTime![k]).toBeCloseTo(gpsAt(1, src), 9);
+      } else {
+        expect(p.channelPresence[k]).toBe(0);
+      }
+    }
+  });
+
+  it('omits a channel no source carried rather than emitting zeros', () => {
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, channelsFor(0, 10, new Set(['intensity'])), 10);
+    for (let i = 0; i < 10; i++) b.push(i, i, i, 0);
+    const p = b.finish();
+    expect(p.intensity).toBeDefined();
+    expect(p.rgb).toBeUndefined();
+    expect(p.gpsTime).toBeUndefined();
+    expect(p.classification).toBeUndefined();
+    expect(p.normals).toBeUndefined();
+  });
+
+  it('drops a misaligned channel for that source instead of shifting it', () => {
+    // A classification array one element short cannot be index-aligned. The
+    // sampler applies the same rule to its own classification input.
+    const n = 20;
+    const good = channelsFor(0, n, new Set(['classification', 'intensity']));
+    const bad: ProfileSourceChannels = {
+      classification: good.classification!.slice(0, n - 1),
+      intensity: good.intensity,
+    };
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, bad, n);
+    for (let i = 0; i < n; i++) b.push(i, i, i, 0);
+    const p = b.finish();
+
+    expect(p.classification).toBeUndefined();
+    for (let k = 0; k < p.count; k++) {
+      expect(profileSectionHas(p, k, 'classification')).toBe(false);
+      expect(profileSectionHas(p, k, 'intensity')).toBe(true);
+      expect(p.intensity![k]).toBe(intensityAt(0, k));
+    }
+  });
+
+  it('assigns one bit per attribute', () => {
+    const bits = Object.values(PROFILE_ATTRIBUTE_BIT);
+    expect(new Set(bits).size).toBe(bits.length);
+    for (const v of bits) expect(v & (v - 1)).toBe(0);
+    expect(bits.reduce((a, c) => a | c, 0)).toBe(0xff);
+  });
+
+  it('reports an empty section without allocating channels', () => {
+    const p = new ProfileSectionBuilder().finish();
+    expect(p.count).toBe(0);
+    expect(p.chainage.length).toBe(0);
+    expect(p.rgb).toBeUndefined();
+  });
+});

--- a/tests/profileSectionRenderer.test.ts
+++ b/tests/profileSectionRenderer.test.ts
@@ -1,0 +1,619 @@
+/**
+ * profileSectionRenderer.test.ts
+ *
+ * The section renderer against a recording 2D context.
+ *
+ * Every expected screen position is computed here from the transform's own
+ * definition, written out in full, rather than by calling the renderer twice
+ * and comparing it with itself. Chainage is stored float32, so an expectation
+ * that ignored `Math.fround` would be testing a number the renderer never
+ * saw.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ProfileSectionRenderer,
+  MAX_STATION_ALPHA,
+  type ProfileRenderingContext,
+  type ProfileSectionFrame,
+  type ProfileSectionScene,
+  type ProfileSectionStyle,
+  type ProfileSurface,
+} from '../src/render/measure/profileSectionRenderer';
+import type { ProfileSectionPoints } from '../src/render/measure/profileSectionBuilder';
+import type { ProfileSample } from '../src/render/measure/profileSampler';
+import type { ProfileView, ProfileViewport } from '../src/render/measure/profileViewTransform';
+
+/** One recorded call, with the context state that was in force for it. */
+interface Op {
+  readonly op: string;
+  readonly args: readonly number[];
+  readonly fillStyle: string;
+  readonly strokeStyle: string;
+  readonly globalAlpha: number;
+  readonly lineWidth: number;
+}
+
+/**
+ * A `CanvasRenderingContext2D` stand-in that records instead of drawing.
+ *
+ * It offers nothing but the drawing calls, so a renderer that tried to build
+ * a DOM node or an SVG element per return would have nowhere to build it and
+ * would throw in the Node environment these tests run in.
+ */
+class RecordingContext implements ProfileRenderingContext {
+  fillStyle: string | CanvasGradient | CanvasPattern = '#000';
+  strokeStyle: string | CanvasGradient | CanvasPattern = '#000';
+  lineWidth = 1;
+  globalAlpha = 1;
+  readonly ops: Op[] = [];
+
+  private record(op: string, args: number[]): void {
+    this.ops.push({
+      op,
+      args,
+      fillStyle: String(this.fillStyle),
+      strokeStyle: String(this.strokeStyle),
+      globalAlpha: this.globalAlpha,
+      lineWidth: this.lineWidth,
+    });
+  }
+
+  setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void {
+    this.record('setTransform', [a, b, c, d, e, f]);
+  }
+  clearRect(x: number, y: number, w: number, h: number): void {
+    this.record('clearRect', [x, y, w, h]);
+  }
+  fillRect(x: number, y: number, w: number, h: number): void {
+    this.record('fillRect', [x, y, w, h]);
+  }
+  beginPath(): void {
+    this.record('beginPath', []);
+  }
+  moveTo(x: number, y: number): void {
+    this.record('moveTo', [x, y]);
+  }
+  lineTo(x: number, y: number): void {
+    this.record('lineTo', [x, y]);
+  }
+  stroke(): void {
+    this.record('stroke', []);
+  }
+
+  of(op: string): Op[] {
+    return this.ops.filter((o) => o.op === op);
+  }
+  names(): string[] {
+    return this.ops.map((o) => o.op);
+  }
+}
+
+class RecordingSurface implements ProfileSurface {
+  readonly ctx = new RecordingContext();
+  readonly sizes: Array<[number, number]> = [];
+  setBackingSize(deviceWidth: number, deviceHeight: number): void {
+    this.sizes.push([deviceWidth, deviceHeight]);
+  }
+}
+
+/** A scheduler whose frames only run when the test says so. */
+class ManualScheduler {
+  readonly queue: Array<() => void> = [];
+  readonly schedule = (draw: () => void): void => {
+    this.queue.push(draw);
+  };
+  flush(): number {
+    const pending = this.queue.splice(0, this.queue.length);
+    for (const fn of pending) fn();
+    return pending.length;
+  }
+}
+
+const VIEWPORT: ProfileViewport = { width: 800, height: 400, devicePixelRatio: 2 };
+
+const VIEW: ProfileView = {
+  centreChainage: 50,
+  centreHeight: 10,
+  pxPerChainage: 4,
+  pxPerHeight: 8,
+};
+
+const STYLE: ProfileSectionStyle = {
+  pointSizePx: 3,
+  pointAlpha: 1,
+  stationWidthPx: 1.5,
+  stationColour: 'rgb(20, 30, 40)',
+  stationAlpha: 0.5,
+};
+
+/**
+ * The transform, written out independently.
+ *
+ * Screen x grows with chainage; screen y is negated because height grows
+ * upward while canvas y grows downward.
+ */
+function expectedScreen(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  chainage: number,
+  height: number,
+): [number, number] {
+  return [
+    viewport.width / 2 + (chainage - view.centreChainage) * view.pxPerChainage,
+    viewport.height / 2 - (height - view.centreHeight) * view.pxPerHeight,
+  ];
+}
+
+function makePoints(chainage: number[], height: number[]): ProfileSectionPoints {
+  const n = chainage.length;
+  return {
+    count: n,
+    chainage: Float32Array.from(chainage),
+    height: Float64Array.from(height),
+    lateralOffset: new Float32Array(n),
+    sourceSlot: new Uint16Array(n),
+    pointIndex: Uint32Array.from(chainage.map((_, i) => i)),
+    channelPresence: new Uint8Array(n),
+  };
+}
+
+function scene(
+  points: ProfileSectionPoints,
+  indices: number[],
+  colours: number[],
+  stations?: ProfileSample[] | null,
+): ProfileSectionScene {
+  return {
+    points,
+    indices: Uint32Array.from(indices),
+    colours: Uint8Array.from(colours),
+    stations: stations ?? null,
+  };
+}
+
+function frameOf(
+  s: ProfileSectionScene,
+  view: ProfileView = VIEW,
+  viewport: ProfileViewport = VIEWPORT,
+  style: ProfileSectionStyle = STYLE,
+): ProfileSectionFrame {
+  return { scene: s, view, viewport, style };
+}
+
+function renderOnce(frame: ProfileSectionFrame): RecordingSurface {
+  const surface = new RecordingSurface();
+  const scheduler = new ManualScheduler();
+  const renderer = new ProfileSectionRenderer(surface, scheduler.schedule);
+  renderer.setFrame(frame);
+  renderer.renderNow();
+  return surface;
+}
+
+describe('ProfileSectionRenderer — observed returns', () => {
+  it('draws exactly the given indices, at the positions the transform defines', () => {
+    // Five returns, three of them drawn, deliberately out of order so a
+    // renderer that walked the point array instead of the index list is
+    // caught by both the count and the positions.
+    const points = makePoints([0, 10, 20, 30, 40], [1, 2, 3, 4, 5]);
+    const indices = [3, 0, 2];
+    const colours = [10, 11, 12, 20, 21, 22, 30, 31, 32];
+    const surface = renderOnce(frameOf(scene(points, indices, colours)));
+
+    const fills = surface.ctx.of('fillRect');
+    expect(fills).toHaveLength(indices.length);
+
+    const size = STYLE.pointSizePx;
+    indices.forEach((i, k) => {
+      const [x, y] = expectedScreen(
+        VIEW,
+        VIEWPORT,
+        Math.fround(points.chainage[i]!),
+        points.height[i]!,
+      );
+      expect(fills[k]!.args).toEqual([x - size / 2, y - size / 2, size, size]);
+    });
+
+    // Spot-check one of them against arithmetic done by hand, so the helper
+    // itself cannot drift unnoticed: index 3 is chainage 30, height 4.
+    // x = 400 + (30 - 50) * 4 = 320 ; y = 200 - (4 - 10) * 8 = 248.
+    expect(fills[0]!.args).toEqual([320 - 1.5, 248 - 1.5, 3, 3]);
+  });
+
+  it('pairs each drawn index with the colour triplet at its own position', () => {
+    const points = makePoints([0, 10, 20], [0, 0, 0]);
+    // Index list is not the identity, so pairing by index rather than by
+    // position gives different colours for every entry.
+    const indices = [2, 0, 1];
+    const colours = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const surface = renderOnce(frameOf(scene(points, indices, colours)));
+
+    const fills = surface.ctx.of('fillRect');
+    expect(fills.map((f) => f.fillStyle)).toEqual([
+      'rgb(1, 2, 3)',
+      'rgb(4, 5, 6)',
+      'rgb(7, 8, 9)',
+    ]);
+  });
+
+  it('assigns fillStyle only when the colour changes', () => {
+    const points = makePoints([0, 10, 20, 30], [0, 0, 0, 0]);
+    const colours = [5, 5, 5, 5, 5, 5, 9, 9, 9, 9, 9, 9];
+    const surface = renderOnce(frameOf(scene(points, [0, 1, 2, 3], colours)));
+    const fills = surface.ctx.of('fillRect');
+    expect(fills.map((f) => f.fillStyle)).toEqual([
+      'rgb(5, 5, 5)',
+      'rgb(5, 5, 5)',
+      'rgb(9, 9, 9)',
+      'rgb(9, 9, 9)',
+    ]);
+  });
+
+  it('truncates rather than reading past a colour array shorter than the index list', () => {
+    const points = makePoints([0, 10, 20], [0, 0, 0]);
+    const surface = renderOnce(frameOf(scene(points, [0, 1, 2], [1, 2, 3, 4, 5, 6])));
+    expect(surface.ctx.of('fillRect')).toHaveLength(2);
+  });
+
+  it('skips an index that is out of range for the section', () => {
+    const points = makePoints([0, 10], [0, 0]);
+    const surface = renderOnce(frameOf(scene(points, [0, 7], [1, 1, 1, 2, 2, 2])));
+    expect(surface.ctx.of('fillRect')).toHaveLength(1);
+  });
+
+  it('creates no per-return DOM: only 2D drawing calls are ever issued', () => {
+    expect(typeof document).toBe('undefined');
+    const points = makePoints([0, 10, 20], [1, 2, 3]);
+    const stations: ProfileSample[] = [
+      { distance: 0, height: 1 },
+      { distance: 10, height: 2 },
+    ];
+    const surface = renderOnce(
+      frameOf(scene(points, [0, 1, 2], [1, 1, 1, 2, 2, 2, 3, 3, 3], stations)),
+    );
+    const allowed = new Set([
+      'setTransform',
+      'clearRect',
+      'fillRect',
+      'beginPath',
+      'moveTo',
+      'lineTo',
+      'stroke',
+    ]);
+    expect(surface.ctx.names().every((n) => allowed.has(n))).toBe(true);
+    expect(surface.ctx.ops.length).toBeGreaterThan(0);
+  });
+});
+
+describe('ProfileSectionRenderer — device pixel ratio', () => {
+  it('sizes the backing store in device pixels and scales the transform by the ratio', () => {
+    const points = makePoints([50], [10]);
+    const surface = renderOnce(frameOf(scene(points, [0], [255, 0, 0])));
+
+    // 800 x 400 CSS at DPR 2.
+    expect(surface.sizes).toEqual([[1600, 800]]);
+    const transform = surface.ctx.of('setTransform');
+    expect(transform).toHaveLength(1);
+    expect(transform[0]!.args).toEqual([2, 0, 0, 2, 0, 0]);
+    // The clear is in CSS pixels, because the transform already carries DPR.
+    expect(surface.ctx.of('clearRect')[0]!.args).toEqual([0, 0, 800, 400]);
+  });
+
+  it('keeps CSS-pixel geometry identical across ratios while the backing store changes', () => {
+    const points = makePoints([20, 60], [4, 16]);
+    const s = scene(points, [0, 1], [1, 1, 1, 2, 2, 2]);
+    const at1 = renderOnce(frameOf(s, VIEW, { width: 800, height: 400, devicePixelRatio: 1 }));
+    const at3 = renderOnce(frameOf(s, VIEW, { width: 800, height: 400, devicePixelRatio: 3 }));
+
+    expect(at1.sizes).toEqual([[800, 400]]);
+    expect(at3.sizes).toEqual([[2400, 1200]]);
+    expect(at1.ctx.of('setTransform')[0]!.args).toEqual([1, 0, 0, 1, 0, 0]);
+    expect(at3.ctx.of('setTransform')[0]!.args).toEqual([3, 0, 0, 3, 0, 0]);
+    expect(at3.ctx.of('fillRect').map((f) => f.args)).toEqual(
+      at1.ctx.of('fillRect').map((f) => f.args),
+    );
+  });
+
+  it('falls back to a ratio of one when the reported ratio is not usable', () => {
+    const points = makePoints([50], [10]);
+    const surface = renderOnce(
+      frameOf(scene(points, [0], [1, 1, 1]), VIEW, {
+        width: 800,
+        height: 400,
+        devicePixelRatio: Number.NaN,
+      }),
+    );
+    expect(surface.sizes).toEqual([[800, 400]]);
+    expect(surface.ctx.of('setTransform')[0]!.args).toEqual([1, 0, 0, 1, 0, 0]);
+  });
+
+  it('resizes the backing store only when the device size actually changes', () => {
+    const surface = new RecordingSurface();
+    const scheduler = new ManualScheduler();
+    const renderer = new ProfileSectionRenderer(surface, scheduler.schedule);
+    const points = makePoints([50], [10]);
+    renderer.setFrame(frameOf(scene(points, [0], [1, 1, 1])));
+    renderer.renderNow();
+    renderer.renderNow();
+    expect(surface.sizes).toHaveLength(1);
+
+    renderer.setFrame(
+      frameOf(scene(points, [0], [1, 1, 1]), VIEW, {
+        width: 800,
+        height: 400,
+        devicePixelRatio: 1,
+      }),
+    );
+    renderer.renderNow();
+    expect(surface.sizes).toEqual([
+      [1600, 800],
+      [800, 400],
+    ]);
+  });
+});
+
+describe('ProfileSectionRenderer — derived station overlay', () => {
+  const points = makePoints([0], [10]);
+  const oneReturn = [0];
+  const oneColour = [255, 255, 255];
+
+  it('draws straight segments between adjacent samples', () => {
+    const stations: ProfileSample[] = [
+      { distance: 0, height: 4, count: 9 },
+      { distance: 25, height: 8, count: 7 },
+      { distance: 50, height: 6, count: 5 },
+    ];
+    const surface = renderOnce(
+      frameOf(scene(points, oneReturn, oneColour, stations)),
+    );
+
+    expect(surface.ctx.of('stroke')).toHaveLength(1);
+    expect(surface.ctx.of('beginPath')).toHaveLength(1);
+    const moves = surface.ctx.of('moveTo');
+    const lines = surface.ctx.of('lineTo');
+    expect(moves).toHaveLength(1);
+    expect(lines).toHaveLength(2);
+    expect(moves[0]!.args).toEqual(expectedScreen(VIEW, VIEWPORT, 0, 4));
+    expect(lines[0]!.args).toEqual(expectedScreen(VIEW, VIEWPORT, 25, 8));
+    expect(lines[1]!.args).toEqual(expectedScreen(VIEW, VIEWPORT, 50, 6));
+  });
+
+  it('breaks the run at a NaN height instead of interpolating across it', () => {
+    const stations: ProfileSample[] = [
+      { distance: 0, height: 4, count: 3 },
+      { distance: 10, height: 5, count: 2 },
+      { distance: 20, height: Number.NaN, count: 0 },
+      { distance: 30, height: 7, count: 4 },
+      { distance: 40, height: 8, count: 6 },
+    ];
+    const surface = renderOnce(frameOf(scene(points, oneReturn, oneColour, stations)));
+
+    // Two runs, not one path.
+    expect(surface.ctx.of('stroke')).toHaveLength(2);
+    expect(surface.ctx.of('beginPath')).toHaveLength(2);
+    const moves = surface.ctx.of('moveTo');
+    expect(moves).toHaveLength(2);
+    expect(moves[0]!.args).toEqual(expectedScreen(VIEW, VIEWPORT, 0, 4));
+    expect(moves[1]!.args).toEqual(expectedScreen(VIEW, VIEWPORT, 30, 7));
+
+    // No segment spans the gap: the only lineTo endpoints are the second
+    // sample of each run, and none of them is reached from across the gap.
+    const lines = surface.ctx.of('lineTo');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]!.args).toEqual(expectedScreen(VIEW, VIEWPORT, 10, 5));
+    expect(lines[1]!.args).toEqual(expectedScreen(VIEW, VIEWPORT, 40, 8));
+
+    // The path structure, read in order, is two closed-off runs.
+    const path = surface.ctx.names().filter((n) => n !== 'fillRect');
+    expect(path).toEqual([
+      'setTransform',
+      'clearRect',
+      'beginPath',
+      'moveTo',
+      'lineTo',
+      'stroke',
+      'beginPath',
+      'moveTo',
+      'lineTo',
+      'stroke',
+    ]);
+  });
+
+  it('leaves an isolated station between two gaps unstroked', () => {
+    const stations: ProfileSample[] = [
+      { distance: 0, height: Number.NaN, count: 0 },
+      { distance: 10, height: 5, count: 1 },
+      { distance: 20, height: Number.NaN, count: 0 },
+    ];
+    const surface = renderOnce(frameOf(scene(points, oneReturn, oneColour, stations)));
+    expect(surface.ctx.of('stroke')).toHaveLength(0);
+    expect(surface.ctx.of('lineTo')).toHaveLength(0);
+  });
+
+  it('draws nothing extra when no station series is supplied', () => {
+    const surface = renderOnce(frameOf(scene(points, oneReturn, oneColour, null)));
+    expect(surface.ctx.of('stroke')).toHaveLength(0);
+    expect(surface.ctx.of('beginPath')).toHaveLength(0);
+  });
+
+  it('draws the derived overlay after every observed return', () => {
+    const many = makePoints([0, 10, 20, 30], [1, 2, 3, 4]);
+    const stations: ProfileSample[] = [
+      { distance: 0, height: 4 },
+      { distance: 30, height: 6 },
+    ];
+    const surface = renderOnce(
+      frameOf(
+        scene(many, [0, 1, 2, 3], [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4], stations),
+      ),
+    );
+    const names = surface.ctx.names();
+    const lastFill = names.lastIndexOf('fillRect');
+    const firstPath = names.indexOf('beginPath');
+    expect(lastFill).toBeGreaterThanOrEqual(0);
+    expect(firstPath).toBeGreaterThanOrEqual(0);
+    expect(lastFill).toBeLessThan(firstPath);
+    expect(names.indexOf('stroke')).toBeGreaterThan(lastFill);
+  });
+
+  it('keeps the derived overlay subordinate to the returns it came from', () => {
+    const stations: ProfileSample[] = [
+      { distance: 0, height: 4 },
+      { distance: 30, height: 6 },
+    ];
+    const loud: ProfileSectionStyle = { ...STYLE, stationAlpha: 1 };
+    const surface = renderOnce(
+      frameOf(scene(points, oneReturn, oneColour, stations), VIEW, VIEWPORT, loud),
+    );
+    const strokes = surface.ctx.of('stroke');
+    const fills = surface.ctx.of('fillRect');
+    expect(strokes[0]!.globalAlpha).toBe(MAX_STATION_ALPHA);
+    expect(strokes[0]!.globalAlpha).toBeLessThan(fills[0]!.globalAlpha);
+    expect(strokes[0]!.strokeStyle).toBe(STYLE.stationColour);
+    expect(strokes[0]!.lineWidth).toBe(STYLE.stationWidthPx);
+  });
+});
+
+describe('ProfileSectionRenderer — coalescing', () => {
+  it('turns several invalidations in one frame into a single draw', () => {
+    const surface = new RecordingSurface();
+    const scheduler = new ManualScheduler();
+    const renderer = new ProfileSectionRenderer(surface, scheduler.schedule);
+    renderer.setFrame(frameOf(scene(makePoints([0], [0]), [0], [1, 1, 1])));
+
+    renderer.requestRender();
+    renderer.requestRender();
+    renderer.requestRender();
+    expect(scheduler.queue).toHaveLength(1);
+    expect(renderer.pending).toBe(true);
+    expect(renderer.drawCount).toBe(0);
+
+    expect(scheduler.flush()).toBe(1);
+    expect(renderer.drawCount).toBe(1);
+    expect(renderer.pending).toBe(false);
+    expect(surface.ctx.of('clearRect')).toHaveLength(1);
+  });
+
+  it('accepts a fresh invalidation after the frame has run', () => {
+    const surface = new RecordingSurface();
+    const scheduler = new ManualScheduler();
+    const renderer = new ProfileSectionRenderer(surface, scheduler.schedule);
+    renderer.setFrame(frameOf(scene(makePoints([0], [0]), [0], [1, 1, 1])));
+
+    renderer.requestRender();
+    scheduler.flush();
+    renderer.requestRender();
+    renderer.requestRender();
+    expect(scheduler.queue).toHaveLength(1);
+    scheduler.flush();
+    expect(renderer.drawCount).toBe(2);
+  });
+
+  it('schedules one more frame when an invalidation is raised during a draw', () => {
+    const surface = new RecordingSurface();
+    const scheduler = new ManualScheduler();
+    const renderer = new ProfileSectionRenderer(surface, scheduler.schedule);
+    renderer.setFrame(frameOf(scene(makePoints([0], [0]), [0], [1, 1, 1])));
+
+    let reentered = false;
+    const originalSetBackingSize = surface.setBackingSize.bind(surface);
+    surface.setBackingSize = (w: number, h: number): void => {
+      originalSetBackingSize(w, h);
+      if (!reentered) {
+        reentered = true;
+        renderer.requestRender();
+      }
+    };
+
+    renderer.requestRender();
+    scheduler.flush();
+    expect(renderer.drawCount).toBe(1);
+    expect(scheduler.queue).toHaveLength(1);
+    scheduler.flush();
+    expect(renderer.drawCount).toBe(2);
+  });
+
+  it('draws nothing before a frame has been set', () => {
+    const surface = new RecordingSurface();
+    const scheduler = new ManualScheduler();
+    const renderer = new ProfileSectionRenderer(surface, scheduler.schedule);
+    renderer.renderNow();
+    expect(surface.ctx.ops).toHaveLength(0);
+    expect(renderer.drawCount).toBe(0);
+  });
+});
+
+describe('ProfileSectionRenderer — non-finite input', () => {
+  it('skips returns whose coordinates are not finite and keeps the rest', () => {
+    const points = makePoints([0, Number.NaN, 20], [1, 2, Number.POSITIVE_INFINITY]);
+    const surface = renderOnce(
+      frameOf(scene(points, [0, 1, 2], [1, 1, 1, 2, 2, 2, 3, 3, 3])),
+    );
+    const fills = surface.ctx.of('fillRect');
+    expect(fills).toHaveLength(1);
+    expect(fills[0]!.fillStyle).toBe('rgb(1, 1, 1)');
+  });
+
+  it('neither throws nor draws when the view scales are not finite', () => {
+    const points = makePoints([0, 10, 20], [1, 2, 3]);
+    const stations: ProfileSample[] = [
+      { distance: 0, height: 1 },
+      { distance: 10, height: 2 },
+    ];
+    const brokenView: ProfileView = {
+      centreChainage: Number.NaN,
+      centreHeight: 0,
+      pxPerChainage: Number.POSITIVE_INFINITY,
+      pxPerHeight: Number.NaN,
+    };
+    const surface = renderOnce(
+      frameOf(scene(points, [0, 1, 2], [1, 1, 1, 2, 2, 2, 3, 3, 3], stations), brokenView),
+    );
+    expect(surface.ctx.of('fillRect')).toHaveLength(0);
+    expect(surface.ctx.of('stroke')).toHaveLength(0);
+    // The frame still completes: the surface was sized and cleared.
+    expect(surface.ctx.of('clearRect')).toHaveLength(1);
+  });
+
+  it('survives a viewport whose size is not usable', () => {
+    const points = makePoints([0], [0]);
+    const surface = renderOnce(
+      frameOf(scene(points, [0], [1, 1, 1]), VIEW, {
+        width: Number.NaN,
+        height: -5,
+        devicePixelRatio: 2,
+      }),
+    );
+    expect(surface.sizes).toEqual([[2, 2]]);
+    expect(surface.ctx.of('clearRect')[0]!.args).toEqual([0, 0, 1, 1]);
+  });
+
+  it('clamps an unusable splat size rather than drawing an unbounded rectangle', () => {
+    const points = makePoints([50, 50], [10, 10]);
+    const bad: ProfileSectionStyle = { ...STYLE, pointSizePx: Number.NaN };
+    const huge: ProfileSectionStyle = { ...STYLE, pointSizePx: 1e9 };
+    const a = renderOnce(frameOf(scene(points, [0], [1, 1, 1]), VIEW, VIEWPORT, bad));
+    const b = renderOnce(frameOf(scene(points, [0], [1, 1, 1]), VIEW, VIEWPORT, huge));
+    expect(a.ctx.of('fillRect')[0]!.args[2]).toBe(1);
+    expect(b.ctx.of('fillRect')[0]!.args[2]).toBe(64);
+  });
+
+  it('terminates on a large index list', () => {
+    const n = 20000;
+    const chainage: number[] = [];
+    const height: number[] = [];
+    for (let i = 0; i < n; i++) {
+      chainage.push(i * 0.01);
+      height.push((i % 17) * 0.5);
+    }
+    const points = makePoints(chainage, height);
+    const indices: number[] = [];
+    const colours: number[] = [];
+    for (let i = 0; i < n; i++) {
+      indices.push(i);
+      colours.push(i & 255, (i >> 3) & 255, (i >> 6) & 255);
+    }
+    const surface = renderOnce(frameOf(scene(points, indices, colours)));
+    expect(surface.ctx.of('fillRect')).toHaveLength(n);
+  });
+});

--- a/tests/profileViewTransform.test.ts
+++ b/tests/profileViewTransform.test.ts
@@ -1,0 +1,299 @@
+/**
+ * profileViewTransform.test.ts
+ *
+ * The section viewport transform, its inverse, and vertical exaggeration.
+ *
+ * Exaggeration is asserted in physical terms: the pixels a metre occupies
+ * vertically over the pixels a metre occupies horizontally. Asserting the
+ * ratio of the two axis scales instead would pass even when the axes are in
+ * different units, which is the case the ratio exists to get right.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  fitProfileView,
+  profileDataToScreen,
+  profileScreenToData,
+  panProfileView,
+  zoomProfileViewAt,
+  viewExaggeration,
+  canStateExaggeration,
+  profileVisibleBounds,
+  toDevicePixels,
+  MIN_DATA_SPAN,
+  type ProfileViewport,
+  type ProfileDataBounds,
+  type ProfileUnitContext,
+  type ProfileView,
+} from '../src/render/measure/profileViewTransform';
+
+const VP: ProfileViewport = { width: 800, height: 300, devicePixelRatio: 2 };
+const BOUNDS: ProfileDataBounds = {
+  minChainage: 0,
+  maxChainage: 200,
+  minHeight: 120,
+  maxHeight: 150,
+};
+const METRES: ProfileUnitContext = { horizontalToMetres: 1, verticalToMetres: 1 };
+const FEET_H: ProfileUnitContext = { horizontalToMetres: 0.3048, verticalToMetres: 1 };
+const UNKNOWN_V: ProfileUnitContext = { horizontalToMetres: 1, verticalToMetres: null };
+
+const s = new Float64Array(2);
+const d = new Float64Array(2);
+
+/** Pixels a physical metre occupies on each axis. */
+function pxPerMetre(view: ProfileView, u: ProfileUnitContext): [number, number] {
+  return [view.pxPerChainage / u.horizontalToMetres!, view.pxPerHeight / u.verticalToMetres!];
+}
+
+describe('fit', () => {
+  it('puts the data extent in the viewport and centres it', () => {
+    const v = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    expect(v.centreChainage).toBe(100);
+    expect(v.centreHeight).toBe(135);
+    profileDataToScreen(v, VP, 0, 150, s);
+    expect(s[0]).toBeCloseTo(0, 9);
+    expect(s[1]).toBeCloseTo(0, 9);
+    profileDataToScreen(v, VP, 200, 120, s);
+    expect(s[0]).toBeCloseTo(800, 9);
+    expect(s[1]).toBeCloseTo(300, 9);
+  });
+
+  it('scales the axes independently and claims no ratio', () => {
+    const v = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    expect(v.pxPerChainage).toBeCloseTo(4, 9);
+    expect(v.pxPerHeight).toBeCloseTo(10, 9);
+  });
+});
+
+describe('round trip', () => {
+  const v = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+  it('returns the same data point through screen space', () => {
+    for (let i = 0; i < 500; i++) {
+      const g = (i * 0.6180339887498949) % 1;
+      const c = BOUNDS.minChainage + g * 200;
+      const h = BOUNDS.minHeight + ((i * 7 * 0.6180339887498949) % 1) * 30;
+      profileDataToScreen(v, VP, c, h, s);
+      profileScreenToData(v, VP, s[0]!, s[1]!, d);
+      expect(d[0]).toBeCloseTo(c, 9);
+      expect(d[1]).toBeCloseTo(h, 9);
+    }
+  });
+
+  it('maps height upward on screen', () => {
+    profileDataToScreen(v, VP, 100, 140, s);
+    const high = s[1]!;
+    profileDataToScreen(v, VP, 100, 130, s);
+    expect(s[1]!).toBeGreaterThan(high);
+  });
+});
+
+describe('pan and zoom', () => {
+  const base = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+
+  it('pans by exactly the screen delta', () => {
+    const p = panProfileView(base, 40, -25);
+    profileDataToScreen(base, VP, 100, 135, s);
+    const before = [s[0]!, s[1]!];
+    profileDataToScreen(p, VP, 100, 135, s);
+    expect(s[0]! - before[0]!).toBeCloseTo(40, 9);
+    expect(s[1]! - before[1]!).toBeCloseTo(-25, 9);
+  });
+
+  it('holds the data under the cursor fixed while zooming', () => {
+    for (const [ax, ay] of [
+      [0, 0],
+      [800, 300],
+      [137, 42],
+      [400, 150],
+    ]) {
+      profileScreenToData(base, VP, ax!, ay!, d);
+      const anchored = [d[0]!, d[1]!];
+      let v = base;
+      for (let i = 0; i < 6; i++) v = zoomProfileViewAt(v, VP, ax!, ay!, 1.2);
+      profileScreenToData(v, VP, ax!, ay!, d);
+      expect(d[0]).toBeCloseTo(anchored[0]!, 6);
+      expect(d[1]).toBeCloseTo(anchored[1]!, 6);
+    }
+  });
+
+  it('zooming out then in returns the original scale', () => {
+    let v = zoomProfileViewAt(base, VP, 300, 100, 1.2);
+    v = zoomProfileViewAt(v, VP, 300, 100, 1 / 1.2);
+    expect(v.pxPerChainage).toBeCloseTo(base.pxPerChainage, 9);
+    expect(v.pxPerHeight).toBeCloseTo(base.pxPerHeight, 9);
+    expect(v.centreChainage).toBeCloseTo(base.centreChainage, 6);
+  });
+
+  it('ignores a non-finite or non-positive zoom factor', () => {
+    expect(zoomProfileViewAt(base, VP, 100, 100, Number.NaN)).toBe(base);
+    expect(zoomProfileViewAt(base, VP, 100, 100, 0)).toBe(base);
+    expect(zoomProfileViewAt(base, VP, 100, 100, -2)).toBe(base);
+  });
+});
+
+describe('true vertical exaggeration', () => {
+  for (const ratio of [1, 2, 5, 10]) {
+    it(`VE ${ratio}x gives a metre ${ratio}x the pixels vertically`, () => {
+      const v = fitProfileView(BOUNDS, VP, { kind: 've', ratio }, METRES)!;
+      const [mx, my] = pxPerMetre(v, METRES);
+      expect(my / mx).toBeCloseTo(ratio, 9);
+      expect(viewExaggeration(v, METRES)).toBeCloseTo(ratio, 9);
+    });
+
+    it(`VE ${ratio}x holds when the axes are in different units`, () => {
+      // Chainage in feet, height in metres. Comparing the two axis scales
+      // directly would be wrong by 1/0.3048 here.
+      const v = fitProfileView(BOUNDS, VP, { kind: 've', ratio }, FEET_H)!;
+      const [mx, my] = pxPerMetre(v, FEET_H);
+      expect(my / mx).toBeCloseTo(ratio, 9);
+      expect(viewExaggeration(v, FEET_H)).toBeCloseTo(ratio, 9);
+      // The raw axis-scale ratio is a different number, so the test above is
+      // not measuring the same thing twice.
+      expect(v.pxPerHeight / v.pxPerChainage).not.toBeCloseTo(ratio, 3);
+    });
+  }
+
+  it('contains the whole extent rather than cropping to hold the ratio', () => {
+    for (const ratio of [1, 2, 5, 10]) {
+      const v = fitProfileView(BOUNDS, VP, { kind: 've', ratio }, METRES)!;
+      const vis = profileVisibleBounds(v, VP);
+      expect(vis.minChainage).toBeLessThanOrEqual(BOUNDS.minChainage + 1e-9);
+      expect(vis.maxChainage).toBeGreaterThanOrEqual(BOUNDS.maxChainage - 1e-9);
+      expect(vis.minHeight).toBeLessThanOrEqual(BOUNDS.minHeight + 1e-9);
+      expect(vis.maxHeight).toBeGreaterThanOrEqual(BOUNDS.maxHeight - 1e-9);
+    }
+  });
+
+  it('survives a zoom', () => {
+    let v = fitProfileView(BOUNDS, VP, { kind: 've', ratio: 5 }, METRES)!;
+    for (let i = 0; i < 5; i++) v = zoomProfileViewAt(v, VP, 250, 90, 1.2);
+    expect(viewExaggeration(v, METRES)).toBeCloseTo(5, 9);
+  });
+
+  it('refuses a ratio when a unit scale is unknown', () => {
+    expect(canStateExaggeration(UNKNOWN_V)).toBe(false);
+    expect(fitProfileView(BOUNDS, VP, { kind: 've', ratio: 2 }, UNKNOWN_V)).toBeNull();
+    const fit = fitProfileView(BOUNDS, VP, { kind: 'fit' }, UNKNOWN_V)!;
+    expect(viewExaggeration(fit, UNKNOWN_V)).toBeNull();
+  });
+
+  it('refuses a ratio that is not a positive number', () => {
+    for (const r of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(fitProfileView(BOUNDS, VP, { kind: 've', ratio: r }, METRES)).toBeNull();
+    }
+  });
+
+  it('refuses a unit scale that is zero or negative', () => {
+    expect(canStateExaggeration({ horizontalToMetres: 0, verticalToMetres: 1 })).toBe(false);
+    expect(canStateExaggeration({ horizontalToMetres: 1, verticalToMetres: -1 })).toBe(false);
+  });
+});
+
+describe('degenerate and hostile input', () => {
+  it('handles a flat section without dividing by zero', () => {
+    const flat: ProfileDataBounds = {
+      minChainage: 0,
+      maxChainage: 200,
+      minHeight: 137.5,
+      maxHeight: 137.5,
+    };
+    const v = fitProfileView(flat, VP, { kind: 'fit' }, METRES)!;
+    expect(Number.isFinite(v.pxPerHeight)).toBe(true);
+    expect(v.pxPerHeight).toBeGreaterThan(0);
+    expect(v.centreHeight).toBe(137.5);
+    profileDataToScreen(v, VP, 100, 137.5, s);
+    expect(Number.isFinite(s[0]!)).toBe(true);
+    expect(Number.isFinite(s[1]!)).toBe(true);
+  });
+
+  it('handles a single-point section on both axes', () => {
+    const pt: ProfileDataBounds = {
+      minChainage: 42,
+      maxChainage: 42,
+      minHeight: 7,
+      maxHeight: 7,
+    };
+    const v = fitProfileView(pt, VP, { kind: 'fit' }, METRES)!;
+    expect(Number.isFinite(v.pxPerChainage)).toBe(true);
+    expect(Number.isFinite(v.pxPerHeight)).toBe(true);
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+  });
+
+  it('keeps a huge chainage span finite', () => {
+    const huge: ProfileDataBounds = {
+      minChainage: -1e15,
+      maxChainage: 1e15,
+      minHeight: 0,
+      maxHeight: 1e12,
+    };
+    const v = fitProfileView(huge, VP, { kind: 'fit' }, METRES)!;
+    expect(Number.isFinite(v.pxPerChainage)).toBe(true);
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+    profileDataToScreen(v, VP, 0, 0, s);
+    expect(Number.isFinite(s[0]!)).toBe(true);
+    expect(Number.isFinite(s[1]!)).toBe(true);
+  });
+
+  it('produces a finite view from non-finite bounds', () => {
+    const bad: ProfileDataBounds = {
+      minChainage: Number.NaN,
+      maxChainage: Number.POSITIVE_INFINITY,
+      minHeight: Number.NEGATIVE_INFINITY,
+      maxHeight: Number.NaN,
+    };
+    const v = fitProfileView(bad, VP, { kind: 'fit' }, METRES)!;
+    for (const n of [v.centreChainage, v.centreHeight, v.pxPerChainage, v.pxPerHeight]) {
+      expect(Number.isFinite(n)).toBe(true);
+    }
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+  });
+
+  it('produces a finite view from a zero-sized viewport', () => {
+    const v = fitProfileView(BOUNDS, { width: 0, height: 0, devicePixelRatio: 1 }, { kind: 'fit' }, METRES)!;
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+    expect(Number.isFinite(v.pxPerHeight)).toBe(true);
+  });
+
+  it('ignores a non-finite pan delta', () => {
+    const base = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    const p = panProfileView(base, Number.NaN, Number.POSITIVE_INFINITY);
+    expect(p.centreChainage).toBe(base.centreChainage);
+    expect(p.centreHeight).toBe(base.centreHeight);
+  });
+
+  it('gives a degenerate axis the documented minimum span', () => {
+    const flat: ProfileDataBounds = {
+      minChainage: 5,
+      maxChainage: 5,
+      minHeight: 0,
+      maxHeight: 10,
+    };
+    const v = fitProfileView(flat, VP, { kind: 'fit' }, METRES)!;
+    expect(v.pxPerChainage).toBeCloseTo(VP.width / MIN_DATA_SPAN, 0);
+  });
+});
+
+describe('device pixels', () => {
+  it('scales by the backing ratio', () => {
+    expect(toDevicePixels(VP, 10)).toBe(20);
+  });
+  it('falls back to 1 for a bad ratio', () => {
+    expect(toDevicePixels({ width: 10, height: 10, devicePixelRatio: 0 }, 10)).toBe(10);
+    expect(toDevicePixels({ width: 10, height: 10, devicePixelRatio: Number.NaN }, 10)).toBe(10);
+  });
+});
+
+describe('resize', () => {
+  it('keeps the centre and rescales the fit', () => {
+    const small = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    const wide = fitProfileView(
+      BOUNDS,
+      { width: 1600, height: 300, devicePixelRatio: 2 },
+      { kind: 'fit' },
+      METRES,
+    )!;
+    expect(wide.centreChainage).toBe(small.centreChainage);
+    expect(wide.pxPerChainage).toBeCloseTo(small.pxPerChainage * 2, 9);
+    expect(wide.pxPerHeight).toBeCloseTo(small.pxPerHeight, 9);
+  });
+});


### PR DESCRIPTION
Stacked on #506 and #509, which it carries.

Batched `fillRect` rather than `putImageData`: a corridor holds roughly 1e3 to 1e5 returns, while an 800x400 plot at DPR 2 is 3.84 M device pixels per frame whatever the count.

The backing store is device pixels and the transform puts later coordinates in CSS pixels.

The station overlay strokes only between adjacent finite samples, so a coverage gap opens a new path. It draws after the splats with capped alpha, so the derived line cannot dominate the observed returns.

Colour arrives from the caller.
