### PR TITLE
Add the docked Profile Workbench panel

### DIFF
--- a/src/lazyChunks.ts
+++ b/src/lazyChunks.ts
@@ -481,3 +481,17 @@ export const loadSessionOwnership = () => import('./io/sessionOwnership');
  * session that carries one. Same hazard as the loaders above.
  */
 export const loadVerifySessionManifest = () => import('./science/verifySessionManifest');
+
+/*
+ * The docked Profile Workbench panel (`src/ui/ProfileWorkbench.ts`) belongs
+ * here too, as
+ *
+ *   export const loadProfileWorkbench = () => import('./ui/ProfileWorkbench');
+ *
+ * and the line lands with the first call site, not before it. A seam nobody
+ * calls is shaken out of this module, no chunk is emitted, and the
+ * chunk-emission guard in vite.config.ts — which derives its required list
+ * from the seams written here — fails the build by name. The panel is
+ * standalone and unreferenced until it is mounted, so the seam is the one part
+ * of it that cannot precede its caller.
+ */

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -591,3 +591,83 @@
   transition: color var(--dur-fast) var(--ease-standard), border-color var(--dur-fast) var(--ease-standard);
 }
 
+
+/* ── Profile Workbench ──────────────────────────────────────────────────────
+   The docked cross-section workbench. It sits UNDER the stage and shares the
+   stage's height with the 3D canvas, so it is a block in the flow, not an
+   overlay: nothing here dims, blurs, or covers the scene, because the scene
+   stays interactive while the workbench is open. Its height is set inline from
+   `profileWorkbenchDock.ts`; the rules below own everything except that. */
+.olv-workbench {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--panel-raised);
+  border-top: 0.5px solid var(--hairline-strong);
+  box-shadow: var(--shadow-raised);
+}
+/* Motion is opt-in: the panel only carries this class when the host reports no
+   reduced-motion preference, and the media query is the second guard for a
+   preference that changes after mount. */
+.olv-workbench-animate { transition: height var(--dur-fast) var(--ease-standard); }
+@media (prefers-reduced-motion: reduce) {
+  .olv-workbench-animate { transition: none; }
+}
+/* The splitter is the top edge itself — a thin grab strip with a comfortable
+   hit area, keyboard-focusable because the arrow keys resize the dock too. */
+.olv-workbench-splitter {
+  position: absolute; top: 0; left: 0; right: 0;
+  height: 8px; cursor: row-resize;
+  touch-action: none;
+}
+.olv-workbench-splitter:hover,
+.olv-workbench-splitter:focus-visible { background: var(--hairline-strong); }
+.olv-workbench-dragging { user-select: none; }
+.olv-workbench-head {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md) var(--space-xs);
+  flex-shrink: 0;
+}
+.olv-workbench-titles { min-width: 0; }
+.olv-workbench-title { font-size: var(--text-sm); color: var(--text); }
+.olv-workbench-scope {
+  font-size: var(--text-xs); color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+.olv-workbench-actions { display: flex; gap: var(--space-xs); flex-shrink: 0; }
+.olv-workbench-btn {
+  font-size: var(--text-xs); color: var(--text-dim);
+  background: rgba(255, 255, 255, 0.04);
+  border: 0.5px solid var(--hairline);
+  border-radius: var(--radius-sm); padding: var(--space-2xs) var(--space-sm);
+}
+.olv-workbench-btn:hover { color: var(--text); }
+.olv-workbench-status {
+  padding: 0 var(--space-md) var(--space-2xs);
+  font-size: var(--text-xs); color: var(--text-faint);
+}
+.olv-workbench-body {
+  display: flex; gap: var(--space-md); min-height: 0; flex: 1;
+  padding: 0 var(--space-md) var(--space-sm);
+}
+.olv-workbench-canvas { flex: 1; min-width: 0; display: block; }
+/* The exact figures for the selected return. A canvas is a picture; this is
+   the readable half of the same information, so it never collapses away. */
+.olv-workbench-detail {
+  width: 216px; flex-shrink: 0; overflow-y: auto;
+  font-size: var(--text-xs); font-variant-numeric: tabular-nums;
+}
+.olv-workbench-detail-row {
+  display: flex; justify-content: space-between; gap: var(--space-sm);
+  padding: var(--space-2xs) 0;
+  border-bottom: 0.5px solid var(--hairline);
+}
+.olv-workbench-detail-key { color: var(--text-faint); }
+.olv-workbench-detail-value { color: var(--text); }
+.olv-workbench-detail-empty { color: var(--text-faint); padding: var(--space-2xs) 0; }
+/* Collapsed shows the header strip only; the body is gone, not merely short. */
+.olv-workbench-collapsed .olv-workbench-body,
+.olv-workbench-collapsed .olv-workbench-status { display: none; }

--- a/src/ui/ProfileWorkbench.ts
+++ b/src/ui/ProfileWorkbench.ts
@@ -1,0 +1,381 @@
+/**
+ * ProfileWorkbench.ts
+ *
+ * The docked Profile Workbench: a plot of the individual returns inside a
+ * measured cross-section, with the exact figures for the selected return
+ * beside it.
+ *
+ * NON-MODAL BY CONTRACT. The workbench exists to inspect a cloud that stays on
+ * screen, so the scene below it keeps rendering, keeps its pointer input, and
+ * keeps its place in the tab order. That rules out every modal device:
+ *
+ *   - no `aria-modal`, and no `dialog` role — the panel is a labelled region;
+ *   - no focus trap, and no focus taken on mount;
+ *   - no backdrop and no blur over the scene;
+ *   - Escape acts only for a key event that arrived from inside the panel, and
+ *     the listener lives on the panel's own root, never on the document, so a
+ *     global Escape binding still sees every press from outside.
+ *
+ * `ResultFocus` remains the modal surface for the compact chart, unchanged.
+ *
+ * Heights are not computed here. Every one of them — opening, dragged,
+ * collapsed, re-derived after a stage resize — comes from
+ * `profileWorkbenchDock.ts`, which owns what the numbers are allowed to be.
+ *
+ * The module reaches the outside world only through the host it is given and
+ * `el()`: no `window`, no `localStorage`, no document-level listeners. That is
+ * what lets the whole panel be driven by a plain object in a test.
+ */
+
+import { el } from './dom';
+import {
+  PROFILE_WORKBENCH_DOCK_KEY,
+  dockOccupiedHeight,
+  maxDockHeight,
+  encodeDockPrefs,
+  resizeDock,
+  restoreDockState,
+  toggleDockCollapsed,
+  type DockLimits,
+  type DockState,
+} from './profileWorkbenchDock';
+
+/** Minimal storage seam — a `Storage` is assignable, a plain object is too. */
+export interface ProfileWorkbenchStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/**
+ * What the workbench needs from whatever is hosting it.
+ *
+ * Structural on purpose: nothing here names the Viewer, a point cloud, or any
+ * render module, so the panel is mounted against a plain object in tests and
+ * against the real stage in the app.
+ */
+export interface ProfileWorkbenchHost {
+  /** The element the dock is appended to. */
+  container(): HTMLElement;
+  /** Height shared between the 3D scene and the dock, in pixels. */
+  stageHeight(): number;
+  /** Subscribe to stage-size changes. Returns the unsubscribe. */
+  onStageResize(cb: () => void): () => void;
+  /** The dock's current occupied height, so the host can resize its canvas. */
+  notifyDockHeight(dockPx: number): void;
+  /** Persisted dock preference. Absent ⇒ the dock opens at its default. */
+  storage?: ProfileWorkbenchStorage;
+  /** True when the user asked for reduced motion. Absent ⇒ treated as false. */
+  prefersReducedMotion?(): boolean;
+}
+
+/** One labelled figure about the selected return. */
+export interface ProfileWorkbenchDetailRow {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface ProfileWorkbenchOptions {
+  /** Region title. Also the panel's accessible name. */
+  readonly title?: string;
+  /** The section the plot covers, shown under the title. */
+  readonly scope?: string;
+  /** Called when the user closes the panel. */
+  readonly onClose?: () => void;
+}
+
+/** What the caller drives the mounted panel through. */
+export interface ProfileWorkbenchHandle {
+  readonly element: HTMLElement;
+  readonly canvas: HTMLCanvasElement;
+  /** Occupied height in pixels, as the dock module derives it. */
+  height(): number;
+  collapsed(): boolean;
+  setCollapsed(collapsed: boolean): void;
+  /** Describe the section the plot covers. */
+  setScope(text: string): void;
+  /** Announce a status politely. */
+  setStatus(text: string): void;
+  /** The selected return's figures, as text. Null clears the selection. */
+  setDetail(rows: readonly ProfileWorkbenchDetailRow[] | null): void;
+  close(): void;
+}
+
+/** Pixels a keyboard nudge moves the splitter. */
+const KEY_RESIZE_STEP = 24;
+
+/** The canvas is a picture of the returns; the numbers live in the detail list. */
+const CANVAS_DESCRIPTION =
+  'Plot of the individual returns across the measured section. Every exact figure is listed in the selected-return details beside it.';
+
+const NO_SELECTION = 'No return selected.';
+
+/**
+ * Mount the workbench into the host's container.
+ *
+ * Opens at the stored height, or this stage's default when nothing usable is
+ * stored. The returned handle is the only way to drive it, and `close()`
+ * leaves the host as it was found — every listener released, the element gone,
+ * and a later mount unaffected.
+ */
+export function mountProfileWorkbench(
+  host: ProfileWorkbenchHost,
+  options: ProfileWorkbenchOptions = {},
+): ProfileWorkbenchHandle {
+  return new ProfileWorkbench(host, options).handle();
+}
+
+class ProfileWorkbench {
+  private readonly _host: ProfileWorkbenchHost;
+  private readonly _options: ProfileWorkbenchOptions;
+  private readonly _root: HTMLElement;
+  private readonly _splitter: HTMLElement;
+  private readonly _scope: HTMLElement;
+  private readonly _status: HTMLElement;
+  private readonly _detail: HTMLElement;
+  private readonly _canvas: HTMLCanvasElement;
+  private readonly _collapseBtn: HTMLButtonElement;
+  private readonly _teardown: (() => void)[] = [];
+  private _state: DockState;
+  private _closed = false;
+  private _dragFrom: number | null = null;
+
+  constructor(host: ProfileWorkbenchHost, options: ProfileWorkbenchOptions) {
+    this._host = host;
+    this._options = options;
+    const title = options.title ?? 'Profile workbench';
+
+    this._state = restoreDockState(
+      host.storage ? host.storage.getItem(PROFILE_WORKBENCH_DOCK_KEY) : null,
+      this._limits(),
+    );
+
+    // The splitter is a real separator, so the height is reachable without a
+    // pointer: the arrow keys move it through the same dock arithmetic a drag
+    // uses, and the value it reports is the height the dock actually occupies.
+    this._splitter = el('div', { className: 'olv-workbench-splitter' });
+    this._splitter.setAttribute('role', 'separator');
+    this._splitter.setAttribute('aria-orientation', 'horizontal');
+    this._splitter.setAttribute('aria-label', 'Resize the profile workbench');
+    this._splitter.setAttribute('tabindex', '0');
+
+    this._scope = el('div', { className: 'olv-workbench-scope', text: options.scope ?? '' });
+    this._collapseBtn = el('button', {
+      className: 'olv-workbench-btn',
+      type: 'button',
+      text: 'Collapse',
+    });
+    const closeBtn = el('button', {
+      className: 'olv-workbench-btn olv-workbench-close',
+      type: 'button',
+      text: 'Close',
+      ariaLabel: 'Close the profile workbench',
+    });
+
+    const head = el('div', { className: 'olv-workbench-head' }, [
+      el('div', { className: 'olv-workbench-titles' }, [
+        el('div', { className: 'olv-workbench-title', text: title }),
+        this._scope,
+      ]),
+      el('div', { className: 'olv-workbench-actions' }, [this._collapseBtn, closeBtn]),
+    ]);
+
+    // Polite, never assertive: a status here reports on a plot the user is
+    // already looking at, and must not cut across what a screen reader is
+    // saying about the scene.
+    this._status = el('div', { className: 'olv-workbench-status' });
+    this._status.setAttribute('role', 'status');
+    this._status.setAttribute('aria-live', 'polite');
+
+    this._canvas = el('canvas', { className: 'olv-workbench-canvas' });
+    this._canvas.setAttribute('role', 'img');
+    this._canvas.setAttribute('aria-label', CANVAS_DESCRIPTION);
+
+    this._detail = el('div', { className: 'olv-workbench-detail' });
+    this._detail.setAttribute('aria-label', 'Selected return');
+    this.setDetail(null);
+
+    const body = el('div', { className: 'olv-workbench-body' }, [this._canvas, this._detail]);
+
+    this._root = el('section', { className: 'olv-workbench' }, [
+      this._splitter,
+      head,
+      this._status,
+      body,
+    ]);
+    // A labelled region, not a dialog: assistive tech can jump to it and out of
+    // it again, and nothing about it says the rest of the app is inert.
+    this._root.setAttribute('role', 'region');
+    this._root.setAttribute('aria-label', title);
+    // Motion is opt-in. With no host opinion, or a stated preference against
+    // it, the height changes land without a transition.
+    if (!this._reducedMotion()) this._root.classList.add('olv-workbench-animate');
+
+    this._on(this._collapseBtn, 'click', () => this.setCollapsed(!this._state.collapsed));
+    this._on(closeBtn, 'click', () => this.close());
+    this._on(this._root, 'keydown', (ev) => this._onKeyDown(ev as KeyboardEvent));
+    this._on(this._splitter, 'keydown', (ev) => this._onSplitterKey(ev as KeyboardEvent));
+    this._on(this._splitter, 'pointerdown', (ev) => this._onPointerDown(ev as PointerEvent));
+    this._on(this._splitter, 'pointermove', (ev) => this._onPointerMove(ev as PointerEvent));
+    this._on(this._splitter, 'pointerup', (ev) => this._onPointerUp(ev as PointerEvent));
+    this._on(this._splitter, 'pointercancel', (ev) => this._onPointerUp(ev as PointerEvent));
+
+    // A stage resize re-derives from the SAME stored preference, so shrinking
+    // the window and growing it again returns the height the user chose rather
+    // than the clamped remnant it passed through.
+    const off = host.onStageResize(() => this._apply());
+    this._teardown.push(off);
+
+    host.container().append(this._root);
+    this._apply();
+  }
+
+  handle(): ProfileWorkbenchHandle {
+    return {
+      element: this._root,
+      canvas: this._canvas,
+      height: () => dockOccupiedHeight(this._state, this._limits()),
+      collapsed: () => this._state.collapsed,
+      setCollapsed: (v: boolean) => this.setCollapsed(v),
+      setScope: (t: string) => {
+        this._scope.textContent = t;
+      },
+      setStatus: (t: string) => {
+        this._status.textContent = t;
+      },
+      setDetail: (rows) => this.setDetail(rows),
+      close: () => this.close(),
+    };
+  }
+
+  setCollapsed(collapsed: boolean): void {
+    if (this._closed || collapsed === this._state.collapsed) return;
+    this._state = toggleDockCollapsed(this._state);
+    this._persist();
+    this._apply();
+    this._status.textContent = this._state.collapsed
+      ? 'Profile workbench collapsed.'
+      : 'Profile workbench restored.';
+  }
+
+  /**
+   * Render the selected return's figures.
+   *
+   * A canvas states nothing an assistive technology can read, so every exact
+   * value the plot shows also exists here as text.
+   */
+  setDetail(rows: readonly ProfileWorkbenchDetailRow[] | null): void {
+    if (!rows || rows.length === 0) {
+      this._detail.replaceChildren(
+        el('div', { className: 'olv-workbench-detail-empty', text: NO_SELECTION }),
+      );
+      return;
+    }
+    this._detail.replaceChildren(
+      ...rows.map((row) =>
+        el('div', { className: 'olv-workbench-detail-row' }, [
+          el('span', { className: 'olv-workbench-detail-key', text: row.label }),
+          el('span', { className: 'olv-workbench-detail-value', text: row.value }),
+        ]),
+      ),
+    );
+  }
+
+  close(): void {
+    if (this._closed) return;
+    this._closed = true;
+    for (const off of this._teardown.splice(0)) off();
+    this._root.remove();
+    this._options.onClose?.();
+  }
+
+  private _limits(): DockLimits {
+    return { stageHeight: this._host.stageHeight() };
+  }
+
+  private _reducedMotion(): boolean {
+    return this._host.prefersReducedMotion ? this._host.prefersReducedMotion() : false;
+  }
+
+  private _on(target: HTMLElement, type: string, fn: (ev: Event) => void): void {
+    target.addEventListener(type, fn as EventListener);
+    this._teardown.push(() => target.removeEventListener(type, fn as EventListener));
+  }
+
+  /** Push the current state to the element, the splitter, and the host. */
+  private _apply(): void {
+    if (this._closed) return;
+    const limits = this._limits();
+    const height = dockOccupiedHeight(this._state, limits);
+    this._root.style.height = `${height}px`;
+    this._root.classList.toggle('olv-workbench-collapsed', this._state.collapsed);
+    this._collapseBtn.textContent = this._state.collapsed ? 'Expand' : 'Collapse';
+    this._collapseBtn.setAttribute('aria-expanded', this._state.collapsed ? 'false' : 'true');
+    this._splitter.setAttribute('aria-valuenow', String(Math.round(height)));
+    this._splitter.setAttribute('aria-valuemin', '0');
+    this._splitter.setAttribute('aria-valuemax', String(Math.round(maxDockHeight(limits))));
+    // The host owns the 3D canvas; it cannot resize what it was not told about.
+    this._host.notifyDockHeight(height);
+  }
+
+  private _persist(): void {
+    this._host.storage?.setItem(PROFILE_WORKBENCH_DOCK_KEY, encodeDockPrefs(this._state));
+  }
+
+  /**
+   * Escape, and only from inside.
+   *
+   * The listener is on the panel's root, so a press anywhere else never
+   * reaches it; the containment check is the second half of the same rule, for
+   * an event routed here by other means. An Escape the panel does act on stops
+   * there rather than also closing whatever else is listening.
+   */
+  private _onKeyDown(ev: KeyboardEvent): void {
+    if (ev.key !== 'Escape') return;
+    const target = ev.target as Node | null;
+    if (!target || !this._root.contains(target)) return;
+    ev.stopPropagation();
+    if (this._state.collapsed) this.close();
+    else this.setCollapsed(true);
+  }
+
+  private _onSplitterKey(ev: KeyboardEvent): void {
+    // A drag upward is a negative screen delta, which is what makes the dock
+    // taller; the arrow keys hand `resizeDock` the same sign.
+    const dy = ev.key === 'ArrowUp' ? -KEY_RESIZE_STEP : ev.key === 'ArrowDown' ? KEY_RESIZE_STEP : 0;
+    if (dy === 0) return;
+    ev.preventDefault();
+    this._resizeBy(dy);
+  }
+
+  private _onPointerDown(ev: PointerEvent): void {
+    this._dragFrom = ev.clientY;
+    this._root.classList.add('olv-workbench-dragging');
+    // Capture on the splitter keeps the drag on this element's own listeners,
+    // so the panel never binds a move handler to the document.
+    this._splitter.setPointerCapture?.(ev.pointerId);
+  }
+
+  private _onPointerMove(ev: PointerEvent): void {
+    if (this._dragFrom === null) return;
+    const dy = ev.clientY - this._dragFrom;
+    if (dy === 0) return;
+    this._dragFrom = ev.clientY;
+    this._resizeBy(dy);
+  }
+
+  private _onPointerUp(ev: PointerEvent): void {
+    if (this._dragFrom === null) return;
+    this._dragFrom = null;
+    this._root.classList.remove('olv-workbench-dragging');
+    this._splitter.releasePointerCapture?.(ev.pointerId);
+    this._persist();
+  }
+
+  /** The one path a height changes by. */
+  private _resizeBy(dy: number): void {
+    if (this._closed) return;
+    this._state = resizeDock(this._state, dy, this._limits());
+    this._persist();
+    this._apply();
+  }
+}

--- a/src/ui/profileWorkbenchDock.ts
+++ b/src/ui/profileWorkbenchDock.ts
@@ -1,0 +1,160 @@
+/**
+ * profileWorkbenchDock.ts
+ *
+ * Geometry and persisted state for the docked Profile Workbench.
+ *
+ * The workbench sits below the stage and shares its height with the 3D
+ * canvas. That makes the split a numeric contract rather than a styling
+ * detail: whatever the user drags, the scene keeps a usable height, because
+ * the workbench exists to inspect a cloud that has to stay visible.
+ *
+ * Pure. No DOM. The panel module owns the elements and the drag events; this
+ * owns what the numbers are allowed to be.
+ */
+
+/** Storage key for the persisted dock preference. */
+export const PROFILE_WORKBENCH_DOCK_KEY = 'olv:measure:profile:workbenchDock:v1';
+
+/** Fraction of the stage the dock takes before a user moves it. */
+export const DEFAULT_DOCK_FRACTION = 0.4;
+
+/** The dock never leaves the scene less than this many pixels. */
+export const MIN_SCENE_HEIGHT = 120;
+
+/** The dock is never shorter than this while open. */
+export const MIN_DOCK_HEIGHT = 140;
+
+/** Height of the collapsed dock, which shows its header only. */
+export const COLLAPSED_DOCK_HEIGHT = 36;
+
+export interface DockLimits {
+  /** Total height available to the stage and the dock together. */
+  readonly stageHeight: number;
+}
+
+export interface DockState {
+  /** Open height in pixels. Retained while collapsed so restore returns to it. */
+  readonly heightPx: number;
+  readonly collapsed: boolean;
+}
+
+function finite(v: number): boolean {
+  return Number.isFinite(v);
+}
+
+/**
+ * The largest open height that still leaves the scene {@link MIN_SCENE_HEIGHT}.
+ *
+ * Falls back to the minimum dock height when the stage is too short to
+ * satisfy both, so a small window yields a cramped layout rather than a
+ * negative one.
+ */
+export function maxDockHeight(limits: DockLimits): number {
+  const stage = finite(limits.stageHeight) ? limits.stageHeight : 0;
+  const room = stage - MIN_SCENE_HEIGHT;
+  return room < MIN_DOCK_HEIGHT ? MIN_DOCK_HEIGHT : room;
+}
+
+/** Clamp an open height into the range this stage allows. */
+export function clampDockHeight(heightPx: number, limits: DockLimits): number {
+  const max = maxDockHeight(limits);
+  if (!finite(heightPx)) return Math.min(defaultDockHeight(limits), max);
+  return Math.min(max, Math.max(MIN_DOCK_HEIGHT, heightPx));
+}
+
+/** The opening height for a stage the user has expressed no preference for. */
+export function defaultDockHeight(limits: DockLimits): number {
+  const stage = finite(limits.stageHeight) ? limits.stageHeight : 0;
+  const max = maxDockHeight(limits);
+  return Math.min(max, Math.max(MIN_DOCK_HEIGHT, Math.round(stage * DEFAULT_DOCK_FRACTION)));
+}
+
+/** The height the dock actually occupies, collapsed or not. */
+export function dockOccupiedHeight(state: DockState, limits: DockLimits): number {
+  return state.collapsed ? COLLAPSED_DOCK_HEIGHT : clampDockHeight(state.heightPx, limits);
+}
+
+/**
+ * The height left for the 3D scene.
+ *
+ * Never returns a negative value, and never zero while the stage has any
+ * height at all, because the scene stays interactive with the dock open.
+ */
+export function sceneHeightFor(state: DockState, limits: DockLimits): number {
+  const stage = finite(limits.stageHeight) && limits.stageHeight > 0 ? limits.stageHeight : 0;
+  return Math.max(0, stage - dockOccupiedHeight(state, limits));
+}
+
+/**
+ * Apply a splitter drag.
+ *
+ * The splitter sits on top of the dock, so dragging it upward by `dy` pixels
+ * (a negative screen delta) makes the dock taller. A drag while collapsed
+ * reopens the dock at the dragged height.
+ */
+export function resizeDock(state: DockState, dyPx: number, limits: DockLimits): DockState {
+  const dy = finite(dyPx) ? dyPx : 0;
+  const from = state.collapsed ? COLLAPSED_DOCK_HEIGHT : state.heightPx;
+  return { heightPx: clampDockHeight(from - dy, limits), collapsed: false };
+}
+
+/** Collapse to the header, or restore the retained open height. */
+export function toggleDockCollapsed(state: DockState): DockState {
+  return { heightPx: state.heightPx, collapsed: !state.collapsed };
+}
+
+/** The state a stage with no stored preference starts in. */
+export function initialDockState(limits: DockLimits): DockState {
+  return { heightPx: defaultDockHeight(limits), collapsed: false };
+}
+
+/**
+ * Re-fit a state to a resized stage.
+ *
+ * The stored height is clamped rather than replaced, so shrinking a window
+ * and growing it again returns the user's own height instead of the default.
+ */
+export function refitDock(state: DockState, limits: DockLimits): DockState {
+  return { heightPx: clampDockHeight(state.heightPx, limits), collapsed: state.collapsed };
+}
+
+export interface PersistedDock {
+  readonly heightPx: number;
+  readonly collapsed: boolean;
+}
+
+/** Serialise the preference. Stores the open height even while collapsed. */
+export function encodeDockPrefs(state: DockState): string {
+  return JSON.stringify({ heightPx: state.heightPx, collapsed: state.collapsed });
+}
+
+/**
+ * Read a stored preference.
+ *
+ * Returns null for anything that is absent, unparseable, or not shaped like a
+ * preference. A corrupt entry opens the workbench at its default rather than
+ * throwing inside the panel's construction.
+ */
+export function decodeDockPrefs(raw: string | null): PersistedDock | null {
+  if (raw == null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const rec = parsed as Record<string, unknown>;
+  const h = rec.heightPx;
+  const c = rec.collapsed;
+  if (typeof h !== 'number' || !Number.isFinite(h) || h <= 0) return null;
+  if (typeof c !== 'boolean') return null;
+  return { heightPx: h, collapsed: c };
+}
+
+/** Restore a state for this stage, falling back to the default. */
+export function restoreDockState(raw: string | null, limits: DockLimits): DockState {
+  const stored = decodeDockPrefs(raw);
+  if (!stored) return initialDockState(limits);
+  return { heightPx: clampDockHeight(stored.heightPx, limits), collapsed: stored.collapsed };
+}

--- a/src/ui/profileWorkbenchDock.ts
+++ b/src/ui/profileWorkbenchDock.ts
@@ -21,8 +21,18 @@ export const DEFAULT_DOCK_FRACTION = 0.4;
 /** The dock never leaves the scene less than this many pixels. */
 export const MIN_SCENE_HEIGHT = 120;
 
-/** The dock is never shorter than this while open. */
+/** The dock's preferred minimum while open, on a stage that can afford it. */
 export const MIN_DOCK_HEIGHT = 140;
+
+/**
+ * The dock's share of a stage too short to give it {@link MIN_DOCK_HEIGHT}
+ * and the scene {@link MIN_SCENE_HEIGHT} at once.
+ *
+ * Below that size the minimums cannot both hold, and preferring the dock
+ * would leave the scene nothing at all. Splitting instead keeps both
+ * present, which is what lets the user drag back out.
+ */
+export const TIGHT_STAGE_DOCK_FRACTION = 0.5;
 
 /** Height of the collapsed dock, which shows its header only. */
 export const COLLAPSED_DOCK_HEIGHT = 36;
@@ -33,8 +43,15 @@ export interface DockLimits {
 }
 
 export interface DockState {
-  /** Open height in pixels. Retained while collapsed so restore returns to it. */
-  readonly heightPx: number;
+  /**
+   * The height the user asked for, in pixels.
+   *
+   * Retained exactly as expressed, including while collapsed and while the
+   * stage is too small to honour it. The height the dock actually occupies
+   * is derived on read by {@link dockOccupiedHeight}, so shrinking a window
+   * and growing it again returns this value rather than a clamped remnant.
+   */
+  readonly preferredHeightPx: number;
   readonly collapsed: boolean;
 }
 
@@ -45,40 +62,58 @@ function finite(v: number): boolean {
 /**
  * The largest open height that still leaves the scene {@link MIN_SCENE_HEIGHT}.
  *
- * Falls back to the minimum dock height when the stage is too short to
- * satisfy both, so a small window yields a cramped layout rather than a
- * negative one.
+ * A stage too short to satisfy both minimums splits instead, so the scene
+ * keeps a share at every stage size rather than being squeezed out by the
+ * dock's own minimum.
  */
 export function maxDockHeight(limits: DockLimits): number {
-  const stage = finite(limits.stageHeight) ? limits.stageHeight : 0;
+  const stage = finite(limits.stageHeight) && limits.stageHeight > 0 ? limits.stageHeight : 0;
+  if (stage <= 0) return 0;
   const room = stage - MIN_SCENE_HEIGHT;
-  return room < MIN_DOCK_HEIGHT ? MIN_DOCK_HEIGHT : room;
+  if (room >= MIN_DOCK_HEIGHT) return room;
+  return Math.floor(stage * TIGHT_STAGE_DOCK_FRACTION);
 }
 
-/** Clamp an open height into the range this stage allows. */
+/**
+ * Clamp an open height into the range this stage allows.
+ *
+ * The lower bound yields to the upper one, so a stage whose whole allowance
+ * is below {@link MIN_DOCK_HEIGHT} produces a height inside its allowance
+ * rather than one above it.
+ */
 export function clampDockHeight(heightPx: number, limits: DockLimits): number {
   const max = maxDockHeight(limits);
-  if (!finite(heightPx)) return Math.min(defaultDockHeight(limits), max);
-  return Math.min(max, Math.max(MIN_DOCK_HEIGHT, heightPx));
+  const min = Math.min(MIN_DOCK_HEIGHT, max);
+  if (!finite(heightPx)) return Math.min(Math.max(min, defaultDockHeight(limits)), max);
+  return Math.min(max, Math.max(min, heightPx));
 }
 
 /** The opening height for a stage the user has expressed no preference for. */
 export function defaultDockHeight(limits: DockLimits): number {
-  const stage = finite(limits.stageHeight) ? limits.stageHeight : 0;
+  const stage = finite(limits.stageHeight) && limits.stageHeight > 0 ? limits.stageHeight : 0;
   const max = maxDockHeight(limits);
-  return Math.min(max, Math.max(MIN_DOCK_HEIGHT, Math.round(stage * DEFAULT_DOCK_FRACTION)));
+  const min = Math.min(MIN_DOCK_HEIGHT, max);
+  return Math.min(max, Math.max(min, Math.round(stage * DEFAULT_DOCK_FRACTION)));
 }
 
-/** The height the dock actually occupies, collapsed or not. */
+/**
+ * The height the dock actually occupies on this stage.
+ *
+ * A collapsed dock shows its header, and even that yields to a stage too
+ * short to hold it beside a scene.
+ */
 export function dockOccupiedHeight(state: DockState, limits: DockLimits): number {
-  return state.collapsed ? COLLAPSED_DOCK_HEIGHT : clampDockHeight(state.heightPx, limits);
+  const max = maxDockHeight(limits);
+  return state.collapsed
+    ? Math.min(COLLAPSED_DOCK_HEIGHT, max)
+    : clampDockHeight(state.preferredHeightPx, limits);
 }
 
 /**
  * The height left for the 3D scene.
  *
- * Never returns a negative value, and never zero while the stage has any
- * height at all, because the scene stays interactive with the dock open.
+ * Positive whenever the stage has any height at all, since the scene stays
+ * interactive with the dock open. The dock's own minimum yields to this.
  */
 export function sceneHeightFor(state: DockState, limits: DockLimits): number {
   const stage = finite(limits.stageHeight) && limits.stageHeight > 0 ? limits.stageHeight : 0;
@@ -94,28 +129,27 @@ export function sceneHeightFor(state: DockState, limits: DockLimits): number {
  */
 export function resizeDock(state: DockState, dyPx: number, limits: DockLimits): DockState {
   const dy = finite(dyPx) ? dyPx : 0;
-  const from = state.collapsed ? COLLAPSED_DOCK_HEIGHT : state.heightPx;
-  return { heightPx: clampDockHeight(from - dy, limits), collapsed: false };
+  if (state.collapsed) {
+    // A collapsed dock shows only its header, so a downward drag has nothing
+    // to shrink. Reopening on one would move the dock opposite the gesture.
+    if (dy >= 0) return state;
+    return {
+      preferredHeightPx: clampDockHeight(COLLAPSED_DOCK_HEIGHT - dy, limits),
+      collapsed: false,
+    };
+  }
+  const from = dockOccupiedHeight(state, limits);
+  return { preferredHeightPx: clampDockHeight(from - dy, limits), collapsed: false };
 }
 
 /** Collapse to the header, or restore the retained open height. */
 export function toggleDockCollapsed(state: DockState): DockState {
-  return { heightPx: state.heightPx, collapsed: !state.collapsed };
+  return { preferredHeightPx: state.preferredHeightPx, collapsed: !state.collapsed };
 }
 
 /** The state a stage with no stored preference starts in. */
 export function initialDockState(limits: DockLimits): DockState {
-  return { heightPx: defaultDockHeight(limits), collapsed: false };
-}
-
-/**
- * Re-fit a state to a resized stage.
- *
- * The stored height is clamped rather than replaced, so shrinking a window
- * and growing it again returns the user's own height instead of the default.
- */
-export function refitDock(state: DockState, limits: DockLimits): DockState {
-  return { heightPx: clampDockHeight(state.heightPx, limits), collapsed: state.collapsed };
+  return { preferredHeightPx: defaultDockHeight(limits), collapsed: false };
 }
 
 export interface PersistedDock {
@@ -125,7 +159,7 @@ export interface PersistedDock {
 
 /** Serialise the preference. Stores the open height even while collapsed. */
 export function encodeDockPrefs(state: DockState): string {
-  return JSON.stringify({ heightPx: state.heightPx, collapsed: state.collapsed });
+  return JSON.stringify({ heightPx: state.preferredHeightPx, collapsed: state.collapsed });
 }
 
 /**
@@ -152,9 +186,15 @@ export function decodeDockPrefs(raw: string | null): PersistedDock | null {
   return { heightPx: h, collapsed: c };
 }
 
-/** Restore a state for this stage, falling back to the default. */
+/**
+ * Restore a state, falling back to this stage's default.
+ *
+ * The stored height is kept as expressed rather than clamped on the way in,
+ * so opening on a small screen and returning to a large one restores the
+ * height the user chose.
+ */
 export function restoreDockState(raw: string | null, limits: DockLimits): DockState {
   const stored = decodeDockPrefs(raw);
   if (!stored) return initialDockState(limits);
-  return { heightPx: clampDockHeight(stored.heightPx, limits), collapsed: stored.collapsed };
+  return { preferredHeightPx: stored.heightPx, collapsed: stored.collapsed };
 }

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -4948,6 +4948,86 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   transition: color var(--dur-fast) var(--ease-standard), border-color var(--dur-fast) var(--ease-standard);
 }
 
+
+/* ── Profile Workbench ──────────────────────────────────────────────────────
+   The docked cross-section workbench. It sits UNDER the stage and shares the
+   stage's height with the 3D canvas, so it is a block in the flow, not an
+   overlay: nothing here dims, blurs, or covers the scene, because the scene
+   stays interactive while the workbench is open. Its height is set inline from
+   `profileWorkbenchDock.ts`; the rules below own everything except that. */
+.olv-workbench {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--panel-raised);
+  border-top: 0.5px solid var(--hairline-strong);
+  box-shadow: var(--shadow-raised);
+}
+/* Motion is opt-in: the panel only carries this class when the host reports no
+   reduced-motion preference, and the media query is the second guard for a
+   preference that changes after mount. */
+.olv-workbench-animate { transition: height var(--dur-fast) var(--ease-standard); }
+@media (prefers-reduced-motion: reduce) {
+  .olv-workbench-animate { transition: none; }
+}
+/* The splitter is the top edge itself — a thin grab strip with a comfortable
+   hit area, keyboard-focusable because the arrow keys resize the dock too. */
+.olv-workbench-splitter {
+  position: absolute; top: 0; left: 0; right: 0;
+  height: 8px; cursor: row-resize;
+  touch-action: none;
+}
+.olv-workbench-splitter:hover,
+.olv-workbench-splitter:focus-visible { background: var(--hairline-strong); }
+.olv-workbench-dragging { user-select: none; }
+.olv-workbench-head {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md) var(--space-xs);
+  flex-shrink: 0;
+}
+.olv-workbench-titles { min-width: 0; }
+.olv-workbench-title { font-size: var(--text-sm); color: var(--text); }
+.olv-workbench-scope {
+  font-size: var(--text-xs); color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+.olv-workbench-actions { display: flex; gap: var(--space-xs); flex-shrink: 0; }
+.olv-workbench-btn {
+  font-size: var(--text-xs); color: var(--text-dim);
+  background: rgba(255, 255, 255, 0.04);
+  border: 0.5px solid var(--hairline);
+  border-radius: var(--radius-sm); padding: var(--space-2xs) var(--space-sm);
+}
+.olv-workbench-btn:hover { color: var(--text); }
+.olv-workbench-status {
+  padding: 0 var(--space-md) var(--space-2xs);
+  font-size: var(--text-xs); color: var(--text-faint);
+}
+.olv-workbench-body {
+  display: flex; gap: var(--space-md); min-height: 0; flex: 1;
+  padding: 0 var(--space-md) var(--space-sm);
+}
+.olv-workbench-canvas { flex: 1; min-width: 0; display: block; }
+/* The exact figures for the selected return. A canvas is a picture; this is
+   the readable half of the same information, so it never collapses away. */
+.olv-workbench-detail {
+  width: 216px; flex-shrink: 0; overflow-y: auto;
+  font-size: var(--text-xs); font-variant-numeric: tabular-nums;
+}
+.olv-workbench-detail-row {
+  display: flex; justify-content: space-between; gap: var(--space-sm);
+  padding: var(--space-2xs) 0;
+  border-bottom: 0.5px solid var(--hairline);
+}
+.olv-workbench-detail-key { color: var(--text-faint); }
+.olv-workbench-detail-value { color: var(--text); }
+.olv-workbench-detail-empty { color: var(--text-faint); padding: var(--space-2xs) 0; }
+/* Collapsed shows the header strip only; the body is gone, not merely short. */
+.olv-workbench-collapsed .olv-workbench-body,
+.olv-workbench-collapsed .olv-workbench-status { display: none; }
 /* ── Classification legend panel ─────────────────────────────────────────── */
 .olv-class-panel {
   /* 248px (was 218): the class name shares the row with a wide point count and

--- a/tests/profileWorkbenchDock.test.ts
+++ b/tests/profileWorkbenchDock.test.ts
@@ -3,8 +3,8 @@
  *
  * The dock shares the stage's height with the 3D canvas, so "the scene stays
  * visible with the workbench open" is a number, not a styling intention.
- * These hold that number at every stage size, including ones too small to
- * satisfy everything.
+ * These hold that number at every stage size, including sizes too small to
+ * satisfy the dock's own minimum.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -16,7 +16,6 @@ import {
   resizeDock,
   toggleDockCollapsed,
   initialDockState,
-  refitDock,
   encodeDockPrefs,
   decodeDockPrefs,
   restoreDockState,
@@ -28,18 +27,28 @@ import {
 } from '../src/ui/profileWorkbenchDock';
 
 const stage = (h: number) => ({ stageHeight: h });
+const SIZES = [1, 2, 20, 36, 100, 140, 141, 200, 259, 260, 261, 400, 720, 1080, 2160, 8000];
 
 describe('the scene keeps height whatever the dock does', () => {
-  const SIZES = [0, 1, 100, 200, 260, 400, 720, 1080, 2160, 8000];
-
-  it('never leaves the scene negative', () => {
+  it('leaves the scene a positive height at every stage with any height', () => {
+    // Regression: a stage at or below the dock's own minimum used to hand the
+    // dock everything and leave the canvas a zero-height buffer, which no
+    // drag could recover from.
     for (const h of SIZES) {
       for (const collapsed of [false, true]) {
-        for (const want of [-1e6, 0, 1, 200, 1e6, Number.NaN]) {
-          const s: DockState = { heightPx: want, collapsed };
-          expect(sceneHeightFor(s, stage(h))).toBeGreaterThanOrEqual(0);
+        for (const want of [-1e6, 0, 1, 200, 5000, 1e6, Number.NaN]) {
+          const s: DockState = { preferredHeightPx: want, collapsed };
+          const scene = sceneHeightFor(s, stage(h));
+          expect(scene).toBeGreaterThan(0);
+          expect(Number.isFinite(scene)).toBe(true);
         }
       }
+    }
+  });
+
+  it('returns zero only for a stage with no height', () => {
+    for (const h of [0, -10, Number.NaN]) {
+      expect(sceneHeightFor({ preferredHeightPx: 400, collapsed: false }, stage(h))).toBe(0);
     }
   });
 
@@ -47,26 +56,35 @@ describe('the scene keeps height whatever the dock does', () => {
     for (const h of SIZES) {
       if (h < MIN_SCENE_HEIGHT + MIN_DOCK_HEIGHT) continue;
       const open = clampDockHeight(Number.POSITIVE_INFINITY, stage(h));
-      expect(sceneHeightFor({ heightPx: open, collapsed: false }, stage(h))).toBeGreaterThanOrEqual(
-        MIN_SCENE_HEIGHT,
-      );
+      expect(
+        sceneHeightFor({ preferredHeightPx: open, collapsed: false }, stage(h)),
+      ).toBeGreaterThanOrEqual(MIN_SCENE_HEIGHT);
     }
   });
 
-  it('yields a cramped layout rather than a negative one on a tiny stage', () => {
-    // 200 px cannot give the dock 140 and the scene 120 at once.
+  it('splits a stage too short for both minimums', () => {
+    // 200 cannot give the dock 140 and the scene 120 at once.
     const s = initialDockState(stage(200));
-    expect(dockOccupiedHeight(s, stage(200))).toBe(MIN_DOCK_HEIGHT);
-    expect(sceneHeightFor(s, stage(200))).toBe(60);
+    expect(dockOccupiedHeight(s, stage(200))).toBe(100);
+    expect(sceneHeightFor(s, stage(200))).toBe(100);
+    // 140 is exactly the dock minimum, and still leaves the scene half.
+    const t = initialDockState(stage(140));
+    expect(dockOccupiedHeight(t, stage(140))).toBe(70);
+    expect(sceneHeightFor(t, stage(140))).toBe(70);
   });
 
   it('adds up to the stage exactly', () => {
     for (const h of SIZES) {
       const s = initialDockState(stage(h));
-      const total = dockOccupiedHeight(s, stage(h)) + sceneHeightFor(s, stage(h));
-      if (h >= MIN_SCENE_HEIGHT + MIN_DOCK_HEIGHT) expect(total).toBe(h);
-      else expect(total).toBeGreaterThanOrEqual(h);
+      expect(dockOccupiedHeight(s, stage(h)) + sceneHeightFor(s, stage(h))).toBe(h);
     }
+  });
+
+  it('shrinks even the collapsed header on a stage that cannot hold it', () => {
+    const s: DockState = { preferredHeightPx: 400, collapsed: true };
+    expect(dockOccupiedHeight(s, stage(1000))).toBe(COLLAPSED_DOCK_HEIGHT);
+    expect(dockOccupiedHeight(s, stage(40))).toBe(20);
+    expect(sceneHeightFor(s, stage(40))).toBe(20);
   });
 });
 
@@ -75,12 +93,8 @@ describe('default height', () => {
     expect(defaultDockHeight(stage(1000))).toBe(Math.round(1000 * DEFAULT_DOCK_FRACTION));
   });
 
-  it('never opens below the dock minimum', () => {
-    expect(defaultDockHeight(stage(300))).toBeGreaterThanOrEqual(MIN_DOCK_HEIGHT);
-  });
-
-  it('never opens past what the stage can spare', () => {
-    for (const h of [200, 300, 500, 1000]) {
+  it('never exceeds what the stage can spare', () => {
+    for (const h of SIZES) {
       expect(defaultDockHeight(stage(h))).toBeLessThanOrEqual(maxDockHeight(stage(h)));
     }
   });
@@ -90,97 +104,95 @@ describe('splitter drag', () => {
   const limits = stage(1000);
 
   it('grows the dock when dragged upward', () => {
-    const s: DockState = { heightPx: 400, collapsed: false };
-    expect(resizeDock(s, -50, limits).heightPx).toBe(450);
+    expect(resizeDock({ preferredHeightPx: 400, collapsed: false }, -50, limits).preferredHeightPx)
+      .toBe(450);
   });
 
   it('shrinks the dock when dragged downward', () => {
-    const s: DockState = { heightPx: 400, collapsed: false };
-    expect(resizeDock(s, 50, limits).heightPx).toBe(350);
+    expect(resizeDock({ preferredHeightPx: 400, collapsed: false }, 50, limits).preferredHeightPx)
+      .toBe(350);
   });
 
   it('clamps rather than letting a drag eat the scene', () => {
-    const s: DockState = { heightPx: 400, collapsed: false };
+    const s: DockState = { preferredHeightPx: 400, collapsed: false };
     const huge = resizeDock(s, -100000, limits);
-    expect(huge.heightPx).toBe(maxDockHeight(limits));
+    expect(huge.preferredHeightPx).toBe(maxDockHeight(limits));
     expect(sceneHeightFor(huge, limits)).toBe(MIN_SCENE_HEIGHT);
-    const tiny = resizeDock(s, 100000, limits);
-    expect(tiny.heightPx).toBe(MIN_DOCK_HEIGHT);
+    expect(resizeDock(s, 100000, limits).preferredHeightPx).toBe(MIN_DOCK_HEIGHT);
   });
 
-  it('reopens a collapsed dock at the dragged height', () => {
-    const s: DockState = { heightPx: 400, collapsed: true };
-    const out = resizeDock(s, -100, limits);
-    expect(out.collapsed).toBe(false);
-    expect(out.heightPx).toBe(clampDockHeight(COLLAPSED_DOCK_HEIGHT + 100, limits));
+  it('reopens a collapsed dock only on an upward drag', () => {
+    const s: DockState = { preferredHeightPx: 400, collapsed: true };
+    const up = resizeDock(s, -100, limits);
+    expect(up.collapsed).toBe(false);
+    expect(up.preferredHeightPx).toBe(clampDockHeight(COLLAPSED_DOCK_HEIGHT + 100, limits));
+  });
+
+  it('leaves a collapsed dock alone when dragged downward', () => {
+    // Regression: a downward drag used to reopen the dock and grow it from
+    // the header to the minimum, moving the surface opposite the gesture.
+    const s: DockState = { preferredHeightPx: 400, collapsed: true };
+    for (const dy of [0, 1, 10, 50, 100, 1000]) {
+      expect(resizeDock(s, dy, limits)).toEqual(s);
+    }
+  });
+
+  it('drags from the height on screen, not from an unhonoured preference', () => {
+    // On a stage too small for the preference, the surface must follow the
+    // pointer from where it actually sits.
+    const small = stage(400);
+    const s: DockState = { preferredHeightPx: 5000, collapsed: false };
+    const shown = dockOccupiedHeight(s, small);
+    expect(resizeDock(s, 40, small).preferredHeightPx).toBe(clampDockHeight(shown - 40, small));
   });
 
   it('ignores a non-finite delta', () => {
-    const s: DockState = { heightPx: 400, collapsed: false };
-    expect(resizeDock(s, Number.NaN, limits).heightPx).toBe(400);
+    expect(resizeDock({ preferredHeightPx: 400, collapsed: false }, Number.NaN, limits)
+      .preferredHeightPx).toBe(400);
   });
 });
 
 describe('collapse', () => {
   it('retains the open height so restore returns to it', () => {
-    const open: DockState = { heightPx: 512, collapsed: false };
+    const open: DockState = { preferredHeightPx: 512, collapsed: false };
     const collapsed = toggleDockCollapsed(open);
-    expect(collapsed.collapsed).toBe(true);
-    expect(collapsed.heightPx).toBe(512);
-    const restored = toggleDockCollapsed(collapsed);
-    expect(restored).toEqual(open);
-  });
-
-  it('occupies only the header while collapsed', () => {
-    const s: DockState = { heightPx: 512, collapsed: true };
-    expect(dockOccupiedHeight(s, stage(1000))).toBe(COLLAPSED_DOCK_HEIGHT);
-    expect(sceneHeightFor(s, stage(1000))).toBe(1000 - COLLAPSED_DOCK_HEIGHT);
+    expect(collapsed).toEqual({ preferredHeightPx: 512, collapsed: true });
+    expect(toggleDockCollapsed(collapsed)).toEqual(open);
   });
 });
 
 describe('stage resize', () => {
-  it('returns the user height when the stage grows back', () => {
-    const chosen: DockState = { heightPx: 600, collapsed: false };
-    const shrunk = refitDock(chosen, stage(400));
-    expect(shrunk.heightPx).toBeLessThan(600);
-    // Refitting the ORIGINAL preference to the restored stage gives it back.
-    const regrown = refitDock(chosen, stage(1200));
-    expect(regrown.heightPx).toBe(600);
+  it('returns the user height after any sequence of stage sizes', () => {
+    // Regression: the preference used to be clamped in place, so shrinking
+    // the window and growing it again left the clamped remnant behind.
+    const chosen: DockState = { preferredHeightPx: 600, collapsed: false };
+    expect(dockOccupiedHeight(chosen, stage(400))).toBeLessThan(600);
+    expect(dockOccupiedHeight(chosen, stage(1200))).toBe(600);
+    for (const h of SIZES) dockOccupiedHeight(chosen, stage(h));
+    expect(chosen.preferredHeightPx).toBe(600);
+    expect(dockOccupiedHeight(chosen, stage(1200))).toBe(600);
   });
 
   it('keeps the collapsed flag across a resize', () => {
-    expect(refitDock({ heightPx: 600, collapsed: true }, stage(300)).collapsed).toBe(true);
+    const s: DockState = { preferredHeightPx: 600, collapsed: true };
+    expect(dockOccupiedHeight(s, stage(300))).toBe(COLLAPSED_DOCK_HEIGHT);
+    expect(s.collapsed).toBe(true);
   });
 });
 
 describe('persistence', () => {
   it('round trips', () => {
-    const s: DockState = { heightPx: 377, collapsed: true };
+    const s: DockState = { preferredHeightPx: 377, collapsed: true };
     expect(decodeDockPrefs(encodeDockPrefs(s))).toEqual({ heightPx: 377, collapsed: true });
-  });
-
-  it('stores the open height even while collapsed', () => {
-    const s: DockState = { heightPx: 377, collapsed: true };
-    expect(decodeDockPrefs(encodeDockPrefs(s))!.heightPx).toBe(377);
   });
 
   it('rejects anything that is not a preference, without throwing', () => {
     for (const raw of [
-      null,
-      '',
-      'not json',
-      '[]',
-      'null',
-      '"str"',
-      '42',
-      '{}',
-      '{"heightPx":400}',
-      '{"collapsed":true}',
-      '{"heightPx":"400","collapsed":true}',
-      '{"heightPx":400,"collapsed":"yes"}',
-      '{"heightPx":null,"collapsed":false}',
-      '{"heightPx":0,"collapsed":false}',
-      '{"heightPx":-10,"collapsed":false}',
+      null, '', 'not json', '[]', 'null', '"str"', '42', '{}',
+      '{"heightPx":400}', '{"collapsed":true}',
+      '{"heightPx":"400","collapsed":true}', '{"heightPx":400,"collapsed":"yes"}',
+      '{"heightPx":null,"collapsed":false}', '{"heightPx":0,"collapsed":false}',
+      '{"heightPx":-10,"collapsed":false}', '{"heightPx":1e999,"collapsed":false}',
     ]) {
       expect(decodeDockPrefs(raw)).toBeNull();
     }
@@ -191,14 +203,14 @@ describe('persistence', () => {
     expect(restoreDockState(null, stage(1000))).toEqual(initialDockState(stage(1000)));
   });
 
-  it('clamps a stored height that no longer fits', () => {
-    const raw = encodeDockPrefs({ heightPx: 5000, collapsed: false });
+  it('keeps a stored height that no longer fits, and honours it again later', () => {
+    // Regression: restoring on a small stage used to overwrite the stored
+    // height with the clamped one, losing it for every later stage.
+    const raw = encodeDockPrefs({ preferredHeightPx: 900, collapsed: false });
     const s = restoreDockState(raw, stage(600));
-    expect(s.heightPx).toBe(maxDockHeight(stage(600)));
+    expect(s.preferredHeightPx).toBe(900);
+    expect(dockOccupiedHeight(s, stage(600))).toBe(maxDockHeight(stage(600)));
     expect(sceneHeightFor(s, stage(600))).toBe(MIN_SCENE_HEIGHT);
-  });
-
-  it('rejects a non-finite stored height', () => {
-    expect(decodeDockPrefs('{"heightPx":1e999,"collapsed":false}')).toBeNull();
+    expect(dockOccupiedHeight(s, stage(2000))).toBe(900);
   });
 });

--- a/tests/profileWorkbenchDock.test.ts
+++ b/tests/profileWorkbenchDock.test.ts
@@ -1,0 +1,204 @@
+/**
+ * profileWorkbenchDock.test.ts
+ *
+ * The dock shares the stage's height with the 3D canvas, so "the scene stays
+ * visible with the workbench open" is a number, not a styling intention.
+ * These hold that number at every stage size, including ones too small to
+ * satisfy everything.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  clampDockHeight,
+  defaultDockHeight,
+  maxDockHeight,
+  dockOccupiedHeight,
+  sceneHeightFor,
+  resizeDock,
+  toggleDockCollapsed,
+  initialDockState,
+  refitDock,
+  encodeDockPrefs,
+  decodeDockPrefs,
+  restoreDockState,
+  MIN_DOCK_HEIGHT,
+  MIN_SCENE_HEIGHT,
+  COLLAPSED_DOCK_HEIGHT,
+  DEFAULT_DOCK_FRACTION,
+  type DockState,
+} from '../src/ui/profileWorkbenchDock';
+
+const stage = (h: number) => ({ stageHeight: h });
+
+describe('the scene keeps height whatever the dock does', () => {
+  const SIZES = [0, 1, 100, 200, 260, 400, 720, 1080, 2160, 8000];
+
+  it('never leaves the scene negative', () => {
+    for (const h of SIZES) {
+      for (const collapsed of [false, true]) {
+        for (const want of [-1e6, 0, 1, 200, 1e6, Number.NaN]) {
+          const s: DockState = { heightPx: want, collapsed };
+          expect(sceneHeightFor(s, stage(h))).toBeGreaterThanOrEqual(0);
+        }
+      }
+    }
+  });
+
+  it('keeps the documented scene minimum whenever the stage can afford it', () => {
+    for (const h of SIZES) {
+      if (h < MIN_SCENE_HEIGHT + MIN_DOCK_HEIGHT) continue;
+      const open = clampDockHeight(Number.POSITIVE_INFINITY, stage(h));
+      expect(sceneHeightFor({ heightPx: open, collapsed: false }, stage(h))).toBeGreaterThanOrEqual(
+        MIN_SCENE_HEIGHT,
+      );
+    }
+  });
+
+  it('yields a cramped layout rather than a negative one on a tiny stage', () => {
+    // 200 px cannot give the dock 140 and the scene 120 at once.
+    const s = initialDockState(stage(200));
+    expect(dockOccupiedHeight(s, stage(200))).toBe(MIN_DOCK_HEIGHT);
+    expect(sceneHeightFor(s, stage(200))).toBe(60);
+  });
+
+  it('adds up to the stage exactly', () => {
+    for (const h of SIZES) {
+      const s = initialDockState(stage(h));
+      const total = dockOccupiedHeight(s, stage(h)) + sceneHeightFor(s, stage(h));
+      if (h >= MIN_SCENE_HEIGHT + MIN_DOCK_HEIGHT) expect(total).toBe(h);
+      else expect(total).toBeGreaterThanOrEqual(h);
+    }
+  });
+});
+
+describe('default height', () => {
+  it('takes the documented fraction of a roomy stage', () => {
+    expect(defaultDockHeight(stage(1000))).toBe(Math.round(1000 * DEFAULT_DOCK_FRACTION));
+  });
+
+  it('never opens below the dock minimum', () => {
+    expect(defaultDockHeight(stage(300))).toBeGreaterThanOrEqual(MIN_DOCK_HEIGHT);
+  });
+
+  it('never opens past what the stage can spare', () => {
+    for (const h of [200, 300, 500, 1000]) {
+      expect(defaultDockHeight(stage(h))).toBeLessThanOrEqual(maxDockHeight(stage(h)));
+    }
+  });
+});
+
+describe('splitter drag', () => {
+  const limits = stage(1000);
+
+  it('grows the dock when dragged upward', () => {
+    const s: DockState = { heightPx: 400, collapsed: false };
+    expect(resizeDock(s, -50, limits).heightPx).toBe(450);
+  });
+
+  it('shrinks the dock when dragged downward', () => {
+    const s: DockState = { heightPx: 400, collapsed: false };
+    expect(resizeDock(s, 50, limits).heightPx).toBe(350);
+  });
+
+  it('clamps rather than letting a drag eat the scene', () => {
+    const s: DockState = { heightPx: 400, collapsed: false };
+    const huge = resizeDock(s, -100000, limits);
+    expect(huge.heightPx).toBe(maxDockHeight(limits));
+    expect(sceneHeightFor(huge, limits)).toBe(MIN_SCENE_HEIGHT);
+    const tiny = resizeDock(s, 100000, limits);
+    expect(tiny.heightPx).toBe(MIN_DOCK_HEIGHT);
+  });
+
+  it('reopens a collapsed dock at the dragged height', () => {
+    const s: DockState = { heightPx: 400, collapsed: true };
+    const out = resizeDock(s, -100, limits);
+    expect(out.collapsed).toBe(false);
+    expect(out.heightPx).toBe(clampDockHeight(COLLAPSED_DOCK_HEIGHT + 100, limits));
+  });
+
+  it('ignores a non-finite delta', () => {
+    const s: DockState = { heightPx: 400, collapsed: false };
+    expect(resizeDock(s, Number.NaN, limits).heightPx).toBe(400);
+  });
+});
+
+describe('collapse', () => {
+  it('retains the open height so restore returns to it', () => {
+    const open: DockState = { heightPx: 512, collapsed: false };
+    const collapsed = toggleDockCollapsed(open);
+    expect(collapsed.collapsed).toBe(true);
+    expect(collapsed.heightPx).toBe(512);
+    const restored = toggleDockCollapsed(collapsed);
+    expect(restored).toEqual(open);
+  });
+
+  it('occupies only the header while collapsed', () => {
+    const s: DockState = { heightPx: 512, collapsed: true };
+    expect(dockOccupiedHeight(s, stage(1000))).toBe(COLLAPSED_DOCK_HEIGHT);
+    expect(sceneHeightFor(s, stage(1000))).toBe(1000 - COLLAPSED_DOCK_HEIGHT);
+  });
+});
+
+describe('stage resize', () => {
+  it('returns the user height when the stage grows back', () => {
+    const chosen: DockState = { heightPx: 600, collapsed: false };
+    const shrunk = refitDock(chosen, stage(400));
+    expect(shrunk.heightPx).toBeLessThan(600);
+    // Refitting the ORIGINAL preference to the restored stage gives it back.
+    const regrown = refitDock(chosen, stage(1200));
+    expect(regrown.heightPx).toBe(600);
+  });
+
+  it('keeps the collapsed flag across a resize', () => {
+    expect(refitDock({ heightPx: 600, collapsed: true }, stage(300)).collapsed).toBe(true);
+  });
+});
+
+describe('persistence', () => {
+  it('round trips', () => {
+    const s: DockState = { heightPx: 377, collapsed: true };
+    expect(decodeDockPrefs(encodeDockPrefs(s))).toEqual({ heightPx: 377, collapsed: true });
+  });
+
+  it('stores the open height even while collapsed', () => {
+    const s: DockState = { heightPx: 377, collapsed: true };
+    expect(decodeDockPrefs(encodeDockPrefs(s))!.heightPx).toBe(377);
+  });
+
+  it('rejects anything that is not a preference, without throwing', () => {
+    for (const raw of [
+      null,
+      '',
+      'not json',
+      '[]',
+      'null',
+      '"str"',
+      '42',
+      '{}',
+      '{"heightPx":400}',
+      '{"collapsed":true}',
+      '{"heightPx":"400","collapsed":true}',
+      '{"heightPx":400,"collapsed":"yes"}',
+      '{"heightPx":null,"collapsed":false}',
+      '{"heightPx":0,"collapsed":false}',
+      '{"heightPx":-10,"collapsed":false}',
+    ]) {
+      expect(decodeDockPrefs(raw)).toBeNull();
+    }
+  });
+
+  it('opens at the default when the stored value is corrupt', () => {
+    expect(restoreDockState('{{{', stage(1000))).toEqual(initialDockState(stage(1000)));
+    expect(restoreDockState(null, stage(1000))).toEqual(initialDockState(stage(1000)));
+  });
+
+  it('clamps a stored height that no longer fits', () => {
+    const raw = encodeDockPrefs({ heightPx: 5000, collapsed: false });
+    const s = restoreDockState(raw, stage(600));
+    expect(s.heightPx).toBe(maxDockHeight(stage(600)));
+    expect(sceneHeightFor(s, stage(600))).toBe(MIN_SCENE_HEIGHT);
+  });
+
+  it('rejects a non-finite stored height', () => {
+    expect(decodeDockPrefs('{"heightPx":1e999,"collapsed":false}')).toBeNull();
+  });
+});

--- a/tests/workbenchPanel.test.ts
+++ b/tests/workbenchPanel.test.ts
@@ -1,0 +1,583 @@
+/**
+ * workbenchPanel.test.ts
+ *
+ * The docked Profile Workbench panel (`src/ui/ProfileWorkbench.ts`), driven in
+ * the node environment through a recording DOM stub and a plain-object host.
+ * Nothing real is touched: no jsdom, no `window`, no `localStorage`, no
+ * document-level listener — which is itself part of what is asserted, since a
+ * panel that reached for any of them could not be driven this way.
+ *
+ * The suite is organised around the non-modal contract, which is what
+ * separates this surface from `ResultFocus`: the 3D scene stays visible and
+ * interactive while the workbench is open, so the panel takes no focus, traps
+ * none, draws no backdrop, declares no `aria-modal`, and answers Escape only
+ * for a press that came from inside it. Each of those has its own test.
+ *
+ * The height assertions call the dock module for their expected values rather
+ * than restating its arithmetic, so a panel that computed a height itself
+ * fails here the moment the two disagree.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  COLLAPSED_DOCK_HEIGHT,
+  PROFILE_WORKBENCH_DOCK_KEY,
+  decodeDockPrefs,
+  defaultDockHeight,
+  dockOccupiedHeight,
+  maxDockHeight,
+} from '../src/ui/profileWorkbenchDock';
+import type {
+  ProfileWorkbenchHandle,
+  ProfileWorkbenchHost,
+  ProfileWorkbenchOptions,
+} from '../src/ui/ProfileWorkbench';
+
+/** A recorded listener registration. */
+interface Listener {
+  readonly type: string;
+  readonly fn: (ev: unknown) => void;
+}
+
+/** A synthetic event, carrying the two calls the panel is allowed to make. */
+interface FakeEvent {
+  type: string;
+  target: FakeEl | null;
+  key?: string;
+  clientY?: number;
+  pointerId?: number;
+  defaultPrevented: boolean;
+  propagationStopped: boolean;
+  preventDefault(): void;
+  stopPropagation(): void;
+}
+
+/** Every listener the module registered on a non-element (document, global). */
+const globalListeners: Listener[] = [];
+/** Every element that had `focus()` called on it. */
+const focused: FakeEl[] = [];
+
+class FakeEl {
+  readonly tagName: string;
+  className = '';
+  title = '';
+  type = '';
+  disabled = false;
+  width = 0;
+  height = 0;
+  readonly children: FakeEl[] = [];
+  parent: FakeEl | null = null;
+  readonly attrs: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly dataset: Record<string, string> = {};
+  readonly listeners: Listener[] = [];
+  private readonly _classes = new Set<string>();
+  private _text = '';
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  readonly classList = {
+    add: (...c: string[]): void => c.forEach((n) => this._classes.add(n)),
+    remove: (...c: string[]): void => c.forEach((n) => this._classes.delete(n)),
+    contains: (c: string): boolean => this._classes.has(c),
+    toggle: (c: string, on?: boolean): void => {
+      const want = on ?? !this._classes.has(c);
+      if (want) this._classes.add(c);
+      else this._classes.delete(c);
+    },
+  };
+
+  /** Class names from both `className` and `classList`, for assertions. */
+  allClasses(): string[] {
+    return [...this.className.split(/\s+/).filter(Boolean), ...this._classes];
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attrs[name] = value;
+  }
+  removeAttribute(name: string): void {
+    delete this.attrs[name];
+  }
+  getAttribute(name: string): string | null {
+    return name in this.attrs ? this.attrs[name] : null;
+  }
+
+  set textContent(v: string) {
+    this._text = v;
+    this.children.length = 0;
+  }
+  get textContent(): string {
+    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
+  }
+  /** This element's OWN text, ignoring descendants. */
+  ownText(): string {
+    return this._text;
+  }
+
+  append(...kids: FakeEl[]): void {
+    for (const k of kids.filter(Boolean)) {
+      k.parent = this;
+      this.children.push(k);
+    }
+  }
+  replaceChildren(...kids: FakeEl[]): void {
+    this.children.length = 0;
+    this.append(...kids);
+  }
+  remove(): void {
+    if (!this.parent) return;
+    const at = this.parent.children.indexOf(this);
+    if (at >= 0) this.parent.children.splice(at, 1);
+    this.parent = null;
+  }
+  contains(node: FakeEl | null): boolean {
+    if (!node) return false;
+    if (node === this) return true;
+    return this.children.some((c) => c.contains(node));
+  }
+
+  addEventListener(type: string, fn: (ev: unknown) => void): void {
+    this.listeners.push({ type, fn });
+  }
+  removeEventListener(type: string, fn: (ev: unknown) => void): void {
+    const at = this.listeners.findIndex((l) => l.type === type && l.fn === fn);
+    if (at >= 0) this.listeners.splice(at, 1);
+  }
+
+  focus(): void {
+    focused.push(this);
+  }
+  blur(): void {
+    /* no-op */
+  }
+  click(): void {
+    this.dispatch('click', {});
+  }
+  setPointerCapture(): void {
+    /* no-op */
+  }
+  releasePointerCapture(): void {
+    /* no-op */
+  }
+  getContext(): null {
+    return null;
+  }
+  getBoundingClientRect(): { width: number; height: number; left: number; top: number } {
+    return { width: 0, height: 0, left: 0, top: 0 };
+  }
+
+  /** Deliver an event to this element's listeners. Returns the event. */
+  dispatch(type: string, props: Partial<FakeEvent>): FakeEvent {
+    const ev: FakeEvent = {
+      type,
+      target: this,
+      defaultPrevented: false,
+      propagationStopped: false,
+      preventDefault(): void {
+        ev.defaultPrevented = true;
+      },
+      stopPropagation(): void {
+        ev.propagationStopped = true;
+      },
+      ...props,
+    };
+    for (const l of [...this.listeners]) if (l.type === type) l.fn(ev);
+    return ev;
+  }
+
+  /** Every element in this subtree, this one first. */
+  tree(): FakeEl[] {
+    return [this as FakeEl, ...this.children.flatMap((c) => c.tree())];
+  }
+  /** Descendants whose own text equals `label`. */
+  findByText(label: string): FakeEl[] {
+    return this.tree().filter((n) => n.ownText() === label);
+  }
+  /** The first descendant carrying `cls`, from `className` or `classList`. */
+  byClass(cls: string): FakeEl | undefined {
+    return this.tree().find((n) => n.allClasses().includes(cls));
+  }
+}
+
+/** A host backed by nothing but plain values, so the panel has no other reach. */
+class FakeHost implements ProfileWorkbenchHost {
+  readonly root = new FakeEl('div');
+  readonly notified: number[] = [];
+  readonly store = new Map<string, string>();
+  readonly resizeSubscribers: (() => void)[] = [];
+  unsubscribeCalls = 0;
+  stagePx: number;
+  reducedMotion: boolean | null;
+
+  constructor(stagePx = 1000, reducedMotion: boolean | null = false) {
+    this.stagePx = stagePx;
+    this.reducedMotion = reducedMotion;
+  }
+
+  container(): HTMLElement {
+    return this.root as unknown as HTMLElement;
+  }
+  stageHeight(): number {
+    return this.stagePx;
+  }
+  onStageResize(cb: () => void): () => void {
+    this.resizeSubscribers.push(cb);
+    return () => {
+      this.unsubscribeCalls++;
+      const at = this.resizeSubscribers.indexOf(cb);
+      if (at >= 0) this.resizeSubscribers.splice(at, 1);
+    };
+  }
+  notifyDockHeight(px: number): void {
+    this.notified.push(px);
+  }
+  readonly storage = {
+    getItem: (k: string): string | null => this.store.get(k) ?? null,
+    setItem: (k: string, v: string): void => {
+      this.store.set(k, v);
+    },
+  };
+  prefersReducedMotion(): boolean {
+    return this.reducedMotion === true;
+  }
+
+  /** Resize the stage and run the subscribers, as the real stage would. */
+  resizeStage(px: number): void {
+    this.stagePx = px;
+    for (const cb of [...this.resizeSubscribers]) cb();
+  }
+  stored(): { heightPx: number; collapsed: boolean } | null {
+    return decodeDockPrefs(this.store.get(PROFILE_WORKBENCH_DOCK_KEY) ?? null);
+  }
+}
+
+beforeEach(() => {
+  globalListeners.length = 0;
+  focused.length = 0;
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.document = {
+    createElement: (tag: string) => new FakeEl(tag),
+    createElementNS: (_ns: string, tag: string) => new FakeEl(tag),
+    // A document-level listener is the shape a focus trap and a stolen global
+    // Escape both take. Recording it rather than dropping it is what lets the
+    // tests below prove the panel registers none.
+    addEventListener: (type: string, fn: (ev: unknown) => void): void => {
+      globalListeners.push({ type, fn });
+    },
+    removeEventListener: (): void => {},
+  };
+  g.HTMLInputElement = class {};
+  g.HTMLAnchorElement = class {};
+  // `window` and `localStorage` are deliberately left undefined: any reach for
+  // either throws a ReferenceError and fails the test that touched it.
+});
+
+afterEach(() => {
+  const g = globalThis as unknown as Record<string, unknown>;
+  delete g.document;
+  delete g.HTMLInputElement;
+  delete g.HTMLAnchorElement;
+});
+
+async function mount(
+  host: FakeHost,
+  options: ProfileWorkbenchOptions = {},
+): Promise<{ handle: ProfileWorkbenchHandle; root: FakeEl }> {
+  const { mountProfileWorkbench } = await import('../src/ui/ProfileWorkbench');
+  const handle = mountProfileWorkbench(host, options);
+  return { handle, root: handle.element as unknown as FakeEl };
+}
+
+describe('Profile Workbench — the non-modal contract', () => {
+  it('is a labelled region, and declares no modal semantics anywhere in its tree', async () => {
+    const host = new FakeHost();
+    const { root } = await mount(host, { title: 'Profile workbench' });
+
+    expect(root.getAttribute('role')).toBe('region');
+    expect(root.getAttribute('aria-label')).toBe('Profile workbench');
+
+    for (const node of root.tree()) {
+      expect(node.getAttribute('aria-modal')).toBeNull();
+      expect(node.getAttribute('role')).not.toBe('dialog');
+      expect(node.getAttribute('role')).not.toBe('alertdialog');
+    }
+  });
+
+  it('traps no focus: no document listener, no focus taken, and Tab is left alone', async () => {
+    const host = new FakeHost();
+    const { root } = await mount(host);
+
+    // A trap needs somewhere to listen from. There is nowhere.
+    expect(globalListeners).toEqual([]);
+    // Opening a non-modal panel must not pull focus off the scene.
+    expect(focused).toEqual([]);
+
+    const close = root.findByText('Close')[0];
+    const tab = close.dispatch('keydown', { key: 'Tab', target: close });
+    expect(tab.defaultPrevented).toBe(false);
+    const rootTab = root.dispatch('keydown', { key: 'Tab', target: close });
+    expect(rootTab.defaultPrevented).toBe(false);
+    // Nothing was pulled back to the panel's own edges.
+    expect(focused).toEqual([]);
+  });
+
+  it('draws no backdrop and blurs nothing', async () => {
+    const host = new FakeHost();
+    const { root } = await mount(host);
+
+    // Exactly one element was mounted: the panel. A backdrop is a sibling.
+    expect(host.root.children).toHaveLength(1);
+    expect(host.root.children[0]).toBe(root);
+
+    for (const node of root.tree()) {
+      for (const cls of node.allClasses()) {
+        expect(cls).not.toMatch(/backdrop|scrim|olv-modal/);
+      }
+      expect(node.style.filter ?? '').not.toContain('blur');
+      expect(node.style.backdropFilter ?? '').toBe('');
+    }
+  });
+
+  it('answers Escape from inside the panel, collapsing and then closing', async () => {
+    const host = new FakeHost();
+    const { handle, root } = await mount(host);
+    const inside = root.findByText('Close')[0];
+
+    const first = root.dispatch('keydown', { key: 'Escape', target: inside });
+    expect(handle.collapsed()).toBe(true);
+    // Handled here, so it does not also reach a global Escape binding.
+    expect(first.propagationStopped).toBe(true);
+
+    root.dispatch('keydown', { key: 'Escape', target: inside });
+    expect(host.root.children).toHaveLength(0);
+  });
+
+  it('ignores an Escape whose focus is outside, leaving the press to the app', async () => {
+    const host = new FakeHost();
+    const { handle, root } = await mount(host);
+    const outside = new FakeEl('button');
+
+    const ev = root.dispatch('keydown', { key: 'Escape', target: outside });
+
+    expect(handle.collapsed()).toBe(false);
+    expect(host.root.children).toHaveLength(1);
+    expect(ev.propagationStopped).toBe(false);
+  });
+});
+
+describe('Profile Workbench — structure', () => {
+  it('holds a described canvas whose exact figures also exist as real text', async () => {
+    const host = new FakeHost();
+    const { handle, root } = await mount(host);
+    const canvas = handle.canvas as unknown as FakeEl;
+
+    expect(canvas.tagName).toBe('canvas');
+    expect(canvas.getAttribute('role')).toBe('img');
+    expect((canvas.getAttribute('aria-label') ?? '').length).toBeGreaterThan(20);
+
+    // Nothing selected reads as nothing selected, not as an empty panel.
+    expect(root.textContent).toContain('No return selected.');
+
+    handle.setDetail([
+      { label: 'Station', value: '12.480 m' },
+      { label: 'Elevation', value: '104.113 m' },
+    ]);
+    // The figures are DOM text, so they are reachable without reading a canvas.
+    expect(root.findByText('Station')).toHaveLength(1);
+    expect(root.findByText('12.480 m')).toHaveLength(1);
+    expect(root.findByText('104.113 m')).toHaveLength(1);
+  });
+
+  it('announces status politely, never assertively', async () => {
+    const host = new FakeHost();
+    const { handle, root } = await mount(host);
+    const status = root.byClass('olv-workbench-status');
+
+    expect(status?.getAttribute('aria-live')).toBe('polite');
+    expect(status?.getAttribute('role')).toBe('status');
+
+    handle.setStatus('Sampling 4,182 returns.');
+    expect(status?.textContent).toContain('4,182');
+  });
+
+  it('carries the animation class only when the host has no reduced-motion preference', async () => {
+    const moving = new FakeHost(1000, false);
+    const { root: movingRoot } = await mount(moving);
+    expect(movingRoot.allClasses()).toContain('olv-workbench-animate');
+
+    const still = new FakeHost(1000, true);
+    const { root: stillRoot } = await mount(still);
+    expect(stillRoot.allClasses()).not.toContain('olv-workbench-animate');
+  });
+});
+
+describe('Profile Workbench — dock geometry', () => {
+  it('opens at this stage default when nothing is stored', async () => {
+    const host = new FakeHost(1000);
+    const { handle, root } = await mount(host);
+    const expected = defaultDockHeight({ stageHeight: 1000 });
+
+    expect(handle.height()).toBe(expected);
+    expect(root.style.height).toBe(`${expected}px`);
+    expect(host.notified.at(-1)).toBe(expected);
+  });
+
+  it('opens at the stored height, and at the default when the stored value is unusable', async () => {
+    const good = new FakeHost(1000);
+    good.store.set(PROFILE_WORKBENCH_DOCK_KEY, JSON.stringify({ heightPx: 512, collapsed: false }));
+    const { handle } = await mount(good);
+    expect(handle.height()).toBe(512);
+
+    const corrupt = new FakeHost(1000);
+    corrupt.store.set(PROFILE_WORKBENCH_DOCK_KEY, '{not json');
+    const { handle: fallback } = await mount(corrupt);
+    expect(fallback.height()).toBe(defaultDockHeight({ stageHeight: 1000 }));
+  });
+
+  it('keeps a stored height the stage cannot honour inside this stage allowance', async () => {
+    const host = new FakeHost(400);
+    host.store.set(PROFILE_WORKBENCH_DOCK_KEY, JSON.stringify({ heightPx: 5000, collapsed: false }));
+    const { handle, root } = await mount(host);
+    const allowed = maxDockHeight({ stageHeight: 400 });
+
+    expect(allowed).toBeLessThan(5000);
+    expect(handle.height()).toBe(allowed);
+    expect(root.style.height).toBe(`${allowed}px`);
+    expect(host.notified.at(-1)).toBe(allowed);
+  });
+
+  it('resizes on a splitter drag, persists the preference, and tells the host', async () => {
+    const host = new FakeHost(1000);
+    const { handle, root } = await mount(host);
+    const splitter = root.byClass('olv-workbench-splitter');
+    const start = handle.height();
+    const before = host.notified.length;
+
+    splitter?.dispatch('pointerdown', { clientY: 600, pointerId: 1 });
+    splitter?.dispatch('pointermove', { clientY: 540, pointerId: 1 });
+
+    // Dragging the top edge UP by 60px makes the dock 60px taller.
+    expect(handle.height()).toBe(start + 60);
+    expect(root.style.height).toBe(`${start + 60}px`);
+    expect(host.notified.length).toBeGreaterThan(before);
+    expect(host.notified.at(-1)).toBe(start + 60);
+
+    splitter?.dispatch('pointerup', { clientY: 540, pointerId: 1 });
+    expect(host.stored()).toEqual({ heightPx: start + 60, collapsed: false });
+  });
+
+  it('resizes from the keyboard through the same dock arithmetic', async () => {
+    const host = new FakeHost(1000);
+    const { handle, root } = await mount(host);
+    const splitter = root.byClass('olv-workbench-splitter');
+    const start = handle.height();
+
+    const up = splitter?.dispatch('keydown', { key: 'ArrowUp' });
+    expect(up?.defaultPrevented).toBe(true);
+    const taller = handle.height();
+    expect(taller).toBeGreaterThan(start);
+
+    splitter?.dispatch('keydown', { key: 'ArrowDown' });
+    expect(handle.height()).toBe(start);
+    expect(host.stored()?.heightPx).toBe(start);
+  });
+
+  it('collapses and restores, persisting both', async () => {
+    const host = new FakeHost(1000);
+    const { handle, root } = await mount(host);
+    const open = handle.height();
+
+    handle.setCollapsed(true);
+    expect(handle.collapsed()).toBe(true);
+    expect(handle.height()).toBe(COLLAPSED_DOCK_HEIGHT);
+    expect(root.style.height).toBe(`${COLLAPSED_DOCK_HEIGHT}px`);
+    expect(host.notified.at(-1)).toBe(COLLAPSED_DOCK_HEIGHT);
+    expect(host.stored()).toEqual({ heightPx: open, collapsed: true });
+
+    handle.setCollapsed(false);
+    expect(handle.height()).toBe(open);
+    expect(host.stored()).toEqual({ heightPx: open, collapsed: false });
+  });
+
+  it('re-derives on a stage resize from the same preference, so a shrink and a re-grow return the chosen height', async () => {
+    const host = new FakeHost(1000);
+    const { handle, root } = await mount(host);
+    const splitter = root.byClass('olv-workbench-splitter');
+    splitter?.dispatch('pointerdown', { clientY: 600, pointerId: 1 });
+    splitter?.dispatch('pointermove', { clientY: 400, pointerId: 1 });
+    splitter?.dispatch('pointerup', { clientY: 400, pointerId: 1 });
+    const chosen = handle.height();
+
+    host.resizeStage(300);
+    const squeezed = dockOccupiedHeight({ preferredHeightPx: chosen, collapsed: false }, { stageHeight: 300 });
+    expect(handle.height()).toBe(squeezed);
+    expect(squeezed).toBeLessThan(chosen);
+    expect(root.style.height).toBe(`${squeezed}px`);
+    // The host has to hear about it, or its 3D canvas keeps the old height.
+    expect(host.notified.at(-1)).toBe(squeezed);
+
+    host.resizeStage(1000);
+    expect(handle.height()).toBe(chosen);
+    expect(host.notified.at(-1)).toBe(chosen);
+  });
+});
+
+describe('Profile Workbench — teardown', () => {
+  it('releases every listener, removes the element, and leaves a later mount clean', async () => {
+    const host = new FakeHost(1000);
+    const { handle, root } = await mount(host);
+    const splitter = root.byClass('olv-workbench-splitter');
+    splitter?.dispatch('pointerdown', { clientY: 600, pointerId: 1 });
+    splitter?.dispatch('pointermove', { clientY: 500, pointerId: 1 });
+    splitter?.dispatch('pointerup', { clientY: 500, pointerId: 1 });
+    const chosen = handle.height();
+    const nodes = root.tree();
+    expect(nodes.some((n) => n.listeners.length > 0)).toBe(true);
+
+    handle.close();
+
+    for (const node of nodes) {
+      expect(node.listeners, `${node.tagName}.${node.className} kept a listener`).toEqual([]);
+    }
+    expect(host.unsubscribeCalls).toBe(1);
+    expect(host.resizeSubscribers).toEqual([]);
+    expect(host.root.children).toHaveLength(0);
+
+    // A stage resize after close reaches nothing.
+    const notifiedAtClose = host.notified.length;
+    host.resizeStage(700);
+    expect(host.notified).toHaveLength(notifiedAtClose);
+
+    // Mounting again works, and picks up the preference the closed panel left.
+    const { handle: second } = await mount(host);
+    expect(host.root.children).toHaveLength(1);
+    expect(host.stored()?.heightPx).toBe(chosen);
+    expect(second.height()).toBe(
+      dockOccupiedHeight({ preferredHeightPx: chosen, collapsed: false }, { stageHeight: 700 }),
+    );
+  });
+
+  it('closes once, however many times it is asked', async () => {
+    const host = new FakeHost(1000);
+    const { handle } = await mount(host);
+
+    handle.close();
+    handle.close();
+
+    expect(host.unsubscribeCalls).toBe(1);
+    expect(host.root.children).toHaveLength(0);
+  });
+
+  it('reports the close through the option the caller passed', async () => {
+    const host = new FakeHost(1000);
+    let closes = 0;
+    const { root } = await mount(host, { onClose: () => { closes++; } });
+
+    root.findByText('Close')[0].dispatch('click', {});
+
+    expect(closes).toBe(1);
+    expect(host.root.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Stacked on #517.

The docked Profile Workbench panel: a header strip, a draggable splitter, a canvas and a details area. All dock arithmetic goes through `profileWorkbenchDock`, so no height is recomputed here.

The 3D scene stays interactive while it is open, which makes the panel a labelled region rather than a dialog. There is no `aria-modal`, no focus trap, no backdrop, and Escape acts only when focus is already inside, so a global binding still receives the press. Status is announced politely. Each of those is asserted against the rendered tree.

The host arrives as a structural object of accessors, following `measurePanelMount`, so nothing here imports the viewer or reaches for `window`, `localStorage` or `document`.

The workbench rules extend the existing inspector stylesheet, and `index` is byte-identical at 362,090 B with no budget moved.
