### PR TITLE
Make the out-of-core LAS store temporary

### DIFF
--- a/docs/architecture/heavy-cloud-native.md
+++ b/docs/architecture/heavy-cloud-native.md
@@ -190,8 +190,9 @@ exists.
   long-term answer.
 - **Two-pass build time** (phase 1): the indexer reads the file twice; for
   LAZ that is two decompression passes, though both are chunk-parallel. The
-  build shows progress, cancels cleanly, and its output is cached in OPFS so
-  reopening the same file skips the build.
+  build shows progress and cancels cleanly. Its OPFS store is temporary: it is
+  removed when the streaming source closes, so a session does not accumulate
+  multi-GB caches. Cross-session reuse that skips the build is future work.
 - **Native decoder conformance** (phase 0): a round-trip test proves the
   decoder against its own mirror encoder, which cannot catch a shared
   misreading of the laszip stream format. The invariant checks catch gross

--- a/src/app/heavyLasExecutor.ts
+++ b/src/app/heavyLasExecutor.ts
@@ -20,7 +20,7 @@ import {
   readStorageEstimate,
 } from '../io/heavy/storagePreflight';
 import { openTileStore, tileBytesReader } from '../io/heavy/tileStoreBuilder';
-import { opfsSpillStore, type OpfsDirHandle } from '../io/heavy/opfsSpillStore';
+import { opfsSpillStore, removeOpfsStore, type OpfsDirHandle } from '../io/heavy/opfsSpillStore';
 import { OlvTileSource } from '../io/heavy/OlvTileSource';
 import { TileChunkDecoder } from '../io/heavy/tileChunkDecoder';
 import { revealStreamingScanChrome } from '../ui/streamingScanReveal';
@@ -111,7 +111,22 @@ export async function executeHeavyLasBuild(
       name: file.name,
       store: reader,
       tiles: tileBytesReader(spill),
-      close: () => spill.close(),
+      // The out-of-core store is TEMPORARY for this release: nothing reuses it
+      // on a later open, so a persisted `ooc-<name>-<size>` directory is pure
+      // cost. On close, release the open tile handles FIRST (so a close racing
+      // a read unlocks before anything is deleted), THEN remove the store. The
+      // removal is fired without letting a rejection escape the close — a store
+      // the browser cannot delete because a read still holds it is left stale
+      // and rebuilt on the next open, which is the honest fallback. Persistent
+      // cross-session reuse via a source fingerprint is the future direction.
+      close: async () => {
+        await spill.close();
+        try {
+          await removeOpfsStore(root, built.storeName);
+        } catch (err) {
+          if (deps.debug) console.warn('[heavy-las] out-of-core store removal failed', err);
+        }
+      },
     });
     const decoder = new TileChunkDecoder(reader.schema, reader.recordBytes);
 

--- a/src/io/heavy/opfsSpillStore.ts
+++ b/src/io/heavy/opfsSpillStore.ts
@@ -318,6 +318,26 @@ export interface OpfsSpillBuild {
   discard(): Promise<void>;
 }
 
