### PR TITLE
Three phone rules that regress silently

### DIFF
--- a/src/styles/65-mobile-touch.css
+++ b/src/styles/65-mobile-touch.css
@@ -32,10 +32,15 @@
   box-shadow: var(--olv-cta-shadow);
   transition: box-shadow var(--dur-fast) var(--ease-standard), transform 90ms var(--ease-standard);
 }
-.olv-open-btn:hover {
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.22) inset,
-    0 8px 30px rgba(0, 178, 255, 0.38);
+/* A tap fires :hover on a touch screen and it sticks until the next tap
+   elsewhere, leaving the control looking permanently pressed. Guarding the
+   rule keeps the affordance on pointers that can actually hover. */
+@media (hover: hover) {
+  .olv-open-btn:hover {
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.22) inset,
+      0 8px 30px rgba(0, 178, 255, 0.38);
+  }
 }
 .olv-open-btn:active { transform: scale(0.96); }
 .olv-open-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -315,7 +320,7 @@
     font-size: 17px; line-height: 1;
     min-width: 44px; min-height: 44px;
   }
-  .olv-touch-hint-x:hover { color: var(--text); }
+  @media (hover: hover) { .olv-touch-hint-x:hover { color: var(--text); } }
 
   /* Scan Info launcher — kept hidden on phones now that the bottom
      sheet peeks. The peeked head bar IS the launcher (tap it to expand),
@@ -423,7 +428,7 @@
     min-width: 44px; min-height: 44px;
     margin: -8px -10px -8px 0;
   }
-  .olv-sheet-close:hover { color: var(--text); }
+  @media (hover: hover) { .olv-sheet-close:hover { color: var(--text); } }
   /* When peeked, hide the close button — there's nothing to close yet.
      It reappears once the sheet is open so the user has a familiar
      dismiss target. */

--- a/src/styles/90-converter-export.css
+++ b/src/styles/90-converter-export.css
@@ -159,7 +159,12 @@
 
 @media (max-width: 767px) {
   .olv-bc-overlay { padding: 0; align-items: stretch; }
+  /* `100vh` on mobile Safari counts the dynamic toolbar, so a full-height
+     dialog runs under the browser chrome and its last row cannot be reached.
+     `dvh` tracks the visible area; the plain `vh` line stays first as the
+     fallback for engines without it. Same pattern as the phone sheet. */
   .olv-bc-dialog { max-width: none; max-height: 100vh; border-radius: 0; padding: var(--space-2xl); }
+  .olv-bc-dialog { max-height: min(100dvh, 100vh); }
 }
 
 /* In-project Export / Convert panel — converter controls in the left column. */

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -14,7 +14,7 @@
  *   empty-state copy changes.
  */
 
-import { expect, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
@@ -207,4 +207,27 @@ export async function expectHittable(locator: Locator, timeout = 15_000): Promis
       { timeout, message: 'the element at the target centre is still something else' },
     )
     .toBe('target');
+}
+
+/**
+ * Activate a control the way the running device actually would.
+ *
+ * The mobile specs run under two projects: `deterministic` (Desktop Chrome,
+ * no touch) and `webkit-mobile` (iPhone 15, touch). Those need different
+ * gestures, and picking the wrong one is quietly misleading in both
+ * directions. `tap()` throws where `hasTouch` is unset, so it cannot simply
+ * be used everywhere. `click()` synthesizes a mouse event, which a handler
+ * bound only to touch events can ignore, so a click-based mobile test can
+ * pass against a control that does nothing under a real thumb.
+ *
+ * Reading `hasTouch` off the project rather than sniffing the user agent
+ * keeps this honest: it reports what Playwright actually configured.
+ */
+export async function activate(locator: Locator): Promise<void> {
+  const hasTouch = test.info().project.use.hasTouch === true;
+  if (hasTouch) {
+    await locator.tap();
+    return;
+  }
+  await locator.click();
 }

