### PR TITLE
feat(profile): draw the section's sample corridor in 3D, behind a toggle

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -160,13 +160,6 @@
       "review": "2027-02-28"
     },
     {
-      "path": "src/render/measure/profileCorridorOutline.ts",
-      "status": "staged",
-      "why": "Drawable geometry for the capsule corridor profileCorridor.ts tests membership against. The scene draws no corridor outline.",
-      "graduation": "The section overlay draws the corridor from this outline.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/render/measure/profileRawFilter.ts",
       "status": "staged",
       "why": "Chooses which accepted corridor returns the raw scatter draws, and describes the choice. The section view draws its scatter without this selection layer.",

--- a/src/app/profileWorkbenchLauncher.ts
+++ b/src/app/profileWorkbenchLauncher.ts
@@ -103,6 +103,12 @@ export interface ProfileWorkbenchLauncherDeps {
    * PNG control.
    */
   exportImage?: (request: ProfileWorkbenchLaunchRequest) => Promise<void>;
+  /**
+   * Show or hide the 3D sample-corridor outline for the section a dock is
+   * plotting. Absent means the dock renders no corridor control (and the 3D
+   * corridor stays off).
+   */
+  onToggleCorridor?: (on: boolean) => void;
   /** Told about a rejected import, so a silent fallback still leaves a trace. */
   onLoadFailure?: (error: unknown) => void;
   /** Told about a `present` that threw, for the same reason. */
@@ -172,12 +178,14 @@ export function createProfileWorkbenchLauncher(
     const rename = deps.rename;
     const exportPdf = deps.exportPdf;
     const exportImage = deps.exportImage;
+    const onToggleCorridor = deps.onToggleCorridor;
     const mounted = module.mountProfileWorkbench(host, {
       title: request.name,
       scope: request.name,
       ...(rename ? { onRename: (name: string) => rename(request.id, name) } : {}),
       ...(exportPdf ? { onExportPdf: () => exportPdf(request.id) } : {}),
       ...(exportImage ? { onExportImage: () => exportImage(request) } : {}),
+      ...(onToggleCorridor ? { onToggleCorridor } : {}),
       onClose: () => {
         // Only for the dock that is still the live one: a panel closed by the
         // mount that replaced it must not hand back the successor's height.

--- a/src/app/profileWorkbenchRuntime.ts
+++ b/src/app/profileWorkbenchRuntime.ts
@@ -25,6 +25,8 @@ import {
 } from './profileWorkbenchSection';
 import { loadProfileWorkbench } from '../lazyChunks';
 import { ProfileLinkOverlay } from '../render/ProfileLinkOverlay';
+import { ProfileCorridorOverlay } from '../render/ProfileCorridorOverlay';
+import type { ProfileCorridorOutline } from '../render/measure/profileCorridorOutline';
 import { focusPoseOnPoint } from '../render/measure/profilePointLink';
 
 import type { ProfileWorkbenchLauncher } from './profileWorkbenchLauncher';
@@ -102,6 +104,13 @@ export function createProfileWorkbenchRuntime(
   // A per-dock overlay would need the launcher to remember to dispose the
   // previous one, which is exactly the "stale mark left in the scene" bug.
   let overlay: ProfileLinkOverlay | null = null;
+  // The sample-corridor outline: one overlay for the runtime, and a visibility
+  // flag the dock's toggle drives. The section presenter supplies the latest
+  // outline (`markSampleCorridor`); the flag decides whether it is drawn, so
+  // toggling never re-runs the section walk.
+  let corridorOverlay: ProfileCorridorOverlay | null = null;
+  let corridorVisible = false;
+  let lastCorridorOutline: ProfileCorridorOutline | null = null;
   const markerHost = deps.markerHost;
   const camera = deps.camera;
 
@@ -116,6 +125,15 @@ export function createProfileWorkbenchRuntime(
             }
             overlay ??= new ProfileLinkOverlay(markerHost());
             overlay.show({ position: marker.position, mode: marker.mode, size: marker.size });
+          },
+          markSampleCorridor: (outline): void => {
+            lastCorridorOutline = outline;
+            // The overlay is built on the first time it is actually shown, not on
+            // every section finish: a dock the user never turns the corridor on
+            // for never touches the scene host at all.
+            if (!corridorVisible) return;
+            corridorOverlay ??= new ProfileCorridorOverlay(markerHost());
+            corridorOverlay.show(outline);
           },
         }
       : {}),
@@ -139,6 +157,19 @@ export function createProfileWorkbenchRuntime(
     stage: createStageProfileWorkbench(deps.stage),
     ...(deps.rename ? { rename: deps.rename } : {}),
     ...(deps.exportPdf ? { exportPdf: deps.exportPdf } : {}),
+    ...(markerHost
+      ? {
+          onToggleCorridor: (on: boolean): void => {
+            corridorVisible = on;
+            if (on) {
+              corridorOverlay ??= new ProfileCorridorOverlay(markerHost());
+              corridorOverlay.show(lastCorridorOutline);
+            } else {
+              corridorOverlay?.show(null);
+            }
+          },
+        }
+      : {}),
     exportImage: async (request) => {
       const current = live;
       if (!current) {

--- a/src/app/profileWorkbenchSection.ts
+++ b/src/app/profileWorkbenchSection.ts
@@ -71,6 +71,10 @@ import {
 } from '../render/measure/profileHitTest';
 import { buildProfilePointDetail } from '../render/measure/profilePointDetail';
 import {
+  buildProfileCorridorOutline,
+  type ProfileCorridorOutline,
+} from '../render/measure/profileCorridorOutline';
+import {
   profileDetailSources,
   profileHoverReadout,
   profileLinkStatusText,
@@ -754,6 +758,13 @@ export interface WorkbenchSectionScene {
   /** Place or clear the 3D mark. Absent ⇒ the link is 2D only. */
   markLinkedReturn?(marker: (ProfileLinkMarker & { readonly size: number }) | null): void;
   /**
+   * Hand the runtime the section's sample-corridor outline (or null to clear) so
+   * it can draw the 3D corridor the transect sampled from. The runtime decides
+   * whether it is currently shown; this only supplies the geometry when a section
+   * finishes. Absent ⇒ no corridor is drawn.
+   */
+  markSampleCorridor?(outline: ProfileCorridorOutline | null): void;
+  /**
    * Move the camera onto a point.
    *
    * Reached ONLY from a deliberate focus action on a clicked selection. A
@@ -847,6 +858,8 @@ export function presentWorkbenchSection(
     // standing in the scene over a section nobody can see any more.
     link?.release();
     link = null;
+    // …and the sample-corridor outline, for the same reason.
+    scene.markSampleCorridor?.(null);
   }
 
   const profile = scene.profile(id);
@@ -902,6 +915,14 @@ export function presentWorkbenchSection(
       // previous one would answer for pixels that now hold different returns.
       link?.invalidate();
     });
+    // The corridor the section sampled from, built from the SAME frame + resolved
+    // half-width the walk used, so the outline encloses exactly the returns the
+    // transect drew from. The runtime decides whether it is currently shown. A
+    // section with no frame (degenerate transect) simply draws no corridor.
+    if (!stopped && section.frame) {
+      const halfWidth = Number.isFinite(section.band) ? section.band : 0;
+      scene.markSampleCorridor?.(buildProfileCorridorOutline(section.frame, halfWidth));
+    }
     // The plot is ready: an export control can now compose from the same state
     // the dock is showing. Skipped if the presentation was already disposed.
     if (!stopped) hooks.onReady?.(plot);

--- a/src/render/ProfileCorridorOverlay.ts
+++ b/src/render/ProfileCorridorOverlay.ts
@@ -1,0 +1,119 @@
+/**
+ * ProfileCorridorOverlay.ts
+ *
+ * The 3D outline of the corridor a profile section actually sampled — the
+ * capsule (or disc / line) of space whose returns the transect drew from. It is
+ * the SAMPLING SUPPORT of the section, NOT an uncertainty band: it says where the
+ * points came from, not how wrong the surface is.
+ *
+ * A SCENE OBJECT, NOT A PROJECTED OVERLAY, and the exact sibling of
+ * {@link ProfileLinkOverlay}: the outline is placed once, in project-frame world
+ * coordinates, and left to the camera, so it holds through an orbit or resize
+ * without the workbench touching the render loop. It owns its own object and
+ * nothing else's; a null clears it.
+ *
+ * Scene membership arrives as {@link ProfileLinkOverlayHost} — `derivedLayerHost()`
+ * satisfies it — so nothing here names the Viewer.
+ */
+
+import * as THREE from 'three/webgpu';
+
+import type { ProfileCorridorOutline } from './measure/profileCorridorOutline';
+import type { ProfileLinkOverlayHost } from './ProfileLinkOverlay';
+
+/** A muted cyan — a boundary the eye reads as context, not as measured geometry. */
+const CORRIDOR_COLOUR = 0x4dd0e1;
+const CORRIDOR_OPACITY = 0.55;
+
+type Vec3 = readonly [number, number, number];
+
+/** Append each consecutive pair of a polyline as a LineSegments pair into `out`. */
+function pushPolyline(poly: readonly Vec3[], out: number[]): void {
+  for (let i = 1; i < poly.length; i++) {
+    const a = poly[i - 1]!;
+    const b = poly[i]!;
+    out.push(a[0], a[1], a[2], b[0], b[1], b[2]);
+  }
+}
+
+/**
+ * The polylines to draw for an outline: the transect down the middle, plus the
+ * boundary. A capsule carries the whole boundary in `loop`; a disc has no loop,
+ * so its two cap rings are drawn instead. A `line` or `none` outline draws only
+ * the transect (or nothing).
+ */
+function outlineSegments(outline: ProfileCorridorOutline): Float32Array {
+  const out: number[] = [];
+  if (outline.centre.length >= 2) pushPolyline(outline.centre, out);
+  if (outline.loop.length >= 2) {
+    pushPolyline(outline.loop, out);
+  } else {
+    if (outline.startCap.length >= 2) pushPolyline(outline.startCap, out);
+    if (outline.endCap.length >= 2) pushPolyline(outline.endCap, out);
+  }
+  return new Float32Array(out);
+}
+
+export class ProfileCorridorOverlay {
+  private readonly _host: ProfileLinkOverlayHost;
+  private readonly _geometry: THREE.BufferGeometry;
+  private readonly _material: THREE.LineBasicMaterial;
+  private readonly _lines: THREE.LineSegments;
+  private _attached = false;
+  private _disposed = false;
+
+  constructor(host: ProfileLinkOverlayHost) {
+    this._host = host;
+    this._geometry = new THREE.BufferGeometry();
+    this._geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(0), 3));
+    this._material = new THREE.LineBasicMaterial({
+      color: CORRIDOR_COLOUR,
+      transparent: true,
+      opacity: CORRIDOR_OPACITY,
+      // Drawn through the scan like the link mark: the corridor encloses the
+      // points it describes, so an occluded outline would only show edge-on.
+      depthTest: false,
+    });
+    this._lines = new THREE.LineSegments(this._geometry, this._material);
+    this._lines.name = 'olv-profile-corridor';
+    this._lines.frustumCulled = false;
+    this._lines.renderOrder = 9;
+    this._lines.visible = false;
+  }
+
+  /** Draw the outline, or clear it with `null` (or a degenerate `none` outline). */
+  show(outline: ProfileCorridorOutline | null): void {
+    if (this._disposed) return;
+    const positions = outline ? outlineSegments(outline) : new Float32Array(0);
+    if (positions.length === 0) {
+      if (this._attached) {
+        this._host.remove(this._lines);
+        this._attached = false;
+      }
+      this._lines.visible = false;
+      this._host.requestFrame();
+      return;
+    }
+    this._geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    this._geometry.computeBoundingSphere();
+    this._lines.visible = true;
+    if (!this._attached) {
+      this._host.add(this._lines);
+      this._attached = true;
+    }
+    this._host.requestFrame();
+  }
+
+  /** Detach and release the GPU resources. Idempotent. */
+  dispose(): void {
+    if (this._disposed) return;
+    this._disposed = true;
+    if (this._attached) {
+      this._host.remove(this._lines);
+      this._attached = false;
+    }
+    this._geometry.dispose();
+    this._material.dispose();
+    this._host.requestFrame();
+  }
+}

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -691,6 +691,11 @@
   outline: 2px solid var(--accent); outline-offset: 2px;
 }
 .olv-workbench-btn:disabled { opacity: 0.6; cursor: default; }
+.olv-workbench-btn.is-active {
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: var(--accent);
+}
 .olv-workbench-status {
   padding: 0 var(--space-md) var(--space-2xs);
   font-size: var(--text-xs); color: var(--text-faint);

--- a/src/ui/ProfileWorkbench.ts
+++ b/src/ui/ProfileWorkbench.ts
@@ -106,6 +106,12 @@ export interface ProfileWorkbenchOptions {
    * a failure shows on the control the user pressed.
    */
   readonly onExportImage?: () => Promise<void>;
+  /**
+   * Show or hide the 3D outline of the corridor the section sampled from — its
+   * sampling support, not an uncertainty band. Absent means no corridor control
+   * is rendered (there is no 3D scene to draw into). Off by default.
+   */
+  readonly onToggleCorridor?: (on: boolean) => void;
   /** Called when the user closes the panel. */
   readonly onClose?: () => void;
 }
@@ -206,6 +212,7 @@ class ProfileWorkbench {
   private readonly _titleInput: HTMLInputElement | null;
   private readonly _exportBtn: HTMLButtonElement | null;
   private readonly _exportImageBtn: HTMLButtonElement | null;
+  private readonly _corridorBtn: HTMLButtonElement | null;
   private readonly _status: HTMLElement;
   private readonly _detail: HTMLElement;
   private readonly _readout: HTMLElement;
@@ -308,10 +315,34 @@ class ProfileWorkbench {
       this._on(btn, 'click', () => void this._exportImage(btn));
     }
 
+    // A toggle, not an action: it flips the 3D sample-corridor outline on and
+    // off. aria-pressed carries the state so it reads as a toggle to assistive
+    // tech; off by default, so the scene is unchanged until the user asks.
+    this._corridorBtn = options.onToggleCorridor
+      ? el('button', {
+          className: 'olv-workbench-btn',
+          type: 'button',
+          text: 'Sample corridor',
+          ariaLabel: 'Show the 3D outline of the corridor this section sampled from',
+        })
+      : null;
+    if (this._corridorBtn) {
+      const btn = this._corridorBtn;
+      btn.setAttribute('aria-pressed', 'false');
+      this._on(btn, 'click', () => {
+        const on = btn.getAttribute('aria-pressed') !== 'true';
+        btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+        btn.classList.toggle('is-active', on);
+        options.onToggleCorridor?.(on);
+      });
+    }
+
     const exportBtns = [this._exportBtn, this._exportImageBtn].filter(
       (b): b is HTMLButtonElement => b !== null,
     );
-    const actions = [...exportBtns, this._collapseBtn, closeBtn];
+    const actions = [this._corridorBtn, ...exportBtns, this._collapseBtn, closeBtn].filter(
+      (b): b is HTMLButtonElement => b !== null,
+    );
     const head = el('div', { className: 'olv-workbench-head' }, [
       el('div', { className: 'olv-workbench-titles' }, [
         this._title,

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -5147,6 +5147,11 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   outline: 2px solid var(--accent); outline-offset: 2px;
 }
 .olv-workbench-btn:disabled { opacity: 0.6; cursor: default; }
+.olv-workbench-btn.is-active {
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: var(--accent);
+}
 .olv-workbench-status {
   padding: 0 var(--space-md) var(--space-2xs);
   font-size: var(--text-xs); color: var(--text-faint);

--- a/tests/profileCorridorOverlay.test.ts
+++ b/tests/profileCorridorOverlay.test.ts
@@ -1,0 +1,87 @@
+/**
+ * profileCorridorOverlay.test.ts
+ *
+ * The 3D sample-corridor overlay. It draws a corridor outline as scene line
+ * segments, attaches to its host only while something is shown, and clears
+ * cleanly — mirroring the ProfileLinkOverlay lifecycle. A degenerate ('none')
+ * outline draws nothing, so an empty section never leaves a stray object.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three/webgpu';
+import { ProfileCorridorOverlay } from '../src/render/ProfileCorridorOverlay';
+import { buildProfileFrame } from '../src/render/measure/profileGeometry';
+import { buildProfileCorridorOutline } from '../src/render/measure/profileCorridorOutline';
+
+function fakeHost() {
+  const added: THREE.Object3D[] = [];
+  let frames = 0;
+  return {
+    added,
+    frames: () => frames,
+    add(o: THREE.Object3D) {
+      added.push(o);
+    },
+    remove(o: THREE.Object3D) {
+      const i = added.indexOf(o);
+      if (i >= 0) added.splice(i, 1);
+    },
+    requestFrame() {
+      frames++;
+    },
+  };
+}
+
+const positionCount = (o: THREE.Object3D): number =>
+  ((o as THREE.LineSegments).geometry.getAttribute('position')?.count as number) ?? 0;
+
+describe('ProfileCorridorOverlay', () => {
+  it('attaches a line object with vertices when shown a capsule outline', () => {
+    const host = fakeHost();
+    const overlay = new ProfileCorridorOverlay(host);
+    const frame = buildProfileFrame([0, 0, 0], [10, 0, 0], [0, 0, 1]);
+    const outline = buildProfileCorridorOutline(frame, 2);
+    expect(outline.kind).toBe('capsule');
+
+    overlay.show(outline);
+    expect(host.added).toHaveLength(1);
+    expect(host.added[0]).toBeInstanceOf(THREE.LineSegments);
+    expect(positionCount(host.added[0]!)).toBeGreaterThan(0);
+    expect(host.added[0]!.visible).toBe(true);
+    expect(host.frames()).toBeGreaterThan(0);
+  });
+
+  it('clears cleanly on null: detaches and hides', () => {
+    const host = fakeHost();
+    const overlay = new ProfileCorridorOverlay(host);
+    const frame = buildProfileFrame([0, 0, 0], [10, 0, 0], [0, 0, 1]);
+    overlay.show(buildProfileCorridorOutline(frame, 2));
+    const obj = host.added[0]!;
+    overlay.show(null);
+    expect(host.added).toHaveLength(0);
+    expect(obj.visible).toBe(false);
+  });
+
+  it('draws nothing for a degenerate (none) outline', () => {
+    const host = fakeHost();
+    const overlay = new ProfileCorridorOverlay(host);
+    // A zero-length section with no up gives a degenerate frame → 'none'.
+    const frame = buildProfileFrame([1, 1, 1], [1, 1, 1], [0, 0, 0]);
+    const outline = buildProfileCorridorOutline(frame, 0);
+    overlay.show(outline);
+    expect(host.added).toHaveLength(0);
+  });
+
+  it('dispose is idempotent and releases the object', () => {
+    const host = fakeHost();
+    const overlay = new ProfileCorridorOverlay(host);
+    const frame = buildProfileFrame([0, 0, 0], [10, 0, 0], [0, 0, 1]);
+    overlay.show(buildProfileCorridorOutline(frame, 2));
+    overlay.dispose();
+    overlay.dispose();
+    expect(host.added).toHaveLength(0);
+    // A show after dispose is a no-op, never a throw.
+    expect(() => overlay.show(buildProfileCorridorOutline(frame, 2))).not.toThrow();
+    expect(host.added).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
The profile section already resolves the corridor it sampled from (its `frame` + resolved half-width `band`), but nothing drew it. This adds a **"Sample corridor"** toggle to the Profile Workbench that shows the 3D outline of that corridor — the capsule of space the transect drew its returns from. It is labelled **sampling support, not an uncertainty band**.

- New `ProfileCorridorOverlay` — a scene object, the sibling of `ProfileLinkOverlay` (placed once, left to the camera, drawn through the cloud). It renders `buildProfileCorridorOutline`'s `loop`/caps/centre as line segments.
- The section presenter hands the runtime the outline via a new `markSampleCorridor` scene method, built from the **same** frame + half-width the walk used, so the outline encloses exactly the returns the section drew from.
- The runtime owns one overlay + a visibility flag the toggle drives, so toggling never re-runs the section walk. **Off by default**, built lazily on first show (a dock the corridor is never turned on for never touches the scene host), and cleared when the dock closes.
- `profileCorridorOutline` graduates out of `unreachable-modules`.

Second half of the "Engineering Profile Support" gem (the raw-scatter filter + all/ground/derived-support selector) follows as a separate PR. tsc clean, full suite green (13,861), overlay unit-tested.