### PR TITLE
feat(profile): filter the section's raw scatter by attribute scope

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -160,13 +160,6 @@
       "review": "2027-02-28"
     },
     {
-      "path": "src/render/measure/profileRawFilter.ts",
-      "status": "staged",
-      "why": "Chooses which accepted corridor returns the raw scatter draws, and describes the choice. The section view draws its scatter without this selection layer.",
-      "graduation": "The section view routes its raw scatter through this filter and shows the descriptor.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/render/streaming/pipelineLimits.ts",
       "status": "staged",
       "why": "Its own header states the position: the P8 fetch/decode/upload separation is evidence-gated, so this is \"the policy math only ... NOT wired into the live scheduler\", and wiring waits on device profiling that shows the P7 upload queue did not already resolve the stalls.",

--- a/src/app/profileWorkbenchLauncher.ts
+++ b/src/app/profileWorkbenchLauncher.ts
@@ -29,6 +29,7 @@ import type {
   ProfileWorkbenchHost,
   ProfileWorkbenchOptions,
 } from '../ui/ProfileWorkbench';
+import type { ProfileRawScope } from '../render/measure/profileRawFilter';
 
 /** The shape the lazy chunk resolves to. Only the mount function is used. */
 export interface ProfileWorkbenchModule {
@@ -109,6 +110,12 @@ export interface ProfileWorkbenchLauncherDeps {
    * corridor stays off).
    */
   onToggleCorridor?: (on: boolean) => void;
+  /**
+   * Re-draw the section's raw scatter through a chosen attribute scope (all /
+   * ground / exclude veg & noise). Absent means the dock renders no scope
+   * selector and draws every corridor return.
+   */
+  onRawScope?: (scope: ProfileRawScope) => void;
   /** Told about a rejected import, so a silent fallback still leaves a trace. */
   onLoadFailure?: (error: unknown) => void;
   /** Told about a `present` that threw, for the same reason. */
@@ -179,6 +186,7 @@ export function createProfileWorkbenchLauncher(
     const exportPdf = deps.exportPdf;
     const exportImage = deps.exportImage;
     const onToggleCorridor = deps.onToggleCorridor;
+    const onRawScope = deps.onRawScope;
     const mounted = module.mountProfileWorkbench(host, {
       title: request.name,
       scope: request.name,
@@ -186,6 +194,7 @@ export function createProfileWorkbenchLauncher(
       ...(exportPdf ? { onExportPdf: () => exportPdf(request.id) } : {}),
       ...(exportImage ? { onExportImage: () => exportImage(request) } : {}),
       ...(onToggleCorridor ? { onToggleCorridor } : {}),
+      ...(onRawScope ? { onRawScope } : {}),
       onClose: () => {
         // Only for the dock that is still the live one: a panel closed by the
         // mount that replaced it must not hand back the successor's height.

--- a/src/app/profileWorkbenchRuntime.ts
+++ b/src/app/profileWorkbenchRuntime.ts
@@ -27,6 +27,10 @@ import { loadProfileWorkbench } from '../lazyChunks';
 import { ProfileLinkOverlay } from '../render/ProfileLinkOverlay';
 import { ProfileCorridorOverlay } from '../render/ProfileCorridorOverlay';
 import type { ProfileCorridorOutline } from '../render/measure/profileCorridorOutline';
+import {
+  rawFilterRequestForScope,
+  type ProfileRawFilterRequest,
+} from '../render/measure/profileRawFilter';
 import { focusPoseOnPoint } from '../render/measure/profilePointLink';
 
 import type { ProfileWorkbenchLauncher } from './profileWorkbenchLauncher';
@@ -152,6 +156,10 @@ export function createProfileWorkbenchRuntime(
   // presentation is released.
   let live: { plot: WorkbenchSectionPlot; name: string } | null = null;
 
+  // The live dock's raw-scatter re-filter, handed over when its plot is ready
+  // and cleared when it is released. One dock at a time, so one slot.
+  let setRawFilter: ((request: ProfileRawFilterRequest) => void) | null = null;
+
   return createProfileWorkbenchLauncher({
     load: () => loadProfileWorkbench(),
     stage: createStageProfileWorkbench(deps.stage),
@@ -183,14 +191,19 @@ export function createProfileWorkbenchRuntime(
         generatedAt: sectionImageStamp(),
       });
     },
+    onRawScope: (scope): void => setRawFilter?.(rawFilterRequestForScope(scope)),
     present: (handle, request) => {
       const dispose = presentWorkbenchSection(handle, request.id, scene, {
         onReady: (plot) => {
           live = { plot, name: request.name };
         },
+        onControls: (controls) => {
+          setRawFilter = controls.setRawFilter;
+        },
       });
       return () => {
         live = null;
+        setRawFilter = null;
         dispose();
       };
     },

--- a/src/app/profileWorkbenchSection.ts
+++ b/src/app/profileWorkbenchSection.ts
@@ -75,6 +75,11 @@ import {
   type ProfileCorridorOutline,
 } from '../render/measure/profileCorridorOutline';
 import {
+  filterProfileRaw,
+  type ProfileRawFilterRequest,
+  type ProfileRawFilterDescriptor,
+} from '../render/measure/profileRawFilter';
+import {
   profileDetailSources,
   profileHoverReadout,
   profileLinkStatusText,
@@ -418,6 +423,13 @@ export interface ComposeSectionOptions {
    */
   readonly indices?: Uint32Array;
   /**
+   * The raw-scatter attribute/source filter to draw through. A non-'all' filter
+   * (or a source-slot selection) narrows the drawn returns to those it keeps and
+   * records the choice in the detail rows. Absent or 'all' draws every corridor
+   * return, exactly as before this existed.
+   */
+  readonly rawFilter?: ProfileRawFilterRequest;
+  /**
    * Vertical reference of the section's heights, for the height-axis title.
    *
    * Absent reads as `unknown`, which titles the axis "Height (datum unknown)".
@@ -577,7 +589,23 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
       : 1;
   const reference: VerticalReference = options.reference ?? 'unknown';
   const axisUnit = scale === 1 ? unit : null;
-  const indices = options.indices ?? drawIndices(section);
+  let indices = options.indices ?? drawIndices(section);
+  // The raw-scatter filter narrows what draws to the returns it keeps. Applied
+  // AFTER the display selection (a drawn point is always in the kept set), so the
+  // dots stay a spread subsample of the kept population — the descriptor reports
+  // that population, which the "Kept" row shows beside the "Drawn" count.
+  let filterDescriptor: ProfileRawFilterDescriptor | null = null;
+  const rawFilter = options.rawFilter;
+  const filterActive =
+    rawFilter != null &&
+    (((rawFilter.filter?.kind ?? 'all') !== 'all') || rawFilter.slots != null);
+  if (filterActive) {
+    const filtered = filterProfileRaw(section.points, rawFilter);
+    filterDescriptor = filtered.descriptor;
+    const kept = new Uint8Array(section.points.count);
+    for (const i of filtered.indices) kept[i] = 1;
+    indices = indices.filter((i) => kept[i] === 1);
+  }
   const colours = new Uint8Array(indices.length * 3);
   const colouring = colourProfileSection(
     {
@@ -673,6 +701,14 @@ export function prepareWorkbenchSection(options: ComposeSectionOptions): Workben
     { label: 'Sources', value: String(section.sources.length) },
     { label: 'Colour', value: colouring.legend.kind === 'unavailable' ? 'unavailable' : colouring.mode },
   ];
+  if (filterDescriptor) {
+    detail.push({
+      label: 'Kept (filter)',
+      value: `${filterDescriptor.keptCount} of ${filterDescriptor.acceptedCount}`,
+    });
+    const rules = filterDescriptor.scopes.filter((s) => s.active).map((s) => s.rule);
+    if (rules.length > 0) detail.push({ label: 'Filter', value: rules.join('; ') });
+  }
 
   const status =
     section.points.count === 0
@@ -840,6 +876,12 @@ export function presentWorkbenchSection(
      * per presentation, and never after `dispose`.
      */
     onReady?: (plot: WorkbenchSectionPlot) => void;
+    /**
+     * Hand the host the controls that re-drive the live plot, once it is ready.
+     * `setRawFilter` re-composes the scatter through a new attribute/source
+     * filter over the SAME extracted section — no re-walk. Called at most once.
+     */
+    onControls?: (controls: { setRawFilter(request: ProfileRawFilterRequest): void }) => void;
   } = {},
 ): () => void {
   let stopped = false;
@@ -879,7 +921,14 @@ export function presentWorkbenchSection(
   const now = scene.now ?? Date.now;
   const schedule = scene.scheduleSlice ?? scheduleFrame;
 
-  function finish(section: ProfileSectionResult, indices: Uint32Array): void {
+  // The raw-scatter filter the dock currently draws through, and the state a
+  // re-filter needs: the extracted section and the display selection, held so a
+  // filter change re-composes from memory rather than re-walking the scene.
+  let currentRawFilter: ProfileRawFilterRequest = { filter: { kind: 'all' } };
+  let liveSection: ProfileSectionResult | null = null;
+  let liveIndices: Uint32Array | null = null;
+
+  function compose(section: ProfileSectionResult, indices: Uint32Array): WorkbenchSectionPlot {
     // A unit is stated only alongside the scale that reaches it: a section is
     // measured in the scan's own render units, and a foot-CRS scan labelled
     // "m" without the factor would read as metres it never was.
@@ -887,6 +936,7 @@ export function presentWorkbenchSection(
     const plot = prepareWorkbenchSection({
       section,
       indices,
+      rawFilter: currentRawFilter,
       canvas: handle.canvas as unknown as WorkbenchCanvas,
       devicePixelRatio: scene.devicePixelRatio(),
       unitSuffix: metres === null ? null : 'm',
@@ -899,6 +949,9 @@ export function presentWorkbenchSection(
     handle.setGroundBasis(plot.view.groundBasisNote);
     handle.setStatus(plot.view.status);
     handle.setDetail(plot.view.detail);
+    // Re-filtering re-composes over the same section, so drop the previous link
+    // and size subscription before building their replacements.
+    link?.release();
     link = attachSectionPointLink({
       plot,
       section,
@@ -907,6 +960,7 @@ export function presentWorkbenchSection(
       unitToMetres: metres,
       devicePixelRatio: scene.devicePixelRatio(),
     });
+    releaseSize?.();
     const observe = scene.observeCanvasSize ?? observeElementSize;
     releaseSize = observe(handle.canvas, () => {
       if (stopped) return;
@@ -915,6 +969,21 @@ export function presentWorkbenchSection(
       // previous one would answer for pixels that now hold different returns.
       link?.invalidate();
     });
+    return plot;
+  }
+
+  function setRawFilter(request: ProfileRawFilterRequest): void {
+    currentRawFilter = request;
+    if (stopped || !liveSection || !liveIndices) return;
+    const plot = compose(liveSection, liveIndices);
+    // The export control composes from whatever the dock currently shows.
+    hooks.onReady?.(plot);
+  }
+
+  function finish(section: ProfileSectionResult, indices: Uint32Array): void {
+    liveSection = section;
+    liveIndices = indices;
+    const plot = compose(section, indices);
     // The corridor the section sampled from, built from the SAME frame + resolved
     // half-width the walk used, so the outline encloses exactly the returns the
     // transect drew from. The runtime decides whether it is currently shown. A
@@ -923,9 +992,12 @@ export function presentWorkbenchSection(
       const halfWidth = Number.isFinite(section.band) ? section.band : 0;
       scene.markSampleCorridor?.(buildProfileCorridorOutline(section.frame, halfWidth));
     }
-    // The plot is ready: an export control can now compose from the same state
-    // the dock is showing. Skipped if the presentation was already disposed.
-    if (!stopped) hooks.onReady?.(plot);
+    // The plot is ready: hand over the re-filter control and let an export
+    // control compose from the same state. Skipped if already disposed.
+    if (!stopped) {
+      hooks.onControls?.({ setRawFilter });
+      hooks.onReady?.(plot);
+    }
   }
 
   // The second stage: set once the corridor walk has answered, and pumped by

--- a/src/render/measure/profileRawFilter.ts
+++ b/src/render/measure/profileRawFilter.ts
@@ -60,6 +60,36 @@ export type ProfileRawFilter =
 /** The rule applied when a request names none: the whole accepted set. */
 export const DEFAULT_PROFILE_RAW_FILTER: ProfileRawFilter = { kind: 'all' };
 
+/** The user-facing scatter scopes the section view offers, in menu order. */
+export type ProfileRawScope = 'all' | 'ground' | 'exclude-non-ground';
+
+/** Menu metadata for the {@link ProfileRawScope} options. */
+export const PROFILE_RAW_SCOPES: readonly {
+  readonly id: ProfileRawScope;
+  readonly label: string;
+  readonly desc: string;
+}[] = [
+  { id: 'all', label: 'All returns', desc: 'Every return the corridor accepted.' },
+  { id: 'ground', label: 'Ground only', desc: 'ASPRS class 2 — the returns the derived surface is built from.' },
+  {
+    id: 'exclude-non-ground',
+    label: 'Exclude veg & noise',
+    desc: 'All but the classes the derived profile drops (vegetation, building, noise).',
+  },
+];
+
+/** The filter request for a chosen scatter scope. */
+export function rawFilterRequestForScope(scope: ProfileRawScope): ProfileRawFilterRequest {
+  switch (scope) {
+    case 'ground':
+      return { filter: { kind: 'ground' } };
+    case 'exclude-non-ground':
+      return { filter: { kind: 'excludeNonGround' } };
+    case 'all':
+      return { filter: { kind: 'all' } };
+  }
+}
+
 /**
  * A filter request.
  *

--- a/src/styles/74-inspector-profile.css
+++ b/src/styles/74-inspector-profile.css
@@ -696,6 +696,16 @@
   background: color-mix(in srgb, var(--accent) 22%, transparent);
   border-color: var(--accent);
 }
+.olv-workbench-select {
+  font-size: var(--text-xs); color: var(--text-dim);
+  background: rgba(255, 255, 255, 0.04);
+  border: 0.5px solid var(--hairline);
+  border-radius: var(--radius-sm); padding: var(--space-2xs) var(--space-sm);
+}
+.olv-workbench-select:hover { color: var(--text); }
+.olv-workbench-select:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}
 .olv-workbench-status {
   padding: 0 var(--space-md) var(--space-2xs);
   font-size: var(--text-xs); color: var(--text-faint);

--- a/src/ui/ProfileWorkbench.ts
+++ b/src/ui/ProfileWorkbench.ts
@@ -28,6 +28,7 @@
  */
 
 import { el } from './dom';
+import { PROFILE_RAW_SCOPES, type ProfileRawScope } from '../render/measure/profileRawFilter';
 import {
   PROFILE_WORKBENCH_DOCK_KEY,
   dockOccupiedHeight,
@@ -112,6 +113,11 @@ export interface ProfileWorkbenchOptions {
    * is rendered (there is no 3D scene to draw into). Off by default.
    */
   readonly onToggleCorridor?: (on: boolean) => void;
+  /**
+   * Re-draw the raw scatter through a chosen attribute scope (all returns /
+   * ground only / exclude vegetation & noise). Absent renders no scope selector.
+   */
+  readonly onRawScope?: (scope: ProfileRawScope) => void;
   /** Called when the user closes the panel. */
   readonly onClose?: () => void;
 }
@@ -213,6 +219,7 @@ class ProfileWorkbench {
   private readonly _exportBtn: HTMLButtonElement | null;
   private readonly _exportImageBtn: HTMLButtonElement | null;
   private readonly _corridorBtn: HTMLButtonElement | null;
+  private readonly _rawScope: HTMLSelectElement | null;
   private readonly _status: HTMLElement;
   private readonly _detail: HTMLElement;
   private readonly _readout: HTMLElement;
@@ -337,12 +344,36 @@ class ProfileWorkbench {
       });
     }
 
+    // The raw-scatter scope selector: which returns the section draws (all /
+    // ground / exclude veg & noise). A plain select, so the choice and its
+    // current value are one control.
+    this._rawScope = options.onRawScope
+      ? (el('select', {
+          className: 'olv-workbench-select',
+          ariaLabel: 'Which returns the section scatter draws',
+        }) as HTMLSelectElement)
+      : null;
+    if (this._rawScope) {
+      const select = this._rawScope;
+      for (const s of PROFILE_RAW_SCOPES) {
+        const opt = el('option', { text: s.label }) as HTMLOptionElement;
+        opt.value = s.id;
+        opt.title = s.desc;
+        select.append(opt);
+      }
+      this._on(select, 'change', () => options.onRawScope?.(select.value as ProfileRawScope));
+    }
+
     const exportBtns = [this._exportBtn, this._exportImageBtn].filter(
       (b): b is HTMLButtonElement => b !== null,
     );
-    const actions = [this._corridorBtn, ...exportBtns, this._collapseBtn, closeBtn].filter(
-      (b): b is HTMLButtonElement => b !== null,
-    );
+    const actions = [
+      this._corridorBtn,
+      this._rawScope,
+      ...exportBtns,
+      this._collapseBtn,
+      closeBtn,
+    ].filter((b): b is HTMLButtonElement | HTMLSelectElement => b !== null);
     const head = el('div', { className: 'olv-workbench-head' }, [
       el('div', { className: 'olv-workbench-titles' }, [
         this._title,

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -5152,6 +5152,16 @@ body[data-theme="high-contrast"] .olv-mode-reset::after {
   background: color-mix(in srgb, var(--accent) 22%, transparent);
   border-color: var(--accent);
 }
+.olv-workbench-select {
+  font-size: var(--text-xs); color: var(--text-dim);
+  background: rgba(255, 255, 255, 0.04);
+  border: 0.5px solid var(--hairline);
+  border-radius: var(--radius-sm); padding: var(--space-2xs) var(--space-sm);
+}
+.olv-workbench-select:hover { color: var(--text); }
+.olv-workbench-select:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}
 .olv-workbench-status {
   padding: 0 var(--space-md) var(--space-2xs);
   font-size: var(--text-xs); color: var(--text-faint);

--- a/tests/profileWorkbenchRawFilter.test.ts
+++ b/tests/profileWorkbenchRawFilter.test.ts
@@ -1,0 +1,129 @@
+/**
+ * profileWorkbenchRawFilter.test.ts
+ *
+ * The raw-scatter filter wired into the section composer: a non-'all' scope
+ * narrows the drawn returns to those it keeps and records the choice in the
+ * detail rows, while 'all' draws every corridor return exactly as before. The
+ * scope→request mapping is the small pure adapter the UI selector drives.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { prepareWorkbenchSection } from '../src/app/profileWorkbenchSection';
+import type { ProfileSectionResult } from '../src/render/measure/profileSectionSeam';
+import { PROFILE_ATTRIBUTE_BIT } from '../src/render/measure/profileSectionBuilder';
+import { rawFilterRequestForScope } from '../src/render/measure/profileRawFilter';
+
+function recordingContext() {
+  const ctx = {
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    globalAlpha: 1,
+    font: '',
+    textAlign: '',
+    textBaseline: '',
+    setTransform: (): void => {},
+    clearRect: (): void => {},
+    fillRect: (): void => {},
+    beginPath: (): void => {},
+    moveTo: (): void => {},
+    lineTo: (): void => {},
+    stroke: (): void => {},
+    fillText: (): void => {},
+  };
+  return ctx;
+}
+class FakeCanvas {
+  width = 0;
+  height = 0;
+  readonly ctx = recordingContext();
+  readonly clientWidth: number;
+  readonly clientHeight: number;
+  constructor(clientWidth: number, clientHeight: number) {
+    this.clientWidth = clientWidth;
+    this.clientHeight = clientHeight;
+  }
+  getContext(): ReturnType<typeof recordingContext> {
+    return this.ctx;
+  }
+}
+
+/** A section of `count` returns, half ground (class 2), half vegetation (class 5). */
+function mixedSection(count: number): ProfileSectionResult {
+  const chainage = new Float32Array(count);
+  const height = new Float64Array(count);
+  const classification = new Uint8Array(count);
+  const channelPresence = new Uint8Array(count);
+  for (let i = 0; i < count; i++) {
+    chainage[i] = (i / (count - 1)) * 100;
+    height[i] = 1000 + (i / (count - 1)) * 10;
+    classification[i] = i % 2 === 0 ? 2 : 5;
+    channelPresence[i] = PROFILE_ATTRIBUTE_BIT.classification;
+  }
+  return {
+    points: {
+      count,
+      chainage,
+      height,
+      lateralOffset: new Float32Array(count),
+      sourceSlot: new Uint16Array(count),
+      pointIndex: new Uint32Array(count),
+      channelPresence,
+      classification,
+    },
+    frame: null as never,
+    band: 2,
+    scope: 'static' as never,
+    scopeLabel: 'One loaded layer.',
+    streamingComplete: null,
+    sources: [],
+    generation: 1,
+    aborted: false,
+    skippedSlots: [],
+    examined: count,
+  } as unknown as ProfileSectionResult;
+}
+
+const rowValue = (
+  plot: ReturnType<typeof prepareWorkbenchSection>,
+  label: string,
+): string | undefined => plot.view.detail?.find((r) => r.label === label)?.value;
+
+describe('rawFilterRequestForScope', () => {
+  it('maps each scope to its filter kind', () => {
+    expect(rawFilterRequestForScope('all')).toEqual({ filter: { kind: 'all' } });
+    expect(rawFilterRequestForScope('ground')).toEqual({ filter: { kind: 'ground' } });
+    expect(rawFilterRequestForScope('exclude-non-ground')).toEqual({
+      filter: { kind: 'excludeNonGround' },
+    });
+  });
+});
+
+describe('prepareWorkbenchSection raw-scatter filter', () => {
+  it('draws every return and shows no filter row for the all scope', () => {
+    const plot = prepareWorkbenchSection({
+      section: mixedSection(100),
+      canvas: new FakeCanvas(640, 320) as never,
+      unitSuffix: 'm',
+      unitScale: 1,
+      rawFilter: rawFilterRequestForScope('all'),
+    });
+    expect(rowValue(plot, 'Drawn')).toBe('100');
+    expect(rowValue(plot, 'Kept (filter)')).toBeUndefined();
+  });
+
+  it('narrows the drawn returns to ground and records the choice', () => {
+    const plot = prepareWorkbenchSection({
+      section: mixedSection(100),
+      canvas: new FakeCanvas(640, 320) as never,
+      unitSuffix: 'm',
+      unitScale: 1,
+      rawFilter: rawFilterRequestForScope('ground'),
+    });
+    // Half the returns are ground; with the whole set under the draw cap, every
+    // ground return draws and no vegetation does.
+    expect(rowValue(plot, 'Drawn')).toBe('50');
+    expect(rowValue(plot, 'Kept (filter)')).toBe('50 of 100');
+    expect(rowValue(plot, 'Filter')).toMatch(/ground/i);
+  });
+});


### PR DESCRIPTION
The second half of the Engineering Profile Support gem (after #773's sample corridor). The section drew every corridor return; the raw-filter selection layer that distinguishes them was tested but unwired.

- A **scope selector** in the Profile Workbench head — **All returns / Ground only / Exclude veg & noise** — redraws the scatter through `filterProfileRaw` over the **same** extracted section (no re-walk), via a new `onControls` hook the presenter hands back.
- The choice is recorded in the detail rows: **"Kept (filter)"** gives the kept population, beside the existing **"Drawn"** subsample count — the two are honest, separate numbers (drawn is a spread subsample of kept).
- The filter runs after the display selection, so a drawn dot is always in the kept set; unclassified points are handled by `filterProfileRaw`'s own honest rules (membership needs positive evidence; exclusion keeps the unclassified, matching the derived reducer).
- The scope→request mapping is a small pure adapter. `profileRawFilter` graduates out of `unreachable-modules`.

tsc clean, full suite green (13,864), new unit tests for the mapping and the composer's filter behaviour.