### PR TITLE
fix(profile): correct the sheet's exaggeration, its overprinted values, and its framing

### DIFF
--- a/scripts/sample-profile-pdf.mjs
+++ b/scripts/sample-profile-pdf.mjs
@@ -1,0 +1,35 @@
+/**
+ * sample-profile-pdf.mjs — build one profile sheet from a synthetic section so
+ * the layout can be looked at rather than only asserted.
+ *
+ * The fixture is deliberately awkward: a 40 m relief over 900 m and 181
+ * stations, which is far more stations than the data band has room to label,
+ * so the thinning path is the one that gets drawn. The date is fixed, for the
+ * same reason the builder refuses to read the clock.
+ *
+ * Usage: npx vite-node scripts/sample-profile-pdf.mjs [outPath]
+ */
+import { writeFileSync } from 'node:fs';
+import { buildProfilePdf } from '../src/render/measure/profilePdf.ts';
+
+const samples = [];
+for (let i = 0; i <= 180; i++) {
+  const d = i * 5;
+  samples.push({
+    distance: d,
+    height: 180 + Math.sin(d / 140) * 18 + Math.sin(d / 37) * 3 + d * 0.012,
+  });
+}
+
+const bytes = await buildProfilePdf({
+  name: 'Sample longitudinal section',
+  samples,
+  corridorWidthM: 4,
+  groundPercentile: 15,
+  crs: 'EPSG:32613',
+  verticalDatum: null,
+  generatedAt: new Date('2026-01-01T00:00:00.000Z'),
+});
+const out = process.argv[2] ?? '/tmp/profile-sample.pdf';
+writeFileSync(out, bytes);
+console.log(`wrote ${out} (${bytes.byteLength} bytes)`);

--- a/scripts/sample-profile-pdf.mjs
+++ b/scripts/sample-profile-pdf.mjs
@@ -9,7 +9,9 @@
  *
  * Usage: npx vite-node scripts/sample-profile-pdf.mjs [outPath]
  */
