### PR TITLE
Stop the panel and the station CSV asserting a datum they do not have

### DIFF
--- a/src/render/measure/profileSummary.ts
+++ b/src/render/measure/profileSummary.ts
@@ -2,8 +2,8 @@
  * profileSummary.ts
  *
  * Profile Intelligence — the civil headline numbers an engineer reads off a
- * section before anything else: length, elevation gain/loss, average and
- * maximum grade, the steepest station range, and the highest/lowest points.
+ * section before anything else: length, height gain/loss, average and maximum
+ * grade, the steepest station range, and the highest/lowest heights.
  * Pure data over the already-sampled height-vs-distance series; no DOM, no
  * three.js, unit-tested with hand-computed fixtures.
  *
@@ -22,6 +22,12 @@
 import type { ProfileChartSample, UnitSystem } from './types';
 import { formatStationing, formatGradePercent } from './civilProfileStats';
 import { formatElevation, formatLength } from './format';
+// Height headings come from one vocabulary, where "Elevation" is earned by an
+// orthometric reference and by nothing else. The panel, the station table, the
+// CSV and the sheet all label from here, so no two of them can name the same
+// number differently.
+import { heightLabel } from '../../geo/height';
+import type { VerticalReference } from '../../geo/height';
 
 const FEET_PER_METRE = 3.280839895013123;
 
