### PR TITLE
feat(3dtiles): follow a tile whose content is an external tileset.json

### DIFF
--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -64,7 +64,9 @@ A tile that refines by REPLACE into tiles with their own content is refused. REP
 
 Implicit tiling opens. A tileset that describes its hierarchy with a subdivision scheme and subtree files rather than a written-out tree is expanded into the equivalent explicit document before it is parsed, so every refusal the explicit path makes applies to it unchanged. Quadtree and octree schemes are read, availability arrives as a constant or as a bitstream in an internal or external buffer, and subtree and buffer URLs pass the same origin and credential checks as tile content, including the directory-escape rule. The expansion is bounded: subtree levels, tiles per subtree, external buffers, available levels, subtree count, total expanded tiles and subtree bytes each have a ceiling that refuses by name rather than truncating. A sphere bounding volume on an implicit tile is refused, as is a tile declaring both `implicitTiling` and `children`. The older extension spellings are refused by name.
 
-What does not open: the wider 3D Tiles ecosystem. B3DM, I3DM, CMPT and glTF content are refused by name, because mesh tiles need a renderer this viewer does not have. A selection cannot reach a nested external `tileset.json`. Draco-compressed tiles are refused rather than partially read.
+A tile whose content is a nested external `tileset.json` is followed: the referenced document is fetched, its own implicit and external references expanded in turn, and its root spliced in as a child in the referencing tile's frame, so a set split across several documents opens as one scene. The follow is bounded — the count of external documents, the nesting depth and the bytes of one document each refuse by name — and a document that references itself, directly or around a cycle, is refused rather than followed forever.
+
+What does not open: the wider 3D Tiles ecosystem. B3DM, I3DM, CMPT and glTF content are refused by name, because mesh tiles need a renderer this viewer does not have. Draco-compressed tiles are refused rather than partially read.
 
 Two further limits of the supported subset are known:
 

--- a/src/app/openTilesetLayer.ts
+++ b/src/app/openTilesetLayer.ts
@@ -33,6 +33,7 @@
 import { LoadCancelledError } from '../io/loadFile';
 import { describeLoadError } from '../io/loadErrors';
 import { expandImplicitTileset } from '../io/tiles3d/implicitExpand';
+import { expandExternalTilesets } from '../io/tiles3d/externalTilesets';
 import { parseTileset } from '../io/tiles3d/tileset';
 import { createTilesetTransport, pntsDeviceTransportCap } from '../io/tiles3d/tilesetTransport';
 import { validateRemoteTilesetUrl } from '../io/tiles3d/tilesetUrl';
@@ -185,7 +186,19 @@ export async function openRemoteTileset(
           transport.fetchSubtreeBytes(subtreeUrl, signal),
         signal: controller.signal,
       });
