### PR TITLE
fix(change): net volume as raw sum, not thresholded gain-loss

### DIFF
--- a/docs/science/METHOD_REGISTRY.md
+++ b/docs/science/METHOD_REGISTRY.md
@@ -40,6 +40,8 @@ the paper that specifies it.
 | `olv.registration.epoch-horizontal-icp` | 1 | Repeat-epoch horizontal alignment (yaw + XY, Z locked) | Besl & McKay (1992); Umeyama (1991) |
 | `olv.volume.stockpile` | 1 | Stockpile cut-fill volume ±1σ | internal (prismatic cut-fill) |
 | `olv.volume.stockpile-area-grid` | 1 | Area-weighted stockpile volume (grid integration) | internal (area-weighted DoD); Sutherland & Hodgman (1974) |
+| `olv.change.dtm-difference` | 1 | DTM-of-difference cut/fill (thresholded gain/loss/net) | Anderson (2019), LoD thresholding |
+| `olv.change.dtm-difference.raw-net` | 1 | DTM-of-difference cut/fill (raw net + thresholded gross) | Anderson (2019), thresholded gross vs raw net |
 | `olv.feature.building-footprint` | 1 | Building footprint candidate extraction | internal (connected-component + boundary trace) |
 | `olv.feature.conductor-fit` | 1 | Conductor centreline and sag fit | internal (parabolic small-sag approximation) |
 

--- a/src/science/methodRegistry.ts
+++ b/src/science/methodRegistry.ts
@@ -27,6 +27,7 @@ export type MethodCategory =
   | 'validation'
   | 'registration'
   | 'volume'
+  | 'change'
   | 'dtm'
   | 'feature'
   | 'provenance';
