### PR TITLE
Add independent-checkpoint vertical-accuracy harness

### DIFF
--- a/tests/checkpointGdbAdapter.test.ts
+++ b/tests/checkpointGdbAdapter.test.ts
@@ -1,0 +1,191 @@
+/**
+ * checkpointGdbAdapter.test.ts — unit tests for the 3DEP checkpoint adapter
+ * (tests/support/checkpointGdb.ts): the fail-closed prerequisite gate, MAE,
+ * and the CSV/extent/CRS helpers it is built from. No I/O, no GDAL calls.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  checkpointPrerequisites,
+  withinTileExtent,
+  crsMatchesTile,
+  toAccuracyCheckpoints,
+  meanAbsoluteError,
+  runCheckpointStudy,
+  MIN_CHECKPOINT_SAMPLE_SIZE,
+  type RawCheckpointRow,
+  type TileFrame,
+} from './support/checkpointGdb';
+
+const TILE: TileFrame = {
+  horizontalEpsg: 6339,
+  verticalEpsg: 5703,
+  minX: 437000,
+  maxX: 438000,
+  minY: 4646000,
+  maxY: 4647000,
+};
+
+function row(overrides: Partial<RawCheckpointRow> = {}): RawCheckpointRow {
+  return {
+    unique_identifier: 'CKPT-1',
+    point_type: 'NVA',
+    source_easting: '437500',
+    source_northing: '4646500',
+    source_elevation: '1000.000',
+    source_horizontal_epsg: '6339',
+    source_vertical_epsg: '5703',
+    accuracy: '0.05',
+    project_id: '182543',
+    ...overrides,
+  };
+}
+
+/** A full sample of MIN_CHECKPOINT_SAMPLE_SIZE well-formed, in-extent, matching-CRS rows. */
+function goodSample(n: number = MIN_CHECKPOINT_SAMPLE_SIZE): RawCheckpointRow[] {
+  const rows: RawCheckpointRow[] = [];
+  for (let i = 0; i < n; i++) {
+    // Spread points across the tile deterministically so extent membership is exact.
+    const x = TILE.minX + 100 + i * 5;
+    const y = TILE.minY + 100 + i * 5;
+    rows.push(
+      row({
+        unique_identifier: `CKPT-${i}`,
+        source_easting: String(x),
+        source_northing: String(y),
+        source_elevation: String(1000 + i),
+      }),
+    );
+  }
+  return rows;
+}
+
+describe('withinTileExtent / crsMatchesTile', () => {
+  it('accepts a point strictly inside the bounds', () => {
+    expect(withinTileExtent(row(), TILE)).toBe(true);
+  });
+
+  it('rejects a point outside the bounds', () => {
+    expect(withinTileExtent(row({ source_easting: '999999', source_northing: '999999' }), TILE)).toBe(
+      false,
+    );
+  });
+
+  it('rejects non-numeric coordinates', () => {
+    expect(withinTileExtent(row({ source_easting: 'nan' }), TILE)).toBe(false);
+  });
+
+  it('matches only when both horizontal and vertical EPSG agree', () => {
+    expect(crsMatchesTile(row(), TILE)).toBe(true);
+    expect(crsMatchesTile(row({ source_horizontal_epsg: '4326' }), TILE)).toBe(false);
+    expect(crsMatchesTile(row({ source_vertical_epsg: '5701' }), TILE)).toBe(false);
+  });
+});
+
+describe('checkpointPrerequisites — fail-closed gate', () => {
+  it('reports ok:true over a full, well-formed sample at the minimum size', () => {
+    const result = checkpointPrerequisites(goodSample(), TILE);
+    expect(result.ok).toBe(true);
+    expect(result.reasons).toEqual([]);
+    expect(result.usable.length).toBe(MIN_CHECKPOINT_SAMPLE_SIZE);
+  });
+
+  it('fails closed with 0 checkpoints in the tile extent (the Rogue-tile case)', () => {
+    const rows = [row({ source_easting: '0', source_northing: '0' })];
+    const result = checkpointPrerequisites(rows, TILE);
+    expect(result.ok).toBe(false);
+    expect(result.usable.length).toBe(0);
+    expect(result.reasons.some((r) => r.includes('fall inside the tile extent'))).toBe(true);
+  });
+
+  it('fails closed when in-extent checkpoints carry a mismatched CRS', () => {
+    const rows = goodSample().map((r) => ({ ...r, source_horizontal_epsg: '4326' }));
+    const result = checkpointPrerequisites(rows, TILE);
+    expect(result.ok).toBe(false);
+    expect(result.reasons.some((r) => r.includes("share the tile's"))).toBe(true);
+  });
+
+  it('fails closed when checkpoints lack a stated accuracy value', () => {
+    const rows = goodSample().map((r) => ({ ...r, accuracy: '' }));
+    const result = checkpointPrerequisites(rows, TILE);
+    expect(result.ok).toBe(false);
+    expect(result.reasons.some((r) => r.includes('accuracy/uncertainty value'))).toBe(true);
+  });
+
+  it('fails closed when checkpoints lack a point_type', () => {
+    const rows = goodSample().map((r) => ({ ...r, point_type: '' }));
+    const result = checkpointPrerequisites(rows, TILE);
+    expect(result.ok).toBe(false);
+    expect(result.reasons.some((r) => r.includes('point_type'))).toBe(true);
+  });
+
+  it('fails closed below MIN_CHECKPOINT_SAMPLE_SIZE even when every other gate passes', () => {
+    const rows = goodSample(MIN_CHECKPOINT_SAMPLE_SIZE - 1);
+    const result = checkpointPrerequisites(rows, TILE);
+    expect(result.ok).toBe(false);
+    expect(result.reasons.some((r) => r.includes('MIN_CHECKPOINT_SAMPLE_SIZE'))).toBe(true);
+  });
+
+  it('lists every failing reason at once, not just the first', () => {
+    // accuracy missing cascades (point_type is only checked among rows that
+    // already have an accuracy value), so this hits: missing accuracy, AND
+    // below minimum sample size — both reported together, not just the first.
+    const rows = goodSample(3).map((r) => ({ ...r, accuracy: '' }));
+    const result = checkpointPrerequisites(rows, TILE);
+    expect(result.ok).toBe(false);
+    expect(result.reasons.length).toBeGreaterThanOrEqual(2);
+    expect(result.reasons.some((r) => r.includes('accuracy/uncertainty value'))).toBe(true);
+    expect(result.reasons.some((r) => r.includes('MIN_CHECKPOINT_SAMPLE_SIZE'))).toBe(true);
+  });
+});
+
+describe('meanAbsoluteError', () => {
+  it('matches a hand-computed value: residuals [1, -2, 3, -4] -> mean(|r|) = (1+2+3+4)/4 = 2.5', () => {
+    expect(meanAbsoluteError([1, -2, 3, -4])).toBeCloseTo(2.5, 12);
+  });
+
+  it('returns null for an empty residual set', () => {
+    expect(meanAbsoluteError([])).toBeNull();
+  });
+});
+
+describe('toAccuracyCheckpoints', () => {
+  it('drops rows with no measured value rather than inventing a zero residual', () => {
+    const rows = goodSample(2);
+    const measured = new Map([[rows[0].unique_identifier, 1000.1]]); // rows[1] absent
+    const cps = toAccuracyCheckpoints(rows, measured);
+    expect(cps.length).toBe(1);
+    expect(cps[0].id).toBe(rows[0].unique_identifier);
+  });
+
+  it('carries the stated accuracy through as referenceSigma', () => {
+    const rows = [row({ accuracy: '0.07' })];
+    const measured = new Map([[rows[0].unique_identifier, 1000.02]]);
+    const cps = toAccuracyCheckpoints(rows, measured);
+    expect(cps[0].referenceSigma).toBeCloseTo(0.07, 12);
+  });
+});
+
+describe('runCheckpointStudy — end to end', () => {
+  it('reports full pooled statistics when every gate passes', () => {
+    const rows = goodSample();
+    // measured = reference + 0.1 for every checkpoint -> bias should be exactly 0.1
+    const measured = new Map(rows.map((r) => [r.unique_identifier, Number(r.source_elevation) + 0.1]));
+    const { prereq, result, mae } = runCheckpointStudy(rows, TILE, measured);
+    expect(prereq.ok).toBe(true);
+    expect(result?.status).toBe('reported');
+    if (result?.status === 'reported') {
+      expect(result.pooled.n).toBe(MIN_CHECKPOINT_SAMPLE_SIZE);
+      expect(result.pooled.bias).toBeCloseTo(0.1, 9);
+      expect(result.pooled.rmse).toBeCloseTo(0.1, 9);
+    }
+    expect(mae).toBeCloseTo(0.1, 9);
+  });
+
+  it('fails closed with result:null and mae:null on the 0-in-extent case', () => {
+    const rows = [row({ source_easting: '0', source_northing: '0' })];
+    const { prereq, result, mae } = runCheckpointStudy(rows, TILE, new Map());
+    expect(prereq.ok).toBe(false);
+    expect(result).toBeNull();
+    expect(mae).toBeNull();
+  });
+});

