### PR TITLE
fix(e57): keep every declared return value and make cell identity order-free

### DIFF
--- a/src/diagnostics/rangeRaster.ts
+++ b/src/diagnostics/rangeRaster.ts
@@ -29,6 +29,7 @@
 import {
   CELL_STATES,
   CellState,
+  cellIndexForRecord,
   cellIndexOf,
   type CellStateValue,
   type OrganizedRangeFrame,
@@ -265,30 +266,26 @@ export function displayPixelOf(
 }
 
 /**
- * The grid cell a display record was decoded from, or null when this frame
- * produced no such record.
+ * The grid cell a display record was decoded from, as a row and column, or null
+ * when this frame produced no such record.
  *
- * A linear scan of `cellToRecord`, which is the only honest way to answer it:
- * the array is the loader's own record of what each cell produced, and there is
- * no second index. The scan is one pass over the grid and runs on an inspection
- * click, not on a repaint.
+ * The search itself is {@link cellIndexForRecord}, in the model, because which
+ * array can answer for which record is a fact about the frame's own storage and
+ * not about drawing. This wrapper only turns a cell index into the row and
+ * column a raster addresses.
  *
- * A frame whose linkage is unavailable answers null without scanning, because
- * `withLinkageUnavailable` has already erased the indices and a match against
- * the erased sentinel would be meaningless.
+ * Searching `cellToRecord` alone was wrong for a multi-return cell: that array
+ * keeps one record per cell, so the second return of a pulse resolved to null
+ * here while `returnsForCell` listed it, and the pointer that landed on the
+ * cell could not be inverted from the record the inspector was showing.
  */
 export function cellForRecord(
   frame: OrganizedRangeFrame,
   record: number,
 ): { readonly row: number; readonly column: number } | null {
-  if (frame.linkage.kind === 'unavailable') return null;
-  if (record < 0) return null;
-  const map = frame.cellToRecord;
-  for (let i = 0; i < map.length; i++) {
-    if (map[i] !== record) continue;
-    return { row: Math.floor(i / frame.width), column: i % frame.width };
-  }
-  return null;
+  const i = cellIndexForRecord(frame, record);
+  if (i === null) return null;
+  return { row: Math.floor(i / frame.width), column: i % frame.width };
 }
 
 /** Every state in value order, re-exported so a legend needs one import. */

--- a/src/io/e57/structuredFrames.ts
+++ b/src/io/e57/structuredFrames.ts
@@ -26,10 +26,13 @@
 import {
   CellState,
   NO_RECORD,
+  RETURN_VALUE_MAX,
+  aggregateCellState,
   buildCellReturns,
   cellIndexOf,
   tallyCellStates,
   type CellReturnInput,
+  type CellStateValue,
   type OrganizedRangeFrame,
   type RangeLinkage,
 } from '../../model/OrganizedRange';
@@ -154,22 +157,43 @@ export class E57GridBuilder {
       return;
     }
     const cell = cellIndexOf(row - this.rowMinimum, column - this.columnMinimum, this.width);
+    const prior = this.cellState[cell] as CellStateValue;
     if (merged === null) {
       // The file itself says this record is unusable. That is evidence about
-      // the record, not about this session, so it is not NOT_DECODED.
-      this.cellState[cell] = CellState.SOURCE_INVALID;
+      // the record, not about this session, so it is not NOT_DECODED. It is
+      // AGGREGATED rather than assigned, so it cannot overwrite a valid sibling
+      // return and leave the cell claiming invalid while `cellToRecord` still
+      // points at a record the merge kept.
+      this.cellState[cell] = aggregateCellState(prior, CellState.SOURCE_INVALID);
       return;
     }
-    this.cellState[cell] = CellState.VALID_RETURN;
-    this.cellToRecord[cell] = merged;
-    if (this.sourceRange && this.range) this.sourceRange[cell] = this.range[i]!;
+    this.cellState[cell] = aggregateCellState(prior, CellState.VALID_RETURN);
+    // The primary is the smallest merged record the cell produced, and the
+    // cell-level range follows it. Comparing rather than overwriting is what
+    // makes both answers the same for any order the merge walks the records in.
+    const held = this.cellToRecord[cell]!;
+    if (held === NO_RECORD || merged < held) {
+      this.cellToRecord[cell] = merged;
+      if (this.sourceRange && this.range) this.sourceRange[cell] = this.range[i]!;
+    }
     if (this.returns && this.returnIndex) {
+      const declaredIndex = this.returnIndex[i]!;
+      if (!Number.isInteger(declaredIndex) || declaredIndex < 0 || declaredIndex > RETURN_VALUE_MAX) {
+        // Same shape as the out-of-bounds row and column above: the file said
+        // something the store cannot hold, so the scan loses its grid rather
+        // than keeping one whose return order was decided by a wrapped value.
+        this.contradiction =
+          `record ${i} declares returnIndex ${declaredIndex}, outside the ` +
+          `0–${RETURN_VALUE_MAX} range a return column can hold`;
+        return;
+      }
       this.returns.push({
         row: row - this.rowMinimum,
         column: column - this.columnMinimum,
         record: merged,
-        returnIndex: this.returnIndex[i]!,
-        returnCount: this.returnCount ? this.returnCount[i]! : 0,
+        returnIndex: declaredIndex,
+        returnCount: this.returnCount ? this.returnCount[i]! : null,
+        sourceRange: this.range ? this.range[i]! : null,
       });
     }
   }
@@ -195,7 +219,10 @@ export class E57GridBuilder {
             returnCellStart: built.returnCellStart,
             returnRecord: built.returnRecord,
             returnIndex: built.returnIndex,
-            returnCountDeclared: built.returnCountDeclared,
+            ...(built.returnCountDeclared
+              ? { returnCountDeclared: built.returnCountDeclared }
+              : {}),
+            ...(built.returnSourceRange ? { returnSourceRange: built.returnSourceRange } : {}),
             returnsSkipped: built.skippedCount,
           }
         : {}),

