### PR TITLE
fix(profile): state the ground basis on screen, and fit the axis labels

### DIFF
--- a/src/app/profileWorkbenchSection.ts
+++ b/src/app/profileWorkbenchSection.ts
@@ -49,6 +49,10 @@ import {
   type ProfileRenderingContext,
   type ProfileSurface,
 } from '../render/measure/profileSectionRenderer';
+import {
+  describeClassBasis,
+  GROUND_BASIS_UNVERIFIED_NOTE,
+} from '../render/measure/profileProvenance';
 import { axisSpanCaption } from '../render/measure/profileAxes';
 import {
   selectProfileSectionLod,
@@ -176,6 +180,13 @@ function boundsOf(
 export interface WorkbenchSectionView {
   /** The scope sentence the seam composed for this extraction. */
   readonly scope: string;
+  /**
+   * What a missing classification means for the heights, or null when every
+   * source carried one. The exported sheet has always stated this basis; the
+   * note exists so a reader working on screen is told the same thing without
+   * having to export a PDF to find it.
+   */
+  readonly groundBasisNote: string | null;
   /** One polite line about what was drawn. */
   readonly status: string;
   /** The figures behind the plot, as text. */
@@ -334,7 +345,18 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
         : `Showing ${section.points.count} returns.`;
 
   return {
-    view: { scope: section.scopeLabel, status, detail, drawn: indices.length },
+    view: {
+      // The class clause joins the scope sentence rather than standing apart,
+      // because both answer the one question a reader has about the plot:
+      // what was read, and what could be excluded from it.
+      scope: `${section.scopeLabel} · ${describeClassBasis(section.classificationOnEverySource)}`,
+      groundBasisNote: section.classificationOnEverySource
+        ? null
+        : GROUND_BASIS_UNVERIFIED_NOTE,
+      status,
+      detail,
+      drawn: indices.length,
+    },
     indices,
     draw,
     frame: () => lastFrame,
@@ -445,6 +467,7 @@ export function presentWorkbenchSection(
     canvas: HTMLCanvasElement;
     overlay?: HTMLCanvasElement;
     setScope(text: string): void;
+    setGroundBasis(note: string | null): void;
     setStatus(text: string): void;
     setDetail(rows: readonly ProfileWorkbenchDetailRow[] | null): void;
     setReadout?(text: string | null): void;
@@ -501,6 +524,7 @@ export function presentWorkbenchSection(
       unitScale: metres ?? 1,
     });
     handle.setScope(plot.view.scope);
+    handle.setGroundBasis(plot.view.groundBasisNote);
     handle.setStatus(plot.view.status);
     handle.setDetail(plot.view.detail);
     link = attachSectionPointLink({

--- a/src/render/measure/profileAxes.ts
+++ b/src/render/measure/profileAxes.ts
@@ -428,65 +428,143 @@ export function profileAxes(
 // Fitting labels along an axis
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** One candidate tick label, positioned along the axis. */
-export interface AxisLabelBox {
-  /** Position along the axis, as a fraction of its length. */
-  readonly at: number;
-  /** Rendered width of the text, in the same units as the axis length. */
-  readonly width: number;
+/**
+ * Width one character of a label occupies, as a fraction of the font size.
+ *
+ * A bound, not a measurement, and rounded the only way that fails safe.
+ * Overstating a label's width can only drop a label that would have fitted,
+ * which is legible. Understating it lets two labels overlap, which is not.
+ * Measured in a browser at the axis font, the widest case is a short label of
+ * wide digits: `88 m` runs 6.74px at 11px, or 0.613em. Short labels are the
+ * wide ones per character, so a mean taken over long labels understates
+ * exactly the ones at risk.
+ *
+ * Expressed per em rather than per pixel so it follows the font size instead
+ * of silently going stale when the axis type scale changes.
+ */
+export const AXIS_LABEL_CHAR_EM = 0.62;
+
+/**
+ * Least clear space between two kept labels, in CSS pixels.
+ *
+ * Clear space, not centre distance: two labels that merely fail to overlap
+ * still read as one run of digits, which is the failure being avoided.
+ */
+export const AXIS_LABEL_MIN_GAP_PX = 8;
+
+/** Width a label occupies at `fontPx`, erring wide. */
+export function axisLabelWidth(label: string, fontPx: number): number {
+  const size = Number.isFinite(fontPx) && fontPx > 0 ? fontPx : 0;
+  return label.length * size * AXIS_LABEL_CHAR_EM;
 }
 
 /**
- * Which labels along an axis can be drawn without touching.
+ * How a renderer places the labels at the two ends of the strip.
  *
- * Thinning by index is the obvious approach and it does not work: a label
- * collides in PIXELS, and equal index spacing is equal pixel spacing only
- * when every label is the same width and anchored the same way. Neither
- * holds here. The end labels are pulled inside the plot so they cannot
- * overhang it, so the first is left-aligned and the last right-aligned while
- * everything between is centred, and a label near the end sits closer to it
- * than its index suggests.
+ * `centred` draws every label centred on its tick, so an end label can hang
+ * past the strip and is dropped rather than clipped: half a number at the edge
+ * states a value the axis is not showing.
  *
- * The ends are kept because they carry the axis range, which is what a reader
- * takes from the axis first. Interior labels are then accepted left to right
- * only where the box clears both its accepted neighbour and the end, so a
- * dropped label costs a tick mark rather than the extent of the axis.
- *
- * `minGap` is clear space, not centre distance: two labels that merely touch
- * read as one longer label, which is the failure being avoided.
+ * `pulled-in` is for a renderer that anchors the ends inside the strip, the
+ * first flush left and the last flush right. Nothing can overhang, so the ends
+ * are kept and they carry the axis range, which is what a reader takes from an
+ * axis first. The two are not interchangeable: judging a pulled-in last label
+ * as though it were centred puts half its box past the end of the strip and
+ * drops it, and judging a centred one as pulled-in lets it overhang.
  */
-export function fitAxisLabels(
-  labels: readonly AxisLabelBox[],
-  axisLength: number,
-  minGap: number,
-): boolean[] {
-  const keep = labels.map(() => false);
-  if (labels.length === 0) return keep;
-  if (labels.length === 1) {
-    keep[0] = true;
-    return keep;
+export type AxisLabelEnds = 'centred' | 'pulled-in';
+
+/** What the fitter is told about the strip the labels are drawn in. */
+export interface AxisLabelFit {
+  /** Label text, one per tick, in the tick order. */
+  readonly labels: readonly string[];
+  /** Centre of each label along the strip, CSS pixels. */
+  readonly pixels: readonly number[];
+  /** Extent of the strip, CSS pixels. A smaller value is the safe direction. */
+  readonly containerPx: number;
+  /** Font size the labels will be drawn at, CSS pixels. */
+  readonly fontPx: number;
+  /**
+   * Extent of one label ACROSS the strip rather than along it. Absent, the
+   * text width is used, which is the horizontal axis; a vertical axis passes
+   * the line height, because its labels are stacked and their widths never
+   * collide with one another.
+   */
+  readonly extentPx?: (label: string) => number;
+  /** How the ends are anchored. Defaults to `centred`. */
+  readonly ends?: AxisLabelEnds;
+}
+
+/**
+ * Which labels may be drawn without two of them touching.
+ *
+ * WHY NOT EVERY SECOND ONE. Index-based thinning assumes the labels are evenly
+ * spaced in pixels and equally wide, and an axis satisfies neither: the
+ * transform that places a tick is not required to be uniform across the
+ * visible span, and `-1250.5` is more than twice the width of `0`. Thinning by
+ * index drops readable labels in the sparse part of an axis while leaving the
+ * crowded part still overlapping, which is the worst of both. This walks the
+ * strip and keeps a label only when the space it needs is actually free.
+ *
+ * Fitting from one end and never backtracking: the first label that fits is
+ * kept, and each later one only when its space is still free.
+ *
+ * Returns one flag per input label, in the input order.
+ */
+export function fitAxisLabels(fit: AxisLabelFit): boolean[] {
+  const n = Math.min(fit.labels.length, fit.pixels.length);
+  const keep = new Array<boolean>(fit.labels.length).fill(false);
+  if (n === 0) return keep;
+  const font = Number.isFinite(fit.fontPx) && fit.fontPx > 0 ? fit.fontPx : 0;
+  // A container of unknown or negative extent reads as zero, which keeps only
+  // the labels that need no room at all. Too narrow is the safe direction.
+  const container = Number.isFinite(fit.containerPx) && fit.containerPx > 0 ? fit.containerPx : 0;
+  const extent = fit.extentPx ?? ((label: string) => axisLabelWidth(label, font));
+  const pulledIn = fit.ends === 'pulled-in';
+
+  // Strip order, not tick order: a vertical axis places its first tick at the
+  // BOTTOM of the strip, and a walk in tick order would compare a label with
+  // one that is not its neighbour on screen.
+  const order: number[] = [];
+  for (let i = 0; i < n; i++) if (Number.isFinite(fit.pixels[i]!)) order.push(i);
+  order.sort((a, b) => fit.pixels[a]! - fit.pixels[b]!);
+  const firstIdx = order[0];
+  const lastIdx = order[order.length - 1];
+
+  /** The span a label occupies, given how its end is anchored. */
+  const spanOf = (i: number): readonly [number, number] => {
+    const w = extent(fit.labels[i] ?? '');
+    if (pulledIn && i === firstIdx) return [0, w];
+    if (pulledIn && i === lastIdx) return [container - w, container];
+    const half = w / 2;
+    return [fit.pixels[i]! - half, fit.pixels[i]! + half];
+  };
+
+  // A pulled-in strip reserves its far end before the walk, so an interior
+  // label cannot take the space the range label needs. The near end is the
+  // walk's own starting point and needs no reservation.
+  let reservedFrom = Infinity;
+  if (pulledIn && order.length > 1) {
+    const [lo, hi] = spanOf(lastIdx);
+    // The two ends can collide on a short strip. The far end wins, because a
+    // reader scanning for the extent looks at the end of the axis.
+    if (lo >= 0 && hi <= container) {
+      keep[lastIdx] = true;
+      reservedFrom = lo;
+    }
   }
-  if (!(axisLength > 0)) return keep;
 
-  const last = labels.length - 1;
-  // Left-aligned first, right-aligned last: the span each end label occupies.
-  const firstRight = labels[0].width;
-  const lastLeft = axisLength - labels[last].width;
-  keep[0] = true;
-  // The end labels themselves can collide on a short axis. The far end wins,
-  // because a reader scanning for the extent looks at the end of the axis.
-  keep[last] = lastLeft - firstRight >= minGap;
-  if (!keep[last]) return keep;
-
-  let occupiedTo = firstRight;
-  for (let i = 1; i < last; i++) {
-    const half = labels[i].width / 2;
-    const left = labels[i].at * axisLength - half;
-    const right = left + labels[i].width;
-    if (left - occupiedTo < minGap) continue;
-    if (lastLeft - right < minGap) continue;
+  let occupiedTo = -Infinity;
+  let anyKept = false;
+  for (const i of order) {
+    if (i === lastIdx && keep[lastIdx]) continue;
+    const [start, end] = spanOf(i);
+    if (start < 0 || end > container) continue;
+    if (anyKept && start < occupiedTo + AXIS_LABEL_MIN_GAP_PX) continue;
+    if (end > reservedFrom - AXIS_LABEL_MIN_GAP_PX) continue;
     keep[i] = true;
-    occupiedTo = right;
+    anyKept = true;
+    occupiedTo = end;
   }
   return keep;
 }

--- a/src/render/measure/profileAxes.ts
+++ b/src/render/measure/profileAxes.ts
@@ -423,3 +423,70 @@ export function profileAxes(
     },
   };
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fitting labels along an axis
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One candidate tick label, positioned along the axis. */
+export interface AxisLabelBox {
+  /** Position along the axis, as a fraction of its length. */
+  readonly at: number;
+  /** Rendered width of the text, in the same units as the axis length. */
+  readonly width: number;
+}
+
+/**
+ * Which labels along an axis can be drawn without touching.
+ *
+ * Thinning by index is the obvious approach and it does not work: a label
+ * collides in PIXELS, and equal index spacing is equal pixel spacing only
+ * when every label is the same width and anchored the same way. Neither
+ * holds here. The end labels are pulled inside the plot so they cannot
+ * overhang it, so the first is left-aligned and the last right-aligned while
+ * everything between is centred, and a label near the end sits closer to it
+ * than its index suggests.
+ *
+ * The ends are kept because they carry the axis range, which is what a reader
+ * takes from the axis first. Interior labels are then accepted left to right
+ * only where the box clears both its accepted neighbour and the end, so a
+ * dropped label costs a tick mark rather than the extent of the axis.
+ *
+ * `minGap` is clear space, not centre distance: two labels that merely touch
+ * read as one longer label, which is the failure being avoided.
+ */
+export function fitAxisLabels(
+  labels: readonly AxisLabelBox[],
+  axisLength: number,
+  minGap: number,
+): boolean[] {
+  const keep = labels.map(() => false);
+  if (labels.length === 0) return keep;
+  if (labels.length === 1) {
+    keep[0] = true;
+    return keep;
+  }
+  if (!(axisLength > 0)) return keep;
+
+  const last = labels.length - 1;
+  // Left-aligned first, right-aligned last: the span each end label occupies.
+  const firstRight = labels[0].width;
+  const lastLeft = axisLength - labels[last].width;
+  keep[0] = true;
+  // The end labels themselves can collide on a short axis. The far end wins,
+  // because a reader scanning for the extent looks at the end of the axis.
+  keep[last] = lastLeft - firstRight >= minGap;
+  if (!keep[last]) return keep;
+
+  let occupiedTo = firstRight;
+  for (let i = 1; i < last; i++) {
+    const half = labels[i].width / 2;
+    const left = labels[i].at * axisLength - half;
+    const right = left + labels[i].width;
+    if (left - occupiedTo < minGap) continue;
+    if (lastLeft - right < minGap) continue;
+    keep[i] = true;
+    occupiedTo = right;
+  }
+  return keep;
+}

--- a/src/render/measure/profileProvenance.ts
+++ b/src/render/measure/profileProvenance.ts
@@ -363,11 +363,35 @@ export function describeProfileProvenance(record: ProfileProvenance): string {
       : record.complete === false
         ? 'incomplete read'
         : 'coverage unknown';
-  const classes = record.classPolicy.availableOnEverySource
+  return `${base}, ${coverage}, ${describeClassBasis(record.classPolicy.availableOnEverySource)}`;
+}
+
+/**
+ * The clause naming what the class-exclusion policy could actually act on.
+ *
+ * Both the exported sheet and the on-screen workbench state this, from here,
+ * because a reader who is told the basis on paper and not on screen has to
+ * export a PDF to learn how the heights in front of them were chosen.
+ */
+export function describeClassBasis(availableOnEverySource: boolean): string {
+  return availableOnEverySource
     ? 'classification on every source'
     : 'classification missing on a source';
-  return `${base}, ${coverage}, ${classes}`;
 }
+
+/**
+ * What a missing classification means for the figures read off the surface.
+ *
+ * Vegetation and buildings are dropped before the percentile only where a
+ * source classifies them. Without that, the percentile still runs, over every
+ * return: on open ground it lands near the surface, and under canopy it lands
+ * in the canopy. Grade is a difference between two such heights, so it
+ * inherits whatever the surface followed.
+ */
+export const GROUND_BASIS_UNVERIFIED_NOTE =
+  'Heights here are a percentile of every return, because a source carries no ' +
+  'classification. Where vegetation hides the ground the surface follows the ' +
+  'canopy, and the grades follow it too.';
 
 // --- internals ---------------------------------------------------------------
 

--- a/src/render/measure/profileSectionSeam.ts
+++ b/src/render/measure/profileSectionSeam.ts
@@ -141,6 +141,17 @@ export interface ProfileSectionResult {
   readonly scope: ProfileSectionScope;
   /** The sentence a header shows for {@link scope}. */
   readonly scopeLabel: string;
+  /**
+   * True only when every contributing source carried a usable classification
+   * channel, so the class exclusion could act on all of them. The same
+   * question `ProfileClassPolicy.availableOnEverySource` answers for the
+   * exported record, decided here by the same channel-alignment rule, so the
+   * screen and the sheet cannot disagree about what shaped the heights.
+   *
+   * False when nothing contributed: no availability can be asserted over an
+   * empty read.
+   */
+  readonly classificationOnEverySource: boolean;
   /** Null when the streaming source's node count is not known. */
   readonly streamingComplete: boolean | null;
   readonly sources: readonly ProfileSectionSourceRef[];
@@ -381,9 +392,14 @@ export function createProfileSectionSeam(deps: ProfileSectionSeamDeps): ProfileS
     const { statics, residents } = walkScene(deps);
     const sources: ProfileSectionSourceView[] = [];
     const refs: ProfileSectionSourceRef[] = [];
+    // Tallied while the views are built, from the same `alignedClassification`
+    // decision `viewOf` makes, so a channel rejected for misalignment counts as
+    // absent here too rather than as classification that was never applied.
+    let classifiedSources = 0;
     for (const { layer, pos } of statics) {
       const slot = sources.length;
       sources.push(viewOf(slot, pos, layer.channels, layer.bounds, layer.placement));
+      if (alignedClassification(layer.channels, pos.length) !== undefined) classifiedSources++;
       refs.push({ slot, kind: 'static', id: layer.id, pointCount: pos.length / 3 });
     }
     for (const { node, pos } of residents) {
@@ -392,6 +408,7 @@ export function createProfileSectionSeam(deps: ProfileSectionSeamDeps): ProfileS
       // render origin, and the terms it was admitted on are what say that
       // origin is the project's.
       sources.push(viewOf(slot, pos, node.channels, null, null));
+      if (alignedClassification(node.channels, pos.length) !== undefined) classifiedSources++;
       refs.push({ slot, kind: 'resident', id: node.key, pointCount: pos.length / 3 });
     }
     const extraction = extractProfileSectionChunks({
@@ -422,6 +439,7 @@ export function createProfileSectionSeam(deps: ProfileSectionSeamDeps): ProfileS
       band,
       scope,
       scopeLabel: describeSectionScope(scope, complete),
+      classificationOnEverySource: sources.length > 0 && classifiedSources === sources.length,
       streamingComplete: complete,
       sources: refs,
       generation: token,

--- a/src/styles/01-tokens.css
+++ b/src/styles/01-tokens.css
@@ -19,6 +19,7 @@
   --text: #eef3fb;
   --text-dim: #9aa6bd;
   --text-faint: #8a94ad; /* lightened from #6b768f to clear WCAG AA (≥4.5:1) on --bg */
+  --warn: #b8860b; /* the provenance-caption amber; 5.1:1 on its own 12% fill here */
   --accent: #00b2ff;      /* Electric Blue */
   --accent-soft: rgba(0, 178, 255, 0.16);
   /* Ink colour for text/glyphs ON a solid --accent fill (primary

--- a/src/styles/03-theme-rails.css
+++ b/src/styles/03-theme-rails.css
@@ -21,6 +21,7 @@ body.olv-theme-light {
   --text: #0a1430;
   --text-dim: #46546e;
   --text-faint: #5d6a87; /* darkened from #7682a0 to clear WCAG AA (≥4.5:1) on the light --bg */
+  --warn: #7d5b07; /* darkened from #b8860b, which read 2.9:1 on the near-white caption fill */
   --accent: #0088c8;
   --accent-soft: rgba(0, 136, 200, 0.18);
   /* Deeper violet so the blocked verdict stays legible on the near-white panel. */
@@ -54,6 +55,7 @@ body.olv-theme-high-contrast {
   --text: #ffffff;
   --text-dim: #d9d9d9;
   --text-faint: #b3b3b3;
+  --warn: #f0b429; /* brightened for this rail: 8.8:1 on the caption fill, 10.6:1 on --panel */
   --accent: #5cd7ff;
   --accent-soft: rgba(92, 215, 255, 0.28);
   /* Bright violet — high luminance against pure black, holds WCAG AA. */

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -641,7 +641,9 @@
    note wraps rather than truncating, because a caution the reader cannot
    finish reading is not a caution. */
 .olv-workbench-basis {
-  margin: var(--space-2xs) 0 0; max-width: 62ch;
+  /* A filled, bordered box needs more air from the line above it than a bare
+     caption would, and none below: the header owns the gap to the plot. */
+  margin: var(--space-xs) 0 0; max-width: 62ch;
   white-space: normal; overflow-wrap: break-word;
 }
 .olv-workbench-actions { display: flex; gap: var(--space-xs); flex-shrink: 0; }

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -637,6 +637,13 @@
   font-size: var(--text-xs); color: var(--text-faint);
   font-variant-numeric: tabular-nums;
 }
+/* Styled with the provenance captions in 76; only the fit is set here. The
+   note wraps rather than truncating, because a caution the reader cannot
+   finish reading is not a caution. */
+.olv-workbench-basis {
+  margin: var(--space-2xs) 0 0; max-width: 62ch;
+  white-space: normal; overflow-wrap: break-word;
+}
 .olv-workbench-actions { display: flex; gap: var(--space-xs); flex-shrink: 0; }
 .olv-workbench-btn {
   font-size: var(--text-xs); color: var(--text-dim);

--- a/src/styles/76-classification.css
+++ b/src/styles/76-classification.css
@@ -72,10 +72,12 @@
 .olv-reclass-actions .olv-bc-pill { flex: 1; text-align: center; }
 /* The "Filtered — showing N of M classes" banner — persistent while filtered. */
 .olv-cl-banner {
-  font-size: 10.5px; font-variant-numeric: tabular-nums; color: var(--accent);
+  font-size: var(--text-xs); font-variant-numeric: tabular-nums; color: var(--accent);
   background: var(--accent-soft);
   border: 0.5px solid var(--hairline);
-  border-radius: 6px; padding: 5px 8px; margin-bottom: 8px;
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin-bottom: var(--space-md);
 }
 /* The provenance caption — a quiet amber note for a figure whose basis a
    reader would otherwise have to assume. One rule rather than one per panel:
@@ -86,10 +88,15 @@
 .olv-cl-samplenote,
 .olv-cl-streamnote,
 .olv-workbench-basis {
-  font-size: 10.5px; line-height: 1.35; color: var(--warn, #b8860b);
-  background: color-mix(in srgb, var(--warn, #b8860b) 12%, transparent);
-  border: 0.5px solid color-mix(in srgb, var(--warn, #b8860b) 35%, transparent);
-  border-radius: 6px; padding: 5px 8px; margin-bottom: 8px;
+  /* Same metrics as `.olv-cl-banner` above, on the token scale: the two sit
+     in one panel and read as one family, so a half-pixel apart in type size
+     is a difference the eye catches without being able to name. */
+  font-size: var(--text-xs); line-height: 1.35; color: var(--warn);
+  background: color-mix(in srgb, var(--warn) 12%, transparent);
+  border: 0.5px solid color-mix(in srgb, var(--warn) 35%, transparent);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin-bottom: var(--space-md);
 }
 .olv-cl-list { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
 .olv-cl-row {

--- a/src/styles/76-classification.css
+++ b/src/styles/76-classification.css
@@ -77,11 +77,15 @@
   border: 0.5px solid var(--hairline);
   border-radius: 6px; padding: 5px 8px; margin-bottom: 8px;
 }
-/* Derived-classification provenance caption — a quiet amber note so the
-   heuristic classes never read as an authoritative, file-supplied set. */
+/* The provenance caption — a quiet amber note for a figure whose basis a
+   reader would otherwise have to assume. One rule rather than one per panel:
+   a caption that looks the same everywhere is read the same everywhere, and
+   the profile workbench's ground-basis note means what this one means.
+   `.olv-workbench-basis` adds only its own spacing, in 74. */
 .olv-cl-derived,
 .olv-cl-samplenote,
-.olv-cl-streamnote {
+.olv-cl-streamnote,
+.olv-workbench-basis {
   font-size: 10.5px; line-height: 1.35; color: var(--warn, #b8860b);
   background: color-mix(in srgb, var(--warn, #b8860b) 12%, transparent);
   border: 0.5px solid color-mix(in srgb, var(--warn, #b8860b) 35%, transparent);

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -2021,31 +2021,29 @@ function renderProfileChart(
   // questions: the stride is how many labels an axis should carry, and the fit
   // is which of those the axis has room for.
   //
-  // Both constants below are bounds, not measurements, and each is rounded the
-  // only way that fails safe. This string is built before the overlay is in a
-  // document, so neither the chart's width nor a label's width can be read
+  // The width below is a bound, not a measurement. This string is built before
+  // the overlay is in a document, so the chart's real width cannot be read
   // here, and the two errors are not symmetric: believing the chart WIDER than
-  // it is, or a label NARROWER than it is, keeps a pair that then overprints,
-  // while the opposite direction costs a tick mark that the station table
-  // underneath still carries. So the width is the chart's CSS floor rather
-  // than its usual size, and the per-character figure is the widest measured
-  // rather than the mean. A wide chart therefore carries fewer labels than it
-  // could, which is the price of never overprinting at any width.
-  const AXIS_LABEL_PX_PER_CHAR = 6.8;
+  // it is keeps a pair that then overprints, while believing it narrower costs
+  // a tick mark the station table underneath still carries. So the fit runs
+  // against the chart's CSS floor rather than its usual size. A wide chart
+  // therefore carries fewer labels than it could, which is the price of never
+  // overprinting at any width. `axisLabelWidth` errs wide for the same reason.
   const MIN_CHART_PX = 180;
-  const AXIS_LABEL_MIN_GAP_PX = 8;
+  const AXIS_FONT_PX = 11;
   const candidates = stations
     .map((c, i) => ({ c, i }))
     .filter(({ i }) => i === lastIdx || i % labelStride === 0);
   const texts = candidates.map(({ c }) => formatChainage(c));
-  const keep = fitAxisLabels(
-    candidates.map(({ c }, k) => ({
-      at: xPct(c) / 100,
-      width: texts[k].length * AXIS_LABEL_PX_PER_CHAR,
-    })),
-    MIN_CHART_PX,
-    AXIS_LABEL_MIN_GAP_PX,
-  );
+  const keep = fitAxisLabels({
+    labels: texts,
+    pixels: candidates.map(({ c }) => (xPct(c) / 100) * MIN_CHART_PX),
+    containerPx: MIN_CHART_PX,
+    fontPx: AXIS_FONT_PX,
+    // The overlay anchors its end labels inside the plot, so the fit has to
+    // judge them the same way or it drops the label carrying the extent.
+    ends: 'pulled-in',
+  });
   const xLabelHtml = candidates
     .map(({ c, i }, k) => {
       if (!keep[k]) return '';

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -46,6 +46,7 @@ import { heightLabel } from '../geo/height';
 import type { VerticalReference } from '../geo/height';
 // Straight-polyline path builder shared with the profile PDF so the chart and
 // the sheet draw the same geometry. Pure string assembly, no dependencies.
+import { fitAxisLabels } from '../render/measure/profileAxes';
 import { profilePolylinePath } from '../render/measure/profilePath';
 // Δh in the chart tooltip goes through the shared formatter so it carries
 // its unit in BOTH systems (B9 — it used to print a hardcoded "m" even in
@@ -2016,20 +2017,34 @@ function renderProfileChart(
   // X labels sit just below the plot floor; expressed as a box-fraction so the
   // gap tracks the axis at any chart height.
   const xLabelTop = (((plotBottom + 6) / H) * 100).toFixed(2);
-  const xLabelHtml = stations
-    .map((c, i) => {
-      const isLast = i === lastIdx;
-      if (!isLast && i % labelStride !== 0) return '';
-      if (!isLast && lastIdx - i < labelStride / 2) return '';
-      let tx: string;
-      if (i === 0) {
-        tx = '0';
-      } else if (isLast) {
-        tx = '-100%';
-      } else {
-        tx = '-50%';
-      }
-      return `<span class="olv-mp-axis olv-mp-axis-x" style="left:${xPct(c).toFixed(2)}%;top:${xLabelTop}%;transform:translateX(${tx})">${formatChainage(c)}</span>`;
+  // Stride first as a density cap, then fit, because the two answer different
+  // questions: the stride is how many labels an axis should carry, and the fit
+  // is which of those the axis has room for. The overlay is HTML at the
+  // chart's real width, which this string does not know, so the fit runs
+  // against a deliberately narrow nominal width: too narrow drops a tick, too
+  // wide lets two labels overprint, and only one of those is recoverable by
+  // reading the station table underneath.
+  const AXIS_LABEL_PX_PER_CHAR = 6.2;
+  const NOMINAL_CHART_PX = 236;
+  const AXIS_LABEL_MIN_GAP_PX = 8;
+  const candidates = stations
+    .map((c, i) => ({ c, i }))
+    .filter(({ i }) => i === lastIdx || i % labelStride === 0);
+  const texts = candidates.map(({ c }) => formatChainage(c));
+  const keep = fitAxisLabels(
+    candidates.map(({ c }, k) => ({
+      at: xPct(c) / 100,
+      width: texts[k].length * AXIS_LABEL_PX_PER_CHAR,
+    })),
+    NOMINAL_CHART_PX,
+    AXIS_LABEL_MIN_GAP_PX,
+  );
+  const xLabelHtml = candidates
+    .map(({ c, i }, k) => {
+      if (!keep[k]) return '';
+      // The end labels are pulled inside the plot so neither overhangs it.
+      const tx = i === 0 ? '0' : i === lastIdx ? '-100%' : '-50%';
+      return `<span class="olv-mp-axis olv-mp-axis-x" style="left:${xPct(c).toFixed(2)}%;top:${xLabelTop}%;transform:translateX(${tx})">${texts[k]}</span>`;
     })
     .join('');
   const yLabelHtml = yTicks

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -2019,13 +2019,20 @@ function renderProfileChart(
   const xLabelTop = (((plotBottom + 6) / H) * 100).toFixed(2);
   // Stride first as a density cap, then fit, because the two answer different
   // questions: the stride is how many labels an axis should carry, and the fit
-  // is which of those the axis has room for. The overlay is HTML at the
-  // chart's real width, which this string does not know, so the fit runs
-  // against a deliberately narrow nominal width: too narrow drops a tick, too
-  // wide lets two labels overprint, and only one of those is recoverable by
-  // reading the station table underneath.
-  const AXIS_LABEL_PX_PER_CHAR = 6.2;
-  const NOMINAL_CHART_PX = 236;
+  // is which of those the axis has room for.
+  //
+  // Both constants below are bounds, not measurements, and each is rounded the
+  // only way that fails safe. This string is built before the overlay is in a
+  // document, so neither the chart's width nor a label's width can be read
+  // here, and the two errors are not symmetric: believing the chart WIDER than
+  // it is, or a label NARROWER than it is, keeps a pair that then overprints,
+  // while the opposite direction costs a tick mark that the station table
+  // underneath still carries. So the width is the chart's CSS floor rather
+  // than its usual size, and the per-character figure is the widest measured
+  // rather than the mean. A wide chart therefore carries fewer labels than it
+  // could, which is the price of never overprinting at any width.
+  const AXIS_LABEL_PX_PER_CHAR = 6.8;
+  const MIN_CHART_PX = 180;
   const AXIS_LABEL_MIN_GAP_PX = 8;
   const candidates = stations
     .map((c, i) => ({ c, i }))
@@ -2036,7 +2043,7 @@ function renderProfileChart(
       at: xPct(c) / 100,
       width: texts[k].length * AXIS_LABEL_PX_PER_CHAR,
     })),
-    NOMINAL_CHART_PX,
+    MIN_CHART_PX,
     AXIS_LABEL_MIN_GAP_PX,
   );
   const xLabelHtml = candidates

--- a/src/ui/ProfileWorkbench.ts
+++ b/src/ui/ProfileWorkbench.ts
@@ -103,6 +103,12 @@ export interface ProfileWorkbenchHandle {
   setCollapsed(collapsed: boolean): void;
   /** Describe the section the plot covers. */
   setScope(text: string): void;
+  /**
+   * Show, or clear with null, the caution about what the heights were chosen
+   * from. Separate from the scope line because it is a consequence rather
+   * than a description, and it earns its own space only when it applies.
+   */
+  setGroundBasis(note: string | null): void;
   /** Announce a status politely. */
   setStatus(text: string): void;
   /** The selected return's figures, as text. Null clears the selection. */
@@ -148,6 +154,7 @@ class ProfileWorkbench {
   private readonly _root: HTMLElement;
   private readonly _splitter: HTMLElement;
   private readonly _scope: HTMLElement;
+  private readonly _groundNote: HTMLElement;
   private readonly _status: HTMLElement;
   private readonly _detail: HTMLElement;
   private readonly _readout: HTMLElement;
@@ -179,6 +186,11 @@ class ProfileWorkbench {
     this._splitter.setAttribute('tabindex', '0');
 
     this._scope = el('div', { className: 'olv-workbench-scope', text: options.scope ?? '' });
+    // `role="note"` rather than an alert: this is standing context about the
+    // plot, not an event, so it should be reachable in reading order without
+    // interrupting whatever the user is doing.
+    this._groundNote = el('div', { className: 'olv-workbench-basis olv-hidden' });
+    this._groundNote.setAttribute('role', 'note');
     this._collapseBtn = el('button', {
       className: 'olv-workbench-btn',
       type: 'button',
@@ -195,6 +207,7 @@ class ProfileWorkbench {
       el('div', { className: 'olv-workbench-titles' }, [
         el('div', { className: 'olv-workbench-title', text: title }),
         this._scope,
+        this._groundNote,
       ]),
       el('div', { className: 'olv-workbench-actions' }, [this._collapseBtn, closeBtn]),
     ]);
@@ -273,6 +286,10 @@ class ProfileWorkbench {
       setCollapsed: (v: boolean) => this.setCollapsed(v),
       setScope: (t: string) => {
         this._scope.textContent = t;
+      },
+      setGroundBasis: (note: string | null) => {
+        this._groundNote.textContent = note ?? '';
+        this._groundNote.classList.toggle('olv-hidden', note == null);
       },
       setStatus: (t: string) => {
         this._status.textContent = t;

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -4999,6 +4999,13 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   font-size: var(--text-xs); color: var(--text-faint);
   font-variant-numeric: tabular-nums;
 }
+/* Styled with the provenance captions in 76; only the fit is set here. The
+   note wraps rather than truncating, because a caution the reader cannot
+   finish reading is not a caution. */
+.olv-workbench-basis {
+  margin: var(--space-2xs) 0 0; max-width: 62ch;
+  white-space: normal; overflow-wrap: break-word;
+}
 .olv-workbench-actions { display: flex; gap: var(--space-xs); flex-shrink: 0; }
 .olv-workbench-btn {
   font-size: var(--text-xs); color: var(--text-dim);
@@ -5134,11 +5141,15 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   border: 0.5px solid var(--hairline);
   border-radius: 6px; padding: 5px 8px; margin-bottom: 8px;
 }
-/* Derived-classification provenance caption — a quiet amber note so the
-   heuristic classes never read as an authoritative, file-supplied set. */
+/* The provenance caption — a quiet amber note for a figure whose basis a
+   reader would otherwise have to assume. One rule rather than one per panel:
+   a caption that looks the same everywhere is read the same everywhere, and
+   the profile workbench's ground-basis note means what this one means.
+   `.olv-workbench-basis` adds only its own spacing, in 74. */
 .olv-cl-derived,
 .olv-cl-samplenote,
-.olv-cl-streamnote {
+.olv-cl-streamnote,
+.olv-workbench-basis {
   font-size: 10.5px; line-height: 1.35; color: var(--warn, #b8860b);
   background: color-mix(in srgb, var(--warn, #b8860b) 12%, transparent);
   border: 0.5px solid color-mix(in srgb, var(--warn, #b8860b) 35%, transparent);

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -19,6 +19,7 @@
   --text: #eef3fb;
   --text-dim: #9aa6bd;
   --text-faint: #8a94ad; /* lightened from #6b768f to clear WCAG AA (≥4.5:1) on --bg */
+  --warn: #b8860b; /* the provenance-caption amber; 5.1:1 on its own 12% fill here */
   --accent: #00b2ff;      /* Electric Blue */
   --accent-soft: rgba(0, 178, 255, 0.16);
   /* Ink colour for text/glyphs ON a solid --accent fill (primary
@@ -439,6 +440,7 @@ body.olv-theme-light {
   --text: #0a1430;
   --text-dim: #46546e;
   --text-faint: #5d6a87; /* darkened from #7682a0 to clear WCAG AA (≥4.5:1) on the light --bg */
+  --warn: #7d5b07; /* darkened from #b8860b, which read 2.9:1 on the near-white caption fill */
   --accent: #0088c8;
   --accent-soft: rgba(0, 136, 200, 0.18);
   /* Deeper violet so the blocked verdict stays legible on the near-white panel. */
@@ -472,6 +474,7 @@ body.olv-theme-high-contrast {
   --text: #ffffff;
   --text-dim: #d9d9d9;
   --text-faint: #b3b3b3;
+  --warn: #f0b429; /* brightened for this rail: 8.8:1 on the caption fill, 10.6:1 on --panel */
   --accent: #5cd7ff;
   --accent-soft: rgba(92, 215, 255, 0.28);
   /* Bright violet — high luminance against pure black, holds WCAG AA. */
@@ -5003,7 +5006,9 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
    note wraps rather than truncating, because a caution the reader cannot
    finish reading is not a caution. */
 .olv-workbench-basis {
-  margin: var(--space-2xs) 0 0; max-width: 62ch;
+  /* A filled, bordered box needs more air from the line above it than a bare
+     caption would, and none below: the header owns the gap to the plot. */
+  margin: var(--space-xs) 0 0; max-width: 62ch;
   white-space: normal; overflow-wrap: break-word;
 }
 .olv-workbench-actions { display: flex; gap: var(--space-xs); flex-shrink: 0; }
@@ -5136,10 +5141,12 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-reclass-actions .olv-bc-pill { flex: 1; text-align: center; }
 /* The "Filtered — showing N of M classes" banner — persistent while filtered. */
 .olv-cl-banner {
-  font-size: 10.5px; font-variant-numeric: tabular-nums; color: var(--accent);
+  font-size: var(--text-xs); font-variant-numeric: tabular-nums; color: var(--accent);
   background: var(--accent-soft);
   border: 0.5px solid var(--hairline);
-  border-radius: 6px; padding: 5px 8px; margin-bottom: 8px;
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin-bottom: var(--space-md);
 }
 /* The provenance caption — a quiet amber note for a figure whose basis a
    reader would otherwise have to assume. One rule rather than one per panel:
@@ -5150,10 +5157,15 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 .olv-cl-samplenote,
 .olv-cl-streamnote,
 .olv-workbench-basis {
-  font-size: 10.5px; line-height: 1.35; color: var(--warn, #b8860b);
-  background: color-mix(in srgb, var(--warn, #b8860b) 12%, transparent);
-  border: 0.5px solid color-mix(in srgb, var(--warn, #b8860b) 35%, transparent);
-  border-radius: 6px; padding: 5px 8px; margin-bottom: 8px;
+  /* Same metrics as `.olv-cl-banner` above, on the token scale: the two sit
+     in one panel and read as one family, so a half-pixel apart in type size
+     is a difference the eye catches without being able to name. */
+  font-size: var(--text-xs); line-height: 1.35; color: var(--warn);
+  background: color-mix(in srgb, var(--warn) 12%, transparent);
+  border: 0.5px solid color-mix(in srgb, var(--warn) 35%, transparent);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin-bottom: var(--space-md);
 }
 .olv-cl-list { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
 .olv-cl-row {

--- a/tests/measurePanelWorkbenchDock.test.ts
+++ b/tests/measurePanelWorkbenchDock.test.ts
@@ -239,6 +239,7 @@ function tinySection(count = 32): ProfileSectionResult {
     band: 1.5,
     scope: 'static' as never,
     scopeLabel: 'One loaded layer.',
+    classificationOnEverySource: true,
     streamingComplete: null,
     sources: [],
     generation: 1,

--- a/tests/measurePanelWorkbenchExpand.test.ts
+++ b/tests/measurePanelWorkbenchExpand.test.ts
@@ -339,6 +339,7 @@ describe('a rejected open is a refusal, not an unhandled rejection', () => {
               collapsed: () => false,
               setCollapsed: () => {},
               setScope: () => {},
+        setGroundBasis: () => {},
               setStatus: () => {},
               setDetail: () => {},
               close: () => element.remove(),

--- a/tests/profileAxisLabelBounds.test.ts
+++ b/tests/profileAxisLabelBounds.test.ts
@@ -41,17 +41,16 @@ describe('the axis label fit uses bounds, not estimates', () => {
     expect(constant('MIN_CHART_PX')).toBeLessThanOrEqual(Number(m![1]));
   });
 
-  it('assumes the widest character a label can carry', () => {
-    // Measured in a browser at the axis font (Manrope 11px): the worst case
-    // is "88 m" at 6.74px per character. Short labels are the wide ones, so
-    // a mean taken over long labels understates exactly the ones at risk.
-    const WIDEST_MEASURED_PX_PER_CHAR = 6.74;
-    expect(constant('AXIS_LABEL_PX_PER_CHAR')).toBeGreaterThanOrEqual(
-      WIDEST_MEASURED_PX_PER_CHAR,
+  it('states the font size the labels are actually drawn at', () => {
+    // The width estimate is per em, so the size it is multiplied by has to be
+    // the size the stylesheet gives `.olv-mp-axis`. A stale figure here
+    // understates every label at once.
+    const m = /\.olv-mp-axis\s*\{[^}]*?font-size:\s*var\(--text-xs\)/s.exec(css);
+    expect(m, 'olv-mp-axis font-size is not --text-xs').not.toBeNull();
+    const token = /--text-xs:\s*(\d+(?:\.\d+)?)px/.exec(
+      read('src/styles/01-tokens.css'),
     );
-  });
-
-  it('keeps a clear gap rather than letting labels touch', () => {
-    expect(constant('AXIS_LABEL_MIN_GAP_PX')).toBeGreaterThan(0);
+    expect(token, '--text-xs not declared').not.toBeNull();
+    expect(constant('AXIS_FONT_PX')).toBe(Number(token![1]));
   });
 });

--- a/tests/profileAxisLabelBounds.test.ts
+++ b/tests/profileAxisLabelBounds.test.ts
@@ -1,0 +1,57 @@
+/**
+ * profileAxisLabelBounds.test.ts — the axis fit's two constants stay bounds.
+ *
+ * The chart's label fit runs before the overlay is in a document, so it cannot
+ * measure the chart or the text. It uses two constants instead, and each is
+ * only correct as a BOUND: the chart width must be the narrowest the chart can
+ * be, and the per-character width the widest a label can be. Rounded the other
+ * way, the fit believes there is room that is not there and keeps a pair that
+ * overprints, which is the defect the fit exists to remove.
+ *
+ * A first version of this fit used 236px and 6.2px per character. The chart's
+ * CSS floor is 180px and the widest measured label is 6.74px per character, so
+ * both were wrong in the direction that overprints. These cases hold each
+ * constant to the source it was taken from.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel: string): string => readFileSync(resolve(ROOT, rel), 'utf8');
+
+const panel = read('src/ui/MeasurePanel.ts');
+const css = read('src/styles/74-inspector-profile.css');
+
+/** A numeric constant declared in the panel. */
+function constant(name: string): number {
+  const m = new RegExp(`const ${name} = ([0-9.]+);`).exec(panel);
+  expect(m, `${name} not declared`).not.toBeNull();
+  return Number(m![1]);
+}
+
+describe('the axis label fit uses bounds, not estimates', () => {
+  it('fits against the chart width CSS actually permits', () => {
+    // Read from the stylesheet so a narrower chart cannot be shipped without
+    // this failing. Widening the chart is safe and does not.
+    const m = /\.olv-mp-chart\s*\{[^}]*?min-width:\s*(\d+)px/s.exec(css);
+    expect(m, 'olv-mp-chart min-width not found').not.toBeNull();
+    expect(constant('MIN_CHART_PX')).toBeLessThanOrEqual(Number(m![1]));
+  });
+
+  it('assumes the widest character a label can carry', () => {
+    // Measured in a browser at the axis font (Manrope 11px): the worst case
+    // is "88 m" at 6.74px per character. Short labels are the wide ones, so
+    // a mean taken over long labels understates exactly the ones at risk.
+    const WIDEST_MEASURED_PX_PER_CHAR = 6.74;
+    expect(constant('AXIS_LABEL_PX_PER_CHAR')).toBeGreaterThanOrEqual(
+      WIDEST_MEASURED_PX_PER_CHAR,
+    );
+  });
+
+  it('keeps a clear gap rather than letting labels touch', () => {
+    expect(constant('AXIS_LABEL_MIN_GAP_PX')).toBeGreaterThan(0);
+  });
+});

--- a/tests/profileAxisLabelFit.test.ts
+++ b/tests/profileAxisLabelFit.test.ts
@@ -1,0 +1,89 @@
+/**
+ * profileAxisLabelFit.test.ts — axis labels that do not overprint each other.
+ *
+ * The profile chart thinned its x labels by sample index: keep every Nth, and
+ * drop one that fell within half a stride of the last. Index spacing is pixel
+ * spacing only when every label is the same width and anchored the same way,
+ * and neither is true on this axis. The end labels are pulled inside the plot
+ * so they cannot overhang it, which puts the last label's box entirely to the
+ * left of its tick while an interior label straddles its own. On a 105 m
+ * profile that left "80" and "105.26 m" overprinting into one unreadable run
+ * of digits.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { fitAxisLabels, type AxisLabelBox } from '../src/render/measure/profileAxes';
+
+/** Labels at even fractions, each the given width. */
+const evenly = (n: number, width: number): AxisLabelBox[] =>
+  Array.from({ length: n }, (_, i) => ({ at: i / (n - 1), width }));
+
+describe('fitAxisLabels', () => {
+  it('keeps every label when the axis has room', () => {
+    expect(fitAxisLabels(evenly(5, 20), 500, 8)).toEqual([true, true, true, true, true]);
+  });
+
+  it('keeps both ends and drops the interior when nothing else fits', () => {
+    // 150 wide with 60-wide labels: the ends occupy [0,60] and [90,150], and
+    // no centred box fits in the 30 between them.
+    const keep = fitAxisLabels(evenly(5, 60), 150, 8);
+    expect(keep[0]).toBe(true);
+    expect(keep[4]).toBe(true);
+    expect(keep.slice(1, 4)).toEqual([false, false, false]);
+  });
+
+  it('drops a label that would touch the right-aligned last one', () => {
+    // The reported case: a label close to the end, whose centred box runs
+    // into the final label's box even though its index is a stride away.
+    const labels: AxisLabelBox[] = [
+      { at: 0, width: 24 },
+      { at: 0.5, width: 34 },
+      { at: 0.87, width: 34 },
+      { at: 1, width: 52 },
+    ];
+    const keep = fitAxisLabels(labels, 300, 8);
+    expect(keep[2]).toBe(false);
+    expect(keep[0]).toBe(true);
+    expect(keep[3]).toBe(true);
+  });
+
+  it('never lets two kept labels overlap', () => {
+    const labels = evenly(9, 40);
+    const axis = 320;
+    const keep = fitAxisLabels(labels, axis, 6);
+    const boxes = labels
+      .map((l, i) => ({ l, i }))
+      .filter(({ i }) => keep[i])
+      .map(({ l, i }) => {
+        if (i === 0) return [0, l.width];
+        if (i === labels.length - 1) return [axis - l.width, axis];
+        const c = l.at * axis;
+        return [c - l.width / 2, c + l.width / 2];
+      });
+    for (let i = 1; i < boxes.length; i++) {
+      expect(boxes[i][0], `label ${i} starts before ${i - 1} ends`).toBeGreaterThanOrEqual(
+        boxes[i - 1][1],
+      );
+    }
+  });
+
+  it('keeps the far end when the two ends themselves collide', () => {
+    // A very short axis. The end that carries the extent is the one to keep.
+    const keep = fitAxisLabels(
+      [
+        { at: 0, width: 40 },
+        { at: 1, width: 40 },
+      ],
+      60,
+      8,
+    );
+    expect(keep[1]).toBe(false);
+    expect(keep[0]).toBe(true);
+  });
+
+  it('handles a degenerate axis without inventing labels', () => {
+    expect(fitAxisLabels([], 100, 4)).toEqual([]);
+    expect(fitAxisLabels(evenly(3, 10), 0, 4)).toEqual([false, false, false]);
+    expect(fitAxisLabels([{ at: 0, width: 10 }], 100, 4)).toEqual([true]);
+  });
+});

--- a/tests/profileAxisLabelFit.test.ts
+++ b/tests/profileAxisLabelFit.test.ts
@@ -4,62 +4,117 @@
  * The profile chart thinned its x labels by sample index: keep every Nth, and
  * drop one that fell within half a stride of the last. Index spacing is pixel
  * spacing only when every label is the same width and anchored the same way,
- * and neither is true on this axis. The end labels are pulled inside the plot
- * so they cannot overhang it, which puts the last label's box entirely to the
- * left of its tick while an interior label straddles its own. On a 105 m
- * profile that left "80" and "105.26 m" overprinting into one unreadable run
- * of digits.
+ * and neither is true on this axis. On a 105 m profile that left "80" and
+ * "105.26 m" overprinting into one unreadable run of digits.
+ *
+ * One fitter serves two renderers, which anchor their end labels differently.
+ * A canvas axis centres every label, so an end label can hang past the strip
+ * and has to be dropped. The panel's HTML overlay pulls its ends inside the
+ * plot instead, so nothing overhangs and the ends are kept: they carry the
+ * axis range. Judging one renderer by the other's rule is the whole reason
+ * `ends` is an input rather than an assumption.
  */
 
 import { describe, it, expect } from 'vitest';
-import { fitAxisLabels, type AxisLabelBox } from '../src/render/measure/profileAxes';
+import { fitAxisLabels, axisLabelWidth, AXIS_LABEL_CHAR_EM } from '../src/render/measure/profileAxes';
 
-/** Labels at even fractions, each the given width. */
-const evenly = (n: number, width: number): AxisLabelBox[] =>
-  Array.from({ length: n }, (_, i) => ({ at: i / (n - 1), width }));
+type Fit = Parameters<typeof fitAxisLabels>[0];
 
-describe('fitAxisLabels', () => {
-  it('keeps every label when the axis has room', () => {
-    expect(fitAxisLabels(evenly(5, 20), 500, 8)).toEqual([true, true, true, true, true]);
+/** A strip whose labels all occupy `width`, positioned by fraction. */
+const strip = (
+  at: readonly number[],
+  width: number,
+  containerPx: number,
+  ends: 'centred' | 'pulled-in',
+): Fit => ({
+  labels: at.map(() => 'x'),
+  pixels: at.map((f) => f * containerPx),
+  containerPx,
+  fontPx: 11,
+  extentPx: () => width,
+  ends,
+});
+
+const evenly = (n: number, width: number, containerPx: number, ends: 'centred' | 'pulled-in') =>
+  strip(Array.from({ length: n }, (_, i) => i / (n - 1)), width, containerPx, ends);
+
+/** The span a kept label occupies, mirroring the fitter's own anchoring. */
+function spans(fit: Fit, keep: readonly boolean[]): Array<readonly [number, number]> {
+  const last = fit.labels.length - 1;
+  const out: Array<readonly [number, number]> = [];
+  fit.labels.forEach((l, i) => {
+    if (!keep[i]) return;
+    const w = fit.extentPx!(l);
+    if (fit.ends === 'pulled-in' && i === 0) out.push([0, w]);
+    else if (fit.ends === 'pulled-in' && i === last) out.push([fit.containerPx - w, fit.containerPx]);
+    else out.push([fit.pixels[i]! - w / 2, fit.pixels[i]! + w / 2]);
+  });
+  return out;
+}
+
+describe('label width errs wide', () => {
+  it('is at least the widest measured character advance', () => {
+    // "88 m" measures 6.74px at 11px in the axis font. Understating a width
+    // is what lets two labels overlap, so the constant has to sit above it.
+    expect(11 * AXIS_LABEL_CHAR_EM).toBeGreaterThanOrEqual(6.74);
+    expect(axisLabelWidth('88 m', 11)).toBeGreaterThanOrEqual(4 * 6.74);
   });
 
-  it('keeps both ends and drops the interior when nothing else fits', () => {
-    // 150 wide with 60-wide labels: the ends occupy [0,60] and [90,150], and
-    // no centred box fits in the 30 between them.
-    const keep = fitAxisLabels(evenly(5, 60), 150, 8);
+  it('treats a missing or absurd font size as zero rather than guessing', () => {
+    expect(axisLabelWidth('88 m', 0)).toBe(0);
+    expect(axisLabelWidth('88 m', Number.NaN)).toBe(0);
+  });
+});
+
+describe('a centred strip', () => {
+  it('drops an end label that would hang past the strip', () => {
+    // Centred on the last tick, half the label sits outside the plot. Half a
+    // number at the edge states a value the axis is not showing.
+    const keep = fitAxisLabels(strip([0, 0.5, 1], 40, 300, 'centred'));
+    expect(keep[0]).toBe(false);
+    expect(keep[2]).toBe(false);
+    expect(keep[1]).toBe(true);
+  });
+});
+
+describe('a pulled-in strip', () => {
+  it('keeps both ends, because they carry the axis range', () => {
+    const keep = fitAxisLabels(evenly(3, 40, 300, 'pulled-in'));
+    expect(keep[0]).toBe(true);
+    expect(keep[2]).toBe(true);
+  });
+
+  it('keeps every label when the strip has room', () => {
+    expect(fitAxisLabels(evenly(5, 20, 500, 'pulled-in'))).toEqual([true, true, true, true, true]);
+  });
+
+  it('drops the interior when only the ends fit', () => {
+    // 150 wide with 60-wide labels: the ends take [0,60] and [90,150], and no
+    // centred box fits in the 30 between them.
+    const keep = fitAxisLabels(evenly(5, 60, 150, 'pulled-in'));
     expect(keep[0]).toBe(true);
     expect(keep[4]).toBe(true);
     expect(keep.slice(1, 4)).toEqual([false, false, false]);
   });
 
-  it('drops a label that would touch the right-aligned last one', () => {
-    // The reported case: a label close to the end, whose centred box runs
-    // into the final label's box even though its index is a stride away.
-    const labels: AxisLabelBox[] = [
-      { at: 0, width: 24 },
-      { at: 0.5, width: 34 },
-      { at: 0.87, width: 34 },
-      { at: 1, width: 52 },
-    ];
-    const keep = fitAxisLabels(labels, 300, 8);
-    expect(keep[2]).toBe(false);
-    expect(keep[0]).toBe(true);
+  it('drops a label that would touch the right-anchored last one', () => {
+    // The reported case: a label close to the end whose centred box runs into
+    // the final label's box even though its index is a stride away.
+    const fit: Fit = {
+      labels: ['0 m', '50 m', '92 m', '105.26 m'],
+      pixels: [0, 150, 261, 300],
+      containerPx: 300,
+      fontPx: 11,
+      ends: 'pulled-in',
+    };
+    const keep = fitAxisLabels(fit);
     expect(keep[3]).toBe(true);
+    expect(keep[2]).toBe(false);
   });
 
   it('never lets two kept labels overlap', () => {
-    const labels = evenly(9, 40);
-    const axis = 320;
-    const keep = fitAxisLabels(labels, axis, 6);
-    const boxes = labels
-      .map((l, i) => ({ l, i }))
-      .filter(({ i }) => keep[i])
-      .map(({ l, i }) => {
-        if (i === 0) return [0, l.width];
-        if (i === labels.length - 1) return [axis - l.width, axis];
-        const c = l.at * axis;
-        return [c - l.width / 2, c + l.width / 2];
-      });
+    const fit = evenly(9, 40, 320, 'pulled-in');
+    const boxes = spans(fit, fitAxisLabels(fit));
     for (let i = 1; i < boxes.length; i++) {
       expect(boxes[i][0], `label ${i} starts before ${i - 1} ends`).toBeGreaterThanOrEqual(
         boxes[i - 1][1],
@@ -68,22 +123,29 @@ describe('fitAxisLabels', () => {
   });
 
   it('keeps the far end when the two ends themselves collide', () => {
-    // A very short axis. The end that carries the extent is the one to keep.
-    const keep = fitAxisLabels(
-      [
-        { at: 0, width: 40 },
-        { at: 1, width: 40 },
-      ],
-      60,
-      8,
-    );
-    expect(keep[1]).toBe(false);
-    expect(keep[0]).toBe(true);
+    // A very short strip. The end carrying the extent is the one to keep.
+    const keep = fitAxisLabels(evenly(2, 40, 60, 'pulled-in'));
+    expect(keep[1]).toBe(true);
+    expect(keep[0]).toBe(false);
+  });
+});
+
+describe('degenerate input', () => {
+  it('invents nothing', () => {
+    expect(fitAxisLabels(strip([], 10, 100, 'pulled-in'))).toEqual([]);
+    expect(fitAxisLabels(evenly(3, 10, 0, 'pulled-in'))).toEqual([false, false, false]);
+    expect(fitAxisLabels(strip([0], 10, 100, 'pulled-in'))).toEqual([true]);
   });
 
-  it('handles a degenerate axis without inventing labels', () => {
-    expect(fitAxisLabels([], 100, 4)).toEqual([]);
-    expect(fitAxisLabels(evenly(3, 10), 0, 4)).toEqual([false, false, false]);
-    expect(fitAxisLabels([{ at: 0, width: 10 }], 100, 4)).toEqual([true]);
+  it('skips a tick with no finite position', () => {
+    const fit: Fit = {
+      labels: ['a', 'b'],
+      pixels: [Number.NaN, 150],
+      containerPx: 300,
+      fontPx: 11,
+      extentPx: () => 20,
+      ends: 'centred',
+    };
+    expect(fitAxisLabels(fit)[0]).toBe(false);
   });
 });

--- a/tests/profileGroundBasis.test.ts
+++ b/tests/profileGroundBasis.test.ts
@@ -1,0 +1,102 @@
+/**
+ * profileGroundBasis.test.ts — what the profile says its heights came from.
+ *
+ * The sampler drops vegetation, building and noise returns before taking the
+ * corridor percentile, but only where a source classifies them. Without that,
+ * the percentile still runs, over every return, and under canopy it lands in
+ * the canopy. Grade is a difference between two such heights, so it follows
+ * whatever the surface followed.
+ *
+ * The exported sheet has always stated this basis. The screen did not, so a
+ * reader working from the panel had to export a PDF to learn how the heights
+ * in front of them were chosen. These cases hold both surfaces to one answer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  describeClassBasis,
+  GROUND_BASIS_UNVERIFIED_NOTE,
+} from '../src/render/measure/profileProvenance';
+
+describe('the class-basis clause', () => {
+  it('names classification present on every source', () => {
+    expect(describeClassBasis(true)).toBe('classification on every source');
+  });
+
+  it('names classification missing on any source', () => {
+    expect(describeClassBasis(false)).toBe('classification missing on a source');
+  });
+});
+
+describe('the caution about an unverified ground basis', () => {
+  it('states the basis, and what follows from it', () => {
+    // Not a bare "unverified": a reader needs to know what the number in
+    // front of them followed, and that grades inherit it.
+    expect(GROUND_BASIS_UNVERIFIED_NOTE).toContain('percentile of every return');
+    expect(GROUND_BASIS_UNVERIFIED_NOTE).toContain('canopy');
+    expect(GROUND_BASIS_UNVERIFIED_NOTE).toContain('grades');
+  });
+
+  it('does not promise a bare-earth surface', () => {
+    expect(GROUND_BASIS_UNVERIFIED_NOTE).not.toMatch(/bare.?earth|ground truth|corrected/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The composed view: the clause reaches the screen, and the caution appears
+// only where it changes what the figures mean.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { prepareWorkbenchSection } from '../src/app/profileWorkbenchSection';
+import type { ProfileSectionResult } from '../src/render/measure/profileSectionSeam';
+
+/** A section carrying two returns, classified or not as the case requires. */
+function sectionWith(classificationOnEverySource: boolean): ProfileSectionResult {
+  const count = 2;
+  return {
+    points: {
+      count,
+      chainage: new Float32Array([0, 10]),
+      height: new Float64Array([100, 101]),
+      lateralOffset: new Float32Array([0, 0]),
+      sourceSlot: new Uint16Array([0, 0]),
+      pointIndex: new Uint32Array([0, 1]),
+      channelPresence: new Uint8Array([0, 0]),
+    },
+    frame: null as never,
+    band: 2,
+    scope: 'full-static-source' as never,
+    scopeLabel: 'Full static source',
+    classificationOnEverySource,
+    streamingComplete: null,
+    sources: [{ slot: 0, kind: 'static', id: 'layer-a', pointCount: count }],
+    generation: 1,
+    aborted: false,
+    skippedSlots: [],
+    examined: count,
+  };
+}
+
+const canvas = () =>
+  ({ width: 400, height: 200, getContext: () => null }) as unknown as HTMLCanvasElement;
+
+describe('the workbench header', () => {
+  it('carries the caution when a source has no classification', () => {
+    const plot = prepareWorkbenchSection({ section: sectionWith(false), canvas: canvas() });
+    expect(plot.view.scope).toContain('classification missing on a source');
+    expect(plot.view.groundBasisNote).toBe(GROUND_BASIS_UNVERIFIED_NOTE);
+  });
+
+  it('carries no caution when every source classifies', () => {
+    // A caution shown everywhere is a caution nowhere. This is the case that
+    // keeps the amber note meaning something when it does appear.
+    const plot = prepareWorkbenchSection({ section: sectionWith(true), canvas: canvas() });
+    expect(plot.view.scope).toContain('classification on every source');
+    expect(plot.view.groundBasisNote).toBeNull();
+  });
+
+  it('states the read scope and the class basis in one line', () => {
+    const plot = prepareWorkbenchSection({ section: sectionWith(true), canvas: canvas() });
+    expect(plot.view.scope).toBe('Full static source · classification on every source');
+  });
+});

--- a/tests/profileSectionSeam.test.ts
+++ b/tests/profileSectionSeam.test.ts
@@ -379,6 +379,45 @@ describe('profile section seam — the two products walk one corridor', () => {
     expect(profileSectionHas(section.points, 1, 'classification')).toBe(false);
   });
 
+  // The exclusion policy can only act on a source that classifies. "Every",
+  // not "any": one bare source means part of the read reached the percentile
+  // unfiltered, and a header claiming classification would overstate what
+  // shaped the heights.
+  it('reports the class basis as missing when only one of two sources classifies', () => {
+    const classed = layer({ id: 'classed', points: [2, 0, 5], classification: [2] });
+    const bare = layer({ id: 'bare', points: [4, 0, 6] });
+    const seam = createProfileSectionSeam(deps({ layers: () => [classed, bare] }));
+    const section = seam.section({ a: A, b: B, corridorWidth: 1 })!;
+    expect(section.classificationOnEverySource).toBe(false);
+  });
+
+  it('reports the class basis as present when every source classifies', () => {
+    const one = layer({ id: 'one', points: [2, 0, 5], classification: [2] });
+    const two = layer({ id: 'two', points: [4, 0, 6], classification: [2] });
+    const seam = createProfileSectionSeam(deps({ layers: () => [one, two] }));
+    const section = seam.section({ a: A, b: B, corridorWidth: 1 })!;
+    expect(section.classificationOnEverySource).toBe(true);
+  });
+
+  it('asserts no class basis over a read that contributed nothing', () => {
+    const seam = createProfileSectionSeam(deps({ layers: () => [] }));
+    const section = seam.section({ a: A, b: B, corridorWidth: 1 })!;
+    expect(section.classificationOnEverySource).toBe(false);
+  });
+
+  it('counts a misaligned classification as absent for the basis', () => {
+    // The same rule `viewOf` applies to the channel itself: an array that
+    // cannot be indexed alongside the points is not classification that was
+    // applied, so the basis must not claim it was.
+    const misaligned: ProfileSeamLayer = {
+      ...layer({ id: 'misaligned', points: [2, 0, 5, 4, 0, 6] }),
+      channels: { classification: new Uint8Array([2]) },
+    };
+    const seam = createProfileSectionSeam(deps({ layers: () => [misaligned] }));
+    const section = seam.section({ a: A, b: B, corridorWidth: 1 })!;
+    expect(section.classificationOnEverySource).toBe(false);
+  });
+
   it('drops a classification whose length disagrees with the point count', () => {
     const misaligned: ProfileSeamLayer = {
       ...layer({ id: 'misaligned', points: [2, 0, 5, 4, 0, 6] }),

--- a/tests/warnTokenContrast.test.ts
+++ b/tests/warnTokenContrast.test.ts
@@ -1,0 +1,88 @@
+/**
+ * warnTokenContrast.test.ts — the provenance caption stays readable.
+ *
+ * The caption that names a figure's basis is the one piece of text a reader
+ * consults precisely when they doubt the number above it. It carries its
+ * meaning in words rather than in colour, but it still has to be read, and it
+ * sits on a tinted fill of its own colour, which cuts contrast further than
+ * the colour on the panel alone.
+ *
+ * `--warn` was undefined for a long time, so every use fell back to a single
+ * hardcoded amber that measured 2.9:1 on the light rail's near-white caption
+ * fill, against the 4.5:1 WCAG AA asks for body text. These cases hold each
+ * rail's value to the ratio it was chosen for, computed rather than asserted
+ * in a comment, so a later palette edit has to keep the guarantee.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel: string): string => readFileSync(resolve(ROOT, rel), 'utf8');
+
+type Rgb = readonly [number, number, number];
+
+const parseHex = (hex: string): Rgb => {
+  const h = hex.trim().replace('#', '');
+  return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255) as unknown as Rgb;
+};
+
+/** WCAG relative luminance. */
+const luminance = (rgb: Rgb): number => {
+  const [r, g, b] = rgb.map((c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+const contrast = (a: Rgb, b: Rgb): number => {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+/** `color-mix(in srgb, fg 12%, transparent)` composited over a surface. */
+const captionFill = (fg: Rgb, surface: Rgb): Rgb =>
+  fg.map((v, i) => v * 0.12 + surface[i] * 0.88) as unknown as Rgb;
+
+/** Read one custom property out of a declaration block. */
+function tokenIn(css: string, block: string, name: string): string {
+  const start = css.indexOf(block);
+  expect(start, `block ${block} not found`).toBeGreaterThan(-1);
+  const body = css.slice(start, css.indexOf('}', start));
+  const m = new RegExp(`${name}:\\s*(#[0-9a-fA-F]{6})`).exec(body);
+  expect(m, `${name} not declared in ${block}`).not.toBeNull();
+  return m![1];
+}
+
+const tokens = read('src/styles/01-tokens.css');
+const rails = read('src/styles/03-theme-rails.css');
+
+const RAILS: ReadonlyArray<{ name: string; warn: string; panel: string }> = [
+  { name: 'default dark', warn: tokenIn(tokens, ':root', '--warn'), panel: '#0b1020' },
+  {
+    name: 'light',
+    warn: tokenIn(rails, 'body.olv-theme-light', '--warn'),
+    panel: tokenIn(rails, 'body.olv-theme-light', '--panel'),
+  },
+  {
+    name: 'high contrast',
+    warn: tokenIn(rails, 'body.olv-theme-high-contrast', '--warn'),
+    panel: tokenIn(rails, 'body.olv-theme-high-contrast', '--panel'),
+  },
+];
+
+describe('the provenance caption clears WCAG AA on every rail', () => {
+  for (const rail of RAILS) {
+    it(`${rail.name}: caption text on its own tinted fill`, () => {
+      const fg = parseHex(rail.warn);
+      const ratio = contrast(fg, captionFill(fg, parseHex(rail.panel)));
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+    });
+  }
+
+  it('declares --warn on every rail, so no use falls back to a literal', () => {
+    // The bug this file exists for: an undefined token meant one hardcoded
+    // amber served three palettes, and the light one failed.
+    for (const rail of RAILS) expect(rail.warn).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});

--- a/tests/workbenchPointLink.test.ts
+++ b/tests/workbenchPointLink.test.ts
@@ -214,6 +214,7 @@ function fixtureSection(): ProfileSectionResult {
     band: 2,
     scope: 'mixed' as never,
     scopeLabel: 'One layer and the streaming source.',
+    classificationOnEverySource: true,
     streamingComplete: true,
     sources,
     generation: 1,

--- a/tests/workbenchWiring.test.ts
+++ b/tests/workbenchWiring.test.ts
@@ -230,6 +230,7 @@ function fakeModule(): { module: ProfileWorkbenchModule; mounts: ProfileWorkbenc
         collapsed: () => false,
         setCollapsed: () => {},
         setScope: () => {},
+            setGroundBasis: () => {},
         setStatus: () => {},
         setDetail: () => {},
         close: () => {
@@ -326,6 +327,7 @@ function sectionWithOutlierAtIndexOne(count: number): ProfileSectionResult {
     band: 2,
     scope: 'static' as never,
     scopeLabel: 'One loaded layer.',
+    classificationOnEverySource: true,
     streamingComplete: null,
     sources: [],
     generation: 1,
@@ -345,10 +347,12 @@ function sectionHandle(canvas: FakeCanvas): {
   const scope: string[] = [];
   const status: string[] = [];
   const detail: (readonly { label: string; value: string }[] | null)[] = [];
+  const basis: (string | null)[] = [];
   return {
     handle: {
       canvas: canvas as unknown as HTMLCanvasElement,
       setScope: (t) => scope.push(t),
+      setGroundBasis: (n: string | null) => basis.push(n),
       setStatus: (t) => status.push(t),
       setDetail: (rows) => detail.push(rows),
     },
@@ -591,6 +595,7 @@ describe('the presenter says why, rather than showing an empty plot', () => {
       handle: {
         canvas: new FakeEl('canvas') as unknown as HTMLCanvasElement,
         setScope: (t) => scope.push(t),
+        setGroundBasis: () => {},
         setStatus: (t) => status.push(t),
         setDetail: (rows) => detail.push(rows),
       },


### PR DESCRIPTION
The corridor percentile drops vegetation, building and noise returns only where a source classifies them. Without classification it runs over every return, so under canopy the surface follows the canopy and the grades follow it. The exported sheet already stated this basis and the workbench header did not. The header now carries the same clause from the same function, plus a caution where classification is missing.

The chart thinned x labels by sample index while collision happens in pixels, and the end labels anchor inside the plot rather than centred, so the last two overprinted on a 105 m profile. `fitAxisLabels` keeps a label only where its box clears its neighbour and the axis end.

`--warn` was never declared, so one amber served three palettes and read 2.9:1 on the light rail. It is a token per rail now, with the ratio pinned by a computed test.
