### PR TITLE
Decode PNTS colours and normals

### DIFF
--- a/src/io/tiles3d/pnts.ts
+++ b/src/io/tiles3d/pnts.ts
@@ -3,17 +3,26 @@
  *
  * A PNTS tile is a 28-byte header, a feature-table JSON + binary, and a
  * batch-table JSON + binary. This reads the header, the feature table's
- * POINTS_LENGTH and optional RTC_CENTER, and the uncompressed float32 POSITION
- * array. It refuses the encodings this subset does not handle — quantised
- * positions, Draco compression — with a clear error rather than mis-decoding.
+ * POINTS_LENGTH and optional RTC_CENTER, and the positions: uncompressed
+ * float32 POSITION, or uint16 POSITION_QUANTIZED against its quantised volume.
+ * It refuses the encodings this subset does not handle — Draco compression,
+ * colours, normals, batch ids — with a clear error rather than mis-decoding.
  * Positions are tile-local; a caller adds RTC_CENTER (and the tile transform) to
  * place them. Pure: takes an ArrayBuffer, returns typed arrays.
+ *
+ * The tile's own declared byteLength is the parse boundary, never the buffer's.
+ * A tile arrives inside whatever the transport handed over, so a section that
+ * is allowed to run to the end of the buffer reads bytes that belong to another
+ * tile, or to no tile at all.
  */
 
 const HEADER_BYTES = 28;
 const MAGIC = 0x73746e70; // 'pnts' little-endian
 /** The only PNTS version this decoder claims to read. */
 const SUPPORTED_VERSION = 1;
