### PR TITLE
feat(workbench): axis indicators, an editable title, and PDF export

### DIFF
--- a/src/app/measurePanelMount.ts
+++ b/src/app/measurePanelMount.ts
@@ -161,6 +161,21 @@ export function createMeasurePanelMount(deps: MeasurePanelMountDeps): MeasurePan
           pose: () => deps.getViewer().getCameraPose(),
           apply: (pose) => deps.getViewer().applyCameraPose(pose),
         },
+        // The dock's title field commits through the SAME controller call the
+        // Measurements panel's own name field does, then refreshes the panel,
+        // so a rename made in either surface is the one name both show.
+        rename: (id, name) => {
+          deps.getViewer().measure.renameMeasurement(id, name);
+          refresh();
+        },
+        // The panel's own export, not a second one. It is the single place the
+        // sheet's inputs are assembled, which is what keeps the read scope and
+        // the classification basis on a sheet exported from the dock.
+        exportPdf: (id) => {
+          const live = panel;
+          if (!live) return Promise.reject(new Error('The measurements panel is not mounted.'));
+          return live.exportProfilePdf(id);
+        },
       });
       return launcher;
     });
@@ -271,6 +286,14 @@ export function createMeasurePanelMount(deps: MeasurePanelMountDeps): MeasurePan
         if (newest) deps.recordUsage('measurement', newest.kind);
       }
       lastMeasurementCount = measurements.length;
