### PR TITLE
Compose 3D Tiles tile transforms instead of only validating them

### DIFF
--- a/src/io/tiles3d/tileTransform.ts
+++ b/src/io/tiles3d/tileTransform.ts
@@ -1,0 +1,237 @@
+/**
+ * tileTransform.ts — the 3D Tiles tile transform, composed and applied.
+ *
+ * A tile's `transform` is a column-major 4x4 affine from that tile's local
+ * space to its PARENT's space. Placing a tile therefore needs the product of
+ * every transform from the root down, and the order is not a matter of taste:
+ * composing the other way puts a tile somewhere plausible rather than
+ * somewhere wrong, which is the hardest kind of error to notice.
+ *
+ * `tileset.ts` validates that a transform is sixteen finite numbers and stops
+ * there. This module is what turns a validated transform into a placement.
+ *
+ * WHAT THE TRANSFORM APPLIES TO, per the 1.1 specification:
+ *
+ *   content                      yes
+ *   `box` bounding volume        yes
+ *   `sphere` bounding volume     yes
+ *   content bounding volume      yes
+ *   viewer request volume        yes
+ *   `region` bounding volume     NO
+ *   `geometricError`             scaled by the largest scaling factor
+ *
+ * The `region` exemption is the one that bites. A region is stated in
+ * EPSG:4979 geographic coordinates, so it is already absolute; multiplying it
+ * by a tile transform treats longitude as if it were a metre and produces a
+ * volume in no coordinate system at all. It is exempt because it does not need
+ * transforming, not because transforming it is merely inaccurate.
+ *
+ * Pure: no fetch, no DOM, no renderer types. Column-major throughout, matching
+ * both the specification and WebGL, so `m[column * 4 + row]`.
+ */
+
+import type { BoundingVolume, Tile } from './tileset';
+
+/** A column-major 4x4, sixteen finite numbers. */
+export type Mat4 = readonly number[];
+
+export type Vec3 = readonly [number, number, number];
+
+/** The column-major identity, which is also the transform of a tile with none. */
+export const IDENTITY_4X4: Mat4 = Object.freeze([
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]);
+
+/**
+ * `parent * child`, the cumulative transform of a child tile.
+ *
+ * Order is the whole content of this function. The child's transform maps
+ * child-local to parent space, and the parent's cumulative maps parent to
+ * root, so root-space = parent_cumulative · child_local. Reversing the operands
+ * yields a matrix that is still finite, still invertible and still wrong.
+ */
+export function composeTileTransform(parent: Mat4, child: Mat4): number[] {
+  const out = new Array<number>(16);
+  for (let col = 0; col < 4; col++) {
+    for (let row = 0; row < 4; row++) {
+      let sum = 0;
+      for (let k = 0; k < 4; k++) sum += parent[k * 4 + row]! * child[col * 4 + k]!;
+      out[col * 4 + row] = sum;
+    }
+  }
+  return out;
+}
+
+/**
+ * The cumulative transform for a path of tiles from the root down.
+ *
+ * A tile without its own transform contributes the identity rather than being
+ * skipped, so a caller can hand over the whole path including the gaps.
+ */
+export function cumulativeTransform(path: readonly (Mat4 | null | undefined)[]): number[] {
+  let acc: Mat4 = IDENTITY_4X4;
+  for (const step of path) {
+    if (!step) continue;
+    acc = composeTileTransform(acc, step);
+  }
+  return [...acc];
+}
+
+/** A point through the full affine, translation included. */
+export function transformPoint(m: Mat4, p: Vec3): [number, number, number] {
+  const [x, y, z] = p;
+  return [
+    m[0]! * x + m[4]! * y + m[8]! * z + m[12]!,
+    m[1]! * x + m[5]! * y + m[9]! * z + m[13]!,
+    m[2]! * x + m[6]! * y + m[10]! * z + m[14]!,
+  ];
+}
+
+/**
+ * A direction through the linear part only.
+ *
+ * Half-axes and normals are directions, not positions: adding the translation
+ * to one moves the shape twice and leaves the box centred somewhere it is not.
+ */
+export function transformDirection(m: Mat4, v: Vec3): [number, number, number] {
+  const [x, y, z] = v;
+  return [
+    m[0]! * x + m[4]! * y + m[8]! * z,
+    m[1]! * x + m[5]! * y + m[9]! * z,
+    m[2]! * x + m[6]! * y + m[10]! * z,
+  ];
+}
+
+/**
+ * The largest scaling factor of the linear part.
+ *
+ * Taken as the longest of the three transformed basis vectors, which is what
+ * the specification's geometric-error scaling means for a non-uniform scale:
+ * the error must not shrink on the axis that grew, so the maximum is the only
+ * safe choice. A mean would under-report and a minimum would under-report
+ * badly, and both look correct under the uniform scale that most tilesets use.
+ */
+export function largestScale(m: Mat4): number {
+  const cx = Math.hypot(m[0]!, m[1]!, m[2]!);
+  const cy = Math.hypot(m[4]!, m[5]!, m[6]!);
+  const cz = Math.hypot(m[8]!, m[9]!, m[10]!);
+  return Math.max(cx, cy, cz);
+}
+
+/** A tile's geometric error under its cumulative transform. */
+export function transformGeometricError(m: Mat4, geometricError: number): number {
+  return geometricError * largestScale(m);
+}
+
+/**
+ * A `box` volume through the transform: centre as a position, each half-axis
+ * as a direction. The result is still twelve numbers in the same layout.
+ */
+export function transformBox(m: Mat4, box: readonly number[]): number[] {
+  const c = transformPoint(m, [box[0]!, box[1]!, box[2]!]);
+  const ax = transformDirection(m, [box[3]!, box[4]!, box[5]!]);
+  const ay = transformDirection(m, [box[6]!, box[7]!, box[8]!]);
+  const az = transformDirection(m, [box[9]!, box[10]!, box[11]!]);
+  return [...c, ...ax, ...ay, ...az];
+}
+
+/**
+ * A `sphere` volume through the transform.
+ *
+ * The radius takes the largest scaling factor, so a non-uniform scale grows the
+ * sphere to enclose the ellipsoid it really became. That is conservative on
+ * purpose: a bounding volume that is too small culls geometry that should have
+ * been drawn, and a viewer that culls what it should draw looks like a decoder
+ * bug rather than a bounds bug.
+ */
+export function transformSphere(m: Mat4, sphere: readonly number[]): number[] {
+  const c = transformPoint(m, [sphere[0]!, sphere[1]!, sphere[2]!]);
+  return [...c, sphere[3]! * largestScale(m)];
+}
+
+/**
+ * A bounding volume through the transform, leaving `region` alone.
+ *
+ * Returns a new volume; the input is not mutated. A volume carrying only a
+ * region comes back unchanged, which is the specification's behaviour and not
+ * an omission.
+ */
+export function transformBoundingVolume(m: Mat4, volume: BoundingVolume): BoundingVolume {
+  const out: { box?: number[]; sphere?: number[]; region?: readonly number[] } = {};
+  if (volume.box) out.box = transformBox(m, volume.box);
+  if (volume.sphere) out.sphere = transformSphere(m, volume.sphere);
+  // EPSG:4979 and therefore absolute. Carried through untouched.
+  if (volume.region) out.region = volume.region;
+  return out as BoundingVolume;
+}
+
+/**
+ * Whether a transform is close enough to the identity to skip.
+ *
+ * Worth asking before walking a deep tileset: most tiles carry no transform at
+ * all, and the ones that do are usually only at the root.
+ */
+export function isIdentityTransform(m: Mat4, epsilon = 0): boolean {
+  for (let i = 0; i < 16; i++) {
+    if (Math.abs(m[i]! - IDENTITY_4X4[i]!) > epsilon) return false;
+  }
+  return true;
+}
+
+/** A tile resolved into the tileset's root space. */
+export interface PlacedTile {
+  readonly tile: Tile;
+  /** Cumulative root-to-tile transform, column-major. */
+  readonly transform: Mat4;
+  /** The tile's bounding volume in root space, `region` left as authored. */
+  readonly boundingVolume: BoundingVolume;
+  /** The tile's geometric error scaled by the cumulative transform. */
+  readonly geometricError: number;
+  /** Root is 0. */
+  readonly depth: number;
+}
+
+/**
+ * Walk a tileset top-down, resolving every tile into root space.
+ *
+ * This is the shape §7.4 asks for: the cumulative transform is computed as the
+ * walk descends, so each tile sees its parent's product rather than
+ * recomputing the chain from the root. Depth-first and eager, because a
+ * tileset's own JSON is already in memory by the time this runs; streaming a
+ * hierarchy that arrives over the wire is a different traversal and belongs
+ * with the scheduler, not here.
+ *
+ * External tileset contents are not followed. A tile whose content URI names
+ * another `tileset.json` is yielded as itself, and resolving it is the
+ * resource layer's job.
+ */
+export function* walkTilePlacements(
+  root: Tile,
+  rootTransform: Mat4 = IDENTITY_4X4,
+): Generator<PlacedTile> {
+  const stack: { tile: Tile; parent: Mat4; depth: number }[] = [
+    { tile: root, parent: rootTransform, depth: 0 },
+  ];
+
+  while (stack.length > 0) {
+    const { tile, parent, depth } = stack.pop()!;
+    const transform = tile.transform ? composeTileTransform(parent, tile.transform) : parent;
+
+    yield {
+      tile,
+      transform,
+      boundingVolume: transformBoundingVolume(transform, tile.boundingVolume),
+      geometricError: transformGeometricError(transform, tile.geometricError),
+      depth,
+    };
+
+    // Pushed in reverse so the walk yields children in authored order, which is
+    // what a reader comparing against the JSON expects.
+    for (let i = tile.children.length - 1; i >= 0; i--) {
+      stack.push({ tile: tile.children[i]!, parent: transform, depth: depth + 1 });
+    }
+  }
+}

