### PR TITLE
feat(render): graduate density-scaled point size (Tier 2 gem H)

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,670 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,669 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -99,7 +99,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,670)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,669)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,

--- a/docs/architecture/float64-frame-migration-plan.md
+++ b/docs/architecture/float64-frame-migration-plan.md
@@ -93,7 +93,7 @@ The gate's number is the larger one because it also counts the reads inside
 frame mistake there is wrong everywhere at once, so the gate has to see it. This
 plan's number is the migration surface, which is consumers only.
 
-Measured, `outside-model`: 130 direct `.positions` reads across 40 files. Both
+Measured, `outside-model`: 131 direct `.positions` reads across 41 files. Both
 numbers are regenerated from the tree rather than quoted from memory, because
 they drift as code moves — they rose to 162 across 43 files while the placement
 architecture was landing, and have since fallen as consumers moved onto the

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
@@ -8,7 +8,7 @@ Five products reach E4 this cycle: `CRS-UTM-PROJECTION` (new), `CHANGE-RASTER` a
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,670 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root shrank by a handful of lines as the tool-toggle wiring moved behind a shared helper; the renderer is unchanged. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,669 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root shrank by a handful of lines as the tool-toggle wiring moved behind a shared helper; the renderer is unchanged. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
 
 ## Out-of-core streaming holds the index, not the whole cloud
 

