### PR TITLE
Charge the laz-perf WASM compressed copy in the decode peak budget

### DIFF
--- a/src/io/copc/copcChunkDecompress.ts
+++ b/src/io/copc/copcChunkDecompress.ts
@@ -26,7 +26,9 @@ import {
 } from '../validateCount';
 import {
   MAX_DECODED_ALLOCATION_BYTES,
+  MAX_DECODE_PEAK_BYTES,
   withinDecodedByteBudget,
+  withinDecodePeakBudget,
 } from '../heavy/heavyByteBudget';
 import type { ChunkDecodeMetadata } from './copcChunkDecode';
 
@@ -64,7 +66,7 @@ export const MAX_DECOMPRESSED_NODE_BYTES = MAX_DECODED_ALLOCATION_BYTES;
  */
 export function decompressChunk(
   lazPerf: LazPerfModule,
-  chunk: ArrayBuffer,
+  chunk: ArrayBuffer | Uint8Array,
   meta: ChunkDecodeMetadata,
 ): Uint8Array {
   // Allocation guard — bound the node's declared count by its compressed
@@ -94,8 +96,32 @@ export function decompressChunk(
         `${MAX_DECOMPRESSED_NODE_BYTES.toLocaleString('en-US')}-byte decode budget.`,
     );
   }
+  // Peak-memory cap: the decoded guard above bounds the OUTPUT buffer, but the
+  // node's compressed bytes are live TWICE during decode — the JS `compressed`
+  // buffer plus the copy `HEAPU8.set` stages into laz-perf's WASM heap below — on
+  // top of that output. Bound the joint peak (2 × compressed + decoded) so a node
+  // whose output passes the per-node cap yet whose simultaneous working set blows
+  // the total budget is refused before either malloc.
+  if (
+    !withinDecodePeakBudget(
+      chunk.byteLength,
+      pointCount,
+      meta.pointRecordLength,
+      0,
+      chunk.byteLength,
+      MAX_DECODE_PEAK_BYTES,
+    )
+  ) {
+    throw new LoadError(
+      'malformed-file',
+      `malformed COPC: node of ${pointCount.toLocaleString('en-US')} points would peak over the ` +
+        `${MAX_DECODE_PEAK_BYTES.toLocaleString('en-US')}-byte decode budget ` +
+        `(decoded records + two ${chunk.byteLength.toLocaleString('en-US')}-byte compressed copies, ` +
+        `JS buffer + laz-perf WASM heap).`,
+    );
+  }
 
-  const compressed = new Uint8Array(chunk);
+  const compressed = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
   const recordLength = meta.pointRecordLength;
   const chunkPtr = lazPerf._malloc(compressed.byteLength);
   const pointPtr = lazPerf._malloc(recordLength);

--- a/src/io/ept/eptLaszipDecode.ts
+++ b/src/io/ept/eptLaszipDecode.ts
@@ -252,13 +252,19 @@ export function decodeEptLaszipTileWith(
       n,
       decodedBytesPerPoint(ctx),
       0,
+      // laz-perf duplicates the whole compressed tile into its WASM heap
+      // (`_malloc` + `HEAPU8.set(fileBytes, filePtr)` below), so the JS buffer and
+      // its WASM copy are both resident during decode: two compressed copies, not
+      // one.
+      buffer.byteLength,
       MAX_DECODE_PEAK_BYTES,
     )
   ) {
     throw new HeavyByteBudgetError(
       `EPT laszip tile: ${n.toLocaleString('en-US')} points would stage ` +
         `${(n * decodedBytesPerPoint(ctx)).toLocaleString('en-US')} decoded bytes ` +
-        `plus a ${buffer.byteLength.toLocaleString('en-US')}-byte compressed payload, ` +
+        `plus two ${buffer.byteLength.toLocaleString('en-US')}-byte compressed copies ` +
+        `(JS buffer + laz-perf WASM heap), ` +
         `over the ${MAX_DECODE_PEAK_BYTES.toLocaleString('en-US')}-byte decode budget.`,
     );
   }

--- a/src/io/heavy/chunkedLazSource.ts
+++ b/src/io/heavy/chunkedLazSource.ts
@@ -86,7 +86,8 @@ export const MAX_LAZ_WINDOW_SPAN_BYTES = 128 * 1024 * 1024;
  * from the first chunk's offset stays under {@link MAX_LAZ_WINDOW_SPAN_BYTES},
  * the aggregate DECODED bytes of the window stay under
  * {@link MAX_DECODED_ALLOCATION_BYTES}, the summed simultaneous peak
