### PR TITLE
Describe the acquisition grid and what it does not establish

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ If you cannot find something below, the directory listing is still the full pict
 | --- | --- |
 | [terrain-intelligence.md](terrain-intelligence.md) | The confidence-aware DTM and contour pipeline under `src/terrain/`. |
 | [contour-studio.md](contour-studio.md) | Turning an analysed scan into a contour deliverable, and the honesty model behind it. |
+| [acquisition-grid.md](acquisition-grid.md) | The scanner grid kept beside the cloud, what each cell state means, and when the link between them is broken. |
 | [validation/terrain-validation-matrix.md](validation/terrain-validation-matrix.md) | Which terrain products are validated, against what, to what tolerance. |
 
 ## Performance and limits

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -99,6 +99,29 @@ The grade is honest about gaps. A scan that only measured part of the ground wil
 
 ---
 
+## Inspect the scanner grid
+
+A terrestrial scan does not arrive as a bare cloud. It arrives as a grid: for
+each row and column the instrument fired along a direction and recorded a
+return, or recorded that nothing came back. When a scan carries that grid, a
+**Range Frame QA** entry appears in the Analyse panel.
+
+The workbench shows one setup at a time, coloured by range or by validity, with
+the counts beside it. Click a cell and the viewer highlights the point it
+produced. Inspect a point and the workbench highlights the cell it came from.
+
+A cell with no return is not a gap in the data. It means the scanner looked that
+way and nothing came back, which is worth knowing when a surface has holes in
+it. The viewer will not tell you why, because the file does not say: dark
+asphalt, glass and open sky all look the same from here.
+
+If the scan was reduced to fit in memory, the grid survives and the link to
+individual points does not. The workbench says so rather than pointing at the
+nearest point, and an export made from that scan records where the link was
+lost.
+
+---
+
 ## Compare two scans
 
 Open a second scan of the same place — a "before" and an "after" — and the viewer offers a comparison. It lines the two up, differences their surfaces, and reports the cut and fill volumes, with a noise floor so small changes below the survey's own precision aren't reported as real movement. You can export the difference grid for use elsewhere.

--- a/docs/acquisition-grid.md
+++ b/docs/acquisition-grid.md
@@ -1,0 +1,147 @@
+# Acquisition grid
+
+A scanner does not measure a cloud of points. It sweeps a grid: for each row and
+column it fires along a direction and records what came back, or records that
+nothing did. Flattening that into a list of coordinates throws away the row, the
+column, and every cell the instrument interrogated without result.
+
+OpenLiDARViewer keeps the grid alongside the cloud, and says plainly when the
+connection between the two has been broken.
+
+## What is preserved
+
+For PTX, organized PCD and structured E57, a loaded scan carries one frame per
+scanner setup. Each frame holds:
+
+- the grid shape, as the source declared it and as the records back it up
+- a state for every cell
+- the geometric range of each valid return, in the scanner's own coordinates
+- the acquisition pose of that setup
+- the display record each cell produced, where that can be proven
+
+A block or scan is its own setup. Two setups that looked at different directions
+keep separate grids and separate poses, because merging them would produce a
+raster that means nothing.
+
+## Cell states
+
+| State | What the source said |
+|---|---|
+| Valid return | A usable return for this cell |
+| No return | The scanner interrogated this direction and received nothing |
+| Source invalid | A record exists and the source declares it unusable |
+| Not decoded | A record exists and this session did not deliver it |
+| Source record missing | The grid declares this cell and the file supplied no record |
+
+These are five states rather than one empty value because they carry different
+weight. A no return is evidence about the scene: the instrument looked and
+nothing came back. A not-decoded cell says nothing about the scene at all, only
+about how much of the file this session read. Reporting the second as the first
+would let a sampling decision read as a property of the surface.
+
+PTX writes `0 0 0` for a cell with no return, and that is the only format here
+with an explicit no-return marker. A PCD record that is not finite is invalid,
+not a no return, because nothing in PCD says the sensor looked and found
+nothing.
+
+## Range
+
+Geometric range is the distance from the setup to the return, computed in the
+scanner's own coordinates before registration and before the viewer recentres
+anything. Taking it afterwards would subtract two large world coordinates and
+lose most of the precision to cancellation, and it would make the value depend
+on the registration being right.
+
+Where E57 declares a spherical range, that is kept separately as the source
+range. The two are different quantities and neither is called a measured range,
+because the file records a number and the viewer does not know how it was
+obtained.
+
+A cell with no return has no range. It does not have a range of zero.
+
+## Linkage
+
+A grid cell links to a displayed point because the loader recorded which point
+that cell produced. Never because a coordinate happened to be nearby.
+
+Three states describe how much of that survives:
+
+- **Exact.** Every valid cell names the record it produced.
+- **Partial.** Some records were not decoded this session. The ones that were
+  still link exactly.
+- **Unavailable.** The identity is gone, and the reason says which step spent
+  it: voxel centroids, a source topology that could not be read as a grid, or an
+  identity that was never established.
+
+Reduction destroys linkage and leaves the grid intact. A cloud reduced to voxel
+centroids still has its grid, its cell states and its ranges, all still true of
+the source, and the workbench still opens. What it cannot do is name the return
+behind a centroid, because a centroid is not a return. It says so rather than
+offering the nearest point.
+
+Where a scan is opened and then exported, the step that spent the identity is
+recorded in the processing manifest, so a reviewer holding only the export can
+see it without the session that produced it.
+
+## The range frame workbench
+
+A launcher appears in the Analyse panel when the loaded scan carries a grid. The
+workbench shows the grid in two modes, range and validity, alongside the counts,
+the range statistics and a per-band coverage report. It loads only when opened,
+so a session that never touches structured data pays almost nothing for it.
+
+Clicking a cell highlights the display point it produced. Inspecting a display
+point highlights the cell it came from. Where a cell cannot name a point, the
+workbench says which of the three linkage states applies and why.
+
+Coverage is reported per band across each axis rather than as one number,
+because sampling selects records in file order while the grid is
+two-dimensional, so the decoded fraction is rarely uniform across it. A band
+report shows where the display under-represents the source.
+
+## What this does not establish
+
+The grid is a record of what the instrument addressed. It is not a measurement
+of the scene.
+
+A no return can be dark asphalt, glass, water, or a distance past the
+instrument. Nothing here names a cause, and nothing built on it may name one.
+
+Agreement between a source-declared range and a range recomputed from the same
+file's coordinates is a decode check. It says the two columns were read
+consistently. It says nothing about how accurately the instrument ranged.
+
+Identity is bookkeeping. That a cell names the record it produced is a fact
+about this decoder rather than about the world, and no external tool holds those
+indices to check them against. It is tested against fixtures whose answer is
+known by construction, and that is as far as it can go.
+
+## Formats
+
+| Format | Grid | Pose | Identity |
+|---|---|---|---|
+| PTX | Per block | Per block, world and scanner-local kept apart | Exact |
+| PCD, ascii and 8-byte float binary | From `WIDTH` and `HEIGHT`, validated against the records | Viewpoint | Exact |
+| PCD, `binary_compressed` and 4-byte float binary | Same | Viewpoint | Not claimed |
+| E57 | From `indexBounds`, validated against decoded indices | Per scan | Exact where the records survive decoding |
+
+PCD identity is refused for two of its encodings because the record order there
+comes from a reader this project does not control or test record for record. The
+grid, the states and the pose are still preserved; only the link to a display
+point is withheld.
+
+A declared grid is a claim. Where the records contradict it, no grid is
+recorded and the load reports why, rather than building a correspondence the
+file does not support.
+
+## Registered claims
+
+`ORG-TOPOLOGY-IDENTITY`, `ORG-RANGE-GEOMETRIC`, `ORG-PTX-SETUP-TOPOLOGY` and
+`ORG-PCD-ORGANIZATION` in `docs/validation/claim-register.yaml` carry what each
+of these is graded at, and what each may not be used to say.
+
+Two of them are capped permanently. Identity cannot be checked by a second
+implementation, because no external tool holds this decoder's record indices.
+Geometric range is a three-term hypotenuse, where a second implementation is a
+second copy of a closed form. Both ceilings are recorded rather than left open,
+because neither is waiting on evidence that might arrive.

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -8,14 +8,14 @@ Format support is still evolving. This page separates what works today from what
 |---|---|---|
 | `LAS` | Drone / aerial LiDAR | Georeferenced; coordinate bridge applied |
 | `LAZ` | Drone / aerial LiDAR | Compressed LAS, decoded in-browser (laz-perf WASM) |
