### PR TITLE
fix(ui): one canonical GPU backend label (§22)

### DIFF
--- a/src/ui/DebugOverlay.ts
+++ b/src/ui/DebugOverlay.ts
@@ -20,6 +20,7 @@ import { formatTelemetry } from '../io/loadTelemetry';
 import { FrameTelemetry } from '../perf/frameTelemetry';
 import { readDevFlags } from '../perf/devFlags';
 import { buildMetricsJson } from '../perf/metricsJson';
+import { backendLabel } from './backendLabel';
 
 /** Live COPC streaming counters — present only while a COPC scan is open. */
 export interface StreamingDebugStats {
@@ -318,18 +319,11 @@ export class DebugOverlay {
     } else {
       this._perf.textContent = '(collecting…)';
     }
-    let backendLabel: string;
-    if (backend === 'webgpu') {
-      backendLabel = 'WebGPU';
-    } else if (backend === 'webgl2') {
-      backendLabel = 'WebGL 2';
-    } else {
-      backendLabel = '—';
-    }
+    const backendText = backendLabel(backend);
 
     if (stats) {
       this._live.textContent = [
-        `backend       ${backendLabel}`,
+        `backend       ${backendText}`,
         `fps           ${stats.fps.toFixed(0)}  (${stats.frameMs.toFixed(1)} ms)`,
         // A WebGPU backend can report 0 draw calls even while millions of
         // points are clearly on screen (the EDL post-pipeline / streaming path

--- a/src/ui/backendLabel.ts
+++ b/src/ui/backendLabel.ts
@@ -1,0 +1,17 @@
+/**
+ * backendLabel.ts — the canonical human name for a GPU backend.
+ *
+ * The tool dock and the debug overlay both display which backend the renderer
+ * initialised, and they had drifted apart ("WebGL2" vs "WebGL 2"). One helper
+ * gives both the same string, so the two readouts can never disagree.
+ */
+
+/** The backend the renderer is on, or null before it has initialised. */
+export type GpuBackend = 'webgpu' | 'webgl2';
+
+/** The display label for a backend; an em dash when it is not yet known. */
+export function backendLabel(backend: GpuBackend | null): string {
+  if (backend === 'webgpu') return 'WebGPU';
+  if (backend === 'webgl2') return 'WebGL 2';
+  return '—';
+}

--- a/src/ui/toolDock.ts
+++ b/src/ui/toolDock.ts
@@ -1,4 +1,5 @@
 import { el } from './dom';
+import { backendLabel } from './backendLabel';
 import {
   ICON_FRAME,
   ICON_SNAPSHOT,
@@ -254,7 +255,7 @@ export class ToolDock {
 
   /** Report which GPU backend the renderer initialised. */
   setBackend(backend: 'webgpu' | 'webgl2'): void {
-    this._backendText.textContent = backend === 'webgpu' ? 'WebGPU' : 'WebGL2';
+    this._backendText.textContent = backendLabel(backend);
   }
 
   /**

--- a/tests/backendLabel.test.ts
+++ b/tests/backendLabel.test.ts
@@ -1,0 +1,20 @@
+/**
+ * backendLabel.test.ts — the one place the GPU backend is turned into text.
+ *
+ * Two readouts named the same backend two different ways: the tool dock showed
+ * "WebGL2", the debug overlay "WebGL 2". This pins a single canonical label both
+ * consume, so the app can never disagree with itself about which backend is live.
+ */
+import { describe, it, expect } from 'vitest';
+import { backendLabel } from '../src/ui/backendLabel';
+
+describe('backendLabel', () => {
+  it('names each backend canonically', () => {
+    expect(backendLabel('webgpu')).toBe('WebGPU');
+    expect(backendLabel('webgl2')).toBe('WebGL 2');
+  });
+
+  it('renders an em dash when the backend is not yet known', () => {
+    expect(backendLabel(null)).toBe('—');
+  });
+});


### PR DESCRIPTION
Brief-04 §22. The tool dock rendered the GPU backend as "WebGL2" and the debug overlay as "WebGL 2" — two readouts of the same fact disagreeing. A single backendLabel() helper (WebGPU / WebGL 2 / em dash when unknown) now feeds both, so the app cannot contradict itself about the live backend. The dock label becomes "WebGL 2"; the metrics JSON keeps the raw enum, unchanged. TDD (2 tests), TSC clean, lints pass; the helper is reachable so needs no staged registry entry.