### PR TITLE
feat: graduate feature extraction into a candidate-review surface (Tier 2 gem I)

### DIFF
--- a/docs/architecture/float64-frame-migration-plan.md
+++ b/docs/architecture/float64-frame-migration-plan.md
@@ -93,7 +93,7 @@ The gate's number is the larger one because it also counts the reads inside
 frame mistake there is wrong everywhere at once, so the gate has to see it. This
 plan's number is the migration surface, which is consumers only.
 
-Measured, `outside-model`: 131 direct `.positions` reads across 41 files. Both
+Measured, `outside-model`: 132 direct `.positions` reads across 42 files. Both
 numbers are regenerated from the tree rather than quoted from memory, because
 they drift as code moves — they rose to 162 across 43 files while the placement
 architecture was landing, and have since fallen as consumers moved onto the

--- a/docs/science/METHOD_REGISTRY.md
+++ b/docs/science/METHOD_REGISTRY.md
@@ -38,6 +38,8 @@ the paper that specifies it.
 | `olv.validation.reliability-wilson` | 1 | Measured-cell reliability | Wilson (1927) |
 | `olv.registration.icp-planar` | 1 | Planar rigid ICP | Besl & McKay (1992); Umeyama (1991) |
 | `olv.volume.stockpile` | 1 | Stockpile cut-fill volume ±1σ | internal (prismatic cut-fill) |
+| `olv.feature.building-footprint` | 1 | Building footprint candidate extraction | internal (connected-component + boundary trace) |
+| `olv.feature.conductor-fit` | 1 | Conductor centreline and sag fit | internal (parabolic small-sag approximation) |
 
 ## Honesty boundary
 

