### PR TITLE
refactor(streaming): optional measured channels on DecodedChunk

### DIFF
--- a/src/io/copc/copcChunkDecode.ts
+++ b/src/io/copc/copcChunkDecode.ts
@@ -41,22 +41,40 @@ export interface ChunkDecodeMetadata {
   rgbEightBit?: boolean;
 }
 
-/** A decoded COPC node chunk — local-space attributes ready for the GPU. */
+/**
+ * A decoded node chunk — local-space attributes ready for the GPU.
+ *
+ * Only `pointCount` and `positions` are required. Every measured channel is
+ * optional because the chunk shape serves more than the LAS family: a `.pnts`
+ * tile carries none of intensity, classification, returns or GPS time, and
+ * allocating zero-filled arrays for them would spend 13 bytes per point saying
+ * something false. An ABSENT channel and a channel of zeros are different
+ * claims — zero classification means "never classified" and zero intensity is
+ * not a measured zero — so a reader must be able to tell them apart.
+ *
+ * A consumer that needs a channel checks for it. Colour modes are gated by the
+ * source's `colorModes()`, so a mode is never offered for a channel the format
+ * cannot fill; the derived products (resident snapshot, profile section, point
+ * inspector) report absence rather than substituting a default.
+ *
+ * The LAS-family decoders — COPC, EPT and the out-of-core tile store — fill all
+ * five on every chunk and are unaffected by the optionality.
+ */
 export interface DecodedChunk {
   /** Points actually decoded (≤ the requested count if the input was short). */
   pointCount: number;
   /** Local-space positions, length `3 · pointCount`. */
   positions: Float32Array;
-  /** Per-point intensity. */
-  intensity: Uint16Array;
-  /** Per-point classification. */
-  classification: Uint8Array;
-  /** Per-point return number. */
-  returnNumber: Uint8Array;
-  /** Per-point total returns. */
-  returnCount: Uint8Array;
-  /** Per-point GPS time. */
-  gpsTime: Float64Array;
+  /** Per-point intensity — absent when the format carries none. */
+  intensity?: Uint16Array;
+  /** Per-point classification — absent when the format carries none. */
+  classification?: Uint8Array;
+  /** Per-point return number — absent when the format carries none. */
+  returnNumber?: Uint8Array;
+  /** Per-point total returns — absent when the format carries none. */
+  returnCount?: Uint8Array;
+  /** Per-point GPS time — absent when the format carries none. */
+  gpsTime?: Float64Array;
   /** Per-point point source id — produced by `decodeRecords`, absent on fakes. */
   pointSourceId?: Uint16Array;
   /** Per-point RGB (0-255), length `3 · pointCount` — only for PDRF 7/8. */
@@ -187,17 +205,19 @@ export function decodeRecords(
 /**
  * The transferable buffers of a decoded chunk — for zero-copy `postMessage`.
  * Each attribute array is created fresh in {@link decodeRecords}, so its
- * backing buffer is always a real `ArrayBuffer`.
+ * backing buffer is always a real `ArrayBuffer`. Channels the chunk does not
+ * carry contribute nothing.
  */
 export function chunkTransferables(decoded: DecodedChunk): ArrayBuffer[] {
-  const out: ArrayBuffer[] = [
-    decoded.positions.buffer as ArrayBuffer,
-    decoded.intensity.buffer as ArrayBuffer,
-    decoded.classification.buffer as ArrayBuffer,
-    decoded.returnNumber.buffer as ArrayBuffer,
-    decoded.returnCount.buffer as ArrayBuffer,
-    decoded.gpsTime.buffer as ArrayBuffer,
-  ];
+  const out: ArrayBuffer[] = [decoded.positions.buffer as ArrayBuffer];
+  // Every measured channel is optional on the chunk, so each is transferred
+  // only when the decoder produced it. Listing an absent one would post a
+  // buffer that is not there.
+  if (decoded.intensity) out.push(decoded.intensity.buffer as ArrayBuffer);
+  if (decoded.classification) out.push(decoded.classification.buffer as ArrayBuffer);
+  if (decoded.returnNumber) out.push(decoded.returnNumber.buffer as ArrayBuffer);
+  if (decoded.returnCount) out.push(decoded.returnCount.buffer as ArrayBuffer);
+  if (decoded.gpsTime) out.push(decoded.gpsTime.buffer as ArrayBuffer);
   if (decoded.pointSourceId) out.push(decoded.pointSourceId.buffer as ArrayBuffer);
   if (decoded.rgb) out.push(decoded.rgb.buffer as ArrayBuffer);
   return out;

--- a/src/io/tiles3d/pntsDecode.ts
+++ b/src/io/tiles3d/pntsDecode.ts
@@ -8,15 +8,15 @@
  * metadata. A `.pnts` body carries none of that, so this module supplies its
  * own metadata shape and its own decoder.
  *
- * WHAT A PNTS TILE DOES NOT CARRY, and why the chunk still has those fields:
- * `DecodedChunk` was written for LAS-derived data and requires intensity,
- * classification, return number, return count and GPS time. A point tile has
- * none of them. They are filled with zeros here because the type requires an
- * array of the right length, NOT because a zero is a reading: zero
- * classification is "never classified" and zero intensity is not a measured
- * zero. A source backed by these tiles therefore advertises only the colour
- * modes the format actually carries, so nothing offers to paint a scan by a
- * channel that holds no information. `tests/pntsDecode.test.ts` pins that.
+ * WHAT A PNTS TILE DOES NOT CARRY, and what the chunk therefore omits:
+ * intensity, classification, return number, return count and GPS time. A point
+ * tile has none of them, and `DecodedChunk` makes every measured channel
+ * optional, so this decoder allocates nothing for them. A zero is not a
+ * reading: zero classification is "never classified" and zero intensity is not
+ * a measured zero, so an absent channel and a zero-filled one must stay
+ * distinguishable. A source backed by these tiles also advertises only the
+ * colour modes the format actually carries, so nothing offers to paint a scan
+ * by a channel that holds no information. `tests/pntsDecode.test.ts` pins both.
  *
  * Positions arrive tile-local. The tile's own `RTC_CENTER`, then its cumulative
  * placement down the tileset tree, then the render origin are applied in
@@ -243,17 +243,11 @@ export class PntsChunkDecoder implements ChunkDecoder {
     });
     this._raiseColourNoticeOnce();
 
-    const decoded: DecodedChunk = {
-      pointCount: n,
-      positions,
-      // Not readings. See the note at the top of this file: the chunk type
-      // requires these arrays, and a point tile carries none of them.
-      intensity: new Uint16Array(n),
-      classification: new Uint8Array(n),
-      returnNumber: new Uint8Array(n),
-      returnCount: new Uint8Array(n),
-      gpsTime: new Float64Array(n),
-    };
+    // Intensity, classification, return number, return count and GPS time are
+    // simply absent — see the note at the top of this file. Nothing is
+    // allocated for them, so a reader is told the channel is missing rather
+    // than handed `pointCount` zeros that look like readings.
+    const decoded: DecodedChunk = { pointCount: n, positions };
     if (this._colour.settled !== 'colour') {
       // The layer is drawn by the elevation ramp. A tile that does carry colour
       // has it withheld rather than painted beside ramped neighbours, because

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -6097,8 +6097,8 @@ export class Viewer {
 
   /**
    * Build display-ready point info for a streaming-node pick hit — the COPC
-   * equivalent of {@link _infoForHit}. The decoded chunk carries every
-   * per-point attribute, so a streaming scan inspects exactly like a static one.
+   * equivalent of {@link _infoForHit}. Each channel is read only when the chunk
+   * carries it, so a format without intensity or classes shows no row for them.
    */
   private _infoForStreamingHit(hit: {
     decoded: DecodedChunk;
@@ -6119,13 +6119,13 @@ export class Viewer {
       local: [point.x, point.y, point.z],
       origin,
       distance: this._camera.position.distanceTo(point),
-      intensity: decoded.intensity[index],
-      classification: decoded.classification[index],
+      intensity: decoded.intensity ? decoded.intensity[index] : null,
+      classification: decoded.classification ? decoded.classification[index] : null,
       rgb,
-      returnNumber: decoded.returnNumber[index],
-      returnCount: decoded.returnCount[index],
+      returnNumber: decoded.returnNumber ? decoded.returnNumber[index] : undefined,
+      returnCount: decoded.returnCount ? decoded.returnCount[index] : undefined,
       pointSourceId: decoded.pointSourceId ? decoded.pointSourceId[index] : undefined,
-      gpsTime: decoded.gpsTime[index],
+      gpsTime: decoded.gpsTime ? decoded.gpsTime[index] : undefined,
       // COPC PDRF 6/7/8 carry no surface normals.
       normal: undefined,
       streamingRefining,

--- a/src/render/streaming/StreamingRenderer.ts
+++ b/src/render/streaming/StreamingRenderer.ts
@@ -302,18 +302,26 @@ export class StreamingRenderer {
       // return ordinals are a handful of small integers, so percentile
       // clipping would merge real ordinals into an endpoint colour instead
       // of guarding against anything.
-      const gpsTime = computeScalarRange(decoded.gpsTime, { count: decoded.pointCount });
-      const returns = scalarRangeOf(decoded.returnNumber, decoded.pointCount);
+      //
+      // A channel the chunk does not carry seeds NOTHING. Its window keeps
+      // whatever it held, because a window derived from an absent array would
+      // be a statement about a measurement the source never made. Elevation is
+      // derived from positions, which every chunk has, so it always seeds.
+      const gpsTime = decoded.gpsTime
+        ? computeScalarRange(decoded.gpsTime, { count: decoded.pointCount })
+        : null;
+      const returns = decoded.returnNumber
+        ? scalarRangeOf(decoded.returnNumber, decoded.pointCount)
+        : null;
       this._ranges = {
         ...this._ranges,
-        minIntensity: intensity.min,
-        maxIntensity: intensity.max,
+        ...(intensity ? { minIntensity: intensity.min, maxIntensity: intensity.max } : {}),
         minZ: elevation.minZ,
         maxZ: elevation.maxZ,
-        minGpsTime: gpsTime.min,
-        maxGpsTime: gpsTime.max,
-        minReturnNumber: returns.min,
-        maxReturnNumber: returns.max,
+        ...(gpsTime ? { minGpsTime: gpsTime.min, maxGpsTime: gpsTime.max } : {}),
+        ...(returns
+          ? { minReturnNumber: returns.min, maxReturnNumber: returns.max }
+          : {}),
       };
       this._rangeSeedDepth = seedDepth;
       // Every mode that colours against a seeded range must repaint the
@@ -329,9 +337,13 @@ export class StreamingRenderer {
     }
     const colors = streamingNodeColors(this._mode, decoded, this._ranges, this._rgbAppearance);
     // Pass the node's decoded per-point classification so the shared class
-    // mask applies to streaming nodes too. A DecodedChunk always carries a
-    // `classification` array (zero-filled when the source lacked the field),
-    // so streaming meshes always get an `aClass` attribute.
+    // mask applies to streaming nodes too. A chunk from a format that carries
+    // no classification passes null, exactly as a static cloud without the
+    // channel does: `buildPointMesh` then skips the `aClass` attribute
+    // entirely and the size graph's guarded mask lookup leaves the mesh fully
+    // visible, instead of every point reading as class 0 and disappearing the
+    // moment someone unticks "Never classified". Intensity is the same story
+    // for the intensity filter.
     //
     // `buildPointMesh` wires every material's size graph to the Viewer's ONE
     // shared `_classMaskUniform` node (not a per-node copy), so a node decoded
@@ -340,8 +352,8 @@ export class StreamingRenderer {
     const handle: PointMeshHandle = this._host.buildPointMesh(
       renderLocalPositions(decoded),
       colors,
-      decoded.classification,
-      decoded.intensity,
+      decoded.classification ?? null,
+      decoded.intensity ?? null,
     );
     this._host.addStreamingMesh(handle.mesh, decoded, node.record.key.depth, node.record.id);
     this._meshes.set(node.record.id, {
@@ -409,10 +421,12 @@ export class StreamingRenderer {
 
   /**
    * The decoded chunk of every resident node — for a resident-snapshot export.
-   * Each chunk carries the full attribute set (positions, intensity, class,
-   * returns, GPS time, optional RGB) kept CPU-side for recolouring, so the
-   * snapshot needs no GPU readback or re-decode. Positions are in local
-   * (render-origin-shifted) space, matching the picking arrays above.
+   * Each chunk carries whatever attributes its format states (positions always;
+   * intensity, class, returns, GPS time and RGB when the source has them) kept
+   * CPU-side for recolouring, so the snapshot needs no GPU readback or
+   * re-decode. The snapshot builder writes a channel only when every chunk has
+   * it. Positions are in local (render-origin-shifted) space, matching the
+   * picking arrays above.
    */
   residentChunks(): DecodedChunk[] {
     const out: DecodedChunk[] = [];

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -442,26 +442,51 @@ function boxCentre(b: Box6): [number, number, number] {
 }
 
 /**
+ * Per-point bytes one channel contributes, or 0 when the chunk omits it.
+ *
+ * The width comes from the array's own `BYTES_PER_ELEMENT` rather than a
+ * repeated literal, so the figure cannot drift from the element type a decoder
+ * actually allocates. `perPoint` is the element count per point: 1 for a
+ * scalar channel, 3 for an interleaved triple.
+ */
+function channelBytes(
+  channel: { readonly BYTES_PER_ELEMENT: number } | undefined,
+  perPoint: number,
+): number {
+  return channel === undefined ? 0 : channel.BYTES_PER_ELEMENT * perPoint;
+}
+
+/**
  * Bytes a decoded chunk occupies.
  *
- * Derived from `pointCount` and the chunk's fixed layout rather than by
- * reading each array's `byteLength`. Reading `.positions` here would raise the
- * direct-position-access ratchet, and this needs no coordinate at all: the
- * decoder sizes every array to `pointCount`, so the arithmetic is exact.
- * `decodedChunkBytes matches the allocated arrays` in the integration suite
- * asserts that against real arrays, where reading them is permitted.
+ * Derived from `pointCount` and the channels the chunk ACTUALLY carries, not
+ * from a fixed LAS-shaped layout. Every measured channel is optional on
+ * {@link DecodedChunk}, so a per-point constant would over-count a source that
+ * fills fewer of them: a `.pnts` tile carries positions alone, and charging it
+ * for intensity, classification, both return fields and GPS time would tell the
+ * queue's byte budget that 13 bytes per point exist which do not. The budget
+ * bounds what the next frame absorbs, so an inflated figure throttles a stream
+ * that had room and a deflated one lets through more than the guard allows.
  *
- * A guessed per-point constant would defeat the queue's byte budget, which
- * exists to bound what the next frame absorbs — chunks differ by which
- * optional attributes the source supplied.
+ * Array lengths are not read here: `pointCount` plus each present channel's
+ * element width is exact, because a decoder sizes every array it produces to
+ * the chunk's point count. Reading `.positions` would additionally raise the
+ * direct-position-access ratchet for no gain. `decodedChunkBytes matches the
+ * allocated arrays` in the integration suite asserts the arithmetic against
+ * real arrays, where reading them is permitted.
  */
 export function decodedChunkBytes(decoded: DecodedChunk): number {
   const n = Math.max(0, decoded.pointCount);
-  // positions Float32x3, intensity Uint16, classification/returnNumber/
-  // returnCount Uint8, gpsTime Float64.
-  let perPoint = 12 + 2 + 1 + 1 + 1 + 8;
-  if (decoded.rgb) perPoint += 3;
-  if (decoded.pointSourceId) perPoint += 2;
+  // Positions are the one required channel — Float32, three per point.
+  const perPoint =
+    3 * Float32Array.BYTES_PER_ELEMENT +
+    channelBytes(decoded.intensity, 1) +
+    channelBytes(decoded.classification, 1) +
+    channelBytes(decoded.returnNumber, 1) +
+    channelBytes(decoded.returnCount, 1) +
+    channelBytes(decoded.gpsTime, 1) +
+    channelBytes(decoded.rgb, 3) +
+    channelBytes(decoded.pointSourceId, 1);
   return n * perPoint;
 }
 

--- a/src/render/streaming/residentSnapshot.ts
+++ b/src/render/streaming/residentSnapshot.ts
@@ -43,9 +43,16 @@ export interface ResidentSnapshotOptions {
 
 /**
  * Concatenate the decoded resident chunks into one PointCloud, or return null
- * when nothing is resident yet. Optional channels (RGB, point-source id) are
- * emitted only when EVERY chunk carries them, so a partially-attributed set
- * never produces a half-filled array the writers would misread.
+ * when nothing is resident yet.
+ *
+ * EVERY per-point channel is emitted only when EVERY chunk carries it, so a
+ * partially-attributed set never produces a half-filled array the writers would
+ * misread. That rule used to cover only RGB and point-source id; it now covers
+ * intensity, classification, returns and GPS time too, because a chunk from a
+ * format that carries none of them (a `.pnts` tile) would otherwise contribute
+ * zeros an exported LAS would present as real classifications and readings.
+ * `PointCloud` already treats each of these as optional, so the writers omit
+ * the field rather than write a fabricated one.
  */
 export function buildResidentSnapshot(
   chunks: readonly DecodedChunk[],
@@ -56,28 +63,38 @@ export function buildResidentSnapshot(
   if (total === 0) return null;
 
   const positions = new Float32Array(total * 3);
-  const intensity = new Uint16Array(total);
-  const classification = new Uint8Array(total);
-  const returnNumber = new Uint8Array(total);
-  const returnCount = new Uint8Array(total);
-  const gpsTime = new Float64Array(total);
 
-  const allRgb = chunks.every((c) => c.rgb !== undefined && c.rgb.length >= c.pointCount * 3);
-  const allPsid = chunks.every(
-    (c) => c.pointSourceId !== undefined && c.pointSourceId.length >= c.pointCount,
-  );
-  const colors = allRgb ? new Uint8Array(total * 3) : undefined;
-  const pointSourceId = allPsid ? new Uint16Array(total) : undefined;
+  /** Whether every chunk carries this channel at full length. */
+  const everyChunkHas = (
+    pick: (c: DecodedChunk) => ArrayLike<number> | undefined,
+    perPoint: number,
+  ): boolean => chunks.every((c) => (pick(c)?.length ?? -1) >= c.pointCount * perPoint);
+
+  const intensity = everyChunkHas((c) => c.intensity, 1) ? new Uint16Array(total) : undefined;
+  const classification = everyChunkHas((c) => c.classification, 1)
+    ? new Uint8Array(total)
+    : undefined;
+  const returnNumber = everyChunkHas((c) => c.returnNumber, 1)
+    ? new Uint8Array(total)
+    : undefined;
+  const returnCount = everyChunkHas((c) => c.returnCount, 1) ? new Uint8Array(total) : undefined;
+  const gpsTime = everyChunkHas((c) => c.gpsTime, 1) ? new Float64Array(total) : undefined;
+  const colors = everyChunkHas((c) => c.rgb, 3) ? new Uint8Array(total * 3) : undefined;
+  const pointSourceId = everyChunkHas((c) => c.pointSourceId, 1)
+    ? new Uint16Array(total)
+    : undefined;
 
   let p = 0; // running point offset
   for (const c of chunks) {
     const n = c.pointCount;
     positions.set(renderLocalPositions(c).subarray(0, n * 3), p * 3);
-    intensity.set(c.intensity.subarray(0, n), p);
-    classification.set(c.classification.subarray(0, n), p);
-    returnNumber.set(c.returnNumber.subarray(0, n), p);
-    returnCount.set(c.returnCount.subarray(0, n), p);
-    gpsTime.set(c.gpsTime.subarray(0, n), p);
+    if (intensity && c.intensity) intensity.set(c.intensity.subarray(0, n), p);
+    if (classification && c.classification) {
+      classification.set(c.classification.subarray(0, n), p);
+    }
+    if (returnNumber && c.returnNumber) returnNumber.set(c.returnNumber.subarray(0, n), p);
+    if (returnCount && c.returnCount) returnCount.set(c.returnCount.subarray(0, n), p);
+    if (gpsTime && c.gpsTime) gpsTime.set(c.gpsTime.subarray(0, n), p);
     if (colors && c.rgb) colors.set(c.rgb.subarray(0, n * 3), p * 3);
     if (pointSourceId && c.pointSourceId) pointSourceId.set(c.pointSourceId.subarray(0, n), p);
     p += n;
@@ -85,11 +102,11 @@ export function buildResidentSnapshot(
 
   return new PointCloud({
     positions,
-    intensity,
-    classification,
-    returnNumber,
-    returnCount,
-    gpsTime,
+    ...(intensity ? { intensity } : {}),
+    ...(classification ? { classification } : {}),
+    ...(returnNumber ? { returnNumber } : {}),
+    ...(returnCount ? { returnCount } : {}),
+    ...(gpsTime ? { gpsTime } : {}),
     ...(colors ? { colors } : {}),
     ...(pointSourceId ? { pointSourceId } : {}),
     origin: [opts.origin[0], opts.origin[1], opts.origin[2]],

--- a/src/render/streaming/streamingAttach.ts
+++ b/src/render/streaming/streamingAttach.ts
@@ -118,9 +118,11 @@ export function buildSchedulerCallbacks(deps: {
     onNodeReady: (node: StreamingNode, decoded: DecodedChunk): void => {
       renderer.onNodeReady(node, decoded);
       // DISPLAY-ONLY class legend hook — hand the host the node's decoded
-      // per-point classification so the legend can fold its histogram in. A
-      // DecodedChunk always carries a `classification` array (zero-filled when
-      // the source lacked the field). Pure read; never touches the GPU mask.
+      // per-point classification so the legend can fold its histogram in. The
+      // channel is optional on a DecodedChunk, and a node from a format that
+      // carries none is skipped: folding zeros in would build a histogram
+      // claiming every point is "never classified". Pure read; never touches
+      // the GPU mask.
       const classesHook = nodeClassesHook();
       if (classesHook && decoded.classification) {
         try {

--- a/src/render/streaming/streamingColors.ts
+++ b/src/render/streaming/streamingColors.ts
@@ -46,16 +46,35 @@ let _rgbWorkFloat: Float32Array | null = null;
 let _rgbWorkOut: Uint8Array | null = null;
 
 /**
- * The grey a node is drawn in when its tile states no colour and the rest of
- * the layer does.
+ * The grey a node is drawn in when the channel the active mode reads is not
+ * something the node states: its tile carries no colour while the rest of the
+ * layer does, or the chunk carries no array for the requested scalar at all.
  *
- * Mid grey is achromatic, and the elevation ramp (Turbo) is not: nothing the
- * ramp produces looks like this, so a flat patch cannot be misread as a height
- * reading. It is a display value only. `rgb` stays absent on the chunk, so the
- * point inspector, the resident-snapshot export and the patch view all keep
- * reporting that these points state no colour.
+ * Mid grey is achromatic, and every ramp the viewer paints (Turbo for
+ * elevation and the scalars, the ASPRS palette for classes) is not: nothing a
+ * ramp produces looks like this, so a flat patch cannot be misread as a
+ * reading. It is a display value only. The chunk keeps saying the channel is
+ * absent, so the point inspector, the resident-snapshot export and the patch
+ * view all keep reporting that these points state nothing.
  */
 export const UNSTATED_COLOUR_GREY = 128;
+
+/**
+ * The flat buffer for a mode whose channel the chunk does not carry.
+ *
+ * Substituting another channel would put a second reading under the first
+ * one's legend: an elevation ramp under an "Intensity" label is a height map a
+ * user would read as intensity. A ramp over a zero-filled stand-in would be
+ * worse still, since it looks like a measurement of zero everywhere. Flat grey
+ * states nothing, which is exactly what the node has to say.
+ *
+ * A source only offers the modes its format can fill (`colorModes()`, which is
+ * `PNTS_COLOR_MODES` for point tiles), so this is the backstop for a mode
+ * arriving from a restored view state rather than a path the UI walks.
+ */
+function channelAbsentColors(pointCount: number): Uint8Array {
+  return new Uint8Array(pointCount * 3).fill(UNSTATED_COLOUR_GREY);
+}
 
 /**
  * Whether a decoded node is one a `.pnts` decoder marked as stating no colour
@@ -132,15 +151,30 @@ export function scalarRangeOf(
   return finiteMinMax(values, count);
 }
 
-/** The intensity `[min, max]` of a decoded chunk — used to seed the global range. */
-export function intensityRangeOf(decoded: DecodedChunk): { min: number; max: number } {
+/**
+ * The intensity `[min, max]` of a decoded chunk — used to seed the global
+ * range — or null when the chunk carries no intensity.
+ *
+ * Null rather than `{ 0, 0 }`: a seeded window of zero width would be a claim
+ * about the cloud's intensity, and a source with no intensity channel has no
+ * such claim to make. The caller leaves the global range untouched instead.
+ */
+export function intensityRangeOf(
+  decoded: DecodedChunk,
+): { min: number; max: number } | null {
+  if (!decoded.intensity) return null;
   return scalarRangeOf(decoded.intensity, decoded.pointCount);
 }
 
 /**
  * Per-point interleaved RGB (3 bytes/point) for one decoded streaming node in
- * the active mode, using the cloud-global ranges. A mode the node cannot
- * satisfy (RGB on a format without it, normals) falls back to elevation.
+ * the active mode, using the cloud-global ranges.
+ *
+ * A mode whose meaning the whole source lacks (RGB on a format without it,
+ * normals) falls back to the elevation ramp, which is the layer's one meaning
+ * in that case rather than a second one. A mode whose per-point channel this
+ * CHUNK does not carry is drawn flat instead — see {@link
+ * channelAbsentColors}; no other channel stands in for it.
  *
  * **Buffer-reuse contract.** When `mode === 'rgb'` and an `rgbAppearance`
  * is passed, the returned `Uint8Array` is a `subarray` view of a shared
@@ -204,6 +238,7 @@ export function streamingNodeColors(
       return out.subarray(0, len);
     }
     case 'intensity':
+      if (!decoded.intensity) return channelAbsentColors(n);
       return colorByIntensity(
         decoded.intensity,
         n,
@@ -211,6 +246,7 @@ export function streamingNodeColors(
         ranges.maxIntensity,
       );
     case 'classification':
+      if (!decoded.classification) return channelAbsentColors(n);
       return colorByClassification(decoded.classification, n);
     // The scalar modes colour against the cloud-GLOBAL window (never a
     // node-local one) for the same reason elevation and intensity do:
@@ -219,8 +255,10 @@ export function streamingNodeColors(
     // magnitude is handled inside `colorByScalar` — the min subtraction
     // happens in double precision, so sub-second deltas survive the ramp.
     case 'gpsTime':
+      if (!decoded.gpsTime) return channelAbsentColors(n);
       return colorByScalar(decoded.gpsTime, n, ranges.minGpsTime, ranges.maxGpsTime);
     case 'returnNumber':
+      if (!decoded.returnNumber) return channelAbsentColors(n);
       return colorByScalar(
         decoded.returnNumber,
         n,

--- a/tests/copcChunkDecode.test.ts
+++ b/tests/copcChunkDecode.test.ts
@@ -56,12 +56,12 @@ test('decodeRecords applies the coordinate bridge and extracts PDRF 6 fields', (
   expect(d.positions[0]).toBeCloseTo(100);
   expect(d.positions[1]).toBeCloseTo(200);
   expect(d.positions[2]).toBeCloseTo(30);
-  expect(d.intensity[0]).toBe(555);
-  expect(d.returnNumber[0]).toBe(1);
-  expect(d.returnCount[0]).toBe(2);
-  expect(d.classification[0]).toBe(5);
-  expect(d.gpsTime[0]).toBeCloseTo(12345.5);
-  expect(d.gpsTime[1]).toBeCloseTo(7.25);
+  expect(d.intensity?.[0]).toBe(555);
+  expect(d.returnNumber?.[0]).toBe(1);
+  expect(d.returnCount?.[0]).toBe(2);
+  expect(d.classification?.[0]).toBe(5);
+  expect(d.gpsTime?.[0]).toBeCloseTo(12345.5);
+  expect(d.gpsTime?.[1]).toBeCloseTo(7.25);
   expect(d.pointSourceId?.[0]).toBe(4242);
   expect(d.pointSourceId?.[1]).toBe(7);
   expect(d.rgb).toBeUndefined();
@@ -187,4 +187,50 @@ test('chunkTransferables lists every backing buffer (and RGB only when present)'
   });
   // The seven PDRF-6 buffers plus RGB.
   expect(chunkTransferables(d7)).toHaveLength(8);
+});
+
+test('chunkTransferables lists only the buffers a positions-only chunk has', () => {
+  // A chunk from a format with no measured channels (a `.pnts` tile) transfers
+  // one buffer. Listing the five absent ones would post buffers that are not
+  // there, and the worker boundary would throw rather than the decode failing
+  // where the mistake is.
+  expect(chunkTransferables({ pointCount: 4, positions: new Float32Array(12) })).toHaveLength(1);
+});
+
+/**
+ * `DecodedChunk` makes intensity, classification, both return fields and GPS
+ * time optional so a format that carries none of them (a `.pnts` tile) can say
+ * so instead of shipping zeros. That optionality is not permission for the LAS
+ * decoders to drop them: a LAS point record carries all five in every PDRF the
+ * COPC spec allows, so a COPC chunk that omitted one would be losing data the
+ * file holds. Pinned here, and for EPT in `eptBinaryDecode.test.ts`, so the
+ * change stays a widening of the contract rather than a removal.
+ */
+test('a COPC chunk carries all five LAS channels — the optionality is not a removal', () => {
+  const raw = buildRecords(30, [
+    { x: 1, y: 2, z: 3, intensity: 77, returnNum: 1, returnCount: 2, classification: 6, gps: 4.5 },
+    { x: 4, y: 5, z: 6, intensity: 88, returnNum: 2, returnCount: 2, classification: 2, gps: 9.5 },
+  ]);
+  const d = decodeRecords(raw, {
+    pointDataRecordFormat: 6,
+    pointRecordLength: 30,
+    pointCount: 2,
+    scale: [1, 1, 1],
+    offset: [0, 0, 0],
+    renderOrigin: [0, 0, 0],
+  });
+  for (const [name, channel] of [
+    ['intensity', d.intensity],
+    ['classification', d.classification],
+    ['returnNumber', d.returnNumber],
+    ['returnCount', d.returnCount],
+    ['gpsTime', d.gpsTime],
+  ] as const) {
+    expect(channel, `a COPC chunk must carry ${name}`).toBeDefined();
+    expect(channel, `${name} must be one value per point`).toHaveLength(2);
+  }
+  // Real readings, not an array of zeros that happens to be the right length.
+  expect([...d.intensity!]).toEqual([77, 88]);
+  expect([...d.classification!]).toEqual([6, 2]);
+  expect([...d.gpsTime!]).toEqual([4.5, 9.5]);
 });

--- a/tests/eptBinaryDecode.test.ts
+++ b/tests/eptBinaryDecode.test.ts
@@ -95,7 +95,7 @@ test('a uint64 value beyond 2^53 − 1 throws; one within range converts exactly
     view.setBigUint64(off('GpsTime'), (1n << 53n) - 1n, true);
   });
   const decoded = decodeEptBinaryTile(ok, 1, schema, [0, 0, 0]);
-  expect(decoded.gpsTime[0]).toBe(9007199254740991);
+  expect(decoded.gpsTime?.[0]).toBe(9007199254740991);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -176,5 +176,48 @@ test('a declared float64 attribute still reads as Float64 (unchanged path)', () 
   });
   const decoded = decodeEptBinaryTile(tile, 1, schema, [0, 0, 0]);
   expect(decoded.positions[0]).toBe(7);
-  expect(decoded.gpsTime[0]).toBe(123456.75);
+  expect(decoded.gpsTime?.[0]).toBe(123456.75);
+});
+
+/**
+ * The mirror of `a COPC chunk carries all five LAS channels` in
+ * `copcChunkDecode.test.ts`. `DecodedChunk` makes the measured channels
+ * optional for formats that carry none of them; EPT is not one of those, so an
+ * EPT tile must keep producing all five and this pins that it does.
+ */
+test('an EPT binary chunk carries all five LAS channels', () => {
+  const schema: EptSchemaField[] = [
+    { name: 'X', size: 4, type: 'signed', scale: 1 },
+    { name: 'Y', size: 4, type: 'signed', scale: 1 },
+    { name: 'Z', size: 4, type: 'signed', scale: 1 },
+    { name: 'Intensity', size: 2, type: 'unsigned', scale: 1 },
+    { name: 'Classification', size: 1, type: 'unsigned', scale: 1 },
+    { name: 'ReturnNumber', size: 1, type: 'unsigned', scale: 1 },
+    { name: 'NumberOfReturns', size: 1, type: 'unsigned', scale: 1 },
+    { name: 'GpsTime', size: 8, type: 'float', scale: 1 },
+  ];
+  const tile = tileFor(schema, (view, off) => {
+    view.setInt32(off('X'), 1, true);
+    view.setUint16(off('Intensity'), 4321, true);
+    view.setUint8(off('Classification'), 6);
+    view.setUint8(off('ReturnNumber'), 2);
+    view.setUint8(off('NumberOfReturns'), 3);
+    view.setFloat64(off('GpsTime'), 55.25, true);
+  });
+  const decoded = decodeEptBinaryTile(tile, 1, schema, [0, 0, 0]);
+  for (const [name, channel] of [
+    ['intensity', decoded.intensity],
+    ['classification', decoded.classification],
+    ['returnNumber', decoded.returnNumber],
+    ['returnCount', decoded.returnCount],
+    ['gpsTime', decoded.gpsTime],
+  ] as const) {
+    expect(channel, `an EPT chunk must carry ${name}`).toBeDefined();
+    expect(channel, `${name} must be one value per point`).toHaveLength(1);
+  }
+  expect(decoded.intensity?.[0]).toBe(4321);
+  expect(decoded.classification?.[0]).toBe(6);
+  expect(decoded.returnNumber?.[0]).toBe(2);
+  expect(decoded.returnCount?.[0]).toBe(3);
+  expect(decoded.gpsTime?.[0]).toBe(55.25);
 });

--- a/tests/eptStreaming.test.ts
+++ b/tests/eptStreaming.test.ts
@@ -107,7 +107,7 @@ test('decodeEptBinaryTile decodes the synthetic fixture cleanly', () => {
 
   // Classification values come from the fixture's choice set {1,2,5,6,9}.
   for (let i = 0; i < 100; i++) {
-    expect([1, 2, 5, 6, 9]).toContain(decoded.classification[i]);
+    expect([1, 2, 5, 6, 9]).toContain(decoded.classification?.[i]);
   }
 });
 

--- a/tests/olvTileSource.test.ts
+++ b/tests/olvTileSource.test.ts
@@ -255,7 +255,7 @@ describe('OlvTileSource', () => {
       }
     }
     expect(outside).toBe(0);
-    expect(decoded.classification[0]).toBe(2);
+    expect(decoded.classification?.[0]).toBe(2);
     expect(decoded.rgb?.[2]).toBe(9);
   });
 

--- a/tests/pntsDecode.test.ts
+++ b/tests/pntsDecode.test.ts
@@ -104,13 +104,17 @@ describe('attributes the format does not carry', () => {
     expect(PNTS_COLOR_MODES).not.toContain('classification');
   });
 
-  it('sizes the required arrays without claiming they are readings', async () => {
+  it('allocates no array for a channel the format does not carry', async () => {
     const out = await decoder.decode(makePnts([[0, 0, 0], [1, 1, 1]]), meta());
     expect(out.pointCount).toBe(2);
-    for (const a of [out.intensity, out.classification, out.returnNumber, out.returnCount]) {
-      expect(a).toHaveLength(2);
-      expect([...a].every((v) => v === 0)).toBe(true);
-    }
+    // Absent, not zero-filled. A zero classification means "never classified"
+    // and a zero intensity is not a measured zero, so the chunk must be able to
+    // say the channel is missing rather than hand a reader 2 fake readings.
+    expect(out.intensity, 'a point tile carries no intensity').toBeUndefined();
+    expect(out.classification, 'a point tile carries no classification').toBeUndefined();
+    expect(out.returnNumber, 'a point tile carries no return number').toBeUndefined();
+    expect(out.returnCount, 'a point tile carries no return count').toBeUndefined();
+    expect(out.gpsTime, 'a point tile carries no GPS time').toBeUndefined();
   });
 
   it('carries RGB through when the tile has it, and omits it when it does not', async () => {

--- a/tests/residentSnapshot.test.ts
+++ b/tests/residentSnapshot.test.ts
@@ -71,6 +71,36 @@ describe('buildResidentSnapshot', () => {
     expect(mixedPsid.pointSourceId).toBeUndefined();
   });
 
+  /**
+   * A `.pnts` tile carries no intensity, classification, returns or GPS time,
+   * so its chunk omits them. An export must omit them too: writing zeros would
+   * put "never classified" and a measured intensity of nought into a LAS file
+   * as if the source had said so. Same all-or-nothing rule RGB and point-source
+   * id already followed.
+   */
+  it('omits a channel no chunk carries rather than exporting zeros', () => {
+    const positionsOnly: DecodedChunk = { pointCount: 3, positions: new Float32Array(9) };
+    const cloud = buildResidentSnapshot([positionsOnly], OPTS)!;
+    expect(cloud.pointCount).toBe(3);
+    expect(cloud.intensity).toBeUndefined();
+    expect(cloud.classification).toBeUndefined();
+    expect(cloud.returnNumber).toBeUndefined();
+    expect(cloud.returnCount).toBeUndefined();
+    expect(cloud.gpsTime).toBeUndefined();
+  });
+
+  it('drops a channel only some chunks carry, keeping the ones every chunk has', () => {
+    const positionsOnly: DecodedChunk = { pointCount: 2, positions: new Float32Array(6) };
+    const mixed = buildResidentSnapshot([chunk(2, 0), positionsOnly], OPTS)!;
+    expect(mixed.pointCount).toBe(4);
+    // Half the points would have been fabricated, so none of it is written.
+    expect(mixed.intensity).toBeUndefined();
+    expect(mixed.classification).toBeUndefined();
+    expect(mixed.gpsTime).toBeUndefined();
+    // Positions are on every chunk, so they survive the mixture.
+    expect(mixed.positions).toHaveLength(12);
+  });
+
   it('stamps the declared count to equal the decoded count (not a lossy read)', () => {
     const cloud = buildResidentSnapshot([chunk(4, 0)], OPTS)!;
     expect(cloud.declaredPointCount).toBe(4);

--- a/tests/streamingColors.test.ts
+++ b/tests/streamingColors.test.ts
@@ -34,7 +34,23 @@ function metadata(hasRgb: boolean, hasGpsTime = true): CopcMetadata {
   };
 }
 
-function chunk(n: number, withRgb: boolean): DecodedChunk {
+/**
+ * A LAS-family chunk: every measured channel present, which is exactly what the
+ * COPC, EPT and tile-store decoders produce. `DecodedChunk` makes those five
+ * optional so a format that carries none of them (a `.pnts` tile) can say so,
+ * but this helper always fills them, and the type says so — a test that seeds
+ * one reads it back without a null check, and the helper cannot quietly stop
+ * producing them.
+ */
+type FullChunk = DecodedChunk &
+  Required<
+    Pick<
+      DecodedChunk,
+      'intensity' | 'classification' | 'returnNumber' | 'returnCount' | 'gpsTime'
+    >
+  >;
+
+function chunk(n: number, withRgb: boolean): FullChunk {
   return {
     pointCount: n,
     positions: new Float32Array(n * 3),
@@ -169,6 +185,46 @@ test('returnNumber mode colours against the GLOBAL return range', () => {
   const out = streamingNodeColors('returnNumber', c, global);
   expect([out[0], out[1], out[2]]).toEqual(CIVIDIS_LO);
   expect([out[6], out[7], out[8]]).toEqual(CIVIDIS_HI);
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Channels the chunk does not carry
+// ────────────────────────────────────────────────────────────────────────────
+
+/** A chunk from a format that carries positions and nothing else — a `.pnts` tile. */
+function positionsOnly(n: number): DecodedChunk {
+  return { pointCount: n, positions: new Float32Array(n * 3) };
+}
+
+test('intensityRangeOf returns null for a chunk with no intensity', () => {
+  // Not { 0, 0 }. A zero-width window is a claim about the cloud's intensity,
+  // and a source with no intensity has no such claim to make — the caller
+  // leaves the cloud-global range alone instead of seeding it from nothing.
+  expect(intensityRangeOf(positionsOnly(4))).toBeNull();
+});
+
+test('a mode whose channel the chunk lacks is drawn flat, never ramped', () => {
+  // The grey stand-in, not a ramp. Substituting elevation would put a height
+  // map under the intensity legend; ramping a zero-filled stand-in would look
+  // like a measurement of nought at every point. Both read as data.
+  const c = positionsOnly(3);
+  const r = ranges({ maxZ: 10, maxIntensity: 255, maxGpsTime: 100, maxReturnNumber: 5 });
+  for (const mode of ['intensity', 'classification', 'gpsTime', 'returnNumber'] as const) {
+    const out = streamingNodeColors(mode, c, r);
+    expect(out, `${mode} must still produce 3 bytes per point`).toHaveLength(9);
+    expect([...out], `${mode} must be flat achromatic grey`).toEqual(new Array(9).fill(128));
+  }
+});
+
+test('elevation still ramps a positions-only chunk — it is derived, not measured', () => {
+  // The counterweight to the test above: elevation comes from positions, which
+  // every chunk carries, so it must NOT be greyed out.
+  const c = positionsOnly(2);
+  c.positions[2] = 0;
+  c.positions[5] = 10;
+  const out = streamingNodeColors('elevation', c, ranges({ maxZ: 10 }));
+  expect(out).toHaveLength(6);
+  expect([out[0], out[1], out[2]]).not.toEqual([out[3], out[4], out[5]]);
 });
 
 test('availableStreamingModes gates gpsTime on the header flag, always offers returnNumber', () => {

--- a/tests/streamingReseed.test.ts
+++ b/tests/streamingReseed.test.ts
@@ -58,11 +58,23 @@ describe('shouldReseedColorRange', () => {
  * colours handed to `buildPointMesh` are captured so the test can assert on
  * the exact bytes a real mesh would upload.
  */
-function viewerCapture(): { viewer: Viewer; captured: Uint8Array[] } {
+function viewerCapture(): {
+  viewer: Viewer;
+  captured: Uint8Array[];
+  /** The class / intensity arguments each `buildPointMesh` call received. */
+  channels: { classification: unknown; intensity: unknown }[];
+} {
   const captured: Uint8Array[] = [];
+  const channels: { classification: unknown; intensity: unknown }[] = [];
   const viewer = {
-    buildPointMesh: (_positions: Float32Array, colors: Uint8Array): PointMeshHandle => {
+    buildPointMesh: (
+      _positions: Float32Array,
+      colors: Uint8Array,
+      classification?: ArrayLike<number> | null,
+      intensity?: ArrayLike<number> | null,
+    ): PointMeshHandle => {
       captured.push(colors.slice());
+      channels.push({ classification, intensity });
       return {
         mesh: {},
         material: {},
@@ -72,7 +84,7 @@ function viewerCapture(): { viewer: Viewer; captured: Uint8Array[] } {
     },
     addStreamingMesh: () => undefined,
   } as unknown as Viewer;
-  return { viewer, captured };
+  return { viewer, captured, channels };
 }
 
 function sourceStub(): StreamingSource {
@@ -138,5 +150,52 @@ describe('StreamingRenderer elevation seed', () => {
     expect(r.maxZ).toBe(dataZ[1]);
     // The cube would have made the window ~85x too tall — assert we didn't.
     expect(r.maxZ - r.minZ).toBeLessThan(2000);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Channels the chunk does not carry
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('onNodeReady with a positions-only chunk', () => {
+  /** A `.pnts`-shaped chunk: positions and nothing else. */
+  const positionsOnly = (zs: number[]): DecodedChunk => {
+    const positions = new Float32Array(zs.length * 3);
+    zs.forEach((z, i) => {
+      positions[i * 3 + 2] = z;
+    });
+    return { pointCount: zs.length, positions };
+  };
+
+  it('leaves a scalar window untouched rather than seeding it from nothing', () => {
+    const { viewer } = viewerCapture();
+    const renderer = new StreamingRenderer(viewer, sourceStub(), 'elevation');
+    const before = renderer.colorRanges;
+    renderer.onNodeReady(nodeAt(0, 'root'), positionsOnly([0, 5, 10]));
+    const after = renderer.colorRanges;
+    // Intensity, GPS time and return number have no chunk data behind them, so
+    // their windows must read exactly as they did before the node arrived. A
+    // window seeded off an absent array would be a claim about a measurement
+    // the source never made.
+    expect(after.minIntensity).toBe(before.minIntensity);
+    expect(after.maxIntensity).toBe(before.maxIntensity);
+    expect(after.minGpsTime).toBe(before.minGpsTime);
+    expect(after.maxGpsTime).toBe(before.maxGpsTime);
+    expect(after.minReturnNumber).toBe(before.minReturnNumber);
+    expect(after.maxReturnNumber).toBe(before.maxReturnNumber);
+    // Elevation comes from positions, which the chunk does carry, so it seeds.
+    expect(after.maxZ).toBe(10);
+  });
+
+  it('passes null class and intensity to the mesh, so no filter reads a fake zero', () => {
+    const { viewer, channels } = viewerCapture();
+    const renderer = new StreamingRenderer(viewer, sourceStub(), 'elevation');
+    renderer.onNodeReady(nodeAt(0, 'root'), positionsOnly([0, 1]));
+    // Not a zero-filled array. `buildPointMesh` skips the `aClass` attribute
+    // for null, which keeps the mesh fully visible; an array of zeros would
+    // make every point read as class 0 and vanish the moment a user unticks
+    // "Never classified" in a scan that was never classified at all.
+    expect(channels[0].classification).toBeNull();
+    expect(channels[0].intensity).toBeNull();
   });
 });

--- a/tests/streamingUploadQueueIntegration.test.ts
+++ b/tests/streamingUploadQueueIntegration.test.ts
@@ -219,6 +219,40 @@ describe('decodedChunkBytes', () => {
     const withRgb = decodedChunkBytes({ ...base, rgb: new Uint8Array(n * 3) });
     expect(withRgb - decodedChunkBytes(base)).toBe(30);
   });
+
+  /**
+   * The figure the queue's byte budget is spent against. It used to be a fixed
+   * LAS-shaped per-point constant, which charged a chunk for intensity,
+   * classification, both return fields and GPS time whether or not it carried
+   * them. A `.pnts` tile carries none of the five, so the budget was told 13
+   * bytes per point existed that did not, and the guard bounded the wrong
+   * number. These two pin that the accounting now follows the chunk.
+   */
+  it('charges a positions-only chunk for positions alone', () => {
+    const n = 250;
+    const positionsOnly = { pointCount: n, positions: new Float32Array(n * 3) };
+    // Float32 × 3 and nothing else.
+    expect(decodedChunkBytes(positionsOnly)).toBe(n * 12);
+  });
+
+  it('differs by exactly the five channels between a LAS chunk and one without', () => {
+    const n = 64;
+    const positionsOnly = { pointCount: n, positions: new Float32Array(n * 3) };
+    const lasShaped = {
+      ...positionsOnly,
+      intensity: new Uint16Array(n),
+      classification: new Uint8Array(n),
+      returnNumber: new Uint8Array(n),
+      returnCount: new Uint8Array(n),
+      gpsTime: new Float64Array(n),
+    };
+    const difference = decodedChunkBytes(lasShaped) - decodedChunkBytes(positionsOnly);
+    // Uint16 + three Uint8 + Float64 = 13 bytes per point, the storage a
+    // format without those channels no longer spends.
+    expect(difference).toBe(n * 13);
+    expect(decodedChunkBytes(lasShaped)).toBe(n * 25);
+    expect(decodedChunkBytes(positionsOnly)).toBe(n * 12);
+  });
 });
 
 /**


### PR DESCRIPTION
`DecodedChunk` required intensity, classification, return number, return count and GPS time. A PNTS tile carries none of them, so `pntsDecode` zero-filled all five to satisfy the type: 13 bytes per point for values that were not readings. A positions-only chunk now costs 12 bytes per point instead of 25.

The five are optional. Seventeen consumer sites were surfaced by the compiler and handled per channel. The snapshot writes a channel only when every chunk has it, a colour mode without its channel draws flat grey, the range seeder skips that window, and `buildPointMesh` gets null. `decodedChunkBytes` sums each present channel's `BYTES_PER_ELEMENT` rather than a fixed LAS layout.

COPC, EPT and the tile store still fill all five. New tests pin that.
