### PR TITLE
fix(tiles3d): only a point tile becomes a streaming node

### DIFF
--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -84,6 +84,16 @@ export async function openRemoteTileset(
     if (cloud.octree.nodes().length === 0) {
       throw new Error('This tileset declares no tile with point content.');
     }
+    // A tile this reader cannot serve is a piece of the scene that would be
+    // missing from a viewer that looked complete. Refuse the open and say which
+    // tiles, rather than drawing the rest.
+    if (!cloud.octree.isComplete) {
+      const first = cloud.octree.errors[0] ?? 'a tile could not be served';
+      throw new Error(
+        `This tileset has ${cloud.octree.errors.length} tile(s) this reader cannot ` +
+          `serve, so opening it would leave part of the scene missing. First: ${first}`,
+      );
+    }
 
     const viewer = deps.getViewer();
     // Captured BEFORE the attach commits, so the post-commit cancel handling

--- a/src/io/tiles3d/tilesetNodes.ts
+++ b/src/io/tiles3d/tilesetNodes.ts
@@ -40,6 +40,22 @@ import type { Tileset } from './tileset';
  */
 export const ASSUMED_TILE_POINTS = 500_000;
 
+/**
+ * How a content URI's filename classifies. Query and fragment are ignored.
+ *
+ * Extension-based, and cheap on purpose: a `.b3dm` or `.glb` is a real 3D Tiles
+ * content type this viewer has no decoder for, and fetching one to discover
+ * that wastes the transfer. 3D Tiles 1.1 does not require an extension, so a
+ * URI carrying none is `unknown` rather than assumed to be a point tile.
+ */
+export function contentKind(uri: string): 'pnts' | 'tileset' | 'other' | 'unknown' {
+  const path = uri.split(/[?#]/)[0]!.toLowerCase();
+  if (path.endsWith('.pnts')) return 'pnts';
+  if (path.endsWith('.json')) return 'tileset';
+  const last = path.split('/').pop() ?? '';
+  return last.includes('.') ? 'other' : 'unknown';
+}
+
 /** What a streaming source needs to serve a tileset's tiles. */
 export interface TilesetNodeIndex {
   /** One record per tile that has content, in walk order. */
@@ -77,6 +93,22 @@ export function tilesetNodes(tileset: Tileset, rootTransform?: Mat4): TilesetNod
     contentParent.length = Math.min(contentParent.length, placed.depth);
     const uri = placed.tile.contentUri;
     if (uri == null) continue;
+
+    // Only a point tile becomes a node. Everything else would be fetched and
+    // handed to the point-tile decoder, which is a runtime failure on bytes
+    // that were never point data. A skip is recorded so the caller can refuse
+    // the open rather than draw a scene with pieces silently absent.
+    const kind = contentKind(uri);
+    if (kind !== 'pnts') {
+      skipped.push(
+        kind === 'tileset'
+          ? `${uri}: an external tileset, which this reader does not follow.`
+          : kind === 'unknown'
+            ? `${uri}: names no file extension, so its content type is undeclared.`
+            : `${uri}: not a point tile, and this viewer decodes no other content.`,
+      );
+      continue;
+    }
 
     const aabb = volumeToAabb(placed.boundingVolume);
     if (aabb == null) {

--- a/tests/tilesetNodes.test.ts
+++ b/tests/tilesetNodes.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { tilesetNodes, ASSUMED_TILE_POINTS } from '../src/io/tiles3d/tilesetNodes';
+import { tilesetNodes, ASSUMED_TILE_POINTS, contentKind } from '../src/io/tiles3d/tilesetNodes';
 import { parseTileset } from '../src/io/tiles3d/tileset';
 
 /** A tileset document with the given root tile tree. */
@@ -131,5 +131,48 @@ describe('what the scheduler and decoder are handed', () => {
     const b = tilesetNodes(t).records[0].bounds;
     expect(b).toHaveLength(6);
     expect(b[3] - b[0]).toBeGreaterThan(0);
+  });
+});
+
+describe('what may become a node', () => {
+  const tree = (uri: string) =>
+    ts({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'REPLACE',
+      content: { uri: 'root.pnts' },
+      children: [{ boundingVolume: BOX, geometricError: 10, content: { uri } }],
+    });
+
+  it('refuses to make a node from a nested tileset', () => {
+    const idx = tilesetNodes(tree('sub/tileset.json'));
+    expect(
+      idx.records.map((r) => r.id),
+      'a .json fetched and handed to the point-tile decoder fails on bytes that ' +
+        'were never point data',
+    ).toEqual(['root.pnts']);
+    expect(idx.skipped.join(' ')).toContain('external tileset');
+  });
+
+  it('refuses mesh content by name rather than fetching it', () => {
+    const idx = tilesetNodes(tree('b.b3dm'));
+    expect(idx.records.map((r) => r.id)).toEqual(['root.pnts']);
+    expect(idx.skipped.join(' ')).toContain('not a point tile');
+  });
+
+  it('does not assume an extensionless content URI is a point tile', () => {
+    // 3D Tiles 1.1 permits content with no extension, identified by its magic
+    // header. Guessing would decode whatever arrived as points.
+    const idx = tilesetNodes(tree('tile-00417'));
+    expect(idx.records.map((r) => r.id)).toEqual(['root.pnts']);
+    expect(idx.skipped.join(' ')).toContain('undeclared');
+  });
+
+  it('classifies the three named forms and the undeclared one', () => {
+    expect(contentKind('a.pnts')).toBe('pnts');
+    expect(contentKind('a.PNTS?v=2')).toBe('pnts');
+    expect(contentKind('sub/tileset.json#x')).toBe('tileset');
+    expect(contentKind('a.b3dm')).toBe('other');
+    expect(contentKind('tile-1')).toBe('unknown');
   });
 });


### PR DESCRIPTION
Found while wiring the streaming open in #622, and it is a defect that PR introduces rather than a gap it leaves.

`tilesetNodes` made a node for any content URI. A nested `tileset.json` or a `.b3dm` would have been fetched and handed to the point-tile decoder, failing at runtime on bytes that were never point data. The one-shot reader this replaced refused both by name, before fetching anything.

Content is now classified by extension, which is cheap and needs no fetch. Anything that is not a point tile is skipped with a reason, and the open refuses when the walk skipped something: a viewer that drew the rest would look complete with pieces missing.

3D Tiles 1.1 permits content with no extension, identified instead by its magic header. Such a URI classifies as undeclared rather than assumed to be a point tile, so nothing decodes whatever arrived as points. Reading the header to resolve it is the next step, and it needs a fetch the extension path does not.

Stacked on #622.
