### PR TITLE
fix(crs): stop treating LAS 2111 math-transform as coordinate-system WKT

### DIFF
--- a/src/io/crs.ts
+++ b/src/io/crs.ts
@@ -6,8 +6,10 @@
  * specification:
  *
  *   1. OGC WKT (LAS 1.4 default and best for modern files) — VLR with
- *      User ID `LASF_Projection`, record ID 2112 (Coordinate System WKT)
- *      or 2111 (Math Transform WKT). Payload is null-terminated ASCII.
+ *      User ID `LASF_Projection`, record ID 2112 (Coordinate System WKT).
+ *      Payload is null-terminated ASCII. Record ID 2111 (Math Transform WKT)
+ *      is a distinct, optional supplemental transform, NOT a coordinate
+ *      system, and is never used as one here.
  *
  *   2. GeoTIFF tags (LAS 1.0–1.3, also LAS 1.4 when the global-encoding
  *      WKT bit is clear) — three VLRs:
@@ -144,9 +146,13 @@ const VLR_RECORD_LENGTH_OFFSET = 20;
 
 /** The user ID every LAS georeference VLR uses. */
 const CRS_USER_ID = 'LASF_Projection';
-/** OGC WKT record IDs. 2112 is the coordinate-system WKT; 2111 is the math transform. */
+/**
+ * OGC WKT record ID for the coordinate-system WKT — the ONLY authoritative CRS.
+ * Record ID 2111 (Math Transform WKT) is a distinct, optional supplemental
+ * transform per the LAS spec and is deliberately NOT read here: it is not a
+ * coordinate system and must never stand in for one.
+ */
 const RECORD_ID_OGC_WKT_COORD = 2112;
-const RECORD_ID_OGC_WKT_MATH = 2111;
 /** GeoTIFF tag VLR record IDs. */
 const RECORD_ID_GEOKEY_DIRECTORY = 34735;
 const RECORD_ID_GEO_DOUBLE_PARAMS = 34736;
@@ -206,9 +212,12 @@ export function parseCrsFromVlrs(
     if (payloadStart + payloadLength > buffer.byteLength) break;
 
     if (userId === CRS_USER_ID) {
-      if (recordId === RECORD_ID_OGC_WKT_COORD || recordId === RECORD_ID_OGC_WKT_MATH) {
+      if (recordId === RECORD_ID_OGC_WKT_COORD) {
         if (!wktPayload) {
-          // The OGC WKT payload is null-terminated ASCII per LAS spec.
+          // 2112 is the ONLY authoritative CRS WKT. 2111 (math transform) is a
+          // supplemental parameter set, not a coordinate system, and must never
+          // be substituted in when 2112 is absent — that would silently label
+          // the file with a transform, not a CRS.
           wktPayload = readNullTerminated(buffer, payloadStart, payloadLength);
         }
       } else if (recordId === RECORD_ID_GEOKEY_DIRECTORY) {

--- a/tests/crs.test.ts
+++ b/tests/crs.test.ts
@@ -288,6 +288,34 @@ test('parseCrsFromVlrs — ignores non-LASF_Projection VLRs', () => {
   expect(parseCrsFromVlrs(buffer, vlrStart, count)).toBeNull();
 });
 
+test('parseCrsFromVlrs — a 2111 math-transform VLR with no 2112 does NOT resolve as a CRS', () => {
+  // Record ID 2111 (Math Transform WKT) is an optional supplemental transform,
+  // not a coordinate system, per the LAS spec. Falling back to it as the CRS
+  // when 2112 is absent would silently mislabel the file's frame.
+  const wktBytes = new TextEncoder().encode(UTM12N_WKT + '\0');
+  const { buffer, vlrStart, count } = buildVlrBuffer(
+    [{ userId: 'LASF_Projection', recordId: 2111, payload: wktBytes }],
+    100,
+  );
+  expect(parseCrsFromVlrs(buffer, vlrStart, count)).toBeNull();
+});
+
+test('parseCrsFromVlrs — a 2112 CRS WKT alongside a 2111 math-transform VLR uses only 2112', () => {
+  const wktBytes = new TextEncoder().encode(UTM12N_WKT + '\0');
+  const mathBytes = new TextEncoder().encode('PARAM_MT["Affine"]\0');
+  const { buffer, vlrStart, count } = buildVlrBuffer(
+    [
+      { userId: 'LASF_Projection', recordId: 2111, payload: mathBytes },
+      { userId: 'LASF_Projection', recordId: 2112, payload: wktBytes },
+    ],
+    100,
+  );
+  const crs = parseCrsFromVlrs(buffer, vlrStart, count);
+  expect(crs).not.toBeNull();
+  expect(crs?.source).toBe('wkt');
+  expect(crs?.epsg).toBe(32612);
+});
+
 test('parseCrsFromVlrs — gracefully returns null on truncated buffer', () => {
   // A "buffer" that promises 5 VLRs but only has bytes for one header.
   const buffer = new ArrayBuffer(100);


### PR DESCRIPTION
Record ID 2112 (Coordinate System WKT) is the authoritative CRS in LAS; 2111 (Math Transform WKT) is an optional supplemental transform, not a CRS. `parseCrsFromVlrs` in `src/io/crs.ts` accepted whichever of 2112/2111 appeared first in the VLR list as `wktPayload`, so a file carrying only 2111 (or with 2111 before 2112) resolved a math transform as the coordinate system rather than leaving the CRS unknown.

Fix: only record ID 2112 populates `wktPayload`; 2111 is no longer read. Fail-closed — a file with only 2111 now resolves to `null` (unknown CRS) instead of a wrong frame.

Not changed: EVLRs stay ignored (COPC pins CRS into a regular VLR, per existing comment) and the WKT payload decode stays ASCII — both left as-is per scope, no evidence of a real gap.

Added two regression tests in `tests/crs.test.ts`: a 2111-only VLR set resolves to `null`, and a 2112+2111 set resolves using only the 2112 EPSG. `npx tsc --noEmit` exit 0, 25/25 crs tests pass, bundle budget unchanged (index 780/780 KiB), lint:claims-language green.