### PR TITLE
Rewrite the v0.6.7 release notes for the full change set

### DIFF
--- a/docs/releases/RELEASE_NOTES_v0.6.7.md
+++ b/docs/releases/RELEASE_NOTES_v0.6.7.md
@@ -1,52 +1,47 @@
 # OpenLiDARViewer v0.6.7
 
-v0.6.7 is a licensing and engineering release. The license changes to AGPL-3.0-only, and underneath it a memory-safety hardening wave reworks the read paths so a malformed or oversized input is refused before it can allocate past budget. Two ingest paths join them: heavy local files stream out of core rather than loading whole, and 3D Tiles implicit tiling opens where an earlier release read only an explicit hierarchy. No new scientific evidence claim is made in this release; the twelve products at E4 stay exactly as validated in v0.6.6.
+v0.6.7 changes the license to AGPL-3.0-only and hardens the read paths so a malformed or oversized file is refused before it can allocate past budget. Two ingest paths are wired: heavy local files stream out of core rather than loading whole, and 3D Tiles implicit tiling opens where an earlier release read only an explicit hierarchy. Five claims reach cross-implementation evidence this cycle, and the Measurements rail was reworked so its readouts are no longer cut.
 
 OpenLiDARViewer remains browser-native and local-first: local files stay on the user's device, and no account is required.
 
 ## Licensing change
 
-v0.6.7 is the first release published under AGPL-3.0-only. Releases through v0.6.6 were published under MIT and remain available under those terms; the change is not retroactive and nothing already distributed changes license.
+v0.6.7 is the first release published under AGPL-3.0-only. Releases through v0.6.6 were published under MIT and remain available under those terms; the change is not retroactive. It covers this project's own source and does not alter the license of any bundled dependency or any test or validation dataset. `LICENSE`, `LICENSING.md`, `COMMERCIAL-LICENSING.md` and `docs/CLA.md` carry the terms, the separate commercial option and the contributor agreement.
 
-The change covers this project's own source. It does not alter the license of any bundled third-party dependency, which each keeps the terms it already carried, and it does not alter the license of any test or validation dataset. The dataset citations and their licenses are recorded where they were before.
+## New cross-implementation evidence
 
-The current terms and the surrounding documents are:
+Five claims reach `E4_CROSS_IMPLEMENTATION_VALIDATED`, bringing the register to seventeen. Each agrees with an independent implementation on synthetic or analytic fixtures. None is accuracy against surveyed ground truth.
 
-- `LICENSE` carries the GNU AGPL v3 text.
-- `LICENSING.md` states what the license means for a user and a redistributor.
-- `COMMERCIAL-LICENSING.md` describes the separate commercial option for use that AGPL-3.0-only does not fit.
-- `docs/CLA.md` is the contributor licensing agreement.
+- `CRS-UTM-PROJECTION`: WGS-84 latitude and longitude to UTM, checked against GeographicLib 2.7 and PROJ 9.8.1 over 36 geodetic fixtures. Zone and hemisphere match on every fixture, easting and northing to under 1.5 mm. Same datum stands on both sides, so no datum transformation is exercised.
+- `CHANGE-RASTER` and `CHANGE-VOLUME`: per-cell change and integrated cut and fill volume, checked against GRASS 8.5.0 over eight synthetic epoch pairs, and change volume also against the closed-form integral of each pair. Agreement is on synthetic pairs, not surveyed field change.
+- `HOLDOUT-RMSE` and `NVA-VVA`: the internal holdout accuracy statistics, recomputed in base R. The check confirms the statistic is computed correctly, not that it is field accuracy: the held-out points come from the same source as the interpolated ones, and neither is ASPRS checkpoint accuracy.
+
+Full figures, tolerances and scope are in `VALIDATION_REPORT_v0.6.7.md`. The twelve products validated in v0.6.6 are unchanged.
 
 ## Reading heavy local files out of core
 
-A very large uncompressed LAS and a chunked LAZ are no longer read whole into memory. Each is indexed into temporary browser storage in the Origin Private File System and streamed from that index, or refused with guidance when the device cannot hold even the index. A stratified preview sample renders at once so the scan is visible immediately, and it is marked incomplete until the full index swaps in behind it, so a partial view is never mistaken for the whole cloud.
+A very large uncompressed LAS and a chunked LAZ are no longer read whole into memory. Each is indexed into temporary browser storage and streamed from that index, or refused with guidance when the device cannot hold even the index. A preview sample renders at once, marked incomplete until the full index swaps in behind it, so a partial view is never mistaken for the whole cloud.
 
-## 3D Tiles implicit tiling
+## 3D Tiles
 
-Quadtree and octree implicit subtrees now open and stream. An earlier release opened a 3D Tiles set only where the tileset declared an explicit tile hierarchy; the implicit form is read now, so a set that encodes its hierarchy as subtrees loads rather than being refused.
+Quadtree and octree implicit subtrees now open and stream, where an earlier release read only an explicit tile hierarchy. Three transform fixes came with them: 3D Tiles 1.0 no longer scales a tile's geometric error the way 1.1 does, so a scaled 1.0 tileset refines at the right level of detail; a sheared or non-uniform tile transform is measured by its true largest stretch, so a bounding sphere is not sized too small and does not cull valid geometry; and PNTS surface normals are transformed correctly, so normal-based shading points the right way.
 
 ## Memory-safety hardening
 
