### PR TITLE
Demote ASPRS-2014 terminology on same-cloud residual diagnostics

### DIFF
--- a/src/terrain/validate/verticalAccuracy.ts
+++ b/src/terrain/validate/verticalAccuracy.ts
@@ -1,10 +1,11 @@
 /**
  * verticalAccuracy.ts
  *
- * Reports the hold-out validation result in the form surveyors actually
- * recognise: the ASPRS 2014 vertical accuracy FORMULAS. Bare RMSE is
- * fine internally; "NVA / VVA at 95% confidence" is what surveyors
- * recognise on a deliverable.
+ * Reports the hold-out validation result as plain internal residual
+ * diagnostics — RMSE, bias, NMAD, P95 absolute residual — computed on
+ * same-cloud hold-out points, not independent survey checkpoints. The
+ * ASPRS 2014 NVA/VVA FORMULAS are applied and shown as named analogs,
+ * never as the leading, headline terminology.
  *
  * HONESTY BOUNDARY (why every user-facing label says "-style (hold-out)"):
  * ASPRS 2014 defines NVA/VVA against INDEPENDENT survey checkpoints — GCPs
@@ -68,12 +69,12 @@ export function computeVerticalAccuracy(report: ValidationReport): VerticalAccur
     bias: Number.isFinite(report.bias) ? report.bias : Number.NaN,
     nmad: Number.isFinite(report.nmad) ? report.nmad : Number.NaN,
     sampleSize: report.sampleSize,
-    standard: 'ASPRS 2014 formulas, hold-out basis',
+    standard: 'internal residual diagnostic; 2014-formula analogs, hold-out basis',
   };
 }
 
 /**
- * Human-readable accuracy lines for a panel or PDF. Honest when there is
+ * Human-readable diagnostic lines for a panel or PDF. Honest when there is
  * no measurement: a single explained line instead of fake figures.
  */
 export function formatVerticalAccuracy(report: ValidationReport, units = 'm'): string[] {
@@ -83,24 +84,24 @@ export function formatVerticalAccuracy(report: ValidationReport, units = 'm'): s
   }
   const u = ` ${units}`;
   const lines = [
-    `Vertical RMSEz: ${a.rmseZ.toFixed(2)}${u} (n=${a.sampleSize}, hold-out)`,
-    `NVA-style @ 95% (${a.standard}): ${a.nva95.toFixed(2)}${u} — ` +
-      `assumes normally distributed error; withheld points, not independent checkpoints`,
-    `VVA-style @ 95% (percentile, hold-out): ${a.vva95.toFixed(2)}${u} — ` +
-      `p95 of ALL residuals, not vegetated-class checkpoints`,
+    `Internal vertical residual RMSE: ${a.rmseZ.toFixed(2)}${u} (n=${a.sampleSize}, hold-out)`,
+    `2014-formula NVA analog: ${a.nva95.toFixed(2)}${u} — ` +
+      `hold-out residuals, not an ASPRS checkpoint assessment; assumes normal error`,
+    `P95 absolute residual (2014-formula VVA analog): ${a.vva95.toFixed(2)}${u} — ` +
+      `hold-out, not vegetated-class checkpoints`,
   ];
   // Bias + NMAD expose what RMSE hides: a systematic offset and a robust spread.
   if (Number.isFinite(a.bias)) {
     const sign = a.bias >= 0 ? '+' : '';
     lines.push(
-      `Systematic bias: ${sign}${a.bias.toFixed(2)}${u} (mean signed residual, hold-out; ` +
+      `Bias: ${sign}${a.bias.toFixed(2)}${u} (mean signed residual, hold-out; ` +
         `${a.bias >= 0 ? 'surface reads low' : 'surface reads high'})`,
     );
   }
   if (Number.isFinite(a.nmad)) {
     lines.push(
       `NMAD (robust spread, hold-out): ${a.nmad.toFixed(2)}${u} — outlier-resistant, ` +
-        `trust over RMSEz when errors are non-normal`,
+        `trust over RMSE when errors are non-normal`,
     );
   }
   return lines;

