### PR TITLE
fix(scripts): resolve symlinks when detecting a CLI entry

### DIFF
--- a/scripts/build-cross-implementation-summary.mjs
+++ b/scripts/build-cross-implementation-summary.mjs
@@ -33,6 +33,7 @@
 import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 import {
   byCodeUnit,
@@ -162,7 +163,7 @@ export function selfCheckProblems(summary) {
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/build-defect-chronology.mjs
+++ b/scripts/build-defect-chronology.mjs
@@ -27,6 +27,7 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { requireBinaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 // Spawned programs are resolved to an absolute path by reading PATH, so the
 // path that runs is a value this script can name rather than whatever the OS
@@ -467,4 +468,4 @@ function main() {
   process.exit(check && stale > 0 ? 1 : 0);
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();
+if (isCliEntry(import.meta.url)) main();

--- a/scripts/build-impact-summary.mjs
+++ b/scripts/build-impact-summary.mjs
@@ -35,6 +35,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 
 import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 import {
   verifyImpactRecords,
   UNCOUNTED_STATUSES,
@@ -133,7 +134,7 @@ export function selfCheckProblems(summary) {
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/build-validation-snapshot.mjs
+++ b/scripts/build-validation-snapshot.mjs
@@ -36,6 +36,7 @@ import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { INPUTS, evidencePath, sha256, deriveSnapshot, renderSummary } from './validation-snapshot-lib.mjs';
 import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -190,7 +191,7 @@ function main() {
   return snapshot.verdict === 'PASS' ? 0 : 1;
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   try {
     process.exit(main());
   } catch (err) {

--- a/scripts/collect-evidence.mjs
+++ b/scripts/collect-evidence.mjs
@@ -29,6 +29,7 @@ import { createHash } from 'node:crypto';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { requireBinaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 // Spawned programs are resolved to an absolute path by reading PATH, so the
 // path that runs is a value this script can name rather than whatever the OS
@@ -557,4 +558,4 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (isCliEntry(import.meta.url)) main();

--- a/scripts/collect-mutation-evidence.mjs
+++ b/scripts/collect-mutation-evidence.mjs
@@ -24,6 +24,7 @@ import { execFileSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { requireBinaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 // Spawned programs are resolved to an absolute path by reading PATH, so the
 // path that runs is a value this script can name rather than whatever the OS
@@ -145,4 +146,4 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (isCliEntry(import.meta.url)) main();

--- a/scripts/create-release-manifest.mjs
+++ b/scripts/create-release-manifest.mjs
@@ -32,6 +32,7 @@ import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from '
 import { createHash } from 'node:crypto';
 import { resolve, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -167,7 +168,7 @@ function sha256File(path) {
 }
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/generate-descriptor-crosscheck.mjs
+++ b/scripts/generate-descriptor-crosscheck.mjs
@@ -33,6 +33,7 @@ import { fileURLToPath } from 'node:url';
 import { platform, arch } from 'node:process';
 import { binaryOnPath } from './lib/binaryOnPath.mjs';
 import { N, CELL, TPI_C, VRM_A, VRM_C, coord } from './descriptor-fixture-params.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT = resolve(ROOT, 'validation/cross-implementation/descriptor');
@@ -144,4 +145,4 @@ function main() {
   process.stdout.write(`descriptor fixtures + references written to ${rel(OUT)} (tpi exit ${tpiRun.code}, vrm saga exit ${sagaRun.code})\n`);
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) main();
+if (isCliEntry(import.meta.url)) main();

--- a/scripts/generate-point-cloud-fixtures.mjs
+++ b/scripts/generate-point-cloud-fixtures.mjs
@@ -115,6 +115,7 @@ import { writeFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -537,6 +538,6 @@ export function readFixture(id) {
   return { points: parseFixtureCsv(csv), truth: parseTruth(tru) };
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   main();
 }

--- a/scripts/generate-raster-fixtures.mjs
+++ b/scripts/generate-raster-fixtures.mjs
@@ -49,6 +49,7 @@
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -733,6 +734,6 @@ function main() {
 }
 
 // Only write files when run directly; the test imports the surface definitions.
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   main();
 }

--- a/scripts/lib/isCliEntry.d.mts
+++ b/scripts/lib/isCliEntry.d.mts
@@ -1,0 +1,5 @@
+/**
+ * Types for isCliEntry.mjs, which the CLI-entry test imports.
+ * Mirrors the arrangement already used for binaryOnPath.d.mts.
+ */
+export declare function isCliEntry(moduleUrl: string, argv1?: string): boolean;

--- a/scripts/lib/isCliEntry.mjs
+++ b/scripts/lib/isCliEntry.mjs
@@ -1,0 +1,48 @@
+/**
+ * isCliEntry.mjs — decide whether this module is the program Node was asked to run.
+ *
+ * The usual form of that check compares two paths:
+ *
+ *   resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))
+ *
+ * Those two sides are not produced the same way. `import.meta.url` comes from
+ * the ESM loader, which has already followed every symlink on the way to the
+ * file, so it always names the real path. `process.argv[1]` is whatever the
+ * caller typed. Invoke a script through a path that crosses a symlink — a
+ * checkout linked from elsewhere, a tool that hands Node a link — and the two
+ * strings differ, the comparison is false, and the CLI body never runs.
+ *
+ * The failure is silent and reads as success: no output, exit 0. A guard that
+ * exits 0 without running is worse than one that crashes, because a caller
+ * cannot tell it apart from a clean pass.
+ *
+ * So both sides are compared after realpathSync, which resolves symlinks the
+ * same way the loader does. Anything that cannot be resolved on disk falls back
+ * to resolve(), so a deleted or synthetic argv[1] gives a plain false instead of
+ * throwing out of a module's top level.
+ */
+
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+/** Real path of `p`, or its resolved form when it does not exist on disk. */
+function realOrResolved(p) {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/**
+ * Whether `moduleUrl` (pass `import.meta.url`) is the entry Node was started
+ * with. False when Node was given no script at all, as in `node -e` or a REPL.
+ *
+ * `argv1` is injectable so the comparison itself can be tested without spawning
+ * a process.
+ */
+export function isCliEntry(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  return realOrResolved(argv1) === realOrResolved(fileURLToPath(moduleUrl));
+}

--- a/scripts/lib/isCliEntry.mjs
+++ b/scripts/lib/isCliEntry.mjs
@@ -1,5 +1,5 @@
 /**
- * isCliEntry.mjs — decide whether this module is the program Node was asked to run.
+ * isCliEntry.mjs: decide whether this module is the program Node was asked to run.
  *
  * The usual form of that check compares two paths:
  *
@@ -8,9 +8,9 @@
  * Those two sides are not produced the same way. `import.meta.url` comes from
  * the ESM loader, which has already followed every symlink on the way to the
  * file, so it always names the real path. `process.argv[1]` is whatever the
- * caller typed. Invoke a script through a path that crosses a symlink — a
- * checkout linked from elsewhere, a tool that hands Node a link — and the two
- * strings differ, the comparison is false, and the CLI body never runs.
+ * caller typed. Invoke a script through a path that crosses a symlink, such as
+ * a checkout linked from elsewhere or a tool that hands Node a link, and the
+ * two strings differ, the comparison is false, and the CLI body never runs.
  *
  * The failure is silent and reads as success: no output, exit 0. A guard that
  * exits 0 without running is worse than one that crashes, because a caller

--- a/scripts/lint-claim-register.mjs
+++ b/scripts/lint-claim-register.mjs
@@ -54,6 +54,7 @@ import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { join, relative, resolve, dirname } from 'node:path';
 import { loadStudies, STUDIES_DIR } from './verify-cross-implementation-study.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -384,7 +385,7 @@ export function readStudies(dir) {
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/lint-dataset-citations.mjs
+++ b/scripts/lint-dataset-citations.mjs
@@ -34,6 +34,7 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, dirname, join, relative, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const REGISTER = resolve(ROOT, 'validation/datasets/dataset-register.yaml');
@@ -114,7 +115,7 @@ function* walk(dir) {
 }
 
 /** True when this module is the entry point rather than an import. */
-const isCli = resolve(process.argv[1] ?? '') === resolve(fileURLToPath(import.meta.url));
+const isCli = isCliEntry(import.meta.url);
 
 if (isCli) {
   const registerText = readFileSync(REGISTER, 'utf8');

--- a/scripts/lint-docs-site.mjs
+++ b/scripts/lint-docs-site.mjs
@@ -27,6 +27,7 @@
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join, relative, sep } from 'node:path';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 /**
  * Every FORBIDDEN pattern below is anchored on `/`. A path from
@@ -137,6 +138,6 @@ function run() {
 // Import-safe: the checks run only when invoked as a script, so the unit test
 // can import htmlShowsEscapedComment without triggering a lint pass (the same
 // guard lint-unsafe-html.mjs uses).
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   run();
 }

--- a/scripts/lint-inline-imports.mjs
+++ b/scripts/lint-inline-imports.mjs
@@ -40,6 +40,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join, relative } from 'node:path';
 import { parseSync } from 'vite';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SRC = resolve(HERE, '..', 'src');
@@ -125,8 +126,7 @@ export function findRuntimeRelativeImports(source, fileName = 'file.ts') {
 // Run the scan only when invoked as a command. Importing this module (the
 // regression tests import `findRuntimeRelativeImports`) must not scan the tree
 // or call process.exit.
-const INVOKED_DIRECTLY =
-  process.argv[1] != null && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+const INVOKED_DIRECTLY = isCliEntry(import.meta.url);
 
 if (INVOKED_DIRECTLY) {
   const offenders = [];

--- a/scripts/lint-oracle-registry.mjs
+++ b/scripts/lint-oracle-registry.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const REGISTRY = resolve(ROOT, 'validation/external-oracles/oracle-registry.json');
@@ -100,7 +101,7 @@ function* walk(dir) {
   }
 }
 
-const isCli = resolve(process.argv[1] ?? '') === resolve(fileURLToPath(import.meta.url));
+const isCli = isCliEntry(import.meta.url);
 
 if (isCli) {
   const registry = JSON.parse(readFileSync(REGISTRY, 'utf8'));

--- a/scripts/lint-release-truth.mjs
+++ b/scripts/lint-release-truth.mjs
@@ -32,6 +32,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 /**
  * Collect every truth-drift problem. `read(relPath)` returns the file's text or
@@ -298,7 +299,7 @@ export function collectReleaseTruthProblems(read) {
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/lint-sbom.mjs
+++ b/scripts/lint-sbom.mjs
@@ -33,6 +33,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 /** Collect SBOM problems. `read(relPath)` returns text or null. */
 export function collectSbomProblems(read) {
@@ -122,7 +123,7 @@ export function collectSbomProblems(read) {
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/lint-spatial-context.mjs
+++ b/scripts/lint-spatial-context.mjs
@@ -37,6 +37,7 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SRC = resolve(ROOT, 'src');
@@ -354,6 +355,6 @@ function main() {
 }
 
 // Run only when invoked as a script, not when imported by a test.
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (isCliEntry(import.meta.url)) {
   main();
 }

--- a/scripts/lint-terrain-field-ids.mjs
+++ b/scripts/lint-terrain-field-ids.mjs
@@ -43,6 +43,7 @@
 import { readFileSync, readdirSync, existsSync, realpathSync } from 'node:fs';
 import { resolve, dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const FIELD_DIR = resolve(ROOT, 'validation/terrain-field');
@@ -138,7 +139,7 @@ export function collectTerrainFieldProblems(manifest, crops, registerIds) {
 
 /** True when this module is the entry point rather than an import. */
 const real = (p) => { try { return realpathSync(resolve(p)); } catch { return resolve(p); } };
-const isCli = real(process.argv[1] ?? '') === real(fileURLToPath(import.meta.url));
+const isCli = isCliEntry(import.meta.url);
 
 if (isCli) {
   const manifest = JSON.parse(readFileSync(MANIFEST, 'utf8'));

--- a/scripts/lint-unsafe-html.mjs
+++ b/scripts/lint-unsafe-html.mjs
@@ -21,6 +21,7 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join, relative } from 'node:path';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SRC = resolve(HERE, '..', 'src');
@@ -88,7 +89,7 @@ function walk(dir) {
 }
 
 // CLI entry — only when run directly, not when imported by the test.
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   const offenders = [];
   for (const file of walk(SRC)) {
     offenders.push(...scanSource(readFileSync(file, 'utf8'), relative(resolve(HERE, '..'), file)));

--- a/scripts/make-contour-fixture.mjs
+++ b/scripts/make-contour-fixture.mjs
@@ -34,6 +34,7 @@
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = resolve(HERE, '../tests/fixtures/reference/contour');
@@ -91,7 +92,7 @@ function writeAsc(path) {
 
 // Run as a script: write the DEM. The GDAL reference is produced separately by
 // the documented `gdal_contour` command (see docs/validation/cross-implementation.md).
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isCliEntry(import.meta.url)) {
   mkdirSync(OUT_DIR, { recursive: true });
   const demPath = resolve(OUT_DIR, 'input-dem.asc');
   writeAsc(demPath);

--- a/scripts/make-profile-fixture.mjs
+++ b/scripts/make-profile-fixture.mjs
@@ -44,6 +44,7 @@
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 import {
   RAMP_A, RAMP_B, RAMP_SAMPLES, RAMP_BAND, RAMP_BIN_STEP,
   RAMP_T_START, RAMP_T_STEP, RAMP_T_COUNT, RAMP_CROSS,
@@ -301,7 +302,7 @@ function writeEndcap() {
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (isCliEntry(import.meta.url)) {
   mkdirSync(OUT_DIR, { recursive: true });
   const ramp = writeRamp();
   const scatter = writeScatter();

--- a/scripts/make-profile-section-fixture.mjs
+++ b/scripts/make-profile-section-fixture.mjs
@@ -21,6 +21,7 @@
  * Orientation beyond Z-up is covered by the metamorphic relations, not here.
  */
 import { writeFileSync } from 'node:fs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 /** Section endpoints. Oblique, and dyadic so the length is exact. */
 export const SECTION_A = [-8, 6];
@@ -196,7 +197,7 @@ export function writeExpected(path) {
   return rows.length;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isCliEntry(import.meta.url)) {
   const base = 'validation/cross-implementation/profile';
   const a = writeSectionFixture(`${base}/profile-section.csv`);
   writeExpected(`${base}/profile-section__expected.csv`);

--- a/scripts/make-slope-fixture.mjs
+++ b/scripts/make-slope-fixture.mjs
@@ -45,6 +45,7 @@
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT_DIR = resolve(ROOT, 'tests/fixtures/reference/slope');
@@ -266,4 +267,4 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (isCliEntry(import.meta.url)) main();

--- a/scripts/make-steep-dem-fixture.mjs
+++ b/scripts/make-steep-dem-fixture.mjs
@@ -60,6 +60,7 @@
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT_DIR = resolve(ROOT, 'tests/fixtures/dem-steep');
@@ -159,4 +160,4 @@ function main() {
   console.log(`  analytic slope range: ${min.toFixed(3)}deg .. ${max.toFixed(3)}deg`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (isCliEntry(import.meta.url)) main();

--- a/scripts/pr-hygiene.mjs
+++ b/scripts/pr-hygiene.mjs
@@ -35,6 +35,7 @@
 import { execFileSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -235,7 +236,7 @@ export function observeBranch(baseRef, headRef, extra = {}, cwd = ROOT) {
   return { baseRef, surface, redundant, realCount, mergeCommits, commitsBehind, ...extra };
 }
 
-const isCli = resolve(process.argv[1] ?? '') === resolve(fileURLToPath(import.meta.url));
+const isCli = isCliEntry(import.meta.url);
 
 if (isCli) {
   const base = process.env.PR_BASE_REF ? `origin/${process.env.PR_BASE_REF}` : 'origin/main';

--- a/scripts/publication-battery.mjs
+++ b/scripts/publication-battery.mjs
@@ -31,6 +31,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { requireBinaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 // Spawned programs are resolved to an absolute path by reading PATH, so the
 // path that runs is a value this script can name rather than whatever the OS
@@ -312,6 +313,6 @@ async function main() {
   return report.verdict === 'PASS' ? 0 : 1;
 }
 
-if (process.argv[1] && process.argv[1].endsWith('publication-battery.mjs')) {
+if (isCliEntry(import.meta.url)) {
   process.exit(await main());
 }

--- a/scripts/render-claim-register.mjs
+++ b/scripts/render-claim-register.mjs
@@ -24,6 +24,7 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const YAML = resolve(ROOT, 'docs/validation/claim-register.yaml');
@@ -123,7 +124,7 @@ const cell = (s) => String(s ?? '—').replace(/\\/g, '\\\\').replace(/\|/g, '\\
 }
 
 // CLI entry — only when run directly, not when imported by the test.
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   const parsed = parseClaimRegister(readFileSync(YAML, 'utf8'));
   const missing = parsed.claims.filter(
     (c) => !c.product || !c.algorithm || !c.current || !c.required || !c.approvedClaim,

--- a/scripts/run-gdaldem-reference.mjs
+++ b/scripts/run-gdaldem-reference.mjs
@@ -51,10 +51,10 @@ import {
 } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { resolve, basename } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { platform, arch } from 'node:process';
 import { FIXTURES, MATRIX_DIR, FIXTURE_DIR, SUNS, cellMetres } from './generate-raster-fixtures.mjs';
 import { binaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const OUT_DIR = resolve(MATRIX_DIR, 'gdal');
 const GDALDEM = 'gdaldem';
@@ -264,6 +264,6 @@ function main() {
 
 export { buildArgs };
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   main();
 }

--- a/scripts/run-pdal-chm-reference.mjs
+++ b/scripts/run-pdal-chm-reference.mjs
@@ -35,6 +35,7 @@ import { fileURLToPath } from 'node:url';
 import { platform, arch } from 'node:process';
 import { FIXTURES, PIPELINE_DIR, EXTENT_M, DTM_CELL_M } from './generate-point-cloud-fixtures.mjs';
 import { binaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT_DIR = resolve(PIPELINE_DIR, 'pdal');
@@ -233,6 +234,6 @@ function main() {
   process.exit(0);
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   main();
 }

--- a/scripts/run-pdal-dsm-reference.mjs
+++ b/scripts/run-pdal-dsm-reference.mjs
@@ -57,6 +57,7 @@ import { fileURLToPath } from 'node:url';
 import { platform, arch } from 'node:process';
 import { FIXTURES, PIPELINE_DIR, EXTENT_M, DTM_CELL_M } from './generate-point-cloud-fixtures.mjs';
 import { binaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT_DIR = resolve(PIPELINE_DIR, 'pdal');
@@ -258,6 +259,6 @@ function main() {
   process.exit(0);
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   main();
 }

--- a/scripts/run-pdal-reference.mjs
+++ b/scripts/run-pdal-reference.mjs
@@ -82,6 +82,7 @@ import { fileURLToPath } from 'node:url';
 import { platform, arch } from 'node:process';
 import { FIXTURES, PIPELINE_DIR, EXTENT_M, DTM_CELL_M } from './generate-point-cloud-fixtures.mjs';
 import { binaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT_DIR = resolve(PIPELINE_DIR, 'pdal');
@@ -387,6 +388,6 @@ function main() {
   process.exit(0);
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   main();
 }

--- a/scripts/validate-release-ref.mjs
+++ b/scripts/validate-release-ref.mjs
@@ -21,6 +21,7 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { requireBinaryOnPath } from './lib/binaryOnPath.mjs';
 import { releaseDocPaths } from './lib/releaseDocs.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 // Spawned programs are resolved to an absolute path by reading PATH, so the
 // path that runs is a value this script can name rather than whatever the OS
@@ -103,7 +104,7 @@ export function validateReleaseRef({ env = {}, git = {}, files = {}, requireTag 
 }
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/verify-archive-portability.mjs
+++ b/scripts/verify-archive-portability.mjs
@@ -39,6 +39,7 @@ import { resolve, dirname, join, relative, posix } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { requireBinaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 // Spawned programs are resolved to an absolute path by reading PATH, so the
 // path that runs is a value this script can name rather than whatever the OS
@@ -891,4 +892,4 @@ function main() {
   process.exit(totalErrors === 0 ? 0 : 1);
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) main();
+if (isCliEntry(import.meta.url)) main();

--- a/scripts/verify-classifier-corpus.mjs
+++ b/scripts/verify-classifier-corpus.mjs
@@ -43,6 +43,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -175,7 +176,7 @@ export function collectCorpusProblems(
 }
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/verify-clean-clone.mjs
+++ b/scripts/verify-clean-clone.mjs
@@ -44,6 +44,7 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { requireBinaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 // Spawned programs are resolved to an absolute path by reading PATH, so the
 // path that runs is a value this script can name rather than whatever the OS
@@ -234,6 +235,6 @@ async function main() {
   return 0;
 }
 
-if (process.argv[1] && process.argv[1].endsWith('verify-clean-clone.mjs')) {
+if (isCliEntry(import.meta.url)) {
   process.exit(await main());
 }

--- a/scripts/verify-cross-implementation-study.mjs
+++ b/scripts/verify-cross-implementation-study.mjs
@@ -44,6 +44,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join, isAbsolute, sep } from 'node:path';
 
 import { binaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -923,7 +924,7 @@ export function verifyStudies(opts = {}) {
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/verify-dataset-register.mjs
+++ b/scripts/verify-dataset-register.mjs
@@ -36,6 +36,7 @@ import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const SCRIPT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const DEFAULT_REGISTER = 'validation/datasets/dataset-register.yaml';
@@ -420,7 +421,7 @@ function arg(name, fallback) {
 }
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/verify-field-study.mjs
+++ b/scripts/verify-field-study.mjs
@@ -43,6 +43,7 @@
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 import {
   validateAgainstSchema,
@@ -426,7 +427,7 @@ export function verifyFieldStudies(opts = {}) {
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/verify-generalization-record.mjs
+++ b/scripts/verify-generalization-record.mjs
@@ -52,6 +52,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 
 import { validateAgainstSchema, isIsoDate, compareCodeUnits } from './lib/recordSchema.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -393,7 +394,7 @@ export function verifyGeneralizationRecords(opts = {}) {
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/verify-ground-filter-metrics.mjs
+++ b/scripts/verify-ground-filter-metrics.mjs
@@ -45,6 +45,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -138,7 +139,7 @@ export function collectMetricRegressions(record, baseline = FROZEN_BASELINE, tol
 }
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/verify-impact-record.mjs
+++ b/scripts/verify-impact-record.mjs
@@ -37,6 +37,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 
 import { validateAgainstSchema, isIsoDate, compareCodeUnits } from './lib/recordSchema.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -241,7 +242,7 @@ export function verifyImpactRecords(opts = {}) {
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/verify-oracle-versions.mjs
+++ b/scripts/verify-oracle-versions.mjs
@@ -55,6 +55,7 @@ import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { resolve, dirname, relative, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { binaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const VALIDATION = resolve(ROOT, 'validation');
@@ -355,6 +356,6 @@ function main() {
   );
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   main();
 }

--- a/scripts/verify-reachability.mjs
+++ b/scripts/verify-reachability.mjs
@@ -25,6 +25,7 @@
 import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const REGISTRY = join(ROOT, 'validation/reachability/claims.json');
@@ -150,6 +151,6 @@ function main() {
   process.exit(failed === 0 ? 0 : 1);
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) main();
+if (isCliEntry(import.meta.url)) main();
 
 export { REGISTRY, LEDGER_DIR };

--- a/scripts/verify-release-assets.mjs
+++ b/scripts/verify-release-assets.mjs
@@ -26,6 +26,7 @@ import { fileURLToPath } from 'node:url';
 // eslint-disable-next-line import/no-relative-packages — same repo, ships in the archive
 import { MANDATORY_RELEASE_STAGES, DEFERRED_RELEASE_STAGES, STAGE_STATES } from './collect-evidence.mjs';
 import { requireBinaryOnPath } from './lib/binaryOnPath.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 // Spawned programs are resolved to an absolute path by reading PATH, so the
 // path that runs is a value this script can name rather than whatever the OS
@@ -392,7 +393,7 @@ export function verifyStagedRelease(dir, opts = {}) {
 }
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/verify-reproduction-record.mjs
+++ b/scripts/verify-reproduction-record.mjs
@@ -37,6 +37,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 
 import { validateAgainstSchema, isIsoDate, compareCodeUnits } from './lib/recordSchema.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -298,7 +299,7 @@ export function verifyReproductionRecords(opts = {}) {
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 function isMain() {
-  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  return isCliEntry(import.meta.url);
 }
 
 if (isMain()) {

--- a/scripts/verify-validation-snapshot.mjs
+++ b/scripts/verify-validation-snapshot.mjs
@@ -43,6 +43,7 @@ import {
 } from './validation-snapshot-lib.mjs';
 import { evidenceReader, writeManifest } from './build-validation-snapshot.mjs';
 import { compareCodeUnits } from './lib/codeUnitOrder.mjs';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const DEFAULT_DIR = join(ROOT, 'validation/snapshot');
@@ -449,7 +450,7 @@ function main() {
   return ok ? 0 : 1;
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isCliEntry(import.meta.url)) {
   try {
     process.exit(main());
   } catch (err) {

--- a/tests/cliEntryDetection.test.ts
+++ b/tests/cliEntryDetection.test.ts
@@ -6,7 +6,7 @@
  * way: the ESM loader has already resolved symlinks by the time it fills in
  * import.meta.url, while argv[1] is the path the caller typed. A comparison
  * that does not resolve both sides is false whenever the invoking path crosses
- * a symlink, and the script then exits 0 having done nothing — a pass that
+ * a symlink, and the script then exits 0 having done nothing, a pass that
  * looks identical to a real one.
  *
  * So this spawns a representative gate through a symlinked checkout path and

--- a/tests/cliEntryDetection.test.ts
+++ b/tests/cliEntryDetection.test.ts
@@ -1,0 +1,81 @@
+/**
+ * cliEntryDetection.test.ts
+ *
+ * The scripts under scripts/ decide whether to run their CLI body by comparing
+ * process.argv[1] against import.meta.url. Those two are not built the same
+ * way: the ESM loader has already resolved symlinks by the time it fills in
+ * import.meta.url, while argv[1] is the path the caller typed. A comparison
+ * that does not resolve both sides is false whenever the invoking path crosses
+ * a symlink, and the script then exits 0 having done nothing — a pass that
+ * looks identical to a real one.
+ *
+ * So this spawns a representative gate through a symlinked checkout path and
+ * asserts it still reports. Without the guard in scripts/lib/isCliEntry.mjs the
+ * stdout assertion fails while the exit code stays 0, which is the whole point.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isCliEntry } from '../scripts/lib/isCliEntry.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * A symlink pointing at the repository root, or null when the platform refuses
+ * to make one. Unprivileged Windows cannot create symlinks, and that is a fact
+ * about the runner rather than a defect in the guard, so the spawn case is
+ * skipped there instead of failing.
+ */
+function linkedRoot(): { link: string; dir: string } | null {
+  const dir = mkdtempSync(join(tmpdir(), 'olv-cli-entry-'));
+  const link = join(dir, 'checkout');
+  try {
+    symlinkSync(ROOT, link, 'dir');
+    return { link, dir };
+  } catch {
+    rmSync(dir, { recursive: true, force: true });
+    return null;
+  }
+}
+
+describe('CLI entry detection', () => {
+  it('runs a gate invoked through a symlinked checkout path', () => {
+    const linked = linkedRoot();
+    if (linked === null) return;
+    try {
+      const script = join(linked.link, 'scripts', 'lint-unsafe-html.mjs');
+      const run = spawnSync(process.execPath, [script], { encoding: 'utf8' });
+      expect(run.status).toBe(0);
+      expect(run.stdout).toContain('lint:unsafe-html OK');
+    } finally {
+      rmSync(linked.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('matches a module reached through a symlink', () => {
+    const linked = linkedRoot();
+    if (linked === null) return;
+    try {
+      const viaLink = join(linked.link, 'scripts', 'lint-unsafe-html.mjs');
+      const real = join(ROOT, 'scripts', 'lint-unsafe-html.mjs');
+      expect(isCliEntry(new URL(`file://${real}`).href, viaLink)).toBe(true);
+    } finally {
+      rmSync(linked.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not match a different script', () => {
+    const self = new URL(`file://${join(ROOT, 'scripts', 'lint-unsafe-html.mjs')}`).href;
+    expect(isCliEntry(self, join(ROOT, 'scripts', 'lint-docs-site.mjs'))).toBe(false);
+  });
+
+  it('is false when Node was given no script, and does not throw on a missing one', () => {
+    const self = new URL(`file://${join(ROOT, 'scripts', 'lint-unsafe-html.mjs')}`).href;
+    expect(isCliEntry(self, undefined)).toBe(false);
+    expect(isCliEntry(self, join(ROOT, 'scripts', 'does-not-exist.mjs'))).toBe(false);
+  });
+});

--- a/tests/cliEntrySweep.test.ts
+++ b/tests/cliEntrySweep.test.ts
@@ -1,0 +1,49 @@
+/**
+ * cliEntrySweep.test.ts — no script may hand-roll its own CLI-entry check.
+ *
+ * Every form the tree carried compared a path the caller typed against one the
+ * ESM loader had already resolved, so invoking a script through a symlink made
+ * the comparison false and the body never ran. The process still exited 0 with
+ * no output, which reads as a clean pass. Five spellings of that bug existed at
+ * once, so pinning the shared helper is not enough: a new script written in any
+ * of them would reintroduce it silently.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const HELPER = 'lib/isCliEntry.mjs';
+
+function scriptFiles(dir: string, prefix = ''): string[] {
+  return readdirSync(resolve(ROOT, dir), { withFileTypes: true }).flatMap((e) =>
+    e.isDirectory()
+      ? scriptFiles(`${dir}/${e.name}`, `${prefix}${e.name}/`)
+      : e.name.endsWith('.mjs')
+        ? [`${prefix}${e.name}`]
+        : [],
+  );
+}
+
+describe('CLI-entry detection', () => {
+  const files = scriptFiles('scripts');
+
+  it('finds the scripts to check', () => {
+    expect(files.length).toBeGreaterThan(30);
+  });
+
+  it('is never hand-rolled from process.argv[1]', () => {
+    const offenders = files.filter((f) => {
+      if (f === HELPER) return false;
+      return readFileSync(resolve(ROOT, 'scripts', f), 'utf8').includes('process.argv[1]');
+    });
+    expect(
+      offenders,
+      'these read process.argv[1] directly. Import isCliEntry from lib/isCliEntry.mjs: ' +
+        'a comparison against an unresolved argv[1] silently skips the CLI body ' +
+        'when the script is reached through a symlink, and still exits 0.',
+    ).toEqual([]);
+  });
+});

--- a/tests/fieldSourceIdLint.test.ts
+++ b/tests/fieldSourceIdLint.test.ts
@@ -55,11 +55,17 @@ const run = (
 /** A scaffold the real CLI can be pointed at: it resolves paths from its own location. */
 function scaffold(manifestDoc: unknown, crops: Record<string, unknown>): string {
   const dir = mkdtempSync(join(tmpdir(), 'olv-field-ids-'));
-  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  mkdirSync(join(dir, 'scripts/lib'), { recursive: true });
   mkdirSync(join(dir, 'validation/terrain-field/datasets'), { recursive: true });
   mkdirSync(join(dir, 'validation/terrain-field/crops'), { recursive: true });
   mkdirSync(join(dir, 'validation/datasets'), { recursive: true });
   copyFileSync(LINT, join(dir, 'scripts/lint-terrain-field-ids.mjs'));
+  // The CLI imports the shared entry guard by relative path, so the scaffold
+  // needs it beside the script or the spawn fails before any rule runs.
+  copyFileSync(
+    resolve(ROOT, 'scripts/lib/isCliEntry.mjs'),
+    join(dir, 'scripts/lib/isCliEntry.mjs'),
+  );
   writeFileSync(
     join(dir, 'validation/terrain-field/datasets/manifest.json'),
     JSON.stringify(manifestDoc),


### PR DESCRIPTION
Fifteen scripts under `scripts/` detect the CLI entry by comparing `process.argv[1]` against `import.meta.url` with neither side realpath'd. Node's ESM loader resolves symlinks before filling in `import.meta.url`, so invoking one of these scripts through a path that crosses a symlink makes the comparison false: the CLI body never runs and the process exits 0 with no output. Four of the fifteen are steps in `test:release:execute`.

`npm run <script>` resolves the working directory first, so CI is not affected today. This is latent, not a live false pass.

`scripts/lib/isCliEntry.mjs` compares both sides after `realpathSync`, falling back to `resolve()` for a path not on disk so a missing `argv[1]` returns false rather than throwing. All fifteen call sites use it. A new test runs `lint-unsafe-html.mjs` through a symlinked checkout; against the old comparison it fails while the exit code stays 0.


Second pass: four more spellings of the same check were in the tree, including `verify-dataset-register.mjs`, which runs in `test:release:execute` as `validation:datasets:verify`. All 32 scripts now import the guard, and a sweep test fails on any script that reads `process.argv[1]` itself.
