### PR TITLE
fix(3dtiles): reveal the workspace and streaming panel on a tileset open

### DIFF
--- a/src/app/openStreaming.ts
+++ b/src/app/openStreaming.ts
@@ -230,6 +230,62 @@ export function activateCommittedStreamingCloud(
 }
 
 /**
+ * Switch the Inspector and the Export panel into STREAMING layout and open the
+ * image-export gate for the freshly attached cloud.
+ *
+ * The same four calls, in the same order, ran written out in the COPC path and
+ * again in the EPT one, and were then not written at all in the tileset one —
+ * which is the failure `streamingScanReveal.ts` already exists to stop, one
+ * surface over. A streaming cloud never goes through `inspector.addCloud`, so
+ * nothing else flips the image-export gate; without these calls the Inspector
+ * keeps its static-cloud layout (Layers, Color by) over a scan that has no
+ * resident layer to drive them, the Export panel keeps offering the file
+ * formats a streaming cloud cannot write, and image export stays dark.
+ *
+ * `imageExportModes` is the map the caller reads off the LIVE viewer
+ * (`availableImageExportModes()`), not a constant: it is what disables the
+ * per-mode buttons a given scene cannot fill. A tileset carries no intensity,
+ * classification or normals, so passing the live map is what keeps those modes
+ * dark rather than offering an export that would render nothing.
+ */
+export function enterStreamingInspectorMode(
+  deps: Pick<OpenStreamingDeps, 'inspector' | 'exportPanel'>,
+  imageExportModes: Parameters<OpenStreamingDeps['exportPanel']['setImageExportAvailability']>[0],
+): void {
+  deps.exportPanel.setImageExportEnabled(true);
+  deps.exportPanel.setImageExportAvailability(imageExportModes);
+  deps.inspector.setStreamingMode(true);
+  deps.exportPanel.setStreamingMode(true);
+}
+
+/**
+ * Return the classification surfaces to their fresh-scan state for a streaming
+ * open: an empty legend, hidden, no reclassify panel, and no class-scope stamp.
+ *
+ * The reset matters for two different reasons depending on the format. A COPC
+ * stream refills the legend lazily as nodes carrying classification become
+ * resident, so this is the empty starting point that refinement builds on. A
+ * 3D Tiles stream never refills it — a point tile carries no LAS
+ * classification — so for a tileset this is not an empty legend waiting to
+ * fill but a control the format cannot support, hidden rather than offered.
+ *
+ * Either way it must run BEFORE the Scan Report is built: the report is scoped
+ * with `classLegendPanel.getVisibility().isFiltered()`, so a previously
+ * filtered scan would otherwise stamp the new one as class-scoped.
+ */
+export function resetClassificationUi(
+  deps: Pick<
+    OpenStreamingDeps,
+    'classLegendPanel' | 'hideReclassifyUi' | 'syncInspectClassScope'
+  >,
+): void {
+  deps.classLegendPanel.setClasses(new Map());
+  deps.classLegendPanel.hide();
+  deps.hideReclassifyUi();
+  deps.syncInspectClassScope();
+}
+
+/**
  * Wire an optional outer abort signal (the Stage URL field's Cancel button) into
  * a load's own AbortController (the progress toast's Cancel) so EITHER cancel
  * aborts the in-flight fetches. Returns a cleanup that detaches the listener —
@@ -505,26 +561,16 @@ export async function openStreamingCopc(
   // The legend is seeded + revealed lazily by `viewer.onStreamingNodeClasses`
   // as nodes carrying classification become resident, and refines as deeper
   // nodes stream in. A streaming source without a classification channel simply
-  // never seeds the legend, so it stays hidden.
-  deps.classLegendPanel.setClasses(new Map());
-  deps.classLegendPanel.hide();
-  deps.hideReclassifyUi();
-  // Clear any prior filtered scan's inspector copy/JSON scope stamp.
-  deps.syncInspectClassScope();
-  // Visual Export Studio — a streaming COPC cloud is now attached;
-  // the image-export buttons in the Inspector can light up. The streaming
-  // path doesn't go through `inspector.addCloud`, so the gate has to flip
-  // here too. Pre-warm the Studio chunk for the same reason as above.
-  deps.exportPanel.setImageExportEnabled(true);
-  // Per-mode gating — streaming COPC / EPT rarely carry normals or
-  // classification; disable the corresponding buttons at the source.
-  deps.exportPanel.setImageExportAvailability(viewer.availableImageExportModes());
-  // Switch the Inspector into streaming layout — hides Layers / Color by
-  // / Point size / Rendering / Export (their streaming-equivalents are
-  // in the StreamingPanel) and pins the panel to the lower-right so
-  // both panels coexist on desktop.
-  deps.inspector.setStreamingMode(true);
-  deps.exportPanel.setStreamingMode(true);
+  // never seeds the legend, so it stays hidden. Shared with the tileset open,
+  // where the same reset means the opposite thing (see the helper).
+  resetClassificationUi(deps);
+  // Streaming layout for the Inspector and the Export panel, plus the
+  // image-export gate: a streaming cloud never goes through
+  // `inspector.addCloud`, so nothing else flips it. Per-mode gating comes off
+  // the live viewer — streaming COPC / EPT rarely carry normals or
+  // classification, so those buttons stay dark at the source. Shared with the
+  // EPT and tileset opens.
+  enterStreamingInspectorMode(deps, viewer.availableImageExportModes());
   try { deps.inspector.setDetail(cloud.sourcePointCount, cloud.sourcePointCount); }
   catch (err) { if (deps.debug) console.warn('[inspector] setDetail (streaming) threw', err); }
   deps.setLastStreamingReportCloud(cloud);
@@ -802,13 +848,10 @@ export async function handleRemoteEpt(
     );
     deps.streamingPanel.setQuality(deps.getStreamingQuality());
     deps.streamingPanel.setPhase('Streaming coarse geometry…');
-    deps.exportPanel.setImageExportEnabled(true);
-    // Per-mode gating — EPT streams almost never carry normals.
-    deps.exportPanel.setImageExportAvailability(viewer.availableImageExportModes());
-    // Same streaming-mode layout the COPC path uses — hide Inspector's
-    // static-cloud sections and populate the streaming Scan Report.
-    deps.inspector.setStreamingMode(true);
-    deps.exportPanel.setStreamingMode(true);
+    // Same streaming-mode layout and image-export gate the COPC path uses.
+    // Per-mode gating comes off the live viewer — EPT streams almost never
+    // carry normals.
+    enterStreamingInspectorMode(deps, viewer.availableImageExportModes());
     try { deps.inspector.setDetail(cloud.sourcePointCount, cloud.sourcePointCount); }
     catch (err) { if (deps.debug) console.warn('[inspector] setDetail (streaming) threw', err); }
     try {

--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -18,6 +18,14 @@
  * candidate only if a cancel lands before the static layers are retired, and
  * publish CRS and provenance to global state ONLY after the commit.
  *
+ * The reveals after the commit are the same ones, minus the ones this format
+ * cannot honestly fill. A tileset states no point total, so nothing here prints
+ * one; it carries no LAS classification, so the class legend and the reclassify
+ * panel are hidden rather than offered empty; and its colour modes come from
+ * what the tiles carried rather than from the format. Everything else a
+ * committed streaming scan reveals — the streaming panel, the streaming
+ * Inspector layout, image export, the left rail — applies unchanged.
+ *
  * Held behind `lazyChunks.loadTilesetOpen` — the tileset parser, traversal,
  * transport and PNTS decoder are a chunk nothing in the startup shell needs.
  */
