### PR TITLE
fix(audit): guard mount-state prose against MULTI_LAYER_MOUNT_ENABLED

### DIFF
--- a/scripts/lint-architecture-truth.mjs
+++ b/scripts/lint-architecture-truth.mjs
@@ -44,6 +44,21 @@ const read = (rel) => {
 };
 const countLines = (rel) => read(rel).split('\n').length;
 
+/**
+ * The mount state a document asserts in words, as 'enabled' | 'disabled', or
+ * null when it makes no present-tense assertion. Matches a PRESENT-TENSE verb
+ * (is/ships/shipped/remains/stays/now) so a historical "was disabled before
+ * v0.6.5" does not register; runs on whitespace-normalised text because the
+ * assertion wraps across a line break ("Multi-layer mounting\nshipped
+ * enabled"); and the [^.] gap stops at a sentence period, so a historical
+ * clause cannot reach a later present-tense verb inside the same match.
+ */
+export function mountStateFromProse(text) {
+  const re = /multi-layer\s+mount(?:ing)?\b[^.]{0,30}?\b(?:is|ships|shipped|remains|stays|now)\s+(enabled|disabled)\b/i;
+  const m = String(text).replace(/\s+/g, ' ').match(re);
+  return m ? m[1].toLowerCase() : null;
+}
+
 const problems = [];
 /** Checks deliberately not performed (absent optional documents). */
 const notes = [];
@@ -145,6 +160,21 @@ const fact = (name, value) => {
       if (claim && (claim[1].toLowerCase() === 'true') !== enabled) {
         problems.push(
           `${rel}: states MULTI_LAYER_MOUNT_ENABLED is ${claim[1]}; the code sets it to ${m[1]}.`,
+        );
+      }
+    }
+    // The policy prose states the mount state in words, not by flag name — the
+    // The policy prose states the mount state in words, not by flag name — the
+    // v0.6.4 "mount is disabled" line outlived the v0.6.5 flip and no check
+    // covered STABILITY_POLICY. Hold that present-tense assertion to the flag.
+    for (const rel of ['docs/project/STABILITY_POLICY.md', ...archDocs()]) {
+      const abs = resolve(ROOT, rel);
+      if (!existsSync(abs)) continue;
+      const stated = mountStateFromProse(read(rel));
+      if (stated && (stated === 'enabled') !== enabled) {
+        problems.push(
+          `${rel}: describes multi-layer mounting as ${stated}; the code sets `
+          + `MULTI_LAYER_MOUNT_ENABLED = ${m[1]}.`,
         );
       }
     }

--- a/tests/mountStateProse.test.ts
+++ b/tests/mountStateProse.test.ts
@@ -1,0 +1,53 @@
+/**
+ * mountStateProse.test.ts — lint:architecture-truth holds the mount-state prose
+ * in STABILITY_POLICY to the MULTI_LAYER_MOUNT_ENABLED flag. The prose states
+ * the state in words, and the v0.6.4 "mount is disabled" line outlived the
+ * v0.6.5 flip with no check covering it. These tests pin the detector: it reads
+ * the current state, ignores a historical clause, and matches across a wrap.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+// @ts-expect-error — plain .mjs lint script, no types
+import { mountStateFromProse } from '../scripts/lint-architecture-truth.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('mountStateFromProse', () => {
+  it('reads the shipped-enabled assertion, even wrapped across a line', () => {
+    expect(mountStateFromProse('Multi-layer mounting\nshipped enabled in v0.6.5.')).toBe('enabled');
+  });
+
+  it('reads a disabled assertion', () => {
+    expect(mountStateFromProse('Multi-layer mounting is disabled by default.')).toBe('disabled');
+  });
+
+  it('ignores a purely historical clause (no present-tense verb reachable)', () => {
+    expect(mountStateFromProse('Multi-layer mounting was disabled before v0.6.5.')).toBeNull();
+  });
+
+  it('skips a historical sentence and reads a later present-tense one', () => {
+    // The first sentence names mounting but has no present-tense verb, so the
+    // match backtracks to the second, present-tense assertion.
+    expect(
+      mountStateFromProse(
+        'Multi-layer mounting was disabled in v0.6.4. Multi-layer mounting now ships enabled.',
+      ),
+    ).toBe('enabled');
+  });
+
+  it('returns null when the document says nothing about mounting', () => {
+    expect(mountStateFromProse('The session schema is at version 7.')).toBeNull();
+  });
+
+  it('agrees with the shipped policy document and the live flag', () => {
+    const policy = readFileSync(resolve(ROOT, 'docs/project/STABILITY_POLICY.md'), 'utf8');
+    const svc = readFileSync(resolve(ROOT, 'src/app/LayerService.ts'), 'utf8');
+    const enabled = /MULTI_LAYER_MOUNT_ENABLED\s*=\s*true/.test(svc);
+    const stated = mountStateFromProse(policy);
+    expect(stated).not.toBeNull();
+    expect(stated === 'enabled').toBe(enabled);
+  });
+});


### PR DESCRIPTION
lint:architecture-truth checked only the literal `MULTI_LAYER_MOUNT_ENABLED is true/false` and scanned only docs/architecture. The mount state that the policy actually states is natural-language — "Multi-layer mounting shipped enabled" in docs/project/STABILITY_POLICY.md — which no check covered. That is how the v0.6.4 "disabled" line outlived the v0.6.5 flip until #719 fixed it by hand.

Add a present-tense mount-state detector (`mountStateFromProse`), scan the policy document alongside the architecture docs, and hold its assertion to the flag. The detector uses a present-tense verb set so a historical "was disabled before v0.6.5" does not register, and runs on whitespace-normalised text so the assertion is caught across a line wrap. mountStateProse.test.ts covers the current-state read, the historical-clause skip, the line-wrap, and binds the shipped policy document to the live flag. Red-green checked: flipping the policy prose to "disabled" fails the lint.