### PR TITLE
feat(inspect): mark a viewer-derived class in the point inspector

### DIFF
--- a/src/render/Viewer.ts
+++ b/src/render/Viewer.ts
@@ -6083,7 +6083,7 @@ export class Viewer {
       origin: [0, 0, 0],
       distance: this._camera.position.distanceTo(point),
       intensity: cloud.intensity ? cloud.intensity[index] : null,
-      classification: cloud.classification ? cloud.classification[index] : null,
+      classification: cloud.classification ? cloud.classification[index] : null, classificationDerived: cloud.classificationIsDerived,
       rgb,
       // inspection extras — passed only when the cloud carries them.
       returnNumber: cloud.returnNumber ? cloud.returnNumber[index] : undefined,

--- a/src/render/pointInfo.ts
+++ b/src/render/pointInfo.ts
@@ -263,6 +263,8 @@ export interface PointInfo {
   intensity: number | null;
   /** ASPRS classification code, or null when the cloud carries none. */
   classification: number | null;
+  /** True when the classification was derived in the viewer, not producer-supplied. */
+  classificationDerived: boolean;
   /** RGB triple, each 0–255, or null when the cloud carries no colour. */
   rgb: [number, number, number] | null;
   /**
@@ -312,6 +314,12 @@ export interface RawPointInfo {
   geographicHorizontal?: boolean;
   intensity: number | null;
   classification: number | null;
+  /**
+   * True when this cloud's classification was DERIVED by the viewer's heuristic
+   * rather than read from the producer file — so the inspector can say the class
+   * is not an authoritative label. A per-cloud fact, carried on each pick.
+   */
+  classificationDerived?: boolean;
   rgb: [number, number, number] | null;
   /** LAS return number, when the cloud carries return data. */
   returnNumber?: number;
@@ -348,6 +356,7 @@ export function makePointInfo(raw: RawPointInfo): PointInfo {
     distance: round(raw.distance, 2),
     intensity: raw.intensity,
     classification: raw.classification,
+    classificationDerived: raw.classificationDerived ?? false,
     rgb: raw.rgb,
   };
   // The inspection extras — carried only when the cloud supplies them,
@@ -414,9 +423,11 @@ export function intensityText(info: PointInfo): string {
 
 /** The classification field's display text — a name, or "Not available". */
 export function classificationText(info: PointInfo): string {
-  return info.classification === null
-    ? 'Not available'
-    : classificationLabel(info.classification);
+  if (info.classification === null) return 'Not available';
+  const label = classificationLabel(info.classification);
+  // Mark a viewer-derived class so it is never read as an authoritative
+  // producer label — the single most important per-point provenance fact.
+  return info.classificationDerived ? `${label} · derived (heuristic)` : label;
 }
 
 /** The RGB field's display text — "r, g, b", or "Not available". */

--- a/tests/pointInfo.test.ts
+++ b/tests/pointInfo.test.ts
@@ -94,6 +94,14 @@ test('field text helpers show real values when present', () => {
   expect(rgbText(info)).toBe('180, 92, 40');
 });
 
+test('classificationText marks a viewer-derived class, and a producer class stays plain', () => {
+  const derived = makePointInfo({ ...fullRaw(), classificationDerived: true });
+  expect(classificationText(derived)).toBe('Ground · derived (heuristic)');
+  // Default (no flag) reads as an authoritative producer label.
+  expect(makePointInfo(fullRaw()).classificationDerived).toBe(false);
+  expect(classificationText(makePointInfo(fullRaw()))).toBe('Ground');
+});
+
 test('field text helpers show "Not available" when an attribute is missing', () => {
   const info = makePointInfo({
     ...fullRaw(),


### PR DESCRIPTION
The point inspector's Classification row read identically whether the class came from the producer file or the viewer's heuristic classifier, so a derived label could be mistaken for an authoritative one.

The point info now carries the cloud's `classificationIsDerived` flag (a per-cloud fact — no per-point array, no worker-transfer cost), and `classificationText` appends `· derived (heuristic)` to a derived class; a producer class stays plain. This is the source-provenance half of gem G; the per-point ground-`support` readout remains a separate, heavier piece (it needs a full-cloud Float32Array transferred back from the classifier worker on every run).

Bundle-safe at the pinned 780/780 index: the inspector UI rides the lazy Viewer chunk, the eager point-info change is a field pass-through, and main.ts/Viewer.ts stay line-neutral. New classificationText coverage; full suite green.