### PR TITLE
fix(provenance): derive the streaming export snapshot's source format

### DIFF
--- a/src/io/session.ts
+++ b/src/io/session.ts
@@ -76,8 +76,8 @@ import type { WorkOwnership } from '../model/workOwnership';
  * transform into the project frame, CRS, up axis), and per-item ownership on
  * measurements and annotations. Through v7 a session described one scan with
  * one origin, so saved work had no way to say which layer it belonged to,
- * which is why multi-layer mounting is disabled. v8 is the persistence half of
- * removing that block; the mount flag itself stays off (see `LayerService.ts`).
+ * which is what blocked multi-layer mounting. v8 is the persistence half of
+ * removing that block, and the mount is now on (see `LayerService.ts`).
  *
  * The per-annotation inspection workflow (`annotation.issue` — severity,
  * open/resolved status, observation date) is additive WITHIN v8 and carries no

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -288,7 +288,7 @@ import { writeFloatColorsInto } from './colorEncode';
 // synchronous `setStreamingQuality` path.
 import type { StreamingScheduler } from './streaming/StreamingScheduler';
 import { buildResidentSnapshot } from './streaming/residentSnapshot';
-import type { StreamingSource } from './streaming/StreamingSource';
+import type { StreamingSource, StreamingSourceKind } from './streaming/StreamingSource';
 import { streamingBudgets, estimateGpuBytes } from './streaming/streamingBudget';
 import type { StreamingQuality } from './streaming/streamingBudget';
 import type { StreamingBenchmark } from './streaming/streamingBenchmark';
@@ -2057,7 +2057,6 @@ export class Viewer {
     this.requestFrame();
   }
 
-
   /**
    * Record what a layer has proven about the project frame. Combined
    * estimators — terrain, profile, cut/fill volume, lasso — read this and
@@ -2114,11 +2113,9 @@ export class Viewer {
    * `staticCount` static clouds the walk has already accepted.
    */
   private _streamingMayCombine(staticCount: number): boolean {
-    // Streaming sources are never mounted into the project frame in this
-    // alpha — `MULTI_LAYER_MOUNT_ENABLED` is off and no mount path exists for
-    // resident nodes at all — so this is `false` today and the predicate
-    // refuses. It is passed rather than hardcoded so that turning mounting on
-    // does not silently re-open the gap.
+    // Mounting is ON (`MULTI_LAYER_MOUNT_ENABLED`), but it reaches static layers
+    // only: `setLayerPlacement` places `_clouds` entries and a stream is not
+    // one, so no resident node is ever in the project frame and this is `false`.
     return streamingMayCombine(staticCount, this._streamingCompatibility(), false);
   }
 
