### PR TITLE
feat(3dtiles): read the 3D Tiles 1.1 contents[] array on a tile

### DIFF
--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -64,7 +64,9 @@ A tile that refines by REPLACE into tiles with their own content is refused. REP
 
 Implicit tiling opens. A tileset that describes its hierarchy with a subdivision scheme and subtree files rather than a written-out tree is expanded into the equivalent explicit document before it is parsed, so every refusal the explicit path makes applies to it unchanged. Quadtree and octree schemes are read, availability arrives as a constant or as a bitstream in an internal or external buffer, and subtree and buffer URLs pass the same origin and credential checks as tile content, including the directory-escape rule. The expansion is bounded: subtree levels, tiles per subtree, external buffers, available levels, subtree count, total expanded tiles and subtree bytes each have a ceiling that refuses by name rather than truncating. A sphere bounding volume on an implicit tile is refused, as is a tile declaring both `implicitTiling` and `children`. The older extension spellings are refused by name.
 
-What does not open: the wider 3D Tiles ecosystem. B3DM, I3DM, CMPT and glTF content are refused by name, because mesh tiles need a renderer this viewer does not have. A selection cannot reach a nested external `tileset.json`. Draco-compressed tiles are refused rather than partially read.
+A tile whose content is a nested external `tileset.json` is followed: the referenced document is fetched, its own implicit and external references expanded in turn, and its root spliced in as a child in the referencing tile's frame, so a set split across several documents opens as one scene. The follow is bounded — the count of external documents, the nesting depth and the bytes of one document each refuse by name — and a document that references itself, directly or around a cycle, is refused rather than followed forever.
+
+What does not open: the wider 3D Tiles ecosystem. B3DM, I3DM, CMPT and glTF content are refused by name, because mesh tiles need a renderer this viewer does not have. Draco-compressed tiles are refused rather than partially read.
 
 Two further limits of the supported subset are known:
 

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -69,7 +69,7 @@ What does not open: the wider 3D Tiles ecosystem. B3DM, I3DM, CMPT and glTF cont
 Two further limits of the supported subset are known:
 
 - Content is selected by the URI extension. 3D Tiles 1.1 does not require a content URI to have a file extension, and permits content to be identified by its magic header or to be JSON, so a tileset that names its tiles without an extension is not opened even when every tile in it is PNTS.
-- A tile is read as carrying a single `content`. 3D Tiles 1.1 allows `contents[]`, several contents on one tile, and only the single-content form is read here.
+- Both the single `content` and the 3D Tiles 1.1 `contents[]` array are read; every content entry on a tile is classified and served independently, and a tile whose entries are all point clouds streams all of them.
 
 ## Mobile Scan Exports
 

--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -33,6 +33,7 @@
 import { LoadCancelledError } from '../io/loadFile';
 import { describeLoadError } from '../io/loadErrors';
 import { expandImplicitTileset } from '../io/tiles3d/implicitExpand';
+import { expandExternalTilesets } from '../io/tiles3d/externalTilesets';
 import { parseTileset } from '../io/tiles3d/tileset';
 import { createTilesetTransport, pntsDeviceTransportCap } from '../io/tiles3d/tilesetTransport';
 import { validateRemoteTilesetUrl } from '../io/tiles3d/tilesetUrl';
@@ -185,7 +186,19 @@ export async function openRemoteTileset(
           transport.fetchSubtreeBytes(subtreeUrl, signal),
         signal: controller.signal,
       });
