### PR TITLE
Test a deliberate-change pair for co-registration before measuring change

### DIFF
--- a/validation/change-pair/README.md
+++ b/validation/change-pair/README.md
@@ -15,7 +15,7 @@ The narrative says flight #1 is the reference, and flight #2 followed after "som
 shapes have been laid at various locations on the bottom of the tank, sometimes in an easily visible position,
 sometimes partly hidden by or under the vegetation".
 
-Table 1 lists them. **The table is a raster image inside the PDF with no text layer behind it.** `pdftotext
+Table 1 lists them. The table is a raster image inside the PDF with no text layer behind it. `pdftotext
 -layout` returns its caption and nothing else, so the dimensions are not machine-extractable from this file.
 The values in `table1.json` were read off the rendered page and are labelled `read-from-rendered-page-image`.
 No OCR engine was installed on this host to corroborate them, so they are a careful transcription rather than
@@ -26,7 +26,7 @@ As transcribed: 22 item types, 62 individual items. The tallest stated item is a
 soil, have no stated dimensions at all, only "25 kg" against the sand. Several items are flat (wooden plank
 1 cm, Plexiglas lid 1 cm) or open mesh that a lidar pulse passes through (iron cage, fine grid, wide grid).
 
-**The document gives no coordinates and no placement map.** Nothing in the dataset says where any individual
+The document gives no coordinates and no placement map. Nothing in the dataset says where any individual
 item went, so there is no ground truth to score a detection against, only a population to compare a count with.
 
 ## Co-registration, which comes first
@@ -37,12 +37,12 @@ DJI TERRA 3.11.13.0. GPS times put flight #1 at 13:12:50 to 13:18:13 UTC and fli
 ground labels to inherit.
 
 Stable ground was taken outside the tank: epoch-1 min-Z at or above 200.5 m, which is the embankment and the
-surrounding hard standing, restricted to cells whose within-cell relief is at most 0.10 m in **both** epochs.
+surrounding hard standing, restricted to cells whose within-cell relief is at most 0.10 m in both epochs.
 That is 231,839 cells, 2,318 m<sup>2</sup>.
 
 | Quantity | Value |
 |---|---|
-| Vertical offset, median of the min-Z difference | **-0.0188 m** (epoch 2 lower) |
+| Vertical offset, median of the min-Z difference | -0.0188 m (epoch 2 lower) |
 | Vertical offset, median of the mean-Z difference | -0.0210 m |
 | Scatter about that offset, NMAD | 0.0326 m (min-Z), 0.0278 m (mean-Z) |
 | Tilt, least-squares plane | 0.250 mm/m, +50.7 mm across the 205 m east-west extent, -11.6 mm across the 332 m north-south extent |
@@ -67,13 +67,13 @@ was measured in this work.
 
 ## Cell size
 
-Measured, not habitual. The two files hold 48,360,428 and 47,893,585 points. Occupied 5 cm bins give a covered
-area of 34,187 m<sup>2</sup> and 34,185 m<sup>2</sup>, so the density is **1,415 and 1,401 points/m<sup>2</sup>**.
+Taken from the data. The two files hold 48,360,428 and 47,893,585 points. Occupied 5 cm bins give a covered
+area of 34,187 m<sup>2</sup> and 34,185 m<sup>2</sup>, so the density is 1,415 and 1,401 points/m<sup>2</sup>.
 
 | Cell | Cells with data in both epochs | Median points/cell | Fraction with 4 or more points in both |
 |---|---|---|---|
 | 0.05 m | 12,037,268 | 3 | 0.279 |
-| **0.10 m** | **3,935,602** | **11** | **0.796** |
+| 0.10 m | 3,935,602 | 11 | 0.796 |
 | 0.20 m | 1,039,432 | 45 | 0.961 |
 | 0.50 m | 170,840 | 282 | 0.985 |
 
@@ -94,7 +94,7 @@ bottom area of "approx. 2.1 ha", which is an independent check that the mask is 
 |---|---|
 | Fewer than 4 points in either epoch | 2,636 m<sup>2</sup>, 13.5% of the tank floor |
 | Vegetation, via epoch-1 relief over a 0.5 m window above 0.35 m | a further 8,989 m<sup>2</sup> |
-| Remaining searchable floor | **7,846 m<sup>2</sup>, 40.3% of the tank floor** |
+| Remaining searchable floor | 7,846 m<sup>2</sup>, 40.3% of the tank floor |
 
 Vegetation is the binding constraint, and the epoch-1 relief threshold is the honest way to state it. The
 scatter of the surface difference scales directly with how vegetated the reference epoch was:
@@ -117,7 +117,7 @@ and the tank floor is described in the source document as progressively vegetate
 The other exclusion is a wet drainage channel. Cells with epoch-1 min-Z between 193.8 and 194.2 m form a
 narrow dendritic feature on the north part of the floor where the difference is several times more likely to
 exceed 0.10 m than on the surrounding floor, and almost always downward, which is not a physical surface
-change. It is 548 m<sup>2</sup> of the searchable floor. It was not masked out; it is left in and it is the main reason the
+change. It is 548 m<sup>2</sup> of the searchable floor. It is left in, and it is the main reason the
 falling-direction count below is as high as it is.
 
 ### Detector, and its own false-positive measure
@@ -138,8 +138,8 @@ have an RMS at or below 0.06 m.
 
 | Direction and area | Stage-1 candidates | Point-verified | Passing |
 |---|---|---|---|
-| Tank, rising | 139 | 134 | **3** |
-| Tank, falling (physically impossible) | 425 | 414 | **1** |
+| Tank, rising | 139 | 134 | 3 |
+| Tank, falling (physically impossible) | 425 | 414 | 1 |
 | Outside the tank, rising | 8 | 8 | 1 |
 | Outside the tank, falling | 34 | 34 | 4 |
 
@@ -150,20 +150,20 @@ it still leaves one impossible in-tank fall standing against three rises.
 
 | East | North | Returns above 0.15 m, epoch 1 | epoch 2 | Peak above local ground | Footprint | Volume |
 |---|---|---|---|---|---|---|
-| 852222.75 | 6517048.50 | **0** | 193 | 0.256 m | 0.135 m<sup>2</sup>, 0.40 x 0.50 m | 0.0207 m<sup>3</sup> |
-| 852224.60 | 6517049.85 | **0** | 223 | 0.410 m | 0.170 m<sup>2</sup>, 0.45 x 0.60 m | 0.0357 m<sup>3</sup> |
-| 852222.35 | 6517052.00 | **0** | 72 | 0.197 m | 0.135 m<sup>2</sup>, 0.60 x 0.35 m | 0.0125 m<sup>3</sup> |
+| 852222.75 | 6517048.50 | 0 | 193 | 0.256 m | 0.135 m<sup>2</sup>, 0.40 x 0.50 m | 0.0207 m<sup>3</sup> |
+| 852224.60 | 6517049.85 | 0 | 223 | 0.410 m | 0.170 m<sup>2</sup>, 0.45 x 0.60 m | 0.0357 m<sup>3</sup> |
+| 852222.35 | 6517052.00 | 0 | 72 | 0.197 m | 0.135 m<sup>2</sup>, 0.60 x 0.35 m | 0.0125 m<sup>3</sup> |
 
 Zero returns above 0.15 m in the reference epoch against 72 to 223 in the second, over ground whose plane fits
-to 0.025 to 0.044 m RMS. Volumes are integrated over the epoch-1 ground plane, so they are the volume standing
-proud of the floor, not a displacement. **0.069 m<sup>3</sup> in total.**
+to 0.025 to 0.044 m RMS. Volumes are integrated over the epoch-1 ground plane, so each is the volume standing
+proud of the floor. 0.069 m<sup>3</sup> in total.
 
 PDAL reproduces all three from its own rasteriser. `writers.gdal output_type=max` at 0.10 m over the same
 window, differenced and dumped through `gdal_translate -of XYZ`, gives peak rises of 0.193, 0.306 and 0.111 m
 before the 0.019 m offset correction, which lands within 0.02 m of the values above once the offset is added.
 See `pdal-crosscheck.json`.
 
-All three sit inside one 3 x 4 m patch. That is not a site-wide recovery of the placed set; it is one cluster.
+All three sit inside one 3 x 4 m patch. The recovered set is one cluster.
 
 ## Does it match the documentation
 
@@ -176,8 +176,8 @@ Table 1 describes. A 0.41 m peak is consistent with a 50 cm construction cone, w
 19 cm brick block, a 19.5 cm jar or a 19.6 cm concrete test tube. No single assignment can be made, because
 the document gives no locations.
 
-Not consistent: **3 of 62 placed items were recovered, and 3 of the 18 whose stated height clears the
-detection threshold.** At the same settings the detector also returned one in-tank fall that cannot be a laid
+Not consistent: 3 of 62 placed items were recovered, and 3 of the 18 whose stated height clears the
+detection threshold. At the same settings the detector also returned one in-tank fall that cannot be a laid
 solid, so even the three cannot be asserted individually at better than roughly 3:1 against the method's own
 false-positive rate. Most of the placed set was never recoverable by surface differencing: 10 items have no
 stated dimensions, several are flat to within a centimetre or are open mesh, 20 of the 62 are 6 cm plastic
@@ -185,10 +185,17 @@ balls, and the pipes and drains are 10 cm cylinders that never fill a 0.10 m cel
 
 ## What this pair does and does not support
 
-It supports a co-registration statement. Two flights, one sensor, one processing chain, 34 minutes apart,
-aligned to 1 to 3 cm horizontally and 1.9 to 2.1 cm vertically with a 0.25 mm/m tilt and a 7 cm block-to-block
-spread. Those numbers are measured on 2,318 m<sup>2</sup> of stable ground outside the changed area, and they
-are the kind of number a change product needs behind it.
+It supports a co-registration statement about the embankment and rim. Two flights, one sensor, one processing
+chain, 34 minutes apart, aligned to 1 to 3 cm horizontally and 1.9 to 2.1 cm vertically with a 0.25 mm/m tilt.
+
+Two limits sit on that number. The 7 cm block-to-block spread is larger than the 1.9 cm offset it varies
+around, so a single alignment figure is the median of a field that moves, and the field is what a per-cell
+difference meets. The 2,318 m<sup>2</sup> it was measured on also lies at or above 200.5 m while the floor it
+is applied to lies below 198 m, leaving the two surfaces disjoint in plan and by about 2.5 m in height.
+
+Carrying the alignment from one surface to the other is an assumption here. Nothing in this pair fixes the
+floor against an independent surface, and an error that varies with range to target would differ between the
+rim and the floor while leaving both figures above unchanged.
 
 It does not support a change-detection demonstration at the scale the source document implies. The controlled
 change is real and deliberate, but it is small relative to what a 1,400 points/m<sup>2</sup> survey can

--- a/validation/change-pair/README.md
+++ b/validation/change-pair/README.md
@@ -1,0 +1,210 @@
+# Co-UDlabs Chassieu flight pair: co-registration and controlled change
+
+Two drone lidar flights over the Django Reinhardt stormwater infiltration tank in Chassieu, Lyon, 34 minutes
+apart on 16 May 2023, with a documented set of solids laid on the tank floor between them. Co-UDlabs
+(H2020 grant 101008626), WP6 Task 6.1, INSA Lyon. DOI 10.5281/zenodo.15175591, CC BY 4.0.
+
+This directory records what the pair supports and what it does not. It moves nothing:
+`docs/validation/claim-register.yaml` is untouched, no study manifest was written under
+`validation/cross-implementation/studies/`, no evidence level changed, and none of OLV's acceptance
+thresholds were run. Whether any of this becomes evidence is a separate decision.
+
+## What the source document states about the placed solids
+
+The narrative says flight #1 is the reference, and flight #2 followed after "some solids of various sizes and
+shapes have been laid at various locations on the bottom of the tank, sometimes in an easily visible position,
+sometimes partly hidden by or under the vegetation".
+
+Table 1 lists them. **The table is a raster image inside the PDF with no text layer behind it.** `pdftotext
+-layout` returns its caption and nothing else, so the dimensions are not machine-extractable from this file.
+The values in `table1.json` were read off the rendered page and are labelled `read-from-rendered-page-image`.
+No OCR engine was installed on this host to corroborate them, so they are a careful transcription rather than
+extracted data. Anything downstream that depends on an exact dimension should go back to the PDF.
+
+As transcribed: 22 item types, 62 individual items. The tallest stated item is a 50 cm construction cone
+(4 placed). 18 items have a stated height of 15 cm or more. 10 items, the 5 bags of sand and the 5 buckets of
+soil, have no stated dimensions at all, only "25 kg" against the sand. Several items are flat (wooden plank
+1 cm, Plexiglas lid 1 cm) or open mesh that a lidar pulse passes through (iron cage, fine grid, wide grid).
+
+**The document gives no coordinates and no placement map.** Nothing in the dataset says where any individual
+item went, so there is no ground truth to score a detection against, only a population to compare a count with.
+
+## Co-registration, which comes first
+
+Both files carry EPSG:2154 (RGF93 v1 / Lambert-93) with EPSG:5720 (NGF-IGN69) heights and were produced by
+DJI TERRA 3.11.13.0. GPS times put flight #1 at 13:12:50 to 13:18:13 UTC and flight #2 at 13:52:10 to
+13:57:03 UTC, a gap of 34.0 minutes. `Classification` is 0 for every point in both files, so there are no
+ground labels to inherit.
+
+Stable ground was taken outside the tank: epoch-1 min-Z at or above 200.5 m, which is the embankment and the
+surrounding hard standing, restricted to cells whose within-cell relief is at most 0.10 m in **both** epochs.
+That is 231,839 cells, 2,318 m<sup>2</sup>.
+
+| Quantity | Value |
+|---|---|
+| Vertical offset, median of the min-Z difference | **-0.0188 m** (epoch 2 lower) |
+| Vertical offset, median of the mean-Z difference | -0.0210 m |
+| Scatter about that offset, NMAD | 0.0326 m (min-Z), 0.0278 m (mean-Z) |
+| Tilt, least-squares plane | 0.250 mm/m, +50.7 mm across the 205 m east-west extent, -11.6 mm across the 332 m north-south extent |
+| Residual scatter after removing the plane, NMAD | 0.0250 m |
+| Median offset per 25 m block (53 blocks) | -0.0505 m to +0.0208 m |
+| Horizontal shift, minimising the difference NMAD over sub-cell shifts | east -0.017 m, north +0.025 m |
+| Horizontal shift, Nuth and Kaeaeb on stable slopes of 5 to 45 degrees | amplitude 0.0093 m |
+
+The bias and the scatter are reported separately on purpose. A single RMS over the stable ground would be
+0.14 m and would be almost entirely tail, hiding both the 1.9 cm bias and the fact that the residual is not
+uniform across the site.
+
+**The two epochs are co-registered.** Horizontally the two independent estimators agree at about 1 to 3 cm,
+which is a quarter of the analysis cell and well inside the sensor's stated 10 cm horizontal system accuracy.
+Vertically there is a systematic offset of 1.9 to 2.1 cm, inside the stated 5 cm vertical accuracy, plus a
+spatially varying component: a 0.25 mm/m tilt, and a block-to-block spread of about 7 cm peak to peak that the
+plane does not absorb. Every change number below is quoted after subtracting that fitted plane.
+
+Both components sit inside the sensor's own published system accuracy for this flying height, which is the
+relevant yardstick here. No comparison against any other epoch pair in this repository is made, because none
+was measured in this work.
+
+## Cell size
+
+Measured, not habitual. The two files hold 48,360,428 and 47,893,585 points. Occupied 5 cm bins give a covered
+area of 34,187 m<sup>2</sup> and 34,185 m<sup>2</sup>, so the density is **1,415 and 1,401 points/m<sup>2</sup>**.
+
+| Cell | Cells with data in both epochs | Median points/cell | Fraction with 4 or more points in both |
+|---|---|---|---|
+| 0.05 m | 12,037,268 | 3 | 0.279 |
+| **0.10 m** | **3,935,602** | **11** | **0.796** |
+| 0.20 m | 1,039,432 | 45 | 0.961 |
+| 0.50 m | 170,840 | 282 | 0.985 |
+
+0.10 m is the smallest cell that still carries a double-figure sample per epoch. It is also the largest cell
+that can resolve the documented items, whose plan dimensions run from 6 cm to 1.23 m and are mostly between
+0.2 and 0.5 m. 0.05 m would put a median of 3 points in a cell, which is too few for a per-cell extremum;
+0.20 m would smear a 0.2 m object across a single cell. Cells with fewer than 4 points in either epoch are
+dropped.
+
+## Change inside the tank
+
+The tank floor is epoch-1 min-Z below 198 m. That area is 19,472 m<sup>2</sup>, against the document's stated
+bottom area of "approx. 2.1 ha", which is an independent check that the mask is the right feature.
+
+### What was excluded and what it cost
+
+| Exclusion | Cost |
+|---|---|
+| Fewer than 4 points in either epoch | 2,636 m<sup>2</sup>, 13.5% of the tank floor |
+| Vegetation, via epoch-1 relief over a 0.5 m window above 0.35 m | a further 8,989 m<sup>2</sup> |
+| Remaining searchable floor | **7,846 m<sup>2</sup>, 40.3% of the tank floor** |
+
+Vegetation is the binding constraint, and the epoch-1 relief threshold is the honest way to state it. The
+scatter of the surface difference scales directly with how vegetated the reference epoch was:
+
+| Epoch-1 relief over 0.5 m | Area | NMAD of the difference | 5 x NMAD |
+|---|---|---|---|
+| 0 to 0.15 m | 1,089 m<sup>2</sup> | 0.017 m | 0.08 m |
+| 0.15 to 0.25 m | 4,002 m<sup>2</sup> | 0.021 m | 0.10 m |
+| 0.25 to 0.35 m | 2,755 m<sup>2</sup> | 0.029 m | 0.15 m |
+| 0.35 to 0.50 m | 2,901 m<sup>2</sup> | 0.037 m | 0.18 m |
+| 0.50 to 1.0 m | 2,454 m<sup>2</sup> | 0.068 m | 0.34 m |
+| 1.0 to 3.0 m | 1,916 m<sup>2</sup> | 0.133 m | 0.67 m |
+| above 3.0 m | 1,718 m<sup>2</sup> | 0.244 m | 1.22 m |
+
+Over the 3,634 m<sup>2</sup> of floor carrying more than 1 m of epoch-1 relief, the difference between two
+flights 34 minutes apart has an NMAD of 0.13 to 0.24 m and a long tail reaching several metres. That is the
+lidar reaching the ground under a bush on one pass and not the other. No 20 cm object is recoverable there,
+and the tank floor is described in the source document as progressively vegetated.
+
+The other exclusion is a wet drainage channel. Cells with epoch-1 min-Z between 193.8 and 194.2 m form a
+narrow dendritic feature on the north part of the floor where the difference is several times more likely to
+exceed 0.10 m than on the surrounding floor, and almost always downward, which is not a physical surface
+change. It is 548 m<sup>2</sup> of the searchable floor. It was not masked out; it is left in and it is the main reason the
+falling-direction count below is as high as it is.
+
+### Detector, and its own false-positive measure
+
+Solids can only add material, so the same detector run in the falling direction measures its own false
+positives. Both directions run over the tank and, separately, over the stable ground outside it.
+
+Stage 1 works on the per-cell max-Z difference at 0.10 m after subtracting the stable-ground plane: connected
+components above +0.10 m, 4 to 200 cells, at least 45% fill of their bounding box, aspect ratio at most 4:1,
+epoch-1 relief at most 0.60 m, and a quiet 3-cell surround (90th percentile of the absolute difference below
+0.15 m).
+
+Stage 2 re-tests every candidate against the raw points, with no raster in the path. A ground plane is fitted
+robustly to the points in a 0.60 to 1.35 m annulus in each epoch, and the returns inside a 0.55 m core are
+counted above 0.15 m. A candidate passes only if the before-epoch has 10 or fewer such returns, the
+after-epoch has 60 or more, the peak stands at least 0.18 m above local ground, and both ground-plane fits
+have an RMS at or below 0.06 m.
+
+| Direction and area | Stage-1 candidates | Point-verified | Passing |
+|---|---|---|---|
+| Tank, rising | 139 | 134 | **3** |
+| Tank, falling (physically impossible) | 425 | 414 | **1** |
+| Outside the tank, rising | 8 | 8 | 1 |
+| Outside the tank, falling | 34 | 34 | 4 |
+
+Stage 1 alone is useless: 425 falling candidates against 139 rising. Stage 2 is what carries the result, and
+it still leaves one impossible in-tank fall standing against three rises.
+
+### The three detections
+
+| East | North | Returns above 0.15 m, epoch 1 | epoch 2 | Peak above local ground | Footprint | Volume |
+|---|---|---|---|---|---|---|
+| 852222.75 | 6517048.50 | **0** | 193 | 0.256 m | 0.135 m<sup>2</sup>, 0.40 x 0.50 m | 0.0207 m<sup>3</sup> |
+| 852224.60 | 6517049.85 | **0** | 223 | 0.410 m | 0.170 m<sup>2</sup>, 0.45 x 0.60 m | 0.0357 m<sup>3</sup> |
+| 852222.35 | 6517052.00 | **0** | 72 | 0.197 m | 0.135 m<sup>2</sup>, 0.60 x 0.35 m | 0.0125 m<sup>3</sup> |
+
+Zero returns above 0.15 m in the reference epoch against 72 to 223 in the second, over ground whose plane fits
+to 0.025 to 0.044 m RMS. Volumes are integrated over the epoch-1 ground plane, so they are the volume standing
+proud of the floor, not a displacement. **0.069 m<sup>3</sup> in total.**
+
+PDAL reproduces all three from its own rasteriser. `writers.gdal output_type=max` at 0.10 m over the same
+window, differenced and dumped through `gdal_translate -of XYZ`, gives peak rises of 0.193, 0.306 and 0.111 m
+before the 0.019 m offset correction, which lands within 0.02 m of the values above once the offset is added.
+See `pdal-crosscheck.json`.
+
+All three sit inside one 3 x 4 m patch. That is not a site-wide recovery of the placed set; it is one cluster.
+
+## Does it match the documentation
+
+Partly, and the honest answer is mostly no.
+
+Consistent: three compact objects appear on the tank floor between the two flights and none disappears in the
+same neighbourhood. Their heights, 0.20 to 0.41 m, and footprints, 0.35 to 0.60 m across, sit inside the range
+Table 1 describes. A 0.41 m peak is consistent with a 50 cm construction cone, whose tip is undersampled; a
+0.26 m peak is consistent with the 24 cm jerrican or a 23 cm iron cage; a 0.20 m peak is consistent with a
+19 cm brick block, a 19.5 cm jar or a 19.6 cm concrete test tube. No single assignment can be made, because
+the document gives no locations.
+
+Not consistent: **3 of 62 placed items were recovered, and 3 of the 18 whose stated height clears the
+detection threshold.** At the same settings the detector also returned one in-tank fall that cannot be a laid
+solid, so even the three cannot be asserted individually at better than roughly 3:1 against the method's own
+false-positive rate. Most of the placed set was never recoverable by surface differencing: 10 items have no
+stated dimensions, several are flat to within a centimetre or are open mesh, 20 of the 62 are 6 cm plastic
+balls, and the pipes and drains are 10 cm cylinders that never fill a 0.10 m cell.
+
+## What this pair does and does not support
+
+It supports a co-registration statement. Two flights, one sensor, one processing chain, 34 minutes apart,
+aligned to 1 to 3 cm horizontally and 1.9 to 2.1 cm vertically with a 0.25 mm/m tilt and a 7 cm block-to-block
+spread. Those numbers are measured on 2,318 m<sup>2</sup> of stable ground outside the changed area, and they
+are the kind of number a change product needs behind it.
+
+It does not support a change-detection demonstration at the scale the source document implies. The controlled
+change is real and deliberate, but it is small relative to what a 1,400 points/m<sup>2</sup> survey can
+resolve through the vegetation actually present on this floor, and the source document supplies no placement
+map to score against. A tank-wide change volume is not defensible from this pair: 60% of the floor is not
+searchable, the recovered set is 3 items in one 3 x 4 m patch, and the falling-direction control does not go
+to zero.
+
+The clean result here is the co-registration. The change measurement is a negative result, and it is more
+useful stated as one than stretched into a positive.
+
+## Files
+
+- `scripts/run-change-pair.py` reads the two LAS files and writes `coregistration.json` and `detections.json`.
+- `pdal/dsm-epoch1.json`, `pdal/dsm-epoch2.json` are the PDAL pipelines, with `DATASET_DIR` and `OUTPUT_DIR`
+  placeholders substituted at run time so no committed file names the host.
+- `pdal-crosscheck.json` holds the PDAL result at the three detections.
+- `table1.json` is the transcription of the source table, with its provenance marked.
+- `reference-runs.json` records every tool version, resolved path, command and output digest.

--- a/validation/change-pair/coregistration.json
+++ b/validation/change-pair/coregistration.json
@@ -1,0 +1,119 @@
+{
+ "stableGround": {
+  "definition": "epoch-1 min-Z >= 200.5 m, within-cell relief <= 0.10 m in both epochs, >= 4 points per cell per epoch",
+  "cells": 231839,
+  "areaM2": 2318.4
+ },
+ "verticalOffsetM": {
+  "minZSurface": {
+   "median": -0.0188,
+   "nmad": 0.0326
+  },
+  "meanZSurface": {
+   "median": -0.021,
+   "nmad": 0.0278
+  }
+ },
+ "tilt": {
+  "interceptM": -0.00876,
+  "perMetreEast": 0.000247297,
+  "perMetreNorth": -3.49579e-05,
+  "magnitudeMmPerM": 0.2498,
+  "acrossEastExtentMm": 50.7,
+  "acrossNorthExtentMm": -11.61,
+  "residualNmadM": 0.025
+ },
+ "blockMediansM": {
+  "blockSizeM": 25,
+  "blocks": 53,
+  "min": -0.0505,
+  "p10": -0.0434,
+  "median": -0.026,
+  "p90": 0.0118,
+  "max": 0.0208
+ },
+ "horizontalShiftM": {
+  "nmadSearch": {
+   "sampleCells": 139795,
+   "gridBestEast": -0.025,
+   "gridBestNorth": 0.025,
+   "subCellEast": -0.017,
+   "subCellNorth": 0.0252,
+   "nmadAtBest": 0.02874,
+   "nmadAtZeroShift": 0.03054
+  },
+  "nuthKaab": {
+   "cells": 697058,
+   "amplitudeM": 0.0093,
+   "directionDeg": 63.8,
+   "eastM": -0.0041,
+   "northM": -0.0083
+  }
+ },
+ "density": {
+  "epoch1": {
+   "points": 48360428,
+   "coveredAreaM2": 34186.8,
+   "pointsPerM2": 1414.6
+  },
+  "epoch2": {
+   "points": 47893585,
+   "coveredAreaM2": 34185.4,
+   "pointsPerM2": 1401.0
+  },
+  "analysisCell": 0.1,
+  "cellsBothEpochs": 3132318,
+  "medianPointsPerCellEpoch1": 13.0,
+  "medianPointsPerCellEpoch2": 13.0,
+  "cellSizeStudy": [
+   {
+    "cellM": 0.05,
+    "cellsBothEpochs": 12037268,
+    "medianPointsPerCellEpoch1": 3.0,
+    "medianPointsPerCellEpoch2": 3.0,
+    "fractionWithAtLeast4InBoth": 0.279,
+    "fractionWithAtLeast10InBoth": 0.007
+   },
+   {
+    "cellM": 0.1,
+    "cellsBothEpochs": 3935602,
+    "medianPointsPerCellEpoch1": 11.0,
+    "medianPointsPerCellEpoch2": 11.0,
+    "fractionWithAtLeast4InBoth": 0.796,
+    "fractionWithAtLeast10InBoth": 0.492
+   },
+   {
+    "cellM": 0.2,
+    "cellsBothEpochs": 1039432,
+    "medianPointsPerCellEpoch1": 45.0,
+    "medianPointsPerCellEpoch2": 44.0,
+    "fractionWithAtLeast4InBoth": 0.961,
+    "fractionWithAtLeast10InBoth": 0.881
+   },
+   {
+    "cellM": 0.25,
+    "cellsBothEpochs": 671218,
+    "medianPointsPerCellEpoch1": 70.0,
+    "medianPointsPerCellEpoch2": 69.0,
+    "fractionWithAtLeast4InBoth": 0.969,
+    "fractionWithAtLeast10InBoth": 0.93
+   },
+   {
+    "cellM": 0.5,
+    "cellsBothEpochs": 170840,
+    "medianPointsPerCellEpoch1": 282.0,
+    "medianPointsPerCellEpoch2": 277.0,
+    "fractionWithAtLeast4InBoth": 0.985,
+    "fractionWithAtLeast10InBoth": 0.968
+   },
+   {
+    "cellM": 1.0,
+    "cellsBothEpochs": 43227,
+    "medianPointsPerCellEpoch1": 1131.0,
+    "medianPointsPerCellEpoch2": 1110.0,
+    "fractionWithAtLeast4InBoth": 0.995,
+    "fractionWithAtLeast10InBoth": 0.985
+   }
+  ]
+ }
+}

--- a/validation/change-pair/detections.json
+++ b/validation/change-pair/detections.json
@@ -1,0 +1,237 @@
+{
+ "exclusions": {
+  "tankBottomM2": 19471.6,
+  "keptWithEnoughPointsM2": 16835.2,
+  "droppedSparseOrSingleEpochM2": 2636.5,
+  "searchableAtRelief035M2": 7846.2
+ },
+ "noiseByEpoch1Relief": [
+  {
+   "reliefLoM": 0,
+   "reliefHiM": 0.15,
+   "areaM2": 1089.4,
+   "medianM": -0.0131,
+   "nmadM": 0.0168,
+   "fiveNmadM": 0.084
+  },
+  {
+   "reliefLoM": 0.15,
+   "reliefHiM": 0.25,
+   "areaM2": 4001.7,
+   "medianM": -0.0158,
+   "nmadM": 0.0206,
+   "fiveNmadM": 0.103
+  },
+  {
+   "reliefLoM": 0.25,
+   "reliefHiM": 0.35,
+   "areaM2": 2755.2,
+   "medianM": -0.0156,
+   "nmadM": 0.0293,
+   "fiveNmadM": 0.147
+  },
+  {
+   "reliefLoM": 0.35,
+   "reliefHiM": 0.5,
+   "areaM2": 2901.4,
+   "medianM": -0.0156,
+   "nmadM": 0.0369,
+   "fiveNmadM": 0.185
+  },
+  {
+   "reliefLoM": 0.5,
+   "reliefHiM": 1.0,
+   "areaM2": 2454.4,
+   "medianM": -0.0139,
+   "nmadM": 0.0683,
+   "fiveNmadM": 0.342
+  },
+  {
+   "reliefLoM": 1.0,
+   "reliefHiM": 3.0,
+   "areaM2": 1915.6,
+   "medianM": -0.0079,
+   "nmadM": 0.1333,
+   "fiveNmadM": 0.667
+  },
+  {
+   "reliefLoM": 3.0,
+   "reliefHiM": 99.0,
+   "areaM2": 1717.6,
+   "medianM": -0.0062,
+   "nmadM": 0.2436,
+   "fiveNmadM": 1.218
+  }
+ ],
+ "counts": {
+  "tank-rise": {
+   "candidates": 139,
+   "pointVerified": 134,
+   "passing": 3
+  },
+  "tank-fall": {
+   "candidates": 425,
+   "pointVerified": 414,
+   "passing": 1
+  },
+  "outside-rise": {
+   "candidates": 8,
+   "pointVerified": 8,
+   "passing": 1
+  },
+  "outside-fall": {
+   "candidates": 34,
+   "pointVerified": 34,
+   "passing": 4
+  }
+ },
+ "confirmed": [
+  {
+   "group": "tank-rise",
+   "E": 852222.75,
+   "N": 6517048.5,
+   "cells": 20,
+   "groundRmsEpoch1M": 0.041,
+   "groundRmsEpoch2M": 0.044,
+   "pointsAbove015Epoch1": 0,
+   "pointsAbove015Epoch2": 193,
+   "maxHeightEpoch1M": 0.086,
+   "maxHeightEpoch2M": 0.256,
+   "footprintM2": 0.135,
+   "bboxM": [
+    0.4,
+    0.5
+   ],
+   "volumeM3": 0.0207
+  },
+  {
+   "group": "tank-rise",
+   "E": 852224.6,
+   "N": 6517049.85,
+   "cells": 26,
+   "groundRmsEpoch1M": 0.026,
+   "groundRmsEpoch2M": 0.027,
+   "pointsAbove015Epoch1": 0,
+   "pointsAbove015Epoch2": 223,
+   "maxHeightEpoch1M": 0.096,
+   "maxHeightEpoch2M": 0.41,
+   "footprintM2": 0.17,
+   "bboxM": [
+    0.45,
+    0.6
+   ],
+   "volumeM3": 0.0357
+  },
+  {
+   "group": "tank-rise",
+   "E": 852222.35,
+   "N": 6517052.0,
+   "cells": 5,
+   "groundRmsEpoch1M": 0.025,
+   "groundRmsEpoch2M": 0.027,
+   "pointsAbove015Epoch1": 0,
+   "pointsAbove015Epoch2": 72,
+   "maxHeightEpoch1M": 0.087,
+   "maxHeightEpoch2M": 0.197,
+   "footprintM2": 0.135,
+   "bboxM": [
+    0.6,
+    0.35
+   ],
+   "volumeM3": 0.0125
+  },
+  {
+   "group": "tank-fall",
+   "E": 852227.0,
+   "N": 6517009.45,
+   "cells": 44,
+   "groundRmsEpoch1M": 0.054,
+   "groundRmsEpoch2M": 0.058,
+   "pointsAbove015Epoch1": 117,
+   "pointsAbove015Epoch2": 3,
+   "maxHeightEpoch1M": 0.243,
+   "maxHeightEpoch2M": 0.171,
+   "footprintM2": null,
+   "bboxM": null,
+   "volumeM3": null
+  },
+  {
+   "group": "outside-rise",
+   "E": 852291.2,
+   "N": 6517040.35,
+   "cells": 13,
+   "groundRmsEpoch1M": 0.035,
+   "groundRmsEpoch2M": 0.033,
+   "pointsAbove015Epoch1": 1,
+   "pointsAbove015Epoch2": 66,
+   "maxHeightEpoch1M": 0.151,
+   "maxHeightEpoch2M": 0.337,
+   "footprintM2": 0.085,
+   "bboxM": [
+    0.45,
+    0.6
+   ],
+   "volumeM3": 0.0161
+  },
+  {
+   "group": "outside-fall",
+   "E": 852239.25,
+   "N": 6517068.4,
+   "cells": 22,
+   "groundRmsEpoch1M": 0.038,
+   "groundRmsEpoch2M": 0.04,
+   "pointsAbove015Epoch1": 96,
+   "pointsAbove015Epoch2": 0,
+   "maxHeightEpoch1M": 0.401,
+   "maxHeightEpoch2M": 0.094,
+   "footprintM2": null,
+   "bboxM": null,
+   "volumeM3": null
+  },
+  {
+   "group": "outside-fall",
+   "E": 852239.75,
+   "N": 6517069.8,
+   "cells": 27,
+   "groundRmsEpoch1M": 0.032,
+   "groundRmsEpoch2M": 0.035,
+   "pointsAbove015Epoch1": 142,
+   "pointsAbove015Epoch2": 0,
+   "maxHeightEpoch1M": 0.396,
+   "maxHeightEpoch2M": 0.07,
+   "footprintM2": null,
+   "bboxM": null,
+   "volumeM3": null
+  },
+  {
+   "group": "outside-fall",
+   "E": 852221.65,
+   "N": 6517079.25,
+   "cells": 52,
+   "groundRmsEpoch1M": 0.045,
+   "groundRmsEpoch2M": 0.046,
+   "pointsAbove015Epoch1": 110,
+   "pointsAbove015Epoch2": 8,
+   "maxHeightEpoch1M": 0.252,
+   "maxHeightEpoch2M": 0.253,
+   "footprintM2": null,
+   "bboxM": null,
+   "volumeM3": null
+  },
+  {
+   "group": "outside-fall",
+   "E": 852220.3,
+   "N": 6517080.15,
+   "cells": 73,
+   "groundRmsEpoch1M": 0.047,
+   "groundRmsEpoch2M": 0.047,
+   "pointsAbove015Epoch1": 132,
+   "pointsAbove015Epoch2": 0,
+   "maxHeightEpoch1M": 0.221,
+   "maxHeightEpoch2M": 0.072,
+   "footprintM2": null,
+   "bboxM": null,
+   "volumeM3": null
+  }
+ ]
+}

--- a/validation/change-pair/pdal-crosscheck.json
+++ b/validation/change-pair/pdal-crosscheck.json
@@ -1,0 +1,31 @@
+{
+ "tool": "PDAL writers.gdal output_type=max, resolution 0.1 m, then gdal_translate -of XYZ",
+ "windowBounds": "E 852218-852232, N 6517042-6517056",
+ "cells": 19600,
+ "objects": [
+  {
+   "E": 852222.75,
+   "N": 6517048.5,
+   "cells": 30,
+   "maxDsmRiseM": 0.193,
+   "p90DsmRiseM": 0.183,
+   "cellsAbove010M": 28
+  },
+  {
+   "E": 852224.6,
+   "N": 6517049.85,
+   "cells": 36,
+   "maxDsmRiseM": 0.306,
+   "p90DsmRiseM": 0.302,
+   "cellsAbove010M": 35
+  },
+  {
+   "E": 852222.35,
+   "N": 6517052.0,
+   "cells": 36,
+   "maxDsmRiseM": 0.111,
+   "p90DsmRiseM": 0.102,
+   "cellsAbove010M": 6
+  }
+ ]
+}

--- a/validation/change-pair/pdal/dsm-epoch1.json
+++ b/validation/change-pair/pdal/dsm-epoch1.json
@@ -1,0 +1,19 @@
+{
+  "pipeline": [
+    { "type": "readers.las", "filename": "DATASET_DIR/chassieu_vol1.las" },
+    { "type": "filters.crop", "bounds": "([852217,852233],[6517041,6517057])" },
+    {
+      "type": "writers.gdal",
+      "filename": "OUTPUT_DIR/dsm-epoch1.tif",
+      "output_type": "max",
+      "resolution": 0.1,
+      "origin_x": 852218,
+      "origin_y": 6517042,
+      "width": 140,
+      "height": 140,
+      "nodata": -9999,
+      "data_type": "float64",
+      "gdaldriver": "GTiff"
+    }
+  ]
+}

--- a/validation/change-pair/pdal/dsm-epoch2.json
+++ b/validation/change-pair/pdal/dsm-epoch2.json
@@ -1,0 +1,19 @@
+{
+  "pipeline": [
+    { "type": "readers.las", "filename": "DATASET_DIR/chassieu_vol2.las" },
+    { "type": "filters.crop", "bounds": "([852217,852233],[6517041,6517057])" },
+    {
+      "type": "writers.gdal",
+      "filename": "OUTPUT_DIR/dsm-epoch2.tif",
+      "output_type": "max",
+      "resolution": 0.1,
+      "origin_x": 852218,
+      "origin_y": 6517042,
+      "width": 140,
+      "height": 140,
+      "nodata": -9999,
+      "data_type": "float64",
+      "gdaldriver": "GTiff"
+    }
+  ]
+}

--- a/validation/change-pair/reference-runs.json
+++ b/validation/change-pair/reference-runs.json
@@ -1,0 +1,186 @@
+{
+ "generatedBy": "validation/change-pair/scripts/run-change-pair.py",
+ "reference": "PDAL, GDAL, laspy, numpy, scipy",
+ "evidenceNote": "A record of one investigation of an external two-epoch dataset. It moves no claim and sets no evidence level: docs/validation/claim-register.yaml is untouched, no cross-implementation study manifest was written, and none of OLV's acceptance thresholds were run. The numbers here are measurements of the dataset, not of any OpenLiDARViewer product.",
+ "environment": {
+  "pdalVersion": "pdal 2.10.2 (git-version: Release)",
+  "pdalResolvedPath": "/opt/homebrew/bin/pdal",
+  "gdalTranslateVersion": "GDAL 3.13.3 \"Iowa City\", released 2026/08/13",
+  "gdalTranslateResolvedPath": "/opt/homebrew/bin/gdal_translate",
+  "pdftotextVersion": "pdftotext version 26.08.0",
+  "pdftotextResolvedPath": "/opt/homebrew/bin/pdftotext",
+  "pythonVersion": "Python 3.11.15",
+  "pythonResolvedPath": "/opt/homebrew/opt/python@3.11/bin/python3.11",
+  "numpyVersion": "2.4.6",
+  "scipyVersion": "1.17.1",
+  "laspyVersion": "2.7.0",
+  "containerPinning": "not-executed",
+  "containerPinningReason": "The Docker daemon is not running on this host, so no pinned image was pulled and no digest exists to record; every tool was invoked from the host PATH.",
+  "platform": "darwin",
+  "architecture": "arm64",
+  "node": "v26.7.0"
+ },
+ "pathPlaceholders": {
+  "DATASET_DIR": "the directory holding the two LAS files and the PDF, supplied at run time",
+  "OUTPUT_DIR": "a scratch directory for the intermediate GeoTIFF and XYZ dumps, supplied at run time",
+  "note": "Absolute paths are not recorded, so no committed file names the machine the analysis ran on."
+ },
+ "parameters": {
+  "grid": {
+   "firstPassBinM": 0.05,
+   "analysisCellM": 0.1,
+   "originX": 852115.0,
+   "originY": 6516819.0,
+   "columns": 2060,
+   "rows": 3330,
+   "minPointsPerCellPerEpoch": 4
+  },
+  "masks": {
+   "tankBottomEpoch1MinZBelowM": 198.0,
+   "outsideEpoch1MinZAtLeastM": 200.5,
+   "stableGroundWithinCellReliefAtMostM": 0.1,
+   "epoch1ReliefWindowCells": 5
+  },
+  "detector": {
+   "surface": "per-cell max-Z difference, epoch 2 minus epoch 1, minus the stable-ground plane",
+   "thresholdM": 0.1,
+   "minCells": 4,
+   "maxCells": 200,
+   "minFillFraction": 0.45,
+   "maxBboxAspect": 4,
+   "maxEpoch1ReliefM": 0.6,
+   "maxRingP90AbsDiffM": 0.15
+  },
+  "pointTest": {
+   "annulusInnerM": 0.6,
+   "annulusOuterM": 1.35,
+   "coreRadiusM": 0.55,
+   "heightThresholdM": 0.15,
+   "maxPointsBeforeChange": 10,
+   "minPointsAfterChange": 60,
+   "minPeakHeightM": 0.18,
+   "maxGroundPlaneRmsM": 0.06
+  },
+  "seed": 20230516
+ },
+ "datasets": [
+  {
+   "file": "chassieu_vol1.las",
+   "role": "reference epoch, flight #1",
+   "bytes": 1644256079,
+   "sha256": "beba5d447b1080893466e1566fcf0bd74d9a901569f08ecce936e50094e4391b"
+  },
+  {
+   "file": "chassieu_vol2.las",
+   "role": "second epoch, flight #2, flown after the solids were laid",
+   "bytes": 1628383417,
+   "sha256": "5dbd261fe664724d8f0ab02b3631d28e8dbfdb5c1f1edf51b38f1a6d2f2374bd"
+  },
+  {
+   "file": "Co-UDlabs Lidar data set description VF 2025 04 04.pdf",
+   "role": "dataset description",
+   "bytes": 1134263,
+   "sha256": "9334b72a108390a04f0b20ac15a666f0ab98f2cfccc01ff2c8a74136cdb4d01e"
+  }
+ ],
+ "datasetSource": {
+  "project": "Co-UDlabs (H2020 grant 101008626), WP6 Task 6.1, INSA Lyon",
+  "doi": "10.5281/zenodo.15175591",
+  "licence": "CC BY 4.0",
+  "site": "Django Reinhardt stormwater infiltration tank, Chassieu, Lyon, France",
+  "sensor": "DJI Zenmuse L1 on a drone",
+  "acquired": "16 May 2023",
+  "crs": "EPSG:2154 RGF93 v1 / Lambert-93 + EPSG:5720 NGF-IGN69 height",
+  "producedBy": "DJI TERRA 3.11.13.0"
+ },
+ "runs": [
+  {
+   "runId": "pdf-text",
+   "kind": "document",
+   "reference": "pdftotext",
+   "argv": [
+    "-layout",
+    "DATASET_DIR/Co-UDlabs Lidar data set description VF 2025 04 04.pdf",
+    "OUTPUT_DIR/desc.txt"
+   ],
+   "commandLine": "pdftotext -layout 'DATASET_DIR/Co-UDlabs Lidar data set description VF 2025 04 04.pdf' OUTPUT_DIR/desc.txt",
+   "exitCode": 0,
+   "stderr": "",
+   "status": "ok",
+   "output": "validation/change-pair/table1.json",
+   "note": "The text layer carries the narrative but not Table 1. Table 1 is a raster image on page 7 with no text behind it, so pdftotext returns only its caption. The values in table1.json were read off the rendered page image and are marked as such; no OCR engine was available on this host to corroborate them.",
+   "sha256": "8c2e52a949ca4f2b5913ec2ab678cd35db42c96781c84e2483116649cee1458d"
+  },
+  {
+   "runId": "analysis",
+   "kind": "coregistration-and-change",
+   "reference": "laspy + numpy + scipy",
+   "script": "validation/change-pair/scripts/run-change-pair.py",
+   "argv": [
+    "validation/change-pair/scripts/run-change-pair.py",
+    "DATASET_DIR",
+    "validation/change-pair"
+   ],
+   "commandLine": "python3 validation/change-pair/scripts/run-change-pair.py DATASET_DIR validation/change-pair",
+   "exitCode": 0,
+   "stderr": "",
+   "status": "ok",
+   "outputs": [
+    "validation/change-pair/coregistration.json",
+    "validation/change-pair/detections.json"
+   ],
+   "scriptSha256": "b62bf793708bc341e6d8fa3aa5ca5f49a8947657abb271b0168eca98e569926d",
+   "sha256": {
+    "validation/change-pair/coregistration.json": "4826c90a7c301d33904dee376c1394a8ee27172899b0ef0dfd4483c42f32a17b",
+    "validation/change-pair/detections.json": "78021857359d8421666de3dd8bc79d6c46a448f4013147f04a2c1c001d6608f1"
+   }
+  },
+  {
+   "runId": "pdal-dsm-epoch1",
+   "kind": "cross-check",
+   "reference": "PDAL",
+   "pipeline": "validation/change-pair/pdal/dsm-epoch1.json",
+   "argv": [
+    "pipeline",
+    "OUTPUT_DIR/dsm-epoch1.json"
+   ],
+   "commandLine": "sed -e 's#DATASET_DIR#<dataset dir>#' -e 's#OUTPUT_DIR#<output dir>#' validation/change-pair/pdal/dsm-epoch1.json > OUTPUT_DIR/dsm-epoch1.json && pdal pipeline OUTPUT_DIR/dsm-epoch1.json",
+   "exitCode": 0,
+   "stderr": "",
+   "status": "ok",
+   "pipelineSha256": "d5ab93a5e40321a8ff1bd3b1ada5b5496dc3568fb6aae87932a87334bc650642"
+  },
+  {
+   "runId": "pdal-dsm-epoch2",
+   "kind": "cross-check",
+   "reference": "PDAL",
+   "pipeline": "validation/change-pair/pdal/dsm-epoch2.json",
+   "argv": [
+    "pipeline",
+    "OUTPUT_DIR/dsm-epoch2.json"
+   ],
+   "commandLine": "sed -e 's#DATASET_DIR#<dataset dir>#' -e 's#OUTPUT_DIR#<output dir>#' validation/change-pair/pdal/dsm-epoch2.json > OUTPUT_DIR/dsm-epoch2.json && pdal pipeline OUTPUT_DIR/dsm-epoch2.json",
+   "exitCode": 0,
+   "stderr": "",
+   "status": "ok",
+   "pipelineSha256": "181d5b723dabfece48e6921d543618d4d382bb8a4d5be0222ee7180974683c49"
+  },
+  {
+   "runId": "pdal-dsm-dump",
+   "kind": "cross-check",
+   "reference": "GDAL",
+   "argv": [
+    "-of",
+    "XYZ",
+    "OUTPUT_DIR/dsm-epochN.tif",
+    "OUTPUT_DIR/dsm-epochN.xyz"
+   ],
+   "commandLine": "gdal_translate -of XYZ OUTPUT_DIR/dsm-epochN.tif OUTPUT_DIR/dsm-epochN.xyz  (N = 1, 2)",
+   "exitCode": 0,
+   "stderr": "",
+   "status": "ok",
+   "output": "validation/change-pair/pdal-crosscheck.json",
+   "sha256": "f1224aa623c7732eb318846a2088e3541b93f109ef9a087eb3e348fda06dd848"
+  }
+ ]
+}

--- a/validation/change-pair/scripts/run-change-pair.py
+++ b/validation/change-pair/scripts/run-change-pair.py
@@ -28,7 +28,7 @@ TANK_MAX_Z = 198.0   # epoch-1 min-Z below this is the tank bottom
 OUTSIDE_MIN_Z = 200.5
 FLAT_RANGE = 0.10    # within-cell relief for the stable hard-ground mask
 RELIEF_WINDOW = 5    # 0.5 m, in analysis cells
-SEED = 20230516
+MAX_FIT_CELLS = 250000
 
 
 def bin_epoch(path):
@@ -76,7 +76,6 @@ def robust(v):
 def main():
     ds, outdir = Path(sys.argv[1]), Path(sys.argv[2])
     outdir.mkdir(parents=True, exist_ok=True)
-    rng = np.random.default_rng(SEED)
     e1 = bin_epoch(ds / "chassieu_vol1.las")
     e2 = bin_epoch(ds / "chassieu_vol2.las")
 
@@ -158,7 +157,15 @@ def main():
     aspect = np.arctan2(-gy, gx)
     stable = enough & (z1 >= 199.0) & (h1 <= 0.30) & (h2 <= 0.30) & np.isfinite(slope)
     textured = np.flatnonzero(stable & (slope > np.radians(3)))
-    sel = rng.choice(textured, size=min(250000, textured.size), replace=False)
+    # Deterministic selection. This pair yields fewer textured cells than the
+    # cap, so every one is used; a larger set takes an even stride. The fit
+    # below is order independent, so a permutation of the same set cannot move
+    # the result.
+    sel = (
+        textured
+        if textured.size <= MAX_FIT_CELLS
+        else textured[:: max(1, textured.size // MAX_FIT_CELLS)][:MAX_FIT_CELLS]
+    )
     row = (sel // NX).astype(float)
     col = (sel % NX).astype(float)
     z1s = z1.ravel()[sel]

--- a/validation/change-pair/scripts/run-change-pair.py
+++ b/validation/change-pair/scripts/run-change-pair.py
@@ -73,8 +73,27 @@ def robust(v):
     return med, float(1.4826 * np.median(np.abs(v - med)))
 
 
+def resolved_dir(raw, *, must_exist):
+    """Resolve a command line path before anything reads or writes through it.
+
+    argv reaches the file system in this script. Resolving collapses any
+    parent segments, so the path that is checked is the path that is opened,
+    and a target that is not a directory stops the run instead of being
+    created somewhere unintended.
+    """
+    path = Path(raw).resolve(strict=False)
+    if must_exist and not path.is_dir():
+        raise SystemExit(f"not an existing directory: {path}")
+    if path.exists() and not path.is_dir():
+        raise SystemExit(f"not a directory: {path}")
+    return path
+
+
 def main():
-    ds, outdir = Path(sys.argv[1]), Path(sys.argv[2])
+    if len(sys.argv) < 3:
+        raise SystemExit("usage: run-change-pair.py <dataset-dir> <output-dir>")
+    ds = resolved_dir(sys.argv[1], must_exist=True)
+    outdir = resolved_dir(sys.argv[2], must_exist=False)
     outdir.mkdir(parents=True, exist_ok=True)
     e1 = bin_epoch(ds / "chassieu_vol1.las")
     e2 = bin_epoch(ds / "chassieu_vol2.las")

--- a/validation/change-pair/scripts/run-change-pair.py
+++ b/validation/change-pair/scripts/run-change-pair.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Co-registration and change measurement for the Co-UDlabs Chassieu flight pair.
+
+Reads the two LAS files, builds a common analysis grid, measures the epoch-to-epoch
+alignment on stable ground outside the infiltration tank, then searches the tank
+floor for surfaces that rose between the two flights. Writes the JSON records that
+sit beside this script. Nothing here reads or writes any OpenLiDARViewer code path;
+the point handling is laspy and the statistics are numpy and scipy.
+
+Usage: run-change-pair.py <dataset-dir> <output-dir>
+"""
+import json
+import sys
+from pathlib import Path
+
+import laspy
+import numpy as np
+from scipy import ndimage as ndi
+from scipy.ndimage import map_coordinates
+from scipy.spatial import cKDTree
+
+FINE = 0.05          # first-pass bin, halved again into the analysis cell
+CELL = 0.10          # analysis cell, justified in README.md from measured density
+ORIGIN_X, ORIGIN_Y = 852115.0, 6516819.0
+NX, NY = 2060, 3330  # covers both epoch bounding boxes with a whole-metre origin
+MIN_PTS = 4          # per cell per epoch
+TANK_MAX_Z = 198.0   # epoch-1 min-Z below this is the tank bottom
+OUTSIDE_MIN_Z = 200.5
+FLAT_RANGE = 0.10    # within-cell relief for the stable hard-ground mask
+RELIEF_WINDOW = 5    # 0.5 m, in analysis cells
+SEED = 20230516
+
+
+def bin_epoch(path):
+    """Per-cell min-Z, max-Z, sum-Z, count and a near-nadir min-Z, at CELL."""
+    nxf, nyf = NX * 2, NY * 2
+    minz = np.full(nxf * nyf, np.inf)
+    maxz = np.full(nxf * nyf, -np.inf)
+    cnt = np.zeros(nxf * nyf, dtype=np.int32)
+    sumz = np.zeros(nxf * nyf)
+    with laspy.open(path) as f:
+        for pts in f.chunk_iterator(8_000_000):
+            x, y, z = np.asarray(pts.x), np.asarray(pts.y), np.asarray(pts.z)
+            ix = np.floor((x - ORIGIN_X) / FINE).astype(np.int64)
+            iy = np.floor((y - ORIGIN_Y) / FINE).astype(np.int64)
+            ok = (ix >= 0) & (ix < nxf) & (iy >= 0) & (iy < nyf)
+            idx = iy[ok] * nxf + ix[ok]
+            zz = z[ok]
+            np.minimum.at(minz, idx, zz)
+            np.maximum.at(maxz, idx, zz)
+            np.add.at(cnt, idx, 1)
+            np.add.at(sumz, idx, zz)
+    minz = minz.reshape(nyf, nxf)
+    maxz = maxz.reshape(nyf, nxf)
+    cnt = cnt.reshape(nyf, nxf)
+    sumz = sumz.reshape(nyf, nxf)
+    minz[cnt == 0] = np.nan
+    maxz[cnt == 0] = np.nan
+    r = lambda a: a.reshape(NY, 2, NX, 2)
+    return dict(
+        minz=np.nanmin(r(minz), axis=(1, 3)),
+        maxz=np.nanmax(r(maxz), axis=(1, 3)),
+        cnt=r(cnt).sum(axis=(1, 3)),
+        sumz=r(sumz).sum(axis=(1, 3)),
+        fine_occupied=int((cnt > 0).sum()),
+        points=int(cnt.sum()),
+        fine_cnt=cnt,
+    )
+
+
+def robust(v):
+    med = float(np.median(v))
+    return med, float(1.4826 * np.median(np.abs(v - med)))
+
+
+def main():
+    ds, outdir = Path(sys.argv[1]), Path(sys.argv[2])
+    outdir.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(SEED)
+    e1 = bin_epoch(ds / "chassieu_vol1.las")
+    e2 = bin_epoch(ds / "chassieu_vol2.las")
+
+    z1, z2 = e1["minz"], e2["minz"]
+    m1, m2 = e1["maxz"], e2["maxz"]
+    c1, c2 = e1["cnt"], e2["cnt"]
+    enough = (c1 >= MIN_PTS) & (c2 >= MIN_PTS)
+    tank = enough & (z1 < TANK_MAX_Z)
+    tank_all = z1 < TANK_MAX_Z
+    outside = enough & (z1 >= OUTSIDE_MIN_Z)
+
+    yy, xx = np.mgrid[0:NY, 0:NX]
+    X = ORIGIN_X + (xx + 0.5) * CELL
+    Y = ORIGIN_Y + (yy + 0.5) * CELL
+
+    density = {}
+    for tag, e in (("epoch1", e1), ("epoch2", e2)):
+        area = e["fine_occupied"] * FINE * FINE
+        density[tag] = dict(points=e["points"], coveredAreaM2=round(area, 1),
+                            pointsPerM2=round(e["points"] / area, 1))
+    both = enough
+    density["analysisCell"] = CELL
+    density["cellsBothEpochs"] = int(both.sum())
+    density["medianPointsPerCellEpoch1"] = float(np.median(c1[both]))
+    density["medianPointsPerCellEpoch2"] = float(np.median(c2[both]))
+
+    # Why CELL is what it is: the sample a cell actually holds, at each candidate size.
+    f1, f2 = e1["fine_cnt"], e2["fine_cnt"]
+    table = []
+    for k in (1, 2, 4, 5, 10, 20):
+        size = round(FINE * k, 3)
+        hh, ww = f1.shape[0] // k * k, f1.shape[1] // k * k
+        agg = lambda a: a[:hh, :ww].reshape(hh // k, k, ww // k, k).sum(axis=(1, 3))
+        a1, a2 = agg(f1), agg(f2)
+        pair = (a1 > 0) & (a2 > 0)
+        table.append(dict(
+            cellM=size, cellsBothEpochs=int(pair.sum()),
+            medianPointsPerCellEpoch1=float(np.median(a1[pair])),
+            medianPointsPerCellEpoch2=float(np.median(a2[pair])),
+            fractionWithAtLeast4InBoth=round(float(((a1 >= 4) & (a2 >= 4)).sum() / pair.sum()), 3),
+            fractionWithAtLeast10InBoth=round(float(((a1 >= 10) & (a2 >= 10)).sum() / pair.sum()), 3)))
+    density["cellSizeStudy"] = table
+    del f1, f2, e1["fine_cnt"], e2["fine_cnt"]
+
+    # ---- co-registration, measured on stable ground OUTSIDE the tank ----
+    h1, h2 = m1 - z1, m2 - z2
+    hard = outside & (h1 <= FLAT_RANGE) & (h2 <= FLAT_RANGE)
+    dz_raw = z2 - z1
+    mean1 = e1["sumz"] / np.maximum(c1, 1)
+    mean2 = e2["sumz"] / np.maximum(c2, 1)
+
+    med_min, nmad_min = robust(dz_raw[hard])
+    med_mean, nmad_mean = robust((mean2 - mean1)[hard])
+
+    A = np.c_[np.ones(int(hard.sum())), X[hard] - X.mean(), Y[hard] - Y.mean()]
+    coef, *_ = np.linalg.lstsq(A, dz_raw[hard], rcond=None)
+    resid = dz_raw[hard] - A @ coef
+    _, nmad_plane = robust(resid)
+
+    blk = int(round(25.0 / CELL))
+    key = ((yy // blk) * 10000 + (xx // blk))[hard]
+    vals = dz_raw[hard]
+    block_meds = []
+    for k in np.unique(key):
+        s = key == k
+        if s.sum() >= 200:
+            block_meds.append(float(np.median(vals[s])))
+    block_meds = np.array(block_meds)
+
+    # horizontal shift: NMAD of the difference minimised over sub-cell shifts
+    Zf = np.where(enough, z1, np.nan)
+    msk = np.isfinite(Zf).astype(float)
+    num = ndi.uniform_filter(np.where(np.isfinite(Zf), Zf, 0.0), 3)
+    den = ndi.uniform_filter(msk, 3)
+    filled = np.where(np.isfinite(Zf), Zf,
+                      np.where(den > 0.3, num / np.maximum(den, 1e-9), np.nan))
+    gy, gx = np.gradient(filled, CELL)
+    slope = np.arctan(np.hypot(gx, gy))
+    aspect = np.arctan2(-gy, gx)
+    stable = enough & (z1 >= 199.0) & (h1 <= 0.30) & (h2 <= 0.30) & np.isfinite(slope)
+    textured = np.flatnonzero(stable & (slope > np.radians(3)))
+    sel = rng.choice(textured, size=min(250000, textured.size), replace=False)
+    row = (sel // NX).astype(float)
+    col = (sel % NX).astype(float)
+    z1s = z1.ravel()[sel]
+    Z2 = np.where(enough, z2, np.nan)
+    V = np.nan_to_num(Z2, nan=0.0)
+    M = np.isfinite(Z2).astype(float)
+    shifts = np.arange(-0.15, 0.1501, 0.025)
+    valid = np.ones(sel.size, bool)
+    for dx in shifts:
+        for dy in shifts:
+            valid &= map_coordinates(M, [row + dy / CELL, col + dx / CELL],
+                                     order=1, mode="nearest") > 0.999
+    row, col, z1s = row[valid], col[valid], z1s[valid]
+    surface = {}
+    best = None
+    for dx in shifts:
+        for dy in shifts:
+            v = map_coordinates(V, [row + dy / CELL, col + dx / CELL],
+                                order=1, mode="nearest")
+            _, n = robust(v - z1s)
+            surface[(round(float(dx), 3), round(float(dy), 3))] = n
+            if best is None or n < best[0]:
+                best = (n, float(dx), float(dy))
+
+    def parabolic(axis):
+        ys = [surface[(round(float(v), 3), round(best[2], 3))] if axis == 0
+              else surface[(round(best[1], 3), round(float(v), 3))] for v in shifts]
+        i = int(np.argmin(ys))
+        if 0 < i < len(shifts) - 1:
+            y0, y1, y2 = ys[i - 1], ys[i], ys[i + 1]
+            return float(shifts[i] + (y0 - y2) / (2 * (y0 - 2 * y1 + y2)) * 0.025)
+        return float(shifts[i])
+
+    # Nuth and Kaeaeb, as an estimator that does not share the search above
+    s = stable & (slope > np.radians(5)) & (slope < np.radians(45))
+    dzs, sl, asp = dz_raw[s], slope[s], aspect[s]
+    med0, nmad0 = robust(dzs)
+    keep = np.abs(dzs - med0) < 3 * nmad0
+    dzs, sl, asp = dzs[keep], sl[keep], asp[keep]
+    y = dzs / np.tan(sl)
+    edges = np.linspace(-np.pi, np.pi, 73)
+    bi = np.digitize(asp, edges) - 1
+    binned = np.array([np.median(y[bi == k]) for k in range(72)])
+    centres = (edges[:-1] + edges[1:]) / 2
+    B = np.c_[np.cos(centres), np.sin(centres), np.ones(72)]
+    nk, *_ = np.linalg.lstsq(B, binned, rcond=None)
+    nk_amp = float(np.hypot(nk[0], nk[1]))
+    nk_dir = float(np.degrees(np.arctan2(nk[1], nk[0])))
+
+    coreg = dict(
+        stableGround=dict(
+            definition=("epoch-1 min-Z >= %.1f m, within-cell relief <= %.2f m in both "
+                        "epochs, >= %d points per cell per epoch" %
+                        (OUTSIDE_MIN_Z, FLAT_RANGE, MIN_PTS)),
+            cells=int(hard.sum()), areaM2=round(float(hard.sum()) * CELL * CELL, 1)),
+        verticalOffsetM=dict(
+            minZSurface=dict(median=round(med_min, 4), nmad=round(nmad_min, 4)),
+            meanZSurface=dict(median=round(med_mean, 4), nmad=round(nmad_mean, 4))),
+        tilt=dict(
+            interceptM=round(float(coef[0]), 5),
+            perMetreEast=float("%.6g" % coef[1]),
+            perMetreNorth=float("%.6g" % coef[2]),
+            magnitudeMmPerM=round(float(np.hypot(coef[1], coef[2]) * 1000), 4),
+            acrossEastExtentMm=round(float(coef[1] * 205 * 1000), 2),
+            acrossNorthExtentMm=round(float(coef[2] * 332 * 1000), 2),
+            residualNmadM=round(nmad_plane, 4)),
+        blockMediansM=dict(
+            blockSizeM=25, blocks=int(block_meds.size),
+            min=round(float(block_meds.min()), 4),
+            p10=round(float(np.percentile(block_meds, 10)), 4),
+            median=round(float(np.median(block_meds)), 4),
+            p90=round(float(np.percentile(block_meds, 90)), 4),
+            max=round(float(block_meds.max()), 4)),
+        horizontalShiftM=dict(
+            nmadSearch=dict(sampleCells=int(row.size),
+                            gridBestEast=round(best[1], 4), gridBestNorth=round(best[2], 4),
+                            subCellEast=round(parabolic(0), 4),
+                            subCellNorth=round(parabolic(1), 4),
+                            nmadAtBest=round(float(best[0]), 5),
+                            nmadAtZeroShift=round(float(surface[(0.0, 0.0)]), 5)),
+            nuthKaab=dict(cells=int(dzs.size), amplitudeM=round(nk_amp, 4),
+                          directionDeg=round(nk_dir, 1),
+                          eastM=round(-nk_amp * np.cos(np.radians(nk_dir)), 4),
+                          northM=round(-nk_amp * np.sin(np.radians(nk_dir)), 4))),
+        density=density)
+    (outdir / "coregistration.json").write_text(json.dumps(coreg, indent=1) + "\n")
+
+    # ---- change inside the tank ----
+    plane = coef[0] + coef[1] * (X - X.mean()) + coef[2] * (Y - Y.mean())
+    dD = np.where(enough, m2 - m1 - plane, np.nan)
+    relief1 = (ndi.maximum_filter(np.where(enough, m1, -9e9), size=RELIEF_WINDOW)
+               - ndi.minimum_filter(np.where(enough, z1, 9e9), size=RELIEF_WINDOW))
+    absd = np.abs(np.nan_to_num(dD, nan=0.0))
+
+    exclusions = dict(
+        tankBottomM2=round(float(tank_all.sum()) * CELL * CELL, 1),
+        keptWithEnoughPointsM2=round(float(tank.sum()) * CELL * CELL, 1),
+        droppedSparseOrSingleEpochM2=round(float((tank_all & ~enough).sum()) * CELL * CELL, 1),
+        searchableAtRelief035M2=round(float((tank & (relief1 <= 0.35)).sum()) * CELL * CELL, 1))
+    bands = []
+    for lo, hi in ((0, .15), (.15, .25), (.25, .35), (.35, .5), (.5, 1.), (1., 3.), (3., 99.)):
+        b = tank & (relief1 >= lo) & (relief1 < hi)
+        if b.sum() < 200:
+            continue
+        med, nmad = robust(dD[b])
+        bands.append(dict(reliefLoM=lo, reliefHiM=hi,
+                          areaM2=round(float(b.sum()) * CELL * CELL, 1),
+                          medianM=round(med, 4), nmadM=round(nmad, 4),
+                          fiveNmadM=round(5 * nmad, 3)))
+
+    def candidates(base, sign, thr=0.10, min_cells=4, flat=0.60, ring_max=0.15, fill=0.45):
+        v = sign * dD
+        lab, n = ndi.label((v > thr) & enough & base)
+        sizes = np.bincount(lab.ravel())
+        sizes[0] = 0
+        boxes = ndi.find_objects(lab)
+        found = []
+        for i in range(1, n + 1):
+            sz = sizes[i]
+            if sz < min_cells or sz > 200:
+                continue
+            box = boxes[i - 1]
+            sub = lab[box] == i
+            hh, ww = sub.shape
+            if sz / (hh * ww) < fill or max(hh, ww) / min(hh, ww) > 4:
+                continue
+            if np.nanmax(relief1[box][sub]) > flat:
+                continue
+            r0, c0 = box[0].start, box[1].start
+            a0, a1 = max(0, r0 - 3), min(NY, r0 + hh + 3)
+            b0, b1 = max(0, c0 - 3), min(NX, c0 + ww + 3)
+            ring = np.ones((a1 - a0, b1 - b0), bool)
+            ring[r0 - a0:r0 - a0 + hh, c0 - b0:c0 - b0 + ww] = False
+            ring &= enough[a0:a1, b0:b1]
+            if ring.sum() < 20 or np.percentile(absd[a0:a1, b0:b1][ring], 90) >= ring_max:
+                continue
+            vv = v[box][sub]
+            found.append(dict(cells=int(sz),
+                              E=round(ORIGIN_X + (c0 + ww / 2) * CELL, 3),
+                              N=round(ORIGIN_Y + (r0 + hh / 2) * CELL, 3),
+                              dsmMedianM=round(float(np.median(vv)), 3),
+                              dsmMaxM=round(float(vv.max()), 3)))
+        return found
+
+    groups = [("tank-rise", tank, +1), ("tank-fall", tank, -1),
+              ("outside-rise", outside, +1), ("outside-fall", outside, -1)]
+    cand = []
+    for name, base, sign in groups:
+        for r in candidates(base, sign):
+            r["group"] = name
+            cand.append(r)
+
+    # ---- point-level test on every candidate ----
+    P = np.array([[r["E"], r["N"]] for r in cand])
+    tree = cKDTree(P)
+    buckets = {1: [[] for _ in cand], 2: [[] for _ in cand]}
+    for epoch, name in ((1, "chassieu_vol1.las"), (2, "chassieu_vol2.las")):
+        with laspy.open(ds / name) as f:
+            for pts in f.chunk_iterator(6_000_000):
+                x, y, z = np.asarray(pts.x), np.asarray(pts.y), np.asarray(pts.z)
+                dist, idx = tree.query(np.c_[x, y], distance_upper_bound=1.4, workers=-1)
+                ok = np.isfinite(dist)
+                xi, yi, zi, ii = x[ok], y[ok], z[ok], idx[ok]
+                order = np.argsort(ii, kind="stable")
+                xi, yi, zi, ii = xi[order], yi[order], zi[order], ii[order]
+                edge = np.searchsorted(ii, np.arange(len(cand) + 1))
+                for k in range(len(cand)):
+                    a, b = edge[k], edge[k + 1]
+                    if b > a:
+                        buckets[epoch][k].append(np.c_[xi[a:b], yi[a:b], zi[a:b]])
+
+    def ground_plane(a, e, n):
+        x, y, z = a[:, 0] - e, a[:, 1] - n, a[:, 2]
+        r = np.hypot(x, y)
+        ring = (r > 0.60) & (r < 1.35)
+        if ring.sum() < 300:
+            return None
+        A_ = np.c_[np.ones(int(ring.sum())), x[ring], y[ring]]
+        b_ = z[ring]
+        co, *_ = np.linalg.lstsq(A_, b_, rcond=None)
+        for _ in range(5):
+            res = b_ - A_ @ co
+            keep_ = res < np.percentile(res, 60)
+            co, *_ = np.linalg.lstsq(A_[keep_], b_[keep_], rcond=None)
+        res = b_ - A_ @ co
+        return co, float(np.std(res[np.abs(res) < 0.15]))
+
+    verified, confirmed = [], []
+    for k, r in enumerate(cand):
+        a1 = np.vstack(buckets[1][k]) if buckets[1][k] else np.zeros((0, 3))
+        a2 = np.vstack(buckets[2][k]) if buckets[2][k] else np.zeros((0, 3))
+        if len(a1) < 800 or len(a2) < 800:
+            continue
+        g1 = ground_plane(a1, r["E"], r["N"])
+        g2 = ground_plane(a2, r["E"], r["N"])
+        if g1 is None or g2 is None:
+            continue
+        (co1, rms1), (co2, rms2) = g1, g2
+        def heights(a, co):
+            x, y = a[:, 0] - r["E"], a[:, 1] - r["N"]
+            return a[:, 2] - (co[0] + co[1] * x + co[2] * y), np.hypot(x, y)
+        h1p, r1p = heights(a1, co1)
+        h2p, r2p = heights(a2, co2)
+        core1, core2 = r1p < 0.55, r2p < 0.55
+        rec = dict(group=r["group"], E=r["E"], N=r["N"], cells=r["cells"],
+                   groundRmsEpoch1M=round(rms1, 3), groundRmsEpoch2M=round(rms2, 3),
+                   pointsAbove015Epoch1=int((h1p[core1] > 0.15).sum()),
+                   pointsAbove015Epoch2=int((h2p[core2] > 0.15).sum()),
+                   maxHeightEpoch1M=round(float(h1p[core1].max()), 3),
+                   maxHeightEpoch2M=round(float(h2p[core2].max()), 3))
+        verified.append(rec)
+        sign = +1 if r["group"].endswith("rise") else -1
+        before, after = ((rec["pointsAbove015Epoch1"], rec["pointsAbove015Epoch2"]) if sign > 0
+                         else (rec["pointsAbove015Epoch2"], rec["pointsAbove015Epoch1"]))
+        peak = rec["maxHeightEpoch2M"] if sign > 0 else rec["maxHeightEpoch1M"]
+        if before <= 10 and after >= 60 and peak >= 0.18 and max(rms1, rms2) <= 0.06:
+            # footprint and volume, both epochs referred to the SAME epoch-1 plane
+            gx_, gy_ = a2[:, 0] - r["E"], a2[:, 1] - r["N"]
+            h2c = a2[:, 2] - (co1[0] + co1[1] * gx_ + co1[2] * gy_)
+            hx_, hy_ = a1[:, 0] - r["E"], a1[:, 1] - r["N"]
+            h1c = a1[:, 2] - (co1[0] + co1[1] * hx_ + co1[2] * hy_)
+            G, ext = 0.05, 0.8
+            NB = int(2 * ext / G)
+            def top(hx, hy, hz):
+                ix = np.floor((hx + ext) / G).astype(int)
+                iy = np.floor((hy + ext) / G).astype(int)
+                ok = (ix >= 0) & (ix < NB) & (iy >= 0) & (iy < NB)
+                out_ = np.full(NB * NB, -9.0)
+                np.maximum.at(out_, iy[ok] * NB + ix[ok], hz[ok])
+                return out_.reshape(NB, NB)
+            t2, t1 = top(gx_, gy_, h2c), top(hx_, hy_, h1c)
+            obj = (t2 > 0.10) & (t1 <= 0.08) & (t1 > -8)
+            lb, nn = ndi.label(obj)
+            if nn:
+                cs = np.bincount(lb.ravel())
+                cs[0] = 0
+                obj = lb == int(np.argmax(cs))
+            ys_, xs_ = np.nonzero(obj)
+            rec = dict(rec)
+            # A footprint is only meaningful for a surface that rose. A candidate in
+            # the falling direction is kept in the record with nulls, because its
+            # count is the false-positive measure and must not be quietly dropped.
+            if sign > 0 and obj.sum():
+                rec["footprintM2"] = round(float(obj.sum()) * G * G, 3)
+                rec["bboxM"] = [round(float((xs_.max() - xs_.min() + 1) * G), 2),
+                                round(float((ys_.max() - ys_.min() + 1) * G), 2)]
+                rec["volumeM3"] = round(float(np.sum(np.clip(t2[obj], 0, None)
+                                                     - np.clip(t1[obj], 0, None)) * G * G), 4)
+            else:
+                rec["footprintM2"] = None
+                rec["bboxM"] = None
+                rec["volumeM3"] = None
+            confirmed.append(rec)
+
+    counts = {}
+    for name, _, _ in groups:
+        counts[name] = dict(
+            candidates=sum(1 for r in cand if r["group"] == name),
+            pointVerified=sum(1 for r in verified if r["group"] == name),
+            passing=sum(1 for r in confirmed if r["group"] == name))
+    (outdir / "detections.json").write_text(json.dumps(dict(
+        exclusions=exclusions, noiseByEpoch1Relief=bands, counts=counts,
+        confirmed=confirmed), indent=1) + "\n")
+    print(json.dumps(dict(coregistration=coreg, exclusions=exclusions,
+                          counts=counts, confirmed=confirmed), indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/change-pair/table1.json
+++ b/validation/change-pair/table1.json
@@ -1,0 +1,53 @@
+{
+ "source": "Co-UDlabs Lidar data set description VF 2025 04 04.pdf, page 7, Table 1",
+ "provenance": "read-from-rendered-page-image",
+ "provenanceNote": [
+  "Table 1 is a raster image inside the PDF. pdftotext -layout returns the caption and nothing else, so the",
+  "cell values are not machine-extractable from this file. The values below were read off the rendered page",
+  "and have not been corroborated by an OCR engine, because none was installed on this host. Treat them as a",
+  "careful transcription, not as extracted data.",
+  "The document states no coordinates and no placement map. It says only that the solids were laid 'at various",
+  "locations on the bottom of the tank, sometimes in an easily visible position, sometimes partly hidden by or",
+  "under the vegetation'. Nothing in this dataset identifies where any individual item went."
+ ],
+ "columns": ["solid", "widthCm", "lengthCm", "heightCm", "diameterCm", "quantity", "comment"],
+ "rows": [
+  ["Iron cage", 24, 34.5, 23, null, 3, null],
+  ["Jerrican", 17, 30, 24, null, 1, null],
+  ["Brick", 10, 22, 5, null, 4, null],
+  ["Brick block", 20, 48.5, 19, null, 4, null],
+  ["Fine grid", 123, 76, null, 4, 1, "4 cm * 4 cm mesh"],
+  ["Wide grid", 90, 60, null, 5, 1, "3.5 cm * 3.5 cm mesh"],
+  ["PVC pipe", null, 106, null, 10, 1, null],
+  ["MF drain", null, 199, null, 10, 1, null],
+  ["MM drain", null, 198, null, 10, 1, null],
+  ["Construction cone", 28, 28, 50, 4.9, 4, null],
+  ["Wooden plank", 70, 60, 1, null, 1, null],
+  ["Tennis ball", null, null, null, 6, 2, null],
+  ["Plastic balls", null, null, null, 6, 20, null],
+  ["Ecocup", null, null, 11.5, "5.2 to 7", 1, null],
+  ["Concrete test tube", null, null, 19.6, 11, 2, null],
+  ["Plexiglas lid", null, null, 1, 30, 1, "transparent"],
+  ["Jar 1", null, null, 19.5, 21, 1, null],
+  ["Jar 2", null, null, 19.5, 21, 1, null],
+  ["Jar 3", null, null, 15.5, 17.5, 1, null],
+  ["Jar 4", null, null, 15.5, 17.5, 1, null],
+  ["Bag of sand", null, null, null, null, 5, "25 kg"],
+  ["Bucket of soil", null, null, null, null, 5, null]
+ ],
+ "derived": {
+  "itemTypes": 22,
+  "individualItems": 62,
+  "itemsWithNoStatedDimensions": 10,
+  "itemsWithNoStatedDimensionsNote": "the 5 bags of sand and the 5 buckets of soil carry a mass or nothing at all",
+  "itemsWithStatedHeightAtLeast15Cm": 18,
+  "itemsWithStatedHeightAtLeast15CmBreakdown": {
+   "Iron cage 23 cm": 3, "Jerrican 24 cm": 1, "Brick block 19 cm": 4,
+   "Construction cone 50 cm": 4, "Concrete test tube 19.6 cm": 2,
+   "Jar 1 19.5 cm": 1, "Jar 2 19.5 cm": 1, "Jar 3 15.5 cm": 1, "Jar 4 15.5 cm": 1
+  },
+  "tallestStatedItemCm": 50,
+  "flatItems": "wooden plank 1 cm, Plexiglas lid 1 cm, and the two grids, which are open mesh",
+  "openMeshItems": "iron cage, fine grid, wide grid: a lidar pulse passes through the openings"
+ }
+}


### PR DESCRIPTION
Two flights over one tank 34 minutes apart, the second after solids were laid on the floor.

On 231,839 stable-ground cells outside the tank the vertical offset is 0.019 m with NMAD 0.033 m, tilt 0.250 mm/m, and horizontal displacement sub-cell (Nuth and Kaab 0.0093 m). The pair is co-registered, which the shoreline pair is not.

The change measurement is a negative result. Of 62 placed items, 18 clear the threshold and 3 were recovered, totalling 0.069 m3, against 1 physically impossible in-tank fall at the same settings. Only 40.3 percent of the floor is searchable, so a tank-wide volume is not defensible.

Table 1 is a raster image, so its dimensions are a visual transcription.
