### PR TITLE
fix(tiles3d): validate the entry URL, not only the tiles below it

### DIFF
--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -26,6 +26,7 @@ import { LoadCancelledError } from '../io/loadFile';
 import { describeLoadError } from '../io/loadErrors';
 import { parseTileset } from '../io/tiles3d/tileset';
 import { createTilesetTransport } from '../io/tiles3d/tilesetTransport';
+import { validateRemoteTilesetUrl } from '../io/tiles3d/tilesetUrl';
 import { PntsChunkDecoder } from '../io/tiles3d/pntsDecode';
 import { TilesetStreamingSource } from '../render/streaming/TilesetStreamingSource';
 import {
@@ -98,6 +99,13 @@ export async function openRemoteTileset(
   let committed = false;
   try {
     await deps.viewerReady;
+    // The entry URL is the ROOT of every trust decision below it. Tile URLs are
+    // validated against a base derived from this one, and part of that check is
+    // that a tile stays on the entry's own origin, so an unchecked entry lets
+    // every tile inherit whatever origin it named. Nothing upstream validates:
+    // the router only pattern-matches a path ending in tileset.json.
+    const entry = validateRemoteTilesetUrl(url);
+    if (!entry.ok) throw new TilesetRefusal(entry.reason);
     const transport = createTilesetTransport();
     const json = await transport.fetchTilesetJson(url, controller.signal);
     let tileset;

--- a/tests/tilesetEntryUrlGuard.test.ts
+++ b/tests/tilesetEntryUrlGuard.test.ts
@@ -1,0 +1,102 @@
+/**
+ * tilesetEntryUrlGuard.test.ts — the entry URL is the root of every trust
+ * decision under it.
+ *
+ * Tile URLs are validated against a base derived from the entry, and part of
+ * that check is that a tile stays on the entry's own origin. So an unchecked
+ * entry does not merely go unvalidated itself: it hands every tile below it an
+ * origin that then passes the same-origin test. Validating tile URLs while
+ * leaving the entry open is a fix with a hole in the middle of it.
+ *
+ * `validateRemoteTilesetUrl` existed the whole time and had exactly one caller,
+ * in the merged reader that the streaming path replaced. Nothing upstream
+ * covers it: the router only pattern-matches a path ending in `tileset.json`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { openRemoteTileset, TilesetRefusal } from '../src/app/openTilesetLayer';
+import { validateRemoteTilesetUrl } from '../src/io/tiles3d/tilesetUrl';
+import { isTilesetEntryUrl } from '../src/app/openStreaming';
+
+/** Deps that fail loudly if anything is fetched. */
+function deps() {
+  const fetched: string[] = [];
+  return {
+    fetched,
+    d: {
+      isLoading: () => false,
+      setLoading: () => {},
+      viewerReady: Promise.resolve(),
+      getViewer: () => ({ clouds: () => [], attachStreamingCloud: vi.fn() }),
+      getStreamingQuality: () => 'balanced',
+      getStreamingBenchmark: () => null,
+      isPhone: () => false,
+      showToast: () => {},
+      debug: false,
+      closeStreaming: () => {},
+      clearOpenStaticLayers: () => {},
+      startStreamingStatusPolling: () => {},
+      revealStreamingChrome: () => {},
+      stage: { hideEmptyState: () => {} },
+      inspectorCards: { refreshProvenanceFromStreaming: () => {} },
+      crsCoordinator: { refreshCrsForStreamingCloud: () => {} },
+      streamingPanel: {
+        setColorModes: vi.fn(), setQuality: () => {}, setSourceUrl: () => {}, setPhase: () => {},
+      },
+      dropZone: {
+        setOpening: () => {}, setCancelHandler: () => {}, setProgress: () => {}, setError: vi.fn(),
+      },
+    },
+  };
+}
+
+const HOSTILE = [
+  ['http://169.254.169.254/tileset.json', 'a cloud metadata address'],
+  ['http://127.0.0.1:8080/tileset.json', 'localhost'],
+  ['file:///etc/tileset.json', 'a local file'],
+  ['http://[::1]/tileset.json', 'loopback over IPv6'],
+] as const;
+
+describe('the entry URL', () => {
+  it.each(HOSTILE)('is refused: %s (%s)', (url) => {
+    expect(validateRemoteTilesetUrl(url).ok).toBe(false);
+  });
+
+  it.each(HOSTILE)('reaches no fetch through the open: %s (%s)', async (url) => {
+    const t = deps();
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: unknown) => {
+      t.fetched.push(String(input));
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+    try {
+      await openRemoteTileset(url, undefined, t.d as never);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(
+      t.fetched,
+      'the open fetched the entry document before deciding whether it was allowed to',
+    ).toEqual([]);
+    expect(t.d.dropZone.setError).toHaveBeenCalled();
+  });
+
+  it('the router alone does not decide this, it only matches the path', () => {
+    // Pinned because "the router checked it" is the assumption that left the
+    // entry unvalidated in the first place.
+    expect(isTilesetEntryUrl('http://169.254.169.254/tileset.json')).toBe(true);
+    expect(validateRemoteTilesetUrl('http://169.254.169.254/tileset.json').ok).toBe(false);
+  });
+
+  it('an ordinary https entry still opens', () => {
+    expect(validateRemoteTilesetUrl('https://tiles.example.com/city/tileset.json').ok).toBe(true);
+  });
+
+  it('refuses a URL that is not a tileset entry point at all', () => {
+    expect(validateRemoteTilesetUrl('https://tiles.example.com/city/').ok).toBe(false);
+  });
+
+  it('carries the refusal as one, so the reason reaches the user', () => {
+    expect(new TilesetRefusal('x') instanceof Error).toBe(true);
+  });
+});


### PR DESCRIPTION
The sixth guarantee the streaming reader dropped, and it makes the previous URL fix partial.

Tile URLs are validated against a base derived from the entry, and part of that check is that a tile stays on the entry's own origin. Leaving the entry unchecked therefore did not skip one validation, it handed every tile below it an origin that then passed the same-origin test.

`validateRemoteTilesetUrl` existed throughout. It carries the private-address block list, the scheme check and the entry-point name check, and its only caller was the merged reader the streaming path replaced. Nothing upstream covers it either: the router pattern-matches a path ending in `tileset.json` and nothing more, so `http://169.254.169.254/tileset.json` reached the transport.

Refused before the entry document is fetched, and carried as a refusal so the reason reaches the user rather than showing as a decode failure. The tests assert what was NOT requested, since that is the actual claim.
