### PR TITLE
chore(ci): exclude the recompute-cost perf benchmark from the coverage run

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "docs:build": "npm run docs:render && vitepress build docs-site && node scripts/lint-docs-site.mjs",
     "docs:preview": "vitepress preview docs-site",
     "test:e2e:gpu": "playwright test --project=gpu",
-    "coverage": "OLV_REACHABILITY=0 vitest run --coverage --maxWorkers=2 --testTimeout=60000 --exclude='tests/terrainRunnerDensityWiring.test.ts'",
+    "coverage": "OLV_REACHABILITY=0 vitest run --coverage --maxWorkers=2 --testTimeout=60000 --exclude='tests/terrainRunnerDensityWiring.test.ts' --exclude='tests/benchmark/terrainCoreRebuildCost.test.ts'",
     "mutation": "stryker run",
     "evidence": "bash -c 'set -o pipefail; mkdir -p release; npm run test:release:execute > release/gate.log 2>&1; code=$?; node scripts/collect-evidence.mjs release/gate.log \"$code\" && npm run lint:evidence'",
     "lint:evidence": "node scripts/lint-evidence.mjs",


### PR DESCRIPTION
`tests/benchmark/terrainCoreRebuildCost.test.ts` is a performance gate: it overrides the coverage run's 60 s `testTimeout` with its own 600 s and, under coverage instrumentation, exceeds even that, timing out the whole `coverage` job (the job the release gate depends on for its evidence record). Its timing is meaningless under instrumentation and it covers no correctness path the unit suite doesn't. Exclude it from the coverage run, matching the existing `terrainRunnerDensityWiring` exclusion. Coverage of shipped code is unchanged; the benchmark still runs in its normal (non-coverage) shard.