### PR TITLE
fix(contour): make ContourStudio.json interval self-describing by unit (§5)

### DIFF
--- a/src/terrain/export/contourDeliverableBuild.ts
+++ b/src/terrain/export/contourDeliverableBuild.ts
@@ -253,7 +253,12 @@ function gatherDeliverable(
           contourStudioDeliverableJson(result.generationParams, {
             contourMethod: opts.contourMethod ?? null,
             purpose: opts.deliverablePurpose ?? null,
-            intervalM: model?.intervalM ?? NaN,
+            // The interval is in the SOURCE vertical unit; it ships with its unit
+            // label and the metres-per-unit factor (null when unknown), so the
+            // JSON never puts a source-unit number in a metre-labelled field.
+            interval: model?.intervalM ?? NaN,
+            intervalUnit: verticalUnit,
+            verticalUnitToMetres: vScale != null && Number.isFinite(vScale) && vScale > 0 ? vScale : null,
             software: provenance.software,
             softwareVersion: provenance.softwareVersion,
             generatedAt: opts.generatedAt.toISOString(),

--- a/src/terrain/export/contourDeliverableJson.ts
+++ b/src/terrain/export/contourDeliverableJson.ts
@@ -26,6 +26,7 @@ function finiteOrNull(v: number): number | null {
  */
 export function validationDeliverableJson(v: ValidationReport): Record<string, unknown> {
   return {
+    schemaVersion: VALIDATION_JSON_SCHEMA,
     estimand: v.estimand,
     method: v.method,
     coverageMode: v.coverageMode,
@@ -52,13 +53,26 @@ export interface ContourStudioJsonContext {
   readonly contourMethod: string | null;
   /** The Contour Studio purpose that produced the deliverable, or null. */
   readonly purpose: string | null;
-  /** The contour interval, in the source vertical unit. */
-  readonly intervalM: number;
+  /** The contour interval, in the SOURCE vertical unit (see {@link intervalUnit}). */
+  readonly interval: number;
+  /** The vertical unit the interval is in — `m` / `ft` / `ftUS` / `units` / `unknown`. */
+  readonly intervalUnit: string;
+  /**
+   * Metres per vertical unit, when the source declares a resolvable vertical
+   * unit — used to emit an SI `intervalMetres` alongside the source value. Null
+   * when the unit is unknown, so no fake metre value is written.
+   */
+  readonly verticalUnitToMetres: number | null;
   readonly software: string;
   readonly softwareVersion: string;
   /** ISO timestamp the deliverable was generated. */
   readonly generatedAt: string;
 }
+
+/** Schema version of the {@link contourStudioDeliverableJson} payload. */
+export const CONTOUR_STUDIO_JSON_SCHEMA = 2;
+/** Schema version of the {@link validationDeliverableJson} payload. */
+export const VALIDATION_JSON_SCHEMA = 1;
 
 /**
  * The ContourStudio.json payload: the exact settings that produced this
@@ -69,10 +83,20 @@ export function contourStudioDeliverableJson(
   params: AnalyseGenerationParams,
   ctx: ContourStudioJsonContext,
 ): Record<string, unknown> {
+  const interval = finiteOrNull(ctx.interval);
+  // SI value ONLY when the vertical unit resolves — an unknown unit ships no
+  // metre value rather than a source-unit number in a metre-labelled field.
+  const intervalMetres =
+    interval !== null && ctx.verticalUnitToMetres != null && Number.isFinite(ctx.verticalUnitToMetres)
+      ? interval * ctx.verticalUnitToMetres
+      : null;
   return {
+    schemaVersion: CONTOUR_STUDIO_JSON_SCHEMA,
     contourMethod: ctx.contourMethod,
     purpose: ctx.purpose,
-    intervalM: finiteOrNull(ctx.intervalM),
+    interval,
+    intervalUnit: ctx.intervalUnit,
+    intervalMetres,
     contourStyle: params.contourStyle,
     interpolation: params.interpolation,
     aggregation: params.aggregation,

--- a/tests/contourDeliverableJson.test.ts
+++ b/tests/contourDeliverableJson.test.ts
@@ -68,34 +68,57 @@ describe('validationDeliverableJson', () => {
   });
 });
 
+const studioCtx = (over: Record<string, unknown> = {}) => ({
+  contourMethod: 'olv.contour.generalize@1',
+  purpose: 'presentation-map',
+  interval: 0.5,
+  intervalUnit: 'm',
+  verticalUnitToMetres: 1,
+  software: 'OpenLiDARViewer',
+  softwareVersion: '0.6.9',
+  generatedAt: '2026-08-31T00:00:00.000Z',
+  ...over,
+});
+
 describe('contourStudioDeliverableJson', () => {
   it('reflects the real generation settings, not defaults', () => {
-    const j = contourStudioDeliverableJson(params, {
-      contourMethod: 'olv.contour.generalize@1',
-      purpose: 'presentation-map',
-      intervalM: 0.5,
-      software: 'OpenLiDARViewer',
-      softwareVersion: '0.6.9',
-      generatedAt: '2026-08-31T00:00:00.000Z',
-    });
+    const j = contourStudioDeliverableJson(params, studioCtx());
+    expect(j.schemaVersion).toBe(2);
     expect(j.contourStyle).toBe('generalized');
     expect(j.interpolation).toBe('idw');
     expect(j.aggregation).toBe('median');
     expect(j.generalizeToleranceCells).toBe(1.5);
     expect(j.contourMethod).toBe('olv.contour.generalize@1');
     expect(j.purpose).toBe('presentation-map');
-    expect(j.intervalM).toBe(0.5);
   });
 
-  it('reports a non-finite interval as null', () => {
-    const j = contourStudioDeliverableJson(params, {
-      contourMethod: null,
-      purpose: null,
-      intervalM: NaN,
-      software: 'OpenLiDARViewer',
-      softwareVersion: '0.6.9',
-      generatedAt: '2026-08-31T00:00:00.000Z',
-    });
-    expect(j.intervalM).toBeNull();
+  it('a metre project carries its interval, unit, and matching SI metres', () => {
+    const j = contourStudioDeliverableJson(params, studioCtx({ interval: 0.5, intervalUnit: 'm', verticalUnitToMetres: 1 }));
+    expect(j.interval).toBe(0.5);
+    expect(j.intervalUnit).toBe('m');
+    expect(j.intervalMetres).toBe(0.5);
+    // The metre-labelled value equals the source value only because the unit IS metre.
+    expect('intervalM' in j).toBe(false);
+  });
+
+  it('a US survey foot project converts the interval to SI, not a fake metre', () => {
+    // 2 ftUS × (1200/3937) m/ftUS = 0.6096012192 m.
+    const j = contourStudioDeliverableJson(params, studioCtx({ interval: 2, intervalUnit: 'ftUS', verticalUnitToMetres: 1200 / 3937 }));
+    expect(j.interval).toBe(2);
+    expect(j.intervalUnit).toBe('ftUS');
+    expect(j.intervalMetres).toBeCloseTo(0.6096012192, 9);
+  });
+
+  it('an unknown vertical unit ships NO metres value, never a fabricated one', () => {
+    const j = contourStudioDeliverableJson(params, studioCtx({ interval: 2, intervalUnit: 'unknown', verticalUnitToMetres: null }));
+    expect(j.interval).toBe(2);
+    expect(j.intervalUnit).toBe('unknown');
+    expect(j.intervalMetres).toBeNull();
+  });
+
+  it('reports a non-finite interval as null (and no SI metres)', () => {
+    const j = contourStudioDeliverableJson(params, studioCtx({ interval: NaN, intervalUnit: 'unknown', verticalUnitToMetres: null }));
+    expect(j.interval).toBeNull();
+    expect(j.intervalMetres).toBeNull();
   });
 });


### PR DESCRIPTION
Final-hardening §5 (contour-package unit semantics). Verified against the current tree: `Provenance.json` already pairs `contourIntervalM` with `contourIntervalUnit`, but `ContourStudio.json` still emitted `intervalM` carrying a **source-unit** value (its own doc said "in the source vertical unit"). An external consumer reading a metre-labelled field would misread a foot-unit project.

- Replace `intervalM` with **`interval` + `intervalUnit`** (the real vertical unit) and an SI **`intervalMetres`** emitted only when the vertical unit resolves — `null` otherwise, never a fabricated metre.
- Add **`schemaVersion`** to the ContourStudio.json and Validation.json payloads.
- Tests cover metre / US-survey-foot (2 ftUS → 0.6096012192 m) / unknown-unit projects.

Other §5/§11 checks came back already-done (Provenance.json self-describing, horizontal/vertical units separate, SHA256SUMS closed over the included set). tsc clean, full suite green (13,870).