-import { writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { buildProfilePdf } from '../src/render/measure/profilePdf.ts';
 
 const samples = [];
@@ -30,6 +32,10 @@ const bytes = await buildProfilePdf({
   verticalDatum: null,
   generatedAt: new Date('2026-01-01T00:00:00.000Z'),
 });
-const out = process.argv[2] ?? '/tmp/profile-sample.pdf';
+// A fixed path under the shared temp directory is predictable, so another
+// user on the same machine can pre-create it and decide where these bytes
+// land. Without an explicit destination this makes its own private directory
+// instead, and prints where it went.
+const out = process.argv[2] ?? join(mkdtempSync(join(tmpdir(), 'olv-profile-')), 'profile-sample.pdf');
 writeFileSync(out, bytes);
 console.log(`wrote ${out} (${bytes.byteLength} bytes)`);

--- a/src/render/measure/profilePdf.ts
+++ b/src/render/measure/profilePdf.ts
@@ -4,13 +4,20 @@
  * Full-page PDF export of a Profile measurement — a deliverable an
  * engineer can print and take measurements off. It renders:
  *
- *   - A large, box-filling section chart with a survey grid, labelled
- *     chainage (X) and height (Y) axes, and the profile drawn as a
- *     straight polyline between adjacent samples, so no plotted height
- *     falls outside the two stations bracketing it (gaps stay breaks).
- *   - The stated horizontal and vertical scales (1:N each) and the
- *     resulting vertical exaggeration, so distances/grades read off the
- *     print are unambiguous — a true civil section convention.
+ *   - A framed section chart with a survey grid, a height (Y) axis, and the
+ *     profile drawn as a straight polyline between adjacent samples, so no
+ *     plotted height falls outside the two stations bracketing it (gaps stay
+ *     breaks).
+ *   - A station data band ruled under the section, carrying partial distance,
+ *     chainage and ground height per station. Its columns come from the plot's
+ *     own x mapping, so a vertical dropped from the curve lands on the figures
+ *     for that station; where the stations are too dense to label, the band
+ *     thins them and says how many it is showing.
+ *   - The stated horizontal and vertical scales (1:N each) and the resulting
+ *     vertical exaggeration, so distances/grades read off the print are
+ *     unambiguous — a true civil section convention. The exaggeration is the
+ *     horizontal denominator over the vertical one, because a smaller
+ *     denominator is a larger drawing.
  *   - A summary block: length, relief, min/max height, mean & max grade,
  *     coverage, sample count, corridor width, CRS/datum.
  *   - A method-and-provenance page: the derived series named exactly as the
@@ -77,6 +84,15 @@ import type { ProfileProvenance } from './profileProvenance';
 import { heightLabel, heightReferenceNote, verticalReferenceFromDatum } from '../../geo/height';
 import type { VerticalReference } from '../../geo/height';
 import { pdfInfoDate } from '../../pdfInfoDate';
+// Where the station band's columns and the summary's value column land. Pure
+// arithmetic over measured text, kept out of the builder so the geometry of
+// the sheet can be asserted without reading a PDF back.
+import {
+  buildStationBand,
+  layoutSummaryRows,
+  wideValueDx,
+  type SummaryRow,
+} from './profileSheetLayout';
 
 /** Same constant the format/summary modules keep module-local. */
 const FEET_PER_METRE = 3.280839895013123;
@@ -137,6 +153,34 @@ const INK_DIM = rgb(0.42, 0.46, 0.52);
 const GRID = rgb(0.82, 0.85, 0.89);
 const GRID_MINOR = rgb(0.92, 0.94, 0.96);
 const CURVE = rgb(0.05, 0.55, 0.78);
+const RULE = rgb(0.68, 0.72, 0.78);
+
+/**
+ * Left stub of the station band, and so the left margin of the plot: the band
+ * rules under the section and its row headings sit beside them, so one number
+ * fixes both. Wide enough for the longest height heading `heightLabel` can
+ * return, because a heading that has to be trimmed loses the qualification it
+ * was printed to carry.
+ */
+const STUB_W = 118;
+/**
+ * Strip between the plot's bottom edge and the top of the station band, for
+ * the grid's own round-interval stationing. The band's stations fall where the
+ * samples fall, which is not on round numbers, so the two rows answer
+ * different questions and both are wanted.
+ */
+const GRID_LABEL_STRIP = 11;
+/** Height of one station-band row, and the size its figures are set at. */
+const BAND_ROW_H = 11;
+const BAND_FONT = 6;
+/** Clear space either side of a band figure before it counts as a collision. */
+const BAND_PAD = 4;
+/** Clear space between a summary label and its value. */
+const SUMMARY_GAP = 8;
+const SUMMARY_ROW_H = 13;
+const SUMMARY_FONT = 8.5;
+/** Inset of the sheet border from the page edge. */
+const BORDER_INSET = 18;
 
 /**
  * pdf-lib's StandardFonts use WinAnsi (CP1252) encoding, which throws on
@@ -249,6 +293,60 @@ function clipText(s: string, font: PDFFont, size: number, maxW: number): string 
   return `${cut}...`;
 }
 
+/**
+ * A stroked box, drawn as four independent segments.
+ *
+ * Not `drawRectangle`, which emits one closed four-segment path. The profile
+ * polyline is the only run of consecutive linetos this sheet is supposed to
+ * contain - it is how a reader of the file, and the gap tests, tell a
+ * continuous section from one broken at a station with no returns - and a
+ * rectangle anywhere on any page adds a three-lineto run that is
+ * indistinguishable from a drawn profile.
+ */
+function strokeBox(
+  p: PDFPage,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  color: ReturnType<typeof rgb>,
+  thickness: number,
+): void {
+  const corners = [
+    [x, y],
+    [x + w, y],
+    [x + w, y + h],
+    [x, y + h],
+  ] as const;
+  for (let i = 0; i < corners.length; i++) {
+    const a = corners[i];
+    const b = corners[(i + 1) % corners.length];
+    p.drawLine({
+      start: { x: a[0], y: a[1] },
+      end: { x: b[0], y: b[1] },
+      thickness,
+      color,
+    });
+  }
+}
+
+/**
+ * The border that makes a page read as a drawing sheet rather than as a page
+ * of text. Drawn on every page of the export, because a sheet that is bordered
+ * on its first page and not its later ones reads as two documents.
+ */
+function drawSheetBorder(p: PDFPage): void {
+  strokeBox(
+    p,
+    BORDER_INSET,
+    BORDER_INSET,
+    PAGE_W - 2 * BORDER_INSET,
+    PAGE_H - 2 * BORDER_INSET,
+    RULE,
+    0.8,
+  );
+}
+
 /** The one-line form of the class-exclusion policy, for the summary block. */
 function exclusionSummary(legend: DerivedSurfaceLegend): string {
   const classes = legend.excludedClasses.join(',');
@@ -315,6 +413,7 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
 
   // ── Page 1: chart + summary ────────────────────────────────────────────
   const page = doc.addPage([PAGE_W, PAGE_H]);
+  drawSheetBorder(page);
   const text = (
     p: PDFPage,
     s: string,
@@ -372,12 +471,18 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
   }
 
   // Plot box (pdf coords, y up). Top edge below the header.
-  const plotLeft = M + 52;
+  const plotLeft = M + STUB_W;
   const plotRight = PAGE_W - M - 6;
   const plotW = plotRight - plotLeft;
   const plotTopY = PAGE_H - M - 44; // y-up coordinate of the TOP edge
-  const plotH = 300;
+  // The section keeps the upper half of the sheet; the rest is spent on the
+  // station band, which is only useful directly under the curve it belongs to.
+  const plotH = 220;
   const plotBotY = plotTopY - plotH;
+  // The band hangs off the bottom edge of the plot and shares its rules, so
+  // the two read as one drawing rather than as a chart above a table.
+  const bandTop = plotBotY - GRID_LABEL_STRIP;
+  const bandBot = bandTop - 3 * BAND_ROW_H;
 
   const len = stats.length;
   const minEl = stats.minElevation;
@@ -408,7 +513,11 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
     for (let cD = 0, n = 0; cD <= len * k + 1e-9 && n < 64; cD += hInt, n++) {
       const x = mapX(cD / k);
       page.drawLine({ start: { x, y: plotTopY }, end: { x, y: plotBotY }, thickness: 0.5, color: GRID });
-      text(page, formatStation(cD / k, system), x - 14, plotBotY - 12, 7, mono, INK_DIM);
+      // Round-interval stationing under the grid. The band below carries the
+      // stations the samples actually fall on, which are not round numbers;
+      // this row is what lets a reader take a chainage off the grid itself.
+      const tick = formatStation(cD / k, system);
+      text(page, tick, x - mono.widthOfTextAtSize(tick, 7) / 2, plotBotY - 8, 7, mono, INK_DIM);
     }
     const vInt = niceInterval(elSpan * k);
     for (
@@ -418,21 +527,16 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
     ) {
       const y = plotTopY - mapYdown(eD / k);
       page.drawLine({ start: { x: plotLeft, y }, end: { x: plotRight, y }, thickness: 0.5, color: GRID_MINOR });
-      text(page, `${eD.toFixed(1)}`, M, y - 3, 7, mono, INK_DIM);
+      // Right-aligned against the axis: a column of heights is read down its
+      // last digit, and a left-aligned column of different-width numbers puts
+      // the units, tens and hundreds places in three different columns.
+      const tick = `${eD.toFixed(1)}`;
+      text(page, tick, plotLeft - 4 - mono.widthOfTextAtSize(tick, 7), y - 3, 7, mono, INK_DIM);
     }
-    // Axis frame.
-    page.drawLine({ start: { x: plotLeft, y: plotTopY }, end: { x: plotLeft, y: plotBotY }, thickness: 1, color: INK_DIM });
-    page.drawLine({ start: { x: plotLeft, y: plotBotY }, end: { x: plotRight, y: plotBotY }, thickness: 1, color: INK_DIM });
+    // The plot frame. A full rectangle rather than two axis lines: the section
+    // is a drawing, and a drawing is bounded on all four sides.
+    strokeBox(page, plotLeft, plotBotY, plotW, plotH, INK_DIM, 1);
     text(page, `${heightWord} (${unit})`, M, plotTopY + 6, 8, bold, INK_DIM);
-    text(
-      page,
-      system === 'metric' ? 'Chainage (station km+m)' : 'Chainage (100 ft stations)',
-      plotRight - 130,
-      plotBotY - 26,
-      8,
-      bold,
-      INK_DIM,
-    );
 
     // Profile runs (break on gaps), drawn as straight segments between
     // adjacent samples so no plotted height falls outside the two stations
@@ -458,14 +562,100 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
     }
     drawRun();
 
+    // ── Station data band (the civil "guitarra") ───────────────────────
+    // One ruled row per quantity, columns dropped from the same x mapping the
+    // polyline was drawn with, so a vertical from the curve lands on its own
+    // figures. Row headings sit in the fixed stub at the left.
+    const partialStr = (m: number | null) => (m == null ? '-' : (m * k).toFixed(1));
+    const bandHeightStr = (m: number | null) => (m == null ? 'gap' : (m * k).toFixed(2));
+    const bandMeasure = (t: string) => mono.widthOfTextAtSize(winAnsiSafe(t), BAND_FONT) + BAND_PAD;
+    const band = buildStationBand({
+      stations: stats.stations.map((st) => ({ chainage: st.chainage, height: st.elevation })),
+      mapX,
+      plotLeft,
+      plotW,
+      // The column is as wide as its widest figure: thinning against the
+      // chainage alone would let a long height overlap its neighbour.
+      widest: (st) => {
+        const cells = [formatStation(st.chainage, system), bandHeightStr(st.height)];
+        return cells.reduce((a, b) => (bandMeasure(b) > bandMeasure(a) ? b : a), cells[0]);
+      },
+      measure: bandMeasure,
+      fontSize: BAND_FONT,
+    });
+
+    const bandRows: Array<[string, (i: number) => string]> = [
+      [`Partial dist. (${unit})`, (i) => partialStr(band.columns[i].partial)],
+      ['Chainage', (i) => formatStation(band.columns[i].chainage, system)],
+      [`${heightWord} (${unit})`, (i) => bandHeightStr(band.columns[i].height)],
+    ];
+    for (let r = 0; r <= bandRows.length; r++) {
+      const y = bandTop - r * BAND_ROW_H;
+      page.drawLine({ start: { x: M, y }, end: { x: plotRight, y }, thickness: 0.5, color: RULE });
+    }
+    for (const x of [M, plotLeft, plotRight]) {
+      page.drawLine({ start: { x, y: bandTop }, end: { x, y: bandBot }, thickness: 0.5, color: RULE });
+    }
+    bandRows.forEach(([head], r) => {
+      const y = bandTop - (r + 1) * BAND_ROW_H + 3.5;
+      text(page, clipText(head, bold, BAND_FONT, STUB_W - 8), M + 4, y, BAND_FONT, bold, INK_DIM);
+    });
+    band.columns.forEach((c, i) => {
+      // The column rule runs up through the label strip to the plot's own
+      // bottom edge, so the figures stay visibly tied to the curve above them.
+      page.drawLine({
+        start: { x: c.x, y: plotBotY },
+        end: { x: c.x, y: bandBot },
+        thickness: 0.4,
+        color: GRID,
+      });
+      bandRows.forEach(([, cell], r) => {
+        const t = winAnsiSafe(cell(i));
+        const y = bandTop - (r + 1) * BAND_ROW_H + 3.5;
+        // Courier throughout, so the figures of one row line up digit under
+        // digit whatever their magnitude.
+        text(page, t, c.x - mono.widthOfTextAtSize(t, BAND_FONT) / 2, y, BAND_FONT, mono, INK);
+      });
+    });
+    // Thinning stated, not silent: a band showing one station in nine looks
+    // exactly like a band showing every station the section has.
+    text(
+      page,
+      band.shown >= band.total
+        ? `Station data band - all ${band.total} stations shown`
+        : `Station data band - ${band.shown} of ${band.total} stations shown (thinned to fit)`,
+      M,
+      bandBot - 10,
+      7,
+      bold,
+      INK_DIM,
+    );
+
     // Stated scales + VEX (the bit that makes the print measurable).
     const hScale = scaleRatio(len, plotW);
     const vScale = scaleRatio(elSpan, plotH);
-    const vex = hScale > 0 ? vScale / hScale : 1;
+    // `scaleRatio` returns the DENOMINATOR of a 1:N scale, so a SMALLER value
+    // is a LARGER drawing. Vertical 1:73 beside horizontal 1:386 means the
+    // relief is drawn 386/73 times taller than the run, which is the
+    // exaggeration. The reciprocal would report a compression on a sheet whose
+    // relief is stretched, and every grade read off it would be wrong by the
+    // square of the error the reader was told to correct for.
+    const vex = vScale > 0 ? hScale / vScale : 1;
     const scaleLine =
       `Horizontal 1:${Math.round(hScale)}   ·   Vertical 1:${Math.round(vScale)}   ·   ` +
       `Vertical exaggeration ${vex.toFixed(1)}:1`;
-    text(page, scaleLine, plotLeft, plotBotY - 26, 9, bold, INK);
+    text(page, scaleLine, M, bandBot - 24, 9, bold, INK);
+    const axisTitle =
+      system === 'metric' ? 'Chainage (station km+m)' : 'Chainage (100 ft stations)';
+    text(
+      page,
+      axisTitle,
+      plotRight - font.widthOfTextAtSize(axisTitle, 8),
+      bandBot - 24,
+      8,
+      bold,
+      INK_DIM,
+    );
   } else {
     text(page, 'No covered samples — nothing to plot.', plotLeft, plotTopY - 20, 11, font, INK_DIM);
   }
