### PR TITLE
feat(science): register contour methods, stamp exports from the registry

### DIFF
--- a/docs/science/METHOD_REGISTRY.md
+++ b/docs/science/METHOD_REGISTRY.md
@@ -26,6 +26,12 @@ the paper that specifies it.
 | `olv.terrain.slope-horn` | 1 | Horn slope & aspect | Horn (1981) |
 | `olv.terrain.vrm` | 1 | Vector Ruggedness Measure | Sappington et al. (2007) |
 | `olv.terrain.tpi` | 1 | Topographic Position Index | Weiss (2001) |
+| `olv.contour.analytical` | 1 | Analytical iso-contour geometry | internal (grid contour extraction) |
+| `olv.contour.generalize` | 1 | Uniform contour generalization | Douglas & Peucker (1973) |
+| `olv.contour.generalize.dp` | 1 | Douglas–Peucker contour simplification | Douglas & Peucker (1973) |
+| `olv.contour.generalize.terrain-adaptive` | 1 | Terrain-adaptive contour generalization | internal (feature-scaled DP) |
+| `olv.class.derived-heuristic` | 3 | Derived point classification (heuristic) | Zhang et al. (2003); internal composition |
+| `olv.topology.linkage-record` | 1 | Source acquisition topology linkage record | internal (provenance record) |
 | `olv.dtm.idw-fill` | 1 | DTM raster + IDW void fill | internal (standard IDW) |
 | `olv.validation.holdout-rmse` | 2 | Hold-out vertical accuracy (classify-inside-fold) | ASPRS (2014) formulas, hold-out basis |
 | `olv.validation.spatial-block` | 2 | Spatial-block cross-validation | Roberts et al. (2017) |

--- a/src/science/methodRegistry.ts
+++ b/src/science/methodRegistry.ts
@@ -23,6 +23,7 @@ export type MethodCategory =
   | 'classification'
   | 'ground'
   | 'terrain'
+  | 'contour'
   | 'validation'
   | 'registration'
   | 'volume'
@@ -195,6 +196,50 @@ export const METHOD_REGISTRY: Readonly<Record<string, MethodEntry>> = {
     citation:
       'Internal composition (provenance record over the loader-recorded cell-to-record index); no single source method.',
     category: 'provenance',
+  },
+  'olv.contour.analytical': {
+    id: 'olv.contour.analytical',
+    version: 1,
+    name: 'Analytical iso-contour geometry',
+    summary:
+      'Exact iso-contours extracted from the terrain grid by linear interpolation ' +
+      'along cell edges, emitted without cartographic simplification.',
+    citation:
+      'Internal implementation of grid iso-contour extraction by edge linear interpolation; no single source method. Cross-checked against GDAL gdal_contour.',
+    category: 'contour',
+  },
+  'olv.contour.generalize.dp': {
+    id: 'olv.contour.generalize.dp',
+    version: 1,
+    name: 'Douglas–Peucker contour simplification',
+    summary:
+      'Per-feature Douglas–Peucker line simplification of the analytical contours ' +
+      'at a fixed tolerance, recording per-feature displacement statistics.',
+    citation: 'Douglas & Peucker (1973), The Canadian Cartographer 10(2):112–122',
+    category: 'contour',
+  },
+  'olv.contour.generalize': {
+    id: 'olv.contour.generalize',
+    version: 1,
+    name: 'Uniform contour generalization',
+    summary:
+      'Cartographic generalization at one uniform Douglas–Peucker tolerance across ' +
+      'every feature, run through the Douglas–Peucker primitive.',
+    citation:
+      'Douglas & Peucker (1973), The Canadian Cartographer 10(2):112–122 (uniform-tolerance application)',
+    category: 'contour',
+  },
+  'olv.contour.generalize.terrain-adaptive': {
+    id: 'olv.contour.generalize.terrain-adaptive',
+    version: 1,
+    name: 'Terrain-adaptive contour generalization',
+    summary:
+      'Cartographic generalization whose Douglas–Peucker tolerance is scaled per ' +
+      'feature by measurement confidence and feature scale — smoothing measured, ' +
+      'long contours more and low-confidence or small closed features less.',
+    citation:
+      'Internal composition (per-feature Douglas–Peucker tolerance scaled by terrain confidence and feature scale); no single source method.',
+    category: 'contour',
   },
 };
 

--- a/src/terrain/contourStudio/contourExportIntent.ts
+++ b/src/terrain/contourStudio/contourExportIntent.ts
@@ -31,6 +31,7 @@ import type { ContourStudioState } from './contourStudioState';
 import type { ContourShapeStyle } from '../contour/contourShapeStyle';
 import type { ContourGeneralizeMode } from '../contour/terrainAwareTolerance';
 import { PURPOSE_META } from './contourStudioPurpose';
