### PR TITLE
feat(3d-tiles): read implicit tiling subtrees and expand them explicitly

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -187,6 +187,27 @@
       "review": "2027-02-28"
     },
     {
+      "path": "src/io/tiles3d/implicitExpand.ts",
+      "status": "staged",
+      "why": "The resource half of 3D Tiles 1.1 implicit tiling: it fetches the .subtree availability files a document names and rewrites the tree into the explicit document parseTileset already reads. The application's only tileset entry, src/app/openTilesetLayer.ts, still calls parseTileset on the fetched body directly, so nothing in the running viewer passes through this. parseTileset therefore still refuses an unexpanded implicit document, and docs/supported-formats.md still states that implicit tiling does not open.",
+      "graduation": "src/app/openTilesetLayer.ts parses the fetched body, passes it through expandImplicitTileset with the transport's fetchSubtreeBytes and the open's abort signal, and hands the result to parseTileset.",
+      "review": "2027-02-28"
+    },
+    {
+      "path": "src/io/tiles3d/implicitTiling.ts",
+      "status": "staged",
+      "why": "The pure half of the same feature: the implicitTiling descriptor and the {level}/{x}/{y}/{z} template substitution. Its only non-test importer is implicitExpand.ts, which is itself unreachable, so the pair is off the production graph together.",
+      "graduation": "implicitExpand.ts graduates; this arrives with it.",
+      "review": "2027-02-28"
+    },
+    {
+      "path": "src/io/tiles3d/subtree.ts",
+      "status": "staged",
+      "why": "The .subtree binary reader under the same feature: the 24-byte container, the JSON and binary chunks, and the three availability bitstreams. Imported only by implicitExpand.ts, which the application does not reach.",
+      "graduation": "implicitExpand.ts graduates; this arrives with it.",
+      "review": "2027-02-28"
+    },
+    {
       "path": "src/process/ProductExecutorRegistry.ts",
       "status": "staged",
       "why": "Named in the v0.6.6 release notes: \"a product executor registry foundation that invokes a registered compute core through ProcessService.runIfAuthorized ... production product routes do not pass through it yet\".",

--- a/src/io/tiles3d/implicitExpand.ts
+++ b/src/io/tiles3d/implicitExpand.ts
@@ -1,0 +1,488 @@
+/**
+ * implicitExpand.ts — turn an implicitly tiled `tileset.json` into the explicit
+ * document the rest of this reader already understands.
+ *
+ * WHY REWRITE THE DOCUMENT RATHER THAN TEACH THE PARSER. `parseTileset` is
+ * synchronous and pure, and it is where every structural refusal in this format
+ * lives: the bounding-volume forms, the finite geometric error, the refine
+ * vocabulary, the depth and tile-count ceilings, the multi-content refusal. An
+ * implicit tree needs the network to know which of its tiles exist, so it
+ * cannot be resolved inside that function. Expanding to an equivalent explicit
+ * document instead means every tile this module invents is then checked by the
+ * same parser that checks an authored one, and `tilesetNodes` and the scheduler
+ * downstream cannot tell the two apart. Nothing here relaxes a refusal; the
+ * output goes through all of them.
+ *
+ * WHAT IS FETCHED, AND THROUGH WHAT. Subtree files and the external
+ * availability buffers they name. Both go through `resolveTilesetContentUrl`,
+ * the same gate a tile's `content.uri` passes: http/https only, no embedded
+ * credentials, the tileset's own origin, no path escaping the tileset's own
+ * directory, and a length cap. A subtree URI is authored by the same untrusted
+ * document a content URI is, and it is fetched EARLIER, so a separate fetch
+ * path here would be a hole in front of the one guard the format has. The bytes
+ * come back through the caller's `fetchSubtreeBytes`, which is the transport's
+ * bounded read with its per-attempt deadline and refused redirects.
+ *
+ * WHAT IS REFUSED BY NAME, rather than half-served:
+ *
+ *   a sphere bounding volume        no exact implicit subdivision exists
+ *   an implicit tile with children  the rule and the list state two hierarchies
+ *   an implicit tile with no content template   the tree would name no data
+ *   a child subtree whose root tile is unavailable   the two disagree
+ *   every ceiling below
+ *
+ * WHAT IS IGNORED, stated because silence is the failure mode this file is
+ * written against: `tileMetadata`, `contentMetadata`, `subtreeMetadata` and
+ * `propertyTables` in a subtree carry semantics about tiles, not tiles, so
+ * dropping them changes what a reader could say about the scene and not which
+ * tiles are in it. Nothing else in a subtree document is skipped.
+ */
+
+import {
+  childCoordinates,
+  geometricErrorForLevel,
+  isAvailable,
+  subdivideBoundingVolume,
+  tileIdFor,
+  tileIndexWithinSubtree,
+  type SubdivisionScheme,
+  type TileCoordinate,
+} from './implicitCoordinates';
+import { parseImplicitTiling, substituteTemplateUri, type ImplicitTiling } from './implicitTiling';
+import {
+  readSubtreeDocument,
+  resolveSubtreeAvailability,
+  subtreeExternalBuffers,
+  subtreeTileCount,
+  type SubtreeAvailability,
+} from './subtree';
+import { MAX_SUBTREE_BYTES } from './tilesetTransport';
+import { resolveTilesetContentUrl, tilesetBaseUrl, tilesetUrlSearch } from './tilesetUrl';
+import { DEFAULT_TILESET_MAX_DEPTH, type BoundingVolume } from './tileset';
+
+/**
+ * Ceilings, and the shape of document each one is here for.
+ *
+ * An implicit tileset is the one place in this format where a very small
+ * document describes an unbounded amount of work. Three hundred bytes of JSON
+ * plus one subtree file can name an eight-level octree, and each subtree it
+ * names can name more. So the count of subtree DOCUMENTS is bounded (that is
+ * the fetch fan-out), the count of expanded TILES is bounded (that is the
+ * allocation), and the bytes of one subtree BODY are bounded (that is the
+ * single read). All three refuse. None truncates, for the reason the explicit
+ * ceilings give: a hierarchy silently pruned mid-expansion renders as a
+ * plausible scene with geometry quietly missing.
+ */
+export const MAX_IMPLICIT_SUBTREES = 512;
+export const MAX_IMPLICIT_TILES = 100_000;
+
+/** What {@link expandImplicitTileset} needs to resolve an implicit document. */
+export interface ExpandImplicitOptions {
+  /** The entry `tileset.json` URL, which every derived URL is resolved against. */
+  readonly entryUrl: string;
+  /**
+   * Read one `.subtree` body or one external availability buffer.
+   *
+   * This is `TilesetTransport.fetchSubtreeBytes`. It is injected rather than
+   * constructed so this module fetches nothing on its own and a test can drive
+   * every path with no network.
+   */
+  readonly fetchSubtreeBytes: (url: string, signal?: AbortSignal) => Promise<ArrayBuffer>;
+  readonly signal?: AbortSignal;
+  /** Override {@link MAX_IMPLICIT_SUBTREES}. */
+  readonly maxSubtrees?: number;
+  /** Override {@link MAX_IMPLICIT_TILES}. */
+  readonly maxTiles?: number;
+  /** Override the per-body byte ceiling. Defaults to the transport's. */
+  readonly maxSubtreeBytes?: number;
+}
+
+/** The raw tile shape this module reads and writes. Deliberately loose. */
+interface RawTile {
+  boundingVolume?: Record<string, unknown>;
+  geometricError?: number;
+  refine?: unknown;
+  transform?: unknown;
+  content?: { uri?: unknown; url?: unknown };
+  contents?: unknown;
+  children?: unknown;
+  implicitTiling?: unknown;
+  [key: string]: unknown;
+}
+
+/** The subtree covering a tile, and the coordinate of that subtree's own root. */
+interface SubtreeContext {
+  readonly root: TileCoordinate;
+  readonly availability: SubtreeAvailability;
+}
+
+/** The mutable budget threaded through one expansion. */
+interface ExpandBudget {
+  readonly maxSubtrees: number;
+  readonly maxTiles: number;
+  subtrees: number;
+  tiles: number;
+}
+
+/** The level-0 coordinate of an implicit tree, per scheme. */
+function rootCoordinate(scheme: SubdivisionScheme): TileCoordinate {
+  return scheme === 'QUADTREE' ? { level: 0, x: 0, y: 0 } : { level: 0, x: 0, y: 0, z: 0 };
+}
+
+/**
+ * The bounding volume an implicit tile may be subdivided from.
+ *
+ * `subdivideBoundingVolume` returns null for a sphere because an eighth of a
+ * sphere is not a sphere, and a bounding volume that is merely close is no
+ * longer a bound. Refusing here names the reason once, rather than producing a
+ * null volume per tile that the parser would then report as a missing
+ * boundingVolume.
+ */
+function implicitRootVolume(raw: Record<string, unknown> | undefined): BoundingVolume {
+  if (!raw) throw new Error('3D Tiles: an implicitly tiled tile has no boundingVolume.');
+  if (raw.sphere !== undefined) {
+    throw new Error(
+      '3D Tiles: an implicitly tiled tile declares a sphere bounding volume, which has no ' +
+        'exact subdivision; this reader expands box and region volumes only.',
+    );
+  }
+  const finite = (v: unknown, want: number): boolean =>
+    Array.isArray(v) && v.length === want && v.every((n) => typeof n === 'number' && Number.isFinite(n));
+  if (finite(raw.box, 12)) return { box: raw.box as number[] };
+  if (finite(raw.region, 6)) return { region: raw.region as number[] };
+  throw new Error(
+    '3D Tiles: an implicitly tiled tile has no box of 12 finite components or region of 6.',
+  );
+}
+
+/** The authored `content.uri`, which on an implicit tile is a template. */
+function contentTemplate(tile: RawTile): string {
+  const raw = tile.content?.uri ?? tile.content?.url;
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new Error(
+      '3D Tiles: an implicitly tiled tile names no content template, so its rule describes a ' +
+        'hierarchy with no data in it.',
+    );
+  }
+  return raw;
+}
+
+/** One expansion, holding the URLs and the budget every subtree fetch shares. */
+class ImplicitExpansion {
+  private readonly base: string;
+  private readonly search: string;
+  private readonly maxSubtreeBytes: number;
+  private readonly loaded = new Map<string, SubtreeAvailability>();
+  private readonly options: ExpandImplicitOptions;
+  private readonly budget: ExpandBudget;
+
+  constructor(options: ExpandImplicitOptions, budget: ExpandBudget) {
+    this.options = options;
+    this.budget = budget;
+    this.base = tilesetBaseUrl(options.entryUrl);
+    this.search = tilesetUrlSearch(options.entryUrl);
+    this.maxSubtreeBytes = options.maxSubtreeBytes ?? MAX_SUBTREE_BYTES;
+  }
+
+  /** Resolve one authored URI through the gate every content URI passes. */
+  private resolve(uri: string, what: string): string {
+    const check = resolveTilesetContentUrl(this.base, uri, this.search);
+    if (!check.ok) throw new Error(`3D Tiles: ${what} refused: ${check.reason}`);
+    return check.url;
+  }
+
+  private throwIfAborted(): void {
+    const signal = this.options.signal;
+    if (signal?.aborted) {
+      throw (signal.reason ?? new DOMException('3D Tiles implicit expansion aborted', 'AbortError'));
+    }
+  }
+
+  private async read(url: string, what: string): Promise<Uint8Array> {
+    this.throwIfAborted();
+    const bytes = await this.options.fetchSubtreeBytes(url, this.options.signal);
+    if (bytes.byteLength > this.maxSubtreeBytes) {
+      throw new Error(
+        `3D Tiles: ${what} is ${bytes.byteLength} bytes, above the ceiling of ` +
+          `${this.maxSubtreeBytes}; refusing to read it.`,
+      );
+    }
+    return new Uint8Array(bytes);
+  }
+
+  /**
+   * Fetch and resolve the subtree rooted at `coord`, once per coordinate.
+   *
+   * External availability buffers are resolved against the SUBTREE's own URL,
+   * because that is what the buffer `uri` is relative to, and the absolute
+   * result is then put through the tileset-directory gate. Resolving straight
+   * against the tileset root would misplace a buffer beside a nested subtree;
+   * skipping the second check would let a `../` in a buffer uri leave the
+   * tileset's own directory.
+   */
+  private async subtreeAt(tiling: ImplicitTiling, coord: TileCoordinate): Promise<SubtreeAvailability> {
+    const key = tileIdFor(tiling.scheme, coord);
+    const already = this.loaded.get(key);
+    if (already) return already;
+    if (++this.budget.subtrees > this.budget.maxSubtrees) {
+      throw new Error(
+        `3D Tiles: this tileset needs more than ${this.budget.maxSubtrees} subtree files; ` +
+          'refusing to expand it.',
+      );
+    }
+    const uri = substituteTemplateUri(tiling.subtreeUriTemplate, tiling.scheme, coord);
+    const url = this.resolve(uri, `the subtree URI "${uri}"`);
+    const doc = readSubtreeDocument(await this.read(url, `the subtree at ${uri}`));
+    const external = new Map<number, Uint8Array>();
+    for (const request of subtreeExternalBuffers(doc)) {
+      let absolute: string;
+      try {
+        absolute = new URL(request.uri, url).toString();
+      } catch {
+        throw new Error(
+          `3D Tiles: a subtree availability buffer URI is not resolvable: ${request.uri}`,
+        );
+      }
+      const bufferUrl = this.resolve(
+        absolute,
+        `the subtree availability buffer "${request.uri}"`,
+      );
+      external.set(
+        request.index,
+        await this.read(bufferUrl, `the availability buffer at ${request.uri}`),
+      );
+    }
+    const availability = resolveSubtreeAvailability(doc, {
+      scheme: tiling.scheme,
+      subtreeLevels: tiling.subtreeLevels,
+    }, external);
+    this.loaded.set(key, availability);
+    return availability;
+  }
+
+  /** Whether the tile at `coord` carries content, per its subtree. */
+  private hasContent(tiling: ImplicitTiling, context: SubtreeContext, coord: TileCoordinate): boolean {
+    const content = context.availability.content;
+    if (content === null) return false;
+    return isAvailable(content, tileIndexWithinSubtree(tiling.scheme, coord, context.root.level));
+  }
+
+  /**
+   * Build the explicit tile at `coord`, and everything available below it.
+   *
+   * The volume is subdivided from the parent's rather than recomputed from the
+   * root, which is what makes a child's bound exactly the parent's half rather
+   * than an independently rounded approximation of it.
+   */
+  private async buildTile(
+    tiling: ImplicitTiling,
+    context: SubtreeContext,
+    coord: TileCoordinate,
+    volume: BoundingVolume,
+    rootGeometricError: number,
+    contentUriTemplate: string,
+  ): Promise<RawTile> {
+    if (++this.budget.tiles > this.budget.maxTiles) {
+      throw new Error(
+        `3D Tiles: this implicit tileset expands to more than ${this.budget.maxTiles} tiles; ` +
+          'refusing to expand it.',
+      );
+    }
+    const tile: RawTile = {
+      boundingVolume: volume as unknown as Record<string, unknown>,
+      geometricError: geometricErrorForLevel(rootGeometricError, coord.level),
+    };
+    if (this.hasContent(tiling, context, coord)) {
+      tile.content = { uri: substituteTemplateUri(contentUriTemplate, tiling.scheme, coord) };
+    }
+    const children = await this.buildChildren(
+      tiling,
+      context,
+      coord,
+      volume,
+      rootGeometricError,
+      contentUriTemplate,
+    );
+    if (children.length > 0) tile.children = children;
+    return tile;
+  }
+
+  /**
+   * The available children of one tile.
+   *
+   * Two cases meet here. While the child stays inside the current subtree its
+   * presence is a bit of that subtree's `tileAvailability`. At the subtree's
+   * deepest level the child is instead the ROOT of another subtree, and its
+   * presence is a bit of `childSubtreeAvailability` addressing the level below
+   * the deepest, which is a different bitstream of a different length. Reading
+   * one where the other belongs is how a reader loses or invents a whole level.
+   */
+  private async buildChildren(
+    tiling: ImplicitTiling,
+    context: SubtreeContext,
+    coord: TileCoordinate,
+    volume: BoundingVolume,
+    rootGeometricError: number,
+    contentUriTemplate: string,
+  ): Promise<RawTile[]> {
+    if (coord.level + 1 > tiling.availableLevels - 1) return [];
+    const depthInSubtree = coord.level + 1 - context.root.level;
+    const crossesSubtree = depthInSubtree === tiling.subtreeLevels;
+    const perSubtree = subtreeTileCount({
+      scheme: tiling.scheme,
+      subtreeLevels: tiling.subtreeLevels,
+    });
+    const out: RawTile[] = [];
+    const kids = childCoordinates(tiling.scheme, coord);
+    for (let index = 0; index < kids.length; index++) {
+      const child = kids[index] as TileCoordinate;
+      const childVolume = subdivideBoundingVolume(tiling.scheme, volume, index);
+      if (childVolume === null) {
+        throw new Error(
+          '3D Tiles: an implicitly tiled bounding volume has no exact subdivision.',
+        );
+      }
+      // Both indices come from the same function; only the frame differs. Inside
+      // the subtree it addresses `tileAvailability`; at the boundary the count
+      // of every tile in the subtree is subtracted, which turns it into the
+      // Morton index of the child-subtree root within `childSubtreeAvailability`.
+      const withinSubtree = tileIndexWithinSubtree(tiling.scheme, child, context.root.level);
+      if (!crossesSubtree) {
+        if (!isAvailable(context.availability.tile, withinSubtree)) continue;
+        out.push(
+          await this.buildTile(
+            tiling,
+            context,
+            child,
+            childVolume,
+            rootGeometricError,
+            contentUriTemplate,
+          ),
+        );
+        continue;
+      }
+      if (!isAvailable(context.availability.childSubtree, withinSubtree - perSubtree)) continue;
+      const availability = await this.subtreeAt(tiling, child);
+      // The two documents state the same fact from opposite sides. A parent
+      // that promises a child subtree whose own root tile is absent is not a
+      // tileset with a hole in it; it is two documents that disagree, and
+      // picking either answer would be a guess.
+      if (!isAvailable(availability.tile, 0)) {
+        throw new Error(
+          `3D Tiles: the subtree at ${tileIdFor(tiling.scheme, child)} is declared available by ` +
+            'its parent but states its own root tile is not.',
+        );
+      }
+      out.push(
+        await this.buildTile(
+          tiling,
+          { root: child, availability },
+          child,
+          childVolume,
+          rootGeometricError,
+          contentUriTemplate,
+        ),
+      );
+    }
+    return out;
+  }
+
+  /** Expand one implicitly tiled tile into an explicit one. */
+  async expandTile(tile: RawTile): Promise<RawTile> {
+    const tiling = parseImplicitTiling(tile.implicitTiling);
+    if (Array.isArray(tile.children) && tile.children.length > 0) {
+      throw new Error(
+        '3D Tiles: a tile declares both implicitTiling and children, which state two different ' +
+          'hierarchies for the same tile.',
+      );
+    }
+    const template = contentTemplate(tile);
+    const volume = implicitRootVolume(tile.boundingVolume);
+    if (typeof tile.geometricError !== 'number' || !Number.isFinite(tile.geometricError)) {
+      throw new Error('3D Tiles: an implicitly tiled tile has no finite geometricError.');
+    }
+    const root = rootCoordinate(tiling.scheme);
+    const availability = await this.subtreeAt(tiling, root);
+    const context: SubtreeContext = { root, availability };
+    const expanded = await this.buildTile(
+      tiling,
+      context,
+      root,
+      volume,
+      tile.geometricError,
+      template,
+    );
+    // Everything the authored tile stated for itself is kept: its transform, its
+    // refine, its own bounding volume and geometric error. Only the rule and the
+    // content TEMPLATE are replaced, by the tree and the content the rule named.
+    const out: RawTile = { ...tile };
+    delete out.implicitTiling;
+    delete out.content;
+    delete out.children;
+    if (expanded.content !== undefined) out.content = expanded.content;
+    if (expanded.children !== undefined) out.children = expanded.children;
+    // An implicit root whose own tileAvailability bit is 0 exists in the
+    // document but not in the tree. It keeps its bounds so the hierarchy above
+    // it still places it, and carries neither content nor children.
+    if (!isAvailable(availability.tile, 0)) {
+      delete out.content;
+      delete out.children;
+    }
+    return out;
+  }
+}
+
+/**
+ * Rewrite a `tileset.json` document so no tile declares `implicitTiling`.
+ *
+ * Takes and returns the RAW document, before `parseTileset`. The result is an
+ * ordinary explicit tileset: hand it to `parseTileset`, which applies every
+ * structural refusal and both of its ceilings to the expansion exactly as it
+ * would to an authored hierarchy.
+ *
+ * A document that declares no implicit tiling anywhere is returned unchanged,
+ * so a caller can run this unconditionally.
+ */
+export async function expandImplicitTileset(
+  doc: object,
+  options: ExpandImplicitOptions,
+): Promise<object> {
+  if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) {
+    throw new Error('3D Tiles: tileset.json is not an object.');
+  }
+  const budget: ExpandBudget = {
+    maxSubtrees: options.maxSubtrees ?? MAX_IMPLICIT_SUBTREES,
+    maxTiles: options.maxTiles ?? MAX_IMPLICIT_TILES,
+    subtrees: 0,
+    tiles: 0,
+  };
+  const expansion = new ImplicitExpansion(options, budget);
+
+  /** Walk the authored tree, expanding each implicit tile where it stands. */
+  async function walk(tile: RawTile, depth: number): Promise<RawTile> {
+    if (depth > DEFAULT_TILESET_MAX_DEPTH) {
+      throw new Error(
+        `3D Tiles: tile hierarchy is deeper than ${DEFAULT_TILESET_MAX_DEPTH} levels; ` +
+          'refusing to expand it.',
+      );
+    }
+    if (tile === null || typeof tile !== 'object' || Array.isArray(tile)) {
+      throw new Error('3D Tiles: a tile is not an object.');
+    }
+    // An expanded tile holds no implicitTiling below it, so it is not re-walked.
+    if (tile.implicitTiling !== undefined) return expansion.expandTile(tile);
+    if (tile.children === undefined) return tile;
+    if (!Array.isArray(tile.children)) {
+      throw new Error('3D Tiles: a tile children field is not an array.');
+    }
+    const children: RawTile[] = [];
+    for (const child of tile.children as RawTile[]) {
+      children.push(await walk(child, depth + 1));
+    }
+    return { ...tile, children };
+  }
+
+  const source = doc as { root?: RawTile };
+  if (source.root === undefined) return doc;
+  return { ...doc, root: await walk(source.root, 0) };
+}

