### PR TITLE
fix(geo): key vertical comparability on the datum, not its surface class

### DIFF
--- a/docs/architecture/spatial-context-consumers.md
+++ b/docs/architecture/spatial-context-consumers.md
@@ -50,7 +50,7 @@ has re-opened the divergence this closes.
   `carrier` path must be free of the deprecated predicates listed below.
 - **Reads** — the context fields it now uses.
 
-## Inventory (16 consumers)
+## Inventory (17 consumers)
 
 | # | Consumer | Status | Routes through | Reads |
 |---|----------|--------|----------------|-------|
@@ -70,6 +70,7 @@ has re-opened the divergence this closes.
 | 14 | Classification | migrated | `src/render/class/classifierCues.ts` | `linearUnitToMetres`, `verticalMetresPerUnit` |
 | 15 | Streaming scan-report extents | migrated | `src/analysis/streamingExtentRows.ts` | `linearUnitKnown`, `linearUnitToMetres`, `verticalMetresPerUnit` |
 | 16 | Tool preflight | migrated | `src/process/toolPreflight.ts` | `metricClaimsPermitted`, `verticalReferenceKnown`, `crsName` |
+| 17 | Cross-CRS project placement | migrated | `src/geo/projectPlacement.ts` | vertical verdict delegated to `src/geo/frameCompatibility.ts` |
 
 ## Deprecated predicates
 

--- a/src/geo/SpatialContext.ts
+++ b/src/geo/SpatialContext.ts
@@ -5,7 +5,7 @@
  * consumer that is about to make a metric claim — a distance in metres, an area
  * in m², a volume in m³, a density in pts/m², an elevation against a datum — can
  * read a single object instead of re-deriving unit, datum, axis and frame from
- * `metadata.crs` five different ways. The inventory tracks 16 consumers that
+ * `metadata.crs` five different ways. The inventory tracks 17 consumers that
  * each used to reach into a `CrsInfo` / `ResolvedCrs` and re-answer the same
  * questions (see docs/architecture/spatial-context-consumers.md, which
  * `scripts/lint-spatial-context.mjs` holds to the tree); the divergence between
