### PR TITLE
Share one coverage predicate across profile summary and civil stats

### DIFF
--- a/src/render/measure/civilProfileStats.ts
+++ b/src/render/measure/civilProfileStats.ts
@@ -59,8 +59,27 @@ export interface CivilProfileStats {
   readonly stations: ProfileStation[];
 }
 
-const finite = (n: number | null | undefined): n is number =>
-  typeof n === 'number' && Number.isFinite(n);
+/**
+ * The ONE coverage rule every profile consumer decides "covered vs gap" from —
+ * civil stats, the summary/max-grade, the CSV/station table and the PDF all
+ * import THIS so the same station can never be a gap in one place and covered
+ * in another.
+ *
+ * A station is covered iff its height is finite AND the corridor returned at
+ * least one point. `count === 0` is the degenerate/vertical sampler branch
+ * borrowing an endpoint elevation across a bin that saw nothing: honest
+ * coverage counts returns, so a zero-return station is a gap even with a finite
+ * height.
+ *
+ * `count === undefined` is treated as covered-if-finite ON PURPOSE. A
+ * measurement from a pre-v0.4.5 session predates stored counts; those series
+ * never carried a count, so a missing count must not retroactively blank a
+ * station that a covered old session already read. Only an explicit `0` — a
+ * count the sampler actually wrote — marks a gap.
+ */
+export function profileSampleCovered(sample: ProfileChartSample): boolean {
+  return Number.isFinite(sample.height) && sample.count !== 0;
+}
 
 /** Compute the civil statistics for a profile sample series. */
 export function computeCivilProfileStats(
@@ -79,9 +98,9 @@ export function computeCivilProfileStats(
     const h = samples[i].height;
     // A station with zero corridor returns is a coverage gap even when the
     // sampler carried a finite height across it — the degenerate/vertical
-    // branch borrows an endpoint elevation with count 0. Honest coverage
-    // counts returns, so a count-0 station is a gap, never a covered station.
-    const el = finite(h) && samples[i].count !== 0 ? h : null;
+    // branch borrows an endpoint elevation with count 0. The shared predicate
+    // owns that rule so the summary/PDF cannot decide it differently.
+    const el = profileSampleCovered(samples[i]) ? h : null;
     if (el != null) {
       hits++;
       if (firstHit < 0) firstHit = i;

--- a/src/render/measure/profileSummary.ts
+++ b/src/render/measure/profileSummary.ts
@@ -20,7 +20,7 @@
  */
 
 import type { ProfileChartSample, UnitSystem } from './types';
-import { formatStationing, formatGradePercent } from './civilProfileStats';
+import { formatStationing, formatGradePercent, profileSampleCovered } from './civilProfileStats';
 import { formatElevation, formatLength } from './format';
 // Height headings come from one vocabulary, where "Elevation" is earned by an
 // orthometric reference and by nothing else. The panel, the station table, the
@@ -73,9 +73,6 @@ export interface ProfileSummaryData {
   /** Lowest covered point (first occurrence on a tie). */
   readonly lowest: ProfileExtreme | null;
 }
-
-const covered = (h: number | undefined): h is number =>
-  typeof h === 'number' && Number.isFinite(h);
 
 /**
  * Take a sampled profile from render space to the numbers a reader is owed —
@@ -149,7 +146,7 @@ export function computeProfileSummary(
 
   for (let i = 0; i < n; i++) {
     const h = samples[i].height;
-    if (!covered(h)) continue;
+    if (!profileSampleCovered(samples[i])) continue;
     hits++;
     if (firstHit < 0) firstHit = i;
     lastHit = i;
@@ -166,7 +163,7 @@ export function computeProfileSummary(
   for (let i = 0; i < n - 1; i++) {
     const a = samples[i];
     const b = samples[i + 1];
-    if (!covered(a.height) || !covered(b.height)) continue; // gap — contribute nothing
+    if (!profileSampleCovered(a) || !profileSampleCovered(b)) continue; // gap — contribute nothing
     const run = b.distance - a.distance;
     if (!(run > 1e-9)) continue; // duplicate station — no honest grade
     segments++;
@@ -317,14 +314,14 @@ export function profileStationRows(
     if (i + 1 < samples.length) {
       const b = samples[i + 1];
       const run = b.distance - s.distance;
-      if (covered(s.height) && covered(b.height) && run > 1e-9) {
+      if (profileSampleCovered(s) && profileSampleCovered(b) && run > 1e-9) {
         grade = (((b.height - s.height) / run) * 100).toFixed(2);
       }
     }
     rows.push({
       station: formatStation(s.distance, system),
       chainage: (s.distance * k).toFixed(2),
-      elevation: covered(s.height) ? (s.height * k).toFixed(3) : '',
+      elevation: profileSampleCovered(s) ? (s.height * k).toFixed(3) : '',
       points: typeof s.count === 'number' && Number.isFinite(s.count) ? String(s.count) : '',
       grade,
     });

--- a/tests/profileCoverageConsistency.test.ts
+++ b/tests/profileCoverageConsistency.test.ts
@@ -1,0 +1,70 @@
+/**
+ * profileCoverageConsistency.test.ts — BUG 8
+ *
+ * The profile summary and the civil statistics must decide "covered vs gap"
+ * from ONE rule. A degenerate sampler emits `{ height: finite, count: 0 }`;
+ * civilProfileStats treats that as a gap (PR #676) but profileSummary used to
+ * treat it as covered by looking at the height alone. For the SAME station the
+ * two modules must now agree, and a legacy `count: undefined` finite sample
+ * must be covered in both.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeCivilProfileStats,
+  profileSampleCovered,
+} from '../src/render/measure/civilProfileStats';
+import { computeProfileSummary } from '../src/render/measure/profileSummary';
+import type { ProfileChartSample } from '../src/render/measure/types';
+
+describe('BUG 8 — profile coverage semantics agree across modules', () => {
+  it('a count:0 finite station is a gap in BOTH summary and civil stats', () => {
+    // Three real stations plus one degenerate count:0 station in the middle.
+    const samples: ProfileChartSample[] = [
+      { distance: 0, height: 100, count: 5 },
+      { distance: 10, height: 101, count: 0 }, // degenerate: finite height, no returns
+      { distance: 20, height: 104, count: 7 },
+    ];
+
+    const civil = computeCivilProfileStats(samples);
+    const summary = computeProfileSummary(samples);
+
+    // Civil marks the middle station as a gap (elevation null).
+    expect(civil.stations[1].elevation).toBeNull();
+    // The shared predicate must agree.
+    expect(profileSampleCovered(samples[1])).toBe(false);
+
+    // Coverage must be identical (2 of 3), not 3/3 from the summary.
+    expect(summary.coverage).toBeCloseTo(civil.coverage, 12);
+    expect(summary.coverage).toBeCloseTo(2 / 3, 12);
+  });
+
+  it('a legacy count:undefined finite station is covered in BOTH', () => {
+    const samples: ProfileChartSample[] = [
+      { distance: 0, height: 100 },
+      { distance: 10, height: 101 },
+      { distance: 20, height: 104 },
+    ];
+    const civil = computeCivilProfileStats(samples);
+    const summary = computeProfileSummary(samples);
+    expect(profileSampleCovered(samples[1])).toBe(true);
+    expect(summary.coverage).toBe(1);
+    expect(civil.coverage).toBe(1);
+  });
+
+  it('max grade skips the count:0 station in the summary too', () => {
+    // Without the shared rule the summary would draw a phantom steep segment
+    // into or out of the count:0 station.
+    const samples: ProfileChartSample[] = [
+      { distance: 0, height: 100, count: 5 },
+      { distance: 1, height: 200, count: 0 }, // huge phantom grade if counted
+      { distance: 2, height: 100, count: 5 },
+    ];
+    const summary = computeProfileSummary(samples);
+    const civil = computeCivilProfileStats(samples);
+    // Both endpoints are covered but the middle is a gap, so no adjacent
+    // covered pair exists: max grade is null on both.
+    expect(summary.maxGrade).toBeNull();
+    expect(civil.maxGrade).toBeNull();
+  });
+});


### PR DESCRIPTION
## Bug

A degenerate profile sample carries a finite height with `count: 0`, a
station where nothing returned. civilProfileStats (PR #676) treats that as
a gap, but profileSummary judged coverage from the height alone. For the
same profile the summary reported it covered, inflated the coverage
fraction, and could draw a phantom grade through it, while the civil stats
and the PDF plot read it as a gap. The PDF draws from both modules, so the
two disagreed on one sheet.

## Fix

`profileSampleCovered` now lives in civilProfileStats and owns the rule:
finite height and a non-zero count. profileSummary imports it for coverage,
gain/loss, max grade, extremes and station rows. A missing count stays
covered-if-finite, so pre-count sessions read as before; only an explicit
zero marks a gap. A new test asserts both modules agree. No fixture changed.
