### PR TITLE
fix(tiles3d): refuse a PNTS tile above a decoded-point ceiling

### DIFF
--- a/src/io/tiles3d/pnts.ts
+++ b/src/io/tiles3d/pnts.ts
@@ -462,8 +462,29 @@ function decodeBatchIds(
   return batchIds;
 }
 
+/**
+ * The most points this viewer will decode from one PNTS tile.
+ *
+ * Matches the ceiling the superseded merged read applied to a whole tileset
+ * (`MAX_TILESET_POINTS`), which the streaming replacement did not carry over.
+ * At the channels {@link PntsTile} expands into, eight million points is about
+ * 200 MB of typed arrays before the renderer sees any of it.
+ */
+export const MAX_PNTS_TILE_POINTS = 8_000_000;
+
+/** Options for {@link parsePnts}. */
+export interface ParsePntsOptions {
+  /**
+   * Ceiling on `POINTS_LENGTH`. Defaults to {@link MAX_PNTS_TILE_POINTS}. A
+   * caller on a constrained device can lower it; raising it past what the
+   * device can hold moves the failure from a named refusal to an allocation
+   * crash.
+   */
+  readonly maxPoints?: number;
+}
+
 /** Decode a PNTS tile's header, feature table, positions, and per-point attributes. */
-export function parsePnts(buffer: ArrayBuffer): PntsTile {
+export function parsePnts(buffer: ArrayBuffer, options: ParsePntsOptions = {}): PntsTile {
   if (buffer.byteLength < HEADER_BYTES) {
     throw new Error('PNTS: buffer shorter than the 28-byte header.');
   }
@@ -529,6 +550,24 @@ export function parsePnts(buffer: ArrayBuffer): PntsTile {
     pointsLength > UINT32_MAX
   ) {
     throw new Error('PNTS: POINTS_LENGTH is not a positive uint32.');
+  }
+
+  // The magnitude ceiling, before the first allocation. The checks above bound
+  // where an accessor may READ; this one bounds what the decode will HOLD, and
+  // they are not the same limit. A tile body is capped at 128 MiB, but
+  // POSITION_QUANTIZED costs six bytes a point, so that cap admits roughly 22.4
+  // million of them, and each becomes a Float32 position plus the intensity,
+  // classification, return and GPS channels the generic chunk contract carries.
+  // The scheduler cannot pre-empt it either: every tile is admitted as
+  // ASSUMED_TILE_POINTS, so a 22-million-point tile is dispatched as though it
+  // were 500,000 and the real figure is only known once the arrays exist.
+  // Refusing names the tile; truncating would render a silently partial one.
+  const maxPoints = options.maxPoints ?? MAX_PNTS_TILE_POINTS;
+  if (pointsLength > maxPoints) {
+    throw new Error(
+      `PNTS: POINTS_LENGTH ${pointsLength} exceeds the ${maxPoints} point ceiling this ` +
+        `viewer decodes in one tile.`,
+    );
   }
 
   // RTC_CENTER is optional, but a present one cannot be dropped when it is

--- a/src/io/tiles3d/pnts.ts.bak
+++ b/src/io/tiles3d/pnts.ts.bak
@@ -465,16 +465,10 @@ function decodeBatchIds(
 /**
  * The most points this viewer will decode from one PNTS tile.
  *
- * The 3D Tiles sibling of COPC's `MAX_NODE_POINTS`: every other streaming path
- * refuses a node above a magnitude it will not hold, and this one did not. It
- * also restores the ceiling the superseded merged read applied to a whole
- * tileset (`MAX_TILESET_POINTS`), which the streaming replacement dropped.
- *
- * Distinct from `validateDeclaredPointCount`, which asks whether the bytes
- * present could back the declared count. For PNTS `arrayStart` already settles
- * that, and a count backed by real bytes can still be one the device cannot
- * hold. Eight million points is roughly 300 MB across the position copies and
- * the channels {@link PntsTile} expands into.
+ * Matches the ceiling the superseded merged read applied to a whole tileset
+ * (`MAX_TILESET_POINTS`), which the streaming replacement did not carry over.
+ * At the channels {@link PntsTile} expands into, eight million points is about
+ * 200 MB of typed arrays before the renderer sees any of it.
  */
 export const MAX_PNTS_TILE_POINTS = 8_000_000;
 

--- a/tests/pntsDecodeCeiling.test.ts
+++ b/tests/pntsDecodeCeiling.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_PNTS_TILE_POINTS, parsePnts } from '../src/io/tiles3d/pnts';
+
+/**
+ * A PNTS tile declaring more points than the decoder is willing to allocate for.
+ *
+ * The transport caps a tile body at 128 MiB, which bounds the DOWNLOAD and not the
+ * decode. POSITION_QUANTIZED costs six bytes a point on the wire, so that cap admits
+ * about 22.4 million points, and each one is expanded into a Float32 position plus the
+ * intensity, classification, return and GPS channels the generic chunk contract carries.
+ * The scheduler cannot see the real figure beforehand either: every tile is admitted as
+ * ASSUMED_TILE_POINTS. The refusal therefore has to happen on POINTS_LENGTH, before the
+ * first array is allocated.
+ */
+function pntsWithDeclaredPoints(pointsLength: number): ArrayBuffer {
+  const featureTable = JSON.stringify({
+    POINTS_LENGTH: pointsLength,
+    POSITION: { byteOffset: 0 },
+  });
+  // Pad the JSON to a 4-byte boundary, as the spec requires.
+  const padded = featureTable.padEnd(Math.ceil(featureTable.length / 4) * 4, ' ');
+  const jsonBytes = new TextEncoder().encode(padded);
+  const HEADER = 28;
+  // No binary section: the refusal must land before any accessor reads one.
+  const buffer = new ArrayBuffer(HEADER + jsonBytes.length);
+  const view = new DataView(buffer);
+  view.setUint32(0, 0x73746e70, true); // "pnts"
+  view.setUint32(4, 1, true);
+  view.setUint32(8, buffer.byteLength, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, 0, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buffer, HEADER).set(jsonBytes);
+  return buffer;
+}
+
+describe('PNTS decoded-point ceiling', () => {
+  it('refuses a tile declaring more points than the ceiling', () => {
+    const tile = pntsWithDeclaredPoints(MAX_PNTS_TILE_POINTS + 1);
+    expect(() => parsePnts(tile)).toThrow(/POINTS_LENGTH/);
+  });
+
+  it('names the ceiling and the declared figure so the refusal is actionable', () => {
+    const tile = pntsWithDeclaredPoints(22_369_621);
+    expect(() => parsePnts(tile)).toThrow(/22369621/);
+    expect(() => parsePnts(tile)).toThrow(new RegExp(String(MAX_PNTS_TILE_POINTS)));
+  });
+
+  it('refuses before allocating, so an absurd declaration costs no memory', () => {
+    // UINT32_MAX points would be ~100 GiB of channels if it reached the allocator.
+    const tile = pntsWithDeclaredPoints(4_294_967_295);
+    expect(() => parsePnts(tile)).toThrow(/POINTS_LENGTH/);
+  });
+
+  it('lets a caller lower the ceiling for a constrained device', () => {
+    const tile = pntsWithDeclaredPoints(1_000);
+    expect(() => parsePnts(tile, { maxPoints: 999 })).toThrow(/POINTS_LENGTH/);
+  });
+
+  it('accepts a tile at exactly the ceiling rather than off by one', () => {
+    // Reaching the position accessor proves the ceiling passed; the truncated
+    // buffer then fails on the section bounds, which is a different refusal.
+    const tile = pntsWithDeclaredPoints(MAX_PNTS_TILE_POINTS);
+    expect(() => parsePnts(tile)).toThrow(/past the feature-table binary section/);
+  });
+});

--- a/tests/pntsDecodeCeiling.test.ts
+++ b/tests/pntsDecodeCeiling.test.ts
@@ -66,3 +66,36 @@ describe('PNTS decoded-point ceiling', () => {
     expect(() => parsePnts(tile)).toThrow(/past the feature-table binary section/);
   });
 });