-| `E57` | Terrestrial laser scanners | ASTM E2807; coordinates, RGB, intensity, classification, normals; multi-scan files merged |
+| `E57` | Terrestrial laser scanners | ASTM E2807; coordinates, RGB, intensity, classification, normals; multi-scan files merged; acquisition grid preserved for structured scans |
 | `PLY` | iPhone / mobile scans | Point clouds and meshes; RGB supported |
 | `OBJ` | Mesh scans, 3D tools | Mesh vertices used as points |
 | `GLB` / `GLTF` | AR tools, mobile scans | Mesh vertices used as points |
 | `XYZ` | Survey / generic export | Whitespace-delimited text; optional RGB; chunked decoding over the in-memory file |
 | `CSV` | Survey / generic export | Comma-delimited text; optional RGB; chunked decoding over the in-memory file |
-| `PCD` | Point Cloud Library | ASCII, binary, and binary-compressed; position, RGB, intensity, normals, labels |
-| `PTX` | Terrestrial laser scanners | Multi-scan text; per-scan pose applied; scanner origin recorded |
+| `PCD` | Point Cloud Library | ASCII, binary, and binary-compressed; position, RGB, intensity, normals, labels; acquisition grid preserved when the header declares one |
+| `PTX` | Terrestrial laser scanners | Multi-scan text; per-scan pose applied; scanner origin recorded; acquisition grid preserved per block |
 | `PTS` | Terrestrial laser scanners | Whitespace-delimited text; optional header count; 3/4/6/7-column layouts; chunked reading |
 | `PNTS` | 3D Tiles point tile | A single tile; magic-byte detected; `RTC_CENTER` applied; Draco refused |
 | `COPC` | Cloud-optimised LiDAR | `.copc.laz`; opened by progressive octree streaming — see [streaming.md](streaming.md) |


### PR DESCRIPTION
The loaders preserve a scanner's acquisition grid beside the cloud, the workbench shows it, and no document said any of that.

The new page covers what each format preserves, what the five cell states mean and why they are five rather than one, why geometric range is taken in the scanner's own coordinates before registration, and the three linkage states.

It gives the limits the same weight as the capability. A no return can be dark asphalt, glass, water or a distance past the instrument, and nothing here names which. Agreement between a declared range and one recomputed from the same file is a decode check rather than ranging accuracy. Identity is bookkeeping about this decoder, which is why two of the four registered claims carry a permanent ceiling instead of an open one.

PCD identity is documented as refused for two encodings, because record order there comes from a reader this project does not control.

The user guide gains a section written for someone using the viewer rather than reading the source.