### PR TITLE
Stop the conductor fit assuming Z is up and calling source units metres

### DIFF
--- a/src/features/FeatureExtractionService.ts
+++ b/src/features/FeatureExtractionService.ts
@@ -140,15 +140,21 @@ export function extractBuildingCandidates(
  * Fit a single conductor candidate to a set of points, or null when the points
  * are not linear enough to be a conductor span (the core's own gate).
  *
+ * `up` is the frame's vertical axis, passed through to the core: sag is measured
+ * along it, and span across the plane perpendicular to it. It is required for
+ * the same reason `unit` is — assuming index 2 is up is the geometric twin of
+ * assuming the source unit is metres.
+ *
  * The id is derived from the span's own midpoint, so re-running over the same
  * span keeps the same candidate rather than minting a fresh one.
  */
 export function extractConductorCandidate(
   points: readonly Vec3[],
   unit: LinearUnitScale,
+  up: Vec3,
   minLinearity = 0.9,
 ): ConductorCandidate | null {
-  const fit = fitConductor(points, minLinearity);
+  const fit = fitConductor(points, up, minLinearity);
   if (!fit.ok) return null;
   const toM = (v: number): number | null => {
     const m = toMetresIfKnown(sourceUnits(v), unit);
@@ -164,18 +170,18 @@ export function extractConductorCandidate(
   }
   cx /= points.length;
   cy /= points.length;
-  const token = positionToken(cx, cy, fit.spanM / 8 || 1);
+  const token = positionToken(cx, cy, fit.spanSource / 8 || 1);
   return {
     id: `conductor-${token}`,
     kind: 'conductor',
     confidence: 'derived',
     linearity: fit.linearity,
-    spanSource: fit.spanM,
-    spanM: toM(fit.spanM),
-    sagSource: fit.sagM,
-    sagM: toM(fit.sagM),
-    residualRmsSource: fit.residualRms,
-    residualRmsM: toM(fit.residualRms),
+    spanSource: fit.spanSource,
+    spanM: toM(fit.spanSource),
+    sagSource: fit.sagSource,
+    sagM: toM(fit.sagSource),
+    residualRmsSource: fit.residualRmsSource,
+    residualRmsM: toM(fit.residualRmsSource),
     pointCount: fit.n,
   };
 }

--- a/src/features/conductors.ts
+++ b/src/features/conductors.ts
@@ -8,6 +8,15 @@
  * approximation to a catenary. It reports the span, the sag (maximum deflection
  * below the straight chord between the ends), and the fit residual.
  *
+ * The vertical is the caller's `up` axis, not index 2. A source whose frame is
+ * not Z-up would otherwise have its sag read off an axis that is not up, and the
+ * span read across one that is; the section-line frame in profileGeometry is the
+ * same seam, and this module reuses it rather than restating the shortcut.
+ *
+ * Span and sag are in the INPUT'S OWN unit, whatever that is, which is why the
+ * fields carry no metric name. The metric twin is emitted one layer up, and only
+ * when the linear unit is known.
+ *
  * It refuses non-linear inputs: a blob of vegetation or a wall is not a
  * conductor, so a low linearity (from the shared covariance descriptors) returns
  * ok:false rather than a plausible-looking sag. The sag is a MEASURED profile,
@@ -16,6 +25,11 @@
  */
 
 import { covarianceEigen, descriptorsFromEigen } from '../classification/geometryDescriptors';
+import {
+  buildProfileFrame,
+  projectPointToProfile,
+  DEGENERATE_HORIZONTAL_LENGTH,
+} from '../render/measure/profileGeometry';
 
 export type Vec3 = readonly [number, number, number];
 
@@ -25,23 +39,37 @@ export interface ConductorFit {
   /** Unit principal (span) direction. */
   readonly centerlineDir: Vec3;
   readonly linearity: number;
-  /** Along-span length covered by the points. */
-  readonly spanM: number;
-  /** Maximum deflection below the straight chord between the span ends. */
-  readonly sagM: number;
-  /** RMS residual of the vertical profile fit. */
-  readonly residualRms: number;
+  /** Along-span length covered by the points, in the input's own unit. */
+  readonly spanSource: number;
+  /**
+   * Maximum deflection below the straight chord between the span ends, measured
+   * along `up`, in the input's own unit.
+   */
+  readonly sagSource: number;
+  /** RMS residual of the vertical profile fit, in the input's own unit. */
+  readonly residualRmsSource: number;
   readonly n: number;
 }
 
 const ZERO_DIR: Vec3 = [0, 0, 0];
 
-/** Fit a conductor; `minLinearity` (default 0.9) is the floor below which the
- *  points are not accepted as a wire. */
-export function fitConductor(points: readonly Vec3[], minLinearity = 0.9): ConductorFit {
+/**
+ * Fit a conductor. `up` is the frame's vertical axis and is required: a wrong
+ * vertical turns sag into a number that is not sag, so there is no default worth
+ * guessing. `minLinearity` (default 0.9) is the floor below which the points are
+ * not accepted as a wire.
+ */
+export function fitConductor(points: readonly Vec3[], up: Vec3, minLinearity = 0.9): ConductorFit {
   const n = points.length;
-  const base = { centerlineDir: ZERO_DIR, linearity: 0, spanM: 0, sagM: 0, residualRms: Number.NaN, n };
+  const base = {
+    centerlineDir: ZERO_DIR, linearity: 0, spanSource: 0, sagSource: 0,
+    residualRmsSource: Number.NaN, n,
+  };
   if (n < 5) return { ...base, ok: false, reason: 'TOO_FEW_POINTS' };
+  // A zero / non-finite up axis has no vertical to project onto. Refuse it here
+  // rather than let it normalise to [0,0,0] and report a flat, sagless wire.
+  const upLen = Math.hypot(up[0], up[1], up[2]);
+  if (!Number.isFinite(upLen) || upLen === 0) return { ...base, ok: false, reason: 'DEGENERATE_UP' };
 
   const flat: number[] = new Array(n * 3);
   let mx = 0, my = 0, mz = 0;
@@ -56,17 +84,37 @@ export function fitConductor(points: readonly Vec3[], minLinearity = 0.9): Condu
   if (linearity < minLinearity) return { ...base, linearity, ok: false, reason: 'NOT_LINEAR' };
 
   const dir = eig.vectors[0]; // principal (span) direction
-  // Along-span parameter s and vertical z per point.
+  // The two extreme points along the principal direction are the span's ends;
+  // they define the section line the profile is measured against.
+  let tMin = Infinity, tMax = -Infinity, iMin = 0, iMax = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = points[i][0] - mx, dy = points[i][1] - my, dz = points[i][2] - mz;
+    const t = dx * dir[0] + dy * dir[1] + dz * dir[2];
+    if (t < tMin) { tMin = t; iMin = i; }
+    if (t > tMax) { tMax = t; iMax = i; }
+  }
+  const end0 = points[iMin], end1 = points[iMax];
+  const frame = buildProfileFrame(
+    [end0[0], end0[1], end0[2]],
+    [end1[0], end1[1], end1[2]],
+    [up[0], up[1], up[2]],
+  );
+  // A span with no plan extent is a vertical drop, not a conductor run: there is
+  // no chainage axis to fit a profile against.
+  if (!(frame.horizontalLength > DEGENERATE_HORIZONTAL_LENGTH)) {
+    return { ...base, linearity, ok: false, reason: 'NO_HORIZONTAL_EXTENT' };
+  }
+  // Chainage along the section line and height along `up`, per point.
   const s = new Array<number>(n), z = new Array<number>(n);
   let sMin = Infinity, sMax = -Infinity;
   for (let i = 0; i < n; i++) {
-    const dx = points[i][0] - mx, dy = points[i][1] - my, dz = points[i][2] - mz;
-    s[i] = dx * dir[0] + dy * dir[1] + dz * dir[2];
-    z[i] = points[i][2];
+    const proj = projectPointToProfile(frame, [points[i][0], points[i][1], points[i][2]]);
+    s[i] = proj.chainage;
+    z[i] = proj.height;
     if (s[i] < sMin) sMin = s[i];
     if (s[i] > sMax) sMax = s[i];
   }
-  const spanM = sMax - sMin;
+  const spanSource = sMax - sMin;
 
   // Least-squares quadratic z ≈ A s² + B s + C.
   const q = fitQuadratic(s, z);
@@ -74,22 +122,25 @@ export function fitConductor(points: readonly Vec3[], minLinearity = 0.9): Condu
   const [A, B, C] = q;
   let sse = 0;
   for (let i = 0; i < n; i++) { const e = A * s[i] * s[i] + B * s[i] + C - z[i]; sse += e * e; }
-  const residualRms = Math.sqrt(sse / n);
+  const residualRmsSource = Math.sqrt(sse / n);
 
   // Sag: max gap between the straight chord (ends) and the fitted curve.
   const zEnd0 = A * sMin * sMin + B * sMin + C;
   const zEnd1 = A * sMax * sMax + B * sMax + C;
-  let sagM = 0;
+  let sagSource = 0;
   const K = 64;
   for (let k = 0; k <= K; k++) {
     const ss = sMin + ((sMax - sMin) * k) / K;
-    const chord = zEnd0 + ((zEnd1 - zEnd0) * (ss - sMin)) / (spanM || 1);
+    const chord = zEnd0 + ((zEnd1 - zEnd0) * (ss - sMin)) / (spanSource || 1);
     const curve = A * ss * ss + B * ss + C;
     const gap = chord - curve; // positive where the wire dips below the chord
-    if (gap > sagM) sagM = gap;
+    if (gap > sagSource) sagSource = gap;
   }
 
-  return { ok: true, centerlineDir: [dir[0], dir[1], dir[2]], linearity, spanM, sagM, residualRms, n };
+  return {
+    ok: true, centerlineDir: [dir[0], dir[1], dir[2]], linearity,
+    spanSource, sagSource, residualRmsSource, n,
+  };
 }
 
 /** Solve least-squares [A,B,C] for z ≈ A x² + B x + C via 3×3 normal equations. */

--- a/tests/conductors.test.ts
+++ b/tests/conductors.test.ts
@@ -5,6 +5,9 @@
 import { describe, it, expect } from 'vitest';
 import { fitConductor, type Vec3 } from '../src/features/conductors';
 
+const Z_UP: Vec3 = [0, 0, 1];
+const Y_UP: Vec3 = [0, 1, 0];
+
 /** A sagging wire along x: z = z0 − sag·(1 − (2x/span − 1)²), plus tiny noise. */
 function saggingWire(span: number, sag: number, n: number, seed = 1): Vec3[] {
   let a = seed >>> 0;
@@ -19,15 +22,20 @@ function saggingWire(span: number, sag: number, n: number, seed = 1): Vec3[] {
   return pts;
 }
 
+/** Rotate +90° about X: the Z-up frame's up axis becomes +Y. Proper rotation. */
+function toYUp(pts: readonly Vec3[]): Vec3[] {
+  return pts.map((p) => [p[0], p[2], -p[1]] as Vec3);
+}
+
 describe('fitConductor', () => {
   it('recovers span and sag of a synthetic sagging wire, high linearity', () => {
     const pts = saggingWire(100, 3, 200);
-    const f = fitConductor(pts);
+    const f = fitConductor(pts, Z_UP);
     expect(f.ok).toBe(true);
     expect(f.linearity).toBeGreaterThan(0.95);
-    expect(f.spanM).toBeCloseTo(100, 0);
-    expect(f.sagM).toBeCloseTo(3, 1); // ~3 m mid-span sag
-    expect(f.residualRms).toBeLessThan(0.05);
+    expect(f.spanSource).toBeCloseTo(100, 0);
+    expect(f.sagSource).toBeCloseTo(3, 1); // ~3 units of mid-span sag
+    expect(f.residualRmsSource).toBeLessThan(0.05);
     // Centreline is horizontal along x.
     expect(Math.abs(f.centerlineDir[0])).toBeGreaterThan(0.99);
   });
@@ -35,21 +43,48 @@ describe('fitConductor', () => {
   it('refuses a blob (not linear) — not every cluster is a wire', () => {
     const blob: Vec3[] = [];
     for (let i = 0; i < 200; i++) blob.push([(i % 10), Math.floor(i / 10) % 10, (i * 7) % 5]);
-    const f = fitConductor(blob);
+    const f = fitConductor(blob, Z_UP);
     expect(f.ok).toBe(false);
     expect(f.reason).toBe('NOT_LINEAR');
   });
 
   it('refuses too few points', () => {
-    const f = fitConductor([[0, 0, 0], [1, 0, 0], [2, 0, 0]]);
+    const f = fitConductor([[0, 0, 0], [1, 0, 0], [2, 0, 0]], Z_UP);
     expect(f.ok).toBe(false);
     expect(f.reason).toBe('TOO_FEW_POINTS');
   });
 
   it('a taut (near-zero-sag) wire fits with ~0 sag and still reads as linear', () => {
     const taut = saggingWire(80, 0.02, 150);
-    const f = fitConductor(taut);
+    const f = fitConductor(taut, Z_UP);
     expect(f.ok).toBe(true);
-    expect(f.sagM).toBeLessThan(0.2);
+    expect(f.sagSource).toBeLessThan(0.2);
+  });
+
+  it('measures the SAME span and sag when the same wire arrives in a Y-up frame', () => {
+    const pts = saggingWire(100, 3, 200);
+    const zUp = fitConductor(pts, Z_UP);
+    const yUp = fitConductor(toYUp(pts), Y_UP);
+    expect(yUp.ok).toBe(true);
+    expect(yUp.spanSource).toBeCloseTo(zUp.spanSource, 9);
+    expect(yUp.sagSource).toBeCloseTo(zUp.sagSource, 9);
+    expect(yUp.sagSource).toBeCloseTo(3, 1);
+    expect(yUp.residualRmsSource).toBeCloseTo(zUp.residualRmsSource, 9);
+  });
+
+  it('reading height off Z in a Y-up frame is what the up axis prevents', () => {
+    // The same wire, fitted against the WRONG up axis: the sag it reports is
+    // not the wire's sag, which is why `up` is a parameter and not an
+    // assumption.
+    const pts = toYUp(saggingWire(100, 3, 200));
+    const wrong = fitConductor(pts, Z_UP);
+    expect(wrong.ok).toBe(true);
+    expect(Math.abs(wrong.sagSource - 3)).toBeGreaterThan(1);
+  });
+
+  it('refuses a degenerate up axis rather than inventing a vertical', () => {
+    const f = fitConductor(saggingWire(100, 3, 200), [0, 0, 0]);
+    expect(f.ok).toBe(false);
+    expect(f.reason).toBe('DEGENERATE_UP');
   });
 });

--- a/tests/featureExtractionService.test.ts
+++ b/tests/featureExtractionService.test.ts
@@ -22,6 +22,8 @@ import { knownUnit, unknownUnit } from '../src/units/units';
 import { footprintsToGeoJson } from '../src/features/footprintGeoJson';
 
 const METRE = knownUnit(1);
+const Z_UP: Vec3 = [0, 0, 1];
+const Y_UP: Vec3 = [0, 1, 0];
 const FOOT = knownUnit(0.3048);
 
 /** A solid 10x10 block of building points. */
@@ -54,7 +56,7 @@ describe('FeatureExtractionService — extraction', () => {
   });
 
   it('fits a straight span as a conductor candidate', () => {
-    const c = extractConductorCandidate(span(), METRE);
+    const c = extractConductorCandidate(span(), METRE, Z_UP);
     expect(c).not.toBeNull();
     expect(c!.kind).toBe('conductor');
     expect(c!.linearity).toBeGreaterThan(0.9);
@@ -65,7 +67,7 @@ describe('FeatureExtractionService — extraction', () => {
   it('rejects a non-linear blob as not a conductor', () => {
     const pts: Vec3[] = [];
     for (let x = 0; x < 6; x++) for (let y = 0; y < 6; y++) pts.push([x, y, 0]);
-    expect(extractConductorCandidate(pts, METRE)).toBeNull();
+    expect(extractConductorCandidate(pts, METRE, Z_UP)).toBeNull();
   });
 });
 
@@ -75,7 +77,7 @@ describe('FeatureExtractionService — unit honesty', () => {
     expect(b.areaSource).toBeGreaterThan(0); // the source measure still stands
     expect(b.areaM2).toBeNull();
 
-    const c = extractConductorCandidate(span(), unknownUnit())!;
+    const c = extractConductorCandidate(span(), unknownUnit(), Z_UP)!;
     expect(c.spanSource).toBeGreaterThan(30);
     expect(c.spanM).toBeNull();
     expect(c.sagM).toBeNull();
@@ -93,11 +95,29 @@ describe('FeatureExtractionService — unit honesty', () => {
     expect(inFeet.areaM2).toBeLessThan(inFeet.areaSource * 0.3048);
   });
 
+  it('a KNOWN unit converts a span whose length is known by construction', () => {
+    // 39 units end to end, in feet: 39 x 0.3048 = 11.8872 m, and nothing else.
+    const c = extractConductorCandidate(span(), FOOT, Z_UP)!;
+    expect(c.spanSource).toBeCloseTo(39, 6);
+    expect(c.spanM).toBeCloseTo(11.8872, 6);
+  });
+
+  it('the up axis reaches the core: a Y-up span measures the same as a Z-up one', () => {
+    const zUp = extractConductorCandidate(span(), METRE, Z_UP)!;
+    const rotated = span().map((p) => [p[0], p[2], -p[1]] as Vec3);
+    const yUp = extractConductorCandidate(rotated, METRE, Y_UP)!;
+    expect(yUp.spanSource).toBeCloseTo(zUp.spanSource, 9);
+    expect(yUp.sagSource).toBeCloseTo(zUp.sagSource, 9);
+    expect(yUp.spanM).toBeCloseTo(zUp.spanM!, 9);
+  });
+
   it('LENGTH converts by the scale once (span, sag and residual alike)', () => {
-    const c = extractConductorCandidate(span(), FOOT)!;
+    const c = extractConductorCandidate(span(), FOOT, Z_UP)!;
     expect(c.spanM).toBeCloseTo(c.spanSource * 0.3048, 9);
     expect(c.sagM).toBeCloseTo(c.sagSource * 0.3048, 9);
     expect(c.residualRmsM).toBeCloseTo(c.residualRmsSource * 0.3048, 9);
+    // A squared conversion would be ~0.093x, not 0.3048x — pin that it is not.
+    expect(c.spanM).toBeGreaterThan(c.spanSource * 0.3048 * 0.3048 * 2);
   });
 
   it('a metre unit leaves the numbers unchanged', () => {
@@ -136,8 +156,8 @@ describe('FeatureExtractionService — stable identity', () => {
   });
 
   it('a conductor id is stable for the same span', () => {
-    const a = extractConductorCandidate(span(), METRE)!;
-    const b = extractConductorCandidate(span(), METRE)!;
+    const a = extractConductorCandidate(span(), METRE, Z_UP)!;
+    const b = extractConductorCandidate(span(), METRE, Z_UP)!;
     expect(b.id).toBe(a.id);
   });
 });


### PR DESCRIPTION
`conductors.ts` carried both defects already fixed in its sibling `buildingFootprints.ts`.

It read the vertical axis as `points[i][2]`, so a source that is not Z-up produced a sag measured along the wrong axis. `fitConductor` now takes the up vector as a required parameter and derives chainage and height through `buildProfileFrame`, the module that already refuses the X and Y chainage with Z height shortcut. Two fail-closed refusals join it: a degenerate up vector, and a span with no horizontal extent.

`spanM`, `sagM` and `residualRms` were computed from whatever unit the input carried and named as metres. On a foot or degree source those numbers were labelled metric and were not. The core fields are now `spanSource`, `sagSource` and `residualRmsSource`, and the metric twin lives on the candidate exactly as it does for footprints: emitted when the unit is known, null otherwise.

A length converts once. The test pins that a 39-unit foot span reads 11.8872 m, and a lower bound rules out a squared factor, since area is the field that converts by the scale squared.

Nothing outside `src/features` and its tests reads these fields, so no interface changed.