--- a/src/io/tiles3d/implicitTiling.ts
+++ b/src/io/tiles3d/implicitTiling.ts
@@ -1,0 +1,170 @@
+/**
+ * implicitTiling.ts — a tile's `implicitTiling` object, and the template URIs
+ * it addresses subtrees and content with.
+ *
+ * An implicitly tiled tile replaces `children` with a rule: a subdivision
+ * scheme, how many levels one subtree file covers, how many levels the whole
+ * tree has, and a template URI that turns a coordinate into a subtree address.
+ * The tile's own `content.uri` is a template too, so one string names every
+ * body in the tree.
+ *
+ * TEMPLATES ARE SUBSTITUTED, NOT INTERPOLATED. Only `{level}`, `{x}`, `{y}` and
+ * `{z}` are replaced, each by a decimal integer, and anything else left in
+ * braces afterwards is refused by name. A reader that ignored an unknown
+ * placeholder would assemble a URI containing a literal `{...}`, fetch it, and
+ * report the 404 as a missing tile rather than as a template it did not
+ * understand. `{z}` in a QUADTREE template is refused for the same reason: a
+ * quadtree coordinate has no z, so any value substituted there is invented.
+ *
+ * WHAT IS REFUSED BY NAME. The `3DTILES_implicit_tiling` extension spells the
+ * depth limit `maximumLevel` (the deepest level index) where 1.1 spells it
+ * `availableLevels` (a count, one greater). Reading one as the other is an
+ * off-by-one that costs or invents an entire level of tiles, so a document
+ * carrying the extension spelling is named rather than guessed at.
+ *
+ * Pure: no fetch, no DOM.
+ */
+
+import { MAX_LEVEL, type SubdivisionScheme, type TileCoordinate } from './implicitCoordinates';
+
+/**
+ * Deepest implicit tree this reader will expand, counted in levels.
+ *
+ * The expansion becomes explicit tiles, and `parseTileset` refuses a hierarchy
+ * deeper than DEFAULT_TILESET_MAX_DEPTH. Bounding `availableLevels` here means
+ * the document is refused for the reason it is actually wrong (it asks for more
+ * levels than this reader expands) rather than for the shape of the tree that
+ * request happened to produce.
+ */
+export const MAX_IMPLICIT_LEVELS = 24;
+
+/** A validated `implicitTiling` object. */
+export interface ImplicitTiling {
+  readonly scheme: SubdivisionScheme;
+  /** Levels one subtree file covers, counting its own root as one. */
+  readonly subtreeLevels: number;
+  /** Levels the whole tree has. The deepest addressable level is one less. */
+  readonly availableLevels: number;
+  /** Template URI for a subtree file, in the tileset's own directory. */
+  readonly subtreeUriTemplate: string;
+}
+
+const PLACEHOLDER = /\{(level|x|y|z)\}/g;
+const ANY_PLACEHOLDER = /\{[^}]*\}/;
+
+/**
+ * Validate one `implicitTiling` object.
+ *
+ * Every field is remote input and every field sizes work: the scheme fixes the
+ * branching factor, `subtreeLevels` is an exponent over it, and
+ * `availableLevels` multiplies the whole tree again. None of them is defaulted.
+ */
+export function parseImplicitTiling(raw: unknown): ImplicitTiling {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('3D Tiles: a tile implicitTiling is not an object.');
+  }
+  const obj = raw as {
+    subdivisionScheme?: unknown;
+    subtreeLevels?: unknown;
+    availableLevels?: unknown;
+    maximumLevel?: unknown;
+    subtrees?: { uri?: unknown };
+  };
+  const scheme = obj.subdivisionScheme;
+  if (scheme !== 'QUADTREE' && scheme !== 'OCTREE') {
+    throw new Error(
+      `3D Tiles: implicitTiling declares subdivisionScheme ${JSON.stringify(scheme)}, ` +
+        'which is not QUADTREE or OCTREE.',
+    );
+  }
+  const subtreeLevels = obj.subtreeLevels;
+  if (!Number.isInteger(subtreeLevels) || (subtreeLevels as number) < 1) {
+    throw new Error('3D Tiles: implicitTiling.subtreeLevels is not an integer of at least 1.');
+  }
+  if (obj.availableLevels === undefined && obj.maximumLevel !== undefined) {
+    throw new Error(
+      '3D Tiles: implicitTiling declares the 3DTILES_implicit_tiling extension\'s ' +
+        '`maximumLevel` rather than 1.1\'s `availableLevels`; this reader implements 1.1 only.',
+    );
+  }
+  const availableLevels = obj.availableLevels;
+  if (!Number.isInteger(availableLevels) || (availableLevels as number) < 1) {
+    throw new Error('3D Tiles: implicitTiling.availableLevels is not an integer of at least 1.');
+  }
+  if ((availableLevels as number) > MAX_IMPLICIT_LEVELS) {
+    throw new Error(
+      `3D Tiles: implicitTiling declares ${availableLevels as number} availableLevels, above ` +
+        `the ceiling of ${MAX_IMPLICIT_LEVELS}; refusing to expand it.`,
+    );
+  }
+  // The deepest level the tree addresses must still have an exact Morton index,
+  // which is what `implicitCoordinates` bounds per scheme.
+  if ((availableLevels as number) - 1 > MAX_LEVEL[scheme]) {
+    throw new Error(
+      `3D Tiles: implicitTiling addresses ${scheme} level ${(availableLevels as number) - 1}, ` +
+        `above the exact-integer limit of ${MAX_LEVEL[scheme]}.`,
+    );
+  }
+  const uri = obj.subtrees?.uri;
+  if (typeof uri !== 'string' || uri.length === 0) {
+    throw new Error('3D Tiles: implicitTiling.subtrees.uri is not a non-empty string.');
+  }
+  return {
+    scheme,
+    subtreeLevels: subtreeLevels as number,
+    availableLevels: availableLevels as number,
+    subtreeUriTemplate: uri,
+  };
+}
+
+/**
+ * Substitute a coordinate into a template URI.
+ *
+ * A template with no placeholder at all is refused: it names one file for every
+ * tile in the tree, so a reader that accepted it would fetch the same body
+ * under many identities and call the result a tileset.
+ */
+export function substituteTemplateUri(
+  template: string,
+  scheme: SubdivisionScheme,
+  coord: TileCoordinate,
+): string {
+  if (typeof template !== 'string' || template.length === 0) {
+    throw new Error('3D Tiles: an implicit template URI is empty.');
+  }
+  if (!PLACEHOLDER.test(template)) {
+    // `PLACEHOLDER` is global, so its lastIndex survives a test; reset it.
+    PLACEHOLDER.lastIndex = 0;
+    throw new Error(
+      `3D Tiles: the implicit template URI "${template}" carries no {level}, {x}, {y} or {z} ` +
+        'placeholder, so it names one file for the whole tree.',
+    );
+  }
+  PLACEHOLDER.lastIndex = 0;
+  if (scheme === 'QUADTREE' && template.includes('{z}')) {
+    throw new Error(
+      `3D Tiles: the implicit template URI "${template}" substitutes {z}, which a QUADTREE ` +
+        'coordinate does not have.',
+    );
+  }
+  const out = template.replace(PLACEHOLDER, (_match, name: string) => {
+    switch (name) {
+      case 'level':
+        return String(coord.level);
+      case 'x':
+        return String(coord.x);
+      case 'y':
+        return String(coord.y);
+      default:
+        return String(coord.z as number);
+    }
+  });
+  const leftover = ANY_PLACEHOLDER.exec(out);
+  if (leftover) {
+    throw new Error(
+      `3D Tiles: the implicit template URI "${template}" carries the placeholder ` +
+        `"${leftover[0]}", which this reader does not substitute.`,
+    );
+  }
+  return out;
+}

