### PR TITLE
Transform PNTS normals, cut transient decode memory, cap concurrency

### DIFF
--- a/src/io/tiles3d/pnts.ts
+++ b/src/io/tiles3d/pnts.ts
@@ -502,6 +502,24 @@ const COLOR_DECODED_BYTES = 3;
 const NORMAL_DECODED_BYTES = 12;
 const BATCH_ID_DECODED_BYTES = 4;
 
+/**
+ * Independent size ceilings on the tile's three variable-length metadata
+ * sections, in bytes, enforced BEFORE the section is decoded or copied.
+ *
+ * The outer tile-body cap (128 MiB at the transport) and the sectioned-length
+ * check bound the sections jointly, but jointly is not enough: a tile could
+ * spend its whole body budget on a batch-table JSON string and force a
+ * `JSON.parse` of a hundred megabytes, or on a batch-table binary this reader
+ * then copies whole. These caps are small and independent of that outer budget,
+ * so an oversized section is named and refused before the expensive step
+ * touches it rather than after. Feature-table JSON holds accessor descriptors
+ * and RTC/quantisation vectors and is tiny in practice; batch-table JSON and
+ * binary hold per-feature properties and are the larger two.
+ */
+export const MAX_PNTS_FEATURE_TABLE_JSON_BYTES = 1 * 1024 * 1024;
+export const MAX_PNTS_BATCH_TABLE_JSON_BYTES = 16 * 1024 * 1024;
+export const MAX_PNTS_BATCH_TABLE_BINARY_BYTES = 64 * 1024 * 1024;
+
 /** Options for {@link parsePnts}. */
 export interface ParsePntsOptions {
   /**
@@ -518,6 +536,25 @@ export interface ParsePntsOptions {
    * declares, so a channel-heavy tile is refused before allocation.
    */
   readonly maxDecodedBytes?: number;
+  /**
+   * Whether to decode the batch-table JSON, copy the batch-table binary, and
+   * materialise BATCH_ID. Defaults to `true`, the full generic-parser contract.
+   *
+   * The streaming decoder discards all three, so it passes `false`: the
+   * batch-table binary is not copied, its JSON is not parsed, and BATCH_ID is
+   * not read into a Uint32Array. `batchTable` and `batchIds` come back null, and
+   * no per-tile batch-table copy is made on the path that would only throw it
+   * away. Draco is still refused from the feature table, which is where point
+   * compression lives; a caller that needs batch metadata leaves this at the
+   * default.
+   */
+  readonly keepBatchMetadata?: boolean;
+  /** Ceiling on the feature-table JSON section in bytes. Defaults to {@link MAX_PNTS_FEATURE_TABLE_JSON_BYTES}. */
+  readonly maxFeatureTableJsonBytes?: number;
+  /** Ceiling on the batch-table JSON section in bytes. Defaults to {@link MAX_PNTS_BATCH_TABLE_JSON_BYTES}. */
+  readonly maxBatchTableJsonBytes?: number;
+  /** Ceiling on the batch-table binary section in bytes. Defaults to {@link MAX_PNTS_BATCH_TABLE_BINARY_BYTES}. */
+  readonly maxBatchTableBinaryBytes?: number;
 }
 
 /**
@@ -588,16 +625,43 @@ export function parsePnts(buffer: ArrayBuffer, options: ParsePntsOptions = {}): 
 
   const btBinStart = btJsonStart + btJsonLength;
 
+  const keepBatchMetadata = options.keepBatchMetadata ?? true;
+
+  // Section-size ceilings, enforced before the JSON is parsed or the binary is
+  // copied, so an oversized section is refused before the expensive step rather
+  // than after it has already run.
+  const maxFtJsonBytes = options.maxFeatureTableJsonBytes ?? MAX_PNTS_FEATURE_TABLE_JSON_BYTES;
+  if (ftJsonLength > maxFtJsonBytes) {
+    throw new Error(
+      `PNTS: feature-table JSON is ${ftJsonLength} bytes, past the ${maxFtJsonBytes} byte ceiling.`,
+    );
+  }
+
   const ft = decodeJsonSection(buffer, ftJsonStart, ftJsonLength, 'feature table');
+
   // Kept, not just checked: BATCH_ID indexes these properties, so the ids and
-  // the table they index have to leave this function together.
-  const batchTable =
-    btJsonLength > 0
-      ? {
-          json: decodeJsonSection(buffer, btJsonStart, btJsonLength, 'batch table'),
-          binary: new Uint8Array(buffer, btBinStart, btBinLength).slice(),
-        }
-      : null;
+  // the table they index have to leave this function together. The streaming
+  // decoder discards both, so it disables this whole block: no JSON.parse of the
+  // batch-table section, no copy of its binary.
+  let batchTable: PntsBatchTable | null = null;
+  if (keepBatchMetadata && btJsonLength > 0) {
+    const maxBtJsonBytes = options.maxBatchTableJsonBytes ?? MAX_PNTS_BATCH_TABLE_JSON_BYTES;
+    if (btJsonLength > maxBtJsonBytes) {
+      throw new Error(
+        `PNTS: batch-table JSON is ${btJsonLength} bytes, past the ${maxBtJsonBytes} byte ceiling.`,
+      );
+    }
+    const maxBtBinBytes = options.maxBatchTableBinaryBytes ?? MAX_PNTS_BATCH_TABLE_BINARY_BYTES;
+    if (btBinLength > maxBtBinBytes) {
+      throw new Error(
+        `PNTS: batch-table binary is ${btBinLength} bytes, past the ${maxBtBinBytes} byte ceiling.`,
+      );
+    }
+    batchTable = {
+      json: decodeJsonSection(buffer, btJsonStart, btJsonLength, 'batch table'),
+      binary: new Uint8Array(buffer, btBinStart, btBinLength).slice(),
+    };
+  }
 
   // Before POINTS_LENGTH, before any accessor, before any binary read: on a
   // Draco tile none of what follows is describing the bytes it thinks it is.
@@ -661,7 +725,11 @@ export function parsePnts(buffer: ArrayBuffer, options: ParsePntsOptions = {}): 
   // whichever position encoding it happens to carry.
   const colors = decodeColors(ft, view, pointsLength, ftBinStart, ftBinLength);
   const normals = decodeNormals(ft, view, pointsLength, ftBinStart, ftBinLength);
-  const batchIds = decodeBatchIds(ft, view, pointsLength, ftBinStart, ftBinLength);
+  // BATCH_ID indexes the batch table. When the caller keeps no batch metadata it
+  // has nothing to index, so the ids are not read into a Uint32Array.
+  const batchIds = keepBatchMetadata
+    ? decodeBatchIds(ft, view, pointsLength, ftBinStart, ftBinLength)
+    : null;
 
   // A tile carrying both encodings is decoded from POSITION: the format gives
   // the uncompressed array precedence over the quantised one.

--- a/src/io/tiles3d/pntsDecode.ts
+++ b/src/io/tiles3d/pntsDecode.ts
@@ -51,6 +51,7 @@
  */
 
 import { parsePnts } from './pnts';
