### PR TITLE
feat(terrain): coloured relief — style the hillshade with an elevation ramp

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -146,13 +146,6 @@
       "review": "2027-02-28"
     },
     {
-      "path": "src/render/paletteCatalog.ts",
-      "status": "staged",
-      "why": "The user-facing palette catalogue plus a registry for custom palettes from the Palette Editor. The editor was never built; colorModes.ts and confidenceOverlay.ts cite this file in prose but import nothing from it.",
-      "graduation": "A palette picker or the Palette Editor reads the catalogue.",
-      "review": "2027-02-28"
-    },
-    {
       "path": "src/render/streaming/pipelineLimits.ts",
       "status": "staged",
       "why": "Its own header states the position: the P8 fetch/decode/upload separation is evidence-gated, so this is \"the policy math only ... NOT wired into the live scheduler\", and wiring waits on device profiling that shows the P7 upload queue did not already resolve the stalls.",

--- a/src/render/hypsometricPalette.ts
+++ b/src/render/hypsometricPalette.ts
@@ -1,0 +1,39 @@
+/**
+ * hypsometricPalette.ts — the built-in perceptual ramps as hypsometric stops.
+ *
+ * The surface-preview path colours a DTM tile through `hypsometricColor`, which
+ * takes a `ColorStop[]` ramp; the point cloud colours elevation through the
+ * named perceptual ramps in `colorModes` (cividis, viridis, …). This samples one
+ * of those named ramps into the stop list the surface renderer wants, so an
+ * analyst can style the terrain preview — and the PNG it exports — with the same
+ * colour-blind-safe ramps the points use, and a swatch can never disagree with
+ * the raster it labels.
+ *
+ * Pure: sampling only, no DOM and no three.js. Imported by the (lazy) Analyse
+ * panel, so it never weighs on the startup bundle.
+ */
+
+import { elevationRampColor, type ElevationPalette } from './colorModes';
+import type { ColorStop } from '../terrain/contour/hypsometric';
+
+/** How many stops to sample a continuous ramp into. Enough for a smooth read. */
+const DEFAULT_STOP_COUNT = 9;
+
+/**
+ * Sample a named perceptual ramp into evenly spaced hypsometric stops. `count`
+ * stops span t ∈ [0, 1] inclusive; the surface renderer interpolates between
+ * them exactly as it does the default terrain ramp.
+ */
+export function builtinHypsometricStops(
+  palette: ElevationPalette,
+  count = DEFAULT_STOP_COUNT,
+): ColorStop[] {
+  const n = Math.max(2, Math.floor(count));
+  const stops: ColorStop[] = [];
+  for (let i = 0; i < n; i++) {
+    const t = i / (n - 1);
+    const [r, g, b] = elevationRampColor(t, palette);
+    stops.push({ t, color: { r, g, b } });
+  }
+  return stops;
+}

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -138,7 +138,11 @@ import { TERRAIN_METRIC_VERSION } from '../terrain/datasetIntelligence';
 import {
   hypsometricColor,
   DEFAULT_CANOPY_PALETTE,
+  type ColorStop,
 } from '../terrain/contour/hypsometric';
+import { builtinHypsometricStops } from '../render/hypsometricPalette';
+import { listBuiltinPalettes } from '../render/paletteCatalog';
+import type { ElevationPalette } from '../render/colorModes';
 import { histogramBins, type Histogram } from '../terrain/contour/histogram';
 import {
   shadeFromSlopeAspect,
@@ -1648,17 +1652,39 @@ export class AnalysePanel {
     const coverage = r.dtm.coverage;
     if (!(cols > 0 && rows > 0) || slope.length !== cols * rows) return null;
 
+    // Elevation range over the covered cells, for the coloured-relief tint. A
+    // flat or empty surface leaves `elevRange` false, so the palette options
+    // stay disabled and the tile is grayscale-only.
+    const z = r.dtm.z;
+    let zMin = Infinity;
+    let zMax = -Infinity;
+    for (let i = 0; i < z.length; i++) {
+      if (coverage[i] !== 0 && Number.isFinite(z[i])) {
+        if (z[i] < zMin) zMin = z[i];
+        if (z[i] > zMax) zMax = z[i];
+      }
+    }
+    const elevRange = zMax > zMin;
+
     const tile = el('div', { className: 'olv-analyse-raster-tile' });
     tile.append(el('div', { className: 'olv-analyse-sublabel', text: 'Relief (hillshade)' }));
     const canvas = this._makeCanvas(cols, rows);
     const wrap = this._rasterWrap(canvas);
     tile.append(wrap.wrap);
-    tile.append(this._grayLegend());
+    // A swappable legend slot: grayscale shade by default, an elevation colour
+    // ramp when the analyst picks a palette.
+    const legendSlot = el('div', { className: 'olv-analyse-legend-slot' });
+    legendSlot.append(this._grayLegend());
+    tile.append(legendSlot);
 
     const caption = el('div', { className: 'olv-analyse-caption' });
     let multi = true;
     let azimuth = 315;
     let altitude = 45;
+    // null = grayscale shading; otherwise the coloured-relief ramp, sampled once
+    // per selection into hypsometric stops.
+    let paletteId: ElevationPalette | null = null;
+    let stops: ColorStop[] = [];
 
     const repaint = (): void => {
       const res = multi
@@ -1667,6 +1693,7 @@ export class AnalysePanel {
             azimuthDeg: azimuth,
             altitudeDeg: altitude,
           });
+      const tinted = paletteId !== null && elevRange;
       const ctx = canvas.getContext('2d');
       if (ctx) {
         const img = ctx.createImageData(cols, rows);
@@ -1678,7 +1705,18 @@ export class AnalysePanel {
             const o = (dst + c) * 4;
             if (res.coverage[si] !== 0) {
               const v = res.shade[si];
-              img.data[o] = v; img.data[o + 1] = v; img.data[o + 2] = v; img.data[o + 3] = 255;
+              if (tinted) {
+                // Coloured relief: the elevation ramp modulated by the shade, so
+                // the hillshade's form reads through the hypsometric colour.
+                const base = hypsometricColor(z[si], zMin, zMax, stops);
+                const k = v / 255;
+                img.data[o] = Math.round(base.r * k);
+                img.data[o + 1] = Math.round(base.g * k);
+                img.data[o + 2] = Math.round(base.b * k);
+              } else {
+                img.data[o] = v; img.data[o + 1] = v; img.data[o + 2] = v;
+              }
+              img.data[o + 3] = 255;
             } else {
               img.data[o + 3] = 0;
             }
@@ -1686,9 +1724,10 @@ export class AnalysePanel {
         }
         ctx.putImageData(img, 0, 0);
       }
-      caption.textContent = multi
+      const light = multi
         ? `Multi-directional · alt ${altitude}°`
         : `Sun ${String(azimuth).padStart(3, '0')}° · alt ${altitude}°`;
+      caption.textContent = tinted ? `Coloured relief · ${light}` : light;
     };
 
     // Coalesce slider repaints into one rAF: dragging fires many `input`
@@ -1763,7 +1802,39 @@ export class AnalysePanel {
       altVal.textContent = `${altitude}°`;
       scheduleRepaint();
     });
-    controls.append(multiLabel, azRow, altRow);
+
+    // Palette: grayscale shading, or an elevation ramp for coloured relief. The
+    // colour-blind-safe ramps are marked so the choice is informed. Disabled on
+    // a flat surface, where an elevation ramp would carry no information.
+    const palRow = el('label', { className: 'olv-analyse-relief-slider' });
+    const palSelect = document.createElement('select');
+    palSelect.className = 'olv-analyse-relief-select';
+    palSelect.setAttribute('aria-label', 'Relief palette');
+    palSelect.disabled = !elevRange;
+    const shadeOpt = document.createElement('option');
+    shadeOpt.value = '';
+    shadeOpt.textContent = 'Shading';
+    palSelect.append(shadeOpt);
+    for (const p of listBuiltinPalettes()) {
+      const opt = document.createElement('option');
+      opt.value = p.id;
+      opt.textContent = p.colorblindSafe ? `${p.label} (CVD-safe)` : p.label;
+      palSelect.append(opt);
+    }
+    palRow.append(el('span', { className: 'olv-analyse-relief-tag', text: 'Colour' }), palSelect);
+    palSelect.addEventListener('change', () => {
+      paletteId = palSelect.value === '' ? null : (palSelect.value as ElevationPalette);
+      stops = paletteId !== null ? builtinHypsometricStops(paletteId) : [];
+      // Swap the legend to match: an elevation ramp when tinted, else the shade.
+      legendSlot.replaceChildren(
+        paletteId !== null && elevRange
+          ? this._legendBar({ min: 0, max: zMax - zMin, palette: stops, unit: this._verticalUnitToken() })
+          : this._grayLegend(),
+      );
+      repaint();
+    });
+
+    controls.append(multiLabel, azRow, altRow, palRow);
     tile.append(controls);
     tile.append(caption);
 

--- a/tests/hypsometricPalette.test.ts
+++ b/tests/hypsometricPalette.test.ts
@@ -1,0 +1,39 @@
+/**
+ * hypsometricPalette.test.ts — sampling a named perceptual ramp into the
+ * hypsometric stop list the surface renderer consumes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { builtinHypsometricStops } from '../src/render/hypsometricPalette';
+import { elevationRampColor } from '../src/render/colorModes';
+import { hypsometricColor } from '../src/terrain/contour/hypsometric';
+
+describe('builtinHypsometricStops', () => {
+  it('spans t ∈ [0,1] inclusive with the requested number of stops', () => {
+    const stops = builtinHypsometricStops('cividis', 5);
+    expect(stops).toHaveLength(5);
+    expect(stops[0].t).toBe(0);
+    expect(stops.at(-1)!.t).toBe(1);
+    expect(stops.map((s) => s.t)).toEqual([0, 0.25, 0.5, 0.75, 1]);
+  });
+
+  it('samples the same colours the point cloud uses for that ramp', () => {
+    const stops = builtinHypsometricStops('viridis', 3);
+    for (const s of stops) {
+      const [r, g, b] = elevationRampColor(s.t, 'viridis');
+      expect(s.color).toEqual({ r, g, b });
+    }
+  });
+
+  it('produces a ramp the surface renderer accepts end to end', () => {
+    const stops = builtinHypsometricStops('inferno');
+    const low = hypsometricColor(0, 0, 100, stops);
+    const high = hypsometricColor(100, 0, 100, stops);
+    // A perceptual ramp moves from dark to bright, so the two ends differ.
+    expect(low).not.toEqual(high);
+  });
+
+  it('never returns fewer than two stops even when asked for one', () => {
+    expect(builtinHypsometricStops('turbo', 1)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
The relief surface preview was grayscale only. It now takes an elevation palette: a **Shading** default, or one of the built-in perceptual ramps (cividis / viridis / inferno / turbo / classic, the colour-blind-safe ones marked), applied as a hypsometric tint modulated by the hillshade so the terrain's form still reads through the colour — the classic **coloured-relief** cartographic product, exportable as the same PNG.

New pure `builtinHypsometricStops` samples a named ramp (the same one the point cloud uses, via `elevationRampColor`) into the surface renderer's `ColorStop[]`, so a legend swatch can never disagree with the raster. The picker reads the staged `paletteCatalog` — now graduated out of unreachable-modules (a palette picker reads it, its stated graduation).

Bundle-safe: every file rides the lazy Analyse chunk, so the eager `index` bundle is untouched (777 KiB, under ceiling). The staged point-cloud `hillshadeColors` stays parked — a 3D hillshade colour mode would edit the eager ColorMode union with no headroom. New adapter test; full suite green.