### PR TITLE
feat(terrain): persistent terrain-core cache key contract (gem G Phase-0.5)

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -27,6 +27,13 @@
       "review": "2027-02-28"
     },
     {
+      "path": "src/terrain/contour/persistentCoreKey.ts",
+      "status": "staged",
+      "why": "The identity and invalidation contract for a persistent (across-reopen) terrain core cache: a full SHA-256 content fingerprint, the core-method generation string, and an integrity digest. It is the library half of the recompute-vs-reuse gate in tests/benchmark/terrainCoreRebuildCost.test.ts, which returned GO (conditional). No storage or reopen path is built, so nothing in the application computes a persistent key; only its own test imports it.",
+      "graduation": "A browser measurement of real OPFS read and deserialization confirms the reuse payoff, then the terrain analysis path keys a persisted core through this module and a monotonicity re-check graduates into the application graph.",
+      "review": "2027-02-28"
+    },
+    {
       "path": "src/classification/classificationEvidence.ts",
       "status": "staged",
       "why": "The per-point evidence record for a classification decision. The derived classifier that ships does not attach one, so no production module constructs or reads the record.",

--- a/src/terrain/contour/persistentCoreKey.ts
+++ b/src/terrain/contour/persistentCoreKey.ts
@@ -1,0 +1,173 @@
+/**
+ * persistentCoreKey.ts
+ *
+ * The identity + invalidation contract a *persistent* (across-reopen) terrain
+ * core cache must satisfy — the "Phase-0.5" library increment behind the
+ * recompute-vs-reuse gate in `tests/benchmark/terrainCoreRebuildCost.test.ts`.
+ *
+ * It deliberately stops short of any storage: no OPFS, no serialization of the
+ * core, no reopen wiring. The gate's own condition — "a browser measurement of
+ * real OPFS read + deserialization must confirm before any storage code is
+ * written" — still stands. What this module provides is the part that is pure,
+ * deterministic and fully Node-testable *now*: how a persisted core would be
+ * keyed, and exactly which input changes must force a miss.
+ *
+ * It differs from the in-memory {@link coreFingerprint} in two ways that only
+ * matter once a core outlives the process that computed it:
+ *
+ *   1. Source identity is a full SHA-256 of the position bytes, not the sampled
+ *      64-bit FNV the in-memory cache uses. The FNV sample hash is safe only
+ *      because `clearTerrainCoreCache()` scopes reuse to one open scan, where
+ *      the cloud is literally the same array; a persisted core is looked up
+ *      against a *freshly loaded* cloud, so a sample-collision would serve the
+ *      wrong terrain. A full digest removes that risk (collision here = a
+ *      cryptographic SHA-256 collision, not a sampling coincidence).
+ *
+ *   2. The key folds in a *method generation* — the id@version tag of every
+ *      registered method whose output is baked into a {@link TerrainCore}. The
+ *      in-memory cache can omit this because code cannot change mid-process; a
+ *      persisted core survives a deploy, so a method version bump must force a
+ *      miss or old-code science would be served silently. This mirrors the OOC
+ *      point cache's `cacheGeneration()`.
+ *
+ * The param-invalidation half is NOT re-implemented here: it reuses
+ * {@link paramsKey} verbatim, so the persistent key can never drift from the
+ * param coverage the in-memory cache already proves in `terrainCoreCache.test.ts`.
+ */
+
+import { methodRef, type MethodRef } from '../../science/methodRegistry';
+
+import { paramsKey } from './terrainCoreCache';
+import type { TerrainCoreParams } from './analyseContours';
+
+/**
+ * Bumped when the persistent key's own scheme changes (field order, digest
+ * input, generation format) in a way that must not match keys written under an
+ * older scheme. Independent of the method versions folded into the generation.
+ */
+export const PERSISTENT_CORE_KEY_VERSION = 1;
+
+/**
+ * The registered methods whose output is baked into an interval-INDEPENDENT
+ * {@link TerrainCore}. If any of these bumps its registry version, a core
+ * persisted under the old version is stale and must miss.
+ *
+ * Interval-stage methods (`olv.contour.*`) are deliberately excluded — they run
+ * *after* the core and are not part of it, exactly as the interval is excluded
+ * from {@link paramsKey}. Registration/volume/topology/feature methods are
+ * excluded because they are not inputs to the terrain core.
+ *
+ * Each id is asserted to exist in the registry by the accompanying test, so a
+ * rename breaks loudly rather than silently dropping a method from the key.
+ */
+export const TERRAIN_CORE_METHOD_IDS: readonly string[] = [
+  'olv.ground.smrf',
+  'olv.class.derived-heuristic',
+  'olv.dtm.idw-fill',
+  'olv.terrain.slope-horn',
+  'olv.terrain.vrm',
+  'olv.terrain.tpi',
+  'olv.validation.holdout-rmse',
+  'olv.validation.spatial-block',
+  'olv.validation.reliability-wilson',
+];
+
+/** Looks up a method's current registry version. Injectable for tests. */
+export type MethodVersionLookup = (id: string) => number;
+
+const registryVersion: MethodVersionLookup = (id) => methodRef(id).version;
+
+/**
+ * The core method generation: `id@version` for every {@link TERRAIN_CORE_METHOD_IDS}
+ * entry, ordered by id for stability, prefixed with the key-scheme version. A
+ * bump to any folded method's version — or to {@link PERSISTENT_CORE_KEY_VERSION}
+ * — changes this string, which changes every persistent key derived from it.
+ *
+ * `versionOf` defaults to the live registry; pass a custom lookup to model a
+ * version bump in a test without mutating the registry.
+ */
+export function coreMethodGeneration(
+  versionOf: MethodVersionLookup = registryVersion,
+): string {
+  const tags = [...TERRAIN_CORE_METHOD_IDS]
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    .map((id) => {
+      const ref: MethodRef = { id, version: versionOf(id) };
+      return `${ref.id}@${ref.version}`;
+    });
+  return `k${PERSISTENT_CORE_KEY_VERSION};${tags.join(',')}`;
+}
+
+/** Render a digest ArrayBuffer as lowercase hex. */
+function toHex(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let out = '';
+  for (let i = 0; i < bytes.length; i++) out += bytes[i].toString(16).padStart(2, '0');
+  return out;
+}
+
+/** SHA-256 of raw bytes, as lowercase hex. Uses the platform WebCrypto (browser
+ *  and Node 18+), matching the OOC file fingerprint. */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  // Copy into a fresh ArrayBuffer-backed view so `digest` hashes exactly these
+  // bytes (never a pooled buffer's neighbours) and the type is a plain
+  // ArrayBuffer, not the SharedArrayBuffer the generic Uint8Array admits.
+  const copy = new Uint8Array(bytes.length);
+  copy.set(bytes);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', copy);
+  return toHex(digest);
+}
+
+/**
+ * Cross-session-safe content identity for a position cloud: a full SHA-256 over
+ * the raw XYZ bytes, folded with the triple count so a truncation that leaves a
+ * prefix identical still differs. Unlike the in-memory FNV sample hash this is
+ * collision-free for practical purposes, which is what a persisted lookup
+ * against a freshly loaded cloud requires.
+ */
+export async function cryptoContentFingerprint(positions: Float32Array): Promise<string> {
+  const count = (positions.length / 3) | 0;
+  const view = new Uint8Array(
+    positions.buffer,
+    positions.byteOffset,
+    positions.byteLength,
+  );
+  const digest = await sha256Hex(view);
+  return `n${count}.${digest}`;
+}
+
+/**
+ * The persistent cache key for a (positions, core params) pair under a given
+ * method generation: `contentFingerprint # paramsKey # generation`. All three
+ * axes must match for a hit; a change in the cloud content, any core param, or
+ * any folded method version yields a different key (a miss).
+ *
+ * `generation` defaults to the live {@link coreMethodGeneration}; it is a
+ * parameter so a caller (or a test) can pin or vary it explicitly.
+ */
+export async function persistentCoreKey(
+  positions: Float32Array,
+  params: TerrainCoreParams,
+  generation: string = coreMethodGeneration(),
+): Promise<string> {
+  const content = await cryptoContentFingerprint(positions);
+  return `${content}#${paramsKey(params)}#${generation}`;
+}
+
+/**
+ * Integrity digest of a serialized payload — the SHA-256 a persisted entry
+ * would be verified against on read, so a truncated or corrupted blob is
+ * rejected rather than deserialized into wrong science. Provided here (pure,
+ * no storage) so the contract is testable before any storage code exists.
+ */
+export async function integrityDigest(bytes: Uint8Array): Promise<string> {
+  return sha256Hex(bytes);
+}
+
+/** True iff `bytes` still hashes to `expected`. A single flipped byte fails. */
+export async function verifyIntegrity(
+  bytes: Uint8Array,
+  expected: string,
+): Promise<boolean> {
+  return (await integrityDigest(bytes)) === expected;
+}

