### PR TITLE
refactor(profile): share one scene-line-overlay base (clears the #773 duplication)

### DIFF
--- a/src/render/ProfileCorridorOverlay.ts
+++ b/src/render/ProfileCorridorOverlay.ts
@@ -19,7 +19,7 @@
 import * as THREE from 'three/webgpu';
 
 import type { ProfileCorridorOutline } from './measure/profileCorridorOutline';
-import type { ProfileLinkOverlayHost } from './ProfileLinkOverlay';
+import { SceneLineOverlay, type SceneOverlayHost } from './sceneLineOverlay';
 
 /** A muted cyan — a boundary the eye reads as context, not as measured geometry. */
 const CORRIDOR_COLOUR = 0x4dd0e1;
@@ -54,66 +54,33 @@ function outlineSegments(outline: ProfileCorridorOutline): Float32Array {
   return new Float32Array(out);
 }
 
-export class ProfileCorridorOverlay {
-  private readonly _host: ProfileLinkOverlayHost;
-  private readonly _geometry: THREE.BufferGeometry;
-  private readonly _material: THREE.LineBasicMaterial;
-  private readonly _lines: THREE.LineSegments;
-  private _attached = false;
-  private _disposed = false;
-
-  constructor(host: ProfileLinkOverlayHost) {
-    this._host = host;
-    this._geometry = new THREE.BufferGeometry();
-    this._geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(0), 3));
-    this._material = new THREE.LineBasicMaterial({
-      color: CORRIDOR_COLOUR,
-      transparent: true,
-      opacity: CORRIDOR_OPACITY,
-      // Drawn through the scan like the link mark: the corridor encloses the
-      // points it describes, so an occluded outline would only show edge-on.
-      depthTest: false,
-    });
-    this._lines = new THREE.LineSegments(this._geometry, this._material);
-    this._lines.name = 'olv-profile-corridor';
-    this._lines.frustumCulled = false;
-    this._lines.renderOrder = 9;
-    this._lines.visible = false;
+export class ProfileCorridorOverlay extends SceneLineOverlay {
+  constructor(host: SceneOverlayHost) {
+    super(
+      host,
+      {
+        color: CORRIDOR_COLOUR,
+        transparent: true,
+        opacity: CORRIDOR_OPACITY,
+        // Drawn through the scan like the link mark: the corridor encloses the
+        // points it describes, so an occluded outline would only show edge-on.
+        depthTest: false,
+      },
+      { name: 'olv-profile-corridor', renderOrder: 9 },
+    );
+    this.geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(0), 3));
   }
 
   /** Draw the outline, or clear it with `null` (or a degenerate `none` outline). */
   show(outline: ProfileCorridorOutline | null): void {
-    if (this._disposed) return;
+    if (this.isDisposed) return;
     const positions = outline ? outlineSegments(outline) : new Float32Array(0);
     if (positions.length === 0) {
-      if (this._attached) {
-        this._host.remove(this._lines);
-        this._attached = false;
-      }
-      this._lines.visible = false;
-      this._host.requestFrame();
+      this.clear();
       return;
     }
-    this._geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    this._geometry.computeBoundingSphere();
-    this._lines.visible = true;
-    if (!this._attached) {
-      this._host.add(this._lines);
-      this._attached = true;
-    }
-    this._host.requestFrame();
-  }
-
-  /** Detach and release the GPU resources. Idempotent. */
-  dispose(): void {
-    if (this._disposed) return;
-    this._disposed = true;
-    if (this._attached) {
-      this._host.remove(this._lines);
-      this._attached = false;
-    }
-    this._geometry.dispose();
-    this._material.dispose();
-    this._host.requestFrame();
+    this.geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    this.geometry.computeBoundingSphere();
+    this.present();
   }
 }

--- a/src/render/ProfileLinkOverlay.ts
+++ b/src/render/ProfileLinkOverlay.ts
@@ -25,13 +25,10 @@
 import * as THREE from 'three/webgpu';
 
 import { profileMarkerSegments } from './measure/profilePointLink';
