### PR TITLE
fix(export): pin PDF Info dates so five builders reproduce

### DIFF
--- a/src/pdfInfoDate.ts
+++ b/src/pdfInfoDate.ts
@@ -1,0 +1,46 @@
+/**
+ * pdfInfoDate.ts — the date a PDF stamps into its Info dictionary.
+ *
+ * pdf-lib defaults CreationDate and ModDate to the wall clock at
+ * `PDFDocument.create()`. Two otherwise-identical builds either side of a
+ * second boundary therefore embed different timestamps and stop being
+ * byte-identical, which is a determinism hole no visible "generated" stamp
+ * covers: the printed date can be pinned while the Info dictionary still
+ * moves. `buildProfilePdf` was flaking on exactly that.
+ *
+ * The rule is that a deliverable's Info date comes from the same value it
+ * prints, so a build with a fixed date reproduces. A builder that prints no
+ * date has nothing to source from, and a wall-clock stamp there carries no
+ * information a reader could use while destroying reproducibility outright,
+ * so it takes the epoch instead.
+ */
+
+/**
+ * The fallback Info date for a document that carries no timestamp of its own.
+ *
+ * Deliberately the Unix epoch rather than "now": it is visibly a placeholder
+ * rather than a plausible-looking wrong date, and it is the same on every
+ * machine, which is the whole point.
+ */
+export const PDF_EPOCH = new Date(0);
+
+/**
+ * Resolve the Info-dictionary date from whatever the caller prints.
+ *
+ * Accepts a Date, an ISO string, or nothing. An unparseable or non-finite
+ * value falls back to the epoch rather than to the clock, because silently
+ * substituting the current time is how the nondeterminism gets back in.
+ */
+export function pdfInfoDate(source?: Date | string | number | null): Date {
+  if (source instanceof Date) {
+    return Number.isFinite(source.getTime()) ? source : PDF_EPOCH;
+  }
+  if (typeof source === 'number') {
+    return Number.isFinite(source) ? new Date(source) : PDF_EPOCH;
+  }
+  if (typeof source === 'string' && source.trim() !== '') {
+    const parsed = new Date(source);
+    if (Number.isFinite(parsed.getTime())) return parsed;
+  }
+  return PDF_EPOCH;
+}

--- a/src/render/measure/profilePdf.ts
+++ b/src/render/measure/profilePdf.ts
@@ -76,6 +76,7 @@ import type { ProfileProvenance } from './profileProvenance';
 // reader can discover which surface a height was measured from.
 import { heightLabel, heightReferenceNote, verticalReferenceFromDatum } from '../../geo/height';
 import type { VerticalReference } from '../../geo/height';
+import { pdfInfoDate } from '../../pdfInfoDate';
 
 /** Same constant the format/summary modules keep module-local. */
 const FEET_PER_METRE = 3.280839895013123;
@@ -276,6 +277,12 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
   doc.setTitle(pdfTitle, { showInWindowTitleBar: true });
   doc.setLanguage('en-US');
   doc.setAuthor('OpenLiDARViewer');
+  // Pin the Info-dictionary dates. pdf-lib defaults CreationDate and ModDate to
+  // the wall clock at `create()`, so two identical builds either side of a
+  // second boundary stop being byte-identical. See src/pdfInfoDate.ts.
+  const infoStamp = pdfInfoDate(input.generatedAt);
+  doc.setCreationDate(infoStamp);
+  doc.setModificationDate(infoStamp);
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
   const mono = await doc.embedFont(StandardFonts.Courier);

--- a/src/render/measure/spaceReportPdf.ts
+++ b/src/render/measure/spaceReportPdf.ts
@@ -25,6 +25,7 @@ import type { ObjectMetrics } from '../../terrain/objectMetrics';
 import { buildSpaceReportContent } from '../../terrain/space/spaceReportLayout';
 import type { FloorPlanModel } from '../../terrain/space/floorplan/extractFloorPlan';
 import type { PlanUnitSystem } from '../../terrain/space/floorplan/floorPlanSvg';
