### PR TITLE
fix(streaming): refuse a full-cloud grade for a source with no stated point total

### DIFF
--- a/src/render/streaming/fullCloudGrade.ts
+++ b/src/render/streaming/fullCloudGrade.ts
@@ -16,6 +16,12 @@
  *      coverage fraction — so a full-cloud grade never implies a completeness it
  *      doesn't have.
  *
+ * A third case sits above both: a source that states NO point total at all
+ * ({@link StreamingSource.sourcePointCount} null). Its per-node counts are
+ * decode-admission estimates, so every figure this module derives from them
+ * would be fabricated. {@link UNSTATED_POINT_TOTAL} is what the grade shows
+ * instead, and it carries no number.
+ *
  * "Exact" needs TWO independent facts, because the sampling plan can only ever
  * see the nodes the octree actually LOADED. `plan.exhaustive` means "the sample
  * covered every loaded node"; it says nothing about a hierarchy that stopped
@@ -34,6 +40,44 @@ import { formatPointCount } from '../../io/loadPlan';
 
 /** Whether a full-cloud grade is exact (all nodes) or estimated from a sample. */
 export type GradeScope = 'exhaustive' | 'sampled';
+
+/**
+ * What the grade shows in place of figures when the source states no point
+ * total. Same two slots the panel already renders for a graded run (a headline
+ * where the coverage label goes, and the note beneath it), so a refusal reads
+ * as a result rather than an error.
+ */
+export interface UnstatedPointTotal {
+  /** Stands in for the coverage label. */
+  readonly headline: string;
+  /** Why no figure is shown. */
+  readonly note: string;
+}
+
+/**
+ * The refusal for a source whose `sourcePointCount` is null.
+ *
+ * A 3D Tiles `tileset.json` states content URIs and no point counts, so every
+ * node record the reader builds carries one assumed figure that exists to
+ * govern decode admission. Summing those yields (tiles x assumed), which tracks
+ * how the tileset is subdivided and not how many points it holds. The streaming
+ * source already refuses to add them up; the grade refuses for the same reason,
+ * because a coverage label, a coverage percent and a density back-scale are all
+ * built on that sum.
+ *
+ * Deliberately carries no number of any kind. Showing the sum with a caveat, or
+ * showing zero, would each put a figure in front of a user that the file never
+ * stated.
+ */
+export const UNSTATED_POINT_TOTAL: UnstatedPointTotal = {
+  headline: 'Full-cloud grade unavailable: this format states no point total',
+  note:
+    "This scan's index says where its tiles are, not how many points they hold. " +
+    'The per-tile counts a grade would add up are decode-admission estimates, so a ' +
+    'point total, a coverage percent, or a density scaled by them would be a ' +
+    'fabricated figure rather than a measurement. COPC and EPT scans state a real ' +
+    'total and grade normally.',
+};
 
 /** The honesty + scaling facts derived from a {@link SamplingPlan}. */
 export interface FullCloudGradeCoverage {

--- a/src/render/streaming/fullCloudGradeAdapter.ts
+++ b/src/render/streaming/fullCloudGradeAdapter.ts
@@ -20,6 +20,13 @@
  *
  * Everything format-specific (COPC chunk records vs. EPT tile URLs) is already
  * behind the `StreamingSource` interface, so one adapter serves both formats.
+ *
+ * One thing it does NOT do is sum the records' point counts for a source that
+ * states no total of its own. A format that names tiles without counting their
+ * points (3D Tiles) leaves the reader stamping one assumed figure per record to
+ * govern decode admission; adding those up here would print a total the file
+ * never stated. `gradeFullCloud` refuses instead, which is the same call the
+ * streaming source makes when it returns null from `sourcePointCount`.
  */
 
 import type { StreamingNode } from './StreamingNode';
@@ -35,6 +42,7 @@ import {
   type GradeFn,
   type GradeProgress,
 } from './fullCloudGradeRunner';
+import { UNSTATED_POINT_TOTAL, type UnstatedPointTotal } from './fullCloudGrade';
 
 /**
  * The minimal slice of a {@link StreamingSource} the grade adapter reads — node
@@ -44,6 +52,16 @@ import {
  * satisfies it without any cast.
  */
 export interface GradeNodeSource {
+  /**
+   * What the SOURCE states as its point total, or null when the format does not
+   * state one. Read for one decision only: whether the per-node `pointCount`
+   * values this adapter projects are measurements or decode-admission
+   * estimates. COPC reads its total from the LAS header and EPT from
+   * `ept.json`, so their node counts sum to a stated figure; a 3D Tiles
+   * tileset states neither, and `TilesetStreamingSource` returns null rather
+   * than summing the assumed per-tile counts it stamped on its records.
+   */
+  readonly sourcePointCount: number | null;
   readonly octree: {
     /** Every known node in the octree. */
     nodes(): StreamingNode[];
@@ -122,16 +140,43 @@ export function makeDecodeNode(
 }
 
 /**
+ * What {@link gradeFullCloud} returns: either a grade, or the reason there
+ * cannot be one. A union rather than a nullable run, so a caller that renders
+ * the result has to decide what the refusal says instead of falling through to
+ * a figure.
+ */
+export type FullCloudGradeOutcome<G> =
+  | { readonly kind: 'graded'; readonly run: FullCloudGradeRun<G> }
+  | ({ readonly kind: 'unavailable' } & UnstatedPointTotal);
+
+/**
+ * Whether this source's per-node counts are measurements. A source that states
+ * no point total stamped its records with a decode-admission estimate, so every
+ * figure the grade derives from them (the coverage label, the coverage percent,
+ * the density back-scale) would be fabricated.
+ *
+ * Null only. Zero is a real answer meaning an empty source and grades normally.
+ */
+function statesPointTotal(source: GradeNodeSource): boolean {
+  return source.sourcePointCount != null;
+}
+
+/**
  * The full live grade in one call: enumerate the source's octree, plan a
  * representative sample within budget, decode it through `decoder`, and grade
  * the assembled points with `grade` (the terrain pipeline at the call site).
  *
  * This is the single entry the "Grade full cloud" UI action invokes — it owns
  * the adapter glue (enumerate + decode) so the panel only has to supply the
- * source, a decoder, the grade, and an optional progress/abort. The returned
- * {@link FullCloudGradeRun} carries the honest coverage label
- * (`run.coverage.label`, e.g. "1.8M of 18.2M points (10%, sampled)") to render
- * next to the verdict.
+ * source, a decoder, the grade, and an optional progress/abort. A graded
+ * outcome carries the honest coverage label (`run.coverage.label`, e.g.
+ * "1.8M of 18.2M points (10%, sampled)") to render next to the verdict.
+ *
+ * A source that states no point total is refused BEFORE any node is read: its
+ * record counts are decode-admission estimates, and this function is where they
+ * would otherwise be summed into a printed total. Refusing here rather than at
+ * the panel keeps the decision with the one module that reads the source
+ * contract, and spares a decode whose result could not be reported.
  */
 export function gradeFullCloud<G>(args: {
   readonly source: GradeNodeSource;
@@ -140,8 +185,11 @@ export function gradeFullCloud<G>(args: {
   readonly options?: SamplingPlanOptions;
   readonly signal?: AbortSignal;
   readonly onProgress?: (progress: GradeProgress) => void;
-}): Promise<FullCloudGradeRun<G>> {
+}): Promise<FullCloudGradeOutcome<G>> {
   const { source, decoder, grade, options, signal, onProgress } = args;
+  if (!statesPointTotal(source)) {
+    return Promise.resolve({ kind: 'unavailable', ...UNSTATED_POINT_TOTAL });
+  }
   return runFullCloudGrade({
     nodes: sampleNodesFromSource(source),
     decodeNode: makeDecodeNode(source, decoder),
@@ -158,5 +206,5 @@ export function gradeFullCloud<G>(args: {
       complete: source.octree.isComplete,
       errorCount: source.octree.errors.length,
     },
-  });
+  }).then((run) => ({ kind: 'graded', run }) as const);
 }

--- a/src/render/streaming/runFullCloudGradeAction.ts
+++ b/src/render/streaming/runFullCloudGradeAction.ts
@@ -62,7 +62,7 @@ export async function runFullCloudGrade(deps: {
     ? (verticalMetresPerUnit(ctx, 'horizontal') ?? metresPerUnit)
     : 1;
   try {
-    const run = await gradeFullCloud({
+    const outcome = await gradeFullCloud({
       source,
       decoder,
       signal,
@@ -84,6 +84,15 @@ export async function runFullCloudGrade(deps: {
     // it silently rather than paint a stale grade over a different (or absent)
     // cloud's panel.
     if (viewer.streamingCloud !== source) return;
+    // A source that states no point total is refused by the adapter before any
+    // node is read, because its record counts are decode-admission estimates.
+    // Render the reason where the coverage label goes and show no figures: the
+    // refusal is a result, not an error, so it keeps the neutral styling.
+    if (outcome.kind === 'unavailable') {
+      panel.setGradeResult(outcome.headline, [], outcome.note);
+      return;
+    }
+    const run = outcome.run;
     panel.setGradeResult(
       run.coverage.label,
       summarizeSampleGrade(run.grade, unitConfirmed),

--- a/tests/fullCloudGrade.test.ts
+++ b/tests/fullCloudGrade.test.ts
@@ -6,7 +6,10 @@
 
 import { describe, it, expect } from 'vitest';
 import { buildSamplingPlan, type SampleNode } from '../src/render/streaming/samplingPlan';
-import { fullCloudGradeCoverage } from '../src/render/streaming/fullCloudGrade';
+import {
+  fullCloudGradeCoverage,
+  UNSTATED_POINT_TOTAL,
+} from '../src/render/streaming/fullCloudGrade';
 
 function nodes(spec: Array<[depth: number, points: number]>): SampleNode[] {
   return spec.map(([depth, pointCount], i) => ({ id: `${depth}-${i}-0-0`, depth, pointCount, byteSize: pointCount * 4 }));
@@ -136,5 +139,26 @@ describe('fullCloudGradeCoverage — completeness gating (a short hierarchy is n
     expect(cov.scope).toBe('sampled'); // driven by the budget, not completeness
     expect(cov.label).toMatch(/sampled/);
     expect(cov.note).toMatch(/representative octree sample/i);
+  });
+});
+
+describe('UNSTATED_POINT_TOTAL — what replaces the figures when a format states no total', () => {
+  it('carries no number of any kind', () => {
+    // The whole point: the sum of the per-node estimates, a percent of it, or a
+    // zero standing in for it would each be a figure the file never stated.
+    expect(UNSTATED_POINT_TOTAL.headline).not.toMatch(/\d/);
+    expect(UNSTATED_POINT_TOTAL.note).not.toMatch(/\d/);
+  });
+
+  it('says the counts are estimates and that no total was stated', () => {
+    expect(UNSTATED_POINT_TOTAL.headline).toMatch(/no point total/i);
+    expect(UNSTATED_POINT_TOTAL.note).toMatch(/decode-admission estimates/i);
+  });
+
+  it('leaves the plan-driven coverage labels untouched', () => {
+    // The refusal is a separate value, not a mutation of the honest labels a
+    // COPC/EPT plan still produces.
+    const plan = buildSamplingPlan(nodes([[0, 500_000], [1, 1_300_000]]), { maxPoints: 10_000_000 });
+    expect(fullCloudGradeCoverage(plan).label).toBe('all 1.8M points (exact)');
   });
 });

--- a/tests/fullCloudGradeAdapter.test.ts
+++ b/tests/fullCloudGradeAdapter.test.ts
@@ -17,12 +17,14 @@ import {
   sampleNodesFromSource,
   makeDecodeNode,
   gradeFullCloud,
+  type FullCloudGradeOutcome,
   type GradeNodeSource,
 } from '../src/render/streaming/fullCloudGradeAdapter';
 import { runFullCloudGrade } from '../src/render/streaming/fullCloudGradeRunner';
 import { createStreamingNode } from '../src/render/streaming/StreamingNode';
 import type { StreamingNode } from '../src/render/streaming/StreamingNode';
 import type { StreamingNodeRecord } from '../src/io/copc/copcTypes';
+import type { StreamingSource } from '../src/render/streaming/StreamingSource';
 import type { ChunkDecodeMetadata, ChunkDecoder, DecodedChunk } from '../src/io/copc/copcChunkDecode';
 
 /** A minimal-but-valid node record; only id/depth/pointCount/byteSize matter here. */
@@ -57,11 +59,17 @@ function fakeSource(
   // existing exhaustive/sampled tests are unaffected; the truncation test sets
   // it false to prove the grade never claims exact over a short hierarchy.
   completeness: { isComplete?: boolean; errors?: readonly string[] } = {},
+  // What the SOURCE states as its point total. Defaults to the sum of the node
+  // records, which is what a COPC/EPT header states and what those formats'
+  // per-node counts add up to. `null` is the 3D Tiles case: the format states
+  // no total and the per-node counts are decode-admission estimates.
+  sourcePointCount: number | null = nodes.reduce((s, n) => s + n.record.pointCount, 0),
 ): GradeNodeSource {
   const byId = new Map(nodes.map((n) => [n.record.id, n]));
   // Reverse-lookup a record's id from the marker we'll stash, so readNodeChunk
   // can encode it. (We key the marker by id directly.)
   return {
+    sourcePointCount,
     octree: {
       nodes: () => nodes,
       store: { get: (id: string) => byId.get(id) },
@@ -98,6 +106,21 @@ function fakeDecoder(seen?: { signals: (AbortSignal | undefined)[] }): ChunkDeco
       };
     },
   };
+}
+
+// Compile-time contract: a real streaming source (COPC's StreamingPointCloud,
+// EPT's, the tileset's) satisfies GradeNodeSource without a cast. The gate the
+// adapter applies reads `sourcePointCount` straight off it, so narrowing that
+// member out of the source interface has to break here rather than at runtime.
+const _sourceSatisfiesAdapter: (s: StreamingSource) => GradeNodeSource = (s) => s;
+void _sourceSatisfiesAdapter;
+
+/** Unwrap a graded outcome, failing the test if the grade was refused. */
+async function graded<G>(outcome: Promise<FullCloudGradeOutcome<G>>) {
+  const settled = await outcome;
+  expect(settled.kind).toBe('graded');
+  if (settled.kind !== 'graded') throw new Error('expected a graded outcome');
+  return settled.run;
 }
 
 describe('sampleNodesFromSource — octree → SampleNode[]', () => {
@@ -196,12 +219,12 @@ describe('adapter ∘ runner — end-to-end with fakes', () => {
 describe('gradeFullCloud — one-call composition + progress', () => {
   it('enumerates, decodes, and grades the source in one call', async () => {
     const src = fakeSource(nodeList(), { '0-0-0-0': 1, '1-0-0-0': 2, '1-1-0-0': 3 });
-    const run = await gradeFullCloud({
+    const run = await graded(gradeFullCloud({
       source: src,
       decoder: fakeDecoder(),
       grade: (pos) => pos.length / 3,
       options: { maxPoints: 10_000 },
-    });
+    }));
     expect(run.coverage.scope).toBe('exhaustive');
     expect(run.grade).toBe(3); // 3 nodes → 3 marker points
     expect(run.coverage.label).toMatch(/exact/);
@@ -246,17 +269,90 @@ describe('gradeFullCloud — one-call composition + progress', () => {
       isComplete: false,
       errors: ['failed to load hierarchy page at 4096: network down'],
     });
-    const run = await gradeFullCloud({
+    const run = await graded(gradeFullCloud({
       source: src,
       decoder: fakeDecoder(),
       grade: (pos) => pos.length / 3,
       options: { maxPoints: 10_000 }, // budget covers every loaded node
-    });
+    }));
     expect(run.coverage.scope).toBe('sampled');
     expect(run.coverage.label).not.toMatch(/exact/);
     expect(run.coverage.label).toMatch(/partial/i);
     // The reason and the (previously write-only) error count reach the user.
     expect(run.coverage.note).toMatch(/did not fully load/i);
     expect(run.coverage.note).toMatch(/1 load error/);
+  });
+});
+
+describe('gradeFullCloud — a source that states no point total', () => {
+  /**
+   * Three tiles, each carrying the SAME flat per-node count. That is exactly
+   * what a 3D Tiles index looks like: `tileset.json` states content URIs and no
+   * point counts anywhere, so every node record is stamped with one assumed
+   * figure that governs decode admission. Summing those is (tiles x assumed),
+   * a number with no relationship to the points in the file, and the streaming
+   * source says so by returning `null` from `sourcePointCount` rather than
+   * adding them up.
+   */
+  const ASSUMED = 500_000;
+  function estimatedNodes(): StreamingNode[] {
+    return [
+      createStreamingNode(record('0-0-0-0', 0, ASSUMED, 1000)),
+      createStreamingNode(record('1-0-0-0', 1, ASSUMED, 1000)),
+      createStreamingNode(record('1-1-0-0', 1, ASSUMED, 1000)),
+    ];
+  }
+  const markers = { '0-0-0-0': 1, '1-0-0-0': 2, '1-1-0-0': 3 };
+
+  it('refuses instead of printing a total summed from per-node estimates', async () => {
+    const src = fakeSource(estimatedNodes(), markers, {}, {}, null);
+    const outcome = await gradeFullCloud({
+      source: src,
+      decoder: fakeDecoder(),
+      grade: (pos) => pos.length / 3,
+      options: { maxPoints: 10_000_000 },
+    });
+    expect(outcome.kind).toBe('unavailable');
+    if (outcome.kind !== 'unavailable') return;
+    // Nothing it hands the panel carries a point figure: not the 1.5M sum, not
+    // a coverage percent over it, not the assumed per-tile count.
+    const shown = `${outcome.headline} ${outcome.note}`;
+    expect(shown).not.toMatch(/\d/);
+    expect(outcome.headline).toMatch(/point total/i);
+    expect(outcome.note).toMatch(/estimate/i);
+  });
+
+  it('does not decode anything for a grade it cannot report', async () => {
+    const reads: string[] = [];
+    const src = fakeSource(estimatedNodes(), markers, { onRead: (id) => reads.push(id) }, {}, null);
+    await gradeFullCloud({ source: src, decoder: fakeDecoder(), grade: () => null });
+    expect(reads).toEqual([]);
+  });
+
+  it('still grades a source that DOES state a total (not a blanket removal)', async () => {
+    // Same octree, same per-node counts. The one difference is that the source
+    // states the total, which is what makes those counts measurements.
+    const src = fakeSource(estimatedNodes(), markers, {}, {}, 3 * ASSUMED);
+    const outcome = await gradeFullCloud({
+      source: src,
+      decoder: fakeDecoder(),
+      grade: (pos) => pos.length / 3,
+      options: { maxPoints: 10_000_000 },
+    });
+    expect(outcome.kind).toBe('graded');
+    if (outcome.kind !== 'graded') return;
+    expect(outcome.run.coverage.scope).toBe('exhaustive');
+    expect(outcome.run.coverage.label).toBe('all 1.5M points (exact)');
+    expect(outcome.run.grade).toBe(3);
+  });
+
+  it('grades a source that states a total of ZERO (null is not zero)', async () => {
+    // An empty source is a real answer, not a missing one, so it grades and
+    // says "no points" rather than being refused with the unstated-total note.
+    const src = fakeSource([], {}, {}, {}, 0);
+    const outcome = await gradeFullCloud({ source: src, decoder: fakeDecoder(), grade: () => null });
+    expect(outcome.kind).toBe('graded');
+    if (outcome.kind !== 'graded') return;
+    expect(outcome.run.coverage.label).toBe('no points available to grade');
   });
 });

--- a/tests/runFullCloudGradeAction.test.ts
+++ b/tests/runFullCloudGradeAction.test.ts
@@ -6,6 +6,10 @@
  * result describes a scan that's no longer shown and must NOT paint over the
  * new (or absent) cloud's panel. gradeFullCloud is mocked so the test can mutate
  * the viewer's active cloud mid-grade without a real GPU/decoder.
+ *
+ * Also pins how the panel renders the adapter's refusal for a source that
+ * states no point total: the reason where the coverage label goes, and no
+ * summary lines at all.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -31,6 +35,7 @@ function makePanel() {
 const sourceA = { crs: () => null };
 const sourceB = { crs: () => null };
 const RUN = { coverage: { label: 'L', note: 'N' }, grade: {} };
+const GRADED = { kind: 'graded', run: RUN };
 
 type FakeViewer = { streamingCloud: { crs: () => null } | null; streamingDecoder: unknown };
 const mkViewer = (cloud: FakeViewer['streamingCloud'], decoder: unknown = {}): FakeViewer => ({
@@ -45,7 +50,7 @@ describe('runFullCloudGrade — stale-cloud guard', () => {
 
   it('paints the result when the active cloud is unchanged', async () => {
     const viewer = mkViewer(sourceA);
-    gradeFullCloud.mockResolvedValue(RUN);
+    gradeFullCloud.mockResolvedValue(GRADED);
     const panel = makePanel();
     await run(viewer, panel);
     expect(panel.setGradeResult).toHaveBeenCalledTimes(1);
@@ -55,7 +60,7 @@ describe('runFullCloudGrade — stale-cloud guard', () => {
     const viewer = mkViewer(sourceA);
     gradeFullCloud.mockImplementation(async () => {
       viewer.streamingCloud = sourceB; // user opened a different scan
-      return RUN;
+      return GRADED;
     });
     const panel = makePanel();
     await run(viewer, panel);
@@ -66,7 +71,7 @@ describe('runFullCloudGrade — stale-cloud guard', () => {
     const viewer = mkViewer(sourceA);
     gradeFullCloud.mockImplementation(async () => {
       viewer.streamingCloud = null; // scan closed
-      return RUN;
+      return GRADED;
     });
     const panel = makePanel();
     await run(viewer, panel);
@@ -84,7 +89,7 @@ describe('runFullCloudGrade — stale-cloud guard', () => {
 describe('runFullCloudGrade — unit-confirmation gate', () => {
   beforeEach(() => {
     gradeFullCloud.mockReset();
-    gradeFullCloud.mockResolvedValue(RUN);
+    gradeFullCloud.mockResolvedValue(GRADED);
     vi.mocked(summarizeSampleGrade).mockClear();
   });
 
@@ -118,5 +123,46 @@ describe('runFullCloudGrade — unit-confirmation gate', () => {
   it('summarises confirmed for a foot CRS', async () => {
     await runWithCrs({ ...CRS_BASE, linearUnit: 'foot', linearUnitToMetres: 0.3048 });
     expect(vi.mocked(summarizeSampleGrade).mock.calls[0][1]).toBe(true);
+  });
+});
+
+describe('runFullCloudGrade — a source that states no point total', () => {
+  beforeEach(() => {
+    gradeFullCloud.mockReset();
+    vi.mocked(summarizeSampleGrade).mockClear();
+  });
+
+  const UNAVAILABLE = {
+    kind: 'unavailable',
+    headline: 'Full-cloud grade unavailable: this format states no point total',
+    note: 'The per-tile counts a grade would add up are decode-admission estimates.',
+  };
+
+  it('shows the reason in place of a coverage label, with no figures', async () => {
+    gradeFullCloud.mockResolvedValue(UNAVAILABLE);
+    const panel = makePanel();
+    await run(mkViewer(sourceA), panel);
+    expect(panel.setGradeResult).toHaveBeenCalledWith(UNAVAILABLE.headline, [], UNAVAILABLE.note);
+    // No density/extent lines are summarised: there is no grade behind them.
+    expect(vi.mocked(summarizeSampleGrade)).not.toHaveBeenCalled();
+  });
+
+  it('is a result, not an error (the refusal is deliberate, nothing failed)', async () => {
+    gradeFullCloud.mockResolvedValue(UNAVAILABLE);
+    const panel = makePanel();
+    await run(mkViewer(sourceA), panel);
+    expect(panel.setGradeError).not.toHaveBeenCalled();
+    expect(panel.setGradeCancelled).not.toHaveBeenCalled();
+  });
+
+  it('discards the refusal too when the cloud is swapped mid-grade', async () => {
+    const viewer = mkViewer(sourceA);
+    gradeFullCloud.mockImplementation(async () => {
+      viewer.streamingCloud = sourceB;
+      return UNAVAILABLE;
+    });
+    const panel = makePanel();
+    await run(viewer, panel);
+    expect(panel.setGradeResult).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
A 3D Tiles tileset states no point count, so every node record the
reader builds carries one assumed figure that governs decode admission.
`gradeFullCloud` projected those records into the sampling plan, which summed
them into `totalPoints` and `sampledPoints`, and `fullCloudGradeCoverage`
printed that sum as the streaming panel's coverage label, with a coverage
percent and a density back-scale built on it. An 812 tile tileset read as "2M of 406M points".
`TilesetStreamingSource` already returns null from `sourcePointCount` rather
than summing the same estimates.

`gradeFullCloud` now reads `sourcePointCount` and returns a refusal carrying no
number when it is null, before any node is read. The panel shows
the reason where the coverage label goes. COPC and EPT state a real total and
grade unchanged. Zero is a stated total and still grades.
