### PR TITLE
fix(streaming): enforce decode ceilings and strict counts in full-cloud grade

### DIFF
--- a/src/render/streaming/fullCloudGrade.ts
+++ b/src/render/streaming/fullCloudGrade.ts
@@ -38,6 +38,71 @@
 import type { SamplingPlan } from './samplingPlan';
 import { formatPointCount } from '../../io/loadPlan';
 
+/**
+ * Hard ceiling on the points a single full-cloud grade may decode, independent
+ * of the sampling budget. The planner always selects at least one node so a
+ * positive budget never decodes nothing — but that guarantee means one
+ * arbitrarily large first node (a COPC root chunk can hold hundreds of millions
+ * of points) becomes the whole plan even when its count dwarfs
+ * {@link SamplingPlanOptions.maxPoints}. The grade runner sizes a Float32Array
+ * at `sampledPoints * 3` BEFORE decoding, so an unchecked first node forces a
+ * multi-gigabyte allocation on a path that never went through the streaming
+ * scheduler's device-aware first-node guard. This ceiling is that guard's
+ * equivalent for the grade: above it the grade refuses rather than allocates.
+ *
+ * Set well above the 2,000,000-point default budget so a legitimately large
+ * first node still grades, while the pathological hundreds-of-millions node is
+ * declined.
+ */
+export const MAX_SAMPLE_POINTS = 8_000_000;
+
+/**
+ * Companion byte ceiling on the decoded POSITIONS buffer (`sampledPoints * 3`
+ * Float32 values). Defends the allocation directly, so a caller that raises the
+ * point budget, or a future wider position element, still cannot drive the
+ * single pre-decode allocation past this size. 256 MiB.
+ */
+export const MAX_SAMPLE_DECODED_BYTES = 256 * 1024 * 1024;
+
+/** Float32 positions are XYZ triples; the decode buffer is `points * 3 * 4` bytes. */
+const DECODED_BYTES_PER_POINT = 3 * Float32Array.BYTES_PER_ELEMENT;
+
+/**
+ * A refusal the grade shows in place of figures. Same two slots the panel
+ * renders for a graded run (a headline where the coverage label goes and a note
+ * beneath), so a refusal reads as a result, not an error.
+ */
+export interface SampleBudgetRefusal {
+  /** Stands in for the coverage label. */
+  readonly headline: string;
+  /** Why the grade was declined. */
+  readonly note: string;
+}
+
+/**
+ * Decide whether a sampling plan is too large to decode safely, returning the
+ * user-facing refusal or `null` when it is within both ceilings. Pure and
+ * deterministic; the runner calls it right after building the plan and BEFORE
+ * sizing the decode buffer, so a plan above the ceiling never allocates.
+ */
+export function sampleBudgetRefusal(
+  plan: Pick<SamplingPlan, 'sampledPoints'>,
+): SampleBudgetRefusal | null {
+  const points = Math.max(0, plan.sampledPoints);
+  const decodedBytes = points * DECODED_BYTES_PER_POINT;
+  if (points <= MAX_SAMPLE_POINTS && decodedBytes <= MAX_SAMPLE_DECODED_BYTES) return null;
+  const mib = Math.round(decodedBytes / (1024 * 1024));
+  return {
+    headline: 'Full-cloud grade unavailable: the sample exceeds the safe decode budget',
+    note:
+      `Grading this cloud would decode ${formatPointCount(points)} points into a single ` +
+      `${mib} MiB buffer, above the ${formatPointCount(MAX_SAMPLE_POINTS)}-point safe ceiling. ` +
+      `The selected octree node is larger than the whole-cloud sample budget, so the grade ` +
+      `declines it here rather than force a multi-gigabyte allocation the streaming loader ` +
+      `itself would refuse. Grade a smaller scan or lower the sample budget.`,
+  };
+}
+
 /** Whether a full-cloud grade is exact (all nodes) or estimated from a sample. */
 export type GradeScope = 'exhaustive' | 'sampled';
 

