### PR TITLE
feat(science): bind scientific claims to registered method ids

### DIFF
--- a/docs/validation/claim-register.yaml
+++ b/docs/validation/claim-register.yaml
@@ -389,6 +389,7 @@ claims:
   - claimId: VOL-STOCKPILE
     product: Stockpile volume
     algorithm: Point-sample estimator over a fitted/explicit base (area-weighted integration pending — Phase 8)
+    methodId: olv.volume.stockpile
     algorithmVersion: v0.5.x
     claim: "Stockpile volume above a reference base."
     currentEvidence: E3_SYNTHETICALLY_VALIDATED
@@ -417,6 +418,7 @@ claims:
   - claimId: GROUND-FILTER
     product: Ground classification
     algorithm: SMRF-core progressive morphological ground filter (subset of Pingel et al. 2013; not the full SMRF pipeline)
+    methodId: olv.ground.smrf
     algorithmVersion: v0.4.4
     claim: "Bare-earth vs non-ground separation via a progressive morphological opening + slope/elevation thresholds."
     currentEvidence: E3_SYNTHETICALLY_VALIDATED
@@ -445,6 +447,7 @@ claims:
   - claimId: DTM
     product: DTM (bare-earth grid)
     algorithm: Gridded interpolation of ground-classified returns
+    methodId: olv.dtm.idw-fill
     algorithmVersion: v0.4.4
     claim: "Bare-earth elevation grid over covered cells; gaps left empty or interpolated, never fabricated."
     currentEvidence: E4_CROSS_IMPLEMENTATION_VALIDATED
@@ -552,6 +555,7 @@ claims:
   - claimId: CONTOURS
     product: Contours
     algorithm: Marching squares + stitching + evidence grading
+    methodId: olv.contour.analytical
     algorithmVersion: v0.4.x
     claim: "Iso-elevation contours graded solid/dashed/gap by supporting confidence."
     currentEvidence: E4_CROSS_IMPLEMENTATION_VALIDATED
@@ -581,6 +585,7 @@ claims:
   - claimId: SLOPE-RASTER
     product: Slope raster
     algorithm: Horn 3x3 gradient
+    methodId: olv.terrain.slope-horn
     algorithmVersion: v0.4.x
     claim: "Slope in degrees per Horn's method; cos-latitude / per-axis cell metres on geographic grids."
     currentEvidence: E4_CROSS_IMPLEMENTATION_VALIDATED
@@ -616,6 +621,7 @@ claims:
   - claimId: ASPECT-RASTER
     product: Aspect raster
     algorithm: Horn 3x3 gradient, downslope azimuth
+    methodId: olv.terrain.slope-horn
     algorithmVersion: v0.4.x
     claim: "Downslope aspect per Horn's method, reported as a compass bearing; per-axis cell metres on geographic grids."
     currentEvidence: E4_CROSS_IMPLEMENTATION_VALIDATED
@@ -683,6 +689,7 @@ claims:
   - claimId: TPI
     product: TPI terrain descriptor
     algorithm: Topographic position index (centre minus mean of the 8 Moore neighbours)
+    methodId: olv.terrain.tpi
     algorithmVersion: v0.4.x
     claim: "Relative-position index over a 3x3 Moore neighbourhood."
     currentEvidence: E4_CROSS_IMPLEMENTATION_VALIDATED
@@ -714,6 +721,7 @@ claims:
   - claimId: VRM
     product: VRM terrain descriptor
     algorithm: Vector ruggedness measure (Sappington et al. 2007), 3x3 mean-resultant of unit normals
+    methodId: olv.terrain.vrm
     algorithmVersion: v0.4.x
     claim: "Vector ruggedness over a 3x3 neighbourhood."
     currentEvidence: E4_CROSS_IMPLEMENTATION_VALIDATED
@@ -746,6 +754,7 @@ claims:
   - claimId: HOLDOUT-RMSE
     product: Hold-out RMSE (interpolation)
     algorithm: Conditional point-wise interpolation holdout
+    methodId: olv.validation.holdout-rmse
     algorithmVersion: v0.4.x
     claim: "RMSE of held-out points against the interpolated surface — an INTERNAL diagnostic, not independent checkpoint accuracy."
     currentEvidence: E4_CROSS_IMPLEMENTATION_VALIDATED
@@ -778,6 +787,7 @@ claims:
   - claimId: NVA-VVA
     product: NVA/VVA-style vertical accuracy
     algorithm: NVA/VVA formula (1.96 x RMSEz) on INTERNAL holdout
