### PR TITLE
Wait for the rail to settle instead of sleeping through it

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -14,7 +14,7 @@
  *   empty-state copy changes.
  */
 
-import type { Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
@@ -131,4 +131,80 @@ export async function dropDenseGridPly(page: Page): Promise<void> {
     return dt;
   }, [...bytes]);
   await page.dispatchEvent('body', 'drop', { dataTransfer });
+}
+
+/**
+ * Wait until the desktop rail chrome has finished its mount animation.
+ *
+ * Two rules in 72-panel-rails.css keep the rail moving after a scan mounts:
+ * `.olv-left-panels:not(.olv-rail-collapsed) > *` runs the 380ms
+ * `olv-rail-panel-in` entrance, and each grabber tab transitions its `left` /
+ * `right` offset over 420ms on `--ease-spring`. `.olv-ws-body` is a direct
+ * child of the rail, so the whole scroller and every control inside it is
+ * still translating while that entrance plays.
+ *
+ * Only those two are awaited. The rail also hosts decorative animations that
+ * never end (status-dot pulse, the Analyse shimmer, the reclassify spinner),
+ * so a blanket "nothing is running" wait would never return.
+ */
+export async function railChromeSettled(page: Page, timeout = 15_000): Promise<void> {
+  // A style change queued in this frame has no running animation yet, so a
+  // check made straight away would pass before the entrance even starts. Let
+  // two frames go by first: that is a frame boundary, not a duration.
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+  await page.waitForFunction(
+    () => {
+      const SETTLING = new Set(['left', 'right', 'width', 'transform', 'opacity']);
+      return document.getAnimations().every((a) => {
+        if (a.playState !== 'running') return true;
+        const anim = a as Animation & { animationName?: string; transitionProperty?: string };
+        if (anim.animationName === 'olv-rail-panel-in') return false;
+        if (anim.transitionProperty === undefined) return true;
+        const target = (a.effect as KeyframeEffect | null)?.target ?? null;
+        if (target === null) return true;
+        const inRail =
+          target.closest('.olv-left-panels, .olv-right-rail, .olv-rail-tab, .olv-right-rail-tab') !==
+          null;
+        return !(inRail && SETTLING.has(anim.transitionProperty));
+      });
+    },
+    undefined,
+    { timeout },
+  );
+}
+
+/**
+ * Wait until `locator` is the element the browser actually hits at its own
+ * centre, then assert it. The layer row's rightmost control clears the
+ * `.olv-ws-body` client edge by 4px, so a few pixels of un-settled transform
+ * put that centre inside the scroller's reserved scrollbar gutter and
+ * `.olv-ws-body` wins the hit test. This waits for the condition the click
+ * needs rather than for a duration, and it keeps the interception check that
+ * `{ force: true }` would switch off.
+ */
+export async function expectHittable(locator: Locator, timeout = 15_000): Promise<void> {
+  await locator.waitFor({ state: 'visible', timeout });
+  await expect
+    .poll(
+      async () => {
+        // A click scrolls its target into view before it hits anything, and the
+        // rail scrolls, so do the same here. Without it the centre of a control
+        // below the fold is outside the viewport and nothing is hit at all.
+        await locator.scrollIntoViewIfNeeded({ timeout: 5_000 });
+        return locator.evaluate((el) => {
+          const r = el.getBoundingClientRect();
+          const hit = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+          if (hit === null) return 'nothing';
+          if (hit === el || el.contains(hit)) return 'target';
+          return hit.className || hit.tagName;
+        });
+      },
+      { timeout, message: 'the element at the target centre is still something else' },
+    )
+    .toBe('target');
 }

