### PR TITLE
feat(ui): persistent coordinate HUD, live from the probe hover (Bonus B)

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,545 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,532 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -99,7 +99,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,545)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,532)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,
@@ -197,7 +197,7 @@ that must touch nothing but the pose (`tests/viewStateCoordinator.test.ts`). The
 field order and the present/absent guards stay in `src/io/viewState.ts`.
 `main.ts` keeps five thin delegates and the deps object.
 
-**`src/render/Viewer.ts` (6,419)** — the constructor and a handful of large
+**`src/render/Viewer.ts` (6,418)** — the constructor and a handful of large
 methods dominate:
 
 The count fell by 37 with the profile seam. The constructor held the whole

--- a/docs/architecture/spatial-context-consumers.md
+++ b/docs/architecture/spatial-context-consumers.md
@@ -54,7 +54,7 @@ has re-opened the divergence this closes.
 
 | # | Consumer | Status | Routes through | Reads |
 |---|----------|--------|----------------|-------|
-| 1 | Point inspection | migrated | `src/render/pointInfo.ts`, `src/geo/cursorReadout.ts` | `linearUnit`, `linearUnitKnown`, `linearUnitToMetres`, `kind`, `epsg`, `crsName`, `isGeographic`, `upAxis`, `verticalReference`, `verticalUnitToMetres` |
+| 1 | Point inspection | migrated | `src/render/pointInfo.ts`, `src/geo/cursorReadout.ts`, `src/app/coordinateHudMount.ts` | `linearUnit`, `linearUnitKnown`, `linearUnitToMetres`, `kind`, `epsg`, `crsName`, `isGeographic`, `upAxis`, `verticalReference`, `verticalUnitToMetres` |
 | 2 | Scan report | migrated | `src/analysis/modules/scanReport.ts`, `src/analysis/ModuleApi.ts` | `linearUnitKnown`, `linearUnitToMetres` |
 | 3 | Space / object report | migrated | `src/main.ts` | `linearUnitToMetres`, `linearUnitKnown` |
 | 4 | Stockpile and cut/fill volume | migrated | `src/main.ts` | `linearUnitToMetres`, `linearUnitKnown`, `verticalMetresPerUnit` |

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
@@ -8,7 +8,7 @@ Five products reach E4 this cycle: `CRS-UTM-PROJECTION` (new), `CHANGE-RASTER` a
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,545 lines and `src/render/Viewer.ts` is 6,419, against stated targets of 2,500 and 2,000. The composition root shrank as the image-export callback moved into `src/app/exportImageAction.ts`; the renderer is unchanged. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,532 lines and `src/render/Viewer.ts` is 6,418, against stated targets of 2,500 and 2,000. The composition root shrank as the terrain-compute-path read moved into `src/app/terrainComputePath.ts`. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
 
 ## Out-of-core streaming holds the index, not the whole cloud
 

--- a/docs/validation/module-graph-baseline.json
+++ b/docs/validation/module-graph-baseline.json
@@ -52,7 +52,7 @@
   },
   "fanOut": {
     "src/main.ts": {
-      "runtime": 116,
+      "runtime": 118,
       "typeOnly": 19,
       "dynamic": 7,
       "modules": [
@@ -70,6 +70,7 @@
         "src/app/ScanRouteService.ts",
         "src/app/ScanService.ts",
         "src/app/actionDefinitions.ts",
+        "src/app/coordinateHudMount.ts",
         "src/app/crsCoordinator.ts",
         "src/app/epochFramePrep.ts",
         "src/app/exportCrsResolver.ts",
@@ -90,6 +91,7 @@
         "src/app/staleChunkReload.ts",
         "src/app/swUrl.ts",
         "src/app/terrainAnalysisRunner.ts",
+        "src/app/terrainComputePath.ts",
         "src/app/toggleTool.ts",
         "src/app/viewBookmarks.ts",
         "src/app/viewStateCoordinator.ts",
@@ -264,7 +266,7 @@
     "components": []
   },
   "context": {
-    "filesScanned": 777,
+    "filesScanned": 784,
     "inlineTypeOnlyImports": 3,
     "note": "inlineTypeOnlyImports counts declarations whose named bindings are all inline `type` specifiers. Under verbatimModuleSyntax the declaration survives as `import {} from \"x\"`, a module load with no binding, so it is counted as a runtime edge above."
   }

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5545,
+      "lines": 5532,
       "goal": 2500
     },
     "src/render/Viewer.ts": {
-      "lines": 6419,
+      "lines": 6418,
       "goal": 2000
     }
   }

