### PR TITLE
Stop the profile mini-chart clipping in a narrow measurement row

### DIFF
--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -132,7 +132,10 @@
   height: 280px;
   min-height: 160px;
   max-height: 640px;
-  min-width: 180px;
+  /* min-width:0 so the chart fills its measurement-row column instead of being
+     forced to 180px and overflowing (clipping the curve tail and last x label)
+     when the row's bullet and gap make that column narrower than the panel. */
+  min-width: 0;
   max-width: 100%;
   resize: vertical;
   overflow: hidden;

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -4513,7 +4513,10 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   height: 280px;
   min-height: 160px;
   max-height: 640px;
-  min-width: 180px;
+  /* min-width:0 so the chart fills its measurement-row column instead of being
+     forced to 180px and overflowing (clipping the curve tail and last x label)
+     when the row's bullet and gap make that column narrower than the panel. */
+  min-width: 0;
   max-width: 100%;
   resize: vertical;
   overflow: hidden;


### PR DESCRIPTION
The profile measurement mini-chart could be clipped on the right (curve tail and last x-axis label cut off) when the measurement row was narrow.

Cause: .olv-mp-chart (src/styles/74-inspector-profile.css) set width:100% together with min-width:180px. Inside a profile measurement row the chart's flex column is narrower than the panel because the row carries a status bullet and gap, so the 180px floor forced the chart wider than its column and an ancestor's overflow clipped the excess. min-width is now 0, so the chart fills its actual column and stays fully visible; the SVG already stretches with preserveAspectRatio=none, so the curve is not distorted.

Regenerated tests/fixtures/style.css.original; styleCssPartition test passes (byte-for-byte partition intact).