### PR TITLE
feat(heavy): persistent OOC cache — reopen on fingerprint hit (Phase 4)

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -20,30 +20,6 @@
   "reviewDates": "Reported by the lint when they pass, never enforced. A gate that turns red on a date with no change to the tree teaches people to edit the date rather than the code.",
   "modules": [
     {
-      "path": "src/io/heavy/oocStoreLiveness.ts",
-      "status": "staged",
-      "why": "Phase 3 of the persistent out-of-core cache: cross-tab liveness over the Web Locks API, so eviction or a rebuild in place never touches a store another tab has open. Pure logic over an injected lock manager, tested; the open path and janitor do not call it yet.",
-      "graduation": "The reopen branch in src/app/heavyLasExecutor.ts holds acquireStoreResidency while a store is open and the janitor consults liveStoreNames before evicting, reached from src/main.ts.",
-      "review": "2027-02-28",
-      "declaredIn": "PR (persistent OOC cache, Phase 3)"
-    },
-    {
-      "path": "src/io/heavy/fileFingerprint.ts",
-      "status": "staged",
-      "why": "Phase 1 of the persistent out-of-core cache: the pre-decode file fingerprint a persisted index is keyed by (SHA-256 over header facts plus sampled byte windows). Pure and tested; the open path does not call it yet, so the reopen branch that consumes it is a later phase.",
-      "graduation": "The reopen branch in src/app/heavyLasExecutor.ts calls fingerprintFromRange before the storage preflight to key the persisted cache map, reached from src/main.ts.",
-      "review": "2027-02-28",
-      "declaredIn": "PR #737 (persistent OOC cache, Phase 1)"
-    },
-    {
-      "path": "src/io/heavy/oocCacheMap.ts",
-      "status": "staged",
-      "why": "Phase 2 of the persistent out-of-core cache: the persisted fingerprint-to-store map (a JSON record in the OPFS root) the reopen branch reads to find a prior index. Pure core plus an OPFS bridge, tested; the open path does not call it yet.",
-      "graduation": "The reopen branch in src/app/heavyLasExecutor.ts reads the map with readCacheMap to resolve a fingerprint to a promoted store, reached from src/main.ts.",
-      "review": "2027-02-28",
-      "declaredIn": "PR #738 (persistent OOC cache, Phase 2)"
-    },
-    {
       "path": "src/features/FeatureExtractionService.ts",
       "status": "staged",
       "why": "Named in the v0.6.6 release notes under \"Also in this release\" as a foundation: \"a feature-extraction service over the building and conductor cores ... Nothing in the running application passes through either\". It is the product-side entry over the two cores; no UI or DerivedLayer calls it.",

--- a/src/app/heavyLasExecutor.ts
+++ b/src/app/heavyLasExecutor.ts
@@ -19,8 +19,34 @@ import {
   storagePreflightRefusal,
   readStorageEstimate,
 } from '../io/heavy/storagePreflight';
-import { openTileStore, tileBytesReader } from '../io/heavy/tileStoreBuilder';
-import { opfsSpillStore, removeOpfsStore, type OpfsDirHandle } from '../io/heavy/opfsSpillStore';
+import {
+  openTileStore,
+  tileBytesReader,
+  TILE_MANIFEST_NAME,
+  TILE_HIERARCHY_NAME,
+} from '../io/heavy/tileStoreBuilder';
+import {
+  opfsSpillStore,
+  removeOpfsStore,
+  readOpfsText,
+  type OpfsDirHandle,
+} from '../io/heavy/opfsSpillStore';
+import { fingerprintFromRange } from '../io/heavy/fileFingerprint';
+import {
+  readCacheMap,
+  writeCacheMap,
+  lookupEntry,
+  upsertEntry,
+  touchEntry,
+  removeByStoreName,
+  selectEvictions,
+  cacheGeneration,
+} from '../io/heavy/oocCacheMap';
+import {
+  resolveLockManager,
+  acquireStoreResidency,
+  liveStoreNames,
+} from '../io/heavy/oocStoreLiveness';
 import { OlvTileSource, PreviewCloudSource } from '../io/heavy/OlvTileSource';
 import { buildPreviewSample } from '../io/heavy/previewSampler';
 import { TileChunkDecoder } from '../io/heavy/tileChunkDecoder';
@@ -50,6 +76,47 @@ import type {
 
 /** Peak staging memory the bucketing pass may hold before spilling to OPFS. */
 const BUILD_MEMORY_BUDGET_BYTES = 128 * 1024 * 1024;
+
+/**
+ * Soft cap on the retained cache: after a fresh build records its store, the
+ * least-recently-used stores are evicted until the retained tile bytes fit this,
+ * so a session that opens many large files does not grow the cache without bound.
+ * A live store (one another tab holds open) is never evicted, whatever its age.
+ */
+const CACHE_BUDGET_BYTES = 8 * 1024 * 1024 * 1024;
+
+/**
+ * Fingerprint the file before any decode, so a persisted index can be looked up
+ * or recorded under a content-based key. Returns null when the source bounds are
+ * absent (an old peek) or any window read fails — the caller reads null as "no
+ * reuse and no record", never as a match, keeping the cache fail-safe.
+ */
+async function computeOpenFingerprint(
+  file: File,
+  facts: LasHeaderFacts,
+  range: RangeSource,
+  signal: AbortSignal,
+): Promise<string | null> {
+  if (!facts.min || !facts.max) return null;
+  try {
+    return await fingerprintFromRange(
+      range,
+      {
+        fileBytes: facts.fileBytes,
+        // A real File always carries a numeric lastModified; default defensively
+        // so a synthetic File missing it still yields a well-formed digest.
+        lastModified: typeof file.lastModified === 'number' ? file.lastModified : 0,
+        declaredPointCount: facts.declaredPointCount,
+        offsetToPointData: facts.offsetToPointData,
+        min: facts.min,
+        max: facts.max,
+      },
+      signal,
+    );
+  } catch {
+    return null;
+  }
+}
 
 const PHASE_LABELS: Record<LocalOocPhase, string> = {
   indexing: 'Indexing for streaming…',
@@ -126,6 +193,130 @@ function newOpenId(): string {
 }
 
 /**
+ * Reopen a cached store from OPFS without rebuilding: read its manifest and
+ * hierarchy back, present them as an {@link OlvTileSource}, and hold a shared
+ * residency lock so an eviction pass in another tab cannot delete it while it is
+ * open. Its `close` RETAINS the store — a reused index is never deleted. Returns
+ * null when the store directory is gone (evicted) or its artifacts cannot be
+ * read (a partial or corrupt store), which the caller treats as a miss.
+ */
+async function reopenFromCache(
+  root: OpfsDirHandle,
+  storeName: string,
+  file: File,
+): Promise<{ source: OlvTileSource; decoder: TileChunkDecoder } | null> {
+  let dir: OpfsDirHandle;
+  try {
+    dir = await root.getDirectoryHandle(storeName);
+  } catch {
+    return null; // store evicted out from under the map
+  }
+  let manifestJson: string;
+  let hierarchy: string;
+  try {
+    manifestJson = await readOpfsText(dir, TILE_MANIFEST_NAME);
+    hierarchy = await readOpfsText(dir, TILE_HIERARCHY_NAME);
+  } catch {
+    return null; // artifacts missing / unreadable → rebuild
+  }
+  const spill = opfsSpillStore(dir);
+  const reader = openTileStore(manifestJson, hierarchy);
+  const locks = resolveLockManager();
+  const releaseResidency = locks ? await acquireStoreResidency(locks, storeName) : null;
+  const source = new OlvTileSource({
+    id: `ooc-${storeName}`,
+    name: file.name,
+    store: reader,
+    tiles: tileBytesReader(spill),
+    // RETAIN: a reused store is kept for the next open. Release the tile handles
+    // and the residency lock, but never delete — the map still points here.
+    close: async () => {
+      await spill.close();
+      await releaseResidency?.();
+    },
+  });
+  const decoder = new TileChunkDecoder(reader.schema, reader.recordBytes);
+  return { source, decoder };
+}
+
+/**
+ * Try to satisfy the open from the persisted cache. Returns a terminal
+ * {@link HeavyOpenResult} on a hit (or a cancel mid-attach), or null to tell the
+ * caller to build fresh — on a miss, a stale entry whose store is gone (cleaned
+ * here), or a reopen whose attach faulted for a non-cancel reason.
+ */
+async function tryReopen(
+  root: OpfsDirHandle,
+  fingerprint: string,
+  generation: string,
+  file: File,
+  deps: HeavyLasBridgeDeps,
+  signal: AbortSignal,
+): Promise<HeavyOpenResult | null> {
+  const map = await readCacheMap(root);
+  const entry = lookupEntry(map, fingerprint, generation);
+  if (!entry) return null;
+  const opened = await reopenFromCache(root, entry.storeName, file);
+  if (!opened) {
+    // The map named a store that is no longer usable; drop the stale entry so a
+    // later open does not keep chasing it, then build fresh.
+    await writeCacheMap(root, removeByStoreName(map, entry.storeName)).catch(() => {});
+    return null;
+  }
+  try {
+    await attachHeavyStream(opened.source, opened.decoder, deps, signal);
+  } catch (err) {
+    await opened.source.close().catch(() => {});
+    if (signal.aborted || isCancel(err)) return { status: 'cancelled' };
+    if (deps.debug) console.warn('[heavy-las] cache reopen attach failed; rebuilding', err);
+    return null;
+  }
+  await writeCacheMap(root, touchEntry(map, fingerprint, generation, Date.now())).catch(() => {});
+  return { status: 'attached', source: opened.source, decoder: opened.decoder };
+}
+
+/**
+ * Record a freshly-built store in the cache map and evict down to the budget.
+ * Best-effort: any failure returns false and the caller then leaves the store
+ * uncommitted (deleted on close), so a cache-write fault never leaks an
+ * unrecorded store nor fails the open. Eviction skips every live store and never
+ * this one — the caller holds its residency lock, so it is in the live set.
+ */
+async function recordAndEvict(
+  root: OpfsDirHandle,
+  fingerprint: string,
+  generation: string,
+  storeName: string,
+  reader: { manifest: { pointCount: number }; recordBytes: number },
+  locks: ReturnType<typeof resolveLockManager>,
+): Promise<boolean> {
+  try {
+    const now = Date.now();
+    const tileBytes = reader.manifest.pointCount * reader.recordBytes;
+    let map = upsertEntry(await readCacheMap(root), {
+      fingerprint,
+      storeName,
+      generation,
+      createdAt: now,
+      lastUsedAt: now,
+      pointCount: reader.manifest.pointCount,
+      tileBytes,
+    });
+    const live = await liveStoreNames(locks);
+    if (live) {
+      for (const name of selectEvictions(map.entries, { budgetBytes: CACHE_BUDGET_BYTES, liveNames: live })) {
+        await removeOpfsStore(root, name).catch(() => {});
+        map = removeByStoreName(map, name);
+      }
+    }
+    await writeCacheMap(root, map);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Build the tile store, reopen it from OPFS, and attach it as a streaming scan.
  * Called only when the decision half has confirmed the plan routes this file out
  * of core, so every failure path here is a CONFIRMED-heavy failure: it returns a
@@ -172,6 +363,18 @@ export async function executeHeavyLasBuild(
 
   const root = await getOpfsRoot();
   if (root === null) return { status: 'unavailable', heavy: true, reason: 'no OPFS root' };
+
+  // Persistent cache. Fingerprint the file before any decode; on a hit, reopen
+  // the stored index instead of rebuilding it. A null fingerprint (a peek with no
+  // bounds, or a read fault) skips both reuse and recording, so the open behaves
+  // exactly as it did before the cache existed.
+  const generation = cacheGeneration();
+  const fingerprint = await computeOpenFingerprint(file, facts, openRange(file), signal);
+  if (signal.aborted) return { status: 'cancelled' };
+  if (fingerprint) {
+    const reopened = await tryReopen(root, fingerprint, generation, file, deps, signal);
+    if (reopened) return reopened;
+  }
 
   if (!janitorSwept) {
     janitorSwept = true;
@@ -252,21 +455,29 @@ export async function executeHeavyLasBuild(
     const dir = await root.getDirectoryHandle(built.storeName);
     const spill = opfsSpillStore(dir);
     const reader = openTileStore(built.manifestJson, built.hierarchy);
+    // Hold a shared residency lock while the store is open, so an eviction pass in
+    // this or another tab cannot delete it from under a live read.
+    const locks = resolveLockManager();
+    const releaseResidency = locks ? await acquireStoreResidency(locks, built.storeName) : null;
+    // Retained once the store is recorded in the cache map (only after a
+    // successful attach, and only when this open has a fingerprint to key it by).
+    // Until then — an attach fault, a build with no fingerprint — the store is
+    // uncommitted and close DELETES it, exactly as before the cache existed.
+    let retain = false;
     const source = new OlvTileSource({
       id: `ooc-${built.storeName}`,
       name: file.name,
       store: reader,
       tiles: tileBytesReader(spill),
-      // The out-of-core store is TEMPORARY for this release: nothing reuses it
-      // on a later open, so a persisted `ooc-<name>-<size>` directory is pure
-      // cost. On close, release the open tile handles FIRST (so a close racing
-      // a read unlocks before anything is deleted), THEN remove the store. The
-      // removal is fired without letting a rejection escape the close — a store
-      // the browser cannot delete because a read still holds it is left stale
-      // and rebuilt on the next open, which is the honest fallback. Persistent
-      // cross-session reuse via a source fingerprint is the future direction.
+      // Release the tile handles FIRST (so a close racing a read unlocks before
+      // anything is touched) and the residency lock, THEN — only for an
+      // uncommitted store — remove it. A committed store is kept for reuse; a
+      // removal that cannot run because a read still holds the handle is
+      // swallowed and the store rebuilt next open, the honest fallback.
       close: async () => {
         await spill.close();
+        await releaseResidency?.();
+        if (retain) return;
         try {
           await removeOpfsStore(root, built.storeName);
         } catch (err) {
@@ -290,6 +501,12 @@ export async function executeHeavyLasBuild(
         if (deps.debug) console.warn('[heavy-las] store cleanup after attach failure failed', closeErr);
       });
       throw err;
+    }
+    // The scan is committed. If this open has a fingerprint, record the store so a
+    // later open reuses it, and retain it on close; a failed record leaves the
+    // store uncommitted (deleted on close), never leaked.
+    if (fingerprint && (await recordAndEvict(root, fingerprint, generation, built.storeName, reader, locks))) {
+      retain = true;
     }
     return { status: 'attached', source, decoder };
   } catch (err) {

--- a/tests/heavyLasStoreLifecycle.test.ts
+++ b/tests/heavyLasStoreLifecycle.test.ts
@@ -145,7 +145,7 @@ function makeEnv(range: RangeSource): { env: HeavyLasBridgeEnv; opfs: ReturnType
 }
 
 describe('heavy LAS out-of-core store lifecycle', () => {
-  it('removes the OPFS store directory when the streaming source closes', async () => {
+  it('retains the recorded OPFS store when the streaming source closes', async () => {
     const buffer = lasBytes(60_000);
     const file = spyFile('heavy.las', buffer.byteLength);
     const { deps, getAttached } = makeDeps();
@@ -155,17 +155,48 @@ describe('heavy LAS out-of-core store lifecycle', () => {
     expect(result.status).toBe('attached');
     if (result.status !== 'attached') throw new Error('unreachable');
 
-    // The finished store is present while the source is attached.
-    const storeName = opfs.topLevel().find((n) => n.startsWith('ooc-'));
+    // The finished store is present, and it has been recorded in the cache map.
+    const storeName = opfs.topLevel().find((n) => n.startsWith('ooc-') && n !== 'ooc-cache-map.json');
     expect(storeName).toBeDefined();
-    expect(opfs.topLevel()).toContain(storeName);
+    expect(opfs.topLevel()).toContain('ooc-cache-map.json');
 
-    // Closing the source releases handles AND removes the persistent store.
+    // Closing the source releases handles but RETAINS the recorded store — the
+    // persistent cache keeps a completed index for the next open.
     const source = getAttached() as OlvTileSource;
     await source.close();
 
-    expect(opfs.topLevel()).not.toContain(storeName);
-    expect(opfs.topLevel().some((n) => n.startsWith('ooc-'))).toBe(false);
+    expect(opfs.topLevel()).toContain(storeName);
+  });
+
+  it('a second open of the same file reuses the store without rebuilding', async () => {
+    const buffer = lasBytes(60_000);
+    const { env, opfs } = makeEnv(new ArrayBufferRangeSource(buffer));
+    let builds = 0;
+    const countingEnv = {
+      ...env,
+      async runIndex(req: Parameters<typeof env.runIndex>[0]) {
+        builds += 1;
+        return env.runIndex(req);
+      },
+    };
+
+    const openOnce = async () => {
+      const { deps } = makeDeps();
+      const result = await openLocalHeavyLas(
+        spyFile('same.las', buffer.byteLength),
+        new AbortController().signal,
+        deps,
+        countingEnv,
+      );
+      expect(result.status).toBe('attached');
+    };
+
+    await openOnce();
+    await openOnce();
+
+    // One index build, one store: the second open reopened the cached index.
+    expect(builds).toBe(1);
+    expect(opfs.topLevel().filter((n) => n.startsWith('ooc-') && n !== 'ooc-cache-map.json')).toHaveLength(1);
   });
 
   it('still releases the tile handles on close (does not regress spill.close)', async () => {

--- a/tests/heavyOocLeakFree.test.ts
+++ b/tests/heavyOocLeakFree.test.ts
@@ -2,18 +2,19 @@
  * heavyOocLeakFree.test.ts — the out-of-core store lifecycle is leak- and
  * collision-free.
  *
- * Every exit path of the heavy-LAS open must end in exactly one of two states:
- * a committed store owned by the live source, OR no store. Never a third,
- * ambiguous state — a promoted store nobody owns, or two opens fighting over
- * one directory. These cases pin that:
+ * Every exit path of the heavy-LAS open must end in a coherent state: a
+ * committed store recorded in the cache map and retained for reuse, or no store
+ * at all. Never a promoted store nobody owns. Since the persistent cache (Phase
+ * 4) these cases pin that:
  *
- *  - two opens of the SAME name and size get DISTINCT stores (no collision);
- *  - closing the old source after a second open keeps the NEW store (no
- *    cross-session delete by shared name);
- *  - an abort right AFTER promotion leaves NO store (the promoted directory is
- *    swept, not stranded);
+ *  - two opens of the SAME file REUSE one recorded store (the cache hit — a
+ *    rebuild is not repeated, and no second directory is created);
+ *  - closing a source of a recorded store RETAINS it, so the next open still
+ *    finds it (the cache survives a close);
+ *  - an abort right AFTER promotion leaves NO store — an uncommitted store is
+ *    never recorded, so it is deleted, not stranded;
  *  - an attach failure AFTER promotion leaves NO store (the source's own close
- *    frees it);
+ *    frees the uncommitted store);
  *  - a promotion-copy failure discards the partial (finding #2).
  *
  * The browser-only seams are the repo's usual fakes: OPFS is
@@ -166,18 +167,25 @@ function makeEnv(
   };
 }
 
+// The store directories only — NOT the `ooc-cache-map.json` record, which also
+// begins with `ooc-` but is the map, not a store.
 const oocDirs = (opfs: ReturnType<typeof fakeOpfs>): string[] =>
-  opfs.topLevel().filter((n) => n.startsWith('ooc-'));
+  opfs.topLevel().filter((n) => n.startsWith('ooc-') && n !== 'ooc-cache-map.json');
 
 describe('heavy OOC store lifecycle is leak- and collision-free', () => {
-  it('gives two opens of the same name and size DISTINCT stores', async () => {
+  it('reuses ONE recorded store for two opens of the same file (the cache hit)', async () => {
     const buffer = lasBytes(40_000);
     const opfs = fakeOpfs({ syncAccess: true, fileMove: true });
+    let builds = 0;
 
     const openOnce = async () => {
       const file = spyFile('same.las', buffer.byteLength);
       const { deps } = makeDeps();
-      const env = makeEnv(new ArrayBufferRangeSource(buffer), opfs);
+      const env = makeEnv(new ArrayBufferRangeSource(buffer), opfs, {
+        afterBuild: () => {
+          builds += 1;
+        },
+      });
       const result = await openLocalHeavyLas(file, new AbortController().signal, deps, env);
       expect(result.status).toBe('attached');
     };
@@ -185,12 +193,13 @@ describe('heavy OOC store lifecycle is leak- and collision-free', () => {
     await openOnce();
     await openOnce();
 
-    const dirs = oocDirs(opfs);
-    expect(dirs).toHaveLength(2);
-    expect(new Set(dirs).size).toBe(2);
+    // The second open matched the fingerprint and reopened the stored index, so
+    // there is exactly one store and the index was built only once.
+    expect(oocDirs(opfs)).toHaveLength(1);
+    expect(builds).toBe(1);
   });
 
-  it('closing the old source after a second open keeps the NEW store', async () => {
+  it('retains the recorded store when a source closes, so a later open still finds it', async () => {
     const buffer = lasBytes(40_000);
     const opfs = fakeOpfs({ syncAccess: true, fileMove: true });
 
@@ -204,20 +213,18 @@ describe('heavy OOC store lifecycle is leak- and collision-free', () => {
     };
 
     const first = await open();
-    const second = await open();
-    const secondDir = oocDirs(opfs).find((n) => n !== null);
-    expect(oocDirs(opfs)).toHaveLength(2);
+    expect(oocDirs(opfs)).toHaveLength(1);
 
-    // Close the OLD source. With a shared name this would delete the new store;
-    // with per-open names it removes only its own.
+    // Closing the source of a RECORDED store retains it — a recorded index is
+    // kept for reuse, not deleted (the pre-cache behaviour).
     await first.close();
+    expect(oocDirs(opfs)).toHaveLength(1);
 
-    const remaining = oocDirs(opfs);
-    expect(remaining).toHaveLength(1);
-    // The survivor is the store the second (still-live) source owns.
+    // A later open of the same file reopens that retained store: still one store,
+    // and the second source is live over it.
+    const second = await open();
+    expect(oocDirs(opfs)).toHaveLength(1);
     expect(second).toBeDefined();
-    expect(remaining[0]).toBeDefined();
-    void secondDir;
   });
 
   it('leaves NO store when the open is aborted right after promotion', async () => {


### PR DESCRIPTION
The behaviour-changing step that makes the persistent out-of-core cache real: wire it into the live heavy-LAS open path.

Before any decode the file is fingerprinted (Phase 1, #737). On a hit in the persisted map (Phase 2, #738) the stored index is reopened straight from OPFS instead of rebuilt — the payoff the Phase-0 gate measured at 20–40× — held under a shared residency lock (Phase 3, #739) so an eviction elsewhere can't delete it while it is open. On a miss the build runs exactly as before, then records its store and retains it on close; a fresh build evicts least-recently-used stores past an 8 GiB budget, never a live one.

Safety: a store is retained only once it is recorded, so an aborted or attach-failed build is still deleted — nothing leaks (the leak-free tests still hold). A null fingerprint (no header bounds, or a read fault) skips reuse and recording, so the open degrades to exactly the pre-cache behaviour. The random per-open store name is unchanged — the map's indirection gives reuse without a shared name, so no two builds contend for one directory.

Graduates the three cache modules from the staged register (now reachable). Verified: 32 Node executor tests via the fake-OPFS harness (one build for two opens of the same file; retain-on-close; abort/attach-fail still delete); the real-OPFS cache-map round-trip and real Web Locks residency checked in a browser. Stacked on #741 (eviction selector + bounds).

Note: cache reuse only speeds files large enough to route out-of-core; small files are unaffected.