### PR TITLE
fix(ui): reduced-motion guard, recoverable truncated names, disabled-export reason

### DIFF
--- a/src/styles/55-micro-interactions.css
+++ b/src/styles/55-micro-interactions.css
@@ -53,3 +53,20 @@
   pointer-events: auto; user-select: none;
 }
 
+
+/* Respect a reduced-motion preference: hold the health dots static and drop the
+   entrance motion, matching the guards the other section files already carry.
+   The pulse is INFINITE, so it is the one that most needs silencing. */
+@media (prefers-reduced-motion: reduce) {
+  .olv-status-warn,
+  .olv-status-fail {
+    animation: none;
+  }
+  .olv-inspector,
+  .olv-navbar,
+  .olv-dock,
+  .olv-backend,
+  .olv-version {
+    animation: none;
+  }
+}

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -2759,7 +2759,10 @@ export class AnalysePanel {
     }
     // Without a regeneration callback we cannot change the interval honestly —
     // lock the picker to the current deliverable so the file matches the panel.
-    if (!canRegen) intervalSel.disabled = true;
+    if (!canRegen) {
+      intervalSel.disabled = true;
+      intervalSel.title = 'Locked to the current deliverable so the exported file matches the panel.';
+    }
 
     // Contour shape style — seeded from the panel's current choice; drives the
     // shape of the plotted contours on the sheet.
@@ -2773,7 +2776,10 @@ export class AnalysePanel {
       if (opt.value === this._contourStyle) o.selected = true;
       styleSel.append(o);
     }
-    if (!canRegen) styleSel.disabled = true;
+    if (!canRegen) {
+      styleSel.disabled = true;
+      styleSel.title = 'Locked to the current deliverable so the exported file matches the panel.';
+    }
 
     const filenameInput = document.createElement('input');
     filenameInput.type = 'text';

--- a/src/ui/BatchConverter.ts
+++ b/src/ui/BatchConverter.ts
@@ -206,7 +206,7 @@ export class BatchConverter {
         this._refresh();
       });
       row.append(
-        el('span', { className: 'olv-bc-file-name', text: f.name }),
+        el('span', { className: 'olv-bc-file-name', text: f.name, title: f.name }),
         el('span', { className: 'olv-bc-file-size', text: formatBytes(f.sizeBytes) }),
         remove,
       );
@@ -416,7 +416,7 @@ export class BatchConverter {
       const top = el('div', { className: 'olv-bc-row-top' });
       top.append(
         el('span', { className: 'olv-bc-row-icon', text: ok ? '●' : '▲' }),
-        el('span', { className: 'olv-bc-row-name', text: r.source }),
+        el('span', { className: 'olv-bc-row-name', text: r.source, title: r.source }),
         el('span', { className: 'olv-bc-row-meta', text: ok ? `${r.report.pointCount.toLocaleString()} pts · ${r.report.crsNote}` : 'failed' }),
       );
       if (ok && r.file) {

--- a/tests/e2e/batchConverter.spec.ts
+++ b/tests/e2e/batchConverter.spec.ts
@@ -44,3 +44,23 @@ test('the modal closes via the backdrop and the ✕ button', async ({ page }) =>
   await page.locator('.olv-bc-close').click();
   await expect(page.locator('.olv-bc-dialog')).toBeHidden();
 });
+
+test('a queued file whose name truncates carries a title so the full name is recoverable', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('.olv-convert-chip').click();
+  const dialog = page.locator('.olv-bc-dialog');
+  await expect(dialog).toBeVisible();
+
+  const longName = '2024-survey-north-tile-047-final-revision.las';
+  await dialog.locator('.olv-file-input').setInputFiles({
+    name: longName,
+    mimeType: 'application/octet-stream',
+    buffer: Buffer.from([0x4c, 0x41, 0x53, 0x46]), // 'LASF' — enough to be listed
+  });
+
+  const nameCell = dialog.locator('.olv-bc-file-name').first();
+  await expect(nameCell).toHaveText(longName);
+  // The cell truncates with an ellipsis in CSS; the title makes the full name
+  // recoverable on hover rather than lost.
+  await expect(nameCell).toHaveAttribute('title', longName);
+});

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -2412,6 +2412,23 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   pointer-events: auto; user-select: none;
 }
 