@@ -233,24 +239,29 @@ export interface ProfileSummaryRow {
  * The summary as label/value display rows, honouring the unit system — the
  * single formatting source for the panel block and the PDF so the two can
  * never disagree on a number.
+ *
+ * `reference` is REQUIRED. It used to be a `datumKnown` boolean defaulting to
+ * `true`, which is fail-open in the worst direction: a caller that omitted it
+ * got the strongest claim on the page. Resolve it once with
+ * `resolveProfileVerticalReference` and pass it in.
  */
 export function profileSummaryRows(
   s: ProfileSummaryData,
   system: UnitSystem,
-  datumKnown = true,
+  reference: VerticalReference,
 ): ProfileSummaryRow[] {
-  // Without a datum the figure is a local render height, so the row says that
-  // rather than calling it an elevation. The number is unchanged and still
+  // The two absolute rows are the only ones that need a reference, and they
+  // take their word from `heightLabel`: an undeclared datum reads "height
+  // (datum unknown)", never "elevation". The numbers are unchanged and still
   // useful — every row above these two is a difference, and a difference never
-  // needed the datum.
-  const point = (which: string): string =>
-    datumKnown ? `${which} point` : `${which} point (local height)`;
+  // needed the datum, which is why the gain/loss row names no reference at all.
+  const heightWord = heightLabel(reference).toLowerCase();
   const len = (m: number | null): string => (m == null ? '—' : formatLength(m, system));
   const extreme = (e: ProfileExtreme | null): string => formatProfileExtreme(e, system);
   return [
     { label: 'Length', value: len(s.lengthM) },
     {
-      label: 'Elevation gain / loss',
+      label: 'Height gain / loss',
       value: s.gainM == null || s.lossM == null ? '—' : `+${len(s.gainM)} / −${len(s.lossM)}`,
     },
     { label: 'Avg grade', value: formatGradePercent(s.averageGrade) },
@@ -264,8 +275,8 @@ export function profileSummaryRows(
             `${formatStation(s.steepest.toChainage, system)} ` +
             `(${formatGradePercent(s.steepest.grade)})`,
     },
-    { label: point('Highest'), value: extreme(s.highest) },
-    { label: point('Lowest'), value: extreme(s.lowest) },
+    { label: `Highest ${heightWord}`, value: extreme(s.highest) },
+    { label: `Lowest ${heightWord}`, value: extreme(s.lowest) },
   ];
 }
 
@@ -322,28 +333,54 @@ export function profileStationRows(
 }
 
 /**
+ * The height column's name for a reference, as a spreadsheet-safe token.
+ *
+ * A machine reader keys on this string, so it is a stable identifier rather
+ * than a rendering of {@link heightLabel} — but it draws the same distinction:
+ * only an orthometric reference is named `elevation`, and an undeclared datum
+ * says so in the column name rather than borrowing one.
+ */
+function heightColumnToken(reference: VerticalReference): string {
+  switch (reference) {
+    case 'orthometric':
+      return 'elevation';
+    case 'ellipsoidal':
+      return 'ellipsoidal_height';
+    case 'depth':
+      return 'depth';
+    case 'local':
+      return 'local_height';
+    case 'unknown':
+      return 'height_datum_unknown';
+  }
+}
+
+/**
  * Build the profile station CSV — the data export the PDF-only station table
  * left missing. One row per station: civil station label, chainage, ground
- * elevation, the corridor point count behind the estimate (blank for samples
+ * height, the corridor point count behind the estimate (blank for samples
  * recorded before v0.4.5 stored counts), and the grade to the next station.
  * Gap stations keep their row with elevation/grade blank — the row count
  * always matches the sample count so downstream joins line up.
  *
- * Headers carry the unit (`_m` / `_ft`) so a spreadsheet never has to guess;
- * values are converted to that unit. Grade is dimensionless percent.
- * Row content comes from `profileStationRows` — the same model the in-panel
- * station table renders.
+ * Headers carry the unit (`_m` / `_ft`) so a spreadsheet never has to guess,
+ * and the height column carries its REFERENCE for the same reason — a machine
+ * reader must not have to assume `elevation_m` meant a sea-level datum.
+ * Values are converted to that unit; grade is dimensionless percent. Row
+ * content comes from `profileStationRows` — the same model the in-panel
+ * station table renders. `reference` is required, for the same fail-open
+ * reason as {@link profileSummaryRows}.
  */
 export function buildProfileCsv(
   samples: ReadonlyArray<ProfileChartSample>,
   system: UnitSystem,
-  datumKnown = true,
+  reference: VerticalReference,
 ): string {
   const unit = system === 'metric' ? 'm' : 'ft';
-  // A refused datum renames the column; it must NOT blank it. A blank already
-  // means "the corridor saw no points here", and spending that signal on a
-  // different problem would trade one silent wrong answer for another.
-  const heightCol = datumKnown ? `elevation_${unit}` : `local_height_${unit}`;
+  // An unearned reference renames the column; it must NOT blank it. A blank
+  // already means "the corridor saw no points here", and spending that signal
+  // on a different problem would trade one silent wrong answer for another.
+  const heightCol = `${heightColumnToken(reference)}_${unit}`;
   const lines: string[] = [
     `station,chainage_${unit},${heightCol},points,grade_to_next_pct`,
   ];

--- a/src/render/measure/profileVerticalReference.ts
+++ b/src/render/measure/profileVerticalReference.ts
@@ -1,0 +1,73 @@
+/**
+ * profileVerticalReference.ts
+ *
+ * One question, one answer: what surface is a profile's height measured from?
+ *
+ * The flag the scene carries is `profileDatumKnown`, and it means the loaded
+ * clouds agree on a render origin — `MeasureController` derives it from
+ * `this._originUp !== null`. Agreeing origins are what makes a stored local
+ * height convertible back to the source's own height; they say nothing about
+ * whether that source declared a vertical datum. Reading the flag as "we know
+ * the datum" is how every display surface came to print "Elevation" over
+ * heights whose reference was never declared.
+ *
+ * This module resolves the honest answer once, so the panel, the station table,
+ * the CSV and the sheet cannot each guess differently.
+ *
+ * Pure: no DOM, no three.js, no CRS resolution — it reads facts the caller
+ * already holds and classifies them through `geo/height`.
+ */
+
+import { verticalReferenceFromDatum } from '../../geo/height';
+import type { VerticalReference } from '../../geo/height';
+import type { ProfileProvenance } from './profileProvenance';
+
+/** Everything the app can know about a profile's vertical reference. */
+export interface ProfileVerticalReferenceInput {
+  /**
+   * The scene's `profileDatumKnown`: whether the loaded clouds share a render
+   * origin. Only an explicit `false` is a refusal — an absent flag is a
+   * summary recorded before the gate existed, not a claim either way.
+   */
+  readonly datumKnown?: boolean;
+  /**
+   * The measurement's provenance record, when it has one. Its
+   * `units.verticalReference` is the reference resolved at sampling time, from
+   * the sources actually read.
+   */
+  readonly provenance?: ProfileProvenance | null;
+  /**
+   * The vertical datum the CRS service resolved, as a name ("NAVD88") or code
+   * ("EPSG:5703"). Null when the frame declared none.
+   */
+  readonly verticalDatum?: string | null;
+}
+
+/**
+ * The reference surface a profile's heights are measured from.
+ *
+ * Three steps, in this order, each one narrower than the last:
+ *
+ *   1. Clouds that disagree on a render origin leave the samples in the
+ *      scene's own frame, so the answer is `local` whatever anything else
+ *      declares — a datum string cannot re-datum a height that was never
+ *      brought back to it.
+ *   2. Otherwise the provenance record answers, because it was resolved from
+ *      the sources the sample actually read. A record that itself says
+ *      `unknown` is not an answer and falls through.
+ *   3. Otherwise the declared datum is classified by
+ *      {@link verticalReferenceFromDatum}, which returns `unknown` for a name
+ *      it does not recognise rather than guessing orthometric.
+ *
+ * Nothing here upgrades an undeclared datum. The default outcome — no
+ * refusal, no record, no datum — is `unknown`, and `unknown` never prints as
+ * an elevation.
+ */
+export function resolveProfileVerticalReference(
+  input: ProfileVerticalReferenceInput,
+): VerticalReference {
+  if (input.datumKnown === false) return 'local';
+  const fromRecord = input.provenance?.units.verticalReference;
+  if (fromRecord != null && fromRecord !== 'unknown') return fromRecord;
+  return verticalReferenceFromDatum({ verticalDatum: input.verticalDatum ?? undefined });
+}

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -37,6 +37,13 @@ import {
   profileSummaryRows,
   type ProfileStationRow,
 } from '../render/measure/profileSummary';
+// What surface a profile's heights are measured from. `profileDatumKnown`
+// answers a different question — whether the loaded clouds share a render
+// origin — so every heading resolves through here instead, and takes its word
+// from `heightLabel`, where only an orthometric reference reads "Elevation".
+import { resolveProfileVerticalReference } from '../render/measure/profileVerticalReference';
+import { heightLabel } from '../geo/height';
+import type { VerticalReference } from '../geo/height';
 // Straight-polyline path builder shared with the profile PDF so the chart and
 // the sheet draw the same geometry. Pure string assembly, no dependencies.
 import { profilePolylinePath } from '../render/measure/profilePath';
@@ -781,8 +788,31 @@ export class MeasurePanel {
   }
 
   /**
+   * The surface this profile's heights are measured from.
+   *
+   * Resolved rather than assumed. The summary carries `profileDatumKnown`,
+   * which reports that the loaded clouds agree on a render origin — the fact
+   * that makes a stored local height restorable, not a declared datum. Reading
+   * it as a datum is what printed "Elevation" over heights no source ever tied
+   * to a sea-level surface. The measurement's provenance record answers when
+   * it has an answer; otherwise the datum the CRS service resolved is
+   * classified, and an unrecognised one stays `unknown`.
+   *
+   * The CRS is read at RENDER time, like the PDF header, so a late CRS
+   * confirmation or a user override reaches the headings on the next update.
+   */
+  private _verticalReference(s: MeasurementSummary): VerticalReference {
+    const ctx = this._cb.getProfileExportContext ? this._cb.getProfileExportContext() : null;
+    return resolveProfileVerticalReference({
+      datumKnown: s.profileDatumKnown,
+      provenance: s.profileProvenance,
+      verticalDatum: ctx?.verticalDatum ?? null,
+    });
+  }
+
+  /**
    * Download the profile's station data as a CSV (station, chainage, ground
-   * elevation, corridor point count, grade-to-next), in the active unit
+   * height, corridor point count, grade-to-next), in the active unit
    * system. Synchronous — the builder is pure string assembly, so unlike the
    * PDF there is no chunk to load and no busy state to manage. v0.4.5,
    * closing the "no profile CSV, station table PDF-only" audit gap.
@@ -790,7 +820,7 @@ export class MeasurePanel {
   private _exportProfileCsv(s: MeasurementSummary): void {
     if (!s.profileChart || s.profileChart.length < 2) return;
     const system = this._cb.getUnitSystem ? this._cb.getUnitSystem() : 'metric';
-    const csv = buildProfileCsv(s.profileChart, system, s.profileDatumKnown !== false);
+    const csv = buildProfileCsv(s.profileChart, system, this._verticalReference(s));
     triggerDownload(new Blob([csv], { type: 'text/csv' }), `${safeFileName(s.name)}-profile.csv`);
   }
 
@@ -836,6 +866,7 @@ export class MeasurePanel {
     const samples = s.profileChart;
     const system = this._cb.getUnitSystem ? this._cb.getUnitSystem() : 'metric';
     const datumKnown = s.profileDatumKnown !== false;
+    const reference = this._verticalReference(s);
     const storedVex = Number(storageGet(PROFILE_VEX_KEY));
     const vex = PROFILE_VEX_OPTIONS.includes(storedVex as 1 | 2 | 5 | 10) ? storedVex : 1;
 
@@ -852,7 +883,7 @@ export class MeasurePanel {
           className: 'olv-rf-stats',
           ariaLabel: `Profile summary for ${s.name}`,
         });
-        for (const row of profileSummaryRows(computeProfileSummary(samples), system, datumKnown)) {
+        for (const row of profileSummaryRows(computeProfileSummary(samples), system, reference)) {
           stats.append(
             el('div', { className: 'olv-rf-stat' }, [
               el('dt', { className: 'olv-rf-stat-label', text: row.label }),
@@ -869,7 +900,7 @@ export class MeasurePanel {
           stationRows,
           unitLabel,
           s.name,
-          datumKnown ? 'Elevation' : 'Local height',
+          heightLabel(reference),
         );
         build();
         const stations = el('div', { className: 'olv-rf-stations' }, [
@@ -1445,11 +1476,12 @@ export class MeasurePanel {
       // its value (the chart itself stays decorative/aria-hidden).
       const summary = computeProfileSummary(s.profileChart);
       const datumKnown = s.profileDatumKnown !== false;
+      const reference = this._verticalReference(s);
       const summaryList = el('dl', {
         className: 'olv-mp-profile-summary',
         ariaLabel: `Profile summary for ${s.name}`,
       });
-      for (const row of profileSummaryRows(summary, system, datumKnown)) {
+      for (const row of profileSummaryRows(summary, system, reference)) {
         summaryList.append(
           el('div', { className: 'olv-mp-summary-row' }, [
             el('dt', { className: 'olv-mp-summary-label', text: row.label }),
@@ -1466,7 +1498,7 @@ export class MeasurePanel {
       // a real table in the DOM acting as the accessible source of truth.
       const stationRows = profileStationRows(s.profileChart, system);
       const unitLabel = system === 'metric' ? 'm' : 'ft';
-      const heightHeader = datumKnown ? 'Elevation' : 'Local height';
+      const heightHeader = heightLabel(reference);
       // Lazy <tbody> (v0.6 perf): the station table is collapsed by default and
       // most measurements are never expanded, yet a dense profile carries one
       // row per sample — building every <tr>/<td> up front spends DOM work on a
@@ -1585,7 +1617,7 @@ export class MeasurePanel {
         text: 'CSV',
         title:
           `Export ${s.name} station data as CSV — ` +
-          'station, chainage, ground elevation, corridor point count, grade.',
+          'station, chainage, ground height, corridor point count, grade.',
         ariaLabel: `Export profile ${s.name} station data as CSV`,
       });
       csvBtn.addEventListener('click', () => {
@@ -1686,7 +1718,7 @@ function buildStationTable(
   stationRows: readonly ProfileStationRow[],
   unitLabel: string,
   name: string,
-  heightHeader = 'Elevation',
+  heightHeader: string,
   coupling?: StationHoverCoupling,
   rowChainages?: readonly number[],
 ): { table: HTMLElement; build: () => void } {

--- a/tests/measureCrashGuards.test.ts
+++ b/tests/measureCrashGuards.test.ts
@@ -153,7 +153,7 @@ describe('profileSummary — zero-length segments, gaps, and missing counts', ()
     ];
     const s = computeProfileSummary(samples);
     expect(Number.isFinite(s.lengthM)).toBe(true);
-    for (const row of profileSummaryRows(s, 'metric')) {
+    for (const row of profileSummaryRows(s, 'metric', 'orthometric')) {
       expect(row.value).not.toMatch(/NaN|Infinity/);
     }
     const rows = profileStationRows(samples, 'metric');
@@ -162,7 +162,7 @@ describe('profileSummary — zero-length segments, gaps, and missing counts', ()
     expect(rows[1].grade).toBe(''); // gap neighbour: blank
     expect(rows[2].elevation).toBe(''); // gap: blank elevation
     expect(rows[0].points).toBe(''); // pre-v0.4.5 series: no fabricated 0
-    const csv = buildProfileCsv(samples, 'imperial');
+    const csv = buildProfileCsv(samples, 'imperial', 'orthometric');
     expect(csv).not.toMatch(/NaN|Infinity/);
     expect(csv.trim().split('\n')).toHaveLength(5); // header + 4 stations
   });

--- a/tests/measurePanelDatumHonesty.test.ts
+++ b/tests/measurePanelDatumHonesty.test.ts
@@ -1,0 +1,328 @@
+/**
+ * measurePanelDatumHonesty.test.ts
+ *
+ * The Measurements panel prints two kinds of height heading for a profile: the
+ * summary row labels under the chart, and the station table's height column.
+ * Both used to be gated on `profileDatumKnown`, which reports that the loaded
+ * clouds share a render origin — not that a vertical datum exists. A cloud with
+ * no declared vertical datum therefore had every absolute height printed under
+ * the word "Elevation", asserting a sea-level surface the file never carried.
+ *
+ * These tests drive the real MeasurePanel through the project's recording DOM
+ * stub and pin the headings on BOTH surfaces — the in-panel dock row and the
+ * `ResultFocus` view — against the reference the app can actually resolve.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+
+const openResultFocus = vi.fn();
+vi.mock('../src/ui/ResultFocus', () => ({
+  openResultFocus: (...args: unknown[]) => openResultFocus(...args),
+}));
+
+import { MeasurePanel } from '../src/ui/MeasurePanel';
+import type { MeasurementSummary } from '../src/render/measure/MeasureController';
+import type { ProfileProvenance } from '../src/render/measure/profileProvenance';
+import type { ProfileChartSample } from '../src/render/measure/types';
+import type { VerticalReference } from '../src/geo/height';
+
+type Handler = (e: unknown) => void;
+
+/** A recording DOM node covering only the surface MeasurePanel touches. */
+class FakeEl {
+  readonly tagName: string;
+  private _classes = new Set<string>();
+  textContent = '';
+  title = '';
+  value = '';
+  innerHTML = '';
+  open = false;
+  disabled = false;
+  readonly dataset: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly children: FakeEl[] = [];
+  parent: FakeEl | null = null;
+  private readonly attrs = new Map<string, string>();
+  private readonly handlers = new Map<string, Handler[]>();
+  clientHeight = 0;
+  offsetWidth = 0;
+
+  constructor(tag: string) {
+    this.tagName = tag.toLowerCase();
+  }
+
+  set className(v: string) {
+    this._classes = new Set(String(v).split(/\s+/).filter(Boolean));
+  }
+  get className(): string {
+    return [...this._classes].join(' ');
+  }
+  get classList() {
+    const classes = this._classes;
+    return {
+      add: (c: string): void => void classes.add(c),
+      remove: (c: string): void => void classes.delete(c),
+      contains: (c: string): boolean => classes.has(c),
+      toggle: (c: string, force?: boolean): boolean => {
+        const want = force === undefined ? !classes.has(c) : force;
+        if (want) classes.add(c);
+        else classes.delete(c);
+        return want;
+      },
+    };
+  }
+
+  get lastElementChild(): FakeEl | null {
+    for (let i = this.children.length - 1; i >= 0; i--) {
+      if (this.children[i].tagName !== '#text') return this.children[i];
+    }
+    return null;
+  }
+
+  private _adopt(kid: unknown): FakeEl {
+    if (kid instanceof FakeEl) {
+      kid.parent = this;
+      return kid;
+    }
+    const t = new FakeEl('#text');
+    t.textContent = String(kid);
+    t.parent = this;
+    return t;
+  }
+  append(...kids: unknown[]): void {
+    for (const k of kids) this.children.push(this._adopt(k));
+  }
+  replaceChildren(...kids: unknown[]): void {
+    this.children.length = 0;
+    for (const k of kids) this.children.push(this._adopt(k));
+  }
+
+  setAttribute(n: string, v: string): void {
+    this.attrs.set(n, v);
+  }
+  getAttribute(n: string): string | null {
+    return this.attrs.get(n) ?? null;
+  }
+
+  addEventListener(type: string, fn: Handler): void {
+    const a = this.handlers.get(type) ?? [];
+    a.push(fn);
+    this.handlers.set(type, a);
+  }
+  removeEventListener(): void {
+    /* not exercised */
+  }
+  dispatchEvent(evt: { type: string; stopPropagation?: () => void }): boolean {
+    for (const fn of this.handlers.get(evt.type) ?? []) fn(evt);
+    return true;
+  }
+  focus(): void {}
+  blur(): void {}
+
+  /** `tag`, `.class`, or `tag.class` — the only selector shapes this panel uses. */
+  private _matches(sel: string): boolean {
+    const parts = sel.split('.');
+    const tag = parts[0];
+    if (tag && this.tagName !== tag.toLowerCase()) return false;
+    for (const c of parts.slice(1)) if (!this._classes.has(c)) return false;
+    return true;
+  }
+  querySelector(sel: string): FakeEl | null {
+    for (const c of this.children) {
+      if (c._matches(sel)) return c;
+      const deep = c.querySelector(sel);
+      if (deep) return deep;
+    }
+    return null;
+  }
+  querySelectorAll(sel: string): FakeEl[] {
+    const out: FakeEl[] = [];
+    const walk = (n: FakeEl): void => {
+      for (const c of n.children) {
+        if (c._matches(sel)) out.push(c);
+        walk(c);
+      }
+    };
+    walk(this);
+    return out;
+  }
+}
+
+/** No-op observer so the panel's resize-persistence path never warns or fires. */
+class FakeResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+beforeAll(() => {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.document = { createElement: (tag: string) => new FakeEl(tag) };
+  g.HTMLInputElement = class HTMLInputElement {};
+  g.HTMLAnchorElement = class HTMLAnchorElement {};
+  g.ResizeObserver = FakeResizeObserver;
+});
+
+beforeEach(() => {
+  openResultFocus.mockClear();
+});
+
+const CHART: ProfileChartSample[] = [
+  { distance: 0, height: 10, count: 5 },
+  { distance: 10, height: 12, count: 8 },
+  { distance: 20, height: 11, count: 3 },
+];
+
+/** A provenance record whose only interesting field is the resolved reference. */
+function record(reference: VerticalReference): ProfileProvenance {
+  return {
+    recordVersion: 1,
+    method: 'corridor-percentile',
+    corridorVersion: 1,
+    capturedAt: '2026-08-23T00:00:00.000Z',
+    up: [0, 0, 1],
+    upDegenerate: false,
+    sources: [],
+    acceptedCount: 0,
+    scope: 'empty',
+    residentOnly: false,
+    complete: null,
+    classPolicy: { excludedClasses: [], availableOnEverySource: false },
+    units: { linearUnit: 'metre', verticalReference: reference, verticalMetresPerUnit: 1 },
+  };
+}
+
+interface Scene {
+  /** Origins agree. The pre-fix flag that was read as "a datum exists". */
+  datumKnown?: boolean;
+  /** What the CRS service resolved, as the host reports it at render time. */
+  verticalDatum?: string | null;
+  /** The measurement's own provenance record, when it has one. */
+  provenance?: ProfileProvenance;
+}
+
+function summary(scene: Scene): MeasurementSummary {
+  return {
+    id: 'p1',
+    kind: 'profile',
+    name: 'Section A',
+    value: '20.00 m',
+    profileChart: CHART,
+    profileDatumKnown: scene.datumKnown ?? true,
+    profileProvenance: scene.provenance,
+  };
+}
+
+/** Mount a panel over one profile row for the given scene. */
+function mount(scene: Scene): FakeEl {
+  const panel = new MeasurePanel({
+    onDelete: () => {},
+    onRename: () => {},
+    onExport: () => {},
+    onImport: () => {},
+    getUnitSystem: () => 'metric',
+    getProfileExportContext: () => ({
+      crs: 'EPSG:32613 — WGS 84 / UTM zone 13N',
+      verticalDatum: scene.verticalDatum ?? null,
+    }),
+  });
+  panel.update([summary(scene)]);
+  return panel.element as unknown as FakeEl;
+}
+
+/** Render the ResultFocus surface for the same scene and return its container. */
+function focusView(scene: Scene): FakeEl {
+  openResultFocus.mockClear();
+  const root = mount(scene);
+  const expand = root
+    .querySelectorAll('button')
+    .find((b) => (b.getAttribute('aria-label') ?? '').includes('Expand'));
+  expect(expand, 'the profile row offers an Expand button').toBeDefined();
+  expand!.dispatchEvent({ type: 'click', stopPropagation: () => {} });
+  expect(openResultFocus).toHaveBeenCalledTimes(1);
+  const opts = openResultFocus.mock.calls[0]![0] as { render: (c: unknown) => void };
+  const container = new FakeEl('div');
+  opts.render(container);
+  return container;
+}
+
+/** The station table's height column heading, without its unit suffix. */
+function heightColumn(scope: FakeEl): string {
+  const heads = scope.querySelectorAll('th').map((th) => th.textContent);
+  expect(heads.length, 'the station table renders its header row').toBeGreaterThan(0);
+  // Station · Chainage · <height> · Points · Grade.
+  return heads[2].replace(/\s*\(m\)$/, '');
+}
+
+/** Every summary row label under the chart. */
+function summaryLabels(scope: FakeEl, cls: string): string[] {
+  return scope.querySelectorAll(`dt.${cls}`).map((dt) => dt.textContent);
+}
+
+describe('MeasurePanel — the dock row never asserts a datum it does not have', () => {
+  it('a cloud with no declared vertical datum gets no elevation heading', () => {
+    const root = mount({ datumKnown: true, verticalDatum: null });
+    expect(heightColumn(root)).toBe('Height (datum unknown)');
+    for (const label of summaryLabels(root, 'olv-mp-summary-label')) {
+      expect(label.toLowerCase()).not.toContain('elevation');
+    }
+  });
+
+  it('agreeing render origins alone do not buy the word elevation', () => {
+    // This is the whole defect: `profileDatumKnown` is true here, and true is
+    // exactly what used to print "Elevation".
+    const root = mount({ datumKnown: true, verticalDatum: null });
+    expect(heightColumn(root)).not.toBe('Elevation');
+  });
+
+  it('a declared orthometric datum does earn it', () => {
+    const root = mount({ datumKnown: true, verticalDatum: 'NAVD88' });
+    expect(heightColumn(root)).toBe('Elevation');
+    expect(summaryLabels(root, 'olv-mp-summary-label')).toContain('Highest elevation');
+  });
+
+  it('an ellipsoidal reference from the provenance record is named as one', () => {
+    const root = mount({ provenance: record('ellipsoidal') });
+    expect(heightColumn(root)).toBe('Ellipsoidal height');
+    expect(summaryLabels(root, 'olv-mp-summary-label')).toContain('Highest ellipsoidal height');
+  });
+
+  it('conflicting render origins still degrade to the local frame', () => {
+    const root = mount({ datumKnown: false, verticalDatum: 'NAVD88' });
+    expect(heightColumn(root)).toBe('Height (local frame)');
+  });
+
+  it('a datum name the tables do not recognise is not promoted', () => {
+    const root = mount({ verticalDatum: 'Site datum (assumed)' });
+    expect(heightColumn(root)).toBe('Height (datum unknown)');
+  });
+});
+
+describe('MeasurePanel — the focus view carries the same headings as the dock', () => {
+  it('a cloud with no declared vertical datum gets no elevation heading', () => {
+    const view = focusView({ datumKnown: true, verticalDatum: null });
+    expect(heightColumn(view)).toBe('Height (datum unknown)');
+    for (const label of summaryLabels(view, 'olv-rf-stat-label')) {
+      expect(label.toLowerCase()).not.toContain('elevation');
+    }
+  });
+
+  it('a declared orthometric datum does earn it', () => {
+    const view = focusView({ verticalDatum: 'NAVD88' });
+    expect(heightColumn(view)).toBe('Elevation');
+    expect(summaryLabels(view, 'olv-rf-stat-label')).toContain('Highest elevation');
+  });
+
+  it('conflicting render origins still degrade to the local frame', () => {
+    const view = focusView({ datumKnown: false, verticalDatum: 'NAVD88' });
+    expect(heightColumn(view)).toBe('Height (local frame)');
+  });
+
+  it('the two surfaces agree heading for heading', () => {
+    const scene: Scene = { verticalDatum: null };
+    expect(heightColumn(focusView(scene))).toBe(heightColumn(mount(scene)));
+    expect(summaryLabels(focusView(scene), 'olv-rf-stat-label')).toEqual(
+      summaryLabels(mount(scene), 'olv-mp-summary-label'),
+    );
+  });
+});

--- a/tests/profilePdf.test.ts
+++ b/tests/profilePdf.test.ts
@@ -582,11 +582,14 @@ describe('the sheet prints the same source elevations as the panel', () => {
       await buildProfilePdf({ name: 'Datum section', samples, generatedAt: FIXED_DATE }),
     );
     const byLabel = new Map(
-      profileSummaryRows(computeProfileSummary(samples), 'metric').map((r) => [r.label, r.value]),
+      profileSummaryRows(computeProfileSummary(samples), 'metric', 'orthometric').map((r) => [
+        r.label,
+        r.value,
+      ]),
     );
-    expect(byLabel.get('Highest point')).toBe('418.16 m @ 0+343.98');
-    expect(text).toContain(byLabel.get('Highest point'));
-    expect(text).toContain(byLabel.get('Lowest point'));
+    expect(byLabel.get('Highest elevation')).toBe('418.16 m @ 0+343.98');
+    expect(text).toContain(byLabel.get('Highest elevation'));
+    expect(text).toContain(byLabel.get('Lowest elevation'));
     // The heights that reach the sheet are the header's, not the render
     // origin's — and never the centimetres a length formatter made of them.
     expect(text).toContain('348.93 m');
@@ -682,12 +685,12 @@ describe('the sheet refuses a datum it cannot assert', () => {
     expect(text).toContain('conflicting cloud origins');
     // And it agrees with the panel, refusal or not.
     const byLabel = new Map(
-      profileSummaryRows(computeProfileSummary(samples), 'metric', false).map((r) => [
+      profileSummaryRows(computeProfileSummary(samples), 'metric', 'local').map((r) => [
         r.label,
         r.value,
       ]),
     );
-    expect(text).toContain(byLabel.get('Highest point (local height)'));
+    expect(text).toContain(byLabel.get('Highest height (local frame)'));
   });
 
   it('a conflicting origin outranks an orthometric record', async () => {

--- a/tests/profileSummary.test.ts
+++ b/tests/profileSummary.test.ts
@@ -21,6 +21,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { ProfileChartSample } from '../src/render/measure/types';
+import type { VerticalReference } from '../src/geo/height';
 import {
   buildProfileCsv,
   computeProfileSummary,
@@ -130,25 +131,25 @@ describe('formatStation', () => {
 
 describe('profileSummaryRows', () => {
   it('metric rows carry the hand-computed values', () => {
-    const rows = profileSummaryRows(computeProfileSummary(FIXTURE), 'metric');
+    const rows = profileSummaryRows(computeProfileSummary(FIXTURE), 'metric', 'orthometric');
     const byLabel = new Map(rows.map((r) => [r.label, r.value]));
     // Length is a distance → adaptive 5-sig-fig precision ("50.000 m").
     expect(byLabel.get('Length')).toBe('50.000 m');
-    expect(byLabel.get('Elevation gain / loss')).toBe('+2.0000 m / −2.0000 m');
+    expect(byLabel.get('Height gain / loss')).toBe('+2.0000 m / −2.0000 m');
     expect(byLabel.get('Avg grade')).toBe('6.00%');
     expect(byLabel.get('Max grade')).toBe('20.00%');
     expect(byLabel.get('Steepest section')).toBe('0+000.00 → 0+010.00 (20.00%)');
-    expect(byLabel.get('Highest point')).toBe('14.00 m @ 0+040.00');
-    expect(byLabel.get('Lowest point')).toBe('10.00 m @ 0+000.00');
+    expect(byLabel.get('Highest elevation')).toBe('14.00 m @ 0+040.00');
+    expect(byLabel.get('Lowest elevation')).toBe('10.00 m @ 0+000.00');
   });
 
   it('imperial rows convert lengths and stationing', () => {
-    const rows = profileSummaryRows(computeProfileSummary(FIXTURE), 'imperial');
+    const rows = profileSummaryRows(computeProfileSummary(FIXTURE), 'imperial', 'orthometric');
     const byLabel = new Map(rows.map((r) => [r.label, r.value]));
     // 50 m = 164.04 ft; 14 m = 45.93 ft; grades are unit-free.
     expect(byLabel.get('Length')).toBe('164.04 ft');
     expect(byLabel.get('Avg grade')).toBe('6.00%');
-    expect(byLabel.get('Highest point')).toBe('45.93 ft @ 1+31.23');
+    expect(byLabel.get('Highest elevation')).toBe('45.93 ft @ 1+31.23');
   });
 
   it('an empty profile renders honest dashes', () => {
@@ -158,17 +159,18 @@ describe('profileSummaryRows', () => {
         { distance: 10, height: NaN },
       ]),
       'metric',
+      'orthometric',
     );
     const byLabel = new Map(rows.map((r) => [r.label, r.value]));
-    expect(byLabel.get('Elevation gain / loss')).toBe('—');
+    expect(byLabel.get('Height gain / loss')).toBe('—');
     expect(byLabel.get('Steepest section')).toBe('—');
-    expect(byLabel.get('Highest point')).toBe('—');
+    expect(byLabel.get('Highest elevation')).toBe('—');
   });
 });
 
 describe('buildProfileCsv', () => {
   it('metric CSV: one row per station, gaps blank, counts carried', () => {
-    const csv = buildProfileCsv(FIXTURE, 'metric');
+    const csv = buildProfileCsv(FIXTURE, 'metric', 'orthometric');
     const lines = csv.trimEnd().split('\n');
     expect(lines[0]).toBe('station,chainage_m,elevation_m,points,grade_to_next_pct');
     expect(lines).toHaveLength(1 + FIXTURE.length);
@@ -184,7 +186,7 @@ describe('buildProfileCsv', () => {
   });
 
   it('imperial CSV converts chainage and elevation and says so in the header', () => {
-    const csv = buildProfileCsv(FIXTURE, 'imperial');
+    const csv = buildProfileCsv(FIXTURE, 'imperial', 'orthometric');
     const lines = csv.trimEnd().split('\n');
     expect(lines[0]).toBe('station,chainage_ft,elevation_ft,points,grade_to_next_pct');
     // 10 m = 32.81 ft chainage; 12 m elevation = 39.370 ft; grade unit-free.
@@ -198,6 +200,7 @@ describe('buildProfileCsv', () => {
         { distance: 10, height: 2 },
       ],
       'metric',
+      'orthometric',
     );
     const lines = csv.trimEnd().split('\n');
     expect(lines[1]).toBe('0+000.00,0.00,1.000,,10.00');
@@ -299,7 +302,7 @@ describe('profileStationRows (v0.4.5, B5 — shared row model)', () => {
 
   it('the CSV is exactly these rows joined — panel table and export cannot diverge', () => {
     const rows = profileStationRows(FIXTURE, 'metric');
-    const lines = buildProfileCsv(FIXTURE, 'metric').trimEnd().split('\n');
+    const lines = buildProfileCsv(FIXTURE, 'metric', 'orthometric').trimEnd().split('\n');
     rows.forEach((r, i) => {
       expect(lines[i + 1]).toBe(
         `${r.station},${r.chainage},${r.elevation},${r.points},${r.grade}`,
@@ -373,12 +376,12 @@ describe('profile display surfaces print SOURCE elevations', () => {
 
   it('the summary rows locate the extremes at their real elevations', () => {
     const byLabel = new Map(
-      profileSummaryRows(computeProfileSummary(SOURCE), 'metric').map((r) => [r.label, r.value]),
+      profileSummaryRows(computeProfileSummary(SOURCE), 'metric', 'orthometric').map((r) => [r.label, r.value]),
     );
-    expect(byLabel.get('Lowest point')).toBe('348.93 m @ 0+000.00');
+    expect(byLabel.get('Lowest elevation')).toBe('348.93 m @ 0+000.00');
     // 418.165 is an exact decimal tie that IEEE-754 holds as 418.16499…, so
     // it rounds down. The elevation is right; the last digit is arithmetic.
-    expect(byLabel.get('Highest point')).toBe('418.16 m @ 0+343.98');
+    expect(byLabel.get('Highest elevation')).toBe('418.16 m @ 0+343.98');
   });
 
   it('an elevation never degrades into centimetres or kilometres', () => {
@@ -391,10 +394,11 @@ describe('profile display surfaces print SOURCE elevations', () => {
         { distance: 10, height: 1200 },
       ]),
       'metric',
+      'orthometric',
     );
     const byLabel = new Map(rows.map((r) => [r.label, r.value]));
-    expect(byLabel.get('Lowest point')).toBe('0.40 m @ 0+000.00');
-    expect(byLabel.get('Highest point')).toBe('1200.00 m @ 0+010.00');
+    expect(byLabel.get('Lowest elevation')).toBe('0.40 m @ 0+000.00');
+    expect(byLabel.get('Highest elevation')).toBe('1200.00 m @ 0+010.00');
   });
 
   it('the station table and the CSV agree with the panel', () => {
@@ -402,18 +406,18 @@ describe('profile display surfaces print SOURCE elevations', () => {
     expect(rows[0].elevation).toBe('348.927');
     expect(rows[1].elevation).toBe(''); // the gap
     expect(rows[2].elevation).toBe('418.165');
-    const lines = buildProfileCsv(SOURCE, 'metric').trimEnd().split('\n');
+    const lines = buildProfileCsv(SOURCE, 'metric', 'orthometric').trimEnd().split('\n');
     expect(lines[1]).toBe(`0+000.00,0.00,${rows[0].elevation},12,`);
     expect(lines[3]).toBe(`0+343.98,343.98,${rows[2].elevation},9,`);
   });
 
   it('imperial converts the restored elevation, it does not re-datum it', () => {
     const byLabel = new Map(
-      profileSummaryRows(computeProfileSummary(SOURCE), 'imperial').map((r) => [r.label, r.value]),
+      profileSummaryRows(computeProfileSummary(SOURCE), 'imperial', 'orthometric').map((r) => [r.label, r.value]),
     );
     // 348.927 m = 1144.77 ft; 418.165 m = 1371.93 ft.
-    expect(byLabel.get('Lowest point')).toBe('1144.77 ft @ 0+00.00');
-    expect(byLabel.get('Highest point')).toBe('1371.93 ft @ 11+28.54');
+    expect(byLabel.get('Lowest elevation')).toBe('1144.77 ft @ 0+00.00');
+    expect(byLabel.get('Highest elevation')).toBe('1371.93 ft @ 11+28.54');
   });
 
   it('an extreme is always located at one of the series own stations', () => {
@@ -460,16 +464,16 @@ describe('a refused datum degrades to local heights, visibly', () => {
 
   it('the summary names the extremes as local heights instead of elevations', () => {
     const byLabel = new Map(
-      profileSummaryRows(computeProfileSummary(LOCAL), 'metric', false).map((r) => [
+      profileSummaryRows(computeProfileSummary(LOCAL), 'metric', 'local').map((r) => [
         r.label,
         r.value,
       ]),
     );
-    expect(byLabel.get('Highest point (local height)')).toBe('-411.87 m @ 0+343.98');
-    expect(byLabel.get('Lowest point (local height)')).toBe('-481.10 m @ 0+000.00');
+    expect(byLabel.get('Highest height (local frame)')).toBe('-411.87 m @ 0+343.98');
+    expect(byLabel.get('Lowest height (local frame)')).toBe('-481.10 m @ 0+000.00');
     // The elevation wording must be gone — that is the whole visible signal.
-    expect(byLabel.has('Highest point')).toBe(false);
-    expect(byLabel.has('Lowest point')).toBe(false);
+    expect(byLabel.has('Highest elevation')).toBe(false);
+    expect(byLabel.has('Lowest elevation')).toBe(false);
   });
 
   it('every delta reads identically with and without a datum', () => {
@@ -483,17 +487,17 @@ describe('a refused datum degrades to local heights, visibly', () => {
       s.lengthM,
     ];
     expect(deltas(without)).toEqual(deltas(withDatum));
-    const rowsOf = (known: boolean, samples: ProfileChartSample[]) =>
-      new Map(profileSummaryRows(computeProfileSummary(samples), 'metric', known).map((r) => [r.label, r.value]));
-    const a = rowsOf(true, scaleProfileSamples(LOCAL, 1, 830.03));
-    const b = rowsOf(false, scaleProfileSamples(LOCAL, 1, null));
-    for (const label of ['Length', 'Elevation gain / loss', 'Avg grade', 'Max grade', 'Steepest section']) {
+    const rowsOf = (reference: VerticalReference, samples: ProfileChartSample[]) =>
+      new Map(profileSummaryRows(computeProfileSummary(samples), 'metric', reference).map((r) => [r.label, r.value]));
+    const a = rowsOf('orthometric', scaleProfileSamples(LOCAL, 1, 830.03));
+    const b = rowsOf('local', scaleProfileSamples(LOCAL, 1, null));
+    for (const label of ['Length', 'Height gain / loss', 'Avg grade', 'Max grade', 'Steepest section']) {
       expect(b.get(label)).toBe(a.get(label));
     }
   });
 
   it('the CSV renames the column rather than blanking it — a blank means no coverage', () => {
-    const csv = buildProfileCsv(LOCAL, 'metric', false);
+    const csv = buildProfileCsv(LOCAL, 'metric', 'local');
     const lines = csv.trimEnd().split('\n');
     expect(lines[0]).toBe('station,chainage_m,local_height_m,points,grade_to_next_pct');
     // The values are real and must stay: blanking them would claim the corridor
@@ -502,19 +506,139 @@ describe('a refused datum degrades to local heights, visibly', () => {
     expect(lines[2]).toBe('0+171.99,171.99,,0,'); // the genuine gap, still blank
   });
 
-  it('a known datum keeps every label and header exactly as it was', () => {
+  it('a declared orthometric datum keeps every label and header as it was', () => {
     const known = scaleProfileSamples(LOCAL, 1, 830.03);
     const byLabel = new Map(
-      profileSummaryRows(computeProfileSummary(known), 'metric', true).map((r) => [r.label, r.value]),
+      profileSummaryRows(computeProfileSummary(known), 'metric', 'orthometric').map((r) => [
+        r.label,
+        r.value,
+      ]),
     );
-    expect(byLabel.get('Highest point')).toBe('418.16 m @ 0+343.98');
-    expect(buildProfileCsv(known, 'metric', true).split('\n')[0]).toBe(
+    expect(byLabel.get('Highest elevation')).toBe('418.16 m @ 0+343.98');
+    expect(buildProfileCsv(known, 'metric', 'orthometric').split('\n')[0]).toBe(
       'station,chainage_m,elevation_m,points,grade_to_next_pct',
     );
-    // Defaulted, the surfaces behave exactly as they did before the gate.
-    expect(profileSummaryRows(computeProfileSummary(known), 'metric')).toEqual(
-      profileSummaryRows(computeProfileSummary(known), 'metric', true),
+  });
+
+  it('agreeing render origins alone buy nothing — that flag is not a datum', () => {
+    // The pre-fix surfaces reached this state through `profileDatumKnown === true`
+    // and printed the elevation wording. The origins agreeing is what makes the
+    // heights restorable; the datum being declared is a separate fact.
+    const known = scaleProfileSamples(LOCAL, 1, 830.03);
+    const byLabel = new Map(
+      profileSummaryRows(computeProfileSummary(known), 'metric', 'unknown').map((r) => [
+        r.label,
+        r.value,
+      ]),
     );
-    expect(buildProfileCsv(known, 'metric')).toBe(buildProfileCsv(known, 'metric', true));
+    expect(byLabel.get('Highest height (datum unknown)')).toBe('418.16 m @ 0+343.98');
+    expect(byLabel.has('Highest elevation')).toBe(false);
+    expect(buildProfileCsv(known, 'metric', 'unknown').split('\n')[0]).toBe(
+      'station,chainage_m,height_datum_unknown_m,points,grade_to_next_pct',
+    );
+  });
+});
+
+/**
+ * The datum gate, re-cut against a resolved vertical reference.
+ *
+ * `profileDatumKnown` reports that the scene's render origins agree. It never
+ * said a vertical datum exists, so a boolean gate defaulting to `true` printed
+ * "Elevation" over heights whose reference was undeclared. Both display
+ * builders now take an explicit {@link VerticalReference} and take every
+ * heading from `heightLabel`, where only `orthometric` yields "Elevation".
+ *
+ * The argument is REQUIRED on purpose: the old default was fail-open, so a
+ * caller that forgot it got the strongest claim on the page.
+ */
+describe('height headings follow the resolved vertical reference', () => {
+  const rowsFor = (reference: VerticalReference) =>
+    new Map(
+      profileSummaryRows(computeProfileSummary(FIXTURE), 'metric', reference).map((r) => [
+        r.label,
+        r.value,
+      ]),
+    );
+
+  it('only an orthometric reference earns the word elevation', () => {
+    expect(rowsFor('orthometric').has('Highest elevation')).toBe(true);
+    expect(rowsFor('orthometric').has('Lowest elevation')).toBe(true);
+  });
+
+  it('an undeclared datum names the extremes as heights of unknown datum', () => {
+    const rows = rowsFor('unknown');
+    expect(rows.get('Highest height (datum unknown)')).toBe('14.00 m @ 0+040.00');
+    expect(rows.get('Lowest height (datum unknown)')).toBe('10.00 m @ 0+000.00');
+  });
+
+  it('NO row label says elevation when the datum is undeclared', () => {
+    for (const label of rowsFor('unknown').keys()) {
+      expect(label.toLowerCase()).not.toContain('elevation');
+    }
+  });
+
+  it('the same holds for every reference that is not orthometric', () => {
+    for (const reference of ['ellipsoidal', 'depth', 'local', 'unknown'] as VerticalReference[]) {
+      for (const label of rowsFor(reference).keys()) {
+        expect(label.toLowerCase()).not.toContain('elevation');
+      }
+    }
+  });
+
+  it('an ellipsoidal height is named one — not silently promoted to elevation', () => {
+    expect(rowsFor('ellipsoidal').has('Highest ellipsoidal height')).toBe(true);
+    expect(rowsFor('local').has('Highest height (local frame)')).toBe(true);
+    expect(rowsFor('depth').has('Highest depth')).toBe(true);
+  });
+
+  it('the gain / loss row is a difference, so it names no reference at all', () => {
+    for (const reference of ['orthometric', 'unknown', 'local'] as VerticalReference[]) {
+      expect(rowsFor(reference).get('Height gain / loss')).toBe('+2.0000 m / −2.0000 m');
+    }
+  });
+
+  it('every value is identical across references — only the wording moves', () => {
+    const values = (reference: VerticalReference) =>
+      profileSummaryRows(computeProfileSummary(FIXTURE), 'metric', reference).map((r) => r.value);
+    expect(values('unknown')).toEqual(values('orthometric'));
+    expect(values('local')).toEqual(values('orthometric'));
+  });
+});
+
+describe('the station CSV column names the reference it actually has', () => {
+  const header = (reference: VerticalReference, system: 'metric' | 'imperial' = 'metric') =>
+    buildProfileCsv(FIXTURE, system, reference).split('\n')[0];
+
+  it('orthometric keeps the elevation column', () => {
+    expect(header('orthometric')).toBe('station,chainage_m,elevation_m,points,grade_to_next_pct');
+  });
+
+  it('an undeclared datum never writes an elevation column', () => {
+    expect(header('unknown')).toBe(
+      'station,chainage_m,height_datum_unknown_m,points,grade_to_next_pct',
+    );
+    expect(header('unknown')).not.toContain('elevation');
+  });
+
+  it('each remaining reference gets its own honest column token', () => {
+    expect(header('local')).toContain('local_height_m');
+    expect(header('ellipsoidal')).toContain('ellipsoidal_height_m');
+    expect(header('depth')).toContain('depth_m');
+    for (const reference of ['local', 'ellipsoidal', 'depth'] as VerticalReference[]) {
+      expect(header(reference)).not.toContain('elevation');
+    }
+  });
+
+  it('the unit suffix rides along in imperial', () => {
+    expect(header('unknown', 'imperial')).toBe(
+      'station,chainage_ft,height_datum_unknown_ft,points,grade_to_next_pct',
+    );
+    expect(header('orthometric', 'imperial')).toContain('elevation_ft');
+  });
+
+  it('the rows are untouched by the reference — only the header moves', () => {
+    const body = (reference: VerticalReference) =>
+      buildProfileCsv(FIXTURE, 'metric', reference).split('\n').slice(1).join('\n');
+    expect(body('unknown')).toBe(body('orthometric'));
   });
 });

--- a/tests/profileVerticalReference.test.ts
+++ b/tests/profileVerticalReference.test.ts
@@ -1,0 +1,93 @@
+/**
+ * profileVerticalReference.test.ts
+ *
+ * One question, one answer: what surface is a profile's height measured from?
+ *
+ * The flag the scene actually carries — `profileDatumKnown` — reports that the
+ * loaded clouds share a render origin. That is not a vertical datum, and the
+ * display surfaces used to read it as one and print "Elevation" over heights
+ * whose datum was never declared. These tests pin the resolution order that
+ * replaces it, and in particular pin the two ways it must REFUSE to upgrade:
+ * an unrecognised datum name and a record that itself says `unknown`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveProfileVerticalReference } from '../src/render/measure/profileVerticalReference';
+import type { ProfileProvenance } from '../src/render/measure/profileProvenance';
+import type { VerticalReference } from '../src/geo/height';
+
+/** A provenance record carrying nothing but the unit context under test. */
+function record(reference: VerticalReference): ProfileProvenance {
+  return {
+    recordVersion: 1,
+    method: 'corridor-percentile',
+    corridorVersion: 1,
+    capturedAt: '2026-08-23T00:00:00.000Z',
+    up: [0, 0, 1],
+    upDegenerate: false,
+    sources: [],
+    acceptedCount: 0,
+    scope: 'empty',
+    residentOnly: false,
+    complete: null,
+    classPolicy: { excludedClasses: [], availableOnEverySource: false },
+    units: { linearUnit: 'metre', verticalReference: reference, verticalMetresPerUnit: 1 },
+  };
+}
+
+describe('resolveProfileVerticalReference', () => {
+  it('conflicting render origins make the heights local, whatever else is declared', () => {
+    expect(
+      resolveProfileVerticalReference({
+        datumKnown: false,
+        verticalDatum: 'NAVD88',
+        provenance: record('orthometric'),
+      }),
+    ).toBe('local');
+  });
+
+  it('an undeclared datum with no record is unknown — never elevation by default', () => {
+    expect(resolveProfileVerticalReference({})).toBe('unknown');
+    expect(
+      resolveProfileVerticalReference({ datumKnown: true, verticalDatum: null, provenance: null }),
+    ).toBe('unknown');
+  });
+
+  it('the provenance record answers when it has an answer', () => {
+    expect(resolveProfileVerticalReference({ provenance: record('ellipsoidal') })).toBe(
+      'ellipsoidal',
+    );
+    expect(resolveProfileVerticalReference({ provenance: record('orthometric') })).toBe(
+      'orthometric',
+    );
+  });
+
+  it('a record that says unknown falls through to the declared datum, not past it', () => {
+    expect(
+      resolveProfileVerticalReference({ provenance: record('unknown'), verticalDatum: 'NAVD88' }),
+    ).toBe('orthometric');
+    expect(
+      resolveProfileVerticalReference({ provenance: record('unknown'), verticalDatum: null }),
+    ).toBe('unknown');
+  });
+
+  it('a datum name the tables do not recognise stays unknown', () => {
+    expect(resolveProfileVerticalReference({ verticalDatum: 'Site datum (assumed)' })).toBe(
+      'unknown',
+    );
+    expect(resolveProfileVerticalReference({ verticalDatum: '' })).toBe('unknown');
+  });
+
+  it('a recognised datum string resolves without a record', () => {
+    expect(resolveProfileVerticalReference({ verticalDatum: 'NAVD88' })).toBe('orthometric');
+    expect(resolveProfileVerticalReference({ verticalDatum: 'EPSG:4979' })).toBe('ellipsoidal');
+    expect(resolveProfileVerticalReference({ verticalDatum: 'MSL depth' })).toBe('depth');
+  });
+
+  it('datumKnown omitted is not read as a refusal — only an explicit false is', () => {
+    expect(resolveProfileVerticalReference({ verticalDatum: 'NAVD88' })).toBe('orthometric');
+    expect(
+      resolveProfileVerticalReference({ datumKnown: true, verticalDatum: 'NAVD88' }),
+    ).toBe('orthometric');
+  });
+});


### PR DESCRIPTION
`MeasureController` sets `profileDatumKnown: this._originUp !== null` — the loaded clouds share a render origin. Three surfaces read it as "a vertical datum exists": the dock summary rows and station table, the `ResultFocus` view and its station table, and the station CSV. A cloud with no declared vertical datum had every absolute height printed under the word Elevation, and its CSV column named `elevation_m`.

New `src/render/measure/profileVerticalReference.ts` resolves the reference the same way #541 resolves it for the sheet: conflicting origins are `local`, otherwise the provenance record's `units.verticalReference`, otherwise `verticalReferenceFromDatum`, which answers `unknown` for a name it does not recognise. Headings come from `heightLabel`, so only an orthometric reference reads Elevation.

`profileSummaryRows` and `buildProfileCsv` now take a required `VerticalReference` instead of a `datumKnown` boolean that defaulted to `true`, and `buildStationTable`'s `heightHeader` loses the same default — the old defaults handed a forgetful caller the strongest claim on the page. `datumKnown` still gates the origin-conflict notice, which is what it actually means. Every number is unchanged; only what it is called moves.

`profilePdf.ts` is untouched and keeps its own private copy of the resolver. Collapsing the two onto this module is a follow-up.