### PR TITLE
fix(ui): flip Range Workbench & Feature Candidates to real theme tokens; group large counts

### DIFF
--- a/src/styles/98c-range-workbench.css
+++ b/src/styles/98c-range-workbench.css
@@ -8,9 +8,9 @@
 .olv-range-launcher {
   margin: 12px 0;
   padding: 12px 14px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--hairline);
   border-radius: 10px;
-  background: var(--olv-surface-2, rgba(255, 255, 255, 0.03));
+  background: var(--panel-raised);
 }
 
 .olv-range-launcher-head {
@@ -41,7 +41,7 @@
 .olv-range-workbench {
   margin: 0 0 14px;
   padding: 12px 14px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--hairline);
   border-radius: 10px;
 }
 
@@ -68,7 +68,7 @@
 .olv-range-mode {
   padding: 4px 10px;
   font-size: 12px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.16));
+  border: 1px solid var(--hairline);
   border-radius: 999px;
   background: transparent;
   color: inherit;
@@ -76,8 +76,8 @@
 }
 
 .olv-range-mode.is-active {
-  background: var(--olv-accent, #2f7fd8);
-  border-color: var(--olv-accent, #2f7fd8);
+  background: var(--accent);
+  border-color: var(--accent);
   color: #fff;
 }
 
@@ -123,7 +123,7 @@
   margin-top: 6px;
   padding: 8px 10px;
   border-radius: 8px;
-  background: var(--olv-surface-2, rgba(255, 255, 255, 0.04));
+  background: var(--panel-raised);
 }
 
 .olv-range-readout-head {
@@ -197,7 +197,7 @@
 
 .olv-range-total th,
 .olv-range-total td {
-  border-top: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border-top: 1px solid var(--hairline);
   opacity: 1;
 }
 
@@ -219,5 +219,5 @@
   padding: 2px 5px;
   border-radius: 4px;
   font-variant-numeric: tabular-nums;
-  background: var(--olv-surface-2, rgba(255, 255, 255, 0.06));
+  background: var(--panel-raised);
 }

--- a/src/styles/98d-feature-candidates.css
+++ b/src/styles/98d-feature-candidates.css
@@ -10,16 +10,16 @@
 .olv-feature-launcher {
   margin-top: 10px;
   padding: 12px 14px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--hairline);
   border-radius: 10px;
-  background: var(--olv-surface-2, rgba(255, 255, 255, 0.03));
+  background: var(--panel-raised);
 }
 
 .olv-feature-launcher-head {
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.55));
+  color: var(--text-dim);
 }
 
 .olv-feature-launcher-title {
@@ -30,20 +30,20 @@
 .olv-feature-launcher-fact {
   margin-top: 4px;
   font-size: 12px;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+  color: var(--text-dim);
 }
 
 .olv-feature-launcher-message {
   margin: 6px 0 10px;
   font-size: 12px;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+  color: var(--text-dim);
 }
 
 .olv-feature-launcher-action {
   padding: 6px 12px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.16));
+  border: 1px solid var(--hairline);
   border-radius: 8px;
-  background: var(--olv-surface-3, rgba(255, 255, 255, 0.06));
+  background: var(--panel-raised);
   color: inherit;
   cursor: pointer;
 }
@@ -51,7 +51,7 @@
 .olv-feature-review {
   margin-top: 10px;
   padding: 12px 14px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--hairline);
   border-radius: 10px;
   display: flex;
   flex-direction: column;
@@ -67,17 +67,17 @@
 .olv-feature-note {
   margin: 0;
   font-size: 12px;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+  color: var(--text-dim);
 }
 
 .olv-feature-derived {
-  color: var(--olv-warn, #e0a33e);
+  color: var(--warn);
 }
 
 .olv-feature-empty {
   margin: 0;
   font-size: 12px;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.5));
+  color: var(--text-dim);
 }
 
 .olv-feature-row {
@@ -86,7 +86,7 @@
   align-items: center;
   gap: 8px;
   padding: 6px 0;
-  border-top: 1px solid var(--olv-border, rgba(255, 255, 255, 0.08));
+  border-top: 1px solid var(--hairline);
 }
 
 .olv-feature-id {
@@ -97,7 +97,7 @@
 .olv-feature-measure {
   flex: 1 1 200px;
   font-size: 12px;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.75));
+  color: var(--text-dim);
   font-variant-numeric: tabular-nums;
 }
 
@@ -108,7 +108,7 @@
 
 .olv-feature-chip {
   padding: 3px 8px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.16));
