### PR TITLE
fix(tiles3d): validate tile URLs, and bound a region-declared tile where its points land

### DIFF
--- a/src/io/tiles3d/tilesetNodes.ts
+++ b/src/io/tiles3d/tilesetNodes.ts
@@ -28,6 +28,7 @@ import type { Box6, StreamingNodeRecord } from '../copc/copcTypes';
 import type { Mat4 } from './tileTransform';
 import { walkTilePlacements } from './tileTransform';
 import { volumeToAabb } from './tilesetTraversal';
+import type { Aabb } from './boundingVolume';
 import { resolveTilesetContentUrl, tilesetBaseUrl, tilesetUrlSearch } from './tilesetUrl';
 import type { Tileset } from './tileset';
 
@@ -77,6 +78,39 @@ export interface TilesetNodeIndex {
   readonly transform: ReadonlyMap<string, Mat4>;
   /** Tiles skipped, and why. Never silent: a dropped tile is missing data. */
   readonly skipped: readonly string[];
+}
+
+/**
+ * A region's bounds put in the same frame as the points that fill them.
+ *
+ * `volumeToAabb` converts a `region` DIRECTLY to ECEF, because a region is
+ * EPSG:4979 and absolute; a box or a sphere arrives already carried through the
+ * tile transform by the walk. The points of a geocentric tileset, though, are
+ * decoded through that transform, root frame included, so they land in the
+ * local ENU frame while a region's box stayed 6,000 km away at the ECEF radius.
+ * The scheduler culls node bounds against the camera, so bounds in one frame
+ * and points in another means it culls against nothing the user is looking at.
+ *
+ * All eight corners are carried across and re-bounded, which is conservative:
+ * a rotated box's axis-aligned bound is larger than the original, never smaller,
+ * so a tile can be admitted that need not have been but none is culled that
+ * should have been drawn.
+ */
+function aabbThroughMatrix(aabb: Aabb, m: readonly number[]): Aabb {
+  const xs: number[] = [], ys: number[] = [], zs: number[] = [];
+  for (const cx of [aabb.min[0], aabb.max[0]]) {
+    for (const cy of [aabb.min[1], aabb.max[1]]) {
+      for (const cz of [aabb.min[2], aabb.max[2]]) {
+        xs.push(m[0] * cx + m[4] * cy + m[8] * cz + m[12]);
+        ys.push(m[1] * cx + m[5] * cy + m[9] * cz + m[13]);
+        zs.push(m[2] * cx + m[6] * cy + m[10] * cz + m[14]);
+      }
+    }
+  }
+  return {
+    min: [Math.min(...xs), Math.min(...ys), Math.min(...zs)],
+    max: [Math.max(...xs), Math.max(...ys), Math.max(...zs)],
+  };
 }
 
 /** An AABB as the streaming model's flat six-number box. */
@@ -130,7 +164,13 @@ export function tilesetNodes(
       continue;
     }
 
