### PR TITLE
fix(audit): resync DEPENDENCIES.md to lockfile and add a drift guard

### DIFF
--- a/docs/project/DEPENDENCIES.md
+++ b/docs/project/DEPENDENCIES.md
@@ -19,12 +19,12 @@ unaffected.
 
 | Field | Value |
 |---|---|
-| Release line | v0.6.6 |
+| Release line | v0.6.7 |
 | Baseline date (UTC) | 2026-07-25 |
 | Canonical Node | 22.17.1 (`.nvmrc`) |
 | Canonical npm | 10.9.2 (`package.json` `packageManager`) |
 | `package-lock` lockfileVersion | 3 |
-| SBOM | CycloneDX 1.6, root `openlidarviewer@0.6.6`, 56 components |
+| SBOM | CycloneDX 1.6, root `openlidarviewer@0.6.7`, 56 components |
 
 The CycloneDX bill of materials for the production dependency set is in
 [sbom.json](../../sbom.json). Licences are credited in
@@ -39,10 +39,10 @@ These ship in the deploy archive.
 | @fontsource-variable/inter | ^5.3.0 | 5.3.0 | OFL-1.1 |
 | @fontsource/jetbrains-mono | ^5.3.0 | 5.3.0 | OFL-1.1 |
 | @fontsource/manrope | ^5.3.0 | 5.3.0 | OFL-1.1 |
-| @loaders.gl/core | ^4.4.2 | 4.4.3 | MIT |
+| @loaders.gl/core | ^4.4.2 | 4.4.4 | MIT |
 | @loaders.gl/gltf | ^4.4.2 | 4.4.3 | MIT |
 | @loaders.gl/obj | ^4.4.2 | 4.4.3 | MIT |
-| @loaders.gl/ply | ^4.4.2 | 4.4.3 | MIT |
+| @loaders.gl/ply | ^4.4.2 | 4.4.4 | MIT |
 | laz-perf | ^0.0.7 | 0.0.7 | Apache-2.0 |
 | pdf-lib | ^1.17.1 | 1.17.1 | MIT |
 | proj4 | ^2.21.0 | 2.21.0 | MIT |
@@ -54,15 +54,15 @@ Build, test, docs, and mutation tooling. None reaches the deployed app.
 
 | Package | Declared range | Resolved | License |
 |---|---|---|---|
-| @playwright/test | ^1.60.0 | 1.62.0 | Apache-2.0 |
+| @playwright/test | ^1.60.0 | 1.62.1 | Apache-2.0 |
 | @stryker-mutator/core | ^9.6.1 | 9.6.1 | Apache-2.0 |
 | @stryker-mutator/vitest-runner | ^9.6.1 | 9.6.1 | Apache-2.0 |
 | @types/proj4 | ^2.19.0 | 2.19.0 | MIT |
 | @types/three | ^0.184.1 | 0.184.1 | MIT |
 | @vitest/coverage-v8 | ^4.1.10 | 4.1.10 | MIT |
-| rollup-plugin-visualizer | ^7.0.1 | 7.0.1 | MIT |
+| rollup-plugin-visualizer | ^7.0.1 | 7.1.1 | MIT |
 | typescript | ~7.0.2 | 7.0.2 | Apache-2.0 |
-| vite | ^8.1.5 | 8.1.5 | MIT |
+| vite | ^8.1.5 | 8.2.1 | MIT |
 | vite-plugin-javascript-obfuscator | ^3.1.0 | 3.1.0 | MIT |
 | vitepress | 1.6.4 | 1.6.4 | MIT |
 | vitest | ^4.1.7 | 4.1.10 | MIT |

--- a/tests/dependenciesDocSync.test.ts
+++ b/tests/dependenciesDocSync.test.ts
@@ -1,0 +1,59 @@
+/**
+ * dependenciesDocSync.test.ts — docs/project/DEPENDENCIES.md is a committed
+ * baseline that restates resolved dependency versions, the release line, and
+ * the SBOM root reference. Those figures drift silently every time a
+ * dependency is bumped or the version rolls, and nothing compared the prose
+ * against package-lock.json or package.json. These tests bind each restated
+ * figure to its source of truth so a stale baseline fails the suite.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p: string): string => readFileSync(resolve(ROOT, p), 'utf8');
+
+const doc = read('docs/project/DEPENDENCIES.md');
+const pkg = JSON.parse(read('package.json')) as { version: string };
+const lock = JSON.parse(read('package-lock.json')) as {
+  packages: Record<string, { version?: string }>;
+};
+
+/** Every `| name | range | resolved | ... |` row whose name is a real package. */
+function docRows(): Array<{ name: string; resolved: string }> {
+  const rows: Array<{ name: string; resolved: string }> = [];
+  for (const line of doc.split('\n')) {
+    const m = line.match(/^\|\s*(@?[\w./-]+)\s*\|\s*(?:[\^~][\d.]+|[\d.]+)\s*\|\s*([\d.]+)\s*\|/);
+    if (!m) continue;
+    const name = m[1].trim();
+    if (lock.packages[`node_modules/${name}`]) rows.push({ name, resolved: m[2].trim() });
+  }
+  return rows;
+}
+
+describe('DEPENDENCIES.md stays in sync with its sources', () => {
+  it('lists real package rows to compare', () => {
+    expect(docRows().length).toBeGreaterThan(5);
+  });
+
+  it('every restated resolved version matches package-lock.json', () => {
+    const drift = docRows()
+      .map(({ name, resolved }) => ({ name, resolved, lock: lock.packages[`node_modules/${name}`].version }))
+      .filter((r) => r.resolved !== r.lock);
+    expect(drift).toEqual([]);
+  });
+
+  it('the release line names the current package version', () => {
+    const m = doc.match(/^\|\s*Release line\s*\|\s*v([\d.]+)\s*\|/m);
+    expect(m, 'no "Release line" row found').not.toBeNull();
+    expect(m![1]).toBe(pkg.version);
+  });
+
+  it('the SBOM root reference names the current package version', () => {
+    const m = doc.match(/root `openlidarviewer@([\d.]+)`/);
+    expect(m, 'no SBOM root reference found').not.toBeNull();
+    expect(m![1]).toBe(pkg.version);
+  });
+});


### PR DESCRIPTION
The committed dependency baseline had drifted from the shipped tree. Update the release line and SBOM root reference to v0.6.7, and correct five resolved versions (loaders.gl core and ply 4.4.3 to 4.4.4, @playwright/test 1.62.0 to 1.62.1, rollup-plugin-visualizer 7.0.1 to 7.1.1, vite 8.1.5 to 8.2.1) to match package-lock.json.

Add tests/dependenciesDocSync.test.ts, which binds every restated resolved version in the doc to package-lock.json and the release line and SBOM root reference to package.json. Red-green verified: the tests fail on reintroduced drift and pass on the corrected baseline. This closes the class rather than the instance.