### PR TITLE
feat(3dtiles): give a declared tileset a local frame, and say when there is none

### DIFF
--- a/src/geo/frame/frameProvenance.ts
+++ b/src/geo/frame/frameProvenance.ts
@@ -1,0 +1,111 @@
+/**
+ * frameProvenance.ts
+ *
+ * What a loaded cloud can say about the frame its coordinates came out of, in a
+ * record small enough to keep beside the cloud for its whole life.
+ *
+ * `spatialFrame.ts` performs the conversion. It deliberately refuses to decide
+ * that a source is geocentric, because nothing in a coordinate says so. This
+ * module holds the ANSWER a reader established from what its format declared,
+ * so the rest of the app reads one statement instead of re-deriving a guess per
+ * surface.
+ *
+ * Three fields carry the weight:
+ *
+ *   basis                what the render coordinates are, and how up is defined;
+ *   anchor               the source coordinate render zero was taken about, so
+ *                        the conversion is reversible rather than merely applied;
+ *   verticalReference    what a height in this cloud is measured from.
+ *
+ * UNKNOWN IS A VALUE, NOT AN ABSENT ONE. A reader that could not establish the
+ * frame records `unknown` and a vertical reference of `unknown`, and every
+ * consumer of a height can then refuse rather than average a rotation that was
+ * never applied into a slope. A record that was simply missing would be read as
+ * "nobody asked yet", which is a different fact.
+ *
+ * THE UNIT SURVIVES AN UNRESOLVED FRAME. Whether the frame is known and what
+ * the linear unit is are separate questions, and a format that establishes
+ * metres for linear distances has established them whether or not its frame is
+ * resolved. Dropping the unit alongside the frame would lose a fact the source
+ * actually stated.
+ *
+ * Pure — no DOM, no three.js, no I/O.
+ */
+
+import type { CrsLinearUnit } from '../../io/crs';
+import type { VerticalReference } from '../height';
+import type { Vec3 } from './spatialFrame';
+
+/**
+ * What the render coordinates of a cloud are.
+ *
+ * `local-enu`   — rotated into an east-north-up frame tangent to the WGS84
+ *                 ellipsoid beneath {@link CloudFrameProvenance.anchor}, so
+ *                 render +Z is local up and a height is a height.
+ * `unknown`     — the source's own axes, recentred and not rotated, with no
+ *                 established statement of which way is up.
+ */
+export type CloudFrameBasis = 'local-enu' | 'unknown';
+
+/** What a cloud can say about the frame it is drawn in. */
+export interface CloudFrameProvenance {
+  readonly basis: CloudFrameBasis;
+  /**
+   * The declaration the basis was established from, verbatim enough to audit.
+   * `null` when no declaration was found, which is the only reason a basis is
+   * `unknown`: it is never a failure to apply a basis that was established.
+   */
+  readonly declaredBy: string | null;
+  /**
+   * The source coordinate render zero was taken about, present only for a
+   * resolved basis. With it, the frame that produced the cloud can be rebuilt
+   * and a render coordinate carried back to the source frame exactly.
+   */
+  readonly anchor?: Vec3;
+  readonly verticalReference: VerticalReference;
+  /** Linear unit of the render coordinates. Independent of the basis. */
+  readonly linearUnit: CrsLinearUnit;
+}
+
+/**
+ * Whether a height, slope or terrain derivative taken from this cloud is
+ * measured along a known up.
+ *
+ * The question is asked of the BASIS, not of the anchor: a recentred cloud has
+ * an origin and still has no established up, and reading the presence of an
+ * origin as permission is exactly the confusion this record exists to end.
+ */
+export function frameHasVerticalMeaning(p: CloudFrameProvenance): boolean {
+  return p.basis === 'local-enu' && p.verticalReference !== 'unknown';
+}
+
+/**
+ * One line naming the basis, the vertical reference and the unit, in the order
+ * a reader needs them: what the axes are, what a height is measured from, and
+ * what the numbers are counted in.
+ */
+export function describeCloudFrame(p: CloudFrameProvenance): string {
+  const basis =
+    p.basis === 'local-enu' ? 'Local east-north-up' : 'Frame not established';
+  const vertical =
+    p.verticalReference === 'ellipsoidal'
+      ? 'ellipsoidal height'
+      : p.verticalReference === 'unknown'
+        ? 'no vertical reference'
+        : `${p.verticalReference} height`;
+  const unit = p.linearUnit === 'unknown' ? 'unit unknown' : `${p.linearUnit}s`;
+  return `${basis}, ${vertical}, ${unit}`;
+}
+
+/**
+ * What an unestablished frame means for anything measured up the Z axis.
+ *
+ * Stated as a consequence rather than as a status, because the scene looks
+ * correct either way: a cloud whose axes were never rotated into a tangent
+ * frame fits the camera and draws exactly as a levelled one does, and the only
+ * visible difference is in the numbers read off it.
+ */
+export const FRAME_UNKNOWN_NOTE =
+  'This source declares no coordinate frame, so which way is up is not ' +
+  'established. Heights, slopes and terrain derivatives taken from it are ' +
+  'measured along an axis that may not be vertical.';

