### PR TITLE
Export the accepted corridor returns, not the reduced series

### DIFF
--- a/src/render/measure/profileReturnsCsv.ts
+++ b/src/render/measure/profileReturnsCsv.ts
@@ -68,12 +68,16 @@ export interface ProfileReturnsSource {
   /** Octree node id (`"depth-x-y-z"`) when the slot is a streaming node. */
   readonly streamingNodeKey?: string;
   /**
-   * xyz-interleaved world positions in this source's OWN index space, so a
-   * row's coordinates are read at its `source_point_index`. Absent means the
-   * caller did not supply coordinates for this layer, and the x/y/z cells
-   * stay blank rather than being reconstructed from the section frame.
+   * Reads this source's coordinate at its OWN point index into `out[0..2]`,
+   * returning false when the index carries no coordinate.
+   *
+   * A reader rather than an array, so the frame a row's x/y/z is written in
+   * is the one the caller resolved rather than whatever a raw buffer happens
+   * to hold. Absent means the caller supplied no coordinates for this layer,
+   * and the x/y/z cells stay blank rather than being reconstructed from the
+   * section frame.
    */
-  readonly positions?: Float64Array | Float32Array;
+  readonly readXYZ?: (index: number, out: Float64Array) => boolean;
 }
 
 export interface ProfileReturnsCsvOptions {
@@ -226,7 +230,9 @@ export function buildProfileReturnsCsv(
     options.verticalReference === 'orthometric' ? 'elevation' : 'height';
 
   const hasStation = metresPerUnit !== null;
-  const hasXyz = options.sources.some((s) => s.positions !== undefined);
+  const hasXyz = options.sources.some((s) => s.readXYZ !== undefined);
+  // Reused across every row, so a full export allocates nothing per point.
+  const xyzScratch = new Float64Array(3);
   const hasStreamingKey = options.sources.some((s) => s.streamingNodeKey !== undefined);
   const hasIntensity = points.intensity !== undefined;
   const hasClassification = points.classification !== undefined;
@@ -287,13 +293,12 @@ export function buildProfileReturnsCsv(
     if (hasStreamingKey) row.push(src?.streamingNodeKey ? csvText(src.streamingNodeKey) : '');
 
     if (hasXyz) {
-      const pos = src?.positions;
-      // A short/misaligned array writes blanks rather than reading a
+      // A reader that declines the index writes blanks rather than putting a
       // neighbouring point's coordinates into this row.
-      const ok = pos !== undefined && (idx + 1) * 3 <= pos.length;
-      row.push(ok ? csvNumber(pos[idx * 3]!, COORD_DECIMALS) : '');
-      row.push(ok ? csvNumber(pos[idx * 3 + 1]!, COORD_DECIMALS) : '');
-      row.push(ok ? csvNumber(pos[idx * 3 + 2]!, COORD_DECIMALS) : '');
+      const ok = src?.readXYZ !== undefined && src.readXYZ(idx, xyzScratch);
+      row.push(ok ? csvNumber(xyzScratch[0]!, COORD_DECIMALS) : '');
+      row.push(ok ? csvNumber(xyzScratch[1]!, COORD_DECIMALS) : '');
+      row.push(ok ? csvNumber(xyzScratch[2]!, COORD_DECIMALS) : '');
     }
 
     if (hasIntensity) {

--- a/src/render/measure/profileReturnsCsv.ts
+++ b/src/render/measure/profileReturnsCsv.ts
@@ -1,0 +1,387 @@
+/**
+ * profileReturnsCsv.ts
+ *
+ * Export the returns a profile corridor actually accepted, one row per return.
+ *
+ * The station CSV (`buildProfileCsv`) is a REDUCTION: one robust height per
+ * station bin. It answers "what is the ground doing here", and it throws away
+ * the returns the estimate was derived from. This export is the other half —
+ * the accepted set itself, each return still carrying the layer and source
+ * index it came from and only the attributes its own source really had.
+ *
+ * Three properties this file exists to hold:
+ *
+ *   - An absent channel stays absent. A source that carries no intensity
+ *     writes an empty cell, never `0`; a measured intensity of 0 and a
+ *     missing one have to stay different values in the file, because a
+ *     spreadsheet cannot recover the difference afterwards. Presence is read
+ *     per point from `channelPresence`, so a section mixing an RGB source
+ *     with a non-RGB one is written honestly row by row.
+ *
+ *   - The file is the FULL accepted set. A caller may pass the indices it is
+ *     currently drawing (visual LOD thins what is on screen); that count is
+ *     recorded in the receipt and never removes a row. An export that
+ *     silently shipped the drawn subset would be a different measurement
+ *     from the one the panel reported.
+ *
+ *   - The height column is named for what the vertical datum supports. Only
+ *     an `orthometric` reference earns `elevation`; every other reference
+ *     writes `height`, the same split `heightLabel` (geo/height.ts) applies
+ *     to the inspector row and `buildProfileCsv` applies to its own header.
+ *
+ * The metadata receipt is a SIDECAR JSON, not a comment block. `toXyz` in
+ * io/exporters.ts states the rule this follows: a CSV never gets comment
+ * lines, because a naive parser must see the header row first.
+ *
+ * Pure and deterministic. `generatedAt` is a parameter, so the same inputs
+ * always produce the same bytes.
+ */
+
+import type { UnitSystem } from './types';
+import { formatStation } from './profileSummary';
+import { classificationLabel } from '../pointInfo';
+import { heightLabel, heightReferenceNote, type VerticalReference } from '../../geo/height';
+import { profileSectionHas, type ProfileSectionPoints } from './profileSectionBuilder';
+
+/** Receipt/format version stamped into the sidecar. */
+export const PROFILE_RETURNS_RECEIPT_VERSION = 1;
+
+/**
+ * Where a source's classification codes came from.
+ *
+ * `source` = the producer wrote them; `derived` = OLV's heuristic classifier
+ * did. Taken from the layer's own metadata (`classificationIsDerived` on the
+ * cloud), never inferred from the codes themselves: a derived classifier
+ * emits the same ASPRS numbers a producer does, so the value carries no
+ * evidence about its own origin. `none` = the layer classifies nothing.
+ */
+export type ClassificationProvenance = 'source' | 'derived' | 'none';
+
+/** One contributing layer, keyed by the slot its returns were pushed under. */
+export interface ProfileReturnsSource {
+  /** The slot passed to `ProfileSectionBuilder.beginSource`. */
+  readonly slot: number;
+  readonly layerId: string;
+  readonly layerName: string;
+  /** Classification provenance for THIS layer; absent reads as unknown. */
+  readonly classificationSource?: ClassificationProvenance;
+  /** Octree node id (`"depth-x-y-z"`) when the slot is a streaming node. */
+  readonly streamingNodeKey?: string;
+  /**
+   * xyz-interleaved world positions in this source's OWN index space, so a
+   * row's coordinates are read at its `source_point_index`. Absent means the
+   * caller did not supply coordinates for this layer, and the x/y/z cells
+   * stay blank rather than being reconstructed from the section frame.
+   */
+  readonly positions?: Float64Array | Float32Array;
+}
+
+export interface ProfileReturnsCsvOptions {
+  readonly measurementId: string;
+  readonly measurementName: string;
+  /** Section endpoints in the project frame. */
+  readonly a: readonly [number, number, number];
+  readonly b: readonly [number, number, number];
+  /** Up axis; normalised into the receipt, so the caller's scale is irrelevant. */
+  readonly up: readonly [number, number, number];
+  /** Corridor half width, in the same unit as the section geometry. */
+  readonly corridorHalfWidth: number;
+  readonly verticalReference: VerticalReference;
+  readonly sources: readonly ProfileReturnsSource[];
+  /** ISO timestamp from the caller. The builder never reads a clock. */
+  readonly generatedAt: string;
+  /** Station notation. Metric km+m, imperial 100-ft. Default metric. */
+  readonly system?: UnitSystem;
+  /**
+   * Metres per section unit. Civil stationing is defined on a real length,
+   * so with no known scale the `station` column is omitted rather than
+   * labelling raw render units as chainage in metres.
+   */
+  readonly unitToMetres?: number;
+  /** Display name of the section unit, for the receipt. */
+  readonly unitName?: string;
+  readonly crsName?: string;
+  /** Whether the viewer was drawing a thinned set when the export was taken. */
+  readonly visualLodInUse?: boolean;
+  /**
+   * The section indices currently DRAWN. Recorded in the receipt as
+   * `displayedCount` and read for nothing else — it can never remove a row.
+   */
+  readonly displayedIndices?: ArrayLike<number>;
+}
+
+export interface ProfileReturnsSourceReceipt {
+  readonly slot: number;
+  readonly layerId: string;
+  readonly layerName: string;
+  readonly classificationSource: ClassificationProvenance | 'unknown';
+  readonly streamingNodeKey?: string;
+  /** Returns this layer contributed to the accepted set. */
+  readonly acceptedCount: number;
+}
+
+export interface ProfileReturnsReceipt {
+  readonly kind: 'profile-returns';
+  readonly version: number;
+  readonly measurement: { readonly id: string; readonly name: string };
+  readonly endpoints: {
+    readonly a: readonly [number, number, number];
+    readonly b: readonly [number, number, number];
+  };
+  /** The up axis after normalisation. */
+  readonly up: readonly [number, number, number];
+  readonly corridorHalfWidth: number;
+  readonly sources: readonly ProfileReturnsSourceReceipt[];
+  /** Rows in the CSV. Always the full accepted set. */
+  readonly acceptedCount: number;
+  /** Returns drawn at export time, or null when the caller passed none. */
+  readonly displayedCount: number | null;
+  readonly visualLodInUse: boolean;
+  readonly vertical: {
+    readonly reference: VerticalReference;
+    readonly column: 'height' | 'elevation';
+    readonly label: string;
+    readonly note: string;
+  };
+  readonly units: {
+    readonly system: UnitSystem;
+    readonly unitName: string | null;
+    readonly metresPerUnit: number | null;
+    readonly crs: string | null;
+  };
+  readonly columns: readonly string[];
+  readonly generatedAt: string;
+}
+
+export interface ProfileReturnsCsvResult {
+  readonly csv: string;
+  readonly receipt: ProfileReturnsReceipt;
+  /** The sidecar, pretty-printed like the GeoJSON export. */
+  readonly receiptJson: string;
+}
+
+/**
+ * Escape a TEXT cell per RFC 4180 and neutralise spreadsheet formula
+ * injection — the same rule `csvCell` applies in export/measurementExport.ts.
+ * A cell beginning `= + - @` or a tab/CR is executed as a formula by Excel and
+ * Sheets, and a layer name is file data, so it gets a literal `'` prefix and
+ * is force-quoted to keep it.
+ */
+function csvText(v: string): string {
+  const neutralise = /^[=+\-@\t\r]/.test(v);
+  const cell = neutralise ? `'${v}` : v;
+  return neutralise || /[",\n\r]/.test(cell) ? `"${cell.replaceAll(/"/g, '""')}"` : cell;
+}
+
+/**
+ * A NUMERIC cell. Never neutralised, so `-1.500` stays a plain number rather
+ * than becoming the text `'-1.500` — the same carve-out `csvCell` makes by
+ * only neutralising `typeof v === 'string'`.
+ */
+function csvNumber(v: number, decimals: number): string {
+  return Number.isFinite(v) ? v.toFixed(decimals) : '';
+}
+
+/** An integer channel value. */
+function csvInt(v: number): string {
+  return Number.isFinite(v) ? String(v) : '';
+}
+
+/** Millimetre precision, matching `coord()` in io/exporters.ts. */
+const COORD_DECIMALS = 3;
+
+function normalise(up: readonly [number, number, number]): [number, number, number] {
+  const len = Math.hypot(up[0], up[1], up[2]);
+  if (!Number.isFinite(len) || len === 0) return [0, 0, 1];
+  return [up[0] / len, up[1] / len, up[2] / len];
+}
+
+/**
+ * Build the returns CSV and its sidecar receipt.
+ *
+ * Every column is present only when the inputs support it: a channel no
+ * source carried is left out of the header entirely, and a channel some but
+ * not all sources carried is present with blank cells where it is absent.
+ */
+export function buildProfileReturnsCsv(
+  points: ProfileSectionPoints,
+  options: ProfileReturnsCsvOptions,
+): ProfileReturnsCsvResult {
+  const n = points.count;
+  const system: UnitSystem = options.system ?? 'metric';
+  const metresPerUnit =
+    typeof options.unitToMetres === 'number' &&
+    Number.isFinite(options.unitToMetres) &&
+    options.unitToMetres > 0
+      ? options.unitToMetres
+      : null;
+
+  const bySlot = new Map<number, ProfileReturnsSource>();
+  for (const s of options.sources) bySlot.set(s.slot, s);
+
+  // Only an orthometric reference asserts a sea-level datum, so only it earns
+  // the name `elevation`. Ellipsoidal, depth, local and unknown all write
+  // `height`, which claims nothing the source did not carry.
+  const heightColumn: 'height' | 'elevation' =
+    options.verticalReference === 'orthometric' ? 'elevation' : 'height';
+
+  const hasStation = metresPerUnit !== null;
+  const hasXyz = options.sources.some((s) => s.positions !== undefined);
+  const hasStreamingKey = options.sources.some((s) => s.streamingNodeKey !== undefined);
+  const hasIntensity = points.intensity !== undefined;
+  const hasClassification = points.classification !== undefined;
+  const hasClassSource =
+    hasClassification &&
+    options.sources.some(
+      (s) => s.classificationSource === 'source' || s.classificationSource === 'derived',
+    );
+  const hasReturnNumber = points.returnNumber !== undefined;
+  const hasReturnCount = points.returnCount !== undefined;
+  const hasPointSourceId = points.pointSourceId !== undefined;
+  const hasGpsTime = points.gpsTime !== undefined;
+  const hasRgb = points.rgb !== undefined;
+
+  const columns: string[] = [
+    ...(hasStation ? ['station'] : []),
+    'chainage',
+    heightColumn,
+    'lateral_offset',
+    'layer_id',
+    'layer_name',
+    'source_point_index',
+    ...(hasStreamingKey ? ['streaming_node_key'] : []),
+    ...(hasXyz ? ['x', 'y', 'z'] : []),
+    ...(hasIntensity ? ['intensity'] : []),
+    ...(hasClassification ? ['classification', 'classification_label'] : []),
+    ...(hasClassSource ? ['classification_source'] : []),
+    ...(hasReturnNumber ? ['return_number'] : []),
+    ...(hasReturnCount ? ['return_count'] : []),
+    ...(hasPointSourceId ? ['point_source_id'] : []),
+    ...(hasGpsTime ? ['gps_time'] : []),
+    ...(hasRgb ? ['r', 'g', 'b'] : []),
+  ];
+
+  const lines: string[] = [columns.join(',')];
+  const acceptedPerSlot = new Map<number, number>();
+
+  for (let i = 0; i < n; i++) {
+    const slot = points.sourceSlot[i]!;
+    const src = bySlot.get(slot);
+    const idx = points.pointIndex[i]!;
+    const chainage = points.chainage[i]!;
+    acceptedPerSlot.set(slot, (acceptedPerSlot.get(slot) ?? 0) + 1);
+
+    const row: string[] = [];
+    if (hasStation) {
+      row.push(
+        Number.isFinite(chainage) ? csvText(formatStation(chainage * metresPerUnit!, system)) : '',
+      );
+    }
+    row.push(csvNumber(chainage, COORD_DECIMALS));
+    row.push(csvNumber(points.height[i]!, COORD_DECIMALS));
+    row.push(csvNumber(points.lateralOffset[i]!, COORD_DECIMALS));
+    row.push(src ? csvText(src.layerId) : '');
+    row.push(src ? csvText(src.layerName) : '');
+    row.push(csvInt(idx));
+
+    if (hasStreamingKey) row.push(src?.streamingNodeKey ? csvText(src.streamingNodeKey) : '');
+
+    if (hasXyz) {
+      const pos = src?.positions;
+      // A short/misaligned array writes blanks rather than reading a
+      // neighbouring point's coordinates into this row.
+      const ok = pos !== undefined && (idx + 1) * 3 <= pos.length;
+      row.push(ok ? csvNumber(pos[idx * 3]!, COORD_DECIMALS) : '');
+      row.push(ok ? csvNumber(pos[idx * 3 + 1]!, COORD_DECIMALS) : '');
+      row.push(ok ? csvNumber(pos[idx * 3 + 2]!, COORD_DECIMALS) : '');
+    }
+
+    if (hasIntensity) {
+      row.push(
+        profileSectionHas(points, i, 'intensity') ? csvInt(points.intensity![i]!) : '',
+      );
+    }
+
+    if (hasClassification) {
+      const present = profileSectionHas(points, i, 'classification');
+      const code = points.classification![i]!;
+      row.push(present ? csvInt(code) : '');
+      row.push(present ? csvText(classificationLabel(code)) : '');
+    }
+
+    if (hasClassSource) {
+      const provenance = src?.classificationSource;
+      const usable =
+        profileSectionHas(points, i, 'classification') &&
+        (provenance === 'source' || provenance === 'derived');
+      row.push(usable ? provenance : '');
+    }
+
+    if (hasReturnNumber) {
+      row.push(
+        profileSectionHas(points, i, 'returnNumber') ? csvInt(points.returnNumber![i]!) : '',
+      );
+    }
+    if (hasReturnCount) {
+      row.push(profileSectionHas(points, i, 'returnCount') ? csvInt(points.returnCount![i]!) : '');
+    }
+    if (hasPointSourceId) {
+      row.push(
+        profileSectionHas(points, i, 'pointSourceId') ? csvInt(points.pointSourceId![i]!) : '',
+      );
+    }
+    if (hasGpsTime) {
+      // GPS time is a large seconds value whose fraction carries the pulse
+      // ordering, so it keeps six decimals rather than the spatial three.
+      row.push(profileSectionHas(points, i, 'gpsTime') ? csvNumber(points.gpsTime![i]!, 6) : '');
+    }
+    if (hasRgb) {
+      const present = profileSectionHas(points, i, 'rgb');
+      row.push(present ? csvInt(points.rgb![i * 3]!) : '');
+      row.push(present ? csvInt(points.rgb![i * 3 + 1]!) : '');
+      row.push(present ? csvInt(points.rgb![i * 3 + 2]!) : '');
+    }
+
+    lines.push(row.join(','));
+  }
+
+  const receipt: ProfileReturnsReceipt = {
+    kind: 'profile-returns',
+    version: PROFILE_RETURNS_RECEIPT_VERSION,
+    measurement: { id: options.measurementId, name: options.measurementName },
+    endpoints: { a: [...options.a] as [number, number, number], b: [...options.b] as [number, number, number] },
+    up: normalise(options.up),
+    corridorHalfWidth: options.corridorHalfWidth,
+    sources: options.sources.map((s) => ({
+      slot: s.slot,
+      layerId: s.layerId,
+      layerName: s.layerName,
+      classificationSource: s.classificationSource ?? 'unknown',
+      ...(s.streamingNodeKey !== undefined ? { streamingNodeKey: s.streamingNodeKey } : {}),
+      acceptedCount: acceptedPerSlot.get(s.slot) ?? 0,
+    })),
+    acceptedCount: n,
+    displayedCount: options.displayedIndices ? options.displayedIndices.length : null,
+    visualLodInUse: options.visualLodInUse ?? false,
+    vertical: {
+      reference: options.verticalReference,
+      column: heightColumn,
+      label: heightLabel(options.verticalReference),
+      note: heightReferenceNote(options.verticalReference),
+    },
+    units: {
+      system,
+      unitName: options.unitName ?? null,
+      metresPerUnit,
+      crs: options.crsName ?? null,
+    },
+    columns,
+    generatedAt: options.generatedAt,
+  };
+
+  return {
+    csv: lines.join('\n') + '\n',
+    receipt,
+    receiptJson: JSON.stringify(receipt, null, 2),
+  };
+}

--- a/src/render/measure/profileSectionBuilder.ts
+++ b/src/render/measure/profileSectionBuilder.ts
@@ -1,0 +1,276 @@
+/**
+ * profileSectionBuilder.ts
+ *
+ * Accumulate the returns accepted by a profile corridor into compact typed
+ * arrays, keeping each return's identity and only the attributes its own
+ * source actually carries.
+ *
+ * The derived series reduces a corridor to one height per station. The
+ * section keeps the returns themselves, so every accepted point has to stay
+ * traceable to the source and index it came from, and an attribute that a
+ * source does not carry has to stay absent rather than becoming zero. A
+ * fabricated zero intensity is indistinguishable from a measured one.
+ *
+ * Presence is recorded per point, not per snapshot. A section can mix a
+ * source that carries RGB with one that does not, so `channelPresence`
+ * carries one bit per attribute per point and a consumer reads a channel
+ * only where its bit is set.
+ *
+ * Storage grows by doubling and is copied out at `finish()`, so the
+ * finished arrays are sized to the accepted count rather than to the
+ * scanned count.
+ */
+
+/** The per-point attributes a section can carry through from a source. */
+export type ProfileAttribute =
+  | 'rgb'
+  | 'intensity'
+  | 'classification'
+  | 'returnNumber'
+  | 'returnCount'
+  | 'pointSourceId'
+  | 'gpsTime'
+  | 'normals';
+
+/** Bit position of each attribute inside `channelPresence`. */
+export const PROFILE_ATTRIBUTE_BIT: Readonly<Record<ProfileAttribute, number>> = {
+  rgb: 1 << 0,
+  intensity: 1 << 1,
+  classification: 1 << 2,
+  returnNumber: 1 << 3,
+  returnCount: 1 << 4,
+  pointSourceId: 1 << 5,
+  gpsTime: 1 << 6,
+  normals: 1 << 7,
+};
+
+export const PROFILE_ATTRIBUTES: readonly ProfileAttribute[] = [
+  'rgb',
+  'intensity',
+  'classification',
+  'returnNumber',
+  'returnCount',
+  'pointSourceId',
+  'gpsTime',
+  'normals',
+];
+
+/**
+ * The channels one source carries, aligned to that source's point index.
+ *
+ * A channel is absent when the source does not carry it. A channel whose
+ * length disagrees with the source's point count is treated as absent, the
+ * same rule `sampleProfile` applies to a misaligned classification array.
+ */
+export interface ProfileSourceChannels {
+  readonly rgb?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  readonly pointSourceId?: Uint16Array;
+  readonly gpsTime?: Float64Array;
+  readonly normals?: Float32Array;
+}
+
+/** Accepted returns, as struct-of-arrays. All arrays share one index space. */
+export interface ProfileSectionPoints {
+  readonly count: number;
+  readonly chainage: Float32Array;
+  readonly height: Float32Array;
+  readonly lateralOffset: Float32Array;
+  readonly sourceSlot: Uint16Array;
+  readonly pointIndex: Uint32Array;
+  /** One bit per {@link ProfileAttribute}; see {@link PROFILE_ATTRIBUTE_BIT}. */
+  readonly channelPresence: Uint8Array;
+  readonly rgb?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  readonly pointSourceId?: Uint16Array;
+  readonly gpsTime?: Float64Array;
+  readonly normals?: Float32Array;
+}
+
+const INITIAL_CAPACITY = 1024;
+
+function grow<T extends { length: number }>(
+  arr: T,
+  capacity: number,
+  make: (n: number) => T,
+  stride: number,
+): T {
+  const next = make(capacity * stride);
+  (next as unknown as { set(a: T): void }).set(arr);
+  return next;
+}
+
+/**
+ * Collect accepted returns from one or more sources.
+ *
+ * Call {@link beginSource} before the points of each source, then
+ * {@link push} per accepted return, then {@link finish} once.
+ */
+export class ProfileSectionBuilder {
+  private _count = 0;
+  private _capacity = INITIAL_CAPACITY;
+
+  private _chainage = new Float32Array(INITIAL_CAPACITY);
+  private _height = new Float32Array(INITIAL_CAPACITY);
+  private _lateral = new Float32Array(INITIAL_CAPACITY);
+  private _slot = new Uint16Array(INITIAL_CAPACITY);
+  private _index = new Uint32Array(INITIAL_CAPACITY);
+  private _presence = new Uint8Array(INITIAL_CAPACITY);
+
+  private _rgb = new Uint8Array(INITIAL_CAPACITY * 3);
+  private _intensity = new Uint16Array(INITIAL_CAPACITY);
+  private _classification = new Uint8Array(INITIAL_CAPACITY);
+  private _returnNumber = new Uint8Array(INITIAL_CAPACITY);
+  private _returnCount = new Uint8Array(INITIAL_CAPACITY);
+  private _pointSourceId = new Uint16Array(INITIAL_CAPACITY);
+  private _gpsTime = new Float64Array(INITIAL_CAPACITY);
+  private _normals = new Float32Array(INITIAL_CAPACITY * 3);
+
+  /** Attributes seen on at least one source, so only those are emitted. */
+  private _seen = 0;
+
+  private _srcSlot = 0;
+  private _srcChannels: ProfileSourceChannels | null = null;
+  private _srcMask = 0;
+
+  /**
+   * Bind the source whose returns follow.
+   *
+   * `pointCount` is the source's own point count. A channel whose length
+   * disagrees with it is dropped for that source, which keeps a misaligned
+   * array from shifting every attribute by one index.
+   */
+  beginSource(slot: number, channels: ProfileSourceChannels | null, pointCount: number): void {
+    this._srcSlot = slot;
+    this._srcChannels = channels;
+    let mask = 0;
+    if (channels) {
+      if (channels.rgb?.length === pointCount * 3) mask |= PROFILE_ATTRIBUTE_BIT.rgb;
+      if (channels.intensity?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.intensity;
+      if (channels.classification?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.classification;
+      if (channels.returnNumber?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.returnNumber;
+      if (channels.returnCount?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.returnCount;
+      if (channels.pointSourceId?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.pointSourceId;
+      if (channels.gpsTime?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.gpsTime;
+      if (channels.normals?.length === pointCount * 3) mask |= PROFILE_ATTRIBUTE_BIT.normals;
+    }
+    this._srcMask = mask;
+    this._seen |= mask;
+  }
+
+  /** Number of returns accepted so far. */
+  get count(): number {
+    return this._count;
+  }
+
+  private _reserve(): void {
+    if (this._count < this._capacity) return;
+    const next = this._capacity * 2;
+    this._chainage = grow(this._chainage, next, (n) => new Float32Array(n), 1);
+    this._height = grow(this._height, next, (n) => new Float32Array(n), 1);
+    this._lateral = grow(this._lateral, next, (n) => new Float32Array(n), 1);
+    this._slot = grow(this._slot, next, (n) => new Uint16Array(n), 1);
+    this._index = grow(this._index, next, (n) => new Uint32Array(n), 1);
+    this._presence = grow(this._presence, next, (n) => new Uint8Array(n), 1);
+    this._rgb = grow(this._rgb, next, (n) => new Uint8Array(n), 3);
+    this._intensity = grow(this._intensity, next, (n) => new Uint16Array(n), 1);
+    this._classification = grow(this._classification, next, (n) => new Uint8Array(n), 1);
+    this._returnNumber = grow(this._returnNumber, next, (n) => new Uint8Array(n), 1);
+    this._returnCount = grow(this._returnCount, next, (n) => new Uint8Array(n), 1);
+    this._pointSourceId = grow(this._pointSourceId, next, (n) => new Uint16Array(n), 1);
+    this._gpsTime = grow(this._gpsTime, next, (n) => new Float64Array(n), 1);
+    this._normals = grow(this._normals, next, (n) => new Float32Array(n), 3);
+    this._capacity = next;
+  }
+
+  /**
+   * Append one accepted return.
+   *
+   * `sourceIndex` is the point's index in the bound source, and it is what
+   * every channel is read at, so an attribute can never be read from a
+   * different point than the one being appended.
+   */
+  push(sourceIndex: number, chainage: number, height: number, lateralOffset: number): void {
+    this._reserve();
+    const i = this._count;
+    this._chainage[i] = chainage;
+    this._height[i] = height;
+    this._lateral[i] = lateralOffset;
+    this._slot[i] = this._srcSlot;
+    this._index[i] = sourceIndex;
+    this._presence[i] = this._srcMask;
+
+    const c = this._srcChannels;
+    if (c) {
+      const m = this._srcMask;
+      if (m & PROFILE_ATTRIBUTE_BIT.rgb) {
+        this._rgb[i * 3] = c.rgb![sourceIndex * 3];
+        this._rgb[i * 3 + 1] = c.rgb![sourceIndex * 3 + 1];
+        this._rgb[i * 3 + 2] = c.rgb![sourceIndex * 3 + 2];
+      }
+      if (m & PROFILE_ATTRIBUTE_BIT.intensity) this._intensity[i] = c.intensity![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.classification)
+        this._classification[i] = c.classification![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.returnNumber)
+        this._returnNumber[i] = c.returnNumber![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.returnCount)
+        this._returnCount[i] = c.returnCount![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.pointSourceId)
+        this._pointSourceId[i] = c.pointSourceId![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.gpsTime) this._gpsTime[i] = c.gpsTime![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.normals) {
+        this._normals[i * 3] = c.normals![sourceIndex * 3];
+        this._normals[i * 3 + 1] = c.normals![sourceIndex * 3 + 1];
+        this._normals[i * 3 + 2] = c.normals![sourceIndex * 3 + 2];
+      }
+    }
+    this._count++;
+  }
+
+  /**
+   * Copy out arrays sized to the accepted count.
+   *
+   * A channel is emitted only when some source carried it. A channel no
+   * source carried is absent from the result rather than present and zero.
+   */
+  finish(): ProfileSectionPoints {
+    const n = this._count;
+    const seen = this._seen;
+    const has = (a: ProfileAttribute): boolean => (seen & PROFILE_ATTRIBUTE_BIT[a]) !== 0;
+    return {
+      count: n,
+      chainage: this._chainage.slice(0, n),
+      height: this._height.slice(0, n),
+      lateralOffset: this._lateral.slice(0, n),
+      sourceSlot: this._slot.slice(0, n),
+      pointIndex: this._index.slice(0, n),
+      channelPresence: this._presence.slice(0, n),
+      ...(has('rgb') ? { rgb: this._rgb.slice(0, n * 3) } : {}),
+      ...(has('intensity') ? { intensity: this._intensity.slice(0, n) } : {}),
+      ...(has('classification') ? { classification: this._classification.slice(0, n) } : {}),
+      ...(has('returnNumber') ? { returnNumber: this._returnNumber.slice(0, n) } : {}),
+      ...(has('returnCount') ? { returnCount: this._returnCount.slice(0, n) } : {}),
+      ...(has('pointSourceId') ? { pointSourceId: this._pointSourceId.slice(0, n) } : {}),
+      ...(has('gpsTime') ? { gpsTime: this._gpsTime.slice(0, n) } : {}),
+      ...(has('normals') ? { normals: this._normals.slice(0, n * 3) } : {}),
+    };
+  }
+}
+
+/** True when point `i` carries attribute `a`. */
+export function profileSectionHas(
+  points: ProfileSectionPoints,
+  i: number,
+  a: ProfileAttribute,
+): boolean {
+  return (points.channelPresence[i]! & PROFILE_ATTRIBUTE_BIT[a]) !== 0;
+}

--- a/src/render/measure/profileSectionBuilder.ts
+++ b/src/render/measure/profileSectionBuilder.ts
@@ -77,7 +77,17 @@ export interface ProfileSourceChannels {
 export interface ProfileSectionPoints {
   readonly count: number;
   readonly chainage: Float32Array;
-  readonly height: Float32Array;
+  /**
+   * Height along `up`, float64.
+   *
+   * Chainage and lateral offset are section relative and bounded by the
+   * section length plus the corridor half width, where float32 resolves
+   * below a millimetre. Height is absolute in the project frame, so it
+   * carries whatever magnitude the frame has: float32 spacing is 3.2e-2 m at
+   * 1e6 and 6.4e-1 m at 1e7. The placement was resolved in float64 during
+   * the read, and storing the result narrower would discard that.
+   */
+  readonly height: Float64Array;
   readonly lateralOffset: Float32Array;
   readonly sourceSlot: Uint16Array;
   readonly pointIndex: Uint32Array;
@@ -117,7 +127,7 @@ export class ProfileSectionBuilder {
   private _capacity = INITIAL_CAPACITY;
 
   private _chainage = new Float32Array(INITIAL_CAPACITY);
-  private _height = new Float32Array(INITIAL_CAPACITY);
+  private _height = new Float64Array(INITIAL_CAPACITY);
   private _lateral = new Float32Array(INITIAL_CAPACITY);
   private _slot = new Uint16Array(INITIAL_CAPACITY);
   private _index = new Uint32Array(INITIAL_CAPACITY);
@@ -176,7 +186,7 @@ export class ProfileSectionBuilder {
     if (this._count < this._capacity) return;
     const next = this._capacity * 2;
     this._chainage = grow(this._chainage, next, (n) => new Float32Array(n), 1);
-    this._height = grow(this._height, next, (n) => new Float32Array(n), 1);
+    this._height = grow(this._height, next, (n) => new Float64Array(n), 1);
     this._lateral = grow(this._lateral, next, (n) => new Float32Array(n), 1);
     this._slot = grow(this._slot, next, (n) => new Uint16Array(n), 1);
     this._index = grow(this._index, next, (n) => new Uint32Array(n), 1);

--- a/tests/profileReturnsCsv.test.ts
+++ b/tests/profileReturnsCsv.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildProfileReturnsCsv,
+  type ProfileReturnsCsvOptions,
+  type ProfileReturnsSource,
+} from '../src/render/measure/profileReturnsCsv';
+import {
+  ProfileSectionBuilder,
+  type ProfileSectionPoints,
+  type ProfileSourceChannels,
+} from '../src/render/measure/profileSectionBuilder';
+import type { VerticalReference } from '../src/geo/height';
+
+const AT = '2026-08-23T00:00:00.000Z';
+
+/** Minimal RFC 4180 reader, so the round-trip test parses with no knowledge of the writer. */
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = '';
+  let quoted = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (quoted) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else quoted = false;
+      } else cell += c;
+      continue;
+    }
+    if (c === '"') quoted = true;
+    else if (c === ',') {
+      row.push(cell);
+      cell = '';
+    } else if (c === '\n') {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = '';
+    } else cell += c;
+  }
+  if (cell !== '' || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+  return rows;
+}
+
+function baseOptions(sources: readonly ProfileReturnsSource[]): ProfileReturnsCsvOptions {
+  return {
+    measurementId: 'm-1',
+    measurementName: 'Section A',
+    a: [0, 0, 0],
+    b: [10, 0, 0],
+    up: [0, 0, 2],
+    corridorHalfWidth: 1.5,
+    verticalReference: 'orthometric',
+    sources,
+    generatedAt: AT,
+    unitToMetres: 1,
+    unitName: 'metre',
+  };
+}
+
+/** A section whose two slots disagree about which channels they carry. */
+function mixedSection(): ProfileSectionPoints {
+  const b = new ProfileSectionBuilder();
+  const rich: ProfileSourceChannels = {
+    intensity: new Uint16Array([0, 7]),
+    classification: new Uint8Array([2, 5]),
+    returnNumber: new Uint8Array([1, 2]),
+    returnCount: new Uint8Array([2, 2]),
+    pointSourceId: new Uint16Array([11, 11]),
+    gpsTime: new Float64Array([100.5, 100.75]),
+    rgb: new Uint8Array([10, 20, 30, 40, 50, 60]),
+  };
+  b.beginSource(0, rich, 2);
+  b.push(0, 1, 100.25, -0.5);
+  b.push(1, 2, 101.5, 0.25);
+  // Second layer carries positions only — no attribute channels at all.
+  b.beginSource(1, null, 2);
+  b.push(0, 3, 102, 0.75);
+  return b.finish();
+}
+
+const MIXED_SOURCES: ProfileReturnsSource[] = [
+  {
+    slot: 0,
+    layerId: 'L0',
+    layerName: 'survey.laz',
+    classificationSource: 'source',
+    positions: new Float64Array([500000.111, 4000000.222, 100.25, 500001, 4000001, 101.5]),
+  },
+  { slot: 1, layerId: 'L1', layerName: 'scan.e57', classificationSource: 'none' },
+];
+
+function rowsOf(csv: string): { header: string[]; body: string[][] } {
+  const parsed = parseCsv(csv);
+  return { header: parsed[0]!, body: parsed.slice(1) };
+}
+
+function col(header: string[], body: string[][], name: string): string[] {
+  const i = header.indexOf(name);
+  expect(i, `column ${name} is missing`).toBeGreaterThanOrEqual(0);
+  return body.map((r) => r[i]!);
+}
+
+describe('profile returns CSV — absent channels', () => {
+  it('writes a blank cell for a channel a source does not carry, never a zero', () => {
+    const { csv } = buildProfileReturnsCsv(mixedSection(), baseOptions(MIXED_SOURCES));
+    const { header, body } = rowsOf(csv);
+    expect(body).toHaveLength(3);
+
+    // The distinction the whole export exists to preserve: an OBSERVED 0 and an
+    // ABSENT channel are different cells.
+    expect(col(header, body, 'intensity')).toEqual(['0', '7', '']);
+    expect(col(header, body, 'classification')).toEqual(['2', '5', '']);
+    expect(col(header, body, 'classification_label')).toEqual(['Ground', 'High vegetation', '']);
+    expect(col(header, body, 'return_number')).toEqual(['1', '2', '']);
+    expect(col(header, body, 'return_count')).toEqual(['2', '2', '']);
+    expect(col(header, body, 'point_source_id')).toEqual(['11', '11', '']);
+    expect(col(header, body, 'gps_time')).toEqual(['100.500000', '100.750000', '']);
+    expect(col(header, body, 'r')).toEqual(['10', '40', '']);
+    expect(col(header, body, 'g')).toEqual(['20', '50', '']);
+    expect(col(header, body, 'b')).toEqual(['30', '60', '']);
+  });
+
+  it('omits a column entirely when no source carries the channel', () => {
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, { intensity: new Uint16Array([5]) }, 1);
+    b.push(0, 0, 1, 0);
+    const { csv } = buildProfileReturnsCsv(
+      b.finish(),
+      baseOptions([{ slot: 0, layerId: 'L0', layerName: 'a.las' }]),
+    );
+    const { header } = rowsOf(csv);
+    expect(header).toContain('intensity');
+    for (const absent of ['classification', 'gps_time', 'return_number', 'r', 'g', 'b']) {
+      expect(header).not.toContain(absent);
+    }
+  });
+
+  it('leaves x/y/z blank for a layer that supplied no positions', () => {
+    const { csv } = buildProfileReturnsCsv(mixedSection(), baseOptions(MIXED_SOURCES));
+    const { header, body } = rowsOf(csv);
+    expect(col(header, body, 'x')).toEqual(['500000.111', '500001.000', '']);
+    expect(col(header, body, 'z')).toEqual(['100.250', '101.500', '']);
+  });
+});
+
+describe('profile returns CSV — full accepted set', () => {
+  it('exports every accepted return when a display subset is supplied', () => {
+    const section = mixedSection();
+    const full = buildProfileReturnsCsv(section, baseOptions(MIXED_SOURCES));
+    const thinned = buildProfileReturnsCsv(section, {
+      ...baseOptions(MIXED_SOURCES),
+      displayedIndices: new Uint32Array([0]),
+      visualLodInUse: true,
+    });
+
+    expect(rowsOf(full.csv).body).toHaveLength(section.count);
+    expect(rowsOf(thinned.csv).body).toHaveLength(section.count);
+    // The subset changes the RECEIPT and nothing else about the file.
+    expect(thinned.csv).toBe(full.csv);
+    expect(thinned.receipt.acceptedCount).toBe(3);
+    expect(thinned.receipt.displayedCount).toBe(1);
+    expect(thinned.receipt.visualLodInUse).toBe(true);
+    expect(full.receipt.displayedCount).toBeNull();
+  });
+
+  it('keeps a row for every return even when a huge display subset is passed', () => {
+    const section = mixedSection();
+    const { csv } = buildProfileReturnsCsv(section, {
+      ...baseOptions(MIXED_SOURCES),
+      displayedIndices: [0, 1, 2, 0, 1],
+    });
+    expect(rowsOf(csv).body).toHaveLength(3);
+  });
+});
+
+describe('profile returns CSV — vertical datum names the column', () => {
+  const cases: Array<[VerticalReference, string]> = [
+    ['orthometric', 'elevation'],
+    ['ellipsoidal', 'height'],
+    ['depth', 'height'],
+    ['local', 'height'],
+    ['unknown', 'height'],
+  ];
+  for (const [reference, expected] of cases) {
+    it(`names the column ${expected} for a ${reference} reference`, () => {
+      const { csv, receipt } = buildProfileReturnsCsv(mixedSection(), {
+        ...baseOptions(MIXED_SOURCES),
+        verticalReference: reference,
+      });
+      const { header } = rowsOf(csv);
+      expect(header).toContain(expected);
+      expect(header).not.toContain(expected === 'height' ? 'elevation' : 'height');
+      expect(receipt.vertical.column).toBe(expected);
+      expect(receipt.vertical.reference).toBe(reference);
+    });
+  }
+
+  it('never calls an undeclared datum an elevation', () => {
+    const { csv } = buildProfileReturnsCsv(mixedSection(), {
+      ...baseOptions(MIXED_SOURCES),
+      verticalReference: 'unknown',
+    });
+    expect(rowsOf(csv).header).not.toContain('elevation');
+  });
+});
+
+describe('profile returns CSV — classification provenance', () => {
+  it('reads producer versus derived from per-source metadata, not from the code', () => {
+    const b = new ProfileSectionBuilder();
+    const cls: ProfileSourceChannels = { classification: new Uint8Array([2]) };
+    b.beginSource(0, cls, 1);
+    b.push(0, 0, 1, 0);
+    b.beginSource(1, cls, 1);
+    b.push(0, 1, 2, 0);
+    const { csv } = buildProfileReturnsCsv(
+      b.finish(),
+      baseOptions([
+        { slot: 0, layerId: 'L0', layerName: 'producer.laz', classificationSource: 'source' },
+        { slot: 1, layerId: 'L1', layerName: 'guessed.laz', classificationSource: 'derived' },
+      ]),
+    );
+    const { header, body } = rowsOf(csv);
+    // Identical ASPRS code 2 in both rows; the provenance still differs.
+    expect(col(header, body, 'classification')).toEqual(['2', '2']);
+    expect(col(header, body, 'classification_source')).toEqual(['source', 'derived']);
+  });
+
+  it('omits the column when no layer declares a provenance', () => {
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, { classification: new Uint8Array([2]) }, 1);
+    b.push(0, 0, 1, 0);
+    const { csv } = buildProfileReturnsCsv(
+      b.finish(),
+      baseOptions([{ slot: 0, layerId: 'L0', layerName: 'a.las' }]),
+    );
+    const { header } = rowsOf(csv);
+    expect(header).toContain('classification');
+    expect(header).not.toContain('classification_source');
+  });
+});
+
+describe('profile returns CSV — receipt', () => {
+  it('records the measurement context and takes the timestamp as a parameter', () => {
+    const { receipt, receiptJson } = buildProfileReturnsCsv(mixedSection(), {
+      ...baseOptions(MIXED_SOURCES),
+      crsName: 'NAD83 / UTM zone 13N (EPSG:26913)',
+      displayedIndices: new Uint32Array([0, 1]),
+      visualLodInUse: true,
+    });
+    expect(receipt.measurement).toEqual({ id: 'm-1', name: 'Section A' });
+    expect(receipt.endpoints.a).toEqual([0, 0, 0]);
+    expect(receipt.endpoints.b).toEqual([10, 0, 0]);
+    expect(receipt.up).toEqual([0, 0, 1]); // normalised from [0,0,2]
+    expect(receipt.corridorHalfWidth).toBe(1.5);
+    expect(receipt.acceptedCount).toBe(3);
+    expect(receipt.displayedCount).toBe(2);
+    expect(receipt.visualLodInUse).toBe(true);
+    expect(receipt.units).toEqual({
+      system: 'metric',
+      unitName: 'metre',
+      metresPerUnit: 1,
+      crs: 'NAD83 / UTM zone 13N (EPSG:26913)',
+    });
+    expect(receipt.vertical.label).toBe('Elevation');
+    expect(receipt.sources.map((s) => [s.layerId, s.classificationSource, s.acceptedCount])).toEqual(
+      [
+        ['L0', 'source', 2],
+        ['L1', 'none', 1],
+      ],
+    );
+    expect(receipt.generatedAt).toBe(AT);
+    expect(JSON.parse(receiptJson).generatedAt).toBe(AT);
+  });
+
+  it('is byte-identical across builds with the same injected timestamp', () => {
+    const a = buildProfileReturnsCsv(mixedSection(), baseOptions(MIXED_SOURCES));
+    const b = buildProfileReturnsCsv(mixedSection(), baseOptions(MIXED_SOURCES));
+    expect(b.csv).toBe(a.csv);
+    expect(b.receiptJson).toBe(a.receiptJson);
+  });
+
+  it('carries the streaming node key when a slot is a streaming node', () => {
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, null, 1);
+    b.push(0, 0, 1, 0);
+    const { csv, receipt } = buildProfileReturnsCsv(
+      b.finish(),
+      baseOptions([
+        { slot: 0, layerId: 'L0', layerName: 'copc', streamingNodeKey: '3-1-2-0' },
+      ]),
+    );
+    const { header, body } = rowsOf(csv);
+    expect(col(header, body, 'streaming_node_key')).toEqual(['3-1-2-0']);
+    expect(receipt.sources[0]!.streamingNodeKey).toBe('3-1-2-0');
+  });
+
+  it('omits the station column when no metres-per-unit scale is known', () => {
+    const opts = baseOptions(MIXED_SOURCES);
+    const withScale = buildProfileReturnsCsv(mixedSection(), opts);
+    const withoutScale = buildProfileReturnsCsv(mixedSection(), {
+      ...opts,
+      unitToMetres: undefined,
+    });
+    expect(rowsOf(withScale.csv).header).toContain('station');
+    expect(col(rowsOf(withScale.csv).header, rowsOf(withScale.csv).body, 'station')).toEqual([
+      '0+001.00',
+      '0+002.00',
+      '0+003.00',
+    ]);
+    expect(rowsOf(withoutScale.csv).header).not.toContain('station');
+    expect(withoutScale.receipt.units.metresPerUnit).toBeNull();
+  });
+});
+
+describe('profile returns CSV — hostile text', () => {
+  for (const hostile of ['=HYPERLINK("http://x","c")', '+1+1', '-2+3', '@SUM(A1)']) {
+    it(`neutralises a layer name starting ${hostile[0]}`, () => {
+      const b = new ProfileSectionBuilder();
+      b.beginSource(0, null, 1);
+      b.push(0, 0, 1, 0);
+      const { csv } = buildProfileReturnsCsv(
+        b.finish(),
+        baseOptions([{ slot: 0, layerId: 'L0', layerName: hostile }]),
+      );
+      const { header, body } = rowsOf(csv);
+      const raw = csv.split('\n')[1]!;
+      // Force-quoted in the bytes, and the parsed value is prefixed so no
+      // spreadsheet evaluates it as a formula.
+      expect(raw).toContain(`"'${hostile.replaceAll('"', '""')}"`);
+      expect(col(header, body, 'layer_name')).toEqual([`'${hostile}`]);
+    });
+  }
+
+  it('leaves a negative number a plain number', () => {
+    const { csv } = buildProfileReturnsCsv(mixedSection(), baseOptions(MIXED_SOURCES));
+    const { header, body } = rowsOf(csv);
+    expect(col(header, body, 'lateral_offset')).toEqual(['-0.500', '0.250', '0.750']);
+    expect(csv).not.toContain("'-0.500");
+  });
+
+  it('round-trips a layer name holding a comma, a double quote and a newline', () => {
+    const nasty = 'Site, "north"\nblock';
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, { intensity: new Uint16Array([0, 3]) }, 2);
+    b.push(0, 0, 1, 0);
+    b.push(1, 5, 2, 0);
+    const { csv } = buildProfileReturnsCsv(
+      b.finish(),
+      baseOptions([{ slot: 0, layerId: 'L,0', layerName: nasty }]),
+    );
+    const { header, body } = rowsOf(csv);
+    expect(body).toHaveLength(2);
+    expect(col(header, body, 'layer_name')).toEqual([nasty, nasty]);
+    expect(col(header, body, 'layer_id')).toEqual(['L,0', 'L,0']);
+    // The embedded newline must not have split the row: the trailing columns
+    // still line up.
+    expect(col(header, body, 'intensity')).toEqual(['0', '3']);
+  });
+});
+
+describe('profile returns CSV — shape', () => {
+  it('puts the header first, uses LF, and ends with a newline', () => {
+    const { csv } = buildProfileReturnsCsv(mixedSection(), baseOptions(MIXED_SOURCES));
+    expect(csv.startsWith('station,chainage,elevation,lateral_offset,')).toBe(true);
+    expect(csv.endsWith('\n')).toBe(true);
+    expect(csv).not.toContain('\r');
+    // A CSV carries no comment lines; the receipt is the sidecar.
+    expect(csv.startsWith('#')).toBe(false);
+  });
+
+  it('gives every row the header cell count', () => {
+    const { csv } = buildProfileReturnsCsv(mixedSection(), baseOptions(MIXED_SOURCES));
+    const { header, body } = rowsOf(csv);
+    for (const r of body) expect(r).toHaveLength(header.length);
+  });
+
+  it('writes an empty body for an empty section', () => {
+    const { csv, receipt } = buildProfileReturnsCsv(
+      new ProfileSectionBuilder().finish(),
+      baseOptions([]),
+    );
+    expect(rowsOf(csv).body).toHaveLength(0);
+    expect(receipt.acceptedCount).toBe(0);
+  });
+});

--- a/tests/profileReturnsCsv.test.ts
+++ b/tests/profileReturnsCsv.test.ts
@@ -79,7 +79,7 @@ function mixedSection(): ProfileSectionPoints {
   b.beginSource(0, rich, 2);
   b.push(0, 1, 100.25, -0.5);
   b.push(1, 2, 101.5, 0.25);
-  // Second layer carries positions only — no attribute channels at all.
+  // Second layer carries coordinates only, no attribute channels at all.
   b.beginSource(1, null, 2);
   b.push(0, 3, 102, 0.75);
   return b.finish();
@@ -91,7 +91,14 @@ const MIXED_SOURCES: ProfileReturnsSource[] = [
     layerId: 'L0',
     layerName: 'survey.laz',
     classificationSource: 'source',
-    positions: new Float64Array([500000.111, 4000000.222, 100.25, 500001, 4000001, 101.5]),
+    readXYZ: (index: number, out: Float64Array): boolean => {
+      const coords = [500000.111, 4000000.222, 100.25, 500001, 4000001, 101.5];
+      if ((index + 1) * 3 > coords.length) return false;
+      out[0] = coords[index * 3]!;
+      out[1] = coords[index * 3 + 1]!;
+      out[2] = coords[index * 3 + 2]!;
+      return true;
+    },
   },
   { slot: 1, layerId: 'L1', layerName: 'scan.e57', classificationSource: 'none' },
 ];
@@ -142,7 +149,7 @@ describe('profile returns CSV — absent channels', () => {
     }
   });
 
-  it('leaves x/y/z blank for a layer that supplied no positions', () => {
+  it('leaves x/y/z blank for a layer that supplied no coordinates', () => {
     const { csv } = buildProfileReturnsCsv(mixedSection(), baseOptions(MIXED_SOURCES));
     const { header, body } = rowsOf(csv);
     expect(col(header, body, 'x')).toEqual(['500000.111', '500001.000', '']);

--- a/tests/profileSectionBuilder.test.ts
+++ b/tests/profileSectionBuilder.test.ts
@@ -1,0 +1,211 @@
+/**
+ * profileSectionBuilder.test.ts
+ *
+ * Attribute integrity for the section builder.
+ *
+ * Every channel value is a distinct function of (slot, sourceIndex), so a
+ * value read one index off, or read from the wrong source, produces a number
+ * that cannot occur at that position. Checking a constant fill would not
+ * separate those failures from a correct read.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ProfileSectionBuilder,
+  profileSectionHas,
+  PROFILE_ATTRIBUTE_BIT,
+  type ProfileSourceChannels,
+} from '../src/render/measure/profileSectionBuilder';
+
+/** Channel values keyed so a one-index shift changes every one of them. */
+const intensityAt = (slot: number, i: number): number => 1000 * (slot + 1) + i * 7;
+const classAt = (slot: number, i: number): number => (slot * 31 + i * 13) % 256;
+const rgbAt = (slot: number, i: number, c: number): number => (slot * 17 + i * 5 + c * 61) % 256;
+const gpsAt = (slot: number, i: number): number => slot * 1e6 + i * 0.001;
+const retNumAt = (slot: number, i: number): number => ((i + slot * 2) % 5) + 1;
+const retCntAt = (slot: number, i: number): number => ((i + slot) % 4) + 1;
+const psidAt = (slot: number, i: number): number => 7000 + slot * 100 + (i % 90);
+const normAt = (slot: number, i: number, c: number): number => slot + i * 0.25 + c * 0.125;
+
+function channelsFor(slot: number, n: number, which: Set<string>): ProfileSourceChannels {
+  const out: Record<string, unknown> = {};
+  if (which.has('rgb')) {
+    const a = new Uint8Array(n * 3);
+    for (let i = 0; i < n; i++) for (let c = 0; c < 3; c++) a[i * 3 + c] = rgbAt(slot, i, c);
+    out.rgb = a;
+  }
+  if (which.has('intensity')) {
+    const a = new Uint16Array(n);
+    for (let i = 0; i < n; i++) a[i] = intensityAt(slot, i);
+    out.intensity = a;
+  }
+  if (which.has('classification')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = classAt(slot, i);
+    out.classification = a;
+  }
+  if (which.has('returnNumber')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = retNumAt(slot, i);
+    out.returnNumber = a;
+  }
+  if (which.has('returnCount')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = retCntAt(slot, i);
+    out.returnCount = a;
+  }
+  if (which.has('pointSourceId')) {
+    const a = new Uint16Array(n);
+    for (let i = 0; i < n; i++) a[i] = psidAt(slot, i);
+    out.pointSourceId = a;
+  }
+  if (which.has('gpsTime')) {
+    const a = new Float64Array(n);
+    for (let i = 0; i < n; i++) a[i] = gpsAt(slot, i);
+    out.gpsTime = a;
+  }
+  if (which.has('normals')) {
+    const a = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) for (let c = 0; c < 3; c++) a[i * 3 + c] = normAt(slot, i, c);
+    out.normals = a;
+  }
+  return out as ProfileSourceChannels;
+}
+
+describe('section builder keeps every attribute on its own point', () => {
+  it('carries a full channel set through unshifted, past a growth boundary', () => {
+    // Accepting every third of 9000 gives 3000 returns, which crosses the
+    // 1024 doubling threshold and then 2048, so the reallocation path runs
+    // rather than only the initial buffer.
+    const n = 9000;
+    const all = new Set([
+      'rgb',
+      'intensity',
+      'classification',
+      'returnNumber',
+      'returnCount',
+      'pointSourceId',
+      'gpsTime',
+      'normals',
+    ]);
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, channelsFor(0, n, all), n);
+    // Accept every third point so source index and section index differ, which
+    // a test accepting all points cannot distinguish from a correct read.
+    const accepted: number[] = [];
+    for (let i = 0; i < n; i += 3) {
+      b.push(i, i * 0.5, i * 0.25, i % 7 === 0 ? 1.5 : -1.5);
+      accepted.push(i);
+    }
+    const p = b.finish();
+    expect(p.count).toBe(accepted.length);
+    expect(p.count).toBeGreaterThan(1024);
+
+    for (let k = 0; k < p.count; k++) {
+      const src = accepted[k]!;
+      expect(p.pointIndex[k]).toBe(src);
+      expect(p.sourceSlot[k]).toBe(0);
+      expect(p.chainage[k]).toBeCloseTo(src * 0.5, 4);
+      expect(p.height[k]).toBeCloseTo(src * 0.25, 4);
+      expect(p.intensity![k]).toBe(intensityAt(0, src));
+      expect(p.classification![k]).toBe(classAt(0, src));
+      expect(p.returnNumber![k]).toBe(retNumAt(0, src));
+      expect(p.returnCount![k]).toBe(retCntAt(0, src));
+      expect(p.pointSourceId![k]).toBe(psidAt(0, src));
+      expect(p.gpsTime![k]).toBeCloseTo(gpsAt(0, src), 9);
+      for (let c = 0; c < 3; c++) {
+        expect(p.rgb![k * 3 + c]).toBe(rgbAt(0, src, c));
+        expect(p.normals![k * 3 + c]).toBeCloseTo(normAt(0, src, c), 5);
+      }
+    }
+  });
+
+  it('keeps mixed sources apart and marks absence per point', () => {
+    // A carries RGB and classification; B carries intensity and GPS time;
+    // C carries nothing. Interleaved so a per-snapshot presence flag would
+    // be wrong for two of the three.
+    const nA = 40;
+    const nB = 40;
+    const nC = 40;
+    const b = new ProfileSectionBuilder();
+
+    b.beginSource(0, channelsFor(0, nA, new Set(['rgb', 'classification'])), nA);
+    for (let i = 0; i < nA; i++) b.push(i, i, i, 0);
+    b.beginSource(1, channelsFor(1, nB, new Set(['intensity', 'gpsTime'])), nB);
+    for (let i = 0; i < nB; i++) b.push(i, i, i, 0);
+    b.beginSource(2, null, nC);
+    for (let i = 0; i < nC; i++) b.push(i, i, i, 0);
+
+    const p = b.finish();
+    expect(p.count).toBe(nA + nB + nC);
+
+    for (let k = 0; k < p.count; k++) {
+      const slot = p.sourceSlot[k]!;
+      const src = p.pointIndex[k]!;
+      if (slot === 0) {
+        expect(profileSectionHas(p, k, 'rgb')).toBe(true);
+        expect(profileSectionHas(p, k, 'classification')).toBe(true);
+        expect(profileSectionHas(p, k, 'intensity')).toBe(false);
+        expect(profileSectionHas(p, k, 'gpsTime')).toBe(false);
+        expect(p.classification![k]).toBe(classAt(0, src));
+        expect(p.rgb![k * 3]).toBe(rgbAt(0, src, 0));
+      } else if (slot === 1) {
+        expect(profileSectionHas(p, k, 'intensity')).toBe(true);
+        expect(profileSectionHas(p, k, 'gpsTime')).toBe(true);
+        expect(profileSectionHas(p, k, 'rgb')).toBe(false);
+        expect(profileSectionHas(p, k, 'classification')).toBe(false);
+        expect(p.intensity![k]).toBe(intensityAt(1, src));
+        expect(p.gpsTime![k]).toBeCloseTo(gpsAt(1, src), 9);
+      } else {
+        expect(p.channelPresence[k]).toBe(0);
+      }
+    }
+  });
+
+  it('omits a channel no source carried rather than emitting zeros', () => {
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, channelsFor(0, 10, new Set(['intensity'])), 10);
+    for (let i = 0; i < 10; i++) b.push(i, i, i, 0);
+    const p = b.finish();
+    expect(p.intensity).toBeDefined();
+    expect(p.rgb).toBeUndefined();
+    expect(p.gpsTime).toBeUndefined();
+    expect(p.classification).toBeUndefined();
+    expect(p.normals).toBeUndefined();
+  });
+
+  it('drops a misaligned channel for that source instead of shifting it', () => {
+    // A classification array one element short cannot be index-aligned. The
+    // sampler applies the same rule to its own classification input.
+    const n = 20;
+    const good = channelsFor(0, n, new Set(['classification', 'intensity']));
+    const bad: ProfileSourceChannels = {
+      classification: good.classification!.slice(0, n - 1),
+      intensity: good.intensity,
+    };
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, bad, n);
+    for (let i = 0; i < n; i++) b.push(i, i, i, 0);
+    const p = b.finish();
+
+    expect(p.classification).toBeUndefined();
+    for (let k = 0; k < p.count; k++) {
+      expect(profileSectionHas(p, k, 'classification')).toBe(false);
+      expect(profileSectionHas(p, k, 'intensity')).toBe(true);
+      expect(p.intensity![k]).toBe(intensityAt(0, k));
+    }
+  });
+
+  it('assigns one bit per attribute', () => {
+    const bits = Object.values(PROFILE_ATTRIBUTE_BIT);
+    expect(new Set(bits).size).toBe(bits.length);
+    for (const v of bits) expect(v & (v - 1)).toBe(0);
+    expect(bits.reduce((a, c) => a | c, 0)).toBe(0xff);
+  });
+
+  it('reports an empty section without allocating channels', () => {
+    const p = new ProfileSectionBuilder().finish();
+    expect(p.count).toBe(0);
+    expect(p.chainage.length).toBe(0);
+    expect(p.rgb).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Stacked on #506, which it carries.

The station CSV exports the reduced series; this exports the accepted corridor returns, with a column present only when the data supports it. A missing channel is blank, never zero, and a displayed-index array never reduces the rows.

The height column follows `heightLabel` in `src/geo/height.ts`, so `elevation` appears only for an orthometric reference. Quoting follows `csvCell` in `src/export/measurementExport.ts`, which prefixes a string cell opening `= + - @` and leaves numeric cells alone.

The receipt is a sidecar JSON with an injectable timestamp. Civil stationing is omitted when no metres-per-unit scale is known.