@@ -37,8 +45,10 @@ import {
 import type { AnalysisRow } from '../analysis/ModuleApi';
 import {
   activateCommittedStreamingCloud,
+  enterStreamingInspectorMode,
   isAbortError,
   linkAbortSignals,
+  resetClassificationUi,
   shouldDropCandidateOnPostCommitCancel,
   type OpenStreamingDeps,
   type StreamingReportInput,
@@ -208,6 +218,30 @@ export async function openRemoteTileset(
     viewer.setMode('orbit');
     viewer.frameAll();
 
+    // A point tile carries no LAS classification, so the legend and the
+    // reclassify panel are not empty-and-waiting here the way they are on a
+    // COPC stream: they are inapplicable, and they live in the left rail this
+    // open is about to reveal, so a previously opened COPC's legend would
+    // otherwise surface class filters over a scan that has no classes. Before
+    // the report, which is scoped by the legend's filter state. Wrapped for the
+    // same reason the report calls below are: the frame-honesty rows are what a
+    // user consults before trusting an elevation, and a throw in the class
+    // surfaces must not be what stops them being published.
+    try {
+      resetClassificationUi(deps);
+    } catch (err) {
+      if (deps.debug) console.warn('[class-legend] reset (tileset) threw', err);
+    }
+    // Streaming layout for the Inspector and the Export panel, plus the image
+    // export gate. Wrapped because the availability map is read off the live
+    // viewer: a throw there would otherwise cost the panel, the status poll and
+    // the chrome reveal below, none of which depend on it.
+    try {
+      enterStreamingInspectorMode(deps, viewer.availableImageExportModes());
+    } catch (err) {
+      if (deps.debug) console.warn('[inspector] streaming mode (tileset) threw', err);
+    }
+
     // The Scan Report for THIS scan. Nothing set it on this path, so the
     // Inspector kept whichever streaming scan was open before: a tileset opened
     // over a COPC read as that COPC, point count included. A tileset carries no
@@ -247,10 +281,59 @@ export async function openRemoteTileset(
       if (deps.debug) console.warn('[inspector] setReport (tileset) threw', err);
     }
 
+    // The left rail. `revealAnalysePanel` is the only call that reaches the
+    // shell's mobile-sheet sync and through it `workspace.setAvailable`, which
+    // is what puts `olv-ws-ready` on the rail; without it
+    // `.olv-left-panels:not(.olv-ws-ready) .olv-ws-body` hid Process Studio,
+    // the Export panel and the Measure panel, and the Measure panel was never
+    // even mounted. `false` for `settled`: a streaming open's route verdict runs
+    // on a sparse coarse frame, so the soft commit waits for the settle
+    // one-shot, exactly as the COPC and EPT opens pass it.
+    try {
+      deps.prewarmExportStudio();
+      deps.revealAnalysePanel(cloud.name, false);
+    } catch (err) {
+      if (deps.debug) console.warn('[workspace] revealAnalysePanel (tileset) threw', err);
+    }
+
     deps.streamingPanel.setColorModes([...cloud.availableColorModes()], cloud.defaultColorMode());
     deps.streamingPanel.setQuality(deps.getStreamingQuality());
     deps.streamingPanel.setSourceUrl(url);
     deps.streamingPanel.setPhase('Streaming coarse geometry…');
+    // The panel's Scan section, written BEFORE the panel becomes visible. The
+    // path populated everything else on the panel and never showed it; showing
+    // it without a summary would have exposed the previously opened scan's
+    // section instead, because `hide()` runs only on close and a
+    // streaming→streaming swap never passes through it. What a tileset states
+    // is its format, its extent and its octree; the point total stays null, so
+    // the Source row reads as absent rather than as a figure.
+    const bounds = cloud.dataBounds();
+    deps.streamingPanel.setSummary({
+      fileName: cloud.name,
+      // No LAS header, so no point-data record format; the panel's 3dtiles
+      // branch states the format and never renders this sentinel.
+      pointFormat: -1,
+      sourcePoints: cloud.sourcePointCount,
+      width: bounds[3] - bounds[0],
+      depth: bounds[4] - bounds[1],
+      height: bounds[5] - bounds[2],
+      // No `spacing`: a tileset declares neither COPC's root-node spacing nor
+      // EPT's node budget, and the panel omits the row rather than dashing it.
+      octreeDepth: cloud.maxDepth(),
+      nodeCount: cloud.octree.nodes().length,
+      format: '3dtiles',
+      crs: cloud.crs(),
+    });
+    deps.streamingPanel.show();
+
+    // A fresh saved-views list for the new scan.
+    try {
+      deps.bookmarks.clear();
+      deps.refreshViewsUI();
+    } catch (err) {
+      if (deps.debug) console.warn('[views] saved-views refresh (tileset) threw', err);
+    }
+
     deps.dropZone.setProgress(null);
     deps.dropZone.setCancelHandler(null);
     deps.startStreamingStatusPolling();

--- a/src/ui/StreamingPanel.ts
+++ b/src/ui/StreamingPanel.ts
@@ -45,6 +45,23 @@ export interface StreamingStatus {
   cacheBytes: number;
 }
 
+/** The streaming formats the panel labels a scan with. */
+export type StreamingSummaryFormat = 'copc' | 'ept' | '3dtiles';
+
+/**
+ * The card title, per format. It is rebuilt on every `setSummary`, so a scan
+ * opened over another one cannot keep the previous format's name, and
+ * {@link DEFAULT_TITLE} is what `hide()` returns it to when no scan is
+ * streaming. A format missing from this table falls back to the neutral title
+ * rather than to whichever entry happened to be the else-branch.
+ */
+const DEFAULT_TITLE = 'Streaming scan';
+const FORMAT_TITLE: Record<StreamingSummaryFormat, string> = {
+  copc: 'Streaming COPC',
+  ept: 'Streaming EPT',
+  '3dtiles': 'Streaming 3D Tiles',
+};
+
 /**
  * The one-time scan summary, derived from the source's metadata.
  *
@@ -62,11 +79,17 @@ export interface StreamingScanSummary {
   width: number;
   depth: number;
   height: number;
-  spacing: number;
+  /**
+   * The source's own resolution figure: COPC's root-node spacing, EPT's node
+   * budget. Absent where the format states neither — a 3D Tiles tileset
+   * declares no point spacing, and the resolution row is omitted rather than
+   * shown as a dash a future number could appear in.
+   */
+  spacing?: number;
   octreeDepth: number;
   nodeCount: number;
   /** which streaming format the source is. */
-  format?: 'copc' | 'ept';
+  format?: StreamingSummaryFormat;
   /** EPT-only: schema summary string for the Format row. */
   schemaSummary?: string;
   /**
@@ -139,7 +162,7 @@ function formatDim(n: number): string {
  * Pure + DOM-free so the decision is unit-tested without standing up the panel.
  */
 export function spacingRowFor(
-  format: 'copc' | 'ept' | undefined,
+  format: StreamingSummaryFormat | undefined,
   spacing: number,
   crs?: SpacingCrs | null,
 ): { readonly label: string; readonly value: string; readonly title: string } {
@@ -352,9 +375,10 @@ export class StreamingPanel {
     this._gradeResult.style.display = 'none';
 
     // The title's text is rebuilt from setSummary's `format` field so it
-    // tracks the actual streaming source (COPC vs. EPT) rather than the
-    // initial hardcoded label.
-    this._title = el('div', { className: 'olv-streaming-title', text: 'Streaming scan' });
+    // tracks the actual streaming source rather than the initial hardcoded
+    // label, and `hide()` puts it back so a closed scan's format does not name
+    // the next one.
+    this._title = el('div', { className: 'olv-streaming-title', text: DEFAULT_TITLE });
     // v0.3.6 mobile collapse — chevron toggle in the head row. Hidden on
     // desktop (CSS handles the gate); on mobile, tapping it collapses the
     // panel body so the user can reclaim canvas with one tap. Tapping
@@ -421,6 +445,13 @@ export class StreamingPanel {
   /** Hide and reset the panel. */
   hide(): void {
     this.element.classList.add('olv-hidden');
+    // The Scan section describes the scan that was streaming. It is not reset
+    // anywhere else, so leaving it here carried a closed scan's File, Format,
+    // Source, Extent and Octree rows — and its format title — into the next
+    // open, where they read as that scan's figures until a `setSummary` for the
+    // new one replaced them.
+    this._title.textContent = DEFAULT_TITLE;
+    this._summary.replaceChildren();
     this._paused = false;
     this._pause.textContent = 'Pause';
     // Reset the progress treatment for the next scan.
@@ -485,18 +516,23 @@ export class StreamingPanel {
   /** Populate the one-time scan summary from the streaming source's metadata. */
   setSummary(summary: StreamingScanSummary): void {
     // Title tracks the actual streaming source. Was hardcoded "Streaming
-    // COPC", which lied during an EPT load.
-    this._title.textContent = summary.format === 'ept' ? 'Streaming EPT' : 'Streaming COPC';
+    // COPC", then a two-way EPT-or-COPC branch, which named a third format's
+    // scan "Streaming COPC" for the same reason the hardcode did.
+    this._title.textContent =
+      summary.format === undefined ? DEFAULT_TITLE : FORMAT_TITLE[summary.format];
     const file = this._statRow('File', this._value(summary.fileName, summary.fileName));
-    // format-aware Format row. COPC shows the LAS PDRF; EPT shows
-    // the schema summary (when supplied) or just "EPT".
+    // format-aware Format row. COPC shows the LAS PDRF; EPT shows the schema
+    // summary (when supplied) or just "EPT"; 3D Tiles carries no LAS header, so
+    // it states the format and the tile type it serves and no record format.
     let formatText: string;
     if (summary.format === 'ept') {
       formatText = summary.schemaSummary ? `EPT · ${summary.schemaSummary}` : 'EPT';
+    } else if (summary.format === '3dtiles') {
+      formatText = '3D Tiles · pnts';
     } else {
       formatText = `COPC LAZ · PDRF ${summary.pointFormat}`;
     }
-    this._summary.replaceChildren(
+    const rows = [
       file,
       this._statRow('Format', this._value(formatText)),
       this._statRow('Source', this._value(
@@ -510,18 +546,23 @@ export class StreamingPanel {
           `${formatDim(summary.width)} × ${formatDim(summary.depth)} × ${formatDim(summary.height)}`,
         ),
       ),
-      // COPC `spacing` is a metric distance; EPT `span` is a points-per-tile
-      // budget. `spacingRowFor` labels + units each correctly so neither is
-      // misread (see its doc-comment for the label-vs-value drift it fixes).
-      (() => {
-        const r = spacingRowFor(summary.format, summary.spacing, summary.crs);
-        return this._statRow(r.label, this._value(r.value, r.title));
-      })(),
+    ];
+    // COPC `spacing` is a metric distance; EPT `span` is a points-per-tile
+    // budget. `spacingRowFor` labels + units each correctly so neither is
+    // misread (see its doc-comment for the label-vs-value drift it fixes). A
+    // format that states neither gets no row at all — a dash here would be a
+    // slot a number could later appear in without a source having stated one.
+    if (summary.spacing !== undefined) {
+      const r = spacingRowFor(summary.format, summary.spacing, summary.crs);
+      rows.push(this._statRow(r.label, this._value(r.value, r.title)));
+    }
+    rows.push(
       this._statRow(
         'Octree',
         this._value(`depth ${summary.octreeDepth} · ${summary.nodeCount} nodes`),
       ),
     );
+    this._summary.replaceChildren(...rows);
   }
 
   /** Populate the colour-mode chips and select the active one. */

--- a/tests/e2e/tilesetOpen.spec.ts
+++ b/tests/e2e/tilesetOpen.spec.ts
@@ -72,14 +72,22 @@ function scanReport(page: Page): Locator {
 /**
  * Points currently drawn, from the `?debug=1` overlay's rendering block.
  *
- * The Streaming panel carries the same counter and would be the natural place
- * to read it, but this open never shows that panel, so the overlay is the
- * surface that actually reports what the renderer drew.
+ * The overlay counts what the RENDERER put on screen this frame, which is not
+ * the same claim as the Streaming panel's resident counter below: one says the
+ * tiles were drawn, the other says they were decoded and admitted. Both are
+ * asserted, because either alone would leave the other unproven.
  */
 async function pointsShown(page: Page): Promise<number> {
   const text = (await page.locator('.olv-debug').textContent()) ?? '';
   const match = /points\s+([\d,]+)\s+shown/.exec(text);
   return match ? Number(match[1].replace(/,/g, '')) : -1;
+}
+
+/** One labelled row of the Streaming panel — its Scan section or its counters. */
+function streamingRow(page: Page, key: string): Locator {
+  return page
+    .locator('.olv-streaming-panel .olv-streaming-row')
+    .filter({ has: page.locator('.olv-streaming-key', { hasText: new RegExp(`^${key}$`) }) });
 }
 
 test.describe('3D Tiles — opening a tileset from a URL', () => {
@@ -99,6 +107,28 @@ test.describe('3D Tiles — opening a tileset from a URL', () => {
     await expect
       .poll(() => pointsShown(page), { timeout: 40_000 })
       .toBe(scene.totalPoints);
+
+    // The Streaming panel is the surface that reports the load, and this open
+    // populated it — colour modes, quality, source URL, phase — and then never
+    // showed it, so none of it was reachable and the ~4 Hz counters below ran
+    // into a hidden panel. It names this format, and its Scan section states
+    // the point total as absent rather than carrying a previous scan's figure.
+    const panel = page.locator('.olv-streaming-panel');
+    await expect(panel).toBeVisible();
+    await expect(panel.locator('.olv-streaming-title')).toHaveText('Streaming 3D Tiles');
+    await expect(streamingRow(page, 'Source')).toContainText('Unknown from source metadata');
+    await expect(streamingRow(page, 'Format')).toContainText('3D Tiles');
+    // The live counter, against the same total the renderer drew. `Unknown` is
+    // the right-hand side because the source states no total.
+    await expect
+      .poll(async () => (await streamingRow(page, 'Points').textContent()) ?? '', {
+        timeout: 40_000,
+      })
+      .toContain(`${scene.totalPoints} / Unknown`);
+    // The controls that ride with the panel: Pause, Clear cache, the full-cloud
+    // grade and the colour / quality chips were all unreachable with it hidden.
+    await expect(panel.locator('.olv-streaming-btn', { hasText: 'Pause' })).toBeVisible();
+    await expect(panel.locator('.olv-streaming-btn', { hasText: 'Clear cache' })).toBeVisible();
 
     // And they are really in the scene, not merely counted: Inspect raycasts the
     // resident nodes, so a card with per-point rows means a click landed on a
@@ -151,20 +181,37 @@ test.describe('3D Tiles — opening a tileset from a URL', () => {
     await expect(page.locator('.olv-measure-bar')).toBeVisible();
     await expect(page.locator('.olv-mkind', { hasText: /^Distance$/ })).toBeVisible();
 
+    // The left rail is available: `.olv-left-panels:not(.olv-ws-ready)
+    // .olv-ws-body { display: none }` hid the whole mode body until a scan
+    // opened, and only the Analyse-panel reveal flips that flag. Without it
+    // every panel below was present in the DOM and invisible on screen.
+    const rail = page.locator('.olv-left-panels');
+    await expect(rail).toHaveClass(/olv-ws-ready/, { timeout: 20_000 });
+    await expect(rail.locator('.olv-ws-tabs')).toBeVisible();
+
     // Process Studio is where a withheld tool says WHY, so it carries the
-    // preflight verdict this regression was about. Its rows are read as content
-    // rather than asserted visible: this open leaves the left rail's mode body
-    // hidden, which is a separate defect and not what this test is pinning.
+    // preflight verdict this regression was about. Its rows are asserted
+    // VISIBLE, which is what the rail reveal makes possible: the Analyse mode
+    // is one tab away rather than behind a body nothing displays.
+    await rail.locator('.olv-ws-tab', { hasText: 'Analyse' }).click();
     const studio = page.locator('.olv-process-studio');
+    await expect(studio).toBeVisible();
     const tools = studio.locator('.olv-ps-tool');
     await expect(tools).toHaveCount(4, { timeout: 20_000 });
     const distance = studio.locator('.olv-ps-tool', { hasText: 'Distance' });
-    await expect(distance).toHaveCount(1);
+    await expect(distance).toBeVisible();
     await expect(distance).not.toHaveClass(/olv-ps-blocked/);
     // The exact sentence the refusal used to carry, on any tool row.
     await expect(
       studio.locator('.olv-ps-tool', { hasText: 'No scan is loaded' }),
     ).toHaveCount(0);
+
+    // The class legend rides in the Data mode next door. A point tile carries no
+    // LAS classification, so it must not be offering class filters here — least
+    // of all a previous scan's, which is what a rail reveal without the reset
+    // would have surfaced.
+    await rail.locator('.olv-ws-tab', { hasText: 'Data' }).click();
+    await expect(page.locator('.olv-class-panel')).toBeHidden();
   });
 
   test('publishes a Scan Report for the tileset, and says up was never established', async ({

--- a/tests/streamingPanelStaleSummary.test.ts
+++ b/tests/streamingPanelStaleSummary.test.ts
@@ -1,0 +1,166 @@
+/**
+ * streamingPanelStaleSummary.test.ts
+ *
+ * The StreamingPanel's Scan section belongs to the scan currently streaming.
+ *
+ * Two ways it stopped doing that. `hide()` reset the pause button, the progress
+ * bar and the grade affordance but left the title and the summary rows alone,
+ * so closing a scan and opening the next one showed the closed scan's File,
+ * Format, Source, Extent and Octree until a new `setSummary` overwrote them.
+ * And `setSummary` decided its title from a two-way branch — EPT or COPC — so a
+ * third streaming format fell through to "Streaming COPC" and a "COPC LAZ ·
+ * PDRF undefined" Format row.
+ *
+ * Same recording DOM stub the other panel tests use (FakeEl), so the render
+ * tree is pinned in the node environment without a browser.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+class FakeEl {
+  className = '';
+  title = '';
+  type = '';
+  disabled = false;
+  private _text = '';
+  readonly children: FakeEl[] = [];
+  readonly dataset: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly classList = {
+    _set: new Set<string>(),
+    add(c: string): void { this._set.add(c); },
+    remove(c: string): void { this._set.delete(c); },
+    toggle(c: string): void { this._set.has(c) ? this._set.delete(c) : this._set.add(c); },
+    contains(c: string): boolean { return this._set.has(c); },
+  };
+  readonly tagName: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+  setAttribute(): void { /* no-op */ }
+  removeAttribute(): void { /* no-op */ }
+  set textContent(v: string) { this._text = v; }
+  get textContent(): string {
+    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
+  }
+  append(...kids: FakeEl[]): void { this.children.push(...kids.filter(Boolean)); }
+  replaceChildren(...kids: FakeEl[]): void { this.children.length = 0; this.children.push(...kids.filter(Boolean)); }
+  addEventListener(): void { /* no-op */ }
+  blur(): void { /* no-op */ }
+  click(): void { /* no-op */ }
+  /** First descendant whose own text contains `substr`, or undefined. */
+  findContaining(substr: string): FakeEl | undefined {
+    if (this._text.includes(substr)) return this;
+    for (const c of this.children) {
+      const hit = c.findContaining(substr);
+      if (hit) return hit;
+    }
+    return undefined;
+  }
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { document: unknown }).document = {
+    createElement: (tag: string) => new FakeEl(tag),
+  };
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.HTMLInputElement ??= class {};
+  g.HTMLAnchorElement ??= class {};
+});
+
+function noopCallbacks() {
+  return {
+    onColorMode() {}, onQuality() {}, onPauseToggle() {}, onClearCache() {},
+    onGradeFullCloud() {}, onCancelGrade() {},
+  };
+}
+
+const COPC_SUMMARY = {
+  fileName: 'autzen.copc.laz',
+  pointFormat: 6,
+  sourcePoints: 10_653_336,
+  width: 620.5,
+  depth: 480.2,
+  height: 63.7,
+  spacing: 2.5,
+  octreeDepth: 5,
+  nodeCount: 141,
+  format: 'copc' as const,
+};
+
+const TILESET_SUMMARY = {
+  fileName: 'tileset.json',
+  pointFormat: -1,
+  sourcePoints: null,
+  width: 120,
+  depth: 90,
+  height: 14,
+  octreeDepth: 3,
+  nodeCount: 27,
+  format: '3dtiles' as const,
+};
+
+async function panelWith(summary: Parameters<
+  Awaited<typeof import('../src/ui/StreamingPanel')>['StreamingPanel']['prototype']['setSummary']
+>[0]) {
+  const { StreamingPanel } = await import('../src/ui/StreamingPanel');
+  const panel = new StreamingPanel(noopCallbacks());
+  panel.setSummary(summary);
+  return { panel, root: panel.element as unknown as FakeEl };
+}
+
+describe('hide() drops the closed scan', () => {
+  it('clears the summary rows so the next scan cannot inherit them', async () => {
+    const { panel, root } = await panelWith(COPC_SUMMARY);
+    expect(root.findContaining('autzen.copc.laz')).toBeDefined();
+    panel.hide();
+    expect(
+      root.findContaining('autzen.copc.laz'),
+      "the closed scan's File row survives into the next open",
+    ).toBeUndefined();
+    expect(root.findContaining('10,653,336')).toBeUndefined();
+  });
+
+  it('returns the title to the format-neutral one', async () => {
+    const { panel, root } = await panelWith(COPC_SUMMARY);
+    expect(root.findContaining('Streaming COPC')).toBeDefined();
+    panel.hide();
+    expect(root.findContaining('Streaming COPC')).toBeUndefined();
+    expect(root.findContaining('Streaming scan')).toBeDefined();
+  });
+});
+
+describe('a 3D Tiles summary states 3D Tiles', () => {
+  it('titles the card for the format that is actually streaming', async () => {
+    const { root } = await panelWith(TILESET_SUMMARY);
+    expect(root.findContaining('Streaming 3D Tiles')).toBeDefined();
+    expect(root.findContaining('Streaming COPC')).toBeUndefined();
+  });
+
+  it('never renders a LAS point-data record format for a format that has none', async () => {
+    const { root } = await panelWith(TILESET_SUMMARY);
+    expect(root.findContaining('PDRF')).toBeUndefined();
+    expect(root.findContaining('3D Tiles')).toBeDefined();
+  });
+
+  it('says the point total is absent rather than printing one', async () => {
+    const { root } = await panelWith(TILESET_SUMMARY);
+    expect(root.findContaining('Unknown from source metadata')).toBeDefined();
+  });
+
+  it('omits the spacing row the format does not state', async () => {
+    // COPC declares a root-node spacing and EPT a node budget. 3D Tiles states
+    // neither, and a dash row would only be a place for a future number to
+    // appear from nowhere.
+    const { root } = await panelWith(TILESET_SUMMARY);
+    expect(root.findContaining('Spacing')).toBeUndefined();
+    expect(root.findContaining('Node budget')).toBeUndefined();
+    // The rows it does state are still there.
+    expect(root.findContaining('depth 3 · 27 nodes')).toBeDefined();
+  });
+
+  it('replaces a previous scan’s rows rather than appending to them', async () => {
+    const { panel, root } = await panelWith(COPC_SUMMARY);
+    panel.setSummary(TILESET_SUMMARY);
+    expect(root.findContaining('autzen.copc.laz')).toBeUndefined();
+    expect(root.findContaining('tileset.json')).toBeDefined();
+  });
+});

--- a/tests/tilesetFrameUnknown.test.ts
+++ b/tests/tilesetFrameUnknown.test.ts
@@ -79,6 +79,7 @@ function deps() {
     attachStreamingCloud: vi.fn(async () => {}),
     setMode: vi.fn(),
     frameAll: vi.fn(),
+    availableImageExportModes: () => new Map(),
   };
   const setReport = vi.fn();
   return {
@@ -98,13 +99,28 @@ function deps() {
       startStreamingStatusPolling: () => {},
       revealStreamingChrome: () => {},
       stage: { hideEmptyState: () => {} },
-      inspector: { setReport },
+      inspector: { setReport, setStreamingMode: vi.fn() },
       // Added by the scan-detection work after this fake was written. The open
       // calls all three before it publishes the report, so a fake without them
       // throws and the report never reaches the Inspector at all.
       setLastStreamingReportCloud: vi.fn(),
       runStreamingModules: () => [],
-      classLegendPanel: { getVisibility: () => ({ isFiltered: false }) },
+      classLegendPanel: {
+        getVisibility: () => ({ isFiltered: false }),
+        setClasses: vi.fn(),
+        hide: vi.fn(),
+      },
+      hideReclassifyUi: vi.fn(),
+      syncInspectClassScope: vi.fn(),
+      exportPanel: {
+        setImageExportEnabled: vi.fn(),
+        setImageExportAvailability: vi.fn(),
+        setStreamingMode: vi.fn(),
+      },
+      bookmarks: { clear: vi.fn() },
+      revealAnalysePanel: vi.fn(),
+      prewarmExportStudio: vi.fn(),
+      refreshViewsUI: vi.fn(),
       inspectorCards: { refreshProvenanceFromStreaming: () => {} },
       crsCoordinator: { refreshCrsForStreamingCloud: () => {} },
       streamingPanel: {
@@ -112,6 +128,8 @@ function deps() {
         setQuality: () => {},
         setSourceUrl: () => {},
         setPhase: () => {},
+        setSummary: vi.fn(),
+        show: vi.fn(),
       },
       dropZone: {
         setOpening: () => {},

--- a/tests/tilesetStreamingOpen.test.ts
+++ b/tests/tilesetStreamingOpen.test.ts
@@ -27,6 +27,8 @@ const DOC = JSON.stringify({
 function deps(doc = DOC) {
   const order: string[] = [];
   const reported: { kind?: string; sourcePointCount?: number | null }[] = [];
+  const summaries: unknown[] = [];
+  const revealed: { name: string; settled?: boolean }[] = [];
   const setReport = vi.fn();
   const viewer = {
     clouds: () => [],
@@ -35,11 +37,17 @@ function deps(doc = DOC) {
     }),
     setMode: vi.fn(),
     frameAll: vi.fn(),
+    // The per-mode image-export gating the streaming opens read off the live
+    // scene. A tileset carries no intensity / classification / normals, so the
+    // map a real viewer returns for one disables those modes at the source.
+    availableImageExportModes: vi.fn(() => new Map([['rgb', { available: true }]])),
   };
   return {
     order,
     viewer,
     reported,
+    summaries,
+    revealed,
     setReport,
     attached: viewer.attachStreamingCloud,
     d: {
@@ -50,8 +58,34 @@ function deps(doc = DOC) {
       runStreamingModules: (c: { sourcePointCount?: number | null }) => [
         { label: 'Source point count', value: String(c.sourcePointCount), status: 'info' },
       ],
-      inspector: { setReport },
-      classLegendPanel: { getVisibility: () => ({ isFiltered: () => false }) },
+      inspector: {
+        setReport,
+        setStreamingMode: vi.fn(),
+        setDetail: vi.fn(),
+        element: { classList: { remove: vi.fn(), add: vi.fn() } },
+      },
+      classLegendPanel: {
+        getVisibility: () => ({ isFiltered: () => false }),
+        setClasses: vi.fn(() => order.push('classes')),
+        hide: vi.fn(() => order.push('legendHide')),
+        show: vi.fn(),
+      },
+      inspectorCards: { refreshProvenanceFromStreaming: () => order.push('provenance'),
+        refreshDatasetIntelligenceFromStreamingCloud: vi.fn() },
+      exportPanel: {
+        setImageExportEnabled: vi.fn(),
+        setImageExportAvailability: vi.fn(),
+        setStreamingMode: vi.fn(),
+      },
+      bookmarks: { clear: vi.fn() },
+      revealAnalysePanel: vi.fn((name: string, settled?: boolean) => {
+        order.push('analyse');
+        revealed.push({ name, settled });
+      }),
+      prewarmExportStudio: vi.fn(),
+      refreshViewsUI: vi.fn(),
+      hideReclassifyUi: vi.fn(() => order.push('reclassifyHide')),
+      syncInspectClassScope: vi.fn(),
       isLoading: () => false,
       setLoading: () => {},
       viewerReady: Promise.resolve(),
@@ -66,13 +100,14 @@ function deps(doc = DOC) {
       startStreamingStatusPolling: () => order.push('poll'),
       revealStreamingChrome: () => order.push('reveal'),
       stage: { hideEmptyState: () => {} },
-      inspectorCards: { refreshProvenanceFromStreaming: () => order.push('provenance') },
       crsCoordinator: { refreshCrsForStreamingCloud: () => order.push('crs') },
       streamingPanel: {
         setColorModes: vi.fn(),
         setQuality: () => {},
         setSourceUrl: () => {},
         setPhase: () => {},
+        setSummary: vi.fn((s: unknown) => { order.push('summary'); summaries.push(s); }),
+        show: vi.fn(() => order.push('panelShow')),
       },
       dropZone: {
         setOpening: () => {},
@@ -188,6 +223,131 @@ describe('the open path', () => {
     );
     expect(t.attached).not.toHaveBeenCalled();
     expect(t.d.dropZone.setError).toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// What a committed tileset reveals
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Open the fixture tileset and hand back the recorded deps. */
+async function opened(doc = DOC) {
+  const t = deps(doc);
+  await withTransport(doc, () =>
+    openRemoteTileset('https://host/d/tileset.json', undefined, t.d as never),
+  );
+  return t;
+}
+
+describe('the workspace a committed tileset reveals', () => {
+  it('makes the left rail available', async () => {
+    // `revealAnalysePanel` is the only call that reaches the shell's
+    // `syncMobileSheet()` -> `workspace.setAvailable(hasScan())`, and
+    // `.olv-left-panels:not(.olv-ws-ready) .olv-ws-body { display: none }` hides
+    // the whole rail body until that flips. Without it a tileset draws points
+    // with Process Studio, the Export panel and the Measure panel all invisible.
+    const t = await opened();
+    expect(t.d.revealAnalysePanel).toHaveBeenCalledTimes(1);
+    expect(t.revealed[0].name).toBe('tileset.json');
+    // `false` — a streaming open's route verdict runs on a sparse coarse frame,
+    // so the soft commit waits for the settle one-shot, as COPC and EPT pass.
+    expect(t.revealed[0].settled).toBe(false);
+  });
+
+  it('shows the streaming panel it has been populating', async () => {
+    // The path already fills the panel (colour modes, quality, source URL,
+    // phase) and polls it four times a second. None of it was reachable.
+    const t = await opened();
+    expect(t.d.streamingPanel.show).toHaveBeenCalledTimes(1);
+  });
+
+  it('switches the Inspector and Export panel into streaming layout', async () => {
+    const t = await opened();
+    expect(t.d.inspector.setStreamingMode).toHaveBeenCalledWith(true);
+    expect(t.d.exportPanel.setStreamingMode).toHaveBeenCalledWith(true);
+  });
+
+  it('lights up image export and gates it on what the scene actually has', async () => {
+    const t = await opened();
+    expect(t.d.exportPanel.setImageExportEnabled).toHaveBeenCalledWith(true);
+    expect(t.viewer.availableImageExportModes).toHaveBeenCalled();
+    expect(t.d.exportPanel.setImageExportAvailability).toHaveBeenCalledTimes(1);
+    expect(t.d.prewarmExportStudio).toHaveBeenCalled();
+  });
+
+  it('gives the scan a fresh saved-views list', async () => {
+    const t = await opened();
+    expect(t.d.bookmarks.clear).toHaveBeenCalled();
+    expect(t.d.refreshViewsUI).toHaveBeenCalled();
+  });
+
+  it('reveals the rail only after the attach has committed', async () => {
+    const t = await opened();
+    expect(t.order.indexOf('analyse')).toBeGreaterThan(t.order.indexOf('attach'));
+  });
+});
+
+describe('the streaming panel a tileset shows', () => {
+  it('states this tileset before the panel becomes visible', async () => {
+    // `hide()` does not clear the summary and a streaming->streaming swap never
+    // calls it, so showing the panel without writing a summary first leaves the
+    // previously opened scan's Scan section and title on screen.
+    const t = await opened();
+    expect(t.d.streamingPanel.setSummary).toHaveBeenCalledTimes(1);
+    expect(t.order.indexOf('summary')).toBeLessThan(t.order.indexOf('panelShow'));
+  });
+
+  it('tags the summary as 3D Tiles, not as COPC', async () => {
+    const t = await opened();
+    const s = t.summaries[0] as { format?: string; fileName?: string };
+    expect(s.format).toBe('3dtiles');
+    expect(s.fileName).toBe('tileset.json');
+  });
+
+  it('keeps the point total absent in the panel too', async () => {
+    const t = await opened();
+    const s = t.summaries[0] as { sourcePoints?: number | null };
+    expect(s.sourcePoints).toBeNull();
+  });
+});
+
+describe('controls a tileset cannot support are not presented', () => {
+  it('never prints a point count the format does not state', async () => {
+    // `inspector.setDetail(n, n)` renders "N / N points" with a percentage bar.
+    // A tileset states no total, so both arguments would be null: the bar reads
+    // 100% and the text is a figure nothing measured. COPC and EPT call it
+    // because they declare a total; this path must not.
+    const t = await opened();
+    expect(t.d.inspector.setDetail).not.toHaveBeenCalled();
+  });
+
+  it('does not push a density and coverage card built from a total of zero', async () => {
+    // `refreshDatasetIntelligenceFromStreamingCloud` buckets points per cubic
+    // metre and coerces a missing total to `sourcePointCount: 0` for the
+    // coverage classifier. Neither input exists here.
+    const t = await opened();
+    expect(t.d.inspectorCards.refreshDatasetIntelligenceFromStreamingCloud).not.toHaveBeenCalled();
+  });
+
+  it('hides the class legend and the reclassify panel rather than revealing them', async () => {
+    // 3D Tiles point tiles carry no LAS classification, so the legend is not an
+    // empty legend waiting to fill: it is inapplicable. It lives in the rail
+    // body this fix reveals, so a previous COPC's legend would otherwise become
+    // visible offering class filters over a scan that has no classes.
+    const t = await opened();
+    expect(t.d.classLegendPanel.hide).toHaveBeenCalledTimes(1);
+    expect(t.d.classLegendPanel.show).not.toHaveBeenCalled();
+    expect(t.d.hideReclassifyUi).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the previous scan's class filter before the report is scoped", async () => {
+    // The report is stamped with `classLegendPanel.getVisibility().isFiltered()`.
+    // A prior filtered COPC would otherwise mark a tileset's Scan Report as
+    // class-scoped when the format has no classes to scope by.
+    const t = await opened();
+    expect(t.d.classLegendPanel.setClasses).toHaveBeenCalledTimes(1);
+    expect(t.d.syncInspectClassScope).toHaveBeenCalledTimes(1);
+    expect(t.order.indexOf('classes')).toBeLessThan(t.order.indexOf('report'));
   });
 });
 


### PR DESCRIPTION
A committed 3D Tiles tileset drew points with almost no application UI. The
open called only `revealStreamingChrome`. `revealAnalysePanel` is the only
path to `workspace.setAvailable`, and
`.olv-left-panels:not(.olv-ws-ready) .olv-ws-body { display: none }` hid the
whole mode body, taking Process Studio, the Export panel and the never
mounted Measure panel with it. The streaming panel was populated and polled
at 4 Hz while still carrying `olv-hidden`.

The open now resets the class legend and reclassify panel, enters the
streaming Inspector layout, gates image export off the live scene, reveals
the rail, and shows the panel with its own summary. `inspector.setDetail`
and the dataset-intelligence card stay unused: both render figures from a
point total 3D Tiles does not state. `StreamingPanel.hide` clears the
summary and title; `setSummary` labels 3dtiles and omits the spacing row.
The two weakened `tilesetOpen.spec.ts` assertions are tightened and fail
without the fix.
