### PR TITLE
Represent several returns in one acquisition cell

### DIFF
--- a/src/model/OrganizedRange.ts
+++ b/src/model/OrganizedRange.ts
@@ -174,6 +174,25 @@ export interface OrganizedRangeFrame {
   readonly cellState: Uint8Array;
   /** Length `width * height`. Display record index, or `NO_RECORD`. */
   readonly cellToRecord: Int32Array;
+  /**
+   * Multi-return description, as four parallel arrays in CSR form.
+   *
+   * Present TOGETHER or not at all. Their absence is not "this frame has no
+   * returns"; it means this frame never described returns per cell, which is
+   * the ordinary case for PTX and PCD, where a cell holds at most one. A
+   * single-return frame therefore allocates nothing here and every existing
+   * accessor keeps its cost.
+   */
+  /** Length `width * height + 1`. Returns of cell `c` live in `[s[c], s[c+1])`. */
+  readonly returnCellStart?: Uint32Array;
+  /** Length `returnCellStart[cells]`, in cell order. Record index, or `NO_RECORD`. */
+  readonly returnRecord?: Int32Array;
+  /** Length as `returnRecord`. The source's own `returnIndex` for each return. */
+  readonly returnIndex?: Uint16Array;
+  /** Length as `returnRecord`. The `returnCount` the source declared for the pulse. */
+  readonly returnCountDeclared?: Uint16Array;
+  /** Returns the build was handed that addressed no cell of this grid. */
+  readonly returnsSkipped?: number;
   /** Length `width * height`. Range in acquisition-local coordinates, NaN where absent. */
   readonly geometricRange?: Float32Array;
   /** Length `width * height`. Range the source itself declared, NaN where absent. */
@@ -304,6 +323,10 @@ export function withLinkageUnavailable(
     frames: set.frames.map((f) => ({
       ...f,
       cellToRecord: new Int32Array(f.cellToRecord.length).fill(NO_RECORD),
+      // The per-return indices are exactly the same defect one level down, so
+      // they are erased on the same terms. The offsets, the return indices and
+      // the declared counts survive: they are topology, not identity.
+      ...(f.returnRecord ? { returnRecord: new Int32Array(f.returnRecord.length).fill(NO_RECORD) } : {}),
       linkage: { kind: 'unavailable', reason } as const,
     })),
   };
@@ -330,4 +353,176 @@ export function organizedRangeTransferables(set: OrganizedRangeSet): ArrayBuffer
     }
   }
   return out;
