### PR TITLE
feat(streaming): carry point-tile normals across the chunk boundary

### DIFF
--- a/src/io/copc/copcChunkDecode.ts
+++ b/src/io/copc/copcChunkDecode.ts
@@ -80,6 +80,20 @@ export interface DecodedChunk {
   /** Per-point RGB (0-255), length `3 · pointCount` — only for PDRF 7/8. */
   rgb?: Uint8Array;
   /**
+   * Per-point surface normals, interleaved xyz, length `3 · pointCount`.
+   *
+   * Absent for the whole LAS family: a PDRF 6/7/8 record reserves no field for
+   * one. A `.pnts` tile can state them, through either a float32 `NORMAL` or an
+   * oct-encoded `NORMAL_OCT16P` accessor, and that is the only source that
+   * fills this today.
+   *
+   * A normal is a MEASUREMENT, so this is never synthesised, defaulted or
+   * zero-filled. A zero triple is not "no normal": it is a degenerate direction,
+   * and a consumer cannot tell the two apart once one has been written. Absence
+   * is the only honest way to say the surface was never measured.
+   */
+  normals?: Float32Array;
+  /**
    * The RGB bit-depth decision this chunk used (true = 8-bit-in-low-byte copied
    * verbatim, false = 16-bit high-byte). Undefined when the chunk carries no
    * RGB. The source reads it off the first RGB chunk and feeds it back as
@@ -220,5 +234,7 @@ export function chunkTransferables(decoded: DecodedChunk): ArrayBuffer[] {
   if (decoded.gpsTime) out.push(decoded.gpsTime.buffer as ArrayBuffer);
   if (decoded.pointSourceId) out.push(decoded.pointSourceId.buffer as ArrayBuffer);
   if (decoded.rgb) out.push(decoded.rgb.buffer as ArrayBuffer);
+  if (decoded.normals) out.push(decoded.normals.buffer as ArrayBuffer);
   return out;
 }
+

--- a/src/io/tiles3d/pntsDecode.ts
+++ b/src/io/tiles3d/pntsDecode.ts
@@ -18,6 +18,12 @@
  * colour modes the format actually carries, so nothing offers to paint a scan
  * by a channel that holds no information. `tests/pntsDecode.test.ts` pins both.
  *
+ * WHAT IT CAN CARRY, beyond position and colour: surface normals, from either a
+ * float32 `NORMAL` or an oct-encoded `NORMAL_OCT16P` accessor. `parsePnts` has
+ * always read them; they now cross into the chunk, so the normals shading path,
+ * the point inspector and the resident-snapshot export reach a streamed tileset
+ * the same way they reach a static cloud.
+ *
  * Positions arrive tile-local. The tile's own `RTC_CENTER`, then its cumulative
  * placement down the tileset tree, then the render origin are applied in
  * float64 before the float32 store, which is the same order the LAS path uses
@@ -87,6 +93,39 @@ function applyMatrix(
 /** What one decoded tile said about colour. */
 export type TileColourState = 'colour' | 'no-colour';
 
+/** What one decoded tile said about surface normals. */
+export type TileNormalsState = 'normals' | 'no-normals';
+
+/**
+ * One layer's answer about one channel, folded from the tiles decoded so far.
+ *
+ * Colour and normals both need it and must not drift apart, so the rule is
+ * written once and read at two states. See {@link TilesetColourConsensus} for
+ * why `settled` is fixed by the first tile with points.
+ */
+interface ChannelConsensus<S extends string> {
+  readonly settled: S | null;
+  readonly disagreeing: number;
+}
+
+/**
+ * Fold one decoded tile into a layer's consensus about one channel. Pure.
+ *
+ * An empty tile leaves the consensus alone: it states nothing either way, and
+ * letting one settle the meaning would hand every tile after it a decision made
+ * from no points.
+ */
+function noteTileChannel<S extends string>(
+  state: ChannelConsensus<S>,
+  pointCount: number,
+  seen: S,
+): ChannelConsensus<S> {
+  if (pointCount <= 0) return state;
+  if (state.settled === null) return { settled: seen, disagreeing: 0 };
+  if (state.settled === seen) return state;
+  return { settled: state.settled, disagreeing: state.disagreeing + 1 };
+}
+
 /**
  * One tileset layer's colour meaning, folded from the tiles decoded so far.
  *
@@ -118,11 +157,40 @@ export function noteTileColour(
   state: TilesetColourConsensus,
   tile: { readonly pointCount: number; readonly hasColour: boolean },
 ): TilesetColourConsensus {
-  if (tile.pointCount <= 0) return state;
-  const seen: TileColourState = tile.hasColour ? 'colour' : 'no-colour';
-  if (state.settled === null) return { settled: seen, disagreeing: 0 };
-  if (state.settled === seen) return state;
-  return { settled: state.settled, disagreeing: state.disagreeing + 1 };
+  return noteTileChannel(state, tile.pointCount, tile.hasColour ? 'colour' : 'no-colour');
+}
+
+/**
+ * One tileset layer's answer about surface normals, folded the same way its
+ * colour meaning is: the first tile with points settles it and it never moves.
+ *
+ * Normals vary per tile exactly as colour does, and the same two failures
+ * follow from letting a layer hold both answers at once. Half a layer painted
+ * by measured direction and half by an elevation ramp is two meanings under one
+ * legend; half a layer carrying normals into the inspector, the profile section
+ * and the resident-snapshot export, from a layer that states it has none, is a
+ * measurement that appears for some points and not others with nothing saying
+ * which is which.
+ */
+export interface TilesetNormalsConsensus {
+  /** The layer's one answer, or null before any tile with points. */
+  readonly settled: TileNormalsState | null;
+  /** How many tiles disagreed with it. */
+  readonly disagreeing: number;
+}
+
+/** No tile decoded yet, so the layer's normals answer is not established. */
+export const NO_TILE_DECODED_NORMALS: TilesetNormalsConsensus = {
+  settled: null,
+  disagreeing: 0,
+};
+
+/** Fold one decoded tile into a layer's normals consensus. Pure. */
+export function noteTileNormals(
+  state: TilesetNormalsConsensus,
+  tile: { readonly pointCount: number; readonly hasNormals: boolean },
+): TilesetNormalsConsensus {
+  return noteTileChannel(state, tile.pointCount, tile.hasNormals ? 'normals' : 'no-normals');
 }
 
 /**
@@ -155,6 +223,35 @@ export function tilesetColourNotice(state: TilesetColourConsensus): string | nul
 }
 
 /**
+ * What a user is told when the layer carries surface normals and some tiles
+ * state none. Those tiles keep no normals and are drawn flat under the Normal
+ * mode, so the absence is visible rather than filled in with a direction.
+ */
+export const MIXED_TILE_NORMALS_KEPT_NOTICE =
+  'Some tiles in this tileset carry surface normals and others do not. The ' +
+  'tiles that state none are drawn flat grey under Normal colouring, and no ' +
+  'direction is reported for their points.';
+
+/**
+ * What a user is told when the layer's first tile stated no normals and a later
+ * one does. Those normals are withheld, so the layer holds one answer: the
+ * Normal colour mode is not offered, and no part of the scan reports a
+ * direction the rest of it cannot.
+ */
+export const MIXED_TILE_NORMALS_DROPPED_NOTICE =
+  'Some tiles in this tileset carry surface normals and others do not. The ' +
+  'layer states none, so no tile normals are used and Normal colouring is not ' +
+  'offered for this scan.';
+
+/** The normals notice for a mixed tileset, or null while every tile has agreed. */
+export function tilesetNormalsNotice(state: TilesetNormalsConsensus): string | null {
+  if (state.disagreeing === 0) return null;
+  return state.settled === 'normals'
+    ? MIXED_TILE_NORMALS_KEPT_NOTICE
+    : MIXED_TILE_NORMALS_DROPPED_NOTICE;
+}
+
+/**
  * A decoded tile that states no colour, inside a layer whose colour meaning IS
  * the colour tiles state.
  *
@@ -176,6 +273,13 @@ export interface PntsChunkDecoderOptions {
    * nothing says why.
    */
   readonly onColourNotice?: (message: string) => void;
+  /**
+   * Called once, with the notice text, the first time a tile disagrees with the
+   * layer's settled answer about surface normals. Same contract as {@link
+   * onColourNotice}: without it the layer still holds one answer, and nothing
+   * says why a Normal chip is missing or a patch is drawn flat.
+   */
+  readonly onNormalsNotice?: (message: string) => void;
 }
 
 /**
@@ -190,11 +294,15 @@ export interface PntsChunkDecoderOptions {
  */
 export class PntsChunkDecoder implements ChunkDecoder {
   private readonly _onColourNotice: ((message: string) => void) | undefined;
+  private readonly _onNormalsNotice: ((message: string) => void) | undefined;
   private _colour: TilesetColourConsensus = NO_TILE_DECODED;
+  private _normals: TilesetNormalsConsensus = NO_TILE_DECODED_NORMALS;
   private _noticed = false;
+  private _normalsNoticed = false;
 
   constructor(options: PntsChunkDecoderOptions = {}) {
     this._onColourNotice = options.onColourNotice;
+    this._onNormalsNotice = options.onNormalsNotice;
   }
 
   /** The layer's colour meaning as the tiles decoded so far have settled it. */
@@ -205,6 +313,16 @@ export class PntsChunkDecoder implements ChunkDecoder {
   /** The mixed-tileset notice, or null while every tile has agreed. */
   get colourNotice(): string | null {
     return tilesetColourNotice(this._colour);
+  }
+
+  /** The layer's normals answer as the tiles decoded so far have settled it. */
+  get normalsConsensus(): TilesetNormalsConsensus {
+    return this._normals;
+  }
+
+  /** The mixed-normals notice, or null while every tile has agreed. */
+  get normalsNotice(): string | null {
+    return tilesetNormalsNotice(this._normals);
   }
 
   async decode(chunk: ArrayBuffer, meta: unknown): Promise<DecodedChunk> {
@@ -243,11 +361,31 @@ export class PntsChunkDecoder implements ChunkDecoder {
     });
     this._raiseColourNoticeOnce();
 
+    // The layer's normals answer, settled the same way and for the same reason.
+    // A tile that disagrees never has its normals re-interpreted: either the
+    // layer carries them and this tile simply states none, or the layer states
+    // none and this tile's normals are withheld.
+    this._normals = noteTileNormals(this._normals, {
+      pointCount: n,
+      hasNormals: tile.normals !== null,
+    });
+    this._raiseNormalsNoticeOnce();
+
     // Intensity, classification, return number, return count and GPS time are
     // simply absent — see the note at the top of this file. Nothing is
     // allocated for them, so a reader is told the channel is missing rather
     // than handed `pointCount` zeros that look like readings.
-    const decoded: DecodedChunk = { pointCount: n, positions };
+    //
+    // Normals are the one channel a point tile CAN state, so they are carried
+    // through as the tile wrote them — never re-normalised, never invented for
+    // a tile that has none.
+    const decoded: DecodedChunk = {
+      pointCount: n,
+      positions,
+      ...(this._normals.settled === 'normals' && tile.normals !== null
+        ? { normals: tile.normals }
+        : {}),
+    };
     if (this._colour.settled !== 'colour') {
       // The layer is drawn by the elevation ramp. A tile that does carry colour
       // has it withheld rather than painted beside ramped neighbours, because
@@ -270,14 +408,27 @@ export class PntsChunkDecoder implements ChunkDecoder {
     this._noticed = true;
     this._onColourNotice?.(notice);
   }
+
+  /** Report a normals mixture the first time one appears, and only then. */
+  private _raiseNormalsNoticeOnce(): void {
+    if (this._normalsNoticed) return;
+    const notice = tilesetNormalsNotice(this._normals);
+    if (notice === null) return;
+    this._normalsNoticed = true;
+    this._onNormalsNotice?.(notice);
+  }
 }
 
 /**
  * The colour modes a point tile can honestly drive.
  *
  * Intensity and classification are absent from the format, so they are absent
- * here. Elevation is derived from position and is always available. Normals
- * appear only when the tile carried them, which varies per tile, so a source
- * decides that from what it read rather than from the format alone.
+ * here. Elevation is derived from position and is always available.
+ *
+ * This is the format's CEILING, not any one layer's offer. Colour and normals
+ * are stated per tile, so a source narrows this list to what its tiles have
+ * actually stated: RGB leaves it for a tileset whose tiles carry none, and
+ * `normal` joins it once a tile has stated normals. See
+ * `TilesetStreamingSource.availableColorModes`.
  */
 export const PNTS_COLOR_MODES = ['rgb', 'elevation'] as const;

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -6112,6 +6112,7 @@ export class Viewer {
     const rgb: [number, number, number] | null = decoded.rgb
       ? [decoded.rgb[index * 3], decoded.rgb[index * 3 + 1], decoded.rgb[index * 3 + 2]]
       : null;
+    const nrm = decoded.normals; // a `.pnts` tile can state them; LAS never does
     return makePointInfo({
       geographicHorizontal: this._inspectGeographicHorizontal,
       layer: cloud ? cloud.name : 'COPC',
@@ -6126,8 +6127,7 @@ export class Viewer {
       returnCount: decoded.returnCount ? decoded.returnCount[index] : undefined,
       pointSourceId: decoded.pointSourceId ? decoded.pointSourceId[index] : undefined,
       gpsTime: decoded.gpsTime ? decoded.gpsTime[index] : undefined,
-      // COPC PDRF 6/7/8 carry no surface normals.
-      normal: undefined,
+      normal: nrm ? [nrm[index * 3], nrm[index * 3 + 1], nrm[index * 3 + 2]] : undefined,
       streamingRefining,
     });
   }

--- a/src/render/colorModes.ts
+++ b/src/render/colorModes.ts
@@ -522,6 +522,35 @@ export function colorByIntensity(
   return out;
 }
 
+/**
+ * RGB-encode `count` interleaved xyz normals: each component −1…+1 → 0…255.
+ *
+ * The vector is normalised first, so un-normalised file normals still map into
+ * range; a zero-length vector is left at the neutral centre rather than divided
+ * by zero. Range-explicit and cloud-free, so the streaming pipeline paints a
+ * decoded node through THIS function rather than a second copy of the encoding
+ * — a drifting copy would give the same surface two colours depending on
+ * whether the scan was streamed or loaded whole.
+ */
+export function colorByNormal(normals: ArrayLike<number>, count: number): Uint8Array {
+  const out = new Uint8Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    let nx = normals[i * 3];
+    let ny = normals[i * 3 + 1];
+    let nz = normals[i * 3 + 2];
+    const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+    if (len > 0) {
+      nx /= len;
+      ny /= len;
+      nz /= len;
+    }
+    out[i * 3] = Math.round((nx + 1) * 0.5 * 255);
+    out[i * 3 + 1] = Math.round((ny + 1) * 0.5 * 255);
+    out[i * 3 + 2] = Math.round((nz + 1) * 0.5 * 255);
+  }
+  return out;
+}
+
 /** Colour `count` points by ASPRS classification code. */
 export function colorByClassification(
   classification: ArrayLike<number>,
@@ -845,27 +874,7 @@ export function colorForMode(
       if (!cloud.normals) {
         throw new Error(`colorForMode('normal'): cloud "${cloud.name}" has no normals attribute`);
       }
-      const src = cloud.normals;
-      const out = new Uint8Array(n * 3);
-
-      // Encode each unit normal direction as RGB: component −1…+1 → 0…255.
-      // The vector is normalised first so un-normalised file normals still map
-      // into range.
-      for (let i = 0; i < n; i++) {
-        let nx = src[i * 3];
-        let ny = src[i * 3 + 1];
-        let nz = src[i * 3 + 2];
-        const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
-        if (len > 0) {
-          nx /= len;
-          ny /= len;
-          nz /= len;
-        }
-        out[i * 3]     = Math.round((nx + 1) * 0.5 * 255);
-        out[i * 3 + 1] = Math.round((ny + 1) * 0.5 * 255);
-        out[i * 3 + 2] = Math.round((nz + 1) * 0.5 * 255);
-      }
-      return out;
+      return colorByNormal(cloud.normals, n);
     }
 
     // ── classification ──────────────────────────────────────────────────────

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -486,6 +486,7 @@ export function decodedChunkBytes(decoded: DecodedChunk): number {
     channelBytes(decoded.returnCount, 1) +
     channelBytes(decoded.gpsTime, 1) +
     channelBytes(decoded.rgb, 3) +
+    channelBytes(decoded.normals, 3) +
     channelBytes(decoded.pointSourceId, 1);
   return n * perPoint;
 }
@@ -1557,6 +1558,13 @@ export class StreamingScheduler {
       .then((decoded) => {
         this._inFlight.delete(id);
         this._inFlightGraceAt.delete(id);
+        // Which channels this chunk actually carried, recorded BEFORE the abort
+        // check and whether or not the node is still wanted. A format that
+        // states a channel per node settles the layer's answer inside the
+        // decoder as each tile is read, so a source that skipped an aborted
+        // chunk would answer `availableColorModes()` from a different set of
+        // tiles than the one the decoder settled on.
+        this._cloud.noteDecodedChannels?.(decoded);
         if (controller.signal.aborted) {
           store.setState(node, 'unloaded');
         } else {

--- a/src/render/streaming/StreamingSource.ts
+++ b/src/render/streaming/StreamingSource.ts
@@ -24,7 +24,7 @@
 import type { Box6, StreamingNodeRecord } from '../../io/copc/copcTypes';
 import type { CloudFrameProvenance } from '../../geo/frame/frameProvenance';
 import type { SpatialFrame } from '../../geo/frame/spatialFrame';
-import type { ChunkDecodeMetadata } from '../../io/copc/copcChunkDecode';
+import type { ChunkDecodeMetadata, DecodedChunk } from '../../io/copc/copcChunkDecode';
 import type { PntsDecodeMetadata } from '../../io/tiles3d/pntsDecode';
 import type { StreamingNode } from './StreamingNode';
 import type { NodeCounts, StreamingNodeStore } from './StreamingNodeStore';
@@ -277,6 +277,21 @@ export interface StreamingSource {
    * future source without the ambiguity can omit it.
    */
   noteDecodedRgbDepth?(eightBit: boolean | undefined): void;
+  /**
+   * Record which measured channels a decoded chunk actually carried.
+   *
+   * COPC and EPT state their channels once, in a header or a schema, so both
+   * omit this and answer {@link availableColorModes} from the document. A 3D
+   * Tiles tileset states them PER TILE: whether it carries colour, or surface
+   * normals, is not knowable until tiles have been read, and reading every tile
+   * to find out is the one thing a streaming source must not do to open.
+   *
+   * So the answer is folded from what has actually been served. Before the
+   * first chunk a source that needs this offers neither channel, because a mode
+   * offered ahead of any tile is a promise about tiles nobody has seen; and it
+   * never offers one that would resolve to a different channel underneath.
+   */
+  noteDecodedChannels?(chunk: DecodedChunk): void;
   /**
    * Release any resource the source holds open — a file handle, a range
    * reader, a decode worker. Called by the Viewer when the streaming cloud is

--- a/src/render/streaming/TilesetStreamingSource.ts
+++ b/src/render/streaming/TilesetStreamingSource.ts
@@ -31,7 +31,16 @@ import { createTranslatedFrame } from '../../geo/frame/spatialFrame';
 import type { CloudFrameProvenance } from '../../geo/frame/frameProvenance';
 import type { Mat4 } from '../../io/tiles3d/tileTransform';
 import type { TilesetTransport } from '../../io/tiles3d/tilesetTransport';
-import { PNTS_COLOR_MODES, type PntsDecodeMetadata } from '../../io/tiles3d/pntsDecode';
+import {
+  NO_TILE_DECODED,
+  NO_TILE_DECODED_NORMALS,
+  noteTileColour,
+  noteTileNormals,
+  PNTS_COLOR_MODES,
+  type PntsDecodeMetadata,
+  type TilesetColourConsensus,
+  type TilesetNormalsConsensus,
+} from '../../io/tiles3d/pntsDecode';
 import { tilesetNodes, type TilesetNodeIndex } from '../../io/tiles3d/tilesetNodes';
 import { volumeToAabb } from '../../io/tiles3d/tilesetTraversal';
 import {
@@ -43,6 +52,7 @@ import { StreamingNodeStore } from './StreamingNodeStore';
 import type { NodeCounts } from './StreamingNodeStore';
 import type { StreamingNode } from './StreamingNode';
 import type {
+  DecodedChunk,
   NodeDecodeMetadata,
   StreamingColorMode,
   StreamingOctreeView,
@@ -158,6 +168,9 @@ export class TilesetStreamingSource implements StreamingSource {
   private readonly _bounds: Box6;
   private readonly _transport: TilesetTransport;
   private readonly _crs: CrsInfo | null;
+  /** What the tiles served so far have stated about colour and about normals. */
+  private _colour: TilesetColourConsensus = NO_TILE_DECODED;
+  private _normals: TilesetNormalsConsensus = NO_TILE_DECODED_NORMALS;
 
   constructor(
     id: string,
@@ -232,16 +245,55 @@ export class TilesetStreamingSource implements StreamingSource {
     return [...this._bounds] as Box6;
   }
 
-  defaultColorMode(): StreamingColorMode {
-    return 'rgb';
+  /**
+   * Fold one served chunk into this layer's answer about colour and normals.
+   *
+   * The decoder holds the same two answers and uses them to decide what to
+   * serve; this holds them to decide what to OFFER, and folds them from the
+   * chunks that actually arrived so the two cannot describe different tilesets.
+   * Both use the same rule and the same pure fold: the first tile with points
+   * settles the answer and it never moves.
+   */
+  noteDecodedChannels(chunk: DecodedChunk): void {
+    this._colour = noteTileColour(this._colour, {
+      pointCount: chunk.pointCount,
+      hasColour: chunk.rgb !== undefined,
+    });
+    this._normals = noteTileNormals(this._normals, {
+      pointCount: chunk.pointCount,
+      hasNormals: chunk.normals !== undefined,
+    });
   }
 
   /**
-   * Only what a point tile can carry. Intensity, classification and returns are
-   * absent from the format, so nothing offers to paint a scan by them.
+   * Elevation until a tile has stated colour, which is what the layer will
+   * actually be drawn by.
+   *
+   * It used to return `'rgb'` unconditionally. A tileset whose tiles state no
+   * colour therefore opened on a mode that fell through to the elevation ramp,
+   * so the scan was painted by height under a Color chip — the same defect as
+   * offering a Normal chip for a layer with no normals, one step earlier.
+   */
+  defaultColorMode(): StreamingColorMode {
+    return this._colour.settled === 'colour' ? 'rgb' : 'elevation';
+  }
+
+  /**
+   * Only what this layer's tiles have actually stated.
+   *
+   * Intensity, classification and returns are absent from the format, so
+   * nothing offers to paint a scan by them. Colour and normals are stated per
+   * TILE rather than per document, so neither is offered before a tile has been
+   * read, and neither is offered for a layer whose tiles carry none: a chip
+   * that silently resolves to another channel says the scan holds a reading it
+   * does not.
    */
   availableColorModes(): readonly StreamingColorMode[] {
-    return PNTS_COLOR_MODES;
+    const modes: StreamingColorMode[] = PNTS_COLOR_MODES.filter(
+      (mode) => mode !== 'rgb' || this._colour.settled === 'colour',
+    );
+    if (this._normals.settled === 'normals') modes.push('normal');
+    return modes;
   }
 
   crs(): CrsInfo | null {

--- a/src/render/streaming/residentSnapshot.ts
+++ b/src/render/streaming/residentSnapshot.ts
@@ -83,6 +83,10 @@ export function buildResidentSnapshot(
   const pointSourceId = everyChunkHas((c) => c.pointSourceId, 1)
     ? new Uint16Array(total)
     : undefined;
+  // Surface normals, from a `.pnts` tileset. Same all-or-nothing rule: a
+  // half-filled array would report a measured direction for points that state
+  // none, and nothing downstream could tell which half was which.
+  const normals = everyChunkHas((c) => c.normals, 3) ? new Float32Array(total * 3) : undefined;
 
   let p = 0; // running point offset
   for (const c of chunks) {
@@ -97,6 +101,7 @@ export function buildResidentSnapshot(
     if (gpsTime && c.gpsTime) gpsTime.set(c.gpsTime.subarray(0, n), p);
     if (colors && c.rgb) colors.set(c.rgb.subarray(0, n * 3), p * 3);
     if (pointSourceId && c.pointSourceId) pointSourceId.set(c.pointSourceId.subarray(0, n), p);
+    if (normals && c.normals) normals.set(c.normals.subarray(0, n * 3), p * 3);
     p += n;
   }
 
@@ -109,6 +114,7 @@ export function buildResidentSnapshot(
     ...(gpsTime ? { gpsTime } : {}),
     ...(colors ? { colors } : {}),
     ...(pointSourceId ? { pointSourceId } : {}),
+    ...(normals ? { normals } : {}),
     origin: [opts.origin[0], opts.origin[1], opts.origin[2]],
     sourceFormat: opts.sourceFormat,
     name: opts.name,

--- a/src/render/streaming/streamingColors.ts
+++ b/src/render/streaming/streamingColors.ts
@@ -16,6 +16,7 @@ import {
   colorByElevation,
   colorByIntensity,
   colorByClassification,
+  colorByNormal,
   colorByScalar,
   finiteMinMax,
 } from '../colorModes';
@@ -170,11 +171,10 @@ export function intensityRangeOf(
  * Per-point interleaved RGB (3 bytes/point) for one decoded streaming node in
  * the active mode, using the cloud-global ranges.
  *
- * A mode whose meaning the whole source lacks (RGB on a format without it,
- * normals) falls back to the elevation ramp, which is the layer's one meaning
- * in that case rather than a second one. A mode whose per-point channel this
- * CHUNK does not carry is drawn flat instead — see {@link
- * channelAbsentColors}; no other channel stands in for it.
+ * RGB on a format without it falls back to the elevation ramp, which is the
+ * layer's one meaning in that case rather than a second one. A mode whose
+ * per-point channel this CHUNK does not carry is drawn flat instead — see
+ * {@link channelAbsentColors}; no other channel stands in for it.
  *
  * **Buffer-reuse contract.** When `mode === 'rgb'` and an `rgbAppearance`
  * is passed, the returned `Uint8Array` is a `subarray` view of a shared
@@ -282,8 +282,17 @@ export function streamingNodeColors(
           (ranges as { spacing?: number }).spacing ?? 0,
         ),
       }).colors;
-    case 'elevation':
     case 'normal':
+      // A chunk with no normals is drawn flat, never ramped by height: an
+      // elevation ramp under a Normal legend is a second reading wearing the
+      // first one's label. A source only offers this mode once a node has
+      // actually stated normals, so a chunk reaching here without them is the
+      // mixed-tileset case (or a restored view state), not the common path.
+      if (!decoded.normals) return channelAbsentColors(n);
+      // The static pipeline's own encoding, not a copy of it, so a surface gets
+      // the same colour whether the scan was streamed or loaded whole.
+      return colorByNormal(decoded.normals, n);
+    case 'elevation':
     default:
       return colorByElevation(renderLocalPositions(decoded), n, ranges.minZ, ranges.maxZ);
   }

--- a/tests/tilesetStreamingNormals.test.ts
+++ b/tests/tilesetStreamingNormals.test.ts
@@ -1,0 +1,486 @@
+/**
+ * tilesetStreamingNormals.test.ts — a point tile's stated normals across the
+ * streaming boundary.
+ *
+ * `parsePnts` has always decoded a tile's NORMAL (and NORMAL_OCT16P) accessor,
+ * and the viewer has always had a normals shading path. The two never met: the
+ * streaming chunk had nowhere to put a normal, so the decoder read one and
+ * dropped it, and a tileset that measured its surfaces drew as if it had not.
+ *
+ * A normal is a measurement. These tests pin that it survives the crossing
+ * unaltered, that nothing is invented when a tile states none, and that a layer
+ * is never offered a colour mode its tiles cannot fill.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PntsChunkDecoder,
+  noteTileNormals,
+  tilesetNormalsNotice,
+  NO_TILE_DECODED_NORMALS,
+  MIXED_TILE_NORMALS_KEPT_NOTICE,
+  MIXED_TILE_NORMALS_DROPPED_NOTICE,
+  type PntsDecodeMetadata,
+} from '../src/io/tiles3d/pntsDecode';
+import {
+  chunkTransferables,
+  type ChunkDecodeMetadata,
+  type DecodedChunk,
+} from '../src/io/copc/copcChunkDecode';
+import { decodedChunkBytes } from '../src/render/streaming/StreamingScheduler';
+import {
+  streamingNodeColors,
+  UNSTATED_COLOUR_GREY,
+  type StreamingColorRanges,
+} from '../src/render/streaming/streamingColors';
+import { colorByNormal } from '../src/render/colorModes';
+import { TilesetStreamingSource } from '../src/render/streaming/TilesetStreamingSource';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import type { TilesetTransport } from '../src/io/tiles3d/tilesetTransport';
+import { buildResidentSnapshot } from '../src/render/streaming/residentSnapshot';
+import { StreamingScheduler } from '../src/render/streaming/StreamingScheduler';
+import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
+import { streamingBudgets } from '../src/render/streaming/streamingBudget';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import { buildSyntheticCopc } from './fixtures/copc/synthCopc';
+
+const PNTS_MAGIC = 0x73746e70;
+
+type Triple = readonly [number, number, number];
+
+/** A minimal valid `.pnts` body, optionally carrying RGB and/or float32 NORMAL. */
+function makePnts(
+  points: readonly Triple[],
+  extras: { rgb?: readonly Triple[]; normals?: readonly Triple[] } = {},
+): ArrayBuffer {
+  const posBytes = points.length * 3 * 4;
+  const rgbBytes = extras.rgb ? points.length * 3 : 0;
+  const normalBytes = extras.normals ? points.length * 3 * 4 : 0;
+  const ft: Record<string, unknown> = {
+    POINTS_LENGTH: points.length,
+    POSITION: { byteOffset: 0 },
+  };
+  if (extras.rgb) ft.RGB = { byteOffset: posBytes };
+  // NORMAL is float32 and must start on a 4-byte boundary within the binary
+  // section, so it follows the (byte-wide) RGB block, whose length is a
+  // multiple of 3. Padded to 4 below so the offset stays aligned.
+  const normalPad = (4 - ((posBytes + rgbBytes) % 4)) % 4;
+  if (extras.normals) ft.NORMAL = { byteOffset: posBytes + rgbBytes + normalPad };
+  let json = JSON.stringify(ft);
+  while (json.length % 8 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const binBytes = posBytes + rgbBytes + normalPad + normalBytes;
+  const total = 28 + jsonBytes.length + binBytes;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, PNTS_MAGIC, true);
+  view.setUint32(4, 1, true);
+  view.setUint32(8, total, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, binBytes, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buf, 28, jsonBytes.length).set(jsonBytes);
+  const binStart = 28 + jsonBytes.length;
+  let k = 0;
+  for (const p of points) for (const c of p) view.setFloat32(binStart + k++ * 4, c, true);
+  if (extras.rgb) {
+    const bytes = new Uint8Array(buf, binStart + posBytes, rgbBytes);
+    let j = 0;
+    for (const c of extras.rgb) for (const v of c) bytes[j++] = v;
+  }
+  if (extras.normals) {
+    const at = binStart + posBytes + rgbBytes + normalPad;
+    let j = 0;
+    for (const nrm of extras.normals) for (const v of nrm) view.setFloat32(at + j++ * 4, v, true);
+  }
+  return buf;
+}
+
+const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+/** A wide view: clip = world/256, so the frustum spans [-256,256]³. */
+const WIDE_VIEW = [1 / 256, 0, 0, 0, 0, 1 / 256, 0, 0, 0, 0, 1 / 256, 0, 0, 0, 0, 1];
+const META: PntsDecodeMetadata = {
+  format: 'pnts',
+  tileTransform: IDENTITY,
+  renderOrigin: [0, 0, 0],
+};
+
+/** Two points at opposite ends of the layer's height span. */
+const LOW_AND_HIGH: readonly Triple[] = [
+  [0, 0, 0],
+  [0, 0, 100],
+];
+/** Two unit normals a tile states: one straight up, one along +X. */
+const STATED_NORMALS: readonly Triple[] = [
+  [0, 0, 1],
+  [1, 0, 0],
+];
+const STATED_RGB: readonly Triple[] = [
+  [200, 10, 10],
+  [10, 200, 10],
+];
+
+const RANGES: StreamingColorRanges = {
+  minZ: 0,
+  maxZ: 100,
+  minIntensity: 0,
+  maxIntensity: 1,
+  minGpsTime: 0,
+  maxGpsTime: 1,
+  minReturnNumber: 0,
+  maxReturnNumber: 1,
+};
+
+/** The colours a node is given, copied out of any shared scratch buffer. */
+function paint(mode: 'normal' | 'rgb', chunk: DecodedChunk): number[] {
+  return [...streamingNodeColors(mode, chunk, RANGES)];
+}
+
+describe('a tile that states normals', () => {
+  it('carries them across the chunk boundary, byte for byte', async () => {
+    const decoded = await new PntsChunkDecoder().decode(
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+      META,
+    );
+    expect(
+      decoded.normals,
+      'parsePnts read the tile’s NORMAL accessor and the chunk dropped it, so a ' +
+        'tileset that measured its surfaces reaches the renderer as if it had not',
+    ).toBeDefined();
+    expect([...(decoded.normals ?? [])]).toEqual([0, 0, 1, 1, 0, 0]);
+    expect(decoded.normals?.length).toBe(3 * decoded.pointCount);
+  });
+
+  it('states no normals when the tile carries none', async () => {
+    const decoded = await new PntsChunkDecoder().decode(makePnts(LOW_AND_HIGH), META);
+    expect(
+      decoded.normals,
+      'absent must stay absent — a zero-filled triple is a direction, not a gap',
+    ).toBeUndefined();
+  });
+
+  it('transfers the normals buffer with the chunk', async () => {
+    const decoded = await new PntsChunkDecoder().decode(
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+      META,
+    );
+    expect(chunkTransferables(decoded)).toContain(decoded.normals?.buffer);
+  });
+
+  it('lists no normals buffer for a chunk that has none', async () => {
+    const decoded = await new PntsChunkDecoder().decode(makePnts(LOW_AND_HIGH), META);
+    expect(chunkTransferables(decoded)).toEqual([decoded.positions.buffer]);
+  });
+});
+
+describe('what the memory guard is charged', () => {
+  it('charges twelve bytes a point for normals that are present', async () => {
+    const withNormals = await new PntsChunkDecoder().decode(
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+      META,
+    );
+    const without = await new PntsChunkDecoder().decode(makePnts(LOW_AND_HIGH), META);
+    expect(
+      decodedChunkBytes(withNormals) - decodedChunkBytes(without),
+      'an uncharged channel makes the byte budget lie about what is resident',
+    ).toBe(3 * Float32Array.BYTES_PER_ELEMENT * withNormals.pointCount);
+  });
+
+  it('charges nothing for normals a chunk does not carry', async () => {
+    const without = await new PntsChunkDecoder().decode(makePnts(LOW_AND_HIGH), META);
+    expect(decodedChunkBytes(without)).toBe(
+      without.pointCount * 3 * Float32Array.BYTES_PER_ELEMENT,
+    );
+  });
+});
+
+describe('painting a streaming node by its normals', () => {
+  it('uses the static pipeline’s encoding, not the elevation ramp', async () => {
+    const decoded = await new PntsChunkDecoder().decode(
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+      META,
+    );
+    expect(paint('normal', decoded)).toEqual([
+      ...colorByNormal(decoded.normals!, decoded.pointCount),
+    ]);
+    // (0,0,1) → (128,128,255) and (1,0,0) → (255,128,128) under n = (n+1)/2.
+    expect(paint('normal', decoded)).toEqual([128, 128, 255, 255, 128, 128]);
+  });
+
+  it('draws flat grey, never a height ramp, when the chunk states no normals', async () => {
+    const decoded = await new PntsChunkDecoder().decode(makePnts(LOW_AND_HIGH), META);
+    expect(
+      paint('normal', decoded),
+      'a height ramp under a Normal legend is a second reading wearing the first one’s label',
+    ).toEqual(Array<number>(6).fill(UNSTATED_COLOUR_GREY));
+  });
+});
+
+// ── the layer's answer ──────────────────────────────────────────────────────
+
+const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
+const TREE = parseTileset(
+  JSON.stringify({
+    asset: { version: '1.0' },
+    geometricError: 100,
+    root: {
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'ADD',
+      content: { uri: 'root.pnts' },
+      children: [{ boundingVolume: BOX, geometricError: 10, content: { uri: 'a.pnts' } }],
+    },
+  }),
+);
+
+const transport = (): TilesetTransport => ({
+  fetchTilesetJson: async () => '{}',
+  fetchTileBytes: async () => new ArrayBuffer(8),
+});
+
+function source(): TilesetStreamingSource {
+  return new TilesetStreamingSource(
+    'id',
+    'A tileset',
+    'https://host/data/tileset.json',
+    transport(),
+    TREE,
+  );
+}
+
+/** Decode `bodies` through one layer's decoder and tell the source what it got. */
+async function serve(
+  s: TilesetStreamingSource,
+  decoder: PntsChunkDecoder,
+  bodies: readonly ArrayBuffer[],
+): Promise<DecodedChunk[]> {
+  const out: DecodedChunk[] = [];
+  for (const body of bodies) {
+    const decoded = await decoder.decode(body, META);
+    s.noteDecodedChannels(decoded);
+    out.push(decoded);
+  }
+  return out;
+}
+
+describe('the colour modes a tileset layer offers', () => {
+  it('offers neither colour nor normals before a tile has been read', () => {
+    const modes = source().availableColorModes();
+    expect(
+      modes,
+      'a mode offered before anything was read is a promise about tiles nobody has seen',
+    ).toEqual(['elevation']);
+  });
+
+  it('offers normals once a tile has stated them', async () => {
+    const s = source();
+    await serve(s, new PntsChunkDecoder(), [
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+    ]);
+    expect(s.availableColorModes()).toContain('normal');
+  });
+
+  it('never offers normals for a tileset whose tiles carry none', async () => {
+    const s = source();
+    await serve(s, new PntsChunkDecoder(), [
+      makePnts(LOW_AND_HIGH, { rgb: STATED_RGB }),
+      makePnts(LOW_AND_HIGH, { rgb: STATED_RGB }),
+    ]);
+    expect(
+      s.availableColorModes(),
+      'a Normal chip on a layer with no normals resolves to something else and lies about it',
+    ).not.toContain('normal');
+  });
+
+  it('offers no RGB mode for a tileset whose tiles state no colour', async () => {
+    const s = source();
+    await serve(s, new PntsChunkDecoder(), [makePnts(LOW_AND_HIGH), makePnts(LOW_AND_HIGH)]);
+    expect(
+      s.availableColorModes(),
+      'an RGB chip that silently resolves to the elevation ramp is the same defect',
+    ).not.toContain('rgb');
+    expect(s.defaultColorMode()).toBe('elevation');
+  });
+
+  it('offers RGB, and defaults to it, once a tile has stated colour', async () => {
+    const s = source();
+    await serve(s, new PntsChunkDecoder(), [makePnts(LOW_AND_HIGH, { rgb: STATED_RGB })]);
+    expect(s.availableColorModes()).toContain('rgb');
+    expect(s.defaultColorMode()).toBe('rgb');
+  });
+
+  it('never offers intensity or classification, which the format cannot fill', async () => {
+    const s = source();
+    await serve(s, new PntsChunkDecoder(), [
+      makePnts(LOW_AND_HIGH, { rgb: STATED_RGB, normals: STATED_NORMALS }),
+    ]);
+    expect(s.availableColorModes()).not.toContain('intensity');
+    expect(s.availableColorModes()).not.toContain('classification');
+  });
+});
+
+describe('a tileset that mixes tiles with and without normals', () => {
+  it('keeps the stated normals and draws the tiles without them flat', async () => {
+    const decoder = new PntsChunkDecoder();
+    const measured = await decoder.decode(
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+      META,
+    );
+    const plain = await decoder.decode(makePnts(LOW_AND_HIGH), META);
+
+    expect(measured.normals).toBeDefined();
+    expect(plain.normals, 'nothing is invented for the tile that states none').toBeUndefined();
+    expect(paint('normal', plain)).toEqual(Array<number>(6).fill(UNSTATED_COLOUR_GREY));
+    expect(decoder.normalsNotice).toBe(MIXED_TILE_NORMALS_KEPT_NOTICE);
+  });
+
+  it('withholds normals from a later tile when the first stated none', async () => {
+    const decoder = new PntsChunkDecoder();
+    await decoder.decode(makePnts(LOW_AND_HIGH), META);
+    const measured = await decoder.decode(
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+      META,
+    );
+    expect(
+      measured.normals,
+      'the layer states it has no normals, so part of it must not carry them into ' +
+        'the inspector, the profile and the export',
+    ).toBeUndefined();
+    expect(decoder.normalsNotice).toBe(MIXED_TILE_NORMALS_DROPPED_NOTICE);
+  });
+
+  it('never offers the normal mode for a layer that withheld them', async () => {
+    const s = source();
+    const decoder = new PntsChunkDecoder();
+    await serve(s, decoder, [
+      makePnts(LOW_AND_HIGH),
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+    ]);
+    expect(s.availableColorModes()).not.toContain('normal');
+  });
+
+  it('raises the notice once, through the shell surface it was given', async () => {
+    const said: string[] = [];
+    const decoder = new PntsChunkDecoder({ onNormalsNotice: (m) => said.push(m) });
+    await decoder.decode(makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }), META);
+    expect(said, 'nothing has disagreed yet').toEqual([]);
+    await decoder.decode(makePnts(LOW_AND_HIGH), META);
+    await decoder.decode(makePnts(LOW_AND_HIGH), META);
+    expect(said).toEqual([MIXED_TILE_NORMALS_KEPT_NOTICE]);
+  });
+
+  it('says nothing when every tile agrees', async () => {
+    const decoder = new PntsChunkDecoder();
+    await decoder.decode(makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }), META);
+    await decoder.decode(makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }), META);
+    expect(decoder.normalsNotice).toBeNull();
+  });
+});
+
+describe('the normals consensus itself', () => {
+  const fold = (...tiles: boolean[]) =>
+    tiles.reduce(
+      (state, hasNormals) => noteTileNormals(state, { pointCount: 2, hasNormals }),
+      NO_TILE_DECODED_NORMALS,
+    );
+
+  it('settles on the first tile with points and never moves', () => {
+    expect(fold(true, false, false).settled).toBe('normals');
+    expect(fold(false, true, true).settled).toBe('no-normals');
+  });
+
+  it('counts every tile that disagreed', () => {
+    expect(fold(true, false, false).disagreeing).toBe(2);
+    expect(fold(true, true, true).disagreeing).toBe(0);
+  });
+
+  it('ignores an empty tile entirely', () => {
+    expect(noteTileNormals(NO_TILE_DECODED_NORMALS, { pointCount: 0, hasNormals: true })).toBe(
+      NO_TILE_DECODED_NORMALS,
+    );
+  });
+
+  it('names which answer the layer kept', () => {
+    expect(tilesetNormalsNotice(fold(true, false))).toBe(MIXED_TILE_NORMALS_KEPT_NOTICE);
+    expect(tilesetNormalsNotice(fold(false, true))).toBe(MIXED_TILE_NORMALS_DROPPED_NOTICE);
+    expect(tilesetNormalsNotice(fold(true, true))).toBeNull();
+  });
+});
+
+const SNAPSHOT_OPTS = {
+  origin: [0, 0, 0] as const,
+  name: 'A tileset',
+  sourceFormat: 'pnts' as const,
+};
+
+describe('the scheduler tells the source what each chunk carried', () => {
+  it('reports every decoded chunk, so the layer answers from what it served', async () => {
+    const fixture = buildSyntheticCopc({
+      center: [0, 0, 0],
+      halfsize: 128,
+      nodes: [
+        { key: [0, 0, 0, 0], pointCount: 200 },
+        { key: [1, 0, 0, 0], pointCount: 100 },
+      ],
+    });
+    const cloud = await StreamingPointCloud.open(
+      new ArrayBufferRangeSource(fixture.buffer),
+      'normals.copc.laz',
+    );
+    const served: (Float32Array | undefined)[] = [];
+    // COPC states its channels in a header and so omits the hook; assigning one
+    // here exercises the scheduler's side of the seam without a tileset
+    // transport. Without this call a tileset layer never learns what its tiles
+    // carried, and every per-tile colour mode stays unoffered for the session.
+    (cloud as unknown as { noteDecodedChannels?: (c: DecodedChunk) => void }).noteDecodedChannels =
+      (c) => served.push(c.normals);
+
+    const decoder = {
+      decode: (_bytes: ArrayBuffer, meta: ChunkDecodeMetadata): Promise<DecodedChunk> =>
+        Promise.resolve({
+          pointCount: meta.pointCount,
+          positions: new Float32Array(meta.pointCount * 3),
+          normals: new Float32Array(meta.pointCount * 3).fill(1),
+        }),
+    };
+    const scheduler = new StreamingScheduler(
+      cloud,
+      decoder,
+      { onNodeReady: () => {}, onNodeEvicted: () => {} },
+      streamingBudgets('balanced', false),
+    );
+    scheduler.update({ viewProjection: WIDE_VIEW, cameraPosition: [0, 0, 0] });
+    for (let i = 0; i < 200; i++) {
+      const s = scheduler.stats();
+      if (s.queued === 0 && s.loading === 0) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    expect(served.length, 'no decoded chunk was reported to the source').toBe(2);
+    expect(served.every((n) => n?.length === 3 * 100 || n?.length === 3 * 200)).toBe(true);
+  });
+});
+
+describe('the derived products that read the chunk', () => {
+  it('reaches the resident snapshot only when every chunk carries normals', async () => {
+    const decoder = new PntsChunkDecoder();
+    const a = await decoder.decode(makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }), META);
+    const b = await decoder.decode(makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }), META);
+    const all = buildResidentSnapshot([a, b], SNAPSHOT_OPTS);
+    expect(all?.normals).toBeDefined();
+    expect([...(all?.normals ?? [])]).toEqual([0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0]);
+
+    const mixedDecoder = new PntsChunkDecoder();
+    const measured = await mixedDecoder.decode(
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+      META,
+    );
+    const plain = await mixedDecoder.decode(makePnts(LOW_AND_HIGH), META);
+    const partial = buildResidentSnapshot([measured, plain], SNAPSHOT_OPTS);
+    expect(
+      partial?.normals,
+      'half a normals array would report a direction for points that state none',
+    ).toBeUndefined();
+  });
+});

--- a/tests/tilesetStreamingSource.test.ts
+++ b/tests/tilesetStreamingSource.test.ts
@@ -62,9 +62,20 @@ describe('what the source refuses to invent', () => {
 
   it('offers only the colour modes a point tile can fill', () => {
     const modes = source().availableColorModes();
-    expect(modes).toContain('rgb');
     expect(modes).not.toContain('intensity');
     expect(modes).not.toContain('classification');
+  });
+
+  it('offers no colour mode for a channel no tile has stated yet', () => {
+    // This used to answer `['rgb', 'elevation']` from the format alone, and
+    // `defaultColorMode()` used to answer `'rgb'` unconditionally. A tileset
+    // whose tiles carry no colour therefore opened on an RGB chip that fell
+    // through to the elevation ramp: the scan was painted by height and
+    // labelled Color. Colour is stated per TILE, so the honest answer before
+    // any tile has been read is that nothing states it.
+    // `tests/tilesetStreamingNormals.test.ts` covers the answer after a read.
+    expect(source().availableColorModes()).toEqual(['elevation']);
+    expect(source().defaultColorMode()).toBe('elevation');
   });
 });
 


### PR DESCRIPTION
`parsePnts` decodes a point tile's float32 `NORMAL` and oct-encoded
`NORMAL_OCT16P` accessors, and `PntsChunkDecoder` dropped both: the streaming
chunk had nowhere to put them. `DecodedChunk` gains an optional
`normals`, listed in `chunkTransferables` and charged in `decodedChunkBytes`.
Normals shading, the point inspector, the profile section and the
resident-snapshot export reach a streamed tileset now.

Normals vary per tile, so a layer settles one answer on its first tile with
points, as its colour meaning already does, and a mixture raises a notice. A
new `noteDecodedChannels` hook folds that answer from the chunks the scheduler
served, so `availableColorModes()` offers `normal` only once a tile has stated
normals. It also retires a defect beside it: `defaultColorMode()` answered `rgb`
unconditionally, so a tileset whose tiles state no colour opened on a Color chip
that fell through to the elevation ramp.
