### PR TITLE
feat(ui): durable findings ledger panel (gem E core)

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,604 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,545 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -99,7 +99,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,604)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,545)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
@@ -8,7 +8,7 @@ Five products reach E4 this cycle: `CRS-UTM-PROJECTION` (new), `CHANGE-RASTER` a
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,604 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root shrank as the scattered keyboard-shortcut listeners moved into one declarative table in `src/ui/keyBindings.ts`; the renderer is unchanged. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,545 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root shrank as the image-export callback moved into `src/app/exportImageAction.ts`; the renderer is unchanged. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
 
 ## Out-of-core streaming holds the index, not the whole cloud
 

--- a/docs/validation/module-graph-baseline.json
+++ b/docs/validation/module-graph-baseline.json
@@ -52,7 +52,7 @@
   },
   "fanOut": {
     "src/main.ts": {
-      "runtime": 115,
+      "runtime": 116,
       "typeOnly": 19,
       "dynamic": 7,
       "modules": [
@@ -73,6 +73,7 @@
         "src/app/crsCoordinator.ts",
         "src/app/epochFramePrep.ts",
         "src/app/exportCrsResolver.ts",
+        "src/app/exportImageAction.ts",
         "src/app/floorPlanPositions.ts",
         "src/app/inspectorCardRefreshers.ts",
         "src/app/kmlActions.ts",
@@ -161,10 +162,10 @@
         "src/ui/embedConfig.ts",
         "src/ui/headerControls.ts",
         "src/ui/isMobileDevice.ts",
+        "src/ui/keyBindings.ts",
         "src/ui/navBarWiring.ts",
         "src/ui/onboarding/bootTour.ts",
         "src/ui/panelChrome.ts",
-        "src/ui/shortcuts.ts",
         "src/ui/streamingScanReveal.ts",
         "src/ui/themes.ts",
         "src/ui/toolDock.ts",
@@ -263,7 +264,7 @@
     "components": []
   },
   "context": {
-    "filesScanned": 770,
+    "filesScanned": 777,
     "inlineTypeOnlyImports": 3,
     "note": "inlineTypeOnlyImports counts declarations whose named bindings are all inline `type` specifiers. Under verbatimModuleSyntax the declaration survives as `import {} from \"x\"`, a module load with no binding, so it is counted as a runtime edge above."
   }

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5604,
+      "lines": 5545,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -160,6 +160,13 @@
       "review": "2027-02-28"
     },
     {
+      "path": "src/ui/findingsPanel.ts",
+      "status": "staged",
+      "why": "The durable findings-ledger review surface: renders a SessionFindings (label/value/±band/confidence/caveats), adds the live measurement findings, removes rows, and exports the ledger as the existing SHA-256 integrity report. Complete and unit-tested, but not yet mounted: the mount must be wired in the composition root (main.ts) — instantiating the shared store and passing the measurements-to-findings + export-with-context callbacks that only main.ts holds — and main.ts is at its shrink-only monolith-size baseline (one line of headroom), so the wiring cannot land without first freeing room via a main.ts decomposition.",
+      "graduation": "A main.ts decomposition opens a wiring seam (e.g. an export-callbacks builder in measurementExportActions), through which ExportPanel mounts buildFindingsPanel with a shared SessionFindings and the ledger export.",
+      "review": "2027-02-28"
+    },
+    {
       "path": "src/render/measure/sessionFindings.ts",
       "status": "staged",
       "why": "The session ledger of measurements with their uncertainty bands, written to be handed to buildReportManifest. The measurement flow shows results in toasts and collects them nowhere.",

--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -160,20 +160,6 @@
       "review": "2027-02-28"
     },
     {
-      "path": "src/ui/findingsPanel.ts",
-      "status": "staged",
-      "why": "The durable findings-ledger review surface: renders a SessionFindings (label/value/±band/confidence/caveats), adds the live measurement findings, removes rows, and exports the ledger as the existing SHA-256 integrity report. Complete and unit-tested, but not yet mounted: the mount must be wired in the composition root (main.ts) — instantiating the shared store and passing the measurements-to-findings + export-with-context callbacks that only main.ts holds — and main.ts is at its shrink-only monolith-size baseline (one line of headroom), so the wiring cannot land without first freeing room via a main.ts decomposition.",
-      "graduation": "A main.ts decomposition opens a wiring seam (e.g. an export-callbacks builder in measurementExportActions), through which ExportPanel mounts buildFindingsPanel with a shared SessionFindings and the ledger export.",
-      "review": "2027-02-28"
-    },
-    {
-      "path": "src/render/measure/sessionFindings.ts",
-      "status": "staged",
-      "why": "The session ledger of measurements with their uncertainty bands, written to be handed to buildReportManifest. The measurement flow shows results in toasts and collects them nowhere.",
-      "graduation": "The measurement flow appends findings here and the report export reads them.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/render/measure/profileCorridorOutline.ts",
       "status": "staged",
       "why": "Drawable geometry for the capsule corridor profileCorridor.ts tests membership against. The scene draws no corridor outline.",

--- a/src/app/exportImageAction.ts
+++ b/src/app/exportImageAction.ts
@@ -1,0 +1,103 @@
+/**
+ * exportImageAction.ts — the ExportPanel "export image" callback, lifted out of
+ * the composition root.
+ *
+ * The Visual Export Studio ships in its own lazy chunk (`viewer.exportImage`
+ * pulls it in on first use); the download triggers off the returned Blob. A
+ * georeferenced ortho export returns world-file data and ships as a PNG + .pgw +
+ * .prj ZIP that QGIS/ArcGIS place directly; every other export ships the bare
+ * PNG. Packaging failures fall back to the bare PNG rather than sinking an
+ * export that already rendered.
+ *
+ * The viewer and the drop zone are read through getters: both are assigned later
+ * in main's boot than the ExportPanel is constructed, so the callback closes over
+ * the getters, not the values.
+ */
+
+import type { ExportMode } from '../export/types';
+import type { Viewer } from '../render/Viewer';
+import { increment as recordUsage } from '../diagnostics/usageCounters';
+import { loadPngWorldFile } from '../lazyChunks';
+import { triggerDownload } from '../io/download';
+
+/** The progress surface the action drives (a `DropZone`, structurally). */
+export interface ExportImageProgress {
+  setProgress(text: string | null, fraction?: number): void;
+  setError(text: string): void;
+}
+
+export interface ExportImageActionDeps {
+  /** The live viewer, or null before the first scan loads. */
+  readonly getViewer: () => Viewer | null;
+  /** The progress surface (assigned later in boot than the panel). */
+  readonly getProgress: () => ExportImageProgress;
+  readonly scans: { readonly activeId: string | null };
+  readonly baseName: (name: string) => string;
+  readonly currentClassScopeStamp: () => string;
+}
+
+const MODE_LABEL: Record<string, string> = {
+  'orthographic-rgb': 'orthographic RGB',
+  'height-map': 'height map',
+  intensity: 'intensity map',
+  classification: 'classification map',
+  depth: 'depth map',
+  normal: 'normal map',
+  contour: 'contour map',
+};
+
+/** Render and download an image export for `mode`. */
+export function exportImageAction(mode: ExportMode, deps: ExportImageActionDeps): void {
+  const viewer = deps.getViewer();
+  if (!viewer) return;
+  const progress = deps.getProgress();
+  const sourceName = deps.scans.activeId ? viewer.getCloud(deps.scans.activeId)?.name : viewer.streamingCloud?.name;
+  const base = sourceName ? deps.baseName(sourceName) : 'openlidarviewer';
+  const label = MODE_LABEL[mode] ?? mode;
+  progress.setProgress(`Exporting ${label}…`);
+  viewer
+    // Thread the active class-scope stamp so a filtered export carries the
+    // "showing N of M classes" banner; empty when nothing is hidden.
+    .exportImage(mode, {}, deps.currentClassScopeStamp())
+    .then(async (result) => {
+      // Georeferenced ortho path: when the exporter returned world-file data
+      // (true top-down ortho frame + known world origin + CRS WKT), the download
+      // is one ZIP — PNG + `.pgw` + `.prj` — that QGIS/ArcGIS place directly.
+      // Packaging failures fall back to the bare PNG.
+      if (result.worldFile) {
+        try {
+          const { buildStudioPngPackage } = await loadPngWorldFile();
+          const wf = result.worldFile;
+          const pkg = buildStudioPngPackage({
+            basename: `${base}-${mode}`,
+            png: new Uint8Array(await result.blob.arrayBuffer()),
+            extent: wf.extent,
+            widthPx: wf.widthPx,
+            heightPx: wf.heightPx,
+            worldOrigin: wf.worldOrigin,
+            wkt: wf.wkt,
+          });
+          if (pkg) {
+            triggerDownload(new Blob([pkg.zip as BlobPart], { type: 'application/zip' }), pkg.filename);
+            recordUsage('export', mode);
+            progress.setProgress(null);
+            return;
+          }
+        } catch (err) {
+          console.warn('[image-export] world-file packaging failed — shipping bare PNG:', err);
+        }
+      }
+      triggerDownload(result.blob, `${base}-${mode}.png`);
+      recordUsage('export', mode);
+      progress.setProgress(null);
+    })
+    .catch((err: unknown) => {
+      recordUsage('error', 'export');
+      progress.setProgress(null);
+      // Surface the orchestrator's explicit reason through the shared toast UI
+      // rather than a modal alert.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error('[image-export]', err);
+      progress.setError(`Image export failed: ${msg}`);
+    });
+}

--- a/src/app/measurementExportActions.ts
+++ b/src/app/measurementExportActions.ts
@@ -12,6 +12,7 @@
 
 import type { Measurement, Vec3 } from '../render/measure/types';
 import type { MeasurementExportContext } from '../export/measurementExport';
+import type { ReportFinding } from '../render/measure/reportManifest';
 import type { GeoExportContext } from './reportExport';
 
 /** The slice of the measure controller these exports read. */
@@ -34,7 +35,10 @@ export interface MeasurementExportActionDeps {
     Pick<typeof import('../export/measurementExport'), 'measurementsToGeoJSON' | 'measurementsToCsv'>
   >;
   readonly loadMeasurementReport: () => Promise<
-    Pick<typeof import('../export/measurementReport'), 'integrityReportFile'>
+    Pick<
+      typeof import('../export/measurementReport'),
+      'integrityReportFile' | 'measurementsToFindings' | 'findingsReportFile'
+    >
   >;
   /** Active scan's classification epoch (0 when none), for the report manifest. */
   readonly activeClassificationEpoch: () => number;
@@ -96,6 +100,42 @@ export async function exportMeasurementIntegrityReport(
     deps.appVersion,
     // Local / unknown-unit scan → the findings' metre labels are nominal (M1).
     measure.crsKnown,
+  );
+  deps.downloadText(f.filename, f.text);
+}
+
+/**
+ * Convert the placed measurements into report findings for the findings ledger.
+ * The panel's "Add current measurements" button drives this; the conversion
+ * lives in the lazy report chunk, so the call is async. Returns an empty array
+ * when nothing is placed.
+ */
+export async function collectMeasurementFindings(
+  deps: MeasurementExportActionDeps,
+): Promise<readonly ReportFinding[]> {
+  const { measure } = deps;
+  const ms = measure.getMeasurements();
+  if (ms.length === 0) return [];
+  const { measurementsToFindings } = await deps.loadMeasurementReport();
+  return measurementsToFindings(ms, measure.worldUp, measure.unitToMetres, measure.verticalUnitToMetres);
+}
+
+/** Export the curated findings ledger as the signed integrity report (JSON). */
+export async function exportFindingsReport(
+  deps: MeasurementExportActionDeps,
+  findings: readonly ReportFinding[],
+): Promise<void> {
+  if (findings.length === 0) return;
+  const geo = deps.geo();
+  const { findingsReportFile } = await deps.loadMeasurementReport();
+  const f = findingsReportFile(
+    findings,
+    geo.name ? deps.baseName(geo.name) : 'scan',
+    geo.crsName,
+    deps.now(),
+    deps.activeClassificationEpoch(),
+    deps.appVersion,
+    deps.measure.crsKnown,
   );
   deps.downloadText(f.filename, f.text);
 }

--- a/src/export/measurementReport.ts
+++ b/src/export/measurementReport.ts
@@ -197,6 +197,43 @@ export function integrityReportFile(
   };
 }
 
+/**
+ * Ledger variant of {@link integrityReportFile}: sign a report built from an
+ * already-assembled {@link ReportFinding} ledger (the findings panel's curated
+ * list) rather than re-deriving findings from live measurements. Same gate, same
+ * manifest builder, same digest — only the finding source differs. The reviewer
+ * has chosen and pruned these findings, so their bands and caveats travel as-is.
+ */
+export function findingsReportFile(
+  findings: readonly ReportFinding[],
+  datasetId: string,
+  crsName: string | undefined,
+  generatedAt: string,
+  classificationEpoch: number,
+  software?: string,
+  unitsVerified: boolean = true,
+  claimId: string = INTEGRITY_REPORT_CLAIM,
+): IntegrityReportFile {
+  const gate = exportGate(claimId);
+  if (!gate.allowed && !gate.exploratoryOnly) {
+    throw new Error(`Findings report refused: ${gate.reason}`);
+  }
+  const manifest = buildReportManifest({
+    dataset: { id: datasetId, crs: crsName },
+    generatedAt,
+    software,
+    classificationEpoch,
+    findings: [...findings],
+  });
+  return {
+    filename: `${datasetId}-findings.json`,
+    text: JSON.stringify(manifest, null, 2),
+    evidence: evidenceNote(claimId) + unverifiedUnitsCaveat(unitsVerified),
+    evidenceStatus: evidenceStatus(claimId),
+    exploratory: gate.exploratoryOnly,
+  };
+}
+
 /** Build (and sign) a report manifest from the placed measurements. */
 export function measurementsToReportManifest(
   measurements: readonly Measurement[],

--- a/src/lazyChunks.ts
+++ b/src/lazyChunks.ts
@@ -525,6 +525,10 @@ export const loadRangeWorkbenchMount = () => import('./ui/rangeWorkbenchMount');
 /** The feature-candidate review surface (building footprints, conductor fits). */
 export const loadFeatureCandidatesMount = () => import('./ui/featureCandidatesMount');
 
+/** The findings-ledger panel + its session store, kept out of the index bundle. */
+export const loadFindingsPanel = () => import('./ui/findingsPanel');
+export const loadSessionFindings = () => import('./render/measure/sessionFindings');
+
 /**
  * The 3D Tiles open — the tileset parser, the traversal, the hardened tileset
  * transport and the PNTS decoder, as one chunk behind the remote-URL router.

--- a/src/main.ts
+++ b/src/main.ts
@@ -138,8 +138,11 @@ import { isSkyPreset } from './render/skyPresets';
 import {
   exportMeasurementsFile,
   exportMeasurementIntegrityReport,
+  collectMeasurementFindings,
+  exportFindingsReport,
   type MeasurementExportActionDeps,
 } from './app/measurementExportActions';
+import { exportImageAction } from './app/exportImageAction';
 import { ClipPanel } from './ui/ClipPanel';
 import type { ClipBox } from './render/clip/clipBox';
 // Two-epoch change detection is loaded on demand (it pulls the terrain
@@ -226,7 +229,6 @@ import {
   loadBatchConverter,
   loadSpaceReportPdf,
   loadFloorPlan,
-  loadPngWorldFile,
   loadPlanetaryComputerCatalog,
   loadRgbAutoNormalize,
   loadEmbedBridge,
@@ -2762,83 +2764,14 @@ const exportPanel = new ExportPanel({
       downloadText(`${baseName(cloud.name)}.${format}`, exportCloud(cloud, format, crsService.context().isGeographic));
     });
   },
-  onExportImage: (mode) => {
-    // The Visual Export Studio ships in its own lazy chunk (`loadExportStudio`),
-    // pulled in by viewer.exportImage on the first invocation. The download
-    // triggers off the returned Blob; an unsupported-on-this-cloud rejection
-    // surfaces as a visible alert.
-    const sourceName = scans.activeId
-      ? viewer.getCloud(scans.activeId)?.name
-      : viewer.streamingCloud?.name;
-    const base = sourceName ? baseName(sourceName) : 'openlidarviewer';
-    // surface a precise per-mode progress string while the lazy
-    // Studio chunk loads and the export renders.
-    const modeLabel: Record<string, string> = {
-      'orthographic-rgb': 'orthographic RGB',
-      'height-map': 'height map',
-      intensity: 'intensity map',
-      classification: 'classification map',
-      depth: 'depth map',
-      normal: 'normal map',
-      contour: 'contour map',
-    };
-    const label = modeLabel[mode] ?? mode;
-    dropZone.setProgress(`Exporting ${label}…`);
-    viewer
-      // Thread the active class-scope stamp so a filtered export carries the
-      // "showing N of M classes" banner; empty when nothing is hidden.
-      .exportImage(mode, {}, currentClassScopeStamp())
-      .then(async (result) => {
-        // Georeferenced ortho path (v0.4.5, workplan C4): when the exporter
-        // returned world-file data (true top-down ortho frame + known world
-        // origin + CRS WKT), the download is one ZIP — PNG + `.pgw` + `.prj`
-        // — that QGIS/ArcGIS place directly. Every other export keeps the
-        // existing bare-PNG download and filename. Packaging failures fall
-        // back to the bare PNG rather than sinking an export that already
-        // rendered fine.
-        if (result.worldFile) {
-          try {
-            const { buildStudioPngPackage } = await loadPngWorldFile();
-            const wf = result.worldFile;
-            const pkg = buildStudioPngPackage({
-              basename: `${base}-${mode}`,
-              png: new Uint8Array(await result.blob.arrayBuffer()),
-              extent: wf.extent,
-              widthPx: wf.widthPx,
-              heightPx: wf.heightPx,
-              worldOrigin: wf.worldOrigin,
-              wkt: wf.wkt,
-            });
-            if (pkg) {
-              triggerDownload(new Blob([pkg.zip as BlobPart], { type: 'application/zip' }), pkg.filename);
-              recordUsage('export', mode);
-              dropZone.setProgress(null);
-              return;
-            }
-          } catch (err) {
-            console.warn('[image-export] world-file packaging failed — shipping bare PNG:', err);
-          }
-        }
-        triggerDownload(result.blob, `${base}-${mode}.png`);
-        recordUsage('export', mode);
-        dropZone.setProgress(null);
-      })
-      .catch((err: unknown) => {
-        recordUsage('error', 'export');
-        dropZone.setProgress(null);
-        // The orchestrator's explicit reason ("Classification export is
-        // unavailable — this cloud has no classification channel.") is the
-        // most actionable thing we can show, so it goes both to the console
-        // (for debugging) and to a non-blocking alert (so the user knows
-        // something happened and why). Replaces the alert with a
-        // Surface the failure through the shared toast UI rather than a
-        // modal alert — blocking the page on a generation failure is a UX
-        // regression we no longer accept.
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error('[image-export]', err);
-        dropZone.setError(`Image export failed: ${msg}`);
-      });
-  },
+  onExportImage: (mode) =>
+    exportImageAction(mode, {
+      getViewer: () => viewer,
+      getProgress: () => dropZone,
+      scans,
+      baseName,
+      currentClassScopeStamp,
+    }),
   onExportReport: (templateId) => {
     // Generate a PDF report from the live scan state + annotations +
     // measurements. The whole `src/report/` module + pdf-lib (~150 KB)
@@ -2952,6 +2885,14 @@ const exportPanel = new ExportPanel({
   exportIntegrityReport: async () => {
     if (!viewer) return;
     await exportMeasurementIntegrityReport(measurementExportActionDeps(viewer));
+  },
+  collectMeasurementFindings: async () => {
+    if (!viewer) return [];
+    return collectMeasurementFindings(measurementExportActionDeps(viewer));
+  },
+  exportFindingsReport: async (findings) => {
+    if (!viewer) return;
+    await exportFindingsReport(measurementExportActionDeps(viewer), findings);
   },
   exportKml: () => void exportSiteKml(kmlDeps),
   kmlStatus: () => siteKmlStatus(kmlDeps),

--- a/src/render/measure/sessionFindings.ts
+++ b/src/render/measure/sessionFindings.ts
@@ -38,6 +38,11 @@ export class SessionFindings {
     return this._findings.pop();
   }
 
+  /** Drop the finding at `index` (a row the reviewer removed). No-op if out of range. */
+  remove(index: number): void {
+    if (index >= 0 && index < this._findings.length) this._findings.splice(index, 1);
+  }
+
   clear(): void {
     this._findings.length = 0;
   }

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -31,8 +31,8 @@ import type { ExportFormat } from '../io/exporters';
 import type { ExportMode } from '../export/types';
 import { buildExportDeliverables, type ExportDeliverables } from './export/exportDeliverables';
 import type { ReportFinding } from '../render/measure/reportManifest';
-import { SessionFindings } from '../render/measure/sessionFindings';
-import { buildFindingsPanel, type MountedFindingsPanel } from './findingsPanel';
+import type { SessionFindings } from '../render/measure/sessionFindings';
+import type { MountedFindingsPanel } from './findingsPanel';
 
 /**
  * Lightweight, allocation-free description of the exportable cloud, used to
@@ -192,9 +192,16 @@ export class ExportPanel {
   private readonly _summary: HTMLElement;
   private readonly _products: HTMLElement;
   private readonly _cb: ExportPanelCallbacks;
-  /** The session findings ledger, owned here and rendered by the findings panel. */
-  private readonly _findings = new SessionFindings();
+  /**
+   * The session findings ledger, owned here and rendered by the findings panel.
+   * Both the store and the panel live in a lazy chunk (kept out of the index
+   * bundle, which sits at its budget ceiling): the first Products render with the
+   * findings callbacks wired imports them and mounts into `_findingsSlot`, and
+   * the reference persists across re-renders.
+   */
+  private _findings: SessionFindings | null = null;
   private _findingsPanel: MountedFindingsPanel | null = null;
+  private _findingsMountStarted = false;
 
   // LAS 1.4 is the converter's lead format (see CONVERT_FORMATS ordering) —
   // default the panel to it so the pill selection matches the recommended choice.
@@ -595,16 +602,17 @@ export class ExportPanel {
       );
       // The durable findings ledger: curate the results worth keeping (each with
       // its band and caveats), then export the whole ledger as the same signed
-      // integrity report. Mounted only when the host wires both halves.
+      // integrity report. Mounted only when the host wires both halves, and lazily
+      // (the panel + store are a separate chunk). An already-mounted panel is
+      // re-attached to the fresh slot so its ledger survives a re-render.
       if (this._cb.collectMeasurementFindings && this._cb.exportFindingsReport) {
-        const collect = this._cb.collectMeasurementFindings;
-        const exportReport = this._cb.exportFindingsReport;
-        this._findingsPanel = buildFindingsPanel({
-          findings: this._findings,
-          collectMeasurements: () => collect(),
-          exportReport: (f) => exportReport(f),
-        });
-        content.append(this._productGroup('Findings ledger', this._findingsPanel.element));
+        const slot = el('div', { className: 'olv-findings-slot' });
+        content.append(this._productGroup('Findings ledger', slot));
+        if (this._findingsPanel) {
+          slot.append(this._findingsPanel.element);
+        } else {
+          this._mountFindingsLedger(slot);
+        }
       }
     }
 
@@ -663,6 +671,30 @@ export class ExportPanel {
   }
 
   /** One labelled product group: label, its stacked actions, one line of hint. */
+  /**
+   * Lazily import the findings store + panel (kept out of the index bundle) and
+   * mount them into `slot`. Guarded so the dynamic import fires once; if the
+   * Products lane re-renders before the chunk resolves, the panel lands in the
+   * latest slot via the re-attach path above. Callbacks are re-read from `_cb`
+   * at mount time, so this stays correct if the host rewires them.
+   */
+  private _mountFindingsLedger(slot: HTMLElement): void {
+    if (this._findingsMountStarted) return;
+    this._findingsMountStarted = true;
+    void Promise.all([
+      import('./findingsPanel'),
+      import('../render/measure/sessionFindings'),
+    ]).then(([{ buildFindingsPanel }, { SessionFindings }]) => {
+      this._findings = new SessionFindings();
+      this._findingsPanel = buildFindingsPanel({
+        findings: this._findings,
+        collectMeasurements: () => this._cb.collectMeasurementFindings?.() ?? Promise.resolve([]),
+        exportReport: (f) => this._cb.exportFindingsReport?.(f),
+      });
+      slot.append(this._findingsPanel.element);
+    });
+  }
+
   private _productGroup(label: string, actions: HTMLElement, hint?: string): HTMLElement {
     const group = el('div', { className: 'olv-export-product-group' });
     group.append(this._label(label), actions);

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -30,6 +30,9 @@ import type { ClipBox } from '../render/clip/clipBox';
 import type { ExportFormat } from '../io/exporters';
 import type { ExportMode } from '../export/types';
 import { buildExportDeliverables, type ExportDeliverables } from './export/exportDeliverables';
+import type { ReportFinding } from '../render/measure/reportManifest';
+import { SessionFindings } from '../render/measure/sessionFindings';
+import { buildFindingsPanel, type MountedFindingsPanel } from './findingsPanel';
 
 /**
  * Lightweight, allocation-free description of the exportable cloud, used to
@@ -116,6 +119,15 @@ export interface ExportPanelCallbacks {
    */
   exportIntegrityReport?: () => void;
   /**
+   * Convert the placed measurements into report findings for the findings
+   * ledger. Async because the converter lives in a lazy chunk. Wiring this AND
+   * {@link exportFindingsReport} mounts the durable findings ledger under the
+   * Measurements group.
+   */
+  collectMeasurementFindings?: () => Promise<readonly ReportFinding[]>;
+  /** Export the curated findings ledger as the signed integrity report (JSON). */
+  exportFindingsReport?: (findings: readonly ReportFinding[]) => void;
+  /**
    * Export a site KML (annotations + measurements + viewpoints) for Google
    * Earth / QGIS. Wired only when the host can supply a lat/lon transform.
    */
@@ -180,6 +192,9 @@ export class ExportPanel {
   private readonly _summary: HTMLElement;
   private readonly _products: HTMLElement;
   private readonly _cb: ExportPanelCallbacks;
+  /** The session findings ledger, owned here and rendered by the findings panel. */
+  private readonly _findings = new SessionFindings();
+  private _findingsPanel: MountedFindingsPanel | null = null;
 
   // LAS 1.4 is the converter's lead format (see CONVERT_FORMATS ordering) —
   // default the panel to it so the pill selection matches the recommended choice.
@@ -578,6 +593,19 @@ export class ExportPanel {
             : `${count} measurement${measurePlural} ready to export.`,
         ),
       );
+      // The durable findings ledger: curate the results worth keeping (each with
+      // its band and caveats), then export the whole ledger as the same signed
+      // integrity report. Mounted only when the host wires both halves.
+      if (this._cb.collectMeasurementFindings && this._cb.exportFindingsReport) {
+        const collect = this._cb.collectMeasurementFindings;
+        const exportReport = this._cb.exportFindingsReport;
+        this._findingsPanel = buildFindingsPanel({
+          findings: this._findings,
+          collectMeasurements: () => collect(),
+          exportReport: (f) => exportReport(f),
+        });
+        content.append(this._productGroup('Findings ledger', this._findingsPanel.element));
+      }
     }
 
     // The map lane: everything that lands in Google Earth / QGIS as lon/lat.
@@ -635,13 +663,12 @@ export class ExportPanel {
   }
 
   /** One labelled product group: label, its stacked actions, one line of hint. */
-  private _productGroup(label: string, actions: HTMLElement, hint: string): HTMLElement {
+  private _productGroup(label: string, actions: HTMLElement, hint?: string): HTMLElement {
     const group = el('div', { className: 'olv-export-product-group' });
-    group.append(
-      this._label(label),
-      actions,
-      el('span', { className: 'olv-export-fullres-hint', text: hint }),
-    );
+    group.append(this._label(label), actions);
+    if (hint) {
+      group.append(el('span', { className: 'olv-export-fullres-hint', text: hint }));
+    }
     return group;
   }
 

--- a/src/ui/ExportPanel.ts
+++ b/src/ui/ExportPanel.ts
@@ -13,7 +13,7 @@
 
 import { el } from './dom';
 import { downloadBytes } from '../io/download';
-import { loadConvertEngine } from '../lazyChunks';
+import { loadConvertEngine, loadFindingsPanel, loadSessionFindings } from '../lazyChunks';
 import { CONVERT_FORMATS, type ConvertFormat, type CrsMode, type ConvertOptions } from '../convert/types';
 import type { CrsInfo } from '../io/crs';
 import type { ResolvedCrs } from '../geo/CoordinateTypes';
@@ -681,18 +681,17 @@ export class ExportPanel {
   private _mountFindingsLedger(slot: HTMLElement): void {
     if (this._findingsMountStarted) return;
     this._findingsMountStarted = true;
-    void Promise.all([
-      import('./findingsPanel'),
-      import('../render/measure/sessionFindings'),
-    ]).then(([{ buildFindingsPanel }, { SessionFindings }]) => {
-      this._findings = new SessionFindings();
-      this._findingsPanel = buildFindingsPanel({
-        findings: this._findings,
-        collectMeasurements: () => this._cb.collectMeasurementFindings?.() ?? Promise.resolve([]),
-        exportReport: (f) => this._cb.exportFindingsReport?.(f),
-      });
-      slot.append(this._findingsPanel.element);
-    });
+    void Promise.all([loadFindingsPanel(), loadSessionFindings()]).then(
+      ([{ buildFindingsPanel }, { SessionFindings }]) => {
+        this._findings = new SessionFindings();
+        this._findingsPanel = buildFindingsPanel({
+          findings: this._findings,
+          collectMeasurements: () => this._cb.collectMeasurementFindings?.() ?? Promise.resolve([]),
+          exportReport: (f) => this._cb.exportFindingsReport?.(f),
+        });
+        slot.append(this._findingsPanel.element);
+      },
+    );
   }
 
   private _productGroup(label: string, actions: HTMLElement, hint?: string): HTMLElement {

--- a/src/ui/findingsPanel.ts
+++ b/src/ui/findingsPanel.ts
@@ -1,0 +1,135 @@
+/**
+ * findingsPanel.ts — the durable project findings ledger surface.
+ *
+ * Measurements and volume/change results are computed ad-hoc and shown in
+ * toasts; the integrity report already assembles the LIVE measurements at export
+ * time. This panel is the step between: a person collects the results worth
+ * keeping into a {@link SessionFindings} ledger — each a number WITH its band and
+ * caveats — reviews them, drops the ones they do not want, and exports the whole
+ * ledger as the existing SHA-256 integrity report. No second report engine: the
+ * host wires the export to `buildReportManifest`.
+ *
+ * Pure DOM (via {@link el}); the collection source and the export/download are
+ * injected so the panel is host-agnostic and unit-testable against a fake DOM.
+ * The ledger is session-scoped: it is not persisted across sessions here (a
+ * durable project store is separate, larger work).
+ */
+
+import type { ReportFinding } from '../render/measure/reportManifest';
+import type { SessionFindings } from '../render/measure/sessionFindings';
+import { el } from './dom';
+
+export interface FindingsPanelDeps {
+  /** The session ledger this panel renders and mutates. */
+  readonly findings: SessionFindings;
+  /**
+   * The findings to append when the reviewer clicks "Add current measurements"
+   * — the host converts the live measurements via `measurementsToFindings`.
+   * Returns an empty array when there is nothing to add.
+   */
+  readonly collectMeasurements: () => readonly ReportFinding[];
+  /**
+   * Export the ledger as the integrity report. The host builds the manifest
+   * (SHA-256) and triggers the download; the panel only decides WHEN and passes
+   * the current ledger snapshot.
+   */
+  readonly exportReport: (findings: readonly ReportFinding[]) => void;
+}
+
+export interface MountedFindingsPanel {
+  readonly element: HTMLElement;
+  /** Re-render from the current ledger (call after an external add). */
+  readonly refresh: () => void;
+}
+
+/** Format a finding's value + unit, with its ± band when present. */
+function formatValue(f: ReportFinding): string {
+  const v = Number.isFinite(f.value) ? f.value.toLocaleString(undefined, { maximumFractionDigits: 2 }) : '—';
+  const band = f.sigma != null && Number.isFinite(f.sigma) ? ` ± ${f.sigma.toLocaleString(undefined, { maximumFractionDigits: 2 })}` : '';
+  return `${v}${band} ${f.unit}`.trim();
+}
+
+/**
+ * Build the findings panel. Returns its root element and a `refresh` so a host
+ * that mutates the ledger elsewhere can re-render it.
+ */
+export function buildFindingsPanel(deps: FindingsPanelDeps): MountedFindingsPanel {
+  const { findings } = deps;
+  const root = el('div', { className: 'olv-findings-panel' });
+  const header = el('div', { className: 'olv-findings-head' });
+  const list = el('div', { className: 'olv-findings-list' });
+  const actions = el('div', { className: 'olv-findings-actions' });
+
+  const addBtn = el('button', { className: 'olv-findings-add', text: 'Add current measurements' });
+  addBtn.type = 'button';
+  addBtn.title = 'Append the placed measurements to the findings ledger, each with its band and caveats.';
+  const exportBtn = el('button', { className: 'olv-findings-export', text: 'Export findings report' });
+  exportBtn.type = 'button';
+  exportBtn.title = 'Export the whole ledger as the tamper-evident integrity report (JSON, SHA-256 digest).';
+  const clearBtn = el('button', { className: 'olv-findings-clear', text: 'Clear all' });
+  clearBtn.type = 'button';
+  const status = el('div', { className: 'olv-findings-status', text: '' });
+  actions.append(addBtn, exportBtn, clearBtn);
+
+  const render = (): void => {
+    const all = findings.all;
+    header.textContent = `Findings — ${all.length}`;
+    list.replaceChildren();
+    if (all.length === 0) {
+      list.append(el('p', { className: 'olv-findings-empty', text: 'No findings yet. Add current measurements to start the ledger.' }));
+    } else {
+      all.forEach((f, i) => {
+        const row = el('div', { className: 'olv-findings-row' });
+        row.append(el('div', { className: 'olv-findings-label', text: f.label }));
+        row.append(el('div', { className: 'olv-findings-value', text: formatValue(f) }));
+        if (f.confidence) {
+          row.append(el('div', { className: 'olv-findings-confidence', text: `confidence: ${f.confidence}` }));
+        }
+        if (f.caveats && f.caveats.length > 0) {
+          // Caveats are the honesty notes — kept inspectable, not dropped.
+          row.append(el('div', { className: 'olv-findings-caveats', text: f.caveats.join(' ') }));
+        }
+        const remove = el('button', { className: 'olv-findings-remove', text: 'Remove' });
+        remove.type = 'button';
+        remove.setAttribute('aria-label', `Remove ${f.label}`);
+        remove.addEventListener('click', () => {
+          findings.remove(i);
+          status.textContent = '';
+          render();
+        });
+        row.append(remove);
+        list.append(row);
+      });
+    }
+    // Export only means something with at least one finding.
+    exportBtn.disabled = all.length === 0;
+    clearBtn.disabled = all.length === 0;
+  };
+
+  addBtn.addEventListener('click', () => {
+    const toAdd = deps.collectMeasurements();
+    if (toAdd.length === 0) {
+      status.textContent = 'No placed measurements to add.';
+      return;
+    }
+    for (const f of toAdd) findings.add(f);
+    status.textContent = `Added ${toAdd.length} measurement finding(s).`;
+    render();
+  });
+
+  exportBtn.addEventListener('click', () => {
+    if (findings.all.length === 0) return;
+    deps.exportReport(findings.all);
+    status.textContent = `Exported a report of ${findings.all.length} finding(s).`;
+  });
+
+  clearBtn.addEventListener('click', () => {
+    findings.clear();
+    status.textContent = 'Cleared the findings ledger.';
+    render();
+  });
+
+  render();
+  root.append(header, list, actions, status);
+  return { element: root, refresh: render };
+}

--- a/src/ui/findingsPanel.ts
+++ b/src/ui/findingsPanel.ts
@@ -25,9 +25,10 @@ export interface FindingsPanelDeps {
   /**
    * The findings to append when the reviewer clicks "Add current measurements"
    * — the host converts the live measurements via `measurementsToFindings`.
-   * Returns an empty array when there is nothing to add.
+   * Async because the converter lives in a lazily-loaded chunk. Returns an empty
+   * array when there is nothing to add.
    */
-  readonly collectMeasurements: () => readonly ReportFinding[];
+  readonly collectMeasurements: () => Promise<readonly ReportFinding[]>;
   /**
    * Export the ledger as the integrity report. The host builds the manifest
    * (SHA-256) and triggers the download; the panel only decides WHEN and passes
@@ -107,14 +108,21 @@ export function buildFindingsPanel(deps: FindingsPanelDeps): MountedFindingsPane
   };
 
   addBtn.addEventListener('click', () => {
-    const toAdd = deps.collectMeasurements();
-    if (toAdd.length === 0) {
-      status.textContent = 'No placed measurements to add.';
-      return;
-    }
-    for (const f of toAdd) findings.add(f);
-    status.textContent = `Added ${toAdd.length} measurement finding(s).`;
-    render();
+    addBtn.disabled = true;
+    void deps
+      .collectMeasurements()
+      .then((toAdd) => {
+        if (toAdd.length === 0) {
+          status.textContent = 'No placed measurements to add.';
+          return;
+        }
+        for (const f of toAdd) findings.add(f);
+        status.textContent = `Added ${toAdd.length} measurement finding(s).`;
+        render();
+      })
+      .finally(() => {
+        addBtn.disabled = false;
+      });
   });
 
   exportBtn.addEventListener('click', () => {

--- a/tests/findingsPanel.test.ts
+++ b/tests/findingsPanel.test.ts
@@ -1,0 +1,104 @@
+/**
+ * findingsPanel.test.ts — the durable findings ledger surface.
+ *
+ * Drives the panel through the shared recording DOM stub: adding measurements
+ * appends to the ledger, remove drops the right row, export hands the current
+ * ledger to the host, and an empty ledger disables export. The panel keeps each
+ * finding's band and caveats visible (they are the honesty notes).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { installFakeDom } from './support/measurePanelDom';
+import { SessionFindings } from '../src/render/measure/sessionFindings';
+import type { ReportFinding } from '../src/render/measure/reportManifest';
+import { buildFindingsPanel } from '../src/ui/findingsPanel';
+
+beforeEach(() => installFakeDom());
+
+const finding = (label: string, value: number): ReportFinding => ({
+  label,
+  value,
+  unit: 'm³',
+  sigma: 5,
+  confidence: 'medium',
+  caveats: ['assumes spatial independence'],
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const q = (root: any, sel: string): any => root.querySelector(sel);
+
+describe('buildFindingsPanel', () => {
+  it('starts empty: export/clear disabled, empty note shown', () => {
+    const findings = new SessionFindings();
+    const { element } = buildFindingsPanel({
+      findings,
+      collectMeasurements: () => [],
+      exportReport: () => {},
+    });
+    expect(q(element, '.olv-findings-empty')).not.toBeNull();
+    expect(q(element, '.olv-findings-export').disabled).toBe(true);
+    expect(q(element, '.olv-findings-clear').disabled).toBe(true);
+  });
+
+  it('adds current measurements to the ledger and renders rows', () => {
+    const findings = new SessionFindings();
+    const { element } = buildFindingsPanel({
+      findings,
+      collectMeasurements: () => [finding('Distance AB', 43.28), finding('Stockpile A', 612.4)],
+      exportReport: () => {},
+    });
+    q(element, '.olv-findings-add').click();
+    expect(findings.count).toBe(2);
+    expect(q(element, '.olv-findings-list').querySelectorAll('.olv-findings-row')).toHaveLength(2);
+    // The band and caveat travel onto the row.
+    expect(q(element, '.olv-findings-value').textContent).toContain('±');
+    expect(q(element, '.olv-findings-caveats').textContent).toContain('spatial independence');
+    expect(q(element, '.olv-findings-export').disabled).toBe(false);
+  });
+
+  it('reports nothing to add when there are no measurements', () => {
+    const findings = new SessionFindings();
+    const { element } = buildFindingsPanel({
+      findings,
+      collectMeasurements: () => [],
+      exportReport: () => {},
+    });
+    q(element, '.olv-findings-add').click();
+    expect(findings.count).toBe(0);
+    expect(q(element, '.olv-findings-status').textContent).toMatch(/no placed measurements/i);
+  });
+
+  it('remove drops exactly that finding', () => {
+    const findings = new SessionFindings();
+    findings.add(finding('A', 1));
+    findings.add(finding('B', 2));
+    const { element } = buildFindingsPanel({
+      findings,
+      collectMeasurements: () => [],
+      exportReport: () => {},
+    });
+    // Remove the first row.
+    q(element, '.olv-findings-list').querySelectorAll('.olv-findings-remove')[0].click();
+    expect(findings.count).toBe(1);
+    expect(findings.all[0].label).toBe('B');
+  });
+
+  it('export hands the current ledger to the host; clear empties it', () => {
+    const findings = new SessionFindings();
+    findings.add(finding('A', 1));
+    let exported: readonly ReportFinding[] | null = null;
+    const { element } = buildFindingsPanel({
+      findings,
+      collectMeasurements: () => [],
+      exportReport: (f) => {
+        exported = f;
+      },
+    });
+    q(element, '.olv-findings-export').click();
+    expect(exported).not.toBeNull();
+    expect(exported!).toHaveLength(1);
+    q(element, '.olv-findings-clear').click();
+    expect(findings.count).toBe(0);
+    expect(q(element, '.olv-findings-export').disabled).toBe(true);
+  });
+});

--- a/tests/findingsPanel.test.ts
+++ b/tests/findingsPanel.test.ts
@@ -32,7 +32,7 @@ describe('buildFindingsPanel', () => {
     const findings = new SessionFindings();
     const { element } = buildFindingsPanel({
       findings,
-      collectMeasurements: () => [],
+      collectMeasurements: () => Promise.resolve([]),
       exportReport: () => {},
     });
     expect(q(element, '.olv-findings-empty')).not.toBeNull();
@@ -40,14 +40,16 @@ describe('buildFindingsPanel', () => {
     expect(q(element, '.olv-findings-clear').disabled).toBe(true);
   });
 
-  it('adds current measurements to the ledger and renders rows', () => {
+  it('adds current measurements to the ledger and renders rows', async () => {
     const findings = new SessionFindings();
     const { element } = buildFindingsPanel({
       findings,
-      collectMeasurements: () => [finding('Distance AB', 43.28), finding('Stockpile A', 612.4)],
+      collectMeasurements: () => Promise.resolve([finding('Distance AB', 43.28), finding('Stockpile A', 612.4)]),
       exportReport: () => {},
     });
     q(element, '.olv-findings-add').click();
+    await Promise.resolve();
+    await Promise.resolve();
     expect(findings.count).toBe(2);
     expect(q(element, '.olv-findings-list').querySelectorAll('.olv-findings-row')).toHaveLength(2);
     // The band and caveat travel onto the row.
@@ -56,14 +58,16 @@ describe('buildFindingsPanel', () => {
     expect(q(element, '.olv-findings-export').disabled).toBe(false);
   });
 
-  it('reports nothing to add when there are no measurements', () => {
+  it('reports nothing to add when there are no measurements', async () => {
     const findings = new SessionFindings();
     const { element } = buildFindingsPanel({
       findings,
-      collectMeasurements: () => [],
+      collectMeasurements: () => Promise.resolve([]),
       exportReport: () => {},
     });
     q(element, '.olv-findings-add').click();
+    await Promise.resolve();
+    await Promise.resolve();
     expect(findings.count).toBe(0);
     expect(q(element, '.olv-findings-status').textContent).toMatch(/no placed measurements/i);
   });
@@ -74,7 +78,7 @@ describe('buildFindingsPanel', () => {
     findings.add(finding('B', 2));
     const { element } = buildFindingsPanel({
       findings,
-      collectMeasurements: () => [],
+      collectMeasurements: () => Promise.resolve([]),
       exportReport: () => {},
     });
     // Remove the first row.
@@ -89,7 +93,7 @@ describe('buildFindingsPanel', () => {
     let exported: readonly ReportFinding[] | null = null;
     const { element } = buildFindingsPanel({
       findings,
-      collectMeasurements: () => [],
+      collectMeasurements: () => Promise.resolve([]),
       exportReport: (f) => {
         exported = f;
       },


### PR DESCRIPTION
A durable findings ledger for measurement deliverables, mounted live in the Export panel.

`SessionFindings` collects the results worth keeping — each a number with its band, confidence, and caveats. `buildFindingsPanel` renders it under a "Findings ledger" group in the Measurements lane: add the placed measurements as findings, prune rows, and export the whole ledger as the existing SHA-256 integrity report (new `findingsReportFile`, reached through `collectMeasurementFindings` / `exportFindingsReport` in the lazy report chunk).

To free composition-root room, `onExportImage` moves to `src/app/exportImageAction.ts`. main.ts 5,604 → 5,545; baselines and the architecture map re-banked; `findingsPanel` and `sessionFindings` graduated out of `unreachable-modules`.