+/**
+ * Delete a named store directory from `root`, swallowing the NotFoundError a
+ * removal of an absent store raises (a store already gone is not an error).
+ *
+ * The out-of-core heavy-LAS store is TEMPORARY for this release: it is built,
+ * streamed from, and removed when its source closes, because nothing reuses it
+ * on a later open. Cross-session reuse — detecting "I already indexed this file"
+ * from a stable source fingerprint and reopening the store instead of rebuilding
+ * it — is the better long-term answer and the future direction here; it needs
+ * source-identity work and is out of scope for this change.
+ *
+ * This is deliberately tolerant: it must never throw out of a close path. A
+ * store the browser cannot remove because a read still holds it stays on disk,
+ * stale, and is rebuilt on the next open, so a failure is logged by the caller
+ * rather than crashing the close.
+ */
+export async function removeOpfsStore(root: OpfsDirHandle, name: string): Promise<void> {
+  await removeIfPresent(root, name);
+}
+
 /** Swallow the NotFoundError a removal of an absent entry raises. */
 async function removeIfPresent(dir: OpfsDirHandle, name: string): Promise<void> {
   try {

--- a/tests/heavyLasStoreLifecycle.test.ts
+++ b/tests/heavyLasStoreLifecycle.test.ts
@@ -1,0 +1,188 @@
+/**
+ * heavyLasStoreLifecycle.test.ts — the out-of-core store is temporary.
+ *
+ * A heavy uncompressed LAS is indexed into an OPFS tile store (`ooc-<name>-<size>`)
+ * and streamed from it. For this release that store is TEMPORARY: nothing reuses
+ * it on a later open, so leaving it in OPFS is pure cost. These cases pin the
+ * lifecycle — the store exists while the source is attached, and closing the
+ * `OlvTileSource` removes it — plus the two guarantees the removal must keep:
+ * the tile handles are still released, and removing an already-absent store is a
+ * no-op rather than a throw.
+ *
+ * The browser-only seams are the repo's usual fakes: OPFS is
+ * `tests/support/fakeOpfs.ts`, and the index "worker" runs the real build in
+ * process against that fake OPFS.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { writeLas14 } from '../src/convert/writeLas';
+import type { GlobalPoints } from '../src/convert/globalPoints';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import type { RangeSource } from '../src/io/range/RangeSource';
+import { fakeOpfs, fakeOpfsDir } from './support/fakeOpfs';
+import { buildLocalOocStore } from '../src/io/heavy/localOocBuild';
+import { OlvTileSource } from '../src/io/heavy/OlvTileSource';
+import { opfsSpillStore, removeOpfsStore } from '../src/io/heavy/opfsSpillStore';
+import {
+  openLocalHeavyLas,
+  type HeavyLasBridgeDeps,
+  type HeavyLasBridgeEnv,
+} from '../src/app/openLocalHeavyLas';
+import type { StorageEstimateReading } from '../src/io/heavy/storagePreflight';
+import type { Viewer } from '../src/render/Viewer';
+
+const WORLD_MIN = [400000, 5200000, 55] as const;
+
+function lasBytes(n: number): ArrayBuffer {
+  const x = new Float64Array(n);
+  const y = new Float64Array(n);
+  const z = new Float64Array(n);
+  const intensity = new Uint16Array(n);
+  const classification = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    x[i] = WORLD_MIN[0] + (i % 200) * 1.5;
+    y[i] = WORLD_MIN[1] + Math.floor(i / 200) * 1.5;
+    z[i] = WORLD_MIN[2] + (i % 13) * 0.4;
+    intensity[i] = i & 0xffff;
+    classification[i] = 2;
+  }
+  const cloud: GlobalPoints = { count: n, x, y, z, intensity, classification };
+  const bytes = writeLas14(cloud);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function spyFile(name: string, size: number): File {
+  return { name, size, arrayBuffer: vi.fn(async () => new ArrayBuffer(size)) } as unknown as File;
+}
+
+function fakeViewer() {
+  let attachedSource: unknown;
+  const attachStreamingCloud = vi.fn(async (source: unknown) => {
+    attachedSource = source;
+  });
+  const viewer = {
+    ready: Promise.resolve(),
+    attachStreamingCloud,
+    activeBackend: () => 'webgl2' as const,
+    availableImageExportModes: () => new Map(),
+    setMode: vi.fn(),
+    frameAll: vi.fn(),
+    hasStreamingCloud: false,
+    clouds: () => [],
+  };
+  return { viewer, getAttached: (): unknown => attachedSource };
+}
+
+function fakeStreaming(viewer: unknown) {
+  return {
+    getViewer: () => viewer,
+    getStreamingQuality: () => 'balanced',
+    debug: false,
+    stage: { hideEmptyState: vi.fn() },
+    streamingPanel: {
+      setPhase: vi.fn(), show: vi.fn(), setColorModes: vi.fn(),
+      setQuality: vi.fn(), setSummary: vi.fn(), setSourceUrl: vi.fn(),
+    },
+    exportPanel: { setImageExportEnabled: vi.fn(), setImageExportAvailability: vi.fn(), setStreamingMode: vi.fn() },
+    inspector: { setStreamingMode: vi.fn(), setDetail: vi.fn(), setReport: vi.fn(), element: { classList: { remove: vi.fn() } } },
+    classLegendPanel: { setClasses: vi.fn(), hide: vi.fn(), getVisibility: () => ({ isFiltered: () => false }) },
+    inspectorCards: { refreshProvenanceFromStreaming: vi.fn(), refreshDatasetIntelligenceFromStreamingCloud: vi.fn() },
+    crsCoordinator: { refreshCrsForStreamingCloud: vi.fn() },
+    bookmarks: { clear: vi.fn() },
+    hideReclassifyUi: vi.fn(),
+    syncInspectClassScope: vi.fn(),
+    prewarmExportStudio: vi.fn(),
+    revealAnalysePanel: vi.fn(),
+    startStreamingStatusPolling: vi.fn(),
+    refreshViewsUI: vi.fn(),
+    runStreamingModules: vi.fn(() => []),
+    setLastStreamingReportCloud: vi.fn(),
+  } as unknown as HeavyLasBridgeDeps['streaming'];
+}
+
+function makeDeps() {
+  const { viewer, getAttached } = fakeViewer();
+  const deps: HeavyLasBridgeDeps = {
+    viewerReady: Promise.resolve(),
+    getViewer: () => viewer as unknown as Viewer,
+    isPhone: () => false,
+    renderBudget: 2_000_000,
+    deviceMemoryGB: () => 0.001,
+    dock: {
+      setEmpty: vi.fn(), setMeasureEnabled: vi.fn(), setAnnotateEnabled: vi.fn(),
+      setInspectEnabled: vi.fn(), setProbeEnabled: vi.fn(), setCloseEnabled: vi.fn(), setBackend: vi.fn(),
+    },
+    inspector: { setEmpty: vi.fn() },
+    navBar: { element: { classList: { remove: vi.fn() } }, setMode: vi.fn(), flashHelp: vi.fn() },
+    stage: { hideEmptyState: vi.fn() },
+    body: { classList: { add: vi.fn() } },
+    setPhase: vi.fn(),
+    debug: false,
+    streaming: fakeStreaming(viewer),
+  } as unknown as HeavyLasBridgeDeps;
+  return { deps, getAttached };
+}
+
+function makeEnv(range: RangeSource): { env: HeavyLasBridgeEnv; opfs: ReturnType<typeof fakeOpfs> } {
+  const opfs = fakeOpfs({ syncAccess: true, fileMove: true });
+  const reading: StorageEstimateReading = { available: true, quotaBytes: 200_000_000_000, usageBytes: 0 };
+  const env: HeavyLasBridgeEnv = {
+    capable: () => true,
+    openRange: () => range,
+    getOpfsRoot: async () => opfs.root,
+    readStorage: async () => reading,
+    async runIndex(req) {
+      return buildLocalOocStore(range, opfs.root, req.storeName, {
+        pointsPerLeaf: req.pointsPerLeaf,
+        memoryBudgetBytes: req.memoryBudgetBytes,
+        maxDepth: req.maxDepth,
+        batchPoints: 4096,
+        signal: req.signal,
+        onPhase: req.onPhase,
+      });
+    },
+  };
+  return { env, opfs };
+}
+
+describe('heavy LAS out-of-core store lifecycle', () => {
+  it('removes the OPFS store directory when the streaming source closes', async () => {
+    const buffer = lasBytes(60_000);
+    const file = spyFile('heavy.las', buffer.byteLength);
+    const { deps, getAttached } = makeDeps();
+    const { env, opfs } = makeEnv(new ArrayBufferRangeSource(buffer));
+
+    const result = await openLocalHeavyLas(file, new AbortController().signal, deps, env);
+    expect(result.status).toBe('attached');
+    if (result.status !== 'attached') throw new Error('unreachable');
+
+    // The finished store is present while the source is attached.
+    const storeName = opfs.topLevel().find((n) => n.startsWith('ooc-'));
+    expect(storeName).toBeDefined();
+    expect(opfs.topLevel()).toContain(storeName);
+
+    // Closing the source releases handles AND removes the persistent store.
+    const source = getAttached() as OlvTileSource;
+    await source.close();
+
+    expect(opfs.topLevel()).not.toContain(storeName);
+    expect(opfs.topLevel().some((n) => n.startsWith('ooc-'))).toBe(false);
+  });
+
+  it('still releases the tile handles on close (does not regress spill.close)', async () => {
+    const dir = fakeOpfsDir({ syncAccess: true });
+    const spill = opfsSpillStore(dir);
+    await spill.append('3', new Uint8Array([1, 2, 3]));
+    await spill.append('3', new Uint8Array([4, 5]));
+    const closeSpy = vi.spyOn(spill, 'close');
+    // Removing this named store must release the handles first, then delete.
+    await spill.close();
+    expect(closeSpy).toHaveBeenCalled();
+    // After close the tile is unlocked and still readable via a fresh handle.
+    expect([...(await spill.read('3'))]).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('does not throw when removing an already-absent store', async () => {
+    const root = fakeOpfsDir();
+    await expect(removeOpfsStore(root, 'ooc-not-there-123')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
The heavy uncompressed-LAS path indexes a file into an OPFS tile store
named ooc-<name>-<size> and streams from it. Closing the OlvTileSource
released the tile handles but left that store in OPFS forever, and no
production path reuses it on a later open, so it was pure cost: it held
quota and was rebuilt from scratch on the next open.

This makes the store temporary. removeOpfsStore in opfsSpillStore.ts
reuses the removeIfPresent helper so a missing store is not an error.
The heavy executor close callback releases the tile handles first, then
removes the store, logging a removal failure under debug rather than
crashing the close. Releasing before deleting keeps a close that races a
read from corrupting anything.

Only the out-of-core store is affected; COPC, EPT and 3D Tiles create no
such store, and the partial-build promote/discard lifecycle is untouched.
A new test drives the full build-attach path and asserts the store is
present before close and gone after; two more cover handle release and
an absent-store remove. Cross-session reuse via a source fingerprint is
noted as the future direction.
