### PR TITLE
Defer Help overlay to lazy chunk, reclaim index headroom

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,532 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,531 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -99,7 +99,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,532)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,531)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
@@ -8,7 +8,7 @@ Five products reach E4 this cycle: `CRS-UTM-PROJECTION` (new), `CHANGE-RASTER` a
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,532 lines and `src/render/Viewer.ts` is 6,418, against stated targets of 2,500 and 2,000. The composition root shrank as the terrain-compute-path read moved into `src/app/terrainComputePath.ts`. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,531 lines and `src/render/Viewer.ts` is 6,418, against stated targets of 2,500 and 2,000. The composition root shrank as the terrain-compute-path read moved into `src/app/terrainComputePath.ts`. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
 
 ## Out-of-core streaming holds the index, not the whole cloud
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5532,
+      "lines": 5531,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/app/helpOverlayLazy.ts
+++ b/src/app/helpOverlayLazy.ts
@@ -1,0 +1,48 @@
+/**
+ * helpOverlayLazy.ts — defer the static Help overlay to the first open.
+ *
+ * The overlay (should-have #15) is pure static markup with no live state,
+ * opened only from the tool dock's Help button or the `onToggleHelp`
+ * shortcut. Nothing before that first open can need it, so `main.ts` holds
+ * only this thin wrapper eagerly; the overlay class itself rides a lazy
+ * chunk (`loadHelpOverlay`).
+ */
+
+import type { HelpOverlay } from '../ui/HelpOverlay';
+import { loadHelpOverlay } from '../lazyChunks';
+
+export interface HelpOverlayLazy {
+  /** `false` before the first mount — the overlay cannot be open yet. */
+  isOpen(): boolean;
+  /** Open the overlay, mounting it into `overlayHost` on first call. */
+  open(): void;
+  /** Toggle the overlay; a call before the first mount opens it. */
+  toggle(): void;
+}
+
+export function createHelpOverlayLazy(overlayHost: HTMLElement): HelpOverlayLazy {
+  let overlay: HelpOverlay | null = null;
+  let loading: Promise<HelpOverlay> | null = null;
+
+  function ensure(): Promise<HelpOverlay> {
+    if (overlay) return Promise.resolve(overlay);
+    if (loading) return loading;
+    loading = loadHelpOverlay().then((mod) => {
+      const created = new mod.HelpOverlay();
+      overlayHost.append(created.element);
+      overlay = created;
+      loading = null;
+      return created;
+    });
+    return loading;
+  }
+
+  return {
+    isOpen: () => overlay?.isOpen ?? false,
+    open: () => { void ensure().then((o) => o.open()); },
+    toggle: () => {
+      if (overlay) overlay.toggle();
+      else void ensure().then((o) => o.open());
+    },
+  };
+}

--- a/src/lazyChunks.ts
+++ b/src/lazyChunks.ts
@@ -290,6 +290,14 @@ export const loadObjectPanel = () => import('./ui/ObjectPanel');
 export const loadDebugOverlay = () => import('./ui/DebugOverlay');
 
 /**
+ * Load the static Help overlay (should-have #15) on the first Help
+ * button press or `onToggleHelp` shortcut, never in the startup shell. The
+ * card is pure static markup with no live state — nothing before the first
+ * open can need it, so it no longer rides the eager index bundle.
+ */
+export const loadHelpOverlay = () => import('./ui/HelpOverlay');
+
+/**
  * Load the live colorbar legend overlay. Fetched the first time the active
  * colour mode is a continuous scalar (elevation / intensity / gpsTime /
  * returnNumber) — an RGB-only session never downloads it, and the eager

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,7 +152,7 @@ import type { ClipBox } from './render/clip/clipBox';
 import { composeClassScopeBannerOntoBlob } from './export/ScanReportRenderer';
 import { planInstantAnswer } from './intelligence/instantAnswer';
 import { decodeFull } from './convert/decodeFull';
-import { HelpOverlay } from './ui/HelpOverlay';
+import { createHelpOverlayLazy } from './app/helpOverlayLazy';
 import {
   buildViewerKeyBindings,
   installKeyDispatch,
@@ -1876,7 +1876,7 @@ function syncInspectorVisuals(): void {
   inspector.setAdvancedWbVisible(viewer.isStreamingActive());
 }
 
-const helpOverlay = new HelpOverlay();
+const helpOverlay = createHelpOverlayLazy(stage.overlay); // lazy chunk, see helpOverlayLazy.ts
 
 const dock = new ToolDock({
   onFrameAll: () => viewer.frameAll(),
@@ -3801,15 +3801,14 @@ void viewerLoaded.then(() => {
     if (analysePanel) mountAnalysePanelElement(analysePanel.element);
     if (objectPanel) mountObjectPanelElement(objectPanel.element);
 
-    // The help overlay is a modal — appended last so it sits above everything.
-    stage.overlay.append(helpOverlay.element);
+    // The help overlay lazy-mounts itself on first Help press (helpOverlayLazy.ts).
 
     // Global keyboard shortcuts — single-key tool access, suppressed while
     // typing. Only wired for the full app, never the minimal embed view: this
     // populates the dispatch table's `globalActions` slot (null until now, so
     // embed leaves these keys unbound). A tool shortcut needs a loaded scan and
     // is inert behind the help modal.
-    const toolsReady = (): boolean => hasScan() && !helpOverlay.isOpen;
+    const toolsReady = (): boolean => hasScan() && !helpOverlay.isOpen();
     globalActionHandlers = {
       onAnnotate: () => { if (toolsReady()) toggleTool(viewer, workflowController, 'annotate'); },
       onMeasure: () => { if (toolsReady()) toggleTool(viewer, workflowController, 'measure'); },
@@ -3819,11 +3818,11 @@ void viewerLoaded.then(() => {
       },
       onDeleteSelection: () => {
         const id = viewer.annotate.selectedId;
-        if (id && !helpOverlay.isOpen) viewer.annotate.remove(id);
+        if (id && !helpOverlay.isOpen()) viewer.annotate.remove(id);
       },
       onToggleHelp: () => helpOverlay.toggle(),
       onUndo: () => {
-        if (helpOverlay.isOpen) return;
+        if (helpOverlay.isOpen()) return;
         const id = scans.activeId;
         const canClass = !!id && viewer.canUndoClassification(id);
         const pick = pickUndo(viewer.annotate.canUndo, canClass);
@@ -3835,7 +3834,7 @@ void viewerLoaded.then(() => {
         if (pick === 'classification') reclassifyUi?.refresh();
       },
       onRedo: () => {
-        if (helpOverlay.isOpen) return;
+        if (helpOverlay.isOpen()) return;
         const id = scans.activeId;
         const canClass = !!id && viewer.canRedoClassification(id);
         const pick = pickRedo(viewer.annotate.canRedo, canClass);


### PR DESCRIPTION
The eager index chunk was pinned at 780/780 KiB (100%), blocking new method-registry entries and roadmap items. The static Help overlay (opened only from the dock's Help button or the onToggleHelp shortcut) was constructed at boot despite being pure markup with no live state.

Routes it through the existing lazyChunks.ts pattern (loadHelpOverlay) via a thin src/app/helpOverlayLazy.ts wrapper that mounts on first open; isOpen() reports false before that mount, correct since the overlay can't be open before it exists. All call sites (toolsReady, undo/redo guards, delete-selection guard) updated to the async-safe accessor.

index: 780 KiB -> 775 KiB. All other chunks unchanged and within ceiling. tsc, lint:inline-imports, lint:monolith-size all green.