### PR TITLE
feat(pick): uniform-grid ray-pick index with exact-parity core (v0.6.8)

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -355,6 +355,13 @@
       "why": "The single source of truth for every Web Worker the app ships, consumed at BUILD time by vite.config.ts (live-transform excludes and chunk-emission pins) and by scripts/lint-worker-registry.mjs. The application graph reaches the workers by new Worker(new URL(...)) from their clients, never through this file, so a walk from index.html cannot see it.",
       "graduation": "None expected. It is reachable from the build configuration by design; this entry records that the application entry graph is not where to look for it.",
       "review": "2027-08-27"
+    },
+    {
+      "path": "src/render/pick/rayPick.ts",
+      "status": "staged",
+      "why": "Uniform-grid ray picker: builds a cell grid over a cloud's position buffer once, then answers an angular-miss pick by walking only the acceptance cone's cells instead of scanning every point the way nearestPointAlongRay does. tests/rayPick.test.ts proves it returns the identical winning point as the linear scan across randomized clouds and rays. Nothing in the running application routes the pick path through it yet.",
+      "graduation": "Viewer._pickDetailed (and the streaming pick) call pickAlongRay behind an opt-in device flag, reached from src/main.ts, once browser latency measurements support making the index the default.",
+      "review": "2027-08-27"
     }
   ]
 }

