### PR TITLE
fix(measure): align Measurements panel to the rail and stop horizontal scroll

### DIFF
--- a/src/styles/72-panel-rails.css
+++ b/src/styles/72-panel-rails.css
@@ -41,7 +41,8 @@
    each panel's own legacy width (Analyse 285 / Classes 248 / Export·Clip·
    Annotate·Measure 218) without editing them one by one. Desktop only — the
    mobile bottom-sheet reparents these panels and owns their sizing. The Measure
-   panel stays user-resizable: a drag writes an inline width that wins over this. */
+   panel stays user-resizable, but its SE grip widens the RAIL (`--olv-rail-width`)
+   rather than the panel alone, so every card widens together and stays flush. */
 @media (min-width: 768px) {
   .olv-left-panels:not(.olv-rail-collapsed) > * {
     width: 100%;

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -7,19 +7,27 @@
   box-shadow: var(--shadow-raised);
 }
 .olv-measure-panel {
-  /* 222px, not 218. Measured: the content box is width minus 26px of padding
-     and border, and the widest row (CSV / Export PDF / Clear profile) needs
-     193px. At 218 that left 192 and clipped the last label by a pixel. */
-  width: 222px; box-sizing: border-box;
-  /* Drag the south-east grip (`.olv-mp-resize`) to widen the panel (and the
-   * profile chart inside it) rightward into the canvas. `overflow: auto` keeps
-   * the native `resize: horizontal` as a fallback; the chosen width is
-   * persisted. `position: relative` anchors the explicit grip, which rides
-   * ABOVE the rail collapse tab that otherwise covers the native corner. */
+  /* Fills the left rail instead of carrying its own fixed width, so the
+     workspace tabs (DATA / WORK / ANALYSE / OUTPUT), the Clip box card and this
+     panel share one width and one right edge. The rail is `--olv-rail-width`
+     (72-panel-rails.css), a clamp(285px, 21vw, 312px) that the SE grip widens by
+     rewriting `--olv-rail-width` for the whole column, so a resize keeps the
+     stack flush. `min-width: 0` lets the panel shrink on the mobile sheet;
+     `max-width: 100%` keeps it inside the rail. The old 222px fixed width sat
+     narrower than the tabs (the source of the misalignment) and cramped the
+     readouts. */
+  width: 100%; min-width: 0; max-width: 100%; box-sizing: border-box;
+  /* `position: relative` anchors the explicit SE grip (`.olv-mp-resize`), which
+   * rides ABOVE the rail collapse tab that otherwise covers the native corner.
+   * The grip resizes the rail width, not this panel alone, so alignment holds. */
   position: relative;
-  min-width: 222px; max-width: 760px;
-  resize: horizontal; overflow: auto;
-  /* `overflow: auto` (needed for the horizontal resize + scrollbar-gutter) drops
+  /* `overflow-x: hidden` makes a horizontal scrollbar structurally impossible:
+     the panel must never require sideways scrolling to see its own readouts,
+     Clip box, or y-axis labels. `scrollbar-gutter: stable` still reserves the
+     vertical track. Any readout wider than the content box wraps (see
+     `.olv-mp-value`) rather than being scrolled to. */
+  overflow-x: hidden; overflow-y: auto;
+  /* `overflow-y: auto` (needed for the vertical scroll + scrollbar-gutter) drops
    * this flex child's automatic min-height to 0, so the left column's flex layout
    * would shrink the panel to just its header whenever the column runs out of
    * room. That happens acutely for an object/interior scan, where the tall

--- a/src/ui/MeasurePanel.ts
+++ b/src/ui/MeasurePanel.ts
@@ -102,11 +102,16 @@ const PROFILE_CHART_HEIGHT_KEY = 'olv:measure:profile:chartHeightPx:v1';
  * (`.olv-mp-chart { min-height: 160px; }`); the
  * `profileChartHeightBounds.test.ts` spec pins the two against drift.
  */
-/** Panel-width resize bounds (drag the SE handle to widen the profile chart).
- *  Mirror of the CSS min/max-width on `.olv-measure-panel`. */
-export const MEASURE_PANEL_MIN_WIDTH_PX = 218;
-export const MEASURE_PANEL_MAX_WIDTH_PX = 760;
-const MEASURE_PANEL_WIDTH_KEY = 'olv:measure:panel:widthPx:v1';
+/** Left-rail width resize bounds. The Measurements panel fills the rail rather
+ *  than carrying its own width, so dragging its SE grip widens the whole rail
+ *  (`--olv-rail-width`): the workspace tabs and every left card widen together
+ *  and stay flush. The floor matches the CSS clamp floor (285px) so the rail is
+ *  never narrower than the widest panel was built for; the ceiling keeps the
+ *  viewport dominant at laptop widths. */
+export const RAIL_MIN_WIDTH_PX = 285;
+export const RAIL_MAX_WIDTH_PX = 480;
+const RAIL_WIDTH_KEY = 'olv:rail:widthPx:v1';
+const RAIL_WIDTH_VAR = '--olv-rail-width';
 
 export const PROFILE_CHART_MIN_HEIGHT_PX = 160;
 /** Upper bound on the resizable profile chart height. See
@@ -349,8 +354,6 @@ export class MeasurePanel {
   private _summaries: MeasurementSummary[] = [];
   /** Persistent geographic-CRS caveat, toggled via {@link setGeographicNotice}. */
   private readonly _geoNotice: HTMLElement;
-  /** Observer that persists the user's dragged panel width. */
-  private _panelWidthObserver?: ResizeObserver;
   /**
    * Active `ResizeObserver` instances created for the profile-chart
    * persistence path. Each `_renderList()` call detaches and replaces
@@ -488,14 +491,34 @@ export class MeasurePanel {
     // so the panel looked resizable but wasn't. This grip rides ABOVE the tab
     // and drives the same width the ResizeObserver already persists.
     this.element.append(this._buildResizeHandle());
-    this._restorePanelWidth();
+    this._restoreRailWidth();
+  }
+
+  /** Current left-rail width in CSS pixels: the measured column width, which
+   *  reflects the clamp default or any persisted override. */
+  private _railWidthPx(): number {
+    const rail = this.element.closest('.olv-left-panels') as HTMLElement | null;
+    return rail?.offsetWidth ?? this.element.offsetWidth;
+  }
+
+  /** Write and persist the left-rail width, clamped to the rail bounds. The var
+   *  drives the column width AND the grabber-tab offset, so the tabs and every
+   *  left card widen together and the stack stays flush. */
+  private _setRailWidth(w: number): void {
+    const clamped = Math.min(
+      RAIL_MAX_WIDTH_PX,
+      Math.max(RAIL_MIN_WIDTH_PX, Math.round(w)),
+    );
+    document.documentElement.style.setProperty(RAIL_WIDTH_VAR, `${clamped}px`);
+    storageSet(RAIL_WIDTH_KEY, String(clamped));
   }
 
   /**
-   * The panel's own south-east resize grip, raised above the rail collapse tab
-   * that covers the native handle. A pointer drag (or arrow keys) rewrites the
-   * panel width within the CSS bounds; the width observer in `_restorePanelWidth`
-   * picks up the change and persists it, so no separate save path is needed.
+   * The panel's south-east resize grip, raised above the rail collapse tab that
+   * covers the native handle. A pointer drag (or arrow keys) rewrites the RAIL
+   * width, not this panel alone: the panel fills the rail, so widening the rail
+   * widens the tabs, the Clip box card and this panel together and keeps their
+   * shared right edge aligned.
    */
   private _buildResizeHandle(): HTMLElement {
     const handle = el('div', {
@@ -507,16 +530,10 @@ export class MeasurePanel {
     handle.setAttribute('aria-orientation', 'vertical');
     handle.tabIndex = 0;
 
-    const clamp = (w: number): number =>
-      Math.min(
-        MEASURE_PANEL_MAX_WIDTH_PX,
-        Math.max(MEASURE_PANEL_MIN_WIDTH_PX, Math.round(w)),
-      );
-
     let startX = 0;
     let startW = 0;
     const onMove = (e: PointerEvent): void => {
-      this.element.style.width = `${clamp(startW + (e.clientX - startX))}px`;
+      this._setRailWidth(startW + (e.clientX - startX));
     };
     const onUp = (e: PointerEvent): void => {
       window.removeEventListener('pointermove', onMove);
@@ -531,7 +548,7 @@ export class MeasurePanel {
     handle.addEventListener('pointerdown', (e) => {
       if (e.button !== 0) return; // primary button / pen / touch only
       startX = e.clientX;
-      startW = this.element.offsetWidth;
+      startW = this._railWidthPx();
       handle.classList.add('olv-mp-resize-active');
       try {
         handle.setPointerCapture(e.pointerId);
@@ -547,10 +564,10 @@ export class MeasurePanel {
     handle.addEventListener('keydown', (e) => {
       const step = e.shiftKey ? 32 : 8;
       if (e.key === 'ArrowLeft') {
-        this.element.style.width = `${clamp(this.element.offsetWidth - step)}px`;
+        this._setRailWidth(this._railWidthPx() - step);
         e.preventDefault();
       } else if (e.key === 'ArrowRight') {
-        this.element.style.width = `${clamp(this.element.offsetWidth + step)}px`;
+        this._setRailWidth(this._railWidthPx() + step);
         e.preventDefault();
       }
     });
@@ -568,40 +585,19 @@ export class MeasurePanel {
   }
 
   /**
-   * Restore the user's last dragged panel width and persist any new width
-   * (the panel is horizontally resizable so the profile chart can be widened
-   * to read). One key, panel-wide; clamped to the CSS resize bounds.
+   * Restore the user's last dragged rail width. The panel fills the rail, so a
+   * stored width is applied to `--olv-rail-width` for the whole column; the grip
+   * writes new values as they are dragged, so no width observer is needed.
+   * One key, rail-wide; clamped to the rail bounds.
    */
-  private _restorePanelWidth(): void {
-    const stored = Number(storageGet(MEASURE_PANEL_WIDTH_KEY));
+  private _restoreRailWidth(): void {
+    const stored = Number(storageGet(RAIL_WIDTH_KEY));
     if (
       Number.isFinite(stored) &&
-      stored >= MEASURE_PANEL_MIN_WIDTH_PX &&
-      stored <= MEASURE_PANEL_MAX_WIDTH_PX
+      stored >= RAIL_MIN_WIDTH_PX &&
+      stored <= RAIL_MAX_WIDTH_PX
     ) {
-      this.element.style.width = `${stored}px`;
-    }
-    if (typeof ResizeObserver === 'undefined') return;
-    try {
-      let primed = false;
-      this._panelWidthObserver = new ResizeObserver(() => {
-        // Skip the first (synchronous) callback so an untouched panel never
-        // writes the default width back to storage.
-        if (!primed) {
-          primed = true;
-          return;
-        }
-        const w = this.element.offsetWidth;
-        if (!Number.isFinite(w) || w <= 0) return;
-        const clamped = Math.min(
-          MEASURE_PANEL_MAX_WIDTH_PX,
-          Math.max(MEASURE_PANEL_MIN_WIDTH_PX, Math.round(w)),
-        );
-        storageSet(MEASURE_PANEL_WIDTH_KEY, String(clamped));
-      });
-      this._panelWidthObserver.observe(this.element);
-    } catch {
-      /* ResizeObserver unavailable — resizing still works, just isn't persisted. */
+      document.documentElement.style.setProperty(RAIL_WIDTH_VAR, `${stored}px`);
     }
   }
 

--- a/tests/e2e/measure.spec.ts
+++ b/tests/e2e/measure.spec.ts
@@ -196,8 +196,8 @@ test(
 );
 
 // Regression: an object/interior scan routes the tall Object/Space panel into
-// the shared left column. `.olv-measure-panel` carries `overflow: auto` (for its
-// horizontal resize), which drops its flex auto-min-height to 0 — so the flex
+// the shared left column. `.olv-measure-panel` carries `overflow-y: auto` (for
+// its vertical scroll), which drops its flex auto-min-height to 0 — so the flex
 // column used to shrink the Measurements panel down to just its header (~25px),
 // clipping the profile chart and readings, whenever the column ran out of room.
 // The fix pins `flex-shrink: 0` so the readout keeps its natural height in

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -3888,7 +3888,8 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
    each panel's own legacy width (Analyse 285 / Classes 248 / Export·Clip·
    Annotate·Measure 218) without editing them one by one. Desktop only — the
    mobile bottom-sheet reparents these panels and owns their sizing. The Measure
-   panel stays user-resizable: a drag writes an inline width that wins over this. */
+   panel stays user-resizable, but its SE grip widens the RAIL (`--olv-rail-width`)
+   rather than the panel alone, so every card widens together and stays flush. */
 @media (min-width: 768px) {
   .olv-left-panels:not(.olv-rail-collapsed) > * {
     width: 100%;
@@ -4388,19 +4389,27 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   box-shadow: var(--shadow-raised);
 }
 .olv-measure-panel {
-  /* 222px, not 218. Measured: the content box is width minus 26px of padding
-     and border, and the widest row (CSV / Export PDF / Clear profile) needs
-     193px. At 218 that left 192 and clipped the last label by a pixel. */
-  width: 222px; box-sizing: border-box;
-  /* Drag the south-east grip (`.olv-mp-resize`) to widen the panel (and the
-   * profile chart inside it) rightward into the canvas. `overflow: auto` keeps
-   * the native `resize: horizontal` as a fallback; the chosen width is
-   * persisted. `position: relative` anchors the explicit grip, which rides
-   * ABOVE the rail collapse tab that otherwise covers the native corner. */
+  /* Fills the left rail instead of carrying its own fixed width, so the
+     workspace tabs (DATA / WORK / ANALYSE / OUTPUT), the Clip box card and this
+     panel share one width and one right edge. The rail is `--olv-rail-width`
+     (72-panel-rails.css), a clamp(285px, 21vw, 312px) that the SE grip widens by
+     rewriting `--olv-rail-width` for the whole column, so a resize keeps the
+     stack flush. `min-width: 0` lets the panel shrink on the mobile sheet;
+     `max-width: 100%` keeps it inside the rail. The old 222px fixed width sat
+     narrower than the tabs (the source of the misalignment) and cramped the
+     readouts. */
+  width: 100%; min-width: 0; max-width: 100%; box-sizing: border-box;
+  /* `position: relative` anchors the explicit SE grip (`.olv-mp-resize`), which
+   * rides ABOVE the rail collapse tab that otherwise covers the native corner.
+   * The grip resizes the rail width, not this panel alone, so alignment holds. */
   position: relative;
-  min-width: 222px; max-width: 760px;
-  resize: horizontal; overflow: auto;
-  /* `overflow: auto` (needed for the horizontal resize + scrollbar-gutter) drops
+  /* `overflow-x: hidden` makes a horizontal scrollbar structurally impossible:
+     the panel must never require sideways scrolling to see its own readouts,
+     Clip box, or y-axis labels. `scrollbar-gutter: stable` still reserves the
+     vertical track. Any readout wider than the content box wraps (see
+     `.olv-mp-value`) rather than being scrolled to. */
+  overflow-x: hidden; overflow-y: auto;
+  /* `overflow-y: auto` (needed for the vertical scroll + scrollbar-gutter) drops
    * this flex child's automatic min-height to 0, so the left column's flex layout
    * would shrink the panel to just its header whenever the column runs out of
    * room. That happens acutely for an object/interior scan, where the tall

--- a/tests/measurePanelExpandAffordance.test.ts
+++ b/tests/measurePanelExpandAffordance.test.ts
@@ -90,19 +90,23 @@ describe('the profile chart offers a working way into the focus view', () => {
     expect(CSS).not.toMatch(/olv-mp-chart-expand-btn/);
   });
 
-  it('sizes the panel from the widest row it has to hold', () => {
-    // Measured in the running app: widest row 193px, chrome 26px. 218 left the
-    // content box at 192 and clipped the last label by a pixel.
-    expect(rule('.olv-measure-panel')).toMatch(/width:\s*222px/);
-    expect(rule('.olv-measure-panel')).toMatch(/min-width:\s*222px/);
+  it('fills the rail rather than carrying its own fixed width', () => {
+    // The panel used to be a fixed 222px, narrower than the workspace tabs and
+    // the cards above it, so its right edge did not line up with theirs. It now
+    // fills the rail (width:100%) and can never force a horizontal scrollbar.
+    expect(rule('.olv-measure-panel')).toMatch(/width:\s*100%/);
+    expect(rule('.olv-measure-panel')).toMatch(/min-width:\s*0/);
+    expect(rule('.olv-measure-panel')).toMatch(/max-width:\s*100%/);
+    expect(rule('.olv-measure-panel')).toMatch(/overflow-x:\s*hidden/);
   });
 
-  it('keeps the left stack aligned', () => {
-    // Annotations, Export/Convert and Clip box sit under Measurements in one
-    // column. A panel 4px wider than its neighbours reads as broken, so the
-    // width change is a stack-wide change or it is a new defect.
-    for (const sel of ['.olv-anno-panel', '.olv-export-panel', '.olv-clip-panel']) {
-      expect(rule(sel), `${sel} must match the measure panel width`).toMatch(/width:\s*222px/);
-    }
+  it('keeps the left stack aligned by making every rail card fill the column', () => {
+    // Alignment no longer depends on each panel declaring the same fixed width.
+    // The open rail forces every child to width:100%, so the workspace tabs, the
+    // Clip box card and the Measurements panel share one width and one right
+    // edge. This rule is the guarantee; losing it reopens the misalignment.
+    expect(CSS).toMatch(
+      /\.olv-left-panels:not\(\.olv-rail-collapsed\)\s*>\s*\*\s*\{[^}]*width:\s*100%/,
+    );
   });
 });


### PR DESCRIPTION
The Measurements panel carried its own fixed 222px width plus a per-panel drag width, so it sat narrower than the workspace tabs (DATA / WORK / ANALYSE / OUTPUT) and the Clip box card, and its right edge did not line up with theirs. The narrow width also cramped the readouts, and `overflow: auto` let a wide row raise a horizontal scrollbar that scrolled the panel's own left content out of view.

## Changes
- `.olv-measure-panel` now fills the rail: `width: 100%; min-width: 0; max-width: 100%; box-sizing: border-box`. The tabs, the Clip box card and the panel share one width and one right edge (all rail cards already fill the column).
- The south-east grip resizes the whole rail via `--olv-rail-width` (clamped 285-480px) and persists it to localStorage, so every card widens together and stays aligned. The panel-width `ResizeObserver`, the inline width and the `MEASURE_PANEL_*` width constants are removed.
- `overflow-x: hidden` makes a horizontal scrollbar structurally impossible; `overflow-y: auto` keeps vertical scroll and `scrollbar-gutter: stable`.
- Long Box, Volume and Area readouts wrap within the panel (`min-width: 0` + `white-space: normal` + `overflow-wrap: anywhere`) instead of being clipped. The profile chart min-width and the #708 label fit are untouched.

## Verification
- In the running build the tab strip and the panel share the same right edge (both 294px, right edge 302px), and stay aligned after a simulated rail resize to 360px.
- At 294px and 360px rail widths, `scrollWidth == clientWidth` (no horizontal scroll) and the Box / Volume / Area readouts wrap fully with no clipping.
- `tsc --noEmit` clean; measure and profile buckets pass (77 files, 1675 tests); styleCssPartition green with the regenerated golden fixture.