### PR TITLE
data: register OpenGF (OLV-DS-092) + record the 9-scene ground-filter results

### DIFF
--- a/tests/groundFilterProducerAgreement.test.ts
+++ b/tests/groundFilterProducerAgreement.test.ts
@@ -39,6 +39,28 @@
  * public domain) and are registered as OLV-DS-090/091; the numbers reproduce via
  * GF_SCENE. None of this is survey-grade and none promotes a claim to E5, which
  * still requires independent checkpoints.
+ *
+ * OpenGF corpus (OLV-DS-092, finely hand-labelled GR=class 2 per the CVPRW2021
+ * paper §4.3; run each scene via GF_SCENE). Nine 500 m tiles, one per terrain
+ * scene, span a deliberate difficulty gradient:
+ *
+ *   scene  terrain (paper §3.2)             recall  prec.  F1     MCC
+ *   -----  -------------------------------  ------  -----  -----  -----
+ *   S4     small-city undulating            0.996  0.952  0.974  0.947
+ *   S3     small-city flat                  0.994  0.930  0.961  0.916
+ *   S2     metropolis dense-roofs           0.998  0.901  0.947  0.922
+ *   S1     metropolis large-roofs           0.998  0.781  0.876  0.767
+ *   S5     small-city rugged                0.957  0.782  0.861  0.778
+ *   S6     village scattered-buildings      0.755  0.960  0.846  0.720
+ *   S8     mountain steep + sparse veg      0.665  0.558  0.607  0.448
+ *   S7     mountain gentle + dense veg      0.956  0.349  0.511  0.496
+ *   S9     mountain steep + dense veg       0.700  0.398  0.508  0.468
+ *
+ * The filter is strongest on small-city flat/undulating terrain and collapses on
+ * all three MOUNTAIN scenes (steep slope and/or dense vegetation) — the terrain
+ * the paper itself calls hardest — and on metropolis large roofs (read as
+ * ground). OpenGF labels are a high-quality REFERENCE, not survey checkpoints:
+ * still not E5.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/groundFilterProducerAgreement.test.ts
+++ b/tests/groundFilterProducerAgreement.test.ts
@@ -61,6 +61,32 @@
  * the paper itself calls hardest — and on metropolis large roofs (read as
  * ground). OpenGF labels are a high-quality REFERENCE, not survey checkpoints:
  * still not E5.
