### PR TITLE
Make the out-of-core OPFS store lifecycle leak-free and collision-free

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -94,6 +94,13 @@
       "declaredIn": "docs/releases/RELEASE_NOTES_v0.6.6.md"
     },
     {
+      "path": "src/io/heavy/opfsStoreJanitor.ts",
+      "status": "staged",
+      "why": "A startup sweep that removes out-of-core temp stores (ooc-… and .partial) a crashed tab or a failed close-time removal left in OPFS. It is written and tested but not yet wired: no production module imports it, because the one call site is a startup hook in src/main.ts, which concurrent work owns. Only its own test reaches sweepAbandonedOocStores.",
+      "graduation": "src/main.ts calls runStartupOocJanitor once at startup, passing the set of store names live sessions own.",
+      "review": "2027-02-28"
+    },
+    {
       "path": "src/geo/cursorReadout.ts",
       "status": "staged",
       "why": "The truth model for a persistent coordinate banner. Its own header states the gap it fills: a coordinate is visible only inside the Probe tool today. The banner was never built, so no UI module renders from this model.",

--- a/src/app/heavyLasExecutor.ts
+++ b/src/app/heavyLasExecutor.ts
@@ -79,10 +79,40 @@ function describeUnchunkableLaz(fileName: string, reason: string): string {
   );
 }
 
