### PR TITLE
Fail a pull request that narrates how it was written

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -58,3 +58,8 @@ jobs:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_OPEN_COUNT: ${{ steps.queue.outputs.count }}
+          # The body is read for process narration. Passed through the
+          # environment rather than interpolated into the run script, so a
+          # body containing quotes or shell metacharacters cannot alter the
+          # command.
+          PR_BODY: ${{ github.event.pull_request.body }}

--- a/scripts/pr-hygiene.mjs
+++ b/scripts/pr-hygiene.mjs
@@ -64,6 +64,62 @@ const list = (files) =>
  *   linearHistoryRequired, commitsBehind, openPrCount, generatedFiles[]
  * }
  */
+
+/**
+ * Wording that describes how the change was produced rather than what it does.
+ *
+ * A pull request body and a commit message are read by people deciding whether
+ * to trust and merge software. An account of the author's attempts, doubts or
+ * instructions is noise there, and it survives in the permanent record long
+ * after the session that produced it is gone. Nothing else in the pipeline
+ * catches it: the prose gate looks for AI-writing tells and the archive gate
+ * never reads a commit message at all.
+ *
+ * The patterns are deliberately narrow. A rule that fires on the word "I"
+ * would be argued with and then disabled, which is worse than no rule, so
+ * each one targets a construction that is hard to write by accident when
+ * describing software.
+ */
+export const NARRATION_PATTERNS = [
+  { id: 'first-person-process',
+    // Allows up to two intervening adverbs ("I then quickly realised"), because
+    // the construction is what matters and the adverb is incidental.
+    re: /\b(?:I|we)\s+(?:\w+ly\s+|then\s+|first\s+|initially\s+|also\s+|originally\s+){0,2}(?:tried|realized|realised|noticed|decided|thought|discovered|found|started|began|went\s+with|opted|assumed|expected)\b/i,
+    why: 'first-person process narration' },
+  { id: 'deliberation', re: /(?:^|\n)\s*(?:Actually|Wait|Hmm|Let me|Let's see|On reflection|Turns out|It turns out)\b/i,
+    why: 'thinking-aloud opener' },
+  { id: 'instruction-echo', re: /\b(?:as\s+(?:you\s+)?(?:requested|asked)|per\s+your\s+(?:request|instruction)|the\s+user\s+(?:asked|wants|requested))\b/i,
+    why: 'echo of the instruction that prompted the work' },
+  { id: 'agent-self-reference', re: /\b(?:sub-?agents?|the\s+agent|Claude|Co-Authored-By|my\s+(?:analysis|reasoning|plan))\b/i,
+    why: 'reference to the authoring process rather than the software' },
+  { id: 'session-artifact', re: /\b(?:in\s+this\s+session|this\s+conversation|the\s+transcript|scratchpad|TODO|FIXME|XXX)\b/,
+    why: 'working-note artifact' },
+  { id: 'try-fail-narrative', re: /\b(?:at\s+first|initially,|my\s+first\s+attempt|that\s+did\s?n[o']t\s+work|second\s+attempt)\b/i,
+    why: 'account of attempts rather than the result' },
+];
+
+/**
+ * Find process narration in a body of authored text.
+ *
+ * Fenced code blocks and quoted lines are exempt: a diff, a log excerpt or a
+ * quoted error legitimately contains any wording at all, and flagging those
+ * would push authors to stop pasting the evidence that makes a PR reviewable.
+ */
+export function collectNarrationProblems(text, label = 'text') {
+  if (!text) return [];
+  const stripped = String(text)
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/^\s*>.*$/gm, ' ')
+    .replace(/`[^`\n]*`/g, ' ');
+  const found = [];
+  for (const { id, re, why } of NARRATION_PATTERNS) {
+    const m = re.exec(stripped);
+    if (m) found.push(`[H7 narration] ${label} contains ${why} ("${m[0].trim()}"). ` +
+      'Say what the software does now, not how the change was arrived at.');
+  }
+  return found;
+}
+
 export function collectHygieneProblems(observation) {
   const {
     baseRef = 'main',
@@ -188,6 +244,23 @@ if (isCli) {
 
   const observation = observeBranch(base, head, { openPrCount, allowedBases: [base] });
   const { errors, warnings } = collectHygieneProblems(observation);
+
+  // The authored text: the PR body, supplied by the workflow, and every commit
+  // message on the branch. Both outlive the session that wrote them, so both
+  // are checked. A missing PR_BODY means the check simply has less to read; it
+  // is not treated as a pass or as a failure.
+  errors.push(...collectNarrationProblems(process.env.PR_BODY ?? '', 'the PR body'));
+  try {
+    const mergeBase = execFileSync('git', ['merge-base', base, head], {
+      cwd: ROOT, encoding: 'utf8',
+    }).trim();
+    const log = execFileSync('git', ['log', '--format=%B', `${mergeBase}..${head}`], {
+      cwd: ROOT, encoding: 'utf8',
+    });
+    errors.push(...collectNarrationProblems(log, 'a commit message on this branch'));
+  } catch {
+    // No git history to read. The PR body check above still applies.
+  }
 
   for (const w of warnings) console.log(`  note: ${w}`);
 

--- a/tests/prHygiene.test.ts
+++ b/tests/prHygiene.test.ts
@@ -25,7 +25,7 @@ import { join } from 'node:path';
 
 // Kept on one line: @ts-expect-error applies to the line that follows it.
 // @ts-expect-error — plain .mjs script, no types
-import { collectHygieneProblems, observeBranch, REDUNDANT_LIMIT } from '../scripts/pr-hygiene.mjs';
+import { collectHygieneProblems, collectNarrationProblems, observeBranch, REDUNDANT_LIMIT } from '../scripts/pr-hygiene.mjs';
 
 interface Report { errors: string[]; warnings: string[] }
 
@@ -222,5 +222,69 @@ describe('observeBranch — measured against real history', () => {
     const o = observeBranch('main', 'merger', { allowedBases: ['main'] }, dir) as { mergeCommits: string[] };
     expect(o.mergeCommits.length).toBe(1);
     expect(ids(run({ ...o, baseRef: 'main', allowedBases: ['main'] }).errors)).toContain('H2');
+  });
+});
+
+/**
+ * H7 — process narration in the authored text.
+ *
+ * A PR body and a commit message are permanent, and they are read by someone
+ * deciding whether to trust the change. An account of the author's attempts,
+ * doubts or instructions belongs in neither. Nothing else in the pipeline
+ * catches it: the prose gate reads documents rather than commit messages, and
+ * the archive gate never sees a PR body at all.
+ *
+ * The cases that matter most here are the NEGATIVES. A rule that fires on
+ * ordinary software description would be argued with and then switched off,
+ * which leaves the project worse than having no rule.
+ */
+describe('H7 process narration', () => {
+  const flagged = (s: string) => collectNarrationProblems(s).length > 0;
+
+  it('passes text that describes the software', () => {
+    for (const ok of [
+      'Pins the Info dictionary dates so two identical builds reproduce.',
+      'The reader found nine dimensions agreed exactly over 1.79 M points.',
+      'Agreement between implementations is not accuracy against surveyed truth.',
+      'GRASS computes in double and reproduces every closed-form volume.',
+      'Every case must agree with the closed form and with the reference.',
+    ]) {
+      expect(flagged(ok), ok).toBe(false);
+    }
+  });
+
+  it('flags an account of how the change was reached', () => {
+    for (const bad of [
+      'I first tried a merge, then rebased onto main.',
+      'We initially assumed the tolerance had been preregistered.',
+      'Actually the digest has to follow the file.',
+      'As requested, the gate is now stricter.',
+      'The user asked for a linear history.',
+      'Let me know whether the tolerance should move.',
+      'A sub-agent verified the reference.',
+      'Left a TODO for the landscape case.',
+    ]) {
+      expect(flagged(bad), bad).toBe(true);
+    }
+  });
+
+  it('exempts fenced code, inline code and quoted lines', () => {
+    // A pasted diff, log or quoted error legitimately contains any wording.
+    // Flagging those would push authors to stop pasting the evidence that
+    // makes a pull request reviewable, which is the opposite of the intent.
+    expect(flagged('```\nI tried this and it failed\n```')).toBe(false);
+    expect(flagged('> I first tried a merge')).toBe(false);
+    expect(flagged('The flag `--let-me-through` is rejected.')).toBe(false);
+  });
+
+  it('names the source so the author knows which text to fix', () => {
+    const [problem] = collectNarrationProblems('As requested, done.', 'the PR body');
+    expect(problem).toContain('the PR body');
+    expect(problem).toContain('H7');
+  });
+
+  it('reads empty and missing text as nothing to report', () => {
+    expect(collectNarrationProblems('')).toEqual([]);
+    expect(collectNarrationProblems(undefined as unknown as string)).toEqual([]);
   });
 });


### PR DESCRIPTION
A PR body and a commit message outlive the work that produced them, and both are read by someone deciding whether to trust the change. An account of attempts, doubts or the instruction behind the work belongs in neither. Nothing else in the pipeline reads them: the prose gate reads documents, and the archive gate never sees a PR body.

H7 checks the body and every commit message on the branch against six narrow constructions: first-person process narration, thinking-aloud openers, echoes of the instruction, references to the authoring process, working-note artifacts, and accounts of failed attempts.

The patterns are deliberately narrow. A rule that fired on ordinary software description would be argued with and then switched off, so the tests weight the negative cases: "The reader found nine dimensions agreed exactly" must pass.

Fenced code, inline code and quoted lines are exempt, because a pasted diff or error legitimately contains any wording and the alternative is authors omitting the evidence that makes a PR reviewable.

The workflow passes the body through the environment rather than the run script, so a body with shell metacharacters cannot alter the command.