--- a/src/io/tiles3d/subtree.ts
+++ b/src/io/tiles3d/subtree.ts
@@ -1,0 +1,463 @@
+/**
+ * subtree.ts — the `.subtree` binary of 3D Tiles 1.1 implicit tiling.
+ *
+ * A subtree file is how an implicit tileset states which tiles actually exist.
+ * The hierarchy itself is a rule (a subdivision scheme and a root volume), so
+ * the only thing a document cannot derive is presence: which of the 4^n or 8^n
+ * addressable tiles in a fixed-depth block are real, which of them carry
+ * content, and which of them continue into a further subtree. Those three
+ * answers are the whole payload.
+ *
+ * THE CONTAINER. Twenty-four bytes of header — `subt`, a version, then two
+ * 64-bit chunk lengths — followed by a JSON chunk and a binary chunk. The JSON
+ * chunk names `buffers` and `bufferViews` in the glTF manner, and each of the
+ * three availability fields either states a CONSTANT (every tile available, or
+ * none) or points at a bufferView holding one bit per tile, LSB-first.
+ *
+ * A buffer with no `uri` is the file's own binary chunk. A buffer WITH a `uri`
+ * lives in a separate file, which is why this module resolves nothing and
+ * fetches nothing: {@link subtreeExternalBuffers} reports what a caller must
+ * fetch, and {@link resolveSubtreeAvailability} takes the results back. Keeping
+ * the fetch outside is what lets the caller put every external buffer through
+ * the same URL guards a tile content URI goes through.
+ *
+ * WHY THE SIZE CHECKS ARE EQUALITIES. The number of bits an availability
+ * bitstream must hold is fixed by the subdivision scheme and `subtreeLevels`,
+ * both of which the caller supplies from the tile's `implicitTiling`. A
+ * bitstream of any other size was written against a different shape, and read
+ * against this one it answers every question about the wrong tile: an available
+ * tile reported missing, a missing tile reported real. So a disagreement is
+ * refused by name rather than tolerated at whichever end happens to fit.
+ *
+ * Pure: no fetch, no DOM.
+ */
+
+import type { Availability, SubdivisionScheme } from './implicitCoordinates';
+
+/** `subt` read as a little-endian uint32 — the first four bytes of the file. */
+export const SUBTREE_MAGIC = 0x74627573;
+/** The only container version 3D Tiles 1.1 defines. */
+export const SUBTREE_VERSION = 1;
+/** magic(4) + version(4) + jsonByteLength(8) + binaryByteLength(8). */
+export const SUBTREE_HEADER_BYTES = 24;
+
+/**
+ * Ceilings, and why each one is here.
+ *
+ * A subtree document is remote input that describes a tree, so every number in
+ * it sizes work. `subtreeLevels` is an exponent: at OCTREE it multiplies the
+ * addressable tile count by eight per level, so a two-digit value in a
+ * two-hundred-byte document describes more tiles than there are atoms worth
+ * allocating. Bounding the exponent first keeps the pow below from reaching
+ * Infinity; bounding the resulting tile count second is the limit that actually
+ * decides what a reader will allocate. The external-buffer count is bounded
+ * because three availability fields need at most three buffers, and a document
+ * naming hundreds is naming fetches, not data.
+ *
+ * All three refuse. None truncates: a subtree read at a shape other than its
+ * own answers availability questions about the wrong tiles.
+ */
+export const MAX_SUBTREE_LEVELS = 24;
+export const MAX_TILES_PER_SUBTREE = 1_048_576;
+export const MAX_SUBTREE_EXTERNAL_BUFFERS = 8;
+
+/** The shape a subtree is read AT, taken from the tile's `implicitTiling`. */
+export interface SubtreeShape {
+  readonly scheme: SubdivisionScheme;
+  /** Levels one subtree covers, counting its own root as one. */
+  readonly subtreeLevels: number;
+}
+
+/** An external availability buffer the caller must fetch and hand back. */
+export interface SubtreeBufferRequest {
+  /** Index into the document's `buffers`, which is the key to return it under. */
+  readonly index: number;
+  /** The buffer's `uri`, exactly as written. Unresolved and unvalidated here. */
+  readonly uri: string;
+  /** The document's declared length, for the caller's own byte ceiling. */
+  readonly byteLength: number;
+}
+
+/** The container, split and structurally checked, before any buffer is read. */
+export interface SubtreeDocument {
+  /** The parsed JSON chunk. */
+  readonly json: SubtreeJson;
+  /** The binary chunk, which is the buffer any `buffers` entry without a uri names. */
+  readonly binary: Uint8Array;
+}
+
+/** The three answers a subtree carries, ready for `isAvailable`. */
+export interface SubtreeAvailability {
+  /** One bit per tile in the subtree's own levels. */
+  readonly tile: Availability;
+  /** One bit per tile, or null when the document states no content at all. */
+  readonly content: Availability | null;
+  /** One bit per child-subtree root, at the level below the subtree's deepest. */
+  readonly childSubtree: Availability;
+  /** Bits `tile` and `content` cover. */
+  readonly tileCount: number;
+  /** Bits `childSubtree` covers. */
+  readonly childSubtreeCount: number;
+}
+
+/** The JSON chunk, as far as this reader interprets it. */
+export interface SubtreeJson {
+  readonly buffers?: readonly { readonly uri?: string; readonly byteLength?: number }[];
+  readonly bufferViews?: readonly {
+    readonly buffer?: number;
+    readonly byteOffset?: number;
+    readonly byteLength?: number;
+  }[];
+  readonly tileAvailability?: unknown;
+  readonly contentAvailability?: unknown;
+  readonly childSubtreeAvailability?: unknown;
+}
+
+/** Children per tile, restated here so this module needs no import for it. */
+function branching(scheme: SubdivisionScheme): number {
+  return scheme === 'QUADTREE' ? 4 : 8;
+}
+
+/**
+ * Tiles one subtree addresses: the full n-ary tree of `subtreeLevels` levels,
+ * `(n^levels - 1) / (n - 1)`.
+ */
+export function subtreeTileCount(shape: SubtreeShape): number {
+  assertShape(shape);
+  const n = branching(shape.scheme);
+  return (n ** shape.subtreeLevels - 1) / (n - 1);
+}
+
+/**
+ * Child-subtree roots one subtree addresses: the whole level immediately below
+ * its deepest, `n^levels`.
+ */
+export function subtreeChildCount(shape: SubtreeShape): number {
+  assertShape(shape);
+  return branching(shape.scheme) ** shape.subtreeLevels;
+}
+
+function assertShape(shape: SubtreeShape): void {
+  const { scheme, subtreeLevels } = shape;
+  if (scheme !== 'QUADTREE' && scheme !== 'OCTREE') {
+    throw new Error(`3D Tiles subtree: unknown subdivision scheme "${String(scheme)}".`);
+  }
+  if (!Number.isInteger(subtreeLevels) || subtreeLevels < 1) {
+    throw new Error('3D Tiles subtree: subtreeLevels must be an integer of at least 1.');
+  }
+  if (subtreeLevels > MAX_SUBTREE_LEVELS) {
+    throw new Error(
+      `3D Tiles subtree: subtreeLevels ${subtreeLevels} is above the ceiling of ` +
+        `${MAX_SUBTREE_LEVELS}; refusing to read it.`,
+    );
+  }
+  const n = branching(scheme);
+  const tiles = (n ** subtreeLevels - 1) / (n - 1);
+  if (tiles > MAX_TILES_PER_SUBTREE) {
+    throw new Error(
+      `3D Tiles subtree: ${scheme} subtreeLevels ${subtreeLevels} describes ${tiles} tiles, ` +
+        `above the ceiling of ${MAX_TILES_PER_SUBTREE}; refusing to read it.`,
+    );
+  }
+}
+
+/** Bytes a bitstream of `bits` bits occupies, LSB-first and byte-aligned. */
+function bitstreamBytes(bits: number): number {
+  return Math.ceil(bits / 8);
+}
+
+/** The four header bytes, printable, so a refusal can say what it actually saw. */
+function magicText(bytes: Uint8Array): string {
+  return Array.from(bytes.subarray(0, Math.min(4, bytes.length)))
+    .map((b) => (b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : '.'))
+    .join('');
+}
+
+/**
+ * Split a `.subtree` body into its JSON and binary chunks.
+ *
+ * Every length in the header is remote input, so each is checked against the
+ * body that actually arrived before a byte of it is indexed. The two chunk
+ * lengths are 64-bit, which JavaScript cannot index with, so they are read as
+ * BigInt and refused above the exact-integer range rather than rounded into a
+ * plausible-looking offset.
+ */
+export function readSubtreeDocument(input: ArrayBuffer | Uint8Array): SubtreeDocument {
+  const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+  if (bytes.byteLength < SUBTREE_HEADER_BYTES) {
+    throw new Error(
+      `3D Tiles subtree: the body is ${bytes.byteLength} bytes, shorter than the ` +
+        `${SUBTREE_HEADER_BYTES}-byte header.`,
+    );
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const magic = view.getUint32(0, true);
+  if (magic !== SUBTREE_MAGIC) {
+    throw new Error(
+      `3D Tiles subtree: the body does not start with the "subt" magic (found "${magicText(bytes)}").`,
+    );
+  }
+  const version = view.getUint32(4, true);
+  if (version !== SUBTREE_VERSION) {
+    throw new Error(
+      `3D Tiles subtree: version ${version} is not the version ${SUBTREE_VERSION} this reader understands.`,
+    );
+  }
+  const jsonLength = view.getBigUint64(8, true);
+  const binaryLength = view.getBigUint64(16, true);
+  const limit = BigInt(Number.MAX_SAFE_INTEGER);
+  if (jsonLength > limit || binaryLength > limit) {
+    throw new Error('3D Tiles subtree: a declared chunk length is not an exact integer.');
+  }
+  const jsonBytes = Number(jsonLength);
+  const binaryBytes = Number(binaryLength);
+  if (jsonBytes === 0) {
+    throw new Error('3D Tiles subtree: the JSON chunk is empty.');
+  }
+  const declared = SUBTREE_HEADER_BYTES + jsonBytes + binaryBytes;
+  if (declared > bytes.byteLength) {
+    throw new Error(
+      `3D Tiles subtree: the header declares ${declared} bytes but the body is ` +
+        `${bytes.byteLength}; it is truncated.`,
+    );
+  }
+  const text = new TextDecoder('utf-8', { fatal: true }).decode(
+    bytes.subarray(SUBTREE_HEADER_BYTES, SUBTREE_HEADER_BYTES + jsonBytes),
+  );
+  let json: unknown;
+  try {
+    json = JSON.parse(text) as unknown;
+  } catch (err) {
+    throw new Error(
+      `3D Tiles subtree: the JSON chunk is not valid JSON (${err instanceof Error ? err.message : String(err)}).`,
+    );
+  }
+  if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+    throw new Error('3D Tiles subtree: the JSON chunk is not an object.');
+  }
+  const binary = bytes.subarray(
+    SUBTREE_HEADER_BYTES + jsonBytes,
+    SUBTREE_HEADER_BYTES + jsonBytes + binaryBytes,
+  );
+  return { json: json as SubtreeJson, binary };
+}
+
+/**
+ * The external buffers this document needs, in `buffers` order.
+ *
+ * Reported rather than fetched. The caller owns the URL decision, and the URL
+ * decision for a 3D Tiles document is not "resolve it": it is the same
+ * same-origin, no-credentials, no-directory-escape gate every tile content URI
+ * passes through.
+ */
+export function subtreeExternalBuffers(doc: SubtreeDocument): readonly SubtreeBufferRequest[] {
+  const buffers = doc.json.buffers;
+  if (buffers === undefined) return [];
+  if (!Array.isArray(buffers)) {
+    throw new Error('3D Tiles subtree: `buffers` is not an array.');
+  }
+  const out: SubtreeBufferRequest[] = [];
+  buffers.forEach((buffer, index) => {
+    if (buffer === null || typeof buffer !== 'object') {
+      throw new Error(`3D Tiles subtree: buffers[${index}] is not an object.`);
+    }
+    const byteLength = buffer.byteLength;
+    if (!Number.isInteger(byteLength) || (byteLength as number) < 0) {
+      throw new Error(`3D Tiles subtree: buffers[${index}] has no non-negative integer byteLength.`);
+    }
+    const uri = buffer.uri;
+    if (uri === undefined) return;
+    if (typeof uri !== 'string' || uri.length === 0) {
+      throw new Error(`3D Tiles subtree: buffers[${index}].uri is not a non-empty string.`);
+    }
+    out.push({ index, uri, byteLength: byteLength as number });
+  });
+  if (out.length > MAX_SUBTREE_EXTERNAL_BUFFERS) {
+    throw new Error(
+      `3D Tiles subtree: ${out.length} external buffers is above the ceiling of ` +
+        `${MAX_SUBTREE_EXTERNAL_BUFFERS}; refusing to read it.`,
+    );
+  }
+  return out;
+}
+
+/** One availability field, before its bitstream (if any) is located. */
+type RawAvailability =
+  | { readonly kind: 'constant'; readonly value: 0 | 1 }
+  | { readonly kind: 'bitstream'; readonly bufferView: number };
+
+/**
+ * Read one availability object.
+ *
+ * 3D Tiles 1.1 spells the bufferView reference `bitstream`. The earlier
+ * `3DTILES_implicit_tiling` extension spelled the same field `bufferView`, and
+ * the two are not interchangeable to a reader that only knows one of them: a
+ * document using the extension spelling would fall through to "declares
+ * neither" and be reported as malformed rather than as a format this reader
+ * does not implement. So it is named in its own refusal.
+ */
+function readAvailability(raw: unknown, field: string): RawAvailability {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`3D Tiles subtree: ${field} is not an object.`);
+  }
+  const obj = raw as { constant?: unknown; bitstream?: unknown; bufferView?: unknown };
+  if (obj.bufferView !== undefined && obj.bitstream === undefined) {
+    throw new Error(
+      `3D Tiles subtree: ${field} uses the 3DTILES_implicit_tiling extension's \`bufferView\` ` +
+        'key rather than 1.1\'s `bitstream`; this reader implements 1.1 only.',
+    );
+  }
+  const hasConstant = obj.constant !== undefined;
+  const hasBitstream = obj.bitstream !== undefined;
+  if (hasConstant && hasBitstream) {
+    throw new Error(`3D Tiles subtree: ${field} declares both constant and bitstream.`);
+  }
+  if (hasConstant) {
+    if (obj.constant !== 0 && obj.constant !== 1) {
+      throw new Error(`3D Tiles subtree: ${field}.constant is not 0 or 1.`);
+    }
+    return { kind: 'constant', value: obj.constant };
+  }
+  if (hasBitstream) {
+    if (!Number.isInteger(obj.bitstream) || (obj.bitstream as number) < 0) {
+      throw new Error(`3D Tiles subtree: ${field}.bitstream is not a bufferView index.`);
+    }
+    return { kind: 'bitstream', bufferView: obj.bitstream as number };
+  }
+  throw new Error(`3D Tiles subtree: ${field} declares neither constant nor bitstream.`);
+}
+
+/**
+ * Locate the bytes of one bufferView, from the internal chunk or from a buffer
+ * the caller fetched, and check that its size is the size this shape needs.
+ */
+function bitstreamFor(
+  doc: SubtreeDocument,
+  external: ReadonlyMap<number, Uint8Array>,
+  index: number,
+  bits: number,
+  field: string,
+): Uint8Array {
+  const views = doc.json.bufferViews;
+  if (!Array.isArray(views)) {
+    throw new Error(`3D Tiles subtree: ${field} names a bufferView but the document declares none.`);
+  }
+  const view = views[index];
+  if (view === undefined || view === null || typeof view !== 'object') {
+    throw new Error(`3D Tiles subtree: ${field} names bufferView ${index}, which does not exist.`);
+  }
+  const bufferIndex = view.buffer;
+  const byteOffset = view.byteOffset ?? 0;
+  const byteLength = view.byteLength;
+  if (!Number.isInteger(bufferIndex) || (bufferIndex as number) < 0) {
+    throw new Error(`3D Tiles subtree: bufferViews[${index}].buffer is not a buffer index.`);
+  }
+  if (!Number.isInteger(byteOffset) || byteOffset < 0) {
+    throw new Error(`3D Tiles subtree: bufferViews[${index}].byteOffset is not a non-negative integer.`);
+  }
+  if (!Number.isInteger(byteLength) || (byteLength as number) < 0) {
+    throw new Error(`3D Tiles subtree: bufferViews[${index}].byteLength is not a non-negative integer.`);
+  }
+  const need = bitstreamBytes(bits);
+  if (byteLength !== need) {
+    throw new Error(
+      `3D Tiles subtree: ${field} is ${byteLength as number} bytes but the ${bits} tiles it must ` +
+        `describe need ${need}; the bitstream disagrees with the subtree's own shape.`,
+    );
+  }
+  const buffers = doc.json.buffers;
+  const buffer = Array.isArray(buffers) ? buffers[bufferIndex as number] : undefined;
+  if (buffer === undefined) {
+    throw new Error(
+      `3D Tiles subtree: bufferViews[${index}] names buffer ${bufferIndex as number}, which does not exist.`,
+    );
+  }
+  const source =
+    buffer.uri === undefined ? doc.binary : external.get(bufferIndex as number);
+  if (source === undefined) {
+    throw new Error(
+      `3D Tiles subtree: buffer ${bufferIndex as number} is external and was not supplied.`,
+    );
+  }
+  const declared = buffer.byteLength;
+  if (Number.isInteger(declared) && (declared as number) > source.byteLength) {
+    throw new Error(
+      `3D Tiles subtree: buffer ${bufferIndex as number} declares ${declared as number} bytes but ` +
+        `${source.byteLength} were available; it is truncated.`,
+    );
+  }
+  if (byteOffset + (byteLength as number) > source.byteLength) {
+    throw new Error(
+      `3D Tiles subtree: bufferViews[${index}] runs past the end of buffer ${bufferIndex as number}.`,
+    );
+  }
+  return source.subarray(byteOffset, byteOffset + (byteLength as number));
+}
+
+/**
+ * Turn a read document into the three availability answers, at one shape.
+ *
+ * `contentAvailability` is 1.1's array form, one entry per content on the tile.
+ * This reader serves a single content per tile (`tileset.ts` refuses the
+ * `contents` array for the same reason), so an array of more than one entry is
+ * refused by name rather than read down to its first element, which would draw
+ * part of a tile and report the tileset complete.
+ */
+export function resolveSubtreeAvailability(
+  doc: SubtreeDocument,
+  shape: SubtreeShape,
+  external: ReadonlyMap<number, Uint8Array> = new Map(),
+): SubtreeAvailability {
+  const tileCount = subtreeTileCount(shape);
+  const childSubtreeCount = subtreeChildCount(shape);
+
+  const build = (raw: RawAvailability, bits: number, field: string): Availability =>
+    raw.kind === 'constant'
+      ? { constant: raw.value, length: bits }
+      : { bitstream: bitstreamFor(doc, external, raw.bufferView, bits, field), length: bits };
+
+  if (doc.json.tileAvailability === undefined) {
+    throw new Error('3D Tiles subtree: the document declares no tileAvailability.');
+  }
+  if (doc.json.childSubtreeAvailability === undefined) {
+    throw new Error('3D Tiles subtree: the document declares no childSubtreeAvailability.');
+  }
+  const tile = build(
+    readAvailability(doc.json.tileAvailability, 'tileAvailability'),
+    tileCount,
+    'tileAvailability',
+  );
+  const childSubtree = build(
+    readAvailability(doc.json.childSubtreeAvailability, 'childSubtreeAvailability'),
+    childSubtreeCount,
+    'childSubtreeAvailability',
+  );
+
+  let content: Availability | null = null;
+  const rawContent = doc.json.contentAvailability;
+  if (rawContent !== undefined) {
+    if (Array.isArray(rawContent)) {
+      if (rawContent.length > 1) {
+        throw new Error(
+          `3D Tiles subtree: contentAvailability declares ${rawContent.length} contents per tile, ` +
+            'the 1.1 multi-content form, which this reader does not serve.',
+        );
+      }
+      if (rawContent.length === 1) {
+        content = build(
+          readAvailability(rawContent[0], 'contentAvailability[0]'),
+          tileCount,
+          'contentAvailability[0]',
+        );
+      }
+    } else {
+      content = build(
+        readAvailability(rawContent, 'contentAvailability'),
+        tileCount,
+        'contentAvailability',
+      );
+    }
+  }
+
+  return { tile, content, childSubtree, tileCount, childSubtreeCount };
+}

