### PR TITLE
feat(io): authoritative whole-file identity for the OOC cache (P0)

### DIFF
--- a/src/app/heavyLasExecutor.ts
+++ b/src/app/heavyLasExecutor.ts
@@ -31,11 +31,12 @@ import {
   readOpfsText,
   type OpfsDirHandle,
 } from '../io/heavy/opfsSpillStore';
-import { fingerprintFromRange } from '../io/heavy/fileFingerprint';
+import { fingerprintFromRange, sourceContentDigestFromRange } from '../io/heavy/fileFingerprint';
 import {
   readCacheMap,
   writeCacheMap,
   lookupEntry,
+  verifiedEntry,
   upsertEntry,
   touchEntry,
   removeByStoreName,
@@ -247,14 +248,17 @@ async function reopenFromCache(
  */
 async function tryReopen(
   root: OpfsDirHandle,
-  fingerprint: string,
   generation: string,
+  sourceContentSha256: string,
   file: File,
   deps: HeavyLasBridgeDeps,
   signal: AbortSignal,
 ): Promise<HeavyOpenResult | null> {
   const map = await readCacheMap(root);
-  const entry = lookupEntry(map, fingerprint, generation);
+  // Reuse is authorised by the whole-file content digest, not the quick locator:
+  // a candidate whose stored digest differs (a file edited outside the sampled
+  // windows) is not returned, so a stale source can never receive a hit.
+  const entry = verifiedEntry(map, generation, sourceContentSha256);
   if (!entry) return null;
   const opened = await reopenFromCache(root, entry.storeName, file);
   if (!opened) {
@@ -271,7 +275,10 @@ async function tryReopen(
     if (deps.debug) console.warn('[heavy-las] cache reopen attach failed; rebuilding', err);
     return null;
   }
-  await writeCacheMap(root, touchEntry(map, fingerprint, generation, Date.now())).catch(() => {});
+  await writeCacheMap(
+    root,
+    touchEntry(map, sourceContentSha256, generation, Date.now()),
+  ).catch(() => {});
   return { status: 'attached', source: opened.source, decoder: opened.decoder };
 }
 
@@ -285,6 +292,7 @@ async function tryReopen(
 async function recordAndEvict(
   root: OpfsDirHandle,
   fingerprint: string,
+  sourceContentSha256: string,
   generation: string,
   storeName: string,
   reader: { manifest: { pointCount: number }; recordBytes: number },
@@ -295,6 +303,7 @@ async function recordAndEvict(
     const tileBytes = reader.manifest.pointCount * reader.recordBytes;
     let map = upsertEntry(await readCacheMap(root), {
       fingerprint,
+      sourceContentSha256,
       storeName,
       generation,
       createdAt: now,
@@ -364,16 +373,41 @@ export async function executeHeavyLasBuild(
   const root = await getOpfsRoot();
   if (root === null) return { status: 'unavailable', heavy: true, reason: 'no OPFS root' };
 
-  // Persistent cache. Fingerprint the file before any decode; on a hit, reopen
-  // the stored index instead of rebuilding it. A null fingerprint (a peek with no
-  // bounds, or a read fault) skips both reuse and recording, so the open behaves
-  // exactly as it did before the cache existed.
+  // Persistent cache. The quick locator (a sampled fingerprint) finds a
+  // CANDIDATE cheaply; the authoritative whole-file source-content digest then
+  // AUTHORISES reuse, so a file edited outside the sampled windows can never
+  // receive a verified hit. A null locator (a peek with no bounds, or a read
+  // fault) skips both reuse and recording, so the open behaves as it did before
+  // the cache existed.
   const generation = cacheGeneration();
   const fingerprint = await computeOpenFingerprint(file, facts, openRange(file), signal);
   if (signal.aborted) return { status: 'cancelled' };
+
+  // The whole-file digest is computed at most once per open, and only when it is
+  // actually needed: to verify a reopen candidate, or to record a freshly built
+  // store. A cold cache with no candidate never pays for it here. (Folding the
+  // digest into the build's existing sequential pass is a browser-measured
+  // follow-up; correctness does not depend on it.)
+  let digestMemo: string | null | undefined;
+  const sourceDigest = async (): Promise<string | null> => {
+    if (digestMemo === undefined) {
+      digestMemo = await sourceContentDigestFromRange(openRange(file), facts.fileBytes, signal);
+    }
+    return digestMemo;
+  };
+
   if (fingerprint) {
-    const reopened = await tryReopen(root, fingerprint, generation, file, deps, signal);
-    if (reopened) return reopened;
+    // Cheap candidate pre-filter: only hash the whole file when the locator finds
+    // a same-generation candidate that could match.
+    const hasCandidate = lookupEntry(await readCacheMap(root), fingerprint, generation) !== null;
+    if (hasCandidate) {
+      const digest = await sourceDigest();
+      if (signal.aborted) return { status: 'cancelled' };
+      if (digest) {
+        const reopened = await tryReopen(root, generation, digest, file, deps, signal);
+        if (reopened) return reopened;
+      }
+    }
   }
 
   if (!janitorSwept) {
@@ -512,10 +546,16 @@ export async function executeHeavyLasBuild(
       });
       throw err;
     }
-    // The scan is committed. If this open has a fingerprint, record the store so a
-    // later open reuses it, and retain it on close; a failed record leaves the
-    // store uncommitted (deleted on close), never leaked.
-    if (fingerprint && (await recordAndEvict(root, fingerprint, generation, built.storeName, reader, locks))) {
+    // The scan is committed. If this open has a locator AND a whole-file digest,
+    // record the store so a later open can verify and reuse it, and retain it on
+    // close. Without the digest the store could never be authorised for reuse, so
+    // it is left uncommitted (deleted on close) rather than recorded unusably.
+    const recordDigest = fingerprint ? await sourceDigest() : null;
+    if (
+      fingerprint &&
+      recordDigest &&
+      (await recordAndEvict(root, fingerprint, recordDigest, generation, built.storeName, reader, locks))
+    ) {
       retain = true;
     }
     return { status: 'attached', source, decoder };

--- a/src/io/heavy/fileFingerprint.ts
+++ b/src/io/heavy/fileFingerprint.ts
@@ -1,27 +1,37 @@
 /**
  * fileFingerprint.ts — the pre-decode identity of a heavy local file.
  *
- * Phase 1 of the persistent out-of-core cache. A persisted index has to be keyed
- * by something that identifies the source file BEFORE it is decoded, and that
- * key must miss whenever the bytes could have changed. `name + size + mtime` is
- * not enough on its own — an in-place edit can preserve both — so the
- * fingerprint folds in the parsed header facts and a set of sampled content
- * windows. Any difference in those inputs yields a different digest, so a cache
- * built on this key can never serve a stale index for an edited file.
+ * The persistent out-of-core cache keys a stored index by two identities, with
+ * different jobs:
  *
- * The digest is SHA-256 over the raw sampled bytes plus a canonical serialisation
- * of the facts and the window layout. SHA-256 rather than the 32-bit FNV used for
- * value fingerprints elsewhere: a collision here is a false cache HIT — stale
- * data served as fresh — the one failure this must not have.
+ *   QUICK LOCATOR ({@link computeFileFingerprint} / {@link fingerprintFromRange}).
+ *   A cheap, constant-cost identity: the parsed header facts plus a fixed set of
+ *   sampled content windows (head, a few interior positions, tail). It reads a
+ *   few kilobytes regardless of file size, so it is what a reopen computes first
+ *   to find a CANDIDATE entry. It is deliberately NOT authoritative: a file
+ *   edited entirely OUTSIDE the sampled windows, preserving size/mtime/header
+ *   facts, produces the same locator. A locator match alone must therefore never
+ *   authorise reuse — it only narrows the search to a candidate.
  *
- * Pure and layer-free: no filename, no path, no decode. `computeFileFingerprint`
- * takes only bytes and facts, so a rename is a HIT (the bytes match) and a
- * content change is a MISS. Reading the windows from an actual file is the
- * caller's job; the sample plan below says which windows to read.
+ *   SOURCE-CONTENT DIGEST ({@link sourceContentDigestFromRange}). The
+ *   authoritative identity: a SHA-256 over the ENTIRE source byte stream,
+ *   computed incrementally in bounded windows so no multi-gigabyte buffer is
+ *   materialised. Two files share this digest only if every byte matches, so it
+ *   is what actually authorises reuse: a candidate is a verified hit only when
+ *   its stored source-content digest equals the one recomputed from the file.
+ *
+ * Both use SHA-256 (not the 32-bit FNV used for value fingerprints elsewhere):
+ * a collision here is a false cache HIT — stale data served as fresh — the one
+ * failure this must not have.
+ *
+ * Pure and layer-free: no filename, no path, no decode. A rename is a HIT (the
+ * bytes match) and any content change is a MISS. Reading from an actual file is
+ * the caller's job.
  */
 
 import { canonicalJson } from '../../canonicalHash';
 import type { RangeSource } from '../range/RangeSource';
+import { IncrementalSha256 } from './incrementalSha256';
 
 /** Bumped when the fingerprint's inputs or layout change, so old keys miss. */
 export const FINGERPRINT_VERSION = 1;
@@ -29,6 +39,15 @@ export const FINGERPRINT_VERSION = 1;
 /** Bytes per sampled window, and the interior sample positions as file fractions. */
 const WINDOW_BYTES = 4096;
 const INTERIOR_FRACTIONS = [0.25, 0.5, 0.75] as const;
+
+/**
+ * Bytes read per window when streaming the whole-file source-content digest. A
+ * bounded working-set size, not a correctness parameter — the digest is
+ * identical for any chunk size (pinned by the incremental-hasher tests). 4 MiB
+ * matches the bridge's existing bounded-read discipline; the browser build can
+ * revisit it once real OPFS/file read throughput is measured.
+ */
+const DIGEST_CHUNK_BYTES = 4 * 1024 * 1024;
 
 /** Pre-decode facts parsed from the LAS/LAZ public header, plus file metadata. */
 export interface FingerprintFacts {
@@ -139,4 +158,52 @@ export async function fingerprintFromRange(
     samples.push({ offset: w.offset, length: bytes.byteLength, bytes });
   }
   return computeFileFingerprint(facts, samples);
+}
+
+/** Progress of a whole-file digest, for a "Verifying local cache…" indicator. */
+export interface DigestProgress {
+  readonly bytesHashed: number;
+  readonly totalBytes: number;
+}
+
+/**
+ * The authoritative source-content digest: SHA-256 over the entire byte stream,
+ * read through the range source in bounded {@link DIGEST_CHUNK_BYTES} windows
+ * and folded incrementally, so working memory stays bounded whatever the file
+ * size. `fileBytes` is the total to read (the caller's parsed header size).
+ *
+ * Fails closed: any read failure, a zero/negative size, or a source that returns
+ * fewer bytes than the file claims (a truncated read) returns null — which the
+ * cache reads as "cannot verify, rebuild", never as a match. Honours an abort
+ * signal between and within chunks so a cancelled verification yields null
+ * rather than a partial digest. `onProgress` is optional and side-effect only.
+ */
+export async function sourceContentDigestFromRange(
+  range: Pick<RangeSource, 'readRange'>,
+  fileBytes: number,
+  signal?: AbortSignal,
+  onProgress?: (p: DigestProgress) => void,
+): Promise<string | null> {
+  if (!Number.isFinite(fileBytes) || fileBytes <= 0) return null;
+  const hasher = new IncrementalSha256();
+  let offset = 0;
+  while (offset < fileBytes) {
+    if (signal?.aborted) return null;
+    const length = Math.min(DIGEST_CHUNK_BYTES, fileBytes - offset);
+    let buf: ArrayBuffer;
+    try {
+      buf = await range.readRange(offset, length, signal);
+    } catch {
+      return null;
+    }
+    const bytes = new Uint8Array(buf);
+    // A short read means the file is not the size the facts claimed — treat it
+    // as unverifiable rather than hashing a truncated stream as if whole.
+    if (bytes.byteLength === 0) return null;
+    hasher.update(bytes);
+    offset += bytes.byteLength;
+    onProgress?.({ bytesHashed: offset, totalBytes: fileBytes });
+  }
+  if (offset !== fileBytes) return null;
+  return hasher.digestHex();
 }

--- a/src/io/heavy/incrementalSha256.ts
+++ b/src/io/heavy/incrementalSha256.ts
@@ -1,0 +1,188 @@
+/**
+ * incrementalSha256.ts — a streaming, bounded-memory SHA-256 (FIPS 180-4).
+ *
+ * The OOC cache needs the digest of an ENTIRE multi-gigabyte source to decide
+ * whether a persisted index still matches the file. Concatenating the file into
+ * one buffer to hash it would defeat the bounded-memory promise the out-of-core
+ * path exists for, and the synchronous one-shot `sha256Bytes` in
+ * `terrain/export/sha256.ts` (built for KB–MB deliverable files) allocates a
+ * padded copy of its whole input. This is the same FIPS 180-4 compression, run
+ * incrementally: feed it the file a bounded window at a time with `update`, then
+ * `digestHex()`.
+ *
+ * Buffers only a partial 64-byte block between updates, so working memory is a
+ * constant regardless of the number of bytes hashed. Deterministic, no DOM, no
+ * three.js, and matches Web Crypto / Node `crypto` for the same input (pinned by
+ * the tests against the published FIPS vectors and against `crypto.subtle`).
+ */
+
+// Round constants: first 32 bits of the fractional parts of the cube roots of
+// the first 64 primes (FIPS 180-4 §4.2.2).
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+const rotr = (x: number, n: number): number => (x >>> n) | (x << (32 - n));
+
+/** A streaming SHA-256 hasher. Feed bytes with {@link update}, finish with
+ *  {@link digestBytes} / {@link digestHex}. One-shot after finishing. */
+export class IncrementalSha256 {
+  // Working hash state: fractional parts of the square roots of the first 8 primes.
+  private h0 = 0x6a09e667;
+  private h1 = 0xbb67ae85;
+  private h2 = 0x3c6ef372;
+  private h3 = 0xa54ff53a;
+  private h4 = 0x510e527f;
+  private h5 = 0x9b05688c;
+  private h6 = 0x1f83d9ab;
+  private h7 = 0x5be0cd19;
+
+  /** Partial block carried between updates (0..63 bytes). */
+  private readonly block = new Uint8Array(64);
+  private blockLen = 0;
+  /** Total bytes fed so far, for the length suffix. */
+  private totalBytes = 0;
+  private finished = false;
+  /** Reused 64-word message schedule, so update() allocates nothing per block. */
+  private readonly w = new Uint32Array(64);
+
+  /** Compress one full 64-byte block starting at `off` in `data`. */
+  private compress(data: Uint8Array, off: number): void {
+    const w = this.w;
+    for (let i = 0; i < 16; i++) {
+      const j = off + i * 4;
+      w[i] = ((data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | data[j + 3]) >>> 0;
+    }
+    for (let i = 16; i < 64; i++) {
+      const s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+      const s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+    }
+    let a = this.h0, b = this.h1, c = this.h2, d = this.h3;
+    let e = this.h4, f = this.h5, g = this.h6, h = this.h7;
+    for (let i = 0; i < 64; i++) {
+      const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const t1 = (h + S1 + ch + K[i] + w[i]) >>> 0;
+      const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const t2 = (S0 + maj) >>> 0;
+      h = g; g = f; f = e;
+      e = (d + t1) >>> 0;
+      d = c; c = b; b = a;
+      a = (t1 + t2) >>> 0;
+    }
+    this.h0 = (this.h0 + a) >>> 0;
+    this.h1 = (this.h1 + b) >>> 0;
+    this.h2 = (this.h2 + c) >>> 0;
+    this.h3 = (this.h3 + d) >>> 0;
+    this.h4 = (this.h4 + e) >>> 0;
+    this.h5 = (this.h5 + f) >>> 0;
+    this.h6 = (this.h6 + g) >>> 0;
+    this.h7 = (this.h7 + h) >>> 0;
+  }
+
+  /** Fold `bytes` into the running digest. Cheap and bounded: at most one 64-byte
+   *  block is buffered between calls. */
+  update(bytes: Uint8Array): this {
+    if (this.finished) throw new Error('IncrementalSha256: update after digest');
+    this.totalBytes += bytes.length;
+    let i = 0;
+    // Top up a partial block first.
+    if (this.blockLen > 0) {
+      const need = 64 - this.blockLen;
+      const take = Math.min(need, bytes.length);
+      this.block.set(bytes.subarray(0, take), this.blockLen);
+      this.blockLen += take;
+      i = take;
+      if (this.blockLen === 64) {
+        this.compress(this.block, 0);
+        this.blockLen = 0;
+      }
+    }
+    // Compress full blocks straight out of the input.
+    for (; i + 64 <= bytes.length; i += 64) this.compress(bytes, i);
+    // Carry the remainder.
+    if (i < bytes.length) {
+      const rem = bytes.length - i;
+      this.block.set(bytes.subarray(i), 0);
+      this.blockLen = rem;
+    }
+    return this;
+  }
+
+  /** Finish and return the raw 32-byte digest. Idempotent-unsafe: call once. */
+  digestBytes(): Uint8Array {
+    if (this.finished) throw new Error('IncrementalSha256: digest called twice');
+    this.finished = true;
+    const bitLen = this.totalBytes * 8;
+    // Pad: 0x80, then zeros, then the 64-bit big-endian bit length.
+    const padLen = this.blockLen < 56 ? 56 - this.blockLen : 120 - this.blockLen;
+    const tail = new Uint8Array(padLen + 8);
+    tail[0] = 0x80;
+    // 64-bit length. JS bit ops are 32-bit, so split into high/low words; the
+    // high word carries lengths beyond 2^32 bits (512 MiB) using float math.
+    const hi = Math.floor(bitLen / 0x100000000);
+    const lo = bitLen >>> 0;
+    tail[padLen] = (hi >>> 24) & 0xff;
+    tail[padLen + 1] = (hi >>> 16) & 0xff;
+    tail[padLen + 2] = (hi >>> 8) & 0xff;
+    tail[padLen + 3] = hi & 0xff;
+    tail[padLen + 4] = (lo >>> 24) & 0xff;
+    tail[padLen + 5] = (lo >>> 16) & 0xff;
+    tail[padLen + 6] = (lo >>> 8) & 0xff;
+    tail[padLen + 7] = lo & 0xff;
+    this.update = () => {
+      throw new Error('IncrementalSha256: update after digest');
+    };
+    // Feed the tail through the same block machinery via a temporary path that
+    // does not touch `finished`/`totalBytes`.
+    this.absorbTail(tail);
+    const out = new Uint8Array(32);
+    const hs = [this.h0, this.h1, this.h2, this.h3, this.h4, this.h5, this.h6, this.h7];
+    for (let i = 0; i < 8; i++) {
+      out[i * 4] = (hs[i] >>> 24) & 0xff;
+      out[i * 4 + 1] = (hs[i] >>> 16) & 0xff;
+      out[i * 4 + 2] = (hs[i] >>> 8) & 0xff;
+      out[i * 4 + 3] = hs[i] & 0xff;
+    }
+    return out;
+  }
+
+  /** Absorb the final padding tail (a multiple of 64 bytes once combined with
+   *  the carried partial block). */
+  private absorbTail(tail: Uint8Array): void {
+    // Complete the carried block, then compress any remaining full blocks.
+    let i = 0;
+    if (this.blockLen > 0) {
+      const need = 64 - this.blockLen;
+      this.block.set(tail.subarray(0, need), this.blockLen);
+      this.compress(this.block, 0);
+      this.blockLen = 0;
+      i = need;
+    }
+    for (; i + 64 <= tail.length; i += 64) this.compress(tail, i);
+  }
+
+  /** Finish and return the digest as lowercase hex. */
+  digestHex(): string {
+    const bytes = this.digestBytes();
+    let hex = '';
+    for (let i = 0; i < bytes.length; i++) hex += bytes[i].toString(16).padStart(2, '0');
+    return hex;
+  }
+}
+
+/** Convenience: the lowercase-hex SHA-256 of a single buffer, via the streaming
+ *  core. For whole-file hashing prefer feeding {@link IncrementalSha256.update}
+ *  bounded windows so nothing large is materialised at once. */
+export function incrementalSha256Hex(bytes: Uint8Array): string {
+  return new IncrementalSha256().update(bytes).digestHex();
+}

--- a/src/io/heavy/oocCacheMap.ts
+++ b/src/io/heavy/oocCacheMap.ts
@@ -27,15 +27,30 @@ import { TILE_STORE_SCHEMA_VERSION } from './tileStore';
 import { FINGERPRINT_VERSION } from './fileFingerprint';
 import { readOpfsText, writeOpfsText, type OpfsDirHandle } from './opfsSpillStore';
 
-/** Bumped when the map's own shape changes, so an old record parses to empty. */
-export const CACHE_MAP_VERSION = 1;
+/** Bumped when the map's own shape changes, so an old record parses to empty.
+ *  v2 adds the authoritative `sourceContentSha256` to every entry. */
+export const CACHE_MAP_VERSION = 2;
+
+/**
+ * Bumped when the SAME source bytes could decode to semantically different OOC
+ * point content — a change in LAS/LAZ decode semantics, classification or
+ * return-number interpretation, coordinate scaling, Extra Bytes handling,
+ * invalid-point filtering, a CRS-relevant point transform, or which source
+ * records are selected. It is NOT the application version: a UI-only release must
+ * not invalidate every cached index. Bump it only when a reused index built by
+ * an older build could now be scientifically wrong, and note the reason here.
+ */
+export const HEAVY_INGEST_SEMANTICS_VERSION = 1;
 
 /** The map's file name in the OPFS root, beside the tile stores it points at. */
 export const CACHE_MAP_FILE = 'ooc-cache-map.json';
 
 /** One cached index: which store holds it, and the facts eviction/telemetry need. */
 export interface OocCacheEntry {
+  /** The quick locator (sampled fingerprint): finds a candidate, never authorises. */
   readonly fingerprint: string;
+  /** The authoritative SHA-256 over the whole source stream: authorises reuse. */
+  readonly sourceContentSha256: string;
   readonly storeName: string;
   readonly generation: string;
   readonly createdAt: number;
@@ -56,7 +71,7 @@ export interface OocCacheMap {
  * schema and the fingerprint scheme, so bumping either invalidates old indices.
  */
 export function cacheGeneration(): string {
-  return `t${TILE_STORE_SCHEMA_VERSION}.f${FINGERPRINT_VERSION}.m${CACHE_MAP_VERSION}`;
+  return `t${TILE_STORE_SCHEMA_VERSION}.f${FINGERPRINT_VERSION}.m${CACHE_MAP_VERSION}.i${HEAVY_INGEST_SEMANTICS_VERSION}`;
 }
 
 export function emptyCacheMap(): OocCacheMap {
@@ -73,10 +88,12 @@ function validEntry(raw: unknown): OocCacheEntry | null {
   const e = raw as Record<string, unknown>;
   const str = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
   const num = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
-  if (!str(e.fingerprint) || !str(e.storeName) || !str(e.generation)) return null;
+  if (!str(e.fingerprint) || !str(e.sourceContentSha256) || !str(e.storeName) || !str(e.generation))
+    return null;
   if (!num(e.createdAt) || !num(e.lastUsedAt) || !num(e.pointCount) || !num(e.tileBytes)) return null;
   return {
     fingerprint: e.fingerprint,
+    sourceContentSha256: e.sourceContentSha256,
     storeName: e.storeName,
     generation: e.generation,
     createdAt: e.createdAt,
@@ -109,31 +126,63 @@ export function parseCacheMap(text: string): OocCacheMap {
   return { version: CACHE_MAP_VERSION, entries };
 }
 
-/** The entry for a fingerprint, only if its generation matches — else null. */
+/**
+ * The CANDIDATE entry for a quick locator, only if its generation matches — else
+ * null. A candidate is not yet a reuse authorisation: the caller must still
+ * verify the source-content digest (see {@link verifiedEntry}). The locator is a
+ * sampled fingerprint, so a file edited outside the sampled windows can match
+ * here while being a different file.
+ */
 export function lookupEntry(map: OocCacheMap, fingerprint: string, generation: string): OocCacheEntry | null {
   return (
     map.entries.find((e) => e.fingerprint === fingerprint && e.generation === generation) ?? null
   );
 }
 
-/** Add or replace the entry for its (fingerprint, generation) pair. Immutable. */
+/**
+ * The entry that authorises reuse: it matches the quick locator AND the
+ * generation AND the authoritative whole-file `sourceContentSha256`. A candidate
+ * whose stored content digest differs from the one recomputed from the file is
+ * NOT returned — that is the stale-source case a locator-only match would wrongly
+ * accept. An empty recomputed digest (verification failed or was cancelled)
+ * never authorises reuse.
+ */
+export function verifiedEntry(
+  map: OocCacheMap,
+  generation: string,
+  sourceContentSha256: string,
+): OocCacheEntry | null {
+  if (!sourceContentSha256) return null;
+  return (
+    map.entries.find(
+      (e) => e.generation === generation && e.sourceContentSha256 === sourceContentSha256,
+    ) ?? null
+  );
+}
+
+/** Add or replace the entry for its authoritative (sourceContentSha256,
+ *  generation) pair. Immutable. Keyed on the content digest, not the sampled
+ *  locator, so two distinct files that share a locator get distinct entries. */
 export function upsertEntry(map: OocCacheMap, next: OocCacheEntry): OocCacheMap {
   const entries = map.entries.filter(
-    (e) => !(e.fingerprint === next.fingerprint && e.generation === next.generation),
+    (e) =>
+      !(e.sourceContentSha256 === next.sourceContentSha256 && e.generation === next.generation),
   );
   entries.push(next);
   return { version: map.version, entries };
 }
 
-/** Bump `lastUsedAt` for the matching entry (for LRU eviction later). Immutable. */
+/** Bump `lastUsedAt` for the matching entry (for LRU eviction). Immutable. */
 export function touchEntry(
   map: OocCacheMap,
-  fingerprint: string,
+  sourceContentSha256: string,
   generation: string,
   now: number,
 ): OocCacheMap {
   const entries = map.entries.map((e) =>
-    e.fingerprint === fingerprint && e.generation === generation ? { ...e, lastUsedAt: now } : e,
+    e.sourceContentSha256 === sourceContentSha256 && e.generation === generation
+      ? { ...e, lastUsedAt: now }
+      : e,
   );
   return { version: map.version, entries };
 }

--- a/tests/fileFingerprint.test.ts
+++ b/tests/fileFingerprint.test.ts
@@ -14,10 +14,12 @@ import {
   fingerprintSamplePlan,
   computeFileFingerprint,
   fingerprintFromRange,
+  sourceContentDigestFromRange,
   FINGERPRINT_VERSION,
   type FingerprintFacts,
   type FingerprintSample,
 } from '../src/io/heavy/fileFingerprint';
+import { incrementalSha256Hex } from '../src/io/heavy/incrementalSha256';
 import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
 
 const facts = (over: Partial<FingerprintFacts> = {}): FingerprintFacts => ({
@@ -158,5 +160,97 @@ describe('fingerprintFromRange', () => {
       readRange: () => Promise.reject(new Error('read failed')),
     };
     expect(await fingerprintFromRange(failing, rangeFacts(size))).toBeNull();
+  });
+});
+
+describe('sourceContentDigestFromRange — authoritative whole-file identity', () => {
+  const SIZE = 200_000;
+  const build = (): Uint8Array => {
+    const b = new Uint8Array(SIZE);
+    for (let i = 0; i < SIZE; i++) b[i] = (i * 31 + 7) & 0xff;
+    return b;
+  };
+  /** A standalone ArrayBuffer holding a copy of `u8` (never a SharedArrayBuffer). */
+  const ab = (u8: Uint8Array): ArrayBuffer => {
+    const copy = new Uint8Array(u8.length);
+    copy.set(u8);
+    return copy.buffer;
+  };
+  /** An offset provably inside NONE of the quick-locator sample windows. */
+  const gapOffset = (): number => {
+    const plan = fingerprintSamplePlan(SIZE);
+    const inAnyWindow = (o: number): boolean =>
+      plan.some((w) => o >= w.offset && o < w.offset + w.length);
+    for (let o = 0; o < SIZE; o++) if (!inAnyWindow(o)) return o;
+    throw new Error('no gap offset found');
+  };
+
+  it('the exact stale-cache vector: quick locator collides, content digest differs', async () => {
+    // B changes a byte OUTSIDE every sampled window, preserving size and facts.
+    const a = build();
+    const b = a.slice();
+    const off = gapOffset();
+    expect(off).toBeGreaterThan(0);
+    b[off] ^= 0xff;
+
+    const f = facts({ fileBytes: SIZE });
+    const srcA = new ArrayBufferRangeSource(ab(a), 'survey.las');
+    const srcB = new ArrayBufferRangeSource(ab(b), 'survey.las');
+
+    // The quick locator cannot tell them apart — this is the false-hit vector.
+    expect(await fingerprintFromRange(srcA, f)).toBe(await fingerprintFromRange(srcB, f));
+    // The authoritative digest does, so reuse of B's index from A is refused.
+    const da = await sourceContentDigestFromRange(srcA, SIZE);
+    const db = await sourceContentDigestFromRange(srcB, SIZE);
+    expect(da).not.toBe(db);
+  });
+
+  it('equals the whole-buffer hash and is chunk-count invariant', async () => {
+    const a = build();
+    const digest = await sourceContentDigestFromRange(new ArrayBufferRangeSource(ab(a), 'a'), SIZE);
+    expect(digest).toBe(incrementalSha256Hex(a));
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('a rename (identical bytes) shares the digest; one changed byte does not', async () => {
+    const a = build();
+    const renamed = new ArrayBufferRangeSource(ab(a), 'renamed.las');
+    expect(await sourceContentDigestFromRange(renamed, SIZE)).toBe(incrementalSha256Hex(a));
+    const edited = a.slice();
+    edited[0] ^= 0x01;
+    expect(await sourceContentDigestFromRange(new ArrayBufferRangeSource(ab(edited), 'a'), SIZE)).not.toBe(
+      incrementalSha256Hex(a),
+    );
+  });
+
+  it('a truncated source (fewer bytes than claimed) fails closed to null', async () => {
+    const a = build();
+    // Claim more bytes than the buffer holds — the read past the end returns
+    // empty, so the digest cannot cover the claimed length.
+    expect(await sourceContentDigestFromRange(new ArrayBufferRangeSource(ab(a), 'a'), SIZE + 4096)).toBeNull();
+  });
+
+  it('an already-aborted signal yields null, never a partial digest', async () => {
+    const a = build();
+    const ac = new AbortController();
+    ac.abort();
+    expect(
+      await sourceContentDigestFromRange(new ArrayBufferRangeSource(ab(a), 'a'), SIZE, ac.signal),
+    ).toBeNull();
+  });
+
+  it('a read error yields null', async () => {
+    const failing = {
+      id: () => 'boom',
+      kind: () => 'array-buffer' as const,
+      size: () => Promise.resolve(SIZE),
+      readRange: () => Promise.reject(new Error('read failed')),
+    };
+    expect(await sourceContentDigestFromRange(failing, SIZE)).toBeNull();
+  });
+
+  it('a non-positive size is null', async () => {
+    const a = build();
+    expect(await sourceContentDigestFromRange(new ArrayBufferRangeSource(ab(a), 'a'), 0)).toBeNull();
   });
 });

--- a/tests/heavyLasStoreLifecycle.test.ts
+++ b/tests/heavyLasStoreLifecycle.test.ts
@@ -1,13 +1,13 @@
 /**
- * heavyLasStoreLifecycle.test.ts — the out-of-core store is temporary.
+ * heavyLasStoreLifecycle.test.ts — the out-of-core store's persistent lifecycle.
  *
  * A heavy uncompressed LAS is indexed into an OPFS tile store (`ooc-<name>-<size>`)
- * and streamed from it. For this release that store is TEMPORARY: nothing reuses
- * it on a later open, so leaving it in OPFS is pure cost. These cases pin the
- * lifecycle — the store exists while the source is attached, and closing the
- * `OlvTileSource` removes it — plus the two guarantees the removal must keep:
- * the tile handles are still released, and removing an already-absent store is a
- * no-op rather than a throw.
+ * and streamed from it. The store is a PERSISTENT cache: a later open of the same
+ * source reuses the built index instead of rebuilding it — but only after the
+ * quick locator finds a candidate AND the whole-file content digest verifies, so
+ * a source edited outside the sampled windows is refused reuse and rebuilt. These
+ * cases pin that lifecycle: a retained store, a verified reuse, a refused stale
+ * reuse, released tile handles on close, and a no-op removal of an absent store.
  *
  * The browser-only seams are the repo's usual fakes: OPFS is
  * `tests/support/fakeOpfs.ts`, and the index "worker" runs the real build in
@@ -18,6 +18,7 @@ import { writeLas14 } from '../src/convert/writeLas';
 import type { GlobalPoints } from '../src/convert/globalPoints';
 import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
 import type { RangeSource } from '../src/io/range/RangeSource';
+import { fingerprintSamplePlan } from '../src/io/heavy/fileFingerprint';
 import { fakeOpfs, fakeOpfsDir } from './support/fakeOpfs';
 import { buildLocalOocStore } from '../src/io/heavy/localOocBuild';
 import { OlvTileSource } from '../src/io/heavy/OlvTileSource';
@@ -197,6 +198,65 @@ describe('heavy LAS out-of-core store lifecycle', () => {
     // One index build, one store: the second open reopened the cached index.
     expect(builds).toBe(1);
     expect(opfs.topLevel().filter((n) => n.startsWith('ooc-') && n !== 'ooc-cache-map.json')).toHaveLength(1);
+  });
+
+  it('refuses reuse when the source changed OUTSIDE the sampled windows (no stale hit)', async () => {
+    // The exact stale-cache vector end-to-end: B preserves size and header facts
+    // and every quick-locator sample window, changing one byte in a gap between
+    // them. The locator matches the cached entry; the whole-file content digest
+    // does not, so reuse must be refused and the index rebuilt.
+    const a = new Uint8Array(lasBytes(60_000));
+    const b = a.slice();
+    const plan = fingerprintSamplePlan(a.length);
+    const inWindow = (o: number): boolean =>
+      plan.some((w) => o >= w.offset && o < w.offset + w.length);
+    let off = -1;
+    for (let o = 0; o < a.length; o++) {
+      if (!inWindow(o)) { off = o; break; }
+    }
+    expect(off).toBeGreaterThan(0);
+    b[off] ^= 0xff;
+
+    const opfs = fakeOpfs({ syncAccess: true, fileMove: true });
+    const reading: StorageEstimateReading = { available: true, quotaBytes: 200_000_000_000, usageBytes: 0 };
+    const abOf = (u8: Uint8Array): ArrayBuffer => {
+      const copy = new Uint8Array(u8.length);
+      copy.set(u8);
+      return copy.buffer;
+    };
+    let builds = 0;
+    const envFor = (buf: Uint8Array): HeavyLasBridgeEnv => ({
+      capable: () => true,
+      openRange: () => new ArrayBufferRangeSource(abOf(buf), 'same.las'),
+      getOpfsRoot: async () => opfs.root,
+      readStorage: async () => reading,
+      async runIndex(req) {
+        builds += 1;
+        return buildLocalOocStore(new ArrayBufferRangeSource(abOf(buf), 'same.las'), opfs.root, req.storeName, {
+          pointsPerLeaf: req.pointsPerLeaf,
+          memoryBudgetBytes: req.memoryBudgetBytes,
+          maxDepth: req.maxDepth,
+          batchPoints: 4096,
+          signal: req.signal,
+          onPhase: req.onPhase,
+        });
+      },
+    });
+
+    const open = async (buf: Uint8Array): Promise<void> => {
+      const { deps } = makeDeps();
+      const result = await openLocalHeavyLas(
+        spyFile('same.las', buf.length),
+        new AbortController().signal,
+        deps,
+        envFor(buf),
+      );
+      expect(result.status).toBe('attached');
+    };
+
+    await open(a); // cold: build #1, records the store keyed by A's content digest
+    await open(b); // locator hits A's entry, digest differs → must rebuild
+    expect(builds).toBe(2);
   });
 
   it('still releases the tile handles on close (does not regress spill.close)', async () => {

--- a/tests/incrementalSha256.test.ts
+++ b/tests/incrementalSha256.test.ts
@@ -1,0 +1,71 @@
+/**
+ * incrementalSha256.test.ts — the streaming SHA-256 is FIPS-correct, matches the
+ * platform Web Crypto, and is invariant to how the input is chunked.
+ *
+ * The last property is the one the OOC cache depends on: a file fed a window at
+ * a time must produce the same digest as the whole file at once, or a persisted
+ * source-content digest would depend on the read size and never match.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IncrementalSha256, incrementalSha256Hex } from '../src/io/heavy/incrementalSha256';
+
+const enc = new TextEncoder();
+
+/** Published FIPS 180-4 / NIST example vectors. */
+const VECTORS: Array<[string, string]> = [
+  ['', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+  ['abc', 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'],
+  [
+    'abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq',
+    '248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1',
+  ],
+];
+
+describe('IncrementalSha256', () => {
+  it('matches the published FIPS 180-4 vectors', () => {
+    for (const [msg, want] of VECTORS) {
+      expect(incrementalSha256Hex(enc.encode(msg))).toBe(want);
+    }
+  });
+
+  it('matches Web Crypto for random inputs of many lengths', async () => {
+    // Lengths straddling block boundaries (55/56/64/65) and the length-suffix
+    // edge, plus a large multi-block input.
+    const lengths = [0, 1, 55, 56, 57, 63, 64, 65, 127, 128, 1000, 100_003];
+    for (const n of lengths) {
+      const bytes = new Uint8Array(n);
+      for (let i = 0; i < n; i++) bytes[i] = (i * 2654435761) & 0xff;
+      const ref = new Uint8Array(await globalThis.crypto.subtle.digest('SHA-256', bytes));
+      let refHex = '';
+      for (const b of ref) refHex += b.toString(16).padStart(2, '0');
+      expect(incrementalSha256Hex(bytes), `len ${n}`).toBe(refHex);
+    }
+  });
+
+  it('is invariant to chunk boundaries', () => {
+    const n = 5000;
+    const bytes = new Uint8Array(n);
+    for (let i = 0; i < n; i++) bytes[i] = (i * 40503) & 0xff;
+    const whole = incrementalSha256Hex(bytes);
+    for (const chunk of [1, 7, 63, 64, 65, 500, 4096]) {
+      const h = new IncrementalSha256();
+      for (let i = 0; i < n; i += chunk) h.update(bytes.subarray(i, Math.min(i + chunk, n)));
+      expect(h.digestHex(), `chunk ${chunk}`).toBe(whole);
+    }
+  });
+
+  it('refuses update after digest', () => {
+    const h = new IncrementalSha256();
+    h.update(enc.encode('abc'));
+    h.digestHex();
+    expect(() => h.update(enc.encode('x'))).toThrow(/after digest/);
+  });
+
+  it('refuses a second digest', () => {
+    const h = new IncrementalSha256();
+    h.update(enc.encode('abc'));
+    h.digestHex();
+    expect(() => h.digestHex()).toThrow(/twice/);
+  });
+});

--- a/tests/oocCacheMap.test.ts
+++ b/tests/oocCacheMap.test.ts
@@ -15,6 +15,7 @@ import {
   serializeCacheMap,
   parseCacheMap,
   lookupEntry,
+  verifiedEntry,
   upsertEntry,
   touchEntry,
   removeByStoreName,
@@ -30,6 +31,7 @@ import { fakeOpfsDir } from './support/fakeOpfs';
 const GEN = 'gen-A';
 const entry = (over: Partial<OocCacheEntry> = {}): OocCacheEntry => ({
   fingerprint: 'fp-1',
+  sourceContentSha256: 'sha-1',
   storeName: 'ooc-abc-123',
   generation: GEN,
   createdAt: 1000,
@@ -62,34 +64,61 @@ describe('oocCacheMap — pure core', () => {
     expect(parsed.entries).toEqual([good]);
   });
 
-  it('looks up only on matching fingerprint AND generation', () => {
+  it('drops an entry missing the authoritative source-content digest', () => {
+    const { sourceContentSha256: _omit, ...noDigest } = entry();
+    const raw = JSON.stringify({ version: CACHE_MAP_VERSION, entries: [noDigest] });
+    expect(parseCacheMap(raw).entries).toEqual([]);
+  });
+
+  it('looks up a CANDIDATE on matching locator AND generation', () => {
     const map = upsertEntry(emptyCacheMap(), entry());
     expect(lookupEntry(map, 'fp-1', GEN)?.storeName).toBe('ooc-abc-123');
     expect(lookupEntry(map, 'fp-other', GEN)).toBeNull();
-    // generation mismatch is a miss even though the fingerprint matches
+    // generation mismatch is a miss even though the locator matches
     expect(lookupEntry(map, 'fp-1', 'gen-B')).toBeNull();
   });
 
-  it('upsert replaces the entry for a (fingerprint, generation) pair without duplicating', () => {
+  it('authorises reuse only on matching content digest AND generation', () => {
+    const map = upsertEntry(emptyCacheMap(), entry());
+    expect(verifiedEntry(map, GEN, 'sha-1')?.storeName).toBe('ooc-abc-123');
+    // A candidate with the same locator but a different whole-file digest — the
+    // edited-outside-the-window case — is NOT authorised.
+    expect(verifiedEntry(map, GEN, 'sha-different')).toBeNull();
+    // Generation mismatch and an empty digest never authorise.
+    expect(verifiedEntry(map, 'gen-B', 'sha-1')).toBeNull();
+    expect(verifiedEntry(map, GEN, '')).toBeNull();
+  });
+
+  it('upsert replaces the entry for a (content digest, generation) pair without duplicating', () => {
     let map = upsertEntry(emptyCacheMap(), entry({ storeName: 'store-old' }));
     map = upsertEntry(map, entry({ storeName: 'store-new' }));
     expect(map.entries).toHaveLength(1);
-    expect(lookupEntry(map, 'fp-1', GEN)?.storeName).toBe('store-new');
+    expect(verifiedEntry(map, GEN, 'sha-1')?.storeName).toBe('store-new');
+  });
+
+  it('upsert keeps two distinct-content entries that share a locator', () => {
+    // A locator collision (same sampled fingerprint, different whole-file bytes)
+    // must not overwrite: each keeps its own store, keyed on the content digest.
+    let map = upsertEntry(emptyCacheMap(), entry({ sourceContentSha256: 'sha-A', storeName: 'store-A' }));
+    map = upsertEntry(map, entry({ sourceContentSha256: 'sha-B', storeName: 'store-B' }));
+    expect(map.entries).toHaveLength(2);
+    expect(verifiedEntry(map, GEN, 'sha-A')?.storeName).toBe('store-A');
+    expect(verifiedEntry(map, GEN, 'sha-B')?.storeName).toBe('store-B');
   });
 
   it('upsert is immutable — it does not mutate the input map', () => {
     const before = upsertEntry(emptyCacheMap(), entry());
     const snapshot = JSON.parse(JSON.stringify(before));
-    upsertEntry(before, entry({ fingerprint: 'fp-2', storeName: 'store-2' }));
+    upsertEntry(before, entry({ sourceContentSha256: 'sha-2', storeName: 'store-2' }));
     expect(before).toEqual(snapshot);
   });
 
   it('touch updates lastUsedAt for the matching entry only', () => {
-    let map = upsertEntry(emptyCacheMap(), entry({ fingerprint: 'fp-1', lastUsedAt: 1000 }));
-    map = upsertEntry(map, entry({ fingerprint: 'fp-2', storeName: 'store-2', lastUsedAt: 1000 }));
-    map = touchEntry(map, 'fp-1', GEN, 9999);
-    expect(lookupEntry(map, 'fp-1', GEN)?.lastUsedAt).toBe(9999);
-    expect(lookupEntry(map, 'fp-2', GEN)?.lastUsedAt).toBe(1000);
+    let map = upsertEntry(emptyCacheMap(), entry({ sourceContentSha256: 'sha-1', lastUsedAt: 1000 }));
+    map = upsertEntry(map, entry({ sourceContentSha256: 'sha-2', storeName: 'store-2', lastUsedAt: 1000 }));
+    map = touchEntry(map, 'sha-1', GEN, 9999);
+    expect(verifiedEntry(map, GEN, 'sha-1')?.lastUsedAt).toBe(9999);
+    expect(verifiedEntry(map, GEN, 'sha-2')?.lastUsedAt).toBe(1000);
   });
 
   it('removeByStoreName drops the entry whose store was deleted out from under it', () => {
@@ -107,6 +136,7 @@ describe('oocCacheMap — pure core', () => {
 describe('selectEvictions', () => {
   const e = (storeName: string, lastUsedAt: number, tileBytes: number): OocCacheEntry => ({
     fingerprint: 'fp-' + storeName,
+    sourceContentSha256: 'sha-' + storeName,
     storeName,
     generation: GEN,
     createdAt: 0,


### PR DESCRIPTION
The persistent out-of-core cache keyed reuse on a sampled fingerprint alone (five 4 KiB windows + header facts). A file edited **outside** those windows, preserving size/mtime/header facts, produced the same key and could receive a stale index — a false cache hit serving old science as fresh.

Splits identity in two:
- **Quick locator** (the existing sampled fingerprint) — finds a *candidate* cheaply; never authorises reuse.
- **Source-content digest** — SHA-256 over the *entire* byte stream; a candidate is a verified hit only when its stored digest matches.

Changes:
- `IncrementalSha256` — streaming, bounded-memory FIPS-180-4, pinned against the FIPS vectors and Web Crypto, chunk-boundary invariant.
- `sourceContentDigestFromRange` — hashes the whole file in bounded 4 MiB windows, cancellable, fail-closed on read fault / truncation / non-positive size.
- Cache map **v2**: entries carry `sourceContentSha256`; `verifiedEntry` authorises on the digest; keyed so a locator collision keeps distinct entries. `cacheGeneration` now folds `HEAVY_INGEST_SEMANTICS_VERSION`, so a decode-semantics change (not a UI release) invalidates reuse.
- Executor gates reuse on the verified digest and records it on build; the digest is computed at most once per open and only when needed (a cold cache pays nothing for it at reopen).

**Deferred / not claimed:** folding the digest into the build's existing sequential pass (a first-open-latency optimisation) is a browser-measured follow-up — no performance claim is made here. The map version bump invalidates pre-existing cached indexes (they rebuild once).

Negative controls: quick locator collides while the content digest differs; rename/one-byte/truncation/cancel/read-error; and the **end-to-end** edit-outside-windows source is refused reuse and rebuilt. Full suite 13,803 pass / 0 fail; tsc, module-graph, layer-boundaries, unreachable-modules, monolith-size green.