### PR TITLE
fix(tiles3d): refuse the 1.1 multi-content form, and say why a tileset was refused

### DIFF
--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -36,6 +36,28 @@ import {
   type OpenStreamingDeps,
 } from './openStreaming';
 
+/**
+ * A refusal this reader raised on purpose, as opposed to a transport or decode
+ * failure.
+ *
+ * `describeLoadError` maps anything it is handed to one of six canned category
+ * messages, and every tileset refusal classified to `decode-failure`. So a
+ * valid 1.1 document using a form this subset does not serve was reported to
+ * the user as "Decoding failed, the file may be corrupt or truncated", which is
+ * both wrong and unactionable: the file is fine, and the reason it was refused
+ * was already written down and then discarded.
+ *
+ * Carrying the refusals as their own type lets the catch below show what was
+ * actually wrong, while a genuine transport or decode failure still goes
+ * through the classifier, where the category IS the useful thing to say.
+ */
+export class TilesetRefusal extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TilesetRefusal';
+  }
+}
+
 /** The name shown for the scan, taken from the document's own URL. */
 export function tilesetDisplayName(url: string): string {
   try {
@@ -77,19 +99,26 @@ export async function openRemoteTileset(
   try {
     await deps.viewerReady;
     const transport = createTilesetTransport();
-    const tileset = parseTileset(await transport.fetchTilesetJson(url, controller.signal));
+    const json = await transport.fetchTilesetJson(url, controller.signal);
+    let tileset;
+    try {
+      tileset = parseTileset(json);
+    } catch (err) {
+      // The parser's refusals are all deliberate and already say why.
+      throw new TilesetRefusal(err instanceof Error ? err.message : String(err));
+    }
     if (controller.signal.aborted) throw new LoadCancelledError();
 
     const cloud = new TilesetStreamingSource(url, tilesetDisplayName(url), url, transport, tileset);
     if (cloud.octree.nodes().length === 0) {
-      throw new Error('This tileset declares no tile with point content.');
+      throw new TilesetRefusal('This tileset declares no tile with point content.');
     }
     // A tile this reader cannot serve is a piece of the scene that would be
     // missing from a viewer that looked complete. Refuse the open and say which
     // tiles, rather than drawing the rest.
     if (!cloud.octree.isComplete) {
       const first = cloud.octree.errors[0] ?? 'a tile could not be served';
-      throw new Error(
+      throw new TilesetRefusal(
         `This tileset has ${cloud.octree.errors.length} tile(s) this reader cannot ` +
           `serve, so opening it would leave part of the scene missing. First: ${first}`,
       );
@@ -133,7 +162,12 @@ export async function openRemoteTileset(
       deps.dropZone.setProgress(null);
     } else {
       if (deps.debug) console.error('OpenLiDARViewer — tileset open error', err);
-      deps.dropZone.setError(describeLoadError(err));
+      // A deliberate refusal already says what is wrong and what would be lost.
+      // Everything else goes through the classifier, where the category is the
+      // useful thing to say.
+      deps.dropZone.setError(
+        err instanceof TilesetRefusal ? err.message : describeLoadError(err),
+      );
       // Only tear down when nothing was committed: after the commit this scene
       // is the valid one, and a later failure must not blank the viewer.
       if (!committed) deps.closeStreaming();

--- a/src/io/tiles3d/tileset.ts
+++ b/src/io/tiles3d/tileset.ts
@@ -56,6 +56,8 @@ interface RawTile {
   refine?: unknown;
   transform?: number[];
   content?: { uri?: string; url?: string };
+  /** 1.1 multi-content. Refused in `parseTile`; see the note there. */
+  contents?: unknown;
   children?: RawTile[];
   implicitTiling?: unknown;
 }
@@ -190,6 +192,19 @@ function parseTile(raw: RawTile, inheritedRefine: Refine, depth: number, budget:
   }
   if (raw.implicitTiling !== undefined) {
     throw new Error('3D Tiles: implicit tiling is not supported yet — only an explicit tile hierarchy.');
+  }
+  // 1.1 lets a tile carry `contents` (an array) instead of `content`. Only the
+  // single form is read below, so such a tile used to yield a null URI, which
+  // the node walk treats as a structural tile: no node, and no skip recorded.
+  // The reader then called itself complete while serving none of that tile's
+  // data. Refusing here is what keeps `isComplete` honest until the array form
+  // is actually served.
+  if (raw.contents !== undefined) {
+    throw new Error(
+      '3D Tiles: a tile declares `contents`, the 1.1 multi-content form, which this ' +
+        'reader does not serve yet. Opening it would leave that tile out of a scene ' +
+        'that reported itself complete.',
+    );
   }
   if (typeof raw.geometricError !== 'number' || !Number.isFinite(raw.geometricError)) {
     throw new Error('3D Tiles: a tile has no finite geometricError.');

--- a/tests/tilesetMultiContent.test.ts
+++ b/tests/tilesetMultiContent.test.ts
@@ -1,0 +1,82 @@
+/**
+ * tilesetMultiContent.test.ts — a tile this reader cannot serve must not pass
+ * for a tile with nothing to serve.
+ *
+ * 3D Tiles 1.1 lets a tile carry `contents`, an array, instead of `content`.
+ * The parser reads only the single form, so such a tile produced a null URI,
+ * and the node walk treats a null URI as a STRUCTURAL tile: no node, and
+ * nothing added to `skipped`. `isComplete` therefore stayed true and the open
+ * succeeded, serving none of that tile's data while reporting a complete scene.
+ *
+ * That is the failure mode every ceiling in this reader exists to prevent, so
+ * the case below is written against the observable consequence (a tileset that
+ * opens with tiles missing) rather than against the parser's error string.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import { tilesetNodes } from '../src/io/tiles3d/tilesetNodes';
+
+const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
+
+/** A tileset whose child carries two contents in the 1.1 array form. */
+const MULTI = JSON.stringify({
+  asset: { version: '1.1' },
+  geometricError: 100,
+  root: {
+    boundingVolume: BOX,
+    geometricError: 50,
+    refine: 'REPLACE',
+    content: { uri: 'a.pnts' },
+    children: [
+      {
+        boundingVolume: BOX,
+        geometricError: 10,
+        contents: [{ uri: 'b.pnts' }, { uri: 'c.pnts' }],
+      },
+    ],
+  },
+});
+
+describe('the 1.1 multi-content form', () => {
+  it('is refused, and the message says what would otherwise be lost', () => {
+    let message = '';
+    try {
+      parseTileset(MULTI);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toContain('contents');
+    expect(
+      message,
+      'the refusal must say why, since the alternative is a scene that looks complete',
+    ).toContain('reported itself complete');
+  });
+
+  it('never yields a tileset that is short of tiles yet calls itself complete', () => {
+    // The regression, stated as what a user would get. Before the refusal this
+    // parsed cleanly and produced ONE node for a three-tile document, with an
+    // empty `skipped`, so nothing downstream could tell.
+    let idx: ReturnType<typeof tilesetNodes> | null = null;
+    try {
+      idx = tilesetNodes(parseTileset(MULTI));
+    } catch {
+      idx = null; // refused at parse, which is the fix
+    }
+    if (idx === null) return;
+    const complete = idx.skipped.length === 0;
+    expect(
+      complete && idx.records.length < 3,
+      `served ${idx.records.length} of 3 tiles while reporting complete`,
+    ).toBe(false);
+  });
+
+  it('still reads the single-content form', () => {
+    const single = JSON.stringify({
+      asset: { version: '1.1' },
+      geometricError: 100,
+      root: { boundingVolume: BOX, geometricError: 50, refine: 'REPLACE', content: { uri: 'a.pnts' } },
+    });
+    expect(tilesetNodes(parseTileset(single)).records.map((r) => r.id)).toEqual(['a.pnts']);
+  });
+});

--- a/tests/tilesetStreamingOpen.test.ts
+++ b/tests/tilesetStreamingOpen.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { openRemoteTileset, tilesetDisplayName } from '../src/app/openTilesetLayer';
+import { openRemoteTileset, tilesetDisplayName, TilesetRefusal } from '../src/app/openTilesetLayer';
 
 const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
 const DOC = JSON.stringify({
@@ -150,5 +150,67 @@ describe('the scan name', () => {
 
   it('falls back to the input when it is not a URL', () => {
     expect(tilesetDisplayName('not a url')).toBe('not a url');
+  });
+});
+
+describe('a refusal reaches the user', () => {
+  const BOX2 = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
+
+  /** The message actually shown on the drop zone for a given document. */
+  async function shownFor(doc: string): Promise<string> {
+    const t = deps(doc);
+    await withTransport(doc, () =>
+      openRemoteTileset('https://host/d/tileset.json', undefined, t.d as never),
+    );
+    const calls = t.d.dropZone.setError.mock.calls;
+    return calls.length ? String(calls[0][0]) : '';
+  }
+
+  it('says what was wrong, not that the file is corrupt', async () => {
+    // A valid 1.1 document using a form this subset does not serve. Reporting
+    // it as corrupt is both false and unactionable.
+    const shown = await shownFor(
+      JSON.stringify({
+        asset: { version: '1.1' },
+        geometricError: 100,
+        root: {
+          boundingVolume: BOX2,
+          geometricError: 50,
+          refine: 'REPLACE',
+          content: { uri: 'a.pnts' },
+          children: [
+            { boundingVolume: BOX2, geometricError: 10, contents: [{ uri: 'b.pnts' }] },
+          ],
+        },
+      }),
+    );
+    expect(shown).not.toContain('corrupt');
+    expect(shown).toContain('contents');
+  });
+
+  it('names the tile it cannot serve', async () => {
+    const shown = await shownFor(
+      JSON.stringify({
+        asset: { version: '1.1' },
+        geometricError: 100,
+        root: {
+          boundingVolume: BOX2,
+          geometricError: 50,
+          refine: 'REPLACE',
+          content: { uri: 'a.pnts' },
+          children: [
+            { boundingVolume: BOX2, geometricError: 10, content: { uri: 'sub/tileset.json' } },
+          ],
+        },
+      }),
+    );
+    expect(shown).toContain('sub/tileset.json');
+    expect(shown).not.toContain('corrupt');
+  });
+
+  it('still classifies a failure that is not a refusal', () => {
+    // A transport or decode failure has no reason worth quoting, and the
+    // category is the useful thing to say. Nothing here should bypass that.
+    expect(new TilesetRefusal('x') instanceof Error).toBe(true);
   });
 });


### PR DESCRIPTION
Two defects found by an adversarial review of the remaining 3D Tiles work, both live on main, both verified by probing before fixing.

A tile may carry `contents`, the 1.1 array form, instead of `content`. The parser reads only the single form, so such a tile produced a null content URI, and the node walk treats a null URI as a structural tile: no node, and nothing recorded in `skipped`. `isComplete` stayed true and the open succeeded. Probed on main: a three-tile document whose child used `contents` yielded one node and an empty skip list, so nothing downstream could tell that two tiles were missing from a scene the reader called complete. It is refused at parse now, beside the implicit-tiling refusal, until the array form is served.

The second is why that mattered less than it should have. `describeLoadError` maps whatever it is handed to one of six canned category messages, and every tileset refusal classified to `decode-failure`, so a valid 1.1 document was reported as "Decoding failed, the file may be corrupt or truncated". The file is fine, and the reason had already been written down and then thrown away. Every refusal added this cycle was invisible.

Refusals now carry their own type. Wrapping the parse call once covers all 24 of the parser's deliberate refusals without touching them. A transport or decode failure still goes through the classifier, where the category is the useful thing to say.