-This wave was worked from an adversarial audit of the read paths, and it changes how the viewer behaves on a hostile or oversized file rather than what it computes on a good one.
+Worked from an adversarial audit of the read paths, this wave changes how the viewer behaves on a hostile or oversized file, not what it computes on a good one. One shared budget caps the LAZ, LAS, COPC and out-of-core readers together, so a malformed multi-gigabyte input is refused before it can allocate past that budget. The COPC, EPT and PNTS decoders account for the full working set of a decode, not only its final arrays, and use a lower ceiling on a phone. Remote transport caps an unknown-length body and a mobile tile to what the decoder is allowed, and cancels abandoned response bodies. EPT and COPC refuse to call a partially loaded cloud complete, and refuse a tile whose declared point count disagrees with its hierarchy. The out-of-core store is leak-free, with a startup janitor that sweeps any store a previous session abandoned.
 
-- One shared decoded-byte budget caps the LAZ chunk table, the LAZ chunks and windows, the LAS record batches, the COPC nodes and the out-of-core tiles together. A malformed multi-gigabyte input is refused before it can allocate past that budget, instead of each reader holding its own uncapped allowance.
-- The out-of-core store in the Origin Private File System is leak-free. Every open takes a unique id, the store is promoted only inside the failure guard, each cancel or attach path either commits the store or deletes it, a short write is handled rather than left behind, and a startup janitor sweeps any store a previous session abandoned.
-- First-node streaming admission reads the device it runs on rather than assuming a fixed ceiling.
-- An over-ceiling non-streaming format fails closed instead of attempting a whole read.
-- Size caps were added to the batch converter and to the metadata readers.
-- A truncated tile or source is refused rather than presented as a smaller complete scan.
+## Interface
 
-## Corrected behaviour
+The Measurements panel now fills the workspace rail, so the Data, Work, Analyse and Output tabs, the Clip box card and the panel share one width and one right edge. Long readouts wrap rather than being cut, no readout forces a horizontal scrollbar, the resize grip widens the whole rail so the stack stays aligned, and a trackpad scroll over the panel reaches the column that scrolls. The profile chart's x-axis labels fit the chart's real width, so a wide chart carries an even set of labels and none loses a digit at the edge.
 
-- The profile PDF max-grade carries the sign the on-screen panel and the callout already show, so the exported sheet no longer disagrees with the panel it was printed from.
+## Fixed
+
+- The profile PDF max-grade carries the sign the on-screen panel already shows.
 - The Inspector elevation rows read the source vertical unit instead of assuming metres.
-- Panel-rail observers that leaked are disposed.
 - A degenerate profile no longer reports full coverage over zero returns.
 - Closing the profile workbench restores the Analyse panel, so its contour controls no longer disappear with it.
-
-## No new evidence claim
-
-v0.6.7 adds no new scientific evidence claim, no new E4 promotion and no new validation study. The twelve registered products at E4 stay exactly as validated in v0.6.6, and the engineering and memory-safety work above is covered by the test suite rather than by a scientific claim. See `VALIDATION_REPORT_v0.6.7.md` and `KNOWN_LIMITATIONS_v0.6.7.md`.
+- Two evidence descriptions were corrected without changing what the evidence says: a product that has reached cross-implementation validation but not field validation is described as such rather than as unchecked, and the aspect tolerance is recorded as carried over from the slope tolerance rather than preregistered.
+- Panel-rail observers that leaked are disposed.
 
 ## Known limitations
 
@@ -54,7 +49,7 @@ The complete list is in `KNOWN_LIMITATIONS_v0.6.7.md`. It carries the v0.6.6 lim
 
 ## Compatibility
 
-Unchanged from v0.6.6. Modern Chromium browsers prefer WebGPU where the platform and adapter provide it and fall back to WebGL 2 otherwise; Firefox and Safari take the WebGL 2 path. Existing sessions remain compatible, and a session saved before this release loads unchanged.
+Unchanged from v0.6.6. Modern Chromium browsers prefer WebGPU where the platform and adapter provide it and fall back to WebGL 2 otherwise; Firefox and Safari take the WebGL 2 path. A session saved before this release loads unchanged.
 
 ## Verifying this release
 


### PR DESCRIPTION
Rewrites RELEASE_NOTES_v0.6.7.md to cover the whole v0.6.6 to v0.6.7 change set and correct a factual error: the prior notes said v0.6.7 makes no new evidence claim, but the register moved from twelve to seventeen claims at E4 this cycle.

New cross-implementation evidence section covers the five promotions: CRS-UTM-PROJECTION against GeographicLib and PROJ over 36 geodetic fixtures, CHANGE-RASTER and CHANGE-VOLUME against GRASS over eight synthetic epoch pairs, and HOLDOUT-RMSE and NVA-VVA recomputed in base R. Each carries the scope the register records: agreement with an independent implementation on synthetic or analytic fixtures, not field accuracy, and the holdout statistics are internal diagnostics rather than checkpoint accuracy.

Also covered: the 3D Tiles geometry pass, the deeper memory hardening, and the Measurements rail rework. Mechanism-level detail is trimmed for a reader.

release-sync, release-truth, claim-prose-sync, archive-vocab, claims-language and doc-links pass. Zero em dashes.