### PR TITLE
refactor(streaming): refine on a depth number, not an octree voxel key

### DIFF
--- a/docs/architecture/float64-frame-migration-plan.md
+++ b/docs/architecture/float64-frame-migration-plan.md
@@ -93,7 +93,7 @@ The gate's number is the larger one because it also counts the reads inside
 frame mistake there is wrong everywhere at once, so the gate has to see it. This
 plan's number is the migration surface, which is consumers only.
 
-Measured, `outside-model`: 128 direct `.positions` reads across 38 files. Both
+Measured, `outside-model`: 129 direct `.positions` reads across 39 files. Both
 numbers are regenerated from the tree rather than quoted from memory, because
 they drift as code moves — they rose to 162 across 43 files while the placement
 architecture was landing, and have since fallen as consumers moved onto the

--- a/docs/validation/position-access-baseline.json
+++ b/docs/validation/position-access-baseline.json
@@ -1,5 +1,5 @@
 {
-  "total": 147,
+  "total": 148,
   "files": {
     "src/app/epochFramePrep.ts": 2,
     "src/app/floorPlanPositions.ts": 4,
@@ -21,6 +21,7 @@
     "src/io/loadPtx.ts": 1,
     "src/io/loadXyz.ts": 1,
     "src/io/parseWorker.ts": 2,
+    "src/io/tiles3d/pntsDecode.ts": 1,
     "src/main.ts": 12,
     "src/model/PointCloud.ts": 17,
     "src/model/pointFrames.ts": 2,

--- a/docs/validation/position-frames.json
+++ b/docs/validation/position-frames.json
@@ -82,7 +82,7 @@
       "symbol": "packTileRecord",
       "frame": "source-local",
       "reads": 3,
-      "why": "Packs each decoded point into a tile-store record; raw.positions is the loader's source-local buffer (scaled value + header offset \u2212 load origin), copied into the tile verbatim with no reframing."
+      "why": "Packs each decoded point into a tile-store record; raw.positions is the loader's source-local buffer (scaled value + header offset − load origin), copied into the tile verbatim with no reframing."
     },
     {
       "file": "src/io/lasDecodeShared.ts",
@@ -169,6 +169,13 @@
       "why": "Worker transport: the freshly parsed buffer is transferred to the main thread in exactly the frame the loader wrote it, untouched."
     },
     {
+      "file": "src/io/tiles3d/pntsDecode.ts",
+      "symbol": "PntsChunkDecoder.decode",
+      "frame": "source-local",
+      "reads": 1,
+      "why": "The array a .pnts body carries, in the tile's own local space before RTC_CENTER. The decoder reads it once, hoisted out of the per-point loop, then applies RTC_CENTER, the tile's cumulative transform and the render origin in float64 to reach render-local. No accessor applies: this buffer belongs to a decoded tile, not to a PointCloud."
+    },
+    {
       "file": "src/main.ts",
       "symbol": "applyScanRoute",
       "frame": "project-local",
@@ -208,7 +215,7 @@
       "symbol": "scanHullPositions",
       "frame": "source-local",
       "reads": 1,
-      "why": "The active static cloud's resident buffer feeds the KML footprint's convex-hull outline, which is traced in the cloud's own source-local XY \u2014 the same frame the bounding-rectangle extent is read in."
+      "why": "The active static cloud's resident buffer feeds the KML footprint's convex-hull outline, which is traced in the cloud's own source-local XY — the same frame the bounding-rectangle extent is read in."
     },
     {
       "file": "src/main.ts",
@@ -271,7 +278,7 @@
       "symbol": "ContourOverlay._upload",
       "frame": "project-local",
       "reads": 1,
-      "why": "Uploads the CONTOUR line-segment vertices (not cloud points) into a THREE.BufferGeometry. They arrive from buildContourOverlayBuffers over a model derived from gatherTerrainPositions, which folds every layer placement in, so the buffer is already in the project frame the scene draws at its origin \u2014 the object carries no further offset."
+      "why": "Uploads the CONTOUR line-segment vertices (not cloud points) into a THREE.BufferGeometry. They arrive from buildContourOverlayBuffers over a model derived from gatherTerrainPositions, which folds every layer placement in, so the buffer is already in the project frame the scene draws at its origin — the object carries no further offset."
     },
     {
       "file": "src/render/densityColors.ts",

--- a/src/io/copc/copcHierarchy.ts
+++ b/src/io/copc/copcHierarchy.ts
@@ -119,6 +119,7 @@ export function parseHierarchyPage(
     nodes.push({
       id: keyId(key),
       key,
+      depth: key.depth,
       bounds,
       pointCount,
       byteOffset: offset,

--- a/src/io/copc/copcTypes.ts
+++ b/src/io/copc/copcTypes.ts
@@ -82,6 +82,16 @@ export interface StreamingNodeRecord {
   id: string;
   key: VoxelKey;
   /**
+   * How deep this node sits in its source's refinement tree, root = 0.
+   *
+   * The scheduler throttles refinement by depth under camera velocity and
+   * memory pressure, and used to read `key.depth` for it. That tied the
+   * policy to an octree voxel key, which only an octree-organised source can
+   * supply. Carrying the number itself lets a source that refines on some
+   * other measure state its depth without inventing voxel coordinates.
+   */
+  depth: number;
+  /**
    * Node bounds in WORLD space, derived from the COPC octree cube. Every
    * source's records use that frame: `StreamingScheduler._localBoundsFor`
    * localises a node as `bounds - source.renderOrigin`, so a record built in

--- a/src/io/heavy/OlvTileSource.ts
+++ b/src/io/heavy/OlvTileSource.ts
@@ -147,6 +147,7 @@ export class OlvTileOctree implements StreamingOctreeView {
       this.store.add({
         id: tileNodeId(key),
         key: tileVoxelKey(key),
+        depth: tileVoxelKey(key).depth,
         bounds,
         pointCount: reader.pointCountOf(key),
         // A tile is addressed by key, not by a file range, so there is no offset

--- a/src/io/tiles3d/pntsDecode.ts
+++ b/src/io/tiles3d/pntsDecode.ts
@@ -1,0 +1,127 @@
+/**
+ * pntsDecode.ts — decode a `.pnts` tile body into the streaming pipeline's
+ * chunk shape.
+ *
+ * The streaming scheduler is format-neutral about decoding: it obtains an
+ * opaque metadata object from the source and hands it, with the tile bytes, to
+ * an injected {@link ChunkDecoder}. COPC and EPT both hand it LAS chunk
+ * metadata. A `.pnts` body carries none of that, so this module supplies its
+ * own metadata shape and its own decoder.
+ *
+ * WHAT A PNTS TILE DOES NOT CARRY, and why the chunk still has those fields:
+ * `DecodedChunk` was written for LAS-derived data and requires intensity,
+ * classification, return number, return count and GPS time. A point tile has
+ * none of them. They are filled with zeros here because the type requires an
+ * array of the right length, NOT because a zero is a reading: zero
+ * classification is "never classified" and zero intensity is not a measured
+ * zero. A source backed by these tiles therefore advertises only the colour
+ * modes the format actually carries, so nothing offers to paint a scan by a
+ * channel that holds no information. `tests/pntsDecode.test.ts` pins that.
+ *
+ * Positions arrive tile-local. The tile's own `RTC_CENTER`, then its cumulative
+ * placement down the tileset tree, then the render origin are applied in
+ * float64 before the float32 store, which is the same order the LAS path uses
+ * and the reason a city-scale tileset does not lose precision at the far edge.
+ *
+ * Pure: no fetch, no DOM.
+ */
+
+import { parsePnts } from './pnts';
+import type { ChunkDecoder, DecodedChunk } from '../copc/copcChunkDecode';
+
+/**
+ * Metadata for decoding one `.pnts` body.
+ *
+ * `format` discriminates this from LAS chunk metadata at the decoder seam.
+ * LAS metadata carries no `format` field, so a decoder narrows with an `in`
+ * check and no existing metadata site had to change.
+ */
+export interface PntsDecodeMetadata {
+  readonly format: 'pnts';
+  /**
+   * Column-major 4x4 placing this tile in the tileset root frame: the product
+   * of every `transform` from the root down to this tile.
+   */
+  readonly tileTransform: readonly number[];
+  /** Render origin, subtracted in float64 before the float32 store. */
+  readonly renderOrigin: readonly [number, number, number];
+}
+
+/** Whether a decoder was handed point-tile metadata rather than LAS metadata. */
+export function isPntsMetadata(meta: unknown): meta is PntsDecodeMetadata {
+  return typeof meta === 'object' && meta !== null && (meta as { format?: unknown }).format === 'pnts';
+}
+
+/** Apply a column-major 4x4 to (x, y, z), in float64. */
+function applyMatrix(
+  m: readonly number[],
+  x: number,
+  y: number,
+  z: number,
+): [number, number, number] {
+  return [
+    m[0] * x + m[4] * y + m[8] * z + m[12],
+    m[1] * x + m[5] * y + m[9] * z + m[13],
+    m[2] * x + m[6] * y + m[10] * z + m[14],
+  ];
+}
+
+/**
+ * Decode a `.pnts` body into a chunk the streaming renderer can store.
+ *
+ * Throws when handed metadata for another format rather than guessing, since a
+ * mis-routed body would decode into plausible-looking rubbish.
+ */
+export class PntsChunkDecoder implements ChunkDecoder {
+  async decode(chunk: ArrayBuffer, meta: unknown): Promise<DecodedChunk> {
+    if (!isPntsMetadata(meta)) {
+      throw new Error('PntsChunkDecoder was handed metadata for another format.');
+    }
+    const tile = parsePnts(chunk);
+    const n = tile.pointsLength;
+    const positions = new Float32Array(n * 3);
+    const [ox, oy, oz] = meta.renderOrigin;
+    const rtc = tile.rtcCenter ?? [0, 0, 0];
+    // Hoisted: the tile's own local array, read once rather than three times
+    // per point. Its frame is the tile's local space, before RTC_CENTER.
+    const local = tile.positions;
+
+    for (let i = 0; i < n; i++) {
+      const j = i * 3;
+      // RTC_CENTER first: the tile stores positions relative to it, and the
+      // transform places the tile, not the offset.
+      const [wx, wy, wz] = applyMatrix(
+        meta.tileTransform,
+        local[j] + rtc[0],
+        local[j + 1] + rtc[1],
+        local[j + 2] + rtc[2],
+      );
+      positions[j] = wx - ox;
+      positions[j + 1] = wy - oy;
+      positions[j + 2] = wz - oz;
+    }
+
+    return {
+      pointCount: n,
+      positions,
+      // Not readings. See the note at the top of this file: the chunk type
+      // requires these arrays, and a point tile carries none of them.
+      intensity: new Uint16Array(n),
+      classification: new Uint8Array(n),
+      returnNumber: new Uint8Array(n),
+      returnCount: new Uint8Array(n),
+      gpsTime: new Float64Array(n),
+      ...(tile.colors ? { rgb: tile.colors } : {}),
+    };
+  }
+}
+
+/**
+ * The colour modes a point tile can honestly drive.
+ *
+ * Intensity and classification are absent from the format, so they are absent
+ * here. Elevation is derived from position and is always available. Normals
+ * appear only when the tile carried them, which varies per tile, so a source
+ * decides that from what it read rather than from the format alone.
+ */
+export const PNTS_COLOR_MODES = ['rgb', 'elevation'] as const;

--- a/src/render/streaming/EptOctree.ts
+++ b/src/render/streaming/EptOctree.ts
@@ -283,6 +283,7 @@ export class EptOctree implements StreamingOctreeView {
     const record: StreamingNodeRecord = {
       id: eptKeyToString(entry.key),
       key: this._toVoxelKey(entry.key),
+      depth: this._toVoxelKey(entry.key).depth,
       bounds: this._boundsForKey(entry.key),
       pointCount: entry.value,
       // EPT tiles are SEPARATE FILES, not byte ranges within one file.

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -953,7 +953,7 @@ export class StreamingScheduler {
         if (boxInFrustum(box, planes)) {
           score = nodeScore({
             bounds: box,
-            depth: node.record.key.depth,
+            depth: node.record.depth,
             cameraPos: view.cameraPosition,
             depthCap,
           });
@@ -1101,7 +1101,7 @@ export class StreamingScheduler {
       lapsed.push({
         id,
         pointCount: node.residentPointCount,
-        depth: node.record.key.depth,
+        depth: node.record.depth,
         distance: distance(centre, view.cameraPosition),
         visible: node.score > 0,
         // Everything here has been out of the selection for a whole defer
@@ -1158,7 +1158,7 @@ export class StreamingScheduler {
         candidates.push({
           id: node.record.id,
           pointCount: node.residentPointCount,
-          depth: node.record.key.depth,
+          depth: node.record.depth,
           distance: distance(centre, view.cameraPosition),
           // `score` is this tick's cull result: > 0 means inside the frustum.
           // On the stable-camera fast path it is the previous rescore's value,

--- a/tests/fullCloudGradeAdapter.test.ts
+++ b/tests/fullCloudGradeAdapter.test.ts
@@ -30,6 +30,7 @@ function record(id: string, depth: number, pointCount: number, byteSize: number)
   return {
     id,
     key: { depth, x: 0, y: 0, z: 0 },
+    depth,
     bounds: [0, 0, 0, 1, 1, 1],
     pointCount,
     byteOffset: 0,

--- a/tests/pntsDecode.test.ts
+++ b/tests/pntsDecode.test.ts
@@ -1,0 +1,139 @@
+/**
+ * pntsDecode.test.ts — decoding a point tile into a streaming chunk.
+ *
+ * Two things are easy to get wrong and expensive to notice later. The order in
+ * which RTC_CENTER, the tile transform and the render origin are applied, which
+ * silently misplaces a tile rather than failing. And the attributes a point tile
+ * does not carry, which must not be offered as if they were measured.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PntsChunkDecoder,
+  isPntsMetadata,
+  PNTS_COLOR_MODES,
+  type PntsDecodeMetadata,
+} from '../src/io/tiles3d/pntsDecode';
+
+const PNTS_MAGIC = 0x73746e70;
+
+/** A minimal valid `.pnts` body, optionally with RTC_CENTER and RGB. */
+function makePnts(
+  points: readonly (readonly [number, number, number])[],
+  rtc?: readonly [number, number, number],
+  rgb?: readonly (readonly [number, number, number])[],
+): ArrayBuffer {
+  const posBytes = points.length * 3 * 4;
+  const ft: Record<string, unknown> = {
+    POINTS_LENGTH: points.length,
+    POSITION: { byteOffset: 0 },
+  };
+  if (rtc) ft.RTC_CENTER = rtc;
+  if (rgb) ft.RGB = { byteOffset: posBytes };
+  let json = JSON.stringify(ft);
+  while (json.length % 8 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const binBytes = posBytes + (rgb ? points.length * 3 : 0);
+  const total = 28 + jsonBytes.length + binBytes;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, PNTS_MAGIC, true);
+  view.setUint32(4, 1, true);
+  view.setUint32(8, total, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, binBytes, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buf, 28, jsonBytes.length).set(jsonBytes);
+  const binStart = 28 + jsonBytes.length;
+  let k = 0;
+  for (const p of points) for (const c of p) view.setFloat32(binStart + k++ * 4, c, true);
+  if (rgb) {
+    const bytes = new Uint8Array(buf, binStart + posBytes, points.length * 3);
+    let j = 0;
+    for (const c of rgb) for (const v of c) bytes[j++] = v;
+  }
+  return buf;
+}
+
+const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+const meta = (over: Partial<PntsDecodeMetadata> = {}): PntsDecodeMetadata => ({
+  format: 'pnts',
+  tileTransform: IDENTITY,
+  renderOrigin: [0, 0, 0],
+  ...over,
+});
+
+const decoder = new PntsChunkDecoder();
+
+describe('placement', () => {
+  it('adds RTC_CENTER before the tile transform, not after', async () => {
+    // Translate by (100, 0, 0). A point at local (1,0,0) with RTC (10,0,0)
+    // belongs at 111. Applying the transform first would give 101 + 10 = 111
+    // too, so use a SCALING transform, where the order is visible.
+    const scaleBy2 = [2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1];
+    const out = await decoder.decode(
+      makePnts([[1, 0, 0]], [10, 0, 0]),
+      meta({ tileTransform: scaleBy2 }),
+    );
+    // (1 + 10) * 2 = 22. Transform-then-RTC would give 1*2 + 10 = 12.
+    expect(out.positions[0]).toBeCloseTo(22, 6);
+  });
+
+  it('subtracts the render origin last', async () => {
+    const out = await decoder.decode(
+      makePnts([[5, 6, 7]]),
+      meta({ renderOrigin: [5, 6, 7] }),
+    );
+    expect([...out.positions.slice(0, 3)]).toEqual([0, 0, 0]);
+  });
+
+  it('places a point through a translating transform', async () => {
+    const translate = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 100, 200, 300, 1];
+    const out = await decoder.decode(makePnts([[1, 2, 3]]), meta({ tileTransform: translate }));
+    expect([...out.positions.slice(0, 3)]).toEqual([101, 202, 303]);
+  });
+});
+
+describe('attributes the format does not carry', () => {
+  it('never offers intensity or classification as a colour mode', () => {
+    expect(
+      PNTS_COLOR_MODES,
+      'a point tile carries neither, so nothing may offer to paint a scan by them',
+    ).not.toContain('intensity');
+    expect(PNTS_COLOR_MODES).not.toContain('classification');
+  });
+
+  it('sizes the required arrays without claiming they are readings', async () => {
+    const out = await decoder.decode(makePnts([[0, 0, 0], [1, 1, 1]]), meta());
+    expect(out.pointCount).toBe(2);
+    for (const a of [out.intensity, out.classification, out.returnNumber, out.returnCount]) {
+      expect(a).toHaveLength(2);
+      expect([...a].every((v) => v === 0)).toBe(true);
+    }
+  });
+
+  it('carries RGB through when the tile has it, and omits it when it does not', async () => {
+    const withRgb = await decoder.decode(
+      makePnts([[0, 0, 0]], undefined, [[10, 20, 30]]),
+      meta(),
+    );
+    expect([...(withRgb.rgb ?? [])]).toEqual([10, 20, 30]);
+    const without = await decoder.decode(makePnts([[0, 0, 0]]), meta());
+    expect(without.rgb).toBeUndefined();
+  });
+});
+
+describe('metadata routing', () => {
+  it('recognises its own metadata and not LAS metadata', () => {
+    expect(isPntsMetadata(meta())).toBe(true);
+    expect(isPntsMetadata({ pointDataRecordFormat: 6, pointRecordLength: 30 })).toBe(false);
+    expect(isPntsMetadata(null)).toBe(false);
+  });
+
+  it('refuses a body routed to it with metadata for another format', async () => {
+    await expect(
+      decoder.decode(makePnts([[0, 0, 0]]), { pointDataRecordFormat: 6 }),
+    ).rejects.toThrow(/another format/);
+  });
+});

--- a/tests/streamingDepthNeutral.test.ts
+++ b/tests/streamingDepthNeutral.test.ts
@@ -1,0 +1,45 @@
+/**
+ * streamingDepthNeutral.test.ts — the scheduler refines on a depth number, not
+ * on an octree voxel key.
+ *
+ * The refinement throttle (velocity depth cap, pressure reduction) used to read
+ * `record.key.depth`. That tied the policy to a key only an octree-organised
+ * source can produce, and 3D Tiles refines on geometric error over a tree that
+ * is not an octree. The depth now travels on the record itself.
+ *
+ * These cases pin the decoupling rather than the throttle's arithmetic, which
+ * streamingScheduler.test.ts already covers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p: string) => readFileSync(resolve(ROOT, p), 'utf8');
+
+describe('the scheduler does not read a voxel key', () => {
+  it('reaches for no key field at all', () => {
+    const src = read('src/render/streaming/StreamingScheduler.ts');
+    expect(
+      src.includes('record.key'),
+      'the scheduler read a voxel key, which a source that is not an octree ' +
+        'cannot supply. Use record.depth.',
+    ).toBe(false);
+  });
+
+  it('states the depth it refines on', () => {
+    expect(read('src/render/streaming/StreamingScheduler.ts')).toContain('record.depth');
+  });
+});
+
+describe('every source states its own depth', () => {
+  it.each([
+    ['src/io/copc/copcHierarchy.ts', 'COPC hierarchy'],
+    ['src/render/streaming/EptOctree.ts', 'EPT octree'],
+    ['src/io/heavy/OlvTileSource.ts', 'out-of-core tile store'],
+  ])('%s sets depth on the records it builds', (path) => {
+    expect(read(path)).toContain('depth:');
+  });
+});

--- a/tests/streamingHierarchyGeneric.test.ts
+++ b/tests/streamingHierarchyGeneric.test.ts
@@ -256,7 +256,7 @@ function irregularStore(): StreamingNodeStore {
     store.add({
       id,
       // The key is format-specific and meaningless here; nothing reads it.
-      key: { depth: 0, x: 0, y: 0, z: 0 },
+      key: { depth: 0, x: 0, y: 0, z: 0 }, depth: 0,
       bounds,
       pointCount: 100,
       byteOffset: 0,
@@ -337,7 +337,7 @@ describe('a malformed hierarchy cannot spin the walk', () => {
     const store = new StreamingNodeStore();
     store.add({
       id: 'orphan',
-      key: { depth: 1, x: 0, y: 0, z: 0 },
+      key: { depth: 1, x: 0, y: 0, z: 0 }, depth: 1,
       bounds: [0, 0, 0, 1, 1, 1],
       pointCount: 1,
       byteOffset: 0,

--- a/tests/streamingNodeStoreCounts.test.ts
+++ b/tests/streamingNodeStoreCounts.test.ts
@@ -14,7 +14,7 @@ import type { StreamingNodeRecord } from '../src/io/copc/copcTypes';
 function rec(id: string): StreamingNodeRecord {
   return {
     id,
-    key: { depth: 0, x: 0, y: 0, z: 0 },
+    key: { depth: 0, x: 0, y: 0, z: 0 }, depth: 0,
     bounds: [0, 0, 0, 1, 1, 1],
     pointCount: 100,
     byteOffset: 0,

--- a/tests/streamingOctree.test.ts
+++ b/tests/streamingOctree.test.ts
@@ -11,7 +11,7 @@ import type { StreamingNodeRecord } from '../src/io/copc/copcTypes';
 function record(id: string, pointCount: number): StreamingNodeRecord {
   return {
     id,
-    key: { depth: 0, x: 0, y: 0, z: 0 },
+    key: { depth: 0, x: 0, y: 0, z: 0 }, depth: 0,
     bounds: [0, 0, 0, 1, 1, 1],
     pointCount,
     byteOffset: 1000,

--- a/tests/streamingScheduler.test.ts
+++ b/tests/streamingScheduler.test.ts
@@ -981,7 +981,7 @@ test('nodes ingested AFTER scheduler construction still stream (late hierarchy)'
   const base = cloud.octree.nodes().find((n) => n.record.id === '2-0-0-0')!;
   cloud.octree.store.add({
     id: '3-0-0-0',
-    key: { depth: 3, x: 0, y: 0, z: 0 },
+    key: { depth: 3, x: 0, y: 0, z: 0 }, depth: 3,
     bounds: [-128, -128, -128, -96, -96, -96],
     pointCount: 200,
     byteOffset: base.record.byteOffset,


### PR DESCRIPTION
First step toward streaming a 3D Tiles tileset instead of reading it once in full.

The scheduler throttles refinement by depth under camera velocity and memory pressure, and read `record.key.depth` to do it. That tied the policy to a voxel key only an octree-organised source can produce. COPC and EPT both have one; a tileset refines on geometric error over a tree that is not an octree, so it has none.

`StreamingNodeRecord` now carries `depth`, set by each of the three sources that build records from the key they already hold. The scheduler reads it, and `record.key` appears nowhere in the scheduler now. Behaviour is unchanged: the same numbers reach the same throttle, and the streaming suites pass untouched. A test pins the decoupling, since a future edit could reach back through the key without any other gate noticing.