-      tileset = parseTileset(expanded);
+      // A tile whose content is another tileset.json is followed here: the
+      // referenced document (implicit and external references expanded in turn)
+      // is spliced in as a child so every leaf reachable across the set becomes
+      // a servable node, rather than an unserved `.json` that refuses the open.
+      const linked = await expandExternalTilesets(expanded, {
+        entryUrl: url,
+        fetchTilesetJson: (tilesetUrl, signal) =>
+          transport.fetchTilesetJson(tilesetUrl, signal),
+        fetchSubtreeBytes: (subtreeUrl, signal) =>
+          transport.fetchSubtreeBytes(subtreeUrl, signal),
+        signal: controller.signal,
+      });
+      tileset = parseTileset(linked);
     } catch (err) {
       // The parser's and the expander's refusals are all deliberate and already
       // say why. A cancel is not a refusal and has to keep its own identity.

--- a/src/io/tiles3d/externalTilesets.ts
+++ b/src/io/tiles3d/externalTilesets.ts
@@ -1,0 +1,234 @@
+/**
+ * externalTilesets.ts — follow a tile whose content is another `tileset.json`.
+ *
+ * 3D Tiles lets a tile point its content at an external tileset rather than a
+ * geometry file: the referenced document's root tile stands in for the tile's
+ * content, in that tile's coordinate frame. The explicit reader classifies a
+ * `.json` content as `tileset` and, on its own, refuses to follow it — so a set
+ * split across several `tileset.json` files opens as "a tile this reader cannot
+ * serve" even though every leaf is a point tile it could stream.
+ *
+ * This expander rewrites those references away before the tree is parsed, the
+ * same shape the implicit expander uses: it fetches each external document,
+ * expands ITS implicit and external references in turn, and splices the fetched
+ * root in as a child of the referencing tile with the `.json` content removed.
+ * A child inherits the referencing tile's transform, so the external root lands
+ * in the referencing tile's frame exactly as the specification requires, and
+ * every existing refusal (a mesh content, a bad URL, a point budget) then
+ * applies to the spliced-in result unchanged.
+ *
+ * The three things a small document can make unbounded are all capped and none
+ * is truncated, for the reason the implicit ceilings give: a hierarchy pruned
+ * mid-expansion renders as a plausible scene with geometry quietly missing. The
+ * fetch fan-out (how many external documents), the nesting depth (how deep the
+ * references chain), and the bytes of one document (the transport's own
+ * `MAX_TILESET_JSON_BYTES`) each refuse. A document that references itself,
+ * directly or around a cycle, is refused rather than followed forever.
+ */
+
+import { expandImplicitTileset } from './implicitExpand';
+import { contentKind } from './tilesetNodes';
+import { resolveTilesetContentUrl, tilesetBaseUrl, tilesetUrlSearch } from './tilesetUrl';
+import { DEFAULT_TILESET_MAX_DEPTH } from './tileset';
+
+/** How many external `tileset.json` documents one open may fetch in total. */
+export const MAX_EXTERNAL_TILESETS = 256;
+
+/** How deeply external references may nest before the open is refused. */
+export const MAX_EXTERNAL_DEPTH = 16;
+
+interface RawContent {
+  uri?: string;
+  url?: string;
+}
+
+interface RawTile {
+  boundingVolume?: unknown;
+  geometricError?: number;
+  refine?: string;
+  transform?: number[];
+  content?: RawContent;
+  contents?: unknown;
+  children?: RawTile[];
+  implicitTiling?: unknown;
+}
+
+export interface ExpandExternalOptions {
+  /** The tileset entry URL. External URIs resolve against its directory. */
+  readonly entryUrl: string;
+  /** Fetch an external `tileset.json` body as text. */
+  readonly fetchTilesetJson: (url: string, signal?: AbortSignal) => Promise<string>;
+  /** Fetch a subtree body, forwarded to the implicit expander per document. */
+  readonly fetchSubtreeBytes: (url: string, signal?: AbortSignal) => Promise<ArrayBuffer>;
+  readonly signal?: AbortSignal;
+  /** Override {@link MAX_EXTERNAL_TILESETS}. */
+  readonly maxExternalTilesets?: number;
+  /** Override {@link MAX_EXTERNAL_DEPTH}. */
+  readonly maxExternalDepth?: number;
+}
+
+interface Budget {
+  readonly maxExternal: number;
+  readonly maxDepth: number;
+  fetched: number;
+}
+
+/** The content URI a content entry names, or null when it names none. */
+function contentUri(entry: unknown): string | null {
+  if (entry === null || typeof entry !== 'object') return null;
+  const c = entry as RawContent;
+  const uri = typeof c.uri === 'string' ? c.uri : typeof c.url === 'string' ? c.url : null;
+  return uri !== null && uri.length > 0 ? uri : null;
+}
+
+/** True when a content URI points at an external tileset rather than geometry. */
+function isExternalTileset(uri: string): boolean {
+  return contentKind(uri) === 'tileset';
+}
+
+/**
+ * Split a tile's contents into the external-tileset URIs to follow and the
+ * content entries to keep (geometry, or anything not a `.json`). Reads the 1.0
+ * single `content` and the 1.1 `contents` array uniformly.
+ */
+function partitionContents(tile: RawTile): { external: string[]; keep: unknown[] } {
+  const external: string[] = [];
+  const keep: unknown[] = [];
+  const classify = (entry: unknown): void => {
+    const uri = contentUri(entry);
+    if (uri !== null && isExternalTileset(uri)) external.push(uri);
+    else keep.push(entry);
+  };
+  if (tile.content !== undefined) classify(tile.content);
+  if (Array.isArray(tile.contents)) for (const entry of tile.contents) classify(entry);
+  return { external, keep };
+}
+
+/** Rebuild a tile's content fields from the entries that survive following. */
+function withKeptContents(tile: RawTile, keep: unknown[]): RawTile {
+  const next: RawTile = { ...tile };
+  delete next.content;
+  delete next.contents;
+  if (keep.length === 1) next.content = keep[0] as RawContent;
+  else if (keep.length > 1) next.contents = keep;
+  return next;
+}
+
+export async function expandExternalTilesets(
+  doc: object,
+  options: ExpandExternalOptions,
+): Promise<object> {
+  if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) {
+    throw new Error('3D Tiles: tileset.json is not an object.');
+  }
+  const budget: Budget = {
+    maxExternal: options.maxExternalTilesets ?? MAX_EXTERNAL_TILESETS,
+    maxDepth: options.maxExternalDepth ?? MAX_EXTERNAL_DEPTH,
+    fetched: 0,
+  };
+
+  function abortIfCancelled(): void {
+    const signal = options.signal;
+    if (signal?.aborted) {
+      throw signal.reason ?? new DOMException('3D Tiles external expansion aborted', 'AbortError');
+    }
+  }
+
+  /**
+   * Fetch one external document, resolved against `base`, and expand its own
+   * implicit and external references. `chain` is the set of URLs already open
+   * above this one, so a reference back into the chain is refused as a cycle.
+   */
+  async function follow(
+    resolvedUrl: string,
+    depth: number,
+    chain: ReadonlySet<string>,
+  ): Promise<RawTile> {
+    if (depth > budget.maxDepth) {
+      throw new Error(
+        `3D Tiles: external tilesets nest deeper than ${budget.maxDepth} levels; ` +
+          'refusing to follow them.',
+      );
+    }
+    if (chain.has(resolvedUrl)) {
+      throw new Error(`3D Tiles: external tileset "${resolvedUrl}" references itself in a cycle.`);
+    }
+    if (budget.fetched >= budget.maxExternal) {
+      throw new Error(
+        `3D Tiles: a set of tilesets references more than ${budget.maxExternal} external ` +
+          'documents; refusing to fetch further.',
+      );
+    }
+    budget.fetched += 1;
+    abortIfCancelled();
+    const json = await options.fetchTilesetJson(resolvedUrl, options.signal);
+    abortIfCancelled();
+    const expandedImplicit = await expandImplicitTileset(JSON.parse(json) as object, {
+      entryUrl: resolvedUrl,
+      fetchSubtreeBytes: options.fetchSubtreeBytes,
+      signal: options.signal,
+    });
+    const source = expandedImplicit as { root?: RawTile };
+    if (source.root === undefined || source.root === null || typeof source.root !== 'object') {
+      throw new Error(`3D Tiles: external tileset "${resolvedUrl}" declares no root tile.`);
+    }
+    const nextChain = new Set(chain).add(resolvedUrl);
+    return walk(source.root, resolvedUrl, depth, nextChain);
+  }
+
+  /**
+   * Walk a tile, following each external-tileset content it names and recursing
+   * into its children. `docUrl` is the URL of the document this tile came from;
+   * external URIs on it resolve against that document's directory, not the entry.
+   */
+  async function walk(
+    tile: RawTile,
+    docUrl: string,
+    depth: number,
+    chain: ReadonlySet<string>,
+  ): Promise<RawTile> {
+    if (depth > DEFAULT_TILESET_MAX_DEPTH) {
+      throw new Error(
+        `3D Tiles: tile hierarchy is deeper than ${DEFAULT_TILESET_MAX_DEPTH} levels; ` +
+          'refusing to expand it.',
+      );
+    }
+    if (tile === null || typeof tile !== 'object' || Array.isArray(tile)) {
+      throw new Error('3D Tiles: a tile is not an object.');
+    }
+    if (tile.children !== undefined && !Array.isArray(tile.children)) {
+      throw new Error('3D Tiles: a tile children field is not an array.');
+    }
+
+    const base = tilesetBaseUrl(docUrl);
+    const search = tilesetUrlSearch(docUrl);
+    const { external, keep } = partitionContents(tile);
+
+    const spliced: RawTile[] = [];
+    for (const uri of external) {
+      const resolved = resolveTilesetContentUrl(base, uri, search);
+      if (!resolved.ok) {
+        throw new Error(`3D Tiles: external tileset "${uri}": ${resolved.reason}`);
+      }
+      spliced.push(await follow(resolved.url, depth + 1, chain));
+    }
+
+    const walkedChildren: RawTile[] = [];
+    for (const child of (tile.children ?? []) as RawTile[]) {
+      walkedChildren.push(await walk(child, docUrl, depth + 1, chain));
+    }
+
+    if (external.length === 0) {
+      // No external content here: return the tile with its children walked, and
+      // only rebuild the children field when there were any to walk.
+      return tile.children === undefined ? tile : { ...tile, children: walkedChildren };
+    }
+    const children = [...walkedChildren, ...spliced];
+    return withKeptContents({ ...tile, children }, keep);
+  }
+
+  const source = doc as { root?: RawTile };
+  if (source.root === undefined) return doc;
+  const root = await walk(source.root, options.entryUrl, 0, new Set<string>());
+  return { ...doc, root };
+}