+import { transformNormal } from './tileTransform';
 import type { ChunkDecoder, DecodedChunk } from '../copc/copcChunkDecode';
 
 /**
@@ -329,14 +330,21 @@ export class PntsChunkDecoder implements ChunkDecoder {
     if (!isPntsMetadata(meta)) {
       throw new Error('PntsChunkDecoder was handed metadata for another format.');
     }
-    const tile = parsePnts(chunk);
+    // The streaming decoder throws away batch ids and the batch table, so it
+    // asks the parser not to copy the batch-table binary or materialise
+    // BATCH_ID. That halves nothing here but spares a copy of the whole
+    // batch-table binary section per tile on the path that never reads it.
+    const tile = parsePnts(chunk, { keepBatchMetadata: false });
     const n = tile.pointsLength;
-    const positions = new Float32Array(n * 3);
     const [ox, oy, oz] = meta.renderOrigin;
     const rtc = tile.rtcCenter ?? [0, 0, 0];
-    // Hoisted: the tile's own local array, read once rather than three times
-    // per point. Its frame is the tile's local space, before RTC_CENTER.
-    const local = tile.positions;
+    // Transformed IN PLACE into the tile's own position array rather than a
+    // second Float32Array of the same size. `parsePnts` allocated `positions`
+    // fresh for this tile and nothing else aliases it, so the tile buffer is
+    // this decoder's to overwrite; it is discarded with `tile` after decode.
+    // Each point reads its three components before any is written, so the
+    // in-place write is safe within one iteration.
+    const positions = tile.positions;
 
     for (let i = 0; i < n; i++) {
       const j = i * 3;
@@ -344,13 +352,33 @@ export class PntsChunkDecoder implements ChunkDecoder {
       // transform places the tile, not the offset.
       const [wx, wy, wz] = applyMatrix(
         meta.tileTransform,
-        local[j] + rtc[0],
-        local[j + 1] + rtc[1],
-        local[j + 2] + rtc[2],
+        positions[j] + rtc[0],
+        positions[j + 1] + rtc[1],
+        positions[j + 2] + rtc[2],
       );
       positions[j] = wx - ox;
       positions[j + 1] = wy - oy;
       positions[j + 2] = wz - oz;
+    }
+
+    // Normals are directions, not positions: they take the inverse-transpose of
+    // the tile transform's linear part (RTC_CENTER and the render origin are
+    // translations and do not touch a direction), renormalised. Transformed in
+    // place into the tile's own normal array for the same ownership reason the
+    // positions are. See `transformNormal`.
+    if (tile.normals !== null) {
+      const normals = tile.normals;
+      for (let i = 0; i < n; i++) {
+        const j = i * 3;
+        const [nx, ny, nz] = transformNormal(meta.tileTransform, [
+          normals[j]!,
+          normals[j + 1]!,
+          normals[j + 2]!,
+        ]);
+        normals[j] = nx;
+        normals[j + 1] = ny;
+        normals[j + 2] = nz;
+      }
     }
 
     // The layer's colour meaning, settled by the first tile with points and
@@ -376,9 +404,10 @@ export class PntsChunkDecoder implements ChunkDecoder {
     // allocated for them, so a reader is told the channel is missing rather
     // than handed `pointCount` zeros that look like readings.
     //
-    // Normals are the one channel a point tile CAN state, so they are carried
-    // through as the tile wrote them — never re-normalised, never invented for
-    // a tile that has none.
+    // Normals are the one channel a point tile CAN state. They are carried
+    // through, transformed into the same root frame as the positions above by
+    // the inverse-transpose of the tile transform, never invented for a tile
+    // that has none.
     const decoded: DecodedChunk = {
       pointCount: n,
       positions,

--- a/src/io/tiles3d/tileTransform.ts
+++ b/src/io/tiles3d/tileTransform.ts
@@ -106,6 +106,74 @@ export function transformDirection(m: Mat4, v: Vec3): [number, number, number] {
 }
 
 /**
+ * A surface normal through the transform's linear part, as a unit vector.
+ *
+ * A normal is not a direction that rides the linear part the way a box half-axis
+ * does. Under a non-uniform or sheared linear map the plane a normal is
+ * perpendicular to is skewed, and applying the same matrix to the normal leaves
+ * it no longer perpendicular to that plane. The 3D Tiles specification (and every
+ * graphics text on the subject) fixes this by transforming a normal with the
+ * inverse-transpose of the upper-left 3x3, then renormalising: the inverse
+ * cancels the skew and the transpose puts it back in the normal's covector space.
+ *
+ * The inverse-transpose is the cofactor matrix of the 3x3 divided by its
+ * determinant. Dividing by the SIGNED determinant matters: a reflection
+ * (negative determinant) must flip the normal, and only the signed divide does
+ * that, which renormalising afterwards preserves rather than erases.
+ *
+ * Degenerate case: a 3x3 whose determinant is zero collapses a dimension and has
+ * no inverse. Rather than emit NaN, the direction is carried through the plain
+ * linear part and normalised, which is the best available answer for a transform
+ * that is not supposed to occur on a real tile. A zero-length result (a normal
+ * the linear part sends to the origin) is returned as written.
+ */
+export function transformNormal(m: Mat4, v: Vec3): [number, number, number] {
+  // Upper-left 3x3, column-major: a3[col][row] = m[col * 4 + row].
+  const a = m[0]!, b = m[1]!, c = m[2]!; // column 0
+  const d = m[4]!, e = m[5]!, f = m[6]!; // column 1
+  const g = m[8]!, h = m[9]!, i = m[10]!; // column 2
+
+  // Cofactor matrix of the 3x3. `cof[row][col]` is the signed minor with that
+  // row and column struck out; the cofactor matrix (not its transpose) is the
+  // inverse-transpose once divided by the determinant.
+  const cof00 = e * i - f * h;
+  const cof01 = -(b * i - c * h);
+  const cof02 = b * f - c * e;
+  const cof10 = -(d * i - f * g);
+  const cof11 = a * i - c * g;
+  const cof12 = -(a * f - c * d);
+  const cof20 = d * h - e * g;
+  const cof21 = -(a * h - b * g);
+  const cof22 = a * e - b * d;
+
+  const det = a * cof00 + d * cof01 + g * cof02;
+  const [x, y, z] = v;
+
+  if (!Number.isFinite(det) || det === 0) {
+    // No inverse. Fall back to the plain linear part, normalised.
+    return normalizeOrZero(
+      a * x + d * y + g * z,
+      b * x + e * y + h * z,
+      c * x + f * y + i * z,
+    );
+  }
+
+  // (inverse-transpose) · v = (cofactor / det) · v. Row `r` of the cofactor
+  // matrix is (cof[r][0], cof[r][1], cof[r][2]).
+  const nx = (cof00 * x + cof01 * y + cof02 * z) / det;
+  const ny = (cof10 * x + cof11 * y + cof12 * z) / det;
+  const nz = (cof20 * x + cof21 * y + cof22 * z) / det;
+  return normalizeOrZero(nx, ny, nz);
+}
+
+/** Normalise a vector, returning it unchanged when its length is zero. */
+function normalizeOrZero(x: number, y: number, z: number): [number, number, number] {
+  const length = Math.hypot(x, y, z);
+  if (length === 0 || !Number.isFinite(length)) return [x, y, z];
+  return [x / length, y / length, z / length];
+}
+
+/**
  * The largest scaling factor of the linear part.
  *
  * Taken as the longest of the three transformed basis vectors, which is what

--- a/src/render/streaming/streamingAttach.ts
+++ b/src/render/streaming/streamingAttach.ts
@@ -30,8 +30,9 @@ import type { StreamingSource } from './StreamingSource';
 import type { StreamingNode } from './StreamingNode';
 import type { StreamingBenchmark } from './streamingBenchmark';
 import type { StreamingQuality } from './streamingBudget';
-import { streamingBudgets, firstAdmissionMaxPoints } from './streamingBudget';
+import { streamingBudgets, firstAdmissionMaxPoints, capPntsConcurrency } from './streamingBudget';
 import { makeStreamingCommit, type StreamingCommit } from './meteredCommit';
+import { PntsChunkDecoder } from '../../io/tiles3d/pntsDecode';
 import type { ChunkDecoder, DecodedChunk } from '../../io/copc/copcChunkDecode';
 import { renderLocalPositions } from '../../model/pointFrames';
 import { loadStreamingRenderer, loadStreamingScheduler } from '../../lazyChunks';
@@ -202,6 +203,14 @@ export async function buildStreamingSession(
   );
   // The commit driver picks the scheduler's commit path (see meteredCommit.ts).
   const commit = makeStreamingCommit(readDevFlags().streamingCommitMode, isMobile, benchmark);
+  // A PNTS source admits nodes on a fixed point estimate a real tile can far
+  // exceed, so its concurrent decodes are held below the shared budget until a
+  // real preflight exists. COPC and EPT carry true per-node counts and keep the
+  // shared budget. See `capPntsConcurrency`.
+  const budgets =
+    decoder instanceof PntsChunkDecoder
+      ? capPntsConcurrency(streamingBudgets(quality, isMobile), isMobile)
+      : streamingBudgets(quality, isMobile);
   const scheduler = new StreamingScheduler(
     cloud,
     decoder,
@@ -211,7 +220,7 @@ export async function buildStreamingSession(
       nodeClassesHook: () => host.streamingNodeClassesHook(),
       nodeReadyHook: () => host.streamingNodeReadyHook(),
     }),
-    streamingBudgets(quality, isMobile),
+    budgets,
     {
       ...commit.schedulerOptions(),
       // Opt-in resident stickiness. The flag lives here, with the other host

--- a/src/render/streaming/streamingBudget.ts
+++ b/src/render/streaming/streamingBudget.ts
@@ -145,6 +145,37 @@ export function streamingBudgets(
   };
 }
 
+/**
+ * The concurrent-decode ceiling for a PNTS (3D Tiles point) source.
+ *
+ * A PNTS tile carries no point count in the tileset JSON, so the scheduler
+ * admits its nodes on a fixed estimate (`ASSUMED_TILE_POINTS`, 500k) that a real
+ * tile can exceed by more than an order of magnitude, and each decode can reach
+ * the per-tile decoded-byte ceiling (192 MiB) before the estimate is corrected.
+ * With the shared budget's 4 desktop / 2 mobile concurrent decodes that admits
+ * several near-ceiling decodes at once, a transient spike the point estimate did
+ * not predict. Until a real per-tile preflight exists, PNTS decodes are held to
+ * one on mobile and two on desktop: a conservative bound that trades a little
+ * fill throughput for a transient-memory ceiling the scheduler can reason about.
+ */
+export const MAX_PNTS_CONCURRENT_DECODES_MOBILE = 1;
+export const MAX_PNTS_CONCURRENT_DECODES_DESKTOP = 2;
+
+/**
+ * Clamp a resolved budget's concurrent-decode count to the PNTS ceiling. Pure,
+ * and only ever lowers: `Math.min` leaves a budget already at or below the cap
+ * untouched.
+ */
+export function capPntsConcurrency(
+  budgets: StreamingBudgets,
+  isMobile: boolean,
+): StreamingBudgets {
+  const cap = isMobile
+    ? MAX_PNTS_CONCURRENT_DECODES_MOBILE
+    : MAX_PNTS_CONCURRENT_DECODES_DESKTOP;
+  return { ...budgets, maxConcurrentDecodes: Math.min(budgets.maxConcurrentDecodes, cap) };
+}
+
 /** A scored node candidate — the minimal shape budget selection needs. */
 export interface ScoredCandidate {
   id: string;

--- a/tests/pntsDecode.test.ts
+++ b/tests/pntsDecode.test.ts
@@ -95,6 +95,42 @@ describe('placement', () => {
   });
 });
 
