### PR TITLE
feat(heavy): persisted fingerprint→store map for the OOC cache

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -28,6 +28,14 @@
       "declaredIn": "PR #737 (persistent OOC cache, Phase 1)"
     },
     {
+      "path": "src/io/heavy/oocCacheMap.ts",
+      "status": "staged",
+      "why": "Phase 2 of the persistent out-of-core cache: the persisted fingerprint-to-store map (a JSON record in the OPFS root) the reopen branch reads to find a prior index. Pure core plus an OPFS bridge, tested; the open path does not call it yet.",
+      "graduation": "The reopen branch in src/app/heavyLasExecutor.ts reads the map with readCacheMap to resolve a fingerprint to a promoted store, reached from src/main.ts.",
+      "review": "2027-02-28",
+      "declaredIn": "PR #738 (persistent OOC cache, Phase 2)"
+    },
+    {
       "path": "src/features/FeatureExtractionService.ts",
       "status": "staged",
       "why": "Named in the v0.6.6 release notes under \"Also in this release\" as a foundation: \"a feature-extraction service over the building and conductor cores ... Nothing in the running application passes through either\". It is the product-side entry over the two cores; no UI or DerivedLayer calls it.",

--- a/src/io/heavy/oocCacheMap.ts
+++ b/src/io/heavy/oocCacheMap.ts
@@ -1,0 +1,161 @@
+/**
+ * oocCacheMap.ts — the persisted fingerprint → store map for the OOC cache.
+ *
+ * Phase 2 of the persistent out-of-core cache. A small JSON record in the OPFS
+ * root records which promoted tile store holds the index for a given file
+ * fingerprint (Phase 1), so a reopen can find it without rebuilding. Everything
+ * here is deliberately small and defensive.
+ *
+ * Two rules the design turns on:
+ *
+ *   Fail closed. A missing, corrupt, or wrong-version record parses to an empty
+ *   map, so the worst a bad file can do is force rebuilds — never a wrong hit. An
+ *   individually malformed entry is dropped, not allowed to match.
+ *
+ *   Generation-gated. A lookup matches only when the cache generation matches
+ *   too. The generation binds the tile-store schema and the fingerprint scheme,
+ *   so an index written by an incompatible build is a miss even when the source
+ *   file has not changed — the stored bytes describe a format this build can no
+ *   longer read.
+ *
+ * The pure core (parse / serialize / lookup / upsert) is what the tests pin; the
+ * OPFS bridge at the end is a thin read/write over the root directory.
+ */
+
+import { canonicalJson } from '../../canonicalHash';
+import { TILE_STORE_SCHEMA_VERSION } from './tileStore';
+import { FINGERPRINT_VERSION } from './fileFingerprint';
+import { readOpfsText, writeOpfsText, type OpfsDirHandle } from './opfsSpillStore';
+
+/** Bumped when the map's own shape changes, so an old record parses to empty. */
+export const CACHE_MAP_VERSION = 1;
+
+/** The map's file name in the OPFS root, beside the tile stores it points at. */
+export const CACHE_MAP_FILE = 'ooc-cache-map.json';
+
+/** One cached index: which store holds it, and the facts eviction/telemetry need. */
+export interface OocCacheEntry {
+  readonly fingerprint: string;
+  readonly storeName: string;
+  readonly generation: string;
+  readonly createdAt: number;
+  readonly lastUsedAt: number;
+  readonly pointCount: number;
+  readonly tileBytes: number;
+}
+
+/** The persisted map: a version and a flat list of entries. */
+export interface OocCacheMap {
+  readonly version: number;
+  readonly entries: readonly OocCacheEntry[];
+}
+
+/**
+ * The current cache generation: an index is only reusable by a build whose
+ * generation string matches the one it was written under. Binds the tile-store
+ * schema and the fingerprint scheme, so bumping either invalidates old indices.
+ */
+export function cacheGeneration(): string {
+  return `t${TILE_STORE_SCHEMA_VERSION}.f${FINGERPRINT_VERSION}.m${CACHE_MAP_VERSION}`;
+}
+
+export function emptyCacheMap(): OocCacheMap {
+  return { version: CACHE_MAP_VERSION, entries: [] };
+}
+
+/** Canonical JSON, so the same map always serialises to the same bytes. */
+export function serializeCacheMap(map: OocCacheMap): string {
+  return canonicalJson(map);
+}
+
+function validEntry(raw: unknown): OocCacheEntry | null {
+  if (raw === null || typeof raw !== 'object') return null;
+  const e = raw as Record<string, unknown>;
+  const str = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
+  const num = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
+  if (!str(e.fingerprint) || !str(e.storeName) || !str(e.generation)) return null;
+  if (!num(e.createdAt) || !num(e.lastUsedAt) || !num(e.pointCount) || !num(e.tileBytes)) return null;
+  return {
+    fingerprint: e.fingerprint,
+    storeName: e.storeName,
+    generation: e.generation,
+    createdAt: e.createdAt,
+    lastUsedAt: e.lastUsedAt,
+    pointCount: e.pointCount,
+    tileBytes: e.tileBytes,
+  };
+}
+
+/**
+ * Parse a serialised map, failing closed. Invalid JSON, a non-object root, a
+ * missing/mismatched version, or a non-array `entries` all yield an empty map;
+ * individually malformed entries are dropped, keeping the valid ones.
+ */
+export function parseCacheMap(text: string): OocCacheMap {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    return emptyCacheMap();
+  }
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return emptyCacheMap();
+  const obj = raw as Record<string, unknown>;
+  if (obj.version !== CACHE_MAP_VERSION || !Array.isArray(obj.entries)) return emptyCacheMap();
+  const entries: OocCacheEntry[] = [];
+  for (const e of obj.entries) {
+    const valid = validEntry(e);
+    if (valid) entries.push(valid);
+  }
+  return { version: CACHE_MAP_VERSION, entries };
+}
+
+/** The entry for a fingerprint, only if its generation matches — else null. */
+export function lookupEntry(map: OocCacheMap, fingerprint: string, generation: string): OocCacheEntry | null {
+  return (
+    map.entries.find((e) => e.fingerprint === fingerprint && e.generation === generation) ?? null
+  );
+}
+
+/** Add or replace the entry for its (fingerprint, generation) pair. Immutable. */
+export function upsertEntry(map: OocCacheMap, next: OocCacheEntry): OocCacheMap {
+  const entries = map.entries.filter(
+    (e) => !(e.fingerprint === next.fingerprint && e.generation === next.generation),
+  );
+  entries.push(next);
+  return { version: map.version, entries };
+}
+
+/** Bump `lastUsedAt` for the matching entry (for LRU eviction later). Immutable. */
+export function touchEntry(
+  map: OocCacheMap,
+  fingerprint: string,
+  generation: string,
+  now: number,
+): OocCacheMap {
+  const entries = map.entries.map((e) =>
+    e.fingerprint === fingerprint && e.generation === generation ? { ...e, lastUsedAt: now } : e,
+  );
+  return { version: map.version, entries };
+}
+
+/** Drop the entry pointing at a store that no longer exists. Immutable. */
+export function removeByStoreName(map: OocCacheMap, storeName: string): OocCacheMap {
+  return { version: map.version, entries: map.entries.filter((e) => e.storeName !== storeName) };
+}
+
+/**
+ * Read the map from the OPFS root, failing closed: a missing file or any read
+ * error yields an empty map rather than throwing.
+ */
+export async function readCacheMap(root: OpfsDirHandle): Promise<OocCacheMap> {
+  try {
+    return parseCacheMap(await readOpfsText(root, CACHE_MAP_FILE));
+  } catch {
+    return emptyCacheMap();
+  }
+}
+
+/** Write the map to the OPFS root (atomic via the OPFS writable swap). */
+export async function writeCacheMap(root: OpfsDirHandle, map: OocCacheMap): Promise<void> {
+  await writeOpfsText(root, CACHE_MAP_FILE, serializeCacheMap(map));
+}

