### PR TITLE
feat(registration): distinct epoch-alignment method + applied-transform provenance

### DIFF
--- a/docs/science/METHOD_REGISTRY.md
+++ b/docs/science/METHOD_REGISTRY.md
@@ -37,6 +37,7 @@ the paper that specifies it.
 | `olv.validation.spatial-block` | 2 | Spatial-block cross-validation | Roberts et al. (2017) |
 | `olv.validation.reliability-wilson` | 1 | Measured-cell reliability | Wilson (1927) |
 | `olv.registration.icp-planar` | 1 | Planar rigid ICP | Besl & McKay (1992); Umeyama (1991) |
+| `olv.registration.epoch-horizontal-icp` | 1 | Repeat-epoch horizontal alignment (yaw + XY, Z locked) | Besl & McKay (1992); Umeyama (1991) |
 | `olv.volume.stockpile` | 1 | Stockpile cut-fill volume ±1σ | internal (prismatic cut-fill) |
 | `olv.feature.building-footprint` | 1 | Building footprint candidate extraction | internal (connected-component + boundary trace) |
 | `olv.feature.conductor-fit` | 1 | Conductor centreline and sag fit | internal (parabolic small-sag approximation) |

--- a/docs/validation/claim-register.yaml
+++ b/docs/validation/claim-register.yaml
@@ -880,7 +880,7 @@ claims:
   - claimId: EPOCH-ALIGN
     product: Epoch alignment
     algorithm: ICP (yaw + horizontal translation model; full model optional)
-    methodId: olv.registration.icp-planar
+    methodId: olv.registration.epoch-horizontal-icp
     algorithmVersion: v0.5.x
     claim: "Rigid alignment of two epochs; horizontal-only model preserves the vertical signal."
     currentEvidence: E2_ANALYTICALLY_VERIFIED

--- a/src/science/methodRegistry.ts
+++ b/src/science/methodRegistry.ts
@@ -192,6 +192,20 @@ export const METHOD_REGISTRY: Readonly<Record<string, MethodEntry>> = {
     category: 'registration',
     implementation: ['src/registration/planarIcp.ts'],
   },
