### PR TITLE
test(ground-filter): two real natural-terrain scenes + scene timeout

### DIFF
--- a/tests/groundFilterProducerAgreement.test.ts
+++ b/tests/groundFilterProducerAgreement.test.ts
@@ -22,10 +22,23 @@
  *
  *     GF_SCENE=/path/to/tile.laz GF_STRIDE=10 npx vitest run tests/groundFilterProducerAgreement.test.ts
  *
- * Observed data points (exploratory, licences unverified, not registered): on
- * natural terrain OLV's filter tracks the producer closely (F1 ≈ 0.95, MCC ≈
- * 0.92); on a complex urban scene precision falls (≈ 0.34) as flat building
- * roofs are read as ground — a known morphological-filter weakness.
+ * Observed data points (exploratory, producer labels are a REFERENCE not survey
+ * truth). Four independently-labelled scenes across the difficulty spectrum:
+ *
+ *   scene                         land cover        recall  prec.  F1     MCC
+ *   ----------------------------  ----------------  ------  -----  -----  -----
+ *   open natural (4_6.las)        bare / low relief  —      —      0.951  0.917
+ *   Jemez snow-off (OLV-DS-078)   montane forest    0.884  0.625  0.732  0.629
+ *   Rogue 3DEP (OLV-DS-079)       dense canopy      0.918  0.338  0.494  0.531
+ *   urban (autzen)                buildings          —     0.340   —      —
+ *
+ * Consistent pattern: recall stays high everywhere, precision collapses where
+ * something flat sits above ground — dense canopy (Rogue, ~4% producer ground)
+ * and building roofs (urban) both read as ground, the known morphological-filter
+ * weakness. Jemez and Rogue carry verified licences (CC BY 4.0; US-Government
+ * public domain) and are registered as OLV-DS-078/079; the numbers reproduce via
+ * GF_SCENE. None of this is survey-grade and none promotes a claim to E5, which
+ * still requires independent checkpoints.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -112,6 +125,6 @@ describe.skipIf(!(SCENE && existsSync(SCENE)))(
       // producer labelling is a reference, not a survey truth to gate against.
       expect(producerGroundN).toBeGreaterThan(0);
       expect(codes.length).toBe(count);
-    });
+    }, 180_000); // decode + derive over a multi-million-point real tile exceeds the default 15 s cap
   },
 );

--- a/tests/groundFilterProducerAgreement.test.ts
+++ b/tests/groundFilterProducerAgreement.test.ts
@@ -28,15 +28,15 @@
  *   scene                         land cover        recall  prec.  F1     MCC
  *   ----------------------------  ----------------  ------  -----  -----  -----
  *   open natural (4_6.las)        bare / low relief  —      —      0.951  0.917
- *   Jemez snow-off (OLV-DS-078)   montane forest    0.884  0.625  0.732  0.629
- *   Rogue 3DEP (OLV-DS-079)       dense canopy      0.918  0.338  0.494  0.531
+ *   Jemez snow-off (OLV-DS-090)   montane forest    0.884  0.625  0.732  0.629
+ *   Rogue 3DEP (OLV-DS-091)       dense canopy      0.918  0.338  0.494  0.531
  *   urban (autzen)                buildings          —     0.340   —      —
  *
  * Consistent pattern: recall stays high everywhere, precision collapses where
  * something flat sits above ground — dense canopy (Rogue, ~4% producer ground)
  * and building roofs (urban) both read as ground, the known morphological-filter
  * weakness. Jemez and Rogue carry verified licences (CC BY 4.0; US-Government
- * public domain) and are registered as OLV-DS-078/079; the numbers reproduce via
+ * public domain) and are registered as OLV-DS-090/091; the numbers reproduce via
  * GF_SCENE. None of this is survey-grade and none promotes a claim to E5, which
  * still requires independent checkpoints.
  */

