### PR TITLE
feat(terrain): replace estimated USGS QL with an honest density reference (§5)

### DIFF
--- a/src/render/measure/mapSheetPdf.ts
+++ b/src/render/measure/mapSheetPdf.ts
@@ -1093,7 +1093,7 @@ function drawTitleBlock(
         ['NVA-style (95%, hold-out)', fmtM(prov.accuracy?.nvaM)],
         ['VVA-style (95th pct, hold-out)', fmtM(prov.accuracy?.vvaM)],
         ['RMSEz', fmtM(prov.accuracy?.rmseZM)],
-        ['USGS 3DEP', prov.accuracy && prov.accuracy.usgsQualityLevel !== 'unknown' ? `${prov.accuracy.usgsQualityLevel} (estimated)` : '—'],
+        ['USGS density ref', prov.accuracy && prov.accuracy.usgsDensityReferenceFloor !== 'none' ? `>= ${prov.accuracy.usgsDensityReferenceFloor} floor` : '—'],
       ]
     : (() => {
         const a = input.accuracy ?? null;
@@ -1101,7 +1101,10 @@ function drawTitleBlock(
           ['NVA-style (95%, hold-out)', fmtM(a?.nvaM)],
           ['VVA-style (95th pct, hold-out)', fmtM(a?.vvaM)],
           ['RMSEz', fmtM(a?.rmseZM)],
-          ['USGS 3DEP', a && a.qualityLevel !== 'unknown' ? `${a.qualityLevel} (estimated)` : '—'],
+          [
+            'USGS density ref',
+            a && a.densityReferenceFloorsMet.length > 0 ? `>= ${a.densityReferenceFloorsMet[0]} floor` : '—',
+          ],
         ];
       })();
   aRows.forEach((r, i) => {

--- a/src/terrain/contour/analyseContours.ts
+++ b/src/terrain/contour/analyseContours.ts
@@ -1015,12 +1015,11 @@ export function computeTerrainCore(
     cellMetrics.meanDensity,
   );
   // Stride honesty: when the gather strided the cloud, the ground density (and
-  // therefore the USGS 3DEP Quality Level graded from it) is a uniform-stride
+  // therefore the USGS 3DEP density reference derived from it) is a uniform-stride
   // extrapolation from the analysed subsample up to the full scan, NOT a
-  // directly counted figure. Surface that the same way the space-scan path
-  // does, so the density-derived QL is never read as an exact, directly-counted
-  // grade. Only when striding actually happened (scale > 1) and a density-based
-  // grade was assigned.
+  // directly counted figure. Surface that the same way the space-scan path does,
+  // so the density figure is never read as an exact, directly-counted one. Only
+  // when striding actually happened (scale > 1) and a density was measured.
   const densityScale =
     Number.isFinite(params.samplePointScale) && (params.samplePointScale as number) > 1
       ? (params.samplePointScale as number)
@@ -1028,7 +1027,7 @@ export function computeTerrainCore(
   if (densityScale > 1 && cellMetrics.meanDensity > 0) {
     warnings.push(
       'Ground density is scaled from the analysed sample to the full scan ' +
-        '(uniform-stride assumption); the USGS 3DEP Quality Level is graded ' +
+        '(uniform-stride assumption); the USGS 3DEP density reference is derived ' +
         'from that scaled density, not a directly counted one.',
     );
   }

--- a/src/terrain/contour/contourCopy.ts
+++ b/src/terrain/contour/contourCopy.ts
@@ -71,12 +71,11 @@ export const METRIC_TOOLTIPS = {
     'VVA-style (hold-out) — the ASPRS vegetated vertical accuracy FORMULA ' +
     '(95th percentile), computed over ALL hold-out residuals, NOT ' +
     'vegetated-class checkpoints.',
-  qualityLevel:
-    'USGS 3DEP Quality Level — where the measured ground density and ' +
-    'vertical accuracy sit against the 3DEP thresholds for that level. ' +
-    'Estimated, not a determination: the RMSEz leg is measured on ' +
-    'internally withheld points (hold-out), NOT the independent ' +
-    'checkpoints a 3DEP assessment requires.',
+  densityReference:
+    'USGS density reference — which 3DEP nominal-pulse-density floor the ' +
+    'measured GROUND-return density clears, as context only. Ground-return ' +
+    'density is not nominal pulse density (NPD/ANPD), so this is a reference ' +
+    'threshold, never a USGS 3DEP quality-level determination.',
   crs:
     'CRS — coordinate reference system; exports are not georeferenced ' +
     'without it.',

--- a/src/terrain/export/exportProvenance.ts
+++ b/src/terrain/export/exportProvenance.ts
@@ -162,8 +162,12 @@ export interface ExportProvenanceAccuracy {
   readonly nvaM: number | null;
   /** Vegetated Vertical Accuracy (95th pct) in metres. */
   readonly vvaM: number | null;
-  /** USGS 3DEP Quality Level (e.g. 'QL2'), or 'unknown'. */
-  readonly usgsQualityLevel: string;
+  /**
+   * The strongest USGS 3DEP nominal-pulse-density FLOOR the measured
+   * ground-return density clears (e.g. 'QL2'), or 'none'. A reference threshold,
+   * NOT a quality-level determination — ground-return density is not pulse density.
+   */
+  readonly usgsDensityReferenceFloor: string;
 }
 
 /**
@@ -353,7 +357,7 @@ export function buildExportProvenance(
           rmseZM: acc.rmseZM,
           nvaM: acc.nvaM ?? null,
           vvaM: acc.vvaM ?? null,
-          usgsQualityLevel: acc.qualityLevel ?? 'unknown',
+          usgsDensityReferenceFloor: acc.densityReferenceFloorsMet[0] ?? 'none',
         }
       : null;
   const pointDensityPerM2 =
@@ -472,7 +476,7 @@ export function analysisRecordFromProvenance(p: ExportProvenance): ScientificAna
       surfaceQuality: p.surfaceQuality,
       exportReadiness: p.exportReadiness,
       rmseZM: p.accuracy?.rmseZM ?? null,
-      usgsQualityLevel: p.accuracy?.usgsQualityLevel ?? 'unknown',
+      usgsDensityReferenceFloor: p.accuracy?.usgsDensityReferenceFloor ?? 'none',
       pointDensityPerM2: p.pointDensityPerM2,
       measuredCells: p.measuredCells,
       totalCells: p.totalCells,
@@ -653,13 +657,13 @@ export function provenanceLines(p: ExportProvenance): string[] {
     // checkpoints (see verticalAccuracy.ts for the honesty boundary).
     kv('NVA-style (95%, hold-out)', p.accuracy ? fmtM(p.accuracy.nvaM) : 'unknown'),
     kv('VVA-style (95th pct, hold-out)', p.accuracy ? fmtM(p.accuracy.vvaM) : 'unknown'),
-    // "(estimated)" mirrors the panel chip: the QL's RMSEz leg is hold-out-
-    // based (withheld points, not independent checkpoints), so the stamped
-    // grade must carry the same qualifier the screen does.
+    // A density REFERENCE, not a quality-level grade: it names the 3DEP
+    // nominal-pulse-density floor the measured ground-return density clears.
+    // Ground-return density is not a pulse-density determination.
     kv(
-      'USGS 3DEP',
-      p.accuracy && p.accuracy.usgsQualityLevel !== 'unknown'
-        ? `${p.accuracy.usgsQualityLevel} (estimated)`
+      'USGS density ref',
+      p.accuracy && p.accuracy.usgsDensityReferenceFloor !== 'none'
+        ? `${p.accuracy.usgsDensityReferenceFloor} density floor (reference)`
         : 'unknown',
     ),
     kv(
@@ -769,11 +773,11 @@ export function provenanceJson(p: ExportProvenance): Record<string, unknown> {
           rmseZM: p.accuracy.rmseZM,
           nvaM: p.accuracy.nvaM,
           vvaM: p.accuracy.vvaM,
-          usgsQualityLevel: p.accuracy.usgsQualityLevel,
+          usgsDensityReferenceFloor: p.accuracy.usgsDensityReferenceFloor,
           // The text surfaces qualify these in the label itself ("NVA-style
-          // (95%, hold-out)", "QL2 (estimated)"). A JSON key cannot, and a
-          // consumer reading `nvaM` has nothing telling it the figure is not an
-          // ASPRS checkpoint result — so the qualifier is a field.
+          // (95%, hold-out)", "USGS density ref: >= QL2 floor"). A JSON key
+          // cannot, and a consumer reading `nvaM` has nothing telling it the
+          // figure is not an ASPRS checkpoint result — so the qualifier is a field.
           basis: ACCURACY_BASIS_NOTE,
         }
       : null,

--- a/src/terrain/export/terrainReportContent.ts
+++ b/src/terrain/export/terrainReportContent.ts
@@ -336,10 +336,10 @@ export function buildTerrainReportContent(
   // ── Quality Metrics ─────────────────────────────────────────────────────
   // ASPRS / USGS 3DEP vocabulary, honestly null-able: when the run measured no
   // RMSEz the whole block reads em-dash / unknown rather than a fabricated zero.
-  const qlFallback = acc && acc.qualityLevel !== 'unknown' ? acc.qualityLevel : DASH;
+  const qlFallback = acc && acc.densityReferenceFloorsMet.length > 0 ? acc.densityReferenceFloorsMet[0] : DASH;
   const qlValue =
-    hasAcc && provenance.accuracy && provenance.accuracy.usgsQualityLevel !== 'unknown'
-      ? provenance.accuracy.usgsQualityLevel
+    hasAcc && provenance.accuracy && provenance.accuracy.usgsDensityReferenceFloor !== 'none'
+      ? provenance.accuracy.usgsDensityReferenceFloor
       : qlFallback;
   // Phase 4 honesty figures, single-sourced from the same result the panel
   // shows. ASCII only (the PDF renderer strips non-Latin1), so "<=" not "≤".
@@ -367,7 +367,7 @@ export function buildTerrainReportContent(
       // spatially-blocked RMSE — the same numbers the Analyse panel surfaces.
       { label: 'Measured reliability', value: reliabilityValue },
       { label: 'Blocked RMSE (spatial CV)', value: blockedValue },
-      { label: 'USGS 3DEP Quality Level', value: qlValue === DASH ? DASH : `${qlValue} (estimated)` },
+      { label: 'USGS density reference', value: qlValue === DASH ? DASH : `>= ${qlValue} floor` },
     ],
   };
 

--- a/src/terrain/quality/demAccuracyStandards.ts
+++ b/src/terrain/quality/demAccuracyStandards.ts
@@ -2,25 +2,33 @@
  * demAccuracyStandards.ts
  *
  * Express the DEM's measured vertical accuracy in the terms a surveyor or
- * agency reviewer expects — the ASPRS 2014 / USGS 3DEP vocabulary — instead of
- * a bare RMSE:
+ * agency reviewer expects — the ASPRS 2014 formula vocabulary — instead of a
+ * bare RMSE, and place the measured GROUND-RETURN density against the USGS 3DEP
+ * density figures as a REFERENCE:
  *
  *   NVA  Non-vegetated Vertical Accuracy at 95% confidence = RMSEz × 1.9600
  *        (valid where error is ~Gaussian: open, bare ground).
  *   VVA  Vegetated Vertical Accuracy at the 95th percentile = the 95th
  *        percentile of the ABSOLUTE residuals (non-parametric, because error
  *        under canopy is skewed — so NOT RMSEz × 1.96).
- *   QL   USGS 3DEP Quality Level, the joint (point-density, RMSEz) grade the
- *        national elevation program collects against. QL2 ("≥2 pts/m² and
- *        ≤0.10 m RMSEz") is the 3DEP baseline.
+ *
+ * WHY NO QUALITY-LEVEL GRADE. A USGS 3DEP Quality Level is a PULSE-density
+ * determination (NPD/ANPD), measured from first returns with single-/usable-
+ * swath context — not the mean GROUND-return density this module has. Ground
+ * returns per square metre are not nominal pulse density, and a merged/tiled
+ * cloud may not carry enough information to determine a collection QL at all.
+ * So this module does NOT emit an "estimated QLx" grade from ground density +
+ * hold-out RMSE. It reports the measured ground-return density and, as CONTEXT
+ * only, which 3DEP nominal-pulse-density FLOORS that density clears — a
+ * reference threshold, never a quality-level determination.
  *
  * HONESTY BOUNDARY: the RMSEz/p95 fed in here come from HOLD-OUT validation
  * (internally withheld ground points), not from the independent survey
  * checkpoints ASPRS 2014 defines NVA/VVA against — and the VVA-analog is the
  * p95 of ALL residuals, not vegetated-class checkpoints. The FORMULAS are
- * ASPRS's; the CLAIM is an estimate. Every user-facing surface must qualify
- * the figures as "-style (hold-out)" and the QL as "(estimated)"; see
- * `verticalAccuracy.ts` for the full statement of this boundary.
+ * ASPRS's; the CLAIM is an estimate. Every user-facing surface qualifies the
+ * figures as "-style (hold-out)"; see `verticalAccuracy.ts` for the full
+ * statement of this boundary.
  *
  * Pure data: no DOM, no I/O. Deterministic. Arithmetic only — the inputs are
  * already produced by the hold-out validation and the cell-metric rollup.
@@ -35,7 +43,9 @@ import { NVA_95_MULTIPLIER } from '../validate/verticalAccuracy';
  */
 export const NVA_K = NVA_95_MULTIPLIER;
 
-export type UsgsQualityLevel = 'QL0' | 'QL1' | 'QL2' | 'QL3' | 'below-QL3' | 'unknown';
+/** A USGS 3DEP quality level whose nominal-pulse-density floor is used here only
+ *  as a REFERENCE threshold against measured ground-return density. */
+export type UsgsDensityFloor = 'QL0' | 'QL1' | 'QL2' | 'QL3';
 
 export interface DemAccuracyStandards {
   /** Measured RMSEz in metres (null when not assessable). */
@@ -44,48 +54,37 @@ export interface DemAccuracyStandards {
   readonly nvaM: number | null;
   /** Vegetated Vertical Accuracy = 95th percentile of |residual|, metres. */
   readonly vvaM: number | null;
-  /** Mean ground returns per square metre. */
+  /**
+   * Mean GROUND-return density (pts/m²). Named `pointDensityPerM2` for the
+   * export-provenance schema that carries it; it is ground-return density, which
+   * is NOT nominal pulse density (NPD/ANPD).
+   */
   readonly pointDensityPerM2: number;
-  /** Best USGS 3DEP Quality Level the data satisfies on BOTH density + RMSEz. */
-  readonly qualityLevel: UsgsQualityLevel;
-  /** Human-readable basis for the QL verdict. */
-  readonly qualityLevelReason: string;
+  /**
+   * The USGS 3DEP nominal-pulse-density FLOORS the measured ground-return
+   * density clears, strongest first — a REFERENCE comparison only. Empty when
+   * the density is unknown or below the QL3 floor. Never a quality-level
+   * determination: ground-return density is not a pulse-density measurement.
+   */
+  readonly densityReferenceFloorsMet: readonly UsgsDensityFloor[];
+  /** Human-readable reference note for the density figure (context, not a grade). */
+  readonly densityReferenceNote: string;
 }
 
 /**
- * USGS 3DEP joint nominal-pulse-density (pts/m²) + RMSEz (m) thresholds,
- * transcribed from the published quality-level table of the USGS Lidar Base
- * Specification (3D Elevation Program, "Topographic Data Quality Levels (QLs)",
- * Table 1):
- *
- *   QL0  RMSEz  5 cm   NPS ≤ 0.35 m   NPD ≥ 8   pts/m²
- *   QL1  RMSEz 10 cm   NPS ≤ 0.35 m   NPD ≥ 8   pts/m²
- *   QL2  RMSEz 10 cm   NPS ≤ 0.71 m   NPD ≥ 2   pts/m²
- *   QL3  RMSEz 20 cm   NPS ≤ 1.41 m   NPD ≥ 0.5 pts/m²
- *
- * BOTH BOUNDS ARE INCLUSIVE, and the comparisons below say so with `>=` / `<=`:
- * the specification writes the density leg as "≥ N pts/square meter", and states
- * the accuracy leg as the RMSEz a collection is required to be at or within, so
- * a value that lands exactly on either figure MEETS that level. Only the density
- * leg is checked here; nominal pulse SPACING is the same quantity expressed
- * inversely, and this module has no swath geometry to check the rest of the
- * specification's collection requirements against.
- *
- * Ordered best level first, and each successive row relaxes BOTH legs (density
- * non-increasing, RMSEz non-decreasing), so the first row a pair satisfies is
- * also the strongest row it satisfies. `tests/qualityLevelOracle.test.ts` pins
- * that property against an independent transcription of the table above, so a
- * reordered or edited row fails rather than silently returning a weaker level.
+ * USGS 3DEP nominal-pulse-density floors (pts/m²), transcribed from the USGS
+ * Lidar Base Specification quality-level table. These are PULSE-density figures;
+ * here they are used only as reference thresholds against measured ground-return
+ * density. QL0 and QL1 share the same 8 pts/m² density floor (they differ by
+ * RMSEz, which is not part of a density reference). Ordered strongest first.
+ * `tests/qualityLevelOracle.test.ts` pins these against an independent
+ * transcription.
  */
-const QL_TABLE: ReadonlyArray<{
-  level: Exclude<UsgsQualityLevel, 'below-QL3' | 'unknown'>;
-  minDensity: number;
-  maxRmseM: number;
-}> = [
-  { level: 'QL0', minDensity: 8, maxRmseM: 0.05 },
-  { level: 'QL1', minDensity: 8, maxRmseM: 0.1 },
-  { level: 'QL2', minDensity: 2, maxRmseM: 0.1 },
-  { level: 'QL3', minDensity: 0.5, maxRmseM: 0.2 },
+const DENSITY_FLOORS: ReadonlyArray<{ level: UsgsDensityFloor; minDensity: number }> = [
+  { level: 'QL0', minDensity: 8 },
+  { level: 'QL1', minDensity: 8 },
+  { level: 'QL2', minDensity: 2 },
+  { level: 'QL3', minDensity: 0.5 },
 ];
 
 /**
@@ -102,26 +101,24 @@ export function demAccuracyStandards(
   const rmseOk = rmseZM != null && Number.isFinite(rmseZM) && rmseZM >= 0;
   const density = Number.isFinite(pointDensityPerM2) && pointDensityPerM2 > 0 ? pointDensityPerM2 : 0;
 
-  let qualityLevel: UsgsQualityLevel;
-  let qualityLevelReason: string;
-  if (!rmseOk || density <= 0) {
-    qualityLevel = 'unknown';
-    qualityLevelReason = !rmseOk
-      ? 'Not enough validated points to measure RMSEz.'
-      : 'No measured ground density.';
+  const densityReferenceFloorsMet = density > 0
+    ? DENSITY_FLOORS.filter((f) => density >= f.minDensity).map((f) => f.level)
+    : [];
+
+  let densityReferenceNote: string;
+  if (density <= 0) {
+    densityReferenceNote = 'No measured ground-return density.';
   } else {
-    const rmse = rmseZM as number;
-    const match = QL_TABLE.find((q) => density >= q.minDensity && rmse <= q.maxRmseM);
-    if (match) {
-      qualityLevel = match.level;
-      // A two-metric comparison (ground density + hold-out RMSEz) against the
-      // 3DEP thresholds — NOT a 3DEP quality-level determination, which requires
-      // independent checkpoint accuracy we do not have. Word it as a comparison.
-      qualityLevelReason = `${density.toFixed(1)} pts/m² and ${rmse.toFixed(2)} m RMSEz match the ${match.level} density + vertical thresholds — an indicative comparison, not a USGS 3DEP determination.`;
-    } else {
-      qualityLevel = 'below-QL3';
-      qualityLevelReason = `${density.toFixed(1)} pts/m² / ${rmse.toFixed(2)} m RMSEz is below the USGS QL3 thresholds (indicative comparison, not a 3DEP determination).`;
-    }
+    // The strongest floor cleared, named as a reference. QL0/QL1 share the 8
+    // pts/m² floor, so report the first (strongest) distinct label.
+    const strongest = densityReferenceFloorsMet[0];
+    const floorText = strongest
+      ? `clears the USGS 3DEP ${strongest} nominal-pulse-density floor`
+      : 'is below the USGS 3DEP QL3 nominal-pulse-density floor (0.5 pulses/m²)';
+    densityReferenceNote =
+      `${density.toFixed(1)} ground returns/m² ${floorText}. ` +
+      'Ground-return density is a reference against the 3DEP pulse-density figures, ' +
+      'not a nominal-pulse-density (NPD/ANPD) determination or a quality-level grade.';
   }
 
   return {
@@ -129,7 +126,7 @@ export function demAccuracyStandards(
     nvaM: rmseOk ? (rmseZM as number) * NVA_K : null,
     vvaM: vvaM != null && Number.isFinite(vvaM) ? vvaM : null,
     pointDensityPerM2: density,
-    qualityLevel,
-    qualityLevelReason,
+    densityReferenceFloorsMet,
+    densityReferenceNote,
   };
 }

--- a/src/terrain/quality/scanFitness.ts
+++ b/src/terrain/quality/scanFitness.ts
@@ -80,8 +80,13 @@ export interface FitnessInputs {
   readonly hasGroundClass: boolean;
   // Integrity / provenance
   readonly coverageMode: string; // 'full' | 'resident-only' | 'sampled' | …
-  /** A USGS-style named tier when one is earnable, else null. */
-  readonly qualityLevel?: string | null;
+  /**
+   * The strongest USGS 3DEP nominal-pulse-density FLOOR the measured
+   * ground-return density clears (e.g. 'QL2'), or null. A reference threshold,
+   * NOT a quality-level determination — ground-return density is not pulse
+   * density.
+   */
+  readonly densityReferenceFloor?: string | null;
 }
 
 /** One traffic-light row in the scorecard. */
@@ -339,14 +344,16 @@ export function buildScanFitness(inp: FitnessInputs): ScanFitness {
     verdict = `Still streaming — ${verdict.charAt(0).toLowerCase()}${verdict.slice(1)}`;
   }
 
-  // A named tier is only earned when density AND accuracy both pass, the file is
-  // georeferenced, AND the grade is on the full cloud — otherwise the QL label
-  // would overclaim (a partial/streaming sample can't earn a tier).
+  // A density-reference badge is shown only when density AND accuracy both pass,
+  // the file is georeferenced, AND the figure is on the full cloud — otherwise a
+  // partial/streaming sample would misrepresent the density. It names the 3DEP
+  // pulse-density FLOOR the ground-return density clears as a REFERENCE, never a
+  // quality-level grade (ground-return density is not a pulse determination).
   const densTone = dimensions.find((d) => d.key === 'density')!.tone;
   const accTone = dimensions.find((d) => d.key === 'accuracy')!.tone;
   const tierBadge =
-    inp.qualityLevel && !provisional && densTone !== 'review' && accTone !== 'review' && inp.crsKnown
-      ? `${inp.qualityLevel} (estimated)`
+    inp.densityReferenceFloor && !provisional && densTone !== 'review' && accTone !== 'review' && inp.crsKnown
+      ? `≥ ${inp.densityReferenceFloor} density floor`
       : null;
 
   // The headline is a bare "± m" claim, so it too is withheld on an unverified

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -2173,32 +2173,25 @@ export class AnalysePanel {
           `${METRIC_TOOLTIPS.nva} ${METRIC_TOOLTIPS.vva}`,
         ));
       }
-      if (std.qualityLevel !== 'unknown') {
-        const qlReason = std.qualityLevelReason;
-        // When the gather strided the cloud, the density behind the QL is a
-        // uniform-stride extrapolation (the core pushes a warning saying so).
-        // Carry that into the QL hint so the chip is never read as an exact,
-        // directly-counted grade — the same honesty the space-scan path gives.
+      if (std.densityReferenceFloorsMet.length > 0) {
+        // When the gather strided the cloud, the density is a uniform-stride
+        // extrapolation (the core pushes a warning saying so). Carry that into
+        // the hint so the figure is never read as an exact, directly-counted
+        // density — the same honesty the space-scan path gives.
         const strideNote = (this._result?.warnings ?? []).some((w) =>
           w.includes('uniform-stride assumption'),
         )
-          ? ' Density is scaled from the analysed sample (uniform-stride assumption), so this grade is an estimate.'
+          ? ' Density is scaled from the analysed sample (uniform-stride assumption).'
           : '';
-        // Keep the dynamic gate reason in the hint, but lead with the
-        // plain-language explanation of what a Quality Level actually is.
-        const qlTooltip =
-          (qlReason
-            ? `${METRIC_TOOLTIPS.qualityLevel} ${qlReason}`
-            : METRIC_TOOLTIPS.qualityLevel) + strideNote;
-        // "(estimated)": the QL's vertical-accuracy leg is hold-out-based
-        // (and the density leg may be stride-scaled) — never a measured,
-        // checkpoint-verified 3DEP grade. The tooltip spells out why.
+        // A density REFERENCE, not a quality-level grade: ground-return density
+        // is not a nominal-pulse-density determination. The chip names the 3DEP
+        // density floor cleared as context; the tooltip states the boundary.
         this._validationRow.append(this._hint(
           el('div', {
             className: 'olv-analyse-ql',
-            text: `USGS 3DEP ${std.qualityLevel} (estimated)`,
+            text: `USGS density ref: ≥ ${std.densityReferenceFloorsMet[0]} floor`,
           }),
-          qlTooltip,
+          std.densityReferenceNote + strideNote,
         ));
       }
     }
@@ -2838,9 +2831,13 @@ export class AnalysePanel {
       ['NVA-style (95%, hold-out)', fmtM(a?.nvaM)],
       ['VVA-style (95th pct, hold-out)', fmtM(a?.vvaM)],
       ['RMSEz', fmtM(a?.rmseZM)],
-      // "(estimated)" — same qualifier the panel chip and provenance stamp
-      // carry: the QL's RMSEz leg is hold-out-based, never checkpoint-verified.
-      ['USGS 3DEP', a && a.qualityLevel !== 'unknown' ? `${a.qualityLevel} (estimated)` : '—'],
+      // A density REFERENCE (which 3DEP nominal-pulse-density floor the measured
+      // ground-return density clears), not a quality-level grade — ground-return
+      // density is not a pulse-density determination.
+      [
+        'USGS density ref',
+        a && a.densityReferenceFloorsMet.length > 0 ? `≥ ${a.densityReferenceFloorsMet[0]} floor` : '—',
+      ],
       ['Approx. scale', 'auto — fits sheet'],
       ['Generated', generatedAt.toISOString().slice(0, 16).replace('T', ' ') + ' UTC'],
     ];
@@ -3081,7 +3078,7 @@ export class AnalysePanel {
     const a = terrainAssessment(r);
     const t = r.cellStatusTally;
     const covered = t.measured + t.interpolated + t.lowConfidence + t.edgeRisk;
-    const ql = r.accuracyStandards.qualityLevel;
+    const densityFloor = r.accuracyStandards.densityReferenceFloorsMet[0] ?? null;
     const hasClass = r.excludedByClassification > 0;
     // Whether the source linear unit is confirmed — the same gate every other
     // unit consumer applies (`crs.linearUnit !== 'unknown'`). An unknown-unit or
@@ -3111,7 +3108,7 @@ export class AnalysePanel {
       unclassifiedFraction: hasClass ? 0 : null,
       hasGroundClass: hasClass,
       coverageMode: r.dtm.coverageMode,
-      qualityLevel: ql !== 'unknown' ? ql : null,
+      densityReferenceFloor: densityFloor,
     };
     const f = buildScanFitness(inputs);
 

--- a/tests/benchmark/provenanceIntegrity.test.ts
+++ b/tests/benchmark/provenanceIntegrity.test.ts
@@ -98,8 +98,7 @@ function readyResult(): AnalyseContoursResult {
       nvaM: 0.27,
       vvaM: 0.3,
       pointDensityPerM2: 4.2,
-      qualityLevel: 'QL2',
-      qualityLevelReason: '4.2 pts/m² and 0.14 m RMSEz meet QL2.',
+      densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
     },
     quality: {
       readiness: 'ready',

--- a/tests/contourDownload.test.ts
+++ b/tests/contourDownload.test.ts
@@ -17,7 +17,7 @@ const PROV: ExportProvenance = {
   contourRequestedIntervalM: null,
   contourMethod: null, contourGeneralizeToleranceCells: null, deliverablePurpose: null,
   surfaceQuality: 'Good', exportReadiness: 'Ready', exportReason: '',
-  accuracy: { rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, usgsQualityLevel: 'QL2' },
+  accuracy: { rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, usgsDensityReferenceFloor: 'QL2' },
   complexity: null,
   pointDensityPerM2: 4.2, measuredCells: 90, totalCells: 100, classScope: null, warnings: [],
   notSurveyGrade: 'Suitability: not survey-grade unless validated against ground-truth control.',

--- a/tests/demAccuracyStandards.test.ts
+++ b/tests/demAccuracyStandards.test.ts
@@ -1,5 +1,6 @@
 /**
- * demAccuracyStandards.test.ts — ASPRS/USGS 3DEP accuracy expression.
+ * demAccuracyStandards.test.ts — ASPRS accuracy expression + USGS density
+ * REFERENCE (no quality-level grade is emitted from ground-return density).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -14,23 +15,34 @@ describe('demAccuracyStandards', () => {
     expect(s.rmseZM).toBe(0.08);
   });
 
-  it('assigns USGS Quality Levels on joint density + RMSEz', () => {
-    // ≥8 pts/m² and ≤0.05 m → QL0
-    expect(demAccuracyStandards(0.04, 0.1, 9).qualityLevel).toBe('QL0');
-    // ≥8 and ≤0.10 (but >0.05) → QL1
-    expect(demAccuracyStandards(0.08, 0.1, 9).qualityLevel).toBe('QL1');
-    // ≥2 and ≤0.10 → QL2 (the 3DEP baseline)
-    expect(demAccuracyStandards(0.09, 0.1, 3).qualityLevel).toBe('QL2');
-    // dense but inaccurate falls back to the accuracy it actually meets
-    expect(demAccuracyStandards(0.18, 0.3, 9).qualityLevel).toBe('QL3');
-    // too sparse / inaccurate for any level
-    expect(demAccuracyStandards(0.5, 0.9, 0.1).qualityLevel).toBe('below-QL3');
+  it('reports which USGS density FLOORS the ground-return density clears (reference only)', () => {
+    // ≥8 pts/m² clears QL0/QL1 (8), QL2 (2) and QL3 (0.5) density floors.
+    expect(demAccuracyStandards(0.04, 0.1, 9).densityReferenceFloorsMet).toEqual(['QL0', 'QL1', 'QL2', 'QL3']);
+    // ≥2 but <8 clears QL2 and QL3 only.
+    expect(demAccuracyStandards(0.09, 0.1, 3).densityReferenceFloorsMet).toEqual(['QL2', 'QL3']);
+    // ≥0.5 but <2 clears QL3 only.
+    expect(demAccuracyStandards(0.18, 0.3, 1).densityReferenceFloorsMet).toEqual(['QL3']);
+    // below the QL3 density floor clears none.
+    expect(demAccuracyStandards(0.5, 0.9, 0.1).densityReferenceFloorsMet).toEqual([]);
   });
 
-  it('is unknown when RMSEz or density is unavailable', () => {
-    expect(demAccuracyStandards(null, null, 5).qualityLevel).toBe('unknown');
-    expect(demAccuracyStandards(0.05, 0.1, 0).qualityLevel).toBe('unknown');
+  it('does NOT emit a quality-level grade, and never claims a determination', () => {
+    const s = demAccuracyStandards(0.04, 0.1, 9);
+    // The graded field is gone; the surface exposes a reference note instead.
+    expect((s as unknown as Record<string, unknown>).qualityLevel).toBeUndefined();
+    expect(s.densityReferenceNote).toMatch(/not a nominal-pulse-density/i);
+    expect(s.densityReferenceNote).toMatch(/QL0/); // names the floor cleared as a reference
+  });
+
+  it('has no density floors and an explicit note when density is unavailable', () => {
+    const s = demAccuracyStandards(0.05, 0.1, 0);
+    expect(s.densityReferenceFloorsMet).toEqual([]);
+    expect(s.densityReferenceNote).toMatch(/No measured ground-return density/i);
+  });
+
+  it('nulls the accuracy figures when RMSEz is unavailable', () => {
     const s = demAccuracyStandards(null, null, 5);
     expect(s.nvaM).toBeNull();
+    expect(s.rmseZM).toBeNull();
   });
 });

--- a/tests/demExport.test.ts
+++ b/tests/demExport.test.ts
@@ -210,7 +210,7 @@ describe('buildDemPackage', () => {
       surface: { canopy: { heightM: new Float32Array([0, 5, NaN, NaN]) } },
       accuracyStandards: {
         rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, pointDensityPerM2: 4.2,
-        qualityLevel: 'QL2', qualityLevelReason: '4.2 pts/m² and 0.14 m RMSEz meet QL2.',
+        densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
       },
       quality: {
         readiness: 'ready', exportReadiness: 'available',

--- a/tests/demPackageReadme.test.ts
+++ b/tests/demPackageReadme.test.ts
@@ -25,7 +25,7 @@ function readyResult(): AnalyseContoursResult {
     surface: { canopy: { heightM: new Float32Array([0, 5, NaN, NaN]) } },
     accuracyStandards: {
       rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, pointDensityPerM2: 4.2,
-      qualityLevel: 'QL2', qualityLevelReason: '4.2 pts/m² and 0.14 m RMSEz meet QL2.',
+      densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
     },
     quality: {
       readiness: 'ready', exportReadiness: 'available',

--- a/tests/densitySampleScale.test.ts
+++ b/tests/densitySampleScale.test.ts
@@ -87,7 +87,7 @@ describe('samplePointScale through the terrain pipeline', () => {
       samplePointScale: 4,
     });
     expect(scaled.warnings.some((w) => w.includes('uniform-stride assumption'))).toBe(true);
-    expect(scaled.warnings.some((w) => /USGS 3DEP Quality Level/.test(w))).toBe(true);
+    expect(scaled.warnings.some((w) => /USGS 3DEP density reference/.test(w))).toBe(true);
   });
 
   it('does NOT add the stride caveat for an un-strided (scale 1) run', () => {

--- a/tests/exportProvenance.test.ts
+++ b/tests/exportProvenance.test.ts
@@ -38,7 +38,7 @@ function readyResult(): AnalyseContoursResult {
     model: { crs: 'EPSG:32610', verticalDatum: 'EPSG:5703', intervalM: 1, contourStyle: 'smooth', coverageMode: 'full' },
     accuracyStandards: {
       rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, pointDensityPerM2: 4.2,
-      qualityLevel: 'QL2', qualityLevelReason: '4.2 pts/m² and 0.14 m RMSEz meet QL2.',
+      densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
     },
     quality: {
       readiness: 'ready', exportReadiness: 'available',
@@ -116,7 +116,7 @@ describe('buildExportProvenance — field derivation', () => {
     const p = buildExportProvenance(readyResult(), OPTS);
     expect(p.accuracy).not.toBeNull();
     expect(p.accuracy?.rmseZM).toBeCloseTo(0.14);
-    expect(p.accuracy?.usgsQualityLevel).toBe('QL2');
+    expect(p.accuracy?.usgsDensityReferenceFloor).toBe('QL2');
     expect(p.pointDensityPerM2).toBeCloseTo(4.2);
   });
 
@@ -152,7 +152,7 @@ describe('buildExportProvenance — field derivation', () => {
     const base = readyResult() as unknown as { accuracyStandards: Record<string, unknown> };
     const noAcc = {
       ...(base as unknown as AnalyseContoursResult),
-      accuracyStandards: { rmseZM: null, nvaM: null, vvaM: null, pointDensityPerM2: 0, qualityLevel: 'unknown', qualityLevelReason: 'x' },
+      accuracyStandards: { rmseZM: null, nvaM: null, vvaM: null, pointDensityPerM2: 0, densityReferenceFloorsMet: [], densityReferenceNote: 'none' },
     } as unknown as AnalyseContoursResult;
     const p = buildExportProvenance(noAcc, OPTS);
     expect(p.accuracy).toBeNull();
@@ -193,9 +193,9 @@ describe('provenanceLines / provenanceJson — shape + identical values', () => 
     expect(text).toMatch(/Contour style\s+Smooth/);
     expect(text).toMatch(/Surface quality\s+Good/);
     expect(text).toMatch(/Export readiness\s+Ready/);
-    // "(estimated)" is load-bearing: the QL's RMSEz leg is hold-out-based,
-    // so the stamped grade must carry the same qualifier the panel chip does.
-    expect(text).toMatch(/USGS 3DEP\s+QL2 \(estimated\)/);
+    // A density REFERENCE, not a quality-level grade: the stamp names the 3DEP
+    // density floor the ground-return density clears, never a determination.
+    expect(text).toMatch(/USGS density ref\s+QL2 density floor \(reference\)/);
     // "-style (hold-out)" is equally load-bearing: the stamp must not claim
     // an ASPRS checkpoint assessment for hold-out figures.
     expect(text).toMatch(/NVA-style \(95%, hold-out\)/);
@@ -217,7 +217,7 @@ describe('provenanceLines / provenanceJson — shape + identical values', () => 
     expect(j.contourStyleLabel).toBe('Smooth');
     expect(j.surfaceQuality).toBe('Good');
     expect(j.exportReadiness).toBe('Ready');
-    expect((j.accuracy as { usgsQualityLevel: string }).usgsQualityLevel).toBe('QL2');
+    expect((j.accuracy as { usgsDensityReferenceFloor: string }).usgsDensityReferenceFloor).toBe('QL2');
     expect(j.notSurveyGrade).toBe(NOT_SURVEY_GRADE_NOTE);
     expect(j.evidence).toMatch(/exploratory/i);
     expect(Array.isArray(j.warnings)).toBe(true);
@@ -380,7 +380,7 @@ describe('processingManifestFromProvenance — the verify-only manifest assembly
 
 describe('provenanceJson — the machine-readable accuracy block states its basis', () => {
   const p: ExportProvenance = buildExportProvenance(readyResult(), OPTS);
-  it('carries a basis string beside nvaM / vvaM / usgsQualityLevel', () => {
+  it('carries a basis string beside nvaM / vvaM / usgsDensityReferenceFloor', () => {
     const j = provenanceJson(p);
     const acc = j.accuracy as Record<string, unknown>;
     expect(acc.nvaM).toBeTypeOf('number');

--- a/tests/exportWriters.test.ts
+++ b/tests/exportWriters.test.ts
@@ -33,7 +33,7 @@ const PROV: ExportProvenance = {
   surfaceQuality: 'Good',
   exportReadiness: 'Ready',
   exportReason: '',
-  accuracy: { rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, usgsQualityLevel: 'QL2' },
+  accuracy: { rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, usgsDensityReferenceFloor: 'QL2' },
   complexity: null,
   pointDensityPerM2: 4.2,
   measuredCells: 90,
@@ -147,7 +147,7 @@ describe('toGeoJSON', () => {
     expect(gj.metadata.metricVersion).toBe('v0.4.1');
     expect(gj.metadata.exportReadiness).toBe('Ready');
     expect(gj.metadata.surfaceQuality).toBe('Good');
-    expect(gj.metadata.accuracy.usgsQualityLevel).toBe('QL2');
+    expect(gj.metadata.accuracy.usgsDensityReferenceFloor).toBe('QL2');
     expect(gj.metadata.generated).toBe('2026-06-05T00:00:00.000Z');
   });
 });
@@ -190,7 +190,7 @@ describe('svgContours', () => {
     const svg = svgContours(model([feat('solid', [[0, 0], [10, 0]], 10, true)]), {
       provenance: {
         ...PROV,
-        accuracy: { rmseZM: 0.1, nvaM: 0.2, vvaM: 0.3, usgsQualityLevel: 'QL2' },
+        accuracy: { rmseZM: 0.1, nvaM: 0.2, vvaM: 0.3, usgsDensityReferenceFloor: 'QL2' },
       },
       unitLabel: 'ft',
     });

--- a/tests/mapSheetPdf.test.ts
+++ b/tests/mapSheetPdf.test.ts
@@ -24,7 +24,7 @@ const PROV: ExportProvenance = {
   contourRequestedIntervalM: null,
   contourMethod: null, contourGeneralizeToleranceCells: null, deliverablePurpose: null,
   surfaceQuality: 'Good', exportReadiness: 'Ready', exportReason: '',
-  accuracy: { rmseZM: 0.08, nvaM: 0.16, vvaM: 0.21, usgsQualityLevel: 'QL2' },
+  accuracy: { rmseZM: 0.08, nvaM: 0.16, vvaM: 0.21, usgsDensityReferenceFloor: 'QL2' },
   complexity: null,
   pointDensityPerM2: 3, measuredCells: 90, totalCells: 100, classScope: null, warnings: [],
   notSurveyGrade: 'Suitability: not survey-grade unless validated against ground-truth control.',

--- a/tests/provenanceConsistency.test.ts
+++ b/tests/provenanceConsistency.test.ts
@@ -91,7 +91,7 @@ function readyResult(): AnalyseContoursResult {
     },
     accuracyStandards: {
       rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, pointDensityPerM2: 4.2,
-      qualityLevel: 'QL2', qualityLevelReason: '4.2 pts/m² and 0.14 m RMSEz meet QL2.',
+      densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
     },
     quality: {
       readiness: 'ready', exportReadiness: 'available',
@@ -316,7 +316,7 @@ describe('provenance consistency — export-ready run', () => {
     expect(prov.exportReason).toBe('');
     expect(prov.horizontalCrs).toBe('EPSG:32610');
     expect(prov.verticalDatum).toBe('EPSG:5703');
-    expect(prov.accuracy).toEqual({ rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, usgsQualityLevel: 'QL2' });
+    expect(prov.accuracy).toEqual({ rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, usgsDensityReferenceFloor: 'QL2' });
   });
 
   it('README, DXF and SVG carry the identical provenance line block, verbatim', async () => {
@@ -376,7 +376,7 @@ describe('provenance consistency — export-ready run', () => {
     expect(mapSheetText).toContain(`${acc.rmseZM!.toFixed(2)} m`);
     expect(mapSheetText).toContain(`${acc.nvaM!.toFixed(2)} m`);
     expect(mapSheetText).toContain(`${acc.vvaM!.toFixed(2)} m`);
-    expect(mapSheetText).toContain(acc.usgsQualityLevel);
+    expect(mapSheetText).toContain(acc.usgsDensityReferenceFloor);
   });
 
   it('the terrain report content embeds the shared provenance verbatim', async () => {

--- a/tests/qualityLevelOracle.test.ts
+++ b/tests/qualityLevelOracle.test.ts
@@ -1,94 +1,63 @@
 /**
- * qualityLevelOracle.test.ts — the USGS 3DEP quality-level comparison against an
- * ANALYTIC ORACLE, not against the implementation's control flow.
+ * qualityLevelOracle.test.ts — the USGS 3DEP nominal-pulse-density FLOORS used
+ * as a REFERENCE, checked against an ANALYTIC ORACLE, not the implementation's
+ * control flow.
  *
- * The quality level is one of the few figures this project produces whose right
- * answer is defined OUTSIDE this repository. USGS publishes the table (3D
- * Elevation Program, "Topographic Data Quality Levels (QLs)" / Lidar Base
- * Specification, Table 1):
+ * The module no longer emits a quality-level GRADE: ground-return density is not
+ * nominal pulse density (NPD/ANPD), and a merged/tiled cloud need not carry the
+ * swath context a 3DEP determination requires. What it reports is, as context
+ * only, which published 3DEP nominal-pulse-density FLOORS the measured
+ * ground-return density clears. USGS publishes those floors (3D Elevation
+ * Program, Lidar Base Specification, Table 1):
  *
- *   ┌───────┬───────────────────┬──────────────────────┐
- *   │ Level │ Vertical accuracy │ Nominal pulse density│
- *   ├───────┼───────────────────┼──────────────────────┤
- *   │ QL0   │ RMSEz  5 cm       │ ≥ 8   pts/m²         │
- *   │ QL1   │ RMSEz 10 cm       │ ≥ 8   pts/m²         │
- *   │ QL2   │ RMSEz 10 cm       │ ≥ 2   pts/m²         │
- *   │ QL3   │ RMSEz 20 cm       │ ≥ 0.5 pts/m²         │
- *   └───────┴───────────────────┴──────────────────────┘
+ *   QL0 ≥ 8 pts/m² · QL1 ≥ 8 · QL2 ≥ 2 · QL3 ≥ 0.5
  *
- * {@link SPEC} below is that table transcribed by hand, and {@link expectedLevel}
- * derives the answer from it by picking the STRONGEST row a (density, RMSEz)
- * pair satisfies — walking an explicit strength order, never the array order.
- * The module under test walks its own table with `Array.prototype.find`, so the
- * two agree only while that table stays ordered best-first with every row
- * relaxing both legs. Reorder or re-tune a row and the grid below reds.
+ * {@link SPEC} is that column transcribed by hand, and {@link expectedFloors}
+ * derives the answer from it, walking an explicit strength order rather than the
+ * array order. The floor is INCLUSIVE ("≥ N pts/m²"), so a density exactly on a
+ * floor clears it; every floor is asserted three times — exactly on it, one ULP
+ * inside, one ULP outside — so a `>` for a `>=` moves exactly one grid point and
+ * is caught.
  *
- * ── WHICH BOUNDS ARE INCLUSIVE, AND WHY ────────────────────────────────────
- * Both. The published density leg is written "≥ N pts/square meter", so a scan
- * landing exactly on the floor MEETS the level. The accuracy leg is the RMSEz a
- * collection is required to be at or within, so a measured RMSEz exactly equal
- * to the figure MEETS it too. "≥ 2 pts/m²" in a specification sentence and `>=`
- * in code are the same claim only once someone has checked, so every one of the
- * six bounds is asserted three times here: exactly on the figure, one ULP inside
- * it, and one ULP outside it. A `>` for a `>=` (or `<` for `<=`) moves exactly
- * one grid point and is caught.
- *
- * ── WHAT THIS DOES NOT ESTABLISH ───────────────────────────────────────────
- * That a scan IS a given quality level. A 3DEP determination rests on RMSEz
- * against independent survey checkpoints plus collection requirements this
- * module never sees; the RMSEz fed in here is hold-out validation against
- * internally withheld ground points. What is verified is the comparison: given a
- * density and an RMSEz, the level named is the one the published table names.
+ * WHAT THIS DOES NOT ESTABLISH: that a scan IS any quality level. This is a
+ * density reference only — a determination rests on pulse density measured from
+ * first returns with swath context, and on checkpoint accuracy, none of which
+ * this module sees.
  */
 
 import { describe, it, expect } from 'vitest';
-import { demAccuracyStandards, type UsgsQualityLevel } from '../src/terrain/quality/demAccuracyStandards';
+import {
+  demAccuracyStandards,
+  type UsgsDensityFloor,
+} from '../src/terrain/quality/demAccuracyStandards';
 
 // ── the oracle ──────────────────────────────────────────────────────────────
 
-/** The published table, transcribed independently of the module's own copy. */
-const SPEC: ReadonlyArray<{
-  readonly level: UsgsQualityLevel;
-  readonly maxRmseM: number;
-  readonly minDensityPerM2: number;
-}> = [
-  { level: 'QL2', maxRmseM: 0.1, minDensityPerM2: 2 },
-  { level: 'QL0', maxRmseM: 0.05, minDensityPerM2: 8 },
-  { level: 'QL3', maxRmseM: 0.2, minDensityPerM2: 0.5 },
-  { level: 'QL1', maxRmseM: 0.1, minDensityPerM2: 8 },
+/** The published density floors, transcribed independently of the module's copy. */
+const SPEC: ReadonlyArray<{ readonly level: UsgsDensityFloor; readonly minDensityPerM2: number }> = [
+  { level: 'QL2', minDensityPerM2: 2 },
+  { level: 'QL0', minDensityPerM2: 8 },
+  { level: 'QL3', minDensityPerM2: 0.5 },
+  { level: 'QL1', minDensityPerM2: 8 },
 ];
 
-/**
- * Strongest → weakest. Deliberately separate from {@link SPEC}'s array order,
- * which is deliberately NOT best-first: the oracle must not be able to inherit
- * an ordering bug from the shape of a table, because that is the exact bug it
- * exists to detect in the module.
- */
-const STRENGTH: readonly UsgsQualityLevel[] = ['QL0', 'QL1', 'QL2', 'QL3'];
+/** Strongest → weakest. Separate from {@link SPEC}'s (non-sorted) array order. */
+const STRENGTH: readonly UsgsDensityFloor[] = ['QL0', 'QL1', 'QL2', 'QL3'];
 
-/**
- * The expected level for a (density, RMSEz) pair, straight off {@link SPEC}.
- * A fact that cannot be established degrades to `unknown` rather than being
- * guessed: no RMSEz, an unusable RMSEz, or no measured density means no level.
- */
-function expectedLevel(densityPerM2: number, rmseZM: number | null): UsgsQualityLevel {
-  if (rmseZM == null || !Number.isFinite(rmseZM) || rmseZM < 0) return 'unknown';
-  if (!Number.isFinite(densityPerM2) || densityPerM2 <= 0) return 'unknown';
-  const met = new Set(
-    SPEC.filter((r) => densityPerM2 >= r.minDensityPerM2 && rmseZM <= r.maxRmseM).map((r) => r.level),
-  );
-  return STRENGTH.find((l) => met.has(l)) ?? 'below-QL3';
+/** The floors a density clears, strongest first, straight off {@link SPEC}. */
+function expectedFloors(densityPerM2: number): UsgsDensityFloor[] {
+  if (!Number.isFinite(densityPerM2) || densityPerM2 <= 0) return [];
+  const met = new Set(SPEC.filter((r) => densityPerM2 >= r.minDensityPerM2).map((r) => r.level));
+  return STRENGTH.filter((l) => met.has(l));
 }
 
-/** The level the module actually reports. */
-const actualLevel = (densityPerM2: number, rmseZM: number | null): UsgsQualityLevel =>
-  demAccuracyStandards(rmseZM, null, densityPerM2).qualityLevel;
+/** The floors the module actually reports. */
+const actualFloors = (densityPerM2: number): readonly UsgsDensityFloor[] =>
+  demAccuracyStandards(0.05, null, densityPerM2).densityReferenceFloorsMet;
 
 // ── ULP stepping ────────────────────────────────────────────────────────────
 
 const BITS = new DataView(new ArrayBuffer(8));
-
-/** The adjacent representable double above (`+1`) or below (`-1`) a positive x. */
 function step(x: number, dir: 1 | -1): number {
   BITS.setFloat64(0, x);
   BITS.setBigUint64(0, BITS.getBigUint64(0) + BigInt(dir));
@@ -97,132 +66,69 @@ function step(x: number, dir: 1 | -1): number {
 const nextUp = (x: number): number => step(x, 1);
 const nextDown = (x: number): number => step(x, -1);
 
-// ── the boundary figures ────────────────────────────────────────────────────
-
 const DENSITY_FLOORS = [0.5, 2, 8] as const;
-const RMSE_CEILINGS = [0.05, 0.1, 0.2] as const;
 
-describe('USGS quality-level classification vs the published 3DEP table', () => {
+describe('USGS density-floor reference vs the published 3DEP table', () => {
   it('steps by one ULP, with nothing representable in between', () => {
-    for (const x of [...DENSITY_FLOORS, ...RMSE_CEILINGS]) {
+    for (const x of DENSITY_FLOORS) {
       expect(nextUp(x)).toBeGreaterThan(x);
       expect(nextDown(x)).toBeLessThan(x);
       expect(nextDown(nextUp(x))).toBe(x);
-      expect(nextUp(nextDown(x))).toBe(x);
-      // Adjacency: the midpoint of x and its neighbour rounds back to one of them.
       expect([x, nextUp(x)]).toContain((x + nextUp(x)) / 2);
     }
   });
 
-  it('both legs are INCLUSIVE: a value exactly on a published bound meets that level', () => {
-    // Density exactly on each floor, with an RMSEz well inside every ceiling.
-    expect(actualLevel(8, 0.01)).toBe('QL0');
-    expect(actualLevel(2, 0.01)).toBe('QL2');
-    expect(actualLevel(0.5, 0.01)).toBe('QL3');
-    // RMSEz exactly on each ceiling, with a density well inside every floor.
-    expect(actualLevel(50, 0.05)).toBe('QL0');
-    expect(actualLevel(50, 0.1)).toBe('QL1');
-    expect(actualLevel(50, 0.2)).toBe('QL3');
-    // Both legs exactly on the bound at once — the corner of each cell.
-    expect(actualLevel(8, 0.05)).toBe('QL0');
-    expect(actualLevel(8, 0.1)).toBe('QL1');
-    expect(actualLevel(2, 0.1)).toBe('QL2');
-    expect(actualLevel(0.5, 0.2)).toBe('QL3');
+  it('the floor is INCLUSIVE: a density exactly on it clears it', () => {
+    expect(actualFloors(8)).toEqual(['QL0', 'QL1', 'QL2', 'QL3']);
+    expect(actualFloors(2)).toEqual(['QL2', 'QL3']);
+    expect(actualFloors(0.5)).toEqual(['QL3']);
   });
 
-  it('one ULP INSIDE a bound still meets the level', () => {
-    expect(actualLevel(nextUp(8), 0.01)).toBe('QL0');
-    expect(actualLevel(nextUp(2), 0.01)).toBe('QL2');
-    expect(actualLevel(nextUp(0.5), 0.01)).toBe('QL3');
-    expect(actualLevel(50, nextDown(0.05))).toBe('QL0');
-    expect(actualLevel(50, nextDown(0.1))).toBe('QL1');
-    expect(actualLevel(50, nextDown(0.2))).toBe('QL3');
+  it('one ULP INSIDE a floor still clears it', () => {
+    expect(actualFloors(nextUp(8))).toEqual(['QL0', 'QL1', 'QL2', 'QL3']);
+    expect(actualFloors(nextUp(2))).toEqual(['QL2', 'QL3']);
+    expect(actualFloors(nextUp(0.5))).toEqual(['QL3']);
   });
 
-  it('one ULP OUTSIDE a bound drops to the next level the pair actually meets', () => {
-    // Density one ULP under a floor: the pair falls through to the next row down.
-    expect(actualLevel(nextDown(8), 0.01)).toBe('QL2');
-    expect(actualLevel(nextDown(2), 0.01)).toBe('QL3');
-    expect(actualLevel(nextDown(0.5), 0.01)).toBe('below-QL3');
-    // RMSEz one ULP over a ceiling: likewise.
-    expect(actualLevel(50, nextUp(0.05))).toBe('QL1');
-    expect(actualLevel(50, nextUp(0.1))).toBe('QL3');
-    expect(actualLevel(50, nextUp(0.2))).toBe('below-QL3');
-    expect(actualLevel(2, nextUp(0.1))).toBe('QL3');
-    expect(actualLevel(0.5, nextUp(0.2))).toBe('below-QL3');
+  it('one ULP OUTSIDE a floor drops it', () => {
+    expect(actualFloors(nextDown(8))).toEqual(['QL2', 'QL3']);
+    expect(actualFloors(nextDown(2))).toEqual(['QL3']);
+    expect(actualFloors(nextDown(0.5))).toEqual([]);
   });
 
-  it('separates QL0 from QL1, which share the 8 pts/m² floor and differ only by RMSEz', () => {
-    for (const density of [8, nextUp(8), 12, 200]) {
-      // Everything at or under 5 cm is QL0; the first representable value above
-      // it is QL1, and QL1 holds all the way to 10 cm inclusive.
-      expect(actualLevel(density, 0)).toBe('QL0');
-      expect(actualLevel(density, nextDown(0.05))).toBe('QL0');
-      expect(actualLevel(density, 0.05)).toBe('QL0');
-      expect(actualLevel(density, nextUp(0.05))).toBe('QL1');
-      expect(actualLevel(density, 0.08)).toBe('QL1');
-      expect(actualLevel(density, nextDown(0.1))).toBe('QL1');
-      expect(actualLevel(density, 0.1)).toBe('QL1');
-      // Past 10 cm the density is irrelevant: only QL3's 20 cm ceiling is left.
-      expect(actualLevel(density, nextUp(0.1))).toBe('QL3');
-    }
-  });
-
-  it('returns the STRONGEST level a pair satisfies, over the whole boundary grid', () => {
+  it('matches the published floors over the whole boundary grid', () => {
     const densities = [
       0, 0.1, 0.25, nextDown(0.5), 0.5, nextUp(0.5), 1, nextDown(2), 2, nextUp(2),
       5, nextDown(8), 8, nextUp(8), 20, 100,
     ];
-    const rmses = [
-      0, 0.01, nextDown(0.05), 0.05, nextUp(0.05), 0.075, nextDown(0.1), 0.1,
-      nextUp(0.1), 0.15, nextDown(0.2), 0.2, nextUp(0.2), 0.5,
-    ];
     const disagreements: string[] = [];
     for (const d of densities) {
-      for (const r of rmses) {
-        const got = actualLevel(d, r);
-        const want = expectedLevel(d, r);
-        if (got !== want) disagreements.push(`density=${d} rmse=${r}: got ${got}, table says ${want}`);
+      const got = actualFloors(d);
+      const want = expectedFloors(d);
+      if (JSON.stringify(got) !== JSON.stringify(want)) {
+        disagreements.push(`density=${d}: got ${JSON.stringify(got)}, table says ${JSON.stringify(want)}`);
       }
     }
     expect(disagreements).toEqual([]);
-    expect(densities.length * rmses.length).toBe(224);
   });
 
-  it('never names a level the published table does not grant that pair', () => {
-    // Soundness, independent of the equality check above: whenever a level comes
-    // back, the pair genuinely clears BOTH legs of that row in the transcription.
+  it('never names a floor the published table does not grant that density', () => {
     for (const d of [0.5, 1, 2, 3, 8, 9, 40]) {
-      for (const r of [0, 0.05, 0.09, 0.1, 0.19, 0.2, 0.4]) {
-        const got = actualLevel(d, r);
-        if (got === 'below-QL3' || got === 'unknown') continue;
-        const row = SPEC.find((s) => s.level === got);
-        expect(row, `no published row named ${got}`).toBeDefined();
+      for (const level of actualFloors(d)) {
+        const row = SPEC.find((s) => s.level === level);
+        expect(row, `no published row named ${level}`).toBeDefined();
         expect(d).toBeGreaterThanOrEqual(row!.minDensityPerM2);
-        expect(r).toBeLessThanOrEqual(row!.maxRmseM);
       }
     }
   });
 
-  it('is below-QL3 when the pair clears no row, rather than rounding down to one', () => {
-    expect(actualLevel(0.4, 0.01)).toBe('below-QL3'); // density under the QL3 floor
-    expect(actualLevel(100, 0.25)).toBe('below-QL3'); // RMSEz over the QL3 ceiling
-    expect(actualLevel(0.4, 0.25)).toBe('below-QL3'); // both
-    expect(demAccuracyStandards(0.25, null, 100).qualityLevelReason).toContain('below the USGS QL3');
+  it('clears no floor when the density is under the QL3 floor', () => {
+    expect(actualFloors(0.4)).toEqual([]);
+    expect(demAccuracyStandards(0.05, null, 0.4).densityReferenceNote).toContain('below the USGS 3DEP QL3');
   });
 });
 
-describe('USGS quality-level classification: inputs that establish no fact', () => {
-  /** Each case must degrade to `unknown` — never to a fabricated level. */
-  const UNUSABLE_RMSE: ReadonlyArray<readonly [string, number | null]> = [
-    ['missing (null)', null],
-    ['NaN', Number.NaN],
-    ['+Infinity', Number.POSITIVE_INFINITY],
-    ['-Infinity', Number.NEGATIVE_INFINITY],
-    ['negative', -0.01],
-    ['very negative', -1000],
-  ];
-
+describe('USGS density reference: inputs that establish no density fact', () => {
   const UNUSABLE_DENSITY: ReadonlyArray<readonly [string, number]> = [
     ['zero', 0],
     ['negative zero', -0],
@@ -232,41 +138,18 @@ describe('USGS quality-level classification: inputs that establish no fact', () 
     ['-Infinity', Number.NEGATIVE_INFINITY],
   ];
 
-  for (const [label, rmse] of UNUSABLE_RMSE) {
-    it(`RMSEz ${label} yields unknown at any density`, () => {
-      for (const density of [0.5, 2, 8, 1000]) {
-        const s = demAccuracyStandards(rmse, 0.2, density);
-        expect(s.qualityLevel).toBe('unknown');
-        expect(s.qualityLevel).toBe(expectedLevel(density, rmse));
-        // An unusable RMSEz cannot become an accuracy figure either.
-        expect(s.rmseZM).toBeNull();
-        expect(s.nvaM).toBeNull();
-        expect(s.qualityLevelReason).toContain('Not enough validated points');
-      }
-    });
-  }
-
   for (const [label, density] of UNUSABLE_DENSITY) {
-    it(`density ${label} yields unknown at any RMSEz`, () => {
-      for (const rmse of [0, 0.01, 0.05, 0.1, 0.2, 5]) {
-        const s = demAccuracyStandards(rmse, 0.2, density);
-        expect(s.qualityLevel).toBe('unknown');
-        expect(s.qualityLevel).toBe(expectedLevel(density, rmse));
-        expect(s.qualityLevelReason).toContain('No measured ground density');
-        // A non-finite or negative density is reported as 0, not passed through.
-        expect(s.pointDensityPerM2).toBe(0);
-        // The RMSEz itself was measurable, so it survives; only the level does not.
-        expect(s.rmseZM).toBe(rmse);
-      }
+    it(`density ${label} clears no floor and says so`, () => {
+      const s = demAccuracyStandards(0.05, 0.2, density);
+      expect(s.densityReferenceFloorsMet).toEqual([]);
+      expect(s.densityReferenceFloorsMet).toEqual(expectedFloors(density));
+      expect(s.densityReferenceNote).toContain('No measured ground-return density');
+      // A non-finite or negative density is reported as 0, not passed through.
+      expect(s.pointDensityPerM2).toBe(0);
+      // The RMSEz itself was measurable, so it survives.
+      expect(s.rmseZM).toBe(0.05);
     });
   }
-
-  it('an RMSEz of exactly zero is a measurement, not a missing fact', () => {
-    const s = demAccuracyStandards(0, null, 9);
-    expect(s.qualityLevel).toBe('QL0');
-    expect(s.rmseZM).toBe(0);
-    expect(s.nvaM).toBe(0);
-  });
 
   it('a non-finite VVA is dropped rather than reported', () => {
     for (const vva of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
@@ -276,17 +159,16 @@ describe('USGS quality-level classification: inputs that establish no fact', () 
     expect(demAccuracyStandards(0.08, 0.21, 9).vvaM).toBe(0.21);
   });
 
-  it('states the level it matched and disclaims a 3DEP determination', () => {
-    for (const [density, rmse, level] of [
-      [9, 0.04, 'QL0'],
-      [9, 0.08, 'QL1'],
-      [3, 0.09, 'QL2'],
-      [1, 0.15, 'QL3'],
+  it('names the floor cleared as a reference and disclaims a determination', () => {
+    for (const [density, strongest] of [
+      [9, 'QL0'],
+      [3, 'QL2'],
+      [1, 'QL3'],
     ] as const) {
-      const s = demAccuracyStandards(rmse, null, density);
-      expect(s.qualityLevel).toBe(level);
-      expect(s.qualityLevelReason).toContain(level);
-      expect(s.qualityLevelReason).toContain('not a USGS 3DEP determination');
+      const s = demAccuracyStandards(0.05, null, density);
+      expect(s.densityReferenceFloorsMet[0]).toBe(strongest);
+      expect(s.densityReferenceNote).toContain(strongest);
+      expect(s.densityReferenceNote).toMatch(/not a nominal-pulse-density/i);
     }
   });
 });

--- a/tests/readinessEngine.test.ts
+++ b/tests/readinessEngine.test.ts
@@ -84,7 +84,7 @@ function readyResult(): AnalyseContoursResult {
     },
     accuracyStandards: {
       rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, pointDensityPerM2: 4.2,
-      qualityLevel: 'QL2', qualityLevelReason: '4.2 pts/m² and 0.14 m RMSEz meet QL2.',
+      densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
     },
     quality: {
       readiness: 'ready', exportReadiness: 'available',

--- a/tests/scanFitness.test.ts
+++ b/tests/scanFitness.test.ts
@@ -25,7 +25,7 @@ function base(over: Partial<FitnessInputs> = {}): FitnessInputs {
     unclassifiedFraction: 0.02,
     hasGroundClass: true,
     coverageMode: 'full',
-    qualityLevel: 'USGS QL1',
+    densityReferenceFloor: 'QL1',
     ...over,
   };
 }
@@ -38,7 +38,7 @@ describe('buildScanFitness — scorecard tones', () => {
     const f = buildScanFitness(base());
     expect(f.overallTone).toBe<FitnessTone>('ready');
     expect(f.verdict).toMatch(/ready for terrain products/i);
-    expect(f.tierBadge).toBe('USGS QL1 (estimated)');
+    expect(f.tierBadge).toBe('≥ QL1 density floor');
     expect(f.headlineAccuracy).toBe('±0.07 m vertical');
     expect(f.dimensions).toHaveLength(6);
   });
@@ -95,7 +95,7 @@ describe('buildScanFitness — provisional (streaming / partial) state', () => {
   it('a full-cloud grade is not provisional and can earn its badge', () => {
     const f = buildScanFitness(base());
     expect(f.provisional).toBe(false);
-    expect(f.tierBadge).toBe('USGS QL1 (estimated)');
+    expect(f.tierBadge).toBe('≥ QL1 density floor');
   });
 });
 
@@ -195,7 +195,7 @@ describe('buildScanFitness — density reports a measurement, not a quality leve
   });
 
   it('marks the tier badge as an estimate, matching every other surface', () => {
-    expect(buildScanFitness(base()).tierBadge).toBe('USGS QL1 (estimated)');
+    expect(buildScanFitness(base()).tierBadge).toBe('≥ QL1 density floor');
   });
 });
 
@@ -231,7 +231,7 @@ describe('buildScanFitness — unverified units fail closed', () => {
     expect(tone(f, 'density')).toBe<FitnessTone>('ready');
     expect(tone(f, 'accuracy')).toBe<FitnessTone>('ready');
     expect(f.headlineAccuracy).toBe('±0.07 m vertical');
-    expect(f.tierBadge).toBe('USGS QL1 (estimated)');
+    expect(f.tierBadge).toBe('≥ QL1 density floor');
     expect(f.caveats.some((c) => /units are unverified/i.test(c))).toBe(false);
   });
 
@@ -239,6 +239,6 @@ describe('buildScanFitness — unverified units fail closed', () => {
     const f = buildScanFitness(base({ unitKnown: true }));
     expect(tone(f, 'density')).toBe<FitnessTone>('ready');
     expect(tone(f, 'accuracy')).toBe<FitnessTone>('ready');
-    expect(f.tierBadge).toBe('USGS QL1 (estimated)');
+    expect(f.tierBadge).toBe('≥ QL1 density floor');
   });
 });

--- a/tests/terrainAssessment.test.ts
+++ b/tests/terrainAssessment.test.ts
@@ -81,8 +81,7 @@ function fixture(o: FixtureOpts = {}): AnalyseContoursResult {
     nvaM: rmseZM != null ? rmseZM * 1.96 : null,
     vvaM: 0.12,
     pointDensityPerM2: o.meanDensity ?? 6,
-    qualityLevel: 'QL2',
-    qualityLevelReason: 'meets QL2',
+    densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
   };
   return {
     quality: quality as DtmQualityReport,

--- a/tests/terrainReportContent.test.ts
+++ b/tests/terrainReportContent.test.ts
@@ -67,8 +67,7 @@ function readyResult(): AnalyseContoursResult {
       nvaM: 0.27,
       vvaM: 0.3,
       pointDensityPerM2: 4.2,
-      qualityLevel: 'QL2',
-      qualityLevelReason: '4.2 pts/m² and 0.14 m RMSEz meet QL2.',
+      densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
     },
     quality: {
       readiness: 'ready',
@@ -138,8 +137,7 @@ function previewResult(): AnalyseContoursResult {
       nvaM: null,
       vvaM: null,
       pointDensityPerM2: 0,
-      qualityLevel: 'unknown',
-      qualityLevelReason: 'Not enough validated points to measure RMSEz.',
+      densityReferenceFloorsMet: [], densityReferenceNote: 'none',
     },
     quality: {
       readiness: 'previewOnly',
@@ -285,7 +283,7 @@ describe('buildTerrainReportContent — section presence + sourcing', () => {
     const text = qm.rows.map((r) => `${r.label}: ${r.value}`).join('\n');
     expect(text).toMatch(/0\.14 m/); // RMSEz
     expect(text).toMatch(/0\.27 m/); // NVA
-    expect(text).toMatch(/QL2 \(estimated\)/);
+    expect(text).toMatch(/>= QL2 floor/);
     // The report's labels carry the honesty qualifiers, same as the panel
     // and the provenance stamp — hold-out formulas, not checkpoints.
     expect(text).toMatch(/NVA-style \(95%, hold-out\)/);

--- a/tests/terrainReportPdf.test.ts
+++ b/tests/terrainReportPdf.test.ts
@@ -40,8 +40,7 @@ function readyResult(): AnalyseContoursResult {
       nvaM: 0.27,
       vvaM: 0.3,
       pointDensityPerM2: 4.2,
-      qualityLevel: 'QL2',
-      qualityLevelReason: '4.2 pts/m² and 0.14 m RMSEz meet QL2.',
+      densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
     },
     quality: {
       readiness: 'ready',
@@ -82,7 +81,7 @@ function previewResult(): AnalyseContoursResult {
     },
     intervalM: 2,
     model: { crs: 'EPSG:32610', verticalDatum: null, intervalM: 2, contourStyle: 'crisp', coverageMode: 'resident-only', features: [{}] },
-    accuracyStandards: { rmseZM: null, nvaM: null, vvaM: null, pointDensityPerM2: 0, qualityLevel: 'unknown', qualityLevelReason: 'Not enough validated points to measure RMSEz.' },
+    accuracyStandards: { rmseZM: null, nvaM: null, vvaM: null, pointDensityPerM2: 0, densityReferenceFloorsMet: [], densityReferenceNote: 'none' },
     quality: {
       readiness: 'previewOnly',
       exportReadiness: 'previewOnly',

--- a/tests/transformProvenance.test.ts
+++ b/tests/transformProvenance.test.ts
@@ -221,7 +221,7 @@ describe('ExportProvenance — discloses a supplied transform, carries none othe
       model: { crs: 'EPSG:32615', verticalDatum: 'EPSG:5703', intervalM: 1, contourStyle: 'smooth', coverageMode: 'full' },
       accuracyStandards: {
         rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, pointDensityPerM2: 4.2,
-        qualityLevel: 'QL2', qualityLevelReason: 'meets QL2.',
+        densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
       },
       quality: {
         readiness: 'ready', exportReadiness: 'available',


### PR DESCRIPTION
§5 of the v0.6.8 hardening pass. `demAccuracyStandards` graded a USGS 3DEP Quality Level (QL0–3) from **mean ground-return density + hold-out RMSEz** and labelled it "(estimated)". That basis is wrong: a 3DEP QL is a **nominal-pulse-density (NPD/ANPD)** determination measured from first returns with swath context. Ground-return density is not pulse density, and a merged/tiled cloud may not carry enough information to determine a QL at all.

- Drop the graded `qualityLevel` / `qualityLevelReason`. Report the measured ground-return density and, as **context only**, which 3DEP nominal-pulse-density **floors** it clears (`densityReferenceFloorsMet` + `densityReferenceNote`) — a reference threshold, never a determination.
- Reworded every surface off "QLx (estimated)": panel chip + modal, map-sheet PDF, terrain report, export provenance (field `usgsQualityLevel` → `usgsDensityReferenceFloor`), scanFitness badge, tooltip, and the stride warning. The allowed "QLx **density floor**" reference phrasing stays.
- Oracle test rewritten to pin the density-floor reference against an independent transcription with ULP boundary checks; the QL-grade tests are removed.

No evidence-level change. NVA/VVA-style hold-out figures are untouched — that's §4 (the vocabulary reframe), a separate PR.

25 files. Full suite 13,799 pass / 0 fail; tsc, claim-register, claims-language, claim-prose-sync, evidence, release-truth all green. Anti-goal satisfied: generic ground-return density can no longer produce a QL0/1/2/3 product state.