### PR TITLE
docs(export): 3D Tiles point tiles can carry normals

### DIFF
--- a/src/app/openStreaming.ts
+++ b/src/app/openStreaming.ts
@@ -244,9 +244,11 @@ export function activateCommittedStreamingCloud(
  *
  * `imageExportModes` is the map the caller reads off the LIVE viewer
  * (`availableImageExportModes()`), not a constant: it is what disables the
- * per-mode buttons a given scene cannot fill. A tileset carries no intensity,
- * classification or normals, so passing the live map is what keeps those modes
- * dark rather than offering an export that would render nothing.
+ * per-mode buttons a given scene cannot fill. A tileset carries no intensity or
+ * classification, so those modes stay dark; it carries normals only when its
+ * tiles state them, and the same live map reflects that per layer. Passing the
+ * live map is what keeps a mode dark rather than offering an export that would
+ * render nothing.
  */
 export function enterStreamingInspectorMode(
   deps: Pick<OpenStreamingDeps, 'inspector' | 'exportPanel'>,

--- a/src/export/NormalMapExporter.ts
+++ b/src/export/NormalMapExporter.ts
@@ -11,6 +11,9 @@
  *   • COPC + EPT streaming sources don't carry normals — LAS reserves
  *     no field for them, and EPT writers rarely emit Normal X/Y/Z
  *     schema attributes.
+ *   • 3D Tiles point tiles DO carry normals when the tileset wrote them
+ *     (PNTS `NORMAL` or `NORMAL_OCT16P`), so a streamed tileset answers
+ *     yes or no per layer from what its tiles stated.
  *   • Static loaders DO sometimes carry normals: PCD with `_normal_`
  *     fields, PTX (from terrestrial scanners), some GLTF + PLY files.
  *

--- a/src/render/exportModeAvailability.ts
+++ b/src/render/exportModeAvailability.ts
@@ -67,7 +67,7 @@ export function imageExportModeAvailability(
     out.set('normal', {
       available: false,
       reason:
-        'This cloud has no per-point normals. LiDAR captures rarely include them; PCD / PTX / GLTF scans with normals are supported.',
+        'This cloud has no per-point normals. LiDAR captures rarely include them; PCD, PTX and GLTF scans and 3D Tiles point tiles that carry normals are supported.',
     });
   } else {
     out.set('normal', { available: true });


### PR DESCRIPTION
Three claims predate the streamed-normals work and read as though only static
loaders ever carry normals. A 3D Tiles tileset carries them when its tiles wrote
PNTS `NORMAL` or `NORMAL_OCT16P`, and the export adapter answers per layer from
what the tiles stated.

The streaming-mode note no longer says a tileset carries no normals. The
`NormalMapExporter` header names the point-tile case beside COPC and EPT. The
Normal Map unavailable reason, which a user reads, lists 3D Tiles among the
sources whose normals are supported.

Behaviour is unchanged: the availability test already pins that a source with
normals is offered the mode, so these are truth corrections to comments and one
help string.
