### PR TITLE
feat(streaming): build the canonical diagnostics record and export it

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -167,13 +167,6 @@
       "review": "2027-02-28"
     },
     {
-      "path": "src/render/streaming/streamingDiagnostics.ts",
-      "status": "staged",
-      "why": "A flat record of everything the streaming path knows about itself. The ?debug=1 overlay still formats its own counters rather than building this record.",
-      "graduation": "The debug overlay, or a metrics export, builds its numbers from this record.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/render/streaming/streamingProfile.ts",
       "status": "staged",
       "why": "It maps a device tier onto a full bundle of streaming-session defaults: quality preset, EDL default and fade-in. The direct calls did not settle its question, they left its value unrealised. src/main.ts hardcodes the initial streamingQuality to 'balanced' and never derives it from deviceCapsValue.tier; streamingBudgets(quality, isMobile) is called with that fixed quality. So no path yet turns a device tier into these session defaults as a whole. tierAdaptation.ts, itself staged, is written to layer runtime FPS stepping on top of this bundle, which marks it as intended future work rather than a superseded module. Wiring it would edit src/main.ts, held off here because concurrent work owns that file.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3920,7 +3920,7 @@ if (debug || benchmark) {
       stats: viewerReady ? viewer.frameStats() : null,
       streaming: streamingDebugSample(),
       terrainCompute: readTerrainComputePath(),
-    }));
+    }), () => (viewerReady ? viewer.streamingScheduler?.diagnostics() ?? null : null));
     stage.overlay.append(debugOverlay.element);
     debugOverlay.start();
   });

--- a/src/perf/metricsJson.ts
+++ b/src/perf/metricsJson.ts
@@ -19,6 +19,7 @@
 
 import type { DevFlags } from './devFlags';
 import type { FrameTelemetrySnapshot } from './frameTelemetry';
+import type { StreamingDiagnostics } from '../render/streaming/streamingDiagnostics';
 
 /** Renderer-level stats, structurally matching `FrameStats` (Viewer.ts). */
 export interface MetricsRenderingInput {
@@ -67,6 +68,12 @@ export interface MetricsJsonInput {
   telemetry: FrameTelemetrySnapshot | null;
   rendering: MetricsRenderingInput | null;
   streaming: MetricsStreamingInput | null;
+  /**
+   * The canonical streaming-diagnostics record (scheduler.diagnostics()), or
+   * null when no streaming cloud is attached. Emitted verbatim into the document;
+   * absent reads as null.
+   */
+  streamingDiagnostics?: StreamingDiagnostics | null;
 }
 
 /** Round to 3 decimals for stable, readable ms values. */
@@ -155,6 +162,11 @@ export function buildMetricsDocument(input: MetricsJsonInput): Record<string, un
           thrashEvents: orNull(s.thrashEvents),
         }
       : null,
+    // The canonical streaming-diagnostics snapshot, emitted verbatim: it is
+    // already a flat record of numbers, literal nulls, and its own `unavailable`
+    // list, so it self-describes what it could not measure. Distinct from the
+    // legacy `streaming` block above, which the overlay text still formats.
+    streamingDiagnostics: input.streamingDiagnostics ?? null,
   };
 }
 

--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -38,7 +38,8 @@ import {
   selectLapsedEvictions,
 } from './evictionPolicy';
 import type { EvictionCandidate, EvictionHysteresis } from './evictionPolicy';
-import type { SchedulerReadinessFacts } from './refinementReadiness';
+import { evaluateRefinementReadiness, type SchedulerReadinessFacts } from './refinementReadiness';
+import { buildStreamingDiagnostics, type StreamingDiagnostics } from './streamingDiagnostics';
 
 /** Renderer-facing callbacks the scheduler drives. */
 export interface SchedulerCallbacks {
@@ -821,6 +822,42 @@ export class StreamingScheduler {
       decodedPendingCount,
       failedCount,
     };
+  }
+
+  /**
+   * One flat streaming-diagnostics snapshot, assembled from the SAME readiness
+   * facts the phase machine acted on and the live store / cache counters. The
+   * five fields the scheduler does not track (generation id, decode-retry total,
+   * GPU-upload queue depth/bytes, resident decoded bytes) are left unset, so the
+   * record reports them as null and names them under `unavailable` rather than
+   * estimating. This is the canonical numbers source for the debug overlay and a
+   * diagnostics export — neither has to re-derive the same metrics.
+   */
+  diagnostics(): StreamingDiagnostics {
+    const facts = this.readinessFacts();
+    const store = this._cloud.octree.store;
+    const s = this.stats();
+    const c = this.cacheStats();
+    return buildStreamingDiagnostics(facts, evaluateRefinementReadiness(facts), {
+      knownNodes: store.counts().known,
+      visibleNodes: s.visible,
+      residentPoints: store.residentPointCount,
+      decodedPendingPoints: store.decodedPendingPointCount,
+      pointBudget: this._pointBudget,
+      lastTickMs: s.lastTickMs,
+      cameraVelocity: s.cameraVelocity,
+      cameraStable: s.isStable,
+      effectiveMaxConcurrent: s.effectiveMaxConcurrent,
+      pressureDepthReduction: s.pressureDepthReduction,
+      fpsBudgetFactor: s.fpsBudgetFactor,
+      fullRescoreCount: s.fullRescoreCount,
+      cacheBytes: c.byteSize,
+      cacheEntries: c.count,
+      cacheMaxBytes: c.maxBytes,
+      cacheHits: c.hits,
+      cacheMisses: c.misses,
+      cacheEvictions: c.evictions,
+    });
   }
 
   /** Whether the camera has settled long enough for full-detail refinement. */

