### PR TITLE
harden EPT tile admission before decode

### DIFF
--- a/src/io/ept/EptChunkDecoder.ts
+++ b/src/io/ept/EptChunkDecoder.ts
@@ -27,6 +27,7 @@ import type {
 import type { EptStreamingPointCloud } from '../../render/streaming/EptStreamingPointCloud';
 import type { EptLaszipWorkerClient } from './worker/eptLaszipWorkerClient';
 import { decodeEptLaszipTile } from './eptLaszipDecode';
+import { parseLasHeader } from '../lasHeader';
 import { LoadError } from '../loadErrors';
 
 export class EptChunkDecoder implements ChunkDecoder {
@@ -71,6 +72,28 @@ export class EptChunkDecoder implements ChunkDecoder {
         // in-process path is the fallback for environments without a worker.
         // Both carry `meta.rgbEightBit` — the dataset-level colour decision.
         {
+          // Memory-admission gate, BEFORE any laz-perf decompression. The
+          // scheduler admitted this node and reserved its memory on the
+          // hierarchy point count (`meta.pointCount`), but an EPT laszip tile is
+          // a complete LAZ file whose own LAS public header count drives the
+          // decode allocation. Parsing the header is cheap (no decompression) and
+          // catches the disagreement before the tile is handed to laz-perf — so a
+          // header claiming 5,000,000 points against a hierarchy of 100 never
+          // reaches the decoder or reserves its allocation. A disagreement is the
+          // dataset contradicting itself, not a transport fault a re-fetch could
+          // heal, so fail closed (permanent). The post-decode reconciliation
+          // below stays as defense-in-depth for the pointCount the decoder
+          // actually produced.
+          const headerPointCount = parseLasHeader(chunk).pointCount;
+          if (headerPointCount !== meta.pointCount) {
+            throw new LoadError(
+              'malformed-file',
+              `malformed EPT dataset: laszip tile header declares ` +
+                `${headerPointCount} points but its hierarchy entry declares ` +
+                `${meta.pointCount}. The hierarchy count governs memory ` +
+                `admission; refusing the tile before decompression.`,
+            );
+          }
           const decoded = await (this._laszipWorker
             ? this._laszipWorker.decodeTile(
                 chunk, this._cloud.renderOrigin, signal, meta.rgbEightBit)

--- a/src/io/ept/eptHierarchy.ts
+++ b/src/io/ept/eptHierarchy.ts
@@ -47,20 +47,53 @@ export interface ParsedHierarchyFile {
 }
 
 /**
+ * Maximum number of entries one hierarchy page may declare.
+ *
+ * The transport already caps a page by bytes, but a densely packed page (short
+ * keys, small counts) reaches a high entry count well below that byte ceiling,
+ * and each entry becomes a parsed object key plus an {@link EptHierarchyEntry}
+ * in up to three arrays. Bound the count directly so the parse heap stays
+ * predictable regardless of how tightly the JSON packs. A real Entwine page
+ * splits at a hierarchy step and holds far fewer than this; the committed
+ * reference fixture holds one. This is a defense-in-depth ceiling, not a tight
+ * fit.
+ */
+export const MAX_HIERARCHY_ENTRIES = 2_000_000;
+
+/**
  * Parse the body of one EPT hierarchy JSON file. Returns the entries
  * partitioned into `nodes` (point counts) and `links` (subtree pointers).
  *
+ * `maxEntries` bounds how many entries one page may declare, defaulting to
+ * {@link MAX_HIERARCHY_ENTRIES}; a page over it is refused before the
+ * partitioned arrays are built. Exposed as a parameter so the bound is testable
+ * without materialising millions of entries.
+ *
  * Throws on malformed input (non-object root, non-numeric values, bad
- * address strings). Throwing here is fine because the streaming-source
- * class wraps the call in its retry/error-typing layer; the caller never
- * sees the raw throw.
+ * address strings) and on a page over the entry ceiling. Throwing here is fine
+ * because the streaming-source class wraps the call in its retry/error-typing
+ * layer; the caller never sees the raw throw.
  */
-export function parseHierarchyFile(text: string): ParsedHierarchyFile {
+export function parseHierarchyFile(
+  text: string,
+  maxEntries: number = MAX_HIERARCHY_ENTRIES,
+): ParsedHierarchyFile {
   const raw = JSON.parse(text) as unknown;
   if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
     throw new Error('EPT hierarchy file root must be a JSON object.');
   }
   const obj = raw as Record<string, unknown>;
+  // Bound the entry count BEFORE building the partitioned arrays. A page above
+  // the ceiling is refused rather than expanded into three parallel arrays of
+  // entry objects — the byte cap in the transport is the outer guard, this is
+  // the inner one for a densely packed page that stays under it.
+  const declaredEntries = Object.keys(obj).length;
+  if (declaredEntries > maxEntries) {
+    throw new Error(
+      `EPT hierarchy page declares ${declaredEntries} entries, over the ` +
+        `${maxEntries} maximum; refusing to parse it.`,
+    );
+  }
   const entries: EptHierarchyEntry[] = [];
   const links: EptHierarchyEntry[] = [];
   const nodes: EptHierarchyEntry[] = [];

--- a/src/io/ept/eptTransport.ts
+++ b/src/io/ept/eptTransport.ts
@@ -58,8 +58,18 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
  * The `boundedRead` helper refuses a `Content-Length` above the cap before
  * reading a byte, then streams with a running counter that cancels the body on
  * the chunk that would cross it — so a lying or absent length can't slip past.
+ *
+ * The hierarchy cap is 16 MiB, not the tile cap. A hierarchy page is a JSON
+ * document that `JSON.parse` inflates well past its byte size (the source
+ * string, the parsed object, and the partitioned entry arrays all coexist), so
+ * a 64 MiB page could stage several hundred MB of heap before the entry-count
+ * bound in `parseHierarchyFile` even sees it. A real Entwine page splits at a
+ * hierarchy step and runs KBs to low single-digit MBs; 16 MiB is far above any
+ * legitimate page (the committed reference fixture is 21 bytes) while cutting
+ * the worst-case parse heap roughly fourfold. The parser applies a matching
+ * entry-count ceiling so a densely packed page can't reach the byte cap first.
  */
-const HIERARCHY_MAX_BYTES = 64 * 1024 * 1024;
+const HIERARCHY_MAX_BYTES = 16 * 1024 * 1024;
 const TILE_MAX_BYTES = 256 * 1024 * 1024;
 /** Maximum retries beyond the initial attempt (so up to 4 total). */
 const DEFAULT_MAX_RETRIES = 3;

--- a/src/render/streaming/StreamingNodeStore.ts
+++ b/src/render/streaming/StreamingNodeStore.ts
@@ -11,6 +11,35 @@
 import type { StreamingNodeRecord } from '../../io/copc/copcTypes';
 import type { StreamingNode, NodeState } from './StreamingNode';
 import { createStreamingNode } from './StreamingNode';
+import { LoadError } from '../../io/loadErrors';
+
+/**
+ * Whether two records sharing an id disagree on a load-bearing immutable field.
+ *
+ * The store keys nodes by id and used to keep whichever record arrived first,
+ * so a malformed hierarchy that declared the same id twice with a different
+ * point count, tile location, or bounds was silently accepted — the scheduler
+ * then admitted memory against one figure and decoded against another. The
+ * fields compared here are exactly the ones that drive memory admission and the
+ * node's spatial identity: point count, the tile's byte offset / size, the node
+ * depth, and the six bounds components. A re-add with every one of these equal
+ * is a genuine idempotent repeat (the same node reached through two hierarchy
+ * pages) and stays a no-op; any disagreement is refused.
+ */
+function recordsConflict(a: StreamingNodeRecord, b: StreamingNodeRecord): boolean {
+  if (
+    a.pointCount !== b.pointCount ||
+    a.byteOffset !== b.byteOffset ||
+    a.byteSize !== b.byteSize ||
+    a.depth !== b.depth
+  ) {
+    return true;
+  }
+  for (let i = 0; i < 6; i++) {
+    if (a.bounds[i] !== b.bounds[i]) return true;
+  }
+  return false;
+}
 
 /** Live node counts by lifecycle state. */
 export interface NodeCounts {
@@ -73,12 +102,30 @@ export class StreamingNodeStore {
   private readonly _queued = new Set<StreamingNode>();
 
   /**
-   * Register a node record discovered in the hierarchy. Idempotent — a record
-   * already present (by id) returns the existing runtime node unchanged.
+   * Register a node record discovered in the hierarchy.
+   *
+   * Idempotent for a genuine repeat: an id already present whose record agrees
+   * on every load-bearing immutable field returns the existing runtime node
+   * unchanged. But an id present with a CONFLICTING record — a different point
+   * count, tile location, or bounds — is a self-contradicting hierarchy, not a
+   * repeat. Keeping the first-seen record silently (the old behaviour) let the
+   * scheduler admit memory against one figure while a later page declared
+   * another; refuse it with a typed error instead.
    */
   add(record: StreamingNodeRecord): StreamingNode {
     const existing = this._nodes.get(record.id);
-    if (existing) return existing;
+    if (existing) {
+      if (recordsConflict(existing.record, record)) {
+        throw new LoadError(
+          'malformed-file',
+          `HIERARCHY_CONFLICT: node "${record.id}" is declared twice with ` +
+            `conflicting records (pointCount ${existing.record.pointCount} vs ` +
+            `${record.pointCount}). The hierarchy contradicts itself; refusing ` +
+            `the malformed node.`,
+        );
+      }
+      return existing;
+    }
     const node = createStreamingNode(record);
     this._nodes.set(record.id, node);
     return node;

--- a/tests/eptChunkDecoder.test.ts
+++ b/tests/eptChunkDecoder.test.ts
@@ -21,8 +21,17 @@ import { EptChunkDecoder } from '../src/io/ept/EptChunkDecoder';
 import type { EptStreamingPointCloud } from '../src/render/streaming/EptStreamingPointCloud';
 import type { EptLaszipWorkerClient } from '../src/io/ept/worker/eptLaszipWorkerClient';
 import type { ChunkDecodeMetadata, DecodedChunk } from '../src/io/copc/copcChunkDecode';
+import { lasHeaderBuffer } from './helpers/lasHeaderBytes';
 
 const RENDER_ORIGIN: [number, number, number] = [100, 200, 300];
+
+// The laszip path parses the tile's own LAS public header BEFORE decompression
+// and refuses when its point count disagrees with the hierarchy count. A
+// routing test therefore has to hand it a real header whose count matches
+// META.pointCount (5); a 16-byte stand-in would trip the pre-decode gate before
+// the routing assertion runs. The binary / zstandard / abort cases never reach
+// the header parse, so they keep their tiny buffers.
+const LAS_TILE_5 = lasHeaderBuffer(5);
 
 // pointCount matches META.pointCount below: EptChunkDecoder now reconciles the
 // decoded laszip tile's count against the hierarchy count and refuses a
@@ -87,7 +96,7 @@ describe('EptChunkDecoder dispatch', () => {
   test('laszip + worker routes to the worker, off the main thread', async () => {
     const { client, decodeTile } = fakeWorker();
     const decoder = new EptChunkDecoder(fakeCloud('laszip'), client);
-    const chunk = new ArrayBuffer(16);
+    const chunk = LAS_TILE_5;
     const signal = new AbortController().signal;
 
     await decoder.decode(chunk, META, signal);
@@ -99,7 +108,7 @@ describe('EptChunkDecoder dispatch', () => {
   test('laszip + worker forwards the pinned dataset RGB bit-depth', async () => {
     const { client, decodeTile } = fakeWorker();
     const decoder = new EptChunkDecoder(fakeCloud('laszip'), client);
-    const chunk = new ArrayBuffer(16);
+    const chunk = LAS_TILE_5;
 
     await decoder.decode(chunk, META_RGB);
 
@@ -108,7 +117,7 @@ describe('EptChunkDecoder dispatch', () => {
 
   test('laszip with no worker falls back to in-process decode', async () => {
     const decoder = new EptChunkDecoder(fakeCloud('laszip'), null);
-    const chunk = new ArrayBuffer(16);
+    const chunk = LAS_TILE_5;
 
     await decoder.decode(chunk, META);
 
@@ -117,7 +126,7 @@ describe('EptChunkDecoder dispatch', () => {
 
   test('laszip in-process fallback forwards the pinned dataset RGB bit-depth', async () => {
     const decoder = new EptChunkDecoder(fakeCloud('laszip'), null);
-    const chunk = new ArrayBuffer(16);
+    const chunk = LAS_TILE_5;
 
     await decoder.decode(chunk, META_RGB);
 
@@ -142,5 +151,49 @@ describe('EptChunkDecoder dispatch', () => {
     await expect(decoder.decode(new ArrayBuffer(8), META)).rejects.toThrow(
       /zstandard.*not supported/i,
     );
+  });
+});
+
+describe('EptChunkDecoder pre-decode admission (Finding 5)', () => {
+  // hierarchy count 100, header count 5,000,000: laz-perf must NEVER be invoked.
+  const HIERARCHY_100: ChunkDecodeMetadata = {
+    pointCount: 100,
+  } as unknown as ChunkDecodeMetadata;
+  const HEADER_5M = lasHeaderBuffer(5_000_000);
+
+  test('worker path: a header count over the hierarchy count is refused before decode', async () => {
+    const { client, decodeTile } = fakeWorker();
+    const decoder = new EptChunkDecoder(fakeCloud('laszip'), client);
+
+    await expect(decoder.decode(HEADER_5M, HIERARCHY_100)).rejects.toThrow(
+      /malformed EPT dataset.*5000000.*100/s,
+    );
+    // The decode entry point is never reached — memory is not admitted.
+    expect(decodeTile).not.toHaveBeenCalled();
+    expect(decodeEptLaszipTile).not.toHaveBeenCalled();
+  });
+
+  test('in-process path: a header count over the hierarchy count is refused before decode', async () => {
+    const decoder = new EptChunkDecoder(fakeCloud('laszip'), null);
+
+    await expect(decoder.decode(HEADER_5M, HIERARCHY_100)).rejects.toThrow(
+      /before decompression/,
+    );
+    expect(decodeEptLaszipTile).not.toHaveBeenCalled();
+  });
+
+  test('a header count that matches the hierarchy count passes the gate', async () => {
+    // The decoded count must also agree so the post-decode reconciliation is
+    // satisfied; this test isolates the pre-decode gate letting a valid tile
+    // through to the decoder.
+    const { client, decodeTile } = fakeWorker(
+      vi.fn(async () => ({ pointCount: 100 }) as unknown as DecodedChunk),
+    );
+    const decoder = new EptChunkDecoder(fakeCloud('laszip'), client);
+    const tile = lasHeaderBuffer(100);
+
+    await decoder.decode(tile, HIERARCHY_100);
+
+    expect(decodeTile).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/eptHardeningWave.test.ts
+++ b/tests/eptHardeningWave.test.ts
@@ -23,6 +23,7 @@ import { EptStreamingPointCloud } from '../src/render/streaming/EptStreamingPoin
 import type { EptTransport } from '../src/render/streaming/EptStreamingPointCloud';
 import { parseEptMetadata } from '../src/io/ept/eptDetect';
 import { LoadError } from '../src/io/loadErrors';
+import { lasHeaderBuffer } from './helpers/lasHeaderBytes';
 import type {
   ChunkDecodeMetadata,
   DecodedChunk,
@@ -296,24 +297,31 @@ function chunkWith(pointCount: number): DecodedChunk {
   } as DecodedChunk;
 }
 
-test('#2 a laszip tile whose header count disagrees with the hierarchy count is refused', async () => {
+// The tile carries a valid LAS header whose count MATCHES the hierarchy (100),
+// so the pre-decode admission gate passes and these tests exercise the
+// POST-decode reconciliation against the count the worker actually returns.
+const TILE_HEADER_100 = lasHeaderBuffer(100);
+
+test('#2 a laszip tile whose decoded count disagrees with the hierarchy count is refused', async () => {
   // The injected worker returns a chunk claiming 10M points against a hierarchy
-  // entry of 100 — the memory-admission bypass the audit flagged.
+  // entry of 100 — the memory-admission bypass the audit flagged. The header
+  // itself declares 100, so this trips the post-decode reconciliation, not the
+  // pre-decode header gate.
   const worker = {
     decodeTile: async (): Promise<DecodedChunk> => chunkWith(10_000_000),
   };
   const decoder = new EptChunkDecoder(laszipCloudStub(), worker as never);
-  await expect(decoder.decode(new ArrayBuffer(0), META_100)).rejects.toThrow(LoadError);
-  await expect(decoder.decode(new ArrayBuffer(0), META_100)).rejects.toThrow(
+  await expect(decoder.decode(TILE_HEADER_100.slice(0), META_100)).rejects.toThrow(LoadError);
+  await expect(decoder.decode(TILE_HEADER_100.slice(0), META_100)).rejects.toThrow(
     /hierarchy entry declares 100/,
   );
 });
 
-test('#2 a laszip tile whose header count matches the hierarchy count passes', async () => {
+test('#2 a laszip tile whose decoded count matches the hierarchy count passes', async () => {
   const worker = {
     decodeTile: async (): Promise<DecodedChunk> => chunkWith(100),
   };
   const decoder = new EptChunkDecoder(laszipCloudStub(), worker as never);
-  const decoded = await decoder.decode(new ArrayBuffer(0), META_100);
+  const decoded = await decoder.decode(TILE_HEADER_100.slice(0), META_100);
   expect(decoded.pointCount).toBe(100);
 });

--- a/tests/eptPredecodeAdmission.test.ts
+++ b/tests/eptPredecodeAdmission.test.ts
@@ -1,0 +1,96 @@
+/**
+ * eptPredecodeAdmission.test.ts
+ *
+ * Covers two EPT hardening findings landed alongside the pre-decode header gate:
+ *
+ *   • Finding 8 — the EPT hierarchy JSON cap. A page over the entry-count
+ *     ceiling is refused by `parseHierarchyFile` before the partitioned arrays
+ *     are built. The byte ceiling itself lives in `eptTransport` and is exported
+ *     for verification through the bounded-read path in its own suite; here we
+ *     lock the parser's entry-count bound.
+ *   • Finding 9 — `StreamingNodeStore.add()`. A repeated id with an identical
+ *     record is idempotent; a repeated id with a conflicting record throws
+ *     HIERARCHY_CONFLICT instead of silently keeping the first-seen figure.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseHierarchyFile, MAX_HIERARCHY_ENTRIES } from '../src/io/ept/eptHierarchy';
+import { StreamingNodeStore } from '../src/render/streaming/StreamingNodeStore';
+import type { StreamingNodeRecord } from '../src/io/copc/copcTypes';
+
+function rec(overrides: Partial<StreamingNodeRecord> = {}): StreamingNodeRecord {
+  return {
+    id: '1-0-0-0',
+    key: { depth: 1, x: 0, y: 0, z: 0 },
+    depth: 1,
+    bounds: [0, 0, 0, 1, 1, 1],
+    pointCount: 100,
+    byteOffset: 0,
+    byteSize: 0,
+    spacing: 1,
+    ...overrides,
+  };
+}
+
+describe('Finding 8 — EPT hierarchy entry-count ceiling', () => {
+  it('accepts a normal single-node hierarchy page', () => {
+    const parsed = parseHierarchyFile(JSON.stringify({ '0-0-0-0': 256 }));
+    expect(parsed.nodes).toHaveLength(1);
+    expect(parsed.totalPoints).toBe(256);
+  });
+
+  it('exposes a finite production entry ceiling', () => {
+    expect(MAX_HIERARCHY_ENTRIES).toBe(2_000_000);
+  });
+
+  it('refuses a page declaring more entries than the ceiling', () => {
+    // A page of 4 valid leaf entries, refused against an injected ceiling of 3.
+    // The bound is the production ceiling by default; passing a small one here
+    // exercises the exact refusal path without materialising millions of keys.
+    const page = JSON.stringify({
+      '1-0-0-0': 10,
+      '1-1-0-0': 20,
+      '1-0-1-0': 30,
+      '1-1-1-0': 40,
+    });
+    expect(() => parseHierarchyFile(page, 3)).toThrow(
+      /declares 4 entries, over the 3 maximum/,
+    );
+    // The same page is accepted under the production ceiling.
+    expect(parseHierarchyFile(page).nodes).toHaveLength(4);
+  });
+});
+
+describe('Finding 9 — StreamingNodeStore.add() conflict detection', () => {
+  it('is idempotent for a repeated id with an identical record', () => {
+    const store = new StreamingNodeStore();
+    const first = store.add(rec());
+    const second = store.add(rec());
+    expect(second).toBe(first);
+    expect(store.size).toBe(1);
+  });
+
+  it('throws HIERARCHY_CONFLICT for a repeated id with a different pointCount', () => {
+    const store = new StreamingNodeStore();
+    store.add(rec({ pointCount: 100 }));
+    expect(() => store.add(rec({ pointCount: 5_000_000 }))).toThrow(
+      /HIERARCHY_CONFLICT/,
+    );
+  });
+
+  it('throws for a repeated id with different bounds', () => {
+    const store = new StreamingNodeStore();
+    store.add(rec());
+    expect(() => store.add(rec({ bounds: [0, 0, 0, 2, 2, 2] }))).toThrow(
+      /HIERARCHY_CONFLICT/,
+    );
+  });
+
+  it('throws for a repeated id with a different tile byte location', () => {
+    const store = new StreamingNodeStore();
+    store.add(rec({ byteOffset: 0, byteSize: 10 }));
+    expect(() => store.add(rec({ byteOffset: 999, byteSize: 10 }))).toThrow(
+      /HIERARCHY_CONFLICT/,
+    );
+  });
+});

--- a/tests/eptTransport.test.ts
+++ b/tests/eptTransport.test.ts
@@ -259,9 +259,12 @@ describe('createEptTransport — internal timeout is a distinct outcome from a u
 });
 
 describe('createEptTransport — bounded bodies (OOM defense)', () => {
-  test('fetchText refuses a hierarchy whose Content-Length exceeds the 64 MiB cap', async () => {
+  test('fetchText refuses a hierarchy whose Content-Length exceeds the 16 MiB cap', async () => {
+    // 17 MiB: under the old 64 MiB hierarchy cap this passed; the lowered cap
+    // refuses it. A 64 MiB JSON page inflates to hundreds of MB of parse heap,
+    // so the ceiling is 16 MiB — far above any legitimate Entwine page.
     const handle = scriptedFetch([
-      { status: 200, body: '{}', headers: { 'content-length': String(65 * 1024 * 1024) } },
+      { status: 200, body: '{}', headers: { 'content-length': String(17 * 1024 * 1024) } },
     ]);
     const t = createEptTransport({ fetchImpl: handle.fn, sleep: () => Promise.resolve() });
     const err = await t

--- a/tests/helpers/lasHeaderBytes.ts
+++ b/tests/helpers/lasHeaderBytes.ts
@@ -1,0 +1,31 @@
+/**
+ * lasHeaderBytes.ts — minimal valid LAS public-header buffer for tests.
+ *
+ * `parseLasHeader` reads a fixed set of public-header fields and rejects a
+ * buffer that is too short, unsigned, or carries a non-finite scale/offset/
+ * bounds. Tests that exercise the EPT pre-decode admission gate need a buffer
+ * that parses cleanly and reports a chosen point count, without pulling in a
+ * real LAZ fixture. This builds exactly that: a legacy (LAS 1.2) public header
+ * with a uint32 point count, positive scale, zero offset/bounds, no VLRs.
+ */
+
+/** Build a minimal, valid LAS 1.2 public header reporting `pointCount`. */
+export function lasHeaderBuffer(pointCount: number): ArrayBuffer {
+  const buffer = new ArrayBuffer(227);
+  const view = new DataView(buffer);
+  // Signature 'LASF'.
+  for (let i = 0; i < 4; i++) view.setUint8(i, 'LASF'.charCodeAt(i));
+  view.setUint8(25, 2); // version minor 2 → legacy uint32 point count
+  view.setUint32(96, 227, true); // offset to point data
+  view.setUint8(104, 0); // point data record format 0
+  view.setUint16(105, 20, true); // point record length
+  view.setUint32(107, pointCount >>> 0, true); // legacy point count
+  // Scale X/Y/Z (must be finite and > 0).
+  view.setFloat64(131, 0.001, true);
+  view.setFloat64(139, 0.001, true);
+  view.setFloat64(147, 0.001, true);
+  // Offset + bounds default to the zeroed buffer (all finite).
+  view.setUint16(94, 227, true); // header size
+  view.setUint32(100, 0, true); // number of VLRs → crs parse skipped
+  return buffer;
+}

--- a/tests/streamingOctree.test.ts
+++ b/tests/streamingOctree.test.ts
@@ -22,11 +22,22 @@ function record(id: string, pointCount: number): StreamingNodeRecord {
 
 // --- StreamingNodeStore ------------------------------------------------------
 
-test('StreamingNodeStore.add is idempotent by id', () => {
+test('StreamingNodeStore.add is idempotent for an identical repeated record', () => {
   const store = new StreamingNodeStore();
   const a = store.add(record('n1', 100));
-  const b = store.add(record('n1', 999));
+  const b = store.add(record('n1', 100));
   expect(a).toBe(b);
+  expect(store.size).toBe(1);
+});
+
+test('StreamingNodeStore.add refuses a conflicting record for the same id', () => {
+  // A malformed hierarchy declaring the same id twice with a different point
+  // count is a self-contradiction, not a repeat: keeping the first-seen figure
+  // silently let the scheduler admit memory against one count and decode
+  // against another. Refuse it with a typed HIERARCHY_CONFLICT instead.
+  const store = new StreamingNodeStore();
+  store.add(record('n1', 100));
+  expect(() => store.add(record('n1', 999))).toThrow(/HIERARCHY_CONFLICT/);
   expect(store.size).toBe(1);
 });
 
@@ -261,10 +272,13 @@ test('StreamingOctree: hitting the hierarchy-page ceiling loads short → NOT co
   const childPages: number[] = [];
   const pages: SynthPage[] = [{ pageKey: [0, 0, 0, 0], nodes: [], childPages }];
   for (let i = 1; i <= FANOUT; i++) {
-    // Spread children across depth-1 octants deterministically; the exact keys
-    // don't matter, only that there are more PAGES (distinct offsets) than the
-    // ceiling admits.
-    const key: SynthKey = [1, i % 2, (i >> 1) % 2, (i >> 2) % 2];
+    // Spread children across DISTINCT depth-5 cells deterministically; the exact
+    // keys don't matter, only that there are more PAGES (distinct offsets) than
+    // the ceiling admits. Each key is unique (a depth-5 grid holds 32^3 cells,
+    // far above the fan-out) so no two pages declare the same node id — the node
+    // store now refuses a same-id record with a conflicting tile offset, which a
+    // reused key would trip before the page-ceiling assertion.
+    const key: SynthKey = [5, i % 32, (i >> 5) % 32, (i >> 10) % 32];
     pages.push({ pageKey: key, nodes: [{ key, pointCount: 10 }], childPages: [] });
     childPages.push(i);
   }


### PR DESCRIPTION
Three EPT ingest guards for the v0.6.7 release.

The laszip path now parses the tile's LAS public header and compares its
point count to the hierarchy count before laz-perf runs, on both the
worker and the in-process path. A tile whose header claims five million
points against a hierarchy of a hundred is refused before the decoder is
reached. Memory admission is no longer bypassed by the tile's own header.
The post-decode reconciliation stays behind the new gate as defense in
depth.

The hierarchy byte cap drops from 64 MiB to 16 MiB, and parseHierarchyFile
refuses a page over two million entries before building its partitioned
arrays. The committed reference fixture needs one entry and 21 bytes, so
16 MiB sits far above any real Entwine page.

StreamingNodeStore.add throws HIERARCHY_CONFLICT when a repeated node id
carries a record disagreeing on point count, tile location, or bounds.

Red-green tests cover each guard; typecheck and the streaming and EPT
suites pass.