+}
+
+/** One return of one pulse, as the source described it. */
+export interface CellReturn {
+  /** Display record index, or `NO_RECORD` when identity was never established. */
+  readonly record: number;
+  /** Which return of the pulse this is, as the source declared it. */
+  readonly returnIndex: number;
+  /** How many returns the source declared for that pulse. */
+  readonly returnCount: number;
+}
+
+/** One return on its way in, addressed by grid cell. */
+export interface CellReturnInput extends CellReturn {
+  readonly row: number;
+  readonly column: number;
+}
+
+/** The arrays a frame carries, plus what the build could not place. */
+export interface BuiltCellReturns {
+  readonly returnCellStart: Uint32Array;
+  readonly returnRecord: Int32Array;
+  readonly returnIndex: Uint16Array;
+  readonly returnCountDeclared: Uint16Array;
+  readonly skippedCount: number;
+}
+
+/**
+ * Build the CSR return description for a grid.
+ *
+ * The shape here is deliberately the same as the profile hit-test's spatial
+ * index build — a per-cell count pass, an exclusive prefix sum into a
+ * `cellStart` array carrying a terminator entry, a placement cursor copied from
+ * it, payloads stored in cell order, and an explicit count of the items that
+ * fell outside — so a reader who knows one recognises the other. It is
+ * reimplemented rather than imported because `src/model` must not depend on
+ * `src/render`.
+ *
+ * The alternative, a dense `width * height * maxReturns` array, is mostly empty
+ * whenever returns are sparse, which is the normal case.
+ *
+ * ORDERING: returns are NOT assumed to arrive in `returnIndex` order, and they
+ * are sorted ascending by `returnIndex` within each cell. That is a real
+ * reordering and it is stated because it is one: `returnIndex` is a physical
+ * fact about the pulse, so it travels with its own record and count rather than
+ * being inferred from a position. Ties keep source order, and the placement
+ * pass is stable, so equal indices are not shuffled.
+ */
+export function buildCellReturns(
+  width: number,
+  height: number,
+  entries: readonly CellReturnInput[],
+): BuiltCellReturns {
+  const cellCount = width * height;
+  const counts = new Uint32Array(cellCount);
+  const cellOf = new Int32Array(entries.length).fill(-1);
+  let live = 0;
+  for (let k = 0; k < entries.length; k++) {
+    const e = entries[k]!;
+    if (e.row < 0 || e.column < 0 || e.row >= height || e.column >= width) continue;
+    const cell = cellIndexOf(e.row, e.column, width);
+    cellOf[k] = cell;
+    counts[cell]!++;
+    live++;
+  }
+
+  // Terminator entry: `cellStart[cellCount]` is the total, so the LAST cell has
+  // an end offset like every other. Without it the last span is unreadable.
+  const returnCellStart = new Uint32Array(cellCount + 1);
+  let running = 0;
+  for (let c = 0; c < cellCount; c++) {
+    running += counts[c]!;
+    returnCellStart[c + 1] = running;
+  }
+
+  const cursor = new Uint32Array(cellCount);
+  cursor.set(returnCellStart.subarray(0, cellCount));
+
+  const returnRecord = new Int32Array(live);
+  const returnIndex = new Uint16Array(live);
+  const returnCountDeclared = new Uint16Array(live);
+  for (let k = 0; k < entries.length; k++) {
+    const cell = cellOf[k]!;
+    if (cell < 0) continue;
+    const e = entries[k]!;
+    const at = cursor[cell]!++;
+    returnRecord[at] = e.record;
+    returnIndex[at] = e.returnIndex;
+    returnCountDeclared[at] = e.returnCount;
+  }
+
+  // Stable insertion sort inside each span. Spans are a handful of returns, and
+  // stability is what keeps two returns declaring the same index in the order
+  // the source wrote them.
+  for (let c = 0; c < cellCount; c++) {
+    const start = returnCellStart[c]!;
+    const end = returnCellStart[c + 1]!;
+    for (let i = start + 1; i < end; i++) {
+      const ri = returnIndex[i]!;
+      const rec = returnRecord[i]!;
+      const rc = returnCountDeclared[i]!;
+      let j = i - 1;
+      while (j >= start && returnIndex[j]! > ri) {
+        returnIndex[j + 1] = returnIndex[j]!;
+        returnRecord[j + 1] = returnRecord[j]!;
+        returnCountDeclared[j + 1] = returnCountDeclared[j]!;
+        j--;
+      }
+      returnIndex[j + 1] = ri;
+      returnRecord[j + 1] = rec;
+      returnCountDeclared[j + 1] = rc;
+    }
+  }
+
+  return {
+    returnCellStart,
+    returnRecord,
+    returnIndex,
+    returnCountDeclared,
+    skippedCount: entries.length - live,
+  };
+}
+
+/**
+ * Resolve every return of a cell.
+ *
+ * Zero, one and many are all `ok: true`: a described cell that produced nothing
+ * answers with an empty list, which is evidence about the scene. A frame that
+ * never described returns at all answers `ok: false` with `not-described`,
+ * because that says nothing about the scene and must not be readable as "none".
+ */
+export function returnsForCell(
+  frame: OrganizedRangeFrame,
+  row: number,
+  column: number,
+):
+  | { readonly ok: true; readonly returns: readonly CellReturn[] }
+  | {
+      readonly ok: false;
+      readonly why: string;
+      readonly reason: 'linkage-unavailable' | 'outside-grid' | 'not-described';
+    } {
+  if (frame.linkage.kind === 'unavailable') {
+    return {
+      ok: false,
+      reason: 'linkage-unavailable',
+      why: `Exact linking unavailable: ${frame.linkage.reason}.`,
+    };
+  }
+  if (row < 0 || column < 0 || row >= frame.height || column >= frame.width) {
+    return { ok: false, reason: 'outside-grid', why: 'Cell is outside the acquisition grid.' };
+  }
+  const { returnCellStart, returnRecord, returnIndex, returnCountDeclared } = frame;
+  if (!returnCellStart || !returnRecord || !returnIndex || !returnCountDeclared) {
+    return {
+      ok: false,
+      reason: 'not-described',
+      why: 'This frame does not describe returns per cell.',
+    };
+  }
+  const cell = cellIndexOf(row, column, frame.width);
+  const start = returnCellStart[cell]!;
+  const end = returnCellStart[cell + 1]!;
+  const out: CellReturn[] = [];
+  for (let i = start; i < end; i++) {
+    out.push({
+      record: returnRecord[i]!,
+      returnIndex: returnIndex[i]!,
+      returnCount: returnCountDeclared[i]!,
+    });
+  }
+  return { ok: true, returns: out };
 }