+  border: 1px solid var(--hairline);
   border-radius: 999px;
   background: transparent;
   color: inherit;
@@ -117,7 +117,7 @@
 }
 
 .olv-feature-chip.is-active {
-  background: var(--olv-accent, #4c9ffe);
-  border-color: var(--olv-accent, #4c9ffe);
+  background: var(--accent);
+  border-color: var(--accent);
   color: #0b0b0d;
 }

--- a/src/ui/RangeWorkbench.ts
+++ b/src/ui/RangeWorkbench.ts
@@ -400,13 +400,13 @@ export class RangeWorkbench {
       const tr = el('tr');
       tr.append(
         el('th', { text: CELL_STATE_LABEL[state] }),
-        el('td', { text: String(share.count) }),
+        el('td', { text: share.count.toLocaleString() }),
         el('td', { text: pct(share.fraction) }),
       );
       table.append(tr);
     }
     const total = el('tr', { className: 'olv-range-total' });
-    total.append(el('th', { text: 'Cells' }), el('td', { text: String(summary.validity.cells) }), el('td'));
+    total.append(el('th', { text: 'Cells' }), el('td', { text: summary.validity.cells.toLocaleString() }), el('td'));
     table.append(total);
     validity.append(table);
     this._stats.append(validity);
@@ -421,9 +421,9 @@ export class RangeWorkbench {
         tr.append(el('th', { text: name }), el('td', { text: value }));
         rt.append(tr);
       };
-      row('Cells with a range', String(r.finiteCount));
-      row('Returns with no representable range', String(r.excludedNonFinite));
-      row('Cells that never carried a range', String(r.cellsWithoutRange));
+      row('Cells with a range', r.finiteCount.toLocaleString());
+      row('Returns with no representable range', r.excludedNonFinite.toLocaleString());
+      row('Cells that never carried a range', r.cellsWithoutRange.toLocaleString());
       row('Nearest', rangeNum(r.min));
       row('Farthest', rangeNum(r.max));
       row('Median', rangeNum(r.median));

--- a/src/ui/featureCandidatesMount.ts
+++ b/src/ui/featureCandidatesMount.ts
@@ -102,7 +102,7 @@ export function mountFeatureCandidates(
     };
   }
 
-  const counts = `${input.buildingPoints.length} building-classified, ${input.conductorPoints.length} wire-classified point(s)`;
+  const counts = `${input.buildingPoints.length.toLocaleString()} building-classified, ${input.conductorPoints.length.toLocaleString()} wire-classified point(s)`;
   card.append(el('div', { className: 'olv-feature-launcher-fact', text: counts }));
   card.append(
     el('p', {

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -9523,9 +9523,9 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 .olv-range-launcher {
   margin: 12px 0;
   padding: 12px 14px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--hairline);
   border-radius: 10px;
-  background: var(--olv-surface-2, rgba(255, 255, 255, 0.03));
+  background: var(--panel-raised);
 }
 
 .olv-range-launcher-head {
@@ -9556,7 +9556,7 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 .olv-range-workbench {
   margin: 0 0 14px;
   padding: 12px 14px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--hairline);
   border-radius: 10px;
 }
 
@@ -9583,7 +9583,7 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 .olv-range-mode {
   padding: 4px 10px;
   font-size: 12px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.16));
+  border: 1px solid var(--hairline);
   border-radius: 999px;
   background: transparent;
   color: inherit;
@@ -9591,8 +9591,8 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 }
 
 .olv-range-mode.is-active {
-  background: var(--olv-accent, #2f7fd8);
-  border-color: var(--olv-accent, #2f7fd8);
+  background: var(--accent);
+  border-color: var(--accent);
   color: #fff;
 }
 
@@ -9638,7 +9638,7 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
   margin-top: 6px;
   padding: 8px 10px;
   border-radius: 8px;
-  background: var(--olv-surface-2, rgba(255, 255, 255, 0.04));
+  background: var(--panel-raised);
 }
 
 .olv-range-readout-head {
@@ -9712,7 +9712,7 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 
 .olv-range-total th,
 .olv-range-total td {
-  border-top: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border-top: 1px solid var(--hairline);
   opacity: 1;
 }
 
@@ -9734,7 +9734,7 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
   padding: 2px 5px;
   border-radius: 4px;
   font-variant-numeric: tabular-nums;
-  background: var(--olv-surface-2, rgba(255, 255, 255, 0.06));
+  background: var(--panel-raised);
 }
 /*
  * 98d-feature-candidates.css — the feature-candidate review surface.
@@ -9748,16 +9748,16 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 .olv-feature-launcher {
   margin-top: 10px;
   padding: 12px 14px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--hairline);
   border-radius: 10px;
-  background: var(--olv-surface-2, rgba(255, 255, 255, 0.03));
+  background: var(--panel-raised);
 }
 
 .olv-feature-launcher-head {
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.55));
+  color: var(--text-dim);
 }
 
 .olv-feature-launcher-title {
@@ -9768,20 +9768,20 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 .olv-feature-launcher-fact {
   margin-top: 4px;
   font-size: 12px;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+  color: var(--text-dim);
 }
 
 .olv-feature-launcher-message {
   margin: 6px 0 10px;
   font-size: 12px;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+  color: var(--text-dim);
 }
 
 .olv-feature-launcher-action {
   padding: 6px 12px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.16));
+  border: 1px solid var(--hairline);
   border-radius: 8px;
-  background: var(--olv-surface-3, rgba(255, 255, 255, 0.06));
+  background: var(--panel-raised);
   color: inherit;
   cursor: pointer;
 }
@@ -9789,7 +9789,7 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 .olv-feature-review {
   margin-top: 10px;
   padding: 12px 14px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--hairline);
   border-radius: 10px;
   display: flex;
   flex-direction: column;
@@ -9805,17 +9805,17 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 .olv-feature-note {
   margin: 0;
   font-size: 12px;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.65));
+  color: var(--text-dim);
 }
 
 .olv-feature-derived {
-  color: var(--olv-warn, #e0a33e);
+  color: var(--warn);
 }
 
 .olv-feature-empty {
   margin: 0;
   font-size: 12px;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.5));
+  color: var(--text-dim);
 }
 
 .olv-feature-row {
@@ -9824,7 +9824,7 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
   align-items: center;
   gap: 8px;
   padding: 6px 0;
-  border-top: 1px solid var(--olv-border, rgba(255, 255, 255, 0.08));
+  border-top: 1px solid var(--hairline);
 }
 
 .olv-feature-id {
@@ -9835,7 +9835,7 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 .olv-feature-measure {
   flex: 1 1 200px;
   font-size: 12px;
-  color: var(--olv-text-dim, rgba(255, 255, 255, 0.75));
+  color: var(--text-dim);
   font-variant-numeric: tabular-nums;
 }
 
@@ -9846,7 +9846,7 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 
 .olv-feature-chip {
   padding: 3px 8px;
-  border: 1px solid var(--olv-border, rgba(255, 255, 255, 0.16));
+  border: 1px solid var(--hairline);
   border-radius: 999px;
   background: transparent;
   color: inherit;
@@ -9855,8 +9855,8 @@ body.olv-cvd .olv-layerhealth-report-line[data-status="warn"] { color: #e69f00; 
 }
 
 .olv-feature-chip.is-active {
-  background: var(--olv-accent, #4c9ffe);
-  border-color: var(--olv-accent, #4c9ffe);
+  background: var(--accent);
+  border-color: var(--accent);
   color: #0b0b0d;
 }
 /* ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Two visible polish fixes, both in the two newest panels (Range Workbench, Feature Candidates):

**1. Light-theme legibility bug (I own this — introduced with gems F/I).** Both panels referenced an `--olv-*` custom-property namespace (`--olv-border`, `--olv-text-dim`, `--olv-surface-2/3`, `--olv-accent`, `--olv-warn`) that is **defined nowhere**, so their dark-only white-alpha *fallbacks* always won and never flipped. In light mode the dim captions and hairline borders rendered near-invisible (white-on-white) while every other panel flipped cleanly. Mapped the 6 tokens to the real, theme-redefined tokens (`--hairline`, `--text-dim`, `--panel-raised`, `--accent`, `--warn`). Verified the `--olv-*` references elsewhere are layout dimensions or correct real-token fallbacks — those are untouched. CSS fixture regenerated.

**2. Large counts without separators.** Range Workbench grid-cell/return counts and the Feature Candidates classified-point counts (tens of thousands to millions) rendered as raw digit runs (`786432`); now `toLocaleString()` so they group and align in the existing `tabular-nums` columns — matching every other readout.

Scope: 2 `src/styles/*.css` (fixture regen) + 2 `src/ui/*.ts`. No monoliths, no `.positions`. tsc 0; partition + mono green; 30-lint archive-gate OK. (Note: committed originally onto the merged #756 branch by mistake; moved to this fresh branch off main.)