### PR TITLE
chore(tiles3d): quarantine the superseded static tileset reader

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -180,22 +180,6 @@
       "review": "2027-02-28"
     },
     {
-      "path": "src/io/tiles3d/tilesetOpen.ts",
-      "status": "staged",
-      "why": "The one-shot open/select/fetch composition over the 3D Tiles pure modules. The parsers it composes ARE now reachable: src/app/openTilesetLayer.ts and src/render/streaming/TilesetStreamingSource.ts reach tileset.ts, pnts.ts, tilesetUrl.ts and tilesetTraversal.ts through src/lazyChunks.ts, so the v0.6.6 statement that the parsers are unreachable no longer holds. What is still unreachable is this whole-tileset read path beside the streaming one.",
-      "graduation": "An open route reads a tileset in full rather than streaming it, and calls openTileset/selectTileContents/fetchTileContent.",
-      "review": "2027-02-28",
-      "declaredIn": "docs/releases/RELEASE_NOTES_v0.6.6.md"
-    },
-    {
-      "path": "src/io/tiles3d/tilesetCloud.ts",
-      "status": "staged",
-      "why": "Merges a whole tileset into one PointCloud. Its only non-test importer is tilesetOpen.ts, which is itself unreachable; the streaming path builds its cloud through TilesetStreamingSource instead.",
-      "graduation": "tilesetOpen graduates and a caller asks for the merged one-shot cloud.",
-      "review": "2027-02-28",
-      "declaredIn": "docs/releases/RELEASE_NOTES_v0.6.6.md"
-    },
-    {
       "path": "src/process/ProductExecutorRegistry.ts",
       "status": "staged",
       "why": "Named in the v0.6.6 release notes: \"a product executor registry foundation that invokes a registered compute core through ProcessService.runIfAuthorized ... production product routes do not pass through it yet\".",

--- a/tests/reference/tiles3d-static/tilesetCloud.ts
+++ b/tests/reference/tiles3d-static/tilesetCloud.ts
@@ -1,4 +1,31 @@
 /**
+ * SUPERSEDED REFERENCE. Not the code the product runs.
+ *
+ * A `tileset.json` opens through `src/app/openTilesetLayer.ts` into
+ * `src/render/streaming/TilesetStreamingSource.ts`. Nothing in `src/` imports
+ * this file and nothing in `src/lazyChunks.ts` names it, so it is out of every
+ * build. It is kept here, out of `src/`, because two of its rules have no
+ * equivalent on the streaming path and are written down nowhere else:
+ *
+ *   - colour survives the load only when EVERY tile carries it, and a tileset
+ *     that mixes coloured and uncoloured tiles says so in a load warning. The
+ *     streaming path colours each tile on its own and falls back to the
+ *     elevation ramp per node, with no warning that the scene mixes two
+ *     colour semantics.
+ *   - a tileset that declares no geocentric root frame records
+ *     `frame.basis = 'unknown'` and carries FRAME_UNKNOWN_NOTE as a load
+ *     warning, so a Scan Report says which way is up was never established.
+ *     The streaming source records no frame provenance at all.
+ *
+ * `MAX_TILESET_POINTS` below is the whole-tileset ceiling this reader applied.
+ * The streaming path bounds a SINGLE tile instead, at
+ * `MAX_PNTS_TILE_POINTS` in `src/io/tiles3d/pnts.ts`, plus the scheduler's
+ * resident budget. There is no whole-tileset equivalent.
+ *
+ * Do not import this from `src/`. Restoring a rule means implementing it on
+ * the streaming path, not reviving this reader.
+ */
+/**
  * tilesetCloud.ts — a 3D Tiles tileset read once, in full, as one `PointCloud`.
  *
  * This is the caller `tilesetOpen.ts` was written for, and it is deliberately
@@ -6,10 +33,9 @@
  * the entry document, selects the finest representation the tree offers,
  * fetches those `.pnts` bodies, and merges them into a single cloud that then
  * lives in the viewer exactly like a decoded LAS: no scheduler, no eviction, no
- * camera feedback. The streaming alternative is not what this is a step toward
- * being — it needs a node store keyed by octree records and LAS-shaped decode
- * metadata that a PNTS content tree has none of, so it is a different reader
- * rather than this one with more code.
+ * camera feedback. The streaming reader that replaced it is a different reader
+ * rather than this one with more code: it needs a node store keyed by octree
+ * records and LAS-shaped decode metadata that a PNTS content tree has none of.
  *
  * WHAT MAKES IT SAFE TO READ EVERYTHING AT ONCE. Nothing here is sized by what
  * the document declares. The transport caps each body, `parseTileset` caps the
@@ -45,13 +71,13 @@
  * rather than a gap it hides.
  */
 
-import { PointCloud } from '../../model/PointCloud';
-import { sanitizeAndRecenter, withLoadWarning } from '../sanitizeCloud';
-import { FRAME_UNKNOWN_NOTE } from '../../geo/frame/frameProvenance';
-import { finiteExtentCentre, resolveTilesetFrame } from './tilesetFrame';
+import { PointCloud } from '../../../src/model/PointCloud';
+import { sanitizeAndRecenter, withLoadWarning } from '../../../src/io/sanitizeCloud';
+import { FRAME_UNKNOWN_NOTE } from '../../../src/geo/frame/frameProvenance';
+import { finiteExtentCentre, resolveTilesetFrame } from '../../../src/io/tiles3d/tilesetFrame';
 import { openTileset, selectTileContents, fetchTileContent } from './tilesetOpen';
-import type { TilesetTransport } from './tilesetTransport';
-import type { ViewCamera } from './tilesetTraversal';
+import type { TilesetTransport } from '../../../src/io/tiles3d/tilesetTransport';
+import type { ViewCamera } from '../../../src/io/tiles3d/tilesetTraversal';
 
 /**
  * Ceiling on the merged point total, checked as the tiles decode.

--- a/tests/reference/tiles3d-static/tilesetOpen.ts
+++ b/tests/reference/tiles3d-static/tilesetOpen.ts
@@ -1,4 +1,20 @@
 /**
+ * SUPERSEDED REFERENCE. Not the code the product runs.
+ *
+ * The fetch/decode half of the one-shot tileset read in `tilesetCloud.ts`
+ * beside it. A `tileset.json` now opens through `src/app/openTilesetLayer.ts`
+ * into `src/render/streaming/TilesetStreamingSource.ts`, which reaches the same
+ * parser, transport and URL guards directly and builds its node index with
+ * `src/io/tiles3d/tilesetNodes.ts`. Nothing in `src/` imports this file.
+ *
+ * `MAX_SELECTED_TILES` below has no streaming equivalent: it capped the fetch
+ * list ONE camera position produced, and the streaming path has no such list.
+ * What bounds the streaming reader is `DEFAULT_TILESET_MAX_TILES` at parse plus
+ * the scheduler's point-pressure budget.
+ *
+ * Do not import this from `src/`.
+ */
+/**
  * tilesetOpen.ts — opening a remote 3D Tiles tileset, selecting what a view
  * needs from it, and decoding the tiles that selection names.
  *
@@ -24,16 +40,9 @@
  * failure mode that is hardest to notice and worst to ship.
  *
  * WHAT IS NOT HERE. Nothing mounts. There is no `StreamingSource` implementation
- * in this module and no viewer wiring, because the streaming contract is built
- * around a node store keyed by octree records and LAS-shaped decode metadata,
- * which a PNTS content tree does not have. This module is the fetch/decode half
- * that such a source would sit on; the source itself is not written.
- *
- * Nothing static imports this file, so none of it reaches the initial bundle.
- * There is deliberately no `loadTiles3d` seam in `lazyChunks.ts` yet either: the
- * build's chunk-emission guard requires every module named by a dynamic import
- * literal there to actually emit a chunk, and a seam with no caller is tree-
- * shaken away and fails that guard. The seam lands with the mount that uses it.
+ * in this module and no viewer wiring. That source was later written directly
+ * against the parser and the node index instead, which is what left this file
+ * with no caller.
  *
  * EXTERNAL TILESETS. A `content.uri` naming another `tileset.json` is reported,
  * not followed. Following one is a second recursion over remote input with its
@@ -41,17 +50,17 @@
  * cap above would be escaped one document at a time.
  */
 
-import { parseTileset, type Tileset, type TilesetParseLimits } from './tileset';
-import { selectTiles, type SelectedTile, type ViewCamera } from './tilesetTraversal';
-import { transformPoint } from './tileTransform';
-import { parsePnts } from './pnts';
+import { parseTileset, type Tileset, type TilesetParseLimits } from '../../../src/io/tiles3d/tileset';
+import { selectTiles, type SelectedTile, type ViewCamera } from '../../../src/io/tiles3d/tilesetTraversal';
+import { transformPoint } from '../../../src/io/tiles3d/tileTransform';
+import { parsePnts } from '../../../src/io/tiles3d/pnts';
 import {
   resolveTilesetContentUrl,
   tilesetBaseUrl,
   tilesetUrlSearch,
   validateRemoteTilesetUrl,
-} from './tilesetUrl';
-import type { TilesetTransport } from './tilesetTransport';
+} from '../../../src/io/tiles3d/tilesetUrl';
+import type { TilesetTransport } from '../../../src/io/tiles3d/tilesetTransport';
 
 /**
  * Ceiling on how many tiles ONE view may select.

--- a/tests/tiles3dTilesetCloud.test.ts
+++ b/tests/tiles3dTilesetCloud.test.ts
@@ -13,10 +13,19 @@
  * coordinates are three different numbers, because a fixture where they
  * coincide proves nothing about the composition. The third is that every
  * refusal stays a refusal rather than becoming a partial cloud.
+ *
+ * WHAT THIS COVERS. The superseded one-shot reader under
+ * `tests/reference/tiles3d-static/`, not the code the product runs. A
+ * `tileset.json` opens through `src/app/openTilesetLayer.ts` into
+ * `src/render/streaming/TilesetStreamingSource.ts`; that path is covered by
+ * `tilesetStreamingOpen.test.ts`, `tilesetStreamingSource.test.ts`,
+ * `tilesetNodes.test.ts`, `tilesetCeilings.test.ts` and `pntsDecode.test.ts`.
+ * A pass here says the reference still behaves as its header describes. It says
+ * nothing about what the viewer does.
  */
 
 import { describe, expect, test } from 'vitest';
