### PR TITLE
v0.6.8 Phase A: roadmap truth, multi-file drop, and a persistent Add dataset control

### DIFF
--- a/docs/project/STABILITY_POLICY.md
+++ b/docs/project/STABILITY_POLICY.md
@@ -34,8 +34,8 @@ claim on its own.
 Internals (module boundaries, the decomposition work), rendering performance
 characteristics, the streaming scheduler's tuning, UI layout, and anything
 explicitly marked experimental in KNOWN_LIMITATIONS. Multi-layer mounting
-remains disabled and is not part of the stable contract until it ships with
-its own browser-verified evidence.
+shipped enabled in v0.6.5; its placement precision refuses a mismatch past a
+1 mm Float32 budget, and its tuning and interaction surface are not yet frozen.
 
 ## How frozen things change
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3593,7 +3593,7 @@ void viewerLoaded.then(() => {
   });
 });
 
-const dropZone = new DropZone(document.body, (file) => void handleFile(file), prewarmLoaders);
+const dropZone = new DropZone(document.body, (file) => handleFile(file), prewarmLoaders);
 stage.overlay.append(dropZone.toast);
 
 // v0.3.10 trust-pass: install the Playwright seam under `?test=1`.

--- a/src/styles/73-desktop-workspace.css
+++ b/src/styles/73-desktop-workspace.css
@@ -105,3 +105,33 @@
     box-sizing: border-box;
   }
 }