--- a/tests/e2e/visualsStudioMobile.spec.ts
+++ b/tests/e2e/visualsStudioMobile.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { dropTinyPly } from './helpers';
+import { activate, dropTinyPly } from './helpers';
 
 /**
  * Visuals Studio — mobile viewport contract.
@@ -40,7 +40,7 @@ async function loadOnPhoneAndOpenSheet(
   // the sheet and activates that tab's slot.
   const viewTab = page.locator('.olv-mobile-sheet .olv-msheet-tab[data-tab="view"]');
   await expect(viewTab).toBeVisible({ timeout: 8_000 });
-  await viewTab.click();
+  await activate(viewTab);
   await expect(page.locator('.olv-msheet-slot[data-tab="view"].is-active')).toBeVisible({
     timeout: 4_000,
   });
@@ -55,7 +55,7 @@ async function loadOnPhoneAndOpenSheet(
       .first()
       .evaluate((el) => (el as HTMLDetailsElement).open);
     if (!isOpen) {
-      await visualsDetails.locator('summary').first().click();
+      await activate(visualsDetails.locator('summary').first());
     }
   }
 }

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -2950,10 +2950,15 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   box-shadow: var(--olv-cta-shadow);
   transition: box-shadow var(--dur-fast) var(--ease-standard), transform 90ms var(--ease-standard);
 }
-.olv-open-btn:hover {
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.22) inset,
-    0 8px 30px rgba(0, 178, 255, 0.38);
+/* A tap fires :hover on a touch screen and it sticks until the next tap
+   elsewhere, leaving the control looking permanently pressed. Guarding the
+   rule keeps the affordance on pointers that can actually hover. */
+@media (hover: hover) {
+  .olv-open-btn:hover {
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.22) inset,
+      0 8px 30px rgba(0, 178, 255, 0.38);
+  }
 }
 .olv-open-btn:active { transform: scale(0.96); }
 .olv-open-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -3233,7 +3238,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
     font-size: 17px; line-height: 1;
     min-width: 44px; min-height: 44px;
   }
-  .olv-touch-hint-x:hover { color: var(--text); }
+  @media (hover: hover) { .olv-touch-hint-x:hover { color: var(--text); } }
 
   /* Scan Info launcher — kept hidden on phones now that the bottom
      sheet peeks. The peeked head bar IS the launcher (tap it to expand),
@@ -3341,7 +3346,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
     min-width: 44px; min-height: 44px;
     margin: -8px -10px -8px 0;
   }
-  .olv-sheet-close:hover { color: var(--text); }
+  @media (hover: hover) { .olv-sheet-close:hover { color: var(--text); } }
   /* When peeked, hide the close button — there's nothing to close yet.
      It reappears once the sheet is open so the user has a familiar
      dismiss target. */