--- a/tests/tiles3dTransform.test.ts
+++ b/tests/tiles3dTransform.test.ts
@@ -1,0 +1,313 @@
+/**
+ * tiles3dTransform.test.ts — the tile transform, against closed forms.
+ *
+ * Every expected value here is computed by hand from the construction, not
+ * read back from the implementation. That matters more than usual for matrix
+ * code: a composition written in the wrong order still produces finite,
+ * invertible, plausible-looking numbers, and a test that asserts "whatever it
+ * returned" passes on both.
+ *
+ * The order case is the load-bearing one. `composeTileTransform(A, B)` must be
+ * A·B, so a translate-then-scale differs from a scale-then-translate, and the
+ * two are distinguished by an explicit hand-worked expectation rather than by
+ * a round trip that would pass either way.
+ *
+ * Column-major throughout: `m[column * 4 + row]`, so the translation lives at
+ * indices 12, 13 and 14.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  IDENTITY_4X4,
+  composeTileTransform,
+  cumulativeTransform,
+  transformPoint,
+  transformDirection,
+  largestScale,
+  transformGeometricError,
+  transformBox,
+  transformSphere,
+  transformBoundingVolume,
+  isIdentityTransform,
+  walkTilePlacements,
+} from '../src/io/tiles3d/tileTransform';
+import type { Tile } from '../src/io/tiles3d/tileset';
+
+/** Column-major translation. */
+const T = (x: number, y: number, z: number): number[] => [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  x, y, z, 1,
+];
+
+/** Column-major scale, per axis so non-uniform cases are expressible. */
+const S = (x: number, y: number, z: number): number[] => [
+  x, 0, 0, 0,
+  0, y, 0, 0,
+  0, 0, z, 0,
+  0, 0, 0, 1,
+];
+
+/** Column-major rotation about Z, radians. */
+const Rz = (a: number): number[] => [
+  Math.cos(a), Math.sin(a), 0, 0,
+  -Math.sin(a), Math.cos(a), 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+];
+
+describe('composition order', () => {
+  it('composes parent then child, so the child transform applies first', () => {
+    // Scale by 2, then translate by 10 in x. A point at x=1 becomes 2, then 12.
+    // Composing the other way would give (1 + 10) * 2 = 22.
+    const m = composeTileTransform(T(10, 0, 0), S(2, 2, 2));
+    expect(transformPoint(m, [1, 0, 0])).toEqual([12, 0, 0]);
+  });
+
+  it('is not commutative, which is the whole reason order is specified', () => {
+    const a = composeTileTransform(T(10, 0, 0), S(2, 2, 2));
+    const b = composeTileTransform(S(2, 2, 2), T(10, 0, 0));
+    expect(transformPoint(a, [1, 0, 0])).toEqual([12, 0, 0]);
+    expect(transformPoint(b, [1, 0, 0])).toEqual([22, 0, 0]);
+    expect(a).not.toEqual(b);
+  });
+
+  it('leaves a matrix unchanged when composed with the identity, either side', () => {
+    const m = composeTileTransform(T(3, -4, 5), Rz(Math.PI / 3));
+    expect(composeTileTransform(IDENTITY_4X4, m)).toEqual(m);
+    expect(composeTileTransform(m, IDENTITY_4X4)).toEqual(m);
+  });
+
+  it('is associative, so a path can be folded in any grouping', () => {
+    const a = T(1, 2, 3);
+    const b = Rz(0.4);
+    const c = S(2, 3, 4);
+    const left = composeTileTransform(composeTileTransform(a, b), c);
+    const right = composeTileTransform(a, composeTileTransform(b, c));
+    for (let i = 0; i < 16; i++) expect(left[i]).toBeCloseTo(right[i]!, 12);
+  });
+});
+
+describe('cumulative transform down a path', () => {
+  it('folds root to leaf in order', () => {
+    // Root translates by 100, child scales by 2. A leaf-local x=1 lands at 102.
+    const m = cumulativeTransform([T(100, 0, 0), S(2, 2, 2)]);
+    expect(transformPoint(m, [1, 0, 0])).toEqual([102, 0, 0]);
+  });
+
+  it('treats a tile with no transform as the identity rather than skipping it', () => {
+    const withGap = cumulativeTransform([T(100, 0, 0), null, S(2, 2, 2), undefined]);
+    const without = cumulativeTransform([T(100, 0, 0), S(2, 2, 2)]);
+    expect(withGap).toEqual(without);
+  });
+
+  it('returns the identity for an empty path', () => {
+    expect(cumulativeTransform([])).toEqual([...IDENTITY_4X4]);
+  });
+});
+
+describe('points and directions differ by the translation', () => {
+  it('carries the translation on a point', () => {
+    expect(transformPoint(T(5, 6, 7), [1, 1, 1])).toEqual([6, 7, 8]);
+  });
+
+  it('ignores the translation on a direction', () => {
+    // A half-axis that picked up the translation would move the box twice.
+    expect(transformDirection(T(5, 6, 7), [1, 1, 1])).toEqual([1, 1, 1]);
+  });
+
+  it('rotates a direction without translating it', () => {
+    const m = composeTileTransform(T(100, 100, 0), Rz(Math.PI / 2));
+    const [x, y, z] = transformDirection(m, [1, 0, 0]);
+    expect(x).toBeCloseTo(0, 12);
+    expect(y).toBeCloseTo(1, 12);
+    expect(z).toBeCloseTo(0, 12);
+  });
+});
+
+describe('largest scaling factor', () => {
+  it('is 1 for the identity', () => {
+    expect(largestScale(IDENTITY_4X4)).toBe(1);
+  });
+
+  it('is the maximum axis under a non-uniform scale, not the mean', () => {
+    // The specification's wording is the LARGEST factor. A mean would give 3.
+    expect(largestScale(S(2, 3, 4))).toBe(4);
+  });
+
+  it('is 1 under a pure rotation, which changes no length', () => {
+    expect(largestScale(Rz(0.7))).toBeCloseTo(1, 12);
+  });
+
+  it('ignores translation, which scales nothing', () => {
+    expect(largestScale(T(1000, -2000, 3000))).toBe(1);
+  });
+
+  it('scales geometric error by that factor', () => {
+    expect(transformGeometricError(S(2, 3, 4), 10)).toBe(40);
+    expect(transformGeometricError(IDENTITY_4X4, 10)).toBe(10);
+  });
+});
+
+describe('box volumes', () => {
+  it('moves the centre and leaves the half-axes alone under translation', () => {
+    const box = [0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3];
+    expect(transformBox(T(10, 20, 30), box)).toEqual([
+      10, 20, 30,
+      1, 0, 0,
+      0, 2, 0,
+      0, 0, 3,
+    ]);
+  });
+
+  it('scales each half-axis independently under a non-uniform scale', () => {
+    const box = [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1];
+    expect(transformBox(S(2, 3, 4), box)).toEqual([
+      0, 0, 0,
+      2, 0, 0,
+      0, 3, 0,
+      0, 0, 4,
+    ]);
+  });
+
+  it('rotates the half-axes with the box', () => {
+    const box = [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1];
+    const out = transformBox(Rz(Math.PI / 2), box);
+    expect(out[3]).toBeCloseTo(0, 12);
+    expect(out[4]).toBeCloseTo(1, 12);
+    expect(out[6]).toBeCloseTo(-1, 12);
+    expect(out[7]).toBeCloseTo(0, 12);
+  });
+});
+
+describe('sphere volumes', () => {
+  it('moves the centre and keeps the radius under translation', () => {
+    expect(transformSphere(T(1, 2, 3), [0, 0, 0, 5])).toEqual([1, 2, 3, 5]);
+  });
+
+  it('grows the radius by the largest factor, so it still encloses the shape', () => {
+    // Under a 2/3/4 scale the sphere becomes an ellipsoid; the enclosing sphere
+    // takes the longest semi-axis. Taking anything smaller would cull geometry
+    // that is really inside.
+    expect(transformSphere(S(2, 3, 4), [0, 0, 0, 1])).toEqual([0, 0, 0, 4]);
+  });
+});
+
+describe('the region exemption', () => {
+  it('leaves a region untouched, because it is already EPSG:4979', () => {
+    const region = [-0.1, 0.5, 0.1, 0.6, 0, 100];
+    const out = transformBoundingVolume(S(2, 3, 4), { region });
+    expect(out.region).toEqual(region);
+    expect(out.box).toBeUndefined();
+    expect(out.sphere).toBeUndefined();
+  });
+
+  it('transforms a box and a sphere in the same volume while sparing the region', () => {
+    const out = transformBoundingVolume(T(10, 0, 0), {
+      box: [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1],
+      sphere: [0, 0, 0, 2],
+      region: [0, 0, 1, 1, 0, 10],
+    });
+    expect(out.box?.slice(0, 3)).toEqual([10, 0, 0]);
+    expect(out.sphere).toEqual([10, 0, 0, 2]);
+    expect(out.region).toEqual([0, 0, 1, 1, 0, 10]);
+  });
+
+  it('does not mutate the volume it was given', () => {
+    const volume = { box: [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1] };
+    const before = [...volume.box];
+    transformBoundingVolume(S(9, 9, 9), volume);
+    expect(volume.box).toEqual(before);
+  });
+});
+
+describe('identity detection', () => {
+  it('recognises the identity and rejects a translation', () => {
+    expect(isIdentityTransform(IDENTITY_4X4)).toBe(true);
+    expect(isIdentityTransform(T(0, 0, 1e-9))).toBe(false);
+  });
+
+  it('accepts a near-identity only when an epsilon allows it', () => {
+    expect(isIdentityTransform(T(0, 0, 1e-9), 1e-6)).toBe(true);
+  });
+});
+
+describe('a worked tileset path, end to end', () => {
+  it('places a leaf point and scales its error through three levels', () => {
+    // Root translates 1000 east. Middle rotates a quarter turn about Z.
+    // Leaf scales by 2. A leaf-local point at (1, 0, 0):
+    //   scale  -> (2, 0, 0)
+    //   rotate -> (0, 2, 0)
+    //   move   -> (1000, 2, 0)
+    const m = cumulativeTransform([T(1000, 0, 0), Rz(Math.PI / 2), S(2, 2, 2)]);
+    const [x, y, z] = transformPoint(m, [1, 0, 0]);
+    expect(x).toBeCloseTo(1000, 9);
+    expect(y).toBeCloseTo(2, 9);
+    expect(z).toBeCloseTo(0, 9);
+
+    // Rotation and translation scale nothing, so the error doubles once.
+    expect(transformGeometricError(m, 16)).toBeCloseTo(32, 9);
+  });
+});
+
+describe('walking a tileset top-down', () => {
+  /** A minimal tile; only the fields the walk reads are set. */
+  const tile = (over: Partial<Tile> = {}): Tile => ({
+    boundingVolume: { box: [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1] },
+    geometricError: 16,
+    refine: 'REPLACE',
+    transform: null,
+    contentUri: null,
+    children: [],
+    ...over,
+  });
+
+  it('accumulates the transform as it descends, so a leaf sees the whole chain', () => {
+    const leaf = tile({ transform: S(2, 2, 2) });
+    const mid = tile({ transform: Rz(Math.PI / 2), children: [leaf] });
+    const root = tile({ transform: T(1000, 0, 0), children: [mid] });
+
+    const placed = [...walkTilePlacements(root)];
+    expect(placed).toHaveLength(3);
+    expect(placed.map((p) => p.depth)).toEqual([0, 1, 2]);
+
+    // Same chain as the worked example above: scale, rotate, translate.
+    const [x, y] = transformPoint(placed[2]!.transform, [1, 0, 0]);
+    expect(x).toBeCloseTo(1000, 9);
+    expect(y).toBeCloseTo(2, 9);
+  });
+
+  it('scales each tile geometric error by its own cumulative transform', () => {
+    const leaf = tile({ geometricError: 4, transform: S(2, 2, 2) });
+    const root = tile({ geometricError: 16, transform: S(3, 3, 3), children: [leaf] });
+    const placed = [...walkTilePlacements(root)];
+    expect(placed[0]!.geometricError).toBeCloseTo(48, 9); // 16 * 3
+    expect(placed[1]!.geometricError).toBeCloseTo(24, 9); // 4 * 3 * 2
+  });
+
+  it('yields children in authored order', () => {
+    const a = tile({ geometricError: 1 });
+    const b = tile({ geometricError: 2 });
+    const c = tile({ geometricError: 3 });
+    const root = tile({ geometricError: 9, children: [a, b, c] });
+    const errors = [...walkTilePlacements(root)].slice(1).map((p) => p.geometricError);
+    expect(errors).toEqual([1, 2, 3]);
+  });
+
+  it('spares a region while transforming a box on a sibling', () => {
+    const regional = tile({ boundingVolume: { region: [0, 0, 1, 1, 0, 10] } });
+    const boxed = tile({ boundingVolume: { box: [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1] } });
+    const root = tile({ transform: T(50, 0, 0), children: [regional, boxed] });
+    const placed = [...walkTilePlacements(root)];
+    expect(placed[1]!.boundingVolume.region).toEqual([0, 0, 1, 1, 0, 10]);
+    expect(placed[2]!.boundingVolume.box?.slice(0, 3)).toEqual([50, 0, 0]);
+  });
+
+  it('passes a tile without a transform straight through', () => {
+    const leaf = tile();
+    const root = tile({ transform: T(7, 0, 0), children: [leaf] });
+    const placed = [...walkTilePlacements(root)];
+    expect(placed[1]!.transform).toEqual(placed[0]!.transform);
+  });
+});


### PR DESCRIPTION
`tileset.ts` checked that a transform was sixteen finite numbers and stopped there. Nothing turned one into a placement, so a tile carrying a transform parsed cleanly and landed wherever its local coordinates happened to fall.

`walkTilePlacements` descends the tree carrying the product, which is the shape §7.4 asks for, and resolves each tile's bounding volume and geometric error into root space as it goes.

Three things the specification is specific about and a plausible implementation gets wrong:

- **Composition is parent times child.** A translate-then-scale differs from a scale-then-translate, and inverting the order still yields a finite, invertible matrix. Four cases fail when it is inverted, which I checked by inverting it.
- **A `region` is EPSG:4979 and is carried through untouched.** Multiplying degrees by a metre transform produces a volume in no coordinate system at all.
- **Geometric error and sphere radius take the largest scaling factor, not the mean.** A non-uniform scale must never shrink a bound, because a bound that is too small culls geometry that should have been drawn and reads as a decoder bug rather than a bounds bug.

Every expected value is worked by hand from the construction rather than read back from the code. 31 tests.
