### PR TITLE
fix: bound the true coexisting decode-memory peak on four paths

### DIFF
--- a/src/io/copc/copcChunkDecode.ts
+++ b/src/io/copc/copcChunkDecode.ts
@@ -114,6 +114,30 @@ export interface ChunkDecoder<TMeta = ChunkDecodeMetadata> {
   decode(chunk: ArrayBuffer, meta: TMeta, signal?: AbortSignal): Promise<DecodedChunk>;
 }
 
+/**
+ * Peak decoded channel-array bytes per point for one PDRF 6/7/8 node, matching
+ * exactly what {@link decodeRecords} allocates and holds LIVE at once.
+ *
+ * Every node fills seven base channels: positions (Float32 · 3 = 12), intensity
+ * (Uint16 = 2), classification (Uint8 = 1), return number (Uint8 = 1), return
+ * count (Uint8 = 1), GPS time (Float64 = 8), point source id (Uint16 = 2) — 27
+ * bytes a point. PDRF 7 and 8 add colour, and both the staged Uint16 rgb16 (3 ·
+ * 2 = 6) and the narrowed Uint8 rgb (3) are RESIDENT together while the narrow
+ * loop runs, so colour costs 9, not 3. PDRF 8's NIR is not decoded, so it is not
+ * charged. Returns {@link Number.POSITIVE_INFINITY} for a non-usable count so a
+ * nonsense value reads as over-budget rather than as zero.
+ */
+export const COPC_BASE_CHANNEL_BYTES_PER_POINT = 27;
+export const COPC_RGB_CHANNEL_BYTES_PER_POINT = 9;
+
+export function copcDecodedChannelBytes(pdrf: number, pointCount: number): number {
+  if (!Number.isFinite(pointCount) || pointCount < 0) return Number.POSITIVE_INFINITY;
+  const hasRgb = pdrf === 7 || pdrf === 8;
+  const perPoint =
+    COPC_BASE_CHANNEL_BYTES_PER_POINT + (hasRgb ? COPC_RGB_CHANNEL_BYTES_PER_POINT : 0);
+  return pointCount * perPoint;
+}
+
 /** Point source id offset in PDRF 6, 7, and 8. */
 const POINT_SOURCE_ID_OFFSET = 20;
 /** GPS time lives at the same offset in PDRF 6, 7, and 8. */

--- a/src/io/copc/copcChunkDecompress.ts
+++ b/src/io/copc/copcChunkDecompress.ts
@@ -28,9 +28,9 @@ import {
   MAX_DECODED_ALLOCATION_BYTES,
   MAX_DECODE_PEAK_BYTES,
   withinDecodedByteBudget,
-  withinDecodePeakBudget,
 } from '../heavy/heavyByteBudget';
 import type { ChunkDecodeMetadata } from './copcChunkDecode';
+import { copcDecodedChannelBytes } from './copcChunkDecode';
 
 /** The instantiated laz-perf WASM module. */
 export type LazPerfModule = Awaited<ReturnType<typeof createLazPerf>>;
@@ -55,6 +55,43 @@ export const MAX_NODE_POINTS = 50_000_000;
  * before the output buffer is allocated, by the shared decode budget.
  */
 export const MAX_DECOMPRESSED_NODE_BYTES = MAX_DECODED_ALLOCATION_BYTES;