-    const aabb = volumeToAabb(placed.boundingVolume);
+    const raw = volumeToAabb(placed.boundingVolume);
+    // A region skipped the walk's transform, so it needs the root frame applied
+    // here or its bounds describe a different place from its points.
+    const aabb =
+      raw !== null && placed.boundingVolume.region !== undefined && rootTransform !== undefined
+        ? aabbThroughMatrix(raw, rootTransform)
+        : raw;
     if (aabb == null) {
       skipped.push(`${uri}: bounding volume carries none of box, region or sphere.`);
       continue;

--- a/src/io/tiles3d/tilesetNodes.ts
+++ b/src/io/tiles3d/tilesetNodes.ts
@@ -28,6 +28,7 @@ import type { Box6, StreamingNodeRecord } from '../copc/copcTypes';
 import type { Mat4 } from './tileTransform';
 import { walkTilePlacements } from './tileTransform';
 import { volumeToAabb } from './tilesetTraversal';
+import { resolveTilesetContentUrl, tilesetBaseUrl, tilesetUrlSearch } from './tilesetUrl';
 import type { Tileset } from './tileset';
 
 /**
@@ -60,7 +61,17 @@ export function contentKind(uri: string): 'pnts' | 'tileset' | 'other' | 'unknow
 export interface TilesetNodeIndex {
   /** One record per tile that has content, in walk order. */
   readonly records: readonly StreamingNodeRecord[];
-  /** Node id to the content URI to fetch, as authored, relative to the tileset. */
+  /**
+   * Node id to the ABSOLUTE, validated URL to fetch.
+   *
+   * Resolved here rather than at fetch time so a document naming a URL this
+   * reader must not request is refused before a single tile is fetched. The
+   * authored URI is never handed to the transport: `resolveTilesetContentUrl`
+   * refuses a non-http scheme, embedded credentials, a private-network host, a
+   * different origin from the tileset, and a path escaping the tileset's own
+   * directory. A `tileset.json` is an untrusted document that names URLs the
+   * viewer will request, so those are not optional.
+   */
   readonly contentUri: ReadonlyMap<string, string>;
   /** Node id to the cumulative root-to-tile transform the decoder must apply. */
   readonly transform: ReadonlyMap<string, Mat4>;
@@ -79,7 +90,16 @@ function toBox6(min: readonly number[], max: readonly number[]): Box6 {
  * `rootTransform` places the whole tileset, which is how a geocentric tileset
  * is brought into a local ENU frame before anything is bounded or culled.
  */
-export function tilesetNodes(tileset: Tileset, rootTransform?: Mat4): TilesetNodeIndex {
+export function tilesetNodes(
+  tileset: Tileset,
+  rootTransform?: Mat4,
+  entryUrl?: string,
+): TilesetNodeIndex {
+  // Without an entry URL there is nothing to resolve against, which is the
+  // shape the pure unit tests use. A caller that fetches MUST pass one; the
+  // streaming source does.
+  const base = entryUrl === undefined ? null : tilesetBaseUrl(entryUrl);
+  const search = entryUrl === undefined ? '' : tilesetUrlSearch(entryUrl);
   const records: StreamingNodeRecord[] = [];
   const contentUri = new Map<string, string>();
   const transform = new Map<string, Mat4>();
@@ -121,6 +141,18 @@ export function tilesetNodes(tileset: Tileset, rootTransform?: Mat4): TilesetNod
     }
     seen.add(uri);
 
+    // Refused before anything is fetched, and named, so the open can say which
+    // tile it would have had to request.
+    let target = uri;
+    if (base !== null) {
+      const resolved = resolveTilesetContentUrl(base, uri, search);
+      if (!resolved.ok) {
+        skipped.push(`${uri}: ${resolved.reason}`);
+        continue;
+      }
+      target = resolved.url;
+    }
+
     // Nearest ANCESTOR that produced a node, which may be several levels up:
     // a chain of structural tiles leaves those depths unset, and looking only
     // one level up left such a leaf parentless.
@@ -148,7 +180,7 @@ export function tilesetNodes(tileset: Tileset, rootTransform?: Mat4): TilesetNod
       spacing: placed.geometricError,
       parentId,
     });
-    contentUri.set(uri, uri);
+    contentUri.set(uri, target);
     transform.set(uri, placed.transform);
     contentParent[placed.depth] = uri;
   }

--- a/src/render/streaming/TilesetStreamingSource.ts
+++ b/src/render/streaming/TilesetStreamingSource.ts
@@ -73,11 +73,6 @@ export function tilesetRootFrameMatrix(tileset: Tileset): Mat4 | null {
   return enuFrameMatrix(anchor) as Mat4;
 }
 
