### PR TITLE
harden EPT ingest against inconsistent datasets

### DIFF
--- a/src/io/ept/EptChunkDecoder.ts
+++ b/src/io/ept/EptChunkDecoder.ts
@@ -27,6 +27,7 @@ import type {
 import type { EptStreamingPointCloud } from '../../render/streaming/EptStreamingPointCloud';
 import type { EptLaszipWorkerClient } from './worker/eptLaszipWorkerClient';
 import { decodeEptLaszipTile } from './eptLaszipDecode';
+import { LoadError } from '../loadErrors';
 
 export class EptChunkDecoder implements ChunkDecoder {
   private readonly _cloud: EptStreamingPointCloud;
@@ -69,10 +70,30 @@ export class EptChunkDecoder implements ChunkDecoder {
         // the main thread (the tile buffer is transferred zero-copy); the
         // in-process path is the fallback for environments without a worker.
         // Both carry `meta.rgbEightBit` — the dataset-level colour decision.
-        return this._laszipWorker
-          ? this._laszipWorker.decodeTile(
-              chunk, this._cloud.renderOrigin, signal, meta.rgbEightBit)
-          : decodeEptLaszipTile(chunk, this._cloud.renderOrigin, meta.rgbEightBit);
+        {
+          const decoded = await (this._laszipWorker
+            ? this._laszipWorker.decodeTile(
+                chunk, this._cloud.renderOrigin, signal, meta.rgbEightBit)
+            : decodeEptLaszipTile(chunk, this._cloud.renderOrigin, meta.rgbEightBit));
+          // The scheduler admitted this node — and reserved its memory — on the
+          // HIERARCHY point count (`meta.pointCount`). But an EPT laszip tile is
+          // a self-describing LAZ file whose own LAS header count drives the
+          // decode allocation. When the two disagree, the header wins by default
+          // and the memory-admission estimate is bypassed by that ratio: a
+          // hierarchy of 100k against a header of 10M lets a tile 100x its
+          // reservation through. A disagreement is not a transport fault a
+          // re-fetch could heal — it is the dataset contradicting itself — so
+          // fail closed (permanent) rather than trust the tile's own figure.
+          if (decoded.pointCount !== meta.pointCount) {
+            throw new LoadError(
+              'malformed-file',
+              `malformed EPT dataset: laszip tile declares ${decoded.pointCount} ` +
+                `points but its hierarchy entry declares ${meta.pointCount}. The ` +
+                `hierarchy count governs memory admission; refusing the tile.`,
+            );
+          }
+          return decoded;
+        }
       case 'zstandard':
         throw new Error(
           'EPT zstandard tile decode is not supported in this build. ' +

--- a/src/io/ept/eptBinaryDecode.ts
+++ b/src/io/ept/eptBinaryDecode.ts
@@ -133,6 +133,53 @@ function findAttr(attrs: readonly AttrLayout[], name: string): AttrLayout | unde
 }
 
 /**
+ * Per-channel constraint on the EPT schema width this decoder can read WITHOUT
+ * losing bits. Each entry lists the (type, size) pairs whose full value range
+ * fits the OLV target array below:
+ *   • Intensity     → Uint16  — unsigned 1 or 2 bytes
+ *   • Classification, ReturnNumber, NumberOfReturns → Uint8 — unsigned 1 byte
+ *   • Red / Green / Blue → 8- or 16-bit only (the RGB narrow recognises no other
+ *     width; a 32-bit channel would be masked to its low byte).
+ * A wider or differently-typed declaration is refused, never truncated: an EPT
+ * Intensity `unsigned` size 4 holding 70000 would wrap to 4464 in a Uint16, and
+ * a Classification size 2 holding 300 would wrap to 44 in a Uint8 — silent
+ * scientific corruption of the same class as the earlier E57 narrowing bug.
+ */
+const CHANNEL_WIDTHS: Readonly<
+  Record<string, ReadonlyArray<{ readonly type: EptSchemaField['type']; readonly size: number }>>
+> = {
+  Intensity: [{ type: 'unsigned', size: 1 }, { type: 'unsigned', size: 2 }],
+  Classification: [{ type: 'unsigned', size: 1 }],
+  ReturnNumber: [{ type: 'unsigned', size: 1 }],
+  NumberOfReturns: [{ type: 'unsigned', size: 1 }],
+  Red: [{ type: 'unsigned', size: 1 }, { type: 'unsigned', size: 2 }],
+  Green: [{ type: 'unsigned', size: 1 }, { type: 'unsigned', size: 2 }],
+  Blue: [{ type: 'unsigned', size: 1 }, { type: 'unsigned', size: 2 }],
+};
+
+/**
+ * Fail closed when a declared channel is wider (or a different type) than the
+ * OLV array it lands in can hold losslessly. Throws a permanent typed error —
+ * the tile is not re-fetchable into a fitting shape, the schema itself is
+ * unsupported, so retrying gains nothing.
+ */
+function assertChannelWidthsFit(attrs: readonly AttrLayout[]): void {
+  for (const attr of attrs) {
+    const allowed = CHANNEL_WIDTHS[attr.name];
+    if (!allowed) continue;
+    if (!allowed.some((w) => w.type === attr.type && w.size === attr.size)) {
+      const widths = allowed.map((w) => `${w.type} ${w.size}-byte`).join(' or ');
+      throw new LoadError(
+        'malformed-file',
+        `unsupported EPT schema: attribute "${attr.name}" is declared ${attr.type} ` +
+          `${attr.size}-byte, which cannot be read without losing bits ` +
+          `(supported: ${widths}). Refusing to truncate.`,
+      );
+    }
+  }
+}
+
+/**
  * Decode one EPT binary tile into a {@link DecodedChunk}.
  *
  * @param buffer        The raw tile bytes as fetched from the EPT data URL.
@@ -157,6 +204,12 @@ export function decodeEptBinaryTile(
   rgbEightBit?: boolean,
 ): DecodedChunk {
   const { attrs, stride } = computeSchemaLayout(schema);
+  // Every OLV channel this decoder materialises is narrower than some width the
+  // EPT schema is allowed to declare. Validate the declared widths fit LOSSLESSLY
+  // before allocating anything — a truncating narrow is silent scientific
+  // corruption, not a display quirk (see the note on the helper).
+  assertChannelWidthsFit(attrs);
+
   const expectedBytes = pointCount * stride;
   if (buffer.byteLength < expectedBytes) {
     // A short tile is almost always a transport problem — partial body
@@ -168,6 +221,19 @@ export function decodeEptBinaryTile(
         `points × ${stride} stride, got ${buffer.byteLength}.`,
       expectedBytes,
       buffer.byteLength,
+    );
+  }
+  // A tile LONGER than the schema-exact size is not a transport hiccup: trailing
+  // bytes mean the hierarchy count, the schema stride, or the writer disagree
+  // about the record layout, and decoding the first N records would silently
+  // read a tile whose real shape we don't know. Require exact equality and fail
+  // closed (permanent) on any surplus.
+  if (buffer.byteLength > expectedBytes) {
+    throw new LoadError(
+      'malformed-file',
+      `malformed EPT binary tile: expected exactly ${expectedBytes} bytes for ` +
+        `${pointCount} points × ${stride} stride, got ${buffer.byteLength} ` +
+        `(${buffer.byteLength - expectedBytes} trailing).`,
     );
   }
 

--- a/src/io/ept/eptDetect.ts
+++ b/src/io/ept/eptDetect.ts
@@ -120,6 +120,14 @@ export function parseEptMetadata(text: string): EptDetection {
   if (typeof span !== 'number' || !Number.isSafeInteger(span) || span <= 0) {
     return { isEpt: false, reason: 'EPT manifest is missing a positive whole "span".' };
   }
+  // EPT's span is the octree's linear voxel resolution, and Entwine builds the
+  // pyramid by repeated halving — so a real span is always a power of two. A
+  // value that is not (say 100) would make `_spacingForDepth`'s `span / 2^depth`
+  // describe a grid the tiles were never laid out on, silently mis-scoring
+  // refinement. Refuse it here rather than let the wrong resolution propagate.
+  if (!Number.isInteger(Math.log2(span))) {
+    return { isEpt: false, reason: `EPT "span" ${span} is not a power of two.` };
+  }
 
   // ── schema ───────────────────────────────────────────────────────────────
   const schema = json['schema'];
@@ -212,8 +220,17 @@ export function parseEptMetadata(text: string): EptDetection {
       srs = wkt;
     }
     const authority = typeof srsField['authority'] === 'string' ? srsField['authority'] : undefined;
-    const horizontalEpsg = parseEpsgCode(srsField['horizontal']);
-    const verticalEpsg = parseEpsgCode(srsField['vertical']);
+    // `srsCodes` is consumed (in `resolveEptCrs`) strictly as EPSG — fed to
+    // `crsFromEpsg` / `isGeographicEpsg`. So a numeric `horizontal` / `vertical`
+    // is an EPSG code ONLY when the manifest's authority says EPSG (or names no
+    // authority, the EPT default). A dataset authored against another registry
+    // (IAU planetary codes, an ESRI well-known id) reuses the same integer space
+    // for entirely different systems; reading 30100 as "EPSG:30100" would place a
+    // Mars cloud on Earth. When the authority is some other registry, refuse the
+    // codes rather than mislabel them — the CRS then stays unresolved (null) here.
+    const epsgAuthority = authority === undefined || authority.toUpperCase() === 'EPSG';
+    const horizontalEpsg = epsgAuthority ? parseEpsgCode(srsField['horizontal']) : undefined;
+    const verticalEpsg = epsgAuthority ? parseEpsgCode(srsField['vertical']) : undefined;
     if (authority !== undefined || horizontalEpsg !== undefined || verticalEpsg !== undefined) {
       srsCodes = { authority, horizontalEpsg, verticalEpsg };
     }

--- a/src/io/ept/eptTransport.ts
+++ b/src/io/ept/eptTransport.ts
@@ -19,6 +19,27 @@
  *
  * Pure — no DOM, no three.js. The injected `fetchImpl`, `sleep`, and
  * `random` make every retry/timeout path deterministically testable.
+ *
+ * KNOWN LIMITATION — no dataset-wide snapshot pinning. COPC is one object, so
+ * `HttpRangeSource` can pin a single ETag / Last-Modified / size and reject a
+ * range read the moment the object changes underneath the session. EPT is a
+ * TREE of independent objects (`ept.json`, many hierarchy pages, many tiles)
+ * fetched over the life of a scan, with no equivalent whole-dataset validator.
+ * If the dataset is REPUBLISHED mid-stream — Entwine rewriting the pyramid, a
+ * bucket sync swapping objects — this transport can mix pages/tiles from the old
+ * and new versions and would not detect it. Each fetch is otherwise independent,
+ * so a per-request ETag pin (record the first `ept.json` response's validator,
+ * send `If-Match` / compare on every derived request, reject on mismatch) is the
+ * natural fix, but it has to thread a validator from the manifest fetch through
+ * `EptStreamingPointCloud` into every hierarchy + tile request and depends on
+ * the host emitting stable validators (many CDNs and S3-compatible stores vary
+ * them per node) — a real change, deferred rather than half-built here. Until
+ * then the practical guard is operational: treat a published EPT as immutable
+ * for the duration of a session, and re-open the scan after a republish. The
+ * per-tile / per-page integrity checks elsewhere (exact-stride binary decode,
+ * hierarchy-vs-tile count reconciliation, the point-count total reconciliation)
+ * still catch a tile that is internally inconsistent — they do not catch a
+ * consistent tile from a DIFFERENT snapshot.
  */
 
 import type { EptTransport } from '../../render/streaming/EptStreamingPointCloud';

--- a/src/render/streaming/EptOctree.ts
+++ b/src/render/streaming/EptOctree.ts
@@ -263,7 +263,36 @@ export class EptOctree implements StreamingOctreeView {
       this._errors.push(`EPT hierarchy exceeded ${MAX_HIERARCHY_FILES} files — stopped`);
       this._frontier = [];
     }
-    if (this._frontier.length === 0) this._fullyLoaded = true;
+    if (this._frontier.length === 0) {
+      this._fullyLoaded = true;
+      this._reconcilePointCount();
+    }
+  }
+
+  /**
+   * After a clean walk, reconcile the resolved point total against `ept.json`'s
+   * declared `points`. A walk that terminates with no fetch/parse errors still
+   * only reports "the traversal stopped and nothing threw" — it never checks
+   * that the nodes it ingested actually account for every point the manifest
+   * promised. A hierarchy that stops cleanly while a depth-capped or otherwise
+   * dropped subtree leaves 700k of 10M points unreachable would read
+   * KNOWN-COMPLETE. Summing the ingested node counts and requiring equality
+   * closes that: on a shortfall (or surplus) push a named POINT_COUNT_MISMATCH
+   * error carrying both totals, which drops {@link isComplete} to false through
+   * the existing error-count gate. Only meaningful when the walk was otherwise
+   * clean — an already-errored walk is incomplete regardless.
+   */
+  private _reconcilePointCount(): void {
+    if (this._errors.length > 0) return;
+    let resolved = 0;
+    for (const node of this.store.all()) resolved += node.record.pointCount;
+    if (resolved !== this._meta.points) {
+      this._errors.push(
+        `POINT_COUNT_MISMATCH: EPT hierarchy resolved ${resolved} points but ` +
+          `ept.json declares ${this._meta.points} (difference ` +
+          `${this._meta.points - resolved}).`,
+      );
+    }
   }
 
   /** Add one EPT hierarchy node to the store as a {@link StreamingNodeRecord}. */

--- a/src/render/streaming/EptStreamingPointCloud.ts
+++ b/src/render/streaming/EptStreamingPointCloud.ts
@@ -185,6 +185,17 @@ export class EptStreamingPointCloud implements StreamingSource {
     // rest deepen in the background and the scheduler refines as they arrive. A
     // small dataset whose hierarchy fits the budget finishes here, unchanged.
     await octree.loadInitialHierarchy(FIRST_PAINT_HIERARCHY_FILES, signal);
+    // The octree tolerates a failed hierarchy fetch by recording the error,
+    // draining the frontier, and marking itself fullyLoaded — so a root file
+    // that never arrived (or parsed) still resolves the walk. Left unchecked,
+    // open() would hand back a cloud with zero nodes, zero points, and
+    // isComplete=false: a "successful" open of nothing that renders blank. The
+    // initial walk must yield at least one usable node (the root/coarse geometry
+    // the scan attaches to) or the open is a failure, not an empty success.
+    if (octree.nodes().length === 0) {
+      const detail = octree.errors[0] ? ` (${octree.errors[0]})` : '';
+      throw new Error(`unable to open EPT hierarchy: no nodes loaded from the root index${detail}`);
+    }
     const cloud = new EptStreamingPointCloud(
       metadata, baseUrl, name, renderOrigin, octree, transport, search,
     );

--- a/tests/eptChunkDecoder.test.ts
+++ b/tests/eptChunkDecoder.test.ts
@@ -24,8 +24,12 @@ import type { ChunkDecodeMetadata, DecodedChunk } from '../src/io/copc/copcChunk
 
 const RENDER_ORIGIN: [number, number, number] = [100, 200, 300];
 
+// pointCount matches META.pointCount below: EptChunkDecoder now reconciles the
+// decoded laszip tile's count against the hierarchy count and refuses a
+// mismatch, so a routing mock must agree with the metadata it is dispatched
+// with or it trips that guard before the routing assertion runs.
 function fakeChunk(): DecodedChunk {
-  return { pointCount: 1 } as unknown as DecodedChunk;
+  return { pointCount: 5 } as unknown as DecodedChunk;
 }
 
 function fakeCloud(

--- a/tests/eptHardeningWave.test.ts
+++ b/tests/eptHardeningWave.test.ts
@@ -1,0 +1,319 @@
+/**
+ * eptHardeningWave.test.ts — adversarial, red-first coverage for the EPT
+ * hardening wave. Each test pins one hole the audit found:
+ *
+ *   #2  laszip tile header count vs hierarchy count — mismatch refused.
+ *   #4  root hierarchy fetch failure — open() rejects, no empty success.
+ *   #5  Σ(node points) vs ept.json.points — mismatch drops isComplete with a
+ *       named POINT_COUNT_MISMATCH reason.
+ *   #9  narrower-than-declared channel widths — Intensity uint32=70000 refused
+ *       (never wrapped to 4464), never truncated.
+ *   #10 EPT binary tile with trailing bytes — refused (exact-stride equality).
+ *   #13 uint64 beyond 2^53 − 1 — refused (already covered; re-asserted here).
+ *   #14 non-power-of-two span refused; non-EPSG authority not read as EPSG.
+ *
+ * Pure Node — no DOM, no three.js, no live HTTP.
+ */
+
+import { test, expect } from 'vitest';
+import { decodeEptBinaryTile } from '../src/io/ept/eptBinaryDecode';
+import { EptChunkDecoder } from '../src/io/ept/EptChunkDecoder';
+import { EptOctree } from '../src/render/streaming/EptOctree';
+import { EptStreamingPointCloud } from '../src/render/streaming/EptStreamingPointCloud';
+import type { EptTransport } from '../src/render/streaming/EptStreamingPointCloud';
+import { parseEptMetadata } from '../src/io/ept/eptDetect';
+import { LoadError } from '../src/io/loadErrors';
+import type {
+  ChunkDecodeMetadata,
+  DecodedChunk,
+} from '../src/io/copc/copcChunkDecode';
+import type { EptKey, EptMetadata, EptSchemaField } from '../src/io/ept/eptTypes';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const XYZ: EptSchemaField[] = [
+  { name: 'X', size: 4, type: 'signed', scale: 0.001, offset: 0 },
+  { name: 'Y', size: 4, type: 'signed', scale: 0.001, offset: 0 },
+  { name: 'Z', size: 4, type: 'signed', scale: 0.001, offset: 0 },
+];
+
+function tileFor(
+  schema: readonly EptSchemaField[],
+  points: number,
+  write: (view: DataView, offsetOf: (name: string) => number, i: number) => void,
+  extraBytes = 0,
+): ArrayBuffer {
+  let stride = 0;
+  const offsets = new Map<string, number>();
+  for (const f of schema) {
+    offsets.set(f.name, stride);
+    stride += f.size;
+  }
+  const buffer = new ArrayBuffer(stride * points + extraBytes);
+  const view = new DataView(buffer);
+  const offOf = (name: string): number => {
+    const off = offsets.get(name);
+    if (off === undefined) throw new Error(`no attribute ${name}`);
+    return off;
+  };
+  for (let i = 0; i < points; i++) {
+    write(view, (n) => i * stride + offOf(n), i);
+  }
+  return buffer;
+}
+
+/** A valid EPT manifest object with the given overrides applied. */
+function buildManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: '1.1.0',
+    dataType: 'binary',
+    hierarchyType: 'json',
+    points: 100,
+    span: 128,
+    schema: [
+      { name: 'X', size: 4, type: 'signed', scale: 0.001, offset: 0 },
+      { name: 'Y', size: 4, type: 'signed', scale: 0.001, offset: 0 },
+      { name: 'Z', size: 4, type: 'signed', scale: 0.001, offset: 0 },
+    ],
+    bounds: [0, 0, 0, 10, 10, 10],
+    ...overrides,
+  };
+}
+
+function parsedMeta(overrides: Record<string, unknown> = {}): EptMetadata {
+  const result = parseEptMetadata(JSON.stringify(buildManifest(overrides)));
+  if (!result.isEpt) throw new Error(`fixture manifest failed to parse: ${result.reason}`);
+  return result.metadata;
+}
+
+// ── #10 exact-stride binary tile ─────────────────────────────────────────────
+
+test('#10 an EPT binary tile with trailing bytes is refused (exact stride)', () => {
+  // 1 point × 12-byte stride = 12 bytes; append 4 trailing bytes.
+  const tile = tileFor(XYZ, 1, (view, off) => {
+    view.setInt32(off('X'), 1000, true);
+    view.setInt32(off('Y'), 2000, true);
+    view.setInt32(off('Z'), 3000, true);
+  }, 4);
+  expect(() => decodeEptBinaryTile(tile, 1, XYZ, [0, 0, 0])).toThrow(LoadError);
+  expect(() => decodeEptBinaryTile(tile, 1, XYZ, [0, 0, 0])).toThrow(/trailing/);
+});
+
+test('#10 an exact-length binary tile still decodes', () => {
+  const tile = tileFor(XYZ, 1, (view, off) => {
+    view.setInt32(off('X'), 1000, true);
+    view.setInt32(off('Y'), 2000, true);
+    view.setInt32(off('Z'), 3000, true);
+  });
+  const decoded = decodeEptBinaryTile(tile, 1, XYZ, [0, 0, 0]);
+  expect(decoded.positions[0]).toBeCloseTo(1, 6);
+});
+
+// ── #9 channel width fits losslessly ─────────────────────────────────────────
+
+test('#9 Intensity declared uint32=70000 is refused, never wrapped to 4464', () => {
+  const schema: EptSchemaField[] = [
+    ...XYZ,
+    { name: 'Intensity', size: 4, type: 'unsigned' },
+  ];
+  const tile = tileFor(schema, 1, (view, off) => {
+    view.setInt32(off('X'), 0, true);
+    view.setInt32(off('Y'), 0, true);
+    view.setInt32(off('Z'), 0, true);
+    view.setUint32(off('Intensity'), 70000, true);
+  });
+  let thrown: unknown;
+  try {
+    decodeEptBinaryTile(tile, 1, schema, [0, 0, 0]);
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown).toBeInstanceOf(LoadError);
+  expect((thrown as Error).message).toMatch(/unsupported EPT schema/);
+  // The wrapped value must never appear anywhere in the error text.
+  expect((thrown as Error).message).not.toMatch(/4464/);
+});
+
+test('#9 Classification declared size 2 is refused (would wrap 300 to 44)', () => {
+  const schema: EptSchemaField[] = [
+    ...XYZ,
+    { name: 'Classification', size: 2, type: 'unsigned' },
+  ];
+  const tile = tileFor(schema, 1, (view, off) => {
+    view.setInt32(off('X'), 0, true);
+    view.setInt32(off('Y'), 0, true);
+    view.setInt32(off('Z'), 0, true);
+    view.setUint16(off('Classification'), 300, true);
+  });
+  expect(() => decodeEptBinaryTile(tile, 1, schema, [0, 0, 0])).toThrow(/unsupported EPT schema/);
+});
+
+test('#9 standard-width channels (Intensity u16, Classification u8) still decode', () => {
+  const schema: EptSchemaField[] = [
+    ...XYZ,
+    { name: 'Intensity', size: 2, type: 'unsigned' },
+    { name: 'Classification', size: 1, type: 'unsigned' },
+  ];
+  const tile = tileFor(schema, 1, (view, off) => {
+    view.setInt32(off('X'), 0, true);
+    view.setInt32(off('Y'), 0, true);
+    view.setInt32(off('Z'), 0, true);
+    view.setUint16(off('Intensity'), 40000, true);
+    view.setUint8(off('Classification'), 12);
+  });
+  const decoded = decodeEptBinaryTile(tile, 1, schema, [0, 0, 0]);
+  expect(decoded.intensity?.[0]).toBe(40000);
+  expect(decoded.classification?.[0]).toBe(12);
+});
+
+// ── #13 uint64 beyond safe integer ───────────────────────────────────────────
+
+test('#13 a uint64 X beyond 2^53 − 1 is refused (not silently rounded)', () => {
+  const schema: EptSchemaField[] = [
+    { name: 'X', size: 8, type: 'unsigned', scale: 1, offset: 0 },
+    { name: 'Y', size: 8, type: 'unsigned', scale: 1, offset: 0 },
+    { name: 'Z', size: 8, type: 'unsigned', scale: 1, offset: 0 },
+  ];
+  const tile = tileFor(schema, 1, (view, off) => {
+    view.setBigUint64(off('X'), (1n << 53n) + 1n, true);
+    view.setBigUint64(off('Y'), 0n, true);
+    view.setBigUint64(off('Z'), 0n, true);
+  });
+  expect(() => decodeEptBinaryTile(tile, 1, schema, [0, 0, 0])).toThrow(LoadError);
+});
+
+// ── #14 metadata validation ──────────────────────────────────────────────────
+
+test('#14 a non-power-of-two span is refused', () => {
+  const result = parseEptMetadata(JSON.stringify(buildManifest({ span: 100 })));
+  expect(result.isEpt).toBe(false);
+  if (!result.isEpt) expect(result.reason).toMatch(/power of two/);
+});
+
+test('#14 a power-of-two span is accepted', () => {
+  const result = parseEptMetadata(JSON.stringify(buildManifest({ span: 256 })));
+  expect(result.isEpt).toBe(true);
+});
+
+test('#14 a numeric horizontal code under a NON-EPSG authority is not read as EPSG', () => {
+  const meta = parsedMeta({
+    srs: { authority: 'IAU', horizontal: '30100', vertical: '30101' },
+  });
+  // The code is preserved on `authority`, but never surfaced as an EPSG code.
+  expect(meta.srsCodes?.authority).toBe('IAU');
+  expect(meta.srsCodes?.horizontalEpsg).toBeUndefined();
+  expect(meta.srsCodes?.verticalEpsg).toBeUndefined();
+});
+
+test('#14 a numeric horizontal code under EPSG authority is read as EPSG', () => {
+  const meta = parsedMeta({
+    srs: { authority: 'EPSG', horizontal: '32612', vertical: '5703' },
+  });
+  expect(meta.srsCodes?.horizontalEpsg).toBe(32612);
+  expect(meta.srsCodes?.verticalEpsg).toBe(5703);
+});
+
+// ── #5 point-count reconciliation ────────────────────────────────────────────
+
+function rootOnlyFetcher(nodePoints: number): (key: EptKey) => Promise<string> {
+  return async (key) => {
+    if (key.d === 0) return JSON.stringify({ '0-0-0-0': nodePoints });
+    throw new Error(`no such hierarchy file ${key.d}-${key.x}-${key.y}-${key.z}`);
+  };
+}
+
+test('#5 a hierarchy whose node counts sum below ept.json.points is not isComplete', async () => {
+  const meta = parsedMeta({ points: 150 });
+  const octree = new EptOctree(meta, rootOnlyFetcher(100));
+  await octree.loadFullHierarchy();
+  expect(octree.fullyLoaded).toBe(true);
+  expect(octree.isComplete).toBe(false);
+  expect(octree.errors.some((e) => e.includes('POINT_COUNT_MISMATCH'))).toBe(true);
+  // The named reason carries both totals.
+  const reason = octree.errors.find((e) => e.includes('POINT_COUNT_MISMATCH'))!;
+  expect(reason).toMatch(/150/);
+  expect(reason).toMatch(/100/);
+});
+
+test('#5 a hierarchy whose node counts sum exactly to ept.json.points is isComplete', async () => {
+  const meta = parsedMeta({ points: 100 });
+  const octree = new EptOctree(meta, rootOnlyFetcher(100));
+  await octree.loadFullHierarchy();
+  expect(octree.isComplete).toBe(true);
+  expect(octree.errors).toHaveLength(0);
+});
+
+// ── #4 root hierarchy failure → open() rejects ───────────────────────────────
+
+test('#4 a failed root hierarchy fetch rejects open() instead of an empty success', async () => {
+  const meta = parsedMeta({ points: 100 });
+  const transport: EptTransport = {
+    fetchText: async () => {
+      throw new Error('503 from CDN');
+    },
+    fetchBytes: async () => new ArrayBuffer(0),
+  };
+  await expect(
+    EptStreamingPointCloud.open(meta, 'https://host/ept.json', 'test', transport),
+  ).rejects.toThrow(/unable to open EPT hierarchy/);
+});
+
+test('#4 a healthy root hierarchy opens with at least one node', async () => {
+  const meta = parsedMeta({ points: 100 });
+  const transport: EptTransport = {
+    fetchText: async () => JSON.stringify({ '0-0-0-0': 100 }),
+    fetchBytes: async () => new ArrayBuffer(0),
+  };
+  const cloud = await EptStreamingPointCloud.open(meta, 'https://host/ept.json', 'test', transport);
+  expect(cloud.octree.nodes().length).toBeGreaterThan(0);
+  await cloud.close();
+});
+
+// ── #2 laszip header count vs hierarchy count ────────────────────────────────
+
+/** A minimal laszip cloud stub the decoder can dispatch against. */
+function laszipCloudStub(): EptStreamingPointCloud {
+  return {
+    dataType: 'laszip',
+    renderOrigin: [0, 0, 0],
+  } as unknown as EptStreamingPointCloud;
+}
+
+const META_100: ChunkDecodeMetadata = {
+  pointDataRecordFormat: -1,
+  pointRecordLength: 0,
+  pointCount: 100,
+  scale: [1, 1, 1],
+  offset: [0, 0, 0],
+  renderOrigin: [0, 0, 0],
+  rgbEightBit: undefined,
+};
+
+function chunkWith(pointCount: number): DecodedChunk {
+  return {
+    pointCount,
+    positions: new Float32Array(pointCount * 3),
+  } as DecodedChunk;
+}
+
+test('#2 a laszip tile whose header count disagrees with the hierarchy count is refused', async () => {
+  // The injected worker returns a chunk claiming 10M points against a hierarchy
+  // entry of 100 — the memory-admission bypass the audit flagged.
+  const worker = {
+    decodeTile: async (): Promise<DecodedChunk> => chunkWith(10_000_000),
+  };
+  const decoder = new EptChunkDecoder(laszipCloudStub(), worker as never);
+  await expect(decoder.decode(new ArrayBuffer(0), META_100)).rejects.toThrow(LoadError);
+  await expect(decoder.decode(new ArrayBuffer(0), META_100)).rejects.toThrow(
+    /hierarchy entry declares 100/,
+  );
+});
+
+test('#2 a laszip tile whose header count matches the hierarchy count passes', async () => {
+  const worker = {
+    decodeTile: async (): Promise<DecodedChunk> => chunkWith(100),
+  };
+  const decoder = new EptChunkDecoder(laszipCloudStub(), worker as never);
+  const decoded = await decoder.decode(new ArrayBuffer(0), META_100);
+  expect(decoded.pointCount).toBe(100);
+});

--- a/tests/eptStreaming.test.ts
+++ b/tests/eptStreaming.test.ts
@@ -173,7 +173,12 @@ const MULTI_FILE_HIERARCHY: Record<string, string> = {
 };
 function multiFileOctree(): EptOctree {
   const fetched: string[] = [];
-  const octree = new EptOctree(loadFixtureMetadata(), (key) => {
+  // The multi-file hierarchy's node counts sum to 190 (100 + 50 + 30 + 10). The
+  // octree now reconciles Σ(node points) against ept.json's declared `points`
+  // for its isComplete claim, so the fixture metadata must declare that total
+  // for a fully-deepened walk to read as complete.
+  const meta: EptMetadata = { ...loadFixtureMetadata(), points: 190 };
+  const octree = new EptOctree(meta, (key) => {
     const id = `${key.d}-${key.x}-${key.y}-${key.z}`;
     fetched.push(id);
     const text = MULTI_FILE_HIERARCHY[id];


### PR DESCRIPTION
Eight audit findings on the EPT path, each validated against source first.

A laszip tile's LAS header count must equal its hierarchy entry, or the chunk
is refused, so a tile cannot bypass the memory the scheduler admitted it on
(#2). open() rejects when the root index loads no node (#4). After a clean
walk the resolved node total must equal ept.json points, else the octree
reports POINT_COUNT_MISMATCH and isComplete goes false (#5).

Binary tiles require an exact schema stride (#10). Channel widths narrower than
the schema fail closed rather than wrap a reading (#9). span must be a power of
two, and a numeric SRS code under a non-EPSG authority is not read as EPSG
(#14). The uint64 guard (#13) is confirmed. The snapshot-pinning limit (#16) is
documented in eptTransport.

Adversarial tests cover each fix; two existing fixtures were realigned.
