### PR TITLE
test(3dtiles): end-to-end coverage for opening a tileset from a URL

### DIFF
--- a/tests/e2e/tilesetOpen.spec.ts
+++ b/tests/e2e/tilesetOpen.spec.ts
@@ -1,0 +1,276 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import {
+  boxTileset,
+  regionTileset,
+  TILESET_ORIGIN,
+  type TilesetScene,
+} from '../fixtures/tileset3d';
+
+/**
+ * 3D Tiles end-to-end: a `tileset.json` URL opens, streams and becomes a scan.
+ *
+ * The path under test is the one a user reaches by pasting a URL. `main.ts`
+ * `handleRemoteUrl` routes a `tileset.json` through `isTilesetEntryUrl` to
+ * `openRemoteTileset`, which fetches the document, walks it into a
+ * `TilesetStreamingSource` and attaches it; the scheduler then culls against the
+ * camera and fetches the `.pnts` bodies it needs. Twelve unit suites cover the
+ * pieces. None of them runs the shell, so none can say whether a tileset arrives
+ * as a scan the rest of the app treats as one.
+ *
+ * WHY THE FIXTURE IS BUILT RATHER THAN SHIPPED. The COPC specs next door need an
+ * 80 MB scan no clone carries, so they `test.skip` on CI and the coverage they
+ * claim is not run there. A tileset does not have that problem: the whole
+ * dataset here is a few kilobytes of JSON and float32, so `tests/fixtures/
+ * tileset3d.ts` builds it and `page.route` serves it. Every test in this file
+ * runs on every machine, CI included — there is no `test.skip` and no fixture
+ * probe, which is the point.
+ *
+ * The host is `tiles.example.com`, following `urlOpen.spec.ts`: it is a public
+ * name, so it passes the SSRF block-list the entry URL is validated against, and
+ * nothing ever leaves the route handler.
+ */
+
+/** Serve one or more synthetic datasets, and record every URL the page asks for. */
+async function serveTilesets(page: Page, ...scenes: TilesetScene[]): Promise<string[]> {
+  const files = new Map(scenes.flatMap((scene) => [...scene.files]));
+  const requested: string[] = [];
+  await page.route(`**://${new URL(TILESET_ORIGIN).host}/**`, async (route) => {
+    const url = route.request().url();
+    requested.push(url);
+    const file = files.get(url);
+    // A 404 rather than an abort: a dataset that names a body this scene does
+    // not serve should fail the way a real host fails, not as a network error.
+    if (!file) return route.fulfill({ status: 404, body: 'not found' });
+    return route.fulfill({
+      status: 200,
+      contentType: file.contentType,
+      headers: { 'access-control-allow-origin': '*' },
+      body: Buffer.from(file.body),
+    });
+  });
+  return requested;
+}
+
+/** Paste the entry URL into the empty state's open-from-URL field and submit. */
+async function openTilesetUrl(page: Page, scene: TilesetScene, query = ''): Promise<void> {
+  await page.goto(`/${query}`);
+  await expect(page.locator('.olv-empty-title')).toBeVisible();
+  await page.locator('.olv-url-input').fill(scene.entryUrl);
+  await page.locator('.olv-url-btn').click();
+}
+
+/** The empty state gives way once the tileset is attached and committed. */
+async function expectAttached(page: Page): Promise<void> {
+  await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 40_000 });
+}
+
+/** The Scan Report body, which lives in a `<details>` that starts collapsed. */
+function scanReport(page: Page): Locator {
+  return page.locator('.olv-report');
+}
+
+/**
+ * Points currently drawn, from the `?debug=1` overlay's rendering block.
+ *
+ * The Streaming panel carries the same counter and would be the natural place
+ * to read it, but this open never shows that panel, so the overlay is the
+ * surface that actually reports what the renderer drew.
+ */
+async function pointsShown(page: Page): Promise<number> {
+  const text = (await page.locator('.olv-debug').textContent()) ?? '';
+  const match = /points\s+([\d,]+)\s+shown/.exec(text);
+  return match ? Number(match[1].replace(/,/g, '')) : -1;
+}
+
+test.describe('3D Tiles — opening a tileset from a URL', () => {
+  test('streams the tiles into the scene and puts a point under the cursor', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    const scene = boxTileset();
+    const requested = await serveTilesets(page, scene);
+
+    await openTilesetUrl(page, scene, '?debug=1');
+    await expectAttached(page);
+
+    // Every point of the dataset reaches the renderer. `points N shown` is the
+    // renderer's own count of what it drew this frame, so this is not "the open
+    // did not throw": it is the fixture's tiles, decoded, uploaded and drawn.
+    await expect
+      .poll(() => pointsShown(page), { timeout: 40_000 })
+      .toBe(scene.totalPoints);
+
+    // And they are really in the scene, not merely counted: Inspect raycasts the
+    // resident nodes, so a card with per-point rows means a click landed on a
+    // decoded tile point. Clicking in a poll waits on the condition (a hit)
+    // rather than on a duration — the framing tween is still settling early on,
+    // so the first click can legitimately miss.
+    await page.locator('.olv-tool', { hasText: 'Inspect' }).click();
+    const canvas = page.locator('.olv-canvas');
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error('the canvas has no bounding box');
+    const card = page.locator('.olv-inspect-card');
+    const offsets = [0.5, 0.46, 0.54, 0.42, 0.58];
+    let attempt = 0;
+    await expect
+      .poll(
+        async () => {
+          const f = offsets[attempt++ % offsets.length];
+          await canvas.click({ position: { x: box.width * f, y: box.height * f } });
+          return card.isVisible();
+        },
+        { timeout: 40_000, message: 'no Inspect click landed on a tileset point' },
+      )
+      .toBe(true);
+    // The card names the layer it hit — this tileset, not a leftover scan.
+    await expect(card).toContainText('tileset.json');
+    await expect(card.locator('.olv-inspect-row').first()).toBeVisible();
+
+    // The scheduler fetched tile bodies, so the open really streamed rather
+    // than drawing something the entry document alone could supply.
+    for (const tile of scene.tileUrls) expect(requested).toContain(tile);
+  });
+
+  test('is a first-class scan: the measurement tools are offered, not refused', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    // Regression pin for the shell reading a null `sourcePointCount` as "no
+    // scan": a tileset states no point total, and while that absence was read as
+    // absence-of-scan every measurement preflight refused with NO_SCAN_LOADED
+    // over a tileset that was drawn and pickable.
+    const scene = boxTileset();
+    await serveTilesets(page, scene);
+    await openTilesetUrl(page, scene);
+    await expectAttached(page);
+
+    // The dock's Measure tool is live and opens the measurement bar.
+    const measure = page.locator('.olv-tool', { hasText: 'Measure' });
+    await expect(measure).toBeEnabled();
+    await measure.click();
+    await expect(page.locator('.olv-measure-bar')).toBeVisible();
+    await expect(page.locator('.olv-mkind', { hasText: /^Distance$/ })).toBeVisible();
+
+    // Process Studio is where a withheld tool says WHY, so it carries the
+    // preflight verdict this regression was about. Its rows are read as content
+    // rather than asserted visible: this open leaves the left rail's mode body
+    // hidden, which is a separate defect and not what this test is pinning.
+    const studio = page.locator('.olv-process-studio');
+    const tools = studio.locator('.olv-ps-tool');
+    await expect(tools).toHaveCount(4, { timeout: 20_000 });
+    const distance = studio.locator('.olv-ps-tool', { hasText: 'Distance' });
+    await expect(distance).toHaveCount(1);
+    await expect(distance).not.toHaveClass(/olv-ps-blocked/);
+    // The exact sentence the refusal used to carry, on any tool row.
+    await expect(
+      studio.locator('.olv-ps-tool', { hasText: 'No scan is loaded' }),
+    ).toHaveCount(0);
+  });
+
+  test('publishes a Scan Report for the tileset, and says up was never established', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    // Two regressions in one open, because they share it. The report was never
+    // published on this path at all, so the Inspector kept the previously opened
+    // scan's rows. And a tileset whose volumes are all `box` declares no
+    // geocentric frame, which draws exactly like one that does — the report is
+    // the only place the difference can appear.
+    const scene = boxTileset();
+    await serveTilesets(page, scene);
+    await openTilesetUrl(page, scene);
+    await expectAttached(page);
+
+    await expect
+      .poll(() => page.locator('.olv-report-row').count(), { timeout: 30_000 })
+      .toBeGreaterThan(0);
+
+    const report = scanReport(page);
+    // The report is about THIS scan: a tileset's own format, and the point total
+    // it does not state, rather than a figure carried over or invented.
+    await expect(report).toContainText('3D Tiles (point tiles)');
+    await expect(report).toContainText('not stated by the source');
+    // The frame statement for a `box` tileset.
+    await expect(report).toContainText('Frame not established, no vertical reference, metres');
+    await expect(report).toContainText('which way is up is not established');
+  });
+
+  test('a region tileset reads as ellipsoidal, and raises no unestablished-frame notice', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    // A `region` is stated in EPSG:4979, which fixes the root frame as WGS84
+    // geocentric. That establishes up, and it establishes it no more strongly
+    // than the document allows: 3D Tiles carries no vertical datum, so the
+    // height is ellipsoidal and naming an orthometric one would be a second lie
+    // in place of the first.
+    const scene = regionTileset();
+    await serveTilesets(page, scene);
+    await openTilesetUrl(page, scene);
+    await expectAttached(page);
+
+    await expect
+      .poll(() => page.locator('.olv-report-row').count(), { timeout: 30_000 })
+      .toBeGreaterThan(0);
+
+    const report = scanReport(page);
+    await expect(report).toContainText('Local east-north-up, ellipsoidal height, metres');
+    await expect(report).toContainText(
+      'region bounding volume (EPSG:4979), which fixes the root frame as WGS84 geocentric',
+    );
+    await expect(report).not.toContainText('Frame not established');
+    await expect(report).not.toContainText('which way is up is not established');
+    // Never an orthometric datum: the format states none, so none may be named.
+    await expect(report).not.toContainText(/orthometric|geoid|EGM\d|NAVD|mean sea level/i);
+  });
+
+  test('refuses a tileset carrying mesh content, by name, before fetching a tile', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    // A `.b3dm` is real 3D Tiles content this viewer has no decoder for. Drawing
+    // the rest would be a scene with a piece silently missing, so the open is
+    // refused — and the refusal has to reach the user as words rather than as a
+    // blank canvas or a generic "decoding failed".
+    const scene = boxTileset({ childContentUri: 'child-a.b3dm', path: '/mesh' });
+    const requested = await serveTilesets(page, scene);
+    await openTilesetUrl(page, scene);
+
+    const toast = page.locator('.olv-toast');
+    await expect(toast).toHaveClass(/olv-toast-error/, { timeout: 40_000 });
+    await expect(toast).toContainText(
+      'This tileset has 1 tile(s) this reader cannot serve, so opening it would leave part of the scene missing.',
+    );
+    await expect(toast).toContainText(
+      'child-a.b3dm: not a point tile, and this viewer decodes no other content.',
+    );
+
+    // The user is left where they started rather than staring at a blank scene.
+    await expect(page.locator('.olv-empty')).toBeVisible();
+    // Never partially mounted: a refused tileset causes no tile fetch at all,
+    // which is a claim about what was NOT requested.
+    expect(requested).toEqual([scene.entryUrl]);
+  });
+
+  test('tells the user why a tileset whose tiles disagree about colour keeps one meaning', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    // The root tile carries RGB and the children carry none. A streaming reader
+    // sees one tile at a time, so the first tile with points settles the layer's
+    // colour meaning and every later tile is drawn in that meaning. Which tile
+    // decodes first is the scheduler's business, so this asserts what both
+    // outcomes must say rather than picking one.
+    const scene = boxTileset({ colour: 'mixed' });
+    await serveTilesets(page, scene);
+    await openTilesetUrl(page, scene);
+    await expectAttached(page);
+
+    const notice = page.locator('.olv-lasso-toast');
+    await expect(notice).toBeVisible({ timeout: 40_000 });
+    await expect(notice).toContainText(
+      'Some tiles in this tileset carry colour and others do not.',
+    );
+    await expect(notice).toContainText('so the scene keeps one colour meaning');
+  });
+});