+describe('transient memory', () => {
+  it('allocates no second XYZ array — positions are transformed in place', async () => {
+    // parsePnts already owns a fresh Float32Array of the tile's positions.
+    // Transforming into a second array of the same size doubled the transient
+    // XYZ footprint of every tile decode. A positions-only tile of N points must
+    // see exactly ONE Float32Array of length 3N allocated across the whole
+    // decode (the parser's), not two.
+    const points = [
+      [0, 0, 0],
+      [1, 1, 1],
+      [2, 2, 2],
+    ] as const;
+    const wanted = points.length * 3;
+    const RealFloat32Array = Float32Array;
+    let ofWantedLength = 0;
+    const Spy = new Proxy(RealFloat32Array, {
+      construct(target, args: [number]) {
+        if (args[0] === wanted) ofWantedLength += 1;
+        return Reflect.construct(target, args) as Float32Array;
+      },
+    });
+    (globalThis as unknown as { Float32Array: typeof Float32Array }).Float32Array =
+      Spy as unknown as typeof Float32Array;
+    try {
+      await new PntsChunkDecoder().decode(makePnts(points), meta());
+    } finally {
+      (globalThis as unknown as { Float32Array: typeof Float32Array }).Float32Array =
+        RealFloat32Array;
+    }
+    expect(
+      ofWantedLength,
+      'the decoder allocated a second positions array instead of reusing the parsed one',
+    ).toBe(1);
+  });
+});
+
 describe('attributes the format does not carry', () => {
   it('never offers intensity or classification as a colour mode', () => {
     expect(

--- a/tests/streamingBudget.test.ts
+++ b/tests/streamingBudget.test.ts
@@ -8,6 +8,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   streamingBudgets,
+  capPntsConcurrency,
+  MAX_PNTS_CONCURRENT_DECODES_MOBILE,
+  MAX_PNTS_CONCURRENT_DECODES_DESKTOP,
   selectWithinBudget,
   decodedBytesPerPoint,
   firstAdmissionMaxDecodedBytes,
@@ -190,5 +193,34 @@ describe('selectWithinBudget — resident stickiness', () => {
       stickyMargin: 0.15,
     });
     expect(wanted).toEqual(new Set(['x', 'r']));
+  });
+});
+
+describe('capPntsConcurrency — the PNTS concurrent-decode ceiling', () => {
+  it('holds desktop PNTS decodes to two, below the shared budget of four', () => {
+    const shared = streamingBudgets('high', false);
+    expect(shared.maxConcurrentDecodes).toBe(4);
+    const capped = capPntsConcurrency(shared, false);
+    expect(capped.maxConcurrentDecodes).toBe(MAX_PNTS_CONCURRENT_DECODES_DESKTOP);
+    expect(capped.maxConcurrentDecodes).toBe(2);
+  });
+
+  it('holds mobile PNTS decodes to one, below the shared budget of two', () => {
+    const shared = streamingBudgets('high', true);
+    expect(shared.maxConcurrentDecodes).toBe(2);
+    const capped = capPntsConcurrency(shared, true);
+    expect(capped.maxConcurrentDecodes).toBe(MAX_PNTS_CONCURRENT_DECODES_MOBILE);
+    expect(capped.maxConcurrentDecodes).toBe(1);
+  });
+
+  it('only ever lowers the count and leaves the rest of the budget untouched', () => {
+    const shared = streamingBudgets('balanced', false);
+    const capped = capPntsConcurrency(shared, false);
+    expect(capped.maxConcurrentDecodes).toBeLessThanOrEqual(shared.maxConcurrentDecodes);
+    expect(capped.pointBudget).toBe(shared.pointBudget);
+    expect(capped.chunkCacheBytes).toBe(shared.chunkCacheBytes);
+    // A budget already at or below the cap is not raised.
+    const already = { ...shared, maxConcurrentDecodes: 1 };
+    expect(capPntsConcurrency(already, false).maxConcurrentDecodes).toBe(1);
   });
 });

--- a/tests/tiles3d.test.ts
+++ b/tests/tiles3d.test.ts
@@ -627,3 +627,77 @@ describe('parsePnts batch ids', () => {
     expect(t.batchTable?.json.classification).toEqual([2]);
   });
 });
