### PR TITLE
Stop the profile PDF asserting a datum it does not have

### DIFF
--- a/src/render/measure/MeasureController.ts
+++ b/src/render/measure/MeasureController.ts
@@ -32,6 +32,7 @@ import type {
 } from './types';
 import { MIN_POINTS, isFull } from './types';
 import type { WorkOwnership } from '../../model/workOwnership';
+import type { ProfileProvenance } from './profileProvenance';
 import {
   distance,
   bearingDegrees,
@@ -292,6 +293,15 @@ export interface MeasurementSummary {
   profileCorridorWidthM?: number;
   /** Profile only — the sampler's corridor percentile (dimensionless). */
   profileGroundPercentile?: number;
+  /**
+   * Profile only — the measurement's provenance record, forwarded unchanged.
+   *
+   * Counts and stable layer ids, so it does not grow with the cloud and needs
+   * no unit conversion at this seam. The PDF prints it because the reader of
+   * an exported file cannot see the app state that produced the estimate.
+   * Absent on a measurement recorded before the record existed.
+   */
+  profileProvenance?: ProfileProvenance;
   /**
    * Profile only — the cumulative chainages (in METRES, through the same B2
    * factor the chart/table read) of the intermediate station dots drawn on the
@@ -926,6 +936,7 @@ export class MeasureController {
       profileCorridorWidthM:
         m.profileCorridorWidth != null ? m.profileCorridorWidth * f : undefined,
       profileGroundPercentile: m.profileGroundPercentile,
+      profileProvenance: m.profileProvenance,
       // Station-dot chainages in metres (× the same B2 factor as the samples),
       // in dot order, so the panel can couple a hovered tick/row to the scene
       // dot at the matching index. Only meaningful for profiles.

--- a/src/render/measure/profilePdf.ts
+++ b/src/render/measure/profilePdf.ts
@@ -5,22 +5,38 @@
  * engineer can print and take measurements off. It renders:
  *
  *   - A large, box-filling section chart with a survey grid, labelled
- *     chainage (X) and elevation (Y) axes, and the profile drawn as a
+ *     chainage (X) and height (Y) axes, and the profile drawn as a
  *     straight polyline between adjacent samples, so no plotted height
  *     falls outside the two stations bracketing it (gaps stay breaks).
  *   - The stated horizontal and vertical scales (1:N each) and the
  *     resulting vertical exaggeration, so distances/grades read off the
  *     print are unambiguous — a true civil section convention.
- *   - A summary block: length, relief, min/max elevation, mean & max
- *     grade, coverage, sample count, corridor width, CRS/datum.
- *   - A station table (chainage · elevation · grade) so values are exact,
+ *   - A summary block: length, relief, min/max height, mean & max grade,
+ *     coverage, sample count, corridor width, CRS/datum.
+ *   - A method-and-provenance page: the derived series named exactly as the
+ *     on-screen legend names it, the contributing sources by stable layer id
+ *     with their classification kind and read kind, the class-exclusion
+ *     policy and how far it reached, and the read scope.
+ *   - A station table (chainage · height · grade) so values are exact,
  *     not eyeballed off the graph.
  *   - A provenance footer carrying the canonical NOT_SURVEY_GRADE_NOTE.
+ *
+ * Three vocabularies are borrowed rather than restated, because a printed
+ * sheet that disagrees with the screen is two answers to one question:
+ *
+ *   - the derived series is named by `profileDerivedLegend`, which refuses to
+ *     name the series after a terrain class it cannot certify;
+ *   - the sources, class policy and read scope come from a
+ *     `ProfileProvenance` record, which the reader of an exported file cannot
+ *     otherwise recover;
+ *   - every height heading comes from `heightLabel`, so only an orthometric
+ *     reference is ever printed as an elevation.
  *
  * pdf-lib is imported here so this whole module lands in its own lazy
  * chunk — the panel dynamic-imports it only when the user clicks Export.
  *
  * Pure of the DOM beyond producing bytes; the caller triggers download.
+ * No clock: `generatedAt` is required, so the same input is the same bytes.
  */
 
 import { PDFDocument, StandardFonts, rgb, type PDFFont, type PDFPage } from 'pdf-lib';
@@ -48,6 +64,18 @@ import {
 // Straight-polyline path builder shared with the panel chart so the sheet and
 // the screen draw the same geometry from the same samples.
 import { profilePolylinePath } from './profilePath';
+// The words for the derived series, and the sentences that qualify it. The
+// sheet prints these verbatim rather than composing a second wording.
+import { buildDerivedSurfaceLegend } from './profileDerivedLegend';
+import type { DerivedSurfaceLegend, DerivedSurfaceSource } from './profileDerivedLegend';
+// What shaped the estimate, as the record the app keeps beside the sample.
+import { describeProfileProvenance } from './profileProvenance';
+import type { ProfileProvenance } from './profileProvenance';
+// Height headings. `Elevation` is earned by an orthometric reference and by
+// nothing else — the sheet outlives the session, so it is the last place a
+// reader can discover which surface a height was measured from.
+import { heightLabel, heightReferenceNote, verticalReferenceFromDatum } from '../../geo/height';
+import type { VerticalReference } from '../../geo/height';
 
 /** Same constant the format/summary modules keep module-local. */
 const FEET_PER_METRE = 3.280839895013123;
@@ -59,19 +87,27 @@ export interface ProfilePdfInput {
   readonly samples: ReadonlyArray<ProfileChartSample>;
   /** Corridor half-width used by the sampler, metres (for provenance). */
   readonly corridorWidthM?: number | null;
-  /** Per-bin elevation percentile used by the sampler (for provenance). */
+  /** Per-bin height percentile used by the sampler (for provenance). */
   readonly groundPercentile?: number | null;
   /** Horizontal CRS string, if known. */
   readonly crs?: string | null;
   /** Vertical datum string, if known. */
   readonly verticalDatum?: string | null;
-  /** True when sampled from streaming-resident nodes only. */
+  /**
+   * True when sampled from streaming-resident nodes only. Ignored when
+   * {@link provenance} is supplied: the record resolves the same fact from
+   * the sources it actually read, and one fact gets one answer.
+   */
   readonly residentOnly?: boolean;
-  /** Generation timestamp (defaults to now). */
-  readonly generatedAt?: Date;
+  /**
+   * Generation timestamp. REQUIRED, and never defaulted from the clock: a
+   * builder that stamps itself cannot be compared byte for byte against
+   * another copy of the same sheet.
+   */
+  readonly generatedAt: Date;
   /**
    * Active unit system (v0.4.5, B9): imperial sheets print feet on the
-   * elevation axis + summary + station table and US 100-ft stationing on
+   * height axis + summary + station table and US 100-ft stationing on
    * the chainage axis. Defaults to metric (the pre-v0.4.5 sheet).
    */
   readonly unitSystem?: UnitSystem;
@@ -79,10 +115,17 @@ export interface ProfilePdfInput {
    * Whether the scene could assert a vertical datum at all. False when the
    * loaded clouds hold conflicting render origins, in which case the samples
    * are LOCAL heights and the sheet must not print the word elevation against
-   * them — a printed sheet outlives the session that made it, so it is the
-   * last place a reader can discover the caveat. Defaults to true.
+   * them. Defaults to true.
    */
   readonly datumKnown?: boolean;
+  /**
+   * What shaped the estimate: which sources were read, by stable layer id,
+   * with their classification kind, whether the class policy could reach all
+   * of them, and whether the read was a full static source or a resident
+   * snapshot. Optional — a sheet exported without one says so on the
+   * provenance page rather than implying a read that was never recorded.
+   */
+  readonly provenance?: ProfileProvenance | null;
 }
 
 const PAGE_W = 792; // US Letter landscape
@@ -127,6 +170,98 @@ function scaleRatio(groundM: number, paperPt: number): number {
   return paperM > 0 ? groundM / paperM : 0;
 }
 
+/**
+ * The reference surface every height heading on this sheet is labelled from.
+ *
+ * A scene that cannot assert a datum yields LOCAL heights whatever a stored
+ * record says, so that answer wins. Otherwise the record's own resolved
+ * reference wins, and a datum string is classified only when the record left
+ * the question open. Nothing here upgrades an undeclared datum: the fallback
+ * is `verticalReferenceFromDatum`, which answers `unknown` for a name it does
+ * not recognise rather than guessing orthometric.
+ */
+function resolveVerticalReference(input: ProfilePdfInput): VerticalReference {
+  if (input.datumKnown === false) return 'local';
+  const fromRecord = input.provenance?.units.verticalReference;
+  if (fromRecord != null && fromRecord !== 'unknown') return fromRecord;
+  return verticalReferenceFromDatum({ verticalDatum: input.verticalDatum ?? undefined });
+}
+
+/**
+ * A column head short enough for the station table, and true for the
+ * reference it describes. `HEIGHT` is honest for an ellipsoidal, local or
+ * undeclared reference; only an orthometric one gets `ELEV`.
+ */
+function heightColumnHead(reference: VerticalReference): string {
+  if (reference === 'orthometric') return 'ELEV';
+  if (reference === 'depth') return 'DEPTH';
+  return 'HEIGHT';
+}
+
+/**
+ * The contributing sources, in the shape the legend describes them in.
+ *
+ * Only the sources that reached the accepted set are handed over: a source
+ * that contributed nothing filtered nothing, so counting it would let the
+ * legend report an exclusion scope the section never had. This is the same
+ * set `buildProfileProvenance` computes `availableOnEverySource` over, so the
+ * two statements cannot drift.
+ */
+function legendSources(record: ProfileProvenance | null | undefined): DerivedSurfaceSource[] {
+  if (record == null) return [];
+  return record.sources
+    .filter((s) => s.contributed)
+    .map((s) => ({
+      label: s.displayName !== '' ? s.displayName : s.layerId,
+      classification: s.classification,
+      read: s.streaming ? ('streaming-resident' as const) : ('static' as const),
+    }));
+}
+
+/** Greedy word wrap against the font's real metrics. WinAnsi-safe first. */
+function wrapText(s: string, font: PDFFont, size: number, maxW: number): string[] {
+  const words = winAnsiSafe(s).split(/\s+/).filter((w) => w !== '');
+  if (words.length === 0) return [];
+  const out: string[] = [];
+  let line = '';
+  for (const w of words) {
+    const next = line === '' ? w : `${line} ${w}`;
+    if (line === '' || font.widthOfTextAtSize(next, size) <= maxW) {
+      line = next;
+    } else {
+      out.push(line);
+      line = w;
+    }
+  }
+  if (line !== '') out.push(line);
+  return out;
+}
+
+/** Trim to fit `maxW`, marking the trim so a truncated id never reads whole. */
+function clipText(s: string, font: PDFFont, size: number, maxW: number): string {
+  const safe = winAnsiSafe(s);
+  if (font.widthOfTextAtSize(safe, size) <= maxW) return safe;
+  let cut = safe;
+  while (cut.length > 1 && font.widthOfTextAtSize(`${cut}...`, size) > maxW) {
+    cut = cut.slice(0, -1);
+  }
+  return `${cut}...`;
+}
+
+/** The one-line form of the class-exclusion policy, for the summary block. */
+function exclusionSummary(legend: DerivedSurfaceLegend): string {
+  const classes = legend.excludedClasses.join(',');
+  if (legend.exclusionScope === 'none') {
+    return legend.sourceCount === 0
+      ? 'Not applied: no contributing source recorded'
+      : 'Not applied: no source carries classification';
+  }
+  if (legend.exclusionScope === 'every-source') {
+    return `Classes ${classes} on every source (${legend.sourcesWithClassification} of ${legend.sourceCount})`;
+  }
+  return `Classes ${classes} on only ${legend.sourcesWithClassification} of ${legend.sourceCount} sources: partial`;
+}
+
 /** Build the profile PDF and return its bytes. */
 export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Array> {
   const doc = await PDFDocument.create();
@@ -146,17 +281,29 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
   const mono = await doc.embedFont(StandardFonts.Courier);
 
   const stats = computeCivilProfileStats(input.samples);
-  const when = input.generatedAt ?? new Date();
+  const when = input.generatedAt;
   // Unit system (B9): every printed number converts ONCE through `k`; the
   // underlying samples/stats stay metres so the geometry math is untouched.
   const system: UnitSystem = input.unitSystem ?? 'metric';
   const k = system === 'metric' ? 1 : FEET_PER_METRE;
   const unit = system === 'metric' ? 'm' : 'ft';
   const datumKnown = input.datumKnown !== false;
-  // Without a datum every height on this sheet is a local render height.
-  const heightWord = datumKnown ? 'Elevation' : 'Local height';
+  const record = input.provenance ?? null;
+  const reference = resolveVerticalReference(input);
+  // The heading every height on this sheet is printed under. Only an
+  // orthometric reference resolves to "Elevation".
+  const heightWord = heightLabel(reference);
+  // One fact, one answer: the record resolves the read scope when it exists.
+  const residentOnly = record != null ? record.residentOnly : input.residentOnly === true;
+  const legend = buildDerivedSurfaceLegend({
+    samples: input.samples,
+    percentile: input.groundPercentile ?? null,
+    corridorHalfWidthM: input.corridorWidthM ?? null,
+    sources: legendSources(record),
+    excludedClasses: record?.classPolicy.excludedClasses,
+  });
   const lenStr = (m: number | null): string => (m == null ? '—' : formatLength(m, system));
-  // An elevation is a datum reading, not a magnitude — see `formatElevation`.
+  // A datum reading is not a magnitude — see `formatElevation`.
   const elevStr = (m: number | null): string => (m == null ? '—' : formatElevation(m, system));
 
   // ── Page 1: chart + summary ────────────────────────────────────────────
@@ -187,10 +334,10 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
     INK_DIM,
   );
   // Provenance header line (v0.4.5, B4) — the CRS, corridor width and
-  // elevation percentile the section was actually computed with, right-aligned
-  // under the timestamp so a printed sheet is self-describing at a glance
-  // (the summary block repeats them in full lower down). Omitted entirely
-  // when the caller knows none of them — no row of dashes.
+  // percentile the section was actually computed with, right-aligned under the
+  // timestamp so a printed sheet is self-describing at a glance (the summary
+  // block repeats them in full lower down). Omitted entirely when the caller
+  // knows none of them — no row of dashes.
   {
     const meta = [
       input.crs ? `CRS ${input.crs}` : null,
@@ -231,7 +378,7 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
   const span = stats.reliefSpan;
 
   // The finite checks are a v0.4.5 crash guard: a corrupt sample (Infinity /
-  // NaN chainage or elevation) would otherwise pass `len > 0`, and the grid
+  // NaN chainage or height) would otherwise pass `len > 0`, and the grid
   // walks below — float accumulators — would loop forever building a PDF
   // that never finishes. Corrupt geometry takes the honest "nothing to plot"
   // branch instead.
@@ -244,7 +391,7 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
     const mapX = (c: number) => plotLeft + (c / len) * plotW;
     const mapYdown = (e: number) => (1 - (e - minEl) / elSpan) * plotH; // local y-down
 
-    // Grid — vertical (chainage) and horizontal (elevation). Tick VALUES are
+    // Grid — vertical (chainage) and horizontal (height). Tick VALUES are
     // chosen in the DISPLAY unit (B9): an imperial sheet needs gridlines on
     // nice 10/25/50 ft steps, not on metre steps relabelled in feet — the
     // display values convert back through `/k` only for positioning.
@@ -316,20 +463,31 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
     text(page, 'No covered samples — nothing to plot.', plotLeft, plotTopY - 20, 11, font, INK_DIM);
   }
 
+  // Chart legend swatch. The caption is the legend's own, so the plotted
+  // series is named on the print exactly as it is named on screen.
+  page.drawLine({
+    start: { x: plotLeft, y: plotBotY - 38 },
+    end: { x: plotLeft + 16, y: plotBotY - 38 },
+    thickness: 1.4,
+    color: CURVE,
+  });
+  text(page, legend.caption, plotLeft + 22, plotBotY - 41, 8, font, INK);
+
   // Summary block (two columns of label:value). The Profile Intelligence
   // rows (gain/loss, steepest station range, located extremes — v0.4.5) come
   // from the shared pure module so they match the panel's summary exactly.
   const intel = computeProfileSummary(input.samples);
-  const sumTop = plotBotY - 48;
+  const sumTop = plotBotY - 52;
+  const contributing = record == null ? 0 : record.sources.filter((s) => s.contributed).length;
   const rows: Array<[string, string]> = [
     ['Length (horizontal)', lenStr(len)],
     ['Relief (height change)', stats.reliefSpan == null ? '-' : lenStr(stats.reliefSpan)],
     [
-      datumKnown ? 'Min / Max elevation' : 'Min / Max local height',
+      `${heightWord} min / max`,
       `${elevStr(stats.minElevation)}  /  ${elevStr(stats.maxElevation)}`,
     ],
     [
-      'Elevation gain / loss',
+      'Height gain / loss',
       intel.gainM == null || intel.lossM == null
         ? '—'
         : `+${lenStr(intel.gainM)}  /  -${lenStr(intel.lossM)}`,
@@ -351,7 +509,7 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
           `(${formatGradePercent(intel.steepest.grade)})`,
     ],
     [
-      datumKnown ? 'Highest / Lowest point' : 'Highest / Lowest point (local height)',
+      `Highest / Lowest ${heightWord.toLowerCase()}`,
       intel.highest == null || intel.lowest == null
         ? '—'
         : `${formatProfileExtreme(intel.highest, system)}  /  ` +
@@ -363,10 +521,12 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
       input.corridorWidthM != null ? lenStr(input.corridorWidthM) : 'auto (5% of length)',
     ],
     [
-      'Estimator',
-      `p${input.groundPercentile != null ? Math.round(input.groundPercentile) : 25} of corridor returns`,
+      'Sources read',
+      record == null
+        ? 'Not recorded'
+        : `${record.sources.length} (${contributing} contributing)`,
     ],
-    ['Non-ground classes', 'Excluded where a source classifies'],
+    ['Vertical reference', reference],
     ['Horizontal CRS', input.crs ?? '— (not georeferenced)'],
     [
       'Vertical datum',
@@ -383,19 +543,212 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
     text(page, r[1], x + 130, y, 8.5, font, INK);
   });
 
+  // Three statements too long for a half-width cell, and too load-bearing to
+  // abbreviate: what the drawn series is, how far the class policy reached,
+  // and what the read is entitled to claim. The page that expands them is
+  // page 2; these are the one-line forms.
+  const wideRows: Array<[string, string]> = [
+    ['Derived series', legend.seriesLabel],
+    ['Class exclusion', exclusionSummary(legend)],
+    ['Read scope', record == null ? 'Not recorded' : describeProfileProvenance(record)],
+  ];
+  const wideTop = sumTop - Math.ceil(rows.length / 2) * 14;
+  wideRows.forEach((r, i) => {
+    const y = wideTop - i * 14;
+    text(page, r[0], M, y, 8.5, bold, INK_DIM);
+    text(page, r[1], M + 130, y, 8.5, font, INK);
+  });
+
   // Provenance footer.
   const prov =
     NOT_SURVEY_GRADE_NOTE +
-    (input.residentOnly ? '  Sampled from streaming-resident points only — may refine as more data loads.' : '');
+    (residentOnly ? '  Sampled from streaming-resident points only — may refine as more data loads.' : '');
   text(page, prov, M, M - 10, 8, font, INK_DIM);
 
-  // ── Page 2+: station table ─────────────────────────────────────────────
-  renderStationTable(doc, font, bold, mono, stats.stations, input.name, system, datumKnown);
+  // ── Page 2: method and provenance ──────────────────────────────────────
+  renderProvenancePage(doc, font, bold, mono, {
+    name: input.name,
+    legend,
+    record,
+    reference,
+    crs: input.crs ?? null,
+    verticalDatum: datumKnown ? (input.verticalDatum ?? null) : null,
+    datumKnown,
+    residentOnly,
+  });
+
+  // ── Page 3+: station table ─────────────────────────────────────────────
+  renderStationTable(doc, font, bold, mono, stats.stations, input.name, system, reference);
 
   return doc.save();
 }
 
-/** Lay out the station/elevation/grade table across as many pages as needed. */
+interface ProvenancePageInput {
+  readonly name: string;
+  readonly legend: DerivedSurfaceLegend;
+  readonly record: ProfileProvenance | null;
+  readonly reference: VerticalReference;
+  readonly crs: string | null;
+  readonly verticalDatum: string | null;
+  readonly datumKnown: boolean;
+  readonly residentOnly: boolean;
+}
+
+/**
+ * The page a reader of an exported file needs and cannot reconstruct: what
+ * the drawn series is, which sources it was read from, and what the read is
+ * entitled to claim.
+ *
+ * Every sentence about the series is the legend's own. The source table is
+ * keyed on the stable layer id, because a display name is user-editable and
+ * so is human context rather than identity.
+ */
+function renderProvenancePage(
+  doc: PDFDocument,
+  font: PDFFont,
+  bold: PDFFont,
+  mono: PDFFont,
+  input: ProvenancePageInput,
+): void {
+  const bottom = M + 16;
+  const usableW = PAGE_W - 2 * M;
+  let page = doc.addPage([PAGE_W, PAGE_H]);
+  let y = PAGE_H - M - 4;
+
+  const put = (s: string, x: number, yy: number, size: number, f: PDFFont, color = INK) =>
+    page.drawText(winAnsiSafe(s), { x, y: yy, size, font: f, color });
+
+  const newPage = () => {
+    page = doc.addPage([PAGE_W, PAGE_H]);
+    y = PAGE_H - M - 4;
+    put('Method and provenance (continued)', M, y, 12, bold);
+    y -= 20;
+  };
+  const need = (h: number) => {
+    if (y - h < bottom) newPage();
+  };
+  const heading = (s: string) => {
+    need(26);
+    y -= 8;
+    put(s, M, y, 10, bold, INK);
+    y -= 13;
+  };
+  const para = (s: string, size = 8.5, color = INK) => {
+    for (const line of wrapText(s, font, size, usableW)) {
+      need(12);
+      put(line, M, y, size, font, color);
+      y -= 11;
+    }
+  };
+
+  put('Method and provenance', M, y, 16, bold);
+  y -= 16;
+  put(input.name, M, y, 10, font, INK_DIM);
+  y -= 12;
+
+  heading('Derived series');
+  for (const line of input.legend.lines) para(line);
+
+  heading('Height reference');
+  para(`${heightLabel(input.reference)}. ${heightReferenceNote(input.reference)}`);
+  para(`Vertical datum: ${input.verticalDatum ?? 'not declared'}`, 8.5, INK_DIM);
+  para(`Horizontal CRS: ${input.crs ?? 'not georeferenced'}`, 8.5, INK_DIM);
+  if (!input.datumKnown) para(DATUM_CONFLICT_MEASURE_NOTICE, 8.5, INK_DIM);
+
+  heading('Sources read');
+  if (input.record == null) {
+    para(
+      'No provenance record was attached to this export, so the contributing sources, ' +
+        'their classification and the read scope are not recorded on this sheet.',
+    );
+  } else {
+    const cols: Array<{ head: string; x: number; w: number }> = [
+      { head: 'LAYER ID', x: M, w: 128 },
+      { head: 'NAME', x: M + 132, w: 128 },
+      { head: 'CLASSIFICATION', x: M + 264, w: 90 },
+      { head: 'READ', x: M + 358, w: 72 },
+      { head: 'ACCEPTED', x: M + 434, w: 70 },
+      { head: 'CONTRIBUTED', x: M + 508, w: 78 },
+      { head: 'RESIDENCY', x: M + 590, w: 82 },
+    ];
+    const drawHead = () => {
+      need(22);
+      for (const c of cols) put(c.head, c.x, y, 7.5, bold, INK_DIM);
+      page.drawLine({
+        start: { x: M, y: y - 3 },
+        end: { x: M + usableW, y: y - 3 },
+        thickness: 0.5,
+        color: GRID,
+      });
+      y -= 13;
+    };
+    drawHead();
+    for (const s of input.record.sources) {
+      if (y - 11 < bottom) {
+        newPage();
+        drawHead();
+      }
+      const cells = [
+        s.layerId,
+        s.displayName !== '' ? s.displayName : '-',
+        s.classification,
+        s.streaming ? 'streaming' : 'static',
+        String(s.acceptedCount),
+        s.contributed ? 'yes' : 'no',
+        !s.streaming
+          ? '-'
+          : s.residency === true
+            ? 'complete'
+            : s.residency === false
+              ? 'incomplete'
+              : 'unknown',
+      ];
+      cells.forEach((cell, i) => {
+        const c = cols[i];
+        put(clipText(cell, mono, 7.5, c.w), c.x, y, 7.5, mono, INK);
+      });
+      y -= 11;
+    }
+    y -= 4;
+    para(`Total accepted returns: ${String(input.record.acceptedCount)}.`, 8.5, INK_DIM);
+
+    heading('Read scope');
+    para(describeProfileProvenance(input.record));
+    para(
+      `Method ${input.record.method}, corridor definition version ` +
+        `${String(input.record.corridorVersion)}, record version ` +
+        `${String(input.record.recordVersion)}, captured ${input.record.capturedAt}.`,
+      8.5,
+      INK_DIM,
+    );
+    if (input.record.upDegenerate) {
+      para(
+        'The scene up axis was degenerate when this sample was taken, so the heights ' +
+          'were not measured along a usable vertical.',
+        8.5,
+        INK_DIM,
+      );
+    }
+  }
+
+  if (input.residentOnly) {
+    para(
+      'Sampled from streaming-resident points only - may refine as more data loads.',
+      8.5,
+      INK_DIM,
+    );
+  }
+
+  need(20);
+  y -= 6;
+  for (const line of wrapText(NOT_SURVEY_GRADE_NOTE, font, 8, usableW)) {
+    need(11);
+    put(line, M, y, 8, font, INK_DIM);
+    y -= 10;
+  }
+}
+
+/** Lay out the station/height/grade table across as many pages as needed. */
 function renderStationTable(
   doc: PDFDocument,
   font: PDFFont,
@@ -404,7 +757,7 @@ function renderStationTable(
   stations: ReturnType<typeof computeCivilProfileStats>['stations'],
   name: string,
   system: UnitSystem,
-  datumKnown: boolean,
+  reference: VerticalReference,
 ): void {
   // B9: the table prints in the display unit; geometry stays metres.
   const k = system === 'metric' ? 1 : FEET_PER_METRE;
@@ -420,6 +773,7 @@ function renderStationTable(
 
   const fmtGrade = (g: number | null) => (g == null ? '—' : `${(g * 100).toFixed(2)}%`);
   const fmtEl = (e: number | null) => (e == null ? 'gap' : (e * k).toFixed(2));
+  const columnHead = heightColumnHead(reference);
 
   let idx = 0;
   while (idx < stations.length) {
@@ -427,13 +781,19 @@ function renderStationTable(
     const put = (s: string, x: number, y: number, size: number, f: PDFFont, color = INK) =>
       page.drawText(winAnsiSafe(s), { x, y, size, font: f, color });
     put('Station table', M, PAGE_H - M - 4, 14, bold);
-    const heightWord = datumKnown ? 'elevation' : 'local height';
-    put(`${name} - STA, ${heightWord} (${unit}), grade to next`, M, PAGE_H - M - 20, 9, font, INK_DIM);
+    put(
+      `${name} - STA, ${heightLabel(reference)} (${unit}), grade to next`,
+      M,
+      PAGE_H - M - 20,
+      9,
+      font,
+      INK_DIM,
+    );
 
     for (let col = 0; col < colCount && idx < stations.length; col++) {
       const x = M + col * (colW + colGap);
       put('STA', x, topY, 8, bold, INK_DIM);
-      put('ELEV', x + 78, topY, 8, bold, INK_DIM);
+      put(columnHead, x + 78, topY, 8, bold, INK_DIM);
       put('GRADE', x + 122, topY, 8, bold, INK_DIM);
       page.drawLine({
         start: { x, y: topY - 3 },

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -755,6 +755,13 @@ export class MeasurePanel {
         // metric regardless of the toggle. Same source the chart/CSV read.
         unitSystem: this._cb.getUnitSystem ? this._cb.getUnitSystem() : 'metric',
         datumKnown: s.profileDatumKnown !== false,
+        // What shaped the estimate. A reader of the exported file cannot see
+        // the app state that produced it, so the sources, the class policy and
+        // the read scope go on the page.
+        provenance: s.profileProvenance ?? null,
+        // The clock is read HERE, at the app boundary. The builder takes the
+        // stamp as a parameter so the same sheet is the same bytes.
+        generatedAt: new Date(),
       });
       triggerDownload(
         new Blob([bytes as BlobPart], { type: 'application/pdf' }),

--- a/tests/measureCrashGuards.test.ts
+++ b/tests/measureCrashGuards.test.ts
@@ -271,7 +271,11 @@ describe('profilePdf — corrupt samples cannot hang the export', () => {
       { distance: 0, height: 10 },
       { distance: Infinity, height: 11 }, // corrupt — len becomes Infinity
     ];
-    const bytes = await buildProfilePdf({ name: 'corrupt', samples });
+    const bytes = await buildProfilePdf({
+      name: 'corrupt',
+      samples,
+      generatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
     expect(bytes.byteLength).toBeGreaterThan(0);
   }, 15000);
 
@@ -280,7 +284,12 @@ describe('profilePdf — corrupt samples cannot hang the export', () => {
       { distance: 0, height: Number.NaN },
       { distance: 4, height: Number.NaN },
     ];
-    const bytes = await buildProfilePdf({ name: 'gaps', samples, unitSystem: 'imperial' });
+    const bytes = await buildProfilePdf({
+      name: 'gaps',
+      samples,
+      unitSystem: 'imperial',
+      generatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
     expect(bytes.byteLength).toBeGreaterThan(0);
   }, 15000);
 });

--- a/tests/profilePdf.test.ts
+++ b/tests/profilePdf.test.ts
@@ -2,6 +2,11 @@
  * profilePdf.test.ts — the PDF export must actually produce bytes for
  * real profiles, including names with characters outside WinAnsi (the
  * pdf-lib StandardFont encoding) which would otherwise throw.
+ *
+ * It must also print the SAME words the app prints on screen: the derived
+ * series as `profileDerivedLegend` names it, the sources / class policy /
+ * read scope from the `ProfileProvenance` record, and every height heading
+ * from `heightLabel`.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -12,6 +17,19 @@ import {
   profileSummaryRows,
   scaleProfileSamples,
 } from '../src/render/measure/profileSummary';
+import {
+  buildDerivedSurfaceLegend,
+  type DerivedSurfaceSource,
+} from '../src/render/measure/profileDerivedLegend';
+import {
+  buildProfileProvenance,
+  describeProfileProvenance,
+  type ProfileClassificationKind,
+  type ProfileProvenance,
+} from '../src/render/measure/profileProvenance';
+import { NON_GROUND_CLASSES } from '../src/terrain/ground/classificationFilter';
+import { heightLabel } from '../src/geo/height';
+import type { VerticalReference } from '../src/geo/height';
 import type { ProfileChartSample } from '../src/render/measure/types';
 
 function ramp(n: number): ProfileChartSample[] {
@@ -23,13 +41,44 @@ function ramp(n: number): ProfileChartSample[] {
 }
 
 const PDF_MAGIC = '%PDF-';
-// Injected, fixed generation date. `buildProfilePdf` defaults `generatedAt` to
-// `new Date()`, which puts a moving timestamp in the page content stream.
+// Injected, fixed generation date. `buildProfilePdf` REQUIRES `generatedAt`
+// and never reads the clock, so the same input is always the same bytes.
 const FIXED_DATE = new Date('2026-01-01T00:00:00.000Z');
+
+/** A provenance record, built through the real builder so it cannot drift. */
+function provenanceOf(
+  sources: ReadonlyArray<{
+    layerId: string;
+    displayName: string;
+    classification: ProfileClassificationKind;
+    streaming?: boolean;
+  }>,
+  acceptedSlots: readonly number[],
+  verticalReference: VerticalReference = 'orthometric',
+): ProfileProvenance {
+  return buildProfileProvenance({
+    capturedAt: '2026-01-01T00:00:00.000Z',
+    up: [0, 0, 1],
+    sources: sources.map((s, i) => ({
+      slot: i,
+      layerId: s.layerId,
+      displayName: s.displayName,
+      classification: s.classification,
+      streaming: s.streaming === true,
+    })),
+    accepted: { count: acceptedSlots.length, sourceSlot: acceptedSlots },
+    excludedClasses: NON_GROUND_CLASSES,
+    units: { linearUnit: 'metre', verticalReference, verticalMetresPerUnit: 1 },
+  });
+}
 
 describe('buildProfilePdf', () => {
   it('produces a non-empty PDF for a normal profile', async () => {
-    const bytes = await buildProfilePdf({ name: 'Profile 1', samples: ramp(64) });
+    const bytes = await buildProfilePdf({
+      name: 'Profile 1',
+      samples: ramp(64),
+      generatedAt: FIXED_DATE,
+    });
     expect(bytes.byteLength).toBeGreaterThan(1000);
     expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe(PDF_MAGIC);
   });
@@ -37,7 +86,11 @@ describe('buildProfilePdf', () => {
   it('does not throw on names with non-WinAnsi characters', async () => {
     // Emoji + Greek + CJK in a renamed measurement must not crash the
     // StandardFont encoder.
-    const bytes = await buildProfilePdf({ name: 'Survey Δ 测量 🚧 §1', samples: ramp(8) });
+    const bytes = await buildProfilePdf({
+      name: 'Survey Δ 测量 🚧 §1',
+      samples: ramp(8),
+      generatedAt: FIXED_DATE,
+    });
     expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe(PDF_MAGIC);
   });
 
@@ -45,7 +98,12 @@ describe('buildProfilePdf', () => {
     const s = ramp(10);
     s[3] = { distance: 6, height: NaN };
     s[4] = { distance: 8, height: NaN };
-    const bytes = await buildProfilePdf({ name: 'Gappy', samples: s, residentOnly: true });
+    const bytes = await buildProfilePdf({
+      name: 'Gappy',
+      samples: s,
+      residentOnly: true,
+      generatedAt: FIXED_DATE,
+    });
     expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe(PDF_MAGIC);
   });
 
@@ -56,20 +114,44 @@ describe('buildProfilePdf', () => {
         { distance: 0, height: NaN },
         { distance: 10, height: NaN },
       ],
+      generatedAt: FIXED_DATE,
     });
     expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe(PDF_MAGIC);
+  });
+
+  /**
+   * No clock inside the builder. Two runs over the same input, minutes or
+   * machines apart, must be the same bytes, or two parties cannot compare a
+   * sheet against the one they were sent.
+   */
+  it('is byte-identical for the same input', async () => {
+    const input = {
+      name: 'Deterministic',
+      samples: ramp(24),
+      corridorWidthM: 4,
+      groundPercentile: 25,
+      crs: 'EPSG:32611',
+      verticalDatum: 'NAVD88',
+      generatedAt: FIXED_DATE,
+      provenance: provenanceOf(
+        [
+          { layerId: 'layer-b', displayName: 'Flight B', classification: 'producer' },
+          { layerId: 'layer-a', displayName: 'Flight A', classification: 'derived' },
+        ],
+        [0, 0, 1],
+      ),
+    } as const;
+    const a = await buildProfilePdf(input);
+    const b = await buildProfilePdf(input);
+    expect(Buffer.from(b).equals(Buffer.from(a))).toBe(true);
   });
 });
 
 /**
- * Recover the drawn text from the PDF bytes. pdf-lib Flate-compresses page
- * content streams and encodes every string drawn with a standard font as a
- * hex string (`<48656C6C6F> Tj`), so a plain byte-grep can never see the
- * words — inflate each stream, then hex-decode the string tokens back to
- * WinAnsi/latin1. Good enough to assert "this label made it onto the page";
- * NOT a layout check.
+ * Inflate every page content stream. pdf-lib Flate-compresses them, so a
+ * plain byte-grep over the file can never see the drawn words.
  */
-function drawnPdfText(bytes: Uint8Array): string {
+function inflatedStreams(bytes: Uint8Array): string {
   const buf = Buffer.from(bytes);
   let idx = 0;
   let streams = '';
@@ -88,9 +170,34 @@ function drawnPdfText(bytes: Uint8Array): string {
     }
     idx = e + 'endstream'.length;
   }
-  return streams.replace(/<([0-9A-Fa-f]+)>/g, (_, hex: string) =>
+  return streams;
+}
+
+/**
+ * The stream text with every drawn string decoded in place, so the PDF path
+ * operators stay on their own lines. Used for the geometry assertions.
+ */
+function drawnPdfText(bytes: Uint8Array): string {
+  return inflatedStreams(bytes).replace(/<([0-9A-Fa-f]+)>/g, (_, hex: string) =>
     Buffer.from(hex, 'hex').toString('latin1'),
   );
+}
+
+/**
+ * Only the drawn strings, in draw order, joined by a single space.
+ *
+ * The provenance page wraps its paragraphs at the font's real metrics, so one
+ * sentence arrives as several `drawText` calls broken at spaces. Rejoining
+ * them lets a test assert the sentence the reader sees rather than whatever
+ * the line breaks happened to be. Good enough to assert "this wording made it
+ * onto the page"; NOT a layout check.
+ */
+function drawnPdfProse(bytes: Uint8Array): string {
+  const parts: string[] = [];
+  for (const m of inflatedStreams(bytes).matchAll(/<([0-9A-Fa-f]+)>/g)) {
+    parts.push(Buffer.from(m[1], 'hex').toString('latin1'));
+  }
+  return parts.join(' ');
 }
 
 describe('provenance metadata (v0.4.5, B4)', () => {
@@ -102,8 +209,9 @@ describe('provenance metadata (v0.4.5, B4)', () => {
       groundPercentile: 25,
       crs: 'EPSG:2225 - NAD83 / California zone 1 (ftUS)',
       verticalDatum: 'NAVD88',
+      generatedAt: FIXED_DATE,
     });
-    const text = drawnPdfText(bytes);
+    const text = drawnPdfProse(bytes);
     expect(text).toContain('EPSG:2225'); // header line + summary row
     expect(text).toContain('NAVD88');
     expect(text).toContain('12.500 m'); // the real corridor, not "auto" (5 sig figs)
@@ -112,35 +220,226 @@ describe('provenance metadata (v0.4.5, B4)', () => {
     expect(text).not.toContain('not georeferenced');
   });
 
-  /**
-   * The sampler reduces each corridor bin to a percentile of the returns that
-   * survived the class gate. That gate drops NON_GROUND_CLASSES
-   * ([3, 4, 5, 6, 7, 18]) and only when an index-aligned classification
-   * channel exists; classes 0, 1, 2, 9 and the 255 "no class channel"
-   * sentinel all reach the percentile. The sheet therefore states the
-   * estimator and the class gate, and never calls p25 a bare-earth surface.
-   */
-  it('states the percentile estimator and the class gate without claiming bare earth', async () => {
+  it('keeps the honest fallbacks when nothing is known', async () => {
     const bytes = await buildProfilePdf({
-      name: 'Levee section A',
-      samples: ramp(16),
-      groundPercentile: 25,
+      name: 'Local scan',
+      samples: ramp(8),
       generatedAt: FIXED_DATE,
     });
-    const text = drawnPdfText(bytes);
-    expect(text).toContain('p25 of corridor returns');
-    expect(text).toContain('Non-ground classes');
-    expect(text).toContain('Excluded where a source classifies');
-    expect(text).not.toContain('bare-earth');
-    expect(text).not.toContain('bare earth');
-    expect(text).not.toContain('ground p25');
-  });
-
-  it('keeps the honest fallbacks when nothing is known', async () => {
-    const bytes = await buildProfilePdf({ name: 'Local scan', samples: ramp(8) });
-    const text = drawnPdfText(bytes);
+    const text = drawnPdfProse(bytes);
     expect(text).toContain('auto (5% of length)');
     expect(text).toContain('not georeferenced');
+  });
+});
+
+/**
+ * Every occurrence of "ground" on the sheet, except the one inside the
+ * standing suitability note ("validated against ground-truth control"),
+ * which is a caveat about validation and not a name for the drawn series.
+ */
+function groundClaims(text: string): string[] {
+  const out: string[] = [];
+  for (const m of text.matchAll(/ground/gi)) {
+    const at = m.index ?? 0;
+    if (/^ground-truth/i.test(text.slice(at, at + 12))) continue;
+    out.push(text.slice(Math.max(0, at - 24), at + 24));
+  }
+  return out;
+}
+
+describe('the derived series is named as the legend names it', () => {
+  const SOURCES: DerivedSurfaceSource[] = [
+    { label: 'Flight A', classification: 'producer', read: 'static' },
+  ];
+
+  it('prints the legend series label and caption verbatim', async () => {
+    const samples = ramp(16);
+    const legend = buildDerivedSurfaceLegend({
+      samples,
+      percentile: 25,
+      corridorHalfWidthM: 12.5,
+      sources: SOURCES,
+      excludedClasses: NON_GROUND_CLASSES,
+    });
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'Levee section A',
+        samples,
+        corridorWidthM: 12.5,
+        groundPercentile: 25,
+        generatedAt: FIXED_DATE,
+        provenance: provenanceOf(
+          [{ layerId: 'layer-a', displayName: 'Flight A', classification: 'producer' }],
+          [0, 0, 0],
+        ),
+      }),
+    );
+    expect(text).toContain(legend.seriesLabel);
+    expect(text).toContain(legend.caption);
+    // And every sentence the legend states about it.
+    for (const line of legend.lines) expect(text).toContain(line);
+  });
+
+  it('never names the series after a terrain class', async () => {
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'Levee section A',
+        samples: ramp(16),
+        groundPercentile: 25,
+        generatedAt: FIXED_DATE,
+        provenance: provenanceOf(
+          [{ layerId: 'layer-a', displayName: 'Flight A', classification: 'producer' }],
+          [0, 0],
+        ),
+      }),
+    );
+    expect(groundClaims(text)).toEqual([]);
+    expect(text.toLowerCase()).not.toContain('bare earth');
+    expect(text.toLowerCase()).not.toContain('bare-earth');
+  });
+
+  it('prints the percentile that actually ran, not the sampler default', async () => {
+    const samples = ramp(16);
+    const legend = buildDerivedSurfaceLegend({
+      samples,
+      percentile: 10,
+      sources: SOURCES,
+      excludedClasses: NON_GROUND_CLASSES,
+    });
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'p10 section',
+        samples,
+        groundPercentile: 10,
+        generatedAt: FIXED_DATE,
+      }),
+    );
+    expect(legend.seriesLabel).toContain('10th percentile');
+    expect(text).toContain(legend.seriesLabel);
+    expect(text).not.toContain('25th percentile');
+  });
+});
+
+describe('the sheet carries the provenance a reader of the file cannot see', () => {
+  it('lists every source read, by stable layer id and display name', async () => {
+    const record = provenanceOf(
+      [
+        { layerId: 'urn:layer:alpha', displayName: 'Alpha flight', classification: 'producer' },
+        {
+          layerId: 'urn:layer:beta',
+          displayName: 'Beta stream',
+          classification: 'derived',
+          streaming: true,
+        },
+      ],
+      [0, 0, 1],
+    );
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'Two sources',
+        samples: ramp(16),
+        generatedAt: FIXED_DATE,
+        provenance: record,
+      }),
+    );
+    expect(text).toContain('urn:layer:alpha');
+    expect(text).toContain('urn:layer:beta');
+    expect(text).toContain('Alpha flight');
+    expect(text).toContain('Beta stream');
+    // The classification kind per source, not one source's answer for both.
+    expect(text).toContain('producer');
+    expect(text).toContain('derived');
+    // The read kind per source.
+    expect(text).toContain('streaming');
+    expect(text).toContain('static');
+    // The counts the record keeps.
+    expect(text).toContain('Total accepted returns: 3.');
+    expect(text).toContain('Sources read');
+    expect(text).toContain('2 (2 contributing)');
+  });
+
+  it('states the read scope from the record, not a default', async () => {
+    const record = provenanceOf(
+      [
+        {
+          layerId: 'urn:layer:stream',
+          displayName: 'Resident only',
+          classification: 'producer',
+          streaming: true,
+        },
+      ],
+      [0, 0],
+    );
+    expect(record.scope).toBe('resident-snapshot');
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'Resident section',
+        samples: ramp(16),
+        generatedAt: FIXED_DATE,
+        provenance: record,
+      }),
+    );
+    expect(text).toContain(describeProfileProvenance(record));
+    expect(text).toContain('a resident streaming snapshot, not the full sources');
+    expect(text).toContain('coverage unknown');
+  });
+
+  it('says so, rather than implying a read, when no record was attached', async () => {
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'No record',
+        samples: ramp(16),
+        generatedAt: FIXED_DATE,
+      }),
+    );
+    expect(text).toContain('No provenance record was attached to this export');
+    expect(text).toContain('Not recorded');
+    expect(text).not.toContain('Full static source');
+  });
+
+  it('refuses to claim full class exclusion when a source carries no classification', async () => {
+    const record = provenanceOf(
+      [
+        { layerId: 'urn:layer:classified', displayName: 'Classified', classification: 'producer' },
+        { layerId: 'urn:layer:raw', displayName: 'Unclassified', classification: 'absent' },
+      ],
+      [0, 1],
+    );
+    expect(record.classPolicy.availableOnEverySource).toBe(false);
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'Partial classification',
+        samples: ramp(16),
+        generatedAt: FIXED_DATE,
+        provenance: record,
+      }),
+    );
+    expect(text).toContain('excluded on only 1 of 2 sources: partial');
+    expect(text).toContain('the exclusion did not apply to the whole section');
+    expect(text).toContain('on only 1 of 2 sources: partial'); // the summary line
+    expect(text).not.toContain('excluded on every contributing source');
+    expect(text).not.toContain('on every source');
+  });
+
+  it('claims full class exclusion only when every contributing source carries it', async () => {
+    const record = provenanceOf(
+      [
+        { layerId: 'urn:layer:a', displayName: 'A', classification: 'producer' },
+        { layerId: 'urn:layer:b', displayName: 'B', classification: 'derived' },
+      ],
+      [0, 1],
+    );
+    expect(record.classPolicy.availableOnEverySource).toBe(true);
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'Full classification',
+        samples: ramp(16),
+        generatedAt: FIXED_DATE,
+        provenance: record,
+      }),
+    );
+    expect(text).toContain('excluded on every contributing source (2 of 2)');
+    expect(text).not.toContain(': partial');
   });
 });
 