--- a/src/terrain/contour/terrainCoreCache.ts
+++ b/src/terrain/contour/terrainCoreCache.ts
@@ -219,7 +219,7 @@ function classificationHash(
  * classification length stay unchanged. Keying only presence + length would let
  * such an edit reuse a stale core and silently emit the wrong DTM.
  */
-function paramsKey(params: TerrainCoreParams): string {
+export function paramsKey(params: TerrainCoreParams): string {
   const g = params.ground;
   const ground = g
     ? [

--- a/tests/persistentCoreKey.test.ts
+++ b/tests/persistentCoreKey.test.ts
@@ -1,0 +1,176 @@
+/**
+ * persistentCoreKey.test.ts — the correctness contract a persistent (across-
+ * reopen) terrain core cache must satisfy, proven in Node with no storage.
+ *
+ * Properties:
+ *   1. Determinism — same positions + params + generation → same key.
+ *   2. Param invalidation — any core param change → a different key (reuses the
+ *      exact `paramsKey` the in-memory cache already proves, so coverage can't
+ *      drift; spot-checked here across the CRS/units/ground/class axes).
+ *   3. Content invalidation, crypto-strength — an edit the in-memory FNV SAMPLE
+ *      hash misses (an unsampled interior triple) still changes the persistent
+ *      key, because it keys on a full SHA-256. This is the cross-session safety
+ *      the sample hash cannot give.
+ *   4. Method-version invalidation — a bump to any folded core method's version
+ *      changes the generation and therefore the key (a persisted core computed
+ *      by old code must miss). Modelled via the injectable version lookup.
+ *   5. Registry integrity — every folded method id actually exists, so a rename
+ *      breaks loudly instead of silently dropping a method from the key.
+ *   6. Integrity digest — a payload verifies against its own digest; a single
+ *      flipped byte fails.
+ *
+ * Pure data: no DOM, no I/O, no OPFS.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { coreFingerprint } from '../src/terrain/contour/terrainCoreCache';
+import type { TerrainCoreParams } from '../src/terrain/contour/analyseContours';
+import {
+  persistentCoreKey,
+  coreMethodGeneration,
+  cryptoContentFingerprint,
+  integrityDigest,
+  verifyIntegrity,
+  TERRAIN_CORE_METHOD_IDS,
+  PERSISTENT_CORE_KEY_VERSION,
+} from '../src/terrain/contour/persistentCoreKey';
+import { method } from '../src/science/methodRegistry';
+
+/** Deterministic Float32Array of XYZ triples (length 3N). */
+function makeCloud(n: number, seed = 1): Float32Array {
+  const f = new Float32Array(n * 3);
+  let s = seed >>> 0;
+  for (let i = 0; i < f.length; i++) {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    f[i] = (s / 0xffffffff) * 100;
+  }
+  return f;
+}
+
+const BASE_PARAMS: TerrainCoreParams = {
+  cellSizeM: 2,
+  crs: 'EPSG:32610',
+  verticalDatum: 'EPSG:5703',
+};
+
+describe('coreMethodGeneration', () => {
+  it('every folded method id exists in the registry', () => {
+    for (const id of TERRAIN_CORE_METHOD_IDS) {
+      expect(method(id), `missing registry method: ${id}`).not.toBeNull();
+    }
+  });
+
+  it('is stable and ordered, and carries the key-scheme version', () => {
+    const gen = coreMethodGeneration();
+    expect(gen).toBe(coreMethodGeneration());
+    expect(gen.startsWith(`k${PERSISTENT_CORE_KEY_VERSION};`)).toBe(true);
+    // Tags are id-sorted: the joined body is already in ascending id order.
+    const body = gen.slice(gen.indexOf(';') + 1);
+    const ids = body.split(',').map((t) => t.slice(0, t.lastIndexOf('@')));
+    expect(ids).toEqual([...ids].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)));
+  });
+
+  it('changes when any folded method version bumps', () => {
+    const base = coreMethodGeneration();
+    const target = TERRAIN_CORE_METHOD_IDS[0];
+    const bumped = coreMethodGeneration((id) =>
+      id === target ? method(id)!.version + 1 : method(id)!.version,
+    );
+    expect(bumped).not.toBe(base);
+  });
+});
+
+describe('persistentCoreKey', () => {
+  it('is deterministic for the same positions + params + generation', async () => {
+    const pos = makeCloud(500);
+    const a = await persistentCoreKey(pos, BASE_PARAMS);
+    const b = await persistentCoreKey(pos, BASE_PARAMS);
+    expect(a).toBe(b);
+  });
+
+  it('misses on any core param change', async () => {
+    const pos = makeCloud(500);
+    const base = await persistentCoreKey(pos, BASE_PARAMS);
+    const variants: TerrainCoreParams[] = [
+      { ...BASE_PARAMS, cellSizeM: 1 },
+      { ...BASE_PARAMS, crs: 'EPSG:32611' },
+      { ...BASE_PARAMS, verticalDatum: 'EPSG:5701' },
+      { ...BASE_PARAMS, isGeographic: true },
+      { ...BASE_PARAMS, verticalUnitToMetres: 0.3048 },
+      { ...BASE_PARAMS, verticalAxis: 'y' },
+      { ...BASE_PARAMS, holdoutSeed: 7 },
+      { ...BASE_PARAMS, excludeClasses: [7] },
+      { ...BASE_PARAMS, ground: { slope: 0.2 } },
+      { ...BASE_PARAMS, samplePointScale: 4 },
+      { ...BASE_PARAMS, aggregation: 'mean' },
+      { ...BASE_PARAMS, latitudeDeg: 37 },
+    ];
+    for (const v of variants) {
+      expect(await persistentCoreKey(pos, v), JSON.stringify(v)).not.toBe(base);
+    }
+  });
+
+  it('misses on the SAME generation only when an input actually changed', async () => {
+    const pos = makeCloud(500);
+    const gen = coreMethodGeneration();
+    const a = await persistentCoreKey(pos, BASE_PARAMS, gen);
+    const b = await persistentCoreKey(pos, BASE_PARAMS, gen);
+    expect(a).toBe(b);
+  });
+
+  it('misses when the method generation changes, inputs held', async () => {
+    const pos = makeCloud(500);
+    const genA = coreMethodGeneration();
+    const genB = coreMethodGeneration((id) =>
+      id === TERRAIN_CORE_METHOD_IDS[0]
+        ? method(id)!.version + 1
+        : method(id)!.version,
+    );
+    const a = await persistentCoreKey(pos, BASE_PARAMS, genA);
+    const b = await persistentCoreKey(pos, BASE_PARAMS, genB);
+    expect(a).not.toBe(b);
+  });
+
+  it('catches an edit the in-memory FNV sample hash misses', async () => {
+    // 500 triples → the sample stride skips most interior triples. Editing an
+    // unsampled interior triple leaves the in-memory sample fingerprint
+    // unchanged (a would-be false HIT across sessions) but changes the full
+    // SHA-256, so the persistent key correctly misses.
+    const a = makeCloud(500);
+    const b = a.slice();
+    b[3] += 1; // triple index 1 (x): outside the first/last/stride samples
+    // Precondition: the in-memory sample hash collides on this edit.
+    expect(coreFingerprint(b, BASE_PARAMS)).toBe(coreFingerprint(a, BASE_PARAMS));
+    // The persistent key does not.
+    expect(await persistentCoreKey(b, BASE_PARAMS)).not.toBe(
+      await persistentCoreKey(a, BASE_PARAMS),
+    );
+  });
+
+  it('cryptoContentFingerprint folds the triple count', async () => {
+    // Same bytes, different declared length can't happen for a real array, but
+    // two clouds of different length must never share a content fingerprint.
+    const short = makeCloud(10);
+    const long = makeCloud(11);
+    expect(await cryptoContentFingerprint(short)).not.toBe(
+      await cryptoContentFingerprint(long),
+    );
+  });
+});
+
+describe('integrity digest', () => {
+  it('verifies a payload against its own digest', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const digest = await integrityDigest(bytes);
+    expect(await verifyIntegrity(bytes, digest)).toBe(true);
+  });
+
+  it('rejects a single flipped byte', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const digest = await integrityDigest(bytes);
+    const tampered = bytes.slice();
+    tampered[2] ^= 0x01;
+    expect(await verifyIntegrity(tampered, digest)).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds `src/terrain/contour/persistentCoreKey.ts` — the identity/invalidation/integrity contract for a persistent (across-reopen) terrain-core cache, behind the recompute-vs-reuse gate (`terrainCoreRebuildCost`, GO conditional).

- Full SHA-256 content fingerprint, replacing the session-scoped FNV sample hash for cross-session safety.
- `coreMethodGeneration()` folds the registry versions of the nine methods baked into a `TerrainCore`; a version bump forces a miss.
- SHA-256 integrity digest + verify.
- `paramsKey` reused verbatim, so param invalidation cannot drift from the in-memory cache.

No OPFS storage, serialization, or reopen wiring — those remain gated on the browser OPFS measurement the benchmark names. Registered as `staged` in the unreachable-modules ledger.

Tests: 11, including a case proving the crypto key catches an interior edit the sample hash misses. Full suite green; module-graph, monolith-size, position-access, unreachable-modules, architecture-truth unchanged/OK.