### PR TITLE
test(science): guard that every claim's supportingTests names a real test

### DIFF
--- a/docs/validation/claim-register.yaml
+++ b/docs/validation/claim-register.yaml
@@ -185,7 +185,7 @@ claims:
     claim: "Planimetric area of a user polygon in square metres when the horizontal unit is known."
     currentEvidence: E4_CROSS_IMPLEMENTATION_VALIDATED
     requiredEvidence: E5_EXTERNALLY_VALIDATED
-    supportingTests: [tests/measure*.test.ts, tests/formatArea*.test.ts, tests/measurementAnalyticalFixtures.test.ts, tests/measureAreaCrossCheck.test.ts]
+    supportingTests: [tests/measure*.test.ts, tests/measurementAnalyticalFixtures.test.ts, tests/measureAreaCrossCheck.test.ts]
     supportingDatasets: [8 planar polygons (OLV-DS-030-AREA-POLYGONS) with a GDAL/OGR OGR_GEOM_AREA reference]
     supportingStudies: [MEAS-AREA-OGR-PLANAR]
     units: [square-metres, source-units]
@@ -366,7 +366,7 @@ claims:
     claim: "Approximate cut/fill volume from a uniform-density point sample against a base."
     currentEvidence: E3_SYNTHETICALLY_VALIDATED
     requiredEvidence: E5_EXTERNALLY_VALIDATED
-    supportingTests: [tests/volume*.test.ts, tests/clipVolume*.test.ts, tests/volumeSyntheticTruth.test.ts, tests/analyticVolumeOracle.test.ts]
+    supportingTests: [tests/volume*.test.ts, tests/volumeSyntheticTruth.test.ts, tests/analyticVolumeOracle.test.ts]
     supportingDatasets: []
     units: [cubic-metres]
     crsDatum: "Refuses on geographic degrees; local metric only."
@@ -999,7 +999,7 @@ claims:
     claim: "Content-integrity digest — detects edits made without re-stamping. NOT proof of authorship."
     currentEvidence: E1_UNIT_VERIFIED
     requiredEvidence: E1_UNIT_VERIFIED
-    supportingTests: [tests/reportManifest*.test.ts, tests/reportVerifier*.test.ts]
+    supportingTests: [tests/reportManifest*.test.ts]
     supportingDatasets: []
     units: [hash]
     crsDatum: n/a

--- a/tests/supportingTestsResolve.test.ts
+++ b/tests/supportingTestsResolve.test.ts
@@ -1,0 +1,70 @@
+/**
+ * supportingTestsResolve.test.ts — every claim's supportingTests must name real
+ * tests.
+ *
+ * docs/validation/claim-register.yaml binds each scientific claim to the tests
+ * that stand behind it, as globs (`tests/measure*.test.ts`) or exact paths.
+ * Nothing checked that those globs still match a file, so a renamed or deleted
+ * test silently orphaned a claim's evidence — the register kept pointing at a
+ * test that no longer exists. This resolves every entry against the real test
+ * tree and fails on any that matches nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Every file under tests/, as repo-relative POSIX paths. */
+function testFiles(): string[] {
+  const out: string[] = [];
+  const walk = (rel: string): void => {
+    for (const e of readdirSync(resolve(ROOT, rel), { withFileTypes: true })) {
+      const child = `${rel}/${e.name}`;
+      if (e.isDirectory()) walk(child);
+      else out.push(child);
+    }
+  };
+  walk('tests');
+  return out;
+}
+
+/** A `tests/…*.test.ts`-style glob (only `*`, no `**`) as an anchored RegExp. */
+function globToRegExp(glob: string): RegExp {
+  const body = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex metachars (not `*`)
+    .replace(/\*/g, '[^/]*');
+  return new RegExp(`^${body}$`);
+}
+
+/** Every distinct supportingTests entry in the register. */
+function supportingTestEntries(): string[] {
+  const yaml = readFileSync(resolve(ROOT, 'docs/validation/claim-register.yaml'), 'utf8');
+  const entries = new Set<string>();
+  for (const m of yaml.matchAll(/supportingTests:\s*\[([^\]]*)\]/g)) {
+    for (const raw of m[1].split(',')) {
+      const t = raw.trim();
+      if (t) entries.add(t);
+    }
+  }
+  return [...entries];
+}
+
+describe('claim-register supportingTests', () => {
+  const files = testFiles();
+  const entries = supportingTestEntries();
+
+  it('has supportingTests entries to check', () => {
+    expect(entries.length).toBeGreaterThan(10);
+  });
+
+  it('every supportingTests entry resolves to at least one real test file', () => {
+    const orphaned = entries.filter((e) => {
+      const re = globToRegExp(e);
+      return !files.some((f) => re.test(f));
+    });
+    expect(orphaned, `supportingTests naming no real test: ${orphaned.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
`claim-register.yaml` binds each scientific claim to the tests that stand behind it (`supportingTests`), but nothing checked those globs still matched a file — so a renamed or deleted test silently orphaned a claim's evidence, leaving the register pointing at a test that no longer exists.

This adds `tests/supportingTestsResolve.test.ts`, which resolves every `supportingTests` entry (glob or exact) against the real test tree and fails on any that matches nothing. It **immediately found three orphaned references** — `tests/formatArea*`, `tests/clipVolume*`, `tests/reportVerifier*` — each of which is already covered by a sibling entry in the same claim (`tests/measure*` matches `measureFormat.test.ts`; the volume claim is covered by `tests/volume*`; REPORT-DIGEST is covered by `tests/reportManifest*`, which tests `verifyReportManifest` tamper-detection). The three dead globs are removed; no claim loses real coverage.

Red-green verified against a reintroduced ghost glob. tsc, claim-register, and claim-prose-sync pass.