+    methodId: olv.validation.holdout-rmse
     algorithmVersion: v0.4.x
     claim: "NVA/VVA-STYLE statistic derived from internal holdout — not an independent checkpoint accuracy assessment."
     currentEvidence: E4_CROSS_IMPLEMENTATION_VALIDATED
@@ -841,6 +851,7 @@ claims:
   - claimId: CONFIDENCE-OVERLAY
     product: Confidence overlay
     algorithm: Measured-cell empirical reliability (measured) + model-based support (interpolated)
+    methodId: olv.validation.reliability-wilson
     algorithmVersion: v0.4.x
     claim: "For measured cells, empirical reliability at a stated tolerance τ; for interpolated cells, a model-based support score that is NOT empirically calibrated."
     currentEvidence: E2_ANALYTICALLY_VERIFIED
@@ -869,6 +880,7 @@ claims:
   - claimId: EPOCH-ALIGN
     product: Epoch alignment
     algorithm: ICP (yaw + horizontal translation model; full model optional)
+    methodId: olv.registration.icp-planar
     algorithmVersion: v0.5.x
     claim: "Rigid alignment of two epochs; horizontal-only model preserves the vertical signal."
     currentEvidence: E2_ANALYTICALLY_VERIFIED
@@ -1049,6 +1061,7 @@ claims:
   - claimId: ORG-TOPOLOGY-IDENTITY
     product: Grid-cell to display-record identity
     algorithm: Loader-recorded cell-to-record index with a linkage state that degrades to unavailable
+    methodId: olv.topology.linkage-record
     algorithmVersion: v0.6.6
     claim: "A grid cell whose frame reports exact linkage resolves to the display record the loader decoded it from, and resolution is refused whenever sanitation, stride or voxelization can no longer prove the correspondence."
     currentEvidence: E3_SYNTHETICALLY_VALIDATED

--- a/tests/claimMethodIds.test.ts
+++ b/tests/claimMethodIds.test.ts
@@ -1,0 +1,40 @@
+/**
+ * claimMethodIds.test.ts — a claim's methodId must name a registered method.
+ *
+ * claim-register.yaml describes each claim's algorithm in free text
+ * (`algorithm:`, `algorithmVersion:`), which is exactly the drift the method
+ * registry exists to fix. Claims that run a registered method now carry a
+ * machine-readable `methodId:` binding it to the catalogue. This asserts every
+ * such binding resolves — a renamed or unregistered method id fails here rather
+ * than pointing a scientific claim at a method the registry does not define.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isMethodId, methodRef, methodTag } from '../src/science/methodRegistry';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const yaml = readFileSync(resolve(ROOT, 'docs/validation/claim-register.yaml'), 'utf8');
+
+function claimMethodIds(): string[] {
+  return [...yaml.matchAll(/^\s{4}methodId:\s*(\S+)/gm)].map((m) => m[1]);
+}
+
+describe('claim-register methodId bindings', () => {
+  it('binds a meaningful number of claims to registered methods', () => {
+    expect(claimMethodIds().length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('every claim methodId names a registered method', () => {
+    const unregistered = claimMethodIds().filter((id) => !isMethodId(id));
+    expect(unregistered, `claim methodIds not in the registry: ${unregistered.join(', ')}`).toEqual([]);
+  });
+
+  it('every claim methodId resolves to a stable id@version tag', () => {
+    for (const id of claimMethodIds()) {
+      expect(methodTag(methodRef(id))).toMatch(/^olv\.[a-z0-9.-]+@\d+$/);
+    }
+  });
+});


### PR DESCRIPTION
Claims in `claim-register.yaml` described their algorithm only in free text (`algorithm:`, `algorithmVersion: v0.5.x`) — the ad-hoc naming the method registry was built to replace. This adds a machine-readable `methodId` to the **thirteen** claims that run a registered method: ground filter→`olv.ground.smrf`, DTM→`idw-fill`, contours→`contour.analytical`, slope+aspect→`terrain.slope-horn`, TPI, VRM, HOLDOUT-RMSE + NVA-VVA→`validation.holdout-rmse`, stockpile→`volume.stockpile`, confidence overlay→`validation.reliability-wilson`, epoch align→`registration.icp-planar`, topology→`topology.linkage-record`.

Claims with no registered method — trivial geometry (distance/area/height/angle), readers (E57), projections (UTM), and unregistered products (DSM/CHM/hillshade/change) — are deliberately left unbound; the field is optional.

Adds `tests/claimMethodIds.test.ts` asserting every claim `methodId` resolves in the registry and renders a stable `id@version` tag (red-green verified). The field is invisible to the evidence-level equality cross-check and to the claim-register renderer, so no evidence gate or generated doc changes. lint:claim-register, claim-prose-sync, evidenceRegistry, and tsc pass.