### PR TITLE
fix(quality): scanFitness density verdict names a pulse-density reference

### DIFF
--- a/src/terrain/quality/scanFitness.ts
+++ b/src/terrain/quality/scanFitness.ts
@@ -105,10 +105,12 @@ export interface ScanFitness {
   /** Worst dimension tone — drives the hero colour. */
   readonly overallTone: FitnessTone;
   /**
-   * Named density-floor badge when earnable (e.g. "≥ QL2 density floor"), else
-   * null. The badge reports which published nominal-pulse-density reference floor
-   * the observed ground-return density clears — density only, never a 3DEP
-   * quality-level determination, so an unadorned "QL2" is deliberately avoided.
+   * Named density-reference badge when earnable (e.g. "≥ QL2 density reference"),
+   * else null. The badge reports which published nominal-pulse-density reference
+   * floor the observed GROUND-RETURN density clears — never a true pulse-density
+   * measurement (this codebase has no return-number-filtered first/only-return
+   * metric) and never a 3DEP quality-level determination, so an unadorned "QL2"
+   * is deliberately avoided.
    */
   readonly tierBadge: string | null;
   /** Headline accuracy string, or null when unvalidated. */
@@ -199,10 +201,12 @@ function densityDimension(d: number | null, unitKnown: boolean): FitnessDimensio
   else if (d >= QL2_DENSITY) tone = 'okay';
   else tone = 'review';
   const v = d >= 100 ? Math.round(d) : Math.round(d * 10) / 10;
+  // "reference" (not "floor met"/"quality level") — this is ground-return
+  // density measured against a pulse-density figure, not a QL determination.
   let summary: string;
-  if (tone === 'ready') summary = `${v} ground pts/m² — at or above ${QL1_DENSITY} pts/m² (the 3DEP QL1 density floor).`;
-  else if (tone === 'okay') summary = `${v} ground pts/m² — at or above ${QL2_DENSITY} pts/m² (the 3DEP QL2 density floor).`;
-  else summary = `${v} ground pts/m² — below ${QL2_DENSITY} pts/m² (the 3DEP QL2 density floor).`;
+  if (tone === 'ready') summary = `${v} ground pts/m² — clears the ${QL1_DENSITY} pts/m² QL1 pulse-density reference.`;
+  else if (tone === 'okay') summary = `${v} ground pts/m² — clears the ${QL2_DENSITY} pts/m² QL2 pulse-density reference.`;
+  else summary = `${v} ground pts/m² — below the ${QL2_DENSITY} pts/m² QL2 pulse-density reference.`;
   return { key: 'density', label: 'Ground detail', tone, summary };
 }
 