--- a/tests/e2e/reclassifyUi.spec.ts
+++ b/tests/e2e/reclassifyUi.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { dropDenseGridPly } from './helpers';
+import { dropDenseGridPly, railChromeSettled, expectHittable } from './helpers';
 
 /**
  * Reclassify control panel — the visible class-picker + undo/redo, driven as a
@@ -64,12 +64,17 @@ test('the reclassify panel mounts and its undo/redo buttons drive class edits', 
   expect(afterEdit).toBe(6);
   await expect(undoBtn).toBeEnabled();
 
-  // Click the REAL Undo button → class reverts, redo enables.
-  await undoBtn.click({ force: true });
+  // Click the REAL Undo button → class reverts, redo enables. The rail entrance
+  // is awaited and the hit test checked, so the click keeps Playwright's
+  // interception guard instead of forcing past it.
+  await railChromeSettled(page);
+  await expectHittable(undoBtn);
+  await undoBtn.click();
   expect(await page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0))).toBe(1);
   await expect(redoBtn).toBeEnabled();
 
   // Click the REAL Redo button → class re-applied.
-  await redoBtn.click({ force: true });
+  await expectHittable(redoBtn);
+  await redoBtn.click();
   expect(await page.evaluate(() => (window as unknown as { __OLV_TEST_API__: { classAt: (i: number) => number } }).__OLV_TEST_API__.classAt(0))).toBe(6);
 });

--- a/tests/e2e/rightRail.spec.ts
+++ b/tests/e2e/rightRail.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { suppressOnboardingTour, dropTinyPly } from './helpers';
+import { suppressOnboardingTour, dropTinyPly, railChromeSettled, expectHittable } from './helpers';
 
 /**
  * tests/e2e/rightRail.spec.ts
@@ -27,7 +27,7 @@ async function loadSample(page: Page, url = '/'): Promise<void> {
   await page.goto(url);
   await dropTinyPly(page);
   await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
-  await page.waitForTimeout(800);
+  await railChromeSettled(page);
 }
 
 test('the Inspector handle is hidden in the empty state (no scan)', async ({ page }) => {
@@ -47,15 +47,18 @@ test('the Inspector handle mounts, is visible, and starts expanded', async ({ pa
 
 test('the Inspector handle sits against the column, not the viewport centre', async ({ page }) => {
   await loadSample(page);
-  const inspBox = await page.locator(INSPECTOR).boundingBox();
-  const tabBox = await page.locator(TAB).boundingBox();
-  expect(inspBox).not.toBeNull();
-  expect(tabBox).not.toBeNull();
-  if (inspBox && tabBox) {
-    const tabRight = tabBox.x + tabBox.width;
-    expect(tabRight).toBeGreaterThanOrEqual(inspBox.x - 8);
-    expect(tabRight).toBeLessThanOrEqual(inspBox.x + 8);
-  }
+  // The handle's `right` offset is transitioned over 420ms on a spring easing
+  // (72-panel-rails.css), so this reads the geometry until it settles rather
+  // than once after a fixed wait. The bound is unchanged.
+  const offset = async (): Promise<number | null> => {
+    const inspBox = await page.locator(INSPECTOR).boundingBox();
+    const tabBox = await page.locator(TAB).boundingBox();
+    if (!inspBox || !tabBox) return null;
+    return tabBox.x + tabBox.width - inspBox.x;
+  };
+  await expect.poll(offset, { timeout: 15_000 }).not.toBeNull();
+  await expect.poll(offset, { timeout: 15_000 }).toBeGreaterThanOrEqual(-8);
+  expect(await offset()).toBeLessThanOrEqual(8);
 });
 
 test('clicking the Inspector handle collapses, then restores, the Inspector', async ({ page }) => {
@@ -63,10 +66,13 @@ test('clicking the Inspector handle collapses, then restores, the Inspector', as
   const tab = page.locator(TAB);
   const inspector = page.locator(INSPECTOR);
 
+  await expectHittable(tab);
   await tab.click();
   await expect(inspector).toHaveClass(/olv-right-collapsed/);
   await expect(tab).toHaveAttribute('aria-expanded', 'false');
 
+  await railChromeSettled(page);
+  await expectHittable(tab);
   await tab.click();
   await expect(inspector).not.toHaveClass(/olv-right-collapsed/);
   await expect(tab).toHaveAttribute('aria-expanded', 'true');
@@ -74,6 +80,7 @@ test('clicking the Inspector handle collapses, then restores, the Inspector', as
 
 test('the Inspector collapsed choice persists across a reload', async ({ page }) => {
   await loadSample(page);
+  await expectHittable(page.locator(TAB));
   await page.locator(TAB).click();
   await expect(page.locator(INSPECTOR)).toHaveClass(/olv-right-collapsed/);
 
@@ -83,7 +90,7 @@ test('the Inspector collapsed choice persists across a reload', async ({ page })
   await page.reload();
   await dropTinyPly(page);
   await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
-  await page.waitForTimeout(600);
+  await railChromeSettled(page);
   await expect(page.locator(INSPECTOR)).toHaveClass(/olv-right-collapsed/);
   await expect(page.locator(TAB)).toHaveAttribute('aria-expanded', 'false');
 });

--- a/tests/e2e/twoScanMount.spec.ts
+++ b/tests/e2e/twoScanMount.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { isBenignPageError } from './pageErrors';
+import { railChromeSettled, expectHittable } from './helpers';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { GlobalPoints } from '../../src/convert/globalPoints';
@@ -156,7 +157,10 @@ test('two georeferenced tiles mount into one frame at their real separation', as
 
   await dropBytes(page, bytesB, 'utm33-b.las');
   await expect(page.locator('.olv-layer')).toHaveCount(2, { timeout: 20_000 });
-  await page.waitForTimeout(500); // frame reconcile + health render
+  // Layer Health renders its own rows off the reconciled frame, so wait for
+  // both cards rather than for a duration.
+  await expect(page.locator('.olv-layerhealth-layer')).toHaveCount(2, { timeout: 20_000 });
+  await railChromeSettled(page);
 
   const layers = await readLayerHealth(page);
 
@@ -208,7 +212,8 @@ test('the surviving layer does not move when a sibling is added or removed (#2)'
   await expect(page.locator('.olv-layer')).toHaveCount(1, { timeout: 20_000 });
   await dropBytes(page, bytesB, 'utm33-b.las');
   await expect(page.locator('.olv-layer')).toHaveCount(2, { timeout: 20_000 });
-  await page.waitForTimeout(500);
+  await expect(page.locator('.olv-layerhealth-layer')).toHaveCount(2, { timeout: 20_000 });
+  await railChromeSettled(page);
 
   const withBoth = await readLayerHealth(page);
   const aWithBoth = withBoth.find((l) => l.name.includes('utm33-a'));
@@ -219,10 +224,17 @@ test('the surviving layer does not move when a sibling is added or removed (#2)'
     `A offset after B added was "${aWithBoth!.offsetToProject}"`,
   ).toBe(true);
 
-  // Remove B from the scene.
-  await page.getByRole('button', { name: 'Remove utm33-b.las' }).click();
+  // Remove B from the scene. The rail entrance translates `.olv-ws-body` and
+  // everything in it, and this control clears the scroller's client edge by
+  // 4px, so the click waits for the entrance to finish and for the button to
+  // be the element actually hit at its own centre.
+  const removeB = page.getByRole('button', { name: 'Remove utm33-b.las' });
+  await railChromeSettled(page);
+  await expectHittable(removeB);
+  await removeB.click();
   await expect(page.locator('.olv-layer')).toHaveCount(1, { timeout: 20_000 });
-  await page.waitForTimeout(300);
+  await expect(page.locator('.olv-layerhealth-layer')).toHaveCount(1, { timeout: 20_000 });
+  await railChromeSettled(page);
 
   const afterRemove = await readLayerHealth(page);
   const aAfter = afterRemove.find((l) => l.name.includes('utm33-a'));
@@ -273,7 +285,8 @@ test('a coordinate read from the mounted non-anchor layer is in the project fram
   await expect(page.locator('.olv-layer')).toHaveCount(1, { timeout: 20_000 });
   await dropBytes(page, bytesB, 'utm33-b.las');
   await expect(page.locator('.olv-layer')).toHaveCount(2, { timeout: 20_000 });
-  await page.waitForTimeout(500); // frame reconcile
+  await expect(page.locator('.olv-layerhealth-layer')).toHaveCount(2, { timeout: 20_000 });
+  await railChromeSettled(page);
 
   // Point 0 of each tile is its own origin corner: tileAt puts i=0 at (ox, oy).
   const pts = await page.evaluate(() => {


### PR DESCRIPTION
Three specs raced the left rail's entrance animation. `.olv-ws-body` is a direct child of `.olv-left-panels`, which runs a 380ms `olv-rail-panel-in` transform, and the grabber tabs spring their offset over 420ms. The layer row's Remove control clears the scroller edge by 4px, which is less than the 6px the entrance is still translating, so an early click lands in the scrollbar gutter and the scroller wins the hit test.

Two helpers replace the waits: one polls `document.getAnimations()` for the rail-scoped entrance and transitions to finish, scoped so the rail's infinite decorative animations do not hang it; the other polls `elementFromPoint` until the target is what a tap would reach.

`reclassifyUi` used `force: true`, which was hiding a control genuinely off-viewport. Scrolling into view fixed it and the interception check is kept.

Ninety passes per configuration across chromium and firefox, including firefox with classic scrollbars forced. The original CI failure needs llvmpipe and did not reproduce on macOS, so this is reasoned from the CSS and measured geometry rather than from a reproduced red.
