### PR TITLE
fix(3dtiles): refuse an unsupported tileset asset.version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ OpenLiDARViewer does not claim survey-grade measurement or support for every LiD
 
 - COPC streaming: a `.copc.laz` file, on disk or hosted at a URL, opens through progressive, octree-based, view-dependent streaming with worker-based decoding and bounded memory, never a full-file load. A remote scan opens from the start screen's open-from-URL field or a shareable `?copc=<url>` deep link
 - EPT (Entwine Point Tile) streaming: local and remote, `binary` and `laszip` tiles
-- 3D Tiles / `.pnts`: a single `.pnts` tile opens as a point cloud — detected by its magic bytes, decoded from uncompressed or quantised positions with colour, and placed by its `RTC_CENTER`. A `tileset.json` is detected by name and reported as not-yet-supported: the tileset document parses and traverses, but nothing mounts a 3D Tiles set as a streaming layer yet, so treat tileset streaming as planned, not shipped
+- 3D Tiles / `.pnts`: a single `.pnts` tile opens as a point cloud — detected by its magic bytes, decoded from uncompressed or quantised positions with colour, and placed by its `RTC_CENTER`
+- 3D Tiles / `tileset.json`: a 3D Tiles 1.0 or 1.1 tileset whose content is PNTS opens from a URL as a static, bounded, one-shot read. The document is parsed, the finest tiles the explicit hierarchy offers are fetched and placed in the tileset root frame, and the whole set is merged into one cloud that behaves like a decoded LAS file. This is not streaming: there is no hierarchical refinement and no screen-space-error response to the camera, every ceiling on the read refuses rather than truncates, and other `asset.version` values are refused by name. Tileset streaming stays planned, not shipped. See [`docs/supported-formats.md`](docs/supported-formats.md) for the limits of the subset
 - A curated catalog of 12 hand-vetted public COPC / EPT datasets
 
 See [`docs/streaming.md`](docs/streaming.md) and [`docs/copc.md`](docs/copc.md).

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -18,6 +18,7 @@ Format support is still evolving. This page separates what works today from what
 | `PTX` | Terrestrial laser scanners | Multi-scan text; per-scan pose applied; scanner origin recorded; acquisition grid preserved per block |
 | `PTS` | Terrestrial laser scanners | Whitespace-delimited text; optional header count; 3/4/6/7-column layouts; chunked reading |
 | `PNTS` | 3D Tiles point tile | A single tile; magic-byte detected; `RTC_CENTER` applied; Draco refused |
+| `tileset.json` | 3D Tiles 1.0 / 1.1 | Opened by URL; read once in full and merged into one cloud; PNTS content only; other `asset.version` values refused |
 | `COPC` | Cloud-optimised LiDAR | `.copc.laz`; opened by progressive octree streaming — see [streaming.md](streaming.md) |
 | `EPT` | Entwine Point Tile | `ept.json` manifest + hierarchy + tiles; binary and laszip tile decode; local and remote — see [streaming.md](streaming.md) |
 
@@ -53,7 +54,16 @@ Georeferenced drone LiDAR surveys in `LAS` and `LAZ` work today, including large
 
 `3D Tiles` / `PNTS`: a single `.pnts` tile opens today. It is detected by its `pnts` magic bytes (so a tile saved under another name still opens, and a file that only borrows the extension is refused rather than read as a tile), decoded through the viewer's PNTS reader — uncompressed `POSITION` and `POSITION_QUANTIZED`, RGBA/RGB/RGB565/CONSTANT_RGBA colour — and placed by adding the feature table's `RTC_CENTER` back to every position. Draco-compressed tiles are refused.
 
