### PR TITLE
feat(3d-tiles): open a tileset that describes its hierarchy implicitly

### DIFF
--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -62,7 +62,9 @@ A streamed tileset reports no source point total. A `tileset.json` never states 
 
 A tile that refines by REPLACE into tiles with their own content is refused. REPLACE means the parent's content is replaced by its children, and the streaming scheduler draws every resident node, which is right for ADD and would draw the coarse parent alongside the fine children for REPLACE. Refusing is preferred to a scene that is quietly doubled. A REPLACE tile that refines into nothing cannot duplicate anything and is served.
 
-What does not open: the wider 3D Tiles ecosystem. B3DM, I3DM, CMPT and glTF content are refused by name, because mesh tiles need a renderer this viewer does not have. Implicit tiling is refused at parse, and a selection cannot reach a nested external `tileset.json`. Draco-compressed tiles are refused rather than partially read.
+Implicit tiling opens. A tileset that describes its hierarchy with a subdivision scheme and subtree files rather than a written-out tree is expanded into the equivalent explicit document before it is parsed, so every refusal the explicit path makes applies to it unchanged. Quadtree and octree schemes are read, availability arrives as a constant or as a bitstream in an internal or external buffer, and subtree and buffer URLs pass the same origin and credential checks as tile content, including the directory-escape rule. The expansion is bounded: subtree levels, tiles per subtree, external buffers, available levels, subtree count, total expanded tiles and subtree bytes each have a ceiling that refuses by name rather than truncating. A sphere bounding volume on an implicit tile is refused, as is a tile declaring both `implicitTiling` and `children`. The older extension spellings are refused by name.
+
+What does not open: the wider 3D Tiles ecosystem. B3DM, I3DM, CMPT and glTF content are refused by name, because mesh tiles need a renderer this viewer does not have. A selection cannot reach a nested external `tileset.json`. Draco-compressed tiles are refused rather than partially read.
 
 Two further limits of the supported subset are known:
 

