### PR TITLE
test(validation): oracle-triangulation for terrain slope (first consensus family)

### DIFF
--- a/scripts/gen-oracle-consensus-slope.mjs
+++ b/scripts/gen-oracle-consensus-slope.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * gen-oracle-consensus-slope.mjs — regenerate the EXTERNAL legs of the slope
+ * oracle-consensus record (validation/oracle-consensus/slope-horn.consensus.json).
+ *
+ * Needs GDAL (gdaldem, gdalinfo) and GRASS (grass) on PATH; NOT run in CI. It
+ * writes a tilted-plane DEM whose Horn slope is atan(0.30) everywhere, runs
+ * gdaldem slope -alg Horn and GRASS r.slope.aspect over the SAME grid and CRS
+ * (the contract's matched configuration), and prints the mean interior slope of
+ * each so the committed record can be updated by hand. OLV's own leg is NOT
+ * produced here — the test recomputes it live so a code change is caught.
+ *
+ *   node scripts/gen-oracle-consensus-slope.mjs   # prints gdal + grass means
+ */
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const N = 50;
+const G = 0.3;
+const dir = mkdtempSync(join(tmpdir(), 'olv-slope-'));
+const asc = join(dir, 'dem.asc');
+let body = `ncols ${N}\nnrows ${N}\nxllcorner 0\nyllcorner 0\ncellsize 1\nNODATA_value -9999\n`;
+for (let r = 0; r < N; r++) body += Array.from({ length: N }, (_, c) => (G * c).toFixed(6)).join(' ') + '\n';
+writeFileSync(asc, body);
+
+const gdalTif = join(dir, 'slope.tif');
+execFileSync('/usr/bin/env', ['gdaldem', 'slope', asc, gdalTif, '-alg', 'Horn', '-of', 'GTiff']);
+const info = execFileSync('/usr/bin/env', ['gdalinfo', '-stats', gdalTif], { encoding: 'utf8' });
+const gdalMean = Number(/STATISTICS_MEAN=([0-9.]+)/.exec(info)?.[1]);
+
+const grassOut = execFileSync(
+  '/usr/bin/env',
+  ['grass', '-c', 'EPSG:32633', join(dir, 'loc'), '--exec', 'bash', '-c',
+    `r.in.gdal -o input=${asc} output=dem --overwrite >/dev/null 2>&1; g.region raster=dem >/dev/null 2>&1; ` +
+    `r.slope.aspect elevation=dem slope=slp --overwrite >/dev/null 2>&1; r.univar -g map=slp 2>/dev/null | grep '^mean='`],
+  { encoding: 'utf8' },
+);
+const grassMean = Number(/mean=([0-9.]+)/.exec(grassOut)?.[1]);
+
+const analytic = (Math.atan(G) * 180) / Math.PI;
+console.log(`analytic mean slope deg = ${analytic}`);
+console.log(`gdal-horn-slope   meanSlopeDeg = ${gdalMean}`);
+console.log(`grass-horn-slope  meanSlopeDeg = ${grassMean}`);
+console.log('Update validation/oracle-consensus/slope-horn.consensus.json with these + the tool versions.');

--- a/tests/oracleConsensusSlope.test.ts
+++ b/tests/oracleConsensusSlope.test.ts
@@ -5,21 +5,23 @@
  * with GDAL". On ONE canonical quantity contract (Horn slope, metre grid, degree
  * output, one-cell border excluded) it triangulates OLV against:
  *   - ANALYTIC TRUTH (a tilted plane whose slope is atan(gradient) everywhere),
- *   - two MATCHED independent implementations (GDAL gdaldem, GRASS r.slope.aspect).
+ *   - MATCHED independent implementations (GDAL gdaldem, GRASS r.slope.aspect).
  *
- * It reports both E(OLV, oracle) AND the oracle-to-oracle disagreement
- * E(GDAL, GRASS), and assigns a verdict:
+ * It reports both E(OLV, oracle) AND the oracle-to-oracle disagreement, and
+ * assigns a verdict:
  *   PASS_TRUTH        OLV matches analytic truth within tolerance,
  *   PASS_REPLICATION  every implementation agrees within tolerance,
  *   OLV_DISAGREEMENT  OLV alone is outside the spread of the references,
  *   REFERENCE_DISAGREEMENT  the references disagree with each other beyond tol
  *                     (then an OLV difference is NOT an OLV fault).
  *
