### PR TITLE
fix(features): stop naming source-unit footprint areas as metres

### DIFF
--- a/src/features/FeatureExtractionService.ts
+++ b/src/features/FeatureExtractionService.ts
@@ -12,7 +12,7 @@
  *
  * 1. UNITS. The cores measure in whatever unit their input carries — the grid's
  *    cell size and the point coordinates are SOURCE units, not metres (the
- *    terrain pipeline's own `cellSizeM` is likewise source units: it is
+ *    terrain pipeline's own `cellSizeSource` is likewise source units: it is
  *    `0.25 / metresPerUnit`). A field called `areaM2` fed from a foot or degree
  *    CRS would therefore be a number labelled m² that is not m². So a candidate
  *    always carries its SOURCE-unit measure, and the metric twin is present only
@@ -110,7 +110,7 @@ export function extractBuildingCandidates(
 ): BuildingCandidate[] {
   // Half a cell: fine enough that two distinct footprints never share a token,
   // coarse enough that a re-run's sub-cell centroid drift keeps the same id.
-  const quantum = grid.cellSizeM / 2;
+  const quantum = grid.cellSizeSource / 2;
   const seen = new Map<string, number>();
   return extractBuildingFootprints(points, grid).map((f) => {
     const token = positionToken(f.centroidX, f.centroidY, quantum);
@@ -119,7 +119,7 @@ export function extractBuildingCandidates(
     const n = (seen.get(token) ?? 0) + 1;
     seen.set(token, n);
     const id = n === 1 ? `building-${token}` : `building-${token}-${n}`;
-    const areaSource = f.areaM2; // core value: cells x cell^2, in SOURCE units^2
+    const areaSource = f.areaSource;
     return {
       id,
       kind: 'building',

--- a/src/features/buildingFootprints.ts
+++ b/src/features/buildingFootprints.ts
@@ -21,11 +21,16 @@ import { traceOccupancyBoundary, type Pt2 } from './footprintTrace';
 export interface FootprintGrid {
   readonly originX: number;
   readonly originY: number;
-  readonly cellSizeM: number;
+  /**
+   * Grid cell size in the INPUT's own unit, matching the point coordinates.
+   * Not metres: the caller grids in whatever frame the scan arrived in, and
+   * naming it so let a foot-unit cell size be read as a metric one.
+   */
+  readonly cellSizeSource: number;
   /** At least this many building points make a cell occupied. Default 1. */
   readonly minPointsPerCell?: number;
-  /** Components below this area (m²) are dropped as noise. Default 4. */
-  readonly minAreaM2?: number;
+  /** Components below this area, in the input's own unit squared, are dropped as noise. Default 4. */
+  readonly minAreaSource?: number;
 }
 
 export interface Footprint {
@@ -40,7 +45,8 @@ export interface Footprint {
    */
   readonly ring: readonly Pt2[];
   readonly cellCount: number;
-  readonly areaM2: number;
+  /** Cell-count area, in the input's own unit squared. */
+  readonly areaSource: number;
   readonly centroidX: number;
   readonly centroidY: number;
   readonly minX: number;
@@ -56,7 +62,7 @@ export interface BuildingPoint {
 
 /** Extract footprints from building points over the given grid. */
 export function extractBuildingFootprints(points: readonly BuildingPoint[], grid: FootprintGrid): Footprint[] {
-  const cell = grid.cellSizeM;
+  const cell = grid.cellSizeSource;
   // cell must be a positive, FINITE size. `Number.isFinite` rejects NaN AND
   // Infinity in one check — an Infinity cell would bin every point into one
   // cell and report an Infinity area.
@@ -66,7 +72,7 @@ export function extractBuildingFootprints(points: readonly BuildingPoint[], grid
   // false), which would admit noise as a building. Fall back to the defaults.
   const rawMinPts = grid.minPointsPerCell ?? 1;
   const minPts = Number.isFinite(rawMinPts) && rawMinPts >= 1 ? rawMinPts : 1;
-  const rawMinArea = grid.minAreaM2 ?? 4;
+  const rawMinArea = grid.minAreaSource ?? 4;
   const minArea = Number.isFinite(rawMinArea) && rawMinArea >= 0 ? rawMinArea : 4;
 
   // Bin points to integer cell coordinates and count per cell.
@@ -111,8 +117,8 @@ export function extractBuildingFootprints(points: readonly BuildingPoint[], grid
         }
       }
     }
-    const areaM2 = cells.length * cell * cell;
-    if (areaM2 < minArea) continue;
+    const areaSource = cells.length * cell * cell;
+    if (areaSource < minArea) continue;
     // Footprint geometry from the cell block (cell centres in world coords).
     let sx = 0, sy = 0, minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
     for (const [cx, cy] of cells) {
@@ -128,12 +134,12 @@ export function extractBuildingFootprints(points: readonly BuildingPoint[], grid
     // Trace the block's outline once, here, where the cells still exist.
     const ring = traceOccupancyBoundary(cells, cell, grid.originX, grid.originY);
     footprints.push({
-      ring, cellCount: cells.length, areaM2,
+      ring, cellCount: cells.length, areaSource,
       centroidX: sx / cells.length, centroidY: sy / cells.length,
       minX, minY, maxX, maxY,
     });
   }
   // Deterministic order: largest footprint first, then by centroid.
-  footprints.sort((a, b) => b.areaM2 - a.areaM2 || a.centroidX - b.centroidX || a.centroidY - b.centroidY);
+  footprints.sort((a, b) => b.areaSource - a.areaSource || a.centroidX - b.centroidX || a.centroidY - b.centroidY);
   return footprints;
 }

--- a/src/features/footprintGeoJson.ts
+++ b/src/features/footprintGeoJson.ts
@@ -2,7 +2,7 @@
  * footprintGeoJson.ts — export building footprints as RFC 7946 GeoJSON.
  *
  * Each footprint's traced ring becomes a Polygon feature carrying its area,
- * centroid and — honestly — its DERIVED status: these are candidates extracted
+ * centroid and, honestly, its DERIVED status: these are candidates extracted
  * from classified points, not surveyed building outlines, and the property set
  * says so. Coordinates are written in the source projected frame (the same
  * frame the points were gridded in); the CRS is recorded in a `metadata` member
@@ -15,7 +15,17 @@ import type { Pt2 } from './footprintTrace';
 export interface FootprintFeatureInput {
   /** Closed outer ring in projected coordinates (first vertex not repeated). */
   readonly ring: readonly Pt2[];
-  readonly areaM2: number;
+  /** Cell-count area in the source frame's own unit squared. Always present. */
+  readonly areaSource: number;
+  /**
+   * The same area in m², or null when the source's linear unit is not known.
+   *
+   * Callers used to collapse these two with `areaM2 ?? areaSource`, which wrote
+   * a foot-unit magnitude into a property named for metres, in a file that
+   * leaves the application. A reader cannot tell that apart from a real m²
+   * value, so the metric property is omitted entirely when it is not known.
+   */
+  readonly areaM2: number | null;
   readonly centroidX: number;
   readonly centroidY: number;
   /** Optional stable id for the footprint. */
@@ -54,7 +64,9 @@ export function footprintsToGeoJson(
         id: f.id ?? i,
         geometry: { type: 'Polygon', coordinates: [coords] },
         properties: {
-          areaM2: round(f.areaM2, 3),
+          areaSource: round(f.areaSource, 3),
+          // Present only when the linear unit is known. See FootprintFeatureInput.
+          ...(f.areaM2 == null ? {} : { areaM2: round(f.areaM2, 3) }),
           centroidX: round(f.centroidX, 3),
           centroidY: round(f.centroidY, 3),
           // Honesty: what this feature actually is.

--- a/tests/buildingFootprints.test.ts
+++ b/tests/buildingFootprints.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { extractBuildingFootprints, type BuildingPoint, type FootprintGrid } from '../src/features/buildingFootprints';
 
-const GRID: FootprintGrid = { originX: 0, originY: 0, cellSizeM: 1, minPointsPerCell: 1, minAreaM2: 4 };
+const GRID: FootprintGrid = { originX: 0, originY: 0, cellSizeSource: 1, minPointsPerCell: 1, minAreaSource: 4 };
 
 /** Fill an axis-aligned rectangle [x0,x1)×[y0,y1) with points at ~0.4 m spacing. */
 function rect(x0: number, y0: number, x1: number, y1: number): BuildingPoint[] {
@@ -22,11 +22,11 @@ describe('extractBuildingFootprints', () => {
     const fps = extractBuildingFootprints([...a, ...b, ...c], GRID);
     expect(fps).toHaveLength(3);
     // Largest first (deterministic order).
-    expect(fps[0].areaM2).toBeGreaterThan(fps[1].areaM2);
+    expect(fps[0].areaSource).toBeGreaterThan(fps[1].areaSource);
     // The 10×10 building's area and centroid.
     const big = fps[0];
-    expect(big.areaM2).toBeGreaterThan(90);
-    expect(big.areaM2).toBeLessThan(115);
+    expect(big.areaSource).toBeGreaterThan(90);
+    expect(big.areaSource).toBeLessThan(115);
     expect(big.centroidX).toBeCloseTo(35, 0);
     expect(big.centroidY).toBeCloseTo(35, 0);
   });
@@ -39,19 +39,19 @@ describe('extractBuildingFootprints', () => {
 
   it('drops sub-threshold noise clusters (honest: a stray point is not a building)', () => {
     const building = rect(0, 0, 10, 10);
-    const noise: BuildingPoint[] = [{ x: 50, y: 50 }, { x: 51, y: 51 }]; // < minAreaM2
+    const noise: BuildingPoint[] = [{ x: 50, y: 50 }, { x: 51, y: 51 }]; // < minAreaSource
     const fps = extractBuildingFootprints([...building, ...noise], GRID);
     expect(fps).toHaveLength(1); // only the real building survives
   });
 
   it('empty input and non-positive cell size yield no footprints', () => {
     expect(extractBuildingFootprints([], GRID)).toEqual([]);
-    expect(extractBuildingFootprints(rect(0, 0, 5, 5), { ...GRID, cellSizeM: 0 })).toEqual([]);
+    expect(extractBuildingFootprints(rect(0, 0, 5, 5), { ...GRID, cellSizeSource: 0 })).toEqual([]);
   });
 
   it('rejects a non-finite (NaN / Infinity) cell size fail-closed', () => {
-    expect(extractBuildingFootprints(rect(0, 0, 5, 5), { ...GRID, cellSizeM: Number.NaN })).toEqual([]);
-    expect(extractBuildingFootprints(rect(0, 0, 5, 5), { ...GRID, cellSizeM: Infinity })).toEqual([]);
+    expect(extractBuildingFootprints(rect(0, 0, 5, 5), { ...GRID, cellSizeSource: Number.NaN })).toEqual([]);
+    expect(extractBuildingFootprints(rect(0, 0, 5, 5), { ...GRID, cellSizeSource: Infinity })).toEqual([]);
   });
 
   it('skips non-finite XY points without corrupting the footprint', () => {
@@ -71,7 +71,7 @@ describe('extractBuildingFootprints', () => {
     const noise: BuildingPoint[] = [{ x: 50, y: 50 }, { x: 51, y: 51 }];
     // NaN thresholds must not silently admit the noise cluster.
     const fps = extractBuildingFootprints([...building, ...noise], {
-      ...GRID, minAreaM2: Number.NaN, minPointsPerCell: Number.NaN,
+      ...GRID, minAreaSource: Number.NaN, minPointsPerCell: Number.NaN,
     });
     expect(fps).toHaveLength(1);
   });

--- a/tests/candidateReview.test.ts
+++ b/tests/candidateReview.test.ts
@@ -19,7 +19,7 @@ import type { BuildingPoint } from '../src/features/buildingFootprints';
 import { knownUnit } from '../src/units/units';
 
 const METRE = knownUnit(1);
-const GRID = { originX: 0, originY: 0, cellSizeM: 1, minPointsPerCell: 1, minAreaM2: 4 };
+const GRID = { originX: 0, originY: 0, cellSizeSource: 1, minPointsPerCell: 1, minAreaSource: 4 };
 
 function block(ox = 0, oy = 0, n = 10): BuildingPoint[] {
   const pts: BuildingPoint[] = [];

--- a/tests/featureExtractionService.test.ts
+++ b/tests/featureExtractionService.test.ts
@@ -32,7 +32,7 @@ function block(ox = 0, oy = 0, n = 10): BuildingPoint[] {
   for (let x = 0; x < n; x++) for (let y = 0; y < n; y++) pts.push({ x: ox + x, y: oy + y });
   return pts;
 }
-const GRID = { originX: 0, originY: 0, cellSizeM: 1, minPointsPerCell: 1, minAreaM2: 4 };
+const GRID = { originX: 0, originY: 0, cellSizeSource: 1, minPointsPerCell: 1, minAreaSource: 4 };
 
 /** A near-straight span with a slight sag. */
 function span(len = 40): Vec3[] {
@@ -194,7 +194,8 @@ describe('FeatureExtractionService — the traced ring', () => {
     const fc = footprintsToGeoJson(
       cands.map((c) => ({
         ring: c.ring,
-        areaM2: c.areaM2 ?? c.areaSource,
+        areaSource: c.areaSource,
+        areaM2: c.areaM2,
         centroidX: c.centroid[0],
         centroidY: c.centroid[1],
         id: c.id,

--- a/tests/footprintGeoJson.test.ts
+++ b/tests/footprintGeoJson.test.ts
@@ -9,7 +9,7 @@ const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 6 }, { x: 0, y: 6 }
 
 describe('footprintsToGeoJson', () => {
   it('emits a closed Polygon feature per footprint with derived provenance', () => {
-    const gj = footprintsToGeoJson([{ ring: square, areaM2: 60, centroidX: 5, centroidY: 3, id: 'b1' }], { crs: 'EPSG:3301' });
+    const gj = footprintsToGeoJson([{ ring: square, areaSource: 60, areaM2: 60, centroidX: 5, centroidY: 3, id: 'b1' }], { crs: 'EPSG:3301' });
     expect(gj.type).toBe('FeatureCollection');
     expect(gj.metadata.crs).toBe('EPSG:3301');
     expect(gj.features).toHaveLength(1);
@@ -27,15 +27,48 @@ describe('footprintsToGeoJson', () => {
   });
 
   it('skips a degenerate ring (<3 vertices)', () => {
-    const gj = footprintsToGeoJson([{ ring: [{ x: 0, y: 0 }, { x: 1, y: 1 }], areaM2: 0, centroidX: 0, centroidY: 0 }]);
+    const gj = footprintsToGeoJson([{ ring: [{ x: 0, y: 0 }, { x: 1, y: 1 }], areaSource: 0, areaM2: 0, centroidX: 0, centroidY: 0 }]);
     expect(gj.features).toHaveLength(0);
   });
 
   it('records a null CRS when none is supplied, and never invents one', () => {
-    const gj = footprintsToGeoJson([{ ring: square, areaM2: 60, centroidX: 5, centroidY: 3 }]);
+    const gj = footprintsToGeoJson([{ ring: square, areaSource: 60, areaM2: 60, centroidX: 5, centroidY: 3 }]);
     expect(gj.metadata.crs).toBeNull();
     // Coordinates are the source projected values, not reprojected.
     const ring = (gj.features[0] as { geometry: { coordinates: number[][][] } }).geometry.coordinates[0];
     expect(ring[1]).toEqual([10, 0]);
+  });
+});
+
+describe('the metric property is never a source-unit magnitude', () => {
+  const ring = [
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+    { x: 3, y: 3 },
+    { x: 0, y: 3 },
+  ];
+
+  it('omits areaM2 when the linear unit is not known', () => {
+    const fc = footprintsToGeoJson([
+      { ring, areaSource: 9, areaM2: null, centroidX: 1.5, centroidY: 1.5 },
+    ]);
+    const props = fc.features[0].properties as Record<string, unknown>;
+    expect(props.areaSource).toBe(9);
+    expect(
+      'areaM2' in props,
+      'a reader cannot tell a foot magnitude from a metric one, so an unknown ' +
+        'unit must leave the metric property out rather than fill it in',
+    ).toBe(false);
+  });
+
+  it('writes areaM2 only from the converted value, not the source one', () => {
+    // 9 ft² is 0.836 m². A writer that fell back to the source number would
+    // emit 9 here.
+    const fc = footprintsToGeoJson([
+      { ring, areaSource: 9, areaM2: 0.836, centroidX: 1.5, centroidY: 1.5 },
+    ]);
+    const props = fc.features[0].properties as Record<string, unknown>;
+    expect(props.areaM2).toBe(0.836);
+    expect(props.areaSource).toBe(9);
   });
 });


### PR DESCRIPTION
`extractBuildingFootprints` is pure and grids whatever coordinates it is handed, but its fields were `cellSizeM`, `minAreaM2` and `areaM2`. For a foot-unit scan those numbers are foot magnitudes under metric names. `FeatureExtractionService` already knew and carried the workaround in a comment beside `const areaSource = f.areaM2`.

The fields now say source, matching what `conductors.ts` already does with `spanSource` and `sagSource`.

The export mattered more. `footprintsToGeoJson` took one `areaM2`, and its documented usage filled it with `areaM2 ?? areaSource`, so an unknown linear unit put a foot magnitude into a metric property of a file that leaves the application. A reader cannot tell that apart from a real m² value. The writer now takes both numbers and omits `areaM2` entirely when the unit is not known, which is the same fail-closed rule the service states for its own candidates.

Two tests pin the export: one that an unknown unit leaves the property out, one that a known unit writes the converted number rather than the source one.
