### PR TITLE
test(numerics): named metamorphic invariants (v0.6.8 §28 hardening)

### DIFF
--- a/tests/changeUncertainty.test.ts
+++ b/tests/changeUncertainty.test.ts
@@ -26,6 +26,22 @@ describe('changeVolumeUncertainty', () => {
     expect(r.sigmaM3).toBeCloseTo(1.0, 6);
   });
 
+  test('epoch-swap invariance: negating the net leaves the band magnitude unchanged and mirrors the bounds', () => {
+    // Swapping before/after negates the net volume (a gain becomes an equal
+    // loss) but changes nothing about the cells or their per-cell error, so the
+    // ± band must be identical in magnitude and the signed bounds must mirror.
+    const base = { significantCells: 400, cellAreaM2: 1, cellSigmaM: 0.05, registrationSigmaM: 0.02 };
+    const gain = changeVolumeUncertainty({ ...base, netVolumeM3: 1000 });
+    const loss = changeVolumeUncertainty({ ...base, netVolumeM3: -1000 });
+    expect(loss.sigmaM3).toBeCloseTo(gain.sigmaM3, 9);
+    expect(loss.randomErrorM3).toBeCloseTo(gain.randomErrorM3, 9);
+    expect(loss.systematicErrorM3).toBeCloseTo(gain.systematicErrorM3, 9);
+    expect(loss.relativeError).toBeCloseTo(gain.relativeError, 9);
+    // Signed bounds mirror through zero: low(+V) = −high(−V), high(+V) = −low(−V).
+    expect(loss.highM3).toBeCloseTo(-gain.lowM3, 6);
+    expect(loss.lowM3).toBeCloseTo(-gain.highM3, 6);
+  });
+
   test('names the error model on the result, and the correlation caveat travels', () => {
     const r = changeVolumeUncertainty({
       netVolumeM3: 1000,

--- a/tests/contourAnalyticValidation.test.ts
+++ b/tests/contourAnalyticValidation.test.ts
@@ -93,6 +93,34 @@ describe('analytic contour validation (§24.1)', () => {
       expect(Math.abs((meanCur - meanPrev) - 4)).toBeLessThan(0.25);
     }
   });
+
+  // ── Degeneracy: a constant surface crosses no intermediate level ──
+  it('a constant surface produces no contour segments at a level it does not equal', () => {
+    const flat = grid(() => 50, 30, 30);
+    const set = contoursAt(flat, { intervalM: 5, levels: [10, 20, 30, 40] });
+    const total = set.levels.reduce((n, l) => n + l.segments.length, 0);
+    // No cell straddles any requested level, so marching squares emits nothing —
+    // a flat surface has no isolines, and inventing one would be a false feature.
+    expect(total).toBe(0);
+  });
+
+  // ── Metamorphic: translating elevation shifts the level labels, not the lines ──
+  it('adding a constant Δz to a tilted plane relabels the isolines by Δz (same geometry)', () => {
+    // z = x (gradient 1 in x): the contour at value L is the vertical line x = L.
+    // Adding Δ makes z = x + Δ, so its contour at value L sits where x = L − Δ —
+    // i.e. exactly where the ORIGINAL surface's contour at value (L − Δ) sits.
+    const plane = (x: number) => x;
+    const delta = 7;
+    const base = contoursAt(grid((x) => plane(x), 41, 41), { intervalM: 10, levels: [20] });
+    const shifted = contoursAt(grid((x) => plane(x) + delta, 41, 41), { intervalM: 10, levels: [20 + delta] });
+    const xs = (s: ReturnType<typeof contoursAt>): number =>
+      mean(vertices(s).map((v) => v.x));
+    expect(base.levels[0].segments.length).toBeGreaterThan(0);
+    expect(shifted.levels[0].segments.length).toBeGreaterThan(0);
+    // Same isoline geometry: the mean x of level 20 on z equals that of level
+    // 20+Δ on z+Δ, to sub-cell precision.
+    expect(Math.abs(xs(shifted) - xs(base))).toBeLessThan(0.1);
+  });
 });
 
 function mean(a: number[]): number {

--- a/tests/invariantMeasurement.test.ts
+++ b/tests/invariantMeasurement.test.ts
@@ -589,6 +589,22 @@ describe('metamorphic: volumeCutFill', () => {
     },
   );
 
+  it('HOLDS: reflecting the cloud about the reference plane swaps fill and cut and negates net', () => {
+    // z → 2·refZ − z mirrors every point across the reference plane, so material
+    // that was above it is now the same amount below and vice-versa: fill and cut
+    // exchange exactly and the signed net inverts. A sign error in the estimator
+    // (e.g. counting a below-plane point as fill) breaks this.
+    const r = volumeCutFill({
+      polygon: HEX,
+      referenceZ: REF_Z,
+      positions: emit(CLOUD, (p) => [p[0], p[1], 2 * REF_Z - p[2]]),
+    });
+    expect(r.pointsInPolygon).toBe(BASE.pointsInPolygon);
+    assertRelClose(r.fill, BASE.cut, TOL_PERMUTATION, 'reflect fill↔cut');
+    assertRelClose(r.cut, BASE.fill, TOL_PERMUTATION, 'reflect cut↔fill');
+    assertScaledClose(r.net, -BASE.net, BASE.fill + BASE.cut, TOL_PERMUTATION, 'reflect net negates');
+  });
+
   it('the all-above fixture has no material below the plane', () => {
     expect(ABOVE_BASE.validity).toBe('ok');
     expect(ABOVE_BASE.cut).toBe(0);


### PR DESCRIPTION
The v0.6.8 hardening audit (§28) flagged specific *named* numerical invariants missing from the property suite. This adds them — pure metamorphic tests over the existing analytic fixtures, no production change:

- **change-volume uncertainty — epoch-swap invariance**: swapping before/after negates the net volume but the ± band magnitude, random/systematic split and relative error are unchanged, and the signed bounds mirror through zero.
- **contours — constant-surface degeneracy**: a flat surface emits no segments at a level it doesn't equal (an invented isoline would be a false feature).
- **contours — elevation-translation label shift**: adding Δz to a tilted plane relabels the isolines by Δz with identical geometry (level L on z+Δ sits where level L−Δ sat on z).
- **cut/fill volume — reflection sign-inversion**: mirroring the cloud about the reference plane swaps fill↔cut and negates net, catching an above/below sign error.

Each asserts a live quantity (the fixtures already straddle the plane / carry relief). Test-only; bundle untouched; full suite green (13,932).