### PR TITLE
lint(release): catch a blanket unchanged claim beside a populated Added list

### DIFF
--- a/scripts/lint-release-truth.mjs
+++ b/scripts/lint-release-truth.mjs
@@ -219,6 +219,44 @@ export function collectReleaseTruthProblems(read) {
     }
   }
 
+  // ── 6b. No blanket "carried forward unchanged" claim while the release adds ─
+  // The three public surfaces each carry their own copy of this claim and drift
+  // apart. Scoped statements ("contour geometry is unchanged unless the mode is
+  // selected", "Unchanged from vX" under Compatibility) are true and are
+  // deliberately not matched; only claims whose subject is the whole
+  // application or its algorithms are.
+  //
+  // Scope, stated plainly: this compares a release's prose against its own
+  // Added list. It cannot see a feature that merged and was never written down
+  // anywhere, which is how v0.6.6 first drifted. That needs release history,
+  // which an extracted archive does not carry.
+  {
+    const BLANKET = [
+      /carries the v[\d.]+ application forward unchanged/i,
+      /(?:terrain and measurement )?algorithms are inherited from v[\d.]+,? unchanged/i,
+      /is the v[\d.]+ application,? unchanged/i,
+    ];
+    const changelog = read('CHANGELOG.md') ?? '';
+    const section = changelog.split(`## [${version}]`)[1]?.split('\n## [')[0] ?? '';
+    const added = section.split('### Added')[1]?.split('\n### ')[0] ?? '';
+    const addedCount = (added.match(/^- /gm) ?? []).length;
+    if (addedCount > 0) {
+      for (const doc of [RELEASE_NOTES, `docs-site/releases/v${version}.md`, 'CHANGELOG.md']) {
+        const text = doc === 'CHANGELOG.md' ? section : read(doc);
+        if (text == null) continue;
+        for (const re of BLANKET) {
+          const hit = re.exec(text);
+          if (!hit) continue;
+          problems.push(
+            `${doc} says "${hit[0]}" while CHANGELOG.md lists ${addedCount} addition(s) ` +
+              `under v${version}. Say what changed, or scope the claim to the part that ` +
+              `genuinely did not.`,
+          );
+        }
+      }
+    }
+  }
+
   // ── 7. The shipped asset index documents the full asset set ───────────────
   // docs/project/RELEASE_CHECKLIST.md is an internal process aid and is export-ignored, so
   // the source archive cannot depend on it. The public, shipped index of what a

--- a/tests/releaseTruthLint.test.ts
+++ b/tests/releaseTruthLint.test.ts
@@ -26,6 +26,8 @@ const CLAIMS = 'docs/validation/claim-register.yaml';
 const DEPS = 'docs/project/DEPENDENCIES.md';
 const NOTICES = 'docs/project/THIRD_PARTY_NOTICES.md';
 const RELEASE_ASSETS = 'docs/release/RELEASE_ASSETS.md';
+const RELEASE_NOTES = `docs/releases/RELEASE_NOTES_v${VERSION}.md`;
+const DOCS_SITE = `docs-site/releases/v${VERSION}.md`;
 
 /** A reader over the real tree with a single-file override. */
 function withOverride(path: string, text: string) {
@@ -121,5 +123,41 @@ describe('lint:release-truth', () => {
     );
     const problems = problemsFor(withOverride(SERVICE, svc));
     expect(problems.some((p) => p.includes('MULTI_LAYER_MOUNT_ENABLED = false'))).toBe(true);
+  });
+
+  // The two phrases below are the wording v0.6.6 actually shipped with before
+  // PR #438 corrected it, not invented examples. The rule guards the direction
+  // a correction can be lost in: a release that lists what it added while a
+  // surface still claims the application came forward untouched.
+  describe('rule 6b — a blanket "unchanged" claim beside a populated Added list', () => {
+    it('fails when the release notes claim the application came forward unchanged', () => {
+      const doc = realRead(RELEASE_NOTES)! + '\n\nIt carries the v0.6.5 application forward unchanged.\n';
+      const problems = problemsFor(withOverride(RELEASE_NOTES, doc));
+      expect(problems.some((p) => p.includes('application forward unchanged'))).toBe(true);
+    });
+
+    it('fails when the changelog claims the algorithms are inherited unchanged', () => {
+      const text = realRead('CHANGELOG.md')!.replace(
+        '- The terrain and measurement algorithms changed in this cycle.',
+        '- The terrain and measurement algorithms are inherited from v0.6.5 unchanged.',
+      );
+      const problems = problemsFor(withOverride('CHANGELOG.md', text));
+      expect(problems.some((p) => p.includes('inherited from v0.6.5'))).toBe(true);
+    });
+
+    it('fails when the public release page carries the claim', () => {
+      const doc = (realRead(DOCS_SITE) ?? '') + '\n\nThis is the v0.6.5 application, unchanged.\n';
+      const problems = problemsFor(withOverride(DOCS_SITE, doc));
+      expect(problems.some((p) => p.includes(DOCS_SITE))).toBe(true);
+    });
+
+    it('leaves a scoped "unchanged" statement alone', () => {
+      // "contour geometry is unchanged ... unless the mode is selected" is true
+      // and must stay sayable, or the rule would push writers toward vaguer prose.
+      const doc =
+        realRead(RELEASE_NOTES)! +
+        '\n\nContour geometry is unchanged for every existing purpose unless the mode is selected.\n';
+      expect(problemsFor(withOverride(RELEASE_NOTES, doc))).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
v0.6.6 shipped stating it carried the v0.6.5 application forward unchanged, after terrain-aware contour generalization had already merged. PR #438 corrected the wording, but nothing would have caught it coming back. Three public surfaces hold their own copy of that claim, `RELEASE_NOTES_vX.Y.Z.md`, `docs-site/releases/vX.Y.Z.md` and the CHANGELOG section, and they drift independently because no gate compares them.

Rule 6b in `lint:release-truth` reads a release's prose against its own Added list and reports the document, the phrase and the count.

Scoped statements stay sayable. Only a claim whose subject is the whole application or its algorithms is matched, so "contour geometry is unchanged unless the mode is selected" passes untouched. A lint that flagged it would push writers toward vaguer prose.

The rule cannot see a feature that merged and was recorded nowhere, which is how the drift began. That needs release history an extracted archive does not carry. The rule carries that limit in a comment beside it. Tests use the wording v0.6.6 shipped with.

