### PR TITLE
fix: state the sample basis of class counts and the footprint basis of density

### DIFF
--- a/src/app/openScan.ts
+++ b/src/app/openScan.ts
@@ -186,7 +186,10 @@ export interface OpenScanDeps {
   /** Surface the instant analysis-on-drop entry point. */
   showInstantAnswer: (name: string) => void;
   /** Repopulate the classification legend from the cloud's per-point class buffer. */
-  refreshClassLegend: (classification?: ArrayLike<number>) => void;
+  refreshClassLegend: (
+    classification?: ArrayLike<number>,
+    sample?: { readonly loaded: number; readonly declared?: number },
+  ) => void;
   /** `?debug=1` — console diagnostics + overlay telemetry. */
   readonly debug: boolean;
   /** `?benchmark=1` — emit a benchmark result on load. */
@@ -524,7 +527,12 @@ export async function openScan(file: File, deps: OpenScanDeps): Promise<void> {
     // channel renders the panel's empty state. DISPLAY-ONLY; the all-visible
     // default mask is applied so nothing is hidden on load.
     try {
-      deps.refreshClassLegend(result.cloud.classification);
+      // Counts come from the points actually loaded, so hand the legend the
+      // loaded-versus-declared basis: a strided load labels them as a sample.
+      deps.refreshClassLegend(result.cloud.classification, {
+        loaded: result.cloud.pointCount,
+        declared: result.cloud.declaredPointCount,
+      });
     } catch (err) {
       if (deps.debug) console.warn('[class-legend] refresh threw', err);
     }

--- a/src/diagnostics/provenance.ts
+++ b/src/diagnostics/provenance.ts
@@ -497,12 +497,12 @@ function matchNumeric(signals: ScanSignals): ProvenanceFingerprint | null {
       // unbounded, it does not claim to resolve the overlap.
       if (signals.densityPerSqM > PHONE_LIDAR_MAX_DENSITY_PER_SQM) {
         return terrestrialFingerprint('medium', [
-          `Density: ${signals.densityPerSqM.toFixed(0)} pts/m² over a ${footprintArea.toFixed(0)} m² footprint`,
+          `Density: ${signals.densityPerSqM.toFixed(0)} pts/m² over a ${footprintArea.toFixed(0)} m² bounding-box footprint`,
           `Above the ${PHONE_LIDAR_MAX_DENSITY_PER_SQM} pts/m² a phone flash pattern reaches at its closest range`,
         ]);
       }
       return phoneLidarFingerprint('medium', [
-        `Density: ${signals.densityPerSqM.toFixed(0)} pts/m² over a ${footprintArea.toFixed(0)} m² footprint`,
+        `Density: ${signals.densityPerSqM.toFixed(0)} pts/m² over a ${footprintArea.toFixed(0)} m² bounding-box footprint`,
       ]);
     }
 
@@ -510,7 +510,7 @@ function matchNumeric(signals: ScanSignals): ProvenanceFingerprint | null {
     // & Ghosh §6). The bound covers the typical airborne range.
     if (signals.densityPerSqM > 0.5 && signals.densityPerSqM < 50 && footprintArea > 10000) {
       return aerialAlsFingerprint('medium', [
-        `Density: ${signals.densityPerSqM.toFixed(1)} pts/m² over a ${(footprintArea / 10000).toFixed(1)} ha footprint`,
+        `Density: ${signals.densityPerSqM.toFixed(1)} pts/m² over a ${(footprintArea / 10000).toFixed(1)} ha bounding-box footprint`,
       ]);
     }
 
@@ -529,7 +529,7 @@ function matchNumeric(signals: ScanSignals): ProvenanceFingerprint | null {
     if (signals.densityPerSqM >= 50 && footprintArea > 2000) {
       const veryDense = signals.densityPerSqM > 1000;
       return droneLidarFingerprint(veryDense ? 'high' : 'medium', [
-        `Density: ${signals.densityPerSqM.toFixed(0)} pts/m² over a ${(footprintArea / 10000).toFixed(2)} ha mapping footprint`,
+        `Density: ${signals.densityPerSqM.toFixed(0)} pts/m² over a ${(footprintArea / 10000).toFixed(2)} ha bounding-box mapping footprint`,
       ]);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1637,7 +1637,7 @@ async function runDeriveClassification(): Promise<void> {
     viewer.applyDerivedClassification(id, result.codes);
     noteEdit('classification');
     lastDerivedConfidence = Number.isFinite(result.confidence) ? result.confidence : null;
-    classLegendPanel.setClasses(countClasses(result.codes));
+    classLegendPanel.setClasses(countClasses(result.codes), { loaded: cloud.pointCount, declared: cloud.declaredPointCount });
     // Surface the run's honest confidence + caveats in the legend caption, not
     // just a flat "derived" tag — so the user sees WHEN to trust it.
     const confPct = Number.isFinite(result.confidence)
@@ -1723,7 +1723,7 @@ async function runFillUnclassified(): Promise<void> {
     viewer.applyDerivedClassification(id, result.codes);
     noteEdit('classification');
     lastDerivedConfidence = Number.isFinite(result.confidence) ? result.confidence : null;
-    classLegendPanel.setClasses(countClasses(result.codes));
+    classLegendPanel.setClasses(countClasses(result.codes), { loaded: cloud.pointCount, declared: cloud.declaredPointCount });
     const confPct = Number.isFinite(result.confidence) ? Math.round(result.confidence * 100) : null;
     classLegendPanel.setDerivedProvenance(true, { confidencePct: confPct, warnings: result.warnings });
     classLegendPanel.show();
@@ -3446,11 +3446,11 @@ function revealAnalysePanel(name: string, settled = true): void {
  * the legend's fresh state is all-visible, so the GPU mask is applied as a
  * no-op identity mask to keep the unfiltered experience unchanged. v0.4.1.
  */
-function refreshClassLegend(classification?: ArrayLike<number>): void {
+function refreshClassLegend(classification?: ArrayLike<number>, sample?: { readonly loaded: number; readonly declared?: number }): void {
   if (classification && classification.length > 0) {
-    classLegendPanel.setClasses(countClasses(toClassBuffer(classification)));
+    classLegendPanel.setClasses(countClasses(toClassBuffer(classification)), sample);
   } else {
-    classLegendPanel.setClasses(new Map());
+    classLegendPanel.setClasses(new Map(), sample);
   }
   // Apply the (all-visible) mask so a previously-filtered scan can't leak its
   // hidden classes onto the freshly loaded one. No-op for the common case.

--- a/src/styles/76-classification.css
+++ b/src/styles/76-classification.css
@@ -80,6 +80,7 @@
 /* Derived-classification provenance caption — a quiet amber note so the
    heuristic classes never read as an authoritative, file-supplied set. */
 .olv-cl-derived,
+.olv-cl-samplenote,
 .olv-cl-streamnote {
   font-size: 10.5px; line-height: 1.35; color: var(--warn, #b8860b);
   background: color-mix(in srgb, var(--warn, #b8860b) 12%, transparent);

--- a/src/ui/ClassLegendPanel.ts
+++ b/src/ui/ClassLegendPanel.ts
@@ -45,6 +45,18 @@ import { classificationLabel } from '../render/pointInfo';
 /** A change the panel reports back to the host after a user interaction. */
 export type ClassLegendChange = (visibility: ClassVisibility) => void;
 
+/**
+ * The basis of the per-class counts: how many points are loaded, and how many
+ * the source file declares. `declared > loaded` means the counts describe a
+ * display sample rather than the whole scan.
+ */
+export interface ClassCountSample {
+  /** Points actually held in memory and counted. */
+  readonly loaded: number;
+  /** The source header's own total, when the format declares one. */
+  readonly declared?: number;
+}
+
 /** Fired after the user toggles the colourblind-safe class palette. */
 export type ClassPaletteChange = (colorblindSafe: boolean) => void;
 
@@ -84,6 +96,9 @@ export class ClassLegendPanel {
 
   /** "Counts accrue as the cloud streams" caption (hidden unless streaming). */
   private readonly _streamingNote: HTMLElement;
+
+  /** "Counts cover the loaded display sample" caption (hidden unless sampled). */
+  private readonly _sampleNote: HTMLElement;
 
   /** The "Show all" reset button. */
   private readonly _showAllBtn: HTMLButtonElement;
@@ -139,6 +154,17 @@ export class ClassLegendPanel {
     });
     this._streamingNote.setAttribute('role', 'note');
 
+    // Sampled caption — the loader strides a cloud too big to hold whole, so
+    // the per-class counts describe the display sample, not the survey. Shown
+    // only when the file declares more points than are loaded, so a fully
+    // resident scan carries no caveat that does not apply to it. Same wording
+    // basis as the Scan Report's "Loaded N (display sample)" row.
+    this._sampleNote = el('div', {
+      className: 'olv-cl-samplenote olv-hidden',
+      text: 'Counts cover the loaded display sample — not the full cloud.',
+    });
+    this._sampleNote.setAttribute('role', 'note');
+
     this._banner = el('div', { className: 'olv-cl-banner olv-hidden' });
     this._banner.setAttribute('role', 'status');
     this._banner.setAttribute('aria-live', 'polite');
@@ -185,6 +211,7 @@ export class ClassLegendPanel {
       head,
       this._provenance,
       this._streamingNote,
+      this._sampleNote,
       this._banner,
       this._list,
       this._empty,
@@ -252,7 +279,7 @@ export class ClassLegendPanel {
    * then renders its empty state. This does NOT emit `onChange`; the host
    * applies the (all-visible) mask itself on load.
    */
-  setClasses(counts: Map<number, number>): void {
+  setClasses(counts: Map<number, number>, sample?: ClassCountSample): void {
     this._counts = new Map(counts);
     this._hasChannel = this._presentCodes().length > 0;
     this._visibility = new ClassVisibility();
@@ -261,6 +288,7 @@ export class ClassLegendPanel {
     // onto a subsequently-loaded file-classified scan.
     this.setDerivedProvenance(false);
     this.setStreamingMode(false);
+    this.setSampledMode(sample);
     this._render();
   }
 
@@ -304,6 +332,24 @@ export class ClassLegendPanel {
    */
   setStreamingMode(on: boolean): void {
     this._streamingNote.classList.toggle('olv-hidden', !on);
+  }
+
+  /**
+   * Show or hide the "loaded display sample" caption from the loaded-versus-
+   * declared point counts. The caption appears only when the source declares
+   * MORE points than are loaded (the loader strided the cloud for display), so
+   * the counts are honestly scoped to the sample. A fully resident scan — no
+   * declared total, or a declared total the load matched — shows nothing, so
+   * the caveat keeps its meaning where it does apply.
+   */
+  setSampledMode(sample?: ClassCountSample): void {
+    const declared = sample?.declared;
+    const sampled =
+      sample !== undefined &&
+      typeof declared === 'number' &&
+      Number.isFinite(declared) &&
+      declared > sample.loaded;
+    this._sampleNote.classList.toggle('olv-hidden', !sampled);
   }
 
   /**

--- a/tests/classLegendSampleDisclosure.test.ts
+++ b/tests/classLegendSampleDisclosure.test.ts
@@ -1,0 +1,209 @@
+/**
+ * classLegendSampleDisclosure.test.ts
+ *
+ * The Classes legend counts the points the loader actually held, so on a cloud
+ * strided for display every class figure describes the sample rather than the
+ * survey. These tests pin the disclosure, not its wording: a sampled scan gets
+ * a visible caption, a fully resident one gets none. Both directions matter —
+ * a caption shown unconditionally would be a caveat everywhere and therefore a
+ * caveat nowhere, so the absent case is asserted as hard as the present one.
+ *
+ * Also pinned: the sensor-inference density signal names the area its footprint
+ * comes from, since the app computes both a bounding box and a tighter hull and
+ * a reader cannot otherwise tell which one the density is over.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ClassLegendPanel } from '../src/ui/ClassLegendPanel';
+import { classify } from '../src/diagnostics/provenance';
+
+type Handler = (e: unknown) => void;
+
+/** A recording DOM node covering only the surface the legend touches. */
+class FakeEl {
+  readonly tagName: string;
+  private _classes = new Set<string>();
+  textContent = '';
+  title = '';
+  value = '';
+  type = '';
+  checked = false;
+  disabled = false;
+  readonly dataset: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly children: FakeEl[] = [];
+  parent: FakeEl | null = null;
+  private readonly attrs = new Map<string, string>();
+  private readonly handlers = new Map<string, Handler[]>();
+
+  constructor(tag: string) {
+    this.tagName = tag.toLowerCase();
+  }
+
+  set className(v: string) {
+    this._classes = new Set(String(v).split(/\s+/).filter(Boolean));
+  }
+  get className(): string {
+    return [...this._classes].join(' ');
+  }
+  get classList() {
+    const classes = this._classes;
+    return {
+      add: (c: string): void => void classes.add(c),
+      remove: (c: string): void => void classes.delete(c),
+      contains: (c: string): boolean => classes.has(c),
+      toggle: (c: string, force?: boolean): boolean => {
+        const want = force === undefined ? !classes.has(c) : force;
+        if (want) classes.add(c);
+        else classes.delete(c);
+        return want;
+      },
+    };
+  }
+
+  private _adopt(kid: unknown): FakeEl[] {
+    if (kid instanceof FakeEl) {
+      if (kid.tagName === '#fragment') {
+        const kids = [...kid.children];
+        kid.children.length = 0;
+        for (const k of kids) k.parent = this;
+        return kids;
+      }
+      kid.parent?.detach(kid);
+      kid.parent = this;
+      return [kid];
+    }
+    const text = new FakeEl('#text');
+    text.textContent = String(kid);
+    text.parent = this;
+    return [text];
+  }
+  detach(kid: FakeEl): void {
+    const at = this.children.indexOf(kid);
+    if (at >= 0) this.children.splice(at, 1);
+  }
+  append(...kids: unknown[]): void {
+    for (const k of kids) this.children.push(...this._adopt(k));
+  }
+  replaceChildren(...kids: unknown[]): void {
+    this.children.length = 0;
+    for (const k of kids) this.children.push(...this._adopt(k));
+  }
+  remove(): void {
+    this.parent?.detach(this);
+    this.parent = null;
+  }
+
+  setAttribute(n: string, v: string): void {
+    this.attrs.set(n, v);
+  }
+  getAttribute(n: string): string | null {
+    return this.attrs.get(n) ?? null;
+  }
+  addEventListener(type: string, fn: Handler): void {
+    const a = this.handlers.get(type) ?? [];
+    a.push(fn);
+    this.handlers.set(type, a);
+  }
+  dispatchEvent(evt: { type: string }): boolean {
+    for (const fn of [...(this.handlers.get(evt.type) ?? [])]) fn(evt);
+    return true;
+  }
+  focus(): void {}
+  blur(): void {}
+
+  private _matches(sel: string): boolean {
+    const parts = sel.split('.');
+    const tag = parts[0];
+    if (tag && this.tagName !== tag.toLowerCase()) return false;
+    for (const c of parts.slice(1)) if (!this._classes.has(c)) return false;
+    return true;
+  }
+  querySelector(sel: string): FakeEl | null {
+    for (const c of this.children) {
+      if (c._matches(sel)) return c;
+      const deep = c.querySelector(sel);
+      if (deep) return deep;
+    }
+    return null;
+  }
+}
+
+beforeAll(() => {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.document = {
+    createElement: (tag: string) => new FakeEl(tag),
+    createDocumentFragment: () => new FakeEl('#fragment'),
+  };
+  g.HTMLInputElement = class HTMLInputElement {};
+});
+
+/** The per-class counts of the session that motivated this: they sum to the sample. */
+const COUNTS = new Map<number, number>([
+  [1, 1_059],
+  [2, 1_700_456],
+  [3, 457_117],
+  [4, 426_754],
+  [5, 237_263],
+  [6, 152_622],
+]);
+const LOADED = 2_975_271;
+
+/** The sample caption node, or null when the panel never built one. */
+function caption(panel: ClassLegendPanel): FakeEl | null {
+  return (panel.element as unknown as FakeEl).querySelector('.olv-cl-samplenote');
+}
+
+/** Whether the caption is currently visible to the reader. */
+function captionShown(panel: ClassLegendPanel): boolean {
+  const node = caption(panel);
+  return node !== null && !node.classList.contains('olv-hidden');
+}
+
+describe('Classes legend — counts name their basis', () => {
+  it('a sampled scan labels its class counts as the loaded sample', () => {
+    const panel = new ClassLegendPanel();
+    panel.setClasses(COUNTS, { loaded: LOADED, declared: 47_900_000 });
+    expect(captionShown(panel)).toBe(true);
+    // Wording is free to change; it must say the counts are of what was loaded.
+    expect(caption(panel)?.textContent ?? '').toMatch(/sample/i);
+  });
+
+  it('a fully resident scan carries no sample caveat', () => {
+    const panel = new ClassLegendPanel();
+    panel.setClasses(COUNTS, { loaded: LOADED, declared: LOADED });
+    expect(captionShown(panel)).toBe(false);
+  });
+
+  it('a source that declares no total carries no sample caveat', () => {
+    const panel = new ClassLegendPanel();
+    panel.setClasses(COUNTS, { loaded: LOADED });
+    expect(captionShown(panel)).toBe(false);
+    panel.setClasses(COUNTS);
+    expect(captionShown(panel)).toBe(false);
+  });
+
+  it('loading a resident scan after a sampled one clears the caveat', () => {
+    const panel = new ClassLegendPanel();
+    panel.setClasses(COUNTS, { loaded: LOADED, declared: 47_900_000 });
+    expect(captionShown(panel)).toBe(true);
+    panel.setClasses(COUNTS, { loaded: LOADED, declared: LOADED });
+    expect(captionShown(panel)).toBe(false);
+  });
+});
+
+describe('Capture provenance — the density footprint names its basis', () => {
+  it('a drone-scale density signal says which area it is over', () => {
+    const f = classify({
+      sourceFormat: 'las',
+      pointCount: 47_900_000,
+      extent: [204.0, 332.3, 60],
+      densityPerSqM: 707,
+    });
+    const signals = f.signals.join(' | ');
+    expect(signals).toMatch(/pts\/m²/);
+    // The app also computes a tighter hull area, so the figure has to say the
+    // basis is the bounding box rather than leaving the reader to guess.
+    expect(signals).toMatch(/bounding.box/i);
+  });
+});

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -5137,6 +5137,7 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 /* Derived-classification provenance caption — a quiet amber note so the
    heuristic classes never read as an authoritative, file-supplied set. */
 .olv-cl-derived,
+.olv-cl-samplenote,
 .olv-cl-streamnote {
   font-size: 10.5px; line-height: 1.35; color: var(--warn, #b8860b);
   background: color-mix(in srgb, var(--warn, #b8860b) 12%, transparent);

--- a/tests/provenanceGroundInstrument.test.ts
+++ b/tests/provenanceGroundInstrument.test.ts
@@ -109,7 +109,7 @@ describe('capture type — a registered multi-station terrestrial scan', () => {
     const fp = classify(signalsForStaticCloud(mineCloud({})));
     expect(fp.captureType).toBe('aerial-als');
     expect(fp.confidence).toBe('medium');
-    expect(fp.signals).toContain('Density: 1.9 pts/m² over a 1434.0 ha footprint');
+    expect(fp.signals).toContain('Density: 1.9 pts/m² over a 1434.0 ha bounding-box footprint');
   });
 
   it('does not assert airborne when the declared instrument is an unrecognised make', () => {
@@ -126,7 +126,7 @@ describe('capture type — a registered multi-station terrestrial scan', () => {
     expect(fp.label).toBe('Ground-based scan — capture method not determined');
     expect(fp.bounds).toEqual([]);
     // The density evidence stays visible, with the reason it was not enough.
-    expect(fp.signals).toContain('Density: 1.9 pts/m² over a 1434.0 ha footprint');
+    expect(fp.signals).toContain('Density: 1.9 pts/m² over a 1434.0 ha bounding-box footprint');
     const why = fp.signals.join(' ');
     expect(why).toMatch(/10 registered scan stations/);
     expect(why).toMatch(/per-scan temperature \/ relativeHumidity \/ atmosphericPressure/);
@@ -259,7 +259,7 @@ describe('capture type — the other bands are unchanged', () => {
     expect(s.declaredGroundInstrument).toBeUndefined();
     expect(fp.captureType).toBe('aerial-als');
     expect(fp.confidence).toBe('medium');
-    expect(fp.signals).toContain('Density: 2.0 pts/m² over a 320.0 ha footprint');
+    expect(fp.signals).toContain('Density: 2.0 pts/m² over a 320.0 ha bounding-box footprint');
   });
 
   it('a spaceborne sensor string still wins outright', () => {


### PR DESCRIPTION
The Classes panel reported per-class counts taken from the loaded display sample with nothing saying so. On a 47.9M point cloud the counts summed to 2,975,271, which is 6.2 percent of the file, and read as full-cloud totals.

A caption now states that counts cover the loaded display sample. It appears only when the source declares a total greater than the loaded count, the same test the Scan Report uses, and clears when a resident scan loads after a sampled one.

Density signals in the provenance panel now name their basis as a bounding-box footprint, which the hull area does not match.

No count, area or density value changed.
