### PR TITLE
fix(io): free decode-worker slots on cancel and cap EPT tile memory

### DIFF
--- a/src/io/copc/worker/copcWorker.ts
+++ b/src/io/copc/worker/copcWorker.ts
@@ -86,12 +86,21 @@ ctx.onmessage = (event: MessageEvent<InMessage>): void => {
   if (msg.type !== 'decode') return;
 
   const { requestId, chunk, meta } = msg;
-  if (cancelled.consume(requestId)) return;
+  // Every accepted request must post exactly ONE terminal reply. A silent return
+  // on a consumed cancel leaves the pool's slot held forever (its job is only
+  // cleared by a reply), so a cancel-consume return posts `cancelled` first.
+  if (cancelled.consume(requestId)) {
+    ctx.postMessage({ type: 'cancelled', requestId });
+    return;
+  }
 
   void (async (): Promise<void> => {
     try {
       const lazPerf = await getLazPerf();
-      if (cancelled.consume(requestId)) return;
+      if (cancelled.consume(requestId)) {
+        ctx.postMessage({ type: 'cancelled', requestId });
+        return;
+      }
       const raw = decompressChunk(lazPerf, chunk, meta);
       const decoded = decodeRecords(raw, meta);
       ctx.postMessage(

--- a/src/io/ept/eptLaszipDecode.ts
+++ b/src/io/ept/eptLaszipDecode.ts
@@ -47,6 +47,11 @@ import {
   validateDeclaredPointCount,
   compressedBytesPerPointFloor,
 } from '../validateCount';
+import {
+  HeavyByteBudgetError,
+  MAX_DECODE_PEAK_BYTES,
+  withinDecodePeakBudget,
+} from '../heavy/heavyByteBudget';
 import { assertFiniteNodeTransform, assertFinitePositions } from '../streamingFiniteGuard';
 import type { DecodedChunk } from '../copc/copcChunkDecode';
 
@@ -100,6 +105,33 @@ interface TileDecodeContext {
   readonly pointSourceOffset: number;
   readonly gpsTimeOffset: number | null;
   readonly rgbOffset: number | null;
+}
+
+/**
+ * Peak decoded bytes ONE point of this tile stages at once, across every output
+ * channel the decode allocates for the tile's format plus the raw-RGB staging
+ * buffer that coexists with the narrowed one. Structural channels are always
+ * present; GPS time and the two RGB buffers are gated exactly as the allocations
+ * below them are, so the estimate tracks the real transient peak rather than a
+ * worst-case guess.
+ *
+ *   positions   Float32 × 3   12
+ *   intensity   Uint16         2
+ *   class       Uint8          1
+ *   returnNo    Uint8          1
+ *   returnCnt   Uint8          1
+ *   sourceId    Uint16         2   ── structural subtotal 19
+ *   gpsTime     Float64        8   (PDRF 1/3/6-8 only)
+ *   rgb         Uint8 × 3      3   (RGB formats only)
+ *   rgb16       Uint16 × 3     6   (RGB staging, freed after narrowing)
+ */
+const EPT_STRUCTURAL_BYTES_PER_POINT = 19;
+function decodedBytesPerPoint(ctx: TileDecodeContext): number {
+  return (
+    EPT_STRUCTURAL_BYTES_PER_POINT +
+    (ctx.gpsTimeOffset !== null ? 8 : 0) +
+    (ctx.hasRgb ? 3 + 6 : 0)
+  );
 }
 
 /** Build the per-tile decode context from a parsed header. */
@@ -206,6 +238,30 @@ export function decodeEptLaszipTileWith(
     compressedBytesPerPointFloor(ctx.recordLength),
     'EPT laszip tile',
   );
+  // The count guard above only bounds the declared count by the tile's own
+  // compressed bytes, and at the loose LAZ ratio floor a large-but-honest tile
+  // can still pass with a point count whose decoded channels — positions,
+  // intensity, classification, returns, source id, GPS time, and both RGB
+  // buffers — stage far more transient memory than the compressed payload. Bound
+  // the SUMMED peak (compressed span held in the WASM heap + every decoded
+  // channel) against the shared heavy-path ceiling BEFORE the seven typed-array
+  // allocations below, so an over-budget tile is refused rather than allocated.
+  if (
+    !withinDecodePeakBudget(
+      buffer.byteLength,
+      n,
+      decodedBytesPerPoint(ctx),
+      0,
+      MAX_DECODE_PEAK_BYTES,
+    )
+  ) {
+    throw new HeavyByteBudgetError(
+      `EPT laszip tile: ${n.toLocaleString('en-US')} points would stage ` +
+        `${(n * decodedBytesPerPoint(ctx)).toLocaleString('en-US')} decoded bytes ` +
+        `plus a ${buffer.byteLength.toLocaleString('en-US')}-byte compressed payload, ` +
+        `over the ${MAX_DECODE_PEAK_BYTES.toLocaleString('en-US')}-byte decode budget.`,
+    );
+  }
   // Fail before decoding a whole tile when its transform is outright non-finite
   // (a bad scale/offset in the header, or a non-finite render origin). Cheap and
   // O(1); it does NOT catch a finite-but-extreme scale overflowing

--- a/src/io/ept/worker/eptLaszipWorker.ts
+++ b/src/io/ept/worker/eptLaszipWorker.ts
@@ -90,12 +90,21 @@ ctx.onmessage = (event: MessageEvent<InMessage>): void => {
   if (msg.type !== 'decode') return;
 
   const { requestId, tile, renderOrigin, rgbEightBit } = msg;
-  if (cancelled.consume(requestId)) return;
+  // Every accepted request must post exactly ONE terminal reply. A silent return
+  // on a consumed cancel leaves the pool's slot held forever (its job is only
+  // cleared by a reply), so a cancel-consume return posts `cancelled` first.
+  if (cancelled.consume(requestId)) {
+    ctx.postMessage({ type: 'cancelled', requestId });
+    return;
+  }
 
   void (async (): Promise<void> => {
     try {
       const lazPerf = await getLazPerf();
-      if (cancelled.consume(requestId)) return;
+      if (cancelled.consume(requestId)) {
+        ctx.postMessage({ type: 'cancelled', requestId });
+        return;
+      }
       const decoded = decodeEptLaszipTileWith(lazPerf, tile, renderOrigin, rgbEightBit);
       ctx.postMessage(
         { type: 'decoded', requestId, decoded },

--- a/src/io/heavy/worker/lazChunkWorker.ts
+++ b/src/io/heavy/worker/lazChunkWorker.ts
@@ -86,12 +86,21 @@ ctx.onmessage = (event: MessageEvent<InMessage>): void => {
   if (msg.type !== 'decode') return;
 
   const { requestId, job } = msg;
-  if (cancelled.consume(requestId)) return;
+  // Every accepted request must post exactly ONE terminal reply. A silent return
+  // on a consumed cancel leaves the pool's slot held forever (its job is only
+  // cleared by a reply), so a cancel-consume return posts `cancelled` first.
+  if (cancelled.consume(requestId)) {
+    ctx.postMessage({ type: 'cancelled', requestId });
+    return;
+  }
 
   void (async (): Promise<void> => {
     try {
       const lazPerf = await getLazPerf();
-      if (cancelled.consume(requestId)) return;
+      if (cancelled.consume(requestId)) {
+        ctx.postMessage({ type: 'cancelled', requestId });
+        return;
+      }
       const decoded = decodeLazChunkLocal(lazPerf, job);
       ctx.postMessage({ type: 'decoded', requestId, decoded }, rawPointsTransferables(decoded));
     } catch (err) {

--- a/src/io/workerPool/DecodeWorkerPool.ts
+++ b/src/io/workerPool/DecodeWorkerPool.ts
@@ -61,7 +61,18 @@ interface ErrorReply {
   requestId: number;
   error: string;
 }
-type PoolReply<T> = DecodedReply<T> | ErrorReply;
+/**
+ * The terminal a worker posts when it consumed a cancel and skipped the decode.
+ * It carries no payload — the caller-facing promise was already rejected by the
+ * abort that triggered the cancel — its only job is to release the slot. Without
+ * it a cancelled request leaves the worker skipped but silent, and the slot it
+ * held is never freed, so repeated cancellation eventually drains every slot.
+ */
+interface CancelledReply {
+  type: 'cancelled';
+  requestId: number;
+}
+type PoolReply<T> = DecodedReply<T> | ErrorReply | CancelledReply;
 
 /**
  * The four rejection messages a pool produces. Held per-client so the COPC and
@@ -512,6 +523,18 @@ export class DecodeWorkerPool<T> {
     // unknown request id must never release a slot that has since been given a
     // different job — that is how two live decodes would end up on one worker.
     if (slot.job?.requestId === reply.requestId) slot.job = null;
+
+    if (reply.type === 'cancelled') {
+      // The worker consumed a cancel and produced its single terminal reply. Its
+      // caller-facing promise was already rejected by `_onAbort`, so there is
+      // nothing to resolve or reject here — clearing `slot.job` above is the
+      // point: it frees the slot the abandoned decode was holding. Drop any
+      // lingering bookkeeping (normally none — the abort already settled it) and
+      // pump so the freed slot picks up queued work.
+      this._settle(reply.requestId);
+      this._pump();
+      return;
+    }
 
     const job = this._settle(reply.requestId);
     if (!job) {

--- a/tests/decodeWorkerPool.test.ts
+++ b/tests/decodeWorkerPool.test.ts
@@ -109,6 +109,16 @@ class FakeWorker implements WorkerLike {
     this.onmessage?.({ data: { type: 'error', requestId, error } } as MessageEvent);
   }
 
+  /**
+   * The worker consumed a cancel and skipped the decode, posting its single
+   * terminal `cancelled` reply instead of a decoded/error one. This is the real
+   * silent-cancel path: the decode never completes, so `inFlight` drops here.
+   */
+  cancel(requestId: number): void {
+    this.inFlight = Math.max(0, this.inFlight - 1);
+    this.onmessage?.({ data: { type: 'cancelled', requestId } } as MessageEvent);
+  }
+
   /** Raw reply — for stale ids and duplicates, where bookkeeping must not move. */
   raw(reply: unknown): void {
     this.onmessage?.({ data: reply } as MessageEvent);
@@ -471,6 +481,89 @@ describe('DecodeWorkerPool — cancellation', () => {
       'worker-death',
       'dispose',
     ]);
+  });
+});
+
+describe('DecodeWorkerPool — silent-cancel terminal', () => {
+  test('a cancelled active job frees its slot when the worker posts its cancelled terminal', async () => {
+    const { pool, workers } = mkPool(1);
+    const controller = new AbortController();
+    const active = job(pool, 1, controller.signal);
+    const queued = job(pool, 2);
+    const activeId = workers[0].decodes[0].requestId;
+
+    controller.abort();
+    await expect(active.promise).rejects.toThrow(/abort/i);
+    // The worker consumed the cancel and skipped the decode: its ONLY terminal
+    // is the `cancelled` reply, never a decoded/error one. The slot stays busy
+    // until that reply lands.
+    expect(pool.activeCount).toBe(1);
+    expect(workers[0].decodes).toHaveLength(1);
+
+    workers[0].cancel(activeId);
+    // The terminal freed the slot, so the queued job dispatched at once.
+    expect(workers[0].decodes).toHaveLength(2);
+    expect(pool.activeCount).toBe(1);
+    workers[0].resolve(workers[0].decodes[1].requestId, 42);
+    expect((await queued.promise).pointCount).toBe(42);
+    expect(pool.pendingCount).toBe(0);
+  });
+
+  test('draining every slot by cancellation repeatedly leaves the next decode able to start', async () => {
+    // The wedge this guards: without a terminal on the silent-cancel path, each
+    // cancelled slot stays held forever, so a fast camera sweep that cancels the
+    // whole pool over and over eventually leaves no slot free and every later
+    // decode queues without end. With the terminal, the slots come back.
+    const N = 3;
+    const { pool, workers } = mkPool(N);
+
+    for (let round = 0; round < 5; round++) {
+      const controllers: AbortController[] = [];
+      const promises: Array<Promise<{ pointCount: number }>> = [];
+      for (let i = 0; i < N; i++) {
+        const c = new AbortController();
+        controllers.push(c);
+        promises.push(job(pool, round * N + i, c.signal).promise);
+      }
+      expect(pool.activeCount).toBe(N);
+      const ids = workers.map((w) => (w.current as PostedMessage).requestId);
+      for (const c of controllers) c.abort();
+      for (const p of promises) await expect(p).rejects.toThrow(/abort/i);
+      // Every slot is still held mid-decode until its terminal arrives.
+      expect(pool.activeCount).toBe(N);
+      workers.forEach((w, i) => w.cancel(ids[i]));
+      expect(pool.activeCount).toBe(0);
+    }
+
+    // After the pool was drained by cancellation five times over, the NEXT
+    // decode still starts on a reusable slot.
+    const fresh = job(pool, 999);
+    const busy = workers.find((w) => w.inFlight === 1);
+    expect(busy).toBeDefined();
+    busy?.resolve((busy.current as PostedMessage).requestId, 7);
+    expect((await fresh.promise).pointCount).toBe(7);
+    expect(pool.pendingCount).toBe(0);
+  });
+
+  test('a cancelled terminal for an already-settled job neither resolves nor rejects again', async () => {
+    const { pool, workers } = mkPool(1);
+    const controller = new AbortController();
+    const active = job(pool, 1, controller.signal);
+    const activeId = workers[0].decodes[0].requestId;
+
+    let settledAgain = false;
+    active.promise.then(
+      () => (settledAgain = true),
+      () => undefined,
+    );
+    controller.abort();
+    await expect(active.promise).rejects.toThrow(/abort/i);
+
+    expect(() => workers[0].cancel(activeId)).not.toThrow();
+    await Promise.resolve();
+    expect(settledAgain).toBe(false);
+    expect(pool.pendingCount).toBe(0);
+    expect(pool.activeCount).toBe(0);
   });
 });
 

--- a/tests/eptLaszipDecode.test.ts
+++ b/tests/eptLaszipDecode.test.ts
@@ -106,6 +106,41 @@ test('decodeEptLaszipTile refuses a non-finite render origin', async () => {
   );
 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Decoded-memory ceiling
+//
+// The declared-count guard only bounds the point count by the tile's own
+// compressed bytes at the loose LAZ ratio floor, so a large-but-plausible count
+// can still stage far more decoded memory than the compressed payload — the
+// positions, intensity, classification, returns, source id, GPS time and both
+// RGB buffers all coexist. A total decoded-byte ceiling refuses such a tile
+// BEFORE any of those arrays is allocated.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('decodeEptLaszipTile refuses a tile whose decoded channels exceed the memory budget', async () => {
+  // A buffer large enough that the count guard admits a huge declared count
+  // (its floor is recordLength / 50), but whose decoded channels would stage
+  // well over the 256 MiB decode budget. The header parses; the LAZ stream is
+  // never touched because the budget check throws first, before allocation.
+  const size = 8 * 1024 * 1024;
+  const buf = new Uint8Array(size);
+  // Seed the ASPRS public header from the real fixture, then override the
+  // fields the guard reads: PDRF 1 (positions + GPS time, no RGB), a 28-byte
+  // record, and a point count that trips the budget yet stays within what the
+  // 8 MiB of bytes could plausibly hold at the ratio floor.
+  buf.set(new Uint8Array(TINY_LAZ_BUF).subarray(0, 375));
+  const v = new DataView(buf.buffer);
+  v.setUint8(104, 1); // OFFSET_POINT_FORMAT → PDRF 1
+  v.setUint16(105, 28, true); // OFFSET_POINT_RECORD_LENGTH
+  const declared = 12_000_000;
+  v.setUint32(107, declared, true); // legacy point count (LAS < 1.4)
+  v.setBigUint64(247, BigInt(declared), true); // extended point count (LAS 1.4)
+
+  await expect(decodeEptLaszipTile(buf.buffer, [0, 0, 0])).rejects.toThrow(
+    /decode budget/,
+  );
+});
+
 test('decodeEptLaszipTile refuses a tile whose scale overflows a coordinate', async () => {
   // parseLasHeader accepts this scale — it is finite and positive — but
   // int32 · 1e300 overflows to ±Infinity in the coordinate loop, which is


### PR DESCRIPTION
## Decode-worker cancellation wedge (blocker)

A worker that consumed a cancel returned silently with no terminal
message. The pool keeps a slot's job set until its reply arrives, so a
cancelled slot was never freed. Repeated cancellation during fast camera
motion drained every slot and queued later
decodes without end. All three workers now post one terminal "cancelled"
reply on every cancel-consume return, and the pool frees the slot on it.
The abort already rejected the promise.

## EPT laszip decoded-memory ceiling

The declared-count guard only bounded points by the tile's compressed
bytes at a loose ratio floor. The decode now refuses a tile whose summed
peak exceeds the shared heavy-path budget before allocating the arrays.

Tests cover the silent-cancel slot reuse and the over-budget refusal.
