### PR TITLE
Harden PNTS decode admission and transport body teardown

### DIFF
--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -37,6 +37,7 @@ import { parseTileset } from '../io/tiles3d/tileset';
 import { createTilesetTransport } from '../io/tiles3d/tilesetTransport';
 import { validateRemoteTilesetUrl } from '../io/tiles3d/tilesetUrl';
 import { PntsChunkDecoder } from '../io/tiles3d/pntsDecode';
+import { pntsDeviceDecodeLimits } from '../io/tiles3d/pnts';
 import { TilesetStreamingSource } from '../render/streaming/TilesetStreamingSource';
 import {
   describeCloudFrame,
@@ -214,7 +215,15 @@ export async function openRemoteTileset(
       // grey patch is owed the explanation rather than left to guess at it. It
       // fires at most once per layer, on the first disagreeing tile, which can be
       // long after this function has returned.
-      new PntsChunkDecoder({ onColourNotice: (message) => deps.showToast(message) }),
+      new PntsChunkDecoder({
+        onColourNotice: (message) => deps.showToast(message),
+        // Device-sized decode ceilings from the same phone signal the streaming
+        // budget uses for concurrency. On mobile a single legal-but-large tile
+        // is refused at decode on its true size rather than allocated at the
+        // desktop default, which the scheduler's `ASSUMED_TILE_POINTS` estimate
+        // cannot catch before the body is fetched.
+        decodeLimits: pntsDeviceDecodeLimits(deps.isPhone()),
+      }),
       deps.getStreamingQuality(),
       deps.isPhone(),
       deps.getStreamingBenchmark(),

--- a/src/io/ept/eptTransport.ts
+++ b/src/io/ept/eptTransport.ts
@@ -46,6 +46,21 @@ import type { EptTransport } from '../../render/streaming/EptStreamingPointCloud
 import { sanitizeUrlForDisplay } from '../range/RangeSource';
 import { ownedExactBuffer, readAtMostBounded, readTextAtMost } from '../range/boundedRead';
 
+/**
+ * Best-effort cancel a response body we are about to abandon (a retryable error
+ * response, or a permanent non-success the caller throws on). Cancelling the
+ * stream releases the connection instead of leaving an error page's body to
+ * trickle in the background. Guarded for runtimes / test stand-ins whose
+ * Response carries no streaming body, and for a `cancel()` that itself rejects.
+ * Mirrors `HttpRangeSource.cancelResponseBody`.
+ */
+function cancelResponseBody(response: Response): void {
+  const body = response.body as ReadableStream<Uint8Array> | null | undefined;
+  if (body && typeof body.cancel === 'function') {
+    void body.cancel().catch(() => undefined);
+  }
+}
+
 /** Per-attempt timeout for one HTTP request, in milliseconds. */
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
 /**
@@ -202,6 +217,11 @@ export function createEptTransport(options: EptTransportOptions = {}): EptTransp
       if (response) {
         // 2xx — success.
         if (response.ok) return response;
+        // Non-success: we are abandoning this response, whether to retry or to
+        // throw. Cancel its body first so the connection is released instead of
+        // left to trickle an error page's body in the background. Mirrors
+        // `HttpRangeSource.cancelResponseBody`.
+        cancelResponseBody(response);
         // 4xx (except 408/429) — permanent. Don't retry; throw immediately.
         if (!RETRYABLE_STATUSES.has(response.status)) {
           throw new Error(

--- a/src/io/range/boundedRead.ts
+++ b/src/io/range/boundedRead.ts
@@ -60,6 +60,23 @@ export const DEFAULT_IDLE_TIMEOUT_MS = 20_000;
  */
 export const DEFAULT_TOTAL_TIMEOUT_MS = 300_000;
 
+/**
+ * The largest buffer the known-length fast path will allocate up front, in bytes.
+ *
+ * The declared-length path used to allocate `new Uint8Array(declared)` the
+ * instant a valid `Content-Length` sat at or below the ceiling — so a hostile
+ * server could force an allocation as large as the ceiling (up to 256 MiB for a
+ * tile) with a header alone, before delivering a single meaningful byte. The
+ * eager allocation only pays off when the body actually arrives; a lie earns a
+ * free quarter-gigabyte. This bounds the immediate allocation to a small initial
+ * size and grows toward `declared` in doublings as bytes truly arrive, still
+ * refusing anything past `declared`. An honest small body (declared at or below
+ * this) is still one allocation; a large honest one costs a handful of doublings
+ * against the memory it is actually filling. 16 MiB keeps the common case
+ * single-shot while capping what a header alone can reserve.
+ */
+export const MAX_DECLARED_PREALLOC_BYTES = 16 * 1024 * 1024;
+
 /** Timing and cancellation for one bounded body read. */
 export interface BoundedReadOptions {
   /**
@@ -431,8 +448,24 @@ export async function readAtMostBounded(
   // and `declaredBodyLength` returns null under any non-identity
   // content-encoding, so a compressed length can never drive this branch.
   if (declared !== null) {
-    const out = new Uint8Array(declared);
+    // Allocate only a bounded initial buffer, never the whole declared size up
+    // front: a large `declared` is a claim, not yet bytes. The buffer grows in
+    // doublings toward `declared` as real bytes land, so a server that declares
+    // 256 MiB and then sends a kilobyte reserves a kilobyte's worth, not the
+    // whole claim. `declared` is already known `<= maxBytes`.
+    let out = new Uint8Array(Math.min(declared, MAX_DECLARED_PREALLOC_BYTES));
     let filled = 0;
+    // Grow `out` so it can hold at least `needed` bytes, doubling until it does
+    // and never past `declared` (which is the hard ceiling for this branch).
+    const ensureCapacity = (needed: number): void => {
+      if (needed <= out.length) return;
+      let next = Math.max(out.length, 1);
+      while (next < needed) next *= 2;
+      if (next > declared) next = declared;
+      const bigger = new Uint8Array(next);
+      bigger.set(out.subarray(0, filled));
+      out = bigger;
+    };
     try {
       for (;;) {
         const { done, value } = await readChunkRacing(
@@ -455,6 +488,7 @@ export async function readAtMostBounded(
             `${what} sent more than its declared ${declared} bytes — refusing to read further.`,
           );
         }
+        ensureCapacity(filled + value.byteLength);
         out.set(value, filled);
         filled += value.byteLength;
       }
@@ -470,10 +504,11 @@ export async function readAtMostBounded(
       }
       throw err;
     }
-    // A body shorter than its declared length leaves trailing zeros in `out`.
-    // Trim to what actually arrived so no phantom bytes reach the decoder; the
-    // exact-length common case returns `out` untouched (still one allocation).
-    return filled === declared ? out : out.slice(0, filled);
+    // `out` now spans exactly what arrived when the body matched or grew to its
+    // declared length; a short body leaves it longer than `filled`. Trim so no
+    // trailing zeros reach the decoder. The exact-length common case (declared
+    // at or below the prealloc bound) returns `out` untouched.
+    return filled === out.length ? out : out.slice(0, filled);
   }
   const chunks: Uint8Array[] = [];
   let total = 0;

--- a/src/io/tiles3d/pnts.ts
+++ b/src/io/tiles3d/pnts.ts
@@ -496,11 +496,49 @@ export const MAX_PNTS_TILE_POINTS = 8_000_000;
  */
 export const MAX_PNTS_DECODED_BYTES = 192 * 1024 * 1024;
 
+/**
+ * The mobile decoded-byte ceiling for one PNTS tile.
+ *
+ * {@link MAX_PNTS_DECODED_BYTES} is the desktop budget. On a phone the same
+ * 192 MiB is a single tile the device has no headroom for: the concurrency cap
+ * stops two concurrent decodes but does not make ONE legal tile safe, and the
+ * scheduler admits a node on `ASSUMED_TILE_POINTS` (500k) long before the real
+ * `POINTS_LENGTH` is known, so an 8M-point tile sails through admission and is
+ * only sized here, at decode. A far lower mobile ceiling refuses that tile on
+ * its true decoded size instead of allocating it. 96 MiB is half the desktop
+ * budget and above a positions-only 8M-point tile's 91.5 MiB, so an ordinary
+ * large tile still opens while a colour/normal-heavy one is refused.
+ */
+export const MAX_PNTS_DECODED_BYTES_MOBILE = 96 * 1024 * 1024;
+
 /** Decoded bytes each channel costs one point, matching what the decoders below allocate. */
 const POSITION_DECODED_BYTES = 12;
 const COLOR_DECODED_BYTES = 3;
 const NORMAL_DECODED_BYTES = 12;
 const BATCH_ID_DECODED_BYTES = 4;
+
+/**
+ * The point and decoded-byte ceilings one PNTS tile is allowed on this device.
+ *
+ * The byte ceiling is the operative memory bound (a channel-heavy tile costs far
+ * more than a positions-only one at the same count); the point ceiling is
+ * derived from it so the two never disagree — floor(ceiling / cheapest per-point
+ * cost), clamped to the desktop count ceiling so mobile never admits a larger
+ * count than desktop. Threaded from the same phone signal the streaming budget
+ * uses for concurrency, so mobile decodes are gated by a mobile-sized ceiling
+ * rather than the desktop default. Pure.
+ */
+export function pntsDeviceDecodeLimits(isMobile: boolean): {
+  maxPoints: number;
+  maxDecodedBytes: number;
+} {
+  const maxDecodedBytes = isMobile ? MAX_PNTS_DECODED_BYTES_MOBILE : MAX_PNTS_DECODED_BYTES;
+  const maxPoints = Math.min(
+    MAX_PNTS_TILE_POINTS,
+    Math.floor(maxDecodedBytes / POSITION_DECODED_BYTES),
+  );
+  return { maxPoints, maxDecodedBytes };
+}
 
 /**
  * Independent size ceilings on the tile's three variable-length metadata

--- a/src/io/tiles3d/pntsDecode.ts
+++ b/src/io/tiles3d/pntsDecode.ts
@@ -281,6 +281,16 @@ export interface PntsChunkDecoderOptions {
    * says why a Normal chip is missing or a patch is drawn flat.
    */
   readonly onNormalsNotice?: (message: string) => void;
+  /**
+   * The point / decoded-byte ceilings one tile may reach on this device, from
+   * {@link pntsDeviceDecodeLimits}. Omitted, the decoder uses the desktop
+   * defaults `parsePnts` already applies. Passing the mobile limits is what
+   * makes a single legal-but-large tile refused at decode on a phone rather than
+   * allocated: the scheduler admits a node on `ASSUMED_TILE_POINTS` before the
+   * real size is known, so this is the first place the true `POINTS_LENGTH` is
+   * measured against a device-sized bound.
+   */
+  readonly decodeLimits?: { readonly maxPoints: number; readonly maxDecodedBytes: number };
 }
 
 /**
@@ -296,6 +306,9 @@ export interface PntsChunkDecoderOptions {
 export class PntsChunkDecoder implements ChunkDecoder {
   private readonly _onColourNotice: ((message: string) => void) | undefined;
   private readonly _onNormalsNotice: ((message: string) => void) | undefined;
+  private readonly _decodeLimits:
+    | { readonly maxPoints: number; readonly maxDecodedBytes: number }
+    | undefined;
   private _colour: TilesetColourConsensus = NO_TILE_DECODED;
   private _normals: TilesetNormalsConsensus = NO_TILE_DECODED_NORMALS;
   private _noticed = false;
@@ -304,6 +317,7 @@ export class PntsChunkDecoder implements ChunkDecoder {
   constructor(options: PntsChunkDecoderOptions = {}) {
     this._onColourNotice = options.onColourNotice;
     this._onNormalsNotice = options.onNormalsNotice;
+    this._decodeLimits = options.decodeLimits;
   }
 
   /** The layer's colour meaning as the tiles decoded so far have settled it. */
@@ -334,7 +348,19 @@ export class PntsChunkDecoder implements ChunkDecoder {
     // asks the parser not to copy the batch-table binary or materialise
     // BATCH_ID. That halves nothing here but spares a copy of the whole
     // batch-table binary section per tile on the path that never reads it.
-    const tile = parsePnts(chunk, { keepBatchMetadata: false });
+    const tile = parsePnts(chunk, {
+      keepBatchMetadata: false,
+      // Device-sized ceilings when the shell supplied them: on mobile a single
+      // legal-but-large tile is refused here on its true decoded size, before
+      // the first position array is allocated, rather than admitted at the
+      // desktop default. Omitted, `parsePnts` keeps its desktop defaults.
+      ...(this._decodeLimits
+        ? {
+            maxPoints: this._decodeLimits.maxPoints,
+            maxDecodedBytes: this._decodeLimits.maxDecodedBytes,
+          }
+        : {}),
+    });
     const n = tile.pointsLength;
     const [ox, oy, oz] = meta.renderOrigin;
     const rtc = tile.rtcCenter ?? [0, 0, 0];

--- a/src/io/tiles3d/tilesetTransport.ts
+++ b/src/io/tiles3d/tilesetTransport.ts
@@ -26,6 +26,21 @@
 import { sanitizeUrlForDisplay } from '../range/RangeSource';
 import { ownedExactBuffer, readAtMostBounded, readTextAtMost } from '../range/boundedRead';
 
+/**
+ * Best-effort cancel a response body we are about to abandon (a retryable error
+ * response, or a permanent non-success the caller throws on). Cancelling the
+ * stream releases the connection instead of leaving an error page's body to
+ * trickle in the background. Guarded for runtimes / test stand-ins whose
+ * Response carries no streaming body, and for a `cancel()` that itself rejects.
+ * Mirrors `HttpRangeSource.cancelResponseBody`.
+ */
+function cancelResponseBody(response: Response): void {
+  const body = response.body as ReadableStream<Uint8Array> | null | undefined;
+  if (body && typeof body.cancel === 'function') {
+    void body.cancel().catch(() => undefined);
+  }
+}
+
 /** Per-attempt timeout for one HTTP request, in milliseconds. */
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
 /**
@@ -205,6 +220,11 @@ export function createTilesetTransport(
       }
       if (response) {
         if (response.ok) return response;
+        // Non-success: this response is being abandoned, to retry or to throw.
+        // Cancel its body first so the connection is released rather than left
+        // to trickle an error page in the background. Mirrors
+        // `HttpRangeSource.cancelResponseBody`.
+        cancelResponseBody(response);
         const message =
           `3D Tiles ${label} fetch failed (${response.status} ${response.statusText}) ` +
           `for ${sanitizeUrlForDisplay(url)}`;

--- a/tests/boundedRead.test.ts
+++ b/tests/boundedRead.test.ts
@@ -16,6 +16,7 @@ import {
   readTextAtMost,
   ownedExactBuffer,
   BoundedReadError,
+  MAX_DECLARED_PREALLOC_BYTES,
 } from '../src/io/range/boundedRead';
 import { RangeReadError } from '../src/io/range/RangeSource';
 
@@ -199,5 +200,52 @@ describe('readTextAtMost', () => {
     const payload = new TextEncoder().encode('{"ept":"json"}');
     const out = await readTextAtMost(streamingResponse([payload]), 1000, 'EPT manifest');
     expect(out).toBe('{"ept":"json"}');
+  });
+});
+
+describe('readAtMostBounded — declared length does not eagerly allocate', () => {
+  it('a large Content-Length with few bytes delivered never allocates the full declared size', async () => {
+    // Declared 200 MiB (under the 256 MiB ceiling) but only 30 bytes arrive: the
+    // pre-fix path did `new Uint8Array(declared)` on the header alone. The
+    // bounded-growth path must never allocate past the small prealloc bound when
+    // the promised bytes never come.
+    const declared = 200 * 1024 * 1024;
+    const cap = 256 * 1024 * 1024;
+    const Real = globalThis.Uint8Array;
+    let overPrealloc = 0;
+    class U8 extends Real {
+      constructor(...args: unknown[]) {
+        if (typeof args[0] === 'number' && args[0] > MAX_DECLARED_PREALLOC_BYTES) {
+          overPrealloc++;
+        }
+        // @ts-expect-error forward whatever the reader passed
+        super(...args);
+      }
+    }
+    (globalThis as { Uint8Array: unknown }).Uint8Array = U8;
+    try {
+      const resp = streamingResponse([bytes(30)], { 'content-length': String(declared) });
+      const out = await readAtMostBounded(resp, cap, 'EPT tile');
+      expect(out.byteLength).toBe(30);
+    } finally {
+      (globalThis as { Uint8Array: unknown }).Uint8Array = Real;
+    }
+    // Nothing larger than the bounded initial prealloc was ever constructed,
+    // even though the header promised 200 MiB.
+    expect(overPrealloc).toBe(0);
+  });
+
+  it('an honest large body still delivers every byte via bounded growth', async () => {
+    // 40 MiB actually delivered in chunks, declared honestly: the growth path
+    // must reach the full size and return all of it.
+    const size = 40 * 1024 * 1024;
+    const chunk = 8 * 1024 * 1024;
+    const parts: Uint8Array[] = [];
+    for (let at = 0; at < size; at += chunk) parts.push(bytes(Math.min(chunk, size - at), 7));
+    const resp = streamingResponse(parts, { 'content-length': String(size) });
+    const out = await readAtMostBounded(resp, 256 * 1024 * 1024, 'EPT tile');
+    expect(out.byteLength).toBe(size);
+    expect(out[0]).toBe(7);
+    expect(out[size - 1]).toBe(7);
   });
 });

--- a/tests/eptTransport.test.ts
+++ b/tests/eptTransport.test.ts
@@ -293,3 +293,54 @@ describe('createEptTransport — bounded bodies (OOM defense)', () => {
     expect(new TextDecoder().decode(new Uint8Array(buf))).toBe('AAAA');
   });
 });
+
+/**
+ * A fetch whose non-success responses expose a body with a spied `cancel()`,
+ * so a test can prove the transport tears the abandoned body down before it
+ * retries or throws. A success step returns a real Response the bounded read
+ * can consume.
+ */
+function bodyCancelFetch(
+  steps: Array<{ status: number; body?: string }>,
+): { fn: typeof fetch; cancels: number } {
+  let i = 0;
+  const handle = { cancels: 0, fn: undefined as unknown as typeof fetch };
+  handle.fn = (async (_input: RequestInfo | URL): Promise<Response> => {
+    const step = steps[Math.min(i++, steps.length - 1)]!;
+    if (step.status >= 200 && step.status < 300) {
+      return new Response(step.body ?? 'ok', { status: 200, statusText: 'OK' });
+    }
+    const body = {
+      cancel: (): Promise<void> => {
+        handle.cancels++;
+        return Promise.resolve();
+      },
+    } as unknown as ReadableStream<Uint8Array>;
+    return {
+      ok: false,
+      status: step.status,
+      statusText: 'Err',
+      body,
+      headers: new Headers(),
+    } as unknown as Response;
+  }) as typeof fetch;
+  return handle;
+}
+
+describe('createEptTransport — abandoned response bodies are cancelled', () => {
+  test('cancels a retryable 503 body before the retry proceeds', async () => {
+    const h = bodyCancelFetch([{ status: 503 }, { status: 200, body: 'ok' }]);
+    const t = createEptTransport({ fetchImpl: h.fn, sleep: () => Promise.resolve() });
+    await expect(t.fetchText('https://example.com/ept.json')).resolves.toBe('ok');
+    expect(h.cancels).toBe(1);
+  });
+
+  test('cancels a permanent 404 body before it throws', async () => {
+    const h = bodyCancelFetch([{ status: 404 }]);
+    const t = createEptTransport({ fetchImpl: h.fn, sleep: () => Promise.resolve() });
+    await expect(
+      t.fetchBytes('https://example.com/ept-data/0-0-0-0.bin'),
+    ).rejects.toThrow(/404/);
+    expect(h.cancels).toBe(1);
+  });
+});

--- a/tests/eptTransport.test.ts
+++ b/tests/eptTransport.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, expect, test } from 'vitest';
+import { bodyCancelFetch } from './helpers/bodyCancelFetch';
 import { createEptTransport, EptTimeoutError } from '../src/io/ept/eptTransport';
 
 /**
@@ -294,38 +295,6 @@ describe('createEptTransport — bounded bodies (OOM defense)', () => {
   });
 });
 
-/**
- * A fetch whose non-success responses expose a body with a spied `cancel()`,
- * so a test can prove the transport tears the abandoned body down before it
- * retries or throws. A success step returns a real Response the bounded read
- * can consume.
- */
-function bodyCancelFetch(
-  steps: Array<{ status: number; body?: string }>,
-): { fn: typeof fetch; cancels: number } {
-  let i = 0;
-  const handle = { cancels: 0, fn: undefined as unknown as typeof fetch };
-  handle.fn = (async (_input: RequestInfo | URL): Promise<Response> => {
-    const step = steps[Math.min(i++, steps.length - 1)]!;
-    if (step.status >= 200 && step.status < 300) {
-      return new Response(step.body ?? 'ok', { status: 200, statusText: 'OK' });
-    }
-    const body = {
-      cancel: (): Promise<void> => {
-        handle.cancels++;
-        return Promise.resolve();
-      },
-    } as unknown as ReadableStream<Uint8Array>;
-    return {
-      ok: false,
-      status: step.status,
-      statusText: 'Err',
-      body,
-      headers: new Headers(),
-    } as unknown as Response;
-  }) as typeof fetch;
-  return handle;
-}
 
 describe('createEptTransport — abandoned response bodies are cancelled', () => {
   test('cancels a retryable 503 body before the retry proceeds', async () => {

--- a/tests/helpers/bodyCancelFetch.ts
+++ b/tests/helpers/bodyCancelFetch.ts
@@ -1,0 +1,32 @@
+/**
+ * A fetch whose non-success responses expose a body with a spied `cancel()`,
+ * so a test can prove a transport tears the abandoned body down before it
+ * retries or throws. A success step returns a real Response the bounded read
+ * can consume. Shared by the EPT and 3D Tiles transport suites.
+ */
+export function bodyCancelFetch(
+  steps: Array<{ status: number; body?: string }>,
+): { fn: typeof fetch; cancels: number } {
+  let i = 0;
+  const handle = { cancels: 0, fn: undefined as unknown as typeof fetch };
+  handle.fn = (async (_input: RequestInfo | URL): Promise<Response> => {
+    const step = steps[Math.min(i++, steps.length - 1)]!;
+    if (step.status >= 200 && step.status < 300) {
+      return new Response(step.body ?? 'ok', { status: 200, statusText: 'OK' });
+    }
+    const body = {
+      cancel: (): Promise<void> => {
+        handle.cancels++;
+        return Promise.resolve();
+      },
+    } as unknown as ReadableStream<Uint8Array>;
+    return {
+      ok: false,
+      status: step.status,
+      statusText: 'Err',
+      body,
+      headers: new Headers(),
+    } as unknown as Response;
+  }) as typeof fetch;
+  return handle;
+}

--- a/tests/pntsDecode.test.ts
+++ b/tests/pntsDecode.test.ts
@@ -14,6 +14,7 @@ import {
   PNTS_COLOR_MODES,
   type PntsDecodeMetadata,
 } from '../src/io/tiles3d/pntsDecode';
+import { pntsDeviceDecodeLimits } from '../src/io/tiles3d/pnts';
 
 const PNTS_MAGIC = 0x73746e70;
 
@@ -164,6 +165,65 @@ describe('attributes the format does not carry', () => {
     expect([...(withRgb.rgb ?? [])]).toEqual([10, 20, 30]);
     const without = await new PntsChunkDecoder().decode(makePnts([[0, 0, 0]]), meta());
     expect(without.rgb).toBeUndefined();
+  });
+});
+
+/**
+ * A `.pnts` header declaring `pointsLength` points with position, colour, normal
+ * and batch-id channels, and NO binary section. The decoded-byte ceiling is
+ * checked before any accessor reads the (absent) binary, so a refusal that lands
+ * here landed before the first big array was allocated.
+ */
+function makeDeclaredAllChannels(pointsLength: number): ArrayBuffer {
+  const ft = JSON.stringify({
+    POINTS_LENGTH: pointsLength,
+    POSITION: { byteOffset: 0 },
+    RGBA: { byteOffset: 0 },
+    NORMAL: { byteOffset: 0 },
+    BATCH_ID: { byteOffset: 0 },
+  });
+  let json = ft;
+  while (json.length % 8 !== 0) json += ' ';
+  const jsonBytes = new TextEncoder().encode(json);
+  const total = 28 + jsonBytes.length;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+  view.setUint32(0, PNTS_MAGIC, true);
+  view.setUint32(4, 1, true);
+  view.setUint32(8, total, true);
+  view.setUint32(12, jsonBytes.length, true);
+  view.setUint32(16, 0, true);
+  view.setUint32(20, 0, true);
+  view.setUint32(24, 0, true);
+  new Uint8Array(buf, 28, jsonBytes.length).set(jsonBytes);
+  return buf;
+}
+
+describe('device-aware decode limits', () => {
+  // 5,000,000 points at 31 decoded bytes each is ~147.8 MiB: above the 96 MiB
+  // mobile ceiling and below the 192 MiB desktop ceiling.
+  const MID_POINTS = 5_000_000;
+
+  it('refuses the mid-size tile when constructed with the mobile ceiling', async () => {
+    const mobile = new PntsChunkDecoder({ decodeLimits: pntsDeviceDecodeLimits(true) });
+    await expect(
+      mobile.decode(makeDeclaredAllChannels(MID_POINTS), meta()),
+    ).rejects.toThrow(/decoded byte/i);
+  });
+
+  it('admits it past the byte ceiling on desktop — a later section refusal, not a byte one', async () => {
+    const desktop = new PntsChunkDecoder({ decodeLimits: pntsDeviceDecodeLimits(false) });
+    await expect(
+      desktop.decode(makeDeclaredAllChannels(MID_POINTS), meta()),
+    ).rejects.toThrow(/section/i);
+  });
+
+  it('the old device-independent decoder (no limits) did not refuse it on decoded bytes', async () => {
+    // Red-green anchor: this is the pre-fix construction. It reaches the section
+    // refusal, never the decoded-byte one — the gap the mobile ceiling closes.
+    await expect(
+      new PntsChunkDecoder().decode(makeDeclaredAllChannels(MID_POINTS), meta()),
+    ).rejects.toThrow(/section/i);
   });
 });
 

--- a/tests/pntsDecodeCeiling.test.ts
+++ b/tests/pntsDecodeCeiling.test.ts
@@ -42,6 +42,45 @@ function pntsWithDeclaredPoints(pointsLength: number): ArrayBuffer {
   return buffer;
 }
 
+/**
+ * Count the large (>4096-element) `Float32Array` / `Uint8Array` allocations that
+ * `run` triggers. The decoder resolves both constructors through the global at
+ * call time, so swapping the bindings here observes any allocation it attempts;
+ * a refusal that fires before the allocation seam leaves the count at zero.
+ */
+function countBigAllocations(run: () => void): number {
+  const RealF32 = globalThis.Float32Array;
+  const RealU8 = globalThis.Uint8Array;
+  let bigAlloc = 0;
+  const note = (n: unknown): void => {
+    if (typeof n === 'number' && n > 4096) bigAlloc++;
+  };
+  class F32 extends RealF32 {
+    constructor(...args: unknown[]) {
+      note(args[0]);
+      // @ts-expect-error forward whatever the decoder passed
+      super(...args);
+    }
+  }
+  class U8 extends RealU8 {
+    constructor(...args: unknown[]) {
+      note(args[0]);
+      // @ts-expect-error forward whatever the decoder passed
+      super(...args);
+    }
+  }
+  (globalThis as { Float32Array: unknown }).Float32Array = F32;
+  (globalThis as { Uint8Array: unknown }).Uint8Array = U8;
+  try {
+    run();
+  } finally {
+    (globalThis as { Float32Array: unknown }).Float32Array = RealF32;
+    (globalThis as { Uint8Array: unknown }).Uint8Array = RealU8;
+  }
+  return bigAlloc;
+}
+
+
 describe('PNTS decoded-point ceiling', () => {
   it('refuses a tile declaring more points than the ceiling', () => {
     const tile = pntsWithDeclaredPoints(MAX_PNTS_TILE_POINTS + 1);
@@ -120,36 +159,9 @@ describe('PNTS decoded-byte ceiling', () => {
 
   it('refuses before allocating: the big typed arrays are never constructed', () => {
     const tile = pntsAllChannels(7_000_000);
-    const RealF32 = globalThis.Float32Array;
-    const RealU8 = globalThis.Uint8Array;
-    let bigAlloc = 0;
-    const note = (n: unknown) => {
-      if (typeof n === 'number' && n > 4096) bigAlloc++;
-    };
-    // The decoder resolves `Float32Array`/`Uint8Array` through the global at
-    // call time, so a swapped binding here observes any allocation it attempts.
-    class F32 extends RealF32 {
-      constructor(...args: unknown[]) {
-        note(args[0]);
-        // @ts-expect-error forward whatever the decoder passed
-        super(...args);
-      }
-    }
-    class U8 extends RealU8 {
-      constructor(...args: unknown[]) {
-        note(args[0]);
-        // @ts-expect-error forward whatever the decoder passed
-        super(...args);
-      }
-    }
-    (globalThis as { Float32Array: unknown }).Float32Array = F32;
-    (globalThis as { Uint8Array: unknown }).Uint8Array = U8;
-    try {
+    const bigAlloc = countBigAllocations(() => {
       expect(() => parsePnts(tile)).toThrow(/decoded byte/i);
-    } finally {
-      (globalThis as { Float32Array: unknown }).Float32Array = RealF32;
-      (globalThis as { Uint8Array: unknown }).Uint8Array = RealU8;
-    }
+    });
     expect(bigAlloc).toBe(0);
   });
 
@@ -189,36 +201,11 @@ describe('device-aware PNTS decode ceiling', () => {
 
   it('refuses the tile on the mobile ceiling before the big allocation', () => {
     const tile = pntsAllChannels(MID_POINTS);
-    const RealF32 = globalThis.Float32Array;
-    const RealU8 = globalThis.Uint8Array;
-    let bigAlloc = 0;
-    const note = (n: unknown) => {
-      if (typeof n === 'number' && n > 4096) bigAlloc++;
-    };
-    class F32 extends RealF32 {
-      constructor(...args: unknown[]) {
-        note(args[0]);
-        // @ts-expect-error forward whatever the decoder passed
-        super(...args);
-      }
-    }
-    class U8 extends RealU8 {
-      constructor(...args: unknown[]) {
-        note(args[0]);
-        // @ts-expect-error forward whatever the decoder passed
-        super(...args);
-      }
-    }
-    (globalThis as { Float32Array: unknown }).Float32Array = F32;
-    (globalThis as { Uint8Array: unknown }).Uint8Array = U8;
-    try {
-      expect(() =>
-        parsePnts(tile, pntsDeviceDecodeLimits(true)),
-      ).toThrow(/decoded byte/i);
-    } finally {
-      (globalThis as { Float32Array: unknown }).Float32Array = RealF32;
-      (globalThis as { Uint8Array: unknown }).Uint8Array = RealU8;
-    }
+    const bigAlloc = countBigAllocations(() => {
+      expect(() => parsePnts(tile, pntsDeviceDecodeLimits(true))).toThrow(
+        /decoded byte/i,
+      );
+    });
     // The allocation seam is never reached: mobile refuses on the true size.
     expect(bigAlloc).toBe(0);
   });

--- a/tests/pntsDecodeCeiling.test.ts
+++ b/tests/pntsDecodeCeiling.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   MAX_PNTS_DECODED_BYTES,
+  MAX_PNTS_DECODED_BYTES_MOBILE,
   MAX_PNTS_TILE_POINTS,
   parsePnts,
+  pntsDeviceDecodeLimits,
 } from '../src/io/tiles3d/pnts';
 
 /**
@@ -156,6 +158,92 @@ describe('PNTS decoded-byte ceiling', () => {
     // it, the same lever `maxPoints` gives for the count ceiling.
     const tile = pntsAllChannels(1_000);
     expect(() => parsePnts(tile, { maxDecodedBytes: 1_000 })).toThrow(/decoded byte/i);
+  });
+});
+
+describe('device-aware PNTS decode ceiling', () => {
+  // 5,000,000 points at 31 decoded bytes each is ~147.8 MiB: above the 96 MiB
+  // mobile ceiling, below the 192 MiB desktop ceiling, and under the 8,000,000
+  // point count ceiling. So it is a single legal tile that mobile must refuse on
+  // its decoded size and desktop must admit — the exact case the scheduler's
+  // ASSUMED_TILE_POINTS estimate cannot catch before the body is fetched.
+  const MID_POINTS = 5_000_000;
+
+  it('sizes the mobile ceiling below desktop and derives a matching point cap', () => {
+    const mobile = pntsDeviceDecodeLimits(true);
+    const desktop = pntsDeviceDecodeLimits(false);
+    expect(mobile.maxDecodedBytes).toBe(MAX_PNTS_DECODED_BYTES_MOBILE);
+    expect(desktop.maxDecodedBytes).toBe(MAX_PNTS_DECODED_BYTES);
+    expect(mobile.maxDecodedBytes).toBeLessThan(desktop.maxDecodedBytes);
+    // The point cap is derived from the byte ceiling and clamped to the desktop
+    // count ceiling, so it never exceeds it.
+    expect(mobile.maxPoints).toBeLessThanOrEqual(MAX_PNTS_TILE_POINTS);
+    expect(desktop.maxPoints).toBeLessThanOrEqual(MAX_PNTS_TILE_POINTS);
+  });
+
+  it('confirms the mid-size tile straddles the two ceilings', () => {
+    expect(MID_POINTS * 31).toBeGreaterThan(MAX_PNTS_DECODED_BYTES_MOBILE);
+    expect(MID_POINTS * 31).toBeLessThan(MAX_PNTS_DECODED_BYTES);
+    expect(MID_POINTS).toBeLessThan(MAX_PNTS_TILE_POINTS);
+  });
+
+  it('refuses the tile on the mobile ceiling before the big allocation', () => {
+    const tile = pntsAllChannels(MID_POINTS);
+    const RealF32 = globalThis.Float32Array;
+    const RealU8 = globalThis.Uint8Array;
+    let bigAlloc = 0;
+    const note = (n: unknown) => {
+      if (typeof n === 'number' && n > 4096) bigAlloc++;
+    };
+    class F32 extends RealF32 {
+      constructor(...args: unknown[]) {
+        note(args[0]);
+        // @ts-expect-error forward whatever the decoder passed
+        super(...args);
+      }
+    }
+    class U8 extends RealU8 {
+      constructor(...args: unknown[]) {
+        note(args[0]);
+        // @ts-expect-error forward whatever the decoder passed
+        super(...args);
+      }
+    }
+    (globalThis as { Float32Array: unknown }).Float32Array = F32;
+    (globalThis as { Uint8Array: unknown }).Uint8Array = U8;
+    try {
+      expect(() =>
+        parsePnts(tile, pntsDeviceDecodeLimits(true)),
+      ).toThrow(/decoded byte/i);
+    } finally {
+      (globalThis as { Float32Array: unknown }).Float32Array = RealF32;
+      (globalThis as { Uint8Array: unknown }).Uint8Array = RealU8;
+    }
+    // The allocation seam is never reached: mobile refuses on the true size.
+    expect(bigAlloc).toBe(0);
+  });
+
+  it('admits the same tile on desktop — the refusal is device-specific', () => {
+    // Desktop limits do NOT throw on the decoded-byte ceiling. The tile has no
+    // binary section, so it reaches the position accessor and then fails on the
+    // section bounds, which is a DIFFERENT refusal — proof the byte ceiling
+    // passed.
+    const tile = pntsAllChannels(MID_POINTS);
+    expect(() => parsePnts(tile, pntsDeviceDecodeLimits(false))).not.toThrow(
+      /decoded byte/i,
+    );
+    expect(() => parsePnts(tile, pntsDeviceDecodeLimits(false))).toThrow(
+      /section/i,
+    );
+  });
+
+  it('the mobile refusal did not hold under the old device-independent default', () => {
+    // Red-green anchor: the pre-fix decoder called parsePnts with no limits, so
+    // this tile sailed through the 192 MiB default. Reproduce that here and show
+    // it does NOT refuse on decoded bytes — which is exactly the gap the mobile
+    // ceiling closes.
+    const tile = pntsAllChannels(MID_POINTS);
+    expect(() => parsePnts(tile)).not.toThrow(/decoded byte/i);
   });
 });
 

--- a/tests/tiles3dTilesetTransport.test.ts
+++ b/tests/tiles3dTilesetTransport.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, expect, test } from 'vitest';
+import { bodyCancelFetch } from './helpers/bodyCancelFetch';
 import {
   createTilesetTransport,
   TilesetTimeoutError,
@@ -183,37 +184,6 @@ describe('createTilesetTransport — bounds and cancellation', () => {
   });
 });
 
-/**
- * A fetch whose non-success responses carry a body with a spied `cancel()`, so
- * a test can prove the transport releases an abandoned body before it retries
- * or throws. Success steps return a real Response the bounded read can consume.
- */
-function bodyCancelFetch(
-  steps: Array<{ status: number; body?: string }>,
-): { fn: typeof fetch; cancels: number } {
-  let i = 0;
-  const handle = { cancels: 0, fn: undefined as unknown as typeof fetch };
-  handle.fn = (async (_input: RequestInfo | URL): Promise<Response> => {
-    const step = steps[Math.min(i++, steps.length - 1)]!;
-    if (step.status >= 200 && step.status < 300) {
-      return new Response(step.body ?? 'ok', { status: 200, statusText: 'OK' });
-    }
-    const body = {
-      cancel: (): Promise<void> => {
-        handle.cancels++;
-        return Promise.resolve();
-      },
-    } as unknown as ReadableStream<Uint8Array>;
-    return {
-      ok: false,
-      status: step.status,
-      statusText: 'Err',
-      body,
-      headers: new Headers(),
-    } as unknown as Response;
-  }) as typeof fetch;
-  return handle;
-}
 
 describe('createTilesetTransport — abandoned response bodies are cancelled', () => {
   test('cancels a retryable 503 body before the retry proceeds', async () => {

--- a/tests/tiles3dTilesetTransport.test.ts
+++ b/tests/tiles3dTilesetTransport.test.ts
@@ -182,3 +182,53 @@ describe('createTilesetTransport — bounds and cancellation', () => {
     expect(buf.byteLength).toBe(4);
   });
 });
+
+/**
+ * A fetch whose non-success responses carry a body with a spied `cancel()`, so
+ * a test can prove the transport releases an abandoned body before it retries
+ * or throws. Success steps return a real Response the bounded read can consume.
+ */
+function bodyCancelFetch(
+  steps: Array<{ status: number; body?: string }>,
+): { fn: typeof fetch; cancels: number } {
+  let i = 0;
+  const handle = { cancels: 0, fn: undefined as unknown as typeof fetch };
+  handle.fn = (async (_input: RequestInfo | URL): Promise<Response> => {
+    const step = steps[Math.min(i++, steps.length - 1)]!;
+    if (step.status >= 200 && step.status < 300) {
+      return new Response(step.body ?? 'ok', { status: 200, statusText: 'OK' });
+    }
+    const body = {
+      cancel: (): Promise<void> => {
+        handle.cancels++;
+        return Promise.resolve();
+      },
+    } as unknown as ReadableStream<Uint8Array>;
+    return {
+      ok: false,
+      status: step.status,
+      statusText: 'Err',
+      body,
+      headers: new Headers(),
+    } as unknown as Response;
+  }) as typeof fetch;
+  return handle;
+}
+
+describe('createTilesetTransport — abandoned response bodies are cancelled', () => {
+  test('cancels a retryable 503 body before the retry proceeds', async () => {
+    const h = bodyCancelFetch([{ status: 503 }, { status: 200, body: '{"asset":{}}' }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW });
+    await expect(t.fetchTilesetJson(URL_JSON)).resolves.toBe('{"asset":{}}');
+    expect(h.cancels).toBe(1);
+  });
+
+  test('cancels a permanent 404 body before it throws', async () => {
+    const h = bodyCancelFetch([{ status: 404 }]);
+    const t = createTilesetTransport({ fetchImpl: h.fn, sleep: NOW });
+    await expect(
+      t.fetchTileBytes('https://tiles.example.org/scan/a/0.pnts'),
+    ).rejects.toThrow(/404/);
+    expect(h.cancels).toBe(1);
+  });
+});


### PR DESCRIPTION
## PNTS device-aware decoded cap (blocker)

The scheduler admits every unfetched PNTS tile on `ASSUMED_TILE_POINTS` (500k) before the body is fetched, so a real 8M-point tile passed the mobile first-node admission guard and was only sized after download, against the device-independent 192 MiB / 8M decode ceilings. The concurrency cap stops two concurrent decodes but not one large tile.

`parsePnts` already accepted `maxPoints` / `maxDecodedBytes`; the decoder was passing neither. `PntsChunkDecoder` now takes `decodeLimits` from `pntsDeviceDecodeLimits(isPhone())`, the same phone signal the streaming budget uses for concurrency. Mobile gets a 96 MiB ceiling with a derived point cap; a tile whose true decoded size exceeds it is refused before the first position array is allocated. Desktop keeps 192 MiB unchanged.

## EPT / 3D Tiles retry-response body cancellation (high)

`HttpRangeSource` cancels an abandoned response body; the EPT and 3D Tiles retry loops did not, on either a retryable status or a permanent non-success. Both now cancel best-effort before retrying or throwing, mirroring `cancelResponseBody`.

## readAtMostBounded known-length preallocation (high)

The known-length fast path did `new Uint8Array(declared)` on a valid Content-Length at or below the cap, letting a header alone force an up-to-256 MiB allocation. The immediate allocation is now capped at 16 MiB and grows toward `declared` in doublings as bytes actually arrive, still refusing anything past `declared`. Honest small bodies stay single-allocation.

## Tests

Red-green per fix (mobile refusal / desktop admit, body-cancel spy on both transports, oversized-header no-eager-allocation). Full suite green (13581 passed); `tsc --noEmit` clean.