### PR TITLE
Bound the three 3D Tiles volume kinds conservatively

### DIFF
--- a/src/io/tiles3d/boundingVolume.ts
+++ b/src/io/tiles3d/boundingVolume.ts
@@ -1,0 +1,301 @@
+/**
+ * boundingVolume.ts — 3D Tiles bounding volumes turned into usable geometry.
+ *
+ * `tileset.ts` parses the three volume forms and `tileTransform.ts` moves the
+ * two Cartesian ones through a tile transform. What a culler actually needs is
+ * one step further on: the corners of an oriented box, a conservative
+ * axis-aligned bound for any of the three forms, and an honest "is the camera
+ * inside this volume" test.
+ *
+ * The one subtle case is `region`. A region is a curved patch of the WGS84
+ * ellipsoid, and the hull of its eight geographic corners does NOT contain it:
+ * the surface bulges outward between the corners, so a corner-only AABB
+ * under-bounds the volume and culls tiles that are on screen. See
+ * `regionToAabb` for the method used instead.
+ *
+ * Pure: no fetch, no DOM, no renderer types. Float64 throughout.
+ */
+
+export interface Aabb {
+  readonly min: readonly [number, number, number];
+  readonly max: readonly [number, number, number];
+}
+
+/** WGS84 semi-major axis, metres. */
+export const WGS84_A = 6378137.0;
+/** WGS84 inverse flattening. */
+export const WGS84_INV_F = 298.257223563;
+/** WGS84 flattening. */
+export const WGS84_F = 1 / WGS84_INV_F;
+/** WGS84 first eccentricity squared, e2 = f * (2 - f). */
+export const WGS84_E2 = WGS84_F * (2 - WGS84_F);
+/** WGS84 semi-minor axis, metres. */
+export const WGS84_B = WGS84_A * (1 - WGS84_F);
+
+const TWO_PI = Math.PI * 2;
+
+/**
+ * The eight corners of an oriented bounding box.
+ *
+ * The twelve numbers are centre(3) then three half-axis VECTORS, not three
+ * half-extents: the axes may be rotated and need not be orthogonal. Corners are
+ * therefore centre ± xHalf ± yHalf ± zHalf over all eight sign combinations,
+ * and reading the twelve values as an axis-aligned min/max would silently drop
+ * every rotation.
+ */
+export function boxCorners(box: readonly number[]): [number, number, number][] {
+  const cx = box[0]!, cy = box[1]!, cz = box[2]!;
+  const ax = box[3]!, ay = box[4]!, az = box[5]!;
+  const bx = box[6]!, by = box[7]!, bz = box[8]!;
+  const dx = box[9]!, dy = box[10]!, dz = box[11]!;
+
+  const out: [number, number, number][] = [];
+  for (const sa of [-1, 1]) {
+    for (const sb of [-1, 1]) {
+      for (const sd of [-1, 1]) {
+        out.push([
+          cx + sa * ax + sb * bx + sd * dx,
+          cy + sa * ay + sb * by + sd * dy,
+          cz + sa * az + sb * bz + sd * dz,
+        ]);
+      }
+    }
+  }
+  return out;
+}
+
+/** Axis-aligned bounds of a point set. Throws on an empty set: there is no answer. */
+export function aabbFromPoints(points: readonly (readonly number[])[]): Aabb {
+  if (points.length === 0) throw new Error('aabbFromPoints: no points.');
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  for (const p of points) {
+    for (let i = 0; i < 3; i++) {
+      const v = p[i]!;
+      if (v < min[i]!) min[i] = v;
+      if (v > max[i]!) max[i] = v;
+    }
+  }
+  return { min, max };
+}
+
+/** Axis-aligned bounds of an oriented box: its corners, then their extent. */
+export function boxToAabb(box: readonly number[]): Aabb {
+  return aabbFromPoints(boxCorners(box));
+}
+
+/** Axis-aligned bounds of `[cx, cy, cz, radius]`. */
+export function sphereToAabb(sphere: readonly number[]): Aabb {
+  const [cx, cy, cz, r] = [sphere[0]!, sphere[1]!, sphere[2]!, Math.abs(sphere[3]!)];
+  return { min: [cx - r, cy - r, cz - r], max: [cx + r, cy + r, cz + r] };
+}
+
+/** Geodetic (radians, metres) to ECEF metres on the WGS84 ellipsoid. */
+export function geodeticToEcef(lon: number, lat: number, h: number): [number, number, number] {
+  const sinLat = Math.sin(lat);
+  const cosLat = Math.cos(lat);
+  const n = WGS84_A / Math.sqrt(1 - WGS84_E2 * sinLat * sinLat);
+  return [
+    (n + h) * cosLat * Math.cos(lon),
+    (n + h) * cosLat * Math.sin(lon),
+    (n * (1 - WGS84_E2) + h) * sinLat,
+  ];
+}
+
+export interface RegionAabbOptions {
+  /**
+   * Upper bound on the angular step between samples, radians. Smaller is
+   * tighter and slower; the outward pad shrinks with the square of it.
+   */
+  readonly maxStep?: number;
+  /** Hard cap on samples per axis, so a whole-globe region stays cheap. */
+  readonly maxSamplesPerAxis?: number;
+}
+
+/** Half a degree. Fine enough that the pad below stays around a hundred metres. */
+const DEFAULT_MAX_STEP = (0.5 * Math.PI) / 180;
+const DEFAULT_MAX_SAMPLES_PER_AXIS = 512;
+
+/**
+ * A conservative ECEF axis-aligned bound for a `region` volume.
+ *
+ * `region` is `[west, south, east, north, minHeight, maxHeight]`, longitude and
+ * latitude in radians on WGS84 / EPSG:4979, heights in metres. `west > east`
+ * means the region crosses the antimeridian and is handled by unwrapping east
+ * forward by 2*pi rather than by splitting the region in two.
+ *
+ * METHOD: dense grid sampling of the two bounding height surfaces, plus a
+ * closed-form outward pad.
+ *
+ * Why not corners. Every ECEF coordinate of the surface is, along a line of
+ * constant latitude, a sinusoid in longitude; along a meridian it is a smooth
+ * curve in latitude. Both bulge away from the chord between their endpoints, so
+ * the extreme of a coordinate generally falls in the INTERIOR of the patch, not
+ * at a corner. A 90-degree-wide equatorial region is the blunt example: its
+ * corners reach x = R*cos(45deg), while the region itself reaches x = R. A
+ * corner-only AABB would be short by nearly a third of the Earth's radius.
+ *
+ * Why this is conservative. Only the two extreme heights are sampled because
+ * every ECEF coordinate is monotone in h at fixed (lon, lat) — the h terms
+ * enter as (N + h)*cos(lat)*cos(lon), (N + h)*cos(lat)*sin(lon) and
+ * (N*(1-e2) + h)*sin(lat), each linear in h — so no interior height can exceed
+ * both surfaces. Across one grid cell of angular width `step`, each coordinate
+ * is a C2 function of the angle whose second derivative is bounded in magnitude
+ * by the maximum geocentric radius R = a + max(0, maxHeight), so its excursion
+ * beyond the values at the cell endpoints is at most R * step^2 / 8 per angular
+ * axis. The returned bound is the sampled extent grown outward by twice that,
+ * once for longitude and once for latitude, with a further factor of two of
+ * headroom for the latitude dependence of the prime-vertical radius N. The
+ * result is an over-bound, never an under-bound, which is the only direction
+ * that is safe for culling.
+ */
+export function regionToAabb(region: readonly number[], opts: RegionAabbOptions = {}): Aabb {
+  const west = region[0]!;
+  const south = region[1]!;
+  let east = region[2]!;
+  const north = region[3]!;
+  const minHeight = region[4]!;
+  const maxHeight = region[5]!;
+
+  // Antimeridian crossing: unwrap east forward so the span is positive.
+  if (east < west) east += TWO_PI;
+
+  const lonSpan = east - west;
+  const latSpan = north - south;
+
+  const maxStep = opts.maxStep ?? DEFAULT_MAX_STEP;
+  const cap = opts.maxSamplesPerAxis ?? DEFAULT_MAX_SAMPLES_PER_AXIS;
+  const divisions = (span: number): number =>
+    Math.min(cap, Math.max(1, Math.ceil(Math.abs(span) / maxStep)));
+
+  const nLon = divisions(lonSpan);
+  const nLat = divisions(latSpan);
+
+  const heights = minHeight === maxHeight ? [minHeight] : [minHeight, maxHeight];
+
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+
+  for (let i = 0; i <= nLon; i++) {
+    const lon = west + (lonSpan * i) / nLon;
+    for (let j = 0; j <= nLat; j++) {
+      const lat = south + (latSpan * j) / nLat;
+      for (const h of heights) {
+        const p = geodeticToEcef(lon, lat, h);
+        for (let k = 0; k < 3; k++) {
+          if (p[k]! < min[k]!) min[k] = p[k]!;
+          if (p[k]! > max[k]!) max[k] = p[k]!;
+        }
+      }
+    }
+  }
+
+  const radius = WGS84_A + Math.max(0, maxHeight);
+  const lonStep = Math.abs(lonSpan) / nLon;
+  const latStep = Math.abs(latSpan) / nLat;
+  // R * step^2 / 8 per axis, doubled for the N(lat) dependence.
+  const pad = (radius * (lonStep * lonStep + latStep * latStep)) / 4;
+
+  return {
+    min: [min[0]! - pad, min[1]! - pad, min[2]! - pad],
+    max: [max[0]! + pad, max[1]! + pad, max[2]! + pad],
+  };
+}
+
+/**
+ * Whether a point lies inside an oriented box.
+ *
+ * Projection onto each half-axis, not an AABB test: for a rotated box the AABB
+ * is strictly larger, so an AABB test reports "inside" for points that are
+ * outside the box. Degenerate (zero-length) half-axes are treated as flat, so a
+ * point must lie exactly on that axis's plane.
+ */
+export function pointInBox(box: readonly number[], p: readonly number[], epsilon = 0): boolean {
+  const d = [p[0]! - box[0]!, p[1]! - box[1]!, p[2]! - box[2]!];
+  for (let axis = 0; axis < 3; axis++) {
+    const o = 3 + axis * 3;
+    const ax = box[o]!, ay = box[o + 1]!, az = box[o + 2]!;
+    const lenSq = ax * ax + ay * ay + az * az;
+    const dot = d[0]! * ax + d[1]! * ay + d[2]! * az;
+    if (lenSq === 0) {
+      if (Math.abs(dot) > epsilon) return false;
+      continue;
+    }
+    // |dot| / |axis| is the distance along the axis; compare against |axis|.
+    if (Math.abs(dot) > lenSq + epsilon * Math.sqrt(lenSq)) return false;
+  }
+  return true;
+}
+
+/** Whether a point lies inside `[cx, cy, cz, radius]`. */
+export function pointInSphere(
+  sphere: readonly number[],
+  p: readonly number[],
+  epsilon = 0,
+): boolean {
+  const dx = p[0]! - sphere[0]!;
+  const dy = p[1]! - sphere[1]!;
+  const dz = p[2]! - sphere[2]!;
+  const r = Math.abs(sphere[3]!) + epsilon;
+  return dx * dx + dy * dy + dz * dz <= r * r;
+}
+
+/**
+ * ECEF to geodetic (lon, lat in radians, h in metres) by Bowring's method.
+ *
+ * Closed form and accurate to well under a millimetre for heights anywhere near
+ * the ellipsoid, which is the regime a 3D Tiles region lives in.
+ */
+export function ecefToGeodetic(p: readonly number[]): [number, number, number] {
+  const x = p[0]!, y = p[1]!, z = p[2]!;
+  const lon = Math.atan2(y, x);
+  const r = Math.hypot(x, y);
+  if (r === 0) {
+    // On the spin axis: latitude is a pole and longitude is arbitrary.
+    const sign = z >= 0 ? 1 : -1;
+    return [lon, (sign * Math.PI) / 2, Math.abs(z) - WGS84_B];
+  }
+  const ep2 = (WGS84_A * WGS84_A - WGS84_B * WGS84_B) / (WGS84_B * WGS84_B);
+  const theta = Math.atan2(z * WGS84_A, r * WGS84_B);
+  const lat = Math.atan2(
+    z + ep2 * WGS84_B * Math.sin(theta) ** 3,
+    r - WGS84_E2 * WGS84_A * Math.cos(theta) ** 3,
+  );
+  const sinLat = Math.sin(lat);
+  const n = WGS84_A / Math.sqrt(1 - WGS84_E2 * sinLat * sinLat);
+  const h = r / Math.cos(lat) - n;
+  return [lon, lat, h];
+}
+
+/**
+ * Whether an ECEF point lies inside a `region` volume.
+ *
+ * Longitude is compared as an offset forward from `west`, so an antimeridian
+ * crossing needs no special case beyond the unwrap.
+ */
+export function pointInRegion(
+  region: readonly number[],
+  p: readonly number[],
+  epsilon = 0,
+): boolean {
+  const west = region[0]!;
+  const south = region[1]!;
+  let east = region[2]!;
+  const north = region[3]!;
+  const minHeight = region[4]!;
+  const maxHeight = region[5]!;
+  if (east < west) east += TWO_PI;
+
+  const [lon, lat, h] = ecefToGeodetic(p);
+  if (h < minHeight - epsilon || h > maxHeight + epsilon) return false;
+  if (lat < south - epsilon || lat > north + epsilon) return false;
+
+  const span = east - west;
+  if (span >= TWO_PI) return true;
+  let offset = (lon - west) % TWO_PI;
+  if (offset < 0) offset += TWO_PI;
+  // A point just west of `west` wraps to nearly 2*pi; fold it back so the
+  // epsilon tolerance still applies at that edge.
+  if (offset > span && offset >= TWO_PI - epsilon) offset -= TWO_PI;
+  return offset >= -epsilon && offset <= span + epsilon;
+}