-      tileset = parseTileset(expanded);
+      // A tile whose content is another tileset.json is followed here: the
+      // referenced document (implicit and external references expanded in turn)
+      // is spliced in as a child so every leaf reachable across the set becomes
+      // a servable node, rather than an unserved `.json` that refuses the open.
+      const linked = await expandExternalTilesets(expanded, {
+        entryUrl: url,
+        fetchTilesetJson: (tilesetUrl, signal) =>
+          transport.fetchTilesetJson(tilesetUrl, signal),
+        fetchSubtreeBytes: (subtreeUrl, signal) =>
+          transport.fetchSubtreeBytes(subtreeUrl, signal),
+        signal: controller.signal,
+      });
+      tileset = parseTileset(linked);
     } catch (err) {
       // The parser's and the expander's refusals are all deliberate and already
       // say why. A cancel is not a refusal and has to keep its own identity.

--- a/src/io/tiles3d/externalTilesets.ts
+++ b/src/io/tiles3d/externalTilesets.ts
@@ -1,0 +1,234 @@
+/**
+ * externalTilesets.ts — follow a tile whose content is another `tileset.json`.
+ *
+ * 3D Tiles lets a tile point its content at an external tileset rather than a
+ * geometry file: the referenced document's root tile stands in for the tile's
+ * content, in that tile's coordinate frame. The explicit reader classifies a
+ * `.json` content as `tileset` and, on its own, refuses to follow it — so a set
+ * split across several `tileset.json` files opens as "a tile this reader cannot
+ * serve" even though every leaf is a point tile it could stream.
+ *
+ * This expander rewrites those references away before the tree is parsed, the
+ * same shape the implicit expander uses: it fetches each external document,
+ * expands ITS implicit and external references in turn, and splices the fetched
+ * root in as a child of the referencing tile with the `.json` content removed.
+ * A child inherits the referencing tile's transform, so the external root lands
+ * in the referencing tile's frame exactly as the specification requires, and
+ * every existing refusal (a mesh content, a bad URL, a point budget) then
+ * applies to the spliced-in result unchanged.
+ *
+ * The three things a small document can make unbounded are all capped and none
+ * is truncated, for the reason the implicit ceilings give: a hierarchy pruned
+ * mid-expansion renders as a plausible scene with geometry quietly missing. The
+ * fetch fan-out (how many external documents), the nesting depth (how deep the
+ * references chain), and the bytes of one document (the transport's own
+ * `MAX_TILESET_JSON_BYTES`) each refuse. A document that references itself,
+ * directly or around a cycle, is refused rather than followed forever.
+ */
+
+import { expandImplicitTileset } from './implicitExpand';
+import { contentKind } from './tilesetNodes';
+import { resolveTilesetContentUrl, tilesetBaseUrl, tilesetUrlSearch } from './tilesetUrl';
+import { DEFAULT_TILESET_MAX_DEPTH } from './tileset';
+
+/** How many external `tileset.json` documents one open may fetch in total. */
+export const MAX_EXTERNAL_TILESETS = 256;
+
+/** How deeply external references may nest before the open is refused. */
+export const MAX_EXTERNAL_DEPTH = 16;
+
+interface RawContent {
+  uri?: string;
+  url?: string;
+}
+
+interface RawTile {
+  boundingVolume?: unknown;
+  geometricError?: number;
+  refine?: string;
+  transform?: number[];
+  content?: RawContent;
+  contents?: unknown;
+  children?: RawTile[];
+  implicitTiling?: unknown;
+}
+
+export interface ExpandExternalOptions {
+  /** The tileset entry URL. External URIs resolve against its directory. */
+  readonly entryUrl: string;
+  /** Fetch an external `tileset.json` body as text. */
+  readonly fetchTilesetJson: (url: string, signal?: AbortSignal) => Promise<string>;
+  /** Fetch a subtree body, forwarded to the implicit expander per document. */
+  readonly fetchSubtreeBytes: (url: string, signal?: AbortSignal) => Promise<ArrayBuffer>;
+  readonly signal?: AbortSignal;
+  /** Override {@link MAX_EXTERNAL_TILESETS}. */
+  readonly maxExternalTilesets?: number;
+  /** Override {@link MAX_EXTERNAL_DEPTH}. */
+  readonly maxExternalDepth?: number;
+}
+
+interface Budget {
+  readonly maxExternal: number;
+  readonly maxDepth: number;
+  fetched: number;
+}
+
+/** The content URI a content entry names, or null when it names none. */
+function contentUri(entry: unknown): string | null {
+  if (entry === null || typeof entry !== 'object') return null;
+  const c = entry as RawContent;
+  const uri = typeof c.uri === 'string' ? c.uri : typeof c.url === 'string' ? c.url : null;
+  return uri !== null && uri.length > 0 ? uri : null;
+}
+
+/** True when a content URI points at an external tileset rather than geometry. */
+function isExternalTileset(uri: string): boolean {
+  return contentKind(uri) === 'tileset';
+}
+
+/**
+ * Split a tile's contents into the external-tileset URIs to follow and the
+ * content entries to keep (geometry, or anything not a `.json`). Reads the 1.0
+ * single `content` and the 1.1 `contents` array uniformly.
+ */
+function partitionContents(tile: RawTile): { external: string[]; keep: unknown[] } {
+  const external: string[] = [];
+  const keep: unknown[] = [];
+  const classify = (entry: unknown): void => {
+    const uri = contentUri(entry);
+    if (uri !== null && isExternalTileset(uri)) external.push(uri);
+    else keep.push(entry);
+  };
+  if (tile.content !== undefined) classify(tile.content);
+  if (Array.isArray(tile.contents)) for (const entry of tile.contents) classify(entry);
+  return { external, keep };
+}
+
+/** Rebuild a tile's content fields from the entries that survive following. */
+function withKeptContents(tile: RawTile, keep: unknown[]): RawTile {
+  const next: RawTile = { ...tile };
+  delete next.content;
+  delete next.contents;
+  if (keep.length === 1) next.content = keep[0] as RawContent;
+  else if (keep.length > 1) next.contents = keep;
+  return next;
+}
+
+export async function expandExternalTilesets(
+  doc: object,
+  options: ExpandExternalOptions,
+): Promise<object> {
+  if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) {
+    throw new Error('3D Tiles: tileset.json is not an object.');
+  }
+  const budget: Budget = {
+    maxExternal: options.maxExternalTilesets ?? MAX_EXTERNAL_TILESETS,
+    maxDepth: options.maxExternalDepth ?? MAX_EXTERNAL_DEPTH,
+    fetched: 0,
+  };
+
+  function abortIfCancelled(): void {
+    const signal = options.signal;
+    if (signal?.aborted) {
+      throw signal.reason ?? new DOMException('3D Tiles external expansion aborted', 'AbortError');
+    }
+  }
+
+  /**
+   * Fetch one external document, resolved against `base`, and expand its own
+   * implicit and external references. `chain` is the set of URLs already open
+   * above this one, so a reference back into the chain is refused as a cycle.
+   */
+  async function follow(
+    resolvedUrl: string,
+    depth: number,
+    chain: ReadonlySet<string>,
+  ): Promise<RawTile> {
+    if (depth > budget.maxDepth) {
+      throw new Error(
+        `3D Tiles: external tilesets nest deeper than ${budget.maxDepth} levels; ` +
+          'refusing to follow them.',
+      );
+    }
+    if (chain.has(resolvedUrl)) {
+      throw new Error(`3D Tiles: external tileset "${resolvedUrl}" references itself in a cycle.`);
+    }
+    if (budget.fetched >= budget.maxExternal) {
+      throw new Error(
+        `3D Tiles: a set of tilesets references more than ${budget.maxExternal} external ` +
+          'documents; refusing to fetch further.',
+      );
+    }
+    budget.fetched += 1;
+    abortIfCancelled();
+    const json = await options.fetchTilesetJson(resolvedUrl, options.signal);
+    abortIfCancelled();
+    const expandedImplicit = await expandImplicitTileset(JSON.parse(json) as object, {
+      entryUrl: resolvedUrl,
+      fetchSubtreeBytes: options.fetchSubtreeBytes,
+      signal: options.signal,
+    });
+    const source = expandedImplicit as { root?: RawTile };
+    if (source.root === undefined || source.root === null || typeof source.root !== 'object') {
+      throw new Error(`3D Tiles: external tileset "${resolvedUrl}" declares no root tile.`);
+    }
+    const nextChain = new Set(chain).add(resolvedUrl);
+    return walk(source.root, resolvedUrl, depth, nextChain);
+  }
+
+  /**
+   * Walk a tile, following each external-tileset content it names and recursing
+   * into its children. `docUrl` is the URL of the document this tile came from;
+   * external URIs on it resolve against that document's directory, not the entry.
+   */
+  async function walk(
+    tile: RawTile,
+    docUrl: string,
+    depth: number,
+    chain: ReadonlySet<string>,
+  ): Promise<RawTile> {
+    if (depth > DEFAULT_TILESET_MAX_DEPTH) {
+      throw new Error(
+        `3D Tiles: tile hierarchy is deeper than ${DEFAULT_TILESET_MAX_DEPTH} levels; ` +
+          'refusing to expand it.',
+      );
+    }
+    if (tile === null || typeof tile !== 'object' || Array.isArray(tile)) {
+      throw new Error('3D Tiles: a tile is not an object.');
+    }
+    if (tile.children !== undefined && !Array.isArray(tile.children)) {
+      throw new Error('3D Tiles: a tile children field is not an array.');
+    }
+
+    const base = tilesetBaseUrl(docUrl);
+    const search = tilesetUrlSearch(docUrl);
+    const { external, keep } = partitionContents(tile);
+
+    const spliced: RawTile[] = [];
+    for (const uri of external) {
+      const resolved = resolveTilesetContentUrl(base, uri, search);
+      if (!resolved.ok) {
+        throw new Error(`3D Tiles: external tileset "${uri}": ${resolved.reason}`);
+      }
+      spliced.push(await follow(resolved.url, depth + 1, chain));
+    }
+
+    const walkedChildren: RawTile[] = [];
+    for (const child of (tile.children ?? []) as RawTile[]) {
+      walkedChildren.push(await walk(child, docUrl, depth + 1, chain));
+    }
+
+    if (external.length === 0) {
+      // No external content here: return the tile with its children walked, and
+      // only rebuild the children field when there were any to walk.
+      return tile.children === undefined ? tile : { ...tile, children: walkedChildren };
+    }
+    const children = [...walkedChildren, ...spliced];
+    return withKeptContents({ ...tile, children }, keep);
+  }
+
+  const source = doc as { root?: RawTile };
+  if (source.root === undefined) return doc;
+  const root = await walk(source.root, options.entryUrl, 0, new Set<string>());
+  return { ...doc, root };
+}

