### PR TITLE
fix(streaming): let a key-shaped id find its own parent across a gap

### DIFF
--- a/src/render/streaming/streamingHierarchy.ts
+++ b/src/render/streaming/streamingHierarchy.ts
@@ -24,6 +24,8 @@
  * Pure — no DOM, no three.js, no I/O.
  */
 
+import { keyFromId, keyId, parentKey } from '../../io/copc/voxelKey';
+
 /** A node's parent id, or `undefined` at a root or for an unknown node. */
 export type ParentLookup = (id: string) => string | undefined;
 
@@ -66,5 +68,28 @@ export function forEachAncestorId(
 export function parentLookupFromStore(store: {
   get(id: string): { readonly record: { readonly parentId?: string } } | undefined;
 }): ParentLookup {
-  return (id) => store.get(id)?.record.parentId;
+  return (id) => {
+    const recorded = store.get(id)?.record.parentId;
+    if (recorded !== undefined) return recorded;
+    // The store has no record for this id, and there are two reasons for that.
+    //
+    // A hierarchy page that has not arrived yet genuinely leaves its ancestors
+    // unknown, and stopping is right: inventing ids above it would protect
+    // nodes that may not exist.
+    //
+    // A COPC entry with a point count of zero is different. It is skipped when
+    // the hierarchy is parsed (`copcHierarchy` collects it as an empty key and
+    // adds no node), so it leaves a HOLE in the middle of a chain whose upper
+    // ids are perfectly well known: an octree id encodes its own key, so the
+    // parent is a shift away. Truncating there loses every real ancestor above
+    // the hole, which drops an ancestor's eviction protection, leaves a coarse
+    // node marked as not superseded once its replacement is resident, and lets
+    // the export frontier keep that ancestor alongside its own descendants.
+    //
+    // So a key-shaped id falls back to the key, and anything else still stops.
+    const key = keyFromId(id);
+    if (key === null) return undefined;
+    const parent = parentKey(key);
+    return parent === null ? undefined : keyId(parent);
+  };
 }

--- a/tests/streamingAncestorGap.test.ts
+++ b/tests/streamingAncestorGap.test.ts
@@ -1,0 +1,75 @@
+/**
+ * streamingAncestorGap.test.ts — a hole in the middle of a chain must not hide
+ * the ancestors above it.
+ *
+ * COPC parses an entry whose point count is zero as structure and adds no node
+ * for it, so a real hierarchy can have a gap between a leaf and its grandparent.
+ * The ancestor walk reads parents out of the node store, and a store miss ended
+ * the walk, which is correct for a hierarchy page that has not arrived and wrong
+ * for a hole whose upper ids are perfectly well known.
+ *
+ * Three shipped consumers read these walks, and each fails differently:
+ * `buildAncestorProtection` drops an ancestor's eviction protection while its
+ * descendants are resident, `buildRefinedAwayIds` leaves a coarse node marked
+ * not-superseded once its replacement arrived, and `computeExportFrontier` keeps
+ * that ancestor beside its own descendants, so an export carries the same ground
+ * twice and its point total over-reports.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { forEachAncestorId, parentLookupFromStore } from '../src/render/streaming/streamingHierarchy';
+
+/** A store holding only the ids given; anything else is a miss. */
+function storeOf(records: ReadonlyMap<string, string | undefined>) {
+  return {
+    get(id: string) {
+      if (!records.has(id)) return undefined;
+      return { record: { parentId: records.get(id) } };
+    },
+  };
+}
+
+describe('an octree id can find its own parent', () => {
+  it('walks past a node the hierarchy skipped', () => {
+    // 2-0-0-0 is the empty middle: parsed as structure, never stored.
+    const store = storeOf(new Map([
+      ['3-0-0-0', '2-0-0-0'],
+      ['1-0-0-0', '0-0-0-0'],
+      ['0-0-0-0', undefined],
+    ]));
+    const seen: string[] = [];
+    forEachAncestorId('3-0-0-0', parentLookupFromStore(store), (a) => seen.push(a));
+    expect(
+      seen,
+      'the walk stopped at the empty node, losing every real ancestor above it',
+    ).toEqual(['2-0-0-0', '1-0-0-0', '0-0-0-0']);
+  });
+
+  it('still prefers what the store recorded', () => {
+    // A source whose parents are not key-derivable must keep winning.
+    const store = storeOf(new Map([['3-1-1-1', 'some-other-id'], ['some-other-id', undefined]]));
+    const seen: string[] = [];
+    forEachAncestorId('3-1-1-1', parentLookupFromStore(store), (a) => seen.push(a));
+    expect(seen).toEqual(['some-other-id']);
+  });
+
+  it('stops at the root rather than walking below depth zero', () => {
+    const seen: string[] = [];
+    forEachAncestorId('0-0-0-0', parentLookupFromStore(storeOf(new Map())), (a) => seen.push(a));
+    expect(seen).toEqual([]);
+  });
+
+  it('stops for an id that is not key-shaped, which is how EPT terminates', () => {
+    // A hierarchy page that has not arrived leaves its ancestors genuinely
+    // unknown. Inventing ids there would protect nodes that may not exist.
+    const seen: string[] = [];
+    forEachAncestorId('ept-page-7', parentLookupFromStore(storeOf(new Map())), (a) => seen.push(a));
+    expect(seen).toEqual([]);
+  });
+
+  it('derives the whole chain when the store is empty but the ids are keys', () => {
+    const seen: string[] = [];
+    forEachAncestorId('2-3-1-0', parentLookupFromStore(storeOf(new Map())), (a) => seen.push(a));
+    expect(seen).toEqual(['1-1-0-0', '0-0-0-0']);
+  });
+});


### PR DESCRIPTION
A code review of this session's streaming work turned this up, and it is live on main.

COPC parses an entry whose point count is zero as structure and adds no node for it (`copcHierarchy.ts:90` collects it as an empty key and continues), so a real hierarchy can carry a hole between a leaf and its grandparent. The ancestor walk reads parents out of the node store, and a store miss ended the walk.

That is correct for a hierarchy page that has not arrived, whose ancestors are genuinely unknown, and wrong for a hole whose upper ids are perfectly well known. An octree id encodes its own key, so the parent is a shift away. Probed on main: a walk from `3-0-0-0` across an unstored `2-0-0-0` yields `["2-0-0-0"]` and never reaches the root.

Three shipped consumers read these walks. `buildAncestorProtection` dropped an ancestor's eviction protection while its descendants were resident. `buildRefinedAwayIds` left a coarse node marked not-superseded once its replacement arrived. `computeExportFrontier` kept that ancestor beside its own descendants, so an export carried the same ground twice and its point total over-reported.

A key-shaped id now falls back to the key, and the store still wins where it has a record. Anything not key-shaped still stops, which is how EPT's partial load is meant to terminate.
