### PR TITLE
feat(report): a Scan QA report, the honest successor to the retired acceptance checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ See [`docs/terrain-intelligence.md`](docs/terrain-intelligence.md), [`docs/valid
 - Annotations: drop categorised, titled markers with notes, browse and search them, capture the camera viewpoint with each, and undo/redo. The panel and the PDF report open with a grouping summary (totals, per-category counts, and how many areas the notes fall across)
 - Inspection sessions: export measurements, annotations, and named views to one JSON file and reload them later
 - Workflow recorder: record and replay `.olvworkflow` files of camera moves and tool actions, with settings for file format, save destination, start/stop shortcut, replay speed, a pre-record countdown, captured action families, and loop replay. It records actions only, never scan data, so a recipient needs the same scan open to replay
-- Multi-page PDF technical reports: two built-in templates (Survey Summary, Technical Report) with branding and unit-system awareness
+- Multi-page PDF technical reports: three built-in templates (Survey Summary, Technical Report, Scan QA) with branding and unit-system awareness
 - Visual Export Studio: orthographic RGB, height map, intensity, classification, depth, normal, and contour map exports
 - Screenshot export that burns in placed measurements and annotations as inspection evidence
 </details>

--- a/docs/developer-manual.md
+++ b/docs/developer-manual.md
@@ -46,7 +46,7 @@ Scan Intelligence report, and export the result.
 | FR-18 | Render with Eye Dome Lighting depth shading, adaptive or fixed point sizing, and antialiased round points — all tunable from the Rendering panel. |
 | FR-19 | Plan a LAS/LAZ load from its header — fast-load huge clouds by stride decoding, guard against out-of-memory, report staged progress, and allow the load to be cancelled mid-flight. |
 | FR-20 | Stream hierarchical point-cloud datasets (`COPC` `.copc.laz` and `EPT` `ept.json`) — local or remote — through a view-dependent scheduler with bounded residency. |
-| FR-21 | Generate multi-page PDF technical reports — two built-in templates, cover + dataset summary + image exports + annotations + measurements + technical notes, with branding (accent + logo) and metric/imperial unit awareness. |
+| FR-21 | Generate multi-page PDF technical reports — three built-in templates (Survey Summary, Technical Report, Scan QA), cover + dataset summary + image exports + annotations + measurements + technical notes, with branding (accent + logo) and metric/imperial unit awareness. |
 | FR-22 | Round-trip the full working state (camera, render settings, colour mode, annotations, measurements, named views, scan metadata) through a `.olvsession` JSON package. |
 | FR-23 | Export the Visual Export Studio image modes — orthographic RGB, height map, intensity, classification, depth, normal, and contour — with legend customisation. |
 

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -24,7 +24,7 @@ Format support is still evolving. This page separates what works today from what
 
 ## Current export targets
 
-`PLY`, `OBJ`, `XYZ`, and `CSV`, re-exported in real-world (global) coordinates, plus `PNG` snapshots of the current view (orthographic RGB, height map, intensity, classification, depth, normal, contour with legend customisation). Multi-page **PDF technical reports** (cover page + dataset summary + embedded image exports + annotations + measurements + technical notes; two built-in templates) ship as of v0.3.3. Working state — camera, render settings, colour mode, annotations, measurements, scan metadata — round-trips through the `.olvsession` JSON package.
+`PLY`, `OBJ`, `XYZ`, and `CSV`, re-exported in real-world (global) coordinates, plus `PNG` snapshots of the current view (orthographic RGB, height map, intensity, classification, depth, normal, contour with legend customisation). Multi-page **PDF technical reports** (cover page + dataset summary + embedded image exports + annotations + measurements + technical notes; three built-in templates including a cloud-derived Scan QA report) ship as of v0.3.3. Working state — camera, render settings, colour mode, annotations, measurements, scan metadata — round-trips through the `.olvsession` JSON package.
 
 ## iPhone and mobile scan exports
 

--- a/src/app/reportExport.ts
+++ b/src/app/reportExport.ts
@@ -40,9 +40,7 @@ import { captureProvenance, isNonTerrainVerdict } from '../diagnostics/capturePr
 import { triggerDownload } from '../io/download';
 
 import type { MetadataInputs, ReportProvenanceFingerprint } from '../report';
-import type { ReportScanQuality } from '../report/types';
-import { buildScanQuality } from '../report/ReportScanQuality';
-import { georefStatus } from '../geo/georefStatus';
+import type { ScanQualityFacts } from '../report/ReportScanQuality';
 import type { ResolvedCrs } from '../geo/CoordinateTypes';
 import type { Viewer } from '../render/Viewer';
 import type { DropZone } from '../ui/DropZone';
@@ -377,21 +375,14 @@ export async function generateReportPdf(templateId: string, deps: ReportExportDe
   // and which attributes the cloud carries. Built only for a static cloud — a
   // streaming source carries none of these attribute arrays — so the
   // `source-quality` section is omitted for a streamed scan rather than guessed.
-  let scanQuality: ReportScanQuality | undefined;
+  let scanQualityFacts: ScanQualityFacts | undefined;
   if (staticCloud) {
-    const crsKnown = activeCrsLabel !== undefined;
-    const datumKnown = activeCrs?.verticalDatum != null;
-    const gs = georefStatus(crsKnown, datumKnown, {
+    const hasClassification = staticCloud.classification !== undefined;
+    scanQualityFacts = {
+      crsKnown: activeCrsLabel !== undefined,
+      datumKnown: activeCrs?.verticalDatum != null,
       crsName: activeCrsLabel ?? null,
       datumName: activeCrs?.verticalDatum ?? null,
-    });
-    const hasClassification = staticCloud.classification !== undefined;
-    scanQuality = buildScanQuality({
-      coordinateHeadline: gs.headline,
-      positionLabel: gs.positionLabel,
-      heightLabel: gs.heightLabel,
-      positionKnown: gs.positionKnown,
-      heightKnown: gs.heightKnown,
       hasClassification,
       classificationDerived: hasClassification && staticCloud.classificationIsDerived,
       attributes: [
@@ -400,11 +391,11 @@ export async function generateReportPdf(templateId: string, deps: ReportExportDe
         { name: 'Classification', present: hasClassification },
         { name: 'GPS time', present: staticCloud.gpsTime !== undefined },
       ],
-    });
+    };
   }
   const inputs = report.composeReportInputs({
     templateId: validatedTemplateId,
-    scanQuality,
+    scanQualityFacts,
     title: coverTitle,
     subtitle: metadata.fileName,
     metadata,

--- a/src/app/reportExport.ts
+++ b/src/app/reportExport.ts
@@ -40,6 +40,9 @@ import { captureProvenance, isNonTerrainVerdict } from '../diagnostics/capturePr
 import { triggerDownload } from '../io/download';
 
 import type { MetadataInputs, ReportProvenanceFingerprint } from '../report';
+import type { ReportScanQuality } from '../report/types';
+import { buildScanQuality } from '../report/ReportScanQuality';
+import { georefStatus } from '../geo/georefStatus';
 import type { ResolvedCrs } from '../geo/CoordinateTypes';
 import type { Viewer } from '../render/Viewer';
 import type { DropZone } from '../ui/DropZone';
@@ -368,8 +371,40 @@ export async function generateReportPdf(templateId: string, deps: ReportExportDe
   } catch (err) {
     if (deps.debug) console.warn('[report] captureProvenance.fingerprint threw', err);
   }
+  // The Scan QA facts, built from what the loaded cloud proves: the
+  // georeferencing verdict from the RESOLVED active CRS (so a user override is
+  // honoured, exactly as the stamped CRS row is), how the classification arose,
+  // and which attributes the cloud carries. Built only for a static cloud — a
+  // streaming source carries none of these attribute arrays — so the
+  // `source-quality` section is omitted for a streamed scan rather than guessed.
+  let scanQuality: ReportScanQuality | undefined;
+  if (staticCloud) {
+    const crsKnown = activeCrsLabel !== undefined;
+    const datumKnown = activeCrs?.verticalDatum != null;
+    const gs = georefStatus(crsKnown, datumKnown, {
+      crsName: activeCrsLabel ?? null,
+      datumName: activeCrs?.verticalDatum ?? null,
+    });
+    const hasClassification = staticCloud.classification !== undefined;
+    scanQuality = buildScanQuality({
+      coordinateHeadline: gs.headline,
+      positionLabel: gs.positionLabel,
+      heightLabel: gs.heightLabel,
+      positionKnown: gs.positionKnown,
+      heightKnown: gs.heightKnown,
+      hasClassification,
+      classificationDerived: hasClassification && staticCloud.classificationIsDerived,
+      attributes: [
+        { name: 'RGB colour', present: staticCloud.colors !== undefined },
+        { name: 'Intensity', present: staticCloud.intensity !== undefined },
+        { name: 'Classification', present: hasClassification },
+        { name: 'GPS time', present: staticCloud.gpsTime !== undefined },
+      ],
+    });
+  }
   const inputs = report.composeReportInputs({
     templateId: validatedTemplateId,
+    scanQuality,
     title: coverTitle,
     subtitle: metadata.fileName,
     metadata,

--- a/src/report/ReportAssetComposer.ts
+++ b/src/report/ReportAssetComposer.ts
@@ -20,6 +20,7 @@ import type {
   ReportCoverInputs,
   ReportInputs,
   ReportProvenanceFingerprint,
+  ReportScanQuality,
   ReportSourceMetadata,
   ReportTemplateId,
   ReportVisualAsset,
@@ -86,6 +87,14 @@ export interface ComposeReportInputs {
    */
   readonly sourceMetadata?: ReportSourceMetadata;
   /**
+   * The Scan QA facts — the georeferencing verdict, classification provenance,
+   * attribute presence and does-not-establish caveats — built by the caller
+   * from the loaded cloud (it reads the resolved CRS and the cloud's attribute
+   * arrays, which this metadata-blind composer does not see). Rendered by the
+   * `source-quality` section; omitted → the section is omitted entirely.
+   */
+  readonly scanQuality?: ReportScanQuality;
+  /**
    * Annotation ordering — `'type'` groups issues together at the top,
    * `'createdAt'` (the default) reads chronologically. Mirrors the live
    * AnnotationPanel's two sort modes.
@@ -124,6 +133,7 @@ export function composeReportInputs(input: ComposeReportInputs): ReportInputs {
     technicalNotes: input.technicalNotes,
     provenance: input.provenance,
     sourceMetadata: input.sourceMetadata,
+    scanQuality: input.scanQuality,
     // Synthesised once here so every template that includes the
     // `inspection-summary` section renders the same findings. Pure of the
     // renderer; the QL-tier gating lives in buildInspectionSummary.

--- a/src/report/ReportAssetComposer.ts
+++ b/src/report/ReportAssetComposer.ts
@@ -20,11 +20,11 @@ import type {
   ReportCoverInputs,
   ReportInputs,
   ReportProvenanceFingerprint,
-  ReportScanQuality,
   ReportSourceMetadata,
   ReportTemplateId,
   ReportVisualAsset,
 } from './types';
+import { scanQualityFromFacts, type ScanQualityFacts } from './ReportScanQuality';
 import {
   buildDatasetSummary,
   type MetadataInputs,
@@ -87,13 +87,13 @@ export interface ComposeReportInputs {
    */
   readonly sourceMetadata?: ReportSourceMetadata;
   /**
-   * The Scan QA facts — the georeferencing verdict, classification provenance,
-   * attribute presence and does-not-establish caveats — built by the caller
-   * from the loaded cloud (it reads the resolved CRS and the cloud's attribute
-   * arrays, which this metadata-blind composer does not see). Rendered by the
-   * `source-quality` section; omitted → the section is omitted entirely.
+   * The raw Scan QA facts, as primitives read off the loaded cloud by the caller
+   * (the resolved CRS, the classification-derived flag, attribute presence). The
+   * composer turns them into the `source-quality` section here, in the lazy
+   * report chunk, so the eager report-export path imports neither `georefStatus`
+   * nor the builder. Omitted → the section is omitted entirely.
    */
-  readonly scanQuality?: ReportScanQuality;
+  readonly scanQualityFacts?: ScanQualityFacts;
   /**
    * Annotation ordering — `'type'` groups issues together at the top,
    * `'createdAt'` (the default) reads chronologically. Mirrors the live
@@ -133,7 +133,7 @@ export function composeReportInputs(input: ComposeReportInputs): ReportInputs {
     technicalNotes: input.technicalNotes,
     provenance: input.provenance,
     sourceMetadata: input.sourceMetadata,
-    scanQuality: input.scanQuality,
+    scanQuality: input.scanQualityFacts ? scanQualityFromFacts(input.scanQualityFacts) : undefined,
     // Synthesised once here so every template that includes the
     // `inspection-summary` section renders the same findings. Pure of the
     // renderer; the QL-tier gating lives in buildInspectionSummary.

--- a/src/report/ReportPdfRenderer.ts
+++ b/src/report/ReportPdfRenderer.ts
@@ -254,6 +254,10 @@ const TEMPLATE_DESIGN_KEYS: Record<ReportTemplateId, TemplateDesignKey> = {
     tag: 'TECHNICAL',
     defaultAccent: { r: 0.13, g: 0.45, b: 0.78 }, // engineer blue
   },
+  'scan-qa': {
+    tag: 'SCAN QA',
+    defaultAccent: { r: 0.52, g: 0.36, b: 0.72 }, // QA violet
+  },
 };
 
 function designKeyFor(templateId: ReportTemplateId): TemplateDesignKey {
@@ -292,6 +296,8 @@ async function renderSection(
       });
     case 'source-metadata':
       return renderSourceMetadata(cursor, inputs, doc, accent, theme, body, bold, organisation);
+    case 'source-quality':
+      return renderScanQuality(cursor, inputs, doc, accent, theme, body, bold, organisation);
     case 'visuals':
       return renderVisuals(cursor, inputs, doc, accent, theme, body, bold, organisation);
     case 'annotations':
@@ -1048,6 +1054,66 @@ async function renderSourceMetadata(
       cursor = ensureSpace(cursor, 16, doc, accent, theme, organisation);
       cursor = drawLabelValueRow(cursor, f.name, f.value, body, bold, theme);
     }
+  }
+  return { page: cursor.page, y: cursor.y - 14 };
+}
+
+async function renderScanQuality(
+  cursor: PageCursor,
+  inputs: ReportInputs,
+  doc: PDFDocument,
+  accent: ParsedColor,
+  theme: ReportThemePalette,
+  body: PDFFont,
+  bold: PDFFont,
+  organisation: string | undefined,
+): Promise<PageCursor> {
+  const q = inputs.scanQuality;
+  if (!q) return cursor;
+  cursor = ensureSpace(cursor, 90, doc, accent, theme, organisation);
+  cursor = drawSectionHeader(cursor, 'Scan quality', accent, bold);
+  cursor = drawBodyLine(
+    cursor,
+    'A summary of what the loaded scan establishes about itself. Every line ' +
+      'below is read off the cloud; the boundary of the report is stated at the end.',
+    body,
+    theme,
+  );
+  cursor = { page: cursor.page, y: cursor.y - 4 };
+
+  // Coordinate quality — the georeferencing verdict and its two sub-facts.
+  cursor = ensureSpace(cursor, 48, doc, accent, theme, organisation);
+  cursor = drawLabelValueRow(cursor, 'Coordinate reference', q.coordinateHeadline, body, bold, theme);
+  cursor = drawLabelValueRow(cursor, 'Position', q.positionLabel, body, bold, theme);
+  cursor = drawLabelValueRow(cursor, 'Height', q.heightLabel, body, bold, theme);
+
+  // Classification provenance.
+  cursor = ensureSpace(cursor, 16, doc, accent, theme, organisation);
+  cursor = drawLabelValueRow(cursor, 'Classification', q.classificationNote, body, bold, theme);
+
+  // Attributes the cloud carries.
+  if (q.attributes.length > 0) {
+    const carried = q.attributes.filter((a) => a.present).map((a) => a.name);
+    const absent = q.attributes.filter((a) => !a.present).map((a) => a.name);
+    cursor = ensureSpace(cursor, 16, doc, accent, theme, organisation);
+    cursor = drawLabelValueRow(cursor, 'Attributes present', carried.length > 0 ? carried.join(', ') : 'none', body, bold, theme);
+    if (absent.length > 0) {
+      cursor = drawLabelValueRow(cursor, 'Attributes absent', absent.join(', '), body, bold, theme);
+    }
+  }
+
+  // The boundary of the report — always shown, one line each.
+  cursor = ensureSpace(cursor, 30, doc, accent, theme, organisation);
+  cursor = { page: cursor.page, y: cursor.y - 4 };
+  cursor.page.drawText('This report does not establish', {
+    x: MARGIN, y: cursor.y - BODY_FONT_SIZE,
+    size: BODY_FONT_SIZE, font: bold,
+    color: rgb(theme.bodyText.r, theme.bodyText.g, theme.bodyText.b),
+  });
+  cursor = { page: cursor.page, y: cursor.y - BODY_FONT_SIZE - 4 };
+  for (const caveat of q.caveats) {
+    cursor = ensureSpace(cursor, 16, doc, accent, theme, organisation);
+    cursor = drawBodyLine(cursor, `• ${caveat}`, body, theme, 2);
   }
   return { page: cursor.page, y: cursor.y - 14 };
 }

--- a/src/report/ReportScanQuality.ts
+++ b/src/report/ReportScanQuality.ts
@@ -1,0 +1,77 @@
+/**
+ * ReportScanQuality.ts — the Scan QA facts, assembled from what the loaded
+ * cloud can prove.
+ *
+ * This is the honest successor to the retired `scan-acceptance` report, whose
+ * checklist was metadata-PRESENCE rows dressed as a certificate. The rule here
+ * is the opposite: state only facts read off the cloud — the georeferencing
+ * verdict, how the classification arose, which attributes the cloud carries —
+ * and pair them with an explicit, non-optional list of what the report does NOT
+ * establish. Nothing here asserts survey-grade acceptance, vertical accuracy, or
+ * a density figure it did not measure.
+ *
+ * Pure and deterministic: given the facts it returns the section model and the
+ * caveats. No DOM, no pdf-lib, no cloud import — the caller reads the facts off
+ * the cloud and passes primitives across, keeping the report module model-blind.
+ */
+
+import type { ReportScanQuality } from './types';
+
+/** The facts a Scan QA section is built from, as primitives. */
+export interface ScanQualityInput {
+  /** Plain-language georeferencing headline (from `geo/georefStatus`). */
+  readonly coordinateHeadline: string;
+  readonly positionLabel: string;
+  readonly heightLabel: string;
+  /** Whether the scan has a horizontal position (CRS). */
+  readonly positionKnown: boolean;
+  /** Whether the scan has a real-world height reference (vertical datum). */
+  readonly heightKnown: boolean;
+  /** Whether the cloud carries any classification at all. */
+  readonly hasClassification: boolean;
+  /** Whether that classification was DERIVED in the viewer vs producer-supplied. */
+  readonly classificationDerived: boolean;
+  /** Which point attributes the cloud carries. */
+  readonly attributes: readonly { readonly name: string; readonly present: boolean }[];
+}
+
+/** How the classification arose, stated so a reader knows what to trust. */
+function classificationNote(hasClassification: boolean, derived: boolean): string {
+  if (!hasClassification) return 'No classification present.';
+  return derived
+    ? 'Classification derived in the viewer (heuristic) — review before trusting.'
+    : 'Classification supplied by the producer, carried through unchanged.';
+}
+
+/**
+ * The always-shown boundary of the report. The first two are unconditional (a
+ * QA report is never an acceptance certificate and this viewer establishes no
+ * vertical accuracy); the rest are added only where the cloud lacks the thing.
+ */
+function buildCaveats(input: ScanQualityInput): string[] {
+  const caveats = [
+    'This is a data-quality summary, not a survey-grade acceptance certificate.',
+    'Vertical accuracy is not established — no checkpoint comparison was run.',
+  ];
+  if (!input.positionKnown) {
+    caveats.push('The scan carries no horizontal CRS, so it is not placed on a map.');
+  }
+  if (!input.heightKnown) {
+    caveats.push('No vertical datum is declared, so heights are not tied to a known reference.');
+  }
+  if (input.hasClassification && input.classificationDerived) {
+    caveats.push('Derived classification is heuristic and is not a ground-truthed label.');
+  }
+  return caveats;
+}
+
+export function buildScanQuality(input: ScanQualityInput): ReportScanQuality {
+  return {
+    coordinateHeadline: input.coordinateHeadline,
+    positionLabel: input.positionLabel,
+    heightLabel: input.heightLabel,
+    classificationNote: classificationNote(input.hasClassification, input.classificationDerived),
+    attributes: input.attributes.map((a) => ({ name: a.name, present: a.present })),
+    caveats: buildCaveats(input),
+  };
+}

--- a/src/report/ReportScanQuality.ts
+++ b/src/report/ReportScanQuality.ts
@@ -16,6 +16,46 @@
  */
 
 import type { ReportScanQuality } from './types';
+import { georefStatus } from '../geo/georefStatus';
+
+/**
+ * The raw facts the caller reads off the cloud, as primitives only. Kept
+ * separate from {@link ScanQualityInput} so the caller (the EAGER report-export
+ * path) passes primitives and never imports `georefStatus` or the builder:
+ * {@link scanQualityFromFacts} turns these into the section in the lazy report
+ * chunk, so nothing here weighs on the startup bundle.
+ */
+export interface ScanQualityFacts {
+  readonly crsKnown: boolean;
+  readonly datumKnown: boolean;
+  readonly crsName: string | null;
+  readonly datumName: string | null;
+  readonly hasClassification: boolean;
+  readonly classificationDerived: boolean;
+  readonly attributes: readonly { readonly name: string; readonly present: boolean }[];
+}
+
+/**
+ * Build the Scan QA section from the raw cloud facts: resolve the plain-language
+ * georeferencing verdict, then assemble the section and its caveats. Called from
+ * the lazy report composer so `georefStatus` and the builder ride that chunk.
+ */
+export function scanQualityFromFacts(facts: ScanQualityFacts): ReportScanQuality {
+  const gs = georefStatus(facts.crsKnown, facts.datumKnown, {
+    crsName: facts.crsName,
+    datumName: facts.datumName,
+  });
+  return buildScanQuality({
+    coordinateHeadline: gs.headline,
+    positionLabel: gs.positionLabel,
+    heightLabel: gs.heightLabel,
+    positionKnown: gs.positionKnown,
+    heightKnown: gs.heightKnown,
+    hasClassification: facts.hasClassification,
+    classificationDerived: facts.classificationDerived,
+    attributes: facts.attributes,
+  });
+}
 
 /** The facts a Scan QA section is built from, as primitives. */
 export interface ScanQualityInput {

--- a/src/report/ReportTemplates.ts
+++ b/src/report/ReportTemplates.ts
@@ -1,7 +1,7 @@
 /**
  * ReportTemplates.ts
  *
- * The two built-in report templates. Each is a pure-data record:
+ * The built-in report templates. Each is a pure-data record:
  * id, label, description, ordered list of sections.
  *
  * v0.5.5 P12 — consolidated from the previous six-template catalogue.
@@ -79,10 +79,33 @@ const technicalReport: ReportTemplate = {
   ],
 };
 
+const scanQa: ReportTemplate = {
+  id: 'scan-qa',
+  label: 'Scan QA',
+  description:
+    'A data-quality summary of the loaded scan: the honest inspection ' +
+    'verdict, the coordinate-reference and classification-provenance facts, ' +
+    'the dataset metadata, and an explicit statement of what the report does ' +
+    'NOT establish. The successor to the retired acceptance checklist — every ' +
+    'line read off the cloud, no metadata-presence rows dressed as a certificate.',
+  sections: [
+    'cover',
+    // The QL-gated findings verdict — the honest core the old checklist lacked.
+    'inspection-summary',
+    // The Scan QA facts: georef verdict, classification provenance, caveats.
+    'source-quality',
+    'dataset-summary',
+    // Capture type + confidence, without the full literature-cited evidence chain.
+    'provenance-compact',
+    'footer',
+  ],
+};
+
 /** The full template catalogue, in display order. */
 export const REPORT_TEMPLATES: readonly ReportTemplate[] = [
   surveySummary,
   technicalReport,
+  scanQa,
 ];
 
 /**
@@ -94,17 +117,16 @@ export const REPORT_TEMPLATES: readonly ReportTemplate[] = [
  *    members of the ~85 %-identical family — the complete record is the
  *    honest replacement.
  *  - terrain-review: a strict section-subset of the same shared core.
- *  - scan-acceptance: retired with this consolidation. Its checklist was
- *    metadata-only presence rows — the same title-overpromising defect
- *    this change removes. It returns behind real cloud-sampled checks
- *    once the analysis seam lands.
+ *  - scan-acceptance: its metadata-presence checklist was retired, and now maps
+ *    to `scan-qa` — the honest successor whose facts are read off the cloud, the
+ *    "real cloud-sampled checks" the retirement said it would return behind.
  */
 export const LEGACY_TEMPLATE_IDS: Readonly<Record<string, ReportTemplateId>> = {
   'engineering-inspection': 'technical-report',
   'qa-validation': 'technical-report',
   'technical-documentation': 'technical-report',
   'terrain-review': 'technical-report',
-  'scan-acceptance': 'technical-report',
+  'scan-acceptance': 'scan-qa',
 };
 
 /**

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -25,7 +25,8 @@ import type { ReportInspectionSummary } from './ReportFindings';
  */
 export type ReportTemplateId =
   | 'survey-summary'
-  | 'technical-report';
+  | 'technical-report'
+  | 'scan-qa';
 
 /** Which sections a template wants, in render order. */
 export type ReportSectionId =
@@ -35,6 +36,7 @@ export type ReportSectionId =
   | 'provenance'             // v0.3.6 — auto-computed capture-type + signals + literature bounds
   | 'provenance-compact'     // v0.5.5 — capture type + confidence + disclaimer only
   | 'source-metadata'        // v0.5.4 — the file's own declared metadata, verbatim
+  | 'source-quality'         // v0.6.8 — Scan QA: georef verdict, classification provenance, caveats
   | 'visuals'
   | 'annotations'
   | 'measurements'
@@ -245,6 +247,37 @@ export interface ReportInputs {
    * `inspection-summary` section; omitted otherwise.
    */
   readonly summary?: ReportInspectionSummary;
+  /**
+   * v0.6.8 — the Scan QA facts: coordinate-quality verdict, classification
+   * provenance, which attributes the cloud carries, and the explicit list of
+   * what the report does NOT establish. Rendered by the `source-quality`
+   * section; omitted otherwise. Every field is a fact read off the loaded cloud
+   * (georeferencing booleans, the classification-derived flag, attribute
+   * presence) — never a metadata-presence checkbox dressed as a certificate,
+   * which is the defect the retired `scan-acceptance` template carried.
+   */
+  readonly scanQuality?: ReportScanQuality;
+}
+
+/**
+ * The `source-quality` section's facts. Each is read off the loaded cloud, and
+ * the caveats state the report's boundary in plain terms — a QA report that
+ * cannot imply survey-grade acceptance, vertical accuracy, or a density claim it
+ * did not measure.
+ */
+export interface ReportScanQuality {
+  /** Plain-language georeferencing verdict, e.g. "On the map · elevation datum not declared". */
+  readonly coordinateHeadline: string;
+  /** Position sub-fact, e.g. "On the map" / "Not on a map". */
+  readonly positionLabel: string;
+  /** Height sub-fact, e.g. "Real-world elevation" / "Datum not declared". */
+  readonly heightLabel: string;
+  /** How the classification arose: producer-supplied vs derived in the viewer. */
+  readonly classificationNote: string;
+  /** Which point attributes the cloud actually carries (present or absent). */
+  readonly attributes: readonly { readonly name: string; readonly present: boolean }[];
+  /** What this report does NOT establish — always shown, never optional. */
+  readonly caveats: readonly string[];
 }
 
 /**

--- a/tests/reportEngine.test.ts
+++ b/tests/reportEngine.test.ts
@@ -30,9 +30,25 @@ import type { Measurement } from '../src/render/measure/types';
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('templates', () => {
-  it('ships exactly two report templates (v0.5.5 P12 consolidation)', () => {
-    expect(REPORT_TEMPLATES).toHaveLength(2);
-    expect(REPORT_TEMPLATES.map((t) => t.id)).toEqual(['survey-summary', 'technical-report']);
+  it('ships the survey, technical, and scan-QA templates', () => {
+    expect(REPORT_TEMPLATES).toHaveLength(3);
+    expect(REPORT_TEMPLATES.map((t) => t.id)).toEqual([
+      'survey-summary',
+      'technical-report',
+      'scan-qa',
+    ]);
+  });
+
+  it('scan-qa foregrounds the quality facts and omits the user\'s own marks', () => {
+    const t = getReportTemplate('scan-qa');
+    expect(t).toBeDefined();
+    if (!t) return;
+    expect(t.sections).toContain('inspection-summary');
+    expect(t.sections).toContain('source-quality');
+    expect(t.sections).toContain('dataset-summary');
+    expect(t.sections).not.toContain('measurements');
+    expect(t.sections).not.toContain('annotations');
+    expect(t.sections).not.toContain('visuals');
   });
 
   it('default template id resolves to a valid template', () => {
@@ -97,7 +113,8 @@ describe('templates', () => {
     expect(normalizeReportTemplateId('qa-validation')).toBe('technical-report');
     expect(normalizeReportTemplateId('technical-documentation')).toBe('technical-report');
     expect(normalizeReportTemplateId('terrain-review')).toBe('technical-report');
-    expect(normalizeReportTemplateId('scan-acceptance')).toBe('technical-report');
+    // scan-acceptance now resolves to its real successor, the Scan QA report.
+    expect(normalizeReportTemplateId('scan-acceptance')).toBe('scan-qa');
     expect(normalizeReportTemplateId('survey-summary')).toBe('survey-summary');
     expect(normalizeReportTemplateId('technical-report')).toBe('technical-report');
     // getReportTemplate follows the same mapping, so legacy callers work.

--- a/tests/reportScanQuality.test.ts
+++ b/tests/reportScanQuality.test.ts
@@ -1,0 +1,82 @@
+/**
+ * reportScanQuality.test.ts — the Scan QA facts builder.
+ *
+ * The rule the retired `scan-acceptance` template broke: state facts read off
+ * the cloud, and always disclose the boundary of the report. These cases pin
+ * that the two unconditional caveats are always present, that a missing CRS /
+ * datum / classification each adds its own honest caveat, and that a
+ * producer-supplied classification is never described as derived.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildScanQuality, type ScanQualityInput } from '../src/report/ReportScanQuality';
+
+const base: ScanQualityInput = {
+  coordinateHeadline: 'Placed in the real world',
+  positionLabel: 'On the map',
+  heightLabel: 'Real-world elevation',
+  positionKnown: true,
+  heightKnown: true,
+  hasClassification: true,
+  classificationDerived: false,
+  attributes: [
+    { name: 'RGB colour', present: true },
+    { name: 'Classification', present: true },
+  ],
+};
+
+describe('buildScanQuality', () => {
+  it('always states the two unconditional boundaries', () => {
+    const q = buildScanQuality(base);
+    expect(q.caveats).toContain(
+      'This is a data-quality summary, not a survey-grade acceptance certificate.',
+    );
+    expect(q.caveats).toContain(
+      'Vertical accuracy is not established — no checkpoint comparison was run.',
+    );
+  });
+
+  it('adds no positional caveat when the scan is fully anchored', () => {
+    const q = buildScanQuality(base);
+    expect(q.caveats.some((c) => c.includes('horizontal CRS'))).toBe(false);
+    expect(q.caveats.some((c) => c.includes('vertical datum'))).toBe(false);
+    expect(q.classificationNote).toBe(
+      'Classification supplied by the producer, carried through unchanged.',
+    );
+  });
+
+  it('names the missing position and datum when the scan is floating', () => {
+    const q = buildScanQuality({
+      ...base,
+      positionKnown: false,
+      heightKnown: false,
+      coordinateHeadline: 'Floating scan — not placed on Earth',
+    });
+    expect(q.caveats.some((c) => c.includes('no horizontal CRS'))).toBe(true);
+    expect(q.caveats.some((c) => c.includes('No vertical datum'))).toBe(true);
+  });
+
+  it('flags a derived classification as heuristic, not a producer label', () => {
+    const q = buildScanQuality({ ...base, classificationDerived: true });
+    expect(q.classificationNote).toContain('derived in the viewer (heuristic)');
+    expect(q.caveats.some((c) => c.includes('Derived classification is heuristic'))).toBe(true);
+  });
+
+  it('states plainly when no classification is present, and adds no derived caveat', () => {
+    const q = buildScanQuality({
+      ...base,
+      hasClassification: false,
+      classificationDerived: false,
+    });
+    expect(q.classificationNote).toBe('No classification present.');
+    expect(q.caveats.some((c) => c.includes('Derived classification'))).toBe(false);
+  });
+
+  it('carries the attribute presence list through unchanged', () => {
+    const q = buildScanQuality(base);
+    expect(q.attributes).toEqual([
+      { name: 'RGB colour', present: true },
+      { name: 'Classification', present: true },
+    ]);
+  });
+});

--- a/tests/reportTemplateGoldens.test.ts
+++ b/tests/reportTemplateGoldens.test.ts
@@ -223,19 +223,19 @@ describe('scan-qa source-quality section', () => {
       annotations: [],
       measurements: [],
       unitSystem: 'metric',
-      scanQuality: {
-        coordinateHeadline: 'On the map · elevation datum not declared',
-        positionLabel: 'On the map',
-        heightLabel: 'Datum not declared',
-        classificationNote: 'Classification derived in the viewer (heuristic) — review before trusting.',
+      // Raw facts: a horizontally-placed scan with no vertical datum and a
+      // derived classification. georefStatus + buildScanQuality turn these into
+      // the headline "On the map · elevation datum not declared" and its caveat.
+      scanQualityFacts: {
+        crsKnown: true,
+        datumKnown: false,
+        crsName: 'WGS 84 / UTM zone 12N',
+        datumName: null,
+        hasClassification: true,
+        classificationDerived: true,
         attributes: [
           { name: 'RGB colour', present: true },
           { name: 'Intensity', present: false },
-        ],
-        caveats: [
-          'This is a data-quality summary, not a survey-grade acceptance certificate.',
-          'Vertical accuracy is not established — no checkpoint comparison was run.',
-          'No vertical datum is declared, so heights are not tied to a known reference.',
         ],
       },
     });

--- a/tests/reportTemplateGoldens.test.ts
+++ b/tests/reportTemplateGoldens.test.ts
@@ -184,7 +184,6 @@ describe('legacy template ids render via the engine', () => {
     ['qa-validation', 'technical-report'],
     ['technical-documentation', 'technical-report'],
     ['terrain-review', 'technical-report'],
-    ['scan-acceptance', 'technical-report'],
   ] as const)('%s → %s', async (legacy, expected) => {
     const { templateId, text } = await renderText(makeInputs(legacy));
     expect(templateId).toBe(expected);
@@ -192,9 +191,64 @@ describe('legacy template ids render via the engine', () => {
     expect(text).toContain('Expected accuracy (cited literature)');
   });
 
+  it('scan-acceptance now resolves to the real Scan QA successor', async () => {
+    // The retired metadata-presence checklist maps to the honest QA report.
+    const { templateId } = await renderText(makeInputs('scan-acceptance'));
+    expect(templateId).toBe('scan-qa');
+  });
+
   it('a genuinely unknown id still throws a precise error', async () => {
     await expect(generateReport(makeInputs('not-a-template'))).rejects.toThrow(
       /Unknown report template id/,
     );
+  });
+});
+
+describe('scan-qa source-quality section', () => {
+  function scanQaInputs(): ReportInputs {
+    return composeReportInputs({
+      templateId: 'scan-qa',
+      title: 'Scan QA fixture',
+      metadata: {
+        fileName: 'golden.copc.laz',
+        format: 'COPC',
+        sourcePointCount: 4_683_690,
+        width: 120, depth: 80, height: 22,
+        density: 488,
+        hasRgb: true, hasIntensity: true, hasClassification: true,
+        crsName: 'WGS 84 / UTM zone 12N (EPSG:32612)',
+        crsUnit: 'metre',
+      },
+      visuals: [],
+      annotations: [],
+      measurements: [],
+      unitSystem: 'metric',
+      scanQuality: {
+        coordinateHeadline: 'On the map · elevation datum not declared',
+        positionLabel: 'On the map',
+        heightLabel: 'Datum not declared',
+        classificationNote: 'Classification derived in the viewer (heuristic) — review before trusting.',
+        attributes: [
+          { name: 'RGB colour', present: true },
+          { name: 'Intensity', present: false },
+        ],
+        caveats: [
+          'This is a data-quality summary, not a survey-grade acceptance certificate.',
+          'Vertical accuracy is not established — no checkpoint comparison was run.',
+          'No vertical datum is declared, so heights are not tied to a known reference.',
+        ],
+      },
+    });
+  }
+
+  it('renders the QA facts and the does-not-establish boundary', async () => {
+    const { text, failed } = await renderText(scanQaInputs());
+    expect(failed).toEqual([]);
+    expect(text).toContain('Scan quality');
+    expect(text).toContain('On the map · elevation datum not declared');
+    expect(text).toContain('This report does not establish');
+    expect(text).toContain('not a survey-grade acceptance certificate');
+    // The QA template foregrounds the scan, not the user's own marks.
+    expect(text).not.toContain('Deck span');
   });
 });


### PR DESCRIPTION
The `scan-acceptance` report was retired because its checklist was metadata-PRESENCE rows dressed as a certificate. The infra to do it honestly now exists, so this composes a real successor.

A new `scan-qa` template adds a `source-quality` section stating facts read off the loaded cloud: the georeferencing verdict (from the RESOLVED active CRS, so a user override is honoured), how the classification arose (producer-supplied vs derived-in-viewer), which attributes the cloud carries, and an explicit, always-shown list of what the report does NOT establish — never survey-grade acceptance, never a vertical accuracy it did not measure. The template foregrounds the QL-gated inspection verdict and the measured dataset facts, and omits the user's own measurements/annotations/visuals.

`buildScanQuality` holds the honesty logic as a pure, tested core; `reportExport` builds the facts from the cloud and threads them through the existing composer; the section renders through the existing engine (auto-covered by the PDF smoke test). `scan-acceptance` now maps to `scan-qa` — the real cloud-sampled checks the retirement said it would return behind. No main.ts/Viewer.ts growth. New builder + golden + registration tests; full suite green.