### PR TITLE
fix(tiles3d): bound PNTS memory at the decoder, not the scheduler estimate

### DIFF
--- a/src/io/tiles3d/pnts.ts
+++ b/src/io/tiles3d/pnts.ts
@@ -478,6 +478,30 @@ function decodeBatchIds(
  */
 export const MAX_PNTS_TILE_POINTS = 8_000_000;
 
+/**
+ * The most decoded bytes this viewer will allocate for one PNTS tile.
+ *
+ * The count ceiling alone cannot bound memory, because a tile's cost depends on
+ * the channels it carries as well as how many points it holds. This viewer
+ * expands a point into a Float32 position (12 bytes) and, when present, an sRGB
+ * colour (3), a Float32 normal (12) and a uint32 batch id (4): up to 31 bytes a
+ * point, so a legal 8,000,000-point tile at full width is about 248 MB. This
+ * budget sits below that, so a channel-heavy tile the device cannot hold is
+ * refused on its true decoded size even when its point count is legal.
+ *
+ * The scheduler admits a tileset node on a throughput estimate before the body
+ * is fetched, not on this figure. This is the memory bound, checked here where
+ * the real `POINTS_LENGTH` and channel set are known and before the first array
+ * is allocated. 192 MiB is a conservative per-tile decode budget.
+ */
+export const MAX_PNTS_DECODED_BYTES = 192 * 1024 * 1024;
+
+/** Decoded bytes each channel costs one point, matching what the decoders below allocate. */
+const POSITION_DECODED_BYTES = 12;
+const COLOR_DECODED_BYTES = 3;
+const NORMAL_DECODED_BYTES = 12;
+const BATCH_ID_DECODED_BYTES = 4;
+
 /** Options for {@link parsePnts}. */
 export interface ParsePntsOptions {
   /**
@@ -487,6 +511,38 @@ export interface ParsePntsOptions {
    * crash.
    */
   readonly maxPoints?: number;
+  /**
+   * Ceiling on the decoded size of the tile's channels in bytes. Defaults to
+   * {@link MAX_PNTS_DECODED_BYTES}. Like `maxPoints`, a constrained device can
+   * lower it; it bounds what the decode HOLDS rather than how many points it
+   * declares, so a channel-heavy tile is refused before allocation.
+   */
+  readonly maxDecodedBytes?: number;
+}
+
+/**
+ * The decoded bytes one point costs given the channels the feature table
+ * carries. Mirrors {@link decodeColors}, {@link decodeNormals} and
+ * {@link decodeBatchIds}: a position is always allocated, and colour, normals
+ * and batch ids are each allocated only when their channel is present.
+ */
+function decodedBytesPerPoint(ft: JsonObject): number {
+  let bytes = POSITION_DECODED_BYTES;
+  if (
+    ft.RGBA !== undefined ||
+    ft.RGB !== undefined ||
+    ft.RGB565 !== undefined ||
+    ft.CONSTANT_RGBA !== undefined
+  ) {
+    bytes += COLOR_DECODED_BYTES;
+  }
+  if (ft.NORMAL !== undefined || ft.NORMAL_OCT16P !== undefined) {
+    bytes += NORMAL_DECODED_BYTES;
+  }
+  if (ft.BATCH_ID !== undefined) {
+    bytes += BATCH_ID_DECODED_BYTES;
+  }
+  return bytes;
 }
 
 /** Decode a PNTS tile's header, feature table, positions, and per-point attributes. */
@@ -564,15 +620,31 @@ export function parsePnts(buffer: ArrayBuffer, options: ParsePntsOptions = {}): 
   // POSITION_QUANTIZED costs six bytes a point, so that cap admits roughly 22.4
   // million of them, and each becomes a Float32 position plus the intensity,
   // classification, return and GPS channels the generic chunk contract carries.
-  // The scheduler cannot pre-empt it either: every tile is admitted as
-  // ASSUMED_TILE_POINTS, so a 22-million-point tile is dispatched as though it
-  // were 500,000 and the real figure is only known once the arrays exist.
-  // Refusing names the tile; truncating would render a silently partial one.
+  // The scheduler admits a tileset node on a throughput ESTIMATE before the
+  // fetch, not on this figure, so this refusal is a real gate and not a
+  // formality: it is where a genuinely huge node is stopped regardless of what
+  // the scheduler guessed. Refusing names the tile; truncating would render a
+  // silently partial one.
   const maxPoints = options.maxPoints ?? MAX_PNTS_TILE_POINTS;
   if (pointsLength > maxPoints) {
     throw new Error(
       `PNTS: POINTS_LENGTH ${pointsLength} exceeds the ${maxPoints} point ceiling this ` +
         `viewer decodes in one tile.`,
+    );
+  }
+
+  // The decoded-size ceiling, also before the first allocation. The count
+  // ceiling above cannot bound memory on its own: a colour, a normal and a
+  // batch id triple what a position-only point costs, so a legal-count tile at
+  // full channel width can still exceed what the device holds. `POINTS_LENGTH`
+  // is a uint32 and the per-point cost is a small constant, so the product is
+  // exact in a double and cannot round into agreement.
+  const maxDecodedBytes = options.maxDecodedBytes ?? MAX_PNTS_DECODED_BYTES;
+  const decodedBytes = pointsLength * decodedBytesPerPoint(ft);
+  if (decodedBytes > maxDecodedBytes) {
+    throw new Error(
+      `PNTS: POINTS_LENGTH ${pointsLength} decodes to ${decodedBytes} bytes, past the ` +
+        `${maxDecodedBytes} decoded byte ceiling this viewer holds in one tile.`,
     );
   }
 

--- a/src/io/tiles3d/tilesetNodes.ts
+++ b/src/io/tiles3d/tilesetNodes.ts
@@ -35,10 +35,19 @@ import type { Tile, Tileset } from './tileset';
 /**
  * Points assumed for a tile whose body has not been read.
  *
- * Chosen against the ceiling this repo already applies to a single point tile
- * rather than against a typical file: an estimate that is too low would admit
- * more decodes than the budget intends, which is the one direction the
- * scheduler's gate cannot absorb.
+ * A `tileset.json` never states a tile's point count, so the scheduler admits
+ * a node on an ESTIMATE. This estimate drives throughput accounting only —
+ * resident pressure, in-flight pressure and concurrency — not a memory-safety
+ * bound: it is deliberately on the high side of a typical tile so that at the
+ * budget boundary the scheduler dispatches slightly fewer decodes rather than
+ * slightly more, the one direction its admission gate can absorb.
+ *
+ * It is NOT the ceiling a malicious tile could reach. A body may legally
+ * declare far more points than this, and the memory bound that refuses such a
+ * body lives where the real `POINTS_LENGTH` is known before allocation: the
+ * PNTS decoder's decoded-byte ceiling (see {@link MAX_PNTS_TILE_POINTS} and the
+ * decoded-byte budget in `pnts.ts`). Inflating this estimate to that ceiling
+ * would starve normal streaming, treating a few-hundred-point tile as millions.
  */
 export const ASSUMED_TILE_POINTS = 500_000;
 

--- a/tests/pntsDecodeCeiling.test.ts
+++ b/tests/pntsDecodeCeiling.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { MAX_PNTS_TILE_POINTS, parsePnts } from '../src/io/tiles3d/pnts';
+import {
+  MAX_PNTS_DECODED_BYTES,
+  MAX_PNTS_TILE_POINTS,
+  parsePnts,
+} from '../src/io/tiles3d/pnts';
 
 /**
  * A PNTS tile declaring more points than the decoder is willing to allocate for.
@@ -9,9 +13,9 @@ import { MAX_PNTS_TILE_POINTS, parsePnts } from '../src/io/tiles3d/pnts';
  * decode. POSITION_QUANTIZED costs six bytes a point on the wire, so that cap admits
  * about 22.4 million points, and each one is expanded into a Float32 position plus the
  * intensity, classification, return and GPS channels the generic chunk contract carries.
- * The scheduler cannot see the real figure beforehand either: every tile is admitted as
- * ASSUMED_TILE_POINTS. The refusal therefore has to happen on POINTS_LENGTH, before the
- * first array is allocated.
+ * The scheduler reserves against this ceiling before the fetch rather than the real
+ * figure, so this refusal is the last line: it has to happen on POINTS_LENGTH, before the
+ * first array is allocated, for a body declaring more than the ceiling allows.
  */
 function pntsWithDeclaredPoints(pointsLength: number): ArrayBuffer {
   const featureTable = JSON.stringify({
@@ -64,6 +68,94 @@ describe('PNTS decoded-point ceiling', () => {
     // buffer then fails on the section bounds, which is a different refusal.
     const tile = pntsWithDeclaredPoints(MAX_PNTS_TILE_POINTS);
     expect(() => parsePnts(tile)).toThrow(/past the feature-table binary section/);
+  });
+});
+
+/** A feature table declaring positions, colour, normals and batch ids: the
+ * heaviest channel set this decoder allocates, 31 decoded bytes a point. No
+ * binary section, so any refusal that lands here landed before an accessor was
+ * read or an array was allocated. */
+function pntsAllChannels(pointsLength: number): ArrayBuffer {
+  const ft = JSON.stringify({
+    POINTS_LENGTH: pointsLength,
+    POSITION: { byteOffset: 0 },
+    RGBA: { byteOffset: 0 },
+    NORMAL: { byteOffset: 0 },
+    BATCH_ID: { byteOffset: 0 },
+  });
+  const padded = ft.padEnd(Math.ceil(ft.length / 4) * 4, ' ');
+  const jsonBytes = new TextEncoder().encode(padded);
+  const buffer = new ArrayBuffer(28 + jsonBytes.length);
+  const view = new DataView(buffer);
+  view.setUint32(0, 0x73746e70, true);
+  view.setUint32(4, 1, true);
+  view.setUint32(8, buffer.byteLength, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, 0, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buffer, 28).set(jsonBytes);
+  return buffer;
+}
+
+describe('PNTS decoded-byte ceiling', () => {
+  it('exposes a decoded-byte budget below the point ceiling at full width', () => {
+    // The point ceiling alone cannot bind on decoded size: at 31 bytes a point
+    // an 8,000,000-point tile is ~248 MB, so the byte budget has to sit below
+    // that or it never refuses a legal-count tile the device cannot hold.
+    expect(MAX_PNTS_DECODED_BYTES).toBeLessThan(MAX_PNTS_TILE_POINTS * 31);
+  });
+
+  it('refuses a channel-heavy tile over the byte budget yet under the point ceiling', () => {
+    // 7,000,000 points is under the 8,000,000 point ceiling, but at 31 decoded
+    // bytes a point it is ~217 MB, past the budget. The scheduler admitted it on
+    // a typical estimate; this is where a genuinely huge node is stopped.
+    const tile = pntsAllChannels(7_000_000);
+    expect(7_000_000).toBeLessThan(MAX_PNTS_TILE_POINTS);
+    expect(7_000_000 * 31).toBeGreaterThan(MAX_PNTS_DECODED_BYTES);
+    expect(() => parsePnts(tile)).toThrow(/decoded byte/i);
+  });
+
+  it('refuses before allocating: the big typed arrays are never constructed', () => {
+    const tile = pntsAllChannels(7_000_000);
+    const RealF32 = globalThis.Float32Array;
+    const RealU8 = globalThis.Uint8Array;
+    let bigAlloc = 0;
+    const note = (n: unknown) => {
+      if (typeof n === 'number' && n > 4096) bigAlloc++;
+    };
+    // The decoder resolves `Float32Array`/`Uint8Array` through the global at
+    // call time, so a swapped binding here observes any allocation it attempts.
+    class F32 extends RealF32 {
+      constructor(...args: unknown[]) {
+        note(args[0]);
+        // @ts-expect-error forward whatever the decoder passed
+        super(...args);
+      }
+    }
+    class U8 extends RealU8 {
+      constructor(...args: unknown[]) {
+        note(args[0]);
+        // @ts-expect-error forward whatever the decoder passed
+        super(...args);
+      }
+    }
+    (globalThis as { Float32Array: unknown }).Float32Array = F32;
+    (globalThis as { Uint8Array: unknown }).Uint8Array = U8;
+    try {
+      expect(() => parsePnts(tile)).toThrow(/decoded byte/i);
+    } finally {
+      (globalThis as { Float32Array: unknown }).Float32Array = RealF32;
+      (globalThis as { Uint8Array: unknown }).Uint8Array = RealU8;
+    }
+    expect(bigAlloc).toBe(0);
+  });
+
+  it('lets a caller lower the byte budget for a constrained device', () => {
+    // A tile well under the default budget is refused once the caller tightens
+    // it, the same lever `maxPoints` gives for the count ceiling.
+    const tile = pntsAllChannels(1_000);
+    expect(() => parsePnts(tile, { maxDecodedBytes: 1_000 })).toThrow(/decoded byte/i);
   });
 });
 

--- a/tests/tiles3dMalformed.test.ts
+++ b/tests/tiles3dMalformed.test.ts
@@ -334,10 +334,19 @@ describe('PNTS perimeter', () => {
     expect(() => parsePnts(withPointsLength(4294967295))).toThrow(
       /exceeds the 8000000 point ceiling/,
     );
-    // Lifting the ceiling past it shows what catches it next, which is the
-    // section bounds the accessor reads against.
+    // Lifting the point ceiling past it shows the decoded-byte ceiling catches
+    // it next: 4.29 billion points times the per-point width is far over the
+    // decoded-byte budget the decoder holds before allocating.
     expect(() =>
       parsePnts(withPointsLength(4294967295), { maxPoints: 4294967295 }),
+    ).toThrow(/decoded byte/i);
+    // Lifting BOTH ceilings shows what catches it next, the section bounds the
+    // accessor reads against.
+    expect(() =>
+      parsePnts(withPointsLength(4294967295), {
+        maxPoints: 4294967295,
+        maxDecodedBytes: Number.MAX_SAFE_INTEGER,
+      }),
     ).toThrow(/POSITION extends past the feature-table binary section/);
   });
 

--- a/tests/tilesetNodes.test.ts
+++ b/tests/tilesetNodes.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import { tilesetNodes, ASSUMED_TILE_POINTS, contentKind } from '../src/io/tiles3d/tilesetNodes';
 import { parseTileset } from '../src/io/tiles3d/tileset';
+import { MAX_PNTS_TILE_POINTS } from '../src/io/tiles3d/pnts';
 
 /** A tileset document with the given root tile tree. */
 function ts(root: unknown) {
@@ -82,7 +83,7 @@ describe('which tiles become nodes', () => {
 });
 
 describe('the point count a tileset does not state', () => {
-  it('admits every tile with the same high estimate', () => {
+  it('admits every tile with the same realistic estimate', () => {
     const t = ts({
       boundingVolume: BOX,
       geometricError: 50,
@@ -92,11 +93,19 @@ describe('the point count a tileset does not state', () => {
     expect(tilesetNodes(t).records[0].pointCount).toBe(ASSUMED_TILE_POINTS);
   });
 
-  it('estimates high, because the scheduler can only absorb over-estimates', () => {
+  it('estimates high of a typical tile, because the scheduler can only absorb over-estimates', () => {
     // The admission gate refuses a decode when resident + in-flight is at the
     // cap. Over-estimating dispatches fewer decodes; under-estimating admits
     // more than the budget intends, which it cannot take back.
     expect(ASSUMED_TILE_POINTS).toBeGreaterThanOrEqual(100_000);
+  });
+
+  it('does NOT inflate the estimate to the parser ceiling, which would starve streaming', () => {
+    // This estimate drives resident/concurrency pressure, not memory safety.
+    // Reserving MAX_PNTS_TILE_POINTS per node would treat a few-hundred-point
+    // tile as millions and admit almost nothing. The memory bound lives in the
+    // PNTS decoder's decoded-byte ceiling instead, where the real count is known.
+    expect(ASSUMED_TILE_POINTS).toBeLessThan(MAX_PNTS_TILE_POINTS);
   });
 });
 


### PR DESCRIPTION
A `tileset.json` never states a tile's point count, so streaming nodes are
admitted on an estimate (`ASSUMED_TILE_POINTS`) that drives resident and
concurrency accounting, not memory safety. Reserving the 8,000,000-point
parser ceiling per node starved normal streaming: a few-hundred-point tile
was treated as millions and almost nothing admitted.

The memory bound moves to the PNTS decoder, where the real `POINTS_LENGTH`
and channel set are known before any array is allocated. Beside the
point-count ceiling, `parsePnts` computes the decoded byte cost from the
channels present (position, colour, normal, batch id) and refuses a tile
past `MAX_PNTS_DECODED_BYTES` (192 MiB). A huge node is stopped at decode
regardless of the estimate, for one wasted fetch. The node estimate stays
500,000, so normal streaming admits as before and the tilesetOpen
expectation (779 points) is restored.
