### PR TITLE
perf(heavy): append OPFS spill tiles through a sync access handle

### DIFF
--- a/src/io/heavy/opfsSpillStore.ts
+++ b/src/io/heavy/opfsSpillStore.ts
@@ -12,8 +12,27 @@
  * it directly in the browser, and a small in-memory fake satisfies it in a Node
  * test. OPFS itself is not available in Node, so the fake is how the append and
  * key-mapping logic is unit-tested; the real handle is exercised in the browser.
+ *
+ * WHY THE APPEND IS NOT A WRITABLE STREAM. `createWritable({ keepExistingData:
+ * true })` is specified to start its swap file as a COPY of the file it will
+ * replace, so appending to a tile costs the tile, not the append. A leaf touched
+ * once per flush cycle is therefore rewritten once per flush cycle, and a build
+ * that flushes thousands of times pays quadratically in the number of appends
+ * for a result that is linear in bytes. Measured in Chromium 142: thirty-two
+ * 4 KiB appends onto an empty file take 36 ms, onto a 64 MiB file 4120 ms, the
+ * same 128 KiB of payload either way. The primitive that does not do this is
+ * `FileSystemSyncAccessHandle` — open once, `write(bytes, { at })` many times,
+ * `close()` — which is what {@link opfsSpillStore} uses when it can get one.
+ *
+ * WHY THE WRITABLE PATH SURVIVES ANYWAY. `createSyncAccessHandle` is exposed
+ * only inside a worker (absent on Chromium's main thread, confirmed by probe)
+ * and is not implemented everywhere at all. So the store DETECTS the primitive
+ * on the handle it was given and falls back to the writable stream when it is
+ * missing or refuses to open. The choice is made from the handle, never from a
+ * user-agent string, and both paths write the same bytes in the same order.
  */
 import type { SpillStore } from './oocIndexer';
+import { TILE_MANIFEST_NAME } from './tileStoreBuilder';
 
 /** The OPFS surface this module uses; a subset the real handles already provide. */
 export interface OpfsWritable {
@@ -26,17 +45,56 @@ export interface OpfsFile {
   arrayBuffer(): Promise<ArrayBuffer>;
   text(): Promise<string>;
 }
+/**
+ * The worker-only random-access handle. Its methods are synchronous in the
+ * current specification and returned promises in earlier Chromium, so the
+ * results are typed as either and awaited; a real handle satisfies this either
+ * way, and awaiting a number is a no-op.
+ */
+export interface OpfsSyncAccessHandle {
+  write(data: Uint8Array, options?: { at?: number }): number | PromiseLike<number>;
+  getSize(): number | PromiseLike<number>;
+  flush(): void | PromiseLike<void>;
+  close(): void | PromiseLike<void>;
+}
 export interface OpfsFileHandle {
   getFile(): Promise<OpfsFile>;
   createWritable(options?: { keepExistingData?: boolean }): Promise<OpfsWritable>;
+  /** Present only where the platform implements it; see the header. */
+  createSyncAccessHandle?(): Promise<OpfsSyncAccessHandle>;
+  /**
+   * Relocate the file. Implemented for FILES in OPFS but not for directories,
+   * which is why {@link OpfsSpillBuild.promote} moves entries rather than the
+   * directory holding them. Optional: some engines expose neither.
+   */
+  move?(destination: OpfsDirHandle, name?: string): Promise<void>;
 }
 export interface OpfsDirHandle {
   getFileHandle(name: string, options?: { create?: boolean }): Promise<OpfsFileHandle>;
+  getDirectoryHandle(name: string, options?: { create?: boolean }): Promise<OpfsDirHandle>;
+  removeEntry(name: string, options?: { recursive?: boolean }): Promise<void>;
   keys(): AsyncIterableIterator<string>;
 }
 
 const TILE_SUFFIX = '.tile';
 const ROOT_TILE = 'root';
+
+/**
+ * Marks a directory as a build in progress. A store under this suffix is never
+ * a store a reader may open: it is whatever the indexer had written when it
+ * stopped, and the only two things that legitimately happen to it are promotion
+ * and deletion.
+ */
+export const PARTIAL_SUFFIX = '.partial';
+
+/**
+ * How many tile files may hold an open sync access handle at once. A handle is
+ * an OS file descriptor and an exclusive lock, and a build touches thousands of
+ * nodes, so they cannot all stay open; the least recently appended is closed to
+ * make room. The cap only bounds descriptors — a reopened tile keeps appending
+ * at its own end, so no bytes are copied when one is evicted and later reopened.
+ */
+const MAX_OPEN_TILE_HANDLES = 64;
 
 function tileFileName(key: string): string {
   return (key === '' ? ROOT_TILE : key) + TILE_SUFFIX;
@@ -47,21 +105,124 @@ function keyFromFileName(name: string): string {
   return base === ROOT_TILE ? '' : base;
 }
 
-/** A {@link SpillStore} over an OPFS directory. */
-export function opfsSpillStore(dir: OpfsDirHandle): SpillStore {
+/** A store that also owns file handles, so a caller can release them. */
+export interface OpfsSpillStore extends SpillStore {
+  /**
+   * Close every open tile handle, flushing what they hold. Idempotent, and
+   * required before another context may open the same files.
+   */
+  close(): Promise<void>;
+  /** True once an append has actually opened a sync access handle. */
+  usesSyncAccess(): boolean;
+}
+
+/** One tile file held open, with the offset its next append goes to. */
+interface OpenTile {
+  readonly handle: OpfsSyncAccessHandle;
+  size: number;
+}
+
+/**
+ * A {@link SpillStore} over an OPFS directory.
+ *
+ * Appends go through a sync access handle held open across flushes when the
+ * platform provides one, and through a writable stream when it does not. The
+ * two produce identical files; they differ only in what they cost.
+ */
+export function opfsSpillStore(dir: OpfsDirHandle): OpfsSpillStore {
+  // Insertion-ordered, so the first key is the least recently appended.
+  const open = new Map<string, OpenTile>();
+  // undefined until the first append has asked; false once the platform has
+  // been found not to offer the primitive, and it is never asked again.
+  let syncUsable: boolean | undefined;
+
+  async function closeTile(name: string): Promise<void> {
+    const tile = open.get(name);
+    if (tile === undefined) return;
+    open.delete(name);
+    await tile.handle.close();
+  }
+
+  /**
+   * The open handle for `name`, opening one if needed, or undefined when this
+   * platform has no sync access handles. Capability detection, not sniffing:
+   * the method is looked for on the handle and then actually called, because a
+   * platform may expose it in a context where it refuses to open.
+   */
+  async function acquire(name: string): Promise<OpenTile | undefined> {
+    if (syncUsable === false) return undefined;
+    const existing = open.get(name);
+    if (existing !== undefined) {
+      // Refresh its place in the eviction order.
+      open.delete(name);
+      open.set(name, existing);
+      return existing;
+    }
+    const handle = await dir.getFileHandle(name, { create: true });
+    if (typeof handle.createSyncAccessHandle !== 'function') {
+      syncUsable = false;
+      return undefined;
+    }
+    // Make room BEFORE opening, so the cap counts handles actually held rather
+    // than handles held after the newest one has already been added.
+    while (open.size >= MAX_OPEN_TILE_HANDLES) {
+      const oldest = open.keys().next();
+      if (oldest.done === true) break;
+      await closeTile(oldest.value);
+    }
+    let access: OpfsSyncAccessHandle;
+    try {
+      access = await handle.createSyncAccessHandle();
+    } catch (err) {
+      // Exposed but unusable in this context. A refusal arrives as a
+      // DOMException; a TypeError means the handle is not the shape this
+      // module thinks it is, which is a fault in the caller rather than a
+      // capability to route around, so it is not swallowed.
+      if (err instanceof TypeError) throw err;
+      syncUsable = false;
+      return undefined;
+    }
+    syncUsable = true;
+    const tile: OpenTile = { handle: access, size: await access.getSize() };
+    open.set(name, tile);
+    return tile;
+  }
+
+  /**
+   * The fallback append. Kept verbatim from the writable-stream version this
+   * module started as, so a platform without sync access handles gets exactly
+   * the behaviour it had before, whole-file copy included.
+   */
+  async function appendViaWritable(name: string, bytes: Uint8Array): Promise<void> {
+    const handle = await dir.getFileHandle(name, { create: true });
+    // Append: keep what is there, seek to the end, write. Several flushes for
+    // one leaf therefore concatenate into a single contiguous tile.
+    const size = (await handle.getFile()).size;
+    const writable = await handle.createWritable({ keepExistingData: true });
+    await writable.seek(size);
+    await writable.write(bytes);
+    await writable.close();
+  }
+
   return {
     async append(key, bytes) {
-      const handle = await dir.getFileHandle(tileFileName(key), { create: true });
-      // Append: keep what is there, seek to the end, write. Several flushes for
-      // one leaf therefore concatenate into a single contiguous tile.
-      const size = (await handle.getFile()).size;
-      const writable = await handle.createWritable({ keepExistingData: true });
-      await writable.seek(size);
-      await writable.write(bytes);
-      await writable.close();
+      const name = tileFileName(key);
+      const tile = await acquire(name);
+      if (tile !== undefined) {
+        // One write at the running end. Nothing already in the tile is read,
+        // rewritten or copied, so the cost is the length of `bytes`.
+        await tile.handle.write(bytes, { at: tile.size });
+        tile.size += bytes.length;
+        return;
+      }
+      await appendViaWritable(name, bytes);
     },
     async read(key) {
-      const handle = await dir.getFileHandle(tileFileName(key));
+      const name = tileFileName(key);
+      // A sync access handle takes an exclusive lock and its buffered writes
+      // need not be visible through getFile(), so the tile is released first.
+      await closeTile(name);
+      const handle = await dir.getFileHandle(name);
       const file = await handle.getFile();
       return new Uint8Array(await file.arrayBuffer());
     },
@@ -71,6 +232,12 @@ export function opfsSpillStore(dir: OpfsDirHandle): SpillStore {
         if (name.endsWith(TILE_SUFFIX)) out.push(keyFromFileName(name));
       }
       return out;
+    },
+    async close() {
+      for (const name of [...open.keys()]) await closeTile(name);
+    },
+    usesSyncAccess() {
+      return syncUsable === true;
     },
   };
 }
@@ -88,4 +255,165 @@ export async function writeOpfsText(dir: OpfsDirHandle, name: string, text: stri
 export async function readOpfsText(dir: OpfsDirHandle, name: string): Promise<string> {
   const handle = await dir.getFileHandle(name);
   return (await handle.getFile()).text();
+}
+
+// ── the partial store ───────────────────────────────────────────────────────
+//
+// An index that stops halfway is not a small problem. The tiles it wrote are
+// the size of the scan, they are indistinguishable from a finished store by
+// their contents, and nothing ever comes back for them, so a user who cancels
+// at seventy-three percent loses that disk until they clear site data. So a
+// build writes into `<name>.partial` and that directory is either PROMOTED, in
+// one pass at the end once the manifest is on disk, or DELETED. There is no
+// third outcome, and no state in which a half-written store carries a name a
+// reader would open.
+
+/** A build in progress, and the two ways it is allowed to end. */
+export interface OpfsSpillBuild {
+  /** Where the indexer writes tiles. */
+  readonly store: OpfsSpillStore;
+  /** The partial directory itself, for the manifest and hierarchy. */
+  readonly dir: OpfsDirHandle;
+  /** `<name>.partial`, the directory the tiles are actually in. */
+  readonly partialName: string;
+  /** The name the store takes once it is finished. */
+  readonly finalName: string;
+  /**
+   * Move the finished store to {@link finalName}. Call only after the manifest
+   * and hierarchy have been written. Resolves to the promoted directory.
+   */
+  promote(): Promise<OpfsDirHandle>;
+  /**
+   * Delete the partial store. Call on cancel, on error and on a quota failure.
+   * Safe to call twice, and safe after a promotion, when it does nothing.
+   */
+  discard(): Promise<void>;
+}
+
+/** Swallow the NotFoundError a removal of an absent entry raises. */
+async function removeIfPresent(dir: OpfsDirHandle, name: string): Promise<void> {
+  try {
+    await dir.removeEntry(name, { recursive: true });
+  } catch (err) {
+    if ((err as { name?: string } | null)?.name === 'NotFoundError') return;
+    throw err;
+  }
+}
+
+/**
+ * Start a build under `<name>.partial` inside `root`.
+ *
+ * Any leftover partial of the same name is removed first, so a session that
+ * died without cleaning up does not have its bytes silently adopted by the next
+ * build. The final name is left alone until {@link OpfsSpillBuild.promote}.
+ */
+export async function openOpfsSpillBuild(root: OpfsDirHandle, name: string): Promise<OpfsSpillBuild> {
+  const partialName = name + PARTIAL_SUFFIX;
+  await removeIfPresent(root, partialName);
+  const dir = await root.getDirectoryHandle(partialName, { create: true });
+  const store = opfsSpillStore(dir);
+  let settled = false;
+
+  return {
+    store,
+    dir,
+    partialName,
+    finalName: name,
+    async promote() {
+      if (settled) throw new Error('opfsSpillStore: this build has already been promoted or discarded');
+      // Flush and unlock every tile before anything is relocated.
+      await store.close();
+      // A store already under this name is a previous build of the same input.
+      // The new one replaces it; leaving both would mean two stores for one
+      // source with nothing to say which is current.
+      await removeIfPresent(root, name);
+      const target = await root.getDirectoryHandle(name, { create: true });
+      const entries: string[] = [];
+      for await (const entry of dir.keys()) entries.push(entry);
+      // The manifest goes last, so a promotion interrupted partway cannot
+      // leave a directory that reads as a store. `openTileStore` needs the
+      // manifest, and until it arrives there is nothing to open.
+      entries.sort((a, b) => Number(a === TILE_MANIFEST_NAME) - Number(b === TILE_MANIFEST_NAME));
+      try {
+        for (const entry of entries) await relocate(dir, target, entry);
+      } catch (err) {
+        // Half a store under the final name is the one outcome this scheme
+        // exists to prevent, so the failed target goes and the partial stays,
+        // still discardable by the caller.
+        await removeIfPresent(root, name);
+        throw err;
+      }
+      settled = true;
+      await removeIfPresent(root, partialName);
+      return target;
+    },
+    async discard() {
+      if (settled) return;
+      settled = true;
+      await store.close();
+      await removeIfPresent(root, partialName);
+    },
+  };
+}
+
+/**
+ * Move one file from the partial store into the promoted one.
+ *
+ * OPFS renames FILES but not directories (confirmed by probe: `move` is on
+ * `FileSystemFileHandle` and absent from `FileSystemDirectoryHandle`), so
+ * promotion is per entry. Chromium has the rename, and a rename moves no bytes.
+ *
+ * Where the rename is missing the bytes are copied and the source deleted
+ * immediately, one file at a time, so what is briefly duplicated is the LARGEST
+ * TILE rather than the store. That keeps `storagePreflight.ts` honest: its
+ * total is unchanged, and the transient excess is one node's worth of records,
+ * far inside the reserve it already holds back. The exception is a cloud so
+ * degenerate that every point settles in one node, where the largest tile IS
+ * the store; such a cloud has no usable octree either way.
+ */
+async function relocate(from: OpfsDirHandle, to: OpfsDirHandle, name: string): Promise<void> {
+  const source = await from.getFileHandle(name);
+  if (typeof source.move === 'function') {
+    await source.move(to, name);
+    return;
+  }
+  const bytes = new Uint8Array(await (await source.getFile()).arrayBuffer());
+  const handle = await to.getFileHandle(name, { create: true });
+  const writable = await handle.createWritable();
+  await writable.write(bytes);
+  await writable.close();
+  await from.removeEntry(name);
+}
+
+/**
+ * Run `build` against a fresh partial store and promote it only if it returns.
+ *
+ * The reason this wrapper exists rather than a note telling callers to clean
+ * up: cancellation, a decode fault and a quota failure all arrive here as the
+ * same thing — the function did not return — and all three must delete the
+ * partial store. A caller that has to remember which of them to catch will one
+ * day catch two of the three.
+ */
+export async function withOpfsSpillBuild<T>(
+  root: OpfsDirHandle,
+  name: string,
+  build: (build: OpfsSpillBuild) => Promise<T>,
+): Promise<{ result: T; dir: OpfsDirHandle }> {
+  const pending = await openOpfsSpillBuild(root, name);
+  let result: T;
+  try {
+    result = await build(pending);
+  } catch (err) {
+    // The build's failure is the one worth reporting. A cleanup that also
+    // fails must not replace it, or the user is told the disk could not be
+    // tidied rather than why their index stopped.
+    try {
+      await pending.discard();
+    } catch {
+      // Nothing further to do: the partial store outlives this attempt and the
+      // next build under the same name removes it.
+    }
+    throw err;
+  }
+  return { result, dir: await pending.promote() };
 }

--- a/src/io/heavy/storagePreflight.ts
+++ b/src/io/heavy/storagePreflight.ts
@@ -33,6 +33,15 @@
  * — the file still opens by the existing whole-file route, and COPC or EPT
  * streams it without a cache at all. Proceeding wrongly costs them their disk.
  *
+ * STILL RIGHT AFTER THE PARTIAL-STORE CHANGE. `opfsSpillStore.ts` builds into
+ * `<name>.partial` and promotes that directory to `<name>` once the manifest is
+ * written. The figures below do not move: the same tiles, hierarchy and
+ * manifest are written once each, and promotion RENAMES files where the engine
+ * offers `FileSystemFileHandle.move`. Where it does not, promotion copies one
+ * file at a time and deletes each source immediately, so the transient excess
+ * is the largest tile rather than a second store, which the reserve below
+ * already covers many times over.
+ *
  * Nothing in the application calls this yet. It is the check that has to exist
  * before any file is routed to local indexing, not the routing itself.
  */

--- a/tests/opfsSpillCost.test.ts
+++ b/tests/opfsSpillCost.test.ts
@@ -1,0 +1,286 @@
+/**
+ * opfsSpillCost.test.ts — what an append to the OPFS spill store COSTS, and
+ * what a build that never finishes leaves behind.
+ *
+ * `opfsSpillStore.test.ts` proves the store ends up holding the right bytes.
+ * That is not enough on its own: a store that copies the whole tile on every
+ * flush also ends up holding the right bytes, and that is precisely the defect
+ * these cases exist to catch. So they measure device traffic and directory
+ * contents rather than tile contents, against `tests/support/fakeOpfs.ts`,
+ * which charges for the copy `createWritable({ keepExistingData: true })` is
+ * specified to make and that Chromium was measured making.
+ */
+import { describe, it, expect } from 'vitest';
+import { fakeOpfs, type FakeOpfsOptions, type FakeOpfsStats } from './support/fakeOpfs';
+import {
+  openOpfsSpillBuild,
+  opfsSpillStore,
+  PARTIAL_SUFFIX,
+  readOpfsText,
+  withOpfsSpillBuild,
+  writeOpfsText,
+} from '../src/io/heavy/opfsSpillStore';
+
+/** Append `total` bytes to one tile in `appends` pieces; report what it cost. */
+async function costOfAppending(
+  appends: number,
+  total: number,
+  options: FakeOpfsOptions,
+): Promise<FakeOpfsStats> {
+  const fake = fakeOpfs(options);
+  const store = opfsSpillStore(fake.root);
+  const bytes = new Uint8Array(total / appends).fill(7);
+  for (let i = 0; i < appends; i++) await store.append('012', bytes);
+  await store.close();
+  expect((await store.read('012')).length).toBe(total); // the bytes still land
+  return fake.stats;
+}
+
+const TOTAL = 1 << 20;
+
+describe('OPFS spill store append cost', () => {
+  it('charges for the bytes appended, not for the tile they land in', async () => {
+    const few = await costOfAppending(8, TOTAL, { syncAccess: true });
+    const many = await costOfAppending(256, TOTAL, { syncAccess: true });
+
+    // The same tile, built from 32x as many flushes, must cost the same.
+    expect(few.bytesCopied + few.bytesWritten).toBe(TOTAL);
+    expect(many.bytesCopied + many.bytesWritten).toBe(TOTAL);
+    // And the file is opened once, not once per flush.
+    expect(many.syncOpens).toBe(1);
+    expect(many.writableOpens).toBe(0);
+  });
+
+  it('measures the writable fallback paying the copy the sync path avoids', async () => {
+    // Not a regression guard: the fallback is what the platform gives when
+    // there is no sync access handle, and its cost is what it is. The case is
+    // here so the two paths are known to be DISTINGUISHABLE BY COST, without
+    // which the case above could pass on either implementation.
+    const many = await costOfAppending(256, TOTAL, {});
+    // n appends of TOTAL/n bytes copy 0 + 1 + ... + (n-1) chunks first.
+    expect(many.bytesCopied).toBe((TOTAL * 255) / 2);
+    expect(many.bytesWritten).toBe(TOTAL);
+    expect(many.writableOpens).toBe(256);
+
+    const few = await costOfAppending(8, TOTAL, {});
+    expect(many.bytesCopied / few.bytesCopied).toBeCloseTo(255 / 7, 5);
+  });
+
+  it('falls back when the handle offers a sync access handle but refuses to open one', async () => {
+    // Capability detection has to survive the platform that advertises the
+    // method in a context where it cannot be used; a presence check alone
+    // would throw here rather than fall back.
+    const stats = await costOfAppending(16, TOTAL, { syncAccessFails: 'refused' });
+    expect(stats.syncOpens).toBe(0);
+    expect(stats.writableOpens).toBe(16);
+    expect(stats.bytesWritten).toBe(TOTAL);
+  });
+
+  it('reports which of the two write paths it actually got', async () => {
+    const withSync = opfsSpillStore(fakeOpfs({ syncAccess: true }).root);
+    expect(withSync.usesSyncAccess()).toBe(false); // nothing has been opened yet
+    await withSync.append('0', new Uint8Array([1]));
+    expect(withSync.usesSyncAccess()).toBe(true);
+    await withSync.close();
+
+    const withoutSync = opfsSpillStore(fakeOpfs({}).root);
+    await withoutSync.append('0', new Uint8Array([1]));
+    expect(withoutSync.usesSyncAccess()).toBe(false);
+    await withoutSync.close();
+  });
+
+  it('does not read a malformed handle as a missing capability', async () => {
+    // A DOMException from createSyncAccessHandle means not in this context, and
+    // the store routes around it. A TypeError means the handle is not what it
+    // claims, and routing around that would turn a fault into a slow build that
+    // looks fine.
+    const fake = fakeOpfs({ syncAccessFails: 'malformed' });
+    const store = opfsSpillStore(fake.root);
+    await expect(store.append('0', new Uint8Array([1]))).rejects.toThrow(TypeError);
+    expect(fake.stats.writableOpens).toBe(0);
+  });
+
+  it('holds a bounded number of files open however many tiles are touched', async () => {
+    const fake = fakeOpfs({ syncAccess: true });
+    const store = opfsSpillStore(fake.root);
+    const keys = Array.from({ length: 400 }, (_, i) => `k${i}`);
+    // Two passes, so every tile is appended to after having been evicted.
+    for (let pass = 0; pass < 2; pass++) {
+      for (const key of keys) await store.append(key, new Uint8Array([pass]));
+    }
+    await store.close();
+
+    expect(fake.stats.peakOpenSyncHandles).toBeLessThanOrEqual(64);
+    expect(fake.stats.bytesCopied).toBe(0); // reopening never rereads the tile
+    expect([...(await store.read('k7'))]).toEqual([0, 1]);
+    expect((await store.keys()).length).toBe(400);
+  });
+});
+
+describe('OPFS spill store write paths agree', () => {
+  /** Build the same store twice over the same appends, on the two paths. */
+  async function storeBuiltWith(options: FakeOpfsOptions): Promise<Map<string, Uint8Array>> {
+    const fake = fakeOpfs(options);
+    const store = opfsSpillStore(fake.root);
+    // Interleaved keys and uneven chunks, so ordering and offsets both matter.
+    for (let round = 0; round < 12; round++) {
+      for (const key of ['', '0', '07', '073', '7']) {
+        const n = 1 + ((round * 7 + key.length) % 23);
+        await store.append(key, new Uint8Array(n).fill((round + key.length) & 0xff));
+      }
+    }
+    await store.close();
+    await writeOpfsText(fake.root, 'manifest.json', '{"round":"trip"}');
+    expect(await readOpfsText(fake.root, 'manifest.json')).toBe('{"round":"trip"}');
+    return fake.snapshot();
+  }
+
+  it('writes byte-identical stores through the sync handle and the writable stream', async () => {
+    const viaSync = await storeBuiltWith({ syncAccess: true });
+    const viaWritable = await storeBuiltWith({});
+
+    expect([...viaSync.keys()].sort()).toEqual([...viaWritable.keys()].sort());
+    expect([...viaSync.keys()].sort()).toEqual([
+      '0.tile',
+      '07.tile',
+      '073.tile',
+      '7.tile',
+      'manifest.json',
+      'root.tile',
+    ]);
+    for (const [name, bytes] of viaSync) {
+      expect(`${name}:${[...bytes].join(',')}`).toBe(`${name}:${[...viaWritable.get(name)!].join(',')}`);
+    }
+  });
+});
+
+describe('OPFS spill store cancellation', () => {
+  const NAME = 'cloud-abc123';
+
+  async function appendSome(build: { store: { append(k: string, b: Uint8Array): Promise<void> } }): Promise<void> {
+    for (const key of ['0', '1', '2']) await build.store.append(key, new Uint8Array(1024).fill(1));
+  }
+
+  it('keeps a build under a partial name until it is promoted', async () => {
+    const fake = fakeOpfs({ syncAccess: true, fileMove: true });
+    const build = await openOpfsSpillBuild(fake.root, NAME);
+    expect(build.partialName).toBe(NAME + PARTIAL_SUFFIX);
+    // The manifest is written BEFORE the last tile, so directory order alone
+    // would relocate it in the middle and the ordering has to be deliberate.
+    await build.store.append('0', new Uint8Array(1024).fill(1));
+    await build.store.append('1', new Uint8Array(1024).fill(1));
+    await writeOpfsText(build.dir, 'manifest.json', '{}');
+    await build.store.append('2', new Uint8Array(1024).fill(1));
+
+    // Nothing under the final name while the build is unfinished.
+    expect(fake.topLevel()).toEqual([NAME + PARTIAL_SUFFIX]);
+
+    await build.promote();
+    expect(fake.topLevel()).toEqual([NAME]);
+    expect([...fake.snapshot().keys()].sort()).toEqual([
+      `${NAME}/0.tile`,
+      `${NAME}/1.tile`,
+      `${NAME}/2.tile`,
+      `${NAME}/manifest.json`,
+    ]);
+    // A promotion that can rename files moves them; it does not rewrite them.
+    expect(fake.stats.fileMoves).toBe(4);
+    // And the manifest arrives last, so an interrupted promotion never leaves
+    // a directory that `openTileStore` would accept.
+    expect(fake.stats.movedNames.at(-1)).toBe('manifest.json');
+  });
+
+  it('leaves nothing behind when a build is cancelled', async () => {
+    const fake = fakeOpfs({ syncAccess: true, fileMove: true });
+    const controller = new AbortController();
+    await expect(
+      withOpfsSpillBuild(fake.root, NAME, async (build) => {
+        await appendSome(build);
+        controller.abort();
+        controller.signal.throwIfAborted();
+      }),
+    ).rejects.toThrow();
+
+    expect(fake.topLevel()).toEqual([]);
+    expect(fake.totalBytes()).toBe(0);
+  });
+
+  it('leaves nothing behind when a build faults or runs out of space', async () => {
+    for (const failure of ['fault', 'quota'] as const) {
+      // 8 KiB of room: enough for the first tiles, not for the whole build.
+      const fake = fakeOpfs({ syncAccess: true, fileMove: true, quotaBytes: failure === 'quota' ? 8192 : undefined });
+      await expect(
+        withOpfsSpillBuild(fake.root, NAME, async (build) => {
+          for (let i = 0; i < 64; i++) await build.store.append(`k${i}`, new Uint8Array(1024).fill(2));
+          if (failure === 'fault') throw new Error('the decoder gave up');
+        }),
+      ).rejects.toThrow();
+
+      expect(fake.topLevel()).toEqual([]);
+      expect(fake.totalBytes()).toBe(0);
+    }
+  });
+
+  it('clears an abandoned partial store before starting the next build', async () => {
+    const fake = fakeOpfs({ syncAccess: true, fileMove: true });
+    // A previous session died without cleaning up.
+    const orphan = await fake.root.getDirectoryHandle(NAME + PARTIAL_SUFFIX, { create: true });
+    await writeOpfsText(orphan, 'stale.tile', 'bytes from a build that never finished');
+    expect(fake.totalBytes()).toBeGreaterThan(0);
+
+    const build = await openOpfsSpillBuild(fake.root, NAME);
+    expect(fake.totalBytes()).toBe(0);
+    await appendSome(build);
+    await build.promote();
+    expect([...fake.snapshot().keys()].sort()).toEqual([`${NAME}/0.tile`, `${NAME}/1.tile`, `${NAME}/2.tile`]);
+  });
+
+  it('leaves no half-promoted store when the promotion itself fails', async () => {
+    // Room for the store but not for a relocation that has to copy: the first
+    // file fails, and the final name must not survive the attempt.
+    const fake = fakeOpfs({ syncAccess: true, fileMove: false, quotaBytes: 3 * 4096 + 1000 });
+    const build = await openOpfsSpillBuild(fake.root, NAME);
+    for (const key of ['0', '1', '2']) await build.store.append(key, new Uint8Array(4096).fill(3));
+
+    await expect(build.promote()).rejects.toThrow();
+    expect(fake.topLevel()).toEqual([NAME + PARTIAL_SUFFIX]);
+
+    await build.discard();
+    expect(fake.topLevel()).toEqual([]);
+    expect(fake.totalBytes()).toBe(0);
+  });
+
+  it('reads a tile back after releasing the handle that was appending to it', async () => {
+    // A sync access handle need not publish its writes before it is closed, so
+    // a read that did not release first could see a short tile.
+    const fake = fakeOpfs({ syncAccess: true });
+    const store = opfsSpillStore(fake.root);
+    for (let i = 0; i < 5; i++) await store.append('0', new Uint8Array([i]));
+    expect([...(await store.read('0'))]).toEqual([0, 1, 2, 3, 4]);
+    // And appending afterwards resumes at the end rather than at zero.
+    await store.append('0', new Uint8Array([9]));
+    expect([...(await store.read('0'))]).toEqual([0, 1, 2, 3, 4, 9]);
+    await store.close();
+  });
+
+  it('promotes without a file rename by relocating one file at a time', async () => {
+    // The engine that has no FileSystemFileHandle.move must still promote, and
+    // must not need a second copy of the whole store to do it.
+    const fake = fakeOpfs({ syncAccess: true, fileMove: false });
+    const { dir } = await withOpfsSpillBuild(fake.root, NAME, async (build) => {
+      for (const key of ['0', '1', '2']) await build.store.append(key, new Uint8Array(4096).fill(3));
+      await writeOpfsText(build.dir, 'manifest.json', '{"promoted":true}');
+    });
+
+    expect(fake.stats.fileMoves).toBe(0);
+    expect(fake.topLevel()).toEqual([NAME]);
+    expect(await readOpfsText(dir, 'manifest.json')).toBe('{"promoted":true}');
+    for (const key of ['0', '1', '2']) {
+      const bytes = fake.snapshot().get(`${NAME}/${key}.tile`)!;
+      expect(bytes.length).toBe(4096);
+      expect(bytes.every((b) => b === 3)).toBe(true);
+    }
+    // Peak occupancy never held two copies of the store: 3 tiles + a manifest.
+    expect(fake.totalBytes()).toBe(3 * 4096 + '{"promoted":true}'.length);
+  });
+});

--- a/tests/opfsSpillStore.test.ts
+++ b/tests/opfsSpillStore.test.ts
@@ -3,11 +3,18 @@
  * fake of the file-system handles.
  *
  * OPFS is a browser API, so the real handles are exercised in the browser; here
- * a small fake stands in for `FileSystemDirectoryHandle` so the store's own logic
+ * a fake stands in for `FileSystemDirectoryHandle` so the store's own logic
  * — append-concatenation, the key-to-file-name mapping, and text artifacts — is
  * unit-tested in Node. A second case runs the whole build into the fake store and
  * reads it back through the tile-store reader, proving the OPFS backing is a drop-
  * in for the memory store used elsewhere.
+ *
+ * The build case runs TWICE, once with sync access handles available and once
+ * without, because the store picks its write path from what the handle offers
+ * and a suite that only ever saw one of them would not notice the other break.
+ * `tests/opfsSpillCost.test.ts` is where the two are separated by cost; here
+ * they only have to agree on the result. The fake itself lives in
+ * `tests/support/fakeOpfs.ts`, shared by both files.
  */
 import { describe, it, expect } from 'vitest';
 import { writeLas14 } from '../src/convert/writeLas';
@@ -20,59 +27,8 @@ import {
   opfsSpillStore,
   readOpfsText,
   writeOpfsText,
-  type OpfsDirHandle,
 } from '../src/io/heavy/opfsSpillStore';
-
-/** An in-memory fake of the OPFS directory/file/writable handles. */
-function fakeOpfsDir(): OpfsDirHandle {
-  const files = new Map<string, Uint8Array>();
-  return {
-    async getFileHandle(name, options) {
-      if (!files.has(name)) {
-        if (!options?.create) throw new Error(`NotFoundError: ${name}`);
-        files.set(name, new Uint8Array(0));
-      }
-      return {
-        async getFile() {
-          const data = files.get(name)!;
-          return {
-            size: data.length,
-            async arrayBuffer() {
-              return data.slice().buffer;
-            },
-            async text() {
-              return new TextDecoder().decode(data);
-            },
-          };
-        },
-        async createWritable(opts) {
-          let buf = opts?.keepExistingData ? files.get(name)!.slice() : new Uint8Array(0);
-          let pos = 0;
-          return {
-            async seek(offset) {
-              pos = offset;
-            },
-            async write(bytes) {
-              if (pos + bytes.length > buf.length) {
-                const grown = new Uint8Array(Math.max(pos + bytes.length, buf.length));
-                grown.set(buf);
-                buf = grown;
-              }
-              buf.set(bytes, pos);
-              pos += bytes.length;
-            },
-            async close() {
-              files.set(name, buf);
-            },
-          };
-        },
-      };
-    },
-    async *keys() {
-      for (const k of files.keys()) yield k;
-    },
-  };
-}
+import { fakeOpfsDir } from './support/fakeOpfs';
 
 describe('OPFS spill store', () => {
   it('appends, reads, maps keys, and round-trips text', async () => {
@@ -90,7 +46,10 @@ describe('OPFS spill store', () => {
     expect(await readOpfsText(dir, 'manifest.json')).toBe('{"ok":true}');
   });
 
-  it('holds a whole build and reads it back through the tile store', async () => {
+  it.each([
+    ['with sync access handles', { syncAccess: true }],
+    ['with only a writable stream', {}],
+  ])('holds a whole build and reads it back through the tile store, %s', async (_label, capabilities) => {
     const n = 3000;
     const x = new Float64Array(n);
     const y = new Float64Array(n);
@@ -106,7 +65,7 @@ describe('OPFS spill store', () => {
     const bytes = writeLas14(cloud);
     const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 
-    const dir = fakeOpfsDir();
+    const dir = fakeOpfsDir(capabilities);
     const store = opfsSpillStore(dir);
     const las = await openSlicedLasSource(new ArrayBufferRangeSource(ab));
     const index = await indexOutOfCore(las.source, store, { pointsPerLeaf: 600, memoryBudgetBytes: 16 * 1024 });

--- a/tests/support/fakeOpfs.ts
+++ b/tests/support/fakeOpfs.ts
@@ -1,0 +1,318 @@
+/**
+ * fakeOpfs.ts — an in-memory Origin Private File System that CHARGES.
+ *
+ * OPFS does not exist in Node, so the spill store's logic is unit-tested
+ * against a fake. A fake that only records final contents is not enough here:
+ * the defect this fake exists to expose — `createWritable({ keepExistingData:
+ * true })` starting its swap file as a copy of the file it replaces — produces
+ * exactly the right contents and merely takes time proportional to the tile
+ * rather than to the append. So every byte the platform would move is counted,
+ * and a test can tell the two write paths apart by cost.
+ *
+ * The counters were calibrated against real OPFS in headless Chromium: thirty-
+ * two 4 KiB appends onto an empty file took 36 ms and onto a 64 MiB file
+ * 4120 ms, which is the whole-file copy this fake charges for, and a sync
+ * access handle wrote the same payload in flat time.
+ *
+ * Capabilities are constructor options rather than fixed, because the real
+ * surface is not fixed: `createSyncAccessHandle` is exposed inside a worker and
+ * not on Chromium's main thread, and `FileSystemFileHandle.move` exists while
+ * the directory equivalent does not. Both were confirmed by probe.
+ *
+ * One place the fake is deliberately STRICTER than the engine measured: a sync
+ * access handle here commits its writes on `close()` or `flush()`, so
+ * `getFile()` on a file with a handle open reports what was last committed.
+ * Chromium was measured committing eagerly, but nothing promises that, and a
+ * store that reads a tile without releasing its handle first would be relying
+ * on the engine rather than on the API.
+ */
+import type { OpfsDirHandle, OpfsFileHandle, OpfsSyncAccessHandle } from '../../src/io/heavy/opfsSpillStore';
+
+export interface FakeOpfsStats {
+  /** Bytes a swap file copies out of the file it is about to replace. */
+  bytesCopied: number;
+  /** Bytes handed to a write() call, by either path. */
+  bytesWritten: number;
+  writableOpens: number;
+  syncOpens: number;
+  fileMoves: number;
+  /** Names passed to `move`, in order, so a promotion's ordering is observable. */
+  movedNames: string[];
+  /** Most tile files holding an open sync access handle at any one moment. */
+  peakOpenSyncHandles: number;
+}
+
+export interface FakeOpfsOptions {
+  /** Expose `createSyncAccessHandle`. Browsers expose it only inside a worker. */
+  readonly syncAccess?: boolean;
+  /**
+   * Expose `createSyncAccessHandle` but have it fail, so the fallback is
+   * reached through the trial rather than through the presence check.
+   * `'refused'` is an engine saying not in this context, which is a capability
+   * gap and the fallback's cue; `'malformed'` is a handle that is not the shape
+   * it claims, which is a fault and must not be quietly routed around.
+   */
+  readonly syncAccessFails?: 'refused' | 'malformed';
+  /** Expose `FileSystemFileHandle.move`. Chromium does; not every engine does. */
+  readonly fileMove?: boolean;
+  /** Reject writes once the store holds this many bytes, as a quota would. */
+  readonly quotaBytes?: number;
+}
+
+interface FakeFile {
+  kind: 'file';
+  /** The committed bytes: what `getFile()` reports. */
+  data: Uint8Array;
+  locked: boolean;
+  /** Bytes an open sync access handle holds beyond `data`, charged to quota. */
+  pending: number;
+}
+interface FakeDir {
+  kind: 'dir';
+  entries: Map<string, FakeFile | FakeDir>;
+}
+
+function domError(name: string, message: string): Error {
+  return Object.assign(new Error(message), { name });
+}
+
+export interface FakeOpfs {
+  /** The root directory handle, to hand to the code under test. */
+  readonly root: OpfsDirHandle;
+  readonly stats: FakeOpfsStats;
+  /** Every file in the tree as `path -> bytes`, for a layout assertion. */
+  snapshot(): Map<string, Uint8Array>;
+  /** Names directly under the root, files and directories alike. */
+  topLevel(): string[];
+  /** Total bytes the tree holds, for a quota or leak assertion. */
+  totalBytes(): number;
+}
+
+export function fakeOpfs(options: FakeOpfsOptions = {}): FakeOpfs {
+  const rootNode: FakeDir = { kind: 'dir', entries: new Map() };
+  const stats: FakeOpfsStats = {
+    bytesCopied: 0,
+    bytesWritten: 0,
+    writableOpens: 0,
+    syncOpens: 0,
+    fileMoves: 0,
+    movedNames: [],
+    peakOpenSyncHandles: 0,
+  };
+  let openSyncHandles = 0;
+
+  function totalBytes(node: FakeDir = rootNode): number {
+    let sum = 0;
+    for (const entry of node.entries.values()) {
+      sum += entry.kind === 'file' ? entry.data.length + entry.pending : totalBytes(entry);
+    }
+    return sum;
+  }
+
+  /** A quota is a property of the ORIGIN, so it counts the whole tree. */
+  function chargeQuota(extra: number): void {
+    if (options.quotaBytes !== undefined && totalBytes() + extra > options.quotaBytes) {
+      throw domError('QuotaExceededError', 'the fake origin is out of space');
+    }
+  }
+
+  function writeAt(target: Uint8Array, bytes: Uint8Array, at: number): Uint8Array {
+    let buf = target;
+    if (at + bytes.length > buf.length) {
+      const grown = new Uint8Array(Math.max(at + bytes.length, buf.length));
+      grown.set(buf);
+      buf = grown;
+    }
+    buf.set(bytes, at);
+    return buf;
+  }
+
+  function makeFileHandle(parent: FakeDir, name: string): OpfsFileHandle {
+    const file = (): FakeFile => {
+      const entry = parent.entries.get(name);
+      if (entry === undefined || entry.kind !== 'file') throw domError('NotFoundError', name);
+      return entry;
+    };
+
+    const handle: OpfsFileHandle = {
+      async getFile() {
+        const data = file().data;
+        return {
+          size: data.length,
+          async arrayBuffer() {
+            return data.slice().buffer;
+          },
+          async text() {
+            return new TextDecoder().decode(data);
+          },
+        };
+      },
+      async createWritable(opts) {
+        const f = file();
+        if (f.locked) throw domError('NoModificationAllowedError', name);
+        stats.writableOpens++;
+        let buf: Uint8Array;
+        if (opts?.keepExistingData) {
+          // THE DEFECT, modelled. The spec starts the swap file as a copy of
+          // the existing file, so an append pays for the whole tile.
+          chargeQuota(f.data.length);
+          buf = f.data.slice();
+          stats.bytesCopied += buf.length;
+        } else {
+          buf = new Uint8Array(0);
+        }
+        let pos = 0;
+        return {
+          async seek(offset) {
+            pos = offset;
+          },
+          async write(bytes) {
+            chargeQuota(bytes.length);
+            stats.bytesWritten += bytes.length;
+            buf = writeAt(buf, bytes, pos);
+            pos += bytes.length;
+          },
+          async close() {
+            file().data = buf;
+          },
+        };
+      },
+    };
+
+    if (options.syncAccess || options.syncAccessFails !== undefined) {
+      handle.createSyncAccessHandle = async (): Promise<OpfsSyncAccessHandle> => {
+        if (options.syncAccessFails === 'refused') {
+          // What the main thread does in a browser that ships the method there.
+          throw domError('InvalidStateError', 'sync access handles are worker-only');
+        }
+        if (options.syncAccessFails === 'malformed') {
+          throw new TypeError('createSyncAccessHandle is not a function');
+        }
+        const f = file();
+        if (f.locked) throw domError('NoModificationAllowedError', name);
+        f.locked = true;
+        stats.syncOpens++;
+        openSyncHandles++;
+        if (openSyncHandles > stats.peakOpenSyncHandles) stats.peakOpenSyncHandles = openSyncHandles;
+        let closed = false;
+        let buf: Uint8Array = f.data.slice();
+        const commit = (): void => {
+          f.data = buf;
+          f.pending = 0;
+        };
+        return {
+          getSize: () => buf.length,
+          write(bytes, at) {
+            if (closed) throw domError('InvalidStateError', 'closed');
+            chargeQuota(bytes.length);
+            stats.bytesWritten += bytes.length;
+            const before = buf.length;
+            buf = writeAt(buf, bytes, at?.at ?? 0);
+            f.pending += buf.length - before;
+            return bytes.length;
+          },
+          flush: commit,
+          close() {
+            if (closed) return;
+            closed = true;
+            commit();
+            f.locked = false;
+            openSyncHandles--;
+          },
+        };
+      };
+    }
+
+    if (options.fileMove) {
+      handle.move = async (destination, newName) => {
+        const f = file();
+        if (f.locked) throw domError('NoModificationAllowedError', name);
+        const target = dirNodeOf(destination);
+        stats.fileMoves++;
+        stats.movedNames.push(name);
+        parent.entries.delete(name);
+        target.entries.set(newName ?? name, f);
+      };
+    }
+    return handle;
+  }
+
+  // Directory handles are wrappers, so a move needs the node behind the handle
+  // it was given rather than the one it was made from.
+  const nodeOfHandle = new WeakMap<OpfsDirHandle, FakeDir>();
+  function dirNodeOf(handle: OpfsDirHandle): FakeDir {
+    const node = nodeOfHandle.get(handle);
+    if (node === undefined) throw domError('NotFoundError', 'unknown directory handle');
+    return node;
+  }
+
+  function makeDirHandle(node: FakeDir): OpfsDirHandle {
+    const handle: OpfsDirHandle = {
+      async getFileHandle(name, opts) {
+        const entry = node.entries.get(name);
+        if (entry === undefined) {
+          if (opts?.create !== true) throw domError('NotFoundError', name);
+          node.entries.set(name, { kind: 'file', data: new Uint8Array(0), locked: false, pending: 0 });
+        } else if (entry.kind !== 'file') {
+          throw domError('TypeMismatchError', name);
+        }
+        return makeFileHandle(node, name);
+      },
+      async getDirectoryHandle(name, opts) {
+        const entry = node.entries.get(name);
+        if (entry === undefined) {
+          if (opts?.create !== true) throw domError('NotFoundError', name);
+          const created: FakeDir = { kind: 'dir', entries: new Map() };
+          node.entries.set(name, created);
+          return makeDirHandle(created);
+        }
+        if (entry.kind !== 'dir') throw domError('TypeMismatchError', name);
+        return makeDirHandle(entry);
+      },
+      async removeEntry(name, opts) {
+        const entry = node.entries.get(name);
+        if (entry === undefined) throw domError('NotFoundError', name);
+        if (entry.kind === 'dir' && entry.entries.size > 0 && opts?.recursive !== true) {
+          throw domError('InvalidModificationError', name);
+        }
+        node.entries.delete(name);
+      },
+      async *keys() {
+        for (const key of [...node.entries.keys()]) yield key;
+      },
+    };
+    nodeOfHandle.set(handle, node);
+    return handle;
+  }
+
+  const root = makeDirHandle(rootNode);
+
+  function snapshotInto(node: FakeDir, prefix: string, into: Map<string, Uint8Array>): void {
+    for (const [name, entry] of node.entries) {
+      if (entry.kind === 'file') into.set(prefix + name, entry.data.slice());
+      else snapshotInto(entry, `${prefix}${name}/`, into);
+    }
+  }
+
+  return {
+    root,
+    stats,
+    snapshot() {
+      const out = new Map<string, Uint8Array>();
+      snapshotInto(rootNode, '', out);
+      return out;
+    },
+    topLevel() {
+      return [...rootNode.entries.keys()];
+    },
+    totalBytes: () => totalBytes(),
+  };
+}
+
+/**
+ * A single directory handle with the shape the store expects, for the cases
+ * that only need one directory rather than a root plus a partial inside it.
+ */
+export function fakeOpfsDir(options: FakeOpfsOptions = {}): OpfsDirHandle {
+  return fakeOpfs(options).root;
+}


### PR DESCRIPTION
`createWritable({ keepExistingData: true })` starts its swap file as a copy of
the file it replaces, so an append to a spill tile cost the tile, not the
append. Confirmed in headless Chromium first: thirty-two 4 KiB appends take
36 ms onto an empty file and 4120 ms onto a 64 MiB one.

Tiles now use a `FileSystemSyncAccessHandle` held open across flushes, capped
at 64. The writable path stays as the fallback, chosen by testing the handle
rather than the user agent, since `createSyncAccessHandle` is absent on the
main thread.

Builds write into `<name>.partial`, promoted once the manifest lands or deleted
on cancel, fault and quota failure. Promotion renames files where the engine
offers `move`, so `storagePreflight.ts` still holds.

Tests count bytes copied and handles opened; contents alone cannot tell the two
versions apart.
