### PR TITLE
fix: close two audit-truth gaps (deps doc drift, oracle substring match)

### DIFF
--- a/docs/project/DEPENDENCIES.md
+++ b/docs/project/DEPENDENCIES.md
@@ -13,7 +13,7 @@ Since v0.6.0 the three bundled font packages moved from 5.2.8 to 5.3.0. No
 package was added or removed, and no other bundled package changed.
 
 The development toolchain moved after that baseline was taken: TypeScript to
-7.0.2, Vite to 8.1.5, and Playwright to 1.62.0. All three are development-only
+7.0.2, Vite to 8.2.1, and Playwright to 1.62.1. All three are development-only
 and none reaches the deployed app, so the runtime dependency set above is
 unaffected.
 
@@ -39,10 +39,10 @@ These ship in the deploy archive.
 | @fontsource-variable/inter | ^5.3.0 | 5.3.0 | OFL-1.1 |
 | @fontsource/jetbrains-mono | ^5.3.0 | 5.3.0 | OFL-1.1 |
 | @fontsource/manrope | ^5.3.0 | 5.3.0 | OFL-1.1 |
-| @loaders.gl/core | ^4.4.2 | 4.4.4 | MIT |
+| @loaders.gl/core | ^4.4.4 | 4.4.4 | MIT |
 | @loaders.gl/gltf | ^4.4.2 | 4.4.3 | MIT |
 | @loaders.gl/obj | ^4.4.2 | 4.4.3 | MIT |
-| @loaders.gl/ply | ^4.4.2 | 4.4.4 | MIT |
+| @loaders.gl/ply | ^4.4.4 | 4.4.4 | MIT |
 | laz-perf | ^0.0.7 | 0.0.7 | Apache-2.0 |
 | pdf-lib | ^1.17.1 | 1.17.1 | MIT |
 | proj4 | ^2.21.0 | 2.21.0 | MIT |
@@ -54,15 +54,16 @@ Build, test, docs, and mutation tooling. None reaches the deployed app.
 
 | Package | Declared range | Resolved | License |
 |---|---|---|---|
-| @playwright/test | ^1.60.0 | 1.62.1 | Apache-2.0 |
+| @loaders.gl/las | ^4.4.4 | 4.4.4 | MIT |
+| @playwright/test | ^1.62.1 | 1.62.1 | Apache-2.0 |
 | @stryker-mutator/core | ^9.6.1 | 9.6.1 | Apache-2.0 |
 | @stryker-mutator/vitest-runner | ^9.6.1 | 9.6.1 | Apache-2.0 |
 | @types/proj4 | ^2.19.0 | 2.19.0 | MIT |
 | @types/three | ^0.184.1 | 0.184.1 | MIT |
 | @vitest/coverage-v8 | ^4.1.10 | 4.1.10 | MIT |
-| rollup-plugin-visualizer | ^7.0.1 | 7.1.1 | MIT |
+| rollup-plugin-visualizer | ^7.1.1 | 7.1.1 | MIT |
 | typescript | ~7.0.2 | 7.0.2 | Apache-2.0 |
-| vite | ^8.1.5 | 8.2.1 | MIT |
+| vite | ^8.2.1 | 8.2.1 | MIT |
 | vite-plugin-javascript-obfuscator | ^3.1.0 | 3.1.0 | MIT |
 | vitepress | 1.6.4 | 1.6.4 | MIT |
 | vitest | ^4.1.7 | 4.1.10 | MIT |
@@ -114,7 +115,7 @@ through `overrides` rather than waiting on the packages that depend on them:
 | brace-expansion | 1.1.15 | 1.1.16 | CVE-2026-13149, exponential-time expansion |
 
 The `vite` override is scoped to `vitepress` alone. The application builds on
-Vite 8.1.5 and is not affected by it. `npm run docs:build` passes on the
+Vite 8.2.1 and is not affected by it. `npm run docs:build` passes on the
 overridden tree.
 
 ## Stubbed to prune
@@ -141,9 +142,9 @@ against, so they wait for a dedicated update:
 VitePress itself stays at 1.6.4, which is the latest stable release; 2.0.0 has
 only alpha builds.
 
