### PR TITLE
Skip clone of uncached oversized chunk; cancel abandoned range bodies

### DIFF
--- a/src/io/range/HttpRangeSource.ts
+++ b/src/io/range/HttpRangeSource.ts
@@ -229,18 +229,21 @@ export class HttpRangeSource implements RangeSource {
     // retried into correctness, because the bytes already decoded belong to a
     // version that no longer exists.
     if (response.status === PRECONDITION_FAILED) {
+      cancelResponseBody(response);
       throw new RangeReadError('resource-changed', RESOURCE_CHANGED_MESSAGE);
     }
     // 206 Partial Content is the expected success. A 200 means the server
     // ignored the Range header and is sending the whole file — that defeats
     // streaming, so it is treated as range-unsupported rather than accepted.
     if (response.status === 200) {
+      cancelResponseBody(response);
       throw new RangeReadError(
         'range-unsupported',
         'This server ignored the range request and returned the whole file.',
       );
     }
     if (response.status !== 206) {
+      cancelResponseBody(response);
       throw new RangeReadError(
         response.status >= 500 ? 'server-error' : 'transport',
         `Range read returned an unexpected status ${response.status}`,
@@ -302,12 +305,14 @@ export class HttpRangeSource implements RangeSource {
       signal,
     );
     if (response.status === 200) {
+      cancelResponseBody(response);
       throw new RangeReadError(
         'range-unsupported',
         'This server ignored the range request and returned the whole file.',
       );
     }
     if (response.status !== 206) {
+      cancelResponseBody(response);
       throw new RangeReadError(
         response.status >= 500 ? 'server-error' : 'transport',
         `Probe returned an unexpected status ${response.status}`,
@@ -488,7 +493,12 @@ export class HttpRangeSource implements RangeSource {
       if (!RETRYABLE_STATUSES.has(response.status)) {
         return response;
       }
-      // Retryable HTTP status — discard the body, back off, try again.
+      // Retryable HTTP status — cancel the unread body before backing off or
+      // throwing, so a slow multi-megabyte error body (a trickling 503) can't
+      // retain network / body resources across the retry or after the final
+      // throw. Best-effort and guarded: a runtime whose Response has no
+      // streaming body just skips it.
+      cancelResponseBody(response);
       lastError = new RangeReadError(
         response.status >= 500 ? 'server-error' : 'transport',
         `Server returned ${response.status} for ${sanitizeUrlForDisplay(this._url)}`,
@@ -509,6 +519,20 @@ export class HttpRangeSource implements RangeSource {
     const ceiling = this._retryBaseMs * Math.pow(2, attempt);
     const delay = Math.max(0, Math.floor(ceiling * this._random()));
     await this._sleep(delay);
+  }
+}
+
+/**
+ * Best-effort cancel a response body we are about to abandon (a retryable error
+ * response, or a non-OK status the caller throws on). Cancelling the stream
+ * releases the connection instead of leaving a slow body to trickle in the
+ * background. Guarded for runtimes / test stand-ins whose Response carries no
+ * streaming body, and for a `cancel()` that itself rejects.
+ */
+function cancelResponseBody(response: Response): void {
+  const body = response.body as ReadableStream<Uint8Array> | null | undefined;
+  if (body && typeof body.cancel === 'function') {
+    void body.cancel().catch(() => undefined);
   }
 }
 

--- a/src/render/streaming/StreamingCache.ts
+++ b/src/render/streaming/StreamingCache.ts
@@ -46,18 +46,27 @@ export class CompressedChunkCache {
     return buffer;
   }
 
-  /** Store a compressed chunk, evicting least-recently-used entries to fit. */
-  put(id: string, bytes: ArrayBuffer): void {
+  /**
+   * Store a compressed chunk, evicting least-recently-used entries to fit.
+   * Returns `true` when the chunk was stored (the cache now holds this exact
+   * buffer, so a caller that transfers it to a worker must copy first), and
+   * `false` when it was refused for exceeding the whole budget (the cache holds
+   * no reference to it, so the caller owns it outright and may transfer it as
+   * is). The explicit result lets the caller skip a defensive copy of an
+   * oversized buffer the cache never took.
+   */
+  put(id: string, bytes: ArrayBuffer): boolean {
     const existing = this._entries.get(id);
     if (existing) {
       this._bytes -= existing.byteLength;
       this._entries.delete(id);
     }
     // A chunk larger than the whole budget is simply not cached.
-    if (bytes.byteLength > this._maxBytes) return;
+    if (bytes.byteLength > this._maxBytes) return false;
     this._entries.set(id, bytes);
     this._bytes += bytes.byteLength;
     this._evictToFit();
+    return true;
   }
 
   /** Whether a node id is cached, without touching its recency. */

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -1617,8 +1617,12 @@ export class StreamingScheduler {
 
   /**
    * Read a node's compressed chunk — from the cache when present, otherwise
-   * from the file (caching the result). The returned buffer is always a fresh
-   * copy, safe to transfer to the decode worker without neutering the cache.
+   * from the file (caching the result). The returned buffer is always safe to
+   * transfer to the decode worker without neutering the cache: a cache hit and
+   * a freshly cached miss both hand back a copy, while a fresh chunk the cache
+   * refused (too big for the budget) is returned as is, since the cache holds
+   * no reference to it — avoiding a needless full-size clone of an oversized
+   * node.
    */
   private async _readChunk(
     node: StreamingNode,
@@ -1628,8 +1632,11 @@ export class StreamingScheduler {
     const cached = this._cache.get(id);
     if (cached) return cached.slice(0);
     const fresh = await this._cloud.readNodeChunk(node.record, signal);
-    this._cache.put(id, fresh);
-    return fresh.slice(0);
+    // When `put` stores the chunk the cache keeps this exact buffer, so the
+    // decoder must get a copy; when it refuses (oversized), the cache holds no
+    // reference and the decoder can own `fresh` directly with no second copy.
+    const stored = this._cache.put(id, fresh);
+    return stored ? fresh.slice(0) : fresh;
   }
 }
 

--- a/tests/remoteObjectIdentity.test.ts
+++ b/tests/remoteObjectIdentity.test.ts
@@ -150,3 +150,54 @@ describe('remote object identity pinning', () => {
     expect(ifMatchSeen[ifMatchSeen.length - 1]).toBeNull(); // then unconditional
   });
 });
+
+describe('retryable response bodies are cancelled before retry/throw (BUG 12)', () => {
+  /** A response whose body.cancel() is observable, of the given status. */
+  function bodyResponse(
+    status: number,
+    onCancel: () => void,
+    headers: Record<string, string> = {},
+  ): Response {
+    return {
+      status,
+      headers: new Headers(headers),
+      body: { cancel: async () => onCancel() },
+    } as unknown as Response;
+  }
+
+  it('cancels the body of a retryable 503 before backing off and after the final throw', async () => {
+    let cancels = 0;
+    const src = new HttpRangeSource(URL, {
+      maxRetries: 1,
+      sleep: async () => {},
+      random: () => 0,
+      fetchImpl: (async () =>
+        bodyResponse(503, () => {
+          cancels += 1;
+        })) as unknown as typeof fetch,
+    });
+    // Probe drives _fetchWithRetryAndTimeout; the 503 is retryable, so the body
+    // is cancelled on the retry AND on the terminal throw — one per attempt.
+    await expect(src.probe()).rejects.toMatchObject({ code: 'server-error' });
+    expect(cancels).toBe(2); // initial attempt + one retry
+  });
+
+  it('cancels the body when a range read throws on a non-206 status', async () => {
+    let cancels = 0;
+    const src = new HttpRangeSource(URL, {
+      maxRetries: 0,
+      sleep: async () => {},
+      fetchImpl: (async (_u: string, init?: RequestInit) => {
+        if (init?.method === 'HEAD') return head({});
+        // A 200 (server ignored Range) is thrown on — its body must be freed.
+        return bodyResponse(200, () => {
+          cancels += 1;
+        });
+      }) as unknown as typeof fetch,
+    });
+    await expect(src.readRange(0, 4)).rejects.toMatchObject({
+      code: 'range-unsupported',
+    });
+    expect(cancels).toBe(1);
+  });
+});

--- a/tests/streamingCache.test.ts
+++ b/tests/streamingCache.test.ts
@@ -50,6 +50,19 @@ test('re-putting an id replaces its bytes without double-counting', () => {
   expect(cache.count).toBe(1);
 });
 
+test('put reports whether the chunk was stored', () => {
+  const cache = new CompressedChunkCache(200);
+  // A chunk that fits is stored → true, and the cache holds this exact buffer.
+  const small = buf(100);
+  expect(cache.put('small', small)).toBe(true);
+  expect(cache.get('small')).toBe(small);
+  // A chunk larger than the whole budget is refused → false, and nothing is
+  // held, so the caller may keep ownership without a defensive copy.
+  const big = buf(500);
+  expect(cache.put('big', big)).toBe(false);
+  expect(cache.has('big')).toBe(false);
+});
+
 test('clear empties the cache', () => {
   const cache = new CompressedChunkCache(1000);
   cache.put('a', buf(100));

--- a/tests/streamingScheduler.test.ts
+++ b/tests/streamingScheduler.test.ts
@@ -1044,3 +1044,83 @@ test('readinessFacts counts are measured over the wanted set, not globally', asy
   expect(f.wantedCount).toBeLessThanOrEqual(cloud.counts().known);
   expect(bucketed).toBeLessThanOrEqual(f.wantedCount);
 });
+
+// --- BUG 11: no needless clone of an uncached oversized chunk ----------------
+
+/** Wrap a cloud so every buffer its `readNodeChunk` returns is recorded by
+ *  identity — the fresh, file-read buffers the scheduler then hands onward. */
+function recordingCloud(
+  cloud: StreamingPointCloud,
+  fresh: Set<ArrayBuffer>,
+): StreamingPointCloud {
+  return new Proxy(cloud, {
+    get(target, prop, receiver) {
+      if (prop === 'readNodeChunk') {
+        return async (...args: Parameters<StreamingPointCloud['readNodeChunk']>) => {
+          const buf = await (target.readNodeChunk as (
+            ...a: typeof args
+          ) => Promise<ArrayBuffer>)(...args);
+          fresh.add(buf);
+          return buf;
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  }) as StreamingPointCloud;
+}
+
+/** A decoder that records the exact chunk buffer it was handed, by identity. */
+function capturingDecoder(seen: ArrayBuffer[]): ChunkDecoder {
+  return {
+    decode(chunk: ArrayBuffer, meta: ChunkDecodeMetadata): Promise<DecodedChunk> {
+      seen.push(chunk);
+      return fakeDecoder.decode(chunk, meta);
+    },
+  };
+}
+
+test('an uncached oversized chunk is handed to the decoder without a second copy', async () => {
+  const cloud = await openCloud();
+  const fresh = new Set<ArrayBuffer>();
+  const seen: ArrayBuffer[] = [];
+  // Cache budget of 1 byte → every node exceeds it and is refused by the cache.
+  const budgets = { ...streamingBudgets('balanced', false), chunkCacheBytes: 1 };
+  const scheduler = new StreamingScheduler(
+    recordingCloud(cloud, fresh),
+    capturingDecoder(seen),
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    budgets,
+  );
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  expect(seen.length).toBeGreaterThan(0);
+  // Every chunk the decoder saw is the SAME buffer instance the file read
+  // produced — no `slice(0)` clone was made for a chunk the cache never stored.
+  for (const chunk of seen) expect(fresh.has(chunk)).toBe(true);
+});
+
+test('a cached chunk is handed to the decoder as a copy, never the cache-held buffer', async () => {
+  const cloud = await openCloud();
+  const fresh = new Set<ArrayBuffer>();
+  const seen: ArrayBuffer[] = [];
+  // A generous cache budget → every node is stored, so the decoder must get a
+  // copy and never the buffer the cache retains.
+  const budgets = {
+    ...streamingBudgets('balanced', false),
+    chunkCacheBytes: 64 * 1024 * 1024,
+  };
+  const scheduler = new StreamingScheduler(
+    recordingCloud(cloud, fresh),
+    capturingDecoder(seen),
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    budgets,
+  );
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  expect(seen.length).toBeGreaterThan(0);
+  expect(fresh.size).toBeGreaterThan(0);
+  for (const chunk of seen) expect(fresh.has(chunk)).toBe(false);
+});


### PR DESCRIPTION
## BUG 11 - scheduler cloned an uncached oversized chunk for no benefit

`CompressedChunkCache.put` now returns whether it stored the chunk. When a
fresh node is larger than the cache budget the cache keeps no reference, so
`_readChunk` returns that buffer directly instead of a full-size `slice(0)`
clone. A stored chunk is still copied so a transfer to the decode worker
cannot neuter the cache's buffer.

## BUG 12 - retryable range bodies were not cancelled

`HttpRangeSource` now best-effort cancels a response body before it retries a
408/429/5xx or throws on a non-206 status, releasing the socket instead of
letting a slow error body trickle across retries.

## Tests

Store/no-store copy contract at the cache and scheduler level, plus body
cancellation on retry and on the terminal throw.
