### PR TITLE
feat(profile): give the axis the detail the plot has room for

### DIFF
--- a/src/app/profileWorkbenchSection.ts
+++ b/src/app/profileWorkbenchSection.ts
@@ -55,8 +55,11 @@ import {
 } from '../render/measure/profileProvenance';
 import {
   axisSpanCaption,
+  CHAINAGE_TICK_SPACING_PX,
   fitAxisLabels,
+  HEIGHT_TICK_SPACING_PX,
   profileAxes,
+  targetTicksForLength,
 } from '../render/measure/profileAxes';
 import {
   selectProfileSectionLod,
@@ -165,9 +168,6 @@ export const AXIS_LABEL_INSET_PX = 4;
 const AXIS_RULE_COLOUR = 'rgba(255, 255, 255, 0.10)';
 const AXIS_TEXT_COLOUR = 'rgba(255, 255, 255, 0.62)';
 const AXIS_TITLE_COLOUR = 'rgba(255, 255, 255, 0.45)';
-
-/** Target major ticks per axis. Fewer than the plot could hold, so labels fit. */
-export const AXIS_TARGET_TICKS = 6;
 
 /**
  * The 2D context, with the text calls the axis needs.
@@ -483,8 +483,11 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
         horizontalUnit: axisUnit,
         verticalUnit: axisUnit,
         units: { horizontalToMetres: null, verticalToMetres: null },
-        targetXTicks: AXIS_TARGET_TICKS,
-        targetYTicks: AXIS_TARGET_TICKS,
+        // Derived from the plot, not fixed: this canvas is often ten times the
+        // width of the panel thumbnail, and a constant target spends that room
+        // on whitespace.
+        targetXTicks: targetTicksForLength(viewport.width, CHAINAGE_TICK_SPACING_PX),
+        targetYTicks: targetTicksForLength(viewport.height, HEIGHT_TICK_SPACING_PX),
       }),
       viewport,
     );

--- a/src/render/measure/profileAxes.ts
+++ b/src/render/measure/profileAxes.ts
@@ -99,6 +99,42 @@ function niceStepAtLeast(raw: number): NiceStep {
 }
 
 /**
+ * The nice step whose tick count comes CLOSEST to what was asked for.
+ *
+ * Rounding the raw step up to the next nice value can only ever produce fewer
+ * ticks than the target, and with a 1-2-5 ladder the shortfall reaches a factor
+ * of two and a half: a span of 13.5 asking for six ticks yields a raw step of
+ * 2.25, which rounds to 5 and draws three. An axis that quietly halves the
+ * detail it was asked for is not reporting a limit, it is just coarse.
+ *
+ * Both neighbours are real nice steps, so choosing between them by the count
+ * they produce cannot land on an unreadable number. The step BELOW is only
+ * taken when its count is strictly closer, so a tie keeps the coarser axis and
+ * the choice stays deterministic.
+ */
+function niceStepNearest(raw: number, span: number, target: number): NiceStep {
+  const up = niceStepAtLeast(raw);
+  if (!(span > 0) || !(target > 0)) return up;
+  // One rung down the 1-2-5 ladder: 1 falls to 5 of the decade below.
+  const i = NICE_MANTISSAS.indexOf(up.mantissa);
+  const down: NiceStep =
+    i > 0
+      ? {
+          step: NICE_MANTISSAS[i - 1]! * Math.pow(10, up.exponent),
+          mantissa: NICE_MANTISSAS[i - 1]!,
+          exponent: up.exponent,
+        }
+      : {
+          step: NICE_MANTISSAS[NICE_MANTISSAS.length - 1]! * Math.pow(10, up.exponent - 1),
+          mantissa: NICE_MANTISSAS[NICE_MANTISSAS.length - 1]!,
+          exponent: up.exponent - 1,
+        };
+  if (!(down.step > MIN_STEP)) return up;
+  const missBy = (s: number): number => Math.abs(span / s - target);
+  return missBy(down.step) < missBy(up.step) ? down : up;
+}
+
+/**
  * Minor divisions per major step, keyed on the step's leading digit: a 1 step
  * splits into 5 (0.2 each), a 2 step into 4 (0.5 each), a 5 step into 5 (1
  * each). Every rule puts the minor lines on a round decimal fraction of the
@@ -144,6 +180,37 @@ function clampTarget(n: number): number {
  * multiple of `step`; every tick lies inside the range whenever the range has
  * width.
  */
+/**
+ * Comfortable spacing between labelled ticks, in CSS pixels.
+ *
+ * The two axes differ because their labels do. A chainage label lies ALONG its
+ * axis and is as wide as its digits, so it needs room for the widest reading
+ * plus a gap. A height label is stacked beside the plot, where what one label
+ * can run into is the line height of its neighbour, which is far smaller than
+ * the text is wide.
+ *
+ * These size the ASK. What actually gets drawn is settled by `fitAxisLabels`,
+ * which drops any label the strip cannot hold, so asking for slightly too many
+ * costs a tick rather than an overlap.
+ */
+export const CHAINAGE_TICK_SPACING_PX = 100;
+export const HEIGHT_TICK_SPACING_PX = 50;
+
+/**
+ * How many ticks a strip of this length can carry.
+ *
+ * A tick target that ignores the plot size gives a wall-sized workbench the
+ * same six ticks as a panel thumbnail, which reads as a coarse axis on the one
+ * surface with room to be precise. Two ticks is the floor because an axis
+ * showing one value states a position without a scale.
+ */
+export function targetTicksForLength(lengthPx: number, spacingPx: number): number {
+  if (!Number.isFinite(lengthPx) || !Number.isFinite(spacingPx) || spacingPx <= 0) {
+    return DEFAULT_TARGET_TICKS;
+  }
+  return Math.min(MAX_TARGET_TICKS, Math.max(2, Math.round(lengthPx / spacingPx)));
+}
+
 export function axisTicks(min: number, max: number, targetCount: number): AxisTicks {
   const a = Number.isFinite(min) ? min : 0;
   const b = Number.isFinite(max) ? max : 0;
@@ -156,7 +223,7 @@ export function axisTicks(min: number, max: number, targetCount: number): AxisTi
   // step below that cannot separate two ticks and would emit a duplicate list.
   const floorStep = Math.max(MIN_STEP, magnitude * Number.EPSILON * 8);
   const raw = span > 0 ? span / target : magnitude > 0 ? magnitude / target : 1;
-  const nice = niceStepAtLeast(Math.max(raw, floorStep));
+  const nice = niceStepNearest(Math.max(raw, floorStep), span, target);
   const decimals = Math.min(MAX_DECIMALS, Math.max(0, -nice.exponent));
   const step = nice.step;
 

--- a/src/render/measure/profileAxes.ts
+++ b/src/render/measure/profileAxes.ts
@@ -131,7 +131,16 @@ function niceStepNearest(raw: number, span: number, target: number): NiceStep {
         };
   if (!(down.step > MIN_STEP)) return up;
   const missBy = (s: number): number => Math.abs(span / s - target);
-  return missBy(down.step) < missBy(up.step) ? down : up;
+  // The finer rung is taken only when it is nearer AND still respects the
+  // upper bound an axis is entitled to: a caller asking for eight ticks has
+  // said what it has room for, and eleven is not a closer answer to that
+  // question, it is a different one. Without this the nearest rule trades one
+  // failure for its mirror image, drawing a crowded axis instead of a coarse
+  // one.
+  // Ticks, not intervals: a range spanning n steps carries n + 1 of them when
+  // its ends land on step boundaries, which is the crowded case worth bounding.
+  const withinCeiling = Math.floor(span / down.step) + 1 <= target + 1;
+  return withinCeiling && missBy(down.step) < missBy(up.step) ? down : up;
 }
 
 /**

--- a/tests/profileAxisIndicators.test.ts
+++ b/tests/profileAxisIndicators.test.ts
@@ -28,13 +28,13 @@ import {
   axisLabelWidth,
   axisTicks,
   chainageTickLabels,
+  DEFAULT_TARGET_TICKS,
   fitAxisLabels,
   heightAxisTitle,
   profileAxes,
 } from '../src/render/measure/profileAxes';
 import {
   AXIS_FONT_PX,
-  AXIS_TARGET_TICKS,
 } from '../src/app/profileWorkbenchSection';
 import { fitProfileView } from '../src/render/measure/profileViewTransform';
 import type { ProfileViewport } from '../src/render/measure/profileViewTransform';
@@ -66,7 +66,7 @@ describe('a tick is an exact multiple of its step', () => {
       [12.0000001, 12.0000009],
     ];
     for (const [lo, hi] of spans) {
-      const ticks = axisTicks(lo, hi, AXIS_TARGET_TICKS);
+      const ticks = axisTicks(lo, hi, DEFAULT_TARGET_TICKS);
       for (const v of ticks.values) {
         const q = v / ticks.step;
         expect(Math.abs(q - Math.round(q)), `${v} is not a multiple of ${ticks.step}`).toBeLessThan(
@@ -100,8 +100,8 @@ describe('the height axis states no more than the scan supports', () => {
       horizontalUnit: 'm',
       verticalUnit: 'm',
       units: NO_SCALE,
-      targetXTicks: AXIS_TARGET_TICKS,
-      targetYTicks: AXIS_TARGET_TICKS,
+      targetXTicks: DEFAULT_TARGET_TICKS,
+      targetYTicks: DEFAULT_TARGET_TICKS,
     });
     expect(axes.y.title).toContain('Height (datum unknown)');
     expect(axes.y.title).not.toContain('Elevation');
@@ -155,8 +155,8 @@ describe('axis labels do not overlap', () => {
       horizontalUnit: 'm',
       verticalUnit: 'm',
       units: NO_SCALE,
-      targetXTicks: AXIS_TARGET_TICKS,
-      targetYTicks: AXIS_TARGET_TICKS,
+      targetXTicks: DEFAULT_TARGET_TICKS,
+      targetYTicks: DEFAULT_TARGET_TICKS,
     });
     const spans = keptSpans(axes.x.labels, axes.x.pixels, NARROW.width, (l) =>
       axisLabelWidth(l, AXIS_FONT_PX),
@@ -180,8 +180,8 @@ describe('axis labels do not overlap', () => {
       horizontalUnit: 'm',
       verticalUnit: 'm',
       units: NO_SCALE,
-      targetXTicks: AXIS_TARGET_TICKS,
-      targetYTicks: AXIS_TARGET_TICKS,
+      targetXTicks: DEFAULT_TARGET_TICKS,
+      targetYTicks: DEFAULT_TARGET_TICKS,
     });
     const spans = keptSpans(axes.y.labels, axes.y.pixels, NARROW.height, () => AXIS_FONT_PX);
     expect(spans.length).toBeGreaterThan(0);

--- a/tests/profileAxisTickDensity.test.ts
+++ b/tests/profileAxisTickDensity.test.ts
@@ -1,0 +1,104 @@
+/**
+ * profileAxisTickDensity.test.ts — an axis that carries the detail it was asked for.
+ *
+ * Two things made the workbench plot coarser than its size warranted.
+ *
+ * The step was always rounded UP to the next nice value, which can only ever
+ * produce fewer ticks than the target. On a 1-2-5 ladder the shortfall reaches
+ * a factor of two and a half: a 13.5 m height span asking for six ticks gives a
+ * raw step of 2.25, which rounds to 5 and draws three. Half the requested
+ * detail, silently.
+ *
+ * And the target itself was a constant, so a workbench canvas ten times the
+ * width of the panel thumbnail asked for the same six ticks and spent the extra
+ * room on whitespace.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  axisTicks,
+  targetTicksForLength,
+  DEFAULT_TARGET_TICKS,
+  MAX_TARGET_TICKS,
+  CHAINAGE_TICK_SPACING_PX,
+  HEIGHT_TICK_SPACING_PX,
+} from '../src/render/measure/profileAxes';
+
+describe('choosing the step nearest the target', () => {
+  it('takes the finer step when it lands closer to the ask', () => {
+    // The reported profile: 13.522 m of height, six ticks wanted. Rounding up
+    // gave a step of 5 and three ticks; 2 is the nearer answer.
+    const t = axisTicks(3.5, 17.022, 6);
+    expect(t.step).toBe(2);
+    expect(t.values.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('keeps the coarser step when THAT is closer', () => {
+    // Not a bias toward density: 97.935 m over six ticks wants 16.3, and 20
+    // misses by less than 10 does. The rule is distance to the target, not
+    // "more ticks".
+    expect(axisTicks(0, 97.935, 6).step).toBe(20);
+  });
+
+  it('never returns a step that is not a nice number', () => {
+    for (const span of [0.7, 3, 13.522, 97.935, 1234, 88_000]) {
+      const { step } = axisTicks(0, span, 6);
+      const m = step / Math.pow(10, Math.floor(Math.log10(step)));
+      expect([1, 2, 5].some((n) => Math.abs(m - n) < 1e-9), `step ${step}`).toBe(true);
+    }
+  });
+
+  it('is deterministic on a tie, keeping the coarser axis', () => {
+    // A span whose two candidates miss the target equally must not depend on
+    // evaluation order.
+    const a = axisTicks(0, 30, 10);
+    const b = axisTicks(0, 30, 10);
+    expect(a.step).toBe(b.step);
+  });
+});
+
+describe('sizing the target to the strip', () => {
+  it('asks for more ticks on a longer strip', () => {
+    const small = targetTicksForLength(220, CHAINAGE_TICK_SPACING_PX);
+    const large = targetTicksForLength(2000, CHAINAGE_TICK_SPACING_PX);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('asks for more height ticks than chainage ticks at one size', () => {
+    // A height label is stacked beside the plot, so what it can collide with is
+    // a line height rather than the width of a reading.
+    expect(targetTicksForLength(500, HEIGHT_TICK_SPACING_PX)).toBeGreaterThan(
+      targetTicksForLength(500, CHAINAGE_TICK_SPACING_PX),
+    );
+  });
+
+  it('never asks for fewer than two, because one tick states no scale', () => {
+    expect(targetTicksForLength(10, CHAINAGE_TICK_SPACING_PX)).toBe(2);
+    expect(targetTicksForLength(0, CHAINAGE_TICK_SPACING_PX)).toBe(2);
+  });
+
+  it('stays within the tick ceiling on an absurd strip', () => {
+    expect(targetTicksForLength(1e9, HEIGHT_TICK_SPACING_PX)).toBeLessThanOrEqual(
+      MAX_TARGET_TICKS,
+    );
+  });
+
+  it('falls back to the default rather than guessing on bad input', () => {
+    expect(targetTicksForLength(Number.NaN, CHAINAGE_TICK_SPACING_PX)).toBe(
+      DEFAULT_TARGET_TICKS,
+    );
+    expect(targetTicksForLength(500, 0)).toBe(DEFAULT_TARGET_TICKS);
+  });
+});
+
+describe('what the reported plot now draws', () => {
+  it('carries finer chainage and height detail at workbench size', () => {
+    // 2000 by 500, the section in the report: chainage every 5 m where it was
+    // every 20, height every 2 m where it was every 5.
+    const x = axisTicks(0, 97.935, targetTicksForLength(2000, CHAINAGE_TICK_SPACING_PX));
+    const y = axisTicks(3.5, 17.022, targetTicksForLength(500, HEIGHT_TICK_SPACING_PX));
+    expect(x.step).toBeLessThanOrEqual(5);
+    expect(y.step).toBeLessThanOrEqual(2);
+    expect(x.values.length).toBeGreaterThanOrEqual(15);
+  });
+});


### PR DESCRIPTION
The axis step was rounded up to the next nice value, so an axis could only ever draw fewer ticks than it was asked for. On a 1-2-5 ladder the shortfall reaches a factor of two and a half: 13.522 m of height asking for six ticks gives a raw step of 2.25, which rounds to 5 and draws three. `axisTicks` now takes whichever neighbouring nice step lands closer to the target, so 97.935 m of chainage still takes 20 where 20 is the nearer answer.

The target was a constant, so the workbench canvas asked for the same six ticks as the panel thumbnail. It now follows the strip length. Chainage and height are sized separately: a height label is stacked beside the plot, where it meets a line height rather than the width of a reading.

At 2000 by 500 the reported section draws chainage every 5 m and height every 2 m.