+  'olv.registration.epoch-horizontal-icp': {
+    id: 'olv.registration.epoch-horizontal-icp',
+    version: 1,
+    name: 'Repeat-epoch horizontal alignment (yaw + XY, Z locked)',
+    summary:
+      'The transform applied to align repeat epochs: the yaw and translation from ' +
+      'the planar ICP solver, with the vertical component constrained to zero so a ' +
+      'real elevation change between epochs is preserved rather than absorbed into ' +
+      'the fit. Describes the applied product; the generic solver it wraps is ' +
+      'olv.registration.icp-planar.',
+    citation: 'Besl & McKay (1992), doi:10.1109/34.121791; Umeyama (1991) planar LS',
+    category: 'registration',
+    implementation: ['src/terrain/change/alignEpochs.ts', 'src/registration/planarIcp.ts'],
+  },
   'olv.volume.stockpile': {
     id: 'olv.volume.stockpile',
     version: 1,

--- a/src/terrain/change/alignEpochs.ts
+++ b/src/terrain/change/alignEpochs.ts
@@ -73,11 +73,29 @@ export interface AlignEpochOptions {
   readonly horizontalUnitKnown?: boolean;
 }
 
+/**
+ * The degrees of freedom of the transform ACTUALLY applied to the `after`
+ * cloud — provenance for the applied product, not the intermediate solver. The
+ * solver (`icpRegister`, method `olv.registration.icp-planar`) computes yaw plus
+ * a full 3-D translation; the repeat-epoch path (method
+ * `olv.registration.epoch-horizontal-icp`) applies `yaw+xy` with Z locked to
+ * preserve a real vertical change, or `yaw+xyz` only when a caller opts out of
+ * the horizontal-only model. `none` when nothing was applied (refused,
+ * degenerate, low overlap, geographic, or frame-incompatible).
+ */
+export type EpochAppliedDof = 'yaw+xy' | 'yaw+xyz' | 'none';
+
 export interface EpochAlignment {
   /** A fit was attempted (both clouds had enough points). */
   readonly attempted: boolean;
   /** The solved transform was applied to the `after` cloud. */
   readonly applied: boolean;
+  /**
+   * Degrees of freedom of the APPLIED transform — describes what moved the
+   * points, not what the solver computed. `yaw+xy` is the repeat-epoch default
+   * (Z locked); a fit that is not applied reports `none`.
+   */
+  readonly appliedDof: EpochAppliedDof;
   /** The residual exceeded the gate, so the transform was NOT applied. */
   readonly refused: boolean;
   /** Too few finite points in a cloud to align. */
@@ -144,6 +162,7 @@ export const LOW_OVERLAP_FRACTION = 0.5;
 const NO_ALIGNMENT: EpochAlignment = {
   attempted: false,
   applied: false,
+  appliedDof: 'none',
   refused: false,
   degenerate: true,
   rmsResidualM: Infinity,
@@ -327,6 +346,7 @@ export function alignEpochClouds(
       alignment: {
         attempted: true,
         applied: false,
+        appliedDof: 'none',
         refused: fit.refused,
         degenerate: fit.degenerate,
         rmsResidualM,
@@ -351,6 +371,7 @@ export function alignEpochClouds(
       alignment: {
         attempted: true,
         applied: false,
+        appliedDof: 'none',
         refused: false,
         degenerate: false,
         rmsResidualM,
@@ -390,6 +411,7 @@ export function alignEpochClouds(
     alignment: {
       attempted: true,
       applied: true,
+      appliedDof: horizontalOnly ? 'yaw+xy' : 'yaw+xyz',
       refused: false,
       degenerate: false,
       rmsResidualM,

--- a/tests/alignEpochs.test.ts
+++ b/tests/alignEpochs.test.ts
@@ -54,6 +54,8 @@ describe('alignEpochClouds', () => {
     const after = cloudFrom(base.map(([x, y, z]) => [x + 3, y - 2, z + 0.5] as P));
     const r = alignEpochClouds(before, after); // horizontalOnly defaults true
     expect(r.alignment.applied).toBe(true);
+    // Provenance describes the APPLIED transform: yaw + XY, Z locked.
+    expect(r.alignment.appliedDof).toBe('yaw+xy');
     expect(r.alignment.translation[2]).toBe(0); // no z applied
     let maxHoriz = 0;
     let minZDelta = Infinity;
@@ -72,6 +74,7 @@ describe('alignEpochClouds', () => {
     const after = cloudFrom(base.map(([x, y, z]) => [x + 3, y - 2, z + 0.5] as P));
     const r = alignEpochClouds(cloudFrom(base), after, { horizontalOnly: false });
     expect(r.alignment.applied).toBe(true);
+    expect(r.alignment.appliedDof).toBe('yaw+xyz'); // opted out of Z-lock
     let maxErr = 0;
     for (let i = 0; i < base.length; i++) {
       const dx = r.after.positions[i * 3] - base[i][0];
@@ -110,7 +113,31 @@ describe('alignEpochClouds', () => {
     expect(r.alignment.attempted).toBe(true);
     expect(r.alignment.refused).toBe(true);
     expect(r.alignment.applied).toBe(false);
+    expect(r.alignment.appliedDof).toBe('none'); // nothing applied
     expect(r.after).toBe(b); // unchanged reference
+  });
+
+  test('withholds a low-overlap (subset-lock) fit and applies nothing', () => {
+    // 30% of `after` matches `before` under a +3/-2 shift; the other 70% is
+    // scattered far away with no correspondence, so the inlier fraction falls
+    // below the gate. With trimming the solver still locks onto the matching
+    // subset (a small residual), which is exactly the failure RMS alone hides —
+    // the transform must be WITHHELD, not applied.
+    const base = scatter(200);
+    const after = cloudFrom(
+      base.map(([x, y, z], i) =>
+        i % 10 < 3
+          ? ([x + 3, y - 2, z] as P)
+          : ([x + 800 + (i % 7), y - 800 - (i % 5), z + 40] as P),
+      ),
+    );
+    const r = alignEpochClouds(cloudFrom(base), after, { trimFraction: 0.3, maxResidualM: 1 });
+    expect(r.alignment.attempted).toBe(true);
+    expect(r.alignment.lowOverlap).toBe(true);
+    expect(r.alignment.overlapFraction).toBeLessThan(0.5);
+    expect(r.alignment.applied).toBe(false);
+    expect(r.alignment.appliedDof).toBe('none');
+    expect(r.after).toBe(after); // unchanged reference — compared as-is
   });
 
   test('a georeferenced (UTM-scale origin) cloud keeps centimetre precision through alignment', () => {


### PR DESCRIPTION
§10 of the v0.6.8 hardening pass. The repeat-epoch path applies **yaw + XY with Z locked** (so a real vertical change survives), but the `EPOCH-ALIGN` claim pointed at the generic solver method `olv.registration.icp-planar`, whose registry summary reads "yaw + 3-D translation" — the intermediate solver, not the transform actually applied to the product.

- New method `olv.registration.epoch-horizontal-icp` v1 ("yaw + XY, Z locked"), wrapping the `icp-planar` solver; `EPOCH-ALIGN` repointed to it. `METHOD_REGISTRY.md` row + generated registry kept in parity.
- `EpochAlignment` now records `appliedDof` (`'yaw+xy' | 'yaw+xyz' | 'none'`) — the degrees of freedom of the transform *applied to the points*, distinct from what the solver computed.
- Tests: `appliedDof` across the horizontal / full-3D / refused paths, plus the previously **untested low-overlap subset-lock** case (fit withheld: `applied=false`, `dof='none'`).

The tz=0 vertical-preservation behaviour was already enforced and tested; this PR makes the provenance describe it. Full suite 13,790 pass / 0 fail; claim-register, method parity, evidence, claims-language, claim-prose-sync all green.