--- a/src/io/e57/structuredSink.ts
+++ b/src/io/e57/structuredSink.ts
@@ -144,17 +144,36 @@ export function e57StructuredBytesPerRecord(
 export const E57_GRID_BYTES_PER_CELL = 2 * (1 + 4);
 /** `sourceRange`, allocated only when the scan declares `sphericalRange`. */
 export const E57_GRID_RANGE_BYTES_PER_CELL = 4;
-/** `returnCellStart`, allocated only when the scan describes returns per cell. */
-export const E57_GRID_RETURN_BYTES_PER_CELL = 4;
+/**
+ * Per-cell cost of the CSR build, when the scan describes returns per cell.
+ *
+ * PEAK, not the finished frame. `buildCellReturns` allocates `counts` and
+ * `cursor`, both `Uint32` over the cells, and both are still live while
+ * `returnCellStart` exists, because the cursor is copied FROM it. Counting only the
+ * surviving array under-stated the moment that actually decides whether the
+ * decode fits, which is the moment a ceiling exists to catch.
+ */
+export const E57_GRID_RETURN_BYTES_PER_CELL = 4 + 4 + 4;
 
 /**
- * Bytes one return costs while the CSR description is built: the `Int32` record,
- * the two `Uint16` source values, and the plain object it arrives in. Object
- * headers are not a typed-array cost and are not covered by the resident
- * allowance, and there is one per return, so they are counted rather than
- * hoped over.
+ * Bytes one return costs at the PEAK of the CSR build.
+ *
+ * Three terms, all live together:
+ *
+ *   72  the plain `CellReturnInput` object the entry arrives in. Object headers
+ *       are not a typed-array cost and are not covered by the resident
+ *       allowance, and there is one per return.
+ *    4  `cellOf`, the `Int32` cell address the count pass records per entry so
+ *       the placement pass does not re-derive it.
+ *   16  the finished arrays: `Int32` record, `Uint32` returnIndex, `Uint32`
+ *       returnCountDeclared, `Float32` returnSourceRange. These are allocated
+ *       while the entry array is still held, so they add rather than replace.
+ *
+ * The two `Uint32` columns were `Uint16`, and the widening is what closed a
+ * silent modulo wrap on a declared index above 65535. Four bytes per return is
+ * the price, and it is counted here so the ceiling sees it.
  */
-export const E57_RETURN_ENTRY_BYTES = 72;
+export const E57_RETURN_ENTRY_BYTES = 72 + 4 + 16;
 
 /**
  * Cells the grid of an eligible scan holds, bounded by what the file can supply.

--- a/src/model/OrganizedRange.ts
+++ b/src/model/OrganizedRange.ts
@@ -172,30 +172,85 @@ export interface OrganizedRangeFrame {
   readonly height: number;
   /** Length `width * height`, indexed by `cellIndex`. */
   readonly cellState: Uint8Array;
-  /** Length `width * height`. Display record index, or `NO_RECORD`. */
+  /**
+   * Length `width * height`. The cell's PRIMARY display record, or `NO_RECORD`.
+   *
+   * A cell that produced several returns produced several records, and one
+   * `Int32` cannot hold them. This array holds the primary and nothing else:
+   * the SMALLEST merged record index the cell produced. Smallest rather than
+   * last-written because the merge numbers records in file order, so the
+   * smallest is the one the file wrote first, and because a rule stated over
+   * the SET of a cell's records gives the same answer whatever order the
+   * loader walked them in. Last-written gave a different primary for the same
+   * file read at a different stride.
+   *
+   * It is a convenience for the single-return case and for the UI, never the
+   * frame's record of identity. Every surviving record is reachable through
+   * `returnRecord`, and {@link cellIndexForRecord} is the reverse direction for
+   * all of them, not only for the primaries.
+   */
   readonly cellToRecord: Int32Array;
   /**
-   * Multi-return description, as four parallel arrays in CSR form.
+   * Multi-return description, as parallel arrays in CSR form.
    *
-   * Present TOGETHER or not at all. Their absence is not "this frame has no
-   * returns"; it means this frame never described returns per cell, which is
-   * the ordinary case for PTX and PCD, where a cell holds at most one. A
-   * single-return frame therefore allocates nothing here and every existing
-   * accessor keeps its cost.
+   * The first three are present TOGETHER or not at all. Their absence is not
+   * "this frame has no returns"; it means this frame never described returns
+   * per cell, which is the ordinary case for PTX and PCD, where a cell holds at
+   * most one. A single-return frame therefore allocates nothing here and every
+   * existing accessor keeps its cost.
+   *
+   * `returnCountDeclared` and `returnSourceRange` are independent of that trio,
+   * because a source can describe its returns while declaring neither. Their
+   * absence is the frame saying the source was silent, which is why neither is
+   * back-filled with a stand-in value.
    */
   /** Length `width * height + 1`. Returns of cell `c` live in `[s[c], s[c+1])`. */
   readonly returnCellStart?: Uint32Array;
   /** Length `returnCellStart[cells]`, in cell order. Record index, or `NO_RECORD`. */
   readonly returnRecord?: Int32Array;
-  /** Length as `returnRecord`. The source's own `returnIndex` for each return. */
-  readonly returnIndex?: Uint16Array;
-  /** Length as `returnRecord`. The `returnCount` the source declared for the pulse. */
-  readonly returnCountDeclared?: Uint16Array;
+  /**
+   * Length as `returnRecord`. The source's own `returnIndex` for each return.
+   *
+   * `Uint32Array`, not `Uint16Array`, because the E57 structured sink sizes
+   * this column from the file's DECLARED maximum and legitimately hands back a
+   * `Uint32Array` when that maximum exceeds 65535. A narrower store took the
+   * value modulo 65536 in silence, so a declared index of 70001 arrived as
+   * 4465 and sorted into the wrong place in its own cell. Two extra bytes per
+   * return is the price of never doing that.
+   */
+  readonly returnIndex?: Uint32Array;
+  /**
+   * Length as `returnRecord`, and ABSENT when the source declared no count.
+   *
+   * A zero here is the source declaring zero. The absence of the array is the
+   * source saying nothing, which used to be written as a zero into an array
+   * whose name asserts a declaration. In E57 the count is a prototype field
+   * that either exists for the whole scan or does not, so absence is a
+   * property of the frame and needs no per-return mask.
+   */
+  readonly returnCountDeclared?: Uint32Array;
+  /**
+   * Length as `returnRecord`. Source-declared range per RETURN, NaN where absent.
+   *
+   * Two returns of one pulse are at two distances, and no single cell-level
+   * number describes both. `sourceRange` keeps a per-cell value for the raster,
+   * defined against the primary record; this array is where the measurement
+   * itself lives.
+   */
+  readonly returnSourceRange?: Float32Array;
   /** Returns the build was handed that addressed no cell of this grid. */
   readonly returnsSkipped?: number;
   /** Length `width * height`. Range in acquisition-local coordinates, NaN where absent. */
   readonly geometricRange?: Float32Array;
-  /** Length `width * height`. Range the source itself declared, NaN where absent. */
+  /**
+   * Length `width * height`. Range the source declared for the cell's PRIMARY
+   * record, NaN where absent.
+   *
+   * Named against `cellToRecord`'s primary rule on purpose. A cell-level range
+   * is a summary, and a summary needs a stated rule or it is whatever the
+   * traversal happened to write last. Callers that need the distances of a
+   * multi-return pulse read `returnSourceRange`, which loses nothing.
+   */
   readonly sourceRange?: Float32Array;
   readonly acquisitionPose?: AcquisitionPose;
   readonly linkage: RangeLinkage;
@@ -361,8 +416,15 @@ export interface CellReturn {
   readonly record: number;
   /** Which return of the pulse this is, as the source declared it. */
   readonly returnIndex: number;
-  /** How many returns the source declared for that pulse. */
-  readonly returnCount: number;
+  /**
+   * How many returns the source declared for that pulse, or null when the
+   * source declared no count at all. Null rather than 0: a source that says
+   * "zero returns" and a source that says nothing are different evidence, and
+   * only one of them is about the pulse.
+   */
+  readonly returnCount: number | null;
+  /** Range the source declared for this return, or null when it declared none. */
+  readonly sourceRange: number | null;
 }
 
 /** One return on its way in, addressed by grid cell. */
@@ -371,13 +433,71 @@ export interface CellReturnInput extends CellReturn {
   readonly column: number;
 }
 
+/**
+ * Aggregate one record's state into the state its CELL already holds.
+ *
+ * Order-independent by construction, which is the whole reason it exists as a
+ * function. `place()` used to assign, so a cell holding a valid record and an
+ * invalid one ended VALID_RETURN or SOURCE_INVALID depending on which record
+ * the loader reached last, and the same file read at a different stride
+ * disagreed with itself.
+ *
+ * VALID_RETURN dominates because the question the cell answers is whether it
+ * produced a usable display record, and one usable return is enough for that.
+ * The invalid siblings are not lost: they are records the merge dropped, so
+ * they never had an identity for the return list to carry either. Anything the
+ * source actually said about the cell beats the fill value the grid started
+ * with, and NOT_DECODED never wins over evidence.
+ */
+export function aggregateCellState(
+  current: CellStateValue,
+  incoming: CellStateValue,
+): CellStateValue {
+  if (current === CellState.VALID_RETURN || incoming === CellState.VALID_RETURN) {
+    return CellState.VALID_RETURN;
+  }
+  if (current === CellState.SOURCE_INVALID || incoming === CellState.SOURCE_INVALID) {
+    return CellState.SOURCE_INVALID;
+  }
+  return incoming;
+}
+
 /** The arrays a frame carries, plus what the build could not place. */
 export interface BuiltCellReturns {
   readonly returnCellStart: Uint32Array;
   readonly returnRecord: Int32Array;
-  readonly returnIndex: Uint16Array;
-  readonly returnCountDeclared: Uint16Array;
+  readonly returnIndex: Uint32Array;
+  /** Absent when no entry declared a count. */
+  readonly returnCountDeclared?: Uint32Array;
+  /** Absent when no entry declared a range. */
+  readonly returnSourceRange?: Float32Array;
   readonly skippedCount: number;
+}
+
+/**
+ * Widest value the return columns can hold. The E57 structured sink sizes an
+ * index column at `u32` when the file declares a maximum this large, so this is
+ * the width the model must accept, not a generous margin.
+ */
+export const RETURN_VALUE_MAX = 4294967295;
+
+/**
+ * Refuse a return column value the store cannot hold, naming what was supplied.
+ *
+ * Refusal, not clamping and not a wrap. Both of those return a number, and a
+ * number returned from here is indistinguishable from a measurement. A value
+ * outside `0..RETURN_VALUE_MAX`, or one that is not an integer, is not a
+ * `returnIndex` any source declared through a supported column, so the build
+ * that produced it is wrong and stops rather than storing a plausible answer.
+ */
+function checkedReturnValue(field: string, value: number, at: number): number {
+  if (!Number.isInteger(value) || value < 0 || value > RETURN_VALUE_MAX) {
+    throw new RangeError(
+      `${field} ${value} at entry ${at} is outside 0..${RETURN_VALUE_MAX}, ` +
+        'so it cannot be stored without changing it',
+    );
+  }
+  return value;
 }
 
 /**
@@ -395,11 +515,16 @@ export interface BuiltCellReturns {
  * whenever returns are sparse, which is the normal case.
  *
  * ORDERING: returns are NOT assumed to arrive in `returnIndex` order, and they
- * are sorted ascending by `returnIndex` within each cell. That is a real
- * reordering and it is stated because it is one: `returnIndex` is a physical
- * fact about the pulse, so it travels with its own record and count rather than
- * being inferred from a position. Ties keep source order, and the placement
- * pass is stable, so equal indices are not shuffled.
+ * are sorted within each cell by `returnIndex` ascending, then by `record`
+ * ascending. That is a real reordering and it is stated because it is one:
+ * `returnIndex` is a physical fact about the pulse, so it travels with its own
+ * record, count and range rather than being inferred from a position.
+ *
+ * The record tie-break is what makes the result a function of the ENTRIES
+ * rather than of their arrival order. Two returns declaring the same index
+ * previously kept the order the caller happened to supply, so the same records
+ * read at a different stride, or merged in a different scan order, produced a
+ * different frame. A total order over the values themselves cannot do that.
  */
 export function buildCellReturns(
   width: number,
@@ -431,39 +556,60 @@ export function buildCellReturns(
   const cursor = new Uint32Array(cellCount);
   cursor.set(returnCellStart.subarray(0, cellCount));
 
+  // Whether the source declared these at all is a property of the whole build,
+  // so it is decided before anything is allocated and an undeclared column
+  // costs no bytes rather than a run of stand-in zeroes.
+  let declaresCount = false;
+  let declaresRange = false;
+  for (let k = 0; k < entries.length; k++) {
+    if (cellOf[k]! < 0) continue;
+    const e = entries[k]!;
+    if (e.returnCount !== null && e.returnCount !== undefined) declaresCount = true;
+    if (e.sourceRange !== null && e.sourceRange !== undefined) declaresRange = true;
+  }
+
   const returnRecord = new Int32Array(live);
-  const returnIndex = new Uint16Array(live);
-  const returnCountDeclared = new Uint16Array(live);
+  const returnIndex = new Uint32Array(live);
+  const returnCountDeclared = declaresCount ? new Uint32Array(live) : undefined;
+  const returnSourceRange = declaresRange ? new Float32Array(live).fill(Number.NaN) : undefined;
   for (let k = 0; k < entries.length; k++) {
     const cell = cellOf[k]!;
     if (cell < 0) continue;
     const e = entries[k]!;
     const at = cursor[cell]!++;
     returnRecord[at] = e.record;
-    returnIndex[at] = e.returnIndex;
-    returnCountDeclared[at] = e.returnCount;
+    returnIndex[at] = checkedReturnValue('returnIndex', e.returnIndex, k);
+    if (returnCountDeclared && e.returnCount !== null && e.returnCount !== undefined) {
+      returnCountDeclared[at] = checkedReturnValue('returnCount', e.returnCount, k);
+    }
+    if (returnSourceRange && e.sourceRange !== null && e.sourceRange !== undefined) {
+      returnSourceRange[at] = e.sourceRange;
+    }
   }
 
-  // Stable insertion sort inside each span. Spans are a handful of returns, and
-  // stability is what keeps two returns declaring the same index in the order
-  // the source wrote them.
+  // Insertion sort inside each span, on the pair (returnIndex, record). Spans
+  // are a handful of returns. The pair is a total order over distinct records,
+  // so the sorted span depends on the entries and not on how they arrived.
   for (let c = 0; c < cellCount; c++) {
     const start = returnCellStart[c]!;
     const end = returnCellStart[c + 1]!;
     for (let i = start + 1; i < end; i++) {
       const ri = returnIndex[i]!;
       const rec = returnRecord[i]!;
-      const rc = returnCountDeclared[i]!;
+      const rc = returnCountDeclared ? returnCountDeclared[i]! : 0;
+      const rr = returnSourceRange ? returnSourceRange[i]! : 0;
       let j = i - 1;
-      while (j >= start && returnIndex[j]! > ri) {
+      while (j >= start && (returnIndex[j]! > ri || (returnIndex[j]! === ri && returnRecord[j]! > rec))) {
         returnIndex[j + 1] = returnIndex[j]!;
         returnRecord[j + 1] = returnRecord[j]!;
-        returnCountDeclared[j + 1] = returnCountDeclared[j]!;
+        if (returnCountDeclared) returnCountDeclared[j + 1] = returnCountDeclared[j]!;
+        if (returnSourceRange) returnSourceRange[j + 1] = returnSourceRange[j]!;
         j--;
       }
       returnIndex[j + 1] = ri;
       returnRecord[j + 1] = rec;
-      returnCountDeclared[j + 1] = rc;
+      if (returnCountDeclared) returnCountDeclared[j + 1] = rc;
+      if (returnSourceRange) returnSourceRange[j + 1] = rr;
     }
   }
 
@@ -471,9 +617,52 @@ export function buildCellReturns(
     returnCellStart,
     returnRecord,
     returnIndex,
-    returnCountDeclared,
+    ...(returnCountDeclared ? { returnCountDeclared } : {}),
+    ...(returnSourceRange ? { returnSourceRange } : {}),
     skippedCount: entries.length - live,
   };
+}
+
+/**
+ * The cell index a display record was decoded from, or null when this frame
+ * produced no such record.
+ *
+ * EVERY surviving record answers here, not only the cell primaries. The CSR
+ * arrays are consulted first because they list every return the frame kept,
+ * while `cellToRecord` keeps one record per cell and so cannot answer for the
+ * second and later returns of a multi-return pulse. Answering null for a record
+ * that `returnsForCell` will happily hand back is the reverse direction
+ * disagreeing with the forward one about which records exist.
+ *
+ * A frame whose linkage is unavailable answers null without scanning, because
+ * `withLinkageUnavailable` has already erased the indices and a match against
+ * the erased sentinel would be meaningless.
+ */
+export function cellIndexForRecord(frame: OrganizedRangeFrame, record: number): number | null {
+  if (frame.linkage.kind === 'unavailable') return null;
+  if (record < 0) return null;
+  const { returnCellStart, returnRecord } = frame;
+  if (returnCellStart && returnRecord) {
+    for (let i = 0; i < returnRecord.length; i++) {
+      if (returnRecord[i] !== record) continue;
+      // The offset is inside exactly one cell's half-open span. Binary search
+      // for the last start that does not exceed it, which is that cell.
+      let low = 0;
+      let high = returnCellStart.length - 1;
+      while (low < high) {
+        const mid = (low + high + 1) >> 1;
+        if (returnCellStart[mid]! <= i) low = mid;
+        else high = mid - 1;
+      }
+      return low;
+    }
+    return null;
+  }
+  const map = frame.cellToRecord;
+  for (let i = 0; i < map.length; i++) {
+    if (map[i] === record) return i;
+  }
+  return null;
 }
 
 /**
@@ -505,8 +694,9 @@ export function returnsForCell(
   if (row < 0 || column < 0 || row >= frame.height || column >= frame.width) {
     return { ok: false, reason: 'outside-grid', why: 'Cell is outside the acquisition grid.' };
   }
-  const { returnCellStart, returnRecord, returnIndex, returnCountDeclared } = frame;
-  if (!returnCellStart || !returnRecord || !returnIndex || !returnCountDeclared) {
+  const { returnCellStart, returnRecord, returnIndex, returnCountDeclared, returnSourceRange } =
+    frame;
+  if (!returnCellStart || !returnRecord || !returnIndex) {
     return {
       ok: false,
       reason: 'not-described',
@@ -518,10 +708,15 @@ export function returnsForCell(
   const end = returnCellStart[cell + 1]!;
   const out: CellReturn[] = [];
   for (let i = start; i < end; i++) {
+    // Absence stays absence on the way out. The count array is missing when the
+    // source declared none, and a 0 substituted here would read as a pulse the
+    // source described as empty.
+    const range = returnSourceRange ? returnSourceRange[i]! : Number.NaN;
     out.push({
       record: returnRecord[i]!,
       returnIndex: returnIndex[i]!,
-      returnCount: returnCountDeclared[i]!,
+      returnCount: returnCountDeclared ? returnCountDeclared[i]! : null,
+      sourceRange: Number.isFinite(range) ? range : null,
     });
   }
   return { ok: true, returns: out };

--- a/tests/e57StructuredRange.test.ts
+++ b/tests/e57StructuredRange.test.ts
@@ -36,7 +36,8 @@ import {
 } from '../src/io/e57/structuredSink';
 import { planE57Decode } from '../src/io/loadPlan';
 import type { E57DecodePlan } from '../src/io/loadPlan';
-import { CellState, recordForCell, returnsForCell } from '../src/model/OrganizedRange';
+import { CellState, NO_RECORD, recordForCell, returnsForCell } from '../src/model/OrganizedRange';
+import { cellForRecord } from '../src/diagnostics/rangeRaster';
 
 function bufferOf(name: string): ArrayBuffer {
   const b = readFileSync(fileURLToPath(new URL(name, import.meta.url)));
@@ -87,6 +88,8 @@ interface SyntheticOptions {
   /** Prototype maxima, deliberately wider than the bounds. */
   proto?: { row: number; column: number };
   withReturns?: boolean;
+  /** Whether the returnCount column exists. Only meaningful with `withReturns`. */
+  withReturnCount?: boolean;
   withRange?: boolean;
 }
 
@@ -149,10 +152,12 @@ function fieldsOf(opts: SyntheticOptions): FieldSpec[] {
       xml: '<returnIndex type="Integer" minimum="0" maximum="3"/>',
       stream: packIntegers(r.map((p) => p.returnIndex ?? 0), 0, bitWidthFor(0, 3)),
     });
-    specs.push({
-      xml: '<returnCount type="Integer" minimum="0" maximum="3"/>',
-      stream: packIntegers(r.map((p) => p.returnCount ?? 1), 0, bitWidthFor(0, 3)),
-    });
+    if (opts.withReturnCount !== false) {
+      specs.push({
+        xml: '<returnCount type="Integer" minimum="0" maximum="3"/>',
+        stream: packIntegers(r.map((p) => p.returnCount ?? 1), 0, bitWidthFor(0, 3)),
+      });
+    }
   }
   if (opts.withRange) {
     specs.push({
@@ -586,6 +591,133 @@ describe('the range the source declares', () => {
     expect(returns.map((r) => r.returnIndex)).toEqual([0, 1]);
     expect(returns.every((r) => r.returnCount === 2)).toBe(true);
     expect(frame.returnRecord!.length).toBe(3);
+  });
+
+  it('keeps BOTH distances of the two-return pulse, not the one written last', async () => {
+    // 12.5 m and 30.25 m are two measurements of two surfaces. A single
+    // cell-level number reported whichever record the merge walked last, so the
+    // near surface disappeared from a cell that had recorded it.
+    const frame = (await loadE57(WITH_RANGE, 'range.e57')).organizedRange!.frames[0];
+    const cell = returnsForCell(frame, 0, 0);
+    expect(cell.ok).toBe(true);
+    if (!cell.ok) throw new Error(cell.why);
+    expect(cell.returns.map((r) => r.sourceRange)).toEqual([12.5, 30.25]);
+    // The cell-level value is the PRIMARY record's, named rather than left to
+    // the traversal: the primary is the smallest merged record the cell made.
+    expect(frame.sourceRange![0]).toBeCloseTo(12.5, 4);
+  });
+
+  it('reverses every record of a multi-return cell, not only the primary', async () => {
+    const frame = (await loadE57(WITH_RANGE, 'range.e57')).organizedRange!.frames[0];
+    const cell = returnsForCell(frame, 0, 0);
+    expect(cell.ok).toBe(true);
+    if (!cell.ok) throw new Error(cell.why);
+    expect(cell.returns).toHaveLength(2);
+    for (const r of cell.returns) {
+      expect(cellForRecord(frame, r.record)).toEqual({ row: 0, column: 0 });
+    }
+  });
+
+  it('says nothing about the count when the source declared no count column', async () => {
+    // A `returnCount` of 0 is the source declaring zero returns. A source with
+    // no such column declared nothing, and the two carried the same value.
+    const silent = buildStructuredE57({
+      records: [{ x: 1, y: 2, z: 3, row: 0, column: 0, returnIndex: 0 }],
+      bounds: { row: [0, 3], column: [0, 4] },
+      withReturns: true,
+      withReturnCount: false,
+    });
+    const frame = (await loadE57(silent, 'silent.e57')).organizedRange!.frames[0];
+    expect(frame.returnIndex).toBeDefined();
+    expect(frame.returnCountDeclared).toBeUndefined();
+    const cell = returnsForCell(frame, 0, 0);
+    expect(cell.ok).toBe(true);
+    if (!cell.ok) throw new Error(cell.why);
+    expect(cell.returns[0].returnCount).toBeNull();
+
+    const declared = buildStructuredE57({
+      records: [{ x: 1, y: 2, z: 3, row: 0, column: 0, returnIndex: 0, returnCount: 0 }],
+      bounds: { row: [0, 3], column: [0, 4] },
+      withReturns: true,
+    });
+    const zero = (await loadE57(declared, 'zero.e57')).organizedRange!.frames[0];
+    const zeroCell = returnsForCell(zero, 0, 0);
+    expect(zeroCell.ok).toBe(true);
+    if (!zeroCell.ok) throw new Error(zeroCell.why);
+    expect(zeroCell.returns[0].returnCount).toBe(0);
+  });
+});
+
+describe('a cell that received both a valid and an invalid record', () => {
+  /** The same two records of cell (0,0), in each order, and nothing else moved. */
+  function fileWith(order: 'valid-first' | 'invalid-first'): ArrayBuffer {
+    const good = { x: 1, y: 2, z: 3, row: 0, column: 0, range: 12.5, returnIndex: 0, returnCount: 2 };
+    const bad = { x: 0, y: 0, z: 0, row: 0, column: 0, invalid: 1, range: 30.25, returnIndex: 1, returnCount: 2 };
+    return buildStructuredE57({
+      records: order === 'valid-first' ? [good, bad] : [bad, good],
+      bounds: { row: [0, 1], column: [0, 1] },
+      withRange: true,
+      withReturns: true,
+    });
+  }
+
+  it('reports the same cell state whichever record the file wrote first', async () => {
+    // `place` assigned rather than aggregated, so the last record to arrive
+    // decided the cell. The same two records in the other order disagreed.
+    const a = (await loadE57(fileWith('valid-first'), 'a.e57')).organizedRange!.frames[0];
+    const b = (await loadE57(fileWith('invalid-first'), 'b.e57')).organizedRange!.frames[0];
+    expect([...a.cellState]).toEqual([...b.cellState]);
+    expect(a.cellState[0]).toBe(CellState.VALID_RETURN);
+  });
+
+  it('never claims a cell is invalid while still pointing at a valid record', async () => {
+    for (const order of ['valid-first', 'invalid-first'] as const) {
+      const frame = (await loadE57(fileWith(order), `${order}.e57`)).organizedRange!.frames[0];
+      for (let i = 0; i < frame.cellState.length; i++) {
+        if (frame.cellState[i] === CellState.VALID_RETURN) continue;
+        expect(frame.cellToRecord[i]).toBe(NO_RECORD);
+      }
+    }
+  });
+
+  it('names the same primary record for two VALID returns in either file order', async () => {
+    // Both records survive the merge here, so the cell has a real choice of
+    // primary. Assigning on every placement made it the last one walked, which
+    // is a property of the traversal rather than of the file.
+    const first = { x: 1, y: 2, z: 3, row: 0, column: 0, range: 12.5, returnIndex: 0, returnCount: 2 };
+    const second = { x: 4, y: 5, z: 6, row: 0, column: 0, range: 30.25, returnIndex: 1, returnCount: 2 };
+    const load = async (records: SyntheticRecord[]) =>
+      (
+        await loadE57(
+          buildStructuredE57({
+            records,
+            bounds: { row: [0, 1], column: [0, 1] },
+            withRange: true,
+            withReturns: true,
+          }),
+          'pair.e57',
+        )
+      ).organizedRange!.frames[0];
+    const a = await load([first, second]);
+    const b = await load([second, first]);
+    expect(a.cellToRecord[0]).toBe(0);
+    expect(b.cellToRecord[0]).toBe(0);
+    // The return list is the same SET either way, ordered by what the source
+    // declared rather than by arrival.
+    const listA = returnsForCell(a, 0, 0);
+    const listB = returnsForCell(b, 0, 0);
+    expect(listA.ok && listB.ok).toBe(true);
+    if (!listA.ok || !listB.ok) throw new Error('cell not described');
+    expect(listA.returns.map((r) => r.returnIndex)).toEqual([0, 1]);
+    expect(listB.returns.map((r) => r.returnIndex)).toEqual([0, 1]);
+  });
+
+  it('resolves the same record for the cell whichever order the file used', async () => {
+    const a = (await loadE57(fileWith('valid-first'), 'a.e57')).organizedRange!.frames[0];
+    const b = (await loadE57(fileWith('invalid-first'), 'b.e57')).organizedRange!.frames[0];
+    expect([...a.cellToRecord]).toEqual([...b.cellToRecord]);
+    expect(recordForCell(a, 0, 0)).toEqual(recordForCell(b, 0, 0));
+    expect(recordForCell(a, 0, 0).ok).toBe(true);
   });
 });
 

--- a/tests/organizedRange.test.ts
+++ b/tests/organizedRange.test.ts
@@ -18,7 +18,10 @@ import {
   recordForCell,
   withLinkageUnavailable,
   buildCellReturns,
+  cellIndexForRecord,
   returnsForCell,
+  aggregateCellState,
+  RETURN_VALUE_MAX,
   type OrganizedRangeFrame,
   type OrganizedRangeSet,
 } from '../src/model/OrganizedRange';
@@ -202,10 +205,10 @@ describe('multiple returns per cell', () => {
     cellState[cellIndexOf(0, 0, width)] = CellState.VALID_RETURN;
     cellState[cellIndexOf(1, 2, width)] = CellState.VALID_RETURN;
     const built = buildCellReturns(width, height, [
-      { row: 0, column: 0, record: 10, returnIndex: 0, returnCount: 1 },
-      { row: 1, column: 2, record: 22, returnIndex: 2, returnCount: 3 },
-      { row: 1, column: 2, record: 20, returnIndex: 0, returnCount: 3 },
-      { row: 1, column: 2, record: 21, returnIndex: 1, returnCount: 3 },
+      { row: 0, column: 0, record: 10, returnIndex: 0, returnCount: 1, sourceRange: null },
+      { row: 1, column: 2, record: 22, returnIndex: 2, returnCount: 3, sourceRange: null },
+      { row: 1, column: 2, record: 20, returnIndex: 0, returnCount: 3, sourceRange: null },
+      { row: 1, column: 2, record: 21, returnIndex: 1, returnCount: 3, sourceRange: null },
     ]);
     return {
       id: 'setup-e57',
@@ -227,7 +230,7 @@ describe('multiple returns per cell', () => {
   it('describes a cell that produced exactly one return', () => {
     const r = returnsForCell(multiReturnFixture(), 0, 0);
     expect(r.ok).toBe(true);
-    if (r.ok) expect(r.returns).toEqual([{ record: 10, returnIndex: 0, returnCount: 1 }]);
+    if (r.ok) expect(r.returns).toEqual([{ record: 10, returnIndex: 0, returnCount: 1, sourceRange: null }]);
   });
 
   it('reports zero returns as an empty list, not as a missing description', () => {
@@ -252,9 +255,9 @@ describe('multiple returns per cell', () => {
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.returns).toEqual([
-        { record: 20, returnIndex: 0, returnCount: 3 },
-        { record: 21, returnIndex: 1, returnCount: 3 },
-        { record: 22, returnIndex: 2, returnCount: 3 },
+        { record: 20, returnIndex: 0, returnCount: 3, sourceRange: null },
+        { record: 21, returnIndex: 1, returnCount: 3, sourceRange: null },
+        { record: 22, returnIndex: 2, returnCount: 3, sourceRange: null },
       ]);
     }
   });
@@ -281,9 +284,9 @@ describe('multiple returns per cell', () => {
 
   it('counts returns that fell outside the grid rather than placing them', () => {
     const built = buildCellReturns(3, 2, [
-      { row: 0, column: 0, record: 1, returnIndex: 0, returnCount: 1 },
-      { row: 9, column: 0, record: 2, returnIndex: 0, returnCount: 1 },
-      { row: 0, column: -1, record: 3, returnIndex: 0, returnCount: 1 },
+      { row: 0, column: 0, record: 1, returnIndex: 0, returnCount: 1, sourceRange: null },
+      { row: 9, column: 0, record: 2, returnIndex: 0, returnCount: 1, sourceRange: null },
+      { row: 0, column: -1, record: 3, returnIndex: 0, returnCount: 1, sourceRange: null },
     ]);
     expect(built.skippedCount).toBe(2);
     expect(built.returnRecord.length).toBe(1);
@@ -336,5 +339,182 @@ describe('multiple returns per cell', () => {
     // cellState, cellToRecord, returnCellStart, returnRecord, returnIndex,
     // returnCountDeclared. Counted, not listed, for the same reason as above.
     expect(organizedRangeTransferables(set)).toHaveLength(6);
+  });
+});
+
+describe('return column values the source declared', () => {
+  /** Every boundary of a 16-bit store, and four values that clear it. */
+  const BOUNDARIES = [0, 1, 65534, 65535, 65536, 70000, 4294967294];
+
+  it('stores a declared returnIndex above 65535 as the source declared it', () => {
+    // A `Uint16Array` took each of these modulo 65536 in silence: 65536 became
+    // 0, 70000 became 4464, and 4294967294 became 65534. Nothing in the frame
+    // could tell the wrapped value from a measured one afterwards.
+    const built = buildCellReturns(
+      BOUNDARIES.length,
+      1,
+      BOUNDARIES.map((v, k) => ({
+        row: 0,
+        column: k,
+        record: k,
+        returnIndex: v,
+        returnCount: v,
+        sourceRange: null,
+      })),
+    );
+    expect([...built.returnIndex]).toEqual(BOUNDARIES);
+    expect([...built.returnCountDeclared!]).toEqual(BOUNDARIES);
+  });
+
+  it('keeps the sort honest for indices that a 16-bit store would reorder', () => {
+    // 65536 wraps to 0 and 70000 wraps to 4464, so a narrowed build sorted this
+    // cell as 0, 4464, 65535 and handed back the records in the wrong order.
+    const built = buildCellReturns(1, 1, [
+      { row: 0, column: 0, record: 7, returnIndex: 70000, returnCount: 3, sourceRange: null },
+      { row: 0, column: 0, record: 8, returnIndex: 65535, returnCount: 3, sourceRange: null },
+      { row: 0, column: 0, record: 9, returnIndex: 65536, returnCount: 3, sourceRange: null },
+    ]);
+    expect([...built.returnIndex]).toEqual([65535, 65536, 70000]);
+    expect([...built.returnRecord]).toEqual([8, 9, 7]);
+  });
+
+  it('orders a returnIndex tie by record, so arrival order cannot decide it', () => {
+    // Two returns declaring the same index used to keep the order the caller
+    // supplied, so the same records read at a different stride produced a
+    // different frame. The pair (returnIndex, record) is a total order and does
+    // not have that freedom.
+    const entries = [
+      { row: 0, column: 0, record: 42, returnIndex: 1, returnCount: 2, sourceRange: null },
+      { row: 0, column: 0, record: 17, returnIndex: 1, returnCount: 2, sourceRange: null },
+    ];
+    const forward = buildCellReturns(1, 1, entries);
+    const backward = buildCellReturns(1, 1, [...entries].reverse());
+    expect([...forward.returnRecord]).toEqual([17, 42]);
+    expect([...backward.returnRecord]).toEqual([...forward.returnRecord]);
+  });
+
+  it('refuses a value no return column can hold rather than wrapping it', () => {
+    // Widening covers everything the E57 sink can hand over, which is `u32`.
+    // Past that there is no honest store, so the build stops and says so.
+    expect(() =>
+      buildCellReturns(1, 1, [
+        {
+          row: 0,
+          column: 0,
+          record: 0,
+          returnIndex: RETURN_VALUE_MAX + 1,
+          returnCount: 1,
+          sourceRange: null,
+        },
+      ]),
+    ).toThrow(/returnIndex 4294967296 at entry 0 is outside 0\.\.4294967295/);
+  });
+});
+
+describe('reversing a record back to its cell', () => {
+  /** One cell holding two returns, the case a single primary cannot describe. */
+  function twoReturnFrame(): OrganizedRangeFrame {
+    const width = 3;
+    const height = 2;
+    const cellState = new Uint8Array(width * height).fill(CellState.NO_RETURN);
+    cellState[cellIndexOf(1, 2, width)] = CellState.VALID_RETURN;
+    const built = buildCellReturns(width, height, [
+      { row: 1, column: 2, record: 100, returnIndex: 0, returnCount: 2, sourceRange: 12.5 },
+      { row: 1, column: 2, record: 101, returnIndex: 1, returnCount: 2, sourceRange: 30.25 },
+    ]);
+    const cellToRecord = new Int32Array(width * height).fill(NO_RECORD);
+    cellToRecord[cellIndexOf(1, 2, width)] = 100;
+    return {
+      id: 'setup-two',
+      sourceKind: 'e57-structured',
+      width,
+      height,
+      cellState,
+      cellToRecord,
+      linkage: { kind: 'exact' },
+      diagnostics: tallyCellStates(cellState),
+      returnCellStart: built.returnCellStart,
+      returnRecord: built.returnRecord,
+      returnIndex: built.returnIndex,
+      returnCountDeclared: built.returnCountDeclared,
+      returnSourceRange: built.returnSourceRange,
+      returnsSkipped: built.skippedCount,
+    };
+  }
+
+  it('reverses EVERY record the cell lists, not only the primary', () => {
+    // The forward and reverse directions must agree about which records exist.
+    // Searching `cellToRecord` alone answered null for record 101 while
+    // `returnsForCell` listed it, so the second return of a pulse was reachable
+    // in one direction only.
+    const frame = twoReturnFrame();
+    const cell = cellIndexOf(1, 2, frame.width);
+    const listed = returnsForCell(frame, 1, 2);
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) throw new Error(listed.why);
+    expect(listed.returns.map((r) => r.record)).toEqual([100, 101]);
+    for (const r of listed.returns) {
+      expect(cellIndexForRecord(frame, r.record)).toBe(cell);
+    }
+  });
+
+  it('still answers null for a record the frame never produced', () => {
+    expect(cellIndexForRecord(twoReturnFrame(), 9999)).toBeNull();
+  });
+
+  it('answers null for every record once linkage is unavailable', () => {
+    const set: OrganizedRangeSet = {
+      kind: 'organized-range',
+      frames: [twoReturnFrame()],
+      organization: 'organized-grid',
+    };
+    const gone = withLinkageUnavailable(set, 'voxel-centroids').frames[0];
+    expect(cellIndexForRecord(gone, 101)).toBeNull();
+  });
+
+  it('keeps both distances of a two-return pulse', () => {
+    // 12.5 m and 30.25 m are two measurements, and one cell-level number
+    // described whichever the traversal reached last.
+    const listed = returnsForCell(twoReturnFrame(), 1, 2);
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) throw new Error(listed.why);
+    expect(listed.returns.map((r) => r.sourceRange)).toEqual([12.5, 30.25]);
+  });
+});
+
+describe('aggregating what several records say about one cell', () => {
+  it('gives the same state for either order of a valid and an invalid record', () => {
+    const forward = aggregateCellState(
+      aggregateCellState(CellState.SOURCE_RECORD_MISSING, CellState.VALID_RETURN),
+      CellState.SOURCE_INVALID,
+    );
+    const backward = aggregateCellState(
+      aggregateCellState(CellState.SOURCE_RECORD_MISSING, CellState.SOURCE_INVALID),
+      CellState.VALID_RETURN,
+    );
+    expect(forward).toBe(CellState.VALID_RETURN);
+    expect(backward).toBe(CellState.VALID_RETURN);
+  });
+
+  it('keeps SOURCE_INVALID when no record of the cell was usable', () => {
+    expect(
+      aggregateCellState(CellState.SOURCE_RECORD_MISSING, CellState.SOURCE_INVALID),
+    ).toBe(CellState.SOURCE_INVALID);
+  });
+});
+
+describe('a source that declared no return count', () => {
+  it('is distinguishable from a source that declared zero', () => {
+    const silent = buildCellReturns(1, 1, [
+      { row: 0, column: 0, record: 0, returnIndex: 0, returnCount: null, sourceRange: null },
+    ]);
+    const declaredZero = buildCellReturns(1, 1, [
+      { row: 0, column: 0, record: 0, returnIndex: 0, returnCount: 0, sourceRange: null },
+    ]);
+    // Absence is the missing array, never a zero written into one whose name
+    // asserts the source declared it.
+    expect(silent.returnCountDeclared).toBeUndefined();
+    expect(declaredZero.returnCountDeclared).toBeDefined();
+    expect([...declaredZero.returnCountDeclared!]).toEqual([0]);
   });
 });


### PR DESCRIPTION
`OrganizedRange` stored `returnIndex` and `returnCountDeclared` in `Uint16Array` while the E57 sink deliberately reports a 32-bit width when a file declares a maximum above 65535. A value the sink was built to hand over could not be held: 70000 stored as 4464, 65536 as 0, and because `buildCellReturns` sorts on those values, the records reordered as well.

They are `Uint32Array` now, and a value outside that range is refused as a scan contradiction rather than wrapped. The memory guard was counting final arrays, not peak, so it was corrected too: 26 bytes per cell against 18, and 92 per return against 72.

Cell state is aggregated over a cell's records rather than assigned by the last writer, so any permutation gives the same result and a cell can no longer read invalid while pointing at a valid record. Every record is reversible, and range is per return.
