### PR TITLE
fix(preflight): wire "load a second scan" to the Add dataset picker

### DIFF
--- a/src/app/preflightActions.ts
+++ b/src/app/preflightActions.ts
@@ -16,6 +16,8 @@
  *                            flag are shown
  *   solo-active-layer      → isolate the active layer (`LayerService.soloOnly`)
  *   classify-scan          → run the classification derive
+ *   load-second-scan       → open the add-a-dataset file picker (the same one
+ *                            the "+ Add dataset" control opens)
  *   continue-exploratory   → arm the measurement anyway. Honest because the
  *   continue-resident-only   figure keeps its own label: `measureConfidence`
  *                            already marks it approximate in the measure bar and
@@ -29,9 +31,6 @@
  *   await-full-coverage — waiting is not an action the app performs; the
  *                         streaming source refines on its own, and a control
  *                         that "waits" would do nothing.
- *   load-second-scan    — the app has no add-a-scan control while a scan is
- *                         open; a second scan arrives by drag-and-drop or from
- *                         the empty state's picker.
  *   align-scans         — placement onto the shared project frame is automatic
  *                         and there is no user-invocable align step to offer.
  *
@@ -57,12 +56,13 @@ export interface PreflightActionHost {
   classifyScan?(): void;
   /** Arm a measurement so the user may proceed with the stated caveat. */
   armMeasurement?(kind: MeasurementKind): void;
+  /** Open the add-a-dataset file picker so a second scan can be loaded. */
+  addDataset?(): void;
 }
 
 /** The actions no host can perform — see the header for why each one is here. */
 export const UNPERFORMABLE_ACTIONS: readonly PreflightActionId[] = [
   'await-full-coverage',
-  'load-second-scan',
   'align-scans',
 ];
 
@@ -95,8 +95,9 @@ function handlerFor(
       const arm = host.armMeasurement;
       return kind !== null && arm ? () => arm(kind) : null;
     }
-    case 'await-full-coverage':
     case 'load-second-scan':
+      return host.addDataset ? () => host.addDataset?.() : null;
+    case 'await-full-coverage':
     case 'align-scans':
       return null;
   }

--- a/src/app/processStudioMount.ts
+++ b/src/app/processStudioMount.ts
@@ -272,6 +272,8 @@ export interface ProcessStudioShell {
   focusCrs(): void;
   /** Reveal the layer list (the `inspect-layer-crs` remediation). */
   focusLayers(): void;
+  /** Open the add-a-dataset file picker (the `load-second-scan` remediation). */
+  addDataset(): void;
 }
 
 /**
@@ -329,6 +331,7 @@ export function createProcessStudioFromShell(shell: ProcessStudioShell): Mounted
         if (id !== null) shell.soloLayer(id);
       },
       classifyScan: () => shell.classifyScan(),
+      addDataset: () => shell.addDataset(),
       // Proceeding arms the tool; the figure keeps the exploratory label the
       // measure surfaces already give it, so nothing here re-states the caveat.
       armMeasurement: (kind) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2240,7 +2240,7 @@ const processStudio = createProcessStudioFromShell({
   crsService, classLegend: classLegendPanel,
   resolveLayerCrs: (name, detected) => crsService.resolveFor({ name, detected: detected ?? undefined, source: 'las-vlr' }),
   soloLayer: (id) => layerService.soloOnly(id), classifyScan: () => { void runDeriveClassification(); },
-  focusCrs: () => { inspector.focusCrsOverride(); }, focusLayers: () => { inspector.focusLayers(); },
+  focusCrs: () => { inspector.focusCrsOverride(); }, focusLayers: () => { inspector.focusLayers(); }, addDataset: () => { stage.promptAddDataset(); },
 });
 
 // Manual classification-edit panel — lazy-loaded below the legend on first

--- a/src/ui/Stage.ts
+++ b/src/ui/Stage.ts
@@ -235,6 +235,15 @@ export class Stage {
     mount.append(this.root);
   }
 
+  /**
+   * Open the add-a-dataset file picker — the same one the "+ Add dataset" button
+   * opens. Lets a host (e.g. the preflight "load a second scan" remediation)
+   * reach the one ingest path without the user hunting for the control.
+   */
+  promptAddDataset(): void {
+    this._addDataset.click();
+  }
+
   /** Hide the empty state once the first cloud loads; reveal the version. */
   hideEmptyState(): void {
     this._empty.classList.add('olv-hidden');

--- a/tests/processStudioProfileCloseRepro.test.ts
+++ b/tests/processStudioProfileCloseRepro.test.ts
@@ -197,7 +197,7 @@ function buildRig() {
     crsService: crsService as never,
     classLegend: { presentCodes: () => [2], classificationIsDerived: () => false },
     resolveLayerCrs: () => metreCrs,
-    soloLayer: () => {}, classifyScan: () => {}, focusCrs: () => {}, focusLayers: () => {},
+    soloLayer: () => {}, classifyScan: () => {}, focusCrs: () => {}, focusLayers: () => {}, addDataset: () => {},
   });
 
   // The shell's reveal/reset handler (main.ts): resolved → refresh+show; null → clearProduced+hide.

