### PR TITLE
fix(shell): read scan presence from the streaming source, not a point total

### DIFF
--- a/src/app/openStreaming.ts
+++ b/src/app/openStreaming.ts
@@ -260,7 +260,10 @@ export function linkAbortSignals(
 export type StreamingReportInput = {
   readonly kind: StreamingSourceKind;
   readonly name: string;
-  readonly sourcePointCount: number;
+  /** The total the source states, or null where the format states none: COPC and
+   *  EPT both declare one, a 3D Tiles tileset declares none. The report renders
+   *  the absence as an absence rather than as a figure. */
+  readonly sourcePointCount: number | null;
   readonly localBounds?: () => readonly [number, number, number, number, number, number];
   readonly metadata?: {
     readonly header?: {

--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -165,11 +165,9 @@ export async function openRemoteTileset(
     const reportCloud: StreamingReportInput = {
       kind: cloud.kind,
       name: cloud.name,
-      // The one cast here. `StreamingReportInput` types this as a number
-      // because COPC and EPT both declare one; a tileset declares none, and it
-      // is that null which must reach the report, where the row reads "not
+      // Null, and typed null all the way through: the report row reads "not
       // stated by the source" instead of a figure nothing measured.
-      sourcePointCount: cloud.sourcePointCount as unknown as number,
+      sourcePointCount: cloud.sourcePointCount,
       maxDepth: () => cloud.maxDepth(),
       octree: { nodes: () => cloud.octree.nodes() },
     };

--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -35,6 +35,7 @@ import {
   linkAbortSignals,
   shouldDropCandidateOnPostCommitCancel,
   type OpenStreamingDeps,
+  type StreamingReportInput,
 } from './openStreaming';
 
 /**
@@ -155,6 +156,31 @@ export async function openRemoteTileset(
     activateCommittedStreamingCloud(cloud, deps);
     viewer.setMode('orbit');
     viewer.frameAll();
+
+    // The Scan Report for THIS scan. Nothing set it on this path, so the
+    // Inspector kept whichever streaming scan was open before: a tileset opened
+    // over a COPC read as that COPC, point count included. A tileset carries no
+    // LAS header, so the report is what a tileset does state — its format, its
+    // octree depth and node count — and an explicitly unstated point total.
+    const reportCloud: StreamingReportInput = {
+      kind: cloud.kind,
+      name: cloud.name,
+      // The one cast here. `StreamingReportInput` types this as a number
+      // because COPC and EPT both declare one; a tileset declares none, and it
+      // is that null which must reach the report, where the row reads "not
+      // stated by the source" instead of a figure nothing measured.
+      sourcePointCount: cloud.sourcePointCount as unknown as number,
+      maxDepth: () => cloud.maxDepth(),
+      octree: { nodes: () => cloud.octree.nodes() },
+    };
+    deps.setLastStreamingReportCloud(reportCloud);
+    try {
+      deps.inspector.setReport(
+        deps.runStreamingModules(reportCloud, deps.classLegendPanel.getVisibility().isFiltered()),
+      );
+    } catch (err) {
+      if (deps.debug) console.warn('[inspector] setReport (tileset) threw', err);
+    }
 
     deps.streamingPanel.setColorModes([...cloud.availableColorModes()], cloud.defaultColorMode());
     deps.streamingPanel.setQuality(deps.getStreamingQuality());

--- a/src/app/processStudioMount.ts
+++ b/src/app/processStudioMount.ts
@@ -52,7 +52,19 @@ const CLASS_BUILDING = 6;
  * viewer or GPU directly.
  */
 export interface LiveScanAccessors {
-  /** Source point count when a streaming source is mounted; null/undefined otherwise (its presence marks the scan as streaming). */
+  /**
+   * True when a streaming source is MOUNTED, whatever it can say about its size.
+   * This, not a point total, is what makes the active scan a streaming one: a
+   * 3D Tiles tileset states no total (its per-tile figures are decode-admission
+   * estimates, so summing them would report a measurement that does not exist),
+   * and reading that absence as "no scan" hid a scan that is drawn, pickable
+   * and measurable from the capability model.
+   */
+  hasStreamingSource(): boolean;
+  /**
+   * The streaming source's SOURCE point total, or null/undefined when the
+   * format states none. Never consulted to decide whether a scan is present.
+   */
   getStreamingPointCount(): number | null | undefined;
   /** Point count of the active static cloud; null/undefined when none is loaded. */
   getActivePointCount(): number | null | undefined;
@@ -71,11 +83,16 @@ export interface LiveScanAccessors {
  * null when nothing is loaded. Classification is reported as `partial` whenever
  * any class code is present — the conservative floor, never `full` — and ground
  * / building trust follows only from the actual class-2 / class-6 codes.
+ *
+ * PRESENCE AND SIZE ARE SEPARATE. Whether a scan is loaded comes from the
+ * mounted source; how many points it has comes from the format. A format that
+ * states no total contributes no `pointCount`, and the signal set carries that
+ * absence rather than a stand-in figure.
  */
 export function signalsFromLive(a: LiveScanAccessors): RawScanSignals | null {
-  const streamPts = a.getStreamingPointCount();
+  const isStreaming = a.hasStreamingSource();
+  const streamPts = isStreaming ? a.getStreamingPointCount() : null;
   const staticPts = a.getActivePointCount();
-  const isStreaming = streamPts != null;
   if (!isStreaming && staticPts == null) return null;
   const codes = a.getPresentClassCodes();
   const hasClasses = codes.length > 0;
@@ -85,9 +102,12 @@ export function signalsFromLive(a: LiveScanAccessors): RawScanSignals | null {
   const classificationProvenance = !hasClasses
     ? 'none'
     : (a.getClassificationDerived() ? 'derived' : 'producer');
+  const pointCount = isStreaming ? streamPts : staticPts;
   return {
     kind: isStreaming ? 'streaming' : 'static',
-    pointCount: isStreaming ? (streamPts as number) : (staticPts as number),
+    // Omitted, not zeroed, when the source states no total: `RawScanSignals`
+    // leaves `pointCount` optional precisely so an unstated size stays unstated.
+    ...(pointCount == null ? {} : { pointCount }),
     crs: a.getResolvedCrs() ?? null,
     classification: hasClasses ? 'partial' : 'none',
     classificationProvenance,
@@ -200,7 +220,12 @@ export function createProcessStudio(deps: ProcessStudioDeps): MountedProcessStud
  * this module never imports the Viewer (and stays Node-testable with a fake).
  */
 export interface StudioViewer {
-  /** The mounted streaming source, or null for a static / empty scene. */
+  /**
+   * The mounted streaming source, or null for a static / empty scene. Its
+   * PRESENCE is what says a streaming scan is loaded; `sourcePointCount` is
+   * null for a format that states no total and is never read as an answer to
+   * that question.
+   */
   readonly streamingCloud: { readonly sourcePointCount: number | null } | null;
   /** Every loaded static layer's id. */
   clouds(): readonly string[];
@@ -280,6 +305,7 @@ function companionSignals(shell: ProcessStudioShell): readonly RawScanSignals[] 
  */
 export function createProcessStudioFromShell(shell: ProcessStudioShell): MountedProcessStudio {
   const accessors: LiveScanAccessors = {
+    hasStreamingSource: () => shell.getViewer().streamingCloud != null,
     getStreamingPointCount: () => shell.getViewer().streamingCloud?.sourcePointCount ?? null,
     getActivePointCount: () => shell.getActiveCloud()?.pointCount ?? null,
     // Resolved CRS (override applied), not raw metadata — Studio agrees with the Inspector (C7).

--- a/src/main.ts
+++ b/src/main.ts
@@ -4249,7 +4249,7 @@ function syncInspectClassScope(): void {
 function runStreamingModules(cloud: {
   readonly kind: StreamingSourceKind;
   readonly name: string;
-  readonly sourcePointCount: number;
+  readonly sourcePointCount: number | null; // null where the format states no total: a tileset declares none, and its per-tile figures are decode-admission estimates rather than counts
   readonly localBounds?: () => readonly [number, number, number, number, number, number];
   readonly metadata?: {
     readonly header?: {
@@ -4280,10 +4280,9 @@ function runStreamingModules(cloud: {
   };
 
   rows.push(info('Source', streamingSourceLabel(cloud.kind)));
-  if (cloud.metadata?.header?.pointDataRecordFormat !== undefined) {
-    rows.push(info('Point format', `PDRF ${cloud.metadata.header.pointDataRecordFormat}`));
-  }
-  rows.push(headerMetric('Source point count', cloud.sourcePointCount.toLocaleString('en-US')));
+  if (cloud.metadata?.header?.pointDataRecordFormat !== undefined) rows.push(info('Point format', `PDRF ${cloud.metadata.header.pointDataRecordFormat}`));
+  // An absent total is reported as absent: a zero, or a summed per-tile estimate, would each read as a figure the source stands behind.
+  rows.push(cloud.sourcePointCount === null ? info('Source point count', 'not stated by the source') : headerMetric('Source point count', cloud.sourcePointCount.toLocaleString('en-US')));
 
   // Bounds — the header's source-coordinate min/max is the TIGHT data extent
   // (a 1000×1000×138 m scan reports 138 m here). Do NOT use `localBounds`: for
@@ -5603,6 +5602,7 @@ function removeCloud(id: string): void {
  */
 function clearOpenStaticLayers(): void {
   lastDerivedConfidence = null;
+  lastStreamingReportCloud = null; // every streaming open commits before calling this, so a streaming→streaming swap retires the previous scan's report here too; that path never reaches `closeStreaming`
   for (const id of viewer.clouds()) {
     viewer.removeCloud(id);
     inspector.removeCloud(id);

--- a/src/process/ProcessPlan.ts
+++ b/src/process/ProcessPlan.ts
@@ -63,8 +63,15 @@ export interface ScanFacts {
   readonly coverage: Coverage;
   /** Detected CRS, or null when none is recoverable. */
   readonly crs: CrsInfo | ResolvedCrs | null;
-  /** Total points in the source (not the resident count). */
-  readonly pointCount: number;
+  /**
+   * Total points the SOURCE STATES (not the resident count), or `null` when it
+   * states none. Absent is not zero: a 3D Tiles tileset carries no count in
+   * `tileset.json` and its per-tile figures are decode-admission estimates, so
+   * a total summed from them would be a measurement nobody made. Zero is a
+   * stated measurement and means the scan is empty; null means the size is
+   * unknown, which is a weaker fact and never evidence of emptiness.
+   */
+  readonly pointCount: number | null;
   readonly hasRgb: boolean;
   readonly hasIntensity: boolean;
   readonly hasGpsTime: boolean;

--- a/src/process/processCapabilities.ts
+++ b/src/process/processCapabilities.ts
@@ -37,6 +37,48 @@ function cap(
   return { product, readiness, reasonCode, reason };
 }
 
+/**
+ * The condition a scan's point total puts on a product, or null when the total
+ * is stated and positive.
+ *
+ * ZERO and UNSTATED are different facts and get different answers. A stated
+ * zero is a measurement — the scan is empty, and "the scan has no points" is
+ * true of it, so the product is refused. An unstated total says nothing about
+ * whether points exist: a 3D Tiles tileset carries no count in `tileset.json`
+ * and its per-tile figures are decode-admission estimates, yet the scan it
+ * mounts is drawn, picked and measured like any other.
+ *
+ * An unstated total is therefore REVIEW, not blocked. The count is a readiness
+ * signal here, never an input: the surface is gridded, and the classifier runs,
+ * over the points the source actually delivers, so refusing would withhold a
+ * product that genuinely works. What it cannot back is the graded deliverable,
+ * whose provenance would have to state a size nobody measured — which is what
+ * `review` already means everywhere else in this model for a fact that is
+ * unverified rather than known-bad.
+ *
+ * It keeps the slot the count check already held, at the head of each product's
+ * chain, so no other verdict moves: a scan that states a total reads exactly as
+ * it did before.
+ */
+function pointTotalCondition(
+  scan: ScanFacts,
+  product: ProductId,
+  verb: 'classify' | 'grid',
+): ProductCapability | null {
+  if (scan.pointCount == null) {
+    return cap(
+      product,
+      'review',
+      'POINT_TOTAL_UNSTATED',
+      `The source states no point total, so the scan's size is unconfirmed; it can be ${verb === 'grid' ? 'gridded' : 'classified'} for inspection over the points the source delivers, and a graded whole-dataset product is withheld.`,
+    );
+  }
+  if (scan.pointCount <= 0) {
+    return cap(product, 'blocked', 'NO_POINTS', `The scan has no points to ${verb}.`);
+  }
+  return null;
+}
+
 /** True when the scan can back a full-dataset product (not resident-only). */
 function isFullCoverage(scan: ScanFacts): boolean {
   return scan.coverage === 'full';
@@ -105,9 +147,8 @@ function compareVerticalReference(a: ScanFacts, b: ScanFacts): VerticalReference
  */
 function classifyGaps(scan: ScanFacts): ProductCapability {
   const p: ProductId = 'classify-gaps';
-  if (scan.pointCount <= 0) {
-    return cap(p, 'blocked', 'NO_POINTS', 'The scan has no points to classify.');
-  }
+  const points = pointTotalCondition(scan, p, 'classify');
+  if (points !== null) return points;
   if (scan.classification === 'full') {
     return cap(p, 'review', 'ALREADY_CLASSIFIED', 'Every point already carries a class; reclassifying would overwrite producer values, so it is an explicit action rather than a default.');
   }
@@ -123,9 +164,8 @@ function classifyGaps(scan: ScanFacts): ProductCapability {
 /** Bare-earth DTM — needs ground and full coverage; unit gates georeferenced use. */
 function dtm(scan: ScanFacts): ProductCapability {
   const p: ProductId = 'dtm';
-  if (scan.pointCount <= 0) {
-    return cap(p, 'blocked', 'NO_POINTS', 'The scan has no points to grid.');
-  }
+  const points = pointTotalCondition(scan, p, 'grid');
+  if (points !== null) return points;
   if (!isFullCoverage(scan)) {
     return cap(p, 'review', 'RESIDENT_ONLY', 'Only the resident streaming set is loaded, so a surface can be built for inspection but a whole-dataset product is withheld until the full cloud is graded.');
   }
@@ -141,9 +181,8 @@ function dtm(scan: ScanFacts): ProductCapability {
 /** Upper-surface DSM — needs full coverage; no ground requirement. */
 function dsm(scan: ScanFacts): ProductCapability {
   const p: ProductId = 'dsm';
-  if (scan.pointCount <= 0) {
-    return cap(p, 'blocked', 'NO_POINTS', 'The scan has no points to grid.');
-  }
+  const points = pointTotalCondition(scan, p, 'grid');
+  if (points !== null) return points;
   if (!isFullCoverage(scan)) {
     return cap(p, 'review', 'RESIDENT_ONLY', 'Only the resident streaming set is loaded, so a surface can be built for inspection but a whole-dataset product is withheld until the full cloud is graded.');
   }

--- a/src/process/scanFacts.ts
+++ b/src/process/scanFacts.ts
@@ -22,7 +22,9 @@ export interface RawScanSignals {
   readonly kind?: 'static' | 'streaming';
   readonly coverage?: Coverage;
   readonly crs?: CrsInfo | ResolvedCrs | null;
-  readonly pointCount?: number;
+  /** The total the source STATES. Omitted (or null) when it states none —
+   *  a format without a point total, not a scan that is empty. */
+  readonly pointCount?: number | null;
   readonly hasRgb?: boolean;
   readonly hasIntensity?: boolean;
   readonly hasGpsTime?: boolean;
@@ -46,6 +48,11 @@ export interface RawScanSignals {
  *   shell did not report is `resident-only` (the honest floor — we cannot claim
  *   to have seen more than the resident set). An explicit coverage is kept.
  * - `crs` defaults to null — an unknown CRS is never assumed to be anything.
+ * - `pointCount` is null when the caller states none. It is NOT defaulted to 0:
+ *   zero is a stated measurement ("this scan is empty") and inventing it for a
+ *   source that simply carries no total is a false claim about the data. A
+ *   stated but non-finite figure still falls to 0, unchanged — garbage in is
+ *   fail-closed, silence is not.
  * - feature flags default to false; `classification` defaults to `none`.
  * - `groundClassified` is true only when it is explicitly true AND some
  *   classification is present, so "trusted ground" can never sit on an
@@ -71,7 +78,10 @@ export function deriveScanFacts(raw: RawScanSignals): ScanFacts {
     kind,
     coverage,
     crs: raw.crs ?? null,
-    pointCount: Number.isFinite(raw.pointCount) ? Math.max(0, raw.pointCount as number) : 0,
+    pointCount:
+      raw.pointCount == null
+        ? null
+        : (Number.isFinite(raw.pointCount) ? Math.max(0, raw.pointCount) : 0),
     hasRgb: raw.hasRgb === true,
     hasIntensity: raw.hasIntensity === true,
     hasGpsTime: raw.hasGpsTime === true,

--- a/src/qa/qaChecks.ts
+++ b/src/qa/qaChecks.ts
@@ -25,8 +25,20 @@ export interface QaCheck {
   readonly reason: string;
 }
 
-/** File integrity: is there actually any point data to work with? */
+/**
+ * File integrity: is there actually any point data to work with?
+ *
+ * Three answers, because there are three facts. A stated positive total passes.
+ * A stated ZERO blocks — the scan is empty, and saying so is a measurement. An
+ * UNSTATED total (a 3D Tiles tileset states none) is neither: it is a check that
+ * could not be run, which is `review`, the same verdict cloud quality gives an
+ * unmeasured spacing. Blocking on it would report an empty scan that is drawn on
+ * screen; passing it would quote a figure nothing measured.
+ */
 function fileIntegrity(f: ScanFacts): QaCheck {
+  if (f.pointCount == null) {
+    return { id: 'FILE_INTEGRITY', label: 'File integrity', status: 'review', reason: "The source states no point total, so the scan's size could not be checked." };
+  }
   if (f.pointCount <= 0) {
     return { id: 'FILE_INTEGRITY', label: 'File integrity', status: 'block', reason: 'No points are present in the scan.' };
   }

--- a/src/validation/authorizationBenchmark.ts
+++ b/src/validation/authorizationBenchmark.ts
@@ -29,9 +29,13 @@ function crs(o: Partial<CrsInfo> = {}): CrsInfo {
   return { source: 'epsg', linearUnit: 'metre', linearUnitToMetres: 1, verticalDatum: 'NAVD88', verticalUnitToMetres: 1, ...o } as CrsInfo;
 }
 
+/** BASE's stated point total, named so a case can vary it without re-reading a
+ *  field that is nullable for sources which state no total. */
+const BASE_POINT_COUNT = 1_000_000;
+
 /** A fully-supported single scan: full coverage, known unit, trusted ground. */
 const BASE: ScanFacts = {
-  kind: 'static', coverage: 'full', crs: crs(), pointCount: 1_000_000,
+  kind: 'static', coverage: 'full', crs: crs(), pointCount: BASE_POINT_COUNT,
   hasRgb: true, hasIntensity: true, hasGpsTime: true, hasReturnNumber: true, hasPointSourceId: false,
   classification: 'full', groundClassified: true, hasBuildingClass: true,
   classificationProvenance: 'producer', medianSpacing: 0.2,
@@ -155,7 +159,7 @@ export const AUTHORIZATION_CASES: readonly BenchmarkCase[] = [
   },
   {
     id: 'A14', title: 'authentic token reused for another dataset', kind: 'adversarial', product: 'dtm', staleCase: true,
-    run: () => reuseAcross([BASE], [{ ...BASE, pointCount: BASE.pointCount - 1 }], 'dtm'),
+    run: () => reuseAcross([BASE], [{ ...BASE, pointCount: BASE_POINT_COUNT - 1 }], 'dtm'),
   },
   {
     id: 'A15', title: 'subject completeness full → partial (coverage)', kind: 'adversarial', product: 'dtm', staleCase: true,

--- a/tests/classificationProvenance.test.ts
+++ b/tests/classificationProvenance.test.ts
@@ -64,6 +64,7 @@ describe('the capability model demotes derived ground to review', () => {
 
 describe('signalsFromLive maps the derived flag to provenance', () => {
   const base: LiveScanAccessors = {
+    hasStreamingSource: () => false,
     getStreamingPointCount: () => null, getActivePointCount: () => 1000, getResolvedCrs: () => metreCrs,
     getPresentClassCodes: () => [2, 6], getClassificationDerived: () => false,
   };

--- a/tests/processCapabilities.test.ts
+++ b/tests/processCapabilities.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from 'vitest';
 import type { CrsInfo } from '../src/io/crs';
 import type { ScanFacts, ProductId } from '../src/process/ProcessPlan';
 import { evaluateCapabilities, capabilityFor } from '../src/process/processCapabilities';
+import { deriveScanFacts } from '../src/process/scanFacts';
 
 function crs(overrides: Partial<CrsInfo> = {}): CrsInfo {
   return {
@@ -211,5 +212,110 @@ describe('plan shape', () => {
       expect(c.reasonCode).toMatch(/^[A-Z][A-Z0-9_]*$/);
       expect(c.reason.length).toBeGreaterThan(10);
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A source that states no point total
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A 3D Tiles tileset states no point total: `tileset.json` carries no count and
+ * the per-tile figures are decode-admission estimates, so summing them would
+ * report a measurement nobody made. `deriveScanFacts` carries that absence
+ * through as a null `pointCount`.
+ *
+ * ZERO and UNSTATED are different facts. Zero is a stated measurement and
+ * "the scan has no points" is true of it. An unstated total says nothing about
+ * whether the scan has points, and the tileset that produces one is drawn,
+ * pickable and gridded from the points the source actually delivers — the count
+ * is a readiness signal, never an input to the raster. Refusing it with
+ * NO_POINTS trades a true generic refusal for a false specific one.
+ */
+describe('a scan that states no point total', () => {
+  /** Signals from a mounted tileset: streaming, no total stated. */
+  const unstated = deriveScanFacts({ kind: 'streaming', coverage: 'full', crs: crs() });
+
+  it('carries the absence through instead of collapsing it to zero', () => {
+    expect(unstated.pointCount).toBeNull();
+  });
+
+  for (const product of ['classify-gaps', 'dtm', 'dsm'] as ProductId[]) {
+    it(`does not tell ${product} the scan has no points`, () => {
+      const v = verdict([unstated], product);
+      expect(v.reasonCode).not.toBe('NO_POINTS');
+      expect(v.reason).not.toMatch(/no points/i);
+    });
+
+    it(`does not refuse ${product} outright over an absent count`, () => {
+      expect(verdict([unstated], product).readiness).not.toBe('blocked');
+    });
+
+    it(`names the absent total as the condition on ${product}`, () => {
+      const v = verdict([unstated], product);
+      expect(v.readiness).toBe('review');
+      expect(v.reasonCode).toBe('POINT_TOTAL_UNSTATED');
+    });
+  }
+
+  it('leaves contours reachable rather than blocked behind a missing DTM', () => {
+    const v = verdict([unstated], 'contours');
+    expect(v.readiness).not.toBe('blocked');
+    expect(v.reasonCode).not.toBe('NO_DTM');
+  });
+
+  it('keeps the metric gates ahead of it: an unknown unit still blocks footprints', () => {
+    const noUnit = deriveScanFacts({ kind: 'streaming', coverage: 'full', crs: crs({ linearUnit: 'unknown' }) });
+    const v = verdict([noUnit], 'building-footprints');
+    expect(v.readiness).toBe('blocked');
+    expect(v.reasonCode).toBe('UNIT_UNKNOWN');
+  });
+});
+
+describe('a scan that states ZERO points', () => {
+  it('keeps the original refusal on classify-gaps', () => {
+    const v = verdict([scan({ pointCount: 0 })], 'classify-gaps');
+    expect(v.readiness).toBe('blocked');
+    expect(v.reasonCode).toBe('NO_POINTS');
+    expect(v.reason).toBe('The scan has no points to classify.');
+  });
+
+  for (const product of ['dtm', 'dsm'] as ProductId[]) {
+    it(`keeps the original refusal on ${product}`, () => {
+      const v = verdict([scan({ pointCount: 0 })], product);
+      expect(v.readiness).toBe('blocked');
+      expect(v.reasonCode).toBe('NO_POINTS');
+      expect(v.reason).toBe('The scan has no points to grid.');
+    });
+  }
+
+  it('still blocks contours behind the missing DTM', () => {
+    const v = verdict([scan({ pointCount: 0 })], 'contours');
+    expect(v.readiness).toBe('blocked');
+    expect(v.reasonCode).toBe('NO_DTM');
+  });
+
+  it('reaches the same refusal through deriveScanFacts', () => {
+    const facts = deriveScanFacts({ kind: 'static', coverage: 'full', crs: crs(), pointCount: 0 });
+    expect(facts.pointCount).toBe(0);
+    expect(verdict([facts], 'dtm').reasonCode).toBe('NO_POINTS');
+  });
+});
+
+describe('a scan that states a real point total', () => {
+  it('is unaffected: every verdict matches the pre-existing plan', () => {
+    const healthy = scan({ groundClassified: true, classificationProvenance: 'producer', classification: 'partial', hasBuildingClass: true });
+    const plan = evaluateCapabilities({ scans: [healthy] });
+    expect(capabilityFor(plan, 'classify-gaps')).toMatchObject({ readiness: 'ready', reasonCode: 'GAPS_CLASSIFIABLE' });
+    expect(capabilityFor(plan, 'dtm')).toMatchObject({ readiness: 'ready', reasonCode: 'GROUND_TRUSTED' });
+    expect(capabilityFor(plan, 'dsm')).toMatchObject({ readiness: 'ready', reasonCode: 'SURFACE_READY' });
+    expect(capabilityFor(plan, 'contours')).toMatchObject({ readiness: 'ready', reasonCode: 'DTM_READY' });
+    expect(capabilityFor(plan, 'building-footprints')).toMatchObject({ readiness: 'ready', reasonCode: 'BUILDING_CLASS_PRESENT' });
+  });
+
+  it('keeps every other single-scan verdict it had before', () => {
+    expect(verdict([scan({ kind: 'streaming', coverage: 'resident-only' })], 'dtm').reasonCode).toBe('RESIDENT_ONLY');
+    expect(verdict([scan({ crs: null })], 'dsm').reasonCode).toBe('UNIT_UNKNOWN');
+    expect(verdict([scan()], 'dtm').reasonCode).toBe('GROUND_DERIVED');
   });
 });

--- a/tests/processStudioMount.test.ts
+++ b/tests/processStudioMount.test.ts
@@ -6,8 +6,12 @@ import { describe, it, expect } from 'vitest';
 import { resolveActiveScanFacts, signalsFromLive } from '../src/app/processStudioMount';
 import type { LiveScanAccessors } from '../src/app/processStudioMount';
 import type { RawScanSignals } from '../src/process/scanFacts';
+import type { CrsInfo } from '../src/io/crs';
+import { spatialContextFrom } from '../src/geo/SpatialContext';
+import { preflightSnapshot } from '../src/app/toolPreflightInput';
 
 const noScan: LiveScanAccessors = {
+  hasStreamingSource: () => false,
   getStreamingPointCount: () => null,
   getActivePointCount: () => null,
   getResolvedCrs: () => null,
@@ -77,12 +81,99 @@ describe('signalsFromLive', () => {
   });
 
   it('treats a mounted streaming source as the active scan over a static cloud', () => {
-    const sig = signalsFromLive({ ...noScan, getStreamingPointCount: () => 9_000_000, getActivePointCount: () => 100 });
+    const sig = signalsFromLive({
+      ...noScan,
+      hasStreamingSource: () => true,
+      getStreamingPointCount: () => 9_000_000,
+      getActivePointCount: () => 100,
+    });
     expect(sig).toMatchObject({ kind: 'streaming', pointCount: 9_000_000 });
   });
 
   it('carries a null CRS through rather than inventing one', () => {
     const sig = signalsFromLive({ ...noScan, getActivePointCount: () => 10, getResolvedCrs: () => null });
     expect(sig?.crs).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A streaming source that states no point total
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A 3D Tiles tileset is drawn, picked and measured like any other streaming
+ * scan, and it states no point total: `sourcePointCount` is null because the
+ * per-tile figures are decode-admission estimates rather than counts. The shell
+ * read that null as "no scan", so the capability model saw an empty scan list
+ * and every tool preflight refused with NO_SCAN_LOADED over a scan on screen.
+ *
+ * A scan is present when a source is MOUNTED. The count is a separate fact, and
+ * an absent one stays absent.
+ */
+const metreCrs = {
+  source: 'epsg',
+  name: 'WGS 84 / UTM zone 12N',
+  epsg: 32612,
+  linearUnit: 'metre',
+  linearUnitToMetres: 1,
+  isGeographic: false,
+  verticalEpsg: 5703,
+  verticalDatum: 'NAVD88',
+  verticalUnitToMetres: 1,
+} as CrsInfo;
+
+const tilesetScan: LiveScanAccessors = {
+  ...noScan,
+  hasStreamingSource: () => true,
+  getStreamingPointCount: () => null,
+  getResolvedCrs: () => metreCrs,
+};
+
+describe('a streaming source with no stated point total', () => {
+  it('is a loaded scan — presence of the source decides, not a count', () => {
+    const sig = signalsFromLive(tilesetScan);
+    expect(sig).not.toBeNull();
+    expect(sig?.kind).toBe('streaming');
+  });
+
+  it('reports no point count rather than inventing one', () => {
+    const sig = signalsFromLive(tilesetScan);
+    expect(sig).not.toBeNull();
+    expect(sig?.pointCount).toBeUndefined();
+  });
+
+  it('resolves scan facts, so the panel leaves its empty state', () => {
+    const facts = resolveActiveScanFacts({ getSignals: () => signalsFromLive(tilesetScan) });
+    expect(facts).not.toBeNull();
+    expect(facts?.kind).toBe('streaming');
+    expect(facts?.coverage).toBe('resident-only');
+  });
+
+  it('still prefers a static cloud when no streaming source is mounted', () => {
+    const sig = signalsFromLive({ ...noScan, getActivePointCount: () => 42 });
+    expect(sig).toMatchObject({ kind: 'static', pointCount: 42 });
+  });
+
+  it('leaves no tool refusing with NO_SCAN_LOADED', () => {
+    const preflights = preflightSnapshot({
+      getActiveSignals: () => signalsFromLive(tilesetScan),
+      getSpatialContext: () => spatialContextFrom(metreCrs),
+      getCompanionSignals: () => [],
+      getDatumResolved: () => true,
+    });
+    expect(preflights.length).toBeGreaterThan(0);
+    const codes = preflights.flatMap((p) => p.reasons.map((r) => r.code));
+    expect(codes).not.toContain('NO_SCAN_LOADED');
+  });
+
+  it('lets a measurement be armed over the scan on screen', () => {
+    const preflights = preflightSnapshot({
+      getActiveSignals: () => signalsFromLive(tilesetScan),
+      getSpatialContext: () => spatialContextFrom(metreCrs),
+      getCompanionSignals: () => [],
+      getDatumResolved: () => true,
+    });
+    const distance = preflights.find((p) => p.tool === 'measure-distance');
+    expect(distance?.status).not.toBe('blocked');
   });
 });

--- a/tests/processStudioMount.test.ts
+++ b/tests/processStudioMount.test.ts
@@ -9,6 +9,7 @@ import type { RawScanSignals } from '../src/process/scanFacts';
 import type { CrsInfo } from '../src/io/crs';
 import { spatialContextFrom } from '../src/geo/SpatialContext';
 import { preflightSnapshot } from '../src/app/toolPreflightInput';
+import { evaluateCapabilities, capabilityFor } from '../src/process/processCapabilities';
 
 const noScan: LiveScanAccessors = {
   hasStreamingSource: () => false,
@@ -164,6 +165,22 @@ describe('a streaming source with no stated point total', () => {
     expect(preflights.length).toBeGreaterThan(0);
     const codes = preflights.flatMap((p) => p.reasons.map((r) => r.code));
     expect(codes).not.toContain('NO_SCAN_LOADED');
+  });
+
+  it('never tells the user a scan on screen has no points', () => {
+    // The end of the live path: accessors → signals → facts → the capability
+    // model. With the total omitted the shell used to hand the evaluator a zero,
+    // and DTM, DSM and classify-gaps each refused a drawn scan with "The scan
+    // has no points to grid."
+    const facts = resolveActiveScanFacts({ getSignals: () => signalsFromLive(tilesetScan) })!;
+    const plan = evaluateCapabilities({ scans: [facts] });
+    for (const product of ['classify-gaps', 'dtm', 'dsm'] as const) {
+      const v = capabilityFor(plan, product)!;
+      expect(v.reasonCode, product).toBe('POINT_TOTAL_UNSTATED');
+      expect(v.reason, product).not.toMatch(/no points/i);
+      expect(v.readiness, product).toBe('review');
+    }
+    expect(capabilityFor(plan, 'contours')!.readiness).not.toBe('blocked');
   });
 
   it('lets a measurement be armed over the scan on screen', () => {

--- a/tests/qaChecks.test.ts
+++ b/tests/qaChecks.test.ts
@@ -34,6 +34,18 @@ describe('runQaChecks', () => {
     expect(worstStatus(checks)).toBe('block');
   });
 
+  it('a source that states no point total reviews file integrity rather than blocking it', () => {
+    // A stated zero means the scan is empty. An unstated total (a 3D Tiles
+    // tileset states none) means the check could not be run, so it reviews:
+    // blocking would report an empty scan that is drawn on screen.
+    const checks = runQaChecks(facts({ kind: 'streaming', pointCount: null }));
+    const integrity = byId(checks, 'FILE_INTEGRITY');
+    expect(integrity.status).toBe('review');
+    expect(integrity.reason).not.toMatch(/no points/i);
+    // Independence holds: the other axes answer on their own evidence.
+    expect(byId(checks, 'SPATIAL_REFERENCE').status).toBe('pass');
+  });
+
   it('a missing CRS blocks only the spatial-reference check (fail closed)', () => {
     const checks = runQaChecks(facts({ crs: null }));
     expect(byId(checks, 'SPATIAL_REFERENCE').status).toBe('block');

--- a/tests/scanFacts.test.ts
+++ b/tests/scanFacts.test.ts
@@ -4,6 +4,8 @@
 
 import { describe, it, expect } from 'vitest';
 import { deriveScanFacts } from '../src/process/scanFacts';
+import { evaluateCapabilities, capabilityFor } from '../src/process/processCapabilities';
+import type { CrsInfo } from '../src/io/crs';
 
 describe('deriveScanFacts — unknowns default to the safe side', () => {
   it('an empty signal set yields a conservative static, no-CRS, unclassified scan', () => {
@@ -11,7 +13,7 @@ describe('deriveScanFacts — unknowns default to the safe side', () => {
     expect(f.kind).toBe('static');
     expect(f.coverage).toBe('full'); // static clouds are whole-file
     expect(f.crs).toBeNull(); // never assume a CRS
-    expect(f.pointCount).toBe(0);
+    expect(f.pointCount).toBeNull(); // a caller that stated no total has not stated zero
     expect(f.classification).toBe('none');
     expect(f.groundClassified).toBe(false);
     expect(f.hasBuildingClass).toBe(false);
@@ -38,6 +40,30 @@ describe('deriveScanFacts — unknowns default to the safe side', () => {
     expect(deriveScanFacts({ pointCount: -5 }).pointCount).toBe(0);
     expect(deriveScanFacts({ pointCount: NaN }).pointCount).toBe(0);
     expect(deriveScanFacts({ pointCount: 1000 }).pointCount).toBe(1000);
+  });
+
+  it('an omitted point count is unstated, and a stated zero is still zero', () => {
+    // Two different facts, kept apart: a source that carries no total (a 3D
+    // Tiles tileset) versus one that measured its scan as empty.
+    expect(deriveScanFacts({ pointCount: 0 }).pointCount).toBe(0);
+    expect(deriveScanFacts({ kind: 'streaming' }).pointCount).toBeNull();
+  });
+
+  it('an unstated total is still fail-closed — no product reaches ready on it', () => {
+    // The safe side is not "assume empty", it is "do not claim". Every product
+    // stays off `ready` for a scan whose size nobody stated, even when every
+    // other fact it needs is present and trusted.
+    const plan = evaluateCapabilities({
+      scans: [deriveScanFacts({
+        kind: 'static', coverage: 'full',
+        crs: { source: 'epsg', linearUnit: 'metre', linearUnitToMetres: 1 } as CrsInfo,
+        classification: 'partial', classificationProvenance: 'producer',
+        groundClassified: true, hasBuildingClass: true,
+      })],
+    });
+    for (const product of ['classify-gaps', 'dtm', 'dsm', 'contours'] as const) {
+      expect(capabilityFor(plan, product)!.readiness, product).not.toBe('ready');
+    }
   });
 
   it('feature flags are false unless explicitly true', () => {

--- a/tests/tilesetStreamingOpen.test.ts
+++ b/tests/tilesetStreamingOpen.test.ts
@@ -291,6 +291,17 @@ describe('the streaming Scan Report in the shell', () => {
     expect(main.match(/cloud\.sourcePointCount\.toLocaleString/g) ?? []).toHaveLength(1);
   });
 
+  it('carries the absent total by type, with no cast to paper over it', () => {
+    // `StreamingReportInput.sourcePointCount` is `number | null`, so the tileset
+    // path assigns the null directly. A cast here would let a future `number`
+    // field silently accept a null again and reach `.toLocaleString`.
+    const open = readFileSync(resolve(ROOT, 'src/app/openTilesetLayer.ts'), 'utf8');
+    expect(open).toContain('sourcePointCount: cloud.sourcePointCount,');
+    expect(open).not.toMatch(/sourcePointCount[^\n]*as unknown as/);
+    const streaming = readFileSync(resolve(ROOT, 'src/app/openStreaming.ts'), 'utf8');
+    expect(streaming).toMatch(/readonly sourcePointCount: number \| null;/);
+  });
+
   it("drops the previous scan's report cloud when a streaming open commits", () => {
     // `clearOpenStaticLayers` runs on every streaming attach once it has
     // committed, including a streaming→streaming swap, which never passes

--- a/tests/tilesetStreamingOpen.test.ts
+++ b/tests/tilesetStreamingOpen.test.ts
@@ -9,7 +9,12 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { openRemoteTileset, tilesetDisplayName, TilesetRefusal } from '../src/app/openTilesetLayer';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
 const DOC = JSON.stringify({
@@ -21,6 +26,8 @@ const DOC = JSON.stringify({
 /** Deps that record the order of the calls the commit sequence makes. */
 function deps(doc = DOC) {
   const order: string[] = [];
+  const reported: { kind?: string; sourcePointCount?: number | null }[] = [];
+  const setReport = vi.fn();
   const viewer = {
     clouds: () => [],
     attachStreamingCloud: vi.fn(async () => {
@@ -32,8 +39,19 @@ function deps(doc = DOC) {
   return {
     order,
     viewer,
+    reported,
+    setReport,
     attached: viewer.attachStreamingCloud,
     d: {
+      setLastStreamingReportCloud: (c: { kind?: string; sourcePointCount?: number | null }) => {
+        reported.push(c);
+        order.push('report');
+      },
+      runStreamingModules: (c: { sourcePointCount?: number | null }) => [
+        { label: 'Source point count', value: String(c.sourcePointCount), status: 'info' },
+      ],
+      inspector: { setReport },
+      classLegendPanel: { getVisibility: () => ({ isFiltered: () => false }) },
       isLoading: () => false,
       setLoading: () => {},
       viewerReady: Promise.resolve(),
@@ -128,6 +146,36 @@ describe('the open path', () => {
     expect(modes).not.toContain('classification');
   });
 
+  it("hands the Inspector this scan's report, not the previous scan's", async () => {
+    // Nothing set the report on this path, so a tileset opened over a COPC left
+    // the COPC's Scan Report on screen: its format, its extent, its point count.
+    const t = deps();
+    await withTransport(DOC, () =>
+      openRemoteTileset('https://host/d/tileset.json', undefined, t.d as never),
+    );
+    expect(t.reported).toHaveLength(1);
+    expect(t.reported[0].kind).toBe('3dtiles');
+    expect(t.setReport).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the point total as absent rather than as a number', async () => {
+    const t = deps();
+    await withTransport(DOC, () =>
+      openRemoteTileset('https://host/d/tileset.json', undefined, t.d as never),
+    );
+    // A tileset states no total and its per-tile figures are decode-admission
+    // estimates. Anything but null here is a figure nothing measured.
+    expect(t.reported[0].sourcePointCount).toBeNull();
+  });
+
+  it('sets the report only after the attach has committed', async () => {
+    const t = deps();
+    await withTransport(DOC, () =>
+      openRemoteTileset('https://host/d/tileset.json', undefined, t.d as never),
+    );
+    expect(t.order.indexOf('report')).toBeGreaterThan(t.order.indexOf('attach'));
+  });
+
   it('refuses a tileset that declares no tile with point content', async () => {
     const empty = JSON.stringify({
       asset: { version: '1.0' },
@@ -212,5 +260,43 @@ describe('a refusal reaches the user', () => {
     // A transport or decode failure has no reason worth quoting, and the
     // category is the useful thing to say. Nothing here should bypass that.
     expect(new TilesetRefusal('x') instanceof Error).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The shell's side of the same report
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `runStreamingModules` and the report cloud it is called with both live in the
+ * shell, which cannot be imported here: `src/main.ts` boots the application on
+ * load. The two facts below are read off its source, the way
+ * `streamingScanReveal.test.ts` reads the attach paths, because a report that
+ * crashes on a null total or that survives a scan swap is not visible from the
+ * open path alone.
+ */
+describe('the streaming Scan Report in the shell', () => {
+  const main = readFileSync(resolve(ROOT, 'src/main.ts'), 'utf8');
+
+  it('accepts a source that states no point total', () => {
+    expect(main).toMatch(/readonly sourcePointCount: number \| null;/);
+  });
+
+  it('never formats that total without checking for it first', () => {
+    const guard = main.indexOf("cloud.sourcePointCount === null ? info('Source point count'");
+    const format = main.indexOf('cloud.sourcePointCount.toLocaleString');
+    expect(guard, 'the null total reaches .toLocaleString and throws').toBeGreaterThan(-1);
+    expect(format).toBeGreaterThan(guard);
+    // One formatting site only, so a second unguarded one cannot hide behind it.
+    expect(main.match(/cloud\.sourcePointCount\.toLocaleString/g) ?? []).toHaveLength(1);
+  });
+
+  it("drops the previous scan's report cloud when a streaming open commits", () => {
+    // `clearOpenStaticLayers` runs on every streaming attach once it has
+    // committed, including a streaming→streaming swap, which never passes
+    // through `closeStreaming`.
+    const body = main.slice(main.indexOf('function clearOpenStaticLayers()'));
+    const end = body.indexOf('\n}');
+    expect(body.slice(0, end)).toContain('lastStreamingReportCloud = null');
   });
 });


### PR DESCRIPTION
A 3D Tiles tileset states no point total, so `TilesetStreamingSource.sourcePointCount` is null: the per-tile figures govern decode admission and are not counts. The shell read that null as "no scan". A tileset that was drawn, pickable and measurable reached the capability model as an empty scan list, and every tool preflight refused with NO_SCAN_LOADED.

Presence now comes from the mounted source, through a new `hasStreamingSource` accessor. The absent total travels as an absent `pointCount`; nothing sums the per-tile estimates or substitutes a zero. `runStreamingModules` takes `number | null` and prints "not stated by the source" rather than calling `toLocaleString` on null. The tileset open sets the report cloud it never set, and every streaming open clears the previous one, so a tileset opened over a COPC no longer shows that COPC's report.
