### PR TITLE
fix: relabel same-cloud held-out returns as such, not ground truth

### DIFF
--- a/src/terrain/validate/calibrateConfidence.ts
+++ b/src/terrain/validate/calibrateConfidence.ts
@@ -9,9 +9,10 @@
  *
  * Definition (documented so it can be argued with): the calibrated
  * confidence of a cell is the empirical probability that the cell's
- * elevation is within a stated vertical tolerance τ of ground truth,
- * estimated from held-out points whose predicted (raw) confidence was
- * similar. So "80% confident" after calibration means "≈80% of held-out
+ * elevation is within a stated vertical tolerance τ of the same-cloud
+ * held-out return, estimated from held-out points whose predicted
+ * (raw) confidence was similar. So "80% confident" after calibration
+ * means "≈80% of held-out
  * points with this raw confidence landed within τ of the rebuilt
  * surface" — a falsifiable claim, not decoration.
  *
@@ -310,13 +311,13 @@ export function applyConfidenceCalibration(
   let cells = 0;
   for (let i = 0; i < n; i++) {
     if (grid.coverage[i] === 2) {
-      // MEASURED cell. The held-out samples are measured ground truth, so the
-      // calibration is a calibration of the MEASURED surface — apply it here.
+      // MEASURED cell. The held-out samples are same-cloud held-out returns, so
+      // the calibration is a calibration of the MEASURED surface — apply it here.
       confidence[i] = Math.round(clamp(calibration.remap(grid.confidence[i]), 0, 100));
       sum += confidence[i];
       cells++;
     } else if (grid.coverage[i] === 1) {
-      // INTERPOLATED cell. No held-out ground truth backs an invented value, and
+      // INTERPOLATED cell. No same-cloud held-out return backs an invented value, and
       // on a dense scan every sample lands in a measured (high-raw) cell, so the
       // curve's lowest knot is high — remapping an interpolated cell would
       // flat-extrapolate that high value down and read FAR interpolation as


### PR DESCRIPTION
calibrateConfidence.ts isotonic-calibrates cell confidence against held-out points drawn from the same point cloud being processed, not an independent survey reference. Three comments (module doc, MEASURED-branch, INTERPOLATED-branch) called those points "ground truth" — reworded to "same-cloud held-out return(s)".

No logic or numeric change; comments only.

Investigated but found no violation: no user-facing string or doc claims unqualified "3D Tiles 1.1 support" in the current source — `docs/supported-formats.md` and `README.md` already scope the claim to the PNTS point-content subset. No edit made for that half of the review.

Verified: `tsc --noEmit` clean, `check-bundle-budget.mjs` passes (index 780/780 KiB, unchanged), `lint-claims-language.mjs` passes, `calibrateConfidence.test.ts` + `cellConfidence.test.ts` (44 tests) pass.