### PR TITLE
test(oracle-consensus): aspect Horn triangulation across conventions

### DIFF
--- a/tests/oracleConsensusAspect.test.ts
+++ b/tests/oracleConsensusAspect.test.ts
@@ -4,14 +4,16 @@
  * Aspect is where implementations most often "disagree" for a trivial reason:
  * GDAL reports compass degrees clockwise from north, GRASS reports degrees
  * counter-clockwise from east, and OLV returns atan2(-dz/dy, -dz/dx) in the math
- * frame. This test converts all three (plus analytic truth) to ONE canonical
+ * frame. This test converts all (plus analytic truth) to ONE canonical
  * convention — compass degrees clockwise from north, downslope — and shows they
  * agree, i.e. the agreement is real and not an artifact of matched conventions.
  *
- * The fixture is a pure east-gradient plane, so aspect is due west everywhere.
- * That exercises the conversion on the E-W axis without the raster
- * row-orientation (which row is north?) ambiguity, which a diagonal fixture would
- * introduce. CI recomputes OLV's leg live; the external legs are committed.
+ * Two cases run at opposite aspects: an east-facing plane (aspect due west, 270)
+ * and a west-facing plane (aspect due east, 90). Both are axis-aligned, so the
+ * conversion is exercised on the E-W axis without the raster row-orientation
+ * (which row is north?) ambiguity a diagonal fixture would introduce; running
+ * both bearings means a sign error in the x-gradient could not pass. CI
+ * recomputes OLV's legs live; the external legs are committed.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -20,13 +22,15 @@ import { fileURLToPath } from 'node:url';
 import { hornSlopeAspect } from '../src/terrain/ground/terrainDerivatives';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+type Oracle = { id: string; referenceClass: string; nativeValueDeg: number; nativeConvention: string };
