### PR TITLE
Link a section return to its own point in 3D

### DIFF
--- a/src/app/measurePanelMount.ts
+++ b/src/app/measurePanelMount.ts
@@ -126,6 +126,11 @@ export function createMeasurePanelMount(deps: MeasurePanelMountDeps): MeasurePan
         return crs.linearUnitKnown === true ? crs.linearUnitToMetres : null;
       },
       devicePixelRatio: () => (typeof window === 'undefined' ? 1 : window.devicePixelRatio),
+      // The scene NOW, for a section that is a snapshot. A return is followed
+      // back by the identity it was recorded under, never by matching
+      // coordinates, so the seam is asked for one specific source point.
+      locateReturn: (ref, out) => deps.getViewer().profileSeam.locateReturn(ref, out),
+      crs: () => deps.crsService.current() ?? undefined,
     };
   }
 
@@ -145,7 +150,18 @@ export function createMeasurePanelMount(deps: MeasurePanelMountDeps): MeasurePan
   function openWorkbench(summary: MeasurementSummary): Promise<boolean> {
     if (!workbenchStage) return Promise.resolve(false);
     workbench ??= loadProfileWorkbenchRuntime().then(({ createProfileWorkbenchRuntime }) => {
-      launcher = createProfileWorkbenchRuntime({ stage: workbenchStage, scene: workbenchScene() });
+      launcher = createProfileWorkbenchRuntime({
+        stage: workbenchStage,
+        scene: workbenchScene(),
+        markerHost: () => deps.getViewer().derivedLayerHost(),
+        // The pose pair, not a focus call: the workbench composes the move so
+        // the arithmetic stays testable, and so the only way here is the
+        // deliberate action on a clicked selection.
+        camera: {
+          pose: () => deps.getViewer().getCameraPose(),
+          apply: (pose) => deps.getViewer().applyCameraPose(pose),
+        },
+      });
       return launcher;
     });
     return workbench.then(

--- a/src/app/profileLinkController.ts
+++ b/src/app/profileLinkController.ts
@@ -1,0 +1,357 @@
+/**
+ * profileLinkController.ts
+ *
+ * Hover and click on the section plot, turned into one selected return and the
+ * marks that describe it.
+ *
+ * FOUR PROPERTIES THIS MODULE EXISTS TO HOLD.
+ *
+ *   1. IDENTITY, NOT POSITION. A pointer position becomes a section index
+ *      through the screen-cell index, and the index becomes a
+ *      `ProfileReturnIdentity` — slot, source kind, source id, source point
+ *      index — before anything is resolved. Nothing downstream ever searches
+ *      the scene for the nearest coordinate.
+ *
+ *   2. HOVER NEVER MOVES THE CAMERA. There is no path from `pointerMove` to
+ *      `focus`. The camera moves only through {@link ProfileLinkController.focusSelection},
+ *      which refuses unless a click has locked a selection AND that selection
+ *      still resolves. Reading along a section drags the pointer across
+ *      hundreds of returns; a camera that followed would make the plot
+ *      unusable.
+ *
+ *   3. ONE FLUSH PER FRAME. A raw pointer move records a position and asks the
+ *      scheduler for a frame. It does not hit-test, does not compose a
+ *      readout, and does not touch a card. A burst of moves inside one frame
+ *      produces exactly one hit-test and at most one presentation, and a flush
+ *      whose result is identical to the last one presents nothing at all.
+ *
+ *   4. A LOST SOURCE IS SAID, NOT HIDDEN. Every flush re-resolves the locked
+ *      selection against the live scene, so a streaming node evicted after the
+ *      snapshot was taken turns the link to `evicted` while the 2D figures and
+ *      the card stay exactly where they were. The selection is not dropped and
+ *      the marker is not left behind claiming the point is still there.
+ *
+ * Nothing here is view-bound. Hit-testing, projection, resolution, drawing,
+ * marking and presentation all arrive as functions, so the whole state machine
+ * runs under Node with no canvas, no three.js and no DOM.
+ */
+
+import {
+  locateProfileReturn,
+  type ProfileLinkState,
+  type ProfileReturnIdentity,
+  type ProfileReturnLink,
+  type ProfileReturnLocator,
+} from '../render/measure/profilePointLink';
+
+import type { ProfilePointDetail } from '../render/measure/profilePointDetail';
+import type { ProfileLinkPoint } from '../render/measure/profileLinkOverlay2d';
+
+/** One resolved return, with where it sits on the plot. */
+export interface ProfileLinkView {
+  readonly identity: ProfileReturnIdentity;
+  readonly state: ProfileLinkState;
+  readonly position: readonly [number, number, number] | null;
+  /** Where the return is drawn, or null when it is not currently drawn. */
+  readonly screen: ProfileLinkPoint | null;
+  /** The concise one-line readout for this return. */
+  readonly readout: string;
+}
+
+/** What the 3D scene is asked to mark. */
+export interface ProfileLinkMarker {
+  readonly position: readonly [number, number, number];
+  /** A locked selection reads heavier than a passing hover. */
+  readonly mode: 'hover' | 'locked';
+}
+
+/** Everything the panel is told after a flush. */
+export interface ProfileLinkUiState {
+  readonly hover: ProfileLinkView | null;
+  readonly locked: ProfileLinkView | null;
+  /** Built only for a locked selection; a hover never pays for a card. */
+  readonly detail: ProfilePointDetail | null;
+}
+
+export interface ProfileLinkControllerDeps {
+  /** Nearest DRAWN return to a plot position, or null. */
+  query: (xPx: number, yPx: number) => number | null;
+  /** Where return `i` is drawn, in plot CSS pixels. False when it is not. */
+  project: (i: number, out: Float64Array) => boolean;
+  /** The stable identity of return `i`, or null. */
+  identify: (i: number) => ProfileReturnIdentity | null;
+  /** The live scene. */
+  locate: ProfileReturnLocator;
+  /** The concise readout for return `i`. */
+  readout: (i: number) => string;
+  /** The card for a locked return. Called only on a lock, never on a hover. */
+  detail: (i: number) => ProfilePointDetail | null;
+  /** Ask for one frame. The callback must run at most once per request. */
+  schedule: (run: () => void) => void;
+  /** Draw the 2D marks. */
+  paint: (hover: ProfileLinkPoint | null, locked: ProfileLinkPoint | null) => void;
+  /** Place or clear the 3D marker. */
+  mark: (marker: ProfileLinkMarker | null) => void;
+  /** Readout line and card. */
+  present: (state: ProfileLinkUiState) => void;
+  /**
+   * Move the camera. OPTIONAL, and reached only from `focusSelection`.
+   * A host that supplies none simply has no focus action.
+   */
+  focus?: (position: readonly [number, number, number]) => void;
+}
+
+/** Counters, so the coalescing can be asserted rather than assumed. */
+export interface ProfileLinkStats {
+  /** Raw pointer events handed in. */
+  readonly pointerEvents: number;
+  /** Flushes actually run. */
+  readonly flushes: number;
+  /** Hit-tests performed. */
+  readonly hitTests: number;
+  /** Readouts composed. */
+  readonly readouts: number;
+  /** Presentations pushed to the panel. */
+  readonly presents: number;
+  /** Camera focus calls. */
+  readonly focuses: number;
+}
+
+export interface ProfileLinkController {
+  /** A raw pointer move. Records and schedules; does no work of its own. */
+  pointerMove(xPx: number, yPx: number): void;
+  /** The pointer left the plot. Clears the hover on the next flush. */
+  pointerLeave(): void;
+  /** A click. Locks the return under it, or clears the lock when it misses. */
+  click(xPx: number, yPx: number): void;
+  /** Drop the locked selection. */
+  clearSelection(): void;
+  /** The locked selection, or null. */
+  selection(): ProfileLinkView | null;
+  /**
+   * Move the camera to the locked selection.
+   *
+   * False when nothing is locked, when the locked return has no live source,
+   * or when the host supplied no camera. Never reachable from a hover.
+   */
+  focusSelection(): boolean;
+  /** Re-resolve against the live scene and repaint. Safe to call at any time. */
+  refresh(): void;
+  stats(): ProfileLinkStats;
+  /** Clear every mark and stop responding. Idempotent. */
+  dispose(): void;
+}
+
+/** What a flush was asked to do with the hover. */
+type Pending = { readonly kind: 'move'; readonly x: number; readonly y: number } | { readonly kind: 'leave' } | null;
+
+/** Two views name the same thing when index and state agree. */
+function sameView(a: ProfileLinkView | null, b: ProfileLinkView | null): boolean {
+  if (a === null || b === null) return a === b;
+  return (
+    a.identity.sectionIndex === b.identity.sectionIndex &&
+    a.state === b.state &&
+    a.screen?.x === b.screen?.x &&
+    a.screen?.y === b.screen?.y
+  );
+}
+
+export function createProfileLinkController(
+  deps: ProfileLinkControllerDeps,
+): ProfileLinkController {
+  const scratch = new Float64Array(3);
+  const screenOut = new Float64Array(2);
+
+  let disposed = false;
+  let pending: Pending = null;
+  let scheduled = false;
+  let hover: ProfileLinkView | null = null;
+  let locked: ProfileLinkView | null = null;
+  let detail: ProfilePointDetail | null = null;
+  let lastHover: ProfileLinkView | null = null;
+  let lastLocked: ProfileLinkView | null = null;
+  let presented = false;
+
+  let pointerEvents = 0;
+  let flushes = 0;
+  let hitTests = 0;
+  let readouts = 0;
+  let presents = 0;
+  let focuses = 0;
+
+  /** Resolve the return at a plot position, or null when none is near. */
+  function viewAt(xPx: number, yPx: number): ProfileLinkView | null {
+    hitTests++;
+    const i = deps.query(xPx, yPx);
+    if (i === null) return null;
+    const identity = deps.identify(i);
+    if (!identity) return null;
+    return viewOf(identity, locateProfileReturn(identity, deps.locate, scratch));
+  }
+
+  /**
+   * Re-resolve a known identity, keeping its screen position current.
+   *
+   * `reuse` carries the readout of a view for the SAME return, so re-reading a
+   * lock every frame costs a resolution and a projection rather than a fresh
+   * line of text. The readout describes the section, which does not change
+   * under a lock; only the link state does.
+   */
+  function viewOf(
+    identity: ProfileReturnIdentity,
+    link: ProfileReturnLink,
+    reuse?: ProfileLinkView,
+  ): ProfileLinkView {
+    const drawn = deps.project(identity.sectionIndex, screenOut);
+    let readout: string;
+    if (reuse && reuse.identity.sectionIndex === identity.sectionIndex) {
+      readout = reuse.readout;
+    } else {
+      readouts++;
+      readout = deps.readout(identity.sectionIndex);
+    }
+    return {
+      identity,
+      state: link.state,
+      position: link.position,
+      screen: drawn ? { x: screenOut[0]!, y: screenOut[1]! } : null,
+      readout,
+    };
+  }
+
+  /** The mark the 3D scene should carry: the lock when there is one. */
+  function markerOf(): ProfileLinkMarker | null {
+    const chosen = locked ?? hover;
+    if (!chosen || chosen.state !== 'linked' || !chosen.position) return null;
+    return { position: chosen.position, mode: locked ? 'locked' : 'hover' };
+  }
+
+  /**
+   * Push the current state outward, and only when it changed.
+   *
+   * The comparison is on identity and link state, not on object identity, so a
+   * pointer wandering inside one return's hit radius repaints nothing.
+   */
+  function emit(): void {
+    if (presented && sameView(hover, lastHover) && sameView(locked, lastLocked)) return;
+    lastHover = hover;
+    lastLocked = locked;
+    presented = true;
+    presents++;
+    deps.paint(hover?.screen ?? null, locked?.screen ?? null);
+    deps.mark(markerOf());
+    deps.present({ hover, locked, detail });
+  }
+
+  /** Re-resolve the locked selection. The 2D figures are never touched. */
+  function refreshLocked(): void {
+    if (!locked) return;
+    locked = viewOf(
+      locked.identity,
+      locateProfileReturn(locked.identity, deps.locate, scratch),
+      locked,
+    );
+  }
+
+  function flush(): void {
+    scheduled = false;
+    if (disposed) return;
+    flushes++;
+    const want = pending;
+    pending = null;
+    if (want?.kind === 'move') hover = viewAt(want.x, want.y);
+    else if (want?.kind === 'leave') hover = null;
+    // A locked node can be evicted while the pointer is elsewhere, so the lock
+    // is re-read on every flush rather than only when it is set.
+    refreshLocked();
+    emit();
+  }
+
+  function request(): void {
+    if (scheduled || disposed) return;
+    scheduled = true;
+    deps.schedule(flush);
+  }
+
+  return {
+    pointerMove(xPx: number, yPx: number): void {
+      if (disposed) return;
+      pointerEvents++;
+      // The ONLY work a raw move does: record and ask for a frame.
+      pending = { kind: 'move', x: xPx, y: yPx };
+      request();
+    },
+
+    pointerLeave(): void {
+      if (disposed) return;
+      pointerEvents++;
+      pending = { kind: 'leave' };
+      request();
+    },
+
+    click(xPx: number, yPx: number): void {
+      if (disposed) return;
+      pointerEvents++;
+      // A click is acted on immediately: the card it opens is the response to
+      // the press, not to the next frame.
+      const picked = viewAt(xPx, yPx);
+      locked = picked;
+      detail = picked ? deps.detail(picked.identity.sectionIndex) : null;
+      hover = picked ?? hover;
+      pending = null;
+      emit();
+    },
+
+    clearSelection(): void {
+      if (disposed) return;
+      locked = null;
+      detail = null;
+      emit();
+    },
+
+    selection(): ProfileLinkView | null {
+      return locked;
+    },
+
+    focusSelection(): boolean {
+      // Locked only. A hover cannot reach here, and neither can a selection
+      // whose source has gone: there is no position to focus on.
+      if (disposed || !locked || locked.state !== 'linked' || !locked.position) return false;
+      if (!deps.focus) return false;
+      focuses++;
+      deps.focus(locked.position);
+      return true;
+    },
+
+    refresh(): void {
+      if (disposed) return;
+      if (hover) {
+        hover = viewOf(
+          hover.identity,
+          locateProfileReturn(hover.identity, deps.locate, scratch),
+          hover,
+        );
+      }
+      refreshLocked();
+      // Forced: a refresh follows a redraw, which cleared the overlay surface,
+      // so the marks have to be laid down again even when nothing changed.
+      presented = false;
+      emit();
+    },
+
+    stats(): ProfileLinkStats {
+      return { pointerEvents, flushes, hitTests, readouts, presents, focuses };
+    },
+
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      pending = null;
+      hover = null;
+      locked = null;
+      detail = null;
+      deps.paint(null, null);
+      deps.mark(null);
+    },
+  };
+}

--- a/src/app/profileWorkbenchRuntime.ts
+++ b/src/app/profileWorkbenchRuntime.ts
@@ -21,15 +21,36 @@ import { createProfileWorkbenchLauncher } from './profileWorkbenchLauncher';
 import { createStageProfileWorkbench } from './profileWorkbenchStage';
 import { presentWorkbenchSection } from './profileWorkbenchSection';
 import { loadProfileWorkbench } from '../lazyChunks';
+import { ProfileLinkOverlay } from '../render/ProfileLinkOverlay';
+import { focusPoseOnPoint } from '../render/measure/profilePointLink';
 
 import type { ProfileWorkbenchLauncher } from './profileWorkbenchLauncher';
 import type { WorkbenchSectionScene } from './profileWorkbenchSection';
+import type { ProfileLinkOverlayHost } from '../render/ProfileLinkOverlay';
+import type { ProfileCameraPose } from '../render/measure/profilePointLink';
 
 export interface ProfileWorkbenchRuntimeDeps {
   /** The stage the dock shares its box with. */
   stage: { root: HTMLElement };
   /** The live scene, read at open time so a dock is a snapshot of that moment. */
   scene: WorkbenchSectionScene;
+  /**
+   * Scene membership for the 3D mark — `viewer.derivedLayerHost()`.
+   *
+   * Held here rather than on the scene because building the mark needs three,
+   * and this module is the first one on the path that is already behind a
+   * dynamic import. Absent leaves the link 2D only.
+   */
+  markerHost?: () => ProfileLinkOverlayHost;
+  /**
+   * Read and write the camera, for the deliberate focus action on a CLICKED
+   * selection. Absent means the workbench simply has no focus action; nothing
+   * else changes, and no hover has a path here either way.
+   */
+  camera?: {
+    pose(): ProfileCameraPose;
+    apply(pose: { position: [number, number, number]; target: [number, number, number] }): void;
+  };
   /**
    * Told about a rejected panel chunk, or a fill that threw. Defaults to a
    * console record: the user already has the focus view, so nothing about the
@@ -48,10 +69,40 @@ export interface ProfileWorkbenchRuntimeDeps {
 export function createProfileWorkbenchRuntime(
   deps: ProfileWorkbenchRuntimeDeps,
 ): ProfileWorkbenchLauncher {
+  // ONE overlay for the runtime, built on first use and reused by every dock.
+  // A per-dock overlay would need the launcher to remember to dispose the
+  // previous one, which is exactly the "stale mark left in the scene" bug.
+  let overlay: ProfileLinkOverlay | null = null;
+  const markerHost = deps.markerHost;
+  const camera = deps.camera;
+
+  const scene: WorkbenchSectionScene = {
+    ...deps.scene,
+    ...(markerHost
+      ? {
+          markLinkedReturn: (marker): void => {
+            if (!marker) {
+              overlay?.show(null);
+              return;
+            }
+            overlay ??= new ProfileLinkOverlay(markerHost());
+            overlay.show({ position: marker.position, mode: marker.mode, size: marker.size });
+          },
+        }
+      : {}),
+    ...(camera
+      ? {
+          focusPoint: (position): void => {
+            camera.apply(focusPoseOnPoint(camera.pose(), position));
+          },
+        }
+      : {}),
+  };
+
   return createProfileWorkbenchLauncher({
     load: () => loadProfileWorkbench(),
     stage: createStageProfileWorkbench(deps.stage),
-    present: (handle, request) => presentWorkbenchSection(handle, request.id, deps.scene),
+    present: (handle, request) => presentWorkbenchSection(handle, request.id, scene),
     onLoadFailure:
       deps.onLoadFailure ??
       ((error) => {

--- a/src/app/profileWorkbenchSection.ts
+++ b/src/app/profileWorkbenchSection.ts
@@ -42,7 +42,7 @@ import {
 } from '../render/measure/profileColour';
 import {
   fitProfileView,
-  type ProfileViewport,
+  profileDataToScreen,
 } from '../render/measure/profileViewTransform';
 import {
   ProfileSectionRenderer,
@@ -54,13 +54,35 @@ import {
   selectProfileSectionLod,
   selectProfileSectionLodChunks,
 } from '../render/measure/profileSectionLod';
+import {
+  buildProfileHitTestIndex,
+  queryProfileHitTest,
+} from '../render/measure/profileHitTest';
+import { buildProfilePointDetail } from '../render/measure/profilePointDetail';
+import {
+  profileDetailSources,
+  profileHoverReadout,
+  profileLinkStatusText,
+  profileMarkerSize,
+  profileReturnIdentity,
+} from '../render/measure/profilePointLink';
+import { drawProfileLinkOverlay } from '../render/measure/profileLinkOverlay2d';
+import { pointVerticalReference } from '../render/pointInfo';
+import { createProfileLinkController } from './profileLinkController';
 
 import type { ProfileWorkbenchDetailRow } from '../ui/ProfileWorkbench';
+import type { ProfileHitTestIndex } from '../render/measure/profileHitTest';
+import type { ProfileView, ProfileViewport } from '../render/measure/profileViewTransform';
+import type { ProfileLinkOverlayContext } from '../render/measure/profileLinkOverlay2d';
+import type { ProfileLinkController, ProfileLinkMarker } from './profileLinkController';
 import type {
+  ProfileReturnLocation,
+  ProfileReturnRef,
   ProfileSectionRequest,
   ProfileSectionResult,
 } from '../render/measure/profileSectionSeam';
 import type { Vec3 } from '../render/measure/types';
+import type { ResolvedCrs } from '../geo/CoordinateTypes';
 
 /**
  * Most returns drawn at once.
@@ -162,11 +184,30 @@ export interface WorkbenchSectionView {
   readonly drawn: number;
 }
 
+/** The placement the last draw used, so a hit-test can agree with the picture. */
+export interface WorkbenchPlotFrame {
+  readonly view: ProfileView;
+  readonly viewport: ProfileViewport;
+}
+
 /** A composed section, with the means to draw it again at a new size. */
 export interface WorkbenchSectionPlot {
   readonly view: WorkbenchSectionView;
+  /** The section indices actually drawn, in draw order. */
+  readonly indices: Uint32Array;
   /** Draw at the canvas's current box. A box with no area draws nothing. */
   draw(): void;
+  /**
+   * The view and viewport the last successful draw used, or null when nothing
+   * has been drawn.
+   *
+   * Published rather than kept private because a hit-test has to be built over
+   * the SAME placement the picture was drawn with. Re-deriving it from the
+   * canvas would be a second `fitProfileView` call that a resize between the
+   * two could make disagree, and a hover would then name a return the reader
+   * is not pointing at.
+   */
+  frame(): WorkbenchPlotFrame | null;
 }
 
 export interface ComposeSectionOptions {
@@ -238,6 +279,8 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
   // until it has run.
   const renderer = surface ? new ProfileSectionRenderer(surface, (draw) => draw()) : null;
 
+  let lastFrame: WorkbenchPlotFrame | null = null;
+
   function draw(): void {
     if (!renderer) return;
     const width = canvas.clientWidth;
@@ -262,6 +305,7 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
       style: SECTION_STYLE,
     });
     renderer.renderNow();
+    lastFrame = { view, viewport };
   }
 
   draw();
@@ -291,7 +335,9 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
 
   return {
     view: { scope: section.scopeLabel, status, detail, drawn: indices.length },
+    indices,
     draw,
+    frame: () => lastFrame,
   };
 }
 
