### PR TITLE
fix(tiles3d): refuse a REPLACE tile that refines into content

### DIFF
--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -60,6 +60,8 @@ What opens: a streamed 3D Tiles 1.0 or 1.1 tileset whose content is PNTS. The en
 
 A streamed tileset reports no source point total. A `tileset.json` never states one, and the per-tile figures the scheduler admits on are decode-admission estimates rather than counts, so a sum of them would read as a measurement it is not. The colour modes offered are the ones a point tile can fill: intensity, classification and returns are absent from the format and are not offered.
 
+A tile that refines by REPLACE into tiles with their own content is refused. REPLACE means the parent's content is replaced by its children, and the streaming scheduler draws every resident node, which is right for ADD and would draw the coarse parent alongside the fine children for REPLACE. Refusing is preferred to a scene that is quietly doubled. A REPLACE tile that refines into nothing cannot duplicate anything and is served.
+
 What does not open: the wider 3D Tiles ecosystem. B3DM, I3DM, CMPT and glTF content are refused by name, because mesh tiles need a renderer this viewer does not have. Implicit tiling is refused at parse, and a selection cannot reach a nested external `tileset.json`. Draco-compressed tiles are refused rather than partially read.
 
 Two further limits of the supported subset are known:

--- a/src/io/tiles3d/tilesetNodes.ts
+++ b/src/io/tiles3d/tilesetNodes.ts
@@ -30,7 +30,7 @@ import { walkTilePlacements } from './tileTransform';
 import { volumeToAabb } from './tilesetTraversal';
 import type { Aabb } from './boundingVolume';
 import { resolveTilesetContentUrl, tilesetBaseUrl, tilesetUrlSearch } from './tilesetUrl';
