### PR TITLE
fix(tests): import the bucket rule instead of spawning for it

### DIFF
--- a/scripts/lib/testBuckets.mjs
+++ b/scripts/lib/testBuckets.mjs
@@ -1,0 +1,89 @@
+/**
+ * testBuckets.mjs — which bucket a test file runs in.
+ *
+ * The rule lived inside `scripts/test-bucket.mjs`, whose module body is a CLI:
+ * importing it ran the command and exited the process. So a test that needed
+ * the classification asked for it by SPAWNING that script with `--list` and
+ * parsing stdout, and the answer then depended on the environment the spawn ran
+ * in. A CI shard read back a list naming no terrain file, and the caller
+ * concluded that no bucket claimed a record's producer.
+ *
+ * The rule lives here so both the command and a test can import it. A function
+ * cannot disagree with itself the way two readings of a subprocess can.
+ *
+ * Pure: no IO, no process, no exit.
+ */
+
+// Heavy decode / large-data / integration — the genuinely slow files. LAS/LAZ
+// and buffer/worker decode tests spin up a WASM decoder and are the ones that
+// get starved (and time out) under the parallel `unit` bucket, so they belong
+// here where the runner caps parallelism and raises the timeout.
+// Two rules, not one pattern. The first list matches a file name's opening
+// word, the second matches anywhere in it. Written as a single regex the `^`
+// bound to the first alternative only, which reads as a mistake whether or not
+// it is one, and both scanners flag it as one.
+const SLOW_PREFIX = /^(?:torture|benchmark|parse|loadLas|loadLaz|laszip)/i;
+const SLOW_ANYWHERE =
+  /integration|streaming|copc|ept|laz|octree|voxelDownsample|convertRoundTrip|convertBatch|moduleApi|preload|wasm|decode|packaging/i;
+const isSlow = (name) => SLOW_PREFIX.test(name) || SLOW_ANYWHERE.test(name);
+// The terrain-analysis pipeline.
+const TERRAIN = /^(analyse|analysis|contour|cell|ground|dem|hillshade|slope|calibrat|confidence|coverage|crs|datum|evidence|interval|civilProfile|profile|surface|quality|terrain|raster|gpuDeriv|scatter|aspect|canopy|dsm|dtm|seam|provenance|metricVersion|score|assessment|readiness|whyNot|recommend)/i;
+// The interface layer.
+const UI = /(panel|mobile|dock|toolbar|nav|button|sheet|inspector|theme|onboarding|tour|command|chip|legend|banner|overlayUi|visualsStudio|measureIcons|measureController|measureRail|fullscreen|standardViews|cameraPresets|annotation|export(Panel|Layout|Ui)|classScope|classVisibility|classLegend|colorMode|colorChip|colorProvenance)/i;
+// The export / report / measurement-document layer — carved out of the old
+// `unit` catch-all so neither bucket grows large enough to stall a single
+// Vitest process in CI. Checked AFTER UI, so an export *panel* stays in `ui`.
+const EXPORT = /(^export|exporter|^measurement|^report|^verify|^audit|^stockpile|^sessionFindings|^kml|^gzip|^zip|^scanReport|^spaceReport|^floorPlanExport|^download)/i;
+
+/**
+ * Bucket a single test-file name. `unit` is the catch-all.
+ *
+ * Exported so a test can ask the question directly. It used to be asked by
+ * spawning this script with `--list` and parsing stdout, which made the answer
+ * depend on the environment the spawn ran in: a CI shard read back a list that
+ * did not name the terrain files, and the caller concluded no bucket claimed
+ * them. Importing the rule cannot disagree with the rule.
+ */
+export function bucketOf(name) {
+  // A nested directory routes explicitly, before any regex gets a look in.
+  const slash = name.indexOf('/');
+  if (slash > 0) {
+    const routed = NESTED_TEST_DIRS[name.slice(0, slash)];
+    if (routed) return routed;
+  }
+  if (isSlow(name)) return 'slow';
+  if (TERRAIN.test(name)) return 'terrain';
+  if (UI.test(name)) return 'ui';
+  if (EXPORT.test(name)) return 'export';
+  return 'unit';
+}
+
+export const BUCKETS = ['unit', 'export', 'terrain', 'ui', 'slow'];
+
+// Test subdirectories that hold UNIT tests, and the bucket each one routes to.
+// tests/e2e/ is deliberately absent — those are Playwright specs. Two reasons
+// this map exists rather than letting the regexes above classify a nested path:
+//   - without the enumeration, a file added under tests/benchmark/ would belong
+//     to no bucket at all, so the release gate would run every bucket green
+//     while never executing it;
+//   - without the explicit bucket, `tests/benchmark/*` matched `slow` only
+//     because SLOW_PREFIX starts with `benchmark` (written for the old
+//     top-level benchmark.test.ts). Those files run in ~50 ms and belong in
+//     `unit`; routing them by accident would also change silently the next time
+//     a bucket regex is edited.
+export const NESTED_TEST_DIRS = { benchmark: 'unit' };
+
+function allTestFiles() {
+  const top = readdirSync(TESTS_DIR).filter((f) => /\.(test|spec)\.ts$/.test(f));
+  const nested = Object.keys(NESTED_TEST_DIRS).flatMap((dir) => {
+    let entries;
+    try {
+      entries = readdirSync(join(TESTS_DIR, dir));
+    } catch {
+      return []; // the directory may legitimately not exist yet
+    }
+    return entries.filter((f) => /\.(test|spec)\.ts$/.test(f)).map((f) => `${dir}/${f}`);
+  });
+  return [...top, ...nested];
+}
+

