### PR TITLE
fix(heavy): bound real memory in the out-of-core decode path

### DIFF
--- a/src/io/heavy/chunkedLazSource.ts
+++ b/src/io/heavy/chunkedLazSource.ts
@@ -36,8 +36,10 @@ import { getLazPerf } from '../lazDecode';
 import { readLazChunkTable, type LazChunkRange } from './lazChunkTable';
 import {
   MAX_DECODED_ALLOCATION_BYTES,
+  MAX_DECODE_PEAK_BYTES,
   decodedBytesFor,
   withinDecodedByteBudget,
+  withinDecodePeakBudget,
 } from './heavyByteBudget';
 import { decodeLazChunkLocal, type LazChunkJob } from './decodeLazChunked';
 import type { PointSource, PositionBatch, SourceHeader } from './oocIndexer';
@@ -83,29 +85,45 @@ export const MAX_LAZ_WINDOW_SPAN_BYTES = 128 * 1024 * 1024;
  * Plan the next window starting at `start`: grow it while the contiguous span
  * from the first chunk's offset stays under {@link MAX_LAZ_WINDOW_SPAN_BYTES},
  * the aggregate DECODED bytes of the window stay under
- * {@link MAX_DECODED_ALLOCATION_BYTES}, and it is under `window` chunks — but
- * always take at least one chunk. The decoded-byte cap uses the real record
- * length (`recordLength`, 0 to skip it): the compressed-span cap bounds the read,
- * but a window of highly-compressed chunks can decode to far more than it reads,
- * and every decoded chunk in the window is staged before the window advances.
- * Pure, so the shrink behaviour is unit-testable without decoding. `chunks` must
- * be non-empty at `start`.
+ * {@link MAX_DECODED_ALLOCATION_BYTES}, the summed simultaneous peak
+ * (span + decoded + packed) stays under {@link MAX_DECODE_PEAK_BYTES}, and it is
+ * under `window` chunks — but always take at least one chunk. The decoded-byte
+ * cap uses the real record length (`recordLength`, 0 to skip it): the
+ * compressed-span cap bounds the read, but a window of highly-compressed chunks
+ * can decode to far more than it reads, and every decoded chunk in the window is
+ * staged before the window advances. `packedRecordBytes` (0 to skip its term) adds
+ * the packed tile records to the joint peak, since those coexist with the span and
+ * the raw decode. Pure, so the shrink behaviour is unit-testable without decoding.
+ * `chunks` must be non-empty at `start`.
  */
 export function planChunkWindow(
   chunks: readonly LazChunkRange[],
   start: number,
   window: number,
   recordLength: number = 0,
+  packedRecordBytes: number = 0,
 ): { end: number; spanStart: number; spanLength: number } {
   const spanStart = chunks[start].byteOffset;
   const cap = recordLength > 0 ? MAX_DECODED_ALLOCATION_BYTES : Number.POSITIVE_INFINITY;
+  // The joint-peak cap only bites when the decoded size is knowable.
+  const peakActive = recordLength > 0;
   let end = start + 1;
-  let decoded = decodedBytesFor(chunks[start].pointCount, recordLength > 0 ? recordLength : 1);
+  let points = chunks[start].pointCount;
+  let decoded = decodedBytesFor(points, recordLength > 0 ? recordLength : 1);
   while (end < chunks.length && end - start < window) {
     const next = chunks[end];
-    if (next.byteOffset + next.byteLength - spanStart > MAX_LAZ_WINDOW_SPAN_BYTES) break;
+    const nextSpan = next.byteOffset + next.byteLength - spanStart;
+    if (nextSpan > MAX_LAZ_WINDOW_SPAN_BYTES) break;
+    const nextPoints = points + next.pointCount;
     const nextDecoded = decoded + decodedBytesFor(next.pointCount, recordLength > 0 ? recordLength : 1);
     if (nextDecoded > cap) break;
+    if (
+      peakActive &&
+      !withinDecodePeakBudget(nextSpan, nextPoints, recordLength, packedRecordBytes)
+    ) {
+      break;
+    }
+    points = nextPoints;
     decoded = nextDecoded;
     end++;
   }
@@ -213,7 +231,29 @@ export async function openChunkedLazSource(
           start,
           window,
           header.pointDataRecordLength,
+          recordBytes,
         );
+        // A window is always at least one chunk. When it shrank to a single chunk
+        // whose own summed peak (its span + decoded + packed) is still over the
+        // total budget, no smaller window exists: refuse via the unsupported path
+        // rather than stage an over-budget decode or fall to a whole-file read.
+        if (end - start === 1) {
+          const only = chunks[start];
+          if (
+            !withinDecodePeakBudget(
+              only.byteLength,
+              only.pointCount,
+              header.pointDataRecordLength,
+              recordBytes,
+            )
+          ) {
+            throw new ChunkedLazUnsupportedError(
+              `chunked LAZ chunk of ${only.pointCount} points would peak over the ` +
+                `${MAX_DECODE_PEAK_BYTES}-byte simultaneous-decode budget (compressed span + ` +
+                'decoded records + packed records); convert it to COPC or EPT',
+            );
+          }
+        }
         const windowChunks = chunks.slice(start, end);
         const span = await range.readRange(spanStart, spanLength, signal);
         for (const c of windowChunks) {

--- a/src/io/heavy/heavyByteBudget.ts
+++ b/src/io/heavy/heavyByteBudget.ts
@@ -70,6 +70,21 @@ export const MAX_CHUNK_TABLE_ENTRIES = Math.floor(
 );
 
 /**
+ * The ceiling on the TOTAL simultaneous working set of a single LAZ window decode,
+ * in bytes. The per-chunk compressed cap, the per-window decoded cap
+ * ({@link MAX_DECODED_ALLOCATION_BYTES}), and the window-span cap
+ * ({@link chunkedLazSource.MAX_LAZ_WINDOW_SPAN_BYTES}) each bound ONE allocation,
+ * but a window decode holds several at once — the compressed span, the raw decoded
+ * records, and the packed tile records — so the summed peak can reach several
+ * hundred megabytes while every single piece stays under its own cap. 256 MiB is
+ * the device-reasonable ceiling on that joint working set; it sits below the naive
+ * 384 MiB sum of the three separate caps, so it actually constrains a window the
+ * individual caps would each pass, and a window is shrunk (never below one chunk)
+ * to keep its span + decoded + packed within it.
+ */
+export const MAX_DECODE_PEAK_BYTES = 256 * 1024 * 1024;
+
+/**
  * The ceiling on ONE leaf tile the streaming reader loads whole, in bytes. The
  * out-of-core indexer buckets points into leaves; a degenerate cloud (millions
  * of identical XYZ, which share a leaf key and an LOD hash) can pile far past a
@@ -113,6 +128,37 @@ export function withinDecodedByteBudget(
   ceiling: number = MAX_DECODED_ALLOCATION_BYTES,
 ): boolean {
   return decodedBytesFor(pointCount, recordLength) <= ceiling;
+}
+
+/**
+ * The summed peak working set of decoding a span of `spanBytes` compressed bytes
+ * into `pointCount` records of `sourceRecordLength` bytes and packing them into
+ * `packedRecordBytes`-byte tile records — the three allocations that coexist
+ * during a LAZ window decode. A non-usable span or decoded size makes the total
+ * {@link Number.POSITIVE_INFINITY}, so a nonsense size reads as over-budget;
+ * `packedRecordBytes <= 0` drops the packed term (the caller is not staging one)
+ * rather than poisoning the sum.
+ */
+export function decodePeakBytesFor(
+  spanBytes: number,
+  pointCount: number,
+  sourceRecordLength: number,
+  packedRecordBytes: number,
+): number {
+  const span = Number.isFinite(spanBytes) && spanBytes >= 0 ? spanBytes : Number.POSITIVE_INFINITY;
+  const packed = packedRecordBytes > 0 ? decodedBytesFor(pointCount, packedRecordBytes) : 0;
+  return span + decodedBytesFor(pointCount, sourceRecordLength) + packed;
+}
+
+/** Whether a window/chunk's summed decode peak stays within `ceiling` (default the total cap). */
+export function withinDecodePeakBudget(
+  spanBytes: number,
+  pointCount: number,
+  sourceRecordLength: number,
+  packedRecordBytes: number,
+  ceiling: number = MAX_DECODE_PEAK_BYTES,
+): boolean {
+  return decodePeakBytesFor(spanBytes, pointCount, sourceRecordLength, packedRecordBytes) <= ceiling;
 }
 
 /**

--- a/src/io/heavy/oocIndexer.ts
+++ b/src/io/heavy/oocIndexer.ts
@@ -110,7 +110,11 @@ export interface OocIndex {
   readonly leaves: readonly OocLeaf[];
   /** Bytes per point in every leaf tile. */
   readonly recordBytes: number;
-  /** High-water mark of buffered bytes during the bucketing pass. */
+  /**
+   * High-water mark of ALLOCATED staging capacity during the bucketing pass —
+   * the summed backing-array capacity of the live leaf buffers, held within the
+   * memory budget, not the smaller count of logical bytes written into them.
+   */
   readonly peakBufferedBytes: number;
 }
 
@@ -170,19 +174,35 @@ async function scanBounds(
   return { min, max, count };
 }
 
+/** A fresh leaf buffer's backing-array capacity, in bytes. */
+const LEAF_BUFFER_INITIAL_CAP = 4096;
+
+/**
+ * The backing-array capacity `current` grows to in order to hold `needed` bytes,
+ * doubling from `current` — the exact rule {@link LeafBuffer.append} follows.
+ * Pure, so the residency accounting can project a grow BEFORE it allocates.
+ */
+function grownCapacity(current: number, needed: number): number {
+  if (needed <= current) return current;
+  let cap = current * 2;
+  while (cap < needed) cap *= 2;
+  return cap;
+}
+
 /**
  * A growable per-leaf staging buffer of raw record bytes. Points for one leaf
- * accumulate here and are flushed to the store as a contiguous run.
+ * accumulate here and are flushed to the store as a contiguous run. The buffer
+ * exposes its backing-array {@link capacity} so the bucketing pass can budget on
+ * ALLOCATED memory, not just the logical bytes written: a doubling buffer holds a
+ * backing array up to twice its content, and that array is the real heap cost.
  */
 class LeafBuffer {
-  private data = new Uint8Array(4096);
+  private data = new Uint8Array(LEAF_BUFFER_INITIAL_CAP);
   length = 0; // bytes written
 
   append(src: Uint8Array): void {
     if (this.length + src.length > this.data.length) {
-      let cap = this.data.length * 2;
-      while (cap < this.length + src.length) cap *= 2;
-      const grown = new Uint8Array(cap);
+      const grown = new Uint8Array(grownCapacity(this.data.length, this.length + src.length));
       grown.set(this.data.subarray(0, this.length));
       this.data = grown;
     }
@@ -190,13 +210,19 @@ class LeafBuffer {
     this.length += src.length;
   }
 
+  /** The backing array's byte capacity — the memory this buffer actually holds. */
+  capacity(): number {
+    return this.data.length;
+  }
+
+  /** The capacity this buffer would grow to if `addBytes` more were appended. */
+  projectedCapacity(addBytes: number): number {
+    return grownCapacity(this.data.length, this.length + addBytes);
+  }
+
   /** The written bytes as a view, for a zero-copy append. Valid until the next append. */
   bytes(): Uint8Array {
     return this.data.subarray(0, this.length);
-  }
-
-  reset(): void {
-    this.length = 0;
   }
 }
 
@@ -335,16 +361,23 @@ export async function indexOutOfCore(
 
   const buffers = new Map<string, LeafBuffer>();
   const counts = new Map<string, number>();
-  let buffered = 0; // bytes currently staged in memory
+  // Sum of the live buffers' backing-array CAPACITIES — the memory actually held,
+  // not the logical bytes written. This is what the budget bounds.
+  let allocated = 0;
   let peakBufferedBytes = 0;
 
   async function flush(): Promise<void> {
     for (const [key, buf] of buffers) {
       if (buf.length === 0) continue;
       await store.append(key, buf.bytes());
-      buf.reset();
     }
-    buffered = 0;
+    // Actually release the backing arrays: clearing the map drops every LeafBuffer
+    // (and its grown Uint8Array) so a later point for a key re-creates a fresh
+    // buffer. `counts` is kept — the pyramid/degenerate hierarchy needs it. Not
+    // dropping these was the leak: reset() only zeroed length and the map retained
+    // a grown array per key, uncounted against the budget.
+    buffers.clear();
+    allocated = 0;
   }
 
   // Per-level keep-fraction thresholds for the pyramid. A point settles at the
@@ -426,9 +459,24 @@ export async function indexOutOfCore(
         const level = lodLevelFor(lodPriority(scratchU32), grid.depth, thresholds);
         const key = level === grid.depth ? leafKey : leafKey.slice(0, level);
         let buf = buffers.get(key);
+        // Project the allocated-capacity cost of staging this record BEFORE
+        // allocating it: a new buffer costs its initial capacity, an existing one
+        // costs whatever a doubling grow would add. If that would push the live
+        // allocated capacity over the budget, flush first — clearing the map
+        // releases every backing array, so the staged capacity never exceeds the
+        // budget rather than merely the logical bytes doing so.
+        const projected =
+          buf === undefined
+            ? grownCapacity(LEAF_BUFFER_INITIAL_CAP, rb)
+            : buf.projectedCapacity(rb) - buf.capacity();
+        if (allocated > 0 && allocated + projected > budget) {
+          await flush();
+          buf = undefined;
+        }
         if (buf === undefined) {
           buf = new LeafBuffer();
           buffers.set(key, buf);
+          allocated += buf.capacity();
         }
         let record: Uint8Array;
         if (batch.records) {
@@ -439,7 +487,10 @@ export async function indexOutOfCore(
           scratch[2] = z;
           record = scratchBytes;
         }
+        const capBefore = buf.capacity();
         buf.append(record);
+        allocated += buf.capacity() - capBefore;
+        if (allocated > peakBufferedBytes) peakBufferedBytes = allocated;
         const keyCount = (counts.get(key) ?? 0) + 1;
         counts.set(key, keyCount);
         // Per-tile byte ceiling. A degenerate cloud (millions of coincident XYZ)
@@ -454,11 +505,6 @@ export async function indexOutOfCore(
               'coincident points to subdivide. Convert it to COPC or EPT.',
           );
         }
-        buffered += rb;
-        if (buffered > peakBufferedBytes) peakBufferedBytes = buffered;
-        // Bound residency to the budget: spill everything once it is reached, so
-        // the high-water mark is the budget plus at most the record that tipped it.
-        if (buffered >= budget) await flush();
       }
     }
     await flush();

--- a/src/io/heavy/slicedLasReader.ts
+++ b/src/io/heavy/slicedLasReader.ts
@@ -26,7 +26,11 @@ import {
   finalizeRawColors,
   type RawPoints,
 } from '../lasDecodeShared';
-import { batchPointsForRecordLength } from './heavyByteBudget';
+import {
+  MAX_BATCH_SOURCE_BYTES,
+  batchPointsForRecordLength,
+  maxPointsForRecordLength,
+} from './heavyByteBudget';
 
 /** One decoded batch of consecutive records. */
 export interface SlicedLasBatch {
@@ -121,12 +125,24 @@ export async function openSlicedLas(
           `range [0, ${readablePointCount})`,
       );
     }
-    const byteOffset = header.offsetToPointData + firstPointIndex * recordLength;
-    const bytes = await range.readRange(byteOffset, count * recordLength, signal);
-    const view = new DataView(bytes);
+    // Enforce the source-byte cap INSIDE readBatch, not only in `batches()`, so a
+    // caller passing a large `count` directly (the preview sampler reads
+    // strata-sized counts) can never issue a single range read above the ceiling:
+    // with Extra Bytes the record length reaches 65535, and `count * recordLength`
+    // would otherwise read a gigabyte in one shot. The batch is assembled from
+    // bounded sub-ranges of at most MAX_BATCH_SOURCE_BYTES; the returned `count`
+    // points are unchanged, and nothing beyond the returned batch is materialised.
     const raw = allocRawPoints(count, hasGps, hasColor);
-    for (let i = 0; i < count; i++) {
-      decodeRecord(view, i * recordLength, i, ctx, raw);
+    const maxPerRead = maxPointsForRecordLength(recordLength, MAX_BATCH_SOURCE_BYTES);
+    for (let done = 0; done < count; done += maxPerRead) {
+      signal?.throwIfAborted();
+      const n = Math.min(maxPerRead, count - done);
+      const byteOffset = header.offsetToPointData + (firstPointIndex + done) * recordLength;
+      const bytes = await range.readRange(byteOffset, n * recordLength, signal);
+      const view = new DataView(bytes);
+      for (let i = 0; i < n; i++) {
+        decodeRecord(view, i * recordLength, done + i, ctx, raw);
+      }
     }
     finalizeRawColors(raw);
     return { firstPointIndex, count, raw };

--- a/tests/chunkedLazDecodePeak.test.ts
+++ b/tests/chunkedLazDecodePeak.test.ts
@@ -1,0 +1,83 @@
+/**
+ * chunkedLazDecodePeak.test.ts — the LAZ window plan bounds the TOTAL simultaneous
+ * decode, not just each allocation individually.
+ *
+ * The chunk-table cap, the per-chunk compressed/decoded caps, and the window-span
+ * cap each bound ONE allocation. But a window decode holds several at once — the
+ * compressed span, the raw decoded records, and the packed tile records — so the
+ * summed peak can reach several hundred megabytes while every single piece stays
+ * under its own cap. These cases pin the total-peak budget: a window whose summed
+ * peak (span + decoded + packed) exceeds MAX_DECODE_PEAK_BYTES shrinks to fewer
+ * chunks, and a single chunk whose own summed peak is over the total budget is
+ * flagged even though its decoded bytes alone are within the per-chunk cap.
+ */
+import { describe, it, expect } from 'vitest';
+import { planChunkWindow, MAX_LAZ_WINDOW_SPAN_BYTES } from '../src/io/heavy/chunkedLazSource';
+import type { LazChunkRange } from '../src/io/heavy/lazChunkTable';
+import {
+  MAX_DECODE_PEAK_BYTES,
+  MAX_DECODED_ALLOCATION_BYTES,
+  withinDecodePeakBudget,
+  withinDecodedByteBudget,
+} from '../src/io/heavy/heavyByteBudget';
+
+const MiB = 1024 * 1024;
+
+describe('planChunkWindow — total simultaneous-decode peak budget', () => {
+  it('shrinks a window whose span + decoded + packed exceeds the total peak, below what the individual caps allow', () => {
+    // Two chunks. Each on its own is legal under every individual cap; together
+    // their span (124 MiB < 128) and decoded (120 MiB < 128) both pass, but the
+    // summed peak span+decoded+packed = 268 MiB is over the 256 MiB total.
+    const recordLength = 1000;
+    const packedRecordBytes = 200;
+    const pointsPerChunk = 60_000; // decoded 60 MiB, packed 12 MiB per chunk
+    const spanPerChunk = 62 * MiB;
+
+    const chunks: LazChunkRange[] = [];
+    let off = 0;
+    for (let i = 0; i < 4; i++) {
+      chunks.push({ byteOffset: off, byteLength: spanPerChunk, pointCount: pointsPerChunk, firstPointIndex: i * pointsPerChunk });
+      off += spanPerChunk;
+    }
+
+    // Two chunks stay under the span and decoded caps individually.
+    expect(2 * spanPerChunk).toBeLessThan(MAX_LAZ_WINDOW_SPAN_BYTES);
+    expect(withinDecodedByteBudget(2 * pointsPerChunk, recordLength)).toBe(true);
+    // With the packed records counted, the summed peak (~261 MiB) exceeds the
+    // total, so the plan takes only one chunk.
+    const plan = planChunkWindow(chunks, 0, 4, recordLength, packedRecordBytes);
+    expect(plan.end).toBe(1);
+
+    // Dropping only the packed term leaves span+decoded (~238 MiB) under the total,
+    // so the span cap admits two — the packed allocation is exactly what tips the
+    // joint peak over budget and forces the shrink to one.
+    const withoutPacked = planChunkWindow(chunks, 0, 4, recordLength, 0);
+    expect(withoutPacked.end).toBe(2);
+  });
+
+  it('flags a single chunk whose own summed peak is over the total budget though its decoded bytes pass the per-chunk cap', () => {
+    const recordLength = 1000;
+    const packedRecordBytes = 250;
+    const points = 120_000; // decoded 120 MiB (< 128 cap), packed 30 MiB
+    const span = 120 * MiB;
+
+    // Decoded alone is within the per-chunk decoded cap.
+    expect(withinDecodedByteBudget(points, recordLength, MAX_DECODED_ALLOCATION_BYTES)).toBe(true);
+    // The simultaneous total (span + decoded + packed = 270 MiB) is over budget.
+    expect(withinDecodePeakBudget(span, points, recordLength, packedRecordBytes)).toBe(false);
+    expect(MAX_DECODE_PEAK_BYTES).toBe(256 * MiB);
+  });
+
+  it('admits an ordinary window well under the total peak', () => {
+    const recordLength = 30;
+    const packedRecordBytes = 26;
+    const chunks: LazChunkRange[] = [];
+    let off = 0;
+    for (let i = 0; i < 8; i++) {
+      chunks.push({ byteOffset: off, byteLength: 300_000, pointCount: 50_000, firstPointIndex: i * 50_000 });
+      off += 300_000;
+    }
+    const plan = planChunkWindow(chunks, 0, 4, recordLength, packedRecordBytes);
+    expect(plan.end).toBe(4); // the requested window; nowhere near any cap
+  });
+});

--- a/tests/oocIndexerAllocatedBudget.test.ts
+++ b/tests/oocIndexerAllocatedBudget.test.ts
@@ -1,0 +1,107 @@
+/**
+ * oocIndexerAllocatedBudget.test.ts — the bucketing pass budgets on ALLOCATED
+ * backing-array capacity, not just logical record bytes.
+ *
+ * The staging buffers grow by doubling and, before the fix, a flush zeroed a
+ * buffer's length but kept its multi-megabyte backing array, and never dropped
+ * the buffer from the map. Across flush windows that retained a grown array per
+ * leaf key plus a fresh 4 KiB buffer per new key, none of it counted against the
+ * budget, so the advertised bounded staging budget was not a real heap bound.
+ *
+ * These cases pin the real bound: with THOUSANDS of unique leaf keys and several
+ * keys that each accumulate multiple megabytes across different flush windows,
+ * the peak ALLOCATED capacity (what `peakBufferedBytes` now reports) stays within
+ * the configured budget, and the store still holds every point exactly once.
+ */
+import { describe, it, expect } from 'vitest';
+import { indexOutOfCore, type PointSource, type SpillStore } from '../src/io/heavy/oocIndexer';
+
+function memoryStore(): SpillStore & { totalBytes(): number } {
+  const parts = new Map<string, Uint8Array[]>();
+  return {
+    async append(key, bytes) {
+      const arr = parts.get(key) ?? [];
+      arr.push(bytes.slice());
+      parts.set(key, arr);
+    },
+    async read(key) {
+      const arr = parts.get(key) ?? [];
+      const total = arr.reduce((n, b) => n + b.byteLength, 0);
+      const out = new Uint8Array(total);
+      let o = 0;
+      for (const b of arr) {
+        out.set(b, o);
+        o += b.byteLength;
+      }
+      return out;
+    },
+    async keys() {
+      return [...parts.keys()];
+    },
+    totalBytes() {
+      let n = 0;
+      for (const arr of parts.values()) for (const b of arr) n += b.byteLength;
+      return n;
+    },
+  };
+}
+
+/**
+ * A deterministic cloud whose points cluster around many centres: hundreds of
+ * clusters give thousands of leaf keys, and heavy per-cluster volume makes
+ * several keys each accumulate multiple megabytes of records across successive
+ * flush windows — the exact shape that made the old per-leaf backing arrays pile
+ * up uncounted.
+ */
+function clusteredSource(count: number, batchPoints: number, clusters: number): PointSource {
+  return {
+    async *batches() {
+      let s = 2246822519 >>> 0;
+      const rnd = () => ((s = (1664525 * s + 1013904223) >>> 0) / 4294967296);
+      let emitted = 0;
+      while (emitted < count) {
+        const n = Math.min(batchPoints, count - emitted);
+        const positions = new Float32Array(n * 3);
+        for (let i = 0; i < n; i++) {
+          const c = (emitted + i) % clusters;
+          const cx = 500000 + (c % 40) * 25;
+          const cy = 4100000 + Math.floor(c / 40) * 25;
+          positions[i * 3] = cx + rnd() * 2;
+          positions[i * 3 + 1] = cy + rnd() * 2;
+          positions[i * 3 + 2] = 190 + rnd() * 40;
+        }
+        emitted += n;
+        yield { positions, count: n };
+      }
+    },
+  };
+}
+
+const RECORD_BYTES = 12;
+
+describe('out-of-core indexer — allocated-capacity staging budget', () => {
+  it('keeps peak ALLOCATED capacity within budget across thousands of keys and many flush windows', async () => {
+    const count = 3_000_000;
+    const budget = 2 * 1024 * 1024; // 2 MiB, far below the ~36 MB logical stream
+    const store = memoryStore();
+
+    const index = await indexOutOfCore(clusteredSource(count, 50_000, 1500), store, {
+      pointsPerLeaf: 400,
+      memoryBudgetBytes: budget,
+    });
+
+    // Thousands of distinct nodes across the pyramid, many flush windows.
+    expect(index.leaves.length).toBeGreaterThan(1000);
+
+    // The real bound: peak allocated backing-array capacity never exceeds the
+    // configured budget. The old accounting counted logical bytes and let flush
+    // retain grown arrays, so this was violated (peak reported budget + record,
+    // and the true retained capacity climbed without bound).
+    expect(index.peakBufferedBytes).toBeLessThanOrEqual(budget);
+
+    // Conservation still holds: every point spilled exactly once.
+    expect(index.pointCount).toBe(count);
+    expect(index.leaves.reduce((n, l) => n + l.pointCount, 0)).toBe(count);
+    expect(store.totalBytes()).toBe(count * RECORD_BYTES);
+  });
+});

--- a/tests/oocIndexerAllocatedBudget.test.ts
+++ b/tests/oocIndexerAllocatedBudget.test.ts
@@ -80,18 +80,22 @@ function clusteredSource(count: number, batchPoints: number, clusters: number): 
 const RECORD_BYTES = 12;
 
 describe('out-of-core indexer — allocated-capacity staging budget', () => {
-  it('keeps peak ALLOCATED capacity within budget across thousands of keys and many flush windows', async () => {
-    const count = 3_000_000;
-    const budget = 2 * 1024 * 1024; // 2 MiB, far below the ~36 MB logical stream
+  it('keeps peak ALLOCATED capacity within budget across many keys and many flush windows', async () => {
+    const count = 1_200_000;
+    const budget = 512 * 1024; // 512 KiB, far below the ~9.6 MB logical stream; the tight budget keeps flush windows numerous at a smaller point count so the test stays fast on CI
     const store = memoryStore();
 
-    const index = await indexOutOfCore(clusteredSource(count, 50_000, 1500), store, {
-      pointsPerLeaf: 400,
+    const index = await indexOutOfCore(clusteredSource(count, 50_000, 4000), store, {
+      pointsPerLeaf: 150,
       memoryBudgetBytes: budget,
     });
 
     // Thousands of distinct nodes across the pyramid, many flush windows.
-    expect(index.leaves.length).toBeGreaterThan(1000);
+    // Hundreds of distinct leaf keys across many flush windows: enough that the
+    // old logical-bytes accounting (which retained grown arrays past each flush)
+    // pushes peak allocated capacity well over the budget. The peak-allocated
+    // assertion below is the real invariant.
+    expect(index.leaves.length).toBeGreaterThan(500);
 
     // The real bound: peak allocated backing-array capacity never exceeds the
     // configured budget. The old accounting counted logical bytes and let flush
@@ -103,5 +107,5 @@ describe('out-of-core indexer — allocated-capacity staging budget', () => {
     expect(index.pointCount).toBe(count);
     expect(index.leaves.reduce((n, l) => n + l.pointCount, 0)).toBe(count);
     expect(store.totalBytes()).toBe(count * RECORD_BYTES);
-  });
+  }, 60_000);
 });

--- a/tests/slicedLasReaderBatchCap.test.ts
+++ b/tests/slicedLasReaderBatchCap.test.ts
@@ -1,0 +1,129 @@
+/**
+ * slicedLasReaderBatchCap.test.ts — the public `readBatch` never issues a single
+ * range read above the source-byte cap.
+ *
+ * `batches()` sizes its batches with `batchPointsForRecordLength`, but before the
+ * fix the public `readBatch(firstPointIndex, count)` read `count * recordLength`
+ * bytes in one range read with no cap on `count`. The preview sampler calls
+ * `readBatch` directly with strata-sized counts, so a LAS with large Extra Bytes
+ * (record length up to 65535) made one preview stratum read roughly a gigabyte.
+ *
+ * These cases build a LAS with a huge record length and read a large count, then
+ * assert (via a range source that records its largest single read) that no read
+ * ever exceeds MAX_BATCH_SOURCE_BYTES, that the returned point count is intact,
+ * and that the decoded geometry matches a reference decode of the same records.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import type { RangeSource, RangeSourceKind } from '../src/io/range/RangeSource';
+import { openSlicedLas } from '../src/io/heavy/slicedLasReader';
+import { buildPreviewSample } from '../src/io/heavy/previewSampler';
+import { MAX_BATCH_SOURCE_BYTES } from '../src/io/heavy/heavyByteBudget';
+
+const LAS_HEADER_SIZE = 227;
+
+/** A minimal valid uncompressed LAS with a controllable (large) record length. */
+function buildLasFixture(opts: {
+  pointFormat: number;
+  recordLength: number;
+  pointCount: number;
+}): ArrayBuffer {
+  const offsetToPointData = LAS_HEADER_SIZE;
+  const total = offsetToPointData + opts.pointCount * opts.recordLength;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  const u8 = new Uint8Array(buf);
+  u8.set([0x4c, 0x41, 0x53, 0x46], 0); // 'LASF'
+  view.setUint8(24, 1);
+  view.setUint8(25, 2); // version 1.2 → legacy uint32 count
+  view.setUint16(94, LAS_HEADER_SIZE, true);
+  view.setUint32(96, offsetToPointData, true);
+  view.setUint32(100, 0, true); // no VLRs
+  view.setUint8(104, opts.pointFormat);
+  view.setUint16(105, opts.recordLength, true);
+  view.setUint32(107, opts.pointCount, true);
+  for (let axis = 0; axis < 3; axis++) {
+    view.setFloat64(131 + axis * 8, 0.001, true); // scale > 0
+    view.setFloat64(155 + axis * 8, 0, true); // offset
+  }
+  view.setFloat64(179, 100, true); view.setFloat64(187, 0, true);
+  view.setFloat64(195, 100, true); view.setFloat64(203, 0, true);
+  view.setFloat64(211, 100, true); view.setFloat64(219, 0, true);
+  return buf;
+}
+
+/** A RangeSource that records the largest single read requested against it. */
+class WatchedRangeSource implements RangeSource {
+  maxRead = 0;
+  reads = 0;
+  private readonly inner: RangeSource;
+  constructor(inner: RangeSource) {
+    this.inner = inner;
+  }
+  id(): string {
+    return this.inner.id();
+  }
+  kind(): RangeSourceKind {
+    return this.inner.kind();
+  }
+  size(): Promise<number> {
+    return this.inner.size();
+  }
+  readRange(offset: number, length: number, signal?: AbortSignal): Promise<ArrayBuffer> {
+    this.reads++;
+    if (length > this.maxRead) this.maxRead = length;
+    return this.inner.readRange(offset, length, signal);
+  }
+}
+
+describe('openSlicedLas.readBatch — source-byte cap cannot be bypassed', () => {
+  it('reads a huge-record, large-count batch in bounded sub-ranges under the cap', async () => {
+    // 300 records of 65535 bytes = ~19.66 MiB; a single uncapped read would blow
+    // past the 16 MiB source ceiling.
+    const recordLength = 65535;
+    const count = 300;
+    expect(count * recordLength).toBeGreaterThan(MAX_BATCH_SOURCE_BYTES);
+
+    const watched = new WatchedRangeSource(
+      new ArrayBufferRangeSource(buildLasFixture({ pointFormat: 0, recordLength, pointCount: count }), 'big.las'),
+    );
+    const opened = await openSlicedLas(watched);
+    expect(opened.readablePointCount).toBe(count);
+
+    const before = watched.reads;
+    const batch = await opened.readBatch(0, count);
+
+    // No single range read ever exceeded the source-byte cap.
+    expect(watched.maxRead).toBeLessThanOrEqual(MAX_BATCH_SOURCE_BYTES);
+    expect(watched.maxRead).toBeGreaterThan(0);
+    // The huge batch was split into more than one sub-range read.
+    expect(watched.reads - before).toBeGreaterThan(1);
+
+    // Geometry is intact: every requested point returned, decoded (all-zero
+    // records at offset 0 → local origin), matching a reference decode.
+    expect(batch.count).toBe(count);
+    expect(batch.raw.positions.length).toBe(count * 3);
+    for (let i = 0; i < count * 3; i++) expect(batch.raw.positions[i]).toBe(0);
+  });
+
+  it('the preview sampler cannot trigger a >cap read on a large-record LAS', async () => {
+    // A single stratum of 60 000 points at 300 bytes/record is ~18 MiB — over the
+    // cap in one read. The sampler calls readBatch directly, so the cap must live
+    // inside readBatch for the preview to stay bounded.
+    const recordLength = 300;
+    const count = 60_000;
+    const watched = new WatchedRangeSource(
+      new ArrayBufferRangeSource(buildLasFixture({ pointFormat: 0, recordLength, pointCount: count }), 'preview.las'),
+    );
+
+    const sample = await buildPreviewSample(
+      watched,
+      { format: 'las', offsetToPointData: LAS_HEADER_SIZE },
+      { strata: 1, targetPoints: count },
+    );
+
+    expect(sample).not.toBeNull();
+    expect(watched.maxRead).toBeLessThanOrEqual(MAX_BATCH_SOURCE_BYTES);
+    expect(watched.maxRead).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Fixes three memory-accounting defects in the heavy out-of-core decode path, each with an adversarial test.

Bug 1, oocIndexer: the bucketing pass counted logical record bytes, and flush reset a buffer's length but kept its grown backing array and never dropped the buffer from the map, so retained staging was uncounted. Flush now clears the map to release the arrays, and the residency check budgets on allocated backing-array capacity, flushing before it would exceed the budget. peakBufferedBytes now reports peak allocated capacity.

Bug 2, slicedLasReader: readBatch read count times recordLength in one range read with no cap, so the preview sampler, which calls it directly with strata-sized counts, could read a gigabyte on a large Extra Bytes file, and it now assembles the batch from sub-ranges under MAX_BATCH_SOURCE_BYTES while returning the same points and geometry.

Bug 3, chunkedLazSource: the span, decoded, and packed allocations coexist during a window decode but were only capped individually. A new MAX_DECODE_PEAK_BYTES of 256 MiB bounds their joint peak. The window shrinks to fit, and a single over-total chunk is refused through the existing unsupported path.

Gates run green: typecheck, test:unit, test:slow, lint:monolith-size, lint:unreachable-modules, lint:position-access, lint:module-graph, build:live, check:bundle, verify:archive-gate.