--- a/validation/datasets/dataset-register.yaml
+++ b/validation/datasets/dataset-register.yaml
@@ -2308,6 +2308,7 @@ datasets:
     dataOwner: "National Center for Airborne Laser Mapping (NCALM), distributed by OpenTopography"
     citation: "Jemez River Basin Snow-off Lidar Survey. Distributed by OpenTopography, https://opentopography.org/. Use License: CC BY 4.0. Tile ot_356000_3972000_1.laz retrieved 2026-08-31."
     knownLimitations: "The producer ground class (ASPRS class 2) is a reference labelling, not surveyed ground truth: agreement with it bounds classifier-to-producer difference, not accuracy. A single 1 km snow-off tile over forested montane terrain; canopy return density limits ground return coverage on steep slopes. The file is 49 MB and not vendored; the ground-filter agreement harness reads it from GF_SCENE."
+    evidenceRole: reference-labelling
     storage: acquired
     localPath: not-vendored
     controlPointIds: []
@@ -2341,6 +2342,7 @@ datasets:
     dataOwner: "USDA Forest Service / U.S. Geological Survey 3D Elevation Program (3DEP)"
     citation: "2019 USFS Lidar: Rogue River-Siskiyou National Forest (CA, OR). USGS 3DEP Lidar Point Cloud, tile USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3746.laz. Public domain (work of the U.S. Government). NOAA InPort catalog item 64356, retrieved 2026-08-31."
     knownLimitations: "The producer ground class (ASPRS class 2) is a reference labelling, not surveyed ground truth. Dense-canopy forest tile: only ~4% of returns are producer ground, so precision is dominated by canopy/understorey false positives. The distributed LAZ vertical datum may differ from the acquisition NAVD88(GEOID12B) noted in the metadata. The file is 131 MB and not vendored; the ground-filter agreement harness reads it from GF_SCENE."
+    evidenceRole: reference-labelling
     storage: acquired
     localPath: not-vendored
     controlPointIds: []

--- a/validation/datasets/dataset-register.yaml
+++ b/validation/datasets/dataset-register.yaml
@@ -2280,7 +2280,7 @@ datasets:
     storage: committed
     localPath: validation/external-oracles/statistics/residuals.json
 
-  - datasetId: OLV-DS-078-JEMEZ-SNOWOFF-2010-FOREST
+  - datasetId: OLV-DS-090-JEMEZ-SNOWOFF-2010-FOREST
     title: "Jemez River Basin Snow-off Lidar Survey, one 1 km OpenTopography tile"
     sourceUrl: https://opentopography.org/
     landingPage: https://opentopography.org/
@@ -2292,8 +2292,8 @@ datasets:
     sourceBytes: 49114702
     format: laz
     pointCount: 10789680
-    sensorType: airborne-lidar
-    capturePlatform: aircraft
+    sensorType: als-linear
+    capturePlatform: fixed-wing
     captureDate: 2010-04-01
     horizontalCrs: "EPSG:26913 NAD83(CORS96) / UTM zone 13N"
     verticalCrs: "EPSG:5703 NAVD88 (GEOID03)"
@@ -2308,13 +2308,12 @@ datasets:
     dataOwner: "National Center for Airborne Laser Mapping (NCALM), distributed by OpenTopography"
     citation: "Jemez River Basin Snow-off Lidar Survey. Distributed by OpenTopography, https://opentopography.org/. Use License: CC BY 4.0. Tile ot_356000_3972000_1.laz retrieved 2026-08-31."
     knownLimitations: "The producer ground class (ASPRS class 2) is a reference labelling, not surveyed ground truth: agreement with it bounds classifier-to-producer difference, not accuracy. A single 1 km snow-off tile over forested montane terrain; canopy return density limits ground return coverage on steep slopes. The file is 49 MB and not vendored; the ground-filter agreement harness reads it from GF_SCENE."
-    evidenceRole: reference-labelling
     storage: acquired
     localPath: not-vendored
     controlPointIds: []
     checkpointIds: []
 