-A whole `tileset.json` does not open yet. The tileset document is parsed and its hierarchy can be traversed (`src/io/tiles3d/`), but nothing mounts a tileset as a streaming layer, so opening one returns an honest "on the roadmap, not shipped" message. Treat tileset streaming as planned, not shipped, until it is announced in the release notes.
+A whole `tileset.json` opens by URL, and it is worth being exact about what that is and what it is not.
+
+What opens: a static, bounded, one-shot read of a 3D Tiles 1.0 or 1.1 tileset whose content is PNTS. The entry document is fetched and parsed, the finest representation the explicit tile hierarchy offers is selected, those `.pnts` bodies are fetched and placed in the tileset root frame, and the result is merged into a single point cloud that then behaves exactly like a decoded LAS file. A document declaring any other `asset.version` is refused by name, because that value fixes the schema the rest of the document is written in. Every ceiling on the read is a refusal rather than a truncation: tile count, tree depth, per-body size and merged point total each fail the open with a message, because a partially assembled tileset would look complete on screen and measure wrong.
+
+What does not open: hierarchical streaming, dynamic screen-space-error refinement against the camera, and the wider 3D Tiles ecosystem (B3DM, I3DM, CMPT, glTF content, implicit tiling, or a selection that reaches a nested external `tileset.json`). Nothing about this open is incremental: the whole tileset is read before anything appears, so it suits a bounded dataset and not a city-scale one. Tileset streaming remains planned, not shipped.
+
+Two further limits of the supported subset are known:
+
+- Content is selected by the URI extension. 3D Tiles 1.1 does not require a content URI to have a file extension, and permits content to be identified by its magic header or to be JSON, so a tileset that names its tiles without an extension is not opened even when every tile in it is PNTS.
+- A tile is read as carrying a single `content`. 3D Tiles 1.1 allows `contents[]`, several contents on one tile, and only the single-content form is read here.
 
 ## Mobile Scan Exports
 

--- a/src/io/sniffFormat.ts
+++ b/src/io/sniffFormat.ts
@@ -217,11 +217,10 @@ export function sniffFormat(buffer: ArrayBuffer, filename: string): DetectedForm
 /**
  * True when a filename names a 3D Tiles TILESET (`tileset.json`).
  *
- * A tileset is the one 3D Tiles entry point that still has no user-facing
- * open: `src/io/tiles3d/tileset.ts` parses the document and
- * `src/io/tiles3d/tilesetTraversal.ts` walks it, but nothing mounts the result
- * as a layer, so a tileset sniffs as `unknown` and the loader uses this to give
- * an honest "on the roadmap" message rather than a generic dead-end.
+ * A tileset opens by URL, not from disk: the document names its tiles by
+ * relative path, and a file picked off disk has no directory to resolve them
+ * against. So a tileset sniffs as `unknown` and the loader uses this to say
+ * where to paste the URL rather than give a generic dead-end.
  *
  * A single `.pnts` tile is deliberately NOT named here. It sniffs as `pnts`,
  * opens through `loadPnts`, and a file that only borrows the extension is

--- a/src/io/tiles3d/tileset.ts
+++ b/src/io/tiles3d/tileset.ts
@@ -1,13 +1,25 @@
 /**
  * tileset.ts — a `tileset.json` parser for the 3D Tiles point-cloud subset.
  *
- * OLV already streams COPC and EPT through one format-agnostic `StreamingSource`
- * + scheduler, so opening 3D Tiles is a matter of turning a tileset into the same
- * node shape. This is the first half: parse an explicit `tileset.json` tree into
- * typed tiles (bounding volume, geometric error, refine, transform, content URI),
- * inheriting `refine` down the tree as the spec requires. It deliberately refuses
- * what this subset does not cover — implicit tiling — with a clear error rather
- * than mis-reading it. Pure: no fetch, no DOM.
+ * This parses an explicit `tileset.json` tree into typed tiles (bounding volume,
+ * geometric error, refine, transform, content URI), inheriting `refine` down the
+ * tree as the spec requires. It is the document half of the static one-shot open
+ * in `tilesetCloud.ts`, which reads a whole tileset once and merges it into a
+ * single cloud. It is not a streaming reader, and nothing here refines against a
+ * camera over time.
+ *
+ * The subset is bounded on purpose, and what falls outside it is refused with a
+ * clear error rather than mis-read: implicit tiling, and any `asset.version`
+ * outside {@link SUPPORTED_ASSET_VERSIONS}.
+ *
+ * Two compatibility limits of this subset are known and not yet addressed. The
+ * selection downstream identifies content by the URI extension, while 1.1 does
+ * not require a content URI to carry one: content may be identified by its magic
+ * header, or be JSON. And a tile here carries a single `content`, while 1.1
+ * allows `contents[]` with several contents on one tile. Both are documented in
+ * docs/supported-formats.md as limits of what opens.
+ *
+ * Pure: no fetch, no DOM.
  */
 
 export type Refine = 'ADD' | 'REPLACE';
