### PR TITLE
feat(security): SHA-256 audit default, embed origin tests, DNS-boundary + credentials:omit (audit §3/§6/§7)

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -23,7 +23,15 @@ release changes what the app reads or where it reaches.
 ## Threats and mitigations
 
 Server-side request forgery via a remote URL is handled by the URL validators
-above and the CSP; the validators run before the fetch, not after.
+above and the CSP; the validators run before the fetch, not after. The validators
+reject unsupported schemes, embedded credentials, and literal private-network
+hosts (localhost, private/link-local/CGNAT IPv4, and unsafe/mapped-private IPv6),
+and remote point-cloud fetches use `credentials: 'omit'` with `redirect: 'error'`.
+This is a syntactic, pre-fetch check: it does not resolve or pin DNS, so a
+public-looking hostname that resolves (or later re-resolves) to a private address
+is bounded by the browser — its CORS, Private Network Access controls, and the
+`connect-src` CSP — not by this client-side validation. OLV does not claim to be
+SSRF-proof or to guarantee a public destination.
 
 Cross-site scripting is handled by a strict Content-Security-Policy. The single
 `innerHTML` sink is enforced static-only by `lint:unsafe-html`, and there is no

--- a/src/app/openStreaming.ts
+++ b/src/app/openStreaming.ts
@@ -705,7 +705,7 @@ export async function handleRemoteEpt(
       // but a 3xx could send the fetch to a private address the validator never
       // saw (it does not resolve DNS or follow hops). Refuse redirects so a
       // validated public URL cannot be bounced somewhere internal.
-      manifestResponse = await fetch(safeUrl, { signal: manifestTimeout.signal, redirect: 'error' });
+      manifestResponse = await fetch(safeUrl, { signal: manifestTimeout.signal, redirect: 'error', credentials: 'omit' });
     } catch (err) {
       // manifestTimeout is aborted by the 20 s timer OR, composed, by the outer
       // load-cancel. Only the timer firing with no user cancel is a timeout:

--- a/src/io/ept/eptTransport.ts
+++ b/src/io/ept/eptTransport.ts
@@ -158,7 +158,7 @@ export function createEptTransport(options: EptTransportOptions = {}): EptTransp
       // `redirect: 'error'`: the EPT host was validated against the SSRF
       // block-list, but a redirect could reach a private address the literal
       // check never resolved. Refuse redirect hops on every hierarchy/tile read.
-      const response = await fetchFn(url, { signal: composed.signal, redirect: 'error' });
+      const response = await fetchFn(url, { signal: composed.signal, redirect: 'error', credentials: 'omit' });
       return response;
     } catch (err) {
       // A per-attempt timeout aborts the in-flight fetch exactly as a user

--- a/src/io/range/HttpRangeSource.ts
+++ b/src/io/range/HttpRangeSource.ts
@@ -461,7 +461,7 @@ export class HttpRangeSource implements RangeSource {
         // `redirect: 'error'` (after `...init` so a caller can't weaken it): the
         // URL host passed the SSRF block-list, but a redirect could reach a
         // private address the literal validator never resolved. Refuse hops.
-        response = await this._fetch(this._url, { ...init, signal, redirect: 'error' });
+        response = await this._fetch(this._url, { ...init, signal, redirect: 'error', credentials: 'omit' });
       } catch (err) {
         clearTimeout(timer);
         cleanup();

--- a/src/io/tiles3d/tilesetTransport.ts
+++ b/src/io/tiles3d/tilesetTransport.ts
@@ -196,7 +196,7 @@ export function createTilesetTransport(
       // `redirect: 'error'`: the host passed the SSRF block-list as a literal
       // string, but a 3xx could send the fetch to a private address no check
       // ever resolved. Refuse the hop rather than follow it.
-      return await fetchFn(url, { signal: composed.signal, redirect: 'error' });
+      return await fetchFn(url, { signal: composed.signal, redirect: 'error', credentials: 'omit' });
     } catch (err) {
       if (deadline.signal.aborted && !outer?.aborted) {
         throw new TilesetTimeoutError(

--- a/src/render/measure/auditLog.ts
+++ b/src/render/measure/auditLog.ts
@@ -1,8 +1,11 @@
 /**
  * auditLog.ts
  *
- * A tamper-evident, replayable record of what was done to a dataset and what
- * each measurement claimed.
+ * An append-only, replayable hash-chain record of what was done to a dataset
+ * and what each measurement claimed. The chain hashes with SHA-256 by default
+ * (a cryptographic digest); the fast non-cryptographic FNV-1a checksum remains
+ * injectable for accidental-corruption detection where that is all that is
+ * wanted — the algorithm is the caller's explicit choice, never implied.
  *
  * Local-first means the data never leaves the machine — but a surveyor staking
  * their name on a number needs more than privacy: they need to prove the number
@@ -136,7 +139,9 @@ export class AuditLog {
   private readonly _entries: AuditEntry[] = [];
   private readonly _hashFn: HashFn;
 
-  constructor(hashFn: HashFn = fnv1a) {
+  // Defaults to the cryptographic SHA-256 so the chain is tamper-evident by
+  // construction; pass fnv1a explicitly for a fast corruption-only checksum.
+  constructor(hashFn: HashFn = sha256) {
     this._hashFn = hashFn;
   }
 
@@ -173,7 +178,9 @@ export class AuditLog {
  */
 export function verifyAuditChain(
   entries: ReadonlyArray<AuditEntry>,
-  hashFn: HashFn = fnv1a,
+  // Must match the algorithm the chain was built with; defaults to SHA-256 like
+  // the AuditLog constructor, and takes fnv1a explicitly to verify a legacy chain.
+  hashFn: HashFn = sha256,
 ): number {
   let prev = GENESIS;
   for (let i = 0; i < entries.length; i++) {

--- a/tests/auditLog.test.ts
+++ b/tests/auditLog.test.ts
@@ -85,6 +85,20 @@ describe('AuditLog hash chain', () => {
     // Verifying with the wrong hash function flags entry 0.
     expect(verifyAuditChain(log.entries, fnv1a)).toBe(0);
   });
+
+  test('defaults to cryptographic SHA-256, so "tamper-evident" is true by construction', () => {
+    const log = new AuditLog();
+    log.append('op', { a: 1 });
+    // A SHA-256 chain hash is 64 hex chars; the 8-char FNV form would not be.
+    expect(log.entries[0].hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(verifyAuditChain(log.entries)).toBe(-1);
+  });
+
+  test('algorithm confusion fails: a SHA-256 chain does not verify as FNV', () => {
+    const log = new AuditLog(); // default sha256
+    log.append('op', { a: 1 });
+    expect(verifyAuditChain(log.entries, fnv1a)).toBe(0);
+  });
 });
 
 import { sha256 as _sha256 } from '../src/render/measure/auditLog';

--- a/tests/embedBridge.test.ts
+++ b/tests/embedBridge.test.ts
@@ -237,47 +237,21 @@ describe('startEmbedBridge — only the true embedding parent may drive the view
     dispose();
   });
 
-  it('with an allow-list set, ACCEPTS a state command from a listed origin', () => {
+  // Once an embedder configures allowedOrigins, the list gates EVERY command
+  // (not just load-file): a genuine-parent state command runs only from a listed
+  // origin, and an unlisted or null/opaque origin is dropped before it runs.
+  // Table-driven so the one dispatch+assert shape is written once.
+  it.each([
+    ['a listed origin', 'https://host.example', true],
+    ['an unlisted origin', 'https://attacker.example', false],
+    ['a null/opaque origin', 'null', false],
+  ] as const)('with an allow-list set, a state command from %s runs=%s', (_label, origin, shouldRun) => {
     const { handlers, calls } = makeHandlers();
     const env = withWindow(false);
     const dispose = startEmbedBridge(handlers, { allowedOrigins: ['https://host.example'] });
-    env.dispatch({
-      source: env.parent,
-      origin: 'https://host.example',
-      data: { type: 'toggle-layer', id: 'cloud_0', visible: true },
-    });
-    expect(calls.onToggleLayer).toHaveBeenCalledWith('cloud_0', true);
-    dispose();
-  });
-
-  it('with an allow-list set, REFUSES a state command from an UNLISTED origin', () => {
-    // The origin allow-list gates every command, not just load-file: once an
-    // embedder configures allowedOrigins, a genuine-parent message from an
-    // origin outside the list is dropped before the command runs.
-    const { handlers, calls } = makeHandlers();
-    const env = withWindow(false);
-    const dispose = startEmbedBridge(handlers, { allowedOrigins: ['https://host.example'] });
-    env.dispatch({
-      source: env.parent,
-      origin: 'https://attacker.example',
-      data: { type: 'toggle-layer', id: 'cloud_0', visible: true },
-    });
-    expect(calls.onToggleLayer).not.toHaveBeenCalled();
-    dispose();
-  });
-
-  it('with an allow-list set, REFUSES a null/opaque origin', () => {
-    // A sandboxed or data-URL parent posts with origin "null"; it can never be
-    // on an explicit allow-list, so a configured allow-list refuses it.
-    const { handlers, calls } = makeHandlers();
-    const env = withWindow(false);
-    const dispose = startEmbedBridge(handlers, { allowedOrigins: ['https://host.example'] });
-    env.dispatch({
-      source: env.parent,
-      origin: 'null',
-      data: { type: 'toggle-layer', id: 'cloud_0', visible: true },
-    });
-    expect(calls.onToggleLayer).not.toHaveBeenCalled();
+    env.dispatch({ source: env.parent, origin, data: { type: 'toggle-layer', id: 'cloud_0', visible: true } });
+    if (shouldRun) expect(calls.onToggleLayer).toHaveBeenCalledWith('cloud_0', true);
+    else expect(calls.onToggleLayer).not.toHaveBeenCalled();
     dispose();
   });
 });

--- a/tests/embedBridge.test.ts
+++ b/tests/embedBridge.test.ts
@@ -236,4 +236,48 @@ describe('startEmbedBridge — only the true embedding parent may drive the view
     expect(calls.onJumpCamera).toHaveBeenCalled();
     dispose();
   });
+
+  it('with an allow-list set, ACCEPTS a state command from a listed origin', () => {
+    const { handlers, calls } = makeHandlers();
+    const env = withWindow(false);
+    const dispose = startEmbedBridge(handlers, { allowedOrigins: ['https://host.example'] });
+    env.dispatch({
+      source: env.parent,
+      origin: 'https://host.example',
+      data: { type: 'toggle-layer', id: 'cloud_0', visible: true },
+    });
+    expect(calls.onToggleLayer).toHaveBeenCalledWith('cloud_0', true);
+    dispose();
+  });
+
+  it('with an allow-list set, REFUSES a state command from an UNLISTED origin', () => {
+    // The origin allow-list gates every command, not just load-file: once an
+    // embedder configures allowedOrigins, a genuine-parent message from an
+    // origin outside the list is dropped before the command runs.
+    const { handlers, calls } = makeHandlers();
+    const env = withWindow(false);
+    const dispose = startEmbedBridge(handlers, { allowedOrigins: ['https://host.example'] });
+    env.dispatch({
+      source: env.parent,
+      origin: 'https://attacker.example',
+      data: { type: 'toggle-layer', id: 'cloud_0', visible: true },
+    });
+    expect(calls.onToggleLayer).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it('with an allow-list set, REFUSES a null/opaque origin', () => {
+    // A sandboxed or data-URL parent posts with origin "null"; it can never be
+    // on an explicit allow-list, so a configured allow-list refuses it.
+    const { handlers, calls } = makeHandlers();
+    const env = withWindow(false);
+    const dispose = startEmbedBridge(handlers, { allowedOrigins: ['https://host.example'] });
+    env.dispatch({
+      source: env.parent,
+      origin: 'null',
+      data: { type: 'toggle-layer', id: 'cloud_0', visible: true },
+    });
+    expect(calls.onToggleLayer).not.toHaveBeenCalled();
+    dispose();
+  });
 });


### PR DESCRIPTION
Residual-hardening audit §3 / §6 / §7 — the security-boundary cluster. Each item was verified against source; the audit's larger asks (a full AuditHashAlgorithm migration; flipping embed state-commands to strict-by-default) were **not** applied because the shipped code already covers the real risk or the flip would break existing embeds.

**§3 AuditLog integrity.** The hash-chain `AuditLog` class defaulted to non-cryptographic FNV-1a while its docstring said "tamper-evident". The shipped provenance chains (`processingManifest`, `reportManifest`) *already* use SHA-256 directly; only this (unreachable) class carried the mismatch. Fix: flip the `AuditLog` constructor and `verifyAuditChain` defaults to the in-file SHA-256 (already present, same layer, FIPS-tested) so the term is true by construction; FNV-1a stays injectable for corruption-only checksums. Docstring reworded; tests for the crypto default + algorithm-confusion.

**§7 remote-URL / DNS boundary.** `docs/threat-model.md` now states that URL validation is a syntactic pre-fetch check that does **not** resolve or pin DNS — a rebinding to a private address is bounded by the browser (CORS, Private Network Access, `connect-src`), not this validator, and OLV makes no SSRF-proof claim. Remote point-cloud fetches now pass `credentials: 'omit'` alongside the existing `redirect: 'error'` (HttpRangeSource, ept, tiles3d, streaming manifest).

**§6 embed origin policy.** The audit's core fear (load-file trusting `event.source` alone) is already false — load-file is unconditionally origin-gated. The permissive state-command path without an allow-list is deliberate back-compat; flipping it strict-by-default would break shipped embeds, so it's unchanged. Added the missing tests: a configured allow-list gates **every** command (listed state command accepted; unlisted and null/opaque origin refused).

Full suite 13,821 pass / 0 fail; tsc, doc-links green.