### PR TITLE
feat(heavy): cross-tab store liveness for the OOC cache

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -20,6 +20,14 @@
   "reviewDates": "Reported by the lint when they pass, never enforced. A gate that turns red on a date with no change to the tree teaches people to edit the date rather than the code.",
   "modules": [
     {
+      "path": "src/io/heavy/oocStoreLiveness.ts",
+      "status": "staged",
+      "why": "Phase 3 of the persistent out-of-core cache: cross-tab liveness over the Web Locks API, so eviction or a rebuild in place never touches a store another tab has open. Pure logic over an injected lock manager, tested; the open path and janitor do not call it yet.",
+      "graduation": "The reopen branch in src/app/heavyLasExecutor.ts holds acquireStoreResidency while a store is open and the janitor consults liveStoreNames before evicting, reached from src/main.ts.",
+      "review": "2027-02-28",
+      "declaredIn": "PR (persistent OOC cache, Phase 3)"
+    },
+    {
       "path": "src/io/heavy/fileFingerprint.ts",
       "status": "staged",
       "why": "Phase 1 of the persistent out-of-core cache: the pre-decode file fingerprint a persisted index is keyed by (SHA-256 over header facts plus sampled byte windows). Pure and tested; the open path does not call it yet, so the reopen branch that consumes it is a later phase.",

--- a/src/io/heavy/oocStoreLiveness.ts
+++ b/src/io/heavy/oocStoreLiveness.ts
@@ -1,0 +1,118 @@
+/**
+ * oocStoreLiveness.ts — cross-tab liveness for the persistent OOC cache.
+ *
+ * Phase 3, and the prerequisite for a stable store name. Today every open builds
+ * a randomly-named store, so two tabs never share one and eviction is safe by
+ * construction. A persistent cache keys the store by the file fingerprint, so two
+ * tabs that open the same file share a store — and then eviction, or a rebuild in
+ * place, must never touch a store another tab still has open.
+ *
+ * The signal is the Web Locks API. A tab holds a SHARED lock named after the
+ * store for as long as it keeps that store open; many tabs can hold the same
+ * shared lock at once. To ask "is anyone using store X" a caller requests an
+ * EXCLUSIVE lock with `ifAvailable`: granted (non-null) means nobody holds it,
+ * null means someone does. No polling, no heartbeat to expire — the browser drops
+ * a tab's locks when the tab goes away.
+ *
+ * The one safety rule: when liveness cannot be determined — the API is absent —
+ * a store reads as BUSY and the live-set is null. A missing signal can only ever
+ * PREVENT an eviction, never cause a wrong one.
+ *
+ * The Web Locks manager is injected (the subset used is small), so the logic is
+ * tested in Node against a fake; the browser passes `navigator.locks`.
+ */
+
+/** The Web Locks subset this module uses — so it can be faked in a test. */
+export interface LockGrantLike {
+  readonly name: string;
+}
+export interface LockRequestOptions {
+  readonly mode?: 'exclusive' | 'shared';
+  readonly ifAvailable?: boolean;
+  readonly signal?: AbortSignal;
+}
+export interface LockManagerLike {
+  request<T>(
+    name: string,
+    options: LockRequestOptions,
+    callback: (lock: LockGrantLike | null) => T | Promise<T>,
+  ): Promise<T>;
+  query(): Promise<{ held: ReadonlyArray<{ name: string }> }>;
+}
+
+/** Lock-name namespace, so a store lock never collides with another app lock. */
+const LOCK_PREFIX = 'olv-ooc-store:';
+
+/** The lock name a store's residency is held under. */
+export function storeLockName(storeName: string): string {
+  return `${LOCK_PREFIX}${storeName}`;
+}
+
+/** The store name behind a lock name, or null if it is not one of ours. */
+function storeNameFromLock(lockName: string): string | null {
+  return lockName.startsWith(LOCK_PREFIX) ? lockName.slice(LOCK_PREFIX.length) : null;
+}
+
+/** The live Web Locks manager, or null when the API is unavailable. */
+export function resolveLockManager(): LockManagerLike | null {
+  const locks = (globalThis.navigator as Navigator | undefined)?.locks;
+  return (locks as unknown as LockManagerLike | undefined) ?? null;
+}
+
+/**
+ * Hold a store's residency: acquire a shared lock and keep it until the returned
+ * function is called. Resolves once the lock is granted, with a release function
+ * whose own promise settles when the lock is actually let go.
+ */
+export function acquireStoreResidency(
+  locks: LockManagerLike,
+  storeName: string,
+  signal?: AbortSignal,
+): Promise<() => Promise<void>> {
+  return new Promise((resolveOuter, rejectOuter) => {
+    let resolveHeld!: () => void;
+    const held = new Promise<void>((r) => {
+      resolveHeld = r;
+    });
+    let requestP: Promise<void>;
+    const release = (): Promise<void> => {
+      resolveHeld();
+      return requestP;
+    };
+    requestP = locks.request(storeLockName(storeName), { mode: 'shared', signal }, () => {
+      resolveOuter(release);
+      return held;
+    });
+    requestP.catch(rejectOuter);
+  });
+}
+
+/**
+ * Whether any tab is currently using the store. Requests an exclusive lock with
+ * `ifAvailable`: a null grant means someone holds it (busy). With no lock manager
+ * the answer is BUSY — never claim a store is free when we cannot tell.
+ */
+export function isStoreBusy(locks: LockManagerLike | null, storeName: string): Promise<boolean> {
+  if (!locks) return Promise.resolve(true);
+  return locks.request(
+    storeLockName(storeName),
+    { mode: 'exclusive', ifAvailable: true },
+    (lock) => lock === null,
+  );
+}
+
+/**
+ * The set of store names currently held by any tab, for an eviction pass to skip.
+ * Null when liveness cannot be determined (no lock manager) — the caller must
+ * then evict nothing.
+ */
+export async function liveStoreNames(locks: LockManagerLike | null): Promise<Set<string> | null> {
+  if (!locks) return null;
+  const { held } = await locks.query();
+  const names = new Set<string>();
+  for (const lock of held) {
+    const storeName = storeNameFromLock(lock.name);
+    if (storeName !== null) names.add(storeName);
+  }
+  return names;
+}

--- a/tests/oocStoreLiveness.test.ts
+++ b/tests/oocStoreLiveness.test.ts
@@ -1,0 +1,108 @@
+/**
+ * oocStoreLiveness.test.ts — cross-tab liveness for the OOC cache.
+ *
+ * Phase 3 of the persistent out-of-core cache, and the safety prerequisite for a
+ * stable store name. Today each open builds a randomly-named store, so two tabs
+ * never collide; once a store name is stable and shared, eviction or a rebuild in
+ * place must never touch a store another tab is using. This module answers "is
+ * anyone using store X" over the Web Locks API: a tab holds a SHARED lock for as
+ * long as it has a store open, and a check for an EXCLUSIVE lock (if available)
+ * tells whether anyone still holds it.
+ *
+ * The functions take an injected lock manager (the Web Locks subset they use), so
+ * the whole thing is tested in Node against a fake that models shared/exclusive
+ * grants. The one rule that matters most is pinned here: when liveness cannot be
+ * determined — no lock manager at all — a store reads as BUSY, so a missing API
+ * can only ever prevent an eviction, never cause a wrong one.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  storeLockName,
+  acquireStoreResidency,
+  isStoreBusy,
+  liveStoreNames,
+  type LockManagerLike,
+} from '../src/io/heavy/oocStoreLiveness';
+
+/** A fake Web Locks manager modelling shared/exclusive grants and ifAvailable. */
+function fakeLocks(): LockManagerLike {
+  const held = new Map<string, { shared: number; exclusive: boolean }>();
+  const canGrant = (name: string, mode: string): boolean => {
+    const h = held.get(name);
+    if (!h) return true;
+    return mode === 'exclusive' ? h.shared === 0 && !h.exclusive : !h.exclusive;
+  };
+  return {
+    async request(name, options, cb) {
+      const mode = options.mode ?? 'exclusive';
+      if (options.ifAvailable && !canGrant(name, mode)) return cb(null);
+      const h = held.get(name) ?? { shared: 0, exclusive: false };
+      if (mode === 'exclusive') h.exclusive = true;
+      else h.shared += 1;
+      held.set(name, h);
+      try {
+        return await cb({ name });
+      } finally {
+        const g = held.get(name)!;
+        if (mode === 'exclusive') g.exclusive = false;
+        else g.shared -= 1;
+        if (g.shared === 0 && !g.exclusive) held.delete(name);
+      }
+    },
+    async query() {
+      return { held: [...held.keys()].map((name) => ({ name })) };
+    },
+  };
+}
+
+describe('oocStoreLiveness', () => {
+  it('namespaces the lock name and includes the store name', () => {
+    const a = storeLockName('ooc-scan-1');
+    const b = storeLockName('ooc-scan-2');
+    expect(a).toContain('ooc-scan-1');
+    expect(a).not.toBe(b);
+  });
+
+  it('a store with no holder is not busy', async () => {
+    expect(await isStoreBusy(fakeLocks(), 'store-1')).toBe(false);
+  });
+
+  it('residency makes a store busy until it is released', async () => {
+    const locks = fakeLocks();
+    const release = await acquireStoreResidency(locks, 'store-1');
+    expect(await isStoreBusy(locks, 'store-1')).toBe(true);
+    await release();
+    expect(await isStoreBusy(locks, 'store-1')).toBe(false);
+  });
+
+  it('two tabs can hold the same store concurrently (shared), and it stays busy until both release', async () => {
+    const locks = fakeLocks();
+    const r1 = await acquireStoreResidency(locks, 'store-1');
+    const r2 = await acquireStoreResidency(locks, 'store-1');
+    expect(await isStoreBusy(locks, 'store-1')).toBe(true);
+    await r1();
+    expect(await isStoreBusy(locks, 'store-1')).toBe(true); // r2 still holds
+    await r2();
+    expect(await isStoreBusy(locks, 'store-1')).toBe(false);
+  });
+
+  it('fails safe: with no lock manager, a store reads as BUSY (never evictable)', async () => {
+    expect(await isStoreBusy(null, 'store-1')).toBe(true);
+  });
+
+  it('liveStoreNames returns the currently-held store names and ignores foreign locks', async () => {
+    const locks = fakeLocks();
+    const r = await acquireStoreResidency(locks, 'store-A');
+    // a lock that is not one of ours must not appear as a live store
+    await locks.request('some-other-app-lock', { mode: 'shared' }, async () => {
+      const live = await liveStoreNames(locks);
+      expect(live).toEqual(new Set(['store-A']));
+    });
+    await r();
+    expect(await liveStoreNames(locks)).toEqual(new Set());
+  });
+
+  it('liveStoreNames is null when liveness cannot be determined (no manager)', async () => {
+    expect(await liveStoreNames(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Phase 3 of the persistent out-of-core cache, and the safety prerequisite for a stable store name. Today every open builds a randomly-named store, so two tabs never collide; once a store is keyed by the file fingerprint (Phase 1, #737), two tabs that open the same file share it — and then eviction or a rebuild in place must never touch a store another tab still has open.

The signal is the Web Locks API. A tab holds a shared lock named after the store for as long as it keeps it open (acquireStoreResidency); isStoreBusy asks for an exclusive lock ifAvailable to tell whether anyone still holds it; liveStoreNames lists the held stores for an eviction pass to skip. No polling, no heartbeat — the browser drops a tab's locks when it goes away.

The one safety rule, pinned by a test: when liveness cannot be determined (no lock manager), a store reads as busy and the live-set is null. A missing signal can only ever prevent an eviction, never cause a wrong one.

Pure logic over an injected lock manager, tested in Node against a fake modelling shared/exclusive grants (7 tests). Unwired — the reopen branch and janitor consume it in a later phase — registered staged. TSC clean, custom lints pass.