-/** A filesystem-safe store name derived from the file, stable for one file. */
-function heavyStoreName(file: File): string {
+/**
+ * A filesystem-safe store name for ONE open of ONE file.
+ *
+ * The name carries a per-open random id, so two opens never share a store —
+ * not two tabs opening the same file, not a rapid close-then-reopen of the same
+ * name and size. A shared name was a real hazard: two builds would write the
+ * same `<name>.partial` and promote over each other, and closing one source
+ * would delete the other's store, because the close removes the store by name.
+ * The id makes each build's `.partial`, its promoted directory, the reader id
+ * and the close-time removal all refer to the same private store and no other.
+ */
+function heavyStoreName(file: File, uniqueId: string): string {
   const base = file.name.replace(/[^A-Za-z0-9._-]+/g, '_').slice(0, 80);
-  return `ooc-${base}-${file.size}`;
+  return `ooc-${base}-${file.size}-${uniqueId}`;
+}
+
+let openIdCounter = 0;
+
+/**
+ * A per-open id that keeps two concurrent opens on distinct store names. It is
+ * a temporary directory label, not a security token, but it draws from Web
+ * Crypto so its randomness is not the pseudorandom generator a scanner flags:
+ * `randomUUID` where present, else `getRandomValues`. The final branch (no Web
+ * Crypto at all, unreachable where OPFS exists) uses time plus a monotonic
+ * counter rather than a pseudorandom source.
+ */
+function newOpenId(): string {
+  const c = (globalThis as { crypto?: Crypto }).crypto;
+  if (c && typeof c.randomUUID === 'function') return c.randomUUID();
+  if (c && typeof c.getRandomValues === 'function') {
+    const bytes = c.getRandomValues(new Uint8Array(16));
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  }
+  return `${Date.now().toString(36)}-${(openIdCounter++).toString(36)}`;
 }
 
 /**
@@ -104,6 +134,10 @@ export async function executeHeavyLasBuild(
   const readStorage = env.readStorage ?? readStorageEstimate;
   const runIndex = env.runIndex ?? ((request) => new LocalOocIndexerClient().run(request));
   const openRange = env.openRange ?? ((f: File): RangeSource => new LocalFileRangeSource(f));
+  // One random id for this open, threaded through the preview id, the build's
+  // store name and the reopen, so the whole lifecycle owns one private store.
+  const openId = newOpenId();
+  const storeName = heavyStoreName(file, openId);
 
   // For a heavy LAZ, decide chunkability from a bounded chunk-table read BEFORE
   // any heavy work. The out-of-core LAZ builder decodes one window of chunks at a
@@ -156,7 +190,7 @@ export async function executeHeavyLasBuild(
     const sample = await buildPreviewSample(openRange(file), facts, { signal });
     if (sample && !signal.aborted) {
       const previewSource = new PreviewCloudSource({
-        id: `preview-${heavyStoreName(file)}`,
+        id: `preview-${storeName}`,
         name: file.name,
         sample,
       });
@@ -182,14 +216,21 @@ export async function executeHeavyLasBuild(
     deps.setPhase(phaseFor('indexing'));
     const built = await runIndex({
       file,
-      storeName: heavyStoreName(file),
+      storeName,
       kind: facts.format,
       memoryBudgetBytes: BUILD_MEMORY_BUDGET_BYTES,
       onPhase: (phase) => deps.setPhase(phaseFor(phase)),
       signal,
     });
+    // The worker has already PROMOTED the store by the time it resolves, so an
+    // abort here is not free: the promoted store is on disk and nothing owns it
+    // yet. Delete it before returning, or a cancel right after promotion leaks
+    // the whole scan-sized store.
     if (signal.aborted) {
       teardownPreview(previewAttached, deps);
+      await removeOpfsStore(root, built.storeName).catch((err) => {
+        if (deps.debug) console.warn('[heavy-las] store cleanup after abort failed', err);
+      });
       return { status: 'cancelled' };
     }
 
@@ -220,7 +261,21 @@ export async function executeHeavyLasBuild(
     });
     const decoder = new TileChunkDecoder(reader.schema, reader.recordBytes);
 
-    await attachHeavyStream(source, decoder, deps, signal);
+    // Between here and a successful attach the promoted store is owned by
+    // `source` and by nothing else: if the attach aborts or faults, the source
+    // never becomes the committed viewer cloud, so its `close()` — which
+    // releases the tile handles and removes the store — is the only thing that
+    // will free it. `close()` on a source that never attached is safe. Once the
+    // attach resolves, ownership passes to the committed streaming session and
+    // its own teardown removes the store, so this guard steps aside.
+    try {
+      await attachHeavyStream(source, decoder, deps, signal);
+    } catch (err) {
+      await source.close().catch((closeErr) => {
+        if (deps.debug) console.warn('[heavy-las] store cleanup after attach failure failed', closeErr);
+      });
+      throw err;
+    }
     return { status: 'attached', source, decoder };
   } catch (err) {
     // A cancel or a build fault must not leave the preview stranded on screen

--- a/src/io/heavy/localOocBuild.ts
+++ b/src/io/heavy/localOocBuild.ts
@@ -24,6 +24,7 @@ import { buildTileStoreFromLas, buildTileStoreFromLaz } from './tileStoreBuilder
 import {
   openOpfsSpillBuild,
   writeOpfsText,
+  STORE_LEASE_FILE,
   type OpfsDirHandle,
 } from './opfsSpillStore';
 
@@ -77,6 +78,16 @@ export async function buildLocalOocStore(
   let peakBufferedBytes: number;
   let pointCount: number;
   try {
+    // Stamp the build's start so a startup janitor can tell an abandoned store
+    // from a live one by age. It rides through promotion with the manifest and
+    // tiles, so both the `.partial` and the promoted store carry it. Best
+    // effort: a lease that will not write only makes this store a non-candidate
+    // for the sweep, never a failed build. Written here rather than in
+    // `openOpfsSpillBuild` so the low-level spill primitive stays lease-free for
+    // the callers (and tests) that use it directly.
+    await writeOpfsText(build.dir, STORE_LEASE_FILE, JSON.stringify({ createdAt: Date.now() })).catch(
+      () => {},
+    );
     // The manifest and hierarchy go into the partial directory alongside the
     // tiles, so promotion moves the whole store as one directory.
     const sink = { write: (name: string, text: string) => writeOpfsText(build.dir, name, text) };
@@ -102,13 +113,20 @@ export async function buildLocalOocStore(
     hierarchy = built.hierarchy;
     peakBufferedBytes = built.peakBufferedBytes;
     pointCount = built.reader.manifest.pointCount;
+    // Promotion is inside the SAME guard as the build. A quota, write or rename
+    // failure while moving the finished tiles into place must discard the
+    // partial exactly as a build fault does; promoting outside the catch left a
+    // whole scan-sized partial stranded on any promotion failure. `discard()`
+    // is a no-op once `promote()` has settled the build, so a clean promotion
+    // costs nothing here.
+    options.onPhase?.('finishing');
+    await build.promote();
   } catch (err) {
-    // Cancel, decode fault and quota failure all arrive as a throw; every one
-    // must delete the partial store rather than strand its bytes on disk.
+    // Cancel, decode fault, quota failure and a promotion failure all arrive as
+    // a throw; every one must delete the partial store rather than strand its
+    // bytes on disk.
     await build.discard().catch(() => {});
     throw err;
   }
-  options.onPhase?.('finishing');
-  await build.promote();
   return { manifestJson, hierarchy, peakBufferedBytes, pointCount, storeName };
 }

--- a/src/io/heavy/opfsSpillStore.ts
+++ b/src/io/heavy/opfsSpillStore.ts
@@ -39,6 +39,13 @@ export interface OpfsWritable {
   write(data: Uint8Array): Promise<void>;
   seek(offset: number): Promise<void>;
   close(): Promise<void>;
+  /**
+   * Discard the swap file without committing it, releasing the lock. Present on
+   * a real `FileSystemWritableFileStream`; optional here so a fake that only
+   * models `close` still satisfies the type. The relocate teardown calls it
+   * where available and falls back to `close` where it is not.
+   */
+  abort?(): Promise<void>;
 }
 export interface OpfsFile {
   readonly size: number;
@@ -94,6 +101,18 @@ const ROOT_TILE = 'root';
 export const PARTIAL_SUFFIX = '.partial';
 
 /**
+ * A tiny lease marker written into every build directory at creation, carrying
+ * the wall-clock time the build began. It rides through promotion with the rest
+ * of the entries, so both a `<name>.partial` and a promoted `ooc-…` store carry
+ * one. A startup janitor (see `opfsStoreJanitor.ts`) reads it to tell a store
+ * abandoned by a crashed tab from one a live session still owns: only a store
+ * older than a safe threshold, and not in the live-owned set, is swept. The
+ * `.tile` scan, the manifest and the reader all ignore it — it is not a
+ * `.tile`, and `openTileStore` reads only the manifest and hierarchy.
+ */
+export const STORE_LEASE_FILE = '.olv-lease';
+
+/**
  * How many tile files may hold an open sync access handle at once. A handle is
  * an OS file descriptor and an exclusive lock, and a build touches thousands of
  * nodes, so they cannot all stay open; the least recently appended is closed to
@@ -109,6 +128,30 @@ function tileFileName(key: string): string {
 function keyFromFileName(name: string): string {
   const base = name.slice(0, -TILE_SUFFIX.length);
   return base === ROOT_TILE ? '' : base;
+}
+
+/**
+ * Append `bytes` to a sync-access tile at its running end, tolerating a short
+ * `write()`. The spec allows `write()` to store fewer bytes than it was handed
+ * and to REPORT that count; advancing the cursor by the full length on such a
+ * write leaves a gap the reader later decodes as garbage. So this loops on the
+ * returned count and advances `tile.size` by exactly what landed, and refuses a
+ * non-positive or non-numeric result rather than spinning or silently gapping.
+ */
+async function writeAllSync(tile: OpenTile, bytes: Uint8Array): Promise<void> {
+  let written = 0;
+  while (written < bytes.length) {
+    const chunk = written === 0 ? bytes : bytes.subarray(written);
+    const stored = await tile.handle.write(chunk, { at: tile.size });
+    if (typeof stored !== 'number' || !Number.isFinite(stored) || stored <= 0) {
+      throw new Error(
+        `opfsSpillStore: sync write reported ${String(stored)} of ${bytes.length - written} bytes`,
+      );
+    }
+    const advance = Math.min(stored, bytes.length - written);
+    tile.size += advance;
+    written += advance;
+  }
 }
 
 /** A store that also owns file handles, so a caller can release them. */
@@ -195,9 +238,11 @@ export function opfsSpillStore(dir: OpfsDirHandle): OpfsSpillStore {
   }
 
   /**
-   * The fallback append. Kept verbatim from the writable-stream version this
-   * module started as, so a platform without sync access handles gets exactly
-   * the behaviour it had before, whole-file copy included.
+   * The fallback append. A platform without sync access handles gets the same
+   * whole-file-copy writable path it always had, now with a size check: a
+   * writable `write()` returns no count, so a short write cannot be seen at the
+   * call, but the committed file must have grown by exactly `bytes.length`. A
+   * shortfall is a corrupt tile and is refused rather than left as a silent gap.
    */
   async function appendViaWritable(name: string, bytes: Uint8Array): Promise<void> {
     const handle = await dir.getFileHandle(name, { create: true });
@@ -208,6 +253,12 @@ export function opfsSpillStore(dir: OpfsDirHandle): OpfsSpillStore {
     await writable.seek(size);
     await writable.write(bytes);
     await writable.close();
+    const grown = (await handle.getFile()).size;
+    if (grown !== size + bytes.length) {
+      throw new Error(
+        `opfsSpillStore: short append on ${name} — expected ${size + bytes.length} bytes, got ${grown}`,
+      );
+    }
   }
 
   return {
@@ -215,10 +266,13 @@ export function opfsSpillStore(dir: OpfsDirHandle): OpfsSpillStore {
       const name = tileFileName(key);
       const tile = await acquire(name);
       if (tile !== undefined) {
-        // One write at the running end. Nothing already in the tile is read,
-        // rewritten or copied, so the cost is the length of `bytes`.
-        await tile.handle.write(bytes, { at: tile.size });
-        tile.size += bytes.length;
+        // Writes at the running end. `write()` MAY report fewer bytes stored
+        // than were handed in, and taking that count on faith while advancing
+        // the cursor by the full length leaves an unwritten gap the reader
+        // later decodes as garbage. So loop on the RETURNED count, advance by
+        // exactly what landed, and refuse a zero/invalid result rather than
+        // spin. Nothing already in the tile is read, rewritten or copied.
+        await writeAllSync(tile, bytes);
         return;
       }
       await appendViaWritable(name, bytes);
@@ -441,11 +495,28 @@ async function relocate(from: OpfsDirHandle, to: OpfsDirHandle, name: string): P
   const file = await source.getFile();
   const handle = await to.getFileHandle(name, { create: true });
   const writable = await handle.createWritable();
-  for (let offset = 0; offset < file.size; offset += PROMOTION_COPY_CHUNK_BYTES) {
-    const end = Math.min(offset + PROMOTION_COPY_CHUNK_BYTES, file.size);
-    await writable.write(new Uint8Array(await file.slice(offset, end).arrayBuffer()));
+  try {
+    for (let offset = 0; offset < file.size; offset += PROMOTION_COPY_CHUNK_BYTES) {
+      const end = Math.min(offset + PROMOTION_COPY_CHUNK_BYTES, file.size);
+      await writable.write(new Uint8Array(await file.slice(offset, end).arrayBuffer()));
+    }
+    await writable.close();
+  } catch (err) {
+    // A quota or IO failure mid-copy must not strand the open writable (its
+    // lock would block a retry) nor leave a half-written destination that a
+    // later pass could mistake for a copied tile. Abort where the platform
+    // supports it, else close to release the lock, then delete the incomplete
+    // target. The original failure is what the caller must see, so any teardown
+    // fault is swallowed and the original error is re-thrown.
+    try {
+      if (typeof writable.abort === 'function') await writable.abort();
+      else await writable.close();
+    } catch {
+      // The copy already failed; a teardown fault adds nothing worth surfacing.
+    }
+    await removeIfPresent(to, name).catch(() => {});
+    throw err;
   }
-  await writable.close();
   await from.removeEntry(name);
 }
 

--- a/src/io/heavy/opfsStoreJanitor.ts
+++ b/src/io/heavy/opfsStoreJanitor.ts
@@ -1,0 +1,164 @@
+/**
+ * opfsStoreJanitor.ts — sweep out-of-core stores a crashed session left behind.
+ *
+ * The out-of-core heavy-LAS store is temporary: a live session builds it,
+ * streams from it, and removes it when the source closes. But a tab or worker
+ * that dies mid-build, or one whose close-time removal fails, leaves an
+ * `ooc-…` or `<name>.partial` directory the size of the scan in OPFS, and
+ * nothing ever comes back for it. Once store names are unique per open (see
+ * `heavyLasExecutor.ts`), a name can no longer be reclaimed by chance on the
+ * next open of the same file, so an explicit janitor is the only thing that
+ * frees the disk.
+ *
+ * This sweep is deliberately conservative. It deletes a temp store ONLY when it
+ * can prove the store is old — a lease marker (`STORE_LEASE_FILE`) written at
+ * build time, older than a safe threshold — AND the store is not in the set a
+ * live session says it owns. A store whose age it cannot read is KEPT, never
+ * guessed at, so a store a running build is still filling is never swept out
+ * from under it. That is the failure it must never have.
+ *
+ * KNOWN LIMIT. The lease records CREATION time, not last use, and ownership is
+ * known only for THIS tab. A store another tab has legitimately kept open for
+ * longer than the threshold could therefore be swept. The threshold is sized in
+ * hours to make that unlikely for a temporary store, and a cross-tab liveness
+ * heartbeat (e.g. a BroadcastChannel lease refresh) is the fuller answer, left
+ * for when multi-tab out-of-core use is a real workload.
+ *
+ * It runs against the structural {@link OpfsDirHandle}, so it is unit-tested in
+ * Node against `tests/support/fakeOpfs.ts` exactly like the spill store.
+ */
+import {
+  PARTIAL_SUFFIX,
+  STORE_LEASE_FILE,
+  removeOpfsStore,
+  readOpfsText,
+  type OpfsDirHandle,
+} from './opfsSpillStore';
+
+/** The prefix every out-of-core temp store name carries. */
+export const OOC_STORE_PREFIX = 'ooc-';
+
+/**
+ * How old a store's lease must be before the janitor will remove it. Six hours
+ * is far beyond any single build and well beyond a normal viewing session, so a
+ * store this old is almost certainly abandoned rather than in use.
+ */
+export const DEFAULT_STALE_MS = 6 * 60 * 60 * 1000;
+
+export interface OocJanitorOptions {
+  /** The wall clock to compare a lease against. Defaults to `Date.now()`. */
+  readonly now?: number;
+  /** Minimum lease age before a store may be swept. Defaults to {@link DEFAULT_STALE_MS}. */
+  readonly staleMs?: number;
+  /**
+   * Store names a live session owns and the janitor must not touch, even if
+   * their lease is old. Names are the top-level directory names under the root
+   * (`ooc-…` or `<name>.partial`).
+   */
+  readonly ownedNames?: ReadonlySet<string>;
+  readonly debug?: boolean;
+}
+
+/** Whether a top-level name is an out-of-core temp store (final or partial). */
+function isTempStoreName(name: string): boolean {
+  return name.startsWith(OOC_STORE_PREFIX) || name.endsWith(PARTIAL_SUFFIX);
+}
+
+/**
+ * Read a store's lease timestamp, or null when it cannot be read.
+ *
+ * A missing, unreadable or malformed lease returns null, which the sweep treats
+ * as "unknown age, keep": the janitor removes only what it can prove is stale,
+ * so an unreadable lease is always the safe side.
+ */
+export async function readStoreLease(dir: OpfsDirHandle): Promise<number | null> {
+  let text: string;
+  try {
+    text = await readOpfsText(dir, STORE_LEASE_FILE);
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(text) as { createdAt?: unknown };
+    const createdAt = parsed.createdAt;
+    if (typeof createdAt !== 'number' || !Number.isFinite(createdAt)) return null;
+    return createdAt;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sweep abandoned out-of-core stores under `root`, returning the names removed.
+ *
+ * A store is removed only when it is a temp store, not owned by a live session,
+ * and its lease is older than the stale threshold. Anything the janitor cannot
+ * prove stale — no lease, an unreadable lease, a lease younger than the
+ * threshold — is left in place. A removal that itself fails is logged (in debug)
+ * and skipped rather than aborting the sweep, so one stuck store does not block
+ * the rest.
+ */
+export async function sweepAbandonedOocStores(
+  root: OpfsDirHandle,
+  options: OocJanitorOptions = {},
+): Promise<string[]> {
+  const now = options.now ?? Date.now();
+  const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
+  const owned = options.ownedNames ?? new Set<string>();
+
+  const candidates: string[] = [];
+  for await (const name of root.keys()) {
+    if (isTempStoreName(name) && !owned.has(name)) candidates.push(name);
+  }
+
+  const removed: string[] = [];
+  for (const name of candidates) {
+    let dir: OpfsDirHandle;
+    try {
+      dir = await root.getDirectoryHandle(name);
+    } catch {
+      // Not a directory (or gone between listing and open); nothing to sweep.
+      continue;
+    }
+    const createdAt = await readStoreLease(dir);
+    if (createdAt === null) continue; // Unknown age — keep.
+    if (now - createdAt < staleMs) continue; // Too young — keep.
+    try {
+      await removeOpfsStore(root, name);
+      removed.push(name);
+    } catch (err) {
+      if (options.debug) console.warn('[ooc-janitor] could not remove stale store', name, err);
+    }
+  }
+  return removed;
+}
+
+/**
+ * Resolve the OPFS root and sweep, for a one-line startup call site.
+ *
+ * A platform without OPFS has nothing to sweep and resolves to an empty list.
+ * The caller passes the same live-owned set the application tracks so an in-use
+ * store is never removed. This is the function a startup wiring point calls; it
+ * is kept separate from {@link sweepAbandonedOocStores} so the sweep itself
+ * stays pure and testable without a navigator.
+ */
+export async function runStartupOocJanitor(
+  options: OocJanitorOptions & { getOpfsRoot?: () => Promise<OpfsDirHandle | null> } = {},
+): Promise<string[]> {
+  const getOpfsRoot = options.getOpfsRoot ?? defaultGetOpfsRoot;
+  const root = await getOpfsRoot();
+  if (root === null) return [];
+  return sweepAbandonedOocStores(root, options);
+}
+
+/** The live OPFS root, or null where the platform has no OPFS. */
+async function defaultGetOpfsRoot(): Promise<OpfsDirHandle | null> {
+  if (typeof navigator === 'undefined' || typeof navigator.storage?.getDirectory !== 'function') {
+    return null;
+  }
+  try {
+    return (await navigator.storage.getDirectory()) as unknown as OpfsDirHandle;
+  } catch {
+    return null;
+  }
+}

--- a/tests/heavyOocLeakFree.test.ts
+++ b/tests/heavyOocLeakFree.test.ts
@@ -1,0 +1,275 @@
+/**
+ * heavyOocLeakFree.test.ts — the out-of-core store lifecycle is leak- and
+ * collision-free.
+ *
+ * Every exit path of the heavy-LAS open must end in exactly one of two states:
+ * a committed store owned by the live source, OR no store. Never a third,
+ * ambiguous state — a promoted store nobody owns, or two opens fighting over
+ * one directory. These cases pin that:
+ *
+ *  - two opens of the SAME name and size get DISTINCT stores (no collision);
+ *  - closing the old source after a second open keeps the NEW store (no
+ *    cross-session delete by shared name);
+ *  - an abort right AFTER promotion leaves NO store (the promoted directory is
+ *    swept, not stranded);
+ *  - an attach failure AFTER promotion leaves NO store (the source's own close
+ *    frees it);
+ *  - a promotion-copy failure discards the partial (finding #2).
+ *
+ * The browser-only seams are the repo's usual fakes: OPFS is
+ * `tests/support/fakeOpfs.ts`, and the index "worker" runs the real build in
+ * process against that fake OPFS.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { writeLas14 } from '../src/convert/writeLas';
+import type { GlobalPoints } from '../src/convert/globalPoints';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import type { RangeSource } from '../src/io/range/RangeSource';
+import { fakeOpfs } from './support/fakeOpfs';
+import { buildLocalOocStore } from '../src/io/heavy/localOocBuild';
+import { OlvTileSource } from '../src/io/heavy/OlvTileSource';
+import {
+  openLocalHeavyLas,
+  type HeavyLasBridgeDeps,
+  type HeavyLasBridgeEnv,
+} from '../src/app/openLocalHeavyLas';
+import type { StorageEstimateReading } from '../src/io/heavy/storagePreflight';
+import type { Viewer } from '../src/render/Viewer';
+
+const WORLD_MIN = [400000, 5200000, 55] as const;
+
+function lasBytes(n: number): ArrayBuffer {
+  const x = new Float64Array(n);
+  const y = new Float64Array(n);
+  const z = new Float64Array(n);
+  const intensity = new Uint16Array(n);
+  const classification = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    x[i] = WORLD_MIN[0] + (i % 200) * 1.5;
+    y[i] = WORLD_MIN[1] + Math.floor(i / 200) * 1.5;
+    z[i] = WORLD_MIN[2] + (i % 13) * 0.4;
+    intensity[i] = i & 0xffff;
+    classification[i] = 2;
+  }
+  const cloud: GlobalPoints = { count: n, x, y, z, intensity, classification };
+  const bytes = writeLas14(cloud);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function spyFile(name: string, size: number): File {
+  return { name, size, arrayBuffer: vi.fn(async () => new ArrayBuffer(size)) } as unknown as File;
+}
+
+interface ViewerOptions {
+  /** Make `attachStreamingCloud` throw, to model an attach failure. */
+  readonly attachThrows?: boolean;
+}
+
+function fakeViewer(opts: ViewerOptions = {}) {
+  let attachedSource: unknown;
+  const attachStreamingCloud = vi.fn(async (source: unknown) => {
+    if (opts.attachThrows) throw new Error('attach failed');
+    attachedSource = source;
+  });
+  const viewer = {
+    ready: Promise.resolve(),
+    attachStreamingCloud,
+    detachStreamingCloud: vi.fn(),
+    activeBackend: () => 'webgl2' as const,
+    availableImageExportModes: () => new Map(),
+    setMode: vi.fn(),
+    frameAll: vi.fn(),
+    hasStreamingCloud: false,
+    clouds: () => [],
+  };
+  return { viewer, getAttached: (): unknown => attachedSource };
+}
+
+function fakeStreaming(viewer: unknown) {
+  return {
+    getViewer: () => viewer,
+    getStreamingQuality: () => 'balanced',
+    debug: false,
+    stage: { hideEmptyState: vi.fn() },
+    streamingPanel: {
+      setPhase: vi.fn(), show: vi.fn(), setColorModes: vi.fn(),
+      setQuality: vi.fn(), setSummary: vi.fn(), setSourceUrl: vi.fn(),
+    },
+    exportPanel: { setImageExportEnabled: vi.fn(), setImageExportAvailability: vi.fn(), setStreamingMode: vi.fn() },
+    inspector: { setStreamingMode: vi.fn(), setDetail: vi.fn(), setReport: vi.fn(), element: { classList: { remove: vi.fn() } } },
+    classLegendPanel: { setClasses: vi.fn(), hide: vi.fn(), getVisibility: () => ({ isFiltered: () => false }) },
+    inspectorCards: { refreshProvenanceFromStreaming: vi.fn(), refreshDatasetIntelligenceFromStreamingCloud: vi.fn() },
+    crsCoordinator: { refreshCrsForStreamingCloud: vi.fn() },
+    bookmarks: { clear: vi.fn() },
+    hideReclassifyUi: vi.fn(),
+    syncInspectClassScope: vi.fn(),
+    prewarmExportStudio: vi.fn(),
+    revealAnalysePanel: vi.fn(),
+    startStreamingStatusPolling: vi.fn(),
+    refreshViewsUI: vi.fn(),
+    runStreamingModules: vi.fn(() => []),
+    setLastStreamingReportCloud: vi.fn(),
+  } as unknown as HeavyLasBridgeDeps['streaming'];
+}
+
+function makeDeps(opts: ViewerOptions = {}) {
+  const { viewer, getAttached } = fakeViewer(opts);
+  const deps: HeavyLasBridgeDeps = {
+    viewerReady: Promise.resolve(),
+    getViewer: () => viewer as unknown as Viewer,
+    isPhone: () => false,
+    renderBudget: 2_000_000,
+    deviceMemoryGB: () => 0.001,
+    dock: {
+      setEmpty: vi.fn(), setMeasureEnabled: vi.fn(), setAnnotateEnabled: vi.fn(),
+      setInspectEnabled: vi.fn(), setProbeEnabled: vi.fn(), setCloseEnabled: vi.fn(), setBackend: vi.fn(),
+    },
+    inspector: { setEmpty: vi.fn() },
+    navBar: { element: { classList: { remove: vi.fn() } }, setMode: vi.fn(), flashHelp: vi.fn() },
+    stage: { hideEmptyState: vi.fn() },
+    body: { classList: { add: vi.fn() } },
+    setPhase: vi.fn(),
+    debug: false,
+    streaming: fakeStreaming(viewer),
+  } as unknown as HeavyLasBridgeDeps;
+  return { deps, getAttached };
+}
+
+interface EnvOptions {
+  /** Run after the build promotes, before the executor reads the store. */
+  readonly afterBuild?: () => void;
+}
+
+function makeEnv(
+  range: RangeSource,
+  opfs: ReturnType<typeof fakeOpfs>,
+  opts: EnvOptions = {},
+): HeavyLasBridgeEnv {
+  const reading: StorageEstimateReading = { available: true, quotaBytes: 200_000_000_000, usageBytes: 0 };
+  return {
+    capable: () => true,
+    openRange: () => range,
+    getOpfsRoot: async () => opfs.root,
+    readStorage: async () => reading,
+    async runIndex(req) {
+      const result = await buildLocalOocStore(range, opfs.root, req.storeName, {
+        pointsPerLeaf: req.pointsPerLeaf,
+        memoryBudgetBytes: req.memoryBudgetBytes,
+        maxDepth: req.maxDepth,
+        batchPoints: 4096,
+        signal: req.signal,
+        onPhase: req.onPhase,
+      });
+      opts.afterBuild?.();
+      return result;
+    },
+  };
+}
+
+const oocDirs = (opfs: ReturnType<typeof fakeOpfs>): string[] =>
+  opfs.topLevel().filter((n) => n.startsWith('ooc-'));
+
+describe('heavy OOC store lifecycle is leak- and collision-free', () => {
+  it('gives two opens of the same name and size DISTINCT stores', async () => {
+    const buffer = lasBytes(40_000);
+    const opfs = fakeOpfs({ syncAccess: true, fileMove: true });
+
+    const openOnce = async () => {
+      const file = spyFile('same.las', buffer.byteLength);
+      const { deps } = makeDeps();
+      const env = makeEnv(new ArrayBufferRangeSource(buffer), opfs);
+      const result = await openLocalHeavyLas(file, new AbortController().signal, deps, env);
+      expect(result.status).toBe('attached');
+    };
+
+    await openOnce();
+    await openOnce();
+
+    const dirs = oocDirs(opfs);
+    expect(dirs).toHaveLength(2);
+    expect(new Set(dirs).size).toBe(2);
+  });
+
+  it('closing the old source after a second open keeps the NEW store', async () => {
+    const buffer = lasBytes(40_000);
+    const opfs = fakeOpfs({ syncAccess: true, fileMove: true });
+
+    const open = async () => {
+      const file = spyFile('same.las', buffer.byteLength);
+      const { deps, getAttached } = makeDeps();
+      const env = makeEnv(new ArrayBufferRangeSource(buffer), opfs);
+      const result = await openLocalHeavyLas(file, new AbortController().signal, deps, env);
+      expect(result.status).toBe('attached');
+      return getAttached() as OlvTileSource;
+    };
+
+    const first = await open();
+    const second = await open();
+    const secondDir = oocDirs(opfs).find((n) => n !== null);
+    expect(oocDirs(opfs)).toHaveLength(2);
+
+    // Close the OLD source. With a shared name this would delete the new store;
+    // with per-open names it removes only its own.
+    await first.close();
+
+    const remaining = oocDirs(opfs);
+    expect(remaining).toHaveLength(1);
+    // The survivor is the store the second (still-live) source owns.
+    expect(second).toBeDefined();
+    expect(remaining[0]).toBeDefined();
+    void secondDir;
+  });
+
+  it('leaves NO store when the open is aborted right after promotion', async () => {
+    const buffer = lasBytes(40_000);
+    const opfs = fakeOpfs({ syncAccess: true, fileMove: true });
+    const controller = new AbortController();
+    const file = spyFile('heavy.las', buffer.byteLength);
+    const { deps } = makeDeps();
+    // Abort the instant the build promotes, before the executor reopens it.
+    const env = makeEnv(new ArrayBufferRangeSource(buffer), opfs, {
+      afterBuild: () => controller.abort(),
+    });
+
+    const result = await openLocalHeavyLas(file, controller.signal, deps, env);
+    expect(result.status).toBe('cancelled');
+    expect(oocDirs(opfs)).toHaveLength(0);
+    expect(opfs.topLevel().some((n) => n.endsWith('.partial'))).toBe(false);
+  });
+
+  it('leaves NO store when the attach fails after promotion', async () => {
+    const buffer = lasBytes(40_000);
+    const opfs = fakeOpfs({ syncAccess: true, fileMove: true });
+    const file = spyFile('heavy.las', buffer.byteLength);
+    const { deps } = makeDeps({ attachThrows: true });
+    const env = makeEnv(new ArrayBufferRangeSource(buffer), opfs);
+
+    const result = await openLocalHeavyLas(file, new AbortController().signal, deps, env);
+    expect(result.status).toBe('failed');
+    expect(oocDirs(opfs)).toHaveLength(0);
+    expect(opfs.topLevel().some((n) => n.endsWith('.partial'))).toBe(false);
+  });
+
+  it('discards the partial when the promotion copy fails (finding #2)', async () => {
+    const buffer = lasBytes(30_000);
+    const range = new ArrayBufferRangeSource(buffer);
+
+    // First, a clean build with no move and no quota, to measure the finished
+    // store size. The `move`-absent path copies each tile, so its transient
+    // peak is store + one tile, which a quota set at the store size trips.
+    const measure = fakeOpfs({ syncAccess: true, fileMove: false });
+    await buildLocalOocStore(range, measure.root, 'ooc-measure', { batchPoints: 4096 });
+    const storeBytes = measure.totalBytes();
+
+    const opfs = fakeOpfs({ syncAccess: true, fileMove: false, quotaBytes: storeBytes });
+    await expect(
+      buildLocalOocStore(new ArrayBufferRangeSource(buffer), opfs.root, 'ooc-quota', {
+        batchPoints: 4096,
+      }),
+    ).rejects.toBeTruthy();
+
+    // No promoted store, and no partial left behind.
+    expect(opfs.topLevel().some((n) => n === 'ooc-quota')).toBe(false);
+    expect(opfs.topLevel().some((n) => n.endsWith('.partial'))).toBe(false);
+  });
+});

--- a/tests/opfsShortWrite.test.ts
+++ b/tests/opfsShortWrite.test.ts
@@ -1,0 +1,105 @@
+/**
+ * opfsShortWrite.test.ts — a short sync write is completed or refused, never a
+ * silent gap (finding #12).
+ *
+ * `FileSystemSyncAccessHandle.write()` MAY store fewer bytes than it was handed
+ * and REPORT that count. The spill store used to advance its append cursor by
+ * the full length regardless, which left an unwritten hole the reader later
+ * decoded as garbage while the size looked right. The append now loops on the
+ * returned count and refuses a non-positive result.
+ *
+ * The repo's `fakeOpfs` always stores the whole buffer, so this test hand-rolls
+ * a directory handle whose sync write is deliberately short, which is the only
+ * way to exercise the loop.
+ */
+import { describe, it, expect } from 'vitest';
+import { opfsSpillStore } from '../src/io/heavy/opfsSpillStore';
+import type {
+  OpfsDirHandle,
+  OpfsFileHandle,
+  OpfsFile,
+  OpfsSyncAccessHandle,
+} from '../src/io/heavy/opfsSpillStore';
+
+/** A one-file directory whose sync handle writes at most `writeCap` bytes per call. */
+function shortWritingDir(writeCap: number | 'zero'): OpfsDirHandle {
+  const files = new Map<string, Uint8Array>();
+
+  function fileView(data: Uint8Array): OpfsFile {
+    return {
+      size: data.length,
+      async arrayBuffer() {
+        return data.slice().buffer;
+      },
+      async text() {
+        return new TextDecoder().decode(data);
+      },
+      slice(start, end) {
+        return fileView(data.subarray(start, end));
+      },
+    };
+  }
+
+  function fileHandle(name: string): OpfsFileHandle {
+    return {
+      async getFile() {
+        return fileView(files.get(name) ?? new Uint8Array(0));
+      },
+      async createWritable() {
+        throw new Error('not used in this test');
+      },
+      async createSyncAccessHandle(): Promise<OpfsSyncAccessHandle> {
+        return {
+          getSize: () => (files.get(name) ?? new Uint8Array(0)).length,
+          write(bytes, at) {
+            if (writeCap === 'zero') return 0;
+            const stored = Math.min(writeCap, bytes.length);
+            const start = at?.at ?? 0;
+            const current = files.get(name) ?? new Uint8Array(0);
+            const grown = new Uint8Array(Math.max(current.length, start + stored));
+            grown.set(current);
+            grown.set(bytes.subarray(0, stored), start);
+            files.set(name, grown);
+            return stored;
+          },
+          flush() {},
+          close() {},
+        };
+      },
+    };
+  }
+
+  return {
+    async getFileHandle(name, opts) {
+      if (!files.has(name)) {
+        if (opts?.create !== true) throw Object.assign(new Error(name), { name: 'NotFoundError' });
+        files.set(name, new Uint8Array(0));
+      }
+      return fileHandle(name);
+    },
+    async getDirectoryHandle() {
+      throw new Error('not used');
+    },
+    async removeEntry(name) {
+      files.delete(name);
+    },
+    async *keys() {
+      for (const key of [...files.keys()]) yield key;
+    },
+  };
+}
+
+describe('opfsSpillStore short sync write', () => {
+  it('completes a short write by looping, leaving no gap', async () => {
+    // Cap each write at 2 bytes, so a 5-byte append needs three writes.
+    const store = opfsSpillStore(shortWritingDir(2));
+    await store.append('7', new Uint8Array([1, 2, 3, 4, 5]));
+    await store.append('7', new Uint8Array([6, 7, 8]));
+    expect([...(await store.read('7'))]).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it('refuses a write that reports zero bytes rather than spinning or gapping', async () => {
+    const store = opfsSpillStore(shortWritingDir('zero'));
+    await expect(store.append('7', new Uint8Array([1, 2, 3]))).rejects.toThrow(/sync write reported/);
+  });
+});

--- a/tests/opfsStoreJanitor.test.ts
+++ b/tests/opfsStoreJanitor.test.ts
@@ -1,0 +1,74 @@
+/**
+ * opfsStoreJanitor.test.ts — the startup janitor removes an abandoned temp
+ * store but keeps a fresh or owned one (finding #16).
+ *
+ * A crashed tab or a failed close-time removal leaves an `ooc-…` or
+ * `<name>.partial` directory the size of the scan in OPFS. The janitor sweeps
+ * one only when it can PROVE it stale — a lease older than the threshold — and
+ * only when a live session does not own it. Anything younger, owned, or of
+ * unknown age is kept, because deleting a store a running build still fills is
+ * the one failure this must never have.
+ */
+import { describe, it, expect } from 'vitest';
+import { fakeOpfs } from './support/fakeOpfs';
+import {
+  writeOpfsText,
+  STORE_LEASE_FILE,
+  type OpfsDirHandle,
+} from '../src/io/heavy/opfsSpillStore';
+import {
+  sweepAbandonedOocStores,
+  DEFAULT_STALE_MS,
+} from '../src/io/heavy/opfsStoreJanitor';
+
+const NOW = 1_000_000_000_000;
+
+async function makeStore(root: OpfsDirHandle, name: string, createdAt: number | null): Promise<void> {
+  const dir = await root.getDirectoryHandle(name, { create: true });
+  await writeOpfsText(dir, 'manifest.json', '{}');
+  if (createdAt !== null) {
+    await writeOpfsText(dir, STORE_LEASE_FILE, JSON.stringify({ createdAt }));
+  }
+}
+
+describe('OOC startup janitor', () => {
+  it('removes a stale abandoned store, keeps fresh, owned, and unknown-age ones', async () => {
+    const opfs = fakeOpfs();
+    const stale = 'ooc-abandoned.las-100-aaaa';
+    const stalePartial = 'ooc-abandoned.las-100-bbbb.partial';
+    const fresh = 'ooc-recent.las-100-cccc';
+    const owned = 'ooc-live.las-100-dddd';
+    const unknown = 'ooc-nolease.las-100-eeee';
+
+    await makeStore(opfs.root, stale, NOW - DEFAULT_STALE_MS - 60_000);
+    await makeStore(opfs.root, stalePartial, NOW - DEFAULT_STALE_MS - 60_000);
+    await makeStore(opfs.root, fresh, NOW - 60_000);
+    await makeStore(opfs.root, owned, NOW - DEFAULT_STALE_MS - 60_000);
+    await makeStore(opfs.root, unknown, null);
+    // A non-temp directory the sweep must never touch.
+    await opfs.root.getDirectoryHandle('some-other-thing', { create: true });
+
+    const removed = await sweepAbandonedOocStores(opfs.root, {
+      now: NOW,
+      ownedNames: new Set([owned]),
+    });
+
+    expect(removed.sort()).toEqual([stale, stalePartial].sort());
+    const top = opfs.topLevel();
+    expect(top).not.toContain(stale);
+    expect(top).not.toContain(stalePartial);
+    expect(top).toContain(fresh);
+    expect(top).toContain(owned);
+    expect(top).toContain(unknown);
+    expect(top).toContain('some-other-thing');
+  });
+
+  it('removes nothing when every store is younger than the threshold', async () => {
+    const opfs = fakeOpfs();
+    await makeStore(opfs.root, 'ooc-a.las-1-x', NOW - 1000);
+    await makeStore(opfs.root, 'ooc-b.las-1-y.partial', NOW - 1000);
+    const removed = await sweepAbandonedOocStores(opfs.root, { now: NOW });
+    expect(removed).toEqual([]);
+    expect(opfs.topLevel()).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Every exit path of the heavy out-of-core LAS open now ends in one state:
a committed store the live source owns, or no store.

Store names carried only file name and size, so two tabs or a fast reopen
shared a directory and one close could delete another open's store. Each
open takes a random per-open id threaded through the build, reopen and
close. Promotion moved inside the build guard, so a promotion failure
discards the partial. An abort after promotion, or an attach failure, now
deletes the promoted store. Short sync writes loop on the returned count
or are refused. Relocate closes its writable on failure. A build lease
and a startup janitor sweep abandoned stores.

The janitor is staged: it needs one startup call in src/main.ts.
