### PR TITLE
fix(streaming): derive the export GPS time claim from each source

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -166,7 +166,7 @@ import type { DebugOverlay, StreamingDebugStats } from './ui/DebugOverlay';
 // Type-only: the overlay itself rides a lazy chunk (loadColorbarOverlay).
 import type { ColorbarOverlay } from './ui/ColorbarOverlay';
 import { estimateDecodedBytes, estimateGpuBytes, type StreamingQuality } from './render/streaming/streamingBudget';
-import { streamingSourceLabel, type StreamingSourceKind } from './render/streaming/StreamingSource';
+import { streamingHasGpsTime, streamingSourceLabel, type StreamingSourceKind } from './render/streaming/StreamingSource';
 import { isZUpFormat } from './io/sniffFormat';
 // `exportCloud` is dynamically imported via `loadExporters` in the onExport
 // callback — the PLY/OBJ/XYZ/CSV encoders stay in their own chunk and never
@@ -2956,8 +2956,8 @@ const exportPanel = new ExportPanel({
       // promised roughly twice the points and bytes the write delivered.
       pointCount: viewer.exportFrontierPointTotal(),
       hasRgb: sc.availableColorModes().includes('rgb'),
-      // COPC/EPT point records (PDRF 6/7/8) carry GPS time.
-      hasGpsTime: true,
+      // Only what THIS source's metadata establishes; see streamingHasGpsTime.
+      hasGpsTime: streamingHasGpsTime(sc),
       crsName: rc.name,
       hasWkt: rc.wkt != null,
       // Streaming classification is read straight from the source records — a

--- a/src/render/streaming/EptStreamingPointCloud.ts
+++ b/src/render/streaming/EptStreamingPointCloud.ts
@@ -245,6 +245,21 @@ export class EptStreamingPointCloud implements StreamingSource {
   }
 
   /**
+   * Whether the tiles carry GPS time, from the `ept.json` schema — the same
+   * declaration {@link availableColorModes} reads for every other channel.
+   *
+   * X, Y and Z are the only dimensions an EPT must declare, so a pyramid that
+   * names no `GpsTime` has none. The answer covers both `dataType`s: the schema
+   * describes the point layout the writer produced, so a laszip pyramid whose
+   * tiles are PDRF 0 or 2 declares no `GpsTime` either. This is metadata, not a
+   * decode, so it is available before the first tile lands, which is when the
+   * export panel has to decide what to offer.
+   */
+  hasGpsTime(): boolean {
+    return this._schemaHas('GpsTime');
+  }
+
+  /**
    * the CRS extracted from `ept.json`'s `srs` object. Prefers the WKT (richest),
    * then falls back to the authority codes (`horizontal` / `vertical`). When the
    * WKT carries no vertical datum but the codes name one, the vertical datum is

--- a/src/render/streaming/StreamingPointCloud.ts
+++ b/src/render/streaming/StreamingPointCloud.ts
@@ -142,6 +142,18 @@ export class StreamingPointCloud implements StreamingSource {
   }
 
   /**
+   * Whether the point records carry GPS time. Read off the LAS header flag
+   * rather than asserted from the format: the header parser rejects any point
+   * data record format outside 6/7/8, all of which carry the field, so the flag
+   * and the format agree here — but the flag is the thing the file states, and
+   * a reader that asserts what a format usually does is how the claim went
+   * wrong for the other sources in the first place.
+   */
+  hasGpsTime(): boolean {
+    return this.metadata.header.hasGpsTime;
+  }
+
+  /**
    * the CRS the COPC public-header parser pulled out of the
    * LASF_Projection VLRs (see `src/io/crs.ts`). Already cached on the
    * header; we re-expose it through the abstract `StreamingSource`

--- a/src/render/streaming/StreamingSource.ts
+++ b/src/render/streaming/StreamingSource.ts
@@ -245,6 +245,26 @@ export interface StreamingSource {
    */
   availableColorModes(): readonly StreamingColorMode[];
   /**
+   * Whether the source's OWN metadata establishes that its point records carry
+   * GPS time — read before a single chunk is decoded, because the export panel
+   * has to decide what to offer while the cloud is still filling in.
+   *
+   * Every implementation answers from something the document states, never from
+   * the format's usual habits: COPC from the LAS header flag (its point format
+   * is validated as 6/7/8, all of which carry the field), EPT from the
+   * `ept.json` schema (X/Y/Z are the only required dimensions, so an EPT that
+   * declares no `GpsTime` has none, whether its tiles are binary or laszip),
+   * 3D Tiles from the format (a `pnts` tile has no GPS time to carry).
+   *
+   * Optional only because the OLV tile store predates it. Absent is not `false`
+   * in meaning: it says this source has not been taught to answer, which is why
+   * {@link streamingHasGpsTime} resolves it conservatively rather than callers
+   * each picking a default. `tests/streamingGpsTimeClaim.test.ts` holds the
+   * shrink-only list of sources still omitting it, so a NEW source cannot join
+   * them silently.
+   */
+  hasGpsTime?(): boolean;
+  /**
    * the source CRS, when the cloud carries projection metadata.
    * COPC clouds get this from the LAS VLRs the public-header parser walks
    * (see `src/io/crs.ts`); EPT clouds get it from `ept.json`'s `srs.wkt`
@@ -299,6 +319,29 @@ export interface StreamingSource {
    * nothing to release and omits it; a COPC source closes its range reader.
    */
   close?(): Promise<void>;
+}
+
+/**
+ * Whether a streaming cloud carries GPS time, as its own metadata states it.
+ *
+ * This is what the export panel offers a GPS time field on, and what the LAS
+ * writers size their records against, so it is a claim about the data rather
+ * than a hint. The shell used to answer it with a literal `true` on the grounds
+ * that COPC mandates point format 6, 7 or 8. That holds for COPC and reaches
+ * none of the other three: an EPT schema need only declare X, Y and Z, a laszip
+ * EPT tile at PDRF 0 or 2 carries no GPS time, a `pnts` tile has none at all,
+ * and an OLV tile store carries it only when the source it was built from did.
+ *
+ * A source that has not been taught {@link StreamingSource.hasGpsTime} resolves
+ * to `false`, which is the conservative direction and not a claim of absence:
+ * the panel declines to offer a field it cannot establish, rather than promising
+ * a column the writer may have to fill with zeros. The cost of being wrong that
+ * way is an unoffered field; the cost of the other way is an export whose GPS
+ * time column is fabricated. Sources still in that position are listed in
+ * `tests/streamingGpsTimeClaim.test.ts`, and the list is shrink-only.
+ */
+export function streamingHasGpsTime(source: StreamingSource): boolean {
+  return source.hasGpsTime?.() === true;
 }
 
 // Re-export `DecodedChunk` so consumers that import `StreamingSource` need

--- a/src/render/streaming/TilesetStreamingSource.ts
+++ b/src/render/streaming/TilesetStreamingSource.ts
@@ -296,6 +296,17 @@ export class TilesetStreamingSource implements StreamingSource {
     return modes;
   }
 
+  /**
+   * Never. A `pnts` tile has no GPS time semantic to carry: its feature table
+   * defines positions, colours and normals, and a batch table holds authored
+   * per-feature properties whose meaning the format does not fix. Nothing in a
+   * tileset promises an acquisition timestamp per point, so there is no time to
+   * export and no reading of any tile that could produce one.
+   */
+  hasGpsTime(): boolean {
+    return false;
+  }
+
   crs(): CrsInfo | null {
     return this._crs;
   }

--- a/tests/streamingGpsTimeClaim.test.ts
+++ b/tests/streamingGpsTimeClaim.test.ts
@@ -1,0 +1,204 @@
+/**
+ * streamingGpsTimeClaim.test.ts — a streaming cloud is offered a GPS time
+ * export field only when its own metadata says it has one.
+ *
+ * The export panel's summary decides what the writer will emit and what the
+ * size estimate counts, so `hasGpsTime` is a statement about the data, not a
+ * hint. The shell answered it with a hardcoded `true` for every streaming
+ * source, justified by COPC's point format. That justification does not reach
+ * the other three: a binary EPT need only declare X/Y/Z, a laszip EPT tile at
+ * PDRF 0 or 2 carries no GPS time, and a `pnts` tile has none in any case.
+ *
+ * These cases pin both directions. A source with no GPS time must not be
+ * offered the field, and a source that has one must still be offered it, so
+ * the fix cannot degrade into removing the field for everybody.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  streamingHasGpsTime,
+  type StreamingSource,
+} from '../src/render/streaming/StreamingSource';
+import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
+import { EptStreamingPointCloud } from '../src/render/streaming/EptStreamingPointCloud';
+import type { EptTransport } from '../src/render/streaming/EptStreamingPointCloud';
+import { TilesetStreamingSource } from '../src/render/streaming/TilesetStreamingSource';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import type { TilesetTransport } from '../src/io/tiles3d/tilesetTransport';
+import { parseEptMetadata } from '../src/io/ept/eptDetect';
+import type { EptMetadata, EptSchemaField } from '../src/io/ept/eptTypes';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import { buildSyntheticCopc } from './fixtures/copc/synthCopc';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const SRC = join(ROOT, 'src');
+const EPT_FIXTURE = join(ROOT, 'tests', 'fixtures', 'ept-tiny');
+
+/** The fixture EPT declares X, Y, Z, Intensity, Classification and nothing else. */
+function fixtureMetadata(): EptMetadata {
+  const parsed = parseEptMetadata(readFileSync(join(EPT_FIXTURE, 'ept.json'), 'utf8'));
+  if (!parsed.isEpt) throw new Error('ept-tiny fixture failed to parse');
+  return parsed.metadata;
+}
+
+/** The same pyramid, written by a producer that DID carry GPS time. */
+function metadataWithGpsTime(): EptMetadata {
+  const base = fixtureMetadata();
+  const gps: EptSchemaField = { name: 'GpsTime', size: 8, type: 'float' };
+  return { ...base, schema: [...base.schema, gps] };
+}
+
+function eptTransport(): EptTransport {
+  const local = (url: string) => join(EPT_FIXTURE, url.replace(/^fixture:\/\/ept-tiny\//, ''));
+  return {
+    fetchText: async (url) => readFileSync(local(url), 'utf8'),
+    fetchBytes: async (url) => {
+      const buf = readFileSync(local(url));
+      return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+    },
+  };
+}
+
+function openEpt(meta: EptMetadata): Promise<EptStreamingPointCloud> {
+  return EptStreamingPointCloud.open(meta, 'fixture://ept-tiny/', 'ept-tiny', eptTransport());
+}
+
+/** A minimal in-spec tileset: a box volume and one point-tile content. */
+const TILESET_DOC = JSON.stringify({
+  asset: { version: '1.0' },
+  geometricError: 100,
+  root: {
+    boundingVolume: { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] },
+    geometricError: 50,
+    refine: 'REPLACE',
+    content: { uri: 'r.pnts' },
+  },
+});
+
+function tilesetSource(): TilesetStreamingSource {
+  const transport: TilesetTransport = {
+    fetchTilesetJson: async () => '{}',
+    fetchTileBytes: async () => new ArrayBuffer(8),
+  };
+  return new TilesetStreamingSource(
+    'tileset-id',
+    'tileset',
+    'https://host/d/tileset.json',
+    transport,
+    parseTileset(TILESET_DOC),
+  );
+}
+
+describe('a streaming source without GPS time is not offered the field', () => {
+  it('answers no for an EPT whose schema declares no GpsTime', async () => {
+    const cloud = await openEpt(fixtureMetadata());
+    expect(cloud.availableColorModes()).not.toContain('rgb');
+    expect(
+      streamingHasGpsTime(cloud),
+      'the ept-tiny schema declares X/Y/Z/Intensity/Classification only, so ' +
+        'offering a GPS time field promises a column the writer cannot fill',
+    ).toBe(false);
+  });
+
+  it('answers no for a 3D Tiles tileset, which has no GPS time in any case', () => {
+    expect(streamingHasGpsTime(tilesetSource())).toBe(false);
+  });
+
+  it('answers no for a source that has not been taught to answer', () => {
+    // The OLV tile store omits the method (see the shrink-only list below).
+    // Absent means unknown, and an unknown channel must not be offered.
+    const untaught = { kind: 'tiles' } as unknown as StreamingSource;
+    expect(streamingHasGpsTime(untaught)).toBe(false);
+  });
+});
+
+describe('a streaming source that does carry GPS time still reports it', () => {
+  it('answers yes for COPC, whose point format is validated as 6/7/8', async () => {
+    const fixture = buildSyntheticCopc({
+      center: [0, 0, 0],
+      halfsize: 128,
+      nodes: [{ key: [0, 0, 0, 0], pointCount: 64 }],
+    });
+    const cloud = await StreamingPointCloud.open(
+      new ArrayBufferRangeSource(fixture.buffer),
+      'gps.copc.laz',
+    );
+    expect(cloud.metadata.header.hasGpsTime).toBe(true);
+    expect(streamingHasGpsTime(cloud)).toBe(true);
+  });
+
+  it('answers yes for an EPT whose schema declares GpsTime', async () => {
+    const cloud = await openEpt(metadataWithGpsTime());
+    expect(
+      streamingHasGpsTime(cloud),
+      'a blanket false would strip the field from every EPT that has one',
+    ).toBe(true);
+  });
+});
+
+describe('the shell reads the answer off the source', () => {
+  const main = readFileSync(join(SRC, 'main.ts'), 'utf8');
+
+  it('never restates the claim as a literal in the export summary', () => {
+    expect(main).not.toMatch(/hasGpsTime:\s*true/);
+  });
+
+  it('derives the streaming answer through the source contract', () => {
+    expect(main).toMatch(/hasGpsTime:\s*streamingHasGpsTime\(sc\)/);
+  });
+});
+
+/**
+ * Sources that do not implement `hasGpsTime`. The OLV tile store manifest
+ * records the answer (`schema.hasGps`) but the file is owned elsewhere, so it
+ * currently resolves to the conservative "not offered". Anything ADDED here is
+ * a source whose export field is decided by a default rather than by its data,
+ * so this list may shrink and never grow.
+ */
+const WITHOUT_ANSWER = ['io/heavy/OlvTileSource.ts'];
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...tsFiles(full));
+    else if (entry.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+function implementers(): { path: string; text: string }[] {
+  return tsFiles(SRC)
+    .map((path) => ({ path, text: readFileSync(path, 'utf8') }))
+    .filter((f) => /class\s+\w+\s+implements\s+StreamingSource\b/.test(f.text))
+    .map((f) => ({ path: relative(SRC, f.path).split('\\').join('/'), text: f.text }));
+}
+
+describe('every streaming source answers the GPS time question', () => {
+  it('finds the implementations at all, so a silent zero cannot pass', () => {
+    expect(implementers().length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('declares hasGpsTime, unless it is on the shrink-only list', () => {
+    const missing = implementers()
+      .filter((f) => !/\bhasGpsTime\b/.test(f.text))
+      .map((f) => f.path)
+      .sort();
+    expect(
+      missing,
+      'a streaming source that cannot say whether it carries GPS time gets a ' +
+        'default in front of a user; add the answer rather than the file',
+    ).toEqual([...WITHOUT_ANSWER].sort());
+  });
+
+  it('keeps the exemption list shrink-only', () => {
+    expect(
+      WITHOUT_ANSWER.length,
+      'the list grew, which means a new source ships an export field decided ' +
+        'by a default rather than by its own metadata',
+    ).toBeLessThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
The export summary reported `hasGpsTime` as a literal `true` for every
streaming cloud, justified by COPC mandating point format 6, 7 or 8. That
covers COPC alone. An EPT schema need only declare X, Y and Z, a laszip
EPT tile at PDRF 0 or 2 carries no GPS time, and a `pnts` tile has none at
all. The panel claimed a field those sources cannot fill and sized LAS 1.2
records against it.

`StreamingSource` gains an optional `hasGpsTime()`. COPC reads the LAS
header flag, EPT reads the `ept.json` schema, 3D Tiles returns false. A
source that does not implement it resolves to false, so an unestablished
channel is not offered. `src/main.ts` is unchanged in line count. The OLV
tile store sits on a shrink-only exemption list.
