### PR TITLE
Sync the claim-register E4-count comment to seventeen

### DIFF
--- a/docs/validation/claim-register.yaml
+++ b/docs/validation/claim-register.yaml
@@ -4,7 +4,7 @@
 # identifiers + gate logic.
 #
 # Honesty rules (do not violate when editing):
-#   - currentEvidence must reflect evidence that EXISTS today. Eleven claims
+#   - currentEvidence must reflect evidence that EXISTS today. Seventeen claims
 #     currently reach E4. Five are algorithm cross-implementations against
 #     GDAL 3.13.1 on a frozen analytic fixture: SLOPE-RASTER, ASPECT-RASTER,
 #     HILLSHADE and CONTOURS (0.5 degree for slope and aspect, 1.0 8-bit level
@@ -26,7 +26,15 @@
 #     4.4.1 quantile(type = 7), over 751 stations on two committed point clouds
 #     within a 1e-6 m tolerance registered before the reference existed. The ramp
 #     fixture also carries a closed form, because ten corridor elevations in an
-#     arithmetic progression reduce without a sort. The slope, hillshade and contour tolerances were registered
+#     arithmetic progression reduce without a sort. Six more reach E4 against
+#     independent references: E57-INGEST against PDAL 2.10.2 readers.e57 over
+#     1.79M points; CRS-UTM-PROJECTION against GeographicLib 2.7 and PROJ 9.8.1
+#     across 36 geodetic fixtures; CHANGE-RASTER against GRASS 8.5.0 r.mapcalc
+#     and CHANGE-VOLUME against GRASS 8.5.0 r.univar with a closed-form check,
+#     each over eight synthetic epoch pairs; and HOLDOUT-RMSE and NVA-VVA
+#     against R 4.4.1, cross-implementation-checked but internal holdout
+#     diagnostics rather than independent checkpoint accuracy. The slope,
+#     hillshade and contour tolerances were registered
 #     before the reference was generated: all three were fixed in the harness
 #     commit a78b0f9 on 2026-07-05, weeks ahead of their results. ASPECT-RASTER
 #     was NOT. Its slot, its tolerance, its flat-ground exclusion and its
@@ -41,8 +49,9 @@
 #     validation has been run). Synthetic known-truth fixtures alone remain E3,
 #     not accuracy.
 #   - externalValidationStatus is `pending` wherever external data is required
-#     and unavailable. Eleven independent reference slots are supplied (six GDAL,
-#     three PDAL, one SAGA, one OGR/SpatiaLite plus R); all remaining
+#     and unavailable. Seventeen independent reference slots are supplied (six
+#     GDAL, four PDAL, one SAGA, one OGR/SpatiaLite with R, one GeographicLib
+#     with PROJ, two GRASS, and two against R); all remaining
 #     independent-reference slots are pending. Never infer it from density /
 #     format / metadata.
 #   - prohibitedClaim lists statements the current evidence does NOT support.


### PR DESCRIPTION
The claim-register honesty comment stated eleven claims reach E4 and enumerated eleven, while the machine entries hold seventeen at E4_CROSS_IMPLEMENTATION_VALIDATED, each with a supporting study. Comment-only drift: no entry, evidence level, or gate behaviour changes.

The comment now names the six added claims with their references. E57-INGEST against PDAL 2.10.2 readers.e57, CRS-UTM-PROJECTION against GeographicLib 2.7 and PROJ 9.8.1, CHANGE-RASTER against GRASS 8.5.0 r.mapcalc, CHANGE-VOLUME against GRASS 8.5.0 r.univar with a closed-form check, and HOLDOUT-RMSE and NVA-VVA against R 4.4.1 as internal holdout diagnostics rather than independent checkpoint accuracy. The reference-slot count moves from eleven to seventeen with the matching taxonomy.

lint:claim-register, lint:claim-prose-sync, and lint:release-truth pass.