--- a/tests/organizedRange.test.ts
+++ b/tests/organizedRange.test.ts
@@ -17,6 +17,8 @@ import {
   tallyCellStates,
   recordForCell,
   withLinkageUnavailable,
+  buildCellReturns,
+  returnsForCell,
   type OrganizedRangeFrame,
   type OrganizedRangeSet,
 } from '../src/model/OrganizedRange';
@@ -175,5 +177,164 @@ describe('worker transferables', () => {
     // This is the regression the hand-written list could not have caught: the
     // new array crosses by transfer rather than by a silent clone.
     expect(organizedRangeTransferables(set)).toHaveLength(3);
+  });
+});
+
+/**
+ * Multiple returns per cell.
+ *
+ * E57 lets one (row, column) carry several returns of the same pulse. The
+ * fixtures below are built so that the two classic prefix-sum defects cannot
+ * hide: the LAST cell of the grid is populated (an offsets array one entry
+ * short, or a sum shifted by one, resolves it wrongly or throws), and the
+ * returns of one cell arrive out of `returnIndex` order.
+ */
+describe('multiple returns per cell', () => {
+  /**
+   * A 3 by 2 grid. Cell (0,0) holds one return, cell (0,1) holds none, cell
+   * (1,2) — the LAST cell — holds three, and they are supplied 2, 0, 1 so a
+   * build that trusts arrival order is visible.
+   */
+  function multiReturnFixture(): OrganizedRangeFrame {
+    const width = 3;
+    const height = 2;
+    const cellState = new Uint8Array(width * height).fill(CellState.NO_RETURN);
+    cellState[cellIndexOf(0, 0, width)] = CellState.VALID_RETURN;
+    cellState[cellIndexOf(1, 2, width)] = CellState.VALID_RETURN;
+    const built = buildCellReturns(width, height, [
+      { row: 0, column: 0, record: 10, returnIndex: 0, returnCount: 1 },
+      { row: 1, column: 2, record: 22, returnIndex: 2, returnCount: 3 },
+      { row: 1, column: 2, record: 20, returnIndex: 0, returnCount: 3 },
+      { row: 1, column: 2, record: 21, returnIndex: 1, returnCount: 3 },
+    ]);
+    return {
+      id: 'setup-e57',
+      sourceKind: 'e57-structured',
+      width,
+      height,
+      cellState,
+      cellToRecord: new Int32Array(width * height).fill(NO_RECORD),
+      linkage: { kind: 'exact' },
+      diagnostics: tallyCellStates(cellState),
+      returnCellStart: built.returnCellStart,
+      returnRecord: built.returnRecord,
+      returnIndex: built.returnIndex,
+      returnCountDeclared: built.returnCountDeclared,
+      returnsSkipped: built.skippedCount,
+    };
+  }
+
+  it('describes a cell that produced exactly one return', () => {
+    const r = returnsForCell(multiReturnFixture(), 0, 0);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.returns).toEqual([{ record: 10, returnIndex: 0, returnCount: 1 }]);
+  });
+
+  it('reports zero returns as an empty list, not as a missing description', () => {
+    // A described cell that got nothing back is evidence about the scene. It
+    // must not read the same as a frame that never described its returns.
+    const r = returnsForCell(multiReturnFixture(), 0, 1);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.returns).toEqual([]);
+  });
+
+  it('separates "no returns" from "this frame never described returns"', () => {
+    const single = frameFixture();
+    const r = returnsForCell(single, 0, 1);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('not-described');
+  });
+
+  it('resolves the three returns of the LAST cell in the grid', () => {
+    // The off-by-one case. Reading only a middle cell passes with a prefix sum
+    // shifted by one and with a missing terminator entry alike.
+    const r = returnsForCell(multiReturnFixture(), 1, 2);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.returns).toEqual([
+        { record: 20, returnIndex: 0, returnCount: 3 },
+        { record: 21, returnIndex: 1, returnCount: 3 },
+        { record: 22, returnIndex: 2, returnCount: 3 },
+      ]);
+    }
+  });
+
+  it('carries the CSR terminator, so the last cell has an end offset', () => {
+    const f = multiReturnFixture();
+    expect(f.returnCellStart).toBeDefined();
+    expect(f.returnCellStart!.length).toBe(f.width * f.height + 1);
+    expect(f.returnCellStart![f.width * f.height]).toBe(4);
+    // The first cell starts at zero: the prefix sum is exclusive, and a sum
+    // shifted by one puts a non-zero value here.
+    expect(f.returnCellStart![0]).toBe(0);
+    expect(f.returnCellStart![1]).toBe(1);
+  });
+
+  it('orders each cell by returnIndex and moves the payload with it', () => {
+    // Returns arrived 2, 0, 1. The sort is ascending by returnIndex, and the
+    // record must travel with its own index rather than staying put.
+    const f = multiReturnFixture();
+    const start = f.returnCellStart![cellIndexOf(1, 2, 3)];
+    expect([...f.returnIndex!.slice(start, start + 3)]).toEqual([0, 1, 2]);
+    expect([...f.returnRecord!.slice(start, start + 3)]).toEqual([20, 21, 22]);
+  });
+
+  it('counts returns that fell outside the grid rather than placing them', () => {
+    const built = buildCellReturns(3, 2, [
+      { row: 0, column: 0, record: 1, returnIndex: 0, returnCount: 1 },
+      { row: 9, column: 0, record: 2, returnIndex: 0, returnCount: 1 },
+      { row: 0, column: -1, record: 3, returnIndex: 0, returnCount: 1 },
+    ]);
+    expect(built.skippedCount).toBe(2);
+    expect(built.returnRecord.length).toBe(1);
+    expect(built.returnCellStart[6]).toBe(1);
+  });
+
+  it('refuses every cell when linkage is unavailable', () => {
+    const f: OrganizedRangeFrame = {
+      ...multiReturnFixture(),
+      linkage: { kind: 'unavailable', reason: 'voxel-centroids' },
+    };
+    const r = returnsForCell(f, 1, 2);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('linkage-unavailable');
+  });
+
+  it('erases the per-return record indices on degrade, keeping the topology', () => {
+    // Same defect as cellToRecord: a stale index surviving a voxel reduction
+    // would claim a centroid IS a source return.
+    const set: OrganizedRangeSet = {
+      kind: 'organized-range',
+      frames: [multiReturnFixture()],
+      organization: 'organized-grid',
+    };
+    const out = withLinkageUnavailable(set, 'voxel-centroids');
+    expect([...out.frames[0].returnRecord!]).toEqual(new Array(4).fill(NO_RECORD));
+    // The grid of what was interrogated survives; only identity is spent.
+    expect([...out.frames[0].returnCellStart!]).toEqual([...set.frames[0].returnCellStart!]);
+    expect([...out.frames[0].returnIndex!]).toEqual([...set.frames[0].returnIndex!]);
+    expect(set.frames[0].returnRecord![0]).toBe(10);
+  });
+
+  it('leaves a single-return frame alone on degrade', () => {
+    const set: OrganizedRangeSet = {
+      kind: 'organized-range',
+      frames: [frameFixture()],
+      organization: 'organized-grid',
+    };
+    const out = withLinkageUnavailable(set, 'voxel-centroids');
+    expect(out.frames[0].returnRecord).toBeUndefined();
+  });
+
+  it('transfers the new arrays instead of cloning them', async () => {
+    const { organizedRangeTransferables } = await import('../src/model/OrganizedRange');
+    const set: OrganizedRangeSet = {
+      kind: 'organized-range',
+      frames: [multiReturnFixture()],
+      organization: 'organized-grid',
+    };
+    // cellState, cellToRecord, returnCellStart, returnRecord, returnIndex,
+    // returnCountDeclared. Counted, not listed, for the same reason as above.
+    expect(organizedRangeTransferables(set)).toHaveLength(6);
   });
 });


### PR DESCRIPTION
A PTX or PCD grid cell holds at most one return. An E57 cell can hold several, distinguished by `returnIndex` with a declared `returnCount`, and the model had no way to say so.

Four optional flat arrays per frame carry them in CSR form: a `cellCount + 1` offset array with the terminator, then record, return index and declared count in cell order, plus a count of returns that fell outside the grid. A frame that does not need them leaves all four undefined and allocates nothing, and `recordForCell` is unchanged for every existing caller.

Flat rather than nested, deliberately. `organizedRangeTransferables` scans a frame's own values one level deep, so a nested group would have crossed the worker boundary by structured clone: correct, silent, and at the copying cost that helper exists to avoid.

Returns are sorted by `returnIndex` within each cell, stably, because the source is not required to emit them in order and the index is a physical fact rather than a position.

No loader produces these yet. Mutation-checked: dropping the terminator and shifting the prefix sum each fail four tests, including the last-cell case that a middle-cell test cannot catch.
