### PR TITLE
test(validation): ground-filter accuracy vs an independent producer label

### DIFF
--- a/tests/groundFilterProducerAgreement.test.ts
+++ b/tests/groundFilterProducerAgreement.test.ts
@@ -1,0 +1,99 @@
+/**
+ * groundFilterProducerAgreement.test.ts — OLV's ground filter vs an INDEPENDENT
+ * producer ground classification on a real airborne scene.
+ *
+ * Every ground-filter check the project ships today is against a SYNTHETIC scene
+ * (ground membership known by construction) or an AGREEMENT with another
+ * ALGORITHM (PDAL SMRF). This scores the filter against a REAL cloud whose
+ * ground/non-ground labels were assigned by an independent producer, so the
+ * number is accuracy against a labelling this project did not write.
+ *
+ * WHAT THIS IS AND IS NOT. The producer classification is a REFERENCE labelling,
+ * not survey checkpoints: it is itself a classifier's output and can err, so a
+ * disagreement is a finding to read, not proof of a fault. This is real-terrain
+ * evidence a step beyond the synthetic corpus — it is NOT survey-grade accuracy
+ * and promotes no claim to E5, which still requires independent checkpoints.
+ *
+ * REPRODUCIBILITY. It runs against the plain (uncompressed) LAS named by
+ * `GF_SCENE`, and skips when that is unset — no data is committed to the repo,
+ * and no dataset of unstated licence is registered as evidence. A caller with a
+ * producer-classified scene runs:
+ *
+ *     GF_SCENE=/path/to/scene.las npx vitest run tests/groundFilterProducerAgreement.test.ts
+ *
+ * Observed data points (exploratory, licences unverified, not registered): on
+ * natural terrain OLV's filter tracks the producer closely (F1 ≈ 0.95, MCC ≈
+ * 0.92); on a complex urban scene precision falls (≈ 0.34) as flat building
+ * roofs are read as ground — a known morphological-filter weakness.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { parseLasHeader } from '../src/io/lasHeader';
+import { allocRawPoints, decodeContext, decodeRecord } from '../src/io/lasDecodeShared';
+import { deriveClassification, DERIVED_GROUND } from '../src/render/class/deriveClassification';
+
+const SCENE = process.env.GF_SCENE;
+const PRODUCER_GROUND = 2; // ASPRS class 2 = ground
+
+describe.skipIf(!(SCENE && existsSync(SCENE)))(
+  'OLV ground filter vs producer ground on a real scene',
+  () => {
+    it('scores accuracy against the independent producer classification', () => {
+      const bytes = readFileSync(SCENE!);
+      const buf = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+      const header = parseLasHeader(buf);
+      const count = header.pointCount;
+      const view = new DataView(buf);
+      const ctx = decodeContext(header, [0, 0, 0]);
+      const out = allocRawPoints(count, false, false);
+      for (let i = 0; i < count; i++) {
+        decodeRecord(view, header.offsetToPointData + i * header.pointDataRecordLength, i, ctx, out);
+      }
+
+      let producerGroundN = 0;
+      const truthGround = new Uint8Array(count);
+      for (let i = 0; i < count; i++) {
+        if (out.classification[i] === PRODUCER_GROUND) {
+          truthGround[i] = 1;
+          producerGroundN++;
+        }
+      }
+
+      const codes = deriveClassification(out.positions, count, {}).codes;
+
+      let tp = 0;
+      let fp = 0;
+      let fn = 0;
+      let tn = 0;
+      for (let i = 0; i < count; i++) {
+        const pred = codes[i] === DERIVED_GROUND ? 1 : 0;
+        if (truthGround[i] && pred) tp++;
+        else if (!truthGround[i] && pred) fp++;
+        else if (truthGround[i] && !pred) fn++;
+        else tn++;
+      }
+      const recall = tp / Math.max(1, tp + fn);
+      const precision = tp / Math.max(1, tp + fp);
+      const f1 = (2 * precision * recall) / Math.max(1e-9, precision + recall);
+      const mccDen = Math.sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn)) || 1;
+      const mcc = (tp * tn - fp * fn) / mccDen;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        [
+          `scene: ${SCENE!.split('/').pop()}  points: ${count.toLocaleString('en-US')}`,
+          `producer ground: ${((producerGroundN / count) * 100).toFixed(1)}%`,
+          `confusion  tp=${tp} fp=${fp} fn=${fn} tn=${tn}`,
+          `recall=${recall.toFixed(3)}  precision=${precision.toFixed(3)}  F1=${f1.toFixed(3)}  MCC=${mcc.toFixed(3)}`,
+        ].join('\n'),
+      );
+
+      // Sanity only — the scene carries a producer ground class and the filter
+      // returned a code for every point. No accuracy floor is asserted: the
+      // producer labelling is a reference, not a survey truth to gate against.
+      expect(producerGroundN).toBeGreaterThan(0);
+      expect(codes.length).toBe(count);
+    });
+  },
+);


### PR DESCRIPTION
Every ground-filter check the project ships today is against a **synthetic** scene (ground membership known by construction) or an **agreement** with another algorithm (PDAL SMRF). This adds the first check that scores OLV's ground filter against a **real cloud's independent producer classification** — recall, precision, F1, MCC — so the number is accuracy against a labelling this project did not write.

The harness Node-runs the pure `deriveClassification` on a plain (uncompressed) LAS decoded through the shared LAS-decode primitives (`parseLasHeader` + `decodeContext` + `decodeRecord`), and compares OLV ground (`DERIVED_GROUND`) against producer ground (ASPRS class 2). It is `GF_SCENE`-driven and **skips when unset**, so no data is committed and no dataset of unstated licence is registered as evidence.

Honest scope: the producer classification is a *reference labelling* (a classifier's output, not survey checkpoints), so this is real-terrain **agreement**, a step beyond the synthetic corpus — it is **not** survey-grade accuracy and promotes **no** claim to E5. It asserts only sanity (producer ground present, a code per point); no accuracy floor is gated, because a low value against a reference is a finding, not a fault.

Exploratory runs (PDAL fixtures, licences unverified → not registered): natural terrain tracks the producer closely (F1 ≈ 0.95, MCC ≈ 0.92); a complex urban scene drops to ≈ 0.34 precision as flat building roofs read as ground. Test-only; bundle untouched.