--- a/scripts/test-bucket.mjs
+++ b/scripts/test-bucket.mjs
@@ -27,6 +27,7 @@
  */
 
 import { readdirSync, readFileSync, rmSync } from 'node:fs';
+import { BUCKETS, NESTED_TEST_DIRS, bucketOf } from './lib/testBuckets.mjs';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join, sep } from 'node:path';
@@ -34,57 +35,6 @@ import { tmpdir } from 'node:os';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const TESTS_DIR = resolve(ROOT, 'tests');
-
-// Heavy decode / large-data / integration — the genuinely slow files. LAS/LAZ
-// and buffer/worker decode tests spin up a WASM decoder and are the ones that
-// get starved (and time out) under the parallel `unit` bucket, so they belong
-// here where the runner caps parallelism and raises the timeout.
-// Two rules, not one pattern. The first list matches a file name's opening
-// word, the second matches anywhere in it. Written as a single regex the `^`
-// bound to the first alternative only, which reads as a mistake whether or not
-// it is one, and both scanners flag it as one.
-const SLOW_PREFIX = /^(?:torture|benchmark|parse|loadLas|loadLaz|laszip)/i;
-const SLOW_ANYWHERE =
-  /integration|streaming|copc|ept|laz|octree|voxelDownsample|convertRoundTrip|convertBatch|moduleApi|preload|wasm|decode|packaging/i;
-const isSlow = (name) => SLOW_PREFIX.test(name) || SLOW_ANYWHERE.test(name);
-// The terrain-analysis pipeline.
-const TERRAIN = /^(analyse|analysis|contour|cell|ground|dem|hillshade|slope|calibrat|confidence|coverage|crs|datum|evidence|interval|civilProfile|profile|surface|quality|terrain|raster|gpuDeriv|scatter|aspect|canopy|dsm|dtm|seam|provenance|metricVersion|score|assessment|readiness|whyNot|recommend)/i;
-// The interface layer.
-const UI = /(panel|mobile|dock|toolbar|nav|button|sheet|inspector|theme|onboarding|tour|command|chip|legend|banner|overlayUi|visualsStudio|measureIcons|measureController|measureRail|fullscreen|standardViews|cameraPresets|annotation|export(Panel|Layout|Ui)|classScope|classVisibility|classLegend|colorMode|colorChip|colorProvenance)/i;
-// The export / report / measurement-document layer — carved out of the old
-// `unit` catch-all so neither bucket grows large enough to stall a single
-// Vitest process in CI. Checked AFTER UI, so an export *panel* stays in `ui`.
-const EXPORT = /(^export|exporter|^measurement|^report|^verify|^audit|^stockpile|^sessionFindings|^kml|^gzip|^zip|^scanReport|^spaceReport|^floorPlanExport|^download)/i;
-
-/** Bucket a single test-file name. `unit` is the catch-all. */
-function bucketOf(name) {
-  // A nested directory routes explicitly, before any regex gets a look in.
-  const slash = name.indexOf('/');
-  if (slash > 0) {
-    const routed = NESTED_TEST_DIRS[name.slice(0, slash)];
-    if (routed) return routed;
-  }
-  if (isSlow(name)) return 'slow';
-  if (TERRAIN.test(name)) return 'terrain';
-  if (UI.test(name)) return 'ui';
-  if (EXPORT.test(name)) return 'export';
-  return 'unit';
-}
-
-const BUCKETS = ['unit', 'export', 'terrain', 'ui', 'slow'];
-
-// Test subdirectories that hold UNIT tests, and the bucket each one routes to.
-// tests/e2e/ is deliberately absent — those are Playwright specs. Two reasons
-// this map exists rather than letting the regexes above classify a nested path:
-//   - without the enumeration, a file added under tests/benchmark/ would belong
-//     to no bucket at all, so the release gate would run every bucket green
-//     while never executing it;
-//   - without the explicit bucket, `tests/benchmark/*` matched `slow` only
-//     because SLOW_PREFIX starts with `benchmark` (written for the old
-//     top-level benchmark.test.ts). Those files run in ~50 ms and belong in
-//     `unit`; routing them by accident would also change silently the next time
-//     a bucket regex is edited.
-const NESTED_TEST_DIRS = { benchmark: 'unit' };
 
 function allTestFiles() {
   const top = readdirSync(TESTS_DIR).filter((f) => /\.(test|spec)\.ts$/.test(f));

--- a/tests/releaseEvidenceOrder.test.ts
+++ b/tests/releaseEvidenceOrder.test.ts
@@ -27,8 +27,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   BUCKET_SCRIPT,
+  ROOT,
   bucketOfTestFile,
   chainOf,
   generatedRecordsRead,
@@ -127,5 +130,23 @@ describe('release chain evidence order', () => {
               `${p.verifier}, or the record is never recomputed at all.`),
       );
     expect(inversions, inversions.join('\n')).toEqual([]);
+  });
+});
+
+describe('the bucket lookup is not read back from a subprocess', () => {
+  it('imports the rule rather than parsing a spawned --list', () => {
+    const src = readFileSync(resolve(ROOT, 'tests/support/evidenceRecords.ts'), 'utf8');
+    expect(
+      src.includes('spawnSync'),
+      'spawning test-bucket.mjs made the answer depend on the environment the ' +
+        'spawn ran in: a CI shard read back a list naming no terrain file, so a ' +
+        'record whose producer is a terrain test looked unclaimed and the walk ' +
+        'found no pairs at all.',
+    ).toBe(false);
+    expect(src).toContain("from '../../scripts/lib/testBuckets.mjs'");
+  });
+
+  it('claims a terrain test as terrain, which is the case CI got wrong', () => {
+    expect(bucketOfTestFile().get('tests/groundFilterPdalAgreement.test.ts')).toBe('terrain');
   });
 });