@@ -3607,14 +3604,6 @@ export class Viewer {
   }
 
   /**
-   * A PointCloud built from the streaming cloud's resident (decoded-so-far)
-   * nodes — the honest display-resolution snapshot the Export / Convert panel
-   * writes when a streaming scan is open. Returns null when no streaming cloud
-   * is attached or nothing is resident yet. Full-resolution re-read isn't
-   * available for a range-read streaming source, so this snapshot is exactly
-   * what the viewer holds; positions carry the render origin as their shift.
-   */
-  /**
    * The resident nodes an export would actually write: the deterministic leaf
    * frontier (Gate 5) — the deepest resident node per octree path, with
    * ancestors that have a resident descendant and anything mid-fade dropped, so
@@ -3657,16 +3646,27 @@ export class Viewer {
     return total;
   }
 
+  /**
+   * A PointCloud built from the streaming cloud's resident (decoded-so-far)
+   * nodes — what the Export / Convert panel writes, a range-read source having
+   * no full-resolution re-read. Positions carry the render origin as their
+   * shift. Null when nothing is streaming or resident, or the kind names no
+   * format: `laz` was stamped on every snapshot, so a 3D Tiles deliverable
+   * claimed bytes it never read. COPC is a LAZ file, EPT decodes LAS records, a
+   * point tile is `pnts`, and an OLV tile store's manifest names none.
+   */
   snapshotResidentCloud(): PointCloud | null {
     const s = this._streaming;
     if (!s) return null;
+    const sourceFormat = ({ copc: 'laz', ept: 'laz', '3dtiles': 'pnts', tiles: null } satisfies Record<StreamingSourceKind, SourceFormat | null>)[s.cloud.kind];
+    if (sourceFormat === null) return null;
     const chunks = this._exportFrontierChunks();
     if (chunks.length === 0) return null;
     const crs = s.cloud.crs();
     return buildResidentSnapshot(chunks, {
       origin: s.cloud.renderOrigin,
       name: s.cloud.name,
-      sourceFormat: 'laz', // COPC and EPT both decode LAZ point records
+      sourceFormat,
       sourcePointCount: s.cloud.sourcePointCount ?? undefined,
       ...(crs ? { metadata: { crs } } : {}),
     });

--- a/src/ui/CatalogPanel.ts
+++ b/src/ui/CatalogPanel.ts
@@ -59,6 +59,22 @@ import type { Sample } from './Stage';
 import { loadPlanetaryComputerCatalog } from '../lazyChunks';
 
 /**
+ * The default hint under the dropdown, shown until a location is picked.
+ *
+ * It used to read "Verified-working public USGS EPT datasets — each URL was
+ * probed at build time", and each of those three claims was false against the
+ * catalog: two entries are European (swisstopo, GURS), two are COPC rather than
+ * EPT, and no script here re-runs the reachability check, so `verifiedAt` is a
+ * date somebody recorded and nothing more. One constant, because the string is
+ * rendered from two places and a second copy is a second thing to correct.
+ */
+const CATALOG_HINT =
+  'Curated public COPC and EPT datasets: USGS 3DEP and European national '
+  + 'programmes. Each entry records its publisher, licence and the date its URL '
+  + 'was last checked; nothing re-checks it, so that date is the whole claim. '
+  + 'For other locations or your own COPC URL, use the URL field above.';
+
+/**
  * The curated entry the start screen promotes as its one-click demo.
  *
  * It must be a record whose licence the tree actually records, which a
@@ -192,9 +208,7 @@ export class CatalogPanel {
 
     this._hint = el('span', {
       className: 'olv-catalog-hint',
-      text: 'Verified-working public USGS EPT datasets — each URL was ' +
-        'probed at build time. For other locations or your own COPC URL, ' +
-        'use the URL field above.',
+      text: CATALOG_HINT,
     });
 
     this._status = el('div', { className: 'olv-catalog-status' });
@@ -231,11 +245,7 @@ export class CatalogPanel {
       const id = this._select.value;
       const loc = id ? getCuratedLocation(id) : undefined;
       this._submit.disabled = loc === undefined;
-      this._hint.textContent = loc
-        ? loc.hint
-        : 'Verified-working public USGS EPT datasets — each URL was ' +
-          'probed at build time. For other locations or your own COPC URL, ' +
-          'use the URL field above.';
+      this._hint.textContent = loc ? loc.hint : CATALOG_HINT;
       if (loc && this._onPickIntent) {
         try { this._onPickIntent(loc.streamUrl); } catch { /* fire-and-forget */ }
       }