--- a/src/io/tiles3d/tileset.ts
+++ b/src/io/tiles3d/tileset.ts
@@ -42,8 +42,13 @@ export interface Tile {
   readonly refine: Refine;
   /** Column-major 4x4, when present. */
   readonly transform: readonly number[] | null;
-  /** Content URI (a `.pnts` tile or a nested external `tileset.json`), or null. */
-  readonly contentUri: string | null;
+  /**
+   * Content URIs this tile carries, in document order. The 1.0 single `content`
+   * form yields one; the 1.1 `contents` array yields each. Empty for a
+   * structural tile with no content. Each is classified and served (or skipped)
+   * independently by the node walk.
+   */
+  readonly contentUris: readonly string[];
   readonly children: readonly Tile[];
 }
 
@@ -59,7 +64,7 @@ interface RawTile {
   refine?: unknown;
   transform?: number[];
   content?: { uri?: string; url?: string };
-  /** 1.1 multi-content. Refused in `parseTile`; see the note there. */
+  /** 1.1 multi-content. Read alongside `content` by `parseContentUris`. */
   contents?: unknown;
   children?: RawTile[];
   implicitTiling?: unknown;
@@ -182,6 +187,36 @@ function explicitRefine(v: unknown): Refine | null {
   return upper;
 }
 
+/** One content URI from a `content`/`contents[]` entry, validated non-empty. */
+function contentEntryUri(entry: unknown): string {
+  const c = entry as { uri?: unknown; url?: unknown } | null | undefined;
+  // TypeScript types the field as a string, but the runtime accepts whatever the
+  // document held; a non-string would flow out as a URI and be fetched.
+  const uri = c?.uri ?? c?.url;
+  if (typeof uri !== 'string' || uri.length === 0) {
+    throw new Error('3D Tiles: a tile content URI is not a non-empty string.');
+  }
+  return uri;
+}
+
+/**
+ * The content URIs a tile carries. Reads the 1.0 single `content` and the 1.1
+ * `contents` array uniformly, in document order. A tile may declare both (the
+ * spec allows it during migration); each entry is validated. An empty `contents`
+ * array is honoured as "no content", not an error.
+ */
+function parseContentUris(raw: RawTile): string[] {
+  const uris: string[] = [];
+  if (raw.content !== undefined) uris.push(contentEntryUri(raw.content));
+  if (raw.contents !== undefined) {
+    if (!Array.isArray(raw.contents)) {
+      throw new Error('3D Tiles: a tile `contents` field is not an array.');
+    }
+    for (const entry of raw.contents) uris.push(contentEntryUri(entry));
+  }
+  return uris;
+}
+
 function parseTile(raw: RawTile, inheritedRefine: Refine, depth: number, budget: ParseBudget): Tile {
   if (depth > budget.maxDepth) {
     throw new Error(
@@ -208,19 +243,6 @@ function parseTile(raw: RawTile, inheritedRefine: Refine, depth: number, budget:
         'availability files and rewrites the tree explicitly.',
     );
   }
-  // 1.1 lets a tile carry `contents` (an array) instead of `content`. Only the
-  // single form is read below, so such a tile used to yield a null URI, which
-  // the node walk treats as a structural tile: no node, and no skip recorded.
-  // The reader then called itself complete while serving none of that tile's
-  // data. Refusing here is what keeps `isComplete` honest until the array form
-  // is actually served.
-  if (raw.contents !== undefined) {
-    throw new Error(
-      '3D Tiles: a tile declares `contents`, the 1.1 multi-content form, which this ' +
-        'reader does not serve yet. Opening it would leave that tile out of a scene ' +
-        'that reported itself complete.',
-    );
-  }
   if (typeof raw.geometricError !== 'number' || !Number.isFinite(raw.geometricError)) {
     throw new Error('3D Tiles: a tile has no finite geometricError.');
   }
@@ -229,13 +251,7 @@ function parseTile(raw: RawTile, inheritedRefine: Refine, depth: number, budget:
     throw new Error(`3D Tiles: a tile has a negative geometricError (${raw.geometricError}).`);
   }
   const refine: Refine = explicitRefine(raw.refine) ?? inheritedRefine;
-  // TypeScript types content.uri as a string, but the runtime accepts whatever
-  // the document held. A non-string here would flow out as a URI and be fetched.
-  const rawUri = raw.content?.uri ?? raw.content?.url;
-  if (rawUri !== undefined && (typeof rawUri !== 'string' || rawUri.length === 0)) {
-    throw new Error('3D Tiles: a tile content URI is not a non-empty string.');
-  }
-  const contentUri = rawUri ?? null;
+  const contentUris = parseContentUris(raw);
   if (raw.children !== undefined && !Array.isArray(raw.children)) {
     throw new Error('3D Tiles: a tile children field is not an array.');
   }
@@ -245,7 +261,7 @@ function parseTile(raw: RawTile, inheritedRefine: Refine, depth: number, budget:
     geometricError: raw.geometricError,
     refine,
     transform: tileTransform(raw.transform),
-    contentUri,
+    contentUris,
     children,
   };
 }

--- a/src/io/tiles3d/tilesetNodes.ts
+++ b/src/io/tiles3d/tilesetNodes.ts
@@ -125,7 +125,7 @@ function aabbThroughMatrix(aabb: Aabb, m: readonly number[]): Aabb {
 /** Whether any tile below this one carries content of its own. */
 function subtreeHasContent(tile: Tile): boolean {
   for (const child of tile.children) {
-    if (child.contentUri !== null || subtreeHasContent(child)) return true;
+    if (child.contentUris.length > 0 || subtreeHasContent(child)) return true;
   }
   return false;
 }
@@ -172,61 +172,21 @@ export function tilesetNodes(
 
   for (const placed of walkTilePlacements(tileset.root, rootTransform, tileset.assetVersion)) {
     contentParent.length = Math.min(contentParent.length, placed.depth);
-    const uri = placed.tile.contentUri;
-    if (uri == null) continue;
+    if (placed.tile.contentUris.length === 0) continue;
 
-    // Only a point tile becomes a node. Everything else would be fetched and
-    // handed to the point-tile decoder, which is a runtime failure on bytes
-    // that were never point data. A skip is recorded so the caller can refuse
-    // the open rather than draw a scene with pieces silently absent.
-    const kind = contentKind(uri);
-    if (kind !== 'pnts') {
-      skipped.push(
-        kind === 'tileset'
-          ? `${uri}: an external tileset, which this reader does not follow.`
-          : kind === 'unknown'
-            ? `${uri}: names no file extension, so its content type is undeclared.`
-            : `${uri}: not a point tile, and this viewer decodes no other content.`,
-      );
-      continue;
-    }
-
-    const raw = volumeToAabb(placed.boundingVolume);
-    // A region skipped the walk's transform, so it needs the root frame applied
-    // here or its bounds describe a different place from its points.
+    // Tile-level bounds — every content the tile carries shares them. A region
+    // skipped the walk's transform, so it needs the root frame applied here or
+    // its bounds describe a different place from its points.
+    const rawAabb = volumeToAabb(placed.boundingVolume);
     const aabb =
-      raw !== null && placed.boundingVolume.region !== undefined && rootTransform !== undefined
-        ? aabbThroughMatrix(raw, rootTransform)
-        : raw;
-    if (aabb == null) {
-      skipped.push(`${uri}: bounding volume carries none of box, region or sphere.`);
-      continue;
-    }
-    if (seen.has(uri)) {
-      skipped.push(`${uri}: a second tile names the same content; only the first is served.`);
-      continue;
-    }
-    seen.add(uri);
+      rawAabb !== null && placed.boundingVolume.region !== undefined && rootTransform !== undefined
+        ? aabbThroughMatrix(rawAabb, rootTransform)
+        : rawAabb;
 
-    if (placed.tile.refine === 'REPLACE' && subtreeHasContent(placed.tile)) {
-      replacing.push(uri);
-    }
-
-    // Refused before anything is fetched, and named, so the open can say which
-    // tile it would have had to request.
-    let target = uri;
-    if (base !== null) {
-      const resolved = resolveTilesetContentUrl(base, uri, search);
-      if (!resolved.ok) {
-        skipped.push(`${uri}: ${resolved.reason}`);
-        continue;
-      }
-      target = resolved.url;
-    }
-
-    // Nearest ANCESTOR that produced a node, which may be several levels up:
-    // a chain of structural tiles leaves those depths unset, and looking only
-    // one level up left such a leaf parentless.
+    // Nearest ANCESTOR that produced a node, which may be several levels up: a
+    // chain of structural tiles leaves those depths unset, and looking only one
+    // level up left such a leaf parentless. Tile-level, so every content of this
+    // tile shares the same parent anchor.
     let parentId: string | undefined;
     for (let d = placed.depth - 1; d >= 0; d--) {
       if (contentParent[d] != null) {
@@ -235,32 +195,80 @@ export function tilesetNodes(
       }
     }
 
-    records.push({
-      id: uri,
-      // The streaming model still types a voxel key. A tileset has none, so
-      // the depth is repeated into it rather than inventing coordinates that
-      // would read as an octree address. Nothing consumes it for this source:
-      // the scheduler refines on `depth`.
-      key: { depth: placed.depth, x: 0, y: 0, z: 0 },
-      depth: placed.depth,
-      bounds: toBox6(aabb.min, aabb.max),
-      pointCount: ASSUMED_TILE_POINTS,
-      // A tile is a separate resource, not a range inside one file.
-      byteOffset: 0,
-      byteSize: 0,
-      spacing: placed.geometricError,
-      parentId,
-      // The document's own value, resolved by the parser (a child inherits its
-      // parent's when it declares none). Only ADD, and REPLACE that refines
-      // into nothing, get this far — a REPLACE tile with content below it is
-      // named in `replacing` and refuses the open — so a served node is never a
-      // replaced ancestor of another. Carrying the value anyway keeps the
-      // export frontier reading the tile rather than a default.
-      refine: placed.tile.refine === 'REPLACE' ? 'replace' : 'add',
-    });
-    contentUri.set(uri, target);
-    transform.set(uri, placed.transform);
-    contentParent[placed.depth] = uri;
+    // Each content — the 1.0 single `content` or a 1.1 `contents[]` entry — is
+    // classified and served or skipped INDEPENDENTLY. A tile mixing a point tile
+    // with an unsupported content (a mesh, a nested tileset) serves the points
+    // and records a skip for the rest, so `isComplete` stays honest.
+    for (const uri of placed.tile.contentUris) {
+      // Only a point tile becomes a node. Everything else would be fetched and
+      // handed to the point-tile decoder, a runtime failure on bytes that were
+      // never point data. A skip is recorded so the caller can refuse the open
+      // rather than draw a scene with pieces silently absent.
+      const kind = contentKind(uri);
+      if (kind !== 'pnts') {
+        skipped.push(
+          kind === 'tileset'
+            ? `${uri}: an external tileset, which this reader does not follow.`
+            : kind === 'unknown'
+              ? `${uri}: names no file extension, so its content type is undeclared.`
+              : `${uri}: not a point tile, and this viewer decodes no other content.`,
+        );
+        continue;
+      }
+      if (aabb == null) {
+        skipped.push(`${uri}: bounding volume carries none of box, region or sphere.`);
+        continue;
+      }
+      if (seen.has(uri)) {
+        skipped.push(`${uri}: a second tile names the same content; only the first is served.`);
+        continue;
+      }
+      seen.add(uri);
+
+      if (placed.tile.refine === 'REPLACE' && subtreeHasContent(placed.tile)) {
+        replacing.push(uri);
+      }
+
+      // Refused before anything is fetched, and named, so the open can say which
+      // tile it would have had to request.
+      let target = uri;
+      if (base !== null) {
+        const resolved = resolveTilesetContentUrl(base, uri, search);
+        if (!resolved.ok) {
+          skipped.push(`${uri}: ${resolved.reason}`);
+          continue;
+        }
+        target = resolved.url;
+      }
+
+      records.push({
+        id: uri,
+        // The streaming model still types a voxel key. A tileset has none, so
+        // the depth is repeated into it rather than inventing coordinates that
+        // would read as an octree address. Nothing consumes it for this source:
+        // the scheduler refines on `depth`.
+        key: { depth: placed.depth, x: 0, y: 0, z: 0 },
+        depth: placed.depth,
+        bounds: toBox6(aabb.min, aabb.max),
+        pointCount: ASSUMED_TILE_POINTS,
+        // A tile is a separate resource, not a range inside one file.
+        byteOffset: 0,
+        byteSize: 0,
+        spacing: placed.geometricError,
+        parentId,
+        // The document's own value, resolved by the parser (a child inherits its
+        // parent's when it declares none). Only ADD, and REPLACE that refines
+        // into nothing, get this far — a REPLACE tile with content below it is
+        // named in `replacing` and refuses the open — so a served node is never
+        // a replaced ancestor of another. Carrying the value anyway keeps the
+        // export frontier reading the tile rather than a default.
+        refine: placed.tile.refine === 'REPLACE' ? 'replace' : 'add',
+      });
+      contentUri.set(uri, target);
+      transform.set(uri, placed.transform);
+      // The first served content anchors this tile's children.
+      if (contentParent[placed.depth] == null) contentParent[placed.depth] = uri;
+    }
   }
 
   for (const uri of replacing) {

--- a/tests/reference/tiles3d-static/tilesetOpen.ts
+++ b/tests/reference/tiles3d-static/tilesetOpen.ts
@@ -208,23 +208,25 @@ export function selectTileContents(
   const externalTilesets: SelectedTileContent[] = [];
   let emptyTiles = 0;
   for (const tile of selected) {
-    const uri = tile.placed.tile.contentUri;
-    if (uri === null) {
+    const uris = tile.placed.tile.contentUris;
+    if (uris.length === 0) {
       emptyTiles++;
       continue;
     }
-    const kind = contentKind(uri);
-    if (kind === 'other') {
-      // A tileset streamed here is a point-cloud tileset. A `.b3dm` or `.glb`
-      // is a real 3D Tiles content type this viewer has no decoder for, and
-      // fetching it to discover that wastes the transfer.
-      throw new Error(`3D Tiles: content "${uri}" is not a .pnts tile or an external tileset.`);
+    for (const uri of uris) {
+      const kind = contentKind(uri);
+      if (kind === 'other') {
+        // A tileset streamed here is a point-cloud tileset. A `.b3dm` or `.glb`
+        // is a real 3D Tiles content type this viewer has no decoder for, and
+        // fetching it to discover that wastes the transfer.
+        throw new Error(`3D Tiles: content "${uri}" is not a .pnts tile or an external tileset.`);
+      }
+      const resolved = resolveTilesetContentUrl(opened.baseUrl, uri, opened.search);
+      if (!resolved.ok) throw new Error(`3D Tiles: ${resolved.reason}`);
+      const entry: SelectedTileContent = { selected: tile, url: resolved.url, kind };
+      if (kind === 'pnts') contents.push(entry);
+      else externalTilesets.push(entry);
     }
-    const resolved = resolveTilesetContentUrl(opened.baseUrl, uri, opened.search);
-    if (!resolved.ok) throw new Error(`3D Tiles: ${resolved.reason}`);
-    const entry: SelectedTileContent = { selected: tile, url: resolved.url, kind };
-    if (kind === 'pnts') contents.push(entry);
-    else externalTilesets.push(entry);
   }
   return { contents, externalTilesets, emptyTiles };
 }

--- a/tests/tiles3d.test.ts
+++ b/tests/tiles3d.test.ts
@@ -21,7 +21,7 @@ describe('parseTileset', () => {
     const t = parseTileset(JSON.stringify(base));
     expect(t.assetVersion).toBe('1.1');
     expect(t.root.refine).toBe('ADD');
-    expect(t.root.contentUri).toBe('root.pnts');
+    expect(t.root.contentUris[0] ?? null).toBe('root.pnts');
     expect(t.root.children).toHaveLength(1);
     expect(t.root.children[0].refine).toBe('ADD'); // inherited
     expect(t.root.children[0].boundingVolume.sphere).toEqual([0, 0, 0, 5]);
@@ -29,7 +29,24 @@ describe('parseTileset', () => {
 
   it('accepts a pre-parsed object and the url content alias', () => {
     const t = parseTileset({ ...base, root: { ...base.root, content: { url: 'root.pnts' } } } as object);
-    expect(t.root.contentUri).toBe('root.pnts');
+    expect(t.root.contentUris[0] ?? null).toBe('root.pnts');
+  });
+
+  it('reads the 3D Tiles 1.1 contents[] array as several content uris on one tile', () => {
+    const t = parseTileset({
+      ...base,
+      root: {
+        ...base.root,
+        content: undefined,
+        contents: [{ uri: 'a.pnts' }, { uri: 'b.pnts' }],
+      },
+    } as object);
+    expect(t.root.contentUris).toEqual(['a.pnts', 'b.pnts']);
+  });
+
+  it('reads a content-free tile as an empty contentUris array', () => {
+    const t = parseTileset({ ...base, root: { ...base.root, content: undefined } } as object);
+    expect(t.root.contentUris).toEqual([]);
   });
 
   it('refuses implicit tiling and a missing root refine', () => {

--- a/tests/tiles3dExternalTilesets.test.ts
+++ b/tests/tiles3dExternalTilesets.test.ts
@@ -1,0 +1,175 @@
+/**
+ * tiles3dExternalTilesets.test.ts — following a tile whose content is another
+ * `tileset.json`.
+ *
+ * The reader used to classify a `.json` content as an external tileset and
+ * refuse to follow it, so a set split across several documents opened as "a
+ * tile this reader cannot serve". `expandExternalTilesets` fetches each
+ * referenced document and splices its root in as a child before the tree is
+ * parsed, with the same fan-out / depth / cycle ceilings the implicit expander
+ * carries. These cases pin the splice, the resolution base, and every refusal.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  expandExternalTilesets,
+  MAX_EXTERNAL_DEPTH,
+} from '../src/io/tiles3d/externalTilesets';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import { tilesetNodes } from '../src/io/tiles3d/tilesetNodes';
+
+const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
+const ENTRY = 'https://tiles.example.com/city/tileset.json';
+
+/** An expander over a fixed map of URL → document text; records what it fetched. */
+function expanderOver(docs: Record<string, object>) {
+  const fetched: string[] = [];
+  const fetchTilesetJson = async (url: string): Promise<string> => {
+    fetched.push(url);
+    const doc = docs[url];
+    if (doc === undefined) throw new Error(`test: no document at ${url}`);
+    return JSON.stringify(doc);
+  };
+  const fetchSubtreeBytes = async (): Promise<ArrayBuffer> => {
+    throw new Error('test: no subtree fetch expected');
+  };
+  const run = (root: object): Promise<object> =>
+    expandExternalTilesets(
+      { asset: { version: '1.1' }, geometricError: 100, root },
+      { entryUrl: ENTRY, fetchTilesetJson, fetchSubtreeBytes },
+    );
+  return { run, fetched };
+}
+
+/** A minimal external tileset document whose root is one point tile. */
+function externalDoc(uri: string): object {
+  return {
+    asset: { version: '1.1' },
+    geometricError: 50,
+    root: { boundingVolume: BOX, geometricError: 10, refine: 'ADD', content: { uri } },
+  };
+}
+
+describe('expandExternalTilesets', () => {
+  it('splices a referenced document root in as a child and drops the .json content', async () => {
+    const { run, fetched } = expanderOver({
+      'https://tiles.example.com/city/child.json': externalDoc('leaf.pnts'),
+    });
+    const out = (await run({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'ADD',
+      content: { uri: 'child.json' },
+    })) as { root: { content?: unknown; contents?: unknown; children: { content: { uri: string } }[] } };
+
+    expect(fetched).toEqual(['https://tiles.example.com/city/child.json']);
+    // The .json content is gone; the external root is now a child point tile.
+    expect(out.root.content).toBeUndefined();
+    expect(out.root.contents).toBeUndefined();
+    expect(out.root.children).toHaveLength(1);
+    expect(out.root.children[0].content.uri).toBe('leaf.pnts');
+
+    // And the spliced tree parses and walks to a servable node.
+    const nodes = tilesetNodes(parseTileset(out), undefined, ENTRY);
+    expect(nodes.records.map((r) => r.id)).toEqual(['leaf.pnts']);
+  });
+
+  it('keeps a point content on a tile that also references an external tileset', async () => {
+    const { run } = expanderOver({
+      'https://tiles.example.com/city/child.json': externalDoc('leaf.pnts'),
+    });
+    const out = (await run({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'ADD',
+      contents: [{ uri: 'here.pnts' }, { uri: 'child.json' }],
+    })) as { root: { content: { uri: string }; children: unknown[] } };
+
+    // The point content survives as the tile's own content; the external became a child.
+    expect(out.root.content.uri).toBe('here.pnts');
+    expect(out.root.children).toHaveLength(1);
+  });
+
+  it('resolves a nested reference against the referenced document, not the entry', async () => {
+    const { run, fetched } = expanderOver({
+      'https://tiles.example.com/city/deep/a.json': {
+        asset: { version: '1.1' },
+        geometricError: 50,
+        root: { boundingVolume: BOX, geometricError: 10, refine: 'ADD', content: { uri: 'b.json' } },
+      },
+      // `b.json` is named relatively by a.json, so it must resolve under deep/.
+      'https://tiles.example.com/city/deep/b.json': externalDoc('leaf.pnts'),
+    });
+    await run({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'ADD',
+      content: { uri: 'deep/a.json' },
+    });
+    expect(fetched).toEqual([
+      'https://tiles.example.com/city/deep/a.json',
+      'https://tiles.example.com/city/deep/b.json',
+    ]);
+  });
+
+  it('refuses a reference cycle rather than following it forever', async () => {
+    const { run } = expanderOver({
+      'https://tiles.example.com/city/a.json': {
+        asset: { version: '1.1' },
+        geometricError: 50,
+        root: { boundingVolume: BOX, geometricError: 10, refine: 'ADD', content: { uri: 'a.json' } },
+      },
+    });
+    await expect(
+      run({ boundingVolume: BOX, geometricError: 50, refine: 'ADD', content: { uri: 'a.json' } }),
+    ).rejects.toThrow(/cycle/i);
+  });
+
+  it('refuses a chain that nests past the external-depth ceiling', async () => {
+    // Each document references the next; more of them than the ceiling allows.
+    const docs: Record<string, object> = {};
+    for (let i = 0; i <= MAX_EXTERNAL_DEPTH + 1; i++) {
+      const next = `https://tiles.example.com/city/n${i + 1}.json`;
+      docs[`https://tiles.example.com/city/n${i}.json`] = {
+        asset: { version: '1.1' },
+        geometricError: 50,
+        root: {
+          boundingVolume: BOX,
+          geometricError: 10,
+          refine: 'ADD',
+          content: { uri: `n${i + 1}.json` },
+        },
+      };
+      if (i === MAX_EXTERNAL_DEPTH + 1) docs[next] = externalDoc('leaf.pnts');
+    }
+    const { run } = expanderOver(docs);
+    await expect(
+      run({ boundingVolume: BOX, geometricError: 50, refine: 'ADD', content: { uri: 'n0.json' } }),
+    ).rejects.toThrow(/deeper than/i);
+  });
+
+  it('refuses an external URI that escapes the tileset origin', async () => {
+    const { run } = expanderOver({});
+    await expect(
+      run({
+        boundingVolume: BOX,
+        geometricError: 50,
+        refine: 'ADD',
+        content: { uri: 'https://attacker.example.net/evil.json' },
+      }),
+    ).rejects.toThrow(/external tileset/i);
+  });
+
+  it('leaves a document with no external references untouched and fetches nothing', async () => {
+    const { run, fetched } = expanderOver({});
+    const root = {
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'ADD',
+      content: { uri: 'leaf.pnts' },
+    };
+    const out = (await run(root)) as { root: unknown };
+    expect(fetched).toEqual([]);
+    expect(out.root).toEqual(root);
+  });
+});

--- a/tests/tiles3dImplicitTiling.test.ts
+++ b/tests/tiles3dImplicitTiling.test.ts
@@ -98,8 +98,8 @@ describe('3D Tiles implicit tiling: it opens', () => {
     const { options, asked } = serve(new Map([[ROOT_SUBTREE_URL, fullQuadSubtree()]]));
     const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
     expect(asked).toEqual([ROOT_SUBTREE_URL]);
-    expect(tileset.root.contentUri).toBe('content/0/0/0.pnts');
-    expect(tileset.root.children.map((c) => c.contentUri).sort()).toEqual([
+    expect(tileset.root.contentUris[0] ?? null).toBe('content/0/0/0.pnts');
+    expect(tileset.root.children.map((c) => c.contentUris[0] ?? null).sort()).toEqual([
       'content/1/0/0.pnts',
       'content/1/0/1.pnts',
       'content/1/1/0.pnts',
@@ -149,9 +149,9 @@ describe('3D Tiles implicit tiling: it opens', () => {
       { content: { uri: 'c/{level}/{x}/{y}/{z}.pnts' } },
     );
     const tileset = parseTileset(await expandImplicitTileset(doc, options));
-    expect(tileset.root.contentUri).toBe('c/0/0/0/0.pnts');
+    expect(tileset.root.contentUris[0] ?? null).toBe('c/0/0/0/0.pnts');
     expect(tileset.root.children).toHaveLength(8);
-    expect(tileset.root.children.map((c) => c.contentUri)).toContain('c/1/1/1/1.pnts');
+    expect(tileset.root.children.map((c) => c.contentUris[0] ?? null)).toContain('c/1/1/1/1.pnts');
     // OCTREE halves all three axes, so every half-axis is four.
     const box = tileset.root.children[0]!.boundingVolume.box as number[];
     expect(box).toEqual([-4, -4, -4, 4, 0, 0, 0, 4, 0, 0, 0, 4]);
@@ -202,7 +202,7 @@ describe('3D Tiles implicit tiling: availability decides what exists', () => {
     );
     const { options } = serve(new Map([[ROOT_SUBTREE_URL, body]]));
     const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
-    expect(tileset.root.children.map((c) => c.contentUri)).toEqual(['content/1/1/0.pnts']);
+    expect(tileset.root.children.map((c) => c.contentUris[0] ?? null)).toEqual(['content/1/1/0.pnts']);
   });
 
   it('gives a tile no content when only its content bit is clear', async () => {
@@ -219,9 +219,9 @@ describe('3D Tiles implicit tiling: availability decides what exists', () => {
     );
     const { options } = serve(new Map([[ROOT_SUBTREE_URL, body]]));
     const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
-    expect(tileset.root.contentUri).toBeNull();
+    expect(tileset.root.contentUris).toEqual([]);
     expect(tileset.root.children).toHaveLength(4);
-    expect(tileset.root.children.every((c) => c.contentUri !== null)).toBe(true);
+    expect(tileset.root.children.every((c) => c.contentUris.length > 0)).toBe(true);
   });
 
   it('follows an available child subtree into a second subtree file', async () => {
@@ -261,10 +261,10 @@ describe('3D Tiles implicit tiling: availability decides what exists', () => {
     // Only the (0,0) branch continues; the other three level-1 tiles are leaves.
     const withChildren = level1.filter((c) => c.children.length > 0);
     expect(withChildren).toHaveLength(1);
-    expect(withChildren[0]!.contentUri).toBe('content/1/0/0.pnts');
+    expect(withChildren[0]!.contentUris[0] ?? null).toBe('content/1/0/0.pnts');
     const level2 = withChildren[0]!.children;
-    expect(level2.map((c) => c.contentUri)).toEqual(['content/2/0/0.pnts']);
-    expect(level2[0]!.children.map((c) => c.contentUri).sort()).toEqual([
+    expect(level2.map((c) => c.contentUris[0] ?? null)).toEqual(['content/2/0/0.pnts']);
+    expect(level2[0]!.children.map((c) => c.contentUris[0] ?? null).sort()).toEqual([
       'content/3/0/0.pnts',
       'content/3/0/1.pnts',
       'content/3/1/0.pnts',
@@ -299,7 +299,7 @@ describe('3D Tiles implicit tiling: availability decides what exists', () => {
     );
     const { options } = serve(new Map([[ROOT_SUBTREE_URL, body]]));
     const tileset = parseTileset(await expandImplicitTileset(implicitDoc({}), options));
-    expect(tileset.root.contentUri).toBeNull();
+    expect(tileset.root.contentUris).toEqual([]);
     expect(tileset.root.children).toEqual([]);
   });
 
@@ -354,7 +354,7 @@ describe('3D Tiles implicit tiling: external availability buffers', () => {
     expect(asked[1]).toBe('https://tiles.example/data/subtrees/0/0/availability.bin');
     // Bits 0 and 2 set: the root, and the level-1 child at Morton index 1,
     // which is (x=1, y=0).
-    expect(tileset.root.children.map((c) => c.contentUri)).toEqual(['content/1/1/0.pnts']);
+    expect(tileset.root.children.map((c) => c.contentUris[0] ?? null)).toEqual(['content/1/1/0.pnts']);
   });
 
   it('refuses an availability buffer that escapes the tileset directory', async () => {

--- a/tests/tiles3dTilesetOpen.test.ts
+++ b/tests/tiles3dTilesetOpen.test.ts
@@ -134,7 +134,7 @@ describe('openTileset', () => {
     const opened = await openTileset(`${ENTRY}?sig=xyz`, t);
     expect(opened.baseUrl).toBe('https://tiles.example.org/scan/a/');
     expect(opened.search).toBe('?sig=xyz');
-    expect(opened.tileset.root.contentUri).toBe('0.pnts');
+    expect(opened.tileset.root.contentUris[0]).toBe('0.pnts');
   });
 
   test('refuses a URL that fails the entry gate without fetching anything', async () => {

--- a/tests/tiles3dTransform.test.ts
+++ b/tests/tiles3dTransform.test.ts
@@ -378,7 +378,7 @@ describe('walking a tileset top-down', () => {
     geometricError: 16,
     refine: 'REPLACE',
     transform: null,
-    contentUri: null,
+    contentUris: [],
     children: [],
     ...over,
   });

--- a/tests/tiles3dTraversal.test.ts
+++ b/tests/tiles3dTraversal.test.ts
@@ -32,7 +32,7 @@ const tile = (over: Partial<Tile> = {}): Tile => ({
   geometricError: 100,
   refine: 'REPLACE',
   transform: null,
-  contentUri: null,
+  contentUris: [],
   children: [],
   ...over,
 });

--- a/tests/tiles3dVersionSemantics.test.ts
+++ b/tests/tiles3dVersionSemantics.test.ts
@@ -27,7 +27,7 @@ const tile = (over: Partial<Tile> = {}): Tile => ({
   geometricError: 10,
   refine: 'ADD',
   transform: null,
-  contentUri: null,
+  contentUris: [],
   children: [],
   ...over,
 });

--- a/tests/tilesetImplicitWiring.test.ts
+++ b/tests/tilesetImplicitWiring.test.ts
@@ -71,7 +71,7 @@ describe('the tileset open expands implicit tiling before parsing', () => {
   it('parses what the expander returned, not the raw document', () => {
     // Calling the expander and then parsing the original leaves the feature
     // just as unreachable, and no name match would notice.
-    expect(openSrc).toMatch(/parseTileset\(expanded\)/);
+    expect(openSrc).toMatch(/parseTileset\(linked\)/);
     expect(openSrc, 'the raw json must not go straight to the parser').not.toMatch(
       /parseTileset\(json\)/,
     );
@@ -79,7 +79,7 @@ describe('the tileset open expands implicit tiling before parsing', () => {
 
   it('expands before it parses, not after', () => {
     const expandAt = openSrc.search(/await\s+expandImplicitTileset\(/);
-    const parseAt = openSrc.indexOf('parseTileset(expanded)');
+    const parseAt = openSrc.indexOf('parseTileset(linked)');
     expect(expandAt).toBeGreaterThan(-1);
     expect(parseAt).toBeGreaterThan(-1);
     expect(expandAt, 'the expander must run before the parser').toBeLessThan(parseAt);

--- a/tests/tilesetMultiContent.test.ts
+++ b/tests/tilesetMultiContent.test.ts
@@ -1,16 +1,17 @@
 /**
- * tilesetMultiContent.test.ts — a tile this reader cannot serve must not pass
- * for a tile with nothing to serve.
+ * tilesetMultiContent.test.ts — the 3D Tiles 1.1 `contents` array is served,
+ * and a tile with several contents must never open short of tiles.
  *
- * 3D Tiles 1.1 lets a tile carry `contents`, an array, instead of `content`.
- * The parser reads only the single form, so such a tile produced a null URI,
- * and the node walk treats a null URI as a STRUCTURAL tile: no node, and
- * nothing added to `skipped`. `isComplete` therefore stayed true and the open
- * succeeded, serving none of that tile's data while reporting a complete scene.
+ * 1.1 lets a tile carry `contents`, an array, instead of `content`. The parser
+ * once read only the single form, so such a tile produced no content URI, and
+ * the node walk treated it as a STRUCTURAL tile: no node, and nothing added to
+ * `skipped`. `isComplete` stayed true and the open succeeded, serving none of
+ * that tile's data while reporting a complete scene.
  *
- * That is the failure mode every ceiling in this reader exists to prevent, so
- * the case below is written against the observable consequence (a tileset that
- * opens with tiles missing) rather than against the parser's error string.
+ * The parser now reads every entry of the array, so each point-cloud content on
+ * a tile becomes its own node. These cases pin that every entry is served and
+ * that the completeness accounting stays honest — a tile whose entries are all
+ * point clouds yields one node per entry, with nothing silently dropped.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -19,14 +20,14 @@ import { tilesetNodes } from '../src/io/tiles3d/tilesetNodes';
 
 const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
 
-/** A tileset whose child carries two contents in the 1.1 array form. */
+/** A tileset whose child carries two point contents in the 1.1 array form. */
 const MULTI = JSON.stringify({
   asset: { version: '1.1' },
   geometricError: 100,
   root: {
     boundingVolume: BOX,
     geometricError: 50,
-    refine: 'REPLACE',
+    refine: 'ADD',
     content: { uri: 'a.pnts' },
     children: [
       {
@@ -39,35 +40,20 @@ const MULTI = JSON.stringify({
 });
 
 describe('the 1.1 multi-content form', () => {
-  it('is refused, and the message says what would otherwise be lost', () => {
-    let message = '';
-    try {
-      parseTileset(MULTI);
-    } catch (e) {
-      message = (e as Error).message;
-    }
-    expect(message).toContain('contents');
-    expect(
-      message,
-      'the refusal must say why, since the alternative is a scene that looks complete',
-    ).toContain('reported itself complete');
+  it('serves every point content in the array as its own node', () => {
+    const idx = tilesetNodes(parseTileset(MULTI));
+    expect(idx.records.map((r) => r.id)).toEqual(['a.pnts', 'b.pnts', 'c.pnts']);
   });
 
   it('never yields a tileset that is short of tiles yet calls itself complete', () => {
-    // The regression, stated as what a user would get. Before the refusal this
-    // parsed cleanly and produced ONE node for a three-tile document, with an
-    // empty `skipped`, so nothing downstream could tell.
-    let idx: ReturnType<typeof tilesetNodes> | null = null;
-    try {
-      idx = tilesetNodes(parseTileset(MULTI));
-    } catch {
-      idx = null; // refused at parse, which is the fix
-    }
-    if (idx === null) return;
+    // The old regression, stated as what a user would get. A three-content
+    // document must serve three nodes, and any content it could not serve must
+    // be recorded in `skipped` rather than silently dropped.
+    const idx = tilesetNodes(parseTileset(MULTI));
     const complete = idx.skipped.length === 0;
     expect(
       complete && idx.records.length < 3,
-      `served ${idx.records.length} of 3 tiles while reporting complete`,
+      `served ${idx.records.length} of 3 contents while reporting complete`,
     ).toBe(false);
   });
 
@@ -75,7 +61,7 @@ describe('the 1.1 multi-content form', () => {
     const single = JSON.stringify({
       asset: { version: '1.1' },
       geometricError: 100,
-      root: { boundingVolume: BOX, geometricError: 50, refine: 'REPLACE', content: { uri: 'a.pnts' } },
+      root: { boundingVolume: BOX, geometricError: 50, refine: 'ADD', content: { uri: 'a.pnts' } },
     });
     expect(tilesetNodes(parseTileset(single)).records.map((r) => r.id)).toEqual(['a.pnts']);
   });

--- a/tests/tilesetStreamingOpen.test.ts
+++ b/tests/tilesetStreamingOpen.test.ts
@@ -393,7 +393,7 @@ describe('a refusal reaches the user', () => {
       }),
     );
     expect(shown).not.toContain('corrupt');
-    expect(shown).toContain('contents');
+    expect(shown).toContain('REPLACE');
   });
 
   it('names the tile it cannot serve', async () => {

--- a/tests/tilesetStreamingOpen.test.ts
+++ b/tests/tilesetStreamingOpen.test.ts
@@ -404,15 +404,15 @@ describe('a refusal reaches the user', () => {
         root: {
           boundingVolume: BOX2,
           geometricError: 50,
-          refine: 'REPLACE',
+          refine: 'ADD',
           content: { uri: 'a.pnts' },
           children: [
-            { boundingVolume: BOX2, geometricError: 10, content: { uri: 'sub/tileset.json' } },
+            { boundingVolume: BOX2, geometricError: 10, content: { uri: 'sub/mesh.glb' } },
           ],
         },
       }),
     );
-    expect(shown).toContain('sub/tileset.json');
+    expect(shown).toContain('sub/mesh.glb');
     expect(shown).not.toContain('corrupt');
   });
 

--- a/tests/tilesetUrlGuards.test.ts
+++ b/tests/tilesetUrlGuards.test.ts
@@ -78,3 +78,26 @@ describe('a content URI this viewer must not request', () => {
     }
   });
 });
+
+describe('a tile carrying several 3D Tiles 1.1 contents', () => {
+  it('emits one node per content, each resolved independently', () => {
+    const tileset = parseTileset(
+      JSON.stringify({
+        asset: { version: '1.1' },
+        geometricError: 100,
+        root: {
+          boundingVolume: BOX,
+          geometricError: 50,
+          refine: 'ADD',
+          contents: [{ uri: 'a.pnts' }, { uri: 'sub/b.pnts' }],
+        },
+      }),
+    );
+    const built = tilesetNodes(tileset, undefined, ENTRY);
+    expect(built.records.map((r) => r.id)).toEqual(['a.pnts', 'sub/b.pnts']);
+    expect(built.contentUri.get('a.pnts')).toBe('https://tiles.example.com/city/a.pnts');
+    expect(built.contentUri.get('sub/b.pnts')).toBe(
+      'https://tiles.example.com/city/sub/b.pnts',
+    );
+  });
+});


### PR DESCRIPTION
A 3D Tiles tile can carry several contents under the 1.1 `contents[]` array. The parser modelled only a single `content`, so any tile using the array was refused.

A tile now carries `contentUris` (a list) rather than one `contentUri`. `parseTile` reads both the single `content` and the `contents[]` array; the node walk classifies and resolves each entry independently and serves every point-cloud content on a tile, so a tile with several `.pnts` contents streams all of them. Content-free tiles carry an empty list, and the per-entry URL guards are unchanged. Removes the `contents[]`-unsupported line from supported-formats.