### PR TITLE
feat(terrain): explicit ASPRS-2024 boundary + legacy 2014 framing (§4)

### DIFF
--- a/src/terrain/export/exportProvenance.ts
+++ b/src/terrain/export/exportProvenance.ts
@@ -147,12 +147,14 @@ export interface ExportPermitStamp {
  * qualifiers the text surfaces put in the label.
  */
 export const ACCURACY_BASIS_NOTE =
-  'RMSEz, NVA and VVA are computed from hold-out residuals within this cloud using the '
-  + 'ASPRS 2014 formulas — withheld ground points, not independent survey checkpoints, and '
-  + 'the VVA figure is the 95th percentile of all hold-out residuals rather than '
-  + 'vegetated-class checkpoints. The quality level compares measured ground density and '
-  + 'that hold-out RMSEz against the 3DEP thresholds. This is not an ASPRS conformance '
-  + 'assessment and not a USGS 3DEP determination.';
+  'RMSEz and the legacy NVA/VVA-style figures are computed from hold-out residuals within '
+  + 'this cloud using the legacy ASPRS 2014 formulas — withheld ground points, not '
+  + 'independent survey checkpoints, and the VVA figure is the 95th percentile of all '
+  + 'hold-out residuals rather than vegetated-class checkpoints. A formal ASPRS 2024 '
+  + '(Edition 2, RMSEV) assessment is not available: it requires an independent checkpoint '
+  + 'set and checkpoint-survey uncertainty. The density figure names which 3DEP '
+  + 'nominal-pulse-density floor the measured ground-return density clears, as a reference '
+  + 'only. This is not an ASPRS conformance assessment and not a USGS 3DEP determination.';
 
 /** Validated vertical-accuracy figures, present only when the run measured them. */
 export interface ExportProvenanceAccuracy {

--- a/src/terrain/export/terrainReportContent.ts
+++ b/src/terrain/export/terrainReportContent.ts
@@ -358,11 +358,12 @@ export function buildTerrainReportContent(
     title: 'Quality Metrics',
     rows: [
       { label: 'Vertical RMSEz', value: hasAcc ? fmtM(provenance.accuracy?.rmseZM) : DASH },
-      // "-style (hold-out)" / "(estimated)": the report carries the same
-      // qualifiers as the Analyse panel and the provenance stamp — hold-out
-      // figures via the ASPRS formulas, never a checkpoint assessment.
-      { label: 'NVA-style (95%, hold-out)', value: hasAcc ? fmtM(provenance.accuracy?.nvaM) : DASH },
-      { label: 'VVA-style (95th pct, hold-out)', value: hasAcc ? fmtM(provenance.accuracy?.vvaM) : DASH },
+      // Legacy 2014-formula diagnostic on hold-out points, never a checkpoint
+      // assessment; the current-standard boundary row below states that the
+      // formal ASPRS 2024 assessment is not available.
+      { label: 'Legacy NVA-style (ASPRS 2014 formulas, hold-out)', value: hasAcc ? fmtM(provenance.accuracy?.nvaM) : DASH },
+      { label: 'Legacy VVA-style (ASPRS 2014 formulas, hold-out)', value: hasAcc ? fmtM(provenance.accuracy?.vvaM) : DASH },
+      { label: 'ASPRS 2024 assessment', value: 'not available (no independent checkpoints)' },
       // Measured-cell empirical reliability (Wilson CI) and the less optimistic
       // spatially-blocked RMSE — the same numbers the Analyse panel surfaces.
       { label: 'Measured reliability', value: reliabilityValue },

--- a/src/terrain/validate/verticalAccuracy.ts
+++ b/src/terrain/validate/verticalAccuracy.ts
@@ -35,6 +35,27 @@ import type { ValidationReport } from './ValidationReport';
 /** ASPRS 95% multiplier for RMSE → NVA under a normal error model. */
 export const NVA_95_MULTIPLIER = 1.96;
 
+/**
+ * The formal-standard boundary, stated explicitly so no surface implies the
+ * hold-out figures are a current-standard assessment. ASPRS Positional Accuracy
+ * Standards Edition 2 (2024) express positional accuracy as RMSEV (not the 2014
+ * RMSEz/NVA vocabulary) and drop the 95% confidence level as the primary
+ * measure; a formal RMSEV also incorporates the checkpoint-survey error, which
+ * an internal hold-out has no way to supply. OLV has no independent checkpoint
+ * set, so it does not — and must not — produce a formal ASPRS 2024 assessment.
+ */
+export const ASPRS_2024_UNAVAILABLE_NOTE =
+  'ASPRS 2024 (Edition 2) assessment: unavailable — it requires an independent ' +
+  'checkpoint set and checkpoint-survey uncertainty (RMSEV), which internal ' +
+  'hold-out validation does not provide.';
+
+/**
+ * The basis tag for the 2014-formula figures, named as a LEGACY diagnostic so a
+ * reader never takes it for the current standard. The formulas are reproducible
+ * and useful; they are not current ASPRS conformance.
+ */
+export const LEGACY_ASPRS_2014_BASIS = 'legacy ASPRS 2014 formulas, hold-out basis';
+
 /** ASPRS-style vertical accuracy figures derived from a validation report. */
 export interface VerticalAccuracy {
   /** RMSEz in source linear units; NaN when not measurable. */
@@ -68,7 +89,7 @@ export function computeVerticalAccuracy(report: ValidationReport): VerticalAccur
     bias: Number.isFinite(report.bias) ? report.bias : Number.NaN,
     nmad: Number.isFinite(report.nmad) ? report.nmad : Number.NaN,
     sampleSize: report.sampleSize,
-    standard: 'ASPRS 2014 formulas, hold-out basis',
+    standard: LEGACY_ASPRS_2014_BASIS,
   };
 }
 

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -69,6 +69,7 @@ import {
   formatHonestValue,
 } from '../terrain/contour/contourCopy';
 import { gradeForConfidence } from '../terrain/ground/cellConfidence';
+import { ASPRS_2024_UNAVAILABLE_NOTE } from '../terrain/validate/verticalAccuracy';
 import { triggerDownload } from '../io/download';
 import {
   coverageHeatmapImage,
@@ -2162,15 +2163,24 @@ export class AnalysePanel {
       const fmtM = (n: number | null): string =>
         n != null && Number.isFinite(n) ? `${n.toFixed(2)} m` : '—';
       if (std.nvaM != null || std.vvaM != null) {
-        // "-style (hold-out)": the figures use the ASPRS 2014 FORMULAS on
-        // internally withheld points, not independent checkpoints — the
-        // label must not claim a checkpoint assessment (see the tooltips).
+        // Legacy 2014-formula diagnostic on internally withheld points, not
+        // independent checkpoints — never a checkpoint assessment, and named
+        // "legacy" so it is not taken for the current standard (see tooltips).
         this._validationRow.append(this._hint(
           el('div', {
             className: 'olv-analyse-strata',
-            text: `NVA-style ${fmtM(std.nvaM)} · VVA-style ${fmtM(std.vvaM)} (95%, hold-out)`,
+            text: `Legacy NVA/VVA-style ${fmtM(std.nvaM)} · ${fmtM(std.vvaM)} (ASPRS 2014 formulas, hold-out)`,
           }),
           `${METRIC_TOOLTIPS.nva} ${METRIC_TOOLTIPS.vva}`,
+        ));
+        // The current-standard boundary, stated so the legacy figures above are
+        // never read as a current ASPRS assessment.
+        this._validationRow.append(this._hint(
+          el('div', {
+            className: 'olv-analyse-strata olv-analyse-standard-note',
+            text: 'ASPRS 2024: not assessed (no independent checkpoints)',
+          }),
+          ASPRS_2024_UNAVAILABLE_NOTE,
         ));
       }
       if (std.densityReferenceFloorsMet.length > 0) {

--- a/tests/analyseContours.test.ts
+++ b/tests/analyseContours.test.ts
@@ -64,7 +64,7 @@ describe('analyseContours', () => {
   });
 
   it('exposes ASPRS accuracy and index-contour labels', () => {
-    expect(r.accuracy.standard).toBe('ASPRS 2014 formulas, hold-out basis');
+    expect(r.accuracy.standard).toBe('legacy ASPRS 2014 formulas, hold-out basis');
     if (Number.isFinite(r.accuracy.rmseZ)) {
       expect(r.accuracy.nva95).toBeCloseTo(1.96 * r.accuracy.rmseZ, 6);
     }

--- a/tests/terrainReportContent.test.ts
+++ b/tests/terrainReportContent.test.ts
@@ -285,9 +285,11 @@ describe('buildTerrainReportContent — section presence + sourcing', () => {
     expect(text).toMatch(/0\.27 m/); // NVA
     expect(text).toMatch(/>= QL2 floor/);
     // The report's labels carry the honesty qualifiers, same as the panel
-    // and the provenance stamp — hold-out formulas, not checkpoints.
-    expect(text).toMatch(/NVA-style \(95%, hold-out\)/);
-    expect(text).toMatch(/VVA-style \(95th pct, hold-out\)/);
+    // and the provenance stamp — legacy 2014-formula hold-out figures, not
+    // checkpoints, with the current-standard boundary stated explicitly.
+    expect(text).toMatch(/Legacy NVA-style \(ASPRS 2014 formulas, hold-out\)/);
+    expect(text).toMatch(/Legacy VVA-style \(ASPRS 2014 formulas, hold-out\)/);
+    expect(text).toMatch(/ASPRS 2024 assessment: not available/);
   });
 
   it('the not-survey-grade note is always present in the footer', () => {

--- a/tests/verticalAccuracy.test.ts
+++ b/tests/verticalAccuracy.test.ts
@@ -7,6 +7,8 @@ import {
   computeVerticalAccuracy,
   formatVerticalAccuracy,
   NVA_95_MULTIPLIER,
+  ASPRS_2024_UNAVAILABLE_NOTE,
+  LEGACY_ASPRS_2014_BASIS,
 } from '../src/terrain/validate/verticalAccuracy';
 import type { ValidationReport } from '../src/terrain/validate/ValidationReport';
 
@@ -40,7 +42,7 @@ describe('computeVerticalAccuracy', () => {
     expect(a.rmseZ).toBe(0.5);
     expect(a.nva95).toBeCloseTo(0.5 * NVA_95_MULTIPLIER, 6);
     expect(a.vva95).toBe(1.1);
-    expect(a.standard).toBe('ASPRS 2014 formulas, hold-out basis');
+    expect(a.standard).toBe('legacy ASPRS 2014 formulas, hold-out basis');
   });
 
   it('carries signed bias + NMAD through, and formats them with direction', () => {
@@ -89,5 +91,29 @@ describe('VerticalAccuracy.standard — a basis tag, not a conformance tag', () 
     expect(a.standard).not.toBe('ASPRS 2014');
     expect(a.standard).toMatch(/formulas/i);
     expect(a.standard).toMatch(/hold-out/i);
+  });
+});
+
+describe('current-standard boundary', () => {
+  it('names the 2014 figures as a LEGACY diagnostic, never the current standard', () => {
+    expect(LEGACY_ASPRS_2014_BASIS).toMatch(/legacy/i);
+    expect(LEGACY_ASPRS_2014_BASIS).toMatch(/2014/);
+    expect(LEGACY_ASPRS_2014_BASIS).toMatch(/hold-out/i);
+  });
+
+  it('states the ASPRS 2024 assessment is unavailable and why', () => {
+    expect(ASPRS_2024_UNAVAILABLE_NOTE).toMatch(/ASPRS 2024|Edition 2/);
+    expect(ASPRS_2024_UNAVAILABLE_NOTE).toMatch(/unavailable/i);
+    expect(ASPRS_2024_UNAVAILABLE_NOTE).toMatch(/independent checkpoint/i);
+    // RMSEV is the current positional-accuracy measure; the note must name it.
+    expect(ASPRS_2024_UNAVAILABLE_NOTE).toMatch(/RMSEV/);
+  });
+
+  it('never claims the 2014 form is current or that NVA-95 is the current measure', () => {
+    // Guards against a regression that re-asserts the outdated vocabulary as current.
+    for (const s of [LEGACY_ASPRS_2014_BASIS, ASPRS_2024_UNAVAILABLE_NOTE]) {
+      expect(s).not.toMatch(/ASPRS 2014 is current/i);
+      expect(s).not.toMatch(/current positional accuracy/i);
+    }
   });
 });


### PR DESCRIPTION
§4 of the v0.6.8 hardening pass. **Stacked on #764** (shares the accuracy surfaces); GitHub will retarget this to `main` once #764 merges.

The hold-out NVA/VVA figures use the **legacy ASPRS 2014 formulas**. Surfaces already qualified them "-style (hold-out)", but nothing named them *legacy* or stated that a formal current-standard assessment (ASPRS 2024, Edition 2, **RMSEV**) is unavailable.

- `verticalAccuracy.ts`: add `ASPRS_2024_UNAVAILABLE_NOTE` (RMSEV needs an independent checkpoint set + checkpoint-survey uncertainty, which internal hold-out cannot supply) and `LEGACY_ASPRS_2014_BASIS`; the accuracy `standard` tag is now the legacy label.
- Analyse panel, terrain report, and the export basis note reframe the NVA/VVA figures as an explicit legacy 2014-formula diagnostic and add an explicit "ASPRS 2024: not assessed (no independent checkpoints)" boundary.
- Text-guard tests: the note names RMSEV and the checkpoint requirement, the legacy label is clearly legacy, and neither string claims 2014 is current.

Premise was partly stale (surfaces already disclaimed), so this is a vocabulary reframe, not new science. No evidence-level change; the arithmetic is untouched. Full suite 13,802 pass / 0 fail; claim-register, claims-language, claim-prose-sync, release-truth green.