--- a/tests/independentCheckpointHarness.test.ts
+++ b/tests/independentCheckpointHarness.test.ts
@@ -1,0 +1,193 @@
+/**
+ * independentCheckpointHarness.test.ts — the INDEPENDENT-CHECKPOINT vertical-
+ * accuracy harness: pairs a point-cloud tile against USGS 3DEP survey
+ * checkpoints (145,299 public-domain checkpoints, distributed as an ESRI
+ * FileGDB) and reports Bias/RMSE/MAE/NMAD/P95 through the existing
+ * `checkpointAccuracy()` engine — or FAILS CLOSED via
+ * `checkpointPrerequisites()` (tests/support/checkpointGdb.ts) when the
+ * prerequisites for an honest comparison are not met.
+ *
+ * ENV CONTRACT — every variable is optional; the suite `describe.skipIf`s
+ * cleanly when the required three are unset, so it never runs in CI or a
+ * bare checkout:
+ *
+ *   CHECKPOINT_SCENE            path to a LAS/LAZ tile with an official
+ *                               (producer) ground classification (ASPRS
+ *                               class 2). REQUIRED to run.
+ *   CHECKPOINT_GDB              path to the checkpoint `.gdb` directory.
+ *                               REQUIRED to run.
+ *   CHECKPOINT_PROJECT_ID       the 3DEP `project_id` whose checkpoints cover
+ *                               the tile's project. REQUIRED to run.
+ *   CHECKPOINT_LAYER            gdb layer name. Defaults to
+ *                               'Consolidated_Standardized_Checkpoints_3DEP_Version2_20250930'.
+ *   CHECKPOINT_HORIZONTAL_EPSG  the tile's horizontal EPSG. Defaults to 6339
+ *                               (UTM 10N), the Rogue reference tile's CRS.
+ *   CHECKPOINT_VERTICAL_EPSG    the tile's vertical EPSG. Defaults to 5703
+ *                               (NAVD88 height), the 3DEP checkpoint
+ *                               convention; a tile in a different vertical
+ *                               datum MUST set this or every checkpoint is
+ *                               correctly excluded by the CRS gate.
+ *
+ * With all three required variables set, this test builds pathway A: an OLV
+ * DTM rasterised directly from the tile's OFFICIAL class-2 ground returns
+ * (no OLV ground classifier involved), sampled at each in-extent, CRS-
+ * matching checkpoint's XY via OLV's own `DtmSurfaceModel` bilinear
+ * interpolation (the SAME surface builder the live pipeline and the
+ * hold-out validation use — see `src/terrain/validate/dtmSurfaceModel.ts`).
+ * Pathway B (raw points -> OLV's own ground classifier -> OLV DTM) is not
+ * exercised here; see `validation/protocols/independent-checkpoints-v1.md`.
+ *
+ * On the reference Rogue tile
+ * (USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3746.laz, project_id 182543),
+ * 0 of that project's 70 checkpoints fall inside this specific tile's extent
+ * — verified by direct query. That is the FAIL-CLOSED "insufficient
+ * checkpoints" path, not a bug in this harness; the assertions below cover
+ * both outcomes and this fixture is expected to take the closed branch.
+ *
+ *   CHECKPOINT_SCENE=/path/to/USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3746.laz \
+ *   CHECKPOINT_GDB=/path/to/Checkpoints_3DEP_2004_2025.gdb \
+ *   CHECKPOINT_PROJECT_ID=182543 \
+ *   npx vitest run tests/independentCheckpointHarness.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { parseLasHeader } from '../src/io/lasHeader';
+import { allocRawPoints, decodeContext, decodeRecord, type RawPoints } from '../src/io/lasDecodeShared';
+import { decodeLaz } from '../src/io/lazDecode';
+import { DtmSurfaceModel } from '../src/terrain/validate/dtmSurfaceModel';
+import {
+  readProjectCheckpointsCsv,
+  runCheckpointStudy,
+  MIN_CHECKPOINT_SAMPLE_SIZE,
+  type TileFrame,
+} from './support/checkpointGdb';
+
+const SCENE = process.env.CHECKPOINT_SCENE;
+const GDB = process.env.CHECKPOINT_GDB;
+const PROJECT_ID = process.env.CHECKPOINT_PROJECT_ID;
+const LAYER =
+  process.env.CHECKPOINT_LAYER ?? 'Consolidated_Standardized_Checkpoints_3DEP_Version2_20250930';
+const HORIZONTAL_EPSG = Number(process.env.CHECKPOINT_HORIZONTAL_EPSG ?? '6339');
+const VERTICAL_EPSG = Number(process.env.CHECKPOINT_VERTICAL_EPSG ?? '5703');
+
+const PRODUCER_GROUND = 2; // ASPRS class 2 = ground
+const CELL_SIZE_M = 1;
+
+/** Decode a plain LAS (uncompressed) or a .laz/COPC into RawPoints — same
+ *  idiom as tests/groundFilterProducerAgreement.test.ts. */
+async function decodeScene(path: string): Promise<{ out: RawPoints; count: number }> {
+  const bytes = readFileSync(path);
+  const buf = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  const header = parseLasHeader(buf);
+  const compressed = /\.(laz|copc\.laz)$/i.test(path);
+  if (compressed) {
+    const out = await decodeLaz(buf, header, [0, 0, 0], 1);
+    return { out, count: header.pointCount };
+  }
+  const count = header.pointCount;
+  const view = new DataView(buf);
+  const ctx = decodeContext(header, [0, 0, 0]);
+  const out = allocRawPoints(count, false, false);
+  for (let i = 0; i < count; i++) {
+    decodeRecord(view, header.offsetToPointData + i * header.pointDataRecordLength, i, ctx, out);
+  }
+  return { out, count };
+}
+
+const ready = Boolean(SCENE && GDB && PROJECT_ID && existsSync(SCENE) && existsSync(GDB));
+
+describe.skipIf(!ready)('independent-checkpoint accuracy harness (pathway A: producer ground -> OLV raster)', () => {
+  it('reports Bias/RMSE/MAE/NMAD/P95 when prerequisites are met, else fails closed with a named reason', async () => {
+    // A full USGS 3DEP tile decode + 1 m DTM rasterisation over its whole
+    // extent is well beyond the default 15 s unit-test timeout.
+    const { out, count } = await decodeScene(SCENE!);
+
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    const trainPts: Array<{ x: number; y: number; z: number }> = [];
+    for (let i = 0; i < count; i++) {
+      if (out.classification[i] !== PRODUCER_GROUND) continue;
+      const x = out.positions[i * 3 + 0];
+      const y = out.positions[i * 3 + 1];
+      const z = out.positions[i * 3 + 2];
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
+      trainPts.push({ x, y, z });
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+    // Sanity: the tile really does carry an official ground classification.
+    expect(trainPts.length).toBeGreaterThan(0);
+
+    const grid = {
+      originH1: minX,
+      originH2: minY,
+      cols: Math.max(1, Math.ceil((maxX - minX) / CELL_SIZE_M) + 1),
+      rows: Math.max(1, Math.ceil((maxY - minY) / CELL_SIZE_M) + 1),
+      cellSizeM: CELL_SIZE_M,
+    };
+    const model = new DtmSurfaceModel({ grid, aggregation: 'median' });
+    model.fit(trainPts);
+
+    const rows = readProjectCheckpointsCsv(GDB!, LAYER, PROJECT_ID!);
+    expect(rows.length).toBeGreaterThan(0); // the project itself must resolve
+
+    const tile: TileFrame = {
+      horizontalEpsg: HORIZONTAL_EPSG,
+      verticalEpsg: VERTICAL_EPSG,
+      minX,
+      maxX,
+      minY,
+      maxY,
+    };
+
+    const measuredById = new Map<string, number>();
+    for (const r of rows) {
+      const x = Number(r.source_easting);
+      const y = Number(r.source_northing);
+      const z = model.predict(x, y);
+      if (z !== null) measuredById.set(r.unique_identifier, z);
+    }
+
+    const { prereq, result, mae } = runCheckpointStudy(rows, tile, measuredById);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      [
+        `scene: ${SCENE!.split('/').pop()}`,
+        `project ${PROJECT_ID}: ${rows.length} checkpoint(s) total`,
+        `tile bounds: X[${minX.toFixed(1)}, ${maxX.toFixed(1)}]  Y[${minY.toFixed(1)}, ${maxY.toFixed(1)}]`,
+        `prerequisites ok: ${prereq.ok}`,
+        ...prereq.reasons.map((r) => `  - ${r}`),
+      ].join('\n'),
+    );
+
+    if (!prereq.ok) {
+      // FAIL-CLOSED path. On the reference Rogue tile this is the expected
+      // outcome: 0 of the project's checkpoints fall inside this tile.
+      expect(result).toBeNull();
+      expect(mae).toBeNull();
+      expect(prereq.reasons.length).toBeGreaterThan(0);
+      expect(prereq.usable.length).toBeLessThan(MIN_CHECKPOINT_SAMPLE_SIZE);
+    } else {
+      expect(result?.status).toBe('reported');
+      if (result?.status === 'reported') {
+        // eslint-disable-next-line no-console
+        console.log(
+          [
+            `n=${result.pooled.n}`,
+            `bias=${result.pooled.bias?.toFixed(4)}`,
+            `rmse=${result.pooled.rmse?.toFixed(4)}`,
+            `mae=${mae?.toFixed(4)}`,
+            `nmad=${result.pooled.nmad?.toFixed(4)}`,
+            `p95=${result.pooled.p95AbsResidual?.toFixed(4)}`,
+          ].join('  '),
+        );
+        expect(mae).not.toBeNull();
+      }
+    }
+  }, 120_000);
+});

