### PR TITLE
Run the iPhone WebKit leg in CI

### DIFF
--- a/.github/workflows/browser-smoke.yml
+++ b/.github/workflows/browser-smoke.yml
@@ -33,6 +33,12 @@ jobs:
         run: ./node_modules/.bin/playwright install --with-deps webkit
       - name: Boot smoke on WebKit
         run: ./node_modules/.bin/playwright test --project=webkit tests/e2e/smoke.spec.ts
+      # The same engine at a phone viewport, with touch and an iPhone user
+      # agent. It runs in the WebKit job because the browser is already
+      # installed here; a separate job would download it twice to prove the
+      # layout of a page this one just booted.
+      - name: Mobile viewport contract on iPhone WebKit
+        run: ./node_modules/.bin/playwright test --project=webkit-mobile
       - name: Upload Playwright report on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
The `webkit-mobile` project landed in #549 but no workflow invoked it, so it ran only when someone typed the command.

It joins the existing `webkit-smoke` job rather than getting one of its own, because that job has already installed WebKit; a separate job would download the browser a second time to check the layout of a page this one just booted.