@@ -473,18 +663,18 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
   // Chart legend swatch. The caption is the legend's own, so the plotted
   // series is named on the print exactly as it is named on screen.
   page.drawLine({
-    start: { x: plotLeft, y: plotBotY - 38 },
-    end: { x: plotLeft + 16, y: plotBotY - 38 },
+    start: { x: M, y: bandBot - 37 },
+    end: { x: M + 16, y: bandBot - 37 },
     thickness: 1.4,
     color: CURVE,
   });
-  text(page, legend.caption, plotLeft + 22, plotBotY - 41, 8, font, INK);
+  text(page, legend.caption, M + 22, bandBot - 40, 8, font, INK);
 
   // Summary block (two columns of label:value). The Profile Intelligence
   // rows (gain/loss, steepest station range, located extremes — v0.4.5) come
   // from the shared pure module so they match the panel's summary exactly.
   const intel = computeProfileSummary(input.samples);
-  const sumTop = plotBotY - 52;
+  const sumTop = bandBot - 62;
   const contributing = record == null ? 0 : record.sources.filter((s) => s.contributed).length;
   const rows: Array<[string, string]> = [
     ['Length (horizontal)', lenStr(len)],
@@ -540,30 +730,76 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
       datumKnown ? (input.verticalDatum ?? '—') : DATUM_CONFLICT_MEASURE_NOTICE,
     ],
   ];
