### PR TITLE
Open a single PNTS tile instead of describing one

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ OpenLiDARViewer does not claim survey-grade measurement or support for every LiD
 
 - COPC streaming: a `.copc.laz` file, on disk or hosted at a URL, opens through progressive, octree-based, view-dependent streaming with worker-based decoding and bounded memory, never a full-file load. A remote scan opens from the start screen's open-from-URL field or a shareable `?copc=<url>` deep link
 - EPT (Entwine Point Tile) streaming: local and remote, `binary` and `laszip` tiles
-- 3D Tiles / `.pnts` (not yet user-facing): a `.pnts` file or a `tileset.json` URL is detected by filename and reported as not-yet-supported rather than opened. v0.6.6 adds `tileset.json` and uncompressed PNTS parsing, but nothing mounts a 3D Tiles set as a streaming layer yet, so treat runtime loading as planned, not shipped
+- 3D Tiles / `.pnts`: a single `.pnts` tile opens as a point cloud — detected by its magic bytes, decoded from uncompressed or quantised positions with colour, and placed by its `RTC_CENTER`. A `tileset.json` is detected by name and reported as not-yet-supported: the tileset document parses and traverses, but nothing mounts a 3D Tiles set as a streaming layer yet, so treat tileset streaming as planned, not shipped
 - A curated catalog of 12 hand-vetted public COPC / EPT datasets
 
 See [`docs/streaming.md`](docs/streaming.md) and [`docs/copc.md`](docs/copc.md).

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -17,6 +17,7 @@ Format support is still evolving. This page separates what works today from what
 | `PCD` | Point Cloud Library | ASCII, binary, and binary-compressed; position, RGB, intensity, normals, labels |
 | `PTX` | Terrestrial laser scanners | Multi-scan text; per-scan pose applied; scanner origin recorded |
 | `PTS` | Terrestrial laser scanners | Whitespace-delimited text; optional header count; 3/4/6/7-column layouts; chunked reading |
+| `PNTS` | 3D Tiles point tile | A single tile; magic-byte detected; `RTC_CENTER` applied; Draco refused |
 | `COPC` | Cloud-optimised LiDAR | `.copc.laz`; opened by progressive octree streaming — see [streaming.md](streaming.md) |
 | `EPT` | Entwine Point Tile | `ept.json` manifest + hierarchy + tiles; binary and laszip tile decode; local and remote — see [streaming.md](streaming.md) |
 
@@ -50,7 +51,9 @@ Georeferenced drone LiDAR surveys in `LAS` and `LAZ` work today, including large
 
 `EPT` (Entwine Point Tile) joins COPC as a first-class streaming source in v0.3.3 — a `ept.json` URL opens an EPT dataset progressively. Both `binary` and `laszip` tile dataTypes are supported; the laz-perf WASM module is shared with the COPC path so a session that touches both formats pays the WASM cost only once. Remote EPT carries the same URL-validation + error-classification polish as remote COPC. See [streaming.md](streaming.md).
 
-`3D Tiles` / `PNTS` (tiled, streamable point clouds): detected but not supported. The loader recognises a `.pnts` file or a `tileset.json` URL by name and returns an honest "on the roadmap, not shipped" message rather than opening it; there is no tileset parser today. Treat the format as planned, not shipped, until the user-facing path is announced in the release notes.
+`3D Tiles` / `PNTS`: a single `.pnts` tile opens today. It is detected by its `pnts` magic bytes (so a tile saved under another name still opens, and a file that only borrows the extension is refused rather than read as a tile), decoded through the viewer's PNTS reader — uncompressed `POSITION` and `POSITION_QUANTIZED`, RGBA/RGB/RGB565/CONSTANT_RGBA colour — and placed by adding the feature table's `RTC_CENTER` back to every position. Draco-compressed tiles are refused.
+
+A whole `tileset.json` does not open yet. The tileset document is parsed and its hierarchy can be traversed (`src/io/tiles3d/`), but nothing mounts a tileset as a streaming layer, so opening one returns an honest "on the roadmap, not shipped" message. Treat tileset streaming as planned, not shipped, until it is announced in the release notes.
 
 ## Mobile Scan Exports
 

