### PR TITLE
Fail a pull request that shows a reviewer work already on main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,6 +50,34 @@ specs run via `npm run test:e2e`.
 Keep the module boundaries intact: one file per format or concern, and
 analysis modules must not import the renderer.
 
+### Branching, and reading your own diff
+
+Cut every branch from current `main`. Branching from another open PR is
+sometimes the only sensible thing to do, and when you do it, say so on the
+`Stacked on:` line, because it changes how the branch has to be landed.
+
+The reason it matters is squash merging. When the parent PR is squashed, its
+commits are replaced by one new commit that your branch has never seen, so
+they never become ancestors of `main` and they keep showing up in your review
+surface. One branch here arrived at 103 commits and 56 files, of which 48 were
+byte-identical to `main`: eight files of work behind forty-eight files of
+noise. Rebasing onto current `main` removes them. `npm run lint:pr-hygiene`
+reports the count, and CI runs it on every PR.
+
+Two diffs answer two different questions, and mixing them up is how a healthy
+branch gets mistaken for a broken one:
+
+```bash
+git diff --name-only origin/main...HEAD   # what a reviewer sees
+git diff --name-only origin/main   HEAD   # how the two trees differ right now
+```
+
+Three dots is measured from where you branched, so it is your work. Two dots
+compares the trees as they stand, so on a branch that is merely behind it also
+counts every file `main` has gained since. A large two-dot diff means you are
+behind. A file that appears in the three-dot diff while being identical between
+`main` and your head means that work is already upstream.
+
 ## Testing policy
 
 New functionality ships with automated tests covering it. This is a

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,26 @@
 ## What this changes
 
-A short description of the change and why it is needed. Link any related
-issue (for example, `Closes #12`).
+A short description of the change and why it is needed. Link any related issue
+(for example, `Closes #12`). If the why is obvious from the title, say what a
+reviewer would otherwise have to reconstruct: what was wrong before, what made
+it wrong, and what convinced you this is the fix rather than a workaround that
+happens to move the symptom.
+
+## Scope
+
+What this PR does not touch, so a reviewer knows where to stop reading.
+
+## Dependencies
+
+Delete the lines that do not apply. A dependency on evidence is not the same as
+a dependency on code: a dataset record that a claim cites has to land first even
+when no source file connects them.
+
+- Depends on: #NNN (code)
+- Depends on: #NNN (evidence: cites a record that PR adds)
+- Stacked on: #NNN (branched from that PR, not from `main`)
+
+An empty list means this branch was cut from current `main`.
 
 ## Type of change
 
@@ -11,13 +30,45 @@ issue (for example, `Closes #12`).
 - [ ] Refactor / internal change
 - [ ] Build, CI, or tooling
 
+## Scientific impact
+
+- [ ] S0: no scientific behaviour
+- [ ] S1: provenance, wording, dataset register, or report scope
+- [ ] S2: numerical or algorithmic
+- [ ] S3: changes a claim, tolerance, evidence level, or an algorithm default
+
+S2 ships with a test that fails before the change and passes after. S3 needs an
+evidence review before merge, because the author's own tests were written
+against the same understanding that produced the change, so they agree with it
+by construction; the question a reviewer answers is whether that understanding
+is right.
+
+## Evidence
+
+What you ran and what it said. Paste the numbers, not a summary of them. A gate
+you did not run is not a gate that passed, and a reviewer cannot tell the two
+apart from prose alone. Exit codes are worth quoting where a command is easy to
+misread as green. If a number moved, say by how much and against what. This
+section is the part of the PR a future reader trusts when the code has changed
+underneath it and the description no longer matches.
+
+- [ ] No tracked baseline, reference run, evidence level, tolerance, or
+      registered study result changed.
+- [ ] A tracked baseline did change. Which, and why the new value is the
+      correct one rather than the one that makes CI pass:
+
 ## How it was tested
 
-Describe what you ran and what you checked. For rendering or navigation
-changes, note the browser and backend (WebGPU or WebGL 2) you tested in.
+Describe what you checked. For rendering or navigation changes, note the
+browser and backend (WebGPU or WebGL 2).
+
+## Rollback
+
+What reverting this leaves behind. Usually nothing.
 
 ## Checklist
 
