### PR TITLE
Select tiles for a view, which gives the 3D Tiles primitives a caller

### DIFF
--- a/src/io/tiles3d/tilesetTraversal.ts
+++ b/src/io/tiles3d/tilesetTraversal.ts
@@ -1,0 +1,268 @@
+/**
+ * tilesetTraversal.ts — decide which tiles a view needs.
+ *
+ * This is where the four 3D Tiles primitives meet. Until now each was correct
+ * in isolation and reachable from nothing:
+ *
+ *   tileTransform        cumulative placement down the tree
+ *   boundingVolume       conservative render-space bounds
+ *   screenSpaceError     the refinement measure
+ *   implicitCoordinates  children of an implicitly tiled subtree
+ *
+ * Composing them is what turns four verified modules into a traversal, and it
+ * is also the first time their assumptions have to agree.
+ *
+ * Still pure. No fetching, no scheduler, no renderer. Subtree availability is
+ * passed in rather than resolved, so an implicit tileset can be traversed here
+ * while the resource layer that fetches subtrees stays a separate concern.
+ *
+ * REFINEMENT, and the part that is easy to get subtly wrong:
+ *
+ *   REPLACE  a refined tile's own content is replaced by its children, so the
+ *            parent must NOT be rendered once its children are selected.
+ *   ADD      a refined tile's content is additive, so the parent IS rendered
+ *            alongside its children.
+ *
+ * Treating ADD as REPLACE drops geometry the tileset intended to keep, and the
+ * result still looks like a plausible scene, which is why both paths are tested
+ * rather than assumed.
+ */
+
+import type { BoundingVolume, Tile, Tileset } from './tileset';
+import {
+  IDENTITY_4X4,
+  transformPoint,
+  walkTilePlacements,
+  type Mat4,
+  type PlacedTile,
+} from './tileTransform';
+import { boxToAabb, regionToAabb, sphereToAabb, type Aabb } from './boundingVolume';
+import { screenSpaceError, shouldRefine, type CameraSseInput } from './screenSpaceError';
+import {
+  childCoordinates,
+  isAvailable,
+  subdivideBoundingVolume,
+  geometricErrorForLevel,
+  tileIdFor,
+  tileIndexWithinSubtree,
+  type Availability,
+  type SubdivisionScheme,
+  type TileCoordinate,
+} from './implicitCoordinates';
+
+/** A camera, minus the geometric error each tile supplies for itself. */
+export type ViewCamera =
+  | {
+      readonly kind: 'perspective';
+      readonly positionEcef: readonly [number, number, number];
+      readonly viewportHeightPx: number;
+      readonly verticalFov: number;
+    }
+  | {
+      readonly kind: 'orthographic';
+      readonly positionEcef: readonly [number, number, number];
+      readonly viewportHeightPx: number;
+      readonly orthographicWorldHeight: number;
+    };
+
+export interface TraversalOptions {
+  /** Refine while the screen-space error exceeds this, in pixels. */
+  readonly maxScreenSpaceErrorPx: number;
+  /** Stop descending past this depth. Guards a pathological tileset. */
+  readonly maxDepth?: number;
+  /** Root transform, when the tileset is placed by something above it. */
+  readonly rootTransform?: Mat4;
+}
+
+/** One tile the view needs, with the numbers that decided it. */
+export interface SelectedTile {
+  readonly placed: PlacedTile;
+  readonly aabb: Aabb;
+  readonly distance: number;
+  readonly screenSpaceError: number;
+  /** True when this tile's own content is drawn. */
+  readonly renders: boolean;
+}
+
+/**
+ * The render-space AABB of a bounding volume.
+ *
+ * A `region` is EPSG:4979 and already absolute, so it is converted directly
+ * rather than through the tile transform. Box and sphere arrive already
+ * transformed by the walk, so they are converted as they stand. Returns null
+ * for a volume carrying none of the three, which `tileset.ts` refuses to parse
+ * but which a hand-built Tile can still produce.
+ */
+export function volumeToAabb(volume: BoundingVolume): Aabb | null {
+  if (volume.region) return regionToAabb(volume.region);
+  if (volume.box) return boxToAabb(volume.box);
+  if (volume.sphere) return sphereToAabb(volume.sphere);
+  return null;
+}
+
+/**
+ * Distance from a point to an AABB, zero when inside.
+ *
+ * Distance to the VOLUME rather than to its centre. Centre distance
+ * under-reports error for a large tile the camera is standing inside, which is
+ * exactly the tile that most needs refining.
+ */
+export function distanceToAabb(aabb: Aabb, p: readonly [number, number, number]): number {
+  let sum = 0;
+  for (let i = 0; i < 3; i++) {
+    const over = Math.max(aabb.min[i]! - p[i]!, 0, p[i]! - aabb.max[i]!);
+    sum += over * over;
+  }
+  return Math.sqrt(sum);
+}
+
+/** The SSE input for one tile under one camera. */
+function sseInputFor(camera: ViewCamera, geometricError: number, distance: number): CameraSseInput {
+  if (camera.kind === 'orthographic') {
+    return {
+      kind: 'orthographic',
+      geometricError,
+      viewportHeightPx: camera.viewportHeightPx,
+      orthographicWorldHeight: camera.orthographicWorldHeight,
+    };
+  }
+  return {
+    kind: 'perspective',
+    geometricError,
+    viewportHeightPx: camera.viewportHeightPx,
+    distance,
+    verticalFov: camera.verticalFov,
+  };
+}
+
+/**
+ * Select the tiles a view needs from an explicit tileset.
+ *
+ * Descends while the screen-space error exceeds the threshold and children
+ * exist. A tile with no children is a leaf and always renders when reached,
+ * however large its error, because there is nothing further to descend to and
+ * dropping it would leave a hole.
+ */
+export function selectTiles(
+  tileset: Tileset,
+  camera: ViewCamera,
+  options: TraversalOptions,
+): SelectedTile[] {
+  const maxDepth = options.maxDepth ?? 32;
+  const rootTransform = options.rootTransform ?? IDENTITY_4X4;
+  const out: SelectedTile[] = [];
+
+  // The walk already carries the cumulative transform, so this only decides
+  // which of its tiles to keep.
+  const byTile = new Map<Tile, PlacedTile>();
+  for (const placed of walkTilePlacements(tileset.root, rootTransform)) {
+    byTile.set(placed.tile, placed);
+  }
+
+  const visit = (tile: Tile): void => {
+    const placed = byTile.get(tile);
+    if (!placed || placed.depth > maxDepth) return;
+
+    const aabb = volumeToAabb(placed.boundingVolume);
+    if (!aabb) return;
+
+    const distance = distanceToAabb(aabb, camera.positionEcef as [number, number, number]);
+    const sse = screenSpaceError(sseInputFor(camera, placed.geometricError, distance));
+
+    const hasChildren = tile.children.length > 0;
+    const refine = hasChildren && placed.depth < maxDepth && shouldRefine(sse, options.maxScreenSpaceErrorPx);
+
+    // REPLACE hides the parent behind its children; ADD keeps both. A leaf
+    // renders regardless, because there is nothing below it to stand in.
+    const renders = !refine || tile.refine === 'ADD';
+    if (renders) out.push({ placed, aabb, distance, screenSpaceError: sse, renders: true });
+
+    if (refine) for (const child of tile.children) visit(child);
+  };
+
+  visit(tileset.root);
+  return out;
+}
+
+/** One implicitly tiled node, materialised only because the traversal reached it. */
+export interface ImplicitTile {
+  readonly coordinate: TileCoordinate;
+  readonly id: string;
+  readonly boundingVolume: BoundingVolume;
+  readonly geometricError: number;
+}
+
+export interface ImplicitSubtreeInput {
+  readonly scheme: SubdivisionScheme;
+  readonly rootCoordinate: TileCoordinate;
+  readonly rootBoundingVolume: BoundingVolume;
+  readonly rootGeometricError: number;
+  /** Levels this subtree covers below its root. */
+  readonly subtreeLevels: number;
+  readonly tileAvailability: Availability;
+}
+
+/**
+ * Materialise the available tiles of one implicit subtree, lazily.
+ *
+ * Nothing is pre-created: a node exists only once the walk descends to it, so a
+ * subtree that declares many levels costs only the part actually reached. An
+ * unavailable tile stops that branch, since its descendants cannot be addressed
+ * through a parent that does not exist.
+ */
+export function* walkImplicitSubtree(input: ImplicitSubtreeInput): Generator<ImplicitTile> {
+  const { scheme, rootCoordinate, subtreeLevels } = input;
+
+  interface Frame {
+    coord: TileCoordinate;
+    volume: BoundingVolume;
+    error: number;
+  }
+  const stack: Frame[] = [
+    { coord: rootCoordinate, volume: input.rootBoundingVolume, error: input.rootGeometricError },
+  ];
+
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    const depth = frame.coord.level - rootCoordinate.level;
+    if (depth < 0 || depth >= subtreeLevels) continue;
+
+    const index = tileIndexWithinSubtree(scheme, frame.coord, rootCoordinate.level);
+    if (!isAvailable(input.tileAvailability, index)) continue;
+
+    yield {
+      coordinate: frame.coord,
+      id: tileIdFor(scheme, frame.coord),
+      boundingVolume: frame.volume,
+      geometricError: frame.error,
+    };
+
+    if (depth + 1 >= subtreeLevels) continue;
+    const children = childCoordinates(scheme, frame.coord);
+    for (let i = children.length - 1; i >= 0; i--) {
+      const volume = subdivideBoundingVolume(scheme, frame.volume, i);
+      // A volume that cannot be subdivided exactly stops the branch rather than
+      // being approximated, because an approximate bound culls real geometry.
+      if (!volume) continue;
+      stack.push({
+        coord: children[i]!,
+        volume,
+        error: geometricErrorForLevel(input.rootGeometricError, children[i]!.level - rootCoordinate.level),
+      });
+    }
+  }
+}
+
+/** The render-space centre of a placed tile, for callers that need one point. */
+export function placedTileCentre(placed: PlacedTile): [number, number, number] | null {
+  const aabb = volumeToAabb(placed.boundingVolume);
+  if (!aabb) return null;
+  return [
+    (aabb.min[0]! + aabb.max[0]!) / 2,
+    (aabb.min[1]! + aabb.max[1]!) / 2,
+    (aabb.min[2]! + aabb.max[2]!) / 2,
+  ];
+}
+
+/** Re-exported so a caller composing a root placement needs one import. */
+export { transformPoint };