@@ -7381,7 +7386,12 @@ body.olv-cvd .olv-di-confidence-chip[data-band="red"]     { background: #d55e00;
 
 @media (max-width: 767px) {
   .olv-bc-overlay { padding: 0; align-items: stretch; }
+  /* `100vh` on mobile Safari counts the dynamic toolbar, so a full-height
+     dialog runs under the browser chrome and its last row cannot be reached.
+     `dvh` tracks the visible area; the plain `vh` line stays first as the
+     fallback for engines without it. Same pattern as the phone sheet. */
   .olv-bc-dialog { max-width: none; max-height: 100vh; border-radius: 0; padding: var(--space-2xl); }
+  .olv-bc-dialog { max-height: min(100dvh, 100vh); }
 }
 
 /* In-project Export / Convert panel — converter controls in the left column. */

--- a/tests/mobileViewportContract.test.ts
+++ b/tests/mobileViewportContract.test.ts
@@ -1,0 +1,80 @@
+/**
+ * mobileViewportContract.test.ts — phone rules that regress silently.
+ *
+ * These three are stylesheet properties, so nothing throws and no screenshot
+ * looks obviously wrong when they break. They surface only on a real phone,
+ * which is the slowest possible place to find them. Reading the sheets
+ * directly catches a regression at unit speed, and the browser contract in
+ * tests/e2e/visualsStudioMobile.spec.ts covers the behaviour on top of this.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const STYLES = fileURLToPath(new URL('../src/styles/', import.meta.url));
+const sheets = readdirSync(STYLES).filter((f) => f.endsWith('.css'));
+const read = (f: string) => readFileSync(`${STYLES}${f}`, 'utf8');
+const ALL = sheets.map((f) => ({ file: f, css: read(f) }));
+
+/** Strip comments so a rule quoted in prose is not read as a declaration. */
+const code = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '');
+
+describe('full-height on mobile Safari', () => {
+  // `100vh` counts the dynamic toolbar, so a full-height element runs under
+  // the browser chrome and its last row cannot be reached. Every declaration
+  // that asks for a full viewport height needs a `dvh` companion.
+  it('pairs every full-viewport height with a dvh companion', () => {
+    const offenders: string[] = [];
+    for (const { file, css } of ALL) {
+      const body = code(css);
+      // A full-height request: 100vh used for height or max-height.
+      if (!/(?:^|[^-\w])(?:max-)?height:\s*[^;]*\b100vh\b/m.test(body)) continue;
+      if (!/\ddvh\b/.test(body)) offenders.push(file);
+    }
+    expect(offenders, 'sheets asking for 100vh with no dvh companion').toEqual([]);
+  });
+});
+
+describe('hover on a touch screen', () => {
+  // A tap fires :hover and it sticks until the next tap elsewhere, so a
+  // control keeps its hover styling indefinitely. The phone stylesheets are
+  // reached only by touch devices, so an unguarded :hover there is always
+  // wrong. Desktop sheets are out of scope: they legitimately assume a mouse.
+  const PHONE_ONLY = ['65-mobile-touch.css', '96-phone-sheet-story.css', '99-mobile-gui-refresh.css'];
+
+  for (const file of PHONE_ONLY) {
+    it(`${file} guards every :hover behind a hover-capable query`, () => {
+      const body = code(read(file));
+      const unguarded: string[] = [];
+      let depth = 0;
+      let guarded = -1;
+      for (const line of body.split('\n')) {
+        if (/@media[^{]*\bhover:\s*hover\b/.test(line) && guarded < 0) guarded = depth;
+        if (/:hover\b/.test(line) && guarded < 0) unguarded.push(line.trim());
+        depth += (line.match(/\{/g) ?? []).length;
+        depth -= (line.match(/\}/g) ?? []).length;
+        if (guarded >= 0 && depth <= guarded) guarded = -1;
+      }
+      expect(unguarded, `unguarded :hover in ${file}`).toEqual([]);
+    });
+  }
+});
+
+describe('input zoom on focus', () => {
+  // Mobile Safari zooms the whole page when a focused input is under 16px,
+  // and the user has to pinch back out. It reads as a font-size preference
+  // and behaves like a navigation bug.
+  it('never sets a text-input font size below 16px in a phone sheet', () => {
+    const offenders: string[] = [];
+    for (const file of ['65-mobile-touch.css', '96-phone-sheet-story.css', '99-mobile-gui-refresh.css']) {
+      const body = code(read(file));
+      const re = /(input|textarea|select)[^{}]*\{[^}]*font-size:\s*([\d.]+)px/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(body)) !== null) {
+        if (Number(m[2]) < 16) offenders.push(`${file}: ${m[1]} at ${m[2]}px`);
+      }
+    }
+    expect(offenders, 'phone inputs below the 16px zoom threshold').toEqual([]);
+  });
+});


### PR DESCRIPTION
Three phone rules that regress without failing anything.

The converter dialog capped at `max-height: 100vh`. Mobile Safari counts the dynamic toolbar in `vh`, so a full-height dialog ran under the browser chrome and its last row could not be reached. It now carries the `min(100dvh, 100vh)` companion the phone sheet already used.

Three `:hover` rules on controls a phone can reach were unguarded. A tap fires hover on a touch screen and it sticks until the next tap elsewhere, so the control kept its hover styling. They sit behind `@media (hover: hover)` now, matching the `hover: none` guard already in the measurement bar.

The mobile spec activated controls with `click()`, which synthesizes a mouse event a touch handler can ignore. A new `activate()` helper reads `hasTouch` off the running project and taps where the device has touch.

A unit test pins all three, mutation-checked. Verified on Playwright `webkit-mobile`, real WebKit at iPhone 15: 10 passed.

The bare `env(safe-area-inset-bottom)` on the phone sheet was left alone. The sheet body carries its own bottom padding, so the inset is additive home-indicator clearance and a `max()` floor would add dead space.