--- a/tests/snapshotSourceFormatTruth.test.ts
+++ b/tests/snapshotSourceFormatTruth.test.ts
@@ -1,0 +1,100 @@
+/**
+ * snapshotSourceFormatTruth.test.ts
+ *
+ * `Viewer.snapshotResidentCloud()` is the cloud the Export / Convert panel
+ * writes for a streaming scan, and its `sourceFormat` is the provenance the
+ * deliverable carries. It was the literal `'laz'` for every source, so a
+ * snapshot taken over a 3D Tiles stream — point tiles, no LAZ record anywhere
+ * in the pipeline — shipped a file stating it came from a format whose bytes
+ * had never been read.
+ *
+ * The real method runs against a fake `this`, the way
+ * `snapshotColorbarPlumbing.test.ts` drives `_buildExportAdapter`: the format
+ * decision is three lines inside a three.js-bound class, and a fake source is
+ * what lets the shipped decision itself be asserted rather than a copy of it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Viewer } from '../src/render/Viewer';
+import type { PointCloud } from '../src/model/PointCloud';
+import type { DecodedChunk } from '../src/io/copc/copcChunkDecode';
+
+/** One resident node's decoded attributes — three points, all channels present. */
+function chunk(): DecodedChunk {
+  const n = 3;
+  return {
+    pointCount: n,
+    positions: new Float32Array([0, 0, 0, 1, 1, 1, 2, 2, 2]),
+    intensity: new Uint16Array(n),
+    classification: new Uint8Array(n),
+    returnNumber: new Uint8Array(n),
+    returnCount: new Uint8Array(n),
+    gpsTime: new Float64Array(n),
+  };
+}
+
+/**
+ * A `Viewer` whose only real state is one resident streaming node on a source
+ * of `kind`. The octree store answers `has`/`get` for that node so the real
+ * export-frontier walk keeps it.
+ */
+function viewerOverStream(kind: string): Viewer {
+  const decoded = chunk();
+  const store = {
+    has: (id: string) => id === 'n0',
+    get: (id: string) => (id === 'n0' ? { record: { parentId: undefined } } : undefined),
+  };
+  // Built on the real prototype so the method's own `this._exportFrontierChunks()`
+  // walk runs — the frontier decision is part of what produces the snapshot.
+  return Object.assign(Object.create(Viewer.prototype) as Viewer, {
+    _streaming: {
+      renderer: { residentFrontierEntries: () => [{ id: 'n0', fadingOut: false, decoded }] },
+      cloud: {
+        kind,
+        name: `scan.${kind}`,
+        renderOrigin: [10, 20, 30] as [number, number, number],
+        sourcePointCount: 99,
+        octree: { store },
+        crs: () => null,
+      },
+    },
+  }) as unknown as Viewer;
+}
+
+/** Invoke the shipped method body against the fake `this`. */
+function snapshot(kind: string): PointCloud | null {
+  const method = (Viewer.prototype as unknown as {
+    snapshotResidentCloud: (this: Viewer) => PointCloud | null;
+  }).snapshotResidentCloud;
+  return method.call(viewerOverStream(kind));
+}
+
+describe('streaming export snapshot — declared source format', () => {
+  it('does not stamp a 3D Tiles stream as LAZ', () => {
+    const cloud = snapshot('3dtiles');
+    expect(cloud).not.toBeNull();
+    expect(cloud!.sourceFormat).not.toBe('laz');
+  });
+
+  it('names a 3D Tiles stream by the tile format it actually decodes', () => {
+    expect(snapshot('3dtiles')!.sourceFormat).toBe('pnts');
+  });
+
+  it('keeps the LAS-family streams on their own record format', () => {
+    expect(snapshot('copc')!.sourceFormat).toBe('laz');
+    expect(snapshot('ept')!.sourceFormat).toBe('laz');
+  });
+
+  it('refuses a snapshot whose source records no format at all', () => {
+    // The OLV tile store's manifest carries no source format, so there is
+    // nothing to derive. Refusing beats stamping a plausible default.
+    expect(snapshot('tiles')).toBeNull();
+  });
+
+  it('still carries the rest of the source provenance', () => {
+    const cloud = snapshot('copc')!;
+    expect(cloud.name).toBe('scan.copc');
+    expect(cloud.pointCount).toBe(3);
+    expect(cloud.sourceDeclaredPointCount).toBe(99);
+  });
+});


### PR DESCRIPTION
The streaming export snapshot stamped `sourceFormat: 'laz'` on every source, so
a deliverable from a 3D Tiles stream named a format whose bytes it never read.
It now derives from the source kind through an exhaustive record: COPC and EPT
decode LAS point records, a point tile is `pnts`, and an OLV tile store's
manifest carries none, so that one is refused rather than defaulted. A new test
drives the shipped method.

Three copy fixes alongside it. The Viewer mount predicate said
`MULTI_LAYER_MOUNT_ENABLED` is off; it is on, and the argument is false because
placement reaches static layers only. The session schema note said mounting is
disabled. The catalog hint claimed USGS EPT datasets probed at build time: two
entries are European, two are COPC, and nothing re-runs the check.