--- a/tests/tiles3dTraversal.test.ts
+++ b/tests/tiles3dTraversal.test.ts
@@ -1,0 +1,248 @@
+/**
+ * tiles3dTraversal.test.ts — the first test that runs the four 3D Tiles
+ * primitives together.
+ *
+ * Each was verified in isolation. What only a composed test can show is that
+ * their assumptions agree: that the walk's transformed volumes are what the
+ * bounds functions expect, that the bounds produce a distance the error measure
+ * can use, and that refinement selects the tiles a viewer would actually draw.
+ *
+ * The refinement cases are the ones worth the most care. REPLACE and ADD differ
+ * only in whether the parent survives its own refinement, and an implementation
+ * that treats ADD as REPLACE silently drops geometry while still producing a
+ * plausible scene.
+ *
+ * Expected values are hand-worked from the construction.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  selectTiles,
+  volumeToAabb,
+  distanceToAabb,
+  walkImplicitSubtree,
+  placedTileCentre,
+  type ViewCamera,
+} from '../src/io/tiles3d/tilesetTraversal';
+import type { Tile, Tileset } from '../src/io/tiles3d/tileset';
+
+/** A unit-ish box tile; only the fields the traversal reads are set. */
+const tile = (over: Partial<Tile> = {}): Tile => ({
+  boundingVolume: { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] },
+  geometricError: 100,
+  refine: 'REPLACE',
+  transform: null,
+  contentUri: null,
+  children: [],
+  ...over,
+});
+
+const tilesetOf = (root: Tile): Tileset => ({
+  assetVersion: '1.1',
+  geometricError: root.geometricError,
+  root,
+});
+
+/** Far enough that a 100 m error is small on screen. */
+const farCamera: ViewCamera = {
+  kind: 'perspective',
+  positionEcef: [100_000, 0, 0],
+  viewportHeightPx: 1000,
+  verticalFov: Math.PI / 3,
+};
+
+/** Close enough that the same error is large. */
+const nearCamera: ViewCamera = {
+  kind: 'perspective',
+  positionEcef: [30, 0, 0],
+  viewportHeightPx: 1000,
+  verticalFov: Math.PI / 3,
+};
+
+describe('distance is measured to the volume, not to its centre', () => {
+  it('is zero when the camera is inside the box', () => {
+    const aabb = volumeToAabb({ box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] })!;
+    expect(distanceToAabb(aabb, [0, 0, 0])).toBe(0);
+    expect(distanceToAabb(aabb, [5, 5, 5])).toBe(0);
+  });
+
+  it('is the gap to the nearest face, not to the centre', () => {
+    // The box spans -10..10 on each axis, so a camera at x=30 is 20 m from the
+    // face and 30 m from the centre. Using the centre would under-report the
+    // error of a tile the camera is nearly touching.
+    const aabb = volumeToAabb({ box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] })!;
+    expect(distanceToAabb(aabb, [30, 0, 0])).toBeCloseTo(20, 9);
+  });
+
+  it('combines all three axes on a corner approach', () => {
+    // 3-4-5 in two axes, from the corner at (10, 10, 10).
+    const aabb = volumeToAabb({ box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] })!;
+    expect(distanceToAabb(aabb, [13, 14, 10])).toBeCloseTo(5, 9);
+  });
+});
+
+describe('volume conversion covers all three kinds', () => {
+  it('converts a box, a sphere and a region, and refuses an empty volume', () => {
+    expect(volumeToAabb({ box: [0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3] })!.max).toEqual([1, 2, 3]);
+    expect(volumeToAabb({ sphere: [0, 0, 0, 5] })!.max).toEqual([5, 5, 5]);
+    // A region is EPSG:4979, so its AABB is an ECEF box near the Earth radius.
+    const r = volumeToAabb({ region: [-0.01, -0.01, 0.01, 0.01, 0, 100] })!;
+    expect(r.max[0]).toBeGreaterThan(6_300_000);
+    expect(volumeToAabb({})).toBeNull();
+  });
+});
+
+describe('refinement', () => {
+  it('returns only the root when the error is already small enough', () => {
+    const root = tile({ children: [tile({ geometricError: 50 })] });
+    const out = selectTiles(tilesetOf(root), farCamera, { maxScreenSpaceErrorPx: 16 });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.placed.depth).toBe(0);
+  });
+
+  it('descends when the error is large, and REPLACE drops the parent', () => {
+    const child = tile({ geometricError: 1 });
+    const root = tile({ refine: 'REPLACE', children: [child] });
+    const out = selectTiles(tilesetOf(root), nearCamera, { maxScreenSpaceErrorPx: 16 });
+    // Only the child renders: a replaced parent is not drawn beside its children.
+    expect(out).toHaveLength(1);
+    expect(out[0]!.placed.depth).toBe(1);
+  });
+
+  it('descends when the error is large, and ADD keeps the parent', () => {
+    // The case that separates the two modes. Treating ADD as REPLACE here would
+    // return one tile and still look like a working traversal.
+    const child = tile({ geometricError: 1 });
+    const root = tile({ refine: 'ADD', children: [child] });
+    const out = selectTiles(tilesetOf(root), nearCamera, { maxScreenSpaceErrorPx: 16 });
+    expect(out).toHaveLength(2);
+    expect(out.map((t) => t.placed.depth).sort()).toEqual([0, 1]);
+  });
+
+  it('renders a leaf however large its error, because nothing stands in for it', () => {
+    const root = tile({ geometricError: 1e9, children: [] });
+    const out = selectTiles(tilesetOf(root), nearCamera, { maxScreenSpaceErrorPx: 16 });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.screenSpaceError).toBeGreaterThan(16);
+  });
+
+  it('stops at maxDepth rather than descending a pathological tileset', () => {
+    let node = tile({ geometricError: 1 });
+    for (let i = 0; i < 20; i++) node = tile({ geometricError: 1000, children: [node] });
+    const out = selectTiles(tilesetOf(node), nearCamera, { maxScreenSpaceErrorPx: 1, maxDepth: 3 });
+    expect(Math.max(...out.map((t) => t.placed.depth))).toBeLessThanOrEqual(3);
+  });
+
+  it('carries the tile transform into the selected bounds', () => {
+    // The root translates 1000 east, so its AABB must sit around x = 1000.
+    const root = tile({ transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1000, 0, 0, 1] });
+    const out = selectTiles(tilesetOf(root), farCamera, { maxScreenSpaceErrorPx: 16 });
+    expect(out[0]!.aabb.min[0]).toBeCloseTo(990, 6);
+    expect(out[0]!.aabb.max[0]).toBeCloseTo(1010, 6);
+  });
+
+  it('an orthographic camera refines on zoom rather than on distance', () => {
+    // Under REPLACE the count does not grow when a tile refines, because the
+    // parent is swapped for its children rather than joined by them. Depth is
+    // what moves, and asserting the count here would pass for the wrong reason.
+    const root = tile({ children: [tile({ geometricError: 1 })] });
+    const wide: ViewCamera = { kind: 'orthographic', positionEcef: [1e6, 0, 0], viewportHeightPx: 1000, orthographicWorldHeight: 100_000 };
+    const zoomed: ViewCamera = { ...wide, orthographicWorldHeight: 100 };
+
+    // Wide: 100 * 1000 / 100000 = 1 px, under the threshold, so the root stands.
+    const outWide = selectTiles(tilesetOf(root), wide, { maxScreenSpaceErrorPx: 16 });
+    expect(outWide.map((t) => t.placed.depth)).toEqual([0]);
+
+    // Zoomed: 100 * 1000 / 100 = 1000 px, so it refines to the child.
+    const outZoom = selectTiles(tilesetOf(root), zoomed, { maxScreenSpaceErrorPx: 16 });
+    expect(outZoom.map((t) => t.placed.depth)).toEqual([1]);
+
+    // Moving the camera without zooming changes nothing, which is the property
+    // that separates the orthographic path from the perspective one.
+    const moved: ViewCamera = { ...wide, positionEcef: [50, 0, 0] };
+    expect(selectTiles(tilesetOf(root), moved, { maxScreenSpaceErrorPx: 16 }).map((t) => t.placed.depth)).toEqual([0]);
+  });
+});
+
+describe('implicit subtree walking', () => {
+  const rootVolume = { box: [0, 0, 0, 16, 0, 0, 0, 16, 0, 0, 0, 16] };
+
+  it('yields only available tiles and materialises nothing else', () => {
+    // Constant 1: every tile in the subtree is available.
+    const all = [...walkImplicitSubtree({
+      scheme: 'QUADTREE',
+      rootCoordinate: { level: 0, x: 0, y: 0 },
+      rootBoundingVolume: rootVolume,
+      rootGeometricError: 100,
+      subtreeLevels: 3,
+      tileAvailability: { constant: 1 },
+    })];
+    // Levels 0, 1 and 2 of a quadtree: 1 + 4 + 16.
+    expect(all).toHaveLength(21);
+  });
+
+  it('yields nothing when the subtree declares nothing available', () => {
+    const none = [...walkImplicitSubtree({
+      scheme: 'QUADTREE',
+      rootCoordinate: { level: 0, x: 0, y: 0 },
+      rootBoundingVolume: rootVolume,
+      rootGeometricError: 100,
+      subtreeLevels: 3,
+      tileAvailability: { constant: 0 },
+    })];
+    expect(none).toHaveLength(0);
+  });
+
+  it('halves the geometric error per level', () => {
+    const tiles = [...walkImplicitSubtree({
+      scheme: 'QUADTREE',
+      rootCoordinate: { level: 0, x: 0, y: 0 },
+      rootBoundingVolume: rootVolume,
+      rootGeometricError: 100,
+      subtreeLevels: 2,
+      tileAvailability: { constant: 1 },
+    })];
+    expect(tiles.find((t) => t.coordinate.level === 0)!.geometricError).toBeCloseTo(100, 9);
+    for (const t of tiles.filter((x) => x.coordinate.level === 1)) {
+      expect(t.geometricError).toBeCloseTo(50, 9);
+    }
+  });
+
+  it('gives every materialised tile a distinct id', () => {
+    const ids = [...walkImplicitSubtree({
+      scheme: 'OCTREE',
+      rootCoordinate: { level: 0, x: 0, y: 0, z: 0 },
+      rootBoundingVolume: rootVolume,
+      rootGeometricError: 64,
+      subtreeLevels: 3,
+      tileAvailability: { constant: 1 },
+    })].map((t) => t.id);
+    // Octree levels 0, 1, 2: 1 + 8 + 64.
+    expect(ids).toHaveLength(73);
+    expect(new Set(ids).size).toBe(73);
+  });
+
+  it('subdivides the bounds, so a child is smaller than its parent', () => {
+    const tiles = [...walkImplicitSubtree({
+      scheme: 'QUADTREE',
+      rootCoordinate: { level: 0, x: 0, y: 0 },
+      rootBoundingVolume: rootVolume,
+      rootGeometricError: 100,
+      subtreeLevels: 2,
+      tileAvailability: { constant: 1 },
+    })];
+    const root = tiles.find((t) => t.coordinate.level === 0)!;
+    const child = tiles.find((t) => t.coordinate.level === 1)!;
+    expect(child.boundingVolume.box![3]).toBeCloseTo(root.boundingVolume.box![3]! / 2, 9);
+    // QUADTREE leaves the vertical half-axis alone.
+    expect(child.boundingVolume.box![11]).toBeCloseTo(root.boundingVolume.box![11]!, 9);
+  });
+});
+
+describe('placed tile centre', () => {
+  it('is the midpoint of the bounds, and null when there are none', () => {
+    const root = tile({ boundingVolume: { box: [5, 6, 7, 1, 0, 0, 0, 1, 0, 0, 0, 1] } });
+    const out = selectTiles(tilesetOf(root), farCamera, { maxScreenSpaceErrorPx: 16 });
+    expect(placedTileCentre(out[0]!.placed)).toEqual([5, 6, 7]);
+  });
+});