+import { SceneLineOverlay, type SceneOverlayHost } from './sceneLineOverlay';
 
-/** Scene membership and redraw, and nothing more. */
-export interface ProfileLinkOverlayHost {
-  add(object: THREE.Object3D): void;
-  remove(object: THREE.Object3D): void;
-  requestFrame(): void;
-}
+/** Scene membership and redraw, and nothing more. The shared overlay host. */
+export type ProfileLinkOverlayHost = SceneOverlayHost;
 
 /** What to mark. `null` clears the mark. */
 export interface ProfileLinkMark {
@@ -47,72 +44,39 @@ const LOCKED_COLOUR = 0xffffff;
 const HOVER_OPACITY = 0.65;
 const LOCKED_OPACITY = 1;
 
-export class ProfileLinkOverlay {
-  private readonly _host: ProfileLinkOverlayHost;
+export class ProfileLinkOverlay extends SceneLineOverlay {
   private readonly _positions = new Float32Array(18);
-  private readonly _geometry: THREE.BufferGeometry;
-  private readonly _material: THREE.LineBasicMaterial;
-  private readonly _lines: THREE.LineSegments;
-  private _attached = false;
-  private _disposed = false;
 
   constructor(host: ProfileLinkOverlayHost) {
-    this._host = host;
-    this._geometry = new THREE.BufferGeometry();
-    this._geometry.setAttribute('position', new THREE.BufferAttribute(this._positions, 3));
-    this._material = new THREE.LineBasicMaterial({
-      color: HOVER_COLOUR,
-      transparent: true,
-      opacity: HOVER_OPACITY,
-      // Drawn through the scan rather than behind it: the marked return is
-      // usually inside the cloud, and a mark occluded by the points it names
-      // would only be visible when the section happened to face the camera.
-      depthTest: false,
-    });
-    this._lines = new THREE.LineSegments(this._geometry, this._material);
-    this._lines.name = 'olv-profile-link-mark';
-    this._lines.frustumCulled = false;
-    this._lines.renderOrder = 10;
-    this._lines.visible = false;
+    super(
+      host,
+      {
+        color: HOVER_COLOUR,
+        transparent: true,
+        opacity: HOVER_OPACITY,
+        // Drawn through the scan rather than behind it: the marked return is
+        // usually inside the cloud, and a mark occluded by the points it names
+        // would only be visible when the section happened to face the camera.
+        depthTest: false,
+      },
+      { name: 'olv-profile-link-mark', renderOrder: 10 },
+    );
+    this.geometry.setAttribute('position', new THREE.BufferAttribute(this._positions, 3));
   }
 
   /** Place the mark, or clear it with `null`. */
   show(mark: ProfileLinkMark | null): void {
-    if (this._disposed) return;
+    if (this.isDisposed) return;
     if (!mark) {
-      if (this._attached) {
-        this._host.remove(this._lines);
-        this._attached = false;
-      }
-      this._lines.visible = false;
-      this._host.requestFrame();
+      this.clear();
       return;
     }
     profileMarkerSegments(mark.position, mark.size, this._positions);
-    const attribute = this._geometry.getAttribute('position');
-    attribute.needsUpdate = true;
-    this._geometry.computeBoundingSphere();
+    this.geometry.getAttribute('position').needsUpdate = true;
+    this.geometry.computeBoundingSphere();
     const locked = mark.mode === 'locked';
-    this._material.color.setHex(locked ? LOCKED_COLOUR : HOVER_COLOUR);
-    this._material.opacity = locked ? LOCKED_OPACITY : HOVER_OPACITY;
-    this._lines.visible = true;
-    if (!this._attached) {
-      this._host.add(this._lines);
-      this._attached = true;
-    }
-    this._host.requestFrame();
-  }
-
-  /** Detach and release the GPU resources. Idempotent. */
-  dispose(): void {
-    if (this._disposed) return;
-    this._disposed = true;
-    if (this._attached) {
-      this._host.remove(this._lines);
-      this._attached = false;
-    }
-    this._geometry.dispose();
-    this._material.dispose();
-    this._host.requestFrame();
+    this.material.color.setHex(locked ? LOCKED_COLOUR : HOVER_COLOUR);
+    this.material.opacity = locked ? LOCKED_OPACITY : HOVER_OPACITY;
+    this.present();
   }
 }

--- a/src/render/sceneLineOverlay.ts
+++ b/src/render/sceneLineOverlay.ts
@@ -1,0 +1,90 @@
+/**
+ * sceneLineOverlay.ts
+ *
+ * The shared lifecycle of a scene-object line overlay: one `THREE.LineSegments`
+ * that attaches to a host only while it is shown, and releases its GPU buffers on
+ * dispose. Subclasses own the geometry contents and when to show/clear; this base
+ * owns the host membership and teardown so each overlay is not its own copy of
+ * the attach / detach / dispose boilerplate.
+ *
+ * The host is the same minimal `add` / `remove` / `requestFrame` surface
+ * `derivedLayerHost()` satisfies, so nothing here names the Viewer.
+ */
+
+import * as THREE from 'three/webgpu';
+
+/** Scene membership and redraw, and nothing more. */
+export interface SceneOverlayHost {
+  add(object: THREE.Object3D): void;
+  remove(object: THREE.Object3D): void;
+  requestFrame(): void;
+}
+
+export interface SceneLineOverlayOptions {
+  /** Object name, for scene inspection. */
+  readonly name: string;
+  /** Draw order relative to the scan and other overlays. */
+  readonly renderOrder: number;
+}
+
+export abstract class SceneLineOverlay {
+  protected readonly host: SceneOverlayHost;
+  protected readonly geometry: THREE.BufferGeometry;
+  protected readonly material: THREE.LineBasicMaterial;
+  protected readonly lines: THREE.LineSegments;
+  private _attached = false;
+  private _disposed = false;
+
+  protected constructor(
+    host: SceneOverlayHost,
+    material: THREE.LineBasicMaterialParameters,
+    options: SceneLineOverlayOptions,
+  ) {
+    this.host = host;
+    this.geometry = new THREE.BufferGeometry();
+    this.material = new THREE.LineBasicMaterial(material);
+    this.lines = new THREE.LineSegments(this.geometry, this.material);
+    this.lines.name = options.name;
+    this.lines.frustumCulled = false;
+    this.lines.renderOrder = options.renderOrder;
+    this.lines.visible = false;
+  }
+
+  /** Whether {@link dispose} has run; a subclass `show` returns early when true. */
+  protected get isDisposed(): boolean {
+    return this._disposed;
+  }
+
+  /** Make the object visible and part of the scene, then request a frame. */
+  protected present(): void {
+    this.lines.visible = true;
+    if (!this._attached) {
+      this.host.add(this.lines);
+      this._attached = true;
+    }
+    this.host.requestFrame();
+  }
+
+  /** Hide and detach the object, then request a frame. */
+  protected clear(): void {
+    if (this._attached) {
+      this.host.remove(this.lines);
+      this._attached = false;
+    }
+    this.lines.visible = false;
+    this.host.requestFrame();
+  }
+
+  /** Detach and release the GPU resources. Idempotent. */
+  dispose(): void {
+    if (this._disposed) return;
+    this._disposed = true;
+    if (this._attached) {
+      this.host.remove(this.lines);
+      this._attached = false;
+    }
+    this.geometry.dispose();
+    this.material.dispose();
+    this.host.requestFrame();
+  }
+}


### PR DESCRIPTION
Follow-up to #773. `ProfileCorridorOverlay` repeated `ProfileLinkOverlay`'s host-attach / detach / dispose boilerplate, which SonarCloud flagged as duplicated new code.

Extract that lifecycle into a shared `SceneLineOverlay` base — one `THREE.LineSegments`, attached to the host only while shown, GPU buffers released on dispose — and have both overlays extend it. Each subclass still owns its geometry contents and decides when to show or clear, so behaviour is unchanged. tsc clean, full suite green (13,861).