### PR TITLE
Lower full-cloud grade sample ceiling to the 2M budget (Finding 7)

### DIFF
--- a/src/render/streaming/fullCloudGrade.ts
+++ b/src/render/streaming/fullCloudGrade.ts
@@ -50,11 +50,16 @@ import { formatPointCount } from '../../io/loadPlan';
  * scheduler's device-aware first-node guard. This ceiling is that guard's
  * equivalent for the grade: above it the grade refuses rather than allocates.
  *
- * Set well above the 2,000,000-point default budget so a legitimately large
- * first node still grades, while the pathological hundreds-of-millions node is
- * declined.
+ * Set at the 2,000,000-point default sample budget. A single node coarser than
+ * the whole-cloud sample is refused rather than graded, because grading one node
+ * holds far more than the final XYZ Float32Array at peak: the compressed node,
+ * the laz-perf WASM input, the raw LAS records, and the decoded positions,
+ * intensity, classification, returns, GPS time, and RGB channels all sit in
+ * memory alongside the sample buffer. Unlike the streaming scheduler this path is
+ * not device-aware, so the ceiling stays at the normal target instead of several
+ * multiples of it. A node above it is declined here rather than allocated.
  */
-export const MAX_SAMPLE_POINTS = 8_000_000;
+export const MAX_SAMPLE_POINTS = 2_000_000;
 
 /**
  * Companion byte ceiling on the decoded POSITIONS buffer (`sampledPoints * 3`

--- a/tests/fullCloudGradeRunner.test.ts
+++ b/tests/fullCloudGradeRunner.test.ts
@@ -271,6 +271,38 @@ describe('runFullCloudGrade — oversized-plan budget guard (BUG 7)', () => {
     expect(refusal.note).toMatch(/safe ceiling/i);
   });
 
+  it('REFUSES a 3M-point node (above the 2M ceiling) before the sample allocation', async () => {
+    // A node coarser than the 2,000,000-point sample target: it sits below the
+    // former 8M ceiling but above the current one, so the peak-memory fix must
+    // decline it. The planner always selects at least one node, so this single
+    // node is the whole plan; the guard fires before positions is sized.
+    expect(MAX_SAMPLE_POINTS).toBe(2_000_000);
+    const coarse: SampleNode[] = [
+      { id: '0-0-0-0', depth: 0, pointCount: 3_000_000, byteSize: 10 },
+    ];
+    const decode = vi.fn();
+    const RealF32 = Float32Array;
+    const sizes: number[] = [];
+    const spy = vi.spyOn(globalThis, 'Float32Array').mockImplementation(((arg: number) => {
+      if (typeof arg === 'number') sizes.push(arg);
+      return new RealF32(arg as number);
+    }) as never);
+    try {
+      await expect(
+        runFullCloudGrade({
+          nodes: coarse,
+          decodeNode: decode,
+          grade: () => null,
+          options: { maxPoints: 2_000_000 },
+        }),
+      ).rejects.toBeInstanceOf(FullCloudGradeRefusedError);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(decode).not.toHaveBeenCalled();
+    expect(sizes.every((n) => n < 3_000_000 * 3)).toBe(true);
+  });
+
   it('grades a normal-sized node fine (the ceiling does not block real work)', async () => {
     const normal: SampleNode[] = [
       { id: '0-0-0-0', depth: 0, pointCount: 3, byteSize: 10 },


### PR DESCRIPTION
## Finding 7: full-cloud grade peak memory

The full-cloud grade budget guard sized only the final XYZ Float32Array
against `MAX_SAMPLE_POINTS`. While grading a single node the path also
holds the compressed node, the laz-perf WASM input, the raw LAS records,
and the decoded positions, intensity, classification, returns, GPS time,
and RGB channels at the same time. An 8M-point PDRF 7/8 node could add
several hundred MB beside the ~96 MB sample array, and this path is not
device-aware like the streaming scheduler.

## Change

`MAX_SAMPLE_POINTS` drops from 8,000,000 to 2,000,000, the normal sample
target. A node coarser than the whole-cloud sample is refused before the
sample and decode allocations instead of graded. The decoded-bytes
ceiling (256 MiB) and the strict decoded-count check are unchanged; no
guard or tolerance is weakened.

## Tests

New runner test: a 3M-point node (below the old ceiling, above the new
one) is refused before any Float32Array is sized and before decode is
called. Existing `MAX_SAMPLE_POINTS + 1` refusal and byte-ceiling tests
still pass. typecheck, the four full-cloud grade suites, scanFitness, and
`validation:study:verify` all green. No study or evidence register grades
a node above 2M points.
