### PR TITLE
Show a preview sample before the heavy out-of-core index

### DIFF
--- a/src/app/heavyLasExecutor.ts
+++ b/src/app/heavyLasExecutor.ts
@@ -21,7 +21,8 @@ import {
 } from '../io/heavy/storagePreflight';
 import { openTileStore, tileBytesReader } from '../io/heavy/tileStoreBuilder';
 import { opfsSpillStore, removeOpfsStore, type OpfsDirHandle } from '../io/heavy/opfsSpillStore';
-import { OlvTileSource } from '../io/heavy/OlvTileSource';
+import { OlvTileSource, PreviewCloudSource } from '../io/heavy/OlvTileSource';
+import { buildPreviewSample } from '../io/heavy/previewSampler';
 import { TileChunkDecoder } from '../io/heavy/tileChunkDecoder';
 import { revealStreamingScanChrome } from '../ui/streamingScanReveal';
 import {
@@ -31,6 +32,7 @@ import {
   type OpenStreamingDeps,
   type StreamingReportInput,
 } from './openStreaming';
+import type { StreamingSource } from '../render/streaming/StreamingSource';
 import { LocalOocIndexerClient } from '../io/heavy/worker/localOocIndexerWorkerClient';
 import type { LocalOocPhase } from '../io/heavy/localOocBuild';
 import { readLazChunkTable } from '../io/heavy/lazChunkTable';
@@ -52,6 +54,13 @@ const PHASE_LABELS: Record<LocalOocPhase, string> = {
   indexing: 'Indexing for streaming…',
   finishing: 'Finishing the index…',
 };
+
+/**
+ * The status shown WHILE the preview sample is up. It has to say two things at
+ * once: what is on screen is a sample, and the full index is still building — so
+ * the user cannot mistake a spread of the cloud for the finished scan.
+ */
+const PREVIEW_PHASE_LABEL = 'Preview sample, building the full index…';
 
 /**
  * The refusal sentence for a heavy LAZ the chunked out-of-core path cannot
@@ -135,17 +144,54 @@ export async function executeHeavyLasBuild(
     return { status: 'unavailable', heavy: true, reason: 'preflight refused without a message' };
   }
 
+  // PREVIEW FIRST. Before the long index build, put a bounded, stratified
+  // sample on screen through the SAME streaming attach the real source uses, so
+  // a multi-gigabyte file is not a blank wait. Best effort: any sampling fault
+  // means no preview, never a failed open. The sample is honest — it reports its
+  // own point count and its octree is incomplete — and it is attached WITHOUT
+  // the committed-scan reveal, so nothing presents it as a finished scan. If the
+  // build then completes, `attachStreamingCloud` replaces (and disposes) it.
+  let previewAttached = false;
   try {
-    deps.setPhase(PHASE_LABELS.indexing);
+    const sample = await buildPreviewSample(openRange(file), facts, { signal });
+    if (sample && !signal.aborted) {
+      const previewSource = new PreviewCloudSource({
+        id: `preview-${heavyStoreName(file)}`,
+        name: file.name,
+        sample,
+      });
+      const previewDecoder = new TileChunkDecoder(sample.schema, sample.recordBytes);
+      await attachStreamingScan(previewSource, previewDecoder, deps, signal);
+      deps.setPhase(PREVIEW_PHASE_LABEL);
+      previewAttached = true;
+    }
+  } catch (err) {
+    if (signal.aborted || isCancel(err)) {
+      teardownPreview(previewAttached, deps);
+      return { status: 'cancelled' };
+    }
+    if (deps.debug) console.warn('[heavy-las] preview sample skipped', err);
+  }
+
+  try {
+    // While a preview is on screen the phase must keep saying it is a sample and
+    // the full index is still building, so the user never reads the preview as
+    // the finished cloud. Without a preview it is the plain build phase.
+    const phaseFor = (phase: LocalOocPhase): string =>
+      previewAttached ? PREVIEW_PHASE_LABEL : PHASE_LABELS[phase];
+    deps.setPhase(phaseFor('indexing'));
     const built = await runIndex({
       file,
       storeName: heavyStoreName(file),
       kind: facts.format,
       memoryBudgetBytes: BUILD_MEMORY_BUDGET_BYTES,
-      onPhase: (phase) => deps.setPhase(PHASE_LABELS[phase]),
+      onPhase: (phase) => deps.setPhase(phaseFor(phase)),
       signal,
     });
-    if (signal.aborted) return { status: 'cancelled' };
+    if (signal.aborted) {
+      teardownPreview(previewAttached, deps);
+      return { status: 'cancelled' };
+    }
 
     const dir = await root.getDirectoryHandle(built.storeName);
     const spill = opfsSpillStore(dir);
@@ -177,11 +223,42 @@ export async function executeHeavyLasBuild(
     await attachHeavyStream(source, decoder, deps, signal);
     return { status: 'attached', source, decoder };
   } catch (err) {
-    if (err instanceof LoadCancelledError || (err as { name?: string })?.name === 'AbortError') {
+    // A cancel or a build fault must not leave the preview stranded on screen
+    // labelled "building the full index" when nothing is building any more.
+    teardownPreview(previewAttached, deps);
+    if (signal.aborted || isCancel(err)) {
       return { status: 'cancelled' };
     }
     if (deps.debug) console.warn('[heavy-las] out-of-core open failed; refusing', err);
     return { status: 'failed', heavy: true, error: err };
+  }
+}
+
+/**
+ * Whether a thrown error is a cancellation on its own terms. A user cancel
+ * surfaces as a {@link LoadCancelledError} or a DOM `AbortError`. An aborted read
+ * can also surface as a `RangeReadError`, which is ambiguous (a genuine read
+ * failure raises the same type), so that case is decided by the `signal.aborted`
+ * check at the call site rather than here, and is not folded in.
+ */
+function isCancel(err: unknown): boolean {
+  const name = (err as { name?: string })?.name;
+  return err instanceof LoadCancelledError || name === 'AbortError';
+}
+
+/**
+ * Detach a still-attached preview scan. Called on every non-`attached` exit
+ * after a preview went up: a successful full attach already replaced and
+ * disposed it through `attachStreamingCloud`, but a cancel or a fault never
+ * reaches that swap, so the preview would otherwise stay on screen. Detaching
+ * disposes the (in-memory) preview session; a viewer with no preview is a no-op.
+ */
+function teardownPreview(previewAttached: boolean, deps: HeavyLasBridgeDeps): void {
+  if (!previewAttached) return;
+  try {
+    deps.getViewer().detachStreamingCloud();
+  } catch (err) {
+    if (deps.debug) console.warn('[heavy-las] preview teardown failed', err);
   }
 }
 
@@ -197,13 +274,35 @@ async function attachHeavyStream(
   deps: HeavyLasBridgeDeps,
   signal: AbortSignal,
 ): Promise<void> {
+  await attachStreamingScan(source, decoder, deps, signal);
+  revealHeavyStreamingSurfaces(source, deps.streaming);
+}
+
+/**
+ * Attach a streaming source and reveal the scan CHROME (dock, nav bar,
+ * inspector), stopping short of the committed-scan reveal. Shared by the full
+ * out-of-core open and the preview: the preview needs the cloud on screen and
+ * the chrome to orbit it, but NOT `revealHeavyStreamingSurfaces`, which
+ * publishes the scan report, provenance, CRS and the Analyse rail as a finished
+ * scan — a claim a sample must not make. The full open calls this and then adds
+ * that reveal.
+ *
+ * `attachStreamingCloud` is transactional: it builds the new session first and
+ * aborts before its commit if `signal` fired, and on a streaming→streaming swap
+ * it detaches and disposes the previous cloud only after the replacement is
+ * built. So attaching the real source over the preview replaces it with no leak,
+ * and a cancel mid-build keeps whatever scene was already up.
+ */
+async function attachStreamingScan(
+  source: StreamingSource,
+  decoder: TileChunkDecoder,
+  deps: HeavyLasBridgeDeps,
+  signal: AbortSignal,
+): Promise<void> {
   await deps.viewerReady;
   const viewer = deps.getViewer();
   await viewer.ready;
   if (signal.aborted) throw new LoadCancelledError();
-  // `attachStreamingCloud` is transactional: it builds the new session first and
-  // aborts before its commit if `signal` fired, so a cancel here keeps whatever
-  // scene the user already had rather than blanking the viewer.
   await viewer.attachStreamingCloud(source, decoder, 'balanced', deps.isPhone(), null, signal);
   deps.stage.hideEmptyState();
   viewer.setMode('orbit');
@@ -215,7 +314,6 @@ async function attachHeavyStream(
     backend: viewer.activeBackend(),
     body: deps.body,
   });
-  revealHeavyStreamingSurfaces(source, deps.streaming);
 }
 
 /**

--- a/src/io/heavy/OlvTileSource.ts
+++ b/src/io/heavy/OlvTileSource.ts
@@ -55,6 +55,7 @@ import type {
 } from '../../render/streaming/StreamingSource';
 import type { TileStoreReader } from './tileStore';
 import { createTranslatedFrame, type SpatialFrame } from '../../geo/frame/spatialFrame';
+import type { PreviewSample } from './previewSampler';
 
 /**
  * Node ids carry a one-character prefix because the root's octant path is the
@@ -343,5 +344,195 @@ export class OlvTileSource implements StreamingSource {
 
   async close(): Promise<void> {
     await this._close?.();
+  }
+}
+
+/**
+ * ─────────────────────────────────────────────────────────────────────────
+ * PreviewCloudSource — a stratified sample as a lightweight streaming source.
+ *
+ * Co-located with {@link OlvTileSource} because it is the same kind of adapter:
+ * tile records presented as a {@link StreamingSource} over a single
+ * {@link StreamingNodeStore}. Keeping it here reuses that one io->render value
+ * edge rather than opening a second one from a new file (the module-graph
+ * ratchet is shrink-only). The heavy out-of-core build blocks for a long time on
+ * a multi-gigabyte file; {@link buildPreviewSample} reads a bounded, spatially
+ * spread SAMPLE, and this wraps it so it attaches through the exact same
+ * `attachStreamingCloud` path the real source uses and renders immediately.
+ *
+ * It is deliberately a SINGLE-LEVEL cloud: one root node holding every sampled
+ * record, decoded once through the shared {@link TileChunkDecoder}. It exists
+ * only until the full index replaces it, so there is no hierarchy to refine.
+ *
+ * HONESTY. A preview must never be mistaken for the complete cloud:
+ *  - {@link PreviewCloudSource.sourcePointCount} is the SAMPLE size, not the
+ *    file's declared count, so every count a report or the Inspector derives is
+ *    the number of points actually on screen.
+ *  - the octree's `isComplete` is false, with a recorded reason, so the
+ *    full-cloud grade and any completeness-sensitive consumer refuse to present
+ *    the sample as a finished scan through the shared capability model.
+ * The framing figures come from the file's own header extent, so the camera
+ * frames the whole scene the sample is spread across.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+/** The single root node's id — the tile-key prefix keeps it distinct in logs. */
+const PREVIEW_NODE_ID = 'p';
+
+/** The reason a preview's octree records for being incomplete, so no consumer
+ *  reads a sampled view as a whole cloud. */
+export const PREVIEW_INCOMPLETE_REASON =
+  'preview sample: a spread of the cloud, the full index is still building';
+
+/**
+ * A one-node octree over the sample. `isComplete` is false by construction: this
+ * is a sample, never the whole cloud, and the recorded reason says so.
+ */
+class PreviewOctree implements StreamingOctreeView {
+  readonly store = new StreamingNodeStore();
+  readonly errors: readonly string[] = [PREVIEW_INCOMPLETE_REASON];
+  readonly isComplete = false;
+
+  constructor(bounds: Box6, pointCount: number, spacing: number) {
+    this.store.add({
+      id: PREVIEW_NODE_ID,
+      key: { depth: 0, x: 0, y: 0, z: 0 },
+      depth: 0,
+      bounds,
+      pointCount,
+      byteOffset: 0,
+      byteSize: 0,
+      spacing,
+      refine: 'replace',
+    });
+  }
+
+  nodes() {
+    return this.store.all();
+  }
+}
+
+export interface PreviewCloudSourceOptions {
+  readonly id: string;
+  readonly name: string;
+  readonly sample: PreviewSample;
+  readonly crs?: CrsInfo | null;
+}
+
+/** A {@link StreamingSource} over a bounded, stratified preview sample. */
+export class PreviewCloudSource implements StreamingSource {
+  readonly id: string;
+  readonly kind = 'tiles' as const;
+  readonly name: string;
+  readonly renderOrigin: [number, number, number];
+  readonly frame: SpatialFrame;
+  readonly octree: PreviewOctree;
+
+  private readonly _sample: PreviewSample;
+  private readonly _crs: CrsInfo | null;
+  private readonly _localCube: Box6;
+
+  constructor(options: PreviewCloudSourceOptions) {
+    this.id = options.id;
+    this.name = options.name;
+    this._sample = options.sample;
+    this._crs = options.crs ?? null;
+    const o = options.sample.origin;
+    this.renderOrigin = [o[0], o[1], o[2]];
+    this.frame = createTranslatedFrame(this.renderOrigin);
+
+    // An equal-sided cube over the file's data extent, for framing the camera.
+    const { localMin, localMax } = options.sample;
+    const size = Math.max(
+      1e-3,
+      localMax[0] - localMin[0],
+      localMax[1] - localMin[1],
+      localMax[2] - localMin[2],
+    );
+    const cx = (localMin[0] + localMax[0]) / 2;
+    const cy = (localMin[1] + localMax[1]) / 2;
+    const cz = (localMin[2] + localMax[2]) / 2;
+    const half = size / 2;
+    this._localCube = [cx - half, cy - half, cz - half, cx + half, cy + half, cz + half];
+    // Node bounds are WORLD (local cube + origin): the scheduler subtracts
+    // `renderOrigin` from them to reach render space, so they must start in the
+    // frame the origin is expressed in. See OlvTileSource's frames note.
+    const worldBounds: Box6 = [
+      this._localCube[0] + o[0],
+      this._localCube[1] + o[1],
+      this._localCube[2] + o[2],
+      this._localCube[3] + o[0],
+      this._localCube[4] + o[1],
+      this._localCube[5] + o[2],
+    ];
+    this.octree = new PreviewOctree(worldBounds, options.sample.pointCount, size);
+  }
+
+  /** THE SAMPLE SIZE — never the file's declared count. See the class note. */
+  get sourcePointCount(): number {
+    return this._sample.pointCount;
+  }
+
+  get residentPointCount(): number {
+    return this.octree.store.residentPointCount;
+  }
+
+  counts(): NodeCounts {
+    return this.octree.store.counts();
+  }
+
+  maxDepth(): number {
+    return 0;
+  }
+
+  localBounds(): Box6 {
+    return [...this._localCube];
+  }
+
+  dataBounds(): Box6 {
+    const { localMin, localMax } = this._sample;
+    return [localMin[0], localMin[1], localMin[2], localMax[0], localMax[1], localMax[2]];
+  }
+
+  defaultColorMode(): StreamingColorMode {
+    return this._sample.schema.hasRgb ? 'rgb' : 'elevation';
+  }
+
+  availableColorModes(): readonly StreamingColorMode[] {
+    const out: StreamingColorMode[] = [];
+    if (this._sample.schema.hasRgb) out.push('rgb');
+    out.push('intensity', 'elevation', 'classification');
+    return out;
+  }
+
+  hasGpsTime(): boolean {
+    return this._sample.schema.hasGps;
+  }
+
+  crs(): CrsInfo | null {
+    return this._crs;
+  }
+
+  async readNodeChunk(_record: StreamingNodeRecord, signal?: AbortSignal): Promise<ArrayBuffer> {
+    signal?.throwIfAborted();
+    // The scheduler transfers the buffer to a worker, so hand it a copy that
+    // owns its bytes rather than a view over the retained sample.
+    return this._sample.records.slice().buffer;
+  }
+
+  decodeMeta(record: StreamingNodeRecord): ChunkDecodeMetadata {
+    return {
+      pointDataRecordFormat: -1,
+      pointRecordLength: this._sample.recordBytes,
+      pointCount: record.pointCount,
+      scale: [1, 1, 1],
+      offset: [0, 0, 0],
+      renderOrigin: [0, 0, 0],
+      rgbEightBit: this._sample.schema.hasRgb ? true : undefined,
+    };
+  }
+
+  async close(): Promise<void> {
+    // In-memory: nothing to release.
   }
 }