--- a/tests/tiles3dExternalTilesets.test.ts
+++ b/tests/tiles3dExternalTilesets.test.ts
@@ -1,0 +1,175 @@
+/**
+ * tiles3dExternalTilesets.test.ts — following a tile whose content is another
+ * `tileset.json`.
+ *
+ * The reader used to classify a `.json` content as an external tileset and
+ * refuse to follow it, so a set split across several documents opened as "a
+ * tile this reader cannot serve". `expandExternalTilesets` fetches each
+ * referenced document and splices its root in as a child before the tree is
+ * parsed, with the same fan-out / depth / cycle ceilings the implicit expander
+ * carries. These cases pin the splice, the resolution base, and every refusal.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  expandExternalTilesets,
+  MAX_EXTERNAL_DEPTH,
+} from '../src/io/tiles3d/externalTilesets';
+import { parseTileset } from '../src/io/tiles3d/tileset';
+import { tilesetNodes } from '../src/io/tiles3d/tilesetNodes';
+
+const BOX = { box: [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 10] };
+const ENTRY = 'https://tiles.example.com/city/tileset.json';
+
+/** An expander over a fixed map of URL → document text; records what it fetched. */
+function expanderOver(docs: Record<string, object>) {
+  const fetched: string[] = [];
+  const fetchTilesetJson = async (url: string): Promise<string> => {
+    fetched.push(url);
+    const doc = docs[url];
+    if (doc === undefined) throw new Error(`test: no document at ${url}`);
+    return JSON.stringify(doc);
+  };
+  const fetchSubtreeBytes = async (): Promise<ArrayBuffer> => {
+    throw new Error('test: no subtree fetch expected');
+  };
+  const run = (root: object): Promise<object> =>
+    expandExternalTilesets(
+      { asset: { version: '1.1' }, geometricError: 100, root },
+      { entryUrl: ENTRY, fetchTilesetJson, fetchSubtreeBytes },
+    );
+  return { run, fetched };
+}
+
+/** A minimal external tileset document whose root is one point tile. */
+function externalDoc(uri: string): object {
+  return {
+    asset: { version: '1.1' },
+    geometricError: 50,
+    root: { boundingVolume: BOX, geometricError: 10, refine: 'ADD', content: { uri } },
+  };
+}
+
+describe('expandExternalTilesets', () => {
+  it('splices a referenced document root in as a child and drops the .json content', async () => {
+    const { run, fetched } = expanderOver({
+      'https://tiles.example.com/city/child.json': externalDoc('leaf.pnts'),
+    });
+    const out = (await run({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'ADD',
+      content: { uri: 'child.json' },
+    })) as { root: { content?: unknown; contents?: unknown; children: { content: { uri: string } }[] } };
+
+    expect(fetched).toEqual(['https://tiles.example.com/city/child.json']);
+    // The .json content is gone; the external root is now a child point tile.
+    expect(out.root.content).toBeUndefined();
+    expect(out.root.contents).toBeUndefined();
+    expect(out.root.children).toHaveLength(1);
+    expect(out.root.children[0].content.uri).toBe('leaf.pnts');
+
+    // And the spliced tree parses and walks to a servable node.
+    const nodes = tilesetNodes(parseTileset(out), undefined, ENTRY);
+    expect(nodes.records.map((r) => r.id)).toEqual(['leaf.pnts']);
+  });
+
+  it('keeps a point content on a tile that also references an external tileset', async () => {
+    const { run } = expanderOver({
+      'https://tiles.example.com/city/child.json': externalDoc('leaf.pnts'),
+    });
+    const out = (await run({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'ADD',
+      contents: [{ uri: 'here.pnts' }, { uri: 'child.json' }],
+    })) as { root: { content: { uri: string }; children: unknown[] } };
+
+    // The point content survives as the tile's own content; the external became a child.
+    expect(out.root.content.uri).toBe('here.pnts');
+    expect(out.root.children).toHaveLength(1);
+  });
+
+  it('resolves a nested reference against the referenced document, not the entry', async () => {
+    const { run, fetched } = expanderOver({
+      'https://tiles.example.com/city/deep/a.json': {
+        asset: { version: '1.1' },
+        geometricError: 50,
+        root: { boundingVolume: BOX, geometricError: 10, refine: 'ADD', content: { uri: 'b.json' } },
+      },
+      // `b.json` is named relatively by a.json, so it must resolve under deep/.
+      'https://tiles.example.com/city/deep/b.json': externalDoc('leaf.pnts'),
+    });
+    await run({
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'ADD',
+      content: { uri: 'deep/a.json' },
+    });
+    expect(fetched).toEqual([
+      'https://tiles.example.com/city/deep/a.json',
+      'https://tiles.example.com/city/deep/b.json',
+    ]);
+  });
+
+  it('refuses a reference cycle rather than following it forever', async () => {
+    const { run } = expanderOver({
+      'https://tiles.example.com/city/a.json': {
+        asset: { version: '1.1' },
+        geometricError: 50,
+        root: { boundingVolume: BOX, geometricError: 10, refine: 'ADD', content: { uri: 'a.json' } },
+      },
+    });
+    await expect(
+      run({ boundingVolume: BOX, geometricError: 50, refine: 'ADD', content: { uri: 'a.json' } }),
+    ).rejects.toThrow(/cycle/i);
+  });
+
+  it('refuses a chain that nests past the external-depth ceiling', async () => {
+    // Each document references the next; more of them than the ceiling allows.
+    const docs: Record<string, object> = {};
+    for (let i = 0; i <= MAX_EXTERNAL_DEPTH + 1; i++) {
+      const next = `https://tiles.example.com/city/n${i + 1}.json`;
+      docs[`https://tiles.example.com/city/n${i}.json`] = {
+        asset: { version: '1.1' },
+        geometricError: 50,
+        root: {
+          boundingVolume: BOX,
+          geometricError: 10,
+          refine: 'ADD',
+          content: { uri: `n${i + 1}.json` },
+        },
+      };
+      if (i === MAX_EXTERNAL_DEPTH + 1) docs[next] = externalDoc('leaf.pnts');
+    }
+    const { run } = expanderOver(docs);
+    await expect(
+      run({ boundingVolume: BOX, geometricError: 50, refine: 'ADD', content: { uri: 'n0.json' } }),
+    ).rejects.toThrow(/deeper than/i);
+  });
+
+  it('refuses an external URI that escapes the tileset origin', async () => {
+    const { run } = expanderOver({});
+    await expect(
+      run({
+        boundingVolume: BOX,
+        geometricError: 50,
+        refine: 'ADD',
+        content: { uri: 'https://attacker.example.net/evil.json' },
+      }),
+    ).rejects.toThrow(/external tileset/i);
+  });
+
+  it('leaves a document with no external references untouched and fetches nothing', async () => {
+    const { run, fetched } = expanderOver({});
+    const root = {
+      boundingVolume: BOX,
+      geometricError: 50,
+      refine: 'ADD',
+      content: { uri: 'leaf.pnts' },
+    };
+    const out = (await run(root)) as { root: unknown };
+    expect(fetched).toEqual([]);
+    expect(out.root).toEqual(root);
+  });
+});