+
+/**
+ * The true peak resident bytes of decoding one COPC node, the larger of the two
+ * phases that never overlap but are each unbounded on their own:
+ *
+ *   phase 1 (laz-perf decompression) = 2·Bc + B_raw — the JS-side compressed
+ *   buffer plus laz-perf's WASM-heap duplicate of it, both live while the raw
+ *   LAS records are staged.
+ *
+ *   phase 2 (`decodeRecords`) = Bc + B_raw + B_channels — the compressed chunk
+ *   the worker still holds, the raw records handed in, and the decoded channel
+ *   arrays being filled, all resident at once.
+ *
+ * Bc is the compressed chunk size, B_raw = pointCount · recordLength, and
+ * B_channels is {@link copcDecodedChannelBytes} for the PDRF. The old guard
+ * charged only phase 1 (`2·Bc + B_raw`) and so admitted a node whose phase-2
+ * working set — where B_channels is a second copy the size of B_raw — blew the
+ * budget. Returns the max so a node is refused when EITHER phase exceeds the cap.
+ */
+export function estimateCopcPeakBytes(
+  meta: ChunkDecodeMetadata,
+  compressedBytes: number,
+  pointCount: number,
+): number {
+  const bc =
+    Number.isFinite(compressedBytes) && compressedBytes >= 0
+      ? compressedBytes
+      : Number.POSITIVE_INFINITY;
+  const rawBytes =
+    Number.isFinite(pointCount) && pointCount >= 0 && meta.pointRecordLength > 0
+      ? pointCount * meta.pointRecordLength
+      : Number.POSITIVE_INFINITY;
+  const channelBytes = copcDecodedChannelBytes(meta.pointDataRecordFormat, pointCount);
+  const phase1 = 2 * bc + rawBytes;
+  const phase2 = bc + rawBytes + channelBytes;
+  return Math.max(phase1, phase2);
+}
 
 /**
  * Decompress one COPC node chunk into raw concatenated LAS records using
@@ -96,28 +133,24 @@ export function decompressChunk(
         `${MAX_DECOMPRESSED_NODE_BYTES.toLocaleString('en-US')}-byte decode budget.`,
     );
   }
-  // Peak-memory cap: the decoded guard above bounds the OUTPUT buffer, but the
-  // node's compressed bytes are live TWICE during decode — the JS `compressed`
-  // buffer plus the copy `HEAPU8.set` stages into laz-perf's WASM heap below — on
-  // top of that output. Bound the joint peak (2 × compressed + decoded) so a node
-  // whose output passes the per-node cap yet whose simultaneous working set blows
-  // the total budget is refused before either malloc.
-  if (
-    !withinDecodePeakBudget(
-      chunk.byteLength,
-      pointCount,
-      meta.pointRecordLength,
-      0,
-      chunk.byteLength,
-      MAX_DECODE_PEAK_BYTES,
-    )
-  ) {
+  // Peak-memory cap: the decoded guard above bounds the OUTPUT buffer, but decode
+  // holds several allocations at once across two non-overlapping phases, and each
+  // phase is unbounded on its own. Phase 1 (laz-perf decompression) peaks at
+  // 2·Bc + B_raw — the JS compressed buffer, laz-perf's WASM-heap duplicate, and
+  // the raw records. Phase 2 (decodeRecords) peaks at Bc + B_raw + B_channels —
+  // the compressed chunk the worker still holds, the raw records, and the decoded
+  // channel arrays. The old guard charged only phase 1, so a node whose phase-2
+  // working set (B_channels is a second B_raw-sized copy) blew the budget slipped
+  // through. Bound the MAX of both phases before either malloc.
+  const peakBytes = estimateCopcPeakBytes(meta, chunk.byteLength, pointCount);
+  if (peakBytes > MAX_DECODE_PEAK_BYTES) {
     throw new LoadError(
       'malformed-file',
-      `malformed COPC: node of ${pointCount.toLocaleString('en-US')} points would peak over the ` +
+      `malformed COPC: node of ${pointCount.toLocaleString('en-US')} points would peak at ` +
+        `${peakBytes.toLocaleString('en-US')} bytes, over the ` +
         `${MAX_DECODE_PEAK_BYTES.toLocaleString('en-US')}-byte decode budget ` +
-        `(decoded records + two ${chunk.byteLength.toLocaleString('en-US')}-byte compressed copies, ` +
-        `JS buffer + laz-perf WASM heap).`,
+        `(max of laz-perf decompression 2·compressed + raw records, and decodeRecords ` +
+        `compressed + raw records + decoded channel arrays).`,
     );
   }
 

--- a/src/io/ept/eptBinaryDecode.ts
+++ b/src/io/ept/eptBinaryDecode.ts
@@ -29,6 +29,7 @@
 import type { EptSchemaField } from './eptTypes';
 import type { DecodedChunk } from '../copc/copcChunkDecode';
 import { LoadError } from '../loadErrors';
+import { MAX_DECODE_PEAK_BYTES } from '../heavy/heavyByteBudget';
 import { assertFiniteNodeTransform, assertFinitePositions } from '../streamingFiniteGuard';
 
 /**
@@ -179,6 +180,52 @@ function assertChannelWidthsFit(attrs: readonly AttrLayout[]): void {
   }
 }
 
+/** Decoded-array bytes each EPT channel costs one point, matching the allocations below. */
+const EPT_POSITION_DECODED_BYTES = 12; // Float32 · 3
+const EPT_INTENSITY_DECODED_BYTES = 2; // Uint16
+const EPT_UINT8_CHANNEL_DECODED_BYTES = 1; // classification / returnNumber / returnCount
+const EPT_GPS_DECODED_BYTES = 8; // Float64
+const EPT_RGB_DECODED_BYTES = 3; // Uint8 · 3
+const EPT_RGB16_STAGING_BYTES = 6; // Uint16 · 3, temporary for uniform 16-bit colour
+
+/** Which channels a resolved schema materialises, for the peak-bytes estimate. */
+export interface EptDecodedChannels {
+  readonly intensity: boolean;
+  readonly classification: boolean;
+  readonly returnNumber: boolean;
+  readonly returnCount: boolean;
+  readonly gpsTime: boolean;
+  readonly rgb: boolean;
+  /** Uniform 16-bit RGB stages a temporary Uint16 buffer resident with the rest. */
+  readonly rgb16Staging: boolean;
+}
+
+/**
+ * Peak resident bytes of decoding one EPT binary tile: the raw tile body (still
+ * held through the DataView for the whole decode) plus every decoded channel
+ * array, plus the temporary Uint16 rgb16 staging when the colour channels are a
+ * uniform 16-bit width. The tile-body cap alone bounds `bodyBytes`; it does not
+ * bound the decoded arrays that coexist with the body, so a wide-schema tile can
+ * pass the body cap yet peak far past the decode budget while the arrays fill.
+ */
+export function eptBinaryPeakBytes(
+  bodyBytes: number,
+  pointCount: number,
+  channels: EptDecodedChannels,
+): number {
+  if (!Number.isFinite(pointCount) || pointCount < 0) return Number.POSITIVE_INFINITY;
+  if (!Number.isFinite(bodyBytes) || bodyBytes < 0) return Number.POSITIVE_INFINITY;
+  let perPoint = EPT_POSITION_DECODED_BYTES;
+  if (channels.intensity) perPoint += EPT_INTENSITY_DECODED_BYTES;
+  if (channels.classification) perPoint += EPT_UINT8_CHANNEL_DECODED_BYTES;
+  if (channels.returnNumber) perPoint += EPT_UINT8_CHANNEL_DECODED_BYTES;
+  if (channels.returnCount) perPoint += EPT_UINT8_CHANNEL_DECODED_BYTES;
+  if (channels.gpsTime) perPoint += EPT_GPS_DECODED_BYTES;
+  if (channels.rgb) perPoint += EPT_RGB_DECODED_BYTES;
+  if (channels.rgb16Staging) perPoint += EPT_RGB16_STAGING_BYTES;
+  return bodyBytes + pointCount * perPoint;
+}
+
 /**
  * Decode one EPT binary tile into a {@link DecodedChunk}.
  *
@@ -202,6 +249,7 @@ export function decodeEptBinaryTile(
   schema: readonly EptSchemaField[],
   renderOrigin: readonly [number, number, number],
   rgbEightBit?: boolean,
+  maxPeakBytes: number = MAX_DECODE_PEAK_BYTES,
 ): DecodedChunk {
   const { attrs, stride } = computeSchemaLayout(schema);
   // Every OLV channel this decoder materialises is narrower than some width the
@@ -260,6 +308,34 @@ export function decodeEptBinaryTile(
   const rAttr = findAttr(attrs, 'Red');
   const gAttr = findAttr(attrs, 'Green');
   const bAttr = findAttr(attrs, 'Blue');
+
+  // Peak-memory cap, BEFORE the first typed array is allocated. The tile-body
+  // cap at the transport bounds `buffer.byteLength`, but the raw body stays
+  // resident through the DataView for the whole decode while the channel arrays
+  // fill alongside it, so a wide-schema tile can pass the body cap yet peak far
+  // past the decode budget. Charge the body plus every channel this schema
+  // materialises (plus the temporary Uint16 rgb16 staging when colour is uniform
+  // 16-bit) and refuse before allocation when the joint peak exceeds the budget.
+  const hasRgb = rAttr !== undefined && gAttr !== undefined && bAttr !== undefined;
+  const rgb16Staging =
+    hasRgb && rAttr!.size === 2 && gAttr!.size === 2 && bAttr!.size === 2;
+  const peakBytes = eptBinaryPeakBytes(buffer.byteLength, pointCount, {
+    intensity: intensityAttr !== undefined,
+    classification: classAttr !== undefined,
+    returnNumber: retNumAttr !== undefined,
+    returnCount: retCntAttr !== undefined,
+    gpsTime: gpsAttr !== undefined,
+    rgb: hasRgb,
+    rgb16Staging,
+  });
+  if (peakBytes > maxPeakBytes) {
+    throw new LoadError(
+      'memory-constraint',
+      `EPT binary tile of ${pointCount.toLocaleString('en-US')} points would peak at ` +
+        `${peakBytes.toLocaleString('en-US')} bytes (raw tile body + decoded channel arrays), ` +
+        `over the ${maxPeakBytes.toLocaleString('en-US')}-byte decode budget.`,
+    );
+  }
 
   const positions = new Float32Array(pointCount * 3);
   // Only X/Y/Z are required of an EPT schema; every measured attribute below is

--- a/src/io/range/boundedRead.ts
+++ b/src/io/range/boundedRead.ts
@@ -77,6 +77,24 @@ export const DEFAULT_TOTAL_TIMEOUT_MS = 300_000;
  */
 export const MAX_DECLARED_PREALLOC_BYTES = 16 * 1024 * 1024;
 
