### PR TITLE
perf(ooc): index the out-of-core octree in one pass for a trusted header

### DIFF
--- a/src/io/heavy/oocIndexer.ts
+++ b/src/io/heavy/oocIndexer.ts
@@ -38,12 +38,32 @@ export interface PositionBatch {
 }
 
 /**
+ * What a trusted source header declares up front: the point count and the
+ * axis-aligned bounds. Both MUST be expressed in the same frame and numeric
+ * precision as the `positions` the batches yield (for the LAS path that is the
+ * origin-relative, Float32-rounded frame), so the grid a header builds is the
+ * grid a measuring pass would build. A header that is off by any amount that
+ * changes the grid is caught and the build falls back to the two-pass path, so
+ * an honest-but-imprecise or malformed header is still correct, only slower.
+ */
+export interface SourceHeader {
+  readonly pointCount: number;
+  readonly min: readonly [number, number, number];
+  readonly max: readonly [number, number, number];
+}
+
+/**
  * A point source the indexer can read TWICE. `batches()` must yield the same
  * points on every call — the bounds pass and the bucketing pass both consume it,
  * and a source that changed between them would place points against stale bounds.
+ *
+ * A source that also exposes a trusted {@link SourceHeader} lets the indexer skip
+ * the bounds pass and build in ONE pass; see {@link indexOutOfCore}.
  */
 export interface PointSource {
   batches(signal?: AbortSignal): AsyncGenerator<PositionBatch>;
+  /** Optional trusted count and bounds that enable a single-pass build. */
+  readonly header?: SourceHeader;
 }
 
 /** Where leaf tiles are spilled. A memory map in tests, an OPFS directory in the browser. */