--- a/tests/tiles3dBoundingVolume.test.ts
+++ b/tests/tiles3dBoundingVolume.test.ts
@@ -1,0 +1,408 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aabbFromPoints,
+  boxCorners,
+  boxToAabb,
+  ecefToGeodetic,
+  geodeticToEcef,
+  pointInBox,
+  pointInRegion,
+  pointInSphere,
+  regionToAabb,
+  sphereToAabb,
+  WGS84_A,
+  WGS84_B,
+  type Aabb,
+} from '../src/io/tiles3d/boundingVolume';
+
+const DEG = Math.PI / 180;
+
+/** Sort corners so a hand-written expected set can be compared order-free. */
+function sortPoints(points: readonly (readonly number[])[]): number[][] {
+  return points
+    .map((p) => [p[0]!, p[1]!, p[2]!])
+    .sort((a, b) => a[0]! - b[0]! || a[1]! - b[1]! || a[2]! - b[2]!);
+}
+
+function expectPointsClose(actual: readonly (readonly number[])[], expected: number[][], tol: number) {
+  const a = sortPoints(actual);
+  const e = sortPoints(expected);
+  expect(a).toHaveLength(e.length);
+  for (let i = 0; i < e.length; i++) {
+    for (let k = 0; k < 3; k++) expect(a[i]![k]!).toBeCloseTo(e[i]![k]!, tol);
+  }
+}
+
+function inside(aabb: Aabb, p: readonly number[], tol: number): boolean {
+  for (let k = 0; k < 3; k++) {
+    if (p[k]! < aabb.min[k]! - tol) return false;
+    if (p[k]! > aabb.max[k]! + tol) return false;
+  }
+  return true;
+}
+
+describe('boxCorners', () => {
+  it('gives the eight corners of an axis-aligned box', () => {
+    // Centre (10, 20, 30), half-extents 1, 2, 3 written as axis-aligned half-axes.
+    const box = [10, 20, 30, 1, 0, 0, 0, 2, 0, 0, 0, 3];
+    const expected: number[][] = [];
+    for (const x of [9, 11]) for (const y of [18, 22]) for (const z of [27, 33]) expected.push([x, y, z]);
+    expectPointsClose(boxCorners(box), expected, 10);
+  });
+
+  it('gives the corners of a box rotated 45 degrees about z', () => {
+    const c = Math.SQRT1_2; // cos(45deg) = sin(45deg)
+    // Unit-length half-axes at +45 and +135 degrees, unit half-axis on z.
+    const box = [0, 0, 0, c, c, 0, -c, c, 0, 0, 0, 1];
+    // centre +- (c,c,0) +- (-c,c,0) gives (0, +-sqrt2, 0) and (+-sqrt2, 0, 0).
+    const s = Math.SQRT2;
+    const expected: number[][] = [];
+    for (const [x, y] of [
+      [s, 0],
+      [-s, 0],
+      [0, s],
+      [0, -s],
+    ]) {
+      for (const z of [-1, 1]) expected.push([x!, y!, z]);
+    }
+    expectPointsClose(boxCorners(box), expected, 10);
+  });
+
+  it('gives the corners of a box with non-uniform half-axes', () => {
+    const box = [1, 1, 1, 2, 0, 0, 0, 5, 0, 0, 0, 0.5];
+    const expected: number[][] = [];
+    for (const x of [-1, 3]) for (const y of [-4, 6]) for (const z of [0.5, 1.5]) expected.push([x, y, z]);
+    expectPointsClose(boxCorners(box), expected, 10);
+  });
+
+  it('is not an axis-aligned reading of the twelve numbers', () => {
+    const c = Math.SQRT1_2;
+    const box = [0, 0, 0, c, c, 0, -c, c, 0, 0, 0, 1];
+    // A naive centre +- (halfAxis components as extents) reading would return
+    // x in [-c, c] = [-0.7071, 0.7071]; the real corners reach sqrt(2).
+    const xs = boxCorners(box).map((p) => p[0]!);
+    expect(Math.max(...xs)).toBeCloseTo(Math.SQRT2, 10);
+    expect(Math.max(...xs)).toBeGreaterThan(c + 0.5);
+  });
+});
+
+describe('aabbFromPoints', () => {
+  it('bounds a hand-written point set', () => {
+    const aabb = aabbFromPoints([
+      [1, -2, 3],
+      [-4, 5, 0],
+      [0, 0, -6],
+    ]);
+    expect(aabb.min).toEqual([-4, -2, -6]);
+    expect(aabb.max).toEqual([1, 5, 3]);
+  });
+
+  it('bounds a single point to itself', () => {
+    const aabb = aabbFromPoints([[7, 8, 9]]);
+    expect(aabb.min).toEqual([7, 8, 9]);
+    expect(aabb.max).toEqual([7, 8, 9]);
+  });
+
+  it('refuses an empty set', () => {
+    expect(() => aabbFromPoints([])).toThrow(/no points/i);
+  });
+});
+
+describe('boxToAabb', () => {
+  it('bounds an axis-aligned box exactly', () => {
+    const aabb = boxToAabb([10, 20, 30, 1, 0, 0, 0, 2, 0, 0, 0, 3]);
+    expect(aabb.min).toEqual([9, 18, 27]);
+    expect(aabb.max).toEqual([11, 22, 33]);
+  });
+
+  it('grows to sqrt(2) for a box rotated 45 degrees', () => {
+    const c = Math.SQRT1_2;
+    const aabb = boxToAabb([0, 0, 0, c, c, 0, -c, c, 0, 0, 0, 1]);
+    for (const k of [0, 1]) {
+      expect(aabb.min[k]!).toBeCloseTo(-Math.SQRT2, 10);
+      expect(aabb.max[k]!).toBeCloseTo(Math.SQRT2, 10);
+    }
+    expect(aabb.min[2]!).toBeCloseTo(-1, 10);
+    expect(aabb.max[2]!).toBeCloseTo(1, 10);
+  });
+
+  it('bounds non-uniform half-axes', () => {
+    const aabb = boxToAabb([1, 1, 1, 2, 0, 0, 0, 5, 0, 0, 0, 0.5]);
+    expect(aabb.min).toEqual([-1, -4, 0.5]);
+    expect(aabb.max).toEqual([3, 6, 1.5]);
+  });
+});
+
+describe('sphereToAabb', () => {
+  it('bounds a sphere by centre plus and minus radius', () => {
+    const aabb = sphereToAabb([1, 2, 3, 4]);
+    expect(aabb.min).toEqual([-3, -2, -1]);
+    expect(aabb.max).toEqual([5, 6, 7]);
+  });
+});
+
+describe('geodeticToEcef', () => {
+  it('places the prime-meridian equator point at (a, 0, 0)', () => {
+    const p = geodeticToEcef(0, 0, 0);
+    expect(p[0]!).toBeCloseTo(WGS84_A, 6);
+    expect(p[1]!).toBeCloseTo(0, 6);
+    expect(p[2]!).toBeCloseTo(0, 6);
+  });
+
+  it('places the north pole at (0, 0, b)', () => {
+    const p = geodeticToEcef(0, Math.PI / 2, 0);
+    expect(Math.hypot(p[0]!, p[1]!)).toBeLessThan(1e-6);
+    expect(p[2]!).toBeCloseTo(WGS84_B, 6);
+  });
+
+  it('adds height along the ellipsoid normal at the equator', () => {
+    const p = geodeticToEcef(0, 0, 1000);
+    expect(p[0]!).toBeCloseTo(WGS84_A + 1000, 6);
+  });
+
+  it('round-trips through ecefToGeodetic', () => {
+    for (const lat of [-80, -30, 0, 17, 62, 89].map((d) => d * DEG)) {
+      for (const lon of [-179, -90, 0, 45, 179].map((d) => d * DEG)) {
+        for (const h of [-500, 0, 12000]) {
+          const [rlon, rlat, rh] = ecefToGeodetic(geodeticToEcef(lon, lat, h));
+          expect(rlon).toBeCloseTo(lon, 9);
+          expect(rlat).toBeCloseTo(lat, 9);
+          expect(rh).toBeCloseTo(h, 4);
+        }
+      }
+    }
+  });
+});
+
+/**
+ * The dense-surface proof. Every sample of a region's two bounding height
+ * surfaces must lie inside the returned AABB.
+ */
+const SURFACE_STEPS = 40; // 41 x 41 samples per height surface.
+let totalSurfaceSamples = 0;
+
+function assertContainsSurface(region: readonly number[], tol = 1e-6): number {
+  const aabb = regionToAabb(region);
+  const west = region[0]!;
+  const south = region[1]!;
+  let east = region[2]!;
+  const north = region[3]!;
+  if (east < west) east += Math.PI * 2;
+  const lonSpan = east - west;
+  const latSpan = north - south;
+  let count = 0;
+  for (let i = 0; i <= SURFACE_STEPS; i++) {
+    const lon = west + (lonSpan * i) / SURFACE_STEPS;
+    for (let j = 0; j <= SURFACE_STEPS; j++) {
+      const lat = south + (latSpan * j) / SURFACE_STEPS;
+      for (const h of [region[4]!, region[5]!]) {
+        const p = geodeticToEcef(lon, lat, h);
+        count++;
+        if (!inside(aabb, p, tol)) {
+          throw new Error(
+            `sample lon=${lon} lat=${lat} h=${h} -> ${p.join(',')} outside ${JSON.stringify(aabb)}`,
+          );
+        }
+      }
+    }
+  }
+  totalSurfaceSamples += count;
+  return count;
+}
+
+describe('regionToAabb dense-surface containment', () => {
+  const cases: { name: string; region: number[] }[] = [
+    { name: 'equator', region: [-5 * DEG, -5 * DEG, 5 * DEG, 5 * DEG, 0, 100] },
+    { name: 'mid latitude', region: [8 * DEG, 40 * DEG, 12 * DEG, 44 * DEG, -50, 2500] },
+    { name: 'high latitude', region: [20 * DEG, 78 * DEG, 30 * DEG, 84 * DEG, 0, 1000] },
+    { name: 'antimeridian crossing', region: [175 * DEG, -20 * DEG, -175 * DEG, -10 * DEG, 0, 500] },
+    { name: 'tall height range', region: [-70 * DEG, -20 * DEG, -68 * DEG, -18 * DEG, -400, 9000] },
+    { name: 'large longitude span', region: [-45 * DEG, -10 * DEG, 45 * DEG, 10 * DEG, 0, 200] },
+  ];
+
+  for (const { name, region } of cases) {
+    it(`contains every surface sample: ${name}`, () => {
+      const n = assertContainsSurface(region);
+      expect(n).toBe((SURFACE_STEPS + 1) * (SURFACE_STEPS + 1) * 2);
+    });
+
+    it(`stays a plausible size: ${name}`, () => {
+      const aabb = regionToAabb(region);
+      const limit = WGS84_A + Math.max(0, region[5]!) + 200000;
+      for (let k = 0; k < 3; k++) {
+        expect(aabb.max[k]! - aabb.min[k]!).toBeLessThanOrEqual(2 * limit);
+        expect(Number.isFinite(aabb.min[k]!)).toBe(true);
+        expect(Number.isFinite(aabb.max[k]!)).toBe(true);
+      }
+    });
+  }
+
+  it('verifies a known total number of surface samples', () => {
+    // 6 regions x 41 x 41 x 2 height surfaces.
+    expect(totalSurfaceSamples).toBe(cases.length * 41 * 41 * 2);
+  });
+});
+
+describe('regionToAabb against a corner-only bound', () => {
+  it('reaches the equatorial bulge that a corner-only AABB misses', () => {
+    // 90 degrees of longitude at the equator, on the ellipsoid.
+    const region = [-45 * DEG, 0, 45 * DEG, 0, 0, 0];
+    // Hand-computed: the region's own x extreme is at lon = 0, x = a.
+    // Its eight geographic corners only reach x = a * cos(45deg).
+    const cornerMaxX = WGS84_A * Math.SQRT1_2;
+    const cornerAabb = aabbFromPoints([
+      geodeticToEcef(-45 * DEG, 0, 0),
+      geodeticToEcef(45 * DEG, 0, 0),
+    ]);
+    expect(cornerAabb.max[0]!).toBeCloseTo(cornerMaxX, 6);
+
+    const bulge = geodeticToEcef(0, 0, 0);
+    expect(bulge[0]!).toBeCloseTo(WGS84_A, 6);
+
+    // The corner-only bound EXCLUDES a real point of the region: this is why
+    // the corner method was rejected.
+    expect(inside(cornerAabb, bulge, 1e-6)).toBe(false);
+    expect(WGS84_A - cornerAabb.max[0]!).toBeGreaterThan(1.8e6);
+
+    // The sampled bound contains it.
+    const aabb = regionToAabb(region);
+    expect(inside(aabb, bulge, 0)).toBe(true);
+    expect(aabb.max[0]!).toBeGreaterThanOrEqual(WGS84_A);
+  });
+
+  it('reaches the pole for a region whose north edge is the pole', () => {
+    const region = [0, 85 * DEG, 90 * DEG, Math.PI / 2, 0, 0];
+    const aabb = regionToAabb(region);
+    // Hand-computed: the north pole on WGS84 sits at z = b.
+    expect(aabb.max[2]!).toBeGreaterThanOrEqual(WGS84_B);
+  });
+
+  it('handles an antimeridian region by unwrapping, not by ignoring it', () => {
+    const region = [179 * DEG, -1 * DEG, -179 * DEG, 1 * DEG, 0, 0];
+    const aabb = regionToAabb(region);
+    // Hand-computed: lon = 180deg, lat = 0, h = 0 gives x = -a, y = 0.
+    const p = geodeticToEcef(Math.PI, 0, 0);
+    expect(p[0]!).toBeCloseTo(-WGS84_A, 6);
+    expect(inside(aabb, p, 0)).toBe(true);
+    // A wrapped reading (west..east taken as -179..179) would span the far side
+    // of the globe and reach x = +a. This bound does not.
+    expect(aabb.max[0]!).toBeLessThan(0);
+  });
+
+  it('bounds a degenerate point region to that point', () => {
+    const region = [0, 0, 0, 0, 0, 0];
+    const aabb = regionToAabb(region);
+    expect(aabb.min[0]!).toBeCloseTo(WGS84_A, 6);
+    expect(aabb.max[0]!).toBeCloseTo(WGS84_A, 6);
+    expect(aabb.min[1]!).toBeCloseTo(0, 6);
+    expect(aabb.max[2]!).toBeCloseTo(0, 6);
+  });
+});
+
+describe('pointInBox', () => {
+  const c = Math.SQRT1_2;
+  const rotated = [0, 0, 0, c, c, 0, -c, c, 0, 0, 0, 1];
+
+  it('accepts the centre and rejects a far point', () => {
+    expect(pointInBox(rotated, [0, 0, 0])).toBe(true);
+    expect(pointInBox(rotated, [10, 0, 0])).toBe(false);
+  });
+
+  it('uses half-axis projection, not the AABB', () => {
+    // The rotated box's AABB reaches x = sqrt(2) = 1.4142, but along +x the box
+    // itself only reaches x = 1 (projection onto each unit half-axis is c*x,
+    // and c * 1 = 0.7071 <= 1 while c * 1.2 = 0.8485 <= 1, c * 1.5 = 1.0607 > 1).
+    expect(pointInBox(rotated, [1.2, 0, 0])).toBe(true);
+    expect(pointInBox(rotated, [1.5, 0, 0])).toBe(false);
+    // (1.3, 1.3, 0) is outside the box (projection onto the first half-axis is
+    // c*1.3 + c*1.3 = 1.838 > 1) but inside its AABB, whose x and y both reach
+    // sqrt(2) = 1.4142. An AABB test would wrongly accept it.
+    expect(pointInBox(rotated, [1.3, 1.3, 0])).toBe(false);
+    expect(inside(boxToAabb(rotated), [1.3, 1.3, 0], 0)).toBe(true);
+  });
+
+  it('accepts a corner and rejects just past it', () => {
+    expect(pointInBox(rotated, [Math.SQRT2, 0, 1], 1e-12)).toBe(true);
+    expect(pointInBox(rotated, [Math.SQRT2 + 1e-3, 0, 1])).toBe(false);
+  });
+
+  it('respects non-uniform half-axes per axis', () => {
+    const box = [1, 1, 1, 2, 0, 0, 0, 5, 0, 0, 0, 0.5];
+    expect(pointInBox(box, [2.9, 5.9, 1.4])).toBe(true);
+    expect(pointInBox(box, [3.1, 0, 1])).toBe(false);
+    expect(pointInBox(box, [1, 6.1, 1])).toBe(false);
+    expect(pointInBox(box, [1, 1, 1.6])).toBe(false);
+  });
+
+  it('treats a zero-length half-axis as a flat slab', () => {
+    const flat = [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0];
+    expect(pointInBox(flat, [0.5, 0.5, 0])).toBe(true);
+    expect(pointInBox(flat, [0.5, 0.5, 0.1])).toBe(true); // z axis is degenerate: dot is 0.
+  });
+});
+
+describe('pointInSphere', () => {
+  it('accepts inside, boundary and rejects outside', () => {
+    const sphere = [1, 2, 3, 5];
+    expect(pointInSphere(sphere, [1, 2, 3])).toBe(true);
+    expect(pointInSphere(sphere, [6, 2, 3])).toBe(true); // exactly r away
+    expect(pointInSphere(sphere, [6.0001, 2, 3])).toBe(false);
+    // 3-4-5: (4, 5, 3) is 5 from the centre in the xy plane.
+    expect(pointInSphere(sphere, [4, 6, 3])).toBe(true);
+    expect(pointInSphere(sphere, [5, 6, 3])).toBe(false);
+  });
+});
+
+describe('pointInRegion', () => {
+  const region = [8 * DEG, 40 * DEG, 12 * DEG, 44 * DEG, -50, 2500];
+
+  it('accepts an interior ECEF point', () => {
+    expect(pointInRegion(region, geodeticToEcef(10 * DEG, 42 * DEG, 500))).toBe(true);
+  });
+
+  it('rejects points above and below the height range', () => {
+    expect(pointInRegion(region, geodeticToEcef(10 * DEG, 42 * DEG, 2600))).toBe(false);
+    expect(pointInRegion(region, geodeticToEcef(10 * DEG, 42 * DEG, -60))).toBe(false);
+  });
+
+  it('rejects points outside the latitude range', () => {
+    expect(pointInRegion(region, geodeticToEcef(10 * DEG, 45 * DEG, 0))).toBe(false);
+    expect(pointInRegion(region, geodeticToEcef(10 * DEG, 39 * DEG, 0))).toBe(false);
+  });
+
+  it('rejects points outside the longitude range', () => {
+    expect(pointInRegion(region, geodeticToEcef(13 * DEG, 42 * DEG, 0))).toBe(false);
+    expect(pointInRegion(region, geodeticToEcef(7 * DEG, 42 * DEG, 0))).toBe(false);
+  });
+
+  it('accepts the corners within a small tolerance', () => {
+    for (const lon of [8 * DEG, 12 * DEG]) {
+      for (const lat of [40 * DEG, 44 * DEG]) {
+        for (const h of [-50, 2500]) {
+          expect(pointInRegion(region, geodeticToEcef(lon, lat, h), 1e-6)).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('handles an antimeridian region', () => {
+    const crossing = [170 * DEG, -5 * DEG, -170 * DEG, 5 * DEG, 0, 1000];
+    expect(pointInRegion(crossing, geodeticToEcef(Math.PI, 0, 100))).toBe(true);
+    expect(pointInRegion(crossing, geodeticToEcef(175 * DEG, 0, 100))).toBe(true);
+    expect(pointInRegion(crossing, geodeticToEcef(-175 * DEG, 0, 100))).toBe(true);
+    expect(pointInRegion(crossing, geodeticToEcef(0, 0, 100))).toBe(false);
+    expect(pointInRegion(crossing, geodeticToEcef(160 * DEG, 0, 100))).toBe(false);
+    expect(pointInRegion(crossing, geodeticToEcef(-160 * DEG, 0, 100))).toBe(false);
+  });
+
+  it('agrees with the AABB on points it accepts', () => {
+    const aabb = regionToAabb(region);
+    for (const lon of [8.5, 10, 11.5]) {
+      for (const lat of [40.5, 42, 43.5]) {
+        const p = geodeticToEcef(lon * DEG, lat * DEG, 1000);
+        expect(pointInRegion(region, p)).toBe(true);
+        expect(inside(aabb, p, 0)).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Conservative render-space bounds for the three 3D Tiles volume kinds, as pure functions. Nothing is wired into the scheduler; that seam belongs to a later phase and collides with work in progress. The three kinds fail in different ways, so each gets its own treatment rather than a shared approximation.

A `box` is oriented, so its 12 values are not an AABB. Corners come from the centre plus every sign combination of the three half-axes in Float64, and containment uses the half-axis projection test rather than an AABB test, with one case covering a point that sits inside the AABB and is correctly rejected anyway.

The `region` case is the one that can silently underbound.

A naive eight-corner AABB excludes real surface points, because an ellipsoidal region bulges outside the hull of its corners: for a 90 degree equatorial region the corner box tops out near `a*cos45` and misses `(a, 0, 0)` by more than 1.8e6 m. A test records that rejection rather than leaving the choice unexplained.

The method used instead samples only the two bounding height surfaces. That is sound because each ECEF coordinate is linear in height at fixed longitude and latitude, since the prime-vertical radius depends on latitude alone, so no interior height can exceed both surfaces. A closed-form outward pad then bounds the angular curvature between samples, which is what stops a coarse grid from missing the bulge between two adjacent samples. The pad errs outward in every direction, and outward is the only safe side: a bound that is too large costs a little wasted work, while one that is too small culls geometry that should have been drawn. Antimeridian crossing unwraps east forward rather than splitting the region in two.

45 tests. The region proof asserts 20,172 dense surface samples land inside the returned box within 1e-6 m, across equator, mid and high latitude, antimeridian, a tall height range and a large longitude span. I re-ran that proof independently at roughly 200 by 200 per region plus 4,000 random interior points, adding a polar cap and a near-global longitude span, and the worst excursion outside the returned box stayed at or below 1e-6 m.
