### PR TITLE
refactor(ui): route remaining string prefs through safeStorage

### DIFF
--- a/src/ui/compassController.ts
+++ b/src/ui/compassController.ts
@@ -25,6 +25,7 @@
  */
 
 import { loadViewCube } from '../lazyChunks';
+import { storageGet, storageSet } from './safeStorage';
 import type { StandardView } from '../render/viewCubeMath';
 import type { ViewCubeHandle, ViewCubeOptions } from './viewCube';
 
@@ -93,20 +94,8 @@ export function browserCompassPlatform(): CompassPlatform {
     isHidden: () => document.hidden,
     onVisibilityChange: (fn) => document.addEventListener('visibilitychange', fn),
     offVisibilityChange: (fn) => document.removeEventListener('visibilitychange', fn),
-    readPref: () => {
-      try {
-        return localStorage.getItem(COMPASS_PREF_KEY);
-      } catch {
-        return null;
-      }
-    },
-    writePref: (value) => {
-      try {
-        localStorage.setItem(COMPASS_PREF_KEY, value);
-      } catch {
-        /* private mode — honour for this session only */
-      }
-    },
+    readPref: () => storageGet(COMPASS_PREF_KEY),
+    writePref: (value) => storageSet(COMPASS_PREF_KEY, value),
   };
 }
 

--- a/src/ui/onboarding/tourSteps.ts
+++ b/src/ui/onboarding/tourSteps.ts
@@ -17,6 +17,8 @@
  * so unit tests use an in-memory fake.
  */
 
+import { storageGet, storageSet, storageRemove } from '../safeStorage';
+
 /** Where the tooltip card sits relative to its target. */
 export type TourPlacement = 'top' | 'bottom' | 'left' | 'right' | 'center';
 
@@ -153,28 +155,9 @@ const STORAGE_KEY = 'olv:tour:v1:completed';
 
 /** Default `localStorage`-backed port. */
 export const DEFAULT_TOUR_STORAGE: TourStoragePort = {
-  hasSeen: () => {
-    try {
-      return typeof localStorage !== 'undefined' && localStorage.getItem(STORAGE_KEY) === '1';
-    } catch {
-      return false;
-    }
-  },
-  setSeen: () => {
-    try {
-      if (typeof localStorage !== 'undefined') localStorage.setItem(STORAGE_KEY, '1');
-    } catch {
-      /* defensive — quota-exceeded / private-mode is fine, the tour
-         simply re-shows on the next session. */
-    }
-  },
-  clear: () => {
-    try {
-      if (typeof localStorage !== 'undefined') localStorage.removeItem(STORAGE_KEY);
-    } catch {
-      /* defensive */
-    }
-  },
+  hasSeen: () => storageGet(STORAGE_KEY) === '1',
+  setSeen: () => storageSet(STORAGE_KEY, '1'),
+  clear: () => storageRemove(STORAGE_KEY),
 };
 
 /**

--- a/src/ui/panelChrome.ts
+++ b/src/ui/panelChrome.ts
@@ -9,6 +9,7 @@
  */
 import { el } from './dom';
 import { applyClassicScrollbarClass } from './classicScrollbars';
+import { storageGet, storageSet } from './safeStorage';
 
 /**
  * Keep the left panel column clear of the measure toolbar (v0.4.5 overlap
@@ -220,12 +221,7 @@ export function wireRailToggle(cfg: RailToggleConfig): () => void {
     tab.title = label;
   };
 
-  let collapsed = false;
-  try {
-    collapsed = localStorage.getItem(cfg.storageKey) === '1';
-  } catch {
-    /* private mode — default expanded */
-  }
+  let collapsed = storageGet(cfg.storageKey) === '1';
   apply(collapsed);
 
   // Named so the disposer can detach it. The tab is removed too, but a host