-  const colW = (PAGE_W - 2 * M) / 2;
-  rows.forEach((r, i) => {
-    const col = i % 2;
-    const line = Math.floor(i / 2);
-    const x = M + col * colW;
-    const y = sumTop - line * 14;
-    text(page, r[0], x, y, 8.5, bold, INK_DIM);
-    text(page, r[1], x + 130, y, 8.5, font, INK);
+  const summaryW = PAGE_W - 2 * M;
+  const colW = summaryW / 2;
+  // The label is set bold and the value regular, so each is measured in the
+  // font it will actually be drawn in. Both are measured AFTER the WinAnsi
+  // transliteration, because that is the string the page receives.
+  const measureLabel = (t: string) => bold.widthOfTextAtSize(winAnsiSafe(t), SUMMARY_FONT);
+  const measureValue = (t: string) => font.widthOfTextAtSize(winAnsiSafe(t), SUMMARY_FONT);
+  // The gutter keeps the left column's value clear of the right column's
+  // label; without it a full-width value would run into the next heading.
+  const layout = layoutSummaryRows({
+    rows: rows.map(([label, value]) => ({ label, value })),
+    measureLabel,
+    measureValue,
+    cellW: colW - 16,
+    wideW: summaryW,
+    gap: SUMMARY_GAP,
   });
 
   // Three statements too long for a half-width cell, and too load-bearing to
   // abbreviate: what the drawn series is, how far the class policy reached,
   // and what the read is entitled to claim. The page that expands them is
-  // page 2; these are the one-line forms.
-  const wideRows: Array<[string, string]> = [
-    ['Derived series', legend.seriesLabel],
-    ['Class exclusion', exclusionSummary(legend)],
-    ['Read scope', record == null ? 'Not recorded' : describeProfileProvenance(record)],
+  // page 2; these are the one-line forms. Any summary row whose label and
+  // value could not share a cell joins them, ahead of them, because it is a
+  // measurement and they are qualifications.
+  const wideRows: SummaryRow[] = [
+    ...layout.promoted,
+    { label: 'Derived series', value: legend.seriesLabel },
+    { label: 'Class exclusion', value: exclusionSummary(legend) },
+    {
+      label: 'Read scope',
+      value: record == null ? 'Not recorded' : describeProfileProvenance(record),
+    },
   ];
-  const wideTop = sumTop - Math.ceil(rows.length / 2) * 14;
+  const wideDx = wideValueDx(wideRows, measureLabel, SUMMARY_GAP, summaryW);
+  const pairLines = Math.ceil(layout.pairs.length / 2);
+  const wideTop = sumTop - pairLines * SUMMARY_ROW_H - 4;
+  const panelBot = wideTop - (wideRows.length - 1) * SUMMARY_ROW_H - 7;
+
+  // A light panel, so the summary reads as one block of findings rather than
+  // as loose lines under the drawing.
+  strokeBox(page, M - 8, panelBot, summaryW + 16, sumTop + 10 - panelBot, RULE, 0.6);
+  page.drawLine({
+    start: { x: M - 8, y: wideTop + 9 },
+    end: { x: PAGE_W - M + 8, y: wideTop + 9 },
+    thickness: 0.5,
+    color: GRID,
+  });
+
+  layout.pairs.forEach((r, i) => {
+    const col = i % 2;
+    const line = Math.floor(i / 2);
+    const x = M + col * colW;
+    const y = sumTop - line * SUMMARY_ROW_H;
+    text(page, r.label, x, y, SUMMARY_FONT, bold, INK_DIM);
+    text(page, r.value, x + layout.valueDx, y, SUMMARY_FONT, font, INK);
+  });
   wideRows.forEach((r, i) => {
-    const y = wideTop - i * 14;
-    text(page, r[0], M, y, 8.5, bold, INK_DIM);
-    text(page, r[1], M + 130, y, 8.5, font, INK);
+    const y = wideTop - i * SUMMARY_ROW_H;
+    text(page, r.label, M, y, SUMMARY_FONT, bold, INK_DIM);
+    // Nothing is wider to move to, so a value that overruns even the full
+    // width is trimmed with the trim marked rather than drawn over the margin.
+    text(
+      page,
+      clipText(r.value, font, SUMMARY_FONT, summaryW - wideDx),
+      M + wideDx,
+      y,
+      SUMMARY_FONT,
+      font,
+      INK,
+    );
   });
 
   // Provenance footer.
@@ -620,6 +856,7 @@ function renderProvenancePage(
   const bottom = M + 16;
   const usableW = PAGE_W - 2 * M;
   let page = doc.addPage([PAGE_W, PAGE_H]);
+  drawSheetBorder(page);
   let y = PAGE_H - M - 4;
 
   const put = (s: string, x: number, yy: number, size: number, f: PDFFont, color = INK) =>
@@ -627,6 +864,7 @@ function renderProvenancePage(
 
   const newPage = () => {
     page = doc.addPage([PAGE_W, PAGE_H]);
+    drawSheetBorder(page);
     y = PAGE_H - M - 4;
     put('Method and provenance (continued)', M, y, 12, bold);
     y -= 20;
@@ -785,6 +1023,7 @@ function renderStationTable(
   let idx = 0;
   while (idx < stations.length) {
     const page = doc.addPage([PAGE_W, PAGE_H]);
+    drawSheetBorder(page);
     const put = (s: string, x: number, y: number, size: number, f: PDFFont, color = INK) =>
       page.drawText(winAnsiSafe(s), { x, y, size, font: f, color });
     put('Station table', M, PAGE_H - M - 4, 14, bold);

--- a/src/render/measure/profileSheetLayout.ts
+++ b/src/render/measure/profileSheetLayout.ts
@@ -1,0 +1,224 @@
+/**
+ * profileSheetLayout.ts
+ *
+ * Where things sit on the printed profile sheet. Pure arithmetic over text
+ * widths and the plot's own x mapping: no pdf-lib, no page, no drawing. The
+ * builder in `profilePdf.ts` draws what this module resolves, which is what
+ * lets a test assert the geometry of the sheet without reading back a PDF.
+ *
+ * Two layout problems live here, and both are the same problem: text has a
+ * width, and a layout that assumes a width instead of measuring one puts two
+ * strings in the same place.
+ *
+ * THE STATION DATA BAND (the civil "guitarra") is the ruled block under the
+ * section carrying, per station, the distance from the previous station, the
+ * running chainage, and the height there. Its columns must land on the same x
+ * the section's polyline was drawn at, so a reader can drop a vertical from
+ * the curve to the figures. That is why the band takes the plot's mapping as
+ * an argument rather than deriving a second one: two derivations of one
+ * mapping are two chances to disagree.
+ *
+ * Stations are usually far denser than the band has room for, so the columns
+ * are thinned by `fitAxisLabels` — the same fitter the on-screen axis uses,
+ * which walks the strip and keeps a column only when the space it needs is
+ * still free. The layout reports how many of how many survived so the sheet
+ * can say so: a band that silently shows one station in nine looks like a
+ * band that shows every station.
+ *
+ * THE SUMMARY VALUE COLUMN is placed at the widest label actually present
+ * rather than at a fixed offset. A fixed offset is a guess about the widest
+ * heading, and the headings are not fixed text: a height heading is whatever
+ * `heightLabel` returns for the scan's vertical reference, and "Height (datum
+ * unknown) min / max" is far wider than a heading written for a declared
+ * datum. When the guess is wrong the value is drawn over the label and the
+ * sheet states neither.
+ */
+
+import { fitAxisLabels } from './profileAxes';
+
+/** Measures a string at the size it will be drawn, in points. */
+export type MeasureText = (text: string) => number;
+
+/** One station column of the data band. */
+export interface StationBandColumn {
+  /** Chainage of the station, metres (the sheet's own unit conversion is later). */
+  readonly chainage: number;
+  /** Page x of the column centre, points. Comes from the plot's mapping. */
+  readonly x: number;
+  /** Height at the station, metres. null at a gap. */
+  readonly height: number | null;
+  /**
+   * Distance from the PREVIOUS SHOWN column, metres; null for the first.
+   *
+   * From the previous shown column and not the previous sample, because the
+   * partial distances of a band must sum to the chainage printed beside them.
+   * A partial measured to a station the band does not draw is a number the
+   * reader cannot check against anything else on the sheet.
+   */
+  readonly partial: number | null;
+}
+
+/** The resolved band: which stations it draws, and how many it dropped. */
+export interface StationBandLayout {
+  readonly columns: readonly StationBandColumn[];
+  /** Stations drawn. */
+  readonly shown: number;
+  /** Stations offered. `shown < total` means the band was thinned. */
+  readonly total: number;
+}
+
+/** A station as the band needs it: where it is, and what it reads. */
+export interface StationBandInput {
+  readonly chainage: number;
+  readonly height: number | null;
+}
+
+export interface StationBandRequest {
+  readonly stations: readonly StationBandInput[];
+  /** The plot's own chainage → page x mapping. Not re-derived here. */
+  readonly mapX: (chainage: number) => number;
+  /** Left edge of the plot area, points. */
+  readonly plotLeft: number;
+  /** Width of the plot area, points. */
+  readonly plotW: number;
+  /** Widest text the column will hold, per station, at its drawn size. */
+  readonly widest: (station: StationBandInput) => string;
+  /** Measures that text. */
+  readonly measure: MeasureText;
+  /** Font size the band cells are drawn at, points. */
+  readonly fontSize: number;
+}
+
+/**
+ * Resolve the band's columns against the plot's mapping.
+ *
+ * Stations with a non-finite chainage are dropped before the fit rather than
+ * carried into it: a column at NaN has no place on the strip, and the fitter's
+ * ordering would put it nowhere in particular.
+ */
+export function buildStationBand(req: StationBandRequest): StationBandLayout {
+  const usable = req.stations.filter((s) => Number.isFinite(s.chainage));
+  const total = usable.length;
+  if (total === 0) return { columns: [], shown: 0, total: 0 };
+
+  const pixels = usable.map((s) => req.mapX(s.chainage) - req.plotLeft);
+  const labels = usable.map((s) => req.widest(s));
+  // The fitter is given the strip in plot-local coordinates, which is the
+  // frame `pixels` is already in. Ends are centred: a band column is drawn
+  // centred on its tick, so an end column that would hang past the frame is
+  // dropped rather than printed half outside the ruling.
+  const keep = fitAxisLabels({
+    labels,
+    pixels,
+    containerPx: req.plotW,
+    fontPx: req.fontSize,
+    extentPx: (label) => req.measure(label),
+    ends: 'centred',
+  });
+
+  const columns: StationBandColumn[] = [];
+  let previous: number | null = null;
+  for (let i = 0; i < usable.length; i++) {
+    if (!keep[i]) continue;
+    const s = usable[i];
+    columns.push({
+      chainage: s.chainage,
+      x: req.mapX(s.chainage),
+      height: s.height,
+      partial: previous == null ? null : s.chainage - previous,
+    });
+    previous = s.chainage;
+  }
+  return { columns, shown: columns.length, total };
+}
+
+/** A label/value pair as the summary block holds it. */
+export interface SummaryRow {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface SummaryLayoutRequest {
+  readonly rows: readonly SummaryRow[];
+  /** Measures a label at the size and weight labels are drawn at. */
+  readonly measureLabel: MeasureText;
+  /** Measures a value at the size and weight values are drawn at. */
+  readonly measureValue: MeasureText;
+  /** Width of one half-width cell, points. */
+  readonly cellW: number;
+  /** Width of the full-width group, points. */
+  readonly wideW: number;
+  /** Clear space between a label and its value, points. */
+  readonly gap: number;
+}
+
+export interface SummaryLayout {
+  /** Rows that fit a half-width cell, in the input order. */
+  readonly pairs: readonly SummaryRow[];
+  /** Rows that did not, moved to the full-width group, in the input order. */
+  readonly promoted: readonly SummaryRow[];
+  /** Value x, as an offset from the cell's left edge. Shared by both columns. */
+  readonly valueDx: number;
+}
+
+/**
+ * Place the summary's value column, and move out the rows that cannot fit.
+ *
+ * The offset is one number for the whole block rather than per row, because
+ * values that start at different x read as a ragged list rather than as a
+ * column, and the block is scanned down its values.
+ *
+ * A row whose label and value together exceed the half-width cell is moved to
+ * the full-width group rather than shortened. The alternatives were considered
+ * and are worse here: shortening the label loses the qualification the label
+ * exists to carry (`Height (datum unknown)` is not `Height`), and wrapping a
+ * value inside a two-column grid pushes every later row down by a variable
+ * amount, so the two columns stop sharing a baseline. The full-width group
+ * already exists on this sheet for statements too long for a cell, so an
+ * over-wide row joins the rows it belongs with.
+ *
+ * Removing a row can narrow the widest remaining label, which can let a row
+ * that was over by a few points fit after all, so the fit is iterated to a
+ * fixed point. The loop is bounded by the row count: each pass either removes
+ * at least one row or stops.
+ */
+export function layoutSummaryRows(req: SummaryLayoutRequest): SummaryLayout {
+  const gap = Math.max(0, req.gap);
+  let kept = req.rows.slice();
+  let valueDx = 0;
+  for (let pass = 0; pass <= req.rows.length; pass++) {
+    valueDx = 0;
+    for (const r of kept) valueDx = Math.max(valueDx, req.measureLabel(r.label) + gap);
+    const fits = kept.filter((r) => valueDx + req.measureValue(r.value) <= req.cellW);
+    if (fits.length === kept.length) break;
+    kept = fits;
+  }
+  // Recompute once more over the surviving set, so the offset is the widest
+  // label that is actually drawn in a cell and not the widest one considered.
+  valueDx = 0;
+  for (const r of kept) valueDx = Math.max(valueDx, req.measureLabel(r.label) + gap);
+  const keptSet = new Set(kept);
+  const promoted = req.rows.filter((r) => !keptSet.has(r));
+  // An empty block still needs a defined column, and a value that overruns
+  // even the full-width group is clipped by the caller rather than moved
+  // again: there is nowhere wider to move it to.
+  return { pairs: kept, promoted, valueDx: Math.min(valueDx, req.cellW) };
+}
+
+/**
+ * The value offset for the full-width group, measured the same way.
+ *
+ * Kept separate from the half-width offset on purpose: the two groups are read
+ * as two blocks, and forcing the wide group to the cell's offset would either
+ * indent it past its own widest label or crowd it against one.
+ */
+export function wideValueDx(
+  rows: readonly SummaryRow[],
+  measureLabel: MeasureText,
+  gap: number,
+  wideW: number,
+): number {
+  let dx = 0;
+  for (const r of rows) dx = Math.max(dx, measureLabel(r.label) + Math.max(0, gap));
+  return Math.min(dx, wideW);
+}

--- a/tests/profileSheet.test.ts
+++ b/tests/profileSheet.test.ts
@@ -1,0 +1,372 @@
+/**
+ * profileSheet.test.ts — the profile PDF as a drawing sheet: does the stated
+ * exaggeration match the drawing, does anything overprint anything else, and
+ * do the station band's columns land where the section put its curve.
+ *
+ * These assert against the drawn page rather than against the layout helpers
+ * alone. A helper that computes the right offset while the builder draws at a
+ * hardcoded one is exactly the defect being pinned, so the offsets are read
+ * back out of the page content stream and checked against the fonts' own
+ * metrics.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { inflateSync } from 'node:zlib';
+import { PDFDocument, StandardFonts, type PDFFont } from 'pdf-lib';
+import { buildProfilePdf } from '../src/render/measure/profilePdf';
+import { buildStationBand } from '../src/render/measure/profileSheetLayout';
+import type { ProfileChartSample } from '../src/render/measure/types';
+
+/** Fixed, injected. The builder never reads the clock. */
+const FIXED_DATE = new Date('2026-01-01T00:00:00.000Z');
+
+/**
+ * A long, gently rolling section: 900 m of chainage over 181 stations with
+ * ~35 m of relief. Long and shallow on purpose — the horizontal and vertical
+ * scales come out an order of magnitude apart, so the two orderings of the
+ * exaggeration are 10:1 and 0.1:1 and cannot be confused for one another.
+ */
+function rollingSection(): ProfileChartSample[] {
+  const out: ProfileChartSample[] = [];
+  for (let i = 0; i <= 180; i++) {
+    const d = i * 5;
+    out.push({ distance: d, height: 180 + Math.sin(d / 140) * 18 + d * 0.012 });
+  }
+  return out;
+}
+
+/** Every content stream, inflated, one entry per stream. */
+function streamsOf(bytes: Uint8Array): string[] {
+  const buf = Buffer.from(bytes);
+  const out: string[] = [];
+  let idx = 0;
+  for (;;) {
+    const s = buf.indexOf('stream', idx);
+    if (s === -1) break;
+    let ds = s + 'stream'.length;
+    if (buf[ds] === 0x0d) ds++;
+    if (buf[ds] === 0x0a) ds++;
+    const e = buf.indexOf('endstream', ds);
+    if (e === -1) break;
+    try {
+      out.push(inflateSync(buf.subarray(ds, e)).toString('latin1'));
+    } catch {
+      out.push(buf.subarray(ds, e).toString('latin1'));
+    }
+    idx = e + 'endstream'.length;
+  }
+  return out;
+}
+
+/** One drawn string, with where and how it was drawn. */
+interface Drawn {
+  readonly base: string;
+  readonly size: number;
+  readonly x: number;
+  readonly y: number;
+  readonly text: string;
+}
+
+const DRAW_RE =
+  /\/([A-Za-z-]+)-\d+ ([\d.]+) Tf[\s\S]{0,40}?1 0 0 1 (-?[\d.]+) (-?[\d.]+) Tm\s*<([0-9A-Fa-f]+)> Tj/g;
+
+function drawnIn(stream: string): Drawn[] {
+  const out: Drawn[] = [];
+  for (const m of stream.matchAll(DRAW_RE)) {
+    out.push({
+      base: m[1],
+      size: Number(m[2]),
+      x: Number(m[3]),
+      y: Number(m[4]),
+      text: Buffer.from(m[5], 'hex').toString('latin1'),
+    });
+  }
+  return out;
+}
+
+/** The sheet's first page: the one carrying the title. */
+function sheetPage(bytes: Uint8Array): { stream: string; drawn: Drawn[] } {
+  for (const stream of streamsOf(bytes)) {
+    const drawn = drawnIn(stream);
+    if (drawn.some((d) => d.text === 'Terrain Profile')) return { stream, drawn };
+  }
+  throw new Error('no page carrying the sheet title');
+}
+
+/** All drawn text on every page, joined, for a wording assertion. */
+function allProse(bytes: Uint8Array): string {
+  return streamsOf(bytes)
+    .flatMap((s) => drawnIn(s).map((d) => d.text))
+    .join(' ');
+}
+
+/** One stroked straight segment, with the pen it was drawn with. */
+interface Segment {
+  readonly x1: number;
+  readonly y1: number;
+  readonly x2: number;
+  readonly y2: number;
+  readonly width: number;
+  readonly stroke: string;
+}
+
+/**
+ * The stroked segments of a page.
+ *
+ * pdf-lib wraps each line in its own q/Q block and restates the stroke colour
+ * and width inside it, so a segment carries its own pen and can be told apart
+ * from the grid rules around it.
+ */
+function segmentsIn(stream: string): Segment[] {
+  const out: Segment[] = [];
+  const re =
+    /((?:-?[\d.]+ ){3})RG\s+([\d.]+) w\s+\[\] 0 d\s+(-?[\d.]+) (-?[\d.]+) m\s+-?[\d.]+ -?[\d.]+ m\s+(-?[\d.]+) (-?[\d.]+) l/g;
+  for (const m of stream.matchAll(re)) {
+    out.push({
+      stroke: m[1].trim(),
+      width: Number(m[2]),
+      x1: Number(m[3]),
+      y1: Number(m[4]),
+      x2: Number(m[5]),
+      y2: Number(m[6]),
+    });
+  }
+  return out;
+}
+
+/**
+ * The plot frame, recovered from the page: the 1pt axis-ink box around the
+ * section. Recovering the mapping from the drawing rather than restating the
+ * builder's constants is the point - a test that hardcodes the plot box would
+ * still pass if the band and the plot moved apart together.
+ */
+function plotBoxIn(stream: string): { left: number; right: number; bottom: number } {
+  const frame = segmentsIn(stream).filter(
+    (g) => g.width === 1 && g.stroke === '0.42 0.46 0.52' && g.y1 === g.y2,
+  );
+  if (frame.length < 2) throw new Error('no plot frame on the page');
+  const bottom = Math.min(...frame.map((g) => g.y1));
+  const edge = frame.find((g) => g.y1 === bottom) as Segment;
+  return {
+    left: Math.min(edge.x1, edge.x2),
+    right: Math.max(edge.x1, edge.x2),
+    bottom,
+  };
+}
+
+/**
+ * The Info-dictionary dates, as the file carries them.
+ *
+ * They live in a compressed object stream, so a byte grep over the file never
+ * sees them - and a clock-defaulted stamp only breaks byte identity when the
+ * two builds fall either side of a second boundary, which is a coin toss
+ * rather than a test. Reading the date back pins it either way.
+ */
+function infoDatesOf(bytes: Uint8Array): string[] {
+  const out: string[] = [];
+  for (const stream of streamsOf(bytes)) {
+    for (const m of stream.matchAll(/\/(?:Creation|Mod)Date \(([^)]*)\)/g)) out.push(m[1]);
+  }
+  return out;
+}
+
+/** The standard fonts, measured exactly as the builder measures them. */
+async function fonts(): Promise<{ regular: PDFFont; bold: PDFFont; mono: PDFFont }> {
+  const doc = await PDFDocument.create();
+  return {
+    regular: await doc.embedFont(StandardFonts.Helvetica),
+    bold: await doc.embedFont(StandardFonts.HelveticaBold),
+    mono: await doc.embedFont(StandardFonts.Courier),
+  };
+}
+
+/** Metric civil stationing back to metres: `0+275.00` is 275 m. */
+function stationToMetres(label: string): number | null {
+  const m = /^(\d+)\+([\d.]+)$/.exec(label);
+  return m == null ? null : Number(m[1]) * 1000 + Number(m[2]);
+}
+
+describe('profile sheet: vertical exaggeration', () => {
+  it('states the exaggeration as horizontal over vertical, not its reciprocal', async () => {
+    const bytes = await buildProfilePdf({
+      name: 'Exaggeration',
+      samples: rollingSection(),
+      generatedAt: FIXED_DATE,
+    });
+    const line = sheetPage(bytes).drawn.find((d) => d.text.startsWith('Horizontal 1:'));
+    expect(line).toBeDefined();
+    const m = /Horizontal 1:(\d+).+Vertical 1:(\d+).+Vertical exaggeration ([\d.]+):1/.exec(
+      line!.text,
+    );
+    expect(m).not.toBeNull();
+    const h = Number(m![1]);
+    const v = Number(m![2]);
+    const stated = Number(m![3]);
+
+    // A 1:N scale states a DENOMINATOR: the smaller denominator is the larger
+    // drawing. This section is long and shallow, so the vertical denominator
+    // is much the smaller of the two and the relief is drawn stretched.
+    expect(v).toBeLessThan(h);
+    expect(stated).toBeCloseTo(h / v, 1);
+    // The reciprocal is what the sheet used to print. Naming it here keeps the
+    // failure legible if the ordering is ever flipped back.
+    expect(stated).not.toBeCloseTo(v / h, 1);
+    expect(stated).toBeGreaterThan(1);
+  });
+});
+
+describe('profile sheet: no overprinting in the summary', () => {
+  it('draws every value clear of the right edge of its own label', async () => {
+    const { regular, bold } = await fonts();
+    // No declared datum, so the height headings take their longest form -
+    // the case a fixed label-width offset gets wrong.
+    const bytes = await buildProfilePdf({
+      name: 'Overprint',
+      samples: rollingSection(),
+      crs: 'EPSG:32613',
+      verticalDatum: null,
+      generatedAt: FIXED_DATE,
+    });
+    const drawn = sheetPage(bytes).drawn;
+
+    // The summary is the block set at 8.5pt: labels bold, values regular.
+    const labels = drawn.filter((d) => d.size === 8.5 && d.base === 'Helvetica-Bold');
+    const values = drawn.filter((d) => d.size === 8.5 && d.base === 'Helvetica');
+    expect(labels.length).toBeGreaterThan(10);
+
+    for (const label of labels) {
+      const right = label.x + bold.widthOfTextAtSize(label.text, label.size);
+      // The value on the same baseline, to the right of this label. Two-column
+      // rows put another label further right; the value is the nearest one.
+      const value = values
+        .filter((v) => Math.abs(v.y - label.y) < 0.01 && v.x > label.x)
+        .sort((a, b) => a.x - b.x)[0];
+      expect(value, `no value drawn for "${label.text}"`).toBeDefined();
+      expect(
+        right,
+        `"${label.text}" ends at ${right.toFixed(1)} but its value starts at ${value.x.toFixed(1)}`,
+      ).toBeLessThanOrEqual(value.x);
+      // And the value must not run off its own page either.
+      expect(value.x + regular.widthOfTextAtSize(value.text, value.size)).toBeLessThanOrEqual(
+        792 - 18,
+      );
+    }
+  });
+});
+
+describe('profile sheet: station data band', () => {
+  it('places each column at the plot mapping for its own chainage', async () => {
+    const { mono } = await fonts();
+    const bytes = await buildProfilePdf({
+      name: 'Band',
+      samples: rollingSection(),
+      generatedAt: FIXED_DATE,
+    });
+    const { stream, drawn } = sheetPage(bytes);
+
+    // The mapping is recovered from the drawing itself rather than assumed.
+    const plot = plotBoxIn(stream);
+
+    // Length, as the summary prints it, is the mapping's domain.
+    const lengthRow = drawn.find((d) => /^\d+\.\d+ m$/.test(d.text) && d.size === 8.5);
+    expect(lengthRow).toBeDefined();
+    const length = 900;
+    expect(Number(lengthRow!.text.replace(' m', ''))).toBeCloseTo(length, 2);
+
+    // The band's chainage cells: Courier, drawn centred on the column.
+    const cells = drawn
+      .filter((d) => d.base === 'Courier' && stationToMetres(d.text) != null)
+      .map((d) => ({
+        chainage: stationToMetres(d.text) as number,
+        centre: d.x + mono.widthOfTextAtSize(d.text, d.size) / 2,
+      }));
+    expect(cells.length).toBeGreaterThan(4);
+
+    for (const c of cells) {
+      const expected = plot.left + (c.chainage / length) * (plot.right - plot.left);
+      expect(
+        c.centre,
+        `column for chainage ${c.chainage} is at ${c.centre.toFixed(3)}, plot maps it to ${expected.toFixed(3)}`,
+      ).toBeCloseTo(expected, 2);
+    }
+  });
+
+  it('thins dense stations and says how many it is showing', async () => {
+    const bytes = await buildProfilePdf({
+      name: 'Band thinning',
+      samples: rollingSection(),
+      generatedAt: FIXED_DATE,
+    });
+    const caption = sheetPage(bytes).drawn.find((d) => d.text.startsWith('Station data band'));
+    expect(caption).toBeDefined();
+    const m = /Station data band - (\d+) of (\d+) stations shown/.exec(caption!.text);
+    expect(m).not.toBeNull();
+    const shown = Number(m![1]);
+    const total = Number(m![2]);
+    expect(total).toBe(181);
+    expect(shown).toBeGreaterThan(2);
+    expect(shown).toBeLessThan(total);
+  });
+
+  it('takes its column x straight from the mapping it is given', () => {
+    const stations = [0, 10, 20, 30, 40, 50].map((chainage) => ({ chainage, height: 5 }));
+    const mapX = (c: number) => 100 + c * 4;
+    const band = buildStationBand({
+      stations,
+      mapX,
+      plotLeft: 100,
+      plotW: 200,
+      widest: () => 'XXXX',
+      measure: () => 20,
+      fontSize: 6,
+    });
+    expect(band.total).toBe(6);
+    expect(band.shown).toBeGreaterThan(0);
+    for (const c of band.columns) expect(c.x).toBe(mapX(c.chainage));
+    // Columns keep the input order, and each partial is the run from the
+    // previous SHOWN column, so the partials sum to the last chainage.
+    const chainages = band.columns.map((c) => c.chainage);
+    expect([...chainages].sort((a, b) => a - b)).toEqual(chainages);
+    const summed = band.columns.reduce((acc, c) => acc + (c.partial ?? 0), chainages[0]);
+    expect(summed).toBeCloseTo(chainages[chainages.length - 1], 9);
+  });
+});
+
+describe('profile sheet: height wording', () => {
+  it('never prints "Elevation" for a scan with no declared datum', async () => {
+    const bytes = await buildProfilePdf({
+      name: 'No datum',
+      samples: rollingSection(),
+      crs: 'EPSG:32613',
+      verticalDatum: null,
+      generatedAt: FIXED_DATE,
+    });
+    const prose = allProse(bytes);
+    expect(prose).toContain('Height (datum unknown)');
+    expect(prose).not.toContain('Elevation');
+    expect(prose).not.toContain('ELEV');
+  });
+});
+
+describe('profile sheet: determinism', () => {
+  it('is byte-identical across two builds of the same input', async () => {
+    const input = {
+      name: 'Deterministic',
+      samples: rollingSection(),
+      crs: 'EPSG:32613',
+      corridorWidthM: 4,
+      groundPercentile: 15,
+      generatedAt: FIXED_DATE,
+    } as const;
+    const a = await buildProfilePdf(input);
+    const b = await buildProfilePdf(input);
+    expect(Buffer.from(b).equals(Buffer.from(a))).toBe(true);
+
+    // Both Info dates come from the caller's own timestamp. Asserted directly
+    // because two builds a millisecond apart share a second, so byte identity
+    // alone would pass a clock-defaulted stamp most of the time.
+    const dates = infoDatesOf(a);
+    expect(dates.length).toBeGreaterThanOrEqual(2);
+    for (const d of dates) expect(d).toBe('D:20260101000000Z');
+  });
+});


### PR DESCRIPTION
Three faults in the exported sheet.

Vertical exaggeration was stated as its own reciprocal. `scaleRatio` returns the denominator of a 1:N scale, so a sheet at H 1:4339 and V 1:461 is stretched 9.4 times vertically; it printed 0.1:1, which reads as compression to anyone taking grades off the paper.

Summary values were placed at a fixed 130pt offset whatever the label's width, so a long label was overprinted by its own value. The offset is now measured from the widest label actually drawn, and a row that cannot fit a half-width cell moves to the full-width group rather than being shortened, because the qualification in `Height (datum unknown)` is the part that would be lost.

The sheet also gains the station data band the civil convention puts under a longitudinal section, carrying partial distance, chainage and ground level against the plot's own x mapping, plus a plot frame, a sheet border and a panelled summary.