--- a/src/io/tiles3d/tileset.ts
+++ b/src/io/tiles3d/tileset.ts
@@ -9,8 +9,11 @@
  * camera over time.
  *
  * The subset is bounded on purpose, and what falls outside it is refused with a
- * clear error rather than mis-read: implicit tiling, and any `asset.version`
- * outside {@link SUPPORTED_ASSET_VERSIONS}.
+ * clear error rather than mis-read: an unexpanded implicit hierarchy, and any
+ * `asset.version` outside {@link SUPPORTED_ASSET_VERSIONS}. Implicit tiling is
+ * resolved before this function rather than inside it: `implicitExpand.ts`
+ * fetches the `.subtree` availability files and rewrites the document into an
+ * explicit one, which this parser then checks like any other.
  *
  * Two compatibility limits of this subset are known and not yet addressed. The
  * selection downstream identifies content by the URI extension, while 1.1 does
@@ -190,8 +193,20 @@ function parseTile(raw: RawTile, inheritedRefine: Refine, depth: number, budget:
       `3D Tiles: tileset declares more than ${budget.maxTiles} tiles; refusing to parse it.`,
     );
   }
+  // This parser is synchronous and pure, and an implicit tree cannot be resolved
+  // without the network: which of its tiles exist is stated by `.subtree` files
+  // the document names. `expandImplicitTileset` fetches those and rewrites the
+  // document into an equivalent explicit one, which then arrives here and is
+  // checked by every rule below exactly as an authored hierarchy is. So this
+  // stays a refusal rather than becoming a branch: a document that reaches the
+  // parser still carrying `implicitTiling` was not expanded, and reading it as
+  // a childless tile would drop its whole tree in silence.
   if (raw.implicitTiling !== undefined) {
-    throw new Error('3D Tiles: implicit tiling is not supported yet — only an explicit tile hierarchy.');
+    throw new Error(
+      '3D Tiles: a tile declares implicit tiling, which this parser does not resolve. ' +
+        'Expand the document with expandImplicitTileset first; it reads the .subtree ' +
+        'availability files and rewrites the tree explicitly.',
+    );
   }
   // 1.1 lets a tile carry `contents` (an array) instead of `content`. Only the
   // single form is read below, so such a tile used to yield a null URI, which

--- a/src/io/tiles3d/tilesetTransport.ts
+++ b/src/io/tiles3d/tilesetTransport.ts
@@ -45,6 +45,18 @@ export const MAX_TILESET_JSON_BYTES = 8 * 1024 * 1024;
  * from a writer that produced unusually large tiles.
  */
 export const MAX_PNTS_TILE_BYTES = 128 * 1024 * 1024;
+/**
+ * Ceiling for one `.subtree` body.
+ *
+ * A subtree carries three availability bitstreams and nothing else: one bit per
+ * tile over the levels it covers. The widest subtree this reader will read at
+ * all is bounded by `MAX_TILES_PER_SUBTREE`, which at about a million tiles is
+ * 128 KB per bitstream, so a legitimate document is orders of magnitude below
+ * this. It is separate from the tile ceiling because a `.subtree` is metadata,
+ * not geometry, and reading it at the 128 MiB a point tile is allowed would
+ * make availability the largest allocation in an implicit open.
+ */
+export const MAX_SUBTREE_BYTES = 8 * 1024 * 1024;
 /** Maximum retries beyond the initial attempt (so up to 4 total). */
 const DEFAULT_MAX_RETRIES = 3;
 /** Base backoff before the first retry — doubled each attempt, jittered. */
@@ -74,6 +86,17 @@ export interface TilesetTransport {
   fetchTilesetJson(url: string, signal?: AbortSignal): Promise<string>;
   /** One `.pnts` body, capped at {@link MAX_PNTS_TILE_BYTES}. */
   fetchTileBytes(url: string, signal?: AbortSignal): Promise<ArrayBuffer>;
+  /**
+   * One `.subtree` body, or one external availability buffer it names, capped
+   * at {@link MAX_SUBTREE_BYTES}.
+   *
+   * A required member rather than an optional one. An implicit tileset's
+   * availability is fetched from the same untrusted origin its tiles are, so it
+   * needs the same per-attempt deadline, the same refused redirects and the
+   * same bounded read; an optional method is one a caller can be missing
+   * without noticing, and the fallback would be a plain fetch with none of them.
+   */
+  fetchSubtreeBytes(url: string, signal?: AbortSignal): Promise<ArrayBuffer>;
 }
 
 /** Tunables for {@link createTilesetTransport}. Defaulted; injected for tests. */
@@ -94,10 +117,12 @@ export interface TilesetTransportOptions {
   maxTilesetJsonBytes?: number;
   /** Override the `.pnts` ceiling. Tests use a tiny one. */
   maxTileBytes?: number;
+  /** Override the `.subtree` ceiling. Tests use a tiny one. */
+  maxSubtreeBytes?: number;
 }
 
 /** What kind of resource a request is reading, for the error vocabulary. */