--- a/src/render/streaming/fullCloudGradeAdapter.ts
+++ b/src/render/streaming/fullCloudGradeAdapter.ts
@@ -37,6 +37,7 @@ import { renderLocalPositions } from '../../model/pointFrames';
 import type { SamplingPlanOptions, SampleNode } from './samplingPlan';
 import {
   runFullCloudGrade,
+  FullCloudGradeRefusedError,
   type DecodeNodeFn,
   type FullCloudGradeRun,
   type GradeFn,
@@ -102,10 +103,11 @@ export function sampleNodesFromSource(source: GradeNodeSource): SampleNode[] {
  *
  * The returned function is cooperative on `signal` at both the range-read and
  * the decode (the COPC worker honours it). A node id absent from the store
- * yields an empty buffer rather than throwing, so a hierarchy that changed
- * under a long grade degrades to slightly-lower coverage instead of aborting —
- * the planner's ids always come from the same `sampleNodesFromSource` snapshot,
- * so in practice this is a guard, not a path.
+ * yields an empty buffer rather than throwing here; the runner then sees a
+ * decoded count (0) that disagrees with the node's declared header count and
+ * fails the grade cleanly, rather than silently reporting a coverage over a
+ * sample it never decoded. The planner's ids always come from the same
+ * `sampleNodesFromSource` snapshot, so in practice this is a guard, not a path.
  *
  * Note: `decoder.decode` TRANSFERS the chunk buffer to the worker; the buffer is
  * freshly read per node and never reused, so the transfer is safe.
@@ -206,5 +208,18 @@ export function gradeFullCloud<G>(args: {
       complete: source.octree.isComplete,
       errorCount: source.octree.errors.length,
     },
-  }).then((run) => ({ kind: 'graded', run }) as const);
+  }).then(
+    (run) => ({ kind: 'graded', run }) as const,
+    (err: unknown) => {
+      // The runner refuses a plan whose selected node exceeds the decode budget
+      // BEFORE it allocates the positions buffer. Surface it the same way as the
+      // unstated-total refusal: an 'unavailable' outcome with a headline + note,
+      // so the panel renders a neutral result rather than a red error. Any other
+      // failure (abort, a short/inconsistent decode) propagates to the caller.
+      if (err instanceof FullCloudGradeRefusedError) {
+        return { kind: 'unavailable', ...err.refusal } as const;
+      }
+      throw err;
+    },
+  );
 }

--- a/src/render/streaming/fullCloudGradeRunner.ts
+++ b/src/render/streaming/fullCloudGradeRunner.ts
@@ -23,9 +23,43 @@
 import { buildSamplingPlan, type SampleNode, type SamplingPlanOptions } from './samplingPlan';
 import {
   fullCloudGradeCoverage,
+  sampleBudgetRefusal,
   type FullCloudGradeCoverage,
   type OctreeCompleteness,
+  type SampleBudgetRefusal,
 } from './fullCloudGrade';
+
+/**
+ * Thrown when a sampling plan exceeds the decode budget ceilings, BEFORE the
+ * runner sizes its positions buffer. Carries the user-facing {@link
+ * SampleBudgetRefusal} so the adapter can turn it into an 'unavailable' outcome
+ * (headline + note) rather than a red error. Distinct from an abort: the runner
+ * already throws for a cancelled signal, and this is the second refusal the same
+ * seam recognises.
+ */
+export class FullCloudGradeRefusedError extends Error {
+  readonly refusal: SampleBudgetRefusal;
+  constructor(refusal: SampleBudgetRefusal) {
+    super(refusal.headline);
+    this.name = 'FullCloudGradeRefusedError';
+    this.refusal = refusal;
+  }
+}
+
+/**
+ * Thrown when a decoded node's point count does not equal the count its header
+ * declared. COPC/EPT/OOC hierarchy counts are exact, so a mismatch means the
+ * sample is not what the plan measured — the coverage percent and the density
+ * back-scale were computed from the PLAN, and silently grading a short (or
+ * over-long) sample under a plan-based scale would report a coverage the grade
+ * never decoded. The grade fails cleanly instead of reweighting.
+ */
+export class FullCloudGradeShortDecodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FullCloudGradeShortDecodeError';
+  }
+}
 
 /** Decode one node's points into local-space XYZ triples. Live = range read + worker. */
 export type DecodeNodeFn = (nodeId: string, signal?: AbortSignal) => Promise<Float32Array>;
