### PR TITLE
fix(ui): button type, verify-modal a11y, severity aria-label

### DIFF
--- a/src/ui/dom.ts
+++ b/src/ui/dom.ts
@@ -40,8 +40,12 @@ export function el<K extends keyof HTMLElementTagNameMap>(
   if (props.tip) node.dataset.tip = props.tip;
   if (props.ariaLabel) node.setAttribute('aria-label', props.ariaLabel);
   if (props.href && node instanceof HTMLAnchorElement) node.href = props.href;
-  if (props.type && (node instanceof HTMLInputElement || node instanceof HTMLButtonElement))
-    node.type = props.type;
+  // `node.tagName === 'BUTTON'` rather than `instanceof HTMLButtonElement`: the
+  // unit-test DOM shim defines HTMLInputElement/HTMLAnchorElement but not
+  // HTMLButtonElement, so the instanceof would throw ReferenceError and break
+  // every el() caller. tagName works in the shim and in the browser alike.
+  if (props.type && (node instanceof HTMLInputElement || node.tagName === 'BUTTON'))
+    (node as HTMLInputElement).type = props.type;
   for (const child of children) node.append(child);
   return node;
 }

--- a/src/ui/dom.ts
+++ b/src/ui/dom.ts
@@ -40,7 +40,8 @@ export function el<K extends keyof HTMLElementTagNameMap>(
   if (props.tip) node.dataset.tip = props.tip;
   if (props.ariaLabel) node.setAttribute('aria-label', props.ariaLabel);
   if (props.href && node instanceof HTMLAnchorElement) node.href = props.href;
-  if (props.type && node instanceof HTMLInputElement) node.type = props.type;
+  if (props.type && (node instanceof HTMLInputElement || node instanceof HTMLButtonElement))
+    node.type = props.type;
   for (const child of children) node.append(child);
   return node;
 }

--- a/src/ui/issueSeverityStyle.ts
+++ b/src/ui/issueSeverityStyle.ts
@@ -45,5 +45,5 @@ export function severityText(severity: IssueSeverity): string {
  * reader, so the name has to carry the rank in words.
  */
 export function severityAriaLabel(severity: IssueSeverity): string {
-  return `Severity: ${severity}`;
+  return `Severity: ${SEVERITY_LABEL[severity]}`;
 }

--- a/src/ui/reportVerifier.ts
+++ b/src/ui/reportVerifier.ts
@@ -38,6 +38,12 @@ export function showReportVerification(result: VerifyReportResult): void {
     'min-width:300px;max-width:440px;padding:18px 20px;border-radius:12px;' +
     'background:var(--panel);border:1px solid var(--hairline);color:var(--text);' +
     'box-shadow:0 8px 30px rgba(0,0,0,0.5);display:flex;flex-direction:column;gap:10px;';
+  // Dialog semantics, matching the app's other modals (Modal.ts, TourOverlay):
+  // a screen reader announces the boundary and reads the verdict headline as the
+  // accessible name, so the tamper/intact result is conveyed, not just coloured.
+  card.setAttribute('role', 'dialog');
+  card.setAttribute('aria-modal', 'true');
+  card.setAttribute('aria-labelledby', 'olv-verify-status');
 
   // Status headline — colour carries the verdict, the WORD carries it too. A
   // digest match with a NON-cryptographic (FNV-1a) checksum is forgeable, so it
@@ -45,6 +51,7 @@ export function showReportVerification(result: VerifyReportResult): void {
   const ok = result.valid;
   const weak = ok && result.cryptographic === false;
   const status = document.createElement('div');
+  status.id = 'olv-verify-status';
   let statusTestid: string;
   if (!ok) {
     statusTestid = 'report-verify-invalid';

--- a/tests/annotationIssuePanel.test.ts
+++ b/tests/annotationIssuePanel.test.ts
@@ -366,7 +366,7 @@ describe('the issue view ranks open issues worst first', () => {
     // Four distinct glyphs: the rank survives greyscale and forced colours.
     expect(new Set(marks.map((m) => m.textContent)).size).toBe(4);
     for (const mark of marks) {
-      expect(mark.getAttribute('aria-label')).toMatch(/^Severity: (low|medium|high|critical)$/);
+      expect(mark.getAttribute('aria-label')).toMatch(/^Severity: (Low|Medium|High|Critical)$/);
     }
     // And the word itself is on the section header above the rows.
     expect(panel.headers().map((h) => h.textContent).join(' ')).toContain('Critical');

--- a/tests/e2e/reportVerify.spec.ts
+++ b/tests/e2e/reportVerify.spec.ts
@@ -75,6 +75,12 @@ test('an exported report verifies as intact', async ({ page }) => {
   await verifyWith(page, reportPath);
   await expect(page.locator('[data-testid="report-verify-valid"]')).toBeVisible({ timeout: 10_000 });
   await expect(page.locator('[data-testid="report-verify-valid"]')).toHaveText(/intact/i);
+  // The verdict is announced: the modal carries dialog semantics, matching the
+  // app's other modals, so a screen reader conveys the intact/tamper result.
+  await expect(page.locator('[data-testid="report-verify"] [role="dialog"]')).toHaveAttribute(
+    'aria-modal',
+    'true',
+  );
   await page.locator('[data-testid="report-verify-close"]').click();
   await expect(page.locator('[data-testid="report-verify"]')).toHaveCount(0);
 });

--- a/tests/issueSeverityStyle.test.ts
+++ b/tests/issueSeverityStyle.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import {
+  severityAriaLabel,
+  severityText,
+  SEVERITY_LABEL,
+} from '../src/ui/issueSeverityStyle';
+import type { IssueSeverity } from '../src/render/annotate/issueWorkflow';
+
+/**
+ * tests/issueSeverityStyle.test.ts
+ *
+ * The module's job is one canonical presentation of the four ranks. The
+ * accessible name must use the same capitalised word the sighted label shows,
+ * not the raw lowercase enum.
+ */
+const RANKS: readonly IssueSeverity[] = ['low', 'medium', 'high', 'critical'];
+
+describe('severityAriaLabel', () => {
+  it('uses the capitalised label, not the raw enum', () => {
+    expect(severityAriaLabel('high')).toBe('Severity: High');
+    expect(severityAriaLabel('low')).toBe('Severity: Low');
+  });
+
+  it('matches the word shown in the visible severityText for every rank', () => {
+    for (const r of RANKS) {
+      expect(severityAriaLabel(r)).toBe(`Severity: ${SEVERITY_LABEL[r]}`);
+      expect(severityText(r).endsWith(SEVERITY_LABEL[r])).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Three isolated quick wins, each in a self-contained module:

1. **el() dropped type on buttons** (src/ui/dom.ts) — the helper applied type only to HTMLInputElement, so 40+ el('button', {type:'button'}) sites silently no-op'd (a bare button defaults to type=submit). Now also honored for HTMLButtonElement. Defensive correctness; DOM behavior is e2e territory (node-only unit suite has no jsdom).
2. **Report-verify modal a11y** (src/ui/reportVerifier.ts) — added role=dialog + aria-modal + aria-labelledby (the verdict headline), matching Modal.ts/TourOverlay. e2e assertion added.
3. **Severity aria-label** (src/ui/issueSeverityStyle.ts) — used the raw lowercase enum; now uses capitalised SEVERITY_LABEL so the accessible name matches the visible word. Unit test added.

tsc clean; unit test green. No ratcheted files, no baselines, no new .positions/CSS.