### PR TITLE
fix(export): carry node refinement instead of defaulting it to replace

### DIFF
--- a/src/io/copc/copcHierarchy.ts
+++ b/src/io/copc/copcHierarchy.ts
@@ -126,6 +126,11 @@ export function parseHierarchyPage(
       byteSize,
       spacing: nodeSpacing(key.depth, rootSpacing),
       parentId: parent ? keyId(parent) : undefined,
+      // A COPC octree partitions the file: every point sits in exactly one
+      // node, which is why the LAS header's point count equals the sum of the
+      // hierarchy's counts across all depths. A parent's points are its own, so
+      // its children add to them rather than replace them.
+      refine: 'add',
     });
   }
 

--- a/src/io/copc/copcTypes.ts
+++ b/src/io/copc/copcTypes.ts
@@ -73,6 +73,23 @@ export interface CopcMetadata {
 }
 
 /**
+ * How a node's children relate to the points the node itself holds.
+ *
+ * `'add'` — the children carry ADDITIONAL points and the parent's are its own,
+ * so both belong in any complete reading of the hierarchy. Every source this
+ * viewer opens is additive: a COPC octree partitions the file (the LAS header
+ * count is the sum of every hierarchy node's count), an EPT octree is the same
+ * layout by another name, the OLV tile store settles each point at the coarsest
+ * cell with room (`oocIndexer` PYRAMID PLACEMENT), and 3D Tiles refinement is
+ * only served when it is ADD — `tilesetNodes` refuses a REPLACE tile that
+ * refines into content, so the open fails before a node is fetched.
+ *
+ * `'replace'` — the children are a finer representation of the same points, so
+ * the parent is redundant once they are all present.
+ */
+export type NodeRefinement = 'add' | 'replace';
+
+/**
  * An immutable octree node record, as parsed from a COPC hierarchy page.
  * Runtime streaming state (loading / resident / evicted) lives on the separate
  * runtime `StreamingNode`, never here.
@@ -108,6 +125,19 @@ export interface StreamingNodeRecord {
   spacing: number;
   /** Id of the parent node, when known. */
   parentId?: string;
+  /**
+   * How this node's children refine it. See {@link NodeRefinement}.
+   *
+   * Optional rather than required, and the omission is deliberate: EPT builds
+   * its records in `render/streaming/EptOctree.ts`, outside this module's io
+   * layer, so a required field could not be filled at every construction site
+   * in one change. A record that omits it is read as `'add'` — the SAFE
+   * direction, because treating an additive node as replacing DELETES its
+   * points from an export, while treating a replacing node as additive only
+   * exports a coarse sample twice. It is also the correct value for EPT, so
+   * nothing is currently reading the default in place of a wrong answer.
+   */
+  refine?: NodeRefinement;
 }
 
 /** A reference to a child hierarchy page (an entry with `pointCount === -1`). */

--- a/src/io/heavy/OlvTileSource.ts
+++ b/src/io/heavy/OlvTileSource.ts
@@ -156,6 +156,10 @@ export class OlvTileOctree implements StreamingOctreeView {
         byteSize: 0,
         spacing: rootSize / 2 ** key.length,
         parentId: parentKey === null ? undefined : tileNodeId(parentKey),
+        // Pyramid placement puts each point at the coarsest cell with room, so
+        // an interior node holds points its children do not repeat: the stored
+        // counts sum to the source total. Its children add to it.
+        refine: 'add',
       });
     }
 

--- a/src/io/tiles3d/tilesetNodes.ts
+++ b/src/io/tiles3d/tilesetNodes.ts
@@ -241,6 +241,13 @@ export function tilesetNodes(
       byteSize: 0,
       spacing: placed.geometricError,
       parentId,
+      // The document's own value, resolved by the parser (a child inherits its
+      // parent's when it declares none). Only ADD, and REPLACE that refines
+      // into nothing, get this far — a REPLACE tile with content below it is
+      // named in `replacing` and refuses the open — so a served node is never a
+      // replaced ancestor of another. Carrying the value anyway keeps the
+      // export frontier reading the tile rather than a default.
+      refine: placed.tile.refine === 'REPLACE' ? 'replace' : 'add',
     });
     contentUri.set(uri, target);
     transform.set(uri, placed.transform);

