### PR TITLE
Bound PNTS sections by the declared tile length

### DIFF
--- a/src/io/tiles3d/pnts.ts
+++ b/src/io/tiles3d/pnts.ts
@@ -3,17 +3,26 @@
  *
  * A PNTS tile is a 28-byte header, a feature-table JSON + binary, and a
  * batch-table JSON + binary. This reads the header, the feature table's
- * POINTS_LENGTH and optional RTC_CENTER, and the uncompressed float32 POSITION
- * array. It refuses the encodings this subset does not handle — quantised
- * positions, Draco compression — with a clear error rather than mis-decoding.
+ * POINTS_LENGTH and optional RTC_CENTER, and the positions: uncompressed
+ * float32 POSITION, or uint16 POSITION_QUANTIZED against its quantised volume.
+ * It refuses the encodings this subset does not handle — Draco compression,
+ * colours, normals, batch ids — with a clear error rather than mis-decoding.
  * Positions are tile-local; a caller adds RTC_CENTER (and the tile transform) to
  * place them. Pure: takes an ArrayBuffer, returns typed arrays.
+ *
+ * The tile's own declared byteLength is the parse boundary, never the buffer's.
+ * A tile arrives inside whatever the transport handed over, so a section that
+ * is allowed to run to the end of the buffer reads bytes that belong to another
+ * tile, or to no tile at all.
  */
 
 const HEADER_BYTES = 28;
 const MAGIC = 0x73746e70; // 'pnts' little-endian
 /** The only PNTS version this decoder claims to read. */
 const SUPPORTED_VERSION = 1;