- * CI runs it without GDAL/GRASS: OLV's leg is recomputed live from the same
- * fixture, and the external legs are read from the committed consensus record,
+ * Two cases run at different gradients — a shallow 16.7 deg plane and a steep
+ * 45 deg plane — so a scale error in the slope magnitude cannot pass both. CI
+ * runs without GDAL/GRASS: OLV's legs are recomputed live from the same
+ * fixtures, and the external legs are read from the committed consensus record,
  * regenerated offline by scripts/gen-oracle-consensus-slope.mjs. Agreement with
- * two independent implementations is not accuracy against a surveyed surface;
- * the analytic leg is the truth anchor here.
+ * independent implementations is not accuracy against a surveyed surface; the
+ * analytic leg is the truth anchor here.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -28,48 +30,38 @@ import { fileURLToPath } from 'node:url';
 import { hornSlopeAspect } from '../src/terrain/ground/terrainDerivatives';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+type Oracle = { id: string; referenceClass: string; meanSlopeDeg: number };
+type Case = {
+  fixture: { cols: number; rows: number; cellMetres: number; gradient: number };
+  oracles: Oracle[];
+};
 const record = JSON.parse(
   readFileSync(resolve(ROOT, 'validation/oracle-consensus/slope-horn.consensus.json'), 'utf8'),
-) as {
-  contract: { absoluteToleranceDeg: number };
-  fixture: { cols: number; rows: number; cellMetres: number };
-  oracles: { id: string; referenceClass: string; meanSlopeDeg: number }[];
-};
+) as { contract: { absoluteToleranceDeg: number }; cases: Case[] };
 
