### PR TITLE
fix(streaming): explicit comparator for the replace-frontier key sort

### DIFF
--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -1415,7 +1415,7 @@ export class StreamingScheduler {
     const hidden = computeReplaceHidden(nodes);
     // Emit only on a real change: an ordered key of the hidden ids is cheap
     // next to re-touching every mesh's visibility each tick.
-    const key = [...hidden].sort().join(' ');
+    const key = [...hidden].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)).join(' ');
     if (key === this._lastHiddenKey) return;
     this._lastHiddenKey = key;
     this._callbacks.onFrontierChanged?.(hidden);


### PR DESCRIPTION
The replace-frontier change-detection key sorted the hidden ids with a bare `Array.prototype.sort()` (S2871), which failed the New-Code reliability gate after #785 merged. It now sorts with a deterministic string comparator; the join delimiter is a plain space.