### PR TITLE
feat(tiles3d): serve a tileset through the streaming pipeline

### DIFF
--- a/src/app/crsCoordinator.ts
+++ b/src/app/crsCoordinator.ts
@@ -31,6 +31,8 @@ function crsSourceForKind(kind: StreamingSourceKind): CrsSource {
       return 'ept-srs';
     case 'tiles':
       return 'las-vlr';
+    case '3dtiles':
+      return 'tileset-region';
     case 'copc':
       return 'copc-meta';
   }

--- a/src/geo/CoordinateTypes.ts
+++ b/src/geo/CoordinateTypes.ts
@@ -51,6 +51,10 @@ export type CrsSource =
   | 'las-vlr'
   | 'copc-meta'
   | 'ept-srs'
+  // A 3D Tiles `region` bounding volume, which the spec fixes as EPSG:4979.
+  // It is the only in-spec place a tileset states a frame; a box- or
+  // sphere-bounded tileset declares none and must not be given one.
+  | 'tileset-region'
   | 'catalog-tile'
   | 'user-override'
   | 'default-assumption';

--- a/src/io/copc/copcChunkDecode.ts
+++ b/src/io/copc/copcChunkDecode.ts
@@ -70,13 +70,16 @@ export interface DecodedChunk {
   rgbEightBit?: boolean;
 }
 
