### PR TITLE
feat: graduate acquisition-coverage QA into the Range Workbench

### DIFF
--- a/docs/architecture/float64-frame-migration-plan.md
+++ b/docs/architecture/float64-frame-migration-plan.md
@@ -93,7 +93,7 @@ The gate's number is the larger one because it also counts the reads inside
 frame mistake there is wrong everywhere at once, so the gate has to see it. This
 plan's number is the migration surface, which is consumers only.
 
-Measured, `outside-model`: 132 direct `.positions` reads across 42 files. Both
+Measured, `outside-model`: 136 direct `.positions` reads across 43 files. Both
 numbers are regenerated from the tree rather than quoted from memory, because
 they drift as code moves — they rose to 162 across 43 files while the placement
 architecture was landing, and have since fallen as consumers moved onto the

--- a/docs/validation/position-access-baseline.json
+++ b/docs/validation/position-access-baseline.json
@@ -1,5 +1,5 @@
 {
-  "total": 151,
+  "total": 155,
   "files": {
     "src/app/epochFramePrep.ts": 2,
     "src/app/featureExtractionInput.ts": 1,
@@ -42,6 +42,7 @@
     "src/render/measure/stockpileVolume.ts": 5,
     "src/render/measure/volume.ts": 1,
     "src/render/patchView.ts": 9,
+    "src/render/recordSelection.ts": 4,
     "src/terrain/change/alignEpochs.ts": 3,
     "src/terrain/change/compareEpochs.ts": 3,
     "src/terrain/worker/terrainCoreWorker.ts": 1

--- a/docs/validation/position-frames.json
+++ b/docs/validation/position-frames.json
@@ -399,6 +399,13 @@
       "why": "The photometric witness patch is a neighbourhood of one picked point inside one layer, taken from that layer own buffer; a tangent basis over neighbours is translation-invariant anyway."
     },
     {
+      "file": "src/render/recordSelection.ts",
+      "symbol": "bindOrganizedRangeLink.register.registerOrganizedRange",
+      "frame": "render-local",
+      "reads": 4,
+      "why": "Builds a record->position callback from the cloud's own recentred buffer for the acquisition-coverage fit. The fit is translation-invariant (per-setup angular extent from the buffer's own bounds), so the recentred render-local frame is exactly what it needs; no origin shift applies."
+    },
+    {
       "file": "src/render/Viewer.ts",
       "symbol": "Viewer._pickDetailed",
       "frame": "source-local",

--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -95,13 +95,6 @@
       "review": "2027-02-28"
     },
     {
-      "path": "src/model/acquisitionCoverage.ts",
-      "status": "staged",
-      "why": "Separates an interrogated-but-empty cell from one nobody looked at, over the acquisition grid of an organized cloud. No terrain or coverage surface consults it; nothing in src/ imports it.",
-      "graduation": "The void/coverage reporting path reads acquisition coverage instead of treating every absence alike.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/registration/registrationModel.ts",
       "status": "staged",
       "why": "Named in the v0.6.6 release notes as the model that \"selects [a planar ICP solver] directly instead of refusing the planar case\". It chooses mount / planar ICP / general ICP / tie-point; no caller asks it to choose.",

--- a/src/model/organizedRangeLink.ts
+++ b/src/model/organizedRangeLink.ts
@@ -29,6 +29,7 @@
  */
 
 import type { OrganizedRangeSet } from './OrganizedRange';
+import type { RecordPosition, UpAxis } from './acquisitionCoverage';
 
 /** What one loaded layer contributes to the workbench. */
 export interface OrganizedLayerEntry {
@@ -36,6 +37,11 @@ export interface OrganizedLayerEntry {
   /** The layer's display name. Shown, never used to key anything. */
   readonly name: string;
   readonly set: OrganizedRangeSet;
+  /** Record → position, for the acquisition-coverage fit. Absent for a layer
+   *  registered before this was threaded; the coverage summary then just omits. */
+  readonly recordPosition?: RecordPosition;
+  /** The cloud's up axis, so the coverage fit projects onto the ground plane. */
+  readonly upAxis?: UpAxis;
 }
 
 const entries = new Map<string, OrganizedLayerEntry>();
@@ -55,13 +61,15 @@ export function registerOrganizedRange(
   layerId: string,
   name: string,
   set: OrganizedRangeSet | undefined,
+  recordPosition?: RecordPosition,
+  upAxis?: UpAxis,
 ): void {
   const had = entries.has(layerId);
   if (!set || set.frames.length === 0) {
     if (!had) return;
     entries.delete(layerId);
   } else {
-    entries.set(layerId, { layerId, name, set });
+    entries.set(layerId, { layerId, name, set, recordPosition, upAxis });
   }
   notifyRegistry();
 }

--- a/src/render/recordSelection.ts
+++ b/src/render/recordSelection.ts
@@ -27,6 +27,7 @@
  */
 
 import type { PointCloud } from '../model/PointCloud';
+import { isZUpFormat } from '../io/sniffFormat';
 import {
   forgetOrganizedRange,
   publishOrganizedPick,
@@ -74,7 +75,21 @@ export function bindOrganizedRangeLink(host: OrganizedLinkHost): OrganizedLinkBr
   });
 
   return {
-    register: (layerId, cloud) => registerOrganizedRange(layerId, cloud.name, cloud.organizedRange),
+    register: (layerId, cloud) =>
+      registerOrganizedRange(
+        layerId,
+        cloud.name,
+        cloud.organizedRange,
+        // Local (recentred) positions: the coverage fit is translation-invariant,
+        // so no origin shift is needed. Returns null past the buffer end.
+        (r) => {
+          const i = 3 * r;
+          return i >= 0 && i + 2 < cloud.positions.length
+            ? [cloud.positions[i], cloud.positions[i + 1], cloud.positions[i + 2]]
+            : null;
+        },
+        isZUpFormat(cloud.sourceFormat) ? 'z' : 'y',
+      ),
     forget: (layerId) => forgetOrganizedRange(layerId),
     layerIdOf: (cloud) => {
       // A linear scan of a table that holds a handful of entries. The pick path

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -707,6 +707,8 @@ export class AnalysePanel {
         this._rangeMounted = m.mountRangeWorkbench({
           set: entry.set,
           layerId: entry.layerId,
+          recordPosition: entry.recordPosition,
+          upAxis: entry.upAxis,
           launcherHost: this._rangeLauncher,
           workbenchHost: this._rangeWorkbench,
           onLaunch: () => this._rangeWorkbench.classList.remove('olv-hidden'),

--- a/src/ui/RangeWorkbench.ts
+++ b/src/ui/RangeWorkbench.ts
@@ -45,6 +45,12 @@ import {
 } from '../diagnostics/rangeRaster';
 import { cellText, linkageText, resolveCellLink } from '../diagnostics/rangeCellLink';
 import {
+  buildAcquisitionCoverage,
+  type AcquisitionCoverageIndex,
+  type RecordPosition,
+  type UpAxis,
+} from '../model/acquisitionCoverage';
+import {
   summariseRangeFrame,
   type BandCoverage,
   type RangeFrameSummary,
@@ -80,6 +86,10 @@ export interface RangeWorkbenchOptions {
   readonly layerId: string;
   /** Ask the renderer to mark a display record, or clear with null. */
   readonly onHighlightRecord?: (record: number | null) => void;
+  /** Record → position, for the set-level acquisition-extent summary. */
+  readonly recordPosition?: RecordPosition;
+  /** The layer's up axis, so the extent fit projects onto the ground plane. */
+  readonly upAxis?: UpAxis;
 }
 
 /**
@@ -90,6 +100,8 @@ export class RangeWorkbench {
 
   private readonly _set: OrganizedRangeSet;
   private readonly _opts: RangeWorkbenchOptions;
+  /** Fitted once from the whole set; null when no record positions were supplied. */
+  private readonly _coverage: AcquisitionCoverageIndex | null;
   private _frameIndex = 0;
   private _mode: RangeRasterMode = 'validity';
   private _plan: RasterPlan = { sourceWidth: 0, sourceHeight: 0, displayWidth: 0, displayHeight: 0 };
@@ -107,6 +119,15 @@ export class RangeWorkbench {
   constructor(opts: RangeWorkbenchOptions) {
     this._set = opts.set;
     this._opts = opts;
+    // Fit the per-setup interrogation extent once, from the set's own valid
+    // cells. Null when the mount supplied no record positions; the summary then
+    // omits rather than inventing an extent.
+    this._coverage = opts.recordPosition
+      ? buildAcquisitionCoverage(this._set, {
+          recordPosition: opts.recordPosition,
+          upAxis: opts.upAxis,
+        })
+      : null;
 
     this.element = el('div', { className: 'olv-range-workbench' });
     this.element.setAttribute('role', 'group');
@@ -422,6 +443,42 @@ export class RangeWorkbench {
     coverage.append(this._bandRow('Columns', summary.coverage.columnBands));
     coverage.append(this._bandRow('Rows', summary.coverage.rowBands));
     this._stats.append(coverage);
+
+    this._appendAcquisitionExtent();
+  }
+
+  /**
+   * A set-level summary of the interrogation extent: how many scanner setups
+   * have an angular extent this session could fit, and how many did not.
+   *
+   * The wording is load-bearing. "Interrogated" here means a ray addressed the
+   * direction, NOT that a surface was seen there — a NO_RETURN cell is still
+   * interrogated, and occlusion is not handled, so the extent is an upper bound.
+   * This block is a set-level fact, not a per-frame one, so it is drawn from the
+   * index fitted once in the constructor and does not depend on the shown frame.
+   */
+  private _appendAcquisitionExtent(): void {
+    const index = this._coverage;
+    if (!index) return;
+
+    const total = this._set.frames.length;
+    const fitted = index.setups.length;
+
+    const block = el('div', { className: 'olv-range-stat-block olv-range-coverage' });
+    block.append(el('h4', { text: 'Acquisition extent' }));
+    block.append(
+      el('p', {
+        className: 'olv-range-note',
+        text: `An interrogation extent was fitted for ${fitted} of ${total} scanner ${total === 1 ? 'setup' : 'setups'}. A fitted setup can answer whether a position lay within the directions its grid addressed; ${index.unfittedFrames} ${index.unfittedFrames === 1 ? 'setup was' : 'setups were'} too sparse to fit and answer indeterminate.`,
+      }),
+    );
+    block.append(
+      el('p', {
+        className: 'olv-range-note',
+        text: 'Interrogated means a ray addressed the direction — including cells that returned nothing — not that a surface was visible there. Occlusion is not modelled, so this is an upper bound on what was seen, not a measurement of coverage.',
+      }),
+    );
+    this._stats.append(block);
   }
 
   private _bandRow(name: string, bands: readonly BandCoverage[]): HTMLElement {

--- a/src/ui/rangeWorkbenchMount.ts
+++ b/src/ui/rangeWorkbenchMount.ts
@@ -16,6 +16,7 @@
  */
 
 import type { OrganizedRangeSet } from '../model/OrganizedRange';
+import type { RecordPosition, UpAxis } from '../model/acquisitionCoverage';
 import { requestOrganizedHighlight, subscribeOrganizedPick } from '../model/organizedRangeLink';
 import { RangeWorkbench } from './RangeWorkbench';
 import { el } from './dom';
@@ -39,6 +40,10 @@ export interface MountRangeWorkbenchOptions {
   readonly set: OrganizedRangeSet;
   /** The renderer's own layer id. The link keys on this, never on a name. */
   readonly layerId: string;
+  /** Record → position, for the acquisition-extent summary. Absent omits it. */
+  readonly recordPosition?: RecordPosition;
+  /** The layer's up axis, so the extent fit projects onto the ground plane. */
+  readonly upAxis?: UpAxis;
   /** Where the launcher card is rendered. */
   readonly launcherHost: HTMLElement;
   /** The container the workbench is rendered into, revealed on launch. */
@@ -59,7 +64,7 @@ export interface MountedRangeWorkbench {
  * at the same moment for the same reason.
  */
 export function mountRangeWorkbench(opts: MountRangeWorkbenchOptions): MountedRangeWorkbench {
-  const { set, layerId, launcherHost, workbenchHost, onLaunch } = opts;
+  const { set, layerId, recordPosition, upAxis, launcherHost, workbenchHost, onLaunch } = opts;
 
   let workbench: RangeWorkbench | null = null;
   let unsubscribe: (() => void) | null = null;
@@ -92,6 +97,8 @@ export function mountRangeWorkbench(opts: MountRangeWorkbenchOptions): MountedRa
       workbench = new RangeWorkbench({
         set,
         layerId,
+        recordPosition,
+        upAxis,
         onHighlightRecord: (record) =>
           requestOrganizedHighlight(record === null ? null : { layerId, record }),
       });

--- a/tests/e2e/rangeWorkbench.spec.ts
+++ b/tests/e2e/rangeWorkbench.spec.ts
@@ -54,6 +54,12 @@ test('offers the workbench for a scan that carries an acquisition grid', async (
   await expect(workbench.locator('.olv-range-canvas')).toBeVisible();
   // Validity leads, and the linkage state is stated rather than assumed.
   await expect(workbench.locator('.olv-range-linkage')).toContainText('Exact linkage');
+
+  // The set-level acquisition-extent summary is present and stays honest: it
+  // reports a fitted extent without claiming surface visibility or coverage.
+  const extent = workbench.locator('.olv-range-coverage');
+  await expect(extent).toContainText('Acquisition extent');
+  await expect(extent).toContainText('not that a surface was visible');
 });
 
 test('offers nothing for a scan that carries no acquisition grid', async ({ page }) => {


### PR DESCRIPTION
Graduates `src/model/acquisitionCoverage.ts` (stranded gem, Tier 2 F) by wiring it into the Range Frame Workbench.

`recordSelection` now registers each layer's local record positions and up axis; the mount threads them to `RangeWorkbench`, which fits the per-setup interrogation extent once and renders a set-level **Acquisition extent** block: how many scanner setups have a fitted extent versus were too sparse (indeterminate).

Honesty framing (scientific-critical-thinking gate): interrogated (a ray addressed the direction, empty returns included) is kept distinct from surface visibility; occlusion is stated as unmodelled, so the extent is an upper bound, not coverage.

Removes the staged unreachable-modules entry; adds an e2e assertion on `.olv-range-coverage`. tsc, unit (13/13), and unreachable-modules lint green.