### PR TITLE
Bound OPFS promotion copy where move() is absent

### DIFF
--- a/src/io/heavy/opfsSpillStore.ts
+++ b/src/io/heavy/opfsSpillStore.ts
@@ -44,6 +44,12 @@ export interface OpfsFile {
   readonly size: number;
   arrayBuffer(): Promise<ArrayBuffer>;
   text(): Promise<string>;
+  /**
+   * A byte range as its own file, without reading the rest. A real `File` is a
+   * `Blob`, whose `slice` returns a `Blob` that satisfies this same shape, so
+   * the promotion fallback can copy a large tile a bounded window at a time.
+   */
+  slice(start: number, end: number): OpfsFile;
 }
 /**
  * The worker-only random-access handle. Its methods are synchronous in the
@@ -393,16 +399,32 @@ export async function openOpfsSpillBuild(root: OpfsDirHandle, name: string): Pro
  * degenerate that every point settles in one node, where the largest tile IS
  * the store; such a cloud has no usable octree either way.
  */
+/**
+ * Window size for the `move`-absent promotion copy. 16 MiB bounds the transient
+ * RAM of a promotion to one chunk while keeping the number of OPFS writes small
+ * for an ordinary multi-megabyte tile; the exact figure is not load-bearing.
+ */
+export const PROMOTION_COPY_CHUNK_BYTES = 16 * 1024 * 1024;
+
 async function relocate(from: OpfsDirHandle, to: OpfsDirHandle, name: string): Promise<void> {
   const source = await from.getFileHandle(name);
   if (typeof source.move === 'function') {
     await source.move(to, name);
     return;
   }
-  const bytes = new Uint8Array(await (await source.getFile()).arrayBuffer());
+  // No `move`: copy the bytes ourselves, but never materialise the whole tile.
+  // A degenerate cloud can settle almost the entire dataset in one node, and
+  // `arrayBuffer()` on such a tile would defeat the out-of-core guarantee at the
+  // final step. Copy in a fixed window so promotion RAM is one chunk regardless
+  // of tile size, then delete the source, preserving the move path's invariant
+  // that at most one tile is briefly duplicated.
+  const file = await source.getFile();
   const handle = await to.getFileHandle(name, { create: true });
   const writable = await handle.createWritable();
-  await writable.write(bytes);
+  for (let offset = 0; offset < file.size; offset += PROMOTION_COPY_CHUNK_BYTES) {
+    const end = Math.min(offset + PROMOTION_COPY_CHUNK_BYTES, file.size);
+    await writable.write(new Uint8Array(await file.slice(offset, end).arrayBuffer()));
+  }
   await writable.close();
   await from.removeEntry(name);
 }

--- a/tests/opfsSpillPromotion.test.ts
+++ b/tests/opfsSpillPromotion.test.ts
@@ -1,0 +1,82 @@
+/**
+ * opfsSpillPromotion.test.ts — the `move`-absent promotion copy stays bounded.
+ *
+ * Promotion moves each tile from the `.partial` store into the final one. Where
+ * `FileSystemFileHandle.move` exists (Chromium) the bytes never move and nothing
+ * is read. Where it is absent (Safari today) the store copies the bytes itself,
+ * and the defect these tests pin is that the copy must not read the whole tile
+ * into memory: a degenerate cloud can settle almost the entire dataset in one
+ * node, and `arrayBuffer()` on that tile would defeat the out-of-core guarantee
+ * at the last step. The fake records every `arrayBuffer()` read size, so a
+ * whole-file read is observable and a windowed copy is provably bounded.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  openOpfsSpillBuild,
+  PROMOTION_COPY_CHUNK_BYTES,
+} from '../src/io/heavy/opfsSpillStore';
+import { fakeOpfs } from './support/fakeOpfs';
+
+/** A tile just over one window, so the fallback must copy in more than one piece. */
+const TILE_BYTES = PROMOTION_COPY_CHUNK_BYTES + 1024;
+
+function patternTile(size: number): Uint8Array {
+  const out = new Uint8Array(size);
+  for (let i = 0; i < size; i++) out[i] = (i * 31 + 7) & 0xff;
+  return out;
+}
+
+function bytesUnder(fs: ReturnType<typeof fakeOpfs>, name: string): Uint8Array {
+  const entry = [...fs.snapshot()].find(([path]) => path.endsWith(name));
+  if (entry === undefined) throw new Error(`no file ending in ${name}`);
+  return entry[1];
+}
+
+describe('OPFS spill promotion', () => {
+  it('copies a multi-chunk tile without ever reading the whole tile, byte-identical, when move() is absent', async () => {
+    const fs = fakeOpfs({ syncAccess: true, fileMove: false });
+    const build = await openOpfsSpillBuild(fs.root, 'store');
+    const tile = patternTile(TILE_BYTES);
+    await build.store.append('3', tile);
+
+    // Discard the write-path bookkeeping; we only judge the promotion copy.
+    fs.stats.arrayBufferReads.length = 0;
+
+    await build.promote();
+
+    // The heart of the fix: no single read is the whole tile. Every read the
+    // fallback made is one window or less.
+    expect(fs.stats.arrayBufferReads.length).toBeGreaterThan(1);
+    expect(Math.max(...fs.stats.arrayBufferReads)).toBeLessThanOrEqual(PROMOTION_COPY_CHUNK_BYTES);
+    expect(fs.stats.arrayBufferReads.some((n) => n === TILE_BYTES)).toBe(false);
+
+    // No move() available, so nothing took the zero-copy path.
+    expect(fs.stats.fileMoves).toBe(0);
+
+    // Byte-identity: the promoted tile equals the source tile exactly.
+    const promoted = bytesUnder(fs, 'store/3.tile');
+    expect(promoted.length).toBe(TILE_BYTES);
+    expect(Buffer.from(promoted).equals(Buffer.from(tile))).toBe(true);
+
+    // The source is gone; only one copy survives.
+    expect(fs.topLevel()).toEqual(['store']);
+  });
+
+  it('takes the zero-copy move() fast path with no read or slice when move() is present', async () => {
+    const fs = fakeOpfs({ syncAccess: true, fileMove: true });
+    const build = await openOpfsSpillBuild(fs.root, 'store');
+    const tile = patternTile(TILE_BYTES);
+    await build.store.append('3', tile);
+
+    fs.stats.arrayBufferReads.length = 0;
+
+    await build.promote();
+
+    // Fast path: one move, zero bytes read.
+    expect(fs.stats.movedNames).toContain('3.tile');
+    expect(fs.stats.arrayBufferReads.length).toBe(0);
+
+    const promoted = bytesUnder(fs, 'store/3.tile');
+    expect(Buffer.from(promoted).equals(Buffer.from(tile))).toBe(true);
+  });
+});

