### PR TITLE
Wire the out-of-core store janitor into the heavy open path

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -94,13 +94,6 @@
       "declaredIn": "docs/releases/RELEASE_NOTES_v0.6.6.md"
     },
     {
-      "path": "src/io/heavy/opfsStoreJanitor.ts",
-      "status": "staged",
-      "why": "A startup sweep that removes out-of-core temp stores (ooc-… and .partial) a crashed tab or a failed close-time removal left in OPFS. It is written and tested but not yet wired: no production module imports it, because the one call site is a startup hook in src/main.ts, which concurrent work owns. Only its own test reaches sweepAbandonedOocStores.",
-      "graduation": "src/main.ts calls runStartupOocJanitor once at startup, passing the set of store names live sessions own.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/geo/cursorReadout.ts",
       "status": "staged",
       "why": "The truth model for a persistent coordinate banner. Its own header states the gap it fills: a coordinate is visible only inside the Probe tool today. The banner was never built, so no UI module renders from this model.",

--- a/src/app/heavyLasExecutor.ts
+++ b/src/app/heavyLasExecutor.ts
@@ -36,6 +36,7 @@ import type { StreamingSource } from '../render/streaming/StreamingSource';
 import { LocalOocIndexerClient } from '../io/heavy/worker/localOocIndexerWorkerClient';
 import type { LocalOocPhase } from '../io/heavy/localOocBuild';
 import { readLazChunkTable } from '../io/heavy/lazChunkTable';
+import { sweepAbandonedOocStores } from '../io/heavy/opfsStoreJanitor';
 import { LocalFileRangeSource } from '../io/range/LocalFileRangeSource';
 import type { RangeSource } from '../io/range/RangeSource';
 import { LoadError } from '../io/loadErrors';
@@ -96,6 +97,12 @@ function heavyStoreName(file: File, uniqueId: string): string {
 }
 
 let openIdCounter = 0;
+
+// A crashed or force-closed session cannot delete its temporary store, so stale
+// `ooc-*` directories accumulate. The first heavy open of a session sweeps them
+// best-effort, keeping this open's own store and anything younger than the lease
+// threshold. It runs where OPFS-heavy usage actually happens rather than at boot.
+let janitorSwept = false;
 
 /**
  * A per-open id that keeps two concurrent opens on distinct store names. It is
@@ -162,6 +169,11 @@ export async function executeHeavyLasBuild(
 
   const root = await getOpfsRoot();
   if (root === null) return { status: 'unavailable', heavy: true, reason: 'no OPFS root' };
+
+  if (!janitorSwept) {
+    janitorSwept = true;
+    void sweepAbandonedOocStores(root, { ownedNames: new Set([storeName]) }).catch(() => {});
+  }
 
   // The disk guard. Sized from the declared point count and the record schema,
   // it refuses BEFORE any byte is written when the tile cache would not fit, or


### PR DESCRIPTION
Completes finding #16 from the memory-safety audit. The out-of-core store
janitor merged in #671 was implemented and tested but never called, so stores
left behind by a crashed or force-closed tab accumulated. This wires it into the
heavy open path: the first heavy open of a session sweeps stale ooc- and
.partial directories best-effort, keeping this open's own store and anything
younger than the six-hour lease. The trigger is heavy OPFS usage rather than
boot, and the call sits in the lazy executor chunk, so the eager shell and
main.ts are untouched. The janitor module leaves the unreachable register now
that production reaches it. Gates green including the reachability lint.
