### PR TITLE
Give a non-finite up axis the degenerate vector it is documented to get

### DIFF
--- a/src/render/measure/profileGeometry.ts
+++ b/src/render/measure/profileGeometry.ts
@@ -43,9 +43,16 @@ function length(v: Vec3): number {
   return Math.hypot(v[0], v[1], v[2]);
 }
 function normalize(v: Vec3): Vec3 {
+  // One check covers every degenerate axis, because each divides to a
+  // non-finite component: a zero length gives 0/0, an infinite one gives
+  // Infinity/Infinity, and a NaN component stays NaN. The alternative is a
+  // NaN unit vector, which every dot product downstream carries silently into
+  // a height, a chainage and a corridor distance.
   const len = length(v);
-  if (len === 0) return [0, 0, 0];
-  return [v[0] / len, v[1] / len, v[2] / len];
+  const out: Vec3 = [v[0] / len, v[1] / len, v[2] / len];
+  return Number.isFinite(out[0]) && Number.isFinite(out[1]) && Number.isFinite(out[2])
+    ? out
+    : [0, 0, 0];
 }
 
 /** The resolved geometry of one section line. All vectors are in render space. */

--- a/tests/profileFrameUpAxis.test.ts
+++ b/tests/profileFrameUpAxis.test.ts
@@ -1,0 +1,97 @@
+/**
+ * profileFrameUpAxis.test.ts
+ *
+ * `buildProfileFrame` documents a zero or non-finite `up` as normalising to
+ * `[0, 0, 0]`. The zero case did that; a non-finite one produced a NaN unit
+ * vector, which every dot product downstream carries into a height, a
+ * chainage and a corridor distance without raising anything.
+ *
+ * These hold the documented contract, and hold that an ordinary axis is
+ * untouched by the guard.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildProfileFrame, projectPointToProfile } from '../src/render/measure/profileGeometry';
+import {
+  profileCorridorAccepts,
+  createProfileHitScratch,
+} from '../src/render/measure/profileCorridor';
+import type { Vec3 } from '../src/render/navMath';
+
+const A: Vec3 = [0, 0, 0];
+const B: Vec3 = [10, 0, 0];
+
+const DEGENERATE: Vec3[] = [
+  [0, 0, 0],
+  [Number.NaN, 0, 1],
+  [0, Number.NaN, 0],
+  [Number.POSITIVE_INFINITY, 0, 0],
+  [0, 0, Number.NEGATIVE_INFINITY],
+  [Number.NaN, Number.NaN, Number.NaN],
+  [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, 0],
+];
+
+describe('a degenerate up axis resolves to the documented zero vector', () => {
+  for (const up of DEGENERATE) {
+    it(`${JSON.stringify(up)} normalises to [0, 0, 0]`, () => {
+      const f = buildProfileFrame(A, B, up);
+      expect(f.up).toEqual([0, 0, 0]);
+      for (const c of f.up) expect(Number.isFinite(c)).toBe(true);
+    });
+  }
+
+  it('leaves every frame field finite, so nothing downstream inherits a NaN', () => {
+    for (const up of DEGENERATE) {
+      const f = buildProfileFrame(A, B, up);
+      for (const v of [...f.up, ...f.along, ...f.lateral, ...f.horizontal, ...f.horizontalAnchor]) {
+        expect(Number.isFinite(v)).toBe(true);
+      }
+      expect(Number.isFinite(f.horizontalLength)).toBe(true);
+      expect(Number.isFinite(f.verticalDelta)).toBe(true);
+    }
+  });
+
+  it('projects a point to finite values rather than NaN', () => {
+    for (const up of DEGENERATE) {
+      const p = projectPointToProfile(buildProfileFrame(A, B, up), [3, 1, 2]);
+      expect(Number.isFinite(p.chainage)).toBe(true);
+      expect(Number.isFinite(p.lateralOffset)).toBe(true);
+      expect(Number.isFinite(p.height)).toBe(true);
+    }
+  });
+
+  it('lets the corridor reach a decision instead of failing every comparison on NaN', () => {
+    const scratch = createProfileHitScratch();
+    for (const up of DEGENERATE) {
+      const f = buildProfileFrame(A, B, up);
+      // The verdict itself is not the point; that it is a boolean reached from
+      // finite arithmetic is.
+      expect(typeof profileCorridorAccepts(f, 1, 1, 3, 0, 0, scratch)).toBe('boolean');
+    }
+  });
+});
+
+describe('an ordinary up axis is untouched by the guard', () => {
+  const CASES: { up: Vec3; want: Vec3 }[] = [
+    { up: [0, 0, 1], want: [0, 0, 1] },
+    { up: [0, 1, 0], want: [0, 1, 0] },
+    { up: [0, 0, 5], want: [0, 0, 1] },
+    { up: [0, -3, 0], want: [0, -1, 0] },
+  ];
+
+  for (const { up, want } of CASES) {
+    it(`${JSON.stringify(up)} normalises to ${JSON.stringify(want)}`, () => {
+      const f = buildProfileFrame(A, B, up);
+      for (let i = 0; i < 3; i++) expect(f.up[i]).toBeCloseTo(want[i]!, 12);
+    });
+  }
+
+  it('keeps a unit length for an oblique axis', () => {
+    const f = buildProfileFrame(A, B, [3, 4, 12]);
+    expect(Math.hypot(...f.up)).toBeCloseTo(1, 12);
+  });
+
+  it('resolves a very small axis rather than treating it as degenerate', () => {
+    const f = buildProfileFrame(A, B, [0, 0, 1e-300]);
+    expect(Math.hypot(...f.up)).toBeCloseTo(1, 12);
+  });
+});


### PR DESCRIPTION
`buildProfileFrame` states that a zero or non-finite `up` normalises to `[0, 0, 0]`. A zero one did. A non-finite one produced a NaN unit vector, and `[Infinity, 0, 0]` produced `[NaN, 0, 0]`.

Nothing raised. Every dot product downstream carried it into a height, a chainage and a corridor distance, and the corridor's own non-finite gate then rejected every point, so a section over such a frame came back empty rather than wrong. The frame is now what its contract says.

One finiteness check on the divided components covers both cases, since a zero length divides to 0/0 and an infinite one to Infinity/Infinity.

The cross-implementation profile numbers are unchanged at max absolute delta 3.552713678800501e-15.