--- a/tests/support/fakeOpfs.ts
+++ b/tests/support/fakeOpfs.ts
@@ -40,6 +40,12 @@ export interface FakeOpfsStats {
   movedNames: string[];
   /** Most tile files holding an open sync access handle at any one moment. */
   peakOpenSyncHandles: number;
+  /**
+   * Byte length returned by every `arrayBuffer()` call, whole-file or slice, in
+   * order. A promotion that reads a whole tile at once shows one read the size
+   * of the tile; a bounded copy shows only reads no larger than its window.
+   */
+  arrayBufferReads: number[];
 }
 
 export interface FakeOpfsOptions {
@@ -98,7 +104,27 @@ export function fakeOpfs(options: FakeOpfsOptions = {}): FakeOpfs {
     fileMoves: 0,
     movedNames: [],
     peakOpenSyncHandles: 0,
+    arrayBufferReads: [],
   };
+
+  // A read-only view over a byte range that records what it hands out and can
+  // slice itself further, so the real `File`/`Blob` `slice(...).arrayBuffer()`
+  // chain the store relies on is modelled, cost included.
+  function makeFileView(data: Uint8Array): import('../../src/io/heavy/opfsSpillStore').OpfsFile {
+    return {
+      size: data.length,
+      async arrayBuffer() {
+        stats.arrayBufferReads.push(data.length);
+        return data.slice().buffer;
+      },
+      async text() {
+        return new TextDecoder().decode(data);
+      },
+      slice(start, end) {
+        return makeFileView(data.subarray(start, end));
+      },
+    };
+  }
   let openSyncHandles = 0;
 
   function totalBytes(node: FakeDir = rootNode): number {
@@ -136,16 +162,7 @@ export function fakeOpfs(options: FakeOpfsOptions = {}): FakeOpfs {
 
     const handle: OpfsFileHandle = {
       async getFile() {
-        const data = file().data;
-        return {
-          size: data.length,
-          async arrayBuffer() {
-            return data.slice().buffer;
-          },
-          async text() {
-            return new TextDecoder().decode(data);
-          },
-        };
+        return makeFileView(file().data);
       },
       async createWritable(opts) {
         const f = file();


### PR DESCRIPTION
Bound OPFS promotion copy where move() is absent

The out-of-core spill store promotes each tile from the .partial store
into the final one. On engines with FileSystemFileHandle.move (Chromium)
the bytes never move. On engines without it (Safari today) relocate()
read the whole tile with getFile().arrayBuffer() before writing it back.
A degenerate cloud can settle almost the entire dataset in one tile, so
that read could pull several gigabytes into the tab and break the
memory-bounded guarantee at the final step.

The move()-absent fallback now copies the source file in fixed 16 MiB
windows through File.slice(...).arrayBuffer(), so promotion RAM is one
chunk regardless of tile size. The move() fast path is unchanged. New
tests prove a multi-chunk tile promotes byte-identically without a
whole-file read and that move() still takes the zero-copy path.