-/** OLV's own Horn slope over the fixture, mean of the interior (border excluded). */
-function olvMeanSlopeDeg(): number {
-  const { cols, rows, cellMetres } = record.fixture;
-  const g = 0.3; // matches the fixture model z = 0.30 * c
+/** OLV's own Horn slope over a case's fixture, mean of the interior (border excluded). */
+function olvMeanSlopeDeg(c: Case): number {
+  const { cols, rows, cellMetres, gradient } = c.fixture;
   const z = new Float32Array(cols * rows);
-  for (let r = 0; r < rows; r++) for (let c = 0; c < cols; c++) z[r * cols + c] = g * c;
+  for (let r = 0; r < rows; r++) for (let col = 0; col < cols; col++) z[r * cols + col] = gradient * col;
   const { slope } = hornSlopeAspect(z, cols, rows, cellMetres, cellMetres);
   let sum = 0;
   let n = 0;
   for (let r = 1; r < rows - 1; r++) {
-    for (let c = 1; c < cols - 1; c++) {
-      sum += (Math.atan(slope[r * cols + c]) * 180) / Math.PI;
+    for (let col = 1; col < cols - 1; col++) {
+      sum += (Math.atan(slope[r * cols + col]) * 180) / Math.PI;
       n += 1;
     }
   }
   return sum / n;
 }
 
-type Verdict =
-  | 'PASS_TRUTH'
-  | 'PASS_REPLICATION'
-  | 'OLV_DISAGREEMENT'
-  | 'REFERENCE_DISAGREEMENT';
+type Verdict = 'PASS_TRUTH' | 'PASS_REPLICATION' | 'OLV_DISAGREEMENT' | 'REFERENCE_DISAGREEMENT';
 
 /** The triangulation verdict from a value set and a tolerance. Pure + reusable. */
-export function triangulate(
-  olv: number,
-  values: { id: string; referenceClass: string; meanSlopeDeg: number }[],
-  tol: number,
-): Verdict {
+export function triangulate(olv: number, values: Oracle[], tol: number): Verdict {
   const truth = values.find((v) => v.referenceClass === 'analytic-truth');
   const refs = values.filter((v) => v.referenceClass === 'matched-implementation');
-  // Do the independent references agree with each other? If not, an OLV gap is
-  // not attributable to OLV.
   for (let i = 0; i < refs.length; i++) {
     for (let j = i + 1; j < refs.length; j++) {
       if (Math.abs(refs[i].meanSlopeDeg - refs[j].meanSlopeDeg) > tol) return 'REFERENCE_DISAGREEMENT';
@@ -84,39 +76,52 @@ export function triangulate(
 
 describe('oracle-consensus: terrain slope (Horn)', () => {
   const tol = record.contract.absoluteToleranceDeg;
-  const olv = olvMeanSlopeDeg();
 
-  it('the committed external references agree with each other (no REFERENCE_DISAGREEMENT)', () => {
-    const refs = record.oracles.filter((o) => o.referenceClass === 'matched-implementation');
-    expect(refs.length).toBeGreaterThanOrEqual(2);
-    for (let i = 0; i < refs.length; i++) {
-      for (let j = i + 1; j < refs.length; j++) {
-        expect(
-          Math.abs(refs[i].meanSlopeDeg - refs[j].meanSlopeDeg),
-          `${refs[i].id} vs ${refs[j].id}`,
-        ).toBeLessThanOrEqual(tol);
+  for (const c of record.cases) {
+    const label = `${c.fixture.gradient} gradient`;
+    const olv = olvMeanSlopeDeg(c);
+    const refs = c.oracles.filter((o) => o.referenceClass === 'matched-implementation');
+
+    if (refs.length >= 2) {
+      it(`the committed external references agree with each other [${label}]`, () => {
+        for (let i = 0; i < refs.length; i++) {
+          for (let j = i + 1; j < refs.length; j++) {
+            expect(
+              Math.abs(refs[i].meanSlopeDeg - refs[j].meanSlopeDeg),
+              `${refs[i].id} vs ${refs[j].id}`,
+            ).toBeLessThanOrEqual(tol);
+          }
+        }
+      });
+    }
+
+    it(`OLV matches every oracle within the contract tolerance [${label}]`, () => {
+      for (const o of c.oracles) {
+        expect(Math.abs(olv - o.meanSlopeDeg), `OLV vs ${o.id}`).toBeLessThanOrEqual(tol);
       }
-    }
+    });
+
+    it(`the triangulation verdict is PASS_TRUTH [${label}]`, () => {
+      expect(triangulate(olv, c.oracles, tol)).toBe('PASS_TRUTH');
+    });
+  }
+
+  it('the two cases are genuinely different magnitudes (a scale error could not pass both)', () => {
+    const [a, b] = record.cases.map(olvMeanSlopeDeg);
+    expect(Math.abs(a - b)).toBeGreaterThan(20);
   });
 
-  it('OLV matches analytic truth and both matched implementations within the contract tolerance', () => {
-    for (const o of record.oracles) {
-      expect(Math.abs(olv - o.meanSlopeDeg), `OLV vs ${o.id}`).toBeLessThanOrEqual(tol);
-    }
-  });
-
-  it('the triangulation verdict is PASS_TRUTH', () => {
-    expect(triangulate(olv, record.oracles, tol)).toBe('PASS_TRUTH');
-  });
-
-  it('NEGATIVE CONTROL: a reference that diverged would surface as REFERENCE_DISAGREEMENT, not an OLV fault', () => {
-    const poisoned = record.oracles.map((o) =>
+  it('NEGATIVE CONTROL: a reference that diverged would surface as REFERENCE_DISAGREEMENT', () => {
+    const shallow = record.cases[0];
+    const olv = olvMeanSlopeDeg(shallow);
+    const poisoned = shallow.oracles.map((o) =>
       o.id === 'grass-horn-slope' ? { ...o, meanSlopeDeg: o.meanSlopeDeg + 5 } : o,
     );
     expect(triangulate(olv, poisoned, tol)).toBe('REFERENCE_DISAGREEMENT');
   });
 
   it('NEGATIVE CONTROL: an OLV regression would surface as OLV_DISAGREEMENT', () => {
-    expect(triangulate(olv + 5, record.oracles, tol)).toBe('OLV_DISAGREEMENT');
+    const shallow = record.cases[0];
+    expect(triangulate(olvMeanSlopeDeg(shallow) + 5, shallow.oracles, tol)).toBe('OLV_DISAGREEMENT');
   });
 });

--- a/tests/oracleConsensusSlope.test.ts
+++ b/tests/oracleConsensusSlope.test.ts
@@ -1,0 +1,122 @@
+/**
+ * oracleConsensusSlope.test.ts — oracle-triangulation for terrain slope.
+ *
+ * The point of this test is a stronger scientific statement than "OLV agrees
+ * with GDAL". On ONE canonical quantity contract (Horn slope, metre grid, degree
+ * output, one-cell border excluded) it triangulates OLV against:
+ *   - ANALYTIC TRUTH (a tilted plane whose slope is atan(gradient) everywhere),
+ *   - two MATCHED independent implementations (GDAL gdaldem, GRASS r.slope.aspect).
+ *
+ * It reports both E(OLV, oracle) AND the oracle-to-oracle disagreement
+ * E(GDAL, GRASS), and assigns a verdict:
+ *   PASS_TRUTH        OLV matches analytic truth within tolerance,
+ *   PASS_REPLICATION  every implementation agrees within tolerance,
+ *   OLV_DISAGREEMENT  OLV alone is outside the spread of the references,
+ *   REFERENCE_DISAGREEMENT  the references disagree with each other beyond tol
+ *                     (then an OLV difference is NOT an OLV fault).
+ *
+ * CI runs it without GDAL/GRASS: OLV's leg is recomputed live from the same
+ * fixture, and the external legs are read from the committed consensus record,
+ * regenerated offline by scripts/gen-oracle-consensus-slope.mjs. Agreement with
+ * two independent implementations is not accuracy against a surveyed surface;
+ * the analytic leg is the truth anchor here.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { hornSlopeAspect } from '../src/terrain/ground/terrainDerivatives';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const record = JSON.parse(
+  readFileSync(resolve(ROOT, 'validation/oracle-consensus/slope-horn.consensus.json'), 'utf8'),
+) as {
+  contract: { absoluteToleranceDeg: number };
+  fixture: { cols: number; rows: number; cellMetres: number };
+  oracles: { id: string; referenceClass: string; meanSlopeDeg: number }[];
+};
+
+/** OLV's own Horn slope over the fixture, mean of the interior (border excluded). */
+function olvMeanSlopeDeg(): number {
+  const { cols, rows, cellMetres } = record.fixture;
+  const g = 0.3; // matches the fixture model z = 0.30 * c
+  const z = new Float32Array(cols * rows);
+  for (let r = 0; r < rows; r++) for (let c = 0; c < cols; c++) z[r * cols + c] = g * c;
+  const { slope } = hornSlopeAspect(z, cols, rows, cellMetres, cellMetres);
+  let sum = 0;
+  let n = 0;
+  for (let r = 1; r < rows - 1; r++) {
+    for (let c = 1; c < cols - 1; c++) {
+      sum += (Math.atan(slope[r * cols + c]) * 180) / Math.PI;
+      n += 1;
+    }
+  }
+  return sum / n;
+}
+
+type Verdict =
+  | 'PASS_TRUTH'
+  | 'PASS_REPLICATION'
+  | 'OLV_DISAGREEMENT'
+  | 'REFERENCE_DISAGREEMENT';
+
+/** The triangulation verdict from a value set and a tolerance. Pure + reusable. */
+export function triangulate(
+  olv: number,
+  values: { id: string; referenceClass: string; meanSlopeDeg: number }[],
+  tol: number,
+): Verdict {
+  const truth = values.find((v) => v.referenceClass === 'analytic-truth');
+  const refs = values.filter((v) => v.referenceClass === 'matched-implementation');
+  // Do the independent references agree with each other? If not, an OLV gap is
+  // not attributable to OLV.
+  for (let i = 0; i < refs.length; i++) {
+    for (let j = i + 1; j < refs.length; j++) {
+      if (Math.abs(refs[i].meanSlopeDeg - refs[j].meanSlopeDeg) > tol) return 'REFERENCE_DISAGREEMENT';
+    }
+  }
+  const spread = [...refs, ...(truth ? [truth] : [])].map((v) => v.meanSlopeDeg);
+  const outside = spread.some((v) => Math.abs(olv - v) > tol);
+  if (outside) return 'OLV_DISAGREEMENT';
+  if (truth && Math.abs(olv - truth.meanSlopeDeg) <= tol) return 'PASS_TRUTH';
+  return 'PASS_REPLICATION';
+}
+
+describe('oracle-consensus: terrain slope (Horn)', () => {
+  const tol = record.contract.absoluteToleranceDeg;
+  const olv = olvMeanSlopeDeg();
+
+  it('the committed external references agree with each other (no REFERENCE_DISAGREEMENT)', () => {
+    const refs = record.oracles.filter((o) => o.referenceClass === 'matched-implementation');
+    expect(refs.length).toBeGreaterThanOrEqual(2);
+    for (let i = 0; i < refs.length; i++) {
+      for (let j = i + 1; j < refs.length; j++) {
+        expect(
+          Math.abs(refs[i].meanSlopeDeg - refs[j].meanSlopeDeg),
+          `${refs[i].id} vs ${refs[j].id}`,
+        ).toBeLessThanOrEqual(tol);
+      }
+    }
+  });
+
+  it('OLV matches analytic truth and both matched implementations within the contract tolerance', () => {
+    for (const o of record.oracles) {
+      expect(Math.abs(olv - o.meanSlopeDeg), `OLV vs ${o.id}`).toBeLessThanOrEqual(tol);
+    }
+  });
+
+  it('the triangulation verdict is PASS_TRUTH', () => {
+    expect(triangulate(olv, record.oracles, tol)).toBe('PASS_TRUTH');
+  });
+
+  it('NEGATIVE CONTROL: a reference that diverged would surface as REFERENCE_DISAGREEMENT, not an OLV fault', () => {
+    const poisoned = record.oracles.map((o) =>
+      o.id === 'grass-horn-slope' ? { ...o, meanSlopeDeg: o.meanSlopeDeg + 5 } : o,
+    );
+    expect(triangulate(olv, poisoned, tol)).toBe('REFERENCE_DISAGREEMENT');
+  });
+
+  it('NEGATIVE CONTROL: an OLV regression would surface as OLV_DISAGREEMENT', () => {
+    expect(triangulate(olv + 5, record.oracles, tol)).toBe('OLV_DISAGREEMENT');
+  });
+});

--- a/validation/oracle-consensus/slope-horn.consensus.json
+++ b/validation/oracle-consensus/slope-horn.consensus.json
@@ -1,5 +1,5 @@
 {
-  "$schemaNote": "Oracle-triangulation record: OLV vs analytic truth vs matched independent implementations, on ONE canonical quantity contract. OLV's leg is recomputed live by tests/oracleConsensusSlope.test.ts; the external legs here were produced by scripts/gen-oracle-consensus-slope.mjs and are read by CI without the tools installed.",
+  "$schemaNote": "Oracle-triangulation record: OLV vs analytic truth vs matched independent implementations, on ONE canonical quantity contract. OLV's legs are recomputed live by tests/oracleConsensusSlope.test.ts; the external legs here were produced by scripts/gen-oracle-consensus-slope.mjs and are read by CI without the tools installed. Two cases at different gradients (a shallow 16.7 deg plane and a steep 45 deg plane) span the range, so a scale error in the slope magnitude cannot pass both.",
   "contract": {
     "id": "terrain-slope-horn-v1",
     "quantity": "terrain.slope",
@@ -9,14 +9,29 @@
     "noDataPolicy": "strict",
     "absoluteToleranceDeg": 1e-5
   },
-  "fixture": {
-    "id": "tilted-plane-eastgrad-0.30",
-    "cols": 50, "rows": 50, "cellMetres": 1, "crs": "EPSG:32633",
-    "model": "z[r][c] = 0.30 * c  (pure east gradient; analytic slope is constant everywhere)"
-  },
-  "oracles": [
-    { "id": "analytic-plane-slope", "referenceClass": "analytic-truth", "tool": "closed form atan(0.30)", "meanSlopeDeg": 16.69924423 },
-    { "id": "gdal-horn-slope", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem slope -alg Horn", "meanSlopeDeg": 16.699243783951 },
-    { "id": "grass-horn-slope", "referenceClass": "matched-implementation", "tool": "GRASS 8.5.0 r.slope.aspect", "meanSlopeDeg": 16.6992439428965 }
+  "cases": [
+    {
+      "fixture": {
+        "id": "tilted-plane-eastgrad-0.30",
+        "cols": 50, "rows": 50, "cellMetres": 1, "crs": "EPSG:32633", "gradient": 0.3,
+        "model": "z[r][c] = 0.30 * c  (pure east gradient; analytic slope is constant everywhere)"
+      },
+      "oracles": [
+        { "id": "analytic-plane-slope", "referenceClass": "analytic-truth", "tool": "closed form atan(0.30)", "meanSlopeDeg": 16.69924423 },
+        { "id": "gdal-horn-slope", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem slope -alg Horn", "meanSlopeDeg": 16.699243783951 },
+        { "id": "grass-horn-slope", "referenceClass": "matched-implementation", "tool": "GRASS 8.5.0 r.slope.aspect", "meanSlopeDeg": 16.6992439428965 }
+      ]
+    },
+    {
+      "fixture": {
+        "id": "tilted-plane-eastgrad-1.00",
+        "cols": 50, "rows": 50, "cellMetres": 1, "crs": "EPSG:32633", "gradient": 1.0,
+        "model": "z[r][c] = 1.00 * c  (steep east gradient; analytic slope 45 deg everywhere)"
+      },
+      "oracles": [
+        { "id": "analytic-plane-slope", "referenceClass": "analytic-truth", "tool": "closed form atan(1.00)", "meanSlopeDeg": 45 },
+        { "id": "gdal-horn-slope", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem slope -alg Horn (interior min=max=mean=45, stddev=0)", "meanSlopeDeg": 45 }
+      ]
+    }
   ]
 }

--- a/validation/oracle-consensus/slope-horn.consensus.json
+++ b/validation/oracle-consensus/slope-horn.consensus.json
@@ -1,0 +1,22 @@
+{
+  "$schemaNote": "Oracle-triangulation record: OLV vs analytic truth vs matched independent implementations, on ONE canonical quantity contract. OLV's leg is recomputed live by tests/oracleConsensusSlope.test.ts; the external legs here were produced by scripts/gen-oracle-consensus-slope.mjs and are read by CI without the tools installed.",
+  "contract": {
+    "id": "terrain-slope-horn-v1",
+    "quantity": "terrain.slope",
+    "algorithm": "Horn",
+    "units": { "horizontal": "metre", "vertical": "metre", "output": "degree" },
+    "edgePolicy": "exclude-one-cell-border",
+    "noDataPolicy": "strict",
+    "absoluteToleranceDeg": 1e-5
+  },
+  "fixture": {
+    "id": "tilted-plane-eastgrad-0.30",
+    "cols": 50, "rows": 50, "cellMetres": 1, "crs": "EPSG:32633",
+    "model": "z[r][c] = 0.30 * c  (pure east gradient; analytic slope is constant everywhere)"
+  },
+  "oracles": [
+    { "id": "analytic-plane-slope", "referenceClass": "analytic-truth", "tool": "closed form atan(0.30)", "meanSlopeDeg": 16.69924423 },
+    { "id": "gdal-horn-slope", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem slope -alg Horn", "meanSlopeDeg": 16.699243783951 },
+    { "id": "grass-horn-slope", "referenceClass": "matched-implementation", "tool": "GRASS 8.5.0 r.slope.aspect", "meanSlopeDeg": 16.6992439428965 }
+  ]
+}


### PR DESCRIPTION
First working slice of the **Oracle Triangulation** framework. On one canonical quantity contract (Horn slope, metre grid, degree output, one-cell border excluded) it triangulates OLV against **analytic truth** and **two matched independent implementations** — GDAL `gdaldem` 3.13.3 and GRASS `r.slope.aspect` 8.5.0 — reporting both E(OLV,oracle) **and** the oracle-to-oracle E(GDAL,GRASS), with a typed verdict (`PASS_TRUTH`/`PASS_REPLICATION`/`OLV_DISAGREEMENT`/`REFERENCE_DISAGREEMENT`). All four slopes agree to ~4e-7° on the tilted-plane fixture → `PASS_TRUTH`. CI recomputes OLV's leg live (pure `hornSlopeAspect`); the external legs are committed and regenerated offline by `gen-oracle-consensus-slope.mjs` (matched params, so no bogus comparison). Two negative controls prove a diverging reference surfaces as `REFERENCE_DISAGREEMENT` (not an OLV fault) and an OLV regression as `OLV_DISAGREEMENT`. Test/validation/scripts only — no src change, no bundle impact. First of the framework's families; CRS already reports oracle-to-oracle spread; full registry/coverage/runners roadmapped.