### PR TITLE
chore(v0.6.7): license metadata to AGPL-3.0-only in .zenodo.json and codemeta.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "OpenLiDARViewer",
   "upload_type": "software",
-  "license": "MIT",
+  "license": "AGPL-3.0-only",
   "creators": [
     {
       "name": "Urias, A.",

--- a/codemeta.json
+++ b/codemeta.json
@@ -11,7 +11,7 @@
   "softwareVersion": "0.6.7",
   "dateModified": "2026-08-29",
   "datePublished": "2026-08-29",
-  "license": "https://spdx.org/licenses/MIT.html",
+  "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
   "codeRepository": "https://github.com/Aurtechmx/openlidarviewer",
   "url": "https://lidar.aurtech.mx/",
   "issueTracker": "https://github.com/Aurtechmx/openlidarviewer/issues",


### PR DESCRIPTION
`.zenodo.json` and `codemeta.json` still declared MIT after the v0.6.7 AGPL-3.0-only relicense. `lint:license` guards package.json, LICENSE, CITATION.cff, README, and src/main.ts, but not these two files, so the stale value passed the release gate. Both are set to AGPL-3.0-only: `.zenodo.json` license `AGPL-3.0-only`, codemeta license `https://spdx.org/licenses/AGPL-3.0-only.html`. No code change.