--- a/tests/tilesetImplicitWiring.test.ts
+++ b/tests/tilesetImplicitWiring.test.ts
@@ -71,7 +71,7 @@ describe('the tileset open expands implicit tiling before parsing', () => {
   it('parses what the expander returned, not the raw document', () => {
     // Calling the expander and then parsing the original leaves the feature
     // just as unreachable, and no name match would notice.
-    expect(openSrc).toMatch(/parseTileset\(expanded\)/);
+    expect(openSrc).toMatch(/parseTileset\(linked\)/);
     expect(openSrc, 'the raw json must not go straight to the parser').not.toMatch(
       /parseTileset\(json\)/,
     );
@@ -79,7 +79,7 @@ describe('the tileset open expands implicit tiling before parsing', () => {
 
   it('expands before it parses, not after', () => {
     const expandAt = openSrc.search(/await\s+expandImplicitTileset\(/);
-    const parseAt = openSrc.indexOf('parseTileset(expanded)');
+    const parseAt = openSrc.indexOf('parseTileset(linked)');
     expect(expandAt).toBeGreaterThan(-1);
     expect(parseAt).toBeGreaterThan(-1);
     expect(expandAt, 'the expander must run before the parser').toBeLessThan(parseAt);

--- a/tests/tilesetStreamingOpen.test.ts
+++ b/tests/tilesetStreamingOpen.test.ts
@@ -404,15 +404,15 @@ describe('a refusal reaches the user', () => {
         root: {
           boundingVolume: BOX2,
           geometricError: 50,
-          refine: 'REPLACE',
+          refine: 'ADD',
           content: { uri: 'a.pnts' },
           children: [
-            { boundingVolume: BOX2, geometricError: 10, content: { uri: 'sub/tileset.json' } },
+            { boundingVolume: BOX2, geometricError: 10, content: { uri: 'sub/mesh.glb' } },
           ],
         },
       }),
     );
-    expect(shown).toContain('sub/tileset.json');
+    expect(shown).toContain('sub/mesh.glb');
     expect(shown).not.toContain('corrupt');
   });
 


### PR DESCRIPTION
Stacked on #783.

A 3D Tiles tile can point its content at another `tileset.json` rather than a geometry file; the referenced document's root stands in for the tile's content in that tile's frame. The reader classified a `.json` content as an external tileset and refused to follow it, so a set split across several documents opened as "a tile this reader cannot serve".

`expandExternalTilesets` fetches each referenced document, expands its own implicit and external references in turn, and splices its root in as a child before the tree is parsed — so a child inherits the referencing tile's transform and every existing refusal applies to the spliced result. The follow is bounded by document count, nesting depth and per-document bytes, and a reference cycle is refused rather than followed forever.