+
+describe('parsePnts batch-metadata gating and section caps', () => {
+  it('reads BATCH_ID and the batch table by default', () => {
+    const t = parsePnts(
+      makeBatchPnts({ batchIds: [0, 1, 2], batchTable: { name: ['a', 'b', 'c'] } }),
+    );
+    expect([...(t.batchIds as Uint32Array)]).toEqual([0, 1, 2]);
+    expect(t.batchTable?.json.name).toEqual(['a', 'b', 'c']);
+  });
+
+  it('materialises neither BATCH_ID nor the batch table when metadata is disabled', () => {
+    const body = makeBatchPnts({ batchIds: [0, 1, 2], batchTable: { name: ['a', 'b', 'c'] } });
+    const RealUint32Array = Uint32Array;
+    let u32OfPointCount = 0;
+    const Spy = new Proxy(RealUint32Array, {
+      construct(target, args: [number]) {
+        if (args[0] === 3) u32OfPointCount += 1;
+        return Reflect.construct(target, args) as Uint32Array;
+      },
+    });
+    (globalThis as unknown as { Uint32Array: typeof Uint32Array }).Uint32Array =
+      Spy as unknown as typeof Uint32Array;
+    let t: ReturnType<typeof parsePnts>;
+    try {
+      t = parsePnts(body, { keepBatchMetadata: false });
+    } finally {
+      (globalThis as unknown as { Uint32Array: typeof Uint32Array }).Uint32Array = RealUint32Array;
+    }
+    expect(t.batchIds, 'BATCH_ID must not be materialised when metadata is disabled').toBeNull();
+    expect(t.batchTable, 'the batch table must not be kept when metadata is disabled').toBeNull();
+    expect(u32OfPointCount, 'no per-point BATCH_ID array was allocated').toBe(0);
+  });
+
+  it('refuses an oversized batch-table JSON before it is parsed', () => {
+    const body = makeBatchPnts({
+      batchIds: [0],
+      batchTable: { note: 'x'.repeat(64) },
+    });
+    const RealParse = JSON.parse;
+    let parseCalls = 0;
+    JSON.parse = ((...args: Parameters<typeof RealParse>) => {
+      parseCalls += 1;
+      return RealParse(...args);
+    }) as typeof JSON.parse;
+    try {
+      expect(() => parsePnts(body, { maxBatchTableJsonBytes: 8 })).toThrow(
+        /batch-table JSON is \d+ bytes, past the 8 byte ceiling/,
+      );
+    } finally {
+      JSON.parse = RealParse;
+    }
+    // The feature table is parsed (1); the batch table is refused on size before
+    // its own JSON.parse, so the count stays at one.
+    expect(parseCalls, 'the batch-table JSON was parsed despite exceeding the cap').toBe(1);
+  });
+
+  it('refuses an oversized feature-table JSON before it is parsed', () => {
+    const body = makeBatchPnts({ batchIds: [0] });
+    expect(() => parsePnts(body, { maxFeatureTableJsonBytes: 4 })).toThrow(
+      /feature-table JSON is \d+ bytes, past the 4 byte ceiling/,
+    );
+  });
+
+  it('refuses an oversized batch-table binary before it is copied', () => {
+    const body = makeBatchPnts({
+      batchIds: [0],
+      batchTable: { name: ['a'] },
+      batchTableBinary: [1, 2, 3, 4, 5, 6, 7, 8],
+    });
+    expect(() => parsePnts(body, { maxBatchTableBinaryBytes: 4 })).toThrow(
+      /batch-table binary is 8 bytes, past the 4 byte ceiling/,
+    );
+  });
+});