-type ReadLabel = 'tileset' | 'tile';
+type ReadLabel = 'tileset' | 'tile' | 'subtree';
 
 /**
  * Build a hardened 3D Tiles transport: per-attempt timeout, bounded retry with
@@ -114,6 +139,7 @@ export function createTilesetTransport(
   const sleep = options.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const maxJsonBytes = options.maxTilesetJsonBytes ?? MAX_TILESET_JSON_BYTES;
   const maxTileBytes = options.maxTileBytes ?? MAX_PNTS_TILE_BYTES;
+  const maxSubtreeBytes = options.maxSubtreeBytes ?? MAX_SUBTREE_BYTES;
 
   /**
    * One GET with a hard deadline, composed with the caller's outer signal.
@@ -203,6 +229,22 @@ export function createTilesetTransport(
         `3D Tiles tileset at ${sanitizeUrlForDisplay(url)}`,
         { signal },
       );
+    },
+    fetchSubtreeBytes: async (url, signal) => {
+      const response = await fetchWithRetry(url, 'subtree', signal);
+      const bytes = await readAtMostBounded(
+        response,
+        maxSubtreeBytes,
+        `3D Tiles subtree at ${sanitizeUrlForDisplay(url)}`,
+        { signal },
+      );
+      // Exact-size, for the same reason the tile read below is: the subtree
+      // reader indexes chunk offsets against the buffer length, so a pooled
+      // backing buffer would present trailing bytes as part of the document.
+      return bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      ) as ArrayBuffer;
     },
     fetchTileBytes: async (url, signal) => {
       const response = await fetchWithRetry(url, 'tile', signal);

--- a/tests/fixtures/subtree3d.ts
+++ b/tests/fixtures/subtree3d.ts
@@ -1,0 +1,70 @@
+/**
+ * subtree3d.ts — synthetic `.subtree` bodies, built rather than shipped.
+ *
+ * The same principle as `tileset3d.ts` beside it: a subtree is a 24-byte header,
+ * a small JSON chunk and at most a few bytes of bitstream, so every case a
+ * reader has to survive can be constructed in a line or two. The header
+ * overrides exist so the malformed cases are built deliberately (a wrong magic,
+ * an unknown version, a length that overruns the body) instead of being
+ * approximated by slicing a valid file and hoping the damage lands somewhere
+ * interesting.
+ *
+ * Pure: no fetch, no DOM.
+ */
+
+/** Availability meaning "every tile in this subtree exists". */
+export const ALL_AVAILABLE = { constant: 1 } as const;
+/** Availability meaning "none of them do". */
+export const NONE_AVAILABLE = { constant: 0 } as const;
+
+/** Header fields a caller may state instead of having them derived. */
+export interface SubtreeHeaderOverrides {
+  /** The binary chunk. Defaults to empty. */
+  readonly binary?: Uint8Array;
+  /** Four bytes to write instead of `subt`. */
+  readonly magic?: string;
+  /** A version other than 1. */
+  readonly version?: number;
+  /** A JSON chunk length other than the real one. */
+  readonly jsonByteLength?: number;
+  /** A binary chunk length other than the real one. */
+  readonly binaryByteLength?: number;
+  /** Cut the finished body to this many bytes. */
+  readonly truncateTo?: number;
+}
+
+/**
+ * One availability bitstream, LSB-first within each byte, sized to `bits`.
+ *
+ * `values[i]` is the bit for element `i`, so index 8 is bit 0 of byte 1. Any
+ * value past `bits` is ignored; any bit past the end of `values` is 0.
+ */
+export function bitstream(values: readonly boolean[], bits = values.length): Uint8Array {
+  const out = new Uint8Array(Math.ceil(bits / 8));
+  for (let i = 0; i < bits; i++) {
+    if (values[i]) out[i >> 3] = (out[i >> 3] as number) | (1 << (i & 7));
+  }
+  return out;
+}
+
+/** A `.subtree` body: the header, the JSON chunk padded to 8 bytes, the binary. */
+export function makeSubtree(json: object, overrides: SubtreeHeaderOverrides = {}): ArrayBuffer {
+  let text = JSON.stringify(json);
+  // The spec pads the JSON chunk with trailing spaces to an 8-byte boundary so
+  // the binary chunk that follows stays aligned.
+  while (text.length % 8 !== 0) text += ' ';
+  const jsonBytes = new TextEncoder().encode(text);
+  const binary = overrides.binary ?? new Uint8Array(0);
+  const total = 24 + jsonBytes.length + binary.length;
+  const out = new Uint8Array(total);
+  const view = new DataView(out.buffer);
+  const magic = overrides.magic ?? 'subt';
+  for (let i = 0; i < 4; i++) out[i] = magic.charCodeAt(i) & 0xff;
+  view.setUint32(4, overrides.version ?? 1, true);
+  view.setBigUint64(8, BigInt(overrides.jsonByteLength ?? jsonBytes.length), true);
+  view.setBigUint64(16, BigInt(overrides.binaryByteLength ?? binary.length), true);
+  out.set(jsonBytes, 24);
+  out.set(binary, 24 + jsonBytes.length);
+  const body = overrides.truncateTo === undefined ? out : out.subarray(0, overrides.truncateTo);
+  return body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength) as ArrayBuffer;
+}