--- a/tests/oocCacheMap.test.ts
+++ b/tests/oocCacheMap.test.ts
@@ -1,0 +1,117 @@
+/**
+ * oocCacheMap.test.ts — the persisted fingerprint → store map for the OOC cache.
+ *
+ * Phase 2 of the persistent out-of-core cache. A small JSON record in the OPFS
+ * root maps a file fingerprint (Phase 1) to the promoted tile store that holds
+ * its index. Two properties matter most and are pinned here: the map fails
+ * CLOSED — a corrupt or wrong-version record reads as empty, so a bad map causes
+ * rebuilds, never a wrong hit — and a lookup matches only when the cache
+ * GENERATION matches too, so an index built by an incompatible tile format is a
+ * miss even when the source file is unchanged.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  emptyCacheMap,
+  serializeCacheMap,
+  parseCacheMap,
+  lookupEntry,
+  upsertEntry,
+  touchEntry,
+  removeByStoreName,
+  readCacheMap,
+  writeCacheMap,
+  cacheGeneration,
+  CACHE_MAP_VERSION,
+  type OocCacheEntry,
+} from '../src/io/heavy/oocCacheMap';
+import { fakeOpfsDir } from './support/fakeOpfs';
+
+const GEN = 'gen-A';
+const entry = (over: Partial<OocCacheEntry> = {}): OocCacheEntry => ({
+  fingerprint: 'fp-1',
+  storeName: 'ooc-abc-123',
+  generation: GEN,
+  createdAt: 1000,
+  lastUsedAt: 1000,
+  pointCount: 5_000_000,
+  tileBytes: 135_000_000,
+  ...over,
+});
+
+describe('oocCacheMap — pure core', () => {
+  it('empty map carries the current version and no entries', () => {
+    expect(emptyCacheMap()).toEqual({ version: CACHE_MAP_VERSION, entries: [] });
+  });
+
+  it('serialize → parse round-trips an entry', () => {
+    const map = upsertEntry(emptyCacheMap(), entry());
+    expect(parseCacheMap(serializeCacheMap(map))).toEqual(map);
+  });
+
+  it('fails closed to empty on invalid JSON, wrong shape, or wrong version', () => {
+    expect(parseCacheMap('not json {')).toEqual(emptyCacheMap());
+    expect(parseCacheMap('[]')).toEqual(emptyCacheMap());
+    expect(parseCacheMap(JSON.stringify({ version: CACHE_MAP_VERSION + 99, entries: [] }))).toEqual(emptyCacheMap());
+  });
+
+  it('drops an individually-malformed entry but keeps the valid ones', () => {
+    const good = entry();
+    const raw = JSON.stringify({ version: CACHE_MAP_VERSION, entries: [good, { fingerprint: 5, storeName: null }] });
+    const parsed = parseCacheMap(raw);
+    expect(parsed.entries).toEqual([good]);
+  });
+
+  it('looks up only on matching fingerprint AND generation', () => {
+    const map = upsertEntry(emptyCacheMap(), entry());
+    expect(lookupEntry(map, 'fp-1', GEN)?.storeName).toBe('ooc-abc-123');
+    expect(lookupEntry(map, 'fp-other', GEN)).toBeNull();
+    // generation mismatch is a miss even though the fingerprint matches
+    expect(lookupEntry(map, 'fp-1', 'gen-B')).toBeNull();
+  });
+
+  it('upsert replaces the entry for a (fingerprint, generation) pair without duplicating', () => {
+    let map = upsertEntry(emptyCacheMap(), entry({ storeName: 'store-old' }));
+    map = upsertEntry(map, entry({ storeName: 'store-new' }));
+    expect(map.entries).toHaveLength(1);
+    expect(lookupEntry(map, 'fp-1', GEN)?.storeName).toBe('store-new');
+  });
+
+  it('upsert is immutable — it does not mutate the input map', () => {
+    const before = upsertEntry(emptyCacheMap(), entry());
+    const snapshot = JSON.parse(JSON.stringify(before));
+    upsertEntry(before, entry({ fingerprint: 'fp-2', storeName: 'store-2' }));
+    expect(before).toEqual(snapshot);
+  });
+
+  it('touch updates lastUsedAt for the matching entry only', () => {
+    let map = upsertEntry(emptyCacheMap(), entry({ fingerprint: 'fp-1', lastUsedAt: 1000 }));
+    map = upsertEntry(map, entry({ fingerprint: 'fp-2', storeName: 'store-2', lastUsedAt: 1000 }));
+    map = touchEntry(map, 'fp-1', GEN, 9999);
+    expect(lookupEntry(map, 'fp-1', GEN)?.lastUsedAt).toBe(9999);
+    expect(lookupEntry(map, 'fp-2', GEN)?.lastUsedAt).toBe(1000);
+  });
+
+  it('removeByStoreName drops the entry whose store was deleted out from under it', () => {
+    const map = upsertEntry(emptyCacheMap(), entry());
+    const after = removeByStoreName(map, 'ooc-abc-123');
+    expect(lookupEntry(after, 'fp-1', GEN)).toBeNull();
+  });
+
+  it('cacheGeneration is a stable non-empty string', () => {
+    expect(cacheGeneration()).toBe(cacheGeneration());
+    expect(cacheGeneration().length).toBeGreaterThan(0);
+  });
+});
+
+describe('oocCacheMap — OPFS bridge', () => {
+  it('write then read round-trips the map through OPFS', async () => {
+    const dir = fakeOpfsDir();
+    const map = upsertEntry(emptyCacheMap(), entry());
+    await writeCacheMap(dir, map);
+    expect(await readCacheMap(dir)).toEqual(map);
+  });
+
+  it('reading a root with no map file returns an empty map (fail-closed)', async () => {
+    expect(await readCacheMap(fakeOpfsDir())).toEqual(emptyCacheMap());
+  });
+});


### PR DESCRIPTION
Phase 2 of the persistent out-of-core cache. A small JSON record in the OPFS root maps a file fingerprint (Phase 1, #737) to the promoted tile store that holds its index, so a reopen can find it without rebuilding.

Two design rules the tests pin. It fails closed: a missing, corrupt, or wrong-version record parses to an empty map, and an individually malformed entry is dropped — so a bad file forces rebuilds, never a wrong hit. And lookups are generation-gated: the generation string binds the tile-store schema and the fingerprint scheme, so an index written by an incompatible build is a miss even when the source file is unchanged (the stored bytes describe a format this build can no longer read).

Pure core — parse / serialize / lookup / upsert / touch / removeByStoreName — plus a thin OPFS read/write bridge over the root directory. Unwired: nothing calls it in the open path yet; the reopen branch consumes it in a later phase, so there is no behaviour change now. 12 tests (TDD, incl. fail-closed and generation-mismatch), TSC clean, custom lints pass.