--- a/src/io/tiles3d/tilesetCloud.ts
+++ b/src/io/tiles3d/tilesetCloud.ts
@@ -32,10 +32,23 @@
  * the transform again here would square it, which for the ECEF placements this
  * format is usually authored in puts the cloud somewhere no test with an
  * identity fixture would ever notice.
+ *
+ * The ROTATION, on the other hand, is done here and nowhere else. Those root
+ * frame coordinates are Cartesian but not necessarily Z-up: where the document
+ * declares a geocentric root frame, +Z is the polar axis, and subtracting an
+ * origin from such a cloud improves its precision without making any of its
+ * axes vertical. `tilesetFrame.ts` reads the declaration and builds the local
+ * east-north-up frame; the points are carried through it before the recentring,
+ * and the frame is kept on the cloud so a render coordinate can be taken back
+ * to the source frame exactly. A tileset that declares nothing is recentred and
+ * recorded as having no established up, which is a fact the layer carries
+ * rather than a gap it hides.
  */
 
 import { PointCloud } from '../../model/PointCloud';
 import { sanitizeAndRecenter, withLoadWarning } from '../sanitizeCloud';
+import { FRAME_UNKNOWN_NOTE } from '../../geo/frame/frameProvenance';
+import { finiteExtentCentre, resolveTilesetFrame } from './tilesetFrame';
 import { openTileset, selectTileContents, fetchTileContent } from './tilesetOpen';
 import type { TilesetTransport } from './tilesetTransport';
 import type { ViewCamera } from './tilesetTraversal';
@@ -180,6 +193,24 @@ export async function loadTilesetCloud(
   }
   const mixedColour = !everyTileHasColour && placed.some((p) => p.colors !== null);
 
+  // The rotation, in place, in Float64, BEFORE the recentring. The anchor is
+  // subtracted inside the frame, so the multiply only ever sees a residual of a
+  // few kilometres rather than an ECEF coordinate whose low digits would not
+  // survive it. `resolveTilesetFrame` returns no frame when the document
+  // declares no geocentric root frame, and the loop is then skipped entirely:
+  // the merged coordinates go to the recentring exactly as the tiles produced
+  // them, and the layer records that its up axis is not established.
+  const resolved = resolveTilesetFrame(opened.tileset, finiteExtentCentre(merged));
+  const { frame } = resolved;
+  if (frame) {
+    for (let i = 0; i + 2 < merged.length; i += 3) {
+      const [e, n, u] = frame.sourceToRenderPoint([merged[i]!, merged[i + 1]!, merged[i + 2]!]);
+      merged[i] = e;
+      merged[i + 1] = n;
+      merged[i + 2] = u;
+    }
+  }
+
   // Destructured rather than read as `.positions`: the position-access gate
   // counts direct reads of that property and is shrink-only, and a sanitation
   // result is not the `PointCloud` buffer that gate is about.
