### PR TITLE
fix(audit): AGPL license in MANIFEST + SBOM root, with guards (v0.6.8 P0-1A)

### DIFF
--- a/docs/project/MANIFEST.md
+++ b/docs/project/MANIFEST.md
@@ -54,4 +54,4 @@ development runs.
 
 ## License
 
-AGPL-3.0-only. See `LICENSE`. Releases through v0.6.6 were published under MIT.
+AGPL-3.0-only. See `LICENSE`. Earlier releases were published under MIT.

--- a/docs/project/MANIFEST.md
+++ b/docs/project/MANIFEST.md
@@ -54,4 +54,4 @@ development runs.
 
 ## License
 
-MIT. See `LICENSE`.
+AGPL-3.0-only. See `LICENSE`. Releases through v0.6.6 were published under MIT.

--- a/docs/validation/test-evidence.json
+++ b/docs/validation/test-evidence.json
@@ -87,7 +87,7 @@
   },
   "packageLockSha256": "523848f026420b04adc4b8b71ae930a6cadc5f6aa9b6a8b37819af7b83ebf7f4",
   "sbom": {
-    "sha256": "e3a18fbde9e5670f14d4047ba097c8e9eb495df12d6fabc91c1584700b2241c7",
+    "sha256": "1adf57a8b8001fc568412f30116008593d5a09e6eefda14000e74384f3e35738",
     "rootName": "openlidarviewer",
     "rootVersion": "0.6.7",
     "bomRef": "openlidarviewer@0.6.7",

--- a/sbom.json
+++ b/sbom.json
@@ -89,7 +89,7 @@
       "licenses": [
         {
           "license": {
-            "id": "MIT",
+            "id": "AGPL-3.0-only",
             "acknowledgement": "declared"
           }
         }

--- a/scripts/lint-license.mjs
+++ b/scripts/lint-license.mjs
@@ -55,6 +55,13 @@ export function checkLicense(root) {
   must(/license:\s*AGPL-3\.0-only/.test(cff), 'CITATION.cff license is not AGPL-3.0-only.');
   must(!/license:\s*MIT\b/.test(cff), 'CITATION.cff still declares MIT as the current license.');
 
+  // The project manifest's own License section. A historical "released under MIT
+  // through v0.6.6" sentence stays legal; what fails is the section leading with
+  // a bare MIT declaration (the stale "MIT. See LICENSE." this closed).
+  const manifest = read('docs/project/MANIFEST.md') || '';
+  must(/AGPL-3\.0-only/.test(manifest), 'docs/project/MANIFEST.md does not state AGPL-3.0-only as the current license.');
+  must(!/##\s*License\s*\n+\s*MIT\b/.test(manifest), 'docs/project/MANIFEST.md still declares MIT as the current license.');
+
   // The archival and machine-readable metadata surfaces. These carry the
   // license to Zenodo and to software indexers, and on the v0.6.7 relicense
   // both shipped MIT and were caught only by hand — lint:license did not read

--- a/scripts/lint-sbom.mjs
+++ b/scripts/lint-sbom.mjs
@@ -88,6 +88,16 @@ export function collectSbomProblems(read) {
     }
   }
 
+  // 2b. Root FIRST-PARTY licence must equal package.json.license. Only the root
+  // is checked; dependency components keep their own (often MIT) licences. A
+  // stale root licence shipped once — an MIT root on the AGPL release.
+  const rootLicenseId = Array.isArray(root.licenses) ? root.licenses[0]?.license?.id : undefined;
+  if (rootLicenseId !== pkg.license) {
+    problems.push(
+      `sbom.json root component license is ${JSON.stringify(rootLicenseId)}, expected "${pkg.license}" (package.json.license).`,
+    );
+  }
+
   // 3 + 4. Direct production dependencies present, at their LOCKED versions.
   //
   // The locked version is the authority: a range in package.json ("^4.4.2")

--- a/scripts/sync-provenance.mjs
+++ b/scripts/sync-provenance.mjs
@@ -155,6 +155,11 @@ function syncSbom(text, { pkg, lockedVersion }) {
     rootC.version = rootVersion;
     rootC['bom-ref'] = rootRef;
     if (rootC.purl) rootC.purl = bumpPurlVersion(rootC.purl, rootVersion);
+    // The FIRST-PARTY licence tracks package.json, so a relicence updates the
+    // SBOM root instead of preserving stale curated metadata. Only the root
+    // component is touched; dependency licences stay as curated.
+    const rootLicense = rootC.licenses?.[0]?.license;
+    if (rootLicense && typeof pkg.license === 'string') rootLicense.id = pkg.license;
   }
 
   // Every listed component -> its locked version.

--- a/tests/licenseLint.test.ts
+++ b/tests/licenseLint.test.ts
@@ -22,6 +22,7 @@ function writeValidFixture(root: string): void {
   w('CITATION.cff', 'cff-version: 1.2.0\nversion: "0.6.7"\nlicense: AGPL-3.0-only\n');
   w('.zenodo.json', JSON.stringify({ title: 'OpenLiDARViewer', upload_type: 'software', license: 'AGPL-3.0-only' }, null, 2));
   w('codemeta.json', JSON.stringify({ name: 'OpenLiDARViewer', version: '0.6.7', license: 'https://spdx.org/licenses/AGPL-3.0-only.html' }, null, 2));
+  w('docs/project/MANIFEST.md', '# Manifest\n\n## License\n\nAGPL-3.0-only. See `LICENSE`. Releases through v0.6.6 were published under MIT.\n');
   w('README.md', [
     '[![License](https://img.shields.io/badge/license-AGPL--3.0--only-blue)](LICENSE)',
     '## License',
@@ -76,6 +77,17 @@ describe('lint:license boundary', () => {
   it('rejects .zenodo.json declaring MIT', () => {
     writeFileSync(resolve(root, '.zenodo.json'), JSON.stringify({ title: 'x', upload_type: 'software', license: 'MIT' }, null, 2));
     expect(checkLicense(root).some((p: string) => /\.zenodo\.json license/.test(p))).toBe(true);
+  });
+
+  it('rejects docs/project/MANIFEST.md declaring MIT as the current license', () => {
+    writeFileSync(resolve(root, 'docs/project/MANIFEST.md'), '# Manifest\n\n## License\n\nMIT. See `LICENSE`.\n');
+    expect(checkLicense(root).some((p: string) => /MANIFEST\.md/.test(p))).toBe(true);
+  });
+
+  it('ACCEPTS MANIFEST.md naming MIT only as historical', () => {
+    // The valid fixture's MANIFEST already carries "released under MIT through
+    // v0.6.6"; that historical sentence must not trip the guard.
+    expect(checkLicense(root)).toEqual([]);
   });
 
   it('rejects codemeta.json declaring the MIT SPDX URL', () => {

--- a/tests/sbomLint.test.ts
+++ b/tests/sbomLint.test.ts
@@ -29,6 +29,8 @@ function withSbom(mutate: (sbom: Record<string, unknown>) => void) {
   return (p: string): string | null => (p === 'sbom.json' ? JSON.stringify(sbom) : realRead(p));
 }
 
+type RootLicensed = { metadata: { component: { licenses: Array<{ license: { id?: string } }> } } };
+
 describe('lint:sbom', () => {
   it('passes on the committed SBOM', () => {
     expect(problemsFor(realRead)).toEqual([]);
@@ -41,6 +43,33 @@ describe('lint:sbom', () => {
     const scoped = sbom.components.filter((c: { group?: string }) => c.group);
     expect(scoped.length).toBeGreaterThan(0);
     expect(problemsFor(realRead)).toEqual([]);
+  });
+
+  it('fails when the root component license is MIT on the AGPL release', () => {
+    const problems = problemsFor(
+      withSbom((s) => {
+        (s as unknown as RootLicensed).metadata.component.licenses[0].license.id = 'MIT';
+      }),
+    );
+    expect(problems.some((p) => /root component license/.test(p))).toBe(true);
+  });
+
+  it('fails when the root component carries a different SPDX id', () => {
+    const problems = problemsFor(
+      withSbom((s) => {
+        (s as unknown as RootLicensed).metadata.component.licenses[0].license.id = 'GPL-3.0-only';
+      }),
+    );
+    expect(problems.some((p) => /root component license/.test(p))).toBe(true);
+  });
+
+  it('fails when the root component has no license', () => {
+    const problems = problemsFor(
+      withSbom((s) => {
+        delete (s as unknown as { metadata: { component: { licenses?: unknown } } }).metadata.component.licenses;
+      }),
+    );
+    expect(problems.some((p) => /root component license/.test(p))).toBe(true);
   });
 
   it('fails when a direct production dependency is absent', () => {


### PR DESCRIPTION
First v0.6.8 auditability delta. Two current-license surfaces still declared MIT on the AGPL-3.0-only release, and no lint covered either:

- `docs/project/MANIFEST.md` ended `MIT. See LICENSE.` → AGPL-3.0-only (historical MIT-through-v0.6.6 noted).
- `sbom.json` root `metadata.component` license was MIT → AGPL-3.0-only. Its dependency components keep their own (often MIT) licenses, correctly.

Guards so it can't recur:
- `lint:license` now checks the MANIFEST License section (a historical 'released under MIT through v0.6.6' sentence stays legal; a bare MIT declaration fails).
- `lint:sbom` asserts the root component license equals `package.json.license`.
- `syncSbom()` updates the root license on a relicense instead of preserving stale curated metadata.

Negative controls: MIT root, other-SPDX root, absent root license, MIT MANIFEST. 26 license/sbom tests pass; lint:license/sbom/release-sync/release-truth all green. No new framework — existing lints extended.