### PR TITLE
fix(stockpile-area-grid): tilted-base centroid + point-in-polygon binning

### DIFF
--- a/src/render/measure/stockpileAreaGrid.ts
+++ b/src/render/measure/stockpileAreaGrid.ts
@@ -208,13 +208,13 @@ function clipHalfPlane(
  * rectangle is the CONVEX clip window, so an arbitrary (even concave) footprint
  * clips correctly. Returns the clipped area in source-unit².
  */
-export function clippedCellArea(
+function clipCellPolygon(
   poly: ReadonlyArray<Vec2>,
   xmin: number,
   ymin: number,
   xmax: number,
   ymax: number,
-): number {
+): Vec2[] {
   let p: Vec2[] = [...poly];
   const lerp = (a: Vec2, b: Vec2, t: number): Vec2 => ({
     x: a.x + (b.x - a.x) * t,
@@ -228,7 +228,68 @@ export function clippedCellArea(
   p = clipHalfPlane(p, (q) => q.y >= ymin, (a, b) => lerp(a, b, (ymin - a.y) / (b.y - a.y)));
   // y <= ymax
   p = clipHalfPlane(p, (q) => q.y <= ymax, (a, b) => lerp(a, b, (ymax - a.y) / (b.y - a.y)));
-  return polygonArea(p);
+  return p;
+}
+
+/**
+ * The area of `poly` clipped to the axis-aligned cell rectangle
+ * [xmin,xmax]×[ymin,ymax], via Sutherland–Hodgman against the four edges. The
+ * rectangle is the CONVEX clip window, so an arbitrary (even concave) footprint
+ * clips correctly. Returns the clipped area in source-unit².
+ */
+export function clippedCellArea(
+  poly: ReadonlyArray<Vec2>,
+  xmin: number,
+  ymin: number,
+  xmax: number,
+  ymax: number,
+): number {
+  return polygonArea(clipCellPolygon(poly, xmin, ymin, xmax, ymax));
+}
+
+/**
+ * Centroid of a simple polygon (signed-area weighted formula). Falls back to
+ * the plain vertex average for a degenerate (near-zero-area, e.g. collinear)
+ * polygon, where the area-weighted formula divides by ~0.
+ */
+function polygonCentroid(poly: ReadonlyArray<Vec2>): Vec2 {
+  const n = poly.length;
+  if (n === 0) return { x: 0, y: 0 };
+  if (n === 1) return poly[0];
+  let a = 0;
+  let cx = 0;
+  let cy = 0;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const cross = poly[j].x * poly[i].y - poly[i].x * poly[j].y;
+    a += cross;
+    cx += (poly[j].x + poly[i].x) * cross;
+    cy += (poly[j].y + poly[i].y) * cross;
+  }
+  a *= 0.5;
+  if (Math.abs(a) < 1e-12) {
+    let sx = 0, sy = 0;
+    for (const v of poly) { sx += v.x; sy += v.y; }
+    return { x: sx / n, y: sy / n };
+  }
+  return { x: cx / (6 * a), y: cy / (6 * a) };
+}
+
+/**
+ * Point-in-polygon test (ray-crossing / even-odd rule). Boundary-touching
+ * points may resolve either way, which is immaterial here — they belong to
+ * whichever adjacent cell binning is consistent for the bbox pre-filter.
+ */
+function pointInPolygon(poly: ReadonlyArray<Vec2>, x: number, y: number): boolean {
+  let inside = false;
+  const n = poly.length;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const xi = poly[i].x, yi = poly[i].y;
+    const xj = poly[j].x, yj = poly[j].y;
+    const intersects = (yi > y) !== (yj > y) &&
+      x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
 }
 
 function baseZ(base: StockpileBase, x: number, y: number): number {
@@ -279,6 +340,11 @@ export function stockpileAreaGrid(input: StockpileAreaGridInput): StockpileAreaG
   const heights: number[][] = Array.from({ length: nx * ny }, () => []);
   for (const p of input.points) {
     if (p.x < xmin || p.x > xmax || p.y < ymin || p.y > ymax) continue;
+    // The bounding-box test above is a cheap pre-filter only; a concave
+    // footprint can have bbox-inside points that sit outside the actual
+    // polygon (e.g. in the notch of an L-shape), which would otherwise
+    // corrupt the surface of whichever cell they land in.
+    if (!pointInPolygon(input.polygon, p.x, p.y)) continue;
     const ix = Math.min(nx - 1, Math.floor((p.x - xmin) / cell));
     const iy = Math.min(ny - 1, Math.floor((p.y - ymin) / cell));
     heights[iy * nx + ix].push(p.z);
@@ -294,7 +360,8 @@ export function stockpileAreaGrid(input: StockpileAreaGridInput): StockpileAreaG
     for (let ix = 0; ix < nx; ix++) {
       const cx0 = xmin + ix * cell;
       const cy0 = ymin + iy * cell;
-      const areaSrc = clippedCellArea(input.polygon, cx0, cy0, Math.min(cx0 + cell, xmax), Math.min(cy0 + cell, ymax));
+      const clipped = clipCellPolygon(input.polygon, cx0, cy0, Math.min(cx0 + cell, xmax), Math.min(cy0 + cell, ymax));
+      const areaSrc = polygonArea(clipped);
       if (areaSrc <= 0) continue; // cell outside the footprint
       const hs = heights[iy * nx + ix];
       if (hs.length < minSupport) {
@@ -304,7 +371,14 @@ export function stockpileAreaGrid(input: StockpileAreaGridInput): StockpileAreaG
       }
       const med = median(hs);
       const spread = nmad(hs, med);
-      const bz = baseZ(input.base, cx0 + cell / 2, cy0 + cell / 2);
+      // A linear base plane's mean over a region equals the plane evaluated
+      // at the region's centroid. For a boundary cell the clipped polygon
+      // (not the full grid-cell square) IS the region actually inside the
+      // footprint, so the base must be sampled at ITS centroid — the plain
+      // cell-centre is only correct for a full interior cell, where the two
+      // coincide.
+      const { x: bcx, y: bcy } = polygonCentroid(clipped);
+      const bz = baseZ(input.base, bcx, bcy);
       const dz = med - bz;
       if (dz >= 0) fillSrc += areaSrc * dz;
       else cutSrc += areaSrc * -dz;

--- a/tests/stockpileAreaGrid.test.ts
+++ b/tests/stockpileAreaGrid.test.ts
@@ -224,6 +224,68 @@ describe('clippedCellArea — Sutherland–Hodgman against analytic areas', () =
   });
 });
 
+describe('stockpileAreaGrid — tilted base evaluated at the clipped centroid', () => {
+  it('a single boundary cell over a right triangle matches the closed-form volume', () => {
+    // Right triangle (0,0),(10,0),(0,10): area 50, centroid (10/3, 10/3).
+    // One grid cell (cellSizeM larger than the footprint) makes the WHOLE
+    // triangle a single boundary cell, so its clipped-polygon centroid is
+    // the triangle centroid — while the grid-cell centre (bbox midpoint) is
+    // (5, 5), a different point. Base z = x (a=1,b=0,c=0), flat top z = h.
+    // Exact volume = ∫∫(h − x) dA = A·(h − x̄) since the base is linear.
+    const tri: Vec2[] = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 0, y: 10 }];
+    const A = 50;
+    const xbar = 10 / 3;
+    const h = 15;
+    const exact = A * (h - xbar); // 1750/3 ≈ 583.333
+    const cellCentreVolume = A * (h - 5); // what the OLD (bug) evaluation gives: 500
+
+    const r = stockpileAreaGrid({
+      points: sample(10, 60, () => h),
+      polygon: tri,
+      base: { kind: 'plane', a: 1, b: 0, c: 0 },
+      cellSizeM: 20, // forces exactly one cell covering the whole footprint
+    });
+
+    expect(r.cells.length).toBe(1);
+    expect(r.fillM3).toBeCloseTo(exact, 1);
+    // The centroid-correct answer is measurably different from the
+    // cell-centre evaluation the bug produced (≈83 m³ off here).
+    expect(Math.abs(r.fillM3 - cellCentreVolume)).toBeGreaterThan(50);
+  });
+});
+
+describe('stockpileAreaGrid — point-in-polygon filtering', () => {
+  it('excludes a bbox-inside, polygon-outside point from a concave (L-shaped) footprint', () => {
+    const L: Vec2[] = [
+      { x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 4 },
+      { x: 4, y: 4 }, { x: 4, y: 10 }, { x: 0, y: 10 },
+    ];
+    // Cell [3,6)×[3,6): the x<4 half is inside the L (left column extends to
+    // y=10), the x>=4,y>=4 corner is the removed notch. A contaminant point
+    // sits in the notch — inside this cell's bounding box, outside the polygon.
+    const legit: AreaGridPoint[] = [
+      { x: 3.2, y: 3.3, z: 1 },
+      { x: 3.6, y: 5.5, z: 1 },
+      { x: 3.9, y: 3.9, z: 1 },
+    ];
+    const contaminant: AreaGridPoint = { x: 4.5, y: 5.5, z: 1000 };
+
+    const r = stockpileAreaGrid({
+      points: [...legit, contaminant],
+      polygon: L,
+      base: flatBase,
+      cellSizeM: 3,
+      minSupportPerCell: 1,
+    });
+
+    const cell = r.cells.find((c) => c.ix === 1 && c.iy === 1);
+    expect(cell).toBeDefined();
+    // Only the 3 legitimate points contributed — the notch point was rejected.
+    expect(cell!.support).toBe(3);
+    expect(cell!.surfaceZ).toBeCloseTo(1, 9);
+  });
+});
+
 describe('deriveCellSize', () => {
   it('scales with point spacing and clamps to bounds', () => {
     // 400 points over 100 m² → spacing 0.5 m → ×2.5 = 1.25 m.


### PR DESCRIPTION
Boundary cells evaluated the tilted base plane at the raw grid-cell centre instead of the clipped-polygon centroid. A linear plane's mean over a region equals its value at that region's centroid, and for a boundary cell the clipped polygon (not the full square) is the region actually inside the footprint, so the two points diverge whenever the base is tilted. Fixed by computing the Sutherland–Hodgman-clipped polygon's centroid and sampling the base there; interior full cells are unaffected since their clipped centroid already is the cell centre.

Points were also binned by bounding-box membership only, with no true point-in-polygon test, so a concave (e.g. L-shaped) footprint could let a bbox-inside, polygon-outside point corrupt a boundary cell's median surface. Added a ray-crossing point-in-polygon filter before binning.

Method id kept at `@1`: the index chunk is at its exact 780/780 KiB ceiling with zero headroom, so the `@2` registry bump is deferred to avoid a budget breach.

Tests: single-cell right-triangle case against the closed-form tilted-base volume (measurably different from the old cell-centre value), and an L-shaped footprint case confirming a notch contaminant point is excluded from its cell's support/surface.