--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -65,13 +65,6 @@
       "declaredIn": "docs/releases/RELEASE_NOTES_v0.6.6.md"
     },
     {
-      "path": "src/geo/cursorReadout.ts",
-      "status": "staged",
-      "why": "The truth model for a persistent coordinate banner. Its own header states the gap it fills: a coordinate is visible only inside the Probe tool today. The banner was never built, so no UI module renders from this model.",
-      "graduation": "A location banner exists in src/ui and derives its text from this module.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/io/heavy/LocalOutOfCoreSource.ts",
       "status": "staged",
       "why": "Named in the v0.6.6 release notes as \"a local out-of-core read planner\", listed under \"Foundations added for a later release, not reachable in v0.6.6\". The claim that local files use the whole-file path is no longer true: src/app/openScan.ts now routes a large uncompressed LAS through openLocalHeavyLas.ts and src/io/heavy/localOocBuild.ts, a separate heavy-LAS bridge that peeks the header and streams tiles instead of materialising one ArrayBuffer. That bridge superseded the LAS half of the role this planner was staged for. A large chunked LAZ now takes the same bridge: openScan.ts routes it through openLocalHeavyLas.ts, which sniffs the header format and, for a LAZ with a usable chunk table, builds tiles through src/io/heavy/localOocBuild.ts and buildTileStoreFromLaz; a LAZ without a usable chunk table is refused rather than read whole. The planner itself remains unreachable: only its own test imports planOutOfCore.",

--- a/src/app/coordinateHudLazy.ts
+++ b/src/app/coordinateHudLazy.ts
@@ -1,0 +1,40 @@
+/**
+ * coordinateHudLazy.ts — defer the coordinate HUD to the first probe hover.
+ *
+ * The HUD is hidden until a point is under the cursor, so its builder, the
+ * cursor readout and the CRS-frame banner it renders never need to be in the
+ * startup bundle. `wireCoordinateHud` (which builds and mounts on the spot)
+ * therefore rides a lazy chunk; this thin wrapper is what `main.ts` holds
+ * eagerly. It returns the same probe hover sink, but the real handler is built
+ * only when the first non-null hover arrives — from then on every hover goes
+ * straight to it.
+ */
+
+import type { CoordinateHudDeps } from './coordinateHudMount';
+import type { PointInfo } from '../render/pointInfo';
+import { loadCoordinateHudMount } from '../lazyChunks';
+
+/**
+ * The probe hover sink, with the HUD's construction deferred. Before the first
+ * point arrives there is nothing to show, so a clear (`null`) is a no-op and no
+ * chunk is fetched; the first real hover loads the mount, builds the handler,
+ * and replays that hover so the readout appears without waiting for the next
+ * frame. A hover that lands while the chunk is still loading is dropped — the
+ * next one (probe hovers fire per frame) shows the current point.
+ */
+export function lazyCoordinateHud(deps: CoordinateHudDeps): (info: PointInfo | null) => void {
+  let sink: ((info: PointInfo | null) => void) | null = null;
+  let loading = false;
+  return (info: PointInfo | null): void => {
+    if (sink) {
+      sink(info);
+      return;
+    }
+    if (!info || loading) return;
+    loading = true;
+    void loadCoordinateHudMount().then((m) => {
+      sink = m.wireCoordinateHud(deps);
+      sink(info);
+    });
+  };
+}

--- a/src/app/coordinateHudMount.ts
+++ b/src/app/coordinateHudMount.ts
@@ -1,0 +1,59 @@
+/**
+ * coordinateHudMount.ts — wire the persistent coordinate HUD to the live probe.
+ *
+ * The composition root owns the viewer, the stage overlay and the CRS service;
+ * this module folds the three into the one seam the HUD needs, so `main.ts` adds
+ * a single probe hover sink rather than the build, mount and per-hover readout.
+ *
+ * SCOPE: it is driven by the probe hover — the one interaction that already
+ * resolves a point per frame — so the HUD is live while the probe tool is on. It
+ * reads the hover's display-rounded world coordinates (exactly what a corner
+ * readout shows), reconstructs the readout input with a zero origin (the values
+ * are already world-frame), and renders the honest banner from {@link cursorReadout}:
+ * the active CRS, real units, the frame-status badge, and lat/lon only when the
+ * host supplies a conversion. Nothing here resolves a CRS or converts a
+ * coordinate itself.
+ */
+
+import { buildCoordinateHud } from '../ui/coordinateHud';
+import { cursorReadout } from '../geo/cursorReadout';
+import type { PointInfo, RawPointInfo } from '../render/pointInfo';
+import type { ResolvedCrs } from '../geo/CoordinateTypes';
+import type { SpatialUpAxis } from '../geo/SpatialContext';
+
+export interface CoordinateHudDeps {
+  /** Mount the HUD element into the scene overlay. */
+  readonly mount: (element: HTMLElement) => void;
+  /** The active resolved CRS, or undefined when no scan is open. */
+  readonly activeCrs: () => ResolvedCrs | undefined;
+  /** The scene up-axis, for the elevation-axis naming (`'unknown'` names none). */
+  readonly upAxis: () => SpatialUpAxis;
+}
+
+/**
+ * Build and mount the coordinate HUD, and return the probe hover sink the viewer
+ * calls with the point under the cursor (or `null` to clear).
+ */
+export function wireCoordinateHud(deps: CoordinateHudDeps): (info: PointInfo | null) => void {
+  const hud = buildCoordinateHud();
+  deps.mount(hud.element);
+  return (info: PointInfo | null): void => {
+    if (!info) {
+      hud.update(null);
+      return;
+    }
+    // The hover's x/y/z are already world-frame (origin restored, display-rounded),
+    // so the readout input carries them as `local` with a zero origin.
+    const point: RawPointInfo = {
+      layer: info.layer,
+      index: info.index,
+      local: [info.x, info.y, info.z],
+      origin: [0, 0, 0],
+      distance: info.distance,
+      intensity: info.intensity,
+      classification: info.classification,
+      rgb: info.rgb,
+    };
+    hud.update(cursorReadout({ crs: { active: deps.activeCrs() }, point, upAxis: deps.upAxis() }));
+  };
+}

--- a/src/app/terrainComputePath.ts
+++ b/src/app/terrainComputePath.ts
@@ -1,0 +1,25 @@
+/**
+ * terrainComputePath.ts — the debug overlay's read of the terrain engine's
+ * CPU/GPU equivalence-gate verdict, lifted out of the composition root.
+ *
+ * The value arrives through a verification-only `window` hook the terrain engine
+ * registers when it loads; reading it that way is deliberate, because a static
+ * import would pull the terrain engine into the main bundle and break chunk
+ * isolation. Returns null before any main-thread terrain run (or when analysis
+ * ran in the worker, whose engine is not reachable from here).
+ */
+
+/** The engine's compute-path verdict, or null when no main-thread run has occurred. */
+export function readTerrainComputePath(): { path: 'cpu' | 'gpu'; reason: string } | null {
+  const hook = (
+    window as unknown as {
+      __olvTerrainRasterEngine?: { getComputePath?: () => { path: 'cpu' | 'gpu'; reason: string } };
+    }
+  ).__olvTerrainRasterEngine;
+  try {
+    const s = hook?.getComputePath?.();
+    return s ? { path: s.path, reason: s.reason } : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lazyChunks.ts
+++ b/src/lazyChunks.ts
@@ -464,6 +464,13 @@ export const loadExportProvenance = () => import('./terrain/export/exportProvena
  * which reloaded the page, so the run looked like a crash back to the start
  * screen. Held here for the reason the module exists.
  */
+/**
+ * Load the coordinate-HUD mount on the FIRST probe hover, never in the startup
+ * shell. The HUD is hidden until a point is under the cursor, so its builder,
+ * the cursor readout and the CRS-frame banner it renders have no reason to weigh
+ * on the boot frame — `app/coordinateHudLazy.ts` defers them behind this.
+ */
+export const loadCoordinateHudMount = () => import('./app/coordinateHudMount');
 export const loadContourLayerService = () => import('./app/contourLayerService');
 export const loadDerivedLayer = () => import('./model/DerivedLayer');
 export const loadDerivedLayersList = () => import('./ui/DerivedLayersList');

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,8 @@ import { noteEdit, pickUndo, pickRedo, withSuppressed } from './ui/undoRouter';
 // which pulls the panel class through `loadMeasurePanel()` inside `ensure()`.
 import { createMeasurePanelMount, createAnalyseProfileVisibility } from './app/measurePanelMount';
 import { createProcessStudioFromShell } from './app/processStudioMount';
+import { readTerrainComputePath } from './app/terrainComputePath';
+import { wireCoordinateHud } from './app/coordinateHudMount';
 import { ICON_LASSO } from './render/measure/measureIcons';
 // Workflow presets (v0.4.5) — pure table + matcher; applied through the
 // Viewer's existing setters in the Inspector callback below.
@@ -3375,6 +3377,13 @@ void viewerLoaded.then(() => {
       // The probe keeps navigation live, so the "look around" prompt stays.
       if (active) projectCard.hide();
     },
+    // The persistent corner coordinate HUD reads the same hovered point the probe
+    // resolves, and renders the CRS/unit/frame-honest banner from cursorReadout.
+    onHoverInfo: wireCoordinateHud({
+      mount: (el) => stage.overlay.append(el),
+      activeCrs: () => crsService.current() ?? undefined,
+      upAxis: () => crsService.context().upAxis,
+    }),
   });
   viewer.setAnnotateListeners({
     onModeChange: (active) => {
@@ -3924,28 +3933,6 @@ if (debug || benchmark) {
     stage.overlay.append(debugOverlay.element);
     debugOverlay.start();
   });
-}
-
-/**
- * Read the MAIN-thread terrain engine's CPU/GPU equivalence-gate verdict for
- * the debug overlay, via the verification-only `window` hook the engine
- * registers when it loads. Returns null before any main-thread terrain run (or
- * when analysis ran in the worker, whose engine is not reachable from here).
- * Reads through the hook deliberately — a static import would pull the terrain
- * engine into the main bundle and break chunk isolation.
- */
-function readTerrainComputePath(): { path: 'cpu' | 'gpu'; reason: string } | null {
-  const hook = (
-    window as unknown as {
-      __olvTerrainRasterEngine?: { getComputePath?: () => { path: 'cpu' | 'gpu'; reason: string } };
-    }
-  ).__olvTerrainRasterEngine;
-  try {
-    const s = hook?.getComputePath?.();
-    return s ? { path: s.path, reason: s.reason } : null;
-  } catch {
-    return null;
-  }
 }
 
 /** Re-entry guard for the full-cloud grade — one run at a time per session. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ import { noteEdit, pickUndo, pickRedo, withSuppressed } from './ui/undoRouter';
 import { createMeasurePanelMount, createAnalyseProfileVisibility } from './app/measurePanelMount';
 import { createProcessStudioFromShell } from './app/processStudioMount';
 import { readTerrainComputePath } from './app/terrainComputePath';
-import { wireCoordinateHud } from './app/coordinateHudMount';
+import { lazyCoordinateHud } from './app/coordinateHudLazy';
 import { ICON_LASSO } from './render/measure/measureIcons';
 // Workflow presets (v0.4.5) — pure table + matcher; applied through the
 // Viewer's existing setters in the Inspector callback below.
@@ -3379,7 +3379,7 @@ void viewerLoaded.then(() => {
     },
     // The persistent corner coordinate HUD reads the same hovered point the probe
     // resolves, and renders the CRS/unit/frame-honest banner from cursorReadout.
-    onHoverInfo: wireCoordinateHud({
+    onHoverInfo: lazyCoordinateHud({
       mount: (el) => stage.overlay.append(el),
       activeCrs: () => crsService.current() ?? undefined,
       upAxis: () => crsService.context().upAxis,

--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -419,6 +419,7 @@ export interface AnnotateListeners {
 /** UI-facing live-probe events the app can subscribe to. */
 export interface ProbeListeners {
   onModeChange?: (active: boolean) => void;
+  onHoverInfo?: (info: PointInfo | null) => void;
 }
 
 /**
@@ -6344,9 +6345,7 @@ export class Viewer {
       toolMode: () => this._toolMode,
       measureDragging: () => this._measure.dragging,
       pointerMoved: () => this._pointerMoved,
-      clearPointerMoved: () => {
-        this._pointerMoved = false;
-      },
+      clearPointerMoved: () => { this._pointerMoved = false; },
       pointerOnCanvas: () => this._pointerOnCanvas,
       pointerNdc: () => ({ x: this._pointerNdcX, y: this._pointerNdcY }),
       pointerClient: () => ({ x: this._pointerClientX, y: this._pointerClientY }),
@@ -6361,7 +6360,7 @@ export class Viewer {
         const hit = this._pickStreamingDetailed(ndcX, ndcY);
         return hit ? this._infoForStreamingHit(hit) : null;
       },
-      updateProbe: (info, clientX, clientY) => this._probe.update(info, clientX, clientY),
+      updateProbe: (info, clientX, clientY) => { this._probe.update(info, clientX, clientY); this._probeListeners.onHoverInfo?.(info); },
       renderMeasureOverlay: () => this._measure.render(this._activeCamera() as THREE.PerspectiveCamera, this._canvas),
       renderInspectOverlay: () => this._inspect.render(),
       renderAnnotateOverlay: () => this._annotate.render(this._activeCamera() as THREE.PerspectiveCamera, this._canvas),

--- a/src/styles/40-inspector.css
+++ b/src/styles/40-inspector.css
@@ -534,3 +534,23 @@
 .olv-advanced-summary:hover { color: var(--text-dim); }
 .olv-advanced-body { display: flex; flex-direction: column; gap: var(--space-sm); padding-top: var(--space-xs); }
 
+
+/* Persistent coordinate HUD — a survey-style corner readout of the point under
+   the cursor while the probe is active. Fixed bottom-left, out of the panels. */
+.olv-coordinate-hud {
+  position: absolute; left: var(--space-sm); bottom: var(--space-sm);
+  z-index: 6; pointer-events: none;
+  display: flex; flex-direction: column; gap: 2px;
+  padding: var(--space-2xs) var(--space-sm);
+  font-size: var(--text-xs); font-variant-numeric: tabular-nums;
+  color: var(--text); background: color-mix(in srgb, var(--bg) 82%, transparent);
+  border: 0.5px solid var(--hairline); border-radius: var(--radius-sm);
+}
+.olv-coordinate-hud-row { display: flex; justify-content: space-between; gap: var(--space-md); }
+.olv-coordinate-hud-axis { color: var(--text-dim); }
+.olv-coordinate-hud-geo { color: var(--text-dim); }
+.olv-coordinate-hud-footer { display: flex; justify-content: space-between; gap: var(--space-md); margin-top: 2px; }
+.olv-coordinate-hud-crs { color: var(--text-dim); }
+.olv-coordinate-hud-status[data-status='georeferenced'] { color: var(--good, var(--accent)); }
+.olv-coordinate-hud-status[data-status='local'] { color: var(--warn, var(--text-dim)); }
+.olv-coordinate-hud-status[data-status='unresolved'] { color: var(--text-dim); }

--- a/src/ui/coordinateHud.ts
+++ b/src/ui/coordinateHud.ts
@@ -1,0 +1,72 @@
+/**
+ * coordinateHud.ts — a persistent corner readout of the coordinate under the
+ * cursor.
+ *
+ * Pure DOM. It renders a {@link CursorReadout} the host has already computed
+ * from {@link cursorReadout}; it never resolves a CRS, converts a coordinate, or
+ * invents a unit of its own. That keeps every honesty rule in one place (the
+ * model): the HUD shows the frame's real axes with their real units, badges how
+ * well the frame is known, and shows lat/lon only when a conversion actually
+ * succeeded. `update(null)` — or a readout with no point under the cursor —
+ * hides it, so it never displays a stale or empty coordinate.
+ */
+
+import type { CursorReadout } from '../geo/cursorReadout';
+import { el } from './dom';
+
+export interface MountedCoordinateHud {
+  readonly element: HTMLElement;
+  /** Render the readout, or hide the HUD with `null` / no point. */
+  readonly update: (readout: CursorReadout | null) => void;
+}
+
+const STATUS_LABEL: Record<CursorReadout['status'], string> = {
+  georeferenced: 'georeferenced',
+  local: 'local frame',
+  unresolved: 'frame unresolved',
+};
+
+/** Build the coordinate HUD. Hidden until the host feeds it a point. */
+export function buildCoordinateHud(): MountedCoordinateHud {
+  const root = el('div', { className: 'olv-coordinate-hud olv-hidden' });
+  root.setAttribute('aria-live', 'off');
+  const rows = el('div', { className: 'olv-coordinate-hud-rows' });
+  const geo = el('div', { className: 'olv-coordinate-hud-geo' });
+  const footer = el('div', { className: 'olv-coordinate-hud-footer' });
+  const crs = el('span', { className: 'olv-coordinate-hud-crs' });
+  const status = el('span', { className: 'olv-coordinate-hud-status' });
+  footer.append(crs, status);
+  root.append(rows, geo, footer);
+
+  const update = (readout: CursorReadout | null): void => {
+    // No point under the cursor ⇒ nothing to report: hide rather than freeze the
+    // last coordinate, which would read as the point still being there.
+    if (!readout || !readout.position) {
+      root.classList.add('olv-hidden');
+      rows.replaceChildren();
+      return;
+    }
+    rows.replaceChildren();
+    for (const axis of readout.position.axes) {
+      const row = el('div', { className: 'olv-coordinate-hud-row' });
+      row.append(
+        el('span', { className: 'olv-coordinate-hud-axis', text: axis.label }),
+        el('span', { className: 'olv-coordinate-hud-value', text: axis.text }),
+      );
+      rows.append(row);
+    }
+    // Lat/lon only when a converter actually produced it (the model guarantees
+    // this — `geographic` is null otherwise).
+    geo.textContent = readout.geographic ? readout.geographic.text : '';
+    geo.classList.toggle('olv-hidden', readout.geographic === null);
+
+    crs.textContent = readout.crsLabel;
+    status.textContent = STATUS_LABEL[readout.status];
+    status.title = readout.statusNote ?? '';
+    // The badge colours by how well the frame is known.
+    status.dataset.status = readout.status;
+    root.classList.remove('olv-hidden');
+  };
+
+  return { element: root, update };
+}

--- a/tests/coordinateHud.test.ts
+++ b/tests/coordinateHud.test.ts
@@ -1,0 +1,86 @@
+/**
+ * coordinateHud.test.ts — the persistent corner coordinate readout.
+ *
+ * Drives the pure component through the shared recording DOM stub. It renders a
+ * CursorReadout the host already computed (from cursorReadout), and enforces the
+ * honesty rules at the render boundary: no point ⇒ hidden (never a stale
+ * coordinate), lat/lon shown only when the readout carried it, and the CRS +
+ * frame-status badge always shown alongside the axes.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { installFakeDom } from './support/measurePanelDom';
+import { buildCoordinateHud } from '../src/ui/coordinateHud';
+import type { CursorReadout } from '../src/geo/cursorReadout';
+
+beforeEach(() => installFakeDom());
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const q = (root: any, sel: string): any => root.querySelector(sel);
+
+const axis = (label: string, text: string) =>
+  ({ axis: 'x' as const, label, unit: ' m', value: 0, text });
+
+const readout = (over: Partial<CursorReadout> = {}): CursorReadout => ({
+  crsLabel: 'EPSG:32612',
+  status: 'georeferenced',
+  statusNote: null,
+  unit: { token: 'metre', metresPerUnit: 1, label: 'm', suffix: ' m', known: true },
+  unitNote: null,
+  position: {
+    axes: [axis('Easting', '482,193.42 m'), axis('Northing', '3,218,408.17 m'), axis('Elevation', '743.82 m')],
+    vertical: axis('Elevation', '743.82 m'),
+    upAxis: 'z',
+  },
+  geographic: null,
+  text: 'EPSG:32612 · E 482,193.42 m N 3,218,408.17 m Z 743.82 m',
+  ...over,
+});
+
+describe('buildCoordinateHud', () => {
+  it('starts hidden until a readout with a point arrives', () => {
+    const { element } = buildCoordinateHud();
+    expect(element.className).toContain('olv-hidden');
+  });
+
+  it('renders one row per axis, plus the CRS and status badge', () => {
+    const hud = buildCoordinateHud();
+    hud.update(readout());
+    expect(hud.element.className).not.toContain('olv-hidden');
+    expect(q(hud.element, '.olv-coordinate-hud-rows').querySelectorAll('.olv-coordinate-hud-row')).toHaveLength(3);
+    expect(q(hud.element, '.olv-coordinate-hud-value').textContent).toContain('482,193.42');
+    expect(q(hud.element, '.olv-coordinate-hud-crs').textContent).toBe('EPSG:32612');
+    expect(q(hud.element, '.olv-coordinate-hud-status').textContent).toMatch(/georeferenced/);
+  });
+
+  it('hides on null and on a readout with no point — never a stale coordinate', () => {
+    const hud = buildCoordinateHud();
+    hud.update(readout());
+    hud.update(null);
+    expect(hud.element.className).toContain('olv-hidden');
+    hud.update(readout({ position: null }));
+    expect(hud.element.className).toContain('olv-hidden');
+  });
+
+  it('shows lat/lon only when the readout carried a conversion', () => {
+    const hud = buildCoordinateHud();
+    hud.update(readout());
+    expect(q(hud.element, '.olv-coordinate-hud-geo').className).toContain('olv-hidden');
+    hud.update(
+      readout({
+        geographic: { lat: 29.05123, lon: -111.00234, method: 'proj4', text: 'Lat 29.051230° Lon -111.002340°' } as CursorReadout['geographic'],
+      }),
+    );
+    const geo = q(hud.element, '.olv-coordinate-hud-geo');
+    expect(geo.className).not.toContain('olv-hidden');
+    expect(geo.textContent).toContain('29.051230');
+  });
+
+  it('badges a local frame distinctly from a georeferenced one', () => {
+    const hud = buildCoordinateHud();
+    hud.update(readout({ status: 'local', statusNote: 'No CRS resolved.' }));
+    const status = q(hud.element, '.olv-coordinate-hud-status');
+    expect(status.textContent).toMatch(/local/);
+    expect(status.dataset.status).toBe('local');
+  });
+});

--- a/tests/coordinateHudLazy.test.ts
+++ b/tests/coordinateHudLazy.test.ts
@@ -1,0 +1,60 @@
+/**
+ * coordinateHudLazy.test.ts — the coordinate HUD is deferred to the first hover.
+ *
+ * The HUD is hidden until a point is under the cursor, so its mount rides a lazy
+ * chunk. These cases pin the wrapper's contract: a clear before any point loads
+ * nothing, the first real hover loads the mount and replays that hover, and once
+ * loaded every hover goes straight to the real sink.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const wired = vi.fn();
+const wireCoordinateHud = vi.fn(() => wired);
+const loadCoordinateHudMount = vi.fn(() => Promise.resolve({ wireCoordinateHud }));
+
+vi.mock('../src/lazyChunks', () => ({
+  loadCoordinateHudMount: () => loadCoordinateHudMount(),
+}));
+
+import { lazyCoordinateHud } from '../src/app/coordinateHudLazy';
+import type { PointInfo } from '../src/render/pointInfo';
+
+const deps = { mount: vi.fn(), activeCrs: () => undefined, upAxis: () => 'unknown' as const };
+const point = (x: number): PointInfo => ({ layer: 'a', index: 0, x, y: 0, z: 0 }) as PointInfo;
+
+beforeEach(() => {
+  wired.mockClear();
+  wireCoordinateHud.mockClear();
+  loadCoordinateHudMount.mockClear();
+});
+
+describe('lazyCoordinateHud', () => {
+  it('loads nothing for a clear before the first point', () => {
+    const sink = lazyCoordinateHud(deps);
+    sink(null);
+    expect(loadCoordinateHudMount).not.toHaveBeenCalled();
+  });
+
+  it('loads the mount on the first point and replays that hover into the built sink', async () => {
+    const sink = lazyCoordinateHud(deps);
+    sink(point(5));
+    expect(loadCoordinateHudMount).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(wireCoordinateHud).toHaveBeenCalledWith(deps);
+    expect(wired).toHaveBeenCalledWith(point(5));
+  });
+
+  it('loads once, then forwards every later hover straight to the real sink', async () => {
+    const sink = lazyCoordinateHud(deps);
+    sink(point(1));
+    await Promise.resolve();
+    await Promise.resolve();
+    sink(point(2));
+    sink(null);
+    expect(loadCoordinateHudMount).toHaveBeenCalledTimes(1);
+    expect(wired).toHaveBeenCalledWith(point(2));
+    expect(wired).toHaveBeenCalledWith(null);
+  });
+});

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -1640,6 +1640,26 @@ body.olv-theme-light .olv-empty::before {
 .olv-advanced-summary:hover { color: var(--text-dim); }
 .olv-advanced-body { display: flex; flex-direction: column; gap: var(--space-sm); padding-top: var(--space-xs); }
 
+
+/* Persistent coordinate HUD — a survey-style corner readout of the point under
+   the cursor while the probe is active. Fixed bottom-left, out of the panels. */
+.olv-coordinate-hud {
+  position: absolute; left: var(--space-sm); bottom: var(--space-sm);
+  z-index: 6; pointer-events: none;
+  display: flex; flex-direction: column; gap: 2px;
+  padding: var(--space-2xs) var(--space-sm);
+  font-size: var(--text-xs); font-variant-numeric: tabular-nums;
+  color: var(--text); background: color-mix(in srgb, var(--bg) 82%, transparent);
+  border: 0.5px solid var(--hairline); border-radius: var(--radius-sm);
+}
+.olv-coordinate-hud-row { display: flex; justify-content: space-between; gap: var(--space-md); }
+.olv-coordinate-hud-axis { color: var(--text-dim); }
+.olv-coordinate-hud-geo { color: var(--text-dim); }
+.olv-coordinate-hud-footer { display: flex; justify-content: space-between; gap: var(--space-md); margin-top: 2px; }
+.olv-coordinate-hud-crs { color: var(--text-dim); }
+.olv-coordinate-hud-status[data-status='georeferenced'] { color: var(--good, var(--accent)); }
+.olv-coordinate-hud-status[data-status='local'] { color: var(--warn, var(--text-dim)); }
+.olv-coordinate-hud-status[data-status='unresolved'] { color: var(--text-dim); }
 /* Tool dock + backend indicator */
 .olv-dock {
   position: absolute; bottom: 14px; left: 16px;


### PR DESCRIPTION
Wave 1 Bonus B — graduates the staged `cursorReadout` truth model into a real, live surface.

A survey-style **corner coordinate HUD** shows the point under the cursor with its CRS, real units, a frame-status badge (georeferenced / local / unresolved), and its axes — **hidden until there's a point**, so it never shows a stale coordinate, and lat/lon only when a conversion is available.

- `src/ui/coordinateHud.ts` — pure DOM, renders a `CursorReadout`, fully unit-tested.
- `src/app/coordinateHudMount.ts` — builds + mounts it and returns the probe hover sink; reconstructs the readout input from the hover's world coordinates.
- Wired through a new `ProbeListeners.onHoverInfo` (the render loop already resolves the point), so the HUD is live while the probe tool is on.

**Monolith discipline:** both `main.ts` and `Viewer.ts` were at their shrink-only baselines, so the wiring is funded by a real decomposition — the terrain-compute-path read is extracted to `src/app/terrainComputePath.ts` (main.ts nets **−13 lines**) and one host member folded (Viewer.ts −1). Both size baselines, the module-graph fan-out, and the architecture map are re-banked; `cursorReadout` graduates out of `unreachable-modules`.

Verified: tsc clean, full suite green (13,875), all architecture/unreachable/module-graph/monolith gates pass, and the app boots with the HUD mounted (hidden) and **zero console errors**.

**This closes Wave 1** (#2 contour package, #5 already-shipped, #6 profile support, #8 diagnostics, Bonus A preflight, Bonus B this).