@@ -77,6 +89,18 @@ interface ParseBudget {
   readonly maxTiles: number;
   tiles: number;
 }
+
+/**
+ * The `asset.version` values this reader claims to understand.
+ *
+ * `asset.version` names the schema the rest of the document is written in, and
+ * with it the base set of tile formats a reader is expected to handle. This
+ * reader implements a bounded subset of 1.0 and 1.1, so a document declaring
+ * anything else is refused rather than read as though the fields below meant
+ * what they mean in those two versions. A future 3.0 that renames or reuses a
+ * field would otherwise parse into a tree that looks valid and is wrong.
+ */
+export const SUPPORTED_ASSET_VERSIONS = ['1.0', '1.1'] as const;
 
 /** Component counts the spec fixes for each bounding-volume form. */
 const BOUNDING_VOLUME_LENGTH = { box: 12, region: 6, sphere: 4 } as const;
@@ -206,6 +230,12 @@ export function parseTileset(input: string | object, limits: TilesetParseLimits 
   const assetVersion = doc.asset?.version;
   if (typeof assetVersion !== 'string') {
     throw new Error('3D Tiles: tileset.json has no asset.version.');
+  }
+  if (!(SUPPORTED_ASSET_VERSIONS as readonly string[]).includes(assetVersion)) {
+    throw new Error(
+      `3D Tiles: tileset.json declares asset.version "${assetVersion}", which is not ` +
+        `${SUPPORTED_ASSET_VERSIONS.join(' or ')}.`,
+    );
   }
   if (typeof doc.geometricError !== 'number' || !Number.isFinite(doc.geometricError)) {
     throw new Error('3D Tiles: tileset.json has no finite geometricError.');

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -2976,8 +2976,10 @@ export class AnalysePanel {
     // classification, DSM, slope/hillshade, 3D overlay, terrain report) has all
     // shipped — leaving them here advertised done work as "planned", which
     // contradicts the buttons in this very panel. These three are the real,
-    // not-yet-shipped roadmap. A single .pnts tile opens today, so what
-    // remains planned is streaming a whole tileset (see supported-formats.md);
+    // not-yet-shipped roadmap. A single .pnts tile opens today, and so does a
+    // whole tileset as a static one-shot read, so what remains planned is
+    // streaming one: hierarchical, camera-driven refinement over time rather
+    // than a bounded read of the whole set (see supported-formats.md);
     // out-of-core loading and co-registered change detection are the open
     // engineering items.
     for (const item of [

--- a/tests/loadFileWarning.test.ts
+++ b/tests/loadFileWarning.test.ts
@@ -70,13 +70,13 @@ describe('large static LAS/LAZ memory caution', () => {
   });
 });
 
-describe('3D Tiles — a tileset is refused, a tile is not', () => {
-  it('rejects a tileset.json with a roadmap message, not a generic error', async () => {
+describe('3D Tiles — a dropped tileset is refused, a tile is not', () => {
+  it('rejects a dropped tileset.json by pointing at the URL field, not a generic error', async () => {
     const f = fakeFile('tileset.json', 1024, '{"asset":{"version":"1.0"}}');
-    await expect(fileMetadata(f)).rejects.toThrow(/3D Tiles|tileset|roadmap/i);
+    await expect(fileMetadata(f)).rejects.toThrow(/opens by URL/i);
   });
 
-  it('accepts a .pnts tile, which the roadmap message no longer covers', async () => {
+  it('accepts a .pnts tile, which the URL-only message does not cover', async () => {
     const f = fakeFile('points.pnts', 4096, 'pnts');
     const meta = await fileMetadata(f);
     expect(meta.format).toBe('pnts');

--- a/tests/tiles3dAssetVersion.test.ts
+++ b/tests/tiles3dAssetVersion.test.ts
@@ -1,0 +1,62 @@
+/**
+ * tiles3dAssetVersion.test.ts — the schema version a tileset declares.
+ *
+ * `asset.version` names the 3D Tiles schema the rest of the document is written
+ * in, and with it the base set of tile formats a reader is expected to handle.
+ * This reader implements a bounded subset of 1.0 and 1.1, so anything else has
+ * to fail the parse: a document written to a later schema can reuse a field name
+ * and still parse into a tree that looks valid and means something else.
+ *
+ * Before this suite, any string at all was accepted, so "2.0" and "banana" both
+ * parsed as though they were 1.1.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseTileset, SUPPORTED_ASSET_VERSIONS } from '../src/io/tiles3d/tileset';
+
+const tileset = (version: unknown) => {
+  const doc: Record<string, unknown> = {
+    geometricError: 100,
+    root: {
+      boundingVolume: { box: [0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 5] },
+      geometricError: 10,
+      refine: 'REPLACE',
+    },
+  };
+  if (version !== undefined) doc.asset = { version };
+  return doc;
+};
+
+describe('tileset asset.version', () => {
+  it('parses every supported version', () => {
+    expect([...SUPPORTED_ASSET_VERSIONS]).toEqual(['1.0', '1.1']);
+    for (const v of SUPPORTED_ASSET_VERSIONS) {
+      expect(parseTileset(tileset(v)).assetVersion).toBe(v);
+    }
+  });
+
+  it('refuses a schema version outside the supported set, naming both', () => {
+    let message = '';
+    try {
+      parseTileset(tileset('2.0'));
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain('2.0');
+    expect(message).toContain('1.0');
+    expect(message).toContain('1.1');
+    expect(message).toMatch(/^3D Tiles: /);
+  });
+
+  it('refuses a version string that names no schema at all', () => {
+    expect(() => parseTileset(tileset('banana'))).toThrow(/"banana"/);
+    expect(() => parseTileset(tileset('1'))).toThrow(/not 1\.0 or 1\.1/);
+    expect(() => parseTileset(tileset('1.10'))).toThrow(/not 1\.0 or 1\.1/);
+  });
+
+  it('still refuses a missing or non-string asset.version', () => {
+    expect(() => parseTileset(tileset(undefined))).toThrow(/no asset\.version/);
+    expect(() => parseTileset(tileset(1.1))).toThrow(/no asset\.version/);
+    expect(() => parseTileset(tileset(null))).toThrow(/no asset\.version/);
+  });
+});

--- a/tests/tiles3dMalformed.test.ts
+++ b/tests/tiles3dMalformed.test.ts
@@ -1,9 +1,9 @@
 /**
  * tiles3dMalformed.test.ts — what the 3D Tiles parsers must refuse.
  *
- * Neither parser is user-facing in v0.6.6, so nothing routes untrusted bytes
- * into them yet. That is exactly when a format boundary is cheap to make
- * strict: `parseTileset` also accepts an already-parsed object, which can carry
+ * A remote `tileset.json` URL now routes untrusted bytes into both, so this is
+ * a live format boundary rather than a precautionary one. `parseTileset` also
+ * accepts an already-parsed object, which can carry
  * NaN where JSON text cannot, and a PNTS tile declares its own length that the
  * decoder should honour instead of reading to the end of whatever buffer it was
  * handed. Every case below was accepted before this suite existed.


### PR DESCRIPTION
`parseTileset` checked only that `asset.version` was a string, so "2.0" and "banana" parsed as though they were compatible. That field decides the tileset schema and the base set of formats a reader must understand, and this reader implements a bounded 1.0 and 1.1 subset. Anything else is now refused, with a message naming both what was found and what is supported, built from the same constant as the rule.

A remote tileset became openable while several statements still said it did not open and that 3D Tiles was parser groundwork. Those are corrected in `README.md`, `docs/supported-formats.md` and four source headers. What ships is described as a static bounded read rather than streaming, because streaming is still unshipped.

Two limits of the subset are recorded rather than implemented: content is selected by URI extension, and one `content` per tile is read.