+
+describe('CONSTANT_RGBA amplification', () => {
+  /**
+   * CONSTANT_RGBA lives in the feature-table JSON, not the binary, so unlike
+   * RGBA, RGB and RGB565 it has no backing bytes for `arrayStart` to bound it
+   * against. Colours are resolved before the positions branch, so a tile of a
+   * few hundred bytes reached `new Uint8Array(pointsLength * 3)` before any
+   * accessor was range-checked. At a uint32 POINTS_LENGTH that is a 12.9 GB
+   * allocation from a file that fits in a packet.
+   */
+  it('refuses a tiny tile that declares a huge constant-coloured cloud', () => {
+    const ft = JSON.stringify({
+      POINTS_LENGTH: 4_294_967_295,
+      CONSTANT_RGBA: [255, 0, 0, 255],
+      POSITION: { byteOffset: 0 },
+    });
+    const padded = ft.padEnd(Math.ceil(ft.length / 4) * 4, ' ');
+    const jsonBytes = new TextEncoder().encode(padded);
+    const buffer = new ArrayBuffer(28 + jsonBytes.length);
+    const view = new DataView(buffer);
+    view.setUint32(0, 0x73746e70, true);
+    view.setUint32(4, 1, true);
+    view.setUint32(8, buffer.byteLength, true);
+    view.setUint32(12, jsonBytes.length, true);
+    view.setUint32(16, 0, true);
+    view.setUint32(20, 0, true);
+    view.setUint32(24, 0, true);
+    new Uint8Array(buffer, 28).set(jsonBytes);
+
+    expect(buffer.byteLength).toBeLessThan(300);
+    expect(() => parsePnts(buffer)).toThrow(/exceeds the 8000000 point ceiling/);
+  });
+});

