### PR TITLE
feat(heavy): pre-decode file fingerprint for the OOC cache

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -20,6 +20,14 @@
   "reviewDates": "Reported by the lint when they pass, never enforced. A gate that turns red on a date with no change to the tree teaches people to edit the date rather than the code.",
   "modules": [
     {
+      "path": "src/io/heavy/fileFingerprint.ts",
+      "status": "staged",
+      "why": "Phase 1 of the persistent out-of-core cache: the pre-decode file fingerprint a persisted index is keyed by (SHA-256 over header facts plus sampled byte windows). Pure and tested; the open path does not call it yet, so the reopen branch that consumes it is a later phase.",
+      "graduation": "The reopen branch in src/app/heavyLasExecutor.ts calls fingerprintFromRange before the storage preflight to key the persisted cache map, reached from src/main.ts.",
+      "review": "2027-02-28",
+      "declaredIn": "PR #737 (persistent OOC cache, Phase 1)"
+    },
+    {
       "path": "src/features/FeatureExtractionService.ts",
       "status": "staged",
       "why": "Named in the v0.6.6 release notes under \"Also in this release\" as a foundation: \"a feature-extraction service over the building and conductor cores ... Nothing in the running application passes through either\". It is the product-side entry over the two cores; no UI or DerivedLayer calls it.",

--- a/src/io/heavy/fileFingerprint.ts
+++ b/src/io/heavy/fileFingerprint.ts
@@ -1,0 +1,142 @@
+/**
+ * fileFingerprint.ts — the pre-decode identity of a heavy local file.
+ *
+ * Phase 1 of the persistent out-of-core cache. A persisted index has to be keyed
+ * by something that identifies the source file BEFORE it is decoded, and that
+ * key must miss whenever the bytes could have changed. `name + size + mtime` is
+ * not enough on its own — an in-place edit can preserve both — so the
+ * fingerprint folds in the parsed header facts and a set of sampled content
+ * windows. Any difference in those inputs yields a different digest, so a cache
+ * built on this key can never serve a stale index for an edited file.
+ *
+ * The digest is SHA-256 over the raw sampled bytes plus a canonical serialisation
+ * of the facts and the window layout. SHA-256 rather than the 32-bit FNV used for
+ * value fingerprints elsewhere: a collision here is a false cache HIT — stale
+ * data served as fresh — the one failure this must not have.
+ *
+ * Pure and layer-free: no filename, no path, no decode. `computeFileFingerprint`
+ * takes only bytes and facts, so a rename is a HIT (the bytes match) and a
+ * content change is a MISS. Reading the windows from an actual file is the
+ * caller's job; the sample plan below says which windows to read.
+ */
+
+import { canonicalJson } from '../../canonicalHash';
+import type { RangeSource } from '../range/RangeSource';
+
+/** Bumped when the fingerprint's inputs or layout change, so old keys miss. */
+export const FINGERPRINT_VERSION = 1;
+
+/** Bytes per sampled window, and the interior sample positions as file fractions. */
+const WINDOW_BYTES = 4096;
+const INTERIOR_FRACTIONS = [0.25, 0.5, 0.75] as const;
+
+/** Pre-decode facts parsed from the LAS/LAZ public header, plus file metadata. */
+export interface FingerprintFacts {
+  readonly fileBytes: number;
+  readonly lastModified: number;
+  readonly declaredPointCount: number;
+  readonly offsetToPointData: number;
+  readonly min: readonly [number, number, number];
+  readonly max: readonly [number, number, number];
+}
+
+/** A byte window to read for the fingerprint. */
+export interface FingerprintWindow {
+  readonly offset: number;
+  readonly length: number;
+}
+
+/** A window that has been read: its position and the bytes found there. */
+export interface FingerprintSample extends FingerprintWindow {
+  readonly bytes: Uint8Array;
+}
+
+/**
+ * The windows to read for a file of `fileBytes`: the head, a few interior
+ * positions, and the tail. Deterministic and bounded (constant count regardless
+ * of size), and every window is clamped inside the file, so a tiny file never
+ * produces a read past its end.
+ */
+export function fingerprintSamplePlan(fileBytes: number): FingerprintWindow[] {
+  if (!Number.isFinite(fileBytes) || fileBytes <= 0) return [];
+  const clamp = (offset: number): FingerprintWindow => {
+    const o = Math.max(0, Math.min(offset, fileBytes));
+    return { offset: o, length: Math.min(WINDOW_BYTES, fileBytes - o) };
+  };
+  const windows: FingerprintWindow[] = [clamp(0)];
+  for (const f of INTERIOR_FRACTIONS) windows.push(clamp(Math.floor(fileBytes * f)));
+  windows.push(clamp(Math.max(0, fileBytes - WINDOW_BYTES)));
+  return windows;
+}
+
+/** Lowercase hex of an ArrayBuffer. */
+function toHex(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let hex = '';
+  for (let i = 0; i < bytes.length; i++) hex += bytes[i].toString(16).padStart(2, '0');
+  return hex;
+}
+
+/**
+ * Fingerprint a file from its header facts and sampled windows. SHA-256 over the
+ * concatenated sample bytes, prefixed by a canonical serialisation of the version,
+ * the facts, and each window's position and length — so identical bytes read at
+ * different offsets, or the same bytes under different facts, fingerprint apart.
+ */
+export async function computeFileFingerprint(
+  facts: FingerprintFacts,
+  samples: readonly FingerprintSample[],
+): Promise<string> {
+  const meta = {
+    v: FINGERPRINT_VERSION,
+    facts: {
+      fileBytes: facts.fileBytes,
+      lastModified: facts.lastModified,
+      declaredPointCount: facts.declaredPointCount,
+      offsetToPointData: facts.offsetToPointData,
+      min: [facts.min[0], facts.min[1], facts.min[2]],
+      max: [facts.max[0], facts.max[1], facts.max[2]],
+    },
+    windows: samples.map((s) => ({ offset: s.offset, length: s.length })),
+  };
+  const metaBytes = new TextEncoder().encode(canonicalJson(meta));
+  const sampleTotal = samples.reduce((n, s) => n + s.bytes.byteLength, 0);
+  const buffer = new Uint8Array(metaBytes.byteLength + sampleTotal);
+  buffer.set(metaBytes, 0);
+  let offset = metaBytes.byteLength;
+  for (const s of samples) {
+    buffer.set(s.bytes, offset);
+    offset += s.bytes.byteLength;
+  }
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', buffer);
+  return toHex(digest);
+}
+
+/**
+ * Fingerprint a file by reading its sample-plan windows through a range source.
+ * The caller supplies the header facts (which carry `fileBytes`, the bounds, and
+ * the file's `lastModified`); this reads the windows and folds everything into
+ * the digest. Fails closed: any read failure — or a file with no readable
+ * windows — returns null, which the cache reads as "cannot identify, rebuild",
+ * never as a match.
+ */
+export async function fingerprintFromRange(
+  range: Pick<RangeSource, 'readRange'>,
+  facts: FingerprintFacts,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  const plan = fingerprintSamplePlan(facts.fileBytes);
+  if (plan.length === 0) return null;
+  const samples: FingerprintSample[] = [];
+  for (const w of plan) {
+    let buf: ArrayBuffer;
+    try {
+      buf = await range.readRange(w.offset, w.length, signal);
+    } catch {
+      return null;
+    }
+    const bytes = new Uint8Array(buf);
+    samples.push({ offset: w.offset, length: bytes.byteLength, bytes });
+  }
+  return computeFileFingerprint(facts, samples);
+}

--- a/tests/fileFingerprint.test.ts
+++ b/tests/fileFingerprint.test.ts
@@ -1,0 +1,162 @@
+/**
+ * fileFingerprint.test.ts — the pre-decode identity of a heavy local file.
+ *
+ * Phase 1 of the persistent out-of-core cache. Before any decode, a file must be
+ * reduced to a content-based fingerprint that a persisted index can be keyed by.
+ * The safety property is the whole point: two files that are not byte-identical
+ * in the sampled regions MUST fingerprint differently, so a cache can never
+ * serve a stale index for an edited file. `name + size + mtime` is deliberately
+ * NOT enough — an in-place edit that preserves size and mtime has to miss — so
+ * the fingerprint folds in header facts and sampled content windows.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  fingerprintSamplePlan,
+  computeFileFingerprint,
+  fingerprintFromRange,
+  FINGERPRINT_VERSION,
+  type FingerprintFacts,
+  type FingerprintSample,
+} from '../src/io/heavy/fileFingerprint';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+
+const facts = (over: Partial<FingerprintFacts> = {}): FingerprintFacts => ({
+  fileBytes: 1_000_000,
+  lastModified: 1_700_000_000_000,
+  declaredPointCount: 250_000,
+  offsetToPointData: 375,
+  min: [500000, 4100000, 190],
+  max: [501000, 4100600, 260],
+  ...over,
+});
+
+const sample = (offset: number, ...vals: number[]): FingerprintSample => ({
+  offset,
+  length: vals.length,
+  bytes: new Uint8Array(vals),
+});
+
+const samples = (): FingerprintSample[] => [sample(0, 1, 2, 3, 4), sample(500_000, 9, 9, 9), sample(999_997, 7, 8, 9)];
+
+describe('fingerprintSamplePlan', () => {
+  it('is deterministic, bounded, and every window lies inside the file', () => {
+    const plan = fingerprintSamplePlan(10_000_000);
+    const plan2 = fingerprintSamplePlan(10_000_000);
+    expect(plan).toEqual(plan2);
+    expect(plan.length).toBeGreaterThan(1);
+    expect(plan.length).toBeLessThanOrEqual(8);
+    for (const w of plan) {
+      expect(w.offset).toBeGreaterThanOrEqual(0);
+      expect(w.length).toBeGreaterThan(0);
+      expect(w.offset + w.length).toBeLessThanOrEqual(10_000_000);
+    }
+  });
+
+  it('covers the head (offset 0) and reaches the tail (end of file)', () => {
+    const size = 10_000_000;
+    const plan = fingerprintSamplePlan(size);
+    expect(plan.some((w) => w.offset === 0)).toBe(true);
+    expect(Math.max(...plan.map((w) => w.offset + w.length))).toBe(size);
+  });
+
+  it('clamps to the file for a tiny file — no window runs past the end', () => {
+    const plan = fingerprintSamplePlan(10);
+    for (const w of plan) expect(w.offset + w.length).toBeLessThanOrEqual(10);
+    expect(plan.length).toBeGreaterThan(0);
+  });
+});
+
+describe('computeFileFingerprint', () => {
+  it('is a 64-char hex sha256 and is deterministic for identical input', async () => {
+    const a = await computeFileFingerprint(facts(), samples());
+    const b = await computeFileFingerprint(facts(), samples());
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(a).toBe(b);
+  });
+
+  it('changes when ANY sampled byte changes — the in-place-edit safety property', async () => {
+    const base = await computeFileFingerprint(facts(), samples());
+    const edited = samples();
+    edited[1].bytes[0] ^= 0x01; // one bit flipped deep in the file
+    const after = await computeFileFingerprint(facts(), edited);
+    expect(after).not.toBe(base);
+  });
+
+  it('changes when any header fact changes (count, offset, size, bounds, mtime)', async () => {
+    const base = await computeFileFingerprint(facts(), samples());
+    for (const over of [
+      { declaredPointCount: 250_001 },
+      { offsetToPointData: 379 },
+      { fileBytes: 1_000_001 },
+      { lastModified: 1_700_000_000_001 },
+      { min: [500000, 4100000, 191] as [number, number, number] },
+      { max: [501001, 4100600, 260] as [number, number, number] },
+    ]) {
+      expect(await computeFileFingerprint(facts(over), samples())).not.toBe(base);
+    }
+  });
+
+  it('depends on WHERE bytes were sampled, not only their values', async () => {
+    const a = await computeFileFingerprint(facts(), [sample(100, 1, 2, 3)]);
+    const b = await computeFileFingerprint(facts(), [sample(200, 1, 2, 3)]);
+    expect(a).not.toBe(b);
+  });
+
+  it('takes no filename — identical content under a different name fingerprints the same', async () => {
+    // The function signature carries no name/path; this pins that a rename is a
+    // cache HIT (correct — the bytes are the same), guarding against anyone
+    // adding a name into the digest later.
+    expect(await computeFileFingerprint(facts(), samples())).toBe(
+      await computeFileFingerprint(facts(), samples()),
+    );
+  });
+
+  it('folds the version in, so a future format change invalidates old keys', async () => {
+    expect(FINGERPRINT_VERSION).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('fingerprintFromRange', () => {
+  const buildBuffer = (size: number): ArrayBuffer => {
+    const b = new Uint8Array(size);
+    for (let i = 0; i < size; i++) b[i] = (i * 31 + 7) & 0xff;
+    return b.buffer;
+  };
+  const rangeFacts = (size: number): FingerprintFacts =>
+    facts({ fileBytes: size, declaredPointCount: 4200, offsetToPointData: 375 });
+
+  it('reads the sample-plan windows and matches a hand-assembled fingerprint', async () => {
+    const size = 200_000;
+    const buf = buildBuffer(size);
+    const src = new ArrayBufferRangeSource(buf, 'x.las');
+    const f = rangeFacts(size);
+
+    const manual: FingerprintSample[] = [];
+    for (const w of fingerprintSamplePlan(size)) {
+      manual.push({ offset: w.offset, length: w.length, bytes: new Uint8Array(buf, w.offset, w.length) });
+    }
+    expect(await fingerprintFromRange(src, f)).toBe(await computeFileFingerprint(f, manual));
+  });
+
+  it('misses when a sampled byte differs (edit preserving size and facts)', async () => {
+    const size = 200_000;
+    const a = buildBuffer(size);
+    const b = a.slice(0);
+    new Uint8Array(b)[Math.floor(size / 2)] ^= 0xff; // flip a byte the interior window reads
+    const f = rangeFacts(size);
+    const fa = await fingerprintFromRange(new ArrayBufferRangeSource(a, 'a'), f);
+    const fb = await fingerprintFromRange(new ArrayBufferRangeSource(b, 'b'), f);
+    expect(fa).not.toBe(fb);
+  });
+
+  it('fails closed to null when a window read throws', async () => {
+    const size = 200_000;
+    const failing = {
+      id: () => 'boom',
+      kind: () => 'array-buffer' as const,
+      size: () => Promise.resolve(size),
+      readRange: () => Promise.reject(new Error('read failed')),
+    };
+    expect(await fingerprintFromRange(failing, rangeFacts(size))).toBeNull();
+  });
+});


### PR DESCRIPTION
Phase 1 of the persistent out-of-core cache (gate is GO per #735 + #736): the content-based identity a persisted index will be keyed by, computed before any decode.

`computeFileFingerprint` is SHA-256 over the parsed header facts (size, declared point count, data offset, bounds, lastModified) plus sampled byte windows from the head, interior, and tail. So an in-place edit that preserves size and mtime still changes the digest — the safety property that stops a cache serving a stale index. SHA-256 rather than the 32-bit value hash used elsewhere, because a collision here is a false hit. No filename or path enters the digest, so a rename is a hit. `fingerprintFromRange` reads the sample-plan windows through a range source and fails closed to null on any read error.

Pure and unwired: nothing in the open path calls it yet — the reopen branch in a later phase is its consumer — so there is no behaviour change and no added read cost on today's opens. 12 tests (TDD), TSC clean, custom lints pass.