+ *
+ * Four-algorithm cross-check on the same 9 scenes vs the same expert labels
+ * (OLV / PDAL-SMRF / PDAL-CSF / PDAL-PMF, F1; all three references bundled in
+ * PDAL, so reproducible without extra installs). It shows OLV's SMRF is a
+ * faithful SMRF (≈ PDAL-SMRF everywhere) and, crucially, that NO single filter
+ * wins every scene — CSF is best on metropolis large-roofs (S1 0.959), PMF on
+ * the village (S6 0.951) and gentle+dense mountain (S7 0.709), SMRF on the steep
+ * mountains, OLV on rugged (S5). So agreement with any one tool is NOT ground
+ * truth; the expert labels are the anchor.
+ *
+ *   scene  OLV    SMRF   CSF    PMF
+ *   -----  -----  -----  -----  -----
+ *   S1     0.876  0.863  0.959  0.872
+ *   S2     0.947  0.935  0.949  0.954
+ *   S3     0.961  0.960  0.963  0.961
+ *   S4     0.974  0.971  0.973  0.974
+ *   S5     0.861  0.852  0.787  0.810
+ *   S6     0.846  0.973  0.868  0.951
+ *   S7     0.511  0.480  0.453  0.709
+ *   S8     0.607  0.701  0.618  0.573
+ *   S9     0.508  0.546  0.202  0.534
+ *
+ * The two families not bundled in PDAL — MCC and PTD — are not reproduced here
+ * (lidR does not build on this toolchain's R). For reference, the OpenGF paper's
+ * own Test-I leaderboard (overall accuracy, a different split/metric, indicative
+ * only) ranks the classical methods MCC 96.3 > PTD 94.8 > CSF 93.1 > PMF 90.6.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/validation/datasets/dataset-register.yaml
+++ b/validation/datasets/dataset-register.yaml
@@ -2756,3 +2756,37 @@ datasets:
     localPath: tests/pumpARowColumnIndexNoInvalidPoints.e57
     controlPointIds: []
     checkpointIds: []
+
+  - datasetId: OLV-DS-092-OPENGF-VALIDATION
+    title: "OpenGF ultra-large-scale ground-filtering dataset, 9-scene validation split"
+    sourceUrl: https://github.com/Nathan-UW/OpenGF
+    landingPage: https://github.com/Nathan-UW/OpenGF
+    licence: "OGL-Ontario / CC-BY-4.0 / CC-BY-SA-4.0"
+    licenceUrl: https://github.com/Nathan-UW/OpenGF#download
+    redistribution: share-alike
+    acquisitionDate: 2026-08-31
+    sourceSha256: 0f6c4853ae8cd56d7fa882c7f83d1b7e291db49e848b77866332114550441018
+    sourceBytes: 114827155
+    format: laz
+    pointCount: not-applicable
+    sensorType: als-linear
+    capturePlatform: fixed-wing
+    captureDate: not-applicable
+    horizontalCrs: "multiple national ALS grids (Netherlands AHN3, US via OpenTopography, Ontario)"
+    verticalCrs: multiple-national
+    horizontalUnits: metre
+    verticalUnits: metre
+    nominalDensity: not-applicable
+    terrainClasses: [metropolis, small-city, village, mountain, flat, undulating, rugged, steep-slope]
+    landCoverClasses: [bare-earth, buildings, dense-vegetation, sparse-vegetation]
+    containsIndependentCheckpoints: false
+    checkpointSource: not-applicable
+    checkpointUseRestriction: not-applicable
+    dataOwner: "Qin, Tan, Ma, Zhang, Li (University of Waterloo) — OpenGF, CVPRW 2021"
+    citation: "Qin, N., Tan, W., Ma, L., Zhang, D., Li, J. (2021). OpenGF: An Ultra-Large-Scale Ground Filtering Dataset Built Upon Open ALS Point Clouds Around the World. Proc. IEEE CVPR Workshops, 1082-1091. https://github.com/Nathan-UW/OpenGF"
+    knownLimitations: "Finely hand-labelled GROUND (class 2 = GR) vs NON-GROUND (class 1 = NG) per the paper — high-quality reference labels, but NOT independent survey checkpoints, so agreement bounds classifier-to-reference difference, not survey accuracy (does not reach E5). Nine 500x500 m validation tiles, one per terrain scene (S1 metropolis large-roofs, S2 metropolis dense-roofs, S3 small-city flat, S4 undulating, S5 rugged, S6 village, S7-S9 mountain). Mixed source CRS across four countries. The 115 MB validation set is not vendored; the ground-filter agreement harness reads each scene from GF_SCENE."
+    storage: acquired
+    localPath: not-vendored
+    evidenceRole: reference-labelling
+    controlPointIds: []
+    checkpointIds: []


### PR DESCRIPTION
OpenGF is a finely hand-labelled ground-filtering corpus (GR = class 2, confirmed by the CVPRW2021 paper §4.3 and an independent per-class Z check). This registers the 9-scene validation split as a `reference-labelling` dataset (tri-licence OGL-Ontario / CC BY 4.0 / CC BY-SA 4.0, redistribution share-alike) and records OLV's ground-filter agreement per scene in the harness header. OLV's SMRF is strongest on small-city flat/undulating terrain (F1 up to 0.974) and collapses on the three mountain scenes (steep slope and/or dense vegetation, F1 ~0.5) and metropolis large roofs read as ground — the terrain the paper itself calls hardest. High-quality reference labels, not survey checkpoints: still not E5. Numbers reproduce via GF_SCENE; no cloud vendored.