### PR TITLE
fix(ui): record tool toggles from every path (measure/inspect/annotate)

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,675 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,670 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -99,7 +99,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,675)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,670)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
@@ -8,7 +8,7 @@ Five products reach E4 this cycle: `CRS-UTM-PROJECTION` (new), `CHANGE-RASTER` a
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,675 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. Both counts are unchanged this cycle: the engineering here landed in the read and streaming paths rather than in the composition root or the renderer, so neither monolith grew or shrank. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,670 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root shrank by a handful of lines as the tool-toggle wiring moved behind a shared helper; the renderer is unchanged. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
 
 ## Out-of-core streaming holds the index, not the whole cloud
 

--- a/docs/validation/module-graph-baseline.json
+++ b/docs/validation/module-graph-baseline.json
@@ -16,7 +16,7 @@
     },
     "io->render": {
       "runtime": 5,
-      "typeOnly": 14,
+      "typeOnly": 16,
       "dynamic": 0,
       "edges": [
         "src/io/heavy/OlvTileSource.ts -> src/render/streaming/StreamingNodeStore.ts",
@@ -52,8 +52,8 @@
   },
   "fanOut": {
     "src/main.ts": {
-      "runtime": 114,
-      "typeOnly": 18,
+      "runtime": 115,
+      "typeOnly": 19,
       "dynamic": 7,
       "modules": [
         "@fontsource/jetbrains-mono/latin-400.css",
@@ -89,10 +89,11 @@
         "src/app/staleChunkReload.ts",
         "src/app/swUrl.ts",
         "src/app/terrainAnalysisRunner.ts",
+        "src/app/toggleTool.ts",
         "src/app/viewBookmarks.ts",
         "src/app/viewStateCoordinator.ts",
         "src/convert/decodeFull.ts",
-        "src/diagnostics/provenance.ts",
+        "src/diagnostics/captureProvenance.ts",
         "src/diagnostics/usageCounters.ts",
         "src/export/ScanReportRenderer.ts",
         "src/export/exportScanIdentity.ts",
@@ -178,7 +179,6 @@
       "dynamic": 1,
       "modules": [
         "src/io/coordinateBridge.ts",
-        "src/io/copc/voxelKey.ts",
         "src/io/sniffFormat.ts",
         "src/lazyChunks.ts",
         "src/perf/devFlags.ts",
@@ -217,7 +217,7 @@
         "src/render/measure/classificationEpoch.ts",
         "src/render/measure/lassoVolume.ts",
         "src/render/measure/lassoVolumeCompute.ts",
-        "src/render/measure/profileSampler.ts",
+        "src/render/measure/profileSectionSeam.ts",
         "src/render/measure/stockpilePresenter.ts",
         "src/render/measure/volume.ts",
         "src/render/navMath.ts",
@@ -229,6 +229,7 @@
         "src/render/presetApplication.ts",
         "src/render/projectElevationScale.ts",
         "src/render/quality/pixelRatioCeiling.ts",
+        "src/render/recordSelection.ts",
         "src/render/refinementPhase.ts",
         "src/render/renderActivityGate.ts",
         "src/render/renderLoop.ts",
@@ -261,7 +262,7 @@
     "components": []
   },
   "context": {
-    "filesScanned": 681,
+    "filesScanned": 765,
     "inlineTypeOnlyImports": 3,
     "note": "inlineTypeOnlyImports counts declarations whose named bindings are all inline `type` specifiers. Under verbatimModuleSyntax the declaration survives as `import {} from \"x\"`, a module load with no binding, so it is counted as a runtime edge above."
   }

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5675,
+      "lines": 5670,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/app/actionDefinitions.ts
+++ b/src/app/actionDefinitions.ts
@@ -11,6 +11,7 @@ import type { Viewer } from '../render/Viewer';
 import type { TourHandle } from '../ui/onboarding/bootTour';
 import type { WorkflowController } from '../ui/WorkflowController';
 import { WORKFLOW_RECORDER_ENABLED } from '../ui/WorkflowController';
+import { toggleTool } from './toggleTool';
 import type { WorkflowConfigPanel } from '../ui/WorkflowConfigPanel';
 import type { WorkflowEvent } from '../render/workflow/workflowRecorder';
 import type { ShortcutSheet } from '../ui/ShortcutSheet';
@@ -186,10 +187,7 @@ export function buildActionRegistry(deps: ActionRegistryDeps): Action[] {
       hint: 'Activate the measurement toolbar.',
       keywords: ['distance', 'area', 'volume'],
       run: () => {
-        const viewer = deps.getViewer();
-        const next = !viewer.measureMode;
-        viewer.setMeasureMode(next);
-        deps.workflowController.capture({ type: 'tool', tool: 'measure', on: next });
+        toggleTool(deps.getViewer(), deps.workflowController, 'measure');
       },
     },
     {
@@ -199,10 +197,7 @@ export function buildActionRegistry(deps: ActionRegistryDeps): Action[] {
       hint: 'Read attributes of any point under the cursor.',
       keywords: ['point info', 'attributes'],
       run: () => {
-        const viewer = deps.getViewer();
-        const next = !viewer.inspectMode;
-        viewer.setInspectMode(next);
-        deps.workflowController.capture({ type: 'tool', tool: 'inspect', on: next });
+        toggleTool(deps.getViewer(), deps.workflowController, 'inspect');
       },
     },
     {
@@ -212,10 +207,7 @@ export function buildActionRegistry(deps: ActionRegistryDeps): Action[] {
       hint: 'Drop notes, info, warnings, or issues on points.',
       keywords: ['note', 'comment', 'mark'],
       run: () => {
-        const viewer = deps.getViewer();
-        const next = !viewer.annotateMode;
-        viewer.setAnnotateMode(next);
-        deps.workflowController.capture({ type: 'tool', tool: 'annotate', on: next });
+        toggleTool(deps.getViewer(), deps.workflowController, 'annotate');
       },
     },
     {

--- a/src/app/toggleTool.ts
+++ b/src/app/toggleTool.ts
@@ -1,0 +1,54 @@
+import type { WorkflowController } from '../ui/WorkflowController';
+
+/**
+ * The mutually-exclusive interaction tools that toggle a Viewer mode and are
+ * recorded by the workflow recorder. Probe is deliberately excluded: no path
+ * records a probe toggle, so it is not funnelled through here.
+ */
+export type ToggleableTool = 'measure' | 'inspect' | 'annotate';
+
+/** The slice of the Viewer this helper needs — a getter and a setter per tool. */
+export interface ToolToggleViewer {
+  readonly measureMode: boolean;
+  readonly inspectMode: boolean;
+  readonly annotateMode: boolean;
+  setMeasureMode(on: boolean): void;
+  setInspectMode(on: boolean): void;
+  setAnnotateMode(on: boolean): void;
+}
+
+const READ: Record<ToggleableTool, (v: ToolToggleViewer) => boolean> = {
+  measure: (v) => v.measureMode,
+  inspect: (v) => v.inspectMode,
+  annotate: (v) => v.annotateMode,
+};
+
+const WRITE: Record<ToggleableTool, (v: ToolToggleViewer, on: boolean) => void> = {
+  measure: (v, on) => v.setMeasureMode(on),
+  inspect: (v, on) => v.setInspectMode(on),
+  annotate: (v, on) => v.setAnnotateMode(on),
+};
+
+/**
+ * Flip one interaction tool and record the toggle, returning the new state.
+ *
+ * The toolbar, the command palette, and the keyboard each toggled a tool by
+ * hand — reading `viewer.<tool>Mode`, calling `set<Tool>Mode`, and (in the
+ * palette only) recording the change. The toolbar and keyboard paths omitted
+ * that recording, so a workflow captured through the palette differed from one
+ * captured through the toolbar for the same action. This centralises the flip
+ * and the capture so every path records identically. `capture` is a no-op
+ * unless a recording is live, so calling it here is always safe. Callers use
+ * the returned next-state for their own extra work (e.g. revealing a
+ * workspace) without re-reading the mode.
+ */
+export function toggleTool(
+  viewer: ToolToggleViewer,
+  workflow: Pick<WorkflowController, 'capture'>,
+  tool: ToggleableTool,
+): boolean {
+  const next = !READ[tool](viewer);
+  WRITE[tool](viewer, next);
+  workflow.capture({ type: 'tool', tool, on: next });
+  return next;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ import type { ShortcutSheet } from './ui/ShortcutSheet';
 import { bootTour, type TourHandle } from './ui/onboarding/bootTour';
 import { findDuplicateIds } from './ui/actionRegistry';
 import { buildActionRegistry } from './app/actionDefinitions';
+import { toggleTool } from './app/toggleTool';
 import { importSession as runImportSession, type SessionIoDeps } from './app/sessionIo';
 import { openScan, type OpenScanDeps } from './app/openScan';
 import {
@@ -1944,10 +1945,10 @@ const dock = new ToolDock({
   onFrameAll: () => viewer.frameAll(),
   onSnapshot: () => void saveSnapshot(),
   onShare: () => void copyShareLink(),
-  onMeasureToggle: () => { const on = !viewer.measureMode; viewer.setMeasureMode(on); if (on) showWorkspaceMode?.('work'); },
-  onInspectToggle: () => viewer.setInspectMode(!viewer.inspectMode),
+  onMeasureToggle: () => { if (toggleTool(viewer, workflowController, 'measure')) showWorkspaceMode?.('work'); },
+  onInspectToggle: () => { toggleTool(viewer, workflowController, 'inspect'); },
   onProbeToggle: () => viewer.setProbeMode(!viewer.probeMode),
-  onAnnotateToggle: () => { const on = !viewer.annotateMode; viewer.setAnnotateMode(on); if (on) showWorkspaceMode?.('work'); },
+  onAnnotateToggle: () => { if (toggleTool(viewer, workflowController, 'annotate')) showWorkspaceMode?.('work'); },
   onAnalyseToggle: () => {
     // Re-open (or hide) the terrain analysis panel. If an object scan had
     // demoted it behind the Object panel, opening Analyse takes over —
@@ -3925,15 +3926,9 @@ void viewerLoaded.then(() => {
     // A tool shortcut needs a loaded scan and is inert behind the help modal.
     const toolsReady = (): boolean => hasScan() && !helpOverlay.isOpen;
     bindShortcuts({
-      onAnnotate: () => {
-        if (toolsReady()) viewer.setAnnotateMode(!viewer.annotateMode);
-      },
-      onMeasure: () => {
-        if (toolsReady()) viewer.setMeasureMode(!viewer.measureMode);
-      },
-      onInspect: () => {
-        if (toolsReady()) viewer.setInspectMode(!viewer.inspectMode);
-      },
+      onAnnotate: () => { if (toolsReady()) toggleTool(viewer, workflowController, 'annotate'); },
+      onMeasure: () => { if (toolsReady()) toggleTool(viewer, workflowController, 'measure'); },
+      onInspect: () => { if (toolsReady()) toggleTool(viewer, workflowController, 'inspect'); },
       onSaveView: () => {
         if (toolsReady()) saveCurrentView();
       },

--- a/tests/toggleTool.test.ts
+++ b/tests/toggleTool.test.ts
@@ -1,0 +1,65 @@
+/**
+ * toggleTool.test.ts — the toolbar, palette, and keyboard toggled interaction
+ * tools by hand, and only the palette recorded the toggle to the workflow
+ * recorder. toggleTool() centralises the flip and the capture so every path
+ * records identically. These tests pin the flip, the returned state, and the
+ * capture that the toolbar/keyboard paths used to miss.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { toggleTool, type ToggleableTool, type ToolToggleViewer } from '../src/app/toggleTool';
+
+function fakeViewer(over: Partial<Record<`${ToggleableTool}Mode`, boolean>> = {}) {
+  const state = {
+    measure: over.measureMode ?? false,
+    inspect: over.inspectMode ?? false,
+    annotate: over.annotateMode ?? false,
+  };
+  const v: ToolToggleViewer = {
+    get measureMode() { return state.measure; },
+    get inspectMode() { return state.inspect; },
+    get annotateMode() { return state.annotate; },
+    setMeasureMode(on) { state.measure = on; },
+    setInspectMode(on) { state.inspect = on; },
+    setAnnotateMode(on) { state.annotate = on; },
+  };
+  return { v, state };
+}
+
+describe('toggleTool', () => {
+  for (const tool of ['measure', 'inspect', 'annotate'] as ToggleableTool[]) {
+    it(`${tool}: flips off→on, sets the mode, and returns the new state`, () => {
+      const { v, state } = fakeViewer();
+      const capture = vi.fn();
+      const next = toggleTool(v, { capture }, tool);
+      expect(next).toBe(true);
+      expect(state[tool]).toBe(true);
+    });
+
+    it(`${tool}: flips on→off from the current mode`, () => {
+      const { v } = fakeViewer({ [`${tool}Mode`]: true } as never);
+      const capture = vi.fn();
+      expect(toggleTool(v, { capture }, tool)).toBe(false);
+    });
+
+    it(`${tool}: records the toggle every time (the bug the toolbar/keyboard had)`, () => {
+      const { v } = fakeViewer();
+      const capture = vi.fn();
+      toggleTool(v, { capture }, tool);
+      expect(capture).toHaveBeenCalledTimes(1);
+      expect(capture).toHaveBeenCalledWith({ type: 'tool', tool, on: true });
+      toggleTool(v, { capture }, tool);
+      expect(capture).toHaveBeenLastCalledWith({ type: 'tool', tool, on: false });
+    });
+  }
+
+  it('sets the mode before capturing, so a recorder reading the viewer sees the new state', () => {
+    const { v, state } = fakeViewer();
+    const order: string[] = [];
+    const capture = vi.fn(() => { order.push(`capture:${state.measure}`); });
+    const origSet = v.setMeasureMode.bind(v);
+    v.setMeasureMode = (on: boolean) => { order.push(`set:${on}`); origSet(on); };
+    toggleTool(v, { capture }, 'measure');
+    expect(order).toEqual(['set:true', 'capture:true']);
+  });
+});


### PR DESCRIPTION
The toolbar, command palette, and keyboard each toggled the measure/inspect/annotate tools by hand — reading `viewer.<tool>Mode`, calling `set<Tool>Mode`, and (in the palette only) recording the change to the workflow recorder. The toolbar and keyboard paths omitted that recording, so a workflow captured through the toolbar differed from one captured through the palette for the same action. The recorder is enabled (`WORKFLOW_RECORDER_ENABLED = true`), so this dropped real toggles from recordings.

Add `src/app/toggleTool.ts`, which flips the mode and records the toggle in one place, and route the palette (`actionDefinitions.ts`), the toolbar, and the keyboard (`main.ts`) through it. Each path keeps its own extra step: the toolbar reveals the Work workspace on toggle-on, the keyboard guards on `toolsReady()`. `capture()` is a no-op unless a recording is live, so the added calls are safe when idle.

Net −25 lines across `main.ts`/`actionDefinitions.ts`; monolith and module-graph baselines re-banked. New `tests/toggleTool.test.ts` pins the flip, the returned state, and the capture the toolbar/keyboard used to miss. tsc, layer-boundaries, module-graph, monolith-size, architecture-truth, and the 267-test workflow/tool battery pass.