--- a/tests/streamingGpsTimeClaim.test.ts
+++ b/tests/streamingGpsTimeClaim.test.ts
@@ -81,6 +81,11 @@ const TILESET_DOC = JSON.stringify({
 function tilesetSource(): TilesetStreamingSource {
   const transport: TilesetTransport = {
     fetchTilesetJson: async () => '{}',
+    // An explicit hierarchy asks for no subtree, so a request for one here would
+    // be the reader inventing work rather than a case this test set up.
+    fetchSubtreeBytes: async () => {
+      throw new Error('this tileset states an explicit hierarchy; no subtree exists');
+    },
     fetchTileBytes: async () => new ArrayBuffer(8),
   };
   return new TilesetStreamingSource(

--- a/tests/tiles3dImplicitTiling.test.ts
+++ b/tests/tiles3dImplicitTiling.test.ts
@@ -1,0 +1,632 @@
+/**
+ * tiles3dImplicitTiling.test.ts — a tileset that states its hierarchy by rule
+ * instead of by JSON.
+ *
+ * The first test here is the one that had to fail before anything was written.
+ * A document declaring `implicitTiling` was refused at parse with "3D Tiles:
+ * implicit tiling is not supported yet", so the tilesets that most need
+ * streaming, the ones large enough that writing the tree out would be absurd,
+ * could not be opened at all.
+ *
+ * WHAT THESE TESTS PIN, beyond "it opens":
+ *
+ *   the availability frames    a tile's presence and a child SUBTREE's presence
+ *                              are different bitstreams of different lengths,
+ *                              and reading one where the other belongs loses or
+ *                              invents a whole level
+ *   the URL gate               a subtree URI is authored by the same untrusted
+ *                              document a content URI is, and is fetched
+ *                              earlier, so it goes through the same refusals
+ *   the ceilings               a three-hundred-byte document can describe an
+ *                              enormous tree; each ceiling refuses by name
+ *   the seam                   the expansion is an ordinary explicit document,
+ *                              so `parseTileset` and `tilesetNodes` apply every
+ *                              refusal they apply to an authored hierarchy
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import { tilesetNodes } from '../src/io/tiles3d/tilesetNodes';
+import { resolveTilesetContentUrl } from '../src/io/tiles3d/tilesetUrl';
+import {
+  expandImplicitTileset,
+  MAX_IMPLICIT_SUBTREES,
+  MAX_IMPLICIT_TILES,
+  type ExpandImplicitOptions,
+} from '../src/io/tiles3d/implicitExpand';
+import { parseImplicitTiling, substituteTemplateUri } from '../src/io/tiles3d/implicitTiling';
+import { makeSubtree, bitstream, ALL_AVAILABLE, NONE_AVAILABLE } from './fixtures/subtree3d';
+
+const ENTRY = 'https://tiles.example/data/tileset.json';
+const BASE = 'https://tiles.example/data/';
+/** Centred on the origin, eight metres of half-axis on each side. */
+const BOX = { box: [0, 0, 0, 8, 0, 0, 0, 8, 0, 0, 0, 8] };
+
+type Bodies = Map<string, ArrayBuffer>;
+
+/** An options object over a fixed set of bodies, recording what was asked for. */
+function serve(bodies: Bodies, extra: Partial<ExpandImplicitOptions> = {}) {
+  const asked: string[] = [];
+  const options: ExpandImplicitOptions = {
+    entryUrl: ENTRY,
+    fetchSubtreeBytes: async (url: string) => {
+      asked.push(url);
+      const body = bodies.get(url);
+      if (!body) throw new Error(`the test served no body for ${url}`);
+      return body;
+    },
+    ...extra,
+  };
+  return { options, asked };
+}
+
+/** A tileset whose root is implicitly tiled. Overrides go on the root tile. */
+function implicitDoc(tiling: object, tile: Record<string, unknown> = {}): object {
+  return {
+    asset: { version: '1.1' },
+    geometricError: 100,
+    root: {
+      boundingVolume: BOX,
+      geometricError: 100,
+      refine: 'ADD',
+      content: { uri: 'content/{level}/{x}/{y}.pnts' },
+      implicitTiling: {
+        subdivisionScheme: 'QUADTREE',
+        subtreeLevels: 2,
+        availableLevels: 2,
+        subtrees: { uri: 'subtrees/{level}/{x}/{y}.subtree' },
+        ...tiling,
+      },
+      ...tile,
+    },
+  };
+}
+
+/** One quadtree subtree covering two levels, everything present. */
+function fullQuadSubtree(): ArrayBuffer {
+  return makeSubtree({
+    tileAvailability: ALL_AVAILABLE,
+    contentAvailability: ALL_AVAILABLE,
+    childSubtreeAvailability: NONE_AVAILABLE,
+  });
+}
+
+const ROOT_SUBTREE_URL = 'https://tiles.example/data/subtrees/0/0/0.subtree';
+
+describe('3D Tiles implicit tiling: it opens', () => {
+  it('expands an implicit quadtree into an explicit hierarchy the parser accepts', async () => {
+    const { options, asked } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]));
+    const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
+    expect(asked).toEqual([ROOT_SUBTREE_URL]);
+    expect(tileset.root.contentUri).toBe('content/0/0/0.pnts');
+    expect(tileset.root.children.map((c) => c.contentUri).sort()).toEqual([
+      'content/1/0/0.pnts',
+      'content/1/0/1.pnts',
+      'content/1/1/0.pnts',
+      'content/1/1/1.pnts',
+    ]);
+  });
+
+  it('halves the geometric error once per level, from the implicit root down', async () => {
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]));
+    const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
+    expect(tileset.root.geometricError).toBe(100);
+    for (const child of tileset.root.children) expect(child.geometricError).toBe(50);
+  });
+
+  it('subdivides the root box exactly, quarter by quarter', async () => {
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]));
+    const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
+    // QUADTREE halves x and y and leaves z whole, so each child is a 4x4x8
+    // quarter column and the four centres are the four (±4, ±4, 0) corners.
+    const centres = tileset.root.children
+      .map((c) => (c.boundingVolume.box as number[]).slice(0, 3).join(','))
+      .sort();
+    expect(centres).toEqual(['-4,-4,0', '-4,4,0', '4,-4,0', '4,4,0']);
+    for (const child of tileset.root.children) {
+      const box = child.boundingVolume.box as number[];
+      expect(box.slice(3)).toEqual([4, 0, 0, 0, 4, 0, 0, 0, 8]);
+    }
+  });
+
+  it('expands an OCTREE tree, substituting {z} into both templates', async () => {
+    const bodies: Bodies = new Map([
+      [
+        'https://tiles.example/data/s/0/0/0/0.subtree',
+        makeSubtree({
+          tileAvailability: ALL_AVAILABLE,
+          contentAvailability: ALL_AVAILABLE,
+          childSubtreeAvailability: NONE_AVAILABLE,
+        }),
+      ],
+    ]);
+    const { options } = serve(bodies);
+    const doc = implicitDoc(
+      {
+        subdivisionScheme: 'OCTREE',
+        subtrees: { uri: 's/{level}/{x}/{y}/{z}.subtree' },
+      },
+      { content: { uri: 'c/{level}/{x}/{y}/{z}.pnts' } },
+    );
+    const tileset = parseTileset(await expandImplicitTileset(doc, options));
+    expect(tileset.root.contentUri).toBe('c/0/0/0/0.pnts');
+    expect(tileset.root.children).toHaveLength(8);
+    expect(tileset.root.children.map((c) => c.contentUri)).toContain('c/1/1/1/1.pnts');
+    // OCTREE halves all three axes, so every half-axis is four.
+    const box = tileset.root.children[0]!.boundingVolume.box as number[];
+    expect(box).toEqual([-4, -4, -4, 4, 0, 0, 0, 4, 0, 0, 0, 4]);
+  });
+
+  it('subdivides a region volume rather than refusing it', async () => {
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]));
+    const doc = implicitDoc({}, { boundingVolume: { region: [-1, -1, 1, 1, 0, 100] } });
+    const tileset = parseTileset(await expandImplicitTileset(doc, options));
+    const regions = tileset.root.children.map((c) => (c.boundingVolume.region as number[]).join(','));
+    // Longitude and latitude halve at zero; the height range stays whole under
+    // QUADTREE subdivision.
+    expect(regions.sort()).toEqual([
+      '-1,-1,0,0,0,100',
+      '-1,0,0,1,0,100',
+      '0,-1,1,0,0,100',
+      '0,0,1,1,0,100',
+    ]);
+  });
+
+  it('leaves a document that declares no implicit tiling untouched', async () => {
+    const explicit = {
+      asset: { version: '1.1' },
+      geometricError: 100,
+      root: { boundingVolume: BOX, geometricError: 10, refine: 'ADD', content: { uri: 'a.pnts' } },
+    };
+    const { options, asked } = serve(new Map());
+    expect(await expandImplicitTileset(explicit, options)).toEqual(explicit);
+    expect(asked).toEqual([]);
+  });
+});
+
+describe('3D Tiles implicit tiling: availability decides what exists', () => {
+  it('omits tiles whose availability bit is clear', async () => {
+    // Five bits: index 0 is the root, and indices 1..4 are the four level-1
+    // children in Morton order, so index 1 + m addresses the child whose Morton
+    // index within its level is m. Bits 0 and 2 set means the root, and the
+    // child at Morton index 1, which is (x=1, y=0).
+    const body = makeSubtree(
+      {
+        buffers: [{ byteLength: 1 }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 1 }],
+        tileAvailability: { bitstream: 0 },
+        contentAvailability: ALL_AVAILABLE,
+        childSubtreeAvailability: NONE_AVAILABLE,
+      },
+      { binary: bitstream([true, false, true, false, false], 5) },
+    );
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, body]]));
+    const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
+    expect(tileset.root.children.map((c) => c.contentUri)).toEqual(['content/1/1/0.pnts']);
+  });
+
+  it('gives a tile no content when only its content bit is clear', async () => {
+    const body = makeSubtree(
+      {
+        buffers: [{ byteLength: 1 }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 1 }],
+        tileAvailability: ALL_AVAILABLE,
+        contentAvailability: [{ bitstream: 0 }],
+        childSubtreeAvailability: NONE_AVAILABLE,
+      },
+      // The root has no content; all four children do.
+      { binary: bitstream([false, true, true, true, true], 5) },
+    );
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, body]]));
+    const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
+    expect(tileset.root.contentUri).toBeNull();
+    expect(tileset.root.children).toHaveLength(4);
+    expect(tileset.root.children.every((c) => c.contentUri !== null)).toBe(true);
+  });
+
+  it('follows an available child subtree into a second subtree file', async () => {
+    // Two levels per subtree, four levels in the tree. The root subtree covers
+    // levels 0 and 1; the child subtree it names covers levels 2 and 3.
+    const root = makeSubtree(
+      {
+        buffers: [{ byteLength: 2 }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 2 }],
+        tileAvailability: ALL_AVAILABLE,
+        contentAvailability: ALL_AVAILABLE,
+        childSubtreeAvailability: { bitstream: 0 },
+      },
+      // Sixteen child-subtree roots at level 2; only Morton index 0, which is
+      // (x=0, y=0), is available.
+      { binary: bitstream([true], 16) },
+    );
+    const child = makeSubtree({
+      tileAvailability: ALL_AVAILABLE,
+      contentAvailability: ALL_AVAILABLE,
+      childSubtreeAvailability: NONE_AVAILABLE,
+    });
+    const bodies: Bodies = new Map([
+      [ROOT_SUBTREE_URL, root],
+      ['https://tiles.example/data/subtrees/2/0/0.subtree', child],
+    ]);
+    const { options, asked } = serve(bodies);
+    const tileset = parseTileset(
+      await expandImplicitTileset(implicitDoc({ availableLevels: 4 }), options),
+    );
+    expect(asked).toEqual([
+      ROOT_SUBTREE_URL,
+      'https://tiles.example/data/subtrees/2/0/0.subtree',
+    ]);
+    const level1 = tileset.root.children;
+    expect(level1).toHaveLength(4);
+    // Only the (0,0) branch continues; the other three level-1 tiles are leaves.
+    const withChildren = level1.filter((c) => c.children.length > 0);
+    expect(withChildren).toHaveLength(1);
+    expect(withChildren[0]!.contentUri).toBe('content/1/0/0.pnts');
+    const level2 = withChildren[0]!.children;
+    expect(level2.map((c) => c.contentUri)).toEqual(['content/2/0/0.pnts']);
+    expect(level2[0]!.children.map((c) => c.contentUri).sort()).toEqual([
+      'content/3/0/0.pnts',
+      'content/3/0/1.pnts',
+      'content/3/1/0.pnts',
+      'content/3/1/1.pnts',
+    ]);
+    // Ten tiles: 1 + 4 + 1 + 4, and the geometric error still halves per level.
+    expect(level2[0]!.geometricError).toBe(25);
+    expect(level2[0]!.children[0]!.geometricError).toBe(12.5);
+  });
+
+  it('stops at availableLevels rather than descending past the tree it declares', async () => {
+    const { options, asked } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]));
+    // availableLevels 1 means the tree is the root alone, so the level-1 bits
+    // in the subtree describe tiles the document says are not addressable.
+    const tileset = parseTileset(
+      await expandImplicitTileset(implicitDoc({ availableLevels: 1 }), options),
+    );
+    expect(tileset.root.children).toEqual([]);
+    expect(asked).toEqual([ROOT_SUBTREE_URL]);
+  });
+
+  it('leaves an implicit root with no tree when its own availability bit is clear', async () => {
+    const body = makeSubtree(
+      {
+        buffers: [{ byteLength: 1 }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 1 }],
+        tileAvailability: { bitstream: 0 },
+        contentAvailability: ALL_AVAILABLE,
+        childSubtreeAvailability: NONE_AVAILABLE,
+      },
+      { binary: bitstream([false, true, true, true, true], 5) },
+    );
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, body]]));
+    const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
+    expect(tileset.root.contentUri).toBeNull();
+    expect(tileset.root.children).toEqual([]);
+  });
+
+  it('refuses a child subtree its parent promised but whose own root is absent', async () => {
+    const root = makeSubtree(
+      {
+        buffers: [{ byteLength: 2 }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 2 }],
+        tileAvailability: ALL_AVAILABLE,
+        childSubtreeAvailability: { bitstream: 0 },
+      },
+      { binary: bitstream([true], 16) },
+    );
+    const child = makeSubtree({
+      tileAvailability: NONE_AVAILABLE,
+      childSubtreeAvailability: NONE_AVAILABLE,
+    });
+    const { options } = serve(
+      new Map([
+        [ROOT_SUBTREE_URL, root],
+        ['https://tiles.example/data/subtrees/2/0/0.subtree', child],
+      ]),
+    );
+    await expect(
+      expandImplicitTileset(implicitDoc({ availableLevels: 4 }), options),
+    ).rejects.toThrow(/declared available by its parent but states its own root tile is not/);
+  });
+});
+
+describe('3D Tiles implicit tiling: external availability buffers', () => {
+  const subtreeWithExternal = (uri: string) =>
+    makeSubtree({
+      buffers: [{ uri, byteLength: 1 }],
+      bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 1 }],
+      tileAvailability: { bitstream: 0 },
+      contentAvailability: ALL_AVAILABLE,
+      childSubtreeAvailability: NONE_AVAILABLE,
+    });
+
+  it('fetches a buffer named beside the subtree file and reads availability from it', async () => {
+    const bits = bitstream([true, false, true, false, false], 5);
+    const bodies: Bodies = new Map([
+      [ROOT_SUBTREE_URL, subtreeWithExternal('availability.bin')],
+      [
+        'https://tiles.example/data/subtrees/0/0/availability.bin',
+        bits.buffer.slice(0, 1) as ArrayBuffer,
+      ],
+    ]);
+    const { options, asked } = serve(bodies);
+    const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
+    // The buffer URI is relative to the SUBTREE file, not to the tileset root.
+    expect(asked[1]).toBe('https://tiles.example/data/subtrees/0/0/availability.bin');
+    // Bits 0 and 2 set: the root, and the level-1 child at Morton index 1,
+    // which is (x=1, y=0).
+    expect(tileset.root.children.map((c) => c.contentUri)).toEqual(['content/1/1/0.pnts']);
+  });
+
+  it('refuses an availability buffer that escapes the tileset directory', async () => {
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, subtreeWithExternal('../../../../secret.bin')]]));
+    await expect(expandImplicitTileset(implicitDoc({}), options)).rejects.toThrow(
+      /escapes the tileset directory \(\/secret\.bin\)/,
+    );
+  });
+
+  it('refuses an availability buffer on another host', async () => {
+    const { options } = serve(
+      new Map([[ROOT_SUBTREE_URL, subtreeWithExternal('https://evil.example/a.bin')]]),
+    );
+    await expect(expandImplicitTileset(implicitDoc({}), options)).rejects.toThrow(
+      /points outside the tileset's own host \(evil\.example\)/,
+    );
+  });
+});
+
+describe('3D Tiles implicit tiling: subtree URLs go through the tile-content gate', () => {
+  /** What `resolveTilesetContentUrl` says about the same URI, for comparison. */
+  function explicitRefusal(uri: string): string {
+    const check = resolveTilesetContentUrl(BASE, uri);
+    if (check.ok) throw new Error(`${uri} was not refused on the explicit path`);
+    return check.reason;
+  }
+
+  const cases: readonly { readonly name: string; readonly template: string }[] = [
+    { name: 'another host', template: 'https://evil.example/s/{level}/{x}/{y}.subtree' },
+    { name: 'a protocol-relative host', template: '//evil.example/s/{level}/{x}/{y}.subtree' },
+    { name: 'a directory escape', template: '../../../etc/{level}/{x}/{y}.subtree' },
+    { name: 'a data: payload', template: 'data:application/octet-stream,{level}{x}{y}' },
+    {
+      name: 'embedded credentials',
+      template: 'https://user:secret@tiles.example/data/s/{level}/{x}/{y}.subtree',
+    },
+  ];
+
+  for (const { name, template } of cases) {
+    it(`refuses a subtree URI naming ${name}, with the refusal the explicit path gives`, async () => {
+      const { options, asked } = serve(new Map());
+      // The template substituted at the root coordinate is what would be fetched.
+      const substituted = substituteTemplateUri(template, 'QUADTREE', { level: 0, x: 0, y: 0 });
+      const reason = explicitRefusal(substituted);
+      await expect(
+        expandImplicitTileset(implicitDoc({ subtrees: { uri: template } }), options),
+      ).rejects.toThrow(reason);
+      // Refused before a byte is requested, not after.
+      expect(asked).toEqual([]);
+    });
+  }
+
+  it('refuses a subtree URI longer than the content-URI ceiling', async () => {
+    const template = `${'a'.repeat(2048)}/{level}/{x}/{y}.subtree`;
+    const { options, asked } = serve(new Map());
+    await expect(
+      expandImplicitTileset(implicitDoc({ subtrees: { uri: template } }), options),
+    ).rejects.toThrow(/longer than 1024 characters/);
+    expect(asked).toEqual([]);
+  });
+
+  it('carries the entry URL query onto subtree requests, as tile requests carry it', async () => {
+    const bodies: Bodies = new Map([
+      [`${ROOT_SUBTREE_URL}?token=abc`, fullQuadSubtree()],
+    ]);
+    const { options, asked } = serve(bodies, { entryUrl: `${ENTRY}?token=abc` });
+    await expandImplicitTileset(implicitDoc({}), options);
+    expect(asked).toEqual([`${ROOT_SUBTREE_URL}?token=abc`]);
+  });
+});
+
+describe('3D Tiles implicit tiling: ceilings refuse rather than truncate', () => {
+  it('refuses more subtree files than the ceiling, and says the ceiling', async () => {
+    const root = makeSubtree(
+      {
+        buffers: [{ byteLength: 2 }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 2 }],
+        tileAvailability: ALL_AVAILABLE,
+        childSubtreeAvailability: { bitstream: 0 },
+      },
+      { binary: bitstream([true, true], 16) },
+    );
+    const child = makeSubtree({
+      tileAvailability: ALL_AVAILABLE,
+      childSubtreeAvailability: NONE_AVAILABLE,
+    });
+    const bodies: Bodies = new Map([
+      [ROOT_SUBTREE_URL, root],
+      ['https://tiles.example/data/subtrees/2/0/0.subtree', child],
+      ['https://tiles.example/data/subtrees/2/1/0.subtree', child],
+    ]);
+    const { options } = serve(bodies, { maxSubtrees: 2 });
+    await expect(
+      expandImplicitTileset(implicitDoc({ availableLevels: 4 }), options),
+    ).rejects.toThrow(/needs more than 2 subtree files; refusing to expand it/);
+  });
+
+  it('refuses an expansion larger than the tile ceiling, and says the ceiling', async () => {
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]), { maxTiles: 3 });
+    await expect(expandImplicitTileset(implicitDoc({}), options)).rejects.toThrow(
+      /expands to more than 3 tiles; refusing to expand it/,
+    );
+  });
+
+  it('refuses a subtree body larger than the byte ceiling, and says the ceiling', async () => {
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]), {
+      maxSubtreeBytes: 16,
+    });
+    await expect(expandImplicitTileset(implicitDoc({}), options)).rejects.toThrow(
+      /bytes, above the ceiling of 16; refusing to read it/,
+    );
+  });
+
+  it('states the shipped ceilings, so a change to one is a change to this test', () => {
+    expect(MAX_IMPLICIT_SUBTREES).toBe(512);
+    expect(MAX_IMPLICIT_TILES).toBe(100_000);
+  });
+
+  it('refuses an availableLevels above the expansion ceiling', async () => {
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]));
+    await expect(
+      expandImplicitTileset(implicitDoc({ availableLevels: 25 }), options),
+    ).rejects.toThrow(/25 availableLevels, above the ceiling of 24; refusing to expand it/);
+  });
+});
+
+describe('3D Tiles implicit tiling: forms refused by name', () => {
+  const refuse = async (doc: object, pattern: RegExp, bodies: Bodies = new Map()) => {
+    const { options } = serve(bodies);
+    await expect(expandImplicitTileset(doc, options)).rejects.toThrow(pattern);
+  };
+
+  it('refuses a sphere bounding volume, which has no exact subdivision', async () => {
+    await refuse(
+      implicitDoc({}, { boundingVolume: { sphere: [0, 0, 0, 10] } }),
+      /sphere bounding volume, which has no exact subdivision/,
+    );
+  });
+
+  it('refuses a tile that declares both implicitTiling and children', async () => {
+    await refuse(
+      implicitDoc({}, { children: [{ boundingVolume: BOX, geometricError: 1 }] }),
+      /both implicitTiling and children, which state two different hierarchies/,
+    );
+  });
+
+  it('refuses an implicit tile with no content template', async () => {
+    const doc = implicitDoc({}) as { root: Record<string, unknown> };
+    delete doc.root.content;
+    await refuse(doc, /names no content template/);
+  });
+
+  it('refuses a subdivision scheme that is neither QUADTREE nor OCTREE', async () => {
+    await refuse(
+      implicitDoc({ subdivisionScheme: 'KDTREE' }),
+      /subdivisionScheme "KDTREE", which is not QUADTREE or OCTREE/,
+    );
+  });
+
+  it('names the extension maximumLevel spelling rather than reading it as availableLevels', () => {
+    expect(() =>
+      parseImplicitTiling({
+        subdivisionScheme: 'QUADTREE',
+        subtreeLevels: 2,
+        maximumLevel: 3,
+        subtrees: { uri: 's/{level}/{x}/{y}.subtree' },
+      }),
+    ).toThrow(/`maximumLevel` rather than 1.1's `availableLevels`/);
+  });
+
+  it('refuses an implicitTiling with no subtrees URI', () => {
+    expect(() =>
+      parseImplicitTiling({ subdivisionScheme: 'QUADTREE', subtreeLevels: 2, availableLevels: 2 }),
+    ).toThrow(/subtrees.uri is not a non-empty string/);
+  });
+
+  it('refuses subtreeLevels below one', () => {
+    expect(() =>
+      parseImplicitTiling({
+        subdivisionScheme: 'QUADTREE',
+        subtreeLevels: 0,
+        availableLevels: 2,
+        subtrees: { uri: 's/{level}.subtree' },
+      }),
+    ).toThrow(/subtreeLevels is not an integer of at least 1/);
+  });
+});
+
+describe('3D Tiles implicit tiling: template substitution', () => {
+  it('substitutes each placeholder with its decimal ordinate', () => {
+    expect(
+      substituteTemplateUri('t/{level}-{x}-{y}.pnts', 'QUADTREE', { level: 3, x: 5, y: 7 }),
+    ).toBe('t/3-5-7.pnts');
+    expect(
+      substituteTemplateUri('t/{level}/{x}/{y}/{z}.pnts', 'OCTREE', {
+        level: 2,
+        x: 1,
+        y: 2,
+        z: 3,
+      }),
+    ).toBe('t/2/1/2/3.pnts');
+  });
+
+  it('substitutes a placeholder that appears more than once', () => {
+    expect(substituteTemplateUri('{level}/{level}/{x}.pnts', 'QUADTREE', { level: 4, x: 1, y: 0 })).toBe(
+      '4/4/1.pnts',
+    );
+  });
+
+  it('refuses {z} in a QUADTREE template, which has no z to substitute', () => {
+    expect(() =>
+      substituteTemplateUri('t/{level}/{x}/{y}/{z}.pnts', 'QUADTREE', { level: 1, x: 0, y: 0 }),
+    ).toThrow(/substitutes \{z\}, which a QUADTREE coordinate does not have/);
+  });
+
+  it('refuses a placeholder it does not substitute rather than fetching it literally', () => {
+    expect(() =>
+      substituteTemplateUri('t/{level}/{face}.pnts', 'QUADTREE', { level: 1, x: 0, y: 0 }),
+    ).toThrow(/carries the placeholder "\{face\}", which this reader does not substitute/);
+  });
+
+  it('refuses a template with no placeholder at all', () => {
+    expect(() => substituteTemplateUri('t/all.pnts', 'QUADTREE', { level: 0, x: 0, y: 0 })).toThrow(
+      /names one file for the whole tree/,
+    );
+  });
+});
+
+describe('3D Tiles implicit tiling: the seam with the explicit reader', () => {
+  it('still refuses an unexpanded implicit document at parse', () => {
+    expect(() => parseTileset(implicitDoc({}))).toThrow(/implicit tiling/);
+  });
+
+  it('builds the same node index an authored hierarchy would', async () => {
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]));
+    const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
+    const index = tilesetNodes(tileset, undefined, ENTRY);
+    expect(index.skipped).toEqual([]);
+    expect(index.records).toHaveLength(5);
+    // Depth, parentage and the resolved absolute URL are what the scheduler
+    // reads; none of them can tell an expanded tile from an authored one.
+    expect(index.records[0]!.depth).toBe(0);
+    expect(index.records[1]!.parentId).toBe('content/0/0/0.pnts');
+    expect(index.contentUri.get('content/1/1/1.pnts')).toBe(
+      'https://tiles.example/data/content/1/1/1.pnts',
+    );
+  });
+
+  it('applies the parser tile ceiling to an expansion, as it does to an authored tree', async () => {
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]));
+    const expanded = await expandImplicitTileset(implicitDoc({}), options);
+    expect(() => parseTileset(expanded, { maxTiles: 3 })).toThrow(
+      /more than 3 tiles; refusing to parse it/,
+    );
+  });
+
+  it('reports an expanded content URI that leaves the tileset, rather than fetching it', async () => {
+    const { options } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]));
+    const doc = implicitDoc({}, { content: { uri: 'https://evil.example/{level}/{x}/{y}.pnts' } });
+    const tileset = parseTileset(await expandImplicitTileset(doc, options));
+    const index = tilesetNodes(tileset, undefined, ENTRY);
+    expect(index.records).toHaveLength(0);
+    expect(index.skipped[0]).toMatch(/points outside the tileset's own host/);
+  });
+
+  it('stops on an aborted signal before it fetches anything', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { options, asked } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]), {
+      signal: controller.signal,
+    });
+    await expect(expandImplicitTileset(implicitDoc({}), options)).rejects.toThrow();
+    expect(asked).toEqual([]);
+  });
+});

