### PR TITLE
feat(measure): make every box corner a drag handle

### DIFF
--- a/src/render/measure/MeasureController.ts
+++ b/src/render/measure/MeasureController.ts
@@ -49,6 +49,7 @@ import {
   BOX_EDGES,
   elevationDatumOffset,
 } from './geometry';
+import { resizeBoxByCorner, BOX_CORNER_INDICES, type BoxCornerIndex } from './boxEdit';
 import { areaBreakdown, lineBreakdown } from './measureBreakdown';
 import type { AreaBreakdown, LineBreakdown } from './measureBreakdown';
 import {
@@ -1683,7 +1684,24 @@ export class MeasureController {
     const point = this._picker(this._dragNdcX, this._dragNdcY);
     if (!point) return;
     const m = this._measurements.find((x) => x.id === drag.id);
-    if (m && drag.vi < m.points.length) {
+    if (!m) return;
+    if (m.kind === 'box' && m.points.length >= 2 && drag.vi >= 0 && drag.vi <= 7) {
+      // A box handle names a wireframe corner, not a stored point. Resizing
+      // keeps the diagonally opposite corner fixed and re-normalises, so the
+      // stored pair stays a valid min/max diagonal and every derived figure
+      // (dimensions, volume, surface area) recomputes from the edited box on
+      // the next model build.
+      const next = resizeBoxByCorner(
+        boxFromCorners(m.points[0], m.points[1]),
+        drag.vi as BoxCornerIndex,
+        [point[0], point[1], point[2]],
+        this._worldUp,
+      );
+      m.points[0] = [next.min[0], next.min[1], next.min[2]];
+      m.points[1] = [next.max[0], next.max[1], next.max[2]];
+      return;
+    }
+    if (drag.vi < m.points.length) {
       m.points[drag.vi] = [point[0], point[1], point[2]];
     }
   }
@@ -1926,13 +1944,19 @@ export class MeasureController {
     L: OverlayLabel[],
   ): void {
     const pts = m.points;
-    pts.forEach((p, i) => {
-      V.push({
-        p,
-        role: 'normal',
-        handle: this._active ? { mid: m.id, vi: i } : undefined,
+    // A box draws its handles on all 8 wireframe corners below, not on the two
+    // stored pick points: only two of a box's corners are stored, and offering
+    // a handle on just those two would leave six corners that look identical
+    // and behave differently.
+    if (m.kind !== 'box') {
+      pts.forEach((p, i) => {
+        V.push({
+          p,
+          role: 'normal',
+          handle: this._active ? { mid: m.id, vi: i } : undefined,
+        });
       });
-    });
+    }
 
     if (m.kind === 'distance' && pts.length >= 2) {
       E.push({ a: pts[0], b: pts[1], style: 'solid' });
@@ -2103,6 +2127,15 @@ export class MeasureController {
       // clipping uniform) read from one source of truth.
       const box = boxFromCorners(pts[0], pts[1]);
       const corners = boxCorners(box, this._worldUp);
+      // The handle index IS the corner index in `boxCorners` order, so the
+      // drag resolves the anchor from the same table the wireframe drew.
+      for (const ci of BOX_CORNER_INDICES) {
+        V.push({
+          p: corners[ci],
+          role: 'normal',
+          handle: this._active ? { mid: m.id, vi: ci } : undefined,
+        });
+      }
       for (const [aI, bI] of BOX_EDGES) {
         E.push({ a: corners[aI], b: corners[bI], style: 'solid' });
       }

--- a/src/render/measure/boxEdit.ts
+++ b/src/render/measure/boxEdit.ts
@@ -1,0 +1,60 @@
+/**
+ * boxEdit.ts
+ *
+ * Pure corner-resize mathematics for a Box measurement. No three.js, no DOM,
+ * so the "where does this box end up" question is answerable in Node without
+ * a viewer.
+ *
+ * A box is stored as two opposite pick points and normalised by
+ * `boxFromCorners`, so it is axis-aligned by construction. Resizing it from a
+ * corner therefore has exactly one honest meaning: the corner diagonally
+ * opposite the grabbed one stays where it is, and the grabbed corner moves to
+ * the new point. Everything else (which extents grow, which shrink, whether
+ * the drag crossed the anchor) falls out of re-normalising that pair.
+ */
+
+import { boxFromCorners, boxCorners, type BoxBounds } from './geometry';
+import type { Vec3 } from '../navMath';
+
+/** An index into the 8 corners `boxCorners` emits, in that same order. */
+export type BoxCornerIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+/** Every corner index, for callers that draw a handle on each one. */
+export const BOX_CORNER_INDICES: readonly BoxCornerIndex[] = [0, 1, 2, 3, 4, 5, 6, 7];
+
+/**
+ * The corner diagonally across the box from `corner`, in `boxCorners` order.
+ *
+ * `boxCorners` emits the low face first (indices 0-3, CCW) then the high face
+ * (4-7, CCW from the same start), both relative to the scan's up-axis. Across
+ * the body diagonal that pairs 0 with 6, 1 with 7, 2 with 4 and 3 with 5. The
+ * mapping is its own inverse, which is what lets a drag that crosses the
+ * anchor be handled by re-normalisation instead of by re-indexing.
+ */
+export function oppositeCornerIndex(corner: BoxCornerIndex): BoxCornerIndex {
+  const OPPOSITE: readonly BoxCornerIndex[] = [6, 7, 4, 5, 2, 3, 0, 1];
+  return OPPOSITE[corner];
+}
+
+/**
+ * The box that results from dragging one corner to `dragged`, with the
+ * opposite corner held fixed.
+ *
+ * `up` selects which axis `corner` counts as vertical, exactly as it does in
+ * `boxCorners`; a Y-up frame (phone-scan meshes) numbers its corners around a
+ * different pair of horizontal axes, so passing the wrong up vector anchors
+ * the drag to the wrong corner rather than merely mislabelling one.
+ *
+ * A drag past the anchor is not an error state: `boxFromCorners` re-normalises
+ * per axis, so the result always has `min <= max` on every axis and the box
+ * flips through zero extent rather than inverting.
+ */
+export function resizeBoxByCorner(
+  box: BoxBounds,
+  corner: BoxCornerIndex,
+  dragged: Vec3,
+  up: Vec3 = [0, 0, 1],
+): BoxBounds {
+  const anchor = boxCorners(box, up)[oppositeCornerIndex(corner)];
+  return boxFromCorners(anchor, dragged);
+}

--- a/tests/boxCornerEdit.test.ts
+++ b/tests/boxCornerEdit.test.ts
@@ -1,0 +1,101 @@
+/**
+ * boxCornerEdit.test.ts
+ *
+ * A committed Box measurement can be resized by dragging any of its 8
+ * wireframe corners. The rules that make that trustworthy:
+ *
+ *   - the corner diagonally opposite the dragged one does not move at all;
+ *   - a drag past that anchor yields a normalised box, never a negative
+ *     extent or a min/max swap;
+ *   - the panel figures (dimensions, volume, surface area) follow the edit;
+ *   - the corner numbering follows the scan's up-axis, so a Y-up frame
+ *     anchors the drag to a different corner than a Z-up one would.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resizeBoxByCorner, oppositeCornerIndex, BOX_CORNER_INDICES } from '../src/render/measure/boxEdit';
+import { boxFromCorners, boxCorners, boxMetrics } from '../src/render/measure/geometry';
+import type { Vec3 } from '../src/render/navMath';
+
+const BOX = boxFromCorners([0, 0, 0], [10, 20, 5]);
+
+describe('box corner resize', () => {
+  it('holds the opposite corner exactly still while the dragged corner moves', () => {
+    for (const ci of BOX_CORNER_INDICES) {
+      const before = boxCorners(BOX, [0, 0, 1]);
+      const anchor = before[oppositeCornerIndex(ci)];
+      const dragged: Vec3 = [
+        before[ci][0] + 3.25,
+        before[ci][1] - 1.5,
+        before[ci][2] + 0.75,
+      ];
+      const after = boxCorners(resizeBoxByCorner(BOX, ci, dragged, [0, 0, 1]), [0, 0, 1]);
+      expect(after[oppositeCornerIndex(ci)]).toEqual(anchor);
+      expect(after[ci]).toEqual(dragged);
+    }
+  });
+
+  it('re-normalises a drag past the anchor instead of inverting the box', () => {
+    // Corner 0 is the low corner on all three axes; dragging it well beyond
+    // corner 6 turns the box inside out unless the pair is re-normalised.
+    const out = resizeBoxByCorner(BOX, 0, [40, 50, 30], [0, 0, 1]);
+    expect(out.min).toEqual([10, 20, 5]);
+    expect(out.max).toEqual([40, 50, 30]);
+    for (let axis = 0; axis < 3; axis++) {
+      expect(out.max[axis]).toBeGreaterThanOrEqual(out.min[axis]);
+    }
+    // The mirror case: dragging the HIGH corner below the low one puts the
+    // anchor above the dragged point on every axis, which is the ordering an
+    // un-normalised min/max pair gets backwards.
+    const flipped = resizeBoxByCorner(BOX, 6, [-4, -6, -2], [0, 0, 1]);
+    expect(flipped.min).toEqual([-4, -6, -2]);
+    expect(flipped.max).toEqual([0, 0, 0]);
+    const fm = boxMetrics(flipped, [0, 0, 1]);
+    expect([fm.width, fm.depth, fm.height]).toEqual([4, 6, 2]);
+    const m = boxMetrics(out, [0, 0, 1]);
+    expect(m.width).toBeGreaterThan(0);
+    expect(m.depth).toBeGreaterThan(0);
+    expect(m.height).toBeGreaterThan(0);
+    expect(m.volume).toBeCloseTo(30 * 30 * 25, 9);
+  });
+
+  it('recomputes the reported dimensions from the edited box', () => {
+    const before = boxMetrics(BOX, [0, 0, 1]);
+    expect([before.width, before.depth, before.height]).toEqual([10, 20, 5]);
+    // Drag corner 6 (max on every axis) outward by 2 m on each axis.
+    const out = resizeBoxByCorner(BOX, 6, [12, 22, 7], [0, 0, 1]);
+    const after = boxMetrics(out, [0, 0, 1]);
+    expect([after.width, after.depth, after.height]).toEqual([12, 22, 7]);
+    expect(after.volume).toBeCloseTo(12 * 22 * 7, 9);
+    expect(after.surfaceArea).toBeCloseTo(2 * (12 * 22 + 22 * 7 + 12 * 7), 9);
+  });
+
+  it('anchors the drag by the scan up-axis, not by an assumed Z', () => {
+    // Corner 2 is (low-up, high-h1, high-h2). Under Z-up the horizontal pair
+    // is (X, Y), so corner 2 sits at min-Z; under Y-up it is (X, Z), so the
+    // same index names a corner at min-Y. Same drag, different anchor,
+    // different box: a hardcoded Z here gives a numerically wrong answer on a
+    // Y-up frame rather than a merely mislabelled one.
+    const dragged: Vec3 = [3, 4, 1];
+    const zUp = resizeBoxByCorner(BOX, 2, dragged, [0, 0, 1]);
+    const yUp = resizeBoxByCorner(BOX, 2, dragged, [0, 1, 0]);
+    expect(yUp).not.toEqual(zUp);
+    // Z-up: corner 2 is (max-X, max-Y, min-Z); anchor is (0, 0, 5).
+    expect(zUp).toEqual({ min: [0, 0, 1], max: [3, 4, 5] });
+    // Y-up: corner 2 is (max-X, min-Y, max-Z); anchor is (0, 20, 0).
+    expect(yUp).toEqual({ min: [0, 4, 0], max: [3, 20, 1] });
+    // And the height for each answer comes off its own up-axis.
+    expect(boxMetrics(zUp, [0, 0, 1]).height).toBeCloseTo(4, 9);
+    expect(boxMetrics(yUp, [0, 1, 0]).height).toBeCloseTo(16, 9);
+  });
+
+  it('pairs every corner with its diagonal opposite, involutively', () => {
+    for (const ci of BOX_CORNER_INDICES) {
+      expect(oppositeCornerIndex(oppositeCornerIndex(ci))).toBe(ci);
+      const c = boxCorners(BOX, [0, 0, 1]);
+      const a = c[ci];
+      const b = c[oppositeCornerIndex(ci)];
+      for (let axis = 0; axis < 3; axis++) expect(a[axis]).not.toBe(b[axis]);
+    }
+  });
+});


### PR DESCRIPTION
A box measurement drew eight corners but only two of them could be dragged: the generic vertex loop emitted handles for the two stored points, and the other six looked identical and did nothing.

All eight corners are handles now, through the existing overlay handle system rather than a second dragging path. `resizeBoxByCorner` in `src/render/measure/boxEdit.ts` is pure: it anchors the opposite corner and rebuilds through `boxFromCorners`, so normalisation is inherited and a corner dragged past its opposite yields a valid box rather than a negative extent. Corner numbering comes from `boxCorners`, so a non-Z up axis is respected.

Sessions are unaffected: the edit rewrites the same two stored points.
