### PR TITLE
Memory and abort hardening across load, streaming, and report paths

### DIFF
--- a/src/convert/convertRunner.ts
+++ b/src/convert/convertRunner.ts
@@ -14,6 +14,45 @@
 import type { PointCloud } from '../model/PointCloud';
 import { convertCloud } from './convertCloud';
 import type { ConvertOptions, ConvertedFile, ConvertReport } from './types';
+import { formatByteSize } from '../io/formatByteSize';
+
+/** A file handle a batch input reads from — the subset {@link guardedBatchInput} needs. */
+export interface BatchFileSource {
+  readonly name: string;
+  readonly size: number;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+/** The message an over-ceiling single file is refused with. */
+export function oversizeBatchFileMessage(
+  name: string,
+  sizeBytes: number,
+  ceilingBytes: number,
+): string {
+  return (
+    `${name} is ${formatByteSize(sizeBytes)}, larger than the ${formatByteSize(ceilingBytes)} ` +
+    `a single file can be read into memory here. Convert it with PDAL or untwine, or split ` +
+    `it, before adding it.`
+  );
+}
+
+/**
+ * Build a {@link BatchInput} whose byte read is gated by a hard per-file memory
+ * ceiling. A file larger than the ceiling is refused BEFORE its ArrayBuffer is
+ * materialised: reading a multi-gigabyte file into one ArrayBuffer takes the
+ * tab down, so the reader rejects up front and {@link runBatch} records a
+ * per-file error instead of crashing the page. Pure and DOM-free.
+ */
+export function guardedBatchInput(file: BatchFileSource, ceilingBytes: number): BatchInput {
+  return {
+    name: file.name,
+    sizeBytes: file.size,
+    bytes: () =>
+      file.size > ceilingBytes
+        ? Promise.reject(new RangeError(oversizeBatchFileMessage(file.name, file.size, ceilingBytes)))
+        : file.arrayBuffer(),
+  };
+}
 
 /**
  * One file to convert: a name, its size (for display without a read), and a

--- a/src/io/heavy/worker/localOocIndexerWorkerClient.ts
+++ b/src/io/heavy/worker/localOocIndexerWorkerClient.ts
@@ -63,6 +63,15 @@ export type LocalOocResponseMessage =
  */
 export class LocalOocIndexerClient {
   run(request: LocalOocIndexRequest): Promise<LocalOocBuildResult> {
+    // If cancellation already happened before run(), no 'abort' event will ever
+    // fire, so a plain listener would let the worker index gigabytes for a build
+    // nobody is waiting on. Refuse up front without creating the worker.
+    if (request.signal?.aborted) {
+      return Promise.reject(
+        Object.assign(new Error('out-of-core index build aborted'), { name: 'AbortError' }),
+      );
+    }
+
     const worker = new Worker(new URL('./localOocIndexerWorker.ts', import.meta.url), {
       type: 'module',
     });

--- a/src/io/loadFile.ts
+++ b/src/io/loadFile.ts
@@ -13,8 +13,10 @@ import {
   e57TooLargeMessage,
   e57NoPlanMessage,
   NON_STREAMING_FORMATS,
+  BOUNDED_DECODE_FORMATS,
   LARGE_NON_LAS_THRESHOLD_BYTES,
   LARGE_STATIC_LAS_THRESHOLD_BYTES,
+  memoryCeilingBytes,
 } from './loadPlan';
 import type { LoadPlan, E57DecodePlan } from './loadPlan';
 import type { E57Preflight } from './e57/preflight';
@@ -312,6 +314,40 @@ function e57Refusal(file: File, preflight: FilePreflight): LoadError | undefined
 }
 
 /**
+ * The refusal an over-ceiling non-streaming format with NO bounded decode
+ * justifies, or `undefined` when the file may be read.
+ *
+ * LAS/LAZ route an over-ceiling file to the out-of-core tile build, and E57 has
+ * its own {@link e57Refusal}. Every other non-streaming format (PLY, PCD, PTX,
+ * PTS, XYZ, OBJ, GLB/GLTF, PNTS) materialises the whole point set at parse time
+ * with no bounded fallback. When the RAW FILE alone already exceeds the device
+ * memory ceiling, the fully decoded set cannot possibly fit, so the load is
+ * refused BEFORE the whole-file read rather than warned about and then run — a
+ * warning that proceeds still takes the tab with it (compare `e57Refusal`: a
+ * verdict known before the read must refuse before the read).
+ */
+function nonStreamingOverCeilingRefusal(
+  file: File,
+  preflight: FilePreflight,
+  options: LoadOptions,
+): LoadError | undefined {
+  const { format } = preflight;
+  if (!NON_STREAMING_FORMATS.has(format) || BOUNDED_DECODE_FORMATS.has(format)) {
+    return undefined;
+  }
+  const ceiling = memoryCeilingBytes(options.deviceMemoryGB, options.isMobile ?? false);
+  if (file.size <= ceiling) return undefined;
+  return new LoadError(
+    'memory-constraint',
+    `${formatInfo(format).label} too large for this device — the file is ` +
+      `${formatByteSize(file.size)}, already past the ${formatByteSize(ceiling)} this tab ` +
+      `can be given, and this format is decoded in full before it can be downsampled, so ` +
+      `the open would run the tab out of memory. Convert to COPC/EPT (PDAL or untwine) to ` +
+      `stream it instead.`,
+  );
+}
+
+/**
  * Assemble the source metadata — the cheap preflight result the UI shows — from
  * a finished preflight. Shared by `fileMetadata` and `loadFile` so both surface
  * exactly the same facts without a second head-slice read.
@@ -522,7 +558,8 @@ export async function loadFile(
   // below materialises the WHOLE file in one ArrayBuffer. Leaving the refusal
   // to the worker meant a 600 MB file already known not to fit was pulled into
   // memory first, on the device least able to hold it, and only then rejected.
-  const refusal = e57Refusal(file, preflight);
+  const refusal =
+    e57Refusal(file, preflight) ?? nonStreamingOverCeilingRefusal(file, preflight, options);
   if (refusal) throw refusal;
 
   // --- Now read the whole file — only once the format is known. ---

--- a/src/io/loadPlan.ts
+++ b/src/io/loadPlan.ts
@@ -106,6 +106,16 @@ export interface LoadPlan {
    * backward-compat — treat `undefined` as `false`.
    */
   buildThenStream?: boolean;
+  /**
+   * True when the file is an over-ceiling non-streaming format with NO bounded
+   * decode (PLY, PCD, PTX, PTS, XYZ, OBJ, GLB/GLTF, PNTS). Unlike LAS/LAZ
+   * (`buildThenStream`) and E57 (its own preflight plan), these have no way to
+   * decode within the ceiling, so the load must be REFUSED before the whole
+   * file is materialised — a warning that still proceeds crashes the tab. The
+   * loader turns this into a `memory-constraint` refusal with guidance to
+   * stream as COPC/EPT or convert. Optional — treat `undefined` as `false`.
+   */
+  refuseOverCeiling?: boolean;
 }
 
 /**
@@ -126,6 +136,18 @@ export const LARGE_NON_LAS_THRESHOLD_BYTES = 300 * 1024 * 1024;
  * huge files that belong in COPC/EPT.
  */
 export const LARGE_STATIC_LAS_THRESHOLD_BYTES = 1024 * 1024 * 1024;
+
+/**
+ * Formats with a bounded decode for an over-ceiling file: LAS/LAZ route to the
+ * out-of-core tile build, and E57 has its own preflight verdict plus stride
+ * plan. Any other format materialises the whole point set at parse time, so an
+ * over-ceiling estimate for it is a hard refusal (see `refuseOverCeiling`).
+ */
+export const BOUNDED_DECODE_FORMATS: ReadonlySet<SourceFormat> = new Set<SourceFormat>([
+  'las',
+  'laz',
+  'e57',
+]);
 
 /** Non-LAS/LAZ formats that decode the whole point set up front. */
 export const NON_STREAMING_FORMATS: ReadonlySet<SourceFormat> = new Set<SourceFormat>([
@@ -531,6 +553,16 @@ export function planLoad(input: LoadPlanInput): LoadPlan {
   // fallback for a caller that does not act on this flag.
   const buildThenStream = (format === 'las' || format === 'laz') && mayExceedCeiling;
 
+  // Fail closed for a non-streaming format with no bounded decode. LAS/LAZ has
+  // the out-of-core build (`buildThenStream`) and E57 has its own preflight
+  // verdict and stride plan; both can survive an over-ceiling file. Everything
+  // else (PLY, PCD, PTX, PTS, XYZ, OBJ, GLB/GLTF, PNTS) materialises the whole
+  // point set at parse time with no bounded fallback, so an over-ceiling
+  // estimate means the decode cannot fit and must be refused, not merely warned
+  // about — a warning that lets the read proceed still takes the tab with it.
+  const refuseOverCeiling =
+    mayExceedCeiling && !BOUNDED_DECODE_FORMATS.has(format);
+
   return {
     mode: plan.mode,
     sourceCount,
@@ -542,6 +574,7 @@ export function planLoad(input: LoadPlanInput): LoadPlan {
     mayExceedCeiling,
     largeNonLasFormat,
     buildThenStream,
+    refuseOverCeiling,
   };
 }
 

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -29,7 +29,7 @@ import {
   nodeScore,
   depthCapForVelocity,
 } from './streamingScore';
-import { selectWithinBudget, DECODED_BYTES_PER_POINT } from './streamingBudget';
+import { selectWithinBudget, firstAdmissionMaxPoints } from './streamingBudget';
 import type { StreamingBudgets, ScoredCandidate } from './streamingBudget';
 import { CompressedChunkCache } from './StreamingCache';
 import {
@@ -247,15 +247,16 @@ const RETRY_BACKOFF_MAX_MS = 30_000;
  * downstream ceiling is the decompressor's 50 M `MAX_NODE_POINTS`: between
  * those two numbers sits a node that decodes and cannot be held.
  *
- * Deliberately absolute rather than a multiple of the point budget. A
- * budget-relative ceiling would refuse on a mobile `low` preset (600 k budget)
- * a node that a desktop renders, which turns a memory guard into a
- * device-dependent blank screen.
+ * A device CLASS ceiling, not a budget-relative one: it keys off desktop vs.
+ * mobile vs. low-memory (see {@link firstAdmissionMaxPoints}), not off the
+ * point budget. A budget-relative ceiling would refuse on a mobile `low` preset
+ * (600 k budget) a node a desktop renders, turning a memory guard into a
+ * device-dependent blank screen; a device-class ceiling instead lowers the
+ * absolute byte line on the devices that cannot survive a half-gigabyte decode.
+ * The scheduler default is the desktop line; the host passes the device-aware
+ * value through {@link SchedulerOptions.firstAdmissionMaxPoints}.
  */
-const FIRST_ADMISSION_MAX_DECODED_BYTES = 512 * 1024 * 1024;
-const FIRST_ADMISSION_MAX_POINTS = Math.floor(
-  FIRST_ADMISSION_MAX_DECODED_BYTES / DECODED_BYTES_PER_POINT,
-);
+const DEFAULT_FIRST_ADMISSION_MAX_POINTS = firstAdmissionMaxPoints(false);
 
 /** Per-scheduler tunables — defaulted, injected for unit tests. */
 export interface SchedulerOptions {
@@ -297,6 +298,13 @@ export interface SchedulerOptions {
   evictionHysteresis?: Partial<Omit<EvictionHysteresis, 'triggerRatio'>>;
   /** Monotonic clock, injected for deterministic tests. */
   now?: () => number;
+  /**
+   * Point ceiling for the empty-viewer first-admission bypass. Absent, the
+   * scheduler uses the desktop default; the host passes the device-aware value
+   * from {@link firstAdmissionMaxPoints} so a phone or low-memory machine gets
+   * a smaller ceiling than a desktop.
+   */
+  firstAdmissionMaxPoints?: number;
 }
 
 /**
@@ -530,7 +538,7 @@ export class StreamingScheduler {
   private readonly _retryReadyAt = new Map<string, number>();
   /**
    * Nodes refused by the first-admission ceiling (see
-   * {@link FIRST_ADMISSION_MAX_POINTS}). Held separately from
+   * the device-aware first-admission ceiling). Held separately from
    * `_decodeFailures`, which counts transient decode errors that a retry can
    * clear: this refusal reads a declared count off an immutable hierarchy
    * record, so it is settled for the session and re-deciding it is waste.
@@ -628,6 +636,8 @@ export class StreamingScheduler {
    * closer or coarser-and-cheaper node.
    */
   private readonly _stickyMargin: number;
+  /** Point ceiling for the empty-viewer first-admission bypass (device-aware). */
+  private readonly _firstAdmissionMaxPoints: number;
   /** Last full rescore's scored list (same lifecycle as `_lastWanted`). */
   private _lastScored: { node: StreamingNode; candidate: ScoredCandidate }[] | null = null;
   /** Tick index of the last full rescore — drives the periodic forced rescore. */
@@ -652,6 +662,8 @@ export class StreamingScheduler {
     this._effectiveMaxConcurrent = budgets.maxConcurrentDecodes;
     this._cache = new CompressedChunkCache(budgets.chunkCacheBytes);
     this._stickyMargin = Math.max(0, Math.min(1, options.stickyMargin ?? 0));
+    this._firstAdmissionMaxPoints =
+      options.firstAdmissionMaxPoints ?? DEFAULT_FIRST_ADMISSION_MAX_POINTS;
     this._evictDeferMs = options.evictDeferMs ?? DEFAULT_EVICT_DEFER_MS;
     this._memoryPressureRatio =
       options.memoryPressureRatio ?? DEFAULT_MEMORY_PRESSURE_RATIO;
@@ -1509,11 +1521,11 @@ export class StreamingScheduler {
       }
       if (
         store.residentPointCount === 0 &&
-        node.record.pointCount > FIRST_ADMISSION_MAX_POINTS
+        node.record.pointCount > this._firstAdmissionMaxPoints
       ) {
         // Bounded bypass. The branch above waves this node through because
         // nothing is resident; that is not a reason to admit any size. A node
-        // past `FIRST_ADMISSION_MAX_POINTS` is refused by name here, before the
+        // past `this._firstAdmissionMaxPoints` is refused by name here, before the
         // range read and before the decoder sizes anything from it.
         //
         // `continue`, not `break`: skipping one node leaves the rest of this
@@ -1532,7 +1544,7 @@ export class StreamingScheduler {
         store.setError(
           node,
           `streaming: first node ${node.record.id} declares ${node.record.pointCount} points, ` +
-            `past the ${FIRST_ADMISSION_MAX_POINTS} point ceiling for a decode admitted ` +
+            `past the ${this._firstAdmissionMaxPoints} point ceiling for a decode admitted ` +
             `before anything is resident.`,
         );
         continue;

--- a/src/render/streaming/streamingAttach.ts
+++ b/src/render/streaming/streamingAttach.ts
@@ -30,12 +30,22 @@ import type { StreamingSource } from './StreamingSource';
 import type { StreamingNode } from './StreamingNode';
 import type { StreamingBenchmark } from './streamingBenchmark';
 import type { StreamingQuality } from './streamingBudget';
-import { streamingBudgets } from './streamingBudget';
+import { streamingBudgets, firstAdmissionMaxPoints } from './streamingBudget';
 import { makeStreamingCommit, type StreamingCommit } from './meteredCommit';
 import type { ChunkDecoder, DecodedChunk } from '../../io/copc/copcChunkDecode';
 import { renderLocalPositions } from '../../model/pointFrames';
 import { loadStreamingRenderer, loadStreamingScheduler } from '../../lazyChunks';
 import { readDevFlags } from '../../perf/devFlags';
+
+/**
+ * `navigator.deviceMemory` in GiB, or undefined when the browser does not
+ * expose it (Safari, Firefox). A coarse, spec-rounded hint — used only to lower
+ * the first-admission ceiling on low-memory devices, never to raise it.
+ */
+function deviceMemoryGiB(): number | undefined {
+  const mem = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
+  return typeof mem === 'number' && mem > 0 ? mem : undefined;
+}
 
 /**
  * The live streaming subsystem — present only while a COPC OR EPT cloud is
@@ -208,6 +218,9 @@ export async function buildStreamingSession(
       // flag reads, so the scheduler stays free of lookups; 0 keeps the plain
       // greedy fill that ships today.
       stickyMargin: readDevFlags().residentStickiness ? RESIDENT_STICKY_MARGIN : 0,
+      // Device-aware first-admission ceiling: a phone or a low-memory machine
+      // gets a smaller "admit any size while empty" limit than a desktop.
+      firstAdmissionMaxPoints: firstAdmissionMaxPoints(isMobile, deviceMemoryGiB()),
     },
   );
   return { cloud, scheduler, renderer, decoder, benchmark, commit };

--- a/src/render/streaming/streamingBudget.ts
+++ b/src/render/streaming/streamingBudget.ts
@@ -46,15 +46,87 @@ const MOBILE_POINT_BUDGET: Record<StreamingQuality, number> = {
 export const BYTES_PER_STREAMING_POINT = 24;
 
 /**
- * CPU-side bytes per decoded point — the shape produced by the worker before
- * GPU upload. Summed: positions (3 × f32 = 12 B), intensity (u16 = 2 B),
- * classification (u8 = 1 B), returnNumber (u8 = 1 B), returnCount (u8 = 1 B),
- * gpsTime (f64 = 8 B) → 25 B / point. Used by the three-tier debug-overlay
- * metric (decoded-tier accounting): in this architecture decoded data is transferred to the
- * GPU atomically, so the decoded tier reports a CPU-residency estimate that
- * mirrors the GPU estimate but with the full decoded attribute set.
+ * CPU-side worst-case bytes per decoded point — the widest shape a LAS-family
+ * source produces before GPU upload. Summed: positions (3 × f32 = 12 B),
+ * intensity (u16 = 2 B), classification (u8 = 1 B), returnNumber (u8 = 1 B),
+ * returnCount (u8 = 1 B), gpsTime (f64 = 8 B), rgb (3 × u8 = 3 B),
+ * pointSourceId (u16 = 2 B) → 30 B / point (PDRF 7/8). The earlier figure of 25
+ * dropped rgb and pointSourceId and so undercounted a coloured point by 5 B.
+ * Used by the debug-overlay decoded-tier estimate and to convert the
+ * first-admission byte ceiling into a point ceiling; a per-channel figure for a
+ * known chunk is {@link decodedBytesPerPoint}.
  */
-export const DECODED_BYTES_PER_POINT = 25;
+export const DECODED_BYTES_PER_POINT = 30;
+
+/** Which optional channels a decoded chunk carries, for a byte estimate. */
+export interface DecodedChannelPresence {
+  readonly intensity?: boolean;
+  readonly classification?: boolean;
+  readonly returnNumber?: boolean;
+  readonly returnCount?: boolean;
+  readonly gpsTime?: boolean;
+  readonly rgb?: boolean;
+  readonly normals?: boolean;
+  readonly pointSourceId?: boolean;
+}
+
+/**
+ * Decoded CPU bytes per point for a chunk carrying exactly `channels`.
+ * Positions (3 × f32) are always present; every other channel is charged only
+ * when present, so a positions-only `.pnts` tile is not billed for LAS
+ * attributes it never carries. Pure — the schema-aware counterpart to the flat
+ * {@link DECODED_BYTES_PER_POINT} worst case.
+ */
+export function decodedBytesPerPoint(channels: DecodedChannelPresence = {}): number {
+  let b = 3 * Float32Array.BYTES_PER_ELEMENT; // positions f32 × 3
+  if (channels.intensity) b += Uint16Array.BYTES_PER_ELEMENT;
+  if (channels.classification) b += Uint8Array.BYTES_PER_ELEMENT;
+  if (channels.returnNumber) b += Uint8Array.BYTES_PER_ELEMENT;
+  if (channels.returnCount) b += Uint8Array.BYTES_PER_ELEMENT;
+  if (channels.gpsTime) b += Float64Array.BYTES_PER_ELEMENT;
+  if (channels.rgb) b += 3 * Uint8Array.BYTES_PER_ELEMENT;
+  if (channels.normals) b += 3 * Float32Array.BYTES_PER_ELEMENT;
+  if (channels.pointSourceId) b += Uint16Array.BYTES_PER_ELEMENT;
+  return b;
+}
+
+/** First-admission decoded-byte ceiling per device class. */
+const DESKTOP_FIRST_ADMISSION_BYTES = 512 * 1024 * 1024;
+const MOBILE_FIRST_ADMISSION_BYTES = 128 * 1024 * 1024;
+const LOW_MEMORY_FIRST_ADMISSION_BYTES = 64 * 1024 * 1024;
+/** `navigator.deviceMemory` at or below this (GiB) counts as low-memory. */
+const LOW_MEMORY_GIB = 2;
+
+/**
+ * Decoded-byte ceiling for the empty-viewer first-admission bypass. Device
+ * aware: a phone or a low-memory machine gets a far smaller ceiling than a
+ * desktop, so the "nothing resident yet, admit any size" path cannot commit a
+ * half-gigabyte decode on a device that has no headroom for it. Pure.
+ */
+export function firstAdmissionMaxDecodedBytes(
+  isMobile: boolean,
+  deviceMemoryGiB?: number,
+): number {
+  let bytes = isMobile ? MOBILE_FIRST_ADMISSION_BYTES : DESKTOP_FIRST_ADMISSION_BYTES;
+  if (deviceMemoryGiB !== undefined && deviceMemoryGiB <= LOW_MEMORY_GIB) {
+    bytes = Math.min(bytes, LOW_MEMORY_FIRST_ADMISSION_BYTES);
+  }
+  return bytes;
+}
+
+/**
+ * Point ceiling for the first-admission bypass — the byte ceiling divided by
+ * the worst-case per-point cost, so the estimate never admits more bytes than
+ * {@link firstAdmissionMaxDecodedBytes} allows. Pure.
+ */
+export function firstAdmissionMaxPoints(
+  isMobile: boolean,
+  deviceMemoryGiB?: number,
+): number {
+  return Math.floor(
+    firstAdmissionMaxDecodedBytes(isMobile, deviceMemoryGiB) / DECODED_BYTES_PER_POINT,
+  );
+}
 
 /** Compressed-chunk cache byte budget — smaller on mobile. */
 const DESKTOP_CHUNK_CACHE_BYTES = 48 * 1024 * 1024;

--- a/src/report/ReportEngine.ts
+++ b/src/report/ReportEngine.ts
@@ -133,6 +133,13 @@ export async function generateReport(
   }
 
   return await new Promise<ReportResult>((resolve, reject) => {
+    // Re-check right before wiring the listener: a signal that aborted after
+    // the shortcut above but before we got here would never fire 'abort' on a
+    // once-listener, so renderReportPdf would start for a cancelled report.
+    if (options.signal?.aborted) {
+      reject(new DOMException('Report generation aborted before it started.', 'AbortError'));
+      return;
+    }
     // The timeout id is captured so the abort path can clear it; without
     // the clear, the timeout's `reject` would still fire after the abort
     // and re-reject a settled promise (harmless but noisy in tests).

--- a/src/ui/BatchConverter.ts
+++ b/src/ui/BatchConverter.ts
@@ -17,11 +17,24 @@ import { el } from './dom';
 import { downloadBytes } from '../io/download';
 import { formatByteSize as formatBytes } from '../io/formatByteSize';
 import { decodeFull } from '../convert/decodeFull';
-import { runBatch, summariseBatch, type BatchInput, type BatchItemResult } from '../convert/convertRunner';
+import { runBatch, summariseBatch, guardedBatchInput, type BatchInput, type BatchItemResult } from '../convert/convertRunner';
+import { memoryCeilingBytes } from '../io/loadPlan';
 import { buildZip, assessZipDownload } from '../convert/zipStore';
 import { CONVERT_FORMATS, type ConvertFormat, type CrsMode, type ConvertOptions } from '../convert/types';
 
 const ACCEPT = '.las,.laz,.xyz,.asc,.txt,.csv,.pts,.ptx,.ply,.pcd,.e57';
+
+/**
+ * The hard per-file byte ceiling for a batch read. The converter decodes one
+ * file at a time, but a single over-ceiling file still crashes the tab the
+ * moment `arrayBuffer()` materialises it, so each file is gated by the same
+ * device memory ceiling the loader uses. `navigator.deviceMemory` is optional
+ * (absent on Safari/Firefox); `memoryCeilingBytes` falls back to its default.
+ */
+function singleFileCeilingBytes(): number {
+  const mem = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
+  return memoryCeilingBytes(typeof mem === 'number' && mem > 0 ? mem : undefined, false);
+}
 
 export class BatchConverter {
   readonly element: HTMLElement;
@@ -175,7 +188,7 @@ export class BatchConverter {
       // multi-GB files no longer loads them all into memory at once. An
       // unreadable file now surfaces a per-file error at convert time instead of
       // silently vanishing here.
-      this._files.push({ name: f.name, sizeBytes: f.size, bytes: () => f.arrayBuffer() });
+      this._files.push(guardedBatchInput(f, singleFileCeilingBytes()));
     }
     this._renderFileList();
     this._refresh();

--- a/src/ui/WorkflowController.ts
+++ b/src/ui/WorkflowController.ts
@@ -16,6 +16,27 @@ import {
   type WorkflowRecorderConfig,
 } from '../render/workflow/workflowConfig';
 
+/**
+ * Whole-file ceiling for a workflow read into a single string. A workflow is a
+ * small JSON document; anything in the tens of megabytes is not one, and
+ * reading it in full would exhaust memory before the parser could reject it.
+ * Mirrors the `.olvsession` read cap.
+ */
+export const MAX_WORKFLOW_TEXT_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Throw when a workflow file is too large to read into a single string. Pure and
+ * DOM-free so the size gate can be tested without constructing the controller.
+ */
+export function assertWorkflowFileSize(sizeBytes: number): void {
+  if (sizeBytes > MAX_WORKFLOW_TEXT_BYTES) {
+    throw new Error(
+      `This workflow file is too large (${Math.round(sizeBytes / (1024 * 1024))} MB; ` +
+        `limit ${Math.round(MAX_WORKFLOW_TEXT_BYTES / (1024 * 1024))} MB).`,
+    );
+  }
+}
+
 /** Minimal File System Access API surface used by the native save path. */
 interface FileSystemWritableLike {
   write(data: string): Promise<void>;
@@ -344,6 +365,11 @@ export class WorkflowController {
    * parsed Workflow. Rejects with a clear error on malformed input.
    */
   async loadFromFile(file: File): Promise<Workflow> {
+    // A workflow is a small JSON document. Reject an over-large file before it
+    // is read into a single string, so a mistaken or hostile multi-hundred-MB
+    // file can't exhaust memory in `file.text()`/`JSON.parse`. Mirrors the
+    // `.olvsession` read cap; the parser bounds the rest once the JSON is in hand.
+    assertWorkflowFileSize(file.size);
     const text = await file.text();
     const result = parseWorkflow(text);
     if (!result.ok) throw new Error(result.error);

--- a/src/ui/reportVerifier.ts
+++ b/src/ui/reportVerifier.ts
@@ -116,8 +116,38 @@ export function showReportVerification(result: VerifyReportResult): void {
   document.body.append(backdrop);
 }
 
+/**
+ * Whole-file ceiling for a report the verifier reads into a single string. A
+ * verifiable report is a small JSON-with-signature document; anything in the
+ * tens of megabytes is not one, and reading it in full would exhaust memory
+ * before the verifier could reject it. Mirrors the `.olvsession` read cap.
+ */
+export const MAX_REPORT_TEXT_BYTES = 32 * 1024 * 1024;
+
+/**
+ * The verification result an over-ceiling file justifies, or `undefined` when
+ * the file is small enough to read. Pure and DOM-free so the size gate can be
+ * tested without standing up the modal.
+ */
+export function oversizeReportResult(sizeBytes: number): VerifyReportResult | undefined {
+  if (sizeBytes <= MAX_REPORT_TEXT_BYTES) return undefined;
+  return {
+    recognised: false,
+    valid: false,
+    reason:
+      `This file is too large to be a report ` +
+      `(${Math.round(sizeBytes / (1024 * 1024))} MB; limit ` +
+      `${Math.round(MAX_REPORT_TEXT_BYTES / (1024 * 1024))} MB).`,
+  };
+}
+
 /** Read a report file, verify it, and show the result. Never throws. */
 export async function verifyAndShow(file: File): Promise<void> {
+  const oversize = oversizeReportResult(file.size);
+  if (oversize) {
+    showReportVerification(oversize);
+    return;
+  }
   let text: string;
   try {
     text = await file.text();

--- a/tests/convertBatch.test.ts
+++ b/tests/convertBatch.test.ts
@@ -4,7 +4,13 @@
 
 import { describe, it, expect } from 'vitest';
 import { buildZip } from '../src/convert/zipStore';
-import { runBatch, dedupeName, summariseBatch, type DecodeFn } from '../src/convert/convertRunner';
+import {
+  runBatch,
+  dedupeName,
+  summariseBatch,
+  guardedBatchInput,
+  type DecodeFn,
+} from '../src/convert/convertRunner';
 import { PointCloud } from '../src/model/PointCloud';
 
 const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
@@ -158,6 +164,52 @@ describe('runBatch', () => {
     );
     expect(results[0].report.ok).toBe(false);
     expect(results[0].report.log[0].message).toMatch(/read error/);
+    expect(results[1].report.ok).toBe(true);
+  });
+});
+
+describe('guardedBatchInput — per-file memory preflight', () => {
+  const CEILING = 100;
+  const decodeOk: DecodeFn = async (_buf, name) => tinyCloud(name);
+
+  function fakeFile(name: string, size: number, onRead: () => void) {
+    return {
+      name,
+      size,
+      arrayBuffer: async (): Promise<ArrayBuffer> => {
+        onRead();
+        return new ArrayBuffer(size);
+      },
+    };
+  }
+
+  it('refuses an over-ceiling file BEFORE arrayBuffer() is called', async () => {
+    let read = false;
+    const input = guardedBatchInput(fakeFile('huge.ply', CEILING + 1, () => { read = true; }), CEILING);
+    expect(input.sizeBytes).toBe(CEILING + 1);
+    await expect(input.bytes()).rejects.toThrow(/larger than/);
+    expect(read).toBe(false); // the bytes were never materialised
+  });
+
+  it('reads a file that fits under the ceiling', async () => {
+    let read = false;
+    const input = guardedBatchInput(fakeFile('ok.las', CEILING, () => { read = true; }), CEILING);
+    const buf = await input.bytes();
+    expect(buf.byteLength).toBe(CEILING);
+    expect(read).toBe(true);
+  });
+
+  it('through runBatch, an over-ceiling file is a per-file error and the batch continues', async () => {
+    const results = await runBatch(
+      [
+        guardedBatchInput(fakeFile('huge.ply', CEILING + 1, () => {}), CEILING),
+        guardedBatchInput(fakeFile('ok.las', 8, () => {}), CEILING),
+      ],
+      { format: 'las' },
+      decodeOk,
+    );
+    expect(results[0].report.ok).toBe(false);
+    expect(results[0].report.log[0].message).toMatch(/larger than/);
     expect(results[1].report.ok).toBe(true);
   });
 });

--- a/tests/loadPlanNonLas.test.ts
+++ b/tests/loadPlanNonLas.test.ts
@@ -88,3 +88,43 @@ describe('LoadPlan.largeNonLasFormat — pre-decode warning', () => {
     expect(plan.largeNonLasFormat).toBe(true);
   });
 });
+
+describe('LoadPlan.refuseOverCeiling — fail closed for unbounded formats', () => {
+  // Well past the 1.5 GB desktop fallback ceiling, so fixed cost alone exceeds
+  // it and no point-budget reshape can bring the estimate down.
+  const OVER = 4_000_000_000;
+
+  it('refuses an over-ceiling PLY — no bounded decode exists for it', () => {
+    const plan = planLoad(input({ fileBytes: OVER, sourceCount: 200_000_000, format: 'ply' }));
+    expect(plan.mayExceedCeiling).toBe(true);
+    expect(plan.refuseOverCeiling).toBe(true);
+    // It is NOT routed to the out-of-core build — that path is LAS/LAZ only.
+    expect(plan.buildThenStream).toBeFalsy();
+  });
+
+  it('refuses every unbounded non-streaming format over the ceiling', () => {
+    for (const fmt of ['ply', 'pcd', 'pts', 'ptx', 'obj', 'glb', 'xyz'] as const) {
+      const plan = planLoad(input({ fileBytes: OVER, sourceCount: 200_000_000, format: fmt }));
+      expect(plan.refuseOverCeiling).toBe(true);
+    }
+  });
+
+  it('does NOT refuse LAS/LAZ — they route to the out-of-core build instead', () => {
+    for (const fmt of ['las', 'laz'] as const) {
+      const plan = planLoad(input({ fileBytes: OVER, sourceCount: 200_000_000, format: fmt }));
+      expect(plan.refuseOverCeiling).toBe(false);
+      expect(plan.buildThenStream).toBe(true);
+    }
+  });
+
+  it('does NOT refuse E57 here — it has its own preflight verdict and stride plan', () => {
+    const plan = planLoad(input({ fileBytes: OVER, sourceCount: 200_000_000, format: 'e57' }));
+    expect(plan.refuseOverCeiling).toBe(false);
+  });
+
+  it('is false when the file fits under the ceiling', () => {
+    const plan = planLoad(input({ fileBytes: 10_000_000, sourceCount: 100_000, format: 'ply' }));
+    expect(plan.mayExceedCeiling).toBe(false);
+    expect(plan.refuseOverCeiling).toBe(false);
+  });
+});

--- a/tests/localOocIndexerAbort.test.ts
+++ b/tests/localOocIndexerAbort.test.ts
@@ -1,0 +1,43 @@
+/**
+ * localOocIndexerAbort.test.ts
+ *
+ * The out-of-core indexer client attaches its abort listener with `{once:true}`.
+ * If the caller's signal is ALREADY aborted when `run()` is called, no 'abort'
+ * event ever fires, so a plain listener would let the worker index a multi-
+ * gigabyte file for a build nobody is waiting on. `run()` must instead check
+ * `signal.aborted` up front and refuse WITHOUT constructing the worker.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { LocalOocIndexerClient } from '../src/io/heavy/worker/localOocIndexerWorkerClient';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function fakeFile(): File {
+  return new File([new Uint8Array(16)], 'huge.las', { type: 'application/octet-stream' });
+}
+
+describe('LocalOocIndexerClient — already-aborted signal', () => {
+  it('refuses an already-aborted build without constructing a worker', async () => {
+    let constructed = 0;
+    class WorkerStub {
+      constructor() {
+        constructed += 1;
+        throw new Error('Worker must not be constructed for an already-aborted build');
+      }
+    }
+    vi.stubGlobal('Worker', WorkerStub);
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const client = new LocalOocIndexerClient();
+    await expect(
+      client.run({ file: fakeFile(), storeName: 'store-x', signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect(constructed).toBe(0);
+  });
+});

--- a/tests/metadataReadCaps.test.ts
+++ b/tests/metadataReadCaps.test.ts
@@ -1,0 +1,52 @@
+/**
+ * metadataReadCaps.test.ts
+ *
+ * Report and workflow files are read whole into a single string with
+ * `file.text()`. Unlike `.olvsession` (capped at 256 MB), those reads were
+ * uncapped, so a mistaken or hostile multi-hundred-MB file could exhaust memory
+ * before the parser rejected it. Both now refuse an over-ceiling file up front.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_REPORT_TEXT_BYTES,
+  oversizeReportResult,
+} from '../src/ui/reportVerifier';
+import {
+  MAX_WORKFLOW_TEXT_BYTES,
+  assertWorkflowFileSize,
+} from '../src/ui/WorkflowController';
+
+describe('report verifier read cap', () => {
+  it('caps the read in the tens of megabytes', () => {
+    expect(MAX_REPORT_TEXT_BYTES).toBe(32 * 1024 * 1024);
+  });
+
+  it('refuses an over-ceiling file with a recognised:false result', () => {
+    const result = oversizeReportResult(MAX_REPORT_TEXT_BYTES + 1);
+    expect(result).toBeDefined();
+    expect(result?.recognised).toBe(false);
+    expect(result?.valid).toBe(false);
+    expect(result?.reason).toMatch(/too large/i);
+  });
+
+  it('passes a file at or under the ceiling', () => {
+    expect(oversizeReportResult(MAX_REPORT_TEXT_BYTES)).toBeUndefined();
+    expect(oversizeReportResult(1_000)).toBeUndefined();
+  });
+});
+
+describe('workflow read cap', () => {
+  it('caps the read in the tens of megabytes', () => {
+    expect(MAX_WORKFLOW_TEXT_BYTES).toBe(32 * 1024 * 1024);
+  });
+
+  it('throws on an over-ceiling file', () => {
+    expect(() => assertWorkflowFileSize(MAX_WORKFLOW_TEXT_BYTES + 1)).toThrow(/too large/i);
+  });
+
+  it('accepts a file at or under the ceiling', () => {
+    expect(() => assertWorkflowFileSize(MAX_WORKFLOW_TEXT_BYTES)).not.toThrow();
+    expect(() => assertWorkflowFileSize(1_000)).not.toThrow();
+  });
+});

--- a/tests/reportEngineAbort.test.ts
+++ b/tests/reportEngineAbort.test.ts
@@ -1,0 +1,53 @@
+/**
+ * reportEngineAbort.test.ts
+ *
+ * `generateReport` accepts an abort signal. When the signal is ALREADY aborted
+ * before the call, the render must never start: the engine rejects with an
+ * AbortError before `renderReportPdf` is reached, on both the straight-render
+ * path (no timeout) and the timeout-race path (a finite timeout, where the
+ * abort listener is wired inside the Promise).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateReport, DEFAULT_TEMPLATE_ID } from '../src/report';
+import type { ReportInputs } from '../src/report';
+
+function makeInputs(): ReportInputs {
+  return {
+    templateId: DEFAULT_TEMPLATE_ID,
+    branding: {
+      organisation: 'Acme Survey Co.',
+      author: 'A. Inspector',
+      accentColor: '#00b2ff',
+      theme: 'light-technical',
+    },
+    cover: {
+      title: 'Survey Summary',
+      subtitle: 'Test',
+      datasetName: 'test.copc.laz',
+      exportedAt: '2026-05-28T15:30:00.000Z',
+    },
+    datasetRows: [{ label: 'Points', value: '1,000' }],
+    visuals: [],
+    annotations: [],
+    measurements: [],
+  };
+}
+
+describe('generateReport — already-aborted signal', () => {
+  it('rejects with AbortError on the timeout-race path (finite timeout)', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      generateReport(makeInputs(), { signal: controller.signal, timeoutMs: 30_000 }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('rejects with AbortError on the straight-render path (no timeout)', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      generateReport(makeInputs(), { signal: controller.signal, timeoutMs: Infinity }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});

--- a/tests/streamingBudget.test.ts
+++ b/tests/streamingBudget.test.ts
@@ -9,8 +9,73 @@ import { describe, it, expect } from 'vitest';
 import {
   streamingBudgets,
   selectWithinBudget,
+  decodedBytesPerPoint,
+  firstAdmissionMaxDecodedBytes,
+  firstAdmissionMaxPoints,
+  DECODED_BYTES_PER_POINT,
   type ScoredCandidate,
 } from '../src/render/streaming/streamingBudget';
+
+describe('decodedBytesPerPoint — schema-aware decoded byte estimate', () => {
+  it('charges positions only for a positions-only chunk', () => {
+    expect(decodedBytesPerPoint()).toBe(12);
+    expect(decodedBytesPerPoint({})).toBe(12);
+  });
+
+  it('charges each present channel at its element width', () => {
+    // Full LAS-family PDRF 7/8 shape: positions 12 + intensity 2 + class 1 +
+    // returnNumber 1 + returnCount 1 + gpsTime 8 + rgb 3 + pointSourceId 2.
+    const full = decodedBytesPerPoint({
+      intensity: true,
+      classification: true,
+      returnNumber: true,
+      returnCount: true,
+      gpsTime: true,
+      rgb: true,
+      pointSourceId: true,
+    });
+    expect(full).toBe(30);
+    // The flat worst-case constant matches this widest LAS-family shape.
+    expect(full).toBe(DECODED_BYTES_PER_POINT);
+    // The earlier flat figure of 25 undercounted a coloured point by rgb (3) +
+    // pointSourceId (2) = 5 bytes.
+    expect(full).toBeGreaterThan(25);
+  });
+
+  it('adds normals as three f32 when present', () => {
+    expect(decodedBytesPerPoint({ normals: true })).toBe(12 + 12);
+  });
+});
+
+describe('first-admission ceiling — device aware', () => {
+  it('gives a desktop the full half-gigabyte byte ceiling', () => {
+    expect(firstAdmissionMaxDecodedBytes(false)).toBe(512 * 1024 * 1024);
+  });
+
+  it('lowers the byte ceiling on mobile and lower still on low memory', () => {
+    const desktop = firstAdmissionMaxDecodedBytes(false);
+    const mobile = firstAdmissionMaxDecodedBytes(true);
+    const lowMem = firstAdmissionMaxDecodedBytes(true, 2);
+    expect(mobile).toBeLessThan(desktop);
+    expect(lowMem).toBeLessThan(mobile);
+    // A low-memory desktop is also clamped, not just phones.
+    expect(firstAdmissionMaxDecodedBytes(false, 2)).toBeLessThan(desktop);
+  });
+
+  it('a plentiful deviceMemory does not raise the ceiling above the class default', () => {
+    expect(firstAdmissionMaxDecodedBytes(false, 32)).toBe(firstAdmissionMaxDecodedBytes(false));
+    expect(firstAdmissionMaxDecodedBytes(true, 32)).toBe(firstAdmissionMaxDecodedBytes(true));
+  });
+
+  it('derives the point ceiling from the byte ceiling and worst-case per point', () => {
+    expect(firstAdmissionMaxPoints(false)).toBe(
+      Math.floor(firstAdmissionMaxDecodedBytes(false) / DECODED_BYTES_PER_POINT),
+    );
+    expect(firstAdmissionMaxPoints(false)).toBe(17_895_697);
+    // A phone admits far fewer points than a desktop through the empty-viewer bypass.
+    expect(firstAdmissionMaxPoints(true)).toBeLessThan(firstAdmissionMaxPoints(false));
+  });
+});
 
 describe('streamingBudgets — desktop resident-point budgets', () => {
   it('resolves the trimmed balanced default and the unchanged low/high', () => {

--- a/tests/streamingFirstAdmission.test.ts
+++ b/tests/streamingFirstAdmission.test.ts
@@ -173,7 +173,7 @@ test('a node just under the ceiling is still admitted through the bypass', async
   // pinned from the test side so a future change to either the byte budget or
   // the per-point figure has to move this number deliberately.
   const ceiling = Math.floor((512 * 1024 * 1024) / DECODED_BYTES_PER_POINT);
-  expect(ceiling).toBe(21_474_836);
+  expect(ceiling).toBe(17_895_697);
   // Well past both the point budget and its 1.5x pressure cap, and past the
   // largest budget this viewer configures anywhere (desktop `high`, 8 M).
   expect(ceiling).toBeGreaterThan(streamingBudgets('high', false).pointBudget * 1.5);


### PR DESCRIPTION
Six independent memory and abort hardening fixes, one test each.

The out-of-core indexer now refuses an already-aborted build before it
constructs the worker, and the report engine re-checks its abort signal
before the render starts. The streaming decoded-point figure moves from a
stale 25 bytes to a 30-byte worst case with a schema-aware per-channel
estimate, and the first-admission ceiling becomes device aware so a phone
or a low-memory machine admits fewer points than a desktop. An
over-ceiling non-streaming format with no bounded decode (PLY, PCD, PTX,
PTS, XYZ, OBJ, GLB) now fails closed with guidance to stream as COPC or
EPT. The batch converter gains a per-file preflight before arrayBuffer,
and the report and workflow file reads gain size ceilings.

Gates green: typecheck, unit, slow, monolith-size, unreachable-modules,
position-access, module-graph, build:live, check:bundle, archive-gate.
