### PR TITLE
Let trackpad scroll reach the Measurements column

### DIFF
--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -26,19 +26,18 @@
      Clip box, or y-axis labels. `scrollbar-gutter: stable` still reserves the
      vertical track. Any readout wider than the content box wraps (see
      `.olv-mp-value`) rather than being scrolled to. */
-  overflow-x: hidden; overflow-y: auto;
-  /* `overflow-y: auto` (needed for the vertical scroll + scrollbar-gutter) drops
-   * this flex child's automatic min-height to 0, so the left column's flex layout
-   * would shrink the panel to just its header whenever the column runs out of
-   * room. That happens acutely for an object/interior scan, where the tall
-   * Object/Space panel fills the column and squeezed the Measurements panel down
-   * to a ~25px sliver — the profile chart and readings clipped away. Pin the
-   * shrink so the panel always keeps its natural height and the COLUMN scrolls
-   * instead; the readout then sizes identically in object-scan and terrain mode. */
+  /* `overflow-x: clip` makes a horizontal scrollbar structurally impossible while
+     leaving `overflow-y: visible`, so this panel is NOT a vertical scroll
+     container: a wheel over it is not swallowed by an inert scroller but passes
+     to `.olv-ws-body`, the column that actually scrolls. The panel no longer
+     needs its own overflow for resize (the SE grip resizes the rail). `clip` is
+     the only x value that keeps y visible; `hidden` would force y to auto and
+     make the panel a scroller again, which swallowed trackpad scrolling. */
+  overflow-x: clip; overflow-y: visible;
+  /* Pin the shrink so the tall Object/Space panel on an interior scan cannot
+     squeeze this one to a header sliver; the panel keeps its natural height and
+     the COLUMN scrolls instead. */
   flex-shrink: 0;
-  /* Reserve the scrollbar's track so an always-on (macOS) vertical scrollbar
-     doesn't eat into the content width and clip the right edge of a reading. */
-  scrollbar-gutter: stable;
   background: var(--panel); border: 0.5px solid var(--hairline);
   border-radius: var(--radius-lg); padding: var(--space-xl);
 }

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -4408,19 +4408,18 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
      Clip box, or y-axis labels. `scrollbar-gutter: stable` still reserves the
      vertical track. Any readout wider than the content box wraps (see
      `.olv-mp-value`) rather than being scrolled to. */
-  overflow-x: hidden; overflow-y: auto;
-  /* `overflow-y: auto` (needed for the vertical scroll + scrollbar-gutter) drops
-   * this flex child's automatic min-height to 0, so the left column's flex layout
-   * would shrink the panel to just its header whenever the column runs out of
-   * room. That happens acutely for an object/interior scan, where the tall
-   * Object/Space panel fills the column and squeezed the Measurements panel down
-   * to a ~25px sliver — the profile chart and readings clipped away. Pin the
-   * shrink so the panel always keeps its natural height and the COLUMN scrolls
-   * instead; the readout then sizes identically in object-scan and terrain mode. */
+  /* `overflow-x: clip` makes a horizontal scrollbar structurally impossible while
+     leaving `overflow-y: visible`, so this panel is NOT a vertical scroll
+     container: a wheel over it is not swallowed by an inert scroller but passes
+     to `.olv-ws-body`, the column that actually scrolls. The panel no longer
+     needs its own overflow for resize (the SE grip resizes the rail). `clip` is
+     the only x value that keeps y visible; `hidden` would force y to auto and
+     make the panel a scroller again, which swallowed trackpad scrolling. */
+  overflow-x: clip; overflow-y: visible;
+  /* Pin the shrink so the tall Object/Space panel on an interior scan cannot
+     squeeze this one to a header sliver; the panel keeps its natural height and
+     the COLUMN scrolls instead. */
   flex-shrink: 0;
-  /* Reserve the scrollbar's track so an always-on (macOS) vertical scrollbar
-     doesn't eat into the content width and clip the right edge of a reading. */
-  scrollbar-gutter: stable;
   background: var(--panel); border: 0.5px solid var(--hairline);
   border-radius: var(--radius-lg); padding: var(--space-xl);
 }

--- a/tests/measurePanelExpandAffordance.test.ts
+++ b/tests/measurePanelExpandAffordance.test.ts
@@ -97,7 +97,11 @@ describe('the profile chart offers a working way into the focus view', () => {
     expect(rule('.olv-measure-panel')).toMatch(/width:\s*100%/);
     expect(rule('.olv-measure-panel')).toMatch(/min-width:\s*0/);
     expect(rule('.olv-measure-panel')).toMatch(/max-width:\s*100%/);
-    expect(rule('.olv-measure-panel')).toMatch(/overflow-x:\s*hidden/);
+    // `overflow-x: clip` forbids a horizontal scrollbar; `overflow-y: visible`
+    // keeps the panel from being a scroll container so a trackpad wheel reaches
+    // the `.olv-ws-body` column that actually scrolls.
+    expect(rule('.olv-measure-panel')).toMatch(/overflow-x:\s*clip/);
+    expect(rule('.olv-measure-panel')).toMatch(/overflow-y:\s*visible/);
   });
 
   it('keeps the left stack aligned by making every rail card fill the column', () => {


### PR DESCRIPTION
The Measurements panel kept overflow-y: auto after its horizontal resize moved to the rail (#709), so it stayed a vertical scroll container. With flex-shrink: 0 it holds its natural height and never overflows itself, yet as an inert scroller it swallowed wheel events, and overscroll-behavior blocked chaining to .olv-ws-body, the column that actually scrolls. A two-finger trackpad scroll therefore did nothing.

The panel now uses overflow-x: clip with overflow-y: visible. Horizontal scrolling stays structurally impossible (clip has no scroll mechanism), and the panel is no longer a vertical scroll container, so the wheel reaches the column. clip is the only overflow-x value that keeps overflow-y visible; hidden would force overflow-y to auto and reintroduce the intercepting scroller.

Golden CSS fixture regenerated; the panel-affordance test now pins overflow-x: clip and overflow-y: visible. tsc clean, measure/style buckets pass.