### PR TITLE
test(oracle-consensus): framework shape-lint for the triangulation families

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
         run: npm run lint:dataset-citations
       - name: Oracle-registry lint (every cited oracle registered, no lineage double-counted)
         run: npm run lint:oracle-registry
+      - name: Oracle-consensus lint (every triangulation record is contract-shaped and test-backed)
+        run: npm run lint:oracle-consensus
       - name: No source files git-ignored
         run: npm run lint:no-ignored-src
       - name: No git-ignored path is tracked (local tooling committed by `git add -A`)

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "lint:terrain-field-ids": "node scripts/lint-terrain-field-ids.mjs",
     "lint:digest-manifests": "node scripts/lint-digest-manifests.mjs",
     "lint:oracle-registry": "node scripts/lint-oracle-registry.mjs",
+    "lint:oracle-consensus": "node scripts/lint-oracle-consensus.mjs",
     "verify:reference-reproducibility": "node scripts/verify-reference-reproducibility.mjs",
     "lint:pr-hygiene": "node scripts/pr-hygiene.mjs",
     "lint:license": "node scripts/lint-license.mjs",

--- a/scripts/lint-oracle-consensus.mjs
+++ b/scripts/lint-oracle-consensus.mjs
@@ -21,6 +21,7 @@
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { resolve, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const DIR = resolve(ROOT, 'validation/oracle-consensus');
@@ -132,4 +133,4 @@ function main() {
 }
 
 // Only run when invoked directly, not when imported by the test.
-if (resolve(process.argv[1] ?? '') === resolve(fileURLToPath(import.meta.url))) main();
+if (isCliEntry(import.meta.url)) main();

--- a/scripts/lint-oracle-consensus.mjs
+++ b/scripts/lint-oracle-consensus.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * lint-oracle-consensus.mjs — shape guard for the oracle-triangulation framework.
+ *
+ * Each `validation/oracle-consensus/*.consensus.json` record triangulates one
+ * OLV quantity against analytic truth and/or matched independent implementations
+ * (GDAL, GRASS, PROJ, PDAL, ...). The records only mean something if they all
+ * carry the same canonical contract and are each backed by a live CI test — a
+ * record with no test is an unverified claim, and a record missing its truth or
+ * matched-implementation legs is not a triangulation.
+ *
+ * This lint enforces that contract over WHATEVER records are present, without a
+ * hardcoded roster: it activates on each family as it lands rather than needing
+ * a central list kept in sync. The rules are a pure function of the parsed
+ * records so tests/oracleConsensusFramework.test.ts exercises the rules, not the
+ * repository's current contents.
+ *
+ * Passing on zero records is intentional: the framework can be introduced before
+ * any family merges, and each family is validated as it arrives.
+ */
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DIR = resolve(ROOT, 'validation/oracle-consensus');
+const TESTS = resolve(ROOT, 'tests');
+
+const REFERENCE_CLASSES = new Set(['analytic-truth', 'matched-implementation', 'exploratory-reference']);
+
+/** Collect every oracle entry a record carries, whether flat or under `cases`. */
+function collectOracles(record) {
+  if (Array.isArray(record.oracles)) return record.oracles;
+  if (Array.isArray(record.cases)) return record.cases.flatMap((c) => c.oracles ?? []);
+  return [];
+}
+
+/**
+ * Rule check for one parsed record. Returns an array of problem strings (empty =
+ * clean). Exported shape: { file, record } in, string[] out.
+ */
+export function collectRecordProblems(file, record) {
+  const problems = [];
+  const contract = record.contract;
+  if (!contract || typeof contract !== 'object') {
+    problems.push(`${file}: missing "contract" object`);
+    return problems; // nothing else is checkable
+  }
+  if (!contract.id) problems.push(`${file}: contract.id is required`);
+  if (!contract.quantity) problems.push(`${file}: contract.quantity is required`);
+
+  // A quantitative triangulation states a tolerance; an exploratory record
+  // states a sensitivity threshold instead — accept either shape.
+  const exploratory = record.evidenceRole === 'exploratory';
+  const hasBound = Object.keys(contract).some((k) => /tolerance|threshold/i.test(k));
+  if (!hasBound) {
+    problems.push(`${file}: contract needs a tolerance (or, for exploratory records, a threshold) field`);
+  }
+
+  const oracles = collectOracles(record);
+  // An exploratory record documents a spread across scenes rather than a single
+  // triangulated answer, so it carries a `scenes` array instead of oracle legs.
+  if (exploratory) {
+    if (!Array.isArray(record.scenes) || record.scenes.length === 0) {
+      problems.push(`${file}: exploratory record needs a non-empty "scenes" array`);
+    }
+  } else if (oracles.length === 0) {
+    problems.push(`${file}: no oracle legs found (flat "oracles" or per-case)`);
+  }
+
+  for (const o of oracles) {
+    if (!o.id) problems.push(`${file}: an oracle leg has no id`);
+    if (!REFERENCE_CLASSES.has(o.referenceClass)) {
+      problems.push(`${file}: oracle "${o.id}" has unknown referenceClass "${o.referenceClass}"`);
+    }
+  }
+
+  // A triangulation needs at least a truth anchor OR two independent references.
+  // An exploratory record (declared) is exempt — it documents disagreement, not
+  // a single answer.
+  const hasTruth = oracles.some((o) => o.referenceClass === 'analytic-truth');
+  const matchedCount = oracles.filter((o) => o.referenceClass === 'matched-implementation').length;
+  if (!exploratory && !hasTruth && matchedCount < 2) {
+    problems.push(
+      `${file}: not a triangulation — needs an analytic-truth leg or >=2 matched implementations ` +
+        `(or evidenceRole:"exploratory")`,
+    );
+  }
+
+  return problems;
+}
+
+/** Map a record filename to the test file that must back it. */
+export function expectedTestName(consensusFile) {
+  // slope-horn.consensus.json -> oracleConsensusSlopeHorn... : we match by the
+  // leading token so the test naming stays readable rather than mechanical.
+  const stem = basename(consensusFile).replace(/\.consensus\.json$/, '');
+  const key = stem.split('-')[0]; // slope, aspect, hillshade, crs, ground, ...
+  return `oracleConsensus${key.charAt(0).toUpperCase()}${key.slice(1)}.test.ts`;
+}
+
+function main() {
+  if (!existsSync(DIR)) {
+    console.log('lint:oracle-consensus OK — no oracle-consensus records yet');
+    return;
+  }
+  const files = readdirSync(DIR).filter((f) => f.endsWith('.consensus.json'));
+  const problems = [];
+
+  for (const f of files) {
+    let record;
+    try {
+      record = JSON.parse(readFileSync(resolve(DIR, f), 'utf8'));
+    } catch (e) {
+      problems.push(`${f}: invalid JSON — ${e.message}`);
+      continue;
+    }
+    problems.push(...collectRecordProblems(f, record));
+
+    const testFile = expectedTestName(f);
+    if (!existsSync(resolve(TESTS, testFile))) {
+      problems.push(`${f}: no backing CI test (expected tests/${testFile})`);
+    }
+  }
+
+  if (problems.length) {
+    console.error('lint:oracle-consensus FAILED:');
+    for (const p of problems) console.error('  - ' + p);
+    process.exit(1);
+  }
+  console.log(`lint:oracle-consensus OK — ${files.length} record(s), each contract-shaped and test-backed`);
+}
+
+// Only run when invoked directly, not when imported by the test.
+if (resolve(process.argv[1] ?? '') === resolve(fileURLToPath(import.meta.url))) main();

--- a/tests/oracleConsensusFramework.test.ts
+++ b/tests/oracleConsensusFramework.test.ts
@@ -1,0 +1,93 @@
+/**
+ * oracleConsensusFramework.test.ts — the rules of the oracle-triangulation
+ * framework, tested as rules rather than against whatever records exist today.
+ *
+ * The lint (scripts/lint-oracle-consensus.mjs) is what keeps every consensus
+ * record contract-shaped and test-backed as families land on separate branches.
+ * These cases pin its behaviour: a well-formed triangulation passes, and each
+ * way a record can be malformed (no contract, no tolerance, an unknown reference
+ * class, a single reference with no truth anchor, an exploratory record without
+ * the declaration) is caught.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, existsSync, readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+// @ts-expect-error — plain .mjs script, no types
+import { collectRecordProblems, expectedTestName } from '../scripts/lint-oracle-consensus.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const goodTruth = {
+  contract: { id: 'x', quantity: 'terrain.slope', absoluteToleranceDeg: 1e-5 },
+  oracles: [
+    { id: 'analytic', referenceClass: 'analytic-truth', meanSlopeDeg: 45 },
+    { id: 'gdal', referenceClass: 'matched-implementation', meanSlopeDeg: 45 },
+  ],
+};
+
+const goodCases = {
+  contract: { id: 'x', quantity: 'terrain.aspect', absoluteToleranceDeg: 0.5 },
+  cases: [
+    { oracles: [{ id: 'analytic', referenceClass: 'analytic-truth' }, { id: 'gdal', referenceClass: 'matched-implementation' }] },
+  ],
+};
+
+const goodExploratory = {
+  contract: { id: 'x', quantity: 'ground.f1', sensitivityThresholdF1: 0.08 },
+  evidenceRole: 'exploratory',
+  scenes: [{ id: 'S1', referenceF1: { smrf: 0.9, csf: 0.8, pmf: 0.85 } }],
+};
+
+describe('oracle-consensus framework: record rules', () => {
+  it('accepts a well-formed triangulation (truth + matched)', () => {
+    expect(collectRecordProblems('good.consensus.json', goodTruth)).toEqual([]);
+  });
+
+  it('accepts a per-case record', () => {
+    expect(collectRecordProblems('good-cases.consensus.json', goodCases)).toEqual([]);
+  });
+
+  it('accepts a declared exploratory record with a single reference', () => {
+    expect(collectRecordProblems('ground.consensus.json', goodExploratory)).toEqual([]);
+  });
+
+  it('rejects a missing contract', () => {
+    const p = collectRecordProblems('x.json', { oracles: [] });
+    expect(p.some((s: string) => /missing "contract"/.test(s))).toBe(true);
+  });
+
+  it('rejects a missing tolerance', () => {
+    const p = collectRecordProblems('x.json', { contract: { id: 'x', quantity: 'q' }, oracles: goodTruth.oracles });
+    expect(p.some((s: string) => /tolerance/.test(s))).toBe(true);
+  });
+
+  it('rejects an unknown referenceClass', () => {
+    const bad = { contract: goodTruth.contract, oracles: [{ id: 'z', referenceClass: 'vibes' }] };
+    expect(collectRecordProblems('x.json', bad).some((s: string) => /unknown referenceClass/.test(s))).toBe(true);
+  });
+
+  it('rejects a single reference with no truth anchor and no exploratory flag', () => {
+    const bad = { contract: goodTruth.contract, oracles: [{ id: 'gdal', referenceClass: 'matched-implementation' }] };
+    expect(collectRecordProblems('x.json', bad).some((s: string) => /not a triangulation/.test(s))).toBe(true);
+  });
+
+  it('maps a record filename to its backing test name', () => {
+    expect(expectedTestName('slope-horn.consensus.json')).toBe('oracleConsensusSlope.test.ts');
+    expect(expectedTestName('crs-utm.consensus.json')).toBe('oracleConsensusCrs.test.ts');
+  });
+});
+
+describe('oracle-consensus framework: the committed records obey the rules', () => {
+  const dir = resolve(ROOT, 'validation/oracle-consensus');
+  const files = existsSync(dir) ? readdirSync(dir).filter((f) => f.endsWith('.consensus.json')) : [];
+
+  it('every present record is contract-shaped and test-backed', () => {
+    // Vacuously true until families merge to this branch; enforced per-family in CI.
+    for (const f of files) {
+      const rec = JSON.parse(readFileSync(resolve(dir, f), 'utf8'));
+      expect(collectRecordProblems(f, rec), f).toEqual([]);
+      expect(existsSync(resolve(ROOT, 'tests', expectedTestName(f))), `${f} backing test`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Finishes the CI-feasible portion of the oracle-triangulation framework by tying the five families (slope, CRS, aspect, ground, hillshade) together under one machine-checked contract.

Adds `lint:oracle-consensus` (wired into the CI lint job): it validates every `validation/oracle-consensus/*.consensus.json` against the canonical contract — id, quantity, a tolerance (or, for an exploratory record, a sensitivity threshold) — requires each record's legs to be a genuine triangulation (an analytic-truth anchor or ≥2 matched implementations, unless declared `exploratory` with scenes), and requires every record to have a backing CI test. It reads whatever records are present, so it activates per family as each lands rather than depending on a central roster, and passes cleanly on zero records.

Rules are covered by `tests/oracleConsensusFramework.test.ts`; verified against all five real records. Lint/test/CI-config only — no src, bundle, or registry changes.