--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -187,27 +187,6 @@
       "review": "2027-02-28"
     },
     {
-      "path": "src/io/tiles3d/implicitExpand.ts",
-      "status": "staged",
-      "why": "The resource half of 3D Tiles 1.1 implicit tiling: it fetches the .subtree availability files a document names and rewrites the tree into the explicit document parseTileset already reads. The application's only tileset entry, src/app/openTilesetLayer.ts, still calls parseTileset on the fetched body directly, so nothing in the running viewer passes through this. parseTileset therefore still refuses an unexpanded implicit document, and docs/supported-formats.md still states that implicit tiling does not open.",
-      "graduation": "src/app/openTilesetLayer.ts parses the fetched body, passes it through expandImplicitTileset with the transport's fetchSubtreeBytes and the open's abort signal, and hands the result to parseTileset.",
-      "review": "2027-02-28"
-    },
-    {
-      "path": "src/io/tiles3d/implicitTiling.ts",
-      "status": "staged",
-      "why": "The pure half of the same feature: the implicitTiling descriptor and the {level}/{x}/{y}/{z} template substitution. Its only non-test importer is implicitExpand.ts, which is itself unreachable, so the pair is off the production graph together.",
-      "graduation": "implicitExpand.ts graduates; this arrives with it.",
-      "review": "2027-02-28"
-    },
-    {
-      "path": "src/io/tiles3d/subtree.ts",
-      "status": "staged",
-      "why": "The .subtree binary reader under the same feature: the 24-byte container, the JSON and binary chunks, and the three availability bitstreams. Imported only by implicitExpand.ts, which the application does not reach.",
-      "graduation": "implicitExpand.ts graduates; this arrives with it.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/process/ProductExecutorRegistry.ts",
       "status": "staged",
       "why": "Named in the v0.6.6 release notes: \"a product executor registry foundation that invokes a registered compute core through ProcessService.runIfAuthorized ... production product routes do not pass through it yet\".",

--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -32,6 +32,7 @@
 
 import { LoadCancelledError } from '../io/loadFile';
 import { describeLoadError } from '../io/loadErrors';
+import { expandImplicitTileset } from '../io/tiles3d/implicitExpand';
 import { parseTileset } from '../io/tiles3d/tileset';
 import { createTilesetTransport } from '../io/tiles3d/tilesetTransport';
 import { validateRemoteTilesetUrl } from '../io/tiles3d/tilesetUrl';
@@ -166,9 +167,22 @@ export async function openRemoteTileset(
     const json = await transport.fetchTilesetJson(url, controller.signal);
     let tileset;
     try {
-      tileset = parseTileset(json);
+      // Expand before parsing. `parseTileset` refuses an implicit document by
+      // design, so the expander has to rewrite it into the equivalent explicit
+      // one first; every existing refusal then applies to the result. A
+      // document that declares no implicit tiling comes back untouched, so this
+      // is safe to run unconditionally and costs an explicit tileset nothing.
+      const expanded = await expandImplicitTileset(JSON.parse(json) as object, {
+        entryUrl: url,
+        fetchSubtreeBytes: (subtreeUrl, signal) =>
+          transport.fetchSubtreeBytes(subtreeUrl, signal),
+        signal: controller.signal,
+      });
+      tileset = parseTileset(expanded);
     } catch (err) {
-      // The parser's refusals are all deliberate and already say why.
+      // The parser's and the expander's refusals are all deliberate and already
+      // say why. A cancel is not a refusal and has to keep its own identity.
+      if (err instanceof LoadCancelledError) throw err;
       throw new TilesetRefusal(err instanceof Error ? err.message : String(err));
     }
     if (controller.signal.aborted) throw new LoadCancelledError();

--- a/tests/tilesetImplicitWiring.test.ts
+++ b/tests/tilesetImplicitWiring.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { expandImplicitTileset } from '../src/io/tiles3d/implicitExpand';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+
+/**
+ * The expander turns an implicit document into an equivalent explicit one, and
+ * `parseTileset` refuses an unexpanded implicit document by design. So the open
+ * path has to call the expander before the parser, or implicit tiling stays
+ * unreachable no matter how complete the reader is.
+ *
+ * This reads the shipped source for the call ordering, because the failure mode
+ * is that nobody calls the expander, and drives the pair directly to prove the
+ * two compose.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const openSrc = readFileSync(
+  fileURLToPath(new URL('../src/app/openTilesetLayer.ts', import.meta.url)),
+  'utf8',
+);
+
+/** One quadtree subtree, root available, no children available. */
+function subtreeBytes(): ArrayBuffer {
+  const json = JSON.stringify({
+    tileAvailability: { constant: 1 },
+    contentAvailability: [{ constant: 1 }],
+    childSubtreeAvailability: { constant: 0 },
+  });
+  const padded = json.padEnd(Math.ceil(json.length / 8) * 8, ' ');
+  const jsonBytes = new TextEncoder().encode(padded);
+  const buf = new ArrayBuffer(24 + jsonBytes.length);
+  const view = new DataView(buf);
+  view.setUint32(0, 0x74627573, true); // "subt"
+  view.setUint32(4, 1, true);
+  view.setBigUint64(8, BigInt(jsonBytes.length), true);
+  view.setBigUint64(16, 0n, true);
+  new Uint8Array(buf, 24).set(jsonBytes);
+  return buf;
+}
+
+const IMPLICIT_DOC = {
+  asset: { version: '1.1' },
+  geometricError: 100,
+  root: {
+    boundingVolume: { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] },
+    geometricError: 100,
+    refine: 'ADD',
+    content: { uri: 'content/{level}/{x}/{y}.pnts' },
+    implicitTiling: {
+      subdivisionScheme: 'QUADTREE',
+      subtreeLevels: 2,
+      availableLevels: 1,
+      subtrees: { uri: 'subtrees/{level}/{x}/{y}.subtree' },
+    },
+  },
+};
+
+describe('the tileset open expands implicit tiling before parsing', () => {
+  it('calls the expander, so an implicit tileset can reach the parser', () => {
+    // The CALL, not the import: an unused import satisfies a bare name match
+    // while the expander never runs.
+    expect(
+      openSrc,
+      'openTilesetLayer never calls expandImplicitTileset, so parseTileset still ' +
+        'refuses every implicit document and the reader is unreachable',
+    ).toMatch(/await\s+expandImplicitTileset\(/);
+  });
+
+  it('parses what the expander returned, not the raw document', () => {
+    // Calling the expander and then parsing the original leaves the feature
+    // just as unreachable, and no name match would notice.
+    expect(openSrc).toMatch(/parseTileset\(expanded\)/);
+    expect(openSrc, 'the raw json must not go straight to the parser').not.toMatch(
+      /parseTileset\(json\)/,
+    );
+  });
+
+  it('expands before it parses, not after', () => {
+    const expandAt = openSrc.search(/await\s+expandImplicitTileset\(/);
+    const parseAt = openSrc.indexOf('parseTileset(expanded)');
+    expect(expandAt).toBeGreaterThan(-1);
+    expect(parseAt).toBeGreaterThan(-1);
+    expect(expandAt, 'the expander must run before the parser').toBeLessThan(parseAt);
+  });
+
+  it('keeps a cancel a cancel, rather than reporting it as a refusal', () => {
+    // The expander awaits network reads, so a user cancelling mid-expansion
+    // lands in this catch. Reported as a TilesetRefusal it would surface as
+    // "this tileset was refused" for a scan the user simply stopped.
+    expect(openSrc).toMatch(/if \(err instanceof LoadCancelledError\) throw err;/);
+  });
+
+  it('the pair composes: an implicit document parses once expanded', async () => {
+    // Unexpanded, the parser refuses by design.
+    expect(() => parseTileset(IMPLICIT_DOC)).toThrow(/implicit tiling/i);
+
+    const expanded = await expandImplicitTileset(IMPLICIT_DOC, {
+      entryUrl: 'https://tiles.example.com/tileset.json',
+      fetchSubtreeBytes: async () => subtreeBytes(),
+    });
+    const tileset = parseTileset(expanded);
+    expect(tileset.root).toBeDefined();
+  });
+
+  it('leaves a non-implicit document untouched, so the call is safe unconditionally', async () => {
+    const explicit = {
+      asset: { version: '1.1' },
+      geometricError: 100,
+      root: {
+        boundingVolume: { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] },
+        geometricError: 100,
+        refine: 'ADD',
+        content: { uri: 'a.pnts' },
+      },
+    };
+    const out = await expandImplicitTileset(explicit, {
+      entryUrl: 'https://tiles.example.com/tileset.json',
+      fetchSubtreeBytes: async () => {
+        throw new Error('an explicit document must fetch no subtree');
+      },
+    });
+    expect(parseTileset(out).root).toBeDefined();
+  });
+});


### PR DESCRIPTION
The subtree reader and the expander landed unreachable. `parseTileset` refuses an
implicit document by design, so a path that only parsed could never open one.

`openRemoteTileset` now expands before it parses. Every refusal the explicit path
makes still applies, because the expander rewrites the document into the
equivalent explicit one rather than teaching the parser a second shape. A tileset
declaring no implicit tiling comes back untouched, so this costs an explicit open
nothing.

A cancel raised while the expander is reading subtrees keeps its own identity
instead of surfacing as "this tileset was refused".

The three modules graduate out of the unreachable register, which is what caught
the omission. `docs/supported-formats.md` now states what opens and what stays
refused.