@@ -88,7 +122,22 @@ export async function runFullCloudGrade<G>(args: {
   const { nodes, decodeNode, grade, options, signal, onProgress, completeness } = args;
 
   const plan = buildSamplingPlan(nodes, options);
+
+  // BUDGET GUARD (before any allocation): the planner always selects at least
+  // one node, so a single huge first node becomes the whole plan even when its
+  // count dwarfs the sample budget. Sizing `positions` at `sampledPoints * 3`
+  // would then allocate multiple gigabytes on a path that never went through the
+  // streaming scheduler's device-aware first-node guard. Refuse here, before the
+  // Float32Array is created, so an oversized plan can never allocate.
+  const refusal = sampleBudgetRefusal(plan);
+  if (refusal) throw new FullCloudGradeRefusedError(refusal);
+
   const coverage = fullCloudGradeCoverage(plan, completeness);
+
+  // Exact per-node header counts (COPC/EPT/OOC state them precisely) keyed by id,
+  // so each decoded node can be checked against what the plan measured.
+  const declaredById = new Map<string, number>();
+  for (const n of nodes) declaredById.set(n.id, Math.max(0, n.pointCount));
 
   // Decode each selected node in plan order, copying its points STRAIGHT into one
   // pre-sized buffer and dropping the chunk reference immediately — so the sample
@@ -96,19 +145,26 @@ export async function runFullCloudGrade<G>(args: {
   // merged copy, ~2× the sample's bytes at peak; this feature exists for large
   // streaming clouds, so that transient matters). The buffer is sized from the
   // plan's sampledPoints — the sum of the selected nodes' exact header counts —
-  // so it normally fits without reallocation.
-  let positions = new Float32Array(plan.sampledPoints * 3);
+  // and, because every node is verified to decode exactly its declared count, it
+  // fills precisely with no reallocation.
+  const positions = new Float32Array(plan.sampledPoints * 3);
   let offset = 0;
   let decodedNodes = 0;
   for (const id of plan.nodeIds) {
     if (signal?.aborted) throw new DOMException('Full-cloud grade aborted', 'AbortError');
     const chunk = await decodeNode(id, signal);
-    if (offset + chunk.length > positions.length) {
-      // A node decoded more points than its header advertised — grow once and
-      // keep going rather than truncate (correctness over the rare extra copy).
-      const grown = new Float32Array(Math.max(offset + chunk.length, positions.length * 2));
-      grown.set(positions.subarray(0, offset));
-      positions = grown;
+    // STRICT DECODE CHECK: the coverage percent and density back-scale were
+    // computed from the PLAN's declared counts. A node that decodes a different
+    // number of points than its header stated (a vanished/changed node, a short
+    // read) would make that scale describe a sample the grade never decoded.
+    // Hierarchy counts are exact, so fail cleanly rather than silently reweight.
+    const declared = declaredById.get(id) ?? 0;
+    if (chunk.length !== declared * 3) {
+      throw new FullCloudGradeShortDecodeError(
+        `Full-cloud grade: node ${id} decoded ${chunk.length / 3} points, but its header ` +
+          `declared ${declared}. Hierarchy counts are exact; refusing to grade an ` +
+          `inconsistent sample rather than report a coverage it never decoded.`,
+      );
     }
     positions.set(chunk, offset);
     offset += chunk.length;
@@ -120,11 +176,10 @@ export async function runFullCloudGrade<G>(args: {
     });
   }
 
-  // Grade exactly the decoded span (offset ≤ capacity when a node decodes fewer
-  // points than its header count). `subarray` is a view — no extra copy — and the
-  // result carries only the small grade + coverage, never the positions, so the
-  // sample isn't retained past the grade call.
-  const sample = offset === positions.length ? positions : positions.subarray(0, offset);
-  const grade_ = grade(sample, coverage.samplePointScale);
+  // Every node decoded exactly its declared count, so `offset === positions.length`
+  // and the whole buffer is the sample — no view/truncation. The result carries
+  // only the small grade + coverage, never the positions, so the sample isn't
+  // retained past the grade call.
+  const grade_ = grade(positions, coverage.samplePointScale);
   return { coverage, grade: grade_ };
 }

--- a/tests/fullCloudGrade.test.ts
+++ b/tests/fullCloudGrade.test.ts
@@ -8,6 +8,9 @@ import { describe, it, expect } from 'vitest';
 import { buildSamplingPlan, type SampleNode } from '../src/render/streaming/samplingPlan';
 import {
   fullCloudGradeCoverage,
+  sampleBudgetRefusal,
+  MAX_SAMPLE_POINTS,
+  MAX_SAMPLE_DECODED_BYTES,
   UNSTATED_POINT_TOTAL,
 } from '../src/render/streaming/fullCloudGrade';
 
@@ -139,6 +142,27 @@ describe('fullCloudGradeCoverage — completeness gating (a short hierarchy is n
     expect(cov.scope).toBe('sampled'); // driven by the budget, not completeness
     expect(cov.label).toMatch(/sampled/);
     expect(cov.note).toMatch(/representative octree sample/i);
+  });
+});
+
+describe('sampleBudgetRefusal — the oversized-plan ceiling (BUG 7)', () => {
+  it('passes a plan within the point ceiling (null = no refusal)', () => {
+    expect(sampleBudgetRefusal({ sampledPoints: MAX_SAMPLE_POINTS })).toBeNull();
+    expect(sampleBudgetRefusal({ sampledPoints: 2_000_000 })).toBeNull();
+    expect(sampleBudgetRefusal({ sampledPoints: 0 })).toBeNull();
+  });
+
+  it('refuses a plan one point above the ceiling, with a headline + note', () => {
+    const refusal = sampleBudgetRefusal({ sampledPoints: MAX_SAMPLE_POINTS + 1 });
+    expect(refusal).not.toBeNull();
+    expect(refusal!.headline).toMatch(/exceeds the safe decode budget/i);
+    expect(refusal!.note).toMatch(/safe ceiling/i);
+  });
+
+  it('the point ceiling keeps the decode buffer within the byte ceiling', () => {
+    // The buffer sized at the point ceiling is `points * 3 * 4` bytes; that must
+    // itself sit under the companion byte ceiling, so the two never disagree.
+    expect(MAX_SAMPLE_POINTS * 3 * 4).toBeLessThanOrEqual(MAX_SAMPLE_DECODED_BYTES);
   });
 });
 

--- a/tests/fullCloudGradeAdapter.test.ts
+++ b/tests/fullCloudGradeAdapter.test.ts
@@ -20,7 +20,11 @@ import {
   type FullCloudGradeOutcome,
   type GradeNodeSource,
 } from '../src/render/streaming/fullCloudGradeAdapter';
-import { runFullCloudGrade } from '../src/render/streaming/fullCloudGradeRunner';
+import {
+  runFullCloudGrade,
+  FullCloudGradeShortDecodeError,
+} from '../src/render/streaming/fullCloudGradeRunner';
+import { MAX_SAMPLE_POINTS } from '../src/render/streaming/fullCloudGrade';
 import { createStreamingNode } from '../src/render/streaming/StreamingNode';
 import type { StreamingNode } from '../src/render/streaming/StreamingNode';
 import type { StreamingNodeRecord } from '../src/io/copc/copcTypes';
@@ -50,7 +54,10 @@ function nodeList(): StreamingNode[] {
 }
 
 /** A fake source: nodes() + store.get over a Map; readNodeChunk encodes the id's
- *  marker into a 1-float buffer; decodeMeta is a stub the fake decoder ignores. */
+ *  marker AND the record's exact point count into a 2-float buffer so the fake
+ *  decoder can emit exactly that many points (COPC/EPT counts are exact, and the
+ *  runner now enforces decoded === declared); decodeMeta is a stub the decoder
+ *  ignores. */
 function fakeSource(
   nodes: StreamingNode[],
   markers: Record<string, number>,
@@ -78,14 +85,16 @@ function fakeSource(
     },
     readNodeChunk: async (rec: StreamingNodeRecord, signal?: AbortSignal): Promise<ArrayBuffer> => {
       hooks.onRead?.(rec.id, signal);
-      return Float32Array.of(markers[rec.id] ?? -1).buffer;
+      return Float32Array.of(markers[rec.id] ?? -1, rec.pointCount).buffer;
     },
     decodeMeta: (): ChunkDecodeMetadata =>
       ({ renderOrigin: [0, 0, 0] } as unknown as ChunkDecodeMetadata),
   };
 }
 
