### PR TITLE
fix(3dtiles): one colour meaning per streaming tileset layer

### DIFF
--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -139,7 +139,13 @@ export async function openRemoteTileset(
     const replacingStatic = viewer.clouds().length > 0;
     await viewer.attachStreamingCloud(
       cloud,
-      new PntsChunkDecoder(),
+      // The decoder settles this layer's colour meaning on its first tile with
+      // points, so a mixed tileset stays honest on screen without this. What the
+      // sink adds is the reason: a user who dropped a coloured tileset and sees a
+      // grey patch is owed the explanation rather than left to guess at it. It
+      // fires at most once per layer, on the first disagreeing tile, which can be
+      // long after this function has returned.
+      new PntsChunkDecoder({ onColourNotice: (message) => deps.showToast(message) }),
       deps.getStreamingQuality(),
       deps.isPhone(),
       deps.getStreamingBenchmark(),

--- a/src/io/tiles3d/pntsDecode.ts
+++ b/src/io/tiles3d/pntsDecode.ts
@@ -23,6 +23,24 @@
  * float64 before the float32 store, which is the same order the LAS path uses
  * and the reason a city-scale tileset does not lose precision at the far edge.
  *
+ * ONE COLOUR MEANING PER LAYER. A point tile states colour per tile: some tiles
+ * of a tileset can carry RGB while others carry none, and the document says
+ * nothing about which. The reader that merged a whole tileset in one pass could
+ * see every tile before it painted anything, and kept colour only when EVERY
+ * tile carried it. A streaming reader sees one tile at a time, so that check
+ * cannot be made up front. It is made here instead, by the decoder that serves
+ * one layer: the first tile with points settles whether the layer's colour is
+ * the colour tiles state or the elevation ramp, and every tile after it is
+ * drawn in THAT meaning. A tile that disagrees is never re-interpreted into the
+ * other meaning, and the mixture is reported through {@link
+ * PntsChunkDecoderOptions.onColourNotice} rather than left for a viewer to
+ * misread as one meaning.
+ *
+ * Nothing is fabricated to make that work. A tile with no colour keeps no
+ * `rgb`, so the point inspector, the resident-snapshot export and the patch
+ * view all keep reading "this states no colour"; only the on-screen colour
+ * buffer is filled, and only flat.
+ *
  * Pure: no fetch, no DOM.
  */
 
@@ -66,13 +84,129 @@ function applyMatrix(
   ];
 }
 
+/** What one decoded tile said about colour. */
+export type TileColourState = 'colour' | 'no-colour';
+
+/**
+ * One tileset layer's colour meaning, folded from the tiles decoded so far.
+ *
+ * `settled` is what the first tile with points established, and it never
+ * changes after that. That fixity is the guard, not an implementation detail:
+ * nodes already uploaded to the scene cannot be repainted from here, so a
+ * meaning that could change would leave the earlier nodes carrying the old one
+ * beside nodes carrying the new one, which is the failure this exists to
+ * prevent.
+ */
+export interface TilesetColourConsensus {
+  /** The layer's one colour meaning, or null before any tile with points. */
+  readonly settled: TileColourState | null;
+  /** How many tiles disagreed with it. */
+  readonly disagreeing: number;
+}
+
+/** No tile decoded yet, so the layer's colour meaning is not established. */
+export const NO_TILE_DECODED: TilesetColourConsensus = { settled: null, disagreeing: 0 };
+
+/**
+ * Fold one decoded tile into a layer's colour consensus. Pure.
+ *
+ * An empty tile leaves the consensus alone. It states nothing about colour
+ * either way, and letting one settle the meaning would hand every tile after it
+ * a decision made from no points.
+ */
+export function noteTileColour(
+  state: TilesetColourConsensus,
+  tile: { readonly pointCount: number; readonly hasColour: boolean },
+): TilesetColourConsensus {
+  if (tile.pointCount <= 0) return state;
+  const seen: TileColourState = tile.hasColour ? 'colour' : 'no-colour';
+  if (state.settled === null) return { settled: seen, disagreeing: 0 };
+  if (state.settled === seen) return state;
+  return { settled: state.settled, disagreeing: state.disagreeing + 1 };
+}
+
+/**
+ * What a user is told when the layer's colour is the colour tiles state and
+ * some tiles state none. Those tiles are drawn flat, so the scene holds one
+ * colour meaning plus a visibly blank stand-in for the tiles that have nothing
+ * to show, rather than two meanings that look alike.
+ */
+export const MIXED_TILE_COLOUR_KEPT_NOTICE =
+  'Some tiles in this tileset carry colour and others do not. The tiles that ' +
+  'state no colour are drawn flat grey rather than ramped by height, so the ' +
+  'scene keeps one colour meaning.';
+
+/**
+ * What a user is told when the layer's colour is the elevation ramp and some
+ * tiles do carry colour. Their colour is withheld, which is the rule the merged
+ * reader enforced when it could read every tile at once.
+ */
+export const MIXED_TILE_COLOUR_DROPPED_NOTICE =
+  'Some tiles in this tileset carry colour and others do not. No tile colour ' +
+  'is used and the whole layer is drawn by the elevation ramp, so the scene ' +
+  'keeps one colour meaning.';
+
+/** The notice for a mixed tileset, or null while every tile has agreed. */
+export function tilesetColourNotice(state: TilesetColourConsensus): string | null {
+  if (state.disagreeing === 0) return null;
+  return state.settled === 'colour'
+    ? MIXED_TILE_COLOUR_KEPT_NOTICE
+    : MIXED_TILE_COLOUR_DROPPED_NOTICE;
+}
+
+/**
+ * A decoded tile that states no colour, inside a layer whose colour meaning IS
+ * the colour tiles state.
+ *
+ * `rgb` stays ABSENT: the mark is not a colour and never becomes one in the
+ * data model. It exists so the renderer can draw the node flat instead of
+ * ramping it by height beside neighbours painted from their own RGB, which is a
+ * display decision and belongs nowhere else.
+ */
+export interface ColourUnstatedChunk extends DecodedChunk {
+  readonly colourUnstated: true;
+}
+
+/** Construction options for {@link PntsChunkDecoder}. */
+export interface PntsChunkDecoderOptions {
+  /**
+   * Called once, with the notice text, the first time a tile disagrees with the
+   * layer's settled colour. The decoder owns no user surface, so the shell
+   * passes one in; without it the layer still holds one colour meaning, and
+   * nothing says why.
+   */
+  readonly onColourNotice?: (message: string) => void;
+}
+
 /**
  * Decode a `.pnts` body into a chunk the streaming renderer can store.
+ *
+ * One instance serves one tileset layer, which is what lets it hold that
+ * layer's colour meaning across the tiles it decodes. Construct a fresh one per
+ * layer.
  *
  * Throws when handed metadata for another format rather than guessing, since a
  * mis-routed body would decode into plausible-looking rubbish.
  */
 export class PntsChunkDecoder implements ChunkDecoder {
+  private readonly _onColourNotice: ((message: string) => void) | undefined;
+  private _colour: TilesetColourConsensus = NO_TILE_DECODED;
+  private _noticed = false;
+
+  constructor(options: PntsChunkDecoderOptions = {}) {
+    this._onColourNotice = options.onColourNotice;
+  }
+
+  /** The layer's colour meaning as the tiles decoded so far have settled it. */
+  get colourConsensus(): TilesetColourConsensus {
+    return this._colour;
+  }
+
+  /** The mixed-tileset notice, or null while every tile has agreed. */
+  get colourNotice(): string | null {
+    return tilesetColourNotice(this._colour);
+  }
+
   async decode(chunk: ArrayBuffer, meta: unknown): Promise<DecodedChunk> {
     if (!isPntsMetadata(meta)) {
       throw new Error('PntsChunkDecoder was handed metadata for another format.');
@@ -101,7 +235,15 @@ export class PntsChunkDecoder implements ChunkDecoder {
       positions[j + 2] = wz - oz;
     }
 
-    return {
+    // The layer's colour meaning, settled by the first tile with points and
+    // fixed from then on. See the note at the top of this file.
+    this._colour = noteTileColour(this._colour, {
+      pointCount: n,
+      hasColour: tile.colors !== null,
+    });
+    this._raiseColourNoticeOnce();
+
+    const decoded: DecodedChunk = {
       pointCount: n,
       positions,
       // Not readings. See the note at the top of this file: the chunk type
@@ -111,8 +253,28 @@ export class PntsChunkDecoder implements ChunkDecoder {
       returnNumber: new Uint8Array(n),
       returnCount: new Uint8Array(n),
       gpsTime: new Float64Array(n),
-      ...(tile.colors ? { rgb: tile.colors } : {}),
     };
+    if (this._colour.settled !== 'colour') {
+      // The layer is drawn by the elevation ramp. A tile that does carry colour
+      // has it withheld rather than painted beside ramped neighbours, because
+      // half a scene in stated colour and half in a height ramp is two
+      // meanings. Withholding states nothing false.
+      return decoded;
+    }
+    if (tile.colors !== null) return { ...decoded, rgb: tile.colors };
+    // Nothing to show and nothing invented: `rgb` stays absent, and the mark
+    // only tells the renderer to draw this node flat.
+    const unstated: ColourUnstatedChunk = { ...decoded, colourUnstated: true };
+    return unstated;
+  }
+
+  /** Report the mixture the first time one appears, and only then. */
+  private _raiseColourNoticeOnce(): void {
+    if (this._noticed) return;
+    const notice = tilesetColourNotice(this._colour);
+    if (notice === null) return;
+    this._noticed = true;
+    this._onColourNotice?.(notice);
   }
 }
 

--- a/src/render/streaming/streamingColors.ts
+++ b/src/render/streaming/streamingColors.ts
@@ -23,6 +23,10 @@ import { densityForChunk, defaultCellSizeForSpacing } from '../densityColors';
 import type { DecodedChunk } from '../../io/copc/copcChunkDecode';
 import { renderLocalPositions } from '../../model/pointFrames';
 import type { CopcMetadata } from '../../io/copc/copcTypes';
+// Type-only: the shape a `.pnts` decoder marks a colourless node with. No
+// runtime import, so the streaming colour chunk does not pull in the tileset
+// parser, and the io layer keeps its own definition of what it produced.
+import type { ColourUnstatedChunk } from '../../io/tiles3d/pntsDecode';
 import { applyRgbAppearance, type RgbAppearance } from '../rgbAppearance';
 
 /**
@@ -40,6 +44,29 @@ import { applyRgbAppearance, type RgbAppearance } from '../rgbAppearance';
  */
 let _rgbWorkFloat: Float32Array | null = null;
 let _rgbWorkOut: Uint8Array | null = null;
+
+/**
+ * The grey a node is drawn in when its tile states no colour and the rest of
+ * the layer does.
+ *
+ * Mid grey is achromatic, and the elevation ramp (Turbo) is not: nothing the
+ * ramp produces looks like this, so a flat patch cannot be misread as a height
+ * reading. It is a display value only. `rgb` stays absent on the chunk, so the
+ * point inspector, the resident-snapshot export and the patch view all keep
+ * reporting that these points state no colour.
+ */
+export const UNSTATED_COLOUR_GREY = 128;
+
+/**
+ * Whether a decoded node is one a `.pnts` decoder marked as stating no colour
+ * inside a layer whose colour meaning is the colour tiles state.
+ *
+ * Read through the marker type rather than a loose string, so renaming the mark
+ * breaks the build instead of silently turning this back into a height ramp.
+ */
+function colourUnstated(decoded: DecodedChunk): boolean {
+  return (decoded as Partial<ColourUnstatedChunk>).colourUnstated === true;
+}
 
 /** Cloud-global colour ranges, so every streaming node colours consistently. */
 export interface StreamingColorRanges {
@@ -132,6 +159,17 @@ export function streamingNodeColors(
     case 'rgb': {
       const src = decoded.rgb;
       if (!src) {
+        // A node marked as stating no colour belongs to a layer whose other
+        // nodes ARE painted from their stated RGB. Ramping it by height would
+        // put a second colour meaning in the same scene, reading as the first.
+        // It is drawn flat instead, and the reader says why (see the mixed
+        // tileset notices in `pntsDecode.ts`).
+        if (colourUnstated(decoded)) {
+          return new Uint8Array(n * 3).fill(UNSTATED_COLOUR_GREY);
+        }
+        // Otherwise the whole source lacks RGB (a COPC/EPT format flag says so,
+        // or every tile of a tileset stated none), so the elevation ramp is the
+        // layer's one meaning rather than a second one.
         return colorByElevation(renderLocalPositions(decoded), n, ranges.minZ, ranges.maxZ);
       }
       // When an appearance bundle is active, apply it in sRGB float

--- a/tests/pntsDecode.test.ts
+++ b/tests/pntsDecode.test.ts
@@ -114,12 +114,15 @@ describe('attributes the format does not carry', () => {
   });
 
   it('carries RGB through when the tile has it, and omits it when it does not', async () => {
-    const withRgb = await decoder.decode(
+    // A decoder instance serves ONE tileset layer and holds that layer's colour
+    // meaning across the tiles it decodes (see tilesetMixedColour.test.ts), so
+    // each of these two tilesets gets its own.
+    const withRgb = await new PntsChunkDecoder().decode(
       makePnts([[0, 0, 0]], undefined, [[10, 20, 30]]),
       meta(),
     );
     expect([...(withRgb.rgb ?? [])]).toEqual([10, 20, 30]);
-    const without = await decoder.decode(makePnts([[0, 0, 0]]), meta());
+    const without = await new PntsChunkDecoder().decode(makePnts([[0, 0, 0]]), meta());
     expect(without.rgb).toBeUndefined();
   });
 });

--- a/tests/tilesetColourNoticeWiring.test.ts
+++ b/tests/tilesetColourNoticeWiring.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { PntsChunkDecoder } from '../src/io/tiles3d/pntsDecode';
+
+/**
+ * The mixed-colour guard settles a layer's colour meaning on its first tile with
+ * points and holds it. That keeps the scene honest on its own, but a user who
+ * dropped a coloured tileset and got a grey patch is owed the reason. The decoder
+ * reports it through `onColourNotice`; the open path has to pass one, or the
+ * guard is correct and silent.
+ *
+ * This reads the shipped source rather than driving a decode, because the wiring
+ * is one argument at one call site and the failure mode is that nobody passed it.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const openTilesetLayerSrc = readFileSync(
+  fileURLToPath(new URL('../src/app/openTilesetLayer.ts', import.meta.url)),
+  'utf8',
+);
+
+describe('the tileset open passes a colour notice sink', () => {
+  it('constructs the decoder with an onColourNotice callback', () => {
+    const construction = openTilesetLayerSrc.match(/new PntsChunkDecoder\([^;]{0,300}\),/);
+    expect(construction, 'openTilesetLayer no longer constructs a PntsChunkDecoder').not.toBeNull();
+    expect(
+      construction?.[0],
+      'the decoder is constructed with no colour-notice sink, so a mixed tileset ' +
+        'is drawn honestly and the user is never told why',
+    ).toMatch(/onColourNotice/);
+  });
+
+  it('routes it to a surface the user actually sees', () => {
+    const construction = openTilesetLayerSrc.match(/new PntsChunkDecoder\([^;]{0,300}\),/);
+    expect(construction?.[0]).toMatch(/showToast/);
+  });
+
+  it('the decoder still accepts the option it is handed', () => {
+    const seen: string[] = [];
+    expect(() => new PntsChunkDecoder({ onColourNotice: (m) => seen.push(m) })).not.toThrow();
+  });
+});

--- a/tests/tilesetMixedColour.test.ts
+++ b/tests/tilesetMixedColour.test.ts
@@ -1,0 +1,259 @@
+/**
+ * tilesetMixedColour.test.ts — one colour meaning per tileset layer.
+ *
+ * The merged 3D Tiles reader kept colour only when EVERY tile carried it, so a
+ * tileset mixing coloured and uncoloured tiles opened uncoloured and said so.
+ * The streaming reader decodes tiles one at a time and cannot inspect them all
+ * up front, and the rule was lost on the way across: a tile with no RGB fell
+ * back to the elevation ramp on its own, beside tiles painted from their stated
+ * RGB. Two colour meanings in one scene, with nothing said about it.
+ *
+ * A viewer reads a scene as ONE colour meaning. These tests pin that a tileset
+ * layer only ever has one, and that a mixture is named rather than drawn.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PntsChunkDecoder,
+  noteTileColour,
+  tilesetColourNotice,
+  NO_TILE_DECODED,
+  MIXED_TILE_COLOUR_KEPT_NOTICE,
+  MIXED_TILE_COLOUR_DROPPED_NOTICE,
+  type PntsDecodeMetadata,
+} from '../src/io/tiles3d/pntsDecode';
+import {
+  streamingNodeColors,
+  UNSTATED_COLOUR_GREY,
+  type StreamingColorRanges,
+} from '../src/render/streaming/streamingColors';
+import { colorByElevation } from '../src/render/colorModes';
+import { renderLocalPositions } from '../src/model/pointFrames';
+
+const PNTS_MAGIC = 0x73746e70;
+
+/** A minimal valid `.pnts` body, optionally carrying per-point RGB. */
+function makePnts(
+  points: readonly (readonly [number, number, number])[],
+  rgb?: readonly (readonly [number, number, number])[],
+): ArrayBuffer {
+  const posBytes = points.length * 3 * 4;
+  const ft: Record<string, unknown> = {
+    POINTS_LENGTH: points.length,
+    POSITION: { byteOffset: 0 },
+  };
+  if (rgb) ft.RGB = { byteOffset: posBytes };
+  let json = JSON.stringify(ft);
+  while (json.length % 8 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const binBytes = posBytes + (rgb ? points.length * 3 : 0);
+  const total = 28 + jsonBytes.length + binBytes;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, PNTS_MAGIC, true);
+  view.setUint32(4, 1, true);
+  view.setUint32(8, total, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, binBytes, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buf, 28, jsonBytes.length).set(jsonBytes);
+  const binStart = 28 + jsonBytes.length;
+  let k = 0;
+  for (const p of points) for (const c of p) view.setFloat32(binStart + k++ * 4, c, true);
+  if (rgb) {
+    const bytes = new Uint8Array(buf, binStart + posBytes, points.length * 3);
+    let j = 0;
+    for (const c of rgb) for (const v of c) bytes[j++] = v;
+  }
+  return buf;
+}
+
+const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+const META: PntsDecodeMetadata = {
+  format: 'pnts',
+  tileTransform: IDENTITY,
+  renderOrigin: [0, 0, 0],
+};
+
+/** Two points at opposite ends of the layer's height span. */
+const LOW_AND_HIGH: readonly (readonly [number, number, number])[] = [
+  [0, 0, 0],
+  [0, 0, 100],
+];
+/** Colour the tile states for those two points. */
+const STATED: readonly (readonly [number, number, number])[] = [
+  [200, 10, 10],
+  [10, 200, 10],
+];
+const STATED_BYTES = Uint8Array.from([200, 10, 10, 10, 200, 10]);
+
+const RANGES: StreamingColorRanges = {
+  minZ: 0,
+  maxZ: 100,
+  minIntensity: 0,
+  maxIntensity: 1,
+  minGpsTime: 0,
+  maxGpsTime: 1,
+  minReturnNumber: 0,
+  maxReturnNumber: 1,
+};
+
+function sameBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/** The colours a node is given, copied out of the shared scratch buffer. */
+function paint(chunk: Parameters<typeof streamingNodeColors>[1]): Uint8Array {
+  return Uint8Array.from(streamingNodeColors('rgb', chunk, RANGES));
+}
+
+describe('a tileset that mixes coloured and uncoloured tiles', () => {
+  it('never paints one tile from its stated colour and another by height', async () => {
+    // ONE decoder, because one decoder serves one tileset layer.
+    const decoder = new PntsChunkDecoder();
+    const coloured = await decoder.decode(makePnts(LOW_AND_HIGH, STATED), META);
+    const plain = await decoder.decode(makePnts(LOW_AND_HIGH), META);
+
+    const heightRamp = colorByElevation(
+      renderLocalPositions(plain),
+      plain.pointCount,
+      RANGES.minZ,
+      RANGES.maxZ,
+    );
+    const fromStatedColour = sameBytes(paint(coloured), STATED_BYTES);
+    const fromHeight = sameBytes(paint(plain), heightRamp);
+
+    expect(
+      fromStatedColour && fromHeight,
+      'one tile is painted from its stated colour and another by height, in the same scene',
+    ).toBe(false);
+  });
+
+  it('says so', async () => {
+    const decoder = new PntsChunkDecoder();
+    await decoder.decode(makePnts(LOW_AND_HIGH, STATED), META);
+    await decoder.decode(makePnts(LOW_AND_HIGH), META);
+
+    expect(
+      decoder.colourNotice,
+      'the mixture was not named anywhere a user could read it',
+    ).not.toBeNull();
+  });
+
+  it('raises the notice once, through the shell surface it was given', async () => {
+    const said: string[] = [];
+    const decoder = new PntsChunkDecoder({ onColourNotice: (m) => said.push(m) });
+    await decoder.decode(makePnts(LOW_AND_HIGH, STATED), META);
+    expect(said, 'nothing has disagreed yet').toEqual([]);
+    await decoder.decode(makePnts(LOW_AND_HIGH), META);
+    await decoder.decode(makePnts(LOW_AND_HIGH), META);
+    expect(said).toEqual([MIXED_TILE_COLOUR_KEPT_NOTICE]);
+  });
+
+  it('draws the tiles that state no colour flat, and keeps the stated colour', async () => {
+    const decoder = new PntsChunkDecoder();
+    const coloured = await decoder.decode(makePnts(LOW_AND_HIGH, STATED), META);
+    const plain = await decoder.decode(makePnts(LOW_AND_HIGH), META);
+
+    expect([...paint(coloured)]).toEqual([...STATED_BYTES]);
+    expect([...paint(plain)]).toEqual(Array<number>(6).fill(UNSTATED_COLOUR_GREY));
+  });
+
+  it('leaves rgb absent on a tile that states none, so no reading is invented', async () => {
+    const decoder = new PntsChunkDecoder();
+    await decoder.decode(makePnts(LOW_AND_HIGH, STATED), META);
+    const plain = await decoder.decode(makePnts(LOW_AND_HIGH), META);
+
+    // The flat grey is a colour BUFFER, not a colour reading. `residentSnapshot`
+    // and the point inspector both read `rgb`, and both must keep reporting
+    // that these points state no colour.
+    expect(plain.rgb).toBeUndefined();
+  });
+
+  it('withholds colour from a tile that has it when the layer is already ramped', async () => {
+    const decoder = new PntsChunkDecoder();
+    const plain = await decoder.decode(makePnts(LOW_AND_HIGH), META);
+    const coloured = await decoder.decode(makePnts(LOW_AND_HIGH, STATED), META);
+
+    const ramp = (c: typeof plain): Uint8Array =>
+      colorByElevation(renderLocalPositions(c), c.pointCount, RANGES.minZ, RANGES.maxZ);
+    expect([...paint(plain)]).toEqual([...ramp(plain)]);
+    expect(
+      [...paint(coloured)],
+      'a tile painted from its stated colour beside ramped neighbours',
+    ).toEqual([...ramp(coloured)]);
+    expect(coloured.rgb).toBeUndefined();
+    expect(decoder.colourNotice).toBe(MIXED_TILE_COLOUR_DROPPED_NOTICE);
+  });
+});
+
+describe('a tileset whose tiles all agree', () => {
+  it('renders in full stated RGB when every tile carries colour', async () => {
+    const decoder = new PntsChunkDecoder();
+    const first = await decoder.decode(makePnts(LOW_AND_HIGH, STATED), META);
+    const second = await decoder.decode(
+      makePnts(LOW_AND_HIGH, [
+        [1, 2, 3],
+        [4, 5, 6],
+      ]),
+      META,
+    );
+
+    expect([...paint(first)]).toEqual([...STATED_BYTES]);
+    expect([...paint(second)]).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(first.rgb, 'colour must survive a uniformly coloured tileset').toBeDefined();
+    expect(second.rgb).toBeDefined();
+    expect(decoder.colourNotice, 'nothing disagreed, so nothing to report').toBeNull();
+  });
+
+  it('uses the elevation ramp with no notice when no tile carries colour', async () => {
+    const decoder = new PntsChunkDecoder();
+    const first = await decoder.decode(makePnts(LOW_AND_HIGH), META);
+    const second = await decoder.decode(makePnts(LOW_AND_HIGH), META);
+
+    for (const c of [first, second]) {
+      expect([...paint(c)]).toEqual([
+        ...colorByElevation(renderLocalPositions(c), c.pointCount, RANGES.minZ, RANGES.maxZ),
+      ]);
+      expect(c.rgb).toBeUndefined();
+    }
+    expect(decoder.colourNotice, 'a uniformly uncoloured tileset is not a mixture').toBeNull();
+  });
+
+});
+
+describe('the colour consensus itself', () => {
+  const fold = (...tiles: boolean[]) =>
+    tiles.reduce(
+      (state, hasColour) => noteTileColour(state, { pointCount: 2, hasColour }),
+      NO_TILE_DECODED,
+    );
+
+  it('settles on the first tile with points and never moves', () => {
+    expect(fold(true, false, false, false).settled).toBe('colour');
+    expect(fold(false, true, true, true).settled).toBe('no-colour');
+  });
+
+  it('counts every tile that disagreed', () => {
+    expect(fold(true, false, false).disagreeing).toBe(2);
+    expect(fold(true, true, true).disagreeing).toBe(0);
+  });
+
+  it('ignores an empty tile entirely', () => {
+    // `parsePnts` refuses a body whose POINTS_LENGTH is zero, so this cannot
+    // arrive through the decoder today. The guard is here because a tile that
+    // states no points states nothing about colour either, and settling a whole
+    // layer's meaning on one would be a decision made from no data.
+    const after = noteTileColour(NO_TILE_DECODED, { pointCount: 0, hasColour: false });
+    expect(after).toBe(NO_TILE_DECODED);
+  });
+
+  it('names which colour the layer kept', () => {
+    expect(tilesetColourNotice(fold(true, false))).toBe(MIXED_TILE_COLOUR_KEPT_NOTICE);
+    expect(tilesetColourNotice(fold(false, true))).toBe(MIXED_TILE_COLOUR_DROPPED_NOTICE);
+    expect(tilesetColourNotice(fold(true, true))).toBeNull();
+  });
+});


### PR DESCRIPTION
The merged 3D Tiles reader kept colour only when every tile carried it, and
warned otherwise. Colour is a per-tile property, and the streaming reader
lost that rule: a tileset mixing coloured and uncoloured tiles drew some
nodes from stated RGB and others from the elevation ramp, in one scene,
silently.

A `PntsChunkDecoder` serves one layer, so it now holds that layer's colour
meaning. The first tile with points settles it, permanently: nodes already
uploaded cannot be repainted. A coloured tile in a ramped layer has its
colour withheld; an uncoloured tile in a coloured layer is drawn flat grey,
not ramped. `rgb` stays absent there, so the inspector and export still
report no stated colour.

`openTilesetLayer.ts` still builds the decoder without an `onColourNotice`
callback, so nothing is shown yet.
