### PR TITLE
io: stream bounded reads into one exact buffer

### DIFF
--- a/src/io/download.ts
+++ b/src/io/download.ts
@@ -9,6 +9,8 @@
  * releases the memory.
  */
 
+import { ownedExactBuffer } from './range/boundedRead';
+
 /** Trigger a browser download of `blob` as `filename`, deferring the URL revoke. */
 export function triggerDownload(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
@@ -29,13 +31,9 @@ export function triggerDownload(blob: Blob, filename: string): void {
 export function downloadBytes(filename: string, bytes: Uint8Array, mime: string): void {
   // Only copy when `bytes` is a partial view: `new Blob([typedArray])` serialises
   // the WHOLE backing ArrayBuffer, so a subarray (non-zero offset or shorter
-  // length) must be sliced to its own bytes. A typed array that owns its whole
+  // length) must be copied to its own bytes. A typed array that owns its whole
   // buffer passes straight through — no copy of a multi-MB export payload.
-  const ab =
-    bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
-      ? (bytes.buffer as ArrayBuffer)
-      : (bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer);
-  triggerDownload(new Blob([ab], { type: mime }), filename);
+  triggerDownload(new Blob([ownedExactBuffer(bytes)], { type: mime }), filename);
 }
 
 /** Download UTF-8 text (defaults to `text/plain`). */

--- a/src/io/ept/eptTransport.ts
+++ b/src/io/ept/eptTransport.ts
@@ -44,7 +44,7 @@
 
 import type { EptTransport } from '../../render/streaming/EptStreamingPointCloud';
 import { sanitizeUrlForDisplay } from '../range/RangeSource';
-import { readAtMostBounded, readTextAtMost } from '../range/boundedRead';
+import { ownedExactBuffer, readAtMostBounded, readTextAtMost } from '../range/boundedRead';
 
 /** Per-attempt timeout for one HTTP request, in milliseconds. */
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
@@ -233,13 +233,10 @@ export function createEptTransport(options: EptTransportOptions = {}): EptTransp
         { signal },
       );
       // Hand back an exact-size ArrayBuffer; a pooled/oversized backing buffer
-      // would hand the decoder trailing bytes that aren't part of the tile. The
-      // cast is sound — a fetch body is never a SharedArrayBuffer — and mirrors
-      // the fixture transport's own slice.
-      return bytes.buffer.slice(
-        bytes.byteOffset,
-        bytes.byteOffset + bytes.byteLength,
-      ) as ArrayBuffer;
+      // would hand the decoder trailing bytes that aren't part of the tile.
+      // `ownedExactBuffer` clones only when the view is partial — an
+      // already-exact body (the common case) passes through with no copy.
+      return ownedExactBuffer(bytes);
     },
   };
 }

--- a/src/io/range/boundedRead.ts
+++ b/src/io/range/boundedRead.ts
@@ -420,10 +420,63 @@ export async function readAtMostBounded(
     }
     return new Uint8Array(buffer);
   }
-  const chunks: Uint8Array[] = [];
-  let total = 0;
   const reader = body.getReader();
   const clock = startClock(options);