-import { loadTilesetCloud } from '../src/io/tiles3d/tilesetCloud';
+import { loadTilesetCloud } from './reference/tiles3d-static/tilesetCloud';
 import type { TilesetTransport } from '../src/io/tiles3d/tilesetTransport';
 
 const ENTRY = 'https://tiles.example.org/scan/a/tileset.json';

--- a/tests/tiles3dTilesetOpen.test.ts
+++ b/tests/tiles3dTilesetOpen.test.ts
@@ -12,6 +12,15 @@
  * gets a test that the cap REFUSES rather than truncates, and the caps are the
  * mutation targets: removing the depth cap must fail a test here, and so must
  * transposing the column-major transform composition.
+ *
+ * WHAT THIS COVERS. The superseded one-shot reader under
+ * `tests/reference/tiles3d-static/`, not the code the product runs. A
+ * `tileset.json` opens through `src/app/openTilesetLayer.ts` into
+ * `src/render/streaming/TilesetStreamingSource.ts`; that path is covered by
+ * `tilesetStreamingOpen.test.ts`, `tilesetStreamingSource.test.ts`,
+ * `tilesetNodes.test.ts`, `tilesetCeilings.test.ts` and `pntsDecode.test.ts`.
+ * A pass here says the reference still behaves as its header describes. It says
+ * nothing about what the viewer does.
  */
 
 import { describe, expect, test } from 'vitest';
