### PR TITLE
feat(streaming): reach the Normal chip and the Normal Map export on a tileset

### DIFF
--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -296,7 +296,47 @@ export async function openRemoteTileset(
       if (deps.debug) console.warn('[workspace] revealAnalysePanel (tileset) threw', err);
     }
 
-    deps.streamingPanel.setColorModes([...cloud.availableColorModes()], cloud.defaultColorMode());
+    // The chip row, and the image-export gate that reads the same answer.
+    //
+    // Published here it is the EMPTY answer: a tileset states colour and
+    // normals per tile, nothing has been read yet, and reading every tile to
+    // find out is the one thing a streaming open must not do. Published once,
+    // that empty answer was the whole session's offer, so a tileset whose tiles
+    // state normals could never show a Normal chip and its Normal Map export
+    // stayed shut. The source folds the answer from the chunks the scheduler
+    // served and signals when the OFFER moves, which happens at most once per
+    // layer, so the row is republished on that signal rather than polled or
+    // redrawn per chunk.
+    //
+    // Registered before the first publish so a chunk that lands in between
+    // still moves the row. `published` is what makes that ordering safe: the
+    // first call through here always establishes this layer's own selection,
+    // and only the calls after it may keep one.
+    let published = false;
+    const publishColorModes = (): void => {
+      deps.streamingPanel.setColorModes(
+        [...cloud.availableColorModes()],
+        cloud.defaultColorMode(),
+        published,
+      );
+      published = true;
+    };
+    cloud.onColorModesChanged(() => {
+      // This notification rides a decode continuation, which can land after a
+      // second scan has replaced this one. A layer that is no longer open must
+      // not repaint the surfaces the layer that replaced it owns.
+      const live = deps.getViewer();
+      if (live.streamingCloud !== cloud) return;
+      try {
+        publishColorModes();
+        // `hasNormals()` answers from the source, so the Normal Map gate moves
+        // with the offer. Read off the LIVE viewer, exactly as the open read it.
+        deps.exportPanel.setImageExportAvailability(live.availableImageExportModes());
+      } catch (err) {
+        if (deps.debug) console.warn('[streaming] colour-mode republish (tileset) threw', err);
+      }
+    });
+    publishColorModes();
     deps.streamingPanel.setQuality(deps.getStreamingQuality());
     deps.streamingPanel.setSourceUrl(url);
     deps.streamingPanel.setPhase('Streaming coarse geometry…');