+  // Declared-length fast path: an identity-encoded body with a valid
+  // Content-Length at or below the ceiling lets us allocate the ONE exact
+  // target up front and stream chunks straight into it. That avoids the
+  // chunk-list + second full-size allocation the unknown-length path needs,
+  // which peaks at ~2x the body size during concatenation. `declared` here is
+  // already known to be `<= maxBytes` (the over-cap refusal above ran first),
+  // and `declaredBodyLength` returns null under any non-identity
+  // content-encoding, so a compressed length can never drive this branch.
+  if (declared !== null) {
+    const out = new Uint8Array(declared);
+    let filled = 0;
+    try {
+      for (;;) {
+        const { done, value } = await readChunkRacing(
+          reader,
+          options.signal,
+          options.timeoutSignal,
+          clock.idleTimeoutMs,
+          clock.totalTimeoutMs,
+          clock.msLeftOfTotal,
+        );
+        if (done) break;
+        if (!value || value.byteLength === 0) continue;
+        if (filled + value.byteLength > declared) {
+          // The body ran past its own declared length. Refuse rather than
+          // grow a second buffer: a Content-Length that undercounts the body
+          // is exactly the lie the ceiling exists to contain.
+          throw new BoundedReadError(
+            what,
+            maxBytes,
+            `${what} sent more than its declared ${declared} bytes — refusing to read further.`,
+          );
+        }
+        out.set(value, filled);
+        filled += value.byteLength;
+      }
+    } catch (err) {
+      await cancelQuietly(reader);
+      if (err instanceof BoundedReadStall) {
+        throw new BoundedReadError(
+          what,
+          maxBytes,
+          `${what} stalled — ${err.message}. The server sent headers but stopped sending data.`,
+          'stalled',
+        );
+      }
+      throw err;
+    }
+    // A body shorter than its declared length leaves trailing zeros in `out`.
+    // Trim to what actually arrived so no phantom bytes reach the decoder; the
+    // exact-length common case returns `out` untouched (still one allocation).
+    return filled === declared ? out : out.slice(0, filled);
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
   try {
     for (;;) {
       const { done, value } = await readChunkRacing(
@@ -458,6 +511,10 @@ export async function readAtMostBounded(
     }
     throw err;
   }
+  // Unknown-length path only: no Content-Length was available, so the size is
+  // discovered by reading. This is the branch that peaks at ~2x during the
+  // join below (chunk buffers still live while `out` fills). It is bounded by
+  // `maxBytes` and, for a single chunk, avoids the copy entirely.
   if (chunks.length === 1) return chunks[0];
   const out = new Uint8Array(total);
   let at = 0;
@@ -466,6 +523,25 @@ export async function readAtMostBounded(
     at += chunk.byteLength;
   }
   return out;
+}
+
+/**
+ * Return an ArrayBuffer that owns exactly `bytes` and nothing more.
+ *
+ * A `Uint8Array` can be a window onto a larger backing buffer (non-zero
+ * `byteOffset`, or a `byteLength` shorter than the buffer). Handing such a view
+ * to a consumer that indexes the raw `ArrayBuffer` — a decoder reading header
+ * offsets against `buffer.byteLength`, `new Blob([buffer])` — would leak the
+ * trailing bytes. When the view already spans its whole buffer this returns
+ * that buffer with no copy; otherwise it copies out just the viewed span. The
+ * cast is sound because these buffers are never `SharedArrayBuffer`.
+ *
+ * Mirrors the inline form in `io/download.ts` so both sites share one rule.
+ */
+export function ownedExactBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+    ? (bytes.buffer as ArrayBuffer)
+    : (bytes.slice().buffer as ArrayBuffer);
 }
 
 /** {@link readAtMostBounded}, decoded as UTF-8. For JSON documents. */

--- a/src/io/tiles3d/tilesetTransport.ts
+++ b/src/io/tiles3d/tilesetTransport.ts
@@ -24,7 +24,7 @@
  */
 
 import { sanitizeUrlForDisplay } from '../range/RangeSource';
-import { readAtMostBounded, readTextAtMost } from '../range/boundedRead';
+import { ownedExactBuffer, readAtMostBounded, readTextAtMost } from '../range/boundedRead';
 
 /** Per-attempt timeout for one HTTP request, in milliseconds. */
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
@@ -241,10 +241,8 @@ export function createTilesetTransport(
       // Exact-size, for the same reason the tile read below is: the subtree
       // reader indexes chunk offsets against the buffer length, so a pooled
       // backing buffer would present trailing bytes as part of the document.
-      return bytes.buffer.slice(
-        bytes.byteOffset,
-        bytes.byteOffset + bytes.byteLength,
-      ) as ArrayBuffer;
+      // `ownedExactBuffer` skips the copy when the body already owns its buffer.
+      return ownedExactBuffer(bytes);
     },
     fetchTileBytes: async (url, signal) => {
       const response = await fetchWithRetry(url, 'tile', signal);
@@ -257,10 +255,8 @@ export function createTilesetTransport(
       // An exact-size ArrayBuffer: a pooled or oversized backing buffer would
       // hand the PNTS decoder trailing bytes that are not part of the tile, and
       // the decoder reads its header offsets against the buffer length.
-      return bytes.buffer.slice(
-        bytes.byteOffset,
-        bytes.byteOffset + bytes.byteLength,
-      ) as ArrayBuffer;
+      // `ownedExactBuffer` avoids the copy when the body already owns its buffer.
+      return ownedExactBuffer(bytes);
     },
   };
 }

--- a/tests/boundedRead.test.ts
+++ b/tests/boundedRead.test.ts
@@ -14,6 +14,7 @@ import {
   readExactlyBounded,
   readAtMostBounded,
   readTextAtMost,
+  ownedExactBuffer,
   BoundedReadError,
 } from '../src/io/range/boundedRead';
 import { RangeReadError } from '../src/io/range/RangeSource';
