### PR TITLE
Centralize a decoded-byte budget across the heavy decode path

### DIFF
--- a/src/io/copc/copcChunkDecompress.ts
+++ b/src/io/copc/copcChunkDecompress.ts
@@ -24,6 +24,10 @@ import {
   validateDeclaredPointCount,
   compressedBytesPerPointFloor,
 } from '../validateCount';
+import {
+  MAX_DECODED_ALLOCATION_BYTES,
+  withinDecodedByteBudget,
+} from '../heavy/heavyByteBudget';
 import type { ChunkDecodeMetadata } from './copcChunkDecode';
 
 /** The instantiated laz-perf WASM module. */
@@ -39,6 +43,16 @@ export type LazPerfModule = Awaited<ReturnType<typeof createLazPerf>>;
  * arrays in `decodeRecords`) into the gigabytes.
  */
 export const MAX_NODE_POINTS = 50_000_000;
+
+/**
+ * Hard ceiling on a node's DECOMPRESSED size, `pointCount * recordLength`, in
+ * bytes. The point cap above bounds the count but not the allocation: a node with
+ * a low point count and a huge record length (LAS Extra Bytes reaches 65535 bytes
+ * per record) still sizes `new Uint8Array(pointCount * recordLength)` into the
+ * gigabytes. COPC is remote and untrusted, so the byte cost is bounded here,
+ * before the output buffer is allocated, by the shared decode budget.
+ */
+export const MAX_DECOMPRESSED_NODE_BYTES = MAX_DECODED_ALLOCATION_BYTES;
 
 /**
  * Decompress one COPC node chunk into raw concatenated LAS records using
@@ -67,6 +81,17 @@ export function decompressChunk(
       'malformed-file',
       `malformed COPC: node claims ${pointCount.toLocaleString('en-US')} points ` +
         `(limit ${MAX_NODE_POINTS.toLocaleString('en-US')}).`,
+    );
+  }
+  // Decoded-byte cap: refuse before sizing `pointCount * recordLength` output.
+  // A node can pass the point cap yet still stage gigabytes when its record is
+  // huge (Extra Bytes), so bound the actual decompressed size, not just the count.
+  if (!withinDecodedByteBudget(pointCount, meta.pointRecordLength, MAX_DECOMPRESSED_NODE_BYTES)) {
+    throw new LoadError(
+      'malformed-file',
+      `malformed COPC: node of ${pointCount.toLocaleString('en-US')} points × ` +
+        `${meta.pointRecordLength} bytes exceeds the ` +
+        `${MAX_DECOMPRESSED_NODE_BYTES.toLocaleString('en-US')}-byte decode budget.`,
     );
   }
 

--- a/src/io/heavy/chunkedLazSource.ts
+++ b/src/io/heavy/chunkedLazSource.ts
@@ -34,6 +34,11 @@ import {
 } from '../lasDecodeShared';
 import { getLazPerf } from '../lazDecode';
 import { readLazChunkTable, type LazChunkRange } from './lazChunkTable';
+import {
+  MAX_DECODED_ALLOCATION_BYTES,
+  decodedBytesFor,
+  withinDecodedByteBudget,
+} from './heavyByteBudget';
 import { decodeLazChunkLocal, type LazChunkJob } from './decodeLazChunked';
 import type { PointSource, PositionBatch, SourceHeader } from './oocIndexer';
 import {
@@ -76,23 +81,32 @@ export const MAX_LAZ_WINDOW_SPAN_BYTES = 128 * 1024 * 1024;
 
 /**
  * Plan the next window starting at `start`: grow it while the contiguous span
- * from the first chunk's offset stays under {@link MAX_LAZ_WINDOW_SPAN_BYTES}
- * and under `window` chunks, but always take at least one chunk. Pure, so the
- * shrink behaviour is unit-testable without decoding. `chunks` must be non-empty
- * at `start`.
+ * from the first chunk's offset stays under {@link MAX_LAZ_WINDOW_SPAN_BYTES},
+ * the aggregate DECODED bytes of the window stay under
+ * {@link MAX_DECODED_ALLOCATION_BYTES}, and it is under `window` chunks — but
+ * always take at least one chunk. The decoded-byte cap uses the real record
+ * length (`recordLength`, 0 to skip it): the compressed-span cap bounds the read,
+ * but a window of highly-compressed chunks can decode to far more than it reads,
+ * and every decoded chunk in the window is staged before the window advances.
+ * Pure, so the shrink behaviour is unit-testable without decoding. `chunks` must
+ * be non-empty at `start`.
  */
 export function planChunkWindow(
   chunks: readonly LazChunkRange[],
   start: number,
   window: number,
+  recordLength: number = 0,
 ): { end: number; spanStart: number; spanLength: number } {
   const spanStart = chunks[start].byteOffset;
+  const cap = recordLength > 0 ? MAX_DECODED_ALLOCATION_BYTES : Number.POSITIVE_INFINITY;
   let end = start + 1;
-  while (
-    end < chunks.length &&
-    end - start < window &&
-    chunks[end].byteOffset + chunks[end].byteLength - spanStart <= MAX_LAZ_WINDOW_SPAN_BYTES
-  ) {
+  let decoded = decodedBytesFor(chunks[start].pointCount, recordLength > 0 ? recordLength : 1);
+  while (end < chunks.length && end - start < window) {
+    const next = chunks[end];
+    if (next.byteOffset + next.byteLength - spanStart > MAX_LAZ_WINDOW_SPAN_BYTES) break;
+    const nextDecoded = decoded + decodedBytesFor(next.pointCount, recordLength > 0 ? recordLength : 1);
+    if (nextDecoded > cap) break;
+    decoded = nextDecoded;
     end++;
   }
   const last = chunks[end - 1];
@@ -100,10 +114,15 @@ export function planChunkWindow(
 }
 
 /**
- * A LAZ the chunked out-of-core path cannot serve: no usable chunk table, or a
- * point format the per-chunk decoder does not support. Named so the open path
- * can route on it (e.g. fall back to the whole-file loader) rather than reading
- * the file whole here.
+ * A LAZ the chunked out-of-core path cannot serve: no usable chunk table, a
+ * point format the per-chunk decoder does not support, or a chunk/window over the
+ * decoded-byte budget. Named so the open path can route on it rather than reading
+ * the file whole here. Routing does NOT mean an automatic whole-file fallback: a
+ * whole-file read is permitted only when an independent load plan proves that
+ * path fits in memory. When this error is raised because a chunk or window
+ * exceeds the byte budget, the file is by construction too large for a bounded
+ * decode, so the whole-file path cannot fit and must not be tried — the file is
+ * refused with convert-to-COPC/EPT guidance.
  */
 export class ChunkedLazUnsupportedError extends Error {
   constructor(message: string) {
@@ -189,7 +208,12 @@ export async function openChunkedLazSource(
         // last chunk's end. `planChunkWindow` caps that span so a wide window of
         // large chunks can never read an unbounded contiguous slice. Nothing
         // outside this window is resident.
-        const { end, spanStart, spanLength } = planChunkWindow(chunks, start, window);
+        const { end, spanStart, spanLength } = planChunkWindow(
+          chunks,
+          start,
+          window,
+          header.pointDataRecordLength,
+        );
         const windowChunks = chunks.slice(start, end);
         const span = await range.readRange(spanStart, spanLength, signal);
         for (const c of windowChunks) {
@@ -215,6 +239,16 @@ function decodeChunkBatch(
   recordBytes: number,
   c: LazChunkRange,
 ): PositionBatch {
+  // Defense in depth behind the table-read cap: never decode a chunk whose
+  // records exceed the decoded-byte budget. readLazChunkTable already refuses
+  // such a chunk, so a supported table cannot reach here over budget; this holds
+  // even if a future caller hands in a chunk that skipped that gate.
+  if (!withinDecodedByteBudget(c.pointCount, header.pointDataRecordLength)) {
+    throw new ChunkedLazUnsupportedError(
+      `chunked LAZ chunk decodes to ${c.pointCount} points of ${header.pointDataRecordLength} ` +
+        'bytes, over the safe decode budget; convert it to COPC or EPT',
+    );
+  }
   const rel = c.byteOffset - spanStart;
   const job: LazChunkJob = {
     chunk: span.slice(rel, rel + c.byteLength),

--- a/src/io/heavy/heavyByteBudget.ts
+++ b/src/io/heavy/heavyByteBudget.ts
@@ -1,0 +1,166 @@
+/**
+ * heavyByteBudget.ts — one shared decoded-byte budget for the heavy/streaming
+ * decode path.
+ *
+ * Every out-of-core reader sizes an allocation from a count it read out of a
+ * file: a chunk's point count, a node's point count, a batch of fixed records, a
+ * chunk table's entry count, a leaf tile's bytes. A malformed or adversarial file
+ * can drive any of those counts far past what the out-of-core spill was built to
+ * protect, because the spill caps RESIDENCY over a whole build while these are
+ * single up-front allocations that happen BEFORE the first point is spilled. A
+ * point-count cap alone does not bound them: the byte cost is `count *
+ * recordLength`, and LAS Extra Bytes lets one record reach 65535 bytes, so a
+ * count that looks modest can still stage gigabytes.
+ *
+ * The fix is one policy, here, rather than five arbitrary constants scattered
+ * across the readers. Limits are derived from a device-reasonable ceiling on a
+ * single staged buffer and from the file's own record length; a site over budget
+ * REFUSES (throws {@link HeavyByteBudgetError}, or reports the reader's existing
+ * `supported: false` / typed-refusal shape) rather than allocating past it, and
+ * never falls back to a whole-file path on refusal.
+ *
+ * Pure — no Viewer, no three.js, no DOM. Node-testable.
+ */
+
+/**
+ * The ceiling on ONE staged decode buffer, in bytes. A single chunk decoded
+ * whole, a single COPC node's records, or a window of LAZ chunks held at once
+ * must all stay under this. 128 MiB is the figure the rest of the heavy path
+ * already treats as its staging budget (the LAZ window-span cap is the same
+ * number); it is comfortably allocatable on a low-end device yet far above any
+ * honest single-unit decode, whose real size is sub-megabyte.
+ */
+export const MAX_DECODED_ALLOCATION_BYTES = 128 * 1024 * 1024;
+
+/**
+ * The largest single SOURCE range-read a fixed-record LAS batch may issue, in
+ * bytes. Uncompressed records are read straight off disk into one buffer, so the
+ * read size is `batchPoints * recordLength`; 16 MiB keeps that one read small
+ * regardless of the record length, which with Extra Bytes can otherwise make a
+ * default-sized batch a gigabyte.
+ */
+export const MAX_BATCH_SOURCE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * The ceiling on the chunk-table staging a plain-LAZ reader allocates BEFORE it
+ * validates any individual chunk: the two `Float64Array(numChunks)` delta
+ * streams plus one range object per chunk. 64 MiB bounds that up-front cost;
+ * {@link MAX_CHUNK_TABLE_ENTRIES} turns it into a hard chunk-count ceiling.
+ */
+export const MAX_CHUNK_TABLE_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Staging cost charged per chunk-table entry: two Float64 deltas (16 bytes) plus
+ * one {@link LazChunkRange}-shaped object, accounted at a conservative 32 bytes.
+ * Deriving the entry ceiling from this and {@link MAX_CHUNK_TABLE_BYTES} keeps
+ * the chunk-count cap honest about the memory it protects rather than a round
+ * number picked in the air.
+ */
+export const CHUNK_TABLE_ENTRY_BYTES = 48;
+
+/**
+ * Hard ceiling on the declared chunk count, derived from the byte budget above.
+ * Real files are far under it: a fixed 50 000-point chunk size turns even a
+ * 60-billion-point cloud into ~1.2 million chunks. A table declaring more is
+ * refused before its delta arrays are allocated. Much lower than the old flat
+ * 16,777,216, whose delta arrays alone reached ~256 MiB.
+ */
+export const MAX_CHUNK_TABLE_ENTRIES = Math.floor(
+  MAX_CHUNK_TABLE_BYTES / CHUNK_TABLE_ENTRY_BYTES,
+);
+
+/**
+ * The ceiling on ONE leaf tile the streaming reader loads whole, in bytes. The
+ * out-of-core indexer buckets points into leaves; a degenerate cloud (millions
+ * of identical XYZ, which share a leaf key and an LOD hash) can pile far past a
+ * leaf's target into one logical node, and the reader reads a whole tile into
+ * memory. 256 MiB is well above a healthy leaf (about `pointsPerLeaf` points)
+ * yet bounds the pathological pile; a node over it is refused at index time so no
+ * oversized tile is ever produced.
+ */
+export const MAX_TILE_BYTES = 256 * 1024 * 1024;
+
+/** A heavy allocation refused for exceeding the decoded-byte budget. */
+export class HeavyByteBudgetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HeavyByteBudgetError';
+  }
+}
+
+/**
+ * Decoded bytes for `pointCount` records of `recordLength` bytes, or
+ * {@link Number.POSITIVE_INFINITY} when either input is not a usable non-negative
+ * number. Infinity is deliberate: a nonsense record length must read as
+ * over-budget, never as zero.
+ */
+export function decodedBytesFor(pointCount: number, recordLength: number): number {
+  if (
+    !Number.isFinite(pointCount) ||
+    !Number.isFinite(recordLength) ||
+    pointCount < 0 ||
+    recordLength <= 0
+  ) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return pointCount * recordLength;
+}
+
+/** Whether `pointCount * recordLength` stays within `ceiling` (default the global cap). */
+export function withinDecodedByteBudget(
+  pointCount: number,
+  recordLength: number,
+  ceiling: number = MAX_DECODED_ALLOCATION_BYTES,
+): boolean {
+  return decodedBytesFor(pointCount, recordLength) <= ceiling;
+}
+
+/**
+ * The largest point count whose decoded records fit `ceiling` for a given record
+ * length, at least 1. Used to size a batch or to derive a per-format point cap.
+ */
+export function maxPointsForRecordLength(
+  recordLength: number,
+  ceiling: number = MAX_DECODED_ALLOCATION_BYTES,
+): number {
+  if (!Number.isFinite(recordLength) || recordLength <= 0) return 1;
+  return Math.max(1, Math.floor(ceiling / recordLength));
+}
+
+/**
+ * Points per fixed-record batch: the caller's desired size, clamped so one
+ * source read never exceeds `sourceCeiling` bytes, and never below one point.
+ * `min(desired, floor(sourceCeiling / recordLength))`.
+ */
+export function batchPointsForRecordLength(
+  recordLength: number,
+  desiredPoints: number,
+  sourceCeiling: number = MAX_BATCH_SOURCE_BYTES,
+): number {
+  const desired = Number.isFinite(desiredPoints) ? Math.floor(desiredPoints) : 1;
+  return Math.max(1, Math.min(desired, maxPointsForRecordLength(recordLength, sourceCeiling)));
+}
+
+/**
+ * Throw {@link HeavyByteBudgetError} when `pointCount * recordLength` exceeds
+ * `ceiling`. `context` names the site for the message ("COPC node", "LAZ chunk",
+ * "tile"). Callers that own a `supported: false` shape should test
+ * {@link withinDecodedByteBudget} instead and report that shape; this is for the
+ * sites whose refusal is a throw.
+ */
+export function assertDecodedByteBudget(
+  pointCount: number,
+  recordLength: number,
+  context: string,
+  ceiling: number = MAX_DECODED_ALLOCATION_BYTES,
+): void {
+  if (!withinDecodedByteBudget(pointCount, recordLength, ceiling)) {
+    const bytes = decodedBytesFor(pointCount, recordLength);
+    const shown = Number.isFinite(bytes) ? bytes.toLocaleString('en-US') : 'an unbounded number of';
+    throw new HeavyByteBudgetError(
+      `${context}: ${pointCount.toLocaleString('en-US')} points × ${recordLength} bytes ` +
+        `would stage ${shown} bytes, over the ${ceiling.toLocaleString('en-US')}-byte decode budget; ` +
+        'convert it to COPC or EPT.',
+    );
+  }
+}

--- a/src/io/heavy/lazChunkTable.ts
+++ b/src/io/heavy/lazChunkTable.ts
@@ -13,9 +13,15 @@
  *
  * Fail-closed contract: a file whose table is absent (pointwise compressor,
  * `-1` offset sentinel), unreadable, or inconsistent with the header reports
- * `supported: false` with a reason — the caller falls back to the legacy
- * whole-file path, and the fast path never guesses at a suspect index. The
- * invariants enforced before any chunk is trusted:
+ * `supported: false` with a reason. A `supported: false` result is NOT a licence
+ * to read the file whole: the caller may fall back to the legacy whole-file path
+ * ONLY when an independent load plan proves the whole-file path fits in memory.
+ * A refusal driven by the byte-budget caps (a chunk over the decoded-byte budget,
+ * a chunk table over the entry ceiling) means the file is too large for a bounded
+ * decode, so a whole-file read of the same file would be larger still and must
+ * not be attempted; those files are refused with convert-to-COPC/EPT guidance.
+ * The fast path never guesses at a suspect index. The invariants enforced before
+ * any chunk is trusted:
  *
  *   • chunk offsets strictly increase and stay inside the file;
  *   • the last chunk ends exactly where the table begins;
@@ -27,6 +33,11 @@
 import type { RangeSource } from '../range/RangeSource';
 import { parseLasHeader, type LasHeader } from '../lasHeader';
 import { ArithmeticDecoder, IntegerDecompressor } from './arithmeticCoder';
+import {
+  MAX_CHUNK_TABLE_ENTRIES,
+  MAX_DECODED_ALLOCATION_BYTES,
+  withinDecodedByteBudget,
+} from './heavyByteBudget';
 
 /** One independently decodable compressed chunk. */
 export interface LazChunkRange {
@@ -75,8 +86,15 @@ const LASZIP_RECORD_ID = 22204;
 
 /** Head read: the full VLR region, capped so a hostile header stays bounded. */
 const MAX_HEAD_BYTES = 4 * 1024 * 1024;
-/** Absurdity guard on the declared chunk count before any allocation. */
-const MAX_CHUNKS = 16_777_216;
+/**
+ * Absurdity guard on the declared chunk count, checked BEFORE the two
+ * `Float64Array(numChunks)` delta streams and the per-chunk range objects are
+ * allocated. {@link MAX_CHUNK_TABLE_ENTRIES} derives it from a byte budget on
+ * that staging, so the ceiling states the memory it protects; the old flat
+ * 16,777,216 let the delta arrays alone reach ~256 MiB before a single chunk was
+ * validated.
+ */
+const MAX_CHUNKS = MAX_CHUNK_TABLE_ENTRIES;
 
 /**
  * Bounded-decode caps on a SINGLE chunk. A LAZ chunk table can be valid yet
@@ -292,6 +310,16 @@ export async function readLazChunkTable(
       return unsupported(
         `chunk ${i} decodes to ${pointCount} points, too large for bounded browser decoding; ` +
           'convert it to COPC or EPT',
+      );
+    }
+    // Decoded-byte cap: the point cap alone does not bound the staging, because
+    // the byte cost is `pointCount * pointDataRecordLength` and LAS Extra Bytes
+    // lets one record reach 65535 bytes. A modest-looking count over a huge
+    // record still stages gigabytes, so refuse on the actual decoded size.
+    if (!withinDecodedByteBudget(pointCount, header.pointDataRecordLength)) {
+      return unsupported(
+        `chunk ${i} decodes to ${pointCount} points of ${header.pointDataRecordLength} bytes, ` +
+          `over the ${MAX_DECODED_ALLOCATION_BYTES}-byte decode budget; convert it to COPC or EPT`,
       );
     }
     if (end > tableOffset) {

--- a/src/io/heavy/oocIndexer.ts
+++ b/src/io/heavy/oocIndexer.ts
@@ -19,6 +19,20 @@
  * an empty index rather than a fault.
  */
 import { octreeGridFor, type OctreeGrid } from './octreeGrid';
+import { MAX_TILE_BYTES, maxPointsForRecordLength } from './heavyByteBudget';
+
+/**
+ * A cloud one of whose logical nodes cannot be brought under the per-tile byte
+ * budget by spatial subdivision — millions of coincident XYZ share a leaf key and
+ * an LOD hash, so they pile into one tile no depth can split. Refused at index
+ * time so no oversized tile is ever produced (and later read whole into memory).
+ */
+export class DegenerateCloudError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DegenerateCloudError';
+  }
+}
 
 /**
  * One batch from a re-iterable source: interleaved xyz positions used to KEY
@@ -106,6 +120,13 @@ export interface IndexOptions {
   /** Bucketing-pass memory ceiling before a spill. Default 64 MB. */
   readonly memoryBudgetBytes?: number;
   readonly maxDepth?: number;
+  /**
+   * Byte ceiling on a single leaf tile. A logical node that cannot be brought
+   * under it by subdivision (coincident points that share a leaf) fails the build
+   * with {@link DegenerateCloudError} rather than producing an oversized tile the
+   * streaming reader would later load whole. Default {@link MAX_TILE_BYTES}.
+   */
+  readonly maxTileBytes?: number;
   readonly signal?: AbortSignal;
   /**
    * Force the two-pass path even when the source header would allow one pass.
@@ -287,6 +308,7 @@ export async function indexOutOfCore(
   const signal = options.signal;
   const pointsPerLeaf = Math.max(1, options.pointsPerLeaf ?? DEFAULT_POINTS_PER_LEAF);
   const budget = Math.max(POSITION_RECORD_BYTES, options.memoryBudgetBytes ?? DEFAULT_MEMORY_BUDGET);
+  const maxTileBytes = Math.max(1, options.maxTileBytes ?? MAX_TILE_BYTES);
 
   // The fast path spills before it can prove the header, so it must be able to
   // undo that if the header proves false: it runs only on a clearable store.
@@ -340,6 +362,7 @@ export async function indexOutOfCore(
   // allocating. `scratch` is packed with x,y,z before reading `scratchU32`.
   const scratchU32 = new Uint32Array(scratch.buffer);
   let recordBytes = -1; // set from the first batch; every batch must agree
+  let maxTilePoints = Infinity; // derived from recordBytes and maxTileBytes once known
 
   // The root cube the fast path holds every point to.
   const loX = grid.root.min[0];
@@ -356,8 +379,12 @@ export async function indexOutOfCore(
       const p = batch.positions;
       const rb = batch.records ? batch.recordBytes ?? 0 : POSITION_RECORD_BYTES;
       if (batch.records && rb <= 0) throw new Error('oocIndexer: a records batch must set a positive recordBytes');
-      if (recordBytes === -1) recordBytes = rb;
-      else if (rb !== recordBytes) throw new Error('oocIndexer: recordBytes changed between batches');
+      if (recordBytes === -1) {
+        recordBytes = rb;
+        maxTilePoints = maxPointsForRecordLength(rb, maxTileBytes);
+      } else if (rb !== recordBytes) {
+        throw new Error('oocIndexer: recordBytes changed between batches');
+      }
 
       for (let i = 0; i < batch.count; i++) {
         const x = p[i * 3];
@@ -413,7 +440,20 @@ export async function indexOutOfCore(
           record = scratchBytes;
         }
         buf.append(record);
-        counts.set(key, (counts.get(key) ?? 0) + 1);
+        const keyCount = (counts.get(key) ?? 0) + 1;
+        counts.set(key, keyCount);
+        // Per-tile byte ceiling. A degenerate cloud (millions of coincident XYZ)
+        // funnels every point into one leaf key and one LOD-hash bucket, so no
+        // grid depth can subdivide it: the pile grows without bound and the reader
+        // would later load the whole tile into memory. Fail closed the moment a
+        // node crosses the budget, so no oversized tile is produced or spilled.
+        if (keyCount > maxTilePoints) {
+          throw new DegenerateCloudError(
+            `oocIndexer: node ${key === '' ? '(root)' : key} exceeds ${maxTilePoints} points ` +
+              `(${maxTileBytes}-byte tile budget at ${rb} bytes/record); the cloud has too many ` +
+              'coincident points to subdivide. Convert it to COPC or EPT.',
+          );
+        }
         buffered += rb;
         if (buffered > peakBufferedBytes) peakBufferedBytes = buffered;
         // Bound residency to the budget: spill everything once it is reached, so

--- a/src/io/heavy/previewSampler.ts
+++ b/src/io/heavy/previewSampler.ts
@@ -32,6 +32,7 @@ import type { RangeSource } from '../range/RangeSource';
 import { decodeContext, finalizeRawColors } from '../lasDecodeShared';
 import { openSlicedLas } from './slicedLasReader';
 import { readLazChunkTable } from './lazChunkTable';
+import { withinDecodedByteBudget } from './heavyByteBudget';
 import { decodeLazChunkLocal } from './decodeLazChunked';
 import { getLazPerf } from '../lazDecode';
 import {
@@ -97,9 +98,13 @@ function localExtent(
 
 /**
  * Build a stratified preview sample, or null when the file is too small to be
- * worth one or the sample cannot be built (an unsupported LAZ table, a decode
- * fault). Null is not an error: the caller simply opens with no preview and
- * waits for the full index.
+ * worth one or the sample cannot be built. Null covers two distinct cases, both
+ * best-effort and neither a failed open: "preview unavailable" (an unsupported
+ * LAZ table, a point format outside the decoder's set, a decode fault, or a file
+ * under the preview-worth threshold) and "preview skipped: chunk exceeds safe
+ * decode budget" (a chunk whose decoded records are over the byte budget is not
+ * decoded for a preview). The caller opens with no preview and waits for the full
+ * index either way.
  */
 export async function buildPreviewSample(
   range: RangeSource,
@@ -209,6 +214,16 @@ async function sampleLaz(
   for (let i = 0; i < wanted && sampled < target; i++) {
     signal?.throwIfAborted();
     const c = chunks[Math.min(chunks.length - 1, Math.floor(i * stride))];
+    // Per-chunk decoded-byte refusal, the same cap the full build enforces. The
+    // sampler decodes a WHOLE chunk before taking the first `take` points it
+    // needs, so a chunk whose `pointCount * pointDataRecordLength` is over budget
+    // would stage the whole over-budget decode just for a preview. Skip this
+    // chunk rather than decode it — a "preview skipped: chunk exceeds safe decode
+    // budget" case, distinct from the "preview unavailable" that a null table or
+    // an unsupported format yields. readLazChunkTable already refuses such a
+    // chunk, so a supported table should never reach here; this stays as the
+    // sampler's own guard against decoding past budget.
+    if (!withinDecodedByteBudget(c.pointCount, header.pointDataRecordLength)) continue;
     // One bounded range read per chunk — never the whole file.
     const bytes = await range.readRange(c.byteOffset, c.byteLength, signal);
     const raw = decodeLazChunkLocal(lazPerf, {

--- a/src/io/heavy/slicedLasReader.ts
+++ b/src/io/heavy/slicedLasReader.ts
@@ -26,6 +26,7 @@ import {
   finalizeRawColors,
   type RawPoints,
 } from '../lasDecodeShared';
+import { batchPointsForRecordLength } from './heavyByteBudget';
 
 /** One decoded batch of consecutive records. */
 export interface SlicedLasBatch {
@@ -60,6 +61,15 @@ export interface SlicedLasOpen {
    * truncated file yields its readable prefix instead of a fault.
    */
   readonly readablePointCount: number;
+  /** The point count the header declares, before any truncation clamp. */
+  readonly declaredPointCount: number;
+  /**
+   * Whether the file physically holds every declared point. `false` when the
+   * bytes after the header cannot back the declared count — a truncated scan.
+   * Carried so a truncated file is never presented as a complete smaller one:
+   * `readablePointCount < declaredPointCount` iff this is `false`.
+   */
+  readonly complete: boolean;
   readonly origin: [number, number, number];
   /** Read one batch of `count` records starting at `firstPointIndex`. */
   readBatch(firstPointIndex: number, count: number): Promise<SlicedLasBatch>;
@@ -85,13 +95,23 @@ export async function openSlicedLas(
       ? Math.floor((size - header.offsetToPointData) / recordLength)
       : 0;
   const readablePointCount = Math.min(header.pointCount, capacity);
+  const declaredPointCount = header.pointCount;
+  const complete = readablePointCount >= declaredPointCount;
 
   const origin: [number, number, number] =
     options.origin ?? [Math.floor(header.min[0]), Math.floor(header.min[1]), Math.floor(header.min[2])];
   const ctx = decodeContext(header, origin);
   const hasColor = pointFormatHasRgb(header.pointFormat);
   const hasGps = ctx.gpsTimeOffset !== null;
-  const batchPoints = Math.max(1, options.batchPoints ?? DEFAULT_BATCH_POINTS);
+  // Cap the batch by a source-byte ceiling, not a flat point count: one batch is
+  // read straight off disk as `batchPoints * recordLength` bytes, and LAS Extra
+  // Bytes lets recordLength reach 65535, so the default 262 144 points would read
+  // ~1 GiB+ in a single range read. `batchPointsForRecordLength` clamps the read
+  // to MAX_BATCH_SOURCE_BYTES while never dropping below one point.
+  const batchPoints = batchPointsForRecordLength(
+    recordLength,
+    Math.max(1, options.batchPoints ?? DEFAULT_BATCH_POINTS),
+  );
   const signal = options.signal;
 
   async function readBatch(firstPointIndex: number, count: number): Promise<SlicedLasBatch> {
@@ -118,5 +138,5 @@ export async function openSlicedLas(
     }
   }
 
-  return { header, readablePointCount, origin, readBatch, batches };
+  return { header, readablePointCount, declaredPointCount, complete, origin, readBatch, batches };
 }

--- a/src/io/heavy/slicedLasSource.ts
+++ b/src/io/heavy/slicedLasSource.ts
@@ -30,6 +30,10 @@ export interface SlicedLasSource {
   readonly schema: TileSchema;
   readonly recordBytes: number;
   readonly readablePointCount: number;
+  /** The header's declared count, before any truncation clamp. */
+  readonly declaredPointCount: number;
+  /** `false` when the file physically holds fewer points than it declares. */
+  readonly complete: boolean;
   readonly origin: [number, number, number];
 }
 
@@ -73,6 +77,8 @@ export async function openSlicedLasSource(
     schema,
     recordBytes,
     readablePointCount: opened.readablePointCount,
+    declaredPointCount: opened.declaredPointCount,
+    complete: opened.complete,
     origin: opened.origin,
   };
 }

--- a/src/io/heavy/tileChunkDecoder.ts
+++ b/src/io/heavy/tileChunkDecoder.ts
@@ -34,6 +34,11 @@ export class TileChunkDecoder implements ChunkDecoder {
     signal?: AbortSignal,
   ): Promise<DecodedChunk> {
     signal?.throwIfAborted();
+    // `meta.pointCount` is the EXACT count the store hierarchy records for this
+    // tile, so decodeTile enforces `byteLength === pointCount * recordBytes` and
+    // throws TileTruncationError on a truncated or corrupt tile. That throw
+    // propagates as a decode fault (the scheduler's normal failure path), never a
+    // silently-sparse tile.
     const tile = decodeTile(new Uint8Array(chunk), this.schema, this.recordBytes, meta.pointCount);
     return {
       pointCount: tile.pointCount,

--- a/src/io/heavy/tileRecord.ts
+++ b/src/io/heavy/tileRecord.ts
@@ -107,21 +107,53 @@ export interface DecodedTile {
   readonly rgb: Uint8Array | null;
 }
 
+/** A tile whose byte length does not match the point count the hierarchy declares. */
+export class TileTruncationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TileTruncationError';
+  }
+}
+
 /**
  * Decode a tile's records straight into typed arrays. Fields are read inline
  * from the byte view — no {@link TilePoint} per point — so a full leaf decodes
- * without a million short-lived objects. `maxPoints` caps the count for a
- * truncated tile; otherwise every whole record present is decoded.
+ * without a million short-lived objects.
+ *
+ * When `expectedPointCount` is given (the exact count the store hierarchy records
+ * for this tile), the tile's byte length MUST equal `expectedPointCount *
+ * recordBytes`. A truncated or over-long tile is a corrupt store, not a smaller
+ * valid one, so it throws {@link TileTruncationError} rather than silently
+ * decoding whatever whole records happen to be present — which would present a
+ * corrupt tile as a sparse one. With no `expectedPointCount` (the loose reader
+ * path) every whole record present is decoded.
  */
 export function decodeTile(
   bytes: Uint8Array,
   schema: TileSchema,
   recordBytes: number,
-  maxPoints: number = Number.POSITIVE_INFINITY,
+  expectedPointCount?: number,
 ): DecodedTile {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const available = recordBytes > 0 ? Math.floor(bytes.byteLength / recordBytes) : 0;
-  const n = Math.max(0, Math.min(available, Math.floor(maxPoints)));
+  let n: number;
+  if (expectedPointCount === undefined) {
+    n = Math.max(0, available);
+  } else {
+    if (!Number.isSafeInteger(expectedPointCount) || expectedPointCount < 0) {
+      throw new TileTruncationError(
+        `tileRecord: expected point count ${expectedPointCount} is not a valid count`,
+      );
+    }
+    const need = expectedPointCount * recordBytes;
+    if (bytes.byteLength !== need) {
+      throw new TileTruncationError(
+        `tileRecord: tile is ${bytes.byteLength} bytes but the hierarchy declares ` +
+          `${expectedPointCount} points × ${recordBytes} bytes = ${need}; the store is truncated or corrupt`,
+      );
+    }
+    n = expectedPointCount;
+  }
   const positions = new Float32Array(n * 3);
   const intensity = new Uint16Array(n);
   const classification = new Uint8Array(n);

--- a/src/io/heavy/tileStore.ts
+++ b/src/io/heavy/tileStore.ts
@@ -25,6 +25,16 @@ export const TILE_STORE_SCHEMA_VERSION = 2;
 export interface TileManifest {
   readonly schemaVersion: number;
   readonly pointCount: number;
+  /**
+   * The point count the source header declared. Equals {@link pointCount} for a
+   * complete scan; larger when the file was physically truncated, so a consumer
+   * can report declared-vs-loaded honesty rather than presenting a truncated scan
+   * as a complete smaller one. Optional so a store written before this field is
+   * read as complete (declared === loaded).
+   */
+  readonly declaredPointCount?: number;
+  /** `false` when the source held fewer physical points than it declared. */
+  readonly complete?: boolean;
   readonly recordBytes: number;
   readonly schema: TileSchema;
   /**
@@ -59,6 +69,7 @@ export function buildTileStore(
   index: OocIndex,
   schema: TileSchema,
   origin: readonly [number, number, number],
+  provenance?: { readonly declaredPointCount: number; readonly complete: boolean },
 ): { manifest: TileManifest; manifestJson: string; hierarchy: string } {
   if (tileRecordBytes(schema) !== index.recordBytes) {
     throw new Error(
@@ -68,6 +79,11 @@ export function buildTileStore(
   const manifest: TileManifest = {
     schemaVersion: TILE_STORE_SCHEMA_VERSION,
     pointCount: index.pointCount,
+    // Carry declared-vs-loaded honesty when the source knows it. Default the
+    // declared count to the loaded count (a complete scan) so a store built
+    // without provenance reads as complete rather than unknown.
+    declaredPointCount: provenance ? provenance.declaredPointCount : index.pointCount,
+    complete: provenance ? provenance.complete : true,
     recordBytes: index.recordBytes,
     schema: { hasGps: schema.hasGps, hasRgb: schema.hasRgb },
     origin: [origin[0], origin[1], origin[2]],
@@ -126,9 +142,18 @@ export function parseTileManifest(input: unknown): TileManifest {
   }
   const boundsRec = asRecord(m.bounds, 'bounds');
   const rootRec = asRecord(m.root, 'root');
+  const pointCount = nonNegativeInt(m.pointCount, 'pointCount');
+  // Optional, so a store written before these fields round-trips as complete.
+  const declaredPointCount =
+    m.declaredPointCount === undefined
+      ? pointCount
+      : nonNegativeInt(m.declaredPointCount, 'declaredPointCount');
+  const complete = m.complete === undefined ? true : bool(m.complete, 'complete');
   return {
     schemaVersion: TILE_STORE_SCHEMA_VERSION,
-    pointCount: nonNegativeInt(m.pointCount, 'pointCount'),
+    pointCount,
+    declaredPointCount,
+    complete,
     recordBytes,
     schema,
     origin: triple(m.origin, 'origin'),

--- a/src/io/heavy/tileStoreBuilder.ts
+++ b/src/io/heavy/tileStoreBuilder.ts
@@ -104,7 +104,10 @@ export async function buildTileStoreFromLas(
     forceSlowPath: options.forceSlowPath,
     signal: options.signal,
   });
-  const { manifestJson, hierarchy } = buildTileStore(index, las.schema, las.origin);
+  const { manifestJson, hierarchy } = buildTileStore(index, las.schema, las.origin, {
+    declaredPointCount: las.declaredPointCount,
+    complete: las.complete,
+  });
 
   if (options.sink) {
     await options.sink.write(TILE_MANIFEST_NAME, manifestJson);

--- a/tests/heavyByteBudgetMemory.test.ts
+++ b/tests/heavyByteBudgetMemory.test.ts
@@ -1,0 +1,430 @@
+/**
+ * heavyByteBudgetMemory.test.ts — adversarial large-file memory suite for the
+ * shared decoded-byte budget ({@link src/io/heavy/heavyByteBudget.ts}).
+ *
+ * Each case is a metadata-only or fake-range fixture — no real gigabyte file —
+ * that would, without the budget, force one enormous allocation or range read
+ * BEFORE the out-of-core spill can protect memory, because the size is bounded
+ * by a point count or a structure count but never by decoded/compressed BYTES at
+ * the real record length. The invariant every case asserts is the same: NO
+ * allocation or read request larger than the configured budget is attempted
+ * before the refusal. Refusals take the reader's own fail-closed shape
+ * (`supported: false`, a typed throw) and never fall back to a whole-file path.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import type { RangeSource } from '../src/io/range/RangeSource';
+import { ArithmeticEncoder, IntegerCompressorEnc } from '../src/io/heavy/arithmeticCoder';
+import {
+  MAX_DECODED_ALLOCATION_BYTES,
+  MAX_BATCH_SOURCE_BYTES,
+  MAX_CHUNK_TABLE_ENTRIES,
+  MAX_TILE_BYTES,
+  batchPointsForRecordLength,
+  withinDecodedByteBudget,
+} from '../src/io/heavy/heavyByteBudget';
+import { readLazChunkTable, type LazChunkRange } from '../src/io/heavy/lazChunkTable';
+import { planChunkWindow } from '../src/io/heavy/chunkedLazSource';
+import { openSlicedLas } from '../src/io/heavy/slicedLasReader';
+import { indexOutOfCore, DegenerateCloudError, type PointSource, type SpillStore } from '../src/io/heavy/oocIndexer';
+import { decodeTile, tileRecordBytes, TileTruncationError, type TileSchema } from '../src/io/heavy/tileRecord';
+import { decompressChunk, type LazPerfModule } from '../src/io/copc/copcChunkDecompress';
+import { buildTileStoreFromLas } from '../src/io/heavy/tileStoreBuilder';
+
+/** An in-memory {@link SpillStore}: append concatenates per key, read joins. */
+function memoryStore(): SpillStore {
+  const tiles = new Map<string, Uint8Array[]>();
+  return {
+    async append(key, bytes) {
+      const parts = tiles.get(key) ?? [];
+      parts.push(bytes.slice());
+      tiles.set(key, parts);
+    },
+    async read(key) {
+      const parts = tiles.get(key) ?? [];
+      const total = parts.reduce((a, p) => a + p.byteLength, 0);
+      const out = new Uint8Array(total);
+      let at = 0;
+      for (const p of parts) {
+        out.set(p, at);
+        at += p.byteLength;
+      }
+      return out;
+    },
+    async keys() {
+      return [...tiles.keys()];
+    },
+    async clear() {
+      tiles.clear();
+    },
+  };
+}
+
+// --- instrumentation --------------------------------------------------------
+
+/** A RangeSource that records the largest single read requested against it. */
+class WatchedRangeSource implements RangeSource {
+  maxRead = 0;
+  private readonly inner: RangeSource;
+  constructor(inner: RangeSource) {
+    this.inner = inner;
+  }
+  id(): string {
+    return this.inner.id();
+  }
+  kind(): ReturnType<RangeSource['kind']> {
+    return this.inner.kind();
+  }
+  size(): Promise<number> {
+    return this.inner.size();
+  }
+  readRange(offset: number, length: number, signal?: AbortSignal): Promise<ArrayBuffer> {
+    if (length > this.maxRead) this.maxRead = length;
+    return this.inner.readRange(offset, length, signal);
+  }
+}
+
+// --- LAZ fixture (shared shape with lazChunkBoundedDecode.test.ts) ----------
+
+const LAZ_HEADER_SIZE = 227;
+const VLR_HEADER = 54;
+const LASZIP_PAYLOAD = 34;
+
+interface LazSpec {
+  compressor: number;
+  chunkSize: number;
+  pointCount: number;
+  chunkByteSizes: number[];
+  chunkPointCounts?: number[];
+  physicalGap?: number;
+  recordLength?: number;
+  pointFormat?: number;
+}
+
+function buildLazFixture(spec: LazSpec): ArrayBuffer {
+  const offsetToPointData = LAZ_HEADER_SIZE + VLR_HEADER + LASZIP_PAYLOAD;
+  const chunksStart = offsetToPointData + 8;
+  const chunkBytesTotal = spec.physicalGap ?? spec.chunkByteSizes.reduce((a, b) => a + b, 0);
+  const tableOffset = chunksStart + chunkBytesTotal;
+
+  const enc = new ArithmeticEncoder();
+  const ic = new IntegerCompressorEnc(enc, 2);
+  let prevCount = 0;
+  let prevStart = 0;
+  for (let i = 0; i < spec.chunkByteSizes.length; i++) {
+    if (spec.chunkPointCounts) {
+      ic.compress(prevCount | 0, spec.chunkPointCounts[i] | 0, 0);
+      prevCount = spec.chunkPointCounts[i];
+    }
+    ic.compress(prevStart | 0, spec.chunkByteSizes[i] | 0, 1);
+    prevStart = spec.chunkByteSizes[i];
+  }
+  const tableBody = enc.done();
+
+  const total = tableOffset + 8 + tableBody.length;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  const u8 = new Uint8Array(buf);
+
+  u8.set([0x4c, 0x41, 0x53, 0x46], 0); // 'LASF'
+  view.setUint8(24, 1);
+  view.setUint8(25, 2);
+  view.setUint16(94, LAZ_HEADER_SIZE, true);
+  view.setUint32(96, offsetToPointData, true);
+  view.setUint32(100, 1, true);
+  view.setUint8(104, 0x80 | (spec.pointFormat ?? 0));
+  view.setUint16(105, spec.recordLength ?? 20, true);
+  view.setUint32(107, spec.pointCount, true);
+  for (let axis = 0; axis < 3; axis++) {
+    view.setFloat64(131 + axis * 8, 0.001, true);
+    view.setFloat64(155 + axis * 8, 0, true);
+  }
+  for (let i = 0; i < 6; i++) view.setFloat64(179 + i * 8, i % 2 === 0 ? 100 : 0, true);
+
+  let c = LAZ_HEADER_SIZE;
+  view.setUint16(c, 0, true);
+  const userId = 'laszip encoded';
+  for (let i = 0; i < userId.length; i++) view.setUint8(c + 2 + i, userId.charCodeAt(i));
+  view.setUint16(c + 18, 22204, true);
+  view.setUint16(c + 20, LASZIP_PAYLOAD, true);
+  c += VLR_HEADER;
+  view.setUint16(c, spec.compressor, true);
+  view.setUint16(c + 2, 0, true);
+  view.setUint8(c + 4, 2);
+  view.setUint8(c + 5, 4);
+  view.setUint16(c + 6, 0, true);
+  view.setUint32(c + 8, 0, true);
+  view.setUint32(c + 12, spec.chunkSize, true);
+
+  view.setBigInt64(offsetToPointData, BigInt(tableOffset), true);
+  for (let i = chunksStart; i < tableOffset; i++) u8[i] = i & 0xff;
+
+  view.setUint32(tableOffset, 0, true);
+  view.setUint32(tableOffset + 4, spec.chunkByteSizes.length, true);
+  u8.set(tableBody, tableOffset + 8);
+  return buf;
+}
+
+// --- LAS fixture (uncompressed, with a controllable record length) ----------
+
+const LAS_HEADER_SIZE = 227;
+
+/** A minimal valid uncompressed LAS with `physicalPoints` records of zero bytes. */
+function buildLasFixture(opts: {
+  pointFormat: number;
+  recordLength: number;
+  declaredPointCount: number;
+  physicalPoints: number;
+}): ArrayBuffer {
+  const offsetToPointData = LAS_HEADER_SIZE;
+  const total = offsetToPointData + opts.physicalPoints * opts.recordLength;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  const u8 = new Uint8Array(buf);
+  u8.set([0x4c, 0x41, 0x53, 0x46], 0); // 'LASF'
+  view.setUint8(24, 1);
+  view.setUint8(25, 2); // version 1.2 → legacy uint32 count
+  view.setUint16(94, LAS_HEADER_SIZE, true);
+  view.setUint32(96, offsetToPointData, true);
+  view.setUint32(100, 0, true); // no VLRs
+  view.setUint8(104, opts.pointFormat);
+  view.setUint16(105, opts.recordLength, true);
+  view.setUint32(107, opts.declaredPointCount, true);
+  for (let axis = 0; axis < 3; axis++) {
+    view.setFloat64(131 + axis * 8, 0.001, true); // scale > 0
+    view.setFloat64(155 + axis * 8, 0, true); // offset
+  }
+  // max=100, min=0 on each axis (non-degenerate box)
+  view.setFloat64(179, 100, true); view.setFloat64(187, 0, true);
+  view.setFloat64(195, 100, true); view.setFloat64(203, 0, true);
+  view.setFloat64(211, 100, true); view.setFloat64(219, 0, true);
+  return buf;
+}
+
+const src = (buf: ArrayBuffer) => new ArrayBufferRangeSource(buf, 'fixture');
+
+// --- fake laz-perf for the COPC node case -----------------------------------
+
+/** Records whether any WASM allocation was attempted, so the test can prove the
+ *  budget refusal happens BEFORE laz-perf is touched. */
+function watchedLazPerf(): { module: LazPerfModule; mallocs: number[] } {
+  const mallocs: number[] = [];
+  const module = {
+    _malloc: (n: number) => {
+      mallocs.push(n);
+      return 1;
+    },
+    _free: () => {},
+    HEAPU8: new Uint8Array(16),
+    ChunkDecoder: class {
+      open(): void {}
+      getPoint(): void {}
+      delete(): void {}
+    },
+  } as unknown as LazPerfModule;
+  return { module, mallocs };
+}
+
+describe('heavyByteBudget — adversarial large-file memory suite', () => {
+  it('LAZ chunk claiming a huge point count is refused before allocation', async () => {
+    const range = new WatchedRangeSource(
+      src(
+        buildLazFixture({
+          compressor: 3,
+          chunkSize: 0xffffffff,
+          pointCount: 500_000_000,
+          chunkByteSizes: [5000],
+          chunkPointCounts: [500_000_000],
+        }),
+      ),
+    );
+    const t = await readLazChunkTable(range);
+    expect(t.supported).toBe(false);
+    // Refused on metadata alone: the largest read stayed tiny, no chunk payload
+    // and no `points × record` buffer was ever fetched or built.
+    expect(range.maxRead).toBeLessThan(64 * 1024);
+  });
+
+  it('LAZ chunk with a huge record length is refused on decoded bytes', async () => {
+    // A modest point count (under the point cap) but a 65535-byte record: the
+    // point cap alone would admit it, the decoded-byte cap refuses it.
+    const points = 100_000;
+    expect(withinDecodedByteBudget(points, 65535)).toBe(false);
+    const t = await readLazChunkTable(
+      src(
+        buildLazFixture({
+          compressor: 3,
+          chunkSize: 0xffffffff,
+          pointCount: points,
+          chunkByteSizes: [5000],
+          chunkPointCounts: [points],
+          recordLength: 65535,
+          pointFormat: 7,
+        }),
+      ),
+    );
+    expect(t.supported).toBe(false);
+    if (!t.supported) expect(t.reason).toContain('decode budget');
+  });
+
+  it('a 16M-chunk table is refused before the delta arrays are allocated', async () => {
+    const numChunks = 16_777_216;
+    expect(numChunks).toBeGreaterThan(MAX_CHUNK_TABLE_ENTRIES);
+    // Only the table head (8 bytes: version + count) needs to be present; the
+    // refusal fires on the count before any body read or Float64Array(numChunks).
+    const range = new WatchedRangeSource(
+      src(
+        buildLazFixture({
+          compressor: 2,
+          chunkSize: 250,
+          pointCount: 250,
+          chunkByteSizes: [64],
+          physicalGap: 64,
+        }),
+      ),
+    );
+    // Rewrite the declared chunk count in the fixture's table head to 16M.
+    const buf = await range.readRange(0, await range.size());
+    const view = new DataView(buf);
+    // Locate the table offset field and patch numChunks at tableOffset+4.
+    const offsetToPointData = LAZ_HEADER_SIZE + VLR_HEADER + LASZIP_PAYLOAD;
+    const tableOffset = Number(view.getBigInt64(offsetToPointData, true));
+    view.setUint32(tableOffset + 4, numChunks, true);
+    const patched = new WatchedRangeSource(src(buf));
+    const t = await readLazChunkTable(patched);
+    expect(t.supported).toBe(false);
+    if (!t.supported) expect(t.reason).toContain('sanity cap');
+    // The delta-array staging (numChunks × 16 bytes ≈ 256 MiB) was never read or
+    // allocated: no read approached even a megabyte.
+    expect(patched.maxRead).toBeLessThan(1024 * 1024);
+  });
+
+  it('four individually-valid chunks whose window decoded bytes exceed budget shrink the window', () => {
+    // Each chunk is a legal, sub-budget decode; four of them together are not.
+    const recordLength = 1000;
+    const perChunkPoints = Math.floor((MAX_DECODED_ALLOCATION_BYTES / recordLength) * 0.4);
+    expect(withinDecodedByteBudget(perChunkPoints, recordLength)).toBe(true);
+    const chunks: LazChunkRange[] = [];
+    let off = 0;
+    for (let i = 0; i < 4; i++) {
+      chunks.push({ byteOffset: off, byteLength: 1000, pointCount: perChunkPoints, firstPointIndex: i * perChunkPoints });
+      off += 1000;
+    }
+    // Without the decoded cap a window of 4 would stage 1.6× the budget at once;
+    // the planner takes at most 2 (0.4 + 0.4 = 0.8 ≤ 1, a third would be 1.2 > 1).
+    const plan = planChunkWindow(chunks, 0, 4, recordLength);
+    expect(plan.end).toBe(2);
+    // The aggregate decoded bytes of the taken window stay within budget.
+    const takenPoints = perChunkPoints * plan.end;
+    expect(withinDecodedByteBudget(takenPoints, recordLength)).toBe(true);
+  });
+
+  it('LAS record length 4096 and 65535 keep one batch read within the source ceiling', async () => {
+    for (const recordLength of [4096, 65535]) {
+      const range = new WatchedRangeSource(
+        src(buildLasFixture({ pointFormat: 0, recordLength, declaredPointCount: 5000, physicalPoints: 5000 })),
+      );
+      const opened = await openSlicedLas(range);
+      const iter = opened.batches();
+      await iter.next(); // read exactly one batch
+      expect(range.maxRead).toBeLessThanOrEqual(MAX_BATCH_SOURCE_BYTES);
+      expect(range.maxRead).toBeGreaterThan(0);
+      // Batch is at least one point and never reads over 16 MiB at this record.
+      expect(batchPointsForRecordLength(recordLength, 262_144)).toBeGreaterThanOrEqual(1);
+      expect(batchPointsForRecordLength(recordLength, 262_144) * recordLength).toBeLessThanOrEqual(
+        MAX_BATCH_SOURCE_BYTES,
+      );
+    }
+  });
+
+  it('100M identical XYZ collapsing to one logical tile fails closed as degenerate', async () => {
+    // The whole cloud shares one XYZ, so every point lands in one leaf key and one
+    // LOD-hash bucket — no depth subdivides it. A tiny tile budget makes the
+    // refusal cheap to prove without materialising 100M points.
+    const recordBytes = 12;
+    const perBatch = 1000;
+    const batches = 50; // 50k identical points
+    const source: PointSource = {
+      async *batches() {
+        for (let b = 0; b < batches; b++) {
+          const positions = new Float32Array(perBatch * 3); // all zero → identical XYZ
+          yield { positions, count: perBatch };
+        }
+      },
+    };
+    const store = memoryStore();
+    // maxTileBytes admits only ~2000 points at 12 bytes; the pile blows past it.
+    const maxTileBytes = 2000 * recordBytes;
+    await expect(
+      indexOutOfCore(source, store, { maxTileBytes, memoryBudgetBytes: 1 << 20 }),
+    ).rejects.toBeInstanceOf(DegenerateCloudError);
+    // No spilled tile ever exceeded the budget: the build refused rather than
+    // producing an oversized tile.
+    for (const key of await store.keys()) {
+      const bytes = await store.read(key);
+      expect(bytes.byteLength).toBeLessThanOrEqual(maxTileBytes);
+    }
+  });
+
+  it('COPC node with a low point count but a huge record length is refused before allocation', () => {
+    const { module, mallocs } = watchedLazPerf();
+    // A point count far under MAX_NODE_POINTS (50M), so the point cap admits it,
+    // but a 65535-byte record makes the decoded size ≈ 197 MB, over budget.
+    const overPoints = 3000;
+    const recordLength = 65535;
+    expect(overPoints * recordLength).toBeGreaterThan(MAX_DECODED_ALLOCATION_BYTES);
+    expect(withinDecodedByteBudget(overPoints, recordLength, MAX_DECODED_ALLOCATION_BYTES)).toBe(false);
+    // Give the guard a plausible compressed size so the count passes the count/byte
+    // validators and only the decoded-byte cap can refuse it.
+    const chunk = new ArrayBuffer(overPoints * recordLength);
+    expect(() =>
+      decompressChunk(module, chunk, {
+        pointDataRecordFormat: 7,
+        pointRecordLength: recordLength,
+        pointCount: overPoints,
+        scale: [1, 1, 1],
+        offset: [0, 0, 0],
+        renderOrigin: [0, 0, 0],
+      }),
+    ).toThrow(/decode budget/);
+    // The refusal happened before any WASM allocation.
+    expect(mallocs).toHaveLength(0);
+  });
+
+  it('a truncated tile is refused, never decoded as a sparse tile', () => {
+    const schema: TileSchema = { hasGps: false, hasRgb: false };
+    const recordBytes = tileRecordBytes(schema);
+    const full = new Uint8Array(10 * recordBytes);
+    // The hierarchy declares 10 points; only 5 records are present.
+    const half = full.subarray(0, 5 * recordBytes);
+    expect(() => decodeTile(half, schema, recordBytes, 10)).toThrow(TileTruncationError);
+    // An exact tile still decodes.
+    const exact = decodeTile(full, schema, recordBytes, 10);
+    expect(exact.pointCount).toBe(10);
+  });
+
+  it('a truncated source LAS carries declared-vs-loaded honesty to the manifest', async () => {
+    const declared = 10_000;
+    const physical = 4_000; // file physically holds fewer points than it declares
+    const range = src(buildLasFixture({ pointFormat: 0, recordLength: 20, declaredPointCount: declared, physicalPoints: physical }));
+    const opened = await openSlicedLas(range);
+    expect(opened.declaredPointCount).toBe(declared);
+    expect(opened.readablePointCount).toBe(physical);
+    expect(opened.complete).toBe(false);
+
+    const store = memoryStore();
+    const built = await buildTileStoreFromLas(range, store);
+    expect(built.reader.manifest.complete).toBe(false);
+    expect(built.reader.manifest.declaredPointCount).toBe(declared);
+    // The loaded count is the physical count, never the declared one — a truncated
+    // scan is not presented as a complete smaller scan.
+    expect(built.reader.manifest.pointCount).toBe(physical);
+    expect(built.reader.manifest.pointCount).toBeLessThan(built.reader.manifest.declaredPointCount!);
+  });
+
+  it('the tile budget constant bounds a leaf the reader would load whole', () => {
+    // Sanity: MAX_TILE_BYTES is the ceiling the degenerate guard enforces.
+    expect(MAX_TILE_BYTES).toBeGreaterThan(0);
+    expect(withinDecodedByteBudget(1, MAX_TILE_BYTES + 1, MAX_TILE_BYTES)).toBe(false);
+  });
+});

--- a/tests/tileChunkDecoder.test.ts
+++ b/tests/tileChunkDecoder.test.ts
@@ -106,7 +106,7 @@ describe('TileChunkDecoder', () => {
     expect(dc.rgbEightBit).toBeUndefined();
   });
 
-  it('honours an aborted signal and clamps a short tile', async () => {
+  it('honours an aborted signal and refuses a truncated tile', async () => {
     const n = 10;
     const schema: TileSchema = { hasGps: true, hasRgb: false };
     const { bytes, recordBytes } = packTile(rawCloud(n, schema), n, schema);
@@ -116,9 +116,12 @@ describe('TileChunkDecoder', () => {
     ctrl.abort();
     await expect(decoder.decode(bytes.buffer as ArrayBuffer, meta(n, recordBytes), ctrl.signal)).rejects.toThrow();
 
-    // A tile with only half its records present decodes just those, never past end.
+    // A tile with only half its records present is a corrupt store, not a smaller
+    // valid one: the hierarchy declares n points, so a tile short of n × recordBytes
+    // is refused as a fault rather than decoded as a sparse tile.
     const half = bytes.subarray(0, 5 * recordBytes);
-    const dc = await decoder.decode(half.slice().buffer as ArrayBuffer, meta(n, recordBytes));
-    expect(dc.pointCount).toBe(5);
+    await expect(
+      decoder.decode(half.slice().buffer as ArrayBuffer, meta(n, recordBytes)),
+    ).rejects.toThrow(/truncated or corrupt/);
   });
 });


### PR DESCRIPTION
## What

One shared decoded-byte budget for the heavy and streaming decode path,
plus the sites that now enforce it. Each reader used to size an allocation
from a point count or a structure count, never from decoded bytes at the
real record length, so a malformed input could force a multi-gigabyte
allocation before the out-of-core spill engaged.

## Policy module

`src/io/heavy/heavyByteBudget.ts` holds the ceilings and the helpers that
derive limits from a record length. `MAX_DECODED_ALLOCATION_BYTES` is 128
MiB, the figure the heavy path already treated as its staging budget.
`MAX_BATCH_SOURCE_BYTES` is 16 MiB. `MAX_CHUNK_TABLE_ENTRIES` and
`MAX_TILE_BYTES` derive from byte budgets rather than round numbers.

## Sites

lazChunkTable refuses a chunk over the decoded-byte budget and caps the
chunk-table entry count before allocating its delta arrays. chunkedLazSource
shrinks a window whose aggregate decoded bytes exceed budget; previewSampler
skips an over-budget chunk. slicedLasReader bounds a batch by the source-byte
ceiling and carries declared, readable, and complete flags to the manifest.
copcChunkDecompress refuses an over-budget node before allocation. oocIndexer
fails a degenerate cloud closed. decodeTile requires an exact tile length.

## Tests

`tests/heavyByteBudgetMemory.test.ts` adds a metadata-only adversarial suite:
huge point count, huge record length, an over-budget window, a 16M-chunk
table, LAS records of 4096 and 65535 bytes, coincident points, an over-budget
COPC node, a truncated tile, and a truncated source. The invariant is that no
read or allocation over budget is attempted before the refusal.
