### PR TITLE
test(streaming): give the legacy baseline a real build origin

### DIFF
--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -267,13 +267,16 @@ export interface SchedulerOptions {
  * appears in this set is a parent of at least one resident node, and it is
  * protected from eviction until its descendants leave too.
  *
- * Ancestry comes from each record's `parentId`, not from shifting its voxel
- * key. The two agree exactly on a regular octree, which is what COPC, EPT and
- * the OLV tile store are; the difference is that a hierarchy which is not an
- * octree still answers. The one behavioural distinction is that the key walk
- * climbed to depth 0 through cells that may hold no node, while this one stops
- * where the hierarchy stops. Only ids of nodes that exist are ever tested
- * against the set, so the phantom entries the key walk added were never read.
+ * Ancestry comes from each record's `parentId` rather than from shifting its
+ * voxel key, so a hierarchy that is not an octree still answers. On a regular
+ * octree the two agree, and where the store has no record `parentLookupFromStore`
+ * derives the parent from a key-shaped id so the walk crosses a gap.
+ *
+ * That fallback is load-bearing, not a tidy-up. A COPC entry with no points is
+ * skipped at parse time and never reaches the store, so a chain can have a hole
+ * with real ancestors above it. Reading `parentId` alone stopped at the hole and
+ * dropped every ancestor beyond, which cost those nodes their eviction
+ * protection while their descendants were still resident.
  */
 function buildAncestorProtection(
   nodes: readonly StreamingNode[],

--- a/tests/fixtures/streaming/legacyBaselineScenario.ts
+++ b/tests/fixtures/streaming/legacyBaselineScenario.ts
@@ -413,20 +413,20 @@ async function openTileScenario(): Promise<StreamingSource> {
     memoryBudgetBytes: 64 * 1024,
   });
   const { manifestJson, hierarchy } = buildTileStore(index, las.schema, las.origin);
-  // The build origin is folded to zero for this fixture. `OlvTileOctree` records
-  // each node's cube in the store's own local frame, while `OlvTileSource`
-  // reports the build's world recentring origin as its `renderOrigin`, and the
-  // scheduler subtracts `renderOrigin` from every record's bounds. With a UTM
-  // build origin that subtraction moves the whole hierarchy hundreds of
-  // kilometres from the camera, every node scores zero, and the fixture records
-  // an empty scheduler instead of a tile-store one. Zeroing the origin makes the
-  // two frames agree, which is the state the scheduler is written against. The
-  // adapter has no construction site in `src/`, so this is a fixture choice, not
-  // a workaround for live behaviour.
-  const manifest = JSON.parse(manifestJson) as { origin: number[] };
-  manifest.origin = [0, 0, 0];
+  // The build origin is carried through as the build measured it. It used to be
+  // folded to zero here, from a time when `OlvTileOctree` recorded each node's
+  // cube in the store's own local frame while `OlvTileSource` reported the world
+  // recentring origin as its `renderOrigin`: the scheduler subtracted the origin
+  // from bounds that had never had it added, so a UTM build moved the hierarchy
+  // hundreds of kilometres and every node scored zero. Zeroing hid that by making
+  // the two frames agree by accident.
+  //
+  // Node bounds are world now, so the frames agree on their own and the recorded
+  // document is byte-identical either way. Keeping a real origin is what makes
+  // this fixture able to fail: with it zeroed, local and world are the same
+  // numbers and a reintroduced double-shift records an identical scheduler.
   const reader = new TileStoreReader(
-    parseTileManifest(manifest),
+    parseTileManifest(JSON.parse(manifestJson)),
     parseHierarchy(hierarchy),
   );
   const tiles: TileBytesReader = { read: (key) => spill.read(key) };


### PR DESCRIPTION
The tile-store fixture folded the manifest origin to zero. That dated from a
time when node bounds were local and `renderOrigin` was world, where zeroing
made the two frames agree by accident. Bounds are world since #587, so they
agree on their own.

Zeroing also left the fixture unable to fail. At the origin local and world are
the same numbers, so reverting #587 recorded an identical scheduler and the
gate passed 3/3. With the origin carried through, that reversal fails two of
the three checks. The recorded baseline document is byte-identical.

Also corrects the ancestor-protection note, which still claimed the phantom
entries the old key walk added were never read. #628 made that walk cross a
store gap, so they are.