--- a/tests/support/checkpointGdb.ts
+++ b/tests/support/checkpointGdb.ts
@@ -150,14 +150,30 @@ function parseCheckpointCsv(csv: string): RawCheckpointRow[] {
  * /vsistdout/`. Requires GDAL's `ogr2ogr` on PATH. No FileGDB parsing is done
  * in this codebase — GDAL is the reference reader for the format.
  */
+/**
+ * Absolute path to GDAL's `ogr2ogr`, resolved through the absolute `which` so
+ * the tool call never depends on PATH resolution (a bare `ogr2ogr` could run an
+ * attacker-planted binary earlier in PATH). `OGR2OGR_BIN` overrides for a
+ * non-standard install. Throws if GDAL is not installed, since the harness
+ * cannot read a FileGDB without it.
+ */
+function resolveOgr2ogr(): string {
+  const override = process.env.OGR2OGR_BIN;
+  if (override) return override;
+  const found = execFileSync('/usr/bin/which', ['ogr2ogr'], { encoding: 'utf8' }).trim();
+  if (!found) throw new Error('ogr2ogr not found on PATH; install GDAL or set OGR2OGR_BIN');
+  return found;
+}
+
 export function readProjectCheckpointsCsv(
   gdbPath: string,
   layer: string,
   projectId: string,
 ): RawCheckpointRow[] {
   const whereValue = /^-?\d+$/.test(projectId) ? projectId : `'${projectId.replace(/'/g, "''")}'`;