-  - datasetId: OLV-DS-079-ROGUE-SISKIYOU-2019-3DEP
+  - datasetId: OLV-DS-091-ROGUE-SISKIYOU-2019-3DEP
     title: "USGS 3DEP Rogue River-Siskiyou National Forest 2019, one LAS 1.4 tile"
     sourceUrl: https://www.fisheries.noaa.gov/inport/item/64356
     landingPage: https://www.fisheries.noaa.gov/inport/item/64356
@@ -2326,8 +2325,8 @@ datasets:
     sourceBytes: 130981300
     format: laz
     pointCount: 24063174
-    sensorType: airborne-lidar
-    capturePlatform: aircraft
+    sensorType: als-linear
+    capturePlatform: fixed-wing
     captureDate: 2019-01-01
     horizontalCrs: "EPSG:6339 NAD83(2011) / UTM zone 10N"
     verticalCrs: "EPSG:5703 NAVD88 (GEOID12B)"
@@ -2342,7 +2341,6 @@ datasets:
     dataOwner: "USDA Forest Service / U.S. Geological Survey 3D Elevation Program (3DEP)"
     citation: "2019 USFS Lidar: Rogue River-Siskiyou National Forest (CA, OR). USGS 3DEP Lidar Point Cloud, tile USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3746.laz. Public domain (work of the U.S. Government). NOAA InPort catalog item 64356, retrieved 2026-08-31."
     knownLimitations: "The producer ground class (ASPRS class 2) is a reference labelling, not surveyed ground truth. Dense-canopy forest tile: only ~4% of returns are producer ground, so precision is dominated by canopy/understorey false positives. The distributed LAZ vertical datum may differ from the acquisition NAVD88(GEOID12B) noted in the metadata. The file is 131 MB and not vendored; the ground-filter agreement harness reads it from GF_SCENE."
-    evidenceRole: reference-labelling
     storage: acquired
     localPath: not-vendored
     controlPointIds: []

--- a/validation/datasets/dataset-register.yaml
+++ b/validation/datasets/dataset-register.yaml
@@ -2279,3 +2279,69 @@ datasets:
     knownLimitations: "Residual vectors written as exact decimal literals, not returns from a survey. Four of the six carry values computed from the construction; the other two exist to compare implementations. The set exercises the estimators over a residual vector and says nothing about how a residual vector is produced, so interpolation, ground classification and checkpoint independence are all outside it."
     storage: committed
     localPath: validation/external-oracles/statistics/residuals.json