-/** A fake decoder: reads the marker the fake source wrote, emits 1 point (m,m,m). */
+/** A fake decoder: reads [marker, count] the fake source wrote, emits exactly
+ *  `count` points all set to the marker — so decoded === declared, the honest
+ *  case the runner requires. */
 function fakeDecoder(seen?: { signals: (AbortSignal | undefined)[] }): ChunkDecoder {
   return {
     decode: async (
@@ -94,15 +103,19 @@ function fakeDecoder(seen?: { signals: (AbortSignal | undefined)[] }): ChunkDeco
       signal?: AbortSignal,
     ): Promise<DecodedChunk> => {
       seen?.signals.push(signal);
-      const m = new Float32Array(chunk)[0];
+      const header = new Float32Array(chunk);
+      const m = header[0];
+      const count = header[1];
+      const positions = new Float32Array(count * 3);
+      positions.fill(m);
       return {
-        pointCount: 1,
-        positions: Float32Array.of(m, m, m),
-        intensity: new Uint16Array(1),
-        classification: new Uint8Array(1),
-        returnNumber: new Uint8Array(1),
-        returnCount: new Uint8Array(1),
-        gpsTime: new Float64Array(1),
+        pointCount: count,
+        positions,
+        intensity: new Uint16Array(count),
+        classification: new Uint8Array(count),
+        returnNumber: new Uint8Array(count),
+        returnCount: new Uint8Array(count),
+        gpsTime: new Float64Array(count),
       };
     },
   };
@@ -143,7 +156,9 @@ describe('makeDecodeNode — id → decoded positions', () => {
     const src = fakeSource(nodeList(), { '1-0-0-0': 42 });
     const decode = makeDecodeNode(src, fakeDecoder());
     const pos = await decode('1-0-0-0');
-    expect(Array.from(pos)).toEqual([42, 42, 42]);
+    // Node '1-0-0-0' declares 200 points → 600 floats, all the marker value.
+    expect(pos).toHaveLength(200 * 3);
+    expect(Array.from(pos).every((v) => v === 42)).toBe(true);
   });
 
   it('yields an empty buffer for an id absent from the store (no throw)', async () => {
@@ -198,7 +213,7 @@ describe('adapter ∘ runner — end-to-end with fakes', () => {
     });
     expect(out.coverage.scope).toBe('exhaustive');
     expect(out.coverage.coveragePercent).toBe(100);
-    expect(out.grade).toEqual({ points: 3, scale: 1 }); // one marker point per node
+    expect(out.grade).toEqual({ points: 600, scale: 1 }); // 100 + 200 + 300 points
   });
 
   it('grades a representative sample and back-scales when over budget', async () => {
@@ -226,7 +241,7 @@ describe('gradeFullCloud — one-call composition + progress', () => {
       options: { maxPoints: 10_000 },
     }));
     expect(run.coverage.scope).toBe('exhaustive');
-    expect(run.grade).toBe(3); // 3 nodes → 3 marker points
+    expect(run.grade).toBe(600); // 100 + 200 + 300 points
     expect(run.coverage.label).toMatch(/exact/);
   });
 