+/**
+ * The ceiling on an UNKNOWN-length body, in bytes — the branch with no
+ * trustworthy identity `Content-Length`.
+ *
+ * That branch cannot stream straight into one exact target: it collects chunks
+ * and concatenates them at the end, so near the caller's ceiling it holds the
+ * chunk list AND the joined buffer at once and peaks at ~2x the body. A tile
+ * caller passes a `maxBytes` as high as 256 MiB, so an unknown-length body could
+ * transiently need ~512 MiB to assemble — over the 256 MiB decode-peak policy the
+ * rest of the pipeline promises. Capping the unknown-length branch at 64 MiB
+ * keeps its ~2x assembly peak (~128 MiB) inside that policy. An honest server
+ * that declares an identity `Content-Length` takes the streaming fast path above
+ * and is unaffected; only a body that refuses to declare its length is held to
+ * this lower bound. Legitimate manifests and hierarchies are far under it, so
+ * their own (smaller) `maxBytes` still governs via the `min` below.
+ */
+export const MAX_UNKNOWN_LENGTH_BODY_BYTES = 64 * 1024 * 1024;
+
 /** Timing and cancellation for one bounded body read. */
 export interface BoundedReadOptions {
   /**
@@ -510,6 +528,11 @@ export async function readAtMostBounded(
     // at or below the prealloc bound) returns `out` untouched.
     return filled === out.length ? out : out.slice(0, filled);
   }
+  // No trustworthy Content-Length: this branch concatenates chunks at the end
+  // and so peaks at ~2x the body during the join. Hold it to a lower ceiling
+  // than the caller's own so that ~2x assembly stays inside the decode-peak
+  // policy; a caller whose maxBytes is already smaller keeps its own limit.
+  const unknownMax = Math.min(maxBytes, MAX_UNKNOWN_LENGTH_BODY_BYTES);
   const chunks: Uint8Array[] = [];
   let total = 0;
   try {
@@ -524,11 +547,11 @@ export async function readAtMostBounded(
       );
       if (done) break;
       if (!value || value.byteLength === 0) continue;
-      if (total + value.byteLength > maxBytes) {
+      if (total + value.byteLength > unknownMax) {
         throw new BoundedReadError(
           what,
-          maxBytes,
-          `${what} exceeds the ${maxBytes}-byte limit — refusing to read further.`,
+          unknownMax,
+          `${what} exceeds the ${unknownMax}-byte unknown-length limit — refusing to read further.`,
         );
       }
       chunks.push(value);

--- a/src/io/tiles3d/pnts.ts
+++ b/src/io/tiles3d/pnts.ts
@@ -741,11 +741,21 @@ export function parsePnts(buffer: ArrayBuffer, options: ParsePntsOptions = {}): 
   // full channel width can still exceed what the device holds. `POINTS_LENGTH`
   // is a uint32 and the per-point cost is a small constant, so the product is
   // exact in a double and cannot round into agreement.
+  //
+  // Charged as a TOTAL peak, not decoded bytes alone: the raw tile body stays
+  // resident (the DataView reads positions and channels straight out of it)
+  // while the decoded arrays fill alongside it, so both coexist. A position-only
+  // tile costs the SAME again decoded as it does on the wire, so an 8M-point
+  // one is ~91.5 MiB body + ~91.5 MiB decoded = ~183 MiB peak while its decoded
+  // half alone (91.5 MiB) sits under the mobile ceiling and would slip through a
+  // decoded-only check. Bound body + decoded against the budget.
   const maxDecodedBytes = options.maxDecodedBytes ?? MAX_PNTS_DECODED_BYTES;
   const decodedBytes = pointsLength * decodedBytesPerPoint(ft);
-  if (decodedBytes > maxDecodedBytes) {
+  const peakBytes = byteLength + decodedBytes;
+  if (peakBytes > maxDecodedBytes) {
     throw new Error(
-      `PNTS: POINTS_LENGTH ${pointsLength} decodes to ${decodedBytes} bytes, past the ` +
+      `PNTS: POINTS_LENGTH ${pointsLength} peaks at ${peakBytes} bytes ` +
+        `(${byteLength}-byte tile body + ${decodedBytes} decoded bytes), past the ` +
         `${maxDecodedBytes} decoded byte ceiling this viewer holds in one tile.`,
     );
   }

--- a/tests/decodePeakMemoryModel.test.ts
+++ b/tests/decodePeakMemoryModel.test.ts
@@ -1,0 +1,324 @@
+/**
+ * decodePeakMemoryModel.test.ts — the decode-memory guards must bound the TRUE
+ * coexisting peak, not just the first decode phase or a single allocation.
+ *
+ * A release audit found three admissible-but-oversized paths the existing guards
+ * let through, plus one error-shape bug:
+ *
+ *   1. COPC — the guard charged only laz-perf phase 1 (2·Bc + B_raw). The second
+ *      phase (decodeRecords) coexists Bc + B_raw + B_channels, where B_channels
+ *      is a second B_raw-sized copy, and was unbounded.
+ *   2. EPT binary — the tile-body cap bounds the raw body but not the decoded
+ *      channel arrays that fill while the body is still resident.
+ *   3a. PNTS — the mobile decoded ceiling counted only the decoded channels, not
+ *      the raw tile body that coexists with them.
+ *   3b. Unknown-length bodies concatenate chunks and peak at ~2x during the join,
+ *      so a 256 MiB unknown-length body could need ~512 MiB to assemble.
+ *
+ * Every case pins an input the OLD guard admits and the NEW guard refuses.
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  decompressChunk,
+  estimateCopcPeakBytes,
+} from '../src/io/copc/copcChunkDecompress';
+import { copcDecodedChannelBytes } from '../src/io/copc/copcChunkDecode';
+import type { ChunkDecodeMetadata } from '../src/io/copc/copcChunkDecode';
+import {
+  MAX_DECODE_PEAK_BYTES,
+  withinDecodePeakBudget,
+} from '../src/io/heavy/heavyByteBudget';
+import {
+  decodeEptBinaryTile,
+  eptBinaryPeakBytes,
+} from '../src/io/ept/eptBinaryDecode';
+import type { EptSchemaField } from '../src/io/ept/eptTypes';
+import { parsePnts } from '../src/io/tiles3d/pnts';
+import { readAtMostBounded, MAX_UNKNOWN_LENGTH_BODY_BYTES } from '../src/io/range/boundedRead';
+import { BoundedReadError } from '../src/io/range/boundedRead';
+import { LoadError } from '../src/io/loadErrors';
+
+const MiB = 1024 * 1024;
+
+// ── BLOCKER 1 — COPC second decode phase ─────────────────────────────────────
+
+describe('COPC estimateCopcPeakBytes — the second decode phase is bounded', () => {
+  const META = (over: Partial<ChunkDecodeMetadata> = {}): ChunkDecodeMetadata => ({
+    pointDataRecordFormat: 7,
+    pointRecordLength: 36,
+    pointCount: 3_000_000,
+    scale: [0.01, 0.01, 0.01],
+    offset: [0, 0, 0],
+    renderOrigin: [0, 0, 0],
+    ...over,
+  });
+
+  // PDRF 7, 3,000,000 points, 36-byte records, 70 MiB compressed chunk.
+  const COMPRESSED = 70 * MiB;
+  const POINTS = 3_000_000;
+
+  test('the concrete case passes the OLD phase-1-only guard', () => {
+    // OLD guard = 2·Bc + B_raw (JS compressed + WASM compressed + raw records).
+    // 2·70 + ~103 = ~243 MiB, under the 256 MiB budget.
+    const phase1Only = withinDecodePeakBudget(
+      COMPRESSED,
+      POINTS,
+      36,
+      0,
+      COMPRESSED,
+      MAX_DECODE_PEAK_BYTES,
+    );
+    expect(phase1Only).toBe(true);
+  });
+
+  test('the NEW two-phase estimate refuses it on phase 2', () => {
+    // NEW = max(phase1, phase2). Phase 2 = Bc + B_raw + B_channels =
+    // 70 + ~103 + ~103 = ~276 MiB, over the 256 MiB budget.
+    const peak = estimateCopcPeakBytes(META(), COMPRESSED, POINTS);
+    expect(peak).toBeGreaterThan(MAX_DECODE_PEAK_BYTES);
+    // And the excess is the decoded channel arrays, not a mistaken double-count
+    // of the compressed bytes.
+    const phase2 = COMPRESSED + POINTS * 36 + copcDecodedChannelBytes(7, POINTS);
+    expect(peak).toBe(phase2);
+  });
+
+  test('PDRF 7 channel bytes are 36/point (27 base + 9 for staged+narrowed RGB)', () => {
+    expect(copcDecodedChannelBytes(7, 1)).toBe(36);
+    expect(copcDecodedChannelBytes(6, 1)).toBe(27);
+    expect(copcDecodedChannelBytes(8, 1)).toBe(36);
+  });
+
+  test('decompressChunk refuses the node BEFORE any _malloc or decode', () => {
+    // A lazPerf stub whose every entry point throws: reaching it would prove the
+    // guard ran too late. The guard must throw the budget LoadError first.
+    const trap = () => {
+      throw new Error('laz-perf was touched — guard ran too late');
+    };
+    const lazPerfTrap = {
+      _malloc: trap,
+      _free: trap,
+      HEAPU8: new Uint8Array(0),
+      ChunkDecoder: function ChunkDecoder() {
+        trap();
+      },
+    } as unknown as Parameters<typeof decompressChunk>[0];
+
+    // A real 70 MiB compressed buffer backs the 3M declared points (floor
+    // 36/50 = 0.72 B/pt admits ~101M, so the count is plausible for the bytes).
+    const chunk = new Uint8Array(COMPRESSED);
+    let thrown: unknown;
+    try {
+      decompressChunk(lazPerfTrap, chunk, META());
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(LoadError);
+    expect((thrown as LoadError).message).toMatch(/decode budget/i);
+    expect((thrown as LoadError).message).not.toMatch(/laz-perf was touched/);
+  });
+
+  test('a node that fits both phases is admitted by the estimate', () => {
+    // 500k PDRF-7 points, 12 MiB compressed: phase1 = 24 + 17.2 = 41.2 MiB,
+    // phase2 = 12 + 17.2 + 17.2 = 46.4 MiB — both well under budget.
+    const peak = estimateCopcPeakBytes(META({ pointCount: 500_000 }), 12 * MiB, 500_000);
+    expect(peak).toBeLessThan(MAX_DECODE_PEAK_BYTES);
+  });
+});
+
+// ── BLOCKER 2 — EPT binary decoded-peak ──────────────────────────────────────
+
+describe('EPT binary decode — the decoded arrays are bounded with the body', () => {
+  // A wide schema at ~31 raw bytes a point: XYZ int32 (12), Intensity u16 (2),
+  // Classification/ReturnNumber/NumberOfReturns u8 (3), GpsTime f64 (8),
+  // RGB u16 (6). Stride 31.
+  const WIDE: EptSchemaField[] = [
+    { name: 'X', size: 4, type: 'signed', scale: 0.01, offset: 0 },
+    { name: 'Y', size: 4, type: 'signed', scale: 0.01, offset: 0 },
+    { name: 'Z', size: 4, type: 'signed', scale: 0.01, offset: 0 },
+    { name: 'Intensity', size: 2, type: 'unsigned' },
+    { name: 'Classification', size: 1, type: 'unsigned' },
+    { name: 'ReturnNumber', size: 1, type: 'unsigned' },
+    { name: 'NumberOfReturns', size: 1, type: 'unsigned' },
+    { name: 'GpsTime', size: 8, type: 'float' },
+    { name: 'Red', size: 2, type: 'unsigned' },
+    { name: 'Green', size: 2, type: 'unsigned' },
+    { name: 'Blue', size: 2, type: 'unsigned' },
+  ];
+  const STRIDE = 31;
+
+  test('the peak charges body + every decoded channel + rgb16 staging', () => {
+    // Per point decoded: positions 12 + intensity 2 + class 1 + retNum 1 +
+    // retCnt 1 + gps 8 + rgb 3 = 28, plus 6 for the uniform-16-bit rgb16 staging.
+    const bodyBytes = 100 * STRIDE;
+    const peak = eptBinaryPeakBytes(bodyBytes, 100, {
+      intensity: true,
+      classification: true,
+      returnNumber: true,
+      returnCount: true,
+      gpsTime: true,
+      rgb: true,
+      rgb16Staging: true,
+    });
+    expect(peak).toBe(bodyBytes + 100 * (28 + 6));
+  });
+
+  test('a wide-schema tile over the budget is refused before typed-array allocation', () => {
+    // 4,200,000 points × 31 raw = ~124 MiB body. Peak = body + decoded(28) +
+    // rgb16(6) = 65 B/point = ~273 MiB, over the 256 MiB budget. The body alone
+    // is well under the transport tile cap, so only the decoded-peak guard stops
+    // it. We pass the shared budget explicitly and confirm the throw.
+    const points = 4_200_000;
+    expect(points * 65).toBeGreaterThan(MAX_DECODE_PEAK_BYTES);
+    expect(points * STRIDE).toBeLessThan(MAX_DECODE_PEAK_BYTES);
+
+    // The guard runs before allocation, so a tile buffer that is too SHORT for
+    // the schema would normally throw the truncation error first; the peak guard
+    // must fire ahead of both the length check's allocation and the arrays. Give
+    // it an exact-size body so the only refusal available is the peak one.
+    const body = new ArrayBuffer(points * STRIDE);
+    let thrown: unknown;
+    try {
+      decodeEptBinaryTile(body, points, WIDE, [0, 0, 0]);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(LoadError);
+    expect((thrown as LoadError).category).toBe('memory-constraint');
+    expect((thrown as LoadError).message).toMatch(/decode budget/i);
+  });
+
+  test('a small tile of the same schema still decodes', () => {
+    const points = 4;
+    const body = new ArrayBuffer(points * STRIDE);
+    const decoded = decodeEptBinaryTile(body, points, WIDE, [0, 0, 0]);
+    expect(decoded.pointCount).toBe(points);
+    expect(decoded.positions.length).toBe(points * 3);
+  });
+});
+
+// ── BLOCKER 3a — PNTS total peak (body + decoded) ────────────────────────────
+
+describe('PNTS decode — the admission is a total peak, not decoded bytes alone', () => {
+  /** A valid position-only PNTS tile carrying its float32 POSITION binary. */
+  function positionOnlyPnts(points: number): ArrayBuffer {
+    const HEADER = 28;
+    const featureTable = JSON.stringify({ POINTS_LENGTH: points, POSITION: { byteOffset: 0 } });
+    const padded = featureTable.padEnd(Math.ceil(featureTable.length / 4) * 4, ' ');
+    const ftJson = new TextEncoder().encode(padded);
+    const ftBinLen = points * 12; // Float32 · 3
+    const buffer = new ArrayBuffer(HEADER + ftJson.length + ftBinLen);
+    const view = new DataView(buffer);
+    view.setUint32(0, 0x73746e70, true); // "pnts"
+    view.setUint32(4, 1, true);
+    view.setUint32(8, buffer.byteLength, true);
+    view.setUint32(12, ftJson.length, true);
+    view.setUint32(16, ftBinLen, true);
+    view.setUint32(20, 0, true);
+    view.setUint32(24, 0, true);
+    new Uint8Array(buffer, HEADER, ftJson.length).set(ftJson);
+    // Binary stays zero-filled: valid float32 zeros, a legitimate tile.
+    return buffer;
+  }
+
+  const POINTS = 100_000;
+
+  test('decoded-only would admit, but body + decoded exceeds the budget', () => {
+    const tile = positionOnlyPnts(POINTS);
+    const decodedBytes = POINTS * 12; // positions only
+    const bodyBytes = tile.byteLength; // ~= decodedBytes + header/json
+    // A budget above decoded alone but below the true peak — the exact gap the
+    // old decoded-only check ignored.
+    const budget = decodedBytes + Math.floor(bodyBytes / 2);
+    expect(decodedBytes).toBeLessThan(budget); // OLD (decoded-only) admits
+    expect(bodyBytes + decodedBytes).toBeGreaterThan(budget); // NEW (peak) refuses
+
+    expect(() => parsePnts(tile, { maxDecodedBytes: budget })).toThrow(/decoded byte/i);
+  });
+
+  test('a budget above the whole peak still decodes the tile', () => {
+    const tile = positionOnlyPnts(POINTS);
+    const peak = tile.byteLength + POINTS * 12;
+    const decoded = parsePnts(tile, { maxDecodedBytes: peak + 1024 });
+    expect(decoded.pointsLength).toBe(POINTS);
+  });
+});
+
+// ── BLOCKER 3b — unknown-length assembly ceiling ─────────────────────────────
+
+describe('readAtMostBounded — unknown-length bodies held below the peak policy', () => {
+  /** A streaming Response with no Content-Length, emitting `chunks` in order. */
+  function unknownLengthResponse(chunks: Uint8Array[]): Response {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(c);
+        controller.close();
+      },
+    });
+    return new Response(body, { headers: {} });
+  }
+
+  test('an unknown-length body above 64 MiB is refused even when maxBytes is 256 MiB', async () => {
+    // Two 40 MiB chunks: 80 MiB total, under the caller's 256 MiB ceiling but
+    // over the 64 MiB unknown-length ceiling that keeps the ~2x join in policy.
+    const chunk = new Uint8Array(40 * MiB);
+    const response = unknownLengthResponse([chunk, new Uint8Array(40 * MiB)]);
+    let thrown: unknown;
+    try {
+      await readAtMostBounded(response, 256 * MiB, 'EPT tile', {});
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BoundedReadError);
+    expect((thrown as BoundedReadError).message).toMatch(/unknown-length limit/i);
+    expect(MAX_UNKNOWN_LENGTH_BODY_BYTES).toBe(64 * MiB);
+  });
+
+  test('an unknown-length body under the ceiling still reads', async () => {
+    const response = unknownLengthResponse([new Uint8Array(8 * MiB), new Uint8Array(8 * MiB)]);
+    const bytes = await readAtMostBounded(response, 256 * MiB, 'EPT tile', {});
+    expect(bytes.byteLength).toBe(16 * MiB);
+  });
+
+  test('an honest identity Content-Length keeps the large streaming fast path', async () => {
+    // 80 MiB declared honestly: the declared-length branch streams into one
+    // exact target and never touches the unknown-length ceiling.
+    const size = 80 * MiB;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(size));
+        controller.close();
+      },
+    });
+    const response = new Response(body, { headers: { 'content-length': String(size) } });
+    const bytes = await readAtMostBounded(response, 256 * MiB, 'EPT tile', {});
+    expect(bytes.byteLength).toBe(size);
+  });
+});
+
+// ── SMALL BUG — Content-Length 0 with a stray body byte ──────────────────────
+
+describe('readAtMostBounded — Content-Length 0 with a stray byte', () => {
+  test('surfaces the bounded-read error, not a raw RangeError from .set()', async () => {
+    // declared === 0 takes the declared-length branch and allocates
+    // Uint8Array(0). The `filled + value.byteLength > declared` check must fire
+    // before ensureCapacity/out.set, so a stray byte is the typed
+    // "sent more than its declared" refusal, not a generic RangeError.
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([0x42]));
+        controller.close();
+      },
+    });
+    const response = new Response(body, { headers: { 'content-length': '0' } });
+    let thrown: unknown;
+    try {
+      await readAtMostBounded(response, 16 * MiB, 'EPT manifest', {});
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BoundedReadError);
+    expect(thrown).not.toBeInstanceOf(RangeError);
+    expect((thrown as BoundedReadError).message).toMatch(/declared/i);
+  });
+});