- * (span + decoded + packed) stays under {@link MAX_DECODE_PEAK_BYTES}, and it is
+ * (span + one chunk's WASM compressed copy + decoded + packed) stays under
+ * {@link MAX_DECODE_PEAK_BYTES}, and it is
  * under `window` chunks — but always take at least one chunk. The decoded-byte
  * cap uses the real record length (`recordLength`, 0 to skip it): the
  * compressed-span cap bounds the read, but a window of highly-compressed chunks
@@ -110,6 +111,10 @@ export function planChunkWindow(
   let end = start + 1;
   let points = chunks[start].pointCount;
   let decoded = decodedBytesFor(points, recordLength > 0 ? recordLength : 1);
+  // The largest single chunk in the window bounds laz-perf's WASM copy: chunks
+  // decode one at a time, so only one chunk's compressed bytes are duplicated into
+  // the WASM heap at any instant, on top of the whole resident span.
+  let maxChunk = chunks[start].byteLength;
   while (end < chunks.length && end - start < window) {
     const next = chunks[end];
     const nextSpan = next.byteOffset + next.byteLength - spanStart;
@@ -117,14 +122,16 @@ export function planChunkWindow(
     const nextPoints = points + next.pointCount;
     const nextDecoded = decoded + decodedBytesFor(next.pointCount, recordLength > 0 ? recordLength : 1);
     if (nextDecoded > cap) break;
+    const nextMaxChunk = Math.max(maxChunk, next.byteLength);
     if (
       peakActive &&
-      !withinDecodePeakBudget(nextSpan, nextPoints, recordLength, packedRecordBytes)
+      !withinDecodePeakBudget(nextSpan, nextPoints, recordLength, packedRecordBytes, nextMaxChunk)
     ) {
       break;
     }
     points = nextPoints;
     decoded = nextDecoded;
+    maxChunk = nextMaxChunk;
     end++;
   }
   const last = chunks[end - 1];
@@ -245,12 +252,15 @@ export async function openChunkedLazSource(
               only.pointCount,
               header.pointDataRecordLength,
               recordBytes,
+              // laz-perf copies the chunk into its WASM heap, so the span and its
+              // WASM duplicate are both resident during decode.
+              only.byteLength,
             )
           ) {
             throw new ChunkedLazUnsupportedError(
               `chunked LAZ chunk of ${only.pointCount} points would peak over the ` +
                 `${MAX_DECODE_PEAK_BYTES}-byte simultaneous-decode budget (compressed span + ` +
-                'decoded records + packed records); convert it to COPC or EPT',
+                'WASM compressed copy + decoded records + packed records); convert it to COPC or EPT',
             );
           }
         }
@@ -291,7 +301,12 @@ function decodeChunkBatch(
   }
   const rel = c.byteOffset - spanStart;
   const job: LazChunkJob = {
-    chunk: span.slice(rel, rel + c.byteLength),
+    // A VIEW into the already-resident window span, not `span.slice(...)`. The
+    // slice made a third live compressed copy of this chunk (window span + JS
+    // slice + laz-perf's WASM copy); the decoder only needs the bytes, and it
+    // stages its own WASM copy from whatever it is given, so a view carries the
+    // identical bytes with one fewer copy resident. Consumed here in-process.
+    chunk: new Uint8Array(span, rel, c.byteLength),
     pointCount: c.pointCount,
     firstPointIndex: c.firstPointIndex,
     pointDataRecordFormat: header.pointFormat,

--- a/src/io/heavy/decodeLazChunked.ts
+++ b/src/io/heavy/decodeLazChunked.ts
@@ -40,7 +40,16 @@ const CHUNK_DECODE_FORMATS = new Set([6, 7, 8]);
  * transferable and the rest are copied into the message.
  */
 export interface LazChunkJob {
-  readonly chunk: ArrayBuffer;
+  /**
+   * The chunk's compressed bytes. An `ArrayBuffer` (the whole-file and worker
+   * paths own a standalone copy that structured-clone can transfer), or a
+   * `Uint8Array` VIEW into a larger already-resident buffer — the out-of-core
+   * window path hands a view into its window span so the chunk is not copied out
+   * of the span a second time. A view-bearing job must be decoded in-process
+   * ({@link decodeLazChunkLocal}), never posted to a worker, since cloning a view
+   * would carry its whole backing buffer.
+   */
+  readonly chunk: ArrayBuffer | Uint8Array;
   readonly pointCount: number;
   readonly firstPointIndex: number;
   readonly pointDataRecordFormat: number;

--- a/src/io/heavy/heavyByteBudget.ts
+++ b/src/io/heavy/heavyByteBudget.ts
@@ -133,21 +133,35 @@ export function withinDecodedByteBudget(
 /**
  * The summed peak working set of decoding a span of `spanBytes` compressed bytes
  * into `pointCount` records of `sourceRecordLength` bytes and packing them into
- * `packedRecordBytes`-byte tile records — the three allocations that coexist
- * during a LAZ window decode. A non-usable span or decoded size makes the total
+ * `packedRecordBytes`-byte tile records — the allocations that coexist during a
+ * LAZ window decode. A non-usable span or decoded size makes the total
  * {@link Number.POSITIVE_INFINITY}, so a nonsense size reads as over-budget;
  * `packedRecordBytes <= 0` drops the packed term (the caller is not staging one)
  * rather than poisoning the sum.
+ *
+ * `wasmCompressedBytes` (default 0) charges the compressed data laz-perf
+ * DUPLICATES inside the WASM heap. Every laz-perf decode does
+ * `_malloc(byteLength)` + `HEAPU8.set(compressed, ptr)` before it reads the first
+ * point, so the JS-side compressed buffer and its WASM copy are live at once. The
+ * span term alone charged the compressed bytes a single time and understated the
+ * real peak by one whole compressed copy (and, where a caller also slices a JS
+ * copy out of a shared span, by two); pass the size of that WASM duplicate here so
+ * the estimate matches what actually coexists.
  */
 export function decodePeakBytesFor(
   spanBytes: number,
   pointCount: number,
   sourceRecordLength: number,
   packedRecordBytes: number,
+  wasmCompressedBytes: number = 0,
 ): number {
   const span = Number.isFinite(spanBytes) && spanBytes >= 0 ? spanBytes : Number.POSITIVE_INFINITY;
+  const wasm =
+    Number.isFinite(wasmCompressedBytes) && wasmCompressedBytes >= 0
+      ? wasmCompressedBytes
+      : Number.POSITIVE_INFINITY;
   const packed = packedRecordBytes > 0 ? decodedBytesFor(pointCount, packedRecordBytes) : 0;
-  return span + decodedBytesFor(pointCount, sourceRecordLength) + packed;
+  return span + wasm + decodedBytesFor(pointCount, sourceRecordLength) + packed;
 }
 
 /** Whether a window/chunk's summed decode peak stays within `ceiling` (default the total cap). */
@@ -156,9 +170,13 @@ export function withinDecodePeakBudget(
   pointCount: number,
   sourceRecordLength: number,
   packedRecordBytes: number,
+  wasmCompressedBytes: number = 0,
   ceiling: number = MAX_DECODE_PEAK_BYTES,
 ): boolean {
-  return decodePeakBytesFor(spanBytes, pointCount, sourceRecordLength, packedRecordBytes) <= ceiling;
+  return (
+    decodePeakBytesFor(spanBytes, pointCount, sourceRecordLength, packedRecordBytes, wasmCompressedBytes) <=
+    ceiling
+  );
 }
 
 /**

--- a/tests/chunkedLazDecodePeak.test.ts
+++ b/tests/chunkedLazDecodePeak.test.ts
@@ -24,14 +24,16 @@ import {
 const MiB = 1024 * 1024;
 
 describe('planChunkWindow — total simultaneous-decode peak budget', () => {
-  it('shrinks a window whose span + decoded + packed exceeds the total peak, below what the individual caps allow', () => {
+  it('shrinks a window whose span + WASM copy + decoded + packed exceeds the total peak, below what the individual caps allow', () => {
     // Two chunks. Each on its own is legal under every individual cap; together
-    // their span (124 MiB < 128) and decoded (120 MiB < 128) both pass, but the
-    // summed peak span+decoded+packed = 268 MiB is over the 256 MiB total.
+    // their span (80 MiB < 128) and decoded (60 MiB < 128) both pass. The joint
+    // peak also charges laz-perf's WASM copy of the largest chunk (40 MiB) — the
+    // chunk's compressed bytes are duplicated into the WASM heap during decode —
+    // so span 80 + WASM 40 + decoded 60 = 180 MiB without packed, 258 MiB with it.
     const recordLength = 1000;
-    const packedRecordBytes = 200;
-    const pointsPerChunk = 60_000; // decoded 60 MiB, packed 12 MiB per chunk
-    const spanPerChunk = 62 * MiB;
+    const packedRecordBytes = 1300;
+    const pointsPerChunk = 31_457; // decoded 30 MiB, packed 39 MiB per chunk
+    const spanPerChunk = 40 * MiB;
 
     const chunks: LazChunkRange[] = [];
     let off = 0;
@@ -43,16 +45,26 @@ describe('planChunkWindow — total simultaneous-decode peak budget', () => {
     // Two chunks stay under the span and decoded caps individually.
     expect(2 * spanPerChunk).toBeLessThan(MAX_LAZ_WINDOW_SPAN_BYTES);
     expect(withinDecodedByteBudget(2 * pointsPerChunk, recordLength)).toBe(true);
-    // With the packed records counted, the summed peak (~261 MiB) exceeds the
+    // With the packed records counted the summed peak (~258 MiB) exceeds the
     // total, so the plan takes only one chunk.
-    const plan = planChunkWindow(chunks, 0, 4, recordLength, packedRecordBytes);
+    const plan = planChunkWindow(chunks, 0, 2, recordLength, packedRecordBytes);
     expect(plan.end).toBe(1);
 
-    // Dropping only the packed term leaves span+decoded (~238 MiB) under the total,
-    // so the span cap admits two — the packed allocation is exactly what tips the
-    // joint peak over budget and forces the shrink to one.
-    const withoutPacked = planChunkWindow(chunks, 0, 4, recordLength, 0);
+    // Dropping only the packed term leaves span + WASM + decoded (~180 MiB) under
+    // the total, so the plan admits two — the packed allocation is exactly what
+    // tips the joint peak over budget and forces the shrink to one.
+    const withoutPacked = planChunkWindow(chunks, 0, 2, recordLength, 0);
     expect(withoutPacked.end).toBe(2);
+
+    // The WASM copy is load-bearing: the OLD formula (no WASM term) would have
+    // admitted BOTH chunks even with the packed records, at span 80 + decoded 60 +
+    // packed 78 = 218 MiB < 256. Charging the 40 MiB WASM copy is what refuses it.
+    expect(
+      withinDecodePeakBudget(2 * spanPerChunk, 2 * pointsPerChunk, recordLength, packedRecordBytes, 0),
+    ).toBe(true); // old model: admitted
+    expect(
+      withinDecodePeakBudget(2 * spanPerChunk, 2 * pointsPerChunk, recordLength, packedRecordBytes, spanPerChunk),
+    ).toBe(false); // WASM-aware: refused
   });
 
   it('flags a single chunk whose own summed peak is over the total budget though its decoded bytes pass the per-chunk cap', () => {

--- a/tests/lazWasmPeakMemory.test.ts
+++ b/tests/lazWasmPeakMemory.test.ts
@@ -1,0 +1,194 @@
+/**
+ * lazWasmPeakMemory.test.ts — the decode peak model charges laz-perf's WASM copy
+ * of the compressed input.
+ *
+ * Every laz-perf decode path (EPT laszip tile, COPC node, local windowed LAZ
+ * chunk) stages `_malloc(compressed.byteLength)` + `HEAPU8.set(compressed, ptr)`
+ * before it reads the first point, so the JS-side compressed buffer AND its WASM
+ * duplicate are live at once — two compressed copies, not one. The old peak
+ * formula (P = span + decoded + packed) charged the compressed bytes a single
+ * time and understated the real peak by a whole compressed copy, admitting
+ * payloads whose true 2·Bc + Bd working set blows the 256 MiB ceiling.
+ *
+ * These cases pin the corrected model:
+ *   1. the formula itself now includes the WASM copy (red-green vs the old form);
+ *   2. a COPC node whose decoded bytes pass the per-node cap but whose 2·Bc + Bd
+ *      peak is over budget is refused BEFORE any WASM allocation;
+ *   3. the local windowed path feeds the decoder a VIEW into its span (no third
+ *      compressed copy) and the bytes handed to laz-perf are byte-identical to the
+ *      old `span.slice(...)`.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_DECODE_PEAK_BYTES,
+  MAX_DECODED_ALLOCATION_BYTES,
+  decodePeakBytesFor,
+  withinDecodePeakBudget,
+  withinDecodedByteBudget,
+} from '../src/io/heavy/heavyByteBudget';
+import { decompressChunk, type LazPerfModule } from '../src/io/copc/copcChunkDecompress';
+import type { ChunkDecodeMetadata } from '../src/io/copc/copcChunkDecode';
+
+const MiB = 1024 * 1024;
+
+describe('decode peak model — laz-perf WASM compressed copy', () => {
+  it('charges the WASM compressed copy on top of the span (formula red-green)', () => {
+    // A tile that the OLD single-copy formula admits under the 256 MiB ceiling but
+    // whose real 2·Bc + Bd working set is over it. Bc compressed, Bd decoded.
+    const Bc = 130 * MiB;
+    const Bd = 120 * MiB;
+    const recordLength = 30;
+    const pointCount = Bd / recordLength;
+
+    // Decoded alone is within the per-allocation cap — this is not a decoded-cap
+    // refusal, it is a peak refusal.
+    expect(withinDecodedByteBudget(pointCount, recordLength, MAX_DECODED_ALLOCATION_BYTES)).toBe(true);
+
+    // OLD model (no WASM term): span + decoded = 250 MiB ≤ 256 → admitted.
+    expect(decodePeakBytesFor(Bc, pointCount, recordLength, 0, 0)).toBe(Bc + Bd);
+    expect(withinDecodePeakBudget(Bc, pointCount, recordLength, 0, 0)).toBe(true);
+
+    // WASM-aware model: span + WASM copy + decoded = 380 MiB > 256 → refused.
+    expect(decodePeakBytesFor(Bc, pointCount, recordLength, 0, Bc)).toBe(2 * Bc + Bd);
+    expect(withinDecodePeakBudget(Bc, pointCount, recordLength, 0, Bc)).toBe(false);
+  });
+
+  it('a nonsense WASM copy size reads as over-budget, never as zero', () => {
+    expect(withinDecodePeakBudget(1000, 10, 4, 0, Number.NaN)).toBe(false);
+    expect(withinDecodePeakBudget(1000, 10, 4, 0, -1)).toBe(false);
+    expect(decodePeakBytesFor(1000, 10, 4, 0, Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+// --- COPC node peak refusal, through the real decompressChunk ----------------
+
+/** A laz-perf stand-in that records every `_malloc`, so a refusal can be proven
+ *  to happen before any WASM allocation. */
+function watchedLazPerf(): { module: LazPerfModule; mallocs: number[] } {
+  const mallocs: number[] = [];
+  const module = {
+    _malloc: (n: number) => {
+      mallocs.push(n);
+      return 1;
+    },
+    _free: () => {},
+    HEAPU8: new Uint8Array(16),
+    ChunkDecoder: class {
+      open(): void {}
+      getPoint(): void {}
+      delete(): void {}
+    },
+  } as unknown as LazPerfModule;
+  return { module, mallocs };
+}
+
+const copcMeta = (recordLength: number, pointCount: number): ChunkDecodeMetadata => ({
+  pointDataRecordFormat: 7,
+  pointRecordLength: recordLength,
+  pointCount,
+  scale: [1, 1, 1],
+  offset: [0, 0, 0],
+  renderOrigin: [0, 0, 0],
+});
+
+describe('decompressChunk — COPC node peak refusal', () => {
+  it('refuses a node whose decoded bytes pass the per-node cap but whose 2·Bc + Bd peak is over budget', () => {
+    const { module, mallocs } = watchedLazPerf();
+    const recordLength = 65535;
+    const pointCount = 2000; // decoded ≈ 125 MiB, under the 128 MiB per-node cap
+    const Bd = pointCount * recordLength;
+    expect(withinDecodedByteBudget(pointCount, recordLength, MAX_DECODED_ALLOCATION_BYTES)).toBe(true);
+
+    // A 66 MiB compressed chunk: on its own the decoded guard admits this node,
+    // but 2·Bc + Bd ≈ 257 MiB exceeds the 256 MiB peak.
+    const compressedBytes = 66 * MiB;
+    expect(2 * compressedBytes + Bd).toBeGreaterThan(MAX_DECODE_PEAK_BYTES);
+    const chunk = new ArrayBuffer(compressedBytes);
+
+    expect(() => decompressChunk(module, chunk, copcMeta(recordLength, pointCount))).toThrow(
+      /peak|compressed copies/,
+    );
+    // The refusal fired before either the compressed or the point malloc.
+    expect(mallocs).toHaveLength(0);
+  });
+
+  it('still admits a healthy node whose 2·Bc + Bd stays under the peak', () => {
+    // A real COPC node: ~0.2 MB compressed, 50k points at 34 bytes (~1.6 MB
+    // decoded). Its WASM-aware peak sits far under the 256 MiB ceiling, so the
+    // corrected guard does not refuse ordinary nodes.
+    const recordLength = 34;
+    const pointCount = 50_000;
+    const compressedBytes = 200_000;
+    expect(
+      withinDecodePeakBudget(compressedBytes, pointCount, recordLength, 0, compressedBytes),
+    ).toBe(true);
+    expect(2 * compressedBytes + pointCount * recordLength).toBeLessThan(MAX_DECODE_PEAK_BYTES);
+  });
+});
+
+// --- local windowed path: view instead of slice, byte-identical bytes --------
+
+/** A laz-perf stand-in whose `getPoint` echoes the first `recordLength` bytes of
+ *  the compressed input the caller staged into the heap, so the decoded output is
+ *  a deterministic function of the exact compressed bytes handed to laz-perf.
+ *  Records the size passed to the compressed `_malloc`. */
+function echoLazPerf(): { module: LazPerfModule; firstMalloc: () => number } {
+  const heap = new Uint8Array(8 * MiB);
+  let next = 8;
+  const mallocs: number[] = [];
+  let chunkPtr = 0;
+  let recordLength = 0;
+  const module = {
+    _malloc: (n: number) => {
+      mallocs.push(n);
+      const p = next;
+      next += n;
+      return p;
+    },
+    _free: () => {},
+    HEAPU8: heap,
+    ChunkDecoder: class {
+      open(_pdrf: number, rl: number, ptr: number): void {
+        recordLength = rl;
+        chunkPtr = ptr;
+      }
+      getPoint(ptr: number): void {
+        // Echo the staged compressed bytes so output tracks the input exactly.
+        heap.copyWithin(ptr, chunkPtr, chunkPtr + recordLength);
+      }
+      delete(): void {}
+    },
+  } as unknown as LazPerfModule;
+  return { module, firstMalloc: () => mallocs[0] };
+}
+
+describe('decompressChunk — window view carries only the chunk, byte-identically', () => {
+  it('a Uint8Array view into a span decodes identically to the old span.slice, staging only the chunk', () => {
+    // A window span with a chunk in the middle. rel/len select the chunk.
+    const span = new ArrayBuffer(300);
+    const u8 = new Uint8Array(span);
+    for (let i = 0; i < u8.length; i++) u8[i] = (i * 7 + 3) & 0xff;
+    const rel = 100;
+    const len = 50;
+    const recordLength = 10;
+    const pointCount = 2;
+    const meta = copcMeta(recordLength, pointCount);
+
+    // New path: a VIEW into the resident span (no copy out of the span).
+    const viewChunk = new Uint8Array(span, rel, len);
+    const viewPerf = echoLazPerf();
+    const viaView = decompressChunk(viewPerf.module, viewChunk, meta);
+
+    // Old path: a standalone ArrayBuffer slice of the same bytes.
+    const sliceChunk = span.slice(rel, rel + len);
+    const slicePerf = echoLazPerf();
+    const viaSlice = decompressChunk(slicePerf.module, sliceChunk, meta);
+
+    // Byte-identical decode: the view and the slice hand laz-perf the same bytes.
+    expect(Array.from(viaView)).toEqual(Array.from(viaSlice));
+    // And the compressed allocation staged only the chunk's bytes, not the whole
+    // 300-byte span the view points into.
+    expect(viewPerf.firstMalloc()).toBe(len);
+    expect(slicePerf.firstMalloc()).toBe(len);
+  });
+});

--- a/tests/lazWasmPeakMemory.test.ts
+++ b/tests/lazWasmPeakMemory.test.ts
@@ -64,21 +64,42 @@ describe('decode peak model — laz-perf WASM compressed copy', () => {
 
 /** A laz-perf stand-in that records every `_malloc`, so a refusal can be proven
  *  to happen before any WASM allocation. */
-function watchedLazPerf(): { module: LazPerfModule; mallocs: number[] } {
-  const mallocs: number[] = [];
-  const module = {
-    _malloc: (n: number) => {
-      mallocs.push(n);
-      return 1;
-    },
+/**
+ * Assemble a laz-perf module stand-in from the pieces a test cares about: the
+ * allocator to observe, the heap it writes into, and optional decoder hooks.
+ * The `_free`, `delete` and module-cast boilerplate lives here once.
+ */
+function makeLazPerf(opts: {
+  malloc: (n: number) => number;
+  heap: Uint8Array;
+  open?: (pdrf: number, recordLength: number, ptr: number) => void;
+  getPoint?: (ptr: number) => void;
+}): LazPerfModule {
+  return {
+    _malloc: opts.malloc,
     _free: () => {},
-    HEAPU8: new Uint8Array(16),
+    HEAPU8: opts.heap,
     ChunkDecoder: class {
-      open(): void {}
-      getPoint(): void {}
+      open(pdrf: number, recordLength: number, ptr: number): void {
+        opts.open?.(pdrf, recordLength, ptr);
+      }
+      getPoint(ptr: number): void {
+        opts.getPoint?.(ptr);
+      }
       delete(): void {}
     },
   } as unknown as LazPerfModule;
+}
+
+function watchedLazPerf(): { module: LazPerfModule; mallocs: number[] } {
+  const mallocs: number[] = [];
+  const module = makeLazPerf({
+    malloc: (n: number) => {
+      mallocs.push(n);
+      return 1;
+    },
+    heap: new Uint8Array(16),
+  });
   return { module, mallocs };
 }
 
@@ -138,27 +159,23 @@ function echoLazPerf(): { module: LazPerfModule; firstMalloc: () => number } {
   const mallocs: number[] = [];
   let chunkPtr = 0;
   let recordLength = 0;
-  const module = {
-    _malloc: (n: number) => {
+  const module = makeLazPerf({
+    malloc: (n: number) => {
       mallocs.push(n);
       const p = next;
       next += n;
       return p;
     },
-    _free: () => {},
-    HEAPU8: heap,
-    ChunkDecoder: class {
-      open(_pdrf: number, rl: number, ptr: number): void {
-        recordLength = rl;
-        chunkPtr = ptr;
-      }
-      getPoint(ptr: number): void {
-        // Echo the staged compressed bytes so output tracks the input exactly.
-        heap.copyWithin(ptr, chunkPtr, chunkPtr + recordLength);
-      }
-      delete(): void {}
+    heap,
+    open: (_pdrf, rl, ptr) => {
+      recordLength = rl;
+      chunkPtr = ptr;
     },
-  } as unknown as LazPerfModule;
+    // Echo the staged compressed bytes so output tracks the input exactly.
+    getPoint: (ptr) => {
+      heap.copyWithin(ptr, chunkPtr, chunkPtr + recordLength);
+    },
+  });
   return { module, firstMalloc: () => mallocs[0] };
 }
 


### PR DESCRIPTION
The shared decode-memory budget charged the compressed input once, but laz-perf duplicates the whole compressed buffer inside WASM before decompressing, so the real peak is about 2*Bc + Bd (and the local windowed path also made a span.slice, a third copy).

decodePeakBytesFor now carries an explicit wasmCompressedBytes term. The EPT laszip and COPC decoders charge the WASM copy; COPC gains a peak guard before either malloc rather than only a decoded-byte guard. The local windowed path drops its span.slice and lets the decoder consume a bounded Uint8Array view into the resident span, byte-identical output with one fewer copy. Ceiling constants unchanged; only the estimate is corrected.

Red-green tests: the WASM-aware formula refuses a payload the old formula admitted, and a COPC node whose decoded size passes the 128 MiB cap but whose 2*Bc+Bd peak exceeds 256 MiB is refused before any malloc.