### PR TITLE
feat(streaming): derive initial quality preset from device tier

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1128,8 +1128,8 @@ function refreshColorbarOverlay(): void {
 let copcDecoder: CopcWorkerClient | null = null;
 /** The EPT laszip decode worker client — created lazily on the first EPT laszip open. */
 let eptLaszipDecoder: EptLaszipWorkerClient | null = null;
-/** The active streaming quality preset. */
-let streamingQuality: StreamingQuality = 'balanced';
+/** The active streaming quality preset — initial value follows the static device tier (mirrors streamingProfile.qualityForTier); display-only and user-overridable. */
+let streamingQuality: StreamingQuality = deviceCapsValue.tier === 'low' ? 'low' : deviceCapsValue.tier === 'high' ? 'high' : 'balanced';
 /** Interval handle for the streaming-status poll, while a COPC is open. */
 let streamingStatusTimer: number | undefined;
 /** Active streaming benchmark collector — non-null only under `?benchmark=1`. */


### PR DESCRIPTION
Today the composition root fixes the initial streaming-quality preset to `'balanced'` for every device (`main.ts:1132`) and only changes it when the user picks a preset. This seeds the initial preset from the device's static tier instead: a low-tier or mobile device first-loads at `'low'` (lighter resident-point budget), a high-tier desktop at `'high'`, everything else stays `'balanced'`. The user can still override in the panel.

Why this is browser-independent and safe: the tier comes from static `navigator` capabilities (device memory, hardware concurrency, mobile) already read at startup — not a runtime performance measurement — so it is a capability-appropriate display default, not a speculative optimization. It touches only the render/quality preset (budget, EDL/fade defaults follow their existing gates), with **zero effect on any scientific output, evidence grade, or measurement**; all overridable.

Scope note (verified by source review): this is the browser-independent half of "Streaming ablation → AUTO". The runtime FPS-based adaptation (`tierAdaptation.ts`) and promoting the metered-commit / decode-pool / resident-stickiness flags stay out of scope — their payoff is frame-time/flicker, which is GPU-bound and can only be validated with a real browser ablation. The mapping mirrors the tested `streamingProfile.qualityForTier`; that module stays staged until its EDL/fade-in half is reconciled with the backend EDL gate. Net-neutral on the monolith ratchet; tsc, layer-boundaries, module-graph, monolith-size, and the streaming/policy suites (297 tests) pass.