### PR TITLE
fix(heavy): answer the GPS time claim from the tile store schema

### DIFF
--- a/src/io/heavy/OlvTileSource.ts
+++ b/src/io/heavy/OlvTileSource.ts
@@ -289,6 +289,14 @@ export class OlvTileSource implements StreamingSource {
    * two and elevation are always drivable; colour depends on whether the source
    * had any.
    */
+  /**
+   * The build wrote a GPS time field only when its source carried one, so the
+   * manifest schema is the answer rather than a property of the format.
+   */
+  hasGpsTime(): boolean {
+    return this._store.schema.hasGps;
+  }
+
   availableColorModes(): readonly StreamingColorMode[] {
     const out: StreamingColorMode[] = [];
     if (this._store.schema.hasRgb) out.push('rgb');

--- a/tests/olvTileSource.test.ts
+++ b/tests/olvTileSource.test.ts
@@ -317,6 +317,24 @@ describe('OlvTileSource', () => {
     expect(mono.decodeMeta(mono.octree.nodes()[0].record).rgbEightBit).toBeUndefined();
   });
 
+  it('answers the GPS time claim from the stored schema, not from the format', async () => {
+    // The export summary picks a LAS record width from this, so a wrong answer
+    // is a wrong file size in front of a user, not just a missing column.
+    const { reader, tiles } = await buildReader(2000);
+
+    const withGps = new TileStoreReader(
+      { ...reader.manifest, schema: { hasGps: true, hasRgb: reader.schema.hasRgb } },
+      reader.leaves(),
+    );
+    expect(new OlvTileSource({ id: 'a', name: 'b', store: withGps, tiles }).hasGpsTime()).toBe(true);
+
+    const withoutGps = new TileStoreReader(
+      { ...reader.manifest, schema: { hasGps: false, hasRgb: reader.schema.hasRgb } },
+      reader.leaves(),
+    );
+    expect(new OlvTileSource({ id: 'c', name: 'd', store: withoutGps, tiles }).hasGpsTime()).toBe(false);
+  });
+
   it('refuses to claim completeness when the hierarchy has a hole', async () => {
     const { reader, tiles } = await buildReader(5000);
     const full = reader.leaves();

--- a/tests/streamingGpsTimeClaim.test.ts
+++ b/tests/streamingGpsTimeClaim.test.ts
@@ -158,7 +158,7 @@ describe('the shell reads the answer off the source', () => {
  * a source whose export field is decided by a default rather than by its data,
  * so this list may shrink and never grow.
  */
-const WITHOUT_ANSWER = ['io/heavy/OlvTileSource.ts'];
+const WITHOUT_ANSWER: string[] = [];
 
 function tsFiles(dir: string): string[] {
   const out: string[] = [];


### PR DESCRIPTION
`OlvTileSource` was the one streaming source still on the conservative default
introduced with the per-source GPS time claim, so a tile store built from a
GPS-bearing scan was never offered the field. The build writes a GPS time record
only when its source carried one, so `manifest.schema.hasGps` is the answer.

The shrink-only exemption list that held it goes to empty.

Worth noting for the next source: the exemption test asserts only that a source
answers, not that it answers correctly, so a hardcoded `true` survived mutation.
A store built with and without GPS now pins both directions and both mutations
fail. The export summary picks a LAS record width from this value, so a wrong
answer is a wrong file size in front of a user.