+      // A rename made in the Measurements list belongs on the open dock's
+      // title too: one name, two views of it. Pushed rather than polled, and
+      // the panel drops the write while its field has focus, so a refresh
+      // cannot overwrite a name someone is still typing into the dock.
+      if (dockedId !== null) {
+        const docked = measurements.find((m) => m.id === dockedId);
+        if (docked) launcher?.handle?.setTitle?.(docked.name);
+      }
     } else {
       // Panel not mounted yet (pre-first-scan, or the chunk is still loading) —
       // kick the lazy mount; `hydrate()` re-runs this once it lands.

--- a/src/app/profileWorkbenchLauncher.ts
+++ b/src/app/profileWorkbenchLauncher.ts
@@ -73,6 +73,27 @@ export interface ProfileWorkbenchLauncherDeps {
     handle: ProfileWorkbenchHandle,
     request: ProfileWorkbenchLaunchRequest,
   ) => void | (() => void);
+  /**
+   * Commit a new name for the measurement a dock is plotting.
+   *
+   * Routed straight through to whatever the host wired, which is the same
+   * rename the Measurements panel's own name field calls. The launcher holds
+   * no name: the request it was opened with carries the name at open time, and
+   * the one authority on it afterwards is the host.
+   *
+   * Absent leaves the dock's title a caption rather than a field.
+   */
+  rename?: (id: string, name: string) => void;
+  /**
+   * Build the profile PDF for one measurement.
+   *
+   * The SAME export the Measurements panel's Export PDF control runs, handed
+   * over rather than reimplemented: a second builder would be a second set of
+   * inputs, and the read scope and classification basis a sheet states are
+   * exactly what a second set gets wrong. Absent means the dock renders no
+   * export control.
+   */
+  exportPdf?: (id: string) => Promise<void>;
   /** Told about a rejected import, so a silent fallback still leaves a trace. */
   onLoadFailure?: (error: unknown) => void;
   /** Told about a `present` that threw, for the same reason. */
@@ -136,9 +157,16 @@ export function createProfileWorkbenchLauncher(
     // the stage the outgoing dock is still holding.
     close();
     const token = ++generation;
+    // The measurement's own name is the title, so the dock, the Measurements
+    // row and the exported sheet are three views of one name. The scope line
+    // under it is filled by the presenter with what the section actually read.
+    const rename = deps.rename;
+    const exportPdf = deps.exportPdf;
     const mounted = module.mountProfileWorkbench(host, {
-      title: 'Profile workbench',
+      title: request.name,
       scope: request.name,
+      ...(rename ? { onRename: (name: string) => rename(request.id, name) } : {}),
+      ...(exportPdf ? { onExportPdf: () => exportPdf(request.id) } : {}),
       onClose: () => {
         // Only for the dock that is still the live one: a panel closed by the
         // mount that replaced it must not hand back the successor's height.

--- a/src/app/profileWorkbenchRuntime.ts
+++ b/src/app/profileWorkbenchRuntime.ts
@@ -52,6 +52,23 @@ export interface ProfileWorkbenchRuntimeDeps {
     apply(pose: { position: [number, number, number]; target: [number, number, number] }): void;
   };
   /**
+   * Commit a new name for the measurement a dock is plotting.
+   *
+   * Wired to the SAME `renameMeasurement` the Measurements panel's name field
+   * calls, so the dock's title is a view of the measurement's name rather than
+   * a second name kept beside it. Absent leaves the title a caption.
+   */
+  rename?: (id: string, name: string) => void;
+  /**
+   * Build the profile PDF for one measurement.
+   *
+   * Handed in as the Measurements panel's own export, not rebuilt here. The
+   * sheet states its read scope and the classification basis of its heights,
+   * and a second assembly of the builder's inputs is precisely how a sheet
+   * comes to state neither. Absent means the dock renders no export control.
+   */
+  exportPdf?: (id: string) => Promise<void>;
+  /**
    * Told about a rejected panel chunk, or a fill that threw. Defaults to a
    * console record: the user already has the focus view, so nothing about the
    * failure is otherwise visible in the app.
@@ -102,6 +119,8 @@ export function createProfileWorkbenchRuntime(
   return createProfileWorkbenchLauncher({
     load: () => loadProfileWorkbench(),
     stage: createStageProfileWorkbench(deps.stage),
+    ...(deps.rename ? { rename: deps.rename } : {}),
+    ...(deps.exportPdf ? { exportPdf: deps.exportPdf } : {}),
     present: (handle, request) => presentWorkbenchSection(handle, request.id, scene),
     onLoadFailure:
       deps.onLoadFailure ??

--- a/src/app/profileWorkbenchSection.ts
+++ b/src/app/profileWorkbenchSection.ts
@@ -53,7 +53,11 @@ import {
   describeClassBasis,
   GROUND_BASIS_UNVERIFIED_NOTE,
 } from '../render/measure/profileProvenance';
-import { axisSpanCaption } from '../render/measure/profileAxes';
+import {
+  axisSpanCaption,
+  fitAxisLabels,
+  profileAxes,
+} from '../render/measure/profileAxes';
 import {
   selectProfileSectionLod,
   selectProfileSectionLodChunks,
@@ -77,6 +81,8 @@ import { createProfileLinkController } from './profileLinkController';
 import type { ProfileWorkbenchDetailRow } from '../ui/ProfileWorkbench';
 import type { ProfileHitTestIndex } from '../render/measure/profileHitTest';
 import type { ProfileView, ProfileViewport } from '../render/measure/profileViewTransform';
+import type { ProfileAxesModel } from '../render/measure/profileAxes';
+import type { VerticalReference } from '../geo/height';
 import type { ProfileLinkOverlayContext } from '../render/measure/profileLinkOverlay2d';
 import type { ProfileLinkController, ProfileLinkMarker } from './profileLinkController';
 import type {
@@ -129,6 +135,144 @@ const SECTION_STYLE = {
   stationColour: 'rgb(255, 214, 102)',
   stationAlpha: 0.55,
 } as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Axis indicators
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Tick label size, CSS pixels.
+ *
+ * Fixed rather than read from the stylesheet: the labels are drawn into a
+ * canvas, and a canvas has no cascade to read a token out of. The value is the
+ * one `--text-xs` resolves to for the panel around it, so the plot's numbers
+ * and the detail list's numbers are the same size on screen.
+ */
+export const AXIS_FONT_PX = 11;
+
+/** How far a label sits from the edge of the plot it labels, CSS pixels. */
+export const AXIS_LABEL_INSET_PX = 4;
+
+/**
+ * Rule, label and title inks.
+ *
+ * The axes are drawn OVER the plot rather than in a gutter carved out of it.
+ * Carving would change the box `fitProfileView` is given, so the picture a
+ * reader has been looking at would shift the moment an axis appeared. Drawing
+ * over it means the ink has to stay quieter than the returns underneath: the
+ * rules read as a grid behind the section, not as another series in it.
+ */
+const AXIS_RULE_COLOUR = 'rgba(255, 255, 255, 0.10)';
+const AXIS_TEXT_COLOUR = 'rgba(255, 255, 255, 0.62)';
+const AXIS_TITLE_COLOUR = 'rgba(255, 255, 255, 0.45)';
+
+/** Target major ticks per axis. Fewer than the plot could hold, so labels fit. */
+export const AXIS_TARGET_TICKS = 6;
+
+/**
+ * The 2D context, with the text calls the axis needs.
+ *
+ * Separate from `ProfileRenderingContext` because that one is the splat
+ * renderer's contract and states only what the splats use. Every text member
+ * is feature-detected before it is called, so a context without them (an
+ * older test double, a stub surface) draws the rules and skips the words
+ * rather than throwing on the way.
+ */
+export interface AxisTextContext extends ProfileRenderingContext {
+  font: string;
+  textAlign: string;
+  textBaseline: string;
+  fillText(text: string, x: number, y: number): void;
+}
+
+function canDrawText(ctx: ProfileRenderingContext): ctx is AxisTextContext {
+  return typeof (ctx as Partial<AxisTextContext>).fillText === 'function';
+}
+
+/**
+ * Draw both axes over a plot that has already been rendered.
+ *
+ * The ticks come from `profileAxes`, so a rule here falls exactly where the
+ * same transform put the returns beside it, and every tick is an exact
+ * multiple of its step. Which labels are actually printed comes from
+ * `fitAxisLabels`, so a narrow dock loses labels rather than stacking them
+ * into an unreadable smear.
+ *
+ * The height axis is titled by what the scan supports and nothing more: a
+ * section with no declared datum reads "Height (datum unknown)" here for the
+ * same reason it does in the point inspector and on the exported sheet.
+ */
+export function drawWorkbenchAxes(
+  ctx: ProfileRenderingContext,
+  axes: ProfileAxesModel,
+  viewport: ProfileViewport,
+): void {
+  const width = viewport.width;
+  const height = viewport.height;
+  if (!(width > 0) || !(height > 0)) return;
+
+  ctx.globalAlpha = 1;
+  ctx.strokeStyle = AXIS_RULE_COLOUR;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (const x of axes.x.pixels) {
+    if (!Number.isFinite(x) || x < 0 || x > width) continue;
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, height);
+  }
+  for (const y of axes.y.pixels) {
+    if (!Number.isFinite(y) || y < 0 || y > height) continue;
+    ctx.moveTo(0, y);
+    ctx.lineTo(width, y);
+  }
+  ctx.stroke();
+
+  if (!canDrawText(ctx)) return;
+  const text = ctx;
+  text.font = `${AXIS_FONT_PX}px system-ui, sans-serif`;
+
+  // Chainage labels run along the bottom edge; the strip they compete for is
+  // the plot's width.
+  const keepX = fitAxisLabels({
+    labels: axes.x.labels,
+    pixels: axes.x.pixels,
+    containerPx: width,
+    fontPx: AXIS_FONT_PX,
+  });
+  text.fillStyle = AXIS_TEXT_COLOUR;
+  text.textAlign = 'center';
+  text.textBaseline = 'bottom';
+  for (let i = 0; i < axes.x.labels.length; i++) {
+    if (!keepX[i]) continue;
+    text.fillText(axes.x.labels[i]!, axes.x.pixels[i]!, height - AXIS_LABEL_INSET_PX);
+  }
+
+  // Height labels are stacked down the left edge, so what one of them can
+  // collide with is the LINE HEIGHT of its neighbour, never its width.
+  const keepY = fitAxisLabels({
+    labels: axes.y.labels,
+    pixels: axes.y.pixels,
+    containerPx: height,
+    fontPx: AXIS_FONT_PX,
+    extentPx: () => AXIS_FONT_PX,
+  });
+  text.textAlign = 'left';
+  text.textBaseline = 'middle';
+  for (let i = 0; i < axes.y.labels.length; i++) {
+    if (!keepY[i]) continue;
+    text.fillText(axes.y.labels[i]!, AXIS_LABEL_INSET_PX, axes.y.pixels[i]!);
+  }
+
+  // The titles carry the units, because a tick label is a bare number and an
+  // axis holds one unit down its whole column.
+  text.fillStyle = AXIS_TITLE_COLOUR;
+  text.textAlign = 'right';
+  text.textBaseline = 'bottom';
+  text.fillText(axes.x.title, width - AXIS_LABEL_INSET_PX, height - AXIS_LABEL_INSET_PX);
+  text.textAlign = 'left';
+  text.textBaseline = 'top';
+  text.fillText(axes.y.title, AXIS_LABEL_INSET_PX, AXIS_LABEL_INSET_PX);
+}
 
 /** The canvas the dock hands over, reduced to what is read from it. */
 export interface WorkbenchCanvas {
@@ -243,6 +387,14 @@ export interface ComposeSectionOptions {
    * Absent, this composes the same selection in one pass.
    */
   readonly indices?: Uint32Array;
+  /**
+   * Vertical reference of the section's heights, for the height-axis title.
+   *
+   * Absent reads as `unknown`, which titles the axis "Height (datum unknown)".
+   * That is the honest default for a caller that has not resolved a CRS: the
+   * axis must never promise a datum the section cannot show one for.
+   */
+  readonly reference?: VerticalReference;
 }
 
 /**
@@ -261,6 +413,8 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
     Number.isFinite(options.unitScale) && (options.unitScale as number) > 0
       ? (options.unitScale as number)
       : 1;
+  const reference: VerticalReference = options.reference ?? 'unknown';
+  const axisUnit = scale === 1 ? unit : null;
   const indices = options.indices ?? drawIndices(section);
   const colours = new Uint8Array(indices.length * 3);
   const colouring = colourProfileSection(
@@ -293,7 +447,7 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
   let lastFrame: WorkbenchPlotFrame | null = null;
 
   function draw(): void {
-    if (!renderer) return;
+    if (!renderer || !ctx) return;
     const width = canvas.clientWidth;
     const height = canvas.clientHeight;
     // A collapsed dock's body is `display: none`, so its canvas reads 0x0.
@@ -316,6 +470,24 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
       style: SECTION_STYLE,
     });
     renderer.renderNow();
+    // After the returns, so the grid sits over the section rather than under
+    // splats that would hide the rules the reader is measuring against.
+    drawWorkbenchAxes(
+      ctx,
+      profileAxes(view, viewport, {
+        reference,
+        // Ticks are read off the section in the scan's OWN render units, so a
+        // unit is named only where those units already ARE that unit. On a
+        // frame whose scale is not 1 the detail rows still carry the converted
+        // spans; the axis prints bare numbers rather than metres it is not in.
+        horizontalUnit: axisUnit,
+        verticalUnit: axisUnit,
+        units: { horizontalToMetres: null, verticalToMetres: null },
+        targetXTicks: AXIS_TARGET_TICKS,
+        targetYTicks: AXIS_TARGET_TICKS,
+      }),
+      viewport,
+    );
     lastFrame = { view, viewport };
   }
 
@@ -522,6 +694,9 @@ export function presentWorkbenchSection(
       devicePixelRatio: scene.devicePixelRatio(),
       unitSuffix: metres === null ? null : 'm',
       unitScale: metres ?? 1,
+      // The SAME reference the detail card's height row is worded from, so the
+      // axis title and the row beside it cannot name two different surfaces.
+      reference: pointVerticalReference(scene.crs?.()),
     });
     handle.setScope(plot.view.scope);
     handle.setGroundBasis(plot.view.groundBasisNote);

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -633,6 +633,22 @@
 }
 .olv-workbench-titles { min-width: 0; }
 .olv-workbench-title { font-size: var(--text-sm); color: var(--text); }
+/* The title as a field, where the host wired somewhere to commit a name to.
+   Dashed until it is reached, so it reads as a caption that can be typed over
+   rather than as another control competing with the buttons beside it. The
+   padding is what gives it a hit area a pointer can actually land on. */
+.olv-workbench-title-input {
+  width: 100%; min-width: 0;
+  background: transparent;
+  border: 0.5px dashed var(--hairline);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2xs) var(--space-xs);
+  cursor: text;
+}
+.olv-workbench-title-input:hover { border-style: solid; border-color: var(--accent); }
+.olv-workbench-title-input:focus-visible {
+  outline: none; border-style: solid; border-color: var(--accent);
+}
 .olv-workbench-scope {
   font-size: var(--text-xs); color: var(--text-faint);
   font-variant-numeric: tabular-nums;
@@ -654,6 +670,10 @@
   border-radius: var(--radius-sm); padding: var(--space-2xs) var(--space-sm);
 }
 .olv-workbench-btn:hover { color: var(--text); }
+.olv-workbench-btn:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}
+.olv-workbench-btn:disabled { opacity: 0.6; cursor: default; }
 .olv-workbench-status {
   padding: 0 var(--space-md) var(--space-2xs);
   font-size: var(--text-xs); color: var(--text-faint);

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -18,6 +18,7 @@ import { storageGet, storageSet } from './safeStorage';
 // lazyChunks.ts (excluded from the live source-transform) so its literal is
 // never scrambled. Importing the thunk pulls nothing heavy into the shell.
 import { loadProfilePdf } from '../lazyChunks';
+import { profilePdfInputFor } from './profilePdfInput';
 import type { MeasurementSummary, ProfileResampleParams } from '../render/measure/MeasureController';
 import {
   DIMENSION_LABEL,
@@ -733,6 +734,24 @@ export class MeasurePanel {
    * initial bundle; the button shows progress and a failure state rather
    * than failing silently.
    */
+  /**
+   * Export one profile by id, for a surface that has no summary in hand.
+   *
+   * The docked workbench's own Export PDF control comes through here rather
+   * than assembling the builder's inputs a second time. A sheet states its
+   * read scope and the classification basis of the heights on it, and those
+   * are exactly the parameters a second call site drops; there is one
+   * assembly, and both controls run it.
+   *
+   * Rejects when the id names nothing this panel is showing, so the control
+   * that called it can report a failure instead of appearing to succeed.
+   */
+  async exportProfilePdf(id: string): Promise<void> {
+    const s = this._summaries.find((x) => x.id === id);
+    if (!s) throw new Error(`No measurement ${id} to export.`);
+    await this._buildProfileSheet(s);
+  }
+
   private async _exportProfilePdf(
     s: MeasurementSummary,
     btn: HTMLButtonElement,
@@ -742,39 +761,7 @@ export class MeasurePanel {
     btn.disabled = true;
     btn.textContent = 'Building…';
     try {
-      const { buildProfilePdf } = await loadProfilePdf();
-      // B4 — pass everything the app actually knows. The builder has carried
-      // these parameters since v0.4.0; this call site discarding them was why
-      // every sheet printed "auto (5 % of length)" / "p25" /
-      // "not georeferenced" even when the CRS service had resolved the frame.
-      const ctx = this._cb.getProfileExportContext
-        ? this._cb.getProfileExportContext()
-        : null;
-      const bytes = await buildProfilePdf({
-        name: s.name,
-        samples: s.profileChart,
-        residentOnly: s.profileChartResidentOnly,
-        corridorWidthM: s.profileCorridorWidthM ?? null,
-        groundPercentile: s.profileGroundPercentile ?? null,
-        crs: ctx?.crs ?? null,
-        verticalDatum: ctx?.verticalDatum ?? null,
-        // B9 — the builder has honoured the unit system since the imperial
-        // sweep, but this call site never passed it, so every sheet printed
-        // metric regardless of the toggle. Same source the chart/CSV read.
-        unitSystem: this._cb.getUnitSystem ? this._cb.getUnitSystem() : 'metric',
-        datumKnown: s.profileDatumKnown !== false,
-        // What shaped the estimate. A reader of the exported file cannot see
-        // the app state that produced it, so the sources, the class policy and
-        // the read scope go on the page.
-        provenance: s.profileProvenance ?? null,
-        // The clock is read HERE, at the app boundary. The builder takes the
-        // stamp as a parameter so the same sheet is the same bytes.
-        generatedAt: new Date(),
-      });
-      triggerDownload(
-        new Blob([bytes as BlobPart], { type: 'application/pdf' }),
-        `${safeFileName(s.name)}-profile.pdf`,
-      );
+      await this._buildProfileSheet(s);
     } catch (err) {
       console.error('OpenLiDARViewer: profile PDF export failed.', err);
       btn.textContent = 'Export failed';
@@ -786,6 +773,34 @@ export class MeasurePanel {
     }
     btn.textContent = label;
     btn.disabled = false;
+  }
+
+  /**
+   * Assemble the sheet's inputs and download it. THE one assembly.
+   *
+   * Throws on failure rather than reporting it, so each control that calls it
+   * shows the failure in its own vocabulary.
+   */
+  private async _buildProfileSheet(s: MeasurementSummary): Promise<void> {
+    if (!s.profileChart || s.profileChart.length < 2) return;
+    const { buildProfilePdf } = await loadProfilePdf();
+    // Assembled in ONE place, shared with the docked workbench's own export
+    // control. What a second assembly drops is the CRS, the unit system and
+    // the provenance record, which is exactly what a reader of the file
+    // cannot recover from anywhere else.
+    const bytes = await buildProfilePdf(
+      profilePdfInputFor(s, {
+        context: this._cb.getProfileExportContext ? this._cb.getProfileExportContext() : null,
+        unitSystem: this._cb.getUnitSystem ? this._cb.getUnitSystem() : 'metric',
+        // The clock is read HERE, at the app boundary. The builder takes the
+        // stamp as a parameter so the same sheet is the same bytes.
+        generatedAt: new Date(),
+      }),
+    );
+    triggerDownload(
+      new Blob([bytes as BlobPart], { type: 'application/pdf' }),
+      `${safeFileName(s.name)}-profile.pdf`,
+    );
   }
 
   /**

--- a/src/ui/ProfileWorkbench.ts
+++ b/src/ui/ProfileWorkbench.ts
@@ -79,6 +79,23 @@ export interface ProfileWorkbenchOptions {
   readonly title?: string;
   /** The section the plot covers, shown under the title. */
   readonly scope?: string;
+  /**
+   * Commit a new name for what the panel is plotting.
+   *
+   * Absent leaves the title a plain caption. When present the title becomes an
+   * editable field, and the name it commits goes wherever the host sends it —
+   * the panel keeps no name of its own, because a second copy is how the
+   * workbench, the Measurements panel and an exported sheet come to disagree.
+   */
+  readonly onRename?: (name: string) => void;
+  /**
+   * Build a PDF of what the panel is plotting.
+   *
+   * Absent means no export control is rendered at all. The panel neither
+   * builds the sheet nor knows what goes on it; it reports what the host's
+   * promise did, so a failure is visible on the control the user pressed.
+   */
+  readonly onExportPdf?: () => Promise<void>;
   /** Called when the user closes the panel. */
   readonly onClose?: () => void;
 }
@@ -109,6 +126,14 @@ export interface ProfileWorkbenchHandle {
    * than a description, and it earns its own space only when it applies.
    */
   setGroundBasis(note: string | null): void;
+  /**
+   * The name shown in the title, when the title is editable.
+   *
+   * OPTIONAL, so a handle built by an older double still satisfies the type.
+   * Writing here does NOT call `onRename`: this is the host telling the panel
+   * what the name now is, not the user asking for it to change.
+   */
+  setTitle?(text: string): void;
   /** Announce a status politely. */
   setStatus(text: string): void;
   /** The selected return's figures, as text. Null clears the selection. */
@@ -133,6 +158,14 @@ const CANVAS_DESCRIPTION =
 
 const NO_SELECTION = 'No return selected.';
 
+/** The export control's resting label, and the two states it passes through. */
+const EXPORT_LABEL = 'Export PDF';
+const EXPORT_WORKING_LABEL = 'Building\u2026';
+const EXPORT_FAILED_LABEL = 'Export failed';
+
+/** How long a failed export keeps saying so before the control resets. */
+const EXPORT_FAILED_MS = 1800;
+
 /**
  * Mount the workbench into the host's container.
  *
@@ -155,6 +188,9 @@ class ProfileWorkbench {
   private readonly _splitter: HTMLElement;
   private readonly _scope: HTMLElement;
   private readonly _groundNote: HTMLElement;
+  private readonly _title: HTMLElement;
+  private readonly _titleInput: HTMLInputElement | null;
+  private readonly _exportBtn: HTMLButtonElement | null;
   private readonly _status: HTMLElement;
   private readonly _detail: HTMLElement;
   private readonly _readout: HTMLElement;
@@ -165,11 +201,14 @@ class ProfileWorkbench {
   private _state: DockState;
   private _closed = false;
   private _dragFrom: number | null = null;
+  /** The last name something outside this panel is known to hold. */
+  private _committedName: string;
 
   constructor(host: ProfileWorkbenchHost, options: ProfileWorkbenchOptions) {
     this._host = host;
     this._options = options;
     const title = options.title ?? 'Profile workbench';
+    this._committedName = title;
 
     this._state = restoreDockState(
       host.storage ? host.storage.getItem(PROFILE_WORKBENCH_DOCK_KEY) : null,
@@ -203,13 +242,52 @@ class ProfileWorkbench {
       ariaLabel: 'Close the profile workbench',
     });
 
+    // Editable only where the host offered somewhere to commit a name to. A
+    // field that took a rename nothing recorded would look like it worked and
+    // leave the panel, the Measurements list and the next export disagreeing.
+    if (options.onRename) {
+      const input = el('input', {
+        className: 'olv-workbench-title olv-workbench-title-input',
+        title: 'Type to rename this profile',
+        ariaLabel: 'Profile name',
+      });
+      input.value = title;
+      // `change`, not `input`: a name is committed when the user is done
+      // typing it, and the Measurements panel's own name field commits on the
+      // same event. Renaming on every keystroke would push a half-typed name
+      // through the controller and out to everything reading it.
+      this._on(input, 'change', () => this._commitName(input));
+      this._titleInput = input;
+      this._title = input;
+    } else {
+      this._titleInput = null;
+      this._title = el('div', { className: 'olv-workbench-title', text: title });
+    }
+
+    // No export control where the host has nothing to build a sheet with.
+    this._exportBtn = options.onExportPdf
+      ? el('button', {
+          className: 'olv-workbench-btn',
+          type: 'button',
+          text: EXPORT_LABEL,
+          ariaLabel: 'Export this profile as a PDF sheet',
+        })
+      : null;
+    if (this._exportBtn) {
+      const btn = this._exportBtn;
+      this._on(btn, 'click', () => void this._exportPdf(btn));
+    }
+
+    const actions = this._exportBtn
+      ? [this._exportBtn, this._collapseBtn, closeBtn]
+      : [this._collapseBtn, closeBtn];
     const head = el('div', { className: 'olv-workbench-head' }, [
       el('div', { className: 'olv-workbench-titles' }, [
-        el('div', { className: 'olv-workbench-title', text: title }),
+        this._title,
         this._scope,
         this._groundNote,
       ]),
-      el('div', { className: 'olv-workbench-actions' }, [this._collapseBtn, closeBtn]),
+      el('div', { className: 'olv-workbench-actions' }, actions),
     ]);
 
     // Polite, never assertive: a status here reports on a plot the user is
@@ -291,6 +369,7 @@ class ProfileWorkbench {
         this._groundNote.textContent = note ?? '';
         this._groundNote.classList.toggle('olv-hidden', note == null);
       },
+      setTitle: (t: string) => this._showName(t),
       setStatus: (t: string) => {
         this._status.textContent = t;
       },
@@ -300,6 +379,72 @@ class ProfileWorkbench {
       },
       close: () => this.close(),
     };
+  }
+
+  /**
+   * Show `name` in the title without committing it.
+   *
+   * The write is skipped while the field has focus: a host refresh landing
+   * mid-edit would otherwise replace the characters the user is still typing
+   * with the name they are typing over.
+   */
+  private _showName(name: string): void {
+    if (this._titleInput) {
+      if (this._titleInput.ownerDocument?.activeElement === this._titleInput) return;
+      this._titleInput.value = name;
+      return;
+    }
+    this._title.textContent = name;
+  }
+
+  /**
+   * Hand a typed name to the host, and put back what the host kept.
+   *
+   * A blank or whitespace-only entry is not a name, and the controller that
+   * owns the measurement refuses it. The field is restored to the last name it
+   * carried rather than left empty, so what the panel shows is always a name
+   * something else also holds.
+   */
+  private _commitName(input: HTMLInputElement): void {
+    const next = input.value.trim();
+    if (!next) {
+      input.value = this._committedName;
+      return;
+    }
+    this._committedName = next;
+    input.value = next;
+    this._root.setAttribute('aria-label', next);
+    this._options.onRename?.(next);
+  }
+
+  /**
+   * Build the sheet the host offered, and say so on the control.
+   *
+   * The panel does not know what a profile sheet contains and does not
+   * assemble one: the promise it is given is the same export the Measurements
+   * panel runs, so the two sheets carry the same provenance because they are
+   * the same sheet. A rejection stops on the button rather than in the
+   * console, because the button is what the user pressed.
+   */
+  private async _exportPdf(btn: HTMLButtonElement): Promise<void> {
+    const run = this._options.onExportPdf;
+    if (!run || btn.disabled) return;
+    btn.disabled = true;
+    btn.textContent = EXPORT_WORKING_LABEL;
+    try {
+      await run();
+    } catch {
+      btn.textContent = EXPORT_FAILED_LABEL;
+      setTimeout(() => {
+        if (this._closed) return;
+        btn.textContent = EXPORT_LABEL;
+        btn.disabled = false;
+      }, EXPORT_FAILED_MS);
+      return;
+    }
+    if (this._closed) return;
+    btn.textContent = EXPORT_LABEL;
+    btn.disabled = false;
   }
 
   setCollapsed(collapsed: boolean): void {

--- a/src/ui/profilePdfInput.ts
+++ b/src/ui/profilePdfInput.ts
@@ -1,0 +1,67 @@
+/**
+ * profilePdfInput.ts
+ *
+ * The one assembly of a profile sheet's inputs.
+ *
+ * WHY IT IS A MODULE OF ITS OWN. Two surfaces export the same sheet — the
+ * Measurements panel's own control and the docked workbench's — and the
+ * parameters a second call site silently drops are the ones that matter most:
+ * the read scope, the classification basis of the heights, the CRS, the unit
+ * system. That has happened here before; the builder has carried those
+ * parameters since v0.4.0 and a call site discarding them was why every sheet
+ * printed "not georeferenced" over a resolved frame. So there is one function
+ * and both controls run it, and a sheet exported from either surface carries
+ * the same provenance because it was assembled the same way.
+ *
+ * Pure. No DOM, no clock: `generatedAt` arrives as a parameter for the same
+ * reason the builder demands one, so the same measurement is the same bytes.
+ */
+
+import type { ProfilePdfInput } from '../render/measure/profilePdf';
+import type { MeasurementSummary } from '../render/measure/MeasureController';
+import type { UnitSystem } from '../render/measure/types';
+
+/** CRS provenance for the sheet header, as the host resolves it at export time. */
+export interface ProfileExportContext {
+  readonly crs: string | null;
+  readonly verticalDatum: string | null;
+}
+
+/** What the caller states about the moment of export. */
+export interface ProfilePdfInputOptions {
+  /** Resolved frame, or null when the host could not state one. */
+  readonly context: ProfileExportContext | null;
+  readonly unitSystem: UnitSystem;
+  /** Read at the app boundary, never inside the builder. */
+  readonly generatedAt: Date;
+}
+
+/**
+ * The sheet's inputs for one profile measurement.
+ *
+ * Every field the app knows is passed. `provenance` in particular: a reader of
+ * an exported file cannot see the app state that produced it, so the sources,
+ * the class policy and the read scope have to travel on the page or they are
+ * lost the moment the session ends.
+ */
+export function profilePdfInputFor(
+  s: MeasurementSummary,
+  options: ProfilePdfInputOptions,
+): ProfilePdfInput {
+  return {
+    name: s.name,
+    samples: s.profileChart ?? [],
+    residentOnly: s.profileChartResidentOnly,
+    corridorWidthM: s.profileCorridorWidthM ?? null,
+    groundPercentile: s.profileGroundPercentile ?? null,
+    crs: options.context?.crs ?? null,
+    verticalDatum: options.context?.verticalDatum ?? null,
+    unitSystem: options.unitSystem,
+    // False only when the loaded clouds hold conflicting render origins, in
+    // which case the samples are local heights and the sheet must not print
+    // the word elevation against them.
+    datumKnown: s.profileDatumKnown !== false,
+    provenance: s.profileProvenance ?? null,
+    generatedAt: options.generatedAt,
+  };
+}

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -4998,6 +4998,22 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
 }
 .olv-workbench-titles { min-width: 0; }
 .olv-workbench-title { font-size: var(--text-sm); color: var(--text); }
+/* The title as a field, where the host wired somewhere to commit a name to.
+   Dashed until it is reached, so it reads as a caption that can be typed over
+   rather than as another control competing with the buttons beside it. The
+   padding is what gives it a hit area a pointer can actually land on. */
+.olv-workbench-title-input {
+  width: 100%; min-width: 0;
+  background: transparent;
+  border: 0.5px dashed var(--hairline);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2xs) var(--space-xs);
+  cursor: text;
+}
+.olv-workbench-title-input:hover { border-style: solid; border-color: var(--accent); }
+.olv-workbench-title-input:focus-visible {
+  outline: none; border-style: solid; border-color: var(--accent);
+}
 .olv-workbench-scope {
   font-size: var(--text-xs); color: var(--text-faint);
   font-variant-numeric: tabular-nums;
@@ -5019,6 +5035,10 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   border-radius: var(--radius-sm); padding: var(--space-2xs) var(--space-sm);
 }
 .olv-workbench-btn:hover { color: var(--text); }
+.olv-workbench-btn:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}
+.olv-workbench-btn:disabled { opacity: 0.6; cursor: default; }
 .olv-workbench-status {
   padding: 0 var(--space-md) var(--space-2xs);
   font-size: var(--text-xs); color: var(--text-faint);

--- a/tests/profileAxisIndicators.test.ts
+++ b/tests/profileAxisIndicators.test.ts
@@ -1,0 +1,217 @@
+/**
+ * profileAxisIndicators.test.ts
+ *
+ * The axis indicators the docked Profile Workbench draws over its plot: where
+ * the ticks fall, what the height axis is allowed to call itself, and which
+ * labels survive a narrow dock.
+ *
+ * Three properties are asserted, each of which the plot is wrong without.
+ *
+ * A TICK IS AN EXACT MULTIPLE OF ITS STEP. A reader measures off the rules, so
+ * a label reading 12 has to sit at 12 and not at 12.000000000000002. The check
+ * is arithmetic rather than textual: every emitted value divided by its step
+ * must be an integer.
+ *
+ * THE HEIGHT AXIS PROMISES NOTHING THE SCAN DOES NOT SUPPORT. A section with
+ * no declared datum is titled "Height (datum unknown)". "Elevation" is earned
+ * by an orthometric reference and by nothing else, on this axis for the same
+ * reason it is in the point inspector and on the exported sheet.
+ *
+ * LABELS DO NOT OVERLAP. `fitAxisLabels` decides which are drawn, and the
+ * assertion below is geometric: every kept pair must be separated by at least
+ * the gap the fitter promises, at the narrowest plot the dock permits.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  AXIS_LABEL_MIN_GAP_PX,
+  axisLabelWidth,
+  axisTicks,
+  chainageTickLabels,
+  fitAxisLabels,
+  heightAxisTitle,
+  profileAxes,
+} from '../src/render/measure/profileAxes';
+import {
+  AXIS_FONT_PX,
+  AXIS_TARGET_TICKS,
+} from '../src/app/profileWorkbenchSection';
+import { fitProfileView } from '../src/render/measure/profileViewTransform';
+import type { ProfileViewport } from '../src/render/measure/profileViewTransform';
+
+/** No metres scale on either axis: the plot's own honest mode. */
+const NO_SCALE = { horizontalToMetres: null, verticalToMetres: null };
+
+/** A section extent with awkward, non-round bounds on both axes. */
+const BOUNDS = {
+  minChainage: -3.7,
+  maxChainage: 241.31,
+  minHeight: 1103.04,
+  maxHeight: 1131.9,
+};
+
+function viewOf(viewport: ProfileViewport) {
+  const view = fitProfileView(BOUNDS, viewport, { kind: 'fit' }, NO_SCALE);
+  if (!view) throw new Error('the fixture bounds must produce a view');
+  return view;
+}
+
+describe('a tick is an exact multiple of its step', () => {
+  it('holds for every span the plot can be asked for', () => {
+    const spans: [number, number][] = [
+      [-3.7, 241.31],
+      [1103.04, 1131.9],
+      [0, 0.0007],
+      [-1_250_500, 1_250_500],
+      [12.0000001, 12.0000009],
+    ];
+    for (const [lo, hi] of spans) {
+      const ticks = axisTicks(lo, hi, AXIS_TARGET_TICKS);
+      for (const v of ticks.values) {
+        const q = v / ticks.step;
+        expect(Math.abs(q - Math.round(q)), `${v} is not a multiple of ${ticks.step}`).toBeLessThan(
+          1e-6,
+        );
+      }
+    }
+  });
+
+  it('prints a label with no binary residue in it', () => {
+    const ticks = axisTicks(0, 0.5, 5);
+    for (const label of chainageTickLabels(ticks)) {
+      expect(label).not.toMatch(/\d{8,}$/);
+    }
+  });
+});
+
+describe('the height axis states no more than the scan supports', () => {
+  it('reads "Height (datum unknown)" for a section with no declared datum', () => {
+    // Built explicitly rather than taken from a default: this is the case a
+    // scan with no vertical datum lands in, and the one an axis is most
+    // tempted to call an elevation.
+    expect(heightAxisTitle('unknown', null)).toBe('Height (datum unknown)');
+    // With a unit the word is unchanged and the unit is appended, the same
+    // `word (unit)` composition the station table's headings use.
+    expect(heightAxisTitle('unknown', 'm')).toBe('Height (datum unknown) (m)');
+
+    const viewport: ProfileViewport = { width: 640, height: 320, devicePixelRatio: 1 };
+    const axes = profileAxes(viewOf(viewport), viewport, {
+      reference: 'unknown',
+      horizontalUnit: 'm',
+      verticalUnit: 'm',
+      units: NO_SCALE,
+      targetXTicks: AXIS_TARGET_TICKS,
+      targetYTicks: AXIS_TARGET_TICKS,
+    });
+    expect(axes.y.title).toContain('Height (datum unknown)');
+    expect(axes.y.title).not.toContain('Elevation');
+    expect(axes.x.title).toBe('Chainage (m)');
+  });
+
+  it('reserves "Elevation" for a reference that earns it', () => {
+    expect(heightAxisTitle('orthometric', 'm')).toBe('Elevation (m)');
+    expect(heightAxisTitle('local', 'm')).toBe('Local height (m)');
+  });
+});
+
+describe('axis labels do not overlap', () => {
+  /**
+   * The narrowest plot the dock can present.
+   *
+   * The detail column is a fixed 216 px and the body carries its own padding,
+   * so a plot narrower than this has no room for a section either. Any
+   * narrower value would only make the fitter drop more, which is the safe
+   * direction; the point of testing at the narrow end is that the fitter must
+   * not simply thin by index and leave the crowded half touching.
+   */
+  const NARROW: ProfileViewport = { width: 180, height: 96, devicePixelRatio: 1 };
+
+  function keptSpans(
+    labels: readonly string[],
+    pixels: readonly number[],
+    containerPx: number,
+    extentOf: (label: string) => number,
+  ): { start: number; end: number }[] {
+    const keep = fitAxisLabels({
+      labels,
+      pixels,
+      containerPx,
+      fontPx: AXIS_FONT_PX,
+      ...(extentOf === undefined ? {} : { extentPx: extentOf }),
+    });
+    const spans: { start: number; end: number }[] = [];
+    for (let i = 0; i < labels.length; i++) {
+      if (!keep[i]) continue;
+      const half = extentOf(labels[i]!) / 2;
+      spans.push({ start: pixels[i]! - half, end: pixels[i]! + half });
+    }
+    spans.sort((a, b) => a.start - b.start);
+    return spans;
+  }
+
+  it('keeps every drawn chainage label clear of its neighbour and of both edges', () => {
+    const axes = profileAxes(viewOf(NARROW), NARROW, {
+      reference: 'unknown',
+      horizontalUnit: 'm',
+      verticalUnit: 'm',
+      units: NO_SCALE,
+      targetXTicks: AXIS_TARGET_TICKS,
+      targetYTicks: AXIS_TARGET_TICKS,
+    });
+    const spans = keptSpans(axes.x.labels, axes.x.pixels, NARROW.width, (l) =>
+      axisLabelWidth(l, AXIS_FONT_PX),
+    );
+    expect(spans.length).toBeGreaterThan(0);
+    for (const s of spans) {
+      expect(s.start).toBeGreaterThanOrEqual(0);
+      expect(s.end).toBeLessThanOrEqual(NARROW.width);
+    }
+    for (let i = 1; i < spans.length; i++) {
+      expect(
+        spans[i]!.start - spans[i - 1]!.end,
+        `label ${i} overlaps the one before it`,
+      ).toBeGreaterThanOrEqual(AXIS_LABEL_MIN_GAP_PX);
+    }
+  });
+
+  it('keeps stacked height labels a line apart down a short plot', () => {
+    const axes = profileAxes(viewOf(NARROW), NARROW, {
+      reference: 'unknown',
+      horizontalUnit: 'm',
+      verticalUnit: 'm',
+      units: NO_SCALE,
+      targetXTicks: AXIS_TARGET_TICKS,
+      targetYTicks: AXIS_TARGET_TICKS,
+    });
+    const spans = keptSpans(axes.y.labels, axes.y.pixels, NARROW.height, () => AXIS_FONT_PX);
+    expect(spans.length).toBeGreaterThan(0);
+    for (let i = 1; i < spans.length; i++) {
+      expect(spans[i]!.start - spans[i - 1]!.end).toBeGreaterThanOrEqual(AXIS_LABEL_MIN_GAP_PX);
+    }
+  });
+
+  it('refuses a label that would run off the end of the strip', () => {
+    // One wide label centred hard against the left edge. Half of it would be
+    // outside the plot, and half a number states a value the axis is not
+    // showing, so it is not drawn at all.
+    const keep = fitAxisLabels({
+      labels: ['-1250.5'],
+      pixels: [2],
+      containerPx: 200,
+      fontPx: AXIS_FONT_PX,
+    });
+    expect(keep).toEqual([false]);
+  });
+
+  it('does not thin by index: an uneven axis keeps its sparse labels', () => {
+    // Three labels crowded at the left, one alone at the right. Index thinning
+    // would keep the 1st and 3rd — still touching — and drop the 4th, which
+    // has a whole plot to itself.
+    const labels = ['0', '1', '2', '300'];
+    const pixels = [20, 26, 32, 160];
+    const keep = fitAxisLabels({ labels, pixels, containerPx: 200, fontPx: AXIS_FONT_PX });
+    expect(keep[3]).toBe(true);
+    expect(keep[1]).toBe(false);
+    expect(keep[2]).toBe(false);
+  });
+});

--- a/tests/workbenchNamePanelExport.test.ts
+++ b/tests/workbenchNamePanelExport.test.ts
@@ -1,0 +1,393 @@
+/**
+ * workbenchNamePanelExport.test.ts
+ *
+ * The docked Profile Workbench's two new controls: the editable title, and
+ * Export PDF.
+ *
+ * ONE NAME, NOT TWO. A profile is named in the Measurements list, in the dock
+ * title and on the exported sheet, and the only way those three can agree is
+ * for none of them to keep a copy. The dock therefore commits a typed name
+ * straight through to the host and shows back whatever the host kept; the
+ * assertions below are that it holds no name of its own and invents none.
+ *
+ * ONE SHEET, NOT TWO. The dock's export runs the host's promise. It builds
+ * nothing and knows nothing about what goes on a profile sheet, which is what
+ * makes a sheet exported from the dock the same sheet, with the same read
+ * scope and the same classification basis, as one exported from the panel.
+ * `profilePdfInputFor` is where that assembly lives, and the last test here
+ * puts its output through the real builder to read the sentence back off the
+ * page.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { inflateSync } from 'node:zlib';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { createProfileWorkbenchLauncher } from '../src/app/profileWorkbenchLauncher';
+import { profilePdfInputFor } from '../src/ui/profilePdfInput';
+import { buildProfilePdf } from '../src/render/measure/profilePdf';
+import {
+  buildProfileProvenance,
+  describeProfileProvenance,
+} from '../src/render/measure/profileProvenance';
+import { NON_GROUND_CLASSES } from '../src/terrain/ground/classificationFilter';
+import type { ProfileWorkbenchHandle, ProfileWorkbenchHost } from '../src/ui/ProfileWorkbench';
+import type { MeasurementSummary } from '../src/render/measure/MeasureController';
+import type { ProfileChartSample } from '../src/render/measure/types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A DOM small enough to hold in one hand
+// ─────────────────────────────────────────────────────────────────────────────
+
+class FakeEl {
+  className = '';
+  title = '';
+  type = '';
+  value = '';
+  disabled = false;
+  textContent = '';
+  readonly children: FakeEl[] = [];
+  readonly attrs: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly dataset: Record<string, string> = {};
+  readonly listeners: { type: string; fn: (ev: unknown) => void }[] = [];
+  readonly classList = {
+    add: (): void => {},
+    remove: (): void => {},
+    contains: (): boolean => false,
+    toggle: (): void => {},
+  };
+  readonly tagName: string;
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+  setAttribute(n: string, v: string): void {
+    this.attrs[n] = v;
+  }
+  getAttribute(n: string): string | null {
+    return n in this.attrs ? this.attrs[n] : null;
+  }
+  append(...kids: FakeEl[]): void {
+    this.children.push(...kids.filter(Boolean));
+  }
+  replaceChildren(...kids: FakeEl[]): void {
+    this.children.length = 0;
+    this.append(...kids);
+  }
+  remove(): void {}
+  contains(): boolean {
+    return false;
+  }
+  addEventListener(type: string, fn: (ev: unknown) => void): void {
+    this.listeners.push({ type, fn });
+  }
+  removeEventListener(): void {}
+  focus(): void {}
+  blur(): void {}
+  setPointerCapture(): void {}
+  releasePointerCapture(): void {}
+  getContext(): null {
+    return null;
+  }
+  dispatch(type: string): void {
+    for (const l of [...this.listeners]) if (l.type === type) l.fn({ type, target: this });
+  }
+  tree(): FakeEl[] {
+    return [this as FakeEl, ...this.children.flatMap((c) => c.tree())];
+  }
+  byClass(cls: string): FakeEl | undefined {
+    return this.tree().find((n) => n.className.split(/\s+/).includes(cls));
+  }
+  byText(text: string): FakeEl | undefined {
+    return this.tree().find((n) => n.textContent === text);
+  }
+}
+
+class FakeHost implements ProfileWorkbenchHost {
+  readonly root = new FakeEl('div');
+  container(): HTMLElement {
+    return this.root as unknown as HTMLElement;
+  }
+  stageHeight(): number {
+    return 1000;
+  }
+  onStageResize(): () => void {
+    return () => {};
+  }
+  notifyDockHeight(): void {}
+  prefersReducedMotion(): boolean {
+    return true;
+  }
+}
+
+beforeEach(() => {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.document = {
+    createElement: (tag: string) => new FakeEl(tag),
+    createElementNS: (_ns: string, tag: string) => new FakeEl(tag),
+    addEventListener: (): void => {},
+    removeEventListener: (): void => {},
+  };
+  g.HTMLInputElement = class {};
+  g.HTMLAnchorElement = class {};
+});
+
+afterEach(() => {
+  const g = globalThis as unknown as Record<string, unknown>;
+  delete g.document;
+  delete g.HTMLInputElement;
+  delete g.HTMLAnchorElement;
+});
+
+/** Open a dock through the real launcher and hand back what it produced. */
+async function openDock(deps: {
+  rename?: (id: string, name: string) => void;
+  exportPdf?: (id: string) => Promise<void>;
+  name?: string;
+}): Promise<{ root: FakeEl; handle: ProfileWorkbenchHandle }> {
+  const host = new FakeHost();
+  const module = await import('../src/ui/ProfileWorkbench');
+  const launcher = createProfileWorkbenchLauncher({
+    load: () => Promise.resolve(module),
+    stage: { host: () => host, canDock: () => true, release: () => {} },
+    ...(deps.rename ? { rename: deps.rename } : {}),
+    ...(deps.exportPdf ? { exportPdf: deps.exportPdf } : {}),
+  });
+  const opened = await launcher.open({
+    id: 'm-1',
+    kind: 'profile',
+    name: deps.name ?? 'Profile 2',
+  });
+  expect(opened).toBe(true);
+  const handle = launcher.handle;
+  if (!handle) throw new Error('the launcher must hold the dock it mounted');
+  return { root: handle.element as unknown as FakeEl, handle };
+}
+
+describe('the dock is titled by the measurement it is plotting', () => {
+  it('opens showing the measurement name, not a generic panel word', async () => {
+    const { root } = await openDock({ rename: () => {} });
+    const field = root.byClass('olv-workbench-title-input');
+    expect(field).toBeDefined();
+    expect(field!.value).toBe('Profile 2');
+    expect(root.getAttribute('aria-label')).toBe('Profile 2');
+  });
+
+  it('is a plain caption where the host wired no way to record a name', async () => {
+    const { root } = await openDock({});
+    expect(root.byClass('olv-workbench-title-input')).toBeUndefined();
+    expect(root.byClass('olv-workbench-title')?.textContent).toBe('Profile 2');
+  });
+
+  it('commits a typed name through the host, keyed on the measurement id', async () => {
+    const renamed: [string, string][] = [];
+    const { root } = await openDock({ rename: (id, name) => renamed.push([id, name]) });
+    const field = root.byClass('olv-workbench-title-input')!;
+    field.value = '  North levee  ';
+    field.dispatch('change');
+    // Trimmed on the way out, and carrying the id the dock was opened for.
+    expect(renamed).toEqual([['m-1', 'North levee']]);
+    expect(field.value).toBe('North levee');
+    expect(root.getAttribute('aria-label')).toBe('North levee');
+  });
+
+  it('refuses a blank name and restores the one something else still holds', async () => {
+    const renamed: string[] = [];
+    const { root } = await openDock({ rename: (_id, name) => renamed.push(name) });
+    const field = root.byClass('olv-workbench-title-input')!;
+    field.value = '   ';
+    field.dispatch('change');
+    expect(renamed).toEqual([]);
+    expect(field.value).toBe('Profile 2');
+  });
+
+  it('takes a name from the host without calling back for it', async () => {
+    // The panel-side rename lands here. Echoing it back through `onRename`
+    // would be a rename loop over a name the controller already holds.
+    const renamed: string[] = [];
+    const { root, handle } = await openDock({ rename: (_id, name) => renamed.push(name) });
+    handle.setTitle?.('Renamed elsewhere');
+    expect(root.byClass('olv-workbench-title-input')!.value).toBe('Renamed elsewhere');
+    expect(renamed).toEqual([]);
+  });
+});
+
+describe('the dock exports the sheet the host builds', () => {
+  it('renders no export control where the host offered no export', async () => {
+    const { root } = await openDock({});
+    expect(root.byText('Export PDF')).toBeUndefined();
+  });
+
+  it('runs the host export for the measurement it is plotting', async () => {
+    const asked: string[] = [];
+    const { root } = await openDock({
+      exportPdf: (id) => {
+        asked.push(id);
+        return Promise.resolve();
+      },
+    });
+    const btn = root.byText('Export PDF');
+    expect(btn).toBeDefined();
+    btn!.dispatch('click');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(asked).toEqual(['m-1']);
+    expect(btn!.textContent).toBe('Export PDF');
+    expect(btn!.disabled).toBe(false);
+  });
+
+  it('reports a failed export on the control that was pressed', async () => {
+    const { root } = await openDock({ exportPdf: () => Promise.reject(new Error('no')) });
+    const btn = root.byText('Export PDF')!;
+    btn.dispatch('click');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(btn.textContent).toBe('Export failed');
+    expect(btn.disabled).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// What lands on the page
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ramp(n: number): ProfileChartSample[] {
+  const out: ProfileChartSample[] = [];
+  for (let i = 0; i < n; i++) out.push({ distance: i * 2, height: 100 + i * 0.4 });
+  return out;
+}
+
+/** The drawn strings of a sheet, rejoined across the builder's line breaks. */
+function drawnPdfProse(bytes: Uint8Array): string {
+  const parts: string[] = [];
+  let inflated = '';
+  const raw = Buffer.from(bytes).toString('latin1');
+  for (const m of raw.matchAll(/stream\r?\n([\s\S]*?)\r?\nendstream/g)) {
+    try {
+      inflated += inflateSync(Buffer.from(m[1]!, 'latin1')).toString('latin1');
+    } catch {
+      inflated += m[1]!;
+    }
+  }
+  for (const m of inflated.matchAll(/<([0-9A-Fa-f]+)>/g)) {
+    parts.push(Buffer.from(m[1]!, 'hex').toString('latin1'));
+  }
+  return parts.join(' ');
+}
+
+/** A resident-only read with classification missing on one source. */
+function provenanceRecord() {
+  return buildProfileProvenance({
+    capturedAt: '2026-01-01T00:00:00.000Z',
+    up: [0, 0, 1],
+    sources: [
+      {
+        slot: 0,
+        layerId: 'urn:layer:alpha',
+        displayName: 'Alpha flight',
+        classification: 'absent',
+        streaming: true,
+      },
+    ],
+    accepted: { count: 2, sourceSlot: [0, 0] },
+    excludedClasses: NON_GROUND_CLASSES,
+    units: { linearUnit: 'metre', verticalReference: 'unknown', verticalMetresPerUnit: 1 },
+  });
+}
+
+function summaryNamed(name: string): MeasurementSummary {
+  return {
+    id: 'm-1',
+    kind: 'profile',
+    name,
+    value: '482.0 m',
+    profileChart: ramp(16),
+    profileChartResidentOnly: true,
+    profileCorridorWidthM: 12.5,
+    profileGroundPercentile: 25,
+    profileDatumKnown: false,
+    profileProvenance: provenanceRecord(),
+  } as unknown as MeasurementSummary;
+}
+
+describe('the exported sheet carries the name and the provenance', () => {
+  const FIXED_DATE = new Date('2026-01-01T00:00:00.000Z');
+
+  it('prints the renamed profile on the sheet', async () => {
+    const input = profilePdfInputFor(summaryNamed('North levee'), {
+      context: { crs: 'EPSG:2225 - NAD83 / California zone 1 (ftUS)', verticalDatum: null },
+      unitSystem: 'metric',
+      generatedAt: FIXED_DATE,
+    });
+    expect(input.name).toBe('North levee');
+    const text = drawnPdfProse(await buildProfilePdf(input));
+    expect(text).toContain('North levee');
+  });
+
+  it('carries the read scope AND the classification basis of the heights', async () => {
+    const record = provenanceRecord();
+    const sentence = describeProfileProvenance(record);
+    // The clause that is easiest to lose and worst to lose: what the heights
+    // were classified on. A sheet without it reads as a clean ground surface.
+    expect(sentence).toContain('classification missing on a source');
+
+    const input = profilePdfInputFor(summaryNamed('North levee'), {
+      context: null,
+      unitSystem: 'metric',
+      generatedAt: FIXED_DATE,
+    });
+    expect(input.provenance).not.toBeNull();
+    const text = drawnPdfProse(await buildProfilePdf(input));
+    expect(text).toContain(sentence);
+    expect(text).toContain('classification missing on a source');
+  });
+
+  it('passes every parameter the app knows, not a subset', async () => {
+    const input = profilePdfInputFor(summaryNamed('North levee'), {
+      context: { crs: 'EPSG:6340 - NAD83(2011) / UTM zone 11N', verticalDatum: 'NAVD88' },
+      unitSystem: 'imperial',
+      generatedAt: FIXED_DATE,
+    });
+    expect(input.crs).toBe('EPSG:6340 - NAD83(2011) / UTM zone 11N');
+    expect(input.verticalDatum).toBe('NAVD88');
+    expect(input.unitSystem).toBe('imperial');
+    expect(input.corridorWidthM).toBe(12.5);
+    expect(input.groundPercentile).toBe(25);
+    expect(input.residentOnly).toBe(true);
+    // A conflicting render origin means these are LOCAL heights, and the sheet
+    // must not print the word elevation over them.
+    expect(input.datumKnown).toBe(false);
+    expect(input.generatedAt).toBe(FIXED_DATE);
+  });
+});
+
+describe('there is one assembly of the sheet, not one per control', () => {
+  /**
+   * Read as source rather than exercised through the panel.
+   *
+   * What has to hold is a property of the FILE: that no control anywhere in it
+   * reaches the builder with inputs of its own. Driving one control cannot
+   * show that, because the second assembly is exactly the one the driven
+   * control does not use, and that is how the CRS and the provenance came to
+   * be missing from every sheet once before.
+   */
+  const source = readFileSync(
+    fileURLToPath(new URL('../src/ui/MeasurePanel.ts', import.meta.url)),
+    'utf8',
+  );
+
+  it('reaches the builder from a single call site', () => {
+    const calls = source.match(/\bbuildProfilePdf\s*\(/g) ?? [];
+    expect(calls.length).toBe(1);
+  });
+
+  it('reaches it through the shared assembly, never with a literal of its own', () => {
+    const at = source.indexOf('buildProfilePdf(');
+    expect(at).toBeGreaterThan(0);
+    expect(source.slice(at, at + 200)).toContain('profilePdfInputFor(');
+  });
+
+  it('exposes the export by id, which is the route the dock takes', () => {
+    expect(source).toContain('async exportProfilePdf(id: string): Promise<void>');
+  });
+});

--- a/tests/workbenchPlotAxes.test.ts
+++ b/tests/workbenchPlotAxes.test.ts
@@ -1,0 +1,311 @@
+/**
+ * workbenchPlotAxes.test.ts
+ *
+ * What the docked workbench actually draws on its plot beyond the returns: the
+ * grid rules, the tick labels, and the two axis titles.
+ *
+ * The plot is a canvas, so the only thing a reader can check is what was
+ * asked of the context. The suite drives `prepareWorkbenchSection` against a
+ * recording 2D context and asserts on the text it was told to draw and where.
+ *
+ * The height axis is the point of the exercise. A section with no declared
+ * datum must be titled "Height (datum unknown)" and never "Elevation": a plot
+ * outlives the reader's memory of which scan it came from, so the axis is
+ * where the surface a height was measured from is stated or lost.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  AXIS_FONT_PX,
+  AXIS_LABEL_INSET_PX,
+  drawWorkbenchAxes,
+  prepareWorkbenchSection,
+} from '../src/app/profileWorkbenchSection';
+import {
+  AXIS_LABEL_MIN_GAP_PX,
+  axisLabelWidth,
+  profileAxes,
+} from '../src/render/measure/profileAxes';
+import { fitProfileView } from '../src/render/measure/profileViewTransform';
+import type { ProfileViewport } from '../src/render/measure/profileViewTransform';
+import type { ProfileSectionResult } from '../src/render/measure/profileSectionSeam';
+
+/** One `fillText` call, as the plot made it. */
+interface DrawnText {
+  readonly text: string;
+  readonly x: number;
+  readonly y: number;
+  readonly align: string;
+  readonly baseline: string;
+}
+
+/** A 2D context that records the calls the axis code makes. */
+function recordingContext() {
+  const texts: DrawnText[] = [];
+  const lines: [number, number, number, number][] = [];
+  let from: [number, number] = [0, 0];
+  const ctx = {
+    fillStyle: '' as string,
+    strokeStyle: '' as string,
+    lineWidth: 0,
+    globalAlpha: 1,
+    font: '',
+    textAlign: '',
+    textBaseline: '',
+    setTransform: (): void => {},
+    clearRect: (): void => {},
+    fillRect: (): void => {},
+    beginPath: (): void => {},
+    moveTo: (x: number, y: number): void => {
+      from = [x, y];
+    },
+    lineTo: (x: number, y: number): void => {
+      lines.push([from[0], from[1], x, y]);
+    },
+    stroke: (): void => {},
+    fillText: (text: string, x: number, y: number): void => {
+      texts.push({ text, x, y, align: ctx.textAlign, baseline: ctx.textBaseline });
+    },
+    texts,
+    lines,
+  };
+  return ctx;
+}
+
+class FakeCanvas {
+  width = 0;
+  height = 0;
+  readonly ctx = recordingContext();
+  readonly clientWidth: number;
+  readonly clientHeight: number;
+  constructor(clientWidth: number, clientHeight: number) {
+    this.clientWidth = clientWidth;
+    this.clientHeight = clientHeight;
+  }
+  getContext(): ReturnType<typeof recordingContext> {
+    return this.ctx;
+  }
+}
+
+/** A ramp section: a chainage run with a real height range over it. */
+function rampSection(count: number): ProfileSectionResult {
+  const chainage = new Float32Array(count);
+  const height = new Float64Array(count);
+  for (let i = 0; i < count; i++) {
+    chainage[i] = (i / (count - 1)) * 241.31 - 3.7;
+    height[i] = 1103.04 + (i / (count - 1)) * 28.86;
+  }
+  return {
+    points: {
+      count,
+      chainage,
+      height,
+      lateralOffset: new Float32Array(count),
+      sourceSlot: new Uint16Array(count),
+      pointIndex: new Uint32Array(count),
+      channelPresence: new Uint8Array(count),
+    },
+    frame: null as never,
+    band: 2,
+    scope: 'static' as never,
+    scopeLabel: 'One loaded layer.',
+    streamingComplete: null,
+    sources: [],
+    generation: 1,
+    aborted: false,
+    skippedSlots: [],
+    examined: count,
+  } as unknown as ProfileSectionResult;
+}
+
+/** A section far out on a projected grid: every chainage label is seven digits. */
+function farFieldSection(count: number): ProfileSectionResult {
+  const section = rampSection(count);
+  const chainage = section.points.chainage as Float32Array;
+  for (let i = 0; i < count; i++) chainage[i] = 1_250_000 + (i / (count - 1)) * 500;
+  return section;
+}
+
+describe('the workbench plot carries axis indicators', () => {
+  it('draws chainage and height titles, and grid rules on both axes', () => {
+    const canvas = new FakeCanvas(640, 320);
+    prepareWorkbenchSection({
+      section: rampSection(200),
+      canvas,
+      unitSuffix: 'm',
+      unitScale: 1,
+      reference: 'orthometric',
+    });
+    const drawn = canvas.ctx.texts.map((t) => t.text);
+    expect(drawn).toContain('Chainage (m)');
+    expect(drawn).toContain('Elevation (m)');
+    // Rules on both axes: at least one full-height and one full-width line.
+    expect(canvas.ctx.lines.some(([x1, y1, x2, y2]) => x1 === x2 && y1 === 0 && y2 === 320)).toBe(
+      true,
+    );
+    expect(canvas.ctx.lines.some(([x1, y1, x2, y2]) => y1 === y2 && x1 === 0 && x2 === 640)).toBe(
+      true,
+    );
+  });
+
+  it('titles the height axis "Height (datum unknown)" when no datum was declared', () => {
+    const canvas = new FakeCanvas(640, 320);
+    prepareWorkbenchSection({
+      section: rampSection(200),
+      canvas,
+      unitSuffix: 'm',
+      unitScale: 1,
+      reference: 'unknown',
+    });
+    const drawn = canvas.ctx.texts.map((t) => t.text);
+    expect(drawn).toContain('Height (datum unknown) (m)');
+    expect(drawn.join(' ')).not.toContain('Elevation');
+  });
+
+  it('says nothing about a datum a caller did not state', () => {
+    // No `reference` at all is the same case as an unresolved CRS, and the
+    // plot must default to the honest wording rather than to an elevation.
+    const canvas = new FakeCanvas(640, 320);
+    prepareWorkbenchSection({ section: rampSection(200), canvas, unitSuffix: 'm', unitScale: 1 });
+    expect(canvas.ctx.texts.map((t) => t.text).join(' ')).toContain('Height (datum unknown)');
+  });
+
+  it('prints bare numbers on a frame whose render units are not the stated unit', () => {
+    // A foot-CRS scan: the spans in the detail list are converted to metres,
+    // but the ticks are read off the section in its own units, so the axis
+    // must not label them with a unit they are not in.
+    const canvas = new FakeCanvas(640, 320);
+    prepareWorkbenchSection({
+      section: rampSection(200),
+      canvas,
+      unitSuffix: 'm',
+      unitScale: 0.3048,
+      reference: 'unknown',
+    });
+    const drawn = canvas.ctx.texts.map((t) => t.text);
+    expect(drawn).toContain('Chainage');
+    expect(drawn).not.toContain('Chainage (m)');
+  });
+
+  it('draws no labels that overlap, at the narrowest plot the dock permits', () => {
+    const viewport: ProfileViewport = { width: 180, height: 96, devicePixelRatio: 1 };
+    const canvas = new FakeCanvas(viewport.width, viewport.height);
+    prepareWorkbenchSection({
+      section: rampSection(200),
+      canvas,
+      unitSuffix: 'm',
+      unitScale: 1,
+      reference: 'unknown',
+    });
+    // The tick labels are the centred, bottom-aligned run; the two titles are
+    // drawn with the other alignments and are not competing with them.
+    const ticks = canvas.ctx.texts
+      .filter((t) => t.align === 'center' && t.baseline === 'bottom')
+      .map((t) => ({
+        start: t.x - axisLabelWidth(t.text, AXIS_FONT_PX) / 2,
+        end: t.x + axisLabelWidth(t.text, AXIS_FONT_PX) / 2,
+      }))
+      .sort((a, b) => a.start - b.start);
+    for (let i = 1; i < ticks.length; i++) {
+      expect(
+        ticks[i]!.start - ticks[i - 1]!.end,
+        'two chainage labels were drawn touching',
+      ).toBeGreaterThanOrEqual(AXIS_LABEL_MIN_GAP_PX);
+    }
+    // Stacked height labels: a line apart, down the left inset.
+    const heights = canvas.ctx.texts
+      .filter((t) => t.align === 'left' && t.baseline === 'middle')
+      .map((t) => t.y)
+      .sort((a, b) => a - b);
+    for (let i = 1; i < heights.length; i++) {
+      expect(heights[i]! - heights[i - 1]!).toBeGreaterThanOrEqual(
+        AXIS_FONT_PX + AXIS_LABEL_MIN_GAP_PX,
+      );
+    }
+    // And every one of them inside the plot the reader can see.
+    for (const t of canvas.ctx.texts) {
+      expect(t.x).toBeGreaterThanOrEqual(0);
+      expect(t.x).toBeLessThanOrEqual(viewport.width);
+      expect(t.y).toBeGreaterThanOrEqual(0);
+      expect(t.y).toBeLessThanOrEqual(viewport.height);
+    }
+  });
+
+  it('drops chainage labels a narrow plot cannot hold rather than stacking them', () => {
+    // Seven-digit chainage on a 180 px plot. The tick scale is chosen from the
+    // section's span, not from how much room a label needs, so at this width
+    // the numbers are wider than the space between the rules they belong to.
+    // Every label drawn has to be clear of its neighbour anyway.
+    const viewport: ProfileViewport = { width: 180, height: 96, devicePixelRatio: 1 };
+    const canvas = new FakeCanvas(viewport.width, viewport.height);
+    prepareWorkbenchSection({
+      section: farFieldSection(200),
+      canvas,
+      unitSuffix: 'm',
+      unitScale: 1,
+      reference: 'unknown',
+    });
+    const ticks = canvas.ctx.texts
+      .filter((t) => t.align === 'center' && t.baseline === 'bottom')
+      .map((t) => ({
+        text: t.text,
+        start: t.x - axisLabelWidth(t.text, AXIS_FONT_PX) / 2,
+        end: t.x + axisLabelWidth(t.text, AXIS_FONT_PX) / 2,
+      }))
+      .sort((a, b) => a.start - b.start);
+    // The labels really are wide enough to collide if nothing dropped any.
+    expect(ticks.every((t) => t.text.length >= 7)).toBe(true);
+    for (let i = 1; i < ticks.length; i++) {
+      expect(
+        ticks[i]!.start - ticks[i - 1]!.end,
+        `"${ticks[i - 1]!.text}" and "${ticks[i]!.text}" were drawn touching`,
+      ).toBeGreaterThanOrEqual(AXIS_LABEL_MIN_GAP_PX);
+    }
+    for (const t of ticks) {
+      expect(t.start).toBeGreaterThanOrEqual(0);
+      expect(t.end).toBeLessThanOrEqual(viewport.width);
+    }
+  });
+
+  it('draws the rules but no words for a context that cannot render text', () => {
+    // An older double, or a browser context missing the text calls. The grid
+    // still lands; nothing throws on the way to it.
+    const viewport: ProfileViewport = { width: 400, height: 200, devicePixelRatio: 1 };
+    const view = fitProfileView(
+      { minChainage: 0, maxChainage: 100, minHeight: 0, maxHeight: 10 },
+      viewport,
+      { kind: 'fit' },
+      { horizontalToMetres: null, verticalToMetres: null },
+    );
+    if (!view) throw new Error('the fixture must produce a view');
+    const bare = recordingContext() as Record<string, unknown>;
+    delete bare.fillText;
+    expect(() =>
+      drawWorkbenchAxes(
+        bare as never,
+        profileAxes(view, viewport, {
+          reference: 'unknown',
+          horizontalUnit: 'm',
+          verticalUnit: 'm',
+          units: { horizontalToMetres: null, verticalToMetres: null },
+        }),
+        viewport,
+      ),
+    ).not.toThrow();
+    expect((bare.lines as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it('insets its labels from the edge rather than sitting on it', () => {
+    const canvas = new FakeCanvas(640, 320);
+    prepareWorkbenchSection({
+      section: rampSection(200),
+      canvas,
+      unitSuffix: 'm',
+      unitScale: 1,
+      reference: 'unknown',
+    });
+    const left = canvas.ctx.texts.filter((t) => t.align === 'left' && t.baseline === 'middle');
+    expect(left.length).toBeGreaterThan(0);
+    for (const t of left) expect(t.x).toBe(AXIS_LABEL_INSET_PX);
+  });
+});


### PR DESCRIPTION
The workbench plot carried no axis indicators, although the numbers behind them already existed. `profileAxes` places the ticks and titles, and `heightLabel` owns the wording, so a scan with no declared datum reads `Height (datum unknown)` here for the same reason it does in the point inspector. Labels come from the shared fitter, centred, because this canvas centres its end labels while the panel overlay pulls its ends inside the plot.

The title is editable and commits through `renameMeasurement`, the call the measurements panel already makes, so one name reaches the panel, the dock and the sheet rather than three.

Export runs the existing PDF builder through a single input assembly shared with the panel, so the read scope and the classification basis travel with it by construction.