--- a/docs/validation/module-graph-baseline.json
+++ b/docs/validation/module-graph-baseline.json
@@ -174,7 +174,7 @@
       ]
     },
     "src/render/Viewer.ts": {
-      "runtime": 76,
+      "runtime": 77,
       "typeOnly": 14,
       "dynamic": 1,
       "modules": [
@@ -198,6 +198,7 @@
         "src/render/colorEncode.ts",
         "src/render/colorLegend.ts",
         "src/render/colorModes.ts",
+        "src/render/densityPointSize.ts",
         "src/render/edl.ts",
         "src/render/edlPresets.ts",
         "src/render/elevationFilterGpu.ts",
@@ -262,7 +263,7 @@
     "components": []
   },
   "context": {
-    "filesScanned": 765,
+    "filesScanned": 770,
     "inlineTypeOnlyImports": 3,
     "note": "inlineTypeOnlyImports counts declarations whose named bindings are all inline `type` specifiers. Under verbatimModuleSyntax the declaration survives as `import {} from \"x\"`, a module load with no binding, so it is counted as a runtime edge above."
   }

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5670,
+      "lines": 5669,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/docs/validation/position-access-baseline.json
+++ b/docs/validation/position-access-baseline.json
@@ -1,5 +1,5 @@
 {
-  "total": 149,
+  "total": 150,
   "files": {
     "src/app/epochFramePrep.ts": 2,
     "src/app/floorPlanPositions.ts": 4,
@@ -30,6 +30,7 @@
     "src/render/InspectTool.ts": 1,
     "src/render/Viewer.ts": 37,
     "src/render/densityColors.ts": 1,
+    "src/render/densityPointSize.ts": 1,
     "src/render/elevationRange.ts": 2,
     "src/render/hillshadeColors.ts": 1,
     "src/render/localDensitySize.ts": 1,

--- a/docs/validation/position-frames.json
+++ b/docs/validation/position-frames.json
@@ -89,7 +89,7 @@
       "symbol": "packTileRecord",
       "frame": "source-local",
       "reads": 3,
-      "why": "Packs each decoded point into a tile-store record; raw.positions is the loader's source-local buffer (scaled value + header offset \u2212 load origin), copied into the tile verbatim with no reframing."
+      "why": "Packs each decoded point into a tile-store record; raw.positions is the loader's source-local buffer (scaled value + header offset − load origin), copied into the tile verbatim with no reframing."
     },
     {
       "file": "src/io/lasDecodeShared.ts",
@@ -222,7 +222,7 @@
       "symbol": "scanHullPositions",
       "frame": "source-local",
       "reads": 1,
-      "why": "The active static cloud's resident buffer feeds the KML footprint's convex-hull outline, which is traced in the cloud's own source-local XY \u2014 the same frame the bounding-rectangle extent is read in."
+      "why": "The active static cloud's resident buffer feeds the KML footprint's convex-hull outline, which is traced in the cloud's own source-local XY — the same frame the bounding-rectangle extent is read in."
     },
     {
       "file": "src/main.ts",
@@ -285,7 +285,7 @@
       "symbol": "ContourOverlay._upload",
       "frame": "project-local",
       "reads": 1,
-      "why": "Uploads the CONTOUR line-segment vertices (not cloud points) into a THREE.BufferGeometry. They arrive from buildContourOverlayBuffers over a model derived from gatherTerrainPositions, which folds every layer placement in, so the buffer is already in the project frame the scene draws at its origin \u2014 the object carries no further offset."
+      "why": "Uploads the CONTOUR line-segment vertices (not cloud points) into a THREE.BufferGeometry. They arrive from buildContourOverlayBuffers over a model derived from gatherTerrainPositions, which folds every layer placement in, so the buffer is already in the project frame the scene draws at its origin — the object carries no further offset."
     },
     {
       "file": "src/render/densityColors.ts",
@@ -293,6 +293,13 @@
       "frame": "source-local",
       "reads": 1,
       "why": "Numeric kernel. The grid is anchored on the buffer own bounds, so the result is invariant under a pure translation: static callers pass source-local, the streaming recolour passes render-local, and both are correct. What it must never be given is two frames concatenated."
+    },
+    {
+      "file": "src/render/densityPointSize.ts",
+      "symbol": "ensureDensitySizes",
+      "frame": "render-local",
+      "reads": 1,
+      "why": "Reads the same positions the cloud's geometry was built from (render-local) to compute a per-point display-size multiplier. The density grid is translation-invariant, so only relative position matters; the result is a rendering aid, never a measurement."
     },
     {
       "file": "src/render/elevationRange.ts",

--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -189,13 +189,6 @@
       "review": "2027-02-28"
     },
     {
-      "path": "src/render/localDensitySize.ts",
-      "status": "staged",
-      "why": "Per-point size from local neighbourhood density. No point-size path in the Viewer reads a per-point size array from here.",
-      "graduation": "The Viewer offers density-scaled point size and computes it through this module.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/render/paletteCatalog.ts",
       "status": "staged",
       "why": "The user-facing palette catalogue plus a registry for custom palettes from the Palette Editor. The editor was never built; colorModes.ts and confidenceOverlay.ts cite this file in prose but import nothing from it.",

--- a/src/io/session.ts
+++ b/src/io/session.ts
@@ -1588,7 +1588,7 @@ function isColorMode(v: string): v is ColorMode {
 
 /** Type guard for the runtime's PointSizeMode union. */
 function isPointSizeMode(v: unknown): v is PointSizeMode {
-  return v === 'fixed' || v === 'adaptive';
+  return v === 'fixed' || v === 'adaptive' || v === 'density';
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -4662,9 +4662,8 @@ async function copyShareLink(): Promise<void> {
 /** Restore a decoded share-link state onto the freshly loaded scan. */
 function applyShareState(state: ShareState, cloud: PointCloud): void {
   if (state.pointSize !== undefined) viewer.setPointSize(state.pointSize);
-  if (state.pointSizeMode === 'adaptive' || state.pointSizeMode === 'fixed') {
-    viewer.setPointSizeMode(state.pointSizeMode);
-  }
+  const psm = state.pointSizeMode;
+  if (psm === 'adaptive' || psm === 'fixed' || psm === 'density') viewer.setPointSizeMode(psm);
   if (state.colorMode && scans.activeId) {
     const modes = availableModes(cloud);
     if (modes.includes(state.colorMode as ColorMode)) {

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -105,7 +105,11 @@ export function parsePrefs(raw: string): Partial<ViewerPrefs> {
   if (typeof o.edlStrength === 'number' && Number.isFinite(o.edlStrength)) {
     out.edlStrength = clamp(o.edlStrength, 0, 1.5);
   }
-  if (o.pointSizeMode === 'adaptive' || o.pointSizeMode === 'fixed') {
+  if (
+    o.pointSizeMode === 'adaptive' ||
+    o.pointSizeMode === 'fixed' ||
+    o.pointSizeMode === 'density'
+  ) {
     out.pointSizeMode = o.pointSizeMode;
   }
   // P13 — validate against the known modes inline (kept type-only on splatShader

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -118,6 +118,7 @@ import type { RefinementReadiness } from './streaming/refinementReadiness';
 import { readDevFlags } from '../perf/devFlags';
 import { POINT_STYLE_DEFAULTS } from './pointStyle';
 import type { PointSizeMode } from './pointStyle';
+import { ensureDensitySizes, pointSizeBaseNode } from './densityPointSize';
 import {
   splatRadiusMultiplier,
   splatForcesAlphaToCoverage,
@@ -3414,9 +3415,10 @@ export class Viewer {
     return this._edlBaseStrength;
   }
 
-  /** Switch between adaptive (distance-scaled) and fixed point sizing. */
+  /** Switch between adaptive (distance-scaled), fixed, and density point sizing. */
   setPointSizeMode(mode: PointSizeMode): void {
     this._pointSizeMode = mode;
+    if (mode === 'density') ensureDensitySizes(this._clouds.values());
     this._reapplyAllSizeModes();
   }
 
@@ -5118,7 +5120,7 @@ export class Viewer {
    * meshes keep the exact prior graph (adaptive node or `null`).
    */
   private _applySizeMode(material: THREE.PointsNodeMaterial): void {
-    const adaptive = this._pointSizeMode === 'adaptive';
+    const base = pointSizeBaseNode(this._pointSizeMode, this._adaptiveSizeNode, material) as TslNode | null;
     // A fold enters this material's size graph only when BOTH the mesh carries
     // the required attribute AND the corresponding filter is currently active.
     //
@@ -5140,15 +5142,13 @@ export class Viewer {
     // size×mask shape as the filters); dropped again the moment it settles.
     const foldFade = this._materialsWithFade.has(material);
     if (!foldClass && !foldElev && !foldInten && !foldFade) {
-      material.sizeNode = (
-        adaptive ? this._adaptiveSizeNode : null
-      ) as typeof material.sizeNode;
+      material.sizeNode = base as typeof material.sizeNode;
       return;
     }
     // At least one filter is active on this material. Route fixed mode through
     // `materialPointSize` (the node form of `material.size`) so the pixel size is
     // preserved while the mask(s) multiply it, then fold each active multiplier.
-    let node: TslNode = adaptive ? this._adaptiveSizeNode : materialPointSize;
+    let node: TslNode = base ?? materialPointSize;
     if (foldElev) node = node.mul(this._elevGpu.maskMultiplier(material));
     if (foldClass) node = node.mul(this._classMaskMultiplier());
     if (foldInten) node = node.mul(this._intenMaskMultiplier());

--- a/src/render/densityPointSize.ts
+++ b/src/render/densityPointSize.ts
@@ -1,0 +1,71 @@
+/**
+ * densityPointSize.ts — the `density` point-size mode's render-side wiring.
+ *
+ * The maths (per-point size from local neighbourhood density) lives in
+ * `localDensitySize.ts`; this is the thin bridge that attaches those per-point
+ * multipliers to a cloud's geometry and selects the size-graph node for the
+ * mode. It is kept out of Viewer.ts so the density feature does not grow the
+ * ratcheted monolith, and imports the maths module — graduating it from the
+ * staged register.
+ *
+ * The multiplier is a DISPLAY aid: sparse regions get larger points and dense
+ * ones smaller, so thin areas read clearly. It never alters point data or any
+ * measurement.
+ */
+import * as THREE from 'three/webgpu';
+import { attribute } from 'three/tsl';
+import { localDensitySizes, autoDensitySizeParams } from './localDensitySize';
+import type { PointSizeMode } from './pointStyle';
+
+// Broad TSL node type, matching how Viewer.ts bridges the three/tsl graph.
+type TslNode = any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+/** userData flag marking a material whose geometry carries the `aSize` attribute. */
+const DENSITY_SIZE_FLAG = 'olvDensitySize';
+
+/** The subset of a cloud entry this module needs. */
+export interface DensitySizeEntry {
+  readonly cloud: { readonly positions: Float32Array };
+  readonly mesh: { readonly geometry: THREE.BufferGeometry };
+  readonly material: THREE.PointsNodeMaterial;
+}
+
+/**
+ * Compute and attach the per-point density-size multiplier to every cloud that
+ * does not yet carry one, from the positions the cloud already holds. Idempotent
+ * (a material already flagged is skipped) and self-tuning (grid and reference
+ * density come from the cloud's own extent). The `aSize` attribute must align
+ * 1:1 with the uploaded instances, so a cloud whose retained positions and mesh
+ * instance count disagree is skipped rather than mis-sized.
+ */
+export function ensureDensitySizes(clouds: Iterable<DensitySizeEntry>): void {
+  for (const entry of clouds) {
+    const material = entry.material;
+    if (material.userData?.[DENSITY_SIZE_FLAG] === true) continue;
+    const positions = entry.cloud.positions;
+    const n = positions.length / 3;
+    const geom = entry.mesh.geometry;
+    if (n === 0 || !(geom instanceof THREE.InstancedBufferGeometry)) continue;
+    if (geom.instanceCount !== n) continue;
+    const scales = localDensitySizes({ positions, ...autoDensitySizeParams(positions) });
+    geom.setAttribute('aSize', new THREE.InstancedBufferAttribute(scales, 1));
+    material.userData[DENSITY_SIZE_FLAG] = true;
+  }
+}
+
+/**
+ * The base size-graph node for a material under the current mode: the adaptive
+ * distance node multiplied by the per-point `aSize` attribute for `density`,
+ * the plain adaptive node for `adaptive` (and for `density` on a material with
+ * no attribute — a streaming node — so it degrades rather than reads a missing
+ * attribute), or null for `fixed` (the material's scalar size is used).
+ */
+export function pointSizeBaseNode(
+  mode: PointSizeMode,
+  adaptiveNode: TslNode,
+  material: THREE.PointsNodeMaterial,
+): TslNode | null {
+  const density = mode === 'density' && material.userData?.[DENSITY_SIZE_FLAG] === true;
+  if (density) return adaptiveNode.mul(attribute('aSize'));
+  return mode === 'fixed' ? null : adaptiveNode;
+}

--- a/src/render/localDensitySize.ts
+++ b/src/render/localDensitySize.ts
@@ -44,6 +44,43 @@ export interface LocalDensitySizeInput {
  * 2.0]` which is the sweet spot a few months of A/B testing on drone
  * + airborne surveys converged on.
  */
+/**
+ * Auto-tune the density grid to a cloud, so density sizing needs no manual
+ * parameters. The reference density is the cloud's mean areal density over its
+ * XY footprint (so an average-density region maps to scale ≈ 1), and the cell is
+ * a few mean spacings wide (enough points per cell for a stable count). Both
+ * derive from one linear extent pass; degenerate input falls back to unit
+ * values, so the size multiplier stays a safe 1 rather than throwing.
+ */
+export function autoDensitySizeParams(positions: Float32Array): {
+  cellSize: number;
+  referenceDensity: number;
+} {
+  const n = positions.length / 3;
+  if (n === 0) return { cellSize: 1, referenceDensity: 1 };
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (let i = 0; i < n; i++) {
+    const x = positions[i * 3];
+    const y = positions[i * 3 + 1];
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+  const width = Math.max(maxX - minX, 1e-6);
+  const height = Math.max(maxY - minY, 1e-6);
+  const area = width * height;
+  const referenceDensity = Math.max(1e-9, n / area);
+  // Mean inter-point spacing ≈ sqrt(area / n); a cell a few spacings wide holds
+  // enough points that its density is a stable estimate, not per-point noise.
+  const meanSpacing = Math.sqrt(area / n);
+  const cellSize = Math.max(1e-3, meanSpacing * 8);
+  return { cellSize, referenceDensity };
+}
+
 export function localDensitySizes(input: LocalDensitySizeInput): Float32Array {
   const positions = input.positions;
   const n = positions.length / 3;

--- a/src/render/pointStyle.ts
+++ b/src/render/pointStyle.ts
@@ -11,7 +11,7 @@
 import { clamp } from '../numeric';
 
 /** How point size responds to camera distance. */
-export type PointSizeMode = 'adaptive' | 'fixed';
+export type PointSizeMode = 'adaptive' | 'fixed' | 'density';
 
 /** Default adaptive-sizing tuning. */
 export const POINT_STYLE_DEFAULTS = {

--- a/src/ui/Inspector.ts
+++ b/src/ui/Inspector.ts
@@ -695,15 +695,24 @@ export class Inspector {
     });
     this._pointSizeSlider = slider;
 
-    this._sizeModeChips = (['adaptive', 'fixed'] as PointSizeMode[]).map((mode) => {
+    const sizeModeLabel: Record<PointSizeMode, string> = {
+      adaptive: 'Adaptive',
+      fixed: 'Fixed',
+      density: 'Density',
+    };
+    const sizeModeTitle: Record<PointSizeMode, string> = {
+      adaptive: 'Points scale with camera distance — far points stay visible, near ones do not bloat',
+      fixed: 'Every point keeps a constant on-screen size',
+      density: 'Sparse areas get larger points and dense areas smaller ones, so thin regions read clearly — a display aid, not a measurement',
+    };
+    this._sizeModeChips = (['adaptive', 'fixed', 'density'] as PointSizeMode[]).map((mode) => {
       const chip = el('button', {
-        className: 'olv-chip',
+        // `olv-size-chip` disambiguates from the colour-mode chip that also
+        // reads "Density" (the heatmap), for both CSS and test targeting.
+        className: 'olv-chip olv-size-chip',
         type: 'button',
-        text: mode === 'adaptive' ? 'Adaptive' : 'Fixed',
-        title:
-          mode === 'adaptive'
-            ? 'Points scale with camera distance — far points stay visible, near ones do not bloat'
-            : 'Every point keeps a constant on-screen size',
+        text: sizeModeLabel[mode],
+        title: sizeModeTitle[mode],
       });
       chip.addEventListener('click', () => {
         chip.blur();

--- a/tests/e2e/rendering.spec.ts
+++ b/tests/e2e/rendering.spec.ts
@@ -100,9 +100,20 @@ test('the Rendering panel switches point-size mode and antialiasing', async ({ p
 
   // Point-size mode — Adaptive is the default; switch to Fixed and back.
   const fixed = page.locator('.olv-chip', { hasText: 'Fixed' });
-  const adaptive = page.locator('.olv-chip', { hasText: 'Adaptive' });
+  const adaptive = page.locator('.olv-size-chip', { hasText: 'Adaptive' });
   await fixed.click();
   await expect(fixed).toHaveClass(/olv-chip-active/);
+  await adaptive.click();
+  await expect(adaptive).toHaveClass(/olv-chip-active/);
+
+  // Density mode computes a per-point size multiplier and multiplies it into the
+  // size graph; scoped to `.olv-size-chip` so it never matches the colour-mode
+  // "Density" heatmap chip. The final `errors` assertion catches a shader/
+  // attribute fault this render path could introduce.
+  const densitySize = page.locator('.olv-size-chip', { hasText: 'Density' });
+  await densitySize.click();
+  await expect(densitySize).toHaveClass(/olv-chip-active/);
+  await page.waitForTimeout(300);
   await adaptive.click();
   await expect(adaptive).toHaveClass(/olv-chip-active/);
 

--- a/tests/localDensitySize.test.ts
+++ b/tests/localDensitySize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { localDensitySizes } from '../src/render/localDensitySize';
+import { localDensitySizes, autoDensitySizeParams } from '../src/render/localDensitySize';
 
 /**
  * tests/localDensitySize.test.ts
@@ -137,5 +137,46 @@ describe('localDensitySizes — pure data formula hardening', () => {
         expect(Number.isFinite(v)).toBe(true);
       }
     }
+  });
+});
+
+describe('autoDensitySizeParams', () => {
+  it('returns safe unit values for an empty cloud', () => {
+    expect(autoDensitySizeParams(new Float32Array(0))).toEqual({ cellSize: 1, referenceDensity: 1 });
+  });
+
+  it('sets the reference to the mean areal density and a positive cell size', () => {
+    // 100 points on a 10×10 grid at spacing 1 → footprint 9×9 = 81 m², so the
+    // mean areal density is 100/81 ≈ 1.235 points/m².
+    const positions = new Float32Array(100 * 3);
+    let k = 0;
+    for (let ix = 0; ix < 10; ix++) {
+      for (let iy = 0; iy < 10; iy++) {
+        positions[k++] = ix;
+        positions[k++] = iy;
+        positions[k++] = 0;
+      }
+    }
+    const { cellSize, referenceDensity } = autoDensitySizeParams(positions);
+    expect(referenceDensity).toBeCloseTo(100 / 81, 2);
+    expect(cellSize).toBeGreaterThan(0);
+  });
+
+  it('feeds params that keep a uniform cloud near scale 1', () => {
+    // A uniform grid has ~constant local density, so every per-point scale
+    // should sit near 1 (neither the sparse-grow nor dense-shrink cap).
+    const positions = new Float32Array(400 * 3);
+    let k = 0;
+    for (let ix = 0; ix < 20; ix++) {
+      for (let iy = 0; iy < 20; iy++) {
+        positions[k++] = ix;
+        positions[k++] = iy;
+        positions[k++] = 0;
+      }
+    }
+    const scales = localDensitySizes({ positions, ...autoDensitySizeParams(positions) });
+    const mean = scales.reduce((s, v) => s + v, 0) / scales.length;
+    expect(mean).toBeGreaterThan(0.6);
+    expect(mean).toBeLessThan(1.6);
   });
 });


### PR DESCRIPTION
Tier 2 gem H. `localDensitySizes()` was a tested-but-unwired core — no point-size path read it. Graduated: a new **density** `PointSizeMode` sizes sparse regions larger and dense regions smaller so thin areas read clearly.

Design:
- The per-point multiplier rides as an `aSize` instance attribute, computed **lazily** on the first switch to the mode (from the positions the cloud already holds), so a session that never uses it pays nothing. It multiplies onto the adaptive distance node; a material without the attribute (a streaming node) falls back to adaptive, so no missing-attribute read is ever compiled.
- **Honest framing:** it is a display aid, never a measurement — the chip title and code say so, and no point data changes.
- All render-side wiring lives in a new `densityPointSize.ts` so **Viewer.ts stays net-neutral** against the monolith ratchet; `localDensitySize.ts` graduates from the staged register. `autoDensitySizeParams()` self-tunes the grid from the cloud extent (TDD).
- UI: a Density chip (`olv-size-chip`, disambiguated from the density *colour* chip); prefs/session/share guards accept the mode.

Verification: unit tests (autoDensitySizeParams + uniform-cloud scale); rendering.spec e2e switches to Density and asserts no shader/console error (CI's real WebGPU/WebGL leg); TSC + monolith/architecture/position-access/release-truth + unreachable lints all green; the doc cascade (baseline, architecture-map, positions plan, position-frames, KNOWN_LIMITATIONS) updated.