### PR TITLE
Bound a tileset before fetching one, and gate every URL it names

### DIFF
--- a/src/io/tiles3d/tileset.ts
+++ b/src/io/tiles3d/tileset.ts
@@ -48,6 +48,36 @@ interface RawTile {
   implicitTiling?: unknown;
 }
 
+/**
+ * Structural ceilings for a parsed tileset.
+ *
+ * A `tileset.json` declares its own shape, so every number that sizes work here
+ * comes from remote input. Depth bounds the recursion below (and with it the
+ * call stack); the tile count bounds the total allocation of a document whose
+ * bytes are already capped but whose node count is not proportional to them —
+ * a few hundred kilobytes of minified JSON can name a very large tree. Both are
+ * refusals, not truncations: a tileset that exceeds either is not partially
+ * mounted, because a silently pruned hierarchy renders as a plausible scene
+ * with geometry missing.
+ */
+export const DEFAULT_TILESET_MAX_DEPTH = 24;
+export const DEFAULT_TILESET_MAX_TILES = 200_000;
+
+/** Overrides for the structural ceilings {@link parseTileset} enforces. */
+export interface TilesetParseLimits {
+  /** Deepest tile below the root. Default {@link DEFAULT_TILESET_MAX_DEPTH}. */
+  readonly maxDepth?: number;
+  /** Total tiles in the tree. Default {@link DEFAULT_TILESET_MAX_TILES}. */
+  readonly maxTiles?: number;
+}
+
+/** The mutable budget threaded through one parse. */
+interface ParseBudget {
+  readonly maxDepth: number;
+  readonly maxTiles: number;
+  tiles: number;
+}
+
 /** Component counts the spec fixes for each bounding-volume form. */
 const BOUNDING_VOLUME_LENGTH = { box: 12, region: 6, sphere: 4 } as const;
 
@@ -123,7 +153,17 @@ function explicitRefine(v: unknown): Refine | null {
   return upper;
 }
 