+- [ ] Branched from current `main`, or the stack is declared above
 - [ ] `npm run typecheck` passes
 - [ ] `npm test` passes
 - [ ] `npm run build` succeeds

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,60 @@
+# Structural check on what a pull request shows a reviewer.
+#
+# Separate from ci.yml because it needs the full history (`fetch-depth: 0`) that
+# the other jobs deliberately do without, and because it reads the pull request
+# rather than the tree. It is read-only: it never comments, labels, or merges.
+#
+# Deliberately absent from the release gate, which runs against an unpacked
+# archive with no `.git` at all.
+name: PR hygiene
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-hygiene-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  hygiene:
+    # Draft PRs are work in progress; the queue is not what they are for.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The whole point: merge-base, three-dot diffs and merge counts do not
+          # exist in a shallow clone.
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch the base branch
+        run: git fetch --no-tags origin "+refs/heads/${BASE}:refs/remotes/origin/${BASE}"
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      - name: Count open non-draft PRs
+        id: queue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          count=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+            --json isDraft --jq '[.[] | select(.isDraft == false)] | length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: PR hygiene
+        run: node scripts/pr-hygiene.mjs
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_OPEN_COUNT: ${{ steps.queue.outputs.count }}

--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
     "lint:worker-registry": "node scripts/lint-worker-registry.mjs",
     "lint:claim-prose-sync": "node scripts/lint-claim-prose-sync.mjs",
     "lint:dataset-citations": "node scripts/lint-dataset-citations.mjs",
-    "verify:reference-reproducibility": "node scripts/verify-reference-reproducibility.mjs"
+    "verify:reference-reproducibility": "node scripts/verify-reference-reproducibility.mjs",
+    "lint:pr-hygiene": "node scripts/pr-hygiene.mjs"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",

