### PR TITLE
Complete the v0.6.7 release notes

### DIFF
--- a/docs/releases/RELEASE_NOTES_v0.6.7.md
+++ b/docs/releases/RELEASE_NOTES_v0.6.7.md
@@ -1,6 +1,6 @@
 # OpenLiDARViewer v0.6.7
 
-v0.6.7 is a licensing and engineering release. The license changes to AGPL-3.0-only, and underneath it a memory-safety hardening wave reworks the read paths so a malformed or oversized input is refused before it can allocate past budget. Two ingest paths join them: heavy local files stream out of core rather than loading whole, and 3D Tiles implicit tiling opens where an earlier release read only an explicit hierarchy. No new scientific evidence claim is made in this release; the twelve products at E4 stay exactly as validated in v0.6.6.
+v0.6.7 is a licensing and engineering release. The license changes to AGPL-3.0-only, and underneath it a memory-safety hardening wave reworks the read paths so a malformed or oversized input is refused before it can allocate past budget. The 3D Tiles path gained a correctness pass alongside it, and two ingest paths join them: heavy local files stream out of core rather than loading whole, and 3D Tiles implicit tiling opens where an earlier release read only an explicit hierarchy. The Measurements rail was reworked so its readouts are no longer cut. No new scientific evidence claim is made in this release; the twelve products at E4 stay exactly as validated in v0.6.6.
 
 OpenLiDARViewer remains browser-native and local-first: local files stay on the user's device, and no account is required.
 
@@ -21,20 +21,41 @@ The current terms and the surrounding documents are:
 
 A very large uncompressed LAS and a chunked LAZ are no longer read whole into memory. Each is indexed into temporary browser storage in the Origin Private File System and streamed from that index, or refused with guidance when the device cannot hold even the index. A stratified preview sample renders at once so the scan is visible immediately, and it is marked incomplete until the full index swaps in behind it, so a partial view is never mistaken for the whole cloud.
 
+On the test machine, a 1.74 GB LAZ opened in about 1 minute 41 seconds through this path, against about 2 minutes 43 seconds on an earlier build. That is one field observation on a single machine and browser, recorded in `docs/benchmarks.md`; open time varies with thermal state and cache.
+
 ## 3D Tiles implicit tiling
 
 Quadtree and octree implicit subtrees now open and stream. An earlier release opened a 3D Tiles set only where the tileset declared an explicit tile hierarchy; the implicit form is read now, so a set that encodes its hierarchy as subtrees loads rather than being refused.
+
+## 3D Tiles geometry correctness
+
+The 3D Tiles transform handling gained three fixes that change where geometry is drawn and refined, not just how much is loaded.
+
+- Geometric error is now version-aware. 3D Tiles 1.0 does not apply the tile transform to a tile's geometric error, while 1.1 scales it by the transform's largest stretch. The viewer scaled unconditionally, so a scaled 1.0 tileset refined at the wrong level of detail; it now leaves 1.0 unscaled and scales 1.1.
+- The transform's largest stretch is measured as the true largest singular value of its upper-left three-by-three, not the longest of its three columns. The column length is right for a rotation with axis-aligned scale but under-reports a shear or a composed non-uniform transform, so a bounding sphere could be sized too small and cull valid geometry. A unit shear now reads about 1.618 where the column measure read about 1.414.
+- PNTS surface normals are transformed by the inverse-transpose of the tile transform and renormalised. Carrying a normal through the plain transform leaves it no longer perpendicular to its surface under any non-uniform or sheared transform; normal-based shading now points the right way.
 
 ## Memory-safety hardening
 
 This wave was worked from an adversarial audit of the read paths, and it changes how the viewer behaves on a hostile or oversized file rather than what it computes on a good one.
 
 - One shared decoded-byte budget caps the LAZ chunk table, the LAZ chunks and windows, the LAS record batches, the COPC nodes and the out-of-core tiles together. A malformed multi-gigabyte input is refused before it can allocate past that budget, instead of each reader holding its own uncapped allowance.
+- The peak-memory estimate charges the compressed bytes twice on a laz-perf decode, once for the JavaScript buffer and once for the copy laz-perf stages into its WASM heap, and the local windowed path drops the extra slice it used to make, so the budget reflects what is actually resident during decompression.
+- COPC, EPT binary and PNTS bound the peak that spans both decode phases, not only the first. A node whose compressed and raw records pass the decompression cap but whose decoded channel arrays would then push the working set over budget is refused before the first allocation.
+- PNTS admission counts the raw tile body together with its decoded channels rather than the decoded arrays alone, and a phone uses a lower ceiling than a desktop, so a single large point tile that would exceed the mobile budget is refused rather than downloaded and then rejected.
+- The remote transport caps a body with no trustworthy Content-Length at 64 MiB, and a mobile 3D Tiles tile download is capped to the mobile decode budget, so transport assembly cannot exceed the memory the decoder is allowed. A declared-length body streams into one exact buffer once enough real bytes have arrived, rather than growing through doubling buffers, and abandoned EPT and 3D Tiles response bodies are cancelled before a retry.
+- EPT and COPC reconcile the point total across the hierarchy against the declared total, and refuse to call a partially loaded cloud complete; an EPT laszip tile whose LAS header count disagrees with its hierarchy entry is refused before laz-perf runs, and an EPT hierarchy that cannot open its root fails rather than opening as an empty scan.
+- Full-cloud grading refuses a sample above its safe point and byte ceilings before allocating, and requires the decoded node count to match the plan.
 - The out-of-core store in the Origin Private File System is leak-free. Every open takes a unique id, the store is promoted only inside the failure guard, each cancel or attach path either commits the store or deletes it, a short write is handled rather than left behind, and a startup janitor sweeps any store a previous session abandoned.