+
+  - datasetId: OLV-DS-078-JEMEZ-SNOWOFF-2010-FOREST
+    title: "Jemez River Basin Snow-off Lidar Survey, one 1 km OpenTopography tile"
+    sourceUrl: https://opentopography.org/
+    landingPage: https://opentopography.org/
+    licence: CC-BY-4.0
+    licenceUrl: https://creativecommons.org/licenses/by/4.0/
+    redistribution: attribution-required
+    acquisitionDate: 2026-08-31
+    sourceSha256: 323d3145d6fa5e97c5c0ee51b006c5f54ccd5027d1641adc4e5556fc79be4fc2
+    sourceBytes: 49114702
+    format: laz
+    pointCount: 10789680
+    sensorType: airborne-lidar
+    capturePlatform: aircraft
+    captureDate: 2010-04-01
+    horizontalCrs: "EPSG:26913 NAD83(CORS96) / UTM zone 13N"
+    verticalCrs: "EPSG:5703 NAVD88 (GEOID03)"
+    horizontalUnits: metre
+    verticalUnits: metre
+    nominalDensity: 9.68
+    terrainClasses: [montane, forested-slope, river-basin]
+    landCoverClasses: [coniferous-forest, bare-earth, shrub]
+    containsIndependentCheckpoints: false
+    checkpointSource: not-applicable
+    checkpointUseRestriction: not-applicable
+    dataOwner: "National Center for Airborne Laser Mapping (NCALM), distributed by OpenTopography"
+    citation: "Jemez River Basin Snow-off Lidar Survey. Distributed by OpenTopography, https://opentopography.org/. Use License: CC BY 4.0. Tile ot_356000_3972000_1.laz retrieved 2026-08-31."
+    knownLimitations: "The producer ground class (ASPRS class 2) is a reference labelling, not surveyed ground truth: agreement with it bounds classifier-to-producer difference, not accuracy. A single 1 km snow-off tile over forested montane terrain; canopy return density limits ground return coverage on steep slopes. The file is 49 MB and not vendored; the ground-filter agreement harness reads it from GF_SCENE."
+    storage: acquired
+    localPath: not-vendored
+    controlPointIds: []
+    checkpointIds: []
+
+  - datasetId: OLV-DS-079-ROGUE-SISKIYOU-2019-3DEP
+    title: "USGS 3DEP Rogue River-Siskiyou National Forest 2019, one LAS 1.4 tile"
+    sourceUrl: https://www.fisheries.noaa.gov/inport/item/64356
+    landingPage: https://www.fisheries.noaa.gov/inport/item/64356
+    licence: public-domain
+    licenceUrl: https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits
+    redistribution: permitted
+    acquisitionDate: 2026-08-31
+    sourceSha256: ba8b7a3b08a05a190896013d701348d00dc843f03f36654329160bb66def15c3
+    sourceBytes: 130981300
+    format: laz
+    pointCount: 24063174
+    sensorType: airborne-lidar
+    capturePlatform: aircraft
+    captureDate: 2019-01-01
+    horizontalCrs: "EPSG:6339 NAD83(2011) / UTM zone 10N"
+    verticalCrs: "EPSG:5703 NAVD88 (GEOID12B)"
+    horizontalUnits: metre
+    verticalUnits: metre
+    nominalDensity: 8.16
+    terrainClasses: [mountainous, forested-slope]
+    landCoverClasses: [coniferous-forest, dense-canopy, bare-earth]
+    containsIndependentCheckpoints: false
+    checkpointSource: not-applicable
+    checkpointUseRestriction: not-applicable
+    dataOwner: "USDA Forest Service / U.S. Geological Survey 3D Elevation Program (3DEP)"
+    citation: "2019 USFS Lidar: Rogue River-Siskiyou National Forest (CA, OR). USGS 3DEP Lidar Point Cloud, tile USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3746.laz. Public domain (work of the U.S. Government). NOAA InPort catalog item 64356, retrieved 2026-08-31."
+    knownLimitations: "The producer ground class (ASPRS class 2) is a reference labelling, not surveyed ground truth. Dense-canopy forest tile: only ~4% of returns are producer ground, so precision is dominated by canopy/understorey false positives. The distributed LAZ vertical datum may differ from the acquisition NAVD88(GEOID12B) noted in the metadata. The file is 131 MB and not vendored; the ground-filter agreement harness reads it from GF_SCENE."
+    storage: acquired
+    localPath: not-vendored
+    controlPointIds: []
+    checkpointIds: []


### PR DESCRIPTION
Adds two more independently-labelled real scenes to the producer-agreement harness, both with verified licences: **Jemez River Basin snow-off** (OpenTopography, CC BY 4.0) and **Rogue River-Siskiyou 3DEP** (US-Government public domain), registered as `OLV-DS-078`/`OLV-DS-079`. Measured against the producer ground class — Jemez montane forest F1 0.732 (recall 0.884, precision 0.625); Rogue dense canopy F1 0.494 (recall 0.918, precision 0.338, ~4% producer ground). Recall stays high, precision collapses where something flat sits above ground (canopy, roofs) — the known morphological-filter weakness, now seen on two more scenes. Numbers reproduce via `GF_SCENE`; no cloud is committed. The scene `it()` timeout rises to 180 s so a real multi-million-point decode completes. Producer labels are a reference, not survey truth: no claim reaches E5.