### PR TITLE
Generate section axis ticks and datum-aware axis words

### DIFF
--- a/src/render/measure/profileAxes.ts
+++ b/src/render/measure/profileAxes.ts
@@ -1,0 +1,425 @@
+/**
+ * profileAxes.ts
+ *
+ * Tick placement and axis titling for a 2D profile cross-section: where the
+ * major and minor rules fall, what each tick reads, and what each axis is
+ * called. Pure. No DOM, no canvas, no renderer.
+ *
+ * Two rules govern the numbers here.
+ *
+ * A tick is an exact multiple of its step. A step is a leading digit of 1, 2
+ * or 5 times a power of ten, so every multiple of it is exact at `-exponent`
+ * decimal places; each tick is built as `index × step` and then snapped to
+ * that many places, which is what keeps a label reading `12` and `0.3`
+ * rather than `12.000000000000002`.
+ *
+ * An axis title states no more about the vertical reference than the scan
+ * supports. `heightLabel` in `geo/height.ts` owns that wording, so a height
+ * with no declared datum reads "Height (datum unknown)" on this axis for the
+ * same reason it does in the point inspector, and "Elevation" appears only
+ * where an orthometric datum was declared. A local frame reads "Local
+ * height", the word the profile PDF sheet and the Measurements panel already
+ * print for a section with no datum.
+ *
+ * Tick labels are bare numbers and the unit sits in the axis title: an axis
+ * holds one unit down its whole column, so the per-value unit banding in
+ * `format.ts` (cm → m → km as a magnitude grows) does not apply to a tick.
+ * The horizontal and vertical units of a profile can differ, so each title
+ * carries its own suffix.
+ */
+
+import type { UnitSystem } from './types';
+import type { ProfileStation } from './profileStations';
+import { formatStation } from './profileSummary';
+import { displayDecimals } from './format';
+import { heightLabel } from '../../geo/height';
+import type { VerticalReference } from '../../geo/height';
+import { profileVisibleBounds, profileDataToScreen } from './profileViewTransform';
+import type {
+  ProfileView,
+  ProfileViewport,
+  ProfileUnitContext,
+} from './profileViewTransform';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tick spacing
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Leading digits a step may take, ascending. */
+const NICE_MANTISSAS: readonly number[] = [1, 2, 5];
+
+/** Smallest step the generator will produce, and the decimal ceiling it implies. */
+const MIN_STEP = 1e-20;
+const MAX_DECIMALS = 20;
+
+/** Hard bound on the emitted tick count, so no input can produce an unbounded list. */
+export const MAX_AXIS_TICKS = 512;
+
+/** Bounds on the requested tick count. */
+export const MAX_TARGET_TICKS = 100;
+export const DEFAULT_TARGET_TICKS = 6;
+
+/** A resolved major-tick scale for one axis. */
+export interface AxisTicks {
+  /** Spacing between adjacent major ticks. Always finite and > 0. */
+  readonly step: number;
+  /** Major tick values, ascending. Never empty; every entry is finite. */
+  readonly values: readonly number[];
+  /** Decimal places a label needs to print any multiple of `step` exactly. */
+  readonly decimals: number;
+  /** Minor divisions per major step. See {@link minorTickStep}. */
+  readonly minorPerMajor: number;
+}
+
+interface NiceStep {
+  readonly step: number;
+  readonly mantissa: number;
+  readonly exponent: number;
+}
+
+/**
+ * The smallest 1/2/5 × 10ⁿ step that is at least `raw`.
+ *
+ * The `1 + 1e-12` slack absorbs the `log10`/`pow` round trip, so a raw step
+ * that already IS 2 × 10ⁿ takes mantissa 2 rather than climbing to 5. A frac
+ * that lands at or above 10 (which the round trip can produce for an exact
+ * power of ten) falls through to the next decade, still a valid step.
+ */
+function niceStepAtLeast(raw: number): NiceStep {
+  const bounded = Number.isFinite(raw) && raw > MIN_STEP ? raw : MIN_STEP;
+  const exponent = Math.floor(Math.log10(bounded));
+  const frac = bounded / Math.pow(10, exponent);
+  for (const m of NICE_MANTISSAS) {
+    if (frac <= m * (1 + 1e-12)) {
+      return { step: m * Math.pow(10, exponent), mantissa: m, exponent };
+    }
+  }
+  const up = exponent + 1;
+  return { step: Math.pow(10, up), mantissa: 1, exponent: up };
+}
+
+/**
+ * Minor divisions per major step, keyed on the step's leading digit: a 1 step
+ * splits into 5 (0.2 each), a 2 step into 4 (0.5 each), a 5 step into 5 (1
+ * each). Every rule puts the minor lines on a round decimal fraction of the
+ * major step, which is what a reader recovers at a glance; splitting a 2 step
+ * into 5 would place lines at 0.4, and a 1 step into 4 at 0.25.
+ */
+function minorsFor(mantissa: number): number {
+  return mantissa === 2 ? 4 : 5;
+}
+
+/** Snap to `decimals` places, so the value is an exact multiple of its step. */
+function snap(v: number, decimals: number): number {
+  if (!Number.isFinite(v)) return 0;
+  return Number(v.toFixed(decimals));
+}
+
+/**
+ * Index of the first (`up`) or last (`down`) multiple of `step` at a bound.
+ *
+ * A bound that IS a multiple can land a hair either side of the integer once
+ * divided, so the comparison carries a relative tolerance rather than an
+ * absolute one: at an index of 5 × 10¹⁴ an absolute epsilon is below the
+ * spacing of the doubles involved and would never fire.
+ */
+function boundIndex(v: number, step: number, dir: 'up' | 'down'): number {
+  const q = v / step;
+  if (!Number.isFinite(q)) return Number.NaN;
+  const tol = 1e-9 * Math.max(1, Math.abs(q));
+  return dir === 'up' ? Math.ceil(q - tol) : Math.floor(q + tol);
+}
+
+function clampTarget(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_TARGET_TICKS;
+  return Math.min(MAX_TARGET_TICKS, Math.max(1, Math.trunc(n)));
+}
+
+/**
+ * Major ticks across `[min, max]` at roughly `targetCount` of them.
+ *
+ * Total on degenerate input: non-finite bounds read as 0, an inverted range is
+ * taken as its ordered pair, and a zero-width range still yields one tick so
+ * the axis remains drawable. Every returned tick is finite and an exact
+ * multiple of `step`; every tick lies inside the range whenever the range has
+ * width.
+ */
+export function axisTicks(min: number, max: number, targetCount: number): AxisTicks {
+  const a = Number.isFinite(min) ? min : 0;
+  const b = Number.isFinite(max) ? max : 0;
+  const lo = Math.min(a, b);
+  const hi = Math.max(a, b);
+  const target = clampTarget(targetCount);
+  const span = hi - lo;
+  const magnitude = Math.max(Math.abs(lo), Math.abs(hi));
+  // Doubles near a magnitude are spaced about EPSILON × magnitude apart, so a
+  // step below that cannot separate two ticks and would emit a duplicate list.
+  const floorStep = Math.max(MIN_STEP, magnitude * Number.EPSILON * 8);
+  const raw = span > 0 ? span / target : magnitude > 0 ? magnitude / target : 1;
+  const nice = niceStepAtLeast(Math.max(raw, floorStep));
+  const decimals = Math.min(MAX_DECIMALS, Math.max(0, -nice.exponent));
+  const step = nice.step;
+
+  const first = boundIndex(lo, step, 'up');
+  const last = boundIndex(hi, step, 'down');
+  const values: number[] = [];
+  if (Number.isFinite(first) && Number.isFinite(last) && last >= first) {
+    const count = Math.min(last - first + 1, MAX_AXIS_TICKS);
+    for (let i = 0; i < count; i++) values.push(snap((first + i) * step, decimals));
+  } else {
+    // Nothing lands inside, which a zero-width range produces whenever its
+    // value is not itself a multiple. One tick still has to exist for the axis
+    // to be drawable, and the nearest multiple keeps that tick exact.
+    const q = lo / step;
+    values.push(snap((Number.isFinite(q) ? Math.round(q) : 0) * step, decimals));
+  }
+  return { step, values, decimals, minorPerMajor: minorsFor(nice.mantissa) };
+}
+
+/**
+ * Spacing of the minor rule. One more decimal place than the major step
+ * covers every division the {@link minorsFor} rule produces: a fifth of
+ * 1 × 10ⁿ is 2 × 10ⁿ⁻¹, a quarter of 2 × 10ⁿ is 5 × 10ⁿ⁻¹, and a fifth of
+ * 5 × 10ⁿ is 1 × 10ⁿ.
+ */
+export function minorTickStep(ticks: AxisTicks): number {
+  return ticks.step / ticks.minorPerMajor;
+}
+
+/** Minor tick values across `[min, max]`, excluding the major ones. */
+export function minorTickValues(ticks: AxisTicks, min: number, max: number): number[] {
+  const a = Number.isFinite(min) ? min : 0;
+  const b = Number.isFinite(max) ? max : 0;
+  const lo = Math.min(a, b);
+  const hi = Math.max(a, b);
+  const step = minorTickStep(ticks);
+  const decimals = Math.min(MAX_DECIMALS, ticks.decimals + 1);
+  const first = boundIndex(lo, step, 'up');
+  const last = boundIndex(hi, step, 'down');
+  if (!Number.isFinite(first) || !Number.isFinite(last) || last < first) return [];
+  const count = Math.min(last - first + 1, MAX_AXIS_TICKS);
+  const out: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const index = first + i;
+    if (index % ticks.minorPerMajor === 0) continue;
+    out.push(snap(index * step, decimals));
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tick labels
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A non-finite readout, the same em dash the measurement formatters print. */
+const NO_VALUE = '—';
+
+/**
+ * One tick as text, fixed to the step's own decimal count. The count comes
+ * from the step rather than from the value, so a column of labels shares one
+ * decimal place and no entry carries binary residue.
+ */
+export function formatAxisValue(value: number, decimals: number): string {
+  if (!Number.isFinite(value)) return NO_VALUE;
+  const places = Number.isFinite(decimals)
+    ? Math.min(MAX_DECIMALS, Math.max(0, Math.trunc(decimals)))
+    : 0;
+  return value.toFixed(places);
+}
+
+/** Plain chainage labels: the tick values as written, unit carried by the title. */
+export function chainageTickLabels(ticks: AxisTicks): string[] {
+  return ticks.values.map((v) => formatAxisValue(v, ticks.decimals));
+}
+
+/**
+ * Civil stationing labels for the chainage axis, or null when they cannot be
+ * stated.
+ *
+ * `formatStation` reads metres, and a profile's chainage is in the scan's own
+ * horizontal unit, so the conversion needs `horizontalToMetres`. Where that is
+ * unknown the station notation would name a kilometre boundary the data never
+ * established, and null is returned instead.
+ */
+export function stationTickLabels(
+  ticks: AxisTicks,
+  units: ProfileUnitContext,
+  system: UnitSystem,
+): string[] | null {
+  const f = units.horizontalToMetres;
+  if (f == null || !Number.isFinite(f) || f <= 0) return null;
+  return ticks.values.map((v) => formatStation(v * f, system));
+}
+
+/**
+ * Station labels for the markers `stationsAlongLine` emitted, in the order it
+ * emitted them. Reads the same chainage field the sampler and the PDF read, so
+ * an axis marker and a station-table row cannot name one position differently.
+ */
+export function stationMarkerLabels(
+  stations: ReadonlyArray<ProfileStation>,
+  metresPerUnit: number,
+  system: UnitSystem,
+): string[] {
+  const f = Number.isFinite(metresPerUnit) && metresPerUnit > 0 ? metresPerUnit : 1;
+  return stations.map((s) => formatStation(s.chainage * f, system));
+}
+
+/**
+ * The visible span of an axis as a readout, e.g. "247.53 m". A span is a
+ * magnitude rather than a tick, so its decimals follow the stack's
+ * significant-figure policy in {@link displayDecimals} instead of the step.
+ */
+export function axisSpanCaption(span: number, unitSuffix: string | null): string {
+  if (!Number.isFinite(span)) return NO_VALUE;
+  const text = span.toFixed(displayDecimals(span, 0, 6));
+  const u = unitSuffix?.trim();
+  return u ? `${text} ${u}` : text;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Axis titles
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The chainage axis word. */
+export const CHAINAGE_AXIS_WORD = 'Chainage';
+
+/**
+ * The height word for a section whose coordinates are in the dataset's own
+ * local frame. The profile PDF sheet and the Measurements panel station table
+ * already print this for a section with no datum.
+ */
+export const PROFILE_LOCAL_HEIGHT_WORD = 'Local height';
+
+/**
+ * The word this profile's height axis uses.
+ *
+ * Every case but the local frame defers to `heightLabel`, so an orthometric
+ * datum reads "Elevation", a WGS 84 ellipsoidal height reads "Ellipsoidal
+ * height", and an absent or unrecognised datum reads "Height (datum unknown)".
+ * A local frame takes the profile surfaces' own word instead of the generic
+ * "Height (local frame)".
+ */
+export function profileHeightWord(reference: VerticalReference): string {
+  return reference === 'local' ? PROFILE_LOCAL_HEIGHT_WORD : heightLabel(reference);
+}
+
+/**
+ * `word (unit)`, the composition the station table's column headings use. An
+ * absent or blank unit leaves the word alone rather than printing empty
+ * brackets.
+ */
+export function axisTitle(word: string, unitSuffix: string | null): string {
+  const u = unitSuffix?.trim();
+  return u ? `${word} (${u})` : word;
+}
+
+/** Title for the chainage axis in its own horizontal unit. */
+export function chainageAxisTitle(unitSuffix: string | null): string {
+  return axisTitle(CHAINAGE_AXIS_WORD, unitSuffix);
+}
+
+/** Title for the height axis in its own vertical unit. */
+export function heightAxisTitle(
+  reference: VerticalReference,
+  unitSuffix: string | null,
+): string {
+  return axisTitle(profileHeightWord(reference), unitSuffix);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Assembled axes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** What the caller states about the section being drawn. */
+export interface ProfileAxesConfig {
+  /** Vertical reference of the section's heights. */
+  readonly reference: VerticalReference;
+  /** Unit suffix for the chainage axis, e.g. "m". Null when unknown. */
+  readonly horizontalUnit: string | null;
+  /** Unit suffix for the height axis, e.g. "m". Null when unknown. */
+  readonly verticalUnit: string | null;
+  /** Metres per data unit on each axis, for the station notation. */
+  readonly units: ProfileUnitContext;
+  /** Civil stationing on the chainage axis instead of plain numbers. */
+  readonly stationing?: boolean;
+  readonly unitSystem?: UnitSystem;
+  readonly targetXTicks?: number;
+  readonly targetYTicks?: number;
+}
+
+/** One drawable axis: its ticks, its labels, its title, its screen positions. */
+export interface ProfileAxis {
+  readonly ticks: AxisTicks;
+  readonly labels: readonly string[];
+  /** Screen position of each tick, CSS pixels from the top left. */
+  readonly pixels: readonly number[];
+  readonly minorPixels: readonly number[];
+  readonly title: string;
+}
+
+/** Both axes of a profile view. */
+export interface ProfileAxesModel {
+  readonly x: ProfileAxis;
+  readonly y: ProfileAxis;
+}
+
+/**
+ * Build both axes for the region a view currently shows.
+ *
+ * Chainage ticks fall on the horizontal, height ticks on the vertical, and
+ * each tick's pixel position comes from the same transform the section
+ * geometry is drawn with, so a rule and the points beside it cannot drift.
+ * A stationing request with no horizontal metres scale falls back to plain
+ * chainage labels rather than to a station notation the units cannot support.
+ */
+export function profileAxes(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  config: ProfileAxesConfig,
+): ProfileAxesModel {
+  const bounds = profileVisibleBounds(view, viewport);
+  const system: UnitSystem = config.unitSystem ?? 'metric';
+
+  const xTicks = axisTicks(
+    bounds.minChainage,
+    bounds.maxChainage,
+    config.targetXTicks ?? DEFAULT_TARGET_TICKS,
+  );
+  const yTicks = axisTicks(
+    bounds.minHeight,
+    bounds.maxHeight,
+    config.targetYTicks ?? DEFAULT_TARGET_TICKS,
+  );
+
+  const stationLabels = config.stationing
+    ? stationTickLabels(xTicks, config.units, system)
+    : null;
+
+  const scratch = new Float64Array(2);
+  const xAt = (chainage: number): number => {
+    profileDataToScreen(view, viewport, chainage, view.centreHeight, scratch);
+    return scratch[0]!;
+  };
+  const yAt = (height: number): number => {
+    profileDataToScreen(view, viewport, view.centreChainage, height, scratch);
+    return scratch[1]!;
+  };
+
+  return {
+    x: {
+      ticks: xTicks,
+      labels: stationLabels ?? chainageTickLabels(xTicks),
+      pixels: xTicks.values.map(xAt),
+      minorPixels: minorTickValues(xTicks, bounds.minChainage, bounds.maxChainage).map(xAt),
+      title: chainageAxisTitle(config.horizontalUnit),
+    },
+    y: {
+      ticks: yTicks,
+      labels: yTicks.values.map((v) => formatAxisValue(v, yTicks.decimals)),
+      pixels: yTicks.values.map(yAt),
+      minorPixels: minorTickValues(yTicks, bounds.minHeight, bounds.maxHeight).map(yAt),
+      title: heightAxisTitle(config.reference, config.verticalUnit),
+    },
+  };
+}

--- a/src/render/measure/profileViewTransform.ts
+++ b/src/render/measure/profileViewTransform.ts
@@ -1,0 +1,268 @@
+/**
+ * profileViewTransform.ts
+ *
+ * The viewport transform for a 2D profile cross-section: data space
+ * (chainage, height) to screen space and back, fit, pan, zoom about a
+ * cursor, and vertical exaggeration.
+ *
+ * Pure. No DOM, no canvas, no renderer. Everything here is a value.
+ *
+ * Vertical exaggeration is a ratio between two physical scales, so it can
+ * only be stated when both axes can be expressed in the same physical unit.
+ * A profile's horizontal and vertical units can differ, and either can be
+ * unknown. When one is unknown the view still works, and the ratio is
+ * reported as null rather than as 1.
+ */
+
+/** Metres per data unit on each axis. Null where the scale is unknown. */
+export interface ProfileUnitContext {
+  readonly horizontalToMetres: number | null;
+  readonly verticalToMetres: number | null;
+}
+
+/** The drawable area, in CSS pixels, and the backing store ratio. */
+export interface ProfileViewport {
+  readonly width: number;
+  readonly height: number;
+  readonly devicePixelRatio: number;
+}
+
+/** Data-space extent to be shown. */
+export interface ProfileDataBounds {
+  readonly minChainage: number;
+  readonly maxChainage: number;
+  readonly minHeight: number;
+  readonly maxHeight: number;
+}
+
+/**
+ * `fit` scales each axis independently to the viewport and claims no ratio.
+ * `ve` holds a true vertical exaggeration and requires both unit scales.
+ */
+export type ProfileScaleMode =
+  | { readonly kind: 'fit' }
+  | { readonly kind: 've'; readonly ratio: number };
+
+/** A resolved view: what sits at the centre, and the scale of each axis. */
+export interface ProfileView {
+  readonly centreChainage: number;
+  readonly centreHeight: number;
+  /** CSS pixels per chainage unit. Always > 0. */
+  readonly pxPerChainage: number;
+  /** CSS pixels per height unit. Always > 0. */
+  readonly pxPerHeight: number;
+}
+
+/**
+ * The smallest span a degenerate axis is given.
+ *
+ * A section whose returns share one height has a zero height span, and
+ * dividing the viewport by it yields infinity. One unit of span puts such a
+ * section on a readable axis instead of an empty one.
+ */
+export const MIN_DATA_SPAN = 1e-6;
+
+/** Scale change per zoom step. */
+export const ZOOM_STEP = 1.2;
+
+const MIN_PX_PER_UNIT = 1e-12;
+const MAX_PX_PER_UNIT = 1e12;
+
+function finite(v: number): boolean {
+  return Number.isFinite(v);
+}
+
+function clampScale(v: number): number {
+  if (!finite(v) || v <= 0) return MIN_PX_PER_UNIT;
+  return Math.min(MAX_PX_PER_UNIT, Math.max(MIN_PX_PER_UNIT, v));
+}
+
+function spanOf(min: number, max: number): number {
+  const s = max - min;
+  if (!finite(s) || s <= MIN_DATA_SPAN) return MIN_DATA_SPAN;
+  return s;
+}
+
+/** True when a true vertical exaggeration can be stated for these units. */
+export function canStateExaggeration(units: ProfileUnitContext): boolean {
+  const h = units.horizontalToMetres;
+  const v = units.verticalToMetres;
+  return h != null && v != null && finite(h) && finite(v) && h > 0 && v > 0;
+}
+
+/**
+ * The view's vertical exaggeration, or null when it cannot be stated.
+ *
+ * Pixels per metre on each axis is the axis scale divided by the metres in
+ * one of its data units. The exaggeration is the vertical figure over the
+ * horizontal one.
+ */
+export function viewExaggeration(
+  view: ProfileView,
+  units: ProfileUnitContext,
+): number | null {
+  if (!canStateExaggeration(units)) return null;
+  const h = units.horizontalToMetres!;
+  const v = units.verticalToMetres!;
+  const pxPerMetreX = view.pxPerChainage / h;
+  const pxPerMetreY = view.pxPerHeight / v;
+  if (!finite(pxPerMetreX) || pxPerMetreX <= 0) return null;
+  const ratio = pxPerMetreY / pxPerMetreX;
+  return finite(ratio) ? ratio : null;
+}
+
+/**
+ * Fit `bounds` into `viewport`.
+ *
+ * Under `fit` each axis takes the viewport independently. Under `ve` both
+ * axes take one base scale chosen so the whole extent still fits, so holding
+ * a ratio never crops an extreme.
+ *
+ * Returns null when the mode asks for an exaggeration the units cannot
+ * support, so a caller must handle that rather than receive a view whose
+ * ratio is a fiction.
+ */
+export function fitProfileView(
+  bounds: ProfileDataBounds,
+  viewport: ProfileViewport,
+  mode: ProfileScaleMode,
+  units: ProfileUnitContext,
+): ProfileView | null {
+  const w = finite(viewport.width) && viewport.width > 0 ? viewport.width : 1;
+  const hgt = finite(viewport.height) && viewport.height > 0 ? viewport.height : 1;
+
+  const minC = finite(bounds.minChainage) ? bounds.minChainage : 0;
+  const maxC = finite(bounds.maxChainage) ? bounds.maxChainage : 0;
+  const minH = finite(bounds.minHeight) ? bounds.minHeight : 0;
+  const maxH = finite(bounds.maxHeight) ? bounds.maxHeight : 0;
+
+  const spanC = spanOf(minC, maxC);
+  const spanH = spanOf(minH, maxH);
+  const centreChainage = (minC + maxC) / 2;
+  const centreHeight = (minH + maxH) / 2;
+
+  if (mode.kind === 'fit') {
+    return {
+      centreChainage,
+      centreHeight,
+      pxPerChainage: clampScale(w / spanC),
+      pxPerHeight: clampScale(hgt / spanH),
+    };
+  }
+
+  if (!canStateExaggeration(units)) return null;
+  const ratio = mode.ratio;
+  if (!finite(ratio) || ratio <= 0) return null;
+  const mPerC = units.horizontalToMetres!;
+  const mPerH = units.verticalToMetres!;
+
+  // pxPerHeight = ratio * pxPerChainage * mPerH / mPerC, so a vertical fit
+  // implies a horizontal scale. Taking the smaller of that and the
+  // horizontal fit keeps both extents inside the viewport.
+  const fromWidth = w / spanC;
+  const fromHeight = ((hgt / spanH) * mPerC) / (ratio * mPerH);
+  const pxPerChainage = clampScale(Math.min(fromWidth, fromHeight));
+  const pxPerHeight = clampScale((ratio * pxPerChainage * mPerH) / mPerC);
+  return { centreChainage, centreHeight, pxPerChainage, pxPerHeight };
+}
+
+/**
+ * Data to screen, in CSS pixels from the top left of the drawable area.
+ *
+ * Height increases upward on screen, so the vertical term is negated.
+ */
+export function profileDataToScreen(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  chainage: number,
+  height: number,
+  out: Float64Array,
+): void {
+  out[0] = viewport.width / 2 + (chainage - view.centreChainage) * view.pxPerChainage;
+  out[1] = viewport.height / 2 - (height - view.centreHeight) * view.pxPerHeight;
+}
+
+/** Screen to data. The inverse of {@link profileDataToScreen}. */
+export function profileScreenToData(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  sx: number,
+  sy: number,
+  out: Float64Array,
+): void {
+  out[0] = view.centreChainage + (sx - viewport.width / 2) / view.pxPerChainage;
+  out[1] = view.centreHeight - (sy - viewport.height / 2) / view.pxPerHeight;
+}
+
+/** Move the view by a screen-space delta. */
+export function panProfileView(
+  view: ProfileView,
+  dxPx: number,
+  dyPx: number,
+): ProfileView {
+  const dx = finite(dxPx) ? dxPx : 0;
+  const dy = finite(dyPx) ? dyPx : 0;
+  return {
+    ...view,
+    centreChainage: view.centreChainage - dx / view.pxPerChainage,
+    centreHeight: view.centreHeight + dy / view.pxPerHeight,
+  };
+}
+
+/**
+ * Zoom about a screen anchor, keeping the data under that anchor fixed.
+ *
+ * Under `fit` both axes scale together, which preserves the aspect the fit
+ * produced. Under `ve` both axes scale together as well, which is what keeps
+ * the exaggeration constant through a zoom.
+ */
+export function zoomProfileViewAt(
+  view: ProfileView,
+  viewport: ProfileViewport,
+  anchorX: number,
+  anchorY: number,
+  factor: number,
+): ProfileView {
+  if (!finite(factor) || factor <= 0) return view;
+  const ax = finite(anchorX) ? anchorX : viewport.width / 2;
+  const ay = finite(anchorY) ? anchorY : viewport.height / 2;
+
+  const before = new Float64Array(2);
+  profileScreenToData(view, viewport, ax, ay, before);
+  const next: ProfileView = {
+    ...view,
+    pxPerChainage: clampScale(view.pxPerChainage * factor),
+    pxPerHeight: clampScale(view.pxPerHeight * factor),
+  };
+  const after = new Float64Array(2);
+  profileScreenToData(next, viewport, ax, ay, after);
+  return {
+    ...next,
+    centreChainage: next.centreChainage + (before[0]! - after[0]!),
+    centreHeight: next.centreHeight + (before[1]! - after[1]!),
+  };
+}
+
+/** Scale a CSS-pixel measure to the canvas backing store. */
+export function toDevicePixels(viewport: ProfileViewport, cssPx: number): number {
+  const dpr =
+    finite(viewport.devicePixelRatio) && viewport.devicePixelRatio > 0
+      ? viewport.devicePixelRatio
+      : 1;
+  return cssPx * dpr;
+}
+
+/** The data-space rectangle the viewport currently shows. */
+export function profileVisibleBounds(
+  view: ProfileView,
+  viewport: ProfileViewport,
+): ProfileDataBounds {
+  const halfC = viewport.width / 2 / view.pxPerChainage;
+  const halfH = viewport.height / 2 / view.pxPerHeight;
+  return {
+    minChainage: view.centreChainage - halfC,
+    maxChainage: view.centreChainage + halfC,
+    minHeight: view.centreHeight - halfH,
+    maxHeight: view.centreHeight + halfH,
+  };
+}

--- a/tests/profileAxes.test.ts
+++ b/tests/profileAxes.test.ts
@@ -1,0 +1,534 @@
+/**
+ * profileAxes.test.ts
+ *
+ * Covers the profile axis generator across seven decades of range, on
+ * degenerate input, and over the vertical-reference wording.
+ *
+ * Exactness check. A tick is asserted to be an exact multiple of its step by
+ * dividing and comparing to the nearest integer with a RELATIVE tolerance, not
+ * by `value % step === 0`. Neither a decimal tick nor a decimal step is exactly
+ * representable in binary — `0.3 % 0.1` is 0.09999999999999998, so a remainder
+ * test would reject a correct tick — and at an index of 5 × 10¹⁴ an absolute
+ * epsilon sits below the spacing of the doubles involved and would never fire.
+ * The label is asserted separately: it must round-trip to the tick and match a
+ * plain decimal shape, which is what "no float noise" means on screen.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  axisTicks,
+  minorTickStep,
+  minorTickValues,
+  formatAxisValue,
+  chainageTickLabels,
+  stationTickLabels,
+  stationMarkerLabels,
+  axisSpanCaption,
+  axisTitle,
+  chainageAxisTitle,
+  heightAxisTitle,
+  profileHeightWord,
+  profileAxes,
+  CHAINAGE_AXIS_WORD,
+  PROFILE_LOCAL_HEIGHT_WORD,
+  DEFAULT_TARGET_TICKS,
+  MAX_AXIS_TICKS,
+  type AxisTicks,
+} from '../src/render/measure/profileAxes';
+import { formatStation } from '../src/render/measure/profileSummary';
+import { heightLabel } from '../src/geo/height';
+import type { VerticalReference } from '../src/geo/height';
+import type {
+  ProfileView,
+  ProfileViewport,
+  ProfileUnitContext,
+} from '../src/render/measure/profileViewTransform';
+
+/** Plain decimal, optional sign, no exponent and no residue tail. */
+const PLAIN_DECIMAL = /^-?\d+(?:\.\d+)?$/;
+
+/** Multiples of `step` divide to an integer within a relative tolerance. */
+function isExactMultiple(value: number, step: number): boolean {
+  const q = value / step;
+  const nearest = Math.round(q);
+  return Math.abs(q - nearest) <= 1e-9 * Math.max(1, Math.abs(q));
+}
+
+function assertWellFormed(t: AxisTicks, lo: number, hi: number, target: number): void {
+  expect(Number.isFinite(t.step)).toBe(true);
+  expect(t.step).toBeGreaterThan(0);
+  expect(t.values.length).toBeGreaterThan(0);
+  expect(t.values.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+  expect(Number.isInteger(t.decimals)).toBe(true);
+  expect(t.decimals).toBeGreaterThanOrEqual(0);
+  expect([4, 5]).toContain(t.minorPerMajor);
+
+  for (let i = 0; i < t.values.length; i++) {
+    const v = t.values[i]!;
+    expect(Number.isFinite(v)).toBe(true);
+    expect(isExactMultiple(v, t.step)).toBe(true);
+    if (i > 0) expect(v).toBeGreaterThan(t.values[i - 1]!);
+  }
+
+  // The step's leading digit is 1, 2 or 5, and the minor rule follows it.
+  const exp = Math.round(Math.log10(t.step / mantissaOf(t.step)));
+  expect([1, 2, 5]).toContain(mantissaOf(t.step));
+  expect(Number.isFinite(exp)).toBe(true);
+  expect(t.minorPerMajor).toBe(mantissaOf(t.step) === 2 ? 4 : 5);
+  // Each minor division lands on a round decimal fraction of the major step.
+  expect([1, 2, 5]).toContain(mantissaOf(minorTickStep(t)));
+
+  // `decimals` is exactly what the step needs: it round-trips there and, when
+  // it is not zero, one place fewer loses the step. Too few decimals and the
+  // first check fails; too many and the second passes where it should not.
+  expect(Number(t.step.toFixed(t.decimals))).toBe(t.step);
+  if (t.decimals > 0) {
+    expect(Number(t.step.toFixed(t.decimals - 1))).not.toBe(t.step);
+  }
+
+  const labels = chainageTickLabels(t);
+  for (let i = 0; i < labels.length; i++) {
+    const label = labels[i]!;
+    expect(label).toMatch(PLAIN_DECIMAL);
+    expect(Number(label)).toBe(t.values[i]!);
+    const dot = label.indexOf('.');
+    expect(dot < 0 ? 0 : label.length - dot - 1).toBe(t.decimals);
+  }
+
+  const span = hi - lo;
+  if (span > 0) {
+    const pad = t.step * 1e-9;
+    for (const v of t.values) {
+      expect(v).toBeGreaterThanOrEqual(lo - pad);
+      expect(v).toBeLessThanOrEqual(hi + pad);
+    }
+    // The chosen step is at least span/target and at most 2.5 × that, so the
+    // count lands between target/2.5 - 1 and target + 1.
+    expect(t.values.length).toBeGreaterThanOrEqual(Math.max(1, Math.floor(target / 2.5) - 1));
+    expect(t.values.length).toBeLessThanOrEqual(target + 1);
+  }
+}
+
+/** Leading digit of a 1/2/5 × 10ⁿ step. */
+function mantissaOf(step: number): number {
+  const e = Math.floor(Math.log10(step) + 1e-12);
+  const m = step / Math.pow(10, e);
+  return Math.round(m * 1e6) / 1e6;
+}
+
+const DECADES = [1e-6, 0.05, 1, 7, 250, 1e6, 1e9];
+const TARGETS = [2, 4, 6, 8, 10, 25];
+
+describe('axisTicks across decades', () => {
+  for (const span of DECADES) {
+    for (const target of TARGETS) {
+      it(`span ${span} at ~${target} ticks`, () => {
+        assertWellFormed(axisTicks(0, span, target), 0, span, target);
+      });
+      it(`span ${span} offset off a boundary at ~${target} ticks`, () => {
+        const lo = span * 0.317;
+        const hi = lo + span;
+        assertWellFormed(axisTicks(lo, hi, target), lo, hi, target);
+      });
+      it(`span ${span} straddling zero at ~${target} ticks`, () => {
+        assertWellFormed(axisTicks(-span / 2, span / 2, target), -span / 2, span / 2, target);
+      });
+    }
+  }
+
+  it('holds exactness on a decimal step where a remainder test would not', () => {
+    const t = axisTicks(0, 0.5, 5);
+    expect(t.step).toBe(0.1);
+    expect(t.values).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5]);
+    expect(chainageTickLabels(t)).toEqual(['0.0', '0.1', '0.2', '0.3', '0.4', '0.5']);
+    // The residue test this module avoids: 0.3 % 0.1 is not zero.
+    expect(0.3 % 0.1).toBeGreaterThan(0);
+  });
+
+  it('emits no float noise where naive arithmetic would', () => {
+    const t = axisTicks(0, 0.7, 7);
+    for (const label of chainageTickLabels(t)) {
+      expect(label).not.toMatch(/0000000|9999999/);
+    }
+    expect(chainageTickLabels(axisTicks(11.9, 12.1, 4))).toContain('12.00');
+  });
+});
+
+describe('axisTicks exact placements', () => {
+  it('places round ticks over 0..100', () => {
+    const t = axisTicks(0, 100, 5);
+    expect(t.step).toBe(20);
+    expect(t.decimals).toBe(0);
+    expect(t.values).toEqual([0, 20, 40, 60, 80, 100]);
+  });
+
+  it('starts at or above the low bound, never below it', () => {
+    const t = axisTicks(3, 97, 5);
+    expect(t.step).toBe(20);
+    expect(t.values).toEqual([20, 40, 60, 80]);
+    expect(t.values[0]!).toBeGreaterThanOrEqual(3);
+  });
+
+  it('ends at or below the high bound', () => {
+    const t = axisTicks(1, 9, 4);
+    expect(t.step).toBe(2);
+    expect(t.values).toEqual([2, 4, 6, 8]);
+  });
+
+  it('counts inclusively at both ends', () => {
+    const t = axisTicks(0, 10, 5);
+    expect(t.values).toEqual([0, 2, 4, 6, 8, 10]);
+    expect(t.values.length).toBe(6);
+  });
+
+  it('keeps the 2 of the 1/2/5 progression', () => {
+    const t = axisTicks(0, 12, 6);
+    expect(t.step).toBe(2);
+    expect(mantissaOf(t.step)).toBe(2);
+  });
+
+  it('keeps the 2 of the progression below one', () => {
+    const t = axisTicks(0, 1.2, 6);
+    expect(t.step).toBe(0.2);
+    expect(mantissaOf(t.step)).toBe(2);
+  });
+
+  it('keeps the 5 of the progression', () => {
+    const t = axisTicks(0, 30, 6);
+    expect(t.step).toBe(5);
+    expect(mantissaOf(t.step)).toBe(5);
+  });
+
+  it('keeps the 1 of the progression', () => {
+    const t = axisTicks(0, 6, 6);
+    expect(t.step).toBe(1);
+    expect(mantissaOf(t.step)).toBe(1);
+  });
+
+  it('sets decimals from the step, not from the value', () => {
+    expect(axisTicks(0, 100, 5).decimals).toBe(0);
+    expect(axisTicks(0, 0.5, 5).decimals).toBe(1);
+    expect(axisTicks(0, 0.25, 5).decimals).toBe(2);
+    expect(axisTicks(0, 2.5e-6, 5).decimals).toBe(7);
+    expect(axisTicks(0, 1e9, 5).decimals).toBe(0);
+  });
+});
+
+describe('minor subdivisions', () => {
+  it('splits a 1 step into 5', () => {
+    const t = axisTicks(0, 6, 6);
+    expect(t.step).toBe(1);
+    expect(t.minorPerMajor).toBe(5);
+    expect(minorTickStep(t)).toBeCloseTo(0.2, 12);
+  });
+
+  it('splits a 2 step into 4', () => {
+    const t = axisTicks(0, 12, 6);
+    expect(t.step).toBe(2);
+    expect(t.minorPerMajor).toBe(4);
+    expect(minorTickStep(t)).toBeCloseTo(0.5, 12);
+  });
+
+  it('splits a 5 step into 5', () => {
+    const t = axisTicks(0, 30, 6);
+    expect(t.step).toBe(5);
+    expect(t.minorPerMajor).toBe(5);
+    expect(minorTickStep(t)).toBeCloseTo(1, 12);
+  });
+
+  it('omits the major positions from the minor list', () => {
+    const t = axisTicks(0, 10, 5);
+    const minors = minorTickValues(t, 0, 10);
+    expect(minors.length).toBeGreaterThan(0);
+    for (const m of minors) {
+      expect(Number.isFinite(m)).toBe(true);
+      expect(t.values).not.toContain(m);
+      expect(isExactMultiple(m, minorTickStep(t))).toBe(true);
+    }
+  });
+
+  it('returns an empty minor list for a zero-width range', () => {
+    const t = axisTicks(5, 5, 6);
+    expect(minorTickValues(t, 5, 5).length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('degenerate input', () => {
+  const CASES: ReadonlyArray<readonly [string, number, number, number]> = [
+    ['zero range at zero', 0, 0, 6],
+    ['zero range at a round value', 250, 250, 6],
+    ['zero range off a boundary', 7.3, 7.3, 6],
+    ['zero range negative', -412.75, -412.75, 6],
+    ['inverted range', 100, 0, 6],
+    ['inverted range off a boundary', 9.5, -3.25, 6],
+    ['NaN low', Number.NaN, 100, 6],
+    ['NaN high', 0, Number.NaN, 6],
+    ['both NaN', Number.NaN, Number.NaN, 6],
+    ['infinite low', Number.NEGATIVE_INFINITY, 100, 6],
+    ['infinite high', 0, Number.POSITIVE_INFINITY, 6],
+    ['both infinite', Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, 6],
+    ['target zero', 0, 100, 0],
+    ['target one', 0, 100, 1],
+    ['target negative', 0, 100, -8],
+    ['target NaN', 0, 100, Number.NaN],
+    ['target infinite', 0, 100, Number.POSITIVE_INFINITY],
+    ['target fractional', 0, 100, 4.7],
+    ['target absurd', 0, 100, 1e9],
+  ];
+
+  for (const [name, lo, hi, target] of CASES) {
+    it(`${name} yields finite ticks without throwing`, () => {
+      const t = axisTicks(lo, hi, target);
+      expect(t.values.length).toBeGreaterThan(0);
+      expect(t.values.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+      expect(Number.isFinite(t.step)).toBe(true);
+      expect(t.step).toBeGreaterThan(0);
+      for (const v of t.values) {
+        expect(Number.isFinite(v)).toBe(true);
+        expect(isExactMultiple(v, t.step)).toBe(true);
+      }
+      for (const label of chainageTickLabels(t)) expect(label).toMatch(PLAIN_DECIMAL);
+    });
+  }
+
+  it('reads an inverted range as its ordered pair', () => {
+    expect(axisTicks(100, 0, 5)).toEqual(axisTicks(0, 100, 5));
+  });
+
+  it('yields at least one tick for a zero range', () => {
+    for (const v of [0, 1, 7.3, -412.75, 1e9, 1e-6]) {
+      expect(axisTicks(v, v, 6).values.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('bounds the tick count under an absurd target', () => {
+    expect(axisTicks(0, 1e9, 1e9).values.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+  });
+
+  it('separates ticks at a magnitude where a fine step could not', () => {
+    const t = axisTicks(1e9, 1e9 + 1e-6, 6);
+    for (let i = 1; i < t.values.length; i++) {
+      expect(t.values[i]!).toBeGreaterThan(t.values[i - 1]!);
+    }
+  });
+
+  it('formats a non-finite tick value as an em dash', () => {
+    expect(formatAxisValue(Number.NaN, 2)).toBe('—');
+    expect(formatAxisValue(Number.POSITIVE_INFINITY, 2)).toBe('—');
+    expect(formatAxisValue(1.5, Number.NaN)).toBe('2');
+  });
+});
+
+describe('chainage labels and civil stationing', () => {
+  const METRIC_UNITS: ProfileUnitContext = { horizontalToMetres: 1, verticalToMetres: 1 };
+  const UNKNOWN_UNITS: ProfileUnitContext = {
+    horizontalToMetres: null,
+    verticalToMetres: 1,
+  };
+
+  it('gives plain chainage labels as bare numbers', () => {
+    const t = axisTicks(0, 500, 5);
+    expect(chainageTickLabels(t)).toEqual(['0', '100', '200', '300', '400', '500']);
+  });
+
+  it('gives civil stationing through the shared station formatter', () => {
+    const t = axisTicks(0, 2000, 4);
+    const labels = stationTickLabels(t, METRIC_UNITS, 'metric');
+    expect(labels).not.toBeNull();
+    expect(labels).toEqual(t.values.map((v) => formatStation(v, 'metric')));
+    expect(labels![0]).toBe('0+000.00');
+    expect(labels).toContain('1+000.00');
+  });
+
+  it('gives imperial stationing through the same formatter', () => {
+    const t = axisTicks(0, 200, 4);
+    const labels = stationTickLabels(t, METRIC_UNITS, 'imperial');
+    expect(labels).toEqual(t.values.map((v) => formatStation(v, 'imperial')));
+  });
+
+  it('converts a foot-unit chainage before stationing it', () => {
+    const feet: ProfileUnitContext = {
+      horizontalToMetres: 0.3048,
+      verticalToMetres: 0.3048,
+    };
+    const t = axisTicks(0, 1000, 4);
+    const labels = stationTickLabels(t, feet, 'metric');
+    expect(labels).toEqual(t.values.map((v) => formatStation(v * 0.3048, 'metric')));
+  });
+
+  it('refuses stationing when the horizontal metres scale is unknown', () => {
+    const t = axisTicks(0, 2000, 4);
+    expect(stationTickLabels(t, UNKNOWN_UNITS, 'metric')).toBeNull();
+    expect(
+      stationTickLabels(t, { horizontalToMetres: 0, verticalToMetres: 1 }, 'metric'),
+    ).toBeNull();
+    expect(
+      stationTickLabels(t, { horizontalToMetres: Number.NaN, verticalToMetres: 1 }, 'metric'),
+    ).toBeNull();
+  });
+
+  it('labels emitted station markers with the same formatter', () => {
+    const stations = [
+      { chainage: 0, position: [0, 0, 0] as [number, number, number], isEndpoint: false },
+      { chainage: 50, position: [50, 0, 0] as [number, number, number], isEndpoint: false },
+      { chainage: 73.4, position: [73.4, 0, 0] as [number, number, number], isEndpoint: true },
+    ];
+    expect(stationMarkerLabels(stations, 1, 'metric')).toEqual([
+      formatStation(0, 'metric'),
+      formatStation(50, 'metric'),
+      formatStation(73.4, 'metric'),
+    ]);
+  });
+
+  it('captions a span on the significant-figure policy', () => {
+    expect(axisSpanCaption(247.5312, 'm')).toBe('247.53 m');
+    expect(axisSpanCaption(247.5312, null)).toBe('247.53');
+    expect(axisSpanCaption(Number.NaN, 'm')).toBe('—');
+  });
+});
+
+describe('axis titles', () => {
+  it('titles the chainage axis with its own unit', () => {
+    expect(chainageAxisTitle('m')).toBe('Chainage (m)');
+    expect(chainageAxisTitle('ft')).toBe('Chainage (ft)');
+    expect(chainageAxisTitle(null)).toBe(CHAINAGE_AXIS_WORD);
+    expect(chainageAxisTitle('  ')).toBe(CHAINAGE_AXIS_WORD);
+  });
+
+  it('carries a different unit on each axis', () => {
+    const model = profileAxes(VIEW, VIEWPORT, {
+      reference: 'orthometric',
+      horizontalUnit: 'm',
+      verticalUnit: 'ft',
+      units: { horizontalToMetres: 1, verticalToMetres: 0.3048 },
+    });
+    expect(model.x.title).toBe('Chainage (m)');
+    expect(model.y.title).toBe('Elevation (ft)');
+  });
+
+  const WORDS: ReadonlyArray<readonly [VerticalReference, string]> = [
+    ['orthometric', 'Elevation'],
+    ['ellipsoidal', 'Ellipsoidal height'],
+    ['depth', 'Depth'],
+    ['unknown', 'Height (datum unknown)'],
+    ['local', 'Local height'],
+  ];
+
+  for (const [reference, word] of WORDS) {
+    it(`says "${word}" for a ${reference} reference`, () => {
+      expect(profileHeightWord(reference)).toBe(word);
+      expect(heightAxisTitle(reference, 'm')).toBe(`${word} (m)`);
+      expect(heightAxisTitle(reference, null)).toBe(word);
+    });
+  }
+
+  it('claims an elevation only where an orthometric datum was declared', () => {
+    for (const [reference] of WORDS) {
+      const asserts = profileHeightWord(reference) === 'Elevation';
+      expect(asserts).toBe(reference === 'orthometric');
+    }
+  });
+
+  it('never says "Elevation" without a datum', () => {
+    expect(profileHeightWord('unknown')).not.toContain('Elevation');
+    expect(profileHeightWord('local')).not.toContain('Elevation');
+    expect(heightAxisTitle('unknown', 'm')).not.toContain('Elevation');
+    expect(heightAxisTitle('local', 'ft')).not.toContain('Elevation');
+  });
+
+  it('defers to the shared height wording for every non-local reference', () => {
+    for (const reference of ['orthometric', 'ellipsoidal', 'depth', 'unknown'] as const) {
+      expect(profileHeightWord(reference)).toBe(heightLabel(reference));
+    }
+    expect(PROFILE_LOCAL_HEIGHT_WORD).toBe('Local height');
+  });
+
+  it('leaves a word alone when its unit is unknown', () => {
+    expect(axisTitle('Chainage', null)).toBe('Chainage');
+    expect(axisTitle('Chainage', 'm')).toBe('Chainage (m)');
+  });
+});
+
+const VIEW: ProfileView = {
+  centreChainage: 250,
+  centreHeight: 120,
+  pxPerChainage: 2,
+  pxPerHeight: 4,
+};
+
+const VIEWPORT: ProfileViewport = { width: 800, height: 400, devicePixelRatio: 1 };
+
+describe('profileAxes over a view', () => {
+  const BASE = {
+    reference: 'unknown' as VerticalReference,
+    horizontalUnit: 'm',
+    verticalUnit: 'm',
+    units: { horizontalToMetres: 1, verticalToMetres: 1 } satisfies ProfileUnitContext,
+  };
+
+  it('produces one label and one pixel per tick', () => {
+    const model = profileAxes(VIEW, VIEWPORT, BASE);
+    expect(model.x.labels.length).toBe(model.x.ticks.values.length);
+    expect(model.x.pixels.length).toBe(model.x.ticks.values.length);
+    expect(model.y.labels.length).toBe(model.y.ticks.values.length);
+    expect(model.y.pixels.length).toBe(model.y.ticks.values.length);
+  });
+
+  it('places ticks inside the drawable area', () => {
+    const model = profileAxes(VIEW, VIEWPORT, BASE);
+    for (const px of model.x.pixels) {
+      expect(px).toBeGreaterThanOrEqual(-1);
+      expect(px).toBeLessThanOrEqual(VIEWPORT.width + 1);
+    }
+    for (const py of model.y.pixels) {
+      expect(py).toBeGreaterThanOrEqual(-1);
+      expect(py).toBeLessThanOrEqual(VIEWPORT.height + 1);
+    }
+  });
+
+  it('runs height upward on screen', () => {
+    const model = profileAxes(VIEW, VIEWPORT, BASE);
+    for (let i = 1; i < model.y.pixels.length; i++) {
+      expect(model.y.pixels[i]!).toBeLessThan(model.y.pixels[i - 1]!);
+    }
+  });
+
+  it('titles the height axis honestly for an undeclared datum', () => {
+    expect(profileAxes(VIEW, VIEWPORT, BASE).y.title).toBe('Height (datum unknown) (m)');
+  });
+
+  it('switches the chainage axis to stationing on request', () => {
+    const model = profileAxes(VIEW, VIEWPORT, { ...BASE, stationing: true });
+    expect(model.x.labels[0]).toMatch(/^-?\d+\+\d+\.\d{2}$/);
+  });
+
+  it('falls back to plain chainage when stationing cannot be stated', () => {
+    const model = profileAxes(VIEW, VIEWPORT, {
+      ...BASE,
+      stationing: true,
+      units: { horizontalToMetres: null, verticalToMetres: null },
+    });
+    for (const label of model.x.labels) expect(label).toMatch(PLAIN_DECIMAL);
+  });
+
+  it('honours the default target tick count', () => {
+    const model = profileAxes(VIEW, VIEWPORT, BASE);
+    expect(model.x.ticks.values.length).toBeLessThanOrEqual(DEFAULT_TARGET_TICKS + 1);
+    expect(model.y.ticks.values.length).toBeLessThanOrEqual(DEFAULT_TARGET_TICKS + 1);
+  });
+
+  it('honours an explicit target per axis', () => {
+    const model = profileAxes(VIEW, VIEWPORT, {
+      ...BASE,
+      targetXTicks: 10,
+      targetYTicks: 3,
+    });
+    expect(model.x.ticks.values.length).toBeGreaterThan(model.y.ticks.values.length);
+  });
+
+  it('emits minor positions between the major ones', () => {
+    const model = profileAxes(VIEW, VIEWPORT, BASE);
+    expect(model.x.minorPixels.length).toBeGreaterThan(model.x.pixels.length);
+    for (const px of model.x.minorPixels) expect(Number.isFinite(px)).toBe(true);
+  });
+});

--- a/tests/profileViewTransform.test.ts
+++ b/tests/profileViewTransform.test.ts
@@ -1,0 +1,299 @@
+/**
+ * profileViewTransform.test.ts
+ *
+ * The section viewport transform, its inverse, and vertical exaggeration.
+ *
+ * Exaggeration is asserted in physical terms: the pixels a metre occupies
+ * vertically over the pixels a metre occupies horizontally. Asserting the
+ * ratio of the two axis scales instead would pass even when the axes are in
+ * different units, which is the case the ratio exists to get right.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  fitProfileView,
+  profileDataToScreen,
+  profileScreenToData,
+  panProfileView,
+  zoomProfileViewAt,
+  viewExaggeration,
+  canStateExaggeration,
+  profileVisibleBounds,
+  toDevicePixels,
+  MIN_DATA_SPAN,
+  type ProfileViewport,
+  type ProfileDataBounds,
+  type ProfileUnitContext,
+  type ProfileView,
+} from '../src/render/measure/profileViewTransform';
+
+const VP: ProfileViewport = { width: 800, height: 300, devicePixelRatio: 2 };
+const BOUNDS: ProfileDataBounds = {
+  minChainage: 0,
+  maxChainage: 200,
+  minHeight: 120,
+  maxHeight: 150,
+};
+const METRES: ProfileUnitContext = { horizontalToMetres: 1, verticalToMetres: 1 };
+const FEET_H: ProfileUnitContext = { horizontalToMetres: 0.3048, verticalToMetres: 1 };
+const UNKNOWN_V: ProfileUnitContext = { horizontalToMetres: 1, verticalToMetres: null };
+
+const s = new Float64Array(2);
+const d = new Float64Array(2);
+
+/** Pixels a physical metre occupies on each axis. */
+function pxPerMetre(view: ProfileView, u: ProfileUnitContext): [number, number] {
+  return [view.pxPerChainage / u.horizontalToMetres!, view.pxPerHeight / u.verticalToMetres!];
+}
+
+describe('fit', () => {
+  it('puts the data extent in the viewport and centres it', () => {
+    const v = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    expect(v.centreChainage).toBe(100);
+    expect(v.centreHeight).toBe(135);
+    profileDataToScreen(v, VP, 0, 150, s);
+    expect(s[0]).toBeCloseTo(0, 9);
+    expect(s[1]).toBeCloseTo(0, 9);
+    profileDataToScreen(v, VP, 200, 120, s);
+    expect(s[0]).toBeCloseTo(800, 9);
+    expect(s[1]).toBeCloseTo(300, 9);
+  });
+
+  it('scales the axes independently and claims no ratio', () => {
+    const v = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    expect(v.pxPerChainage).toBeCloseTo(4, 9);
+    expect(v.pxPerHeight).toBeCloseTo(10, 9);
+  });
+});
+
+describe('round trip', () => {
+  const v = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+  it('returns the same data point through screen space', () => {
+    for (let i = 0; i < 500; i++) {
+      const g = (i * 0.6180339887498949) % 1;
+      const c = BOUNDS.minChainage + g * 200;
+      const h = BOUNDS.minHeight + ((i * 7 * 0.6180339887498949) % 1) * 30;
+      profileDataToScreen(v, VP, c, h, s);
+      profileScreenToData(v, VP, s[0]!, s[1]!, d);
+      expect(d[0]).toBeCloseTo(c, 9);
+      expect(d[1]).toBeCloseTo(h, 9);
+    }
+  });
+
+  it('maps height upward on screen', () => {
+    profileDataToScreen(v, VP, 100, 140, s);
+    const high = s[1]!;
+    profileDataToScreen(v, VP, 100, 130, s);
+    expect(s[1]!).toBeGreaterThan(high);
+  });
+});
+
+describe('pan and zoom', () => {
+  const base = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+
+  it('pans by exactly the screen delta', () => {
+    const p = panProfileView(base, 40, -25);
+    profileDataToScreen(base, VP, 100, 135, s);
+    const before = [s[0]!, s[1]!];
+    profileDataToScreen(p, VP, 100, 135, s);
+    expect(s[0]! - before[0]!).toBeCloseTo(40, 9);
+    expect(s[1]! - before[1]!).toBeCloseTo(-25, 9);
+  });
+
+  it('holds the data under the cursor fixed while zooming', () => {
+    for (const [ax, ay] of [
+      [0, 0],
+      [800, 300],
+      [137, 42],
+      [400, 150],
+    ]) {
+      profileScreenToData(base, VP, ax!, ay!, d);
+      const anchored = [d[0]!, d[1]!];
+      let v = base;
+      for (let i = 0; i < 6; i++) v = zoomProfileViewAt(v, VP, ax!, ay!, 1.2);
+      profileScreenToData(v, VP, ax!, ay!, d);
+      expect(d[0]).toBeCloseTo(anchored[0]!, 6);
+      expect(d[1]).toBeCloseTo(anchored[1]!, 6);
+    }
+  });
+
+  it('zooming out then in returns the original scale', () => {
+    let v = zoomProfileViewAt(base, VP, 300, 100, 1.2);
+    v = zoomProfileViewAt(v, VP, 300, 100, 1 / 1.2);
+    expect(v.pxPerChainage).toBeCloseTo(base.pxPerChainage, 9);
+    expect(v.pxPerHeight).toBeCloseTo(base.pxPerHeight, 9);
+    expect(v.centreChainage).toBeCloseTo(base.centreChainage, 6);
+  });
+
+  it('ignores a non-finite or non-positive zoom factor', () => {
+    expect(zoomProfileViewAt(base, VP, 100, 100, Number.NaN)).toBe(base);
+    expect(zoomProfileViewAt(base, VP, 100, 100, 0)).toBe(base);
+    expect(zoomProfileViewAt(base, VP, 100, 100, -2)).toBe(base);
+  });
+});
+
+describe('true vertical exaggeration', () => {
+  for (const ratio of [1, 2, 5, 10]) {
+    it(`VE ${ratio}x gives a metre ${ratio}x the pixels vertically`, () => {
+      const v = fitProfileView(BOUNDS, VP, { kind: 've', ratio }, METRES)!;
+      const [mx, my] = pxPerMetre(v, METRES);
+      expect(my / mx).toBeCloseTo(ratio, 9);
+      expect(viewExaggeration(v, METRES)).toBeCloseTo(ratio, 9);
+    });
+
+    it(`VE ${ratio}x holds when the axes are in different units`, () => {
+      // Chainage in feet, height in metres. Comparing the two axis scales
+      // directly would be wrong by 1/0.3048 here.
+      const v = fitProfileView(BOUNDS, VP, { kind: 've', ratio }, FEET_H)!;
+      const [mx, my] = pxPerMetre(v, FEET_H);
+      expect(my / mx).toBeCloseTo(ratio, 9);
+      expect(viewExaggeration(v, FEET_H)).toBeCloseTo(ratio, 9);
+      // The raw axis-scale ratio is a different number, so the test above is
+      // not measuring the same thing twice.
+      expect(v.pxPerHeight / v.pxPerChainage).not.toBeCloseTo(ratio, 3);
+    });
+  }
+
+  it('contains the whole extent rather than cropping to hold the ratio', () => {
+    for (const ratio of [1, 2, 5, 10]) {
+      const v = fitProfileView(BOUNDS, VP, { kind: 've', ratio }, METRES)!;
+      const vis = profileVisibleBounds(v, VP);
+      expect(vis.minChainage).toBeLessThanOrEqual(BOUNDS.minChainage + 1e-9);
+      expect(vis.maxChainage).toBeGreaterThanOrEqual(BOUNDS.maxChainage - 1e-9);
+      expect(vis.minHeight).toBeLessThanOrEqual(BOUNDS.minHeight + 1e-9);
+      expect(vis.maxHeight).toBeGreaterThanOrEqual(BOUNDS.maxHeight - 1e-9);
+    }
+  });
+
+  it('survives a zoom', () => {
+    let v = fitProfileView(BOUNDS, VP, { kind: 've', ratio: 5 }, METRES)!;
+    for (let i = 0; i < 5; i++) v = zoomProfileViewAt(v, VP, 250, 90, 1.2);
+    expect(viewExaggeration(v, METRES)).toBeCloseTo(5, 9);
+  });
+
+  it('refuses a ratio when a unit scale is unknown', () => {
+    expect(canStateExaggeration(UNKNOWN_V)).toBe(false);
+    expect(fitProfileView(BOUNDS, VP, { kind: 've', ratio: 2 }, UNKNOWN_V)).toBeNull();
+    const fit = fitProfileView(BOUNDS, VP, { kind: 'fit' }, UNKNOWN_V)!;
+    expect(viewExaggeration(fit, UNKNOWN_V)).toBeNull();
+  });
+
+  it('refuses a ratio that is not a positive number', () => {
+    for (const r of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(fitProfileView(BOUNDS, VP, { kind: 've', ratio: r }, METRES)).toBeNull();
+    }
+  });
+
+  it('refuses a unit scale that is zero or negative', () => {
+    expect(canStateExaggeration({ horizontalToMetres: 0, verticalToMetres: 1 })).toBe(false);
+    expect(canStateExaggeration({ horizontalToMetres: 1, verticalToMetres: -1 })).toBe(false);
+  });
+});
+
+describe('degenerate and hostile input', () => {
+  it('handles a flat section without dividing by zero', () => {
+    const flat: ProfileDataBounds = {
+      minChainage: 0,
+      maxChainage: 200,
+      minHeight: 137.5,
+      maxHeight: 137.5,
+    };
+    const v = fitProfileView(flat, VP, { kind: 'fit' }, METRES)!;
+    expect(Number.isFinite(v.pxPerHeight)).toBe(true);
+    expect(v.pxPerHeight).toBeGreaterThan(0);
+    expect(v.centreHeight).toBe(137.5);
+    profileDataToScreen(v, VP, 100, 137.5, s);
+    expect(Number.isFinite(s[0]!)).toBe(true);
+    expect(Number.isFinite(s[1]!)).toBe(true);
+  });
+
+  it('handles a single-point section on both axes', () => {
+    const pt: ProfileDataBounds = {
+      minChainage: 42,
+      maxChainage: 42,
+      minHeight: 7,
+      maxHeight: 7,
+    };
+    const v = fitProfileView(pt, VP, { kind: 'fit' }, METRES)!;
+    expect(Number.isFinite(v.pxPerChainage)).toBe(true);
+    expect(Number.isFinite(v.pxPerHeight)).toBe(true);
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+  });
+
+  it('keeps a huge chainage span finite', () => {
+    const huge: ProfileDataBounds = {
+      minChainage: -1e15,
+      maxChainage: 1e15,
+      minHeight: 0,
+      maxHeight: 1e12,
+    };
+    const v = fitProfileView(huge, VP, { kind: 'fit' }, METRES)!;
+    expect(Number.isFinite(v.pxPerChainage)).toBe(true);
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+    profileDataToScreen(v, VP, 0, 0, s);
+    expect(Number.isFinite(s[0]!)).toBe(true);
+    expect(Number.isFinite(s[1]!)).toBe(true);
+  });
+
+  it('produces a finite view from non-finite bounds', () => {
+    const bad: ProfileDataBounds = {
+      minChainage: Number.NaN,
+      maxChainage: Number.POSITIVE_INFINITY,
+      minHeight: Number.NEGATIVE_INFINITY,
+      maxHeight: Number.NaN,
+    };
+    const v = fitProfileView(bad, VP, { kind: 'fit' }, METRES)!;
+    for (const n of [v.centreChainage, v.centreHeight, v.pxPerChainage, v.pxPerHeight]) {
+      expect(Number.isFinite(n)).toBe(true);
+    }
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+  });
+
+  it('produces a finite view from a zero-sized viewport', () => {
+    const v = fitProfileView(BOUNDS, { width: 0, height: 0, devicePixelRatio: 1 }, { kind: 'fit' }, METRES)!;
+    expect(v.pxPerChainage).toBeGreaterThan(0);
+    expect(Number.isFinite(v.pxPerHeight)).toBe(true);
+  });
+
+  it('ignores a non-finite pan delta', () => {
+    const base = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    const p = panProfileView(base, Number.NaN, Number.POSITIVE_INFINITY);
+    expect(p.centreChainage).toBe(base.centreChainage);
+    expect(p.centreHeight).toBe(base.centreHeight);
+  });
+
+  it('gives a degenerate axis the documented minimum span', () => {
+    const flat: ProfileDataBounds = {
+      minChainage: 5,
+      maxChainage: 5,
+      minHeight: 0,
+      maxHeight: 10,
+    };
+    const v = fitProfileView(flat, VP, { kind: 'fit' }, METRES)!;
+    expect(v.pxPerChainage).toBeCloseTo(VP.width / MIN_DATA_SPAN, 0);
+  });
+});
+
+describe('device pixels', () => {
+  it('scales by the backing ratio', () => {
+    expect(toDevicePixels(VP, 10)).toBe(20);
+  });
+  it('falls back to 1 for a bad ratio', () => {
+    expect(toDevicePixels({ width: 10, height: 10, devicePixelRatio: 0 }, 10)).toBe(10);
+    expect(toDevicePixels({ width: 10, height: 10, devicePixelRatio: Number.NaN }, 10)).toBe(10);
+  });
+});
+
+describe('resize', () => {
+  it('keeps the centre and rescales the fit', () => {
+    const small = fitProfileView(BOUNDS, VP, { kind: 'fit' }, METRES)!;
+    const wide = fitProfileView(
+      BOUNDS,
+      { width: 1600, height: 300, devicePixelRatio: 2 },
+      { kind: 'fit' },
+      METRES,
+    )!;
+    expect(wide.centreChainage).toBe(small.centreChainage);
+    expect(wide.pxPerChainage).toBeCloseTo(small.pxPerChainage * 2, 9);
+    expect(wide.pxPerHeight).toBeCloseTo(small.pxPerHeight, 9);
+  });
+});


### PR DESCRIPTION
Stacked on #509, which it carries.

Ticks land on a 1/2/5 times a power of ten step with a resolution floor, and each is an integer multiple snapped to the places that step needs, so a label never reads 12.000000000000002. Minor divisions follow the step's leading digit.

The Y axis word comes from `heightLabel` in `src/geo/height.ts`, so `Elevation` appears only for an orthometric reference. The local case uses `Local height`, the word the profile PDF and the measure panel already use.

Tick labels are bare numbers with the unit in the axis title, since the existing length formatters band the unit per value. Civil stationing routes through `formatStation`.