--- a/src/io/heavy/previewSampler.ts
+++ b/src/io/heavy/previewSampler.ts
@@ -1,0 +1,265 @@
+/**
+ * previewSampler.ts — a stratified, bounded sample of a heavy cloud.
+ *
+ * The out-of-core index build blocks for a long time on a multi-gigabyte file,
+ * and until it returns nothing is on screen. This module reads a small,
+ * spatially spread SAMPLE of the cloud from bounded range reads so a
+ * representative view can render immediately while the full index builds behind
+ * it. The sample is a spread ACROSS the whole file, not the first N points:
+ * airborne LAS is flightline-ordered, so the front of the file is one corner of
+ * the flight, and a front-only sample would show a sliver rather than the scene.
+ *
+ * The reads are bounded exactly like the rest of the out-of-core path. For an
+ * uncompressed LAS the point records are fixed-size and randomly addressable, so
+ * the sampler seeks to evenly spaced strata and reads one small batch at each
+ * ({@link openSlicedLas}'s `readBatch`), never the whole file. For a chunked LAZ
+ * it reads the chunk table ({@link readLazChunkTable}) and decodes a spread of
+ * individual chunks, one bounded range read each. The largest single read is one
+ * stratum batch (LAS) or one chunk span (LAZ), far smaller than the file.
+ *
+ * The decoded points are packed into the same fixed-length tile records the
+ * out-of-core store uses ({@link packTileRecord}), so the preview streams
+ * through the existing {@link TileChunkDecoder} rather than a parallel decoder.
+ * A lighter direct read is used rather than the sequential
+ * {@link openSlicedLasSource} / {@link openChunkedLazSource} `PointSource`
+ * wrappers because those iterate the WHOLE file in order; the sample needs to
+ * seek to a spread of positions and stop, which is cleaner expressed directly on
+ * the reader and the chunk table while reusing their record packing.
+ *
+ * Pure, RangeSource-only — Node-testable over an ArrayBufferRangeSource.
+ */
+import type { RangeSource } from '../range/RangeSource';
+import { decodeContext, finalizeRawColors } from '../lasDecodeShared';
+import { openSlicedLas } from './slicedLasReader';
+import { readLazChunkTable } from './lazChunkTable';
+import { decodeLazChunkLocal } from './decodeLazChunked';
+import { getLazPerf } from '../lazDecode';
+import {
+  packTileRecord,
+  tileRecordBytes,
+  tileSchemaForHeader,
+  type TileSchema,
+} from './tileRecord';
+
+/** A bounded, stratified sample ready to wrap as a preview streaming source. */
+export interface PreviewSample {
+  /** Every sampled point packed as a fixed-length tile record, back to back. */
+  readonly records: Uint8Array;
+  readonly recordBytes: number;
+  readonly schema: TileSchema;
+  /** How many points the sample holds — the ONLY count a preview may claim. */
+  readonly pointCount: number;
+  /** The recentring origin (floored header minimum), world = local + origin. */
+  readonly origin: [number, number, number];
+  /** The file's tight extent in local (render) space, from the LAS header. */
+  readonly localMin: [number, number, number];
+  readonly localMax: [number, number, number];
+}
+
+export interface PreviewSampleOptions {
+  /** Upper bound on the sampled point count. Default one million. */
+  readonly targetPoints?: number;
+  /** How many strata to spread the reads across. Default 64. */
+  readonly strata?: number;
+  readonly signal?: AbortSignal;
+}
+
+/** Target sampled points — the cap the design names, on the order of a million. */
+const DEFAULT_TARGET_POINTS = 1_000_000;
+/** Strata to spread the reads across the file. */
+const DEFAULT_STRATA = 64;
+/**
+ * Below this the file is not worth previewing: the full build will return about
+ * as fast as the sample renders, so a preview only adds a flash of a second
+ * cloud. Heavy files are far larger than this; a tiny fixture returns null.
+ */
+const MIN_PREVIEW_POINTS = 50_000;
+
+/** Local (render) extent of the file from its world header bounds and origin. */
+function localExtent(
+  worldMin: readonly number[],
+  worldMax: readonly number[],
+  origin: readonly [number, number, number],
+): { min: [number, number, number]; max: [number, number, number] } {
+  return {
+    min: [
+      Math.fround(worldMin[0] - origin[0]),
+      Math.fround(worldMin[1] - origin[1]),
+      Math.fround(worldMin[2] - origin[2]),
+    ],
+    max: [
+      Math.fround(worldMax[0] - origin[0]),
+      Math.fround(worldMax[1] - origin[1]),
+      Math.fround(worldMax[2] - origin[2]),
+    ],
+  };
+}
+
+/**
+ * Build a stratified preview sample, or null when the file is too small to be
+ * worth one or the sample cannot be built (an unsupported LAZ table, a decode
+ * fault). Null is not an error: the caller simply opens with no preview and
+ * waits for the full index.
+ */
+export async function buildPreviewSample(
+  range: RangeSource,
+  facts: { readonly format: 'las' | 'laz'; readonly offsetToPointData: number },
+  options: PreviewSampleOptions = {},
+): Promise<PreviewSample | null> {
+  const target = Math.max(1, Math.floor(options.targetPoints ?? DEFAULT_TARGET_POINTS));
+  const strata = Math.max(1, Math.floor(options.strata ?? DEFAULT_STRATA));
+  const signal = options.signal;
+  try {
+    return facts.format === 'laz'
+      ? await sampleLaz(range, facts.offsetToPointData, target, strata, signal)
+      : await sampleLas(range, target, strata, signal);
+  } catch {
+    // Best effort: any read or decode fault means no preview, not a failed open.
+    return null;
+  }
+}
+
+/**
+ * Sample an uncompressed LAS: divide the readable points into `strata` even
+ * bands and read one small batch at the start of each, so the sample spans the
+ * whole file. Each batch is one bounded {@link RangeSource} range.
+ */
+async function sampleLas(
+  range: RangeSource,
+  target: number,
+  strata: number,
+  signal: AbortSignal | undefined,
+): Promise<PreviewSample | null> {
+  const opened = await openSlicedLas(range, { signal });
+  const total = opened.readablePointCount;
+  if (total < MIN_PREVIEW_POINTS) return null;
+
+  const ctx = decodeContext(opened.header, opened.origin);
+  const schema = tileSchemaForHeader(opened.header.pointFormat, ctx);
+  const recordBytes = tileRecordBytes(schema);
+
+  const bands = Math.min(strata, total);
+  const step = total / bands;
+  const perBand = Math.max(1, Math.min(Math.floor(target / bands), Math.floor(total / bands)));
+
+  const chunks: Uint8Array[] = [];
+  let sampled = 0;
+  for (let b = 0; b < bands && sampled < target; b++) {
+    signal?.throwIfAborted();
+    const start = Math.min(Math.floor(b * step), total - perBand);
+    const count = Math.min(perBand, target - sampled);
+    const batch = await opened.readBatch(start, count);
+    chunks.push(packBatch(batch.raw, batch.count, schema, recordBytes));
+    sampled += batch.count;
+  }
+  if (sampled === 0) return null;
+
+  const { min, max } = localExtent(opened.header.min, opened.header.max, opened.origin);
+  return {
+    records: concat(chunks, sampled * recordBytes),
+    recordBytes,
+    schema,
+    pointCount: sampled,
+    origin: opened.origin,
+    localMin: min,
+    localMax: max,
+  };
+}
+
+/**
+ * Sample a chunked LAZ: read the chunk table, pick a spread of chunks across the
+ * file, and decode each one from its own bounded range read. Returns null when
+ * the table is unusable or the point format is outside the per-chunk decoder's
+ * set (6, 7, 8) — the same fail-closed set the full LAZ build supports.
+ */
+async function sampleLaz(
+  range: RangeSource,
+  offsetToPointData: number,
+  target: number,
+  strata: number,
+  signal: AbortSignal | undefined,
+): Promise<PreviewSample | null> {
+  const table = await readLazChunkTable(range, signal, offsetToPointData);
+  if (!table.supported) return null;
+  const header = table.header;
+  if (![6, 7, 8].includes(header.pointFormat)) return null;
+  const chunks = table.chunks;
+  if (chunks.length === 0) return null;
+
+  const total = header.pointCount;
+  if (total < MIN_PREVIEW_POINTS) return null;
+
+  const origin: [number, number, number] = [
+    Math.floor(header.min[0]),
+    Math.floor(header.min[1]),
+    Math.floor(header.min[2]),
+  ];
+  const ctx = decodeContext(header, origin);
+  const schema = tileSchemaForHeader(header.pointFormat, ctx);
+  const recordBytes = tileRecordBytes(schema);
+  const lazPerf = await getLazPerf();
+
+  // Pick a spread of chunk indices across the file, so the decoded points span
+  // the whole flight rather than its first chunks.
+  const wanted = Math.min(strata, chunks.length);
+  const stride = chunks.length / wanted;
+
+  const packed: Uint8Array[] = [];
+  let sampled = 0;
+  for (let i = 0; i < wanted && sampled < target; i++) {
+    signal?.throwIfAborted();
+    const c = chunks[Math.min(chunks.length - 1, Math.floor(i * stride))];
+    // One bounded range read per chunk — never the whole file.
+    const bytes = await range.readRange(c.byteOffset, c.byteLength, signal);
+    const raw = decodeLazChunkLocal(lazPerf, {
+      chunk: bytes,
+      pointCount: c.pointCount,
+      firstPointIndex: c.firstPointIndex,
+      pointDataRecordFormat: header.pointFormat,
+      pointRecordLength: header.pointDataRecordLength,
+      scale: header.scale,
+      offset: header.offset,
+      ctx,
+    });
+    finalizeRawColors(raw);
+    const take = Math.min(c.pointCount, target - sampled);
+    packed.push(packBatch(raw, take, schema, recordBytes));
+    sampled += take;
+  }
+  if (sampled === 0) return null;
+
+  const { min, max } = localExtent(header.min, header.max, origin);
+  return {
+    records: concat(packed, sampled * recordBytes),
+    recordBytes,
+    schema,
+    pointCount: sampled,
+    origin,
+    localMin: min,
+    localMax: max,
+  };
+}
+
+/** Pack the first `count` points of a decoded batch into tile records. */
+function packBatch(
+  raw: import('../lasDecodeShared').RawPoints,
+  count: number,
+  schema: TileSchema,
+  recordBytes: number,
+): Uint8Array {
+  const out = new Uint8Array(count * recordBytes);
+  const view = new DataView(out.buffer);
+  for (let i = 0; i < count; i++) packTileRecord(raw, i, schema, view, i * recordBytes);
+  return out;
+}
+
+/** Concatenate packed batches into one contiguous record buffer. */
+function concat(parts: readonly Uint8Array[], totalBytes: number): Uint8Array {
+  const out = new Uint8Array(totalBytes);
+  let at = 0;
+  for (const part of parts) {
+    out.set(part, at);
+    at += part.byteLength;
+  }
+  return out;
+}