### PR DESCRIPTION
A release audit found the decode-memory guards bound the first decode phase and individual caps but not the coexisting total across the second phase or the body plus decoded pair. Four paths admitted oversized inputs.

COPC second phase (blocker 1). The guard charged only laz-perf phase one (2*Bc + B_raw). decodeRecords then coexists Bc + B_raw + B_channels, where B_channels is a second raw-sized copy. A PDRF 7 node of 3,000,000 points, 36-byte records, 70 MiB compressed passed phase one (~243 MiB) but peaked ~276 MiB. estimateCopcPeakBytes now returns the max of both phases and refuses before any malloc.

EPT binary (blocker 2). The tile-body cap did not bound the decoded channel arrays that fill while the raw body is resident. decodeEptBinaryTile now charges body + decoded channels + rgb16 staging before allocation.

PNTS total peak (blocker 3a). The mobile decoded ceiling counted only decoded channels, not the raw tile body. Admission is now body + decoded, so a position-only tile whose decoded half fit the ceiling is refused on its real peak.

Unknown-length assembly (blocker 3b). The unknown-length branch concatenates chunks and peaks at ~2x. It is now capped at 64 MiB so assembly stays inside the 256 MiB policy; the honest identity Content-Length fast path is unchanged.

Small bug: confirmed the Content-Length 0 stray-byte path already returns the bounded-read error before the growth allocation; added a regression test.

Red-green tests for each path plus the helper arithmetic. tsc clean; touched buckets pass.