@@ -327,6 +373,46 @@ export interface WorkbenchSectionScene {
   now?(): number;
   /** Watch the plot's box. Absent ⇒ a `ResizeObserver` on the canvas. */
   observeCanvasSize?(canvas: HTMLCanvasElement, onChange: () => void): () => void;
+  /**
+   * The CURRENT project-frame coordinate of one recorded source point.
+   *
+   * `viewer.profileSeam.locateReturn`. Absent leaves the plot exactly as it
+   * was before this existed: hover and click still read the section, and no
+   * mark is placed in 3D, because there is nothing to route the identity
+   * through.
+   */
+  locateReturn?(ref: ProfileReturnRef, out: Float64Array): ProfileReturnLocation;
+  /** Place or clear the 3D mark. Absent ⇒ the link is 2D only. */
+  markLinkedReturn?(marker: (ProfileLinkMarker & { readonly size: number }) | null): void;
+  /**
+   * Move the camera onto a point.
+   *
+   * Reached ONLY from a deliberate focus action on a clicked selection. A
+   * hover has no path to it, which is why it is not part of the marker call.
+   */
+  focusPoint?(position: readonly [number, number, number]): void;
+  /** Resolved CRS of the section frame, for the height wording. */
+  crs?(): ResolvedCrs | undefined;
+  /** Subscribe to pointer input on the plot. Absent ⇒ DOM listeners. */
+  observePointer?(canvas: HTMLCanvasElement, handlers: WorkbenchPointerHandlers): () => void;
+  /** One frame for the pointer flush. Absent ⇒ a frame callback. */
+  schedulePointerFlush?(run: () => void): void;
+}
+
+/** What the plot does with pointer input, independent of how it arrives. */
+export interface WorkbenchPointerHandlers {
+  move(xPx: number, yPx: number): void;
+  leave(): void;
+  click(xPx: number, yPx: number): void;
+  /**
+   * The deliberate focus gesture: lock the return under the pointer AND move
+   * the camera onto it.
+   *
+   * A separate entry from `click` because the camera is exactly what a hover
+   * must never do. Hover and click each have their own way in, and only this
+   * one reaches a camera at all.
+   */
+  focus(xPx: number, yPx: number): void;
 }
 
 /** A frame if the host has one, a task otherwise. */
