### PR TITLE
Add chunked-LAZ out-of-core tile store builder

### DIFF
--- a/docs/validation/position-access-baseline.json
+++ b/docs/validation/position-access-baseline.json
@@ -1,10 +1,11 @@
 {
-  "total": 148,
+  "total": 149,
   "files": {
     "src/app/epochFramePrep.ts": 2,
     "src/app/floorPlanPositions.ts": 4,
     "src/app/terrainAnalysisRunner.ts": 3,
     "src/io/copc/copcChunkDecode.ts": 1,
+    "src/io/heavy/chunkedLazSource.ts": 1,
     "src/io/heavy/decodeLazChunked.ts": 2,
     "src/io/heavy/oocIndexer.ts": 2,
     "src/io/heavy/slicedLasSource.ts": 1,

--- a/docs/validation/position-frames.json
+++ b/docs/validation/position-frames.json
@@ -43,6 +43,13 @@
       "why": "Lists the decoded chunk buffers for a zero-copy postMessage. No arithmetic happens; the buffer stays recentred on the streaming render origin."
     },
     {
+      "file": "src/io/heavy/chunkedLazSource.ts",
+      "symbol": "decodeChunkBatch",
+      "frame": "source-local",
+      "reads": 1,
+      "why": "Exposes each decoded LAZ chunk to the indexer through the PointSource contract; the load origin travels beside it (returned as `origin`), so the packed batch stays source-local, mirroring the LAS sliced source."
+    },
+    {
       "file": "src/io/heavy/decodeLazChunked.ts",
       "symbol": "placeChunk",
       "frame": "source-local",
@@ -82,7 +89,7 @@
       "symbol": "packTileRecord",
       "frame": "source-local",
       "reads": 3,
-      "why": "Packs each decoded point into a tile-store record; raw.positions is the loader's source-local buffer (scaled value + header offset − load origin), copied into the tile verbatim with no reframing."
+      "why": "Packs each decoded point into a tile-store record; raw.positions is the loader's source-local buffer (scaled value + header offset \u2212 load origin), copied into the tile verbatim with no reframing."
     },
     {
       "file": "src/io/lasDecodeShared.ts",
@@ -215,7 +222,7 @@
       "symbol": "scanHullPositions",
       "frame": "source-local",
       "reads": 1,
-      "why": "The active static cloud's resident buffer feeds the KML footprint's convex-hull outline, which is traced in the cloud's own source-local XY — the same frame the bounding-rectangle extent is read in."
+      "why": "The active static cloud's resident buffer feeds the KML footprint's convex-hull outline, which is traced in the cloud's own source-local XY \u2014 the same frame the bounding-rectangle extent is read in."
     },
     {
       "file": "src/main.ts",
@@ -278,7 +285,7 @@
       "symbol": "ContourOverlay._upload",
       "frame": "project-local",
       "reads": 1,
-      "why": "Uploads the CONTOUR line-segment vertices (not cloud points) into a THREE.BufferGeometry. They arrive from buildContourOverlayBuffers over a model derived from gatherTerrainPositions, which folds every layer placement in, so the buffer is already in the project frame the scene draws at its origin — the object carries no further offset."
+      "why": "Uploads the CONTOUR line-segment vertices (not cloud points) into a THREE.BufferGeometry. They arrive from buildContourOverlayBuffers over a model derived from gatherTerrainPositions, which folds every layer placement in, so the buffer is already in the project frame the scene draws at its origin \u2014 the object carries no further offset."
     },
     {
       "file": "src/render/densityColors.ts",

--- a/src/io/heavy/chunkedLazSource.ts
+++ b/src/io/heavy/chunkedLazSource.ts
@@ -1,0 +1,243 @@
+/**
+ * chunkedLazSource.ts — feed a chunked LAZ file to the out-of-core indexer.
+ *
+ * The uncompressed sibling {@link openSlicedLasSource} reads a plain LAS as
+ * bounded batches of packed tile records. A modern LAZ compresses its points in
+ * independent chunks and carries a table of per-chunk byte ranges, so the same
+ * out-of-core shape is reachable without ever holding the whole file: read the
+ * header, the laszip VLR and the chunk table over three small range reads
+ * ({@link readLazChunkTable}), then decode one bounded window of chunks at a
+ * time, pack each decoded chunk into fixed-length tile records, yield it, and
+ * discard it before the next window. Peak residency is a window of chunks, never
+ * the cloud.
+ *
+ * Scope is deliberate and matches the two format audits. Only a LAZ whose chunk
+ * table {@link readLazChunkTable} can randomly address is supported; a pointwise
+ * (pre-chunking) LAZ, an interrupted writer, or any table defect throws
+ * {@link ChunkedLazUnsupportedError} rather than falling back to a whole-file
+ * read. Only the point formats the per-chunk laz-perf decoder is exercised for
+ * (PDRF 6, 7, 8 — the set the committed multichunk fixture uses) are decoded;
+ * any other format is refused by name through the same error.
+ *
+ * Re-iterable because `batches()` re-reads chunks from the {@link RangeSource}
+ * on each call, so the indexer's optional bounds pass and its bucketing pass see
+ * identical points. Pure and RangeSource-only, so the whole build is Node-
+ * testable through laz-perf's WASM decoder; the browser passes an OPFS-file
+ * RangeSource and an OPFS spill store.
+ */
+import type { RangeSource } from '../range/RangeSource';
+import { parseLasHeader, type LasHeader } from '../lasHeader';
+import {
+  decodeContext,
+  finalizeRawColors,
+  type DecodeContext,
+} from '../lasDecodeShared';
+import { getLazPerf } from '../lazDecode';
+import { readLazChunkTable, type LazChunkRange } from './lazChunkTable';
+import { decodeLazChunkLocal, type LazChunkJob } from './decodeLazChunked';
+import type { PointSource, PositionBatch, SourceHeader } from './oocIndexer';
+import {
+  packTileRecord,
+  tileRecordBytes,
+  tileSchemaForHeader,
+  type TileSchema,
+} from './tileRecord';
+
+/** Point formats the per-chunk laz-perf decoder is exercised for (COPC's set). */
+const CHUNK_DECODE_FORMATS = new Set([6, 7, 8]);
+
+/**
+ * Fixed prefix read for the LAS public header, sized so a header parse never
+ * pulls more than a few kilobytes. The full VLR-region read the chunk table
+ * needs is bounded separately by `offsetToPointData`.
+ */
+const HEADER_PROBE_BYTES = 8 * 1024;
+
+/**
+ * How many consecutive chunks to pull and decode per range read. Chunks are
+ * stored back to back, so a window reads one contiguous span, decodes each chunk
+ * in it, and frees the span before the next. The default keeps a real
+ * multi-gigabyte cloud (thousands of ~50 000-point chunks) streaming a few chunks
+ * at a time; a test lowers it to prove the largest read never approaches the file.
+ */
+export const DEFAULT_CHUNK_WINDOW = 4;
+
+/**
+ * A LAZ the chunked out-of-core path cannot serve: no usable chunk table, or a
+ * point format the per-chunk decoder does not support. Named so the open path
+ * can route on it (e.g. fall back to the whole-file loader) rather than reading
+ * the file whole here.
+ */
+export class ChunkedLazUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ChunkedLazUnsupportedError';
+  }
+}
+
+export interface ChunkedLazOptions {
+  /** Recentring origin. Defaults to the floored header minimum, as the LAS path does. */
+  readonly origin?: [number, number, number];
+  /** Consecutive chunks decoded per range read. Default {@link DEFAULT_CHUNK_WINDOW}. */
+  readonly chunkWindow?: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface ChunkedLazSource {
+  readonly source: PointSource;
+  readonly schema: TileSchema;
+  readonly recordBytes: number;
+  readonly pointCount: number;
+  readonly origin: [number, number, number];
+  readonly header: LasHeader;
+}
+
+/**
+ * Open a chunked LAZ as a {@link PointSource} of packed tile records.
+ *
+ * Throws {@link ChunkedLazUnsupportedError} for a LAZ without a usable chunk
+ * table or with an unsupported point format, and whatever {@link parseLasHeader}
+ * throws for a file that is not LAS at all. Never reads the whole file: the
+ * header, VLRs and chunk table come from bounded range reads, and the points
+ * stream a window of chunks at a time.
+ */
+export async function openChunkedLazSource(
+  range: RangeSource,
+  options: ChunkedLazOptions = {},
+): Promise<ChunkedLazSource> {
+  const size = await range.size();
+  const probe = await range.readRange(0, Math.min(size, HEADER_PROBE_BYTES), options.signal);
+  const probeHeader = parseLasHeader(probe);
+
+  // Cap the chunk-table's prefix read at the point-data offset: every VLR
+  // precedes the point data, so this covers the laszip VLR without pulling the
+  // 4 MiB default, which on a small file would be the whole file.
+  const table = await readLazChunkTable(range, options.signal, probeHeader.offsetToPointData);
+  if (!table.supported) {
+    throw new ChunkedLazUnsupportedError(
+      `chunked LAZ out-of-core needs a usable chunk table: ${table.reason}`,
+    );
+  }
+  const header = table.header;
+  if (!CHUNK_DECODE_FORMATS.has(header.pointFormat)) {
+    throw new ChunkedLazUnsupportedError(
+      `chunked LAZ out-of-core supports point formats 6, 7 and 8; ` +
+        `this file is point format ${header.pointFormat}`,
+    );
+  }
+
+  const origin: [number, number, number] =
+    options.origin ?? [
+      Math.floor(header.min[0]),
+      Math.floor(header.min[1]),
+      Math.floor(header.min[2]),
+    ];
+  const ctx = decodeContext(header, origin);
+  const schema = tileSchemaForHeader(header.pointFormat, ctx);
+  const recordBytes = tileRecordBytes(schema);
+  const chunks = table.chunks;
+  const window = Math.max(1, Math.floor(options.chunkWindow ?? DEFAULT_CHUNK_WINDOW));
+
+  const sourceHeader = chunkedSourceHeader(header.min, header.max, origin, header.pointCount);
+
+  const source: PointSource = {
+    header: sourceHeader,
+    async *batches(signal): AsyncGenerator<PositionBatch> {
+      if (chunks.length === 0) return;
+      const lazPerf = await getLazPerf();
+      for (let start = 0; start < chunks.length; start += window) {
+        signal?.throwIfAborted();
+        const end = Math.min(start + window, chunks.length);
+        const windowChunks = chunks.slice(start, end);
+        // One contiguous range read for the whole window: chunks are packed
+        // back to back, so the span runs from the first chunk's offset to the
+        // last chunk's end. Nothing outside this window is resident.
+        const spanStart = windowChunks[0].byteOffset;
+        const last = windowChunks[windowChunks.length - 1];
+        const spanLength = last.byteOffset + last.byteLength - spanStart;
+        const span = await range.readRange(spanStart, spanLength, signal);
+        for (const c of windowChunks) {
+          signal?.throwIfAborted();
+          yield decodeChunkBatch(lazPerf, span, spanStart, header, ctx, schema, recordBytes, c);
+        }
+      }
+    },
+  };
+
+  return { source, schema, recordBytes, pointCount: header.pointCount, origin, header };
+}
+
+/** Decode one chunk out of the already-read window span into a packed batch. */
+function decodeChunkBatch(
+  lazPerf: Awaited<ReturnType<typeof getLazPerf>>,
+  span: ArrayBuffer,
+  spanStart: number,
+  header: LasHeader,
+  ctx: DecodeContext,
+  schema: TileSchema,
+  recordBytes: number,
+  c: LazChunkRange,
+): PositionBatch {
+  const rel = c.byteOffset - spanStart;
+  const job: LazChunkJob = {
+    chunk: span.slice(rel, rel + c.byteLength),
+    pointCount: c.pointCount,
+    firstPointIndex: c.firstPointIndex,
+    pointDataRecordFormat: header.pointFormat,
+    pointRecordLength: header.pointDataRecordLength,
+    scale: header.scale,
+    offset: header.offset,
+    ctx,
+  };
+  const raw = decodeLazChunkLocal(lazPerf, job);
+  // Narrow colours per chunk, exactly as the LAS sliced reader finalizes per
+  // batch, so `packTileRecord` sees `raw.colors` rather than the 16-bit staging.
+  finalizeRawColors(raw);
+  const records = new Uint8Array(c.pointCount * recordBytes);
+  const view = new DataView(records.buffer);
+  for (let i = 0; i < c.pointCount; i++) {
+    packTileRecord(raw, i, schema, view, i * recordBytes);
+  }
+  return { positions: raw.positions, count: c.pointCount, records, recordBytes };
+}
+
+/**
+ * The trusted {@link SourceHeader} that lets the indexer skip its bounds pass.
+ *
+ * The LAS header carries the point count and the axis-aligned bounds in WORLD
+ * coordinates; the decoded batches yield positions in the origin-relative,
+ * Float32 frame `decodeRecord` produces (`local = int * scale + offset - origin`,
+ * narrowed to Float32). The world bounds are moved into that same frame here —
+ * `Math.fround(worldBound - origin)`, one subtraction then a Float32 narrowing,
+ * mirroring the decode — so the grid the header builds is the grid the bounds
+ * pass would build. `pointCount` is the chunk table's total, which
+ * {@link readLazChunkTable} has already checked equals the header count.
+ *
+ * When the count is not a finite point or the box is degenerate the header is
+ * dropped and the build keeps its two-pass path. The indexer re-checks both, so
+ * an honest-but-imprecise header stays correct, only slower.
+ */
+function chunkedSourceHeader(
+  worldMin: readonly [number, number, number],
+  worldMax: readonly [number, number, number],
+  origin: readonly [number, number, number],
+  pointCount: number,
+): SourceHeader | undefined {
+  if (!Number.isFinite(pointCount) || pointCount < 1) return undefined;
+  const min: [number, number, number] = [
+    Math.fround(worldMin[0] - origin[0]),
+    Math.fround(worldMin[1] - origin[1]),
+    Math.fround(worldMin[2] - origin[2]),
+  ];
+  const max: [number, number, number] = [
+    Math.fround(worldMax[0] - origin[0]),
+    Math.fround(worldMax[1] - origin[1]),
+    Math.fround(worldMax[2] - origin[2]),
+  ];
+  for (let a = 0; a < 3; a++) {
+    if (!Number.isFinite(min[a]) || !Number.isFinite(max[a])) return undefined;
+  }
+  const extent = Math.max(max[0] - min[0], max[1] - min[1], max[2] - min[2]);
+  if (!(extent > 0)) return undefined;
+  return { pointCount, min, max };
+}

--- a/src/io/heavy/lazChunkTable.ts
+++ b/src/io/heavy/lazChunkTable.ts
@@ -133,13 +133,24 @@ function unsupported(reason: string): LazChunkTableUnsupported {
  * Throws only what {@link parseLasHeader} throws (a file that is not LAS at
  * all); every table-level defect reports `supported: false` instead, so the
  * caller's fallback decision is one branch.
+ *
+ * `maxHeadBytes` caps the single prefix read that covers the public header and
+ * the VLR region; it defaults to {@link MAX_HEAD_BYTES} and is clamped to that
+ * cap. A caller that already knows `offsetToPointData` (every VLR precedes the
+ * point data) passes it here so the prefix read stays a few hundred bytes on a
+ * file whose header is small, instead of reading up to the 4 MiB default — which
+ * on a file smaller than the default would be the whole file. All the VLRs must
+ * still fall inside the prefix, so too small a cap simply reports `supported:
+ * false` (no laszip VLR found), it never mis-reads the table.
  */
 export async function readLazChunkTable(
   range: RangeSource,
   signal?: AbortSignal,
+  maxHeadBytes: number = MAX_HEAD_BYTES,
 ): Promise<LazChunkTableResult> {
   const size = await range.size();
-  const headLength = Math.min(size, MAX_HEAD_BYTES);
+  const headCap = Math.min(MAX_HEAD_BYTES, Math.max(0, Math.floor(maxHeadBytes)));
+  const headLength = Math.min(size, headCap);
   const head = await range.readRange(0, headLength, signal);
   const header = parseLasHeader(head);
 

--- a/src/io/heavy/tileStoreBuilder.ts
+++ b/src/io/heavy/tileStoreBuilder.ts
@@ -26,6 +26,7 @@ import type { RangeSource } from '../range/RangeSource';
 import type { SpillStore } from './oocIndexer';
 import { indexOutOfCore } from './oocIndexer';
 import { openSlicedLasSource } from './slicedLasSource';
+import { openChunkedLazSource, type ChunkedLazOptions } from './chunkedLazSource';
 import type { SlicedLasOptions } from './slicedLasReader';
 import {
   buildTileStore,
@@ -55,6 +56,8 @@ export interface BuildTileStoreOptions {
   readonly sink?: TileArtifactSink;
   /** Passed through to the sliced LAS reader (batch size, explicit origin). */
   readonly las?: SlicedLasOptions;
+  /** Passed through to the chunked LAZ source (origin, chunk window). */
+  readonly laz?: ChunkedLazOptions;
   /**
    * Force the two-pass index build even when the LAS header would allow one
    * pass. The store is identical either way for a valid header; this exists so a
@@ -102,6 +105,47 @@ export async function buildTileStoreFromLas(
     signal: options.signal,
   });
   const { manifestJson, hierarchy } = buildTileStore(index, las.schema, las.origin);
+
+  if (options.sink) {
+    await options.sink.write(TILE_MANIFEST_NAME, manifestJson);
+    await options.sink.write(TILE_HIERARCHY_NAME, hierarchy);
+  }
+
+  return {
+    reader: openTileStore(manifestJson, hierarchy),
+    tiles: tileBytesReader(spill),
+    manifestJson,
+    hierarchy,
+    peakBufferedBytes: index.peakBufferedBytes,
+  };
+}
+
+/**
+ * Build a tile store from a chunked LAZ, reading it out of core. Mirrors
+ * {@link buildTileStoreFromLas} exactly, differing only in how points are
+ * produced: {@link openChunkedLazSource} decodes a bounded window of chunks at a
+ * time from the file's chunk table instead of reading uncompressed slices.
+ *
+ * Throws {@link ChunkedLazUnsupportedError} for a LAZ the chunk table cannot
+ * randomly address (pointwise LAZ, interrupted writer) or an unsupported point
+ * format, so the caller routes rather than reading the file whole. The returned
+ * reader is parsed back out of the manifest and hierarchy, like the LAS build,
+ * so what streams is what a later session would reopen.
+ */
+export async function buildTileStoreFromLaz(
+  range: RangeSource,
+  spill: SpillStore,
+  options: BuildTileStoreOptions = {},
+): Promise<BuiltTileStore> {
+  const laz = await openChunkedLazSource(range, options.laz ?? {});
+  const index = await indexOutOfCore(laz.source, spill, {
+    pointsPerLeaf: options.pointsPerLeaf,
+    memoryBudgetBytes: options.memoryBudgetBytes,
+    maxDepth: options.maxDepth,
+    forceSlowPath: options.forceSlowPath,
+    signal: options.signal,
+  });
+  const { manifestJson, hierarchy } = buildTileStore(index, laz.schema, laz.origin);
 
   if (options.sink) {
     await options.sink.write(TILE_MANIFEST_NAME, manifestJson);

--- a/tests/chunkedLazStoreBuilder.test.ts
+++ b/tests/chunkedLazStoreBuilder.test.ts
@@ -1,0 +1,257 @@
+/**
+ * chunkedLazStoreBuilder.test.ts — a chunked LAZ becomes a streamable store
+ * out of core, the compressed sibling of tileStoreBuilder.test.ts.
+ *
+ * The committed multichunk.laz (written by the LAS writer, compressed by PDAL,
+ * PDRF 7, 120 000 points across 3 real laszip chunks) is fed through
+ * `buildTileStoreFromLaz`. The suite proves four things: the store conserves
+ * every point; the build never reads the file whole, streaming a bounded window
+ * of chunks instead; a LAZ the chunk table cannot address is refused by a named
+ * error; and the store round-trips (artifacts reopen and every node decodes back
+ * to the world coordinates it came from). A fifth test proves the one-pass fast
+ * path (trusted header) is byte-identical to the two-pass path.
+ *
+ * The fixture is only ~291 KB, so the header/VLR/chunk-table scan — bounded by a
+ * file-size-independent constant, not by the cloud — is a real fraction of it
+ * only because the file is small. The point-data reads are what scale with the
+ * cloud; those are what the instrumented assertion pins to a single chunk.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { RangeSource, RangeSourceKind } from '../src/io/range/RangeSource';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import { parseLasHeader } from '../src/io/lasHeader';
+import { readLazChunkTable } from '../src/io/heavy/lazChunkTable';
+import type { SpillStore } from '../src/io/heavy/oocIndexer';
+import {
+  buildTileStoreFromLaz,
+  openTileStore,
+  TILE_HIERARCHY_NAME,
+  TILE_MANIFEST_NAME,
+  type TileArtifactSink,
+} from '../src/io/heavy/tileStoreBuilder';
+import { ChunkedLazUnsupportedError } from '../src/io/heavy/chunkedLazSource';
+import { OlvTileSource } from '../src/io/heavy/OlvTileSource';
+import { TileChunkDecoder } from '../src/io/heavy/tileChunkDecoder';
+
+function loadFixture(name: string): ArrayBuffer {
+  const b = readFileSync(resolve(__dirname, 'fixtures', name));
+  return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength) as ArrayBuffer;
+}
+
+/** A RangeSource that records every read's [offset, length). */
+function counting(inner: RangeSource): {
+  range: RangeSource;
+  reads: Array<{ offset: number; length: number }>;
+} {
+  const reads: Array<{ offset: number; length: number }> = [];
+  const range: RangeSource = {
+    id: () => inner.id(),
+    kind: (): RangeSourceKind => inner.kind(),
+    size: () => inner.size(),
+    async readRange(offset, length, signal) {
+      const buf = await inner.readRange(offset, length, signal);
+      reads.push({ offset, length: buf.byteLength });
+      return buf;
+    },
+  };
+  return { range, reads };
+}
+
+function memorySpill(withClear = false): SpillStore {
+  const parts = new Map<string, Uint8Array[]>();
+  const store: SpillStore = {
+    async append(key, bytes) {
+      (parts.get(key) ?? parts.set(key, []).get(key)!).push(bytes.slice());
+    },
+    async read(key) {
+      const arr = parts.get(key) ?? [];
+      const out = new Uint8Array(arr.reduce((n, b) => n + b.byteLength, 0));
+      let o = 0;
+      for (const b of arr) {
+        out.set(b, o);
+        o += b.byteLength;
+      }
+      return out;
+    },
+    async keys() {
+      return [...parts.keys()];
+    },
+  };
+  if (withClear) {
+    (store as { clear?: () => Promise<void> }).clear = async () => {
+      parts.clear();
+    };
+  }
+  return store;
+}
+
+function memorySink(): TileArtifactSink & { readonly files: Map<string, string> } {
+  const files = new Map<string, string>();
+  return {
+    files,
+    async write(name, text) {
+      files.set(name, text);
+    },
+  };
+}
+
+const FIXTURE = 'multichunk.laz';
+const FIXTURE_POINTS = 120_000;
+
+describe('chunked LAZ tile store builder', () => {
+  it('builds a store that conserves every point and never reads the file whole', async () => {
+    const buffer = loadFixture(FIXTURE);
+    const fileBytes = buffer.byteLength;
+    const header = parseLasHeader(buffer);
+    const table = await readLazChunkTable(new ArrayBufferRangeSource(buffer));
+    expect(table.supported, 'fixture is a chunked LAZ').toBe(true);
+    if (!table.supported) throw new Error('unreachable');
+    // The fixture must genuinely span more than one chunk, or "windowed" is a lie.
+    expect(table.chunks.length).toBeGreaterThan(1);
+    const largestChunkBytes = Math.max(...table.chunks.map((c) => c.byteLength));
+
+    const { range, reads } = counting(new ArrayBufferRangeSource(buffer));
+    const spill = memorySpill();
+    const built = await buildTileStoreFromLaz(range, spill, {
+      pointsPerLeaf: 20_000,
+      memoryBudgetBytes: 256 * 1024,
+      // One chunk per read, so the largest point-data read is a single chunk.
+      laz: { chunkWindow: 1 },
+    });
+
+    expect(built.reader.manifest.pointCount).toBe(FIXTURE_POINTS);
+    expect(built.reader.leaves().reduce((s, l) => s + l.pointCount, 0)).toBe(FIXTURE_POINTS);
+
+    // THE OUT-OF-CORE ASSERTION. No single read materialises the file, and the
+    // reads that carry point data (offset at or past the point-data offset) are
+    // each bounded by one chunk — they do not scale with the cloud. The one-time
+    // header/VLR/chunk-table scan reads a small prefix bounded by the point-data
+    // offset, never the whole file.
+    expect(reads.length).toBeGreaterThan(table.chunks.length);
+    const largest = Math.max(...reads.map((r) => r.length));
+    expect(largest).toBeLessThan(fileBytes); // never the whole file in one read
+    expect(largest).toBeLessThanOrEqual(largestChunkBytes);
+    expect(largest).toBeLessThan(fileBytes / 2); // never even half of it
+
+    const pointDataReads = reads.filter((r) => r.offset >= header.offsetToPointData);
+    expect(Math.max(...pointDataReads.map((r) => r.length))).toBeLessThanOrEqual(largestChunkBytes);
+    // Every header/VLR scan read (offset 0) is a small fixed prefix (the 8 KiB
+    // header probe, or the offsetToPointData-bounded chunk-table head), a
+    // constant that does not grow with the cloud.
+    const scanReads = reads.filter((r) => r.offset < header.offsetToPointData);
+    for (const r of scanReads) {
+      expect(r.length).toBeLessThanOrEqual(8 * 1024);
+    }
+  });
+
+  it('refuses a LAZ without a usable chunk table by a named error, not a whole read', async () => {
+    // An uncompressed LAS has no laszip VLR: the chunk-table reader reports
+    // unsupported, and the source throws rather than falling back to a whole read.
+    const las = loadFixture('tiny.las');
+    const { range, reads } = counting(new ArrayBufferRangeSource(las));
+    await expect(buildTileStoreFromLaz(range, memorySpill())).rejects.toBeInstanceOf(
+      ChunkedLazUnsupportedError,
+    );
+    // It gave up on the header/VLR scan; it never read the point body whole.
+    const header = parseLasHeader(las);
+    const bodyReads = reads.filter((r) => r.offset >= header.offsetToPointData && r.length > 64);
+    expect(bodyReads.length).toBe(0);
+  });
+
+  it('refuses a chunked LAZ whose point format the chunk decoder does not support', async () => {
+    // tiny-pdrf0.laz and tiny-pdrf1.laz have usable chunk tables but PDRF 0/1,
+    // which the per-chunk decoder is not exercised for; the source names the
+    // format in the error rather than decoding it wrong.
+    for (const name of ['tiny-pdrf0.laz', 'tiny-pdrf1.laz']) {
+      const buffer = loadFixture(name);
+      const fmt = parseLasHeader(buffer).pointFormat;
+      await expect(
+        buildTileStoreFromLaz(new ArrayBufferRangeSource(buffer), memorySpill()),
+      ).rejects.toThrow(
+        new RegExp(`point format(s)?[^0-9]*${fmt}`),
+      );
+    }
+  });
+
+  it('round-trips: artifacts reopen and every node decodes to world coordinates', async () => {
+    const buffer = loadFixture(FIXTURE);
+    const header = parseLasHeader(buffer);
+    const spill = memorySpill();
+    const sink = memorySink();
+    const built = await buildTileStoreFromLaz(new ArrayBufferRangeSource(buffer), spill, {
+      pointsPerLeaf: 20_000,
+      memoryBudgetBytes: 256 * 1024,
+      sink,
+    });
+
+    expect([...sink.files.keys()].sort()).toEqual([TILE_HIERARCHY_NAME, TILE_MANIFEST_NAME]);
+    const reopened = openTileStore(
+      sink.files.get(TILE_MANIFEST_NAME)!,
+      sink.files.get(TILE_HIERARCHY_NAME)!,
+    );
+    expect(reopened.manifest).toEqual(built.reader.manifest);
+
+    const source = new OlvTileSource({
+      id: 'laz-1',
+      name: FIXTURE,
+      store: built.reader,
+      tiles: built.tiles,
+    });
+    const decoder = new TileChunkDecoder(built.reader.schema, built.reader.recordBytes);
+    expect(source.octree.isComplete).toBe(true);
+    expect(source.sourcePointCount).toBe(FIXTURE_POINTS);
+
+    let checked = 0;
+    for (const node of source.octree.nodes()) {
+      if (node.record.pointCount === 0) continue;
+      const decoded = await decoder.decode(
+        await source.readNodeChunk(node.record),
+        source.decodeMeta(node.record),
+      );
+      for (let i = 0; i < decoded.pointCount; i++) {
+        for (let a = 0; a < 3; a++) {
+          const world = decoded.positions[i * 3 + a] + source.renderOrigin[a];
+          expect(world).toBeGreaterThanOrEqual(header.min[a] - 1);
+          expect(world).toBeLessThanOrEqual(header.max[a] + 1);
+        }
+      }
+      checked += decoded.pointCount;
+    }
+    expect(checked).toBe(FIXTURE_POINTS);
+  });
+
+  it('one-pass (trusted header) build is byte-identical to the two-pass build', async () => {
+    const buffer = loadFixture(FIXTURE);
+    const opts = { pointsPerLeaf: 20_000, memoryBudgetBytes: 256 * 1024 } as const;
+
+    const fastSpill = memorySpill(true); // clear present -> one-pass eligible
+    const fastCount = counting(new ArrayBufferRangeSource(buffer));
+    const fast = await buildTileStoreFromLaz(fastCount.range, fastSpill, opts);
+
+    const slowSpill = memorySpill(true);
+    const slowCount = counting(new ArrayBufferRangeSource(buffer));
+    const slow = await buildTileStoreFromLaz(slowCount.range, slowSpill, {
+      ...opts,
+      forceSlowPath: true,
+    });
+
+    // The trusted header is genuinely used: the one-pass build streams the
+    // chunks once, the forced two-pass build streams them twice, so the fast
+    // build issues strictly fewer point-data reads. If the header were rejected
+    // both would take two passes and this would not hold.
+    const bodyReads = (c: typeof fastCount) =>
+      c.reads.filter((r) => r.offset >= parseLasHeader(buffer).offsetToPointData && r.length > 64)
+        .length;
+    expect(bodyReads(fastCount)).toBeLessThan(bodyReads(slowCount));
+
+    expect(fast.manifestJson).toBe(slow.manifestJson);
+    expect(fast.hierarchy).toBe(slow.hierarchy);
+    for (const leaf of fast.reader.leaves()) {
+      const a = await fast.tiles.read(leaf.key);
+      const b = await slow.tiles.read(leaf.key);
+      expect(a).toEqual(b);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds the format-neutral builder for compressed-LAZ out-of-core support, the
compressed sibling of the existing LAS bridge. `src/io/heavy` only; the open
path is not touched.

`chunkedLazSource.ts` opens a chunked LAZ as a `PointSource`. It reads the LAS
header, laszip VLR and chunk table over bounded range reads, then decodes a
window of chunks at a time, packs each decoded chunk into fixed-length tile
records, yields it, and drops it before the next window. Peak residency is a
window of chunks, never the file.

`buildTileStoreFromLaz` mirrors `buildTileStoreFromLas`: open the source,
`indexOutOfCore`, `buildTileStore`, write the manifest and hierarchy to the sink.

## Scope

Supports only a LAZ whose chunk table `readLazChunkTable` can address, and only
point formats 6, 7 and 8. A pointwise LAZ, an interrupted writer, or an
unsupported format throws `ChunkedLazUnsupportedError` rather than reading the
file whole. `readLazChunkTable` gains an optional head-read cap so the header
scan stays a small prefix.

## Tests

Built from the committed `multichunk.laz` (PDRF 7, 120000 points, 3 chunks).
The instrumented range source records every read; the largest single read is one
chunk, well under half the file, and no whole-file read occurs. A trusted source
header drives a one-pass build proven byte-identical to the two-pass build. Round
trip: artifacts reopen and every node decodes back to world coordinates.