--- a/tests/fixtures/tileset3d.ts
+++ b/tests/fixtures/tileset3d.ts
@@ -1,0 +1,281 @@
+/**
+ * tileset3d.ts — synthetic 3D Tiles datasets, small enough to live in the repo.
+ *
+ * The COPC end-to-end tests need an 80 MB scan that no clone carries, so they
+ * skip on CI and the coverage they claim is not run there. A tileset has no
+ * such excuse: a `tileset.json` is a few hundred bytes of JSON and a `.pnts`
+ * body is a header plus float32 positions, so a whole streaming dataset fits in
+ * a few kilobytes and can be BUILT rather than shipped. Nothing here reads the
+ * disk or the network, which is what lets the e2e specs serve these bodies from
+ * `page.route` and run everywhere.
+ *
+ * WHAT EACH SCENE IS FOR. `boxTileset` declares its volumes as `box`, which
+ * states nothing about which way is up; `regionTileset` declares a `region`,
+ * which fixes the root frame as WGS84 geocentric. The pair is the difference
+ * the Scan Report has to state, and it is the only difference between them: the
+ * two draw identically, so a test that did not read the report could not tell
+ * them apart.
+ *
+ * Point counts are kept under a thousand on purpose. The viewer's counters
+ * abbreviate at 1 000 (`formatCount`), so a small dataset lets a spec assert on
+ * an exact integer instead of a rounded "0.9K".
+ *
+ * Pure: no fetch, no DOM, no Playwright. A spec turns {@link TilesetScene.files}
+ * into routes.
+ */
+
+import { geodeticToEcef } from '../../src/io/tiles3d/boundingVolume';
+
+/** `pnts`, little-endian — the first four bytes of every point-tile body. */
+export const PNTS_MAGIC = 0x73746e70;
+
+export type Point3 = readonly [number, number, number];
+export type Rgb = readonly [number, number, number];
+
+/** Optional feature-table content for {@link makePnts}. */
+export interface PntsOptions {
+  /** `RTC_CENTER`, the tile-local origin the positions are relative to. */
+  readonly rtc?: Point3;
+  /** One `RGB` triple per point, or omitted for a tile that states no colour. */
+  readonly rgb?: readonly Rgb[];
+}
+
+/**
+ * A minimal valid `.pnts` body: the 28-byte header, the feature-table JSON
+ * padded to an 8-byte boundary, then the feature-table binary.
+ *
+ * The same construction the unit suite uses (`tests/pntsDecode.test.ts`,
+ * `tests/tiles3dTilesetOpen.test.ts`, `tests/pntsDecodeCeiling.test.ts`), kept
+ * here so the browser tests do not add a fourth copy of it.
+ */
+export function makePnts(points: readonly Point3[], options: PntsOptions = {}): Uint8Array {
+  const positionBytes = points.length * 3 * 4;
+  const featureTable: Record<string, unknown> = {
+    POINTS_LENGTH: points.length,
+    POSITION: { byteOffset: 0 },
+  };
+  if (options.rtc) featureTable.RTC_CENTER = options.rtc;
+  if (options.rgb) featureTable.RGB = { byteOffset: positionBytes };
+  let json = JSON.stringify(featureTable);
+  while (json.length % 8 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const binaryBytes = positionBytes + (options.rgb ? points.length * 3 : 0);
+  const total = 28 + jsonBytes.length + binaryBytes;
+  const buffer = new ArrayBuffer(total);
+  const view = new DataView(buffer);
+  view.setUint32(0, PNTS_MAGIC, true);
+  view.setUint32(4, 1, true); // version
+  view.setUint32(8, total, true); // byteLength
+  view.setUint32(12, jsonBytes.length, true); // featureTableJSONByteLength
+  view.setUint32(16, binaryBytes, true); // featureTableBinaryByteLength
+  view.setUint32(20, 0, true); // batchTableJSONByteLength
+  view.setUint32(24, 0, true); // batchTableBinaryByteLength
+  new Uint8Array(buffer, 28, jsonBytes.length).set(jsonBytes);
+  const binaryStart = 28 + jsonBytes.length;
+  let k = 0;
+  for (const p of points) for (const c of p) view.setFloat32(binaryStart + k++ * 4, c, true);
+  if (options.rgb) {
+    const bytes = new Uint8Array(buffer, binaryStart + positionBytes, points.length * 3);
+    let j = 0;
+    for (const c of options.rgb) for (const v of c) bytes[j++] = v;
+  }
+  return new Uint8Array(buffer);
+}
+
+/**
+ * A square grid of points over `[-half, half]` on x and y, with a gentle
+ * sinusoidal z so the cloud has volume and the camera framing produces a
+ * sensible orbit pose rather than an edge-on plane.
+ */
+export function gridPoints(side: number, half: number, offset: Point3 = [0, 0, 0]): Point3[] {
+  const points: Point3[] = [];
+  for (let i = 0; i < side; i++) {
+    for (let j = 0; j < side; j++) {
+      const u = side === 1 ? 0.5 : i / (side - 1);
+      const v = side === 1 ? 0.5 : j / (side - 1);
+      const x = (u * 2 - 1) * half;
+      const y = (v * 2 - 1) * half;
+      const z = Math.sin(u * Math.PI) * Math.cos(v * Math.PI) * (half * 0.15);
+      points.push([x + offset[0], y + offset[1], z + offset[2]]);
+    }
+  }
+  return points;
+}
+
+/** One grey per point, so a tile "carries colour" without carrying meaning. */
+export function flatRgb(count: number): Rgb[] {
+  return Array.from({ length: count }, (_, i) => {
+    const v = 60 + ((i * 7) % 180);
+    return [v, v, v] as Rgb;
+  });
+}
+
+/** One body the page may fetch, with the content type the route serves it as. */
+export interface ServedFile {
+  readonly contentType: string;
+  readonly body: Uint8Array;
+}
+
+/** A whole synthetic dataset: the URL a user pastes, and everything under it. */
+export interface TilesetScene {
+  /** The `tileset.json` URL a user pastes into the open-from-URL field. */
+  readonly entryUrl: string;
+  /** Absolute URL to body, for every document and tile the page may request. */
+  readonly files: ReadonlyMap<string, ServedFile>;
+  /** Absolute URLs of the `.pnts` bodies, in document order. */
+  readonly tileUrls: readonly string[];
+  /** Total points across every tile this scene serves. */
+  readonly totalPoints: number;
+}
+
+const JSON_TYPE = 'application/json';
+const TILE_TYPE = 'application/octet-stream';
+
+function jsonFile(value: unknown): ServedFile {
+  return { contentType: JSON_TYPE, body: new TextEncoder().encode(JSON.stringify(value)) };
+}
+
+/** The default host. Not loopback and not private, so the SSRF gate passes it. */
+export const TILESET_ORIGIN = 'https://tiles.example.com';
+
+/** How a scene colours its tiles. `mixed` is a tileset that disagrees with itself. */
+export type SceneColour = 'all' | 'none' | 'mixed';
+
+/** Knobs for {@link boxTileset}. Each default is the valid, happy-path value. */
+export interface BoxTilesetOptions {
+  /** `asset.version`. A value outside 1.0 / 1.1 is refused by the parser. */
+  readonly assetVersion?: string;
+  /** Whether the tiles carry `RGB`. */
+  readonly colour?: SceneColour;
+  /** Directory the dataset is served from, so two scenes can coexist on one page. */
+  readonly path?: string;
+  /**
+   * Content URI for the child tile, overriding the default `.pnts`. A `.b3dm`
+   * is real 3D Tiles content this viewer has no decoder for, which is what a
+   * refusal test wants.
+   */
+  readonly childContentUri?: string;
+}
+
+/**
+ * A three-tile dataset whose volumes are all `box`, so the document declares no
+ * geocentric frame and the report must say which way is up was never
+ * established.
+ *
+ * `refine` is ADD throughout: a REPLACE tile that refines into content is
+ * refused by the node walk, because this viewer draws every resident node and
+ * would therefore draw a replaced parent alongside its replacements.
+ */
+export function boxTileset(options: BoxTilesetOptions = {}): TilesetScene {
+  const path = options.path ?? '/box';
+  const base = `${TILESET_ORIGIN}${path}`;
+  const colour = options.colour ?? 'all';
+  const childUri = options.childContentUri ?? 'child-a.pnts';
+
+  const root = gridPoints(21, 10);
+  const childA = gridPoints(13, 4, [-5, -5, 0]);
+  const childB = gridPoints(13, 4, [5, 5, 0]);
+
+  const files = new Map<string, ServedFile>();
+  files.set(
+    `${base}/tileset.json`,
+    jsonFile({
+      asset: { version: options.assetVersion ?? '1.1' },
+      geometricError: 40,
+      root: {
+        boundingVolume: { box: [0, 0, 0, 12, 0, 0, 0, 12, 0, 0, 0, 4] },
+        geometricError: 12,
+        refine: 'ADD',
+        content: { uri: 'root.pnts' },
+        children: [
+          {
+            boundingVolume: { box: [-5, -5, 0, 5, 0, 0, 0, 5, 0, 0, 0, 3] },
+            geometricError: 2,
+            content: { uri: childUri },
+          },
+          {
+            boundingVolume: { box: [5, 5, 0, 5, 0, 0, 0, 5, 0, 0, 0, 3] },
+            geometricError: 2,
+            content: { uri: 'child-b.pnts' },
+          },
+        ],
+      },
+    }),
+  );
+
+  // `mixed` is the case the colour consensus exists for: the root states RGB
+  // and the children state none, so whichever tile decodes first settles the
+  // layer's one colour meaning and the other disagrees with it.
+  const withColour = (points: readonly Point3[], carries: boolean): Uint8Array =>
+    makePnts(points, carries ? { rgb: flatRgb(points.length) } : {});
+  const rootCarries = colour !== 'none';
+  const childCarries = colour === 'all';
+
+  const tileUrls: string[] = [];
+  const addTile = (name: string, body: Uint8Array): void => {
+    const url = `${base}/${name}`;
+    files.set(url, { contentType: TILE_TYPE, body });
+    tileUrls.push(url);
+  };
+  addTile('root.pnts', withColour(root, rootCarries));
+  if (childUri.endsWith('.pnts')) addTile(childUri, withColour(childA, childCarries));
+  addTile('child-b.pnts', withColour(childB, childCarries));
+
+  return {
+    entryUrl: `${base}/tileset.json`,
+    files,
+    tileUrls,
+    totalPoints:
+      root.length + (childUri.endsWith('.pnts') ? childA.length : 0) + childB.length,
+  };
+}
+
+/**
+ * A dataset whose root volume is a `region`, which is stated in EPSG:4979 and
+ * so fixes the root frame as WGS84 geocentric.
+ *
+ * Its points are therefore ECEF, computed here rather than written by hand: the
+ * viewer places the tile through the ENU root transform it derives from the
+ * region, and points that were not in that frame would land kilometres away
+ * from the bounds the scheduler culls against.
+ */
+export function regionTileset(path = '/region'): TilesetScene {
+  const base = `${TILESET_ORIGIN}${path}`;
+  const west = (-105.001 * Math.PI) / 180;
+  const east = (-104.999 * Math.PI) / 180;
+  const south = (39.999 * Math.PI) / 180;
+  const north = (40.001 * Math.PI) / 180;
+  const minHeight = 1600;
+  const maxHeight = 1660;
+
+  // A grid across the region, each sample lifted to ECEF at the mid height.
+  const points: Point3[] = [];
+  const side = 21;
+  for (let i = 0; i < side; i++) {
+    for (let j = 0; j < side; j++) {
+      const lon = west + ((east - west) * i) / (side - 1);
+      const lat = south + ((north - south) * j) / (side - 1);
+      const h = minHeight + 30 + Math.sin(i * 0.6) * Math.cos(j * 0.6) * 20;
+      points.push(geodeticToEcef(lon, lat, h) as Point3);
+    }
+  }
+
+  const files = new Map<string, ServedFile>();
+  files.set(
+    `${base}/tileset.json`,
+    jsonFile({
+      asset: { version: '1.1' },
+      geometricError: 60,
+      root: {
+        boundingVolume: { region: [west, south, east, north, minHeight, maxHeight] },
+        geometricError: 10,
+        refine: 'ADD',
+        content: { uri: 'root.pnts' },
+      },
+    }),
+  );
+  const tileUrl = `${base}/root.pnts`;
+  files.set(tileUrl, { contentType: TILE_TYPE, body: makePnts(points, { rgb: flatRgb(points.length) }) });
+
+  return { entryUrl: `${base}/tileset.json`, files, tileUrls: [tileUrl], totalPoints: points.length };
+}


### PR DESCRIPTION
3D Tiles had twelve unit suites and no browser test. This adds
`tests/e2e/tilesetOpen.spec.ts` over the path a user reaches by pasting a URL.
`handleRemoteUrl` routes a `tileset.json` to `openRemoteTileset`, which builds a
`TilesetStreamingSource`, attaches it, and streams its PNTS bodies.

`tests/fixtures/tileset3d.ts` builds the datasets in memory and `page.route`
serves them, so nothing skips on CI the way the COPC specs do.

Six tests: tiles stream and an Inspect click lands on a decoded point; the
measurement tools are offered rather than refused for want of a scan; the Scan
Report is published; a box tileset reports an unestablished frame while a region
tileset reports ellipsoidal height; mesh content is refused by name before any
tile fetch; a mixed-colour tileset states why one colour meaning is kept.

No source change.
