### PR TITLE
feat(layers): a Layers-panel section listing derived analytical layers

### DIFF
--- a/src/app/terrainAnalysisRunner.ts
+++ b/src/app/terrainAnalysisRunner.ts
@@ -45,12 +45,15 @@ import type { ContourGeneralizeMode } from '../terrain/contour/terrainAwareToler
 // TYPE-ONLY: the service and the overlay it builds both load lazily, so
 // neither this import nor the runner widens the startup shell chunk.
 import type { ContourLayerService } from './contourLayerService';
+import type { DerivedLayer, DerivedLayerStore } from '../model/DerivedLayer';
+import type { DerivedLayersList } from '../ui/DerivedLayersList';
 import {
   loadTerrainCoreCache,
   loadComputeTerrainCoreAsync,
   loadContourLayerService,
   loadContourOverlay,
   loadDerivedLayer,
+  loadDerivedLayersList,
   loadDerivedLayerReceipt,
 } from '../lazyChunks';
 // Tiny pure constant (no heavy terrain code rides along) — the unit-aware
@@ -279,6 +282,12 @@ export function createTerrainAnalysisRunner(
   // three-free — the overlay class (and with it three/webgpu) arrives through a
   // lazy import, so nothing here widens the startup shell.
   let contourLayers: ContourLayerService | null = null;
+  // The shared derived-layer store and the Layers-panel section that lists it.
+  // Both are built once, lazily, alongside the first product's service, so every
+  // derived layer (contours today; more as each is routed through the store) is
+  // listed and toggled in one place rather than through a per-product control.
+  let derivedStore: DerivedLayerStore | null = null;
+  let derivedList: DerivedLayersList | null = null;
 
   /** The contour derived-layer service, or null before the first analysis. */
   const getContourLayers = (): ContourLayerService | null => contourLayers;
@@ -299,6 +308,32 @@ export function createTerrainAnalysisRunner(
     return scale != null ? verticalUnitLabel(scale) : null;
   }
 
+  /**
+   * Route a Layers-list visibility change to the service that owns the layer's
+   * geometry. The store holds display state, but each product's service is what
+   * mirrors it onto the scene, so a generic control dispatches by type. Contours
+   * are the only routed product today; another is added here as it joins the
+   * store, and a layer with no service yet updates its record only.
+   */
+  function applyDerivedVisibility(layer: DerivedLayer, visible: boolean): void {
+    if (layer.type === 'contours' && contourLayers) {
+      const scanId = layer.sourceScanIds[0];
+      if (scanId) contourLayers.setVisible(scanId, visible);
+      return;
+    }
+    derivedStore?.setVisible(layer.id, visible);
+  }
+
+  /** Opacity counterpart of {@link applyDerivedVisibility}. */
+  function applyDerivedOpacity(layer: DerivedLayer, opacity: number): void {
+    if (layer.type === 'contours' && contourLayers) {
+      const scanId = layer.sourceScanIds[0];
+      if (scanId) contourLayers.setOpacity(scanId, opacity);
+      return;
+    }
+    derivedStore?.setOpacity(layer.id, opacity);
+  }
+
   async function showContourLayer(
     result: AnalyseContoursResult,
     scanId: string | null,
@@ -309,17 +344,35 @@ export function createTerrainAnalysisRunner(
       const cloud = viewer.getCloud(scanId);
       if (!cloud) return;
       if (!contourLayers) {
-        const [{ createContourLayerService }, { DerivedLayerStore }, { ContourOverlay }] =
-          await Promise.all([
-            loadContourLayerService(),
-            loadDerivedLayer(),
-            loadContourOverlay(),
-          ]);
+        const [
+          { createContourLayerService },
+          { DerivedLayerStore },
+          { ContourOverlay },
+          { createDerivedLayersList },
+        ] = await Promise.all([
+          loadContourLayerService(),
+          loadDerivedLayer(),
+          loadContourOverlay(),
+          loadDerivedLayersList(),
+        ]);
+        // ONE store, shared by every product's service and the Layers-panel
+        // list, so a layer is listed the moment its service registers it.
+        const store = new DerivedLayerStore();
+        derivedStore = store;
         contourLayers = createContourLayerService({
           host: viewer.derivedLayerHost(),
-          store: new DerivedLayerStore(),
+          store,
           makeOverlay: (host) => new ContourOverlay(host),
         });
+        // The list reads the store; its controls route back to the owning
+        // service, which updates the store AND the drawn geometry. A store
+        // notification then re-renders the row, so the two cannot drift.
+        derivedList = createDerivedLayersList({
+          store,
+          onSetVisible: (layer, visible) => applyDerivedVisibility(layer, visible),
+          onSetOpacity: (layer, opacity) => applyDerivedOpacity(layer, opacity),
+        });
+        getAnalysePanel().setDerivedLayersList(derivedList.element);
       }
       // The digest identifies the RUN reproducibly: the record's fingerprint
       // covers the scientific content only — not build, not time — so two runs

--- a/src/lazyChunks.ts
+++ b/src/lazyChunks.ts
@@ -466,6 +466,7 @@ export const loadExportProvenance = () => import('./terrain/export/exportProvena
  */
 export const loadContourLayerService = () => import('./app/contourLayerService');
 export const loadDerivedLayer = () => import('./model/DerivedLayer');
+export const loadDerivedLayersList = () => import('./ui/DerivedLayersList');
 export const loadContourOverlay = () => import('./render/ContourOverlay');
 export const loadDerivedLayerReceipt = () => import('./science/derivedLayerReceipt');
 

--- a/src/model/DerivedLayer.ts
+++ b/src/model/DerivedLayer.ts
@@ -85,12 +85,33 @@ function makeLayer(init: DerivedLayerInit, generation: number): DerivedLayer {
  */
 export class DerivedLayerStore {
   private readonly _byId = new Map<string, DerivedLayer>();
+  private readonly _listeners = new Set<() => void>();
+
+  /**
+   * Observe every change to the set of layers — a put, a remove, or a display
+   * mutation (visibility, opacity, style, solo). A Layers-panel section reads
+   * `list()` on each call to re-render, so it never drifts from the store. The
+   * listener is called after the change has landed. Returns an unsubscribe.
+   */
+  subscribe(listener: () => void): () => void {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  }
+
+  private _notify(): void {
+    // A copy so a listener that unsubscribes during dispatch cannot mutate the
+    // set mid-iteration.
+    for (const listener of [...this._listeners]) listener();
+  }
 
   /** Add a new layer, or regenerate an existing one (generation bumps). */
   put(init: DerivedLayerInit): DerivedLayer {
     const prev = this._byId.get(init.id);
     const layer = makeLayer(init, prev ? prev.generation + 1 : 1);
     this._byId.set(init.id, layer);
+    this._notify();
     return layer;
   }
 
@@ -103,7 +124,9 @@ export class DerivedLayerStore {
   }
 
   remove(id: string): boolean {
-    return this._byId.delete(id);
+    const removed = this._byId.delete(id);
+    if (removed) this._notify();
+    return removed;
   }
 
   /** All layers, in insertion order. */
@@ -135,6 +158,7 @@ export class DerivedLayerStore {
     for (const [key, layer] of this._byId) {
       this._byId.set(key, { ...layer, visible: id === null ? true : key === id });
     }
+    this._notify();
   }
 
   private _patch(id: string, patch: Partial<DerivedLayer>): DerivedLayer | undefined {
@@ -142,6 +166,7 @@ export class DerivedLayerStore {
     if (!prev) return undefined;
     const next = { ...prev, ...patch };
     this._byId.set(id, next);
+    this._notify();
     return next;
   }
 }

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -447,6 +447,8 @@ export class AnalysePanel {
   private readonly _contourLauncher: HTMLElement;
   /** Host for the 3D contour derived-layer controls; empty until a layer is drawn. */
   private readonly _contourLayerControls: HTMLElement;
+  /** Mount point for the generic derived-layers list (built by the runner). */
+  private readonly _derivedLayersHost: HTMLElement;
   private readonly _contourDeliverable: HTMLElement;
   /** Monotonic token so a slow lazy launcher load can't mount a stale result. */
   private _contourToken = 0;
@@ -598,6 +600,7 @@ export class AnalysePanel {
 
     this._contourLauncher = el('div', { className: 'olv-analyse-contour-launcher' });
     this._contourLayerControls = el('div', { className: 'olv-analyse-layer-controls olv-hidden' });
+    this._derivedLayersHost = el('div', { className: 'olv-analyse-derived-layers' });
     this._contourDeliverable = el('div', {
       className: 'olv-analyse-contour-deliverable olv-hidden',
     });
@@ -639,7 +642,12 @@ export class AnalysePanel {
     // own "Terrain Products" eyebrow; this wrapper just groups + spaces it. Only
     // the stale caveat outranks it, so a stale verdict is never read as current.
     const terrainProducts = el('div', { className: 'olv-analyse-products' });
-    terrainProducts.append(this._contourLauncher, this._contourLayerControls, this._contourDeliverable);
+    terrainProducts.append(
+      this._contourLauncher,
+      this._contourLayerControls,
+      this._derivedLayersHost,
+      this._contourDeliverable,
+    );
 
     this._resultsRegion.append(
       this._staleNotice,
@@ -902,6 +910,15 @@ export class AnalysePanel {
    * re-reads what the service actually applied, so the record stays the single
    * source of truth and the UI can never drift from what is drawn.
    */
+  /**
+   * Mount the generic derived-layers list (the runner builds it against the
+   * shared store). Idempotent: a second call replaces the mounted element, so a
+   * re-init cannot stack two lists.
+   */
+  setDerivedLayersList(element: HTMLElement): void {
+    this._derivedLayersHost.replaceChildren(element);
+  }
+
   setContourLayerControls(controls: ContourLayerControls | null): void {
     const host = this._contourLayerControls;
     host.replaceChildren();

--- a/src/ui/DerivedLayersList.ts
+++ b/src/ui/DerivedLayersList.ts
@@ -1,0 +1,120 @@
+/**
+ * DerivedLayersList.ts — the Layers-panel section that lists analytical layers.
+ *
+ * A derived product (contours today; conductors, surfaces and change rasters as
+ * each is routed through the store) is a first-class scene layer: named,
+ * provenance-carrying, and shown or faded like a scan. This is the generic list
+ * that makes them manageable in one place, reading the shared
+ * {@link DerivedLayerStore} and re-rendering whenever it changes.
+ *
+ * It owns no product lifecycle. The store holds the display STATE, but each
+ * product's own service is what mirrors that state onto the geometry it draws,
+ * so a control here calls back through `onSetVisible` / `onSetOpacity` — the
+ * caller routes those to the right service, which updates the store and the
+ * scene together. The list then re-renders from the store's notification, so
+ * what it shows can never drift from what is drawn. Pure DOM, no three.js.
+ */
+
+import { el } from './dom';
+import type { DerivedLayer, DerivedLayerStore, DerivedLayerType } from '../model/DerivedLayer';
+
+/** Human label for a layer type, so a row reads as a product not an enum. */
+const TYPE_LABEL: Record<DerivedLayerType, string> = {
+  'dtm-mesh': 'Terrain (DTM)',
+  'dsm-mesh': 'Surface (DSM)',
+  contours: 'Contours',
+  slope: 'Slope',
+  hillshade: 'Hillshade',
+  'change-raster': 'Change',
+  'building-polygons': 'Buildings',
+  'conductor-lines': 'Conductors',
+};
+
+export interface DerivedLayersListDeps {
+  readonly store: DerivedLayerStore;
+  /**
+   * Show or hide a layer. Routed by the caller to the product's own service so
+   * the geometry follows; returns the applied visibility, or undefined when the
+   * layer is gone. The control re-reads the store on the resulting notification.
+   */
+  readonly onSetVisible: (layer: DerivedLayer, visible: boolean) => void;
+  /** Set a layer's opacity (0..1), routed the same way as {@link onSetVisible}. */
+  readonly onSetOpacity: (layer: DerivedLayer, opacity: number) => void;
+}
+
+export interface DerivedLayersList {
+  /** The section element to mount into the Layers panel. */
+  readonly element: HTMLElement;
+  /** Stop observing the store. */
+  dispose(): void;
+}
+
+/** One layer's row: name, type, honesty chip, Show toggle, opacity. */
+function renderRow(layer: DerivedLayer, deps: DerivedLayersListDeps): HTMLElement {
+  const row = el('div', { className: 'olv-analyse-layer-row' });
+
+  const label = el('label', { className: 'olv-analyse-layer-toggle' });
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.checked = layer.visible;
+  cb.setAttribute('aria-label', `Show ${layer.name} in the 3D scene`);
+  cb.addEventListener('change', () => {
+    // The service, not the checkbox, decides; the store notification re-renders
+    // the row to the applied state, so no optimistic write is kept here.
+    deps.onSetVisible(layer, cb.checked);
+  });
+  label.append(cb, el('span', { text: layer.name }));
+
+  const meta = el('span', {
+    className: 'olv-analyse-layer-tag',
+    text: layer.evidenceExploratory ? `${TYPE_LABEL[layer.type]} · exploratory` : TYPE_LABEL[layer.type],
+  });
+
+  const opRow = el('label', { className: 'olv-analyse-layer-slider' });
+  const opVal = el('span', {
+    className: 'olv-analyse-layer-val',
+    text: `${Math.round(layer.opacity * 100)}%`,
+  });
+  const opInput = document.createElement('input');
+  opInput.type = 'range';
+  opInput.min = '0';
+  opInput.max = '100';
+  opInput.step = '5';
+  opInput.value = String(Math.round(layer.opacity * 100));
+  opInput.setAttribute('aria-label', `${layer.name} opacity`);
+  opInput.addEventListener('input', () => {
+    deps.onSetOpacity(layer, Number(opInput.value) / 100);
+  });
+  opRow.append(el('span', { className: 'olv-analyse-layer-tag', text: 'Opacity' }), opInput, opVal);
+
+  row.append(label, meta, opRow);
+  return row;
+}
+
+export function createDerivedLayersList(deps: DerivedLayersListDeps): DerivedLayersList {
+  const element = el('div', { className: 'olv-analyse-layer-controls' });
+
+  const render = (): void => {
+    element.replaceChildren();
+    const layers = deps.store.list();
+    if (layers.length === 0) {
+      // Empty until the first analysis produces a layer; hidden so the panel
+      // shows no empty header.
+      element.classList.add('olv-hidden');
+      return;
+    }
+    element.classList.remove('olv-hidden');
+    element.append(el('div', { className: 'olv-analyse-layer-head', text: 'Derived layers' }));
+    for (const layer of layers) element.append(renderRow(layer, deps));
+  };
+
+  render();
+  const unsubscribe = deps.store.subscribe(render);
+
+  return {
+    element,
+    dispose(): void {
+      unsubscribe();
+    },
+  };
+}

--- a/tests/derivedLayer.test.ts
+++ b/tests/derivedLayer.test.ts
@@ -52,4 +52,33 @@ describe('DerivedLayerStore', () => {
     expect(s.remove('a')).toBe(true);
     expect(s.has('a')).toBe(false);
   });
+
+  it('notifies a subscriber on every change and stops after unsubscribe', () => {
+    const s = new DerivedLayerStore();
+    let calls = 0;
+    const off = s.subscribe(() => {
+      calls += 1;
+    });
+    s.put({ id: 'a', type: 'contours', name: 'Contours', sourceScanIds: ['x'] });
+    s.setVisible('a', false);
+    s.setOpacity('a', 0.5);
+    s.setStyle('a', { ramp: 'x' });
+    s.solo('a');
+    s.remove('a');
+    expect(calls).toBe(6);
+    off();
+    s.put({ id: 'b', type: 'slope', name: 'Slope', sourceScanIds: ['x'] });
+    expect(calls).toBe(6);
+  });
+
+  it('does not notify when a remove or patch hits no layer', () => {
+    const s = new DerivedLayerStore();
+    let calls = 0;
+    s.subscribe(() => {
+      calls += 1;
+    });
+    expect(s.remove('missing')).toBe(false);
+    expect(s.setVisible('missing', false)).toBeUndefined();
+    expect(calls).toBe(0);
+  });
 });

--- a/tests/derivedLayersList.test.ts
+++ b/tests/derivedLayersList.test.ts
@@ -1,0 +1,120 @@
+/**
+ * derivedLayersList.test.ts — the Layers-panel section that lists derived
+ * products, over the recording DOM shim the other panel tests use.
+ *
+ * The property under test: the list is a pure view of the shared
+ * `DerivedLayerStore`. It renders a row per layer, re-renders on every store
+ * change (so it can never drift from what is drawn), routes a control back
+ * through the injected handler rather than writing the store itself, and stops
+ * observing on dispose.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { installFakeDom } from './support/measurePanelDom';
+import { DerivedLayerStore, type DerivedLayer } from '../src/model/DerivedLayer';
+import { createDerivedLayersList } from '../src/ui/DerivedLayersList';
+
+beforeEach(() => installFakeDom());
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const q = (root: any, sel: string): any => root.querySelector(sel);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const qa = (root: any, sel: string): any[] => root.querySelectorAll(sel);
+
+describe('createDerivedLayersList', () => {
+  it('is hidden with no rows until a layer exists', () => {
+    const store = new DerivedLayerStore();
+    const { element } = createDerivedLayersList({
+      store,
+      onSetVisible: () => {},
+      onSetOpacity: () => {},
+    });
+    expect(element.classList.contains('olv-hidden')).toBe(true);
+    expect(qa(element, '.olv-analyse-layer-row')).toHaveLength(0);
+  });
+
+  it('renders a row per layer and re-renders when the store changes', () => {
+    const store = new DerivedLayerStore();
+    const { element } = createDerivedLayersList({
+      store,
+      onSetVisible: () => {},
+      onSetOpacity: () => {},
+    });
+    store.put({ id: 'contours:a', type: 'contours', name: 'Contours', sourceScanIds: ['a'] });
+    expect(element.classList.contains('olv-hidden')).toBe(false);
+    expect(qa(element, '.olv-analyse-layer-row')).toHaveLength(1);
+    expect(q(element, '.olv-analyse-layer-head').textContent).toBe('Derived layers');
+
+    // A second product joins — the list follows the store's notification.
+    store.put({ id: 'cond:a', type: 'conductor-lines', name: 'Conductors', sourceScanIds: ['a'] });
+    expect(qa(element, '.olv-analyse-layer-row')).toHaveLength(2);
+  });
+
+  it('marks an exploratory layer in its type tag', () => {
+    const store = new DerivedLayerStore();
+    const { element } = createDerivedLayersList({
+      store,
+      onSetVisible: () => {},
+      onSetOpacity: () => {},
+    });
+    store.put({
+      id: 'ch',
+      type: 'change-raster',
+      name: 'Change',
+      sourceScanIds: ['a', 'b'],
+      evidenceExploratory: true,
+    });
+    const tags = qa(element, '.olv-analyse-layer-tag').map((t) => t.textContent);
+    expect(tags).toContain('Change · exploratory');
+  });
+
+  it('routes a visibility toggle back through the handler, not the store', () => {
+    const store = new DerivedLayerStore();
+    const calls: { layer: DerivedLayer; visible: boolean }[] = [];
+    const { element } = createDerivedLayersList({
+      store,
+      onSetVisible: (layer, visible) => calls.push({ layer, visible }),
+      onSetOpacity: () => {},
+    });
+    store.put({ id: 'contours:a', type: 'contours', name: 'Contours', sourceScanIds: ['a'] });
+    const cb = q(element, 'input');
+    cb.checked = false;
+    cb.dispatchEvent({ type: 'change' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].visible).toBe(false);
+    expect(calls[0].layer.id).toBe('contours:a');
+    // The list itself did not write the store — the record is still visible
+    // until the service applies the change and notifies.
+    expect(store.get('contours:a')!.visible).toBe(true);
+  });
+
+  it('routes an opacity change through the handler', () => {
+    const store = new DerivedLayerStore();
+    const calls: number[] = [];
+    const { element } = createDerivedLayersList({
+      store,
+      onSetVisible: () => {},
+      onSetOpacity: (_layer, opacity) => calls.push(opacity),
+    });
+    store.put({ id: 'contours:a', type: 'contours', name: 'Contours', sourceScanIds: ['a'] });
+    const range = qa(element, 'input').find((i) => i.type === 'range');
+    range.value = '40';
+    range.dispatchEvent({ type: 'input' });
+    expect(calls).toEqual([0.4]);
+  });
+
+  it('stops re-rendering after dispose', () => {
+    const store = new DerivedLayerStore();
+    const { element, dispose } = createDerivedLayersList({
+      store,
+      onSetVisible: () => {},
+      onSetOpacity: () => {},
+    });
+    store.put({ id: 'contours:a', type: 'contours', name: 'Contours', sourceScanIds: ['a'] });
+    expect(qa(element, '.olv-analyse-layer-row')).toHaveLength(1);
+    dispose();
+    store.put({ id: 'cond:a', type: 'conductor-lines', name: 'Conductors', sourceScanIds: ['a'] });
+    // No new row: the list is no longer observing.
+    expect(qa(element, '.olv-analyse-layer-row')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
The `DerivedLayerStore` modelled derived products (DTM, DSM, contours, slope, hillshade, change, buildings, conductors) but only the contour service consumed it — through a private store and a contour-specific control block. This makes derived layers first-class: one shared store and a generic list showing every layer with a Show toggle and opacity, the spine every future product plugs into.

`DerivedLayerStore` gains `subscribe()`, fired on every change, so the list is a pure view that re-renders from the store and cannot drift from what is drawn. `DerivedLayersList` (pure DOM, reusing the existing `olv-analyse-layer-*` row styles — no CSS change) routes a control back through the owning service: the store holds display state, the service mirrors it onto the geometry, so toggling a contour still repaints. The runner lifts the store to one shared instance, builds the list, and mounts it in the Analyse panel; contours appear as the first row. Conductors and the raster surfaces route in as follow-ons.

No `main.ts`/`Viewer.ts` growth — all wiring is in the runner, AnalysePanel, model and ui. Store subscribe + list component + routing are unit/integration tested (13 new cases); the full in-browser analysis flow that produces a layer was not re-run for this slice.