### PR TITLE
feat(change): a typed RegistrationArtifact for repeat-epoch alignment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5341,7 +5341,7 @@ function compareLoadedLayers(): void {
   void (async () => {
     // Load the change-detection code on demand, then yield a frame so the
     // "working" line paints before the synchronous ground-filter compute.
-    const [{ buildSharedEpochDtms }, { alignEpochClouds, summarizeAlignment }, { compareDtms, summarizeChange }, { changeToEsriAscii }] =
+    const [{ buildSharedEpochDtms }, { alignEpochClouds, summarizeAlignment, buildRegistrationArtifact, summarizeRegistration }, { compareDtms, summarizeChange }, { changeToEsriAscii }] =
       await Promise.all([
         loadCompareEpochs(),
         loadAlignEpochs(),
@@ -5384,7 +5384,7 @@ function compareLoadedLayers(): void {
         verticalUnitToMetres: ctxA.verticalUnitToMetres, // Z keeps its OWN declared scale; the horizontal verdict never stands in for it
       });
       const header = `${baseName(a.name)} (before) → ${baseName(b.name)} (after)`;
-      inspector.setCompareResult([header, summarizeAlignment(alignment), ...summarizeChange(cmp, { registrationSigmaM: alignment.applied ? alignment.rmsResidualM : 0, horizontalUnitToMetres: frames.horizontalUnitToMetres })]);
+      inspector.setCompareResult([header, summarizeAlignment(alignment), summarizeRegistration(buildRegistrationArtifact(alignment, { targetId: ids[0], targetName: a.name, sourceId: ids[1], sourceName: b.name }, Date.now())), ...summarizeChange(cmp, { registrationSigmaM: alignment.applied ? alignment.rmsResidualM : 0, horizontalUnitToMetres: frames.horizontalUnitToMetres })]);
       // A georeferenced .asc of the signed difference. The shared grid is built
       // in the common world frame, so its origin IS the scan's projected corner.
       // The .asc grid geometry (cellsize + corners) is in the source LINEAR

--- a/src/terrain/change/alignEpochs.ts
+++ b/src/terrain/change/alignEpochs.ts
@@ -469,3 +469,13 @@ export function summarizeAlignment(a: EpochAlignment): string {
     ? `${base} Indicative local-frame result — one or both epochs declare no CRS or vertical datum, so this is not a georeferenced agreement.`
     : base;
 }
+
+// The registration provenance record and its readout — re-exported here so the
+// compare flow, which already lazy-loads this module, reaches them through the
+// same import rather than a second lazy chunk.
+export {
+  buildRegistrationArtifact,
+  summarizeRegistration,
+  type RegistrationArtifact,
+  type RegistrationScans,
+} from './registrationArtifact';

--- a/src/terrain/change/registrationArtifact.ts
+++ b/src/terrain/change/registrationArtifact.ts
@@ -1,0 +1,102 @@
+/**
+ * registrationArtifact.ts — a typed provenance record for a repeat-epoch
+ * registration.
+ *
+ * `alignEpochs` already solves and reports the transform (yaw, translation,
+ * residual, applied-or-refused) in {@link EpochAlignment}, but that value has no
+ * identity: it does not say WHICH two scans it registered, by WHICH method at
+ * which version, or WHEN. A {@link RegistrationArtifact} is that identity wrapped
+ * around the alignment — the small, honest provenance record a change comparison
+ * can carry, log, or export beside its result so "what aligned what, and was it
+ * trusted" travels with the numbers rather than only living in a display string.
+ *
+ * Pure data: it composes the alignment the solver already produced with the
+ * source/target identity the caller holds and the registered method reference.
+ * It states the transform and whether it was APPLIED; it never re-solves and
+ * never moves geometry. The full registration workspace (tie points,
+ * accept/reject, a persisted registry) is a separate, larger piece.
+ */
+
+import type { EpochAlignment, EpochAppliedDof } from './alignEpochs';
+import type { Vec3 } from './icpRegister';
+import { methodRef, type MethodRef } from '../../science/methodRegistry';
+
+/** The registered method the epoch alignment implements. */
+const EPOCH_ALIGN_METHOD_ID = 'olv.registration.epoch-horizontal-icp';
+
+/** Identity the caller supplies for the two registered scans. */
+export interface RegistrationScans {
+  /** The scan held fixed (the "before" epoch). */
+  readonly targetId: string;
+  readonly targetName: string;
+  /** The scan transformed onto the target (the "after" epoch). */
+  readonly sourceId: string;
+  readonly sourceName: string;
+}
+
+/**
+ * A repeat-epoch registration, as a provenance record. Carries the identity of
+ * the two scans, the method that solved it, the transform and its residual, and
+ * whether it was applied — plus a `generatedAt` stamp so a later reader can tell
+ * a fresh registration from a stale one.
+ */
+export interface RegistrationArtifact {
+  readonly kind: 'registration';
+  readonly method: MethodRef;
+  readonly scans: RegistrationScans;
+  /** Whether a transform was solved and applied (vs. refused / not attempted). */
+  readonly applied: boolean;
+  readonly refused: boolean;
+  /** Which degrees of freedom the applied transform used. */
+  readonly appliedDof: EpochAppliedDof;
+  /** Final RMS residual of the fit, in metres. */
+  readonly rmsResidualM: number;
+  /** Solved yaw about vertical, in degrees. */
+  readonly yawDeg: number;
+  /** Solved translation (metres) mapping source onto target. */
+  readonly translation: Vec3;
+  /** Fraction of the scenes that overlapped, 0..1. */
+  readonly overlapFraction: number;
+  /** Epoch-millisecond stamp of when this record was built (staleness marker). */
+  readonly generatedAt: number;
+}
+
+/** Build the provenance record from a solved alignment and the scan identity. */
+export function buildRegistrationArtifact(
+  alignment: EpochAlignment,
+  scans: RegistrationScans,
+  generatedAt: number,
+): RegistrationArtifact {
+  return {
+    kind: 'registration',
+    method: methodRef(EPOCH_ALIGN_METHOD_ID),
+    scans,
+    applied: alignment.applied,
+    refused: alignment.refused,
+    appliedDof: alignment.appliedDof,
+    rmsResidualM: alignment.rmsResidualM,
+    yawDeg: alignment.yawDeg,
+    translation: alignment.translation,
+    overlapFraction: alignment.overlapFraction,
+    generatedAt,
+  };
+}
+
+/**
+ * A one-line, honest summary of a registration for the compare readout. States
+ * the applied case with its residual and DOF, and names the refused / not-run
+ * cases plainly rather than implying a transform that was not used.
+ */
+export function summarizeRegistration(a: RegistrationArtifact): string {
+  const m = `${a.method.id}@${a.method.version}`;
+  if (a.applied) {
+    return (
+      `Registration: applied (${a.appliedDof}) — ` +
+      `residual ${a.rmsResidualM.toFixed(3)} m, overlap ${Math.round(a.overlapFraction * 100)}% · ${m}`
+    );
+  }
+  if (a.refused) {
+    return `Registration: refused — residual ${a.rmsResidualM.toFixed(3)} m exceeded the gate; epochs compared unshifted · ${m}`;
+  }
+  return `Registration: not applied — epochs compared in their own frames · ${m}`;
+}

--- a/tests/registrationArtifact.test.ts
+++ b/tests/registrationArtifact.test.ts
@@ -1,0 +1,85 @@
+/**
+ * registrationArtifact.test.ts — the typed provenance record for a repeat-epoch
+ * registration.
+ *
+ * The record wraps the alignment the solver produced with the identity of the
+ * two scans, the registered method, and a staleness stamp. These cases pin that
+ * it carries the transform faithfully, names the method at its version, and that
+ * the one-line readout states applied / refused / not-run honestly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildRegistrationArtifact,
+  summarizeRegistration,
+} from '../src/terrain/change/registrationArtifact';
+import type { EpochAlignment } from '../src/terrain/change/alignEpochs';
+import { method } from '../src/science/methodRegistry';
+
+const scans = { targetId: 'a', targetName: '2025.laz', sourceId: 'b', sourceName: '2026.laz' };
+
+function alignment(over: Partial<EpochAlignment> = {}): EpochAlignment {
+  return {
+    attempted: true,
+    applied: true,
+    appliedDof: 'yaw+xy',
+    refused: false,
+    degenerate: false,
+    rmsResidualM: 0.042,
+    yawDeg: 1.3,
+    translation: [0.1, -0.2, 0],
+    sampleCount: 5000,
+    overlapFraction: 0.87,
+    ...over,
+  } as EpochAlignment;
+}
+
+describe('buildRegistrationArtifact', () => {
+  it('carries the alignment, the scans, and the registered method at its version', () => {
+    const art = buildRegistrationArtifact(alignment(), scans, 1_700_000_000_000);
+    expect(art.kind).toBe('registration');
+    expect(art.scans).toEqual(scans);
+    expect(art.appliedDof).toBe('yaw+xy');
+    expect(art.rmsResidualM).toBeCloseTo(0.042);
+    expect(art.translation).toEqual([0.1, -0.2, 0]);
+    expect(art.overlapFraction).toBeCloseTo(0.87);
+    expect(art.generatedAt).toBe(1_700_000_000_000);
+    // The method reference resolves to a real registered method.
+    expect(art.method.id).toBe('olv.registration.epoch-horizontal-icp');
+    expect(method(art.method.id)?.version).toBe(art.method.version);
+  });
+});
+
+describe('summarizeRegistration', () => {
+  it('states an applied registration with its residual, DOF and overlap', () => {
+    const s = summarizeRegistration(buildRegistrationArtifact(alignment(), scans, 0));
+    expect(s).toContain('applied (yaw+xy)');
+    expect(s).toContain('residual 0.042 m');
+    expect(s).toContain('overlap 87%');
+    expect(s).toContain('olv.registration.epoch-horizontal-icp@');
+  });
+
+  it('names a refused registration without implying the transform was used', () => {
+    const s = summarizeRegistration(
+      buildRegistrationArtifact(
+        alignment({ applied: false, refused: true, appliedDof: 'none' }),
+        scans,
+        0,
+      ),
+    );
+    expect(s).toContain('refused');
+    expect(s).toContain('compared unshifted');
+  });
+
+  it('names a not-run registration plainly', () => {
+    const s = summarizeRegistration(
+      buildRegistrationArtifact(
+        alignment({ applied: false, refused: false, appliedDof: 'none' }),
+        scans,
+        0,
+      ),
+    );
+    expect(s).toContain('not applied');
+    expect(s).toContain('their own frames');
+  });
+});


### PR DESCRIPTION
The epoch alignment already solved and reported its transform (yaw, translation, residual, applied-or-refused), but the result had no *identity*: it never said which two scans it registered, by which method at which version, or when.

`RegistrationArtifact` (new pure `src/terrain/change/registrationArtifact.ts`) wraps the alignment with that provenance — source/target scan ids + names, the registered method reference (`olv.registration.epoch-horizontal-icp@v`), the applied DOF + residual + yaw + translation + overlap, and a `generatedAt` staleness stamp. `summarizeRegistration` renders a one-line readout that states applied / refused / not-run honestly (never implying a transform that was not used). The two-epoch compare flow builds the record and shows the line beside the existing alignment summary.

Pure data: it never re-solves and never moves geometry. It rides the already-lazy change chunk, so the startup bundle is untouched (index unchanged), and the main.ts wiring is line-neutral (no monolith growth). The full registration workspace (tie points, accept/reject, a persisted registry) stays a separate, larger piece — this is the bounded provenance slice. New builder + summarizer tests; full suite green.