### PR TITLE
feat(heavy): janitor sweep of orphaned promoted OOC stores (Phase 6)

### DIFF
--- a/src/app/heavyLasExecutor.ts
+++ b/src/app/heavyLasExecutor.ts
@@ -62,7 +62,7 @@ import type { StreamingSource } from '../render/streaming/StreamingSource';
 import { LocalOocIndexerClient } from '../io/heavy/worker/localOocIndexerWorkerClient';
 import type { LocalOocPhase } from '../io/heavy/localOocBuild';
 import { readLazChunkTable } from '../io/heavy/lazChunkTable';
-import { sweepAbandonedOocStores } from '../io/heavy/opfsStoreJanitor';
+import { sweepAbandonedOocStores, sweepPromotedOrphans } from '../io/heavy/opfsStoreJanitor';
 import { LocalFileRangeSource } from '../io/range/LocalFileRangeSource';
 import type { RangeSource } from '../io/range/RangeSource';
 import { LoadError } from '../io/loadErrors';
@@ -379,6 +379,16 @@ export async function executeHeavyLasBuild(
   if (!janitorSwept) {
     janitorSwept = true;
     void sweepAbandonedOocStores(root, { ownedNames: new Set([storeName]) }).catch(() => {});
+    // Also reclaim promoted stores the cache no longer references and no live tab
+    // holds (Phase 6). Skipped entirely when liveness is unavailable — without a
+    // live-set an in-use store cannot be told from an orphan, so nothing is swept.
+    void (async () => {
+      const live = await liveStoreNames(resolveLockManager());
+      if (!live) return;
+      const map = await readCacheMap(root);
+      const referenced = new Set(map.entries.map((e) => e.storeName));
+      await sweepPromotedOrphans(root, { referenced, live, debug: deps.debug });
+    })().catch(() => {});
   }
 
   // The disk guard. Sized from the declared point count and the record schema,

--- a/src/io/heavy/opfsStoreJanitor.ts
+++ b/src/io/heavy/opfsStoreJanitor.ts
@@ -30,12 +30,14 @@
  * that stopped mid-flight: nothing promotes it, no reader opens it, and it only
  * costs disk, so reclaiming it is safe.
  *
- * FUTURE WORK. Sweeping promoted stores safely needs a real cross-tab liveness
- * mechanism — a BroadcastChannel lease refresh, or Web Locks plus a lease
- * heartbeat — so a store still owned by any live tab can be told from one no tab
- * holds. Until that exists, abandoned promoted stores are reclaimed only when a
- * later build of the same source replaces them, or when the user clears site
- * data.
+ * PROMOTED STORES ARE NOW SWEPT SEPARATELY. That liveness mechanism exists (Web
+ * Locks residency, `oocStoreLiveness.ts`), so {@link sweepPromotedOrphans}
+ * reclaims a promoted store when it is neither referenced by the persistent
+ * cache map nor held open by any live tab — and only when its lease is old, so a
+ * store another tab just promoted but has not yet recorded is left alone. The
+ * conservative `.partial`-only sweep below is unchanged; the two run side by
+ * side. When liveness is unavailable the promoted sweep does not run at all, so
+ * an in-use store is never mistaken for an orphan.
  *
  * It runs against the structural {@link OpfsDirHandle}, so it is unit-tested in
  * Node against `tests/support/fakeOpfs.ts` exactly like the spill store.
@@ -47,6 +49,7 @@ import {
   readOpfsText,
   type OpfsDirHandle,
 } from './opfsSpillStore';
+import { CACHE_MAP_FILE } from './oocCacheMap';
 
 /** The prefix every out-of-core temp store name carries. */
 export const OOC_STORE_PREFIX = 'ooc-';
@@ -151,6 +154,81 @@ export async function sweepAbandonedOocStores(
       removed.push(name);
     } catch (err) {
       if (options.debug) console.warn('[ooc-janitor] could not remove stale store', name, err);
+    }
+  }
+  return removed;
+}
+
+/**
+ * Whether a top-level name is a PROMOTED final store: an `ooc-…` directory that
+ * is not a build partial and not the cache-map record. These are the finished
+ * indices the persistent cache keeps.
+ */
+function isPromotedStore(name: string): boolean {
+  return (
+    name.startsWith(OOC_STORE_PREFIX) && !name.endsWith(PARTIAL_SUFFIX) && name !== CACHE_MAP_FILE
+  );
+}
+
+/**
+ * The promoted stores that are orphans: neither referenced by the cache map nor
+ * held open by any live tab. A referenced store is the cache and is kept; a live
+ * store is in use and must never be deleted from under the tab that holds it.
+ */
+export function selectOrphanPromoted(
+  names: readonly string[],
+  referenced: ReadonlySet<string>,
+  live: ReadonlySet<string>,
+): string[] {
+  return names.filter(
+    (name) => isPromotedStore(name) && !referenced.has(name) && !live.has(name),
+  );
+}
+
+export interface PromotedSweepOptions {
+  /** Store names the cache map points at — the cache; never swept. */
+  readonly referenced: ReadonlySet<string>;
+  /** Store names a live tab holds open (from Web Locks); never swept. */
+  readonly live: ReadonlySet<string>;
+  readonly now?: number;
+  readonly staleMs?: number;
+  readonly debug?: boolean;
+}
+
+/**
+ * Sweep promoted `ooc-…` stores that no longer belong to anything: not in the
+ * cache map, not held by a live tab, and — the race guard — with a lease older
+ * than the stale threshold, so a store another tab just promoted but has not yet
+ * recorded or locked is left alone. This is the sweep the header once listed as
+ * future work; it is safe now that the map names the cache and Web Locks name
+ * the live stores. The caller supplies both sets and must NOT call this when
+ * liveness is unavailable, or an in-use store could read as an orphan.
+ */
+export async function sweepPromotedOrphans(
+  root: OpfsDirHandle,
+  options: PromotedSweepOptions,
+): Promise<string[]> {
+  const now = options.now ?? Date.now();
+  const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
+  const names: string[] = [];
+  for await (const name of root.keys()) names.push(name);
+
+  const removed: string[] = [];
+  for (const name of selectOrphanPromoted(names, options.referenced, options.live)) {
+    let dir: OpfsDirHandle;
+    try {
+      dir = await root.getDirectoryHandle(name);
+    } catch {
+      continue;
+    }
+    const createdAt = await readStoreLease(dir);
+    if (createdAt === null) continue; // Unknown age — keep.
+    if (now - createdAt < staleMs) continue; // Fresh — a just-promoted store; keep.
+    try {
+      await removeOpfsStore(root, name);
+      removed.push(name);
+    } catch (err) {
+      if (options.debug) console.warn('[ooc-janitor] could not remove orphan store', name, err);
     }
   }
   return removed;

--- a/tests/opfsStoreJanitor.test.ts
+++ b/tests/opfsStoreJanitor.test.ts
@@ -20,6 +20,8 @@ import {
 } from '../src/io/heavy/opfsSpillStore';
 import {
   sweepAbandonedOocStores,
+  sweepPromotedOrphans,
+  selectOrphanPromoted,
   DEFAULT_STALE_MS,
 } from '../src/io/heavy/opfsStoreJanitor';
 
@@ -83,5 +85,50 @@ describe('OOC startup janitor', () => {
     const removed = await sweepAbandonedOocStores(opfs.root, { now: NOW });
     expect(removed).toEqual([]);
     expect(opfs.topLevel()).toHaveLength(2);
+  });
+});
+
+describe('selectOrphanPromoted', () => {
+  const names = [
+    'ooc-a-100-x',            // promoted, orphan
+    'ooc-b-100-y',            // promoted, referenced
+    'ooc-c-100-z',            // promoted, live
+    'ooc-d-100-w.partial',    // a build partial — not promoted
+    'ooc-cache-map.json',     // the map record — not a store
+  ];
+  const referenced = new Set(['ooc-b-100-y']);
+  const live = new Set(['ooc-c-100-z']);
+
+  it('picks only promoted stores that are neither referenced nor live', () => {
+    expect(selectOrphanPromoted(names, referenced, live)).toEqual(['ooc-a-100-x']);
+  });
+
+  it('never selects a partial or the cache-map file', () => {
+    const got = selectOrphanPromoted(names, new Set(), new Set());
+    expect(got).not.toContain('ooc-d-100-w.partial');
+    expect(got).not.toContain('ooc-cache-map.json');
+  });
+});
+
+describe('sweepPromotedOrphans', () => {
+  it('removes a stale orphan, but keeps referenced, live, fresh, and unknown-age promoted stores', async () => {
+    const opfs = fakeOpfs();
+    await makeStore(opfs.root, 'ooc-orphan-100-a', NOW - DEFAULT_STALE_MS - 60_000); // stale orphan → sweep
+    await makeStore(opfs.root, 'ooc-referenced-100-b', NOW - DEFAULT_STALE_MS - 60_000); // in map → keep
+    await makeStore(opfs.root, 'ooc-live-100-c', NOW - DEFAULT_STALE_MS - 60_000); // held by a tab → keep
+    await makeStore(opfs.root, 'ooc-fresh-100-d', NOW - 60_000); // just promoted → keep (race guard)
+    await makeStore(opfs.root, 'ooc-nolease-100-e', null); // unknown age → keep
+
+    const removed = await sweepPromotedOrphans(opfs.root, {
+      referenced: new Set(['ooc-referenced-100-b']),
+      live: new Set(['ooc-live-100-c']),
+      now: NOW,
+    });
+
+    expect(removed).toEqual(['ooc-orphan-100-a']);
+    expect(opfs.topLevel()).not.toContain('ooc-orphan-100-a');
+    for (const kept of ['ooc-referenced-100-b', 'ooc-live-100-c', 'ooc-fresh-100-d', 'ooc-nolease-100-e']) {
+      expect(opfs.topLevel()).toContain(kept);
+    }
   });
 });


### PR DESCRIPTION
The last piece of the persistent out-of-core cache: reclaim promoted `ooc-…` stores that no longer belong to anything. This is the sweep the janitor header long listed as FUTURE WORK — safe now that the cache map (#738) names the cache and Web Locks (#739) name the live stores.

sweepPromotedOrphans removes a promoted store only when it is (a) not referenced by the cache map, (b) not held open by any live tab, AND (c) its lease is older than the stale threshold — the race guard, so a store another tab just promoted but has not yet recorded or locked is left alone. It is wired into the first-heavy-open janitor pass and skipped entirely when liveness is unavailable: without a live-set an in-use store cannot be told from an orphan, so nothing is swept.

The conservative `.partial`-only sweep is unchanged; the two run side by side. Per-build eviction (#741) still enforces the byte budget; this reclaims leaks from crashes and failed records that the map never knew about. Pure selector TDD-tested; the sweep tested against the fake-OPFS harness (stale orphan removed; referenced, live, fresh, and unknown-age stores kept). Stacked on #742.