--- a/src/ui/DebugOverlay.ts
+++ b/src/ui/DebugOverlay.ts
@@ -20,6 +20,7 @@ import { formatTelemetry } from '../io/loadTelemetry';
 import { FrameTelemetry } from '../perf/frameTelemetry';
 import { readDevFlags } from '../perf/devFlags';
 import { buildMetricsJson } from '../perf/metricsJson';
+import type { StreamingDiagnostics } from '../render/streaming/streamingDiagnostics';
 import { backendLabel } from './backendLabel';
 
 /** Live COPC streaming counters — present only while a COPC scan is open. */
@@ -141,6 +142,8 @@ export class DebugOverlay {
   private readonly _telemetry: HTMLElement;
   private readonly _benchmark: HTMLElement;
   private readonly _sample: () => DebugSample;
+  /** The canonical streaming-diagnostics snapshot for the metrics export. */
+  private readonly _diagnostics: () => StreamingDiagnostics | null;
   private _timer: number | undefined;
   /**
    * Per-frame collector (v0.5.5 P0) — constructed here (the overlay only
@@ -152,8 +155,12 @@ export class DebugOverlay {
   /** Most recent polled sample — reused by {@link metricsJson}. */
   private _lastSample: DebugSample | null = null;
 
-  constructor(sample: () => DebugSample) {
+  constructor(
+    sample: () => DebugSample,
+    diagnostics: () => StreamingDiagnostics | null = () => null,
+  ) {
     this._sample = sample;
+    this._diagnostics = diagnostics;
 
     this._live = el('pre', { className: 'olv-debug-block', text: 'initialising…' });
     this._perf = el('pre', { className: 'olv-debug-block', text: '(collecting…)' });
@@ -278,6 +285,7 @@ export class DebugOverlay {
       telemetry: this._perfCollector.snapshot(),
       rendering: sample.stats,
       streaming: sample.streaming ?? null,
+      streamingDiagnostics: this._diagnostics(),
     });
   }
 

--- a/tests/streamingScheduler.test.ts
+++ b/tests/streamingScheduler.test.ts
@@ -144,6 +144,40 @@ test('the scheduler streams every visible node within budget', async () => {
   expect(cloud.residentPointCount).toBe(3100);
 });
 
+test('diagnostics() reports the live streaming state and names what it cannot measure', async () => {
+  const cloud = await openCloud();
+  const scheduler = new StreamingScheduler(
+    cloud,
+    fakeDecoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    streamingBudgets('balanced', false),
+  );
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  const d = scheduler.diagnostics();
+  // Real, measured quantities from the same store the render path draws.
+  expect(d.residentNodes).toBe(5);
+  expect(d.residentPoints).toBe(3100);
+  expect(d.pointBudget).toBeGreaterThan(0);
+  expect(d.cacheMaxBytes).toBeGreaterThan(0);
+  // The five fields the scheduler does not track are null AND named — never faked.
+  expect(d.generationId).toBeNull();
+  expect(d.decodeRetryCount).toBeNull();
+  expect(d.uploadPendingNodes).toBeNull();
+  expect(d.uploadPendingBytes).toBeNull();
+  expect(d.residentDecodedBytes).toBeNull();
+  expect(d.unavailable).toEqual(
+    expect.arrayContaining([
+      'generationId',
+      'decodeRetryCount',
+      'uploadPendingNodes',
+      'uploadPendingBytes',
+      'residentDecodedBytes',
+    ]),
+  );
+});
+
 test('nodes at real UTM-scale coordinates still reach resident (origin-localisation guard)', async () => {
   // Regression guard for the v0.6.0-alpha.1 EPT blank-render bug: node bounds
   // were offset by the render origin twice, so every node at a large projected


### PR DESCRIPTION
Wave 1 #8. The staged `streamingDiagnostics` record (32 fields, each a number or a literal `null` named under `unavailable`) was assembled nowhere.

- **`StreamingScheduler.diagnostics()`** builds it from the **same** readiness facts the phase machine acts on and the live store / cache counters. The five fields the scheduler genuinely doesn't track — generation id, decode-retry total, GPU-upload depth/bytes, resident decoded bytes — stay `null` and are **named** under `unavailable`, never estimated.
- The `?debug=1` overlay's **metrics JSON now carries this record verbatim** under `streamingDiagnostics`, so a bug-report attachment has the canonical numbers rather than a re-derived subset. Threaded via a diagnostics accessor into `DebugOverlay` (no growth to the shrink-only `main.ts` / `Viewer.ts`).
- `streamingDiagnostics` graduates out of `unreachable-modules`.

The overlay's own text formatter is deliberately unchanged — a later step can repoint it at this record, and surfacing the five `unavailable` fields needs upstream scheduler changes (also deferred). tsc clean, full suite green (13,862), new scheduler test asserts the live values and the named-null honesty.