+  const ogr2ogr = resolveOgr2ogr();
   const csv = execFileSync(
-    'ogr2ogr',
+    ogr2ogr,
     [
       '-f',
       'CSV',

--- a/tests/support/checkpointGdb.ts
+++ b/tests/support/checkpointGdb.ts
@@ -1,0 +1,318 @@
+/**
+ * checkpointGdb.ts — TEST-SUPPORT adapter between USGS 3DEP survey checkpoints
+ * stored in an ESRI FileGDB and OLV's existing checkpoint-accuracy engine at
+ * `src/validation/checkpointAccuracy.ts`.
+ *
+ * This file ships with neither the app bundle nor `src/`: it is loaded only by
+ * tests. It does not reimplement bias/RMSE/NMAD/median/P90/P95 — those are
+ * computed by `checkpointAccuracy()`, reused as-is. What this file adds is
+ * specific to the 3DEP checkpoint format and to pairing checkpoints with a
+ * point-cloud tile:
+ *
+ *   - reading rows out of the `.gdb` with GDAL's `ogr2ogr` (no FileGDB reader
+ *     is written here — GDAL already reads the format correctly);
+ *   - the FAIL-CLOSED prerequisite gate a checkpoint set must pass before any
+ *     of its rows may be treated as an independent, usable checkpoint; and
+ *   - Mean Absolute Error, which `checkpointAccuracy()` does not report
+ *     (it reports bias, RMSE, median, NMAD, P90/P95, max — MAE is computed
+ *     here directly from the same residuals it returns).
+ *
+ * Fail-closed prerequisites, in the order checked:
+ *   1. at least one checkpoint of the project falls inside the tile extent;
+ *   2. of those, at least one shares the tile's horizontal AND vertical EPSG
+ *      (a checkpoint surveyed in a different datum is not comparable without
+ *      a reprojection this module does not perform, so it is excluded, not
+ *      silently reprojected);
+ *   3. of those, the checkpoint states an accuracy/uncertainty value;
+ *   4. of those, the checkpoint states a point_type (NVA/VVA) — the field
+ *      that marks it as an independent survey observation rather than a
+ *      derived or unlabelled row;
+ *   5. the surviving count is >= MIN_CHECKPOINT_SAMPLE_SIZE.
+ * Any failure is reported with a specific reason string; the gate does not
+ * stop at the first failure; nothing partial is computed for a closed gate.
+ */
+
+import { execFileSync } from 'node:child_process';
+import {
+  checkpointAccuracy,
+  type Checkpoint,
+  type CheckpointResult,
+} from '../../src/validation/checkpointAccuracy';
+
+/**
+ * Minimum usable checkpoint count before an accuracy figure is reported.
+ * Named and exported so a caller can see and tune the floor rather than
+ * hunting a magic number. 20 is the smallest sample this harness treats as
+ * saying something about a spatial bias rather than noise from a handful of
+ * points; it is a project choice, not a value copied from a standard.
+ */
+export const MIN_CHECKPOINT_SAMPLE_SIZE = 20;
+
+/** One row read from the checkpoint FileGDB, as strings (raw CSV cells). */
+export interface RawCheckpointRow {
+  readonly unique_identifier: string;
+  readonly point_type: string; // 'NVA' | 'VVA' | ''
+  readonly source_easting: string;
+  readonly source_northing: string;
+  readonly source_elevation: string;
+  readonly source_horizontal_epsg: string;
+  readonly source_vertical_epsg: string;
+  readonly accuracy: string;
+  readonly project_id: string;
+}
+
+const CSV_FIELDS = [
+  'unique_identifier',
+  'point_type',
+  'source_easting',
+  'source_northing',
+  'source_elevation',
+  'source_horizontal_epsg',
+  'source_vertical_epsg',
+  'accuracy',
+  'project_id',
+] as const;
+
+/** The tile's known frame: its CRS and its horizontal extent. */
+export interface TileFrame {
+  readonly horizontalEpsg: number;
+  readonly verticalEpsg: number;
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minY: number;
+  readonly maxY: number;
+}
+
+/**
+ * Minimal RFC-4180-ish CSV parser: handles double-quoted fields with escaped
+ * `""`, commas inside quotes, and CRLF/LF line endings. Sufficient for
+ * `ogr2ogr -f CSV` output, which is what this module ever parses.
+ */
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cur += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ',') {
+      cells.push(cur);
+      cur = '';
+    } else {
+      cur += c;
+    }
+  }
+  cells.push(cur);
+  return cells;
+}
+
+function parseCheckpointCsv(csv: string): RawCheckpointRow[] {
+  const lines = csv.split(/\r\n|\n/).filter((l) => l.length > 0);
+  if (lines.length === 0) return [];
+  const header = parseCsvLine(lines[0]);
+  const idx = new Map(header.map((h, i) => [h, i]));
+  const rows: RawCheckpointRow[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cells = parseCsvLine(lines[i]);
+    const get = (field: string): string => {
+      const j = idx.get(field);
+      return j === undefined ? '' : (cells[j] ?? '');
+    };
+    rows.push({
+      unique_identifier: get('unique_identifier'),
+      point_type: get('point_type'),
+      source_easting: get('source_easting'),
+      source_northing: get('source_northing'),
+      source_elevation: get('source_elevation'),
+      source_horizontal_epsg: get('source_horizontal_epsg'),
+      source_vertical_epsg: get('source_vertical_epsg'),
+      accuracy: get('accuracy'),
+      project_id: get('project_id'),
+    });
+  }
+  return rows;
+}
+
+/**
+ * Read one project's checkpoints out of the FileGDB with `ogr2ogr -f CSV
+ * /vsistdout/`. Requires GDAL's `ogr2ogr` on PATH. No FileGDB parsing is done
+ * in this codebase — GDAL is the reference reader for the format.
+ */
+export function readProjectCheckpointsCsv(
+  gdbPath: string,
+  layer: string,
+  projectId: string,
+): RawCheckpointRow[] {
+  const whereValue = /^-?\d+$/.test(projectId) ? projectId : `'${projectId.replace(/'/g, "''")}'`;
+  const csv = execFileSync(
+    'ogr2ogr',
+    [
+      '-f',
+      'CSV',
+      '/vsistdout/',
+      gdbPath,
+      layer,
+      '-where',
+      `project_id=${whereValue}`,
+      '-select',
+      CSV_FIELDS.join(','),
+    ],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+  return parseCheckpointCsv(csv);
+}
+
+export function withinTileExtent(row: RawCheckpointRow, tile: TileFrame): boolean {
+  const x = Number(row.source_easting);
+  const y = Number(row.source_northing);
+  return (
+    Number.isFinite(x) &&
+    Number.isFinite(y) &&
+    x >= tile.minX &&
+    x <= tile.maxX &&
+    y >= tile.minY &&
+    y <= tile.maxY
+  );
+}
+
+export function crsMatchesTile(row: RawCheckpointRow, tile: TileFrame): boolean {
+  const h = Number(row.source_horizontal_epsg);
+  const v = Number(row.source_vertical_epsg);
+  return Number.isFinite(h) && Number.isFinite(v) && h === tile.horizontalEpsg && v === tile.verticalEpsg;
+}
+
+function hasAccuracy(row: RawCheckpointRow): boolean {
+  return row.accuracy !== '' && Number.isFinite(Number(row.accuracy)) && Number(row.accuracy) >= 0;
+}
+
+function hasPointType(row: RawCheckpointRow): boolean {
+  return row.point_type === 'NVA' || row.point_type === 'VVA';
+}
+
+export interface PrerequisiteResult {
+  readonly ok: boolean;
+  readonly reasons: string[];
+  /** Rows that passed every gate except the minimum-sample-size check. */
+  readonly usable: readonly RawCheckpointRow[];
+}
+
+/**
+ * The fail-closed prerequisite gate. See the file header for the ordered list
+ * of checks. Every failing check appends its own reason; the gate never stops
+ * at the first failure, so a caller sees the whole picture in one pass.
+ */
+export function checkpointPrerequisites(rows: readonly RawCheckpointRow[], tile: TileFrame): PrerequisiteResult {
+  const reasons: string[] = [];
+
+  const inExtent = rows.filter((r) => withinTileExtent(r, tile));
+  if (inExtent.length === 0) {
+    reasons.push(`0 of ${rows.length} project checkpoint(s) fall inside the tile extent`);
+  }
+
+  const crsOk = inExtent.filter((r) => crsMatchesTile(r, tile));
+  if (inExtent.length > 0 && crsOk.length === 0) {
+    reasons.push(
+      `${inExtent.length} checkpoint(s) in extent, but none share the tile's ` +
+        `horizontal/vertical EPSG (${tile.horizontalEpsg}/${tile.verticalEpsg})`,
+    );
+  } else if (crsOk.length < inExtent.length) {
+    reasons.push(
+      `${inExtent.length - crsOk.length} in-extent checkpoint(s) excluded: CRS does not match the tile ` +
+        `(EPSG ${tile.horizontalEpsg}/${tile.verticalEpsg})`,
+    );
+  }
+
+  const withAccuracy = crsOk.filter(hasAccuracy);
+  if (crsOk.length > 0 && withAccuracy.length < crsOk.length) {
+    reasons.push(`${crsOk.length - withAccuracy.length} checkpoint(s) lack a stated accuracy/uncertainty value`);
+  }
+
+  const withPointType = withAccuracy.filter(hasPointType);
+  if (withAccuracy.length > 0 && withPointType.length < withAccuracy.length) {
+    reasons.push(
+      `${withAccuracy.length - withPointType.length} checkpoint(s) lack a point_type (NVA/VVA); ` +
+        'independence cannot be established without it',
+    );
+  }
+
+  if (withPointType.length < MIN_CHECKPOINT_SAMPLE_SIZE) {
+    reasons.push(
+      `${withPointType.length} usable checkpoint(s), ${MIN_CHECKPOINT_SAMPLE_SIZE} required ` +
+        '(MIN_CHECKPOINT_SAMPLE_SIZE)',
+    );
+  }
+
+  return { ok: reasons.length === 0, reasons, usable: withPointType };
+}
+
+/**
+ * Build `checkpointAccuracy()` input from checkpoint rows that already passed
+ * `checkpointPrerequisites`, given the product's measured elevation at each
+ * checkpoint's XY (by `unique_identifier`). Rows with no measured value
+ * (outside DTM coverage) are dropped — they carry no comparison, not a zero.
+ */
+export function toAccuracyCheckpoints(
+  rows: readonly RawCheckpointRow[],
+  measuredById: ReadonlyMap<string, number>,
+): Checkpoint[] {
+  const out: Checkpoint[] = [];
+  for (const r of rows) {
+    const measured = measuredById.get(r.unique_identifier);
+    if (measured === undefined || !Number.isFinite(measured)) continue;
+    out.push({
+      id: r.unique_identifier,
+      measured,
+      reference: Number(r.source_elevation),
+      usage: 'independent',
+      referenceSigma: Number(r.accuracy),
+    });
+  }
+  return out;
+}
+
+/** Mean Absolute Error over residuals — not reported by `checkpointAccuracy()`. */
+export function meanAbsoluteError(residuals: readonly number[]): number | null {
+  if (residuals.length === 0) return null;
+  let sum = 0;
+  for (const r of residuals) sum += Math.abs(r);
+  return sum / residuals.length;
+}
+
+export interface CheckpointStudyOutcome {
+  readonly prereq: PrerequisiteResult;
+  readonly result: CheckpointResult | null;
+  readonly mae: number | null;
+}
+
+/**
+ * End-to-end: gate, then (only if the gate passes) compute pooled/stratified
+ * accuracy plus MAE. Fails closed: `result`/`mae` stay `null` whenever
+ * `prereq.ok` is false, never a partial figure over an ungated sample.
+ */
+export function runCheckpointStudy(
+  rows: readonly RawCheckpointRow[],
+  tile: TileFrame,
+  measuredById: ReadonlyMap<string, number>,
+): CheckpointStudyOutcome {
+  const prereq = checkpointPrerequisites(rows, tile);
+  if (!prereq.ok) {
+    return { prereq, result: null, mae: null };
+  }
+  const checkpoints = toAccuracyCheckpoints(prereq.usable, measuredById);
+  const result = checkpointAccuracy(checkpoints, { minSample: MIN_CHECKPOINT_SAMPLE_SIZE });
+  const mae =
+    result.status === 'reported' ? meanAbsoluteError(result.residuals.map((r) => r.residual)) : null;
+  return { prereq, result, mae };
+}

--- a/validation/protocols/independent-checkpoints-v1.md
+++ b/validation/protocols/independent-checkpoints-v1.md
@@ -1,0 +1,82 @@
+# Independent-checkpoint vertical accuracy, v1
+
+This is a narrative protocol note, not a `.protocol.json` record: it documents
+`tests/support/checkpointGdb.ts` and `tests/independentCheckpointHarness.test.ts`,
+the harness that pairs a point-cloud tile against USGS 3DEP survey checkpoints.
+It does not itself gate a frozen claim comparison (see
+`validation/protocols/README.md` for that machinery); it is the reference for
+what the harness checks and reports.
+
+## Why this is the path to E5
+
+Every DTM accuracy figure this project has produced so far is either synthetic
+(ground truth known by construction) or cross-implementation agreement against
+another algorithm (PDAL, GDAL). Both are useful and neither is physical
+accuracy: two programs computing the same wrong answer agree perfectly.
+Independent survey checkpoints — 145,299 of them, public domain, in the USGS
+3DEP checkpoint database — are observations nothing in this project produced or
+tuned against. Comparing OLV's output to them is the one comparison that can
+move a claim from "consistent with another implementation" to "consistent with
+where the ground actually is."
+
+## Inputs
+
+- A point-cloud tile (LAS/LAZ) with a known horizontal and vertical EPSG.
+- The 3DEP checkpoint FileGDB, queried by `ogr2ogr` for the rows whose
+  `project_id` covers that tile's flight project.
+- Per checkpoint: `source_easting`/`source_northing`/`source_elevation`,
+  `source_horizontal_epsg`/`source_vertical_epsg`, `accuracy`, `point_type`.
+
+## Fail-closed prerequisites
+
+`checkpointPrerequisites()` refuses to report a figure unless, in order:
+
+1. at least one project checkpoint falls inside the tile's horizontal extent;
+2. of those, at least one shares the tile's horizontal AND vertical EPSG — a
+   checkpoint surveyed in a different datum is excluded rather than silently
+   reprojected;
+3. of those, the checkpoint states an accuracy/uncertainty value;
+4. of those, the checkpoint states a `point_type` (NVA/VVA), the field marking
+   it as an independent survey observation;
+5. the surviving count is at least `MIN_CHECKPOINT_SAMPLE_SIZE` (20).
+
+Every failing check is reported with its own reason string; the gate does not
+stop at the first failure, and nothing partial is computed when it is closed.
+
+## Statistics reported
+
+Once the gate passes, `src/validation/checkpointAccuracy.ts` (the existing,
+already-tested accuracy engine — reused here, not reimplemented) computes,
+pooled and per-stratum, over signed residuals `measured − reference`:
+
+- **bias** — mean residual
+- **RMSE** — root mean square residual
+- **median** and **NMAD** (1.4826 × median absolute deviation from the median)
+- **P90 / P95** of the absolute residual
+- **max absolute residual**
+- a 95 % confidence interval on the bias (normal approximation)
+
+`tests/support/checkpointGdb.ts` adds **MAE** (mean absolute residual), which
+`checkpointAccuracy()` does not report, computed directly from the same
+residuals.
+
+## Two separate pathways
+
+- **Pathway A** — official (producer) class-2 ground returns rasterised
+  directly into an OLV DTM via `DtmSurfaceModel`, sampled at each checkpoint.
+  This measures OLV's *surface builder* against survey truth, holding the
+  ground labelling fixed to a source OLV did not classify.
+- **Pathway B** — raw, unclassified points run through OLV's own ground
+  classifier, then rasterised the same way.
+
+The gap between pathway A and pathway B's accuracy figures is the ground
+classifier's own accuracy penalty, isolated from the surface builder's. The
+harness currently exercises pathway A; pathway B is future work using the same
+gate and the same statistics.
+
+## Reference fixture
+
+`USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3746.laz` (project_id `182543`) has
+0 of that project's 70 checkpoints inside its own extent — verified by direct
+query. Running the harness against it exercises the fail-closed
+"insufficient checkpoints" branch, not a reported accuracy figure.

--- a/validation/protocols/independent-checkpoints-v1.md
+++ b/validation/protocols/independent-checkpoints-v1.md
@@ -13,8 +13,8 @@ Every DTM accuracy figure this project has produced so far is either synthetic
 (ground truth known by construction) or cross-implementation agreement against
 another algorithm (PDAL, GDAL). Both are useful and neither is physical
 accuracy: two programs computing the same wrong answer agree perfectly.
-Independent survey checkpoints — 145,299 of them, public domain, in the USGS
-3DEP checkpoint database — are observations nothing in this project produced or
+Independent survey checkpoints (145,299 of them, public domain, in the USGS
+3DEP checkpoint database) are observations nothing in this project produced or
 tuned against. Comparing OLV's output to them is the one comparison that can
 move a claim from "consistent with another implementation" to "consistent with
 where the ground actually is."
@@ -32,9 +32,9 @@ where the ground actually is."
 `checkpointPrerequisites()` refuses to report a figure unless, in order:
 
 1. at least one project checkpoint falls inside the tile's horizontal extent;
-2. of those, at least one shares the tile's horizontal AND vertical EPSG — a
+2. of those, at least one shares the tile's horizontal AND vertical EPSG (a
    checkpoint surveyed in a different datum is excluded rather than silently
-   reprojected;
+   reprojected);
 3. of those, the checkpoint states an accuracy/uncertainty value;
 4. of those, the checkpoint states a `point_type` (NVA/VVA), the field marking
    it as an independent survey observation;
