### PR TITLE
test(validation): oracle-triangulation for CRS/UTM (second consensus family)

### DIFF
--- a/tests/oracleConsensusCrs.test.ts
+++ b/tests/oracleConsensusCrs.test.ts
@@ -1,0 +1,66 @@
+/**
+ * oracleConsensusCrs.test.ts — the CRS/UTM row of the oracle-consensus matrix.
+ *
+ * The live OLV-vs-oracle check for this family is geodesyOracleAgreement.test.ts
+ * (OLV latLonToUtm vs committed PROJ + GeographicLib). This test does the two
+ * things that make CRS a coherent member of the consensus matrix, without
+ * re-deriving that geodesy math:
+ *   1. Drift guard — the matrix record's oracleSpread must equal the committed
+ *      geodesy reference's oracleAgreement, so the record cannot silently
+ *      diverge from the data the live test actually runs against.
+ *   2. The triangulation inequality — the oracle-to-oracle spread must be far
+ *      below both the acceptance tolerance AND OLV's own residual, which is what
+ *      makes OLV's residual attributable to OLV rather than to the references.
+ *      That is the whole point of triangulation: PROJ is not treated as truth.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const record = JSON.parse(
+  readFileSync(resolve(ROOT, 'validation/oracle-consensus/crs-utm.consensus.json'), 'utf8'),
+);
+const geodesyRef = JSON.parse(
+  readFileSync(resolve(ROOT, 'validation/external-oracles/geodesy/references/oracle-utm.json'), 'utf8'),
+);
+const protocol = JSON.parse(
+  readFileSync(resolve(ROOT, 'validation/external-oracles/geodesy/protocol.json'), 'utf8'),
+);
+
+describe('oracle-consensus: CRS / UTM projection', () => {
+  const tol = record.contract.absoluteToleranceM as number;
+
+  it('the record tolerance matches the geodesy protocol (single source)', () => {
+    expect(tol).toBe(protocol.metrics.toleranceAbs);
+  });
+
+  it('DRIFT GUARD: the record oracleSpread equals the committed geodesy oracleAgreement', () => {
+    expect(record.oracleSpread.maxAbsEastingM).toBe(geodesyRef.oracleAgreement.maxAbsEastingM);
+    expect(record.oracleSpread.maxAbsNorthingM).toBe(geodesyRef.oracleAgreement.maxAbsNorthingM);
+  });
+
+  it('the two independent implementations agree far below the acceptance tolerance', () => {
+    // PROJ vs GeographicLib, separate lineages. If this were near the tolerance,
+    // a candidate result inside tolerance could be oracle noise, not a real pass.
+    const spread = Math.max(record.oracleSpread.maxAbsEastingM, record.oracleSpread.maxAbsNorthingM);
+    expect(spread).toBeLessThan(tol / 1000);
+  });
+
+  it('OLV passes tolerance, but its residual exceeds the oracle spread — so it is attributable to OLV (PASS_REPLICATION)', () => {
+    const olv = Math.max(record.olvResidual.maxAbsEastingM, record.olvResidual.maxAbsNorthingM);
+    const spread = Math.max(record.oracleSpread.maxAbsEastingM, record.oracleSpread.maxAbsNorthingM);
+    expect(olv).toBeLessThanOrEqual(tol); // within acceptance
+    expect(olv).toBeGreaterThan(spread); // but not machine-tight: residual is the candidate's
+    expect(record.verdict).toBe('PASS_REPLICATION');
+  });
+
+  it('names its live cross-implementation test', () => {
+    expect(record.liveTest).toBe('tests/geodesyOracleAgreement.test.ts');
+    expect(record.oracles.map((o: { referenceClass: string }) => o.referenceClass)).toEqual([
+      'matched-implementation',
+      'matched-implementation',
+    ]);
+  });
+});

--- a/validation/oracle-consensus/crs-utm.consensus.json
+++ b/validation/oracle-consensus/crs-utm.consensus.json
@@ -1,0 +1,21 @@
+{
+  "$schemaNote": "Oracle-triangulation record for the CRS/UTM family. There is no closed-form truth leg for an arbitrary UTM projection, so two matched implementations (PROJ, GeographicLib) anchor it. OLV's live leg is checked by tests/geodesyOracleAgreement.test.ts (latLonToUtm vs both, without the tools installed); this record frames that family in the consensus matrix and is guarded against drift by tests/oracleConsensusCrs.test.ts.",
+  "contract": {
+    "id": "crs-utm-projection-v1",
+    "quantity": "crs.utm-projection",
+    "algorithm": "WGS-84 geographic to WGS-84 UTM (zone, hemisphere, easting, northing)",
+    "units": { "horizontal": "degree", "output": "metre" },
+    "domainPolicy": "refuse latitudes outside 80S..84N rather than extrapolate",
+    "absoluteToleranceM": 0.0015
+  },
+  "fixtures": { "id": "geodesy-utm-36", "count": 36, "source": "validation/external-oracles/geodesy/fixtures.json" },
+  "oracles": [
+    { "id": "proj-9.8.1", "referenceClass": "matched-implementation", "tool": "PROJ 9.8.1 cs2cs" },
+    { "id": "geographiclib-2.7", "referenceClass": "matched-implementation", "tool": "GeographicLib 2.7 GeoConvert" }
+  ],
+  "oracleSpread": { "maxAbsEastingM": 2.0372681319713593e-9, "maxAbsNorthingM": 1.862645149230957e-9 },
+  "olvResidual": { "maxAbsEastingM": 4.531e-4, "maxAbsNorthingM": 9.521e-4, "source": "VALIDATION_REPORT_v0.6.7 / claim CRS-UTM-PROJECTION" },
+  "verdict": "PASS_REPLICATION",
+  "verdictNote": "OLV agrees with both independent implementations within the 1.5 mm acceptance tolerance. The two oracles agree with EACH OTHER to ~2e-9 m, six orders below the tolerance and below OLV's own residual, so OLV's ~1e-3 m residual is attributable to the candidate's transverse-Mercator series, not to oracle disagreement. Replication within tolerance, not machine-tight truth.",
+  "liveTest": "tests/geodesyOracleAgreement.test.ts"
+}


### PR DESCRIPTION
Second family of the Oracle Triangulation matrix. CRS is already live-tested by `geodesyOracleAgreement.test.ts` (OLV `latLonToUtm` vs committed PROJ 9.8.1 + GeographicLib 2.7); this frames it in the matrix format and adds two guards: (1) a **drift guard** tying the record's `oracleSpread` to the committed geodesy `oracleAgreement`, and (2) the **triangulation inequality** — the two independent implementations agree to ~2×10⁻⁹ m, six orders below the 1.5 mm acceptance tolerance *and* below OLV's own ~1×10⁻³ m residual. So OLV's residual is attributable to its transverse-Mercator series, not oracle disagreement — verdict `PASS_REPLICATION` (within tolerance, honestly not machine-tight). No closed-form truth leg exists for arbitrary UTM, so two matched implementations anchor it. Test/validation only — no src, no bundle. Depends on the `oracle-consensus/` dir also created by #820 (different file, no conflict).