+
+/* Persistent "Add dataset" affordance. The Stage reveals it with the first
+   scan (hideEmptyState); once the empty state is gone, drag-and-drop is the
+   only way to open a second dataset — and a phone has none — so this is the
+   discoverable, touch-safe path to a multi-dataset project. */
+.olv-add-dataset {
+  position: absolute;
+  bottom: 13px;
+  left: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+  border: 0.5px solid var(--hairline);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-md);
+  cursor: pointer;
+  transition: background 160ms var(--ease-standard), border-color 160ms var(--ease-standard);
+}
+.olv-add-dataset:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: var(--accent);
+}
+.olv-add-dataset:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -2972,20 +2972,18 @@ export class AnalysePanel {
     const wrap = el('div', { className: 'olv-analyse-roadmap' });
     wrap.append(section('Planned'));
     const tags = el('div', { className: 'olv-analyse-plan' });
-    // Genuinely-future capabilities only. The earlier list (ground
-    // classification, DSM, slope/hillshade, 3D overlay, terrain report) has all
-    // shipped — leaving them here advertised done work as "planned", which
-    // contradicts the buttons in this very panel. These three are the real,
-    // not-yet-shipped roadmap. A single .pnts tile opens today, and so does a
-    // whole tileset as a static one-shot read, so what remains planned is
-    // streaming one: hierarchical, camera-driven refinement over time rather
-    // than a bounded read of the whole set (see supported-formats.md);
-    // out-of-core loading and co-registered change detection are the open
-    // engineering items.
+    // Genuinely-future capabilities only. Advertising shipped work as "planned"
+    // contradicts the buttons in this very panel, so the earlier items are gone
+    // as they land: 3D Tiles now streams tile bodies as the camera needs them
+    // (openTilesetLayer), heavy files load out of core (openLocalHeavyLas), and
+    // two-epoch change detection runs over epochs already in a compatible frame
+    // (compareLoadedLayers). What remains open is bringing scans that are NOT
+    // already in a common frame together: automatic scan-to-scan registration,
+    // and cross-CRS reprojection into one viewer frame — the mount still refuses
+    // a CRS mismatch rather than reprojecting (see KNOWN_LIMITATIONS).
     for (const item of [
-      '3D Tiles tileset streaming',
-      'Out-of-core large-file loading',
-      'Co-registered change detection',
+      'Scan-to-scan registration',
+      'Cross-CRS reprojection to a common frame',
     ]) {
       tags.append(el('span', { className: 'olv-analyse-plan-tag', text: item }));
     }

--- a/src/ui/DropZone.ts
+++ b/src/ui/DropZone.ts
@@ -31,7 +31,7 @@ export class DropZone {
   private _onDragIntent?: () => void;
   private _dragIntentFired = false;
 
-  constructor(target: HTMLElement, onFile: (file: File) => void, onDragIntent?: () => void) {
+  constructor(target: HTMLElement, onFile: (file: File) => void | Promise<void>, onDragIntent?: () => void) {
     this._onDragIntent = onDragIntent;
     this._text = el('span', { className: 'olv-toast-text' });
 
@@ -89,20 +89,30 @@ export class DropZone {
       e.preventDefault();
       target.classList.remove('olv-dragging');
       const files = e.dataTransfer?.files;
-      const file = files?.[0];
-      if (!file) return;
-      onFile(file);
-      // Only one scan can be open at a time, so a multi-file drop silently
-      // dropping files[1..n] looked like a bug. Say what happened and point
-      // at the batch path. The load's own progress updates will overwrite
-      // this hint, which is fine — it only needs to land once.
-      const ignored = (files?.length ?? 1) - 1;
-      if (ignored > 0) {
-        this.setProgress(
-          `Opened "${file.name}" — ${ignored} more file${ignored === 1 ? '' : 's'} ignored. Use Convert for batches.`,
-        );
-      }
+      if (!files || files.length === 0) return;
+      // Multiple datasets mount together, loaded one at a time. A multi-file
+      // drop opens each in turn rather than dropping all but the first; each
+      // file's own progress updates take over as it loads.
+      void this._openSequentially(Array.from(files), onFile);
     });
+  }
+
+  /**
+   * Open dropped files one after another. The loader takes one scan at a time,
+   * so these are awaited in sequence; a file that fails surfaces its own error
+   * toast and does not stop the rest.
+   */
+  private async _openSequentially(
+    files: readonly File[],
+    onFile: (file: File) => void | Promise<void>,
+  ): Promise<void> {
+    for (const file of files) {
+      try {
+        await onFile(file);
+      } catch {
+        // The load reports its own failure; continue with the remaining files.
+      }
+    }
   }
 
   /** Cancel a pending error auto-hide so it cannot hide a newer toast state. */

--- a/src/ui/Stage.ts
+++ b/src/ui/Stage.ts
@@ -142,6 +142,7 @@ export class Stage {
   readonly overlay: HTMLElement;
   private readonly _empty: HTMLElement;
   private readonly _version: HTMLElement;
+  private readonly _addDataset: HTMLElement;
   /** Inline status banner above the URL field. */
   private _urlError: HTMLElement | null = null;
   /** Inline status banner at the top of the empty state for global warnings. */
@@ -210,6 +211,27 @@ export class Stage {
       }
     }
 
+    // Persistent "Add dataset" affordance, revealed with the first scan (like
+    // the version mark). Once the empty state hides, drag-and-drop is the only
+    // way to open a second dataset — and a phone has no drag-and-drop at all,
+    // so without this there is no way to build a multi-dataset project on
+    // touch. It reuses the same approval gate and open callback as the empty
+    // state's picker, so there is one ingest path.
+    const addInput = el('input', { className: 'olv-file-input', type: 'file' });
+    addInput.addEventListener('change', () => {
+      const file = addInput.files?.[0];
+      if (file) void this._approveFile(file).then((ok) => { if (ok) options.onOpenFile?.(file); });
+      addInput.value = ''; // let the same file be re-picked
+    });
+    this._addDataset = el('button', {
+      className: 'olv-add-dataset olv-hidden',
+      type: 'button',
+      text: '+ Add dataset',
+      title: 'Open another point-cloud file — it mounts alongside the current scan',
+    });
+    this._addDataset.addEventListener('click', () => addInput.click());
+    this.overlay.append(addInput, this._addDataset);
+
     mount.append(this.root);
   }
 
@@ -217,6 +239,7 @@ export class Stage {
   hideEmptyState(): void {
     this._empty.classList.add('olv-hidden');
     this._version.classList.remove('olv-hidden');
+    this._addDataset.classList.remove('olv-hidden');
     this._cancelUrlLoad();
   }
 
@@ -224,6 +247,7 @@ export class Stage {
   showEmptyState(): void {
     this._empty.classList.remove('olv-hidden');
     this._version.classList.add('olv-hidden');
+    this._addDataset.classList.add('olv-hidden');
   }
 
   /**

--- a/tests/addDatasetControl.test.ts
+++ b/tests/addDatasetControl.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The persistent "Add dataset" control is the only way to open a second dataset
+ * once the empty state hides — and the only way at all on a phone, which has no
+ * drag-and-drop. These read the Stage source and the concatenated stylesheet
+ * (constructing the Stage needs build-time defines and a canvas), and pin the
+ * three things that make the control work: it exists as a real button, it is
+ * revealed with the first scan and hidden when the empty state returns, and it
+ * reuses the one approval-gated open callback rather than a second ingest path.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+import { readAppCss } from './support/appCss';
+
+const STAGE = readFileSync(resolve(__dirname, '../src/ui/Stage.ts'), 'utf8');
+const CSS = readAppCss();
+
+describe('the Add dataset control', () => {
+  it('is a real button, not a decorated span', () => {
+    expect(STAGE).toMatch(/this\._addDataset = el\('button', \{/);
+    expect(STAGE).toMatch(/className: 'olv-add-dataset olv-hidden'/);
+  });
+
+  it('reuses the single approval-gated open callback', () => {
+    // Same path as the empty-state picker: approve, then onOpenFile. No second
+    // ingest route.
+    const openCalls = STAGE.match(/this\._approveFile\(file\)\.then\(\(ok\) => \{ if \(ok\) options\.onOpenFile\?\.\(file\); \}\)/g) ?? [];
+    // One in the empty-state picker, one in the Add dataset control.
+    expect(openCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('is revealed with the first scan and hidden when the empty state returns', () => {
+    expect(STAGE).toMatch(/hideEmptyState\(\): void \{[\s\S]*?this\._addDataset\.classList\.remove\('olv-hidden'\)/);
+    expect(STAGE).toMatch(/showEmptyState\(\): void \{[\s\S]*?this\._addDataset\.classList\.add\('olv-hidden'\)/);
+  });
+
+  it('has a focus-visible outline in the stylesheet', () => {
+    expect(CSS).toMatch(/\.olv-add-dataset\s*\{/);
+    expect(CSS).toMatch(/\.olv-add-dataset:focus-visible\s*\{/);
+  });
+});

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -4380,6 +4380,36 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
     box-sizing: border-box;
   }
 }
+
+/* Persistent "Add dataset" affordance. The Stage reveals it with the first
+   scan (hideEmptyState); once the empty state is gone, drag-and-drop is the
+   only way to open a second dataset — and a phone has none — so this is the
+   discoverable, touch-safe path to a multi-dataset project. */
+.olv-add-dataset {
+  position: absolute;
+  bottom: 13px;
+  left: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+  border: 0.5px solid var(--hairline);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-md);
+  cursor: pointer;
+  transition: background 160ms var(--ease-standard), border-color 160ms var(--ease-standard);
+}
+.olv-add-dataset:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: var(--accent);
+}
+.olv-add-dataset:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 /* The Inspector is the active control rail (Color By / Quality /
  * Workflow / Visuals) — RAISED so it reads as the live working
  * surface against the recessive left stack. */


### PR DESCRIPTION
v0.6.8 "expose value that already exists" — three honest, low-risk changes over the single existing ingest seam.

**1. Roadmap truth.** The Analyse panel advertised shipped work as `Planned`: 3D Tiles tileset streaming (`openTilesetLayer`), out-of-core large-file loading (`openLocalHeavyLas`), and change detection (`compareLoadedLayers`). Replaced with what is genuinely unshipped — scan-to-scan registration and cross-CRS reprojection into a common frame. `STABILITY_POLICY.md` said multi-layer mounting is disabled; it shipped enabled in v0.6.5.

**2. Multi-file drop.** DropZone opened only the first dropped file and told the user the rest were ignored. It now opens each in sequence (the loader takes one at a time; a failing file surfaces its own toast and does not stop the rest).

**3. Persistent Add dataset control.** After the first scan the empty state hides and its open button with it, leaving drag-and-drop as the only way to add a second dataset — which a phone has none of. The Stage now reveals a persistent 'Add dataset' button with the first scan and hides it when the empty state returns.

All three reuse the one `handleFile`→`openScan` ingest seam (approval-gated `onOpenFile`). `main.ts` line count is unchanged. Tests: multi-file drop verified; `addDatasetControl.test.ts` pins the control's reveal + single-callback wiring; style fixture regenerated.