### PR TITLE
Hold a released document to the register at its own tag

### DIFF
--- a/scripts/lint-claim-prose-sync.mjs
+++ b/scripts/lint-claim-prose-sync.mjs
@@ -26,11 +26,21 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { resolve, dirname } from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { parseRegister, VALID_LEVELS } from './lint-claim-register.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-/** Truth documents that describe the evidence state and must not contradict it. */
+/**
+ * Truth documents that describe the evidence state and must not contradict it.
+ *
+ * A document under `docs/releases/` carrying a version describes THAT release.
+ * Its E4 count was true at that tag and stays true; holding it to the live
+ * register would make the lint demand that a shipped, archived record be
+ * rewritten every time a claim is promoted afterwards. So a versioned release
+ * document is compared against the register AT ITS OWN TAG. See
+ * {@link expectedCountFor}.
+ */
 const TRUTH_DOCS = [
   // The release notes and validation report state the E4 count to the public and
   // were NOT scanned, which is half of why "Ten products are now at E4" survived
@@ -84,9 +94,71 @@ function e4FromRegister() {
   return { ids, count: ids.length };
 }
 
+/** `docs/releases/<anything>_v1.2.3.md` -> "v1.2.3", else null. */
+export function releaseVersionOf(rel) {
+  const m = /^docs\/releases\/.*_(v\d+\.\d+\.\d+)\.md$/.exec(rel);
+  return m ? m[1] : null;
+}
+
+/** Whether the repository has a tag by that name. */
+function tagExists(tag, cwd = ROOT) {
+  try {
+    execFileSync('git', ['rev-parse', '--verify', `refs/tags/${tag}`], {
+      cwd, stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The E4 count in the register as it stood at `tag`, or null when unreadable. */
+export function e4CountAtTag(tag, cwd = ROOT) {
+  try {
+    const yaml = execFileSync('git', ['show', `${tag}:docs/validation/claim-register.yaml`], {
+      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: 1 << 24,
+    });
+    const levels = [...VALID_LEVELS];
+    const e4Rank = levels.indexOf('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    return parseRegister(yaml).filter((c) => {
+      const r = levels.indexOf(c.current);
+      return r !== -1 && r >= e4Rank;
+    }).length;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The count a document must agree with, and why.
+ *
+ * WHAT THIS DELIBERATELY STILL CATCHES. The failure this lint exists for is a
+ * release document understating the count at the moment it ships: "Ten products
+ * are now at E4" survived past twelve. A release document for a version with no
+ * tag yet is the release being PREPARED, so it is held to the live register and
+ * that failure is caught exactly as before. Only an already-tagged release is
+ * read against its own tag, and only because it is then a historical record
+ * rather than a description of main.
+ *
+ * When git cannot answer, a tagged document is skipped rather than failed. An
+ * extracted archive has no history, and the release gate runs there.
+ */
+export function expectedCountFor(rel, liveCount, deps = {}) {
+  const hasTag = deps.tagExists ?? tagExists;
+  const atTag = deps.e4CountAtTag ?? e4CountAtTag;
+  const version = releaseVersionOf(rel);
+  if (version === null) return { count: liveCount, basis: 'the register' };
+  if (!hasTag(version)) {
+    return { count: liveCount, basis: `the register, because ${version} is not tagged yet` };
+  }
+  const tagged = atTag(version);
+  if (tagged === null) return { count: null, basis: `unreadable at tag ${version}` };
+  return { count: tagged, basis: `the register at tag ${version}` };
+}
+
 function collectProseProblems(count) {
   const problems = [];
-  const expectedWord = NUMBER_WORDS[count] ?? String(count);
+  const skipped = [];
   // A count word paired with an E4 / cross-implementation claim in one sentence.
   const any = `(?:${COUNT_ALTERNATION}|${COUNT_DIGITS})`;
   const countClaim = new RegExp(
@@ -100,6 +172,14 @@ function collectProseProblems(count) {
   for (const rel of TRUTH_DOCS) {
     const abs = resolve(ROOT, rel);
     if (!existsSync(abs)) continue;
+
+    const { count: docCount, basis } = expectedCountFor(rel, count);
+    if (docCount === null) {
+      skipped.push(`${rel}: ${basis}`);
+      continue;
+    }
+    const docExpectedWord = NUMBER_WORDS[docCount] ?? String(docCount);
+
     const text = readFileSync(abs, 'utf8');
     const lines = text.split('\n');
     for (let i = 0; i < lines.length; i++) {
@@ -109,9 +189,9 @@ function collectProseProblems(count) {
       const re = new RegExp(countClaim.source, 'gi');
       while ((m = re.exec(line)) !== null) {
         const word = (m[1] ?? m[2] ?? '').toLowerCase();
-        if (word && word !== expectedWord && word !== String(count)) {
+        if (word && word !== docExpectedWord && word !== String(docCount)) {
           problems.push(
-            `${rel}:${i + 1} says "${word}" next to an E4 / cross-implementation claim, but the register has ${count} E4 product(s) ("${expectedWord}"). Update the prose to match the register.`,
+            `${rel}:${i + 1} says "${word}" next to an E4 / cross-implementation claim, but ${basis} has ${docCount} E4 product(s) ("${docExpectedWord}"). Update the prose to match it.`,
           );
         }
       }
@@ -120,18 +200,18 @@ function collectProseProblems(count) {
       //    "other than" / "except" / "besides" exempts the line.
       const allSlotsPending =
         /every reference slot\b(?![^.\n]*\b(?:other than|except|besides|apart from)\b)[^.\n]*\bpending\b/i;
-      if (count > 0 && allSlotsPending.test(line)) {
+      if (docCount > 0 && allSlotsPending.test(line)) {
         problems.push(
-          `${rel}:${i + 1} says every reference slot is pending, but the register supplies ${count} (${e4Ids.join(', ')}). Remove the obsolete absolute.`,
+          `${rel}:${i + 1} says every reference slot is pending, but ${basis} supplies ${docCount}. Remove the obsolete absolute.`,
         );
       }
     }
   }
-  return problems;
+  return { problems, skipped };
 }
 
 const { ids: e4Ids, count } = e4FromRegister();
-const problems = collectProseProblems(count);
+const { problems, skipped } = collectProseProblems(count);
 
 if (problems.length > 0) {
   console.error('lint:claim-prose-sync FAILED — truth documents disagree with the claim register:\n');

--- a/tests/claimProseSyncScope.test.ts
+++ b/tests/claimProseSyncScope.test.ts
@@ -1,0 +1,116 @@
+/**
+ * claimProseSyncScope.test.ts — which count a truth document is held to.
+ *
+ * The lint exists because "Ten products are now at E4" survived past twelve in
+ * a published release note. Scoping a versioned release document to its own tag
+ * must not give that failure a way back, so the case that matters most here is
+ * the one where a release is being PREPARED: no tag yet, so the document is
+ * still held to the live register and the original bug is still caught.
+ *
+ * Only an already-tagged release reads against its tag, and only because it has
+ * become a historical record. Holding it to the live register would have the
+ * lint demand that a shipped, archived document be rewritten every time a claim
+ * is promoted afterwards, which is the opposite of what a truth gate is for.
+ *
+ * The helpers take their git access as parameters, so these cases decide their
+ * own history rather than depending on the tags this checkout happens to have.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Kept on one line: @ts-expect-error applies to the line that follows it.
+// @ts-expect-error — plain .mjs script, no types
+import { releaseVersionOf, expectedCountFor } from '../scripts/lint-claim-prose-sync.mjs';
+
+interface Expectation { count: number | null; basis: string }
+
+const call = (
+  rel: string,
+  live: number,
+  tags: string[],
+  atTag: Record<string, number | null>,
+): Expectation =>
+  expectedCountFor(rel, live, {
+    tagExists: (t: string) => tags.includes(t),
+    e4CountAtTag: (t: string) => (t in atTag ? atTag[t] : null),
+  }) as Expectation;
+
+describe('recognising a versioned release document', () => {
+  it('reads the version out of a release filename', () => {
+    expect(releaseVersionOf('docs/releases/RELEASE_NOTES_v0.6.6.md')).toBe('v0.6.6');
+    expect(releaseVersionOf('docs/releases/VALIDATION_REPORT_v0.6.6.md')).toBe('v0.6.6');
+    expect(releaseVersionOf('docs/releases/KNOWN_LIMITATIONS_v1.12.3.md')).toBe('v1.12.3');
+  });
+
+  it('treats everything else as a living document', () => {
+    expect(releaseVersionOf('ARTIFACT_EVALUATION.md')).toBeNull();
+    expect(releaseVersionOf('docs/validation/EVIDENCE_MODEL.md')).toBeNull();
+    expect(releaseVersionOf('docs/project/CLAIMS_AND_LIMITATIONS.md')).toBeNull();
+    // Not under docs/releases/, so the version in the name does not scope it.
+    expect(releaseVersionOf('docs/validation/matrix_v0.6.6.md')).toBeNull();
+  });
+});
+
+describe('a living document is held to the live register', () => {
+  it('takes the live count whatever the tags say', () => {
+    const r = call('ARTIFACT_EVALUATION.md', 14, ['v0.6.6'], { 'v0.6.6': 12 });
+    expect(r.count).toBe(14);
+    expect(r.basis).toBe('the register');
+  });
+});
+
+describe('a tagged release document is held to its own tag', () => {
+  it('takes the count at the tag, not the live one', () => {
+    // The whole point: 12 was true for v0.6.6 and stays true.
+    const r = call('docs/releases/VALIDATION_REPORT_v0.6.6.md', 14, ['v0.6.6'], { 'v0.6.6': 12 });
+    expect(r.count).toBe(12);
+    expect(r.basis).toContain('at tag v0.6.6');
+  });
+
+  it('still fails a tagged document that disagrees with its own tag', () => {
+    // Scoping is not an exemption. A release note that understated the count at
+    // the moment it shipped is still wrong, and is still caught.
+    const r = call('docs/releases/RELEASE_NOTES_v0.6.6.md', 14, ['v0.6.6'], { 'v0.6.6': 12 });
+    expect(r.count).toBe(12);
+    // Prose saying "ten" would be compared against 12 and rejected.
+    expect(r.count).not.toBe(10);
+  });
+});
+
+describe('the release being prepared, which is where the original bug lived', () => {
+  it('is held to the LIVE register when its version has no tag yet', () => {
+    // "Ten products are now at E4" was published in a release note. At that
+    // moment there was no tag, so this branch is the one that catches it.
+    const r = call('docs/releases/RELEASE_NOTES_v0.6.7.md', 14, ['v0.6.6'], { 'v0.6.6': 12 });
+    expect(r.count).toBe(14);
+    expect(r.basis).toContain('not tagged yet');
+  });
+
+  it('does not fall back to an older tag just because one exists', () => {
+    const r = call('docs/releases/VALIDATION_REPORT_v0.7.0.md', 20, ['v0.6.6'], { 'v0.6.6': 12 });
+    expect(r.count).toBe(20);
+  });
+});
+
+describe('when git cannot answer', () => {
+  it('skips a tagged document rather than failing it', () => {
+    // An extracted archive has no history and the release gate runs there.
+    // Failing every release document in that environment would make the gate
+    // impossible to pass for a reason that has nothing to do with the evidence.
+    const r = call('docs/releases/RELEASE_NOTES_v0.6.6.md', 14, ['v0.6.6'], { 'v0.6.6': null });
+    expect(r.count).toBeNull();
+    expect(r.basis).toContain('unreadable');
+  });
+
+  it('still holds a living document to the live register with no git at all', () => {
+    const r = call('docs/validation/EVIDENCE_MODEL.md', 14, [], {});
+    expect(r.count).toBe(14);
+  });
+
+  it('holds an untagged release document to the live register with no git at all', () => {
+    // No tags readable means no tag matched, which is the prepared-release
+    // branch. That fails safe: the document is checked rather than skipped.
+    const r = call('docs/releases/RELEASE_NOTES_v0.6.7.md', 14, [], {});
+    expect(r.count).toBe(14);
+  });
+});


### PR DESCRIPTION
`lint:claim-prose-sync` held every truth document to the live register, including `RELEASE_NOTES_v0.6.6.md`, `VALIDATION_REPORT_v0.6.6.md` and `KNOWN_LIMITATIONS_v0.6.6.md`. Those describe a shipped release with an archived DOI. Twelve products were at E4 at tag `v0.6.6`, which is exactly what they say, so every promotion after the release demanded that a published record be rewritten to describe `main` instead.

A versioned document under `docs/releases/` now reads the register at its own tag.

The failure this lint exists for is a release document understating the count as it ships: "Ten products are now at E4" survived past twelve. That is untouched. A release whose version carries no tag yet is the one being **prepared**, so it is still held to the live register, which is the branch that catches exactly that bug. Only an already-tagged release reads against its tag, because it has become a historical record rather than a description of `main`.

Where git cannot answer, a tagged document is skipped rather than failed. The release gate runs against an extracted archive with no history, and failing every release document there would be a refusal about the environment rather than about the evidence.

Both directions are mutation-tested. Scoping an untagged document to a tag fails three cases; holding a tagged document to the live count fails two.

No claim is promoted here. With `CHANGE-RASTER` and `CHANGE-VOLUME` promoted locally as a check, the three v0.6.6 documents pass and the four living documents correctly demand fourteen, which is the behaviour this change is for.
