### PR TITLE
Propagate tile-store completeness and harden the readers

### DIFF
--- a/src/io/copc/copcHeader.ts
+++ b/src/io/copc/copcHeader.ts
@@ -13,6 +13,7 @@
  */
 
 import { LoadError } from '../loadErrors';
+import { readSafeUint64 } from '../lasHeader';
 import { parseCrsFromVlrs } from '../crs';
 import type { CopcMetadata, CopcHeaderInfo, CopcInfo } from './copcTypes';
 
@@ -87,7 +88,7 @@ export function parseCopcMetadata(headSlice: ArrayBuffer): CopcMetadata {
   if (min.some((v) => !Number.isFinite(v)) || max.some((v) => !Number.isFinite(v))) {
     throw new LoadError('malformed-file', 'LAS header bounds are invalid.');
   }
-  const pointCount = Number(view.getBigUint64(247, true));
+  const pointCount = readSafeUint64(view, 247, 'LAS point count');
   if (!Number.isFinite(pointCount) || pointCount < 0) {
     throw new LoadError('malformed-file', 'LAS point count is invalid.');
   }
@@ -125,8 +126,8 @@ export function parseCopcMetadata(headSlice: ArrayBuffer): CopcMetadata {
     ],
     halfsize: view.getFloat64(ip + 24, true),
     spacing: view.getFloat64(ip + 32, true),
-    rootHierOffset: Number(view.getBigUint64(ip + 40, true)),
-    rootHierSize: Number(view.getBigUint64(ip + 48, true)),
+    rootHierOffset: readSafeUint64(view, ip + 40, 'COPC root hierarchy offset'),
+    rootHierSize: readSafeUint64(view, ip + 48, 'COPC root hierarchy size'),
     gpsTimeRange: [
       view.getFloat64(ip + 56, true),
       view.getFloat64(ip + 64, true),

--- a/src/io/heavy/OlvTileSource.ts
+++ b/src/io/heavy/OlvTileSource.ts
@@ -65,6 +65,10 @@ import type { PreviewSample } from './previewSampler';
  */
 const ID_PREFIX = 't';
 
+/** The tag a truncated source's completeness reason carries, so a consumer can
+ *  recognise the physical-truncation case distinct from a hierarchy hole. */
+export const SOURCE_TRUNCATED_REASON = 'SOURCE_TRUNCATED';
+
 /** The node id for an octant path. */
 export function tileNodeId(key: string): string {
   return ID_PREFIX + key;
@@ -97,6 +101,24 @@ export function tileVoxelKey(key: string): VoxelKey {
   return { depth: key.length, x, y, z };
 }
 
+/**
+ * The `ArrayBuffer` to hand a worker for `bytes`, ready to transfer.
+ *
+ * When `bytes` owns its whole backing buffer (offset 0 and exactly as long as
+ * the buffer) the buffer is returned as-is, so a caller that transfers it moves
+ * the existing allocation with no copy. A `slice()` there would transiently
+ * double the tile — 256 MiB becomes 512 MiB before decode. Only a partial view
+ * is copied, since transferring its buffer would carry bytes outside the view.
+ * Safe to transfer the returned buffer only when `bytes` is single-use (a reader
+ * that returns a fresh array per call); a retained partial view is copied here.
+ */
+function ownedBuffer(bytes: Uint8Array): ArrayBuffer {
+  if (bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength) {
+    return bytes.buffer as ArrayBuffer;
+  }
+  return bytes.slice().buffer;
+}
+
 /** Reads one tile's stored bytes. A memory map in tests, OPFS in the browser. */
 export interface TileBytesReader {
   read(key: string, signal?: AbortSignal): Promise<Uint8Array>;
@@ -112,6 +134,14 @@ export interface TileBytesReader {
  * still added, since dropping it would lose its points as well, but the gap is
  * recorded and {@link isComplete} goes false, so a completeness-sensitive
  * consumer refuses to claim the cloud is whole.
+ *
+ * The manifest also carries the source's own completeness: a physically
+ * truncated LAS (the header declared more points than the file held) is written
+ * with `complete: false` and a `declaredPointCount` above the loaded count. That
+ * store can have a perfectly coherent hierarchy, so the ancestor check alone
+ * would call it whole; the constructor reads the manifest flag as well and
+ * records a named {@link SOURCE_TRUNCATED_REASON} so a scientific grade sees a
+ * truncated source rather than a smaller complete one.
  */
 export class OlvTileOctree implements StreamingOctreeView {
   readonly store = new StreamingNodeStore();
@@ -175,6 +205,18 @@ export class OlvTileOctree implements StreamingOctreeView {
     if (keys.length !== reader.manifest.leafCount) {
       this._errors.push(
         `tile store: manifest declares ${reader.manifest.leafCount} nodes but the hierarchy lists ${keys.length}`,
+      );
+    }
+
+    // Source-level completeness: the hierarchy above can be whole while the
+    // source it was built from was physically truncated. The manifest records
+    // that; surface it as a named reason so `isComplete` goes false and a grade
+    // reads a truncated source honestly.
+    if (reader.manifest.complete === false) {
+      const declared = reader.manifest.declaredPointCount ?? reader.manifest.pointCount;
+      const readable = reader.manifest.pointCount;
+      this._errors.push(
+        `${SOURCE_TRUNCATED_REASON}: declared ${declared}, readable ${readable}`,
       );
     }
   }
@@ -248,6 +290,12 @@ export class OlvTileSource implements StreamingSource {
     return this._store.manifest.pointCount;
   }
 
+  /** The point count the source header declared. Above {@link sourcePointCount}
+   *  (the readable count) when the source file was physically truncated. */
+  get declaredPointCount(): number {
+    return this._store.manifest.declaredPointCount ?? this._store.manifest.pointCount;
+  }
+
   get residentPointCount(): number {
     return this.octree.store.residentPointCount;
   }
@@ -313,9 +361,13 @@ export class OlvTileSource implements StreamingSource {
     signal?.throwIfAborted();
     const bytes = await this._tiles.read(tileKeyOf(record.id), signal);
     signal?.throwIfAborted();
-    // The scheduler transfers the buffer to a worker, so hand it one that owns
-    // its bytes: a subarray view would transfer the whole backing store with it.
-    return bytes.slice().buffer;
+    // The scheduler transfers the buffer to a worker. The bytes reader returns a
+    // fresh, single-use array per call, so when it owns its whole backing buffer
+    // we transfer that buffer directly — a needless `slice()` here would
+    // transiently double a 256 MiB tile to 512 MiB before decode. Only a partial
+    // view (offset, or shorter than its buffer) is copied, since transferring its
+    // buffer would take bytes outside the view with it.
+    return ownedBuffer(bytes);
   }
 
   /**
@@ -515,9 +567,11 @@ export class PreviewCloudSource implements StreamingSource {
 
   async readNodeChunk(_record: StreamingNodeRecord, signal?: AbortSignal): Promise<ArrayBuffer> {
     signal?.throwIfAborted();
-    // The scheduler transfers the buffer to a worker, so hand it a copy that
-    // owns its bytes rather than a view over the retained sample.
-    return this._sample.records.slice().buffer;
+    // The scheduler transfers the buffer to a worker. The preview's records are
+    // retained for the life of the source, so a view into them must be copied;
+    // but a records array that owns its whole backing buffer can be transferred
+    // directly. `ownedBuffer` makes exactly that distinction.
+    return ownedBuffer(this._sample.records);
   }
 
   decodeMeta(record: StreamingNodeRecord): ChunkDecodeMetadata {

--- a/src/io/heavy/tileStore.ts
+++ b/src/io/heavy/tileStore.ts
@@ -16,7 +16,13 @@
  * caller reads and writes the blobs through a store of its choice.
  */
 import { octreeGridOf, type Cube, type OctreeGrid } from './octreeGrid';
-import { readTileRecord, tileRecordBytes, type TilePoint, type TileSchema } from './tileRecord';
+import {
+  readTileRecord,
+  tileRecordBytes,
+  TileTruncationError,
+  type TilePoint,
+  type TileSchema,
+} from './tileRecord';
 import type { OocIndex } from './oocIndexer';
 
 /** Bumped when the manifest or hierarchy format changes meaning. */
@@ -149,6 +155,26 @@ export function parseTileManifest(input: unknown): TileManifest {
       ? pointCount
       : nonNegativeInt(m.declaredPointCount, 'declaredPointCount');
   const complete = m.complete === undefined ? true : bool(m.complete, 'complete');
+  // A truncated source has more declared than loaded; a complete one has them
+  // equal. Anything else — declared below loaded, or a `complete` flag that
+  // disagrees with the counts — is an inconsistent manifest, not a store to
+  // trust, so refuse it here rather than let a grade read the mismatch as truth.
+  if (declaredPointCount < pointCount) {
+    fail(`declaredPointCount ${declaredPointCount} is below pointCount ${pointCount}`);
+  }
+  if (complete && declaredPointCount !== pointCount) {
+    fail(
+      `complete is true but declaredPointCount ${declaredPointCount} differs from pointCount ${pointCount}`,
+    );
+  }
+  const bounds = { min: triple(boundsRec.min, 'bounds.min'), max: triple(boundsRec.max, 'bounds.max') };
+  for (let a = 0; a < 3; a++) {
+    if (bounds.min[a] > bounds.max[a]) {
+      fail(`bounds.min[${a}] ${bounds.min[a]} exceeds bounds.max[${a}] ${bounds.max[a]}`);
+    }
+  }
+  const rootSize = finite(rootRec.size, 'root.size');
+  if (rootSize <= 0) fail(`root.size must be positive, got ${rootSize}`);
   return {
     schemaVersion: TILE_STORE_SCHEMA_VERSION,
     pointCount,
@@ -157,8 +183,8 @@ export function parseTileManifest(input: unknown): TileManifest {
     recordBytes,
     schema,
     origin: triple(m.origin, 'origin'),
-    bounds: { min: triple(boundsRec.min, 'bounds.min'), max: triple(boundsRec.max, 'bounds.max') },
-    root: { min: triple(rootRec.min, 'root.min'), size: finite(rootRec.size, 'root.size') },
+    bounds,
+    root: { min: triple(rootRec.min, 'root.min'), size: rootSize },
     depth: nonNegativeInt(m.depth, 'depth'),
     leafCount: nonNegativeInt(m.leafCount, 'leafCount'),
   };
@@ -196,7 +222,35 @@ export class TileStoreReader {
   constructor(manifest: TileManifest, leaves: readonly TileStoreLeaf[]) {
     this.manifest = manifest;
     this.grid = octreeGridOf(manifest.root, manifest.depth);
-    this.countByKey = new Map(leaves.map((l) => [l.key, l.pointCount]));
+    // Build the index by hand rather than `new Map(entries)`: a Map silently
+    // keeps the last value for a duplicate key, which would collapse two nodes
+    // that claim the same octant into one and quietly drop the other's points.
+    // A duplicate key is a corrupt hierarchy, so refuse it. While walking, check
+    // the depth and the running sum: a node deeper than the declared octree, or
+    // leaves that between them claim MORE points than the manifest declares, is
+    // corruption and is refused here. A sum BELOW the manifest total is not
+    // refused — that is a dropped node, the tolerated hole `OlvTileOctree`
+    // records as a completeness error while still offering the points it has.
+    const countByKey = new Map<string, number>();
+    let sum = 0;
+    for (const leaf of leaves) {
+      if (countByKey.has(leaf.key)) {
+        fail(`hierarchy has a duplicate node key ${JSON.stringify(leaf.key)}`);
+      }
+      if (leaf.key.length > manifest.depth) {
+        fail(
+          `hierarchy node ${JSON.stringify(leaf.key)} is deeper than the declared octree depth ${manifest.depth}`,
+        );
+      }
+      countByKey.set(leaf.key, leaf.pointCount);
+      sum += leaf.pointCount;
+    }
+    if (sum > manifest.pointCount) {
+      fail(
+        `hierarchy leaf counts sum to ${sum}, more than the ${manifest.pointCount} points the manifest declares`,
+      );
+    }
+    this.countByKey = countByKey;
   }
 
   get schema(): TileSchema {
@@ -219,13 +273,25 @@ export class TileStoreReader {
     return this.countByKey.get(key) ?? 0;
   }
 
-  /** Decode a leaf tile's bytes into points. */
+  /**
+   * Decode a leaf tile's bytes into points. Strict: the byte length must be an
+   * exact multiple of the record size. Trailing bytes that do not complete a
+   * record mean a truncated or corrupt tile, not a shorter valid one, so this
+   * refuses rather than floor the count and silently present a broken tile as a
+   * smaller good one — matching the strictness of the streaming `decodeTile`.
+   */
   decodeTile(bytes: Uint8Array): TilePoint[] {
+    const recordBytes = this.manifest.recordBytes;
+    if (recordBytes <= 0 || bytes.byteLength % recordBytes !== 0) {
+      throw new TileTruncationError(
+        `tileStore: tile is ${bytes.byteLength} bytes, not a whole multiple of the ${recordBytes}-byte record; the store is truncated or corrupt`,
+      );
+    }
     const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-    const n = Math.floor(bytes.byteLength / this.manifest.recordBytes);
+    const n = bytes.byteLength / recordBytes;
     const out: TilePoint[] = [];
     for (let i = 0; i < n; i++) {
-      out.push(readTileRecord(view, i * this.manifest.recordBytes, this.manifest.schema));
+      out.push(readTileRecord(view, i * recordBytes, this.manifest.schema));
     }
     return out;
   }

--- a/src/io/lasHeader.ts
+++ b/src/io/lasHeader.ts
@@ -12,6 +12,21 @@ import { LoadError } from './loadErrors';
 import { parseCrsFromVlrs } from './crs';
 import type { CrsInfo } from './crs';
 
+/**
+ * Read a little-endian uint64 as a Number, refusing values JavaScript cannot
+ * hold exactly. Above 2^53−1 a `Number` silently loses low bits, so a point
+ * count, byte offset or hierarchy size read that large would be quietly wrong —
+ * a corruption no downstream check could recover. Guard BEFORE the conversion
+ * and reject the file with a typed error instead.
+ */
+export function readSafeUint64(view: DataView, offset: number, what: string): number {
+  const value = view.getBigUint64(offset, true);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new LoadError('malformed-file', `${what} ${value} exceeds the safe integer range.`);
+  }
+  return Number(value);
+}
+
 /** Parsed subset of the LAS public header block. */
 export interface LasHeader {
   pointCount: number;
@@ -140,7 +155,7 @@ export function parseLasHeader(buffer: ArrayBuffer): LasHeader {
     if (buffer.byteLength < MIN_LAS_1_4_HEADER_BYTES) {
       throw new Error('Not a valid LAS 1.4 file: the header is truncated');
     }
-    pointCount = Number(view.getBigUint64(OFFSET_EXTENDED_POINT_COUNT, true));
+    pointCount = readSafeUint64(view, OFFSET_EXTENDED_POINT_COUNT, 'LAS point count');
   }
 
   const scale: [number, number, number] = [

--- a/tests/lasHeader.test.ts
+++ b/tests/lasHeader.test.ts
@@ -114,4 +114,22 @@ describe('parseLasHeader — corrupted numeric header fields', () => {
     new Uint8Array(buf).fill(0xff, 155, 163); // offset-X float64 → NaN
     expect(() => parseLasHeader(buf)).toThrow(LoadError);
   });
+
+  test('a uint64 point count above 2^53 is refused, not silently truncated', () => {
+    // The extended point count is a uint64 at offset 247. A value JavaScript's
+    // Number cannot hold exactly would silently lose its low bits; the parser
+    // must refuse before converting rather than proceed with a wrong count.
+    const buf = loadFixture();
+    // 2^53 + 1 — one above Number.MAX_SAFE_INTEGER, not exactly representable.
+    new DataView(buf).setBigUint64(247, (1n << 53n) + 1n, true);
+    let caught: unknown;
+    try {
+      parseLasHeader(buf);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(LoadError);
+    expect((caught as LoadError).category).toBe('malformed-file');
+    expect((caught as LoadError).message).toMatch(/safe integer range/);
+  });
 });

--- a/tests/olvTileSource.test.ts
+++ b/tests/olvTileSource.test.ts
@@ -30,6 +30,7 @@ import {
 import { TileChunkDecoder } from '../src/io/heavy/tileChunkDecoder';
 import {
   OlvTileSource,
+  SOURCE_TRUNCATED_REASON,
   tileKeyOf,
   tileNodeId,
   tileVoxelKey,
@@ -350,6 +351,78 @@ describe('OlvTileSource', () => {
     // The orphan's own points are still offered — dropping the node would lose
     // them on top of losing the parent.
     expect(source.octree.store.get(tileNodeId(orphan.key))).toBeDefined();
+  });
+
+  it('propagates a truncated source: manifest.complete=false drops isComplete', async () => {
+    const { reader, tiles } = await buildReader(5000);
+    // A physically truncated source: header declared more than the file held, so
+    // the store carries complete=false with a declared count above the readable
+    // one. The hierarchy itself is coherent, so only the manifest flag can catch
+    // this.
+    const readable = reader.manifest.pointCount;
+    const truncated = new TileStoreReader(
+      { ...reader.manifest, complete: false, declaredPointCount: readable + 1234 },
+      reader.leaves(),
+    );
+    const source = new OlvTileSource({ id: 'x', name: 'y', store: truncated, tiles });
+    expect(source.octree.isComplete).toBe(false);
+    const reason = source.octree.errors.find((e) => e.startsWith(SOURCE_TRUNCATED_REASON));
+    expect(reason).toBeDefined();
+    expect(reason).toContain(`declared ${readable + 1234}`);
+    expect(reason).toContain(`readable ${readable}`);
+    expect(source.declaredPointCount).toBe(readable + 1234);
+    expect(source.sourcePointCount).toBe(readable);
+
+    // A complete store still reports whole, with no truncation reason.
+    const whole = makeSource(reader, tiles);
+    expect(whole.octree.isComplete).toBe(true);
+    expect(whole.octree.errors.some((e) => e.startsWith(SOURCE_TRUNCATED_REASON))).toBe(false);
+    expect(whole.declaredPointCount).toBe(readable);
+  });
+
+  it('readNodeChunk transfers an owned buffer and copies a partial view', async () => {
+    const { reader } = await buildReader(5000);
+    const node = new OlvTileSource({
+      id: 'x',
+      name: 'y',
+      store: reader,
+      tiles: { read: async () => new Uint8Array(0) },
+    }).octree.nodes().find((n) => n.record.pointCount > 0)!.record;
+
+    // Owned: the reader hands back a fresh full-buffer array, so the chunk is
+    // the SAME underlying buffer — no transient doubling before transfer.
+    let handed!: Uint8Array;
+    const ownedSource = new OlvTileSource({
+      id: 'a',
+      name: 'b',
+      store: reader,
+      tiles: {
+        read: async () => {
+          handed = new Uint8Array(node.pointCount * reader.recordBytes);
+          for (let i = 0; i < handed.length; i++) handed[i] = i & 0xff;
+          return handed;
+        },
+      },
+    });
+    const ownedChunk = await ownedSource.readNodeChunk(node);
+    expect(ownedChunk).toBe(handed.buffer);
+    expect(new Uint8Array(ownedChunk)[7]).toBe(7);
+
+    // Partial view: a subarray over a larger buffer must be copied, or the
+    // transfer would carry bytes outside the view. The copy holds the same data.
+    const backing = new Uint8Array(node.pointCount * reader.recordBytes + 16);
+    for (let i = 0; i < backing.length; i++) backing[i] = (i * 3) & 0xff;
+    const view = backing.subarray(8, 8 + node.pointCount * reader.recordBytes);
+    const viewSource = new OlvTileSource({
+      id: 'c',
+      name: 'd',
+      store: reader,
+      tiles: { read: async () => view },
+    });
+    const copiedChunk = await viewSource.readNodeChunk(node);
+    expect(copiedChunk).not.toBe(backing.buffer);
+    expect(copiedChunk.byteLength).toBe(view.byteLength);
+    expect(new Uint8Array(copiedChunk)).toEqual(new Uint8Array(view));
   });
 
   it('streams through the scheduler with the camera framing the cube', async () => {

--- a/tests/tileStore.test.ts
+++ b/tests/tileStore.test.ts
@@ -132,6 +132,81 @@ describe('tile store', () => {
     expect(() => parseHierarchy('3 12\nnotaline\n')).toThrow();
     expect(() => parseHierarchy('8 5\n')).toThrow(/bad key/); // 8 is not an octant digit
   });
+
+  it('refuses a manifest whose completeness invariants do not hold', () => {
+    // Declared below loaded is impossible: a source cannot load more points than
+    // it declared.
+    expect(() =>
+      parseTileManifest({ ...validManifest(), declaredPointCount: 4 }),
+    ).toThrow(/declaredPointCount/);
+    // A complete scan must have declared === loaded; a mismatch with the flag
+    // still set is an inconsistent store.
+    expect(() =>
+      parseTileManifest({ ...validManifest(), complete: true, declaredPointCount: 12, pointCount: 10 }),
+    ).toThrow(/complete is true/);
+    // Degenerate geometry: min above max, or a non-positive root cube.
+    expect(() =>
+      parseTileManifest({ ...validManifest(), bounds: { min: [2, 0, 0], max: [1, 1, 1] } }),
+    ).toThrow(/bounds\.min/);
+    expect(() =>
+      parseTileManifest({ ...validManifest(), root: { min: [0, 0, 0], size: 0 } }),
+    ).toThrow(/root\.size must be positive/);
+    // A truncated source round-trips: declared above loaded, complete false.
+    const truncated = parseTileManifest({
+      ...validManifest(),
+      pointCount: 10,
+      declaredPointCount: 25,
+      complete: false,
+    });
+    expect(truncated.complete).toBe(false);
+    expect(truncated.declaredPointCount).toBe(25);
+  });
+
+  it('refuses a hierarchy with a duplicate key, a bad sum, or an over-deep node', () => {
+    const manifest = parseTileManifest({ ...validManifest(), pointCount: 10, depth: 2 });
+    // A Map would silently collapse the duplicate and drop the second node's
+    // points; the reader must refuse instead.
+    expect(
+      () => new TileStoreReader(manifest, [{ key: '0', pointCount: 5 }, { key: '0', pointCount: 5 }]),
+    ).toThrow(/duplicate node key/);
+    // Leaf counts that claim MORE points than the manifest declares — an
+    // over-count is corruption. (An under-count is a tolerated hole, refused
+    // elsewhere as an incompleteness, not here.)
+    expect(
+      () => new TileStoreReader(manifest, [{ key: '0', pointCount: 7 }, { key: '1', pointCount: 7 }]),
+    ).toThrow(/more than/);
+    // A hole (sum below the manifest total) is tolerated at this layer.
+    expect(
+      () => new TileStoreReader(manifest, [{ key: '0', pointCount: 4 }]),
+    ).not.toThrow();
+    // A node deeper than the declared octree depth.
+    expect(
+      () => new TileStoreReader(manifest, [{ key: '000', pointCount: 10 }]),
+    ).toThrow(/deeper than the declared octree depth/);
+    // A consistent hierarchy is accepted.
+    expect(
+      () => new TileStoreReader(manifest, [{ key: '0', pointCount: 4 }, { key: '1', pointCount: 6 }]),
+    ).not.toThrow();
+  });
+
+  it('decodeTile refuses trailing bytes that do not complete a record', async () => {
+    const n = 2000;
+    const { index, store, schema, origin } = await buildIndex(n);
+    const { manifestJson, hierarchy } = buildTileStore(index, schema, origin);
+    const reader = new TileStoreReader(
+      parseTileManifest(JSON.parse(manifestJson)),
+      parseHierarchy(hierarchy),
+    );
+    const leaf = reader.leaves().find((l) => l.pointCount > 0)!;
+    const bytes = await store.read(leaf.key);
+    // Exact bytes decode.
+    expect(reader.decodeTile(bytes).length).toBe(reader.pointCountOf(leaf.key));
+    // One trailing byte makes it not a whole multiple of the record: refused,
+    // rather than floored to a smaller "valid" tile.
+    const overlong = new Uint8Array(bytes.byteLength + 1);
+    overlong.set(bytes, 0);
+    expect(() => reader.decodeTile(overlong)).toThrow(/truncated or corrupt/);
+  });
 });
 
 function validManifest(): Record<string, unknown> {


### PR DESCRIPTION
## What

Root-cause fixes and hardening in the out-of-core tile path.

- OlvTileOctree reads the manifest complete flag, so a physically truncated LAS
  with a coherent hierarchy reports isComplete false and a named
  SOURCE_TRUNCATED reason carrying its declared and readable counts. A complete
  store still reports whole.
- readNodeChunk transfers a buffer the reader already owns rather than slicing
  it, which stopped a 256 MiB tile doubling to 512 MiB before decode; a partial
  view is still copied.
- parseTileManifest refuses declared below loaded, a complete flag that
  disagrees with the counts, inverted bounds, and a non-positive root cube.
  TileStoreReader rejects duplicate node keys, over-deep nodes, and leaves that
  over-count the manifest. The low-level decodeTile refuses trailing bytes.
- LAS and COPC uint64 reads refuse values above the safe integer range before
  conversion, instead of silently losing low bits.

## Note

A sum below the manifest total stays tolerated: that is the dropped-node hole
OlvTileOctree already records as an incompleteness, so only an over-count is
refused here.

## Tests

New coverage for each defect. Full gate suite green.