-The TypeScript 7 / Vite 8.1.5 toolchain bump is no longer deferred. Dependabot
-#40 landed as a dedicated toolchain update: TypeScript 7.0.2, Vite 8.1.5, and
-Playwright 1.62.0, with no application source change. It was taken on its own
+The TypeScript 7 / Vite 8.2.1 toolchain bump is no longer deferred. Dependabot
+#40 landed as a dedicated toolchain update: TypeScript 7.0.2, Vite 8.2.1, and
+Playwright 1.62.1, with no application source change. It was taken on its own
 rather than alongside the migrations above so the build and test contract could
 be re-validated against one variable.
 

--- a/scripts/verify-oracle-versions.mjs
+++ b/scripts/verify-oracle-versions.mjs
@@ -72,7 +72,8 @@ const rel = (abs) => relative(ROOT, abs).split('\\').join('/');
  * `GDAL 3.13.1 "Iowa City", released 2026/06/01` to a sentence naming two tools.
  *
  * `names` is matched against a study's `reference.tool` field, case-insensitively
- * and as a substring, so "GDAL/OGR SpatiaLite and R" resolves to both GDAL and R.
+ * and as a WHOLE WORD, so "GDAL/OGR SpatiaLite and R" resolves to both GDAL and
+ * R, while "GeographicLib" is NOT mistaken for GDAL by the `ogr` inside it.
  */
 const ORACLES = [
   {
@@ -112,11 +113,21 @@ function bareVersion(text) {
   return /(\d+\.\d+\.\d+)/.exec(text)?.[1] ?? null;
 }
 
+/**
+ * Whether a name matches a tool field. A string name matches as a WHOLE WORD,
+ * not a bare substring: `ogr` matches "GDAL/OGR" (the slash is a boundary) but
+ * NOT "GeographicLib", where the letters `ogr` sit mid-word. Substring matching
+ * misread "GeographicLib" as GDAL and then attributed the PROJ version beside it
+ * to GDAL — the false positive this word-boundary form removes. A RegExp name is
+ * used as given (the `R` language token already relies on this).
+ */
+function nameMatches(name, tool) {
+  return name instanceof RegExp ? name.test(tool) : new RegExp(`\\b${name}\\b`, 'i').test(tool);
+}
+
 /** Which oracles a record's tool field names. */
-function oraclesFor(tool) {
-  return ORACLES.filter((o) =>
-    o.names.some((n) => (n instanceof RegExp ? n.test(tool) : tool.toLowerCase().includes(n))),
-  );
+export function oraclesFor(tool) {
+  return ORACLES.filter((o) => o.names.some((n) => nameMatches(n, tool)));
 }
 
 /** Every *.json under a directory tree, skipping the frozen snapshot. */

--- a/tests/dependenciesDocSync.test.ts
+++ b/tests/dependenciesDocSync.test.ts
@@ -16,19 +16,28 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const read = (p: string): string => readFileSync(resolve(ROOT, p), 'utf8');
 
 const doc = read('docs/project/DEPENDENCIES.md');
-const pkg = JSON.parse(read('package.json')) as { version: string };
+const pkg = JSON.parse(read('package.json')) as {
+  version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
 const lock = JSON.parse(read('package-lock.json')) as {
   packages: Record<string, { version?: string }>;
 };
 
+/** Every direct dependency package.json declares, name → declared range. */
+const directDeps: Record<string, string> = { ...pkg.dependencies, ...pkg.devDependencies };
+
 /** Every `| name | range | resolved | ... |` row whose name is a real package. */
-function docRows(): Array<{ name: string; resolved: string }> {
-  const rows: Array<{ name: string; resolved: string }> = [];
+function docRows(): Array<{ name: string; range: string; resolved: string }> {
+  const rows: Array<{ name: string; range: string; resolved: string }> = [];
   for (const line of doc.split('\n')) {
-    const m = line.match(/^\|\s*(@?[\w./-]+)\s*\|\s*(?:[\^~][\d.]+|[\d.]+)\s*\|\s*([\d.]+)\s*\|/);
+    const m = line.match(/^\|\s*(@?[\w./-]+)\s*\|\s*([~^]?[\d.]+)\s*\|\s*([\d.]+)\s*\|/);
     if (!m) continue;
     const name = m[1].trim();
-    if (lock.packages[`node_modules/${name}`]) rows.push({ name, resolved: m[2].trim() });
+    if (lock.packages[`node_modules/${name}`]) {
+      rows.push({ name, range: m[2].trim(), resolved: m[3].trim() });
+    }
   }
   return rows;
 }
@@ -43,6 +52,23 @@ describe('DEPENDENCIES.md stays in sync with its sources', () => {
       .map(({ name, resolved }) => ({ name, resolved, lock: lock.packages[`node_modules/${name}`].version }))
       .filter((r) => r.resolved !== r.lock);
     expect(drift).toEqual([]);
+  });
+
+  it('every restated declared range matches the range package.json declares', () => {
+    // The resolved column tracked the lockfile, but the declared-range column was
+    // never checked against package.json, so a stale range (e.g. ^4.4.2 when the
+    // manifest says ^4.4.4) passed silently. This binds that column too.
+    const drift = docRows()
+      .filter((r) => r.name in directDeps)
+      .map((r) => ({ name: r.name, doc: r.range, pkg: directDeps[r.name] }))
+      .filter((r) => r.doc !== r.pkg);
+    expect(drift).toEqual([]);
+  });
+
+  it('has a row for every direct dependency package.json declares', () => {
+    const documented = new Set(docRows().map((r) => r.name));
+    const missing = Object.keys(directDeps).filter((name) => !documented.has(name));
+    expect(missing).toEqual([]);
   });
 
   it('the release line names the current package version', () => {

--- a/tests/verifyOracleMatch.test.ts
+++ b/tests/verifyOracleMatch.test.ts
@@ -1,0 +1,33 @@
+/**
+ * verifyOracleMatch.test.ts — the oracle name matcher, with the negative control
+ * that its own bug taught us to write.
+ *
+ * `verify-oracle-versions.mjs` maps a study's free-text `reference.tool` field to
+ * the oracle tools it names. It once matched by bare substring, so "GeographicLib"
+ * — which contains the letters `ogr` — was read as GDAL, and the PROJ version
+ * beside it was reported as a phantom GDAL release. These pin the whole-word
+ * matcher: real tool tokens match, the letters buried in another word do not.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs script, no type declarations
+import { oraclesFor } from '../scripts/verify-oracle-versions.mjs';
+
+const ids = (tool: string): string[] => oraclesFor(tool).map((o: { id: string }) => o.id);
+
+describe('oraclesFor — whole-word tool matching', () => {
+  it('matches real tool tokens, including inside a slash-joined name', () => {
+    expect(ids('GDAL 3.13.1')).toEqual(['GDAL']);
+    expect(ids('GDAL/OGR SpatiaLite and R')).toEqual(expect.arrayContaining(['GDAL', 'R']));
+    expect(ids('PDAL 2.10.2')).toEqual(['PDAL']);
+  });
+
+  it('does NOT mistake GeographicLib for GDAL via the "ogr" buried in it', () => {
+    // The exact false positive: a PROJ/GeographicLib study must not resolve to GDAL.
+    expect(ids('PROJ and GeographicLib')).not.toContain('GDAL');
+    expect(ids('PROJ and GeographicLib')).toEqual([]);
+  });
+
+  it('does not match a tool named nowhere in the field', () => {
+    expect(ids('CloudCompare 2.13.2')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes two findings from the audit review, each with the guard that lets it recur caught by a test.

**#1 — DEPENDENCIES.md drift.** Five declared ranges lagged package.json (@loaders.gl/core, @loaders.gl/ply, @playwright/test, rollup-plugin-visualizer, vite), the prose named old Vite/Playwright versions, and @loaders.gl/las had no row at all — all invisible because dependenciesDocSync only compared the *resolved* column to the lockfile. The doc is corrected, and the test now also (a) checks each declared-range column against package.json and (b) requires a row for every direct dependency. Both new checks were confirmed red against the stale doc before the fix.

**#3 — oracle verifier substring false positive.** verify-oracle-versions matched tool names by bare `.includes()`, so 'GeographicLib' (containing 'ogr') resolved to GDAL and the PROJ version beside it was reported as a phantom GDAL 9.8.1. Matching is now whole-word; `oraclesFor` is exported and covered by a negative-control test (a PROJ/GeographicLib field must not resolve to GDAL). Verified the phantom 9.8.1 is gone from the script's GDAL output. (The remaining GDAL 3.13.1-vs-3.13.3 report is genuine study/environment drift, not this bug.)

TSC clean; lint:release-truth, lint:doc-links, and the two guard tests pass.