+const UINT32_MAX = 0xffffffff;
+/** The divisor the point-cloud format specifies for a quantised component. */
+const QUANTIZED_FULL_SCALE = 65535;
 
 export interface PntsTile {
   readonly version: number;
@@ -24,19 +33,100 @@ export interface PntsTile {
   readonly positions: Float32Array;
 }
 
-interface FeatureTableJson {
-  POINTS_LENGTH?: number;
-  RTC_CENTER?: unknown;
-  POSITION?: { byteOffset?: number };
-  POSITION_QUANTIZED?: unknown;
+type JsonObject = Record<string, unknown>;
+
+/** Decode one JSON section: UTF-8 text holding a single object. */
+function decodeJsonSection(
+  buffer: ArrayBuffer,
+  start: number,
+  length: number,
+  label: string,
+): JsonObject {
+  let text: string;
+  try {
+    // `fatal` so an ill-formed byte sequence is refused rather than replaced
+    // with U+FFFD, which would turn a corrupt tile into a JSON syntax error
+    // that names the wrong problem.
+    text = new TextDecoder('utf-8', { fatal: true }).decode(new Uint8Array(buffer, start, length));
+  } catch {
+    throw new Error(`PNTS: ${label} JSON is not valid UTF-8.`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error(`PNTS: ${label} JSON does not parse.`);
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`PNTS: ${label} JSON is not an object.`);
+  }
+  return parsed as JsonObject;
 }
 
-/** Decode a PNTS tile's header, feature table, and uncompressed positions. */
+/**
+ * Read a feature-table accessor's byteOffset. A byteOffset is an index into the
+ * feature-table binary, so it is a non-negative whole number. Fractional or
+ * negative values reach DataView construction and fail there, far from the tile
+ * that carried them.
+ */
+function accessorByteOffset(descriptor: unknown, name: string): number {
+  if (typeof descriptor !== 'object' || descriptor === null || Array.isArray(descriptor)) {
+    throw new Error(`PNTS: ${name} is not a feature-table accessor object.`);
+  }
+  const byteOffset = (descriptor as { byteOffset?: unknown }).byteOffset;
+  if (typeof byteOffset !== 'number' || !Number.isSafeInteger(byteOffset) || byteOffset < 0) {
+    throw new Error(`PNTS: ${name}.byteOffset is not a non-negative whole number.`);
+  }
+  return byteOffset;
+}
+
+/** Read a 3-component vector of real numbers from the feature-table JSON. */
+function vec3(value: unknown, name: string): [number, number, number] {
+  if (!Array.isArray(value) || value.length !== 3) {
+    throw new Error(`PNTS: ${name} must have 3 components.`);
+  }
+  // JSON writes NaN and Infinity as null, so a component is checked for being a
+  // number as well as for being finite.
+  if (!value.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+    throw new Error(`PNTS: ${name} has a component that is not a finite number.`);
+  }
+  return [value[0] as number, value[1] as number, value[2] as number];
+}
+
+/**
+ * Resolve an array's absolute start in the buffer, having checked it lies
+ * wholly inside the feature-table binary section.
+ */
+function arrayStart(
+  name: string,
+  byteOffset: number,
+  components: number,
+  bytesPerComponent: number,
+  binStart: number,
+  binLength: number,
+): number {
+  const need = components * bytesPerComponent;
+  const start = binStart + byteOffset;
+  const end = start + need;
+  // Guard the arithmetic before it is compared. POINTS_LENGTH is a uint32 and
+  // byteOffset only a safe integer, so `end` is the term that can leave the
+  // exactly-representable range, and a range check on an approximation decides
+  // nothing.
+  if (!Number.isSafeInteger(need) || !Number.isSafeInteger(end)) {
+    throw new Error(`PNTS: ${name} spans a byte range too large to address exactly.`);
+  }
+  if (end > binStart + binLength) {
+    throw new Error(`PNTS: ${name} extends past the feature-table binary section.`);
+  }
+  return start;
+}
+
+/** Decode a PNTS tile's header, feature table, and positions. */
 export function parsePnts(buffer: ArrayBuffer): PntsTile {
-  const view = new DataView(buffer);
   if (buffer.byteLength < HEADER_BYTES) {
     throw new Error('PNTS: buffer shorter than the 28-byte header.');
   }
+  const view = new DataView(buffer);
   if (view.getUint32(0, true) !== MAGIC) {
     throw new Error('PNTS: bad magic — not a pnts tile.');
   }
@@ -45,79 +135,101 @@ export function parsePnts(buffer: ArrayBuffer): PntsTile {
     throw new Error(`PNTS: version ${version} is not supported, only ${SUPPORTED_VERSION}.`);
   }
   const byteLength = view.getUint32(8, true);
-  if (byteLength > buffer.byteLength) {
-    throw new Error('PNTS: declared byteLength exceeds the buffer.');
-  }
   if (byteLength < HEADER_BYTES) {
     throw new Error('PNTS: declared byteLength is shorter than the header.');
   }
-  // The DECLARED tile length is the parse boundary, not the buffer. A tile
-  // concatenated with trailing bytes would otherwise let a feature table or a
-  // POSITION range run past its own tile and read whatever followed it.
-  const limit = byteLength;
-  const ftJsonLen = view.getUint32(12, true);
-  const ftBinLen = view.getUint32(16, true);
-
-  const ftJsonStart = HEADER_BYTES;
-  const ftBinStart = ftJsonStart + ftJsonLen;
-  if (ftBinStart + ftBinLen > limit) {
-    throw new Error('PNTS: feature table extends past the declared tile length.');
+  if (byteLength > buffer.byteLength) {
+    throw new Error('PNTS: declared byteLength exceeds the buffer.');
   }
 
-  const ftJsonText = new TextDecoder().decode(new Uint8Array(buffer, ftJsonStart, ftJsonLen));
-  const ft = JSON.parse(ftJsonText) as FeatureTableJson;
+  const ftJsonLength = view.getUint32(12, true);
+  const ftBinLength = view.getUint32(16, true);
+  const btJsonLength = view.getUint32(20, true);
+  const btBinLength = view.getUint32(24, true);
+  // Four uint32 lengths plus the header sum to at most about 1.7e10, exact in a
+  // double, so this total cannot be rounded into agreement.
+  const sectioned = HEADER_BYTES + ftJsonLength + ftBinLength + btJsonLength + btBinLength;
+  if (sectioned > byteLength) {
+    throw new Error('PNTS: section lengths overrun the declared byteLength.');
+  }
+  if (sectioned < byteLength) {
+    throw new Error('PNTS: declared byteLength leaves bytes past the last section.');
+  }
+  // The sections now sum exactly to a declared length that fits the buffer, so
+  // every section start and end is in range by construction, and any byte past
+  // the declared length belongs to whatever followed this tile.
+  const ftJsonStart = HEADER_BYTES;
+  const ftBinStart = ftJsonStart + ftJsonLength;
+  const btJsonStart = ftBinStart + ftBinLength;
+
+  const ft = decodeJsonSection(buffer, ftJsonStart, ftJsonLength, 'feature table');
+  // The batch table is read for well-formedness only; its properties belong to
+  // a caller this decoder does not have yet.
+  if (btJsonLength > 0) decodeJsonSection(buffer, btJsonStart, btJsonLength, 'batch table');
 
   const pointsLength = ft.POINTS_LENGTH;
-  if (typeof pointsLength !== 'number' || !Number.isInteger(pointsLength) || pointsLength < 0) {
-    throw new Error('PNTS: feature table has no valid POINTS_LENGTH.');
-  }
-  if (ft.POSITION_QUANTIZED !== undefined) {
-    throw new Error('PNTS: POSITION_QUANTIZED is not supported yet — only float32 POSITION.');
-  }
-  if (!ft.POSITION || typeof ft.POSITION.byteOffset !== 'number') {
-    throw new Error('PNTS: feature table has no float32 POSITION.');
-  }
-  // A byteOffset is an index into the feature-table binary, so it is a
-  // non-negative whole number. Fractional or negative values reach DataView
-  // construction and fail there, far from the tile that carried them.
-  if (!Number.isSafeInteger(ft.POSITION.byteOffset) || ft.POSITION.byteOffset < 0) {
-    throw new Error('PNTS: POSITION.byteOffset is not a non-negative whole number.');
+  if (
+    typeof pointsLength !== 'number' ||
+    !Number.isInteger(pointsLength) ||
+    pointsLength <= 0 ||
+    pointsLength > UINT32_MAX
+  ) {
+    throw new Error('PNTS: POINTS_LENGTH is not a positive uint32.');
   }
 
   // RTC_CENTER is optional, but a present one cannot be dropped when it is
   // malformed. POSITION holds tile-local coordinates, so a tile that keeps its
   // positions and loses its center renders at the local origin, which for a
   // georeferenced tile is a silent relocation rather than a missing offset.
-  // JSON writes NaN and Infinity as null, so a component is checked for being
-  // a number as well as for being finite.
-  const rtc: unknown = ft.RTC_CENTER;
-  let rtcCenter: [number, number, number] | null = null;
-  if (rtc !== undefined) {
-    if (!Array.isArray(rtc) || rtc.length !== 3) {
-      throw new Error('PNTS: RTC_CENTER must have 3 components.');
-    }
-    if (!rtc.every((n) => typeof n === 'number' && Number.isFinite(n))) {
-      throw new Error('PNTS: RTC_CENTER has a component that is not a finite number.');
-    }
-    rtcCenter = [rtc[0] as number, rtc[1] as number, rtc[2] as number];
+  const rtcCenter = ft.RTC_CENTER === undefined ? null : vec3(ft.RTC_CENTER, 'RTC_CENTER');
+
+  const components = pointsLength * 3;
+
+  // A tile carrying both encodings is decoded from POSITION: the format gives
+  // the uncompressed array precedence over the quantised one.
+  if (ft.POSITION !== undefined) {
+    const byteOffset = accessorByteOffset(ft.POSITION, 'POSITION');
+    const start = arrayStart('POSITION', byteOffset, components, 4, ftBinStart, ftBinLength);
+    // Copy rather than view: POSITION.byteOffset need not be 4-aligned within
+    // the buffer, and a Float32Array view requires alignment. Allocating after
+    // the range check keeps a tile that declares four billion points from
+    // reserving the memory before it is refused.
+    const positions = new Float32Array(components);
+    for (let i = 0; i < components; i++) positions[i] = view.getFloat32(start + i * 4, true);
+    return { version, pointsLength, rtcCenter, positions };
   }
 
-  const posOffset = ftBinStart + ft.POSITION.byteOffset;
-  const need = pointsLength * 3 * 4;
-  // Guard the product itself: a POINTS_LENGTH near the safe-integer ceiling
-  // makes `need` lose precision, and the range check below would then compare
-  // an approximation.
-  if (!Number.isSafeInteger(need)) {
-    throw new Error(`PNTS: POINTS_LENGTH ${pointsLength} is too large to address.`);
+  if (ft.POSITION_QUANTIZED !== undefined) {
+    const byteOffset = accessorByteOffset(ft.POSITION_QUANTIZED, 'POSITION_QUANTIZED');
+    // The volume is what makes the uint16 codes mean anything. Without it the
+    // codes are not coordinates at all, so neither member is defaultable.
+    if (ft.QUANTIZED_VOLUME_OFFSET === undefined) {
+      throw new Error('PNTS: POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET.');
+    }
+    if (ft.QUANTIZED_VOLUME_SCALE === undefined) {
+      throw new Error('PNTS: POSITION_QUANTIZED requires QUANTIZED_VOLUME_SCALE.');
+    }
+    const volumeOffset = vec3(ft.QUANTIZED_VOLUME_OFFSET, 'QUANTIZED_VOLUME_OFFSET');
+    const volumeScale = vec3(ft.QUANTIZED_VOLUME_SCALE, 'QUANTIZED_VOLUME_SCALE');
+    const start = arrayStart(
+      'POSITION_QUANTIZED',
+      byteOffset,
+      components,
+      2,
+      ftBinStart,
+      ftBinLength,
+    );
+    const positions = new Float32Array(components);
+    for (let i = 0; i < components; i++) {
+      const axis = i % 3;
+      const code = view.getUint16(start + i * 2, true);
+      // Float64 the whole way, narrowed once on the store. A quantised volume
+      // can sit far from the origin, so rounding the scaled code before the
+      // offset is added rounds twice and loses a step the format still carries.
+      positions[i] = (code * volumeScale[axis]) / QUANTIZED_FULL_SCALE + volumeOffset[axis];
+    }
+    return { version, pointsLength, rtcCenter, positions };
   }
-  if (posOffset + need > limit) {
-    throw new Error('PNTS: POSITION array extends past the declared tile length.');
-  }
-  // Copy (POSITION.byteOffset need not be 4-aligned within the buffer, and a
-  // Float32Array view requires alignment).
-  const positions = new Float32Array(pointsLength * 3);
-  const src = new DataView(buffer, posOffset, need);
-  for (let i = 0; i < positions.length; i++) positions[i] = src.getFloat32(i * 4, true);
 
-  return { version, pointsLength, rtcCenter, positions };
+  throw new Error('PNTS: feature table has neither POSITION nor POSITION_QUANTIZED.');
 }

--- a/src/io/tiles3d/pnts.ts
+++ b/src/io/tiles3d/pnts.ts
@@ -3,12 +3,20 @@
  *
  * A PNTS tile is a 28-byte header, a feature-table JSON + binary, and a
  * batch-table JSON + binary. This reads the header, the feature table's
- * POINTS_LENGTH and optional RTC_CENTER, and the positions: uncompressed
- * float32 POSITION, or uint16 POSITION_QUANTIZED against its quantised volume.
- * It refuses the encodings this subset does not handle — Draco compression,
- * colours, normals, batch ids — with a clear error rather than mis-decoding.
- * Positions are tile-local; a caller adds RTC_CENTER (and the tile transform) to
- * place them. Pure: takes an ArrayBuffer, returns typed arrays.
+ * POINTS_LENGTH and optional RTC_CENTER, the positions (uncompressed float32
+ * POSITION, or uint16 POSITION_QUANTIZED against its quantised volume), the
+ * colours (RGBA, RGB, RGB565, CONSTANT_RGBA) and the normals (float32 NORMAL or
+ * oct-encoded NORMAL_OCT16P). It refuses the encodings this subset does not
+ * handle — Draco compression, batch ids — with a clear error rather than
+ * mis-decoding. Positions are tile-local; a caller adds RTC_CENTER (and the tile
+ * transform) to place them. Pure: takes an ArrayBuffer, returns typed arrays.
+ *
+ * Colour leaves here as sRGB-encoded bytes, three channels per point, which is
+ * what `PointCloud.colors` holds and what every other loader in this viewer
+ * produces; the one sRGB-to-linear conversion lives at the render upload seam
+ * (src/render/colorEncode.ts) and is not this decoder's to apply. PNTS colour
+ * channels are already 8-bit, so none of the 16-bit narrowing the LAS path does
+ * applies here.
  *
  * The tile's own declared byteLength is the parse boundary, never the buffer's.
  * A tile arrives inside whatever the transport handed over, so a section that
@@ -23,6 +31,14 @@ const SUPPORTED_VERSION = 1;
 const UINT32_MAX = 0xffffffff;
 /** The divisor the point-cloud format specifies for a quantised component. */
 const QUANTIZED_FULL_SCALE = 65535;
+/** The widest value one colour channel can carry once decoded. */
+const UINT8_MAX = 255;
+/** Widest value of the 5-bit red and blue fields of an RGB565 word. */
+const RGB565_5BIT_MAX = 31;
+/** Widest value of the 6-bit green field of an RGB565 word. */
+const RGB565_6BIT_MAX = 63;
+/** The widest value one oct16p component can carry before it is decoded. */
+const OCT16P_MAX = 255;
 
 export interface PntsTile {
   readonly version: number;
@@ -31,6 +47,16 @@ export interface PntsTile {
   readonly rtcCenter: readonly [number, number, number] | null;
   /** Tile-local xyz, length `pointsLength * 3`. */
   readonly positions: Float32Array;
+  /**
+   * Interleaved sRGB rgb bytes, length `pointsLength * 3`, or null when the
+   * tile carries no colour at all.
+   */
+  readonly colors: Uint8Array | null;
+  /**
+   * Interleaved unit xyz normals, length `pointsLength * 3`, or null when the
+   * tile carries no normals.
+   */
+  readonly normals: Float32Array | null;
 }
 
 type JsonObject = Record<string, unknown>;
@@ -121,7 +147,190 @@ function arrayStart(
   return start;
 }
 
-/** Decode a PNTS tile's header, feature table, and positions. */
+/**
+ * Rescale one packed colour field to the full 0-255 range. A field of `max`
+ * carries a fraction of full brightness, so the widest value it can hold has to
+ * arrive as 255. Shifting the field up to the top of the byte instead leaves
+ * the low bits clear and caps the channel at 248 (5-bit) or 252 (6-bit), so a
+ * tile that wrote white gets back an off-white it never stored, and the error
+ * grows with brightness rather than staying at the quantisation step.
+ */
+function expandColorField(value: number, max: number): number {
+  return Math.round((value * UINT8_MAX) / max);
+}
+
+/** Write one rgb triple into an interleaved colour buffer. */
+function setRgb(colors: Uint8Array, point: number, r: number, g: number, b: number): void {
+  const at = point * 3;
+  colors[at] = r;
+  colors[at + 1] = g;
+  colors[at + 2] = b;
+}
+
+/**
+ * Read CONSTANT_RGBA, which lives in the feature-table JSON rather than the
+ * binary: four bytes that colour every point of the tile the same.
+ */
+function constantRgba(value: unknown): [number, number, number, number] {
+  if (!Array.isArray(value) || value.length !== 4) {
+    throw new Error('PNTS: CONSTANT_RGBA must have 4 components.');
+  }
+  // JSON writes NaN and Infinity as null, so a component is checked for being a
+  // number as well as for being a byte.
+  const isByte = (n: unknown) =>
+    typeof n === 'number' && Number.isInteger(n) && n >= 0 && n <= UINT8_MAX;
+  if (!value.every(isByte)) {
+    throw new Error('PNTS: CONSTANT_RGBA has a component that is not a whole number in 0-255.');
+  }
+  return [value[0] as number, value[1] as number, value[2] as number, value[3] as number];
+}
+
+/**
+ * Decode whichever colour encoding the tile carries, as sRGB rgb bytes.
+ *
+ * The format ranks the encodings — RGBA, then RGB, then RGB565, then
+ * CONSTANT_RGBA — and a tile may legally carry more than one. The ranking is
+ * resolved before anything is read, so a tile with both RGBA and RGB565 is
+ * coloured from RGBA whatever the RGB565 array holds. A defect in the chosen
+ * encoding is refused: falling through to the next-ranked one would answer a
+ * corrupt tile with colours that are not the ones it asked for.
+ *
+ * The alpha byte of RGBA and CONSTANT_RGBA is validated and then dropped. The
+ * viewer's colour buffer is three channels wide, so there is nowhere to carry
+ * it; a caller that needs opacity needs a wider buffer first.
+ */
+function decodeColors(
+  ft: JsonObject,
+  view: DataView,
+  pointsLength: number,
+  binStart: number,
+  binLength: number,
+): Uint8Array | null {
+  if (ft.RGBA !== undefined) {
+    const byteOffset = accessorByteOffset(ft.RGBA, 'RGBA');
+    const start = arrayStart('RGBA', byteOffset, pointsLength * 4, 1, binStart, binLength);
+    const colors = new Uint8Array(pointsLength * 3);
+    for (let i = 0; i < pointsLength; i++) {
+      const at = start + i * 4;
+      setRgb(colors, i, view.getUint8(at), view.getUint8(at + 1), view.getUint8(at + 2));
+    }
+    return colors;
+  }
+
+  if (ft.RGB !== undefined) {
+    const byteOffset = accessorByteOffset(ft.RGB, 'RGB');
+    const start = arrayStart('RGB', byteOffset, pointsLength * 3, 1, binStart, binLength);
+    const colors = new Uint8Array(pointsLength * 3);
+    for (let i = 0; i < pointsLength; i++) {
+      const at = start + i * 3;
+      setRgb(colors, i, view.getUint8(at), view.getUint8(at + 1), view.getUint8(at + 2));
+    }
+    return colors;
+  }
+
+  if (ft.RGB565 !== undefined) {
+    const byteOffset = accessorByteOffset(ft.RGB565, 'RGB565');
+    const start = arrayStart('RGB565', byteOffset, pointsLength, 2, binStart, binLength);
+    const colors = new Uint8Array(pointsLength * 3);
+    for (let i = 0; i < pointsLength; i++) {
+      // Read through the DataView rather than a Uint16Array view: byteOffset
+      // need not be 2-aligned within the buffer, and the word is little-endian
+      // whatever the host is. Red occupies the top 5 bits, green the middle 6,
+      // blue the bottom 5.
+      const packed = view.getUint16(start + i * 2, true);
+      setRgb(
+        colors,
+        i,
+        expandColorField((packed >> 11) & 0x1f, RGB565_5BIT_MAX),
+        expandColorField((packed >> 5) & 0x3f, RGB565_6BIT_MAX),
+        expandColorField(packed & 0x1f, RGB565_5BIT_MAX),
+      );
+    }
+    return colors;
+  }
+
+  if (ft.CONSTANT_RGBA !== undefined) {
+    const [r, g, b] = constantRgba(ft.CONSTANT_RGBA);
+    const colors = new Uint8Array(pointsLength * 3);
+    for (let i = 0; i < pointsLength; i++) setRgb(colors, i, r, g, b);
+    return colors;
+  }
+
+  return null;
+}
+
+/** The sign of a component, counting zero as positive, as oct encoding does. */
+function signNotZero(value: number): number {
+  return value < 0 ? -1 : 1;
+}
+
+/**
+ * Decode one oct16p pair into a unit normal.
+ *
+ * Oct encoding projects the unit sphere onto the octahedron |x| + |y| + |z| = 1
+ * and stores the two coordinates of that projection, folding the lower
+ * hemisphere outwards into the corners of the square. Decoding undoes the fold
+ * and then normalises: the point recovered on the octahedron is a direction but
+ * not a unit vector, and the two bytes rarely name a point that was on the
+ * sphere to begin with, so an unnormalised result is a normal whose length
+ * varies with direction by up to a factor of the square root of 3.
+ */
+function octDecodeInto(u: number, v: number, out: Float32Array, at: number): void {
+  const px = (u / OCT16P_MAX) * 2 - 1;
+  const py = (v / OCT16P_MAX) * 2 - 1;
+  const z = 1 - Math.abs(px) - Math.abs(py);
+  // The fold reads both original magnitudes, so neither is overwritten first.
+  const x = z < 0 ? (1 - Math.abs(py)) * signNotZero(px) : px;
+  const y = z < 0 ? (1 - Math.abs(px)) * signNotZero(py) : py;
+  // On the octahedron |x| + |y| + |z| = 1, so no decoded triple is the zero
+  // vector and the division below always has a positive divisor.
+  const length = Math.sqrt(x * x + y * y + z * z);
+  out[at] = x / length;
+  out[at + 1] = y / length;
+  out[at + 2] = z / length;
+}
+
+/**
+ * Decode whichever normal encoding the tile carries.
+ *
+ * NORMAL outranks NORMAL_OCT16P: the float32 array is the tile's own directions
+ * at full precision, and the oct-encoded one is a lossy alternative to it, so a
+ * tile carrying both is decoded from the exact array. A float32 NORMAL is
+ * copied as written rather than re-normalised — the file's own lengths are the
+ * data, and this decoder does not silently rewrite them.
+ */
+function decodeNormals(
+  ft: JsonObject,
+  view: DataView,
+  pointsLength: number,
+  binStart: number,
+  binLength: number,
+): Float32Array | null {
+  if (ft.NORMAL !== undefined) {
+    const byteOffset = accessorByteOffset(ft.NORMAL, 'NORMAL');
+    const components = pointsLength * 3;
+    const start = arrayStart('NORMAL', byteOffset, components, 4, binStart, binLength);
+    // Copied rather than viewed, for the alignment reason POSITION is copied.
+    const normals = new Float32Array(components);
+    for (let i = 0; i < components; i++) normals[i] = view.getFloat32(start + i * 4, true);
+    return normals;
+  }
+
+  if (ft.NORMAL_OCT16P !== undefined) {
+    const byteOffset = accessorByteOffset(ft.NORMAL_OCT16P, 'NORMAL_OCT16P');
+    const start = arrayStart('NORMAL_OCT16P', byteOffset, pointsLength * 2, 1, binStart, binLength);
+    const normals = new Float32Array(pointsLength * 3);
+    for (let i = 0; i < pointsLength; i++) {
+      const at = start + i * 2;
+      octDecodeInto(view.getUint8(at), view.getUint8(at + 1), normals, i * 3);
+    }
+    return normals;
+  }
+
+  return null;
+}
+
+/** Decode a PNTS tile's header, feature table, positions, colours, and normals. */
 export function parsePnts(buffer: ArrayBuffer): PntsTile {
   if (buffer.byteLength < HEADER_BYTES) {
     throw new Error('PNTS: buffer shorter than the 28-byte header.');
@@ -185,6 +394,12 @@ export function parsePnts(buffer: ArrayBuffer): PntsTile {
 
   const components = pointsLength * 3;
 
+  // Colour and normals are resolved before the positions branch, so a tile
+  // whose colour array overruns its section is refused whichever position
+  // encoding it happens to carry.
+  const colors = decodeColors(ft, view, pointsLength, ftBinStart, ftBinLength);
+  const normals = decodeNormals(ft, view, pointsLength, ftBinStart, ftBinLength);
+
   // A tile carrying both encodings is decoded from POSITION: the format gives
   // the uncompressed array precedence over the quantised one.
   if (ft.POSITION !== undefined) {
@@ -196,7 +411,7 @@ export function parsePnts(buffer: ArrayBuffer): PntsTile {
     // reserving the memory before it is refused.
     const positions = new Float32Array(components);
     for (let i = 0; i < components; i++) positions[i] = view.getFloat32(start + i * 4, true);
-    return { version, pointsLength, rtcCenter, positions };
+    return { version, pointsLength, rtcCenter, positions, colors, normals };
   }
 
   if (ft.POSITION_QUANTIZED !== undefined) {
@@ -228,7 +443,7 @@ export function parsePnts(buffer: ArrayBuffer): PntsTile {
       // offset is added rounds twice and loses a step the format still carries.
       positions[i] = (code * volumeScale[axis]) / QUANTIZED_FULL_SCALE + volumeOffset[axis];
     }
-    return { version, pointsLength, rtcCenter, positions };
+    return { version, pointsLength, rtcCenter, positions, colors, normals };
   }
 
   throw new Error('PNTS: feature table has neither POSITION nor POSITION_QUANTIZED.');

--- a/tests/tiles3d.test.ts
+++ b/tests/tiles3d.test.ts
@@ -91,11 +91,139 @@ describe('parsePnts', () => {
     expect([...t.positions]).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
-  it('refuses a bad magic and quantised positions', () => {
+  it('refuses a bad magic', () => {
     const bad = new ArrayBuffer(28);
     new DataView(bad).setUint32(0, 0x12345678, true);
     expect(() => parsePnts(bad)).toThrow(/magic/);
+  });
 
-    expect(() => parsePnts(makeFeatureTablePnts({ POINTS_LENGTH: 1, POSITION_QUANTIZED: { byteOffset: 0 } }))).toThrow(/QUANTIZED/);
+  it('refuses a feature table with no position array at all', () => {
+    expect(() => parsePnts(makeFeatureTablePnts({ POINTS_LENGTH: 1 }))).toThrow(
+      /neither POSITION nor POSITION_QUANTIZED/,
+    );
+  });
+});
+
+/**
+ * Build a PNTS whose feature-table binary holds the arrays given, in order:
+ * float32 POSITION first, then uint16 POSITION_QUANTIZED. Both may be present,
+ * which is the case that pins the format's precedence rule.
+ */
+function makePositionPnts(opts: {
+  position?: number[][];
+  quantized?: number[][];
+  volumeOffset?: number[];
+  volumeScale?: number[];
+}): ArrayBuffer {
+  const pointsLength = (opts.position ?? opts.quantized ?? []).length;
+  const ft: Record<string, unknown> = { POINTS_LENGTH: pointsLength };
+  let binBytes = 0;
+  let positionAt = 0;
+  let quantizedAt = 0;
+  if (opts.position) {
+    positionAt = binBytes;
+    ft.POSITION = { byteOffset: positionAt };
+    binBytes += pointsLength * 3 * 4;
+  }
+  if (opts.quantized) {
+    quantizedAt = binBytes;
+    ft.POSITION_QUANTIZED = { byteOffset: quantizedAt };
+    binBytes += pointsLength * 3 * 2;
+  }
+  if (opts.volumeOffset) ft.QUANTIZED_VOLUME_OFFSET = opts.volumeOffset;
+  if (opts.volumeScale) ft.QUANTIZED_VOLUME_SCALE = opts.volumeScale;
+  let json = JSON.stringify(ft);
+  while (json.length % 8 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const total = 28 + jsonBytes.length + binBytes;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, 0x73746e70, true);
+  view.setUint32(4, 1, true);
+  view.setUint32(8, total, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, binBytes, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buf, 28, jsonBytes.length).set(jsonBytes);
+  const binStart = 28 + jsonBytes.length;
+  if (opts.position) {
+    let k = 0;
+    for (const p of opts.position) for (const c of p) view.setFloat32(binStart + positionAt + k++ * 4, c, true);
+  }
+  if (opts.quantized) {
+    let k = 0;
+    for (const p of opts.quantized) for (const c of p) view.setUint16(binStart + quantizedAt + k++ * 2, c, true);
+  }
+  return buf;
+}
+
+describe('parsePnts quantised positions', () => {
+  it('dequantises against the volume with 65535 as full scale', () => {
+    // Scale equal to full scale makes the expected value the code itself, so a
+    // divisor of 65536 shows up as 32767.5 and 65534 instead of 32768 and 65535.
+    const t = parsePnts(
+      makePositionPnts({
+        quantized: [
+          [0, 32768, 65535],
+          [65535, 0, 1],
+        ],
+        volumeOffset: [0, 0, 0],
+        volumeScale: [65535, 65535, 65535],
+      }),
+    );
+    expect(t.pointsLength).toBe(2);
+    expect([...t.positions]).toEqual([0, 32768, 65535, 65535, 0, 1]);
+  });
+
+  it('applies a per-axis scale and offset', () => {
+    const t = parsePnts(
+      makePositionPnts({
+        quantized: [[0, 65535, 32768]],
+        volumeOffset: [10, 20, 30],
+        volumeScale: [65535, 131070, 65535],
+      }),
+    );
+    // 0/full + 10; 65535 * 2 full-scale steps + 20; half of full scale + 30.
+    expect([...t.positions]).toEqual([10, 131090, 32798]);
+  });
+
+  it('keeps the scaled code in Float64 until the volume offset is added', () => {
+    // A 1 km volume sitting 1000 km from the origin. Each code below is a value
+    // whose float32-rounded intermediate lands on the other side of a float32
+    // step once the offset is added, so narrowing before the addition rounds
+    // twice and moves the point.
+    const t = parsePnts(
+      makePositionPnts({
+        quantized: [[49909, 54947, 63016]],
+        volumeOffset: [1_000_000, 1_000_000, 1_000_000],
+        volumeScale: [100, 100, 100],
+      }),
+    );
+    expect([...t.positions]).toEqual([1000076.1875, 1000083.8125, 1000096.1875]);
+    // What the same tile would decode to if the intermediate were narrowed:
+    expect([...t.positions]).not.toEqual([1000076.125, 1000083.875, 1000096.125]);
+  });
+
+  it('prefers POSITION when a tile carries both encodings', () => {
+    // The quantised array would place this point at 1001, 1001, 1001.
+    const t = parsePnts(
+      makePositionPnts({
+        position: [[1, 2, 3]],
+        quantized: [[65535, 65535, 65535]],
+        volumeOffset: [1000, 1000, 1000],
+        volumeScale: [1, 1, 1],
+      }),
+    );
+    expect([...t.positions]).toEqual([1, 2, 3]);
+  });
+
+  it('refuses a quantised array with no volume to interpret it', () => {
+    const noVolume = makePositionPnts({ quantized: [[1, 2, 3]] });
+    expect(() => parsePnts(noVolume)).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET/);
+    const noScale = makePositionPnts({ quantized: [[1, 2, 3]], volumeOffset: [0, 0, 0] });
+    expect(() => parsePnts(noScale)).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_SCALE/);
+    const noOffset = makePositionPnts({ quantized: [[1, 2, 3]], volumeScale: [1, 1, 1] });
+    expect(() => parsePnts(noOffset)).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET/);
   });
 });

--- a/tests/tiles3d.test.ts
+++ b/tests/tiles3d.test.ts
@@ -227,3 +227,228 @@ describe('parsePnts quantised positions', () => {
     expect(() => parsePnts(noOffset)).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET/);
   });
 });
+
+/**
+ * Build a PNTS tile whose feature-table binary holds a zeroed float32 POSITION
+ * followed by whichever colour and normal arrays were asked for, in that order.
+ * Several encodings can be present at once, which is what pins the format's
+ * precedence rules; `CONSTANT_RGBA` is written into the feature-table JSON
+ * verbatim, because that is where the format keeps it.
+ */
+function makeAttributePnts(opts: {
+  pointsLength?: number;
+  rgba?: number[][];
+  rgb?: number[][];
+  rgb565?: number[];
+  constantRgba?: unknown;
+  normal?: number[][];
+  normalOct16p?: number[][];
+}): ArrayBuffer {
+  const pointsLength = opts.pointsLength ?? 1;
+  const ft: Record<string, unknown> = { POINTS_LENGTH: pointsLength, POSITION: { byteOffset: 0 } };
+  let binBytes = pointsLength * 3 * 4;
+  const claim = (key: string, bytes: number): number => {
+    const at = binBytes;
+    ft[key] = { byteOffset: at };
+    binBytes += bytes;
+    return at;
+  };
+  const rgbaAt = opts.rgba ? claim('RGBA', pointsLength * 4) : 0;
+  const rgbAt = opts.rgb ? claim('RGB', pointsLength * 3) : 0;
+  const rgb565At = opts.rgb565 ? claim('RGB565', pointsLength * 2) : 0;
+  const normalAt = opts.normal ? claim('NORMAL', pointsLength * 3 * 4) : 0;
+  const octAt = opts.normalOct16p ? claim('NORMAL_OCT16P', pointsLength * 2) : 0;
+  if (opts.constantRgba !== undefined) ft.CONSTANT_RGBA = opts.constantRgba;
+
+  let json = JSON.stringify(ft);
+  while (json.length % 8 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const total = 28 + jsonBytes.length + binBytes;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, 0x73746e70, true);
+  view.setUint32(4, 1, true);
+  view.setUint32(8, total, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, binBytes, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buf, 28, jsonBytes.length).set(jsonBytes);
+
+  const bin = new Uint8Array(buf, 28 + jsonBytes.length, binBytes);
+  const binStart = 28 + jsonBytes.length;
+  if (opts.rgba) opts.rgba.forEach((c, i) => bin.set(c, rgbaAt + i * 4));
+  if (opts.rgb) opts.rgb.forEach((c, i) => bin.set(c, rgbAt + i * 3));
+  if (opts.rgb565) opts.rgb565.forEach((w, i) => view.setUint16(binStart + rgb565At + i * 2, w, true));
+  if (opts.normal) {
+    let k = 0;
+    for (const n of opts.normal) for (const c of n) view.setFloat32(binStart + normalAt + k++ * 4, c, true);
+  }
+  if (opts.normalOct16p) opts.normalOct16p.forEach((p, i) => bin.set(p, octAt + i * 2));
+  return buf;
+}
+
+/** Pack a 5/6/5 word the way a writer would, from the raw field values. */
+const rgb565Word = (r5: number, g6: number, b5: number) => (r5 << 11) | (g6 << 5) | b5;
+
+describe('parsePnts colours', () => {
+  it('reports no colour when the tile carries none', () => {
+    expect(parsePnts(makeAttributePnts({})).colors).toBeNull();
+  });
+
+  it('decodes RGBA, keeping the three channels the colour buffer holds', () => {
+    const t = parsePnts(
+      makeAttributePnts({ pointsLength: 2, rgba: [[10, 20, 30, 255], [200, 100, 50, 0]] }),
+    );
+    // The alpha byte has no destination in a three-channel buffer, and a zero
+    // alpha does not blank the colour it accompanied.
+    expect([...(t.colors as Uint8Array)]).toEqual([10, 20, 30, 200, 100, 50]);
+  });
+
+  it('decodes RGB', () => {
+    const t = parsePnts(makeAttributePnts({ pointsLength: 2, rgb: [[1, 2, 3], [253, 254, 255]] }));
+    expect([...(t.colors as Uint8Array)]).toEqual([1, 2, 3, 253, 254, 255]);
+  });
+
+  it('decodes CONSTANT_RGBA onto every point', () => {
+    const t = parsePnts(makeAttributePnts({ pointsLength: 3, constantRgba: [70, 80, 90, 255] }));
+    expect([...(t.colors as Uint8Array)]).toEqual([70, 80, 90, 70, 80, 90, 70, 80, 90]);
+  });
+
+  it('leaves PNTS colour at the 8-bit values the tile wrote', () => {
+    // PNTS channels are bytes. LAS carries 16-bit RGB and this viewer narrows
+    // it on the way in; applying any of that here would divide these values by
+    // 257 or shift them to zero.
+    const t = parsePnts(makeAttributePnts({ rgb: [[255, 128, 1]] }));
+    expect([...(t.colors as Uint8Array)]).toEqual([255, 128, 1]);
+  });
+
+  it('expands each RGB565 field across the full 8-bit range', () => {
+    const t = parsePnts(
+      makeAttributePnts({
+        pointsLength: 6,
+        rgb565: [
+          rgb565Word(31, 63, 31), // white
+          rgb565Word(0, 0, 0), //    black
+          rgb565Word(31, 0, 0), //   red at full strength
+          rgb565Word(0, 63, 0), //   green at full strength
+          rgb565Word(0, 0, 31), //   blue at full strength
+          rgb565Word(16, 32, 8), //  mid-range, distinct per field width
+        ],
+      }),
+    );
+    expect([...(t.colors as Uint8Array)]).toEqual([
+      255, 255, 255, // a shift-only expansion would give 248, 252, 248
+      0, 0, 0,
+      255, 0, 0,
+      0, 255, 0,
+      0, 0, 255,
+      // round(16*255/31) = 132, round(32*255/63) = 130, round(8*255/31) = 66.
+      // Shifting instead would give 128, 128, 64.
+      132, 130, 66,
+    ]);
+  });
+
+  it('reads the RGB565 fields at their own widths and positions', () => {
+    // Field values chosen so red, green and blue are all different, and so
+    // swapping the green and blue widths changes both of them.
+    const t = parsePnts(makeAttributePnts({ rgb565: [rgb565Word(1, 2, 3)] }));
+    // round(1*255/31) = 8, round(2*255/63) = 8, round(3*255/31) = 25.
+    // Reading green as 5 bits would give 16; blue as 6 bits would give 12.
+    expect([...(t.colors as Uint8Array)]).toEqual([8, 8, 25]);
+  });
+
+  it('ranks RGBA over RGB over RGB565 over CONSTANT_RGBA', () => {
+    // Every encoding present at once, each carrying a colour no other one could
+    // produce, so the winner names itself.
+    const all = {
+      rgba: [[10, 20, 30, 255]],
+      rgb: [[40, 50, 60]],
+      rgb565: [rgb565Word(31, 0, 0)], // 255, 0, 0
+      constantRgba: [70, 80, 90, 255],
+    };
+    expect([...(parsePnts(makeAttributePnts(all)).colors as Uint8Array)]).toEqual([10, 20, 30]);
+    const { rgba: _rgba, ...noRgba } = all;
+    expect([...(parsePnts(makeAttributePnts(noRgba)).colors as Uint8Array)]).toEqual([40, 50, 60]);
+    const { rgb: _rgb, ...noRgb } = noRgba;
+    expect([...(parsePnts(makeAttributePnts(noRgb)).colors as Uint8Array)]).toEqual([255, 0, 0]);
+    const { rgb565: _rgb565, ...noRgb565 } = noRgb;
+    expect([...(parsePnts(makeAttributePnts(noRgb565)).colors as Uint8Array)]).toEqual([70, 80, 90]);
+  });
+});
+
+/**
+ * The chord between a decoded oct16p normal and the direction it was encoded
+ * from, at the widest the encoding allows.
+ *
+ * Each of the two stored bytes carries one coordinate of the octahedral
+ * projection over [-1, 1], so rounding moves it by at most 1/255. Decoding maps
+ * (px, py) to (px, py, 1 − |px| − |py|) — or its folded form, which has the same
+ * shape — whose derivative in either coordinate has length sqrt(2), so the
+ * unnormalised point moves by at most 2·sqrt(2)/255. That point lies on the
+ * octahedron |x| + |y| + |z| = 1, whose nearest point to the origin is at
+ * 1/sqrt(3), and normalising two vectors of length at least L separates them by
+ * at most 2/(2L) times their difference. So the unit vectors differ by at most
+ * sqrt(3) · 2·sqrt(2)/255 = 2·sqrt(6)/255, about 0.0192.
+ */
+const OCT16P_CHORD_BOUND = (2 * Math.sqrt(6)) / 255;
+
+/** Euclidean distance between two 3-vectors. */
+const chord = (a: readonly number[], b: readonly number[]) =>
+  Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+
+describe('parsePnts normals', () => {
+  it('reports no normals when the tile carries none', () => {
+    expect(parsePnts(makeAttributePnts({})).normals).toBeNull();
+  });
+
+  it('decodes float32 NORMAL as the tile wrote it', () => {
+    const t = parsePnts(makeAttributePnts({ pointsLength: 2, normal: [[0, 0, 1], [0.5, -0.5, 0.25]] }));
+    expect([...(t.normals as Float32Array)]).toEqual([0, 0, 1, 0.5, -0.5, 0.25]);
+  });
+
+  it('decodes the oct16p corners and the body diagonal exactly', () => {
+    // (255, 255) folds to px = py = 1, z = −1, so the folded point is (0, 0, −1)
+    // and needs no rounding at all. (170, 170) gives px = py = 1/3 and z = 1/3,
+    // which normalises to the body diagonal.
+    const t = parsePnts(makeAttributePnts({ pointsLength: 2, normalOct16p: [[255, 255], [170, 170]] }));
+    const n = [...(t.normals as Float32Array)];
+    expect(chord(n.slice(0, 3), [0, 0, -1])).toBeLessThan(1e-6);
+    const third = 1 / Math.sqrt(3);
+    expect(chord(n.slice(3, 6), [third, third, third])).toBeLessThan(1e-6);
+  });
+
+  it('round-trips the axis and oblique directions inside the encoding bound', () => {
+    // Codes are the octahedral projection of each direction rounded to a byte:
+    // ((p * 0.5 + 0.5) * 255), with the lower hemisphere folded outwards first.
+    const cases: ReadonlyArray<{ code: [number, number]; direction: [number, number, number] }> = [
+      { code: [255, 128], direction: [1, 0, 0] },
+      { code: [0, 128], direction: [-1, 0, 0] },
+      { code: [128, 255], direction: [0, 1, 0] },
+      { code: [128, 0], direction: [0, -1, 0] },
+      { code: [128, 128], direction: [0, 0, 1] },
+      { code: [255, 255], direction: [0, 0, -1] },
+      { code: [170, 170], direction: [1 / Math.sqrt(3), 1 / Math.sqrt(3), 1 / Math.sqrt(3)] },
+      { code: [219, 44], direction: [0.6, -0.48, -0.64] },
+    ];
+    const t = parsePnts(
+      makeAttributePnts({ pointsLength: cases.length, normalOct16p: cases.map((c) => [...c.code]) }),
+    );
+    const normals = t.normals as Float32Array;
+    cases.forEach((c, i) => {
+      const decoded = [normals[i * 3], normals[i * 3 + 1], normals[i * 3 + 2]];
+      // A direction, so unit length whatever the two bytes happened to name.
+      expect(Math.hypot(decoded[0], decoded[1], decoded[2])).toBeCloseTo(1, 6);
+      expect(chord(decoded, c.direction)).toBeLessThan(OCT16P_CHORD_BOUND);
+    });
+  });
+
+  it('prefers NORMAL when a tile carries both encodings', () => {
+    // The oct16p pair would decode to the body diagonal, which shares no
+    // component with the float32 array.
+    const t = parsePnts(
+      makeAttributePnts({ normal: [[0, 0, 1]], normalOct16p: [[170, 170]] }),
+    );
+    expect([...(t.normals as Float32Array)]).toEqual([0, 0, 1]);
+  });
+});

--- a/tests/tiles3dMalformed.test.ts
+++ b/tests/tiles3dMalformed.test.ts
@@ -489,3 +489,174 @@ describe('PNTS quantised perimeter', () => {
     ).toThrow(/POSITION_QUANTIZED spans a byte range too large to address exactly/);
   });
 });
+
+/**
+ * A tile whose feature table is `ft`, over a feature-table binary of `binBytes`
+ * bytes. The default 24 bytes is a float32 POSITION for 2 points, so a colour
+ * or normal array added at any offset overruns the section and the fixtures
+ * below say by how much rather than by whether.
+ */
+const attributes = (ft: Record<string, unknown>, binBytes = 24) =>
+  assemble({ ftJson: ftJsonBytes(ft), ftBin: new Uint8Array(binBytes) });
+
+/** POINTS_LENGTH 2 with a POSITION that fits the default 24-byte binary. */
+const twoPoints = { POINTS_LENGTH: 2, POSITION: { byteOffset: 0 } };
+
+describe('PNTS colour perimeter', () => {
+  it('accepts the well-formed baseline of each encoding', () => {
+    // 8 bytes of RGBA, 6 of RGB, 4 of RGB565 all fit alongside the 24 bytes of
+    // POSITION when the binary is grown to hold them.
+    expect(parsePnts(attributes({ ...twoPoints, RGBA: { byteOffset: 24 } }, 32)).colors).toHaveLength(6);
+    expect(parsePnts(attributes({ ...twoPoints, RGB: { byteOffset: 24 } }, 30)).colors).toHaveLength(6);
+    expect(parsePnts(attributes({ ...twoPoints, RGB565: { byteOffset: 24 } }, 28)).colors).toHaveLength(6);
+    expect(parsePnts(attributes({ ...twoPoints, CONSTANT_RGBA: [1, 2, 3, 4] })).colors).toHaveLength(6);
+  });
+
+  it('refuses a colour array that runs past the feature-table binary', () => {
+    // Each array is one byte short of fitting: the section ends where POSITION
+    // does, so any colour byte at all is outside it.
+    expect(() => parsePnts(attributes({ ...twoPoints, RGBA: { byteOffset: 24 } }, 31))).toThrow(
+      /RGBA extends past the feature-table binary section/,
+    );
+    expect(() => parsePnts(attributes({ ...twoPoints, RGB: { byteOffset: 24 } }, 29))).toThrow(
+      /RGB extends past the feature-table binary section/,
+    );
+    expect(() => parsePnts(attributes({ ...twoPoints, RGB565: { byteOffset: 24 } }, 27))).toThrow(
+      /RGB565 extends past the feature-table binary section/,
+    );
+    // Wholly outside, rather than one byte over.
+    expect(() => parsePnts(attributes({ ...twoPoints, RGBA: { byteOffset: 1024 } }, 32))).toThrow(
+      /RGBA extends past the feature-table binary section/,
+    );
+  });
+
+  it('refuses a colour byte range whose arithmetic would not be exact', () => {
+    for (const key of ['RGBA', 'RGB', 'RGB565']) {
+      expect(() =>
+        parsePnts(attributes({ ...twoPoints, [key]: { byteOffset: Number.MAX_SAFE_INTEGER - 8 } }, 32)),
+      ).toThrow(new RegExp(`${key} spans a byte range too large to address exactly`));
+    }
+  });
+
+  it('refuses a colour accessor that is not an accessor object', () => {
+    for (const key of ['RGBA', 'RGB', 'RGB565']) {
+      for (const value of [0, 'nope', [0], null, true]) {
+        expect(() => parsePnts(attributes({ ...twoPoints, [key]: value }, 32))).toThrow(
+          new RegExp(`${key} is not a feature-table accessor object`),
+        );
+      }
+      expect(() => parsePnts(attributes({ ...twoPoints, [key]: {} }, 32))).toThrow(
+        new RegExp(`${key}\\.byteOffset is not a non-negative whole number`),
+      );
+      expect(() => parsePnts(attributes({ ...twoPoints, [key]: { byteOffset: -4 } }, 32))).toThrow(
+        new RegExp(`${key}\\.byteOffset is not a non-negative whole number`),
+      );
+      expect(() => parsePnts(attributes({ ...twoPoints, [key]: { byteOffset: 1.5 } }, 32))).toThrow(
+        new RegExp(`${key}\\.byteOffset is not a non-negative whole number`),
+      );
+    }
+  });
+
+  it('refuses a CONSTANT_RGBA that is not four bytes', () => {
+    const bad = (value: unknown) => () => parsePnts(attributes({ ...twoPoints, CONSTANT_RGBA: value }));
+    expect(bad([1, 2, 3])).toThrow(/CONSTANT_RGBA must have 4 components/);
+    expect(bad([1, 2, 3, 4, 5])).toThrow(/CONSTANT_RGBA must have 4 components/);
+    expect(bad([])).toThrow(/CONSTANT_RGBA must have 4 components/);
+    expect(bad({ r: 1, g: 2, b: 3, a: 4 })).toThrow(/CONSTANT_RGBA must have 4 components/);
+    expect(bad('white')).toThrow(/CONSTANT_RGBA must have 4 components/);
+    expect(bad(255)).toThrow(/CONSTANT_RGBA must have 4 components/);
+    expect(bad(null)).toThrow(/CONSTANT_RGBA must have 4 components/);
+    for (const component of [-1, 256, 1.5, '255', true, null, Number.NaN]) {
+      expect(bad([1, 2, 3, component])).toThrow(
+        /CONSTANT_RGBA has a component that is not a whole number in 0-255/,
+      );
+    }
+    // The bounds are inclusive, so the refusals above are about the values.
+    expect(parsePnts(attributes({ ...twoPoints, CONSTANT_RGBA: [0, 255, 0, 255] })).colors).toEqual(
+      new Uint8Array([0, 255, 0, 0, 255, 0]),
+    );
+  });
+
+  it('refuses a malformed colour array instead of falling back to a lower-ranked one', () => {
+    // Every lower-ranked encoding is present and well-formed. A decoder that
+    // answered the defect by moving down the ranking would return a colour, and
+    // the colour it returned would not be the one the tile named.
+    const lower = { RGB: { byteOffset: 24 }, RGB565: { byteOffset: 30 }, CONSTANT_RGBA: [9, 9, 9, 255] };
+    expect(() =>
+      parsePnts(attributes({ ...twoPoints, RGBA: { byteOffset: 34 }, ...lower }, 34)),
+    ).toThrow(/RGBA extends past the feature-table binary section/);
+    expect(() =>
+      parsePnts(attributes({ ...twoPoints, RGB: { byteOffset: 34 }, RGB565: { byteOffset: 24 }, CONSTANT_RGBA: [9, 9, 9, 255] }, 34)),
+    ).toThrow(/RGB extends past the feature-table binary section/);
+    expect(() =>
+      parsePnts(attributes({ ...twoPoints, RGB565: { byteOffset: 34 }, CONSTANT_RGBA: [9, 9, 9, 255] }, 34)),
+    ).toThrow(/RGB565 extends past the feature-table binary section/);
+  });
+});
+
+describe('PNTS normal perimeter', () => {
+  it('accepts the well-formed baseline of each encoding', () => {
+    expect(parsePnts(attributes({ ...twoPoints, NORMAL: { byteOffset: 24 } }, 48)).normals).toHaveLength(6);
+    expect(parsePnts(attributes({ ...twoPoints, NORMAL_OCT16P: { byteOffset: 24 } }, 28)).normals).toHaveLength(6);
+  });
+
+  it('refuses a normal array that runs past the feature-table binary', () => {
+    expect(() => parsePnts(attributes({ ...twoPoints, NORMAL: { byteOffset: 24 } }, 47))).toThrow(
+      /NORMAL extends past the feature-table binary section/,
+    );
+    expect(() => parsePnts(attributes({ ...twoPoints, NORMAL_OCT16P: { byteOffset: 24 } }, 27))).toThrow(
+      /NORMAL_OCT16P extends past the feature-table binary section/,
+    );
+    expect(() => parsePnts(attributes({ ...twoPoints, NORMAL: { byteOffset: 4096 } }, 48))).toThrow(
+      /NORMAL extends past the feature-table binary section/,
+    );
+  });
+
+  it('refuses a normal byte range whose arithmetic would not be exact', () => {
+    for (const key of ['NORMAL', 'NORMAL_OCT16P']) {
+      expect(() =>
+        parsePnts(attributes({ ...twoPoints, [key]: { byteOffset: Number.MAX_SAFE_INTEGER - 8 } }, 48)),
+      ).toThrow(new RegExp(`${key} spans a byte range too large to address exactly`));
+    }
+  });
+
+  it('refuses a normal accessor that is not an accessor object', () => {
+    for (const key of ['NORMAL', 'NORMAL_OCT16P']) {
+      for (const value of [0, 'nope', [0], null, true]) {
+        expect(() => parsePnts(attributes({ ...twoPoints, [key]: value }, 48))).toThrow(
+          new RegExp(`${key} is not a feature-table accessor object`),
+        );
+      }
+      expect(() => parsePnts(attributes({ ...twoPoints, [key]: {} }, 48))).toThrow(
+        new RegExp(`${key}\\.byteOffset is not a non-negative whole number`),
+      );
+      expect(() => parsePnts(attributes({ ...twoPoints, [key]: { byteOffset: -2 } }, 48))).toThrow(
+        new RegExp(`${key}\\.byteOffset is not a non-negative whole number`),
+      );
+      expect(() => parsePnts(attributes({ ...twoPoints, [key]: { byteOffset: 0.5 } }, 48))).toThrow(
+        new RegExp(`${key}\\.byteOffset is not a non-negative whole number`),
+      );
+    }
+  });
+
+  it('refuses a malformed NORMAL instead of falling back to NORMAL_OCT16P', () => {
+    expect(() =>
+      parsePnts(
+        attributes({ ...twoPoints, NORMAL: { byteOffset: 28 }, NORMAL_OCT16P: { byteOffset: 24 } }, 28),
+      ),
+    ).toThrow(/NORMAL extends past the feature-table binary section/);
+  });
+
+  it('refuses a colour or normal array on a quantised tile too', () => {
+    // The position encoding does not decide whether the other arrays are
+    // checked: the 12-byte binary holds the quantised positions and nothing else.
+    const volume = { QUANTIZED_VOLUME_OFFSET: [0, 0, 0], QUANTIZED_VOLUME_SCALE: [1, 1, 1] };
+    const base = { POINTS_LENGTH: 2, POSITION_QUANTIZED: { byteOffset: 0 }, ...volume };
+    expect(() => parsePnts(attributes({ ...base, RGB: { byteOffset: 12 } }, 12))).toThrow(
+      /RGB extends past the feature-table binary section/,
+    );
+    expect(() => parsePnts(attributes({ ...base, NORMAL_OCT16P: { byteOffset: 12 } }, 12))).toThrow(
+      /NORMAL_OCT16P extends past the feature-table binary section/,
+    );
+  });
+});

--- a/tests/tiles3dMalformed.test.ts
+++ b/tests/tiles3dMalformed.test.ts
@@ -112,63 +112,273 @@ describe('tileset.json perimeter', () => {
   });
 });
 
-/** Build a PNTS tile. `declaredLength` defaults to the real byte length. */
-function pnts(opts: {
-  version?: number;
-  pointsLength?: number;
-  positionByteOffset?: number;
-  declaredLength?: number;
-  trailing?: number;
-  rtc?: unknown;
-} = {}): ArrayBuffer {
+const EMPTY = new Uint8Array(0);
+const utf8 = (text: string) => new TextEncoder().encode(text);
+
+/** Serialise a feature table the way a writer would, padded to 4 bytes. */
+function ftJsonBytes(ft: Record<string, unknown>): Uint8Array {
+  let json = JSON.stringify(ft);
+  while (json.length % 4 !== 0) json += ' ';
+  return utf8(json);
+}
+
+/**
+ * Assemble a PNTS tile from section bytes. Every header field can be set
+ * independently of what the sections actually hold, which is the point: these
+ * fixtures are tiles whose header disagrees with their body.
+ */
+function assemble(
+  sections: { ftJson: Uint8Array; ftBin?: Uint8Array; btJson?: Uint8Array; btBin?: Uint8Array },
+  header: {
+    version?: number;
+    byteLength?: number;
+    /** Applied to the real tile length when `byteLength` is not given. */
+    byteLengthDelta?: number;
+    ftJsonLength?: number;
+    ftBinLength?: number;
+    btJsonLength?: number;
+    btBinLength?: number;
+    /** Bytes appended after the tile, as a concatenated stream would carry. */
+    trailing?: number;
+  } = {},
+): ArrayBuffer {
+  const parts = [
+    sections.ftJson,
+    sections.ftBin ?? EMPTY,
+    sections.btJson ?? EMPTY,
+    sections.btBin ?? EMPTY,
+  ];
+  const tileBytes = 28 + parts.reduce((n, s) => n + s.length, 0);
+  const buf = new ArrayBuffer(tileBytes + (header.trailing ?? 0));
+  const view = new DataView(buf);
+  view.setUint32(0, 0x73746e70, true);
+  view.setUint32(4, header.version ?? 1, true);
+  view.setUint32(8, header.byteLength ?? tileBytes + (header.byteLengthDelta ?? 0), true);
+  view.setUint32(12, header.ftJsonLength ?? parts[0].length, true);
+  view.setUint32(16, header.ftBinLength ?? parts[1].length, true);
+  view.setUint32(20, header.btJsonLength ?? parts[2].length, true);
+  view.setUint32(24, header.btBinLength ?? parts[3].length, true);
+  const bytes = new Uint8Array(buf);
+  let at = 28;
+  for (const part of parts) {
+    bytes.set(part, at);
+    at += part.length;
+  }
+  return buf;
+}
+
+/**
+ * Build a float32-POSITION PNTS tile. `ft` replaces the whole feature table;
+ * `binPoints` sizes the feature-table binary independently of POINTS_LENGTH.
+ */
+function pnts(
+  opts: {
+    version?: number;
+    pointsLength?: number;
+    positionByteOffset?: number;
+    declaredLength?: number;
+    trailing?: number;
+    rtc?: unknown;
+    ft?: Record<string, unknown>;
+    binPoints?: number;
+    btJson?: Uint8Array;
+  } = {},
+): ArrayBuffer {
   const pointsLength = opts.pointsLength ?? 2;
-  const ftJson: Record<string, unknown> = {
+  const ft: Record<string, unknown> = opts.ft ?? {
     POINTS_LENGTH: pointsLength,
     POSITION: { byteOffset: opts.positionByteOffset ?? 0 },
   };
-  if (opts.rtc !== undefined) ftJson.RTC_CENTER = opts.rtc;
-  let json = JSON.stringify(ftJson);
-  while (json.length % 4 !== 0) json += ' ';
-  const jsonBytes = new TextEncoder().encode(json);
-  const binBytes = pointsLength * 3 * 4;
-  const tileBytes = 28 + jsonBytes.length + binBytes;
-  const total = tileBytes + (opts.trailing ?? 0);
-  const buf = new ArrayBuffer(total);
-  const view = new DataView(buf);
-  view.setUint32(0, 0x73746e70, true);
-  view.setUint32(4, opts.version ?? 1, true);
-  // The declared length is the TILE, not the buffer: trailing bytes are
-  // whatever followed it in a concatenated stream.
-  view.setUint32(8, opts.declaredLength ?? tileBytes, true);
-  view.setUint32(12, jsonBytes.length, true);
-  view.setUint32(16, binBytes, true);
-  new Uint8Array(buf).set(jsonBytes, 28);
-  return buf;
+  if (opts.rtc !== undefined) ft.RTC_CENTER = opts.rtc;
+  return assemble(
+    {
+      ftJson: ftJsonBytes(ft),
+      ftBin: new Uint8Array((opts.binPoints ?? pointsLength) * 3 * 4),
+      btJson: opts.btJson,
+    },
+    { version: opts.version, byteLength: opts.declaredLength, trailing: opts.trailing },
+  );
 }
+
+/** A tile whose only defect is the POINTS_LENGTH it declares. */
+const withPointsLength = (value: unknown) =>
+  pnts({ ft: { POINTS_LENGTH: value, POSITION: { byteOffset: 0 } }, binPoints: 2 });
 
 describe('PNTS perimeter', () => {
   it('accepts the well-formed baseline', () => {
     expect(parsePnts(pnts()).pointsLength).toBe(2);
   });
 
-  it('refuses a version it does not claim to read', () => {
-    expect(() => parsePnts(pnts({ version: 2 }))).toThrow(/version 2 is not supported/);
+  it('refuses a buffer that cannot hold the header', () => {
+    expect(() => parsePnts(new ArrayBuffer(27))).toThrow(/buffer shorter than the 28-byte header/);
+    expect(() => parsePnts(new ArrayBuffer(0))).toThrow(/buffer shorter than the 28-byte header/);
   });
 
-  it('treats the declared tile length as the boundary, not the buffer', () => {
-    // 64 trailing bytes follow the tile. POSITION starts 4 bytes into the
-    // feature-table binary, so its 24 bytes run 4 past the tile and into them.
-    // The buffer can satisfy that read; the tile cannot.
-    const withTrailing = pnts({ trailing: 64, positionByteOffset: 4 });
-    expect(() => parsePnts(withTrailing)).toThrow(/past the declared tile length/);
-    // Without the trailing bytes the buffer would have refused it anyway, so
-    // the case above is the one that needs the declared length to be enforced.
-    expect(parsePnts(pnts()).pointsLength).toBe(2);
+  it('refuses a version it does not claim to read', () => {
+    expect(() => parsePnts(pnts({ version: 2 }))).toThrow(/version 2 is not supported/);
+    expect(() => parsePnts(pnts({ version: 0 }))).toThrow(/version 0 is not supported/);
+  });
+
+  it('refuses a declared byteLength outside the buffer or under the header', () => {
+    // Declared past the end of what arrived: no section can be satisfied from
+    // bytes the transport never delivered.
+    expect(() => parsePnts(assemble({ ftJson: utf8('{}  ') }, { byteLengthDelta: 8 }))).toThrow(
+      /declared byteLength exceeds the buffer/,
+    );
+    expect(() => parsePnts(assemble({ ftJson: utf8('{}  ') }, { byteLength: 27 }))).toThrow(
+      /declared byteLength is shorter than the header/,
+    );
+  });
+
+  it('refuses a declared byteLength that is not the sum of its sections', () => {
+    // Shorter than the sections imply: the body runs past the tile.
+    expect(() => parsePnts(pnts({ declaredLength: 28 + 4 }))).toThrow(
+      /section lengths overrun the declared byteLength/,
+    );
+    // Longer than the sections imply: bytes inside the tile that no section
+    // accounts for. The trailing room is what lets the declaration grow while
+    // still fitting the buffer.
+    expect(() =>
+      parsePnts(
+        assemble(
+          { ftJson: ftJsonBytes({ POINTS_LENGTH: 1, POSITION: { byteOffset: 0 } }), ftBin: new Uint8Array(12) },
+          { byteLengthDelta: 16, trailing: 16 },
+        ),
+      ),
+    ).toThrow(/declared byteLength leaves bytes past the last section/);
+  });
+
+  it('refuses a feature-table JSON length that overruns the tile', () => {
+    const ftJson = ftJsonBytes({ POINTS_LENGTH: 1, POSITION: { byteOffset: 0 } });
+    const ftBin = new Uint8Array(12);
+    expect(() =>
+      parsePnts(assemble({ ftJson, ftBin }, { ftJsonLength: ftJson.length + 4 })),
+    ).toThrow(/section lengths overrun the declared byteLength/);
+    expect(() => parsePnts(assemble({ ftJson, ftBin }, { ftJsonLength: 0xffffffff }))).toThrow(
+      /section lengths overrun the declared byteLength/,
+    );
+    expect(() => parsePnts(assemble({ ftJson, ftBin }, { ftBinLength: 0xffffffff }))).toThrow(
+      /section lengths overrun the declared byteLength/,
+    );
+    expect(() => parsePnts(assemble({ ftJson, ftBin }, { btJsonLength: 0xffffffff }))).toThrow(
+      /section lengths overrun the declared byteLength/,
+    );
+    expect(() => parsePnts(assemble({ ftJson, ftBin }, { btBinLength: 0xffffffff }))).toThrow(
+      /section lengths overrun the declared byteLength/,
+    );
+  });
+
+  it('refuses a binary section that starts inside the JSON text', () => {
+    // The section lengths still add up, so only the truncated JSON gives the
+    // shortfall away: the feature-table binary begins 8 bytes early.
+    const ftJson = ftJsonBytes({ POINTS_LENGTH: 1, POSITION: { byteOffset: 0 } });
+    const ftBin = new Uint8Array(12);
+    expect(() =>
+      parsePnts(
+        assemble({ ftJson, ftBin }, { ftJsonLength: ftJson.length - 8, ftBinLength: ftBin.length + 8 }),
+      ),
+    ).toThrow(/feature table JSON does not parse/);
+  });
+
+  it('refuses a feature table that is not UTF-8, not JSON, or not an object', () => {
+    // 0xff never appears in well-formed UTF-8.
+    expect(() => parsePnts(assemble({ ftJson: new Uint8Array([0x7b, 0xff, 0x7d, 0x20]) }))).toThrow(
+      /feature table JSON is not valid UTF-8/,
+    );
+    expect(() => parsePnts(assemble({ ftJson: utf8('{oops} ') }))).toThrow(
+      /feature table JSON does not parse/,
+    );
+    expect(() => parsePnts(assemble({ ftJson: EMPTY }))).toThrow(/feature table JSON does not parse/);
+    expect(() => parsePnts(assemble({ ftJson: utf8('[1,2,3]') }))).toThrow(
+      /feature table JSON is not an object/,
+    );
+    expect(() => parsePnts(assemble({ ftJson: utf8('null') }))).toThrow(
+      /feature table JSON is not an object/,
+    );
+    expect(() => parsePnts(assemble({ ftJson: utf8('7') }))).toThrow(
+      /feature table JSON is not an object/,
+    );
+  });
+
+  it('refuses a batch table that does not parse, and accepts one that does', () => {
+    expect(() => parsePnts(pnts({ btJson: utf8('{oops} ') }))).toThrow(
+      /batch table JSON does not parse/,
+    );
+    expect(() => parsePnts(pnts({ btJson: new Uint8Array([0x7b, 0xff, 0x7d, 0x20]) }))).toThrow(
+      /batch table JSON is not valid UTF-8/,
+    );
+    expect(() => parsePnts(pnts({ btJson: utf8('[]  ') }))).toThrow(
+      /batch table JSON is not an object/,
+    );
+    expect(parsePnts(pnts({ btJson: utf8('{"name":[1,2]}  ') })).pointsLength).toBe(2);
+  });
+
+  it('refuses a POINTS_LENGTH that is not a positive uint32', () => {
+    for (const value of [0, -1, -2.5, 1.5, 4294967296, 1e300, '2', true, null, [2]]) {
+      expect(() => parsePnts(withPointsLength(value))).toThrow(
+        /POINTS_LENGTH is not a positive uint32/,
+      );
+    }
+    // JSON has no NaN or Infinity literal; `JSON.stringify` writes both as null,
+    // which is the form a real feature table would hold.
+    expect(() => parsePnts(withPointsLength(Number.NaN))).toThrow(
+      /POINTS_LENGTH is not a positive uint32/,
+    );
+    // Absent entirely.
+    expect(() => parsePnts(pnts({ ft: { POSITION: { byteOffset: 0 } }, binPoints: 2 }))).toThrow(
+      /POINTS_LENGTH is not a positive uint32/,
+    );
+    // The upper bound is inclusive, so the refusal above is about the value and
+    // not about uint32 generally.
+    expect(() => parsePnts(withPointsLength(4294967295))).toThrow(
+      /POSITION extends past the feature-table binary section/,
+    );
+  });
+
+  it('refuses a POSITION that is not an accessor object', () => {
+    for (const position of [0, 'nope', [0], null, true]) {
+      expect(() => parsePnts(pnts({ ft: { POINTS_LENGTH: 2, POSITION: position }, binPoints: 2 }))).toThrow(
+        /POSITION is not a feature-table accessor object/,
+      );
+    }
+    expect(() => parsePnts(pnts({ ft: { POINTS_LENGTH: 2, POSITION: {} }, binPoints: 2 }))).toThrow(
+      /POSITION\.byteOffset is not a non-negative whole number/,
+    );
   });
 
   it('refuses a fractional or negative POSITION.byteOffset', () => {
     expect(() => parsePnts(pnts({ positionByteOffset: 1.5 }))).toThrow(/non-negative whole number/);
     expect(() => parsePnts(pnts({ positionByteOffset: -4 }))).toThrow(/non-negative whole number/);
+    // Past the safe-integer ceiling the offset is no longer the number that was
+    // written, so it is refused before any arithmetic is done on it.
+    expect(() => parsePnts(pnts({ positionByteOffset: 2 ** 53 }))).toThrow(
+      /non-negative whole number/,
+    );
+  });
+
+  it('refuses a byte range whose arithmetic would not be exact', () => {
+    // A safe offset plus a safe length whose sum is not safe: the range check
+    // would otherwise compare an approximation and could compare it favourably.
+    expect(() => parsePnts(pnts({ positionByteOffset: Number.MAX_SAFE_INTEGER - 8 }))).toThrow(
+      /POSITION spans a byte range too large to address exactly/,
+    );
+  });
+
+  it('treats the declared tile length as the boundary, not the buffer', () => {
+    // A tile followed by 64 bytes of whatever came next in the stream still
+    // decodes: the trailing bytes are not the tile's problem.
+    expect(parsePnts(pnts({ trailing: 64 })).pointsLength).toBe(2);
+    // POSITION starts 4 bytes into the feature-table binary, so its 24 bytes run
+    // 4 past the section and into those trailing bytes. The buffer can satisfy
+    // that read; the tile cannot.
+    expect(() => parsePnts(pnts({ trailing: 64, positionByteOffset: 4 }))).toThrow(
+      /POSITION extends past the feature-table binary section/,
+    );
+    // The same overrun without trailing bytes, so the case above is about the
+    // section boundary rather than about running out of buffer.
+    expect(() => parsePnts(pnts({ positionByteOffset: 4 }))).toThrow(
+      /POSITION extends past the feature-table binary section/,
+    );
   });
 
   it('refuses a malformed RTC_CENTER rather than dropping it', () => {
@@ -192,5 +402,90 @@ describe('PNTS perimeter', () => {
     expect(parsePnts(pnts({ rtc: [1, 2, 3] })).rtcCenter).toEqual([1, 2, 3]);
     expect(parsePnts(pnts({ rtc: [0, 0, 0] })).rtcCenter).toEqual([0, 0, 0]);
     expect(parsePnts(pnts()).rtcCenter).toBeNull();
+  });
+});
+
+/** A quantised tile whose feature table is `ft`, over a 2-point binary. */
+const quantized = (ft: Record<string, unknown>) =>
+  assemble({ ftJson: ftJsonBytes(ft), ftBin: new Uint8Array(12) });
+
+describe('PNTS quantised perimeter', () => {
+  const volume = { QUANTIZED_VOLUME_OFFSET: [0, 0, 0], QUANTIZED_VOLUME_SCALE: [1, 1, 1] };
+
+  it('accepts the well-formed baseline', () => {
+    const tile = quantized({ POINTS_LENGTH: 2, POSITION_QUANTIZED: { byteOffset: 0 }, ...volume });
+    expect([...parsePnts(tile).positions]).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+
+  it('refuses a quantised array with no volume to interpret it', () => {
+    expect(() => parsePnts(quantized({ POINTS_LENGTH: 2, POSITION_QUANTIZED: { byteOffset: 0 } }))).toThrow(
+      /POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET/,
+    );
+    expect(() =>
+      parsePnts(
+        quantized({
+          POINTS_LENGTH: 2,
+          POSITION_QUANTIZED: { byteOffset: 0 },
+          QUANTIZED_VOLUME_OFFSET: [0, 0, 0],
+        }),
+      ),
+    ).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_SCALE/);
+    expect(() =>
+      parsePnts(
+        quantized({
+          POINTS_LENGTH: 2,
+          POSITION_QUANTIZED: { byteOffset: 0 },
+          QUANTIZED_VOLUME_SCALE: [1, 1, 1],
+        }),
+      ),
+    ).toThrow(/POSITION_QUANTIZED requires QUANTIZED_VOLUME_OFFSET/);
+  });
+
+  it('refuses a quantised volume that is not three real numbers', () => {
+    expect(() =>
+      parsePnts(
+        quantized({ POINTS_LENGTH: 2, POSITION_QUANTIZED: { byteOffset: 0 }, ...volume, QUANTIZED_VOLUME_SCALE: [1, 1] }),
+      ),
+    ).toThrow(/QUANTIZED_VOLUME_SCALE must have 3 components/);
+    expect(() =>
+      parsePnts(
+        quantized({
+          POINTS_LENGTH: 2,
+          POSITION_QUANTIZED: { byteOffset: 0 },
+          ...volume,
+          QUANTIZED_VOLUME_OFFSET: [1, 2, Number.NaN],
+        }),
+      ),
+    ).toThrow(/QUANTIZED_VOLUME_OFFSET has a component that is not a finite number/);
+    expect(() =>
+      parsePnts(
+        quantized({
+          POINTS_LENGTH: 2,
+          POSITION_QUANTIZED: { byteOffset: 0 },
+          ...volume,
+          QUANTIZED_VOLUME_SCALE: { x: 1, y: 1, z: 1 },
+        }),
+      ),
+    ).toThrow(/QUANTIZED_VOLUME_SCALE must have 3 components/);
+  });
+
+  it('refuses a quantised array that runs past the feature-table binary', () => {
+    // 2 points of uint16 xyz need 12 bytes, and the section holds 12, so an
+    // offset of 2 is two bytes too many.
+    expect(() =>
+      parsePnts(quantized({ POINTS_LENGTH: 2, POSITION_QUANTIZED: { byteOffset: 2 }, ...volume })),
+    ).toThrow(/POSITION_QUANTIZED extends past the feature-table binary section/);
+    expect(() =>
+      parsePnts(quantized({ POINTS_LENGTH: 3, POSITION_QUANTIZED: { byteOffset: 0 }, ...volume })),
+    ).toThrow(/POSITION_QUANTIZED extends past the feature-table binary section/);
+    expect(() =>
+      parsePnts(
+        quantized({
+          POINTS_LENGTH: 2,
+          POSITION_QUANTIZED: { byteOffset: Number.MAX_SAFE_INTEGER - 8 },
+          ...volume,
+        }),
+      ),
+    ).toThrow(/POSITION_QUANTIZED spans a byte range too large to address exactly/);
   });
 });


### PR DESCRIPTION
Stacked on #518.

Colour decodes `RGBA`, `RGB`, `RGB565` and `CONSTANT_RGBA`, ranked in that order from feature-table key presence before any byte is read, so a tile carrying several decodes from the highest and never falls through on a defect.

PNTS colour is already 8-bit and leaves the decoder as sRGB bytes with no normalisation. The 16-bit narrowing in `lasDecodeShared` is LAS-specific, and the single sRGB to linear seam stays at the render upload. The alpha byte is validated and dropped, since `PointCloud.colors` is three channels wide.

Normals decode float32 `NORMAL` and `NORMAL_OCT16P`, preferring `NORMAL`. Decoded normals are unit length, within a chord bound of 2·sqrt(6)/255 derived from the one-byte-per-coordinate rounding.