@@ -232,6 +233,37 @@ export const METHOD_REGISTRY: Readonly<Record<string, MethodEntry>> = {
       'Sutherland & Hodgman (1974) polygon clipping); standard earthworks method.',
     category: 'volume',
     implementation: ['src/render/measure/stockpileAreaGrid.ts'],
+  },
+  // Legacy id: the net figure this describes is the ABOVE-LoD thresholded
+  // gain-minus-loss (see changeDetection.ts's `netVolumeM3`). Kept resolvable
+  // for existing exports/sessions; `.raw-net` below is the corrected successor
+  // and should be preferred for new net-volume figures.
+  'olv.change.dtm-difference': {
+    id: 'olv.change.dtm-difference',
+    version: 1,
+    name: 'DTM-of-difference cut/fill (thresholded gain/loss/net)',
+    summary:
+      'Per-cell two-epoch elevation difference, classified against a Level-of-Detection ' +
+      'threshold; gain and loss volumes sum only above-LoD cells, and net is gain minus ' +
+      'loss over that same thresholded subset.',
+    citation: 'Anderson (2019), pubs.usgs.gov/publication/70202166 (LoD thresholding for gross change)',
+    category: 'change',
+    implementation: ['src/terrain/change/changeDetection.ts', 'src/terrain/change/compareDtms.ts'],
+  },
+  'olv.change.dtm-difference.raw-net': {
+    id: 'olv.change.dtm-difference.raw-net',
+    version: 1,
+    name: 'DTM-of-difference cut/fill (raw net + thresholded gross)',
+    summary:
+      'Same per-cell two-epoch difference as olv.change.dtm-difference, but reports the ' +
+      'net volume as a raw sum over ALL comparable cells (no LoD threshold), alongside the ' +
+      'LoD-thresholded gross gain/loss for erosion/deposition reporting. Thresholding is ' +
+      'correct for gross change (noise inflates both sides) but biases the net, since ' +
+      'uncorrelated sub-LoD error of opposite sign would otherwise cancel and instead gets ' +
+      'zeroed out asymmetrically.',
+    citation: 'Anderson (2019), pubs.usgs.gov/publication/70202166 (thresholded gross vs raw net)',
+    category: 'change',
+    implementation: ['src/terrain/change/changeDetection.ts', 'src/terrain/change/compareDtms.ts'],
   },
   'olv.topology.linkage-record': {
     id: 'olv.topology.linkage-record',

--- a/src/terrain/change/changeDetection.ts
+++ b/src/terrain/change/changeDetection.ts
@@ -70,10 +70,37 @@ export interface ChangeStats {
   readonly unchanged: number;
   /** Fraction of comparable cells that changed significantly, 0..1. */
   readonly significantFraction: number;
-  /** Volumes (m³) over comparable cells: gain (Δ>0), loss (Δ<0), and net = gain − loss. */
+  /**
+   * Volumes (m³) over ABOVE-LoD cells only: gain (Δ>+LoD), loss (Δ<−LoD), and
+   * net = gain − loss. Thresholding is the right call for GROSS erosion/
+   * deposition (Anderson, USGS pubs.usgs.gov/publication/70202166 — noise
+   * inflates both sides equally, so dropping sub-LoD cells removes it), but
+   * applying the SAME threshold to the NET is a bias: uncorrelated random
+   * error that would cancel in a raw sum survives here because opposite-sign
+   * sub-LoD cells are both zeroed out before they can offset each other. Use
+   * {@link rawNetVolumeM3} for the net figure; these three remain exactly the
+   * legacy `olv.change.dtm-difference@1` quantities and are NOT redefined.
+   */
   readonly gainVolumeM3: number;
   readonly lossVolumeM3: number;
   readonly netVolumeM3: number;
+  /**
+   * Net volume (m³) summed over EVERY comparable cell (no LoD threshold):
+   * Σ Δz·cellArea. Per Anderson, this is the statistically correct net —
+   * uncorrelated sub-LoD noise of both signs is free to cancel, instead of
+   * being clipped to zero on one side only. This is the primary net figure
+   * (`olv.change.dtm-difference@2`); `netVolumeM3` above is kept unchanged
+   * for `@1` provenance.
+   */
+  readonly rawNetVolumeM3: number;
+  /** Alias of {@link gainVolumeM3} under the `@2` naming (above-LoD gain). */
+  readonly detectableGainVolumeM3: number;
+  /** Alias of {@link lossVolumeM3} under the `@2` naming (above-LoD loss). */
+  readonly detectableLossVolumeM3: number;
+  /** Alias of {@link netVolumeM3} under the `@2` naming (thresholded net, for gross/net comparison). */
+  readonly detectableNetVolumeM3: number;
+  /** Fraction of comparable cells whose |Δ| exceeds the LoD (same value as {@link significantFraction}, named for `@2`'s gross/net reconciliation). */
+  readonly areaAboveLoDFraction: number;
   /** Mean |Δ| over comparable cells (m). */
   readonly meanAbsChangeM: number;
   /** Signed extremes (m): largest gain (≥0) and largest loss (≤0). */
@@ -152,6 +179,7 @@ export function detectChange(
   let lost = 0;
   let gainVolumeM3 = 0;
   let lossVolumeM3 = 0;
+  let rawNetVolumeM3 = 0;
   let absSum = 0;
   let maxGainM = 0;
   let maxLossM = 0;
@@ -172,8 +200,14 @@ export function detectChange(
       absSum += Math.abs(d);
       if (d > maxGainM) maxGainM = d;
       if (d < maxLossM) maxLossM = d;
-      // Volumes count ONLY significant (above-LoD) cells — a DEM-of-difference
-      // thresholds out the noise floor so sub-LoD jitter never inflates cut/fill.
+      // rawNetVolumeM3 integrates EVERY comparable cell, thresholded or not —
+      // the correct net estimator (Anderson, USGS pubs.usgs.gov/publication/70202166):
+      // uncorrelated sub-LoD noise of both signs is free to cancel here, unlike
+      // the thresholded gain/loss volumes below.
+      rawNetVolumeM3 += d * cellArea;
+      // Detectable (above-LoD) gain/loss volumes — correct for GROSS
+      // erosion/deposition, where thresholding out the noise floor stops
+      // sub-LoD jitter from inflating cut/fill in either direction.
       if (d > lod) { classes[oi] = 1; gained++; gainVolumeM3 += d * cellArea; }
       else if (d < -lod) { classes[oi] = -1; lost++; lossVolumeM3 += -d * cellArea; }
       else classes[oi] = 0;
@@ -191,6 +225,11 @@ export function detectChange(
     gainVolumeM3,
     lossVolumeM3,
     netVolumeM3: gainVolumeM3 - lossVolumeM3,
+    rawNetVolumeM3,
+    detectableGainVolumeM3: gainVolumeM3,
+    detectableLossVolumeM3: lossVolumeM3,
+    detectableNetVolumeM3: gainVolumeM3 - lossVolumeM3,
+    areaAboveLoDFraction: comparable > 0 ? (gained + lost) / comparable : 0,
     meanAbsChangeM: comparable > 0 ? absSum / comparable : 0,
     maxGainM,
     maxLossM,

--- a/src/terrain/change/compareDtms.ts
+++ b/src/terrain/change/compareDtms.ts
@@ -267,8 +267,14 @@ export function summarizeChange(comparison: EpochComparison, ctx: ChangeSummaryC
     );
   } else {
     lines.push(
-      `Net volume change: ${s.netVolumeM3.toFixed(1)} m³ ` +
-        `(gain ${s.gainVolumeM3.toFixed(1)} m³, loss ${s.lossVolumeM3.toFixed(1)} m³).`,
+      `Net volume change (raw, all comparable cells, no LoD threshold): ${s.rawNetVolumeM3.toFixed(1)} m³.`,
+    );
+    lines.push(
+      `Detectable gross change (above the ${comparison.levelOfDetectionM} m level of detection): ` +
+        `gain ${s.detectableGainVolumeM3.toFixed(1)} m³, loss ${s.detectableLossVolumeM3.toFixed(1)} m³, ` +
+        `thresholded net ${s.detectableNetVolumeM3.toFixed(1)} m³ — thresholding the net biases it ` +
+        `(uncorrelated sub-LoD error should cancel, not zero out asymmetrically), so the raw net above ` +
+        `is the reported net figure.`,
     );
     // Qualify the net volume with a ± band + detectability. A bare figure hides
     // whether the change exceeds the noise, and an unquantified co-registration

--- a/tests/changeNetVolumeRaw.test.ts
+++ b/tests/changeNetVolumeRaw.test.ts
@@ -1,0 +1,93 @@
+/**
+ * changeNetVolumeRaw.test.ts
+ *
+ * Proves the raw-net vs thresholded-net distinction added to `detectChange`.
+ * Per Anderson (USGS, pubs.usgs.gov/publication/70202166), thresholding at the
+ * Level-of-Detection is correct for GROSS erosion/deposition (noise inflates
+ * both sides), but applying the same threshold to the NET is a bias: it zeros
+ * out sub-LoD cells before opposite-sign error can cancel, instead of letting
+ * it cancel in a raw sum.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { detectChange, type ChangeGrid } from '../src/terrain/change/changeDetection';
+
+function grid(width: number, height: number, cellSizeM: number, fill: number | number[]): ChangeGrid {
+  const values = new Float32Array(width * height);
+  if (Array.isArray(fill)) values.set(fill);
+  else values.fill(fill);
+  return { width, height, cellSizeM, values };
+}
+
+describe('detectChange — raw net vs thresholded net', () => {
+  it('mixed-sign sub-LoD cells: the OLD thresholded net reads ~0 while rawNetVolumeM3 recovers the true non-zero net', () => {
+    const lod = 0.1;
+    // 4 cells, 1 m² each. Sub-LoD diffs of mixed sign: +0.05, +0.05, -0.03, -0.03.
+    // True net over all 4 cells = (0.05+0.05-0.03-0.03) * 1 m² = 0.04 m³ — real,
+    // non-zero, but every cell individually is below the 0.1 m LoD.
+    const a = grid(2, 2, 1, [0, 0, 0, 0]);
+    const b = grid(2, 2, 1, [0.05, 0.05, -0.03, -0.03]);
+    const r = detectChange(a, b, { levelOfDetectionM: lod });
+
+    // Every cell is sub-LoD: nothing is classified as gain or loss.
+    expect(r.stats.gained).toBe(0);
+    expect(r.stats.lost).toBe(0);
+    expect(r.stats.unchanged).toBe(4);
+
+    // The OLD (thresholded) net is exactly zero — the bug this fixes.
+    expect(r.stats.netVolumeM3).toBe(0);
+    expect(r.stats.detectableNetVolumeM3).toBe(0);
+    expect(r.stats.gainVolumeM3).toBe(0);
+    expect(r.stats.lossVolumeM3).toBe(0);
+
+    // The raw net recovers the true non-zero net over all comparable cells.
+    expect(r.stats.rawNetVolumeM3).toBeCloseTo(0.04, 6);
+    expect(r.stats.rawNetVolumeM3).not.toBe(r.stats.netVolumeM3);
+  });
+
+  it('real gains+losses: detectable gross (above-LoD) volumes differ from the raw net total', () => {
+    const lod = 0.1;
+    // Cell areas 1 m² each (cellSizeM=1). Mix of above-LoD and sub-LoD cells.
+    const a = grid(2, 3, 1, [0, 0, 0, 0, 0, 0]);
+    const b = grid(2, 3, 1, [
+      1.0, -1.0, // strong gain, strong loss (above LoD)
+      0.05, -0.02, // sub-LoD gain, sub-LoD loss
+      0.2, -0.3, // above-LoD gain, above-LoD loss
+    ]);
+    const r = detectChange(a, b, { levelOfDetectionM: lod });
+
+    // Above-LoD classification: 1.0, 0.2 gain; -1.0, -0.3 loss; 0.05/-0.02 unchanged.
+    expect(r.stats.gained).toBe(2);
+    expect(r.stats.lost).toBe(2);
+    expect(r.stats.unchanged).toBe(2);
+
+    const expectedDetectableGain = 1.0 + 0.2;
+    const expectedDetectableLoss = 1.0 + 0.3;
+    expect(r.stats.detectableGainVolumeM3).toBeCloseTo(expectedDetectableGain, 6);
+    expect(r.stats.detectableLossVolumeM3).toBeCloseTo(expectedDetectableLoss, 6);
+    expect(r.stats.detectableNetVolumeM3).toBeCloseTo(expectedDetectableGain - expectedDetectableLoss, 6);
+
+    // Raw net includes the sub-LoD cells too, so it differs from the
+    // detectable (thresholded) net by exactly the sub-LoD contribution.
+    const expectedRawNet = 1.0 - 1.0 + 0.05 - 0.02 + 0.2 - 0.3;
+    expect(r.stats.rawNetVolumeM3).toBeCloseTo(expectedRawNet, 6);
+    expect(r.stats.rawNetVolumeM3).not.toBeCloseTo(r.stats.detectableNetVolumeM3, 6);
+
+    // Both families are reported and reconcile: gross gain/loss plus the
+    // area-above-LoD fraction fully account for the classification counts.
+    expect(r.stats.areaAboveLoDFraction).toBeCloseTo(4 / 6, 6);
+    expect(r.stats.areaAboveLoDFraction).toBe(r.stats.significantFraction);
+    expect(r.stats.gainVolumeM3).toBe(r.stats.detectableGainVolumeM3);
+    expect(r.stats.lossVolumeM3).toBe(r.stats.detectableLossVolumeM3);
+    expect(r.stats.netVolumeM3).toBe(r.stats.detectableNetVolumeM3);
+  });
+
+  it('legacy @1 fields (gainVolumeM3/lossVolumeM3/netVolumeM3) are unchanged in meaning — still thresholded', () => {
+    const r = detectChange(grid(3, 3, 2, 0), grid(3, 3, 2, 1));
+    // Same assertions as the pre-existing "uniform +1 m gain" pin, proving @1's
+    // outputs were not mutated by adding the @2 fields.
+    expect(r.stats.gainVolumeM3).toBe(36);
+    expect(r.stats.netVolumeM3).toBe(36);
+    expect(r.stats.rawNetVolumeM3).toBe(36); // no sub-LoD cells here, so raw == thresholded
+  });
+});

--- a/tests/methodSupportingTests.test.ts
+++ b/tests/methodSupportingTests.test.ts
@@ -60,6 +60,15 @@ const SUPPORTING_TESTS: Readonly<Record<string, readonly string[]>> = {
   ],
   'olv.volume.stockpile-area-grid': ['tests/stockpileAreaGrid.test.ts'],
   'olv.topology.linkage-record': ['tests/sourceTopologyManifest.test.ts'],
+  'olv.change.dtm-difference': [
+    'tests/changeDetection.test.ts',
+    'tests/compareDtms.test.ts',
+    'tests/changeGrassAgreement.test.ts',
+  ],
+  'olv.change.dtm-difference.raw-net': [
+    'tests/changeNetVolumeRaw.test.ts',
+    'tests/changeVolumeAnalyticalOracle.test.ts',
+  ],
   'olv.feature.building-footprint': ['tests/buildingFootprints.test.ts', 'tests/footprintTrace.test.ts'],
   'olv.feature.conductor-fit': ['tests/conductors.test.ts'],
   'olv.contour.analytical': [


### PR DESCRIPTION
DTM-of-difference change detection computed net volume as gainVolumeM3 − lossVolumeM3, both summed only over above-LoD cells. Per Anderson (USGS, pubs.usgs.gov/publication/70202166), LoD thresholding is correct for gross erosion/deposition (noise inflates both sides equally) but biases the net: uncorrelated sub-LoD error of opposite sign gets zeroed asymmetrically instead of cancelling in a raw sum.

Adds `rawNetVolumeM3` (Σ over all comparable cells, no threshold) as the corrected net figure, plus `detectableGainVolumeM3`/`detectableLossVolumeM3`/`detectableNetVolumeM3`/`areaAboveLoDFraction` for gross reporting. The legacy `gainVolumeM3`/`lossVolumeM3`/`netVolumeM3` fields are unchanged.

Registers `olv.change.dtm-difference` (legacy, thresholded net) and `olv.change.dtm-difference.raw-net` (corrected) in the method registry, with doc parity. `summarizeChange` now prints both the raw net and the thresholded gross with an explanation.

New tests: a mixed-sign sub-LoD field where the old thresholded net reads 0 while `rawNetVolumeM3` recovers the true non-zero net, and a mixed gross+sub-LoD field showing gross ≠ raw net.

`npx tsc --noEmit` exit 0. `npx vitest run` on the 9 affected test files: 119 passed. Bundle budget: index 780/780 KiB, unchanged, gate passes.