--- a/src/io/formatInfo.ts
+++ b/src/io/formatInfo.ts
@@ -44,6 +44,10 @@ const FORMAT_INFO: Record<SourceFormat, FormatInfo> = {
   // is decoded whole rather than through the chunked line reader.
   ptx: { label: 'PTX scan', isText: false, hasHeaderCount: false },
   pts: { label: 'PTS scan', isText: true, hasHeaderCount: false },
+  // A PNTS tile states POINTS_LENGTH in its feature table, but that JSON sits
+  // behind a header whose section lengths have to be read first, which is more
+  // than the head-slice preflight does — so no header count is claimed here.
+  pnts: { label: '3D Tiles PNTS tile', isText: false, hasHeaderCount: false },
 };
 
 /** The facts for a format. Throws on an unregistered format. */

--- a/src/io/loadFile.ts
+++ b/src/io/loadFile.ts
@@ -247,9 +247,9 @@ async function preflightFile(
     if (is3dTilesName(file.name)) {
       throw new LoadError(
         'unsupported-format',
-        `3D Tiles / PNTS isn't openable yet — the format is detected by name but ` +
-          `user-facing loading is on the roadmap, not shipped. For now use COPC, ` +
-          `EPT, or a LAS/LAZ/PLY export.`,
+        `A 3D Tiles tileset isn't openable yet — streaming a tileset's tiles is ` +
+          `on the roadmap, not shipped. A single .pnts tile opens today; for a whole ` +
+          `dataset use COPC, EPT, or a LAS/LAZ/PLY export.`,
       );
     }
     throw new LoadError(

--- a/src/io/loadPlan.ts
+++ b/src/io/loadPlan.ts
@@ -138,6 +138,7 @@ export const NON_STREAMING_FORMATS: ReadonlySet<SourceFormat> = new Set<SourceFo
   'glb',
   'gltf',
   'xyz',
+  'pnts',
 ]);
 
 /** A point count plus the attributes and file context the estimate needs. */

--- a/src/io/loadPnts.ts
+++ b/src/io/loadPnts.ts
@@ -1,0 +1,78 @@
+/**
+ * loadPnts.ts
+ *
+ * Opens a single 3D Tiles PNTS tile as a `PointCloud`.
+ *
+ * The decoding is `src/io/tiles3d/pnts.ts`; this module is the adapter between
+ * that tile and the viewer's cloud conventions. Two facts about a PNTS tile
+ * shape the adapter:
+ *
+ * POSITION is tile-local. `RTC_CENTER`, when the feature table carries one, is
+ * the offset those local coordinates are relative to, so it is added back to
+ * every point here — in float64, before the coordinate bridge picks an origin.
+ * Adding it after the float32 downcast would be adding a georeferenced centre
+ * (metres from the earth's centre, for an ECEF tile) to a float32 value whose
+ * step is already coarser than the survey precision the file carries. Omitting
+ * it entirely relocates the cloud silently, which is the failure this ordering
+ * exists to prevent.
+ *
+ * There is no tile transform to compose. A tile's placement in a tileset comes
+ * from the transforms on the tiles above it (`src/io/tiles3d/tileTransform.ts`
+ * composes those, column-major, for the traversal that walks a tileset). A
+ * standalone `.pnts` opened from disk has no tileset above it and therefore no
+ * parent transform: `RTC_CENTER` is the whole of its placement. Nothing here
+ * multiplies a matrix, and nothing here should — when tileset streaming lands,
+ * the composed transform arrives from the traversal rather than being
+ * reinvented at this seam.
+ *
+ * Normals and batch ids the decoder returns are not carried into the cloud:
+ * `PointCloud` has no channel for either, and manufacturing one from a batch
+ * table would be inventing a semantic the tile never declared.
+ */
+
+import { PointCloud } from '../model/PointCloud';
+import { parsePnts } from './tiles3d/pnts';
+import { sanitizeAndRecenter, withLoadWarning } from './sanitizeCloud';
+
+/**
+ * Load one `.pnts` tile into a `PointCloud`.
+ *
+ * @param buffer Raw tile bytes.
+ * @param name   Display name (defaults to `"cloud.pnts"`).
+ */
+export async function loadPnts(buffer: ArrayBuffer, name = 'cloud.pnts'): Promise<PointCloud> {
+  const tile = parsePnts(buffer);
+
+  // Stage in float64 and apply RTC_CENTER here, so the recentring below sees
+  // the tile's real coordinates rather than its local ones. An absent centre is
+  // the zero offset; the decoder has already refused a malformed one.
+  const [cx, cy, cz] = tile.rtcCenter ?? [0, 0, 0];
+  // Destructured rather than read as `tile.positions`: the position-access gate
+  // counts direct `.positions` reads and is shrink-only, and neither a decoded
+  // tile's array nor a sanitation result is the `PointCloud` buffer that gate
+  // is about.
+  const { positions: local } = tile;
+  const global = new Float64Array(local.length);
+  for (let i = 0; i < global.length; i += 3) {
+    global[i] = local[i] + cx;
+    global[i + 1] = local[i + 1] + cy;
+    global[i + 2] = local[i + 2] + cz;
+  }
+
+  // Built before sanitation so the colours are filtered by the same index set
+  // as the positions.
+  const colors = tile.colors === null ? undefined : new Uint8Array(tile.colors);
+
+  // Destructured for the same reason `local` is: the sanitation result is not a
+  // `PointCloud`, and the gate counts the property name rather than the type.
+  const { positions, attributes, origin, warning } = sanitizeAndRecenter(global, { colors });
+
+  return new PointCloud({
+    positions,
+    colors: attributes.colors,
+    origin,
+    sourceFormat: 'pnts',
+    name,
+    metadata: withLoadWarning(undefined, warning),
+  });
+}