-- First-node streaming admission reads the device it runs on rather than assuming a fixed ceiling.
-- An over-ceiling non-streaming format fails closed instead of attempting a whole read.
-- Size caps were added to the batch converter and to the metadata readers.
-- A truncated tile or source is refused rather than presented as a smaller complete scan.
+- First-node streaming admission reads the device it runs on rather than assuming a fixed ceiling, an over-ceiling non-streaming format fails closed instead of attempting a whole read, size caps were added to the batch converter and the metadata readers, and a truncated tile or source is refused rather than presented as a smaller complete scan.
+
+## Interface
+
+The Measurements rail was reported as cut on the right, and the profile chart's x-axis dropped a tick and clipped its last label. Both are fixed.
+
+- The profile chart's x-axis labels fit the chart's real width rather than a fixed floor, so a wide chart carries every label it has room for at an even spacing and none loses a leading digit at the edge.
+- The Measurements panel fills the workspace rail instead of carrying its own narrower fixed width, so the Data / Work / Analyse / Output tabs, the Clip box card and the panel share one width and one right edge. Long readouts, such as a volume's fill, cut and net line, wrap onto further lines rather than being cut, and no readout forces a horizontal scrollbar.
+- The panel's resize grip widens the whole rail rather than the one panel, so the stack stays aligned at every width, and a trackpad scroll over the panel reaches the column that scrolls.
 
 ## Corrected behaviour
 
@@ -46,11 +67,13 @@ This wave was worked from an adversarial audit of the read paths, and it changes
 
 ## No new evidence claim
 
-v0.6.7 adds no new scientific evidence claim, no new E4 promotion and no new validation study. The twelve registered products at E4 stay exactly as validated in v0.6.6, and the engineering and memory-safety work above is covered by the test suite rather than by a scientific claim. See `VALIDATION_REPORT_v0.6.7.md` and `KNOWN_LIMITATIONS_v0.6.7.md`.
+v0.6.7 adds no new scientific evidence claim, no new E4 promotion and no new validation study. The twelve registered products at E4 stay exactly as validated in v0.6.6, and the engineering and memory-safety work above is covered by the test suite rather than by a scientific claim.
+
+Two evidence descriptions were corrected without changing what the evidence says. An exported terrain product that has reached cross-implementation validation but not field validation is now described as such, rather than as pre-cross-implementation and unchecked against an independent tool, so the terrain report and the map sheet agree on a product's standing. The aspect-raster tolerance is recorded as carried over from the slope tolerance in the same change that produced its result, not as preregistered ahead of it, which the slope, hillshade and contour tolerances were. See `VALIDATION_REPORT_v0.6.7.md` and `KNOWN_LIMITATIONS_v0.6.7.md`.
 
 ## Known limitations
 
-The complete list is in `KNOWN_LIMITATIONS_v0.6.7.md`. It carries the v0.6.6 limits forward. The two monoliths are unchanged this cycle, there is still no cross-CRS reprojection into a common viewer frame, and the residual streaming flicker at the point-budget boundary is unchanged in the default configuration.
+The complete list is in `KNOWN_LIMITATIONS_v0.6.7.md`. It carries the v0.6.6 limits forward. The two monoliths are unchanged this cycle, there is still no cross-CRS reprojection into a common viewer frame, and the residual streaming flicker at the point-budget boundary is unchanged in the default configuration. The decode-memory budget is device-aware for PNTS; the other formats share a single ceiling rather than a per-device one.
 
 ## Compatibility
 


### PR DESCRIPTION
Expands RELEASE_NOTES_v0.6.7.md to cover the full v0.6.6 to v0.6.7 change set, in the voice and structure of the v0.6.6 notes.

Added sections and bullets for the 3D Tiles geometry correctness pass (version-aware geometric error for 1.0 vs 1.1, the true largest-singular-value transform scale, inverse-transpose PNTS normals), the deeper decode-memory accounting (charging the laz-perf WASM compressed copy, bounding the coexisting two-phase peak on COPC, EPT binary and PNTS, device-aware PNTS admission and transport, the declared-length reader and the 64 MiB unknown-length body cap, EPT and COPC completeness reconciliation, full-cloud grade ceilings), the Measurements rail rework (fills the rail, aligned tabs and cards, wrapping readouts, rail-driven resize, restored trackpad scroll), and the two corrected evidence descriptions (cross-implementation-but-not-field wording, aspect tolerance recorded as carried over rather than preregistered). No new evidence claim; twelve products at E4 unchanged.

release-sync, release-truth, claim-prose-sync, archive-vocab, claims-language and doc-links pass. Zero em dashes.