### PR TITLE
fix(measure): bound the lasso occlusion grid to its candidate set

### DIFF
--- a/src/render/measure/lassoOcclusion.ts
+++ b/src/render/measure/lassoOcclusion.ts
@@ -69,10 +69,10 @@
  * basis produced a number rather than to claim a separation the geometry does
  * not support.
  *
- * The rejection never runs on a candidate set too small or too structureless to
- * estimate from. It reports `applied: false` with a reason instead of guessing,
- * because a guessed tolerance silently deletes part of a real surface and the
- * volume that comes out still looks plausible.
+ * The rejection never runs on a candidate set too small, too structureless or
+ * too oddly shaped to estimate from. It reports `applied: false` with a reason
+ * instead of guessing, because a guessed tolerance silently deletes part of a
+ * real surface and the volume that comes out still looks plausible.
  */
 
 /**
@@ -99,6 +99,7 @@ export type OcclusionOutcome =
   | 'applied'
   | 'too-few-points'
   | 'degenerate-extent'
+  | 'degenerate-aspect'
   | 'too-few-adjacent-cells';
 
 /** The keep decision, with the scales it was taken at. */
@@ -139,6 +140,29 @@ const MIN_CANDIDATES = 32;
 
 /** Fewest adjacent occupied cell pairs the step estimate needs. */
 const MIN_ADJACENT_PAIRS = 8;
