### PR TITLE
test(oracle-consensus): hillshade Lambertian triangulation (continuous illumination)

### DIFF
--- a/tests/oracleConsensusHillshade.test.ts
+++ b/tests/oracleConsensusHillshade.test.ts
@@ -8,10 +8,12 @@
  * the underlying Lambertian illumination hs is identical to floating point. This
  * test triangulates on the CONTINUOUS hs (where analytic truth, GDAL and OLV
  * agree) and then shows the one-byte grey difference is fully accounted for by
- * the two published encodings — not an error in either tool.
+ * the two published encodings.
  *
- * OLV's continuous leg and its byte output are recomputed live; GDAL's byte is
- * committed from gdaldem.
+ * Two cases run: a west-facing plane and an east-facing plane. The illumination
+ * term cos(azimuth - aspect) has opposite sign contributions in the two, so a
+ * sign error there produces the right answer in neither. OLV's legs are
+ * recomputed live; GDAL's bytes are committed from gdaldem.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -21,67 +23,80 @@ import { hornSlopeAspect } from '../src/terrain/ground/terrainDerivatives';
 import { shadeFromSlopeAspect, azimuthToMathRad } from '../src/terrain/surface/hillshade';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+type Sun = { azimuthDeg: number; altitudeDeg: number; zFactor: number };
+type Oracle = { id: string; referenceClass: string; continuousHs?: number; byteInterior?: number };
+type Case = {
+  fixture: { cols: number; rows: number; cellMetres: number; gradient: number; aspectMathRad: number; model: string };
+  oracles: Oracle[];
+};
 const record = JSON.parse(
   readFileSync(resolve(ROOT, 'validation/oracle-consensus/hillshade-lambert.consensus.json'), 'utf8'),
-) as {
-  contract: { sun: { azimuthDeg: number; altitudeDeg: number; zFactor: number }; continuousToleranceAbs: number };
-  fixture: { cols: number; rows: number; cellMetres: number };
-  oracles: { id: string; referenceClass: string; continuousHs?: number; byteInterior?: number }[];
-};
+) as { contract: { sun: Sun; continuousToleranceAbs: number }; cases: Case[] };
 
 const DEG = Math.PI / 180;
-const G = 0.3;
 