--- a/tests/tiles3dSubtree.test.ts
+++ b/tests/tiles3dSubtree.test.ts
@@ -1,0 +1,395 @@
+/**
+ * tiles3dSubtree.test.ts — the `.subtree` binary reader.
+ *
+ * A subtree file is the only part of an implicit tileset that states fact
+ * rather than rule, so every wrong answer this reader could give is a tile
+ * reported present that is not, or absent that is. The cases below are the ways
+ * that happens: a constant read as a bitstream, a bitstream located in the
+ * wrong buffer, a bitstream sized for a different subtree shape, and a body
+ * whose header promises more than it carries.
+ *
+ * Every expected number is hand-computed from the stated rule. A QUADTREE
+ * subtree of 2 levels addresses 1 + 4 = 5 tiles and 16 child-subtree roots; an
+ * OCTREE subtree of 2 levels addresses 1 + 8 = 9 tiles and 64 child roots.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  readSubtreeDocument,
+  resolveSubtreeAvailability,
+  subtreeExternalBuffers,
+  subtreeTileCount,
+  subtreeChildCount,
+  MAX_SUBTREE_LEVELS,
+  MAX_TILES_PER_SUBTREE,
+  MAX_SUBTREE_EXTERNAL_BUFFERS,
+  type SubtreeShape,
+} from '../src/io/tiles3d/subtree';
+import { isAvailable } from '../src/io/tiles3d/implicitCoordinates';
+import { makeSubtree, bitstream, ALL_AVAILABLE, NONE_AVAILABLE } from './fixtures/subtree3d';
+
+const QUAD2: SubtreeShape = { scheme: 'QUADTREE', subtreeLevels: 2 };
+const OCT2: SubtreeShape = { scheme: 'OCTREE', subtreeLevels: 2 };
+
+/** Read a body and resolve it in one step, for the cases with no external buffer. */
+function read(body: ArrayBuffer, shape: SubtreeShape = QUAD2) {
+  return resolveSubtreeAvailability(readSubtreeDocument(body), shape);
+}
+
+describe('subtree shape arithmetic', () => {
+  it('counts the tiles and child roots each scheme addresses', () => {
+    expect(subtreeTileCount(QUAD2)).toBe(5);
+    expect(subtreeChildCount(QUAD2)).toBe(16);
+    expect(subtreeTileCount(OCT2)).toBe(9);
+    expect(subtreeChildCount(OCT2)).toBe(64);
+    expect(subtreeTileCount({ scheme: 'QUADTREE', subtreeLevels: 1 })).toBe(1);
+  });
+});
+
+describe('subtree availability: constants', () => {
+  it('reads an all-available constant as available at every index', () => {
+    const a = read(
+      makeSubtree({
+        tileAvailability: ALL_AVAILABLE,
+        contentAvailability: ALL_AVAILABLE,
+        childSubtreeAvailability: NONE_AVAILABLE,
+      }),
+    );
+    expect(a.tileCount).toBe(5);
+    expect(a.childSubtreeCount).toBe(16);
+    for (let i = 0; i < 5; i++) expect(isAvailable(a.tile, i)).toBe(true);
+    expect(isAvailable(a.childSubtree, 15)).toBe(false);
+  });
+
+  it('carries the tile count as the availability length, so an index past it throws', () => {
+    const a = read(
+      makeSubtree({ tileAvailability: ALL_AVAILABLE, childSubtreeAvailability: NONE_AVAILABLE }),
+    );
+    expect(() => isAvailable(a.tile, 5)).toThrow(/outside the 5 tiles covered/);
+  });
+
+  it('reports no content when the document states none', () => {
+    const a = read(
+      makeSubtree({ tileAvailability: ALL_AVAILABLE, childSubtreeAvailability: NONE_AVAILABLE }),
+    );
+    expect(a.content).toBeNull();
+  });
+});
+
+describe('subtree availability: internal bitstreams', () => {
+  /** Root plus the first and last of its four children. */
+  const PATTERN = [true, true, false, false, true];
+
+  it('reads a bitstream out of the internal binary chunk, LSB-first', () => {
+    const bits = bitstream(PATTERN, 5);
+    // 1 + 2 + 16 = 19: bit 0, bit 1 and bit 4 set in the single byte.
+    expect(bits[0]).toBe(0b10011);
+    const a = read(
+      makeSubtree(
+        {
+          buffers: [{ byteLength: 1 }],
+          bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 1 }],
+          tileAvailability: { bitstream: 0 },
+          childSubtreeAvailability: NONE_AVAILABLE,
+        },
+        { binary: bits },
+      ),
+    );
+    expect([0, 1, 2, 3, 4].map((i) => isAvailable(a.tile, i))).toEqual(PATTERN);
+  });
+
+  it('reads a bitstream at a non-zero bufferView offset', () => {
+    const binary = new Uint8Array([0xff, 0b10011]);
+    const a = read(
+      makeSubtree(
+        {
+          buffers: [{ byteLength: 2 }],
+          bufferViews: [{ buffer: 0, byteOffset: 1, byteLength: 1 }],
+          tileAvailability: { bitstream: 0 },
+          childSubtreeAvailability: NONE_AVAILABLE,
+        },
+        { binary },
+      ),
+    );
+    expect([0, 1, 2, 3, 4].map((i) => isAvailable(a.tile, i))).toEqual(PATTERN);
+  });
+
+  it('reads an OCTREE subtree at its own wider shape', () => {
+    // Nine tiles need two bytes; sixty-four child roots need eight.
+    const a = read(
+      makeSubtree(
+        {
+          buffers: [{ byteLength: 2 }],
+          bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 2 }],
+          tileAvailability: { bitstream: 0 },
+          childSubtreeAvailability: NONE_AVAILABLE,
+        },
+        { binary: bitstream([true, false, false, false, false, false, false, false, true], 9) },
+      ),
+      OCT2,
+    );
+    expect(a.tileCount).toBe(9);
+    expect(isAvailable(a.tile, 0)).toBe(true);
+    expect(isAvailable(a.tile, 8)).toBe(true);
+    expect(isAvailable(a.tile, 4)).toBe(false);
+  });
+});
+
+describe('subtree availability: external bitstream buffers', () => {
+  const doc = () =>
+    readSubtreeDocument(
+      makeSubtree({
+        buffers: [{ uri: 'availability.bin', byteLength: 1 }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 1 }],
+        tileAvailability: { bitstream: 0 },
+        childSubtreeAvailability: NONE_AVAILABLE,
+      }),
+    );
+
+  it('reports the external buffer a caller must fetch, without fetching it', () => {
+    expect(subtreeExternalBuffers(doc())).toEqual([
+      { index: 0, uri: 'availability.bin', byteLength: 1 },
+    ]);
+  });
+
+  it('reads the bitstream out of the buffer the caller supplies', () => {
+    const a = resolveSubtreeAvailability(
+      doc(),
+      QUAD2,
+      new Map([[0, bitstream([true, false, true, false, true], 5)]]),
+    );
+    expect([0, 1, 2, 3, 4].map((i) => isAvailable(a.tile, i))).toEqual([
+      true,
+      false,
+      true,
+      false,
+      true,
+    ]);
+  });
+
+  it('refuses when an external buffer was never supplied', () => {
+    expect(() => resolveSubtreeAvailability(doc(), QUAD2)).toThrow(
+      /buffer 0 is external and was not supplied/,
+    );
+  });
+
+  it('refuses an external buffer shorter than the document declares', () => {
+    expect(() =>
+      resolveSubtreeAvailability(doc(), QUAD2, new Map([[0, new Uint8Array(0)]])),
+    ).toThrow(/declares 1 bytes but 0 were available; it is truncated/);
+  });
+
+  it('refuses more external buffers than the ceiling allows', () => {
+    const buffers = Array.from({ length: MAX_SUBTREE_EXTERNAL_BUFFERS + 1 }, (_, i) => ({
+      uri: `b${i}.bin`,
+      byteLength: 1,
+    }));
+    expect(() =>
+      subtreeExternalBuffers(
+        readSubtreeDocument(
+          makeSubtree({
+            buffers,
+            tileAvailability: ALL_AVAILABLE,
+            childSubtreeAvailability: NONE_AVAILABLE,
+          }),
+        ),
+      ),
+    ).toThrow(/external buffers is above the ceiling of 8; refusing/);
+  });
+});
+
+describe('subtree container: malformed headers', () => {
+  it('refuses a body shorter than the header', () => {
+    expect(() => readSubtreeDocument(new Uint8Array(12))).toThrow(
+      /12 bytes, shorter than the 24-byte header/,
+    );
+  });
+
+  it('refuses a body that does not carry the subt magic, and says what it saw', () => {
+    const body = makeSubtree(
+      { tileAvailability: ALL_AVAILABLE, childSubtreeAvailability: NONE_AVAILABLE },
+      { magic: 'glTF' },
+    );
+    expect(() => readSubtreeDocument(body)).toThrow(/does not start with the "subt" magic \(found "glTF"\)/);
+  });
+
+  it('refuses a container version it does not implement', () => {
+    const body = makeSubtree(
+      { tileAvailability: ALL_AVAILABLE, childSubtreeAvailability: NONE_AVAILABLE },
+      { version: 2 },
+    );
+    expect(() => readSubtreeDocument(body)).toThrow(/version 2 is not the version 1/);
+  });
+
+  it('refuses a header whose chunk lengths overrun the body', () => {
+    const body = makeSubtree(
+      { tileAvailability: ALL_AVAILABLE, childSubtreeAvailability: NONE_AVAILABLE },
+      { binaryByteLength: 4096 },
+    );
+    expect(() => readSubtreeDocument(body)).toThrow(/it is truncated/);
+  });
+
+  it('refuses a body cut short of the length its header declares', () => {
+    const body = makeSubtree(
+      { tileAvailability: ALL_AVAILABLE, childSubtreeAvailability: NONE_AVAILABLE },
+      { truncateTo: 30 },
+    );
+    expect(() => readSubtreeDocument(body)).toThrow(/it is truncated/);
+  });
+
+  it('refuses an empty JSON chunk', () => {
+    const body = makeSubtree(
+      { tileAvailability: ALL_AVAILABLE, childSubtreeAvailability: NONE_AVAILABLE },
+      { jsonByteLength: 0 },
+    );
+    expect(() => readSubtreeDocument(body)).toThrow(/JSON chunk is empty/);
+  });
+
+  it('refuses a JSON chunk that is not valid JSON', () => {
+    const good = new Uint8Array(
+      makeSubtree({ tileAvailability: ALL_AVAILABLE, childSubtreeAvailability: NONE_AVAILABLE }),
+    );
+    good[24] = 0x7b; // an opening brace with no close
+    good[25] = 0x7b;
+    expect(() => readSubtreeDocument(good)).toThrow(/is not valid JSON/);
+  });
+});
+
+describe('subtree availability: shape disagreements', () => {
+  it('refuses a bitstream sized for a different number of levels', () => {
+    // One byte covers the five tiles of a 2-level quadtree. Read at 3 levels
+    // the same subtree addresses 21 tiles and needs three.
+    const body = makeSubtree(
+      {
+        buffers: [{ byteLength: 1 }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 1 }],
+        tileAvailability: { bitstream: 0 },
+        childSubtreeAvailability: NONE_AVAILABLE,
+      },
+      { binary: bitstream([true], 5) },
+    );
+    expect(() =>
+      resolveSubtreeAvailability(readSubtreeDocument(body), {
+        scheme: 'QUADTREE',
+        subtreeLevels: 3,
+      }),
+    ).toThrow(/is 1 bytes but the 21 tiles it must describe need 3; the bitstream disagrees/);
+  });
+
+  it('refuses a bufferView that runs past the end of its buffer', () => {
+    const body = makeSubtree(
+      {
+        buffers: [{ byteLength: 1 }],
+        bufferViews: [{ buffer: 0, byteOffset: 4, byteLength: 1 }],
+        tileAvailability: { bitstream: 0 },
+        childSubtreeAvailability: NONE_AVAILABLE,
+      },
+      { binary: new Uint8Array(1) },
+    );
+    expect(() => resolveSubtreeAvailability(readSubtreeDocument(body), QUAD2)).toThrow(
+      /runs past the end of buffer 0/,
+    );
+  });
+
+  it('refuses a bitstream naming a bufferView that does not exist', () => {
+    const body = makeSubtree({
+      bufferViews: [],
+      tileAvailability: { bitstream: 3 },
+      childSubtreeAvailability: NONE_AVAILABLE,
+    });
+    expect(() => resolveSubtreeAvailability(readSubtreeDocument(body), QUAD2)).toThrow(
+      /names bufferView 3, which does not exist/,
+    );
+  });
+});
+
+describe('subtree availability: forms this reader does not implement', () => {
+  it('names the extension bufferView spelling rather than calling the document malformed', () => {
+    const body = makeSubtree({
+      bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 1 }],
+      buffers: [{ byteLength: 1 }],
+      tileAvailability: { bufferView: 0 },
+      childSubtreeAvailability: NONE_AVAILABLE,
+    });
+    expect(() => resolveSubtreeAvailability(readSubtreeDocument(body), QUAD2)).toThrow(
+      /3DTILES_implicit_tiling extension's `bufferView` key/,
+    );
+  });
+
+  it('refuses several contents per tile by name', () => {
+    const body = makeSubtree({
+      tileAvailability: ALL_AVAILABLE,
+      contentAvailability: [ALL_AVAILABLE, ALL_AVAILABLE],
+      childSubtreeAvailability: NONE_AVAILABLE,
+    });
+    expect(() => resolveSubtreeAvailability(readSubtreeDocument(body), QUAD2)).toThrow(
+      /declares 2 contents per tile, the 1.1 multi-content form/,
+    );
+  });
+
+  it('refuses an availability declaring both a constant and a bitstream', () => {
+    const body = makeSubtree({
+      tileAvailability: { constant: 1, bitstream: 0 },
+      childSubtreeAvailability: NONE_AVAILABLE,
+    });
+    expect(() => resolveSubtreeAvailability(readSubtreeDocument(body), QUAD2)).toThrow(
+      /declares both constant and bitstream/,
+    );
+  });
+
+  it('refuses an availability declaring neither', () => {
+    const body = makeSubtree({
+      tileAvailability: {},
+      childSubtreeAvailability: NONE_AVAILABLE,
+    });
+    expect(() => resolveSubtreeAvailability(readSubtreeDocument(body), QUAD2)).toThrow(
+      /declares neither constant nor bitstream/,
+    );
+  });
+
+  it('refuses a document with no tileAvailability at all', () => {
+    const body = makeSubtree({ childSubtreeAvailability: NONE_AVAILABLE });
+    expect(() => resolveSubtreeAvailability(readSubtreeDocument(body), QUAD2)).toThrow(
+      /declares no tileAvailability/,
+    );
+  });
+});
+
+describe('subtree ceilings refuse rather than truncate', () => {
+  const body = () =>
+    readSubtreeDocument(
+      makeSubtree({ tileAvailability: ALL_AVAILABLE, childSubtreeAvailability: NONE_AVAILABLE }),
+    );
+
+  it('refuses subtreeLevels above the structural ceiling, and says the ceiling', () => {
+    expect(() =>
+      resolveSubtreeAvailability(body(), {
+        scheme: 'QUADTREE',
+        subtreeLevels: MAX_SUBTREE_LEVELS + 1,
+      }),
+    ).toThrow(/subtreeLevels 25 is above the ceiling of 24; refusing/);
+  });
+
+  it('refuses a subtree describing more tiles than the ceiling, and says both numbers', () => {
+    // OCTREE at 8 levels addresses (8^8 - 1) / 7 = 2 396 745 tiles.
+    expect(() =>
+      resolveSubtreeAvailability(body(), { scheme: 'OCTREE', subtreeLevels: 8 }),
+    ).toThrow(
+      new RegExp(`describes 2396745 tiles, above the ceiling of ${MAX_TILES_PER_SUBTREE}; refusing`),
+    );
+  });
+
+  it('accepts a subtree just inside the tile ceiling', () => {
+    // OCTREE at 7 levels addresses (8^7 - 1) / 7 = 299 593 tiles.
+    expect(subtreeTileCount({ scheme: 'OCTREE', subtreeLevels: 7 })).toBe(299_593);
+    expect(() =>
+      resolveSubtreeAvailability(body(), { scheme: 'OCTREE', subtreeLevels: 7 }),
+    ).not.toThrow();
+  });
+
+  it('refuses subtreeLevels below one', () => {
+    expect(() =>
+      resolveSubtreeAvailability(body(), { scheme: 'QUADTREE', subtreeLevels: 0 }),
+    ).toThrow(/subtreeLevels must be an integer of at least 1/);
+  });
+});