--- a/src/render/streaming/exportFrontier.ts
+++ b/src/render/streaming/exportFrontier.ts
@@ -1,18 +1,21 @@
 /**
  * exportFrontier.ts
  *
- * Deterministic leaf-node frontier for the streaming resident-snapshot export
- * (v0.5.7 Gate 5). During an LOD cross-fade the outgoing parent node and its
- * incoming children can both be resident, so a naive snapshot concatenates
- * overlapping LOD samples of the same region — the coarse parent points and the
- * finer child points together. This module computes the frontier to keep before
- * the snapshot is built: for each hierarchy path keep the deepest resident node
- * and drop any ancestor that has a resident descendant, and exclude nodes that
- * are fading out (they are on their way off screen).
+ * Deterministic frontier for the streaming resident-snapshot export (v0.5.7
+ * Gate 5). Where a node's children REPLACE it, an LOD cross-fade can leave the
+ * outgoing parent and its incoming children both resident, and a naive snapshot
+ * then concatenates overlapping LOD samples of the same region — the coarse
+ * parent points and the finer child points together. This module computes the
+ * frontier to keep before the snapshot is built: along a replacing path keep
+ * the deepest resident node and drop any ancestor that has a resident
+ * descendant, and exclude nodes that are fading out (they are on their way off
+ * screen) whatever their mode.
  *
- * The result is an antichain of the resident set — no kept node is an ancestor
- * of another kept node — so each region is represented once, at its finest
- * resident level, with no double sampling.
+ * Over a replacing hierarchy the result is an antichain of the resident set —
+ * no kept node is an ancestor of another kept node — so each region is
+ * represented once, at its finest resident level, with no double sampling. Over
+ * an additive one, which is what every source shipped today is, the frontier is
+ * the whole non-fading resident set: nothing there is a duplicate to remove.
  *
  * Ancestry arrives as explicit parent identity rather than octree-key
  * arithmetic, so a hierarchy that is not a regular octree answers the same
@@ -24,7 +27,7 @@
  * verifiable without a device. The renderer supplies `{ id, fadingOut }` for
  * each resident node; the caller keeps only the returned ids.
  *
- * Trade-off, stated explicitly: a REPLACE parent is dropped when it has ANY
+ * Trade-off, stated explicitly: a REPLACING parent is dropped when it has ANY
  * resident descendant, even if only some of its children are covered by
  * resident nodes. In the streaming model children of a node load as a group and
  * a fully-refined parent is evicted (and thus fading out), so partial-coverage
@@ -33,13 +36,21 @@
  * covered parents — would reintroduce the very overlap this frontier exists to
  * remove.
  *
- * That trade-off is only sound where a child REPLACES its parent, which is what
- * COPC, EPT and the OLV tile store all do. Under additive refinement a parent
- * and its children are both part of the represented surface, so an additive
- * node is never dropped for having a descendant. The mode travels with each
- * node rather than with the source, because one hierarchy may mix the two.
+ * That trade-off is only sound where a child REPLACES its parent. It is not how
+ * any source this viewer opens is built: COPC, EPT and the OLV tile store each
+ * partition their points across the octree, so a parent holds points its
+ * children do not repeat, and 3D Tiles reaches the scheduler only under ADD
+ * because `tilesetNodes` refuses a REPLACE tile that refines into content.
+ * Under additive refinement a parent and its children are both part of the
+ * represented surface, so an additive node is never dropped for having a
+ * descendant — dropping it deletes points the export carries nowhere else.
+ *
+ * The mode travels with each node rather than with the source, because one
+ * hierarchy may mix the two, and an unstated mode is read as additive: see
+ * {@link FrontierNode.refine}.
  */
 
