### PR TITLE
fix(change): name the independent-cell uncertainty model in the change summary (§4)

### DIFF
--- a/src/terrain/change/compareDtms.ts
+++ b/src/terrain/change/compareDtms.ts
@@ -295,8 +295,8 @@ export function summarizeChange(comparison: EpochComparison, ctx: ChangeSummaryC
       } else {
         lines.push(
           u.detectable
-            ? `Volume uncertainty: ±${u.sigmaM3.toFixed(1)} m³ (1σ, ${(u.relativeError * 100).toFixed(0)}% relative); ${u.confidence} confidence.`
-            : `Net volume is below the level of detection: ±${u.sigmaM3.toFixed(1)} m³ (1σ) — not distinguishable from noise.`,
+            ? `Independent-cell model uncertainty: ±${u.sigmaM3.toFixed(1)} m³ (1σ, ${(u.relativeError * 100).toFixed(0)}% relative). Net volume exceeds the selected 1.96σ threshold under the independent-cell uncertainty model.`
+            : `Independent-cell model uncertainty: ±${u.sigmaM3.toFixed(1)} m³ (1σ) — net volume is below the selected 1.96σ threshold, not distinguishable from noise.`,
         );
       }
       if (!(ctx.registrationSigmaM && ctx.registrationSigmaM > 0)) {

--- a/tests/compareDtms.test.ts
+++ b/tests/compareDtms.test.ts
@@ -148,7 +148,7 @@ describe('summarizeChange', () => {
     const a = grid([1, 1, 1, 1], 2, 2);
     const b = grid([2, 2, 2, 2], 2, 2);
     const lines = summarizeChange(compareDtms(a, b), { horizontalUnitToMetres: 1, registrationSigmaM: 0.02 });
-    expect(lines.some((l) => /Volume uncertainty|below the level of detection/.test(l))).toBe(true);
+    expect(lines.some((l) => /Independent-cell model uncertainty|below the selected 1\.96σ threshold/.test(l))).toBe(true);
   });
 
   it('flags the band as a lower bound when the co-registration error is unquantified (#3)', () => {


### PR DESCRIPTION
Final-hardening §4 (change-uncertainty terminology). The DoD model identity (`model: 'independent-cells'`, covariance-refused) shipped in #763, but the primary user-facing summary still printed **"Volume uncertainty: ±X m³ … ; high confidence"** — which reads as a calibrated probability and doesn't name its model.

- Reword to **"Independent-cell model uncertainty: ±X m³ (1σ, Y% relative). Net volume exceeds the selected 1.96σ threshold under the independent-cell uncertainty model."** (§4.1 label + §4.4 detectability framing).
- **Drop the uncalibrated "confidence" tier from this scientific line** (§4.2's "remove the tier from scientific outputs" — chosen over relabelling, since the tier is *high-confidence = low-error* and a naive "relative-uncertainty tier" rename would invert its meaning). The numeric % relative stays.
- Data model's `confidence` field + tests unchanged; `UNCERTAINTY-BAND` evidence level **not** promoted; net-volume-exceeds-threshold is not asserted as independently-established spatial change.

Historical release notes / contour-grade "confidence" (a different concept) left untouched. tsc clean, full suite green (13,867).