### PR TITLE
Close three findings in the oracle image tooling

### DIFF
--- a/validation/oracles/Dockerfile
+++ b/validation/oracles/Dockerfile
@@ -125,10 +125,11 @@ ENV WBT_PATH="${ORACLE_PREFIX}/bin"
 #
 # This is a separate manifest from the project's own package.json on purpose:
 # an oracle must never enter the application's dependency tree, its lockfile or
-# its SBOM.
+# its SBOM. --ignore-scripts: a package's install hooks are arbitrary code, and
+# nothing here needs one to run for the validator to work.
 COPY npm/package.json npm/package-lock.json /opt/node-oracles/
 RUN cd /opt/node-oracles \
- && npm ci --omit=dev --no-audit --no-fund \
+ && npm ci --omit=dev --no-audit --no-fund --ignore-scripts \
  && npm cache clean --force
 ENV PATH="/opt/node-oracles/node_modules/.bin:${PATH}"
 

--- a/validation/oracles/record-oracle-versions.mjs
+++ b/validation/oracles/record-oracle-versions.mjs
@@ -36,7 +36,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { writeFileSync, readFileSync, existsSync, realpathSync } from 'node:fs';
-import { resolve, dirname, delimiter } from 'node:path';
+import { resolve, dirname, relative, isAbsolute, delimiter } from 'node:path';
 import { platform, arch } from 'node:process';
 
 /** Where the Dockerfile bakes the identity of the image itself. */
@@ -215,6 +215,16 @@ function main() {
   // directory does not exist stops the run rather than being written blind.
   const target = process.argv[2] ? resolve(process.argv[2]) : null;
   if (target) {
+    // Canonicalising a path from argv says what it points at; it does not say
+    // the caller was allowed to point there. The resolved target is held
+    // inside the directory the run was started in, so a parent segment names
+    // a refusal rather than a file outside the tree.
+    const rel = relative(process.cwd(), target);
+    if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
+      process.stderr.write(`refusing to write outside ${process.cwd()}: ${target}\n`);
+      process.exitCode = 1;
+      return;
+    }
     if (!existsSync(dirname(target))) {
       process.stderr.write(`no such directory for output: ${dirname(target)}\n`);
       process.exitCode = 1;

--- a/validation/oracles/solve-lock.mjs
+++ b/validation/oracles/solve-lock.mjs
@@ -27,7 +27,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { resolve, dirname, delimiter } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const HERE = resolve(dirname(fileURLToPath(import.meta.url)));
@@ -74,6 +74,22 @@ export const SPECS = [
 /** Which solved package supplies each oracle the validation records name. */
 const ORACLE_PACKAGES = { GDAL: 'libgdal-core', PDAL: 'pdal' };
 
+/**
+ * Absolute path to an executable found on PATH.
+ *
+ * The binary is invoked by this path rather than by name, so the process that
+ * runs is the one this lookup saw, and a directory added to PATH afterwards
+ * cannot substitute a different file for it.
+ */
+function resolveOnPath(name) {
+  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+    if (dir === '') continue;
+    const candidate = resolve(dir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error(`${name} was not found on PATH`);
+}
+
 function solve() {
   const args = [
     'create', '--yes', '--dry-run', '--json',
@@ -82,7 +98,8 @@ function solve() {
     '-n', 'olv-oracles',
     ...SPECS,
   ];
-  const r = spawnSync('micromamba', args, {
+  const micromamba = resolveOnPath('micromamba');
+  const r = spawnSync(micromamba, args, {
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
     env: {


### PR DESCRIPTION
Three findings reported against `validation/oracles/` after #527.

The image installed npm packages with lifecycle scripts enabled, so a package's install hook ran arbitrary code while the image was built. Installs pass `--ignore-scripts`, which nothing in this manifest needs.

The recorder canonicalised its output path from argv. Canonicalising says what a path points at, not that the caller was allowed to point there, so the resolved target is now held inside the directory the run started in: an absolute path elsewhere and a parent segment are both refused.

The solver invoked `micromamba` by name, so a directory prepended to PATH could substitute a different file between the lookup and the call. It resolves the binary once and runs that path.