--- a/tests/heavyLasBridgeStreaming.test.ts
+++ b/tests/heavyLasBridgeStreaming.test.ts
@@ -210,9 +210,11 @@ describe('openLocalHeavyLas — the out-of-core local LAS bridge', () => {
 
     const result = await openLocalHeavyLas(file, new AbortController().signal, deps, env);
 
-    // The bridge took the OOC path and attached a streaming source.
+    // The bridge took the OOC path and attached a streaming source. It attaches
+    // twice: a preview sample first, then the full index that replaces it. The
+    // source it settles on is the full OlvTileSource.
     expect(result.status).toBe('attached');
-    expect(attachStreamingCloud).toHaveBeenCalledTimes(1);
+    expect(attachStreamingCloud).toHaveBeenCalledTimes(2);
     const attached = getAttached() as OlvTileSource;
     expect(attached).toBeInstanceOf(OlvTileSource);
     expect(result.status === 'attached' && result.source).toBe(attached);

--- a/tests/heavyLasPreviewFirst.test.ts
+++ b/tests/heavyLasPreviewFirst.test.ts
@@ -1,0 +1,357 @@
+/**
+ * heavyLasPreviewFirst.test.ts — the heavy open shows a preview before the index.
+ *
+ * A multi-gigabyte LAS/LAZ takes a long time to index out of core, and until the
+ * index returns nothing is on screen. The preview-first path reads a bounded,
+ * stratified SAMPLE of the cloud and attaches it immediately through the same
+ * `attachStreamingCloud` the real source uses, then replaces it with the full
+ * streamed index when the build completes. These cases pin that behaviour:
+ *
+ *  1. ordering — a preview (a `PreviewCloudSource`, reporting the SAMPLE count)
+ *     is attached BEFORE the index build resolves; the full `OlvTileSource` (the
+ *     real count) is attached second, replacing it.
+ *  2. stratified + bounded — the sample's reads span the whole file and no
+ *     whole-file read happens (an instrumented range plus a `File.arrayBuffer`
+ *     spy).
+ *  3. cancel — cancelling during the preview or the index tears down cleanly:
+ *     the preview is detached, no store is left in OPFS.
+ *  4. honesty — the preview reports its sample size, not the file total, and its
+ *     octree is marked incomplete.
+ *
+ * The browser seams are the repo's usual fakes: OPFS is `tests/support/fakeOpfs`
+ * and the "worker" runs the real build in process. The one addition is a
+ * DEFERRED runIndex, so a test can observe the scene while the build is pending.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { writeLas14 } from '../src/convert/writeLas';
+import type { GlobalPoints } from '../src/convert/globalPoints';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import type { RangeSource, RangeSourceKind } from '../src/io/range/RangeSource';
+import { fakeOpfs } from './support/fakeOpfs';
+import { buildLocalOocStore } from '../src/io/heavy/localOocBuild';
+import { OlvTileSource, PreviewCloudSource } from '../src/io/heavy/OlvTileSource';
+import { buildPreviewSample } from '../src/io/heavy/previewSampler';
+import {
+  openLocalHeavyLas,
+  type HeavyLasBridgeDeps,
+  type HeavyLasBridgeEnv,
+} from '../src/app/openLocalHeavyLas';
+import type { StorageEstimateReading } from '../src/io/heavy/storagePreflight';
+import type { Viewer } from '../src/render/Viewer';
+
+const WORLD_MIN = [400000, 5200000, 55] as const;
+
+/** An uncompressed LAS whose points span a wide XY grid, so a stratified sample
+ *  across file order is a spread across the footprint. */
+function lasBytes(n: number): ArrayBuffer {
+  const x = new Float64Array(n);
+  const y = new Float64Array(n);
+  const z = new Float64Array(n);
+  const intensity = new Uint16Array(n);
+  const classification = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    x[i] = WORLD_MIN[0] + (i % 1000) * 1.5;
+    y[i] = WORLD_MIN[1] + Math.floor(i / 1000) * 1.5;
+    z[i] = WORLD_MIN[2] + (i % 13) * 0.4;
+    intensity[i] = i & 0xffff;
+    classification[i] = 2;
+  }
+  const cloud: GlobalPoints = { count: n, x, y, z, intensity, classification };
+  const bytes = writeLas14(cloud);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function spyFile(name: string, size: number): { file: File; arrayBuffer: ReturnType<typeof vi.fn> } {
+  const arrayBuffer = vi.fn(async () => new ArrayBuffer(size));
+  const file = { name, size, arrayBuffer } as unknown as File;
+  return { file, arrayBuffer };
+}
+
+/** A range source that records each read's absolute offset and length, so a
+ *  test can prove the sample spans the file and never reads it whole. */
+class RecordingRange implements RangeSource {
+  readonly reads: Array<{ offset: number; length: number }> = [];
+  private readonly inner: RangeSource;
+  constructor(inner: RangeSource) {
+    this.inner = inner;
+  }
+  id(): string {
+    return this.inner.id();
+  }
+  kind(): RangeSourceKind {
+    return this.inner.kind();
+  }
+  size(): Promise<number> {
+    return this.inner.size();
+  }
+  async readRange(offset: number, length: number, signal?: AbortSignal): Promise<ArrayBuffer> {
+    const buf = await this.inner.readRange(offset, length, signal);
+    this.reads.push({ offset, length: buf.byteLength });
+    return buf;
+  }
+}
+
+/** A viewer stub recording every attach in order and whether a detach happened. */
+function fakeViewer() {
+  const attached: unknown[] = [];
+  let current: unknown = null;
+  const attachStreamingCloud = vi.fn(async (source: unknown) => {
+    attached.push(source);
+    current = source;
+  });
+  const detachStreamingCloud = vi.fn(() => {
+    current = null;
+  });
+  const viewer = {
+    ready: Promise.resolve(),
+    attachStreamingCloud,
+    detachStreamingCloud,
+    activeBackend: () => 'webgl2' as const,
+    availableImageExportModes: () => new Map(),
+    setMode: vi.fn(),
+    frameAll: vi.fn(),
+    hasStreamingCloud: false,
+    clouds: () => [],
+  };
+  return { viewer, attachStreamingCloud, detachStreamingCloud, attached, getCurrent: () => current };
+}
+
+function fakeStreaming(viewer: unknown) {
+  return {
+    getViewer: () => viewer,
+    getStreamingQuality: () => 'balanced',
+    debug: false,
+    stage: { hideEmptyState: vi.fn() },
+    streamingPanel: {
+      setPhase: vi.fn(), show: vi.fn(), setColorModes: vi.fn(),
+      setQuality: vi.fn(), setSummary: vi.fn(), setSourceUrl: vi.fn(),
+    },
+    exportPanel: { setImageExportEnabled: vi.fn(), setImageExportAvailability: vi.fn(), setStreamingMode: vi.fn() },
+    inspector: { setStreamingMode: vi.fn(), setDetail: vi.fn(), setReport: vi.fn(), element: { classList: { remove: vi.fn() } } },
+    classLegendPanel: { setClasses: vi.fn(), hide: vi.fn(), getVisibility: () => ({ isFiltered: () => false }) },
+    inspectorCards: { refreshProvenanceFromStreaming: vi.fn(), refreshDatasetIntelligenceFromStreamingCloud: vi.fn() },
+    crsCoordinator: { refreshCrsForStreamingCloud: vi.fn() },
+    bookmarks: { clear: vi.fn() },
+    hideReclassifyUi: vi.fn(),
+    syncInspectClassScope: vi.fn(),
+    prewarmExportStudio: vi.fn(),
+    revealAnalysePanel: vi.fn(),
+    startStreamingStatusPolling: vi.fn(),
+    refreshViewsUI: vi.fn(),
+    runStreamingModules: vi.fn(() => []),
+    setLastStreamingReportCloud: vi.fn(),
+  } as unknown as HeavyLasBridgeDeps['streaming'];
+}
+
+function makeDeps() {
+  const v = fakeViewer();
+  const navBar = { element: { classList: { remove: vi.fn() } }, setMode: vi.fn(), flashHelp: vi.fn() };
+  const phases: string[] = [];
+  const deps: HeavyLasBridgeDeps = {
+    viewerReady: Promise.resolve(),
+    getViewer: () => v.viewer as unknown as Viewer,
+    isPhone: () => false,
+    renderBudget: 2_000_000,
+    deviceMemoryGB: () => 0.001,
+    dock: {
+      setEmpty: vi.fn(), setMeasureEnabled: vi.fn(), setAnnotateEnabled: vi.fn(),
+      setInspectEnabled: vi.fn(), setProbeEnabled: vi.fn(), setCloseEnabled: vi.fn(), setBackend: vi.fn(),
+    },
+    inspector: { setEmpty: vi.fn() },
+    navBar,
+    stage: { hideEmptyState: vi.fn() },
+    body: { classList: { add: vi.fn() } },
+    setPhase: (p) => phases.push(p),
+    debug: false,
+    streaming: fakeStreaming(v.viewer),
+  };
+  return { deps, ...v, phases };
+}
+
+/** A deferred so a test can hold the build pending, then release it. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeEnv(opts: {
+  range: RangeSource;
+  gate?: Promise<void>;
+  onBuildStart?: () => void;
+}): { env: HeavyLasBridgeEnv; opfs: ReturnType<typeof fakeOpfs> } {
+  const opfs = fakeOpfs({ syncAccess: true, fileMove: true });
+  const reading: StorageEstimateReading = { available: true, quotaBytes: 200_000_000_000, usageBytes: 0 };
+  const env: HeavyLasBridgeEnv = {
+    capable: () => true,
+    openRange: () => opts.range,
+    getOpfsRoot: async () => opfs.root,
+    readStorage: async () => reading,
+    async runIndex(req) {
+      opts.onBuildStart?.();
+      if (opts.gate) await opts.gate;
+      return buildLocalOocStore(opts.range, opfs.root, req.storeName, {
+        pointsPerLeaf: req.pointsPerLeaf,
+        memoryBudgetBytes: req.memoryBudgetBytes,
+        maxDepth: req.maxDepth,
+        batchPoints: 4096,
+        signal: req.signal,
+        onPhase: req.onPhase,
+      });
+    },
+  };
+  return { env, opfs };
+}
+
+/** Wait until `cond` holds, letting the sampler's awaits drain. */
+async function waitFor(cond: () => boolean, tries = 200): Promise<void> {
+  for (let i = 0; i < tries; i++) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  throw new Error('waitFor timed out');
+}
+
+describe('heavy open — preview-first attach and swap', () => {
+  it('attaches a preview before the index, then replaces it with the full source', async () => {
+    const n = 400_000;
+    const buffer = lasBytes(n);
+    const range = new RecordingRange(new ArrayBufferRangeSource(buffer));
+    const { file } = spyFile('heavy.las', buffer.byteLength);
+    const { deps, attachStreamingCloud, attached } = makeDeps();
+
+    const gate = deferred<void>();
+    let buildStarted = false;
+    const { env } = makeEnv({ range, gate: gate.promise, onBuildStart: () => (buildStarted = true) });
+
+    const open = openLocalHeavyLas(file, new AbortController().signal, deps, env);
+
+    // The index build has begun (and is gated). The preview must already be up,
+    // since the executor attaches it before it calls runIndex.
+    await waitFor(() => buildStarted);
+    expect(attachStreamingCloud).toHaveBeenCalledTimes(1);
+    const preview = attached[0] as PreviewCloudSource;
+    expect(preview).toBeInstanceOf(PreviewCloudSource);
+    // The preview reports the SAMPLE size — fewer than the file's points.
+    expect(preview.sourcePointCount).toBeGreaterThan(0);
+    expect(preview.sourcePointCount).toBeLessThanOrEqual(n);
+    expect(preview.octree.isComplete).toBe(false);
+
+    // Release the build. The full source attaches second and replaces the preview.
+    gate.resolve();
+    const result = await open;
+    expect(result.status).toBe('attached');
+    expect(attachStreamingCloud).toHaveBeenCalledTimes(2);
+    const full = attached[1] as OlvTileSource;
+    expect(full).toBeInstanceOf(OlvTileSource);
+    expect(full.sourcePointCount).toBe(n);
+  });
+
+  it('samples across the whole file with bounded reads, never the whole file', async () => {
+    const n = 400_000;
+    const buffer = lasBytes(n);
+    const fileBytes = buffer.byteLength;
+    const range = new RecordingRange(new ArrayBufferRangeSource(buffer));
+    const { file, arrayBuffer } = spyFile('heavy.las', fileBytes);
+    const { deps } = makeDeps();
+    const { env } = makeEnv({ range });
+
+    const result = await openLocalHeavyLas(file, new AbortController().signal, deps, env);
+    expect(result.status).toBe('attached');
+
+    // The whole-file read never happened.
+    expect(arrayBuffer).not.toHaveBeenCalled();
+
+    // The sample's point-data reads (past the header/VLR region) span the file:
+    // the earliest and the latest start far apart, across most of the file.
+    const offsetToPointData = 375; // LAS 1.4 minimal header; point reads are well past it.
+    const pointReads = range.reads.filter((r) => r.offset >= offsetToPointData);
+    const offsets = pointReads.map((r) => r.offset);
+    const earliest = Math.min(...offsets);
+    const latest = Math.max(...offsets);
+    expect(pointReads.length).toBeGreaterThan(8);
+    // A front-only sample would put every read near the start; a stratified one
+    // reaches into the last third of the file.
+    expect(latest - earliest).toBeGreaterThan(fileBytes / 2);
+
+    // No single read approaches the file: the sliced reader's fixed 4 MiB header
+    // cap plus at most one stratum batch, independent of the file size.
+    const READ_CAP = 4 * 1024 * 1024 + 1 * 1024 * 1024;
+    const largest = Math.max(...range.reads.map((r) => r.length));
+    expect(largest).toBeLessThanOrEqual(READ_CAP);
+    expect(largest).toBeLessThan(fileBytes);
+  });
+
+  it('tears down the preview and leaves no store when cancelled during the index', async () => {
+    const n = 400_000;
+    const buffer = lasBytes(n);
+    const range = new RecordingRange(new ArrayBufferRangeSource(buffer));
+    const { file } = spyFile('heavy.las', buffer.byteLength);
+    const { deps, attachStreamingCloud, detachStreamingCloud, attached } = makeDeps();
+    const controller = new AbortController();
+
+    const gate = deferred<void>();
+    const { env, opfs } = makeEnv({
+      range,
+      gate: gate.promise,
+      onBuildStart: () => {
+        // The build has started and the preview is up; cancel now, then let the
+        // gated build observe the abort and throw.
+        controller.abort();
+        gate.resolve();
+      },
+    });
+
+    const result = await openLocalHeavyLas(file, controller.signal, deps, env);
+
+    expect(result.status).toBe('cancelled');
+    // The preview WAS attached, and it WAS detached — no stuck preview.
+    expect(attachStreamingCloud).toHaveBeenCalledTimes(1);
+    expect(attached[0]).toBeInstanceOf(PreviewCloudSource);
+    expect(detachStreamingCloud).toHaveBeenCalledTimes(1);
+    // The partial store was discarded.
+    expect(opfs.topLevel()).toEqual([]);
+  });
+});
+
+describe('buildPreviewSample — stratified, bounded, honest', () => {
+  it('reports the sample size, not the file total, and spans the file', async () => {
+    const n = 400_000;
+    const buffer = lasBytes(n);
+    const range = new RecordingRange(new ArrayBufferRangeSource(buffer));
+
+    // A small target so the sample is clearly a fraction of the file.
+    const sample = await buildPreviewSample(
+      range,
+      { format: 'las', offsetToPointData: 375 },
+      { targetPoints: 40_000, strata: 32 },
+    );
+    if (!sample) throw new Error('expected a sample');
+
+    // Honesty: the sample count is well under the file total.
+    expect(sample.pointCount).toBeGreaterThan(0);
+    expect(sample.pointCount).toBeLessThanOrEqual(40_000);
+    expect(sample.pointCount).toBeLessThan(n);
+
+    // A PreviewCloudSource over it claims only the sample and is incomplete.
+    const src = new PreviewCloudSource({ id: 'p', name: 'heavy.las', sample });
+    expect(src.sourcePointCount).toBe(sample.pointCount);
+    expect(src.octree.isComplete).toBe(false);
+
+    // Spread: reads reach deep into the file, not just the front.
+    const pointReads = range.reads.filter((r) => r.offset >= 375);
+    const spread = Math.max(...pointReads.map((r) => r.offset)) - Math.min(...pointReads.map((r) => r.offset));
+    expect(spread).toBeGreaterThan(buffer.byteLength / 2);
+  });
+
+  it('returns null for a file too small to be worth a preview', async () => {
+    const buffer = lasBytes(10_000);
+    const range = new ArrayBufferRangeSource(buffer);
+    const sample = await buildPreviewSample(range, { format: 'las', offsetToPointData: 375 });
+    expect(sample).toBeNull();
+  });
+});

--- a/tests/heavyLazBridgeRouting.test.ts
+++ b/tests/heavyLazBridgeRouting.test.ts
@@ -158,7 +158,8 @@ describe('openLocalHeavyLas — chunked LAZ routing', () => {
     expect(result.status).toBe('attached');
     expect(runIndex).toHaveBeenCalledTimes(1);
     expect(runIndex.mock.calls[0][0].kind).toBe('laz');
-    expect(attachStreamingCloud).toHaveBeenCalledTimes(1);
+    // A preview sample attaches first, then the full index replaces it.
+    expect(attachStreamingCloud).toHaveBeenCalledTimes(2);
     const attached = getAttached() as OlvTileSource;
     expect(attached).toBeInstanceOf(OlvTileSource);
     expect(attached.sourcePointCount).toBe(120_000);


### PR DESCRIPTION
## What

A large local LAS or LAZ showed nothing until its out-of-core index
finished, a long blank wait on a multi-gigabyte file. This attaches a
representative preview immediately, then swaps in the full streamed index
when the build completes.

## How

Before `runIndex`, the executor builds a bounded, stratified sample and
attaches it through the same `attachStreamingCloud` the real source uses.
When the index returns, the full `OlvTileSource` attaches and replaces the
preview, which the attach path disposes. The sampler reads a spread of
small ranges across the whole file, not the front, since airborne LAS is
flightline-ordered: even strata for uncompressed LAS, a spread of chunks
for chunked LAZ, packed into the tile records the shared decoder reads.
The largest read is one stratum batch or one chunk, never the file.

## Honesty

The preview reports its sample point count, never the file total, and its
octree is marked incomplete, so no report or grade presents a sample as a
finished scan. The committed-scan reveal runs only for the full source.
The phase says a preview is up while the full index builds.

## Cancel

A cancel during the preview or the build detaches the preview and leaves
no store: no stuck preview, the partial OPFS store discarded.

## Tests

Ordering (preview first, full second, replaced), stratified and bounded
reads (spanning the file, no whole-file read), cancel teardown, and the
sample-size honesty are covered; each guard was mutation-checked.