--- a/src/render/pick/rayPick.ts
+++ b/src/render/pick/rayPick.ts
@@ -1,0 +1,264 @@
+/**
+ * rayPick.ts — a uniform-grid spatial index for angular-miss ray picking.
+ *
+ * The shipping picker (`nearestPointAlongRay` in ../navMath) scans every point
+ * in a cloud for each hover or click — O(N) per query, over a buffer that can
+ * hold millions of points, on the pointer-move-driven probe path. This module
+ * builds a uniform cell grid over the same interleaved Float32 position buffer
+ * once, then answers a pick by visiting only the cells the ray's acceptance
+ * cone can touch, so a repeated interactive query costs work proportional to
+ * the cone rather than to the cloud.
+ *
+ * CONTRACT. For a given (origin, dir, tolerance, accept) the winning point is
+ * the SAME point the linear scan accepts. "Accept" is the caller's angular gate
+ * `offset / along < tolerance` (the 0.07 the Viewer and the streaming picker
+ * use). The metric (perpendicular-offset-squared over along-squared, with the
+ * perpendicular taken from the cross product |v x d|, not |v|^2 - along^2), the
+ * strict-less update that makes the lowest point index win an exact tie, and
+ * the `along > 0` in-front rule all match ../navMath exactly, so the winning
+ * index is identical. tests/rayPick.test.ts fuzzes this against the real
+ * `nearestPointAlongRay` across randomized clouds and rays.
+ *
+ * SAFETY. The grid is an optimisation, never a correctness authority: on a
+ * degenerate grid, a ray that misses the cloud's box, or a cone that would
+ * cover most of the grid, the query falls back to the exact linear scan. It can
+ * therefore never return a point the linear scan would not, nor miss one it
+ * would.
+ *
+ * FRAME. The index, the ray, and the accept predicate are all in the caller's
+ * chosen frame (whatever frame the passed-in buffer is in). Build one index per
+ * immutable position buffer, mirroring PointCloud's lazy bounds cache.
+ */
+import type { Vec3 } from '../navMath';
+
+/** An opaque uniform-grid index over a cloud's interleaved xyz positions. */
+export interface RayPickIndex {
+  /** The indexed buffer, referenced (not copied). */
+  readonly positions: Float32Array;
+  /** Number of points (`positions.length / 3`). */
+  readonly count: number;
+  /** Edge length of one cubic cell, or Infinity for a degenerate grid. */
+  readonly cellSize: number;
+  /** Grid origin (min corner) in the buffer's frame. */
+  readonly min: Vec3;
+  /** Cell counts per axis (each >= 1). */
+  readonly dims: Vec3;
+  /** Packed cell key -> point indices in that cell. */
+  readonly cells: ReadonlyMap<number, readonly number[]>;
+}
+
+/** A picked point. `index` is the point index (buffer offset / 3). */
+export interface RayPickHit {
+  readonly index: number;
+  readonly point: Vec3;
+  /** Perpendicular distance from the ray line (world units). */
+  readonly offset: number;
+  /** Projection distance from origin to closest approach. */
+  readonly along: number;
+}
+
+/**
+ * Build a uniform-grid index over an interleaved xyz `Float32Array`.
+ *
+ * Cell size targets roughly one point per cell (`cbrt(volume / count)`), the
+ * same heuristic the snap index uses. Non-finite points are left out of the
+ * grid: the linear scan can never pick one either (their score is NaN and every
+ * comparison against it is false), so omitting them keeps the two in agreement.
+ */
+export function buildRayPickIndex(positions: Float32Array): RayPickIndex {
+  const count = Math.floor(positions.length / 3);
+  if (count === 0) {
+    return { positions, count: 0, cellSize: Infinity, min: [0, 0, 0], dims: [1, 1, 1], cells: new Map() };
+  }
+
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  for (let i = 0; i < count; i++) {
+    const x = positions[i * 3], y = positions[i * 3 + 1], z = positions[i * 3 + 2];
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
+    if (x < minX) minX = x; if (x > maxX) maxX = x;
+    if (y < minY) minY = y; if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+  }
+  if (!Number.isFinite(minX)) {
+    // No finite point: a degenerate index that always falls back to linear.
+    return { positions, count, cellSize: Infinity, min: [0, 0, 0], dims: [1, 1, 1], cells: new Map() };
+  }
+
+  const spanX = Math.max(maxX - minX, 0);
+  const spanY = Math.max(maxY - minY, 0);
+  const spanZ = Math.max(maxZ - minZ, 0);
+  const volume = spanX * spanY * spanZ;
+  let cellSize: number;
+  if (volume > 0) {
+    cellSize = Math.cbrt(volume / count);
+  } else {
+    const largest = Math.max(spanX, spanY, spanZ);
+    cellSize = largest > 0 ? largest : 1;
+  }
+  if (!Number.isFinite(cellSize) || cellSize <= 0) cellSize = 1;
+
+  const dimX = Math.max(1, Math.floor(spanX / cellSize) + 1);
+  const dimY = Math.max(1, Math.floor(spanY / cellSize) + 1);
+  const dimZ = Math.max(1, Math.floor(spanZ / cellSize) + 1);
+
+  const cells = new Map<number, number[]>();
+  for (let i = 0; i < count; i++) {
+    const x = positions[i * 3], y = positions[i * 3 + 1], z = positions[i * 3 + 2];
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
+    const ix = Math.min(dimX - 1, Math.floor((x - minX) / cellSize));
+    const iy = Math.min(dimY - 1, Math.floor((y - minY) / cellSize));
+    const iz = Math.min(dimZ - 1, Math.floor((z - minZ) / cellSize));
+    const key = (ix * dimY + iy) * dimZ + iz;
+    const bucket = cells.get(key);
+    if (bucket === undefined) cells.set(key, [i]); else bucket.push(i);
+  }
+
+  return { positions, count, cellSize, min: [minX, minY, minZ], dims: [dimX, dimY, dimZ], cells };
+}
+
+/**
+ * Pick the point of smallest angular miss along `dir` from `origin` whose miss
+ * is under `tolerance`, or null when none qualifies.
+ *
+ * Identical in result to accepting `nearestPointAlongRay(...)` under
+ * `offset / along < tolerance`. `dir` need not be unit length. `accept`, when
+ * given, receives the point index and gates candidacy exactly as the linear
+ * scan's predicate does.
+ */
+export function pickAlongRay(
+  index: RayPickIndex,
+  origin: Vec3,
+  dir: Vec3,
+  tolerance: number,
+  accept?: (i: number) => boolean,
+): RayPickHit | null {
+  const { positions, count, cellSize, min, dims } = index;
+  if (count === 0) return null;
+
+  const len = Math.hypot(dir[0], dir[1], dir[2]);
+  if (!(len > 0) || !Number.isFinite(len)) return null;
+  const dx = dir[0] / len, dy = dir[1] / len, dz = dir[2] / len;
+  const ox = origin[0], oy = origin[1], oz = origin[2];
+  if (!Number.isFinite(ox) || !Number.isFinite(oy) || !Number.isFinite(oz)) return null;
+  if (!(tolerance > 0) || !Number.isFinite(tolerance)) return null;
+
+  const tolSq = tolerance * tolerance;
+
+  // Running winner. The tie-break (`i < bestIndex` on an exact score tie)
+  // reproduces the linear scan's lowest-index-wins regardless of visit order.
+  let bestScoreSq = Infinity;
+  let bestIndex = -1;
+  let bestPerpSq = 0;
+  let bestAlong = 0;
+  const consider = (i: number): void => {
+    if (accept !== undefined && !accept(i)) return;
+    const vx = positions[i * 3] - ox, vy = positions[i * 3 + 1] - oy, vz = positions[i * 3 + 2] - oz;
+    const along = vx * dx + vy * dy + vz * dz;
+    if (along <= 0) return;
+    const cx = vy * dz - vz * dy, cy = vz * dx - vx * dz, cz = vx * dy - vy * dx;
+    const perpSq = cx * cx + cy * cy + cz * cz;
+    const scoreSq = perpSq / (along * along);
+    if (scoreSq < bestScoreSq || (scoreSq === bestScoreSq && (bestIndex === -1 || i < bestIndex))) {
+      bestScoreSq = scoreSq; bestIndex = i; bestPerpSq = perpSq; bestAlong = along;
+    }
+  };
+
+  const finish = (): RayPickHit | null => {
+    if (bestIndex === -1 || bestScoreSq >= tolSq) return null;
+    return {
+      index: bestIndex,
+      point: [positions[bestIndex * 3], positions[bestIndex * 3 + 1], positions[bestIndex * 3 + 2]],
+      offset: Math.sqrt(bestPerpSq),
+      along: bestAlong,
+    };
+  };
+
+  const scanLinear = (): RayPickHit | null => {
+    for (let i = 0; i < count; i++) consider(i);
+    return finish();
+  };
+
+  // Degenerate grid: nothing to walk, scan exactly.
+  if (!Number.isFinite(cellSize) || cellSize <= 0 || index.cells.size === 0) {
+    return scanLinear();
+  }
+
+  const dimX = dims[0], dimY = dims[1], dimZ = dims[2];
+  const bMinX = min[0], bMinY = min[1], bMinZ = min[2];
+  const bMaxX = bMinX + dimX * cellSize;
+  const bMaxY = bMinY + dimY * cellSize;
+  const bMaxZ = bMinZ + dimZ * cellSize;
+
+  // Ray/box slab intersection, in the along parameter (dir is unit).
+  let tEnter = 0;
+  let tExit = Infinity;
+  const slab = (o: number, d: number, lo: number, hi: number): boolean => {
+    if (d === 0) return o >= lo && o <= hi; // parallel: inside the slab or never
+    let t0 = (lo - o) / d, t1 = (hi - o) / d;
+    if (t0 > t1) { const tmp = t0; t0 = t1; t1 = tmp; }
+    if (t0 > tEnter) tEnter = t0;
+    if (t1 < tExit) tExit = t1;
+    return tEnter <= tExit;
+  };
+  const hitsBox =
+    slab(ox, dx, bMinX, bMaxX) &&
+    slab(oy, dy, bMinY, bMaxY) &&
+    slab(oz, dz, bMinZ, bMaxZ);
+
+  if (!hitsBox || tExit <= 0) {
+    // The forward ray line never enters the cloud's box. A point could still
+    // fall inside the narrow acceptance cone near a corner, so this is not
+    // automatically empty; the exact linear scan settles it. This is the
+    // "hovering past the cloud" case, rare on the interactive hot path.
+    return scanLinear();
+  }
+  if (tEnter < 0) tEnter = 0;
+
+  // Walk the ray's span through the box, sampling at cell-length steps. Around
+  // each sampled cell, scan a cube of cells wide enough to hold any point whose
+  // angular miss is under tolerance at that distance: at along `a` such a point
+  // lies within `tolerance * a` of the line. `+ 2` covers cell quantisation and
+  // the up-to-one-cell gap between a point's true along and its nearest sample.
+  const visited = new Set<number>();
+  const cellOf = (a: number): [number, number, number] => {
+    const px = ox + a * dx, py = oy + a * dy, pz = oz + a * dz;
+    const cx = Math.min(dimX - 1, Math.max(0, Math.floor((px - bMinX) / cellSize)));
+    const cy = Math.min(dimY - 1, Math.max(0, Math.floor((py - bMinY) / cellSize)));
+    const cz = Math.min(dimZ - 1, Math.max(0, Math.floor((pz - bMinZ) / cellSize)));
+    return [cx, cy, cz];
+  };
+
+  // If the cone would sweep most of the grid, the walk saves nothing; scan.
+  const coneRadiusCellsAt = (a: number): number => Math.floor((tolerance * a) / cellSize) + 2;
+  if (coneRadiusCellsAt(tExit) * 2 + 1 >= Math.max(dimX, dimY, dimZ)) {
+    return scanLinear();
+  }
+
+  const scanCell = (cx: number, cy: number, cz: number): void => {
+    if (cx < 0 || cy < 0 || cz < 0 || cx >= dimX || cy >= dimY || cz >= dimZ) return;
+    const key = (cx * dimY + cy) * dimZ + cz;
+    if (visited.has(key)) return;
+    visited.add(key);
+    const bucket = index.cells.get(key);
+    if (bucket === undefined) return;
+    for (let k = 0; k < bucket.length; k++) consider(bucket[k]);
+  };
+
+  const step = cellSize;
+  for (let a = tEnter; a <= tExit + step; a += step) {
+    const clamped = a > tExit ? tExit : a;
+    const [cx, cy, cz] = cellOf(clamped);
+    const r = coneRadiusCellsAt(clamped);
+    for (let di = -r; di <= r; di++) {
+      for (let dj = -r; dj <= r; dj++) {
+        for (let dk = -r; dk <= r; dk++) {
+          scanCell(cx + di, cy + dj, cz + dk);
+        }
+      }
+    }
+    if (clamped === tExit) break;
+  }
+
+  return finish();
+}

