### PR TITLE
refactor(science): stamp contour products from the registry, not a literal

### DIFF
--- a/src/terrain/contourStudio/contourAdaptiveGeneralize.ts
+++ b/src/terrain/contourStudio/contourAdaptiveGeneralize.ts
@@ -76,7 +76,9 @@ export function terrainAwareCartographicProduct(
     toleranceSource: opts.baseToleranceSource,
     horizontalUnit: opts.horizontalUnit,
     methodId: opts.methodId ?? 'olv.contour.generalize.terrain-adaptive',
-    methodVersion: opts.methodVersion ?? '1',
+    // Let cartographicProduct derive the version from the registry unless a
+    // caller explicitly overrides it — no hardcoded literal.
+    methodVersion: opts.methodVersion,
     toleranceForFeature: (f, base) => base * adaptiveToleranceFactor(f, { longFeatureLen, smallRingLen }),
   });
 }

--- a/src/terrain/contourStudio/contourGeometryProduct.ts
+++ b/src/terrain/contourStudio/contourGeometryProduct.ts
@@ -19,6 +19,7 @@
 
 import type { ContourFeature } from '../contour/contourFeatureModel';
 import { canonicalHash } from '../../canonicalHash';
+import { methodRef } from '../../science/methodRegistry';
 import { raw, sourceUnits, toMetresIfKnown, type LinearUnitScale } from '../../units/units';
 
 export type ContourGeometryRole = 'analytical-isoline' | 'cartographic-generalization';
@@ -71,10 +72,13 @@ export function analyticalProduct(
   features: readonly ContourFeature[],
   method: { methodId?: string; methodVersion?: string } = {},
 ): ContourGeometryProduct {
+  const methodId = method.methodId ?? 'olv.contour.analytical';
   return {
     role: 'analytical-isoline',
-    methodId: method.methodId ?? 'olv.contour.analytical',
-    methodVersion: method.methodVersion ?? '1',
+    methodId,
+    // Version from the registry (fail-closed: methodRef throws on an
+    // unregistered id) instead of a hardcoded literal.
+    methodVersion: method.methodVersion ?? String(methodRef(methodId).version),
     contentHash: hashFeatures(features),
     sourceAnalyticalHash: null,
     features,
@@ -138,7 +142,7 @@ export function cartographicProduct(
     : 0;
 
   const methodId = opts.methodId ?? 'olv.contour.generalize.dp';
-  const methodVersion = opts.methodVersion ?? '1';
+  const methodVersion = opts.methodVersion ?? String(methodRef(methodId).version);
   const tolM = toMetresIfKnown(sourceUnits(tol), opts.horizontalUnit);
 
   return {

--- a/tests/contourGeometryProduct.test.ts
+++ b/tests/contourGeometryProduct.test.ts
@@ -109,3 +109,26 @@ describe('cartographicProduct', () => {
     expect(() => cartographicProduct(analytical, { toleranceSource: Number.NaN, horizontalUnit: knownUnit(1) })).toThrow();
   });
 });
+
+describe('method version comes from the registry (fail-closed)', () => {
+  const analytical = analyticalProduct([jagged]);
+
+  it('stamps the registered version, not a hardcoded literal', () => {
+    // Registry versions are integers; the product carries them as strings.
+    expect(analyticalProduct([jagged]).methodVersion).toBe('1'); // olv.contour.analytical@1
+    expect(
+      cartographicProduct(analytical, { toleranceSource: 2, horizontalUnit: knownUnit(1) }).methodVersion,
+    ).toBe('1'); // olv.contour.generalize.dp@1
+  });
+
+  it('throws on an unregistered method id rather than stamping a phantom method', () => {
+    expect(() => analyticalProduct([jagged], { methodId: 'olv.contour.ghost' })).toThrow(/Unknown method id/);
+    expect(() =>
+      cartographicProduct(analytical, {
+        toleranceSource: 2,
+        horizontalUnit: knownUnit(1),
+        methodId: 'olv.contour.ghost',
+      }),
+    ).toThrow(/Unknown method id/);
+  });
+});


### PR DESCRIPTION
`analyticalProduct`, `cartographicProduct`, and the terrain-adaptive wrapper each defaulted their `methodVersion` to a hardcoded `'1'`, so a registered version bump would silently not reach the stamped provenance (and a typo'd id would still stamp). Derive the version from the method registry — `String(methodRef(id).version)` — **fail-closed**: an unregistered id throws rather than stamping a phantom method.

Stamped versions are unchanged (all at `1`), so no product fingerprint or export changes. This completes the registry routing started for the export intent in the contour-method-registry PR, so every contour method stamp — export intent and geometry product alike — now flows from one source. New tests pin the registry-derived version and the fail-closed throw. tsc, layer-boundaries, module-graph, monolith-size, and the contour suites pass.