@@ -190,6 +221,11 @@ export async function loadTilesetCloud(
   const mixedWarning = mixedColour
     ? 'Some tiles in this tileset carry colour and others do not, so the merged layer is uncoloured.'
     : undefined;
+  // Carried as a warning as well as in the frame record. The record is what a
+  // consumer reads to refuse a vertical measurement; the warning is what says
+  // so on the Scan Report, where a user deciding whether to trust an elevation
+  // is actually looking.
+  const frameWarning = resolved.provenance.basis === 'unknown' ? FRAME_UNKNOWN_NOTE : undefined;
   return new PointCloud({
     positions,
     colors: attributes.colors,
@@ -199,6 +235,12 @@ export async function loadTilesetCloud(
     // it is; the tileset is how they were found, not what they are.
     sourceFormat: 'pnts',
     name: options.name ?? tilesetDisplayName(opened.entryUrl),
-    metadata: withLoadWarning(withLoadWarning(undefined, warning), mixedWarning),
+    metadata: {
+      ...withLoadWarning(
+        withLoadWarning(withLoadWarning(undefined, warning), mixedWarning),
+        frameWarning,
+      ),
+      frame: resolved.provenance,
+    },
   });
 }

--- a/src/io/tiles3d/tilesetFrame.ts
+++ b/src/io/tiles3d/tilesetFrame.ts
@@ -1,0 +1,172 @@
+/**
+ * tilesetFrame.ts — which frame a 3D Tiles tileset places its points in.
+ *
+ * A tileset's root space is Cartesian and the specification says Z is up for a
+ * LOCAL one. It does not say a tileset IS local, and the common authoring for a
+ * globe-scale dataset is WGS84 geocentric (EPSG:4978), where +Z is the polar
+ * axis and local up is roughly the ellipsoid normal. The two differ by the
+ * co-latitude: at 25°N that is over sixty degrees. A cloud recentred out of
+ * ECEF and never rotated fits the camera and draws as a plausible scene, and
+ * every height, slope, terrain derivative and up-dependent clip taken off it is
+ * measured along an axis that is not vertical.
+ *
+ * WHAT COUNTS AS A DECLARATION, and why the magnitudes are not one.
+ *
+ * A `region` bounding volume is stated in EPSG:4979 geographic coordinates and
+ * is the one volume form the tile transform does NOT apply to (see
+ * `tileTransform.ts`). It is therefore an absolute geographic statement about
+ * where the tile's TRANSFORMED content lies, which is only meaningful if the
+ * transformed content is in the global geocentric frame those coordinates are
+ * defined against. A tileset carrying one has declared its root frame; that is
+ * the declaration this module reads.
+ *
+ * What it will NOT read is the size of the numbers. A coordinate near the
+ * Earth's radius may be ECEF, and it may equally be a projected grid with a
+ * large false easting or a local model authored far from its own origin.
+ * Nothing separates those by magnitude, and a detector that guessed would put
+ * a fabricated vertical datum into every report downstream. A tileset that
+ * declares nothing is UNKNOWN, and stays unknown.
+ *
+ * WHAT SURVIVES AN UNKNOWN FRAME. The unit does. 3D Tiles establishes metres
+ * for linear distances regardless of which CRS a particular tileset sits in, so
+ * an unresolved frame is recorded with a vertical reference of `unknown` and a
+ * linear unit of `metre`. Discarding the unit alongside the frame would throw
+ * away a fact the format actually states.
+ *
+ * Pure: no fetch, no DOM, no renderer types. Float64 throughout.
+ */
+
+import { createLocalEnuFrame, type SpatialFrame, type Vec3 } from '../../geo/frame/spatialFrame';
+import type { CloudFrameProvenance } from '../../geo/frame/frameProvenance';
+import type { Tile, Tileset } from './tileset';
+
+/** The declaration text recorded when a region bounding volume establishes the frame. */
+export const REGION_DECLARES_GEOCENTRIC =
+  'region bounding volume (EPSG:4979), which fixes the root frame as WGS84 geocentric';
+
+/** What the document itself says about its root frame. */
+export interface TilesetFrameDeclaration {
+  /** True only when the document states it, never when the coordinates suggest it. */
+  readonly geocentric: boolean;
+  /** The statement that established it, or `null` when nothing did. */
+  readonly declaredBy: string | null;
+}
+
+/** Six finite numbers, the shape `parseTileset` accepts for a region. */
+function isRegion(volume: { readonly region?: readonly number[] }): boolean {
+  const r = volume.region;
+  return Array.isArray(r) && r.length === 6 && r.every((v) => Number.isFinite(v));
+}
+
+/**
+ * Read the tileset's own statement about its root frame.
+ *
+ * The whole tree is walked rather than the root alone: a root may carry a box
+ * or a sphere while its children carry regions, and a region anywhere in the
+ * tree makes the same absolute geographic statement about the frame all of them
+ * share. The walk is iterative and the tree is already bounded in depth and
+ * count by `parseTileset`, so it terminates on any document that parsed.
+ */
+export function declaredTilesetFrame(tileset: Tileset): TilesetFrameDeclaration {
+  const stack: Tile[] = [tileset.root];
+  while (stack.length > 0) {
+    const tile = stack.pop()!;
+    if (isRegion(tile.boundingVolume)) {
+      return { geocentric: true, declaredBy: REGION_DECLARES_GEOCENTRIC };
+    }
+    for (const child of tile.children) stack.push(child);
+  }
+  return { geocentric: false, declaredBy: null };
+}
+
+/** A frame to draw a tileset in, with the record of how it was arrived at. */
+export interface ResolvedTilesetFrame {
+  /**
+   * The conversion from root-frame coordinates to render coordinates, or `null`
+   * when the frame was not established.
+   *
+   * `null` rather than a translated stand-in on purpose. A caller that recentres
+   * has done something a frame object would make look like a decision, and the
+   * absence is what forces it to record `unknown` instead of an up axis it
+   * never established.
+   */
+  readonly frame: SpatialFrame | null;
+  readonly provenance: CloudFrameProvenance;
+}
+
+/**
+ * Resolve the frame a tileset's merged points should be drawn in.
+ *
+ * `anchor` is a root-frame coordinate inside the data — the centre of its
+ * extent is what the caller has — and it becomes the tangent point of the ENU
+ * frame. It is refused when it is not finite, and at the geocentre, where the
+ * ellipsoid normal is not defined and any rotation would be arbitrary. Both
+ * refusals produce `unknown`, never a frame built on a guessed anchor.
+ */
+export function resolveTilesetFrame(
+  tileset: Tileset,
+  anchor: Vec3 | null,
+): ResolvedTilesetFrame {
+  const declaration = declaredTilesetFrame(tileset);
+  const usable =
+    anchor !== null &&
+    anchor.every((v) => Number.isFinite(v)) &&
+    Math.hypot(anchor[0], anchor[1], anchor[2]) > 0;
+  if (!declaration.geocentric || !usable) {
+    return {
+      frame: null,
+      provenance: {
+        basis: 'unknown',
+        declaredBy: null,
+        verticalReference: 'unknown',
+        linearUnit: 'metre',
+      },
+    };
+  }
+  return {
+    frame: createLocalEnuFrame(anchor),
+    provenance: {
+      basis: 'local-enu',
+      declaredBy: declaration.declaredBy,
+      anchor: [anchor[0], anchor[1], anchor[2]],
+      // Heights in an ENU frame tangent to the WGS84 ellipsoid are heights
+      // above that ellipsoid. 3D Tiles carries no vertical datum, so this is
+      // the only reference available and never becomes an orthometric one.
+      verticalReference: 'ellipsoidal',
+      linearUnit: 'metre',
+    },
+  };
+}
+
+/**
+ * The mid-point of the finite extent of interleaved xyz triples, or `null` when
+ * no point is finite.
+ *
+ * The extent mid-point rather than the mean: it is decided by the two extreme
+ * coordinates on each axis and so does not move when tiles of very different
+ * point counts are merged, which keeps the anchor (and with it the rotation,
+ * and every render coordinate) the same for the same geometry.
+ *
+ * Non-finite coordinates are skipped instead of poisoning the result. They are
+ * removed further down by `sanitizeAndRecenter`, but the anchor is chosen
+ * before that runs, and a NaN anchor would rotate every point in the cloud to
+ * NaN and lose the whole scene rather than one bad point.
+ */
+export function finiteExtentCentre(xyz: Float64Array): Vec3 | null {
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  let seen = false;
+  for (let i = 0; i + 2 < xyz.length; i += 3) {
+    const x = xyz[i]!, y = xyz[i + 1]!, z = xyz[i + 2]!;
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
+    seen = true;
+    if (x < min[0]!) min[0] = x;
+    if (y < min[1]!) min[1] = y;
+    if (z < min[2]!) min[2] = z;
+    if (x > max[0]!) max[0] = x;
+    if (y > max[1]!) max[1] = y;
+    if (z > max[2]!) max[2] = z;
+  }
+  if (!seen) return null;
+  return [(min[0]! + max[0]!) / 2, (min[1]! + max[1]!) / 2, (min[2]! + max[2]!) / 2];
+}

--- a/src/model/PointCloud.ts
+++ b/src/model/PointCloud.ts
@@ -1,5 +1,6 @@
 import type { SourceFormat } from '../io/sniffFormat';
 import type { CrsInfo } from '../io/crs';
+import type { CloudFrameProvenance } from '../geo/frame/frameProvenance';
 import type { OrganizedRangeSet } from './OrganizedRange';
 
 /**
@@ -60,6 +61,22 @@ export interface CloudMetadata {
    * rely on this for distance-in-true-metres and CRS provenance display.
    */
   crs?: CrsInfo | null;
+  /**
+   * What the source declared about the frame these coordinates sit in, and
+   * therefore whether a height taken from them is measured along a known up.
+   *
+   * Distinct from {@link crs}, which is a CRS a header named. A format can fix
+   * the frame without naming a CRS — a 3D Tiles tileset whose bounding volumes
+   * are geographic regions is placed in WGS84 geocentric coordinates and
+   * carries no CRS string anywhere — and the reader that rotated such a cloud
+   * into a local east-north-up frame records the tangent point here so the
+   * rotation stays reversible.
+   *
+   * Absent for the formats that do not resolve a frame at all. A basis of
+   * `unknown` is a stronger statement than absence: it says a reader looked and
+   * the source declared nothing.
+   */
+  frame?: CloudFrameProvenance;
   /**
    * Non-fatal anomalies the loader worked around rather than failing on —
    * e.g. an E57 scan skipped because it carries no Cartesian X/Y/Z, or a

--- a/tests/tilesetSpatialFrame.test.ts
+++ b/tests/tilesetSpatialFrame.test.ts
@@ -1,0 +1,324 @@
+/**
+ * tilesetSpatialFrame.test.ts — a tileset's points land in a frame that knows
+ * which way is up, or say they do not.
+ *
+ * The failure this file exists to catch leaves no visual trace. A tileset
+ * authored in WGS84 geocentric coordinates, recentred and never rotated, fits
+ * the camera and draws as a plausible scene; only the numbers read off it are
+ * wrong, because +Z there is the polar axis and not local up.
+ *
+ * So the fixture is placed at Monterrey, 25.6866°N 100.3161°W, where the two
+ * axes are 64.3° apart. A fixture on the equator at longitude zero has them
+ * coincide, and every assertion below would pass against a reader that only
+ * subtracts an origin.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { loadTilesetCloud } from '../src/io/tiles3d/tilesetCloud';
+import {
+  declaredTilesetFrame,
+  finiteExtentCentre,
+  resolveTilesetFrame,
+} from '../src/io/tiles3d/tilesetFrame';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import { geodeticToEcef } from '../src/io/tiles3d/boundingVolume';
+import { createLocalEnuFrame, createTranslatedFrame } from '../src/geo/frame/spatialFrame';
+import { describeCloudFrame, frameHasVerticalMeaning } from '../src/geo/frame/frameProvenance';
+import type { TilesetTransport } from '../src/io/tiles3d/tilesetTransport';
+
+const ENTRY = 'https://tiles.example.org/scan/a/tileset.json';
+const BASE = 'https://tiles.example.org/scan/a/';
+const PNTS_MAGIC = 0x73746e70; // 'pnts', little-endian
+
+const DEG = Math.PI / 180;
+/** Monterrey. Chosen because ECEF +Z and local up are far apart here. */
+const LAT = 25.6866 * DEG;
+const LON = -100.3161 * DEG;
+const HEIGHT = 540;
+
+const ANCHOR = geodeticToEcef(LON, LAT, HEIGHT);
+
+/** The ellipsoid normal at the fixture, in ECEF. This is what "up" means there. */
+const UP_ECEF: [number, number, number] = [
+  Math.cos(LAT) * Math.cos(LON),
+  Math.cos(LAT) * Math.sin(LON),
+  Math.sin(LAT),
+];
+/** East at the fixture, in ECEF. */
+const EAST_ECEF: [number, number, number] = [-Math.sin(LON), Math.cos(LON), 0];
+
+function angleDeg(a: readonly number[], b: readonly number[]): number {
+  const dot = a[0]! * b[0]! + a[1]! * b[1]! + a[2]! * b[2]!;
+  const la = Math.hypot(a[0]!, a[1]!, a[2]!);
+  const lb = Math.hypot(b[0]!, b[1]!, b[2]!);
+  return (Math.acos(Math.min(1, Math.max(-1, dot / (la * lb)))) * 180) / Math.PI;
+}
+
+/** A minimal PNTS tile: 28-byte header, feature-table JSON, feature-table binary. */
+function makePnts(
+  points: readonly (readonly [number, number, number])[],
+  rtc?: readonly [number, number, number],
+): ArrayBuffer {
+  const ft: Record<string, unknown> = { POINTS_LENGTH: points.length, POSITION: { byteOffset: 0 } };
+  if (rtc) ft.RTC_CENTER = rtc;
+  let json = JSON.stringify(ft);
+  while (json.length % 8 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const binBytes = points.length * 3 * 4;
+  const total = 28 + jsonBytes.length + binBytes;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, PNTS_MAGIC, true);
+  view.setUint32(4, 1, true);
+  view.setUint32(8, total, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, binBytes, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buf, 28, jsonBytes.length).set(jsonBytes);
+  const binStart = 28 + jsonBytes.length;
+  let k = 0;
+  for (const p of points) for (const c of p) view.setFloat32(binStart + k++ * 4, c, true);
+  return buf;
+}
+
+function fakeTransport(
+  json: Record<string, string>,
+  tiles: Record<string, ArrayBuffer>,
+): TilesetTransport {
+  return {
+    fetchTilesetJson: async (url) => {
+      const body = json[url];
+      if (body === undefined) throw new Error(`no tileset at ${url}`);
+      return body;
+    },
+    fetchTileBytes: async (url) => {
+      const body = tiles[url];
+      if (body === undefined) throw new Error(`no tile at ${url}`);
+      return body;
+    },
+  };
+}
+
+/** A patch of the ellipsoid around the fixture, in EPSG:4979 radians and metres. */
+const REGION = [LON - 0.001, LAT - 0.001, LON + 0.001, LAT + 0.001, 0, 2000];
+/** A Cartesian volume wide enough to hold the tile, declaring nothing about the frame. */
+const BOX = [ANCHOR[0], ANCHOR[1], ANCHOR[2], 1000, 0, 0, 0, 1000, 0, 0, 0, 1000];
+
+/**
+ * Three points on the ground at the fixture: the anchor, one 100 m along the
+ * local ellipsoid normal, one 50 m east.
+ *
+ * They are carried as an `RTC_CENTER` at the anchor plus small local offsets,
+ * which is how a real tileset states them and what keeps the float32 position
+ * block precise. The result reaching the merge is the anchor plus the offset,
+ * in the tileset's root frame.
+ */
+const OFFSETS: [number, number, number][] = [
+  [0, 0, 0],
+  [UP_ECEF[0] * 100, UP_ECEF[1] * 100, UP_ECEF[2] * 100],
+  [EAST_ECEF[0] * 50, EAST_ECEF[1] * 50, EAST_ECEF[2] * 50],
+];
+
+function fixture(volume: Record<string, unknown>): {
+  json: Record<string, string>;
+  tiles: Record<string, ArrayBuffer>;
+} {
+  return {
+    json: {
+      [ENTRY]: JSON.stringify({
+        asset: { version: '1.1' },
+        geometricError: 100,
+        root: {
+          boundingVolume: volume,
+          geometricError: 0,
+          refine: 'REPLACE',
+          content: { uri: 'a.pnts' },
+        },
+      }),
+    },
+    tiles: { [`${BASE}a.pnts`]: makePnts(OFFSETS, ANCHOR) },
+  };
+}
+
+/** Point `i` of a loaded cloud, back in the cloud's own render coordinates. */
+function renderPoint(
+  cloud: { positions: Float32Array; origin: [number, number, number] },
+  i: number,
+): [number, number, number] {
+  const [ox, oy, oz] = cloud.origin;
+  return [
+    cloud.positions[i * 3]! + ox,
+    cloud.positions[i * 3 + 1]! + oy,
+    cloud.positions[i * 3 + 2]! + oz,
+  ];
+}
+
+describe('the fixture separates the two axes', () => {
+  test('ECEF +Z and local up are 64.3° apart at the fixture', () => {
+    // Analytically the co-latitude: the ellipsoid normal makes an angle of
+    // 90° − φ with the polar axis. An assertion at a fixture where this were
+    // near zero would hold against a reader that never rotated anything.
+    expect(angleDeg([0, 0, 1], UP_ECEF)).toBeCloseTo(90 - 25.6866, 9);
+    expect(angleDeg([0, 0, 1], UP_ECEF)).toBeGreaterThan(60);
+  });
+});
+
+describe('a declared geocentric tileset is drawn in a local ENU frame', () => {
+  test('the cloud up axis is local up, not ECEF +Z', async () => {
+    const f = fixture({ region: REGION });
+    const cloud = await loadTilesetCloud(ENTRY, fakeTransport(f.json, f.tiles));
+    expect(cloud.pointCount).toBe(3);
+
+    const base = renderPoint(cloud, 0);
+    const vertical = renderPoint(cloud, 1);
+    const eastward = renderPoint(cloud, 2);
+    const up: [number, number, number] = [
+      vertical[0] - base[0],
+      vertical[1] - base[1],
+      vertical[2] - base[2],
+    ];
+    const east: [number, number, number] = [
+      eastward[0] - base[0],
+      eastward[1] - base[1],
+      eastward[2] - base[2],
+    ];
+
+    // The 100 m along the ellipsoid normal is 100 m of render Z and nothing
+    // else. Without the rotation this vector is the ECEF normal itself, which
+    // at this latitude puts most of its length in X and Y.
+    expect(angleDeg(up, [0, 0, 1])).toBeLessThan(0.01);
+    expect(up[2]).toBeCloseTo(100, 1);
+    expect(Math.hypot(up[0], up[1])).toBeLessThan(0.05);
+
+    // And the 50 m east is horizontal, which is the same statement read the
+    // other way round: a frame that got up right and the horizontal plane
+    // wrong is not a frame.
+    expect(east[0]).toBeCloseTo(50, 1);
+    expect(Math.abs(east[2])).toBeLessThan(0.05);
+
+    expect(cloud.metadata?.frame?.basis).toBe('local-enu');
+    expect(cloud.metadata?.frame?.verticalReference).toBe('ellipsoidal');
+    expect(cloud.metadata?.frame?.linearUnit).toBe('metre');
+    expect(cloud.metadata?.frame?.declaredBy).toMatch(/region bounding volume/);
+    expect(frameHasVerticalMeaning(cloud.metadata!.frame!)).toBe(true);
+  });
+
+  test('a region on a child declares the frame the whole tree shares', () => {
+    const tileset = parseTileset({
+      asset: { version: '1.1' },
+      geometricError: 100,
+      root: {
+        boundingVolume: { box: BOX },
+        geometricError: 10,
+        refine: 'REPLACE',
+        children: [{ boundingVolume: { region: REGION }, geometricError: 0 }],
+      },
+    });
+    expect(declaredTilesetFrame(tileset).geocentric).toBe(true);
+  });
+});
+
+describe('the frame is reversible', () => {
+  test('an ECEF coordinate survives the round trip to a millimetre', () => {
+    const frame = createLocalEnuFrame(ANCHOR);
+    // Points across a kilometre of the fixture, which is the scale a one-shot
+    // tileset read covers, plus the anchor itself.
+    const samples: [number, number, number][] = [
+      [ANCHOR[0], ANCHOR[1], ANCHOR[2]],
+      [ANCHOR[0] + 1000, ANCHOR[1] - 250, ANCHOR[2] + 700],
+      [ANCHOR[0] - 3210.5, ANCHOR[1] + 44.25, ANCHOR[2] - 918.75],
+    ];
+    for (const p of samples) {
+      const back = frame.renderToSourcePoint(frame.sourceToRenderPoint(p));
+      // 1e-6 m. The residual is Float64 rounding on a coordinate of 6.4e6 m,
+      // where one ulp is about 1e-9 m, so the tolerance is six orders of
+      // magnitude above the noise and still far below anything a survey cares
+      // about.
+      for (let i = 0; i < 3; i++) expect(Math.abs(back[i]! - p[i]!)).toBeLessThan(1e-6);
+    }
+  });
+
+  test('the recorded anchor rebuilds the frame the cloud was drawn in', async () => {
+    const f = fixture({ region: REGION });
+    const cloud = await loadTilesetCloud(ENTRY, fakeTransport(f.json, f.tiles));
+    const anchor = cloud.metadata?.frame?.anchor;
+    expect(anchor).toBeDefined();
+    // The provenance is only reversible if the anchor it kept is the one the
+    // rotation used. Rebuilding the frame from it and undoing the render
+    // coordinate has to land back on the tile's own ECEF position.
+    const rebuilt = createLocalEnuFrame(anchor!);
+    const recovered = rebuilt.renderToSourcePoint(renderPoint(cloud, 0));
+    for (let i = 0; i < 3; i++) expect(Math.abs(recovered[i]! - ANCHOR[i]!)).toBeLessThan(0.01);
+  });
+});
+
+describe('an undeclared frame stays unknown', () => {
+  test('a tileset with no region claims no vertical reference', async () => {
+    const f = fixture({ box: BOX });
+    const cloud = await loadTilesetCloud(ENTRY, fakeTransport(f.json, f.tiles));
+    const frame = cloud.metadata?.frame;
+    expect(frame?.basis).toBe('unknown');
+    expect(frame?.verticalReference).toBe('unknown');
+    expect(frame?.declaredBy).toBeNull();
+    expect(frame?.anchor).toBeUndefined();
+    expect(frameHasVerticalMeaning(frame!)).toBe(false);
+    expect(describeCloudFrame(frame!)).toBe('Frame not established, no vertical reference, metres');
+    // The unit is a separate fact and the tileset states it. An unresolved
+    // frame does not un-state it.
+    expect(frame?.linearUnit).toBe('metre');
+    expect(cloud.metadata?.loadWarnings?.join(' ')).toMatch(/which way is up is not established/);
+  });
+
+  test('a large coordinate is not a declaration', () => {
+    // The fixture's coordinates are 6.4 million metres from the origin and
+    // sit inside a Cartesian box. A reader that decided from magnitude would
+    // call this geocentric and invent an ellipsoidal height for a cloud that
+    // may be a projected grid with a large false easting.
+    const tileset = parseTileset({
+      asset: { version: '1.1' },
+      geometricError: 100,
+      root: { boundingVolume: { box: BOX }, geometricError: 0, refine: 'REPLACE' },
+    });
+    expect(declaredTilesetFrame(tileset)).toEqual({ geocentric: false, declaredBy: null });
+    expect(resolveTilesetFrame(tileset, ANCHOR).frame).toBeNull();
+    expect(resolveTilesetFrame(tileset, ANCHOR).provenance.basis).toBe('unknown');
+  });
+
+  test('a declared frame with no usable anchor stays unknown rather than guessing one', () => {
+    const tileset = parseTileset({
+      asset: { version: '1.1' },
+      geometricError: 100,
+      root: { boundingVolume: { region: REGION }, geometricError: 0, refine: 'REPLACE' },
+    });
+    // The geocentre has no ellipsoid normal, so there is no tangent frame to
+    // build and no rotation that would be less arbitrary than another.
+    expect(resolveTilesetFrame(tileset, [0, 0, 0]).provenance.basis).toBe('unknown');
+    expect(resolveTilesetFrame(tileset, null).provenance.basis).toBe('unknown');
+    expect(finiteExtentCentre(new Float64Array([NaN, NaN, NaN]))).toBeNull();
+  });
+});
+
+describe('recentring alone never sets an up axis', () => {
+  test('an unrotated cloud is a pure translation of the source coordinates', async () => {
+    const f = fixture({ box: BOX });
+    const cloud = await loadTilesetCloud(ENTRY, fakeTransport(f.json, f.tiles));
+    // Every render coordinate is the ECEF coordinate minus the origin, exactly.
+    // Nothing turned; that is the whole point of recording the frame as unknown.
+    for (let i = 0; i < 3; i++) {
+      const p = renderPoint(cloud, i);
+      for (let k = 0; k < 3; k++) {
+        expect(Math.abs(p[k]! - (ANCHOR[k]! + OFFSETS[i]![k]!))).toBeLessThan(0.05);
+      }
+    }
+  });
+
+  test('a translated frame reports the source axis, which here is 64.3° off up', () => {
+    const translated = createTranslatedFrame(ANCHOR);
+    expect(translated.isTranslationOnly).toBe(true);
+    // Its up is the source's own +Z. Calling that vertical at this fixture is
+    // the defect: it is more than sixty degrees away from the ellipsoid normal.
+    expect(angleDeg(translated.renderWorldUp(), UP_ECEF)).toBeCloseTo(90 - 25.6866, 6);
+    expect(angleDeg(createLocalEnuFrame(ANCHOR).renderWorldUp(), [0, 0, 1])).toBeCloseTo(0, 9);
+  });
+});


### PR DESCRIPTION
A tileset was recentred and mounted as an ordinary cloud. Subtracting a large origin improves precision but rotates nothing, so a geocentric tileset arrived with ECEF +Z standing in for local up. At Monterrey those differ by 64.3 degrees, which every height, slope and vertical measurement then inherits.

A tileset whose frame is declared now carries a local ENU frame built by the existing `createLocalEnuFrame`, with the anchor recorded so the transform is reversible.

The declaration is read, never guessed. A `region` bounding volume is stated in EPSG:4979 and is the one volume the tile transform does not apply to, so it fixes the root frame. Nothing else in the format declares one, so a tileset bounded only by boxes or spheres stays unknown, records that, and warns what it means for vertical results. Metres are recorded either way, because the specification establishes the unit independently of the frame.
