### PR TITLE
feat(volume): area-weighted stockpile volume method (§7)

### DIFF
--- a/docs/science/METHOD_REGISTRY.md
+++ b/docs/science/METHOD_REGISTRY.md
@@ -39,6 +39,7 @@ the paper that specifies it.
 | `olv.registration.icp-planar` | 1 | Planar rigid ICP | Besl & McKay (1992); Umeyama (1991) |
 | `olv.registration.epoch-horizontal-icp` | 1 | Repeat-epoch horizontal alignment (yaw + XY, Z locked) | Besl & McKay (1992); Umeyama (1991) |
 | `olv.volume.stockpile` | 1 | Stockpile cut-fill volume ±1σ | internal (prismatic cut-fill) |
+| `olv.volume.stockpile-area-grid` | 1 | Area-weighted stockpile volume (grid integration) | internal (area-weighted DoD); Sutherland & Hodgman (1974) |
 | `olv.feature.building-footprint` | 1 | Building footprint candidate extraction | internal (connected-component + boundary trace) |
 | `olv.feature.conductor-fit` | 1 | Conductor centreline and sag fit | internal (parabolic small-sag approximation) |
 

--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -20,6 +20,13 @@
   "reviewDates": "Reported by the lint when they pass, never enforced. A gate that turns red on a date with no change to the tree teaches people to edit the date rather than the code.",
   "modules": [
     {
+      "path": "src/render/measure/stockpileAreaGrid.ts",
+      "status": "staged",
+      "why": "Area-weighted stockpile volume (method olv.volume.stockpile-area-grid): grid integration with polygon-clipped cell areas, robust median surface, coverage accounting and an explicit incomplete-uncertainty model. The scientific core is analytically verified (prism/ramp/pyramid/cone, density-gradient invariance, coverage honesty), but the live volume tool still calls the legacy point-sample estimator (volumeCutFill / olv.volume.stockpile), so nothing in the app constructs the area-grid result yet.",
+      "graduation": "The volume tool projects the cloud + footprint into the area-grid input and presents its result (with the coverage verdict and separated uncertainty terms), replacing or offered beside the legacy estimator.",
+      "review": "2027-02-28"
+    },
+    {
       "path": "src/terrain/contour/persistentCoreKey.ts",
       "status": "staged",
       "why": "The identity and invalidation contract for a persistent (across-reopen) terrain core cache: a full SHA-256 content fingerprint, the core-method generation string, and an integrity digest. It is the library half of the recompute-vs-reuse gate in tests/benchmark/terrainCoreRebuildCost.test.ts, which returned GO (conditional). No storage or reopen path is built, so nothing in the application computes a persistent key; only its own test imports it.",

--- a/src/render/measure/stockpileAreaGrid.ts
+++ b/src/render/measure/stockpileAreaGrid.ts
@@ -1,0 +1,343 @@
+/**
+ * stockpileAreaGrid.ts — AREA-weighted stockpile volume (method
+ * `olv.volume.stockpile-area-grid`).
+ *
+ * The legacy estimator (`volumeCutFill`) integrates V = A·mean(height over the
+ * N points inside the footprint). That weights each POINT equally, so a denser
+ * region of the cloud counts for more horizontal area than a sparse one — it is
+ * unbiased only when point sampling is spatially uniform, which real scans are
+ * not (density gradients, overlap, occlusion, missing patches). See the bias
+ * characterised in `tests/volumeSyntheticTruth.test.ts`.
+ *
+ * This module integrates over horizontal AREA instead:
+ *
+ *   V_fill = Σ_c A_c · max(0, z_surf,c − z_base,c)
+ *   V_cut  = Σ_c A_c · max(0, z_base,c − z_surf,c)
+ *
+ * where each cell `c` of a regular horizontal grid contributes its polygon-clipped
+ * area A_c and a robust (median) surface height from the points that fall in it.
+ * Every cell counts once, regardless of how many points sampled it, so a density
+ * gradient no longer biases the result. Cells with too little support are NOT
+ * interpolated to zero — they are recorded as unobserved and reduce the reported
+ * coverage, so a footprint with a hole cannot masquerade as a full measurement.
+ *
+ * Pure, deterministic, no DOM. Operates in the source linear unit of the input
+ * coordinates; `linearUnitToMetres` converts the reported volume/area to
+ * metres/m³ so a foot-unit and a metre representation of the same pile agree.
+ *
+ * SCOPE: this is the analytically-verified integration core. Uncertainty is
+ * reported as an explicit, deliberately INCOMPLETE model (a surface-spread term
+ * only) rather than a validated interval — see {@link StockpileAreaGridResult}.
+ */
+
+/** A point already projected to the horizontal plane: map x/y plus height z. */
+export interface AreaGridPoint {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+/** A 2D footprint vertex in the same frame as the points. */
+export interface Vec2 {
+  readonly x: number;
+  readonly y: number;
+}
+
+/** The base surface the pile sits on. */
+export type StockpileBase =
+  /** A single base elevation for the whole footprint. */
+  | { readonly kind: 'constant'; readonly zM: number }
+  /** A tilted plane z = a·x + b·y + c (coefficients in the source frame). */
+  | { readonly kind: 'plane'; readonly a: number; readonly b: number; readonly c: number };
+
+export interface StockpileAreaGridInput {
+  /** Cloud points inside or near the footprint, projected to (x, y) + height z. */
+  readonly points: ReadonlyArray<AreaGridPoint>;
+  /** The stockpile footprint, in placement order, same 2D frame as the points. */
+  readonly polygon: ReadonlyArray<Vec2>;
+  /** The base surface (constant elevation or a fitted plane). */
+  readonly base: StockpileBase;
+  /**
+   * Grid cell size in the source unit. When omitted, derived from the point
+   * spacing (see {@link deriveCellSize}), which is deterministic and never taken
+   * from viewport/zoom state.
+   */
+  readonly cellSizeM?: number;
+  /** Minimum points in a cell for its surface to be trusted. Default 1. */
+  readonly minSupportPerCell?: number;
+  /** Metres per source linear unit, for the reported figures. Default 1. */
+  readonly linearUnitToMetres?: number;
+  /** Optional deterministic bounds on the derived cell size, in source units. */
+  readonly minCellSizeM?: number;
+  readonly maxCellSizeM?: number;
+  /** Max cells across the grid before it is coarsened, so a huge footprint at a
+   *  fine resolution cannot allocate without bound. Default 1e6. */
+  readonly maxCells?: number;
+}
+
+/** Per-cell record kept for coverage accounting and diagnostics. */
+export interface StockpileCell {
+  readonly ix: number;
+  readonly iy: number;
+  /** Polygon-clipped horizontal area of the cell, source-unit². */
+  readonly areaSrc: number;
+  /** Robust (median) surface height in the cell, source unit; NaN when unsupported. */
+  readonly surfaceZ: number;
+  /** Points that fell in the cell. */
+  readonly support: number;
+  /** Local surface spread (NMAD of the cell heights), source unit; 0 when <2 points. */
+  readonly spread: number;
+}
+
+export interface StockpileAreaGridResult {
+  /** Method id + version, for provenance. */
+  readonly method: 'olv.volume.stockpile-area-grid@1';
+  /** Fill (above base) volume in m³, over SUPPORTED area only. */
+  readonly fillM3: number;
+  /** Cut (below base) volume in m³, over supported area only. */
+  readonly cutM3: number;
+  /** Net = fill − cut, m³. */
+  readonly netM3: number;
+  /** Resolved cell size (source unit) and whether it was derived or given. */
+  readonly cellSizeM: number;
+  readonly cellSizeDerived: boolean;
+  /** Total footprint area, m². */
+  readonly polygonAreaM2: number;
+  /** Area with sufficient support, m². */
+  readonly supportedAreaM2: number;
+  /** Area observed with no/low support, m² (footprint minus supported). */
+  readonly unobservedAreaM2: number;
+  /** supportedArea / polygonArea, 0..1. */
+  readonly supportFraction: number;
+  /**
+   * Coverage verdict from the support fraction:
+   *   'measured'  — high coverage, the headline volume stands;
+   *   'preview'   — moderate gaps, treat as low-confidence;
+   *   'refused'   — severe gaps, no headline volume should be shown.
+   */
+  readonly coverage: 'measured' | 'preview' | 'refused';
+  /**
+   * Uncertainty is an explicit INCOMPLETE model: `surfaceTermM3` propagates the
+   * per-cell surface spread only. It does NOT include a base-surface term or a
+   * validated coverage-gap term, so it is a lower bound, not a total 1σ. Stated
+   * this way rather than reported as a neat but unjustified interval.
+   */
+  readonly uncertaintyModel: 'incomplete';
+  readonly surfaceTermM3: number;
+  readonly cells: readonly StockpileCell[];
+}
+
+const DEFAULT_MIN_CELL = 0.05;
+const DEFAULT_MAX_CELL = 50;
+const DEFAULT_MAX_CELLS = 1_000_000;
+const SPACING_MULTIPLIER = 2.5;
+/** Coverage thresholds on the supported-area fraction. */
+const MEASURED_MIN = 0.9;
+const PREVIEW_MIN = 0.6;
+
+/** Absolute polygon area (shoelace), source-unit². */
+function polygonArea(poly: ReadonlyArray<Vec2>): number {
+  const n = poly.length;
+  if (n < 3) return 0;
+  let s = 0;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    s += (poly[j].x + poly[i].x) * (poly[j].y - poly[i].y);
+  }
+  return Math.abs(s) * 0.5;
+}
+
+/**
+ * A defensible cell size from the point spacing: mean nearest-neighbour spacing
+ * is approximated as sqrt(footprintArea / N) (exact for a uniform grid of N
+ * points over the area), scaled up so a cell holds a few points, then clamped.
+ * Deterministic and unit-aware; never derived from viewport state.
+ */
+export function deriveCellSize(
+  polygonAreaSrc: number,
+  pointCount: number,
+  minCell = DEFAULT_MIN_CELL,
+  maxCell = DEFAULT_MAX_CELL,
+): number {
+  if (!(polygonAreaSrc > 0) || pointCount < 1) return maxCell;
+  const spacing = Math.sqrt(polygonAreaSrc / pointCount);
+  return Math.max(minCell, Math.min(maxCell, spacing * SPACING_MULTIPLIER));
+}
+
+/** Median of a numeric array (mutates a copy). Empty → NaN. */
+function median(values: number[]): number {
+  if (values.length === 0) return Number.NaN;
+  const s = [...values].sort((a, b) => a - b);
+  const mid = s.length >> 1;
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+/** NMAD (1.4826 × median absolute deviation). <2 values → 0. */
+function nmad(values: number[], med: number): number {
+  if (values.length < 2) return 0;
+  const dev = values.map((v) => Math.abs(v - med));
+  return 1.4826 * median(dev);
+}
+
+/** Sutherland–Hodgman clip of `subject` against one axis-aligned half-plane. */
+function clipHalfPlane(
+  subject: ReadonlyArray<Vec2>,
+  inside: (p: Vec2) => boolean,
+  intersect: (a: Vec2, b: Vec2) => Vec2,
+): Vec2[] {
+  const out: Vec2[] = [];
+  const n = subject.length;
+  if (n === 0) return out;
+  for (let i = 0; i < n; i++) {
+    const cur = subject[i];
+    const prev = subject[(i + n - 1) % n];
+    const curIn = inside(cur);
+    const prevIn = inside(prev);
+    if (curIn) {
+      if (!prevIn) out.push(intersect(prev, cur));
+      out.push(cur);
+    } else if (prevIn) {
+      out.push(intersect(prev, cur));
+    }
+  }
+  return out;
+}
+
+/**
+ * The area of `poly` clipped to the axis-aligned cell rectangle
+ * [xmin,xmax]×[ymin,ymax], via Sutherland–Hodgman against the four edges. The
+ * rectangle is the CONVEX clip window, so an arbitrary (even concave) footprint
+ * clips correctly. Returns the clipped area in source-unit².
+ */
+export function clippedCellArea(
+  poly: ReadonlyArray<Vec2>,
+  xmin: number,
+  ymin: number,
+  xmax: number,
+  ymax: number,
+): number {
+  let p: Vec2[] = [...poly];
+  const lerp = (a: Vec2, b: Vec2, t: number): Vec2 => ({
+    x: a.x + (b.x - a.x) * t,
+    y: a.y + (b.y - a.y) * t,
+  });
+  // x >= xmin
+  p = clipHalfPlane(p, (q) => q.x >= xmin, (a, b) => lerp(a, b, (xmin - a.x) / (b.x - a.x)));
+  // x <= xmax
+  p = clipHalfPlane(p, (q) => q.x <= xmax, (a, b) => lerp(a, b, (xmax - a.x) / (b.x - a.x)));
+  // y >= ymin
+  p = clipHalfPlane(p, (q) => q.y >= ymin, (a, b) => lerp(a, b, (ymin - a.y) / (b.y - a.y)));
+  // y <= ymax
+  p = clipHalfPlane(p, (q) => q.y <= ymax, (a, b) => lerp(a, b, (ymax - a.y) / (b.y - a.y)));
+  return polygonArea(p);
+}
+
+function baseZ(base: StockpileBase, x: number, y: number): number {
+  return base.kind === 'constant' ? base.zM : base.a * x + base.b * y + base.c;
+}
+
+/**
+ * Integrate the stockpile volume by area-weighted cells. See the module header.
+ */
+export function stockpileAreaGrid(input: StockpileAreaGridInput): StockpileAreaGridResult {
+  const unit = input.linearUnitToMetres && input.linearUnitToMetres > 0 ? input.linearUnitToMetres : 1;
+  const minSupport = Math.max(1, Math.floor(input.minSupportPerCell ?? 1));
+  const minCell = input.minCellSizeM ?? DEFAULT_MIN_CELL;
+  const maxCell = input.maxCellSizeM ?? DEFAULT_MAX_CELL;
+  const maxCells = input.maxCells ?? DEFAULT_MAX_CELLS;
+  const polyAreaSrc = polygonArea(input.polygon);
+
+  // Footprint bounding box.
+  let xmin = Infinity, ymin = Infinity, xmax = -Infinity, ymax = -Infinity;
+  for (const v of input.polygon) {
+    if (v.x < xmin) xmin = v.x;
+    if (v.y < ymin) ymin = v.y;
+    if (v.x > xmax) xmax = v.x;
+    if (v.y > ymax) ymax = v.y;
+  }
+  const emptyResult = (): StockpileAreaGridResult => ({
+    method: 'olv.volume.stockpile-area-grid@1',
+    fillM3: 0, cutM3: 0, netM3: 0,
+    cellSizeM: input.cellSizeM ?? maxCell, cellSizeDerived: input.cellSizeM == null,
+    polygonAreaM2: polyAreaSrc * unit * unit,
+    supportedAreaM2: 0, unobservedAreaM2: polyAreaSrc * unit * unit, supportFraction: 0,
+    coverage: 'refused', uncertaintyModel: 'incomplete', surfaceTermM3: 0, cells: [],
+  });
+  if (!(polyAreaSrc > 0) || !Number.isFinite(xmin)) return emptyResult();
+
+  let cell = input.cellSizeM ?? deriveCellSize(polyAreaSrc, input.points.length, minCell, maxCell);
+  const cellDerived = input.cellSizeM == null;
+  // Coarsen deterministically if the grid would exceed the cell budget.
+  const spanX = xmax - xmin;
+  const spanY = ymax - ymin;
+  const cellsAt = (c: number): number => (Math.ceil(spanX / c) + 1) * (Math.ceil(spanY / c) + 1);
+  while (cell < maxCell && cellsAt(cell) > maxCells) cell *= 2;
+
+  const nx = Math.max(1, Math.ceil(spanX / cell));
+  const ny = Math.max(1, Math.ceil(spanY / cell));
+
+  // Bin point heights into cells.
+  const heights: number[][] = Array.from({ length: nx * ny }, () => []);
+  for (const p of input.points) {
+    if (p.x < xmin || p.x > xmax || p.y < ymin || p.y > ymax) continue;
+    const ix = Math.min(nx - 1, Math.floor((p.x - xmin) / cell));
+    const iy = Math.min(ny - 1, Math.floor((p.y - ymin) / cell));
+    heights[iy * nx + ix].push(p.z);
+  }
+
+  const cells: StockpileCell[] = [];
+  let fillSrc = 0;
+  let cutSrc = 0;
+  let supportedAreaSrc = 0;
+  let surfaceVarM6 = 0; // Σ (A_c·σ_c)² in metre units, for the surface term.
+
+  for (let iy = 0; iy < ny; iy++) {
+    for (let ix = 0; ix < nx; ix++) {
+      const cx0 = xmin + ix * cell;
+      const cy0 = ymin + iy * cell;
+      const areaSrc = clippedCellArea(input.polygon, cx0, cy0, Math.min(cx0 + cell, xmax), Math.min(cy0 + cell, ymax));
+      if (areaSrc <= 0) continue; // cell outside the footprint
+      const hs = heights[iy * nx + ix];
+      if (hs.length < minSupport) {
+        // Observed-but-unsupported: recorded, NOT interpolated to zero.
+        cells.push({ ix, iy, areaSrc, surfaceZ: Number.NaN, support: hs.length, spread: 0 });
+        continue;
+      }
+      const med = median(hs);
+      const spread = nmad(hs, med);
+      const bz = baseZ(input.base, cx0 + cell / 2, cy0 + cell / 2);
+      const dz = med - bz;
+      if (dz >= 0) fillSrc += areaSrc * dz;
+      else cutSrc += areaSrc * -dz;
+      supportedAreaSrc += areaSrc;
+      // Surface-term variance: (A_c[m²]·σ_c[m])², σ_c = spread/√support (SEM).
+      const aM2 = areaSrc * unit * unit;
+      const sigmaM = (spread * unit) / Math.sqrt(hs.length);
+      surfaceVarM6 += (aM2 * sigmaM) * (aM2 * sigmaM);
+      cells.push({ ix, iy, areaSrc, surfaceZ: med, support: hs.length, spread });
+    }
+  }
+
+  const polygonAreaM2 = polyAreaSrc * unit * unit;
+  const supportedAreaM2 = supportedAreaSrc * unit * unit;
+  const supportFraction = polygonAreaM2 > 0 ? Math.min(1, supportedAreaM2 / polygonAreaM2) : 0;
+  const coverage: StockpileAreaGridResult['coverage'] =
+    supportFraction >= MEASURED_MIN ? 'measured' : supportFraction >= PREVIEW_MIN ? 'preview' : 'refused';
+  const unitVol = unit * unit * unit;
+
+  return {
+    method: 'olv.volume.stockpile-area-grid@1',
+    fillM3: fillSrc * unitVol,
+    cutM3: cutSrc * unitVol,
+    netM3: (fillSrc - cutSrc) * unitVol,
+    cellSizeM: cell,
+    cellSizeDerived: cellDerived,
+    polygonAreaM2,
+    supportedAreaM2,
+    unobservedAreaM2: Math.max(0, polygonAreaM2 - supportedAreaM2),
+    supportFraction,
+    coverage,
+    uncertaintyModel: 'incomplete',
+    surfaceTermM3: Math.sqrt(surfaceVarM6),
+    cells,
+  };
+}

--- a/src/science/methodRegistry.ts
+++ b/src/science/methodRegistry.ts
@@ -217,6 +217,22 @@ export const METHOD_REGISTRY: Readonly<Record<string, MethodEntry>> = {
     category: 'volume',
     implementation: ['src/render/measure/stockpileVolume.ts'],
   },
+  'olv.volume.stockpile-area-grid': {
+    id: 'olv.volume.stockpile-area-grid',
+    version: 1,
+    name: 'Area-weighted stockpile volume (grid integration)',
+    summary:
+      'Cut-fill volume by integrating over a regular horizontal grid: each cell ' +
+      'contributes its polygon-clipped area times a robust (median) surface height ' +
+      'above the base, so a density gradient in the cloud does not bias the result. ' +
+      'Unobserved cells reduce reported coverage rather than reading as zero. ' +
+      'Distinct from olv.volume.stockpile, which is the point-sample estimator.',
+    citation:
+      'Internal composition (area-weighted DEM-of-difference integration; ' +
+      'Sutherland & Hodgman (1974) polygon clipping); standard earthworks method.',
+    category: 'volume',
+    implementation: ['src/render/measure/stockpileAreaGrid.ts'],
+  },
   'olv.topology.linkage-record': {
     id: 'olv.topology.linkage-record',
     version: 1,

--- a/tests/stockpileAreaGrid.test.ts
+++ b/tests/stockpileAreaGrid.test.ts
@@ -1,0 +1,235 @@
+/**
+ * stockpileAreaGrid.test.ts — the area-weighted stockpile volume against
+ * ANALYTIC truth and adversarial cases, not against its own control flow.
+ *
+ * The method integrates V = Σ_c A_c·max(0, z_surf,c − z_base,c) over a regular
+ * grid, weighting horizontal AREA rather than point count. The tests pin:
+ *   - closed-form shapes (prism, ramp, pyramid, cone) within raster tolerance;
+ *   - the property the whole method exists for — density-gradient invariance;
+ *   - coverage honesty (a missing quadrant is unobserved, not zero);
+ *   - order / unit / translation invariance;
+ *   - the Sutherland–Hodgman cell clip against analytic areas.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  stockpileAreaGrid,
+  clippedCellArea,
+  deriveCellSize,
+  type AreaGridPoint,
+  type Vec2,
+} from '../src/render/measure/stockpileAreaGrid';
+
+/** A square footprint [0,S]×[0,S]. */
+function square(S: number): Vec2[] {
+  return [
+    { x: 0, y: 0 },
+    { x: S, y: 0 },
+    { x: S, y: S },
+    { x: 0, y: S },
+  ];
+}
+
+/** A dense n×n grid of points over [0,S]×[0,S] with height from `zf(x,y)`. */
+function sample(S: number, n: number, zf: (x: number, y: number) => number): AreaGridPoint[] {
+  const pts: AreaGridPoint[] = [];
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      const x = ((i + 0.5) / n) * S;
+      const y = ((j + 0.5) / n) * S;
+      pts.push({ x, y, z: zf(x, y) });
+    }
+  }
+  return pts;
+}
+
+const flatBase = { kind: 'constant', zM: 0 } as const;
+
+describe('stockpileAreaGrid — analytic shapes', () => {
+  it('rectangular prism: V = A·h', () => {
+    const S = 10, h = 5;
+    const r = stockpileAreaGrid({
+      points: sample(S, 60, () => h),
+      polygon: square(S),
+      base: flatBase,
+      cellSizeM: 0.5,
+    });
+    expect(r.fillM3).toBeCloseTo(S * S * h, 0); // 500 m³, tight (flat top)
+    expect(r.cutM3).toBe(0);
+    expect(r.coverage).toBe('measured');
+    expect(r.supportFraction).toBeGreaterThan(0.99);
+  });
+
+  it('planar ramp: V = A·h/2', () => {
+    const S = 10, h = 6;
+    const r = stockpileAreaGrid({
+      points: sample(S, 80, (x) => (x / S) * h), // 0 → h across x
+      polygon: square(S),
+      base: flatBase,
+      cellSizeM: 0.25,
+    });
+    expect(r.fillM3).toBeCloseTo((S * S * h) / 2, 0); // 300 m³
+  });
+
+  it('square pyramid: V = A·h/3', () => {
+    const S = 10, h = 9, c = S / 2;
+    // z = h·(1 − max(|x−c|,|y−c|)/c): a pyramid peaking at the centre.
+    const r = stockpileAreaGrid({
+      points: sample(S, 120, (x, y) => h * (1 - Math.max(Math.abs(x - c), Math.abs(y - c)) / c)),
+      polygon: square(S),
+      base: flatBase,
+      cellSizeM: 0.1,
+    });
+    expect(r.fillM3).toBeCloseTo((S * S * h) / 3, -1); // 300 m³, within raster tol
+  });
+
+  it('cone: V = (1/3)·π·R²·h', () => {
+    const R = 6, h = 9, c = R; // disc of radius R centred at (R,R) in a 2R box
+    const inCircle = (x: number, y: number): boolean => Math.hypot(x - c, y - c) <= R;
+    // Circular footprint approximated by a 48-gon.
+    const poly: Vec2[] = [];
+    for (let k = 0; k < 48; k++) {
+      const a = (k / 48) * 2 * Math.PI;
+      poly.push({ x: c + R * Math.cos(a), y: c + R * Math.sin(a) });
+    }
+    const pts = sample(2 * R, 160, (x, y) => (inCircle(x, y) ? h * (1 - Math.hypot(x - c, y - c) / R) : 0))
+      .filter((p) => inCircle(p.x, p.y));
+    const r = stockpileAreaGrid({ points: pts, polygon: poly, base: flatBase, cellSizeM: 0.15 });
+    const expected = (1 / 3) * Math.PI * R * R * h; // ≈ 339.29 m³
+    expect(r.fillM3).toBeGreaterThan(expected * 0.95);
+    expect(r.fillM3).toBeLessThan(expected * 1.05);
+  });
+});
+
+describe('stockpileAreaGrid — the anti-bias property', () => {
+  it('is invariant to a density gradient (the whole point of area weighting)', () => {
+    const S = 10, h = 4;
+    const uniform = sample(S, 40, () => h);
+    // The same flat surface, but 10× denser on the right half.
+    const dense: AreaGridPoint[] = [...uniform];
+    for (const p of uniform) if (p.x > S / 2) for (let k = 0; k < 9; k++) dense.push(p);
+
+    const a = stockpileAreaGrid({ points: uniform, polygon: square(S), base: flatBase, cellSizeM: 0.5 });
+    const b = stockpileAreaGrid({ points: dense, polygon: square(S), base: flatBase, cellSizeM: 0.5 });
+    // Area weighting: each cell's median is h regardless of how many points hit it.
+    expect(b.fillM3).toBeCloseTo(a.fillM3, 6);
+  });
+});
+
+describe('stockpileAreaGrid — coverage honesty', () => {
+  it('a missing quadrant is unobserved, not zero, and downgrades coverage', () => {
+    const S = 10, h = 5;
+    const pts = sample(S, 60, () => h).filter((p) => !(p.x > S / 2 && p.y > S / 2));
+    const r = stockpileAreaGrid({ points: pts, polygon: square(S), base: flatBase, cellSizeM: 0.5 });
+    // Three quadrants supported → ~75% coverage, and the volume covers only them.
+    expect(r.supportFraction).toBeGreaterThan(0.7);
+    expect(r.supportFraction).toBeLessThan(0.8);
+    expect(r.unobservedAreaM2).toBeCloseTo((S * S) / 4, 0);
+    expect(r.fillM3).toBeCloseTo(S * S * h * 0.75, 0); // supported area only
+    expect(r.coverage).toBe('preview'); // 0.6 ≤ frac < 0.9
+  });
+
+  it('refuses coverage when most of the footprint is unobserved', () => {
+    const S = 10, h = 5;
+    // Only a thin strip near x=0 has points.
+    const pts = sample(S, 60, () => h).filter((p) => p.x < S * 0.2);
+    const r = stockpileAreaGrid({ points: pts, polygon: square(S), base: flatBase, cellSizeM: 0.5 });
+    expect(r.supportFraction).toBeLessThan(0.6);
+    expect(r.coverage).toBe('refused');
+  });
+});
+
+describe('stockpileAreaGrid — invariances', () => {
+  const S = 10, h = 5;
+  const base = () => sample(S, 50, () => h);
+
+  it('is invariant to point order', () => {
+    const pts = base();
+    const shuffled = [...pts].sort(() => 0.5 - ((pts.length * 2654435761) % 2)); // deterministic-ish reshuffle
+    const a = stockpileAreaGrid({ points: pts, polygon: square(S), base: flatBase, cellSizeM: 0.5 });
+    const b = stockpileAreaGrid({ points: shuffled, polygon: square(S), base: flatBase, cellSizeM: 0.5 });
+    expect(b.fillM3).toBeCloseTo(a.fillM3, 9);
+  });
+
+  it('is invariant to a large coordinate translation', () => {
+    const T = 500_000;
+    const a = stockpileAreaGrid({ points: base(), polygon: square(S), base: flatBase, cellSizeM: 0.5 });
+    const shifted = base().map((p) => ({ x: p.x + T, y: p.y + T, z: p.z }));
+    const poly = square(S).map((v) => ({ x: v.x + T, y: v.y + T }));
+    const b = stockpileAreaGrid({ points: shifted, polygon: poly, base: flatBase, cellSizeM: 0.5 });
+    expect(b.fillM3).toBeCloseTo(a.fillM3, 6);
+  });
+
+  it('agrees across metre and foot representations after unit conversion', () => {
+    const metres = stockpileAreaGrid({ points: base(), polygon: square(S), base: flatBase, cellSizeM: 0.5 });
+    // Same geometry expressed in feet: coordinates ÷ 0.3048, unit factor 0.3048.
+    const FT = 1 / 0.3048;
+    const ptsFt = base().map((p) => ({ x: p.x * FT, y: p.y * FT, z: p.z * FT }));
+    const polyFt = square(S).map((v) => ({ x: v.x * FT, y: v.y * FT }));
+    const feet = stockpileAreaGrid({
+      points: ptsFt,
+      polygon: polyFt,
+      base: { kind: 'constant', zM: 0 },
+      cellSizeM: 0.5 * FT,
+      linearUnitToMetres: 0.3048,
+    });
+    expect(feet.fillM3).toBeCloseTo(metres.fillM3, 0);
+  });
+});
+
+describe('stockpileAreaGrid — base surface modes', () => {
+  it('a tilted plane base cancels a matching tilted surface to ~zero volume', () => {
+    const S = 10;
+    // Surface z = 2 + 0.5x; base plane identical → no volume above base.
+    const r = stockpileAreaGrid({
+      points: sample(S, 60, (x) => 2 + 0.5 * x),
+      polygon: square(S),
+      base: { kind: 'plane', a: 0.5, b: 0, c: 2 },
+      cellSizeM: 0.5,
+    });
+    expect(Math.abs(r.netM3)).toBeLessThan(1); // ~0 within cell-centre quadrature
+  });
+});
+
+describe('clippedCellArea — Sutherland–Hodgman against analytic areas', () => {
+  const S = 10;
+  it('a cell fully inside the footprint clips to the full cell area', () => {
+    expect(clippedCellArea(square(S), 2, 2, 3, 3)).toBeCloseTo(1, 9);
+  });
+  it('a cell fully outside clips to zero', () => {
+    expect(clippedCellArea(square(S), 12, 12, 13, 13)).toBeCloseTo(0, 9);
+  });
+  it('a boundary cell clips to the overlap area', () => {
+    // Cell [9,11]×[4,6] overlaps the footprint only on x∈[9,10] → area 1×2 = 2.
+    expect(clippedCellArea(square(S), 9, 4, 11, 6)).toBeCloseTo(2, 9);
+  });
+  it('clips a rotated (diamond) footprint correctly', () => {
+    const diamond: Vec2[] = [
+      { x: 5, y: 0 }, { x: 10, y: 5 }, { x: 5, y: 10 }, { x: 0, y: 5 },
+    ]; // area = 50
+    // A central cell fully inside the diamond → full area.
+    expect(clippedCellArea(diamond, 4, 4, 6, 6)).toBeCloseTo(4, 9);
+    // A corner cell entirely outside the diamond → 0.
+    expect(clippedCellArea(diamond, 0, 0, 1, 1)).toBeCloseTo(0, 9);
+  });
+  it('handles a concave (L-shaped) footprint', () => {
+    const L: Vec2[] = [
+      { x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 4 },
+      { x: 4, y: 4 }, { x: 4, y: 10 }, { x: 0, y: 10 },
+    ];
+    // A cell in the notch (the removed top-right) clips to zero.
+    expect(clippedCellArea(L, 6, 6, 7, 7)).toBeCloseTo(0, 9);
+    // A cell in the solid lower band clips to full.
+    expect(clippedCellArea(L, 6, 1, 7, 2)).toBeCloseTo(1, 9);
+  });
+});
+
+describe('deriveCellSize', () => {
+  it('scales with point spacing and clamps to bounds', () => {
+    // 400 points over 100 m² → spacing 0.5 m → ×2.5 = 1.25 m.
+    expect(deriveCellSize(100, 400)).toBeCloseTo(1.25, 6);
+    // Clamps: a tiny cloud does not produce an unbounded cell.
+    expect(deriveCellSize(1e9, 1, 0.05, 50)).toBe(50);
+    expect(deriveCellSize(0, 0)).toBe(50); // degenerate → max
+  });
+});


### PR DESCRIPTION
§7 of the "07" hardening audit. The legacy stockpile estimator (`volumeCutFill` / `olv.volume.stockpile`) integrates V = A·mean(point thickness) — point-count-weighted, so a density gradient in the cloud biases the result (the repo's own `volumeSyntheticTruth` tests already measure −30% on a gradient, +33% on a missing quadrant).

New method `olv.volume.stockpile-area-grid`: **V = Σ_c A_c·max(0, z_surf,c − z_base,c)** over a regular horizontal grid.
- Each cell contributes its **polygon-clipped area** (Sutherland–Hodgman) × a **robust median** surface height above the base, so every cell counts once regardless of point density.
- Cell size derived from point spacing (deterministic, unit-aware, never from viewport), clamped, with a cell budget.
- **Coverage honesty**: unobserved cells reduce reported coverage (`measured`/`preview`/`refused`) rather than reading as zero.
- Base modes: constant elevation and fitted plane. Uncertainty is an **explicit incomplete** model (surface-spread term only), not a validated interval.

**Staged** (registered in `unreachable-modules.json`): a pure, analytically-verified library. The live volume tool still calls the legacy estimator; UI wiring is a deliberate follow-up (the legacy method is preserved per §7.1). Method id, `METHOD_REGISTRY.md` row, and layer boundaries all in order.

Tests (17): rectangular prism (V=A·h), planar ramp (A·h/2), square pyramid (A·h/3), cone ((1/3)πR²h) within raster tolerance; **density-gradient invariance** (the property the method exists for); missing-quadrant coverage downgrade + severe-gap refusal; point-order / large-translation / metre-vs-foot invariance; tilted-plane base cancellation; and Sutherland–Hodgman clip (inside/outside/boundary/rotated/concave) vs analytic areas. Full suite 13,834 pass / 0 fail; tsc, method-parity, unreachable-modules, module-graph, layer-boundaries green.