+import { methodRef, methodTag } from '../../science/methodRegistry';
 
 /**
  * The purpose-driven product facts a deliverable renders on its sheet, so a
@@ -139,7 +140,12 @@ export function contourExportIntentFromState(state: ContourStudioState): Contour
     : generalizeMode === 'terrain-aware'
       ? 'olv.contour.generalize.terrain-adaptive'
       : 'olv.contour.generalize';
-  const methodVersion = 1;
+  // Version and tag come from the registry, fail-closed: methodRef throws on an
+  // unregistered id, so a stamped export can never name a method the catalogue
+  // does not define, and a method-version bump flows through here on its own
+  // instead of being hand-kept at 1.
+  const ref = methodRef(methodId);
+  const methodVersion = ref.version;
 
   const meta = PURPOSE_META[state.purpose];
   return {
@@ -150,7 +156,7 @@ export function contourExportIntentFromState(state: ContourStudioState): Contour
     labelsIndexOnly: state.labels.indexOnly,
     methodId,
     methodVersion,
-    methodTag: `${methodId}@${methodVersion}`,
+    methodTag: methodTag(ref),
     deliverable: {
       label: meta.label,
       statement: meta.summary,

--- a/tests/methodRegistry.test.ts
+++ b/tests/methodRegistry.test.ts
@@ -7,6 +7,9 @@
  * record can never reference a method the registry does not define).
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   METHOD_REGISTRY,
   method,
@@ -15,12 +18,37 @@ import {
   methodTag,
 } from '../src/science/methodRegistry';
 
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
 describe('METHOD_REGISTRY invariants', () => {
-  it('every key equals its entry id and is namespaced olv.<area>.<method>', () => {
+  it('every key equals its entry id and is namespaced olv.<area>.<method>[.<variant>]', () => {
     for (const [key, entry] of Object.entries(METHOD_REGISTRY)) {
       expect(entry.id).toBe(key);
-      expect(key).toMatch(/^olv\.[a-z]+\.[a-z0-9-]+$/);
+      // area.method, plus optional dotted variant segments (e.g.
+      // olv.contour.generalize.terrain-adaptive names a variant of a method).
+      expect(key).toMatch(/^olv\.[a-z]+\.[a-z0-9-]+(?:\.[a-z0-9-]+)*$/);
     }
+  });
+
+  it('docs/science/METHOD_REGISTRY.md lists every registered method (doc↔registry parity)', () => {
+    const doc = readFileSync(resolve(ROOT, 'docs/science/METHOD_REGISTRY.md'), 'utf8');
+    const documented = new Set(
+      [...doc.matchAll(/`(olv\.[a-z0-9.-]+)`/g)].map((m) => m[1]),
+    );
+    const missing = Object.keys(METHOD_REGISTRY).filter((id) => !documented.has(id));
+    expect(missing, `METHOD_REGISTRY.md omits: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('docs/science/METHOD_REGISTRY.md names no method the registry does not define', () => {
+    const doc = readFileSync(resolve(ROOT, 'docs/science/METHOD_REGISTRY.md'), 'utf8');
+    // Only the table rows name real ids; a prose example id would be a false
+    // positive, so restrict to backticked ids on table rows (lines starting "|").
+    const rowIds = doc
+      .split('\n')
+      .filter((l) => l.startsWith('| `olv.'))
+      .flatMap((l) => [...l.matchAll(/`(olv\.[a-z0-9.-]+)`/g)].map((m) => m[1]));
+    const unknown = rowIds.filter((id) => !isMethodId(id));
+    expect(unknown, `METHOD_REGISTRY.md rows name unregistered ids: ${unknown.join(', ')}`).toEqual([]);
   });
 
   it('every version is a positive integer', () => {


### PR DESCRIPTION
The four contour method ids were already stamped into export provenance (`olv.contour.analytical`, `.generalize`, `.generalize.dp`, `.generalize.terrain-adaptive`) but were **absent from the method registry**, and `contourExportIntent` hand-built the tag with `methodVersion` hardcoded to 1 — so a bump would silently not flow through, and a typo'd id would still stamp.

This registers the four under a new `contour` category with honest citations — **Douglas & Peucker (1973)** for the two DP-based passes; internal-composition notes for the analytical grid extraction (edge linear interpolation, cross-checked against GDAL) and the terrain-adaptive per-feature tolerance — and routes the export stamping through `methodRef`/`methodTag`. That makes it **fail-closed**: an unregistered id throws rather than stamping a phantom method, and a version bump propagates automatically. Stamped tags are unchanged (all at `@1`).

Also restores doc↔registry parity: adds the four contour methods plus two previously-omitted entries (`olv.class.derived-heuristic`, `olv.topology.linkage-record`) to `METHOD_REGISTRY.md`, and adds a **parity test** (red-green verified) asserting the doc lists every registered method and names none the registry doesn't define. tsc, layer-boundaries, module-graph, monolith-size, claim-register, and the 632-test contour/provenance/registry suites pass.