--- a/tests/tiles3dTransform.test.ts
+++ b/tests/tiles3dTransform.test.ts
@@ -23,6 +23,7 @@ import {
   cumulativeTransform,
   transformPoint,
   transformDirection,
+  transformNormal,
   largestScale,
   transformGeometricError,
   transformBox,
@@ -123,6 +124,81 @@ describe('points and directions differ by the translation', () => {
     expect(x).toBeCloseTo(0, 12);
     expect(y).toBeCloseTo(1, 12);
     expect(z).toBeCloseTo(0, 12);
+  });
+});
+
+describe('normals take the inverse-transpose, not the plain linear part', () => {
+  it('leaves a normal unchanged under the identity', () => {
+    expect(transformNormal(IDENTITY_4X4, [0, 0, 1])).toEqual([0, 0, 1]);
+  });
+
+  it('ignores translation, which does not touch a direction', () => {
+    expect(transformNormal(T(5, 6, 7), [0, 0, 1])).toEqual([0, 0, 1]);
+  });
+
+  it('rotates +X to +Y under a 90-degree Z rotation', () => {
+    const [x, y, z] = transformNormal(Rz(Math.PI / 2), [1, 0, 0]);
+    expect(x).toBeCloseTo(0, 12);
+    expect(y).toBeCloseTo(1, 12);
+    expect(z).toBeCloseTo(0, 12);
+  });
+
+  it('preserves direction and unit length under a uniform scale', () => {
+    // The inverse-transpose of a uniform scale s is (1/s)·I, so the direction is
+    // the same and renormalisation restores unit length.
+    const [x, y, z] = transformNormal(S(4, 4, 4), [0, 0, 1]);
+    expect(x).toBeCloseTo(0, 12);
+    expect(y).toBeCloseTo(0, 12);
+    expect(z).toBeCloseTo(1, 12);
+  });
+
+  it('renormalises to unit length whatever the scale', () => {
+    const [x, y, z] = transformNormal(S(2, 3, 4), [1, 1, 1]);
+    expect(Math.hypot(x, y, z)).toBeCloseTo(1, 12);
+  });
+
+  it('differs from the plain linear part under a NON-uniform scale', () => {
+    // Under S(1,1,4) a plane normal (0,0,1) is bent by the inverse-transpose to
+    // point MORE steeply, not less: the plain matrix scales the z component up
+    // (wrong), the inverse-transpose scales it by 1/4 relative to x,y (right).
+    // A 45-degree normal in the x-z plane is the sharpest witness.
+    const m = S(1, 1, 4);
+    const inClinedNormal: [number, number, number] = [Math.SQRT1_2, 0, Math.SQRT1_2];
+
+    const invT = transformNormal(m, inClinedNormal);
+    // Plain linear part, normalised, is what a naive multiply would produce.
+    const plain = transformDirection(m, inClinedNormal);
+    const plainLen = Math.hypot(...plain);
+    const plainUnit = plain.map((c) => c / plainLen);
+
+    // The two disagree: the plain multiply tilts z UP (0.97), the
+    // inverse-transpose tilts it DOWN (0.24).
+    expect(Math.abs(invT[2] - plainUnit[2])).toBeGreaterThan(0.1);
+    // Closed form: inverse-transpose of S(1,1,4) is S(1,1,1/4); applied to
+    // (1/√2,0,1/√2) gives (1/√2,0,1/(4√2)), normalised.
+    const ex = 1 / Math.SQRT2, ez = 1 / (4 * Math.SQRT2);
+    const exLen = Math.hypot(ex, 0, ez);
+    expect(invT[0]).toBeCloseTo(ex / exLen, 12);
+    expect(invT[2]).toBeCloseTo(ez / exLen, 12);
+  });
+
+  it('applies the rotational root frame of an ENU-style transform', () => {
+    // A root transform combining a rotation and a translation (the shape an ENU
+    // placement takes): the translation is ignored and the rotation carried.
+    const m = composeTileTransform(T(6378137, 0, 0), Rz(Math.PI / 2));
+    const [x, y, z] = transformNormal(m, [1, 0, 0]);
+    expect(x).toBeCloseTo(0, 9);
+    expect(y).toBeCloseTo(1, 9);
+    expect(z).toBeCloseTo(0, 9);
+  });
+
+  it('falls back to the normalised linear part on a degenerate transform', () => {
+    // A rank-deficient 3x3 (z axis collapsed) has no inverse; rather than NaN,
+    // the direction rides the plain linear part, normalised.
+    const collapsed = S(2, 2, 0);
+    const [x, y, z] = transformNormal(collapsed, [1, 0, 0]);
+    expect(Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)).toBe(true);
+    expect(Math.hypot(x, y, z)).toBeCloseTo(1, 12);
   });
 });
 

