### PR TITLE
fix(tiles3d): record and surface an unestablished tileset frame

### DIFF
--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -223,10 +223,26 @@ export async function openRemoteTileset(
       octree: { nodes: () => cloud.octree.nodes() },
     };
     deps.setLastStreamingReportCloud(reportCloud);
+    // One report, built once. `setReport` replaces the Inspector's rows rather
+    // than appending, so two calls would leave only whatever the second one
+    // published. The streaming rows are gathered separately from the frame rows
+    // for a different reason: the frame statement says whether which way is up
+    // was ever established, and losing it because an unrelated module threw
+    // would leave a user reading heights with nothing to warn them.
+    let streamingRows: AnalysisRow[] = [];
     try {
-      deps.inspector.setReport(
-        deps.runStreamingModules(reportCloud, deps.classLegendPanel.getVisibility().isFiltered()),
+      streamingRows = deps.runStreamingModules(
+        reportCloud,
+        deps.classLegendPanel.getVisibility().isFiltered(),
       );
+    } catch (err) {
+      if (deps.debug) console.warn('[inspector] runStreamingModules (tileset) threw', err);
+    }
+    try {
+      deps.inspector.setReport([
+        ...streamingRows,
+        ...tilesetFrameReportRows(cloud.frameProvenance),
+      ]);
     } catch (err) {
       if (deps.debug) console.warn('[inspector] setReport (tileset) threw', err);
     }
@@ -235,14 +251,6 @@ export async function openRemoteTileset(
     deps.streamingPanel.setQuality(deps.getStreamingQuality());
     deps.streamingPanel.setSourceUrl(url);
     deps.streamingPanel.setPhase('Streaming coarse geometry…');
-    // The frame statement, on the Scan Report. Wrapped the way the COPC and EPT
-    // paths wrap their report calls: a panel that throws must not tear down a
-    // scene that is already committed and drawing.
-    try {
-      deps.inspector.setReport(tilesetFrameReportRows(cloud.frameProvenance));
-    } catch (err) {
-      if (deps.debug) console.warn('[inspector] setReport (tileset) threw', err);
-    }
     deps.dropZone.setProgress(null);
     deps.dropZone.setCancelHandler(null);
     deps.startStreamingStatusPolling();

--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -30,6 +30,12 @@ import { validateRemoteTilesetUrl } from '../io/tiles3d/tilesetUrl';
 import { PntsChunkDecoder } from '../io/tiles3d/pntsDecode';
 import { TilesetStreamingSource } from '../render/streaming/TilesetStreamingSource';
 import {
+  describeCloudFrame,
+  FRAME_UNKNOWN_NOTE,
+  type CloudFrameProvenance,
+} from '../geo/frame/frameProvenance';
+import type { AnalysisRow } from '../analysis/ModuleApi';
+import {
   activateCommittedStreamingCloud,
   isAbortError,
   linkAbortSignals,
@@ -69,6 +75,45 @@ export function tilesetDisplayName(url: string): string {
   } catch {
     return url;
   }
+}
+
+/**
+ * The Scan Report rows that state what the tileset established about up.
+ *
+ * A tileset declaring no geocentric root frame draws exactly like one that
+ * does: it recentres, it fits the camera, it looks like a scene. The only place
+ * the difference can appear is in words, so it is said here, on the surface a
+ * user consults before trusting an elevation — the same place the COPC and EPT
+ * opens put their honesty rows.
+ *
+ * The established case is stated no more strongly than the document allows. A
+ * `region` fixes the root frame as WGS84 geocentric, which makes a height an
+ * ELLIPSOIDAL height; 3D Tiles carries no vertical datum, so naming an
+ * orthometric one here would be a different lie from the one this fixes.
+ *
+ * Pure — no DOM, no viewer — so the wording is testable without an open.
+ */
+export function tilesetFrameReportRows(
+  provenance: CloudFrameProvenance | undefined,
+): AnalysisRow[] {
+  // A source that states nothing gets no row. Inventing "unknown" on its behalf
+  // would report a determination that was never made.
+  if (provenance === undefined) return [];
+  const established = provenance.basis !== 'unknown';
+  const rows: AnalysisRow[] = [
+    {
+      label: 'Vertical frame',
+      value: describeCloudFrame(provenance),
+      status: established ? 'info' : 'warn',
+    },
+  ];
+  if (established && provenance.declaredBy !== null) {
+    rows.push({ label: 'Frame declared by', value: provenance.declaredBy, status: 'info' });
+  }
+  if (!established) {
+    rows.push({ label: 'Vertical reference', value: FRAME_UNKNOWN_NOTE, status: 'warn' });
+  }
+  return rows;
 }
 
 /**
@@ -190,6 +235,14 @@ export async function openRemoteTileset(
     deps.streamingPanel.setQuality(deps.getStreamingQuality());
     deps.streamingPanel.setSourceUrl(url);
     deps.streamingPanel.setPhase('Streaming coarse geometry…');
+    // The frame statement, on the Scan Report. Wrapped the way the COPC and EPT
+    // paths wrap their report calls: a panel that throws must not tear down a
+    // scene that is already committed and drawing.
+    try {
+      deps.inspector.setReport(tilesetFrameReportRows(cloud.frameProvenance));
+    } catch (err) {
+      if (deps.debug) console.warn('[inspector] setReport (tileset) threw', err);
+    }
     deps.dropZone.setProgress(null);
     deps.dropZone.setCancelHandler(null);
     deps.startStreamingStatusPolling();

--- a/src/io/tiles3d/tilesetFrame.ts
+++ b/src/io/tiles3d/tilesetFrame.ts
@@ -112,34 +112,99 @@ export function resolveTilesetFrame(
   tileset: Tileset,
   anchor: Vec3 | null,
 ): ResolvedTilesetFrame {
+  const established = establishedTilesetFrame(tileset, anchor);
+  return {
+    frame: established === null ? null : createLocalEnuFrame(established.anchor),
+    provenance: frameProvenanceOf(established),
+  };
+}
+
+/**
+ * The anchor an ENU frame may be built on, or `null` when the tileset gave no
+ * grounds to build one.
+ *
+ * The single place the question is decided, because two callers ask it: the
+ * merged reader below, and the streaming reader that needs the same rotation as
+ * a matrix. A second copy of the guard is how a document ends up ROTATED by one
+ * path and recorded as unrotated by the other, or the reverse: recorded as
+ * levelled while its tiles were left in ECEF. Either way the scene draws and
+ * only the numbers are wrong.
+ *
+ * The anchor is refused when it is not finite, and at the geocentre, where the
+ * ellipsoid normal is not defined and any rotation would be arbitrary.
+ */
+function establishedTilesetFrame(
+  tileset: Tileset,
+  anchor: Vec3 | null,
+): { readonly anchor: Vec3; readonly declaredBy: string } | null {
   const declaration = declaredTilesetFrame(tileset);
   const usable =
     anchor !== null &&
     anchor.every((v) => Number.isFinite(v)) &&
     Math.hypot(anchor[0], anchor[1], anchor[2]) > 0;
-  if (!declaration.geocentric || !usable) {
+  if (!declaration.geocentric || !usable || declaration.declaredBy === null) return null;
+  return { anchor, declaredBy: declaration.declaredBy };
+}
+
+/** The record kept beside a cloud, for an established frame and for none. */
+function frameProvenanceOf(
+  established: { readonly anchor: Vec3; readonly declaredBy: string } | null,
+): CloudFrameProvenance {
+  if (established === null) {
     return {
-      frame: null,
-      provenance: {
-        basis: 'unknown',
-        declaredBy: null,
-        verticalReference: 'unknown',
-        linearUnit: 'metre',
-      },
+      basis: 'unknown',
+      declaredBy: null,
+      verticalReference: 'unknown',
+      linearUnit: 'metre',
     };
   }
+  const [x, y, z] = established.anchor;
   return {
-    frame: createLocalEnuFrame(anchor),
-    provenance: {
-      basis: 'local-enu',
-      declaredBy: declaration.declaredBy,
-      anchor: [anchor[0], anchor[1], anchor[2]],
-      // Heights in an ENU frame tangent to the WGS84 ellipsoid are heights
-      // above that ellipsoid. 3D Tiles carries no vertical datum, so this is
-      // the only reference available and never becomes an orthometric one.
-      verticalReference: 'ellipsoidal',
-      linearUnit: 'metre',
-    },
+    basis: 'local-enu',
+    declaredBy: established.declaredBy,
+    anchor: [x, y, z],
+    // Heights in an ENU frame tangent to the WGS84 ellipsoid are heights
+    // above that ellipsoid. 3D Tiles carries no vertical datum, so this is
+    // the only reference available and never becomes an orthometric one.
+    verticalReference: 'ellipsoidal',
+    linearUnit: 'metre',
+  };
+}
+
+/** A frame for a STREAMED tileset: the root transform, and how it was arrived at. */
+export interface StreamingTilesetFrame {
+  /**
+   * The rotation to put at the root of the tile tree, or `null` when the frame
+   * was not established. A matrix rather than a `SpatialFrame` because a
+   * streaming reader never holds every point: it places each tile by composing
+   * transforms down the tree.
+   */
+  readonly rootTransform: readonly number[] | null;
+  readonly provenance: CloudFrameProvenance;
+}
+
+/**
+ * Resolve the frame a STREAMED tileset's tiles should be placed in.
+ *
+ * The same decision `resolveTilesetFrame` makes, expressed as the matrix the
+ * streaming path needs, so the transform that is APPLIED and the provenance
+ * that is RECORDED come out of one call and cannot disagree. A caller that
+ * asked for them separately could rotate without recording it, or record a
+ * levelled frame it never applied.
+ *
+ * `anchor` is the centre of the ROOT bounding volume rather than of the loaded
+ * points: a streaming resident set changes as the camera moves, and an anchor
+ * that moved with it would give the same tile different render coordinates on
+ * different frames.
+ */
+export function resolveStreamingTilesetFrame(
+  tileset: Tileset,
+  anchor: Vec3 | null,
+): StreamingTilesetFrame {
+  const established = establishedTilesetFrame(tileset, anchor);
+  return {
+    rootTransform: established === null ? null : enuFrameMatrix(established.anchor),
+    provenance: frameProvenanceOf(established),
   };
 }
 

--- a/src/render/streaming/StreamingSource.ts
+++ b/src/render/streaming/StreamingSource.ts
@@ -22,6 +22,7 @@
  */
 
 import type { Box6, StreamingNodeRecord } from '../../io/copc/copcTypes';
+import type { CloudFrameProvenance } from '../../geo/frame/frameProvenance';
 import type { SpatialFrame } from '../../geo/frame/spatialFrame';
 import type { ChunkDecodeMetadata } from '../../io/copc/copcChunkDecode';
 import type { PntsDecodeMetadata } from '../../io/tiles3d/pntsDecode';
@@ -160,6 +161,30 @@ export interface StreamingSource {
    * so refuses rather than reporting a coordinate off by hundreds of metres.
    */
   readonly frame: SpatialFrame;
+  /**
+   * What the SOURCE DOCUMENT established about the frame, as opposed to the
+   * conversion {@link frame} performs.
+   *
+   * The two answer different questions. `frame` always exists, because every
+   * source has to put its points somewhere; this says whether the document ever
+   * stated which way is up. A 3D Tiles tileset with only a `box` bounding
+   * volume declares nothing, so it records `basis: 'unknown'` and no vertical
+   * reference, and the Scan Report can say so. Absent that record, a tileset
+   * whose up axis was never established is indistinguishable from one whose
+   * was: both recentre, both fit the camera, both draw.
+   *
+   * UNKNOWN IS A VALUE, NOT AN ABSENT ONE. A source that asked and could not
+   * establish the frame records `basis: 'unknown'`. Omitting the property is a
+   * different statement — "this source has not been taught to answer yet" —
+   * and consumers must not read one as the other.
+   *
+   * Optional only because the COPC, EPT and OLV-tile sources predate it and
+   * settling what those three declare is a separate question (a projected-CRS
+   * COPC has a known up that this record's two-value basis cannot yet express).
+   * `tests/streamingFrameProvenance.test.ts` holds the shrink-only list of
+   * sources still omitting it, so a NEW source cannot join them silently.
+   */
+  readonly frameProvenance?: CloudFrameProvenance;
   /** The runtime octree — nodes, state, scoring inputs. */
   readonly octree: StreamingOctreeView;
   /**

--- a/src/render/streaming/TilesetStreamingSource.ts
+++ b/src/render/streaming/TilesetStreamingSource.ts
@@ -26,14 +26,18 @@
 
 import type { Box6, StreamingNodeRecord } from '../../io/copc/copcTypes';
 import type { CrsInfo } from '../../io/crs';
-import type { SpatialFrame } from '../../geo/frame/spatialFrame';
+import type { SpatialFrame, Vec3 } from '../../geo/frame/spatialFrame';
 import { createTranslatedFrame } from '../../geo/frame/spatialFrame';
+import type { CloudFrameProvenance } from '../../geo/frame/frameProvenance';
 import type { Mat4 } from '../../io/tiles3d/tileTransform';
 import type { TilesetTransport } from '../../io/tiles3d/tilesetTransport';
 import { PNTS_COLOR_MODES, type PntsDecodeMetadata } from '../../io/tiles3d/pntsDecode';
 import { tilesetNodes, type TilesetNodeIndex } from '../../io/tiles3d/tilesetNodes';
 import { volumeToAabb } from '../../io/tiles3d/tilesetTraversal';
-import { declaredTilesetFrame, enuFrameMatrix } from '../../io/tiles3d/tilesetFrame';
+import {
+  resolveStreamingTilesetFrame,
+  type StreamingTilesetFrame,
+} from '../../io/tiles3d/tilesetFrame';
 import type { Tileset } from '../../io/tiles3d/tileset';
 import { StreamingNodeStore } from './StreamingNodeStore';
 import type { NodeCounts } from './StreamingNodeStore';
@@ -61,16 +65,31 @@ import type {
  * the verticals read off it are wrong, which is a failure with no visual trace.
  */
 export function tilesetRootFrameMatrix(tileset: Tileset): Mat4 | null {
-  if (!declaredTilesetFrame(tileset).geocentric) return null;
+  return (tilesetRootFrame(tileset).rootTransform as Mat4 | null) ?? null;
+}
+
+/**
+ * The root transform AND the record of how it was arrived at, from one call.
+ *
+ * Asking for the two separately is how a tileset ends up rotated and recorded
+ * as unrotated, or recorded as levelled while its tiles stayed in ECEF. The
+ * resolver decides once and returns both.
+ *
+ * The anchor is the centre of the ROOT bounding volume, fixed by the document,
+ * so the rotation is the same on every run and at every camera position — a
+ * streaming reader's resident set is not.
+ */
+export function tilesetRootFrame(tileset: Tileset): StreamingTilesetFrame {
   const aabb = volumeToAabb(tileset.root.boundingVolume);
-  if (aabb == null) return null;
-  const anchor: [number, number, number] = [
-    (aabb.min[0] + aabb.max[0]) / 2,
-    (aabb.min[1] + aabb.max[1]) / 2,
-    (aabb.min[2] + aabb.max[2]) / 2,
-  ];
-  if (!anchor.every(Number.isFinite) || Math.hypot(...anchor) === 0) return null;
-  return enuFrameMatrix(anchor) as Mat4;
+  const anchor: Vec3 | null =
+    aabb == null
+      ? null
+      : [
+          (aabb.min[0] + aabb.max[0]) / 2,
+          (aabb.min[1] + aabb.max[1]) / 2,
+          (aabb.min[2] + aabb.max[2]) / 2,
+        ];
+  return resolveStreamingTilesetFrame(tileset, anchor);
 }
 
 /** The union of every node's bounds, or null when there are no nodes. */
@@ -120,6 +139,16 @@ export class TilesetStreamingSource implements StreamingSource {
   readonly kind: StreamingSourceKind = '3dtiles';
   readonly renderOrigin: [number, number, number];
   readonly frame: SpatialFrame;
+  /**
+   * What this document actually said about its root frame.
+   *
+   * A tileset carrying only a `box` or a `sphere` declares nothing, so `basis`
+   * is `unknown` and there is no vertical reference. That is a fact the source
+   * states rather than one a consumer has to re-derive, and it is the only
+   * thing separating a tileset whose up axis was established from one whose was
+   * not — the two draw identically.
+   */
+  readonly frameProvenance: CloudFrameProvenance;
   readonly octree: StreamingOctreeView;
 
   readonly id: string;
@@ -145,12 +174,22 @@ export class TilesetStreamingSource implements StreamingSource {
     this._crs = crs;
     // Resolved here rather than by the caller: a caller that forgets leaves a
     // geocentric tileset in ECEF, and nothing on screen says so.
+    const resolved = tilesetRootFrame(tileset);
+    // An injected transform is not something the document declared, so the
+    // document's declaration no longer describes the render coordinates and the
+    // frame goes back to unestablished. Recording the document's answer beside
+    // somebody else's transform is the mismatch this whole record exists to
+    // prevent.
+    this.frameProvenance =
+      rootTransform === undefined
+        ? resolved.provenance
+        : { basis: 'unknown', declaredBy: null, verticalReference: 'unknown', linearUnit: 'metre' };
     // The entry URL is passed so every content URI is resolved and VALIDATED
     // before a tile is fetched. Without it the index would hand the transport
     // whatever the document wrote.
     this._index = tilesetNodes(
       tileset,
-      rootTransform ?? tilesetRootFrameMatrix(tileset) ?? undefined,
+      rootTransform ?? (resolved.rootTransform as Mat4 | null) ?? undefined,
       baseUrl,
     );
     this._bounds = unionBounds(this._index.records) ?? [0, 0, 0, 0, 0, 0];

--- a/tests/streamingFrameProvenance.test.ts
+++ b/tests/streamingFrameProvenance.test.ts
@@ -1,0 +1,78 @@
+/**
+ * streamingFrameProvenance.test.ts — a new streaming source cannot quietly
+ * decline to say what its document established about up.
+ *
+ * `StreamingSource.frameProvenance` is optional in the type, and only because
+ * three sources predate it: settling what a projected-CRS COPC, an EPT pyramid
+ * or an OLV tile store declares is a separate question from the 3D Tiles one,
+ * and answering it by guessing would put a fabricated vertical reference in
+ * front of a user.
+ *
+ * Optional in the type means a source added tomorrow could omit the property
+ * and nothing would complain — which is exactly the regression this whole area
+ * is about, one level up. So the omission is a LIST, and the list is
+ * shrink-only: adding a source without the record fails here, and teaching one
+ * of the three to answer is a deletion from the list.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC = fileURLToPath(new URL('../src', import.meta.url));
+
+/**
+ * Sources that predate the record and are not covered by this change. Anything
+ * ADDED here is a source whose vertical reference nobody can read, so this list
+ * may shrink and never grow.
+ */
+const WITHOUT_RECORD = [
+  'io/heavy/OlvTileSource.ts',
+  'render/streaming/EptStreamingPointCloud.ts',
+  'render/streaming/StreamingPointCloud.ts',
+];
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...tsFiles(full));
+    else if (entry.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+/** Every file declaring a class that implements the streaming contract. */
+function implementers(): { path: string; text: string }[] {
+  return tsFiles(SRC)
+    .map((path) => ({ path, text: readFileSync(path, 'utf8') }))
+    .filter((f) => /class\s+\w+\s+implements\s+StreamingSource\b/.test(f.text))
+    .map((f) => ({ path: relative(SRC, f.path).split('\\').join('/'), text: f.text }));
+}
+
+describe('every streaming source states its frame provenance', () => {
+  it('finds the implementations at all, so a silent zero cannot pass', () => {
+    expect(implementers().length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('declares frameProvenance, unless it is on the shrink-only list', () => {
+    const missing = implementers()
+      .filter((f) => !/\bframeProvenance\b/.test(f.text))
+      .map((f) => f.path)
+      .sort();
+    expect(
+      missing,
+      'a streaming source with no frame record is indistinguishable from one ' +
+        'whose up axis was established; add the record rather than the file',
+    ).toEqual([...WITHOUT_RECORD].sort());
+  });
+
+  it('keeps the exemption list shrink-only', () => {
+    expect(
+      WITHOUT_RECORD.length,
+      'the list grew, which means a new source shipped without saying whether ' +
+        'its heights are measured along a known up',
+    ).toBeLessThanOrEqual(3);
+  });
+});

--- a/tests/tilesetFrameUnknown.test.ts
+++ b/tests/tilesetFrameUnknown.test.ts
@@ -99,6 +99,12 @@ function deps() {
       revealStreamingChrome: () => {},
       stage: { hideEmptyState: () => {} },
       inspector: { setReport },
+      // Added by the scan-detection work after this fake was written. The open
+      // calls all three before it publishes the report, so a fake without them
+      // throws and the report never reaches the Inspector at all.
+      setLastStreamingReportCloud: vi.fn(),
+      runStreamingModules: () => [],
+      classLegendPanel: { getVisibility: () => ({ isFiltered: false }) },
       inspectorCards: { refreshProvenanceFromStreaming: () => {} },
       crsCoordinator: { refreshCrsForStreamingCloud: () => {} },
       streamingPanel: {

--- a/tests/tilesetFrameUnknown.test.ts
+++ b/tests/tilesetFrameUnknown.test.ts
@@ -1,0 +1,206 @@
+/**
+ * tilesetFrameUnknown.test.ts — a streamed tileset says whether it ever
+ * established which way is up.
+ *
+ * A `region` bounding volume is the only in-spec way a 3D Tiles document
+ * declares that its root frame is WGS84 geocentric. A document carrying only a
+ * `box` or a `sphere` declares nothing, so its up axis is genuinely unknown and
+ * every height, slope and terrain derivative read off it is measured along an
+ * axis that may not be vertical. The scene draws identically either way, which
+ * is why this has to be stated rather than seen.
+ *
+ * The merged reader recorded that on the cloud and raised a load warning. The
+ * streaming replacement recorded nothing, so an unestablished tileset looked
+ * exactly like an established one. These cases pin both halves back on: the
+ * record on the source, and the notice on the surface a user reads.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { openRemoteTileset } from '../src/app/openTilesetLayer';
+import { TilesetStreamingSource } from '../src/render/streaming/TilesetStreamingSource';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import { FRAME_UNKNOWN_NOTE } from '../src/geo/frame/frameProvenance';
+import { REGION_DECLARES_GEOCENTRIC } from '../src/io/tiles3d/tilesetFrame';
+import type { TilesetTransport } from '../src/io/tiles3d/tilesetTransport';
+
+const DEG = Math.PI / 180;
+
+/** A box declares nothing about the frame the coordinates are in. */
+const BOX_DOC = JSON.stringify({
+  asset: { version: '1.0' },
+  geometricError: 100,
+  root: {
+    boundingVolume: { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] },
+    geometricError: 50,
+    refine: 'REPLACE',
+    content: { uri: 'r.pnts' },
+  },
+});
+
+/**
+ * A region is stated in EPSG:4979 and is the one volume the tile transform does
+ * not apply to, so carrying one IS the declaration. Monterrey, where the polar
+ * axis and local up are 64.3 degrees apart.
+ */
+const REGION_DOC = JSON.stringify({
+  asset: { version: '1.0' },
+  geometricError: 100,
+  root: {
+    boundingVolume: {
+      region: [-100.32 * DEG, 25.68 * DEG, -100.31 * DEG, 25.69 * DEG, 500, 580],
+    },
+    geometricError: 50,
+    refine: 'REPLACE',
+    content: { uri: 'r.pnts' },
+  },
+});
+
+function transport(): TilesetTransport {
+  return {
+    fetchTilesetJson: async () => '{}',
+    fetchTileBytes: async () => new ArrayBuffer(8),
+  };
+}
+
+function sourceFor(doc: string): TilesetStreamingSource {
+  return new TilesetStreamingSource(
+    'id',
+    'n',
+    'https://host/d/tileset.json',
+    transport(),
+    parseTileset(doc),
+  );
+}
+
+/** Deps thin enough to open with, recording what reached the Scan Report. */
+function deps() {
+  const viewer = {
+    clouds: () => [],
+    attachStreamingCloud: vi.fn(async () => {}),
+    setMode: vi.fn(),
+    frameAll: vi.fn(),
+  };
+  const setReport = vi.fn();
+  return {
+    setReport,
+    d: {
+      isLoading: () => false,
+      setLoading: () => {},
+      viewerReady: Promise.resolve(),
+      getViewer: () => viewer,
+      getStreamingQuality: () => 'balanced',
+      getStreamingBenchmark: () => null,
+      isPhone: () => false,
+      showToast: () => {},
+      debug: false,
+      closeStreaming: () => {},
+      clearOpenStaticLayers: () => {},
+      startStreamingStatusPolling: () => {},
+      revealStreamingChrome: () => {},
+      stage: { hideEmptyState: () => {} },
+      inspector: { setReport },
+      inspectorCards: { refreshProvenanceFromStreaming: () => {} },
+      crsCoordinator: { refreshCrsForStreamingCloud: () => {} },
+      streamingPanel: {
+        setColorModes: vi.fn(),
+        setQuality: () => {},
+        setSourceUrl: () => {},
+        setPhase: () => {},
+      },
+      dropZone: {
+        setOpening: () => {},
+        setCancelHandler: () => {},
+        setProgress: () => {},
+        setError: vi.fn(),
+      },
+    },
+  };
+}
+
+/** Serve the tileset document without touching the network. */
+function withTransport<T>(doc: string, run: () => Promise<T>): Promise<T> {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: unknown) => {
+    const url = String(input);
+    if (url.endsWith('tileset.json')) {
+      return new Response(doc, { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(new ArrayBuffer(0), { status: 404 });
+  }) as unknown as typeof fetch;
+  return run().finally(() => {
+    globalThis.fetch = realFetch;
+  });
+}
+
+/** Everything the open path wrote to the Scan Report, as one blob of text. */
+async function reportTextFor(doc: string): Promise<string> {
+  const t = deps();
+  await withTransport(doc, () =>
+    openRemoteTileset('https://host/d/tileset.json', undefined, t.d as never),
+  );
+  return t.setReport.mock.calls
+    .flatMap((call) => (call[0] as { label: string; value: string }[]) ?? [])
+    .map((row) => `${row.label}: ${row.value}`)
+    .join('\n');
+}
+
+describe('a tileset that declares no geocentric frame', () => {
+  it('records that its frame was never established', () => {
+    const p = sourceFor(BOX_DOC).frameProvenance;
+    expect(
+      p,
+      'no record at all reads as "nobody asked", which is a different fact from ' +
+        '"asked and could not be established"',
+    ).not.toBeNull();
+    expect(p!.basis).toBe('unknown');
+    expect(p!.declaredBy).toBeNull();
+    expect(p!.verticalReference).toBe('unknown');
+    // The unit survives an unresolved frame: 3D Tiles states metres regardless.
+    expect(p!.linearUnit).toBe('metre');
+  });
+
+  it('says so on the Scan Report, where a user deciding on an elevation looks', async () => {
+    expect(
+      await reportTextFor(BOX_DOC),
+      'a field nobody reads leaves the user unable to tell an unestablished ' +
+        'tileset from an established one',
+    ).toContain(FRAME_UNKNOWN_NOTE);
+  });
+});
+
+describe('a tileset that declares a region', () => {
+  it('records the frame it established, and what established it', () => {
+    const p = sourceFor(REGION_DOC).frameProvenance;
+    expect(p).not.toBeNull();
+    expect(p!.basis).toBe('local-enu');
+    expect(p!.declaredBy).toBe(REGION_DECLARES_GEOCENTRIC);
+    expect(p!.anchor, 'without the anchor the frame is applied but not reversible').toBeDefined();
+  });
+
+  it('raises no unknown-frame notice', async () => {
+    expect(
+      await reportTextFor(REGION_DOC),
+      'crying wolf on a tileset that did declare its frame trains the user to ' +
+        'ignore the notice that matters',
+    ).not.toContain(FRAME_UNKNOWN_NOTE);
+  });
+});
+
+describe('what a region does NOT establish', () => {
+  it('records an ellipsoidal vertical reference, never an orthometric datum', () => {
+    const p = sourceFor(REGION_DOC).frameProvenance;
+    expect(
+      p!.verticalReference,
+      'an ENU frame tangent to the WGS84 ellipsoid gives heights above that ' +
+        'ellipsoid; 3D Tiles carries no vertical datum',
+    ).toBe('ellipsoidal');
+  });
+
+  it('does not name a geoid or an orthometric datum on the Scan Report', async () => {
+    const text = (await reportTextFor(REGION_DOC)).toLowerCase();
+    expect(text).toContain('ellipsoidal');
+    for (const lie of ['orthometric', 'geoid', 'egm', 'navd', 'mean sea level', 'msl']) {
+      expect(text, `the report claims ${lie}, which the document never stated`).not.toContain(lie);
+    }
+  });
+});


### PR DESCRIPTION
A streamed 3D Tiles tileset set a translated frame and recorded nothing the
document declared, so one whose up axis was never established looked identical
to one whose was. `TilesetStreamingSource` now carries a `CloudFrameProvenance`
resolved through `declaredTilesetFrame`, and the tileset open path writes it to
the Scan Report. A document with only a box or sphere bounding volume gets a
warn row and `FRAME_UNKNOWN_NOTE`. A document with a region gets the
established frame plus the declaration that fixed it, as an ellipsoidal
vertical reference and never an orthometric datum. The root transform and the
record now come from one resolver, so the rotation applied and the frame
recorded cannot disagree. `frameProvenance` is optional on `StreamingSource`
because the COPC, EPT and OLV-tile sources predate it; a shrink-only test holds
that list.
