### PR TITLE
fix(copc): reconcile hierarchy point total against LAS header

### DIFF
--- a/src/render/streaming/StreamingOctree.ts
+++ b/src/render/streaming/StreamingOctree.ts
@@ -21,6 +21,47 @@ import type { StreamingNode } from './StreamingNode';
 /** A hard cap on hierarchy pages, so a malformed file cannot loop forever. */
 const MAX_HIERARCHY_PAGES = 4096;
 
+/**
+ * The named reason pushed into {@link StreamingOctree.errors} when the resolved
+ * hierarchy's point total does not equal the LAS header's declared count. A
+ * consumer greps for this to tell a count gap apart from a fetch/parse error.
+ */
+export const POINT_COUNT_MISMATCH = 'POINT_COUNT_MISMATCH';
+
+/**
+ * The outcome of reconciling the LAS header's declared point total against the
+ * sum of the resolved hierarchy's per-node counts.
+ *
+ * - `EXACT`   — the hierarchy is fully resolved AND its counts sum to the header.
+ * - `MISMATCH` — fully resolved, but the sums disagree (a page/subtree is missing
+ *   or the file's own totals are inconsistent).
+ * - `UNKNOWN` — the hierarchy is not yet fully resolved, so no verdict is possible.
+ */
+export type PointTotalStatus = 'EXACT' | 'MISMATCH' | 'UNKNOWN';
+
+/** A declared-vs-resolved point-total comparison. */
+export interface PointTotalReconciliation {
+  readonly status: PointTotalStatus;
+  /** The LAS header's declared point count. */
+  readonly declared: number;
+  /** The sum of the resolved hierarchy's per-node point counts. */
+  readonly resolved: number;
+}
+
+/**
+ * Compare a declared total (LAS header) against a resolved hierarchy total.
+ * Until the hierarchy is fully resolved the resolved sum is still growing, so
+ * the only honest verdict is `UNKNOWN` — never `EXACT`.
+ */
+export function reconcilePointTotals(
+  declared: number,
+  resolved: number,
+  hierarchyResolved: boolean,
+): PointTotalReconciliation {
+  if (!hierarchyResolved) return { status: 'UNKNOWN', declared, resolved };
+  return { status: declared === resolved ? 'EXACT' : 'MISMATCH', declared, resolved };
+}
+
 /** The octree of a COPC file — its node store and hierarchy ingestion. */
 export class StreamingOctree {
   readonly store = new StreamingNodeStore();
@@ -56,7 +97,32 @@ export class StreamingOctree {
    * gate on THIS, not on `fullyLoaded`.
    */
   get isComplete(): boolean {
-    return this._fullyLoaded && this._errors.length === 0;
+    return (
+      this._fullyLoaded &&
+      this._errors.length === 0 &&
+      this.pointTotals.status === 'EXACT'
+    );
+  }
+
+  /**
+   * The declared (LAS header) vs resolved (Σ hierarchy node counts) point-total
+   * reconciliation. Reads `UNKNOWN` until the hierarchy is fully resolved, then
+   * `EXACT` or `MISMATCH`. A consumer that needs scientific completeness (the
+   * full-cloud grade's "exact" label) requires `EXACT`.
+   */
+  get pointTotals(): PointTotalReconciliation {
+    return reconcilePointTotals(
+      this._source.metadata.header.pointCount,
+      this._resolvedPointCount(),
+      this._fullyLoaded,
+    );
+  }
+
+  /** Sum of every resolved node's declared point count. */
+  private _resolvedPointCount(): number {
+    let total = 0;
+    for (const node of this.store.all()) total += node.record.pointCount;
+    return total;
   }
 
   /** Every known node. */
@@ -129,6 +195,19 @@ export class StreamingOctree {
 
     this._resolveChildLinks();
     this._fullyLoaded = true;
+
+    // Reconcile the COPC partition invariant: Σ(node point counts) must equal
+    // the LAS header's declared total. A hierarchy can walk to completion with
+    // no fetch/parse error yet still sum short (a dropped subtree, an
+    // inconsistent file), which no other check above would catch. Record the
+    // gap as a named reason so `isComplete` goes false and a consumer can see
+    // the declared/resolved totals rather than silently overclaiming "exact".
+    const totals = this.pointTotals;
+    if (totals.status === 'MISMATCH') {
+      this._errors.push(
+        `${POINT_COUNT_MISMATCH}: LAS header declares ${totals.declared} points but the resolved hierarchy sums to ${totals.resolved}`,
+      );
+    }
   }
 
   /** Add a page's data nodes to the store and record its parse errors. */

--- a/tests/fixtures/copc/synthCopc.ts
+++ b/tests/fixtures/copc/synthCopc.ts
@@ -60,6 +60,13 @@ export interface SynthCopcOptions {
   headerMin?: [number, number, number];
   headerMax?: [number, number, number];
   spacing?: number;
+  /**
+   * Override the LAS header's declared point count. By default the header count
+   * equals the sum of the node point counts (the COPC partition invariant); set
+   * this to model a file whose header disagrees with the hierarchy sum, so a
+   * declared-vs-resolved reconciliation can be exercised.
+   */
+  headerPointCount?: number;
   /** Flat node list — wrapped in a single root page. */
   nodes?: SynthNode[];
   /** Explicit multi-page layout; `pages[0]` is the root. Overrides `nodes`. */
@@ -143,6 +150,10 @@ export function buildSyntheticCopc(options: SynthCopcOptions = {}): SynthCopcRes
   }
   const chunksTotal = chunkCursor - pointDataOffset;
 
+  // The declared header count defaults to the true node sum (the partition
+  // invariant); an override lets a test model a header that disagrees.
+  const headerPointCount = options.headerPointCount ?? pointCount;
+
   const evlrHeaderStart = pointDataOffset + chunksTotal;
   const pagesStart = evlrHeaderStart + EVLR_HEADER_SIZE;
   const rootHierOffset = pagesStart + resolved[0].blobOffset;
@@ -170,7 +181,7 @@ export function buildSyntheticCopc(options: SynthCopcOptions = {}): SynthCopcRes
   view.setUint32(100, 1, true); // one VLR — the COPC info VLR
   view.setUint8(104, pdrf);
   view.setUint16(105, recordLength, true);
-  view.setUint32(107, pointCount > 0xffffffff ? 0 : pointCount, true);
+  view.setUint32(107, headerPointCount > 0xffffffff ? 0 : headerPointCount, true);
   view.setFloat64(131, scale[0], true);
   view.setFloat64(139, scale[1], true);
   view.setFloat64(147, scale[2], true);
@@ -190,7 +201,7 @@ export function buildSyntheticCopc(options: SynthCopcOptions = {}): SynthCopcRes
   view.setFloat64(219, hMin[2], true);
   view.setBigUint64(235, BigInt(evlrHeaderStart), true);
   view.setUint32(243, 1, true); // one EVLR — the COPC hierarchy
-  view.setBigUint64(247, BigInt(pointCount), true);
+  view.setBigUint64(247, BigInt(headerPointCount), true);
 
   // --- COPC info VLR (header at 375, payload at 429) -------------------------
   writeAscii(377, options.corrupt === 'no-copc-vlr' ? 'LASF_Spec' : 'copc', 16);

--- a/tests/streamingOctree.test.ts
+++ b/tests/streamingOctree.test.ts
@@ -278,6 +278,75 @@ test('StreamingOctree: hitting the hierarchy-page ceiling loads short → NOT co
   expect(cloud.octree.isComplete).toBe(false);
 });
 
+// --- StreamingOctree point-count reconciliation ------------------------------
+//
+// A COPC octree partitions the file: every point sits in exactly one node, so
+// Σ(node point counts) === LAS-header point count is an exact invariant. A
+// hierarchy can walk to completion with no fetch/parse error yet still resolve
+// to fewer points than the header declares — a gap no other completeness check
+// above would catch. These pin that the reconciliation catches it.
+
+test('StreamingOctree: hierarchy summing SHORT of the header → MISMATCH, not complete', async () => {
+  // Nodes sum to 1400, but the LAS header declares 2000 — a whole subtree's
+  // worth of points the hierarchy never accounts for, with no parse error.
+  const fixture = buildSyntheticCopc({
+    center: [0, 0, 0],
+    halfsize: 128,
+    nodes: [
+      { key: [0, 0, 0, 0], pointCount: 1000 },
+      { key: [1, 0, 0, 0], pointCount: 400 },
+    ],
+    headerPointCount: 2000,
+  });
+  const cloud = await StreamingPointCloud.open(
+    new ArrayBufferRangeSource(fixture.buffer),
+    'short.copc.laz',
+  );
+  // Structurally the walk looks healthy: it finished and dropped nothing.
+  expect(cloud.octree.fullyLoaded).toBe(true);
+  expect(cloud.octree.nodes()).toHaveLength(2);
+
+  const totals = cloud.octree.pointTotals;
+  expect(totals.status).toBe('MISMATCH');
+  expect(totals.declared).toBe(2000);
+  expect(totals.resolved).toBe(1400);
+  expect(cloud.octree.errors.some((e) => e.startsWith('POINT_COUNT_MISMATCH'))).toBe(true);
+  expect(cloud.octree.isComplete).toBe(false);
+});
+
+test('StreamingOctree: hierarchy summing to the header → EXACT and complete', async () => {
+  const fixture = buildSyntheticCopc({
+    center: [0, 0, 0],
+    halfsize: 128,
+    nodes: [
+      { key: [0, 0, 0, 0], pointCount: 1000 },
+      { key: [1, 0, 0, 0], pointCount: 400 },
+    ],
+    // headerPointCount omitted → defaults to the true node sum (1400).
+  });
+  const cloud = await StreamingPointCloud.open(
+    new ArrayBufferRangeSource(fixture.buffer),
+    'exact.copc.laz',
+  );
+  const totals = cloud.octree.pointTotals;
+  expect(totals.status).toBe('EXACT');
+  expect(totals.declared).toBe(1400);
+  expect(totals.resolved).toBe(1400);
+  expect(cloud.octree.errors).toEqual([]);
+  expect(cloud.octree.isComplete).toBe(true);
+});
+
+test('StreamingOctree: an unresolved hierarchy reads UNKNOWN, never EXACT', async () => {
+  const fixture = twoPageFixture();
+  const source = await CopcSource.open(new ArrayBufferRangeSource(fixture.buffer));
+  const octree = new StreamingOctree(source);
+  // Before loadFullHierarchy: only the root page is ingested, the walk has not
+  // finished, so no EXACT/MISMATCH verdict is possible.
+  expect(octree.fullyLoaded).toBe(false);
+  expect(octree.pointTotals.status).toBe('UNKNOWN');
+  expect(octree.isComplete).toBe(false);
+});
+
 // --- StreamingOctree cancel vs. timeout on the hierarchy walk ----------------
 //
 // The mid-walk `signal.aborted` guard must keep the three outcomes distinct: a


### PR DESCRIPTION
## What

A COPC octree partitions the file, so the LAS header point count equals
the sum of the hierarchy's per-node counts. `StreamingOctree.isComplete`
checked only that the walk finished with no fetch or parse error, so a
structurally valid hierarchy resolving short of the header (a dropped
subtree whose own parse raised nothing, an inconsistent file) still read
complete and fed the full-cloud grade an "exact" label it had not earned.

## Change

Add a declared-vs-resolved reconciliation yielding `EXACT`, `MISMATCH`,
or `UNKNOWN`, exposed as `octree.pointTotals`. `isComplete` now also
requires `EXACT`; a short sum records a named `POINT_COUNT_MISMATCH`
reason carrying both totals. An unresolved hierarchy reads `UNKNOWN`,
never `EXACT`. Visualization is unaffected; only the completeness claim
tightens. Tests cover short, exact, and unresolved cases.