@@ -357,15 +443,18 @@ function observeElementSize(canvas: HTMLCanvasElement, onChange: () => void): ()
 export function presentWorkbenchSection(
   handle: {
     canvas: HTMLCanvasElement;
+    overlay?: HTMLCanvasElement;
     setScope(text: string): void;
     setStatus(text: string): void;
     setDetail(rows: readonly ProfileWorkbenchDetailRow[] | null): void;
+    setReadout?(text: string | null): void;
   },
   id: string,
   scene: WorkbenchSectionScene,
 ): () => void {
   let stopped = false;
   let releaseSize: (() => void) | null = null;
+  let link: SectionPointLink | null = null;
   // The seam reads this on every chunk boundary, so abandoning the walk costs
   // one more chunk rather than the rest of the scene.
   const signal = { aborted: false };
@@ -375,6 +464,10 @@ export function presentWorkbenchSection(
     signal.aborted = true;
     releaseSize?.();
     releaseSize = null;
+    // Takes the 3D mark with it: a dock that is gone must not leave a cross
+    // standing in the scene over a section nobody can see any more.
+    link?.release();
+    link = null;
   }
 
   const profile = scene.profile(id);
@@ -410,9 +503,21 @@ export function presentWorkbenchSection(
     handle.setScope(plot.view.scope);
     handle.setStatus(plot.view.status);
     handle.setDetail(plot.view.detail);
+    link = attachSectionPointLink({
+      plot,
+      section,
+      handle,
+      scene,
+      unitToMetres: metres,
+      devicePixelRatio: scene.devicePixelRatio(),
+    });
     const observe = scene.observeCanvasSize ?? observeElementSize;
     releaseSize = observe(handle.canvas, () => {
-      if (!stopped) plot.draw();
+      if (stopped) return;
+      plot.draw();
+      // The plot's placement just changed, so the hit index built over the
+      // previous one would answer for pixels that now hold different returns.
+      link?.invalidate();
     });
   }
 
@@ -452,4 +557,270 @@ export function presentWorkbenchSection(
 
   slice();
   return dispose;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Point linkage: the section plot to the return it names in 3D
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Pixel radius a hover reaches.
+ *
+ * Wide enough that a single return is catchable with an ordinary pointer, and
+ * narrow enough that the nearest-with-deterministic-tie-break rule in
+ * `queryProfileHitTest` is deciding between neighbours rather than between
+ * halves of the plot.
+ */
+export const HIT_RADIUS_PX = 8;
+
+/** The row the detail list carries for the state of the 3D link. */
+export const LINK_ROW_LABEL = '3D link';
+
+/** What the plot needs to link its returns to the scene. */
+export interface SectionPointLinkOptions {
+  readonly plot: WorkbenchSectionPlot;
+  readonly section: ProfileSectionResult;
+  readonly handle: {
+    canvas: HTMLCanvasElement;
+    overlay?: HTMLCanvasElement;
+    setDetail(rows: readonly ProfileWorkbenchDetailRow[] | null): void;
+    setReadout?(text: string | null): void;
+  };
+  readonly scene: WorkbenchSectionScene;
+  /** Metres per section unit, or null when the frame cannot state one. */
+  readonly unitToMetres: number | null;
+  readonly devicePixelRatio: number;
+}
+
+/** A live linkage, and the means to take it down. */
+export interface SectionPointLink {
+  readonly controller: ProfileLinkController;
+  /** Rebuild the hit-test index and repaint. Call after the plot redraws. */
+  invalidate(): void;
+  release(): void;
+}
+
+/** A frame if the host has one, a task otherwise. */
+function schedulePointerFrame(run: () => void): void {
+  if (typeof requestAnimationFrame === 'function') requestAnimationFrame(() => run());
+  else setTimeout(run, 0);
+}
+
+/**
+ * Bind pointer input on the plot with plain DOM listeners.
+ *
+ * `offsetX/offsetY` is the plot's own coordinate space, which is what the hit
+ * index and the draw transform are both stated in; a client coordinate would
+ * need the canvas rectangle and would be wrong for one frame after any scroll
+ * or dock resize that has not laid out yet.
+ */
+function observePointerOnCanvas(
+  canvas: HTMLCanvasElement,
+  handlers: WorkbenchPointerHandlers,
+): () => void {
+  const at = (ev: Event): { x: number; y: number } => {
+    const p = ev as PointerEvent;
+    return { x: p.offsetX, y: p.offsetY };
+  };
+  const onMove = (ev: Event): void => {
+    const p = at(ev);
+    handlers.move(p.x, p.y);
+  };
+  const onLeave = (): void => handlers.leave();
+  const onClick = (ev: Event): void => {
+    const p = at(ev);
+    handlers.click(p.x, p.y);
+  };
+  // Double click, not a modifier: the camera move is the one action here that
+  // changes the 3D view, so it takes a gesture nobody performs by accident
+  // while reading along the section.
+  const onDoubleClick = (ev: Event): void => {
+    const p = at(ev);
+    handlers.focus(p.x, p.y);
+  };
+  canvas.addEventListener('pointermove', onMove);
+  canvas.addEventListener('pointerleave', onLeave);
+  canvas.addEventListener('pointercancel', onLeave);
+  canvas.addEventListener('click', onClick);
+  canvas.addEventListener('dblclick', onDoubleClick);
+  return () => {
+    canvas.removeEventListener('pointermove', onMove);
+    canvas.removeEventListener('pointerleave', onLeave);
+    canvas.removeEventListener('pointercancel', onLeave);
+    canvas.removeEventListener('click', onClick);
+    canvas.removeEventListener('dblclick', onDoubleClick);
+  };
+}
+
+/** The detail rows for one locked return, with the state of its 3D link. */
+function lockedDetailRows(
+  detail: ReturnType<typeof buildProfilePointDetail>,
+  state: ProfileReturnLocation,
+): ProfileWorkbenchDetailRow[] {
+  const rows: ProfileWorkbenchDetailRow[] = [];
+  if (detail) {
+    for (const row of detail.rows) {
+      // A row the return does not carry keeps its label and says so. Dropping
+      // it would make an absent channel indistinguishable from one the section
+      // never had, which is the distinction the descriptor exists to hold.
+      rows.push({ label: row.label, value: row.known && row.value !== null ? row.value : 'unknown' });
+    }
+  }
+  rows.push({ label: LINK_ROW_LABEL, value: profileLinkStatusText(state) });
+  return rows;
+}
+
+/**
+ * Wire hover and click on the section plot to the return they name in 3D.
+ *
+ * Returns null when the host offers no way to resolve a return, in which case
+ * the plot behaves exactly as it did before: it draws, it reports its figures,
+ * and it takes no pointer input at all.
+ *
+ * EVERY ROUTE IS BY IDENTITY. A pointer position picks a section INDEX through
+ * the screen-cell index; the index becomes a slot, a source kind, a source id
+ * and that source's own point index; the scene is asked for THAT point. No
+ * step of it compares coordinates, so two returns a millimetre apart in a
+ * corridor are never confused for one another.
+ */
+export function attachSectionPointLink(
+  options: SectionPointLinkOptions,
+): SectionPointLink | null {
+  const { plot, section, handle, scene } = options;
+  const locateReturn = scene.locateReturn;
+  if (!locateReturn) return null;
+
+  const points = section.points;
+  const reference = pointVerticalReference(scene.crs?.());
+  const unitToMetres = options.unitToMetres ?? undefined;
+  // The card reads its world coordinates through the SAME locator the marker
+  // uses, so an evicted node blanks the coordinate rows instead of showing
+  // where the point used to be.
+  const locator = (
+    identity: { kind: 'static' | 'resident'; sourceId: string; pointIndex: number },
+    out: Float64Array,
+  ): ProfileReturnLocation =>
+    locateReturn(
+      { kind: identity.kind, id: identity.sourceId, pointIndex: identity.pointIndex },
+      out,
+    );
+  const detailSources = profileDetailSources(section.sources, locator);
+  const markerSize = profileMarkerSize(section.band);
+
+  let index: ProfileHitTestIndex | null = null;
+
+  /** The hit index for the CURRENT drawn frame, rebuilt only when it changed. */
+  function ensureIndex(): ProfileHitTestIndex | null {
+    if (index) return index;
+    const frame = plot.frame();
+    if (!frame) return null;
+    index = buildProfileHitTestIndex({
+      section: points,
+      displayed: plot.indices,
+      widthPx: frame.viewport.width,
+      heightPx: frame.viewport.height,
+      // The affine restated from `profileDataToScreen`: same origin, same
+      // scales, same sign flip on height. The two cannot drift because the
+      // view they read is the one the draw recorded.
+      projection: {
+        chainageAtOrigin: frame.view.centreChainage,
+        heightAtOrigin: frame.view.centreHeight,
+        originXPx: frame.viewport.width / 2,
+        originYPx: frame.viewport.height / 2,
+        pxPerChainage: frame.view.pxPerChainage,
+        pxPerHeight: frame.view.pxPerHeight,
+      },
+      cellSizePx: HIT_RADIUS_PX * 2,
+    });
+    return index;
+  }
+
+  function paint(
+    hover: { x: number; y: number } | null,
+    locked: { x: number; y: number } | null,
+  ): void {
+    const overlay = handle.overlay;
+    if (!overlay) return;
+    const ctx = overlay.getContext('2d') as ProfileLinkOverlayContext | null;
+    if (!ctx) return;
+    const width = overlay.clientWidth;
+    const height = overlay.clientHeight;
+    if (!(width > 0) || !(height > 0)) return;
+    const dpr = options.devicePixelRatio > 0 ? options.devicePixelRatio : 1;
+    const deviceWidth = Math.max(1, Math.round(width * dpr));
+    const deviceHeight = Math.max(1, Math.round(height * dpr));
+    // Assigning either dimension clears the surface, so it is written only on
+    // a real change; the draw below clears it anyway.
+    if (overlay.width !== deviceWidth) overlay.width = deviceWidth;
+    if (overlay.height !== deviceHeight) overlay.height = deviceHeight;
+    drawProfileLinkOverlay(ctx, {
+      widthPx: width,
+      heightPx: height,
+      devicePixelRatio: dpr,
+      hover,
+      locked,
+    });
+  }
+
+  const controller = createProfileLinkController({
+    query: (x, y) => {
+      const live = ensureIndex();
+      return live ? queryProfileHitTest(live, x, y, HIT_RADIUS_PX) : null;
+    },
+    project: (i, out) => {
+      const frame = plot.frame();
+      if (!frame || i < 0 || i >= points.count) return false;
+      profileDataToScreen(frame.view, frame.viewport, points.chainage[i]!, points.height[i]!, out);
+      return Number.isFinite(out[0]!) && Number.isFinite(out[1]!);
+    },
+    identify: (i) => profileReturnIdentity(points, section.sources, i),
+    locate: (identity, out) => locator(identity, out),
+    readout: (i) =>
+      profileHoverReadout(points, i, { reference, unitToMetres }),
+    detail: (i) =>
+      buildProfilePointDetail(points, i, {
+        sources: detailSources,
+        crs: scene.crs?.(),
+        ...(unitToMetres === undefined ? {} : { unitToMetres }),
+      }),
+    schedule: scene.schedulePointerFlush ?? schedulePointerFrame,
+    paint,
+    mark: (marker) => {
+      scene.markLinkedReturn?.(marker ? { ...marker, size: markerSize } : null);
+    },
+    present: (state) => {
+      // The hover line, then the locked one: a pointer that has left the plot
+      // leaves the selection's own line standing rather than an empty strip.
+      handle.setReadout?.(state.hover?.readout ?? state.locked?.readout ?? null);
+      // With nothing selected the list returns to the section's own figures,
+      // which is what the panel showed before anything was clicked.
+      handle.setDetail(
+        state.locked ? lockedDetailRows(state.detail, state.locked.state) : plot.view.detail,
+      );
+    },
+    ...(scene.focusPoint ? { focus: scene.focusPoint } : {}),
+  });
+
+  const observe = scene.observePointer ?? observePointerOnCanvas;
+  const release = observe(handle.canvas, {
+    move: (x, y) => controller.pointerMove(x, y),
+    leave: () => controller.pointerLeave(),
+    click: (x, y) => controller.click(x, y),
+    focus: (x, y) => {
+      controller.click(x, y);
+      controller.focusSelection();
+    },
+  });
+
+  return {
+    controller,
+    invalidate: () => {
+      index = null;
+      controller.refresh();
+    },
+    release: () => {
+      release();
+      controller.dispose();
+    },
+  };
 }

--- a/src/render/ProfileLinkOverlay.ts
+++ b/src/render/ProfileLinkOverlay.ts
@@ -1,0 +1,118 @@
+/**
+ * ProfileLinkOverlay.ts
+ *
+ * The mark the 3D scene carries for the return selected in the Profile
+ * Workbench: a small three-axis cross standing on the source point.
+ *
+ * A SCENE OBJECT, NOT A PROJECTED OVERLAY. The inspector draws its marker as
+ * an SVG halo re-projected from the camera every frame, which is crisp but
+ * needs a per-frame hook. This mark is placed once and left to the camera, so
+ * it stays on the point through an orbit, a fly and a resize without the
+ * workbench subscribing to the render loop at all. Its arm length comes from
+ * the corridor half width (`profileMarkerSize`), so it reads at the scale of
+ * the section that produced it rather than at a constant that is invisible on
+ * one scan and a wall across another.
+ *
+ * IT DOES NOT TOUCH THE INSPECTOR. Profile selection and Inspect selection are
+ * separate states: a hover over the section must not clear a point the user
+ * picked with the inspector, and picking with the inspector must not clear the
+ * section's mark. This overlay owns its own object and nothing else's.
+ *
+ * Scene membership arrives as {@link ProfileLinkOverlayHost} — `derivedLayerHost()`
+ * satisfies it — so nothing here names the Viewer.
+ */
+
+import * as THREE from 'three/webgpu';
+
+import { profileMarkerSegments } from './measure/profilePointLink';
+
+/** Scene membership and redraw, and nothing more. */
+export interface ProfileLinkOverlayHost {
+  add(object: THREE.Object3D): void;
+  remove(object: THREE.Object3D): void;
+  requestFrame(): void;
+}
+
+/** What to mark. `null` clears the mark. */
+export interface ProfileLinkMark {
+  readonly position: readonly [number, number, number];
+  readonly mode: 'hover' | 'locked';
+  /** Arm length in scene units, from {@link profileMarkerSize}. */
+  readonly size: number;
+}
+
+/** A passing hover is quieter than a selection the user committed to. */
+const HOVER_COLOUR = 0xffd666;
+const LOCKED_COLOUR = 0xffffff;
+const HOVER_OPACITY = 0.65;
+const LOCKED_OPACITY = 1;
+
+export class ProfileLinkOverlay {
+  private readonly _host: ProfileLinkOverlayHost;
+  private readonly _positions = new Float32Array(18);
+  private readonly _geometry: THREE.BufferGeometry;
+  private readonly _material: THREE.LineBasicMaterial;
+  private readonly _lines: THREE.LineSegments;
+  private _attached = false;
+  private _disposed = false;
+
+  constructor(host: ProfileLinkOverlayHost) {
+    this._host = host;
+    this._geometry = new THREE.BufferGeometry();
+    this._geometry.setAttribute('position', new THREE.BufferAttribute(this._positions, 3));
+    this._material = new THREE.LineBasicMaterial({
+      color: HOVER_COLOUR,
+      transparent: true,
+      opacity: HOVER_OPACITY,
+      // Drawn through the scan rather than behind it: the marked return is
+      // usually inside the cloud, and a mark occluded by the points it names
+      // would only be visible when the section happened to face the camera.
+      depthTest: false,
+    });
+    this._lines = new THREE.LineSegments(this._geometry, this._material);
+    this._lines.name = 'olv-profile-link-mark';
+    this._lines.frustumCulled = false;
+    this._lines.renderOrder = 10;
+    this._lines.visible = false;
+  }
+
+  /** Place the mark, or clear it with `null`. */
+  show(mark: ProfileLinkMark | null): void {
+    if (this._disposed) return;
+    if (!mark) {
+      if (this._attached) {
+        this._host.remove(this._lines);
+        this._attached = false;
+      }
+      this._lines.visible = false;
+      this._host.requestFrame();
+      return;
+    }
+    profileMarkerSegments(mark.position, mark.size, this._positions);
+    const attribute = this._geometry.getAttribute('position');
+    attribute.needsUpdate = true;
+    this._geometry.computeBoundingSphere();
+    const locked = mark.mode === 'locked';
+    this._material.color.setHex(locked ? LOCKED_COLOUR : HOVER_COLOUR);
+    this._material.opacity = locked ? LOCKED_OPACITY : HOVER_OPACITY;
+    this._lines.visible = true;
+    if (!this._attached) {
+      this._host.add(this._lines);
+      this._attached = true;
+    }
+    this._host.requestFrame();
+  }
+
+  /** Detach and release the GPU resources. Idempotent. */
+  dispose(): void {
+    if (this._disposed) return;
+    this._disposed = true;
+    if (this._attached) {
+      this._host.remove(this._lines);
+      this._attached = false;
+    }
+    this._geometry.dispose();
+    this._material.dispose();
+    this._host.requestFrame();
+  }
+}

--- a/src/render/measure/profileLinkOverlay2d.ts
+++ b/src/render/measure/profileLinkOverlay2d.ts
@@ -1,0 +1,143 @@
+/**
+ * profileLinkOverlay2d.ts
+ *
+ * The crosshair and the highlight box the section plot draws over the return
+ * under the pointer, and over the one a click locked.
+ *
+ * A SEPARATE SURFACE FROM THE PLOT, and that is the whole reason this module
+ * exists rather than a branch inside `ProfileSectionRenderer`. A section can
+ * hold a hundred thousand splats; redrawing them to move a crosshair two
+ * pixels would put the entire point set through `fillRect` on every hover
+ * frame. Here the surface is cleared and three or four strokes are laid down,
+ * so hover cost is independent of how many returns the section holds.
+ *
+ * The locked mark is drawn AFTER the hover mark and reads heavier, so a hover
+ * passing over a locked return never leaves the reader unsure which of the two
+ * the card below is describing.
+ *
+ * No DOM. The context is a structural interface satisfied by a real
+ * `CanvasRenderingContext2D` and by a recording double, the same arrangement
+ * the section renderer uses.
+ */
+
+/** The 2D operations this overlay uses, and nothing more. */
+export interface ProfileLinkOverlayContext {
+  strokeStyle: string | CanvasGradient | CanvasPattern;
+  lineWidth: number;
+  globalAlpha: number;
+  setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void;
+  clearRect(x: number, y: number, w: number, h: number): void;
+  beginPath(): void;
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  closePath(): void;
+  stroke(): void;
+}
+
+/** A screen position inside the plot, in CSS pixels from its top left. */
+export interface ProfileLinkPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+/** What to draw over the plot this frame. */
+export interface ProfileLinkOverlayFrame {
+  /** Plot box, CSS pixels. */
+  readonly widthPx: number;
+  readonly heightPx: number;
+  /** Device pixels per CSS pixel. Non-finite or non-positive reads as 1. */
+  readonly devicePixelRatio: number;
+  /** The return under the pointer, or null. */
+  readonly hover: ProfileLinkPoint | null;
+  /** The return a click locked, or null. */
+  readonly locked: ProfileLinkPoint | null;
+}
+
+/** Half-side of the box drawn around a marked return, CSS pixels. */
+export const MARK_HALF_PX = 6;
+
+/** Stroke weights and colours, CSS pixels. The plot owns the palette. */
+const HOVER_STYLE = {
+  colour: 'rgb(255, 214, 102)',
+  alpha: 0.55,
+  widthPx: 1,
+} as const;
+
+const LOCKED_STYLE = {
+  colour: 'rgb(255, 255, 255)',
+  alpha: 0.9,
+  widthPx: 1.5,
+} as const;
+
+function positive(v: number, fallback: number): number {
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+
+function drawable(p: ProfileLinkPoint | null): p is ProfileLinkPoint {
+  return p !== null && Number.isFinite(p.x) && Number.isFinite(p.y);
+}
+
+/** A square centred on the point, as one closed path. */
+function box(ctx: ProfileLinkOverlayContext, p: ProfileLinkPoint, half: number): void {
+  ctx.beginPath();
+  ctx.moveTo(p.x - half, p.y - half);
+  ctx.lineTo(p.x + half, p.y - half);
+  ctx.lineTo(p.x + half, p.y + half);
+  ctx.lineTo(p.x - half, p.y + half);
+  ctx.closePath();
+  ctx.stroke();
+}
+
+/** Full-width and full-height rules through the point. */
+function crosshair(
+  ctx: ProfileLinkOverlayContext,
+  p: ProfileLinkPoint,
+  widthPx: number,
+  heightPx: number,
+): void {
+  ctx.beginPath();
+  ctx.moveTo(0, p.y);
+  ctx.lineTo(widthPx, p.y);
+  ctx.moveTo(p.x, 0);
+  ctx.lineTo(p.x, heightPx);
+  ctx.stroke();
+}
+
+/**
+ * Clear the overlay and draw this frame's marks.
+ *
+ * ALWAYS clears, including when there is nothing to draw: a frame with no
+ * hover is how a pointer leaving the plot removes the crosshair, and skipping
+ * the clear would leave the last one painted over a plot nobody is pointing
+ * at.
+ */
+export function drawProfileLinkOverlay(
+  ctx: ProfileLinkOverlayContext,
+  frame: ProfileLinkOverlayFrame,
+): void {
+  const dpr = positive(frame.devicePixelRatio, 1);
+  const width = positive(frame.widthPx, 0);
+  const height = positive(frame.heightPx, 0);
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, Math.max(width, 1), Math.max(height, 1));
+  if (width <= 0 || height <= 0) return;
+
+  if (drawable(frame.hover)) {
+    ctx.globalAlpha = HOVER_STYLE.alpha;
+    ctx.strokeStyle = HOVER_STYLE.colour;
+    ctx.lineWidth = HOVER_STYLE.widthPx;
+    crosshair(ctx, frame.hover, width, height);
+    box(ctx, frame.hover, MARK_HALF_PX);
+  }
+
+  // Locked last, and heavier: the card below describes THIS return, so it has
+  // to stay the stronger of the two marks while the pointer moves over others.
+  if (drawable(frame.locked)) {
+    ctx.globalAlpha = LOCKED_STYLE.alpha;
+    ctx.strokeStyle = LOCKED_STYLE.colour;
+    ctx.lineWidth = LOCKED_STYLE.widthPx;
+    box(ctx, frame.locked, MARK_HALF_PX);
+  }
+
+  ctx.globalAlpha = 1;
+}

--- a/src/render/measure/profilePointLink.ts
+++ b/src/render/measure/profilePointLink.ts
@@ -1,0 +1,335 @@
+/**
+ * profilePointLink.ts
+ *
+ * The identity a profile return is followed by, and what that identity
+ * resolves to in the live scene.
+ *
+ * A section is a SNAPSHOT. It records, per accepted return, the slot it came
+ * from and that source's own point index; the seam records what each slot was
+ * — a static layer id, or a streaming octree node key. Those two together are
+ * the whole route back to the scene:
+ *
+ *   static     slot -> layer id -> point index -> placed project coordinate
+ *   streaming  slot -> node key -> point index -> resident decoded point
+ *
+ * NOTHING HERE MATCHES ON COORDINATES. A corridor is a band a few metres wide
+ * around one line, so its returns are close together by construction and a
+ * nearest-XYZ lookup would answer with a neighbour for most of them — silently,
+ * and more often the denser the scan. The identity is carried, not recovered.
+ *
+ * THE SNAPSHOT OUTLIVES THE SCENE. A streaming node resident when the corridor
+ * was walked can be evicted a moment later, and a static layer can be removed
+ * or hidden. The 2D section still holds every figure it recorded, so it stays
+ * on screen; only the 3D link goes. {@link ProfileLinkState} keeps those two
+ * apart — `evicted` names the streaming case specifically, because a node that
+ * has left residency is expected and reversible, while a source that is gone
+ * for another reason is not. Neither is ever reported as `linked`.
+ *
+ * Pure and DOM-free: no canvas, no three.js, no viewer. The live scene arrives
+ * as a {@link ProfileReturnLocator} function, so the whole route runs under
+ * Node against plain arrays.
+ */
+
+import { heightLabel, type VerticalReference } from '../../geo/height';
+import { classificationLabel } from '../pointInfo';
+import { formatStation } from './profileSummary';
+import { profileSectionHas } from './profileSectionBuilder';
+
+import type { ProfileReturnsSource } from './profileReturnsCsv';
+import type { ProfileSectionPoints } from './profileSectionBuilder';
+import type { ProfileSectionSourceRef } from './profileSectionSeam';
+import type { UnitSystem } from './types';
+
+/** What one section slot was read from. Mirrors `ProfileSectionSourceRef`. */
+export type ProfileSourceKind = 'static' | 'resident';
+
+/**
+ * The stable route from one section return back to the scene.
+ *
+ * `sectionIndex` addresses the 2D arrays; the other three address the source.
+ * They are recorded together so a consumer can never pair a 2D figure with a
+ * different source point than the one it was read from.
+ */
+export interface ProfileReturnIdentity {
+  /** Index into the section arrays. */
+  readonly sectionIndex: number;
+  /** The builder slot this return was pushed under. */
+  readonly slot: number;
+  readonly kind: ProfileSourceKind;
+  /** Layer id for a static source; octree node key for a resident one. */
+  readonly sourceId: string;
+  /** The point's index in its OWN source, not in the section. */
+  readonly pointIndex: number;
+}
+
+/**
+ * Whether the source point behind a return can still be pointed at.
+ *
+ *   - `linked`      the source is present and yielded a coordinate;
+ *   - `evicted`     the streaming node that carried it is no longer resident;
+ *   - `unavailable` any other reason there is no coordinate to give — the
+ *                   static layer is gone or is no longer eligible, the index
+ *                   is outside the source, or the buffer was dropped.
+ */
+export type ProfileLinkState = 'linked' | 'evicted' | 'unavailable';
+
+/** An identity resolved against the scene as it is right now. */
+export interface ProfileReturnLink {
+  readonly identity: ProfileReturnIdentity;
+  readonly state: ProfileLinkState;
+  /** The project-frame position, and ONLY when `state` is `linked`. */
+  readonly position: readonly [number, number, number] | null;
+}
+
+/**
+ * The live scene, as one function.
+ *
+ * Writes the project-frame coordinate into `out[0..2]` and returns `linked`,
+ * or leaves `out` alone and returns why it could not.
+ */
+export type ProfileReturnLocator = (
+  identity: ProfileReturnIdentity,
+  out: Float64Array,
+) => ProfileLinkState;
+
+/**
+ * The identity of section return `i`, or `null` when there is none.
+ *
+ * `null` covers an index outside the section and a slot no source ref names.
+ * An unnamed slot is a section whose sources and points disagree, and guessing
+ * a source for it would attach the return to a layer it never came from.
+ */
+export function profileReturnIdentity(
+  points: ProfileSectionPoints,
+  sources: readonly ProfileSectionSourceRef[],
+  i: number,
+): ProfileReturnIdentity | null {
+  if (!Number.isInteger(i) || i < 0 || i >= points.count) return null;
+  const slot = points.sourceSlot[i]!;
+  const ref = sources.find((s) => s.slot === slot);
+  if (!ref) return null;
+  return {
+    sectionIndex: i,
+    slot,
+    kind: ref.kind,
+    sourceId: ref.id,
+    pointIndex: points.pointIndex[i]!,
+  };
+}
+
+/**
+ * Resolve an identity against the live scene.
+ *
+ * A locator that answers `linked` with a non-finite coordinate is downgraded
+ * to `unavailable`: a marker at NaN is not a marker, and reporting the link as
+ * live would claim a position nothing can be drawn at.
+ */
+export function locateProfileReturn(
+  identity: ProfileReturnIdentity,
+  locate: ProfileReturnLocator,
+  scratch?: Float64Array,
+): ProfileReturnLink {
+  const out = scratch ?? new Float64Array(3);
+  const state = locate(identity, out);
+  if (state !== 'linked') return { identity, state, position: null };
+  const x = out[0]!;
+  const y = out[1]!;
+  const z = out[2]!;
+  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+    return { identity, state: 'unavailable', position: null };
+  }
+  return { identity, state: 'linked', position: [x, y, z] };
+}
+
+/** The sentence a panel shows for a link state. */
+export function profileLinkNote(state: ProfileLinkState): string {
+  switch (state) {
+    case 'linked':
+      return 'Marked in the 3D view.';
+    case 'evicted':
+      return 'The streaming node behind this return is no longer loaded, so it cannot be marked in 3D.';
+    case 'unavailable':
+      return 'This return has no live source in the scene, so it cannot be marked in 3D.';
+  }
+}
+
+/** The short value the detail list carries for a link state. */
+export function profileLinkStatusText(state: ProfileLinkState): string {
+  switch (state) {
+    case 'linked':
+      return 'marked in 3D';
+    case 'evicted':
+      return 'source node evicted';
+    case 'unavailable':
+      return 'source unavailable';
+  }
+}
+
+/**
+ * Source records for the detail card, from the section's own source refs.
+ *
+ * The seam records a static layer under the id the layer is named by, so the
+ * id IS the display name here; inventing a second name would let the card
+ * disagree with the returns export about which layer a return came from. A
+ * resident slot additionally carries its octree key, which is the one row that
+ * distinguishes a streaming return from a static one.
+ *
+ * `readXYZ` is the SAME locator the 3D marker uses, so the card's world
+ * coordinates are read from the scene as it is now: an evicted node's rows go
+ * unknown rather than showing the position it used to be at.
+ */
+export function profileDetailSources(
+  sources: readonly ProfileSectionSourceRef[],
+  locate?: ProfileReturnLocator,
+): ProfileReturnsSource[] {
+  return sources.map((s) => {
+    const readXYZ = locate
+      ? (index: number, out: Float64Array): boolean =>
+          locate(
+            { sectionIndex: -1, slot: s.slot, kind: s.kind, sourceId: s.id, pointIndex: index },
+            out,
+          ) === 'linked'
+      : undefined;
+    return s.kind === 'resident'
+      ? {
+          slot: s.slot,
+          layerId: s.id,
+          layerName: s.id,
+          streamingNodeKey: s.id,
+          ...(readXYZ ? { readXYZ } : {}),
+        }
+      : { slot: s.slot, layerId: s.id, layerName: s.id, ...(readXYZ ? { readXYZ } : {}) };
+  });
+}
+
+/**
+ * Arm length of the 3D marker, in the section's own units.
+ *
+ * Derived from the corridor half width rather than fixed, because a corridor
+ * is the only length the section knows to be meaningful at this scale: a
+ * 0.5 m band and a 50 m band want markers three orders of magnitude apart, and
+ * a constant would be invisible in one and a wall across the other. A
+ * non-positive or non-finite band falls back to a unit arm, which is at least
+ * drawable.
+ */
+export const MARKER_BAND_FRACTION = 0.35;
+
+export function profileMarkerSize(band: number): number {
+  if (!Number.isFinite(band) || band <= 0) return 1;
+  return band * MARKER_BAND_FRACTION;
+}
+
+/**
+ * Endpoints of a three-axis cross centred on `position`, as interleaved XYZ.
+ *
+ * Six vertices, three segments. Axis aligned rather than screen aligned so it
+ * needs no camera and no per-frame update: it is a scene object like any
+ * other, and it stays put while the user orbits.
+ */
+export function profileMarkerSegments(
+  position: readonly [number, number, number],
+  size: number,
+  out?: Float32Array,
+): Float32Array {
+  const v = out && out.length >= 18 ? out : new Float32Array(18);
+  const s = Number.isFinite(size) && size > 0 ? size : 1;
+  const [x, y, z] = position;
+  v[0] = x - s; v[1] = y; v[2] = z;
+  v[3] = x + s; v[4] = y; v[5] = z;
+  v[6] = x; v[7] = y - s; v[8] = z;
+  v[9] = x; v[10] = y + s; v[11] = z;
+  v[12] = x; v[13] = y; v[14] = z - s;
+  v[15] = x; v[16] = y; v[17] = z + s;
+  return v;
+}
+
+/** A camera pose, structurally — `Viewer.getCameraPose()` satisfies it. */
+export interface ProfileCameraPose {
+  readonly position: readonly [number, number, number];
+  readonly target: readonly [number, number, number];
+}
+
+/**
+ * The pose that puts `point` under the orbit pivot without changing the view.
+ *
+ * The eye moves by the same vector the pivot does, so the direction the camera
+ * looks along and its distance from the pivot both survive. That is what makes
+ * this a focus rather than a jump: the user keeps the orientation they had.
+ *
+ * ONLY EVER CALLED FROM A DELIBERATE ACTION. A hover that moved the camera
+ * would make the plot unusable, because reading along the section would drag
+ * the scene under the reader.
+ */
+export function focusPoseOnPoint(
+  pose: ProfileCameraPose,
+  point: readonly [number, number, number],
+): { position: [number, number, number]; target: [number, number, number] } {
+  const dx = point[0] - pose.target[0];
+  const dy = point[1] - pose.target[1];
+  const dz = point[2] - pose.target[2];
+  return {
+    position: [pose.position[0] + dx, pose.position[1] + dy, pose.position[2] + dz],
+    target: [point[0], point[1], point[2]],
+  };
+}
+
+/** Decimals the readout carries, matching the detail card's spatial rows. */
+const READOUT_DECIMALS = 3;
+
+export interface ProfileHoverReadoutOptions {
+  /** Decides the height WORDING. Absent reads as an undeclared datum. */
+  readonly reference?: VerticalReference;
+  /** Station notation. Metric km+m, imperial 100-ft. Default metric. */
+  readonly system?: UnitSystem;
+  /**
+   * Metres per section unit. With no known scale there is no station to
+   * quote, so the readout leads with chainage instead of labelling render
+   * units as a civil station — the same refusal the detail card makes.
+   */
+  readonly unitToMetres?: number;
+}
+
+/**
+ * One line about the return under the pointer.
+ *
+ * Deliberately SHORT and deliberately a subset: where the return sits along
+ * the section, how high it is, and its class where it carries one. Everything
+ * else belongs to the card a click opens. A hover readout that grew into the
+ * card would have to be laid out per pointer move, which is the cost this
+ * whole path is arranged to avoid.
+ *
+ * The height wording comes from `heightLabel`, unchanged, so a hover and the
+ * card can never name the same quantity differently.
+ */
+export function profileHoverReadout(
+  points: ProfileSectionPoints,
+  i: number,
+  options: ProfileHoverReadoutOptions = {},
+): string {
+  if (!Number.isInteger(i) || i < 0 || i >= points.count) return '';
+  const chainage = points.chainage[i]!;
+  const height = points.height[i]!;
+  const metres =
+    typeof options.unitToMetres === 'number' &&
+    Number.isFinite(options.unitToMetres) &&
+    options.unitToMetres > 0
+      ? options.unitToMetres
+      : null;
+
+  const parts: string[] = [];
+  if (metres !== null && Number.isFinite(chainage)) {
+    parts.push(`Station ${formatStation(chainage * metres, options.system ?? 'metric')}`);
+  } else if (Number.isFinite(chainage)) {
+    parts.push(`Chainage ${chainage.toFixed(READOUT_DECIMALS)}`);
+  }
+  if (Number.isFinite(height)) {
+    parts.push(`${heightLabel(options.reference ?? 'unknown')} ${height.toFixed(READOUT_DECIMALS)}`);
+  }
+  // Absence is not zero: the class is quoted only where this return's own
+  // presence bit is set, never read out of the zero-filled array.
+  if (points.classification !== undefined && profileSectionHas(points, i, 'classification')) {
+    const code = points.classification[i]!;
+    parts.push(`${code} (${classificationLabel(code)})`);
+  }
+  return parts.join(' · ');
+}

--- a/src/render/measure/profileSectionSeam.ts
+++ b/src/render/measure/profileSectionSeam.ts
@@ -177,9 +177,37 @@ export interface ProfileSectionSeam {
   sectionChunks(req: ProfileSectionRequest): Generator<number, ProfileSectionResult | null, void>;
   /** {@link sectionChunks} run to completion. */
   section(req: ProfileSectionRequest): ProfileSectionResult | null;
+  /**
+   * Read one source point's CURRENT project-frame coordinate, by the identity
+   * a section recorded for it.
+   *
+   * The counterpart to {@link sectionChunks}: the section is a snapshot, this
+   * is the scene now. It exists so a consumer can follow a return back to the
+   * scan WITHOUT matching coordinates — a corridor's returns sit within a few
+   * metres of each other, so a nearest-position lookup answers with a
+   * neighbour more often than not.
+   *
+   * `evicted` is reserved for a streaming node that is no longer resident, the
+   * one way a source routinely disappears under a section that is still on
+   * screen. Everything else that yields no coordinate is `unavailable`. A
+   * missing source is never reported as `linked`.
+   */
+  locateReturn(ref: ProfileReturnRef, out: Float64Array): ProfileReturnLocation;
   /** Refuse every outstanding and future extraction. Permanent. */
   abandon(): void;
 }
+
+/** One source point, addressed the way a section records it. */
+export interface ProfileReturnRef {
+  readonly kind: 'static' | 'resident';
+  /** Layer id for a static source; octree node key for a resident one. */
+  readonly id: string;
+  /** The point's index in its own source. */
+  readonly pointIndex: number;
+}
+
+/** Whether a recorded return still has a live coordinate, and if not, why. */
+export type ProfileReturnLocation = 'linked' | 'evicted' | 'unavailable';
 
 /**
  * A channel is used only when its length agrees with the point count it is
@@ -403,9 +431,67 @@ export function createProfileSectionSeam(deps: ProfileSectionSeamDeps): ProfileS
     };
   }
 
+  /**
+   * The current coordinate of one recorded source point.
+   *
+   * Reads the SAME accessors an extraction reads, so a return the section
+   * accepted and a marker placed on it can never come from different scenes.
+   * Static layers go through {@link integrableClouds}, the seam's one
+   * eligibility rule: a layer hidden since the section was taken is off the
+   * screen, and a marker on it would point into a scan the user cannot see.
+   *
+   * Residency is decided by the node KEY, never by arrival order or by the
+   * buffer's contents. A key no resident node carries is `evicted`; a key that
+   * is still resident but holds no coordinate at that index is `unavailable`.
+   */
+  function locateReturn(ref: ProfileReturnRef, out: Float64Array): ProfileReturnLocation {
+    // The SAME walk an extraction runs, so a return the section accepted and a
+    // marker placed on it can never come from different scenes. Static layers
+    // come through `integrableClouds`: a layer hidden since the section was
+    // taken is off the screen, and a marker on it would point into a scan the
+    // user cannot see.
+    const { statics, residents } = walkScene(deps);
+    const index = ref.pointIndex;
+    const usable = (pos: Float32Array): boolean =>
+      Number.isInteger(index) && index >= 0 && index * 3 + 2 < pos.length;
+    const base = index * 3;
+
+    if (ref.kind === 'resident') {
+      // Residency is decided by the node KEY, never by arrival order or by
+      // what a buffer happens to hold.
+      for (const { node, pos } of residents) {
+        if (node.key !== ref.id) continue;
+        if (!usable(pos)) return 'unavailable';
+        out[0] = pos[base]!;
+        out[1] = pos[base + 1]!;
+        out[2] = pos[base + 2]!;
+        return 'linked';
+      }
+      // A stream the host is not combining is not an eviction: the node may
+      // well still be loaded, and saying it was evicted would name the wrong
+      // reason for the missing mark.
+      return deps.streamingMayCombine(statics.length) ? 'evicted' : 'unavailable';
+    }
+
+    for (const { layer, pos } of statics) {
+      if (layer.id !== ref.id) continue;
+      if (!usable(pos)) return 'unavailable';
+      // Folded exactly once, through the same helper the extraction's reader
+      // uses, so a mounted layer's mark lands where its returns were read from
+      // rather than at its unplaced source position.
+      const [dx, dy, dz] = accumulatorOffset(layer.placement);
+      out[0] = pos[base]! + dx;
+      out[1] = pos[base + 1]! + dy;
+      out[2] = pos[base + 2]! + dz;
+      return 'linked';
+    }
+    return 'unavailable';
+  }
+
   return {
     sampleSeries,
     sectionChunks,
+    locateReturn,
     section(req) {
       const it = sectionChunks(req);
       let step = it.next();

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -653,7 +653,29 @@
   display: flex; gap: var(--space-md); min-height: 0; flex: 1;
   padding: 0 var(--space-md) var(--space-sm);
 }
-.olv-workbench-canvas { flex: 1; min-width: 0; display: block; }
+/* The plot column: the picture, the crosshair over it, and the one-line
+   readout under it. The wrapper is what flexes; the two canvases are stacked,
+   so the crosshair can be redrawn without touching the splats beneath it. */
+.olv-workbench-plotwrap {
+  flex: 1; min-width: 0; min-height: 0;
+  display: flex; flex-direction: column;
+}
+.olv-workbench-plot { position: relative; flex: 1; min-height: 0; }
+.olv-workbench-canvas,
+.olv-workbench-overlay {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%; display: block;
+}
+/* Decoration only: it never receives the pointer, so the events the plot
+   listens for are the ones the reader aimed at the plot. */
+.olv-workbench-overlay { pointer-events: none; }
+.olv-workbench-canvas { cursor: crosshair; }
+.olv-workbench-readout {
+  min-height: 1.2em; padding-top: var(--space-2xs);
+  font-size: var(--text-xs); color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
 /* The exact figures for the selected return. A canvas is a picture; this is
    the readable half of the same information, so it never collapses away. */
 .olv-workbench-detail {

--- a/src/ui/ProfileWorkbench.ts
+++ b/src/ui/ProfileWorkbench.ts
@@ -87,6 +87,16 @@ export interface ProfileWorkbenchOptions {
 export interface ProfileWorkbenchHandle {
   readonly element: HTMLElement;
   readonly canvas: HTMLCanvasElement;
+  /**
+   * The surface the hover crosshair and the selection box are drawn on,
+   * stacked over the plot.
+   *
+   * OPTIONAL, so a handle built by an older double still satisfies the type.
+   * A separate canvas because a section can hold a hundred thousand splats:
+   * moving a crosshair by redrawing the plot would put every one of them
+   * through `fillRect` on each hover frame.
+   */
+  readonly overlay?: HTMLCanvasElement;
   /** Occupied height in pixels, as the dock module derives it. */
   height(): number;
   collapsed(): boolean;
@@ -97,6 +107,14 @@ export interface ProfileWorkbenchHandle {
   setStatus(text: string): void;
   /** The selected return's figures, as text. Null clears the selection. */
   setDetail(rows: readonly ProfileWorkbenchDetailRow[] | null): void;
+  /**
+   * The one-line readout for the return under the pointer. Null clears it.
+   *
+   * Separate from `setStatus`, which is a polite live region: a line that
+   * changes on every hover would have a screen reader announcing the plot
+   * continuously while the pointer crosses it.
+   */
+  setReadout?(text: string | null): void;
   close(): void;
 }
 
@@ -132,7 +150,9 @@ class ProfileWorkbench {
   private readonly _scope: HTMLElement;
   private readonly _status: HTMLElement;
   private readonly _detail: HTMLElement;
+  private readonly _readout: HTMLElement;
   private readonly _canvas: HTMLCanvasElement;
+  private readonly _overlay: HTMLCanvasElement;
   private readonly _collapseBtn: HTMLButtonElement;
   private readonly _teardown: (() => void)[] = [];
   private _state: DockState;
@@ -190,11 +210,25 @@ class ProfileWorkbench {
     this._canvas.setAttribute('role', 'img');
     this._canvas.setAttribute('aria-label', CANVAS_DESCRIPTION);
 
+    // Decoration over a picture: the crosshair states nothing the readout and
+    // the detail rows do not already state as text, so it is hidden from
+    // assistive technology rather than announced as a second image.
+    this._overlay = el('canvas', { className: 'olv-workbench-overlay' });
+    this._overlay.setAttribute('aria-hidden', 'true');
+
     this._detail = el('div', { className: 'olv-workbench-detail' });
     this._detail.setAttribute('aria-label', 'Selected return');
     this.setDetail(null);
 
-    const body = el('div', { className: 'olv-workbench-body' }, [this._canvas, this._detail]);
+    // Not a live region. The pointer crosses hundreds of returns in a sweep,
+    // and announcing each one would talk over everything else.
+    this._readout = el('div', { className: 'olv-workbench-readout' });
+
+    const plot = el('div', { className: 'olv-workbench-plot' }, [this._canvas, this._overlay]);
+    const body = el('div', { className: 'olv-workbench-body' }, [
+      el('div', { className: 'olv-workbench-plotwrap' }, [plot, this._readout]),
+      this._detail,
+    ]);
 
     this._root = el('section', { className: 'olv-workbench' }, [
       this._splitter,
@@ -233,6 +267,7 @@ class ProfileWorkbench {
     return {
       element: this._root,
       canvas: this._canvas,
+      overlay: this._overlay,
       height: () => dockOccupiedHeight(this._state, this._limits()),
       collapsed: () => this._state.collapsed,
       setCollapsed: (v: boolean) => this.setCollapsed(v),
@@ -243,6 +278,9 @@ class ProfileWorkbench {
         this._status.textContent = t;
       },
       setDetail: (rows) => this.setDetail(rows),
+      setReadout: (t: string | null) => {
+        this._readout.textContent = t ?? '';
+      },
       close: () => this.close(),
     };
   }

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -5010,7 +5010,29 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   display: flex; gap: var(--space-md); min-height: 0; flex: 1;
   padding: 0 var(--space-md) var(--space-sm);
 }
-.olv-workbench-canvas { flex: 1; min-width: 0; display: block; }
+/* The plot column: the picture, the crosshair over it, and the one-line
+   readout under it. The wrapper is what flexes; the two canvases are stacked,
+   so the crosshair can be redrawn without touching the splats beneath it. */
+.olv-workbench-plotwrap {
+  flex: 1; min-width: 0; min-height: 0;
+  display: flex; flex-direction: column;
+}
+.olv-workbench-plot { position: relative; flex: 1; min-height: 0; }
+.olv-workbench-canvas,
+.olv-workbench-overlay {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%; display: block;
+}
+/* Decoration only: it never receives the pointer, so the events the plot
+   listens for are the ones the reader aimed at the plot. */
+.olv-workbench-overlay { pointer-events: none; }
+.olv-workbench-canvas { cursor: crosshair; }
+.olv-workbench-readout {
+  min-height: 1.2em; padding-top: var(--space-2xs);
+  font-size: var(--text-xs); color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
 /* The exact figures for the selected return. A canvas is a picture; this is
    the readable half of the same information, so it never collapses away. */
 .olv-workbench-detail {

--- a/tests/workbenchPointLink.test.ts
+++ b/tests/workbenchPointLink.test.ts
@@ -1,0 +1,1126 @@
+/**
+ * workbenchPointLink.test.ts
+ *
+ * The link between a return drawn in the Profile Workbench and the same return
+ * in the 3D scene.
+ *
+ * Node environment with a per-test recording DOM stub — the convention the
+ * workbench suites already use, and the reason the presenter can be driven for
+ * real here rather than through a double. No jsdom, no `window`.
+ *
+ * Each block pins one property the feature is only worth having if it holds:
+ *
+ *   - a return is followed by its recorded IDENTITY (slot, source kind, source
+ *     id, that source's own point index) and never by matching coordinates,
+ *     because a corridor's returns sit within centimetres of each other;
+ *   - a hover never moves the camera, and the only path to the camera is the
+ *     deliberate gesture on a CLICKED selection;
+ *   - profile selection and Inspect selection are separate states, so nothing
+ *     on this path reaches the inspector at all;
+ *   - a streaming node evicted after the snapshot leaves the 2D figures intact
+ *     and reports the 3D link as gone, rather than marking a point that is no
+ *     longer resident;
+ *   - a burst of raw pointer moves inside one frame costs exactly one
+ *     hit-test, one readout and one presentation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import {
+  focusPoseOnPoint,
+  locateProfileReturn,
+  profileDetailSources,
+  profileHoverReadout,
+  profileLinkStatusText,
+  profileMarkerSegments,
+  profileMarkerSize,
+  profileReturnIdentity,
+} from '../src/render/measure/profilePointLink';
+import { drawProfileLinkOverlay, MARK_HALF_PX } from '../src/render/measure/profileLinkOverlay2d';
+import { createProfileLinkController } from '../src/app/profileLinkController';
+import {
+  attachSectionPointLink,
+  prepareWorkbenchSection,
+  HIT_RADIUS_PX,
+  LINK_ROW_LABEL,
+} from '../src/app/profileWorkbenchSection';
+import { createProfileSectionSeam } from '../src/render/measure/profileSectionSeam';
+import { profileDataToScreen } from '../src/render/measure/profileViewTransform';
+
+import type { ProfileSectionPoints } from '../src/render/measure/profileSectionBuilder';
+import type {
+  ProfileReturnLocation,
+  ProfileReturnRef,
+  ProfileSectionResult,
+  ProfileSectionSourceRef,
+} from '../src/render/measure/profileSectionSeam';
+import type { ProfileReturnIdentity } from '../src/render/measure/profilePointLink';
+import type { WorkbenchSectionScene } from '../src/app/profileWorkbenchSection';
+import type { ProfileWorkbenchDetailRow } from '../src/ui/ProfileWorkbench';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readSource = (rel: string): string => readFileSync(resolve(REPO, rel), 'utf8');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Recording DOM stub
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Recorded {
+  op: string;
+  args: number[];
+}
+
+/** A 2D context that records every call the overlay makes. */
+class RecordingContext {
+  strokeStyle: string | CanvasGradient | CanvasPattern = '';
+  fillStyle: string | CanvasGradient | CanvasPattern = '';
+  lineWidth = 0;
+  globalAlpha = 1;
+  readonly ops: Recorded[] = [];
+  setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void {
+    this.ops.push({ op: 'setTransform', args: [a, b, c, d, e, f] });
+  }
+  clearRect(x: number, y: number, w: number, h: number): void {
+    this.ops.push({ op: 'clearRect', args: [x, y, w, h] });
+  }
+  fillRect(x: number, y: number, w: number, h: number): void {
+    this.ops.push({ op: 'fillRect', args: [x, y, w, h] });
+  }
+  beginPath(): void {
+    this.ops.push({ op: 'beginPath', args: [] });
+  }
+  moveTo(x: number, y: number): void {
+    this.ops.push({ op: 'moveTo', args: [x, y] });
+  }
+  lineTo(x: number, y: number): void {
+    this.ops.push({ op: 'lineTo', args: [x, y] });
+  }
+  closePath(): void {
+    this.ops.push({ op: 'closePath', args: [] });
+  }
+  stroke(): void {
+    this.ops.push({ op: 'stroke', args: [] });
+  }
+  count(op: string): number {
+    return this.ops.filter((o) => o.op === op).length;
+  }
+}
+
+/** A canvas that records its listeners, so a test can dispatch to them. */
+class FakeCanvas {
+  width = 0;
+  height = 0;
+  clientWidth = 0;
+  clientHeight = 0;
+  readonly ctx = new RecordingContext();
+  readonly listeners = new Map<string, ((ev: unknown) => void)[]>();
+  constructor(width = 0, height = 0) {
+    this.clientWidth = width;
+    this.clientHeight = height;
+  }
+  getContext(): RecordingContext {
+    return this.ctx;
+  }
+  addEventListener(type: string, fn: (ev: unknown) => void): void {
+    const list = this.listeners.get(type) ?? [];
+    list.push(fn);
+    this.listeners.set(type, list);
+  }
+  removeEventListener(type: string, fn: (ev: unknown) => void): void {
+    const list = this.listeners.get(type) ?? [];
+    const at = list.indexOf(fn);
+    if (at >= 0) list.splice(at, 1);
+  }
+  fire(type: string, ev: unknown): void {
+    for (const fn of [...(this.listeners.get(type) ?? [])]) fn(ev);
+  }
+  bound(type: string): number {
+    return (this.listeners.get(type) ?? []).length;
+  }
+}
+
+beforeEach(() => {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.document = {
+    createElement: () => ({}),
+    createElementNS: () => ({}),
+    addEventListener: (): void => {},
+    removeEventListener: (): void => {},
+  };
+});
+
+afterEach(() => {
+  const g = globalThis as unknown as Record<string, unknown>;
+  delete g.document;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const STATIC_ID = 'scan-a';
+const NODE_KEY = '3-2-1-0';
+
+/**
+ * Five returns over two sources, one static and one streaming.
+ *
+ * The source point indices are deliberately NOT the section indices and are
+ * deliberately not ordered: a route that lost the recorded index and fell back
+ * to the section index, or to the nearest neighbour, produces different numbers
+ * on every one of them.
+ */
+const SOURCE_INDICES = [41, 7, 900, 3, 12];
+const SLOTS = [0, 1, 0, 1, 0];
+
+function fixtureSection(): ProfileSectionResult {
+  const count = SOURCE_INDICES.length;
+  const chainage = new Float32Array(count);
+  const height = new Float64Array(count);
+  const lateralOffset = new Float32Array(count);
+  const sourceSlot = new Uint16Array(count);
+  const pointIndex = new Uint32Array(count);
+  const classification = new Uint8Array(count);
+  const channelPresence = new Uint8Array(count);
+  for (let i = 0; i < count; i++) {
+    chainage[i] = i * 5;
+    height[i] = 100 + i;
+    lateralOffset[i] = i % 2 === 0 ? 0.25 : -0.25;
+    sourceSlot[i] = SLOTS[i]!;
+    pointIndex[i] = SOURCE_INDICES[i]!;
+    classification[i] = 2;
+    // classification bit set on every point of this fixture
+    channelPresence[i] = 1 << 2;
+  }
+  const points: ProfileSectionPoints = {
+    count,
+    chainage,
+    height,
+    lateralOffset,
+    sourceSlot,
+    pointIndex,
+    channelPresence,
+    classification,
+  };
+  const sources: ProfileSectionSourceRef[] = [
+    { slot: 0, kind: 'static', id: STATIC_ID, pointCount: 1000 },
+    { slot: 1, kind: 'resident', id: NODE_KEY, pointCount: 500 },
+  ];
+  return {
+    points,
+    frame: null as never,
+    band: 2,
+    scope: 'mixed' as never,
+    scopeLabel: 'One layer and the streaming source.',
+    streamingComplete: true,
+    sources,
+    generation: 1,
+    aborted: false,
+    skippedSlots: [],
+    examined: count,
+  };
+}
+
+/** A locator that answers from a table keyed by the recorded identity. */
+function tableLocator(
+  table: Map<string, [number, number, number]>,
+  evicted: Set<string> = new Set(),
+): {
+  locate: (ref: ProfileReturnRef, out: Float64Array) => ProfileReturnLocation;
+  calls: ProfileReturnRef[];
+} {
+  const calls: ProfileReturnRef[] = [];
+  return {
+    calls,
+    locate: (ref, out) => {
+      calls.push({ kind: ref.kind, id: ref.id, pointIndex: ref.pointIndex });
+      if (evicted.has(ref.id)) return 'evicted';
+      const hit = table.get(`${ref.kind}:${ref.id}:${ref.pointIndex}`);
+      if (!hit) return 'unavailable';
+      out[0] = hit[0];
+      out[1] = hit[1];
+      out[2] = hit[2];
+      return 'linked';
+    },
+  };
+}
+
+/**
+ * Positions for every fixture return, placed a CENTIMETRE apart.
+ *
+ * That spacing is the point: a route that searched the scene for the nearest
+ * coordinate would have a field of near-coincident candidates to choose wrongly
+ * from, exactly as it would in a real corridor.
+ */
+function fixtureTable(): Map<string, [number, number, number]> {
+  const table = new Map<string, [number, number, number]>();
+  for (let i = 0; i < SOURCE_INDICES.length; i++) {
+    const kind = SLOTS[i] === 0 ? 'static' : 'resident';
+    const id = SLOTS[i] === 0 ? STATIC_ID : NODE_KEY;
+    table.set(`${kind}:${id}:${SOURCE_INDICES[i]!}`, [10 + i * 0.01, 20, 30 + i * 0.01]);
+  }
+  return table;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Identity routing
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('a return is routed by the identity the section recorded', () => {
+  it('reads slot, source kind, source id and the SOURCE point index', () => {
+    const section = fixtureSection();
+    for (let i = 0; i < section.points.count; i++) {
+      const identity = profileReturnIdentity(section.points, section.sources, i);
+      expect(identity, `return ${i}`).not.toBeNull();
+      expect(identity!.sectionIndex).toBe(i);
+      expect(identity!.slot).toBe(SLOTS[i]);
+      expect(identity!.kind).toBe(SLOTS[i] === 0 ? 'static' : 'resident');
+      expect(identity!.sourceId).toBe(SLOTS[i] === 0 ? STATIC_ID : NODE_KEY);
+      // The recorded index, not the section index and not a neighbour's.
+      expect(identity!.pointIndex).toBe(SOURCE_INDICES[i]);
+    }
+  });
+
+  it('refuses a slot no source ref names rather than guessing a layer', () => {
+    const section = fixtureSection();
+    section.points.sourceSlot[2] = 9;
+    expect(profileReturnIdentity(section.points, section.sources, 2)).toBeNull();
+  });
+
+  it('refuses an index outside the section', () => {
+    const section = fixtureSection();
+    expect(profileReturnIdentity(section.points, section.sources, -1)).toBeNull();
+    expect(profileReturnIdentity(section.points, section.sources, 5)).toBeNull();
+    expect(profileReturnIdentity(section.points, section.sources, 1.5)).toBeNull();
+  });
+
+  it('asks the scene for exactly that identity, never for a nearby position', () => {
+    const section = fixtureSection();
+    const { locate, calls } = tableLocator(fixtureTable());
+    const identity = profileReturnIdentity(section.points, section.sources, 3)!;
+    const link = locateProfileReturn(identity, (id, out) =>
+      locate({ kind: id.kind, id: id.sourceId, pointIndex: id.pointIndex }, out),
+    );
+    expect(calls).toEqual([{ kind: 'resident', id: NODE_KEY, pointIndex: 3 }]);
+    expect(link.state).toBe('linked');
+    // The table's entry for THAT identity, not for either neighbour a
+    // centimetre away.
+    expect(link.position).toEqual([10.03, 20, 30.03]);
+  });
+
+  it('downgrades a non-finite coordinate rather than marking NaN', () => {
+    const identity: ProfileReturnIdentity = {
+      sectionIndex: 0,
+      slot: 0,
+      kind: 'static',
+      sourceId: STATIC_ID,
+      pointIndex: 41,
+    };
+    const link = locateProfileReturn(identity, (_id, out) => {
+      out[0] = Number.NaN;
+      out[1] = 0;
+      out[2] = 0;
+      return 'linked';
+    });
+    expect(link.state).toBe('unavailable');
+    expect(link.position).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The seam's own resolution
+// ─────────────────────────────────────────────────────────────────────────────
+
+function seamWith(options: {
+  layerPositions?: Float32Array | null;
+  placement?: { sourceToProject: readonly [number, number, number] } | null;
+  visible?: boolean;
+  nodes?: { key: string; positions: Float32Array | null }[];
+}): ReturnType<typeof createProfileSectionSeam> {
+  return createProfileSectionSeam({
+    layers: () => [
+      {
+        mesh: { visible: options.visible ?? true },
+        id: STATIC_ID,
+        positions: options.layerPositions ?? new Float32Array([1, 2, 3, 4, 5, 6]),
+        channels: null,
+        bounds: null,
+        placement: (options.placement ?? null) as never,
+      },
+    ],
+    residentNodes: () =>
+      (options.nodes ?? [{ key: NODE_KEY, positions: new Float32Array([7, 8, 9, 10, 11, 12]) }]).map(
+        (n) => ({ key: n.key, positions: n.positions, channels: null }),
+      ),
+    streamingMayCombine: () => true,
+    worldUp: () => [0, 0, 1],
+    streamingCoverage: () => null,
+  });
+}
+
+describe('the seam resolves a recorded return against the scene as it is now', () => {
+  it('reads a static layer at its own index, with the placement folded once', () => {
+    const seam = seamWith({ placement: { sourceToProject: [100, 200, 300] } });
+    const out = new Float64Array(3);
+    expect(seam.locateReturn({ kind: 'static', id: STATIC_ID, pointIndex: 1 }, out)).toBe('linked');
+    expect([...out]).toEqual([104, 205, 306]);
+  });
+
+  it('reads a resident node at its own index', () => {
+    const seam = seamWith({});
+    const out = new Float64Array(3);
+    expect(seam.locateReturn({ kind: 'resident', id: NODE_KEY, pointIndex: 0 }, out)).toBe('linked');
+    expect([...out]).toEqual([7, 8, 9]);
+  });
+
+  it('reports a node that is no longer resident as EVICTED, never as linked', () => {
+    const seam = seamWith({ nodes: [{ key: 'other-node', positions: new Float32Array([0, 0, 0]) }] });
+    const out = new Float64Array(3);
+    expect(seam.locateReturn({ kind: 'resident', id: NODE_KEY, pointIndex: 0 }, out)).toBe('evicted');
+  });
+
+  it('reports a resident node with no coordinate at that index as unavailable', () => {
+    const seam = seamWith({});
+    const out = new Float64Array(3);
+    expect(seam.locateReturn({ kind: 'resident', id: NODE_KEY, pointIndex: 99 }, out)).toBe(
+      'unavailable',
+    );
+  });
+
+  it('reports a hidden static layer as unavailable rather than marking it', () => {
+    const seam = seamWith({ visible: false });
+    const out = new Float64Array(3);
+    expect(seam.locateReturn({ kind: 'static', id: STATIC_ID, pointIndex: 0 }, out)).toBe(
+      'unavailable',
+    );
+  });
+
+  it('reports a layer id nothing carries as unavailable', () => {
+    const seam = seamWith({});
+    const out = new Float64Array(3);
+    expect(seam.locateReturn({ kind: 'static', id: 'gone', pointIndex: 0 }, out)).toBe(
+      'unavailable',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The controller
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ControllerRig {
+  controller: ReturnType<typeof createProfileLinkController>;
+  frames: (() => void)[];
+  runFrame(): void;
+  paints: ({ hover: unknown; locked: unknown })[];
+  marks: (null | { position: readonly [number, number, number]; mode: string })[];
+  presents: { hover: unknown; locked: unknown; detail: unknown }[];
+  focuses: readonly (readonly [number, number, number])[];
+  locateCalls: ProfileReturnRef[];
+  detailCalls: number[];
+  readoutCalls: number[];
+  evict(): void;
+}
+
+/**
+ * A controller over the fixture section.
+ *
+ * `query` maps a pixel to a section index by a fixed table, so the test drives
+ * hit results directly rather than reconstructing the plot's geometry; the
+ * geometry itself is exercised end to end further down.
+ */
+function controllerRig(options: { withFocus?: boolean } = {}): ControllerRig {
+  const section = fixtureSection();
+  const table = fixtureTable();
+  const evicted = new Set<string>();
+  const { locate, calls } = tableLocator(table, evicted);
+  const frames: (() => void)[] = [];
+  const paints: ({ hover: unknown; locked: unknown })[] = [];
+  const marks: (null | { position: readonly [number, number, number]; mode: string })[] = [];
+  const presents: { hover: unknown; locked: unknown; detail: unknown }[] = [];
+  const focuses: (readonly [number, number, number])[] = [];
+  const detailCalls: number[] = [];
+  const readoutCalls: number[] = [];
+
+  const controller = createProfileLinkController({
+    // x is the section index times ten; anything else misses.
+    query: (x) => {
+      const i = Math.round(x / 10);
+      return i >= 0 && i < section.points.count ? i : null;
+    },
+    project: (i, out) => {
+      out[0] = i * 10;
+      out[1] = 50;
+      return true;
+    },
+    identify: (i) => profileReturnIdentity(section.points, section.sources, i),
+    locate: (identity, out) =>
+      locate({ kind: identity.kind, id: identity.sourceId, pointIndex: identity.pointIndex }, out),
+    readout: (i) => {
+      readoutCalls.push(i);
+      return profileHoverReadout(section.points, i);
+    },
+    detail: (i) => {
+      detailCalls.push(i);
+      return { index: i, coordinateHeading: 'World', verticalReference: 'unknown', verticalNote: '', rows: [] };
+    },
+    schedule: (run) => {
+      frames.push(run);
+    },
+    paint: (hover, locked) => {
+      paints.push({ hover, locked });
+    },
+    mark: (marker) => {
+      marks.push(marker);
+    },
+    present: (state) => {
+      presents.push({ hover: state.hover, locked: state.locked, detail: state.detail });
+    },
+    ...(options.withFocus
+      ? {
+          focus: (position: readonly [number, number, number]): void => {
+            focuses.push(position);
+          },
+        }
+      : {}),
+  });
+
+  return {
+    controller,
+    frames,
+    runFrame: () => {
+      const next = frames.shift();
+      next?.();
+    },
+    paints,
+    marks,
+    presents,
+    focuses,
+    locateCalls: calls,
+    detailCalls,
+    readoutCalls,
+    evict: () => evicted.add(NODE_KEY),
+  };
+}
+
+describe('hover', () => {
+  it('coalesces a burst of raw moves into ONE hit-test and one presentation', () => {
+    const rig = controllerRig();
+    for (let n = 0; n < 50; n++) rig.controller.pointerMove(20 + n * 0.01, 50);
+    // Nothing has happened yet: a raw move records and asks for a frame.
+    expect(rig.controller.stats().hitTests).toBe(0);
+    expect(rig.readoutCalls).toHaveLength(0);
+    expect(rig.presents).toHaveLength(0);
+    expect(rig.frames).toHaveLength(1);
+
+    rig.runFrame();
+    const stats = rig.controller.stats();
+    expect(stats.pointerEvents).toBe(50);
+    expect(stats.flushes).toBe(1);
+    expect(stats.hitTests).toBe(1);
+    expect(rig.readoutCalls).toEqual([2]);
+    expect(rig.presents).toHaveLength(1);
+    expect(rig.paints).toHaveLength(1);
+  });
+
+  it('presents nothing at all when a later frame resolves to the same return', () => {
+    const rig = controllerRig();
+    rig.controller.pointerMove(20, 50);
+    rig.runFrame();
+    expect(rig.presents).toHaveLength(1);
+    rig.controller.pointerMove(21, 50);
+    rig.runFrame();
+    expect(rig.controller.stats().hitTests).toBe(2);
+    expect(rig.presents).toHaveLength(1);
+  });
+
+  it('marks the hovered return in 3D, at the position its identity resolved to', () => {
+    const rig = controllerRig();
+    rig.controller.pointerMove(30, 50);
+    rig.runFrame();
+    expect(rig.marks).toEqual([{ position: [10.03, 20, 30.03], mode: 'hover' }]);
+    expect(rig.locateCalls).toEqual([{ kind: 'resident', id: NODE_KEY, pointIndex: 3 }]);
+  });
+
+  it('NEVER moves the camera', () => {
+    const rig = controllerRig({ withFocus: true });
+    for (let i = 0; i < 5; i++) {
+      rig.controller.pointerMove(i * 10, 50);
+      rig.runFrame();
+    }
+    rig.controller.pointerLeave();
+    rig.runFrame();
+    expect(rig.focuses).toEqual([]);
+    expect(rig.controller.stats().focuses).toBe(0);
+  });
+
+  it('does not build the detail card', () => {
+    const rig = controllerRig();
+    rig.controller.pointerMove(10, 50);
+    rig.runFrame();
+    expect(rig.detailCalls).toEqual([]);
+    expect(rig.presents.at(-1)!.detail).toBeNull();
+  });
+
+  it('clears on leave', () => {
+    const rig = controllerRig();
+    rig.controller.pointerMove(10, 50);
+    rig.runFrame();
+    rig.controller.pointerLeave();
+    rig.runFrame();
+    expect(rig.marks.at(-1)).toBeNull();
+    expect(rig.paints.at(-1)).toEqual({ hover: null, locked: null });
+  });
+});
+
+describe('click', () => {
+  it('locks the selection and builds the card, without waiting for a frame', () => {
+    const rig = controllerRig();
+    rig.controller.click(10, 50);
+    expect(rig.detailCalls).toEqual([1]);
+    const locked = rig.controller.selection()!;
+    expect(locked.identity.pointIndex).toBe(SOURCE_INDICES[1]);
+    expect(locked.identity.kind).toBe('resident');
+    expect(rig.presents.at(-1)!.detail).not.toBeNull();
+  });
+
+  it('does not move the camera on its own', () => {
+    const rig = controllerRig({ withFocus: true });
+    rig.controller.click(10, 50);
+    expect(rig.focuses).toEqual([]);
+  });
+
+  it('marks the LOCKED return even while the pointer moves over others', () => {
+    const rig = controllerRig();
+    rig.controller.click(10, 50);
+    rig.controller.pointerMove(40, 50);
+    rig.runFrame();
+    expect(rig.marks.at(-1)).toEqual({ position: [10.01, 20, 30.01], mode: 'locked' });
+  });
+
+  it('clears the lock when it misses every return', () => {
+    const rig = controllerRig();
+    rig.controller.click(10, 50);
+    rig.controller.click(9999, 50);
+    expect(rig.controller.selection()).toBeNull();
+    expect(rig.presents.at(-1)!.detail).toBeNull();
+  });
+});
+
+describe('the deliberate focus action', () => {
+  it('moves the camera only for a locked selection with a live source', () => {
+    const rig = controllerRig({ withFocus: true });
+    expect(rig.controller.focusSelection()).toBe(false);
+    rig.controller.click(10, 50);
+    expect(rig.controller.focusSelection()).toBe(true);
+    expect(rig.focuses).toEqual([[10.01, 20, 30.01]]);
+  });
+
+  it('refuses when the locked return has lost its source', () => {
+    const rig = controllerRig({ withFocus: true });
+    rig.controller.click(10, 50);
+    rig.evict();
+    rig.controller.refresh();
+    expect(rig.controller.focusSelection()).toBe(false);
+    expect(rig.focuses).toEqual([]);
+  });
+
+  it('refuses when the host supplied no camera', () => {
+    const rig = controllerRig();
+    rig.controller.click(10, 50);
+    expect(rig.controller.focusSelection()).toBe(false);
+  });
+
+  it('composes a pose that keeps the viewing direction and distance', () => {
+    const next = focusPoseOnPoint({ position: [0, 0, 10], target: [0, 0, 0] }, [5, 5, 5]);
+    expect(next.target).toEqual([5, 5, 5]);
+    expect(next.position).toEqual([5, 5, 15]);
+  });
+});
+
+describe('a source lost after the snapshot', () => {
+  it('keeps the 2D selection and reports the 3D link as evicted', () => {
+    const rig = controllerRig();
+    rig.controller.click(10, 50);
+    const before = rig.controller.selection()!;
+    expect(before.state).toBe('linked');
+
+    rig.evict();
+    rig.controller.pointerMove(0, 50);
+    rig.runFrame();
+
+    const after = rig.controller.selection()!;
+    // Still selected, still the same return, still carrying its 2D figures.
+    expect(after).not.toBeNull();
+    expect(after.identity).toEqual(before.identity);
+    expect(after.readout).toBe(before.readout);
+    // And no longer claimed to be marked.
+    expect(after.state).toBe('evicted');
+    expect(after.position).toBeNull();
+    expect(rig.marks.at(-1)).toBeNull();
+  });
+
+  it('never reports an evicted node as linked, however often it is re-read', () => {
+    const rig = controllerRig();
+    rig.controller.click(10, 50);
+    rig.evict();
+    for (let n = 0; n < 5; n++) rig.controller.refresh();
+    expect(rig.controller.selection()!.state).toBe('evicted');
+    expect(rig.marks.filter((m) => m !== null).every((m) => m!.mode === 'locked')).toBe(true);
+    expect(rig.marks.at(-1)).toBeNull();
+  });
+
+  it('has wording for every state', () => {
+    expect(profileLinkStatusText('linked')).toBe('marked in 3D');
+    expect(profileLinkStatusText('evicted')).toBe('source node evicted');
+    expect(profileLinkStatusText('unavailable')).toBe('source unavailable');
+  });
+});
+
+describe('dispose', () => {
+  it('clears both marks and stops responding', () => {
+    const rig = controllerRig();
+    rig.controller.click(10, 50);
+    rig.controller.dispose();
+    expect(rig.marks.at(-1)).toBeNull();
+    expect(rig.paints.at(-1)).toEqual({ hover: null, locked: null });
+    const presents = rig.presents.length;
+    rig.controller.pointerMove(10, 50);
+    expect(rig.presents).toHaveLength(presents);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Profile selection and Inspect selection are separate states
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The inspector's own surface, named the way the tool names it. */
+const INSPECTOR_REFERENCES = /Inspect|inspectMode|showPoint/;
+
+describe('the profile link never touches the inspector', () => {
+  const path = [
+    'src/render/measure/profilePointLink.ts',
+    'src/render/measure/profileLinkOverlay2d.ts',
+    'src/render/ProfileLinkOverlay.ts',
+    'src/app/profileLinkController.ts',
+    'src/app/profileWorkbenchSection.ts',
+    'src/app/profileWorkbenchRuntime.ts',
+  ];
+
+  for (const rel of path) {
+    it(`${rel} names no part of the inspector's selection`, () => {
+      const source = readSource(rel);
+      // The doc comment in ProfileLinkOverlay explains the separation, so the
+      // check is on CODE: strip block comments before matching.
+      const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      expect(INSPECTOR_REFERENCES.test(code), `${rel} reaches the inspector`).toBe(false);
+    });
+  }
+
+  it('reads only the seam members it declares, over a full hover-click-focus cycle', () => {
+    const touched = new Set<string>();
+    const rig = endToEnd({ watch: touched });
+    const p = rig.pixelOf(2);
+    rig.canvas.fire('pointermove', { offsetX: p.x, offsetY: p.y });
+    rig.frames.shift()!();
+    rig.canvas.fire('click', { offsetX: p.x, offsetY: p.y });
+    rig.canvas.fire('dblclick', { offsetX: p.x, offsetY: p.y });
+    rig.canvas.fire('pointerleave', {});
+    rig.frames.shift()!();
+    // The whole surface the link is allowed to reach. An inspector-driving
+    // mutation has to add a member here, and adding one fails this.
+    expect([...touched].sort()).toEqual(
+      [
+        'crs',
+        'focusPoint',
+        'locateReturn',
+        'markLinkedReturn',
+        'observePointer',
+        'schedulePointerFlush',
+      ].sort(),
+    );
+    for (const name of touched) expect(INSPECTOR_REFERENCES.test(name)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The 2D overlay
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('the 2D crosshair', () => {
+  it('clears the surface even with nothing to draw', () => {
+    const ctx = new RecordingContext();
+    drawProfileLinkOverlay(ctx, {
+      widthPx: 200,
+      heightPx: 100,
+      devicePixelRatio: 2,
+      hover: null,
+      locked: null,
+    });
+    expect(ctx.count('clearRect')).toBe(1);
+    expect(ctx.count('stroke')).toBe(0);
+    expect(ctx.ops[0]).toEqual({ op: 'setTransform', args: [2, 0, 0, 2, 0, 0] });
+  });
+
+  it('draws a full-width and full-height rule through the hover, and a box', () => {
+    const ctx = new RecordingContext();
+    drawProfileLinkOverlay(ctx, {
+      widthPx: 200,
+      heightPx: 100,
+      devicePixelRatio: 1,
+      hover: { x: 40, y: 60 },
+      locked: null,
+    });
+    const moves = ctx.ops.filter((o) => o.op === 'moveTo').map((o) => o.args);
+    expect(moves).toContainEqual([0, 60]);
+    expect(moves).toContainEqual([40, 0]);
+    const lines = ctx.ops.filter((o) => o.op === 'lineTo').map((o) => o.args);
+    expect(lines).toContainEqual([200, 60]);
+    expect(lines).toContainEqual([40, 100]);
+    expect(lines).toContainEqual([40 + MARK_HALF_PX, 60 - MARK_HALF_PX]);
+  });
+
+  it('draws the locked box last, so it reads over a passing hover', () => {
+    const ctx = new RecordingContext();
+    drawProfileLinkOverlay(ctx, {
+      widthPx: 200,
+      heightPx: 100,
+      devicePixelRatio: 1,
+      hover: { x: 40, y: 60 },
+      locked: { x: 90, y: 20 },
+    });
+    const lastPath = ctx.ops.map((o) => o.args).filter((a) => a.length === 2);
+    expect(lastPath.at(-1)).toEqual([90 - MARK_HALF_PX, 20 + MARK_HALF_PX]);
+  });
+
+  it('skips a non-finite mark rather than stroking to NaN', () => {
+    const ctx = new RecordingContext();
+    drawProfileLinkOverlay(ctx, {
+      widthPx: 200,
+      heightPx: 100,
+      devicePixelRatio: 1,
+      hover: { x: Number.NaN, y: 60 },
+      locked: null,
+    });
+    expect(ctx.count('stroke')).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The 3D marker geometry
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('the 3D mark', () => {
+  it('is sized from the corridor, so it reads at the section\'s own scale', () => {
+    expect(profileMarkerSize(2)).toBeCloseTo(0.7, 12);
+    expect(profileMarkerSize(20)).toBeCloseTo(7, 12);
+    expect(profileMarkerSize(0)).toBe(1);
+    expect(profileMarkerSize(Number.NaN)).toBe(1);
+  });
+
+  it('is a three-axis cross centred on the point', () => {
+    const v = profileMarkerSegments([1, 2, 3], 0.5);
+    expect([...v.subarray(0, 6)]).toEqual([0.5, 2, 3, 1.5, 2, 3]);
+    expect([...v.subarray(6, 12)]).toEqual([1, 1.5, 3, 1, 2.5, 3]);
+    expect([...v.subarray(12, 18)]).toEqual([1, 2, 2.5, 1, 2, 3.5]);
+  });
+
+  it('writes into the buffer it is given, so a move allocates nothing', () => {
+    const buffer = new Float32Array(18);
+    expect(profileMarkerSegments([0, 0, 0], 1, buffer)).toBe(buffer);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The readout and the card
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('the hover readout', () => {
+  it('leads with chainage when no scale reaches metres', () => {
+    const section = fixtureSection();
+    const text = profileHoverReadout(section.points, 2);
+    expect(text).toContain('Chainage 10.000');
+    expect(text).not.toContain('Station');
+  });
+
+  it('leads with a station when the frame states a scale', () => {
+    const section = fixtureSection();
+    const text = profileHoverReadout(section.points, 2, { unitToMetres: 1 });
+    expect(text).toContain('Station');
+  });
+
+  it('takes its height wording from the vertical reference, unchanged', () => {
+    const section = fixtureSection();
+    expect(profileHoverReadout(section.points, 0, { reference: 'orthometric' })).toContain(
+      'Elevation 100.000',
+    );
+    expect(profileHoverReadout(section.points, 0, { reference: 'ellipsoidal' })).toContain(
+      'Ellipsoidal height 100.000',
+    );
+    expect(profileHoverReadout(section.points, 0)).toContain('Height (datum unknown)');
+  });
+
+  it('quotes a class only where the point carries one', () => {
+    const section = fixtureSection();
+    expect(profileHoverReadout(section.points, 0)).toContain('2 (Ground)');
+    section.points.channelPresence[0] = 0;
+    expect(profileHoverReadout(section.points, 0)).not.toContain('Ground');
+  });
+
+  it('is empty for an index the section does not hold', () => {
+    const section = fixtureSection();
+    expect(profileHoverReadout(section.points, 99)).toBe('');
+  });
+});
+
+describe('the card sources', () => {
+  it('names a streaming slot by its node key and a static slot by its layer', () => {
+    const section = fixtureSection();
+    const built = profileDetailSources(section.sources);
+    expect(built[0]!.layerId).toBe(STATIC_ID);
+    expect(built[0]!.streamingNodeKey).toBeUndefined();
+    expect(built[1]!.streamingNodeKey).toBe(NODE_KEY);
+  });
+
+  it('reads coordinates through the SAME locator the marker uses', () => {
+    const section = fixtureSection();
+    const { locate, calls } = tableLocator(fixtureTable());
+    const built = profileDetailSources(section.sources, (identity, out) =>
+      locate({ kind: identity.kind, id: identity.sourceId, pointIndex: identity.pointIndex }, out),
+    );
+    const out = new Float64Array(3);
+    expect(built[1]!.readXYZ!(7, out)).toBe(true);
+    expect(calls.at(-1)).toEqual({ kind: 'resident', id: NODE_KEY, pointIndex: 7 });
+    expect([...out]).toEqual([10.01, 20, 30.01]);
+  });
+
+  it('declines an evicted node rather than answering with a stale position', () => {
+    const section = fixtureSection();
+    const { locate } = tableLocator(fixtureTable(), new Set([NODE_KEY]));
+    const built = profileDetailSources(section.sources, (identity, out) =>
+      locate({ kind: identity.kind, id: identity.sourceId, pointIndex: identity.pointIndex }, out),
+    );
+    expect(built[1]!.readXYZ!(7, new Float64Array(3))).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// End to end, over the real plot geometry
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface EndToEndRig {
+  link: NonNullable<ReturnType<typeof attachSectionPointLink>>;
+  canvas: FakeCanvas;
+  overlay: FakeCanvas;
+  detail: (readonly ProfileWorkbenchDetailRow[] | null)[];
+  readouts: (string | null)[];
+  markers: unknown[];
+  frames: (() => void)[];
+  /** Plot pixel of section return `i`, from the placement the draw used. */
+  pixelOf(i: number): { x: number; y: number };
+}
+
+function endToEnd(options: { evicted?: Set<string>; watch?: Set<string> } = {}): EndToEndRig {
+  const section = fixtureSection();
+  const canvas = new FakeCanvas(320, 160);
+  const overlay = new FakeCanvas(320, 160);
+  const detail: (readonly ProfileWorkbenchDetailRow[] | null)[] = [];
+  const readouts: (string | null)[] = [];
+  const markers: unknown[] = [];
+  const frames: (() => void)[] = [];
+  const { locate } = tableLocator(fixtureTable(), options.evicted ?? new Set());
+
+  const plot = prepareWorkbenchSection({
+    section,
+    canvas: canvas as never,
+    devicePixelRatio: 1,
+  });
+
+  const scene: WorkbenchSectionScene = {
+    profile: () => null,
+    sectionChunks: function* () {
+      return null;
+    },
+    metresPerUnit: () => 1,
+    devicePixelRatio: () => 1,
+    locateReturn: (ref, out) => locate(ref, out),
+    markLinkedReturn: (marker) => {
+      markers.push(marker);
+    },
+    schedulePointerFlush: (run) => {
+      frames.push(run);
+    },
+  };
+
+  // Every read of a seam member is recorded, so a test can pin the whole
+  // surface the link touches rather than only the calls it thought to spy on.
+  const watched = options.watch
+    ? (new Proxy(scene, {
+        get(target, key: string): unknown {
+          options.watch!.add(key);
+          return Reflect.get(target, key) as unknown;
+        },
+      }) as WorkbenchSectionScene)
+    : scene;
+
+  const link = attachSectionPointLink({
+    plot,
+    section,
+    handle: {
+      canvas: canvas as never,
+      overlay: overlay as never,
+      setDetail: (rows) => detail.push(rows),
+      setReadout: (text) => readouts.push(text),
+    },
+    scene: watched,
+    unitToMetres: 1,
+    devicePixelRatio: 1,
+  })!;
+
+  const frame = plot.frame()!;
+  return {
+    link,
+    canvas,
+    overlay,
+    detail,
+    readouts,
+    markers,
+    frames,
+    pixelOf: (i) => {
+      const out = new Float64Array(2);
+      profileDataToScreen(
+        frame.view,
+        frame.viewport,
+        section.points.chainage[i]!,
+        section.points.height[i]!,
+        out,
+      );
+      return { x: out[0]!, y: out[1]! };
+    },
+  };
+}
+
+describe('the plot, end to end', () => {
+  it('binds pointer input and releases every listener', () => {
+    const rig = endToEnd();
+    expect(rig.canvas.bound('pointermove')).toBe(1);
+    expect(rig.canvas.bound('click')).toBe(1);
+    expect(rig.canvas.bound('dblclick')).toBe(1);
+    rig.link.release();
+    expect(rig.canvas.bound('pointermove')).toBe(0);
+    expect(rig.canvas.bound('click')).toBe(0);
+    expect(rig.canvas.bound('dblclick')).toBe(0);
+  });
+
+  it('hits the return under the pointer and marks that one in 3D', () => {
+    const rig = endToEnd();
+    const p = rig.pixelOf(3);
+    rig.canvas.fire('pointermove', { offsetX: p.x, offsetY: p.y });
+    expect(rig.frames).toHaveLength(1);
+    rig.frames.shift()!();
+    expect(rig.markers.at(-1)).toEqual({
+      position: [10.03, 20, 30.03],
+      mode: 'hover',
+      size: profileMarkerSize(2),
+    });
+    expect(rig.readouts.at(-1)).toContain('Station');
+  });
+
+  it('misses cleanly well outside the hit radius', () => {
+    const rig = endToEnd();
+    const p = rig.pixelOf(0);
+    rig.canvas.fire('pointermove', { offsetX: p.x + HIT_RADIUS_PX * 6, offsetY: p.y });
+    rig.frames.shift()!();
+    expect(rig.markers.at(-1)).toBeNull();
+  });
+
+  it('opens the card on a click, with the link row', () => {
+    const rig = endToEnd();
+    const p = rig.pixelOf(1);
+    rig.canvas.fire('click', { offsetX: p.x, offsetY: p.y });
+    const rows = rig.detail.at(-1)!;
+    expect(rows!.some((r) => r.label === LINK_ROW_LABEL && r.value === 'marked in 3D')).toBe(true);
+    expect(rows!.some((r) => r.label === 'Source point index' && r.value === '7')).toBe(true);
+    expect(rows!.some((r) => r.label === 'Streaming node' && r.value === NODE_KEY)).toBe(true);
+  });
+
+  it('says an evicted node is gone while the card keeps its 2D figures', () => {
+    const rig = endToEnd({ evicted: new Set([NODE_KEY]) });
+    const p = rig.pixelOf(1);
+    rig.canvas.fire('click', { offsetX: p.x, offsetY: p.y });
+    const rows = rig.detail.at(-1)!;
+    expect(rows!.some((r) => r.label === LINK_ROW_LABEL && r.value === 'source node evicted')).toBe(
+      true,
+    );
+    // The section's own figures survive; only the world coordinates go.
+    expect(rows!.some((r) => r.label === 'Chainage' && r.value === '5.000')).toBe(true);
+    expect(rig.markers.at(-1)).toBeNull();
+    expect(rig.link.controller.selection()).not.toBeNull();
+  });
+
+  it('returns the detail list to the section figures when the click misses', () => {
+    const rig = endToEnd();
+    const p = rig.pixelOf(1);
+    rig.canvas.fire('click', { offsetX: p.x, offsetY: p.y });
+    rig.canvas.fire('click', { offsetX: -500, offsetY: -500 });
+    const rows = rig.detail.at(-1)!;
+    expect(rows!.some((r) => r.label === 'Returns in corridor')).toBe(true);
+  });
+
+  it('paints the crosshair onto the overlay, never onto the plot', () => {
+    const rig = endToEnd();
+    const plotOps = rig.canvas.ctx.ops.length;
+    const p = rig.pixelOf(2);
+    rig.canvas.fire('pointermove', { offsetX: p.x, offsetY: p.y });
+    rig.frames.shift()!();
+    expect(rig.overlay.ctx.count('stroke')).toBeGreaterThan(0);
+    expect(rig.canvas.ctx.ops).toHaveLength(plotOps);
+  });
+
+  it('sizes the overlay backing store in device pixels', () => {
+    const rig = endToEnd();
+    const p = rig.pixelOf(2);
+    rig.canvas.fire('pointermove', { offsetX: p.x, offsetY: p.y });
+    rig.frames.shift()!();
+    expect(rig.overlay.width).toBe(320);
+    expect(rig.overlay.height).toBe(160);
+  });
+
+  it('does no per-raw-event work: fifty moves, one frame, one readout', () => {
+    const rig = endToEnd();
+    const p = rig.pixelOf(2);
+    for (let n = 0; n < 50; n++) {
+      rig.canvas.fire('pointermove', { offsetX: p.x + n * 0.001, offsetY: p.y });
+    }
+    expect(rig.frames).toHaveLength(1);
+    expect(rig.readouts).toHaveLength(0);
+    rig.frames.shift()!();
+    expect(rig.readouts).toHaveLength(1);
+    expect(rig.link.controller.stats().hitTests).toBe(1);
+  });
+
+  it('offers no link at all when the host cannot resolve a return', () => {
+    const section = fixtureSection();
+    const canvas = new FakeCanvas(320, 160);
+    const plot = prepareWorkbenchSection({ section, canvas: canvas as never });
+    const attached = attachSectionPointLink({
+      plot,
+      section,
+      handle: { canvas: canvas as never, setDetail: () => {} },
+      scene: {
+        profile: () => null,
+        sectionChunks: function* () {
+          return null;
+        },
+        metresPerUnit: () => null,
+        devicePixelRatio: () => 1,
+      },
+      unitToMetres: null,
+      devicePixelRatio: 1,
+    });
+    expect(attached).toBeNull();
+    expect(canvas.bound('pointermove')).toBe(0);
+  });
+});


### PR DESCRIPTION
Hovering a return in the section marks the same return in 3D, and clicking locks it and fills the detail card.

Identity is routed, never matched. A static return goes slot, layer id, point index, placed coordinate; a streaming one goes slot, stable node key, point index, resident point. Both resolve through the same `walkScene` an extraction runs, so a return the section accepted and the mark placed on it cannot come from different scenes. No step compares coordinates, which in a corridor would pick a neighbour.

The mark is a scene object added through `derivedLayerHost` rather than a projected overlay, so it tracks the camera without a render-loop subscription. Nothing on the link path names `InspectTool`, pinned by a proxy recording every seam member the link reads.

Hover cannot reach the camera; only a locked selection can, on a deliberate action. Fifty raw pointer moves inside one frame perform one hit test.

An evicted streaming node keeps the 2D readout, clears the mark, and reads unknown rather than a stale position.