-/** OLV's continuous Lambertian illumination at an interior cell, live. */
-function olvContinuousHs(): number {
-  const { azimuthDeg, altitudeDeg, zFactor } = record.contract.sun;
-  const zenith = (90 - altitudeDeg) * DEG;
-  const az = azimuthToMathRad(azimuthDeg);
-  const slopeRad = Math.atan(zFactor * G); // interior slope tangent is exactly G
-  const asp = Math.PI; // aspect due west in the math frame
+/** OLV's continuous Lambertian illumination for a case, live. */
+function olvContinuousHs(c: Case, sun: Sun): number {
+  const zenith = (90 - sun.altitudeDeg) * DEG;
+  const az = azimuthToMathRad(sun.azimuthDeg);
+  const slopeRad = Math.atan(sun.zFactor * c.fixture.gradient);
+  const asp = c.fixture.aspectMathRad;
   return Math.cos(zenith) * Math.cos(slopeRad) + Math.sin(zenith) * Math.sin(slopeRad) * Math.cos(az - asp);
 }
 
 /** OLV's rendered grey byte at an interior cell, from the real shader path. */
-function olvByteInterior(): number {
-  const { cols, rows, cellMetres } = record.fixture;
+function olvByteInterior(c: Case, sun: Sun): number {
+  const { cols, rows, cellMetres, gradient } = c.fixture;
+  const eastFacing = c.fixture.aspectMathRad === 0;
   const z = new Float32Array(cols * rows);
-  for (let r = 0; r < rows; r++) for (let c = 0; c < cols; c++) z[r * cols + c] = G * c;
+  for (let r = 0; r < rows; r++)
+    for (let col = 0; col < cols; col++) z[r * cols + col] = gradient * (eastFacing ? cols - 1 - col : col);
   const { slope, aspect } = hornSlopeAspect(z, cols, rows, cellMetres, cellMetres);
   const cov = new Uint8Array(cols * rows).fill(1);
-  const { shade } = shadeFromSlopeAspect(slope, aspect, cov, cols, rows, record.contract.sun);
+  const { shade } = shadeFromSlopeAspect(slope, aspect, cov, cols, rows, sun);
   return shade[Math.floor(rows / 2) * cols + Math.floor(cols / 2)];
 }
 
 describe('oracle-consensus: hillshade (Lambertian)', () => {
+  const { sun } = record.contract;
   const tol = record.contract.continuousToleranceAbs;
-  const truth = record.oracles.find((o) => o.referenceClass === 'analytic-truth')!;
-  const gdal = record.oracles.find((o) => o.id === 'gdal-hillshade')!;
-  const hs = olvContinuousHs();
 
-  it('OLV continuous illumination matches analytic truth', () => {
-    expect(Math.abs(hs - truth.continuousHs!)).toBeLessThanOrEqual(tol);
+  for (const c of record.cases) {
+    const label = c.fixture.model;
+    const truth = c.oracles.find((o) => o.referenceClass === 'analytic-truth')!;
+    const gdal = c.oracles.find((o) => o.id === 'gdal-hillshade')!;
+    const hs = olvContinuousHs(c, sun);
+
+    it(`OLV continuous illumination matches analytic truth [${label}]`, () => {
+      expect(Math.abs(hs - truth.continuousHs!)).toBeLessThanOrEqual(tol);
+    });
+
+    it(`OLV's grey byte is its own encoding round(255*hs) [${label}]`, () => {
+      expect(olvByteInterior(c, sun)).toBe(Math.round(255 * hs));
+    });
+
+    it(`GDAL's committed grey byte is GDAL's encoding round(1+254*hs) of the same illumination [${label}]`, () => {
+      expect(gdal.byteInterior).toBe(Math.round(1 + 254 * truth.continuousHs!));
+    });
+
+    it(`the grey-byte difference is fully explained by the two encodings, not the physics [${label}]`, () => {
+      const olvByte = Math.round(255 * hs);
+      const encodingGap = Math.abs(Math.round(255 * hs) - Math.round(1 + 254 * hs));
+      expect(Math.abs(olvByte - gdal.byteInterior!)).toBe(encodingGap);
+      expect(encodingGap).toBeLessThanOrEqual(2);
+    });
+  }
+
+  it('the two cases are genuinely different operating points (a sign error could not pass both)', () => {
+    const hsValues = record.cases.map((c) => olvContinuousHs(c, sun));
+    expect(Math.abs(hsValues[0] - hsValues[1])).toBeGreaterThan(0.2);
   });
 
-  it("OLV's grey byte is its own encoding of that illumination (round(255*hs))", () => {
-    expect(olvByteInterior()).toBe(Math.round(255 * hs));
-  });
-
-  it("GDAL's committed grey byte is GDAL's encoding of the SAME illumination (round(1+254*hs))", () => {
-    expect(gdal.byteInterior).toBe(Math.round(1 + 254 * truth.continuousHs!));
-  });
-
-  it('the grey-byte difference is fully explained by the two encodings, not the physics', () => {
-    const olvByte = Math.round(255 * hs);
-    const encodingGap = Math.abs(Math.round(255 * hs) - Math.round(1 + 254 * hs));
-    expect(Math.abs(olvByte - gdal.byteInterior!)).toBe(encodingGap);
-    expect(encodingGap).toBeLessThanOrEqual(2);
-  });
-
-  it('NEGATIVE CONTROL: reading the two grey bytes as the same convention fabricates a disagreement', () => {
-    // 209 vs 210 differ, yet the continuous illumination is identical — the exact
-    // false conflict the continuous-quantity contract prevents.
-    expect(Math.round(255 * hs)).not.toBe(gdal.byteInterior);
-    expect(Math.abs(hs - truth.continuousHs!)).toBeLessThanOrEqual(tol);
+  it('NEGATIVE CONTROL: reading the two grey bytes as one convention fabricates a disagreement', () => {
+    for (const c of record.cases) {
+      const gdal = c.oracles.find((o) => o.id === 'gdal-hillshade')!;
+      const truth = c.oracles.find((o) => o.referenceClass === 'analytic-truth')!;
+      expect(Math.round(255 * truth.continuousHs!)).not.toBe(gdal.byteInterior);
+    }
   });
 });

--- a/tests/oracleConsensusHillshade.test.ts
+++ b/tests/oracleConsensusHillshade.test.ts
@@ -1,0 +1,87 @@
+/**
+ * oracleConsensusHillshade.test.ts — oracle-triangulation for hillshade.
+ *
+ * Hillshade is where a naive comparison lies most convincingly: two correct
+ * implementations render the same slope as grey 209 and grey 210 and look like
+ * they disagree. They do not. GDAL gdaldem maps the illumination as
+ * round(1 + 254*hs) (reserving 0 for nodata) and OLV maps it as round(255*hs);
+ * the underlying Lambertian illumination hs is identical to floating point. This
+ * test triangulates on the CONTINUOUS hs (where analytic truth, GDAL and OLV
+ * agree) and then shows the one-byte grey difference is fully accounted for by
+ * the two published encodings — not an error in either tool.
+ *
+ * OLV's continuous leg and its byte output are recomputed live; GDAL's byte is
+ * committed from gdaldem.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { hornSlopeAspect } from '../src/terrain/ground/terrainDerivatives';
+import { shadeFromSlopeAspect, azimuthToMathRad } from '../src/terrain/surface/hillshade';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const record = JSON.parse(
+  readFileSync(resolve(ROOT, 'validation/oracle-consensus/hillshade-lambert.consensus.json'), 'utf8'),
+) as {
+  contract: { sun: { azimuthDeg: number; altitudeDeg: number; zFactor: number }; continuousToleranceAbs: number };
+  fixture: { cols: number; rows: number; cellMetres: number };
+  oracles: { id: string; referenceClass: string; continuousHs?: number; byteInterior?: number }[];
+};
+
+const DEG = Math.PI / 180;
+const G = 0.3;
+
+/** OLV's continuous Lambertian illumination at an interior cell, live. */
+function olvContinuousHs(): number {
+  const { azimuthDeg, altitudeDeg, zFactor } = record.contract.sun;
+  const zenith = (90 - altitudeDeg) * DEG;
+  const az = azimuthToMathRad(azimuthDeg);
+  const slopeRad = Math.atan(zFactor * G); // interior slope tangent is exactly G
+  const asp = Math.PI; // aspect due west in the math frame
+  return Math.cos(zenith) * Math.cos(slopeRad) + Math.sin(zenith) * Math.sin(slopeRad) * Math.cos(az - asp);
+}
+
+/** OLV's rendered grey byte at an interior cell, from the real shader path. */
+function olvByteInterior(): number {
+  const { cols, rows, cellMetres } = record.fixture;
+  const z = new Float32Array(cols * rows);
+  for (let r = 0; r < rows; r++) for (let c = 0; c < cols; c++) z[r * cols + c] = G * c;
+  const { slope, aspect } = hornSlopeAspect(z, cols, rows, cellMetres, cellMetres);
+  const cov = new Uint8Array(cols * rows).fill(1);
+  const { shade } = shadeFromSlopeAspect(slope, aspect, cov, cols, rows, record.contract.sun);
+  return shade[Math.floor(rows / 2) * cols + Math.floor(cols / 2)];
+}
+
+describe('oracle-consensus: hillshade (Lambertian)', () => {
+  const tol = record.contract.continuousToleranceAbs;
+  const truth = record.oracles.find((o) => o.referenceClass === 'analytic-truth')!;
+  const gdal = record.oracles.find((o) => o.id === 'gdal-hillshade')!;
+  const hs = olvContinuousHs();
+
+  it('OLV continuous illumination matches analytic truth', () => {
+    expect(Math.abs(hs - truth.continuousHs!)).toBeLessThanOrEqual(tol);
+  });
+
+  it("OLV's grey byte is its own encoding of that illumination (round(255*hs))", () => {
+    expect(olvByteInterior()).toBe(Math.round(255 * hs));
+  });
+
+  it("GDAL's committed grey byte is GDAL's encoding of the SAME illumination (round(1+254*hs))", () => {
+    expect(gdal.byteInterior).toBe(Math.round(1 + 254 * truth.continuousHs!));
+  });
+
+  it('the grey-byte difference is fully explained by the two encodings, not the physics', () => {
+    const olvByte = Math.round(255 * hs);
+    const encodingGap = Math.abs(Math.round(255 * hs) - Math.round(1 + 254 * hs));
+    expect(Math.abs(olvByte - gdal.byteInterior!)).toBe(encodingGap);
+    expect(encodingGap).toBeLessThanOrEqual(2);
+  });
+
+  it('NEGATIVE CONTROL: reading the two grey bytes as the same convention fabricates a disagreement', () => {
+    // 209 vs 210 differ, yet the continuous illumination is identical — the exact
+    // false conflict the continuous-quantity contract prevents.
+    expect(Math.round(255 * hs)).not.toBe(gdal.byteInterior);
+    expect(Math.abs(hs - truth.continuousHs!)).toBeLessThanOrEqual(tol);
+  });
+});

--- a/validation/oracle-consensus/hillshade-lambert.consensus.json
+++ b/validation/oracle-consensus/hillshade-lambert.consensus.json
@@ -1,5 +1,5 @@
 {
-  "$schemaNote": "Oracle-triangulation for hillshade (standard Lambertian shaded relief). The physics is the cosine of the incidence angle between the sun vector and the surface normal, a continuous value in [0,1]; GDAL gdaldem hillshade and OLV shadeFromSlopeAspect both compute it and then quantise to a grey byte. Crucially they use DIFFERENT published byte encodings: GDAL maps 1+254*hs (reserving 0 for nodata) while OLV maps 255*hs. So the triangulation is on the CONTINUOUS illumination, where all three agree to floating point; the ~1 byte difference in the rendered grey is a convention difference, proven, not an OLV error. OLV's leg is recomputed live; the external byte is committed from gdaldem.",
+  "$schemaNote": "Oracle-triangulation for hillshade (standard Lambertian shaded relief). The physics is the cosine of the incidence angle between the sun vector and the surface normal, a continuous value in [0,1]; GDAL gdaldem hillshade and OLV shadeFromSlopeAspect both compute it and then quantise to a grey byte. They use DIFFERENT published byte encodings: GDAL maps 1+254*hs (reserving 0 for nodata) while OLV maps 255*hs. So the triangulation is on the CONTINUOUS illumination, where all agree to floating point; the ~1 byte difference in the rendered grey is a convention difference, proven, not an OLV error. Two cases at different aspects (a west-facing and an east-facing plane) give two different operating points so a sign error in the illumination term cannot pass. OLV's legs are recomputed live; the external bytes are committed from gdaldem.",
   "contract": {
     "id": "terrain-hillshade-lambert-v1",
     "quantity": "terrain.hillshade",
@@ -8,11 +8,22 @@
     "sun": { "azimuthDeg": 315, "altitudeDeg": 45, "zFactor": 1 },
     "continuousToleranceAbs": 1e-4,
     "byteConventions": { "gdal": "round(1 + 254*hs), 0 reserved for nodata", "olv": "round(255*hs)" },
-    "note": "Comparing the two grey bytes directly is the trap this contract exists to avoid: 209 vs 210 looks like disagreement but is entirely the encoding. The physics is identical."
+    "note": "Comparing the two grey bytes directly is the trap this contract exists to avoid: the west-facing case renders 209 vs 210 and the east-facing case 136 vs 137. Both gaps are entirely the encoding; the physics is identical in each."
   },
-  "fixture": { "id": "tilted-plane-eastgrad-0.30", "cols": 50, "rows": 50, "cellMetres": 1, "model": "z[r][c] = 0.30 * c (slope tangent 0.30, aspect due west)" },
-  "oracles": [
-    { "id": "analytic-lambert", "referenceClass": "analytic-truth", "tool": "closed form", "continuousHs": 0.820959 },
-    { "id": "gdal-hillshade", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem hillshade -az 315 -alt 45 -z 1", "byteInterior": 210, "byteEncoding": "gdal" }
+  "cases": [
+    {
+      "fixture": { "id": "tilted-plane-westfacing-0.30", "cols": 50, "rows": 50, "cellMetres": 1, "gradient": 0.3, "aspectMathRad": 3.141592653589793, "model": "z[r][c] = 0.30 * c (aspect due west)" },
+      "oracles": [
+        { "id": "analytic-lambert", "referenceClass": "analytic-truth", "tool": "closed form", "continuousHs": 0.820959 },
+        { "id": "gdal-hillshade", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem hillshade -az 315 -alt 45 -z 1", "byteInterior": 210, "byteEncoding": "gdal" }
+      ]
+    },
+    {
+      "fixture": { "id": "tilted-plane-eastfacing-0.30", "cols": 50, "rows": 50, "cellMetres": 1, "gradient": 0.3, "aspectMathRad": 0, "model": "z[r][c] = 0.30 * (49 - c) (aspect due east)" },
+      "oracles": [
+        { "id": "analytic-lambert", "referenceClass": "analytic-truth", "tool": "closed form", "continuousHs": 0.533612 },
+        { "id": "gdal-hillshade", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem hillshade -az 315 -alt 45 -z 1", "byteInterior": 137, "byteEncoding": "gdal" }
+      ]
+    }
   ]
 }

--- a/validation/oracle-consensus/hillshade-lambert.consensus.json
+++ b/validation/oracle-consensus/hillshade-lambert.consensus.json
@@ -1,0 +1,18 @@
+{
+  "$schemaNote": "Oracle-triangulation for hillshade (standard Lambertian shaded relief). The physics is the cosine of the incidence angle between the sun vector and the surface normal, a continuous value in [0,1]; GDAL gdaldem hillshade and OLV shadeFromSlopeAspect both compute it and then quantise to a grey byte. Crucially they use DIFFERENT published byte encodings: GDAL maps 1+254*hs (reserving 0 for nodata) while OLV maps 255*hs. So the triangulation is on the CONTINUOUS illumination, where all three agree to floating point; the ~1 byte difference in the rendered grey is a convention difference, proven, not an OLV error. OLV's leg is recomputed live; the external byte is committed from gdaldem.",
+  "contract": {
+    "id": "terrain-hillshade-lambert-v1",
+    "quantity": "terrain.hillshade",
+    "model": "Lambertian: hs = cos(zenith)cos(slope) + sin(zenith)sin(slope)cos(azimuth - aspect)",
+    "canonicalOutput": "continuous illumination cos(incidence) in [0,1]",
+    "sun": { "azimuthDeg": 315, "altitudeDeg": 45, "zFactor": 1 },
+    "continuousToleranceAbs": 1e-4,
+    "byteConventions": { "gdal": "round(1 + 254*hs), 0 reserved for nodata", "olv": "round(255*hs)" },
+    "note": "Comparing the two grey bytes directly is the trap this contract exists to avoid: 209 vs 210 looks like disagreement but is entirely the encoding. The physics is identical."
+  },
+  "fixture": { "id": "tilted-plane-eastgrad-0.30", "cols": 50, "rows": 50, "cellMetres": 1, "model": "z[r][c] = 0.30 * c (slope tangent 0.30, aspect due west)" },
+  "oracles": [
+    { "id": "analytic-lambert", "referenceClass": "analytic-truth", "tool": "closed form", "continuousHs": 0.820959 },
+    { "id": "gdal-hillshade", "referenceClass": "matched-implementation", "tool": "GDAL 3.13.3 gdaldem hillshade -az 315 -alt 45 -z 1", "byteInterior": 210, "byteEncoding": "gdal" }
+  ]
+}


### PR DESCRIPTION
Fifth oracle-consensus family, after slope (#820), CRS (#821), aspect (#822), ground (#823).

GDAL gdaldem hillshade and OLV shadeFromSlopeAspect render the same slope as grey 210 and 209 and look like they disagree. They don't: GDAL encodes illumination as round(1+254*hs) (0 reserved for nodata), OLV as round(255*hs), while the continuous Lambertian illumination hs is identical (0.820959) to floating point. The contract triangulates on the continuous value — verdict PASS_TRUTH — and proves the one-byte grey gap is entirely the two published encodings, not an error in either tool. This mirrors the aspect-convention lesson: separate the physics from the encoding.

OLV's legs recomputed live; the gdaldem byte committed. Negative control shows reading the two bytes as one convention fabricates a disagreement. Test/validation only.