### PR TITLE
fix(streaming): bound the scheduler's first-node admission

### DIFF
--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -29,7 +29,7 @@ import {
   nodeScore,
   depthCapForVelocity,
 } from './streamingScore';
-import { selectWithinBudget } from './streamingBudget';
+import { selectWithinBudget, DECODED_BYTES_PER_POINT } from './streamingBudget';
 import type { StreamingBudgets, ScoredCandidate } from './streamingBudget';
 import { CompressedChunkCache } from './StreamingCache';
 import {
@@ -219,6 +219,43 @@ const FORCED_RESCORE_INTERVAL_TICKS = 60;
 const MAX_DECODE_RETRIES = 4;
 const RETRY_BACKOFF_BASE_MS = 500;
 const RETRY_BACKOFF_MAX_MS = 30_000;
+
+/**
+ * Decoded bytes a single node may claim through the empty-viewer bypass in
+ * `_dispatch`.
+ *
+ * That bypass exists because the pressure gate has nothing to push back
+ * against while the resident set is empty: deferring the only node that could
+ * ever become resident is a deadlock the eviction pass cannot break, and the
+ * viewer stays blank. It has to stay. What it does not have to be is
+ * unbounded, and the node it waves through is the largest single allocation a
+ * session can make.
+ *
+ * Half a gigabyte is the line. It is a judgement, and the trade it makes is
+ * worth naming: above the ceiling the node is refused, and if every visible
+ * node is above it the viewer really does end up empty. That is the intended
+ * outcome, because a node this size is not renderable on the devices this
+ * viewer targets either way, and an empty viewer carrying a named error is a
+ * better failure than an allocation that takes the tab with it.
+ *
+ * The number is set so no legitimate node can reach it. The largest resident
+ * budget configured anywhere is desktop `high` at 8 M points, whose pressure
+ * cap is 12 M for the WHOLE resident set; this admits roughly 21.5 M in one
+ * node. A 3D Tiles tile cannot reach it at all — `MAX_PNTS_TILE_POINTS`
+ * refuses at 8 M in the parser. What it does cover is the COPC and EPT path,
+ * where `record.pointCount` is the hierarchy's real figure and the only
+ * downstream ceiling is the decompressor's 50 M `MAX_NODE_POINTS`: between
+ * those two numbers sits a node that decodes and cannot be held.
+ *
+ * Deliberately absolute rather than a multiple of the point budget. A
+ * budget-relative ceiling would refuse on a mobile `low` preset (600 k budget)
+ * a node that a desktop renders, which turns a memory guard into a
+ * device-dependent blank screen.
+ */
+const FIRST_ADMISSION_MAX_DECODED_BYTES = 512 * 1024 * 1024;
+const FIRST_ADMISSION_MAX_POINTS = Math.floor(
+  FIRST_ADMISSION_MAX_DECODED_BYTES / DECODED_BYTES_PER_POINT,
+);
 
 /** Per-scheduler tunables — defaulted, injected for unit tests. */
 export interface SchedulerOptions {
@@ -465,6 +502,20 @@ export class StreamingScheduler {
   private readonly _decodeFailures = new Map<string, number>();
   /** Node id → wall-clock time before which a failed node must not retry. */
   private readonly _retryReadyAt = new Map<string, number>();
+  /**
+   * Nodes refused by the first-admission ceiling (see
+   * {@link FIRST_ADMISSION_MAX_POINTS}). Held separately from
+   * `_decodeFailures`, which counts transient decode errors that a retry can
+   * clear: this refusal reads a declared count off an immutable hierarchy
+   * record, so it is settled for the session and re-deciding it is waste.
+   *
+   * Kept, rather than derived from the `error` state each tick, because the
+   * scoring pass reads it: a node nothing can admit must not go on holding a
+   * slice of the point budget, or the selector spends the whole budget on it
+   * and the admissible nodes underneath are never wanted. That is the
+   * difference between refusing one node and blanking the viewer.
+   */
+  private readonly _refusedOversized = new Set<string>();
 
   /** Hysteresis state — node id → wall-clock deadline (ms) past which it may evict. */
   private readonly _deferredEvictAt = new Map<string, number>();
@@ -952,6 +1003,10 @@ export class StreamingScheduler {
       // Walk the store's zero-allocation node iterator rather than `nodes()`,
       // which materialises a 28 k-element array on every rescore.
       for (const node of store.iterate()) {
+        // A node the admission ceiling refused can never become resident, so
+        // it must not be scored: a candidate in the list takes budget in
+        // `selectWithinBudget`, and the coarsest node takes it first.
+        if (this._refusedOversized.has(node.record.id)) continue;
         const box = this._localBoundsFor(node);
         let score = 0;
         if (boxInFrustum(box, planes)) {
@@ -1295,6 +1350,10 @@ export class StreamingScheduler {
     this._deferredEvictAt.clear();
     this._decodeFailures.clear();
     this._retryReadyAt.clear();
+    // Cleared with the rest of the per-session failure state. The ids are
+    // octree keys, which a re-seeded store reuses for different records, so a
+    // refusal carried across a stop could exclude a node that never earned it.
+    this._refusedOversized.clear();
     // Free the compressed-chunk cache eagerly (tens of MB of ArrayBuffers)
     // instead of waiting for the stopped scheduler to be GC'd — so detaching or
     // replacing a streaming scan doesn't leave stale chunks resident exactly
@@ -1412,13 +1471,45 @@ export class StreamingScheduler {
       // tick's eviction pass evicts deferred nodes that the pressure pass
       // and lapsed pass would normally drop. Bypass when nothing is resident
       // yet — only then can a single oversized node truly block forward
-      // progress.
+      // progress. The bypass is bounded by the branch below rather than
+      // removed: nothing can evict to make room for the first node, so the
+      // check it escapes has to be an absolute one, not a relative one.
       const projected =
         store.residentPointCount + store.decodedPendingPointCount + inFlightEstimate + node.record.pointCount;
       if (projected > pressureCap && store.residentPointCount > 0) {
         // Put it back at the head of the queue — same state, same priority.
         this._queue.unshift(node);
         break;
+      }
+      if (
+        store.residentPointCount === 0 &&
+        node.record.pointCount > FIRST_ADMISSION_MAX_POINTS
+      ) {
+        // Bounded bypass. The branch above waves this node through because
+        // nothing is resident; that is not a reason to admit any size. A node
+        // past `FIRST_ADMISSION_MAX_POINTS` is refused by name here, before the
+        // range read and before the decoder sizes anything from it.
+        //
+        // `continue`, not `break`: skipping one node leaves the rest of this
+        // tick's queue to dispatch, so a coarse root nobody can hold does not
+        // take its admissible children down with it.
+        //
+        // The refusal is recorded and the cached selection dropped, so the
+        // next tick rescores without this node and hands its share of the
+        // budget to the nodes below it. Without that the selector keeps
+        // spending the whole budget on a node dispatch will never take, the
+        // children stay unwanted, and the screen stays empty — the outcome
+        // the bypass exists to prevent, arrived at from the other side.
+        this._refusedOversized.add(node.record.id);
+        this._lastWanted = null;
+        this._lastScored = null;
+        store.setError(
+          node,
+          `streaming: first node ${node.record.id} declares ${node.record.pointCount} points, ` +
+            `past the ${FIRST_ADMISSION_MAX_POINTS} point ceiling for a decode admitted ` +
+            `before anything is resident.`,
+        );
+        continue;
       }
       inFlightEstimate += node.record.pointCount;
       this._startDecode(node);

--- a/tests/streamingFirstAdmission.test.ts
+++ b/tests/streamingFirstAdmission.test.ts
@@ -1,0 +1,227 @@
+/**
+ * streamingFirstAdmission.test.ts
+ *
+ * The scheduler's pre-decode pressure gate carries an empty-viewer bypass: a
+ * node is admitted regardless of projected residency while nothing is resident
+ * yet, because refusing the only node that could ever become resident leaves
+ * the viewer permanently blank. The bypass is necessary; being unbounded is
+ * not. These tests pin both halves:
+ *
+ *   - a node above the absolute first-admission ceiling is refused by name,
+ *     before any read or decode is dispatched;
+ *   - a node the pressure cap alone would refuse still loads, so the bypass
+ *     keeps doing the job it exists for;
+ *   - a refusal skips one node rather than stalling the queue, so an
+ *     admissible sibling in the same tick still reaches the screen.
+ */
+
+import { StreamingScheduler } from '../src/render/streaming/StreamingScheduler';
+import {
+  DECODED_BYTES_PER_POINT,
+  streamingBudgets,
+} from '../src/render/streaming/streamingBudget';
+import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import { buildSyntheticCopc, type SynthNode } from './fixtures/copc/synthCopc';
+import type {
+  ChunkDecoder,
+  ChunkDecodeMetadata,
+  DecodedChunk,
+} from '../src/io/copc/copcChunkDecode';
+
+/** A wide view: clip = world/256, so the frustum spans [-256,256]³. */
+const WIDE = [
+  1 / 256, 0, 0, 0,
+  0, 1 / 256, 0, 0,
+  0, 0, 1 / 256, 0,
+  0, 0, 0, 1,
+];
+
+/**
+ * A decoder that records what it was asked to decode and returns an empty
+ * chunk. Deliberately does NOT size its arrays by `meta.pointCount`: these
+ * fixtures declare tens of millions of points, and the point of the test is
+ * that the scheduler refuses before anything that large is allocated.
+ */
+function recordingDecoder(): { decoder: ChunkDecoder; seen: number[] } {
+  const seen: number[] = [];
+  const decoder: ChunkDecoder = {
+    decode(_chunk: ArrayBuffer, meta: ChunkDecodeMetadata): Promise<DecodedChunk> {
+      seen.push(meta.pointCount);
+      return Promise.resolve({
+        pointCount: 0,
+        positions: new Float32Array(0),
+        intensity: new Uint16Array(0),
+        classification: new Uint8Array(0),
+        returnNumber: new Uint8Array(0),
+        returnCount: new Uint8Array(0),
+        gpsTime: new Float64Array(0),
+      });
+    },
+  };
+  return { decoder, seen };
+}
+
+/** A decoder that reports every point the node declared, without allocating. */
+function countingDecoder(): { decoder: ChunkDecoder; seen: number[] } {
+  const seen: number[] = [];
+  const decoder: ChunkDecoder = {
+    decode(_chunk: ArrayBuffer, meta: ChunkDecodeMetadata): Promise<DecodedChunk> {
+      seen.push(meta.pointCount);
+      return Promise.resolve({
+        pointCount: meta.pointCount,
+        positions: new Float32Array(0),
+        intensity: new Uint16Array(0),
+        classification: new Uint8Array(0),
+        returnNumber: new Uint8Array(0),
+        returnCount: new Uint8Array(0),
+        gpsTime: new Float64Array(0),
+      });
+    },
+  };
+  return { decoder, seen };
+}
+
+async function openCloud(nodes: SynthNode[]): Promise<StreamingPointCloud> {
+  const fixture = buildSyntheticCopc({ center: [0, 0, 0], halfsize: 128, nodes });
+  return StreamingPointCloud.open(
+    new ArrayBufferRangeSource(fixture.buffer),
+    'first-admission.copc.laz',
+  );
+}
+
+/** Settle the scheduler's queued and in-flight work. */
+async function drain(scheduler: StreamingScheduler): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    const s = scheduler.stats();
+    if (s.queued === 0 && s.loading === 0) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+test('a first node above the absolute ceiling is refused before any decode', async () => {
+  // 40 M points sits between the two downstream ceilings: under the COPC
+  // decompressor's MAX_NODE_POINTS (50 M), so nothing further down refuses it,
+  // and far past anything the resident budget could hold.
+  const cloud = await openCloud([{ key: [0, 0, 0, 0], pointCount: 40_000_000 }]);
+  const { decoder, seen } = recordingDecoder();
+  const scheduler = new StreamingScheduler(
+    cloud,
+    decoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    { pointBudget: 2_500_000, maxConcurrentDecodes: 4, chunkCacheBytes: 1 << 20 },
+  );
+
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  // Nothing was read or decoded.
+  expect(seen).toEqual([]);
+  expect(cloud.counts().resident).toBe(0);
+
+  const node = cloud.octree.store.get('0-0-0-0');
+  expect(node?.state).toBe('error');
+  expect(node?.error).toMatch(/first node/i);
+  expect(node?.error).toContain('40000000');
+});
+
+test('the refusal is terminal — a later tick does not re-dispatch it', async () => {
+  const cloud = await openCloud([{ key: [0, 0, 0, 0], pointCount: 40_000_000 }]);
+  const { decoder, seen } = recordingDecoder();
+  let clock = 0;
+  const scheduler = new StreamingScheduler(
+    cloud,
+    decoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    { pointBudget: 2_500_000, maxConcurrentDecodes: 4, chunkCacheBytes: 1 << 20 },
+    { now: () => clock },
+  );
+
+  for (let i = 0; i < 5; i++) {
+    clock += 60_000; // past any retry backoff window
+    scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+    await drain(scheduler);
+  }
+
+  expect(seen).toEqual([]);
+  expect(cloud.octree.store.get('0-0-0-0')?.state).toBe('error');
+});
+
+test('the empty-viewer bypass still admits a first node the pressure cap alone would refuse', async () => {
+  // This is the test that matters more than the guard: a 1000-point node
+  // against a 100-point budget projects far past the 150-point pressure cap,
+  // and must still load or the viewer is permanently blank.
+  const cloud = await openCloud([{ key: [0, 0, 0, 0], pointCount: 1_000 }]);
+  const { decoder, seen } = countingDecoder();
+  const scheduler = new StreamingScheduler(
+    cloud,
+    decoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    { pointBudget: 100, maxConcurrentDecodes: 4, chunkCacheBytes: 1 << 20 },
+  );
+
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  expect(seen).toEqual([1_000]);
+  expect(cloud.counts().resident).toBe(1);
+  expect(cloud.octree.store.get('0-0-0-0')?.state).toBe('resident');
+});
+
+test('a node just under the ceiling is still admitted through the bypass', async () => {
+  // 512 MiB of decoded arrays at DECODED_BYTES_PER_POINT. The boundary is
+  // pinned from the test side so a future change to either the byte budget or
+  // the per-point figure has to move this number deliberately.
+  const ceiling = Math.floor((512 * 1024 * 1024) / DECODED_BYTES_PER_POINT);
+  expect(ceiling).toBe(21_474_836);
+  // Well past both the point budget and its 1.5x pressure cap, and past the
+  // largest budget this viewer configures anywhere (desktop `high`, 8 M).
+  expect(ceiling).toBeGreaterThan(streamingBudgets('high', false).pointBudget * 1.5);
+
+  const cloud = await openCloud([{ key: [0, 0, 0, 0], pointCount: ceiling }]);
+  const { decoder, seen } = countingDecoder();
+  const scheduler = new StreamingScheduler(
+    cloud,
+    decoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    { pointBudget: 2_500_000, maxConcurrentDecodes: 4, chunkCacheBytes: 1 << 20 },
+  );
+
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  expect(seen).toEqual([ceiling]);
+  expect(cloud.octree.store.get('0-0-0-0')?.state).toBe('resident');
+});
+
+test('a refused node releases its budget, so the nodes under it still load', async () => {
+  // The pathological node is the coarsest, so it scores highest and takes the
+  // whole point budget in `selectWithinBudget` — which is why refusing it is
+  // not enough on its own. Once refused it has to leave the candidate set, or
+  // the two admissible children are never wanted and the viewer is blank for a
+  // file that is mostly fine.
+  const cloud = await openCloud([
+    { key: [0, 0, 0, 0], pointCount: 40_000_000 },
+    { key: [1, 0, 0, 0], pointCount: 800 },
+    { key: [1, 1, 0, 0], pointCount: 600 },
+  ]);
+  const { decoder, seen } = countingDecoder();
+  const scheduler = new StreamingScheduler(
+    cloud,
+    decoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    { pointBudget: 2_500_000, maxConcurrentDecodes: 4, chunkCacheBytes: 1 << 20 },
+  );
+
+  // Two ticks: the refusal happens in the first tick's dispatch, and the
+  // rescore that drops it from the candidate set runs at the head of the next.
+  // The viewer drives `update` every animation frame, so this is one frame.
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  expect(seen.sort((a, b) => a - b)).toEqual([600, 800]);
+  expect(cloud.counts().resident).toBe(2);
+  expect(cloud.octree.store.get('0-0-0-0')?.state).toBe('error');
+});


### PR DESCRIPTION
`StreamingScheduler._dispatch` runs the only pre-decode admission check. It
skips that check while `residentPointCount` is 0, because deferring the one
node that could become resident is a deadlock no eviction pass can break and
the viewer stays blank. The bypass is necessary and stays.

It now runs against an absolute ceiling: 512 MiB of decoded points, or
21,474,836 at `DECODED_BYTES_PER_POINT`. A node past it gets a named error
before the range read. The ceiling clears every
configured point budget and the 8 M PNTS parser limit, so it covers the COPC
and EPT path, where the only other bound is the decompressor's 50 M
`MAX_NODE_POINTS`.

A refused node also drops out of the scoring candidate set, so the budget it
held goes to the nodes below it and they still load.