--- a/tests/tilesetStreamingNormals.test.ts
+++ b/tests/tilesetStreamingNormals.test.ts
@@ -152,6 +152,32 @@ describe('a tile that states normals', () => {
     expect(decoded.normals?.length).toBe(3 * decoded.pointCount);
   });
 
+  it('transforms the stated directions into the tile transform frame', async () => {
+    // A 90-degree Z rotation as the tile transform. The normals must ride it:
+    // the tile states +Z and +X, and both are directions in the tile's local
+    // frame that the transform places into the root frame. A decoder that
+    // returned them untransformed would report a surface facing a direction it
+    // does not, under any tile that is rotated relative to the root.
+    const ROTATE_Z90: PntsDecodeMetadata = {
+      format: 'pnts',
+      tileTransform: [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+      renderOrigin: [0, 0, 0],
+    };
+    const decoded = await new PntsChunkDecoder().decode(
+      makePnts(LOW_AND_HIGH, { normals: STATED_NORMALS }),
+      ROTATE_Z90,
+    );
+    const n = [...(decoded.normals ?? [])];
+    // +Z is on the rotation axis, unchanged.
+    expect(n[0]).toBeCloseTo(0, 6);
+    expect(n[1]).toBeCloseTo(0, 6);
+    expect(n[2]).toBeCloseTo(1, 6);
+    // +X rotates to +Y.
+    expect(n[3]).toBeCloseTo(0, 6);
+    expect(n[4]).toBeCloseTo(1, 6);
+    expect(n[5]).toBeCloseTo(0, 6);
+  });
+
   it('states no normals when the tile carries none', async () => {
     const decoded = await new PntsChunkDecoder().decode(makePnts(LOW_AND_HIGH), META);
     expect(


### PR DESCRIPTION
Hardens the 3D Tiles PNTS path for v0.6.7 across four findings.

Normals were returned untransformed, so a rotated or scaled tile
reported surfaces facing the wrong way. A new transformNormal helper
applies the inverse-transpose of the tile transform linear part and
renormalises, run over decoded NORMAL and NORMAL_OCT16P.

The streaming decoder allocated a second Float32Array for positions
of the same size the parser already owns; it now transforms that buffer
in place, halving transient XYZ memory per tile.

parsePnts gains keepBatchMetadata, which the streaming path sets false
so the batch-table binary is not copied and BATCH_ID is not read, plus
independent size ceilings on the feature-table JSON, batch-table JSON
and batch-table binary sections, enforced before parse or copy. The
generic parser keeps full batch support.

A PNTS source admits nodes on a fixed point estimate a real tile can
far exceed, so its concurrent decodes are held to one on mobile and two
on desktop until a real preflight exists. COPC and EPT keep the shared
budget.

Every change ships with a red-green test. typecheck, lint:int-truncation,
lint:position-access, lint:layer-boundaries and the tiles3d and streaming
unit buckets pass.