@@ -20,7 +29,7 @@ import {
   selectTileContents,
   fetchTileContent,
   MAX_SELECTED_TILES,
-} from '../src/io/tiles3d/tilesetOpen';
+} from './reference/tiles3d-static/tilesetOpen';
 import { DEFAULT_TILESET_MAX_DEPTH } from '../src/io/tiles3d/tileset';
 import type { TilesetTransport } from '../src/io/tiles3d/tilesetTransport';
 import type { ViewCamera } from '../src/io/tiles3d/tilesetTraversal';

--- a/tests/tilesetSpatialFrame.test.ts
+++ b/tests/tilesetSpatialFrame.test.ts
@@ -11,10 +11,18 @@
  * axes are 64.3° apart. A fixture on the equator at longitude zero has them
  * coincide, and every assertion below would pass against a reader that only
  * subtracts an origin.
+ *
+ * MIXED SUBJECT. `declaredTilesetFrame`, `resolveTilesetFrame`,
+ * `finiteExtentCentre` and `createLocalEnuFrame` are live modules. The four
+ * cases that call `loadTilesetCloud` read the superseded one-shot reader under
+ * `tests/reference/tiles3d-static/`, because the frame-provenance record they
+ * assert (`frame.basis`, `verticalReference`, `anchor`, the not-established
+ * load warning) exists only there. `TilesetStreamingSource` applies a root ENU
+ * rotation but records no provenance, so nothing on the live path pins it.
  */
 
 import { describe, expect, test } from 'vitest';
-import { loadTilesetCloud } from '../src/io/tiles3d/tilesetCloud';
+import { loadTilesetCloud } from './reference/tiles3d-static/tilesetCloud';
 import {
   declaredTilesetFrame,
   finiteExtentCentre,


### PR DESCRIPTION
`src/io/tiles3d/tilesetCloud.ts` and `src/io/tiles3d/tilesetOpen.ts` implement
the one-shot tileset read that `src/app/openTilesetLayer.ts` and
`src/render/streaming/TilesetStreamingSource.ts` replaced. Neither has a
production importer, neither is named in `src/lazyChunks.ts`, and both carried
unit suites, so a green run implied coverage the viewer does not have. Both move
to `tests/reference/tiles3d-static/` with headers naming the live path.

They are not deleted. Two rules have no streaming equivalent: colour survives
only when every tile carries it, with a warning when tiles mix, and a tileset
declaring no geocentric root frame records `frame.basis` unknown plus the
not-established load warning. `MAX_SELECTED_TILES` and `MAX_TILESET_POINTS` have
no whole-tileset counterpart either; `pnts.ts` bounds a single tile instead.