-/** Resolve a tile's authored content URI against the tileset document. */
-export function resolveTileUrl(baseUrl: string, uri: string): string {
-  return new URL(uri, baseUrl).toString();
-}
-
 /** The union of every node's bounds, or null when there are no nodes. */
 function unionBounds(records: readonly StreamingNodeRecord[]): Box6 | null {
   if (records.length === 0) return null;
@@ -132,7 +127,6 @@ export class TilesetStreamingSource implements StreamingSource {
 
   private readonly _index: TilesetNodeIndex;
   private readonly _bounds: Box6;
-  private readonly _baseUrl: string;
   private readonly _transport: TilesetTransport;
   private readonly _crs: CrsInfo | null;
 
@@ -147,12 +141,18 @@ export class TilesetStreamingSource implements StreamingSource {
   ) {
     this.id = id;
     this.name = name;
-    this._baseUrl = baseUrl;
     this._transport = transport;
     this._crs = crs;
     // Resolved here rather than by the caller: a caller that forgets leaves a
     // geocentric tileset in ECEF, and nothing on screen says so.
-    this._index = tilesetNodes(tileset, rootTransform ?? tilesetRootFrameMatrix(tileset) ?? undefined);
+    // The entry URL is passed so every content URI is resolved and VALIDATED
+    // before a tile is fetched. Without it the index would hand the transport
+    // whatever the document wrote.
+    this._index = tilesetNodes(
+      tileset,
+      rootTransform ?? tilesetRootFrameMatrix(tileset) ?? undefined,
+      baseUrl,
+    );
     this._bounds = unionBounds(this._index.records) ?? [0, 0, 0, 0, 0, 0];
     this.renderOrigin = centreOf(this._bounds);
     this.frame = createTranslatedFrame(this.renderOrigin);
@@ -210,9 +210,11 @@ export class TilesetStreamingSource implements StreamingSource {
   }
 
   async readNodeChunk(record: StreamingNodeRecord, signal?: AbortSignal): Promise<ArrayBuffer> {
-    const uri = this._index.contentUri.get(record.id);
-    if (uri == null) throw new Error(`No content URI for tile ${record.id}.`);
-    return this._transport.fetchTileBytes(resolveTileUrl(this._baseUrl, uri), signal);
+    // Already absolute and already validated by the index. Re-resolving here
+    // against the base would undo that check for an authored absolute URL.
+    const url = this._index.contentUri.get(record.id);
+    if (url == null) throw new Error(`No content URL for tile ${record.id}.`);
+    return this._transport.fetchTileBytes(url, signal);
   }
 
   decodeMeta(record: StreamingNodeRecord): NodeDecodeMetadata {

--- a/tests/tilesetRegionBounds.test.ts
+++ b/tests/tilesetRegionBounds.test.ts
@@ -1,0 +1,91 @@
+/**
+ * tilesetRegionBounds.test.ts — a tile's bounds and its points describe the
+ * same place.
+ *
+ * `volumeToAabb` converts a `region` directly to ECEF, because a region is
+ * EPSG:4979 and absolute, while a box or sphere arrives already carried through
+ * the tile transform by the walk. A geocentric tileset's POINTS are decoded
+ * through that transform, root frame included, so they land near the ENU origin
+ * while the region's box stayed out at the ECEF radius, some six thousand
+ * kilometres away.
+ *
+ * The scheduler culls node bounds against the camera. Bounds in one frame and
+ * points in another means it culls against a place the user is not looking at,
+ * and a tileset either shows nothing or streams by accident. `region` is also
+ * the only in-spec declaration of geocentricity, so this is precisely the case
+ * the ENU frame exists to serve.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import { tilesetNodes } from '../src/io/tiles3d/tilesetNodes';
+import { tilesetRootFrameMatrix } from '../src/render/streaming/TilesetStreamingSource';
+
+const DEG = Math.PI / 180;
+/** Monterrey, where the polar axis and local up are 64 degrees apart. */
+const REGION = {
+  region: [-100.32 * DEG, 25.68 * DEG, -100.31 * DEG, 25.69 * DEG, 500, 580],
+};
+
+const geocentric = parseTileset(
+  JSON.stringify({
+    asset: { version: '1.1' },
+    geometricError: 100,
+    root: {
+      boundingVolume: REGION,
+      geometricError: 50,
+      refine: 'REPLACE',
+      content: { uri: 'r.pnts' },
+    },
+  }),
+);
+
+/** Distance from the frame origin to the centre of a node's bounds. */
+function centreDistance(b: readonly number[]): number {
+  return Math.hypot((b[0] + b[3]) / 2, (b[1] + b[4]) / 2, (b[2] + b[5]) / 2);
+}
+
+describe('a region-bounded tileset', () => {
+  it('bounds its tiles in the frame its points decode into', () => {
+    const m = tilesetRootFrameMatrix(geocentric);
+    expect(m, 'a region declares geocentricity, so a frame must be built').not.toBeNull();
+    const idx = tilesetNodes(geocentric, m ?? undefined);
+    const d = centreDistance(idx.records[0].bounds);
+    // Points decode to within a few hundred metres of the ENU origin. Bounds
+    // left in ECEF sit at the Earth's radius, about 6.37e6 m out.
+    expect(
+      d,
+      `node bounds sit ${Math.round(d)} m from the frame origin while the points ` +
+        'land within a few hundred; the scheduler would cull against empty space',
+    ).toBeLessThan(50_000);
+  });
+
+  it('keeps the bounds big enough to contain the region', () => {
+    const idx = tilesetNodes(geocentric, tilesetRootFrameMatrix(geocentric) ?? undefined);
+    const b = idx.records[0].bounds;
+    // The region spans about 0.01 degrees, roughly a kilometre. A rotated box's
+    // axis-aligned bound is larger than the original, never smaller.
+    expect(b[3] - b[0]).toBeGreaterThan(100);
+    expect(b[4] - b[1]).toBeGreaterThan(100);
+  });
+
+  it('leaves a box-bounded tileset alone, since the walk already placed it', () => {
+    const boxed = parseTileset(
+      JSON.stringify({
+        asset: { version: '1.1' },
+        geometricError: 100,
+        root: {
+          boundingVolume: { box: [5, 6, 7, 10, 0, 0, 0, 10, 0, 0, 0, 10] },
+          geometricError: 50,
+          refine: 'REPLACE',
+          content: { uri: 'r.pnts' },
+        },
+      }),
+    );
+    // No frame is declared for a box, so nothing is applied and the bounds are
+    // the authored ones.
+    expect(tilesetRootFrameMatrix(boxed)).toBeNull();
+    const b = tilesetNodes(boxed).records[0].bounds;
+    expect(centreDistance(b)).toBeCloseTo(Math.hypot(5, 6, 7), 6);
+  });
+});

--- a/tests/tilesetStreamingSource.test.ts
+++ b/tests/tilesetStreamingSource.test.ts
@@ -11,7 +11,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   TilesetStreamingSource,
-  resolveTileUrl,
   tilesetRootFrameMatrix,
 } from '../src/render/streaming/TilesetStreamingSource';
 import { geodeticToEcef } from '../src/io/tiles3d/boundingVolume';
@@ -67,9 +66,9 @@ describe('what the source refuses to invent', () => {
 
 describe('addressing a tile', () => {
   it('resolves a content URI against the tileset document, not the host root', () => {
-    expect(resolveTileUrl('https://host/data/tileset.json', 'sub/a.pnts')).toBe(
-      'https://host/data/sub/a.pnts',
-    );
+    const s = source();
+    const node = s.octree.nodes().find((n) => n.record.id === 'sub/a.pnts');
+    expect(node, 'the relative content URI should have produced a node').toBeDefined();
   });
 
   it('fetches the resolved URL for a node', async () => {

--- a/tests/tilesetUrlGuards.test.ts
+++ b/tests/tilesetUrlGuards.test.ts
@@ -1,0 +1,78 @@
+/**
+ * tilesetUrlGuards.test.ts — a tileset.json is an untrusted document that names
+ * URLs this viewer will request.
+ *
+ * The merged reader resolved every content URI through
+ * `resolveTilesetContentUrl`, which refuses a non-http scheme, embedded
+ * credentials, a private-network host, a different origin from the tileset, and
+ * a path escaping the tileset's directory. The streaming reader that replaced it
+ * resolved with a bare `new URL(uri, base)` and fetched whatever came out, so a
+ * document could direct the viewer at a cloud metadata endpoint or an arbitrary
+ * host and the transport, which validates nothing, would go there.
+ *
+ * These cases are written against the index rather than the validator, because
+ * the validator was never the thing that was missing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import { tilesetNodes } from '../src/io/tiles3d/tilesetNodes';
+
+const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
+const ENTRY = 'https://tiles.example.com/city/tileset.json';
+
+/** A tileset whose one child names `uri` as its content. */
+function withContent(uri: string) {
+  return parseTileset(
+    JSON.stringify({
+      asset: { version: '1.0' },
+      geometricError: 100,
+      root: {
+        boundingVolume: BOX,
+        geometricError: 50,
+        refine: 'REPLACE',
+        content: { uri: 'ok.pnts' },
+        children: [{ boundingVolume: BOX, geometricError: 10, content: { uri } }],
+      },
+    }),
+  );
+}
+
+const idx = (uri: string) => tilesetNodes(withContent(uri), undefined, ENTRY);
+
+describe('a content URI this viewer must not request', () => {
+  it.each([
+    ['http://169.254.169.254/latest/meta-data/iam/', 'a cloud metadata address'],
+    ['https://attacker.example.net/collect.pnts', 'another origin'],
+    ['file:///etc/passwd', 'a local file'],
+    ['https://user:pw@tiles.example.com/city/a.pnts', 'embedded credentials'],
+    ['../../../secrets/a.pnts', 'a path outside the tileset directory'],
+  ])('refuses %s (%s), and fetches nothing', (uri) => {
+    const built = idx(uri);
+    const targets = [...built.contentUri.values()].join(' ');
+    expect(
+      built.records.map((r) => r.id),
+      'the refused content became a node, so the viewer would have requested it',
+    ).toEqual(['ok.pnts']);
+    expect(targets).not.toContain('169.254');
+    expect(targets).not.toContain('attacker');
+    expect(targets).not.toContain('file:');
+    expect(built.skipped.length).toBe(1);
+  });
+
+  it('serves an ordinary relative URI, resolved to an absolute URL', () => {
+    const built = idx('sub/b.pnts');
+    expect(built.records.map((r) => r.id)).toEqual(['ok.pnts', 'sub/b.pnts']);
+    expect(built.contentUri.get('sub/b.pnts')).toBe(
+      'https://tiles.example.com/city/sub/b.pnts',
+    );
+  });
+
+  it('hands the transport an absolute URL, never the authored text', () => {
+    // The authored URI is relative; anything that reached the transport as
+    // written would be resolved a second time, against whatever base it held.
+    for (const url of idx('sub/b.pnts').contentUri.values()) {
+      expect(url.startsWith('https://')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
A `tileset.json` is an untrusted document that names URLs this viewer will request.

The merged reader resolved every content URI through `resolveTilesetContentUrl`, which refuses a non-http scheme, embedded credentials, a private-network host, an origin other than the tileset's own, and a path escaping the tileset directory. The streaming reader that replaced it resolved with a bare `new URL(uri, base)` and fetched the result. `tilesetTransport` validates nothing, so a document could direct the viewer at a cloud metadata address, an arbitrary host, or a local file.

Resolution and validation now happen while the node index is built. A document naming a URL this reader must not request is refused before a single tile is fetched, and the refusal names the tile. The index stores the absolute validated URL, and the transport is handed that rather than the authored text, so nothing is resolved a second time against a base it did not come from.

The guards themselves are unchanged and were never the missing piece. The tests are written against the index for that reason.


Also here, found while auditing the same file. `volumeToAabb` converts a `region` directly to ECEF, because a region is EPSG:4979 and absolute, while a box or sphere arrives already carried through the tile transform by the walk. A geocentric tileset's points are decoded through that transform, root frame included, so they land near the ENU origin while the region's box stayed out at the ECEF radius.

Measured before the fix: node bounds 6,374,687 m from the frame origin, points within a few hundred.

The scheduler culls node bounds against the camera, so it was culling against a place the user is not looking at. A region is also the only in-spec declaration of geocentricity, so this is exactly the case the local frame exists to serve.
