### PR TITLE
feat(measure): deterministic section-image (PNG) export in the profile workbench

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -224,13 +224,6 @@
       "review": "2027-02-28"
     },
     {
-      "path": "src/render/measure/profileSectionImage.ts",
-      "status": "staged",
-      "why": "It composes a section into a PNG-ready raster with axes, legend, scope and counts by driving the live ProfileSectionRenderer through an offsetting proxy, so the exported pixels come off the same splat loop as the on-screen view. The PDF sheet path did not replace it: profilePdf.ts and profileSheetLayout.ts draw the section as a straight vector polyline with a station data band, a different product from a raster scatter PNG, and neither imports this module. No export route calls composeSectionImage yet, so the raster path stays off the production graph. MeasurePanel offers only PDF and JSON session export, no PNG.",
-      "graduation": "The profile export UI in src/ui/MeasurePanel.ts offers a section-image (PNG) product and routes it through composeSectionImage.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/render/streaming/pipelineLimits.ts",
       "status": "staged",
       "why": "Its own header states the position: the P8 fetch/decode/upload separation is evidence-gated, so this is \"the policy math only ... NOT wired into the live scheduler\", and wiring waits on device profiling that shows the P7 upload queue did not already resolve the stalls.",

--- a/src/app/profileWorkbenchLauncher.ts
+++ b/src/app/profileWorkbenchLauncher.ts
@@ -94,6 +94,15 @@ export interface ProfileWorkbenchLauncherDeps {
    * export control.
    */
   exportPdf?: (id: string) => Promise<void>;
+  /**
+   * Save a PNG of the section a dock is plotting.
+   *
+   * The raster of the returns off the same splat loop as the plot on screen —
+   * a different product from the PDF sheet. Composed from the live plot the
+   * presenter built, not re-extracted here. Absent means the dock renders no
+   * PNG control.
+   */
+  exportImage?: (request: ProfileWorkbenchLaunchRequest) => Promise<void>;
   /** Told about a rejected import, so a silent fallback still leaves a trace. */
   onLoadFailure?: (error: unknown) => void;
   /** Told about a `present` that threw, for the same reason. */
@@ -162,11 +171,13 @@ export function createProfileWorkbenchLauncher(
     // under it is filled by the presenter with what the section actually read.
     const rename = deps.rename;
     const exportPdf = deps.exportPdf;
+    const exportImage = deps.exportImage;
     const mounted = module.mountProfileWorkbench(host, {
       title: request.name,
       scope: request.name,
       ...(rename ? { onRename: (name: string) => rename(request.id, name) } : {}),
       ...(exportPdf ? { onExportPdf: () => exportPdf(request.id) } : {}),
+      ...(exportImage ? { onExportImage: () => exportImage(request) } : {}),
       onClose: () => {
         // Only for the dock that is still the live one: a panel closed by the
         // mount that replaced it must not hand back the successor's height.

--- a/src/app/profileWorkbenchRuntime.ts
+++ b/src/app/profileWorkbenchRuntime.ts
@@ -19,15 +19,27 @@
 
 import { createProfileWorkbenchLauncher } from './profileWorkbenchLauncher';
 import { createStageProfileWorkbench } from './profileWorkbenchStage';
-import { presentWorkbenchSection } from './profileWorkbenchSection';
+import {
+  exportProfileSectionImagePng,
+  presentWorkbenchSection,
+} from './profileWorkbenchSection';
 import { loadProfileWorkbench } from '../lazyChunks';
 import { ProfileLinkOverlay } from '../render/ProfileLinkOverlay';
 import { focusPoseOnPoint } from '../render/measure/profilePointLink';
 
 import type { ProfileWorkbenchLauncher } from './profileWorkbenchLauncher';
-import type { WorkbenchSectionScene } from './profileWorkbenchSection';
+import type { WorkbenchSectionPlot, WorkbenchSectionScene } from './profileWorkbenchSection';
 import type { ProfileLinkOverlayHost } from '../render/ProfileLinkOverlay';
 import type { ProfileCameraPose } from '../render/measure/profilePointLink';
+
+/**
+ * A UTC timestamp for the exported PNG's caption, in the same deterministic
+ * shape the profile PDF prints (`YYYY-MM-DD HH:MM UTC`). Read once, at the
+ * export boundary — the compose never reads a clock of its own.
+ */
+function sectionImageStamp(): string {
+  return `${new Date().toISOString().slice(0, 16).replace('T', ' ')} UTC`;
+}
 
 export interface ProfileWorkbenchRuntimeDeps {
   /** The stage the dock shares its box with. */
@@ -116,12 +128,41 @@ export function createProfileWorkbenchRuntime(
       : {}),
   };
 
+  // The plot the live dock is showing, captured when the presenter finishes so
+  // the PNG export composes from the same state rather than re-extracting the
+  // section. One dock at a time, so one slot: it is cleared when the dock's
+  // presentation is released.
+  let live: { plot: WorkbenchSectionPlot; name: string } | null = null;
+
   return createProfileWorkbenchLauncher({
     load: () => loadProfileWorkbench(),
     stage: createStageProfileWorkbench(deps.stage),
     ...(deps.rename ? { rename: deps.rename } : {}),
     ...(deps.exportPdf ? { exportPdf: deps.exportPdf } : {}),
-    present: (handle, request) => presentWorkbenchSection(handle, request.id, scene),
+    exportImage: async (request) => {
+      const current = live;
+      if (!current) {
+        throw new Error('The section is not ready to export yet.');
+      }
+      // The clock is read HERE, at the app boundary, and handed to the compose
+      // as a preformatted string, so the same section is the same pixels. Same
+      // deterministic stamp shape the PDF sheet prints.
+      await exportProfileSectionImagePng(current.plot, {
+        name: request.name,
+        generatedAt: sectionImageStamp(),
+      });
+    },
+    present: (handle, request) => {
+      const dispose = presentWorkbenchSection(handle, request.id, scene, {
+        onReady: (plot) => {
+          live = { plot, name: request.name };
+        },
+      });
+      return () => {
+        live = null;
+        dispose();
+      };
+    },
     onLoadFailure:
       deps.onLoadFailure ??
       ((error) => {

--- a/src/app/profileWorkbenchSection.ts
+++ b/src/app/profileWorkbenchSection.ts
@@ -78,12 +78,22 @@ import {
   profileReturnIdentity,
 } from '../render/measure/profilePointLink';
 import { drawProfileLinkOverlay } from '../render/measure/profileLinkOverlay2d';
+import {
+  composeProfileSectionImage,
+  type ProfileImageSurface,
+  type ProfileSectionImageRequest,
+} from '../render/measure/profileSectionImage';
+import { triggerDownload } from '../io/download';
 import { pointVerticalReference } from '../render/pointInfo';
 import { createProfileLinkController } from './profileLinkController';
 
 import type { ProfileWorkbenchDetailRow } from '../ui/ProfileWorkbench';
 import type { ProfileHitTestIndex } from '../render/measure/profileHitTest';
-import type { ProfileView, ProfileViewport } from '../render/measure/profileViewTransform';
+import type {
+  ProfileDataBounds,
+  ProfileView,
+  ProfileViewport,
+} from '../render/measure/profileViewTransform';
 import type { ProfileAxesModel } from '../render/measure/profileAxes';
 import type { VerticalReference } from '../geo/height';
 import type { ProfileLinkOverlayContext } from '../render/measure/profileLinkOverlay2d';
@@ -350,6 +360,22 @@ export interface WorkbenchSectionPlot {
   readonly view: WorkbenchSectionView;
   /** The section indices actually drawn, in draw order. */
   readonly indices: Uint32Array;
+  /**
+   * Assemble a {@link ProfileSectionImageRequest} for a PNG export of this
+   * section against `surface` at `size`.
+   *
+   * The request is built from the SAME state the plot drew from — the section's
+   * points, the drawn indices, the colours already resolved for them, and the
+   * extent over every accepted return — so an exported PNG cannot decimate,
+   * recolour or re-fit differently from the on-screen view. `acceptedCount` is
+   * every accepted return, and the compose counts the drawn ones from the draw,
+   * which is what keeps the caption's two figures honest.
+   */
+  imageRequest(
+    surface: ProfileImageSurface,
+    size: ProfileViewport,
+    opts: { name: string; generatedAt: string | null },
+  ): ProfileSectionImageRequest;
   /** Draw at the canvas's current box. A box with no area draws nothing. */
   draw(): void;
   /**
@@ -395,6 +421,138 @@ export interface ComposeSectionOptions {
    * axis must never promise a datum the section cannot show one for.
    */
   readonly reference?: VerticalReference;
+}
+
+/**
+ * Assemble a section-image (PNG) request from live section state.
+ *
+ * The one place the exported raster's inputs are gathered, so an export cannot
+ * quietly draw a different section from the one on screen. `indices` are the
+ * returns actually drawn and `colours` are the ones already resolved for them,
+ * both in draw order; `bounds` is the extent over EVERY accepted return, and
+ * `acceptedCount` is that same accepted total — the compose counts the drawn
+ * ones from its own draw, so the caption's two figures stay honest. The axis
+ * unit is stated only where the section's own render units already ARE that
+ * unit (scale 1), matching what the on-screen axes show.
+ */
+export function buildProfileSectionImageRequest(input: {
+  readonly surface: ProfileImageSurface;
+  readonly size: ProfileViewport;
+  readonly section: ProfileSectionResult;
+  readonly indices: Uint32Array;
+  readonly colours: Uint8Array;
+  readonly bounds: ProfileDataBounds;
+  readonly reference: VerticalReference;
+  readonly unitSuffix: string | null;
+  readonly unitScale: number;
+  readonly name: string;
+  readonly generatedAt: string | null;
+}): ProfileSectionImageRequest {
+  const axisUnit = input.unitScale === 1 ? input.unitSuffix : null;
+  return {
+    surface: input.surface,
+    size: input.size,
+    scene: {
+      points: input.section.points,
+      indices: input.indices,
+      colours: input.colours,
+      stations: null,
+    },
+    bounds: input.bounds,
+    scaleMode: { kind: 'fit' },
+    axes: {
+      reference: input.reference,
+      horizontalUnit: axisUnit,
+      verticalUnit: axisUnit,
+      units: { horizontalToMetres: null, verticalToMetres: null },
+    },
+    style: SECTION_STYLE,
+    name: input.name,
+    scope: input.section.scope,
+    streamingComplete: input.section.streamingComplete,
+    // Every accepted return, never the display cap: the drawn count is counted
+    // from the draw inside the compose, so decimation discloses itself.
+    acceptedCount: input.section.points.count,
+    legend: null,
+    generatedAt: input.generatedAt,
+  };
+}
+
+/** Default export raster size — a readable report-page figure at 2× backing. */
+export const SECTION_IMAGE_EXPORT_SIZE: ProfileViewport = {
+  width: 1600,
+  height: 900,
+  devicePixelRatio: 2,
+};
+
+/**
+ * Sanitise a section name into a safe download file stem.
+ *
+ * Unicode-aware: `\w` would collapse an all-non-ASCII name ("測線",
+ * "Sección-Ñ") to the fallback, so any letter or number in any script rides
+ * through, and only a genuinely empty result becomes "section".
+ */
+function safeImageFileName(name: string): string {
+  return name.replace(/[^\p{L}\p{N}._-]+/gu, '_').replace(/^_+|_+$/g, '') || 'section';
+}
+
+/** A 2D-capable canvas the PNG export composes onto and encodes from. */
+export interface SectionImageCanvas {
+  width: number;
+  height: number;
+  getContext(id: '2d'): ProfileImageSurface['ctx'] | null;
+  toBlob(callback: (blob: Blob | null) => void, type?: string): void;
+}
+
+/** How the export reaches the DOM, injectable so the wiring is testable. */
+export interface SectionImageExportPorts {
+  /** A blank raster canvas. Defaults to a detached `<canvas>` element. */
+  createCanvas?: () => SectionImageCanvas;
+  /** Hand the encoded PNG to the browser. Defaults to {@link triggerDownload}. */
+  download?: (blob: Blob, filename: string) => void;
+}
+
+function defaultSectionImageCanvas(): SectionImageCanvas {
+  if (typeof document === 'undefined') {
+    throw new Error('No document to create a canvas for the section-image export.');
+  }
+  return document.createElement('canvas') as unknown as SectionImageCanvas;
+}
+
+/**
+ * Render one section to a PNG and download it.
+ *
+ * The compose is the same DOM-free routine the unit tests drive; this only
+ * gives it a real canvas context, encodes the result, and funnels the blob
+ * through the shared download helper. A context or an encode that the browser
+ * refuses throws, so the control the user pressed can show the failure rather
+ * than appearing to have saved a file.
+ */
+export async function exportProfileSectionImagePng(
+  plot: WorkbenchSectionPlot,
+  opts: { name: string; generatedAt: string | null; size?: ProfileViewport },
+  ports: SectionImageExportPorts = {},
+): Promise<void> {
+  const canvas = (ports.createCanvas ?? defaultSectionImageCanvas)();
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('A 2D canvas context is unavailable for the section-image export.');
+  const surface: ProfileImageSurface = {
+    ctx,
+    setBackingSize: (deviceWidth, deviceHeight) => {
+      canvas.width = deviceWidth;
+      canvas.height = deviceHeight;
+    },
+  };
+  const request = plot.imageRequest(surface, opts.size ?? SECTION_IMAGE_EXPORT_SIZE, {
+    name: opts.name,
+    generatedAt: opts.generatedAt,
+  });
+  composeProfileSectionImage(request);
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob((b) => resolve(b), 'image/png');
+  });
+  if (!blob) throw new Error('The browser could not encode the section image as a PNG.');
+  (ports.download ?? triggerDownload)(blob, `${safeImageFileName(opts.name)}.png`);
 }
 
 /**
@@ -533,6 +691,20 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
       drawn: indices.length,
     },
     indices,
+    imageRequest: (surface, size, opts) =>
+      buildProfileSectionImageRequest({
+        surface,
+        size,
+        section,
+        indices,
+        colours,
+        bounds,
+        reference,
+        unitSuffix: unit,
+        unitScale: scale,
+        name: opts.name,
+        generatedAt: opts.generatedAt,
+      }),
     draw,
     frame: () => lastFrame,
   };
@@ -649,6 +821,15 @@ export function presentWorkbenchSection(
   },
   id: string,
   scene: WorkbenchSectionScene,
+  hooks: {
+    /**
+     * The composed plot, once the corridor walk and the display selection have
+     * finished. Handed over so an export control can reach the SAME plot the
+     * dock is showing rather than re-extract the section. Called at most once
+     * per presentation, and never after `dispose`.
+     */
+    onReady?: (plot: WorkbenchSectionPlot) => void;
+  } = {},
 ): () => void {
   let stopped = false;
   let releaseSize: (() => void) | null = null;
@@ -721,6 +902,9 @@ export function presentWorkbenchSection(
       // previous one would answer for pixels that now hold different returns.
       link?.invalidate();
     });
+    // The plot is ready: an export control can now compose from the same state
+    // the dock is showing. Skipped if the presentation was already disposed.
+    if (!stopped) hooks.onReady?.(plot);
   }
 
   // The second stage: set once the corridor walk has answered, and pumped by

--- a/src/ui/ProfileWorkbench.ts
+++ b/src/ui/ProfileWorkbench.ts
@@ -96,6 +96,16 @@ export interface ProfileWorkbenchOptions {
    * promise did, so a failure is visible on the control the user pressed.
    */
   readonly onExportPdf?: () => Promise<void>;
+  /**
+   * Save a PNG of the section the panel is plotting.
+   *
+   * A different product from the PDF sheet: a raster of the individual returns
+   * off the same splat loop as the plot on screen, not the vector polyline the
+   * sheet draws. Absent means no PNG control is rendered. The panel neither
+   * composes nor encodes the image; it reports what the host's promise did, so
+   * a failure shows on the control the user pressed.
+   */
+  readonly onExportImage?: () => Promise<void>;
   /** Called when the user closes the panel. */
   readonly onClose?: () => void;
 }
@@ -163,6 +173,10 @@ const EXPORT_LABEL = 'Export PDF';
 const EXPORT_WORKING_LABEL = 'Building\u2026';
 const EXPORT_FAILED_LABEL = 'Export failed';
 
+/** The PNG control's resting label, and the two states it passes through. */
+const EXPORT_PNG_LABEL = 'Export PNG';
+const EXPORT_PNG_WORKING_LABEL = 'Saving\u2026';
+
 /** How long a failed export keeps saying so before the control resets. */
 const EXPORT_FAILED_MS = 1800;
 
@@ -191,6 +205,7 @@ class ProfileWorkbench {
   private readonly _title: HTMLElement;
   private readonly _titleInput: HTMLInputElement | null;
   private readonly _exportBtn: HTMLButtonElement | null;
+  private readonly _exportImageBtn: HTMLButtonElement | null;
   private readonly _status: HTMLElement;
   private readonly _detail: HTMLElement;
   private readonly _readout: HTMLElement;
@@ -278,9 +293,25 @@ class ProfileWorkbench {
       this._on(btn, 'click', () => void this._exportPdf(btn));
     }
 
-    const actions = this._exportBtn
-      ? [this._exportBtn, this._collapseBtn, closeBtn]
-      : [this._collapseBtn, closeBtn];
+    // The PNG control is independent of the PDF one: a host may offer the raster
+    // section image without the vector sheet, or both, or neither.
+    this._exportImageBtn = options.onExportImage
+      ? el('button', {
+          className: 'olv-workbench-btn',
+          type: 'button',
+          text: EXPORT_PNG_LABEL,
+          ariaLabel: 'Export this section as a PNG image',
+        })
+      : null;
+    if (this._exportImageBtn) {
+      const btn = this._exportImageBtn;
+      this._on(btn, 'click', () => void this._exportImage(btn));
+    }
+
+    const exportBtns = [this._exportBtn, this._exportImageBtn].filter(
+      (b): b is HTMLButtonElement => b !== null,
+    );
+    const actions = [...exportBtns, this._collapseBtn, closeBtn];
     const head = el('div', { className: 'olv-workbench-head' }, [
       el('div', { className: 'olv-workbench-titles' }, [
         this._title,
@@ -444,6 +475,34 @@ class ProfileWorkbench {
     }
     if (this._closed) return;
     btn.textContent = EXPORT_LABEL;
+    btn.disabled = false;
+  }
+
+  /**
+   * Save the section PNG the host offered, and say so on the control.
+   *
+   * Mirrors the PDF path: the panel composes nothing itself, it runs the
+   * host's promise and reports the outcome on the button the user pressed. A
+   * rejection stops here, on the control, rather than in the console.
+   */
+  private async _exportImage(btn: HTMLButtonElement): Promise<void> {
+    const run = this._options.onExportImage;
+    if (!run || btn.disabled) return;
+    btn.disabled = true;
+    btn.textContent = EXPORT_PNG_WORKING_LABEL;
+    try {
+      await run();
+    } catch {
+      btn.textContent = EXPORT_FAILED_LABEL;
+      setTimeout(() => {
+        if (this._closed) return;
+        btn.textContent = EXPORT_PNG_LABEL;
+        btn.disabled = false;
+      }, EXPORT_FAILED_MS);
+      return;
+    }
+    if (this._closed) return;
+    btn.textContent = EXPORT_PNG_LABEL;
     btn.disabled = false;
   }
 

--- a/tests/profileWorkbenchSectionImage.test.ts
+++ b/tests/profileWorkbenchSectionImage.test.ts
@@ -1,0 +1,382 @@
+/**
+ * profileWorkbenchSectionImage.test.ts
+ *
+ * The wiring that turns a live workbench section into a PNG export. The compose
+ * itself is covered by profileSectionImage.test.ts; what is under test here is
+ * the join:
+ *
+ *   the request the builder assembles carries the TRUE accepted count (every
+ *   accepted return), the drawn indices, and the colours resolved for them, so
+ *   the drawn ≤ accepted honesty the compose enforces is preserved through the
+ *   wiring rather than defeated by feeding it the display cap;
+ *
+ *   the scope and streaming completeness are threaded from the section, not
+ *   re-derived;
+ *
+ *   the export composes onto a real 2D context, encodes a PNG, and downloads it
+ *   deterministically — the same section produces the same draw twice.
+ *
+ * No jsdom: the canvas is a recording double, which is also what proves the
+ * export path never reaches for a DOM the compose forbids.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildProfileSectionImageRequest,
+  exportProfileSectionImagePng,
+  prepareWorkbenchSection,
+  type SectionImageCanvas,
+  type WorkbenchCanvas,
+  type WorkbenchSectionPlot,
+} from '../src/app/profileWorkbenchSection';
+import { composeProfileSectionImage } from '../src/render/measure/profileSectionImage';
+import type {
+  ProfileImageContext,
+  ProfileImageSurface,
+} from '../src/render/measure/profileSectionImage';
+import type { ProfileSectionResult } from '../src/render/measure/profileSectionSeam';
+import type { ProfileSectionPoints } from '../src/render/measure/profileSectionBuilder';
+import type { ProfileViewport } from '../src/render/measure/profileViewTransform';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Recording canvas
+// ─────────────────────────────────────────────────────────────────────────────
+
+class RecordingContext implements ProfileImageContext {
+  fillStyle: string | CanvasGradient | CanvasPattern = '#000';
+  strokeStyle: string | CanvasGradient | CanvasPattern = '#000';
+  lineWidth = 1;
+  globalAlpha = 1;
+  font = '10px sans-serif';
+  textAlign: CanvasTextAlign = 'start';
+  textBaseline: CanvasTextBaseline = 'alphabetic';
+  readonly ops: string[] = [];
+  private rec(op: string): void {
+    this.ops.push(op);
+  }
+  setTransform(): void {
+    this.rec('setTransform');
+  }
+  clearRect(): void {
+    this.rec('clearRect');
+  }
+  fillRect(): void {
+    this.rec('fillRect');
+  }
+  beginPath(): void {
+    this.rec('beginPath');
+  }
+  moveTo(): void {
+    this.rec('moveTo');
+  }
+  lineTo(): void {
+    this.rec('lineTo');
+  }
+  stroke(): void {
+    this.rec('stroke');
+  }
+  fillText(): void {
+    this.rec('fillText');
+  }
+  save(): void {
+    this.rec('save');
+  }
+  restore(): void {
+    this.rec('restore');
+  }
+  translate(): void {
+    this.rec('translate');
+  }
+  rotate(): void {
+    this.rec('rotate');
+  }
+  rect(): void {
+    this.rec('rect');
+  }
+  clip(): void {
+    this.rec('clip');
+  }
+}
+
+class RecordingCanvas implements SectionImageCanvas {
+  width = 0;
+  height = 0;
+  readonly ctx = new RecordingContext();
+  getContext(): ProfileImageSurface['ctx'] | null {
+    return this.ctx;
+  }
+  toBlob(callback: (blob: Blob | null) => void): void {
+    callback(new Blob([`png:${this.ctx.ops.length}`], { type: 'image/png' }));
+  }
+}
+
+/** A canvas whose 2D context is unavailable, as an older engine may report. */
+class NoContextCanvas implements SectionImageCanvas {
+  width = 0;
+  height = 0;
+  getContext(): ProfileImageSurface['ctx'] | null {
+    return null;
+  }
+  toBlob(callback: (blob: Blob | null) => void): void {
+    callback(null);
+  }
+}
+
+/** A canvas with a working context whose PNG encode fails (`toBlob` → null). */
+class EncodeFailsCanvas implements SectionImageCanvas {
+  width = 0;
+  height = 0;
+  readonly ctx = new RecordingContext();
+  getContext(): ProfileImageSurface['ctx'] | null {
+    return this.ctx;
+  }
+  toBlob(callback: (blob: Blob | null) => void): void {
+    callback(null);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SIZE: ProfileViewport = { width: 800, height: 500, devicePixelRatio: 2 };
+
+function makePoints(chainage: number[], height: number[]): ProfileSectionPoints {
+  const n = chainage.length;
+  return {
+    count: n,
+    chainage: Float32Array.from(chainage),
+    height: Float64Array.from(height),
+    lateralOffset: new Float32Array(n),
+    sourceSlot: new Uint16Array(n),
+    pointIndex: Uint32Array.from(chainage.map((_, i) => i)),
+    channelPresence: new Uint8Array(n),
+  };
+}
+
+/** A section carrying the fields the builder and the workbench read. */
+function makeSection(count: number): ProfileSectionResult {
+  const chainage = Array.from({ length: count }, (_, i) => i * 5);
+  const height = Array.from({ length: count }, (_, i) => 10 + (i % 4) * 0.3);
+  return {
+    points: makePoints(chainage, height),
+    frame: { origin: [0, 0, 0] } as unknown as ProfileSectionResult['frame'],
+    band: 2,
+    scope: 'resident-snapshot',
+    scopeLabel: 'Resident snapshot, coverage unknown',
+    classificationOnEverySource: true,
+    streamingComplete: null,
+    sources: [],
+    generation: 1,
+    aborted: false,
+    skippedSlots: [],
+    examined: count,
+  };
+}
+
+/** A workbench canvas whose 2D context is absent — the plot still composes its
+ *  request from the section state it captured. */
+function nullContextCanvas(): WorkbenchCanvas {
+  return {
+    width: 0,
+    height: 0,
+    clientWidth: 0,
+    clientHeight: 0,
+    getContext: () => null,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The builder assembles from live state
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildProfileSectionImageRequest — assembled from live section state', () => {
+  it('carries the accepted total, the drawn indices, and the threaded scope', () => {
+    const section = makeSection(6);
+    const indices = Uint32Array.from([0, 1, 2, 3, 4, 5]);
+    const colours = new Uint8Array(indices.length * 3);
+    const surface: ProfileImageSurface = {
+      ctx: new RecordingContext(),
+      setBackingSize: () => {},
+    };
+    const request = buildProfileSectionImageRequest({
+      surface,
+      size: SIZE,
+      section,
+      indices,
+      colours,
+      bounds: { minChainage: 0, maxChainage: 25, minHeight: 10, maxHeight: 10.9 },
+      reference: 'orthometric',
+      unitSuffix: 'm',
+      unitScale: 1,
+      name: 'Section A',
+      generatedAt: '2026-08-28 12:00 UTC',
+    });
+
+    // The accepted total is the section's own count, NOT the display cap.
+    expect(request.acceptedCount).toBe(section.points.count);
+    expect(request.scene.indices).toBe(indices);
+    expect(request.scene.points).toBe(section.points);
+    expect(request.scene.stations).toBeNull();
+    expect(request.scope).toBe('resident-snapshot');
+    expect(request.streamingComplete).toBeNull();
+    // Unit stated only where the render unit already is that unit (scale 1).
+    expect(request.axes.horizontalUnit).toBe('m');
+  });
+
+  it('drops the axis unit when the render scale is not 1', () => {
+    const section = makeSection(4);
+    const request = buildProfileSectionImageRequest({
+      surface: { ctx: new RecordingContext(), setBackingSize: () => {} },
+      size: SIZE,
+      section,
+      indices: Uint32Array.from([0, 1, 2, 3]),
+      colours: new Uint8Array(12),
+      bounds: { minChainage: 0, maxChainage: 15, minHeight: 10, maxHeight: 10.9 },
+      reference: 'unknown',
+      unitSuffix: 'm',
+      unitScale: 0.3048,
+      name: 'Section B',
+      generatedAt: null,
+    });
+    expect(request.axes.horizontalUnit).toBeNull();
+    expect(request.axes.verticalUnit).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Honesty preserved through the plot
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('prepareWorkbenchSection.imageRequest — drawn ≤ accepted', () => {
+  it('builds a request whose drawn indices never exceed the accepted total', () => {
+    const section = makeSection(9);
+    const plot = prepareWorkbenchSection({
+      section,
+      canvas: nullContextCanvas(),
+      unitSuffix: 'm',
+      unitScale: 1,
+    });
+    const surface: ProfileImageSurface = { ctx: new RecordingContext(), setBackingSize: () => {} };
+    const request = plot.imageRequest(surface, SIZE, { name: 'Live', generatedAt: null });
+
+    expect(request.acceptedCount).toBe(section.points.count);
+    expect(request.scene.indices.length).toBeLessThanOrEqual(request.acceptedCount);
+    // The colours are one triplet per drawn index, as the renderer expects.
+    expect(request.scene.colours.length).toBe(request.scene.indices.length * 3);
+
+    // Composing the request discloses the two counts, and the drawn count is
+    // counted from the draw, never taken as the accepted total.
+    const result = composeProfileSectionImage(request);
+    expect(result.acceptedCount).toBe(section.points.count);
+    expect(result.drawnCount).toBeLessThanOrEqual(result.acceptedCount);
+    expect(result.countsCaption).toContain('accepted');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The export
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A minimal plot whose only live behaviour is the request it composes. */
+function fakePlot(section: ProfileSectionResult): WorkbenchSectionPlot {
+  const indices = Uint32Array.from(section.points.chainage.map((_, i) => i));
+  const colours = new Uint8Array(indices.length * 3);
+  return {
+    view: {
+      scope: section.scopeLabel,
+      groundBasisNote: null,
+      status: '',
+      detail: [],
+      drawn: indices.length,
+    },
+    indices,
+    imageRequest: (surface, size, opts) =>
+      buildProfileSectionImageRequest({
+        surface,
+        size,
+        section,
+        indices,
+        colours,
+        bounds: { minChainage: 0, maxChainage: 25, minHeight: 10, maxHeight: 10.9 },
+        reference: 'orthometric',
+        unitSuffix: 'm',
+        unitScale: 1,
+        name: opts.name,
+        generatedAt: opts.generatedAt,
+      }),
+    draw: () => {},
+    frame: () => null,
+  };
+}
+
+describe('exportProfileSectionImagePng — composes, encodes, downloads', () => {
+  it('renders onto a 2D context and hands a PNG to the download helper', async () => {
+    const section = makeSection(6);
+    const plot = fakePlot(section);
+    let saved: { blob: Blob; filename: string } | null = null;
+    const canvas = new RecordingCanvas();
+
+    await exportProfileSectionImagePng(
+      plot,
+      { name: 'Section A/B', generatedAt: '2026-08-28 12:00 UTC', size: SIZE },
+      { createCanvas: () => canvas, download: (blob, filename) => (saved = { blob, filename }) },
+    );
+
+    expect(saved).not.toBeNull();
+    expect(saved!.filename).toBe('Section_A_B.png');
+    expect(saved!.blob.type).toBe('image/png');
+    // The compose actually drew onto the context: splats and text are present.
+    expect(canvas.ctx.ops).toContain('fillRect');
+    expect(canvas.ctx.ops).toContain('fillText');
+    // The backing store was sized from the request, in device pixels.
+    expect(canvas.width).toBe(SIZE.width * SIZE.devicePixelRatio);
+  });
+
+  it('is deterministic: the same section draws the same operations twice', async () => {
+    const section = makeSection(7);
+    const runOps = async (): Promise<string[]> => {
+      const canvas = new RecordingCanvas();
+      await exportProfileSectionImagePng(
+        fakePlot(section),
+        { name: 'S', generatedAt: '2026-08-28 12:00 UTC', size: SIZE },
+        { createCanvas: () => canvas, download: () => {} },
+      );
+      return canvas.ctx.ops;
+    };
+    expect(await runOps()).toEqual(await runOps());
+  });
+
+  it('throws rather than appearing to save when no 2D context is available', async () => {
+    await expect(
+      exportProfileSectionImagePng(
+        fakePlot(makeSection(4)),
+        { name: 'S', generatedAt: null },
+        { createCanvas: () => new NoContextCanvas(), download: () => {} },
+      ),
+    ).rejects.toThrow(/context/i);
+  });
+
+  it('throws, and downloads nothing, when the browser refuses to encode the PNG', async () => {
+    let downloaded = false;
+    await expect(
+      exportProfileSectionImagePng(
+        fakePlot(makeSection(5)),
+        { name: 'S', generatedAt: null, size: SIZE },
+        { createCanvas: () => new EncodeFailsCanvas(), download: () => (downloaded = true) },
+      ),
+    ).rejects.toThrow(/encode/i);
+    expect(downloaded).toBe(false);
+  });
+
+  it('preserves a non-ASCII section name in the download filename', async () => {
+    let filename: string | null = null;
+    await exportProfileSectionImagePng(
+      fakePlot(makeSection(5)),
+      { name: 'Sección-Ñ 測線', generatedAt: null, size: SIZE },
+      { createCanvas: () => new RecordingCanvas(), download: (_blob, name) => (filename = name) },
+    );
+    // Letters in any script ride through; only the space becomes a separator.
+    expect(filename).toBe('Sección-Ñ_測線.png');
+  });
+});


### PR DESCRIPTION
Graduates the staged `src/render/measure/profileSectionImage.ts` core by wiring a deterministic PNG export of the profile cross-section into the Profile Workbench, beside the existing PDF and session-JSON exports. An Export PNG button builds a `ProfileSectionImageRequest` from the live section state, renders it onto an offscreen canvas through `composeProfileSectionImage`, and downloads the result. The exported pixels come off the same splat loop as the on-screen view; the caption carries both the drawn and the true accepted return counts, so a decimated view discloses itself. The timestamp is read once at the app boundary as a preformatted UTC string, so a section exports byte-identically twice.

The export lives in the workbench rather than MeasurePanel because MeasurePanel holds only the resampled line chart, which carries no corridor scatter or accepted-return total — a section image built there would report zero accepted returns. The now-reachable module is removed from the unreachable-modules registry. New tests cover the request builder, the drawn-not-greater-than-accepted invariant through the real compose, deterministic double-run, both loud-failure branches (no 2D context, encode refused), and Unicode filename round-tripping. tsc, unreachable-modules, layer-boundaries, module-graph, and the workbench test suites pass.