### PR TITLE
State the real reason an E4 product is exploratory in export notes

### DIFF
--- a/src/terrain/export/exportProvenance.ts
+++ b/src/terrain/export/exportProvenance.ts
@@ -36,7 +36,8 @@ import {
 } from '../contour/terrainAssessment';
 import { readinessLine } from '../quality/readinessEngine';
 import { contourShapeStyleLabel, type ContourShapeStyle } from '../contour/contourShapeStyle';
-import { exportGate } from '../../validation/evidenceRegistry';
+import { exportGate, EVIDENCE_REGISTRY } from '../../validation/evidenceRegistry';
+import { evidenceRank, INDEPENDENCE_FLOOR } from '../../validation/evidenceLevel';
 import { buildIdentityProvenance } from '../../build/buildIdentity';
 import { methodRef, methodTag } from '../../science/methodRegistry';
 import {
@@ -78,9 +79,11 @@ export { NOT_SURVEY_GRADE_NOTE };
  * on the artifact so a downstream reader sees the gate verdict, per the evidence
  * model. When a product reaches its required level the note flips automatically.
  */
-export const EVIDENCE_GATE_NOTE: string = exportGate('DTM').exploratoryOnly
-  ? 'Evidence: exploratory export. Terrain products are validated only against synthetic known-truth (pre-E4) — not cross-validated against an independent tool, and not field-validated. Do not present as a validated deliverable.'
-  : 'Evidence: meets the required validation level for this product.';
+export const EVIDENCE_GATE_NOTE: string = !exportGate('DTM').exploratoryOnly
+  ? 'Evidence: meets the required validation level for this product.'
+  : evidenceRank(EVIDENCE_REGISTRY['DTM'].current) >= evidenceRank(INDEPENDENCE_FLOOR)
+    ? 'Evidence: exploratory export. The terrain products are cross-implementation validated against independent tools, but the DTM has not reached its required external field-validation level and is not field-validated against ground control. Do not present as a validated deliverable.'
+    : 'Evidence: exploratory export. Terrain products are validated only against synthetic known-truth (pre-E4) — not cross-validated against an independent tool, and not field-validated. Do not present as a validated deliverable.';
 
 /**
  * Derived terrain-complexity record (v0.5.4), present only when the run

--- a/src/validation/exportEvidenceNote.ts
+++ b/src/validation/exportEvidenceNote.ts
@@ -17,7 +17,8 @@
  * Pure data. No DOM, no I/O.
  */
 
-import { exportGate } from './evidenceRegistry';
+import { exportGate, EVIDENCE_REGISTRY } from './evidenceRegistry';
+import { evidenceRank, INDEPENDENCE_FLOOR } from './evidenceLevel';
 
 /**
  * The evidence note for a product identified by its claim id. Derived from the
@@ -27,11 +28,26 @@ import { exportGate } from './evidenceRegistry';
 export function evidenceNote(claimId: string): string {
   const d = exportGate(claimId);
   if (d.exploratoryOnly) {
-    return (
-      'Evidence: exploratory export — this product is below its required evidence ' +
-      'level (not cross-validated against an independent implementation, and not ' +
-      'field-validated). Do not present it as a validated deliverable.'
-    );
+    // A product can be exploratory for two different reasons, and conflating
+    // them understates the evidence: it may sit below the independence floor
+    // (genuinely not cross-validated), or it may be cross-implementation
+    // validated (E4) yet still below a higher required level (E5 field). Name
+    // the real reason from the product's current level.
+    const current = EVIDENCE_REGISTRY[claimId]?.current;
+    const crossValidated =
+      current != null && evidenceRank(current) >= evidenceRank(INDEPENDENCE_FLOOR);
+    return crossValidated
+      ? (
+        'Evidence: exploratory export — this product is cross-implementation ' +
+        'validated against an independent implementation, but below its required ' +
+        'level (not field-validated against ground control). Do not present it ' +
+        'as a validated deliverable.'
+      )
+      : (
+        'Evidence: exploratory export — this product is below its required evidence ' +
+        'level (not cross-validated against an independent implementation, and not ' +
+        'field-validated). Do not present it as a validated deliverable.'
+      );
   }
   if (d.allowed) {
     return 'Evidence: validated export — this product meets its required evidence level.';


### PR DESCRIPTION
Found while checking an exported terrain report against its sibling map sheet: the two disagreed. The map sheet correctly said the contour geometry is cross-implementation validated, but the terrain report said terrain products are pre-E4 and not cross-validated against an independent tool.

That report wording is stale. The claim register has DTM, contours, TPI and VRM at E4 (cross-implementation validated against PDAL, gdaldem and SAGA). The DTM export is still exploratory because its required level is E5 external field validation and it sits at E4, not because it is pre-E4.

Both exploratory notes (exportEvidenceNote.ts and the EVIDENCE_GATE_NOTE in exportProvenance.ts) now read the product's current level: an E4 product below its required level reads as cross-implementation validated but not field-validated against ground control; a genuinely pre-E4 product keeps the old wording. tsc clean; export, evidence and PDF tests pass (64); archive-vocab and claims-language lints pass.