### PR TITLE
fix(validation): make the snapshot rebuild non-destructive by default

### DIFF
--- a/scripts/build-validation-snapshot.mjs
+++ b/scripts/build-validation-snapshot.mjs
@@ -3,9 +3,15 @@
  * build-validation-snapshot.mjs — collect the candidate's validation state into
  * one directory that can be checked on its own.
  *
- *   npm run validation:snapshot
- *   node scripts/build-validation-snapshot.mjs --out <dir>
+ *   npm run validation:snapshot            # refuses to overwrite an existing baseline
+ *   node scripts/build-validation-snapshot.mjs --out <dir>   # build elsewhere freely
+ *   node scripts/build-validation-snapshot.mjs --force       # rebuild the baseline in place
  *   node scripts/build-validation-snapshot.mjs --preserve-existing
+ *
+ * The committed `validation/snapshot/` is a frozen baseline. With no `--out`, a
+ * rebuild would wipe it and regenerate from the current tree, so the default is
+ * NON-DESTRUCTIVE: it refuses when the baseline already exists unless `--force`
+ * is given. An explicit `--out <dir>` always builds into that directory.
  *
  * The output is `validation/snapshot/`: a copy of every record the snapshot
  * cites, a `snapshot.json` derived from those copies, a `SUMMARY.md` rendered
@@ -44,6 +50,18 @@ const arg = (name, fallback) => {
   const i = process.argv.indexOf(name);
   return i >= 0 ? process.argv[i + 1] : fallback;
 };
+
+/**
+ * Whether to refuse an in-place rebuild. The committed `validation/snapshot/` is
+ * a frozen baseline; a plain `npm run validation:snapshot` used to wipe it and
+ * rebuild from the current tree, destroying the baseline by default. Refuse when
+ * no explicit `--out` was given AND the default output already exists AND
+ * `--force` was not passed: an explicit `--out <dir>` builds elsewhere freely,
+ * and `--force` rebuilds in place on purpose.
+ */
+export function refuseInPlaceOverwrite({ outPassed, exists, force }) {
+  return !outPassed && exists && !force;
+}
 
 /** Every file under a repository directory, as repo-relative paths. */
 function walk(dirAbs, base) {
@@ -113,7 +131,21 @@ export function writeManifest(dir) {
 }
 
 function main() {
-  const out = resolve(arg('--out', join(ROOT, 'validation/snapshot')));
+  const outArg = arg('--out', null);
+  const out = resolve(outArg ?? join(ROOT, 'validation/snapshot'));
+  if (refuseInPlaceOverwrite({
+    outPassed: outArg != null,
+    exists: existsSync(out),
+    force: process.argv.includes('--force'),
+  })) {
+    console.error(
+      'build-validation-snapshot: refusing to overwrite the frozen validation/snapshot baseline.\n'
+      + '  The committed snapshot is a frozen baseline; rebuilding it in place from the current\n'
+      + '  tree would destroy it. Build elsewhere with "--out <dir>", or rebuild in place on\n'
+      + '  purpose with "--force".',
+    );
+    process.exit(2);
+  }
   /**
    * Carry a record the working tree no longer holds over from the snapshot
    * being replaced.

--- a/tests/snapshotOverwriteGuard.test.ts
+++ b/tests/snapshotOverwriteGuard.test.ts
@@ -1,0 +1,32 @@
+/**
+ * snapshotOverwriteGuard.test.ts — the validation-snapshot builder must not wipe
+ * the frozen baseline by default.
+ *
+ * The committed validation/snapshot/ is a frozen baseline. A plain
+ * `npm run validation:snapshot` used to rmSync it and rebuild from the current
+ * tree, destroying the baseline. refuseInPlaceOverwrite guards that: it refuses
+ * only the accidental case — no explicit --out, the baseline already exists, and
+ * no --force — while an explicit --out or --force proceeds.
+ */
+
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs build script, no types
+import { refuseInPlaceOverwrite } from '../scripts/build-validation-snapshot.mjs';
+
+describe('refuseInPlaceOverwrite', () => {
+  it('refuses the accidental in-place rebuild (no --out, baseline exists, no --force)', () => {
+    expect(refuseInPlaceOverwrite({ outPassed: false, exists: true, force: false })).toBe(true);
+  });
+
+  it('proceeds when the baseline does not exist yet', () => {
+    expect(refuseInPlaceOverwrite({ outPassed: false, exists: false, force: false })).toBe(false);
+  });
+
+  it('proceeds with an explicit --out even when a baseline exists', () => {
+    expect(refuseInPlaceOverwrite({ outPassed: true, exists: true, force: false })).toBe(false);
+  });
+
+  it('proceeds with --force (an intentional in-place rebuild)', () => {
+    expect(refuseInPlaceOverwrite({ outPassed: false, exists: true, force: true })).toBe(false);
+  });
+});


### PR DESCRIPTION
`build-validation-snapshot.mjs` defaulted `--out` to `validation/snapshot` and `rmSync`'d it, so a plain `npm run validation:snapshot` (with no `--out`) **wiped the committed frozen baseline** and rebuilt from the current tree — destroying a frozen artifact by default.

Refuse the in-place rebuild when no `--out` was given, the baseline already exists, and `--force` was not passed. An explicit `--out <dir>` still builds elsewhere freely; `--force` rebuilds the baseline in place on purpose. Only the manual `validation:snapshot` script runs the build — no gate or CI does — so this changes nothing in the pipeline.

Adds a `refuseInPlaceOverwrite` helper with a truth-table test. **Verified directly**: a default run now exits 2 with guidance and `validation/snapshot/snapshot.json` survives intact.

Scope note (verified during this): P2's other two concerns are already handled — the builder already classifies an unrun producer as `not-executed` (never `failed`/absent), and the snapshot is an intentionally frozen baseline so version-aware inputs are moot. tsc and the guard test pass.