@@ -46,30 +46,28 @@ stop at the first failure, and nothing partial is computed when it is closed.
 ## Statistics reported
 
 Once the gate passes, `src/validation/checkpointAccuracy.ts` (the existing,
-already-tested accuracy engine — reused here, not reimplemented) computes,
-pooled and per-stratum, over signed residuals `measured − reference`:
+already-tested accuracy engine, reused here rather than reimplemented) computes
+the following pooled and per-stratum, over signed residuals `measured − reference`:
+bias (mean residual), RMSE (root mean square residual), median, NMAD
+(1.4826 × median absolute deviation from the median), P90 and P95 of the
+absolute residual, the maximum absolute residual, and a 95% confidence interval
+on the bias (normal approximation).
 
-- **bias** — mean residual
-- **RMSE** — root mean square residual
-- **median** and **NMAD** (1.4826 × median absolute deviation from the median)
-- **P90 / P95** of the absolute residual
-- **max absolute residual**
-- a 95 % confidence interval on the bias (normal approximation)
-
-`tests/support/checkpointGdb.ts` adds **MAE** (mean absolute residual), which
+`tests/support/checkpointGdb.ts` adds MAE (mean absolute residual), which
 `checkpointAccuracy()` does not report, computed directly from the same
 residuals.
 
 ## Two separate pathways
 