@@ -152,6 +451,18 @@ describe('provenance metadata (v0.4.5, B4)', () => {
 const MOVE_OP = /^\s*-?[\d.]+ -?[\d.]+ m\s*$/;
 const LINE_OP = /^\s*-?[\d.]+ -?[\d.]+ l\s*$/;
 const CURVE_OP = /^\s*-?[\d.]+ -?[\d.]+ -?[\d.]+ -?[\d.]+ -?[\d.]+ -?[\d.]+ c\s*$/;
+
+/** Longest run of consecutive linetos after a moveto. */
+function longestRun(lines: readonly string[]): number {
+  let longest = 0;
+  let run = 0;
+  for (const l of lines) {
+    if (LINE_OP.test(l)) run++;
+    else if (MOVE_OP.test(l)) run = 0;
+    if (run > longest) longest = run;
+  }
+  return longest;
+}
 
 describe('profile geometry — the sheet draws only what the samples say', () => {
   /**
@@ -173,16 +484,9 @@ describe('profile geometry — the sheet draws only what the samples say', () =>
     });
     const lines = drawnPdfText(bytes).split('\n');
     expect(lines.filter((l) => CURVE_OP.test(l))).toHaveLength(0);
-    // Longest run of consecutive linetos after a moveto: the grid draws
-    // moveto/lineto pairs, the profile draws one moveto and three linetos.
-    let longest = 0;
-    let run = 0;
-    for (const l of lines) {
-      if (LINE_OP.test(l)) run++;
-      else if (MOVE_OP.test(l)) run = 0;
-      if (run > longest) longest = run;
-    }
-    expect(longest).toBe(plateau.length - 1);
+    // The grid draws moveto/lineto pairs, the profile draws one moveto and
+    // three linetos.
+    expect(longestRun(lines)).toBe(plateau.length - 1);
   });
 
   it('breaks the drawn line at a coverage gap', async () => {
@@ -204,16 +508,15 @@ describe('profile geometry — the sheet draws only what the samples say', () =>
       generatedAt: FIXED_DATE,
     });
     const lines = drawnPdfText(bytes).split('\n');
+    const text = drawnPdfProse(bytes);
     expect(lines.filter((l) => CURVE_OP.test(l))).toHaveLength(0);
     // Two runs of two linetos each, never a single run that bridges the gap.
-    let longest = 0;
-    let run = 0;
-    for (const l of lines) {
-      if (LINE_OP.test(l)) run++;
-      else if (MOVE_OP.test(l)) run = 0;
-      if (run > longest) longest = run;
-    }
-    expect(longest).toBe(2);
+    expect(longestRun(lines)).toBe(2);
+    // And the sheet SAYS the line breaks, with the gap count the legend counted.
+    expect(text).toContain('1 of 7 stations had no returns in the corridor');
+    expect(text).toContain('never interpolated across them');
+    // The station table prints the gap as a gap, not as an interpolated height.
+    expect(text).toContain('gap');
   });
 });
 
@@ -224,8 +527,10 @@ describe('unit system (v0.4.5, B9) — the sheet honours the active toggle end-t
       samples: ramp(16),
       corridorWidthM: 12.5,
       unitSystem: 'imperial',
+      verticalDatum: 'NAVD88',
+      generatedAt: FIXED_DATE,
     });
-    const text = drawnPdfText(bytes);
+    const text = drawnPdfProse(bytes);
     // Chart axes.
     expect(text).toContain('Elevation (ft)');
     expect(text).toContain('Chainage (100 ft stations)');
@@ -236,18 +541,23 @@ describe('unit system (v0.4.5, B9) — the sheet honours the active toggle end-t
     // figs); the corridor 12.5 m = 41.0105 ft → "41.010 ft".
     expect(text).toContain('98.425 ft');
     expect(text).toContain('41.010 ft');
-    // Station table: header names the unit; elevations convert per station
+    // Station table: header names the unit; heights convert per station
     // (station 0 sits at exactly 100 m = 328.0840 ft → "328.08").
-    expect(text).toContain('elevation (ft)');
+    expect(text).toContain('Elevation (ft), grade to next');
     expect(text).toContain('328.08');
   });
 
   it('metric stays the default sheet when no unit system is passed', async () => {
-    const bytes = await buildProfilePdf({ name: 'Metric section', samples: ramp(16) });
-    const text = drawnPdfText(bytes);
+    const bytes = await buildProfilePdf({
+      name: 'Metric section',
+      samples: ramp(16),
+      verticalDatum: 'NAVD88',
+      generatedAt: FIXED_DATE,
+    });
+    const text = drawnPdfProse(bytes);
     expect(text).toContain('Elevation (m)');
     expect(text).toContain('Chainage (station km+m)');
-    expect(text).toContain('elevation (m)');
+    expect(text).toContain('Elevation (m), grade to next');
     expect(text).not.toContain('Elevation (ft)');
   });
 });
@@ -268,17 +578,83 @@ describe('the sheet prints the same source elevations as the panel', () => {
       1,
       830.03,
     );
-    const text = drawnPdfText(await buildProfilePdf({ name: 'Datum section', samples }));
+    const text = drawnPdfProse(
+      await buildProfilePdf({ name: 'Datum section', samples, generatedAt: FIXED_DATE }),
+    );
     const byLabel = new Map(
       profileSummaryRows(computeProfileSummary(samples), 'metric').map((r) => [r.label, r.value]),
     );
     expect(byLabel.get('Highest point')).toBe('418.16 m @ 0+343.98');
     expect(text).toContain(byLabel.get('Highest point'));
     expect(text).toContain(byLabel.get('Lowest point'));
-    // The elevations that reach the sheet are the header's, not the render
+    // The heights that reach the sheet are the header's, not the render
     // origin's — and never the centimetres a length formatter made of them.
     expect(text).toContain('348.93 m');
     expect(text).not.toContain('41186.5');
+  });
+});
+
+describe('height wording follows heightLabel, never the sheet author', () => {
+  it('an undeclared datum is a height, not an elevation', async () => {
+    const text = drawnPdfProse(
+      await buildProfilePdf({ name: 'No datum', samples: ramp(16), generatedAt: FIXED_DATE }),
+    );
+    expect(heightLabel('unknown')).toBe('Height (datum unknown)');
+    expect(text).toContain('Height (datum unknown) (m)');
+    expect(text).toContain('Height (datum unknown) min / max');
+    expect(text).toContain('Highest / Lowest height (datum unknown)');
+    expect(text).toContain('No vertical datum is declared');
+    // Nothing on the sheet may call these elevations.
+    expect(text).not.toContain('Elevation (m)');
+    expect(text).not.toContain('Elevation min / max');
+  });
+
+  it('a datum the tables do not recognise is not upgraded to an elevation', async () => {
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'Unrecognised datum',
+        samples: ramp(16),
+        verticalDatum: 'Site benchmark 1972',
+        generatedAt: FIXED_DATE,
+      }),
+    );
+    expect(text).toContain('Height (datum unknown) (m)');
+    expect(text).toContain('Site benchmark 1972'); // still printed, still named
+    expect(text).not.toContain('Elevation (m)');
+  });
+
+  it('an orthometric datum earns Elevation', async () => {
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'NAVD88 section',
+        samples: ramp(16),
+        verticalDatum: 'NAVD88',
+        generatedAt: FIXED_DATE,
+      }),
+    );
+    expect(heightLabel('orthometric')).toBe('Elevation');
+    expect(text).toContain('Elevation (m)');
+    expect(text).toContain('Elevation min / max');
+    expect(text).toContain('Highest / Lowest elevation');
+    expect(text).toContain('approximately mean sea level');
+  });
+
+  it('an ellipsoidal reference in the record is not printed as an elevation', async () => {
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'GNSS section',
+        samples: ramp(16),
+        generatedAt: FIXED_DATE,
+        provenance: provenanceOf(
+          [{ layerId: 'urn:layer:a', displayName: 'A', classification: 'producer' }],
+          [0, 0],
+          'ellipsoidal',
+        ),
+      }),
+    );
+    expect(text).toContain('Ellipsoidal height (m)');
+    expect(text).toContain('Not a sea-level elevation.');
+    expect(text).not.toContain('Elevation (m)');
   });
 });
 
@@ -290,12 +666,17 @@ describe('the sheet refuses a datum it cannot assert', () => {
       { distance: 171.99, height: -449.53, count: 4 },
       { distance: 343.98, height: -411.865, count: 9 },
     ];
-    const text = drawnPdfText(
-      await buildProfilePdf({ name: 'Unresolved datum', samples, datumKnown: false }),
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'Unresolved datum',
+        samples,
+        datumKnown: false,
+        generatedAt: FIXED_DATE,
+      }),
     );
     // Nothing on the sheet may call these elevations.
-    expect(text).toContain('Local height (m)');
-    expect(text).toContain('Min / Max local height');
+    expect(text).toContain('Height (local frame) (m)');
+    expect(text).toContain('Height (local frame) min / max');
     expect(text).not.toContain('Elevation (m)');
     // The sheet's existing datum row is where a reader looks for exactly this.
     expect(text).toContain('conflicting cloud origins');
@@ -309,9 +690,35 @@ describe('the sheet refuses a datum it cannot assert', () => {
     expect(text).toContain(byLabel.get('Highest point (local height)'));
   });
 
+  it('a conflicting origin outranks an orthometric record', async () => {
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'Conflicting origins',
+        samples: ramp(16),
+        datumKnown: false,
+        verticalDatum: 'NAVD88',
+        generatedAt: FIXED_DATE,
+        provenance: provenanceOf(
+          [{ layerId: 'urn:layer:a', displayName: 'A', classification: 'producer' }],
+          [0, 0],
+          'orthometric',
+        ),
+      }),
+    );
+    expect(text).toContain('Height (local frame) (m)');
+    expect(text).not.toContain('Elevation (m)');
+  });
+
   it('a resolvable datum leaves the sheet exactly as it was', async () => {
-    const text = drawnPdfText(await buildProfilePdf({ name: 'Metric section', samples: ramp(16) }));
+    const text = drawnPdfProse(
+      await buildProfilePdf({
+        name: 'Metric section',
+        samples: ramp(16),
+        verticalDatum: 'NAVD88',
+        generatedAt: FIXED_DATE,
+      }),
+    );
     expect(text).toContain('Elevation (m)');
-    expect(text).not.toContain('Local height (m)');
+    expect(text).not.toContain('Height (local frame) (m)');
   });
 });


### PR DESCRIPTION
The Profile PDF asserted a datum it did not have. `heightWord` was `datumKnown ? 'Elevation' : 'Local height'`, and `datumKnown` is `this._originUp !== null`, which says the scene's origins agree rather than that a vertical datum exists. A cloud carrying no vertical datum printed `Elevation (m)` on its axis, its min and max rows, and its station-table header.

Every heading now resolves through `heightLabel`, so an undeclared datum reads `Height (datum unknown)`, an ellipsoidal record reads `Ellipsoidal height`, and NAVD88 still earns `Elevation`. Conflicting origins outrank the record.

The derived series takes its words from `profileDerivedLegend` rather than a second set of its own, so the sheet and the screen cannot give two answers. A provenance page lists each contributing source by stable layer id with its classification kind and read scope, and only contributing sources reach the legend, so the sheet cannot claim a class policy covered the whole section.

`generatedAt` defaulted to `new Date()` inside the builder, which made byte identity impossible. It is now required and read at the app boundary.
