### PR TITLE
Correct stale MIT license claims to AGPL-3.0-only

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -4,7 +4,7 @@ OpenLiDARViewer is developed and maintained by:
 
 - **A. Urias** — creator and maintainer, Aurtech (aurtech.mx).
 
-Copyright © 2026 Aurtech. Released under the MIT License; see [LICENSE](../LICENSE).
+Copyright © 2026 Aurtech. Released under the GNU Affero General Public License version 3 only (AGPL-3.0-only); see [LICENSE](../LICENSE). Releases through v0.6.6 were under the MIT License.
 
 This file lists the project's own authors. Third-party open-source dependencies
 and their licences are credited in [THIRD_PARTY_NOTICES.md](project/THIRD_PARTY_NOTICES.md)

--- a/docs/developer-manual.md
+++ b/docs/developer-manual.md
@@ -59,7 +59,7 @@ Scan Intelligence report, and export the result.
 | NFR-3 | **Compatibility** — works on modern evergreen browsers; WebGPU where available, WebGL 2 everywhere else. |
 | NFR-4 | **Zero friction** — usable with no install and no file conversion. |
 | NFR-5 | **Quality** — strict TypeScript; the algorithmic core is test-first; CI gates every change. |
-| NFR-6 | **Licensing** — MIT; citable via `CITATION.cff`. |
+| NFR-6 | **Licensing** — AGPL-3.0-only; citable via `CITATION.cff`. |
 | NFR-7 | **Deployability** — builds to static files hostable on any CDN or GitHub Pages. |
 | NFR-8 | **Maintainability** — one responsibility per file; analysis modules never import the renderer. |
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # OpenLiDARViewer
 
-> A browser-native, local-first LiDAR and point-cloud viewer. Open a `.las`, `.laz`, or `.copc.laz` scan (or a remote COPC / Entwine EPT `ept.json` URL) in a browser tab, then inspect, navigate in 3D, colour, measure, analyse terrain, classify, annotate, and export. Everything runs on the user's device. Files stay local, and it needs no account. MIT-licensed and citable (Zenodo DOI).
+> A browser-native, local-first LiDAR and point-cloud viewer. Open a `.las`, `.laz`, or `.copc.laz` scan (or a remote COPC / Entwine EPT `ept.json` URL) in a browser tab, then inspect, navigate in 3D, colour, measure, analyse terrain, classify, annotate, and export. Everything runs on the user's device. Files stay local, and it needs no account. AGPL-3.0-only licensed and citable (Zenodo DOI).
 
 Live app: https://lidar.aurtech.mx/ · Source: https://github.com/Aurtechmx/openlidarviewer · DOI: https://doi.org/10.5281/zenodo.21544619
 
@@ -24,7 +24,7 @@ Live app: https://lidar.aurtech.mx/ · Source: https://github.com/Aurtechmx/open
 
 ## Key facts
 
-- Open-source (MIT) browser-based LiDAR and point-cloud viewer and terrain-analysis tool.
+- Open-source (AGPL-3.0-only) browser-based LiDAR and point-cloud viewer and terrain-analysis tool.
 - Runs entirely client-side. Local files never leave the device.
 - Research-derived, with a published evidence model, claim register, reproducibility record, and a Zenodo archive.
 


### PR DESCRIPTION
Three public files and the developer manual still stated MIT after the v0.6.7 relicense to AGPL-3.0-only, contradicting LICENSE, README, and LICENSING.md.

Fixed: docs/AUTHORS.md, public/llms.txt (the LLM-facing summary, both the intro line and the one-line description), and docs/developer-manual.md now state AGPL-3.0-only and note that releases through v0.6.6 were MIT. Historical release notes (v0.5.x through v0.6.6) and the third-party dependency notices keep their MIT wording, which is correct for those versions and packages. lint:license and lint:release-truth pass.