### PR TITLE
chore: extend lint:license to guard .zenodo.json and codemeta.json

### DIFF
--- a/scripts/lint-license.mjs
+++ b/scripts/lint-license.mjs
@@ -10,8 +10,9 @@
  *   last MIT release         v0.6.6
  *
  * It asserts the CURRENT-license surfaces (package.json, LICENSE, CITATION.cff,
- * the README License section and badge, the app console banner, and the current
- * release notes) all say AGPL-3.0-only. It does NOT blindly reject the string
+ * .zenodo.json, codemeta.json, the README License section and badge, the app
+ * console banner, and the current release notes) all say AGPL-3.0-only. It does
+ * NOT blindly reject the string
  * "MIT": historical statements ("releases through v0.6.6 were distributed under
  * MIT"), third-party notices, and license texts legitimately mention MIT, and
  * those are left alone. Only the guarded current-license surfaces are checked,
@@ -53,6 +54,28 @@ export function checkLicense(root) {
   const cff = read('CITATION.cff') || '';
   must(/license:\s*AGPL-3\.0-only/.test(cff), 'CITATION.cff license is not AGPL-3.0-only.');
   must(!/license:\s*MIT\b/.test(cff), 'CITATION.cff still declares MIT as the current license.');
+
+  // The archival and machine-readable metadata surfaces. These carry the
+  // license to Zenodo and to software indexers, and on the v0.6.7 relicense
+  // both shipped MIT and were caught only by hand — lint:license did not read
+  // them. Zenodo uses the SPDX identifier; codemeta uses the SPDX URL.
+  const zenodoText = read('.zenodo.json');
+  must(zenodoText != null, '.zenodo.json is missing.');
+  if (zenodoText != null) {
+    let zenodo = {};
+    try { zenodo = JSON.parse(zenodoText); } catch { problems.push('.zenodo.json is not valid JSON.'); }
+    must(zenodo.license === CURRENT_LICENSE, `.zenodo.json license is ${JSON.stringify(zenodo.license)}, expected ${CURRENT_LICENSE}.`);
+  }
+
+  const codemetaText = read('codemeta.json');
+  must(codemetaText != null, 'codemeta.json is missing.');
+  if (codemetaText != null) {
+    let codemeta = {};
+    try { codemeta = JSON.parse(codemetaText); } catch { problems.push('codemeta.json is not valid JSON.'); }
+    const cmLicense = typeof codemeta.license === 'string' ? codemeta.license : '';
+    must(/AGPL-3\.0-only/.test(cmLicense), `codemeta.json license is ${JSON.stringify(codemeta.license)}, expected the AGPL-3.0-only SPDX URL.`);
+    must(!/\/MIT\b/.test(cmLicense), 'codemeta.json still declares the MIT license.');
+  }
 
   const readme = read('README.md') || '';
   must(/license-AGPL/.test(readme), 'README license badge is not AGPL.');

--- a/tests/licenseLint.test.ts
+++ b/tests/licenseLint.test.ts
@@ -20,6 +20,8 @@ function writeValidFixture(root: string): void {
   w('COMMERCIAL-LICENSING.md', '# Commercial licensing\n');
   w('docs/CLA.md', '# Contributor License Agreement\n');
   w('CITATION.cff', 'cff-version: 1.2.0\nversion: "0.6.7"\nlicense: AGPL-3.0-only\n');
+  w('.zenodo.json', JSON.stringify({ title: 'OpenLiDARViewer', upload_type: 'software', license: 'AGPL-3.0-only' }, null, 2));
+  w('codemeta.json', JSON.stringify({ name: 'OpenLiDARViewer', version: '0.6.7', license: 'https://spdx.org/licenses/AGPL-3.0-only.html' }, null, 2));
   w('README.md', [
     '[![License](https://img.shields.io/badge/license-AGPL--3.0--only-blue)](LICENSE)',
     '## License',
@@ -69,6 +71,17 @@ describe('lint:license boundary', () => {
     writeFileSync(resolve(root, 'CITATION.cff'), 'cff-version: 1.2.0\nversion: "0.6.7"\nlicense: MIT\n');
     const problems = checkLicense(root);
     expect(problems.some((p: string) => /CITATION\.cff/.test(p))).toBe(true);
+  });
+
+  it('rejects .zenodo.json declaring MIT', () => {
+    writeFileSync(resolve(root, '.zenodo.json'), JSON.stringify({ title: 'x', upload_type: 'software', license: 'MIT' }, null, 2));
+    expect(checkLicense(root).some((p: string) => /\.zenodo\.json license/.test(p))).toBe(true);
+  });
+
+  it('rejects codemeta.json declaring the MIT SPDX URL', () => {
+    writeFileSync(resolve(root, 'codemeta.json'), JSON.stringify({ name: 'x', version: '0.6.7', license: 'https://spdx.org/licenses/MIT.html' }, null, 2));
+    const problems = checkLicense(root);
+    expect(problems.some((p: string) => /codemeta\.json/.test(p))).toBe(true);
   });
 
   it('ACCEPTS an accurate historical MIT statement', () => {


### PR DESCRIPTION
`lint:license` guarded package.json, LICENSE, CITATION.cff, README, and src/main.ts, but not `.zenodo.json` or `codemeta.json`. Both carry the license to Zenodo and to software indexers, and both shipped MIT on the v0.6.7 AGPL relicense, corrected by hand. The lint now asserts `.zenodo.json` uses the `AGPL-3.0-only` SPDX identifier and `codemeta.json` the AGPL-3.0-only SPDX URL, and rejects an MIT value in either. Two unit tests cover the new surfaces (10 total). No runtime code change.