+
+/**
+ * Most cells the grid may hold, per usable candidate.
+ *
+ * The cell is built from the bounding box AREA, so a selection that is wide and
+ * very thin drives the area, and with it the cell, towards zero while the width
+ * stays long: the column count is `width / cell`, which grows as the square root
+ * of the aspect ratio and is bounded by nothing in the geometry. A thousand
+ * pixels of width holding thirty-two points spread over a hundredth of a pixel
+ * of height already asks for more cells than there are points, and a height near
+ * the floating-point noise of a projection asks for tens of millions of them,
+ * which is tens of millions of Float64 slots for a handful of returns.
+ *
+ * One cell per point is the loosest bound that still means something. The whole
+ * estimate rests on a cell holding about nine points, so a grid finer than one
+ * cell per point cannot produce a nearest-SURFACE depth: every cell minimum is a
+ * single return, the adjacent-cell step is point-to-point noise rather than the
+ * step a surface makes, and the tolerance built on it would be a guess. The
+ * bound therefore fires only where the estimate was already meaningless, and a
+ * selection of any ordinary shape stays far below it: a square-ish box spends
+ * about `N / 9` cells, an eighth of the bound.
+ */
+const MAX_CELLS_PER_POINT = 1;
 
 /**
  * Decide which candidates the camera can see.
@@ -188,6 +212,16 @@ export function rejectOccluded(field: LassoDepthField): OcclusionRejection {
   }
   const cols = Math.floor(width / cell) + 1;
   const rows = Math.floor(height / cell) + 1;
+
+  // Refuse before allocating, not after. An extreme aspect ratio is a real
+  // geometry the polygon test can hand over, and the answer to it is the same
+  // answer this module gives to any candidate set it cannot estimate from: say
+  // the tolerance could not be found and let the caller report a through-
+  // surfaces figure. Declining costs the caller nothing it had before, and the
+  // grid it would have built cannot separate surfaces anyway.
+  if (!(cols * rows <= usable * MAX_CELLS_PER_POINT)) {
+    return { keep, keptCount: n, applied: false, outcome: 'degenerate-aspect', cellSizePx: cell, depthTolerance: 0 };
+  }
 
   // The three nearest depths per cell, in one pass. The smallest is the depth
   // buffer; the third is the scatter probe. Infinity marks "no such return".

--- a/tests/lassoOcclusion.test.ts
+++ b/tests/lassoOcclusion.test.ts
@@ -214,3 +214,107 @@ describe('rejectOccluded — refuses to guess', () => {
     expect(describeLassoSelectionBasis('through-surfaces')).toBe('all depths along the ray');
   });
 });
+
+describe('rejectOccluded — a selection too thin to grid', () => {
+  /**
+   * The cell comes from the bounding box AREA, so a wide, near-flat selection
+   * sends the cell towards zero while the width stays long, and the column count
+   * grows as the square root of the aspect ratio with nothing in the geometry to
+   * stop it. These pin the grid to the point count instead: a handful of points
+   * may not ask for a grid larger than itself, whatever shape they arrive in.
+   */
+  function ribbon(n: number, width: number, height: number): Sample[] {
+    const out: Sample[] = [];
+    for (let i = 0; i < n; i++) {
+      out.push({ x: (i / (n - 1)) * width, y: i % 2 === 0 ? 0 : height, d: 10 + (i % 3) });
+    }
+    return out;
+  }
+
+  /** Cells the grid would hold at the cell size the decision reports. */
+  function gridCells(cellSizePx: number, width: number, height: number): number {
+    return (Math.floor(width / cellSizePx) + 1) * (Math.floor(height / cellSizePx) + 1);
+  }
+
+  it('does not build a grid larger than the candidate set', () => {
+    // 1000 px of width, 32 points, a height at the noise floor of a projected
+    // coordinate. The unbounded cell size here is about 1.7e-4 px, which is
+    // about 6e6 columns: five Float64 slots each, so gigabytes of typed array
+    // for 32 returns. Measured as bytes of array buffer rather than as elapsed
+    // time, which would be a machine-speed assertion and not a bound.
+    const samples = ribbon(32, 1000, 1e-10);
+    expect(gridCells(3 * Math.sqrt((1000 * 1e-10) / 32), 1000, 1e-10)).toBeGreaterThan(1e6);
+
+    const before = process.memoryUsage().arrayBuffers;
+    const decision = rejectOccluded(field(samples));
+    const grown = process.memoryUsage().arrayBuffers - before;
+
+    expect(grown).toBeLessThan(4 * 1024 * 1024);
+    expect(decision.applied).toBe(false);
+    expect(decision.outcome).toBe('degenerate-aspect');
+  });
+
+  it('declines rather than returning a quietly degraded selection', () => {
+    const samples = ribbon(64, 1000, 1e-6);
+    const decision = rejectOccluded(field(samples));
+
+    expect(decision.applied).toBe(false);
+    expect(decision.outcome).toBe('degenerate-aspect');
+    expect(decision.keptCount).toBe(samples.length);
+    for (let i = 0; i < samples.length; i++) expect(decision.keep[i]).toBe(1);
+    // An unapplied outcome must read as a through-surfaces figure in the clause,
+    // exactly as the other refusals do.
+    expect(describeLassoSelectionBasis('occluded-excluded', decision.outcome)).toContain(
+      'all depths taken',
+    );
+  });
+
+  it('holds the bound to the point count, not to a fixed grid size', () => {
+    // Same shape, 64× the points. A fixed cell cap would decline both or accept
+    // both; the bound is the candidate count, so the denser ribbon is the one
+    // that gets a grid.
+    const shape = (n: number) => ribbon(n, 1000, 0.5);
+    const sparse = rejectOccluded(field(shape(32)));
+    const dense = rejectOccluded(field(shape(2048)));
+
+    expect(gridCells(sparse.cellSizePx, 1000, 0.5)).toBeGreaterThan(32);
+    expect(sparse.applied).toBe(false);
+    expect(sparse.outcome).toBe('degenerate-aspect');
+    expect(gridCells(dense.cellSizePx, 1000, 0.5)).toBeLessThanOrEqual(2048);
+    expect(dense.outcome).not.toBe('degenerate-aspect');
+  });
+
+  it('leaves an ordinary selection on exactly the path it took before', () => {
+    // The bound must not touch what a normal lasso selects: a well-shaped
+    // selection spends about N / 9 cells, far under one cell per point. Both
+    // ends of the module's behaviour are pinned here, point for point.
+    const near = surface(24, 480, () => 10, 0.02, 1);
+    const far = surface(24, 480, () => 25, 0.02, 2);
+    const both = [...near, ...far];
+    const decision = rejectOccluded(field(both));
+
+    expect(decision.outcome).toBe('applied');
+    expect(gridCells(decision.cellSizePx, 480, 480)).toBeLessThan(both.length);
+    expect(decision.keptCount).toBe(near.length);
+    for (let i = 0; i < both.length; i++) {
+      expect(decision.keep[i]).toBe(i < near.length ? 1 : 0);
+    }
+
+    const steep = surface(40, 800, (u, v) => 5 + u * 120 + v * 80, 0.3, 5);
+    const uncarved = rejectOccluded(field(steep));
+    expect(uncarved.outcome).toBe('applied');
+    expect(uncarved.keptCount).toBe(steep.length);
+  });
+
+  it('still reports an exactly-zero extent as a degenerate extent', () => {
+    // The zero case was handled before the bound existed and keeps its own
+    // reason: no extent at all is not the same finding as an extent so thin the
+    // grid outruns the points.
+    const line: Sample[] = [];
+    for (let i = 0; i < 200; i++) line.push({ x: i, y: 10, d: i });
+    const decision = rejectOccluded(field(line));
+    expect(decision.applied).toBe(false);
+    expect(decision.outcome).toBe('degenerate-extent');
+    expect(decision.keptCount).toBe(line.length);
+  });
+});


### PR DESCRIPTION
The occlusion depth buffer sized its grid from the projected point spacing, `3 * sqrt(area / count)`. A selection that is wide but very thin has an area approaching zero while its width stays large, so the cell size collapses and the grid grows without bound. Measured: 32 points at an aspect ratio of 1e10 allocated 285 MB of array buffers, and the walk then declined for too few adjacent cell pairs, so the allocation bought nothing.

The grid is now capped at one cell per candidate point, checked before any allocation, and a selection past it declines through the existing refusal path with its own outcome. One cell per point is where the estimate stops meaning anything: below it every cell minimum is a single return, so the adjacent-cell step measures point spacing rather than a surface.

Ordinary selections are unchanged.