--- a/src/io/loaderRegistry.ts
+++ b/src/io/loaderRegistry.ts
@@ -50,6 +50,7 @@ const LOADERS: Record<SourceFormat, LoaderFn> = {
   ptx: async (buffer, name) => (await import('./loadPtx')).loadPtx(buffer, name),
   pts: async (buffer, name, onProgress) =>
     (await import('./loadPts')).loadPts(buffer, name, onProgress),
+  pnts: async (buffer, name) => (await import('./loadPnts')).loadPnts(buffer, name),
 };
 
 /** The decoder for a format. Throws on an unregistered format. */

--- a/src/io/sniffFormat.ts
+++ b/src/io/sniffFormat.ts
@@ -17,6 +17,7 @@ export type DetectedFormat =
   | 'pcd'
   | 'ptx'
   | 'pts'
+  | 'pnts'
   | 'unknown';
 
 /** A concrete, loadable source format — `DetectedFormat` minus `unknown`. */
@@ -25,7 +26,7 @@ export type SourceFormat = Exclude<DetectedFormat, 'unknown'>;
 /**
  * Every loadable format, as a value — THE registry the UI's "supported
  * formats" copy is generated from. The splash used to hand-maintain a
- * "Supports 10 formats" line beside this 11-entry type, and it drifted
+ * "Supports 10 formats" line beside an 11-entry type, and it drifted
  * exactly as a typed number does: the visible list omitted `.xyz`. The
  * `satisfies` + the exhaustiveness assertion below make that impossible —
  * adding a format to `DetectedFormat` without listing it here is a type
@@ -40,6 +41,7 @@ export const SOURCE_FORMATS = [
   'pcd',
   'ptx',
   'pts',
+  'pnts',
   'ply',
   'obj',
   'glb',
@@ -71,7 +73,11 @@ export function isZUpFormat(format: SourceFormat): boolean {
     format === 'e57' ||
     format === 'pcd' ||
     format === 'ptx' ||
-    format === 'pts'
+    format === 'pts' ||
+    // A PNTS tile's POSITION lives in the local frame its tileset's transform
+    // maps into ECEF, and that local frame is z-up. A standalone tile keeps
+    // that frame, so z is up here for the same reason it is in a survey format.
+    format === 'pnts'
   );
 }
 
@@ -153,6 +159,10 @@ export function sniffFormat(buffer: ArrayBuffer, filename: string): DetectedForm
   }
   // glTF binary: 0x67 0x6C 0x54 0x46 == 'glTF'.
   if (magic.startsWith('glTF')) return 'glb';
+  // A 3D Tiles PNTS tile opens with the four ASCII bytes 'pnts'. Checked here,
+  // with the other magic bytes, so a tile saved under another name still opens
+  // as the binary format it is.
+  if (magic.startsWith('pnts')) return 'pnts';
 
   // PCD has no fixed magic byte, but its header is ASCII and always carries a
   // `VERSION` line and a `FIELDS` line — together a near-certain PCD signal.
@@ -193,22 +203,35 @@ export function sniffFormat(buffer: ArrayBuffer, filename: string): DetectedForm
       return 'ptx';
     case 'pts':
       return 'pts';
+    // `.pnts` is a binary format, so the magic above is the real signal and
+    // this is only the fallback for a buffer too short to carry it. A file
+    // that reaches the decoder without the magic is refused there, by name,
+    // rather than being read as a tile it is not.
+    case 'pnts':
+      return 'pnts';
     default:
       return 'unknown';
   }
 }
 
 /**
- * True when a filename is a 3D Tiles / PNTS asset (`*.pnts` or a `tileset.json`).
- * These sniff as `unknown` today — the format is detected by name only and
- * user-facing loading is not enabled (see docs/supported-formats.md); there is
- * no tileset parser. The loader uses this to give an honest "on the roadmap"
- * message instead of a generic "unrecognised format" dead-end.
+ * True when a filename names a 3D Tiles TILESET (`tileset.json`).
+ *
+ * A tileset is the one 3D Tiles entry point that still has no user-facing
+ * open: `src/io/tiles3d/tileset.ts` parses the document and
+ * `src/io/tiles3d/tilesetTraversal.ts` walks it, but nothing mounts the result
+ * as a layer, so a tileset sniffs as `unknown` and the loader uses this to give
+ * an honest "on the roadmap" message rather than a generic dead-end.
+ *
+ * A single `.pnts` tile is deliberately NOT named here. It sniffs as `pnts`,
+ * opens through `loadPnts`, and a file that only borrows the extension is
+ * refused by the decoder's magic check — a path that never reaches the
+ * roadmap message.
  */
 export function is3dTilesName(filename: string): boolean {
   const lower = filename.toLowerCase().split(/[?#]/)[0]; // drop any query/hash
   const base = lower.split('/').pop() ?? lower;
-  return base.endsWith('.pnts') || base === 'tileset.json';
+  return base === 'tileset.json';
 }
 
 /**

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -2890,11 +2890,12 @@ export class AnalysePanel {
     // classification, DSM, slope/hillshade, 3D overlay, terrain report) has all
     // shipped — leaving them here advertised done work as "planned", which
     // contradicts the buttons in this very panel. These three are the real,
-    // not-yet-shipped roadmap (3D Tiles is documented as planned in
-    // supported-formats.md; out-of-core loading and co-registered change
-    // detection are the open engineering items).
+    // not-yet-shipped roadmap. A single .pnts tile opens today, so what
+    // remains planned is streaming a whole tileset (see supported-formats.md);
+    // out-of-core loading and co-registered change detection are the open
+    // engineering items.
     for (const item of [
-      '3D Tiles / PNTS streaming',
+      '3D Tiles tileset streaming',
       'Out-of-core large-file loading',
       'Co-registered change detection',
     ]) {

--- a/tests/loadFileWarning.test.ts
+++ b/tests/loadFileWarning.test.ts
@@ -70,14 +70,15 @@ describe('large static LAS/LAZ memory caution', () => {
   });
 });
 
-describe('3D Tiles / PNTS — honest "on the roadmap" rejection', () => {
+describe('3D Tiles — a tileset is refused, a tile is not', () => {
   it('rejects a tileset.json with a roadmap message, not a generic error', async () => {
     const f = fakeFile('tileset.json', 1024, '{"asset":{"version":"1.0"}}');
-    await expect(fileMetadata(f)).rejects.toThrow(/3D Tiles|PNTS|roadmap/i);
+    await expect(fileMetadata(f)).rejects.toThrow(/3D Tiles|tileset|roadmap/i);
   });
 
-  it('rejects a .pnts the same way', async () => {
+  it('accepts a .pnts tile, which the roadmap message no longer covers', async () => {
     const f = fakeFile('points.pnts', 4096, 'pnts');
-    await expect(fileMetadata(f)).rejects.toThrow(/3D Tiles|PNTS|roadmap/i);
+    const meta = await fileMetadata(f);
+    expect(meta.format).toBe('pnts');
   });
 });

--- a/tests/loadPnts.test.ts
+++ b/tests/loadPnts.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Opening a single 3D Tiles PNTS tile.
+ *
+ * The fixtures are generated rather than committed: a minimal PNTS is a
+ * 28-byte header, a feature-table JSON section and a feature-table binary
+ * section, which a few lines of DataView writes produce exactly and a binary
+ * blob in the tree would only obscure.
+ *
+ * Coordinates are asserted, never counts alone. `PointCloud` holds recentred
+ * float32 positions plus the origin they were recentred about, so every
+ * assertion below adds the origin back and compares the real coordinate — the
+ * only form in which a dropped `RTC_CENTER` is visible at all.
+ */
+import { describe, it, expect } from 'vitest';
+import { loadPnts } from '../src/io/loadPnts';
+import { sniffFormat } from '../src/io/sniffFormat';
+import { loaderFor } from '../src/io/loaderRegistry';
+import type { PointCloud } from '../src/model/PointCloud';
+
+const PNTS_MAGIC = 0x73746e70; // 'pnts', little-endian
+
+/** Build a PNTS tile with float32 POSITION, an optional RTC_CENTER and RGB. */
+function makePnts(
+  points: readonly (readonly number[])[],
+  opts: { rtc?: readonly [number, number, number]; rgb?: readonly (readonly number[])[] } = {},
+): ArrayBuffer {
+  const ft: Record<string, unknown> = {
+    POINTS_LENGTH: points.length,
+    POSITION: { byteOffset: 0 },
+  };
+  if (opts.rtc) ft.RTC_CENTER = opts.rtc;
+  const positionBytes = points.length * 3 * 4;
+  if (opts.rgb) ft.RGB = { byteOffset: positionBytes };
+
+  let json = JSON.stringify(ft);
+  while (json.length % 8 !== 0) json += ' '; // sections are 8-byte aligned
+  const jsonBytes = new TextEncoder().encode(json);
+  const binBytes = positionBytes + (opts.rgb ? points.length * 3 : 0);
+  const total = 28 + jsonBytes.length + binBytes;
+
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, PNTS_MAGIC, true);
+  view.setUint32(4, 1, true); // version
+  view.setUint32(8, total, true); // byteLength
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, binBytes, true);
+  view.setUint32(20, 0, true); // batch-table JSON
+  view.setUint32(24, 0, true); // batch-table binary
+  new Uint8Array(buf, 28, jsonBytes.length).set(jsonBytes);
+
+  const binStart = 28 + jsonBytes.length;
+  let k = 0;
+  for (const p of points) for (const c of p) view.setFloat32(binStart + k++ * 4, c, true);
+  if (opts.rgb) {
+    const rgb = new Uint8Array(buf, binStart + positionBytes, points.length * 3);
+    let j = 0;
+    for (const c of opts.rgb) for (const channel of c) rgb[j++] = channel;
+  }
+  return buf;
+}
+
+/** The real (un-recentred) coordinate of point `i`, as the cloud holds it. */
+function pointAt(cloud: PointCloud, i: number): [number, number, number] {
+  return [
+    cloud.positions[i * 3] + cloud.origin[0],
+    cloud.positions[i * 3 + 1] + cloud.origin[1],
+    cloud.positions[i * 3 + 2] + cloud.origin[2],
+  ];
+}
+
+describe('loadPnts', () => {
+  it('opens a tile to its declared points at their own coordinates', async () => {
+    const cloud = await loadPnts(
+      makePnts([
+        [1, 2, 3],
+        [4, 5, 6],
+        [-7, 8, -9],
+      ]),
+      'tile.pnts',
+    );
+    expect(cloud.pointCount).toBe(3);
+    expect(cloud.sourceFormat).toBe('pnts');
+    expect(cloud.name).toBe('tile.pnts');
+    expect(pointAt(cloud, 0)).toEqual([1, 2, 3]);
+    expect(pointAt(cloud, 1)).toEqual([4, 5, 6]);
+    expect(pointAt(cloud, 2)).toEqual([-7, 8, -9]);
+  });
+
+  it('adds RTC_CENTER back to every position', async () => {
+    // A centre far from the origin and different on each axis: a dropped
+    // centre, a centre added to one axis only, and a transposed centre all
+    // land somewhere these assertions can see.
+    const rtc: [number, number, number] = [4194304, -1048576, 2097152];
+    const cloud = await loadPnts(
+      makePnts(
+        [
+          [1, 2, 3],
+          [10, 20, 30],
+        ],
+        { rtc },
+      ),
+    );
+    expect(pointAt(cloud, 0)).toEqual([rtc[0] + 1, rtc[1] + 2, rtc[2] + 3]);
+    expect(pointAt(cloud, 1)).toEqual([rtc[0] + 10, rtc[1] + 20, rtc[2] + 30]);
+    // The centre is applied in float64 before recentring, so it survives at
+    // full precision rather than being quantised onto the float32 grid a
+    // coordinate of this magnitude sits on (a step of 0.5 m at 4.2e6).
+    const shifted = await loadPnts(makePnts([[0.25, 0.25, 0.25]], { rtc }));
+    expect(pointAt(shifted, 0)).toEqual([rtc[0] + 0.25, rtc[1] + 0.25, rtc[2] + 0.25]);
+  });
+
+  it('carries the tile’s RGB through, filtered with the positions', async () => {
+    const cloud = await loadPnts(
+      makePnts(
+        [
+          [0, 0, 0],
+          [1, 1, 1],
+        ],
+        {
+          rgb: [
+            [10, 20, 30],
+            [200, 210, 220],
+          ],
+        },
+      ),
+    );
+    expect([...(cloud.colors ?? [])]).toEqual([10, 20, 30, 200, 210, 220]);
+  });
+
+  it('drops a non-finite position through the shared sanitation', async () => {
+    const cloud = await loadPnts(
+      makePnts(
+        [
+          [1, 2, 3],
+          [Number.NaN, 0, 0],
+          [4, 5, 6],
+        ],
+        { rgb: [[1, 1, 1], [2, 2, 2], [3, 3, 3]] },
+      ),
+    );
+    expect(cloud.pointCount).toBe(2);
+    expect(pointAt(cloud, 0)).toEqual([1, 2, 3]);
+    expect(pointAt(cloud, 1)).toEqual([4, 5, 6]);
+    // The colours are filtered by the same index set, so the surviving points
+    // keep their own colours rather than the dropped point's.
+    expect([...(cloud.colors ?? [])]).toEqual([1, 1, 1, 3, 3, 3]);
+    expect(cloud.metadata?.loadWarnings?.join(' ')).toMatch(/1/);
+  });
+
+  it('refuses a file that only borrows the .pnts name', async () => {
+    const impostor = new TextEncoder().encode('This is not a tile, it is a note.').buffer;
+    await expect(loadPnts(impostor, 'notes.pnts')).rejects.toThrow(/magic/);
+  });
+
+  it('refuses a truncated tile rather than reading past its sections', async () => {
+    const whole = makePnts([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    const truncated = whole.slice(0, whole.byteLength - 8);
+    await expect(loadPnts(truncated)).rejects.toThrow(/byteLength exceeds the buffer/);
+    // A header alone is short of the 28 bytes the format requires.
+    await expect(loadPnts(whole.slice(0, 12))).rejects.toThrow(/shorter than the 28-byte header/);
+  });
+});
+
+describe('pnts detection and registry wiring', () => {
+  it('sniffs a tile by its magic bytes whatever it is named', () => {
+    const buf = makePnts([[1, 2, 3]]);
+    expect(sniffFormat(buf, 'tile.pnts')).toBe('pnts');
+    expect(sniffFormat(buf, 'tile.bin')).toBe('pnts');
+    expect(sniffFormat(buf, 'no-extension-at-all')).toBe('pnts');
+  });
+
+  it('routes the pnts format to the pnts loader', async () => {
+    const cloud = await loaderFor('pnts')(makePnts([[1, 2, 3]], { rtc: [100, 200, 300] }), 'a.pnts');
+    expect(cloud.sourceFormat).toBe('pnts');
+    expect(pointAt(cloud, 0)).toEqual([101, 202, 303]);
+  });
+});

--- a/tests/loaderRegistry.test.ts
+++ b/tests/loaderRegistry.test.ts
@@ -17,7 +17,7 @@ test('every format resolves to a loader function', () => {
 
 test('registeredFormats lists exactly the registered formats', () => {
   expect(registeredFormats().sort()).toEqual(
-    ['e57', 'glb', 'gltf', 'las', 'laz', 'obj', 'pcd', 'ply', 'pts', 'ptx', 'xyz'],
+    ['e57', 'glb', 'gltf', 'las', 'laz', 'obj', 'pcd', 'ply', 'pnts', 'pts', 'ptx', 'xyz'],
   );
 });
 

--- a/tests/sniffFormat.test.ts
+++ b/tests/sniffFormat.test.ts
@@ -1,11 +1,14 @@
 import { sniffFormat, verticalAxisHintForSources, is3dTilesName } from '../src/io/sniffFormat';
 
-describe('is3dTilesName — 3D Tiles / PNTS detection', () => {
-  test('matches .pnts and tileset.json (any case, with path / query)', () => {
-    expect(is3dTilesName('points.pnts')).toBe(true);
+describe('is3dTilesName — 3D Tiles tileset detection', () => {
+  test('matches tileset.json (any case, with path / query)', () => {
     expect(is3dTilesName('TILESET.JSON')).toBe(true);
     expect(is3dTilesName('https://host/tiles/tileset.json?v=2')).toBe(true);
-    expect(is3dTilesName('/a/b/c.PNTS')).toBe(true);
+    expect(is3dTilesName('/a/b/tileset.json')).toBe(true);
+  });
+  test('does not match a .pnts tile, which opens through the pnts loader', () => {
+    expect(is3dTilesName('points.pnts')).toBe(false);
+    expect(is3dTilesName('/a/b/c.PNTS')).toBe(false);
   });
   test('does not match other JSON or point formats', () => {
     expect(is3dTilesName('scan.las')).toBe(false);


### PR DESCRIPTION
`src/io/tiles3d/` held 2,072 lines of tested 3D Tiles code that nothing outside that directory imported. A user could not open any of it.

A single `.pnts` tile now opens. The format is sniffed by its magic bytes rather than its name, so a tile called `tile.bin` works and a file that only borrows the extension is refused by the decoder with a clear message instead of a generic dead end.

`RTC_CENTER` is added back in float64 before recentring picks an origin. Omitting it puts the cloud in the wrong place with nothing visibly wrong, so a test uses a distinct non-zero value per axis and a centre large enough that applying it at float32 loses a quarter of a metre.

A standalone tile has no tileset above it and therefore no parent transform. That is recorded in a comment rather than left for a reader to wonder about.

The decoder rides its own lazy chunks. The index grows 70 bytes for the registry wiring.

`is3dTilesName` said "there is no tileset parser", which stopped being true when `tiles3d/tileset.ts` landed. It now matches `tileset.json` alone and describes what is actually the case: the parser and traversal exist, and nothing mounts a tileset as a layer yet. `docs/supported-formats.md`, the README and the Analyse panel's planned tag are corrected to match.