+
+/* Respect a reduced-motion preference: hold the health dots static and drop the
+   entrance motion, matching the guards the other section files already carry.
+   The pulse is INFINITE, so it is the one that most needs silencing. */
+@media (prefers-reduced-motion: reduce) {
+  .olv-status-warn,
+  .olv-status-fail {
+    animation: none;
+  }
+  .olv-inspector,
+  .olv-navbar,
+  .olv-dock,
+  .olv-backend,
+  .olv-version {
+    animation: none;
+  }
+}
 /* Export buttons (Inspector)
  *
  * Two layouts share the same `.olv-export-btn` styling:

--- a/tests/microInteractionsReducedMotion.test.ts
+++ b/tests/microInteractionsReducedMotion.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * tests/microInteractionsReducedMotion.test.ts
+ *
+ * The health-status dots pulse on an INFINITE animation and the chrome panels
+ * slide in on mount. A viewer who asked the OS to reduce motion must get neither
+ * — so 55-micro-interactions.css has to carry a `prefers-reduced-motion` guard,
+ * like the other section files already do. This pins that guard so it can't be
+ * dropped in a later edit.
+ */
+const css = readFileSync(
+  fileURLToPath(new URL('../src/styles/55-micro-interactions.css', import.meta.url)),
+  'utf8',
+);
+
+describe('55-micro-interactions.css reduced-motion guard', () => {
+  it('declares a prefers-reduced-motion: reduce block', () => {
+    expect(css).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+  });
+
+  it('silences the infinite health-dot pulse under reduced motion', () => {
+    // The block must set animation:none for the status dots. Extract the block
+    // and confirm both the selector and the reset are inside it.
+    const block = css.slice(css.indexOf('prefers-reduced-motion'));
+    expect(block).toContain('.olv-status-fail');
+    expect(block).toMatch(/animation:\s*none/);
+  });
+
+  it('still defines the infinite pulse it is guarding (guard is not vacuous)', () => {
+    expect(css).toMatch(/olv-dot-pulse[^;]*infinite/);
+  });
+});


### PR DESCRIPTION
Three **visibly-noticeable** UI/UX quick wins (found by a scout that honestly stopped at 3 — the codebase is already a11y-mature):

1. **Reduced-motion guard (highest impact).** `55-micro-interactions.css` had *no* `prefers-reduced-motion` block, yet defines an **infinite** health-dot pulse and panel slide-ins. A motion-sensitive user saw perpetual pulsing + entrance motion. Added the guard (`animation: none`) matching the 14 other section files. Fixture regenerated; pinned by `tests/microInteractionsReducedMotion.test.ts`.
2. **Truncated filenames were unrecoverable.** Batch-converter rows truncate long names with an ellipsis but carried no `title` — the rest of `2024-survey-north-tile-047-final.laz` was simply lost. Added `title=name` on the queue + result rows; e2e (`batchConverter.spec.ts`) queues a long-named file and asserts the title.
3. **Silently-disabled export selects.** The Analyse map-export dialog greyed out the interval + style dropdowns with the reason only in a code comment; added a `title` telling the user they're locked to the current deliverable so the file matches the panel.

Scope: two `src/ui/*.ts` files + one `src/styles/*.css` (fixture regenerated). No monoliths, no `.positions`, no methodRegistry. tsc 0; reduced-motion + partition + mono tests green; 30-lint archive-gate OK. Win 3 is a trivial `title` on a modal state not cheaply reached by e2e — shipped tsc-verified without a dedicated test.