### PR TITLE
feat(heavy): storage preflight for out-of-core indexing

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -159,6 +159,13 @@
       "review": "2027-02-28"
     },
     {
+      "path": "src/io/heavy/storagePreflight.ts",
+      "status": "staged",
+      "why": "The disk guard that must run before any file is routed to local indexing: it sizes the tile cache an out-of-core build would write from the declared point count and the record schema, then asks navigator.storage.estimate() whether that fits. Nothing routes a file to the indexer yet, so nothing calls it. It was added ahead of the routing on purpose, because a routing that lands without it fills a user's disk and then fails part-way through.",
+      "graduation": "The local open path calls storagePreflight before buildTileStoreFromLas and refuses on the verdict, arriving with tileStoreBuilder.",
+      "review": "2027-02-28"
+    },
+    {
       "path": "src/io/heavy/tileStoreBuilder.ts",
       "status": "staged",
       "why": "The one call from a LAS file to a streamable tile store. It is the top of the out-of-core cluster and has no non-test importer at all.",

--- a/src/io/heavy/octreeGrid.ts
+++ b/src/io/heavy/octreeGrid.ts
@@ -43,8 +43,15 @@ export interface OctreeGrid {
  */
 export const DEFAULT_MAX_DEPTH = 16;
 
-/** `ceil(log8(ratio))`, i.e. the octree depth whose `8 ** depth` leaves cover `ratio`. */
-function depthForRatio(ratio: number): number {
+/**
+ * `ceil(log8(ratio))`, i.e. the octree depth whose `8 ** depth` leaves cover
+ * `ratio`.
+ *
+ * Exported so a caller that has to predict the shape of a build BEFORE running
+ * it — the storage preflight, which sizes the cache an index would write —
+ * derives the depth from the same rule the build uses instead of restating it.
+ */
+export function depthForRatio(ratio: number): number {
   if (ratio <= 1) return 0;
   return Math.ceil(Math.log2(ratio) / 3);
 }

--- a/src/io/heavy/oocIndexer.ts
+++ b/src/io/heavy/oocIndexer.ts
@@ -82,7 +82,13 @@ export interface IndexOptions {
   readonly signal?: AbortSignal;
 }
 
-const DEFAULT_POINTS_PER_LEAF = 100_000;
+/**
+ * Target points per leaf when a caller names none. Exported so the storage
+ * preflight sizes a prospective index against the same figure the build will
+ * actually use; a preflight holding its own copy would go quietly wrong the day
+ * this one changed.
+ */
+export const DEFAULT_POINTS_PER_LEAF = 100_000;
 const DEFAULT_MEMORY_BUDGET = 64 * 1024 * 1024;
 /** The record when the source carries no attributes: three float32 xyz. */
 const POSITION_RECORD_BYTES = 12;

--- a/src/io/heavy/storagePreflight.ts
+++ b/src/io/heavy/storagePreflight.ts
@@ -1,0 +1,502 @@
+/**
+ * storagePreflight.ts — will the index this file needs actually fit on disk?
+ *
+ * Out-of-core indexing turns a scan the browser cannot hold into a tile store
+ * the browser writes to the Origin Private File System and streams back. That
+ * store is not small: it is a fixed-length record per point plus one file per
+ * octree node, and nothing about the compressed input bounds it. A 5 GB LAZ can
+ * carry four hundred million points, and four hundred million points at the
+ * record layout in `tileRecord.ts` is over 11 GB of cache. Routing that file to
+ * the indexer without asking first is how a viewer fills a user's disk and then
+ * fails at ninety-two percent, leaving the bytes it already wrote behind with no
+ * store to show for them.
+ *
+ * So the demand is computed from the POINT COUNT AND THE SCHEMA, which the LAS
+ * public header states before a record is read, never from the file size. The
+ * per-point figure comes from {@link tileRecordBytes}, so this module cannot
+ * drift from the layout it is predicting, and the node count comes from
+ * {@link depthForRatio} and {@link DEFAULT_POINTS_PER_LEAF} for the same reason.
+ *
+ * TWO HALVES, DELIBERATELY APART. {@link estimateIndexDiskDemand} and
+ * {@link decideStoragePreflight} are pure: same input, same answer, no browser.
+ * {@link readStorageEstimate} is the one impure seam, and it takes the navigator
+ * as an argument so the policy is testable in Node — the same split
+ * `io/workerPool/decodePoolSize.ts` uses for `navigator.hardwareConcurrency`.
+ *
+ * FAIL CLOSED. `navigator.storage.estimate()` is optional, approximate, and
+ * absent or throwing in exactly the contexts where a large write is most likely
+ * to be discarded. A missing estimate therefore REFUSES rather than proceeding:
+ * a guard that reads "could not check" as "checked and fine" is the fail-open
+ * null guard this repository already treats as a defect (compare `e57Refusal`,
+ * which refuses an E57 whose declaration will not parse rather than reading it
+ * unguarded). Refusing costs the user the out-of-core path, which is recoverable
+ * — the file still opens by the existing whole-file route, and COPC or EPT
+ * streams it without a cache at all. Proceeding wrongly costs them their disk.
+ *
+ * Nothing in the application calls this yet. It is the check that has to exist
+ * before any file is routed to local indexing, not the routing itself.
+ */
+
+import { formatByteSize } from '../formatByteSize';
+import { LoadError } from '../loadErrors';
+import { DEFAULT_POINTS_PER_LEAF } from './oocIndexer';
+import { DEFAULT_MAX_DEPTH, depthForRatio } from './octreeGrid';
+import { tileRecordBytes, type TileSchema } from './tileRecord';
+
+// ── the margin ──────────────────────────────────────────────────────────────
+//
+// The guard requires the demand to fit inside the free space MINUS a reserve,
+// never the free space itself. Three reasons the last byte is not usable:
+//
+//  1. `estimate()` is documented as an approximation, and browsers deliberately
+//     blur it — Chromium pads reported usage to blunt storage-based
+//     fingerprinting — so the number is a neighbourhood, not a measurement.
+//  2. A quota is not a reservation. It moves with free disk on the host, and a
+//     browser under storage pressure evicts a whole origin rather than failing
+//     one write, so an index that lands with nothing to spare can take the rest
+//     of the origin's data down with it later.
+//  3. The demand is itself an estimate. The tile payload is exact given the
+//     header, but the node count is bounded rather than known, and a build that
+//     lands within a percent of its prediction has no room for the gap.
+//
+// A fraction alone leaves too little on a small quota; a flat floor alone
+// scales badly on a large one. So the reserve is the LARGER of the two.
+/** Share of the reported free space held back from any index. */
+export const STORAGE_HEADROOM_FRACTION = 0.2;
+/**
+ * Smallest reserve, whatever the fraction works out to. Below roughly a quarter
+ * of a gigabyte of slack an origin is inside the band where browsers evict, so
+ * a build that would land there is not a build worth starting.
+ */
+export const STORAGE_HEADROOM_FLOOR_BYTES = 256 * 1024 * 1024;
+
+// ── per-node costs ──────────────────────────────────────────────────────────
+
+/**
+ * Bytes charged for each tile file beyond its records. A tile is one OPFS file
+ * backed by one host file, and a filesystem hands out whole blocks: a tile
+ * holding a single record still occupies one. 4 KiB is the common block size on
+ * the filesystems this runs over (APFS, ext4, NTFS).
+ */
+export const TILE_FILE_OVERHEAD_BYTES = 4096;
+
+/**
+ * Bytes charged per hierarchy line. `tileStore.ts` writes one `key count` line
+ * per node: the key is at most `depth` octant digits, then a space, a decimal
+ * count and a newline. Twenty digits covers any count a `Number` can state.
+ */
+const HIERARCHY_LINE_OVERHEAD_BYTES = 22;
+
+/**
+ * Bytes charged for `manifest.json`. It is a fixed set of fields — bounds, root
+ * cube, schema, counts — pretty-printed at two-space indent, so its size does
+ * not grow with the scan. 2 KiB is comfortably above what it prints.
+ */
+const MANIFEST_BYTES = 2048;
+
+/** Every cell at every level of an octree `depth` deep: `(8 ** (depth + 1) - 1) / 7`. */
+function cellsThroughDepth(depth: number): number {
+  return (8 ** (depth + 1) - 1) / 7;
+}
+
+/**
+ * How much a node is assumed to be under-filled. Pyramid placement settles each
+ * point at the coarsest cell with room, so a perfectly packed build occupies
+ * `pointCount / pointsPerLeaf` nodes; a spatially sparse one occupies more,
+ * because a cell holding six points still costs a file. Two is the allowance,
+ * and it is capped by {@link cellsThroughDepth}, which is the real ceiling.
+ */
+const NODE_FILL_ALLOWANCE = 2;
+
+// ── the demand ──────────────────────────────────────────────────────────────
+
+export interface IndexDiskDemandInput {
+  /** Points the source declares. From the LAS public header, not from a decode. */
+  readonly pointCount: number;
+  /** Which optional fields the records carry; fixes the per-point record size. */
+  readonly schema: TileSchema;
+  /** Target points per leaf the build will use. Defaults to the indexer's own. */
+  readonly pointsPerLeaf?: number;
+}
+
+/** What indexing a source would write, and how that figure was reached. */
+export interface IndexDiskDemand {
+  /** False when the input does not describe a countable index; then `bytes` means nothing. */
+  readonly known: boolean;
+  /** Why it is not known, when it is not. */
+  readonly reason?: string;
+  /**
+   * False once `bytes` leaves exact-integer range. The figure is still the right
+   * magnitude and still orders correctly, but it no longer counts bytes, so a
+   * caller must not treat a near-miss comparison as meaningful.
+   */
+  readonly exact: boolean;
+  readonly pointCount: number;
+  /** Straight from {@link tileRecordBytes}: 19 bare, 30 with GPS time and RGB. */
+  readonly recordBytes: number;
+  /** `pointCount * recordBytes`. Every point is written to exactly one node. */
+  readonly tileBytes: number;
+  readonly depth: number;
+  readonly nodeCount: number;
+  readonly nodeOverheadBytes: number;
+  readonly hierarchyBytes: number;
+  readonly manifestBytes: number;
+  /** The total the preflight compares against available storage. */
+  readonly bytes: number;
+}
+
+function unknownDemand(pointCount: number, recordBytes: number, reason: string): IndexDiskDemand {
+  return {
+    known: false,
+    reason,
+    exact: false,
+    pointCount,
+    recordBytes,
+    tileBytes: 0,
+    depth: 0,
+    nodeCount: 0,
+    nodeOverheadBytes: 0,
+    hierarchyBytes: 0,
+    manifestBytes: 0,
+    bytes: 0,
+  };
+}
+
+/**
+ * The disk an out-of-core index of this source would occupy.
+ *
+ * Sized from the declared point count and the record schema, never from the
+ * input's byte size: a compressed file says nothing about how much uncompressed,
+ * fixed-length cache it becomes, and the whole reason the guard exists is that
+ * the cache is routinely several times the file.
+ *
+ * Fails closed on an input it cannot count. A point count that is negative,
+ * fractional, infinite or NaN yields `known: false` rather than a number, so a
+ * malformed header cannot produce a small demand that sails past the check.
+ */
+export function estimateIndexDiskDemand(input: IndexDiskDemandInput): IndexDiskDemand {
+  const recordBytes = tileRecordBytes(input.schema);
+  const pointCount = input.pointCount;
+  if (typeof pointCount !== 'number' || !Number.isFinite(pointCount)) {
+    return unknownDemand(pointCount, recordBytes, 'the source declares no finite point count');
+  }
+  if (pointCount < 0 || !Number.isInteger(pointCount)) {
+    return unknownDemand(
+      pointCount,
+      recordBytes,
+      `the declared point count ${pointCount} is not a whole number of points`,
+    );
+  }
+
+  const pointsPerLeaf = Math.max(1, Math.floor(input.pointsPerLeaf ?? DEFAULT_POINTS_PER_LEAF));
+  const depth = Math.max(0, Math.min(DEFAULT_MAX_DEPTH, depthForRatio(pointCount / pointsPerLeaf)));
+  const nodeCount = Math.min(
+    pointCount,
+    cellsThroughDepth(depth),
+    Math.ceil(pointCount / pointsPerLeaf) * NODE_FILL_ALLOWANCE,
+  );
+
+  const tileBytes = pointCount * recordBytes;
+  const nodeOverheadBytes = nodeCount * TILE_FILE_OVERHEAD_BYTES;
+  const hierarchyBytes = nodeCount * (depth + HIERARCHY_LINE_OVERHEAD_BYTES);
+  const manifestBytes = MANIFEST_BYTES;
+  const bytes = tileBytes + nodeOverheadBytes + hierarchyBytes + manifestBytes;
+
+  return {
+    known: true,
+    exact: Number.isSafeInteger(bytes),
+    pointCount,
+    recordBytes,
+    tileBytes,
+    depth,
+    nodeCount,
+    nodeOverheadBytes,
+    hierarchyBytes,
+    manifestBytes,
+    bytes,
+  };
+}
+
+// ── the browser's side, as data ──────────────────────────────────────────────
+
+/**
+ * What the browser said about storage, or that it said nothing. Deliberately a
+ * plain record rather than a `StorageEstimate`: the decision is given this, so
+ * every branch — including the absent one — is reachable from a Node test.
+ */
+export interface StorageEstimateReading {
+  readonly available: boolean;
+  readonly quotaBytes?: number;
+  readonly usageBytes?: number;
+  /** Why nothing was read, when `available` is false. Quoted in the refusal. */
+  readonly reason?: string;
+}
+
+/** The injected seam: anything that can answer "how much storage is there?". */
+export type StorageEstimateReader = () => Promise<StorageEstimateReading>;
+
+/** The slice of `StorageManager` this module calls. */
+export interface StorageManagerLike {
+  estimate(): Promise<{ quota?: number; usage?: number }>;
+}
+/** The slice of `Navigator` this module reads. */
+export interface NavigatorLike {
+  readonly storage?: StorageManagerLike;
+}
+
+/**
+ * Read `navigator.storage.estimate()`. The only impure function here.
+ *
+ * Never throws and never guesses. `navigator.storage` is absent outside a secure
+ * context and in some privacy modes, and `estimate()` itself rejects where
+ * storage is blocked; both come back as `available: false` with the reason
+ * attached, which {@link decideStoragePreflight} turns into a refusal.
+ */
+export async function readStorageEstimate(navigatorLike?: NavigatorLike): Promise<StorageEstimateReading> {
+  const nav = navigatorLike ?? (globalThis as { navigator?: NavigatorLike }).navigator;
+  const storage = nav?.storage;
+  if (!storage || typeof storage.estimate !== 'function') {
+    return { available: false, reason: 'this browser exposes no navigator.storage.estimate()' };
+  }
+  try {
+    const estimate = await storage.estimate();
+    return { available: true, quotaBytes: estimate.quota, usageBytes: estimate.usage };
+  } catch (err) {
+    return {
+      available: false,
+      reason: `navigator.storage.estimate() failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+// ── the decision ────────────────────────────────────────────────────────────
+
+export type StoragePreflightOutcome =
+  | 'proceed'
+  /** The demand is larger than what is available after the reserve. */
+  | 'insufficient-storage'
+  /** No estimate was readable at all. Refuses: unknown is not permission. */
+  | 'estimate-unavailable'
+  /** An estimate came back that does not describe a usable quota. */
+  | 'quota-unknown'
+  /** The estimate is readable and the origin is granted nothing. */
+  | 'no-quota'
+  /** The source does not state a countable point count. */
+  | 'demand-unknown';
+
+export interface StoragePreflightVerdict {
+  readonly outcome: StoragePreflightOutcome;
+  readonly proceed: boolean;
+  /** What the index would need. Always stated, whatever the outcome. */
+  readonly requiredBytes: number;
+  /** What it may use: free space less the reserve. Zero when nothing is known. */
+  readonly availableBytes: number;
+  /** What the reserve held back. Zero when there was no figure to reserve from. */
+  readonly reservedBytes: number;
+  /** `quota - usage` as reported, before the reserve. Null when unknown. */
+  readonly freeBytes: number | null;
+  readonly quotaBytes: number | null;
+  readonly usageBytes: number | null;
+  /** The user-facing sentence. Names the required and available figures. */
+  readonly message: string;
+}
+
+export interface StoragePreflightOptions {
+  readonly headroomFraction?: number;
+  readonly headroomFloorBytes?: number;
+}
+
+/** `1234567` becomes `1,234,567`, without depending on the host locale. */
+function groupDigits(value: number): string {
+  if (!Number.isFinite(value)) return String(value);
+  const [whole, ...rest] = Math.abs(value).toFixed(0).split('.');
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return (value < 0 ? '-' : '') + grouped + (rest.length > 0 ? `.${rest.join('')}` : '');
+}
+
+/** The sentence every refusal ends on: the way out that needs no local cache. */
+const CONVERT_ADVICE =
+  'Convert it to COPC or EPT (PDAL or untwine) and open that instead: those stream from the ' +
+  'file and write no local cache.';
+
+/** How the demand figure was reached, so a user can check it against the header. */
+function demandProvenance(demand: IndexDiskDemand): string {
+  return (
+    `The cache is sized by the points, not by the file: ${groupDigits(demand.pointCount)} points at ` +
+    `${demand.recordBytes} bytes per point, plus ${groupDigits(demand.nodeCount)} tile files and the ` +
+    `hierarchy. A compressed file gives no bound on that, which is why the file's own size is not ` +
+    `the check.`
+  );
+}
+
+function verdict(
+  outcome: StoragePreflightOutcome,
+  demand: IndexDiskDemand,
+  message: string,
+  space: {
+    availableBytes?: number;
+    reservedBytes?: number;
+    freeBytes?: number | null;
+    quotaBytes?: number | null;
+    usageBytes?: number | null;
+  } = {},
+): StoragePreflightVerdict {
+  return {
+    outcome,
+    proceed: outcome === 'proceed',
+    requiredBytes: demand.bytes,
+    availableBytes: space.availableBytes ?? 0,
+    reservedBytes: space.reservedBytes ?? 0,
+    freeBytes: space.freeBytes ?? null,
+    quotaBytes: space.quotaBytes ?? null,
+    usageBytes: space.usageBytes ?? null,
+    message,
+  };
+}
+
+/**
+ * Proceed, or refuse by name.
+ *
+ * Pure. The browser's answer arrives as {@link StorageEstimateReading} rather
+ * than being read here, so the branch that matters most — no estimate at all —
+ * is an ordinary test case instead of an environment nobody can reproduce.
+ *
+ * Every path that is not `proceed` is a refusal, and every refusal states what
+ * was needed. The four ways it can refuse are distinct on purpose: "you need
+ * more than you have", "I could not ask", "the answer did not parse", and "you
+ * were granted nothing" are different problems with different remedies, and
+ * collapsing them into one boolean would lose the only thing a user could act on.
+ */
+export function decideStoragePreflight(
+  demand: IndexDiskDemand,
+  reading: StorageEstimateReading,
+  options: StoragePreflightOptions = {},
+): StoragePreflightVerdict {
+  if (!demand.known) {
+    return verdict(
+      'demand-unknown',
+      demand,
+      `The storage an index would need cannot be established: ${demand.reason ?? 'no reason recorded'}. ` +
+        `The file may be malformed or truncated. Indexing is refused rather than started blind. ${CONVERT_ADVICE}`,
+    );
+  }
+
+  const required = formatByteSize(demand.bytes);
+
+  if (!reading.available) {
+    return verdict(
+      'estimate-unavailable',
+      demand,
+      `Indexing this scan would need about ${required} of local cache, and this browser does not ` +
+        `report a storage estimate (${reading.reason ?? 'no reason recorded'}), so the space available ` +
+        `is unknown. Indexing is refused rather than started: a build that runs out part-way leaves ` +
+        `the cache it already wrote behind with no store to show for it, and an unreadable estimate ` +
+        `is not permission. ${demandProvenance(demand)} ${CONVERT_ADVICE}`,
+    );
+  }
+
+  const quota = reading.quotaBytes;
+  const usage = reading.usageBytes ?? 0;
+  if (typeof quota !== 'number' || !Number.isFinite(quota) || quota < 0
+    || typeof usage !== 'number' || !Number.isFinite(usage) || usage < 0) {
+    return verdict(
+      'quota-unknown',
+      demand,
+      `Indexing this scan would need about ${required} of local cache, and the storage estimate this ` +
+        `browser returned does not describe a usable quota (quota ${String(quota)}, usage ` +
+        `${String(reading.usageBytes)}), so the space available is unknown. Indexing is refused ` +
+        `rather than started blind. ${CONVERT_ADVICE}`,
+    );
+  }
+
+  if (quota === 0) {
+    return verdict(
+      'no-quota',
+      demand,
+      `Indexing this scan would need about ${required} of local cache and this browser grants this ` +
+        `page no storage at all (a quota of ${formatByteSize(0)}), so there is nowhere to write it. ` +
+        `Private browsing and blocked site data both do this. ${CONVERT_ADVICE}`,
+      { freeBytes: 0, quotaBytes: 0, usageBytes: usage, availableBytes: 0 },
+    );
+  }
+
+  const free = Math.max(0, quota - usage);
+  const reserved = Math.max(
+    free * (options.headroomFraction ?? STORAGE_HEADROOM_FRACTION),
+    options.headroomFloorBytes ?? STORAGE_HEADROOM_FLOOR_BYTES,
+  );
+  const available = Math.max(0, free - reserved);
+  const space = {
+    availableBytes: available,
+    reservedBytes: reserved,
+    freeBytes: free,
+    quotaBytes: quota,
+    usageBytes: usage,
+  };
+
+  if (demand.bytes <= available) {
+    return verdict(
+      'proceed',
+      demand,
+      `Indexing this scan needs about ${required} of local cache and this browser has about ` +
+        `${formatByteSize(available)} usable, after holding ${formatByteSize(reserved)} of the ` +
+        `${formatByteSize(free)} it reports free in reserve.`,
+      space,
+    );
+  }
+
+  return verdict(
+    'insufficient-storage',
+    demand,
+    `Indexing this scan needs about ${required} of local cache and only about ` +
+      `${formatByteSize(available)} is usable, so it is refused before anything is written. ` +
+      `${demandProvenance(demand)} This browser reports ${formatByteSize(free)} free of a ` +
+      `${formatByteSize(quota)} quota, of which ${formatByteSize(reserved)} is held back so an index ` +
+      `cannot consume the last of it. ${CONVERT_ADVICE}`,
+    space,
+  );
+}
+
+/**
+ * The refusal a finished verdict already justifies, or `undefined` when the
+ * index may be built. Shaped after `e57Refusal` in `io/loadFile.ts` so the two
+ * pre-read guards hand the same kind of object to the same describing path.
+ *
+ * The category is `memory-constraint`, the nearest of the six
+ * {@link LoadErrorCategory} values: this is a storage ceiling rather than a RAM
+ * one, but both are "this device cannot hold what this file needs", and the
+ * message carries the specifics the category cannot.
+ */
+export function storagePreflightRefusal(
+  result: StoragePreflightVerdict,
+  name: string,
+): LoadError | undefined {
+  if (result.proceed) return undefined;
+  return new LoadError('memory-constraint', `${name}: ${result.message}`);
+}
+
+/**
+ * Size the index, ask for the estimate, decide. The reader is a parameter with
+ * the live one as its default, so production gets the browser and a test gets
+ * whatever it wants without touching a global.
+ *
+ * A reader that throws is treated exactly as a reader that reports nothing:
+ * refused, with what it threw quoted. Nothing about a thrown estimate makes the
+ * disk more likely to be there.
+ */
+export async function storagePreflight(
+  input: IndexDiskDemandInput,
+  read: StorageEstimateReader = readStorageEstimate,
+  options: StoragePreflightOptions = {},
+): Promise<StoragePreflightVerdict> {
+  let reading: StorageEstimateReading;
+  try {
+    reading = await read();
+  } catch (err) {
+    reading = {
+      available: false,
+      reason: `the storage estimate threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  return decideStoragePreflight(estimateIndexDiskDemand(input), reading, options);
+}

--- a/tests/storagePreflight.test.ts
+++ b/tests/storagePreflight.test.ts
@@ -1,0 +1,294 @@
+/**
+ * storagePreflight.test.ts — the guard that runs BEFORE a file is indexed to disk.
+ *
+ * Two halves, tested apart. The demand half asks what indexing a source would
+ * write, from the point count and the record schema rather than from the
+ * compressed input size, because a 5 GB LAZ can hold hundreds of millions of
+ * points and the cache it produces is several times the file. The decision half
+ * compares that against what the browser reports free and either proceeds or
+ * refuses by name.
+ *
+ * The cases that matter are the ones where a naive guard says yes: an estimate
+ * that is missing entirely, an origin granted no quota at all, and a point count
+ * large enough that the byte arithmetic leaves exact-integer range.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  estimateIndexDiskDemand,
+  decideStoragePreflight,
+  storagePreflight,
+  storagePreflightRefusal,
+  readStorageEstimate,
+  STORAGE_HEADROOM_FRACTION,
+  STORAGE_HEADROOM_FLOOR_BYTES,
+  type StorageEstimateReading,
+} from '../src/io/heavy/storagePreflight';
+import { tileRecordBytes, type TileSchema } from '../src/io/heavy/tileRecord';
+import { LoadError } from '../src/io/loadErrors';
+import { formatByteSize } from '../src/io/formatByteSize';
+
+const MINIMAL: TileSchema = { hasGps: false, hasRgb: false };
+const FULL: TileSchema = { hasGps: true, hasRgb: true };
+
+const GB = 1024 ** 3;
+
+/** A reading that reports `quota` total and `usage` already spent. */
+function reads(quota: number, usage = 0): StorageEstimateReading {
+  return { available: true, quotaBytes: quota, usageBytes: usage };
+}
+
+describe('estimateIndexDiskDemand', () => {
+  it('takes the per-point record size from the record layout, not an assumption', () => {
+    const lean = estimateIndexDiskDemand({ pointCount: 1_000_000, schema: MINIMAL });
+    const rich = estimateIndexDiskDemand({ pointCount: 1_000_000, schema: FULL });
+    expect(lean.recordBytes).toBe(tileRecordBytes(MINIMAL));
+    expect(rich.recordBytes).toBe(tileRecordBytes(FULL));
+    expect(rich.recordBytes).toBeGreaterThan(lean.recordBytes);
+    expect(lean.tileBytes).toBe(1_000_000 * tileRecordBytes(MINIMAL));
+    expect(rich.tileBytes).toBe(1_000_000 * tileRecordBytes(FULL));
+  });
+
+  it('counts hierarchy and per-node overhead on top of the tile payload', () => {
+    const d = estimateIndexDiskDemand({ pointCount: 50_000_000, schema: FULL });
+    expect(d.nodeCount).toBeGreaterThan(0);
+    expect(d.hierarchyBytes).toBeGreaterThan(0);
+    expect(d.manifestBytes).toBeGreaterThan(0);
+    expect(d.bytes).toBeGreaterThan(d.tileBytes);
+    expect(d.bytes).toBe(d.tileBytes + d.hierarchyBytes + d.nodeOverheadBytes + d.manifestBytes);
+  });
+
+  it('scales with the point count a header declares, not with a compressed file size', () => {
+    // The case the guard exists for: a 5 GB LAZ holding 400 M points. The cache
+    // is several times the input, so a size-based check would wave it through.
+    const d = estimateIndexDiskDemand({ pointCount: 400_000_000, schema: FULL });
+    expect(d.known).toBe(true);
+    expect(d.bytes).toBeGreaterThan(5 * GB * 2);
+  });
+
+  it('is monotonic in the point count', () => {
+    const a = estimateIndexDiskDemand({ pointCount: 10_000_000, schema: FULL });
+    const b = estimateIndexDiskDemand({ pointCount: 10_000_001, schema: FULL });
+    expect(b.bytes).toBeGreaterThanOrEqual(a.bytes);
+  });
+
+  it('reports an empty source as a known, near-zero demand', () => {
+    const d = estimateIndexDiskDemand({ pointCount: 0, schema: MINIMAL });
+    expect(d.known).toBe(true);
+    expect(d.tileBytes).toBe(0);
+    expect(d.bytes).toBeGreaterThanOrEqual(0);
+    expect(Number.isFinite(d.bytes)).toBe(true);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1, 1.5])(
+    'refuses to state a demand for a point count of %p',
+    (pointCount) => {
+      const d = estimateIndexDiskDemand({ pointCount, schema: FULL });
+      expect(d.known).toBe(false);
+      expect(d.reason ?? '').not.toBe('');
+    },
+  );
+
+  it('stays finite and flags itself inexact when the byte arithmetic leaves safe-integer range', () => {
+    // A LAS 1.4 header states the point count as a u64, so a malformed or
+    // hostile header can declare more points than a double counts in bytes.
+    const d = estimateIndexDiskDemand({ pointCount: 1e15, schema: FULL });
+    expect(Number.isFinite(d.bytes)).toBe(true);
+    expect(d.bytes).toBeGreaterThan(Number.MAX_SAFE_INTEGER);
+    expect(d.exact).toBe(false);
+    // It must not wrap, saturate low, or otherwise come back small enough to fit.
+    const verdict = decideStoragePreflight(d, reads(1024 * GB));
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.outcome).toBe('insufficient-storage');
+  });
+
+  it('keeps ordinary counts exact', () => {
+    const d = estimateIndexDiskDemand({ pointCount: 250_000_000, schema: FULL });
+    expect(d.exact).toBe(true);
+    expect(Number.isSafeInteger(d.bytes)).toBe(true);
+  });
+});
+
+describe('decideStoragePreflight', () => {
+  const demand = estimateIndexDiskDemand({ pointCount: 200_000_000, schema: FULL });
+
+  it('refuses when the demand exceeds what is available', () => {
+    const verdict = decideStoragePreflight(demand, reads(2 * GB));
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.outcome).toBe('insufficient-storage');
+    expect(verdict.requiredBytes).toBe(demand.bytes);
+  });
+
+  it('proceeds when the demand fits with room to spare', () => {
+    const verdict = decideStoragePreflight(demand, reads(200 * GB));
+    expect(verdict.proceed).toBe(true);
+    expect(verdict.outcome).toBe('proceed');
+    expect(verdict.availableBytes).toBeGreaterThan(verdict.requiredBytes);
+  });
+
+  it('counts storage already in use against what is free', () => {
+    const quota = 200 * GB;
+    const spacious = decideStoragePreflight(demand, reads(quota, 0));
+    const crowded = decideStoragePreflight(demand, reads(quota, quota - GB));
+    expect(spacious.proceed).toBe(true);
+    expect(crowded.proceed).toBe(false);
+    expect(crowded.availableBytes).toBeLessThan(spacious.availableBytes);
+  });
+
+  it('keeps a margin below the reported free space rather than filling it', () => {
+    // Sized to fit the raw free space and NOT the margin: the whole point of
+    // the reserve is that a build which only just fits is refused.
+    const small = estimateIndexDiskDemand({ pointCount: 100_000, schema: MINIMAL });
+    const free = small.bytes + STORAGE_HEADROOM_FLOOR_BYTES / 2;
+    const verdict = decideStoragePreflight(small, reads(free));
+    expect(free).toBeGreaterThan(small.bytes); // it does fit, unguarded
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.outcome).toBe('insufficient-storage');
+    expect(verdict.reservedBytes).toBeGreaterThan(0);
+    expect(verdict.availableBytes).toBeLessThan(free);
+  });
+
+  it('reserves at least the fraction of free space the constant names', () => {
+    const free = 1000 * GB;
+    const verdict = decideStoragePreflight(demand, reads(free));
+    expect(verdict.reservedBytes).toBeGreaterThanOrEqual(free * STORAGE_HEADROOM_FRACTION);
+    expect(verdict.availableBytes).toBeLessThanOrEqual(free - free * STORAGE_HEADROOM_FRACTION);
+  });
+
+  it('refuses when the browser reports no estimate at all', () => {
+    const verdict = decideStoragePreflight(demand, { available: false, reason: 'no navigator.storage' });
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.outcome).toBe('estimate-unavailable');
+  });
+
+  it('refuses when the origin is granted no quota', () => {
+    const verdict = decideStoragePreflight(demand, reads(0));
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.outcome).toBe('no-quota');
+  });
+
+  it.each([
+    ['a missing quota', { available: true, usageBytes: 0 } as StorageEstimateReading],
+    ['a non-numeric quota', { available: true, quotaBytes: Number.NaN, usageBytes: 0 } as StorageEstimateReading],
+    ['an infinite quota', { available: true, quotaBytes: Number.POSITIVE_INFINITY, usageBytes: 0 } as StorageEstimateReading],
+    ['a negative usage', { available: true, quotaBytes: 100 * GB, usageBytes: -1 } as StorageEstimateReading],
+  ])('refuses on %s', (_label, reading) => {
+    const verdict = decideStoragePreflight(demand, reading);
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.outcome).toBe('quota-unknown');
+  });
+
+  it('refuses when the demand itself could not be established', () => {
+    const unknown = estimateIndexDiskDemand({ pointCount: Number.NaN, schema: FULL });
+    const verdict = decideStoragePreflight(unknown, reads(1000 * GB));
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.outcome).toBe('demand-unknown');
+  });
+
+  it('treats usage above quota as no room rather than negative room', () => {
+    const verdict = decideStoragePreflight(demand, reads(10 * GB, 12 * GB));
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.availableBytes).toBe(0);
+  });
+});
+
+describe('the refusal names numbers a user can act on', () => {
+  const demand = estimateIndexDiskDemand({ pointCount: 200_000_000, schema: FULL });
+
+  it('states both the required and the available figures, not a bare verdict', () => {
+    const verdict = decideStoragePreflight(demand, reads(4 * GB));
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.message).toContain(formatByteSize(verdict.requiredBytes));
+    expect(verdict.message).toContain(formatByteSize(verdict.availableBytes));
+    // Not reducible to a boolean: the two figures must differ and both appear.
+    expect(formatByteSize(verdict.requiredBytes)).not.toBe(formatByteSize(verdict.availableBytes));
+  });
+
+  it('states the required figure even when the available one was never reported', () => {
+    const verdict = decideStoragePreflight(demand, { available: false, reason: 'storage API absent' });
+    expect(verdict.message).toContain(formatByteSize(verdict.requiredBytes));
+    expect(verdict.message.toLowerCase()).toContain('not report');
+  });
+
+  it('explains where the demand comes from, so the figure is checkable', () => {
+    const verdict = decideStoragePreflight(demand, reads(4 * GB));
+    expect(verdict.message).toContain(String(demand.recordBytes));
+    expect(verdict.message).toContain('200,000,000');
+  });
+
+  it('raises a categorised LoadError the existing refusal path can describe', () => {
+    const verdict = decideStoragePreflight(demand, reads(4 * GB));
+    const err = storagePreflightRefusal(verdict, 'big.laz');
+    expect(err).toBeInstanceOf(LoadError);
+    expect(err?.category).toBe('memory-constraint');
+    expect(err?.message).toContain('big.laz');
+    expect(err?.message).toContain(formatByteSize(verdict.requiredBytes));
+    expect(err?.message).toContain(formatByteSize(verdict.availableBytes));
+  });
+
+  it('raises nothing when the verdict proceeds', () => {
+    const verdict = decideStoragePreflight(demand, reads(500 * GB));
+    expect(storagePreflightRefusal(verdict, 'big.laz')).toBeUndefined();
+  });
+});
+
+describe('storagePreflight', () => {
+  it('asks the injected reader rather than the global navigator', async () => {
+    let asked = 0;
+    const verdict = await storagePreflight(
+      { pointCount: 1_000_000, schema: MINIMAL },
+      async () => {
+        asked++;
+        return reads(500 * GB);
+      },
+    );
+    expect(asked).toBe(1);
+    expect(verdict.proceed).toBe(true);
+  });
+
+  it('refuses when the injected reader reports nothing', async () => {
+    const verdict = await storagePreflight({ pointCount: 1_000_000, schema: MINIMAL }, async () => ({
+      available: false,
+      reason: 'test',
+    }));
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.outcome).toBe('estimate-unavailable');
+  });
+
+  it('refuses when the injected reader throws', async () => {
+    const verdict = await storagePreflight({ pointCount: 1_000_000, schema: MINIMAL }, async () => {
+      throw new Error('estimate blew up');
+    });
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.outcome).toBe('estimate-unavailable');
+    expect(verdict.message).toContain('estimate blew up');
+  });
+});
+
+describe('readStorageEstimate', () => {
+  it('reports unavailable in an environment with no storage manager, without throwing', async () => {
+    const reading = await readStorageEstimate();
+    expect(reading.available).toBe(false);
+    expect(reading.reason ?? '').not.toBe('');
+  });
+
+  it('reads a storage manager that is present', async () => {
+    const nav = { storage: { estimate: async () => ({ quota: 12345, usage: 67 }) } };
+    const reading = await readStorageEstimate(nav);
+    expect(reading.available).toBe(true);
+    expect(reading.quotaBytes).toBe(12345);
+    expect(reading.usageBytes).toBe(67);
+  });
+
+  it('reports unavailable when the storage manager throws', async () => {
+    const nav = {
+      storage: {
+        estimate: async () => {
+          throw new Error('SecurityError');
+        },
+      },
+    };
+    const reading = await readStorageEstimate(nav);
+    expect(reading.available).toBe(false);
+    expect(reading.reason).toContain('SecurityError');
+  });
+});


### PR DESCRIPTION
A storage preflight for the out-of-core indexer, as a pure unit. Nothing is wired into the open path.

`estimateIndexDiskDemand` sizes the disk an index would occupy from the declared point count and the record schema. `tileRecordBytes` gives 19 bytes per point bare and 30 with GPS time and RGB; the octree depth rule gives the node count, charged one filesystem block and one hierarchy line each. A 5 GB LAZ holding 400 million points asks for 11 GB of cache, so the input's size is not the check.

`decideStoragePreflight` takes the `navigator.storage.estimate()` reading as data. A missing estimate refuses. Free space is cut by 20 percent or 256 MiB, whichever is larger.

35 tests. Three guard mutations were run and each killed the matching test.
