### PR TITLE
feat(features): export accepted building footprints as GeoJSON (gem C)

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -20,13 +20,6 @@
   "reviewDates": "Reported by the lint when they pass, never enforced. A gate that turns red on a date with no change to the tree teaches people to edit the date rather than the code.",
   "modules": [
     {
-      "path": "src/features/footprintGeoJson.ts",
-      "status": "staged",
-      "why": "Writes extracted footprints as RFC 7946 GeoJSON. The candidate-review surface (v0.6.8) reviews footprints but offers no GeoJSON export, so no export route imports this writer.",
-      "graduation": "The export layer offers a footprint product and routes it through this writer.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/terrain/contour/persistentCoreKey.ts",
       "status": "staged",
       "why": "The identity and invalidation contract for a persistent (across-reopen) terrain core cache: a full SHA-256 content fingerprint, the core-method generation string, and an integrity digest. It is the library half of the recompute-vs-reuse gate in tests/benchmark/terrainCoreRebuildCost.test.ts, which returned GO (conditional). No storage or reopen path is built, so nothing in the application computes a persistent key; only its own test imports it.",

--- a/src/ui/featureCandidatesMount.ts
+++ b/src/ui/featureCandidatesMount.ts
@@ -37,6 +37,9 @@ import {
   type ConductorCandidate,
 } from '../features/FeatureExtractionService';
 import { CandidateReviewStore, type CandidateStatus } from '../features/candidateReview';
+import { footprintsToGeoJson } from '../features/footprintGeoJson';
+import { methodRef, methodTag } from '../science/methodRegistry';
+import { triggerDownload } from '../io/download';
 import { el } from './dom';
 
 export interface MountFeatureCandidatesOptions {
@@ -70,6 +73,10 @@ export function mountFeatureCandidates(
 ): MountedFeatureCandidates {
   const { cloud, launcherHost, reviewHost, onLaunch } = opts;
   const review = new CandidateReviewStore();
+  // A CRS label for the GeoJSON provenance, or null when the scan is not
+  // georeferenced. Prefer the EPSG code, else the CRS's own best-effort name.
+  const crs = cloud.metadata?.crs;
+  const crsLabel = crs ? (crs.epsg != null ? `EPSG:${crs.epsg}` : crs.name) : null;
   let built = false;
 
   const card = el('div', { className: 'olv-feature-launcher' });
@@ -119,7 +126,7 @@ export function mountFeatureCandidates(
   button.addEventListener('click', () => {
     if (!built) {
       built = true;
-      reviewHost.replaceChildren(buildReview(input, review));
+      reviewHost.replaceChildren(buildReview(input, review, crsLabel));
     }
     onLaunch();
   });
@@ -136,7 +143,11 @@ export function mountFeatureCandidates(
 }
 
 /** Build the review list element from the extraction input. */
-function buildReview(input: FeatureExtractionInput, review: CandidateReviewStore): HTMLElement {
+function buildReview(
+  input: FeatureExtractionInput,
+  review: CandidateReviewStore,
+  crsLabel: string | null,
+): HTMLElement {
   const root = el('div', { className: 'olv-feature-review' });
 
   if (input.classificationIsDerived) {
@@ -156,7 +167,7 @@ function buildReview(input: FeatureExtractionInput, review: CandidateReviewStore
   const conductor = extractConductorCandidate(input.conductorPoints, input.unit, input.up);
   const conductors = conductor ? [conductor] : [];
 
-  root.append(renderBuildingSection(buildings, review));
+  root.append(renderBuildingSection(buildings, review, crsLabel));
   root.append(renderConductorSection(conductors, input.conductorPoints.length, review));
   return root;
 }
@@ -200,6 +211,7 @@ function statusChips(
 function renderBuildingSection(
   buildings: readonly BuildingCandidate[],
   review: CandidateReviewStore,
+  crsLabel: string | null,
 ): HTMLElement {
   const section = el('div', { className: 'olv-feature-section' });
   section.append(
@@ -227,7 +239,68 @@ function renderBuildingSection(
     row.append(statusChips(b.id, review, row));
     section.append(row);
   }
+  section.append(buildFootprintExport(buildings, review, crsLabel));
   return section;
+}
+
+/**
+ * The GeoJSON FeatureCollection for the ACCEPTED building footprints, or null
+ * when none are accepted. Pure: maps each accepted candidate to the exporter's
+ * input and stamps the CRS + the registered method tag. The exporter itself
+ * hard-codes the derived-candidate labelling, so this can never emit an
+ * unreviewed candidate (the accepted-filter) nor a certified outline.
+ */
+export function acceptedFootprintGeoJson(
+  buildings: readonly BuildingCandidate[],
+  review: CandidateReviewStore,
+  crsLabel: string | null,
+): ReturnType<typeof footprintsToGeoJson> | null {
+  const accepted = review.accepted(buildings);
+  if (accepted.length === 0) return null;
+  return footprintsToGeoJson(
+    accepted.map((b) => ({
+      ring: b.ring,
+      areaSource: b.areaSource,
+      areaM2: b.areaM2,
+      centroidX: b.centroid[0],
+      centroidY: b.centroid[1],
+      id: b.id,
+    })),
+    { crs: crsLabel, method: methodTag(methodRef('olv.feature.building-footprint')) },
+  );
+}
+
+/**
+ * The "Export accepted (GeoJSON)" control. The accepted set is recomputed at
+ * click time from the live review store, so it never ships an unreviewed or
+ * since-rejected candidate. A status line reports what happened rather than
+ * downloading an empty file.
+ */
+function buildFootprintExport(
+  buildings: readonly BuildingCandidate[],
+  review: CandidateReviewStore,
+  crsLabel: string | null,
+): HTMLElement {
+  const wrap = el('div', { className: 'olv-feature-export' });
+  const status = el('div', { className: 'olv-feature-export-status', text: '' });
+  const button = el('button', {
+    className: 'olv-feature-export-action',
+    text: 'Export accepted (GeoJSON)',
+  });
+  button.type = 'button';
+  button.title = 'Download the ACCEPTED building-footprint candidates as RFC 7946 GeoJSON. Derived candidates, not surveyed outlines.';
+  button.addEventListener('click', () => {
+    const geojson = acceptedFootprintGeoJson(buildings, review, crsLabel);
+    if (!geojson) {
+      status.textContent = 'No accepted footprints to export — accept at least one candidate first.';
+      return;
+    }
+    const blob = new Blob([JSON.stringify(geojson, null, 2)], { type: 'application/geo+json' });
+    triggerDownload(blob, 'building-footprint-candidates.geojson');
+    status.textContent = `Exported ${geojson.features.length} accepted footprint candidate(s).`;
+  });
+  wrap.append(button, status);
+  return wrap;
 }
 
 function renderConductorSection(

--- a/tests/featureFootprintExport.test.ts
+++ b/tests/featureFootprintExport.test.ts
@@ -1,0 +1,72 @@
+/**
+ * featureFootprintExport.test.ts — the "Export accepted (GeoJSON)" wiring.
+ *
+ * Pins that the export helper ships ONLY reviewer-accepted footprints, records
+ * the CRS + registered method, and returns null when nothing is accepted — the
+ * anti-goal being an unreviewed or rejected candidate leaving as a deliverable.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { acceptedFootprintGeoJson } from '../src/ui/featureCandidatesMount';
+import { CandidateReviewStore } from '../src/features/candidateReview';
+import type { BuildingCandidate } from '../src/features/FeatureExtractionService';
+
+function building(id: string): BuildingCandidate {
+  return {
+    kind: 'building',
+    id,
+    confidence: 'derived',
+    areaSource: 42,
+    areaM2: 42,
+    cellCount: 10,
+    ring: [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 1 },
+      { x: 0, y: 1 },
+    ],
+    centroid: [0.5, 0.5],
+    bounds: [0, 0, 1, 1],
+  };
+}
+
+describe('acceptedFootprintGeoJson', () => {
+  it('exports only accepted candidates, never unreviewed or rejected', () => {
+    const buildings = [building('a'), building('b'), building('c')];
+    const review = new CandidateReviewStore();
+    review.accept('a');
+    review.reject('b');
+    // 'c' left unreviewed.
+    const gj = acceptedFootprintGeoJson(buildings, review, 'EPSG:32612');
+    expect(gj).not.toBeNull();
+    expect(gj!.features).toHaveLength(1);
+    // The one feature is the accepted one (feature-level id per RFC 7946).
+    expect(gj!.features[0].id).toBe('a');
+  });
+
+  it('returns null when nothing is accepted (no empty file)', () => {
+    const buildings = [building('a'), building('b')];
+    const review = new CandidateReviewStore();
+    review.reject('a'); // reject one, leave one unreviewed
+    expect(acceptedFootprintGeoJson(buildings, review, 'EPSG:32612')).toBeNull();
+  });
+
+  it('records the CRS and stamps the registered method; labels features derived', () => {
+    const review = new CandidateReviewStore();
+    review.accept('a');
+    const gj = acceptedFootprintGeoJson([building('a')], review, 'EPSG:3301')!;
+    expect(gj.metadata.crs).toBe('EPSG:3301');
+    // The method tag is the registered building-footprint method.
+    expect(JSON.stringify(gj)).toContain('olv.feature.building-footprint@1');
+    // The exporter's own honest labelling travels (derived candidate).
+    const props = gj.features[0].properties as Record<string, unknown>;
+    expect(props.source).toBe('derived');
+  });
+
+  it('carries a null CRS through for a non-georeferenced scan', () => {
+    const review = new CandidateReviewStore();
+    review.accept('a');
+    const gj = acceptedFootprintGeoJson([building('a')], review, null)!;
+    expect(gj.metadata.crs).toBeNull();
+  });
+});


### PR DESCRIPTION
Gem C from the "09" product-unlock validation — the cleanest Wave-1 win. The candidate-review surface reviewed footprints but shipped no deliverable, while the honest RFC 7946 exporter `footprintsToGeoJson` and the `CandidateReviewStore.accepted()` filter already existed and were tested with **zero production callers**.

- Adds an "Export accepted (GeoJSON)" button to the review surface (`featureCandidatesMount.ts`).
- The accepted set is recomputed **at click time** from the live review store, so an unreviewed or since-rejected candidate can never be shipped.
- The download stamps the source CRS and the registered method tag `olv.feature.building-footprint@1`; the exporter's own `source: 'derived'` / `building-footprint-candidate` labelling travels, so nothing claims a surveyed outline. Empty-accepted downloads nothing and says why.
- Export logic extracted to a pure `acceptedFootprintGeoJson` helper with a negative-control test (only-accepted / null-when-none / CRS + method stamp / derived labelling). `footprintGeoJson` graduates out of the unreachable-modules register.

Anti-goals honoured: derived labelling is baked into the exporter, and the accepted-filter prevents exporting unreviewed candidates. Full suite 13,825 pass / 0 fail; tsc, module-graph, layer-boundaries, unreachable-modules green.