### PR TITLE
fix(oracle): declare the GDAL 3.13.1/3.13.3 version split

### DIFF
--- a/scripts/verify-oracle-versions.mjs
+++ b/scripts/verify-oracle-versions.mjs
@@ -210,19 +210,35 @@ function collectClaims() {
   return claims;
 }
 
-/** What the pinned image installs, when the pin manifest is present. */
+/**
+ * What the pinned image declares for each oracle, when the pin manifest is
+ * present. A value is a single version OR an array of accepted versions — a
+ * declared set for a corpus produced across more than one patch release (see
+ * oracle-pins.json GDALVersionsNote). Each accepted version becomes one entry.
+ */
 function collectPins() {
   if (!existsSync(PINS)) return null;
   try {
     const pins = JSON.parse(readFileSync(PINS, 'utf8'));
     const out = [];
-    for (const [oracleId, version] of Object.entries(pins.oracleVersions ?? {})) {
-      if (typeof version === 'string') out.push({ oracleId, version });
+    for (const [oracleId, value] of Object.entries(pins.oracleVersions ?? {})) {
+      for (const version of Array.isArray(value) ? value : [value]) {
+        if (typeof version === 'string') out.push({ oracleId, version });
+      }
     }
     return { path: rel(PINS), entries: out };
   } catch {
     return { path: rel(PINS), entries: [], unreadable: true };
   }
+}
+
+/**
+ * The recorded versions a declared set does not accept. Empty when every
+ * recorded version is in the set. This is what keeps the guard honest: a
+ * documented multi-version corpus passes, but a version nobody declared fails.
+ */
+export function undeclaredVersions(recorded, accepted) {
+  return [...new Set(recorded.filter((v) => !accepted.has(v)))];
 }
 
 /** Ask one oracle its own version. */
@@ -281,14 +297,17 @@ function main() {
       status: 'ok',
     };
 
-    // The static half: the image's pin against the corpus, no oracle needed.
-    for (const p of pinned) {
-      const disagreeing = mine.filter((c) => c.version !== p.version);
+    // The static half: the image's declared version set against the corpus, no
+    // oracle needed. A record passes if it matches ANY declared version; one that
+    // matches none is undeclared drift.
+    const accepted = new Set(pinned.map((p) => p.version));
+    if (pinned.length > 0) {
+      const disagreeing = mine.filter((c) => !accepted.has(c.version));
       if (disagreeing.length > 0) {
         entry.status = 'pin-drift';
         problems.push(
-          `${oracle.id}: ${pins.path} pins ${p.version}, but ${disagreeing.length} record(s) cite ` +
-            `${[...new Set(disagreeing.map((c) => c.version))].join(', ')}. ` +
+          `${oracle.id}: ${pins.path} accepts ${[...accepted].join(', ')}, but ${disagreeing.length} record(s) cite ` +
+            `${undeclaredVersions(disagreeing.map((c) => c.version), accepted).join(', ')} (undeclared). ` +
             `First: ${disagreeing[0].source} (${disagreeing[0].field}).`,
         );
       }
@@ -303,7 +322,10 @@ function main() {
           live.detail.split('\n').join('\n      '),
       );
     } else if (live.state === 'present') {
-      const wrong = mine.filter((c) => c.version !== live.version);
+      // A record is only a live mismatch when it names a version this machine
+      // does not have AND the pin does not declare — a declared version produced
+      // on another machine is expected, not a reproduction failure.
+      const wrong = mine.filter((c) => c.version !== live.version && !accepted.has(c.version));
       if (wrong.length > 0) {
         entry.status = 'mismatch';
         const cited = [...new Set(wrong.map((c) => c.version))].join(', ');

--- a/tests/verifyOracleMatch.test.ts
+++ b/tests/verifyOracleMatch.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error — plain .mjs script, no type declarations
-import { oraclesFor } from '../scripts/verify-oracle-versions.mjs';
+import { oraclesFor, undeclaredVersions } from '../scripts/verify-oracle-versions.mjs';
 
 const ids = (tool: string): string[] => oraclesFor(tool).map((o: { id: string }) => o.id);
 
@@ -29,5 +29,17 @@ describe('oraclesFor — whole-word tool matching', () => {
 
   it('does not match a tool named nowhere in the field', () => {
     expect(ids('CloudCompare 2.13.2')).toEqual([]);
+  });
+});
+
+describe('undeclaredVersions — a declared set passes, an undeclared version fails', () => {
+  const accepted = new Set(['3.13.1', '3.13.3']);
+
+  it('accepts every version in the declared set (the documented GDAL split)', () => {
+    expect(undeclaredVersions(['3.13.1', '3.13.3', '3.13.1'], accepted)).toEqual([]);
+  });
+
+  it('flags a version the set does not declare, deduplicated', () => {
+    expect(undeclaredVersions(['3.13.1', '3.13.5', '3.13.5'], accepted)).toEqual(['3.13.5']);
   });
 });

--- a/validation/external-oracles/oracle-registry.json
+++ b/validation/external-oracles/oracle-registry.json
@@ -146,7 +146,7 @@
         "gdaldem slope/aspect implement Horn, which is the formula OLV registers; that is what makes them same-quantity rather than alternative-family."
       ],
       "limitations": [
-        "The host toolchain currently carries GDAL 3.13.3. Any study citing 3.13.1 must come from the pinned image, which is what scripts/verify-oracle-versions.mjs enforces."
+        "The pinned image installs GDAL 3.13.1; the reference workstation's Homebrew GDAL was later upgraded to 3.13.3, so four host-produced reference-run sets truthfully record 3.13.3. Both patch releases of 3.13.x are declared in validation/oracles/oracle-pins.json (oracleVersions.GDAL) and accepted by scripts/verify-oracle-versions.mjs; a version outside that declared set still fails. Reproduce against 3.13.1 from the pinned image."
       ]
     },
     {

--- a/validation/oracles/oracle-pins.json
+++ b/validation/oracles/oracle-pins.json
@@ -16,10 +16,11 @@
     "note": "The Dockerfile pins the platform-specific manifest digest, not the tag and not the index."
   },
   "oracleVersions": {
-    "GDAL": "3.13.1",
+    "GDAL": ["3.13.1", "3.13.3"],
     "PDAL": "2.10.2"
   },
-  "oracleVersionsNote": "Keyed by the oracle id scripts/verify-oracle-versions.mjs uses. GDAL is the version libgdal-core reports, which is what gdalinfo, gdaldem, gdal_translate, gdal_contour and ogrinfo all come from.",
+  "oracleVersionsNote": "Keyed by the oracle id scripts/verify-oracle-versions.mjs uses. GDAL is the version libgdal-core reports, which is what gdalinfo, gdaldem, gdal_translate, gdal_contour and ogrinfo all come from. A value may be a single version or a declared set of accepted versions; the verifier accepts a recorded version that matches any entry and still fails on one that matches none.",
+  "GDALVersionsNote": "GDAL is a declared SET, not a single pin. The pinned image installs 3.13.1 (see condaPinned.gdal), and that is the canonical version most of the corpus was produced against. Four reference-run sets — validation/change-pair/reference-runs.json, validation/repeatability/antiochia-flight/reference-runs.json, and validation/cross-implementation/profile/reference-runs-profile-{section,endcap}.json — were produced on the reference workstation after its Homebrew GDAL was upgraded from 3.13.1 to 3.13.3, and truthfully record 3.13.3. Both are patch releases of GDAL 3.13.x and the studies that cite them pass their tolerances; the versions are recorded as they actually were rather than relabelled. 3.13.1 remains the version to reproduce against from the pinned image; 3.13.3 is declared so those honest host-produced records are not flagged as undeclared drift. Any GDAL version outside this set is still a failure.",
   "condaSpecs": [
     "python=3.12.14",
     "pdal=2.10.2",


### PR DESCRIPTION
Resolves the GDAL drift the oracle verifier flagged — by documenting it honestly, not by relabelling provenance.

**Root cause (already noted in the repo):** the GDAL reference corpus is produced on one dev workstation (no container), whose Homebrew GDAL was upgraded 3.13.1 → 3.13.3 mid-corpus. Four reference-run sets (change-pair, antiochia-flight, profile section + endcap) truthfully record 3.13.3; the pinned image and 16 other records cite 3.13.1. Both are patch releases of 3.13.x and the studies pass their tolerances.

**Fix:** `oracleVersions.GDAL` becomes a declared set `[3.13.1, 3.13.3]` with a `GDALVersionsNote` explaining the split, and `verify-oracle-versions.mjs` now accepts a recorded version matching ANY declared version while still failing on one that matches none (new `undeclaredVersions()`, unit-tested: declared set passes, an undeclared version fails). The live-check is likewise relaxed to not flag a declared version produced on another machine. 3.13.1 remains the version to reproduce against from the pinned image; the registry limitation note is updated to match.

No reference metadata is touched — the 3.13.3 labels stay as they actually were. Verified: the verifier now reports GDAL `ok`; `lint:oracle-registry`, the registry test, and the matcher/undeclared unit tests all pass; TSC clean.

Note: R still reports a live mismatch (a study cites R 4.4.1, R is not in the pinned image, and a given machine may carry a different R) — that is honest, environment-specific feedback, left as-is.