@@ -311,7 +315,7 @@ export function buildScanFitness(inp: FitnessInputs): ScanFitness {
     georeferencing: 'it isn’t placed in the real world (no map position or height datum)',
     coverage: 'ground coverage is sparse — most of the surface is interpolated',
     density: unitKnown
-      ? 'ground density is below survey thresholds'
+      ? 'ground-return density is below the pulse-density reference'
       : 'coordinate units are unverified, so density can’t be graded',
     accuracy: unitKnown
       ? 'vertical accuracy isn’t validated'
@@ -353,7 +357,7 @@ export function buildScanFitness(inp: FitnessInputs): ScanFitness {
   const accTone = dimensions.find((d) => d.key === 'accuracy')!.tone;
   const tierBadge =
     inp.densityReferenceFloor && !provisional && densTone !== 'review' && accTone !== 'review' && inp.crsKnown
-      ? `≥ ${inp.densityReferenceFloor} density floor`
+      ? `≥ ${inp.densityReferenceFloor} density reference`
       : null;
 
   // The headline is a bare "± m" claim, so it too is withheld on an unverified

--- a/tests/scanFitness.test.ts
+++ b/tests/scanFitness.test.ts
@@ -38,7 +38,7 @@ describe('buildScanFitness — scorecard tones', () => {
     const f = buildScanFitness(base());
     expect(f.overallTone).toBe<FitnessTone>('ready');
     expect(f.verdict).toMatch(/ready for terrain products/i);
-    expect(f.tierBadge).toBe('≥ QL1 density floor');
+    expect(f.tierBadge).toBe('≥ QL1 density reference');
     expect(f.headlineAccuracy).toBe('±0.07 m vertical');
     expect(f.dimensions).toHaveLength(6);
   });
@@ -95,7 +95,7 @@ describe('buildScanFitness — provisional (streaming / partial) state', () => {
   it('a full-cloud grade is not provisional and can earn its badge', () => {
     const f = buildScanFitness(base());
     expect(f.provisional).toBe(false);
-    expect(f.tierBadge).toBe('≥ QL1 density floor');
+    expect(f.tierBadge).toBe('≥ QL1 density reference');
   });
 });
 
@@ -189,13 +189,25 @@ describe('buildScanFitness — density reports a measurement, not a quality leve
 
   it('keeps the measured density and names the threshold it is compared against', () => {
     expect(summary(12)).toMatch(/12 ground pts\/m²/);
-    expect(summary(12)).toMatch(/8 pts\/m².*QL1 density floor/i);
-    expect(summary(3)).toMatch(/2 pts\/m².*QL2 density floor/i);
-    expect(summary(0.9)).toMatch(/below.*2 pts\/m².*QL2 density floor/i);
+    expect(summary(12)).toMatch(/clears the 8 pts\/m² QL1 pulse-density reference/i);
+    expect(summary(3)).toMatch(/clears the 2 pts\/m² QL2 pulse-density reference/i);
+    expect(summary(0.9)).toMatch(/below the 2 pts\/m² QL2 pulse-density reference/i);
+  });
+
+  it('labels the QL comparison as a pulse-density reference, not a ground-density quality level', () => {
+    // The known semantic gap: `groundDensityPerM2` is GROUND-RETURN density,
+    // while USGS 3DEP QL floors are nominal PULSE density (first/single-swath
+    // returns). The summary must name the floors as a "pulse-density reference"
+    // rather than imply the measured ground-return figure IS a pulse-density
+    // quality-level determination.
+    for (const d of [12, 3, 0.9]) {
+      expect(summary(d)).toMatch(/pulse-density reference/i);
+      expect(summary(d)).not.toMatch(/\bQL\d density floor\b/i);
+    }
   });
 
   it('marks the tier badge as an estimate, matching every other surface', () => {
-    expect(buildScanFitness(base()).tierBadge).toBe('≥ QL1 density floor');
+    expect(buildScanFitness(base()).tierBadge).toBe('≥ QL1 density reference');
   });
 });
 
@@ -231,7 +243,7 @@ describe('buildScanFitness — unverified units fail closed', () => {
     expect(tone(f, 'density')).toBe<FitnessTone>('ready');
     expect(tone(f, 'accuracy')).toBe<FitnessTone>('ready');
     expect(f.headlineAccuracy).toBe('±0.07 m vertical');
-    expect(f.tierBadge).toBe('≥ QL1 density floor');
+    expect(f.tierBadge).toBe('≥ QL1 density reference');
     expect(f.caveats.some((c) => /units are unverified/i.test(c))).toBe(false);
   });
 
@@ -239,6 +251,6 @@ describe('buildScanFitness — unverified units fail closed', () => {
     const f = buildScanFitness(base({ unitKnown: true }));
     expect(tone(f, 'density')).toBe<FitnessTone>('ready');
     expect(tone(f, 'accuracy')).toBe<FitnessTone>('ready');
-    expect(f.tierBadge).toBe('≥ QL1 density floor');
+    expect(f.tierBadge).toBe('≥ QL1 density reference');
   });
 });


### PR DESCRIPTION
Reviewer flagged: \`scanFitness.ts\` measures ground-classified-return density but its verdict compared that figure against USGS 3DEP QL floors, which are nominal PULSE density from single-swath first returns — not ground-return density. The source comment already admitted the gap.

Verified the pipeline's density input (\`cellMetrics.meanDensity\`, threaded through \`AnalysePanel\`) is ground-classified-return density only; no return-number-filtered first/only-return metric reaches this module, so a true pulse-density figure cannot be computed here without a larger data-flow change. No such number is fabricated.

Fix is a labelling/semantics change: the density summary and tier badge now say "QLx pulse-density reference" (a threshold comparison) instead of "QLx density floor" (which read as a floor the scan met). Updated \`tests/scanFitness.test.ts\` to lock the corrected wording and assert the old "QLx density floor" phrasing no longer appears.

Net-neutral on the bundle: \`index\` chunk stays 780/780 KiB before and after.