### PR TITLE
fix: bound declared-length transport peak and cap PNTS transport per device

### DIFF
--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -34,7 +34,7 @@ import { LoadCancelledError } from '../io/loadFile';
 import { describeLoadError } from '../io/loadErrors';
 import { expandImplicitTileset } from '../io/tiles3d/implicitExpand';
 import { parseTileset } from '../io/tiles3d/tileset';
-import { createTilesetTransport } from '../io/tiles3d/tilesetTransport';
+import { createTilesetTransport, pntsDeviceTransportCap } from '../io/tiles3d/tilesetTransport';
 import { validateRemoteTilesetUrl } from '../io/tiles3d/tilesetUrl';
 import { PntsChunkDecoder } from '../io/tiles3d/pntsDecode';
 import { pntsDeviceDecodeLimits } from '../io/tiles3d/pnts';
@@ -164,7 +164,13 @@ export async function openRemoteTileset(
     // the router only pattern-matches a path ending in tileset.json.
     const entry = validateRemoteTilesetUrl(url);
     if (!entry.ok) throw new TilesetRefusal(entry.reason);
-    const transport = createTilesetTransport();
+    // A device-sized `.pnts` transport cap from the same PNTS peak policy the
+    // decode step uses: on a phone a legal-but-large tile is refused before its
+    // body is fetched, not downloaded to the desktop 128 MiB ceiling and then
+    // refused at decode. Desktop keeps 128 MiB.
+    const transport = createTilesetTransport({
+      maxTileBytes: pntsDeviceTransportCap(deps.isPhone()),
+    });
     const json = await transport.fetchTilesetJson(url, controller.signal);
     let tileset;
     try {

--- a/src/io/range/boundedRead.ts
+++ b/src/io/range/boundedRead.ts
@@ -69,11 +69,15 @@ export const DEFAULT_TOTAL_TIMEOUT_MS = 300_000;
  * tile) with a header alone, before delivering a single meaningful byte. The
  * eager allocation only pays off when the body actually arrives; a lie earns a
  * free quarter-gigabyte. This bounds the immediate allocation to a small initial
- * size and grows toward `declared` in doublings as bytes truly arrive, still
- * refusing anything past `declared`. An honest small body (declared at or below
- * this) is still one allocation; a large honest one costs a handful of doublings
- * against the memory it is actually filling. 16 MiB keeps the common case
- * single-shot while capping what a header alone can reserve.
+ * size; only once this many GENUINE bytes have arrived (confirming a substantial
+ * real body, not a header claim) does the reader allocate exactly `declared`
+ * once and stream the remainder straight into it, still refusing anything past
+ * `declared`. An honest small body (declared at or below this) is one allocation
+ * and is never reallocated; a large honest one pays a single final copy, so the
+ * transient peak is about `declared + MAX_DECLARED_PREALLOC_BYTES` rather than
+ * the ~1.5x declared that continued doubling would hold at its last step.
+ * 16 MiB keeps the common case single-shot while capping what a header alone can
+ * reserve.
  */
 export const MAX_DECLARED_PREALLOC_BYTES = 16 * 1024 * 1024;
 
@@ -467,20 +471,27 @@ export async function readAtMostBounded(
   // content-encoding, so a compressed length can never drive this branch.
   if (declared !== null) {
     // Allocate only a bounded initial buffer, never the whole declared size up
-    // front: a large `declared` is a claim, not yet bytes. The buffer grows in
-    // doublings toward `declared` as real bytes land, so a server that declares
-    // 256 MiB and then sends a kilobyte reserves a kilobyte's worth, not the
-    // whole claim. `declared` is already known `<= maxBytes`.
+    // front: a large `declared` is a claim, not yet bytes. `declared` is already
+    // known `<= maxBytes`. A small honest body (declared at or below the prealloc
+    // bound) fits this one buffer and is never reallocated.
     let out = new Uint8Array(Math.min(declared, MAX_DECLARED_PREALLOC_BYTES));
     let filled = 0;
-    // Grow `out` so it can hold at least `needed` bytes, doubling until it does
-    // and never past `declared` (which is the hard ceiling for this branch).
+    // Grow `out` so it can hold at least `needed` bytes. The initial buffer is
+    // `min(declared, PREALLOC)`, so this only ever fires when `declared` exceeds
+    // the prealloc bound AND real bytes have filled it — i.e. at least
+    // MAX_DECLARED_PREALLOC_BYTES of genuine body have already arrived,
+    // confirming a substantial real body rather than a header alone. At that
+    // point allocate exactly `declared` ONCE and stream the remainder straight
+    // in, instead of doubling. Doubling's final step held the old and new
+    // buffers together at ~1.5x declared (a 128 MiB body peaked ~192 MiB); a
+    // single final allocation bounds the transient peak to about
+    // `declared + MAX_DECLARED_PREALLOC_BYTES`. A trickle under the prealloc
+    // bound never reaches here, so a header claim alone can never force the
+    // large allocation. `declared` is the hard ceiling (over-declared bodies are
+    // refused before this), so one allocation suffices — no growth loop.
     const ensureCapacity = (needed: number): void => {
       if (needed <= out.length) return;
-      let next = Math.max(out.length, 1);
-      while (next < needed) next *= 2;
-      if (next > declared) next = declared;
-      const bigger = new Uint8Array(next);
+      const bigger = new Uint8Array(declared);
       bigger.set(out.subarray(0, filled));
       out = bigger;
     };

--- a/src/io/tiles3d/tilesetTransport.ts
+++ b/src/io/tiles3d/tilesetTransport.ts
@@ -25,6 +25,7 @@
 
 import { sanitizeUrlForDisplay } from '../range/RangeSource';
 import { ownedExactBuffer, readAtMostBounded, readTextAtMost } from '../range/boundedRead';
+import { MAX_PNTS_DECODED_BYTES, pntsDeviceDecodeLimits } from './pnts';
 
 /**
  * Best-effort cancel a response body we are about to abandon (a retryable error
@@ -60,6 +61,24 @@ export const MAX_TILESET_JSON_BYTES = 8 * 1024 * 1024;
  * from a writer that produced unusually large tiles.
  */
 export const MAX_PNTS_TILE_BYTES = 128 * 1024 * 1024;
+/**
+ * The transport ceiling for one `.pnts` body on this device.
+ *
+ * {@link MAX_PNTS_TILE_BYTES} is the desktop cap; the DECODE step is already
+ * device-aware ({@link pntsDeviceDecodeLimits}), so a phone left at the desktop
+ * transport cap would DOWNLOAD a tile up to 128 MiB only to refuse it at decode
+ * on its true size. This derives the transport cap from the SAME PNTS device
+ * peak policy rather than inventing a separate mobile number: it scales the
+ * desktop transport cap by the device's decoded-byte budget ratio, so the
+ * transport ceiling tracks the decode ceiling. Desktop's ratio is 1 and it
+ * stays at 128 MiB; mobile's 96 MiB decode budget is half the 192 MiB desktop
+ * budget, so the mobile transport cap is 64 MiB. A body a phone could never hold
+ * is then refused before its bytes are fetched, not after.
+ */
+export function pntsDeviceTransportCap(isMobile: boolean): number {
+  const { maxDecodedBytes } = pntsDeviceDecodeLimits(isMobile);
+  return Math.round(MAX_PNTS_TILE_BYTES * (maxDecodedBytes / MAX_PNTS_DECODED_BYTES));
+}
 /**
  * Ceiling for one `.subtree` body.
  *

--- a/tests/boundedRead.test.ts
+++ b/tests/boundedRead.test.ts
@@ -235,6 +235,41 @@ describe('readAtMostBounded — declared length does not eagerly allocate', () =
     expect(overPrealloc).toBe(0);
   });
 
+  it('a large declared body allocates one big buffer, not the ~1.5x doubling peak', async () => {
+    // 128 MiB delivered in chunks. Doubling grew 16->32->64->128 MiB and held
+    // the old and new buffers together at the last step (~192 MiB, 1.5x). The
+    // single-final-allocation path must construct exactly ONE buffer larger than
+    // the prealloc bound, sized exactly `declared`, so the large-allocation
+    // total is `declared` (128 MiB), not ~1.5x it.
+    const declared = 128 * 1024 * 1024;
+    const chunk = 8 * 1024 * 1024;
+    const Real = globalThis.Uint8Array;
+    const largeAllocs: number[] = [];
+    class U8 extends Real {
+      constructor(...args: unknown[]) {
+        if (typeof args[0] === 'number' && args[0] > MAX_DECLARED_PREALLOC_BYTES) {
+          largeAllocs.push(args[0]);
+        }
+        // @ts-expect-error forward whatever the reader passed
+        super(...args);
+      }
+    }
+    (globalThis as { Uint8Array: unknown }).Uint8Array = U8;
+    let out: Uint8Array;
+    try {
+      const parts: Uint8Array[] = [];
+      for (let at = 0; at < declared; at += chunk) parts.push(bytes(chunk, 3));
+      const resp = streamingResponse(parts, { 'content-length': String(declared) });
+      out = await readAtMostBounded(resp, 256 * 1024 * 1024, 'EPT tile');
+    } finally {
+      (globalThis as { Uint8Array: unknown }).Uint8Array = Real;
+    }
+    expect(out.byteLength).toBe(declared);
+    // Exactly one large buffer, sized exactly `declared` — never a second big
+    // buffer coexisting, so the transient peak is `declared + prealloc`, not 1.5x.
+    expect(largeAllocs).toEqual([declared]);
+  });
+
   it('an honest large body still delivers every byte via bounded growth', async () => {
     // 40 MiB actually delivered in chunks, declared honestly: the growth path
     // must reach the full size and return all of it.

--- a/tests/tiles3dTilesetTransport.test.ts
+++ b/tests/tiles3dTilesetTransport.test.ts
@@ -10,10 +10,38 @@
 
 import { describe, expect, test } from 'vitest';
 import { bodyCancelFetch } from './helpers/bodyCancelFetch';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import {
   createTilesetTransport,
+  pntsDeviceTransportCap,
+  MAX_PNTS_TILE_BYTES,
   TilesetTimeoutError,
 } from '../src/io/tiles3d/tilesetTransport';
+
+describe('pntsDeviceTransportCap — the .pnts transport cap tracks the device decode budget', () => {
+  test('desktop keeps the full 128 MiB tile ceiling', () => {
+    expect(pntsDeviceTransportCap(false)).toBe(MAX_PNTS_TILE_BYTES);
+    expect(pntsDeviceTransportCap(false)).toBe(128 * 1024 * 1024);
+  });
+
+  test('a phone gets half the ceiling, matching the halved mobile decode budget', () => {
+    // Mobile decode budget is 96 MiB vs the 192 MiB desktop budget, so the
+    // transport cap is scaled to half: 64 MiB. A legal-but-large tile a phone
+    // cannot hold is refused before its body is fetched, not after decode.
+    expect(pntsDeviceTransportCap(true)).toBe(64 * 1024 * 1024);
+  });
+
+  test('the open path wires the device cap into the transport it builds', () => {
+    const src = readFileSync(
+      fileURLToPath(new URL('../src/app/openTilesetLayer.ts', import.meta.url)),
+      'utf8',
+    );
+    const call = src.match(/createTilesetTransport\(\{[^;]{0,200}\}\)/);
+    expect(call, 'openTilesetLayer no longer configures createTilesetTransport').not.toBeNull();
+    expect(call?.[0]).toMatch(/maxTileBytes:\s*pntsDeviceTransportCap\(deps\.isPhone\(\)\)/);
+  });
+});
 
 /** A fetch returning a scripted sequence of responses. */
 function scriptedFetch(


### PR DESCRIPTION
Two v0.6.7 memory-model blockers.

**Declared-length assembly peak (src/io/range/boundedRead.ts).** The declared-length branch of `readAtMostBounded` grew its buffer toward `declared` by doubling, so the final doubling held the old and new buffers together at about 1.5x declared (a 128 MiB body peaked near 192 MiB; a 256 MiB EPT body near 384 MiB), above the transport peak policy. The bounded initial prealloc stays: no allocation of `declared` from the header alone. Once genuine bytes fill that 16 MiB prealloc (so a header claim or a sub-16 MiB trickle never triggers it), the reader allocates exactly `declared` once and streams the remainder straight in. Transient peak is now about `declared + 16 MiB`. Over-declared and short-body refusals unchanged.

**Device-aware PNTS transport cap (src/app/openTilesetLayer.ts).** The open built the tileset transport with no `maxTileBytes`, defaulting to 128 MiB even on a phone, while PNTS decode was already device-aware, so a phone downloaded a tile it then refused at decode. New `pntsDeviceTransportCap` derives the cap from the same decode budget: desktop 128 MiB, mobile 64 MiB (half, matching the halved mobile decode budget).

Tests: red-green pinned in tests/boundedRead.test.ts (one big buffer, not 1.5x) and tests/tiles3dTilesetTransport.test.ts (device caps + open-path wiring). `tsc --noEmit` clean; boundedRead, tiles3dTilesetTransport, decodePeakMemoryModel, eptManifestBound, tileset streaming/open/lint buckets pass.