--- a/tests/tiles3dTilesetCloud.test.ts
+++ b/tests/tiles3dTilesetCloud.test.ts
@@ -84,6 +84,11 @@ function fakeTransport(
       if (body === undefined) throw new Error(`3D Tiles tileset fetch failed (404) for ${url}`);
       return body;
     },
+    // An explicit hierarchy asks for no subtree, so a request for one here would
+    // be the reader inventing work rather than a case this test set up.
+    fetchSubtreeBytes: async () => {
+      throw new Error('this tileset states an explicit hierarchy; no subtree exists');
+    },
     fetchTileBytes: async (url) => {
       requests.push(url);
       const body = tiles[url];

--- a/tests/tiles3dTilesetOpen.test.ts
+++ b/tests/tiles3dTilesetOpen.test.ts
@@ -83,6 +83,11 @@ function fakeTransport(
       if (body === undefined) throw new Error(`3D Tiles tileset fetch failed (404) for ${url}`);
       return body;
     },
+    // An explicit hierarchy asks for no subtree, so a request for one here would
+    // be the reader inventing work rather than a case this test set up.
+    fetchSubtreeBytes: async () => {
+      throw new Error('this tileset states an explicit hierarchy; no subtree exists');
+    },
     fetchTileBytes: async (url) => {
       requests.push(url);
       const body = tiles[url];
@@ -165,6 +170,11 @@ describe('openTileset', () => {
         // the window where a careless open would already hold a tileset.
         controller.abort();
         return doc(rawTile({ refine: 'REPLACE', content: { uri: '0.pnts' } }));
+      },
+      // An explicit hierarchy asks for no subtree, so a request for one here would
+      // be the reader inventing work rather than a case this test set up.
+      fetchSubtreeBytes: async () => {
+        throw new Error('this tileset states an explicit hierarchy; no subtree exists');
       },
       fetchTileBytes: async () => {
         throw new Error('no tile should be read on an aborted open');

--- a/tests/tiles3dTilesetTransport.test.ts
+++ b/tests/tiles3dTilesetTransport.test.ts
@@ -105,6 +105,37 @@ describe('createTilesetTransport — bounds and cancellation', () => {
     );
   });
 
+  test('refuses a subtree body past the ceiling, in its own vocabulary', async () => {
+    const h = scriptedFetch([{ status: 200, body: 'x'.repeat(4096) }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW, maxSubtreeBytes: 64 });
+    await expect(
+      t.fetchSubtreeBytes('https://tiles.example.org/scan/a/subtrees/0/0/0.subtree'),
+    ).rejects.toThrow(/3D Tiles subtree/);
+  });
+
+  test('a subtree read refuses a redirect and retries a transient status', async () => {
+    // The same discipline the tile read gets: availability is fetched from the
+    // same untrusted origin the tiles are, and a 3xx could send it to a host no
+    // block-list ever resolved.
+    const h = scriptedFetch([{ status: 503 }, { status: 200, body: 'ok' }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW });
+    const bytes = await t.fetchSubtreeBytes(
+      'https://tiles.example.org/scan/a/subtrees/0/0/0.subtree',
+    );
+    expect(bytes.byteLength).toBe(2);
+    expect(h.calls).toBe(2);
+    expect(h.init.every((i) => i.redirect === 'error')).toBe(true);
+  });
+
+  test('a subtree body arrives in an exact-size buffer', async () => {
+    const h = scriptedFetch([{ status: 200, body: 'subtree-bytes' }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW });
+    const bytes = await t.fetchSubtreeBytes(
+      'https://tiles.example.org/scan/a/subtrees/0/0/0.subtree',
+    );
+    expect(bytes.byteLength).toBe('subtree-bytes'.length);
+  });
+
   test('a stalled request surfaces as a timeout, not as a cancel', async () => {
     const h = neverAnsweringFetch();
     const t = createTilesetTransport({

--- a/tests/tilesetCeilings.test.ts
+++ b/tests/tilesetCeilings.test.ts
@@ -57,6 +57,11 @@ function fan(n: number): unknown {
 
 const transport = (): TilesetTransport => ({
   fetchTilesetJson: async () => '{}',
+  // An explicit hierarchy asks for no subtree, so a request for one here would
+  // be the reader inventing work rather than a case this test set up.
+  fetchSubtreeBytes: async () => {
+    throw new Error('this tileset states an explicit hierarchy; no subtree exists');
+  },
   fetchTileBytes: async () => new ArrayBuffer(8),
 });
 

--- a/tests/tilesetFrameUnknown.test.ts
+++ b/tests/tilesetFrameUnknown.test.ts
@@ -58,6 +58,11 @@ const REGION_DOC = JSON.stringify({
 function transport(): TilesetTransport {
   return {
     fetchTilesetJson: async () => '{}',
+    // An explicit hierarchy asks for no subtree, so a request for one here would
+    // be the reader inventing work rather than a case this test set up.
+    fetchSubtreeBytes: async () => {
+      throw new Error('this tileset states an explicit hierarchy; no subtree exists');
+    },
     fetchTileBytes: async () => new ArrayBuffer(8),
   };
 }

--- a/tests/tilesetSpatialFrame.test.ts
+++ b/tests/tilesetSpatialFrame.test.ts
@@ -100,6 +100,11 @@ function fakeTransport(
       if (body === undefined) throw new Error(`no tileset at ${url}`);
       return body;
     },
+    // An explicit hierarchy asks for no subtree, so a request for one here would
+    // be the reader inventing work rather than a case this test set up.
+    fetchSubtreeBytes: async () => {
+      throw new Error('this tileset states an explicit hierarchy; no subtree exists');
+    },
     fetchTileBytes: async (url) => {
       const body = tiles[url];
       if (body === undefined) throw new Error(`no tile at ${url}`);

--- a/tests/tilesetStreamingNormals.test.ts
+++ b/tests/tilesetStreamingNormals.test.ts
@@ -236,6 +236,11 @@ const TREE = parseTileset(
 
 const transport = (): TilesetTransport => ({
   fetchTilesetJson: async () => '{}',
+  // An explicit hierarchy asks for no subtree, so a request for one here would
+  // be the reader inventing work rather than a case this test set up.
+  fetchSubtreeBytes: async () => {
+    throw new Error('this tileset states an explicit hierarchy; no subtree exists');
+  },
   fetchTileBytes: async () => new ArrayBuffer(8),
 });
 

--- a/tests/tilesetStreamingSource.test.ts
+++ b/tests/tilesetStreamingSource.test.ts
@@ -41,6 +41,11 @@ function transport(): TilesetTransport & { readonly asked: string[] } {
   return {
     asked,
     fetchTilesetJson: async () => '{}',
+    // An explicit hierarchy asks for no subtree, so a request for one here would
+    // be the reader inventing work rather than a case this test set up.
+    fetchSubtreeBytes: async () => {
+      throw new Error('this tileset states an explicit hierarchy; no subtree exists');
+    },
     fetchTileBytes: async (url: string) => {
       asked.push(url);
       return new ArrayBuffer(8);


### PR DESCRIPTION
Adds a `.subtree` reader and an expansion pass for 3D Tiles 1.1 implicit
tiling. `subtree.ts` parses the 24 byte container, its JSON and binary chunks,
and the three availability fields, each a constant or a bitstream held in the
internal chunk or an external buffer. `implicitTiling.ts` validates the
descriptor and substitutes the coordinate placeholders.
`implicitExpand.ts` fetches subtrees and rewrites the document into an explicit
tileset, so `parseTileset` and `tilesetNodes` apply their existing refusals to
it unchanged.

Subtree and availability buffer URLs pass `resolveTilesetContentUrl`, the same
gate a tile content URI passes. Ceilings bound subtree levels, tiles per
subtree, external buffers, subtree files, expanded tiles and subtree bytes, and
each refuses by name. The three modules are registered as staged; no
application path reaches them yet, so `docs/supported-formats.md` is unchanged.
