### PR TITLE
Colour section returns by capability, never by fabricated values

### DIFF
--- a/src/render/measure/profileColour.ts
+++ b/src/render/measure/profileColour.ts
@@ -1,0 +1,904 @@
+/**
+ * profileColour.ts
+ *
+ * Colour the returns of a profile cross-section, and say what the colours
+ * mean.
+ *
+ * The 2D section is a second view of the same returns the 3D scene holds, so
+ * it colours them through the SAME primitives: `colorByScalar` /
+ * `colorByIntensity` for the ramped scalars, `colorByClassification` and
+ * `classColor` for the ASPRS classes, `computeScalarRange` for the percentile
+ * window. A section that painted its own ramp would drift from the scene it
+ * is a section of, and a legend swatch would stop matching the pixels.
+ *
+ * Four rules the section adds on top of those primitives:
+ *
+ *   1. UNORDERED IDS NEVER GET A RAMP. `colorModes.ts` refuses `pointSourceId`
+ *      a colour mode outright: the id is absent from its `ColorMode` union, so
+ *      no ramp signature in that module accepts one. The same refusal is
+ *      spelled here as a type: {@link ProfileRampMode} lists the four ordered
+ *      scalars, {@link profileRampPalette} is the only door to a ramp, and it
+ *      accepts nothing else. Point source id and source layer are
+ *      {@link ProfileCategoricalMode}s and take the qualitative palette.
+ *      Flight line 7 is not "more" than flight line 3, and a sequential ramp
+ *      would claim it is.
+ *
+ *   2. A MISSING ATTRIBUTE IS NOT A ZERO. A section can mix a source that
+ *      carries intensity with one that does not, and `channelPresence` records
+ *      that per point. A point whose bit is clear takes
+ *      {@link PROFILE_UNKNOWN_COLOUR} and is counted into the legend's unknown
+ *      bucket. It is never fed to the ramp, and it never reaches the range
+ *      computation, so an absent intensity cannot pull the window down to 0
+ *      nor read as a measured dark return.
+ *
+ *   3. A HEIGHT RANGE IS NAMED. Section-local, active layer, and project
+ *      shared answer different questions — the shape of this cut, this layer
+ *      against itself, this cut against the whole project — and produce
+ *      different pictures from the same points. The caller asks for one and
+ *      the legend reports which was used, so a reader is never left to guess
+ *      what the ramp endpoints refer to.
+ *
+ *   4. A MODE WITH TOO LITTLE BEHIND IT IS NOT OFFERED. See
+ *      {@link profileModeAvailability}.
+ *
+ * Output goes into a caller-owned `Uint8Array` of RGB triplets, one triplet
+ * per displayed index. Per call the module allocates a scratch value buffer, a
+ * scratch slot buffer, and the legend; nothing is allocated per point.
+ *
+ * Pure — no DOM, no canvas — so the rules are testable without a renderer.
+ */
+
+import type { ElevationPalette } from '../colorModes';
+import {
+  DEFAULT_ELEVATION_PALETTE,
+  DEFAULT_SCALAR_PALETTE,
+  classColor,
+  colorblindSafeClasses,
+  colorByClassification,
+  colorByIntensity,
+  colorByScalar,
+} from '../colorModes';
+import { computeScalarRange } from '../elevationRange';
+import { classificationLabel } from '../pointInfo';
+import type { ProfileAttribute, ProfileSectionPoints } from './profileSectionBuilder';
+import { profileSectionHas } from './profileSectionBuilder';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Modes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The four scalars a section can ramp.
+ *
+ * Every one of them is ORDERED: height rises, intensity is a return strength,
+ * a 2nd return follows a 1st, and GPS time runs forwards. A perceptual ramp
+ * encodes that order honestly. Nothing else belongs in this union — adding a
+ * member is the act of claiming its values have a magnitude.
+ */
+export type ProfileRampMode = 'height' | 'intensity' | 'returnNumber' | 'gpsTime';
+
+/**
+ * The three id-like attributes, painted from a qualitative palette.
+ *
+ * Class 6 is not twice class 3 and flight line 7 is not more than flight line
+ * 3, so these get colours that differ without ordering. They are excluded from
+ * {@link ProfileRampMode} by construction, which is how `colorModes.ts` keeps
+ * `pointSourceId` off its ramps: the type simply does not admit them.
+ */
+export type ProfileCategoricalMode = 'classification' | 'sourceLayer' | 'pointSourceId';
+
+/** RGB, which is already a colour and is copied through unchanged. */
+export type ProfileDirectMode = 'rgb';
+
+/** Everything a section can be coloured by. */
+export type ProfileColourMode = ProfileRampMode | ProfileCategoricalMode | ProfileDirectMode;
+
+/** How a mode turns a value into a colour. */
+export type ProfileColourKind = 'ramp' | 'categorical' | 'direct' | 'unavailable';
+
+const RAMP_MODES: ReadonlySet<ProfileColourMode> = new Set<ProfileRampMode>([
+  'height',
+  'intensity',
+  'returnNumber',
+  'gpsTime',
+]);
+
+const CATEGORICAL_MODES: ReadonlySet<ProfileColourMode> = new Set<ProfileCategoricalMode>([
+  'classification',
+  'sourceLayer',
+  'pointSourceId',
+]);
+
+/** Every mode, in the order a picker should list them. */
+export const PROFILE_COLOUR_MODES: readonly ProfileColourMode[] = [
+  'rgb',
+  'height',
+  'intensity',
+  'classification',
+  'returnNumber',
+  'gpsTime',
+  'sourceLayer',
+  'pointSourceId',
+];
+
+/** Whether `mode` ramps, keys a qualitative palette, or copies bytes. */
+export function profileColourKind(mode: ProfileColourMode): Exclude<ProfileColourKind, 'unavailable'> {
+  if (RAMP_MODES.has(mode)) return 'ramp';
+  if (CATEGORICAL_MODES.has(mode)) return 'categorical';
+  return 'direct';
+}
+
+/**
+ * The ramp each ordered scalar uses.
+ *
+ * Height keeps elevation's Turbo default and the other three keep the scalar
+ * default (CVD-safe Cividis), the same split `colorModes.ts` makes, so a
+ * section and the 3D scene show one scalar in one ramp.
+ *
+ * This is the only function in the module that names a palette, and its
+ * parameter type is {@link ProfileRampMode}. A categorical mode cannot be
+ * passed to it, so no ramp lookup can be reached for an unordered id.
+ */
+export function profileRampPalette(mode: ProfileRampMode): ElevationPalette {
+  return mode === 'height' ? DEFAULT_ELEVATION_PALETTE : DEFAULT_SCALAR_PALETTE;
+}
+
+/** The presence bit a mode reads, or null when the mode needs no channel. */
+function attributeFor(mode: ProfileColourMode): ProfileAttribute | null {
+  switch (mode) {
+    case 'rgb':
+      return 'rgb';
+    case 'intensity':
+      return 'intensity';
+    case 'classification':
+      return 'classification';
+    case 'returnNumber':
+      return 'returnNumber';
+    case 'gpsTime':
+      return 'gpsTime';
+    case 'pointSourceId':
+      return 'pointSourceId';
+    // Height and source slot are recorded for every accepted return by the
+    // section builder itself, so they have no presence bit to read.
+    case 'height':
+    case 'sourceLayer':
+      return null;
+  }
+}
+
+/** True when the section carries the array `mode` reads at all. */
+function channelPresent(points: ProfileSectionPoints, mode: ProfileColourMode): boolean {
+  switch (mode) {
+    case 'rgb':
+      return points.rgb != null;
+    case 'intensity':
+      return points.intensity != null;
+    case 'classification':
+      return points.classification != null;
+    case 'returnNumber':
+      return points.returnNumber != null;
+    case 'gpsTime':
+      return points.gpsTime != null;
+    case 'pointSourceId':
+      return points.pointSourceId != null;
+    case 'height':
+    case 'sourceLayer':
+      return true;
+  }
+}
+
+/** The value `mode` reads at section index `i`. Ramp and categorical only. */
+function valueAt(points: ProfileSectionPoints, mode: ProfileColourMode, i: number): number {
+  switch (mode) {
+    case 'height':
+      return points.height[i];
+    case 'intensity':
+      return points.intensity![i];
+    case 'returnNumber':
+      return points.returnNumber![i];
+    case 'gpsTime':
+      return points.gpsTime![i];
+    case 'classification':
+      return points.classification![i];
+    case 'pointSourceId':
+      return points.pointSourceId![i];
+    case 'sourceLayer':
+      return points.sourceSlot[i];
+    case 'rgb':
+      return 0;
+  }
+}
+
+/**
+ * True when point `i` carries what `mode` needs.
+ *
+ * Structural attributes are always carried. A channel attribute is carried
+ * only where its presence bit is set, and a ramped value additionally has to
+ * be finite: a NaN height is as absent as a missing one, and both belong in
+ * the unknown bucket rather than at a ramp endpoint.
+ */
+function supports(points: ProfileSectionPoints, mode: ProfileColourMode, i: number): boolean {
+  if (i < 0 || i >= points.count) return false;
+  const attr = attributeFor(mode);
+  if (attr !== null && !profileSectionHas(points, i, attr)) return false;
+  if (RAMP_MODES.has(mode)) return Number.isFinite(valueAt(points, mode, i));
+  return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Availability
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Fewest supporting points a mode needs before it is offered.
+ *
+ * Below this the colouring is a handful of stray dots against a field of
+ * unknown grey, which reads as a rendering fault rather than as a thin
+ * attribute.
+ */
+export const PROFILE_MODE_MIN_POINTS = 8;
+
+/** Smallest share of the displayed points a mode needs behind it. */
+export const PROFILE_MODE_MIN_FRACTION = 0.25;
+
+/** Why a mode is or is not offered. */
+export type ProfileModeReason =
+  /** Offered. */
+  | 'ok'
+  /** No source in the section carries the attribute. */
+  | 'absent'
+  /** Fewer than {@link PROFILE_MODE_MIN_POINTS} displayed points carry it. */
+  | 'tooFewPoints'
+  /** Under {@link PROFILE_MODE_MIN_FRACTION} of the displayed points carry it. */
+  | 'tooSmallFraction'
+  /** Every supporting point carries the same value, so the mode has one colour. */
+  | 'noVariation';
+
+/** What the availability rule found for one mode. */
+export interface ProfileModeAvailability {
+  readonly mode: ProfileColourMode;
+  readonly available: boolean;
+  readonly reason: ProfileModeReason;
+  /** Displayed points that carry the attribute. */
+  readonly supporting: number;
+  /** Displayed points in total. */
+  readonly displayed: number;
+  /**
+   * Distinct values among the supporting points, counted up to 2. Two is all
+   * the rule needs, and stopping there keeps a 16-bit id space from building a
+   * set the size of the section.
+   */
+  readonly distinct: number;
+}
+
+/**
+ * Whether `mode` has enough behind it to be offered for `indices`.
+ *
+ * THE RULE. A mode is available when all three hold:
+ *
+ *   1. the section carries the attribute at all (some source supplied it);
+ *   2. at least {@link PROFILE_MODE_MIN_POINTS} of the displayed points carry
+ *      it, AND at least {@link PROFILE_MODE_MIN_FRACTION} of them do;
+ *   3. those supporting points hold at least two distinct values.
+ *
+ * The count and the fraction are both required because either alone fails at
+ * one end: a fixed count would offer a mode backed by 30 points out of a
+ * million, and a fraction alone would offer one backed by 3 points out of 6.
+ *
+ * Clause 3 is what "one colour" means per kind. A ramp whose supporting values
+ * do not vary paints every point the ramp's bottom colour; a categorical mode
+ * with one category paints every point one swatch. In both cases the picture
+ * carries no information the section did not already show, and a uniform wash
+ * reads as a broken render — the same reasoning `colorModeSupport.ts` gives for
+ * refusing a mode whose attribute is missing outright.
+ */
+export function profileModeAvailability(
+  points: ProfileSectionPoints,
+  mode: ProfileColourMode,
+  indices: ArrayLike<number>,
+): ProfileModeAvailability {
+  const displayed = indices.length;
+  if (!channelPresent(points, mode)) {
+    return { mode, available: false, reason: 'absent', supporting: 0, displayed, distinct: 0 };
+  }
+
+  let supporting = 0;
+  let distinct = 0;
+  const direct = mode === 'rgb';
+  const rgb = points.rgb;
+  let firstKey = 0;
+  let sawFirst = false;
+
+  for (let k = 0; k < displayed; k++) {
+    const i = indices[k];
+    if (!supports(points, mode, i)) continue;
+    supporting++;
+    if (distinct >= 2) continue;
+    const key = direct
+      ? (rgb![i * 3] << 16) | (rgb![i * 3 + 1] << 8) | rgb![i * 3 + 2]
+      : valueAt(points, mode, i);
+    if (!sawFirst) {
+      firstKey = key;
+      sawFirst = true;
+      distinct = 1;
+    } else if (key !== firstKey) {
+      distinct = 2;
+    }
+  }
+
+  const fraction = displayed === 0 ? 0 : supporting / displayed;
+  let reason: ProfileModeReason = 'ok';
+  if (supporting < PROFILE_MODE_MIN_POINTS) reason = 'tooFewPoints';
+  else if (fraction < PROFILE_MODE_MIN_FRACTION) reason = 'tooSmallFraction';
+  else if (distinct < 2) reason = 'noVariation';
+
+  return { mode, available: reason === 'ok', reason, supporting, displayed, distinct };
+}
+
+/** Every mode the section can honestly offer for `indices`, in picker order. */
+export function availableProfileColourModes(
+  points: ProfileSectionPoints,
+  indices: ArrayLike<number>,
+): ProfileColourMode[] {
+  return PROFILE_COLOUR_MODES.filter((m) => profileModeAvailability(points, m, indices).available);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Height range
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Which heights the ramp is normalised against.
+ *
+ * `sectionLocal` spends the whole palette on this cut, which shows its shape
+ * best and makes two cuts incomparable. `activeLayer` normalises one layer
+ * against itself, so a thin layer inside a tall section keeps its detail.
+ * `projectShared` uses a window the caller holds for the whole project, which
+ * is the only one under which two sections can be read side by side.
+ */
+export type ProfileHeightRangeScope = 'sectionLocal' | 'activeLayer' | 'projectShared';
+
+/** A height-range request. The caller picks; this module never guesses. */
+export type ProfileHeightRangeRequest =
+  | { readonly scope: 'sectionLocal' }
+  | { readonly scope: 'activeLayer'; readonly slot: number }
+  | { readonly scope: 'projectShared'; readonly min: number; readonly max: number };
+
+/**
+ * The window a ramp was normalised against, and where it came from.
+ *
+ * Returned with the colours so a legend can state the scope rather than
+ * implying one. `trueMin` / `trueMax` are the unclipped extremes of whatever
+ * was sampled, so a legend can say the endpoints are a percentile window.
+ */
+export interface ProfileRampRange {
+  readonly scope: ProfileHeightRangeScope;
+  readonly min: number;
+  readonly max: number;
+  readonly trueMin: number;
+  readonly trueMax: number;
+  /** Set only for `activeLayer`. */
+  readonly slot?: number;
+  /** Human label for the scope, e.g. "This section". */
+  readonly label: string;
+}
+
+const SCOPE_LABEL: Readonly<Record<ProfileHeightRangeScope, string>> = {
+  sectionLocal: 'This section',
+  activeLayer: 'Active layer',
+  projectShared: 'Project shared',
+};
+
+/**
+ * The scope a mode other than height ranges over.
+ *
+ * Intensity, return number, and GPS time are normalised against the section's
+ * own supporting values. They are reported with the same `scope` field as
+ * height so a legend reads one shape for every ramp, and so "section local"
+ * is stated rather than assumed.
+ */
+const NON_HEIGHT_SCOPE: ProfileHeightRangeScope = 'sectionLocal';
+
+/**
+ * Default height scope, applied when a caller passes none.
+ *
+ * Section-local, and named as such in the returned legend. The default exists
+ * so a caller can omit the field; it does not let the choice go unreported.
+ */
+export const DEFAULT_PROFILE_HEIGHT_SCOPE: ProfileHeightRangeRequest = { scope: 'sectionLocal' };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Qualitative palette
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Qualitative colours for unordered ids — flight lines and source layers.
+ *
+ * Hues chosen to be far apart with no luminance order, so nothing about the
+ * sequence suggests a magnitude. Cycled by position in the sorted id list, so
+ * a section with more ids than colours repeats rather than ramps.
+ */
+const QUALITATIVE: readonly (readonly [number, number, number])[] = [
+  [ 31, 119, 180],
+  [255, 127,  14],
+  [ 44, 160,  44],
+  [214,  39,  40],
+  [148, 103, 189],
+  [140,  86,  75],
+  [227, 119, 194],
+  [127, 127, 127],
+  [188, 189,  34],
+  [ 23, 190, 207],
+  [ 96,  70, 160],
+  [200, 160,  60],
+];
+
+/**
+ * The colourblind-safe qualitative set — Okabe-Ito, the same palette the
+ * colourblind-safe class colours in `colorModes.ts` are built on.
+ *
+ * Selected by the SAME global switch, read through `colorblindSafeClasses()`.
+ * A user who turned that on to separate ground from buildings would otherwise
+ * still get red/green flight lines from the set above.
+ */
+const QUALITATIVE_CVD: readonly (readonly [number, number, number])[] = [
+  [  0, 114, 178],
+  [230, 159,   0],
+  [  0, 158, 115],
+  [213,  94,   0],
+  [204, 121, 167],
+  [ 86, 180, 233],
+  [240, 228,  66],
+  [ 90,  90,  90],
+];
+
+/** The qualitative palette the colourblind-safe setting currently selects. */
+function qualitativePalette(): readonly (readonly [number, number, number])[] {
+  return colorblindSafeClasses() ? QUALITATIVE_CVD : QUALITATIVE;
+}
+
+/**
+ * The colour a point takes when its attribute is absent.
+ *
+ * A desaturated slate that no ramp endpoint and no class swatch lands on, and
+ * that no greyscale value can equal (its blue channel differs from its red and
+ * green). Absent has to look like absent, not like a low measurement.
+ */
+export const PROFILE_UNKNOWN_COLOUR: readonly [number, number, number] = [110, 110, 118];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Legend
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One swatch of a categorical legend. */
+export interface ProfileColourCategory {
+  /** The class code, source id, or source slot this swatch stands for. */
+  readonly value: number;
+  readonly label: string;
+  readonly colour: readonly [number, number, number];
+  /** Displayed points that took this swatch. */
+  readonly count: number;
+}
+
+/** The legend row for points whose attribute was absent. */
+export interface ProfileUnknownBucket {
+  readonly label: string;
+  readonly colour: readonly [number, number, number];
+  readonly count: number;
+}
+
+/**
+ * Everything a legend needs to describe the colouring it labels.
+ *
+ * `range` and `categories` are mutually exclusive by `kind`, and `unknown` is
+ * non-null exactly when at least one displayed point was coloured as unknown,
+ * so a legend can never omit a bucket the picture contains.
+ */
+export interface ProfileColourLegend {
+  readonly mode: ProfileColourMode;
+  readonly kind: ProfileColourKind;
+  /** Set for `ramp`; null otherwise, including for every categorical mode. */
+  readonly palette: ElevationPalette | null;
+  /** Set for `ramp`; carries the scope the window came from. */
+  readonly range: ProfileRampRange | null;
+  /** Set for `categorical`, ordered by ascending value. */
+  readonly categories: readonly ProfileColourCategory[] | null;
+  /** Non-null when the picture contains unknown-coloured points. */
+  readonly unknown: ProfileUnknownBucket | null;
+  /** Whether the colourblind-safe categorical palettes were in force. */
+  readonly colourblindSafe: boolean;
+}
+
+/** What one colouring pass produced. */
+export interface ProfileColourResult {
+  readonly mode: ProfileColourMode;
+  /** Triplets written into the output buffer. Equals `indices.length`. */
+  readonly count: number;
+  /** How many of those took {@link PROFILE_UNKNOWN_COLOUR}. */
+  readonly unknownCount: number;
+  readonly availability: ProfileModeAvailability;
+  readonly legend: ProfileColourLegend;
+}
+
+/** A colouring request. */
+export interface ProfileColourRequest {
+  readonly points: ProfileSectionPoints;
+  readonly mode: ProfileColourMode;
+  /** Section indices to colour, in the order the caller draws them. */
+  readonly indices: ArrayLike<number>;
+  /**
+   * Which heights the height ramp normalises against. Defaults to
+   * {@link DEFAULT_PROFILE_HEIGHT_SCOPE}, and whatever is used is reported in
+   * `legend.range.scope`.
+   */
+  readonly heightRange?: ProfileHeightRangeRequest;
+  /** Layer names by source slot, for the `sourceLayer` legend. */
+  readonly sourceLabels?: ReadonlyMap<number, string>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Colouring
+// ─────────────────────────────────────────────────────────────────────────────
+
+function writeUnknown(out: Uint8Array, k: number): void {
+  out[k * 3] = PROFILE_UNKNOWN_COLOUR[0];
+  out[k * 3 + 1] = PROFILE_UNKNOWN_COLOUR[1];
+  out[k * 3 + 2] = PROFILE_UNKNOWN_COLOUR[2];
+}
+
+function unknownBucket(count: number): ProfileUnknownBucket | null {
+  return count === 0
+    ? null
+    : { label: 'Unknown (attribute not carried)', colour: PROFILE_UNKNOWN_COLOUR, count };
+}
+
+/**
+ * Fill `out` with one RGB triplet per entry of `request.indices`.
+ *
+ * `out` must hold at least `indices.length * 3` bytes; a shorter buffer throws
+ * rather than colouring part of the section.
+ *
+ * A mode the availability rule refuses is not encoded at all: every displayed
+ * point takes the unknown colour and the legend comes back with kind
+ * `'unavailable'`. Painting it anyway would show a picture the data does not
+ * support, and a caller that offers only
+ * {@link availableProfileColourModes} never reaches this branch.
+ */
+export function colourProfileSection(
+  request: ProfileColourRequest,
+  out: Uint8Array,
+): ProfileColourResult {
+  const { points, mode, indices } = request;
+  const n = indices.length;
+  if (out.length < n * 3) {
+    throw new RangeError(`profile colour buffer holds ${out.length} bytes, needs ${n * 3}`);
+  }
+
+  const availability = profileModeAvailability(points, mode, indices);
+  const colourblindSafe = colorblindSafeClasses();
+
+  if (!availability.available) {
+    for (let k = 0; k < n; k++) writeUnknown(out, k);
+    return {
+      mode,
+      count: n,
+      unknownCount: n,
+      availability,
+      legend: {
+        mode,
+        kind: 'unavailable',
+        palette: null,
+        range: null,
+        categories: null,
+        unknown: unknownBucket(n),
+        colourblindSafe,
+      },
+    };
+  }
+
+  switch (profileColourKind(mode)) {
+    case 'direct':
+      return colourDirect(request, out, availability, colourblindSafe);
+    case 'categorical':
+      return colourCategorical(
+        request,
+        mode as ProfileCategoricalMode,
+        out,
+        availability,
+        colourblindSafe,
+      );
+    case 'ramp':
+      return colourRamp(request, mode as ProfileRampMode, out, availability, colourblindSafe);
+  }
+}
+
+/** RGB — the bytes the source already carried, copied through. */
+function colourDirect(
+  request: ProfileColourRequest,
+  out: Uint8Array,
+  availability: ProfileModeAvailability,
+  colourblindSafe: boolean,
+): ProfileColourResult {
+  const { points, indices } = request;
+  const n = indices.length;
+  const rgb = points.rgb!;
+  let unknown = 0;
+  for (let k = 0; k < n; k++) {
+    const i = indices[k];
+    if (!supports(points, 'rgb', i)) {
+      writeUnknown(out, k);
+      unknown++;
+      continue;
+    }
+    out[k * 3] = rgb[i * 3];
+    out[k * 3 + 1] = rgb[i * 3 + 1];
+    out[k * 3 + 2] = rgb[i * 3 + 2];
+  }
+  return {
+    mode: 'rgb',
+    count: n,
+    unknownCount: unknown,
+    availability,
+    legend: {
+      mode: 'rgb',
+      kind: 'direct',
+      palette: null,
+      range: null,
+      categories: null,
+      unknown: unknownBucket(unknown),
+      colourblindSafe,
+    },
+  };
+}
+
+/**
+ * Classification, source layer, and point source id.
+ *
+ * The distinct values are sorted ascending and the palette is indexed by
+ * position in that sorted list, so an id's colour depends only on the set of
+ * ids in the section — never on the order the returns were drawn in, and never
+ * on a hash or a random draw. Classification does not use that palette at all:
+ * it goes through `colorByClassification` and `classColor`, so the section
+ * shows the ASPRS colours the 3D scene shows, including the colourblind-safe
+ * variant when that setting is on.
+ */
+function colourCategorical(
+  request: ProfileColourRequest,
+  mode: ProfileCategoricalMode,
+  out: Uint8Array,
+  availability: ProfileModeAvailability,
+  colourblindSafe: boolean,
+): ProfileColourResult {
+  const { points, indices, sourceLabels } = request;
+  const n = indices.length;
+
+  // Gather the supporting values, and the output slot each belongs to.
+  const values = new Float64Array(n);
+  const slots = new Uint32Array(n);
+  let m = 0;
+  let unknown = 0;
+  for (let k = 0; k < n; k++) {
+    const i = indices[k];
+    if (!supports(points, mode, i)) {
+      writeUnknown(out, k);
+      unknown++;
+      continue;
+    }
+    values[m] = valueAt(points, mode, i);
+    slots[m] = k;
+    m++;
+  }
+
+  const counts = new Map<number, number>();
+  for (let j = 0; j < m; j++) counts.set(values[j], (counts.get(values[j]) ?? 0) + 1);
+  const ordered = [...counts.keys()].sort((a, b) => a - b);
+
+  const categories: ProfileColourCategory[] = [];
+  const colourOf = new Map<number, readonly [number, number, number]>();
+
+  if (mode === 'classification') {
+    // One shared pass through OLV's class palette, so a section and the scene
+    // paint the same code the same colour.
+    const packed = new Uint8Array(m);
+    for (let j = 0; j < m; j++) packed[j] = values[j] & 0xff;
+    const bytes = colorByClassification(packed, m);
+    for (let j = 0; j < m; j++) {
+      const k = slots[j];
+      out[k * 3] = bytes[j * 3];
+      out[k * 3 + 1] = bytes[j * 3 + 1];
+      out[k * 3 + 2] = bytes[j * 3 + 2];
+    }
+    for (const code of ordered) {
+      categories.push({
+        value: code,
+        label: classificationLabel(code),
+        colour: classColor(code),
+        count: counts.get(code)!,
+      });
+    }
+  } else {
+    const palette = qualitativePalette();
+    ordered.forEach((value, rank) => colourOf.set(value, palette[rank % palette.length]));
+    for (let j = 0; j < m; j++) {
+      const c = colourOf.get(values[j])!;
+      const k = slots[j];
+      out[k * 3] = c[0];
+      out[k * 3 + 1] = c[1];
+      out[k * 3 + 2] = c[2];
+    }
+    for (const value of ordered) {
+      const label =
+        mode === 'sourceLayer'
+          ? (sourceLabels?.get(value) ?? `Layer ${value}`)
+          : `Source ${value}`;
+      const c = colourOf.get(value)!;
+      categories.push({ value, label, colour: [c[0], c[1], c[2]], count: counts.get(value)! });
+    }
+  }
+
+  return {
+    mode,
+    count: n,
+    unknownCount: unknown,
+    availability,
+    legend: {
+      mode,
+      kind: 'categorical',
+      // No palette: a categorical legend draws swatches, not a bar. Naming a
+      // ramp here is the mistake this field's null-ness exists to prevent.
+      palette: null,
+      range: null,
+      categories,
+      unknown: unknownBucket(unknown),
+      colourblindSafe,
+    },
+  };
+}
+
+/**
+ * Height, intensity, return number, and GPS time.
+ *
+ * Values are gathered from the supporting points only, ranged, and then
+ * handed to the same `colorByIntensity` / `colorByScalar` the scene uses, so
+ * the section's pixels come out of OLV's one ramp implementation. Points
+ * without the attribute never enter the gathered buffer, so they neither take
+ * a colour nor move the window.
+ */
+function colourRamp(
+  request: ProfileColourRequest,
+  mode: ProfileRampMode,
+  out: Uint8Array,
+  availability: ProfileModeAvailability,
+  colourblindSafe: boolean,
+): ProfileColourResult {
+  const { points, indices } = request;
+  const n = indices.length;
+  const values = new Float64Array(n);
+  const slots = new Uint32Array(n);
+  let m = 0;
+  let unknown = 0;
+  for (let k = 0; k < n; k++) {
+    const i = indices[k];
+    if (!supports(points, mode, i)) {
+      writeUnknown(out, k);
+      unknown++;
+      continue;
+    }
+    values[m] = valueAt(points, mode, i);
+    slots[m] = k;
+    m++;
+  }
+
+  const range = resolveRampRange(request, mode, values, m);
+  const palette = profileRampPalette(mode);
+  const bytes =
+    mode === 'intensity'
+      ? colorByIntensity(values, m, range.min, range.max, palette)
+      : colorByScalar(values, m, range.min, range.max, palette);
+
+  for (let j = 0; j < m; j++) {
+    const k = slots[j];
+    out[k * 3] = bytes[j * 3];
+    out[k * 3 + 1] = bytes[j * 3 + 1];
+    out[k * 3 + 2] = bytes[j * 3 + 2];
+  }
+
+  return {
+    mode,
+    count: n,
+    unknownCount: unknown,
+    availability,
+    legend: {
+      mode,
+      kind: 'ramp',
+      palette,
+      range,
+      categories: null,
+      unknown: unknownBucket(unknown),
+      colourblindSafe,
+    },
+  };
+}
+
+/**
+ * The window a ramp normalises against, tagged with where it came from.
+ *
+ * Height honours the requested scope. `projectShared` takes the caller's
+ * window verbatim — it is the caller's, and narrowing it would break the
+ * comparison between sections it exists for. `activeLayer` re-gathers the
+ * heights of one source slot; a slot with no displayed points falls back to
+ * the section's own heights AND says so by reporting `sectionLocal`, because a
+ * legend that named an empty layer would describe a window that was not used.
+ *
+ * Return number ranges on raw finite min/max: the ordinals are small, have no
+ * outlier failure mode, and a percentile trim would fold the deepest returns
+ * into the top stop. The other scalars keep the p5–p95 clip
+ * `computeScalarRange` applies by default.
+ */
+function resolveRampRange(
+  request: ProfileColourRequest,
+  mode: ProfileRampMode,
+  gathered: Float64Array,
+  m: number,
+): ProfileRampRange {
+  const raw = mode === 'returnNumber' ? { lowerPercentile: 0, upperPercentile: 100 } : {};
+
+  if (mode !== 'height') {
+    const r = computeScalarRange(gathered, { count: m, ...raw });
+    return {
+      scope: NON_HEIGHT_SCOPE,
+      min: r.min,
+      max: r.max,
+      trueMin: r.trueMin,
+      trueMax: r.trueMax,
+      label: SCOPE_LABEL[NON_HEIGHT_SCOPE],
+    };
+  }
+
+  const req = request.heightRange ?? DEFAULT_PROFILE_HEIGHT_SCOPE;
+
+  if (req.scope === 'projectShared') {
+    return {
+      scope: 'projectShared',
+      min: req.min,
+      max: req.max,
+      trueMin: req.min,
+      trueMax: req.max,
+      label: SCOPE_LABEL.projectShared,
+    };
+  }
+
+  if (req.scope === 'activeLayer') {
+    const { points, indices } = request;
+    const layer = new Float64Array(indices.length);
+    let c = 0;
+    for (let k = 0; k < indices.length; k++) {
+      const i = indices[k];
+      if (!supports(points, 'height', i)) continue;
+      if (points.sourceSlot[i] !== req.slot) continue;
+      layer[c++] = points.height[i];
+    }
+    if (c > 0) {
+      const r = computeScalarRange(layer, { count: c });
+      return {
+        scope: 'activeLayer',
+        min: r.min,
+        max: r.max,
+        trueMin: r.trueMin,
+        trueMax: r.trueMax,
+        slot: req.slot,
+        label: SCOPE_LABEL.activeLayer,
+      };
+    }
+  }
+
+  const r = computeScalarRange(gathered, { count: m });
+  return {
+    scope: 'sectionLocal',
+    min: r.min,
+    max: r.max,
+    trueMin: r.trueMin,
+    trueMax: r.trueMax,
+    label: SCOPE_LABEL.sectionLocal,
+  };
+}

--- a/src/render/measure/profileSectionBuilder.ts
+++ b/src/render/measure/profileSectionBuilder.ts
@@ -1,0 +1,276 @@
+/**
+ * profileSectionBuilder.ts
+ *
+ * Accumulate the returns accepted by a profile corridor into compact typed
+ * arrays, keeping each return's identity and only the attributes its own
+ * source actually carries.
+ *
+ * The derived series reduces a corridor to one height per station. The
+ * section keeps the returns themselves, so every accepted point has to stay
+ * traceable to the source and index it came from, and an attribute that a
+ * source does not carry has to stay absent rather than becoming zero. A
+ * fabricated zero intensity is indistinguishable from a measured one.
+ *
+ * Presence is recorded per point, not per snapshot. A section can mix a
+ * source that carries RGB with one that does not, so `channelPresence`
+ * carries one bit per attribute per point and a consumer reads a channel
+ * only where its bit is set.
+ *
+ * Storage grows by doubling and is copied out at `finish()`, so the
+ * finished arrays are sized to the accepted count rather than to the
+ * scanned count.
+ */
+
+/** The per-point attributes a section can carry through from a source. */
+export type ProfileAttribute =
+  | 'rgb'
+  | 'intensity'
+  | 'classification'
+  | 'returnNumber'
+  | 'returnCount'
+  | 'pointSourceId'
+  | 'gpsTime'
+  | 'normals';
+
+/** Bit position of each attribute inside `channelPresence`. */
+export const PROFILE_ATTRIBUTE_BIT: Readonly<Record<ProfileAttribute, number>> = {
+  rgb: 1 << 0,
+  intensity: 1 << 1,
+  classification: 1 << 2,
+  returnNumber: 1 << 3,
+  returnCount: 1 << 4,
+  pointSourceId: 1 << 5,
+  gpsTime: 1 << 6,
+  normals: 1 << 7,
+};
+
+export const PROFILE_ATTRIBUTES: readonly ProfileAttribute[] = [
+  'rgb',
+  'intensity',
+  'classification',
+  'returnNumber',
+  'returnCount',
+  'pointSourceId',
+  'gpsTime',
+  'normals',
+];
+
+/**
+ * The channels one source carries, aligned to that source's point index.
+ *
+ * A channel is absent when the source does not carry it. A channel whose
+ * length disagrees with the source's point count is treated as absent, the
+ * same rule `sampleProfile` applies to a misaligned classification array.
+ */
+export interface ProfileSourceChannels {
+  readonly rgb?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  readonly pointSourceId?: Uint16Array;
+  readonly gpsTime?: Float64Array;
+  readonly normals?: Float32Array;
+}
+
+/** Accepted returns, as struct-of-arrays. All arrays share one index space. */
+export interface ProfileSectionPoints {
+  readonly count: number;
+  readonly chainage: Float32Array;
+  readonly height: Float32Array;
+  readonly lateralOffset: Float32Array;
+  readonly sourceSlot: Uint16Array;
+  readonly pointIndex: Uint32Array;
+  /** One bit per {@link ProfileAttribute}; see {@link PROFILE_ATTRIBUTE_BIT}. */
+  readonly channelPresence: Uint8Array;
+  readonly rgb?: Uint8Array;
+  readonly intensity?: Uint16Array;
+  readonly classification?: Uint8Array;
+  readonly returnNumber?: Uint8Array;
+  readonly returnCount?: Uint8Array;
+  readonly pointSourceId?: Uint16Array;
+  readonly gpsTime?: Float64Array;
+  readonly normals?: Float32Array;
+}
+
+const INITIAL_CAPACITY = 1024;
+
+function grow<T extends { length: number }>(
+  arr: T,
+  capacity: number,
+  make: (n: number) => T,
+  stride: number,
+): T {
+  const next = make(capacity * stride);
+  (next as unknown as { set(a: T): void }).set(arr);
+  return next;
+}
+
+/**
+ * Collect accepted returns from one or more sources.
+ *
+ * Call {@link beginSource} before the points of each source, then
+ * {@link push} per accepted return, then {@link finish} once.
+ */
+export class ProfileSectionBuilder {
+  private _count = 0;
+  private _capacity = INITIAL_CAPACITY;
+
+  private _chainage = new Float32Array(INITIAL_CAPACITY);
+  private _height = new Float32Array(INITIAL_CAPACITY);
+  private _lateral = new Float32Array(INITIAL_CAPACITY);
+  private _slot = new Uint16Array(INITIAL_CAPACITY);
+  private _index = new Uint32Array(INITIAL_CAPACITY);
+  private _presence = new Uint8Array(INITIAL_CAPACITY);
+
+  private _rgb = new Uint8Array(INITIAL_CAPACITY * 3);
+  private _intensity = new Uint16Array(INITIAL_CAPACITY);
+  private _classification = new Uint8Array(INITIAL_CAPACITY);
+  private _returnNumber = new Uint8Array(INITIAL_CAPACITY);
+  private _returnCount = new Uint8Array(INITIAL_CAPACITY);
+  private _pointSourceId = new Uint16Array(INITIAL_CAPACITY);
+  private _gpsTime = new Float64Array(INITIAL_CAPACITY);
+  private _normals = new Float32Array(INITIAL_CAPACITY * 3);
+
+  /** Attributes seen on at least one source, so only those are emitted. */
+  private _seen = 0;
+
+  private _srcSlot = 0;
+  private _srcChannels: ProfileSourceChannels | null = null;
+  private _srcMask = 0;
+
+  /**
+   * Bind the source whose returns follow.
+   *
+   * `pointCount` is the source's own point count. A channel whose length
+   * disagrees with it is dropped for that source, which keeps a misaligned
+   * array from shifting every attribute by one index.
+   */
+  beginSource(slot: number, channels: ProfileSourceChannels | null, pointCount: number): void {
+    this._srcSlot = slot;
+    this._srcChannels = channels;
+    let mask = 0;
+    if (channels) {
+      if (channels.rgb?.length === pointCount * 3) mask |= PROFILE_ATTRIBUTE_BIT.rgb;
+      if (channels.intensity?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.intensity;
+      if (channels.classification?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.classification;
+      if (channels.returnNumber?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.returnNumber;
+      if (channels.returnCount?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.returnCount;
+      if (channels.pointSourceId?.length === pointCount)
+        mask |= PROFILE_ATTRIBUTE_BIT.pointSourceId;
+      if (channels.gpsTime?.length === pointCount) mask |= PROFILE_ATTRIBUTE_BIT.gpsTime;
+      if (channels.normals?.length === pointCount * 3) mask |= PROFILE_ATTRIBUTE_BIT.normals;
+    }
+    this._srcMask = mask;
+    this._seen |= mask;
+  }
+
+  /** Number of returns accepted so far. */
+  get count(): number {
+    return this._count;
+  }
+
+  private _reserve(): void {
+    if (this._count < this._capacity) return;
+    const next = this._capacity * 2;
+    this._chainage = grow(this._chainage, next, (n) => new Float32Array(n), 1);
+    this._height = grow(this._height, next, (n) => new Float32Array(n), 1);
+    this._lateral = grow(this._lateral, next, (n) => new Float32Array(n), 1);
+    this._slot = grow(this._slot, next, (n) => new Uint16Array(n), 1);
+    this._index = grow(this._index, next, (n) => new Uint32Array(n), 1);
+    this._presence = grow(this._presence, next, (n) => new Uint8Array(n), 1);
+    this._rgb = grow(this._rgb, next, (n) => new Uint8Array(n), 3);
+    this._intensity = grow(this._intensity, next, (n) => new Uint16Array(n), 1);
+    this._classification = grow(this._classification, next, (n) => new Uint8Array(n), 1);
+    this._returnNumber = grow(this._returnNumber, next, (n) => new Uint8Array(n), 1);
+    this._returnCount = grow(this._returnCount, next, (n) => new Uint8Array(n), 1);
+    this._pointSourceId = grow(this._pointSourceId, next, (n) => new Uint16Array(n), 1);
+    this._gpsTime = grow(this._gpsTime, next, (n) => new Float64Array(n), 1);
+    this._normals = grow(this._normals, next, (n) => new Float32Array(n), 3);
+    this._capacity = next;
+  }
+
+  /**
+   * Append one accepted return.
+   *
+   * `sourceIndex` is the point's index in the bound source, and it is what
+   * every channel is read at, so an attribute can never be read from a
+   * different point than the one being appended.
+   */
+  push(sourceIndex: number, chainage: number, height: number, lateralOffset: number): void {
+    this._reserve();
+    const i = this._count;
+    this._chainage[i] = chainage;
+    this._height[i] = height;
+    this._lateral[i] = lateralOffset;
+    this._slot[i] = this._srcSlot;
+    this._index[i] = sourceIndex;
+    this._presence[i] = this._srcMask;
+
+    const c = this._srcChannels;
+    if (c) {
+      const m = this._srcMask;
+      if (m & PROFILE_ATTRIBUTE_BIT.rgb) {
+        this._rgb[i * 3] = c.rgb![sourceIndex * 3];
+        this._rgb[i * 3 + 1] = c.rgb![sourceIndex * 3 + 1];
+        this._rgb[i * 3 + 2] = c.rgb![sourceIndex * 3 + 2];
+      }
+      if (m & PROFILE_ATTRIBUTE_BIT.intensity) this._intensity[i] = c.intensity![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.classification)
+        this._classification[i] = c.classification![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.returnNumber)
+        this._returnNumber[i] = c.returnNumber![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.returnCount)
+        this._returnCount[i] = c.returnCount![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.pointSourceId)
+        this._pointSourceId[i] = c.pointSourceId![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.gpsTime) this._gpsTime[i] = c.gpsTime![sourceIndex];
+      if (m & PROFILE_ATTRIBUTE_BIT.normals) {
+        this._normals[i * 3] = c.normals![sourceIndex * 3];
+        this._normals[i * 3 + 1] = c.normals![sourceIndex * 3 + 1];
+        this._normals[i * 3 + 2] = c.normals![sourceIndex * 3 + 2];
+      }
+    }
+    this._count++;
+  }
+
+  /**
+   * Copy out arrays sized to the accepted count.
+   *
+   * A channel is emitted only when some source carried it. A channel no
+   * source carried is absent from the result rather than present and zero.
+   */
+  finish(): ProfileSectionPoints {
+    const n = this._count;
+    const seen = this._seen;
+    const has = (a: ProfileAttribute): boolean => (seen & PROFILE_ATTRIBUTE_BIT[a]) !== 0;
+    return {
+      count: n,
+      chainage: this._chainage.slice(0, n),
+      height: this._height.slice(0, n),
+      lateralOffset: this._lateral.slice(0, n),
+      sourceSlot: this._slot.slice(0, n),
+      pointIndex: this._index.slice(0, n),
+      channelPresence: this._presence.slice(0, n),
+      ...(has('rgb') ? { rgb: this._rgb.slice(0, n * 3) } : {}),
+      ...(has('intensity') ? { intensity: this._intensity.slice(0, n) } : {}),
+      ...(has('classification') ? { classification: this._classification.slice(0, n) } : {}),
+      ...(has('returnNumber') ? { returnNumber: this._returnNumber.slice(0, n) } : {}),
+      ...(has('returnCount') ? { returnCount: this._returnCount.slice(0, n) } : {}),
+      ...(has('pointSourceId') ? { pointSourceId: this._pointSourceId.slice(0, n) } : {}),
+      ...(has('gpsTime') ? { gpsTime: this._gpsTime.slice(0, n) } : {}),
+      ...(has('normals') ? { normals: this._normals.slice(0, n * 3) } : {}),
+    };
+  }
+}
+
+/** True when point `i` carries attribute `a`. */
+export function profileSectionHas(
+  points: ProfileSectionPoints,
+  i: number,
+  a: ProfileAttribute,
+): boolean {
+  return (points.channelPresence[i]! & PROFILE_ATTRIBUTE_BIT[a]) !== 0;
+}

--- a/src/render/measure/profileSectionBuilder.ts
+++ b/src/render/measure/profileSectionBuilder.ts
@@ -77,7 +77,17 @@ export interface ProfileSourceChannels {
 export interface ProfileSectionPoints {
   readonly count: number;
   readonly chainage: Float32Array;
-  readonly height: Float32Array;
+  /**
+   * Height along `up`, float64.
+   *
+   * Chainage and lateral offset are section relative and bounded by the
+   * section length plus the corridor half width, where float32 resolves
+   * below a millimetre. Height is absolute in the project frame, so it
+   * carries whatever magnitude the frame has: float32 spacing is 3.2e-2 m at
+   * 1e6 and 6.4e-1 m at 1e7. The placement was resolved in float64 during
+   * the read, and storing the result narrower would discard that.
+   */
+  readonly height: Float64Array;
   readonly lateralOffset: Float32Array;
   readonly sourceSlot: Uint16Array;
   readonly pointIndex: Uint32Array;
@@ -117,7 +127,7 @@ export class ProfileSectionBuilder {
   private _capacity = INITIAL_CAPACITY;
 
   private _chainage = new Float32Array(INITIAL_CAPACITY);
-  private _height = new Float32Array(INITIAL_CAPACITY);
+  private _height = new Float64Array(INITIAL_CAPACITY);
   private _lateral = new Float32Array(INITIAL_CAPACITY);
   private _slot = new Uint16Array(INITIAL_CAPACITY);
   private _index = new Uint32Array(INITIAL_CAPACITY);
@@ -176,7 +186,7 @@ export class ProfileSectionBuilder {
     if (this._count < this._capacity) return;
     const next = this._capacity * 2;
     this._chainage = grow(this._chainage, next, (n) => new Float32Array(n), 1);
-    this._height = grow(this._height, next, (n) => new Float32Array(n), 1);
+    this._height = grow(this._height, next, (n) => new Float64Array(n), 1);
     this._lateral = grow(this._lateral, next, (n) => new Float32Array(n), 1);
     this._slot = grow(this._slot, next, (n) => new Uint16Array(n), 1);
     this._index = grow(this._index, next, (n) => new Uint32Array(n), 1);

--- a/tests/profileColour.test.ts
+++ b/tests/profileColour.test.ts
@@ -1,0 +1,532 @@
+/**
+ * profileColour.test.ts — the five colouring rules a profile section owes a
+ * reader, each pinned by its own case.
+ *
+ * The fixtures are two-source sections, because every rule here is about a
+ * section whose sources disagree: slot 0 carries intensity, GPS time, RGB and
+ * return number, slot 1 carries none of them. Heights are 100..111 on slot 0
+ * and 200..211 on slot 1, so a section-local window, an active-layer window,
+ * and a project window are three visibly different pictures of the same cut.
+ *
+ *   1. unordered ids never reach a sequential ramp
+ *   2. classification is OLV's class palette, colourblind setting included
+ *   3. a missing attribute is unknown, not zero
+ *   4. a mode with too little behind it is refused
+ *   5. the height window states which scope it came from
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  DEFAULT_ELEVATION_PALETTE,
+  DEFAULT_SCALAR_PALETTE,
+  ELEVATION_PALETTES,
+  classColor,
+  colorblindSafeClasses,
+  elevationRampColor,
+  setColorblindSafeClasses,
+} from '../src/render/colorModes';
+import {
+  DEFAULT_PROFILE_HEIGHT_SCOPE,
+  PROFILE_COLOUR_MODES,
+  PROFILE_MODE_MIN_FRACTION,
+  PROFILE_MODE_MIN_POINTS,
+  PROFILE_UNKNOWN_COLOUR,
+  availableProfileColourModes,
+  colourProfileSection,
+  profileColourKind,
+  profileModeAvailability,
+  profileRampPalette,
+  type ProfileColourMode,
+  type ProfileColourRequest,
+} from '../src/render/measure/profileColour';
+import {
+  ProfileSectionBuilder,
+  type ProfileSectionPoints,
+  type ProfileSourceChannels,
+} from '../src/render/measure/profileSectionBuilder';
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+interface SourceSpec {
+  readonly slot: number;
+  readonly count: number;
+  readonly height: (j: number) => number;
+  readonly channels: ProfileSourceChannels | null;
+}
+
+function section(specs: readonly SourceSpec[]): ProfileSectionPoints {
+  const b = new ProfileSectionBuilder();
+  for (const s of specs) {
+    b.beginSource(s.slot, s.channels, s.count);
+    for (let j = 0; j < s.count; j++) b.push(j, j * 0.5, s.height(j), 0);
+  }
+  return b.finish();
+}
+
+const all = (p: ProfileSectionPoints): number[] => Array.from({ length: p.count }, (_, i) => i);
+
+function colourAt(out: Uint8Array, k: number): [number, number, number] {
+  return [out[k * 3], out[k * 3 + 1], out[k * 3 + 2]];
+}
+
+function run(request: ProfileColourRequest) {
+  const out = new Uint8Array(request.indices.length * 3);
+  const result = colourProfileSection(request, out);
+  return { out, result };
+}
+
+const RICH = 12;
+
+/** Slot 0: carries everything. Intensity starts at a measured 0. */
+function richChannels(): ProfileSourceChannels {
+  const rgb = new Uint8Array(RICH * 3);
+  const intensity = new Uint16Array(RICH);
+  const classification = new Uint8Array(RICH);
+  const returnNumber = new Uint8Array(RICH);
+  const pointSourceId = new Uint16Array(RICH);
+  const gpsTime = new Float64Array(RICH);
+  for (let j = 0; j < RICH; j++) {
+    rgb[j * 3] = 10 + j;
+    rgb[j * 3 + 1] = 20 + j;
+    rgb[j * 3 + 2] = 30 + j;
+    intensity[j] = j * 100;
+    classification[j] = j % 2 === 0 ? 2 : 6;
+    returnNumber[j] = (j % 2) + 1;
+    pointSourceId[j] = 7;
+    gpsTime[j] = 3.0e8 + j * 0.25;
+  }
+  return { rgb, intensity, classification, returnNumber, pointSourceId, gpsTime };
+}
+
+/** Slot 1: classification and a flight-line id only. No intensity at all. */
+function poorChannels(): ProfileSourceChannels {
+  const classification = new Uint8Array(RICH);
+  const pointSourceId = new Uint16Array(RICH);
+  for (let j = 0; j < RICH; j++) {
+    classification[j] = j % 2 === 0 ? 2 : 5;
+    pointSourceId[j] = 3;
+  }
+  return { classification, pointSourceId };
+}
+
+/** Indices 0–11 = slot 0 (rich, heights 100–111), 12–23 = slot 1 (heights 200–211). */
+const mixed = (): ProfileSectionPoints =>
+  section([
+    { slot: 0, count: RICH, height: (j) => 100 + j, channels: richChannels() },
+    { slot: 1, count: RICH, height: (j) => 200 + j, channels: poorChannels() },
+  ]);
+
+/** Slot 1 carries nothing at all, so half the section has no classification. */
+const halfClassified = (): ProfileSectionPoints =>
+  section([
+    { slot: 0, count: RICH, height: (j) => 100 + j, channels: richChannels() },
+    { slot: 1, count: RICH, height: (j) => 200 + j, channels: null },
+  ]);
+
+function intensityOnly(count: number, f: (j: number) => number): ProfileSourceChannels {
+  const intensity = new Uint16Array(count);
+  for (let j = 0; j < count; j++) intensity[j] = f(j);
+  return { intensity };
+}
+
+afterEach(() => setColorblindSafeClasses(false));
+
+// ── rule 1: unordered ids never take a sequential ramp ───────────────────────
+
+describe('unordered ids stay categorical', () => {
+  it('routes point source id and source layer away from every ramp', () => {
+    expect(profileColourKind('pointSourceId')).toBe('categorical');
+    expect(profileColourKind('sourceLayer')).toBe('categorical');
+    expect(profileColourKind('returnNumber')).toBe('ramp');
+
+    // `profileRampPalette` is the module's only door to a ramp, and its
+    // parameter type refuses an unordered id — the same refusal `colorModes.ts`
+    // makes by leaving `pointSourceId` out of its `ColorMode` union.
+    // @ts-expect-error pointSourceId is not a ProfileRampMode
+    expect(() => profileRampPalette('pointSourceId')).toBeTypeOf('function');
+  });
+
+  it('gives neither id mode a palette, a range, or any ramp colour', () => {
+    // Five flight lines, so a sequential encoding would have five ramp stops to
+    // land on: t = 0, 0.25, 0.5, 0.75, 1.
+    const ids = [1, 1, 1, 1, 4, 4, 4, 4, 9, 9, 9, 9, 12, 12, 12, 12, 30, 30, 30, 30];
+    const pointSourceId = Uint16Array.from(ids);
+    const points = section([
+      { slot: 0, count: ids.length, height: (j) => j, channels: { pointSourceId } },
+    ]);
+    const indices = all(points);
+
+    for (const mode of ['pointSourceId', 'sourceLayer'] as const) {
+      const src =
+        mode === 'pointSourceId'
+          ? points
+          : section([
+              { slot: 0, count: 6, height: (j) => j, channels: null },
+              { slot: 1, count: 6, height: (j) => 10 + j, channels: null },
+              { slot: 2, count: 6, height: (j) => 20 + j, channels: null },
+              { slot: 3, count: 6, height: (j) => 30 + j, channels: null },
+              { slot: 4, count: 6, height: (j) => 40 + j, channels: null },
+            ]);
+      const idx = mode === 'pointSourceId' ? indices : all(src);
+      const { result } = run({ points: src, mode, indices: idx });
+
+      expect(result.legend.kind).toBe('categorical');
+      expect(result.legend.palette).toBeNull();
+      expect(result.legend.range).toBeNull();
+      expect(result.legend.categories).toHaveLength(5);
+
+      const swatches = result.legend.categories!.map((c) => c.colour);
+      // No swatch is the colour a sequential ramp would put at its rank, in
+      // ANY catalogue palette — Cividis and Turbo included.
+      for (const palette of ELEVATION_PALETTES) {
+        for (let rank = 0; rank < swatches.length; rank++) {
+          const ramp = elevationRampColor(rank / (swatches.length - 1), palette.id);
+          expect(swatches[rank]).not.toEqual(ramp);
+        }
+      }
+      // A sequential ramp is monotonic in luminance. This palette is not, so
+      // the swatch order cannot be read as an ordering.
+      const luma = swatches.map((c) => 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2]);
+      const rising = luma.every((v, i) => i === 0 || v >= luma[i - 1]);
+      const falling = luma.every((v, i) => i === 0 || v <= luma[i - 1]);
+      expect(rising || falling).toBe(false);
+    }
+  });
+
+  it('assigns a category colour by sorted id, so draw order cannot change it', () => {
+    const points = mixed();
+    const forwards = run({ points, mode: 'pointSourceId', indices: all(points) });
+    const backwards = run({
+      points,
+      mode: 'pointSourceId',
+      indices: all(points).reverse(),
+    });
+
+    for (let i = 0; i < points.count; i++) {
+      const k = points.count - 1 - i;
+      expect(colourAt(backwards.out, k)).toEqual(colourAt(forwards.out, i));
+    }
+    // Ids 3 and 7: 3 sorts first and takes the first swatch, in both passes.
+    expect(forwards.result.legend.categories!.map((c) => c.value)).toEqual([3, 7]);
+    expect(backwards.result.legend.categories![0].colour).toEqual(
+      forwards.result.legend.categories![0].colour,
+    );
+  });
+
+  it('draws no colour from a random source', () => {
+    const src = readFileSync(
+      new URL('../src/render/measure/profileColour.ts', import.meta.url),
+      'utf8',
+    );
+    expect(src).not.toMatch(/Math\.random/);
+  });
+});
+
+// ── rule 2: classification is OLV's class palette ────────────────────────────
+
+describe('classification reuses the class palette', () => {
+  it('paints every code exactly what classColor gives it', () => {
+    const points = mixed();
+    const { out, result } = run({ points, mode: 'classification', indices: all(points) });
+
+    expect(colourAt(out, 0)).toEqual(classColor(2)); // slot 0, code 2
+    expect(colourAt(out, 1)).toEqual(classColor(6)); // slot 0, code 6
+    expect(colourAt(out, 13)).toEqual(classColor(5)); // slot 1, code 5
+    for (const c of result.legend.categories!) {
+      expect(c.colour).toEqual(classColor(c.value));
+    }
+    expect(result.legend.categories!.map((c) => c.value)).toEqual([2, 5, 6]);
+  });
+
+  it('follows the global colourblind-safe setting for classes', () => {
+    const points = mixed();
+    expect(colorblindSafeClasses()).toBe(false);
+    const plain = run({ points, mode: 'classification', indices: all(points) });
+    expect(plain.result.legend.colourblindSafe).toBe(false);
+
+    setColorblindSafeClasses(true);
+    const safe = run({ points, mode: 'classification', indices: all(points) });
+
+    expect(safe.result.legend.colourblindSafe).toBe(true);
+    expect(colourAt(safe.out, 0)).not.toEqual(colourAt(plain.out, 0));
+    expect(colourAt(safe.out, 0)).toEqual(classColor(2));
+    expect(safe.result.legend.categories!.map((c) => c.colour)).toEqual(
+      safe.result.legend.categories!.map((c) => classColor(c.value)),
+    );
+  });
+
+  it('follows the same setting for the qualitative id palette', () => {
+    const points = mixed();
+    const plain = run({ points, mode: 'pointSourceId', indices: all(points) });
+    setColorblindSafeClasses(true);
+    const safe = run({ points, mode: 'pointSourceId', indices: all(points) });
+
+    expect(safe.result.legend.colourblindSafe).toBe(true);
+    expect(colourAt(safe.out, 0)).not.toEqual(colourAt(plain.out, 0));
+  });
+});
+
+// ── rule 3: a missing attribute is unknown, never zero ───────────────────────
+
+describe('a missing attribute is not a zero', () => {
+  it('separates an absent intensity from a measured intensity of 0', () => {
+    const points = mixed();
+    const { out, result } = run({ points, mode: 'intensity', indices: all(points) });
+
+    // Section index 0 is slot 0's first return: intensity measured as 0, the
+    // bottom of the window, so it takes the ramp's bottom colour.
+    const bottom = elevationRampColor(0, DEFAULT_SCALAR_PALETTE);
+    expect(points.intensity![0]).toBe(0);
+    expect(colourAt(out, 0)).toEqual(bottom);
+
+    // Section index 12 is slot 1, which carries no intensity at all.
+    expect(colourAt(out, 12)).toEqual([...PROFILE_UNKNOWN_COLOUR]);
+    expect(colourAt(out, 12)).not.toEqual(bottom);
+    expect(colourAt(out, 12)).not.toEqual(colourAt(out, 0));
+
+    // The absent points never entered the window either.
+    expect(result.legend.range!.min).toBe(0);
+    expect(result.legend.range!.max).toBe(1100);
+    expect(result.unknownCount).toBe(RICH);
+  });
+
+  it('reports the unknown points in the legend', () => {
+    const points = mixed();
+    const { result } = run({ points, mode: 'intensity', indices: all(points) });
+
+    expect(result.legend.unknown).not.toBeNull();
+    expect(result.legend.unknown!.count).toBe(RICH);
+    expect(result.legend.unknown!.colour).toEqual(PROFILE_UNKNOWN_COLOUR);
+    expect(result.legend.unknown!.label).toMatch(/unknown/i);
+  });
+
+  it('leaves no unknown bucket when every point carries the attribute', () => {
+    const points = mixed();
+    const { result } = run({ points, mode: 'classification', indices: all(points) });
+    expect(result.unknownCount).toBe(0);
+    expect(result.legend.unknown).toBeNull();
+  });
+
+  it('does not read an absent classification as "never classified"', () => {
+    const points = halfClassified();
+    const { out, result } = run({ points, mode: 'classification', indices: all(points) });
+
+    expect(colourAt(out, 12)).toEqual([...PROFILE_UNKNOWN_COLOUR]);
+    expect(colourAt(out, 12)).not.toEqual(classColor(0));
+    expect(result.legend.unknown!.count).toBe(RICH);
+    expect(result.legend.categories!.map((c) => c.value)).toEqual([2, 6]);
+  });
+});
+
+// ── rule 4: a mode with too little behind it is refused ──────────────────────
+
+describe('mode availability', () => {
+  it('refuses an attribute no source carries', () => {
+    const points = mixed();
+    const a = profileModeAvailability(points, 'rgb', all(points));
+    expect(a.available).toBe(true);
+
+    const bare = section([{ slot: 0, count: 12, height: (j) => j, channels: null }]);
+    const gps = profileModeAvailability(bare, 'gpsTime', all(bare));
+    expect(gps.available).toBe(false);
+    expect(gps.reason).toBe('absent');
+  });
+
+  it('refuses a mode carried by fewer than the minimum number of points', () => {
+    const points = section([
+      { slot: 0, count: 20, height: (j) => j, channels: null },
+      { slot: 1, count: 4, height: (j) => 50 + j, channels: intensityOnly(4, (j) => j * 10) },
+    ]);
+    const a = profileModeAvailability(points, 'intensity', all(points));
+    expect(a.supporting).toBe(4);
+    expect(a.supporting).toBeLessThan(PROFILE_MODE_MIN_POINTS);
+    expect(a.reason).toBe('tooFewPoints');
+    expect(a.available).toBe(false);
+    expect(availableProfileColourModes(points, all(points))).not.toContain('intensity');
+  });
+
+  it('refuses a mode carried by too small a share of the section', () => {
+    const points = section([
+      { slot: 0, count: 50, height: (j) => j, channels: null },
+      { slot: 1, count: 10, height: (j) => 50 + j, channels: intensityOnly(10, (j) => j * 10) },
+    ]);
+    const a = profileModeAvailability(points, 'intensity', all(points));
+    expect(a.supporting).toBe(10);
+    expect(a.supporting / a.displayed).toBeLessThan(PROFILE_MODE_MIN_FRACTION);
+    expect(a.reason).toBe('tooSmallFraction');
+    expect(a.available).toBe(false);
+  });
+
+  it('refuses a mode whose supporting points all hold one value', () => {
+    const points = section([
+      {
+        slot: 0,
+        count: 12,
+        height: (j) => j,
+        channels: { classification: new Uint8Array(12).fill(2) },
+      },
+    ]);
+    const a = profileModeAvailability(points, 'classification', all(points));
+    expect(a.reason).toBe('noVariation');
+    expect(a.available).toBe(false);
+    // One flight line is one swatch, and the same rule applies.
+    expect(profileModeAvailability(points, 'sourceLayer', all(points)).reason).toBe('noVariation');
+    // Height still varies here, so it stays on offer.
+    expect(profileModeAvailability(points, 'height', all(points)).available).toBe(true);
+  });
+
+  it('paints a refused mode as unknown rather than encoding it', () => {
+    const points = section([
+      { slot: 0, count: 20, height: (j) => j, channels: null },
+      { slot: 1, count: 4, height: (j) => 50 + j, channels: intensityOnly(4, (j) => j * 10) },
+    ]);
+    const { out, result } = run({ points, mode: 'intensity', indices: all(points) });
+
+    expect(result.legend.kind).toBe('unavailable');
+    expect(result.legend.range).toBeNull();
+    expect(result.unknownCount).toBe(points.count);
+    // Including the four points that DO carry intensity: a mode this thin is
+    // not encoded at all.
+    expect(colourAt(out, 21)).toEqual([...PROFILE_UNKNOWN_COLOUR]);
+  });
+
+  it('lists only the modes the section supports', () => {
+    const points = mixed();
+    const modes = availableProfileColourModes(points, all(points));
+    expect(modes).toEqual(
+      PROFILE_COLOUR_MODES.filter((m) => modes.includes(m as ProfileColourMode)),
+    );
+    for (const m of ['rgb', 'height', 'intensity', 'classification', 'sourceLayer'] as const) {
+      expect(modes).toContain(m);
+    }
+  });
+});
+
+// ── rule 5: the height window names its scope ────────────────────────────────
+
+describe('the height window states which range it used', () => {
+  it('reports the section-local window by default, and says so', () => {
+    const points = mixed();
+    const { result } = run({ points, mode: 'height', indices: all(points) });
+
+    expect(DEFAULT_PROFILE_HEIGHT_SCOPE.scope).toBe('sectionLocal');
+    expect(result.legend.range!.scope).toBe('sectionLocal');
+    expect(result.legend.range!.label).toBe('This section');
+    expect(result.legend.range!.min).toBe(101);
+    expect(result.legend.range!.max).toBe(210);
+    expect(result.legend.range!.trueMin).toBe(100);
+    expect(result.legend.range!.trueMax).toBe(211);
+    expect(result.legend.palette).toBe(DEFAULT_ELEVATION_PALETTE);
+  });
+
+  it('normalises one layer against itself when the active layer is asked for', () => {
+    const points = mixed();
+    const { result } = run({
+      points,
+      mode: 'height',
+      indices: all(points),
+      heightRange: { scope: 'activeLayer', slot: 1 },
+    });
+
+    expect(result.legend.range!.scope).toBe('activeLayer');
+    expect(result.legend.range!.slot).toBe(1);
+    expect(result.legend.range!.label).toBe('Active layer');
+    expect(result.legend.range!.min).toBe(200);
+    expect(result.legend.range!.max).toBe(211);
+  });
+
+  it('takes a project window verbatim so two sections stay comparable', () => {
+    const points = mixed();
+    const { result } = run({
+      points,
+      mode: 'height',
+      indices: all(points),
+      heightRange: { scope: 'projectShared', min: 0, max: 1000 },
+    });
+
+    expect(result.legend.range!.scope).toBe('projectShared');
+    expect(result.legend.range!.min).toBe(0);
+    expect(result.legend.range!.max).toBe(1000);
+    expect(result.legend.range!.label).toBe('Project shared');
+  });
+
+  it('keeps a section-local request off the project window', () => {
+    const points = mixed();
+    const local = run({
+      points,
+      mode: 'height',
+      indices: all(points),
+      heightRange: { scope: 'sectionLocal' },
+    });
+    const shared = run({
+      points,
+      mode: 'height',
+      indices: all(points),
+      heightRange: { scope: 'projectShared', min: 0, max: 1000 },
+    });
+    const layer = run({
+      points,
+      mode: 'height',
+      indices: all(points),
+      heightRange: { scope: 'activeLayer', slot: 1 },
+    });
+
+    expect(local.result.legend.range!.scope).toBe('sectionLocal');
+    expect(local.result.legend.range!.min).not.toBe(0);
+    expect(local.result.legend.range!.max).not.toBe(1000);
+
+    // Section index 12 is slot 1's lowest return. The three scopes put it at
+    // three different places on the ramp, so the picture differs too.
+    expect(colourAt(local.out, 12)).not.toEqual(colourAt(shared.out, 12));
+    expect(colourAt(local.out, 12)).not.toEqual(colourAt(layer.out, 12));
+    expect(colourAt(shared.out, 12)).not.toEqual(colourAt(layer.out, 12));
+  });
+
+  it('names the section as the scope for the non-height scalars', () => {
+    const points = mixed();
+    for (const mode of ['intensity', 'returnNumber', 'gpsTime'] as const) {
+      const { result } = run({ points, mode, indices: all(points) });
+      expect(result.legend.range!.scope).toBe('sectionLocal');
+      expect(result.legend.palette).toBe(DEFAULT_SCALAR_PALETTE);
+    }
+  });
+
+  it('ranges return number on the raw ordinals rather than a percentile band', () => {
+    const points = mixed();
+    const { result } = run({ points, mode: 'returnNumber', indices: all(points) });
+    expect(result.legend.range!.min).toBe(1);
+    expect(result.legend.range!.max).toBe(2);
+  });
+});
+
+// ── output shape ─────────────────────────────────────────────────────────────
+
+describe('output buffer', () => {
+  it('fills the caller-owned buffer and reports how much it wrote', () => {
+    const points = mixed();
+    const indices = [3, 5, 7, 9, 11, 13, 15, 17, 19, 21];
+    const out = new Uint8Array(indices.length * 3 + 6).fill(1);
+    const result = colourProfileSection({ points, mode: 'height', indices }, out);
+
+    expect(result.count).toBe(indices.length);
+    // The tail beyond the written triplets is untouched.
+    expect([...out.slice(indices.length * 3)]).toEqual([1, 1, 1, 1, 1, 1]);
+    expect(colourAt(out, 0)).not.toEqual([1, 1, 1]);
+  });
+
+  it('refuses a buffer that cannot hold the section', () => {
+    const points = mixed();
+    const indices = all(points);
+    expect(() =>
+      colourProfileSection({ points, mode: 'height', indices }, new Uint8Array(3)),
+    ).toThrow(RangeError);
+  });
+
+  it('copies RGB through unchanged where a source carries it', () => {
+    const points = mixed();
+    const { out } = run({ points, mode: 'rgb', indices: all(points) });
+    expect(colourAt(out, 4)).toEqual([14, 24, 34]);
+    expect(colourAt(out, 12)).toEqual([...PROFILE_UNKNOWN_COLOUR]);
+  });
+});

--- a/tests/profileSectionBuilder.test.ts
+++ b/tests/profileSectionBuilder.test.ts
@@ -1,0 +1,211 @@
+/**
+ * profileSectionBuilder.test.ts
+ *
+ * Attribute integrity for the section builder.
+ *
+ * Every channel value is a distinct function of (slot, sourceIndex), so a
+ * value read one index off, or read from the wrong source, produces a number
+ * that cannot occur at that position. Checking a constant fill would not
+ * separate those failures from a correct read.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ProfileSectionBuilder,
+  profileSectionHas,
+  PROFILE_ATTRIBUTE_BIT,
+  type ProfileSourceChannels,
+} from '../src/render/measure/profileSectionBuilder';
+
+/** Channel values keyed so a one-index shift changes every one of them. */
+const intensityAt = (slot: number, i: number): number => 1000 * (slot + 1) + i * 7;
+const classAt = (slot: number, i: number): number => (slot * 31 + i * 13) % 256;
+const rgbAt = (slot: number, i: number, c: number): number => (slot * 17 + i * 5 + c * 61) % 256;
+const gpsAt = (slot: number, i: number): number => slot * 1e6 + i * 0.001;
+const retNumAt = (slot: number, i: number): number => ((i + slot * 2) % 5) + 1;
+const retCntAt = (slot: number, i: number): number => ((i + slot) % 4) + 1;
+const psidAt = (slot: number, i: number): number => 7000 + slot * 100 + (i % 90);
+const normAt = (slot: number, i: number, c: number): number => slot + i * 0.25 + c * 0.125;
+
+function channelsFor(slot: number, n: number, which: Set<string>): ProfileSourceChannels {
+  const out: Record<string, unknown> = {};
+  if (which.has('rgb')) {
+    const a = new Uint8Array(n * 3);
+    for (let i = 0; i < n; i++) for (let c = 0; c < 3; c++) a[i * 3 + c] = rgbAt(slot, i, c);
+    out.rgb = a;
+  }
+  if (which.has('intensity')) {
+    const a = new Uint16Array(n);
+    for (let i = 0; i < n; i++) a[i] = intensityAt(slot, i);
+    out.intensity = a;
+  }
+  if (which.has('classification')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = classAt(slot, i);
+    out.classification = a;
+  }
+  if (which.has('returnNumber')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = retNumAt(slot, i);
+    out.returnNumber = a;
+  }
+  if (which.has('returnCount')) {
+    const a = new Uint8Array(n);
+    for (let i = 0; i < n; i++) a[i] = retCntAt(slot, i);
+    out.returnCount = a;
+  }
+  if (which.has('pointSourceId')) {
+    const a = new Uint16Array(n);
+    for (let i = 0; i < n; i++) a[i] = psidAt(slot, i);
+    out.pointSourceId = a;
+  }
+  if (which.has('gpsTime')) {
+    const a = new Float64Array(n);
+    for (let i = 0; i < n; i++) a[i] = gpsAt(slot, i);
+    out.gpsTime = a;
+  }
+  if (which.has('normals')) {
+    const a = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) for (let c = 0; c < 3; c++) a[i * 3 + c] = normAt(slot, i, c);
+    out.normals = a;
+  }
+  return out as ProfileSourceChannels;
+}
+
+describe('section builder keeps every attribute on its own point', () => {
+  it('carries a full channel set through unshifted, past a growth boundary', () => {
+    // Accepting every third of 9000 gives 3000 returns, which crosses the
+    // 1024 doubling threshold and then 2048, so the reallocation path runs
+    // rather than only the initial buffer.
+    const n = 9000;
+    const all = new Set([
+      'rgb',
+      'intensity',
+      'classification',
+      'returnNumber',
+      'returnCount',
+      'pointSourceId',
+      'gpsTime',
+      'normals',
+    ]);
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, channelsFor(0, n, all), n);
+    // Accept every third point so source index and section index differ, which
+    // a test accepting all points cannot distinguish from a correct read.
+    const accepted: number[] = [];
+    for (let i = 0; i < n; i += 3) {
+      b.push(i, i * 0.5, i * 0.25, i % 7 === 0 ? 1.5 : -1.5);
+      accepted.push(i);
+    }
+    const p = b.finish();
+    expect(p.count).toBe(accepted.length);
+    expect(p.count).toBeGreaterThan(1024);
+
+    for (let k = 0; k < p.count; k++) {
+      const src = accepted[k]!;
+      expect(p.pointIndex[k]).toBe(src);
+      expect(p.sourceSlot[k]).toBe(0);
+      expect(p.chainage[k]).toBeCloseTo(src * 0.5, 4);
+      expect(p.height[k]).toBeCloseTo(src * 0.25, 4);
+      expect(p.intensity![k]).toBe(intensityAt(0, src));
+      expect(p.classification![k]).toBe(classAt(0, src));
+      expect(p.returnNumber![k]).toBe(retNumAt(0, src));
+      expect(p.returnCount![k]).toBe(retCntAt(0, src));
+      expect(p.pointSourceId![k]).toBe(psidAt(0, src));
+      expect(p.gpsTime![k]).toBeCloseTo(gpsAt(0, src), 9);
+      for (let c = 0; c < 3; c++) {
+        expect(p.rgb![k * 3 + c]).toBe(rgbAt(0, src, c));
+        expect(p.normals![k * 3 + c]).toBeCloseTo(normAt(0, src, c), 5);
+      }
+    }
+  });
+
+  it('keeps mixed sources apart and marks absence per point', () => {
+    // A carries RGB and classification; B carries intensity and GPS time;
+    // C carries nothing. Interleaved so a per-snapshot presence flag would
+    // be wrong for two of the three.
+    const nA = 40;
+    const nB = 40;
+    const nC = 40;
+    const b = new ProfileSectionBuilder();
+
+    b.beginSource(0, channelsFor(0, nA, new Set(['rgb', 'classification'])), nA);
+    for (let i = 0; i < nA; i++) b.push(i, i, i, 0);
+    b.beginSource(1, channelsFor(1, nB, new Set(['intensity', 'gpsTime'])), nB);
+    for (let i = 0; i < nB; i++) b.push(i, i, i, 0);
+    b.beginSource(2, null, nC);
+    for (let i = 0; i < nC; i++) b.push(i, i, i, 0);
+
+    const p = b.finish();
+    expect(p.count).toBe(nA + nB + nC);
+
+    for (let k = 0; k < p.count; k++) {
+      const slot = p.sourceSlot[k]!;
+      const src = p.pointIndex[k]!;
+      if (slot === 0) {
+        expect(profileSectionHas(p, k, 'rgb')).toBe(true);
+        expect(profileSectionHas(p, k, 'classification')).toBe(true);
+        expect(profileSectionHas(p, k, 'intensity')).toBe(false);
+        expect(profileSectionHas(p, k, 'gpsTime')).toBe(false);
+        expect(p.classification![k]).toBe(classAt(0, src));
+        expect(p.rgb![k * 3]).toBe(rgbAt(0, src, 0));
+      } else if (slot === 1) {
+        expect(profileSectionHas(p, k, 'intensity')).toBe(true);
+        expect(profileSectionHas(p, k, 'gpsTime')).toBe(true);
+        expect(profileSectionHas(p, k, 'rgb')).toBe(false);
+        expect(profileSectionHas(p, k, 'classification')).toBe(false);
+        expect(p.intensity![k]).toBe(intensityAt(1, src));
+        expect(p.gpsTime![k]).toBeCloseTo(gpsAt(1, src), 9);
+      } else {
+        expect(p.channelPresence[k]).toBe(0);
+      }
+    }
+  });
+
+  it('omits a channel no source carried rather than emitting zeros', () => {
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, channelsFor(0, 10, new Set(['intensity'])), 10);
+    for (let i = 0; i < 10; i++) b.push(i, i, i, 0);
+    const p = b.finish();
+    expect(p.intensity).toBeDefined();
+    expect(p.rgb).toBeUndefined();
+    expect(p.gpsTime).toBeUndefined();
+    expect(p.classification).toBeUndefined();
+    expect(p.normals).toBeUndefined();
+  });
+
+  it('drops a misaligned channel for that source instead of shifting it', () => {
+    // A classification array one element short cannot be index-aligned. The
+    // sampler applies the same rule to its own classification input.
+    const n = 20;
+    const good = channelsFor(0, n, new Set(['classification', 'intensity']));
+    const bad: ProfileSourceChannels = {
+      classification: good.classification!.slice(0, n - 1),
+      intensity: good.intensity,
+    };
+    const b = new ProfileSectionBuilder();
+    b.beginSource(0, bad, n);
+    for (let i = 0; i < n; i++) b.push(i, i, i, 0);
+    const p = b.finish();
+
+    expect(p.classification).toBeUndefined();
+    for (let k = 0; k < p.count; k++) {
+      expect(profileSectionHas(p, k, 'classification')).toBe(false);
+      expect(profileSectionHas(p, k, 'intensity')).toBe(true);
+      expect(p.intensity![k]).toBe(intensityAt(0, k));
+    }
+  });
+
+  it('assigns one bit per attribute', () => {
+    const bits = Object.values(PROFILE_ATTRIBUTE_BIT);
+    expect(new Set(bits).size).toBe(bits.length);
+    for (const v of bits) expect(v & (v - 1)).toBe(0);
+    expect(bits.reduce((a, c) => a | c, 0)).toBe(0xff);
+  });
+
+  it('reports an empty section without allocating channels', () => {
+    const p = new ProfileSectionBuilder().finish();
+    expect(p.count).toBe(0);
+    expect(p.chainage.length).toBe(0);
+    expect(p.rgb).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Stacked on #506, which it carries.

`colorModes.ts` refuses a ramp for point source id by omitting it from the `ColorMode` union rather than by a runtime guard. This follows that mechanism: ramp modes and categorical modes are disjoint types and the palette door accepts only the former, pinned by a compile-checked test.

Classification goes through `colorByClassification` and `classColor`, so there is no second class table, and the colourblind-safe setting is module state that applies without a parameter.

A point whose presence bit is clear takes an explicit unknown colour and never enters the ranged values, so an observed 0 and an absent value paint differently. A height range always reports its scope.