@@ -128,6 +129,68 @@ describe('readAtMostBounded', () => {
 
   it('rejects an invalid ceiling', async () => {
     await expect(readAtMostBounded(streamingResponse([]), 0, 'x')).rejects.toBeInstanceOf(BoundedReadError);
+  });
+
+  it('preallocates ONE exact target for a declared length and streams into it', async () => {
+    // A valid identity Content-Length at or below the ceiling must drive the
+    // single-allocation path: no chunk list, no second full-size buffer. We
+    // count constructions of `Uint8Array(declared)` and assert exactly one,
+    // proving chunks stream directly into the preallocated target.
+    const chunks = [bytes(40), bytes(40), bytes(20)];
+    const declared = 100;
+    const RealU8 = globalThis.Uint8Array;
+    let targetAllocs = 0;
+    class SpyU8 extends RealU8 {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      constructor(...args: any[]) {
+        super(...(args as [number]));
+        if (typeof args[0] === 'number' && args[0] === declared) targetAllocs += 1;
+      }
+    }
+    (globalThis as { Uint8Array: typeof Uint8Array }).Uint8Array = SpyU8;
+    try {
+      const resp = streamingResponse(chunks, { 'content-length': String(declared) });
+      const out = await readAtMostBounded(resp, 256, 'EPT tile');
+      expect(out.byteLength).toBe(declared);
+      // Exact ownership: whole-buffer view, no trailing bytes past the payload.
+      expect(out.byteOffset).toBe(0);
+      expect(out.buffer.byteLength).toBe(declared);
+    } finally {
+      (globalThis as { Uint8Array: typeof Uint8Array }).Uint8Array = RealU8;
+    }
+    expect(targetAllocs).toBe(1);
+  });
+
+  it('trims a body shorter than its declared length to what arrived', async () => {
+    const resp = streamingResponse([bytes(30)], { 'content-length': '100' });
+    const out = await readAtMostBounded(resp, 256, 'EPT tile');
+    expect(out.byteLength).toBe(30);
+    expect(out.buffer.byteLength).toBe(30);
+  });
+
+  it('refuses a body that runs past its declared length', async () => {
+    const resp = streamingResponse([bytes(60), bytes(60)], { 'content-length': '100' });
+    await expect(readAtMostBounded(resp, 256, 'EPT tile')).rejects.toMatchObject({
+      name: 'BoundedReadError',
+      what: 'EPT tile',
+    });
+  });
+});
+
+describe('ownedExactBuffer', () => {
+  it('returns the same underlying buffer for an already-exact view (no clone)', () => {
+    const src = bytes(64);
+    const ab = ownedExactBuffer(src);
+    expect(ab).toBe(src.buffer);
+  });
+
+  it('copies out only the viewed span for a partial view', () => {
+    const backing = new Uint8Array(64).fill(7);
+    const view = backing.subarray(8, 24);
+    const ab = ownedExactBuffer(view);
+    expect(ab).not.toBe(backing.buffer);
+    expect(ab.byteLength).toBe(16);
+    expect(new Uint8Array(ab).every((b) => b === 7)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

Bounded remote body reads peaked near twice the body size: the shared
reader accumulated chunks in a list, allocated a second full-size
Uint8Array to join them, and each transport then ran buffer.slice for an
exact-sized buffer, a third transient copy before LAZ/PNTS decode.

readAtMostBounded now takes a single-allocation path when an identity
Content-Length at or below the ceiling is known. It preallocates exactly
that length and streams chunks into it. A body exceeding its declared
length is refused; a short body is trimmed to what arrived. Unknown-length
responses keep the chunk-list path, which is documented as the ~2x branch.

ownedExactBuffer(bytes) returns the backing buffer when the view already
spans it, else copies the viewed span. The EPT tile, 3D Tiles tile, and
subtree transports use it in place of an unconditional slice, so an exact
body is not cloned. download.ts reuses the same helper.

## Cap note

The EPT 256 MiB tile ceiling is unchanged. It is documented as headroom
over the ~140 MB legitimate worst case (a 4M-point node, widest layout).
No committed fixture or curated dataset approaches it; fixtures are KB.
Tightening below the documented worst case is not clearly safe, so the
cap stays and the evidence is recorded here.

## Tests

boundedRead.test.ts adds: single exact target allocation for a declared
length, refusal past declared length, short-body trim, and ownedExactBuffer
pass-through versus partial-view copy. Typecheck clean; io/range, EPT, and
3D Tiles suites pass (624 tests across the touched areas).
