### PR TITLE
Share the stage height between the workbench dock and the scene

### DIFF
--- a/src/ui/profileWorkbenchDock.ts
+++ b/src/ui/profileWorkbenchDock.ts
@@ -1,0 +1,160 @@
+/**
+ * profileWorkbenchDock.ts
+ *
+ * Geometry and persisted state for the docked Profile Workbench.
+ *
+ * The workbench sits below the stage and shares its height with the 3D
+ * canvas. That makes the split a numeric contract rather than a styling
+ * detail: whatever the user drags, the scene keeps a usable height, because
+ * the workbench exists to inspect a cloud that has to stay visible.
+ *
+ * Pure. No DOM. The panel module owns the elements and the drag events; this
+ * owns what the numbers are allowed to be.
+ */
+
+/** Storage key for the persisted dock preference. */
+export const PROFILE_WORKBENCH_DOCK_KEY = 'olv:measure:profile:workbenchDock:v1';
+
+/** Fraction of the stage the dock takes before a user moves it. */
+export const DEFAULT_DOCK_FRACTION = 0.4;
+
+/** The dock never leaves the scene less than this many pixels. */
+export const MIN_SCENE_HEIGHT = 120;
+
+/** The dock is never shorter than this while open. */
+export const MIN_DOCK_HEIGHT = 140;
+
+/** Height of the collapsed dock, which shows its header only. */
+export const COLLAPSED_DOCK_HEIGHT = 36;
+
+export interface DockLimits {
+  /** Total height available to the stage and the dock together. */
+  readonly stageHeight: number;
+}
+
+export interface DockState {
+  /** Open height in pixels. Retained while collapsed so restore returns to it. */
+  readonly heightPx: number;
+  readonly collapsed: boolean;
+}
+
+function finite(v: number): boolean {
+  return Number.isFinite(v);
+}
+
+/**
+ * The largest open height that still leaves the scene {@link MIN_SCENE_HEIGHT}.
+ *
+ * Falls back to the minimum dock height when the stage is too short to
+ * satisfy both, so a small window yields a cramped layout rather than a
+ * negative one.
+ */
+export function maxDockHeight(limits: DockLimits): number {
+  const stage = finite(limits.stageHeight) ? limits.stageHeight : 0;
+  const room = stage - MIN_SCENE_HEIGHT;
+  return room < MIN_DOCK_HEIGHT ? MIN_DOCK_HEIGHT : room;
+}
+
+/** Clamp an open height into the range this stage allows. */
+export function clampDockHeight(heightPx: number, limits: DockLimits): number {
+  const max = maxDockHeight(limits);
+  if (!finite(heightPx)) return Math.min(defaultDockHeight(limits), max);
+  return Math.min(max, Math.max(MIN_DOCK_HEIGHT, heightPx));
+}
+
+/** The opening height for a stage the user has expressed no preference for. */
+export function defaultDockHeight(limits: DockLimits): number {
+  const stage = finite(limits.stageHeight) ? limits.stageHeight : 0;
+  const max = maxDockHeight(limits);
+  return Math.min(max, Math.max(MIN_DOCK_HEIGHT, Math.round(stage * DEFAULT_DOCK_FRACTION)));
+}
+
+/** The height the dock actually occupies, collapsed or not. */
+export function dockOccupiedHeight(state: DockState, limits: DockLimits): number {
+  return state.collapsed ? COLLAPSED_DOCK_HEIGHT : clampDockHeight(state.heightPx, limits);
+}
+
+/**
+ * The height left for the 3D scene.
+ *
+ * Never returns a negative value, and never zero while the stage has any
+ * height at all, because the scene stays interactive with the dock open.
+ */
+export function sceneHeightFor(state: DockState, limits: DockLimits): number {
+  const stage = finite(limits.stageHeight) && limits.stageHeight > 0 ? limits.stageHeight : 0;
+  return Math.max(0, stage - dockOccupiedHeight(state, limits));
+}
+
+/**
+ * Apply a splitter drag.
+ *
+ * The splitter sits on top of the dock, so dragging it upward by `dy` pixels
+ * (a negative screen delta) makes the dock taller. A drag while collapsed
+ * reopens the dock at the dragged height.
+ */
+export function resizeDock(state: DockState, dyPx: number, limits: DockLimits): DockState {
+  const dy = finite(dyPx) ? dyPx : 0;
+  const from = state.collapsed ? COLLAPSED_DOCK_HEIGHT : state.heightPx;
+  return { heightPx: clampDockHeight(from - dy, limits), collapsed: false };
+}
+
+/** Collapse to the header, or restore the retained open height. */
+export function toggleDockCollapsed(state: DockState): DockState {
+  return { heightPx: state.heightPx, collapsed: !state.collapsed };
+}
+
+/** The state a stage with no stored preference starts in. */
+export function initialDockState(limits: DockLimits): DockState {
+  return { heightPx: defaultDockHeight(limits), collapsed: false };
+}
+
+/**
+ * Re-fit a state to a resized stage.
+ *
+ * The stored height is clamped rather than replaced, so shrinking a window
+ * and growing it again returns the user's own height instead of the default.
+ */
+export function refitDock(state: DockState, limits: DockLimits): DockState {
+  return { heightPx: clampDockHeight(state.heightPx, limits), collapsed: state.collapsed };
+}
+
+export interface PersistedDock {
+  readonly heightPx: number;
+  readonly collapsed: boolean;
+}
+
+/** Serialise the preference. Stores the open height even while collapsed. */
+export function encodeDockPrefs(state: DockState): string {
+  return JSON.stringify({ heightPx: state.heightPx, collapsed: state.collapsed });
+}
+
+/**
+ * Read a stored preference.
+ *
+ * Returns null for anything that is absent, unparseable, or not shaped like a
+ * preference. A corrupt entry opens the workbench at its default rather than
+ * throwing inside the panel's construction.
+ */
+export function decodeDockPrefs(raw: string | null): PersistedDock | null {
+  if (raw == null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const rec = parsed as Record<string, unknown>;
+  const h = rec.heightPx;
+  const c = rec.collapsed;
+  if (typeof h !== 'number' || !Number.isFinite(h) || h <= 0) return null;
+  if (typeof c !== 'boolean') return null;
+  return { heightPx: h, collapsed: c };
+}
+
+/** Restore a state for this stage, falling back to the default. */
+export function restoreDockState(raw: string | null, limits: DockLimits): DockState {
+  const stored = decodeDockPrefs(raw);
+  if (!stored) return initialDockState(limits);
+  return { heightPx: clampDockHeight(stored.heightPx, limits), collapsed: stored.collapsed };
+}

--- a/src/ui/profileWorkbenchDock.ts
+++ b/src/ui/profileWorkbenchDock.ts
@@ -21,8 +21,18 @@ export const DEFAULT_DOCK_FRACTION = 0.4;
 /** The dock never leaves the scene less than this many pixels. */
 export const MIN_SCENE_HEIGHT = 120;
 
-/** The dock is never shorter than this while open. */
+/** The dock's preferred minimum while open, on a stage that can afford it. */
 export const MIN_DOCK_HEIGHT = 140;
+
+/**
+ * The dock's share of a stage too short to give it {@link MIN_DOCK_HEIGHT}
+ * and the scene {@link MIN_SCENE_HEIGHT} at once.
+ *
+ * Below that size the minimums cannot both hold, and preferring the dock
+ * would leave the scene nothing at all. Splitting instead keeps both
+ * present, which is what lets the user drag back out.
+ */
+export const TIGHT_STAGE_DOCK_FRACTION = 0.5;
 
 /** Height of the collapsed dock, which shows its header only. */
 export const COLLAPSED_DOCK_HEIGHT = 36;
@@ -33,8 +43,15 @@ export interface DockLimits {
 }
 
 export interface DockState {
-  /** Open height in pixels. Retained while collapsed so restore returns to it. */
-  readonly heightPx: number;
+  /**
+   * The height the user asked for, in pixels.
+   *
+   * Retained exactly as expressed, including while collapsed and while the
+   * stage is too small to honour it. The height the dock actually occupies
+   * is derived on read by {@link dockOccupiedHeight}, so shrinking a window
+   * and growing it again returns this value rather than a clamped remnant.
+   */
+  readonly preferredHeightPx: number;
   readonly collapsed: boolean;
 }
 
@@ -45,40 +62,58 @@ function finite(v: number): boolean {
 /**
  * The largest open height that still leaves the scene {@link MIN_SCENE_HEIGHT}.
  *
- * Falls back to the minimum dock height when the stage is too short to
- * satisfy both, so a small window yields a cramped layout rather than a
- * negative one.
+ * A stage too short to satisfy both minimums splits instead, so the scene
+ * keeps a share at every stage size rather than being squeezed out by the
+ * dock's own minimum.
  */
 export function maxDockHeight(limits: DockLimits): number {
-  const stage = finite(limits.stageHeight) ? limits.stageHeight : 0;
+  const stage = finite(limits.stageHeight) && limits.stageHeight > 0 ? limits.stageHeight : 0;
+  if (stage <= 0) return 0;
   const room = stage - MIN_SCENE_HEIGHT;
-  return room < MIN_DOCK_HEIGHT ? MIN_DOCK_HEIGHT : room;
+  if (room >= MIN_DOCK_HEIGHT) return room;
+  return Math.floor(stage * TIGHT_STAGE_DOCK_FRACTION);
 }
 
-/** Clamp an open height into the range this stage allows. */
+/**
+ * Clamp an open height into the range this stage allows.
+ *
+ * The lower bound yields to the upper one, so a stage whose whole allowance
+ * is below {@link MIN_DOCK_HEIGHT} produces a height inside its allowance
+ * rather than one above it.
+ */
 export function clampDockHeight(heightPx: number, limits: DockLimits): number {
   const max = maxDockHeight(limits);
-  if (!finite(heightPx)) return Math.min(defaultDockHeight(limits), max);
-  return Math.min(max, Math.max(MIN_DOCK_HEIGHT, heightPx));
+  const min = Math.min(MIN_DOCK_HEIGHT, max);
+  if (!finite(heightPx)) return Math.min(Math.max(min, defaultDockHeight(limits)), max);
+  return Math.min(max, Math.max(min, heightPx));
 }
 
 /** The opening height for a stage the user has expressed no preference for. */
 export function defaultDockHeight(limits: DockLimits): number {
-  const stage = finite(limits.stageHeight) ? limits.stageHeight : 0;
+  const stage = finite(limits.stageHeight) && limits.stageHeight > 0 ? limits.stageHeight : 0;
   const max = maxDockHeight(limits);
-  return Math.min(max, Math.max(MIN_DOCK_HEIGHT, Math.round(stage * DEFAULT_DOCK_FRACTION)));
+  const min = Math.min(MIN_DOCK_HEIGHT, max);
+  return Math.min(max, Math.max(min, Math.round(stage * DEFAULT_DOCK_FRACTION)));
 }
 
-/** The height the dock actually occupies, collapsed or not. */
+/**
+ * The height the dock actually occupies on this stage.
+ *
+ * A collapsed dock shows its header, and even that yields to a stage too
+ * short to hold it beside a scene.
+ */
 export function dockOccupiedHeight(state: DockState, limits: DockLimits): number {
-  return state.collapsed ? COLLAPSED_DOCK_HEIGHT : clampDockHeight(state.heightPx, limits);
+  const max = maxDockHeight(limits);
+  return state.collapsed
+    ? Math.min(COLLAPSED_DOCK_HEIGHT, max)
+    : clampDockHeight(state.preferredHeightPx, limits);
 }
 
 /**
  * The height left for the 3D scene.
  *
- * Never returns a negative value, and never zero while the stage has any
- * height at all, because the scene stays interactive with the dock open.
+ * Positive whenever the stage has any height at all, since the scene stays
+ * interactive with the dock open. The dock's own minimum yields to this.
  */
 export function sceneHeightFor(state: DockState, limits: DockLimits): number {
   const stage = finite(limits.stageHeight) && limits.stageHeight > 0 ? limits.stageHeight : 0;
@@ -94,28 +129,27 @@ export function sceneHeightFor(state: DockState, limits: DockLimits): number {
  */
 export function resizeDock(state: DockState, dyPx: number, limits: DockLimits): DockState {
   const dy = finite(dyPx) ? dyPx : 0;
-  const from = state.collapsed ? COLLAPSED_DOCK_HEIGHT : state.heightPx;
-  return { heightPx: clampDockHeight(from - dy, limits), collapsed: false };
+  if (state.collapsed) {
+    // A collapsed dock shows only its header, so a downward drag has nothing
+    // to shrink. Reopening on one would move the dock opposite the gesture.
+    if (dy >= 0) return state;
+    return {
+      preferredHeightPx: clampDockHeight(COLLAPSED_DOCK_HEIGHT - dy, limits),
+      collapsed: false,
+    };
+  }
+  const from = dockOccupiedHeight(state, limits);
+  return { preferredHeightPx: clampDockHeight(from - dy, limits), collapsed: false };
 }
 
 /** Collapse to the header, or restore the retained open height. */
 export function toggleDockCollapsed(state: DockState): DockState {
-  return { heightPx: state.heightPx, collapsed: !state.collapsed };
+  return { preferredHeightPx: state.preferredHeightPx, collapsed: !state.collapsed };
 }
 
 /** The state a stage with no stored preference starts in. */
 export function initialDockState(limits: DockLimits): DockState {
-  return { heightPx: defaultDockHeight(limits), collapsed: false };
-}
-
-/**
- * Re-fit a state to a resized stage.
- *
- * The stored height is clamped rather than replaced, so shrinking a window
- * and growing it again returns the user's own height instead of the default.
- */
-export function refitDock(state: DockState, limits: DockLimits): DockState {
-  return { heightPx: clampDockHeight(state.heightPx, limits), collapsed: state.collapsed };
+  return { preferredHeightPx: defaultDockHeight(limits), collapsed: false };
 }
 
 export interface PersistedDock {
@@ -125,7 +159,7 @@ export interface PersistedDock {
 
 /** Serialise the preference. Stores the open height even while collapsed. */
 export function encodeDockPrefs(state: DockState): string {
-  return JSON.stringify({ heightPx: state.heightPx, collapsed: state.collapsed });
+  return JSON.stringify({ heightPx: state.preferredHeightPx, collapsed: state.collapsed });
 }
 
 /**
@@ -152,9 +186,15 @@ export function decodeDockPrefs(raw: string | null): PersistedDock | null {
   return { heightPx: h, collapsed: c };
 }
 
-/** Restore a state for this stage, falling back to the default. */
+/**
+ * Restore a state, falling back to this stage's default.
+ *
+ * The stored height is kept as expressed rather than clamped on the way in,
+ * so opening on a small screen and returning to a large one restores the
+ * height the user chose.
+ */
 export function restoreDockState(raw: string | null, limits: DockLimits): DockState {
   const stored = decodeDockPrefs(raw);
   if (!stored) return initialDockState(limits);
-  return { heightPx: clampDockHeight(stored.heightPx, limits), collapsed: stored.collapsed };
+  return { preferredHeightPx: stored.heightPx, collapsed: stored.collapsed };
 }

--- a/tests/profileWorkbenchDock.test.ts
+++ b/tests/profileWorkbenchDock.test.ts
@@ -3,8 +3,8 @@
  *
  * The dock shares the stage's height with the 3D canvas, so "the scene stays
  * visible with the workbench open" is a number, not a styling intention.
- * These hold that number at every stage size, including ones too small to
- * satisfy everything.
+ * These hold that number at every stage size, including sizes too small to
+ * satisfy the dock's own minimum.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -16,7 +16,6 @@ import {
   resizeDock,
   toggleDockCollapsed,
   initialDockState,
-  refitDock,
   encodeDockPrefs,
   decodeDockPrefs,
   restoreDockState,
@@ -28,18 +27,28 @@ import {
 } from '../src/ui/profileWorkbenchDock';
 
 const stage = (h: number) => ({ stageHeight: h });
+const SIZES = [1, 2, 20, 36, 100, 140, 141, 200, 259, 260, 261, 400, 720, 1080, 2160, 8000];
 
 describe('the scene keeps height whatever the dock does', () => {
-  const SIZES = [0, 1, 100, 200, 260, 400, 720, 1080, 2160, 8000];
-
-  it('never leaves the scene negative', () => {
+  it('leaves the scene a positive height at every stage with any height', () => {
+    // Regression: a stage at or below the dock's own minimum used to hand the
+    // dock everything and leave the canvas a zero-height buffer, which no
+    // drag could recover from.
     for (const h of SIZES) {
       for (const collapsed of [false, true]) {
-        for (const want of [-1e6, 0, 1, 200, 1e6, Number.NaN]) {
-          const s: DockState = { heightPx: want, collapsed };
-          expect(sceneHeightFor(s, stage(h))).toBeGreaterThanOrEqual(0);
+        for (const want of [-1e6, 0, 1, 200, 5000, 1e6, Number.NaN]) {
+          const s: DockState = { preferredHeightPx: want, collapsed };
+          const scene = sceneHeightFor(s, stage(h));
+          expect(scene).toBeGreaterThan(0);
+          expect(Number.isFinite(scene)).toBe(true);
         }
       }
+    }
+  });
+
+  it('returns zero only for a stage with no height', () => {
+    for (const h of [0, -10, Number.NaN]) {
+      expect(sceneHeightFor({ preferredHeightPx: 400, collapsed: false }, stage(h))).toBe(0);
     }
   });
 
@@ -47,26 +56,35 @@ describe('the scene keeps height whatever the dock does', () => {
     for (const h of SIZES) {
       if (h < MIN_SCENE_HEIGHT + MIN_DOCK_HEIGHT) continue;
       const open = clampDockHeight(Number.POSITIVE_INFINITY, stage(h));
-      expect(sceneHeightFor({ heightPx: open, collapsed: false }, stage(h))).toBeGreaterThanOrEqual(
-        MIN_SCENE_HEIGHT,
-      );
+      expect(
+        sceneHeightFor({ preferredHeightPx: open, collapsed: false }, stage(h)),
+      ).toBeGreaterThanOrEqual(MIN_SCENE_HEIGHT);
     }
   });
 
-  it('yields a cramped layout rather than a negative one on a tiny stage', () => {
-    // 200 px cannot give the dock 140 and the scene 120 at once.
+  it('splits a stage too short for both minimums', () => {
+    // 200 cannot give the dock 140 and the scene 120 at once.
     const s = initialDockState(stage(200));
-    expect(dockOccupiedHeight(s, stage(200))).toBe(MIN_DOCK_HEIGHT);
-    expect(sceneHeightFor(s, stage(200))).toBe(60);
+    expect(dockOccupiedHeight(s, stage(200))).toBe(100);
+    expect(sceneHeightFor(s, stage(200))).toBe(100);
+    // 140 is exactly the dock minimum, and still leaves the scene half.
+    const t = initialDockState(stage(140));
+    expect(dockOccupiedHeight(t, stage(140))).toBe(70);
+    expect(sceneHeightFor(t, stage(140))).toBe(70);
   });
 
   it('adds up to the stage exactly', () => {
     for (const h of SIZES) {
       const s = initialDockState(stage(h));
-      const total = dockOccupiedHeight(s, stage(h)) + sceneHeightFor(s, stage(h));
-      if (h >= MIN_SCENE_HEIGHT + MIN_DOCK_HEIGHT) expect(total).toBe(h);
-      else expect(total).toBeGreaterThanOrEqual(h);
+      expect(dockOccupiedHeight(s, stage(h)) + sceneHeightFor(s, stage(h))).toBe(h);
     }
+  });
+
+  it('shrinks even the collapsed header on a stage that cannot hold it', () => {
+    const s: DockState = { preferredHeightPx: 400, collapsed: true };
+    expect(dockOccupiedHeight(s, stage(1000))).toBe(COLLAPSED_DOCK_HEIGHT);
+    expect(dockOccupiedHeight(s, stage(40))).toBe(20);
+    expect(sceneHeightFor(s, stage(40))).toBe(20);
   });
 });
 
@@ -75,12 +93,8 @@ describe('default height', () => {
     expect(defaultDockHeight(stage(1000))).toBe(Math.round(1000 * DEFAULT_DOCK_FRACTION));
   });
 
-  it('never opens below the dock minimum', () => {
-    expect(defaultDockHeight(stage(300))).toBeGreaterThanOrEqual(MIN_DOCK_HEIGHT);
-  });
-
-  it('never opens past what the stage can spare', () => {
-    for (const h of [200, 300, 500, 1000]) {
+  it('never exceeds what the stage can spare', () => {
+    for (const h of SIZES) {
       expect(defaultDockHeight(stage(h))).toBeLessThanOrEqual(maxDockHeight(stage(h)));
     }
   });
@@ -90,97 +104,95 @@ describe('splitter drag', () => {
   const limits = stage(1000);
 
   it('grows the dock when dragged upward', () => {
-    const s: DockState = { heightPx: 400, collapsed: false };
-    expect(resizeDock(s, -50, limits).heightPx).toBe(450);
+    expect(resizeDock({ preferredHeightPx: 400, collapsed: false }, -50, limits).preferredHeightPx)
+      .toBe(450);
   });
 
   it('shrinks the dock when dragged downward', () => {
-    const s: DockState = { heightPx: 400, collapsed: false };
-    expect(resizeDock(s, 50, limits).heightPx).toBe(350);
+    expect(resizeDock({ preferredHeightPx: 400, collapsed: false }, 50, limits).preferredHeightPx)
+      .toBe(350);
   });
 
   it('clamps rather than letting a drag eat the scene', () => {
-    const s: DockState = { heightPx: 400, collapsed: false };
+    const s: DockState = { preferredHeightPx: 400, collapsed: false };
     const huge = resizeDock(s, -100000, limits);
-    expect(huge.heightPx).toBe(maxDockHeight(limits));
+    expect(huge.preferredHeightPx).toBe(maxDockHeight(limits));
     expect(sceneHeightFor(huge, limits)).toBe(MIN_SCENE_HEIGHT);
-    const tiny = resizeDock(s, 100000, limits);
-    expect(tiny.heightPx).toBe(MIN_DOCK_HEIGHT);
+    expect(resizeDock(s, 100000, limits).preferredHeightPx).toBe(MIN_DOCK_HEIGHT);
   });
 
-  it('reopens a collapsed dock at the dragged height', () => {
-    const s: DockState = { heightPx: 400, collapsed: true };
-    const out = resizeDock(s, -100, limits);
-    expect(out.collapsed).toBe(false);
-    expect(out.heightPx).toBe(clampDockHeight(COLLAPSED_DOCK_HEIGHT + 100, limits));
+  it('reopens a collapsed dock only on an upward drag', () => {
+    const s: DockState = { preferredHeightPx: 400, collapsed: true };
+    const up = resizeDock(s, -100, limits);
+    expect(up.collapsed).toBe(false);
+    expect(up.preferredHeightPx).toBe(clampDockHeight(COLLAPSED_DOCK_HEIGHT + 100, limits));
+  });
+
+  it('leaves a collapsed dock alone when dragged downward', () => {
+    // Regression: a downward drag used to reopen the dock and grow it from
+    // the header to the minimum, moving the surface opposite the gesture.
+    const s: DockState = { preferredHeightPx: 400, collapsed: true };
+    for (const dy of [0, 1, 10, 50, 100, 1000]) {
+      expect(resizeDock(s, dy, limits)).toEqual(s);
+    }
+  });
+
+  it('drags from the height on screen, not from an unhonoured preference', () => {
+    // On a stage too small for the preference, the surface must follow the
+    // pointer from where it actually sits.
+    const small = stage(400);
+    const s: DockState = { preferredHeightPx: 5000, collapsed: false };
+    const shown = dockOccupiedHeight(s, small);
+    expect(resizeDock(s, 40, small).preferredHeightPx).toBe(clampDockHeight(shown - 40, small));
   });
 
   it('ignores a non-finite delta', () => {
-    const s: DockState = { heightPx: 400, collapsed: false };
-    expect(resizeDock(s, Number.NaN, limits).heightPx).toBe(400);
+    expect(resizeDock({ preferredHeightPx: 400, collapsed: false }, Number.NaN, limits)
+      .preferredHeightPx).toBe(400);
   });
 });
 
 describe('collapse', () => {
   it('retains the open height so restore returns to it', () => {
-    const open: DockState = { heightPx: 512, collapsed: false };
+    const open: DockState = { preferredHeightPx: 512, collapsed: false };
     const collapsed = toggleDockCollapsed(open);
-    expect(collapsed.collapsed).toBe(true);
-    expect(collapsed.heightPx).toBe(512);
-    const restored = toggleDockCollapsed(collapsed);
-    expect(restored).toEqual(open);
-  });
-
-  it('occupies only the header while collapsed', () => {
-    const s: DockState = { heightPx: 512, collapsed: true };
-    expect(dockOccupiedHeight(s, stage(1000))).toBe(COLLAPSED_DOCK_HEIGHT);
-    expect(sceneHeightFor(s, stage(1000))).toBe(1000 - COLLAPSED_DOCK_HEIGHT);
+    expect(collapsed).toEqual({ preferredHeightPx: 512, collapsed: true });
+    expect(toggleDockCollapsed(collapsed)).toEqual(open);
   });
 });
 
 describe('stage resize', () => {
-  it('returns the user height when the stage grows back', () => {
-    const chosen: DockState = { heightPx: 600, collapsed: false };
-    const shrunk = refitDock(chosen, stage(400));
-    expect(shrunk.heightPx).toBeLessThan(600);
-    // Refitting the ORIGINAL preference to the restored stage gives it back.
-    const regrown = refitDock(chosen, stage(1200));
-    expect(regrown.heightPx).toBe(600);
+  it('returns the user height after any sequence of stage sizes', () => {
+    // Regression: the preference used to be clamped in place, so shrinking
+    // the window and growing it again left the clamped remnant behind.
+    const chosen: DockState = { preferredHeightPx: 600, collapsed: false };
+    expect(dockOccupiedHeight(chosen, stage(400))).toBeLessThan(600);
+    expect(dockOccupiedHeight(chosen, stage(1200))).toBe(600);
+    for (const h of SIZES) dockOccupiedHeight(chosen, stage(h));
+    expect(chosen.preferredHeightPx).toBe(600);
+    expect(dockOccupiedHeight(chosen, stage(1200))).toBe(600);
   });
 
   it('keeps the collapsed flag across a resize', () => {
-    expect(refitDock({ heightPx: 600, collapsed: true }, stage(300)).collapsed).toBe(true);
+    const s: DockState = { preferredHeightPx: 600, collapsed: true };
+    expect(dockOccupiedHeight(s, stage(300))).toBe(COLLAPSED_DOCK_HEIGHT);
+    expect(s.collapsed).toBe(true);
   });
 });
 
 describe('persistence', () => {
   it('round trips', () => {
-    const s: DockState = { heightPx: 377, collapsed: true };
+    const s: DockState = { preferredHeightPx: 377, collapsed: true };
     expect(decodeDockPrefs(encodeDockPrefs(s))).toEqual({ heightPx: 377, collapsed: true });
-  });
-
-  it('stores the open height even while collapsed', () => {
-    const s: DockState = { heightPx: 377, collapsed: true };
-    expect(decodeDockPrefs(encodeDockPrefs(s))!.heightPx).toBe(377);
   });
 
   it('rejects anything that is not a preference, without throwing', () => {
     for (const raw of [
-      null,
-      '',
-      'not json',
-      '[]',
-      'null',
-      '"str"',
-      '42',
-      '{}',
-      '{"heightPx":400}',
-      '{"collapsed":true}',
-      '{"heightPx":"400","collapsed":true}',
-      '{"heightPx":400,"collapsed":"yes"}',
-      '{"heightPx":null,"collapsed":false}',
-      '{"heightPx":0,"collapsed":false}',
-      '{"heightPx":-10,"collapsed":false}',
+      null, '', 'not json', '[]', 'null', '"str"', '42', '{}',
+      '{"heightPx":400}', '{"collapsed":true}',
+      '{"heightPx":"400","collapsed":true}', '{"heightPx":400,"collapsed":"yes"}',
+      '{"heightPx":null,"collapsed":false}', '{"heightPx":0,"collapsed":false}',
+      '{"heightPx":-10,"collapsed":false}', '{"heightPx":1e999,"collapsed":false}',
     ]) {
       expect(decodeDockPrefs(raw)).toBeNull();
     }
@@ -191,14 +203,14 @@ describe('persistence', () => {
     expect(restoreDockState(null, stage(1000))).toEqual(initialDockState(stage(1000)));
   });
 
-  it('clamps a stored height that no longer fits', () => {
-    const raw = encodeDockPrefs({ heightPx: 5000, collapsed: false });
+  it('keeps a stored height that no longer fits, and honours it again later', () => {
+    // Regression: restoring on a small stage used to overwrite the stored
+    // height with the clamped one, losing it for every later stage.
+    const raw = encodeDockPrefs({ preferredHeightPx: 900, collapsed: false });
     const s = restoreDockState(raw, stage(600));
-    expect(s.heightPx).toBe(maxDockHeight(stage(600)));
+    expect(s.preferredHeightPx).toBe(900);
+    expect(dockOccupiedHeight(s, stage(600))).toBe(maxDockHeight(stage(600)));
     expect(sceneHeightFor(s, stage(600))).toBe(MIN_SCENE_HEIGHT);
-  });
-
-  it('rejects a non-finite stored height', () => {
-    expect(decodeDockPrefs('{"heightPx":1e999,"collapsed":false}')).toBeNull();
+    expect(dockOccupiedHeight(s, stage(2000))).toBe(900);
   });
 });

--- a/tests/profileWorkbenchDock.test.ts
+++ b/tests/profileWorkbenchDock.test.ts
@@ -1,0 +1,204 @@
+/**
+ * profileWorkbenchDock.test.ts
+ *
+ * The dock shares the stage's height with the 3D canvas, so "the scene stays
+ * visible with the workbench open" is a number, not a styling intention.
+ * These hold that number at every stage size, including ones too small to
+ * satisfy everything.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  clampDockHeight,
+  defaultDockHeight,
+  maxDockHeight,
+  dockOccupiedHeight,
+  sceneHeightFor,
+  resizeDock,
+  toggleDockCollapsed,
+  initialDockState,
+  refitDock,
+  encodeDockPrefs,
+  decodeDockPrefs,
+  restoreDockState,
+  MIN_DOCK_HEIGHT,
+  MIN_SCENE_HEIGHT,
+  COLLAPSED_DOCK_HEIGHT,
+  DEFAULT_DOCK_FRACTION,
+  type DockState,
+} from '../src/ui/profileWorkbenchDock';
+
+const stage = (h: number) => ({ stageHeight: h });
+
+describe('the scene keeps height whatever the dock does', () => {
+  const SIZES = [0, 1, 100, 200, 260, 400, 720, 1080, 2160, 8000];
+
+  it('never leaves the scene negative', () => {
+    for (const h of SIZES) {
+      for (const collapsed of [false, true]) {
+        for (const want of [-1e6, 0, 1, 200, 1e6, Number.NaN]) {
+          const s: DockState = { heightPx: want, collapsed };
+          expect(sceneHeightFor(s, stage(h))).toBeGreaterThanOrEqual(0);
+        }
+      }
+    }
+  });
+
+  it('keeps the documented scene minimum whenever the stage can afford it', () => {
+    for (const h of SIZES) {
+      if (h < MIN_SCENE_HEIGHT + MIN_DOCK_HEIGHT) continue;
+      const open = clampDockHeight(Number.POSITIVE_INFINITY, stage(h));
+      expect(sceneHeightFor({ heightPx: open, collapsed: false }, stage(h))).toBeGreaterThanOrEqual(
+        MIN_SCENE_HEIGHT,
+      );
+    }
+  });
+
+  it('yields a cramped layout rather than a negative one on a tiny stage', () => {
+    // 200 px cannot give the dock 140 and the scene 120 at once.
+    const s = initialDockState(stage(200));
+    expect(dockOccupiedHeight(s, stage(200))).toBe(MIN_DOCK_HEIGHT);
+    expect(sceneHeightFor(s, stage(200))).toBe(60);
+  });
+
+  it('adds up to the stage exactly', () => {
+    for (const h of SIZES) {
+      const s = initialDockState(stage(h));
+      const total = dockOccupiedHeight(s, stage(h)) + sceneHeightFor(s, stage(h));
+      if (h >= MIN_SCENE_HEIGHT + MIN_DOCK_HEIGHT) expect(total).toBe(h);
+      else expect(total).toBeGreaterThanOrEqual(h);
+    }
+  });
+});
+
+describe('default height', () => {
+  it('takes the documented fraction of a roomy stage', () => {
+    expect(defaultDockHeight(stage(1000))).toBe(Math.round(1000 * DEFAULT_DOCK_FRACTION));
+  });
+
+  it('never opens below the dock minimum', () => {
+    expect(defaultDockHeight(stage(300))).toBeGreaterThanOrEqual(MIN_DOCK_HEIGHT);
+  });
+
+  it('never opens past what the stage can spare', () => {
+    for (const h of [200, 300, 500, 1000]) {
+      expect(defaultDockHeight(stage(h))).toBeLessThanOrEqual(maxDockHeight(stage(h)));
+    }
+  });
+});
+
+describe('splitter drag', () => {
+  const limits = stage(1000);
+
+  it('grows the dock when dragged upward', () => {
+    const s: DockState = { heightPx: 400, collapsed: false };
+    expect(resizeDock(s, -50, limits).heightPx).toBe(450);
+  });
+
+  it('shrinks the dock when dragged downward', () => {
+    const s: DockState = { heightPx: 400, collapsed: false };
+    expect(resizeDock(s, 50, limits).heightPx).toBe(350);
+  });
+
+  it('clamps rather than letting a drag eat the scene', () => {
+    const s: DockState = { heightPx: 400, collapsed: false };
+    const huge = resizeDock(s, -100000, limits);
+    expect(huge.heightPx).toBe(maxDockHeight(limits));
+    expect(sceneHeightFor(huge, limits)).toBe(MIN_SCENE_HEIGHT);
+    const tiny = resizeDock(s, 100000, limits);
+    expect(tiny.heightPx).toBe(MIN_DOCK_HEIGHT);
+  });
+
+  it('reopens a collapsed dock at the dragged height', () => {
+    const s: DockState = { heightPx: 400, collapsed: true };
+    const out = resizeDock(s, -100, limits);
+    expect(out.collapsed).toBe(false);
+    expect(out.heightPx).toBe(clampDockHeight(COLLAPSED_DOCK_HEIGHT + 100, limits));
+  });
+
+  it('ignores a non-finite delta', () => {
+    const s: DockState = { heightPx: 400, collapsed: false };
+    expect(resizeDock(s, Number.NaN, limits).heightPx).toBe(400);
+  });
+});
+
+describe('collapse', () => {
+  it('retains the open height so restore returns to it', () => {
+    const open: DockState = { heightPx: 512, collapsed: false };
+    const collapsed = toggleDockCollapsed(open);
+    expect(collapsed.collapsed).toBe(true);
+    expect(collapsed.heightPx).toBe(512);
+    const restored = toggleDockCollapsed(collapsed);
+    expect(restored).toEqual(open);
+  });
+
+  it('occupies only the header while collapsed', () => {
+    const s: DockState = { heightPx: 512, collapsed: true };
+    expect(dockOccupiedHeight(s, stage(1000))).toBe(COLLAPSED_DOCK_HEIGHT);
+    expect(sceneHeightFor(s, stage(1000))).toBe(1000 - COLLAPSED_DOCK_HEIGHT);
+  });
+});
+
+describe('stage resize', () => {
+  it('returns the user height when the stage grows back', () => {
+    const chosen: DockState = { heightPx: 600, collapsed: false };
+    const shrunk = refitDock(chosen, stage(400));
+    expect(shrunk.heightPx).toBeLessThan(600);
+    // Refitting the ORIGINAL preference to the restored stage gives it back.
+    const regrown = refitDock(chosen, stage(1200));
+    expect(regrown.heightPx).toBe(600);
+  });
+
+  it('keeps the collapsed flag across a resize', () => {
+    expect(refitDock({ heightPx: 600, collapsed: true }, stage(300)).collapsed).toBe(true);
+  });
+});
+
+describe('persistence', () => {
+  it('round trips', () => {
+    const s: DockState = { heightPx: 377, collapsed: true };
+    expect(decodeDockPrefs(encodeDockPrefs(s))).toEqual({ heightPx: 377, collapsed: true });
+  });
+
+  it('stores the open height even while collapsed', () => {
+    const s: DockState = { heightPx: 377, collapsed: true };
+    expect(decodeDockPrefs(encodeDockPrefs(s))!.heightPx).toBe(377);
+  });
+
+  it('rejects anything that is not a preference, without throwing', () => {
+    for (const raw of [
+      null,
+      '',
+      'not json',
+      '[]',
+      'null',
+      '"str"',
+      '42',
+      '{}',
+      '{"heightPx":400}',
+      '{"collapsed":true}',
+      '{"heightPx":"400","collapsed":true}',
+      '{"heightPx":400,"collapsed":"yes"}',
+      '{"heightPx":null,"collapsed":false}',
+      '{"heightPx":0,"collapsed":false}',
+      '{"heightPx":-10,"collapsed":false}',
+    ]) {
+      expect(decodeDockPrefs(raw)).toBeNull();
+    }
+  });
+
+  it('opens at the default when the stored value is corrupt', () => {
+    expect(restoreDockState('{{{', stage(1000))).toEqual(initialDockState(stage(1000)));
+    expect(restoreDockState(null, stage(1000))).toEqual(initialDockState(stage(1000)));
+  });
+
+  it('clamps a stored height that no longer fits', () => {
+    const raw = encodeDockPrefs({ heightPx: 5000, collapsed: false });
+    const s = restoreDockState(raw, stage(600));
+    expect(s.heightPx).toBe(maxDockHeight(stage(600)));
+    expect(sceneHeightFor(s, stage(600))).toBe(MIN_SCENE_HEIGHT);
+  });
+
+  it('rejects a non-finite stored height', () => {
+    expect(decodeDockPrefs('{"heightPx":1e999,"collapsed":false}')).toBeNull();
+  });
+});


### PR DESCRIPTION
The workbench takes its height from the same space as the 3D canvas, so the split is a numeric contract rather than a styling detail.

The dock's minimum yields to the scene: a stage too short for both splits instead, so the scene keeps a positive height at every stage size. The preferred height is retained as expressed and the occupied height derived on read, so shrinking a window and growing it again returns the user's own height. A downward drag on a collapsed dock leaves it collapsed.

A stored preference that is absent, unparseable or wrongly shaped opens at the default.

Geometry and state only; the panel and its `lazyChunks` seam come later.