@@ -242,7 +257,9 @@ describe('gradeFullCloud — one-call composition + progress', () => {
     });
     expect(seen.map((p) => p.decodedNodes)).toEqual([1, 2, 3]);
     expect(seen.every((p) => p.totalNodes === 3)).toBe(true);
-    expect(seen.map((p) => p.decodedPoints)).toEqual([1, 2, 3]); // one marker pt per node
+    // Plan order is root (depth 0), then depth-1 nodes by count desc: 300 then
+    // 200. Cumulative decoded points: 100, +300, +200.
+    expect(seen.map((p) => p.decodedPoints)).toEqual([100, 400, 600]);
   });
 
   it('cancels cleanly when the signal is already aborted', async () => {
@@ -281,6 +298,65 @@ describe('gradeFullCloud — one-call composition + progress', () => {
     // The reason and the (previously write-only) error count reach the user.
     expect(run.coverage.note).toMatch(/did not fully load/i);
     expect(run.coverage.note).toMatch(/1 load error/);
+  });
+});
+
+describe('gradeFullCloud — oversized first node is refused (BUG 7)', () => {
+  it('returns an unavailable outcome (no decode) when the plan exceeds the ceiling', async () => {
+    // One node above the point ceiling becomes the whole plan (the planner always
+    // takes at least one). The grade must refuse before decoding rather than size
+    // a multi-gigabyte positions buffer.
+    const huge = [createStreamingNode(record('0-0-0-0', 0, MAX_SAMPLE_POINTS + 1, 10))];
+    const reads: string[] = [];
+    const src = fakeSource(huge, { '0-0-0-0': 1 }, { onRead: (id) => reads.push(id) });
+    const outcome = await gradeFullCloud({
+      source: src,
+      decoder: fakeDecoder(),
+      grade: (pos) => pos.length / 3,
+    });
+    expect(outcome.kind).toBe('unavailable');
+    if (outcome.kind !== 'unavailable') return;
+    expect(outcome.headline).toMatch(/safe decode budget/i);
+    expect(outcome.note).toMatch(/safe ceiling/i);
+    expect(reads).toEqual([]); // nothing was read/decoded
+  });
+
+  it('still grades a normally-sized cloud (the ceiling does not block real work)', async () => {
+    const src = fakeSource(nodeList(), { '0-0-0-0': 1, '1-0-0-0': 2, '1-1-0-0': 3 });
+    const outcome = await gradeFullCloud({
+      source: src,
+      decoder: fakeDecoder(),
+      grade: (pos) => pos.length / 3,
+      options: { maxPoints: 10_000 },
+    });
+    expect(outcome.kind).toBe('graded');
+  });
+});
+
+describe('gradeFullCloud — a decoded count that disagrees with the header (BUG 8)', () => {
+  it('fails the grade rather than report coverage over a sample it never decoded', async () => {
+    // A decoder that always emits a single point, regardless of the header count.
+    // Node headers declare 100/200/300, so every node is a short decode.
+    const shortDecoder: ChunkDecoder = {
+      decode: async (): Promise<DecodedChunk> => ({
+        pointCount: 1,
+        positions: Float32Array.of(1, 1, 1),
+        intensity: new Uint16Array(1),
+        classification: new Uint8Array(1),
+        returnNumber: new Uint8Array(1),
+        returnCount: new Uint8Array(1),
+        gpsTime: new Float64Array(1),
+      }),
+    };
+    const src = fakeSource(nodeList(), { '0-0-0-0': 1, '1-0-0-0': 2, '1-1-0-0': 3 });
+    await expect(
+      gradeFullCloud({
+        source: src,
+        decoder: shortDecoder,
+        grade: (pos) => pos.length / 3,
+        options: { maxPoints: 10_000 },
+      }),
+    ).rejects.toBeInstanceOf(FullCloudGradeShortDecodeError);
   });
 });
 