--- a/tests/toolPreflightWiring.test.ts
+++ b/tests/toolPreflightWiring.test.ts
@@ -118,12 +118,13 @@ interface Performed {
   focusLayers: number;
   solo: string[];
   classify: number;
+  addDataset: number;
   measureMode: boolean[];
   kinds: string[];
 }
 
 function fakeShell(options: FakeShellOptions = {}): { shell: ProcessStudioShell; done: Performed } {
-  const done: Performed = { focusCrs: 0, focusLayers: 0, solo: [], classify: 0, measureMode: [], kinds: [] };
+  const done: Performed = { focusCrs: 0, focusLayers: 0, solo: [], classify: 0, addDataset: 0, measureMode: [], kinds: [] };
   const companions = options.companions ?? [];
   const viewer: StudioViewer = {
     streamingCloud: null,
@@ -157,6 +158,7 @@ function fakeShell(options: FakeShellOptions = {}): { shell: ProcessStudioShell;
     classifyScan: () => { done.classify += 1; },
     focusCrs: () => { done.focusCrs += 1; },
     focusLayers: () => { done.focusLayers += 1; },
+    addDataset: () => { done.addDataset += 1; },
   };
   return { shell, done };
 }
@@ -265,6 +267,7 @@ describe('remediation dispatch', () => {
     soloActiveLayer: () => {},
     classifyScan: () => {},
     armMeasurement: () => {},
+    addDataset: () => {},
   };
 
   it('carries out every action a host can perform', () => {
@@ -273,6 +276,20 @@ describe('remediation dispatch', () => {
     expect(runner.canRun('inspect-layer-crs', 'measure-area')).toBe(true);
     expect(runner.canRun('solo-active-layer', 'measure-area')).toBe(true);
     expect(runner.canRun('classify-scan', 'terrain-dtm')).toBe(true);
+  });
+
+  it('runs "load a second scan" through the host, which opens the add-dataset picker', () => {
+    const { shell, done } = fakeShell();
+    const runner = createPreflightActionRunner({ addDataset: () => shell.addDataset() });
+    expect(runner.canRun('load-second-scan', 'cross-epoch-change')).toBe(true);
+    expect(runner.run('load-second-scan', 'cross-epoch-change')).toBe(true);
+    expect(done.addDataset).toBe(1);
+  });
+
+  it('reports "load a second scan" unavailable when the host cannot add one', () => {
+    const runner = createPreflightActionRunner({});
+    expect(runner.canRun('load-second-scan', 'cross-epoch-change')).toBe(false);
+    expect(runner.run('load-second-scan', 'cross-epoch-change')).toBe(false);
   });
 
   it('offers "continue" only for a measurement, where proceeding is a real action', () => {


### PR DESCRIPTION
Bonus A. The preflight remediation for a tool that needs a second scan was listed under `UNPERFORMABLE_ACTIONS`, on the stale premise that "the app has no add-a-scan control while a scan is open" — but the persistent **"+ Add dataset"** control has since shipped (`Stage`).

- Route `load-second-scan` to a new `PreflightActionHost.addDataset()` that opens that same picker via a new `Stage.promptAddDataset()`, reusing the one ingest path.
- Remove `load-second-scan` from `UNPERFORMABLE_ACTIONS`; correct the header prose.
- No growth to the shrink-only `main.ts` (the shell wiring rides an existing line).

The remediation now performs the action instead of reporting itself absent. tsc clean, full suite green (13,866), new wiring tests (performs when wired, reports unavailable when not).