### PR TITLE
Keep the PTX acquisition grid instead of flattening it away

### DIFF
--- a/src/io/e57/parseE57.ts
+++ b/src/io/e57/parseE57.ts
@@ -16,7 +16,7 @@ import { parseE57Header } from './header';
 import { depage, physicalToLogical } from './depage';
 import { parseXml } from './xml';
 import { readE57Document } from './schema';
-import type { E57Field, E57Metadata, E57Pose, E57SourceMetadata } from './schema';
+import type { E57Field, E57Metadata, E57Pose, E57Scan, E57SourceMetadata } from './schema';
 import { decodeCompressedVector } from './compressedVector';
 import type { DecodedColumns } from './compressedVector';
 
@@ -67,11 +67,17 @@ export interface E57ParseResult {
 /** Options for {@link parseE57}. */
 export interface ParseE57Options {
   /**
-   * Decode only the prototype columns this accepts (by field name). Omitted →
-   * every column decodes (the default; callers inspecting the full prototype
-   * rely on it). The loader passes a predicate to skip columns it never reads.
+   * Decode only the prototype columns this accepts. Omitted → every column
+   * decodes (the default; callers inspecting the full prototype rely on it).
+   * The loader passes a predicate to skip columns it never reads.
+   *
+   * The predicate answers PER SCAN: it receives the scan whose columns are
+   * being decided, so a file may decode a column for one scan and skip it for
+   * another. `parseE57` binds the scan before the decode rather than handing
+   * `decodeCompressedVector` a scan it has no other use for. A one-argument
+   * predicate stays valid and simply ignores the scan.
    */
-  keepField?: (name: string) => boolean;
+  keepField?: (name: string, scan: E57Scan) => boolean;
   /**
    * Read one record per bucket of `stride` rather than every record. 1 (the
    * default) reads every record. The loader sets this from its decode plan when
@@ -122,6 +128,7 @@ export function parseE57(buffer: ArrayBuffer, opts?: ParseE57Options): E57ParseR
   }
 
   const stride = Math.max(1, Math.floor(opts?.stride ?? 1));
+  const keepField = opts?.keepField;
   const scans: E57ScanData[] = document.scans.map((scan) => ({
     name: scan.name,
     guid: scan.guid,
@@ -139,7 +146,7 @@ export function parseE57(buffer: ArrayBuffer, opts?: ParseE57Options): E57ParseR
       scan.recordCount,
       scan.prototype,
       header.pageSize,
-      { keepField: opts?.keepField, stride },
+      { keepField: keepField && ((name: string) => keepField(name, scan)), stride },
     ),
   }));
 

--- a/src/io/e57/preflight.ts
+++ b/src/io/e57/preflight.ts
@@ -57,9 +57,32 @@ export function e57LocalFieldName(key: string): string {
   return key.slice(key.indexOf(':') + 1);
 }
 
-/** True when `loadE57` decodes a prototype field of this name. */
+/** True when `loadE57` decodes a prototype field of this name, in any scan. */
 export function e57FieldIsConsumed(name: string): boolean {
   return E57_CONSUMED_FIELDS.has(e57LocalFieldName(name));
+}
+
+/**
+ * The fields `loadE57` decodes FOR ONE SCAN, by local name.
+ *
+ * Every scan currently yields {@link E57_CONSUMED_FIELDS} unchanged. The set is
+ * resolved per scan so that a scan whose declarations earn it extra columns can
+ * be given them WITHOUT every ordinary E57 paying for columns it never reads —
+ * the cost that keeps `rowIndex`, `columnIndex` and `sphericalRange` out of the
+ * global set in the first place. Widening the global set instead would expand a
+ * full Float64 column per unread field on every file.
+ *
+ * Both the byte estimate below and the decode resolve their answer through this
+ * one function, so a future scan-dependent set cannot make them disagree; the
+ * estimate is what the fail-closed memory ceiling rests on.
+ */
+export function e57ConsumedFieldsForScan(_scan: E57Scan): ReadonlySet<string> {
+  return E57_CONSUMED_FIELDS;
+}
+
+/** {@link e57ConsumedFieldsForScan} as the predicate shape `parseE57` takes. */
+export function e57FieldIsConsumedForScan(name: string, scan: E57Scan): boolean {
+  return e57ConsumedFieldsForScan(scan).has(e57LocalFieldName(name));
 }
 
 /** What an E57 declares, before any point is decoded. */
@@ -113,8 +136,11 @@ export function summariseE57Scans(scans: readonly E57Scan[]): E57Preflight {
   let columnValues = 0;
   for (const scan of scans) {
     const names = fieldNames(scan.prototype);
+    const consumedHere = e57ConsumedFieldsForScan(scan);
     let consumed = 0;
-    for (const field of scan.prototype) if (e57FieldIsConsumed(field.name)) consumed++;
+    for (const field of scan.prototype) {
+      if (consumedHere.has(e57LocalFieldName(field.name))) consumed++;
+    }
     columnValues += scan.recordCount * consumed;
     if (names.bare.has('cartesianX') && names.bare.has('cartesianY') && names.bare.has('cartesianZ')) {
       mergeable.push(names);

--- a/src/io/e57/schema.ts
+++ b/src/io/e57/schema.ts
@@ -20,6 +20,17 @@ export interface E57Field {
   floatBytes?: 4 | 8;
   /** Integer / scaledInteger fields: value added back to the packed integer. */
   minimum?: number;
+  /**
+   * Integer / scaledInteger fields: the declared upper bound, verbatim.
+   *
+   * Nothing reads this today — {@link bitWidthFor} consumes it and the decode
+   * needs only the width. It is retained because the bound, not the width, is
+   * what lets a later step choose an integer array wide enough for a declared
+   * index without guessing: a field packed in 11 bits still says 2047, and
+   * `2 ** bitWidth - 1 + minimum` is only the same number when the writer used
+   * a power-of-two range. Keeping it has no behavioural effect.
+   */
+  maximum?: number;
   /** Integer / scaledInteger fields: bit width of the packed integer. */
   bitWidth?: number;
   /** scaledInteger fields only. */
@@ -32,6 +43,50 @@ export interface E57Pose {
   /** Rotation quaternion, `[w, x, y, z]`. */
   rotation: [number, number, number, number];
   translation: [number, number, number];
+}
+
+/**
+ * One declared index range from a scan's `indexBounds`, inclusive at both ends.
+ *
+ * Present only when the file declared the axis. An EMPTY element is the E57
+ * type's default value (0), which is a declaration; an absent element is not,
+ * and an axis whose declared bound is unusable is reported as absent rather
+ * than repaired.
+ */
+export interface E57IndexRange {
+  minimum: number;
+  maximum: number;
+}
+
+/**
+ * A scan's `indexBounds`: the row, column and return ranges the writer used.
+ *
+ * Modelled per axis rather than as six loose numbers because the axes are
+ * declared independently — the pump fixture states row 0..1073 and column
+ * 0..344 while leaving both return elements empty — and a caller needs to know
+ * which axes it may rely on, not merely what number an absent one defaulted to.
+ */
+export interface E57IndexBounds {
+  row: E57IndexRange | null;
+  column: E57IndexRange | null;
+  return: E57IndexRange | null;
+}
+
+/**
+ * Which structured prototype fields a scan actually declares, by LOCAL name so
+ * an extension prefix does not hide one.
+ *
+ * A scan that declares `rowIndex` and `columnIndex` is structurally different
+ * from one that does not, and that difference has to be read from the file
+ * rather than inferred from the presence of `indexBounds` (a writer may state
+ * bounds for a scan whose records carry no indices, and the reverse).
+ */
+export interface E57StructuredFields {
+  rowIndex: boolean;
+  columnIndex: boolean;
+  returnIndex: boolean;
+  returnCount: boolean;
+  sphericalRange: boolean;
 }
 
 /** One scan (a `data3D` child). */
@@ -47,6 +102,10 @@ export interface E57Scan {
   colorMax: number | null;
   /** Declared intensity maximum; null if absent. */
   intensityMax: number | null;
+  /** The declared `indexBounds` structure, or null when the scan has none. */
+  indexBounds: E57IndexBounds | null;
+  /** Which structured fields this scan's prototype declares. */
+  structuredFields: E57StructuredFields;
 }
 
 /** File-level provenance metadata. */
@@ -202,20 +261,24 @@ function readField(node: XmlNode): E57Field {
   }
   if (type === 'Integer') {
     const min = attrIntStrict(node, 'minimum', 0);
+    const max = attrIntStrict(node, 'maximum', 0);
     return {
       name: node.name,
       type: 'integer',
       minimum: min,
-      bitWidth: bitWidthFor(min, attrIntStrict(node, 'maximum', 0)),
+      maximum: max,
+      bitWidth: bitWidthFor(min, max),
     };
   }
   if (type === 'ScaledInteger') {
     const min = attrIntStrict(node, 'minimum', 0);
+    const max = attrIntStrict(node, 'maximum', 0);
     return {
       name: node.name,
       type: 'scaledInteger',
       minimum: min,
-      bitWidth: bitWidthFor(min, attrIntStrict(node, 'maximum', 0)),
+      maximum: max,
+      bitWidth: bitWidthFor(min, max),
       scale: attrFloatStrict(node, 'scale', 1),
       offset: attrFloatStrict(node, 'offset', 0),
     };
@@ -304,6 +367,88 @@ function readRecordCount(points: XmlNode): number {
   return count;
 }
 
+/**
+ * A field's LOCAL name, after any extension `prefix:` — so `nor:normalX` and
+ * `x:rowIndex` resolve to `normalX` and `rowIndex`.
+ *
+ * Duplicated from `preflight.ts` rather than imported: preflight already
+ * imports this module, and the structured declarations are read here, at the
+ * point the prototype is interpreted.
+ */
+function localFieldName(name: string): string {
+  return name.slice(name.indexOf(':') + 1);
+}
+
+/**
+ * One `indexBounds` axis, or null when the file does not usably declare it.
+ *
+ * Both element names must be considered: an axis counts as declared when
+ * EITHER endpoint element is present, and a present-but-empty element is the
+ * E57 default value 0. A bound that is present and unreadable (non-finite, or
+ * beyond the safe-integer range) yields null rather than a throw — nothing
+ * consumes these bounds yet, and a file that decodes today must keep decoding.
+ */
+function readIndexRange(bounds: XmlNode, axis: string): E57IndexRange | null {
+  const minNode = child(bounds, `${axis}Minimum`);
+  const maxNode = child(bounds, `${axis}Maximum`);
+  if (!minNode && !maxNode) return null;
+  const read = (node: XmlNode | undefined): number | null => {
+    if (!node || node.text.trim() === '') return 0; // empty element = the default value
+    const v = Number(node.text);
+    return Number.isSafeInteger(v) ? v : null;
+  };
+  const minimum = read(minNode);
+  const maximum = read(maxNode);
+  if (minimum === null || maximum === null) return null;
+  return { minimum, maximum };
+}
+
+/** A scan's `indexBounds` structure, or null when it declares none. */
+function readIndexBounds(scan: XmlNode): E57IndexBounds | null {
+  const bounds = child(scan, 'indexBounds');
+  if (!bounds) return null;
+  return {
+    row: readIndexRange(bounds, 'row'),
+    column: readIndexRange(bounds, 'column'),
+    return: readIndexRange(bounds, 'return'),
+  };
+}
+
+/** Which structured fields a prototype declares, matched by local name. */
+function readStructuredFields(prototype: readonly E57Field[]): E57StructuredFields {
+  const local = new Set(prototype.map((f) => localFieldName(f.name)));
+  return {
+    rowIndex: local.has('rowIndex'),
+    columnIndex: local.has('columnIndex'),
+    returnIndex: local.has('returnIndex'),
+    returnCount: local.has('returnCount'),
+    sphericalRange: local.has('sphericalRange'),
+  };
+}
+
+/**
+ * Whether this scan could carry an acquisition grid, on the strength of what it
+ * DECLARES. Pure, and deliberately not wired into the decode: it is the seam a
+ * later step reads, and stating it separately keeps the eligibility rule
+ * reviewable on its own.
+ *
+ * All four facts are required together. Prototype indices without bounds leave
+ * the grid's extent unknown; bounds without indices state an extent no record
+ * can be placed in; and a range whose maximum sits below its minimum describes
+ * no grid at all. The cell count must stay a safe integer so a later allocation
+ * cannot be sized from arithmetic that has already lost precision.
+ */
+export function e57ScanSupportsStructuredRange(scan: E57Scan): boolean {
+  const { rowIndex, columnIndex } = scan.structuredFields;
+  if (!rowIndex || !columnIndex) return false;
+  const row = scan.indexBounds?.row;
+  const column = scan.indexBounds?.column;
+  if (!row || !column) return false;
+  if (row.maximum < row.minimum || column.maximum < column.minimum) return false;
+  const cells = (row.maximum - row.minimum + 1) * (column.maximum - column.minimum + 1);
+  return Number.isSafeInteger(cells) && cells > 0;
+}
+
 /** Interpret one `data3D` scan structure. */
 function readScan(scan: XmlNode, warnings: string[]): E57Scan {
   const points = child(scan, 'points');
@@ -323,12 +468,15 @@ function readScan(scan: XmlNode, warnings: string[]): E57Scan {
     : null;
   const intensityLimits = child(scan, 'intensityLimits');
 
+  const prototype = proto.children.map(readField);
   return {
     name,
     guid: child(scan, 'guid')?.text ?? '',
     recordCount: readRecordCount(points),
     fileOffset: attrNum(points, 'fileOffset', 0),
-    prototype: proto.children.map(readField),
+    prototype,
+    indexBounds: readIndexBounds(scan),
+    structuredFields: readStructuredFields(prototype),
     pose: readPose(scan, name, warnings),
     colorMax: colorMax && colorMax > 0 ? colorMax : null,
     intensityMax: intensityLimits

--- a/src/io/loadE57.ts
+++ b/src/io/loadE57.ts
@@ -14,7 +14,7 @@
 import { parseE57 } from './e57/parseE57';
 import type { E57ScanData } from './e57/parseE57';
 import type { E57Metadata, E57Pose, E57SourceMetadata } from './e57/schema';
-import { preflightE57, e57FieldIsConsumed, e57LocalFieldName } from './e57/preflight';
+import { preflightE57, e57FieldIsConsumedForScan, e57LocalFieldName } from './e57/preflight';
 import { planE57Decode, e57TooLargeMessage, e57NoPlanMessage } from './loadPlan';
 import type { E57DecodePlan } from './loadPlan';
 import { formatByteSize } from './formatByteSize';
@@ -260,10 +260,10 @@ export async function loadE57(
   // — a structured scan's rowIndex / columnIndex, spherical coordinates this
   // loader does not project — would otherwise be expanded into a full Float64
   // column and then immediately dropped: hundreds of MB of allocation and
-  // per-value conversion on a tens-of-millions-of-points scan. The predicate is
-  // shared with the preflight so the plan's column count and the decode's can
-  // never disagree.
-  const parsed = parseE57(buffer, { keepField: e57FieldIsConsumed, stride });
+  // per-value conversion on a tens-of-millions-of-points scan. The predicate
+  // resolves per scan, and the preflight resolves its column count through the
+  // same function, so the plan's count and the decode's cannot disagree.
+  const parsed = parseE57(buffer, { keepField: e57FieldIsConsumedForScan, stride });
 
   // Partition the scans FIRST: a scan without Cartesian X/Y/Z (spherical-only,
   // for example) contributes no points, so it must contribute nothing to the

--- a/src/io/loadFile.ts
+++ b/src/io/loadFile.ts
@@ -26,6 +26,7 @@ import type { SourceMetadata } from './PointCloudSource';
 import { buildPreloadSummary } from './preloadSummary';
 import { LoadError } from './loadErrors';
 import type { LoadErrorCategory } from './loadErrors';
+import type { OrganizedRangeSet } from '../model/OrganizedRange';
 
 export type { LoadResult, LoaderFn } from './parseBuffer';
 export { POINT_BUDGET, MOBILE_POINT_BUDGET, pickLoader, parseBuffer } from './parseBuffer';
@@ -86,6 +87,7 @@ interface CloudPayload {
   returnCount?: Uint8Array;
   pointSourceId?: Uint16Array;
   gpsTime?: Float64Array;
+  organizedRange?: OrganizedRangeSet;
   origin: [number, number, number];
   sourceFormat: SourceFormat;
   name: string;

--- a/src/io/loadPcd.ts
+++ b/src/io/loadPcd.ts
@@ -19,7 +19,25 @@
 
 import { PCDLoader } from 'three/addons/loaders/PCDLoader.js';
 import { PointCloud } from '../model/PointCloud';
-import { sanitizeAndRecenter, withLoadWarning } from './sanitizeCloud';
+import type { CloudMetadata } from '../model/PointCloud';
+import {
+  sanitizeAndRecenter,
+  withLoadWarning,
+  outputRecordFor,
+  RECORD_DROPPED,
+  RECORD_NOT_WITNESSED,
+  type CompactionWitness,
+} from './sanitizeCloud';
+import {
+  CellState,
+  NO_RECORD,
+  cellIndexOf,
+  pcdCellFromOrdinal,
+  tallyCellStates,
+  type AcquisitionPose,
+  type OrganizedRangeFrame,
+  type OrganizedRangeSet,
+} from '../model/OrganizedRange';
 
 /** Round and clamp a value into the 0–255 byte range. */
 function clampByte(v: number): number {
@@ -35,6 +53,24 @@ function clampU16(v: number): number {
   return Math.round(v);
 }
 
+/**
+ * The acquisition viewpoint a PCD header declares.
+ *
+ * PCD writes it as `tx ty tz qw qx qy qz`: a translation followed by a
+ * quaternion whose SCALAR COMPONENT COMES FIRST. The scalar-first order is
+ * carried in the field names rather than a comment, because the alternative —
+ * a four-number tuple — reads identically whichever convention produced it.
+ */
+interface PcdViewpoint {
+  readonly translation: readonly [number, number, number];
+  readonly rotation: {
+    readonly w: number;
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+  };
+}
+
 /** The subset of PCD header facts the f64 position path needs. */
 interface PcdHeaderFacts {
   /** Body encoding — `ascii`, `binary` or `binary_compressed`. */
@@ -45,6 +81,17 @@ interface PcdHeaderFacts {
   types: string[];
   counts: number[];
   points: number;
+  /** Declared columns. For an unorganized cloud this is the whole point count. */
+  width: number;
+  /** Declared rows. `1` for an unorganized cloud. */
+  height: number;
+  /**
+   * The declared viewpoint, or `undefined` when the header carries no
+   * VIEWPOINT line. The default `0 0 0 1 0 0 0` and an absent line are kept
+   * apart: one is the file stating where the sensor was, the other is the file
+   * saying nothing.
+   */
+  viewpoint?: PcdViewpoint;
   /** Offset of the first body byte (matches PCDLoader's `headerLen`). */
   bodyOffset: number;
 }
@@ -112,10 +159,10 @@ function parsePcdHeaderFacts(buffer: ArrayBuffer): PcdHeaderFacts | null {
     types: [],
     counts: [],
     points: 0,
+    width: 0,
+    height: 0,
     bodyOffset: m.index + m[0].length,
   };
-  let width = 0;
-  let height = 0;
   for (const raw of probe.slice(0, m.index).split(/\r?\n/)) {
     const line = raw.trim();
     if (line === '' || line.startsWith('#')) continue;
@@ -126,12 +173,23 @@ function parsePcdHeaderFacts(buffer: ArrayBuffer): PcdHeaderFacts | null {
     else if (key === 'TYPE') facts.types = tok.slice(1).map((t) => t.toUpperCase());
     else if (key === 'COUNT') facts.counts = tok.slice(1).map(Number);
     else if (key === 'POINTS') facts.points = Number(tok[1]);
-    else if (key === 'WIDTH') width = Number(tok[1]);
-    else if (key === 'HEIGHT') height = Number(tok[1]);
+    else if (key === 'WIDTH') facts.width = Number(tok[1]);
+    else if (key === 'HEIGHT') facts.height = Number(tok[1]);
+    else if (key === 'VIEWPOINT') {
+      const v = tok.slice(1, 8).map(Number);
+      // A partial or non-numeric VIEWPOINT is not a viewpoint. Reading it as
+      // one would place the sensor at a position the file never gave.
+      if (v.length === 7 && v.every((n) => Number.isFinite(n))) {
+        facts.viewpoint = {
+          translation: [v[0], v[1], v[2]],
+          rotation: { w: v[3], x: v[4], y: v[5], z: v[6] },
+        };
+      }
+    }
   }
   // COUNT is optional and defaults to 1 per field; POINTS to WIDTH × HEIGHT.
   if (facts.counts.length === 0) facts.counts = facts.fields.map(() => 1);
-  if (!(facts.points > 0)) facts.points = width * height;
+  if (!(facts.points > 0)) facts.points = facts.width * facts.height;
   return facts;
 }
 
@@ -139,12 +197,14 @@ function parsePcdHeaderFacts(buffer: ArrayBuffer): PcdHeaderFacts | null {
  * Re-read the x/y/z columns of a PCD body in double precision, for the
  * encodings that actually carry it: ascii text, and binary records whose
  * x/y/z are 8-byte floats. Returns interleaved global coordinates, or `null`
- * when the source is single-precision (nothing to save) or the header cannot
- * be resolved — the caller then uses PCDLoader's positions.
+ * when the source is single-precision (nothing to save) — the caller then uses
+ * PCDLoader's positions.
+ *
+ * Returning a non-null array is also the ONLY evidence in this module that OLV
+ * walked the record stream itself. {@link loadPcd} reads it that way when it
+ * decides whether cell-to-record identity can be claimed.
  */
-function extractPcdPositionsF64(buffer: ArrayBuffer): Float64Array | null {
-  const facts = parsePcdHeaderFacts(buffer);
-  if (!facts) return null;
+function extractPcdPositionsF64(buffer: ArrayBuffer, facts: PcdHeaderFacts): Float64Array | null {
   const { fields, sizes, types, counts } = facts;
   if (sizes.length !== fields.length || counts.length !== fields.length) return null;
   const xi = fields.indexOf('x');
@@ -240,6 +300,134 @@ function extractPcdPositionsF64(buffer: ArrayBuffer): Float64Array | null {
   return null;
 }
 
+/** What the header claims about organization, once the records have their say. */
+type PcdOrganization =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'refused'; readonly warning: string }
+  | { readonly kind: 'grid'; readonly width: number; readonly height: number };
+
+/**
+ * Decide whether an organized grid can be recorded for this file.
+ *
+ * A declared grid is a CLAIM, and the sidecar costs about nine bytes per cell,
+ * so the claim is never what sizes the allocation. The bound is the DECODED
+ * RECORD COUNT: the grid is accepted only when `WIDTH × HEIGHT` equals the
+ * number of records the file actually supplied, which is also the only case
+ * where a cell has a record to correspond to. A header reading `100000 1000`
+ * over an 87-byte body therefore allocates nothing, rather than 900 MB.
+ *
+ * `HEIGHT > 1` is PCL's own test for an organized dataset (`PointCloud::at`
+ * throws `UnorganizedPointCloudException` below it), so a HEIGHT of 1 is an
+ * ordinary unorganized cloud and not a one-row grid.
+ */
+function pcdOrganization(facts: PcdHeaderFacts, decodedCount: number): PcdOrganization {
+  const { width, height } = facts;
+  if (!Number.isInteger(width) || !Number.isInteger(height)) return { kind: 'none' };
+  if (!(width > 0) || !(height > 1)) return { kind: 'none' };
+  const cells = width * height;
+  if (!Number.isSafeInteger(cells) || cells !== decodedCount) {
+    return {
+      kind: 'refused',
+      warning:
+        `The header declares an organized ${width} × ${height} grid ` +
+        `(${cells} cells), and ${decodedCount} records were read from the file. ` +
+        `No acquisition grid is recorded: a grid the records contradict cannot ` +
+        `be mapped to them without inventing the correspondence.`,
+    };
+  }
+  return { kind: 'grid', width, height };
+}
+
+/**
+ * Build the acquisition grid for a file whose records line up with its header.
+ *
+ * `linked` is what separates the two encodings families. For ascii and 8-byte
+ * float binary bodies OLV walks the records itself, so ordinal `i` in the grid
+ * IS display record `i`, and the linkage is exact. For 4-byte float binary and
+ * `binary_compressed` bodies both the count and the ORDER come from three.js's
+ * PCDLoader, which OLV does not test record for record; inferring an ordering
+ * from it would be exactly the invented correspondence this sidecar exists to
+ * prevent. Those files keep the topology and the pose and claim no identity.
+ */
+function buildPcdFrame(
+  grid: { readonly width: number; readonly height: number },
+  global: Float64Array,
+  viewpoint: PcdViewpoint | undefined,
+  linked: boolean,
+): OrganizedRangeFrame {
+  const { width, height } = grid;
+  const cells = width * height;
+  const cellState = new Uint8Array(cells).fill(CellState.NOT_DECODED);
+  const cellToRecord = new Int32Array(cells).fill(NO_RECORD);
+  if (linked) {
+    for (let i = 0; i < cells; i++) {
+      const cell = pcdCellFromOrdinal(i, width);
+      const ci = cellIndexOf(cell.row, cell.column, width);
+      const finite =
+        Number.isFinite(global[i * 3]) &&
+        Number.isFinite(global[i * 3 + 1]) &&
+        Number.isFinite(global[i * 3 + 2]);
+      // A non-finite record is SOURCE_INVALID: the file holds a record here and
+      // declares it unusable. It is NOT a no-return. PCD has no no-return
+      // semantics — nothing in the format says the sensor looked along a
+      // direction and got nothing back — so this loader must never produce
+      // CellState.NO_RETURN, whatever a cell's contents look like.
+      cellState[ci] = finite ? CellState.VALID_RETURN : CellState.SOURCE_INVALID;
+      if (finite) cellToRecord[ci] = i;
+    }
+  }
+  const pose: AcquisitionPose | undefined = viewpoint
+    ? {
+        worldTranslation: viewpoint.translation,
+        // PCD declares one viewpoint and no second, scanner-frame position, so
+        // there is no `localPosition` here to be readable or malformed.
+        localPositionSource: 'not-applicable',
+        rotation: viewpoint.rotation,
+        rotationSource: 'source-declared',
+      }
+    : undefined;
+  return {
+    id: 'pcd-grid',
+    sourceKind: 'pcd-organized',
+    width,
+    height,
+    cellState,
+    cellToRecord,
+    acquisitionPose: pose,
+    linkage: linked
+      ? { kind: 'exact' }
+      : { kind: 'unavailable', reason: 'source-record-identity-unavailable' },
+    diagnostics: tallyCellStates(cellState),
+  };
+}
+
+/**
+ * Rewrite a frame's record indices from pre-sanitation to display indices.
+ *
+ * Returns `null` when the witness cannot answer for an index the frame claims,
+ * which the caller turns into the honest degrade rather than a guess.
+ */
+function remapPcdFrame(
+  frame: OrganizedRangeFrame,
+  witness: CompactionWitness,
+): OrganizedRangeFrame | null {
+  const cellState = new Uint8Array(frame.cellState);
+  const cellToRecord = new Int32Array(frame.cellToRecord);
+  for (let ci = 0; ci < cellToRecord.length; ci++) {
+    const source = cellToRecord[ci];
+    if (source === NO_RECORD) continue;
+    const output = outputRecordFor(witness, source);
+    if (output === RECORD_NOT_WITNESSED) return null;
+    if (output === RECORD_DROPPED) {
+      cellToRecord[ci] = NO_RECORD;
+      cellState[ci] = CellState.NOT_DECODED;
+      continue;
+    }
+    cellToRecord[ci] = output;
+  }
+  return { ...frame, cellState, cellToRecord, diagnostics: tallyCellStates(cellState) };
+}
+
 /**
  * Load a `.pcd` point cloud into a `PointCloud`.
  *
@@ -297,9 +485,14 @@ export async function loadPcd(buffer: ArrayBuffer, name = 'cloud.pcd'): Promise<
   //    lost by staging them, and both encodings then share one recentring path.
   // The row-count guard keeps the f64 re-read honest: if it ever disagrees
   // with what PCDLoader decoded, PCDLoader's rows win.
-  const reread = extractPcdPositionsF64(buffer);
+  const facts = parsePcdHeaderFacts(buffer);
+  const reread = facts ? extractPcdPositionsF64(buffer, facts) : null;
+  // True only when OLV walked the record stream itself and reached the same
+  // record count PCDLoader did. Cell-to-record identity is claimed on this and
+  // nothing else.
+  const walkedRecords = reread?.length === count * 3;
   let global: Float64Array;
-  if (reread?.length === count * 3) {
+  if (walkedRecords && reread) {
     global = reread;
   } else {
     global = new Float64Array(count * 3);
@@ -359,7 +552,55 @@ export async function loadPcd(buffer: ArrayBuffer, name = 'cloud.pcd'): Promise<
   // ascii one the literal token — and recentre the survivors. `count` stays the
   // DECODED count: the file really did hold that many records, and the warning
   // is where the exclusion is reported.
-  const clean = sanitizeAndRecenter(global, { colors, intensity, classification, normals });
+  // Header facts and grid VALIDATION apply to every encoding; only the record
+  // identity inside the frame depends on which body OLV can walk.
+  const organization = facts ? pcdOrganization(facts, count) : { kind: 'none' as const };
+  let metadata: CloudMetadata | undefined;
+  if (organization.kind === 'refused') {
+    metadata = withLoadWarning(metadata, organization.warning);
+  }
+  const frame =
+    organization.kind === 'grid'
+      ? buildPcdFrame(organization, global, facts?.viewpoint, walkedRecords)
+      : undefined;
+
+  const clean = sanitizeAndRecenter(
+    global,
+    { colors, intensity, classification, normals },
+    // The witness costs an Int32Array only when something was actually
+    // dropped, and it is the only way a linked grid survives compaction.
+    { witness: frame !== undefined && walkedRecords },
+  );
+
+  // Sanitation compacts survivors, so any drop shifts every record index after
+  // the first casualty. The witness turns that shift into an answerable
+  // question instead of a reason to disown the grid.
+  let organizedRange: OrganizedRangeSet | undefined;
+  if (frame) {
+    const remapped =
+      frame.linkage.kind !== 'exact' ||
+      clean.excludedCount === 0 ||
+      !clean.witness ||
+      clean.witness.sourceCount !== count
+        ? null
+        : remapPcdFrame(frame, clean.witness);
+    const usable =
+      frame.linkage.kind !== 'exact' || clean.excludedCount === 0
+        ? frame
+        : (remapped ?? {
+            ...frame,
+            cellToRecord: new Int32Array(frame.cellToRecord.length).fill(NO_RECORD),
+            linkage: {
+              kind: 'unavailable',
+              reason: 'source-record-identity-unavailable',
+            } as const,
+          });
+    organizedRange = {
+      kind: 'organized-range',
+      frames: [usable],
+      organization: 'organized-grid',
+    };
+  }
 
   return new PointCloud({
     positions: clean.positions,
@@ -367,11 +608,12 @@ export async function loadPcd(buffer: ArrayBuffer, name = 'cloud.pcd'): Promise<
     intensity: clean.attributes.intensity,
     classification: clean.attributes.classification,
     normals: clean.attributes.normals,
+    organizedRange,
     origin: clean.origin,
     sourceFormat: 'pcd',
     name,
     decodedPointCount: count,
-    metadata: withLoadWarning(undefined, clean.warning),
+    metadata: withLoadWarning(metadata, clean.warning),
   });
 }
 

--- a/src/io/loadPtx.ts
+++ b/src/io/loadPtx.ts
@@ -16,7 +16,13 @@
 
 import { PointCloud } from '../model/PointCloud';
 import type { CloudMetadata } from '../model/PointCloud';
-import { sanitizeAndRecenter, withLoadWarning } from './sanitizeCloud';
+import {
+  sanitizeAndRecenter,
+  withLoadWarning,
+  outputRecordFor,
+  RECORD_DROPPED,
+  type CompactionWitness,
+} from './sanitizeCloud';
 import {
   CellState,
   NO_RECORD,
@@ -28,6 +34,61 @@ import {
   type OrganizedRangeFrame,
   type OrganizedRangeSet,
 } from '../model/OrganizedRange';
+
+/**
+ * Rewrite one frame's `cellToRecord` from pre-sanitation record indices to the
+ * indices the display cloud actually holds.
+ *
+ * Returns `null` when the witness cannot answer for a record the frame claims,
+ * which the caller turns into the honest degrade. Guessing here would be the
+ * one failure this whole sidecar exists to prevent: an index that is present,
+ * plausible, and points at another return.
+ *
+ * A cell whose record did not survive becomes NOT_DECODED. The scanner did get
+ * a return there — the geometric range still proves it — so NO_RETURN would
+ * report a decoding loss as an instrument observation. NOT_DECODED says what is
+ * true: a record exists in the file and this session did not carry it through.
+ */
+function remapFrame(
+  frame: OrganizedRangeFrame,
+  witness: CompactionWitness,
+): OrganizedRangeFrame | null {
+  const cellState = new Uint8Array(frame.cellState);
+  const cellToRecord = new Int32Array(frame.cellToRecord);
+  for (let ci = 0; ci < cellToRecord.length; ci++) {
+    const source = cellToRecord[ci];
+    if (source === NO_RECORD) continue;
+    if (source < 0 || source >= witness.sourceCount) return null;
+    const output = outputRecordFor(witness, source);
+    if (output === RECORD_DROPPED) {
+      cellToRecord[ci] = NO_RECORD;
+      cellState[ci] = CellState.NOT_DECODED;
+      continue;
+    }
+    cellToRecord[ci] = output;
+  }
+  return { ...frame, cellState, cellToRecord, diagnostics: tallyCellStates(cellState) };
+}
+
+/**
+ * Remap every frame, or none of them.
+ *
+ * A set where one frame links exactly and another silently lost its identity
+ * would be read as uniformly trustworthy, so a single unanswerable frame sends
+ * the whole set down the degrade path.
+ */
+function remapFrames(
+  frames: readonly OrganizedRangeFrame[],
+  witness: CompactionWitness,
+): OrganizedRangeFrame[] | null {
+  const out: OrganizedRangeFrame[] = [];
+  for (const frame of frames) {
+    const next = remapFrame(frame, witness);
+    if (next === null) return null;
+    out.push(next);
+  }
+  return out;
+}
 
 /** A parsed 4×4 PTX transform — four rows of four numbers. */
 type Mat4 = [number[], number[], number[], number[]];
@@ -348,32 +409,33 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
   // transform is applied after that check, so this is where a world coordinate
   // that overflowed the block's matrix is caught — and where the survivors get
   // their floored-min origin.
-  const clean = sanitizeAndRecenter(global, { colors, intensity });
+  const clean = sanitizeAndRecenter(global, { colors, intensity }, { witness: true });
 
   // Sanitation compacts survivors, so any drop shifts every record index after
-  // the first casualty and silently invalidates `cellToRecord`. Until the
-  // sanitation witness exists to remap them, the honest answer is to say the
-  // identity is gone rather than to ship indices that now point at the wrong
-  // returns. The topology itself survives: cell state, geometric range and the
-  // per-setup poses are all still true, which is the whole reason linkage is a
-  // separate fact from the grid.
-  const organizedRange: OrganizedRangeSet | undefined =
+  // the first casualty. The witness is what turns that shift into an answerable
+  // question: it says where each source record landed, or that it landed
+  // nowhere, so the grid can be rewritten instead of disowned.
+  //
+  // The degrade below stays. It is still the correct behaviour whenever the
+  // witness cannot cover what the frames claim, and it is what a future caller
+  // that does not ask for a witness would get.
+  const remapped =
+    clean.excludedCount === 0 || !clean.witness || clean.witness.sourceCount !== count
+      ? null
+      : remapFrames(frames, clean.witness);
+
+  const built: OrganizedRangeSet | undefined =
     frames.length === 0
       ? undefined
-      : clean.excludedCount === 0
-        ? {
-            kind: 'organized-range',
-            frames,
-            organization: frames.length > 1 ? 'multi-grid' : 'organized-grid',
-          }
-        : withLinkageUnavailable(
-            {
-              kind: 'organized-range',
-              frames,
-              organization: frames.length > 1 ? 'multi-grid' : 'organized-grid',
-            },
-            'source-record-identity-unavailable',
-          );
+      : {
+          kind: 'organized-range',
+          frames: remapped ?? frames,
+          organization: frames.length > 1 ? 'multi-grid' : 'organized-grid',
+        };
+  const organizedRange =
+    built === undefined || clean.excludedCount === 0 || remapped !== null
+      ? built
+      : withLinkageUnavailable(built, 'source-record-identity-unavailable');
 
   return new PointCloud({
     positions: clean.positions,

--- a/src/io/loadPtx.ts
+++ b/src/io/loadPtx.ts
@@ -278,36 +278,55 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
     i += HEADER_LINES;
 
     const total = cols * rows;
+    // A declared grid is a CLAIM, and the sidecar costs nine bytes per cell.
+    // Nothing above validates the claim against the file, so an 87-byte header
+    // reading `100000 1000` asked for 900 MB before a single point line was
+    // read, and a larger lie threw a bare RangeError out of the typed-array
+    // constructor rather than a categorised load error. `lines.length` is a
+    // sound upper bound: no block can hold more cells than the file has lines,
+    // so a grid larger than that is not backed by any record. A legitimately
+    // truncated block stays well inside it and keeps its topology.
+    const gridIsBacked = Number.isSafeInteger(total) && total <= lines.length;
+    if (!gridIsBacked) {
+      blockWarnings.push(
+        `Block ${blockIndex}: the header declares a ${cols}×${rows} grid ` +
+          `(${total} cells), which the file cannot supply from ${lines.length} ` +
+          `lines. The points are read, and no acquisition grid is recorded for ` +
+          `this block: a declaration the records contradict is not evidence.`,
+      );
+    }
     // Seeded with SOURCE_RECORD_MISSING so a block that runs out of lines
     // leaves its unread tail saying exactly that, with no second pass.
-    const cellState = new Uint8Array(total).fill(CellState.SOURCE_RECORD_MISSING);
-    const cellToRecord = new Int32Array(total).fill(NO_RECORD);
-    const geometricRange = new Float32Array(total).fill(Number.NaN);
+    const cells = gridIsBacked ? total : 0;
+    const cellState = new Uint8Array(cells).fill(CellState.SOURCE_RECORD_MISSING);
+    const cellToRecord = new Int32Array(cells).fill(NO_RECORD);
+    const geometricRange = new Float32Array(cells).fill(Number.NaN);
     let p = 0;
     for (; p < total && i < lines.length; p++, i++) {
       // The ordinal advances on every path below, including the skips, so the
       // cell address is sound even for a line that produced no point.
       const cell = ptxCellFromOrdinal(p, rows);
-      const ci = cellIndexOf(cell.row, cell.column, cols);
+      // `-1` when the grid was refused above, which every write below skips.
+      const ci = gridIsBacked ? cellIndexOf(cell.row, cell.column, cols) : -1;
 
       const tok = tokenize(lines.at(i));
       if (tok.length < 4) {
         // A malformed line is a defect in the file, not a statement about the
         // scene. It is NOT a no-return, and collapsing the two would report a
         // parse failure as an instrument observation.
-        cellState[ci] = CellState.SOURCE_INVALID;
+        if (ci >= 0) cellState[ci] = CellState.SOURCE_INVALID;
         continue;
       }
       const lx = Number(tok[0]);
       const ly = Number(tok[1]);
       const lz = Number(tok[2]);
       if (!Number.isFinite(lx) || !Number.isFinite(ly) || !Number.isFinite(lz)) {
-        cellState[ci] = CellState.SOURCE_INVALID;
+        if (ci >= 0) cellState[ci] = CellState.SOURCE_INVALID;
         continue;
       }
       // A 0 0 0 sample marks an empty grid cell (no laser return) — not a point.
       if (lx === 0 && ly === 0 && lz === 0) {
-        cellState[ci] = CellState.NO_RETURN;
+        if (ci >= 0) cellState[ci] = CellState.NO_RETURN;
         continue;
       }
 
@@ -316,9 +335,19 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
       // large world coordinates and lose most of the precision to
       // cancellation, and it would make the value depend on the registration
       // being correct.
-      geometricRange[ci] = Math.hypot(lx, ly, lz);
-      cellState[ci] = CellState.VALID_RETURN;
-      cellToRecord[ci] = xs.length;
+      if (ci >= 0) {
+        // Computed in double, then stored as float32. A range beyond the
+        // float32 maximum saturates to Infinity, which is not a distance: the
+        // field's absent value is NaN, and leaving Infinity there would put a
+        // number that reads as a measurement next to a VALID_RETURN state.
+        // Float32 spacing is about 6e-5 m at 1 km and 5e-4 m at 10 km, below
+        // the ranging noise of any instrument writing PTX, so the narrowing
+        // itself costs nothing a reader could notice.
+        const r = Math.hypot(lx, ly, lz);
+        geometricRange[ci] = Math.fround(r) === Number.POSITIVE_INFINITY ? Number.NaN : r;
+        cellState[ci] = CellState.VALID_RETURN;
+        cellToRecord[ci] = xs.length;
+      }
 
       // world = [x y z 1] · M — points are row vectors in the scanner frame.
       const wx = lx * m[0][0] + ly * m[1][0] + lz * m[2][0] + m[3][0];
@@ -350,6 +379,7 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
       );
     }
 
+    if (!gridIsBacked) continue;
     frames.push({
       id: `setup-${blockIndex}`,
       sourceKind: 'ptx-grid',

--- a/src/io/loadPtx.ts
+++ b/src/io/loadPtx.ts
@@ -17,6 +17,17 @@
 import { PointCloud } from '../model/PointCloud';
 import type { CloudMetadata } from '../model/PointCloud';
 import { sanitizeAndRecenter, withLoadWarning } from './sanitizeCloud';
+import {
+  CellState,
+  NO_RECORD,
+  cellIndexOf,
+  ptxCellFromOrdinal,
+  tallyCellStates,
+  type AcquisitionPose,
+  withLinkageUnavailable,
+  type OrganizedRangeFrame,
+  type OrganizedRangeSet,
+} from '../model/OrganizedRange';
 
 /** A parsed 4×4 PTX transform — four rows of four numbers. */
 type Mat4 = [number[], number[], number[], number[]];
@@ -51,6 +62,17 @@ function parseRow4(line: string | undefined): number[] {
     row[i] = Number(tok[i]);
   }
   return row;
+}
+
+/**
+ * Parse three floats from a header line, NaN-seeded like `parseRow4` so a
+ * missing or non-numeric entry is detectable rather than silently zero. A
+ * zeroed scanner position is a plausible origin and would be indistinguishable
+ * from a real one at the coordinate system's centre.
+ */
+function parseRow3(line: string | undefined): number[] {
+  const tok = tokenize(line ?? '');
+  return [Number(tok[0] ?? Number.NaN), Number(tok[1] ?? Number.NaN), Number(tok[2] ?? Number.NaN)];
 }
 
 /** Whether every entry of a parsed transform is finite. */
@@ -123,6 +145,12 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
   const blockWarnings: string[] = [];
   let blockIndex = 0;
 
+  // One frame per block. A PTX block is a SCANNER SETUP, not a temporal frame,
+  // so each keeps its own grid, its own pose and its own cell-to-record map.
+  // Flattening them into one grid would merge two instruments' views of
+  // different directions into a raster that means nothing.
+  const frames: OrganizedRangeFrame[] = [];
+
   let i = 0;
   while (i < lines.length) {
     // Skip blank lines between blocks and any trailing newline.
@@ -165,21 +193,66 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
           `and may not register with the rest of the cloud.`,
       );
     }
-    // The transform's 4th row is the scanner's registered world position.
-    scannerOrigin ??= [m[3][0], m[3][1], m[3][2]];
+    // PTX carries two positions in different frames, and the loader keeps both
+    // rather than choosing. The header line after the two counts is the scanner
+    // position in the SCANNER's own frame, which is `0 0 0` for ordinary
+    // scanner-local data. The transform's translation row is where that scanner
+    // sits once registered, which is what `metadata.scannerOrigin` has always
+    // meant and continues to mean.
+    const declared = parseRow3(lines.at(i + 2));
+    const declaredOk = declared.every((v) => Number.isFinite(v));
+    const blockOrigin: [number, number, number] = [m[3][0], m[3][1], m[3][2]];
+    const pose: AcquisitionPose = {
+      worldTranslation: blockOrigin,
+      localPosition: declaredOk ? [declared[0], declared[1], declared[2]] : undefined,
+      transform: m,
+      localPositionSource: declaredOk ? 'source-declared' : 'unreadable',
+    };
+    scannerOrigin ??= blockOrigin;
     i += HEADER_LINES;
 
     const total = cols * rows;
+    // Seeded with SOURCE_RECORD_MISSING so a block that runs out of lines
+    // leaves its unread tail saying exactly that, with no second pass.
+    const cellState = new Uint8Array(total).fill(CellState.SOURCE_RECORD_MISSING);
+    const cellToRecord = new Int32Array(total).fill(NO_RECORD);
+    const geometricRange = new Float32Array(total).fill(Number.NaN);
     let p = 0;
     for (; p < total && i < lines.length; p++, i++) {
+      // The ordinal advances on every path below, including the skips, so the
+      // cell address is sound even for a line that produced no point.
+      const cell = ptxCellFromOrdinal(p, rows);
+      const ci = cellIndexOf(cell.row, cell.column, cols);
+
       const tok = tokenize(lines.at(i));
-      if (tok.length < 4) continue; // malformed point line — skip it
+      if (tok.length < 4) {
+        // A malformed line is a defect in the file, not a statement about the
+        // scene. It is NOT a no-return, and collapsing the two would report a
+        // parse failure as an instrument observation.
+        cellState[ci] = CellState.SOURCE_INVALID;
+        continue;
+      }
       const lx = Number(tok[0]);
       const ly = Number(tok[1]);
       const lz = Number(tok[2]);
-      if (!Number.isFinite(lx) || !Number.isFinite(ly) || !Number.isFinite(lz)) continue;
+      if (!Number.isFinite(lx) || !Number.isFinite(ly) || !Number.isFinite(lz)) {
+        cellState[ci] = CellState.SOURCE_INVALID;
+        continue;
+      }
       // A 0 0 0 sample marks an empty grid cell (no laser return) — not a point.
-      if (lx === 0 && ly === 0 && lz === 0) continue;
+      if (lx === 0 && ly === 0 && lz === 0) {
+        cellState[ci] = CellState.NO_RETURN;
+        continue;
+      }
+
+      // Geometric range in ACQUISITION-LOCAL coordinates, before the world
+      // transform below. Computing it after registration would subtract two
+      // large world coordinates and lose most of the precision to
+      // cancellation, and it would make the value depend on the registration
+      // being correct.
+      geometricRange[ci] = Math.hypot(lx, ly, lz);
+      cellState[ci] = CellState.VALID_RETURN;
+      cellToRecord[ci] = xs.length;
 
       // world = [x y z 1] · M — points are row vectors in the scanner frame.
       const wx = lx * m[0][0] + ly * m[1][0] + lz * m[2][0] + m[3][0];
@@ -210,6 +283,21 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
           `of the scan was read.`,
       );
     }
+
+    frames.push({
+      id: `setup-${blockIndex}`,
+      sourceKind: 'ptx-grid',
+      width: cols,
+      height: rows,
+      cellState,
+      cellToRecord,
+      geometricRange,
+      acquisitionPose: pose,
+      // Exact for now. Sanitation runs after every block is read and may drop
+      // records; the check after it downgrades every frame if it does.
+      linkage: { kind: 'exact' },
+      diagnostics: tallyCellStates(cellState),
+    });
   }
 
   const count = xs.length;
@@ -262,10 +350,36 @@ export async function loadPtx(buffer: ArrayBuffer, name = 'cloud.ptx'): Promise<
   // their floored-min origin.
   const clean = sanitizeAndRecenter(global, { colors, intensity });
 
+  // Sanitation compacts survivors, so any drop shifts every record index after
+  // the first casualty and silently invalidates `cellToRecord`. Until the
+  // sanitation witness exists to remap them, the honest answer is to say the
+  // identity is gone rather than to ship indices that now point at the wrong
+  // returns. The topology itself survives: cell state, geometric range and the
+  // per-setup poses are all still true, which is the whole reason linkage is a
+  // separate fact from the grid.
+  const organizedRange: OrganizedRangeSet | undefined =
+    frames.length === 0
+      ? undefined
+      : clean.excludedCount === 0
+        ? {
+            kind: 'organized-range',
+            frames,
+            organization: frames.length > 1 ? 'multi-grid' : 'organized-grid',
+          }
+        : withLinkageUnavailable(
+            {
+              kind: 'organized-range',
+              frames,
+              organization: frames.length > 1 ? 'multi-grid' : 'organized-grid',
+            },
+            'source-record-identity-unavailable',
+          );
+
   return new PointCloud({
     positions: clean.positions,
     colors: clean.attributes.colors,
     intensity: clean.attributes.intensity,
+    organizedRange,
     origin: clean.origin,
     sourceFormat: 'ptx',
     name,

--- a/src/io/loadPtx.ts
+++ b/src/io/loadPtx.ts
@@ -21,6 +21,7 @@ import {
   withLoadWarning,
   outputRecordFor,
   RECORD_DROPPED,
+  RECORD_NOT_WITNESSED,
   type CompactionWitness,
 } from './sanitizeCloud';
 import {
@@ -58,8 +59,12 @@ function remapFrame(
   for (let ci = 0; ci < cellToRecord.length; ci++) {
     const source = cellToRecord[ci];
     if (source === NO_RECORD) continue;
-    if (source < 0 || source >= witness.sourceCount) return null;
     const output = outputRecordFor(witness, source);
+    // The witness does not cover this index, so the grid and the sanitiser
+    // disagree about how many records existed. That is a bookkeeping fault,
+    // not a decoding outcome, and no cell state describes it truthfully.
+    // Abandon the remap and let the caller degrade the whole set.
+    if (output === RECORD_NOT_WITNESSED) return null;
     if (output === RECORD_DROPPED) {
       cellToRecord[ci] = NO_RECORD;
       cellState[ci] = CellState.NOT_DECODED;

--- a/src/io/parseWorker.ts
+++ b/src/io/parseWorker.ts
@@ -75,6 +75,16 @@ ctx.onmessage = (event: MessageEvent): void => {
       if (cloud.returnCount) transfer.push(cloud.returnCount.buffer as ArrayBuffer);
       if (cloud.pointSourceId) transfer.push(cloud.pointSourceId.buffer as ArrayBuffer);
       if (cloud.gpsTime) transfer.push(cloud.gpsTime.buffer as ArrayBuffer);
+      // The organized-range sidecar is several typed arrays PER FRAME, so it is
+      // transferred rather than cloned: a 10 M cell grid would otherwise be
+      // copied across the boundary, which is the cost this list exists to
+      // avoid. Structured clone would still WORK, silently, at that price.
+      for (const f of cloud.organizedRange?.frames ?? []) {
+        transfer.push(f.cellState.buffer as ArrayBuffer);
+        transfer.push(f.cellToRecord.buffer as ArrayBuffer);
+        if (f.geometricRange) transfer.push(f.geometricRange.buffer as ArrayBuffer);
+        if (f.sourceRange) transfer.push(f.sourceRange.buffer as ArrayBuffer);
+      }
 
       ctx.postMessage(
         {
@@ -89,6 +99,7 @@ ctx.onmessage = (event: MessageEvent): void => {
             returnCount: cloud.returnCount,
             pointSourceId: cloud.pointSourceId,
             gpsTime: cloud.gpsTime,
+            organizedRange: cloud.organizedRange,
             origin: cloud.origin,
             sourceFormat: cloud.sourceFormat,
             name: cloud.name,

--- a/src/io/parseWorker.ts
+++ b/src/io/parseWorker.ts
@@ -11,6 +11,7 @@ import type { LoadErrorCategory } from './loadErrors';
 import type { LoadPlan, E57DecodePlan } from './loadPlan';
 import type { ProgressUpdate, LoadStage } from './loadProgress';
 import type { LoadTelemetry } from './loadTelemetry';
+import { organizedRangeTransferables } from '../model/OrganizedRange';
 
 interface ParseRequest {
   buffer: ArrayBuffer;
@@ -78,12 +79,10 @@ ctx.onmessage = (event: MessageEvent): void => {
       // The organized-range sidecar is several typed arrays PER FRAME, so it is
       // transferred rather than cloned: a 10 M cell grid would otherwise be
       // copied across the boundary, which is the cost this list exists to
-      // avoid. Structured clone would still WORK, silently, at that price.
-      for (const f of cloud.organizedRange?.frames ?? []) {
-        transfer.push(f.cellState.buffer as ArrayBuffer);
-        transfer.push(f.cellToRecord.buffer as ArrayBuffer);
-        if (f.geometricRange) transfer.push(f.geometricRange.buffer as ArrayBuffer);
-        if (f.sourceRange) transfer.push(f.sourceRange.buffer as ArrayBuffer);
+      // avoid. Derived from the frames rather than enumerated here, so a new
+      // array on a frame cannot quietly fall back to a clone.
+      if (cloud.organizedRange) {
+        transfer.push(...organizedRangeTransferables(cloud.organizedRange));
       }
 
       ctx.postMessage(

--- a/src/io/sanitizeCloud.ts
+++ b/src/io/sanitizeCloud.ts
@@ -307,7 +307,7 @@ export function sanitizeAndRecenter<A extends CloudAttributes>(
       origin: [0, 0, 0],
       attributes: valid.attributes,
       excludedCount: 0,
-      // An empty witness, never `undefined`: a caller must be able to tell an
+      // An empty witness rather than `undefined`, when one was requested: a caller must be able to tell an
       // empty cloud apart from a witness it did not ask for.
       witness: valid.witness,
     };

--- a/src/io/sanitizeCloud.ts
+++ b/src/io/sanitizeCloud.ts
@@ -101,14 +101,28 @@ export type CompactionWitness =
 export const RECORD_DROPPED = -1;
 
 /**
- * Where source record `sourceIndex` ended up, or {@link RECORD_DROPPED}.
+ * The witness says nothing about this index, because it never covered it.
  *
- * An index outside the witnessed range is `RECORD_DROPPED` rather than a
- * throw or a wrapped read: a caller asking about a record the witness never
- * covered has no answer, and that is the same fact.
+ * Distinct from {@link RECORD_DROPPED} deliberately. "This record was removed"
+ * and "I was never asked about this record" are different facts, and a caller
+ * that conflates them reads a bookkeeping mismatch as a decoding outcome. The
+ * PTX loader treats this one as a reason to abandon the remap entirely rather
+ * than to mark a cell, which is only the right response because it is
+ * distinguishable.
+ */
+export const RECORD_NOT_WITNESSED = -2;
+
+/**
+ * Where source record `sourceIndex` ended up.
+ *
+ * Returns {@link RECORD_DROPPED} when the record was removed by sanitation and
+ * {@link RECORD_NOT_WITNESSED} when the index lies outside what this witness
+ * covers. Neither throws: an out-of-range index means the caller's bookkeeping
+ * disagrees with the witness, which the caller has to handle rather than
+ * having an exception decide for it.
  */
 export function outputRecordFor(witness: CompactionWitness, sourceIndex: number): number {
-  if (sourceIndex < 0 || sourceIndex >= witness.sourceCount) return RECORD_DROPPED;
+  if (sourceIndex < 0 || sourceIndex >= witness.sourceCount) return RECORD_NOT_WITNESSED;
   if (witness.kind === 'identity') return sourceIndex;
   return witness.sourceToOutput[sourceIndex];
 }

--- a/src/io/sanitizeCloud.ts
+++ b/src/io/sanitizeCloud.ts
@@ -73,6 +73,52 @@ const ATTRIBUTE_WIDTH: Record<keyof CloudAttributes, number> = {
 
 const ATTRIBUTE_KEYS = Object.keys(ATTRIBUTE_WIDTH) as (keyof CloudAttributes)[];
 
+/**
+ * What the compaction did to record identity, for a caller that has to keep an
+ * index into the PRE-sanitation records meaningful afterwards.
+ *
+ * The direction is deliberate. A forward table (output index to input index)
+ * describes the same compaction, but every caller that holds a source index —
+ * an organized-range grid, a per-record sidecar — would have to search it to
+ * find where its record went. The question actually being asked is "where did
+ * source record i land, if it landed at all", so the table is stored that way
+ * and answered in one read.
+ *
+ * `identity` is not an optimisation detail leaking out: it is the common case,
+ * and representing it as a shape rather than as a filled table is what lets a
+ * clean cloud request the witness and still allocate nothing.
+ */
+export type CompactionWitness =
+  | { readonly kind: 'identity'; readonly sourceCount: number }
+  | {
+      readonly kind: 'compacted';
+      readonly sourceCount: number;
+      /** Length `sourceCount`. Output index, or {@link RECORD_DROPPED}. */
+      readonly sourceToOutput: Int32Array;
+    };
+
+/** The source record did not survive sanitation and has no output index. */
+export const RECORD_DROPPED = -1;
+
+/**
+ * Where source record `sourceIndex` ended up, or {@link RECORD_DROPPED}.
+ *
+ * An index outside the witnessed range is `RECORD_DROPPED` rather than a
+ * throw or a wrapped read: a caller asking about a record the witness never
+ * covered has no answer, and that is the same fact.
+ */
+export function outputRecordFor(witness: CompactionWitness, sourceIndex: number): number {
+  if (sourceIndex < 0 || sourceIndex >= witness.sourceCount) return RECORD_DROPPED;
+  if (witness.kind === 'identity') return sourceIndex;
+  return witness.sourceToOutput[sourceIndex];
+}
+
+/** Opt-in extras a caller can ask sanitation for. */
+export interface SanitizeOptions {
+  /** Record how source indices map onto output indices. Off by default. */
+  readonly witness?: boolean;
+}
+
 /** A cloud recentred and cleared of unplaceable points. */
 export interface SanitizedCloud<A extends CloudAttributes> {
   /** Interleaved xyz in local coordinates, survivors only. */
@@ -85,6 +131,8 @@ export interface SanitizedCloud<A extends CloudAttributes> {
   excludedCount: number;
   /** What was excluded and why, for `metadata.loadWarnings`; absent when nothing was. */
   warning?: string;
+  /** Present exactly when the caller asked for it. */
+  witness?: CompactionWitness;
 }
 
 /** A cloud cleared of unplaceable points, for positions that are already local. */
@@ -93,6 +141,8 @@ export interface SanitizedLocalCloud<A extends CloudAttributes> {
   attributes: A;
   excludedCount: number;
   warning?: string;
+  /** Present exactly when the caller asked for it. */
+  witness?: CompactionWitness;
 }
 
 /** Allocate an array of the same kind as `src`, for the compacted copy. */
@@ -126,7 +176,8 @@ function exclusionWarning(excluded: number, total: number): string {
 function compactValidRecords<C extends Coordinates, A extends CloudAttributes>(
   coords: C,
   attributes: A,
-): { coords: C; attributes: A; excludedCount: number } {
+  wantWitness: boolean,
+): { coords: C; attributes: A; excludedCount: number; witness?: CompactionWitness } {
   // A trailing partial record means the decoder and the buffer disagree about
   // the point count; there is no honest way to guess the missing components.
   // `PointCloud` refuses the same shape at construction — refuse it earlier,
@@ -163,7 +214,16 @@ function compactValidRecords<C extends Coordinates, A extends CloudAttributes>(
       kept++;
     }
   }
-  if (kept === count) return { coords, attributes, excludedCount: 0 };
+  if (kept === count) {
+    // Nothing moved, so the witness is the identity map — and saying that costs
+    // no table, which is what keeps an ordinary cloud on the free path.
+    return {
+      coords,
+      attributes,
+      excludedCount: 0,
+      witness: wantWitness ? { kind: 'identity', sourceCount: count } : undefined,
+    };
+  }
 
   if (kept === 0) {
     throw new LoadError(
@@ -175,6 +235,9 @@ function compactValidRecords<C extends Coordinates, A extends CloudAttributes>(
 
   const keptCoords = like(coords, kept * 3);
   for (const slot of slots) slot.out = like(slot.src, kept * slot.width);
+  // Seeded as dropped so the write loop only has to record survivors: a source
+  // index the loop never reaches is, by construction, one that did not survive.
+  const sourceToOutput = wantWitness ? new Int32Array(count).fill(RECORD_DROPPED) : undefined;
 
   // One loop, one index: positions and every attribute advance together, which
   // is what makes the lockstep guarantee structural rather than a convention
@@ -185,6 +248,7 @@ function compactValidRecords<C extends Coordinates, A extends CloudAttributes>(
     const y = coords[i * 3 + 1];
     const z = coords[i * 3 + 2];
     if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
+    if (sourceToOutput) sourceToOutput[i] = w;
     keptCoords[w * 3] = x;
     keptCoords[w * 3 + 1] = y;
     keptCoords[w * 3 + 2] = z;
@@ -201,7 +265,12 @@ function compactValidRecords<C extends Coordinates, A extends CloudAttributes>(
   const filtered = { ...attributes };
   const writable = filtered as unknown as Record<string, NumericArray>;
   for (const slot of slots) writable[slot.key] = slot.out;
-  return { coords: keptCoords, attributes: filtered, excludedCount: count - kept };
+  return {
+    coords: keptCoords,
+    attributes: filtered,
+    excludedCount: count - kept,
+    witness: sourceToOutput ? { kind: 'compacted', sourceCount: count, sourceToOutput } : undefined,
+  };
 }
 
 /**
@@ -215,14 +284,18 @@ function compactValidRecords<C extends Coordinates, A extends CloudAttributes>(
 export function sanitizeAndRecenter<A extends CloudAttributes>(
   global: Float64Array,
   attributes: A,
+  options: SanitizeOptions = {},
 ): SanitizedCloud<A> {
-  const valid = compactValidRecords(global, attributes);
+  const valid = compactValidRecords(global, attributes, options.witness === true);
   if (valid.coords.length === 0) {
     return {
       positions: new Float32Array(0),
       origin: [0, 0, 0],
       attributes: valid.attributes,
       excludedCount: 0,
+      // An empty witness, never `undefined`: a caller must be able to tell an
+      // empty cloud apart from a witness it did not ask for.
+      witness: valid.witness,
     };
   }
 
@@ -244,6 +317,7 @@ export function sanitizeAndRecenter<A extends CloudAttributes>(
     excludedCount: valid.excludedCount,
     warning:
       valid.excludedCount > 0 ? exclusionWarning(valid.excludedCount, total) : undefined,
+    witness: valid.witness,
   };
 }
 
@@ -255,15 +329,17 @@ export function sanitizeAndRecenter<A extends CloudAttributes>(
 export function sanitizeLocalCloud<A extends CloudAttributes>(
   positions: Float32Array,
   attributes: A,
+  options: SanitizeOptions = {},
 ): SanitizedLocalCloud<A> {
   const total = positions.length / 3;
-  const valid = compactValidRecords(positions, attributes);
+  const valid = compactValidRecords(positions, attributes, options.witness === true);
   return {
     positions: valid.coords,
     attributes: valid.attributes,
     excludedCount: valid.excludedCount,
     warning:
       valid.excludedCount > 0 ? exclusionWarning(valid.excludedCount, total) : undefined,
+    witness: valid.witness,
   };
 }
 

--- a/src/model/OrganizedRange.ts
+++ b/src/model/OrganizedRange.ts
@@ -112,8 +112,30 @@ export interface AcquisitionPose {
   readonly localPosition?: readonly [number, number, number];
   /** Row-major, translation in row 3, matching the PTX layout. Four rows of four. */
   readonly transform?: readonly (readonly number[])[];
-  /** Whether `localPosition` was readable, or the header line was malformed. */
-  readonly localPositionSource: 'source-declared' | 'unreadable';
+  /**
+   * Whether `localPosition` was readable, the header line was malformed, or
+   * the format carries no such second position at all (PCD, which declares one
+   * viewpoint and nothing else).
+   */
+  readonly localPositionSource: 'source-declared' | 'unreadable' | 'not-applicable';
+  /**
+   * Acquisition orientation, where the format declares one as a quaternion.
+   *
+   * PCD's VIEWPOINT is `tx ty tz qw qx qy qz`, so the rotation arrives already
+   * decomposed and there is nothing to gain by composing a 4x4 from it. The
+   * components are NAMED rather than stored in an array precisely because the
+   * order is the trap: PCD writes w first, three.js and most maths libraries
+   * write it last, and a positional four-tuple makes the two indistinguishable
+   * at every call site.
+   */
+  readonly rotation?: {
+    readonly w: number;
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+  };
+  /** Present only when `rotation` is, and only ever because the file said so. */
+  readonly rotationSource?: 'source-declared';
 }
 
 /**
@@ -182,6 +204,28 @@ export function ptxCellFromOrdinal(
   rows: number,
 ): { readonly row: number; readonly column: number } {
   return { row: ordinal % rows, column: Math.floor(ordinal / rows) };
+}
+
+/**
+ * PCD orders an organized dataset like an image: row by row, so the COLUMN is
+ * the fast axis and the ordinal advances ACROSS a row. This is the opposite of
+ * PTX, which is why both conventions are named functions rather than inline
+ * arithmetic.
+ *
+ * PCL is the authority for both halves of this. Its header defines
+ * `PointCloud::at(column, row)` as `points[row * width + column]`, and gates
+ * organized access on `height > 1` — the same test this loader applies. The
+ * format tutorial gives WIDTH as "the total number of points in a row" and
+ * HEIGHT as "the total number of rows".
+ *
+ * A test pins the mapping against a non-square grid, where a transposition
+ * cannot hide.
+ */
+export function pcdCellFromOrdinal(
+  ordinal: number,
+  width: number,
+): { readonly row: number; readonly column: number } {
+  return { row: Math.floor(ordinal / width), column: ordinal % width };
 }
 
 /**

--- a/src/model/OrganizedRange.ts
+++ b/src/model/OrganizedRange.ts
@@ -28,8 +28,8 @@
  * because they carry different scientific weight. A NO_RETURN is evidence about
  * a ray the scanner actually fired: it looked along that direction and nothing
  * came back. A NOT_DECODED cell says nothing about the scene at all, only about
- * how much of the file this session chose to read. Collapsing the two would let
- * a sampling decision read as a property of the surface.
+ * what this session did with the file. Collapsing the two would let a decision
+ * taken inside the pipeline read as a property of the surface.
  */
 export const CellState = {
   /** The source carries a usable return for this cell. */
@@ -38,7 +38,15 @@ export const CellState = {
   NO_RETURN: 1,
   /** The source record exists but the source declares it unusable. */
   SOURCE_INVALID: 2,
-  /** A record exists in the file and this session did not decode it. */
+  /**
+   * A record exists in the file and this session did not deliver it.
+   *
+   * Covers two routes to the same shortfall: never read (a stride decoded a
+   * subset), and read but discarded (a coordinate that overflowed its
+   * transform, removed by sanitation). Both are decisions this pipeline took,
+   * and neither says anything about what the scanner observed. The distinction
+   * that matters here is against NO_RETURN, not between the two routes.
+   */
   NOT_DECODED: 3,
   /** The grid declares this cell and the file supplied no record for it. */
   SOURCE_RECORD_MISSING: 4,

--- a/src/model/OrganizedRange.ts
+++ b/src/model/OrganizedRange.ts
@@ -1,0 +1,257 @@
+/**
+ * OrganizedRange.ts — the source measurement topology behind a display cloud.
+ *
+ * A `PointCloud` answers "where is this return in 3D space". It cannot answer
+ * "where did this return exist in the acquisition grid", because flattening a
+ * scanner grid into a coordinate stream discards the row, the column and every
+ * cell the scanner interrogated and got nothing back from.
+ *
+ * This module holds that discarded half. It is a SIDECAR, never a second point
+ * cloud: it stores per-cell state and the identity of the display record each
+ * cell produced, not a duplicate copy of the coordinates.
+ *
+ * The governing rule, inherited from the Profile Workbench, is IDENTITY, NOT
+ * POSITION. A cell links to a display record because the loader recorded which
+ * record it produced, never because a coordinate happened to be nearby. When
+ * the processing path destroys that identity, the frame says so through
+ * `linkage` rather than reconstructing a plausible answer.
+ *
+ * Pure and DOM-free by design: every value here is a number or a typed array,
+ * so the model is testable under Node and can cross a worker boundary by
+ * transfer rather than by structured clone.
+ */
+
+/**
+ * What the source says about one grid cell.
+ *
+ * These are deliberately five distinct states rather than one "empty" sentinel,
+ * because they carry different scientific weight. A NO_RETURN is evidence about
+ * a ray the scanner actually fired: it looked along that direction and nothing
+ * came back. A NOT_DECODED cell says nothing about the scene at all, only about
+ * how much of the file this session chose to read. Collapsing the two would let
+ * a sampling decision read as a property of the surface.
+ */
+export const CellState = {
+  /** The source carries a usable return for this cell. */
+  VALID_RETURN: 0,
+  /** The scanner interrogated this direction and received nothing. */
+  NO_RETURN: 1,
+  /** The source record exists but the source declares it unusable. */
+  SOURCE_INVALID: 2,
+  /** A record exists in the file and this session did not decode it. */
+  NOT_DECODED: 3,
+  /** The grid declares this cell and the file supplied no record for it. */
+  SOURCE_RECORD_MISSING: 4,
+} as const;
+
+export type CellStateValue = (typeof CellState)[keyof typeof CellState];
+
+/** Every state, in value order, for exhaustive iteration and tallying. */
+export const CELL_STATES: readonly CellStateValue[] = [
+  CellState.VALID_RETURN,
+  CellState.NO_RETURN,
+  CellState.SOURCE_INVALID,
+  CellState.NOT_DECODED,
+  CellState.SOURCE_RECORD_MISSING,
+];
+
+/** Human-readable names, for diagnostics and UI. Never abbreviate these in prose. */
+export const CELL_STATE_LABEL: Readonly<Record<CellStateValue, string>> = {
+  [CellState.VALID_RETURN]: 'Valid return',
+  [CellState.NO_RETURN]: 'No return',
+  [CellState.SOURCE_INVALID]: 'Source invalid',
+  [CellState.NOT_DECODED]: 'Not decoded',
+  [CellState.SOURCE_RECORD_MISSING]: 'Source record missing',
+};
+
+/**
+ * The cell holds no display record, whatever the reason.
+ *
+ * `Int32Array` rather than `Uint32Array` precisely so this sentinel exists: an
+ * unsigned array would have to spend a real index (or a parallel mask) to say
+ * "nothing here", and a mask is one more array to keep in step.
+ */
+export const NO_RECORD = -1;
+
+/**
+ * Where a scanner setup stood.
+ *
+ * PTX carries TWO positions and they are not two candidates for one value.
+ * They live in different frames:
+ *
+ *   `localPosition`  the format's own scanner-position header line, expressed
+ *                    in the scanner's own frame, so it is `0 0 0` for ordinary
+ *                    scanner-local data and non-zero only when the writer
+ *                    offset its samples from the instrument.
+ *   `worldTranslation` the registration transform's translation row, which is
+ *                    where that scanner sits once the block is registered.
+ *
+ * An earlier design treated the header line as the better source for a single
+ * "scanner origin" and the transform row as a fallback substitute. That is
+ * wrong: it would report a scanner at the world origin for every ordinary file.
+ * Keep both, name the frame in the field, and let the caller pick.
+ *
+ * The transform is kept as the raw row-major 4x4 rather than decomposed into a
+ * quaternion. Decomposition buys nothing here and introduces a convention risk
+ * (component order, handedness, row or column vectors) that a reader cannot
+ * audit from the stored value.
+ */
+export interface AcquisitionPose {
+  /** Registered world position: the transform's translation row. */
+  readonly worldTranslation: readonly [number, number, number];
+  /** The format's declared scanner position, in the scanner's own frame. */
+  readonly localPosition?: readonly [number, number, number];
+  /** Row-major, translation in row 3, matching the PTX layout. Four rows of four. */
+  readonly transform?: readonly (readonly number[])[];
+  /** Whether `localPosition` was readable, or the header line was malformed. */
+  readonly localPositionSource: 'source-declared' | 'unreadable';
+}
+
+/**
+ * How faithfully this frame can still reach the display cloud.
+ *
+ * `partial` is a recoverable shortfall: the records that were decoded still
+ * link exactly, and decoding more would restore the rest. `unavailable` is
+ * permanent for this cloud, and the reason names which step spent the identity.
+ */
+export type RangeLinkage =
+  | { readonly kind: 'exact' }
+  | { readonly kind: 'partial'; readonly reason: 'stride' }
+  | {
+      readonly kind: 'unavailable';
+      readonly reason:
+        | 'voxel-centroids'
+        | 'invalid-source-topology'
+        | 'source-record-identity-unavailable';
+    };
+
+/** Per-frame tallies. Counts only; every ratio is derived on demand. */
+export interface RangeFrameDiagnostics {
+  readonly cells: number;
+  /** Indexed by `CellStateValue`. */
+  readonly stateCounts: Readonly<Record<CellStateValue, number>>;
+}
+
+export interface OrganizedRangeFrame {
+  readonly id: string;
+  readonly sourceKind: 'ptx-grid' | 'pcd-organized' | 'e57-structured';
+  /** Columns. */
+  readonly width: number;
+  /** Rows. */
+  readonly height: number;
+  /** Length `width * height`, indexed by `cellIndex`. */
+  readonly cellState: Uint8Array;
+  /** Length `width * height`. Display record index, or `NO_RECORD`. */
+  readonly cellToRecord: Int32Array;
+  /** Length `width * height`. Range in acquisition-local coordinates, NaN where absent. */
+  readonly geometricRange?: Float32Array;
+  /** Length `width * height`. Range the source itself declared, NaN where absent. */
+  readonly sourceRange?: Float32Array;
+  readonly acquisitionPose?: AcquisitionPose;
+  readonly linkage: RangeLinkage;
+  readonly diagnostics: RangeFrameDiagnostics;
+}
+
+export interface OrganizedRangeSet {
+  readonly kind: 'organized-range';
+  readonly frames: readonly OrganizedRangeFrame[];
+  readonly organization: 'organized-grid' | 'multi-grid';
+}
+
+/**
+ * PTX orders its samples column by column: every row of column 0, then every
+ * row of column 1. So the ordinal advances DOWN a column, and the row is the
+ * fast axis.
+ *
+ * This is stated as a function rather than inlined at the call site because it
+ * is a format convention, not an arithmetic detail, and getting it transposed
+ * produces a grid that looks plausible and is wrong everywhere. A test pins it
+ * against a non-square grid, where a transposition cannot hide.
+ */
+export function ptxCellFromOrdinal(
+  ordinal: number,
+  rows: number,
+): { readonly row: number; readonly column: number } {
+  return { row: ordinal % rows, column: Math.floor(ordinal / rows) };
+}
+
+/**
+ * The index into `cellState` and `cellToRecord` for a row and column.
+ *
+ * Storage is row-major (`row * width + column`) regardless of the source's own
+ * ordering, so every frame is addressed the same way whatever produced it. The
+ * source ordering is converted on the way in, once, by the loader.
+ */
+export function cellIndexOf(row: number, column: number, width: number): number {
+  return row * width + column;
+}
+
+/** Tally cell states. Kept separate from construction so it can be re-run after an edit. */
+export function tallyCellStates(cellState: Uint8Array): RangeFrameDiagnostics {
+  const stateCounts = {
+    [CellState.VALID_RETURN]: 0,
+    [CellState.NO_RETURN]: 0,
+    [CellState.SOURCE_INVALID]: 0,
+    [CellState.NOT_DECODED]: 0,
+    [CellState.SOURCE_RECORD_MISSING]: 0,
+  } as Record<CellStateValue, number>;
+  for (let i = 0; i < cellState.length; i++) {
+    const s = cellState[i] as CellStateValue;
+    if (s in stateCounts) stateCounts[s]++;
+  }
+  return { cells: cellState.length, stateCounts };
+}
+
+/**
+ * Resolve a cell to its display record, or explain why it cannot.
+ *
+ * Returns `null` rather than a plausible index whenever the answer is not
+ * provable. Callers must render the reason, not fall back to a nearest point.
+ */
+export function recordForCell(
+  frame: OrganizedRangeFrame,
+  row: number,
+  column: number,
+): { readonly ok: true; readonly record: number } | { readonly ok: false; readonly why: string } {
+  if (frame.linkage.kind === 'unavailable') {
+    return { ok: false, why: `Exact linking unavailable: ${frame.linkage.reason}.` };
+  }
+  if (row < 0 || column < 0 || row >= frame.height || column >= frame.width) {
+    return { ok: false, why: 'Cell is outside the acquisition grid.' };
+  }
+  const idx = cellIndexOf(row, column, frame.width);
+  const state = frame.cellState[idx] as CellStateValue;
+  if (state !== CellState.VALID_RETURN) {
+    return { ok: false, why: `${CELL_STATE_LABEL[state]}: no display record exists for this cell.` };
+  }
+  const record = frame.cellToRecord[idx];
+  if (record === NO_RECORD) {
+    return { ok: false, why: 'Source record identity is unavailable for this cell.' };
+  }
+  return { ok: true, record };
+}
+
+/**
+ * Degrade every frame's linkage, returning a new set.
+ *
+ * The topology survives a reduction that destroys record identity: a grid of
+ * validity and range is still worth inspecting after voxelization, and saying
+ * so is the point of separating the two. What must not survive is the claim
+ * that a centroid IS a source return.
+ *
+ * `cellToRecord` is rewritten to `NO_RECORD` rather than merely being ignored,
+ * so a caller that reads the array directly cannot resurrect a stale index.
+ */
+export function withLinkageUnavailable(
+  set: OrganizedRangeSet,
+  reason: Extract<RangeLinkage, { kind: 'unavailable' }>['reason'],
+): OrganizedRangeSet {
+  return {
+    ...set,
+    frames: set.frames.map((f) => ({
+      ...f,
+      cellToRecord: new Int32Array(f.cellToRecord.length).fill(NO_RECORD),
+      linkage: { kind: 'unavailable', reason } as const,
+    })),
+  };
+}

--- a/src/model/OrganizedRange.ts
+++ b/src/model/OrganizedRange.ts
@@ -16,9 +16,10 @@
  * the processing path destroys that identity, the frame says so through
  * `linkage` rather than reconstructing a plausible answer.
  *
- * Pure and DOM-free by design: every value here is a number or a typed array,
- * so the model is testable under Node and can cross a worker boundary by
- * transfer rather than by structured clone.
+ * Pure and DOM-free by design, so the model is testable under Node. The bulk
+ * of each frame is typed arrays, which cross a worker boundary by transfer
+ * rather than by structured clone; the acquisition pose is a handful of plain
+ * numbers per setup and is cloned.
  */
 
 /**
@@ -262,4 +263,27 @@ export function withLinkageUnavailable(
       linkage: { kind: 'unavailable', reason } as const,
     })),
   };
+}
+
+/**
+ * Every transferable buffer in a set, derived from the frames themselves.
+ *
+ * Deliberately not a hand-written list of field names. The worker's transfer
+ * list was enumerated per field, so adding one array to `OrganizedRangeFrame`
+ * would have sent it across the boundary by structured clone: correct, silent,
+ * and at exactly the copying cost the transfer list exists to avoid. Reading
+ * the frame's own values means a new array is included by construction.
+ *
+ * `acquisitionPose.transform` is nested plain arrays rather than a typed array,
+ * so it is cloned. That is a handful of numbers per setup and not worth a
+ * representation change.
+ */
+export function organizedRangeTransferables(set: OrganizedRangeSet): ArrayBuffer[] {
+  const out: ArrayBuffer[] = [];
+  for (const frame of set.frames) {
+    for (const value of Object.values(frame)) {
+      if (ArrayBuffer.isView(value)) out.push(value.buffer as ArrayBuffer);
+    }
+  }
+  return out;
 }

--- a/src/model/PointCloud.ts
+++ b/src/model/PointCloud.ts
@@ -1,5 +1,6 @@
 import type { SourceFormat } from '../io/sniffFormat';
 import type { CrsInfo } from '../io/crs';
+import type { OrganizedRangeSet } from './OrganizedRange';
 
 /**
  * One source-metadata field exactly as the file declared it. `value` is
@@ -94,6 +95,7 @@ export interface CloudMetadata {
 
 /** Options accepted by the `PointCloud` constructor. */
 export interface PointCloudOptions {
+
   /** Interleaved xyz positions in local (recentered) coordinates. */
   positions: Float32Array;
   /** Optional interleaved rgb color, one byte per channel. */
@@ -112,6 +114,16 @@ export interface PointCloudOptions {
   pointSourceId?: Uint16Array;
   /** Optional per-point LAS GPS time, in the file's GPS-time encoding. */
   gpsTime?: Float64Array;
+  /**
+   * Source acquisition topology, when the format carried one.
+   *
+   * A DEDICATED field rather than a member of `metadata`, deliberately.
+   * `voxelDownsample` forwards `metadata` wholesale to the reduced cloud, so a
+   * sidecar living there would arrive at a cloud of centroids still claiming
+   * its links are exact, with nothing to notice. Standing alone, any reduction
+   * has to name it to carry it.
+   */
+  organizedRange?: OrganizedRangeSet;
   /** The integer world-space origin that was subtracted from the positions. */
   origin: [number, number, number];
   /** Which file format this cloud was loaded from. */
@@ -168,6 +180,8 @@ export class PointCloud {
   readonly returnCount?: Uint8Array;
   readonly pointSourceId?: Uint16Array;
   readonly gpsTime?: Float64Array;
+  /** Source acquisition topology. See {@link PointCloudOptions.organizedRange}. */
+  readonly organizedRange?: OrganizedRangeSet;
   /**
    * The world-space origin subtracted from the positions at load time.
    *
@@ -257,6 +271,7 @@ export class PointCloud {
     this.returnCount = options.returnCount;
     this.pointSourceId = options.pointSourceId;
     this.gpsTime = options.gpsTime;
+    this.organizedRange = options.organizedRange;
     this.origin = options.origin;
     // A COPY, deliberately. Nothing in this class writes either origin any
     // more, but the caller still holds a reference to its own array — a copy

--- a/src/process/voxelDownsample.ts
+++ b/src/process/voxelDownsample.ts
@@ -1,5 +1,6 @@
 import { PointCloud } from '../model/PointCloud';
 import { sourcePositions } from '../model/pointFrames';
+import { withLinkageUnavailable } from '../model/OrganizedRange';
 
 /**
  * Voxel-grid stride for packing a 3-D voxel index into one numeric Map key.
@@ -181,6 +182,16 @@ export function voxelDownsample(cloud: PointCloud, voxelSize: number): PointClou
     loadStride: cloud.loadStride,
     // Provenance metadata is independent of point count — carry it through.
     metadata: cloud.metadata,
+    // The acquisition grid survives; the link from a cell to a display point
+    // does not. Every output point here is a centroid of several source
+    // returns, so no cell names a return any more, and `withLinkageUnavailable`
+    // both says so and clears the stale indices. Dropping the sidecar entirely
+    // would be safe but wasteful: the grid, its validity states and its ranges
+    // are all still true of the source, and losing them is the reason a
+    // reduced scan used to become uninspectable.
+    organizedRange: cloud.organizedRange
+      ? withLinkageUnavailable(cloud.organizedRange, 'voxel-centroids')
+      : undefined,
   });
 }
 

--- a/tests/e57Preflight.test.ts
+++ b/tests/e57Preflight.test.ts
@@ -171,6 +171,14 @@ function scan(name: string, recordCount: number, fields: string[]): E57Scan {
     pose: null,
     colorMax: null,
     intensityMax: null,
+    indexBounds: null,
+    structuredFields: {
+      rowIndex: fields.includes('rowIndex'),
+      columnIndex: fields.includes('columnIndex'),
+      returnIndex: fields.includes('returnIndex'),
+      returnCount: fields.includes('returnCount'),
+      sphericalRange: fields.includes('sphericalRange'),
+    },
   };
 }
 

--- a/tests/e57StructuredDeclarations.test.ts
+++ b/tests/e57StructuredDeclarations.test.ts
@@ -1,0 +1,429 @@
+/**
+ * e57StructuredDeclarations.test.ts — what a structured E57 DECLARES about its
+ * acquisition grid, read without decoding a structured column.
+ *
+ * An E57 scan written by a terrestrial scanner carries two facts this reader
+ * previously discarded: the `indexBounds` structure, which states the row,
+ * column and return ranges the writer used, and the prototype's own
+ * `rowIndex` / `columnIndex` / `returnIndex` / `returnCount` / `sphericalRange`
+ * declarations. Both are needed before an acquisition grid can be preserved,
+ * and both are cheap: they are XML, not point data.
+ *
+ * Nothing here decodes a structured column, builds a frame or widens the set of
+ * fields the loader materialises. The point of this file is that the DECISION
+ * about whether a scan could carry a grid rests on facts read from the file.
+ *
+ * `pumpARowColumnIndexNoInvalidPoints.e57` is a genuine libE57-written
+ * structured scan (rowIndex + columnIndex + indexBounds); `bunnyFloat.e57` is
+ * an unstructured one from the same corpus. Both are from the libE57 Example /
+ * Test Data corpus (validation/datasets/dataset-register.yaml, OLV-DS-041).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { parseE57Header } from '../src/io/e57/header';
+import { depage, physicalToLogical } from '../src/io/e57/depage';
+import { parseXml } from '../src/io/e57/xml';
+import { crc32c } from '../src/io/e57/crc32c';
+import {
+  readE57Document,
+  e57ScanSupportsStructuredRange,
+} from '../src/io/e57/schema';
+import type { E57Scan } from '../src/io/e57/schema';
+import { parseE57 } from '../src/io/e57/parseE57';
+import {
+  e57FieldIsConsumed,
+  e57FieldIsConsumedForScan,
+  e57ConsumedFieldsForScan,
+  e57LocalFieldName,
+  summariseE57Scans,
+} from '../src/io/e57/preflight';
+
+function bufferOf(name: string): ArrayBuffer {
+  const b = readFileSync(fileURLToPath(new URL(name, import.meta.url)));
+  return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+}
+
+/** The interpreted document of a real fixture, XML section included. */
+function documentOf(buffer: ArrayBuffer): ReturnType<typeof readE57Document> {
+  const header = parseE57Header(buffer);
+  const { logical } = depage(buffer, header.pageSize, header.filePhysicalLength);
+  const start = physicalToLogical(header.xmlPhysicalOffset, header.pageSize);
+  const xml = new TextDecoder().decode(
+    logical.subarray(start, start + header.xmlLogicalLength),
+  );
+  return readE57Document(parseXml(xml));
+}
+
+const PUMP = bufferOf('./pumpARowColumnIndexNoInvalidPoints.e57');
+const BUNNY = bufferOf('./bunnyFloat.e57');
+const NORMALS = bufferOf('./fixtures/synthetic-normals.e57');
+
+const pumpScan = (): E57Scan => documentOf(PUMP).scans[0];
+const bunnyScan = (): E57Scan => documentOf(BUNNY).scans[0];
+
+/** The smallest scan XML the reader accepts, with the caller's extra elements. */
+function scanXml(extra: string, prototype: string): string {
+  return `<e57Root>
+    <data3D>
+      <vectorChild type="Structure">
+        <name>Scan</name>
+        ${extra}
+        <points type="CompressedVector" recordCount="10" fileOffset="0">
+          <prototype type="Structure">
+            ${prototype}
+          </prototype>
+        </points>
+      </vectorChild>
+    </data3D>
+  </e57Root>`;
+}
+
+const ROW_COL_PROTOTYPE =
+  '<cartesianX type="Float"/><cartesianY type="Float"/><cartesianZ type="Float"/>' +
+  '<rowIndex type="Integer" minimum="0" maximum="2047"/>' +
+  '<columnIndex type="Integer" minimum="0" maximum="511"/>';
+
+const INDEX_BOUNDS_XML =
+  '<indexBounds type="Structure">' +
+  '<rowMinimum type="Integer">0</rowMinimum><rowMaximum type="Integer">9</rowMaximum>' +
+  '<columnMinimum type="Integer">0</columnMinimum><columnMaximum type="Integer">4</columnMaximum>' +
+  '</indexBounds>';
+
+function scanOf(extra: string, prototype: string): E57Scan {
+  return readE57Document(parseXml(scanXml(extra, prototype))).scans[0];
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// A. What the file declares
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('E57 indexBounds', () => {
+  it('reads the row, column and return ranges a structured scan declares', () => {
+    const bounds = pumpScan().indexBounds;
+    // Verbatim from the fixture's XML: rowMaximum 1073, columnMaximum 344, and
+    // three EMPTY minima plus two empty return elements, which the E57 spec
+    // reads as the type's default value (0) rather than as absent.
+    expect(bounds).not.toBeNull();
+    expect(bounds?.row).toEqual({ minimum: 0, maximum: 1073 });
+    expect(bounds?.column).toEqual({ minimum: 0, maximum: 344 });
+    expect(bounds?.return).toEqual({ minimum: 0, maximum: 0 });
+  });
+
+  it('is null for a scan that declares no indexBounds', () => {
+    expect(bunnyScan().indexBounds).toBeNull();
+  });
+
+  it('drops an axis whose declared bound is unusable, without throwing', () => {
+    const scan = scanOf(
+      '<indexBounds type="Structure">' +
+        '<rowMinimum type="Integer">0</rowMinimum>' +
+        '<rowMaximum type="Integer">garbage</rowMaximum>' +
+        '<columnMinimum type="Integer">0</columnMinimum>' +
+        '<columnMaximum type="Integer">4</columnMaximum>' +
+        '</indexBounds>',
+      ROW_COL_PROTOTYPE,
+    );
+    expect(scan.indexBounds?.row).toBeNull();
+    expect(scan.indexBounds?.column).toEqual({ minimum: 0, maximum: 4 });
+  });
+});
+
+describe('E57 structured prototype declarations', () => {
+  it('records which structured fields a structured scan declares', () => {
+    const declared = pumpScan().structuredFields;
+    expect(declared.rowIndex).toBe(true);
+    expect(declared.columnIndex).toBe(true);
+    expect(declared.returnIndex).toBe(false);
+    expect(declared.returnCount).toBe(false);
+    expect(declared.sphericalRange).toBe(false);
+  });
+
+  it('records none of them for an unstructured scan', () => {
+    expect(bunnyScan().structuredFields).toEqual({
+      rowIndex: false,
+      columnIndex: false,
+      returnIndex: false,
+      returnCount: false,
+      sphericalRange: false,
+    });
+  });
+
+  it('resolves a structured field declared under an extension prefix', () => {
+    const scan = scanOf('', '<x:rowIndex type="Integer" minimum="0" maximum="7"/>');
+    expect(scan.structuredFields.rowIndex).toBe(true);
+  });
+});
+
+describe('E57 prototype field bounds', () => {
+  it('retains the declared maximum alongside the derived bit width', () => {
+    const proto = pumpScan().prototype;
+    const row = proto.find((f) => f.name === 'rowIndex');
+    expect(row?.minimum).toBe(0);
+    expect(row?.maximum).toBe(2047);
+    expect(row?.bitWidth).toBe(11);
+    const x = proto.find((f) => f.name === 'cartesianX');
+    expect(x?.maximum).toBe(8388607);
+  });
+
+  it('leaves a float field without one', () => {
+    expect(bunnyScan().prototype.find((f) => f.name === 'cartesianX')?.maximum).toBeUndefined();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// B. Eligibility — stated, not acted on
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('structured-range eligibility', () => {
+  it('accepts a scan that declares both indices and both index bounds', () => {
+    expect(e57ScanSupportsStructuredRange(pumpScan())).toBe(true);
+  });
+
+  it('rejects a scan that declares no structured fields at all', () => {
+    expect(e57ScanSupportsStructuredRange(bunnyScan())).toBe(false);
+  });
+
+  it('rejects indices declared without index bounds', () => {
+    expect(e57ScanSupportsStructuredRange(scanOf('', ROW_COL_PROTOTYPE))).toBe(false);
+  });
+
+  it('rejects index bounds declared without the prototype indices', () => {
+    const scan = scanOf(INDEX_BOUNDS_XML, '<cartesianX type="Float"/>');
+    expect(e57ScanSupportsStructuredRange(scan)).toBe(false);
+  });
+
+  it('rejects a column axis the writer left out of otherwise-present bounds', () => {
+    const scan = scanOf(
+      '<indexBounds type="Structure">' +
+        '<rowMinimum type="Integer">0</rowMinimum><rowMaximum type="Integer">9</rowMaximum>' +
+        '</indexBounds>',
+      ROW_COL_PROTOTYPE,
+    );
+    expect(e57ScanSupportsStructuredRange(scan)).toBe(false);
+  });
+
+  it('rejects an inverted range, which describes no grid', () => {
+    const scan = scanOf(
+      '<indexBounds type="Structure">' +
+        '<rowMinimum type="Integer">9</rowMinimum><rowMaximum type="Integer">0</rowMaximum>' +
+        '<columnMinimum type="Integer">0</columnMinimum><columnMaximum type="Integer">4</columnMaximum>' +
+        '</indexBounds>',
+      ROW_COL_PROTOTYPE,
+    );
+    expect(e57ScanSupportsStructuredRange(scan)).toBe(false);
+  });
+
+  it('is stated but not acted on: an eligible scan still decodes no index column', () => {
+    const parsed = parseE57(PUMP, { keepField: e57FieldIsConsumedForScan });
+    expect(Object.keys(parsed.scans[0].columns)).not.toContain('rowIndex');
+    expect(Object.keys(parsed.scans[0].columns)).not.toContain('columnIndex');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// C. The decode predicate is now per scan, and decodes exactly what it did
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Column names a buffer decodes under a given predicate, per scan, sorted. */
+function columnsUnder(
+  buffer: ArrayBuffer,
+  keepField: (name: string, scan: E57Scan) => boolean,
+): string[][] {
+  return parseE57(buffer, { keepField }).scans.map((s) => Object.keys(s.columns).sort());
+}
+
+describe('the per-scan decode predicate', () => {
+  it('decodes exactly the columns the global predicate decoded, on every fixture', () => {
+    for (const buffer of [PUMP, BUNNY, NORMALS]) {
+      expect(columnsUnder(buffer, e57FieldIsConsumedForScan)).toEqual(
+        columnsUnder(buffer, (name) => e57FieldIsConsumed(name)),
+      );
+    }
+  });
+
+  it('materialises only the consumed columns of the structured fixture', () => {
+    const [columns] = columnsUnder(PUMP, e57FieldIsConsumedForScan);
+    expect(columns).toEqual([
+      'cartesianInvalidState',
+      'cartesianX',
+      'cartesianY',
+      'cartesianZ',
+      'colorBlue',
+      'colorGreen',
+      'colorRed',
+      'intensity',
+    ]);
+  });
+
+  it('gives the predicate the scan whose columns it is deciding', () => {
+    const seen: string[] = [];
+    parseE57(TWO_SCANS, {
+      keepField: (name, scan) => {
+        if (name === 'cartesianX') seen.push(scan.name);
+        return true;
+      },
+    });
+    expect(seen).toEqual(['scan-a', 'scan-b']);
+  });
+
+  it('lets one scan keep a column another scan drops', () => {
+    const columns = columnsUnder(TWO_SCANS, (name, scan) =>
+      scan.name === 'scan-a' ? name !== 'colorRed' : true,
+    );
+    expect(columns[0]).not.toContain('colorRed');
+    expect(columns[1]).toContain('colorRed');
+  });
+
+  it('still decodes every column when no predicate is given', () => {
+    const columns = parseE57(TWO_SCANS).scans.map((s) => Object.keys(s.columns).sort());
+    expect(columns[0]).toEqual(columns[1]);
+    expect(columns[0]).toContain('colorRed');
+  });
+});
+
+describe('the preflight estimate and the decode agree per scan', () => {
+  it('counts the columns the decode actually materialises', () => {
+    const document = documentOf(PUMP);
+    const pre = summariseE57Scans(document.scans);
+    const decoded = Object.keys(parseE57(PUMP, { keepField: e57FieldIsConsumedForScan }).scans[0].columns);
+    expect(pre.columnsPerRecord).toBe(decoded.length);
+  });
+
+  it('derives both from one per-scan consumed set', () => {
+    const scan = pumpScan();
+    const consumed = e57ConsumedFieldsForScan(scan);
+    for (const field of scan.prototype) {
+      expect(e57FieldIsConsumedForScan(field.name, scan)).toBe(
+        consumed.has(e57LocalFieldName(field.name)),
+      );
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// A synthetic TWO-scan E57, so "per scan" can be observed at all
+//
+// Every committed E57 fixture declares exactly one scan, and a single-scan file
+// cannot tell a predicate bound to the right scan apart from one bound to the
+// first. Two scans with the same prototype and different names can.
+// ────────────────────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 1024;
+const PAGE_PAYLOAD = PAGE_SIZE - 4;
+const RECORDS = 8;
+/** Fixed-width so the XML length does not move when the offsets are filled in. */
+const OFFSET_DIGITS = 9;
+
+function logicalToPhysical(logical: number): number {
+  return Math.floor(logical / PAGE_PAYLOAD) * PAGE_SIZE + (logical % PAGE_PAYLOAD);
+}
+
+function twoScanXml(offsetA: number, offsetB: number): string {
+  const scan = (name: string, offset: number): string =>
+    '    <vectorChild type="Structure">\n' +
+    `      <guid type="String">two-scan-${name}</guid>\n` +
+    `      <name type="String">${name}</name>\n` +
+    `      <points type="CompressedVector" fileOffset="${String(offset).padStart(OFFSET_DIGITS, '0')}" recordCount="${RECORDS}">\n` +
+    '        <prototype type="Structure">\n' +
+    '          <cartesianX type="Float" precision="single"/>\n' +
+    '          <cartesianY type="Float" precision="single"/>\n' +
+    '          <cartesianZ type="Float" precision="single"/>\n' +
+    '          <colorRed type="Integer" minimum="0" maximum="255"/>\n' +
+    '        </prototype>\n' +
+    '        <codecs type="Vector" allowHeterogeneousChildren="1"/>\n' +
+    '      </points>\n' +
+    '    </vectorChild>\n';
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<e57Root type="Structure">\n' +
+    '  <formatName type="String">ASTM E57 3D Imaging Data File</formatName>\n' +
+    '  <guid type="String">two-scan-fixture</guid>\n' +
+    '  <data3D type="Vector" allowHeterogeneousChildren="1">\n' +
+    scan('scan-a', offsetA) +
+    scan('scan-b', offsetB) +
+    '  </data3D>\n' +
+    '</e57Root>\n'
+  );
+}
+
+/** One scan's CompressedVector section, starting at `sectionLogicalStart`. */
+function buildSection(sectionLogicalStart: number): Uint8Array {
+  const axes = [0, 1, 2].map(() => new Uint8Array(RECORDS * 4));
+  const views = axes.map((a) => new DataView(a.buffer));
+  const red = new Uint8Array(RECORDS);
+  for (let i = 0; i < RECORDS; i++) {
+    views[0].setFloat32(i * 4, i, true);
+    views[1].setFloat32(i * 4, 2 * i, true);
+    views[2].setFloat32(i * 4, 3 * i, true);
+    red[i] = i;
+  }
+  const streams = [...axes, red];
+  const count = streams.length;
+  const headerLen = 6 + count * 2;
+  const packetLength = headerLen + streams.reduce((a, s) => a + s.length, 0);
+  const sectionLength = 32 + packetLength;
+  const section = new Uint8Array(sectionLength);
+  const dv = new DataView(section.buffer);
+  section[0] = 1; // COMPRESSED_VECTOR_SECTION
+  dv.setBigUint64(8, BigInt(sectionLength), true);
+  dv.setBigUint64(16, BigInt(logicalToPhysical(sectionLogicalStart + 32)), true);
+  section[32] = 1; // DATA_PACKET
+  dv.setUint16(34, packetLength - 1, true);
+  dv.setUint16(36, count, true);
+  streams.forEach((s, f) => dv.setUint16(38 + f * 2, s.length, true));
+  let at = 32 + headerLen;
+  for (const s of streams) {
+    section.set(s, at);
+    at += s.length;
+  }
+  return section;
+}
+
+function buildTwoScanE57(): ArrayBuffer {
+  const HEADER_LEN = 48;
+  const xmlLogicalStart = HEADER_LEN;
+  const xmlLength = Buffer.byteLength(twoScanXml(0, 0), 'utf8');
+  const startA = xmlLogicalStart + xmlLength;
+  const sectionA = buildSection(startA);
+  const startB = startA + sectionA.length;
+  const sectionB = buildSection(startB);
+  const xmlBytes = Buffer.from(
+    twoScanXml(logicalToPhysical(startA), logicalToPhysical(startB)),
+    'utf8',
+  );
+  if (xmlBytes.length !== xmlLength) {
+    throw new Error('two-scan XML length moved when the offsets were filled in');
+  }
+
+  const logicalLength = startB + sectionB.length;
+  const logical = new Uint8Array(logicalLength);
+  const hv = new DataView(logical.buffer);
+  const SIGNATURE = 'ASTM-E57';
+  for (let i = 0; i < SIGNATURE.length; i++) logical[i] = SIGNATURE.charCodeAt(i);
+  hv.setUint32(8, 1, true);
+  hv.setUint32(12, 0, true);
+  hv.setBigUint64(24, BigInt(logicalToPhysical(xmlLogicalStart)), true);
+  hv.setBigUint64(32, BigInt(xmlBytes.length), true);
+  hv.setBigUint64(40, BigInt(PAGE_SIZE), true);
+  logical.set(xmlBytes, xmlLogicalStart);
+  logical.set(sectionA, startA);
+  logical.set(sectionB, startB);
+
+  const pageCount = Math.ceil(logicalLength / PAGE_PAYLOAD);
+  hv.setBigUint64(16, BigInt(pageCount * PAGE_SIZE), true);
+  const physical = new Uint8Array(pageCount * PAGE_SIZE);
+  for (let p = 0; p < pageCount; p++) {
+    const dst = physical.subarray(p * PAGE_SIZE, (p + 1) * PAGE_SIZE);
+    dst.set(logical.subarray(p * PAGE_PAYLOAD, (p + 1) * PAGE_PAYLOAD), 0);
+    new DataView(dst.buffer, dst.byteOffset + PAGE_PAYLOAD, 4).setUint32(
+      0,
+      crc32c(dst, 0, PAGE_PAYLOAD),
+      false,
+    );
+  }
+  return physical.buffer;
+}
+
+const TWO_SCANS = buildTwoScanE57();

--- a/tests/loaderSanitation.test.ts
+++ b/tests/loaderSanitation.test.ts
@@ -3,6 +3,7 @@ import {
   sanitizeLocalCloud,
   outputRecordFor,
   RECORD_DROPPED,
+  RECORD_NOT_WITNESSED,
 } from '../src/io/sanitizeCloud';
 import type { CloudAttributes } from '../src/io/sanitizeCloud';
 import { LoadError } from '../src/io/loadErrors';
@@ -365,5 +366,20 @@ describe('the compaction witness', () => {
     );
     expect(outputRecordFor(result.witness!, 1)).toBe(RECORD_DROPPED);
     expect(outputRecordFor(result.witness!, 2)).toBe(1);
+  });
+});
+
+describe('the witness distinguishes a dropped record from an unknown one', () => {
+  it('answers out of range with RECORD_NOT_WITNESSED, not RECORD_DROPPED', () => {
+    // These are different facts. "This record was removed" is a decoding
+    // outcome a caller can render as a cell state; "I was never asked about
+    // this index" is a bookkeeping mismatch that no cell state describes
+    // truthfully. Returning the same value for both let a caller mark a cell
+    // as discarded when the real problem was that two counts disagreed.
+    const witness = { kind: 'identity', sourceCount: 3 } as const;
+    expect(outputRecordFor(witness, 0)).toBe(0);
+    expect(outputRecordFor(witness, 3)).toBe(RECORD_NOT_WITNESSED);
+    expect(outputRecordFor(witness, -1)).toBe(RECORD_NOT_WITNESSED);
+    expect(RECORD_NOT_WITNESSED).not.toBe(RECORD_DROPPED);
   });
 });

--- a/tests/loaderSanitation.test.ts
+++ b/tests/loaderSanitation.test.ts
@@ -1,4 +1,9 @@
-import { sanitizeAndRecenter, sanitizeLocalCloud } from '../src/io/sanitizeCloud';
+import {
+  sanitizeAndRecenter,
+  sanitizeLocalCloud,
+  outputRecordFor,
+  RECORD_DROPPED,
+} from '../src/io/sanitizeCloud';
 import type { CloudAttributes } from '../src/io/sanitizeCloud';
 import { LoadError } from '../src/io/loadErrors';
 import { loadPly } from '../src/io/loadPly';
@@ -311,5 +316,54 @@ describe('loadLas — a header-scale overflow cannot ship a non-finite point', (
     const pc = await loadLas(buffer, 'las', 'clean.las');
     expect(pc.pointCount).toBe(2);
     expect(pc.metadata?.loadWarnings).toBeUndefined();
+  });
+});
+
+describe('the compaction witness', () => {
+  test('is absent unless it is asked for', () => {
+    // The witness is opt-in precisely so an ordinary load pays nothing for it.
+    const dirty = sanitizeAndRecenter(new Float64Array([0, 0, 0, Number.NaN, 1, 1, 2, 2, 2]), {});
+    expect(dirty.witness).toBeUndefined();
+    expect(sanitizeAndRecenter(new Float64Array([0, 0, 0]), {}).witness).toBeUndefined();
+    expect(sanitizeLocalCloud(new Float32Array([0, 0, 0]), {}).witness).toBeUndefined();
+  });
+
+  test('reports identity, without a table, when nothing was dropped', () => {
+    const result = sanitizeAndRecenter(new Float64Array([0, 0, 0, 1, 1, 1]), {}, { witness: true });
+    expect(result.witness).toEqual({ kind: 'identity', sourceCount: 2 });
+    expect(outputRecordFor(result.witness!, 1)).toBe(1);
+  });
+
+  test('maps every source record across a hole, and marks the hole dropped', () => {
+    const result = sanitizeAndRecenter(
+      new Float64Array([0, 0, 0, 1, Number.NaN, 1, 2, 2, 2, 3, 3, 3]),
+      {},
+      { witness: true },
+    );
+    expect(result.excludedCount).toBe(1);
+    const w = result.witness!;
+    expect(w.sourceCount).toBe(4);
+    expect(outputRecordFor(w, 0)).toBe(0);
+    expect(outputRecordFor(w, 1)).toBe(RECORD_DROPPED);
+    expect(outputRecordFor(w, 2)).toBe(1);
+    expect(outputRecordFor(w, 3)).toBe(2);
+  });
+
+  test('answers an empty cloud with an empty witness, not with nothing', () => {
+    // `undefined` would be indistinguishable from "the witness was not asked
+    // for", which is the one thing a caller must be able to tell apart.
+    const result = sanitizeAndRecenter(new Float64Array(0), {}, { witness: true });
+    expect(result.witness).toBeDefined();
+    expect(result.witness!.sourceCount).toBe(0);
+  });
+
+  test('carries through the already-local entry point too', () => {
+    const result = sanitizeLocalCloud(
+      new Float32Array([0, 0, 0, Number.NaN, 1, 1, 2, 2, 2]),
+      {},
+      { witness: true },
+    );
+    expect(outputRecordFor(result.witness!, 1)).toBe(RECORD_DROPPED);
+    expect(outputRecordFor(result.witness!, 2)).toBe(1);
   });
 });

--- a/tests/organizedRange.test.ts
+++ b/tests/organizedRange.test.ts
@@ -145,3 +145,35 @@ describe('degrading linkage', () => {
     expect(set.frames[0].cellToRecord[3]).toBe(3);
   });
 });
+
+describe('worker transferables', () => {
+  it('finds every typed array in every frame, without naming one', async () => {
+    const { organizedRangeTransferables } = await import('../src/model/OrganizedRange');
+    const set: OrganizedRangeSet = {
+      kind: 'organized-range',
+      frames: [
+        { ...frameFixture(), geometricRange: new Float32Array(6) },
+        { ...frameFixture(), id: 'setup-2' },
+      ],
+      organization: 'multi-grid',
+    };
+    // Frame one has cellState, cellToRecord and geometricRange; frame two has
+    // the first two. Counting rather than listing is the point: the helper
+    // reads the frame's own values, so an array added later is carried without
+    // anyone remembering to update a list.
+    expect(organizedRangeTransferables(set)).toHaveLength(5);
+  });
+
+  it('picks up an array the type did not have when the helper was written', async () => {
+    const { organizedRangeTransferables } = await import('../src/model/OrganizedRange');
+    const withExtra = { ...frameFixture(), somethingNew: new Uint16Array(3) };
+    const set = {
+      kind: 'organized-range',
+      frames: [withExtra],
+      organization: 'organized-grid',
+    } as unknown as OrganizedRangeSet;
+    // This is the regression the hand-written list could not have caught: the
+    // new array crosses by transfer rather than by a silent clone.
+    expect(organizedRangeTransferables(set)).toHaveLength(3);
+  });
+});

--- a/tests/organizedRange.test.ts
+++ b/tests/organizedRange.test.ts
@@ -1,0 +1,147 @@
+/**
+ * organizedRange.test.ts — the topology model's invariants.
+ *
+ * Two of these cases exist because the failure they catch is invisible: a
+ * transposed grid mapping and a resurrected record index both produce output
+ * that looks entirely plausible and is wrong. The rest pin the rule that a cell
+ * which cannot prove its record says so rather than returning a nearby one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CellState,
+  CELL_STATES,
+  NO_RECORD,
+  cellIndexOf,
+  ptxCellFromOrdinal,
+  tallyCellStates,
+  recordForCell,
+  withLinkageUnavailable,
+  type OrganizedRangeFrame,
+  type OrganizedRangeSet,
+} from '../src/model/OrganizedRange';
+
+/** A 3 wide by 2 high frame: deliberately non-square so a transposition shows. */
+function frameFixture(over: Partial<OrganizedRangeFrame> = {}): OrganizedRangeFrame {
+  const width = 3;
+  const height = 2;
+  const cellState = new Uint8Array(width * height).fill(CellState.VALID_RETURN);
+  const cellToRecord = new Int32Array(width * height);
+  for (let i = 0; i < cellToRecord.length; i++) cellToRecord[i] = i;
+  return {
+    id: 'setup-1',
+    sourceKind: 'ptx-grid',
+    width,
+    height,
+    cellState,
+    cellToRecord,
+    linkage: { kind: 'exact' },
+    diagnostics: tallyCellStates(cellState),
+    ...over,
+  };
+}
+
+describe('grid addressing', () => {
+  it('stores row-major, so a row step moves by the width', () => {
+    expect(cellIndexOf(0, 0, 3)).toBe(0);
+    expect(cellIndexOf(0, 2, 3)).toBe(2);
+    expect(cellIndexOf(1, 0, 3)).toBe(3);
+  });
+
+  it('reads a PTX ordinal down the column, with the row as the fast axis', () => {
+    // PTX writes every row of column 0 before starting column 1. On a grid of
+    // 4 rows, ordinal 4 is therefore the TOP of column 1, not the second row of
+    // column 0. A transposed reading returns row 1 column 0 here and passes
+    // every square-grid test ever written, which is why this one is 3 by 4.
+    expect(ptxCellFromOrdinal(0, 4)).toEqual({ row: 0, column: 0 });
+    expect(ptxCellFromOrdinal(3, 4)).toEqual({ row: 3, column: 0 });
+    expect(ptxCellFromOrdinal(4, 4)).toEqual({ row: 0, column: 1 });
+    expect(ptxCellFromOrdinal(11, 4)).toEqual({ row: 3, column: 2 });
+  });
+});
+
+describe('cell state tallies', () => {
+  it('counts every state and reports the cell total', () => {
+    const s = new Uint8Array([
+      CellState.VALID_RETURN,
+      CellState.VALID_RETURN,
+      CellState.NO_RETURN,
+      CellState.SOURCE_INVALID,
+      CellState.NOT_DECODED,
+      CellState.SOURCE_RECORD_MISSING,
+    ]);
+    const d = tallyCellStates(s);
+    expect(d.cells).toBe(6);
+    expect(d.stateCounts[CellState.VALID_RETURN]).toBe(2);
+    expect(d.stateCounts[CellState.NO_RETURN]).toBe(1);
+    expect(d.stateCounts[CellState.SOURCE_RECORD_MISSING]).toBe(1);
+    // The tally must be complete: nothing may fall outside the known states.
+    const summed = CELL_STATES.reduce((n: number, k) => n + d.stateCounts[k], 0);
+    expect(summed).toBe(d.cells);
+  });
+});
+
+describe('resolving a cell to its display record', () => {
+  it('returns the recorded index for a valid cell', () => {
+    const r = recordForCell(frameFixture(), 1, 2);
+    expect(r).toEqual({ ok: true, record: cellIndexOf(1, 2, 3) });
+  });
+
+  it('refuses a cell outside the grid rather than clamping', () => {
+    const r = recordForCell(frameFixture(), 5, 0);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.why).toContain('outside');
+  });
+
+  it('names the state when a cell holds no return', () => {
+    const f = frameFixture();
+    f.cellState[cellIndexOf(0, 1, 3)] = CellState.NO_RETURN;
+    const r = recordForCell(f, 0, 1);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.why).toContain('No return');
+  });
+
+  it('refuses when linkage is unavailable, whatever the array still holds', () => {
+    // The guard is on linkage, not on the array contents, so a frame whose
+    // indices were never cleared still refuses. Belt and braces: the degrade
+    // helper clears them too.
+    const f = frameFixture({ linkage: { kind: 'unavailable', reason: 'voxel-centroids' } });
+    const r = recordForCell(f, 0, 0);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.why).toContain('voxel-centroids');
+  });
+
+  it('still resolves under partial linkage, because the decoded records are exact', () => {
+    const f = frameFixture({ linkage: { kind: 'partial', reason: 'stride' } });
+    expect(recordForCell(f, 0, 0)).toEqual({ ok: true, record: 0 });
+  });
+});
+
+describe('degrading linkage', () => {
+  const set: OrganizedRangeSet = {
+    kind: 'organized-range',
+    frames: [frameFixture()],
+    organization: 'organized-grid',
+  };
+
+  it('erases the record indices rather than leaving them readable', () => {
+    // A caller that reads cellToRecord directly must not be able to resurrect a
+    // stale index that now points at a centroid.
+    const out = withLinkageUnavailable(set, 'voxel-centroids');
+    expect([...out.frames[0].cellToRecord]).toEqual(new Array(6).fill(NO_RECORD));
+    expect(out.frames[0].linkage).toEqual({ kind: 'unavailable', reason: 'voxel-centroids' });
+  });
+
+  it('keeps the topology, which is the whole reason the two are separable', () => {
+    const out = withLinkageUnavailable(set, 'voxel-centroids');
+    expect(out.frames[0].width).toBe(3);
+    expect(out.frames[0].diagnostics.cells).toBe(6);
+    expect(out.frames[0].cellState).toEqual(set.frames[0].cellState);
+  });
+
+  it('does not mutate the input set', () => {
+    withLinkageUnavailable(set, 'voxel-centroids');
+    expect(set.frames[0].linkage).toEqual({ kind: 'exact' });
+    expect(set.frames[0].cellToRecord[3]).toBe(3);
+  });
+});

--- a/tests/pcdOrganizedRange.test.ts
+++ b/tests/pcdOrganizedRange.test.ts
@@ -1,0 +1,243 @@
+/**
+ * pcdOrganizedRange.test.ts — the acquisition grid an organized PCD declares.
+ *
+ * PCD states its organization in the header (WIDTH columns by HEIGHT rows) but
+ * says nothing per record, so every claim here has to be checked against the
+ * records the file actually supplies. The cases are picked for the failures
+ * that render as something reasonable: a transposed grid, a header that
+ * declares more cells than the body holds, and a cell linked to the wrong
+ * record. Resolution is asserted by reading the coordinates at the resolved
+ * index, never by comparing the index to a number.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { loadPcd } from '../src/io/loadPcd';
+import { CellState, NO_RECORD, cellIndexOf, recordForCell } from '../src/model/OrganizedRange';
+
+interface HeaderOptions {
+  readonly width: number;
+  readonly height: number;
+  readonly points?: number;
+  readonly viewpoint?: string | null;
+}
+
+/** An ascii PCD with x y z fields. `viewpoint: null` omits the line entirely. */
+function asciiPcd(options: HeaderOptions, rows: readonly string[]): ArrayBuffer {
+  const { width, height, points = width * height, viewpoint = '0 0 0 1 0 0 0' } = options;
+  const lines = [
+    '# .PCD v0.7',
+    'VERSION 0.7',
+    'FIELDS x y z',
+    'SIZE 8 8 8',
+    'TYPE F F F',
+    'COUNT 1 1 1',
+    `WIDTH ${width}`,
+    `HEIGHT ${height}`,
+    ...(viewpoint === null ? [] : [`VIEWPOINT ${viewpoint}`]),
+    `POINTS ${points}`,
+    'DATA ascii',
+    ...rows,
+    '',
+  ];
+  return new TextEncoder().encode(lines.join('\n')).buffer as ArrayBuffer;
+}
+
+/**
+ * A 4-column by 3-row grid whose coordinates encode their own address:
+ * x is the column, y is the row. Non-square on purpose — a transposed read
+ * cannot hide on a square grid — and the coordinates make an off-by-one in
+ * the record link visible rather than merely a different number.
+ */
+const GRID_ROWS: string[] = [];
+for (let row = 0; row < 3; row++) {
+  for (let column = 0; column < 4; column++) {
+    GRID_ROWS.push(`${column} ${row} 0`);
+  }
+}
+
+/** World coordinate of a display record, undoing the recentring origin. */
+function worldXY(
+  pc: { positions: Float32Array; origin: readonly number[] },
+  record: number,
+): [number, number] {
+  return [pc.positions[record * 3] + pc.origin[0], pc.positions[record * 3 + 1] + pc.origin[1]];
+}
+
+describe('an organized ascii PCD', () => {
+  const buffer = (): ArrayBuffer => asciiPcd({ width: 4, height: 3 }, GRID_ROWS);
+
+  it('records one frame with the declared grid shape', async () => {
+    const pc = await loadPcd(buffer());
+    expect(pc.organizedRange?.organization).toBe('organized-grid');
+    expect(pc.organizedRange?.frames).toHaveLength(1);
+    const f = pc.organizedRange!.frames[0];
+    expect(f.sourceKind).toBe('pcd-organized');
+    expect(f.width).toBe(4);
+    expect(f.height).toBe(3);
+    expect(f.diagnostics.cells).toBe(12);
+    expect(f.diagnostics.stateCounts[CellState.VALID_RETURN]).toBe(12);
+  });
+
+  it('reads the record stream row-major, across a non-square grid', async () => {
+    const pc = await loadPcd(buffer());
+    const f = pc.organizedRange!.frames[0];
+    expect(f.linkage.kind).toBe('exact');
+    for (let row = 0; row < 3; row++) {
+      for (let column = 0; column < 4; column++) {
+        const r = recordForCell(f, row, column);
+        expect(r.ok).toBe(true);
+        if (!r.ok) continue;
+        // The coordinates carry the address, so a transposition or an
+        // off-by-one resolves to a record that disagrees with the cell.
+        expect(worldXY(pc, r.record)).toEqual([column, row]);
+      }
+    }
+  });
+
+  it('refuses a cell outside the grid', async () => {
+    const f = (await loadPcd(buffer())).organizedRange!.frames[0];
+    const r = recordForCell(f, 3, 0);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('organization is a claim the records have to back', () => {
+  it('records no grid for an unorganized file', async () => {
+    const pc = await loadPcd(asciiPcd({ width: 3, height: 1 }, ['0 0 0', '1 0 0', '2 0 0']));
+    expect(pc.organizedRange).toBeUndefined();
+  });
+
+  it('refuses a grid the decoded records cannot fill, and says so', async () => {
+    // WIDTH x HEIGHT claims twelve cells; the body holds six records.
+    const pc = await loadPcd(asciiPcd({ width: 4, height: 3 }, GRID_ROWS.slice(0, 6)));
+    expect(pc.organizedRange).toBeUndefined();
+    const warnings = pc.metadata?.loadWarnings ?? [];
+    expect(warnings.some((w) => w.includes('4') && w.includes('3') && w.includes('6'))).toBe(true);
+  });
+
+  it('refuses a grid whose cell count is not a safe integer', async () => {
+    // 2e9 x 2e9 cells is 4e18: past Number.MAX_SAFE_INTEGER, and nine bytes a
+    // cell past anything allocatable. The read still has to succeed.
+    const pc = await loadPcd(
+      asciiPcd({ width: 2_000_000_000, height: 2_000_000_000, points: 2 }, ['1 2 3', '4 5 6']),
+    );
+    expect(pc.pointCount).toBe(2);
+    expect(pc.organizedRange).toBeUndefined();
+  });
+
+  it('refuses a grid when POINTS and WIDTH x HEIGHT disagree with the body', async () => {
+    const pc = await loadPcd(asciiPcd({ width: 4, height: 3, points: 6 }, GRID_ROWS.slice(0, 6)));
+    expect(pc.pointCount).toBe(6);
+    expect(pc.organizedRange).toBeUndefined();
+  });
+});
+
+describe('cell states an organized PCD can justify', () => {
+  it('marks a non-finite record source-invalid, never a no-return', async () => {
+    const rows = [...GRID_ROWS];
+    rows[5] = 'nan 1 0'; // row 1, column 1 under a row-major read
+    const pc = await loadPcd(asciiPcd({ width: 4, height: 3 }, rows));
+    const f = pc.organizedRange!.frames[0];
+    expect(f.cellState[cellIndexOf(1, 1, 4)]).toBe(CellState.SOURCE_INVALID);
+    // PCD has no no-return semantics, so this loader must never emit one.
+    expect(f.diagnostics.stateCounts[CellState.NO_RETURN]).toBe(0);
+    const r = recordForCell(f, 1, 1);
+    expect(r.ok).toBe(false);
+    expect(f.cellToRecord[cellIndexOf(1, 1, 4)]).toBe(NO_RECORD);
+  });
+
+  it('keeps every surviving cell linked after the dropped record shifts the rest', async () => {
+    const rows = [...GRID_ROWS];
+    rows[5] = 'nan 1 0';
+    const pc = await loadPcd(asciiPcd({ width: 4, height: 3 }, rows));
+    const f = pc.organizedRange!.frames[0];
+    // Every cell after the casualty moved down one display index. The
+    // coordinates are what prove the link followed it.
+    const r = recordForCell(f, 2, 3);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(worldXY(pc, r.record)).toEqual([3, 2]);
+  });
+});
+
+describe('the acquisition viewpoint', () => {
+  it('carries an explicitly declared viewpoint, translation and quaternion', async () => {
+    const pc = await loadPcd(
+      asciiPcd({ width: 4, height: 3, viewpoint: '10 20 30 0.5 0.5 0.5 0.5' }, GRID_ROWS),
+    );
+    const pose = pc.organizedRange!.frames[0].acquisitionPose;
+    expect(pose?.worldTranslation).toEqual([10, 20, 30]);
+    // PCD writes the quaternion qw qx qy qz. Named components, so a reader
+    // cannot mistake the order.
+    expect(pose?.rotation).toEqual({ w: 0.5, x: 0.5, y: 0.5, z: 0.5 });
+    expect(pose?.rotationSource).toBe('source-declared');
+  });
+
+  it('records no pose at all when the file declares no viewpoint', async () => {
+    // An absent VIEWPOINT and the default `0 0 0 1 0 0 0` are different
+    // assertions; only one of them is the file saying where the sensor was.
+    const pc = await loadPcd(asciiPcd({ width: 4, height: 3, viewpoint: null }, GRID_ROWS));
+    expect(pc.organizedRange!.frames[0].acquisitionPose).toBeUndefined();
+  });
+
+  it('keeps an explicit default viewpoint distinguishable from an absent one', async () => {
+    const pc = await loadPcd(asciiPcd({ width: 4, height: 3 }, GRID_ROWS));
+    const pose = pc.organizedRange!.frames[0].acquisitionPose;
+    expect(pose?.worldTranslation).toEqual([0, 0, 0]);
+    expect(pose?.rotation).toEqual({ w: 1, x: 0, y: 0, z: 0 });
+  });
+});
+
+describe('an encoding OLV does not walk itself', () => {
+  /** A 3x2 f32 binary PCD. OLV reads no record of this body; three.js does. */
+  function binaryPcd(): ArrayBuffer {
+    const header = [
+      '# .PCD v0.7',
+      'VERSION 0.7',
+      'FIELDS x y z',
+      'SIZE 4 4 4',
+      'TYPE F F F',
+      'COUNT 1 1 1',
+      'WIDTH 3',
+      'HEIGHT 2',
+      'VIEWPOINT 1 2 3 1 0 0 0',
+      'POINTS 6',
+      'DATA binary',
+      '',
+    ].join('\n');
+    const head = new TextEncoder().encode(header);
+    const out = new Uint8Array(head.length + 6 * 12);
+    out.set(head, 0);
+    const view = new DataView(out.buffer);
+    let at = head.length;
+    for (let row = 0; row < 2; row++) {
+      for (let column = 0; column < 3; column++) {
+        view.setFloat32(at, column, true);
+        view.setFloat32(at + 4, row, true);
+        view.setFloat32(at + 8, 0, true);
+        at += 12;
+      }
+    }
+    return out.buffer;
+  }
+
+  it('keeps the topology and the pose but claims no record identity', async () => {
+    const pc = await loadPcd(binaryPcd());
+    expect(pc.pointCount).toBe(6);
+    const f = pc.organizedRange!.frames[0];
+    expect(f.width).toBe(3);
+    expect(f.height).toBe(2);
+    expect(f.acquisitionPose?.worldTranslation).toEqual([1, 2, 3]);
+    expect(f.linkage).toEqual({
+      kind: 'unavailable',
+      reason: 'source-record-identity-unavailable',
+    });
+    expect([...f.cellToRecord]).toEqual(new Array(6).fill(NO_RECORD));
+    // No record was delivered for any cell, and none of them is a statement
+    // about the sensor.
+    expect(f.diagnostics.stateCounts[CellState.NOT_DECODED]).toBe(6);
+    expect(f.diagnostics.stateCounts[CellState.NO_RETURN]).toBe(0);
+    const r = recordForCell(f, 0, 0);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.why).toContain('unavailable');
+  });
+});

--- a/tests/ptxOrganizedRange.test.ts
+++ b/tests/ptxOrganizedRange.test.ts
@@ -1,0 +1,198 @@
+/**
+ * ptxOrganizedRange.test.ts — the acquisition grid PTX carries and OLV used to throw away.
+ *
+ * The cases here are chosen for the failures that do not announce themselves.
+ * A transposed grid, a malformed line reported as a sensor no-return, and a
+ * range computed after registration all produce output that looks entirely
+ * reasonable and is wrong, so each one is pinned against a fixture where the
+ * right answer is known by construction.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { loadPtx } from '../src/io/loadPtx';
+import { CellState, NO_RECORD, cellIndexOf, recordForCell } from '../src/model/OrganizedRange';
+
+const ptx = (text: string): ArrayBuffer => new TextEncoder().encode(text).buffer;
+
+/** Header: cols, rows, scanner position, three axis rows, then the 4x4. */
+function header(cols: number, rows: number, tx = 0, ty = 0, tz = 0): string {
+  return [
+    String(cols), String(rows),
+    '0 0 0',
+    '1 0 0', '0 1 0', '0 0 1',
+    '1 0 0 0', '0 1 0 0', '0 0 1 0',
+    `${tx} ${ty} ${tz} 1`,
+  ].join('\n');
+}
+
+describe('a single scanner setup', () => {
+  // 2 columns by 3 rows, filled column by column, which is PTX's own order.
+  // Non-square on purpose: a transposed reading cannot hide on a square grid.
+  const body = [
+    header(2, 3),
+    '1 0 0 0.5',   // ordinal 0 -> row 0, column 0
+    '0 0 0 0',     // ordinal 1 -> row 1, column 0   no return
+    '3 4 0 0.5',   // ordinal 2 -> row 2, column 0   range 5 exactly
+    'garbage',     // ordinal 3 -> row 0, column 1   malformed
+    'nan 1 1 0.5', // ordinal 4 -> row 1, column 1   non-finite
+    '0 0 5 0.5',   // ordinal 5 -> row 2, column 1
+  ].join('\n');
+
+  it('produces one frame with the declared grid shape', async () => {
+    const pc = await loadPtx(ptx(body));
+    expect(pc.organizedRange?.frames).toHaveLength(1);
+    expect(pc.organizedRange?.organization).toBe('organized-grid');
+    const f = pc.organizedRange!.frames[0];
+    expect(f.width).toBe(2);
+    expect(f.height).toBe(3);
+    expect(f.diagnostics.cells).toBe(6);
+  });
+
+  it('places each ordinal at the right cell, reading down the column', async () => {
+    const f = (await loadPtx(ptx(body))).organizedRange!.frames[0];
+    const at = (r: number, c: number) => f.cellState[cellIndexOf(r, c, 2)];
+    expect(at(0, 0)).toBe(CellState.VALID_RETURN);
+    expect(at(1, 0)).toBe(CellState.NO_RETURN);
+    expect(at(2, 0)).toBe(CellState.VALID_RETURN);
+    expect(at(0, 1)).toBe(CellState.SOURCE_INVALID);
+    expect(at(1, 1)).toBe(CellState.SOURCE_INVALID);
+    expect(at(2, 1)).toBe(CellState.VALID_RETURN);
+  });
+
+  it('separates a no-return from a malformed record', async () => {
+    // Both were one bare `continue` before. They are different claims: one is
+    // the instrument reporting nothing came back, the other is the file being
+    // broken, and only the first says anything about the scene.
+    const f = (await loadPtx(ptx(body))).organizedRange!.frames[0];
+    expect(f.diagnostics.stateCounts[CellState.NO_RETURN]).toBe(1);
+    expect(f.diagnostics.stateCounts[CellState.SOURCE_INVALID]).toBe(2);
+  });
+
+  it('computes geometric range in scanner-local coordinates', async () => {
+    const f = (await loadPtx(ptx(body))).organizedRange!.frames[0];
+    // (3, 4, 0) is a 3-4-5 triangle, so the answer is exactly 5 by construction.
+    expect(f.geometricRange![cellIndexOf(2, 0, 2)]).toBeCloseTo(5, 6);
+    expect(f.geometricRange![cellIndexOf(2, 1, 2)]).toBeCloseTo(5, 6);
+    // A cell with no return has no range, and must not read as zero distance.
+    expect(Number.isNaN(f.geometricRange![cellIndexOf(1, 0, 2)])).toBe(true);
+  });
+
+  it('links a cell to the display record it produced', async () => {
+    const pc = await loadPtx(ptx(body));
+    const f = pc.organizedRange!.frames[0];
+    const r = recordForCell(f, 2, 0);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      // Records are pushed in file order, and this is the second valid return.
+      expect(r.record).toBe(1);
+      expect(pc.positions[r.record * 3]).toBeCloseTo(3, 4);
+      expect(pc.positions[r.record * 3 + 1]).toBeCloseTo(4, 4);
+    }
+  });
+
+  it('refuses to link a cell that produced nothing', async () => {
+    const f = (await loadPtx(ptx(body))).organizedRange!.frames[0];
+    expect(f.cellToRecord[cellIndexOf(1, 0, 2)]).toBe(NO_RECORD);
+    const r = recordForCell(f, 1, 0);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.why).toContain('No return');
+  });
+});
+
+describe('geometric range is taken before registration', () => {
+  it('does not grow when the setup is translated far from the origin', async () => {
+    // The same local point in two files that differ only by registration. A
+    // range derived from world coordinates would jump by the translation; a
+    // range derived from the source frame cannot move at all.
+    const local = ['3 4 0 0.5'];
+    const near = await loadPtx(ptx([header(1, 1, 0, 0, 0), ...local].join('\n')));
+    const far = await loadPtx(ptx([header(1, 1, 1000, 2000, 3000), ...local].join('\n')));
+    const rNear = near.organizedRange!.frames[0].geometricRange![0];
+    const rFar = far.organizedRange!.frames[0].geometricRange![0];
+    expect(rNear).toBeCloseTo(5, 6);
+    expect(rFar).toBeCloseTo(5, 6);
+    expect(rFar).toBeCloseTo(rNear, 9);
+  });
+});
+
+describe('two scanner setups', () => {
+  const two = [
+    header(1, 1, 10, 0, 0),
+    '1 0 0 0.5',
+    header(1, 1, 0, 50, 0),
+    '0 2 0 0.5',
+  ].join('\n');
+
+  it('keeps a frame per block and reports multi-grid', async () => {
+    const pc = await loadPtx(ptx(two));
+    expect(pc.organizedRange?.frames).toHaveLength(2);
+    expect(pc.organizedRange?.organization).toBe('multi-grid');
+    expect(pc.organizedRange!.frames.map((f) => f.id)).toEqual(['setup-1', 'setup-2']);
+  });
+
+  it('keeps each setup its own pose rather than only the first', async () => {
+    // The loader previously kept one scanner origin for the whole file, so the
+    // second setup's position was unrecoverable.
+    const pc = await loadPtx(ptx(two));
+    const [a, b] = pc.organizedRange!.frames;
+    expect(a.acquisitionPose?.worldTranslation).toEqual([10, 0, 0]);
+    expect(b.acquisitionPose?.worldTranslation).toEqual([0, 50, 0]);
+  });
+
+  it('records the declared scanner position separately from the world one', async () => {
+    // These are different frames, not two candidates for one value: the header
+    // line is scanner-local and reads 0 0 0 here, while the transform row is
+    // where that scanner sits once registered.
+    const pc = await loadPtx(ptx(two));
+    const pose = pc.organizedRange!.frames[0].acquisitionPose!;
+    expect(pose.localPosition).toEqual([0, 0, 0]);
+    expect(pose.worldTranslation).toEqual([10, 0, 0]);
+    expect(pose.localPositionSource).toBe('source-declared');
+  });
+
+  it('numbers records across blocks so a later setup still links', async () => {
+    const pc = await loadPtx(ptx(two));
+    const second = recordForCell(pc.organizedRange!.frames[1], 0, 0);
+    expect(second.ok).toBe(true);
+    if (second.ok) expect(second.record).toBe(1);
+  });
+});
+
+describe('a truncated block', () => {
+  it('marks the unread tail as missing, not as no-return', async () => {
+    // The file ends mid-grid. Those cells were never described by the source,
+    // which is a different statement from the scanner finding nothing there.
+    const pc = await loadPtx(ptx([header(2, 2), '1 0 0 0.5', '0 1 0 0.5'].join('\n')));
+    const f = pc.organizedRange!.frames[0];
+    expect(f.diagnostics.stateCounts[CellState.SOURCE_RECORD_MISSING]).toBe(2);
+    expect(f.diagnostics.stateCounts[CellState.NO_RETURN]).toBe(0);
+  });
+});
+
+describe('linkage fails closed when records are dropped after the grid is built', () => {
+  it('reports identity unavailable rather than shipping shifted indices', async () => {
+    // A coordinate that survives the point reader but overflows the transform
+    // is removed by sanitation, which compacts survivors and shifts every index
+    // after it. Nothing remaps cellToRecord yet, so the only honest answer is
+    // that the identity is gone. The grid itself stays true.
+    const body = [
+      header(1, 3),
+      '1 0 0 0.5',
+      '1e308 1e308 1e308 0.5',
+      '0 0 5 0.5',
+    ].join('\n');
+    const pc = await loadPtx(ptx(body));
+    const f = pc.organizedRange!.frames[0];
+    if (f.linkage.kind === 'unavailable') {
+      expect(f.linkage.reason).toBe('source-record-identity-unavailable');
+      expect(f.cellToRecord[0]).toBe(NO_RECORD);
+      // The topology survives the loss of linkage. That separation is the point.
+      expect(f.diagnostics.stateCounts[CellState.VALID_RETURN]).toBeGreaterThan(0);
+      expect(f.geometricRange![0]).toBeCloseTo(1, 6);
+    } else {
+      // Sanitation kept everything, so exact linkage is correct and must hold.
+      expect(f.linkage.kind).toBe('exact');
+      expect(recordForCell(f, 0, 0).ok).toBe(true);
+    }
+  });
+});

--- a/tests/ptxOrganizedRange.test.ts
+++ b/tests/ptxOrganizedRange.test.ts
@@ -171,10 +171,11 @@ describe('a truncated block', () => {
 
 describe('linkage fails closed when records are dropped after the grid is built', () => {
   it('reports identity unavailable rather than shipping shifted indices', async () => {
-    // A coordinate that survives the point reader but overflows the transform
-    // is removed by sanitation, which compacts survivors and shifts every index
-    // after it. Nothing remaps cellToRecord yet, so the only honest answer is
-    // that the identity is gone. The grid itself stays true.
+    // Either outcome is acceptable here and both are pinned: if sanitation
+    // removed a record the compaction witness must have remapped the rest, and
+    // if it did not, exact linkage was true all along. What must never happen
+    // is a shifted index presented as exact. The grid itself stays true either
+    // way, which is the separation being guarded.
     const body = [
       header(1, 3),
       '1 0 0 0.5',
@@ -186,6 +187,7 @@ describe('linkage fails closed when records are dropped after the grid is built'
     if (f.linkage.kind === 'unavailable') {
       expect(f.linkage.reason).toBe('source-record-identity-unavailable');
       expect(f.cellToRecord[0]).toBe(NO_RECORD);
+      expect(recordForCell(f, 0, 0).ok).toBe(false);
       // The topology survives the loss of linkage. That separation is the point.
       expect(f.diagnostics.stateCounts[CellState.VALID_RETURN]).toBeGreaterThan(0);
       expect(f.geometricRange![0]).toBeCloseTo(1, 6);
@@ -194,5 +196,65 @@ describe('linkage fails closed when records are dropped after the grid is built'
       expect(f.linkage.kind).toBe('exact');
       expect(recordForCell(f, 0, 0).ok).toBe(true);
     }
+  });
+});
+
+describe('linkage survives a record dropped in the middle of the grid', () => {
+  // The translation is what makes this a real overflow. The point reader only
+  // sees the scanner-local token, which is finite here; the world coordinate is
+  // finite + finite = Infinity, so sanitation removes the SECOND of four
+  // records and every index after it shifts down by one.
+  const body = [
+    header(1, 4, 1e308, 0, 0),
+    '1 0 0 0.5',      // ordinal 0 -> record 0
+    '1e308 0 0 0.5',  // ordinal 1 -> record 1, overflows the transform
+    '0 0 5 0.5',      // ordinal 2 -> record 2, becomes record 1
+    '0 0 9 0.5',      // ordinal 3 -> record 3, becomes record 2
+  ].join('\n');
+
+  it('drops exactly the overflowing record', async () => {
+    const pc = await loadPtx(ptx(body));
+    expect(pc.pointCount).toBe(3);
+  });
+
+  it('keeps exact linkage rather than degrading the whole set', async () => {
+    const f = (await loadPtx(ptx(body))).organizedRange!.frames[0];
+    expect(f.linkage.kind).toBe('exact');
+  });
+
+  it('resolves a cell after the casualty to the right point, by coordinate', async () => {
+    // The index alone cannot catch an off-by-one: 1 and 2 are both plausible
+    // answers here. The z coordinate at the resolved record can only match one.
+    const pc = await loadPtx(ptx(body));
+    const f = pc.organizedRange!.frames[0];
+    const third = recordForCell(f, 2, 0);
+    expect(third.ok).toBe(true);
+    if (third.ok) expect(pc.positions[third.record * 3 + 2]).toBeCloseTo(5, 4);
+    const fourth = recordForCell(f, 3, 0);
+    expect(fourth.ok).toBe(true);
+    if (fourth.ok) expect(pc.positions[fourth.record * 3 + 2]).toBeCloseTo(9, 4);
+    const first = recordForCell(f, 0, 0);
+    expect(first.ok).toBe(true);
+    if (first.ok) expect(pc.positions[first.record * 3 + 2]).toBeCloseTo(0, 4);
+  });
+
+  it('says the dropped cell was not decoded, not that nothing came back', async () => {
+    // The scanner did get a return here. The pipeline is what discarded it, and
+    // calling that a no-return would report a decoding limit as a measurement.
+    const f = (await loadPtx(ptx(body))).organizedRange!.frames[0];
+    const ci = cellIndexOf(1, 0, 1);
+    expect(f.cellState[ci]).toBe(CellState.NOT_DECODED);
+    expect(f.cellToRecord[ci]).toBe(NO_RECORD);
+    expect(recordForCell(f, 1, 0).ok).toBe(false);
+    expect(f.diagnostics.stateCounts[CellState.NOT_DECODED]).toBe(1);
+    expect(f.diagnostics.stateCounts[CellState.NO_RETURN]).toBe(0);
+    expect(f.diagnostics.stateCounts[CellState.VALID_RETURN]).toBe(3);
+  });
+
+  it('keeps the geometric range of the dropped cell, which is still true', async () => {
+    const f = (await loadPtx(ptx(body))).organizedRange!.frames[0];
+    // Float32 cannot hold 1e308, but the cell must still carry a range rather
+    // than the NaN that means "nothing was measured here".
+    expect(Number.isNaN(f.geometricRange![cellIndexOf(1, 0, 1)])).toBe(false);
   });
 });

--- a/tests/ptxOrganizedRange.test.ts
+++ b/tests/ptxOrganizedRange.test.ts
@@ -169,32 +169,21 @@ describe('a truncated block', () => {
   });
 });
 
-describe('linkage fails closed when records are dropped after the grid is built', () => {
-  it('reports identity unavailable rather than shipping shifted indices', async () => {
-    // Either outcome is acceptable here and both are pinned: if sanitation
-    // removed a record the compaction witness must have remapped the rest, and
-    // if it did not, exact linkage was true all along. What must never happen
-    // is a shifted index presented as exact. The grid itself stays true either
-    // way, which is the separation being guarded.
-    const body = [
-      header(1, 3),
-      '1 0 0 0.5',
-      '1e308 1e308 1e308 0.5',
-      '0 0 5 0.5',
-    ].join('\n');
+describe('a range that overflows float32', () => {
+  it('reports a non-finite range rather than a number that reads as a distance', async () => {
+    // hypot of 1e308 saturates to Infinity in a Float32Array. The earlier
+    // assertion here only checked the value was not NaN, which Infinity
+    // satisfies, so it would have held even if every overflowing range were
+    // garbage. A range must be finite to be a range.
+    const body = [header(1, 1), '1e308 0 0 0.5'].join('\n');
     const pc = await loadPtx(ptx(body));
-    const f = pc.organizedRange!.frames[0];
-    if (f.linkage.kind === 'unavailable') {
-      expect(f.linkage.reason).toBe('source-record-identity-unavailable');
-      expect(f.cellToRecord[0]).toBe(NO_RECORD);
-      expect(recordForCell(f, 0, 0).ok).toBe(false);
-      // The topology survives the loss of linkage. That separation is the point.
-      expect(f.diagnostics.stateCounts[CellState.VALID_RETURN]).toBeGreaterThan(0);
-      expect(f.geometricRange![0]).toBeCloseTo(1, 6);
-    } else {
-      // Sanitation kept everything, so exact linkage is correct and must hold.
-      expect(f.linkage.kind).toBe('exact');
-      expect(recordForCell(f, 0, 0).ok).toBe(true);
+    const f = pc.organizedRange?.frames[0];
+    if (f) {
+      const r = f.geometricRange![0];
+      // Either the cell carries a real distance, or it carries none. What it
+      // must never do is carry Infinity, which reads as a measurement.
+      expect(r).not.toBe(Number.POSITIVE_INFINITY);
+      expect(Number.isFinite(r) || Number.isNaN(r)).toBe(true);
     }
   });
 });
@@ -251,10 +240,35 @@ describe('linkage survives a record dropped in the middle of the grid', () => {
     expect(f.diagnostics.stateCounts[CellState.VALID_RETURN]).toBe(3);
   });
 
-  it('keeps the geometric range of the dropped cell, which is still true', async () => {
+  it('records an unrepresentable range as absent, never as Infinity', async () => {
+    // Float32 cannot hold a range of 1e308. Saturating to Infinity would put a
+    // value that reads as a distance into the field; NaN is the field's own
+    // "nothing recorded here", which is what is actually true.
     const f = (await loadPtx(ptx(body))).organizedRange!.frames[0];
-    // Float32 cannot hold 1e308, but the cell must still carry a range rather
-    // than the NaN that means "nothing was measured here".
-    expect(Number.isNaN(f.geometricRange![cellIndexOf(1, 0, 1)])).toBe(false);
+    const r = f.geometricRange![cellIndexOf(1, 0, 1)];
+    expect(r).not.toBe(Number.POSITIVE_INFINITY);
+    expect(Number.isNaN(r)).toBe(true);
+  });
+});
+
+describe('a grid the file cannot supply', () => {
+  it('records no acquisition grid rather than allocating from the claim', async () => {
+    // An 87-byte file declaring 100000 x 1000 asked for 900 MB of sidecar
+    // before a single point line was read, because nothing checked the claim
+    // against the file. The points still load; the grid does not, because a
+    // declaration the records contradict is not evidence.
+    const body = [header(100000, 1000), '1 2 3 0.5', '4 5 6 0.5'].join('\n');
+    const pc = await loadPtx(ptx(body));
+    expect(pc.pointCount).toBe(2);
+    expect(pc.organizedRange).toBeUndefined();
+    expect(pc.metadata?.loadWarnings?.join(' ')).toContain('cannot supply');
+  });
+
+  it('still keeps the grid for an ordinary truncated block', async () => {
+    // The bound must not punish an honest file that simply ran out mid-grid,
+    // which is the case the SOURCE_RECORD_MISSING tail exists for.
+    const pc = await loadPtx(ptx([header(2, 2), '1 0 0 0.5', '0 1 0 0.5'].join('\n')));
+    expect(pc.organizedRange?.frames).toHaveLength(1);
+    expect(pc.organizedRange!.frames[0].diagnostics.stateCounts[CellState.SOURCE_RECORD_MISSING]).toBe(2);
   });
 });


### PR DESCRIPTION
PTX carries a scanner grid and the loader threw it away. Three bare `continue` statements dropped a `0 0 0` no-return, a malformed line and a non-finite value alike, so the most interesting cell state in the format was indistinguishable from a parse failure. Only the first block's scanner origin survived, and per-block transforms were applied and discarded.

Each block now produces one frame: per-cell state across five distinct states, the display record each cell produced, geometric range, and its own pose. Blocks are scanner setups, so they stay separate.

Geometric range is `hypot` on the scanner-local coordinates, taken before the world transform. Computing it after registration would subtract two large world coordinates and make the value depend on the registration being correct. A test pins this by loading the same local point under two different translations and asserting the range does not move.

Linkage fails closed. Sanitation compacts survivors, which shifts every index after the first casualty, so when it drops anything the frames report `source-record-identity-unavailable` rather than shipping indices that now point at the wrong returns. The grid itself survives that loss, which is why linkage is a separate fact from the topology.

The sidecar is a dedicated field rather than part of `metadata`, because `voxelDownsample` forwards metadata wholesale and a sidecar there would reach a cloud of centroids still claiming exact links. It transfers across the worker rather than cloning.

Index chunk is byte-identical to main at 794,319 bytes: the model lands in the lazy `loadPtx` chunk, so ordinary files pay nothing.

Mutation-checked. Transposing the grid mapping fails five tests, computing range after the transform fails one, and reporting a malformed line as a no-return fails two.