--- a/src/render/exportAdapter.ts
+++ b/src/render/exportAdapter.ts
@@ -329,11 +329,23 @@ export function buildExportAdapter(host: ExportAdapterHost): ExportSceneAdapter 
       return total > 0 ? assigned / total : null;
     },
     hasNormals(): boolean {
-      // COPC + EPT streaming sources never carry normals in
-      // production (LAS reserves no field for them; EPT writers rarely
-      // emit Normal X/Y/Z attrs). Static loaders (PCD, PTX, GLTF)
-      // sometimes do — check the field explicitly.
-      if (host.streaming()) return false;
+      // Dispatch on the abstract `availableColorModes()` for streaming, exactly
+      // as hasRgb / hasIntensity / hasClassification do.
+      //
+      // This used to answer `false` for every streaming source, on the grounds
+      // that COPC and EPT carry no normals: LAS reserves no field for them and
+      // EPT writers rarely emit Normal X/Y/Z attributes. That is still true of
+      // those two formats, and both still report no `normal` mode, so the gate
+      // stays shut exactly where it was shut before. It is not true of a 3D
+      // Tiles tileset, whose tiles state a NORMAL accessor per tile and whose
+      // source offers `normal` once a tile has stated one — a measurement that
+      // reaches the renderer, the resident snapshot and the profile, and was
+      // then refused an export by a claim about the format rather than about
+      // the data. Static loaders (PCD, PTX, GLTF) still check the field.
+      const streaming = host.streaming();
+      if (streaming) {
+        return streaming.cloud.availableColorModes().includes('normal');
+      }
       for (const { cloud } of visibleEntries()) {
         if (cloud.normals) return true;
       }

--- a/src/render/streaming/TilesetStreamingSource.ts
+++ b/src/render/streaming/TilesetStreamingSource.ts
@@ -171,6 +171,8 @@ export class TilesetStreamingSource implements StreamingSource {
   /** What the tiles served so far have stated about colour and about normals. */
   private _colour: TilesetColourConsensus = NO_TILE_DECODED;
   private _normals: TilesetNormalsConsensus = NO_TILE_DECODED_NORMALS;
+  /** Who wants to be told when the OFFER below moves. See {@link onColorModesChanged}. */
+  private readonly _offerListeners = new Set<() => void>();
 
   constructor(
     id: string,
@@ -255,6 +257,7 @@ export class TilesetStreamingSource implements StreamingSource {
    * settles the answer and it never moves.
    */
   noteDecodedChannels(chunk: DecodedChunk): void {
+    const before = this._offer();
     this._colour = noteTileColour(this._colour, {
       pointCount: chunk.pointCount,
       hasColour: chunk.rgb !== undefined,
@@ -263,6 +266,61 @@ export class TilesetStreamingSource implements StreamingSource {
       pointCount: chunk.pointCount,
       hasNormals: chunk.normals !== undefined,
     });
+    if (this._offer() === before) return;
+    for (const listener of this._offerListeners) {
+      // A listener that throws must not reach the scheduler's decode
+      // continuation: the throw lands in its `.catch`, which records a cleanly
+      // decoded node as failed and backs it off. Who was told is a UI concern;
+      // what the layer answers is not, and it is already folded above.
+      try {
+        listener();
+      } catch {
+        /* the layer's answer is unaffected */
+      }
+    }
+  }
+
+  /**
+   * The two facts {@link availableColorModes} and {@link defaultColorMode} read,
+   * as one integer.
+   *
+   * The consensus carries more than the offer does — a disagreeing count that
+   * moves with every mismatched tile and changes nothing a user can see. Folding
+   * the offer to a scalar is what lets `noteDecodedChannels` fire on the change
+   * a surface would have to redraw for and stay silent on the rest, without
+   * building an array on a path that runs once per decoded chunk.
+   */
+  private _offer(): number {
+    return (
+      (this._colour.settled === 'colour' ? 1 : 0) |
+      (this._normals.settled === 'normals' ? 2 : 0)
+    );
+  }
+
+  /**
+   * Be told when the set of colour modes this layer offers CHANGES.
+   *
+   * A tileset states colour and normals per tile, so its answer is not knowable
+   * at open: it is folded from the chunks the scheduler served, and the first
+   * tile with points settles it. A consumer that read the answer once, at open,
+   * therefore read the empty one and kept it for the session, which is how a
+   * tileset whose tiles state normals never offered a Normal chip.
+   *
+   * A CHANGE signal rather than a per-chunk one, because the answer moves at
+   * most once and then stops: `settled` is fixed by the first tile with points
+   * and never moves after it, so every later chunk would ask a surface to
+   * redraw the row it already has. Nothing polls, and the notification runs on
+   * the decode continuation, so a listener belongs to the surface it updates
+   * and does no work of its own.
+   *
+   * Returns the unsubscribe. The source holds the listener, so one that is
+   * never removed lives exactly as long as the layer does.
+   */
+  onColorModesChanged(listener: () => void): () => void {
+    this._offerListeners.add(listener);
+    return () => {
+      this._offerListeners.delete(listener);
+    };
   }
 
   /**

--- a/src/ui/StreamingPanel.ts
+++ b/src/ui/StreamingPanel.ts
@@ -293,6 +293,8 @@ export class StreamingPanel {
   /** True while a grade is running — flips the grade button into a Cancel control. */
   private _gradeRunning = false;
   private _modeButtons = new Map<ColorMode, HTMLButtonElement>();
+  /** The mode whose chip carries `olv-chip-active`, or null when none does. */
+  private _activeMode: ColorMode | null = null;
   private _paused = false;
 
   constructor(callbacks: StreamingPanelCallbacks) {
@@ -565,8 +567,21 @@ export class StreamingPanel {
     this._summary.replaceChildren(...rows);
   }
 
-  /** Populate the colour-mode chips and select the active one. */
-  setColorModes(modes: ColorMode[], active: ColorMode): void {
+  /**
+   * Populate the colour-mode chips and select one.
+   *
+   * `keepActive` is for a REPUBLISH of the SAME scan's row. A 3D Tiles layer
+   * states its channels per tile, so its offer is the empty one at open and
+   * grows once a tile has been read; republishing it with the layer's default
+   * would throw away whatever the user had selected in between. With the flag
+   * set, a selection that is still offered is kept and `active` is only the
+   * fallback. It defaults to false so a FRESH scan's row still opens on that
+   * scan's own default rather than inheriting the previous scan's mode — the
+   * panel is never hidden on a streaming-to-streaming swap, so the previous
+   * selection is still here to inherit.
+   */
+  setColorModes(modes: ColorMode[], active: ColorMode, keepActive = false): void {
+    const previous = this._activeMode;
     this._modeRow.replaceChildren();
     this._modeButtons = new Map();
     for (const mode of modes) {
@@ -578,7 +593,28 @@ export class StreamingPanel {
       this._modeButtons.set(mode, chip);
       this._modeRow.append(chip);
     }
-    this._selectMode(active);
+    const kept = keepActive && previous !== null && this._modeButtons.has(previous);
+    this._selectMode(kept ? previous : active);
+    // The user's mode is no longer on offer, so the row now says something the
+    // renderer is not doing. Moving the renderer to the mode the row does offer
+    // is the only resolution that leaves one meaning on screen: leaving it
+    // painting under a chip that no longer exists is the silent mismatch this
+    // surface exists to prevent, and nothing here may invent the channel back.
+    if (keepActive && !kept && previous !== null && this._activeMode !== null) {
+      this._callbacks.onColorMode(this._activeMode);
+    }
+  }
+
+  /**
+   * The colour mode the chip row currently shows as active, or null when no
+   * offered chip is selected.
+   *
+   * Null rather than a guess: a row asked to select a mode it does not offer
+   * highlights nothing, and reporting the unoffered mode as active would be the
+   * panel claiming a chip a user cannot see.
+   */
+  activeColorMode(): ColorMode | null {
+    return this._activeMode;
   }
 
   /** Reflect the active quality preset. */
@@ -690,6 +726,9 @@ export class StreamingPanel {
   }
 
   private _selectMode(mode: ColorMode): void {
+    // Recorded from what the row can actually show, not from what was asked
+    // for, so `activeColorMode()` and the highlighted chip cannot disagree.
+    this._activeMode = this._modeButtons.has(mode) ? mode : null;
     for (const [m, chip] of this._modeButtons) {
       chip.classList.toggle('olv-chip-active', m === mode);
     }

--- a/tests/e2e/tilesetOpen.spec.ts
+++ b/tests/e2e/tilesetOpen.spec.ts
@@ -299,6 +299,61 @@ test.describe('3D Tiles — opening a tileset from a URL', () => {
     expect(requested).toEqual([scene.entryUrl]);
   });
 
+  test('offers the Normal chip and the Normal Map export once a tile has stated normals', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    // A tileset states its channels PER TILE, so the chip row and the image
+    // export gate are both published at open, before any tile exists, from an
+    // answer that offers neither colour nor normals. Published once, that empty
+    // answer was the whole session's offer: the tiles here carry a float32
+    // NORMAL accessor that reaches the renderer, and nothing a user could click
+    // ever said so.
+    const scene = boxTileset({ normals: true, colour: 'none' });
+    await serveTilesets(page, scene);
+    await openTilesetUrl(page, scene);
+    await expectAttached(page);
+
+    const chips = page.locator('.olv-streaming-panel .olv-streaming-chips').first();
+    await expect(chips.locator('.olv-chip', { hasText: /^Normal$/ })).toBeVisible({
+      timeout: 40_000,
+    });
+    // The user's mode survives the republish: the row opened on Height, which
+    // is what the layer could serve before a tile had been read, and the chip
+    // that arrives beside it must not steal the selection.
+    await expect(chips.locator('.olv-chip-active')).toHaveText('Height');
+
+    // And the export that reads the same answer. `hasNormals()` returned false
+    // for every streaming source, so this button was dark over a scan whose
+    // tiles carry measured directions.
+    const normalMap = page.locator('.olv-export-btn', { hasText: /^Normal map$/ });
+    await expect(normalMap).toBeEnabled({ timeout: 40_000 });
+  });
+
+  test('offers neither, for a tileset whose tiles state no normals', async ({ page }) => {
+    test.setTimeout(90_000);
+    // The half that matters as much: a chip that resolves to another channel,
+    // or an export that renders a uniform grey image, says the scan holds a
+    // reading it does not.
+    const scene = boxTileset();
+    await serveTilesets(page, scene);
+    await openTilesetUrl(page, scene);
+    await expectAttached(page);
+
+    // Waited on through a surface that DOES move, so this is not asserting an
+    // absence before anything could have appeared: Points only reaches the
+    // total once every tile has been decoded and reported to the source.
+    await expect
+      .poll(async () => (await streamingRow(page, 'Points').textContent()) ?? '', {
+        timeout: 40_000,
+      })
+      .toContain(`${scene.totalPoints} / Unknown`);
+
+    const chips = page.locator('.olv-streaming-panel .olv-streaming-chips').first();
+    await expect(chips.locator('.olv-chip', { hasText: /^Normal$/ })).toHaveCount(0);
+    await expect(page.locator('.olv-export-btn', { hasText: /^Normal map$/ })).toBeDisabled();
+  });
+
   test('tells the user why a tileset whose tiles disagree about colour keeps one meaning', async ({
     page,
   }) => {

--- a/tests/exportAdapter.test.ts
+++ b/tests/exportAdapter.test.ts
@@ -283,6 +283,27 @@ describe('export adapter — streaming capability gates', () => {
     expect(buildExportAdapter(streamingHost(['rgb', 'elevation'])).hasIntensity()).toBe(false);
     expect(buildExportAdapter(streamingHost(['rgb', 'intensity'])).hasIntensity()).toBe(true);
   });
+
+  it('reports normals from the source, not from the format', () => {
+    // `hasNormals` used to answer false for EVERY streaming source, on the
+    // grounds that COPC and EPT carry none. A 3D Tiles tileset states a NORMAL
+    // accessor per tile, so its source offers the `normal` mode once a tile has
+    // stated one — and the Normal Map export was refused on a claim about the
+    // format rather than about the data.
+    expect(buildExportAdapter(streamingHost(['elevation', 'normal'])).hasNormals()).toBe(true);
+  });
+
+  it('keeps the Normal Map gate shut for a source that offers no normals', () => {
+    // The COPC and EPT rows, and a tileset whose tiles state none: all three
+    // report no `normal` mode, so all three stay exactly as shut as before.
+    for (const modes of [
+      ['rgb', 'intensity', 'elevation', 'classification'],
+      ['rgb', 'elevation'],
+      ['elevation'],
+    ]) {
+      expect(buildExportAdapter(streamingHost(modes)).hasNormals()).toBe(false);
+    }
+  });
 });
 
 describe('export adapter — combined bounds', () => {

--- a/tests/fixtures/tileset3d.ts
+++ b/tests/fixtures/tileset3d.ts
@@ -38,6 +38,12 @@ export interface PntsOptions {
   readonly rtc?: Point3;
   /** One `RGB` triple per point, or omitted for a tile that states no colour. */
   readonly rgb?: readonly Rgb[];
+  /**
+   * One float32 `NORMAL` triple per point, or omitted for a tile that states
+   * none. Stated per TILE, exactly as `RGB` is, which is why a tileset's answer
+   * about normals cannot be read off the entry document.
+   */
+  readonly normals?: readonly Point3[];
 }
 
 /**
@@ -50,16 +56,25 @@ export interface PntsOptions {
  */
 export function makePnts(points: readonly Point3[], options: PntsOptions = {}): Uint8Array {
   const positionBytes = points.length * 3 * 4;
+  const rgbBytes = options.rgb ? points.length * 3 : 0;
+  // NORMAL is float32 and must start on a 4-byte boundary inside the binary
+  // section. The RGB block is byte-wide and a multiple of three long, so it can
+  // leave the cursor off a word; this pads it back on.
+  const normalPad = options.normals ? (4 - ((positionBytes + rgbBytes) % 4)) % 4 : 0;
+  const normalBytes = options.normals ? points.length * 3 * 4 : 0;
   const featureTable: Record<string, unknown> = {
     POINTS_LENGTH: points.length,
     POSITION: { byteOffset: 0 },
   };
   if (options.rtc) featureTable.RTC_CENTER = options.rtc;
   if (options.rgb) featureTable.RGB = { byteOffset: positionBytes };
+  if (options.normals) {
+    featureTable.NORMAL = { byteOffset: positionBytes + rgbBytes + normalPad };
+  }
   let json = JSON.stringify(featureTable);
   while (json.length % 8 !== 0) json += ' ';
   const jsonBytes = new TextEncoder().encode(json);
-  const binaryBytes = positionBytes + (options.rgb ? points.length * 3 : 0);
+  const binaryBytes = positionBytes + rgbBytes + normalPad + normalBytes;
   const total = 28 + jsonBytes.length + binaryBytes;
   const buffer = new ArrayBuffer(total);
   const view = new DataView(buffer);
@@ -78,6 +93,11 @@ export function makePnts(points: readonly Point3[], options: PntsOptions = {}): 
     const bytes = new Uint8Array(buffer, binaryStart + positionBytes, points.length * 3);
     let j = 0;
     for (const c of options.rgb) for (const v of c) bytes[j++] = v;
+  }
+  if (options.normals) {
+    const at = binaryStart + positionBytes + rgbBytes + normalPad;
+    let j = 0;
+    for (const n of options.normals) for (const v of n) view.setFloat32(at + j++ * 4, v, true);
   }
   return new Uint8Array(buffer);
 }
@@ -100,6 +120,23 @@ export function gridPoints(side: number, half: number, offset: Point3 = [0, 0, 0
     }
   }
   return points;
+}
+
+/**
+ * One unit normal per point, cycling through the three axes.
+ *
+ * Real directions rather than a constant: the `normal` colour mode encodes
+ * `n` as `(n + 1) / 2`, so a single repeated direction would paint the whole
+ * tile one colour and a chip that resolved to something else would look the
+ * same.
+ */
+export function unitNormals(count: number): Point3[] {
+  const axes: Point3[] = [
+    [0, 0, 1],
+    [1, 0, 0],
+    [0, 1, 0],
+  ];
+  return Array.from({ length: count }, (_, i) => axes[i % 3]);
 }
 
 /** One grey per point, so a tile "carries colour" without carrying meaning. */
@@ -147,6 +184,12 @@ export interface BoxTilesetOptions {
   readonly assetVersion?: string;
   /** Whether the tiles carry `RGB`. */
   readonly colour?: SceneColour;
+  /**
+   * Whether every tile carries a float32 `NORMAL` accessor. Off by default,
+   * because a tileset that states no normals is the common case and the one
+   * that must keep offering no Normal chip and no Normal Map.
+   */
+  readonly normals?: boolean;
   /** Directory the dataset is served from, so two scenes can coexist on one page. */
   readonly path?: string;
   /**
@@ -206,8 +249,12 @@ export function boxTileset(options: BoxTilesetOptions = {}): TilesetScene {
   // `mixed` is the case the colour consensus exists for: the root states RGB
   // and the children state none, so whichever tile decodes first settles the
   // layer's one colour meaning and the other disagrees with it.
+  const withNormals = options.normals === true;
   const withColour = (points: readonly Point3[], carries: boolean): Uint8Array =>
-    makePnts(points, carries ? { rgb: flatRgb(points.length) } : {});
+    makePnts(points, {
+      ...(carries ? { rgb: flatRgb(points.length) } : {}),
+      ...(withNormals ? { normals: unitNormals(points.length) } : {}),
+    });
   const rootCarries = colour !== 'none';
   const childCarries = colour === 'all';
 

--- a/tests/streamingPanelColorModes.test.ts
+++ b/tests/streamingPanelColorModes.test.ts
@@ -1,0 +1,190 @@
+/**
+ * streamingPanelColorModes.test.ts — the chip row across a republish.
+ *
+ * A 3D Tiles layer cannot state its channels at open: they are per tile, so the
+ * row is published from the empty answer and republished once a tile has been
+ * read. That republish carries the layer's DEFAULT mode, which would silently
+ * throw away whatever the user had selected in between — a scan repainting
+ * itself because a tile finished downloading.
+ *
+ * These cases pin the panel's side of it: what the row reports as active, what
+ * survives a republish, and what happens when the user's mode is no longer on
+ * offer. The DOM stub records listeners and dispatches clicks, so the selection
+ * under test is the one a user makes rather than one the caller passes in.
+ */
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import type { ColorMode } from '../src/render/colorModes';
+
+class FakeEl {
+  className = '';
+  title = '';
+  type = '';
+  disabled = false;
+  private _text = '';
+  readonly children: FakeEl[] = [];
+  readonly dataset: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  private readonly _listeners: (() => void)[] = [];
+  readonly classList = {
+    _set: new Set<string>(),
+    add(c: string): void { this._set.add(c); },
+    remove(c: string): void { this._set.delete(c); },
+    toggle(c: string, on?: boolean): void {
+      const want = on ?? !this._set.has(c);
+      if (want) this._set.add(c); else this._set.delete(c);
+    },
+    contains(c: string): boolean { return this._set.has(c); },
+  };
+  readonly tagName: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+  setAttribute(): void { /* no-op */ }
+  removeAttribute(): void { /* no-op */ }
+  set textContent(v: string) { this._text = v; }
+  get textContent(): string {
+    return [this._text, ...this.children.map((c) => c.textContent)].filter(Boolean).join(' ');
+  }
+  get ownText(): string { return this._text; }
+  append(...kids: FakeEl[]): void { this.children.push(...kids.filter(Boolean)); }
+  replaceChildren(...kids: FakeEl[]): void {
+    this.children.length = 0;
+    this.children.push(...kids.filter(Boolean));
+  }
+  addEventListener(_type: string, handler: () => void): void { this._listeners.push(handler); }
+  blur(): void { /* no-op */ }
+  click(): void { for (const h of this._listeners) h(); }
+  /** Every descendant carrying the chip class, in row order. */
+  chips(): FakeEl[] {
+    const out: FakeEl[] = [];
+    if (this.className.split(' ').includes('olv-chip')) out.push(this);
+    for (const c of this.children) out.push(...c.chips());
+    return out;
+  }
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { document: unknown }).document = {
+    createElement: (tag: string) => new FakeEl(tag),
+  };
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.HTMLInputElement ??= class {};
+  g.HTMLAnchorElement ??= class {};
+});
+
+function callbacks() {
+  return {
+    onColorMode: vi.fn(),
+    onQuality: vi.fn(),
+    onPauseToggle: vi.fn(),
+    onClearCache: vi.fn(),
+    onGradeFullCloud: vi.fn(),
+    onCancelGrade: vi.fn(),
+  };
+}
+
+async function panelWith(cb: ReturnType<typeof callbacks>) {
+  const { StreamingPanel } = await import('../src/ui/StreamingPanel');
+  const panel = new StreamingPanel(cb);
+  const root = panel.element as unknown as FakeEl;
+  /** The colour chips only — the quality row's chips carry the same class. */
+  const modeChip = (label: string): FakeEl => {
+    const hit = root.chips().find((c) => c.ownText === label);
+    if (!hit) throw new Error(`no chip labelled ${label}`);
+    return hit;
+  };
+  const highlighted = (): string[] =>
+    root.chips().filter((c) => c.classList.contains('olv-chip-active')).map((c) => c.ownText);
+  return { panel, modeChip, highlighted };
+}
+
+const ELEVATION_ONLY: ColorMode[] = ['elevation'];
+const WITH_NORMALS: ColorMode[] = ['elevation', 'normal'];
+const WITH_COLOUR: ColorMode[] = ['rgb', 'elevation'];
+
+describe('what the chip row reports as active', () => {
+  it('names the mode the row opened on', async () => {
+    const { panel } = await panelWith(callbacks());
+    panel.setColorModes(WITH_COLOUR, 'rgb');
+    expect(panel.activeColorMode()).toBe('rgb');
+  });
+
+  it('follows the user’s click', async () => {
+    const cb = callbacks();
+    const { panel, modeChip } = await panelWith(cb);
+    panel.setColorModes(WITH_COLOUR, 'rgb');
+    modeChip('Height').click();
+    expect(panel.activeColorMode()).toBe('elevation');
+    expect(cb.onColorMode).toHaveBeenCalledWith('elevation');
+  });
+
+  it('reports null when the selected mode is not one the row offers', async () => {
+    const { panel } = await panelWith(callbacks());
+    panel.setColorModes(ELEVATION_ONLY, 'normal');
+    expect(
+      panel.activeColorMode(),
+      'no chip is highlighted, so naming one would claim a control the user cannot see',
+    ).toBeNull();
+  });
+});
+
+describe('a republish of the same scan’s row', () => {
+  it('keeps the mode the user selected', async () => {
+    const cb = callbacks();
+    const { panel, modeChip, highlighted } = await panelWith(cb);
+    panel.setColorModes(WITH_COLOUR, 'rgb');
+    modeChip('Height').click();
+    cb.onColorMode.mockClear();
+
+    // The layer's answer moved: a tile stated normals. The row grows, and the
+    // default it would open on is Color.
+    panel.setColorModes(['rgb', 'elevation', 'normal'], 'rgb', true);
+
+    expect(
+      panel.activeColorMode(),
+      'a tile finishing its download must not repaint the scan the user was reading',
+    ).toBe('elevation');
+    expect(highlighted()).toEqual(['Height']);
+    expect(cb.onColorMode, 'nothing changed, so the renderer is not told to').not.toHaveBeenCalled();
+  });
+
+  it('adds the new chip without selecting it', async () => {
+    const { panel, highlighted } = await panelWith(callbacks());
+    panel.setColorModes(ELEVATION_ONLY, 'elevation');
+    panel.setColorModes(WITH_NORMALS, 'elevation', true);
+    expect(highlighted()).toEqual(['Height']);
+    expect(panel.activeColorMode()).toBe('elevation');
+  });
+
+  it('falls back to the layer default, and moves the renderer, when the mode is withdrawn', async () => {
+    const cb = callbacks();
+    const { panel, modeChip } = await panelWith(cb);
+    panel.setColorModes(['rgb', 'elevation', 'normal'], 'rgb');
+    modeChip('Normal').click();
+    cb.onColorMode.mockClear();
+
+    panel.setColorModes(WITH_COLOUR, 'rgb', true);
+
+    expect(
+      panel.activeColorMode(),
+      'a chip for a mode the layer cannot serve is the defect this row exists to prevent',
+    ).toBe('rgb');
+    expect(
+      cb.onColorMode,
+      'the row and the scene must not end up showing two different meanings',
+    ).toHaveBeenCalledWith('rgb');
+  });
+});
+
+describe('a fresh scan’s row', () => {
+  it('opens on its own default rather than inheriting the previous scan’s mode', async () => {
+    const { panel, modeChip } = await panelWith(callbacks());
+    panel.setColorModes(WITH_COLOUR, 'rgb');
+    modeChip('Height').click();
+
+    // A second scan replaces the first. The panel is never hidden on a
+    // streaming-to-streaming swap, so the previous selection is still here.
+    panel.setColorModes(WITH_COLOUR, 'rgb');
+
+    expect(panel.activeColorMode()).toBe('rgb');
+  });
+});

--- a/tests/tilesetStreamingModeWiring.test.ts
+++ b/tests/tilesetStreamingModeWiring.test.ts
@@ -1,0 +1,300 @@
+/**
+ * tilesetStreamingModeWiring.test.ts — the two call sites between a tileset's
+ * answer about its channels and the surfaces that act on it.
+ *
+ * `TilesetStreamingSource` folds that answer from the chunks the scheduler
+ * actually served: nothing is offered before a tile has been read, and the
+ * answer settles on the first tile with points. Both consumers read it once and
+ * never again.
+ *
+ * The open published the chip row BEFORE any tile existed, so the row was
+ * always the empty answer and a tileset whose tiles state normals could never
+ * show a Normal chip. The export adapter answered `hasNormals()` from the
+ * FORMAT — false for every streaming source — so the Normal Map export was shut
+ * for a tileset that carries measured directions.
+ *
+ * Both directions are pinned here. A tileset that states normals must offer
+ * both; a tileset that states none must offer neither, which matters exactly as
+ * much: an offered chip that resolves to another channel is the defect this
+ * area exists to prevent.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { openRemoteTileset } from '../src/app/openTilesetLayer';
+import { PntsChunkDecoder, type PntsDecodeMetadata } from '../src/io/tiles3d/pntsDecode';
+import { buildExportAdapter, type ExportAdapterHost } from '../src/render/exportAdapter';
+import { imageExportModeAvailability } from '../src/render/exportModeAvailability';
+import type { TilesetStreamingSource } from '../src/render/streaming/TilesetStreamingSource';
+import type { DecodedChunk } from '../src/io/copc/copcChunkDecode';
+import { gridPoints, makePnts, unitNormals } from './fixtures/tileset3d';
+
+const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
+const DOC = JSON.stringify({
+  asset: { version: '1.0' },
+  geometricError: 100,
+  root: { boundingVolume: BOX, geometricError: 50, refine: 'ADD', content: { uri: 'r.pnts' } },
+});
+
+const META: PntsDecodeMetadata = {
+  format: 'pnts',
+  tileTransform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+  renderOrigin: [0, 0, 0],
+};
+
+const POINTS = gridPoints(3, 5);
+
+/** One decoded tile body, with or without a stated NORMAL accessor. */
+async function tile(normals: boolean): Promise<DecodedChunk> {
+  const body = makePnts(POINTS, normals ? { normals: unitNormals(POINTS.length) } : {});
+  return new PntsChunkDecoder().decode(body.buffer as ArrayBuffer, META);
+}
+
+/**
+ * The shell collaborators the open writes into, recording every publish.
+ *
+ * `streamingCloud` is a real getter over the attached source rather than a
+ * fixed value: the republish must refuse to repaint the panel for a layer that
+ * is no longer the open one, and a mock that always agreed could not show it.
+ */
+function harness() {
+  const setColorModes = vi.fn();
+  const setImageExportAvailability = vi.fn();
+  let attached: TilesetStreamingSource | null = null;
+  const viewer = {
+    clouds: () => [],
+    attachStreamingCloud: vi.fn(async (cloud: TilesetStreamingSource) => {
+      attached = cloud;
+    }),
+    setMode: vi.fn(),
+    frameAll: vi.fn(),
+    get streamingCloud() {
+      return attached;
+    },
+    // The live per-mode map, built from the adapter the same way the real
+    // viewer builds it, so the Normal Map gate here is the one a user meets.
+    availableImageExportModes: vi.fn(() =>
+      imageExportModeAvailability({
+        hasAabb: true,
+        zRange: 10,
+        hasIntensity: false,
+        hasClassification: false,
+        hasNormals: adapter().hasNormals(),
+      }),
+    ),
+  };
+  const adapter = (): ReturnType<typeof buildExportAdapter> =>
+    buildExportAdapter({
+      clouds: () => new Map(),
+      streaming: () =>
+        attached === null
+          ? null
+          : ({ cloud: attached } as unknown as ReturnType<ExportAdapterHost['streaming']>),
+      setColorMode: vi.fn(),
+      setStreamingColorMode: vi.fn(),
+      setVisible: vi.fn(),
+      snapshot: vi.fn(async () => new Blob()),
+      renderFramedTopDown: vi.fn(async () => null),
+      renderFigure: vi.fn(async () => null),
+      figureViewContext: vi.fn(),
+    } as unknown as ExportAdapterHost);
+
+  return {
+    setColorModes,
+    setImageExportAvailability,
+    adapter,
+    cloud: (): TilesetStreamingSource => {
+      if (attached === null) throw new Error('nothing was attached');
+      return attached;
+    },
+    d: {
+      setLastStreamingReportCloud: vi.fn(),
+      runStreamingModules: () => [],
+      inspector: { setReport: vi.fn(), setStreamingMode: vi.fn() },
+      classLegendPanel: {
+        getVisibility: () => ({ isFiltered: () => false }),
+        setClasses: vi.fn(),
+        hide: vi.fn(),
+      },
+      inspectorCards: {
+        refreshProvenanceFromStreaming: vi.fn(),
+        refreshDatasetIntelligenceFromStreamingCloud: vi.fn(),
+      },
+      exportPanel: {
+        setImageExportEnabled: vi.fn(),
+        setImageExportAvailability,
+        setStreamingMode: vi.fn(),
+      },
+      bookmarks: { clear: vi.fn() },
+      revealAnalysePanel: vi.fn(),
+      prewarmExportStudio: vi.fn(),
+      refreshViewsUI: vi.fn(),
+      hideReclassifyUi: vi.fn(),
+      syncInspectClassScope: vi.fn(),
+      isLoading: () => false,
+      setLoading: vi.fn(),
+      viewerReady: Promise.resolve(),
+      getViewer: () => viewer,
+      getStreamingQuality: () => 'balanced',
+      getStreamingBenchmark: () => null,
+      isPhone: () => false,
+      showToast: vi.fn(),
+      debug: false,
+      closeStreaming: vi.fn(),
+      clearOpenStaticLayers: vi.fn(),
+      startStreamingStatusPolling: vi.fn(),
+      revealStreamingChrome: vi.fn(),
+      stage: { hideEmptyState: vi.fn() },
+      crsCoordinator: { refreshCrsForStreamingCloud: vi.fn() },
+      streamingPanel: {
+        setColorModes,
+        setQuality: vi.fn(),
+        setSourceUrl: vi.fn(),
+        setPhase: vi.fn(),
+        setSummary: vi.fn(),
+        show: vi.fn(),
+      },
+      dropZone: {
+        setOpening: vi.fn(),
+        setCancelHandler: vi.fn(),
+        setProgress: vi.fn(),
+        setError: vi.fn(),
+      },
+    },
+  };
+}
+
+/** Serve the entry document without touching the network. */
+async function open(t: ReturnType<typeof harness>): Promise<void> {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: unknown) =>
+    String(input).endsWith('tileset.json')
+      ? new Response(DOC, { status: 200, headers: { 'content-type': 'application/json' } })
+      : new Response(new ArrayBuffer(0), { status: 404 })) as unknown as typeof fetch;
+  try {
+    await openRemoteTileset('https://host/d/tileset.json', undefined, t.d as never);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}
+
+/** Every colour-mode row the panel was given, in publish order. */
+function rows(t: ReturnType<typeof harness>): string[][] {
+  return t.setColorModes.mock.calls.map((call) => [...(call[0] as string[])]);
+}
+
+describe('the colour-mode row a tileset publishes', () => {
+  it('offers nothing but height before a tile has been read', async () => {
+    const t = harness();
+    await open(t);
+    expect(
+      rows(t),
+      'a mode published before any tile is a promise about tiles nobody has seen',
+    ).toEqual([['elevation']]);
+  });
+
+  it('republishes with the Normal chip once a tile has stated normals', async () => {
+    const t = harness();
+    await open(t);
+    t.cloud().noteDecodedChannels(await tile(true));
+    expect(
+      rows(t).at(-1),
+      'the row was published once at open, from the empty answer, so a tileset ' +
+        'whose tiles state normals could never show the Normal chip',
+    ).toContain('normal');
+  });
+
+  it('republishes exactly once, not on every chunk the scheduler serves', async () => {
+    const t = harness();
+    await open(t);
+    for (let i = 0; i < 4; i++) t.cloud().noteDecodedChannels(await tile(true));
+    expect(t.setColorModes).toHaveBeenCalledTimes(2);
+  });
+
+  it('never offers the Normal chip for a tileset whose tiles state none', async () => {
+    const t = harness();
+    await open(t);
+    for (let i = 0; i < 3; i++) t.cloud().noteDecodedChannels(await tile(false));
+    for (const row of rows(t)) expect(row).not.toContain('normal');
+  });
+
+  it('leaves the row alone when the answer settles without moving the offer', async () => {
+    const t = harness();
+    await open(t);
+    t.cloud().noteDecodedChannels(await tile(false));
+    expect(
+      t.setColorModes,
+      'a tile that states neither colour nor normals changes nothing a user can see',
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes a fresh scan’s row without keeping the previous scan’s selection', async () => {
+    const t = harness();
+    await open(t);
+    await open(t);
+    // The panel is never hidden on a streaming-to-streaming swap, so the
+    // previous scan's selection is still there to inherit. Only a republish of
+    // the SAME layer's row may keep one.
+    for (const call of t.setColorModes.mock.calls) expect(call[2]).toBeFalsy();
+  });
+
+  it('refuses to repaint the row for a layer that is no longer open', async () => {
+    const t = harness();
+    await open(t);
+    const stale = t.cloud();
+    const before = t.setColorModes.mock.calls.length;
+    // A second scan takes the viewer. The decode continuation that carries this
+    // notification can land after that swap.
+    await open(t);
+    stale.noteDecodedChannels(await tile(true));
+    expect(rows(t).slice(before).every((row) => !row.includes('normal'))).toBe(true);
+  });
+});
+
+describe('the Normal Map export gate', () => {
+  it('opens for a tileset whose tiles state normals', async () => {
+    const t = harness();
+    await open(t);
+    expect(t.adapter().hasNormals(), 'nothing has been read yet').toBe(false);
+    t.cloud().noteDecodedChannels(await tile(true));
+    expect(
+      t.adapter().hasNormals(),
+      'hasNormals answered from the format, so every streaming source was false',
+    ).toBe(true);
+    expect(imageExportModeAvailability({
+      hasAabb: true,
+      zRange: 10,
+      hasIntensity: false,
+      hasClassification: false,
+      hasNormals: t.adapter().hasNormals(),
+    }).get('normal')?.available).toBe(true);
+  });
+
+  it('stays shut for a tileset whose tiles state none', async () => {
+    const t = harness();
+    await open(t);
+    for (let i = 0; i < 3; i++) t.cloud().noteDecodedChannels(await tile(false));
+    expect(t.adapter().hasNormals()).toBe(false);
+    expect(imageExportModeAvailability({
+      hasAabb: true,
+      zRange: 10,
+      hasIntensity: false,
+      hasClassification: false,
+      hasNormals: t.adapter().hasNormals(),
+    }).get('normal')?.available).toBe(false);
+  });
+
+  it('is republished off the live viewer when the answer moves', async () => {
+    const t = harness();
+    await open(t);
+    const before = t.setImageExportAvailability.mock.calls.length;
+    t.cloud().noteDecodedChannels(await tile(true));
+    const published = t.setImageExportAvailability.mock.calls.at(-1)?.[0] as
+      | Map<string, { available: boolean }>
+      | undefined;
+    expect(
+      t.setImageExportAvailability.mock.calls.length,
+      'the map was read once at open, when no tile had stated anything',
+    ).toBeGreaterThan(before);
+    expect(published?.get('normal')?.available).toBe(true);
+  });
+});

--- a/tests/tilesetStreamingNormals.test.ts
+++ b/tests/tilesetStreamingNormals.test.ts
@@ -320,6 +320,78 @@ describe('the colour modes a tileset layer offers', () => {
   });
 });
 
+describe('the signal a layer raises when its offer moves', () => {
+  it('fires once, when the first tile with points settles the answer', async () => {
+    const s = source();
+    const fired: string[][] = [];
+    s.onColorModesChanged(() => fired.push([...s.availableColorModes()]));
+    await serve(s, new PntsChunkDecoder(), [
+      makePnts(LOW_AND_HIGH, { rgb: STATED_RGB, normals: STATED_NORMALS }),
+      makePnts(LOW_AND_HIGH, { rgb: STATED_RGB, normals: STATED_NORMALS }),
+      makePnts(LOW_AND_HIGH, { rgb: STATED_RGB, normals: STATED_NORMALS }),
+    ]);
+    expect(
+      fired,
+      'the answer settles on the first tile with points and never moves, so every ' +
+        'later chunk would ask a surface to redraw the row it already has',
+    ).toEqual([['rgb', 'elevation', 'normal']]);
+  });
+
+  it('stays silent when the answer settles without moving what is offered', async () => {
+    const s = source();
+    const fired: number[] = [];
+    s.onColorModesChanged(() => fired.push(1));
+    await serve(s, new PntsChunkDecoder(), [makePnts(LOW_AND_HIGH), makePnts(LOW_AND_HIGH)]);
+    expect(s.availableColorModes()).toEqual(['elevation']);
+    expect(fired, 'nothing a user can see changed').toEqual([]);
+  });
+
+  it('stays silent for a chunk with no points, which settles nothing', () => {
+    const s = source();
+    const fired: number[] = [];
+    s.onColorModesChanged(() => fired.push(1));
+    // Built rather than decoded: `parsePnts` refuses a zero POINTS_LENGTH, so
+    // an empty chunk can only reach the fold from somewhere other than a tile
+    // body. The fold ignores it either way, and the signal must too.
+    s.noteDecodedChannels({
+      pointCount: 0,
+      positions: new Float32Array(0),
+      normals: new Float32Array(0),
+    });
+    expect(fired).toEqual([]);
+    expect(s.availableColorModes()).toEqual(['elevation']);
+  });
+
+  it('stops telling a listener that unsubscribed', async () => {
+    const s = source();
+    const fired: number[] = [];
+    const off = s.onColorModesChanged(() => fired.push(1));
+    off();
+    await serve(s, new PntsChunkDecoder(), [
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+    ]);
+    expect(fired).toEqual([]);
+  });
+
+  it('folds the answer even when a listener throws', async () => {
+    const s = source();
+    const seen: string[] = [];
+    s.onColorModesChanged(() => {
+      throw new Error('a panel blew up');
+    });
+    s.onColorModesChanged(() => seen.push('second'));
+    await serve(s, new PntsChunkDecoder(), [
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+    ]);
+    expect(
+      s.availableColorModes(),
+      'the notification rides the scheduler’s decode continuation: a throw there ' +
+        'records a cleanly decoded node as failed and backs it off',
+    ).toContain('normal');
+    expect(seen).toEqual(['second']);
+  });
+});
+
 describe('a tileset that mixes tiles with and without normals', () => {
   it('keeps the stated normals and draws the tiles without them flat', async () => {
     const decoder = new PntsChunkDecoder();


### PR DESCRIPTION
Point-tile normals cross the streaming chunk boundary already. Two call sites
kept them out of reach.

A tileset states colour and normals per tile, so `TilesetStreamingSource` folds
the answer from the chunks the scheduler served and settles it on the first tile
with points. The open read that answer once, before any tile existed, so the
chip row was the empty offer for the whole session. The source now raises a
change signal when the offered set moves, at most once per layer, and the open
republishes the row and the image-export map on it. `StreamingPanel` gains
`activeColorMode()` and keeps a still-offered selection across a republish.

`exportAdapter.hasNormals()` answered false for every streaming source. It now
reads `availableColorModes()`. COPC and EPT offer no normal mode, so both stay
shut.