--- a/scripts/pr-hygiene.mjs
+++ b/scripts/pr-hygiene.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * pr-hygiene.mjs — structural guard for what a pull request shows a reviewer.
+ *
+ * A branch cut from another branch that is later SQUASH-merged replays history
+ * forever. Squashing replaces N commits with one, so the originals never become
+ * ancestors of `main` and keep reappearing in the child's review surface. One
+ * PR here reached 103 commits and 56 files of which 48 were byte-identical to
+ * main: eight files of real work behind forty-eight files of noise, and no gate
+ * saw it.
+ *
+ * The diagnostic is `redundant`: a file in the three-dot review surface whose
+ * content is identical between the base and the head. It is shown to a reviewer
+ * for no reason. Zero is the normal value, including for a branch that is
+ * merely behind.
+ *
+ * Two measurements are easy to confuse, and confusing them is how a stale but
+ * healthy branch gets misread as a broken one:
+ *
+ *   surface = git diff --name-only BASE...HEAD   what review shows
+ *   real    = git diff --name-only BASE   HEAD   how the trees differ NOW
+ *
+ * `real` counts main's newer files as differences, so it is large and
+ * meaningless for any branch that is behind. Replay is judged by `redundant`
+ * and merge commits, never by `real` alone.
+ *
+ * This lint hard-fails only on objective structure. Size is not incorrectness:
+ * a generated validation record is large because the evidence is large, and a
+ * wide refactor is wide because the change is wide. Those warn.
+ *
+ * Needs real history (`fetch-depth: 0`). Deliberately NOT part of the release
+ * gate, which runs against an unpacked archive with no `.git`.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Hard-fail once this many surface files are byte-identical to the base. */
+export const REDUNDANT_LIMIT = 3;
+/** Or once this share of the surface is, whichever trips first. */
+export const REDUNDANT_SHARE = 0.2;
+/** Surface this many times the real tree delta reads as replay, WITH redundancy. */
+export const AMPLIFICATION = 2;
+/** Above this many open non-draft PRs the queue is warned about, never failed. */
+export const QUEUE_WARN = 8;
+/** Commits behind the base before the branch is called stale. */
+export const STALE_WARN = 40;
+/** A surface this wide is noted so a reviewer can budget for it. */
+export const WIDE_NOTE = 40;
+
+const list = (files) =>
+  files.slice(0, 10).join(', ') + (files.length > 10 ? `, and ${files.length - 10} more` : '');
+
+/**
+ * Problems in one observed branch. Pure: a function of what it is given, so the
+ * cases in tests/prHygiene.test.ts construct histories rather than depending on
+ * whatever the repository happens to contain today.
+ *
+ * observation = {
+ *   baseRef, allowedBases, surface[], redundant[], realCount, mergeCommits[],
+ *   linearHistoryRequired, commitsBehind, openPrCount, generatedFiles[]
+ * }
+ */
+export function collectHygieneProblems(observation) {
+  const {
+    baseRef = 'main',
+    allowedBases = ['main'],
+    surface = [],
+    redundant = [],
+    realCount = 0,
+    mergeCommits = [],
+    linearHistoryRequired = true,
+    commitsBehind = 0,
+    openPrCount = 0,
+    generatedFiles = [],
+  } = observation;
+
+  const errors = [];
+  const warnings = [];
+
+  if (!allowedBases.includes(baseRef)) {
+    errors.push(
+      `[H1 base-invalid] the PR targets '${baseRef}'; this repository merges into ` +
+        `${allowedBases.map((b) => `'${b}'`).join(' or ')}. Retarget the PR.`,
+    );
+  }
+
+  if (linearHistoryRequired && mergeCommits.length > 0) {
+    errors.push(
+      `[H2 merge-commit] ${mergeCommits.length} merge commit(s) on a branch where main ` +
+        'requires linear history. Rebase onto current main rather than merging it in.',
+    );
+  }
+
+  const share = surface.length > 0 ? redundant.length / surface.length : 0;
+  if (redundant.length >= REDUNDANT_LIMIT || (redundant.length > 0 && share >= REDUNDANT_SHARE)) {
+    errors.push(
+      `[H3 redundant-surface] ${redundant.length} of ${surface.length} file(s) in the review ` +
+        `surface are byte-identical to ${baseRef}: ${list(redundant)}. Those commits are already ` +
+        'upstream, most often because this branch was cut from a branch that was later ' +
+        'squash-merged. Rebase onto current main; do not add a waiver.',
+    );
+  } else if (redundant.length > 0) {
+    warnings.push(
+      `[W1 redundant-surface] ${redundant.length} file(s) in the review surface match ` +
+        `${baseRef} exactly: ${list(redundant)}. Rebasing takes them out of review.`,
+    );
+  }
+
+  if (realCount > 0 && surface.length > realCount * AMPLIFICATION && redundant.length > 0) {
+    errors.push(
+      `[H4 surface-amplified] review shows ${surface.length} file(s) but the trees differ in ` +
+        `${realCount}, and ${redundant.length} surface file(s) are already upstream. The branch ` +
+        'is replaying history. Rebase onto current main.',
+    );
+  }
+
+  if (openPrCount > QUEUE_WARN) {
+    warnings.push(
+      `[W2 queue-depth] ${openPrCount} open non-draft PRs. Each merge invalidates the rest when ` +
+        'the base requires branches to be up to date. This never blocks a merge.',
+    );
+  }
+
+  if (commitsBehind > STALE_WARN) {
+    warnings.push(
+      `[W3 stale-base] ${commitsBehind} commit(s) behind ${baseRef}. Not a defect; it does mean ` +
+        'review is reading against an old tree.',
+    );
+  }
+
+  if (generatedFiles.length > 0) {
+    warnings.push(
+      `[W4 generated-record] ${generatedFiles.length} generated evidence file(s): ` +
+        `${list(generatedFiles)}. Large because the evidence is large. Size is not scope.`,
+    );
+  }
+
+  if (errors.length === 0 && surface.length > WIDE_NOTE && redundant.length === 0) {
+    warnings.push(
+      `[W5 wide-change] ${surface.length} file(s), none redundant. A wide change is not a ` +
+        'malformed one; noted so a reviewer can budget for it.',
+    );
+  }
+
+  return { errors, warnings };
+}
+
+const lines = (out) => (out ? out.split('\n').filter(Boolean) : []);
+
+/**
+ * Reads the observation this lint needs out of real history.
+ *
+ * `cwd` is a parameter rather than a constant so the cases in
+ * tests/prHygiene.test.ts can build a repository with the history they are
+ * about and read it with the same code CI runs.
+ */
+export function observeBranch(baseRef, headRef, extra = {}, cwd = ROOT) {
+  const git = (...args) => execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+
+  const mergeBase = git('merge-base', baseRef, headRef);
+  const surface = lines(git('diff', '--name-only', `${mergeBase}...${headRef}`));
+  const realCount = lines(git('diff', '--name-only', baseRef, headRef)).length;
+  const mergeCommits = lines(git('log', '--oneline', '--merges', `${mergeBase}..${headRef}`));
+  const commitsBehind = lines(git('rev-list', `${mergeBase}..${baseRef}`)).length;
+
+  const redundant = surface.filter((file) => {
+    try {
+      git('diff', '--quiet', baseRef, headRef, '--', file);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+  return { baseRef, surface, redundant, realCount, mergeCommits, commitsBehind, ...extra };
+}
+
+const isCli = resolve(process.argv[1] ?? '') === resolve(fileURLToPath(import.meta.url));
+
+if (isCli) {
+  const base = process.env.PR_BASE_REF ? `origin/${process.env.PR_BASE_REF}` : 'origin/main';
+  const head = process.env.PR_HEAD_SHA || 'HEAD';
+  const openPrCount = Number(process.env.PR_OPEN_COUNT || 0);
+
+  const observation = observeBranch(base, head, { openPrCount, allowedBases: [base] });
+  const { errors, warnings } = collectHygieneProblems(observation);
+
+  for (const w of warnings) console.log(`  note: ${w}`);
+
+  if (errors.length > 0) {
+    console.error(`\nlint:pr-hygiene: ${errors.length} problem(s):\n`);
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error('');
+    process.exit(1);
+  }
+
+  console.log(
+    `lint:pr-hygiene: OK — ${observation.surface.length} file(s) in review, ` +
+      `${observation.redundant.length} redundant, ${observation.mergeCommits.length} merge commit(s), ` +
+      `${observation.commitsBehind} commit(s) behind ${base}.`,
+  );
+}

--- a/tests/prHygiene.test.ts
+++ b/tests/prHygiene.test.ts
@@ -1,0 +1,226 @@
+/**
+ * prHygiene.test.ts — proves the PR-hygiene lint REJECTS, and for the stated
+ * reason, and that it does NOT reject the healthy branches it resembles.
+ *
+ * The rule that matters is the replay predicate, and it is the one easiest to
+ * write backwards: `redundant` counts surface files IDENTICAL to the base, not
+ * files that differ. Inverted, it would flag every honest PR and pass the
+ * pathological one, and both mistakes look the same in a green CI run. The
+ * predicate therefore gets its direction pinned explicitly, and the
+ * merely-behind case exists to fail if the two-dot and three-dot measurements
+ * are ever swapped.
+ *
+ * `collectHygieneProblems` takes an observation, so the rule cases are a
+ * function of what they pass. `observeBranch` reads real history, so it is
+ * tested against real repositories built in a temp directory: the important one
+ * is a branch cut from a parent that is then squash-merged, which is how the
+ * 103-commit, 48-redundant-file PR happened.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Kept on one line: @ts-expect-error applies to the line that follows it.
+// @ts-expect-error — plain .mjs script, no types
+import { collectHygieneProblems, observeBranch, REDUNDANT_LIMIT } from '../scripts/pr-hygiene.mjs';
+
+interface Report { errors: string[]; warnings: string[] }
+
+const run = (o: Record<string, unknown>): Report => collectHygieneProblems(o) as Report;
+const ids = (msgs: string[]) => msgs.map((m) => m.slice(1, m.indexOf(' ')));
+
+/** A healthy PR: a few files, nothing already upstream, no merges. */
+const CLEAN = {
+  baseRef: 'main',
+  allowedBases: ['main'],
+  surface: ['src/a.ts', 'tests/a.test.ts'],
+  redundant: [],
+  realCount: 2,
+  mergeCommits: [],
+  commitsBehind: 0,
+  openPrCount: 3,
+};
+
+describe('pr-hygiene — the healthy shapes it must not reject', () => {
+  it('passes a clean branch', () => {
+    expect(run(CLEAN)).toEqual({ errors: [], warnings: [] });
+  });
+
+  it('passes a branch that is merely behind, whose two-dot delta is huge', () => {
+    // The trap: `real` counts main's newer files, so it dwarfs the surface on
+    // any stale branch. Judging replay by `real` would condemn this one.
+    const report = run({ ...CLEAN, realCount: 166, commitsBehind: 9 });
+    expect(report.errors).toEqual([]);
+  });
+
+  it('passes a wide refactor with nothing redundant, noting the width only', () => {
+    const surface = Array.from({ length: 60 }, (_, i) => `src/m${i}.ts`);
+    const report = run({ ...CLEAN, surface, realCount: 60 });
+    expect(report.errors).toEqual([]);
+    expect(ids(report.warnings)).toContain('W5');
+  });
+
+  it('passes a large generated evidence record, because size is not scope', () => {
+    const report = run({
+      ...CLEAN,
+      surface: ['validation/x/reference-runs.json'],
+      realCount: 1,
+      generatedFiles: ['validation/x/reference-runs.json'],
+    });
+    expect(report.errors).toEqual([]);
+    expect(ids(report.warnings)).toContain('W4');
+  });
+
+  it('warns but never fails on queue depth, so a security fix is not blocked', () => {
+    const report = run({ ...CLEAN, openPrCount: 14 });
+    expect(report.errors).toEqual([]);
+    expect(ids(report.warnings)).toContain('W2');
+  });
+
+  it('warns but never fails on a stale base', () => {
+    const report = run({ ...CLEAN, commitsBehind: 120 });
+    expect(report.errors).toEqual([]);
+    expect(ids(report.warnings)).toContain('W3');
+  });
+});
+
+describe('pr-hygiene — the structural rejections', () => {
+  it('H1 rejects a PR targeting a branch this repository does not merge into', () => {
+    const report = run({ ...CLEAN, baseRef: 'release/v1', allowedBases: ['main'] });
+    expect(ids(report.errors)).toContain('H1');
+    expect(report.errors[0]).toContain('release/v1');
+  });
+
+  it('H2 rejects merge commits where linear history is required', () => {
+    const report = run({ ...CLEAN, mergeCommits: ['abc Merge branch main'] });
+    expect(ids(report.errors)).toContain('H2');
+  });
+
+  it('H2 stays quiet where linear history is not required', () => {
+    const report = run({ ...CLEAN, mergeCommits: ['abc Merge'], linearHistoryRequired: false });
+    expect(report.errors).toEqual([]);
+  });
+
+  it('H3 rejects a surface mostly identical to the base, and names the files', () => {
+    const surface = ['src/real.ts', 'src/old1.ts', 'src/old2.ts', 'src/old3.ts'];
+    const report = run({ ...CLEAN, surface, redundant: surface.slice(1), realCount: 1 });
+    expect(ids(report.errors)).toContain('H3');
+    expect(report.errors.find((e) => e.startsWith('[H3'))).toContain('src/old1.ts');
+  });
+
+  it('H3 tells the reader to rebase rather than to add a waiver', () => {
+    const surface = ['a', 'b', 'c', 'd'];
+    const report = run({ ...CLEAN, surface, redundant: ['b', 'c', 'd'], realCount: 1 });
+    const h3 = report.errors.find((e) => e.startsWith('[H3')) as string;
+    expect(h3).toContain('Rebase onto current main');
+    expect(h3).toContain('do not add a waiver');
+  });
+
+  it('H3 fails on a small surface once the redundant SHARE is material', () => {
+    // Two of four is under REDUNDANT_LIMIT but half the review is noise.
+    expect(REDUNDANT_LIMIT).toBe(3);
+    const report = run({ ...CLEAN, surface: ['a', 'b', 'c', 'd'], redundant: ['a', 'b'], realCount: 2 });
+    expect(ids(report.errors)).toContain('H3');
+  });
+
+  it('H3 only warns on a single redundant file in a wide surface', () => {
+    const surface = Array.from({ length: 30 }, (_, i) => `src/m${i}.ts`);
+    const report = run({ ...CLEAN, surface, redundant: ['src/m0.ts'], realCount: 30 });
+    expect(report.errors).toEqual([]);
+    expect(ids(report.warnings)).toContain('W1');
+  });
+
+  it('H4 rejects a surface far larger than the real delta WHEN files are upstream', () => {
+    const surface = Array.from({ length: 56 }, (_, i) => `f${i}`);
+    const report = run({ ...CLEAN, surface, redundant: surface.slice(8), realCount: 8 });
+    expect(ids(report.errors)).toContain('H4');
+  });
+
+  it('H4 stays quiet when the surface is large but nothing is upstream', () => {
+    // A genuinely wide change against a stale base must not read as replay.
+    const surface = Array.from({ length: 56 }, (_, i) => `f${i}`);
+    const report = run({ ...CLEAN, surface, redundant: [], realCount: 8 });
+    expect(ids(report.errors)).not.toContain('H4');
+  });
+});
+
+describe('observeBranch — measured against real history', () => {
+  let dir: string;
+  const git = (...args: string[]) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' }).trim();
+  const commit = (path: string, body: string, message: string) => {
+    mkdirSync(join(dir, path, '..'), { recursive: true });
+    writeFileSync(join(dir, path), body);
+    git('add', '-A');
+    git('-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '-q', '-m', message);
+  };
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'olv-hygiene-'));
+    git('init', '-q', '-b', 'main');
+    commit('base.txt', 'base\n', 'base');
+
+    // A parent branch does two files of work.
+    git('checkout', '-q', '-b', 'parent');
+    commit('parent1.txt', 'one\n', 'parent one');
+    commit('parent2.txt', 'two\n', 'parent two');
+
+    // A child is cut FROM the parent and adds its own file.
+    git('checkout', '-q', '-b', 'child');
+    commit('child.txt', 'child\n', 'child work');
+
+    // The parent is then SQUASH-merged into main. Its two commits are replaced
+    // by one that is not an ancestor of the child, so the child's merge-base
+    // with main stays at `base` and the parent's files reappear in its surface.
+    git('checkout', '-q', 'main');
+    git('merge', '--squash', '-q', 'parent');
+    git('-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '-q', '-m', 'parent work (#1)');
+
+    // A second branch is cut from main AFTER the squash and is merely behind.
+    git('checkout', '-q', '-b', 'behind', 'main');
+    commit('behind.txt', 'b\n', 'behind work');
+    git('checkout', '-q', 'main');
+    commit('later.txt', 'later\n', 'main moves on');
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('measures a squash-merged-parent replay: the parent files are redundant', () => {
+    const o = observeBranch('main', 'child', { allowedBases: ['main'] }, dir) as {
+      surface: string[]; redundant: string[]; realCount: number; mergeCommits: string[];
+    };
+    // Surface shows the child's own file AND the parent's two, already upstream.
+    expect(o.surface.sort()).toEqual(['child.txt', 'parent1.txt', 'parent2.txt']);
+    expect(o.redundant.sort()).toEqual(['parent1.txt', 'parent2.txt']);
+    const report = run({ ...o, baseRef: 'main', allowedBases: ['main'] });
+    expect(ids(report.errors)).toContain('H3');
+  });
+
+  it('pins the predicate direction: the child\'s OWN file is never redundant', () => {
+    // Inverting the predicate would put child.txt here and drop the parent
+    // files, which is the mutation this case exists to kill.
+    const o = observeBranch('main', 'child', {}, dir) as { redundant: string[] };
+    expect(o.redundant).not.toContain('child.txt');
+  });
+
+  it('measures a merely-behind branch as clean, however far behind it is', () => {
+    const o = observeBranch('main', 'behind', { allowedBases: ['main'] }, dir) as {
+      surface: string[]; redundant: string[]; realCount: number;
+    };
+    expect(o.surface).toEqual(['behind.txt']);
+    expect(o.redundant).toEqual([]);
+    // The two-dot delta also counts what main gained: the trap this guards.
+    expect(o.realCount).toBeGreaterThan(o.surface.length);
+    expect(run({ ...o, baseRef: 'main', allowedBases: ['main'] }).errors).toEqual([]);
+  });
+
+  it('counts merge commits on a branch that merges main in', () => {
+    git('checkout', '-q', '-b', 'merger', 'behind');
+    git('-c', 'user.name=t', '-c', 'user.email=t@t', 'merge', '-q', '--no-ff', 'main', '-m', 'Merge main');
+    const o = observeBranch('main', 'merger', { allowedBases: ['main'] }, dir) as { mergeCommits: string[] };
+    expect(o.mergeCommits.length).toBe(1);
+    expect(ids(run({ ...o, baseRef: 'main', allowedBases: ['main'] }).errors)).toContain('H2');
+  });
+});


### PR DESCRIPTION
A branch cut from a branch that is later squash-merged replays history. The squash produces a commit the child never saw, so the originals never become ancestors of `main` and keep reappearing in review. One PR here reached 103 commits and 56 files, 48 of them byte-identical to `main`. The diagnostic is a surface file whose content matches the base, and zero is the normal value even far behind.

H1 to H4 fail on an invalid base, merge commits, a redundant surface, and amplification. Queue depth, stale bases, generated records and wide refactors warn, because size is not incorrectness.

Against the real case the 56-file head reports H2, H3 and H4; its repaired form and a merely-behind branch report clean. Inverting the replay predicate fails three tests.

Read-only, full history, out of the release gate.