-import type { Tileset } from './tileset';
+import type { Tile, Tileset } from './tileset';
 
 /**
  * Points assumed for a tile whose body has not been read.
@@ -113,6 +113,14 @@ function aabbThroughMatrix(aabb: Aabb, m: readonly number[]): Aabb {
   };
 }
 
+/** Whether any tile below this one carries content of its own. */
+function subtreeHasContent(tile: Tile): boolean {
+  for (const child of tile.children) {
+    if (child.contentUri !== null || subtreeHasContent(child)) return true;
+  }
+  return false;
+}
+
 /** An AABB as the streaming model's flat six-number box. */
 function toBox6(min: readonly number[], max: readonly number[]): Box6 {
   return [min[0], min[1], min[2], max[0], max[1], max[2]];
@@ -139,6 +147,16 @@ export function tilesetNodes(
   const transform = new Map<string, Mat4>();
   const skipped: string[] = [];
   const seen = new Set<string>();
+  // REPLACE means a refined tile's content is replaced by its children, so the
+  // parent must not be drawn once they are selected. The streaming scheduler
+  // has no such rule: it draws every resident node, which is exactly right for
+  // ADD and duplicates geometry for REPLACE, over-reporting displayed points
+  // along with it. Rather than draw a scene that is quietly wrong, a REPLACE
+  // tile that actually refines into content is refused by name.
+  //
+  // A REPLACE tile whose subtree holds no further content refines into nothing,
+  // so nothing can be duplicated and it is served.
+  const replacing: string[] = [];
   // Nearest ancestor WITH content, so the store's parent chain skips the
   // structural tiles that produce no node of their own.
   const contentParent: string[] = [];
@@ -180,6 +198,10 @@ export function tilesetNodes(
       continue;
     }
     seen.add(uri);
+
+    if (placed.tile.refine === 'REPLACE' && subtreeHasContent(placed.tile)) {
+      replacing.push(uri);
+    }
 
     // Refused before anything is fetched, and named, so the open can say which
     // tile it would have had to request.
@@ -223,6 +245,13 @@ export function tilesetNodes(
     contentUri.set(uri, target);
     transform.set(uri, placed.transform);
     contentParent[placed.depth] = uri;
+  }
+
+  for (const uri of replacing) {
+    skipped.push(
+      `${uri}: refines by REPLACE into tiles with their own content, which this ` +
+        `reader would draw alongside it rather than instead of it.`,
+    );
   }
 
   return { records, contentUri, transform, skipped };

--- a/tests/tilesetRefineMode.test.ts
+++ b/tests/tilesetRefineMode.test.ts
@@ -1,0 +1,93 @@
+/**
+ * tilesetRefineMode.test.ts — the two refinement modes are not the same scene.
+ *
+ * ADD means a refined tile's content is additive: the parent IS drawn alongside
+ * its children. REPLACE means the parent's content is replaced by them, so it
+ * must NOT be drawn once they are selected.
+ *
+ * The streaming scheduler draws every resident node. That is exactly right for
+ * ADD. For REPLACE it draws the coarse parent and the fine children over the
+ * same ground, which duplicates geometry on screen and inflates the displayed
+ * point count. `Tile.refine` is parsed and reaches the streaming path nowhere,
+ * so nothing downstream could tell the two apart.
+ *
+ * Until the scheduler can suppress a replaced ancestor, a REPLACE tile that
+ * genuinely refines into content is refused by name rather than drawn wrongly.
+ * A REPLACE tile that refines into nothing cannot duplicate anything, so it is
+ * served.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import { tilesetNodes } from '../src/io/tiles3d/tilesetNodes';
+
+const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
+
+const doc = (refine: string, childHasContent: boolean) =>
+  JSON.stringify({
+    asset: { version: '1.1' },
+    geometricError: 100,
+    root: {
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine,
+      content: { uri: 'root.pnts' },
+      children: [
+        {
+          boundingVolume: BOX,
+          geometricError: 10,
+          ...(childHasContent ? { content: { uri: 'child.pnts' } } : {}),
+        },
+      ],
+    },
+  });
+
+describe('refinement mode', () => {
+  it('serves an ADD tileset, parent and child together', () => {
+    // Additive refinement is what the scheduler already does correctly.
+    const idx = tilesetNodes(parseTileset(doc('ADD', true)));
+    expect(idx.records.map((r) => r.id)).toEqual(['root.pnts', 'child.pnts']);
+    expect(idx.skipped).toEqual([]);
+  });
+
+  it('refuses a REPLACE tile that refines into content', () => {
+    const idx = tilesetNodes(parseTileset(doc('REPLACE', true)));
+    expect(
+      idx.skipped.join(' '),
+      'drawing the parent alongside its replacement duplicates geometry and ' +
+        'inflates the displayed point count',
+    ).toContain('REPLACE');
+    expect(idx.skipped.join(' ')).toContain('root.pnts');
+  });
+
+  it('serves a REPLACE tile that refines into nothing', () => {
+    // Nothing replaces it, so nothing can be drawn twice.
+    const idx = tilesetNodes(parseTileset(doc('REPLACE', false)));
+    expect(idx.records.map((r) => r.id)).toEqual(['root.pnts']);
+    expect(idx.skipped).toEqual([]);
+  });
+
+  it('sees content anywhere below, not only in a direct child', () => {
+    const deep = JSON.stringify({
+      asset: { version: '1.1' },
+      geometricError: 100,
+      root: {
+        boundingVolume: BOX,
+        geometricError: 50,
+        refine: 'REPLACE',
+        content: { uri: 'root.pnts' },
+        children: [
+          {
+            boundingVolume: BOX,
+            geometricError: 20,
+            children: [{ boundingVolume: BOX, geometricError: 5, content: { uri: 'deep.pnts' } }],
+          },
+        ],
+      },
+    });
+    expect(
+      tilesetNodes(parseTileset(deep)).skipped.join(' '),
+      'a structural tile between the parent and its replacement hides nothing',
+    ).toContain('REPLACE');
+  });
+});

--- a/tests/tilesetStreamingSource.test.ts
+++ b/tests/tilesetStreamingSource.test.ts
@@ -23,10 +23,14 @@ function ts(root: unknown) {
   return parseTileset(JSON.stringify({ asset: { version: '1.0' }, geometricError: 100, root }));
 }
 
+// ADD, not REPLACE: these cases are about the shape the scheduler reads, and
+// additive refinement is the mode where a parent and its children are both
+// served. A REPLACE parent that refines into content is refused separately, so
+// using it here would make every case in this file test that refusal instead.
 const TREE = ts({
   boundingVolume: BOX,
   geometricError: 50,
-  refine: 'REPLACE',
+  refine: 'ADD',
   content: { uri: 'root.pnts' },
   children: [{ boundingVolume: BOX, geometricError: 10, content: { uri: 'sub/a.pnts' } }],
 });

--- a/tests/tilesetUrlGuards.test.ts
+++ b/tests/tilesetUrlGuards.test.ts
@@ -57,7 +57,9 @@ describe('a content URI this viewer must not request', () => {
     expect(targets).not.toContain('169.254');
     expect(targets).not.toContain('attacker');
     expect(targets).not.toContain('file:');
-    expect(built.skipped.length).toBe(1);
+    // The fixture's root refines by REPLACE, which is refused separately, so
+    // assert the URL refusal specifically rather than counting skips.
+    expect(built.skipped.some((r) => r.startsWith(uri))).toBe(true);
   });
 
   it('serves an ordinary relative URI, resolved to an absolute URL', () => {


### PR DESCRIPTION
The fifth guarantee the streaming reader dropped, found by the retirement audit.

`Tile.refine` is parsed in fourteen places and reaches the streaming path in none. `StreamingNodeRecord` has no such field, so nothing downstream can tell the two refinement modes apart.

They are not the same scene. ADD means a refined tile's content is additive and the parent is drawn alongside its children, which is exactly what the scheduler does. REPLACE means the parent's content is replaced by them, so the scheduler draws the coarse parent over the same ground as the fine children that were meant to replace it. That duplicates geometry on screen and inflates the displayed point count.

Refused by name until the scheduler can suppress a replaced ancestor. A REPLACE tile whose subtree carries no content refines into nothing, so nothing can be drawn twice and it is served. The subtree is searched to any depth, because a structural tile between a parent and its replacement hides the conflict from a direct-children check.

One existing test asserted an exact skip count and now sees two. It asserts the specific refusal instead, which is the better assertion regardless.