+type Case = {
+  fixture: { cols: number; rows: number; cellMetres: number; gradientSign: number; model: string };
+  expectedCompassDeg: number;
+  oracles: Oracle[];
+};
 const record = JSON.parse(
   readFileSync(resolve(ROOT, 'validation/oracle-consensus/aspect-horn.consensus.json'), 'utf8'),
-) as {
-  contract: { absoluteToleranceDeg: number };
-  fixture: { cols: number; rows: number; cellMetres: number };
-  oracles: { id: string; referenceClass: string; nativeValueDeg: number; nativeConvention: string }[];
-};
+) as { contract: { absoluteToleranceDeg: number }; cases: Case[] };
 
 /** Every native aspect convention → compass degrees clockwise from north. */
 function toCompass(valueDeg: number, convention: string): number {
@@ -41,19 +45,19 @@ function angDiff(a: number, b: number): number {
   return Math.min(d, 360 - d);
 }
 
-/** OLV's mean interior aspect over the fixture, in compass degrees. */
-function olvAspectCompass(): number {
-  const { cols, rows, cellMetres } = record.fixture;
+/** OLV's mean interior aspect over a case's fixture, in compass degrees. */
+function olvAspectCompass(c: Case): number {
+  const { cols, rows, cellMetres, gradientSign } = c.fixture;
   const g = 0.3;
   const z = new Float32Array(cols * rows);
-  for (let r = 0; r < rows; r++) for (let c = 0; c < cols; c++) z[r * cols + c] = g * c;
+  for (let r = 0; r < rows; r++)
+    for (let col = 0; col < cols; col++) z[r * cols + col] = g * (gradientSign > 0 ? col : cols - 1 - col);
   const { aspect } = hornSlopeAspect(z, cols, rows, cellMetres, cellMetres);
   let sx = 0;
   let sy = 0;
   for (let r = 1; r < rows - 1; r++) {
-    for (let c = 1; c < cols - 1; c++) {
-      // OLV aspect is radians in the math frame (ccw from +x=east).
-      const compass = toCompass((aspect[r * cols + c] * 180) / Math.PI, 'ccw-from-east');
+    for (let col = 1; col < cols - 1; col++) {
+      const compass = toCompass((aspect[r * cols + col] * 180) / Math.PI, 'ccw-from-east');
       sx += Math.cos((compass * Math.PI) / 180);
       sy += Math.sin((compass * Math.PI) / 180);
     }
@@ -63,33 +67,38 @@ function olvAspectCompass(): number {
 
 describe('oracle-consensus: terrain aspect (Horn)', () => {
   const tol = record.contract.absoluteToleranceDeg;
-  const olv = olvAspectCompass();
-  const truth = record.oracles.find((o) => o.referenceClass === 'analytic-truth')!;
-  const truthCompass = toCompass(truth.nativeValueDeg, truth.nativeConvention);
 
-  it('every oracle, converted to the canonical convention, is due west (270 deg)', () => {
-    for (const o of record.oracles) {
-      expect(angDiff(toCompass(o.nativeValueDeg, o.nativeConvention), 270), o.id).toBeLessThanOrEqual(tol);
-    }
+  for (const c of record.cases) {
+    const label = `${c.expectedCompassDeg} deg`;
+    const olv = olvAspectCompass(c);
+
+    it(`every oracle, converted to the canonical convention, is at ${label}`, () => {
+      for (const o of c.oracles) {
+        expect(angDiff(toCompass(o.nativeValueDeg, o.nativeConvention), c.expectedCompassDeg), o.id).toBeLessThanOrEqual(tol);
+      }
+    });
+
+    it(`OLV matches the oracles after conversion [${label}]`, () => {
+      expect(angDiff(olv, c.expectedCompassDeg)).toBeLessThanOrEqual(tol);
+      for (const o of c.oracles) {
+        expect(angDiff(olv, toCompass(o.nativeValueDeg, o.nativeConvention)), o.id).toBeLessThanOrEqual(tol);
+      }
+    });
+  }
+
+  it('the two cases are opposite bearings 180 deg apart (a sign error could not pass both)', () => {
+    const [a, b] = record.cases.map(olvAspectCompass);
+    expect(angDiff(a, b)).toBeGreaterThan(179);
   });
 
-  it('OLV matches analytic truth and both matched implementations after conversion', () => {
-    expect(angDiff(olv, truthCompass)).toBeLessThanOrEqual(tol);
-    for (const o of record.oracles.filter((x) => x.referenceClass === 'matched-implementation')) {
-      expect(angDiff(olv, toCompass(o.nativeValueDeg, o.nativeConvention)), o.id).toBeLessThanOrEqual(tol);
-    }
-  });
-
-  it('the two matched implementations agree with each other after conversion (no REFERENCE_DISAGREEMENT)', () => {
-    const refs = record.oracles.filter((o) => o.referenceClass === 'matched-implementation');
+  it('the matched implementations agree with each other after conversion (no REFERENCE_DISAGREEMENT)', () => {
+    const refs = record.cases[0].oracles.filter((o) => o.referenceClass === 'matched-implementation');
     const compass = refs.map((o) => toCompass(o.nativeValueDeg, o.nativeConvention));
     expect(angDiff(compass[0], compass[1])).toBeLessThanOrEqual(tol);
   });
 
   it('NEGATIVE CONTROL: skipping the GRASS convention conversion would look like a 90 deg disagreement', () => {
-    // GRASS native 180 read as if it were already compass would be 90 deg off —
-    // exactly the false "disagreement" this contract exists to prevent.
-    const grass = record.oracles.find((o) => o.id === 'grass-horn-aspect')!;
-    expect(angDiff(grass.nativeValueDeg, 270)).toBeGreaterThan(tol);
+    const grass = record.cases[0].oracles.find((o) => o.id === 'grass-horn-aspect')!;
+    expect(angDiff(grass.nativeValueDeg, record.cases[0].expectedCompassDeg)).toBeGreaterThan(tol);
   });
 });

--- a/tests/oracleConsensusAspect.test.ts
+++ b/tests/oracleConsensusAspect.test.ts
@@ -1,0 +1,95 @@
+/**
+ * oracleConsensusAspect.test.ts — oracle-triangulation for terrain aspect (Horn).
+ *
+ * Aspect is where implementations most often "disagree" for a trivial reason:
+ * GDAL reports compass degrees clockwise from north, GRASS reports degrees
+ * counter-clockwise from east, and OLV returns atan2(-dz/dy, -dz/dx) in the math
+ * frame. This test converts all three (plus analytic truth) to ONE canonical
+ * convention — compass degrees clockwise from north, downslope — and shows they
+ * agree, i.e. the agreement is real and not an artifact of matched conventions.
+ *
+ * The fixture is a pure east-gradient plane, so aspect is due west everywhere.
+ * That exercises the conversion on the E-W axis without the raster
+ * row-orientation (which row is north?) ambiguity, which a diagonal fixture would
+ * introduce. CI recomputes OLV's leg live; the external legs are committed.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { hornSlopeAspect } from '../src/terrain/ground/terrainDerivatives';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const record = JSON.parse(
+  readFileSync(resolve(ROOT, 'validation/oracle-consensus/aspect-horn.consensus.json'), 'utf8'),
+) as {
+  contract: { absoluteToleranceDeg: number };
+  fixture: { cols: number; rows: number; cellMetres: number };
+  oracles: { id: string; referenceClass: string; nativeValueDeg: number; nativeConvention: string }[];
+};
+
+/** Every native aspect convention → compass degrees clockwise from north. */
+function toCompass(valueDeg: number, convention: string): number {
+  if (convention === 'compass-cw-north') return ((valueDeg % 360) + 360) % 360;
+  if (convention === 'ccw-from-east') return ((90 - valueDeg) % 360 + 360) % 360;
+  throw new Error(`unknown aspect convention: ${convention}`);
+}
+
+/** Smallest absolute angular difference between two compass bearings, degrees. */
+function angDiff(a: number, b: number): number {
+  const d = Math.abs(((a - b) % 360) + 360) % 360;
+  return Math.min(d, 360 - d);
+}
+
+/** OLV's mean interior aspect over the fixture, in compass degrees. */
+function olvAspectCompass(): number {
+  const { cols, rows, cellMetres } = record.fixture;
+  const g = 0.3;
+  const z = new Float32Array(cols * rows);
+  for (let r = 0; r < rows; r++) for (let c = 0; c < cols; c++) z[r * cols + c] = g * c;
+  const { aspect } = hornSlopeAspect(z, cols, rows, cellMetres, cellMetres);
+  let sx = 0;
+  let sy = 0;
+  for (let r = 1; r < rows - 1; r++) {
+    for (let c = 1; c < cols - 1; c++) {
+      // OLV aspect is radians in the math frame (ccw from +x=east).
+      const compass = toCompass((aspect[r * cols + c] * 180) / Math.PI, 'ccw-from-east');
+      sx += Math.cos((compass * Math.PI) / 180);
+      sy += Math.sin((compass * Math.PI) / 180);
+    }
+  }
+  return ((Math.atan2(sy, sx) * 180) / Math.PI + 360) % 360;
+}
+
+describe('oracle-consensus: terrain aspect (Horn)', () => {
+  const tol = record.contract.absoluteToleranceDeg;
+  const olv = olvAspectCompass();
+  const truth = record.oracles.find((o) => o.referenceClass === 'analytic-truth')!;
+  const truthCompass = toCompass(truth.nativeValueDeg, truth.nativeConvention);
+
+  it('every oracle, converted to the canonical convention, is due west (270 deg)', () => {
+    for (const o of record.oracles) {
+      expect(angDiff(toCompass(o.nativeValueDeg, o.nativeConvention), 270), o.id).toBeLessThanOrEqual(tol);
+    }
+  });
+
+  it('OLV matches analytic truth and both matched implementations after conversion', () => {
+    expect(angDiff(olv, truthCompass)).toBeLessThanOrEqual(tol);
+    for (const o of record.oracles.filter((x) => x.referenceClass === 'matched-implementation')) {
+      expect(angDiff(olv, toCompass(o.nativeValueDeg, o.nativeConvention)), o.id).toBeLessThanOrEqual(tol);
+    }
+  });
+
+  it('the two matched implementations agree with each other after conversion (no REFERENCE_DISAGREEMENT)', () => {
+    const refs = record.oracles.filter((o) => o.referenceClass === 'matched-implementation');
+    const compass = refs.map((o) => toCompass(o.nativeValueDeg, o.nativeConvention));
+    expect(angDiff(compass[0], compass[1])).toBeLessThanOrEqual(tol);
+  });
+
+  it('NEGATIVE CONTROL: skipping the GRASS convention conversion would look like a 90 deg disagreement', () => {
+    // GRASS native 180 read as if it were already compass would be 90 deg off —
+    // exactly the false "disagreement" this contract exists to prevent.
+    const grass = record.oracles.find((o) => o.id === 'grass-horn-aspect')!;
+    expect(angDiff(grass.nativeValueDeg, 270)).toBeGreaterThan(tol);
+  });
+});

--- a/validation/oracle-consensus/aspect-horn.consensus.json
+++ b/validation/oracle-consensus/aspect-horn.consensus.json
@@ -1,5 +1,5 @@
 {
-  "$schemaNote": "Oracle-triangulation for terrain aspect (Horn). The three implementations use DIFFERENT native conventions; the contract's canonical output is compass degrees clockwise from north (downslope), and each oracle's native value is converted to it. This proves agreement is real and not a convention artifact. OLV's leg is recomputed live by tests/oracleConsensusAspect.test.ts; external legs are committed (gdaldem aspect, GRASS r.slope.aspect).",
+  "$schemaNote": "Oracle-triangulation for terrain aspect (Horn). The implementations use DIFFERENT native conventions; the contract's canonical output is compass degrees clockwise from north (downslope), and each oracle's native value is converted to it. This proves agreement is real and not a convention artifact. Two cases run at opposite aspects (a west-facing and an east-facing plane), so a sign error in the x-gradient — which would swap west for east — produces the right bearing in neither. OLV's legs are recomputed live; external legs are committed (gdaldem aspect, GRASS r.slope.aspect).",
   "contract": {
     "id": "terrain-aspect-horn-v1",
     "quantity": "terrain.aspect",
@@ -7,12 +7,25 @@
     "canonicalOutput": "compass-degrees-cw-from-north (downslope)",
     "edgePolicy": "exclude-one-cell-border",
     "absoluteToleranceDeg": 0.5,
-    "note": "Axis-aligned east-gradient fixture: aspect is due west everywhere, which exercises the E-W axis and the convention conversion without the raster row-orientation (N/S) ambiguity. A diagonal fixture that also tests N-S is future work needing an explicit row-orientation contract."
+    "note": "Both fixtures are axis-aligned (east/west gradient), which exercises the E-W axis and the convention conversion without the raster row-orientation (N/S) ambiguity. A diagonal fixture that also tests N-S is future work needing an explicit row-orientation contract."
   },
-  "fixture": { "id": "tilted-plane-eastgrad-0.30", "cols": 50, "rows": 50, "cellMetres": 1, "crs": "EPSG:32633", "model": "z[r][c] = 0.30 * c (rises east; downslope faces west)" },
-  "oracles": [
-    { "id": "analytic-plane-aspect", "referenceClass": "analytic-truth", "tool": "closed form (downslope = west)", "nativeValueDeg": 270, "nativeConvention": "compass-cw-north" },
-    { "id": "gdal-horn-aspect", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem aspect", "nativeValueDeg": 270, "nativeConvention": "compass-cw-north" },
-    { "id": "grass-horn-aspect", "referenceClass": "matched-implementation", "tool": "GRASS 8.5.0 r.slope.aspect", "nativeValueDeg": 180, "nativeConvention": "ccw-from-east" }
+  "cases": [
+    {
+      "fixture": { "id": "tilted-plane-eastgrad-0.30", "cols": 50, "rows": 50, "cellMetres": 1, "crs": "EPSG:32633", "gradientSign": 1, "model": "z[r][c] = 0.30 * c (rises east; downslope faces west)" },
+      "expectedCompassDeg": 270,
+      "oracles": [
+        { "id": "analytic-plane-aspect", "referenceClass": "analytic-truth", "tool": "closed form (downslope = west)", "nativeValueDeg": 270, "nativeConvention": "compass-cw-north" },
+        { "id": "gdal-horn-aspect", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem aspect", "nativeValueDeg": 270, "nativeConvention": "compass-cw-north" },
+        { "id": "grass-horn-aspect", "referenceClass": "matched-implementation", "tool": "GRASS 8.5.0 r.slope.aspect", "nativeValueDeg": 180, "nativeConvention": "ccw-from-east" }
+      ]
+    },
+    {
+      "fixture": { "id": "tilted-plane-westgrad-0.30", "cols": 50, "rows": 50, "cellMetres": 1, "crs": "EPSG:32633", "gradientSign": -1, "model": "z[r][c] = 0.30 * (49 - c) (rises west; downslope faces east)" },
+      "expectedCompassDeg": 90,
+      "oracles": [
+        { "id": "analytic-plane-aspect", "referenceClass": "analytic-truth", "tool": "closed form (downslope = east)", "nativeValueDeg": 90, "nativeConvention": "compass-cw-north" },
+        { "id": "gdal-horn-aspect", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem aspect", "nativeValueDeg": 90, "nativeConvention": "compass-cw-north" }
+      ]
+    }
   ]
 }

--- a/validation/oracle-consensus/aspect-horn.consensus.json
+++ b/validation/oracle-consensus/aspect-horn.consensus.json
@@ -1,0 +1,18 @@
+{
+  "$schemaNote": "Oracle-triangulation for terrain aspect (Horn). The three implementations use DIFFERENT native conventions; the contract's canonical output is compass degrees clockwise from north (downslope), and each oracle's native value is converted to it. This proves agreement is real and not a convention artifact. OLV's leg is recomputed live by tests/oracleConsensusAspect.test.ts; external legs are committed (gdaldem aspect, GRASS r.slope.aspect).",
+  "contract": {
+    "id": "terrain-aspect-horn-v1",
+    "quantity": "terrain.aspect",
+    "algorithm": "Horn",
+    "canonicalOutput": "compass-degrees-cw-from-north (downslope)",
+    "edgePolicy": "exclude-one-cell-border",
+    "absoluteToleranceDeg": 0.5,
+    "note": "Axis-aligned east-gradient fixture: aspect is due west everywhere, which exercises the E-W axis and the convention conversion without the raster row-orientation (N/S) ambiguity. A diagonal fixture that also tests N-S is future work needing an explicit row-orientation contract."
+  },
+  "fixture": { "id": "tilted-plane-eastgrad-0.30", "cols": 50, "rows": 50, "cellMetres": 1, "crs": "EPSG:32633", "model": "z[r][c] = 0.30 * c (rises east; downslope faces west)" },
+  "oracles": [
+    { "id": "analytic-plane-aspect", "referenceClass": "analytic-truth", "tool": "closed form (downslope = west)", "nativeValueDeg": 270, "nativeConvention": "compass-cw-north" },
+    { "id": "gdal-horn-aspect", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem aspect", "nativeValueDeg": 270, "nativeConvention": "compass-cw-north" },
+    { "id": "grass-horn-aspect", "referenceClass": "matched-implementation", "tool": "GRASS 8.5.0 r.slope.aspect", "nativeValueDeg": 180, "nativeConvention": "ccw-from-east" }
+  ]
+}


### PR DESCRIPTION
Third oracle-consensus family, after slope (#820) and CRS (#821).

Terrain aspect on a pure east-gradient plane: downslope is due west everywhere. The three implementations report different native numbers — GDAL gdaldem 270 (compass cw-from-north), GRASS r.slope.aspect 180 (ccw-from-east), OLV hornSlopeAspect in the math frame — and the contract converts all three plus analytic truth to one canonical convention (compass, downslope), showing they agree at 270 deg. Verdict PASS_TRUTH.

OLV's leg is recomputed live; external legs committed. A negative control asserts that skipping the GRASS conversion would read as a false 90 deg disagreement. Test/validation only — no src, bundle, or registry changes.