@@ -195,7 +195,7 @@ export interface SpatialContextPlacement {
  * project-frame placement. A `null` / `undefined` CRS fails closed: the context
  * resolves to `unknown`, and `metricClaimsPermitted` is `false`.
  *
- * Accepting both inputs is what lets all 16 consumers route through this one
+ * Accepting both inputs is what lets all 17 consumers route through this one
  * façade without hand-building anything: a `CrsInfo` is bridged through the
  * canonical `resolvedFromCrsInfo` mapper, while a `ResolvedCrs` — which already
  * carries the resolved `kind` (including `local` / `unknown`, which a `CrsInfo`

--- a/src/geo/frameCompatibility.ts
+++ b/src/geo/frameCompatibility.ts
@@ -26,6 +26,7 @@
  * Pure — no DOM, no three.js, no proj4. Runs unchanged in Node tests.
  */
 
+import { resolveVerticalEpsg } from './height';
 import type { SpatialContext } from './SpatialContext';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -103,15 +104,24 @@ export function declaredFrameLabel(ctx: SpatialContext): string | null {
 }
 
 /**
- * The vertical identity a frame comparison keys on. The reference CLASS from
- * {@link SpatialContext.verticalReference} is authoritative (it already folds
- * EPSG and name into one answer), and `'unknown'` means no identity — so two
- * undeclared datums do not match each other.
+ * The vertical identity a frame comparison keys on, most specific first.
+ *
+ * The EPSG code comes first because the reference CLASS does not separate two
+ * datums that share a surface: NAVD88 and EGM2008 are both `orthometric`, and
+ * keying on the class alone reported them as the same reference. They differ by
+ * about a metre across North America, so a change comparison spanning the two
+ * would have attributed that offset to the ground.
+ *
+ * `undefined` means no identity, so two undeclared datums do not match each
+ * other. The class remains the last resort, for a frame that carries a surface
+ * with no datum specific enough to resolve.
  */
 function verticalIdentity(ctx: SpatialContext): string | undefined {
-  if (ctx.verticalReference !== 'unknown') return ctx.verticalReference;
+  const code = resolveVerticalEpsg(ctx);
+  if (code !== undefined) return `epsg:${code}`;
   const declared = ctx.verticalDatum?.trim().toLowerCase();
-  return declared && declared.length > 0 ? declared : undefined;
+  if (declared && declared.length > 0) return declared;
+  return ctx.verticalReference !== 'unknown' ? ctx.verticalReference : undefined;
 }
 
 /** Whether a metres-per-unit factor is a real measurement rather than a placeholder. */

--- a/src/geo/height.ts
+++ b/src/geo/height.ts
@@ -147,7 +147,13 @@ export interface VerticalDatumRef {
 }
 
 /** Resolve a datum ref to its EPSG code, or `undefined` when none is recoverable. */
-function resolveVerticalEpsg(d: VerticalDatumRef): number | undefined {
+/**
+ * The EPSG code a declared vertical datum resolves to, from an explicit code, a
+ * known datum name, or an `EPSG:nnnn` string. Exported because the code is the
+ * only identity that separates two datums sharing a reference surface, and a
+ * caller comparing frames needs that separation rather than the surface class.
+ */
+export function resolveVerticalEpsg(d: VerticalDatumRef): number | undefined {
   if (d.verticalEpsg !== undefined && Number.isFinite(d.verticalEpsg) && d.verticalEpsg > 0) {
     return d.verticalEpsg;
   }

--- a/src/geo/projectPlacement.ts
+++ b/src/geo/projectPlacement.ts
@@ -17,6 +17,8 @@
 
 import type { GlobalPoints } from '../convert/globalPoints';
 import { reprojectGlobal, type ReprojectResult } from '../convert/reproject';
+import type { SpatialContext } from './SpatialContext';
+import { compareSpatialFrames, type FrameCompatibility } from './frameCompatibility';
 
 export type HorizontalPlacement = 'identity' | 'reproject' | 'needs-registration';
 
@@ -25,10 +27,10 @@ export interface PlacementInputs {
   readonly layerEpsg: number | null;
   /** The project's horizontal EPSG, or null when no project CRS is set. */
   readonly projectEpsg: number | null;
-  /** Whether the layer's vertical datum is resolved. */
-  readonly layerVerticalKnown: boolean;
-  /** Whether the project's vertical datum is resolved. */
-  readonly projectVerticalKnown: boolean;
+  /** The layer's frame, read for its vertical reference and vertical unit. */
+  readonly layerFrame: SpatialContext;
+  /** The project's frame, read the same way. */
+  readonly projectFrame: SpatialContext;
 }
 
 export interface PlacementPlan {
@@ -39,12 +41,30 @@ export interface PlacementPlan {
   readonly reason: string;
 }
 
+/**
+ * Why heights are withheld, in the words the frame comparison already used.
+ * Restating the reason here would let the two drift, and the note a user reads
+ * would stop matching the evidence the verdict was made on.
+ */
+function verticalWithheldNote(vertical: FrameCompatibility): string {
+  const stated = vertical.notes.find((n) => n.startsWith('Vertical'));
+  return (
+    stated ??
+    'Heights are not on a confirmed common reference, so height and change claims are withheld.'
+  );
+}
+
 /** Decide how a layer enters the project frame, without moving any points. */
 export function planPlacement(inp: PlacementInputs): PlacementPlan {
-  const verticalComparable = inp.layerVerticalKnown && inp.projectVerticalKnown;
-  const vNote = verticalComparable
-    ? ''
-    : ' Vertical datum is unresolved on one side, so the layer mounts in X/Y and height/change claims are withheld.';
+  // Delegated rather than decided here. Two vertical datums can both be
+  // resolved and still not be comparable: NAVD88 in feet and EGM2008 in metres
+  // are each fully declared, sit on different surfaces, and carry different
+  // unit scales. `compareSpatialFrames` already weighs reference identity and
+  // unit scale together, and a second opinion on the same question is a second
+  // answer to maintain.
+  const vertical = compareSpatialFrames(inp.layerFrame, inp.projectFrame);
+  const verticalComparable = vertical.verticalComparable;
+  const vNote = verticalComparable ? '' : ` ${verticalWithheldNote(vertical)}`;
 
   if (inp.projectEpsg == null) {
     return {

--- a/tests/frameCompatibility.test.ts
+++ b/tests/frameCompatibility.test.ts
@@ -123,6 +123,33 @@ describe('compareSpatialFrames — vertical permission is separate', () => {
   const navd88 = (over: Partial<CrsInfo> = {}) =>
     spatialContextFrom(crs({ verticalEpsg: 5703, verticalDatum: 'NAVD88', verticalUnitToMetres: 1, ...over }));
 
+  // Two orthometric datums are not one datum. NAVD88 and EGM2008 both classify
+  // as `orthometric`, so a comparison keyed on the reference class read them as
+  // the same surface. They differ by roughly a metre across North America, and
+  // a change study spanning the two would have reported that offset as ground
+  // movement.
+  it('separates two datums that share a reference surface', () => {
+    const navd = navd88();
+    const egm = spatialContextFrom(
+      crs({ verticalEpsg: 3855, verticalDatum: 'EGM2008', verticalUnitToMetres: 1 }),
+    );
+    expect(navd.verticalReference).toBe(egm.verticalReference); // both orthometric
+    const v = compareSpatialFrames(navd, egm);
+    expect(v.verticalFrameConflict).toBe(true);
+    expect(v.verticalComparable).toBe(false);
+    expect(v.notes.some((n) => n.includes('common surface'))).toBe(true);
+  });
+
+  it('still matches one datum declared by code against the same datum by name', () => {
+    // The identity is the resolved code, so a frame naming NAVD88 and a frame
+    // carrying 5703 are the same reference rather than two spellings.
+    const byCode = spatialContextFrom(crs({ verticalEpsg: 5703, verticalUnitToMetres: 1 }));
+    const byName = spatialContextFrom(crs({ verticalDatum: 'NAVD88', verticalUnitToMetres: 1 }));
+    const v = compareSpatialFrames(byCode, byName);
+    expect(v.verticalFrameConflict).toBe(false);
+    expect(v.verticalComparable).toBe(true);
+  });
+
   it('horizontal agreement does NOT imply vertical agreement', () => {
     const a = navd88();
     const b = spatialContextFrom(

--- a/tests/projectPlacement.test.ts
+++ b/tests/projectPlacement.test.ts
@@ -1,9 +1,42 @@
 import { describe, it, expect } from 'vitest';
 import { planPlacement, placeInProject } from '../src/geo/projectPlacement';
+import { spatialContextFrom } from '../src/geo/SpatialContext';
+import type { CrsInfo } from '../src/io/crs';
 import type { GlobalPoints } from '../src/convert/globalPoints';
 
+const US_SURVEY_FOOT = 1200 / 3937;
+
+function crs(over: Partial<CrsInfo> = {}): CrsInfo {
+  return {
+    source: 'wkt',
+    name: 'WGS 84 / UTM zone 12N',
+    epsg: 32612,
+    linearUnit: 'metre',
+    linearUnitToMetres: 1,
+    isGeographic: false,
+    ...over,
+  };
+}
+
+/** A frame whose vertical side is fully declared: NAVD88 heights in metres. */
+const navd88Metres = () =>
+  spatialContextFrom(crs({ verticalEpsg: 5703, verticalDatum: 'NAVD88', verticalUnitToMetres: 1 }));
+
+/** The same datum, declared in US survey feet. */
+const navd88Feet = () =>
+  spatialContextFrom(
+    crs({ verticalEpsg: 5703, verticalDatum: 'NAVD88', verticalUnitToMetres: US_SURVEY_FOOT }),
+  );
+
+/** A different vertical surface, also fully declared, also in metres. */
+const egm2008Metres = () =>
+  spatialContextFrom(crs({ verticalEpsg: 3855, verticalDatum: 'EGM2008', verticalUnitToMetres: 1 }));
+
+/** Nothing declared vertically. */
+const noVertical = () => spatialContextFrom(crs());
+
 describe('planPlacement', () => {
-  const both = { layerVerticalKnown: true, projectVerticalKnown: true };
+  const both = { layerFrame: navd88Metres(), projectFrame: navd88Metres() };
 
   it('reprojects between two known projected CRSs, height comparable', () => {
     const p = planPlacement({ layerEpsg: 32611, projectEpsg: 32612, ...both });
@@ -29,10 +62,50 @@ describe('planPlacement', () => {
   });
 
   it('withholds height comparability when a vertical datum is unresolved', () => {
-    const p = planPlacement({ layerEpsg: 32611, projectEpsg: 32612, layerVerticalKnown: true, projectVerticalKnown: false });
+    const p = planPlacement({
+      layerEpsg: 32611,
+      projectEpsg: 32612,
+      layerFrame: navd88Metres(),
+      projectFrame: noVertical(),
+    });
     expect(p.horizontal).toBe('reproject'); // X/Y still placed
     expect(p.verticalComparable).toBe(false);
+    expect(p.reason).toContain('Vertical datum is unknown');
+  });
+
+  // Both sides fully declared is not the same question as both sides
+  // comparable. These two cases are the ones a "is it known?" test cannot see.
+  it('withholds height when two resolved datums sit on different surfaces', () => {
+    const p = planPlacement({
+      layerEpsg: 32612,
+      projectEpsg: 32612,
+      layerFrame: navd88Metres(),
+      projectFrame: egm2008Metres(),
+    });
+    expect(p.horizontal).toBe('identity');
+    expect(p.verticalComparable).toBe(false);
+    expect(p.reason).toContain('common surface');
+  });
+
+  it('withholds height when one resolved datum is in feet and the other in metres', () => {
+    const p = planPlacement({
+      layerEpsg: 32612,
+      projectEpsg: 32612,
+      layerFrame: navd88Feet(),
+      projectFrame: navd88Metres(),
+    });
+    expect(p.verticalComparable).toBe(false);
     expect(p.reason).toContain('withheld');
+  });
+
+  it('allows height when the datum and the vertical unit both match', () => {
+    const p = planPlacement({
+      layerEpsg: 32611,
+      projectEpsg: 32612,
+      layerFrame: navd88Metres(),
+      projectFrame: navd88Metres(),
+    });
+    expect(p.verticalComparable).toBe(true);
   });
 });
 


### PR DESCRIPTION
`verticalIdentity` in `frameCompatibility.ts` keyed on the vertical reference class, and its comment claimed that class folds EPSG and name into one answer. It does not: `VerticalReference` is a surface, so NAVD88 and EGM2008 both resolve to `orthometric` and compared as the same reference. The two differ by roughly a metre across North America, and `src/app/epochFramePrep.ts` uses this comparison for epoch change, so that offset could be reported as ground movement.

Identity is now the resolved vertical EPSG code, falling back to the declared datum name and then to the class. A datum given by code and the same datum given by name still match.

`planPlacement` held a second rule, treating both datums being resolved as comparable, which cannot express two resolved datums that differ. It now takes the two frames and delegates.