@@ -233,11 +229,7 @@ export function wireRailToggle(cfg: RailToggleConfig): () => void {
   const onClick = (): void => {
     collapsed = !collapsed;
     apply(collapsed);
-    try {
-      localStorage.setItem(cfg.storageKey, collapsed ? '1' : '0');
-    } catch {
-      /* ignore */
-    }
+    storageSet(cfg.storageKey, collapsed ? '1' : '0');
   };
   tab.addEventListener('click', onClick);
   cfg.overlay.append(tab);

--- a/src/ui/safeStorage.ts
+++ b/src/ui/safeStorage.ts
@@ -43,3 +43,18 @@ export function storageSet(key: string, value: string): void {
     // Best-effort persistence; ignore quota / security failures.
   }
 }
+
+/**
+ * Remove a value. Best-effort — silently swallows any storage error
+ * (security, privacy mode). Never throws. Used where clearing a
+ * preference is itself a one-line string call, e.g. resetting a
+ * one-shot onboarding marker.
+ */
+export function storageRemove(key: string): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem(key);
+  } catch {
+    // Best-effort; ignore security failures.
+  }
+}

--- a/tests/safeStorage.test.ts
+++ b/tests/safeStorage.test.ts
@@ -1,0 +1,53 @@
+/**
+ * safeStorage.test.ts — guarded localStorage access. Persistence here is
+ * always a nice-to-have (a panel-collapse flag, a compass toggle, a one-shot
+ * tour marker), so every helper must degrade to "the preference just doesn't
+ * persist" rather than throw out of a constructor or event handler. These
+ * tests pin get/set/remove against a working store, a throwing store, and a
+ * store that is entirely absent.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { storageGet, storageSet, storageRemove } from '../src/ui/safeStorage';
+
+const realDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+function install(stub: unknown): void {
+  Object.defineProperty(globalThis, 'localStorage', { value: stub, configurable: true });
+}
+
+afterEach(() => {
+  if (realDescriptor) Object.defineProperty(globalThis, 'localStorage', realDescriptor);
+  else delete (globalThis as { localStorage?: unknown }).localStorage;
+});
+
+describe('safeStorage', () => {
+  it('reads, writes, and removes through a working store', () => {
+    const map = new Map<string, string>();
+    install({
+      getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+      setItem: (k: string, v: string) => void map.set(k, v),
+      removeItem: (k: string) => void map.delete(k),
+    });
+    expect(storageGet('k')).toBeNull();
+    storageSet('k', 'v');
+    expect(storageGet('k')).toBe('v');
+    storageRemove('k');
+    expect(storageGet('k')).toBeNull();
+  });
+
+  it('never throws when the store throws on every access', () => {
+    const boom = () => { throw new Error('SecurityError'); };
+    install({ getItem: boom, setItem: boom, removeItem: boom });
+    expect(storageGet('k')).toBeNull();
+    expect(() => storageSet('k', 'v')).not.toThrow();
+    expect(() => storageRemove('k')).not.toThrow();
+  });
+
+  it('never throws when localStorage is undefined (Node / sandboxed embed)', () => {
+    install(undefined);
+    expect(storageGet('k')).toBeNull();
+    expect(() => storageSet('k', 'v')).not.toThrow();
+    expect(() => storageRemove('k')).not.toThrow();
+  });
+});


### PR DESCRIPTION
The compass toggle (`compassController`), the rail-collapse flags (`panelChrome`), and the onboarding-seen marker (`tourSteps`) each read and wrote `localStorage` with their own inline try/catch rather than the shared `safeStorage` helper. This consolidates them: adds `storageRemove` beside `storageGet`/`storageSet`, and routes all three stores through the helper, keeping the exact same keys so no stored preference is lost.

Behaviour is unchanged — each site was already guarded — but the guard now lives in one place that treats an absent, sandboxed (embed), or quota-limited store uniformly as 'the preference just doesn't persist'. Net −21 lines of duplicated boilerplate. New `tests/safeStorage.test.ts` pins get/set/remove against a working store, a store that throws on every access, and an absent store. tsc, layer-boundaries, module-graph, monolith-size, and the compass/tour/safeStorage suites pass.