--- a/tests/analyseContours.test.ts
+++ b/tests/analyseContours.test.ts
@@ -64,7 +64,7 @@ describe('analyseContours', () => {
   });
 
   it('exposes ASPRS accuracy and index-contour labels', () => {
-    expect(r.accuracy.standard).toBe('ASPRS 2014 formulas, hold-out basis');
+    expect(r.accuracy.standard).toBe('internal residual diagnostic; 2014-formula analogs, hold-out basis');
     if (Number.isFinite(r.accuracy.rmseZ)) {
       expect(r.accuracy.nva95).toBeCloseTo(1.96 * r.accuracy.rmseZ, 6);
     }

--- a/tests/verticalAccuracy.test.ts
+++ b/tests/verticalAccuracy.test.ts
@@ -40,7 +40,7 @@ describe('computeVerticalAccuracy', () => {
     expect(a.rmseZ).toBe(0.5);
     expect(a.nva95).toBeCloseTo(0.5 * NVA_95_MULTIPLIER, 6);
     expect(a.vva95).toBe(1.1);
-    expect(a.standard).toBe('ASPRS 2014 formulas, hold-out basis');
+    expect(a.standard).toBe('internal residual diagnostic; 2014-formula analogs, hold-out basis');
   });
 
   it('carries signed bias + NMAD through, and formats them with direction', () => {
@@ -49,7 +49,7 @@ describe('computeVerticalAccuracy', () => {
     expect(a.nmad).toBe(0.3);
     const lines = formatVerticalAccuracy(report(0.5, 1.1, 100, -0.08, 0.3)).join('\n');
     // Negative bias ⇒ surface reads high; NMAD line present.
-    expect(lines).toMatch(/Systematic bias: -0\.08 m.*reads high/);
+    expect(lines).toMatch(/Bias: -0\.08 m.*reads high/);
     expect(lines).toMatch(/NMAD \(robust spread, hold-out\): 0\.30 m/);
   });
 
@@ -60,11 +60,11 @@ describe('computeVerticalAccuracy', () => {
 });
 
 describe('formatVerticalAccuracy', () => {
-  it('states the normal-distribution assumption and both figures', () => {
+  it('leads with plain residual diagnostics, not an ASPRS conformance claim', () => {
     const lines = formatVerticalAccuracy(report(0.5, 1.1));
-    expect(lines.join(' ')).toMatch(/NVA-style @ 95%/);
-    expect(lines.join(' ')).toMatch(/assumes normally distributed/i);
-    expect(lines.join(' ')).toMatch(/VVA-style @ 95%/);
+    expect(lines[0]).toMatch(/Internal vertical residual RMSE/);
+    expect(lines.join(' ')).toMatch(/not an ASPRS checkpoint assessment/i);
+    expect(lines.join(' ')).toMatch(/2014-formula (NVA|VVA) analog/i);
   });
 
   it('qualifies every figure as hold-out — never an independent-checkpoint claim', () => {
@@ -72,7 +72,7 @@ describe('formatVerticalAccuracy', () => {
     // All three lines carry the hold-out qualifier.
     for (const line of lines) expect(line).toMatch(/hold-out/);
     // The disclosures name what the figures are NOT.
-    expect(lines.join(' ')).toMatch(/not independent checkpoints/i);
+    expect(lines.join(' ')).toMatch(/not an ASPRS checkpoint assessment/i);
     expect(lines.join(' ')).toMatch(/not vegetated-class checkpoints/i);
   });
 
@@ -87,7 +87,7 @@ describe('VerticalAccuracy.standard — a basis tag, not a conformance tag', () 
   it('never reads as a bare "ASPRS 2014" conformance claim', () => {
     const a = computeVerticalAccuracy(report(0.5, 1.1));
     expect(a.standard).not.toBe('ASPRS 2014');
-    expect(a.standard).toMatch(/formulas/i);
+    expect(a.standard).toMatch(/internal residual diagnostic/i);
     expect(a.standard).toMatch(/hold-out/i);
   });
 });


### PR DESCRIPTION
formatVerticalAccuracy() output now leads with plain internal residual
diagnostics — RMSE, bias, NMAD, P95 absolute residual — rather than
ASPRS-2014 NVA/VVA headline terms. NVA and VVA are still reported, now
explicitly framed as "2014-formula analogs on hold-out residuals, not
an ASPRS checkpoint assessment."

No computation, output values, or method id changed —
olv.validation.holdout-rmse stays byte-identical. Only labels,
comments, and the `standard` string in verticalAccuracy.ts moved.
Tests updated for the new wording; numeric assertions unchanged.

ASPRS's current standard (Edition 2 Version 2, 2024) drops 95%
confidence as the primary measure and requires independent
checkpoints — the ASPRS-2024 checkpoint method itself is out of scope
here (see PR #809's checkpoint harness).