@@ -343,7 +419,7 @@ describe('gradeFullCloud — a source that states no point total', () => {
     if (outcome.kind !== 'graded') return;
     expect(outcome.run.coverage.scope).toBe('exhaustive');
     expect(outcome.run.coverage.label).toBe('all 1.5M points (exact)');
-    expect(outcome.run.grade).toBe(3);
+    expect(outcome.run.grade).toBe(3 * ASSUMED); // every declared point decoded
   });
 
   it('grades a source that states a total of ZERO (null is not zero)', async () => {

--- a/tests/fullCloudGradeRunner.test.ts
+++ b/tests/fullCloudGradeRunner.test.ts
@@ -3,29 +3,45 @@
  *
  * Decode and grade are injected (live streaming I/O and the terrain pipeline are
  * browser/heavy and stay out of this layer), so these tests pin the deterministic
- * orchestration: plan → coverage → ordered assembly → one back-scaled grade, plus
- * the honest exhaustive-vs-sampled coverage and cooperative cancellation.
+ * orchestration: plan → budget guard → coverage → ordered assembly → one
+ * back-scaled grade, plus the honest exhaustive-vs-sampled coverage, the strict
+ * decoded-count check, the oversized-plan refusal, and cooperative cancellation.
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { runFullCloudGrade } from '../src/render/streaming/fullCloudGradeRunner';
+import {
+  runFullCloudGrade,
+  FullCloudGradeRefusedError,
+  FullCloudGradeShortDecodeError,
+} from '../src/render/streaming/fullCloudGradeRunner';
 import type { SampleNode } from '../src/render/streaming/samplingPlan';
+import { MAX_SAMPLE_POINTS } from '../src/render/streaming/fullCloudGrade';
 import { gradeSampleDensity } from '../src/render/streaming/sampleGrade';
 
-/** Three nodes, 100 pts each (300 total). byteSize is irrelevant to these tests. */
+/** Three nodes: root 2 pts, then two depth-1 nodes (3 and 1 pts) → 6 total. */
 function nodes(): SampleNode[] {
   return [
-    { id: '0-0-0-0', depth: 0, pointCount: 100, byteSize: 1000 },
-    { id: '1-0-0-0', depth: 1, pointCount: 100, byteSize: 1000 },
-    { id: '1-1-0-0', depth: 1, pointCount: 100, byteSize: 1000 },
+    { id: '0-0-0-0', depth: 0, pointCount: 2, byteSize: 1000 },
+    { id: '1-0-0-0', depth: 1, pointCount: 3, byteSize: 1000 },
+    { id: '1-1-0-0', depth: 1, pointCount: 1, byteSize: 1000 },
   ];
 }
 
-/** A decode that returns one identifiable XYZ triple per node (id → marker value). */
+/** Points per node id, matching the header counts in {@link nodes}. */
+const COUNT: Record<string, number> = { '0-0-0-0': 2, '1-0-0-0': 3, '1-1-0-0': 1 };
+
+/**
+ * A decode that returns EXACTLY the node's declared count of identical XYZ
+ * triples (all set to the id's marker) — the honest case COPC/EPT always meet,
+ * since hierarchy counts are exact.
+ */
 function markerDecode(marker: Record<string, number>) {
   return async (id: string): Promise<Float32Array> => {
     const v = marker[id];
-    return Float32Array.of(v, v, v);
+    const n = COUNT[id] ?? 0;
+    const out = new Float32Array(n * 3);
+    out.fill(v);
+    return out;
   };
 }
 
@@ -36,7 +52,7 @@ describe('runFullCloudGrade — orchestration', () => {
       nodes: nodes(),
       decodeNode: markerDecode({ '0-0-0-0': 1, '1-0-0-0': 2, '1-1-0-0': 3 }),
       grade,
-      // budget above the 300 total → every node selected → exhaustive
+      // budget above the 6 total → every node selected → exhaustive
       options: { maxPoints: 10_000 },
     });
     expect(out.coverage.scope).toBe('exhaustive');
@@ -44,77 +60,89 @@ describe('runFullCloudGrade — orchestration', () => {
     expect(out.coverage.samplePointScale).toBe(1);
     expect(grade).toHaveBeenCalledTimes(1);
     expect(grade.mock.calls[0][1]).toBe(1); // scale passed through
+    // The whole sample (6 points) is graded, no truncation.
+    expect(grade.mock.calls[0][0]).toHaveLength(18);
   });
 
   it('sampled plan: back-scales density and marks the grade as sampled', async () => {
-    // maxPoints 100 → only the root node (100 pts) is decoded; 100 of 300 = 33%.
+    // maxPoints 2 → only the root node (2 pts) is decoded; 2 of 6 = 33%.
     const out = await runFullCloudGrade({
       nodes: nodes(),
       decodeNode: markerDecode({ '0-0-0-0': 1, '1-0-0-0': 2, '1-1-0-0': 3 }),
       grade: (_pos, scale) => scale,
-      options: { maxPoints: 100 },
+      options: { maxPoints: 2 },
     });
     expect(out.coverage.scope).toBe('sampled');
     expect(out.coverage.coveragePercent).toBe(33);
-    expect(out.coverage.samplePointScale).toBeCloseTo(3, 5); // 300/100
+    expect(out.coverage.samplePointScale).toBeCloseTo(3, 5); // 6/2
     expect(out.grade).toBeCloseTo(3, 5);
     expect(out.coverage.note).toMatch(/representative octree sample/i);
   });
 
   it('assembles decoded chunks in deterministic plan order', async () => {
-    // Root first (shallow), then the two depth-1 nodes by id. Markers prove order.
+    // Root first (shallow), then the two depth-1 nodes by count desc, then id.
+    // Markers prove order: root=10 (2 pts), 1-0-0-0=20 (3 pts), 1-1-0-0=30 (1 pt).
     const out = await runFullCloudGrade({
       nodes: nodes(),
       decodeNode: markerDecode({ '0-0-0-0': 10, '1-0-0-0': 20, '1-1-0-0': 30 }),
       grade: (pos) => Array.from(pos),
       options: { maxPoints: 10_000 },
     });
-    // each node contributed one [v,v,v] triple, in shallow→deep, id-sorted order
-    // (the grade is `Array.from(pos)`, so it proves both order AND length).
-    expect(out.grade).toEqual([10, 10, 10, 20, 20, 20, 30, 30, 30]);
+    expect(out.grade).toEqual([
+      10, 10, 10, 10, 10, 10, // root: 2 pts
+      20, 20, 20, 20, 20, 20, 20, 20, 20, // 1-0-0-0: 3 pts
+      30, 30, 30, // 1-1-0-0: 1 pt
+    ]);
   });
 
-  it('assembles correctly when a node decodes MORE points than its header count (grow path)', async () => {
-    // The buffer is pre-sized from the plan's per-node header counts; a node that
-    // decodes extra points must grow the buffer, not truncate. Root header says
-    // 100 pts but decodes 2 triples; the others decode 1 each — order preserved.
+  it('FAILS the grade when a node decodes MORE points than its header count', async () => {
+    // The plan sizes coverage + the density back-scale from the exact header
+    // counts. A node decoding extra points is a hierarchy/decoder inconsistency,
+    // not something to silently absorb — fail cleanly.
     const decode = async (id: string): Promise<Float32Array> =>
-      id === '0-0-0-0' ? Float32Array.of(1, 1, 1, 9, 9, 9) : (async () => {
-        const v = { '1-0-0-0': 2, '1-1-0-0': 3 }[id]!;
-        return Float32Array.of(v, v, v);
-      })();
-    const out = await runFullCloudGrade({
-      nodes: nodes(),
-      decodeNode: decode,
-      grade: (pos) => Array.from(pos),
-      options: { maxPoints: 10_000 },
-    });
-    expect(out.grade).toEqual([1, 1, 1, 9, 9, 9, 2, 2, 2, 3, 3, 3]);
+      id === '0-0-0-0'
+        ? Float32Array.of(1, 1, 1, 9, 9, 9, 5, 5, 5) // 3 pts, header says 2
+        : markerDecode({ '1-0-0-0': 2, '1-1-0-0': 3 })(id);
+    await expect(
+      runFullCloudGrade({
+        nodes: nodes(),
+        decodeNode: decode,
+        grade: (pos) => Array.from(pos),
+        options: { maxPoints: 10_000 },
+      }),
+    ).rejects.toBeInstanceOf(FullCloudGradeShortDecodeError);
   });
 
-  it('grades only the decoded span when nodes decode FEWER points than their header count', async () => {
-    // header counts total 300, but each node decodes a single triple → the grade
-    // must see exactly 9 floats, not a zero-padded 900-float buffer.
-    const out = await runFullCloudGrade({
-      nodes: nodes(),
-      decodeNode: markerDecode({ '0-0-0-0': 5, '1-0-0-0': 6, '1-1-0-0': 7 }),
-      grade: (pos) => pos.length,
-      options: { maxPoints: 10_000 },
-    });
-    expect(out.grade).toBe(9);
+  it('FAILS the grade when a node decodes FEWER points than its header count', async () => {
+    // The defect BUG 8 guards: a short decode under a plan-based scale would
+    // report a coverage the grade never decoded. Strict check → clean failure.
+    const decode = async (id: string): Promise<Float32Array> =>
+      id === '1-0-0-0'
+        ? Float32Array.of(2, 2, 2) // 1 pt, header says 3
+        : markerDecode({ '0-0-0-0': 1, '1-1-0-0': 3 })(id);
+    await expect(
+      runFullCloudGrade({
+        nodes: nodes(),
+        decodeNode: decode,
+        grade: (pos) => pos.length,
+        options: { maxPoints: 10_000 },
+      }),
+    ).rejects.toThrow(/decoded 1 points.*declared 3/);
   });
 
   it('EQUIVALENCE: the streamed-into-one-buffer grade equals grading a manual concat', async () => {
     // The memory optimisation (decode straight into a pre-sized buffer, release
-    // each chunk) must not change the result. Build varied-size chunks, grade via
-    // the runner with the REAL gradeSampleDensity, and compare field-for-field to
-    // grading a hand-concatenated buffer of the same points in the same order.
+    // each chunk) must not change the result. Build varied-size chunks whose
+    // counts MATCH their headers, grade via the runner with the REAL
+    // gradeSampleDensity, and compare field-for-field to grading a
+    // hand-concatenated buffer of the same points in the same order.
     const big: SampleNode[] = [
       { id: '0-0-0-0', depth: 0, pointCount: 2, byteSize: 1 },
       { id: '1-0-0-0', depth: 1, pointCount: 3, byteSize: 1 },
       { id: '1-1-0-0', depth: 1, pointCount: 1, byteSize: 1 },
     ];
     // Deterministic, finite points; a couple of non-finite to exercise validity.
+    // Each chunk's point count equals its header count above.
     const chunkFor: Record<string, Float32Array> = {
       '0-0-0-0': Float32Array.of(0, 0, 0, 10, 5, 2),
       '1-0-0-0': Float32Array.of(3, 4, 1, 7, 1, 9, NaN, 2, 2),
@@ -162,7 +190,7 @@ describe('runFullCloudGrade — orchestration', () => {
   });
 
   it('forwards octree completeness: an incomplete hierarchy is never labelled exact', async () => {
-    // Budget covers all 300 points → plan.exhaustive is true → the old path said
+    // Budget covers all 6 points → plan.exhaustive is true → the old path said
     // "exact". A false `completeness` (a truncated hierarchy) must override that.
     const out = await runFullCloudGrade({
       nodes: nodes(),
@@ -186,5 +214,74 @@ describe('runFullCloudGrade — orchestration', () => {
     });
     expect(out.coverage.scope).toBe('exhaustive');
     expect(out.coverage.label).toMatch(/exact/);
+  });
+});
+
+describe('runFullCloudGrade — oversized-plan budget guard (BUG 7)', () => {
+  it('REFUSES a first node above the point ceiling WITHOUT the giant allocation', async () => {
+    // The planner always selects at least one node, so a single node above the
+    // sample budget becomes the whole plan. Sizing positions at sampledPoints*3
+    // would allocate multiple gigabytes; the guard must refuse before that.
+    const huge: SampleNode[] = [
+      { id: '0-0-0-0', depth: 0, pointCount: MAX_SAMPLE_POINTS + 1, byteSize: 10 },
+    ];
+    const decode = vi.fn();
+
+    // Spy every Float32Array construction so we can prove none of the giant
+    // decode buffer was allocated. Safe here because the refusal is thrown
+    // before decode/coverage, so nothing on this path constructs a Float32Array.
+    const RealF32 = Float32Array;
+    const sizes: number[] = [];
+    const spy = vi.spyOn(globalThis, 'Float32Array').mockImplementation(((arg: number) => {
+      if (typeof arg === 'number') sizes.push(arg);
+      return new RealF32(arg as number);
+    }) as never);
+
+    try {
+      await expect(
+        runFullCloudGrade({
+          nodes: huge,
+          decodeNode: decode,
+          grade: () => null,
+          options: { maxPoints: 2_000_000 },
+        }),
+      ).rejects.toBeInstanceOf(FullCloudGradeRefusedError);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // The refusal fired before any decode and before the multi-gigabyte buffer.
+    expect(decode).not.toHaveBeenCalled();
+    expect(sizes.every((n) => n < (MAX_SAMPLE_POINTS + 1) * 3)).toBe(true);
+  });
+
+  it('carries a user-facing refusal (headline + note) on the error', async () => {
+    const huge: SampleNode[] = [
+      { id: '0-0-0-0', depth: 0, pointCount: MAX_SAMPLE_POINTS + 1, byteSize: 10 },
+    ];
+    let caught: unknown;
+    try {
+      await runFullCloudGrade({ nodes: huge, decodeNode: vi.fn(), grade: () => null });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FullCloudGradeRefusedError);
+    const refusal = (caught as FullCloudGradeRefusedError).refusal;
+    expect(refusal.headline).toMatch(/exceeds the safe decode budget/i);
+    expect(refusal.note).toMatch(/safe ceiling/i);
+  });
+
+  it('grades a normal-sized node fine (the ceiling does not block real work)', async () => {
+    const normal: SampleNode[] = [
+      { id: '0-0-0-0', depth: 0, pointCount: 3, byteSize: 10 },
+    ];
+    const out = await runFullCloudGrade({
+      nodes: normal,
+      decodeNode: async () => new Float32Array(9), // 3 pts, matches header
+      grade: (pos) => pos.length,
+      options: { maxPoints: 2_000_000 },
+    });
+    expect(out.grade).toBe(9);
+    expect(out.coverage.scope).toBe('exhaustive');
   });
 });


### PR DESCRIPTION
## What

Two safety fixes in the full-cloud grade path.

**Oversized first node (blocker).** The sampling planner always keeps at
least one node, so a single huge first node became the whole plan and the
runner sized a positions buffer at sampledPoints times three before
decoding, forcing a multi-gigabyte allocation past the streaming loader's
own device-aware first-node guard. New MAX_SAMPLE_POINTS (8M) and
MAX_SAMPLE_DECODED_BYTES (256 MiB) ceilings refuse an oversized plan
before the buffer is created; the adapter reports it as a neutral
unavailable outcome rather than a crash.

**Coverage over undecoded points.** The runner tolerated a node decoding
fewer points than its header declared while scaling coverage from the
plan, so density could reflect a sample it never read. Since COPC/EPT/OOC
hierarchy counts are exact, the runner now requires decoded equals
declared per node or fails the grade cleanly.

## Tests

Adversarial coverage: an oversized node refuses with no giant allocation
(the Float32Array constructor is spied) and a normal node grades; a
decoded count that disagrees with the header fails the grade.
