### PR TITLE
Fail closed on heavy LAS instead of the whole-file loader

### DIFF
--- a/docs/architecture/heavy-cloud-native.md
+++ b/docs/architecture/heavy-cloud-native.md
@@ -143,10 +143,16 @@ and dispatches the index to `localOocIndexerWorker`. The worker wraps the
 `buildTileStoreFromLas`, and posts back the manifest and hierarchy. The main
 thread reopens the promoted store from OPFS, constructs an `OlvTileSource`, and
 hands it to `Viewer.attachStreamingCloud` with the shared streaming-scan reveal
-(`streamingScanReveal.ts`). Any non-attach outcome falls back to the whole-file
-loader, so the path never makes a working open worse. The non-attach cases are:
-the plan does not route out of core, OPFS or workers are absent, the preflight
-refuses, or the build fails before commit. A Node test drives the whole decision
+(`streamingScanReveal.ts`). Heaviness is decided first, from the header peek and
+the plan, independently of capability. A file the plan does NOT route out of core
+returns `not-heavy` and the whole-file loader takes it unchanged. But once a file
+is confirmed heavy, the whole-file loader is not a safe fallback: its single
+`new Uint8Array(total)` is the allocation that made the file heavy. So a heavy
+file whose out-of-core path cannot complete — OPFS or workers absent, the
+preflight refuses, or the build fails before commit — returns a `heavy: true`
+status and the open REFUSES with a named reason that points at COPC/EPT, rather
+than falling through into an out-of-memory crash. Only `attached` and `cancelled`
+are terminal otherwise. A Node test drives the whole decision
 and dispatch against a fake OPFS and an in-process build. It asserts the largest
 single read is a bounded batch far smaller than the file and that the streamed
 cloud reports the source point count.

