### PR TITLE
Fix five profile, inspector, and loader defects

### DIFF
--- a/src/io/loadFile.ts
+++ b/src/io/loadFile.ts
@@ -336,6 +336,8 @@ function nonStreamingOverCeilingRefusal(
     return undefined;
   }
   const ceiling = memoryCeilingBytes(options.deviceMemoryGB, options.isMobile ?? false);
+  // Gate on raw file size by design: an ASCII/whole-file parse needs transient
+  // memory that exceeds the decoded size, so file size is the conservative bound.
   if (file.size <= ceiling) return undefined;
   return new LoadError(
     'memory-constraint',

--- a/src/io/loadPlan.ts
+++ b/src/io/loadPlan.ts
@@ -106,16 +106,6 @@ export interface LoadPlan {
    * than read whole. Optional for backward-compat, treat `undefined` as `false`.
    */
   buildThenStream?: boolean;
-  /**
-   * True when the file is an over-ceiling non-streaming format with NO bounded
-   * decode (PLY, PCD, PTX, PTS, XYZ, OBJ, GLB/GLTF, PNTS). Unlike LAS/LAZ
-   * (`buildThenStream`) and E57 (its own preflight plan), these have no way to
-   * decode within the ceiling, so the load must be REFUSED before the whole
-   * file is materialised — a warning that still proceeds crashes the tab. The
-   * loader turns this into a `memory-constraint` refusal with guidance to
-   * stream as COPC/EPT or convert. Optional — treat `undefined` as `false`.
-   */
-  refuseOverCeiling?: boolean;
 }
 
 /**
@@ -141,7 +131,8 @@ export const LARGE_STATIC_LAS_THRESHOLD_BYTES = 1024 * 1024 * 1024;
  * Formats with a bounded decode for an over-ceiling file: LAS/LAZ route to the
  * out-of-core tile build, and E57 has its own preflight verdict plus stride
  * plan. Any other format materialises the whole point set at parse time, so an
- * over-ceiling estimate for it is a hard refusal (see `refuseOverCeiling`).
+ * over-ceiling file for it is a hard refusal — enforced at the loader on raw
+ * file size (see `nonStreamingOverCeilingRefusal` in loadFile.ts).
  */
 export const BOUNDED_DECODE_FORMATS: ReadonlySet<SourceFormat> = new Set<SourceFormat>([
   'las',
@@ -553,16 +544,6 @@ export function planLoad(input: LoadPlanInput): LoadPlan {
   // fallback for a caller that does not act on this flag.
   const buildThenStream = (format === 'las' || format === 'laz') && mayExceedCeiling;
 
-  // Fail closed for a non-streaming format with no bounded decode. LAS/LAZ has
-  // the out-of-core build (`buildThenStream`) and E57 has its own preflight
-  // verdict and stride plan; both can survive an over-ceiling file. Everything
-  // else (PLY, PCD, PTX, PTS, XYZ, OBJ, GLB/GLTF, PNTS) materialises the whole
-  // point set at parse time with no bounded fallback, so an over-ceiling
-  // estimate means the decode cannot fit and must be refused, not merely warned
-  // about — a warning that lets the read proceed still takes the tab with it.
-  const refuseOverCeiling =
-    mayExceedCeiling && !BOUNDED_DECODE_FORMATS.has(format);
-
   return {
     mode: plan.mode,
     sourceCount,
@@ -574,7 +555,6 @@ export function planLoad(input: LoadPlanInput): LoadPlan {
     mayExceedCeiling,
     largeNonLasFormat,
     buildThenStream,
-    refuseOverCeiling,
   };
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3751,9 +3751,9 @@ void viewerLoaded.then(() => {
     containPanelWheel(rightRail);
     // Push the column below the measure toolbar whenever it is visible —
     // see wireMeasureBarClearance for why this is measured, not static CSS.
-    wireMeasureBarClearance(viewer.measureElements.hint, leftPanels);
+    stage.addTeardown(wireMeasureBarClearance(viewer.measureElements.hint, leftPanels));
     // P11 — keep the column above the real dock height, and add the one-tap rail collapse.
-    wireDockClearance(dock.dock, leftPanels);
+    stage.addTeardown(wireDockClearance(dock.dock, leftPanels));
     stage.addTeardown(wireRailToggle({
       overlay: stage.overlay,
       panels: [leftPanels],
@@ -3987,7 +3987,7 @@ void viewerLoaded.then(() => {
       // resolves. Wire the toolbar-overlap guard on the column up front (same as
       // the full app's ?measurements=1 path) so it holds regardless of order.
       const col = ensureBareLeftPanels();
-      wireMeasureBarClearance(viewer.measureElements.hint, col);
+      stage.addTeardown(wireMeasureBarClearance(viewer.measureElements.hint, col));
       void measureMount.ensure().then((p) => col.append(p.element));
     }
     if (embedConfig.forceAnnotations) {

--- a/src/render/InspectTool.ts
+++ b/src/render/InspectTool.ts
@@ -492,7 +492,7 @@ export class InspectTool {
           infoRow('Longitude', `${lon.toFixed(7)}°`),
         );
         if (typeof elev === 'number') {
-          rows.push(infoRow('Elevation', `${elev.toFixed(3)} m`));
+          rows.push(infoRow('Elevation', `${elev.toFixed(3)}${worldLabels.zUnit}`));
         }
       }
       // UTM grid — always shown when a geographic position exists.
@@ -517,7 +517,7 @@ export class InspectTool {
           infoRow('Northing', `${utm.northing.toFixed(3)} m`),
         );
         if (typeof utm.elevation === 'number') {
-          rows.push(infoRow('Elevation', `${utm.elevation.toFixed(3)} m`));
+          rows.push(infoRow('Elevation', `${utm.elevation.toFixed(3)}${worldLabels.zUnit}`));
         }
       }
     }

--- a/src/render/measure/civilProfileStats.ts
+++ b/src/render/measure/civilProfileStats.ts
@@ -77,7 +77,11 @@ export function computeCivilProfileStats(
 
   for (let i = 0; i < n; i++) {
     const h = samples[i].height;
-    const el = finite(h) ? h : null;
+    // A station with zero corridor returns is a coverage gap even when the
+    // sampler carried a finite height across it — the degenerate/vertical
+    // branch borrows an endpoint elevation with count 0. Honest coverage
+    // counts returns, so a count-0 station is a gap, never a covered station.
+    const el = finite(h) && samples[i].count !== 0 ? h : null;
     if (el != null) {
       hits++;
       if (firstHit < 0) firstHit = i;

--- a/src/render/measure/profilePdf.ts
+++ b/src/render/measure/profilePdf.ts
@@ -1290,7 +1290,11 @@ export async function buildProfilePdf(input: ProfilePdfInput): Promise<Uint8Arra
       span: 2,
     },
     { label: 'MEAN GRADE (%)', value: bare(formatGradePercent(stats.meanGrade)) },
-    { label: 'MAX GRADE (%)', value: bare(formatGradePercent(stats.maxGrade)) },
+    // Signed steepest grade: the panel, the callout, and this KPI must agree on
+    // sign for one profile. stats.maxGrade is an unsigned magnitude; intel.maxGrade
+    // is the signed steepest-section grade (same segment). The ratio/degrees row
+    // below stays magnitude on purpose.
+    { label: 'MAX GRADE (%)', value: bare(formatGradePercent(intel.maxGrade)) },
     { label: 'COVERAGE (%)', value: `${(stats.coverage * 100).toFixed(0)}` },
     { label: 'GAPS', value: `${gapCount}` },
     {

--- a/src/ui/panelChrome.ts
+++ b/src/ui/panelChrome.ts
@@ -33,7 +33,7 @@ import { applyClassicScrollbarClass } from './classicScrollbars';
  * slides as the window resizes without its own box changing), so a window
  * resize listener recomputes alongside the ResizeObserver.
  */
-export function wireMeasureBarClearance(bar: HTMLElement, column: HTMLElement): void {
+export function wireMeasureBarClearance(bar: HTMLElement, column: HTMLElement): () => void {
   const update = (): void => {
     const h = bar.offsetHeight; // 0 while .olv-hidden (display: none)
     if (h <= 0) { column.style.setProperty('--olv-measure-bar-clear', '0px'); return; }
@@ -46,17 +46,27 @@ export function wireMeasureBarClearance(bar: HTMLElement, column: HTMLElement): 
     // with the same rhythm as panel → panel.
     column.style.setProperty('--olv-measure-bar-clear', overlaps ? `${h + 8}px` : '0px');
   };
+  let observer: ResizeObserver | null = null;
   if (typeof ResizeObserver !== 'undefined') {
     try {
       const ro = new ResizeObserver(update);
       ro.observe(bar);
       ro.observe(column);
+      observer = ro;
     } catch {
       /* Static layout fallback — only ancient engines, overlap is cosmetic. */
     }
   }
-  if (typeof window !== 'undefined') window.addEventListener('resize', update);
+  const hasWindow = typeof window !== 'undefined';
+  if (hasWindow) window.addEventListener('resize', update);
   update();
+  // Without this the torn-down column left an observer watching a detached
+  // toolbar and a resize handler firing against it forever.
+  return () => {
+    observer?.disconnect();
+    observer = null;
+    if (hasWindow) window.removeEventListener('resize', update);
+  };
 }
 
 /**
@@ -67,20 +77,30 @@ export function wireMeasureBarClearance(bar: HTMLElement, column: HTMLElement): 
  * dock. Fallback 80px (the previous static reserve) keeps layout unchanged where
  * ResizeObserver is unavailable.
  */
-export function wireDockClearance(dock: HTMLElement, column: HTMLElement): void {
+export function wireDockClearance(dock: HTMLElement, column: HTMLElement): () => void {
   // The column's scroll affordance travels with it, so the composition root
   // wires the rail once rather than remembering two calls that must agree.
-  wireRailScrollAffordance(column, applyClassicScrollbarClass());
-  if (typeof ResizeObserver === 'undefined') return;
-  try {
-    const ro = new ResizeObserver(() => {
-      const h = dock.offsetHeight; // 0 while hidden (display: none)
-      column.style.setProperty('--olv-dock-clear', h > 0 ? `${h + 14 + 8}px` : '80px');
-    });
-    ro.observe(dock);
-  } catch {
-    /* Static 80px fallback — only ancient engines. */
+  const disposeRail = wireRailScrollAffordance(column, applyClassicScrollbarClass());
+  let observer: ResizeObserver | null = null;
+  if (typeof ResizeObserver !== 'undefined') {
+    try {
+      const ro = new ResizeObserver(() => {
+        const h = dock.offsetHeight; // 0 while hidden (display: none)
+        column.style.setProperty('--olv-dock-clear', h > 0 ? `${h + 14 + 8}px` : '80px');
+      });
+      ro.observe(dock);
+      observer = ro;
+    } catch {
+      /* Static 80px fallback — only ancient engines. */
+    }
   }
+  // Disposes both the dock observer and the rail affordance it captured, so a
+  // torn-down column leaves neither watching detached nodes.
+  return () => {
+    observer?.disconnect();
+    observer = null;
+    disposeRail();
+  };
 }
 
 /**

--- a/tests/civilProfileStats.test.ts
+++ b/tests/civilProfileStats.test.ts
@@ -52,6 +52,23 @@ describe('computeCivilProfileStats', () => {
     expect(stats.maxGrade).toBeNull();
     expect(stats.coverage).toBe(0);
   });
+
+  it('BUG 5 — a zero-return station is a gap, not 100% coverage', () => {
+    // The sampler's degenerate/vertical branch emits two coincident-in-plan
+    // stations with a FINITE endpoint height but count 0 — no corridor returns.
+    // Counting a finite height as covered reported coverage 2/2 = 100% over
+    // zero returns, so the PDF printed "Every station returned. No part is
+    // interpolated." beside a count column of 0. A count-0 station is a gap.
+    const degenerate: ProfileChartSample[] = [
+      { distance: 0, height: 12.5, count: 0 },
+      { distance: 0, height: 12.5, count: 0 },
+    ];
+    const stats = computeCivilProfileStats(degenerate);
+    expect(stats.coverage).not.toBe(1);
+    expect(stats.coverage).toBe(0);
+    expect(stats.stations[0].elevation).toBeNull();
+    expect(stats.stations[1].elevation).toBeNull();
+  });
 });
 
 describe('civil formatters', () => {

--- a/tests/inspectToolElevationUnit.test.ts
+++ b/tests/inspectToolElevationUnit.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Inspector elevation-row unit honesty.
+ *
+ * The Geographic and UTM groups printed their Elevation value with a hardcoded
+ * " m" suffix, while the value itself is the source Z carried through
+ * unconverted — so a scan whose vertical unit is feet (metre horizontal, foot
+ * height) showed the World Z row in feet and these Elevation rows in metres on
+ * the same card. The suffix must be the CRS-aware `worldCoordLabels(crs).zUnit`,
+ * the same one the World / Local Z rows already use.
+ *
+ * A recording DOM stub rather than jsdom (which this repo does not install),
+ * matching the panel suites — what matters is the string the row renders.
+ */
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import * as THREE from 'three/webgpu';
+import { InspectTool } from '../src/render/InspectTool';
+import { makePointInfo, worldCoordLabels } from '../src/render/pointInfo';
+import type { ResolvedCrs } from '../src/geo/CoordinateTypes';
+
+type Handler = (e: unknown) => void;
+
+/** A recording DOM node covering only the surface InspectTool touches. */
+class FakeEl {
+  readonly tagName: string;
+  private _classes = new Set<string>();
+  textContent = '';
+  title = '';
+  innerHTML = '';
+  readonly dataset: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly children: FakeEl[] = [];
+  parent: FakeEl | null = null;
+  private readonly attrs = new Map<string, string>();
+  private readonly handlers = new Map<string, Handler[]>();
+
+  constructor(tag: string) {
+    this.tagName = tag.toLowerCase();
+  }
+
+  set className(v: string) {
+    this._classes = new Set(String(v).split(/\s+/).filter(Boolean));
+  }
+  get className(): string {
+    return [...this._classes].join(' ');
+  }
+  get classList() {
+    const classes = this._classes;
+    return {
+      add: (c: string): void => void classes.add(c),
+      remove: (c: string): void => void classes.delete(c),
+      contains: (c: string): boolean => classes.has(c),
+      toggle: (c: string, force?: boolean): boolean => {
+        const want = force === undefined ? !classes.has(c) : force;
+        if (want) classes.add(c);
+        else classes.delete(c);
+        return want;
+      },
+    };
+  }
+
+  private _adopt(kid: unknown): FakeEl {
+    if (kid instanceof FakeEl) {
+      kid.parent = this;
+      return kid;
+    }
+    const t = new FakeEl('#text');
+    t.textContent = String(kid);
+    t.parent = this;
+    return t;
+  }
+  append(...kids: unknown[]): void {
+    for (const k of kids) this.children.push(this._adopt(k));
+  }
+  replaceChildren(...kids: unknown[]): void {
+    this.children.length = 0;
+    for (const k of kids) this.children.push(this._adopt(k));
+  }
+  remove(): void {}
+  setAttribute(n: string, v: string): void {
+    this.attrs.set(n, v);
+  }
+  getAttribute(n: string): string | null {
+    return this.attrs.get(n) ?? null;
+  }
+  addEventListener(type: string, fn: Handler): void {
+    const a = this.handlers.get(type) ?? [];
+    a.push(fn);
+    this.handlers.set(type, a);
+  }
+  removeEventListener(): void {}
+  focus(): void {}
+  blur(): void {}
+
+  private _matches(sel: string): boolean {
+    const parts = sel.split('.');
+    const tag = parts[0];
+    if (tag && this.tagName !== tag.toLowerCase()) return false;
+    for (const c of parts.slice(1)) if (!this._classes.has(c)) return false;
+    return true;
+  }
+  querySelector(sel: string): FakeEl | null {
+    for (const c of this.children) {
+      if (c._matches(sel)) return c;
+      const deep = c.querySelector(sel);
+      if (deep) return deep;
+    }
+    return null;
+  }
+  querySelectorAll(sel: string): FakeEl[] {
+    const out: FakeEl[] = [];
+    const walk = (n: FakeEl): void => {
+      for (const c of n.children) {
+        if (c._matches(sel)) out.push(c);
+        walk(c);
+      }
+    };
+    walk(this);
+    return out;
+  }
+}
+
+beforeAll(() => {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.document = {
+    createElement: (tag: string) => new FakeEl(tag),
+    createElementNS: (_ns: string, tag: string) => new FakeEl(tag),
+  };
+  g.HTMLInputElement = class HTMLInputElement {};
+  g.HTMLAnchorElement = class HTMLAnchorElement {};
+});
+
+/** Geographic horizontal frame with a DECLARED foot height. */
+const geoFootHeight: ResolvedCrs = {
+  kind: 'geographic',
+  name: 'WGS 84 + foot height',
+  epsg: 4326,
+  linearUnit: 'metre',
+  linearUnitToMetres: 1,
+  verticalUnitToMetres: 0.3048, // international foot
+  source: 'las-vlr',
+  confidence: 'high',
+  userConfirmed: false,
+};
+
+function elevationRowValues(card: FakeEl): string[] {
+  const out: string[] = [];
+  for (const row of card.querySelectorAll('.olv-inspect-row')) {
+    const label = row.querySelector('.olv-inspect-row-label')?.textContent ?? '';
+    const value = row.querySelector('.olv-inspect-row-value')?.textContent ?? '';
+    if (label === 'Elevation') out.push(value);
+  }
+  return out;
+}
+
+describe('InspectTool elevation-row unit', () => {
+  it('renders the Elevation suffix from worldLabels.zUnit, never a hardcoded metre', () => {
+    const camera = {} as unknown as THREE.PerspectiveCamera;
+    const canvas = new FakeEl('canvas') as unknown as HTMLCanvasElement;
+    const tool = new InspectTool(camera, canvas, { onExit: vi.fn() });
+
+    // A geographic pick: world X = lon, Y = lat (inside the UTM latitude band),
+    // Z = a foot height. No origin shift, so world == the local values.
+    const info = makePointInfo({
+      layer: 'survey.laz',
+      index: 3,
+      local: [-100, 40, 123.456],
+      origin: [0, 0, 0],
+      distance: 0,
+      geographicHorizontal: true,
+      intensity: null,
+      classification: null,
+      rgb: null,
+    });
+    (tool as unknown as { _selected: unknown })._selected = {
+      info,
+      world: new THREE.Vector3(-100, 40, 123.456),
+    };
+
+    // Triggers a card repaint with the new context.
+    tool.setCoordinateContext({ crs: geoFootHeight });
+
+    const zUnit = worldCoordLabels(geoFootHeight).zUnit;
+    expect(zUnit).toBe(' ft');
+
+    const elevValues = elevationRowValues(tool.card as unknown as FakeEl);
+    // The UTM group's Elevation row exists and carries the CRS-aware unit.
+    expect(elevValues.length).toBeGreaterThan(0);
+    for (const v of elevValues) {
+      expect(v.endsWith(zUnit)).toBe(true);
+      expect(v.endsWith(' m')).toBe(false);
+    }
+  });
+});

--- a/tests/loadPlanNonLas.test.ts
+++ b/tests/loadPlanNonLas.test.ts
@@ -89,42 +89,36 @@ describe('LoadPlan.largeNonLasFormat — pre-decode warning', () => {
   });
 });
 
-describe('LoadPlan.refuseOverCeiling — fail closed for unbounded formats', () => {
+describe('LoadPlan over-ceiling routing for unbounded formats', () => {
   // Well past the 1.5 GB desktop fallback ceiling, so fixed cost alone exceeds
   // it and no point-budget reshape can bring the estimate down.
   const OVER = 4_000_000_000;
 
-  it('refuses an over-ceiling PLY — no bounded decode exists for it', () => {
+  it('flags an over-ceiling PLY and does NOT route it to the out-of-core build', () => {
     const plan = planLoad(input({ fileBytes: OVER, sourceCount: 200_000_000, format: 'ply' }));
     expect(plan.mayExceedCeiling).toBe(true);
-    expect(plan.refuseOverCeiling).toBe(true);
     // It is NOT routed to the out-of-core build — that path is LAS/LAZ only.
     expect(plan.buildThenStream).toBeFalsy();
   });
 
-  it('refuses every unbounded non-streaming format over the ceiling', () => {
+  it('flags every unbounded non-streaming format over the ceiling', () => {
     for (const fmt of ['ply', 'pcd', 'pts', 'ptx', 'obj', 'glb', 'xyz'] as const) {
       const plan = planLoad(input({ fileBytes: OVER, sourceCount: 200_000_000, format: fmt }));
-      expect(plan.refuseOverCeiling).toBe(true);
+      expect(plan.mayExceedCeiling).toBe(true);
+      expect(plan.buildThenStream).toBeFalsy();
     }
   });
 
-  it('does NOT refuse LAS/LAZ — they route to the out-of-core build instead', () => {
+  it('routes LAS/LAZ to the out-of-core build instead of flagging a refusal', () => {
     for (const fmt of ['las', 'laz'] as const) {
       const plan = planLoad(input({ fileBytes: OVER, sourceCount: 200_000_000, format: fmt }));
-      expect(plan.refuseOverCeiling).toBe(false);
       expect(plan.buildThenStream).toBe(true);
     }
   });
 
-  it('does NOT refuse E57 here — it has its own preflight verdict and stride plan', () => {
-    const plan = planLoad(input({ fileBytes: OVER, sourceCount: 200_000_000, format: 'e57' }));
-    expect(plan.refuseOverCeiling).toBe(false);
-  });
-
-  it('is false when the file fits under the ceiling', () => {
+  it('does not over-flag when the file fits under the ceiling', () => {
     const plan = planLoad(input({ fileBytes: 10_000_000, sourceCount: 100_000, format: 'ply' }));
     expect(plan.mayExceedCeiling).toBe(false);
-    expect(plan.refuseOverCeiling).toBe(false);
+    expect(plan.buildThenStream).toBeFalsy();
   });
 });

--- a/tests/panelClearanceTeardown.test.ts
+++ b/tests/panelClearanceTeardown.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `wireMeasureBarClearance` and `wireDockClearance` each owned observers (and,
+ * for the measure bar, a window `resize` handler) but returned nothing, so a
+ * torn-down column left them running against detached nodes. `wireDockClearance`
+ * additionally discarded the `wireRailScrollAffordance` disposer it created.
+ *
+ * These assertions pin the disposer contract the sibling `wireRailToggle` and
+ * `wireRailScrollAffordance` already hold: every registration is matched by a
+ * removal. Recording stubs rather than jsdom, matching the other panel suites —
+ * what matters is that a disconnect answers every observe and a removeEventListener
+ * answers every addEventListener.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { wireMeasureBarClearance, wireDockClearance } from '../src/ui/panelChrome';
+
+interface SpyObserver {
+  observe: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+let observers: SpyObserver[];
+
+class SpyResizeObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  constructor() {
+    observers.push(this);
+  }
+}
+class SpyMutationObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  constructor() {
+    observers.push(this);
+  }
+}
+
+function makeEl(): HTMLElement {
+  const classes = new Set<string>();
+  return {
+    offsetHeight: 40,
+    scrollHeight: 1200,
+    clientHeight: 400,
+    getBoundingClientRect: () => ({ left: 0, right: 100, top: 0, bottom: 100 }),
+    style: { setProperty: (): void => {} },
+    classList: {
+      toggle: (n: string, on?: boolean): void => void (on ? classes.add(n) : classes.delete(n)),
+      add: (n: string): void => void classes.add(n),
+      contains: (n: string): boolean => classes.has(n),
+    },
+  } as unknown as HTMLElement;
+}
+
+const saved = {
+  resize: globalThis.ResizeObserver,
+  mutation: globalThis.MutationObserver,
+  window: (globalThis as { window?: unknown }).window,
+  document: (globalThis as { document?: unknown }).document,
+};
+
+let removeResize: ReturnType<typeof vi.fn>;
+let addResize: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  observers = [];
+  globalThis.ResizeObserver = SpyResizeObserver as unknown as typeof ResizeObserver;
+  globalThis.MutationObserver = SpyMutationObserver as unknown as typeof MutationObserver;
+  addResize = vi.fn();
+  removeResize = vi.fn();
+  (globalThis as { window?: unknown }).window = {
+    addEventListener: addResize,
+    removeEventListener: removeResize,
+  };
+  // Minimal document so applyClassicScrollbarClass measures a classic (>0)
+  // scrollbar and the rail affordance actually attaches observers.
+  (globalThis as { document?: unknown }).document = {
+    createElement: () => ({
+      style: { cssText: '' },
+      offsetWidth: 15,
+      clientWidth: 0,
+      remove: (): void => {},
+    }),
+    body: { appendChild: (): void => {} },
+    documentElement: { classList: { toggle: (): void => {} } },
+  };
+});
+
+afterEach(() => {
+  globalThis.ResizeObserver = saved.resize;
+  globalThis.MutationObserver = saved.mutation;
+  (globalThis as { window?: unknown }).window = saved.window;
+  (globalThis as { document?: unknown }).document = saved.document;
+});
+
+describe('wireMeasureBarClearance teardown', () => {
+  it('returns a disposer that disconnects its observer and drops the resize listener', () => {
+    const dispose = wireMeasureBarClearance(makeEl(), makeEl());
+    expect(typeof dispose).toBe('function');
+    expect(observers).toHaveLength(1);
+    expect(addResize).toHaveBeenCalledTimes(1);
+
+    dispose();
+    expect(observers[0].disconnect).toHaveBeenCalledTimes(1);
+    expect(removeResize).toHaveBeenCalledTimes(1);
+    expect(removeResize.mock.calls[0][0]).toBe('resize');
+  });
+});
+
+describe('wireDockClearance teardown', () => {
+  it('returns a disposer that disconnects the dock observer AND the rail affordance', () => {
+    const dispose = wireDockClearance(makeEl(), makeEl());
+    expect(typeof dispose).toBe('function');
+    // Rail affordance (classic scrollbars) attaches a ResizeObserver + a
+    // MutationObserver; the dock clearance attaches its own ResizeObserver.
+    expect(observers).toHaveLength(3);
+
+    dispose();
+    for (const o of observers) expect(o.disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/profilePdf.test.ts
+++ b/tests/profilePdf.test.ts
@@ -17,6 +17,7 @@ import {
   profileSummaryRows,
   scaleProfileSamples,
 } from '../src/render/measure/profileSummary';
+import { computeCivilProfileStats } from '../src/render/measure/civilProfileStats';
 import {
   buildDerivedSurfaceLegend,
   type DerivedSurfaceSource,
@@ -805,5 +806,42 @@ describe('profile sheet: the ground under the section', () => {
     for (let i = 1; i < xs.length; i++) widest = Math.max(widest, xs[i] - xs[i - 1]);
     const span = xs[xs.length - 1] - xs[0];
     expect(widest / span).toBeGreaterThan(0.4);
+  });
+});
+
+/**
+ * BUG 1 — the KPI band's `MAX GRADE (%)` used `stats.maxGrade`, an unsigned
+ * magnitude, while the on-screen panel and the sheet's steepest-range callout
+ * print the SIGNED steepest grade (`intel.maxGrade`). A descending profile then
+ * read "-70.00%" on screen and in the callout but "70.00" in the KPI on the same
+ * sheet. The signed steepest grade is the single source of truth.
+ */
+describe('BUG 1 — signed MAX GRADE KPI', () => {
+  // A clear steepest DESCENDING segment (-0.7) distinct from the mean (-0.3).
+  const descending: ProfileChartSample[] = [
+    { distance: 0, height: 10 },
+    { distance: 10, height: 9 },
+    { distance: 20, height: 2 },
+    { distance: 30, height: 1 },
+  ];
+
+  it('the civil magnitude and the signed summary grade diverge in sign', () => {
+    expect(computeCivilProfileStats(descending).maxGrade).toBeCloseTo(0.7, 10);
+    expect(computeProfileSummary(descending).maxGrade).toBeCloseTo(-0.7, 10);
+  });
+
+  it('draws the KPI percent SIGNED, matching the callout (no unsigned magnitude)', async () => {
+    const bytes = await buildProfilePdf({
+      name: 'Descending',
+      samples: descending,
+      generatedAt: FIXED_DATE,
+    });
+    const text = drawnPdfText(bytes);
+    const total = (text.match(/70\.00/g) ?? []).length;
+    const signed = (text.match(/-70\.00/g) ?? []).length;
+    // The KPI cell (bare, no % sign) plus the signed callout both carry 70.00;
+    // every one of them must be signed. Pre-fix the KPI leaked an unsigned copy.
+    expect(total).toBeGreaterThan(0);
+    expect(signed).toBe(total);
   });
 });


### PR DESCRIPTION
Fixes five validated defects, each with a regression test.

The profile PDF KPI band printed max grade as an unsigned magnitude while the
panel and the steepest-range callout printed it signed, so a descending
profile contradicted itself on one sheet. The KPI now reads the signed
steepest grade; ratio and degrees stay magnitude. The inspector's Geographic
and UTM elevation rows hardcoded a metre suffix over a source Z that can be
feet, and now use the CRS-aware vertical unit. The measure-bar and dock
clearance wiring returned no disposer, leaking a ResizeObserver and a resize
handler; both now return a teardown the call sites register.

A degenerate profile counted zero-return stations as full coverage; a
count-zero station is now a gap. The dead refuseOverCeiling field was removed.
