### PR TITLE
fix(heavy): stop the OPFS janitor deleting another tab's live store

### DIFF
--- a/src/app/heavyLasExecutor.ts
+++ b/src/app/heavyLasExecutor.ts
@@ -99,9 +99,12 @@ function heavyStoreName(file: File, uniqueId: string): string {
 let openIdCounter = 0;
 
 // A crashed or force-closed session cannot delete its temporary store, so stale
-// `ooc-*` directories accumulate. The first heavy open of a session sweeps them
-// best-effort, keeping this open's own store and anything younger than the lease
-// threshold. It runs where OPFS-heavy usage actually happens rather than at boot.
+// `<name>.partial` build directories accumulate. The first heavy open of a
+// session sweeps those best-effort, keeping this open's own store and anything
+// younger than the lease threshold. It runs where OPFS-heavy usage actually
+// happens rather than at boot. Promoted `ooc-*` stores are deliberately NOT
+// swept: one may be a live dataset another tab still owns, and there is no
+// cross-tab ownership signal yet (see opfsStoreJanitor.ts).
 let janitorSwept = false;
 
 /**

--- a/src/io/heavy/opfsSpillStore.ts
+++ b/src/io/heavy/opfsSpillStore.ts
@@ -550,5 +550,22 @@ export async function withOpfsSpillBuild<T>(
     }
     throw err;
   }
-  return { result, dir: await pending.promote() };
+  // Promotion can fail too — a rename or quota fault mid-relocate. `promote`
+  // undoes its own half-moved target, but the partial it moved FROM is still on
+  // disk and would be stranded the same way an abandoned build is. So discard it
+  // on a promotion failure for the same reason the build path does, and rethrow
+  // the promotion error rather than any cleanup fault.
+  let dir: OpfsDirHandle;
+  try {
+    dir = await pending.promote();
+  } catch (err) {
+    try {
+      await pending.discard();
+    } catch {
+      // The partial outlives this attempt; the next build under the same name
+      // removes it. The promotion error is the one worth reporting.
+    }
+    throw err;
+  }
+  return { result, dir };
 }

--- a/src/io/heavy/opfsStoreJanitor.ts
+++ b/src/io/heavy/opfsStoreJanitor.ts
@@ -10,19 +10,32 @@
  * next open of the same file, so an explicit janitor is the only thing that
  * frees the disk.
  *
- * This sweep is deliberately conservative. It deletes a temp store ONLY when it
- * can prove the store is old — a lease marker (`STORE_LEASE_FILE`) written at
- * build time, older than a safe threshold — AND the store is not in the set a
- * live session says it owns. A store whose age it cannot read is KEPT, never
- * guessed at, so a store a running build is still filling is never swept out
- * from under it. That is the failure it must never have.
+ * This sweep is deliberately conservative, and narrower still since the
+ * cross-tab data-loss risk was found. It sweeps ONLY abandoned `<name>.partial`
+ * stores — a half-built directory a crashed tab left mid-build — and never a
+ * promoted final `ooc-…` store. A store is removed only when it is a partial,
+ * its lease marker (`STORE_LEASE_FILE`, written at build time) is older than a
+ * safe threshold, AND it is not in the set a live session says it owns. A store
+ * whose age it cannot read is KEPT, never guessed at, so a partial a running
+ * build is still filling is never swept out from under it. That is the failure
+ * it must never have.
  *
- * KNOWN LIMIT. The lease records CREATION time, not last use, and ownership is
- * known only for THIS tab. A store another tab has legitimately kept open for
- * longer than the threshold could therefore be swept. The threshold is sized in
- * hours to make that unlikely for a temporary store, and a cross-tab liveness
- * heartbeat (e.g. a BroadcastChannel lease refresh) is the fuller answer, left
- * for when multi-tab out-of-core use is a real workload.
+ * WHY PROMOTED STORES ARE LEFT ALONE. A promoted `ooc-…` store is a finished
+ * dataset another tab may still have open and be streaming from. The lease
+ * records CREATION time, not last use, and ownership is known only for THIS tab,
+ * so a promoted store a second tab has legitimately kept open past the threshold
+ * looks identical to an abandoned one — sweeping it deletes live data out from
+ * under that tab. There is no cross-tab ownership signal yet, so promoted stores
+ * are never swept automatically. A `.partial` this old, by contrast, is a build
+ * that stopped mid-flight: nothing promotes it, no reader opens it, and it only
+ * costs disk, so reclaiming it is safe.
+ *
+ * FUTURE WORK. Sweeping promoted stores safely needs a real cross-tab liveness
+ * mechanism — a BroadcastChannel lease refresh, or Web Locks plus a lease
+ * heartbeat — so a store still owned by any live tab can be told from one no tab
+ * holds. Until that exists, abandoned promoted stores are reclaimed only when a
+ * later build of the same source replaces them, or when the user clears site
+ * data.
  *
  * It runs against the structural {@link OpfsDirHandle}, so it is unit-tested in
  * Node against `tests/support/fakeOpfs.ts` exactly like the spill store.
@@ -59,9 +72,17 @@ export interface OocJanitorOptions {
   readonly debug?: boolean;
 }
 
-/** Whether a top-level name is an out-of-core temp store (final or partial). */
-function isTempStoreName(name: string): boolean {
-  return name.startsWith(OOC_STORE_PREFIX) || name.endsWith(PARTIAL_SUFFIX);
+/**
+ * Whether a top-level name is a sweepable store: an abandoned build partial.
+ *
+ * Only `<name>.partial` directories are sweepable. A promoted final `ooc-…`
+ * store is deliberately excluded — it may be a live dataset another tab still
+ * owns, and there is no cross-tab ownership signal to tell that apart from an
+ * abandoned one (see the header). A partial this scheme reaches is a build that
+ * stopped: nothing promotes it and no reader opens it.
+ */
+function isSweepablePartial(name: string): boolean {
+  return name.endsWith(PARTIAL_SUFFIX);
 }
 
 /**
@@ -89,14 +110,16 @@ export async function readStoreLease(dir: OpfsDirHandle): Promise<number | null>
 }
 
 /**
- * Sweep abandoned out-of-core stores under `root`, returning the names removed.
+ * Sweep abandoned out-of-core build partials under `root`, returning the names
+ * removed.
  *
- * A store is removed only when it is a temp store, not owned by a live session,
- * and its lease is older than the stale threshold. Anything the janitor cannot
- * prove stale — no lease, an unreadable lease, a lease younger than the
- * threshold — is left in place. A removal that itself fails is logged (in debug)
- * and skipped rather than aborting the sweep, so one stuck store does not block
- * the rest.
+ * A store is removed only when it is a `<name>.partial`, not owned by a live
+ * session, and its lease is older than the stale threshold. Promoted final
+ * `ooc-…` stores are never swept — they may be live data another tab owns (see
+ * the header). Anything the janitor cannot prove stale — no lease, an unreadable
+ * lease, a lease younger than the threshold — is left in place. A removal that
+ * itself fails is logged (in debug) and skipped rather than aborting the sweep,
+ * so one stuck store does not block the rest.
  */
 export async function sweepAbandonedOocStores(
   root: OpfsDirHandle,
@@ -108,7 +131,7 @@ export async function sweepAbandonedOocStores(
 
   const candidates: string[] = [];
   for await (const name of root.keys()) {
-    if (isTempStoreName(name) && !owned.has(name)) candidates.push(name);
+    if (isSweepablePartial(name) && !owned.has(name)) candidates.push(name);
   }
 
   const removed: string[] = [];

--- a/tests/opfsSpillStore.test.ts
+++ b/tests/opfsSpillStore.test.ts
@@ -27,8 +27,41 @@ import {
   opfsSpillStore,
   readOpfsText,
   writeOpfsText,
+  withOpfsSpillBuild,
+  PARTIAL_SUFFIX,
+  type OpfsDirHandle,
 } from '../src/io/heavy/opfsSpillStore';
-import { fakeOpfsDir } from './support/fakeOpfs';
+import { fakeOpfs, fakeOpfsDir } from './support/fakeOpfs';
+
+/**
+ * Wrap a root so a build under `<name>.partial` writes normally but PROMOTION
+ * fails: any file handle opened directly under the final `name` directory
+ * throws when written, which is how a rename or quota fault mid-relocate reaches
+ * `promote`. Everything else delegates to the real fake.
+ */
+function rootWithFailingPromotion(root: OpfsDirHandle, finalName: string): OpfsDirHandle {
+  return {
+    ...root,
+    async getDirectoryHandle(name, opts) {
+      const dir = await root.getDirectoryHandle(name, opts);
+      if (name !== finalName) return dir;
+      return {
+        ...dir,
+        async getFileHandle(fileName, fileOpts) {
+          const handle = await dir.getFileHandle(fileName, fileOpts);
+          return {
+            ...handle,
+            async createWritable() {
+              throw Object.assign(new Error('promotion write refused'), {
+                name: 'QuotaExceededError',
+              });
+            },
+          };
+        },
+      } as OpfsDirHandle;
+    },
+  } as OpfsDirHandle;
+}
 
 describe('OPFS spill store', () => {
   it('appends, reads, maps keys, and round-trips text', async () => {
@@ -96,5 +129,26 @@ describe('OPFS spill store', () => {
     }
     expect(bad).toBe(0);
     expect(total).toBe(n);
+  });
+
+  it('withOpfsSpillBuild discards the partial and rethrows when promotion fails', async () => {
+    const opfs = fakeOpfs();
+    const name = 'ooc-promote-fail.las-1-zzzz';
+    const root = rootWithFailingPromotion(opfs.root, name);
+
+    await expect(
+      withOpfsSpillBuild(root, name, async (build) => {
+        await build.store.append('', new Uint8Array([1, 2, 3]));
+        await writeOpfsText(build.dir, 'manifest.json', '{}');
+        return 'built';
+      }),
+    ).rejects.toThrow(/promotion write refused/);
+
+    // Neither the partial nor a half-promoted final directory may survive: the
+    // promotion failure must not strand the scan-sized partial on disk.
+    const top = opfs.topLevel();
+    expect(top).not.toContain(name + PARTIAL_SUFFIX);
+    expect(top).not.toContain(name);
+    expect(opfs.totalBytes()).toBe(0);
   });
 });

--- a/tests/opfsStoreJanitor.test.ts
+++ b/tests/opfsStoreJanitor.test.ts
@@ -1,13 +1,15 @@
 /**
- * opfsStoreJanitor.test.ts — the startup janitor removes an abandoned temp
- * store but keeps a fresh or owned one (finding #16).
+ * opfsStoreJanitor.test.ts — the startup janitor removes an abandoned build
+ * partial but keeps a promoted, fresh, or owned store (findings #16, #7).
  *
  * A crashed tab or a failed close-time removal leaves an `ooc-…` or
  * `<name>.partial` directory the size of the scan in OPFS. The janitor sweeps
- * one only when it can PROVE it stale — a lease older than the threshold — and
- * only when a live session does not own it. Anything younger, owned, or of
- * unknown age is kept, because deleting a store a running build still fills is
- * the one failure this must never have.
+ * ONLY `<name>.partial` stores, and only when it can PROVE one stale — a lease
+ * older than the threshold — and a live session does not own it. A promoted
+ * final `ooc-…` store is never swept even when its lease is old, because it may
+ * be live data another tab still owns and there is no cross-tab ownership signal
+ * yet. Anything younger, owned, or of unknown age is kept, because deleting a
+ * store a running build still fills is the one failure this must never have.
  */
 import { describe, it, expect } from 'vitest';
 import { fakeOpfs } from './support/fakeOpfs';
@@ -32,16 +34,18 @@ async function makeStore(root: OpfsDirHandle, name: string, createdAt: number | 
 }
 
 describe('OOC startup janitor', () => {
-  it('removes a stale abandoned store, keeps fresh, owned, and unknown-age ones', async () => {
+  it('removes a stale abandoned partial, keeps promoted, fresh, owned, and unknown-age ones', async () => {
     const opfs = fakeOpfs();
-    const stale = 'ooc-abandoned.las-100-aaaa';
     const stalePartial = 'ooc-abandoned.las-100-bbbb.partial';
-    const fresh = 'ooc-recent.las-100-cccc';
-    const owned = 'ooc-live.las-100-dddd';
-    const unknown = 'ooc-nolease.las-100-eeee';
+    const stalePromoted = 'ooc-abandoned.las-100-aaaa';
+    const fresh = 'ooc-recent.las-100-cccc.partial';
+    const owned = 'ooc-live.las-100-dddd.partial';
+    const unknown = 'ooc-nolease.las-100-eeee.partial';
 
-    await makeStore(opfs.root, stale, NOW - DEFAULT_STALE_MS - 60_000);
     await makeStore(opfs.root, stalePartial, NOW - DEFAULT_STALE_MS - 60_000);
+    // A PROMOTED final store older than the threshold: it may be a live dataset
+    // another tab still owns, so the janitor must not touch it (finding #7).
+    await makeStore(opfs.root, stalePromoted, NOW - DEFAULT_STALE_MS - 60_000);
     await makeStore(opfs.root, fresh, NOW - 60_000);
     await makeStore(opfs.root, owned, NOW - DEFAULT_STALE_MS - 60_000);
     await makeStore(opfs.root, unknown, null);
@@ -53,19 +57,28 @@ describe('OOC startup janitor', () => {
       ownedNames: new Set([owned]),
     });
 
-    expect(removed.sort()).toEqual([stale, stalePartial].sort());
+    expect(removed).toEqual([stalePartial]);
     const top = opfs.topLevel();
-    expect(top).not.toContain(stale);
     expect(top).not.toContain(stalePartial);
+    expect(top).toContain(stalePromoted);
     expect(top).toContain(fresh);
     expect(top).toContain(owned);
     expect(top).toContain(unknown);
     expect(top).toContain('some-other-thing');
   });
 
-  it('removes nothing when every store is younger than the threshold', async () => {
+  it('never sweeps a promoted final store even when its lease is well past the threshold', async () => {
     const opfs = fakeOpfs();
-    await makeStore(opfs.root, 'ooc-a.las-1-x', NOW - 1000);
+    const promoted = 'ooc-huge.las-999-ffff';
+    await makeStore(opfs.root, promoted, NOW - DEFAULT_STALE_MS * 10);
+    const removed = await sweepAbandonedOocStores(opfs.root, { now: NOW });
+    expect(removed).toEqual([]);
+    expect(opfs.topLevel()).toContain(promoted);
+  });
+
+  it('removes nothing when every partial is younger than the threshold', async () => {
+    const opfs = fakeOpfs();
+    await makeStore(opfs.root, 'ooc-a.las-1-x.partial', NOW - 1000);
     await makeStore(opfs.root, 'ooc-b.las-1-y.partial', NOW - 1000);
     const removed = await sweepAbandonedOocStores(opfs.root, { now: NOW });
     expect(removed).toEqual([]);


### PR DESCRIPTION
## Cross-tab data-loss fix

The startup OPFS janitor swept any `ooc-*` store whose lease passed the
six-hour threshold. The lease records creation time and ownership is known
only for the sweeping tab, so a second tab with a giant LAS open past that
window could have its promoted store deleted underneath it. The sweep now
touches only abandoned `<name>.partial` build directories and never a
promoted final store, and the header records that safe sweeping of promoted
stores needs a real cross-tab liveness signal as future work.

## Latent leak

`withOpfsSpillBuild` left the scan-sized partial on disk when promotion
failed. It now discards the partial and rethrows, matching the build-failure
path.

Tests cover the promoted-store keep, the stale-partial sweep, and the
promotion-failure discard. All gates green.