+import { pdfInfoDate } from '../../pdfInfoDate';
 
 export interface SpaceReportPdfInput {
   readonly space: SpaceMetrics | null;
@@ -73,6 +74,12 @@ export async function buildSpaceReportPdf(input: SpaceReportPdfInput): Promise<U
   doc.setTitle(content.title, { showInWindowTitleBar: true });
   doc.setLanguage('en-US');
   doc.setAuthor('OpenLiDARViewer');
+  // Pin the Info-dictionary dates. pdf-lib defaults CreationDate and ModDate to
+  // the wall clock at `create()`, so two identical builds either side of a
+  // second boundary stop being byte-identical. See src/pdfInfoDate.ts.
+  const infoStamp = pdfInfoDate(input.generatedAt);
+  doc.setCreationDate(infoStamp);
+  doc.setModificationDate(infoStamp);
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
 

--- a/src/render/measure/terrainReportPdf.ts
+++ b/src/render/measure/terrainReportPdf.ts
@@ -33,6 +33,7 @@ import {
   type TerrainReportContent,
   type TerrainReportContentOptions,
 } from '../../terrain/export/terrainReportContent';
+import { pdfInfoDate } from '../../pdfInfoDate';
 
 const INK = rgb(0.12, 0.14, 0.18);
 const DIM = rgb(0.42, 0.46, 0.52);
@@ -83,7 +84,8 @@ function isContent(x: unknown): x is TerrainReportContent {
  * Build the Terrain Intelligence Report PDF and return its bytes. Accepts either
  * a pre-built {@link TerrainReportContent} (preferred when the caller already
  * assembled it) or a raw {@link AnalyseContoursResult} + provenance options
- * (assembled here). Pure given a fixed `generatedAt`.
+ * (assembled here). Pure: it carries no timestamp, and its Info-dictionary
+ * dates are pinned rather than read from the clock.
  */
 export async function buildTerrainReportPdf(
   input: TerrainReportContent | AnalyseContoursResult,
@@ -100,6 +102,12 @@ export async function buildTerrainReportPdf(
   doc.setTitle(content.title, { showInWindowTitleBar: true });
   doc.setLanguage('en-US');
   doc.setAuthor('OpenLiDARViewer');
+  // Pin the Info-dictionary dates. pdf-lib defaults CreationDate and ModDate to
+  // the wall clock at `create()`, so two identical builds either side of a
+  // second boundary stop being byte-identical. See src/pdfInfoDate.ts.
+  const infoStamp = pdfInfoDate(undefined);
+  doc.setCreationDate(infoStamp);
+  doc.setModificationDate(infoStamp);
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
 

--- a/src/report/ReportPdfRenderer.ts
+++ b/src/report/ReportPdfRenderer.ts
@@ -35,6 +35,7 @@ import { buildIdentityLabel } from '../build/buildIdentity';
 import { describeAnnotationGroups } from '../render/annotate/annotationClustering';
 import type { AnnotationType } from '../render/annotate/types';
 import type { FindingTier, ReportFinding, ReportInspectionSummary } from './ReportFindings';
+import { pdfInfoDate } from '../pdfInfoDate';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Layout constants — letter portrait, 0.6 inch margins.
@@ -113,7 +114,13 @@ export async function renderReportPdf(
   doc.setAuthor(inputs.branding.author ?? 'OpenLiDARViewer');
   doc.setCreator(`OpenLiDARViewer Report Engine v${buildIdentityLabel()}`);
   doc.setProducer('pdf-lib (lazy chunk)');
-  doc.setCreationDate(new Date());
+  // Pin the Info-dictionary dates from the cover's own export timestamp.
+  // pdf-lib defaults CreationDate and ModDate to the wall clock at `create()`,
+  // so two identical builds either side of a second boundary stop being
+  // byte-identical. See src/pdfInfoDate.ts.
+  const infoStamp = pdfInfoDate(inputs.cover.exportedAt);
+  doc.setCreationDate(infoStamp);
+  doc.setModificationDate(infoStamp);
 
   const helvetica = await doc.embedFont(StandardFonts.Helvetica);
   const helveticaBold = await doc.embedFont(StandardFonts.HelveticaBold);

--- a/src/terrain/export/contourStudioPdf.ts
+++ b/src/terrain/export/contourStudioPdf.ts
@@ -20,6 +20,7 @@
 
 import { PDFDocument, StandardFonts, rgb, degrees, type PDFFont, type PDFPage } from 'pdf-lib';
 import type { ContourPdfModel } from '../contourStudio/contourDeliverablePdfModel';
+import { pdfInfoDate } from '../../pdfInfoDate';
 
 const INK = rgb(0.12, 0.14, 0.18);
 const DIM = rgb(0.42, 0.46, 0.52);
@@ -98,6 +99,16 @@ export async function buildContourStudioPdf(model: ContourPdfModel): Promise<Uin
   doc.setTitle(pdfTitle, { showInWindowTitleBar: true });
   doc.setLanguage('en-US');
   doc.setAuthor('OpenLiDARViewer');
+  // Pin the Info-dictionary dates. pdf-lib defaults CreationDate and ModDate to
+  // the wall clock at `create()`, so two identical builds either side of a
+  // second boundary stop being byte-identical. See src/pdfInfoDate.ts.
+  // The model carries its timestamp only as rendered title-block text, so
+  // there is no structured date to source from here. The page still prints
+  // "Generated ...", and the Info dictionary takes the epoch rather than the
+  // clock.
+  const infoStamp = pdfInfoDate(undefined);
+  doc.setCreationDate(infoStamp);
+  doc.setModificationDate(infoStamp);
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
 

--- a/tests/pdfInfoDate.test.ts
+++ b/tests/pdfInfoDate.test.ts
@@ -1,0 +1,47 @@
+/**
+ * pdfInfoDate.test.ts — the Info-dictionary date must never come from a clock.
+ *
+ * The defect this guards against is subtle because the failure is intermittent:
+ * two builds only differ when they straddle a second boundary. So the cases
+ * that matter are the fallbacks, where reaching for `new Date()` would look
+ * harmless and would reintroduce the flake.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { pdfInfoDate, PDF_EPOCH } from '../src/pdfInfoDate';
+
+describe('pdfInfoDate', () => {
+  it('passes a Date through unchanged', () => {
+    const d = new Date('2026-03-04T05:06:07Z');
+    expect(pdfInfoDate(d).getTime()).toBe(d.getTime());
+  });
+
+  it('parses an ISO string, which is how most models carry the stamp', () => {
+    expect(pdfInfoDate('2026-03-04T05:06:07Z').toISOString()).toBe('2026-03-04T05:06:07.000Z');
+  });
+
+  it('accepts epoch milliseconds', () => {
+    expect(pdfInfoDate(1_700_000_000_000).getTime()).toBe(1_700_000_000_000);
+  });
+
+  for (const [label, value] of [
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty string', ''],
+    ['whitespace', '   '],
+    ['an unparseable string', 'not a date'],
+    ['an invalid Date', new Date('nonsense')],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ] as const) {
+    it(`falls back to the epoch for ${label}, never to the clock`, () => {
+      expect(pdfInfoDate(value as never).getTime()).toBe(PDF_EPOCH.getTime());
+    });
+  }
+
+  it('is stable across calls, which is the property the PDFs depend on', () => {
+    const a = pdfInfoDate(undefined);
+    const b = pdfInfoDate(undefined);
+    expect(a.getTime()).toBe(b.getTime());
+  });
+});

--- a/tests/pdfInfoDateDeterminism.test.ts
+++ b/tests/pdfInfoDateDeterminism.test.ts
@@ -1,0 +1,47 @@
+/**
+ * pdfInfoDateDeterminism.test.ts — PDF bytes must not move with the clock.
+ *
+ * The bug this pins down was intermittent by nature: pdf-lib stamps
+ * CreationDate and ModDate from the wall clock at `create()`, so two builds
+ * only diverged when they happened to straddle a second boundary. A test that
+ * simply builds twice therefore passes most of the time and fails in CI,
+ * which is how it survived. Advancing the clock between the two builds turns
+ * that race into a deterministic check.
+ *
+ * Every builder here is expected to be a pure function of its input. If one
+ * gains a new clock read, this fails every run rather than one run in five.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildProfilePdf } from '../src/render/measure/profilePdf';
+
+afterEach(() => { vi.useRealTimers(); });
+
+/** Build once, jump the clock a full second, build again. */
+async function buildAcrossASecondBoundary(build: () => Promise<Uint8Array>) {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-01-01T00:00:00.900Z'));
+  const first = Buffer.from(await build());
+  vi.setSystemTime(new Date('2026-01-01T00:00:01.900Z'));
+  const second = Buffer.from(await build());
+  return { first, second };
+}
+
+describe('PDF builders do not read the clock', () => {
+  it('buildProfilePdf is byte-identical across a second boundary', async () => {
+    const input = {
+      name: 'Deterministic',
+      samples: Array.from({ length: 24 }, (_, i) => ({
+        distanceM: i, elevationM: i * 0.5, groundElevationM: i * 0.4, count: 3,
+      })),
+      corridorWidthM: 4,
+      groundPercentile: 25,
+      crs: 'EPSG:32611',
+      verticalDatum: 'NAVD88',
+      generatedAt: new Date('2026-02-03T04:05:06Z'),
+    } as never;
+    const { first, second } = await buildAcrossASecondBoundary(() => buildProfilePdf(input));
+    expect(second.equals(first)).toBe(true);
+  });
+
+});


### PR DESCRIPTION
`tests/profilePdf.test.ts > is byte-identical for the same input` fails intermittently, including on #561's coverage job. pdf-lib defaults `CreationDate` and `ModDate` to the wall clock at `PDFDocument.create()`, so two builds that straddle a second boundary embed different timestamps. Decompressing the differing object stream shows `/ModDate (D:...4601Z)` against `(D:...4602Z)`. The pinned `generatedAt` never covered it: the Info dictionary is separate from the printed date.

`mapSheetPdf` already pinned both dates, with a comment describing this exact hole. The other five builders did not.

`pdfInfoDate` sources the Info date from whatever the document prints and falls back to the epoch, never the clock. `terrainReportPdf` also claimed purity given a `generatedAt` it has no field for.

The new determinism test advances the clock between the two builds, so the race fails every run instead of one in five. Verified red-green: reverting the pin fails it, restoring it passes.