@@ -54,6 +74,13 @@ export interface SpillStore {
   read(key: string): Promise<Uint8Array>;
   /** Every key written so far. */
   keys(): Promise<string[]>;
+  /**
+   * Drop every spilled tile, returning the store to empty. Optional: the
+   * single-pass fast path only runs on a store that can be cleared, because a
+   * header it later finds untrustworthy has to be rolled back before the two-pass
+   * path re-spills. A store without `clear` always takes the two-pass path.
+   */
+  clear?(): Promise<void>;
 }
 
 export interface OocLeaf {
@@ -80,6 +107,12 @@ export interface IndexOptions {
   readonly memoryBudgetBytes?: number;
   readonly maxDepth?: number;
   readonly signal?: AbortSignal;
+  /**
+   * Force the two-pass path even when the source header would allow one pass.
+   * The build is identical either way for a valid header; this exists so a test
+   * can run both paths on one fixture and compare, and as an escape hatch.
+   */
+  readonly forceSlowPath?: boolean;
 }
 
 /**
@@ -146,6 +179,64 @@ class LeafBuffer {
   }
 }
 
+/** Raised inside the fast pass when a point escapes the header's declared root. */
+class HeaderBoundsExceeded extends Error {}
+
+/**
+ * A header is usable for the single-pass build only if it names a finite count
+ * of at least one point and a finite, non-degenerate box. A zero-extent box (a
+ * single point, or an empty cloud) has no grid to build, so it takes two passes.
+ */
+function usableHeader(header: SourceHeader | undefined): SourceHeader | undefined {
+  if (!header) return undefined;
+  if (!Number.isFinite(header.pointCount) || header.pointCount < 1) return undefined;
+  for (let a = 0; a < 3; a++) {
+    if (!Number.isFinite(header.min[a]) || !Number.isFinite(header.max[a])) return undefined;
+    if (header.max[a] < header.min[a]) return undefined;
+  }
+  const extent = Math.max(
+    header.max[0] - header.min[0],
+    header.max[1] - header.min[1],
+    header.max[2] - header.min[2],
+  );
+  return extent > 0 ? header : undefined;
+}
+
+/** Two grids place points identically iff their root cube and depth match. */
+function gridsMatch(a: OctreeGrid, b: OctreeGrid): boolean {
+  return (
+    a.depth === b.depth &&
+    a.root.size === b.root.size &&
+    a.root.min[0] === b.root.min[0] &&
+    a.root.min[1] === b.root.min[1] &&
+    a.root.min[2] === b.root.min[2]
+  );
+}
+
+/**
+ * Index a point source into a spilled octree.
+ *
+ * The default build reads the source twice: pass one takes the bounds and count
+ * that fix the {@link OctreeGrid}, pass two buckets every point into its leaf.
+ * When the source exposes a trusted {@link PointSource.header} — a finite count
+ * and a non-degenerate box — and the store can be cleared, the bounds pass is
+ * skipped and the grid is built from the header, halving the decode work on a
+ * large file.
+ *
+ * The fast path is fenced so a wrong header can never ship a wrong index. It
+ * tracks the bounds it actually sees; a point outside the declared root aborts
+ * the pass at once, and even a box that merely contains the cloud is rejected
+ * unless the grid it builds is the same grid the measured bounds would build. On
+ * any rejection the spilled tiles are cleared and the build re-enters its own
+ * two-pass path from the start, so a malformed or imprecise header is still
+ * correct, only slower. For a header that is exact, the one-pass and two-pass
+ * indexes are byte-for-byte identical: same nodes, per-node counts, tile bytes,
+ * and manifest.
+ *
+ * The bucketing loop lives inline here, and the fallback is a re-entry with
+ * {@link IndexOptions.forceSlowPath}, so the single `.positions` read stays one
+ * classified source-local site rather than splitting across a helper.
+ */
 export async function indexOutOfCore(
   source: PointSource,
   store: SpillStore,
@@ -155,8 +246,28 @@ export async function indexOutOfCore(
   const pointsPerLeaf = Math.max(1, options.pointsPerLeaf ?? DEFAULT_POINTS_PER_LEAF);
   const budget = Math.max(POSITION_RECORD_BYTES, options.memoryBudgetBytes ?? DEFAULT_MEMORY_BUDGET);
 
-  const { min, max, count } = await scanBounds(source, signal);
-  const grid = octreeGridFor(min, max, count, pointsPerLeaf, options.maxDepth);
+  // The fast path spills before it can prove the header, so it must be able to
+  // undo that if the header proves false: it runs only on a clearable store.
+  const header = options.forceSlowPath ? undefined : usableHeader(source.header);
+  const track = !!(header && typeof store.clear === 'function');
+
+  // The grid is fixed up front: from the header on the fast path, from a bounds
+  // pass otherwise. `bounds`/`count` are what the slow path returns; the fast
+  // path overwrites them with what it observes, which for an exact header equals
+  // these anyway.
+  let grid: OctreeGrid;
+  let min: [number, number, number];
+  let max: [number, number, number];
+  let count: number;
+  if (track && header) {
+    grid = octreeGridFor(header.min, header.max, header.pointCount, pointsPerLeaf, options.maxDepth);
+    min = [Infinity, Infinity, Infinity];
+    max = [-Infinity, -Infinity, -Infinity];
+    count = 0;
+  } else {
+    ({ min, max, count } = await scanBounds(source, signal));
+    grid = octreeGridFor(min, max, count, pointsPerLeaf, options.maxDepth);
+  }
 
   const buffers = new Map<string, LeafBuffer>();
   const counts = new Map<string, number>();
@@ -185,66 +296,125 @@ export async function indexOutOfCore(
   const scratchBytes = new Uint8Array(scratch.buffer);
   let recordBytes = -1; // set from the first batch; every batch must agree
 
-  for await (const batch of source.batches(signal)) {
-    signal?.throwIfAborted();
-    const p = batch.positions;
-    const rb = batch.records ? batch.recordBytes ?? 0 : POSITION_RECORD_BYTES;
-    if (batch.records && rb <= 0) throw new Error('oocIndexer: a records batch must set a positive recordBytes');
-    if (recordBytes === -1) recordBytes = rb;
-    else if (rb !== recordBytes) throw new Error('oocIndexer: recordBytes changed between batches');
+  // The root cube the fast path holds every point to.
+  const loX = grid.root.min[0];
+  const loY = grid.root.min[1];
+  const loZ = grid.root.min[2];
+  const hiX = loX + grid.root.size;
+  const hiY = loY + grid.root.size;
+  const hiZ = loZ + grid.root.size;
+  let escaped = false; // a fast-path point left the declared root
 
-    for (let i = 0; i < batch.count; i++) {
-      const x = p[i * 3];
-      const y = p[i * 3 + 1];
-      const z = p[i * 3 + 2];
-      // PYRAMID PLACEMENT. A point does not go straight to its leaf: it settles
-      // at the COARSEST level whose cell still has room. That is what gives the
-      // scheduler something to draw before the fine tiles arrive — with every
-      // point at max depth there is no coarse representation, so showing the
-      // whole scan would mean loading the whole scan, which is the memory wall
-      // this indexer exists to remove.
-      //
-      // The octant path makes the ancestor walk free: the level-d cell of a leaf
-      // path is its first d characters, so no extra geometry is computed. When
-      // every level is full the deepest takes the overflow, so no point is ever
-      // dropped and conservation holds exactly.
-      const leafKey = grid.leafKeyFor(x, y, z);
-      let key = leafKey;
-      for (let d = 0; d <= grid.depth; d++) {
-        const candidate = d === grid.depth ? leafKey : leafKey.slice(0, d);
-        const filled = occupancy.get(candidate) ?? 0;
-        if (filled < nodeCapacity || d === grid.depth) {
-          occupancy.set(candidate, filled + 1);
-          key = candidate;
-          break;
+  try {
+    for await (const batch of source.batches(signal)) {
+      signal?.throwIfAborted();
+      const p = batch.positions;
+      const rb = batch.records ? batch.recordBytes ?? 0 : POSITION_RECORD_BYTES;
+      if (batch.records && rb <= 0) throw new Error('oocIndexer: a records batch must set a positive recordBytes');
+      if (recordBytes === -1) recordBytes = rb;
+      else if (rb !== recordBytes) throw new Error('oocIndexer: recordBytes changed between batches');
+
+      for (let i = 0; i < batch.count; i++) {
+        const x = p[i * 3];
+        const y = p[i * 3 + 1];
+        const z = p[i * 3 + 2];
+        if (track) {
+          count++;
+          if (x < min[0]) min[0] = x;
+          if (x > max[0]) max[0] = x;
+          if (y < min[1]) min[1] = y;
+          if (y > max[1]) max[1] = y;
+          if (z < min[2]) min[2] = z;
+          if (z > max[2]) max[2] = z;
+          // The header promised this box. A point outside it means the header
+          // lied; do not let leafKeyFor clamp it into an edge leaf and ship a
+          // silently misplaced point. Abort now and let the rebuild take over.
+          if (x < loX || x > hiX || y < loY || y > hiY || z < loZ || z > hiZ) {
+            throw new HeaderBoundsExceeded();
+          }
         }
+        // PYRAMID PLACEMENT. A point does not go straight to its leaf: it settles
+        // at the COARSEST level whose cell still has room. That is what gives the
+        // scheduler something to draw before the fine tiles arrive — with every
+        // point at max depth there is no coarse representation, so showing the
+        // whole scan would mean loading the whole scan, which is the memory wall
+        // this indexer exists to remove.
+        //
+        // The octant path makes the ancestor walk free: the level-d cell of a leaf
+        // path is its first d characters, so no extra geometry is computed. When
+        // every level is full the deepest takes the overflow, so no point is ever
+        // dropped and conservation holds exactly.
+        const leafKey = grid.leafKeyFor(x, y, z);
+        let key = leafKey;
+        for (let d = 0; d <= grid.depth; d++) {
+          const candidate = d === grid.depth ? leafKey : leafKey.slice(0, d);
+          const filled = occupancy.get(candidate) ?? 0;
+          if (filled < nodeCapacity || d === grid.depth) {
+            occupancy.set(candidate, filled + 1);
+            key = candidate;
+            break;
+          }
+        }
+        let buf = buffers.get(key);
+        if (buf === undefined) {
+          buf = new LeafBuffer();
+          buffers.set(key, buf);
+        }
+        let record: Uint8Array;
+        if (batch.records) {
+          record = batch.records.subarray(i * rb, i * rb + rb);
+        } else {
+          scratch[0] = x;
+          scratch[1] = y;
+          scratch[2] = z;
+          record = scratchBytes;
+        }
+        buf.append(record);
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+        buffered += rb;
+        if (buffered > peakBufferedBytes) peakBufferedBytes = buffered;
+        // Bound residency to the budget: spill everything once it is reached, so
+        // the high-water mark is the budget plus at most the record that tipped it.
+        if (buffered >= budget) await flush();
       }
-      let buf = buffers.get(key);
-      if (buf === undefined) {
-        buf = new LeafBuffer();
-        buffers.set(key, buf);
-      }
-      let record: Uint8Array;
-      if (batch.records) {
-        record = batch.records.subarray(i * rb, i * rb + rb);
-      } else {
-        scratch[0] = x;
-        scratch[1] = y;
-        scratch[2] = z;
-        record = scratchBytes;
-      }
-      buf.append(record);
-      counts.set(key, (counts.get(key) ?? 0) + 1);
-      buffered += rb;
-      if (buffered > peakBufferedBytes) peakBufferedBytes = buffered;
-      // Bound residency to the budget: spill everything once it is reached, so
-      // the high-water mark is the budget plus at most the record that tipped it.
-      if (buffered >= budget) await flush();
     }
+    await flush();
+  } catch (err) {
+    if (!(err instanceof HeaderBoundsExceeded)) throw err;
+    escaped = true;
   }
-  await flush();
-  if (recordBytes === -1) recordBytes = POSITION_RECORD_BYTES;
 
+  if (track) {
+    // Keep the fast build only if the box held every point AND the grid the
+    // observed bounds and count would build is the SAME grid — only then is this
+    // layout the two-pass path's layout. A looser box or an off count builds a
+    // different, still-valid tree, which is not identity, so rebuild instead.
+    const measuredGrid = escaped
+      ? grid
+      : octreeGridFor(min, max, count, pointsPerLeaf, options.maxDepth);
+    if (!escaped && gridsMatch(measuredGrid, grid)) {
+      if (recordBytes === -1) recordBytes = POSITION_RECORD_BYTES;
+      return assembleIndex(grid, count, min, max, counts, recordBytes, peakBufferedBytes);
+    }
+    // Untrustworthy header: drop the fast tiles and rebuild in two passes.
+    await store.clear!();
+    return indexOutOfCore(source, store, { ...options, forceSlowPath: true });
+  }
+
+  if (recordBytes === -1) recordBytes = POSITION_RECORD_BYTES;
+  return assembleIndex(grid, count, min, max, counts, recordBytes, peakBufferedBytes);
+}
+
+/** Assemble the sorted leaf list and the returned index from a finished pass. */
+function assembleIndex(
+  grid: OctreeGrid,
+  count: number,
+  min: [number, number, number],
+  max: [number, number, number],
+  counts: Map<string, number>,
+  recordBytes: number,
+  peakBufferedBytes: number,
+): OocIndex {
   const leaves: OocLeaf[] = [...counts.entries()]
     .map(([key, pointCount]) => ({ key, pointCount }))
     .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));

--- a/tests/oocOnePass.test.ts
+++ b/tests/oocOnePass.test.ts
@@ -1,0 +1,293 @@
+/**
+ * oocOnePass.test.ts — the single-pass out-of-core build and its guards.
+ *
+ * When a source exposes a trusted header (a finite count and a non-degenerate
+ * bounding box), the indexer skips the bounds pass and builds the octree in ONE
+ * read instead of two. The tests here pin the four properties that make that safe
+ * to run beside the two-pass path:
+ *
+ *   1. a valid header is read once, not twice;
+ *   2. the fast index is byte-for-byte the two-pass index — same nodes, per-node
+ *      counts, tile bytes, and manifest;
+ *   3. a header whose bounds a point escapes is rejected, and the build rebuilds
+ *      from measured bounds to the exact two-pass result;
+ *   4. a source with no usable header takes the two-pass path unchanged.
+ *
+ * A memory spill store with `clear` stands in for OPFS, so the whole build and
+ * its rollback run in Node.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  indexOutOfCore,
+  type OocIndex,
+  type PointSource,
+  type SourceHeader,
+  type SpillStore,
+} from '../src/io/heavy/oocIndexer';
+import { buildTileStore } from '../src/io/heavy/tileStore';
+import type { TileSchema } from '../src/io/heavy/tileRecord';
+
+/** An in-memory {@link SpillStore} that can be cleared, so the fast path may run. */
+function clearableStore(): SpillStore & { totalBytes(): number; cleared: number } {
+  const parts = new Map<string, Uint8Array[]>();
+  const store = {
+    cleared: 0,
+    async append(key: string, bytes: Uint8Array) {
+      const arr = parts.get(key) ?? [];
+      arr.push(bytes.slice());
+      parts.set(key, arr);
+    },
+    async read(key: string) {
+      const arr = parts.get(key) ?? [];
+      const total = arr.reduce((n, b) => n + b.byteLength, 0);
+      const out = new Uint8Array(total);
+      let o = 0;
+      for (const b of arr) {
+        out.set(b, o);
+        o += b.byteLength;
+      }
+      return out;
+    },
+    async keys() {
+      return [...parts.keys()];
+    },
+    async clear() {
+      parts.clear();
+      store.cleared += 1;
+    },
+    totalBytes() {
+      let n = 0;
+      for (const arr of parts.values()) for (const b of arr) n += b.byteLength;
+      return n;
+    },
+  };
+  return store;
+}
+
+/** Same store shape, but WITHOUT `clear` — a store the fast path must decline. */
+function plainStore(): SpillStore {
+  const s = clearableStore();
+  return { append: s.append, read: s.read, keys: s.keys };
+}
+
+const RECORD_BYTES = 19; // BASE_BYTES for a hasGps:false, hasRgb:false tile schema
+const SCHEMA: TileSchema = { hasGps: false, hasRgb: false };
+const ORIGIN: [number, number, number] = [0, 0, 0];
+
+/**
+ * A deterministic cloud that COUNTS how many point-records it decodes across all
+ * `batches()` iterations, so a test can tell one pass from two. Positions are
+ * packed into the first 12 bytes of each 19-byte record, so the store is a real
+ * tile store the manifest builder accepts.
+ */
+function countingSource(
+  count: number,
+  batchPoints: number,
+  headerFor: (min: [number, number, number], max: [number, number, number]) => SourceHeader | undefined,
+): PointSource & { reads: number; outlier?: [number, number, number] } {
+  const pts = new Float32Array(count * 3);
+  let s = 987654321 >>> 0;
+  const rnd = () => ((s = (1664525 * s + 1013904223) >>> 0) / 4294967296);
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < count; i++) {
+    const x = 500000 + rnd() * 1000;
+    const y = 4100000 + rnd() * 600;
+    const z = 190 + rnd() * 70;
+    pts[i * 3] = x;
+    pts[i * 3 + 1] = y;
+    pts[i * 3 + 2] = z;
+    for (let a = 0; a < 3; a++) {
+      const v = pts[i * 3 + a];
+      if (v < min[a]) min[a] = v;
+      if (v > max[a]) max[a] = v;
+    }
+  }
+
+  const src: PointSource & { reads: number; outlier?: [number, number, number] } = {
+    reads: 0,
+    header: headerFor(min, max),
+    async *batches(signal) {
+      for (let first = 0; first < count; first += batchPoints) {
+        signal?.throwIfAborted();
+        const n = Math.min(batchPoints, count - first);
+        const positions = new Float32Array(n * 3);
+        const records = new Uint8Array(n * RECORD_BYTES);
+        const view = new DataView(records.buffer);
+        for (let i = 0; i < n; i++) {
+          positions.set(pts.subarray((first + i) * 3, (first + i) * 3 + 3), i * 3);
+          view.setFloat32(i * RECORD_BYTES + 0, positions[i * 3], true);
+          view.setFloat32(i * RECORD_BYTES + 4, positions[i * 3 + 1], true);
+          view.setFloat32(i * RECORD_BYTES + 8, positions[i * 3 + 2], true);
+          view.setUint16(i * RECORD_BYTES + 12, (first + i) & 0xffff, true); // intensity, distinguishes records
+        }
+        src.reads += n;
+        yield { positions, count: n, records, recordBytes: RECORD_BYTES };
+      }
+    },
+  };
+  return src;
+}
+
+/** The exact-header source: header bounds equal the measured Float32 extrema. */
+function exactSource(count: number, batchPoints: number) {
+  return countingSource(count, batchPoints, (min, max) => ({ pointCount: count, min, max }));
+}
+
+/** Deep-comparable view of an index: the data that must be identical, minus closures. */
+function shape(index: OocIndex) {
+  return {
+    root: index.grid.root,
+    depth: index.depth,
+    pointCount: index.pointCount,
+    bounds: index.bounds,
+    recordBytes: index.recordBytes,
+    peakBufferedBytes: index.peakBufferedBytes,
+    leaves: [...index.leaves].map((l) => ({ key: l.key, pointCount: l.pointCount })),
+  };
+}
+
+/** Every tile's bytes, keyed, so two stores can be compared exactly. */
+async function tiles(store: SpillStore, index: OocIndex): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  for (const leaf of index.leaves) {
+    const bytes = await store.read(leaf.key);
+    out.set(leaf.key, Buffer.from(bytes).toString('hex'));
+  }
+  return out;
+}
+
+describe('single-pass out-of-core build', () => {
+  it('reads each point ONCE for a valid-header source', async () => {
+    const count = 200_000;
+    const src = exactSource(count, 20_000);
+    const store = clearableStore();
+
+    await indexOutOfCore(src, store, { pointsPerLeaf: 10_000, memoryBudgetBytes: 256 * 1024 });
+
+    // Two passes would decode 2 * count records. One pass decodes exactly count.
+    expect(src.reads).toBe(count);
+  });
+
+  it('produces a byte-for-byte identical index to the two-pass path', async () => {
+    const count = 200_000;
+    const opts = { pointsPerLeaf: 10_000, memoryBudgetBytes: 256 * 1024 } as const;
+
+    const fastStore = clearableStore();
+    const fast = await indexOutOfCore(exactSource(count, 20_000), fastStore, opts);
+
+    const slowSrc = exactSource(count, 20_000);
+    const slowStore = clearableStore();
+    const slow = await indexOutOfCore(slowSrc, slowStore, { ...opts, forceSlowPath: true });
+
+    // The forced path really did read twice; the fast one really did not.
+    expect(slowSrc.reads).toBe(count * 2);
+
+    // 1. Same nodes and per-node counts, same bounds, same peak memory.
+    expect(shape(fast)).toEqual(shape(slow));
+    // 2. Same tile bytes for every key.
+    expect(await tiles(fastStore, fast)).toEqual(await tiles(slowStore, slow));
+    // 3. Same manifest and hierarchy.
+    const a = buildTileStore(fast, SCHEMA, ORIGIN);
+    const b = buildTileStore(slow, SCHEMA, ORIGIN);
+    expect(a.manifestJson).toBe(b.manifestJson);
+    expect(a.hierarchy).toBe(b.hierarchy);
+  });
+
+  it('rejects a header whose bounds a point escapes and rebuilds the two-pass index', async () => {
+    const count = 120_000;
+    const opts = { pointsPerLeaf: 8_000, memoryBudgetBytes: 128 * 1024 } as const;
+
+    // A header that under-declares the box: shrink max so real points fall outside.
+    const liar = countingSource(count, 15_000, (min, max) => ({
+      pointCount: count,
+      min,
+      max: [max[0] - 200, max[1] - 120, max[2] - 15],
+    }));
+    const liarStore = clearableStore();
+    const fromLiar = await indexOutOfCore(liar, liarStore, opts);
+
+    // The fast attempt aborted (store was cleared) and re-read from the start.
+    expect(liarStore.cleared).toBeGreaterThan(0);
+
+    // The result equals what a pure two-pass build makes from the honest points.
+    const honestSrc = exactSource(count, 15_000);
+    const honestStore = clearableStore();
+    const honest = await indexOutOfCore(honestSrc, honestStore, { ...opts, forceSlowPath: true });
+
+    expect(shape(fromLiar)).toEqual(shape(honest));
+    expect(await tiles(liarStore, fromLiar)).toEqual(await tiles(honestStore, honest));
+  });
+
+  it('aborts EARLY when the escaping point is in the first batch (does not finish the fast pass)', async () => {
+    const count = 100_000;
+    const batch = 10_000;
+    // Under-declare the box so the very first batch already holds outliers.
+    const liar = countingSource(count, batch, (min, max) => ({
+      pointCount: count,
+      min,
+      max: [max[0] - 300, max[1], max[2]],
+    }));
+    const store = clearableStore();
+    await indexOutOfCore(liar, store, { pointsPerLeaf: 8_000, memoryBudgetBytes: 128 * 1024 });
+
+    // reads = (short fast attempt that stopped inside the first batch) + full slow 2 passes.
+    // If the fast attempt had run to the end it would be batch..count before failing,
+    // pushing reads to 3 * count. Early abort keeps it well under that.
+    expect(store.cleared).toBeGreaterThan(0);
+    expect(liar.reads).toBeLessThan(count * 3);
+    expect(liar.reads).toBeLessThanOrEqual(count * 2 + batch);
+  });
+
+  it('takes the two-pass path unchanged when the header is missing', async () => {
+    const count = 80_000;
+    const noHeader = countingSource(count, 10_000, () => undefined);
+    const store = clearableStore();
+    await indexOutOfCore(noHeader, store, { pointsPerLeaf: 8_000, memoryBudgetBytes: 128 * 1024 });
+    expect(noHeader.reads).toBe(count * 2);
+    expect(store.cleared).toBe(0);
+  });
+
+  it('takes the two-pass path when the header bounds are degenerate', async () => {
+    const count = 40_000;
+    // Zero-extent box: min === max. Not usable, so no fast path.
+    const degen = countingSource(count, 10_000, (min) => ({ pointCount: count, min, max: min }));
+    const store = clearableStore();
+    await indexOutOfCore(degen, store, { pointsPerLeaf: 8_000, memoryBudgetBytes: 128 * 1024 });
+    expect(store.cleared).toBe(0);
+    expect(degen.reads).toBe(count * 2);
+  });
+
+  it('falls back on a superset header whose grid differs, and still equals the two-pass index', async () => {
+    const count = 90_000;
+    const opts = { pointsPerLeaf: 8_000, memoryBudgetBytes: 128 * 1024 } as const;
+    // Bounds strictly contain every point but are larger, so the grid the header
+    // builds is not the grid measured bounds build. No point escapes, so only the
+    // post-pass grid check catches it.
+    const superset = countingSource(count, 15_000, (min, max) => ({
+      pointCount: count,
+      min: [min[0] - 500, min[1] - 500, min[2] - 500],
+      max: [max[0] + 500, max[1] + 500, max[2] + 500],
+    }));
+    const supStore = clearableStore();
+    const fromSuperset = await indexOutOfCore(superset, supStore, opts);
+    expect(supStore.cleared).toBeGreaterThan(0);
+
+    const honestStore = clearableStore();
+    const honest = await indexOutOfCore(exactSource(count, 15_000), honestStore, {
+      ...opts,
+      forceSlowPath: true,
+    });
+    expect(shape(fromSuperset)).toEqual(shape(honest));
+    expect(await tiles(supStore, fromSuperset)).toEqual(await tiles(honestStore, honest));
+  });
+
+  it('declines the fast path on a store that cannot be cleared (two passes, correct)', async () => {
+    const count = 60_000;
+    const opts = { pointsPerLeaf: 8_000, memoryBudgetBytes: 128 * 1024 } as const;
+    const src = exactSource(count, 10_000);
+    await indexOutOfCore(src, plainStore(), opts);
+    // No clear() means no safe rollback, so the build stays two-pass.
+    expect(src.reads).toBe(count * 2);
+  });
+});


### PR DESCRIPTION
`indexOutOfCore` read every point twice: pass one for the bounds and count
that fix the octree grid, pass two to bucket and spill. When a `PointSource`
exposes a trusted header (finite count, non-degenerate box) and the spill
store can be cleared, this build skips the bounds pass and derives the grid
from the header, decoding a large file once instead of twice.

The fast path tracks the bounds it sees. A point outside the declared root
aborts it, and a box that only contains the cloud is rejected unless it
builds the same grid the measured bounds would. On rejection the tiles are
cleared and the two-pass path reruns, so a wrong header stays correct. For an
exact header the paths produce a byte-identical index, proven by a new test.
The signature is unchanged.