--- a/tests/tiles3dMalformed.test.ts
+++ b/tests/tiles3dMalformed.test.ts
@@ -329,10 +329,16 @@ describe('PNTS perimeter', () => {
       /POINTS_LENGTH is not a positive uint32/,
     );
     // The upper bound is inclusive, so the refusal above is about the value and
-    // not about uint32 generally.
+    // not about uint32 generally. A valid uint32 clears this check and is
+    // refused by the decoded-point ceiling instead.
     expect(() => parsePnts(withPointsLength(4294967295))).toThrow(
-      /POSITION extends past the feature-table binary section/,
+      /exceeds the 8000000 point ceiling/,
     );
+    // Lifting the ceiling past it shows what catches it next, which is the
+    // section bounds the accessor reads against.
+    expect(() =>
+      parsePnts(withPointsLength(4294967295), { maxPoints: 4294967295 }),
+    ).toThrow(/POSITION extends past the feature-table binary section/);
   });
 
   it('refuses a POSITION that is not an accessor object', () => {


### PR DESCRIPTION
The transport caps a PNTS body at 128 MiB, which bounds the download and not the
decode. `POSITION_QUANTIZED` costs six bytes a point, so that cap admits about
22.4 million of them, and each becomes a Float32 position plus the intensity,
classification, return and GPS channels the generic chunk contract carries. One
tile could reach roughly 900 MB of typed arrays on a phone or tablet.

The scheduler could not pre-empt it. Every tile is admitted as
`ASSUMED_TILE_POINTS` (500,000), so a 22-million-point tile was dispatched as
though it were 500,000, and `_commitDecoded` took the real count only once the
arrays existed. The superseded merged read capped a tileset at
`MAX_TILESET_POINTS`; the streaming replacement did not carry that over.

`POINTS_LENGTH` is now checked against `MAX_PNTS_TILE_POINTS` before the first
allocation, with a per-call override for constrained devices. Existing bounds
checks are unchanged: one test now asserts both the ceiling and, with the
ceiling lifted, the section-bounds refusal it used to reach.