--- a/tests/rayPick.test.ts
+++ b/tests/rayPick.test.ts
@@ -1,0 +1,168 @@
+/**
+ * rayPick.test.ts — the grid ray-picker must agree with the linear picker.
+ *
+ * The whole point of the index is speed WITHOUT a change in which point is
+ * picked. So the test is not "close enough": across randomized clouds and rays
+ * it diffs `pickAlongRay` against the shipping `nearestPointAlongRay` under the
+ * same angular acceptance gate, and requires the identical winning point index
+ * (and matching offset/along on that winner). Any grid bug that visits too few
+ * cells shows up here as a disagreement, not as a silently worse pick.
+ *
+ * Pure Node. No DOM, no three.js, no I/O, no Math.random — clouds and rays come
+ * from a seeded mulberry32 so every failure reproduces.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { buildRayPickIndex, pickAlongRay } from '../src/render/pick/rayPick';
+import { nearestPointAlongRay, type Vec3 } from '../src/render/navMath';
+
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function cloud(points: ReadonlyArray<readonly [number, number, number]>): Float32Array {
+  const out = new Float32Array(points.length * 3);
+  points.forEach((p, i) => { out[i * 3] = p[0]; out[i * 3 + 1] = p[1]; out[i * 3 + 2] = p[2]; });
+  return out;
+}
+
+/** What the linear picker accepts under `offset/along < tolerance`. */
+function linearIndex(positions: Float32Array, o: Vec3, d: Vec3, tol: number, accept?: (i: number) => boolean): number | null {
+  const hit = nearestPointAlongRay(positions, o, d, accept);
+  if (hit === null) return null;
+  return hit.offset / hit.along < tol ? hit.index : null;
+}
+
+const TOLERANCES = [0.02, 0.07, 0.3];
+
+describe('rayPick — small known cases', () => {
+  it('returns null on an empty cloud', () => {
+    const idx = buildRayPickIndex(new Float32Array(0));
+    expect(pickAlongRay(idx, [0, 0, 0], [1, 0, 0], 0.07)).toBeNull();
+  });
+
+  it('picks a point sitting on the ray', () => {
+    const idx = buildRayPickIndex(cloud([[5, 0, 0], [5, 4, 0]]));
+    const hit = pickAlongRay(idx, [0, 0, 0], [1, 0, 0], 0.07);
+    expect(hit?.index).toBe(0);
+    expect(hit?.along).toBeCloseTo(5, 9);
+    expect(hit?.offset).toBeCloseTo(0, 9);
+  });
+
+  it('ignores points behind the origin', () => {
+    const idx = buildRayPickIndex(cloud([[-5, 0, 0], [5, 0, 0]]));
+    expect(pickAlongRay(idx, [0, 0, 0], [1, 0, 0], 0.07)?.index).toBe(1);
+  });
+
+  it('rejects a point outside the angular tolerance', () => {
+    // offset 3, along 4 -> score 0.75, far above any tested tolerance.
+    const idx = buildRayPickIndex(cloud([[4, 3, 0]]));
+    expect(pickAlongRay(idx, [0, 0, 0], [1, 0, 0], 0.07)).toBeNull();
+  });
+
+  it('breaks an exact tie on the lowest point index', () => {
+    const idx = buildRayPickIndex(cloud([[5, 0, 0], [5, 0, 0], [5, 0, 0]]));
+    expect(pickAlongRay(idx, [0, 0, 0], [1, 0, 0], 0.07)?.index).toBe(0);
+  });
+
+  it('returns null for a zero-length or non-finite direction', () => {
+    const idx = buildRayPickIndex(cloud([[5, 0, 0]]));
+    expect(pickAlongRay(idx, [0, 0, 0], [0, 0, 0], 0.07)).toBeNull();
+    expect(pickAlongRay(idx, [0, 0, 0], [Number.NaN, 0, 0], 0.07)).toBeNull();
+  });
+
+  it('is scale-invariant in the direction (need not be unit length)', () => {
+    const idx = buildRayPickIndex(cloud([[5, 0.1, 0]]));
+    const a = pickAlongRay(idx, [0, 0, 0], [1, 0, 0], 0.07);
+    const b = pickAlongRay(idx, [0, 0, 0], [7, 0, 0], 0.07);
+    expect(a?.index).toBe(b?.index);
+    expect(a?.along).toBeCloseTo(b?.along ?? -1, 9);
+  });
+});
+
+describe('rayPick — parity with nearestPointAlongRay across randomized clouds', () => {
+  it('returns the identical winning point under the same acceptance gate', () => {
+    let hits = 0; // sanity: make sure we actually exercise the accepted branch
+    for (let seed = 1; seed <= 260; seed++) {
+      const rand = mulberry32(seed);
+      const n = [1, 2, 40, 400][seed % 4];
+      const scale = [1e-2, 1, 1e3][seed % 3];
+      const pts: Array<readonly [number, number, number]> = [];
+      for (let i = 0; i < n; i++) {
+        pts.push([rand() * scale, rand() * scale, rand() * scale]);
+      }
+      // Salt some clouds with exact duplicates and an axis-hugging line to
+      // stress ties and near-axis reordering.
+      if (seed % 5 === 0 && n > 3) {
+        pts.push([...pts[0]] as [number, number, number]);
+        for (let i = 0; i < 5; i++) pts.push([i * scale * 0.1, 1e-6 * scale, 0]);
+      }
+      const positions = cloud(pts);
+      const idx = buildRayPickIndex(positions);
+
+      for (const tol of TOLERANCES) {
+        for (let trial = 0; trial < 6; trial++) {
+          let o: Vec3;
+          let d: Vec3;
+          if (trial < 4) {
+            // Targeted ray: aim from a random origin roughly at a random point,
+            // so the accepted branch is frequently exercised.
+            const target = pts[Math.floor(rand() * pts.length)];
+            o = [rand() * scale, rand() * scale, -scale - rand() * scale];
+            d = [target[0] - o[0], target[1] - o[1], target[2] - o[2]];
+            // small jitter so it does not pass exactly through the point
+            d = [d[0] + (rand() - 0.5) * 0.02 * scale, d[1] + (rand() - 0.5) * 0.02 * scale, d[2]];
+          } else {
+            o = [rand() * scale, rand() * scale, rand() * scale];
+            d = [rand() - 0.5, rand() - 0.5, rand() - 0.5];
+          }
+          if (Math.hypot(d[0], d[1], d[2]) === 0) continue;
+
+          const lin = nearestPointAlongRay(positions, o, d);
+          const linScore = lin === null ? Infinity : lin.offset / lin.along;
+          const grid = pickAlongRay(idx, o, d, tol);
+
+          if (linScore < tol * (1 - 1e-6)) {
+            // Clearly accepted: the grid must return the same winning point.
+            expect(grid).not.toBeNull();
+            expect(grid?.index).toBe(lin?.index);
+            expect(grid?.along).toBeCloseTo(lin?.along ?? -1, 6);
+            expect(grid?.offset).toBeCloseTo(lin?.offset ?? -1, 6);
+            hits++;
+          } else if (linScore > tol * (1 + 1e-6)) {
+            // Clearly rejected: nothing is inside the cone.
+            expect(grid).toBeNull();
+          }
+          // else: within a hair of the gate boundary — skip (ULP-sensitive).
+        }
+      }
+    }
+    expect(hits).toBeGreaterThan(200);
+  });
+
+  it('honours an accept predicate identically to the linear scan', () => {
+    for (let seed = 1; seed <= 120; seed++) {
+      const rand = mulberry32(seed * 7 + 3);
+      const pts: Array<readonly [number, number, number]> = [];
+      for (let i = 0; i < 120; i++) pts.push([rand() * 100, rand() * 100, rand() * 100]);
+      const positions = cloud(pts);
+      const idx = buildRayPickIndex(positions);
+      const accept = (i: number): boolean => i % 3 !== 0;
+
+      const target = pts[Math.floor(rand() * pts.length)];
+      const o: Vec3 = [rand() * 100, rand() * 100, -120];
+      const d: Vec3 = [target[0] - o[0], target[1] - o[1], target[2] - o[2]];
+      const tol = 0.1;
+
+      const lin = linearIndex(positions, o, d, tol, accept);
+      const grid = pickAlongRay(idx, o, d, tol, accept);
+      expect(grid === null ? null : grid.index).toBe(lin);
+    }
+  });
+});


### PR DESCRIPTION
First v0.6.8 interaction-feel piece. Interactive picking (`nearestPointAlongRay`) scans the whole position buffer per query on the pointer-move probe path — the interaction-latency bottleneck on multi-million-point clouds.

`src/render/pick/rayPick.ts` builds a uniform cell grid once per position buffer and answers an angular-miss pick by walking only the acceptance cone's cells. It returns the identical winning point as the linear scan (same perpendicular/along metric, lowest-index tie-break, in-front rule); `tests/rayPick.test.ts` fuzzes it against `nearestPointAlongRay` across randomized clouds and rays and requires exact winning-index parity. Degenerate grids, rays that miss the cloud box, and wide cones fall back to the exact linear scan.

Staged, not wired: the latency win needs browser measurement and the Viewer wire-in is a follow-up. Registered staged in `unreachable-modules.json`. No shipping behavior changes.