-function parseTile(raw: RawTile, inheritedRefine: Refine): Tile {
+function parseTile(raw: RawTile, inheritedRefine: Refine, depth: number, budget: ParseBudget): Tile {
+  if (depth > budget.maxDepth) {
+    throw new Error(
+      `3D Tiles: tile hierarchy is deeper than ${budget.maxDepth} levels; refusing to parse it.`,
+    );
+  }
+  if (++budget.tiles > budget.maxTiles) {
+    throw new Error(
+      `3D Tiles: tileset declares more than ${budget.maxTiles} tiles; refusing to parse it.`,
+    );
+  }
   if (raw.implicitTiling !== undefined) {
     throw new Error('3D Tiles: implicit tiling is not supported yet — only an explicit tile hierarchy.');
   }
@@ -145,7 +185,7 @@ function parseTile(raw: RawTile, inheritedRefine: Refine): Tile {
   if (raw.children !== undefined && !Array.isArray(raw.children)) {
     throw new Error('3D Tiles: a tile children field is not an array.');
   }
-  const children = (raw.children ?? []).map((c) => parseTile(c, refine));
+  const children = (raw.children ?? []).map((c) => parseTile(c, refine, depth + 1, budget));
   return {
     boundingVolume: boundingVolume(raw.boundingVolume),
     geometricError: raw.geometricError,
@@ -157,7 +197,7 @@ function parseTile(raw: RawTile, inheritedRefine: Refine): Tile {
 }
 
 /** Parse a `tileset.json` (string or already-parsed object) into a typed tree. */
-export function parseTileset(input: string | object): Tileset {
+export function parseTileset(input: string | object, limits: TilesetParseLimits = {}): Tileset {
   const doc = (typeof input === 'string' ? JSON.parse(input) : input) as {
     asset?: { version?: string };
     geometricError?: number;
@@ -179,9 +219,14 @@ export function parseTileset(input: string | object): Tileset {
   if (!rootRefine) {
     throw new Error('3D Tiles: the root tile must declare refine ADD or REPLACE.');
   }
+  const budget: ParseBudget = {
+    maxDepth: limits.maxDepth ?? DEFAULT_TILESET_MAX_DEPTH,
+    maxTiles: limits.maxTiles ?? DEFAULT_TILESET_MAX_TILES,
+    tiles: 0,
+  };
   return {
     assetVersion,
     geometricError: doc.geometricError,
-    root: parseTile(doc.root, rootRefine),
+    root: parseTile(doc.root, rootRefine, 0, budget),
   };
 }

--- a/src/io/tiles3d/tilesetOpen.ts
+++ b/src/io/tiles3d/tilesetOpen.ts
@@ -1,0 +1,272 @@
+/**
+ * tilesetOpen.ts — opening a remote 3D Tiles tileset, selecting what a view
+ * needs from it, and decoding the tiles that selection names.
+ *
+ * This is the resource layer the pure modules beside it were written to be
+ * driven by. `tileset.ts` parses, `tileTransform.ts` places, `screenSpaceError.ts`
+ * measures, `tilesetTraversal.ts` decides, `pnts.ts` decodes; none of them
+ * fetch, and none of them knew about each other's caller. Three functions here
+ * compose them into the open → select → read → decode sequence, and each keeps
+ * its own refusal:
+ *
+ *   openTileset          fetch + parse + validate, or refuse
+ *   selectTileContents   traverse, resolve URIs, cap the result
+ *   fetchTileContent     read one `.pnts` and place it in root space
+ *
+ * WHAT IS BOUNDED, AND WHY EVERY NUMBER HERE IS ONE. A tileset declares its own
+ * structure, so nothing it says may size an allocation on its own. The document
+ * body is capped by the transport; the tile COUNT and the tree DEPTH are capped
+ * at parse, because a small document can name a large tree; the SELECTION is
+ * capped, because a legal shallow tileset with a very wide root would otherwise
+ * hand the caller an unbounded list of fetches from one camera position. Each
+ * cap refuses. None truncates, because a hierarchy silently pruned mid-traversal
+ * renders as a plausible scene with geometry quietly missing, which is the
+ * failure mode that is hardest to notice and worst to ship.
+ *
+ * WHAT IS NOT HERE. Nothing mounts. There is no `StreamingSource` implementation
+ * in this module and no viewer wiring, because the streaming contract is built
+ * around a node store keyed by octree records and LAS-shaped decode metadata,
+ * which a PNTS content tree does not have. This module is the fetch/decode half
+ * that such a source would sit on; the source itself is not written.
+ *
+ * Nothing static imports this file, so none of it reaches the initial bundle.
+ * There is deliberately no `loadTiles3d` seam in `lazyChunks.ts` yet either: the
+ * build's chunk-emission guard requires every module named by a dynamic import
+ * literal there to actually emit a chunk, and a seam with no caller is tree-
+ * shaken away and fails that guard. The seam lands with the mount that uses it.
+ *
+ * EXTERNAL TILESETS. A `content.uri` naming another `tileset.json` is reported,
+ * not followed. Following one is a second recursion over remote input with its
+ * own depth budget, and stubbing it as "fetch and splice" is how the tile-count
+ * cap above would be escaped one document at a time.
+ */
+
+import { parseTileset, type Tileset, type TilesetParseLimits } from './tileset';
+import { selectTiles, type SelectedTile, type ViewCamera } from './tilesetTraversal';
+import { transformPoint } from './tileTransform';
+import { parsePnts } from './pnts';
+import {
+  resolveTilesetContentUrl,
+  tilesetBaseUrl,
+  tilesetUrlSearch,
+  validateRemoteTilesetUrl,
+} from './tilesetUrl';
+import type { TilesetTransport } from './tilesetTransport';
+
+/**
+ * Ceiling on how many tiles ONE view may select.
+ *
+ * The traversal's depth cap bounds how deep it descends but not how wide: a
+ * legal tileset can put a hundred thousand children under a root with a large
+ * geometric error, and a camera close to it refines into all of them. This is
+ * the cap on the fetch list that comes out, and it is a refusal so a caller
+ * never streams a quietly truncated view believing it is complete.
+ */
+export const MAX_SELECTED_TILES = 4096;
+
+/** A tileset fetched, parsed and validated, with the URLs its content resolves against. */
+export interface OpenedTileset {
+  /** The entry URL, as it passed validation. */
+  readonly entryUrl: string;
+  /** The directory content URIs resolve against, always ending in `/`. */
+  readonly baseUrl: string;
+  /** The entry URL's query, re-attached to derived requests. */
+  readonly search: string;
+  readonly tileset: Tileset;
+}
+
+/** One tile a view selected, with its content resolved to a fetchable URL. */
+export interface SelectedTileContent {
+  readonly selected: SelectedTile;
+  /** The validated absolute URL of this tile's content. */
+  readonly url: string;
+  /** `pnts` for a point tile; `tileset` for an external tileset, which is not followed. */
+  readonly kind: 'pnts' | 'tileset';
+}
+
+/** What one selection produced, including what it deliberately did not fetch. */
+export interface TileSelection {
+  /** Tiles whose content is a `.pnts`, in traversal order. */
+  readonly contents: readonly SelectedTileContent[];
+  /**
+   * External `tileset.json` contents the selection reached and did NOT follow.
+   * Reported rather than dropped, so a caller can say that part of the scene is
+   * missing instead of showing an incomplete one as if it were whole.
+   */
+  readonly externalTilesets: readonly SelectedTileContent[];
+  /** Selected tiles that render but carry no content of their own. */
+  readonly emptyTiles: number;
+}
+
+/** A `.pnts` tile decoded and placed into the tileset's root space. */
+export interface PlacedTileContent {
+  readonly url: string;
+  readonly pointCount: number;
+  /**
+   * Root-space xyz triples, float64.
+   *
+   * Float64 because the placement is applied here: a PNTS tile's positions are
+   * tile-local float32, and a 3D Tiles transform is routinely an ECEF placement
+   * whose translation is millions of metres. Adding that to a float32 value
+   * whose step is already coarser than the survey precision the file carries
+   * destroys the precision before any consumer sees it, so the composition
+   * happens in float64 and the downcast is left to whoever builds a buffer.
+   */
+  readonly positions: Float64Array;
+  /** Interleaved sRGB bytes, or null when the tile carries no colour. */
+  readonly colors: Uint8Array | null;
+}
+
+/**
+ * Fetch, parse and validate a tileset entry document.
+ *
+ * Every refusal happens before anything is returned: a URL that fails the SSRF
+ * and entrypoint gate is never fetched, a body past the transport ceiling is
+ * never fully read, and a document whose tree exceeds the depth or tile budget
+ * throws rather than yielding a partial tree. Nothing is ever half-opened.
+ */
+export async function openTileset(
+  url: string,
+  transport: TilesetTransport,
+  signal?: AbortSignal,
+  limits: TilesetParseLimits = {},
+): Promise<OpenedTileset> {
+  const check = validateRemoteTilesetUrl(url);
+  if (!check.ok) throw new Error(`3D Tiles: ${check.reason}`);
+  // Every request below uses the VALIDATED url, never the raw input.
+  const entryUrl = check.url;
+  const text = await transport.fetchTilesetJson(entryUrl, signal);
+  if (signal?.aborted) {
+    throw signal.reason ?? new DOMException('3D Tiles open aborted', 'AbortError');
+  }
+  // `parseTileset` throws on a malformed or over-budget document; it is not
+  // caught here, because there is no partial tileset worth returning.
+  const tileset = parseTileset(text, limits);
+  return {
+    entryUrl,
+    baseUrl: tilesetBaseUrl(entryUrl),
+    search: tilesetUrlSearch(entryUrl),
+    tileset,
+  };
+}
+
+/** How a content URI's filename classifies. Query and fragment are ignored. */
+function contentKind(uri: string): 'pnts' | 'tileset' | 'other' {
+  const path = uri.split(/[?#]/)[0]!.toLowerCase();
+  if (path.endsWith('.pnts')) return 'pnts';
+  if (path.endsWith('.json')) return 'tileset';
+  return 'other';
+}
+
+export interface SelectOptions {
+  /** Refine while the screen-space error exceeds this, in pixels. */
+  readonly maxScreenSpaceErrorPx: number;
+  /** Stop descending past this depth. Defaults to the traversal's own cap. */
+  readonly maxDepth?: number;
+  /** Ceiling on the selection. Default {@link MAX_SELECTED_TILES}. */
+  readonly maxSelectedTiles?: number;
+}
+
+/**
+ * Select the tiles a view needs and resolve each one's content to a URL.
+ *
+ * The traversal is `selectTiles`, unchanged: transforms compose there, bounds
+ * and screen-space error are measured there, and ADD-versus-REPLACE refinement
+ * is decided there. This function adds the resource half — resolving each
+ * selected tile's `content.uri` through the same-origin, same-directory gate,
+ * and refusing a selection larger than the cap.
+ *
+ * A content URI that fails resolution throws. It is remote input naming a fetch
+ * the guard refused, and skipping it would render most of a tileset that was
+ * trying to direct the viewer somewhere it must not go.
+ */
+export function selectTileContents(
+  opened: OpenedTileset,
+  camera: ViewCamera,
+  options: SelectOptions,
+): TileSelection {
+  const cap = options.maxSelectedTiles ?? MAX_SELECTED_TILES;
+  const selected = selectTiles(opened.tileset, camera, {
+    maxScreenSpaceErrorPx: options.maxScreenSpaceErrorPx,
+    ...(options.maxDepth !== undefined && { maxDepth: options.maxDepth }),
+  });
+  if (selected.length > cap) {
+    throw new Error(
+      `3D Tiles: this view selects ${selected.length} tiles, past the ${cap}-tile ceiling; refusing to fetch them.`,
+    );
+  }
+  const contents: SelectedTileContent[] = [];
+  const externalTilesets: SelectedTileContent[] = [];
+  let emptyTiles = 0;
+  for (const tile of selected) {
+    const uri = tile.placed.tile.contentUri;
+    if (uri === null) {
+      emptyTiles++;
+      continue;
+    }
+    const kind = contentKind(uri);
+    if (kind === 'other') {
+      // A tileset streamed here is a point-cloud tileset. A `.b3dm` or `.glb`
+      // is a real 3D Tiles content type this viewer has no decoder for, and
+      // fetching it to discover that wastes the transfer.
+      throw new Error(`3D Tiles: content "${uri}" is not a .pnts tile or an external tileset.`);
+    }
+    const resolved = resolveTilesetContentUrl(opened.baseUrl, uri, opened.search);
+    if (!resolved.ok) throw new Error(`3D Tiles: ${resolved.reason}`);
+    const entry: SelectedTileContent = { selected: tile, url: resolved.url, kind };
+    if (kind === 'pnts') contents.push(entry);
+    else externalTilesets.push(entry);
+  }
+  return { contents, externalTilesets, emptyTiles };
+}
+
+/**
+ * Fetch one selected `.pnts` and place its points in the tileset's root space.
+ *
+ * The decode is `parsePnts` — the same decoder a standalone `.pnts` opens
+ * through, not a second one. The placement is the composition the standalone
+ * path deliberately has no parent for: `RTC_CENTER` first, because it is stated
+ * in the tile's own local frame, then the cumulative tile transform the
+ * traversal carried down from the root.
+ *
+ * The order is the whole content of the function. Applying the transform before
+ * `RTC_CENTER` rotates and scales a centre stated in the untransformed frame,
+ * which leaves the tile somewhere plausible rather than somewhere wrong — and
+ * the composition is column-major (`m[col * 4 + row]`, via `transformPoint`),
+ * so a transposed read produces a scene that is subtly, consistently misplaced
+ * rather than one that obviously fails.
+ */
+export async function fetchTileContent(
+  content: SelectedTileContent,
+  transport: TilesetTransport,
+  signal?: AbortSignal,
+): Promise<PlacedTileContent> {
+  if (content.kind !== 'pnts') {
+    throw new Error(`3D Tiles: ${content.url} is an external tileset, not a point tile.`);
+  }
+  const bytes = await transport.fetchTileBytes(content.url, signal);
+  if (signal?.aborted) {
+    throw signal.reason ?? new DOMException('3D Tiles tile read aborted', 'AbortError');
+  }
+  const tile = parsePnts(bytes);
+  const [cx, cy, cz] = tile.rtcCenter ?? [0, 0, 0];
+  const { positions: local } = tile;
+  const matrix = content.selected.placed.transform;
+  const out = new Float64Array(local.length);
+  for (let i = 0; i < out.length; i += 3) {
+    const [x, y, z] = transformPoint(matrix, [
+      local[i]! + cx,
+      local[i + 1]! + cy,
+      local[i + 2]! + cz,
+    ]);
+    out[i] = x;
+    out[i + 1] = y;
+    out[i + 2] = z;
+  }
+  return {
+    url: content.url,
+    pointCount: tile.pointsLength,
+    positions: out,
+    colors: tile.colors,
+  };
+}

--- a/src/io/tiles3d/tilesetTransport.ts
+++ b/src/io/tiles3d/tilesetTransport.ts
@@ -1,0 +1,224 @@
+/**
+ * tilesetTransport.ts — the hardened remote fetch for 3D Tiles.
+ *
+ * WHY THIS IS NOT `createEptTransport`. The EPT transport carries the same
+ * discipline this needs (per-attempt timeout, bounded retry with jittered
+ * backoff, `redirect: 'error'`, bounded body reads), but it is EPT-specific in
+ * two ways that matter rather than one that is cosmetic. Its two read shapes
+ * are named `hierarchy` and `tile` and it embeds those words in the error
+ * messages it throws, and `describeRemoteEptError` PATTERN-MATCHES those exact
+ * strings to build the user-facing message. Borrowing it would make a failed
+ * `.pnts` fetch tell the user that "EPT tile fetch failed", and would tie any
+ * future change to the 3D Tiles messages to the EPT classifier's regexes. The
+ * ceilings differ too: a tileset.json and a `.pnts` are not an ept.json and a
+ * LAZ chunk. So the discipline is mirrored and the vocabulary is this format's.
+ *
+ * The bounded reads are genuinely shared: `readTextAtMost` / `readAtMostBounded`
+ * refuse a declared oversize before the first byte, stop on the chunk that
+ * crosses the ceiling, carry an idle-silence budget, and stay wired to the
+ * caller's cancel. Nothing about them is EPT-flavoured.
+ *
+ * Pure apart from `fetch` itself — the injected `fetchImpl`, `sleep` and
+ * `random` make every retry, timeout and abort path deterministically testable
+ * with no network, the way the EPT transport's tests do.
+ */
+
+import { sanitizeUrlForDisplay } from '../range/RangeSource';
+import { readAtMostBounded, readTextAtMost } from '../range/boundedRead';
+
+/** Per-attempt timeout for one HTTP request, in milliseconds. */
+const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
+/**
+ * Ceiling for a `tileset.json` body. The document is JSON metadata — bounding
+ * volumes, geometric errors, content URIs — while the geometry lives in the
+ * `.pnts` files it names, so even a continent-scale tileset's entry document is
+ * kilobytes to low megabytes. Well above any real document and far below a
+ * memory hazard. The tile COUNT inside a document this size is separately
+ * capped by `parseTileset`, because a few hundred kilobytes of minified JSON
+ * can still name a very large tree.
+ */
+export const MAX_TILESET_JSON_BYTES = 8 * 1024 * 1024;
+/**
+ * Ceiling for one `.pnts` body. PNTS is uncompressed, so its size is bounded by
+ * its point count: 4M points carrying position, colour and normal is roughly
+ * 130 MB. 128 MiB refuses a hostile body without rejecting a legitimate tile
+ * from a writer that produced unusually large tiles.
+ */
+export const MAX_PNTS_TILE_BYTES = 128 * 1024 * 1024;
+/** Maximum retries beyond the initial attempt (so up to 4 total). */
+const DEFAULT_MAX_RETRIES = 3;
+/** Base backoff before the first retry — doubled each attempt, jittered. */
+const DEFAULT_RETRY_BASE_MS = 250;
+/** HTTP statuses that are transient transport faults worth retrying. */
+const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+
+/**
+ * An internal per-attempt request deadline elapsed.
+ *
+ * Deliberately distinct from a user cancel: a timeout is a real failure the
+ * user should see, not a silent cancellation. `code: 'timeout'` matches the
+ * convention COPC's `RangeReadError` and EPT's `EptTimeoutError` already use,
+ * so `isAbortError` in the streaming open path refuses to read it as a cancel.
+ */
+export class TilesetTimeoutError extends Error {
+  readonly code = 'timeout' as const;
+  constructor(message: string) {
+    super(message);
+    this.name = 'TilesetTimeoutError';
+  }
+}
+
+/** What a 3D Tiles open reads over the wire. */
+export interface TilesetTransport {
+  /** The entry or an external `tileset.json`, capped at {@link MAX_TILESET_JSON_BYTES}. */
+  fetchTilesetJson(url: string, signal?: AbortSignal): Promise<string>;
+  /** One `.pnts` body, capped at {@link MAX_PNTS_TILE_BYTES}. */
+  fetchTileBytes(url: string, signal?: AbortSignal): Promise<ArrayBuffer>;
+}
+
+/** Tunables for {@link createTilesetTransport}. Defaulted; injected for tests. */
+export interface TilesetTransportOptions {
+  /** Per-attempt timeout, in ms. Default {@link DEFAULT_REQUEST_TIMEOUT_MS}. */
+  requestTimeoutMs?: number;
+  /** Maximum retries beyond the initial attempt. */
+  maxRetries?: number;
+  /** Base backoff before the first retry, ms. */
+  retryBaseMs?: number;
+  /** Replacement `fetch` — production callers omit this; tests inject a fake. */
+  fetchImpl?: typeof fetch;
+  /** PRNG in `[0, 1)`; tests inject a deterministic version for jitter. */
+  random?: () => number;
+  /** Sleep helper, ms. Tests can substitute a synchronous resolver. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Override the tileset.json ceiling. Tests use a tiny one. */
+  maxTilesetJsonBytes?: number;
+  /** Override the `.pnts` ceiling. Tests use a tiny one. */
+  maxTileBytes?: number;
+}
+
+/** What kind of resource a request is reading, for the error vocabulary. */
+type ReadLabel = 'tileset' | 'tile';
+
+/**
+ * Build a hardened 3D Tiles transport: per-attempt timeout, bounded retry with
+ * jittered backoff, refused redirects, and bounded body reads.
+ */
+export function createTilesetTransport(
+  options: TilesetTransportOptions = {},
+): TilesetTransport {
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const retryBaseMs = options.retryBaseMs ?? DEFAULT_RETRY_BASE_MS;
+  const fetchFn = options.fetchImpl ?? ((...args: Parameters<typeof fetch>) => fetch(...args));
+  const random = options.random ?? Math.random;
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const maxJsonBytes = options.maxTilesetJsonBytes ?? MAX_TILESET_JSON_BYTES;
+  const maxTileBytes = options.maxTileBytes ?? MAX_PNTS_TILE_BYTES;
+
+  /**
+   * One GET with a hard deadline, composed with the caller's outer signal.
+   *
+   * The composed controller is what the fetch sees, so either source aborts it;
+   * which of the two fired is recovered afterwards, because both surface as an
+   * indistinguishable `AbortError` on the rejection itself.
+   */
+  async function fetchOnce(url: string, outer?: AbortSignal): Promise<Response> {
+    if (outer?.aborted) {
+      throw outer.reason ?? new DOMException('3D Tiles fetch aborted before request', 'AbortError');
+    }
+    const deadline = new AbortController();
+    const timer = setTimeout(() => deadline.abort(), requestTimeoutMs);
+    const composed = new AbortController();
+    const onAbort = (): void => composed.abort();
+    if (outer) outer.addEventListener('abort', onAbort, { once: true });
+    deadline.signal.addEventListener('abort', onAbort, { once: true });
+    try {
+      // `redirect: 'error'`: the host passed the SSRF block-list as a literal
+      // string, but a 3xx could send the fetch to a private address no check
+      // ever resolved. Refuse the hop rather than follow it.
+      return await fetchFn(url, { signal: composed.signal, redirect: 'error' });
+    } catch (err) {
+      if (deadline.signal.aborted && !outer?.aborted) {
+        throw new TilesetTimeoutError(
+          `3D Tiles request timed out after ${requestTimeoutMs} ms for ${sanitizeUrlForDisplay(url)}`,
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+      if (outer) outer.removeEventListener('abort', onAbort);
+      deadline.signal.removeEventListener('abort', onAbort);
+    }
+  }
+
+  /** Exponential backoff, jittered ±50 % so clients do not retry in lockstep. */
+  function backoffMs(n: number): number {
+    const exp = retryBaseMs * Math.pow(2, n - 1);
+    return Math.max(0, Math.round(exp * (1 + (random() - 0.5))));
+  }
+
+  async function fetchWithRetry(
+    url: string,
+    label: ReadLabel,
+    outer?: AbortSignal,
+  ): Promise<Response> {
+    let lastError: unknown = null;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      if (outer?.aborted) {
+        throw outer.reason ?? new DOMException('3D Tiles fetch aborted between retries', 'AbortError');
+      }
+      let response: Response | null = null;
+      // Only the transport call sits inside the try; the status classification
+      // below is outside it so a permanent-error throw is not swallowed back
+      // into the retry loop.
+      try {
+        response = await fetchOnce(url, outer);
+      } catch (err) {
+        if (outer?.aborted) throw err;
+        lastError = err;
+      }
+      if (response) {
+        if (response.ok) return response;
+        const message =
+          `3D Tiles ${label} fetch failed (${response.status} ${response.statusText}) ` +
+          `for ${sanitizeUrlForDisplay(url)}`;
+        // 4xx other than 408/429 is permanent; retrying only delays the error.
+        if (!RETRYABLE_STATUSES.has(response.status)) throw new Error(message);
+        lastError = new Error(message);
+      }
+      if (attempt < maxRetries) await sleep(backoffMs(attempt + 1));
+    }
+    if (lastError instanceof Error) throw lastError;
+    throw new Error(`3D Tiles ${label} fetch failed for ${sanitizeUrlForDisplay(url)}`);
+  }
+
+  return {
+    fetchTilesetJson: async (url, signal) => {
+      const response = await fetchWithRetry(url, 'tileset', signal);
+      // The retry loop bounds the header round-trip only; the bytes that follow
+      // need their own ceiling and stall clock.
+      return readTextAtMost(
+        response,
+        maxJsonBytes,
+        `3D Tiles tileset at ${sanitizeUrlForDisplay(url)}`,
+        { signal },
+      );
+    },
+    fetchTileBytes: async (url, signal) => {
+      const response = await fetchWithRetry(url, 'tile', signal);
+      const bytes = await readAtMostBounded(
+        response,
+        maxTileBytes,
+        `3D Tiles tile at ${sanitizeUrlForDisplay(url)}`,
+        { signal },
+      );
+      // An exact-size ArrayBuffer: a pooled or oversized backing buffer would
+      // hand the PNTS decoder trailing bytes that are not part of the tile, and
+      // the decoder reads its header offsets against the buffer length.
+      return bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      ) as ArrayBuffer;
+    },
+  };
+}

--- a/src/io/tiles3d/tilesetUrl.ts
+++ b/src/io/tiles3d/tilesetUrl.ts
@@ -1,0 +1,202 @@
+/**
+ * tilesetUrl.ts — URL hygiene for a remote 3D Tiles entry, and the safe
+ * resolution of the URLs its content names.
+ *
+ * A `tileset.json` is remote input whose CONTENT names more URLs to fetch. That
+ * is the difference between this module and `eptUrls.ts`: an EPT dataset's
+ * hierarchy and tile URLs are DERIVED from the manifest URL by a fixed naming
+ * rule, so nothing the manifest says can redirect a fetch. A tileset instead
+ * carries `content.uri` strings written by whoever authored the document, and a
+ * viewer that resolves them with `new URL(uri, base)` and fetches the result
+ * will happily fetch `https://elsewhere.example/collect?...`, `//evil.example/x`,
+ * a `data:` payload, or `../../../secrets.json`.
+ *
+ * So resolution here is a decision, not a concatenation:
+ *
+ *   scheme      http/https only, which rejects data:, blob:, file:, javascript:
+ *   host        must be the tileset's own origin, which rejects an absolute or
+ *               protocol-relative URI pointing anywhere else
+ *   path        must stay at or below the tileset's own directory, which
+ *               rejects a `../` walk up to a sibling prefix on the same host
+ *   userinfo    rejected, as on every other remote entry in the app
+ *   length      capped, so a pathological URI cannot be assembled at all
+ *
+ * The entry URL itself goes through the shared `validateRemoteCopcUrl`, which
+ * is where the SSRF host block-list (`isBlockedHost`: loopback, RFC 1918,
+ * link-local, CGNAT, unique-local, `.internal` / `.local` suffixes) lives. The
+ * origin check above is what extends that one gate to every derived fetch:
+ * because a content URI can never leave the validated origin, it can never
+ * reach a host the block-list did not already see.
+ *
+ * Pure — no fetch, no DOM.
+ */
+
+import {
+  validateRemoteCopcUrl,
+  isBlockedHost,
+  MAX_REMOTE_COPC_URL_LENGTH,
+} from '../range/RangeSource';
+import { is3dTilesName } from '../sniffFormat';
+
+/** Maximum acceptable length of a tileset URL — same guard as the COPC entry. */
+export const MAX_REMOTE_TILESET_URL_LENGTH = MAX_REMOTE_COPC_URL_LENGTH;
+
+/**
+ * Ceiling for a single `content.uri` string, before resolution.
+ *
+ * Short enough that no legitimate relative path comes near it, and long enough
+ * that the check never fires on a real dataset. The RESOLVED URL is checked
+ * against the full URL-length cap separately, because a short URI appended to a
+ * long base can still exceed it.
+ */
+export const MAX_CONTENT_URI_LENGTH = 1024;
+
+/**
+ * True when `url` is a 3D Tiles entry point (a `tileset.json`).
+ *
+ * URL-pattern only — no network, no schema fetch — so a router can dispatch on
+ * it synchronously, exactly as {@link import('../../app/openStreaming').isEptUrl}
+ * does for EPT. The filename rule is {@link is3dTilesName}, reused rather than
+ * restated so the sniffer and the router cannot drift apart. A URL `new URL`
+ * cannot parse still gets a raw-string test, so routing stays deterministic
+ * instead of throwing.
+ */
+export function isTilesetUrl(url: string): boolean {
+  try {
+    return is3dTilesName(new URL(url).pathname);
+  } catch {
+    return is3dTilesName(url);
+  }
+}
+
+/** The result shape every validator in this module returns. */
+export type UrlCheck = { ok: true; url: string } | { ok: false; reason: string };
+
+/**
+ * Validate a remote 3D Tiles entry URL.
+ *
+ * Layers on `validateRemoteCopcUrl` — http/https only, no userinfo, length cap,
+ * and the shared `isBlockedHost` SSRF barrier — with the 3D Tiles requirement
+ * that the path name the canonical `tileset.json` entrypoint. Returns the
+ * original URL on success so callers fetch the string that passed the gate.
+ */
+export function validateRemoteTilesetUrl(raw: string): UrlCheck {
+  const base = validateRemoteCopcUrl(raw);
+  if (!base.ok) return base;
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    // validateRemoteCopcUrl already proved this parses; guard rather than assert.
+    return { ok: false, reason: 'URL is not parseable.' };
+  }
+  if (!is3dTilesName(u.pathname)) {
+    return {
+      ok: false,
+      reason: 'A 3D Tiles URL must end in /tileset.json (the tileset entrypoint).',
+    };
+  }
+  return { ok: true, url: raw };
+}
+
+/**
+ * The directory containing the entry `tileset.json`, always ending in `/`.
+ *
+ * Query and fragment are dropped: they belong to the manifest request, and
+ * {@link tilesetUrlSearch} carries the auth half of them forward separately.
+ */
+export function tilesetBaseUrl(entryUrl: string): string {
+  const u = new URL(entryUrl);
+  const pathname = u.pathname.replace(/[^/]*$/, '');
+  return `${u.origin}${pathname.endsWith('/') ? pathname : `${pathname}/`}`;
+}
+
+/**
+ * The auth/query string carried on the entry URL, to be re-attached to derived
+ * requests. Mirrors `eptUrlSearch`: a prefix-scoped credential (an Azure SAS, a
+ * CDN `?token=`) authorises the whole directory, and dropping it loads the
+ * tileset and then 403s on the first tile. Returns `''` when there is none.
+ */
+export function tilesetUrlSearch(entryUrl: string): string {
+  try {
+    return new URL(entryUrl).search;
+  } catch {
+    const q = entryUrl.indexOf('?');
+    return q < 0 ? '' : entryUrl.slice(q).split('#')[0]!;
+  }
+}
+
+/**
+ * Resolve one `content.uri` against the tileset's base directory, or refuse it.
+ *
+ * The refusals are the point of the function; see the module comment for what
+ * each one keeps out. `search` is appended only when the URI carries no query
+ * of its own, so an authored `?v=2` is never silently replaced by the entry
+ * credential.
+ */
+export function resolveTilesetContentUrl(
+  baseUrl: string,
+  contentUri: string,
+  search = '',
+): UrlCheck {
+  if (typeof contentUri !== 'string' || contentUri.length === 0) {
+    return { ok: false, reason: 'A tile content URI is empty.' };
+  }
+  if (contentUri.length > MAX_CONTENT_URI_LENGTH) {
+    return {
+      ok: false,
+      reason: `A tile content URI is longer than ${MAX_CONTENT_URI_LENGTH} characters.`,
+    };
+  }
+  let base: URL;
+  try {
+    base = new URL(baseUrl);
+  } catch {
+    return { ok: false, reason: 'The tileset base URL is not parseable.' };
+  }
+  let resolved: URL;
+  try {
+    resolved = new URL(contentUri, base);
+  } catch {
+    return { ok: false, reason: `A tile content URI is not resolvable: ${contentUri}` };
+  }
+  if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
+    return {
+      ok: false,
+      reason: `A tile content URI uses the ${resolved.protocol} scheme; only http and https are fetched.`,
+    };
+  }
+  if (resolved.username !== '' || resolved.password !== '') {
+    return { ok: false, reason: 'A tile content URI carries embedded credentials.' };
+  }
+  // The entry URL passed the SSRF block-list; a content URI that stays on that
+  // origin inherits the result. One that leaves it has never been checked, and
+  // checking it here would still be checking a host the user never chose — so
+  // it is refused outright rather than re-validated.
+  if (resolved.origin !== base.origin) {
+    return {
+      ok: false,
+      reason: `A tile content URI points outside the tileset's own host (${resolved.host}).`,
+    };
+  }
+  // Belt and braces: `origin` equality already implies this, but the block-list
+  // is the guarantee being relied on and it costs one call to state it directly.
+  if (isBlockedHost(resolved.hostname)) {
+    return { ok: false, reason: 'A tile content URI points at a private network address.' };
+  }
+  // `new URL` normalises `..` before this runs, so the comparison is against the
+  // real path the fetch would use rather than the text the document wrote.
+  if (!resolved.pathname.startsWith(base.pathname)) {
+    return {
+      ok: false,
+      reason: `A tile content URI escapes the tileset directory (${resolved.pathname}).`,
+    };
+  }
+  if (resolved.search === '' && search !== '') resolved.search = search;
+  // A short URI on a long base can still assemble past the entry-URL ceiling.
+  const out = resolved.toString();
+  if (out.length > MAX_REMOTE_TILESET_URL_LENGTH) {
+    return { ok: false, reason: 'A resolved tile content URL is too long.' };
+  }
+  return { ok: true, url: out };
+}

--- a/tests/tiles3dTilesetOpen.test.ts
+++ b/tests/tiles3dTilesetOpen.test.ts
@@ -1,0 +1,393 @@
+/**
+ * tiles3dTilesetOpen.test.ts — opening a tileset over a faked transport,
+ * selecting what a view needs, and decoding one tile into root space.
+ *
+ * No network. The transport is a plain object serving a scripted map of URL to
+ * body, which is also how the fetch-count assertions below can say that a
+ * refused tileset caused no tile fetch at all — "never partially mounted" is a
+ * claim about what was NOT requested, so it has to be measured that way.
+ *
+ * The bounded cases are the ones worth the most care. This feature family has
+ * produced allocation defects where a declaration sized the work, so each cap
+ * gets a test that the cap REFUSES rather than truncates, and the caps are the
+ * mutation targets: removing the depth cap must fail a test here, and so must
+ * transposing the column-major transform composition.
+ */
+
+import { describe, expect, test } from 'vitest';
+import {
+  openTileset,
+  selectTileContents,
+  fetchTileContent,
+  MAX_SELECTED_TILES,
+} from '../src/io/tiles3d/tilesetOpen';
+import { DEFAULT_TILESET_MAX_DEPTH } from '../src/io/tiles3d/tileset';
+import type { TilesetTransport } from '../src/io/tiles3d/tilesetTransport';
+import type { ViewCamera } from '../src/io/tiles3d/tilesetTraversal';
+
+const ENTRY = 'https://tiles.example.org/scan/a/tileset.json';
+
+const PNTS_MAGIC = 0x73746e70; // 'pnts', little-endian
+
+/** A minimal PNTS tile: 28-byte header, feature-table JSON, feature-table binary. */
+function makePnts(
+  points: readonly (readonly [number, number, number])[],
+  rtc?: readonly [number, number, number],
+): ArrayBuffer {
+  const ft: Record<string, unknown> = {
+    POINTS_LENGTH: points.length,
+    POSITION: { byteOffset: 0 },
+  };
+  if (rtc) ft.RTC_CENTER = rtc;
+  let json = JSON.stringify(ft);
+  while (json.length % 8 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const binBytes = points.length * 3 * 4;
+  const total = 28 + jsonBytes.length + binBytes;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, PNTS_MAGIC, true);
+  view.setUint32(4, 1, true);
+  view.setUint32(8, total, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, binBytes, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buf, 28, jsonBytes.length).set(jsonBytes);
+  const binStart = 28 + jsonBytes.length;
+  let k = 0;
+  for (const p of points) for (const c of p) view.setFloat32(binStart + k++ * 4, c, true);
+  return buf;
+}
+
+/** A transport over an in-memory URL map, counting what it was asked for. */
+function fakeTransport(
+  json: Record<string, string>,
+  tiles: Record<string, ArrayBuffer> = {},
+): TilesetTransport & { readonly requests: string[] } {
+  const requests: string[] = [];
+  return {
+    requests,
+    fetchTilesetJson: async (url) => {
+      requests.push(url);
+      const body = json[url];
+      if (body === undefined) throw new Error(`3D Tiles tileset fetch failed (404) for ${url}`);
+      return body;
+    },
+    fetchTileBytes: async (url) => {
+      requests.push(url);
+      const body = tiles[url];
+      if (body === undefined) throw new Error(`3D Tiles tile fetch failed (404) for ${url}`);
+      return body;
+    },
+  };
+}
+
+/** A box tile with only the fields the parser requires. */
+function rawTile(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    boundingVolume: { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] },
+    geometricError: 100,
+    ...over,
+  };
+}
+
+function doc(root: Record<string, unknown>): string {
+  return JSON.stringify({ asset: { version: '1.1' }, geometricError: 100, root });
+}
+
+/** Close enough that a 100 m geometric error refines. */
+const nearCamera: ViewCamera = {
+  kind: 'perspective',
+  positionEcef: [30, 0, 0],
+  viewportHeightPx: 1000,
+  verticalFov: Math.PI / 3,
+};
+
+/** Far enough that the same error does not. */
+const farCamera: ViewCamera = {
+  kind: 'perspective',
+  positionEcef: [100_000, 0, 0],
+  viewportHeightPx: 1000,
+  verticalFov: Math.PI / 3,
+};
+
+describe('openTileset', () => {
+  test('opens a valid tileset and derives its base and query', async () => {
+    const t = fakeTransport({
+      [`${ENTRY}?sig=xyz`]: doc(rawTile({ refine: 'REPLACE', content: { uri: '0.pnts' } })),
+    });
+    const opened = await openTileset(`${ENTRY}?sig=xyz`, t);
+    expect(opened.baseUrl).toBe('https://tiles.example.org/scan/a/');
+    expect(opened.search).toBe('?sig=xyz');
+    expect(opened.tileset.root.contentUri).toBe('0.pnts');
+  });
+
+  test('refuses a URL that fails the entry gate without fetching anything', async () => {
+    const t = fakeTransport({});
+    await expect(openTileset('http://127.0.0.1/tileset.json', t)).rejects.toThrow(/private network/i);
+    await expect(openTileset('https://h.example/scan/ept.json', t)).rejects.toThrow(/tileset\.json/);
+    expect(t.requests).toEqual([]);
+  });
+
+  test('refuses a malformed document and mounts none of it', async () => {
+    const cases: Record<string, RegExp> = {
+      'not json at all': /./,
+      '{"geometricError":1,"root":{}}': /asset\.version/,
+      '{"asset":{"version":"1.1"},"root":{}}': /finite geometricError/,
+      '{"asset":{"version":"1.1"},"geometricError":1}': /no root tile/,
+      [doc(rawTile({}))]: /must declare refine/,
+      [doc(rawTile({ refine: 'SOMETIMES' }))]: /not ADD or REPLACE/,
+      [doc(rawTile({ refine: 'REPLACE', boundingVolume: { box: [1, 2, 3] } }))]: /12 components/,
+      [doc(rawTile({ refine: 'REPLACE', implicitTiling: {} }))]: /implicit tiling/,
+      [doc(rawTile({ refine: 'REPLACE', content: { uri: 42 } }))]: /non-empty string/,
+    };
+    for (const [body, pattern] of Object.entries(cases)) {
+      const t = fakeTransport({ [ENTRY]: body });
+      await expect(openTileset(ENTRY, t), body.slice(0, 40)).rejects.toThrow(pattern);
+    }
+  });
+
+  test('an abort during the open leaves nothing opened', async () => {
+    const controller = new AbortController();
+    const t: TilesetTransport = {
+      fetchTilesetJson: async () => {
+        // The cancel lands after the body arrives but before anything is parsed:
+        // the window where a careless open would already hold a tileset.
+        controller.abort();
+        return doc(rawTile({ refine: 'REPLACE', content: { uri: '0.pnts' } }));
+      },
+      fetchTileBytes: async () => {
+        throw new Error('no tile should be read on an aborted open');
+      },
+    };
+    let opened: unknown = 'untouched';
+    await expect(
+      openTileset(ENTRY, t, controller.signal).then((r) => {
+        opened = r;
+      }),
+    ).rejects.toThrow(/abort/i);
+    expect(opened).toBe('untouched');
+  });
+});
+
+describe('traversal is capped, and refuses rather than truncating', () => {
+  /** A chain of `depth` nested tiles, each with a large error so every level refines. */
+  function chain(depth: number): string {
+    let node = rawTile({ geometricError: 1000, content: { uri: `${depth}.pnts` } });
+    for (let i = depth - 1; i >= 0; i--) {
+      node = rawTile({ geometricError: 1000, content: { uri: `${i}.pnts` }, children: [node] });
+    }
+    return doc({ ...node, refine: 'REPLACE' });
+  }
+
+  test('a tileset deeper than the cap is refused at parse, not partly parsed', async () => {
+    const t = fakeTransport({ [ENTRY]: chain(DEFAULT_TILESET_MAX_DEPTH + 1) });
+    await expect(openTileset(ENTRY, t)).rejects.toThrow(
+      new RegExp(`deeper than ${DEFAULT_TILESET_MAX_DEPTH} levels`),
+    );
+  });
+
+  test('a tileset exactly at the cap still opens', async () => {
+    const t = fakeTransport({ [ENTRY]: chain(DEFAULT_TILESET_MAX_DEPTH) });
+    await expect(openTileset(ENTRY, t)).resolves.toBeTruthy();
+  });
+
+  test('a lower explicit depth cap is honoured', async () => {
+    const t = fakeTransport({ [ENTRY]: chain(6) });
+    await expect(openTileset(ENTRY, t, undefined, { maxDepth: 4 })).rejects.toThrow(
+      /deeper than 4 levels/,
+    );
+    await expect(openTileset(ENTRY, t, undefined, { maxDepth: 8 })).resolves.toBeTruthy();
+  });
+
+  test('a tile count past the cap is refused', async () => {
+    const children = Array.from({ length: 40 }, (_, i) =>
+      rawTile({ geometricError: 1, content: { uri: `${i}.pnts` } }),
+    );
+    const t = fakeTransport({ [ENTRY]: doc(rawTile({ refine: 'REPLACE', children })) });
+    await expect(openTileset(ENTRY, t, undefined, { maxTiles: 20 })).rejects.toThrow(
+      /more than 20 tiles/,
+    );
+  });
+
+  test('a selection past the ceiling is refused, not silently shortened', async () => {
+    // Wide rather than deep: the depth cap says nothing about a root with a
+    // very large number of children, and one camera position reaches them all.
+    const children = Array.from({ length: 12 }, (_, i) =>
+      rawTile({ geometricError: 1, content: { uri: `${i}.pnts` } }),
+    );
+    const t = fakeTransport({
+      [ENTRY]: doc(rawTile({ refine: 'ADD', geometricError: 1000, children })),
+    });
+    const opened = await openTileset(ENTRY, t);
+    expect(() =>
+      selectTileContents(opened, nearCamera, { maxScreenSpaceErrorPx: 1, maxSelectedTiles: 5 }),
+    ).toThrow(/past the 5-tile ceiling/);
+    // The default ceiling is a real number, not Infinity dressed up as one.
+    expect(MAX_SELECTED_TILES).toBeLessThan(100_000);
+  });
+});
+
+describe('selectTileContents', () => {
+  const twoLevel = doc(
+    rawTile({
+      refine: 'REPLACE',
+      geometricError: 1000,
+      content: { uri: 'root.pnts' },
+      children: [
+        rawTile({ geometricError: 1, content: { uri: 'child.pnts' } }),
+      ],
+    }),
+  );
+
+  test('a distant view keeps the root and resolves its content URL', async () => {
+    const opened = await openTileset(ENTRY, fakeTransport({ [ENTRY]: twoLevel }));
+    const sel = selectTileContents(opened, farCamera, { maxScreenSpaceErrorPx: 16 });
+    expect(sel.contents.map((c) => c.url)).toEqual([
+      'https://tiles.example.org/scan/a/root.pnts',
+    ]);
+  });
+
+  test('a close view refines to the child, and REPLACE drops the parent', async () => {
+    const opened = await openTileset(ENTRY, fakeTransport({ [ENTRY]: twoLevel }));
+    const sel = selectTileContents(opened, nearCamera, { maxScreenSpaceErrorPx: 1 });
+    expect(sel.contents.map((c) => c.url)).toEqual([
+      'https://tiles.example.org/scan/a/child.pnts',
+    ]);
+  });
+
+  test('a tileset naming a URL outside its own base is refused', async () => {
+    const body = doc(
+      rawTile({ refine: 'REPLACE', content: { uri: 'https://evil.example/x.pnts' } }),
+    );
+    const t = fakeTransport({ [ENTRY]: body });
+    const opened = await openTileset(ENTRY, t);
+    expect(() => selectTileContents(opened, farCamera, { maxScreenSpaceErrorPx: 16 })).toThrow(
+      /outside the tileset's own host/,
+    );
+    // Refused before any fetch: only the tileset.json was ever requested.
+    expect(t.requests).toEqual([ENTRY]);
+  });
+
+  test('a `..` escape on the tileset’s own host is refused too', async () => {
+    const body = doc(rawTile({ refine: 'REPLACE', content: { uri: '../../etc/x.pnts' } }));
+    const opened = await openTileset(ENTRY, fakeTransport({ [ENTRY]: body }));
+    expect(() => selectTileContents(opened, farCamera, { maxScreenSpaceErrorPx: 16 })).toThrow(
+      /escapes the tileset directory/,
+    );
+  });
+
+  test('an external tileset is reported rather than followed', async () => {
+    const body = doc(rawTile({ refine: 'REPLACE', content: { uri: 'sub/tileset.json' } }));
+    const t = fakeTransport({ [ENTRY]: body });
+    const opened = await openTileset(ENTRY, t);
+    const sel = selectTileContents(opened, farCamera, { maxScreenSpaceErrorPx: 16 });
+    expect(sel.contents).toEqual([]);
+    expect(sel.externalTilesets.map((c) => c.url)).toEqual([
+      'https://tiles.example.org/scan/a/sub/tileset.json',
+    ]);
+    expect(t.requests).toEqual([ENTRY]);
+  });
+
+  test('a content type this viewer cannot decode is refused, not fetched', async () => {
+    const body = doc(rawTile({ refine: 'REPLACE', content: { uri: 'model.b3dm' } }));
+    const opened = await openTileset(ENTRY, fakeTransport({ [ENTRY]: body }));
+    expect(() => selectTileContents(opened, farCamera, { maxScreenSpaceErrorPx: 16 })).toThrow(
+      /not a \.pnts tile/,
+    );
+  });
+
+  test('a selected tile with no content of its own is counted, not invented', async () => {
+    const body = doc(rawTile({ refine: 'REPLACE' }));
+    const opened = await openTileset(ENTRY, fakeTransport({ [ENTRY]: body }));
+    const sel = selectTileContents(opened, farCamera, { maxScreenSpaceErrorPx: 16 });
+    expect(sel.contents).toEqual([]);
+    expect(sel.emptyTiles).toBe(1);
+  });
+});
+
+describe('fetchTileContent places a tile in root space', () => {
+  /**
+   * A transform that is asymmetric in every way that matters: it is not its own
+   * transpose, and its translation lives in the last COLUMN, which is where a
+   * column-major 4x4 keeps it (`m[col * 4 + row]`, so indices 12..14). A
+   * row-major read of the same sixteen numbers picks up 3, 7, 11 instead, and a
+   * transposed composition mixes the rotation into the wrong axes — both
+   * produce a scene that is plausibly placed and wrong.
+   */
+  const TRANSFORM = [
+    0, 1, 0, 0,
+    -1, 0, 0, 0,
+    0, 0, 2, 0,
+    100, 200, 300, 1,
+  ];
+
+  test('applies RTC_CENTER, then the cumulative transform, in float64', async () => {
+    const body = doc(
+      rawTile({ refine: 'REPLACE', transform: TRANSFORM, content: { uri: '0.pnts' } }),
+    );
+    const url = 'https://tiles.example.org/scan/a/0.pnts';
+    const t = fakeTransform(body, url);
+    const opened = await openTileset(ENTRY, t);
+    const sel = selectTileContents(opened, farCamera, { maxScreenSpaceErrorPx: 16 });
+    const placed = await fetchTileContent(sel.contents[0]!, t);
+
+    // Local (1, 2, 3) + RTC (10, 20, 30) = (11, 22, 33). Through the transform:
+    //   x' = 0*11 + -1*22 + 0*33 + 100 =  78
+    //   y' = 1*11 +  0*22 + 0*33 + 200 = 211
+    //   z' = 0*11 +  0*22 + 2*33 + 300 = 366
+    expect(placed.pointCount).toBe(2);
+    expect(placed.positions).toBeInstanceOf(Float64Array);
+    expect([...placed.positions.slice(0, 3)]).toEqual([78, 211, 366]);
+    // Second point local (4, 5, 6) + RTC = (14, 25, 36):
+    //   x' = -25 + 100 = 75, y' = 14 + 200 = 214, z' = 72 + 300 = 372
+    expect([...placed.positions.slice(3, 6)]).toEqual([75, 214, 372]);
+  });
+
+  test('composes a nested transform parent-first, not child-first', async () => {
+    // The child rotates, the parent translates. Parent-then-child places the
+    // rotated point at the parent's offset; the reverse order rotates the
+    // offset itself and lands somewhere else entirely.
+    const child = rawTile({
+      geometricError: 1,
+      transform: [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+      content: { uri: 'c.pnts' },
+    });
+    const body = doc(
+      rawTile({
+        refine: 'REPLACE',
+        geometricError: 1000,
+        transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1000, 0, 0, 1],
+        children: [child],
+      }),
+    );
+    const url = 'https://tiles.example.org/scan/a/c.pnts';
+    const t = fakeTransport({ [ENTRY]: body }, { [url]: makePnts([[1, 0, 0], [0, 1, 0]]) });
+    const opened = await openTileset(ENTRY, t);
+    const sel = selectTileContents(opened, nearCamera, { maxScreenSpaceErrorPx: 1 });
+    const placed = await fetchTileContent(sel.contents[0]!, t);
+    // (1,0,0) rotated to (0,1,0), then translated by the parent: (1000, 1, 0).
+    expect([...placed.positions.slice(0, 3)]).toEqual([1000, 1, 0]);
+    // (0,1,0) rotated to (-1,0,0), then translated: (999, 0, 0).
+    expect([...placed.positions.slice(3, 6)]).toEqual([999, 0, 0]);
+  });
+
+  test('refuses to decode an external tileset as a point tile', async () => {
+    const body = doc(rawTile({ refine: 'REPLACE', content: { uri: 'sub/tileset.json' } }));
+    const t = fakeTransport({ [ENTRY]: body });
+    const opened = await openTileset(ENTRY, t);
+    const sel = selectTileContents(opened, farCamera, { maxScreenSpaceErrorPx: 16 });
+    await expect(fetchTileContent(sel.externalTilesets[0]!, t)).rejects.toThrow(
+      /external tileset, not a point tile/,
+    );
+  });
+
+  /** The transform case's transport: one tileset document and one two-point tile. */
+  function fakeTransform(body: string, url: string): ReturnType<typeof fakeTransport> {
+    return fakeTransport(
+      { [ENTRY]: body },
+      { [url]: makePnts([[1, 2, 3], [4, 5, 6]], [10, 20, 30]) },
+    );
+  }
+});

--- a/tests/tiles3dTilesetTransport.test.ts
+++ b/tests/tiles3dTilesetTransport.test.ts
@@ -1,0 +1,153 @@
+/**
+ * tiles3dTilesetTransport.test.ts — the hardened 3D Tiles remote fetch.
+ *
+ * The injected `fetchImpl`, `sleep` and `random` make every retry, timeout and
+ * abort path deterministic with no network, the same way the EPT transport's
+ * tests do. What is asserted is mostly what the transport REFUSES: an oversized
+ * body, a redirect, a permanent status it must not retry, and a cancel that
+ * must stay distinguishable from a deadline.
+ */
+
+import { describe, expect, test } from 'vitest';
+import {
+  createTilesetTransport,
+  TilesetTimeoutError,
+} from '../src/io/tiles3d/tilesetTransport';
+
+/** A fetch returning a scripted sequence of responses. */
+function scriptedFetch(
+  steps: Array<{ status: number; body?: string; headers?: Record<string, string> } | { throws: Error }>,
+): { fn: typeof fetch; calls: number; init: RequestInit[] } {
+  let i = 0;
+  const handle = { calls: 0, init: [] as RequestInit[], fn: undefined as unknown as typeof fetch };
+  handle.fn = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    handle.calls++;
+    if (init) handle.init.push(init);
+    const step = steps[Math.min(i++, steps.length - 1)]!;
+    if ('throws' in step) throw step.throws;
+    return new Response(step.body ?? '', {
+      status: step.status,
+      statusText: step.status === 200 ? 'OK' : 'Err',
+      headers: step.headers,
+    });
+  }) as typeof fetch;
+  return handle;
+}
+
+/** A fetch that answers only when the signal it was handed aborts. */
+function neverAnsweringFetch(): { fn: typeof fetch; calls: number } {
+  const handle = { calls: 0, fn: undefined as unknown as typeof fetch };
+  handle.fn = ((_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    handle.calls++;
+    return new Promise<Response>((_resolve, reject) => {
+      const sig = init?.signal;
+      if (!sig) return;
+      const onAbort = (): void => reject(sig.reason ?? new DOMException('Aborted', 'AbortError'));
+      if (sig.aborted) onAbort();
+      else sig.addEventListener('abort', onAbort, { once: true });
+    });
+  }) as typeof fetch;
+  return handle;
+}
+
+const NOW = () => Promise.resolve();
+const URL_JSON = 'https://tiles.example.org/scan/a/tileset.json';
+
+describe('createTilesetTransport — success and retry', () => {
+  test('returns the tileset body on a first-attempt 200', async () => {
+    const h = scriptedFetch([{ status: 200, body: '{"asset":{}}' }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW });
+    await expect(t.fetchTilesetJson(URL_JSON)).resolves.toBe('{"asset":{}}');
+    expect(h.calls).toBe(1);
+  });
+
+  test('refuses to follow a redirect on every request', async () => {
+    const h = scriptedFetch([{ status: 200, body: '{}' }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW });
+    await t.fetchTilesetJson(URL_JSON);
+    expect(h.init[0]!.redirect).toBe('error');
+  });
+
+  test('retries a transient status and then succeeds', async () => {
+    const h = scriptedFetch([{ status: 503 }, { status: 200, body: 'ok' }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW, random: () => 0.5 });
+    await expect(t.fetchTilesetJson(URL_JSON)).resolves.toBe('ok');
+    expect(h.calls).toBe(2);
+  });
+
+  test('does not retry a permanent 404', async () => {
+    const h = scriptedFetch([{ status: 404 }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW });
+    await expect(t.fetchTilesetJson(URL_JSON)).rejects.toThrow(/3D Tiles tileset fetch failed \(404/);
+    expect(h.calls).toBe(1);
+  });
+
+  test('gives up after the retry budget', async () => {
+    const h = scriptedFetch([{ status: 500 }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW, maxRetries: 2, random: () => 0.5 });
+    await expect(t.fetchTilesetJson(URL_JSON)).rejects.toThrow(/500/);
+    expect(h.calls).toBe(3);
+  });
+});
+
+describe('createTilesetTransport — bounds and cancellation', () => {
+  test('refuses a tileset body past the ceiling', async () => {
+    const h = scriptedFetch([{ status: 200, body: 'x'.repeat(4096) }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW, maxTilesetJsonBytes: 64 });
+    await expect(t.fetchTilesetJson(URL_JSON)).rejects.toThrow(/3D Tiles tileset/);
+  });
+
+  test('refuses a tile body past the ceiling', async () => {
+    const h = scriptedFetch([{ status: 200, body: 'x'.repeat(4096) }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW, maxTileBytes: 64 });
+    await expect(t.fetchTileBytes('https://tiles.example.org/scan/a/0.pnts')).rejects.toThrow(
+      /3D Tiles tile/,
+    );
+  });
+
+  test('a stalled request surfaces as a timeout, not as a cancel', async () => {
+    const h = neverAnsweringFetch();
+    const t = createTilesetTransport({
+      fetchImpl: h.fn,
+      sleep: NOW,
+      maxRetries: 0,
+      requestTimeoutMs: 5,
+    });
+    const err = await t.fetchTilesetJson(URL_JSON).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(TilesetTimeoutError);
+    expect((err as TilesetTimeoutError).code).toBe('timeout');
+    expect((err as Error).name).not.toBe('AbortError');
+  });
+
+  test('an outer cancel propagates as an abort and stops the retry loop', async () => {
+    const h = neverAnsweringFetch();
+    const controller = new AbortController();
+    const t = createTilesetTransport({
+      fetchImpl: h.fn,
+      sleep: NOW,
+      maxRetries: 3,
+      requestTimeoutMs: 10_000,
+    });
+    const promise = t.fetchTilesetJson(URL_JSON, controller.signal);
+    controller.abort();
+    const err = await promise.catch((e: unknown) => e);
+    expect((err as Error).name).toBe('AbortError');
+    expect(h.calls).toBe(1);
+  });
+
+  test('an already-aborted signal issues no request at all', async () => {
+    const h = scriptedFetch([{ status: 200, body: 'ok' }]);
+    const controller = new AbortController();
+    controller.abort();
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW });
+    await expect(t.fetchTilesetJson(URL_JSON, controller.signal)).rejects.toThrow();
+    expect(h.calls).toBe(0);
+  });
+
+  test('a returned tile buffer is exactly the bytes, with no trailing slack', async () => {
+    const h = scriptedFetch([{ status: 200, body: 'abcd' }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW });
+    const buf = await t.fetchTileBytes('https://tiles.example.org/scan/a/0.pnts');
+    expect(buf.byteLength).toBe(4);
+  });
+});

--- a/tests/tiles3dTilesetUrl.test.ts
+++ b/tests/tiles3dTilesetUrl.test.ts
@@ -1,0 +1,147 @@
+/**
+ * tiles3dTilesetUrl.test.ts — the URL guard for a remote 3D Tiles entry and
+ * for the content URIs the entry document names.
+ *
+ * A tileset.json is remote input whose CONTENT names more URLs to fetch, which
+ * is the whole reason this module exists separately from `eptUrls.ts`. So the
+ * cases below are mostly hostile documents rather than malformed ones: a
+ * content URI that leaves the host, one that walks up out of the tileset's own
+ * directory, one that swaps the scheme for `data:`, and one that hides the host
+ * change behind a protocol-relative form.
+ */
+
+import { describe, expect, test } from 'vitest';
+import {
+  isTilesetUrl,
+  resolveTilesetContentUrl,
+  tilesetBaseUrl,
+  tilesetUrlSearch,
+  validateRemoteTilesetUrl,
+  MAX_CONTENT_URI_LENGTH,
+} from '../src/io/tiles3d/tilesetUrl';
+
+const BASE = 'https://tiles.example.org/scan/a/';
+
+describe('isTilesetUrl', () => {
+  test('recognises a tileset entry, with or without a query', () => {
+    expect(isTilesetUrl('https://h.example/x/tileset.json')).toBe(true);
+    expect(isTilesetUrl('https://h.example/x/tileset.json?token=abc')).toBe(true);
+  });
+
+  test('does not claim an ept.json or a bare directory', () => {
+    expect(isTilesetUrl('https://h.example/x/ept.json')).toBe(false);
+    expect(isTilesetUrl('https://h.example/x/')).toBe(false);
+    expect(isTilesetUrl('https://h.example/x/subtileset.json')).toBe(false);
+  });
+});
+
+describe('validateRemoteTilesetUrl', () => {
+  test('accepts a plain https tileset URL and returns it unchanged', () => {
+    const r = validateRemoteTilesetUrl('https://tiles.example.org/scan/a/tileset.json');
+    expect(r).toEqual({ ok: true, url: 'https://tiles.example.org/scan/a/tileset.json' });
+  });
+
+  test('refuses a non-tileset path', () => {
+    const r = validateRemoteTilesetUrl('https://tiles.example.org/scan/a/ept.json');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/tileset\.json/);
+  });
+
+  test('refuses a private-network host through the shared SSRF block-list', () => {
+    for (const host of ['localhost', '127.0.0.1', '10.0.0.5', '169.254.169.254', 'svc.internal']) {
+      const r = validateRemoteTilesetUrl(`http://${host}/tileset.json`);
+      expect(r.ok, host).toBe(false);
+    }
+  });
+
+  test('refuses a non-http scheme and embedded credentials', () => {
+    expect(validateRemoteTilesetUrl('file:///tmp/tileset.json').ok).toBe(false);
+    expect(validateRemoteTilesetUrl('https://u:p@h.example/tileset.json').ok).toBe(false);
+  });
+});
+
+describe('tilesetBaseUrl / tilesetUrlSearch', () => {
+  test('the base is the entry directory, query and fragment dropped', () => {
+    expect(tilesetBaseUrl('https://h.example/a/b/tileset.json?t=1#f')).toBe(
+      'https://h.example/a/b/',
+    );
+  });
+
+  test('the query is carried separately so a signed dataset keeps its credential', () => {
+    expect(tilesetUrlSearch('https://h.example/a/tileset.json?sig=xyz')).toBe('?sig=xyz');
+    expect(tilesetUrlSearch('https://h.example/a/tileset.json')).toBe('');
+  });
+});
+
+describe('resolveTilesetContentUrl — what it accepts', () => {
+  test('a relative URI resolves under the tileset directory', () => {
+    expect(resolveTilesetContentUrl(BASE, 'tiles/0.pnts')).toEqual({
+      ok: true,
+      url: 'https://tiles.example.org/scan/a/tiles/0.pnts',
+    });
+  });
+
+  test('the entry query rides derived requests', () => {
+    const r = resolveTilesetContentUrl(BASE, '0.pnts', '?sig=xyz');
+    expect(r).toEqual({ ok: true, url: 'https://tiles.example.org/scan/a/0.pnts?sig=xyz' });
+  });
+
+  test("an authored query is not replaced by the entry's", () => {
+    const r = resolveTilesetContentUrl(BASE, '0.pnts?v=2', '?sig=xyz');
+    expect(r).toEqual({ ok: true, url: 'https://tiles.example.org/scan/a/0.pnts?v=2' });
+  });
+
+  test('a same-directory absolute URL is accepted', () => {
+    const r = resolveTilesetContentUrl(BASE, 'https://tiles.example.org/scan/a/deep/0.pnts');
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('resolveTilesetContentUrl — what it refuses', () => {
+  test('an absolute URI naming another host', () => {
+    const r = resolveTilesetContentUrl(BASE, 'https://evil.example/collect.pnts');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/outside the tileset's own host/);
+  });
+
+  test('a protocol-relative URI, which hides the host change', () => {
+    const r = resolveTilesetContentUrl(BASE, '//evil.example/x.pnts');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/outside the tileset's own host/);
+  });
+
+  test('a private-network host reached from a public tileset', () => {
+    const r = resolveTilesetContentUrl(BASE, 'http://169.254.169.254/latest/meta-data');
+    expect(r.ok).toBe(false);
+  });
+
+  test('a `..` walk out of the tileset directory, on the same host', () => {
+    const r = resolveTilesetContentUrl(BASE, '../../secrets/0.pnts');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/escapes the tileset directory/);
+  });
+
+  test('a root-relative URI landing on a sibling prefix', () => {
+    const r = resolveTilesetContentUrl(BASE, '/scan/b/0.pnts');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/escapes the tileset directory/);
+  });
+
+  test('a non-http scheme', () => {
+    for (const uri of ['data:application/octet-stream;base64,AAAA', 'javascript:alert(1)', 'file:///etc/passwd']) {
+      expect(resolveTilesetContentUrl(BASE, uri).ok, uri).toBe(false);
+    }
+  });
+
+  test('embedded credentials on the content URI', () => {
+    const r = resolveTilesetContentUrl(BASE, 'https://u:p@tiles.example.org/scan/a/0.pnts');
+    expect(r.ok).toBe(false);
+  });
+
+  test('an empty URI and one past the length ceiling', () => {
+    expect(resolveTilesetContentUrl(BASE, '').ok).toBe(false);
+    expect(resolveTilesetContentUrl(BASE, `${'a'.repeat(MAX_CONTENT_URI_LENGTH + 1)}.pnts`).ok).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
`parseTileset` recursed over a tileset document with no depth or tile bound, and `walkTilePlacements` materialises every placement regardless of the traversal's own depth option. Nothing fed it remote input, so it was latent rather than exploitable. This adds the remote path, so the bounds land first: depth 24, 200,000 tiles, refused at parse rather than truncated.

A tileset URL is validated by the same barrier the EPT path uses, including its host block list. Then every content URI is re-gated, which EPT never has to do: EPT derives each hierarchy and tile URL from the validated base by a fixed naming rule, so nothing inside `ept.json` can redirect a fetch. A tileset's content URIs are authored remote input. Each resolved URL must be http or https, share the tileset's origin, and resolve under its base path, so a sibling-prefix walk or a host swap is refused.

External tileset contents are reported rather than followed. Following one is a second recursion over remote input that would let the tile budget be escaped a document at a time.

The transport is separate from the EPT one, whose read labels are embedded in messages an EPT-specific classifier pattern matches. The shared bounded readers are reused directly.

Traversal, screen-space error and transform composition now have a caller. Mounting as a layer does not: the streaming source interface is shaped around octree node records and LAS decode metadata, which a tile content tree has none of. Nothing claims tileset support, because nothing mounts one.