--- a/tests/support/evidenceRecords.ts
+++ b/tests/support/evidenceRecords.ts
@@ -23,7 +23,8 @@
 
 import { expect } from 'vitest';
 import { readFileSync, readdirSync } from 'node:fs';
-import { spawnSync } from 'node:child_process';
+// @ts-expect-error - plain .mjs script, no types
+import { bucketOf } from '../../scripts/lib/testBuckets.mjs';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -57,21 +58,34 @@ export function chainOf(scriptId: string): string[] {
     .filter((s) => s !== '');
 }
 
-/** `tests/foo.test.ts` -> bucket, from the single source of that classification. */
+/**
+ * `tests/foo.test.ts` -> bucket, from the single source of that classification.
+ *
+ * The rule is imported, not read back from a spawned `--list`. Parsing a
+ * subprocess's stdout made the answer depend on the environment the spawn ran
+ * in: a CI shard read a list that named no terrain file, so a record whose
+ * producer is a terrain test looked as though no bucket claimed it, and the
+ * walk found no pairs at all. A function cannot disagree with itself.
+ */
 export function bucketOfTestFile(): Map<string, string> {
-  const out = spawnSync(process.execPath, ['scripts/test-bucket.mjs', '--list'], {
-    cwd: ROOT,
-    encoding: 'utf8',
-  });
-  expect(out.status, `test-bucket.mjs --list failed: ${out.stderr}`).toBe(0);
+  const files = readdirSync(resolve(ROOT, 'tests'), { withFileTypes: true });
   const map = new Map<string, string>();
-  for (const line of out.stdout.split('\n')) {
-    const [bucket, file] = line.split('\t');
-    if (bucket && file) map.set(file.trim(), bucket.trim());
+  for (const e of files) {
+    if (e.isFile() && /\.(test|spec)\.ts$/.test(e.name)) {
+      map.set(`tests/${e.name}`, bucketOf(e.name) as string);
+    }
+    if (!e.isDirectory()) continue;
+    // Nested test directories route explicitly; bucketOf takes the same
+    // `dir/file.test.ts` shape the script's own walk hands it.
+    for (const n of readdirSync(resolve(ROOT, 'tests', e.name))) {
+      if (!/\.(test|spec)\.ts$/.test(n)) continue;
+      map.set(`tests/${e.name}/${n}`, bucketOf(`${e.name}/${n}`) as string);
+    }
   }
-  expect(map.size).toBeGreaterThan(0);
+  expect(map.size, 'no test files found under tests/').toBeGreaterThan(0);
   return map;
 }
+
 
 /** Every `validation/...` path a verifier script names in its own source. */
 export function declaredPaths(scriptFile: string): string[] {


### PR DESCRIPTION
main is red on the last two merges. Both fail the same test, and it passes locally on the same tree.

`releaseEvidenceOrder` learned which bucket regenerates an evidence record by spawning `test-bucket.mjs --list` and parsing stdout, so the answer depended on the environment the spawn ran in. A CI unit shard read back a list naming no terrain file. A record whose producer is a terrain test then looked as though no bucket claimed it, the walk found no verifier/producer pairs at all, and the anti-vacuity assertion failed.

The classification moves to `scripts/lib/testBuckets.mjs`, which the command and the test both import. It could not be imported before: the CLI is the module body, so importing it ran the command and called `process.exit`.

Two tests pin it. One refuses a spawn in the helper. The other asserts the terrain file CI got wrong is claimed as terrain.