--- a/docs/validation/position-access-baseline.json
+++ b/docs/validation/position-access-baseline.json
@@ -1,5 +1,5 @@
 {
-  "total": 150,
+  "total": 151,
   "files": {
     "src/app/epochFramePrep.ts": 2,
     "src/app/featureExtractionInput.ts": 1,

--- a/docs/validation/position-access-baseline.json
+++ b/docs/validation/position-access-baseline.json
@@ -2,6 +2,7 @@
   "total": 150,
   "files": {
     "src/app/epochFramePrep.ts": 2,
+    "src/app/featureExtractionInput.ts": 1,
     "src/app/floorPlanPositions.ts": 4,
     "src/app/terrainAnalysisRunner.ts": 3,
     "src/io/copc/copcChunkDecode.ts": 1,

--- a/docs/validation/position-frames.json
+++ b/docs/validation/position-frames.json
@@ -15,6 +15,13 @@
       "why": "Each epoch's buffer is paired with its own sourceOrigin so the two are gridded in one common world frame; differencing raw local coordinates would compare mismatched locations. Extracted from compareLoadedLayers."
     },
     {
+      "file": "src/app/featureExtractionInput.ts",
+      "symbol": "buildFeatureExtractionInput",
+      "frame": "render-local",
+      "reads": 1,
+      "why": "Reads the cloud's recentred buffer to split building/wire points for the feature cores. Both cores are translation-invariant (footprint grid on the points' own bounds; conductor fit from their covariance), so the recentred render-local frame is exactly what they consume and no origin shift applies."
+    },
+    {
       "file": "src/app/floorPlanPositions.ts",
       "symbol": "floorPlanPositions",
       "frame": "project-local",

--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -20,46 +20,10 @@
   "reviewDates": "Reported by the lint when they pass, never enforced. A gate that turns red on a date with no change to the tree teaches people to edit the date rather than the code.",
   "modules": [
     {
-      "path": "src/features/FeatureExtractionService.ts",
-      "status": "staged",
-      "why": "Named in the v0.6.6 release notes under \"Also in this release\" as a foundation: \"a feature-extraction service over the building and conductor cores ... Nothing in the running application passes through either\". It is the product-side entry over the two cores; no UI or DerivedLayer calls it.",
-      "graduation": "A candidate-review surface or a DerivedLayer producer calls extractFeatures, reached from src/main.ts or src/lazyChunks.ts.",
-      "review": "2027-02-28",
-      "declaredIn": "docs/releases/RELEASE_NOTES_v0.6.6.md"
-    },
-    {
-      "path": "src/features/buildingFootprints.ts",
-      "status": "staged",
-      "why": "A pure core under FeatureExtractionService. Its only non-test importer is that service, which is itself unreachable, so the whole cluster is off the production graph together.",
-      "graduation": "FeatureExtractionService graduates; this arrives with it.",
-      "review": "2027-02-28"
-    },
-    {
-      "path": "src/features/conductors.ts",
-      "status": "staged",
-      "why": "A pure core under FeatureExtractionService, in the same cluster and unreachable for the same reason.",
-      "graduation": "FeatureExtractionService graduates; this arrives with it.",
-      "review": "2027-02-28"
-    },
-    {
-      "path": "src/features/footprintTrace.ts",
-      "status": "staged",
-      "why": "The trace/simplify/orthogonalise step the footprint core and the GeoJSON writer share. Both importers are inside the same unreachable cluster.",
-      "graduation": "FeatureExtractionService graduates; this arrives with it.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/features/footprintGeoJson.ts",
       "status": "staged",
-      "why": "Writes extracted footprints as RFC 7946 GeoJSON. No export route offers footprints, so nothing in the export layer imports it.",
+      "why": "Writes extracted footprints as RFC 7946 GeoJSON. The candidate-review surface (v0.6.8) reviews footprints but offers no GeoJSON export, so no export route imports this writer.",
       "graduation": "The export layer offers a footprint product and routes it through this writer.",
-      "review": "2027-02-28"
-    },
-    {
-      "path": "src/features/candidateReview.ts",
-      "status": "staged",
-      "why": "Holds accept/reject/pending state over extracted candidates. There is no candidate-review UI, so nothing holds the state.",
-      "graduation": "A review surface exists and reads this store.",
       "review": "2027-02-28"
     },
     {

--- a/src/app/featureExtractionInput.ts
+++ b/src/app/featureExtractionInput.ts
@@ -1,0 +1,146 @@
+/**
+ * featureExtractionInput.ts — turn a loaded cloud into feature-extraction input.
+ *
+ * The feature cores (building footprints, conductor fit) take plain geometry, not
+ * a PointCloud. This is the one place that reads a cloud's classified points and
+ * shapes them for `FeatureExtractionService`, so the UI mount that reviews the
+ * candidates never learns what a PointCloud is.
+ *
+ * WHAT IT READS, AND WHY THAT IS HONEST TO CARRY FORWARD. Building points are the
+ * points a classifier marked ASPRS class 6; wire points, class 14. That
+ * classification may be the file's own or one the viewer DERIVED heuristically —
+ * a weaker basis — so `classificationIsDerived` travels with the input and the
+ * review surface states which it was. A candidate built on derived classes is a
+ * candidate about a guess, and the surface must not hide that.
+ *
+ * FRAME. The cloud's positions are its recentred (render-local) buffer. Both
+ * cores are translation-invariant — the footprint grid anchors on the points'
+ * own bounds, the conductor fit works from their covariance — so the recentred
+ * frame is exactly what they need and no origin shift is applied. The horizontal
+ * pair is chosen by the up axis: (x, y) for a Z-up source, (x, z) for a Y-up one,
+ * so a footprint is measured in the ground plane and not a wall.
+ *
+ * Returns null when the cloud carries neither building nor wire points: there is
+ * nothing to extract and the launcher should not appear.
+ */
+
+import type { PointCloud } from '../model/PointCloud';
+import type { BuildingPoint, FootprintGrid } from '../features/buildingFootprints';
+import type { Vec3 } from '../features/conductors';
+import { knownUnit, unknownUnit, type LinearUnitScale } from '../units/units';
+import { defaultCellSizeForSpacing } from '../render/densityColors';
+import { isZUpFormat } from '../io/sniffFormat';
+
+/** ASPRS classification codes the feature cores consume. */
+const ASPRS_BUILDING = 6;
+const ASPRS_WIRE_CONDUCTOR = 14;
+
+export interface FeatureExtractionInput {
+  readonly buildingPoints: readonly BuildingPoint[];
+  readonly buildingGrid: FootprintGrid;
+  readonly conductorPoints: readonly Vec3[];
+  readonly unit: LinearUnitScale;
+  /** The frame's vertical axis, for the conductor sag/span split. */
+  readonly up: Vec3;
+  /**
+   * True when the classification these points came from was DERIVED by the
+   * viewer's heuristic rather than read from the file. The review surface states
+   * it: a candidate over derived classes is a candidate about a guess.
+   */
+  readonly classificationIsDerived: boolean;
+}
+
+/** Nominal point spacing in source units, from a horizontal bbox and count. */
+function nominalSpacing(
+  minH1: number,
+  maxH1: number,
+  minH2: number,
+  maxH2: number,
+  n: number,
+): number {
+  const area = Math.max(0, maxH1 - minH1) * Math.max(0, maxH2 - minH2);
+  if (!(area > 0) || n < 1) return 1;
+  return Math.sqrt(area / n);
+}
+
+/**
+ * The cloud's linear unit as a conversion scale, or unknown.
+ *
+ * KNOWN only when a CRS is actually present AND declares a usable linear unit: a
+ * MISSING crs must read as unknown, not as metres. Guarding on `linearUnit` alone
+ * would let a null crs pass as known (the fail-open trap the measurement surface
+ * has hit before), so the crs presence and the positive factor are both checked.
+ */
+function unitOf(cloud: PointCloud): LinearUnitScale {
+  const crs = cloud.metadata?.crs;
+  if (crs != null && crs.linearUnit !== 'unknown' && crs.linearUnitToMetres > 0) {
+    return knownUnit(crs.linearUnitToMetres);
+  }
+  return unknownUnit();
+}
+
+/**
+ * Build feature-extraction input from a cloud's classified points, or null when
+ * it carries none. The linear unit for the candidates' metric twins is derived
+ * from the cloud's own CRS, fail-closed to unknown when none is declared.
+ */
+export function buildFeatureExtractionInput(
+  cloud: PointCloud | null | undefined,
+): FeatureExtractionInput | null {
+  if (!cloud) return null;
+  const classification = cloud.classification;
+  const positions = cloud.positions;
+  if (!classification || positions.length === 0) return null;
+  const unit = unitOf(cloud);
+
+  const zUp = isZUpFormat(cloud.sourceFormat);
+  // The second horizontal axis by up axis; the first is always x.
+  const h2i = zUp ? 1 : 2;
+
+  const buildingPoints: BuildingPoint[] = [];
+  const conductorPoints: Vec3[] = [];
+  let minH1 = Infinity;
+  let maxH1 = -Infinity;
+  let minH2 = Infinity;
+  let maxH2 = -Infinity;
+
+  const n = Math.min(classification.length, positions.length / 3);
+  for (let i = 0; i < n; i++) {
+    const code = classification[i];
+    if (code !== ASPRS_BUILDING && code !== ASPRS_WIRE_CONDUCTOR) continue;
+    const b = i * 3;
+    const x = positions[b];
+    const y = positions[b + 1];
+    const z = positions[b + 2];
+    if (code === ASPRS_BUILDING) {
+      const h1 = x;
+      const h2 = h2i === 1 ? y : z;
+      buildingPoints.push({ x: h1, y: h2 });
+      if (h1 < minH1) minH1 = h1;
+      if (h1 > maxH1) maxH1 = h1;
+      if (h2 < minH2) minH2 = h2;
+      if (h2 > maxH2) maxH2 = h2;
+    } else {
+      conductorPoints.push([x, y, z]);
+    }
+  }
+
+  if (buildingPoints.length === 0 && conductorPoints.length === 0) return null;
+
+  const spacing = nominalSpacing(minH1, maxH1, minH2, maxH2, buildingPoints.length);
+  const cellSizeSource = defaultCellSizeForSpacing(spacing);
+  const buildingGrid: FootprintGrid = {
+    originX: Number.isFinite(minH1) ? minH1 : 0,
+    originY: Number.isFinite(minH2) ? minH2 : 0,
+    cellSizeSource,
+  };
+
+  return {
+    buildingPoints,
+    buildingGrid,
+    conductorPoints,
+    unit,
+    up: zUp ? [0, 0, 1] : [0, 1, 0],
+    classificationIsDerived: cloud.classificationIsDerived,
+  };
+}

--- a/src/lazyChunks.ts
+++ b/src/lazyChunks.ts
@@ -522,6 +522,9 @@ export const loadProfileWorkbenchRuntime = () => import('./app/profileWorkbenchR
  */
 export const loadRangeWorkbenchMount = () => import('./ui/rangeWorkbenchMount');
 
+/** The feature-candidate review surface (building footprints, conductor fits). */
+export const loadFeatureCandidatesMount = () => import('./ui/featureCandidatesMount');
+
 /**
  * The 3D Tiles open — the tileset parser, the traversal, the hardened tileset
  * transport and the PNTS decoder, as one chunk behind the remote-URL router.

--- a/src/main.ts
+++ b/src/main.ts
@@ -2133,7 +2133,7 @@ function newAnalysePanel(
     // Same cached-core rebuild, generalised with the contour shape-style picker so
     // an export reflects the user's chosen interval AND line shape.
     buildResultForExport: (opts) => terrainRunner.buildResultForExport(opts),
-    getExportBasename: () => lastCloudName, getAnnotations: () => viewer.annotate.getAnnotations(), getActiveScanId: () => scans.activeExportTargetId(),
+    getExportBasename: () => lastCloudName, getAnnotations: () => viewer.annotate.getAnnotations(), getActiveScanId: () => scans.activeExportTargetId(), getFeatureCloud: (id) => viewer.getCloud(id) ?? null,
     // Terrain Intelligence Report (v0.4.5): hand the report the Inspector
     // card's CURRENT Dataset Intelligence summary so the PDF's bucket labels
     // are the card's own strings (null when the card is empty — the report

--- a/src/science/methodRegistry.ts
+++ b/src/science/methodRegistry.ts
@@ -28,6 +28,7 @@ export type MethodCategory =
   | 'registration'
   | 'volume'
   | 'dtm'
+  | 'feature'
   | 'provenance';
 
 /** A lightweight reference to a registered method at its current version. */
@@ -215,6 +216,34 @@ export const METHOD_REGISTRY: Readonly<Record<string, MethodEntry>> = {
       'Internal composition (provenance record over the loader-recorded cell-to-record index); no single source method.',
     category: 'provenance',
     implementation: ['src/science/sourceTopology.ts'],
+  },
+  'olv.feature.building-footprint': {
+    id: 'olv.feature.building-footprint',
+    version: 1,
+    name: 'Building footprint candidate extraction',
+    summary:
+      'Building-classified points are rasterised to a binary occupancy grid, grouped ' +
+      'into 8-connected components above a noise-area floor, and each component is ' +
+      'traced to an outline. A footprint is a derived candidate over classified points, ' +
+      'not a surveyed or detected building.',
+    citation:
+      'Internal composition of connected-component labelling over an occupancy grid and boundary tracing; no single source method.',
+    category: 'feature',
+    implementation: ['src/features/buildingFootprints.ts', 'src/features/footprintTrace.ts'],
+  },
+  'olv.feature.conductor-fit': {
+    id: 'olv.feature.conductor-fit',
+    version: 1,
+    name: 'Conductor centreline and sag fit',
+    summary:
+      'Wire-classified points are fitted to a horizontal centreline (principal direction) ' +
+      'and a vertical parabolic profile along it — the small-sag approximation to a ' +
+      'catenary. Reports span, sag and fit residual as a derived candidate, not a ' +
+      'calibrated catenary.',
+    citation:
+      'Parabolic small-sag approximation to the catenary; standard overhead-line result. Internal least-squares implementation.',
+    category: 'feature',
+    implementation: ['src/features/conductors.ts'],
   },
   'olv.contour.analytical': {
     id: 'olv.contour.analytical',

--- a/src/styles/98d-feature-candidates.css
+++ b/src/styles/98d-feature-candidates.css
@@ -1,0 +1,123 @@
+/*
+ * 98d-feature-candidates.css — the feature-candidate review surface.
+ *
+ * A context-sensitive launcher (shown only for a classified scan) and the
+ * candidate-review list behind it: building footprints and a conductor fit,
+ * each a derived candidate a reviewer accepts, rejects or leaves pending.
+ * Styled to match the Range Frame Workbench launcher next to it.
+ */
+
+.olv-feature-launcher {
+  margin-top: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border-radius: 10px;
+  background: var(--olv-surface-2, rgba(255, 255, 255, 0.03));
+}
+
+.olv-feature-launcher-head {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.55));
+}
+
+.olv-feature-launcher-title {
+  margin-top: 4px;
+  font-weight: 600;
+}
+
+.olv-feature-launcher-fact {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+}
+
+.olv-feature-launcher-message {
+  margin: 6px 0 10px;
+  font-size: 12px;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+}
+
+.olv-feature-launcher-action {
+  padding: 6px 12px;
+  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.16));
+  border-radius: 8px;
+  background: var(--olv-surface-3, rgba(255, 255, 255, 0.06));
+  color: inherit;
+  cursor: pointer;
+}
+
+.olv-feature-review {
+  margin-top: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.olv-feature-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.olv-feature-note {
+  margin: 0;
+  font-size: 12px;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+}
+
+.olv-feature-derived {
+  color: var(--olv-warn, #e0a33e);
+}
+
+.olv-feature-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.5));
+}
+
+.olv-feature-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-top: 1px solid var(--olv-border, rgba(255, 255, 255, 0.08));
+}
+
+.olv-feature-id {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12px;
+}
+
+.olv-feature-measure {
+  flex: 1 1 200px;
+  font-size: 12px;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.75));
+  font-variant-numeric: tabular-nums;
+}
+
+.olv-feature-chips {
+  display: flex;
+  gap: 4px;
+}
+
+.olv-feature-chip {
+  padding: 3px 8px;
+  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.16));
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.olv-feature-chip.is-active {
+  background: var(--olv-accent, #4c9ffe);
+  border-color: var(--olv-accent, #4c9ffe);
+  color: #0b0b0d;
+}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -42,5 +42,6 @@ import './97-contour-studio.css'; // Contour Studio: launcher, workspace, eviden
 import './98-layer-health.css'; // Colorbar legend overlay and Layer Health card: spatial facts and compatibility.
 import './98b-process-studio.css'; // Process Studio panel: adaptive stages, product eligibility and QA checks.
 import './98c-range-workbench.css'; // Range Frame Workbench: structured-data launcher, acquisition-grid raster, legend and per-frame diagnostics.
+import './98d-feature-candidates.css'; // Feature candidates: classified-scan launcher and the building/conductor candidate-review list.
 import './99-mobile-gui-refresh.css'; // Mobile GUI refresh (v0.6.x) and the landscape-phone left rail.
 import './99z-forced-colors.css'; // Windows High Contrast / forced-colors — the final override block.

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -111,6 +111,7 @@ import {
   loadContourStudioMount,
   loadContourExportAdapter,
   loadRangeWorkbenchMount,
+  loadFeatureCandidatesMount,
 } from '../lazyChunks';
 import {
   organizedRangeFor,
@@ -118,6 +119,8 @@ import {
   type OrganizedLayerEntry,
 } from '../model/organizedRangeLink';
 import type { MountedRangeWorkbench } from './rangeWorkbenchMount';
+import type { MountedFeatureCandidates } from './featureCandidatesMount';
+import type { PointCloud } from '../model/PointCloud';
 import { openModal, type ModalHandle } from './Modal';
 import type { SheetSize, SheetOrientation, MapSheetPurpose } from '../render/measure/mapSheetPdf';
 import type { Annotation } from '../render/annotate/types';
@@ -226,6 +229,13 @@ export interface AnalysePanelCallbacks {
    * tell the two apart and behaves as before.
    */
   getActiveScanId?: () => string | null;
+  /**
+   * The loaded cloud for a scan, or null. The panel offers the feature-candidate
+   * review launcher when the cloud carries a classification; the (lazy) review
+   * surface reads the building- and wire-classified points itself. Omitted in
+   * embeds with no feature review.
+   */
+  getFeatureCloud?: (scanId: string) => PointCloud | null;
   /**
    * Switch the 3D viewer's colour mode to the colourblind-safe 'confidence'
    * trust overlay — the SAME per-cell confidence + strong/moderate/weak
@@ -429,6 +439,11 @@ export class AnalysePanel {
   private _rangeLayerId: string | null = null;
   private _rangeToken = 0;
   private _rangeUnsubscribe: (() => void) | null = null;
+  private readonly _featureLauncher: HTMLElement;
+  private readonly _featureReview: HTMLElement;
+  private _featureMounted: MountedFeatureCandidates | null = null;
+  private _featureScanId: string | null = null;
+  private _featureToken = 0;
   private readonly _contourLauncher: HTMLElement;
   /** Host for the 3D contour derived-layer controls; empty until a layer is drawn. */
   private readonly _contourLayerControls: HTMLElement;
@@ -575,6 +590,12 @@ export class AnalysePanel {
     this._rangeLauncher = el('div', { className: 'olv-analyse-range-launcher' });
     this._rangeWorkbench = el('div', { className: 'olv-analyse-range-workbench olv-hidden' });
 
+    // Feature candidates (v0.6.8). A context-sensitive launcher for the
+    // candidate-review surface, rendered ONLY when the active scan carries
+    // building- or wire-classified points, and mounted from its own lazy chunk.
+    this._featureLauncher = el('div', { className: 'olv-analyse-feature-launcher' });
+    this._featureReview = el('div', { className: 'olv-analyse-feature-review olv-hidden' });
+
     this._contourLauncher = el('div', { className: 'olv-analyse-contour-launcher' });
     this._contourLayerControls = el('div', { className: 'olv-analyse-layer-controls olv-hidden' });
     this._contourDeliverable = el('div', {
@@ -639,6 +660,8 @@ export class AnalysePanel {
       this._status,
       this._rangeLauncher,
       this._rangeWorkbench,
+      this._featureLauncher,
+      this._featureReview,
       this._resultsRegion,
       this._roadmap,
       this._scanTypeControl.element,
@@ -656,6 +679,7 @@ export class AnalysePanel {
     // was mounted before this panel was.
     this._rangeUnsubscribe = subscribeOrganizedRange(() => this._refreshRangeLauncher());
     this._refreshRangeLauncher();
+    this._refreshFeatureLauncher();
   }
 
   /**
@@ -703,8 +727,52 @@ export class AnalysePanel {
     this._rangeWorkbench.classList.add('olv-hidden');
   }
 
+  /**
+   * Show, replace, or remove the feature-candidate launcher for whichever scan
+   * is active. Gated on the host returning extraction input — a scan with no
+   * building- or wire-classified points shows no launcher.
+   */
+  private _refreshFeatureLauncher(): void {
+    const scanId = this._cb.getActiveScanId?.() ?? null;
+    const cloud = scanId ? this._cb.getFeatureCloud?.(scanId) ?? null : null;
+    // Gate cheaply on the presence of a classification — the specific
+    // building/wire scan is the lazy surface's job, not a per-refresh cost.
+    if (!scanId || !cloud || !cloud.classification) {
+      this._teardownFeatures();
+      return;
+    }
+    if (this._featureScanId === scanId && this._featureMounted) return;
+    this._teardownFeatures();
+    this._featureScanId = scanId;
+    const token = ++this._featureToken;
+    void loadFeatureCandidatesMount()
+      .then((m) => {
+        if (token !== this._featureToken) return;
+        this._featureMounted = m.mountFeatureCandidates({
+          cloud,
+          launcherHost: this._featureLauncher,
+          reviewHost: this._featureReview,
+          onLaunch: () => this._featureReview.classList.remove('olv-hidden'),
+        });
+      })
+      .catch(() => {
+        /* An optional review surface: omit it rather than break the panel. */
+      });
+  }
+
+  private _teardownFeatures(): void {
+    this._featureToken++;
+    this._featureMounted?.dispose();
+    this._featureMounted = null;
+    this._featureScanId = null;
+    this._featureLauncher.replaceChildren();
+    this._featureReview.replaceChildren();
+    this._featureReview.classList.add('olv-hidden');
+  }
+
   /** Drop the registry subscription. Call when the panel is discarded. */
   destroy(): void {
+    this._teardownFeatures();
     this._rangeUnsubscribe?.();
     this._rangeUnsubscribe = null;
     this._teardownRange();
@@ -2043,6 +2111,7 @@ export class AnalysePanel {
     // launcher is gated on, so this is where a newly opened structured file
     // gets its entry point.
     this._refreshRangeLauncher();
+    this._refreshFeatureLauncher();
   }
 
   /**

--- a/src/ui/featureCandidatesMount.ts
+++ b/src/ui/featureCandidatesMount.ts
@@ -1,0 +1,271 @@
+/**
+ * featureCandidatesMount.ts — the review surface for extracted feature candidates.
+ *
+ * The building-footprint and conductor-fit cores propose candidates; this is
+ * where a person reviews them. It loads as one split chunk the first time a
+ * layer is found to carry building- or wire-classified points, so a session that
+ * never opens such data loads none of it. The only route in is
+ * `loadFeatureCandidatesMount()` in `lazyChunks.ts`.
+ *
+ * WHAT THIS SURFACE PROMISES, AND WHAT IT REFUSES TO. Every row is a DERIVED
+ * CANDIDATE, never a detected building or a surveyed conductor. It is a proposal
+ * from classified points, and when that classification was the viewer's own
+ * heuristic rather than the file's, the header says so — a candidate over a
+ * guess is a guess. Measures are shown in the source unit always, and in metres
+ * only when the linear unit is known; a candidate never invents a metric figure.
+ * Nothing here claims a footprint is a building outline of record, and nothing
+ * asserts a cadastral or survey accuracy.
+ *
+ * A conductor is ONE fit over ALL wire-classified points: the core reports a
+ * single span and sag, or declines when the points are not linear enough to be a
+ * conductor. It is labelled as a parabolic fit, not a calibrated catenary.
+ *
+ * The review decisions live in a `CandidateReviewStore`, keyed by each
+ * candidate's geometry-derived id, so a re-open re-attaches a judgment to the
+ * thing it was made about rather than to a list position.
+ */
+
+import type { PointCloud } from '../model/PointCloud';
+import {
+  buildFeatureExtractionInput,
+  type FeatureExtractionInput,
+} from '../app/featureExtractionInput';
+import {
+  extractBuildingCandidates,
+  extractConductorCandidate,
+  type BuildingCandidate,
+  type ConductorCandidate,
+} from '../features/FeatureExtractionService';
+import { CandidateReviewStore, type CandidateStatus } from '../features/candidateReview';
+import { el } from './dom';
+
+export interface MountFeatureCandidatesOptions {
+  readonly cloud: PointCloud;
+  /** Where the launcher card is rendered. */
+  readonly launcherHost: HTMLElement;
+  /** The container the review list is rendered into, revealed on launch. */
+  readonly reviewHost: HTMLElement;
+  /** Reveals `reviewHost`. */
+  readonly onLaunch: () => void;
+}
+
+export interface MountedFeatureCandidates {
+  readonly dispose: () => void;
+}
+
+/** A source-unit measure, plus its metric twin only when the unit is known. */
+function measure(source: number, metric: number | null, unitSuffix: string): string {
+  const s = source.toFixed(2);
+  return metric === null ? `${s} ${unitSuffix} (source unit)` : `${metric.toFixed(2)} ${unitSuffix}`;
+}
+
+/**
+ * Render the launcher and wire the review list behind it.
+ *
+ * Extraction runs on the first launch, not on mount, so a layer whose launcher
+ * is never pressed costs one card.
+ */
+export function mountFeatureCandidates(
+  opts: MountFeatureCandidatesOptions,
+): MountedFeatureCandidates {
+  const { cloud, launcherHost, reviewHost, onLaunch } = opts;
+  const review = new CandidateReviewStore();
+  let built = false;
+
+  const card = el('div', { className: 'olv-feature-launcher' });
+  card.setAttribute('role', 'group');
+  card.setAttribute('aria-label', 'Feature candidates');
+  card.append(el('div', { className: 'olv-feature-launcher-head', text: 'Feature Candidates' }));
+  card.append(
+    el('div', {
+      className: 'olv-feature-launcher-title',
+      text: 'Propose footprints and conductors from classified points',
+    }),
+  );
+
+  // Read the building/wire points once, here, so the gate that showed this
+  // launcher (any classification present) is separated from the specific fact.
+  const input = buildFeatureExtractionInput(cloud);
+  if (!input) {
+    card.append(
+      el('div', {
+        className: 'olv-feature-launcher-fact',
+        text: 'This scan carries no building- or wire-classified points.',
+      }),
+    );
+    launcherHost.replaceChildren(card);
+    return {
+      dispose: () => {
+        launcherHost.replaceChildren();
+        reviewHost.replaceChildren();
+      },
+    };
+  }
+
+  const counts = `${input.buildingPoints.length} building-classified, ${input.conductorPoints.length} wire-classified point(s)`;
+  card.append(el('div', { className: 'olv-feature-launcher-fact', text: counts }));
+  card.append(
+    el('p', {
+      className: 'olv-feature-launcher-message',
+      text: 'Each result is a derived candidate for review, not a detected building or surveyed conductor.',
+    }),
+  );
+
+  const button = el('button', {
+    className: 'olv-feature-launcher-action',
+    text: 'Extract candidates',
+  });
+  button.type = 'button';
+  button.addEventListener('click', () => {
+    if (!built) {
+      built = true;
+      reviewHost.replaceChildren(buildReview(input, review));
+    }
+    onLaunch();
+  });
+  card.append(button);
+
+  launcherHost.replaceChildren(card);
+
+  return {
+    dispose: () => {
+      launcherHost.replaceChildren();
+      reviewHost.replaceChildren();
+    },
+  };
+}
+
+/** Build the review list element from the extraction input. */
+function buildReview(input: FeatureExtractionInput, review: CandidateReviewStore): HTMLElement {
+  const root = el('div', { className: 'olv-feature-review' });
+
+  if (input.classificationIsDerived) {
+    root.append(
+      el('p', {
+        className: 'olv-feature-note olv-feature-derived',
+        text: 'These candidates are built on the viewer’s own heuristic classification, not classes from the file — a candidate about a guess.',
+      }),
+    );
+  }
+
+  const buildings = extractBuildingCandidates(
+    input.buildingPoints,
+    input.buildingGrid,
+    input.unit,
+  );
+  const conductor = extractConductorCandidate(input.conductorPoints, input.unit, input.up);
+  const conductors = conductor ? [conductor] : [];
+
+  root.append(renderBuildingSection(buildings, review));
+  root.append(renderConductorSection(conductors, input.conductorPoints.length, review));
+  return root;
+}
+
+function statusChips(
+  id: string,
+  review: CandidateReviewStore,
+  row: HTMLElement,
+): HTMLElement {
+  const chips = el('div', { className: 'olv-feature-chips' });
+  const paint = (): void => {
+    const status: CandidateStatus = review.statusOf(id);
+    row.dataset.status = status;
+    for (const [value, btn] of entries) {
+      btn.classList.toggle('is-active', value === status);
+      btn.setAttribute('aria-pressed', value === status ? 'true' : 'false');
+    }
+  };
+  const entries: ReadonlyArray<readonly [CandidateStatus, HTMLButtonElement]> = (
+    [
+      ['accepted', 'Accept'],
+      ['review', 'Pending'],
+      ['rejected', 'Reject'],
+    ] as ReadonlyArray<readonly [CandidateStatus, string]>
+  ).map(([value, label]) => {
+    const btn = el('button', { className: 'olv-feature-chip', text: label });
+    btn.type = 'button';
+    btn.addEventListener('click', () => {
+      if (value === 'accepted') review.accept(id);
+      else if (value === 'rejected') review.reject(id);
+      else review.reset(id);
+      paint();
+    });
+    chips.append(btn);
+    return [value, btn] as const;
+  });
+  paint();
+  return chips;
+}
+
+function renderBuildingSection(
+  buildings: readonly BuildingCandidate[],
+  review: CandidateReviewStore,
+): HTMLElement {
+  const section = el('div', { className: 'olv-feature-section' });
+  section.append(
+    el('h4', { text: `Building footprints — ${buildings.length} candidate(s)` }),
+  );
+  section.append(
+    el('p', {
+      className: 'olv-feature-note',
+      text: 'Connected regions of building-classified points. A region can be trees or noise that survived classification; it is not asserted to be a building.',
+    }),
+  );
+  if (buildings.length === 0) {
+    section.append(el('p', { className: 'olv-feature-empty', text: 'No footprint candidates.' }));
+    return section;
+  }
+  for (const b of buildings) {
+    const row = el('div', { className: 'olv-feature-row' });
+    row.append(el('div', { className: 'olv-feature-id', text: b.id }));
+    row.append(
+      el('div', {
+        className: 'olv-feature-measure',
+        text: `Area ${measure(b.areaSource, b.areaM2, 'm²')} · ${b.cellCount} cells`,
+      }),
+    );
+    row.append(statusChips(b.id, review, row));
+    section.append(row);
+  }
+  return section;
+}
+
+function renderConductorSection(
+  conductors: readonly ConductorCandidate[],
+  wirePointCount: number,
+  review: CandidateReviewStore,
+): HTMLElement {
+  const section = el('div', { className: 'olv-feature-section' });
+  section.append(el('h4', { text: `Conductor fit — ${conductors.length} candidate(s)` }));
+  section.append(
+    el('p', {
+      className: 'olv-feature-note',
+      text: 'A single parabolic fit over all wire-classified points — a small-sag approximation, not a calibrated catenary. The fit is declined when the points are not linear enough to be one span.',
+    }),
+  );
+  if (conductors.length === 0) {
+    section.append(
+      el('p', {
+        className: 'olv-feature-empty',
+        text:
+          wirePointCount > 0
+            ? 'Wire points were present but did not fit a single conductor span.'
+            : 'No wire-classified points.',
+      }),
+    );
+    return section;
+  }
+  for (const c of conductors) {
+    const row = el('div', { className: 'olv-feature-row' });
+    row.append(el('div', { className: 'olv-feature-id', text: c.id }));
+    row.append(
+      el('div', {
+        className: 'olv-feature-measure',
+        text: `Span ${measure(c.spanSource, c.spanM, 'm')} · sag ${measure(c.sagSource, c.sagM, 'm')} · linearity ${c.linearity.toFixed(3)} · RMS ${measure(c.residualRmsSource, c.residualRmsM, 'm')}`,
+      }),
+    );
+    row.append(statusChips(c.id, review, row));
+    section.append(row);
+  }
+  return section;
+}

--- a/tests/e2e/featureCandidates.spec.ts
+++ b/tests/e2e/featureCandidates.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  activate,
+  dropTinyLas,
+  dropTinyPly,
+  expectHittable,
+  railChromeSettled,
+  showWorkspaceMode,
+} from './helpers';
+
+/**
+ * Feature-candidate review surface (v0.6.8) — the context-sensitive launcher.
+ *
+ * The contract: the launcher appears ONLY for a scan that carries a
+ * classification, and the review list is honest — every result is a DERIVED
+ * candidate, never a detected building or surveyed conductor.
+ *
+ * `tiny.las` carries a classification including class 6 (building) and no class
+ * 14 (wire), so it drives both the building-candidate path and the "no wire
+ * points" path. `tiny.ply` carries no classification, so it drives the absence
+ * assertion. The extraction maths itself is pinned in the Node tests.
+ */
+async function openAnalyse(page: Page): Promise<void> {
+  await showWorkspaceMode(page, 'analyse');
+  const panel = page.locator('.olv-analyse-panel');
+  await expect(panel).toBeVisible({ timeout: 20_000 });
+  if (await panel.evaluate((el) => el.classList.contains('olv-collapsed'))) {
+    await panel.locator('.olv-panel-head').click();
+  }
+}
+
+test('offers feature candidates for a classified scan, framed as candidates', async ({ page }) => {
+  await page.goto('/?test=1');
+  await dropTinyLas(page);
+  await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
+  await railChromeSettled(page);
+  await openAnalyse(page);
+
+  const launcher = page.locator('.olv-feature-launcher');
+  await expect(launcher).toBeVisible({ timeout: 20_000 });
+  // The launcher states the honest framing before anything is extracted.
+  await expect(launcher).toContainText('derived candidate');
+
+  await expect(page.locator('.olv-feature-review')).toBeHidden();
+  const extract = launcher.locator('.olv-feature-launcher-action');
+  await expectHittable(extract);
+  await activate(extract);
+
+  const review = page.locator('.olv-feature-review');
+  await expect(review).toBeVisible();
+  // Both sections render; the conductor path is the "no wire points" one.
+  await expect(review).toContainText('Building footprints');
+  await expect(review).toContainText('Conductor fit');
+  await expect(review).toContainText('No wire-classified points');
+});
+
+test('offers no feature candidates for a scan with no classification', async ({ page }) => {
+  await page.goto('/?test=1');
+  await dropTinyPly(page);
+  await expect(page.locator('.olv-empty')).toBeHidden({ timeout: 20_000 });
+  await railChromeSettled(page);
+  await openAnalyse(page);
+
+  // tiny.ply carries RGB only, no classification channel, so the launcher
+  // never appears.
+  expect(await page.locator('.olv-feature-launcher').count()).toBe(0);
+});

--- a/tests/featureExtractionInput.test.ts
+++ b/tests/featureExtractionInput.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { buildFeatureExtractionInput } from '../src/app/featureExtractionInput';
+import type { PointCloud } from '../src/model/PointCloud';
+
+/**
+ * tests/featureExtractionInput.test.ts
+ *
+ * The bridge from a loaded cloud to the feature cores. What is guarded here is
+ * exactly what the review surface trusts: which points are building vs wire, the
+ * horizontal pair by up axis, and the fail-CLOSED unit derivation (a missing CRS
+ * must read as unknown, never as metres).
+ */
+
+/** A minimal cloud stub — only the fields the builder reads. */
+function stub(fields: Partial<PointCloud>): PointCloud {
+  return {
+    positions: new Float32Array(0),
+    classification: undefined,
+    classificationIsDerived: false,
+    sourceFormat: 'las',
+    metadata: undefined,
+    ...fields,
+  } as unknown as PointCloud;
+}
+
+describe('buildFeatureExtractionInput', () => {
+  it('returns null when the cloud has no classification', () => {
+    expect(buildFeatureExtractionInput(stub({ positions: new Float32Array([0, 0, 0]) }))).toBeNull();
+  });
+
+  it('returns null when no point is building- or wire-classified', () => {
+    const input = buildFeatureExtractionInput(
+      stub({
+        positions: new Float32Array([0, 0, 0, 1, 1, 1]),
+        classification: new Uint8Array([2, 5]), // ground, high vegetation
+      }),
+    );
+    expect(input).toBeNull();
+  });
+
+  it('splits building (6) and wire (14) points, Z-up using (x, y) horizontal', () => {
+    const input = buildFeatureExtractionInput(
+      stub({
+        // building at (10, 20, 3), wire at (1, 2, 40)
+        positions: new Float32Array([10, 20, 3, 1, 2, 40]),
+        classification: new Uint8Array([6, 14]),
+        sourceFormat: 'las',
+      }),
+    );
+    expect(input).not.toBeNull();
+    expect(input!.buildingPoints).toEqual([{ x: 10, y: 20 }]);
+    expect(input!.conductorPoints).toEqual([[1, 2, 40]]);
+    expect(input!.up).toEqual([0, 0, 1]);
+  });
+
+  it('uses (x, z) horizontal for a Y-up format', () => {
+    const input = buildFeatureExtractionInput(
+      stub({
+        positions: new Float32Array([10, 99, 20]), // y is up, so horizontal is (x=10, z=20)
+        classification: new Uint8Array([6]),
+        sourceFormat: 'ply',
+      }),
+    );
+    expect(input!.buildingPoints).toEqual([{ x: 10, y: 20 }]);
+    expect(input!.up).toEqual([0, 1, 0]);
+  });
+
+  it('derives a KNOWN unit only when the CRS declares one', () => {
+    const known = buildFeatureExtractionInput(
+      stub({
+        positions: new Float32Array([0, 0, 0]),
+        classification: new Uint8Array([6]),
+        metadata: { crs: { linearUnit: 'foot', linearUnitToMetres: 0.3048 } },
+      } as unknown as Partial<PointCloud>),
+    );
+    expect(known!.unit.known).toBe(true);
+  });
+
+  it('fails CLOSED to an unknown unit when no CRS is present', () => {
+    const input = buildFeatureExtractionInput(
+      stub({
+        positions: new Float32Array([0, 0, 0]),
+        classification: new Uint8Array([6]),
+        metadata: undefined,
+      }),
+    );
+    expect(input!.unit.known).toBe(false);
+  });
+
+  it('fails CLOSED when the CRS linear unit is unknown', () => {
+    const input = buildFeatureExtractionInput(
+      stub({
+        positions: new Float32Array([0, 0, 0]),
+        classification: new Uint8Array([6]),
+        metadata: { crs: { linearUnit: 'unknown', linearUnitToMetres: 1 } },
+      } as unknown as Partial<PointCloud>),
+    );
+    expect(input!.unit.known).toBe(false);
+  });
+
+  it('carries the derived-classification flag through', () => {
+    const input = buildFeatureExtractionInput(
+      stub({
+        positions: new Float32Array([0, 0, 0]),
+        classification: new Uint8Array([6]),
+        classificationIsDerived: true,
+      }),
+    );
+    expect(input!.classificationIsDerived).toBe(true);
+  });
+});

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -9692,6 +9692,129 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
   font-variant-numeric: tabular-nums;
   background: var(--olv-surface-2, rgba(255, 255, 255, 0.06));
 }
+/*
+ * 98d-feature-candidates.css — the feature-candidate review surface.
+ *
+ * A context-sensitive launcher (shown only for a classified scan) and the
+ * candidate-review list behind it: building footprints and a conductor fit,
+ * each a derived candidate a reviewer accepts, rejects or leaves pending.
+ * Styled to match the Range Frame Workbench launcher next to it.
+ */
+
+.olv-feature-launcher {
+  margin-top: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border-radius: 10px;
+  background: var(--olv-surface-2, rgba(255, 255, 255, 0.03));
+}
+
+.olv-feature-launcher-head {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.55));
+}
+
+.olv-feature-launcher-title {
+  margin-top: 4px;
+  font-weight: 600;
+}
+
+.olv-feature-launcher-fact {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+}
+
+.olv-feature-launcher-message {
+  margin: 6px 0 10px;
+  font-size: 12px;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+}
+
+.olv-feature-launcher-action {
+  padding: 6px 12px;
+  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.16));
+  border-radius: 8px;
+  background: var(--olv-surface-3, rgba(255, 255, 255, 0.06));
+  color: inherit;
+  cursor: pointer;
+}
+
+.olv-feature-review {
+  margin-top: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.olv-feature-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.olv-feature-note {
+  margin: 0;
+  font-size: 12px;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+}
+
+.olv-feature-derived {
+  color: var(--olv-warn, #e0a33e);
+}
+
+.olv-feature-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.5));
+}
+
+.olv-feature-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-top: 1px solid var(--olv-border, rgba(255, 255, 255, 0.08));
+}
+
+.olv-feature-id {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12px;
+}
+
+.olv-feature-measure {
+  flex: 1 1 200px;
+  font-size: 12px;
+  color: var(--olv-text-dim, rgba(255, 255, 255, 0.75));
+  font-variant-numeric: tabular-nums;
+}
+
+.olv-feature-chips {
+  display: flex;
+  gap: 4px;
+}
+
+.olv-feature-chip {
+  padding: 3px 8px;
+  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.16));
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.olv-feature-chip.is-active {
+  background: var(--olv-accent, #4c9ffe);
+  border-color: var(--olv-accent, #4c9ffe);
+  color: #0b0b0d;
+}
 /* ═══════════════════════════════════════════════════════════════════════════
    MOBILE GUI REFRESH (v0.6.x) — hero-console material + accent on phones
    ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Graduates the stranded building-footprint and conductor-fit cores into a wired, honest surface.

A lazy **Feature Candidates** launcher appears in the Analyse panel whenever the active scan carries a classification. It reads the building-classified (ASPRS 6) and wire-classified (ASPRS 14) points, proposes footprint and conductor candidates via `FeatureExtractionService`, and lets a reviewer accept / reject / leave-pending each (`CandidateReviewStore`, keyed by geometry-derived id).

**Honesty framing (scientific-critical-thinking gate):**
- Every result is a *derived candidate*, never a detected building or surveyed conductor; no cadastral or survey-accuracy claim.
- Measures shown in the source unit always; metric twin only when the CRS declares a linear unit (fail-closed to `null`, guarding the missing-CRS trap).
- A conductor is one parabolic small-sag fit, labelled as such, declined when the points are not linear enough.
- A candidate built on the viewer's *derived* heuristic classification says so.

**Graduation:** removes `FeatureExtractionService`, `buildingFootprints`, `conductors`, `footprintTrace`, `candidateReview` from the staged register; adds `olv.feature.building-footprint` + `olv.feature.conductor-fit` to the method registry (new `feature` category). main.ts and Viewer.ts untouched by the ratchets (feature input reached only through the lazy chunk; main passes just the cloud).

Green: tsc, unit (8 new + methodRegistry + css-partition), all four ratchets (unreachable/position-access/monolith/module-graph), full archive-gate (30 lints). e2e added (`featureCandidates.spec.ts`).