### PR TITLE
fix(validation): reconcile defect composition against its own-version changelog entry

### DIFF
--- a/scripts/validation-snapshot-lib.mjs
+++ b/scripts/validation-snapshot-lib.mjs
@@ -283,6 +283,26 @@ export function newestChangelogEntry(text) {
 }
 
 /**
+ * The changelog section for a SPECIFIC version, as `{ version, date, body }`, or
+ * null. The defect audit is a frozen event: `defect-registry.json` carries a
+ * `registryVersion`, and the prose describing its composition lives in that
+ * version's changelog entry — not the newest one. Reading the composition from
+ * the entry that states it, rather than from whatever entry is newest, is what
+ * keeps the reconcile honest once the changelog advances past the audit.
+ */
+export function changelogEntryForVersion(text, version) {
+  const re = new RegExp(
+    `^##\\s*\\[${version.replace(/\./g, '\\.')}\\]\\s*-\\s*(\\d{4}-\\d{2}-\\d{2})`,
+    'm',
+  );
+  const m = text.match(re);
+  if (!m) return null;
+  const rest = text.slice(m.index + m[0].length);
+  const next = rest.search(/^##\s*\[/m);
+  return { version, date: m[1], body: next < 0 ? rest : rest.slice(0, next) };
+}
+
+/**
  * The defect composition the changelog entry states in prose.
  *
  * The snapshot derives its own composition from the records and then compares
@@ -590,11 +610,14 @@ export function deriveSnapshot({ read, has, digest, listed, storedPathOf }) {
   const registryText = read('validation/defects/defect-registry.json');
   const registry = registryText == null ? null : JSON.parse(registryText);
   const changelog = read('CHANGELOG.md');
-  const entry = changelog == null ? null : newestChangelogEntry(changelog);
 
   let defects = { source: 'validation/defects/defect-registry.json', status: 'not-executed' };
   if (registry != null) {
     const derived = derivedComposition(registry);
+    // The composition prose lives in the changelog entry for the registry's own
+    // version (the frozen audit), not whatever entry is newest.
+    const entry =
+      changelog == null ? null : changelogEntryForVersion(changelog, registry.registryVersion);
     const declared = entry == null ? null : declaredComposition(entry.body);
     const checks = Object.keys(derived).map((k) => ({
       figure: k,

--- a/scripts/validation-snapshot-lib.mjs
+++ b/scripts/validation-snapshot-lib.mjs
@@ -292,7 +292,7 @@ export function newestChangelogEntry(text) {
  */
 export function changelogEntryForVersion(text, version) {
   const re = new RegExp(
-    `^##\\s*\\[${version.replace(/\./g, '\\.')}\\]\\s*-\\s*(\\d{4}-\\d{2}-\\d{2})`,
+    `^##\\s*\\[${escapeRegExp(version)}\\]\\s*-\\s*(\\d{4}-\\d{2}-\\d{2})`,
     'm',
   );
   const m = text.match(re);

--- a/scripts/validation-snapshot-lib.mjs
+++ b/scripts/validation-snapshot-lib.mjs
@@ -310,7 +310,10 @@ export function changelogEntryForVersion(text, version) {
  * that describes it cannot drift apart without one of these figures moving.
  */
 export function declaredComposition(changelogBody) {
-  const flat = changelogBody.replace(/\s+/g, ' ');
+  // Collapse runs of whitespace to single spaces so the prose regexes below can
+  // span line breaks. split/join rather than replace: this is normalisation for
+  // matching, not escaping, and the replace form is easily misread as the latter.
+  const flat = changelogBody.split(/\s+/).join(' ');
   const pick = (re) => countFromText(flat.match(re)?.[1] ?? null);
   return {
     total: pick(/\b([A-Za-z]+|\d+) defects are fixed\b/i),

--- a/tests/defectCompositionReconcile.test.ts
+++ b/tests/defectCompositionReconcile.test.ts
@@ -1,0 +1,44 @@
+/**
+ * defectCompositionReconcile.test.ts — the defect registry and the changelog
+ * prose that describes it must agree.
+ *
+ * The defect audit is a frozen event: `defect-registry.json` carries a
+ * `registryVersion`, and the composition prose ("Eighteen defects are fixed;
+ * twelve were exposed by a validation suite; …") lives in that version's
+ * changelog entry, not the newest one. The snapshot builder once read the
+ * composition from the NEWEST entry, so once the changelog advanced past the
+ * audit the declared figures came back null and a matching registry was reported
+ * as a disagreement. This pins the real invariant against the correct entry:
+ * every figure the registry derives is stated, in words, by its own-version
+ * changelog entry — so adding a defect without updating that prose (or vice
+ * versa) fails here.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+// @ts-expect-error — plain .mjs script, no type declarations.
+import { derivedComposition, declaredComposition, changelogEntryForVersion } from '../scripts/validation-snapshot-lib.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p: string): string => readFileSync(resolve(ROOT, p), 'utf8');
+const registry = JSON.parse(read('validation/defects/defect-registry.json')) as {
+  registryVersion: string;
+};
+const changelog = read('CHANGELOG.md');
+
+describe('defect composition reconciles with its own-version changelog entry', () => {
+  it('the registry version has a changelog entry', () => {
+    expect(changelogEntryForVersion(changelog, registry.registryVersion)).not.toBeNull();
+  });
+
+  it('every derived figure is stated, and matches, in that entry', () => {
+    const entry = changelogEntryForVersion(changelog, registry.registryVersion);
+    const declared = declaredComposition(entry.body);
+    const derived = derivedComposition(registry);
+    for (const figure of Object.keys(derived)) {
+      expect(declared[figure], `${figure} must be stated in CHANGELOG [${registry.registryVersion}]`).not.toBeNull();
+      expect(declared[figure], `${figure} derived vs stated`).toBe(derived[figure]);
+    }
+  });
+});


### PR DESCRIPTION
Audit item #2's one genuine sub-defect. The snapshot reported "the derived defect composition disagrees with the composition the changelog states" — but there is no data inconsistency. The registry (`registryVersion: 0.6.2`, 18 defects) and the v0.6.2 changelog entry agree on all five figures: eighteen fixed, twelve by validation suite, six by code review, five carried, four reaching output.

The bug was in the builder: `declaredComposition` parsed the NEWEST changelog entry (v0.6.7), which carries none of the audit prose, so every declared figure came back null and a matching registry reconciled as false. Fix: read the composition from the changelog entry for the registry's own version (`changelogEntryForVersion(registryVersion)`), where the audit prose actually lives.

No figure, defect record, or other snapshot field changes — the frozen v0.6.2 baseline re-derives identically (the mapping/re-derivation test confirms), and the builder now reports `reconciles: yes`. A new guard test pins the real invariant: the registry and its own-version changelog entry must state the same composition, so adding a defect without updating that prose (or vice versa) fails the suite. TSC clean; snapshot-mapping + guard tests pass.