+const UINT32_MAX = 0xffffffff;
+/** The divisor the point-cloud format specifies for a quantised component. */
+const QUANTIZED_FULL_SCALE = 65535;
 
 export interface PntsTile {
   readonly version: number;
@@ -24,19 +33,100 @@ export interface PntsTile {
   readonly positions: Float32Array;
 }
 
-interface FeatureTableJson {
-  POINTS_LENGTH?: number;
-  RTC_CENTER?: unknown;
-  POSITION?: { byteOffset?: number };
-  POSITION_QUANTIZED?: unknown;
+type JsonObject = Record<string, unknown>;
+
+/** Decode one JSON section: UTF-8 text holding a single object. */
+function decodeJsonSection(
+  buffer: ArrayBuffer,
+  start: number,
+  length: number,
+  label: string,
+): JsonObject {
+  let text: string;
+  try {
+    // `fatal` so an ill-formed byte sequence is refused rather than replaced
+    // with U+FFFD, which would turn a corrupt tile into a JSON syntax error
+    // that names the wrong problem.
+    text = new TextDecoder('utf-8', { fatal: true }).decode(new Uint8Array(buffer, start, length));
+  } catch {
+    throw new Error(`PNTS: ${label} JSON is not valid UTF-8.`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error(`PNTS: ${label} JSON does not parse.`);
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`PNTS: ${label} JSON is not an object.`);
+  }
+  return parsed as JsonObject;
 }
 
-/** Decode a PNTS tile's header, feature table, and uncompressed positions. */
+/**
+ * Read a feature-table accessor's byteOffset. A byteOffset is an index into the
+ * feature-table binary, so it is a non-negative whole number. Fractional or
+ * negative values reach DataView construction and fail there, far from the tile
+ * that carried them.
+ */
+function accessorByteOffset(descriptor: unknown, name: string): number {
+  if (typeof descriptor !== 'object' || descriptor === null || Array.isArray(descriptor)) {
+    throw new Error(`PNTS: ${name} is not a feature-table accessor object.`);
+  }
+  const byteOffset = (descriptor as { byteOffset?: unknown }).byteOffset;
+  if (typeof byteOffset !== 'number' || !Number.isSafeInteger(byteOffset) || byteOffset < 0) {
+    throw new Error(`PNTS: ${name}.byteOffset is not a non-negative whole number.`);
+  }
+  return byteOffset;
+}
+
+/** Read a 3-component vector of real numbers from the feature-table JSON. */
+function vec3(value: unknown, name: string): [number, number, number] {
+  if (!Array.isArray(value) || value.length !== 3) {
+    throw new Error(`PNTS: ${name} must have 3 components.`);
+  }
+  // JSON writes NaN and Infinity as null, so a component is checked for being a
+  // number as well as for being finite.
+  if (!value.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+    throw new Error(`PNTS: ${name} has a component that is not a finite number.`);
+  }
+  return [value[0] as number, value[1] as number, value[2] as number];
+}
+
+/**
+ * Resolve an array's absolute start in the buffer, having checked it lies
+ * wholly inside the feature-table binary section.
+ */
+function arrayStart(
+  name: string,
+  byteOffset: number,
+  components: number,
+  bytesPerComponent: number,
+  binStart: number,
+  binLength: number,
+): number {
+  const need = components * bytesPerComponent;
+  const start = binStart + byteOffset;
+  const end = start + need;
+  // Guard the arithmetic before it is compared. POINTS_LENGTH is a uint32 and
+  // byteOffset only a safe integer, so `end` is the term that can leave the
+  // exactly-representable range, and a range check on an approximation decides
+  // nothing.
+  if (!Number.isSafeInteger(need) || !Number.isSafeInteger(end)) {
+    throw new Error(`PNTS: ${name} spans a byte range too large to address exactly.`);
+  }
+  if (end > binStart + binLength) {
+    throw new Error(`PNTS: ${name} extends past the feature-table binary section.`);
+  }
+  return start;
+}
+
+/** Decode a PNTS tile's header, feature table, and positions. */
 export function parsePnts(buffer: ArrayBuffer): PntsTile {
-  const view = new DataView(buffer);
   if (buffer.byteLength < HEADER_BYTES) {
     throw new Error('PNTS: buffer shorter than the 28-byte header.');
   }
+  const view = new DataView(buffer);
   if (view.getUint32(0, true) !== MAGIC) {
     throw new Error('PNTS: bad magic — not a pnts tile.');
   }
@@ -45,79 +135,101 @@ export function parsePnts(buffer: ArrayBuffer): PntsTile {
     throw new Error(`PNTS: version ${version} is not supported, only ${SUPPORTED_VERSION}.`);
   }
   const byteLength = view.getUint32(8, true);
-  if (byteLength > buffer.byteLength) {
-    throw new Error('PNTS: declared byteLength exceeds the buffer.');
-  }
   if (byteLength < HEADER_BYTES) {
     throw new Error('PNTS: declared byteLength is shorter than the header.');
   }
-  // The DECLARED tile length is the parse boundary, not the buffer. A tile
-  // concatenated with trailing bytes would otherwise let a feature table or a
-  // POSITION range run past its own tile and read whatever followed it.
-  const limit = byteLength;
-  const ftJsonLen = view.getUint32(12, true);
-  const ftBinLen = view.getUint32(16, true);
-
-  const ftJsonStart = HEADER_BYTES;
-  const ftBinStart = ftJsonStart + ftJsonLen;
-  if (ftBinStart + ftBinLen > limit) {
-    throw new Error('PNTS: feature table extends past the declared tile length.');
+  if (byteLength > buffer.byteLength) {
+    throw new Error('PNTS: declared byteLength exceeds the buffer.');
   }
 
-  const ftJsonText = new TextDecoder().decode(new Uint8Array(buffer, ftJsonStart, ftJsonLen));
-  const ft = JSON.parse(ftJsonText) as FeatureTableJson;
+  const ftJsonLength = view.getUint32(12, true);
+  const ftBinLength = view.getUint32(16, true);
+  const btJsonLength = view.getUint32(20, true);
+  const btBinLength = view.getUint32(24, true);
+  // Four uint32 lengths plus the header sum to at most about 1.7e10, exact in a
+  // double, so this total cannot be rounded into agreement.
+  const sectioned = HEADER_BYTES + ftJsonLength + ftBinLength + btJsonLength + btBinLength;
+  if (sectioned > byteLength) {
+    throw new Error('PNTS: section lengths overrun the declared byteLength.');
+  }
+  if (sectioned < byteLength) {
+    throw new Error('PNTS: declared byteLength leaves bytes past the last section.');
+  }
+  // The sections now sum exactly to a declared length that fits the buffer, so
+  // every section start and end is in range by construction, and any byte past
+  // the declared length belongs to whatever followed this tile.
+  const ftJsonStart = HEADER_BYTES;
+  const ftBinStart = ftJsonStart + ftJsonLength;
+  const btJsonStart = ftBinStart + ftBinLength;
+
+  const ft = decodeJsonSection(buffer, ftJsonStart, ftJsonLength, 'feature table');
+  // The batch table is read for well-formedness only; its properties belong to
+  // a caller this decoder does not have yet.
+  if (btJsonLength > 0) decodeJsonSection(buffer, btJsonStart, btJsonLength, 'batch table');
 
   const pointsLength = ft.POINTS_LENGTH;
-  if (typeof pointsLength !== 'number' || !Number.isInteger(pointsLength) || pointsLength < 0) {
-    throw new Error('PNTS: feature table has no valid POINTS_LENGTH.');
-  }
-  if (ft.POSITION_QUANTIZED !== undefined) {
-    throw new Error('PNTS: POSITION_QUANTIZED is not supported yet — only float32 POSITION.');
-  }
-  if (!ft.POSITION || typeof ft.POSITION.byteOffset !== 'number') {
-    throw new Error('PNTS: feature table has no float32 POSITION.');
-  }
-  // A byteOffset is an index into the feature-table binary, so it is a
-  // non-negative whole number. Fractional or negative values reach DataView
-  // construction and fail there, far from the tile that carried them.
-  if (!Number.isSafeInteger(ft.POSITION.byteOffset) || ft.POSITION.byteOffset < 0) {
-    throw new Error('PNTS: POSITION.byteOffset is not a non-negative whole number.');
+  if (
+    typeof pointsLength !== 'number' ||
+    !Number.isInteger(pointsLength) ||
+    pointsLength <= 0 ||
+    pointsLength > UINT32_MAX
+  ) {
+    throw new Error('PNTS: POINTS_LENGTH is not a positive uint32.');
   }
 
   // RTC_CENTER is optional, but a present one cannot be dropped when it is
   // malformed. POSITION holds tile-local coordinates, so a tile that keeps its
   // positions and loses its center renders at the local origin, which for a
   // georeferenced tile is a silent relocation rather than a missing offset.
-  // JSON writes NaN and Infinity as null, so a component is checked for being
-  // a number as well as for being finite.
-  const rtc: unknown = ft.RTC_CENTER;
-  let rtcCenter: [number, number, number] | null = null;
-  if (rtc !== undefined) {
-    if (!Array.isArray(rtc) || rtc.length !== 3) {
-      throw new Error('PNTS: RTC_CENTER must have 3 components.');
-    }
-    if (!rtc.every((n) => typeof n === 'number' && Number.isFinite(n))) {
-      throw new Error('PNTS: RTC_CENTER has a component that is not a finite number.');
-    }
-    rtcCenter = [rtc[0] as number, rtc[1] as number, rtc[2] as number];
+  const rtcCenter = ft.RTC_CENTER === undefined ? null : vec3(ft.RTC_CENTER, 'RTC_CENTER');
+
+  const components = pointsLength * 3;
+
+  // A tile carrying both encodings is decoded from POSITION: the format gives
+  // the uncompressed array precedence over the quantised one.
+  if (ft.POSITION !== undefined) {
+    const byteOffset = accessorByteOffset(ft.POSITION, 'POSITION');
+    const start = arrayStart('POSITION', byteOffset, components, 4, ftBinStart, ftBinLength);
+    // Copy rather than view: POSITION.byteOffset need not be 4-aligned within
+    // the buffer, and a Float32Array view requires alignment. Allocating after
+    // the range check keeps a tile that declares four billion points from
+    // reserving the memory before it is refused.
+    const positions = new Float32Array(components);
+    for (let i = 0; i < components; i++) positions[i] = view.getFloat32(start + i * 4, true);
+    return { version, pointsLength, rtcCenter, positions };
   }
 
-  const posOffset = ftBinStart + ft.POSITION.byteOffset;
-  const need = pointsLength * 3 * 4;
-  // Guard the product itself: a POINTS_LENGTH near the safe-integer ceiling
-  // makes `need` lose precision, and the range check below would then compare
-  // an approximation.
-  if (!Number.isSafeInteger(need)) {
-    throw new Error(`PNTS: POINTS_LENGTH ${pointsLength} is too large to address.`);
+  if (ft.POSITION_QUANTIZED !== undefined) {
+    const byteOffset = accessorByteOffset(ft.POSITION_QUANTIZED, 'POSITION_QUANTIZED');
+    // The volume is what makes the uint16 codes mean anything. Without it the
+    // codes are not coordinates at all, so neither member is defaultable.
+    if (ft.QUANTIZED_VOLUME_OFFSET === undefined) {
+      throw new Error('PNTS: POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET.');
+    }
+    if (ft.QUANTIZED_VOLUME_SCALE === undefined) {
+      throw new Error('PNTS: POSITION_QUANTIZED requires QUANTIZED_VOLUME_SCALE.');
+    }
+    const volumeOffset = vec3(ft.QUANTIZED_VOLUME_OFFSET, 'QUANTIZED_VOLUME_OFFSET');
+    const volumeScale = vec3(ft.QUANTIZED_VOLUME_SCALE, 'QUANTIZED_VOLUME_SCALE');
+    const start = arrayStart(
+      'POSITION_QUANTIZED',
+      byteOffset,
+      components,
+      2,
+      ftBinStart,
+      ftBinLength,
+    );
+    const positions = new Float32Array(components);
+    for (let i = 0; i < components; i++) {
+      const axis = i % 3;
+      const code = view.getUint16(start + i * 2, true);
+      // Float64 the whole way, narrowed once on the store. A quantised volume
+      // can sit far from the origin, so rounding the scaled code before the
+      // offset is added rounds twice and loses a step the format still carries.
+      positions[i] = (code * volumeScale[axis]) / QUANTIZED_FULL_SCALE + volumeOffset[axis];
+    }
+    return { version, pointsLength, rtcCenter, positions };
   }
-  if (posOffset + need > limit) {
-    throw new Error('PNTS: POSITION array extends past the declared tile length.');
-  }
-  // Copy (POSITION.byteOffset need not be 4-aligned within the buffer, and a
-  // Float32Array view requires alignment).
-  const positions = new Float32Array(pointsLength * 3);
-  const src = new DataView(buffer, posOffset, need);
-  for (let i = 0; i < positions.length; i++) positions[i] = src.getFloat32(i * 4, true);
 
-  return { version, pointsLength, rtcCenter, positions };
+  throw new Error('PNTS: feature table has neither POSITION nor POSITION_QUANTIZED.');
 }

--- a/tests/tiles3d.test.ts
+++ b/tests/tiles3d.test.ts
@@ -91,11 +91,139 @@ describe('parsePnts', () => {
     expect([...t.positions]).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
-  it('refuses a bad magic and quantised positions', () => {
+  it('refuses a bad magic', () => {
     const bad = new ArrayBuffer(28);
     new DataView(bad).setUint32(0, 0x12345678, true);
     expect(() => parsePnts(bad)).toThrow(/magic/);
+  });
 
-    expect(() => parsePnts(makeFeatureTablePnts({ POINTS_LENGTH: 1, POSITION_QUANTIZED: { byteOffset: 0 } }))).toThrow(/QUANTIZED/);
+  it('refuses a feature table with no position array at all', () => {
+    expect(() => parsePnts(makeFeatureTablePnts({ POINTS_LENGTH: 1 }))).toThrow(
+      /neither POSITION nor POSITION_QUANTIZED/,
+    );
+  });
+});
+
+/**
+ * Build a PNTS whose feature-table binary holds the arrays given, in order:
+ * float32 POSITION first, then uint16 POSITION_QUANTIZED. Both may be present,
+ * which is the case that pins the format's precedence rule.
+ */
+function makePositionPnts(opts: {
+  position?: number[][];
+  quantized?: number[][];
+  volumeOffset?: number[];
+  volumeScale?: number[];
+}): ArrayBuffer {
+  const pointsLength = (opts.position ?? opts.quantized ?? []).length;
+  const ft: Record<string, unknown> = { POINTS_LENGTH: pointsLength };
+  let binBytes = 0;
+  let positionAt = 0;
+  let quantizedAt = 0;
+  if (opts.position) {
+    positionAt = binBytes;
+    ft.POSITION = { byteOffset: positionAt };
+    binBytes += pointsLength * 3 * 4;
+  }
+  if (opts.quantized) {
+    quantizedAt = binBytes;
+    ft.POSITION_QUANTIZED = { byteOffset: quantizedAt };
+    binBytes += pointsLength * 3 * 2;
+  }
+  if (opts.volumeOffset) ft.QUANTIZED_VOLUME_OFFSET = opts.volumeOffset;
+  if (opts.volumeScale) ft.QUANTIZED_VOLUME_SCALE = opts.volumeScale;
+  let json = JSON.stringify(ft);
+  while (json.length % 8 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const total = 28 + jsonBytes.length + binBytes;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, 0x73746e70, true);
+  view.setUint32(4, 1, true);
+  view.setUint32(8, total, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, binBytes, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buf, 28, jsonBytes.length).set(jsonBytes);
+  const binStart = 28 + jsonBytes.length;
+  if (opts.position) {
+    let k = 0;
+    for (const p of opts.position) for (const c of p) view.setFloat32(binStart + positionAt + k++ * 4, c, true);
+  }
+  if (opts.quantized) {
+    let k = 0;
+    for (const p of opts.quantized) for (const c of p) view.setUint16(binStart + quantizedAt + k++ * 2, c, true);
+  }
+  return buf;
+}
+
+describe('parsePnts quantised positions', () => {
+  it('dequantises against the volume with 65535 as full scale', () => {
+    // Scale equal to full scale makes the expected value the code itself, so a
+    // divisor of 65536 shows up as 32767.5 and 65534 instead of 32768 and 65535.
+    const t = parsePnts(
+      makePositionPnts({
+        quantized: [
+          [0, 32768, 65535],
+          [65535, 0, 1],
+        ],
+        volumeOffset: [0, 0, 0],
+        volumeScale: [65535, 65535, 65535],
+      }),
+    );
+    expect(t.pointsLength).toBe(2);
+    expect([...t.positions]).toEqual([0, 32768, 65535, 65535, 0, 1]);
+  });
+
+  it('applies a per-axis scale and offset', () => {
+    const t = parsePnts(
+      makePositionPnts({
+        quantized: [[0, 65535, 32768]],
+        volumeOffset: [10, 20, 30],
+        volumeScale: [65535, 131070, 65535],
+      }),
+    );
+    // 0/full + 10; 65535 * 2 full-scale steps + 20; half of full scale + 30.
+    expect([...t.positions]).toEqual([10, 131090, 32798]);
+  });
+
+  it('keeps the scaled code in Float64 until the volume offset is added', () => {
+    // A 1 km volume sitting 1000 km from the origin. Each code below is a value
+    // whose float32-rounded intermediate lands on the other side of a float32
+    // step once the offset is added, so narrowing before the addition rounds
+    // twice and moves the point.
+    const t = parsePnts(
+      makePositionPnts({
+        quantized: [[49909, 54947, 63016]],
+        volumeOffset: [1_000_000, 1_000_000, 1_000_000],
+        volumeScale: [100, 100, 100],
+      }),
+    );
+    expect([...t.positions]).toEqual([1000076.1875, 1000083.8125, 1000096.1875]);
+    // What the same tile would decode to if the intermediate were narrowed:
+    expect([...t.positions]).not.toEqual([1000076.125, 1000083.875, 1000096.125]);
+  });
+
+  it('prefers POSITION when a tile carries both encodings', () => {
+    // The quantised array would place this point at 1001, 1001, 1001.
+    const t = parsePnts(
+      makePositionPnts({
+        position: [[1, 2, 3]],
+        quantized: [[65535, 65535, 65535]],
+        volumeOffset: [1000, 1000, 1000],
+        volumeScale: [1, 1, 1],
+      }),
+    );
+    expect([...t.positions]).toEqual([1, 2, 3]);
+  });
+
+  it('refuses a quantised array with no volume to interpret it', () => {
+    const noVolume = makePositionPnts({ quantized: [[1, 2, 3]] });
+    expect(() => parsePnts(noVolume)).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET/);
+    const noScale = makePositionPnts({ quantized: [[1, 2, 3]], volumeOffset: [0, 0, 0] });
+    expect(() => parsePnts(noScale)).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_SCALE/);
+    const noOffset = makePositionPnts({ quantized: [[1, 2, 3]], volumeScale: [1, 1, 1] });
+    expect(() => parsePnts(noOffset)).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET/);
   });
 });

--- a/tests/tiles3dMalformed.test.ts
+++ b/tests/tiles3dMalformed.test.ts
@@ -112,63 +112,273 @@ describe('tileset.json perimeter', () => {
   });
 });
 
-/** Build a PNTS tile. `declaredLength` defaults to the real byte length. */
-function pnts(opts: {
-  version?: number;
-  pointsLength?: number;
-  positionByteOffset?: number;
-  declaredLength?: number;
-  trailing?: number;
-  rtc?: unknown;
-} = {}): ArrayBuffer {
+const EMPTY = new Uint8Array(0);
+const utf8 = (text: string) => new TextEncoder().encode(text);
+
+/** Serialise a feature table the way a writer would, padded to 4 bytes. */
+function ftJsonBytes(ft: Record<string, unknown>): Uint8Array {
+  let json = JSON.stringify(ft);
+  while (json.length % 4 !== 0) json += ' ';
+  return utf8(json);
+}
+
+/**
+ * Assemble a PNTS tile from section bytes. Every header field can be set
+ * independently of what the sections actually hold, which is the point: these
+ * fixtures are tiles whose header disagrees with their body.
+ */
+function assemble(
+  sections: { ftJson: Uint8Array; ftBin?: Uint8Array; btJson?: Uint8Array; btBin?: Uint8Array },
+  header: {
+    version?: number;
+    byteLength?: number;
+    /** Applied to the real tile length when `byteLength` is not given. */
+    byteLengthDelta?: number;
+    ftJsonLength?: number;
+    ftBinLength?: number;
+    btJsonLength?: number;
+    btBinLength?: number;
+    /** Bytes appended after the tile, as a concatenated stream would carry. */
+    trailing?: number;
+  } = {},
+): ArrayBuffer {
+  const parts = [
+    sections.ftJson,
+    sections.ftBin ?? EMPTY,
+    sections.btJson ?? EMPTY,
+    sections.btBin ?? EMPTY,
+  ];
+  const tileBytes = 28 + parts.reduce((n, s) => n + s.length, 0);
+  const buf = new ArrayBuffer(tileBytes + (header.trailing ?? 0));
+  const view = new DataView(buf);
+  view.setUint32(0, 0x73746e70, true);
+  view.setUint32(4, header.version ?? 1, true);
+  view.setUint32(8, header.byteLength ?? tileBytes + (header.byteLengthDelta ?? 0), true);
+  view.setUint32(12, header.ftJsonLength ?? parts[0].length, true);
+  view.setUint32(16, header.ftBinLength ?? parts[1].length, true);
+  view.setUint32(20, header.btJsonLength ?? parts[2].length, true);
+  view.setUint32(24, header.btBinLength ?? parts[3].length, true);
+  const bytes = new Uint8Array(buf);
+  let at = 28;
+  for (const part of parts) {
+    bytes.set(part, at);
+    at += part.length;
+  }
+  return buf;
+}
+
+/**
+ * Build a float32-POSITION PNTS tile. `ft` replaces the whole feature table;
+ * `binPoints` sizes the feature-table binary independently of POINTS_LENGTH.
+ */
+function pnts(
+  opts: {
+    version?: number;
+    pointsLength?: number;
+    positionByteOffset?: number;
+    declaredLength?: number;
+    trailing?: number;
+    rtc?: unknown;
+    ft?: Record<string, unknown>;
+    binPoints?: number;
+    btJson?: Uint8Array;
+  } = {},
+): ArrayBuffer {
   const pointsLength = opts.pointsLength ?? 2;
-  const ftJson: Record<string, unknown> = {
+  const ft: Record<string, unknown> = opts.ft ?? {
     POINTS_LENGTH: pointsLength,
     POSITION: { byteOffset: opts.positionByteOffset ?? 0 },
   };
-  if (opts.rtc !== undefined) ftJson.RTC_CENTER = opts.rtc;
-  let json = JSON.stringify(ftJson);
-  while (json.length % 4 !== 0) json += ' ';
-  const jsonBytes = new TextEncoder().encode(json);
-  const binBytes = pointsLength * 3 * 4;
-  const tileBytes = 28 + jsonBytes.length + binBytes;
-  const total = tileBytes + (opts.trailing ?? 0);
-  const buf = new ArrayBuffer(total);
-  const view = new DataView(buf);
-  view.setUint32(0, 0x73746e70, true);
-  view.setUint32(4, opts.version ?? 1, true);
-  // The declared length is the TILE, not the buffer: trailing bytes are
-  // whatever followed it in a concatenated stream.
-  view.setUint32(8, opts.declaredLength ?? tileBytes, true);
-  view.setUint32(12, jsonBytes.length, true);
-  view.setUint32(16, binBytes, true);
-  new Uint8Array(buf).set(jsonBytes, 28);
-  return buf;
+  if (opts.rtc !== undefined) ft.RTC_CENTER = opts.rtc;
+  return assemble(
+    {
+      ftJson: ftJsonBytes(ft),
+      ftBin: new Uint8Array((opts.binPoints ?? pointsLength) * 3 * 4),
+      btJson: opts.btJson,
+    },
+    { version: opts.version, byteLength: opts.declaredLength, trailing: opts.trailing },
+  );
 }
+
+/** A tile whose only defect is the POINTS_LENGTH it declares. */
+const withPointsLength = (value: unknown) =>
+  pnts({ ft: { POINTS_LENGTH: value, POSITION: { byteOffset: 0 } }, binPoints: 2 });
 
 describe('PNTS perimeter', () => {
   it('accepts the well-formed baseline', () => {
     expect(parsePnts(pnts()).pointsLength).toBe(2);
   });
 
-  it('refuses a version it does not claim to read', () => {
-    expect(() => parsePnts(pnts({ version: 2 }))).toThrow(/version 2 is not supported/);
+  it('refuses a buffer that cannot hold the header', () => {
+    expect(() => parsePnts(new ArrayBuffer(27))).toThrow(/buffer shorter than the 28-byte header/);
+    expect(() => parsePnts(new ArrayBuffer(0))).toThrow(/buffer shorter than the 28-byte header/);
   });
 
-  it('treats the declared tile length as the boundary, not the buffer', () => {
-    // 64 trailing bytes follow the tile. POSITION starts 4 bytes into the
-    // feature-table binary, so its 24 bytes run 4 past the tile and into them.
-    // The buffer can satisfy that read; the tile cannot.
-    const withTrailing = pnts({ trailing: 64, positionByteOffset: 4 });
-    expect(() => parsePnts(withTrailing)).toThrow(/past the declared tile length/);
-    // Without the trailing bytes the buffer would have refused it anyway, so
-    // the case above is the one that needs the declared length to be enforced.
-    expect(parsePnts(pnts()).pointsLength).toBe(2);
+  it('refuses a version it does not claim to read', () => {
+    expect(() => parsePnts(pnts({ version: 2 }))).toThrow(/version 2 is not supported/);
+    expect(() => parsePnts(pnts({ version: 0 }))).toThrow(/version 0 is not supported/);
+  });
+
+  it('refuses a declared byteLength outside the buffer or under the header', () => {
+    // Declared past the end of what arrived: no section can be satisfied from
+    // bytes the transport never delivered.
+    expect(() => parsePnts(assemble({ ftJson: utf8('{}  ') }, { byteLengthDelta: 8 }))).toThrow(
+      /declared byteLength exceeds the buffer/,
+    );
+    expect(() => parsePnts(assemble({ ftJson: utf8('{}  ') }, { byteLength: 27 }))).toThrow(
+      /declared byteLength is shorter than the header/,
+    );
+  });
+
+  it('refuses a declared byteLength that is not the sum of its sections', () => {
+    // Shorter than the sections imply: the body runs past the tile.
+    expect(() => parsePnts(pnts({ declaredLength: 28 + 4 }))).toThrow(
+      /section lengths overrun the declared byteLength/,
+    );
+    // Longer than the sections imply: bytes inside the tile that no section
+    // accounts for. The trailing room is what lets the declaration grow while
+    // still fitting the buffer.
+    expect(() =>
+      parsePnts(
+        assemble(
+          { ftJson: ftJsonBytes({ POINTS_LENGTH: 1, POSITION: { byteOffset: 0 } }), ftBin: new Uint8Array(12) },
+          { byteLengthDelta: 16, trailing: 16 },
+        ),
+      ),
+    ).toThrow(/declared byteLength leaves bytes past the last section/);
+  });
+
+  it('refuses a feature-table JSON length that overruns the tile', () => {
+    const ftJson = ftJsonBytes({ POINTS_LENGTH: 1, POSITION: { byteOffset: 0 } });
+    const ftBin = new Uint8Array(12);
+    expect(() =>
+      parsePnts(assemble({ ftJson, ftBin }, { ftJsonLength: ftJson.length + 4 })),
+    ).toThrow(/section lengths overrun the declared byteLength/);
+    expect(() => parsePnts(assemble({ ftJson, ftBin }, { ftJsonLength: 0xffffffff }))).toThrow(
+      /section lengths overrun the declared byteLength/,
+    );
+    expect(() => parsePnts(assemble({ ftJson, ftBin }, { ftBinLength: 0xffffffff }))).toThrow(
+      /section lengths overrun the declared byteLength/,
+    );
+    expect(() => parsePnts(assemble({ ftJson, ftBin }, { btJsonLength: 0xffffffff }))).toThrow(
+      /section lengths overrun the declared byteLength/,
+    );
+    expect(() => parsePnts(assemble({ ftJson, ftBin }, { btBinLength: 0xffffffff }))).toThrow(
+      /section lengths overrun the declared byteLength/,
+    );
+  });
+
+  it('refuses a binary section that starts inside the JSON text', () => {
+    // The section lengths still add up, so only the truncated JSON gives the
+    // shortfall away: the feature-table binary begins 8 bytes early.
+    const ftJson = ftJsonBytes({ POINTS_LENGTH: 1, POSITION: { byteOffset: 0 } });
+    const ftBin = new Uint8Array(12);
+    expect(() =>
+      parsePnts(
+        assemble({ ftJson, ftBin }, { ftJsonLength: ftJson.length - 8, ftBinLength: ftBin.length + 8 }),
+      ),
+    ).toThrow(/feature table JSON does not parse/);
+  });
+
+  it('refuses a feature table that is not UTF-8, not JSON, or not an object', () => {
+    // 0xff never appears in well-formed UTF-8.
+    expect(() => parsePnts(assemble({ ftJson: new Uint8Array([0x7b, 0xff, 0x7d, 0x20]) }))).toThrow(
+      /feature table JSON is not valid UTF-8/,
+    );
+    expect(() => parsePnts(assemble({ ftJson: utf8('{oops} ') }))).toThrow(
+      /feature table JSON does not parse/,
+    );
+    expect(() => parsePnts(assemble({ ftJson: EMPTY }))).toThrow(/feature table JSON does not parse/);
+    expect(() => parsePnts(assemble({ ftJson: utf8('[1,2,3]') }))).toThrow(
+      /feature table JSON is not an object/,
+    );
+    expect(() => parsePnts(assemble({ ftJson: utf8('null') }))).toThrow(
+      /feature table JSON is not an object/,
+    );
+    expect(() => parsePnts(assemble({ ftJson: utf8('7') }))).toThrow(
+      /feature table JSON is not an object/,
+    );
+  });
+
+  it('refuses a batch table that does not parse, and accepts one that does', () => {
+    expect(() => parsePnts(pnts({ btJson: utf8('{oops} ') }))).toThrow(
+      /batch table JSON does not parse/,
+    );
+    expect(() => parsePnts(pnts({ btJson: new Uint8Array([0x7b, 0xff, 0x7d, 0x20]) }))).toThrow(
+      /batch table JSON is not valid UTF-8/,
+    );
+    expect(() => parsePnts(pnts({ btJson: utf8('[]  ') }))).toThrow(
+      /batch table JSON is not an object/,
+    );
+    expect(parsePnts(pnts({ btJson: utf8('{"name":[1,2]}  ') })).pointsLength).toBe(2);
+  });
+
+  it('refuses a POINTS_LENGTH that is not a positive uint32', () => {
+    for (const value of [0, -1, -2.5, 1.5, 4294967296, 1e300, '2', true, null, [2]]) {
+      expect(() => parsePnts(withPointsLength(value))).toThrow(
+        /POINTS_LENGTH is not a positive uint32/,
+      );
+    }
+    // JSON has no NaN or Infinity literal; `JSON.stringify` writes both as null,
+    // which is the form a real feature table would hold.
+    expect(() => parsePnts(withPointsLength(Number.NaN))).toThrow(
+      /POINTS_LENGTH is not a positive uint32/,
+    );
+    // Absent entirely.
+    expect(() => parsePnts(pnts({ ft: { POSITION: { byteOffset: 0 } }, binPoints: 2 }))).toThrow(
+      /POINTS_LENGTH is not a positive uint32/,
+    );
+    // The upper bound is inclusive, so the refusal above is about the value and
+    // not about uint32 generally.
+    expect(() => parsePnts(withPointsLength(4294967295))).toThrow(
+      /POSITION extends past the feature-table binary section/,
+    );
+  });
+
+  it('refuses a POSITION that is not an accessor object', () => {
+    for (const position of [0, 'nope', [0], null, true]) {
+      expect(() => parsePnts(pnts({ ft: { POINTS_LENGTH: 2, POSITION: position }, binPoints: 2 }))).toThrow(
+        /POSITION is not a feature-table accessor object/,
+      );
+    }
+    expect(() => parsePnts(pnts({ ft: { POINTS_LENGTH: 2, POSITION: {} }, binPoints: 2 }))).toThrow(
+      /POSITION\.byteOffset is not a non-negative whole number/,
+    );
   });
 
   it('refuses a fractional or negative POSITION.byteOffset', () => {
     expect(() => parsePnts(pnts({ positionByteOffset: 1.5 }))).toThrow(/non-negative whole number/);
     expect(() => parsePnts(pnts({ positionByteOffset: -4 }))).toThrow(/non-negative whole number/);
+    // Past the safe-integer ceiling the offset is no longer the number that was
+    // written, so it is refused before any arithmetic is done on it.
+    expect(() => parsePnts(pnts({ positionByteOffset: 2 ** 53 }))).toThrow(
+      /non-negative whole number/,
+    );
+  });
+
+  it('refuses a byte range whose arithmetic would not be exact', () => {
+    // A safe offset plus a safe length whose sum is not safe: the range check
+    // would otherwise compare an approximation and could compare it favourably.
+    expect(() => parsePnts(pnts({ positionByteOffset: Number.MAX_SAFE_INTEGER - 8 }))).toThrow(
+      /POSITION spans a byte range too large to address exactly/,
+    );
+  });
+
+  it('treats the declared tile length as the boundary, not the buffer', () => {
+    // A tile followed by 64 bytes of whatever came next in the stream still
+    // decodes: the trailing bytes are not the tile's problem.
+    expect(parsePnts(pnts({ trailing: 64 })).pointsLength).toBe(2);
+    // POSITION starts 4 bytes into the feature-table binary, so its 24 bytes run
+    // 4 past the section and into those trailing bytes. The buffer can satisfy
+    // that read; the tile cannot.
+    expect(() => parsePnts(pnts({ trailing: 64, positionByteOffset: 4 }))).toThrow(
+      /POSITION extends past the feature-table binary section/,
+    );
+    // The same overrun without trailing bytes, so the case above is about the
+    // section boundary rather than about running out of buffer.
+    expect(() => parsePnts(pnts({ positionByteOffset: 4 }))).toThrow(
+      /POSITION extends past the feature-table binary section/,
+    );
   });
 
   it('refuses a malformed RTC_CENTER rather than dropping it', () => {
@@ -192,5 +402,90 @@ describe('PNTS perimeter', () => {
     expect(parsePnts(pnts({ rtc: [1, 2, 3] })).rtcCenter).toEqual([1, 2, 3]);
     expect(parsePnts(pnts({ rtc: [0, 0, 0] })).rtcCenter).toEqual([0, 0, 0]);
     expect(parsePnts(pnts()).rtcCenter).toBeNull();
+  });
+});
+
+/** A quantised tile whose feature table is `ft`, over a 2-point binary. */
+const quantized = (ft: Record<string, unknown>) =>
+  assemble({ ftJson: ftJsonBytes(ft), ftBin: new Uint8Array(12) });
+
+describe('PNTS quantised perimeter', () => {
+  const volume = { QUANTIZED_VOLUME_OFFSET: [0, 0, 0], QUANTIZED_VOLUME_SCALE: [1, 1, 1] };
+
+  it('accepts the well-formed baseline', () => {
+    const tile = quantized({ POINTS_LENGTH: 2, POSITION_QUANTIZED: { byteOffset: 0 }, ...volume });
+    expect([...parsePnts(tile).positions]).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+
+  it('refuses a quantised array with no volume to interpret it', () => {
+    expect(() => parsePnts(quantized({ POINTS_LENGTH: 2, POSITION_QUANTIZED: { byteOffset: 0 } }))).toThrow(
+      /POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET/,
+    );
+    expect(() =>
+      parsePnts(
+        quantized({
+          POINTS_LENGTH: 2,
+          POSITION_QUANTIZED: { byteOffset: 0 },
+          QUANTIZED_VOLUME_OFFSET: [0, 0, 0],
+        }),
+      ),
+    ).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_SCALE/);
+    expect(() =>
+      parsePnts(
+        quantized({
+          POINTS_LENGTH: 2,
+          POSITION_QUANTIZED: { byteOffset: 0 },
+          QUANTIZED_VOLUME_SCALE: [1, 1, 1],
+        }),
+      ),
+    ).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET/);
+  });
+
+  it('refuses a quantised volume that is not three real numbers', () => {
+    expect(() =>
+      parsePnts(
+        quantized({ POINTS_LENGTH: 2, POSITION_QUANTIZED: { byteOffset: 0 }, ...volume, QUANTIZED_VOLUME_SCALE: [1, 1] }),
+      ),
+    ).toThrow(/QUANTIZED_VOLUME_SCALE must have 3 components/);
+    expect(() =>
+      parsePnts(
+        quantized({
+          POINTS_LENGTH: 2,
+          POSITION_QUANTIZED: { byteOffset: 0 },
+          ...volume,
+          QUANTIZED_VOLUME_OFFSET: [1, 2, Number.NaN],
+        }),
+      ),
+    ).toThrow(/QUANTIZED_VOLUME_OFFSET has a component that is not a finite number/);
+    expect(() =>
+      parsePnts(
+        quantized({
+          POINTS_LENGTH: 2,
+          POSITION_QUANTIZED: { byteOffset: 0 },
+          ...volume,
+          QUANTIZED_VOLUME_SCALE: { x: 1, y: 1, z: 1 },
+        }),
+      ),
+    ).toThrow(/QUANTIZED_VOLUME_SCALE must have 3 components/);
+  });
+
+  it('refuses a quantised array that runs past the feature-table binary', () => {
+    // 2 points of uint16 xyz need 12 bytes, and the section holds 12, so an
+    // offset of 2 is two bytes too many.
+    expect(() =>
+      parsePnts(quantized({ POINTS_LENGTH: 2, POSITION_QUANTIZED: { byteOffset: 2 }, ...volume })),
+    ).toThrow(/POSITION_QUANTIZED extends past the feature-table binary section/);
+    expect(() =>
+      parsePnts(quantized({ POINTS_LENGTH: 3, POSITION_QUANTIZED: { byteOffset: 0 }, ...volume })),
+    ).toThrow(/POSITION_QUANTIZED extends past the feature-table binary section/);
+    expect(() =>
+      parsePnts(
+        quantized({
+          POINTS_LENGTH: 2,
+          POSITION_QUANTIZED: { byteOffset: Number.MAX_SAFE_INTEGER - 8 },
+          ...volume,
+        }),
+      ),
+    ).toThrow(/POSITION_QUANTIZED spans a byte range too large to address exactly/);
   });
 });


### PR DESCRIPTION
`pnts.ts` decoded float32 `POSITION` and took the browser's buffer length as the tile boundary.

The four section lengths must now sum exactly to a declared `byteLength` that fits the buffer, so every boundary is in range by construction. `POINTS_LENGTH` must be a positive uint32, and the position array is allocated after its range is checked, so a tile declaring 4294967295 points is refused rather than reserving 51 GB first. Feature and batch JSON must be valid UTF-8, parse, and be an object.

`POSITION_QUANTIZED` decodes only when `POSITION` is absent and requires both volume vectors. Dequantization stays in float64.

Colours, normals, batch ids and Draco remain refused.