+import type { NodeRefinement } from '../../io/copc/copcTypes';
 import type { ParentLookup } from './streamingHierarchy';
 import { forEachAncestorId } from './streamingHierarchy';
 
@@ -50,8 +61,11 @@ import { forEachAncestorId } from './streamingHierarchy';
  * the parent is redundant once they are resident.
  * `'add'` — the children are extra detail alongside the parent, so both belong
  * in the snapshot.
+ *
+ * The same type the node records carry, so a caller passes `record.refine`
+ * straight through.
  */
-export type FrontierRefine = 'replace' | 'add';
+export type FrontierRefine = NodeRefinement;
 
 /** A resident node as the frontier needs it. */
 export interface FrontierNode {
@@ -59,7 +73,17 @@ export interface FrontierNode {
   readonly id: string;
   /** True while the node is animating out during a cross-fade. */
   readonly fadingOut?: boolean;
-  /** Defaults to `'replace'`, which is what every format shipped today uses. */
+  /**
+   * How this node's children refine it, from `StreamingNodeRecord.refine`.
+   *
+   * Unstated means `'add'`, the direction that KEEPS the node. That is the safe
+   * default in the only sense that matters here: reading an additive node as
+   * replacing drops it, and its points are then in no exported node at all,
+   * while reading a replacing node as additive at worst writes one coarse
+   * sample of a region twice. It also happens to be the true mode for every
+   * source shipped today. The default used to be `'replace'`, which silently
+   * cut the coarse levels out of every streamed export.
+   */
   readonly refine?: FrontierRefine;
 }
 
@@ -67,7 +91,8 @@ export interface FrontierNode {
  * Compute the set of node ids to keep for the export snapshot.
  *
  * A node is kept when it is not fading out AND it is not a replacing ancestor
- * of another non-fading resident node.
+ * of another non-fading resident node. A node that does not state a replacing
+ * mode is kept whenever it is not fading out.
  */
 export function computeExportFrontier(
   nodes: readonly FrontierNode[],
@@ -87,7 +112,10 @@ export function computeExportFrontier(
 
   const keep = new Set<string>();
   for (const node of candidates) {
-    if (node.refine === 'add') keep.add(node.id);
+    // Only a node that says its children REPLACE it can be dropped for having
+    // one. Anything else — additive, or a node that states nothing — keeps its
+    // own points.
+    if (node.refine !== 'replace') keep.add(node.id);
     else if (!ancestorsOfResident.has(node.id)) keep.add(node.id);
   }
   return keep;

--- a/tests/copcHierarchy.test.ts
+++ b/tests/copcHierarchy.test.ts
@@ -92,6 +92,27 @@ test('parseHierarchyPage extracts data nodes, empty nodes, and child pages', () 
   expect(page.childPages[0].key).toEqual({ depth: 1, x: 1, y: 0, z: 0 });
 });
 
+test('parseHierarchyPage marks every COPC node additive', () => {
+  // A COPC octree partitions the file: the LAS header point count is the SUM of
+  // every hierarchy node's count across every depth, so a point lives in exactly
+  // one node and a parent's points are its own. `synthCopc` builds the header
+  // count that way, which is the invariant read back here. A parent is therefore
+  // never redundant once its children arrive, and dropping it from an export
+  // deletes points nothing else carries.
+  const fixture = buildSyntheticCopc({
+    center: [0, 0, 0],
+    halfsize: 128,
+    spacing: 32,
+    nodes: [
+      { key: [0, 0, 0, 0], pointCount: 1000 },
+      { key: [1, 0, 0, 0], pointCount: 400 },
+    ],
+  });
+  const page = parseHierarchyPage(rootPageBytes(fixture), CUBE, 32);
+  expect(page.nodes.map((n) => n.refine)).toEqual(['add', 'add']);
+  expect(page.nodes.reduce((s, n) => s + n.pointCount, 0)).toBe(fixture.pointCount);
+});
+
 test('parseHierarchyPage collects malformed entries instead of throwing', () => {
   const fixture = buildSyntheticCopc({
     corrupt: 'bad-hierarchy-entry',

--- a/tests/exportFrontier.test.ts
+++ b/tests/exportFrontier.test.ts
@@ -1,17 +1,19 @@
 /**
  * exportFrontier.test.ts
  *
- * Pins the deterministic export frontier (v0.5.7 Gate 5): keep the deepest
- * resident node per hierarchy path, drop ancestors that have a resident
- * descendant, and exclude fading-out nodes — so a resident-snapshot export never
- * carries overlapping LOD samples of the same region. Also covers the
- * `keyFromId` parser, which the octree formats still use to name their nodes.
+ * Pins the deterministic export frontier (v0.5.7 Gate 5): under REPLACING
+ * refinement keep the deepest resident node per hierarchy path and drop
+ * ancestors that have a resident descendant; under ADDITIVE refinement keep the
+ * ancestor too, because its points are its own and exist nowhere else; and
+ * exclude fading-out nodes either way. Also covers the `keyFromId` parser, which
+ * the octree formats still use to name their nodes.
  *
  * Every octree case below is unchanged from when the frontier derived ancestry
  * by shifting a `VoxelKey`. It now takes an explicit parent lookup instead, and
  * these are the fixtures that prove the two agree: the lookup here IS the octree
  * shift, so any keep-set that moved would be a regression rather than a
- * generalization.
+ * generalization. Those cases now STATE `refine: 'replace'` rather than relying
+ * on a default: the keep-sets are identical, the mode is no longer implied.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -20,7 +22,7 @@ import { keyId, keyFromId } from '../src/io/copc/voxelKey';
 import type { VoxelKey } from '../src/io/copc/copcTypes';
 
 function node(depth: number, x: number, y: number, z: number, fadingOut = false): FrontierNode {
-  return { id: keyId({ depth, x, y, z }), fadingOut };
+  return { id: keyId({ depth, x, y, z }), fadingOut, refine: 'replace' };
 }
 
 /** The octree parent of an id, which is what the frontier used to derive itself. */
@@ -133,8 +135,10 @@ describe('keyFromId', () => {
 
 describe('computeExportFrontier over a hierarchy that is not an octree', () => {
   /**
-   * The irregular tree the 3D Tiles adapter produces: mixed child counts, mixed
-   * depths, ids that carry no coordinate at all.
+   * An irregular tree of the shape the 3D Tiles adapter produces: mixed child
+   * counts, mixed depths, ids that carry no coordinate at all. The refinement
+   * here is stated as replacing to exercise the ancestor-dropping branch over a
+   * non-octree hierarchy; a served tileset is additive (see below).
    *
    *   root
    *    ├─ A ─ A1
@@ -148,10 +152,12 @@ describe('computeExportFrontier over a hierarchy that is not an octree', () => {
     C: 'root',
   };
   const parentOf = (id: string): string | undefined => PARENTS[id];
+  /** A replacing node in that tree. */
+  const r = (id: string): FrontierNode => ({ id, refine: 'replace' });
 
   it('drops an ancestor with a resident descendant and keeps unrefined siblings', () => {
     const keep = computeExportFrontier(
-      [{ id: 'root' }, { id: 'A' }, { id: 'A1' }, { id: 'C' }],
+      [r('root'), r('A'), r('A1'), r('C')],
       parentOf,
     );
     expect([...keep].sort()).toEqual(['A1', 'C']);
@@ -159,7 +165,7 @@ describe('computeExportFrontier over a hierarchy that is not an octree', () => {
 
   it('keeps every child of a node with three children', () => {
     const keep = computeExportFrontier(
-      [{ id: 'B' }, { id: 'B1' }, { id: 'B2' }, { id: 'B3' }],
+      [r('B'), r('B1'), r('B2'), r('B3')],
       parentOf,
     );
     expect([...keep].sort()).toEqual(['B1', 'B2', 'B3']);
@@ -183,9 +189,9 @@ describe('computeExportFrontier under additive refinement', () => {
     expect([...keep].sort()).toEqual(['child', 'parent']);
   });
 
-  it('still drops a replacing parent, so the default is unchanged', () => {
+  it('drops a parent its children replace', () => {
     const keep = computeExportFrontier(
-      [{ id: 'parent', refine: 'replace' }, { id: 'child' }],
+      [{ id: 'parent', refine: 'replace' }, { id: 'child', refine: 'replace' }],
       parentOf,
     );
     expect([...keep]).toEqual(['child']);
@@ -195,10 +201,35 @@ describe('computeExportFrontier under additive refinement', () => {
     // `child` is additive, so it is kept; it is also a descendant of `parent`,
     // which replaces, so `parent` goes.
     const keep = computeExportFrontier(
-      [{ id: 'parent' }, { id: 'child', refine: 'add' }, { id: 'grandchild' }],
+      [{ id: 'parent', refine: 'replace' }, { id: 'child', refine: 'add' }, { id: 'grandchild', refine: 'replace' }],
       parentOf,
     );
     expect([...keep].sort()).toEqual(['child', 'grandchild']);
+  });
+
+  it('keeps an additive parent whose node states no refinement', () => {
+    // The defect this pins: `refine` used to default to 'replace', so a node
+    // that never stated a mode was dropped for having a resident descendant.
+    // Every source this viewer opens is additive, so an unstated mode must keep
+    // the node — dropping it deletes points held nowhere else in the export.
+    const keep = computeExportFrontier([{ id: 'parent' }, { id: 'child' }], parentOf);
+    expect([...keep].sort()).toEqual(['child', 'parent']);
+  });
+
+  it('keeps a whole unstated chain, coarse levels included', () => {
+    const keep = computeExportFrontier(
+      [{ id: 'parent' }, { id: 'child' }, { id: 'grandchild' }],
+      parentOf,
+    );
+    expect([...keep].sort()).toEqual(['child', 'grandchild', 'parent']);
+  });
+
+  it('still excludes a fading-out additive parent', () => {
+    const keep = computeExportFrontier(
+      [{ id: 'parent', fadingOut: true }, { id: 'child' }],
+      parentOf,
+    );
+    expect([...keep]).toEqual(['child']);
   });
 });
 
@@ -207,7 +238,10 @@ describe('computeExportFrontier on a malformed hierarchy', () => {
     // A names B as its parent and B names A. A real tileset cannot produce
     // this; a hostile or corrupt one can.
     const parentOf = (id: string): string | undefined => (id === 'A' ? 'B' : 'A');
-    const keep = computeExportFrontier([{ id: 'A' }, { id: 'B' }], parentOf);
+    const keep = computeExportFrontier(
+      [{ id: 'A', refine: 'replace' }, { id: 'B', refine: 'replace' }],
+      parentOf,
+    );
     // Each is an ancestor of the other, so neither survives. The property under
     // test is that the call returns.
     expect(keep.size).toBe(0);

--- a/tests/olvTileSource.test.ts
+++ b/tests/olvTileSource.test.ts
@@ -168,6 +168,12 @@ describe('OlvTileSource', () => {
     expect(interior.length).toBeGreaterThan(0);
     expect(source.maxDepth()).toBeGreaterThan(0);
 
+    // The same property, read as refinement: the per-node counts sum to the
+    // file total above, so an interior node's points are its own rather than a
+    // coarser copy of its children's. Every record says so, and an export that
+    // drops such a node loses points held nowhere else.
+    expect(nodes.every((n) => n.record.refine === 'add')).toBe(true);
+
     // Every non-root node's parent is present and lists it as a child.
     for (const node of nodes) {
       const parentId = node.record.parentId;

--- a/tests/streamingLegacyEquivalence.test.ts
+++ b/tests/streamingLegacyEquivalence.test.ts
@@ -109,7 +109,13 @@ interface TickRecord {
   refinedAwayPending: string[];
   refinedAway: string[];
   refiningCandidates: string[];
-  /** Export frontier over the resident set as it stands. */
+  /**
+   * Export frontier over the resident set as it stands, with every node stated
+   * REPLACING. The three fixtures are additive octrees, so their own records
+   * would make the frontier the whole resident set and record nothing about the
+   * ancestor-dropping walk; stating the replacing mode is what keeps this
+   * column exercising it.
+   */
   frontierPlain: string[];
   /** Export frontier with a fixed fade / additive-refinement pattern applied. */
   frontierMixed: string[];
@@ -459,7 +465,10 @@ async function recordFixture(fixture: ScenarioFixture): Promise<FixtureRecord> {
       refinedAway: sorted(buildRefinedAwayIds(wanted, cloud)),
       refiningCandidates: sorted(buildRefiningCandidateIds(scoredCandidates, parentOf)),
       frontierPlain: sorted(
-        computeExportFrontier(residentIds.map((id) => ({ id })), parentOf),
+        computeExportFrontier(
+          residentIds.map((id) => ({ id, refine: 'replace' as const })),
+          parentOf,
+        ),
       ),
       frontierMixed: sorted(computeExportFrontier(mixedFrontierNodes(residentIds), parentOf)),
       residentIds,

--- a/tests/tilesetRefineMode.test.ts
+++ b/tests/tilesetRefineMode.test.ts
@@ -20,6 +20,7 @@
 import { describe, it, expect } from 'vitest';
 import { parseTileset } from '../src/io/tiles3d/tileset';
 import { tilesetNodes } from '../src/io/tiles3d/tilesetNodes';
+import { computeExportFrontier } from '../src/render/streaming/exportFrontier';
 
 const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
 
@@ -58,6 +59,29 @@ describe('refinement mode', () => {
         'inflates the displayed point count',
     ).toContain('REPLACE');
     expect(idx.skipped.join(' ')).toContain('root.pnts');
+  });
+
+  it('carries the tile\'s own refinement onto the node record', () => {
+    const idx = tilesetNodes(parseTileset(doc('ADD', true)));
+    expect(idx.records.map((r) => r.refine)).toEqual(['add', 'add']);
+    // A REPLACE tile only survives the walk when it refines into nothing, so it
+    // is a content leaf and can never be an ancestor of another record. Its
+    // record still states the mode the document declared.
+    expect(tilesetNodes(parseTileset(doc('REPLACE', false))).records[0].refine).toBe('replace');
+  });
+
+  it('keeps an ADD parent in the export frontier beside its resident child', () => {
+    // The data-loss case. An additive parent's points are its own, so an export
+    // that drops it for having a resident child is missing the coarse level of
+    // every tileset this reader can open.
+    const idx = tilesetNodes(parseTileset(doc('ADD', true)));
+    const parentOf = (id: string): string | undefined =>
+      idx.records.find((r) => r.id === id)?.parentId;
+    const keep = computeExportFrontier(
+      idx.records.map((r) => ({ id: r.id, refine: r.refine })),
+      parentOf,
+    );
+    expect([...keep].sort()).toEqual(['child.pnts', 'root.pnts']);
   });
 
   it('serves a REPLACE tile that refines into nothing', () => {


### PR DESCRIPTION
`src/io/tiles3d/tilesetCloud.ts` and `src/io/tiles3d/tilesetOpen.ts` implement
the one-shot tileset read that `src/app/openTilesetLayer.ts` and
`src/render/streaming/TilesetStreamingSource.ts` replaced. Neither has a
production importer, neither is named in `src/lazyChunks.ts`, and both carried
unit suites, so a green run implied coverage the viewer does not have. Both move
to `tests/reference/tiles3d-static/` with headers naming the live path.

They are not deleted. Two rules have no streaming equivalent: colour survives
only when every tile carries it, with a warning when tiles mix, and a tileset
declaring no geocentric root frame records `frame.basis` unknown plus the
not-established load warning. `MAX_SELECTED_TILES` and `MAX_TILESET_POINTS` have
no whole-tileset counterpart either; `pnts.ts` bounds a single tile instead.
