### PR TITLE
feat(heavy): OOC cache eviction selector + source bounds in facts

### DIFF
--- a/src/app/heavyLasTypes.ts
+++ b/src/app/heavyLasTypes.ts
@@ -93,6 +93,11 @@ export interface LasHeaderFacts {
   readonly schema: TileSchema;
   readonly attributes: PointAttributes;
   readonly fileBytes: number;
+  /** Source bounds from the public header, folded into the cache fingerprint so
+   *  a file whose extent changed cannot match a stored index. Optional: absent
+   *  bounds make the fingerprint unavailable, which the cache reads as a miss. */
+  readonly min?: readonly [number, number, number];
+  readonly max?: readonly [number, number, number];
 }
 
 /**

--- a/src/app/openLocalHeavyLas.ts
+++ b/src/app/openLocalHeavyLas.ts
@@ -149,6 +149,8 @@ async function peekLasHeaderFacts(
     schema,
     attributes,
     fileBytes: size,
+    min: [header.min[0], header.min[1], header.min[2]],
+    max: [header.max[0], header.max[1], header.max[2]],
   };
 }
 

--- a/src/io/heavy/oocCacheMap.ts
+++ b/src/io/heavy/oocCacheMap.ts
@@ -143,6 +143,36 @@ export function removeByStoreName(map: OocCacheMap, storeName: string): OocCache
   return { version: map.version, entries: map.entries.filter((e) => e.storeName !== storeName) };
 }
 
+export interface EvictionBudget {
+  /** Total tile bytes the retained stores may occupy. */
+  readonly budgetBytes: number;
+  /** Stores a tab currently has open — never evicted, whatever their age. */
+  readonly liveNames: ReadonlySet<string>;
+}
+
+/**
+ * The store names to evict so the retained stores fit the byte budget, oldest
+ * use first. A live store is never chosen, even when it is the oldest and the
+ * budget is blown — a store in use must not be deleted from under it, so an
+ * over-budget cache of only-live stores evicts nothing and waits.
+ */
+export function selectEvictions(
+  entries: readonly OocCacheEntry[],
+  { budgetBytes, liveNames }: EvictionBudget,
+): string[] {
+  let total = entries.reduce((n, e) => n + e.tileBytes, 0);
+  if (total <= budgetBytes) return [];
+  const evict: string[] = [];
+  const byOldest = [...entries].sort((a, b) => a.lastUsedAt - b.lastUsedAt);
+  for (const entry of byOldest) {
+    if (total <= budgetBytes) break;
+    if (liveNames.has(entry.storeName)) continue;
+    evict.push(entry.storeName);
+    total -= entry.tileBytes;
+  }
+  return evict;
+}
+
 /**
  * Read the map from the OPFS root, failing closed: a missing file or any read
  * error yields an empty map rather than throwing.

--- a/tests/oocCacheMap.test.ts
+++ b/tests/oocCacheMap.test.ts
@@ -18,6 +18,7 @@ import {
   upsertEntry,
   touchEntry,
   removeByStoreName,
+  selectEvictions,
   readCacheMap,
   writeCacheMap,
   cacheGeneration,
@@ -100,6 +101,43 @@ describe('oocCacheMap — pure core', () => {
   it('cacheGeneration is a stable non-empty string', () => {
     expect(cacheGeneration()).toBe(cacheGeneration());
     expect(cacheGeneration().length).toBeGreaterThan(0);
+  });
+});
+
+describe('selectEvictions', () => {
+  const e = (storeName: string, lastUsedAt: number, tileBytes: number): OocCacheEntry => ({
+    fingerprint: 'fp-' + storeName,
+    storeName,
+    generation: GEN,
+    createdAt: 0,
+    lastUsedAt,
+    pointCount: 1,
+    tileBytes,
+  });
+
+  it('evicts nothing when total is within the byte budget', () => {
+    const entries = [e('a', 1, 100), e('b', 2, 100)];
+    expect(selectEvictions(entries, { budgetBytes: 1000, liveNames: new Set() })).toEqual([]);
+  });
+
+  it('evicts least-recently-used first until under budget', () => {
+    const entries = [e('newest', 30, 100), e('oldest', 10, 100), e('mid', 20, 100)];
+    // budget 150 → must drop 150 bytes → oldest then mid (100 each), leaving 100 ≤ 150
+    expect(selectEvictions(entries, { budgetBytes: 150, liveNames: new Set() })).toEqual(['oldest', 'mid']);
+  });
+
+  it('never evicts a live store, even if it is the oldest', () => {
+    const entries = [e('oldest-live', 10, 100), e('mid', 20, 100), e('newest', 30, 100)];
+    // total 300, budget 120 → must shed 180+; oldest is live so it is skipped,
+    // and mid + newest (100 each) are dropped to reach 100 ≤ 120.
+    const evict = selectEvictions(entries, { budgetBytes: 120, liveNames: new Set(['oldest-live']) });
+    expect(evict).not.toContain('oldest-live');
+    expect(evict).toEqual(['mid', 'newest']);
+  });
+
+  it('evicts nothing when only live stores remain over budget', () => {
+    const entries = [e('a', 1, 100), e('b', 2, 100)];
+    expect(selectEvictions(entries, { budgetBytes: 50, liveNames: new Set(['a', 'b']) })).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Phase 4 prep for the persistent out-of-core cache — two pure pieces the reopen wiring will consume.

selectEvictions() chooses the least-recently-used stores to drop so the retained cache fits a byte budget, and never selects a store a tab currently has open (Phase 3 liveness): an over-budget cache of only-live stores evicts nothing and waits, because a store in use must not be deleted from under it.

The LAS header facts now carry the source bounds (min/max, optional), which fold into the file fingerprint (#737) so a file whose extent changed cannot match a stored index. Both changes are additive and unwired: the bounds are unused until the reopen branch, and absent bounds simply make the fingerprint unavailable — a miss, never a wrong hit. 4 new tests (TDD), TSC clean, lints pass.