### PR TITLE
docs(release): fix the 'promotes no grade' release-doc contradiction + guard it

### DIFF
--- a/docs/releases/REPRODUCIBILITY_v0.6.7.md
+++ b/docs/releases/REPRODUCIBILITY_v0.6.7.md
@@ -4,7 +4,7 @@ The version-agnostic toolchain, pinning, and method are in [REPRODUCIBILITY.md](
 
 ## Validation baseline
 
-The frozen validation snapshot under `validation/snapshot/` is the 0.6.2 validation baseline, carried forward. 0.6.3 through 0.6.7 added features and evidence but did not re-run the cross-platform portability workflow or a defect audit, so the snapshot's defect registry, portability record (`docs/validation/evidence/portability-v0.6.2/`), and build-identity are the 0.6.2 ones, unchanged because the runs that would refresh them were not repeated. Its checks still hold on its own bytes; it is a baseline this release inherits, not a fresh 0.6.7 run. v0.6.7 promotes no grade, so no new study feeds this baseline.
+The frozen validation snapshot under `validation/snapshot/` is the 0.6.2 validation baseline, carried forward. 0.6.3 through 0.6.7 added features and evidence but did not re-run the cross-platform portability workflow or a defect audit, so the snapshot's defect registry, portability record (`docs/validation/evidence/portability-v0.6.2/`), and build-identity are the 0.6.2 ones, unchanged because the runs that would refresh them were not repeated. Its checks still hold on its own bytes; it is a baseline this release inherits, not a fresh 0.6.7 run. v0.6.7's evidence promotions this cycle are cross-implementation studies recorded in the claim register (see `VALIDATION_REPORT_v0.6.7.md`); none re-ran the cross-platform portability or defect workflow this snapshot records, so no new study feeds this inherited baseline.
 
 ## Toolchain
 

--- a/scripts/lint-release-truth.mjs
+++ b/scripts/lint-release-truth.mjs
@@ -140,6 +140,35 @@ export function collectReleaseTruthProblems(read) {
     }
   }
 
+  // ── 3b. "promotes no grade" wording vs this cycle's actual promotions ─────
+  // A release whose VALIDATION_REPORT states promotions this cycle must not also
+  // carry "promotes no grade" in any of its truth docs. This is the exact
+  // contradiction v0.6.7 shipped: REPRODUCIBILITY said "v0.6.7 promotes no
+  // grade" (scoped to the inherited snapshot, but read as a global claim) while
+  // the validation report promoted five claims to E4. No prior gate caught it.
+  {
+    const REPRO = `docs/releases/REPRODUCIBILITY_v${version}.md`;
+    const valText = read(VALREPORT) ?? '';
+    const promotedThisCycle =
+      /reach(?:es)? [^.]*E4[^.]* this cycle|promotes? \w+ evidence claim|to seventeen products at E4|from twelve to seventeen/i.test(
+        valText,
+      );
+    if (promotedThisCycle) {
+      const NO_GRADE = /promotes? no (?:new )?grade/i;
+      for (const doc of [REPRO, KNOWN, RELEASE_NOTES]) {
+        const text = read(doc);
+        if (text == null) continue;
+        const m = NO_GRADE.exec(text);
+        if (m) {
+          problems.push(
+            `${doc} says "${m[0]}", but VALIDATION_REPORT_v${version}.md states this cycle promoted ` +
+              `claims. Scope or remove the "no grade" wording so the release docs do not contradict.`,
+          );
+        }
+      }
+    }
+  }
+
   // ── 4. Dependency-audit doc names the current release ─────────────────────
   {
     const text = read(DEPS);

--- a/tests/releaseTruthLint.test.ts
+++ b/tests/releaseTruthLint.test.ts
@@ -67,6 +67,15 @@ describe('lint:release-truth', () => {
     expect(problems.some((p) => /nothing/i.test(p) && /E4/.test(p))).toBe(true);
   });
 
+  it('fails on "promotes no grade" while the validation report promoted claims this cycle', () => {
+    // Rule 3b: the exact v0.6.7 contradiction — REPRODUCIBILITY said "promotes
+    // no grade" while the validation report promoted five claims to E4.
+    const REPRO = `docs/releases/REPRODUCIBILITY_v${VERSION}.md`;
+    const doc = (realRead(REPRO) ?? '# repro\n') + '\n\nv' + VERSION + ' promotes no grade.\n';
+    const problems = problemsFor(withOverride(REPRO, doc));
+    expect(problems.some((p) => /no grade/i.test(p) && /contradict|promoted/i.test(p))).toBe(true);
+  });
+
   it('fails on a stale dependency-audit version heading', () => {
     const doc = realRead(DEPS)!.replace(
       `# Dependency audit (v${VERSION})`,


### PR DESCRIPTION
`REPRODUCIBILITY_v0.6.7.md` said *'v0.6.7 promotes no grade'* — scoped to the inherited 0.6.2 snapshot, but read as a global claim it contradicts `VALIDATION_REPORT_v0.6.7.md` (five claims promoted to E4, twelve→seventeen). No existing gate caught it. Fix: (1) reword the sentence to what is true — the promotions are cross-implementation studies in the claim register; none re-ran the portability/defect workflow the snapshot records, so nothing feeds the inherited baseline. (2) Add `lint:release-truth` rule 3b — a version whose validation report states promotions this cycle may not carry 'promotes no grade' in any truth doc. New `releaseTruthLint` test; negative-control verified. Docs+script+test only.