### PR DESCRIPTION
Four modules landed correct and reachable from nothing: the cumulative transform (#551), the conservative bounds (#553), the screen-space error (#552) and the implicit coordinates (#554). This composes them into a traversal, which is the first time their assumptions have to agree. Typecheck passing across the four is itself part of the result.

Distance is measured to the bounding volume, not to its centre. Centre distance under-reports the error of a large tile the camera is standing inside, which is precisely the tile that most needs refining, so the traversal takes the gap to the nearest face and returns zero once the camera is within the volume. A test pins the 3-4-5 corner case.

`REPLACE` and `ADD` differ only in whether a refined tile still renders beside its children, so each has its own case. Treating `ADD` as `REPLACE` drops geometry and still produces a plausible scene, which is why it is asserted rather than assumed. A leaf renders however large its error, because nothing stands in for it. Depth is capped so a pathological tileset cannot walk forever, and the cap is tested against a twenty-deep chain.

Implicit subtrees materialise a node only when the walk reaches it, so a subtree declaring many levels costs only the part actually traversed. An unavailable tile stops that branch, since its descendants cannot be addressed through a parent that does not exist.

Still pure: no fetching, no scheduler, no renderer.

17 tests. One of them caught a mistake in my own expectation: under `REPLACE` the selected count does not grow when a tile refines, because the parent is swapped for its children rather than joined by them. Depth is what moves, and asserting the count would have passed for the wrong reason.