-/** Decodes a compressed COPC node chunk into local-space attributes. */
-export interface ChunkDecoder {
-  decode(
-    chunk: ArrayBuffer,
-    meta: ChunkDecodeMetadata,
-    signal?: AbortSignal,
-  ): Promise<DecodedChunk>;
+/**
+ * Decodes one node's bytes into local-space attributes.
+ *
+ * The metadata type is a parameter because the scheduler never inspects it: it
+ * takes whatever the source returns and hands it to the decoder that source was
+ * built with. A LAZ decoder keeps the default and is unchanged; a decoder for
+ * another body, such as a `.pnts` tile, names its own metadata instead.
+ */
+export interface ChunkDecoder<TMeta = ChunkDecodeMetadata> {
+  decode(chunk: ArrayBuffer, meta: TMeta, signal?: AbortSignal): Promise<DecodedChunk>;
 }
 
 /** Point source id offset in PDRF 6, 7, and 8. */

--- a/src/io/tiles3d/tilesetNodes.ts
+++ b/src/io/tiles3d/tilesetNodes.ts
@@ -1,0 +1,125 @@
+/**
+ * tilesetNodes.ts — turn a parsed tileset into the streaming node model.
+ *
+ * The scheduler culls, scores and budgets over a flat store of nodes, each
+ * carrying an id, a depth, world bounds and a point count. A tileset carries
+ * the first three directly once its tree is walked. The fourth it does not
+ * carry at all, which is the one interesting decision here.
+ *
+ * POINT COUNTS. A `tileset.json` never states how many points a tile holds;
+ * only the `.pnts` body knows, and reading every body to find out would defeat
+ * the point of streaming. So each node is admitted with an ESTIMATE, and the
+ * estimate is deliberately high. The scheduler's own admission gate documents
+ * why that is the safe direction: it refuses to start a decode while resident
+ * plus in-flight already sits at the pressure cap, and "small over-estimates
+ * only mean we dispatch slightly fewer decodes when at the boundary, never
+ * more". Once a tile decodes, the store holds its true resident count, so the
+ * estimate governs admission only and never what the viewer reports.
+ *
+ * IDENTITY. A node is identified by its content URI resolved against the
+ * tileset, which is stable across runs and unique per body. Tiles without
+ * content are structure, not data: they are walked for their transform and
+ * their children but produce no node, because there is nothing to fetch.
+ *
+ * Pure: no fetch, no DOM.
+ */
+
+import type { Box6, StreamingNodeRecord } from '../copc/copcTypes';
+import type { Mat4 } from './tileTransform';
+import { walkTilePlacements } from './tileTransform';
+import { volumeToAabb } from './tilesetTraversal';
+import type { Tileset } from './tileset';
+
+/**
+ * Points assumed for a tile whose body has not been read.
+ *
+ * Chosen against the ceiling this repo already applies to a single point tile
+ * rather than against a typical file: an estimate that is too low would admit
+ * more decodes than the budget intends, which is the one direction the
+ * scheduler's gate cannot absorb.
+ */
+export const ASSUMED_TILE_POINTS = 500_000;
+
+/** What a streaming source needs to serve a tileset's tiles. */
+export interface TilesetNodeIndex {
+  /** One record per tile that has content, in walk order. */
+  readonly records: readonly StreamingNodeRecord[];
+  /** Node id to the content URI to fetch, as authored, relative to the tileset. */
+  readonly contentUri: ReadonlyMap<string, string>;
+  /** Node id to the cumulative root-to-tile transform the decoder must apply. */
+  readonly transform: ReadonlyMap<string, Mat4>;
+  /** Tiles skipped, and why. Never silent: a dropped tile is missing data. */
+  readonly skipped: readonly string[];
+}
+
+/** An AABB as the streaming model's flat six-number box. */
+function toBox6(min: readonly number[], max: readonly number[]): Box6 {
+  return [min[0], min[1], min[2], max[0], max[1], max[2]];
+}
+
+/**
+ * Build the node index for a tileset.
+ *
+ * `rootTransform` places the whole tileset, which is how a geocentric tileset
+ * is brought into a local ENU frame before anything is bounded or culled.
+ */
+export function tilesetNodes(tileset: Tileset, rootTransform?: Mat4): TilesetNodeIndex {
+  const records: StreamingNodeRecord[] = [];
+  const contentUri = new Map<string, string>();
+  const transform = new Map<string, Mat4>();
+  const skipped: string[] = [];
+  const seen = new Set<string>();
+  // Nearest ancestor WITH content, so the store's parent chain skips the
+  // structural tiles that produce no node of their own.
+  const contentParent: string[] = [];
+
+  for (const placed of walkTilePlacements(tileset.root, rootTransform)) {
+    contentParent.length = Math.min(contentParent.length, placed.depth);
+    const uri = placed.tile.contentUri;
+    if (uri == null) continue;
+
+    const aabb = volumeToAabb(placed.boundingVolume);
+    if (aabb == null) {
+      skipped.push(`${uri}: bounding volume carries none of box, region or sphere.`);
+      continue;
+    }
+    if (seen.has(uri)) {
+      skipped.push(`${uri}: a second tile names the same content; only the first is served.`);
+      continue;
+    }
+    seen.add(uri);
+
+    // Nearest ANCESTOR that produced a node, which may be several levels up:
+    // a chain of structural tiles leaves those depths unset, and looking only
+    // one level up left such a leaf parentless.
+    let parentId: string | undefined;
+    for (let d = placed.depth - 1; d >= 0; d--) {
+      if (contentParent[d] != null) {
+        parentId = contentParent[d];
+        break;
+      }
+    }
+
+    records.push({
+      id: uri,
+      // The streaming model still types a voxel key. A tileset has none, so
+      // the depth is repeated into it rather than inventing coordinates that
+      // would read as an octree address. Nothing consumes it for this source:
+      // the scheduler refines on `depth`.
+      key: { depth: placed.depth, x: 0, y: 0, z: 0 },
+      depth: placed.depth,
+      bounds: toBox6(aabb.min, aabb.max),
+      pointCount: ASSUMED_TILE_POINTS,
+      // A tile is a separate resource, not a range inside one file.
+      byteOffset: 0,
+      byteSize: 0,
+      spacing: placed.geometricError,
+      parentId,
+    });
+    contentUri.set(uri, uri);
+    transform.set(uri, placed.transform);
+    contentParent[placed.depth] = uri;
+  }
+
+  return { records, contentUri, transform, skipped };
+}

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -20,6 +20,7 @@ import {
 } from './streamingHierarchy';
 import { GpuUploadQueue } from '../gpuUploadQueue';
 import type { ChunkDecoder, DecodedChunk } from '../../io/copc/copcChunkDecode';
+import type { NodeDecodeMetadata } from './StreamingSource';
 import type { StreamingSource } from './StreamingSource';
 import type { StreamingNode } from './StreamingNode';
 import {
@@ -432,7 +433,7 @@ export function decodedChunkBytes(decoded: DecodedChunk): number {
  */
 export class StreamingScheduler {
   private readonly _cloud: StreamingSource;
-  private readonly _decoder: ChunkDecoder;
+  private readonly _decoder: ChunkDecoder<NodeDecodeMetadata>;
   private readonly _callbacks: SchedulerCallbacks;
   private readonly _localBounds = new Map<string, Box6>();
   /** The cloud's render origin, captured once for lazy bounds computation. */
@@ -556,7 +557,7 @@ export class StreamingScheduler {
 
   constructor(
     cloud: StreamingSource,
-    decoder: ChunkDecoder,
+    decoder: ChunkDecoder<NodeDecodeMetadata>,
     callbacks: SchedulerCallbacks,
     budgets: StreamingBudgets,
     options: SchedulerOptions = {},

--- a/src/render/streaming/StreamingSource.ts
+++ b/src/render/streaming/StreamingSource.ts
@@ -24,6 +24,7 @@
 import type { Box6, StreamingNodeRecord } from '../../io/copc/copcTypes';
 import type { SpatialFrame } from '../../geo/frame/spatialFrame';
 import type { ChunkDecodeMetadata } from '../../io/copc/copcChunkDecode';
+import type { PntsDecodeMetadata } from '../../io/tiles3d/pntsDecode';
 import type { StreamingNode } from './StreamingNode';
 import type { NodeCounts, StreamingNodeStore } from './StreamingNodeStore';
 
@@ -71,8 +72,19 @@ export interface StreamingOctreeView {
   readonly errors: readonly string[];
 }
 
+/**
+ * What a decoder is handed alongside a node's bytes.
+ *
+ * The scheduler never reads a field of this: it obtains it from the source and
+ * passes it to the decoder the source was built with. So the union only has to
+ * be wide enough for every body a source can serve. LAS metadata carries no
+ * `format` field, which is what lets a decoder narrow with an `in` check
+ * without a single existing metadata site changing.
+ */
+export type NodeDecodeMetadata = ChunkDecodeMetadata | PntsDecodeMetadata;
+
 /** The on-disk format a streaming source is backed by. */
-export type StreamingSourceKind = 'copc' | 'ept' | 'tiles';
+export type StreamingSourceKind = 'copc' | 'ept' | 'tiles' | '3dtiles';
 
 /**
  * The name to show a user for a source kind. Kept beside the union so a new
@@ -86,6 +98,8 @@ export function streamingSourceLabel(kind: StreamingSourceKind): string {
       return 'EPT (Entwine Point Tile)';
     case 'tiles':
       return 'OLV tile store (out-of-core index)';
+    case '3dtiles':
+      return '3D Tiles (point tiles)';
     case 'copc':
       return 'COPC (Cloud Optimized Point Cloud)';
   }
@@ -101,6 +115,8 @@ export function streamingFormatToken(kind: StreamingSourceKind): string {
       return 'EPT';
     case 'tiles':
       return 'OLV tiles';
+    case '3dtiles':
+      return '3D Tiles';
     case 'copc':
       return 'COPC';
   }
@@ -226,7 +242,7 @@ export interface StreamingSource {
    * etc. The scheduler hands this to the {@link ChunkDecoder} along with
    * the chunk bytes, and the worker uses it to produce a {@link DecodedChunk}.
    */
-  decodeMeta(record: StreamingNodeRecord): ChunkDecodeMetadata;
+  decodeMeta(record: StreamingNodeRecord): NodeDecodeMetadata;
   /**
    * Record the RGB bit-depth decision the first decoded chunk made, so the
    * source can hand it back through {@link ChunkDecodeMetadata.rgbEightBit} and

--- a/src/render/streaming/TilesetStreamingSource.ts
+++ b/src/render/streaming/TilesetStreamingSource.ts
@@ -1,0 +1,197 @@
+/**
+ * TilesetStreamingSource.ts — a 3D Tiles tileset as a streaming source.
+ *
+ * The scheduler, the renderer and the picking path all read a source through
+ * {@link StreamingSource} and never learn which format is behind it. COPC and
+ * EPT satisfy it as octrees of LAZ chunks. A tileset satisfies it as a tree of
+ * separately addressed `.pnts` bodies, which the interface already allows:
+ * `readNodeChunk` is the seam where a source turns a node into bytes however
+ * its format requires, and the decoder is injected rather than assumed.
+ *
+ * What this source does NOT do, deliberately:
+ *
+ *   Implicit tiling. `tilesetNodes` walks the explicit tree, so a tileset that
+ *   declares subtrees produces no nodes for them. The parser already refuses
+ *   such a document, so this cannot silently under-serve one.
+ *
+ *   Mesh content. A tile whose content is not a point tile has no place in a
+ *   point cloud, and the parser refuses those too.
+ *
+ * POINT COUNTS. `sourcePointCount` is null rather than a sum of the per-node
+ * estimates. The estimates exist to govern decode admission and are not
+ * measurements, so adding them up would put a fabricated total in front of a
+ * user and into the scan report. Null is the interface's way of saying the
+ * format does not state it.
+ */
+
+import type { Box6, StreamingNodeRecord } from '../../io/copc/copcTypes';
+import type { CrsInfo } from '../../io/crs';
+import type { SpatialFrame } from '../../geo/frame/spatialFrame';
+import { createTranslatedFrame } from '../../geo/frame/spatialFrame';
+import type { Mat4 } from '../../io/tiles3d/tileTransform';
+import type { TilesetTransport } from '../../io/tiles3d/tilesetTransport';
+import { PNTS_COLOR_MODES, type PntsDecodeMetadata } from '../../io/tiles3d/pntsDecode';
+import { tilesetNodes, type TilesetNodeIndex } from '../../io/tiles3d/tilesetNodes';
+import type { Tileset } from '../../io/tiles3d/tileset';
+import { StreamingNodeStore } from './StreamingNodeStore';
+import type { NodeCounts } from './StreamingNodeStore';
+import type { StreamingNode } from './StreamingNode';
+import type {
+  NodeDecodeMetadata,
+  StreamingColorMode,
+  StreamingOctreeView,
+  StreamingSource,
+  StreamingSourceKind,
+} from './StreamingSource';
+
+/** Resolve a tile's authored content URI against the tileset document. */
+export function resolveTileUrl(baseUrl: string, uri: string): string {
+  return new URL(uri, baseUrl).toString();
+}
+
+/** The union of every node's bounds, or null when there are no nodes. */
+function unionBounds(records: readonly StreamingNodeRecord[]): Box6 | null {
+  if (records.length === 0) return null;
+  const b: number[] = [...records[0].bounds];
+  for (const r of records) {
+    for (let i = 0; i < 3; i++) {
+      if (r.bounds[i] < b[i]) b[i] = r.bounds[i];
+      if (r.bounds[i + 3] > b[i + 3]) b[i + 3] = r.bounds[i + 3];
+    }
+  }
+  return b as Box6;
+}
+
+/** Centre of a box, used as the render origin so float32 keeps its precision. */
+function centreOf(b: Box6): [number, number, number] {
+  return [(b[0] + b[3]) / 2, (b[1] + b[4]) / 2, (b[2] + b[5]) / 2];
+}
+
+/** The octree-shaped view the scheduler reads. A tileset tree is not an octree. */
+class TilesetTreeView implements StreamingOctreeView {
+  readonly store = new StreamingNodeStore();
+  readonly errors: readonly string[];
+
+  constructor(index: TilesetNodeIndex) {
+    for (const record of index.records) this.store.add(record);
+    for (const record of index.records) {
+      if (record.parentId == null) continue;
+      this.store.get(record.parentId)?.childIds.push(record.id);
+    }
+    this.errors = index.skipped;
+  }
+
+  nodes(): StreamingNode[] {
+    return this.store.all();
+  }
+
+  /** Complete when the walk kept every tile it met. A skip is a dropped tile. */
+  get isComplete(): boolean {
+    return this.errors.length === 0;
+  }
+}
+
+/** A tileset served through the streaming pipeline. */
+export class TilesetStreamingSource implements StreamingSource {
+  readonly kind: StreamingSourceKind = '3dtiles';
+  readonly renderOrigin: [number, number, number];
+  readonly frame: SpatialFrame;
+  readonly octree: StreamingOctreeView;
+
+  readonly id: string;
+  readonly name: string;
+
+  private readonly _index: TilesetNodeIndex;
+  private readonly _bounds: Box6;
+  private readonly _baseUrl: string;
+  private readonly _transport: TilesetTransport;
+  private readonly _crs: CrsInfo | null;
+
+  constructor(
+    id: string,
+    name: string,
+    baseUrl: string,
+    transport: TilesetTransport,
+    tileset: Tileset,
+    rootTransform?: Mat4,
+    crs: CrsInfo | null = null,
+  ) {
+    this.id = id;
+    this.name = name;
+    this._baseUrl = baseUrl;
+    this._transport = transport;
+    this._crs = crs;
+    this._index = tilesetNodes(tileset, rootTransform);
+    this._bounds = unionBounds(this._index.records) ?? [0, 0, 0, 0, 0, 0];
+    this.renderOrigin = centreOf(this._bounds);
+    this.frame = createTranslatedFrame(this.renderOrigin);
+    this.octree = new TilesetTreeView(this._index);
+  }
+
+  /**
+   * Null on purpose: a tileset states no point total, and the per-node numbers
+   * are admission estimates rather than counts. See the note at the top.
+   */
+  get sourcePointCount(): number | null {
+    return null;
+  }
+
+  get residentPointCount(): number {
+    return this.octree.store.residentPointCount;
+  }
+
+  counts(): NodeCounts {
+    return this.octree.store.counts();
+  }
+
+  maxDepth(): number {
+    let d = 0;
+    for (const node of this.octree.nodes()) if (node.record.depth > d) d = node.record.depth;
+    return d;
+  }
+
+  /** Bounds relative to the render origin, which is what the culler works in. */
+  localBounds(): Box6 {
+    const [rx, ry, rz] = this.renderOrigin;
+    const b = this._bounds;
+    return [b[0] - rx, b[1] - ry, b[2] - rz, b[3] - rx, b[4] - ry, b[5] - rz];
+  }
+
+  /** The tileset's own bounds, before the render origin is taken out. */
+  dataBounds(): Box6 {
+    return [...this._bounds] as Box6;
+  }
+
+  defaultColorMode(): StreamingColorMode {
+    return 'rgb';
+  }
+
+  /**
+   * Only what a point tile can carry. Intensity, classification and returns are
+   * absent from the format, so nothing offers to paint a scan by them.
+   */
+  availableColorModes(): readonly StreamingColorMode[] {
+    return PNTS_COLOR_MODES;
+  }
+
+  crs(): CrsInfo | null {
+    return this._crs;
+  }
+
+  async readNodeChunk(record: StreamingNodeRecord, signal?: AbortSignal): Promise<ArrayBuffer> {
+    const uri = this._index.contentUri.get(record.id);
+    if (uri == null) throw new Error(`No content URI for tile ${record.id}.`);
+    return this._transport.fetchTileBytes(resolveTileUrl(this._baseUrl, uri), signal);
+  }
+
+  decodeMeta(record: StreamingNodeRecord): NodeDecodeMetadata {
+    const transform = this._index.transform.get(record.id);
+    if (transform == null) throw new Error(`No transform for tile ${record.id}.`);
+    const meta: PntsDecodeMetadata = {
+      format: 'pnts',
+      tileTransform: transform,
+      renderOrigin: this.renderOrigin,
+    };
+    return meta;
+  }
+}

--- a/src/render/streaming/fullCloudGradeAdapter.ts
+++ b/src/render/streaming/fullCloudGradeAdapter.ts
@@ -23,8 +23,9 @@
  */
 
 import type { StreamingNode } from './StreamingNode';
+import type { NodeDecodeMetadata } from './StreamingSource';
 import type { StreamingNodeRecord } from '../../io/copc/copcTypes';
-import type { ChunkDecodeMetadata, ChunkDecoder } from '../../io/copc/copcChunkDecode';
+import type { ChunkDecoder } from '../../io/copc/copcChunkDecode';
 import { renderLocalPositions } from '../../model/pointFrames';
 import type { SamplingPlanOptions, SampleNode } from './samplingPlan';
 import {
@@ -58,7 +59,7 @@ export interface GradeNodeSource {
     readonly errors: readonly string[];
   };
   readNodeChunk(record: StreamingNodeRecord, signal?: AbortSignal): Promise<ArrayBuffer>;
-  decodeMeta(record: StreamingNodeRecord): ChunkDecodeMetadata;
+  decodeMeta(record: StreamingNodeRecord): NodeDecodeMetadata;
 }
 
 /**
@@ -93,7 +94,7 @@ export function sampleNodesFromSource(source: GradeNodeSource): SampleNode[] {
  */
 export function makeDecodeNode(
   source: GradeNodeSource,
-  decoder: ChunkDecoder,
+  decoder: ChunkDecoder<NodeDecodeMetadata>,
 ): DecodeNodeFn {
   return async (id: string, signal?: AbortSignal): Promise<Float32Array> => {
     const node = source.octree.store.get(id);
@@ -134,7 +135,7 @@ export function makeDecodeNode(
  */
 export function gradeFullCloud<G>(args: {
   readonly source: GradeNodeSource;
-  readonly decoder: ChunkDecoder;
+  readonly decoder: ChunkDecoder<NodeDecodeMetadata>;
   readonly grade: GradeFn<G>;
   readonly options?: SamplingPlanOptions;
   readonly signal?: AbortSignal;

--- a/src/ui/Inspector.ts
+++ b/src/ui/Inspector.ts
@@ -2229,6 +2229,7 @@ export class Inspector {
       'las-vlr': 'LAS / LAZ georeference VLR',
       'copc-meta': 'COPC metadata',
       'ept-srs': 'EPT srs.wkt',
+      'tileset-region': '3D Tiles region bounding volume',
       'catalog-tile': 'Public-catalog tile',
       'user-override': 'User override',
       'default-assumption': 'No metadata',

--- a/tests/benchmark/streamingNav.test.ts
+++ b/tests/benchmark/streamingNav.test.ts
@@ -42,6 +42,7 @@ import {
   StreamingScheduler,
   decodedChunkBytes,
 } from '../../src/render/streaming/StreamingScheduler';
+import type { NodeDecodeMetadata } from '../../src/render/streaming/StreamingSource';
 import type { StreamingSource } from '../../src/render/streaming/StreamingSource';
 import { streamingBudgets } from '../../src/render/streaming/streamingBudget';
 import type {
@@ -263,7 +264,7 @@ export async function runStreamingNavigation(opts: NavRunOptions): Promise<NavRu
   // wrapped source hands the decoder — the seam that lets a decode be tied
   // back to the node that dispatched it, without touching the scheduler.
   const firstQueuedAt = new Map<string, number>();
-  const metaToNode = new Map<ChunkDecodeMetadata, { id: string; est: number }>();
+  const metaToNode = new Map<NodeDecodeMetadata, { id: string; est: number }>();
   const evictedAt = new Map<string, number>();
   let inFlightBytes = 0;
   let decodedNotResidentBytes = 0;
@@ -275,7 +276,7 @@ export async function runStreamingNavigation(opts: NavRunOptions): Promise<NavRu
   const wrappedSource = new Proxy(cloud as StreamingSource, {
     get(target, prop, _receiver) {
       if (prop === 'decodeMeta') {
-        return (record: Parameters<StreamingSource['decodeMeta']>[0]): ChunkDecodeMetadata => {
+        return (record: Parameters<StreamingSource['decodeMeta']>[0]): NodeDecodeMetadata => {
           const meta = target.decodeMeta(record);
           const id = record.id;
           const est = record.pointCount * EST_BYTES_PER_POINT;
@@ -298,12 +299,15 @@ export async function runStreamingNavigation(opts: NavRunOptions): Promise<NavRu
 
   // --- Decoder wrapper: time the real decode, and account decoded bytes as a
   //     not-yet-resident backlog until onNodeReady clears them. ---
-  const decoder: ChunkDecoder = {
+  const decoder: ChunkDecoder<NodeDecodeMetadata> = {
     decode: async (
       _chunk: ArrayBuffer,
-      meta: ChunkDecodeMetadata,
+      meta: NodeDecodeMetadata,
       _signal?: AbortSignal,
     ): Promise<DecodedChunk> => {
+      // This benchmark drives a COPC source. Point-tile metadata reaching it
+      // would mean the harness was rewired, not that the decode should guess.
+      if ('format' in meta) throw new Error('streamingNav drives COPC, not point tiles.');
       const started = now();
       const decoded = representativeDecode(meta);
       samples.pushDecodeMs(now() - started);

--- a/tests/tilesetNodes.test.ts
+++ b/tests/tilesetNodes.test.ts
@@ -1,0 +1,135 @@
+/**
+ * tilesetNodes.test.ts — a tileset seen as streaming nodes.
+ *
+ * The interesting decisions are the ones the format does not settle: what a
+ * tile's point count is before its body is read, which tiles become nodes at
+ * all, and how the parent chain survives tiles that carry no content.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { tilesetNodes, ASSUMED_TILE_POINTS } from '../src/io/tiles3d/tilesetNodes';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+
+/** A tileset document with the given root tile tree. */
+function ts(root: unknown) {
+  return parseTileset(JSON.stringify({ asset: { version: '1.0' }, geometricError: 100, root }));
+}
+
+const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
+
+describe('which tiles become nodes', () => {
+  it('makes a node per tile that has content', () => {
+    const t = ts({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'REPLACE',
+      content: { uri: 'root.pnts' },
+      children: [
+        { boundingVolume: BOX, geometricError: 10, content: { uri: 'a.pnts' } },
+        { boundingVolume: BOX, geometricError: 10, content: { uri: 'b.pnts' } },
+      ],
+    });
+    const idx = tilesetNodes(t);
+    expect(idx.records.map((r) => r.id)).toEqual(['root.pnts', 'a.pnts', 'b.pnts']);
+  });
+
+  it('produces no node for a tile that carries no content', () => {
+    const t = ts({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'REPLACE',
+      children: [{ boundingVolume: BOX, geometricError: 10, content: { uri: 'only.pnts' } }],
+    });
+    const idx = tilesetNodes(t);
+    expect(idx.records.map((r) => r.id)).toEqual(['only.pnts']);
+  });
+
+  it('keeps the parent chain across a structural tile', () => {
+    // root(content) -> middle(NO content) -> leaf(content).
+    const t = ts({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'REPLACE',
+      content: { uri: 'root.pnts' },
+      children: [
+        {
+          boundingVolume: BOX,
+          geometricError: 25,
+          children: [{ boundingVolume: BOX, geometricError: 10, content: { uri: 'leaf.pnts' } }],
+        },
+      ],
+    });
+    const idx = tilesetNodes(t);
+    const leaf = idx.records.find((r) => r.id === 'leaf.pnts');
+    expect(
+      leaf?.parentId,
+      'the leaf must chain to the nearest ancestor that has a node, not to a tile with none',
+    ).toBe('root.pnts');
+  });
+
+  it('records a skip rather than dropping a tile silently', () => {
+    const t = ts({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'REPLACE',
+      content: { uri: 'dup.pnts' },
+      children: [{ boundingVolume: BOX, geometricError: 10, content: { uri: 'dup.pnts' } }],
+    });
+    const idx = tilesetNodes(t);
+    expect(idx.records).toHaveLength(1);
+    expect(idx.skipped.join(' ')).toContain('same content');
+  });
+});
+
+describe('the point count a tileset does not state', () => {
+  it('admits every tile with the same high estimate', () => {
+    const t = ts({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'REPLACE',
+      content: { uri: 'root.pnts' },
+    });
+    expect(tilesetNodes(t).records[0].pointCount).toBe(ASSUMED_TILE_POINTS);
+  });
+
+  it('estimates high, because the scheduler can only absorb over-estimates', () => {
+    // The admission gate refuses a decode when resident + in-flight is at the
+    // cap. Over-estimating dispatches fewer decodes; under-estimating admits
+    // more than the budget intends, which it cannot take back.
+    expect(ASSUMED_TILE_POINTS).toBeGreaterThanOrEqual(100_000);
+  });
+});
+
+describe('what the scheduler and decoder are handed', () => {
+  it('carries depth and a per-tile transform', () => {
+    const t = ts({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'REPLACE',
+      content: { uri: 'root.pnts' },
+      children: [
+        {
+          boundingVolume: BOX,
+          geometricError: 10,
+          transform: [2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 5, 0, 0, 1],
+          content: { uri: 'child.pnts' },
+        },
+      ],
+    });
+    const idx = tilesetNodes(t);
+    expect(idx.records.find((r) => r.id === 'child.pnts')?.depth).toBe(1);
+    expect(idx.transform.get('child.pnts')?.[12]).toBe(5);
+  });
+
+  it('bounds every node, so nothing is culled against an empty box', () => {
+    const t = ts({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'REPLACE',
+      content: { uri: 'root.pnts' },
+    });
+    const b = tilesetNodes(t).records[0].bounds;
+    expect(b).toHaveLength(6);
+    expect(b[3] - b[0]).toBeGreaterThan(0);
+  });
+});

--- a/tests/tilesetStreamingSource.test.ts
+++ b/tests/tilesetStreamingSource.test.ts
@@ -1,0 +1,110 @@
+/**
+ * tilesetStreamingSource.test.ts — a tileset served through the streaming
+ * pipeline.
+ *
+ * The source's job is to answer the scheduler honestly about a format that
+ * states less than COPC does. The cases that matter are the ones where it would
+ * be easy to invent an answer: a point total the tileset never gives, colour
+ * modes the bodies cannot fill, and a tile URL resolved against the wrong base.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TilesetStreamingSource, resolveTileUrl } from '../src/render/streaming/TilesetStreamingSource';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import type { TilesetTransport } from '../src/io/tiles3d/tilesetTransport';
+
+const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
+
+function ts(root: unknown) {
+  return parseTileset(JSON.stringify({ asset: { version: '1.0' }, geometricError: 100, root }));
+}
+
+const TREE = ts({
+  boundingVolume: BOX,
+  geometricError: 50,
+  refine: 'REPLACE',
+  content: { uri: 'root.pnts' },
+  children: [{ boundingVolume: BOX, geometricError: 10, content: { uri: 'sub/a.pnts' } }],
+});
+
+/** A transport that records what it was asked for. */
+function transport(): TilesetTransport & { readonly asked: string[] } {
+  const asked: string[] = [];
+  return {
+    asked,
+    fetchTilesetJson: async () => '{}',
+    fetchTileBytes: async (url: string) => {
+      asked.push(url);
+      return new ArrayBuffer(8);
+    },
+  };
+}
+
+const source = (t = transport()) =>
+  new TilesetStreamingSource('id', 'A tileset', 'https://host/data/tileset.json', t, TREE);
+
+describe('what the source refuses to invent', () => {
+  it('reports no source point count, because a tileset states none', () => {
+    expect(
+      source().sourcePointCount,
+      'the per-node numbers are admission estimates, so summing them would put ' +
+        'a fabricated total in the scan report',
+    ).toBeNull();
+  });
+
+  it('offers only the colour modes a point tile can fill', () => {
+    const modes = source().availableColorModes();
+    expect(modes).toContain('rgb');
+    expect(modes).not.toContain('intensity');
+    expect(modes).not.toContain('classification');
+  });
+});
+
+describe('addressing a tile', () => {
+  it('resolves a content URI against the tileset document, not the host root', () => {
+    expect(resolveTileUrl('https://host/data/tileset.json', 'sub/a.pnts')).toBe(
+      'https://host/data/sub/a.pnts',
+    );
+  });
+
+  it('fetches the resolved URL for a node', async () => {
+    const t = transport();
+    const s = source(t);
+    const node = s.octree.nodes().find((n) => n.record.id === 'sub/a.pnts')!;
+    await s.readNodeChunk(node.record);
+    expect(t.asked).toEqual(['https://host/data/sub/a.pnts']);
+  });
+
+  it('hands the decoder the tile transform', () => {
+    const s = source();
+    const meta = s.decodeMeta(s.octree.nodes()[0].record);
+    expect('format' in meta && meta.format).toBe('pnts');
+  });
+});
+
+describe('the shape the scheduler reads', () => {
+  it('exposes one node per tile with content, with the parent chain wired', () => {
+    const s = source();
+    const ids = s.octree.nodes().map((n) => n.record.id).sort();
+    expect(ids).toEqual(['root.pnts', 'sub/a.pnts']);
+    expect(s.octree.store.get('root.pnts')?.childIds).toEqual(['sub/a.pnts']);
+  });
+
+  it('centres the render origin inside the data bounds', () => {
+    const s = source();
+    const b = s.dataBounds();
+    const [rx] = s.renderOrigin;
+    expect(rx).toBeGreaterThanOrEqual(b[0]);
+    expect(rx).toBeLessThanOrEqual(b[3]);
+  });
+
+  it('reports local bounds around the origin', () => {
+    const l = source().localBounds();
+    expect(l[0]).toBeLessThanOrEqual(0);
+    expect(l[3]).toBeGreaterThanOrEqual(0);
+  });
+
+  it('says it is complete only when the walk dropped nothing', () => {
+    expect(source().octree.isComplete).toBe(true);
+  });
+});


### PR DESCRIPTION
Third step toward streaming a tileset. The scheduler culls, scores and budgets over a flat store of nodes carrying an id, a depth, world bounds and a point count. A walked tileset supplies the first three directly. It never states the fourth, and that is the only real decision here.

Each node is admitted with a high estimate, because the scheduler's own admission gate says that is the absorbable direction: it refuses a decode while resident plus in-flight already sits at the pressure cap, so an over-estimate dispatches fewer decodes rather than more. Once a tile decodes the store holds its true resident count, so the estimate governs admission and never what the viewer reports.

A tile with no content is structure. It is walked for its transform and its children but produces no node, since there is nothing to fetch, and its descendants chain to the nearest ancestor that did produce one. That ancestor can be several levels up, which a test caught: looking one level up left such a leaf with no parent at all.

A duplicate content URI and a volume carrying none of box, region or sphere are recorded as skips. A dropped tile is missing data, so nothing is dropped silently.


Also here: `decodeMeta` returns the union of the two bodies a source can serve, and `ChunkDecoder` takes its metadata as a parameter defaulting to the LAS shape, so every existing decoder is unchanged. `TilesetStreamingSource` implements the contract on top of the node index and fetches each tile through the existing transport. It reports no source point count, because summing admission estimates would put a fabricated total in the scan report.

Adding the `3dtiles` kind made three exhaustive switches fail to compile, which is what that union's comment says it is for.

Its CRS source is the `region` bounding volume, the only in-spec place a tileset states a frame.