-- **Pathway A** — official (producer) class-2 ground returns rasterised
-  directly into an OLV DTM via `DtmSurfaceModel`, sampled at each checkpoint.
-  This measures OLV's *surface builder* against survey truth, holding the
-  ground labelling fixed to a source OLV did not classify.
-- **Pathway B** — raw, unclassified points run through OLV's own ground
-  classifier, then rasterised the same way.
+Pathway A rasterises the official (producer) class-2 ground returns directly
+into an OLV DTM via `DtmSurfaceModel`, sampled at each checkpoint. This measures
+OLV's surface builder against survey truth, holding the ground labelling fixed
+to a source OLV did not classify.
 
-The gap between pathway A and pathway B's accuracy figures is the ground
+Pathway B runs raw, unclassified points through OLV's own ground classifier,
+then rasterises the same way.
+
+The gap between pathway A and pathway B accuracy figures is the ground
 classifier's own accuracy penalty, isolated from the surface builder's. The
 harness currently exercises pathway A; pathway B is future work using the same
 gate and the same statistics.
@@ -77,6 +75,6 @@ gate and the same statistics.
 ## Reference fixture
 
 `USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3746.laz` (project_id `182543`) has
-0 of that project's 70 checkpoints inside its own extent — verified by direct
+0 of that project's 70 checkpoints inside its own extent, verified by direct
 query. Running the harness against it exercises the fail-closed
 "insufficient checkpoints" branch, not a reported accuracy figure.


### PR DESCRIPTION
Pairs a point-cloud tile against USGS 3DEP survey checkpoints (145,299 public-domain records, ESRI FileGDB) and reports Bias/RMSE/MAE/NMAD/P90/P95 via the existing checkpointAccuracy() engine, reused rather than reimplemented.

tests/support/checkpointGdb.ts reads a project's checkpoints with ogr2ogr and gates them through checkpointPrerequisites(): tile-extent membership, matching horizontal/vertical EPSG, a stated uncertainty value, point_type (NVA/VVA) independence, and MIN_CHECKPOINT_SAMPLE_SIZE (20). Every failing check is named; nothing partial is computed while the gate is closed.

tests/independentCheckpointHarness.test.ts is env-driven (CHECKPOINT_SCENE/CHECKPOINT_GDB/CHECKPOINT_PROJECT_ID), skips cleanly without them, and builds pathway A (official class-2 ground -> OLV DTM via DtmSurfaceModel) sampled at checkpoint XY. On the reference Rogue tile it correctly takes the fail-closed branch (0 of 70 project checkpoints fall inside that tile's extent).

validation/protocols/independent-checkpoints-v1.md documents inputs, the gate, and the pathway-A/pathway-B split. Test/script-only; src/ and the dataset register are untouched.