--- a/src/app/heavyLasExecutor.ts
+++ b/src/app/heavyLasExecutor.ts
@@ -58,8 +58,10 @@ function heavyStoreName(file: File): string {
 /**
  * Build the tile store, reopen it from OPFS, and attach it as a streaming scan.
  * Called only when the decision half has confirmed the plan routes this file out
- * of core. Every failure path returns a non-`attached` status the caller reads
- * as "fall back to the whole-file loader", so this can never leave a blank scene.
+ * of core, so every failure path here is a CONFIRMED-heavy failure: it returns a
+ * non-`attached`, `heavy: true` status the caller reads as "refuse, do not fall
+ * back", because the whole-file loader would face the same too-large allocation.
+ * `cancelled` is the one non-heavy tag: the user stopped the open on purpose.
  */
 export async function executeHeavyLasBuild(
   file: File,
@@ -73,19 +75,21 @@ export async function executeHeavyLasBuild(
   const runIndex = env.runIndex ?? ((request) => new LocalOocIndexerClient().run(request));
 
   const root = await getOpfsRoot();
-  if (root === null) return { status: 'unavailable', reason: 'no OPFS root' };
+  if (root === null) return { status: 'unavailable', heavy: true, reason: 'no OPFS root' };
 
   // The disk guard. Sized from the declared point count and the record schema,
-  // it refuses BEFORE any byte is written when the tile cache would not fit —
-  // the fail-closed answer when storage cannot even be read.
+  // it refuses BEFORE any byte is written when the tile cache would not fit, or
+  // when storage cannot even be read. The file is already confirmed heavy, so
+  // this refusal reaches the user rather than falling through to a whole-file
+  // load that would hit the same ceiling.
   const verdict = await storagePreflight(
     { pointCount: facts.declaredPointCount, schema: facts.schema },
     readStorage,
   );
   if (!verdict.proceed) {
     const error = storagePreflightRefusal(verdict, file.name);
-    if (error) return { status: 'refused', error };
-    return { status: 'unavailable', reason: 'preflight refused without a message' };
+    if (error) return { status: 'refused', heavy: true, error };
+    return { status: 'unavailable', heavy: true, reason: 'preflight refused without a message' };
   }
 
   try {
@@ -117,8 +121,8 @@ export async function executeHeavyLasBuild(
     if (err instanceof LoadCancelledError || (err as { name?: string })?.name === 'AbortError') {
       return { status: 'cancelled' };
     }
-    if (deps.debug) console.warn('[heavy-las] out-of-core open failed; falling back', err);
-    return { status: 'failed', error: err };
+    if (deps.debug) console.warn('[heavy-las] out-of-core open failed; refusing', err);
+    return { status: 'failed', heavy: true, error: err };
   }
 }
 

--- a/src/app/heavyLasTypes.ts
+++ b/src/app/heavyLasTypes.ts
@@ -89,17 +89,30 @@ export interface LasHeaderFacts {
   readonly fileBytes: number;
 }
 
-/** The outcome of an out-of-core open attempt. */
+/**
+ * The outcome of an out-of-core open attempt.
+ *
+ * The `heavy` flag on `unavailable`, `refused` and `failed` is the fail-closed
+ * discriminator the router reads. It records whether the file was CONFIRMED
+ * heavy (the header peek parsed and {@link planLoad} set `buildThenStream`)
+ * before the out-of-core path could not complete. `heavy: true` means the
+ * whole-file loader would face the very allocation that made the file heavy, so
+ * the caller must REFUSE rather than fall through. `heavy: false` means the file
+ * was never routed out of core and the whole-file loader is the correct answer,
+ * so the caller falls through as before. This is why heaviness is decided
+ * independently of capability: an `unavailable` result alone cannot say whether
+ * a fall-through is safe; the flag can.
+ */
 export type HeavyOpenResult =
   /** A streaming source was attached — the file is open. */
   | { readonly status: 'attached'; readonly source: OlvTileSource; readonly decoder: TileChunkDecoder }
   /** The plan did not route this file out of core; the caller loads it whole. */
   | { readonly status: 'not-heavy' }
-  /** OPFS or workers were unavailable; the caller loads the file whole. */
-  | { readonly status: 'unavailable'; readonly reason: string }
-  /** The storage preflight refused; the caller may surface the named message. */
-  | { readonly status: 'refused'; readonly error: LoadError }
+  /** OPFS or workers were unavailable. Fall through only when `heavy` is false. */
+  | { readonly status: 'unavailable'; readonly heavy: boolean; readonly reason: string }
+  /** The storage preflight refused. Fall through only when `heavy` is false. */
+  | { readonly status: 'refused'; readonly heavy: boolean; readonly error: LoadError }
   /** The build or attach was cancelled before commit. */
   | { readonly status: 'cancelled' }
-  /** The build or attach failed before commit; the caller loads the file whole. */
-  | { readonly status: 'failed'; readonly error: unknown };
+  /** The build or attach failed before commit. Fall through only when `heavy` is false. */
+  | { readonly status: 'failed'; readonly heavy: boolean; readonly error: unknown };

--- a/src/app/openLocalHeavyLas.ts
+++ b/src/app/openLocalHeavyLas.ts
@@ -16,12 +16,18 @@
  * delegates there only after the plan has already routed the file out of core,
  * so a small LAS, any LAZ, or a non-capable environment never loads that chunk.
  *
- * FAIL SAFE, ALWAYS. This wires into the live file-open path, so it must never
- * make a working open worse. Every way the out-of-core path can decline — the
- * plan says no, OPFS or workers are absent, the preflight refuses, the build or
- * the attach throws before the commit — returns a status the caller reads as
- * "fall back to the whole-file loader". A crash or a blank scene where the file
- * used to open is the one outcome this function exists to prevent.
+ * FAIL SAFE FOR SMALL FILES, FAIL CLOSED FOR HEAVY ONES. This wires into the
+ * live file-open path. Heaviness is decided FIRST, independently of capability:
+ * the cheap header peek and the same {@link planLoad} the loader runs. A file
+ * the plan does NOT route out of core returns `not-heavy` and the caller loads
+ * it whole, exactly as before — a browser without OPFS still opens every small
+ * LAS. But once a file is CONFIRMED heavy, the whole-file loader is not a safe
+ * answer: its single `new Uint8Array(total)` is the very allocation that made
+ * the file heavy, so for a heavy file every way the out-of-core path can decline
+ * — OPFS or workers absent, the preflight refuses, the build throws — returns a
+ * `heavy: true` status the caller reads as "refuse and tell the user", never
+ * "fall back". Falling a heavy file through to the whole-file loader would trade
+ * a clean refusal for an out-of-memory crash; that is the outcome this guards.
  */
 import type { RangeSource } from '../io/range/RangeSource';
 import { LocalFileRangeSource } from '../io/range/LocalFileRangeSource';
@@ -47,6 +53,36 @@ export type {
   HeavyOpenResult,
   LasHeaderFacts,
 } from './heavyLasTypes';
+
+/**
+ * The user-facing sentence for a heavy file the out-of-core path could not open.
+ * Every branch names why the file could not stream AND points at the real way
+ * out — converting to COPC or EPT, which stream from the file and write no local
+ * cache. Never generic: the whole point of the fail-closed change is that the
+ * user learns the true reason instead of watching the tab run out of memory.
+ *
+ * Only `unavailable`, `refused` and `failed` reach here, and only when `heavy`
+ * is true; the router guarantees that before calling it.
+ */
+export function describeHeavyRefusal(
+  result: Extract<HeavyOpenResult, { status: 'unavailable' | 'refused' | 'failed' }>,
+): string {
+  const convert =
+    'Convert it to COPC or EPT (with PDAL or untwine) and open that instead, which streams ' +
+    'from the file and writes no local cache.';
+  if (result.status === 'refused') {
+    // The preflight already built a precise sentence (the file name, the bytes
+    // it needed against what was free, and the same convert advice); keep it.
+    return result.error.message;
+  }
+  if (result.status === 'unavailable') {
+    return (
+      'This LAS is too large to open in one piece, and this browser has no storage for the ' +
+      `streaming index (${result.reason}). ${convert}`
+    );
+  }
+  return `This LAS is too large to open in one piece, and its streaming index could not be built. ${convert}`;
+}
 
 /** How many header bytes to peek. The LAS public header is 375 bytes; this is
  *  generous slack, and always far smaller than a file that routes out of core. */
@@ -116,8 +152,9 @@ function defaultOpenRange(file: File): RangeSource {
 
 /**
  * Attempt to open `file` through the out-of-core build. See the module header
- * for the fail-safe contract: any non-`attached` result is the caller's cue to
- * fall back to the whole-file loader (or, for `refused`, to surface the message).
+ * for the contract: a `not-heavy` result is the caller's cue to load the file
+ * whole; a `heavy: true` `unavailable` / `refused` / `failed` is its cue to
+ * refuse and surface the message; `attached` / `cancelled` are terminal.
  */
 export async function openLocalHeavyLas(
   file: File,
@@ -128,12 +165,11 @@ export async function openLocalHeavyLas(
   const capable = env.capable ?? defaultCapable;
   const openRange = env.openRange ?? defaultOpenRange;
 
-  // Capability probe first, before any read: without OPFS and workers the
-  // out-of-core path cannot run, and the whole-file loader is the answer. In a
-  // Node/JSDOM harness neither exists, so this returns immediately and the live
-  // open path behaves exactly as it did before this module.
-  if (!capable()) return { status: 'unavailable', reason: 'OPFS or Web Workers unavailable' };
-
+  // Heaviness FIRST, before the capability probe. The header peek is a small
+  // ranged read that is cheap even where the out-of-core path cannot run, and it
+  // is what tells us whether a fall-through to the whole-file loader is safe. A
+  // file whose header does not parse as an uncompressed LAS is not one this path
+  // handles, so it is not-heavy and the whole-file loader takes it.
   const facts = await peekLasHeaderFacts(openRange(file), signal);
   if (facts === null) return { status: 'not-heavy' };
 
@@ -151,9 +187,20 @@ export async function openLocalHeavyLas(
   });
   if (!plan.buildThenStream) return { status: 'not-heavy' };
 
-  // Only now, with the file confirmed heavy, load the out-of-core execution
-  // chunk. The decision path above never triggers this import, so the eager
-  // shell never pays for the cluster.
+  // The file is CONFIRMED heavy from here on. Now the capability probe: without
+  // OPFS and workers the out-of-core path cannot run, and the whole-file loader
+  // is NOT a safe fall-back for a heavy file — it faces the same too-large
+  // allocation. So this refuses (`heavy: true`) rather than falling through. In
+  // a Node/JSDOM harness neither Worker nor OPFS exists, but a test injects
+  // `env.capable`, so this branch is exercised deliberately, not by the harness.
+  if (!capable()) {
+    return { status: 'unavailable', heavy: true, reason: 'OPFS or Web Workers unavailable' };
+  }
+
+  // With the file confirmed heavy and the platform capable, load the out-of-core
+  // execution chunk. The decision path above never triggers this import, so the
+  // eager shell never pays for the cluster. Every non-`attached`/`cancelled`
+  // result it returns is a confirmed-heavy failure the caller must surface.
   const { executeHeavyLasBuild } = await loadHeavyLasExecutor();
   return executeHeavyLasBuild(file, signal, facts, deps, env);
 }

--- a/src/app/openScan.ts
+++ b/src/app/openScan.ts
@@ -26,7 +26,7 @@ import { describeLoadError } from '../io/loadErrors';
 import { formatTelemetry } from '../io/loadTelemetry';
 import { buildBenchmarkResult, formatBenchmarkResult } from '../io/benchmark';
 import { LoadCancelledError } from '../io/loadFile';
-import { openLocalHeavyLas } from './openLocalHeavyLas';
+import { openLocalHeavyLas, describeHeavyRefusal } from './openLocalHeavyLas';
 import type { OpenStreamingDeps } from './openStreaming';
 import { availableModes } from '../render/colorModes';
 import { recommendColorMode } from '../render/colorModeRecommend';
@@ -259,11 +259,13 @@ export async function openScan(file: File, deps: OpenScanDeps): Promise<void> {
     // A large uncompressed LAS whose whole-file load would exceed the memory
     // ceiling is built into an out-of-core OPFS tile store and streamed, rather
     // than materialised as one ArrayBuffer. The bridge reads only the header
-    // first and decides: it returns `attached` only when a streaming scan is on
-    // screen, and every other outcome — the plan does not route out of core,
-    // OPFS or workers are absent, the storage preflight refuses, or the build
-    // failed before commit — falls through to the whole-file loader below
-    // unchanged, so the out-of-core path can never make a working open worse.
+    // first and decides. It returns `attached` when a streaming scan is on
+    // screen and `cancelled` when the user stopped; `not-heavy` means the file
+    // was never routed out of core, so the whole-file loader below takes it
+    // unchanged. But a `heavy: true` `unavailable` / `refused` / `failed` means
+    // the file IS heavy and the out-of-core path could not run: the whole-file
+    // loader would face the same too-large allocation, so this REFUSES with a
+    // named reason instead of falling through into an out-of-memory crash.
     const heavy = await openLocalHeavyLas(file, controller.signal, {
       viewerReady: deps.viewerReady,
       getViewer: deps.getViewer,
@@ -290,6 +292,20 @@ export async function openScan(file: File, deps: OpenScanDeps): Promise<void> {
     if (heavy.status === 'cancelled') {
       deps.dropZone.setCancelHandler(null);
       deps.dropZone.setProgress(null);
+      return;
+    }
+    // A CONFIRMED-heavy file whose out-of-core index could not be built must NOT
+    // reach the whole-file loader. Surface the named reason on the drop zone the
+    // same way a load failure is surfaced, and stop. `not-heavy` (and a
+    // defensive `heavy: false`) still falls through to the loader below.
+    if (heavy.status !== 'not-heavy' && heavy.heavy) {
+      deps.dropZone.setCancelHandler(null);
+      deps.dropZone.setProgress(null);
+      const message = describeHeavyRefusal(heavy);
+      if (deps.debug) {
+        console.error('OpenLiDARViewer — heavy LAS refused (out-of-core unavailable)', heavy);
+      }
+      deps.dropZone.setError(message);
       return;
     }
     // Phones get a tighter point budget — limited GPU memory and fill-rate.

--- a/tests/heavyLasBridgeStreaming.test.ts
+++ b/tests/heavyLasBridgeStreaming.test.ts
@@ -29,7 +29,9 @@ import type { RangeSource } from '../src/io/range/RangeSource';
 import { fakeOpfs } from './support/fakeOpfs';
 import { buildLocalOocStore } from '../src/io/heavy/localOocBuild';
 import { OlvTileSource } from '../src/io/heavy/OlvTileSource';
+import { LoadError } from '../src/io/loadErrors';
 import {
+  describeHeavyRefusal,
   openLocalHeavyLas,
   type HeavyLasBridgeDeps,
   type HeavyLasBridgeEnv,
@@ -260,7 +262,7 @@ describe('openLocalHeavyLas — the out-of-core local LAS bridge', () => {
     expect(attachStreamingCloud).not.toHaveBeenCalled();
   });
 
-  it('falls back (unavailable) when OPFS or workers are absent', async () => {
+  it('refuses fail-closed (heavy) when a HEAVY file finds OPFS or workers absent', async () => {
     const buffer = lasBytes(160_000);
     const { range } = counting(new ArrayBufferRangeSource(buffer));
     const { file } = spyFile('heavy.las', buffer.byteLength);
@@ -269,7 +271,26 @@ describe('openLocalHeavyLas — the out-of-core local LAS bridge', () => {
 
     const result = await openLocalHeavyLas(file, new AbortController().signal, deps, env);
 
+    // The file IS heavy, so an absent out-of-core platform is a fail-closed
+    // refusal, NOT a fall-through: `heavy` is true so the caller must not reach
+    // the whole-file loader that would hit the same too-large allocation.
     expect(result.status).toBe('unavailable');
+    if (result.status === 'unavailable') expect(result.heavy).toBe(true);
+    expect(attachStreamingCloud).not.toHaveBeenCalled();
+  });
+
+  it('leaves a NOT-heavy file on the whole-file path even when OPFS or workers are absent', async () => {
+    // Heaviness is decided BEFORE capability: a small LAS on a browser without
+    // OPFS still opens whole. The capability probe never refuses a small file.
+    const buffer = lasBytes(40_000);
+    const { range } = counting(new ArrayBufferRangeSource(buffer));
+    const { file } = spyFile('small.las', buffer.byteLength);
+    const { deps, attachStreamingCloud } = makeDeps({ deviceMemoryGB: 8 });
+    const { env } = makeEnv({ range, capable: false });
+
+    const result = await openLocalHeavyLas(file, new AbortController().signal, deps, env);
+
+    expect(result.status).toBe('not-heavy');
     expect(attachStreamingCloud).not.toHaveBeenCalled();
   });
 
@@ -287,10 +308,40 @@ describe('openLocalHeavyLas — the out-of-core local LAS bridge', () => {
 
     expect(result.status).toBe('refused');
     if (result.status === 'refused') {
+      expect(result.heavy).toBe(true);
       expect(result.error.message).toContain('heavy.las');
     }
     // Nothing was attached and nothing was written to OPFS.
     expect(attachStreamingCloud).not.toHaveBeenCalled();
     expect(opfs.topLevel()).toEqual([]);
+  });
+});
+
+describe('describeHeavyRefusal — the named, actionable refusal sentence', () => {
+  it('names no browser storage and points to COPC/EPT when unavailable', () => {
+    const msg = describeHeavyRefusal({
+      status: 'unavailable',
+      heavy: true,
+      reason: 'OPFS or Web Workers unavailable',
+    });
+    expect(msg).toMatch(/storage/i);
+    expect(msg).toContain('OPFS or Web Workers unavailable');
+    expect(msg).toMatch(/COPC or EPT/);
+  });
+
+  it('names a failed index build and points to COPC/EPT when the build threw', () => {
+    const msg = describeHeavyRefusal({
+      status: 'failed',
+      heavy: true,
+      error: new Error('worker crashed'),
+    });
+    expect(msg).toMatch(/could not be built/);
+    expect(msg).toMatch(/COPC or EPT/);
+  });
+
+  it('passes the preflight sentence through unchanged when refused', () => {
+    const error = new LoadError('memory-constraint', 'big.las: needs 9 GB, 2 GB free. Convert to COPC or EPT.');
+    const msg = describeHeavyRefusal({ status: 'refused', heavy: true, error });
+    expect(msg).toBe(error.message);
   });
 });

--- a/tests/openScan.test.ts
+++ b/tests/openScan.test.ts
@@ -1,10 +1,26 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The out-of-core LAS bridge is mocked so this suite can drive `openScan`'s
+// routing against every bridge outcome without a real header peek, worker or
+// OPFS. It defaults to `not-heavy` so the pre-existing static-loader tests below
+// keep reaching `loadLocalSource` exactly as before; individual tests override
+// `heavyResult` to return `attached`, `cancelled`, or a fail-closed heavy status.
+let heavyResult: HeavyOpenResult = { status: 'not-heavy' };
+vi.mock('../src/app/openLocalHeavyLas', async (importActual) => ({
+  // Keep the REAL `describeHeavyRefusal` (a pure string builder `openScan` calls
+  // to phrase the refusal); only the async bridge decision is stubbed.
+  ...(await importActual<typeof import('../src/app/openLocalHeavyLas')>()),
+  openLocalHeavyLas: vi.fn(async () => heavyResult),
+}));
+
 import {
   openScan,
   layerChipCount,
   shouldResetSavedWork,
   type OpenScanDeps,
 } from '../src/app/openScan';
+import type { HeavyOpenResult } from '../src/app/heavyLasTypes';
+import { LoadError } from '../src/io/loadErrors';
 import { COPC_DETECT_MIN_BYTES } from '../src/io/copc/copcDetect';
 import type { Viewer } from '../src/render/Viewer';
 import type { ClassScope } from '../src/render/class/classScope';
@@ -156,6 +172,10 @@ function makeDeps(over: { loading?: boolean } = {}) {
   return { deps, calls };
 }
 
+beforeEach(() => {
+  heavyResult = { status: 'not-heavy' };
+});
+
 describe('openScan — the file router', () => {
   it('routes an .olvsession to the session loader UNDER the load guard, never the cloud worker', async () => {
     const { deps, calls } = makeDeps();
@@ -213,5 +233,87 @@ describe('openScan — the file router', () => {
     expect(calls.closeStreaming).toHaveBeenCalledTimes(1);
     expect(calls.setLoading).toHaveBeenNthCalledWith(1, true);
     expect(calls.setLoading).toHaveBeenLastCalledWith(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The fail-CLOSED contract for heavy LAS. The out-of-core architecture is
+// fail-SAFE: a heavy file whose out-of-core index could not be built must NOT
+// fall through to the whole-file loader, whose `new Uint8Array(total)` is the
+// very allocation that made the file heavy. It must refuse instead. A file that
+// is NOT heavy keeps falling through, so this is a fail-closed for heavy files
+// only, never a blanket refusal.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('openScan — heavy-LAS fail-closed routing', () => {
+  const refusalPreflight = new LoadError(
+    'memory-constraint',
+    'big.las: not enough storage for the streaming index. Convert it to COPC or EPT.',
+  );
+
+  it('NEVER calls loadLocalSource for a KNOWN-HEAVY LAS when the bridge is unavailable', async () => {
+    heavyResult = { status: 'unavailable', heavy: true, reason: 'OPFS or Web Workers unavailable' };
+    const { deps, calls } = makeDeps();
+    await openScan(fakeFile('big.las', new ArrayBuffer(0)), deps);
+    expect(calls.loadLocalSource).not.toHaveBeenCalled();
+    // The refusal is surfaced to the user on the drop zone.
+    expect(calls.setError).toHaveBeenCalledTimes(1);
+    expect(calls.setLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it('NEVER calls loadLocalSource for a KNOWN-HEAVY LAS when the bridge refused (preflight)', async () => {
+    heavyResult = { status: 'refused', heavy: true, error: refusalPreflight };
+    const { deps, calls } = makeDeps();
+    await openScan(fakeFile('big.las', new ArrayBuffer(0)), deps);
+    expect(calls.loadLocalSource).not.toHaveBeenCalled();
+    expect(calls.setError).toHaveBeenCalledTimes(1);
+  });
+
+  it('NEVER calls loadLocalSource for a KNOWN-HEAVY LAS when the bridge build failed', async () => {
+    heavyResult = { status: 'failed', heavy: true, error: new Error('index build threw') };
+    const { deps, calls } = makeDeps();
+    await openScan(fakeFile('big.las', new ArrayBuffer(0)), deps);
+    expect(calls.loadLocalSource).not.toHaveBeenCalled();
+    expect(calls.setError).toHaveBeenCalledTimes(1);
+  });
+
+  it('STILL calls loadLocalSource for a NOT-heavy file on the same bridge statuses', async () => {
+    for (const status of [
+      { status: 'unavailable', heavy: false, reason: 'OPFS or Web Workers unavailable' },
+      { status: 'failed', heavy: false, error: new Error('x') },
+    ] as HeavyOpenResult[]) {
+      heavyResult = status;
+      const { deps, calls } = makeDeps();
+      await openScan(fakeFile('small.las', new ArrayBuffer(0)), deps);
+      // Not heavy → the whole-file loader is free to take it (it rejects here,
+      // which is the loader-not-exercised stub, proving it WAS reached).
+      expect(calls.loadLocalSource).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('surfaces a refusal message that names the reason and points to COPC/EPT', async () => {
+    heavyResult = { status: 'refused', heavy: true, error: refusalPreflight };
+    const { deps, calls } = makeDeps();
+    await openScan(fakeFile('big.las', new ArrayBuffer(0)), deps);
+    const message = calls.setError.mock.calls[0][0] as string;
+    expect(message).toContain('storage');
+    expect(message).toMatch(/COPC|EPT/);
+  });
+
+  it('surfaces a named reason for an unavailable heavy file and points to COPC/EPT', async () => {
+    heavyResult = { status: 'unavailable', heavy: true, reason: 'OPFS or Web Workers unavailable' };
+    const { deps, calls } = makeDeps();
+    await openScan(fakeFile('big.las', new ArrayBuffer(0)), deps);
+    const message = calls.setError.mock.calls[0][0] as string;
+    expect(message).toMatch(/storage|browser/i);
+    expect(message).toMatch(/COPC|EPT/);
+  });
+
+  it('stops on attached and cancelled without calling the whole-file loader', async () => {
+    heavyResult = { status: 'cancelled' };
+    const cancelled = makeDeps();
+    await openScan(fakeFile('big.las', new ArrayBuffer(0)), cancelled.deps);
+    expect(cancelled.calls.loadLocalSource).not.toHaveBeenCalled();
+    expect(cancelled.calls.setError).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
A known-heavy uncompressed LAS could fall back from the out-of-core path
into the whole-file loader and run the tab out of memory. The out-of-core
architecture is meant to be fail-safe, but for a heavy file the whole-file
path faces the same too-large allocation that made the file heavy, so this
was fail-open into a worse failure.

openLocalHeavyLas now decides heaviness first, from the header peek and
planLoad, before the capability probe. A not-heavy file still takes the
whole-file loader on any browser, including one without OPFS. A confirmed
heavy file whose out-of-core path cannot run (OPFS or workers absent,
storage preflight refused, or the index build failed) returns a heavy:true
status. openScan surfaces a named refusal that points to COPC or EPT and
never calls loadLocalSource. An openScan spy test proves loadLocalSource is
skipped for heavy files on unavailable, refused and failed, and still called
for not-heavy files on the same statuses. Updates heavy-cloud-native.md to
describe the refusal.
