### PR TITLE
feat(streaming): human-readable diagnostics panel in the debug overlay

### DIFF
--- a/src/io/formatByteSize.ts
+++ b/src/io/formatByteSize.ts
@@ -20,3 +20,13 @@ export function formatByteSize(bytes: number): string {
   if (v >= 1024) return `${(v / 1024).toFixed(1)} KB`;
   return `${Math.round(v)} B`;
 }
+
+/**
+ * Render an integer with thousands separators: 4_200_000 → "4,200,000". The
+ * companion count formatter to {@link formatByteSize}, kept here so the overlay
+ * and the streaming-diagnostics readout share one grouping rule rather than each
+ * carrying a copy. Pure — no DOM, no three.js.
+ */
+export function groupInt(n: number): string {
+  return Math.round(n).toLocaleString('en-US');
+}

--- a/src/render/streaming/streamingDiagnostics.ts
+++ b/src/render/streaming/streamingDiagnostics.ts
@@ -388,6 +388,12 @@ export function formatStreamingDiagnostics(d: StreamingDiagnostics | null): stri
 
   const fraction = (n: number | null): string => (n === null ? '—' : n.toFixed(3));
 
+  // Precomputed so the upload-queue line is a flat template, not one nesting a
+  // template literal inside a `show` callback inside another template.
+  const uploadNodes = show('uploadPendingNodes', () => `${groupInt(d.uploadPendingNodes ?? 0)} nodes`);
+  const uploadBytes = show('uploadPendingBytes', () => formatByteSize(d.uploadPendingBytes ?? 0));
+  const residentDecoded = show('residentDecodedBytes', () => formatByteSize(d.residentDecodedBytes ?? 0));
+
   const lines: string[] = [
     `readiness     ${d.readinessPhase}` +
       ` · resident ${show('fractionResident', () => fraction(d.fractionResident))}` +
@@ -415,9 +421,7 @@ export function formatStreamingDiagnostics(d: StreamingDiagnostics | null): stri
       ` evict ${groupInt(d.cacheEvictions)}`,
     `generation    ${show('generationId', () => groupInt(d.generationId ?? 0))}` +
       ` · decode retries ${show('decodeRetryCount', () => groupInt(d.decodeRetryCount ?? 0))}`,
-    `upload queue  ${show('uploadPendingNodes', () => `${groupInt(d.uploadPendingNodes ?? 0)} nodes`)}` +
-      ` · ${show('uploadPendingBytes', () => formatByteSize(d.uploadPendingBytes ?? 0))}` +
-      ` · resident decoded ${show('residentDecodedBytes', () => formatByteSize(d.residentDecodedBytes ?? 0))}`,
+    `upload queue  ${uploadNodes} · ${uploadBytes} · resident decoded ${residentDecoded}`,
   ];
 
   return lines.join('\n');

--- a/src/render/streaming/streamingDiagnostics.ts
+++ b/src/render/streaming/streamingDiagnostics.ts
@@ -51,6 +51,7 @@ import type {
   RefinementReadinessPhase,
   SchedulerReadinessFacts,
 } from './refinementReadiness';
+import { formatByteSize, groupInt } from '../../io/formatByteSize';
 
 /**
  * Everything outside the readiness facts, as the scheduler already reports it.
@@ -367,14 +368,6 @@ export function buildStreamingDiagnostics(
 }
 
 /**
- * Render one integer with thousands separators: 4200000 → "4,200,000".
- * Non-integers (fractions, multipliers) are left to the caller.
- */
-function groupInt(n: number): string {
-  return Math.round(n).toLocaleString('en-US');
-}
-
-/**
  * A human-readable rendering of one diagnostics snapshot — the text half of the
  * record the `?debug=1` overlay already carries into its metrics JSON, so a
  * developer reads the SAME numbers a test asserts on rather than a second
@@ -416,15 +409,15 @@ export function formatStreamingDiagnostics(d: StreamingDiagnostics | null): stri
     `adaptation    concurrency ${groupInt(d.effectiveMaxConcurrent)}` +
       ` · pressure -${groupInt(d.pressureDepthReduction)} depth` +
       ` · fps budget ×${d.fpsBudgetFactor.toFixed(2)}`,
-    `cache         ${groupInt(d.cacheBytes)} / ${groupInt(d.cacheMaxBytes)} bytes` +
+    `cache         ${formatByteSize(d.cacheBytes)} / ${formatByteSize(d.cacheMaxBytes)}` +
       ` · ${groupInt(d.cacheEntries)} entries` +
       ` · hits ${groupInt(d.cacheHits)} misses ${groupInt(d.cacheMisses)}` +
       ` evict ${groupInt(d.cacheEvictions)}`,
     `generation    ${show('generationId', () => groupInt(d.generationId ?? 0))}` +
       ` · decode retries ${show('decodeRetryCount', () => groupInt(d.decodeRetryCount ?? 0))}`,
     `upload queue  ${show('uploadPendingNodes', () => `${groupInt(d.uploadPendingNodes ?? 0)} nodes`)}` +
-      ` · ${show('uploadPendingBytes', () => `${groupInt(d.uploadPendingBytes ?? 0)} bytes`)}` +
-      ` · resident decoded ${show('residentDecodedBytes', () => `${groupInt(d.residentDecodedBytes ?? 0)} bytes`)}`,
+      ` · ${show('uploadPendingBytes', () => formatByteSize(d.uploadPendingBytes ?? 0))}` +
+      ` · resident decoded ${show('residentDecodedBytes', () => formatByteSize(d.residentDecodedBytes ?? 0))}`,
   ];
 
   return lines.join('\n');

--- a/src/render/streaming/streamingDiagnostics.ts
+++ b/src/render/streaming/streamingDiagnostics.ts
@@ -365,3 +365,67 @@ export function buildStreamingDiagnostics(
     unavailable,
   };
 }
+
+/**
+ * Render one integer with thousands separators: 4200000 → "4,200,000".
+ * Non-integers (fractions, multipliers) are left to the caller.
+ */
+function groupInt(n: number): string {
+  return Math.round(n).toLocaleString('en-US');
+}
+
+/**
+ * A human-readable rendering of one diagnostics snapshot — the text half of the
+ * record the `?debug=1` overlay already carries into its metrics JSON, so a
+ * developer reads the SAME numbers a test asserts on rather than a second
+ * derivation.
+ *
+ * THE HONESTY RULE CARRIES THROUGH. A field named in `d.unavailable` is printed
+ * as the literal word `unavailable`, never as `0` or `—`: the record's own
+ * account of what it could not measure is preserved verbatim in the readout, so
+ * a reader never mistakes a gap for a measured zero. Pure — no DOM, no clock.
+ */
+export function formatStreamingDiagnostics(d: StreamingDiagnostics | null): string {
+  if (d === null) return '(no active stream)';
+
+  const gone = new Set<string>(d.unavailable);
+  /** A value field, or the word `unavailable` when the record named it so. */
+  const show = (field: StreamingDiagnosticField, render: () => string): string =>
+    gone.has(field) ? 'unavailable' : render();
+
+  const fraction = (n: number | null): string => (n === null ? '—' : n.toFixed(3));
+
+  const lines: string[] = [
+    `readiness     ${d.readinessPhase}` +
+      ` · resident ${show('fractionResident', () => fraction(d.fractionResident))}` +
+      ` · churn ${show('churn', () => fraction(d.churn))}`,
+    `wanted nodes  ${groupInt(d.wantedNodes)} wanted` +
+      ` · ${groupInt(d.residentNodes)} resident` +
+      ` · ${groupInt(d.inFlightNodes)} in-flight` +
+      ` · ${groupInt(d.queuedNodes)} queued`,
+    `              ${groupInt(d.decodedPendingNodes)} decoded-pending` +
+      ` · ${groupInt(d.failedNodes)} failed` +
+      ` · ${groupInt(d.knownNodes)} known` +
+      ` · ${groupInt(d.visibleNodes)} visible`,
+    `points        ${groupInt(d.residentPoints)} resident` +
+      ` · ${groupInt(d.decodedPendingPoints)} decoded-pending` +
+      ` / ${groupInt(d.pointBudget)} budget`,
+    `scheduler     tick ${d.lastTickMs.toFixed(1)} ms` +
+      ` · camera ${d.cameraVelocity.toFixed(2)} u/s (${d.cameraState})` +
+      ` · rescores ${groupInt(d.fullRescoreCount)}`,
+    `adaptation    concurrency ${groupInt(d.effectiveMaxConcurrent)}` +
+      ` · pressure -${groupInt(d.pressureDepthReduction)} depth` +
+      ` · fps budget ×${d.fpsBudgetFactor.toFixed(2)}`,
+    `cache         ${groupInt(d.cacheBytes)} / ${groupInt(d.cacheMaxBytes)} bytes` +
+      ` · ${groupInt(d.cacheEntries)} entries` +
+      ` · hits ${groupInt(d.cacheHits)} misses ${groupInt(d.cacheMisses)}` +
+      ` evict ${groupInt(d.cacheEvictions)}`,
+    `generation    ${show('generationId', () => groupInt(d.generationId ?? 0))}` +
+      ` · decode retries ${show('decodeRetryCount', () => groupInt(d.decodeRetryCount ?? 0))}`,
+    `upload queue  ${show('uploadPendingNodes', () => `${groupInt(d.uploadPendingNodes ?? 0)} nodes`)}` +
+      ` · ${show('uploadPendingBytes', () => `${groupInt(d.uploadPendingBytes ?? 0)} bytes`)}` +
+      ` · resident decoded ${show('residentDecodedBytes', () => `${groupInt(d.residentDecodedBytes ?? 0)} bytes`)}`,
+  ];
+
+  return lines.join('\n');
+}

--- a/src/ui/DebugOverlay.ts
+++ b/src/ui/DebugOverlay.ts
@@ -21,6 +21,7 @@ import { FrameTelemetry } from '../perf/frameTelemetry';
 import { readDevFlags } from '../perf/devFlags';
 import { buildMetricsJson } from '../perf/metricsJson';
 import type { StreamingDiagnostics } from '../render/streaming/streamingDiagnostics';
+import { formatStreamingDiagnostics } from '../render/streaming/streamingDiagnostics';
 import { backendLabel } from './backendLabel';
 
 /** Live COPC streaming counters — present only while a COPC scan is open. */
@@ -140,6 +141,8 @@ export class DebugOverlay {
   private readonly _streamingLabel: HTMLElement;
   private readonly _streaming: HTMLElement;
   private readonly _telemetry: HTMLElement;
+  private readonly _diagnosticsLabel: HTMLElement;
+  private readonly _diagnosticsText: HTMLElement;
   private readonly _benchmark: HTMLElement;
   private readonly _sample: () => DebugSample;
   /** The canonical streaming-diagnostics snapshot for the metrics export. */
@@ -172,6 +175,14 @@ export class DebugOverlay {
     this._telemetry = el('pre', {
       className: 'olv-debug-block',
       text: '(no scan loaded yet)',
+    });
+    this._diagnosticsLabel = el('div', {
+      className: 'olv-debug-label',
+      text: 'streaming diagnostics',
+    });
+    this._diagnosticsText = el('pre', {
+      className: 'olv-debug-block',
+      text: '(no active stream)',
     });
     this._benchmark = el('pre', { className: 'olv-debug-block olv-hidden' });
 
@@ -225,6 +236,8 @@ export class DebugOverlay {
       this._streaming,
       el('div', { className: 'olv-debug-label', text: 'last load' }),
       this._telemetry,
+      this._diagnosticsLabel,
+      this._diagnosticsText,
       this._benchmark,
       copyBtn,
     ]);
@@ -305,6 +318,8 @@ export class DebugOverlay {
     const sample = this._sample();
     this._lastSample = sample;
     const { backend, stats, streaming, terrainCompute } = sample;
+
+    this._diagnosticsText.textContent = formatStreamingDiagnostics(this._diagnostics());
 
     // Perf section (v0.5.5 P0) — rolling frame-time percentiles, over-budget
     // frame counters, longest observed main-thread task (honest "—" where the

--- a/src/ui/DebugOverlay.ts
+++ b/src/ui/DebugOverlay.ts
@@ -13,7 +13,7 @@
 
 import { el } from './dom';
 import { registerMetricsHook } from '../perf/metricsHook';
-import { formatByteSize as formatBytes } from '../io/formatByteSize';
+import { formatByteSize as formatBytes, groupInt as formatInt } from '../io/formatByteSize';
 import type { FrameStats } from '../render/Viewer';
 import type { LoadTelemetry } from '../io/loadTelemetry';
 import { formatTelemetry } from '../io/loadTelemetry';
@@ -123,11 +123,6 @@ export function formatTerrainCompute(
 /** Overlay refresh interval — about 4 Hz, deliberately never per frame. */
 const REFRESH_MS = 250;
 
-
-/** Render an integer with thousands separators: 4200000 → "4,200,000". */
-function formatInt(n: number): string {
-  return Math.round(n).toLocaleString('en-US');
-}
 
 /**
  * The `?debug=1` overlay panel. Construct it with a sampler, mount `element`,

--- a/tests/streamingDiagnostics.test.ts
+++ b/tests/streamingDiagnostics.test.ts
@@ -26,41 +26,7 @@ import {
   evaluateRefinementReadiness,
   type SchedulerReadinessFacts,
 } from '../src/render/streaming/refinementReadiness';
-
-/** A mid-load wanted set: 60 of 100 resident, work still moving. */
-const FACTS: SchedulerReadinessFacts = {
-  wantedCount: 100,
-  residentCount: 60,
-  inFlightCount: 4,
-  queuedCount: 36,
-  decodedPendingCount: 2,
-  failedCount: 1,
-};
-
-/** Everything the scheduler reports today, with no optional field supplied. */
-function extra(overrides: Partial<SchedulerDiagnosticsExtra> = {}): SchedulerDiagnosticsExtra {
-  return {
-    knownNodes: 28_000,
-    visibleNodes: 140,
-    residentPoints: 3_200_000,
-    decodedPendingPoints: 51_000,
-    pointBudget: 5_000_000,
-    lastTickMs: 2.5,
-    cameraVelocity: 0.75,
-    cameraStable: true,
-    effectiveMaxConcurrent: 3,
-    pressureDepthReduction: 1,
-    fpsBudgetFactor: 0.85,
-    fullRescoreCount: 12,
-    cacheBytes: 8_388_608,
-    cacheEntries: 64,
-    cacheMaxBytes: 16_777_216,
-    cacheHits: 900,
-    cacheMisses: 100,
-    cacheEvictions: 7,
-    ...overrides,
-  };
-}
+import { FACTS, extra } from './support/streamingDiagnosticsFixture';
 
 /** The five quantities the streaming path cannot supply through the scheduler. */
 const OPTIONAL_FIELDS = [

--- a/tests/streamingDiagnosticsFormat.test.ts
+++ b/tests/streamingDiagnosticsFormat.test.ts
@@ -2,19 +2,28 @@
  * streamingDiagnosticsFormat.test.ts
  *
  * Pins `formatStreamingDiagnostics`, the text half of the streaming-diagnostics
- * record. The one property that matters more than layout is honesty: a field
- * the record names in `unavailable` must render as the word `unavailable`, never
- * as `0` or a dash — otherwise a reader quotes an invented zero from a bug
- * report. These tests assert that directly, plus the null-input and
- * fully-populated cases.
+ * record. Three properties matter more than layout.
+ *
+ * Honesty: a field the record names in `unavailable` must render as the word
+ * `unavailable`, never as `0` or a dash — otherwise a reader quotes an invented
+ * zero from a bug report.
+ *
+ * Completeness (anti-rot): the formatter hand-lays-out its lines rather than
+ * iterating `STREAMING_DIAGNOSTIC_FIELDS`, so a field added to the record later
+ * would compile clean and silently never render. A per-field reachability check
+ * fails CI the moment that happens — the marker map is typed against the field
+ * union, so a new field is both a compile error here and a missing line there.
  */
 
 import { describe, it, expect } from 'vitest';
 import {
   buildStreamingDiagnostics,
   formatStreamingDiagnostics,
+  STREAMING_DIAGNOSTIC_FIELDS,
   type SchedulerDiagnosticsExtra,
+  type StreamingDiagnosticField,
 } from '../src/render/streaming/streamingDiagnostics';
+import { formatByteSize, groupInt } from '../src/io/formatByteSize';
 import {
   evaluateRefinementReadiness,
   type SchedulerReadinessFacts,
@@ -61,42 +70,79 @@ function build(overrides: Partial<SchedulerDiagnosticsExtra> = {}) {
   );
 }
 
+/** All five otherwise-unavailable quantities, so nothing lands in `unavailable`. */
+const OPTIONALS = {
+  generationId: 42,
+  decodeRetryCount: 5,
+  uploadPendingNodes: 8,
+  uploadPendingBytes: 65_536,
+  residentDecodedBytes: 12_582_912,
+} as const;
+
 describe('formatStreamingDiagnostics', () => {
   it('renders a short line for a null record', () => {
     expect(formatStreamingDiagnostics(null)).toBe('(no active stream)');
   });
 
-  it('renders every value field of a fully-populated record', () => {
-    // Supply all five otherwise-optional quantities so nothing is unavailable.
-    const d = build({
-      generationId: 42,
-      decodeRetryCount: 5,
-      uploadPendingNodes: 8,
-      uploadPendingBytes: 65_536,
-      residentDecodedBytes: 12_582_912,
-    });
+  it('makes every diagnostic field reachable in a fully-populated readout', () => {
+    const d = build({ ...OPTIONALS });
     expect(d.unavailable).toEqual([]);
-
     const text = formatStreamingDiagnostics(d);
-    expect(text).not.toContain('unavailable');
-    // Readiness + wanted set + points + scheduler + cache + optionals present.
-    expect(text).toContain('readiness');
-    expect(text).toContain('resident 0.600'); // fractionResident
-    expect(text).toContain('100 wanted');
-    expect(text).toContain('60 resident');
-    expect(text).toContain('4 in-flight');
-    expect(text).toContain('36 queued');
-    expect(text).toContain('1 failed');
-    expect(text).toContain('3,200,000 resident');
-    expect(text).toContain('5,000,000 budget');
-    expect(text).toContain('tick 2.5 ms');
-    expect(text).toContain('(stable)');
-    expect(text).toContain('×0.85'); // fps budget factor
-    expect(text).toContain('hits 900 misses 100');
-    expect(text).toContain('42'); // generationId
-    expect(text).toContain('8 nodes'); // uploadPendingNodes
-    expect(text).toContain('65,536 bytes'); // uploadPendingBytes
-    expect(text).toContain('12,582,912 bytes'); // residentDecodedBytes
+
+    // A distinctive marker per field, derived from the record's own values so
+    // the check tracks the data rather than a second hard-coded copy. Typed
+    // against the field union: adding a field to the record without an entry
+    // here is a compile error, and its marker then forces a rendered line.
+    const markers: Record<StreamingDiagnosticField, string> = {
+      readinessPhase: `readiness     ${d.readinessPhase}`,
+      fractionResident: `resident ${d.fractionResident!.toFixed(3)}`,
+      churn: `churn ${d.churn!.toFixed(3)}`,
+      wantedNodes: `${groupInt(d.wantedNodes)} wanted`,
+      residentNodes: `${groupInt(d.residentNodes)} resident`,
+      inFlightNodes: `${groupInt(d.inFlightNodes)} in-flight`,
+      queuedNodes: `${groupInt(d.queuedNodes)} queued`,
+      decodedPendingNodes: `${groupInt(d.decodedPendingNodes)} decoded-pending`,
+      failedNodes: `${groupInt(d.failedNodes)} failed`,
+      knownNodes: `${groupInt(d.knownNodes)} known`,
+      visibleNodes: `${groupInt(d.visibleNodes)} visible`,
+      residentPoints: `${groupInt(d.residentPoints)} resident`,
+      decodedPendingPoints: `${groupInt(d.decodedPendingPoints)} decoded-pending`,
+      pointBudget: `${groupInt(d.pointBudget)} budget`,
+      lastTickMs: `tick ${d.lastTickMs.toFixed(1)} ms`,
+      cameraVelocity: `${d.cameraVelocity.toFixed(2)} u/s`,
+      cameraState: `(${d.cameraState})`,
+      effectiveMaxConcurrent: `concurrency ${groupInt(d.effectiveMaxConcurrent)}`,
+      pressureDepthReduction: `-${groupInt(d.pressureDepthReduction)} depth`,
+      fpsBudgetFactor: `×${d.fpsBudgetFactor.toFixed(2)}`,
+      fullRescoreCount: `rescores ${groupInt(d.fullRescoreCount)}`,
+      cacheBytes: `${formatByteSize(d.cacheBytes)} /`,
+      cacheEntries: `${groupInt(d.cacheEntries)} entries`,
+      cacheMaxBytes: `/ ${formatByteSize(d.cacheMaxBytes)}`,
+      cacheHits: `hits ${groupInt(d.cacheHits)}`,
+      cacheMisses: `misses ${groupInt(d.cacheMisses)}`,
+      cacheEvictions: `evict ${groupInt(d.cacheEvictions)}`,
+      generationId: `generation    ${groupInt(d.generationId!)}`,
+      decodeRetryCount: `decode retries ${groupInt(d.decodeRetryCount!)}`,
+      uploadPendingNodes: `${groupInt(d.uploadPendingNodes!)} nodes`,
+      uploadPendingBytes: formatByteSize(d.uploadPendingBytes!),
+      residentDecodedBytes: `resident decoded ${formatByteSize(d.residentDecodedBytes!)}`,
+    };
+
+    // The map covers exactly the field list — no field left unmarked, none stale.
+    expect(Object.keys(markers).sort()).toEqual([...STREAMING_DIAGNOSTIC_FIELDS].sort());
+    for (const field of STREAMING_DIAGNOSTIC_FIELDS) {
+      expect(text, `field ${field} not reachable in output`).toContain(markers[field]);
+    }
+  });
+
+  it('renders byte quantities through the shared formatter, not raw integers', () => {
+    const d = build({ uploadPendingBytes: 65_536, residentDecodedBytes: 12_582_912 });
+    const text = formatStreamingDiagnostics(d);
+    expect(text).toContain('8.0 MB');   // cacheBytes
+    expect(text).toContain('16.0 MB');  // cacheMaxBytes
+    expect(text).toContain('64.0 KB');  // uploadPendingBytes
+    expect(text).toContain('12.0 MB');  // residentDecodedBytes
+    expect(text).not.toContain('8,388,608');
   });
 
   it('prints named-unavailable fields as "unavailable", never a number', () => {
@@ -113,9 +159,7 @@ describe('formatStreamingDiagnostics', () => {
     );
 
     const text = formatStreamingDiagnostics(d);
-    const generationLine = text
-      .split('\n')
-      .find((l) => l.startsWith('generation'));
+    const generationLine = text.split('\n').find((l) => l.startsWith('generation'));
     expect(generationLine).toBeDefined();
     // The word, not a fabricated 0.
     expect(generationLine).toContain('unavailable');
@@ -125,12 +169,12 @@ describe('formatStreamingDiagnostics', () => {
     expect(uploadLine).toBeDefined();
     // All three quantities on this line are unavailable, none rendered as 0.
     expect(uploadLine).not.toContain('0 nodes');
-    expect(uploadLine).not.toContain('0 bytes');
+    expect(uploadLine).not.toContain('0 B');
     expect((uploadLine!.match(/unavailable/g) ?? []).length).toBe(3);
   });
 
   it('prints fractionResident/churn as "unavailable" when readiness is unknown', () => {
-    // An empty wanted set → phase 'unknown' → both derived terms null.
+    // An empty wanted set → phase 'unknown' → both derived terms null and named.
     const emptyFacts: SchedulerReadinessFacts = {
       wantedCount: 0,
       residentCount: 0,
@@ -144,11 +188,15 @@ describe('formatStreamingDiagnostics', () => {
       evaluateRefinementReadiness(emptyFacts),
       extra(),
     );
-    const text = formatStreamingDiagnostics(d);
     expect(d.unavailable).toContain('fractionResident');
     expect(d.unavailable).toContain('churn');
-    const readinessLine = text.split('\n')[0];
+    const readinessLine = text0(d);
     expect(readinessLine).toContain('resident unavailable');
     expect(readinessLine).toContain('churn unavailable');
   });
 });
+
+/** The first (readiness) line of a rendered record. */
+function text0(d: Parameters<typeof formatStreamingDiagnostics>[0]): string {
+  return formatStreamingDiagnostics(d).split('\n')[0];
+}

--- a/tests/streamingDiagnosticsFormat.test.ts
+++ b/tests/streamingDiagnosticsFormat.test.ts
@@ -1,0 +1,154 @@
+/**
+ * streamingDiagnosticsFormat.test.ts
+ *
+ * Pins `formatStreamingDiagnostics`, the text half of the streaming-diagnostics
+ * record. The one property that matters more than layout is honesty: a field
+ * the record names in `unavailable` must render as the word `unavailable`, never
+ * as `0` or a dash — otherwise a reader quotes an invented zero from a bug
+ * report. These tests assert that directly, plus the null-input and
+ * fully-populated cases.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildStreamingDiagnostics,
+  formatStreamingDiagnostics,
+  type SchedulerDiagnosticsExtra,
+} from '../src/render/streaming/streamingDiagnostics';
+import {
+  evaluateRefinementReadiness,
+  type SchedulerReadinessFacts,
+} from '../src/render/streaming/refinementReadiness';
+
+const FACTS: SchedulerReadinessFacts = {
+  wantedCount: 100,
+  residentCount: 60,
+  inFlightCount: 4,
+  queuedCount: 36,
+  decodedPendingCount: 2,
+  failedCount: 1,
+};
+
+function extra(overrides: Partial<SchedulerDiagnosticsExtra> = {}): SchedulerDiagnosticsExtra {
+  return {
+    knownNodes: 28_000,
+    visibleNodes: 140,
+    residentPoints: 3_200_000,
+    decodedPendingPoints: 51_000,
+    pointBudget: 5_000_000,
+    lastTickMs: 2.5,
+    cameraVelocity: 0.75,
+    cameraStable: true,
+    effectiveMaxConcurrent: 3,
+    pressureDepthReduction: 1,
+    fpsBudgetFactor: 0.85,
+    fullRescoreCount: 12,
+    cacheBytes: 8_388_608,
+    cacheEntries: 64,
+    cacheMaxBytes: 16_777_216,
+    cacheHits: 900,
+    cacheMisses: 100,
+    cacheEvictions: 7,
+    ...overrides,
+  };
+}
+
+function build(overrides: Partial<SchedulerDiagnosticsExtra> = {}) {
+  return buildStreamingDiagnostics(
+    FACTS,
+    evaluateRefinementReadiness(FACTS),
+    extra(overrides),
+  );
+}
+
+describe('formatStreamingDiagnostics', () => {
+  it('renders a short line for a null record', () => {
+    expect(formatStreamingDiagnostics(null)).toBe('(no active stream)');
+  });
+
+  it('renders every value field of a fully-populated record', () => {
+    // Supply all five otherwise-optional quantities so nothing is unavailable.
+    const d = build({
+      generationId: 42,
+      decodeRetryCount: 5,
+      uploadPendingNodes: 8,
+      uploadPendingBytes: 65_536,
+      residentDecodedBytes: 12_582_912,
+    });
+    expect(d.unavailable).toEqual([]);
+
+    const text = formatStreamingDiagnostics(d);
+    expect(text).not.toContain('unavailable');
+    // Readiness + wanted set + points + scheduler + cache + optionals present.
+    expect(text).toContain('readiness');
+    expect(text).toContain('resident 0.600'); // fractionResident
+    expect(text).toContain('100 wanted');
+    expect(text).toContain('60 resident');
+    expect(text).toContain('4 in-flight');
+    expect(text).toContain('36 queued');
+    expect(text).toContain('1 failed');
+    expect(text).toContain('3,200,000 resident');
+    expect(text).toContain('5,000,000 budget');
+    expect(text).toContain('tick 2.5 ms');
+    expect(text).toContain('(stable)');
+    expect(text).toContain('×0.85'); // fps budget factor
+    expect(text).toContain('hits 900 misses 100');
+    expect(text).toContain('42'); // generationId
+    expect(text).toContain('8 nodes'); // uploadPendingNodes
+    expect(text).toContain('65,536 bytes'); // uploadPendingBytes
+    expect(text).toContain('12,582,912 bytes'); // residentDecodedBytes
+  });
+
+  it('prints named-unavailable fields as "unavailable", never a number', () => {
+    // No optional quantities supplied: all five land in `unavailable`.
+    const d = build();
+    expect([...d.unavailable].sort()).toEqual(
+      [
+        'decodeRetryCount',
+        'generationId',
+        'residentDecodedBytes',
+        'uploadPendingBytes',
+        'uploadPendingNodes',
+      ].sort(),
+    );
+
+    const text = formatStreamingDiagnostics(d);
+    const generationLine = text
+      .split('\n')
+      .find((l) => l.startsWith('generation'));
+    expect(generationLine).toBeDefined();
+    // The word, not a fabricated 0.
+    expect(generationLine).toContain('unavailable');
+    expect(generationLine).not.toMatch(/generation\s+0\b/);
+
+    const uploadLine = text.split('\n').find((l) => l.startsWith('upload queue'));
+    expect(uploadLine).toBeDefined();
+    // All three quantities on this line are unavailable, none rendered as 0.
+    expect(uploadLine).not.toContain('0 nodes');
+    expect(uploadLine).not.toContain('0 bytes');
+    expect((uploadLine!.match(/unavailable/g) ?? []).length).toBe(3);
+  });
+
+  it('prints fractionResident/churn as "unavailable" when readiness is unknown', () => {
+    // An empty wanted set → phase 'unknown' → both derived terms null.
+    const emptyFacts: SchedulerReadinessFacts = {
+      wantedCount: 0,
+      residentCount: 0,
+      inFlightCount: 0,
+      queuedCount: 0,
+      decodedPendingCount: 0,
+      failedCount: 0,
+    };
+    const d = buildStreamingDiagnostics(
+      emptyFacts,
+      evaluateRefinementReadiness(emptyFacts),
+      extra(),
+    );
+    const text = formatStreamingDiagnostics(d);
+    expect(d.unavailable).toContain('fractionResident');
+    expect(d.unavailable).toContain('churn');
+    const readinessLine = text.split('\n')[0];
+    expect(readinessLine).toContain('resident unavailable');
+    expect(readinessLine).toContain('churn unavailable');
+  });
+});

--- a/tests/streamingDiagnosticsFormat.test.ts
+++ b/tests/streamingDiagnosticsFormat.test.ts
@@ -23,7 +23,6 @@ import {
   type SchedulerDiagnosticsExtra,
   type StreamingDiagnosticField,
 } from '../src/render/streaming/streamingDiagnostics';
-import { formatByteSize, groupInt } from '../src/io/formatByteSize';
 import {
   evaluateRefinementReadiness,
   type SchedulerReadinessFacts,
@@ -89,49 +88,50 @@ describe('formatStreamingDiagnostics', () => {
     expect(d.unavailable).toEqual([]);
     const text = formatStreamingDiagnostics(d);
 
-    // A distinctive marker per field, derived from the record's own values so
-    // the check tracks the data rather than a second hard-coded copy. Typed
-    // against the field union: adding a field to the record without an entry
-    // here is a compile error, and its marker then forces a rendered line.
-    const markers: Record<StreamingDiagnosticField, string> = {
-      readinessPhase: `readiness     ${d.readinessPhase}`,
-      fractionResident: `resident ${d.fractionResident!.toFixed(3)}`,
-      churn: `churn ${d.churn!.toFixed(3)}`,
-      wantedNodes: `${groupInt(d.wantedNodes)} wanted`,
-      residentNodes: `${groupInt(d.residentNodes)} resident`,
-      inFlightNodes: `${groupInt(d.inFlightNodes)} in-flight`,
-      queuedNodes: `${groupInt(d.queuedNodes)} queued`,
-      decodedPendingNodes: `${groupInt(d.decodedPendingNodes)} decoded-pending`,
-      failedNodes: `${groupInt(d.failedNodes)} failed`,
-      knownNodes: `${groupInt(d.knownNodes)} known`,
-      visibleNodes: `${groupInt(d.visibleNodes)} visible`,
-      residentPoints: `${groupInt(d.residentPoints)} resident`,
-      decodedPendingPoints: `${groupInt(d.decodedPendingPoints)} decoded-pending`,
-      pointBudget: `${groupInt(d.pointBudget)} budget`,
-      lastTickMs: `tick ${d.lastTickMs.toFixed(1)} ms`,
-      cameraVelocity: `${d.cameraVelocity.toFixed(2)} u/s`,
-      cameraState: `(${d.cameraState})`,
-      effectiveMaxConcurrent: `concurrency ${groupInt(d.effectiveMaxConcurrent)}`,
-      pressureDepthReduction: `-${groupInt(d.pressureDepthReduction)} depth`,
-      fpsBudgetFactor: `×${d.fpsBudgetFactor.toFixed(2)}`,
-      fullRescoreCount: `rescores ${groupInt(d.fullRescoreCount)}`,
-      cacheBytes: `${formatByteSize(d.cacheBytes)} /`,
-      cacheEntries: `${groupInt(d.cacheEntries)} entries`,
-      cacheMaxBytes: `/ ${formatByteSize(d.cacheMaxBytes)}`,
-      cacheHits: `hits ${groupInt(d.cacheHits)}`,
-      cacheMisses: `misses ${groupInt(d.cacheMisses)}`,
-      cacheEvictions: `evict ${groupInt(d.cacheEvictions)}`,
-      generationId: `generation    ${groupInt(d.generationId!)}`,
-      decodeRetryCount: `decode retries ${groupInt(d.decodeRetryCount!)}`,
-      uploadPendingNodes: `${groupInt(d.uploadPendingNodes!)} nodes`,
-      uploadPendingBytes: formatByteSize(d.uploadPendingBytes!),
-      residentDecodedBytes: `resident decoded ${formatByteSize(d.residentDecodedBytes!)}`,
+    // A distinctive per-field pattern anchored to that field's label or position
+    // in the readout — short and structural, so it does not restate (and drift
+    // from, or duplicate) the formatter's own interpolations. Typed against the
+    // field union: adding a field to the record without an entry here is a
+    // compile error, and its pattern then forces a rendered line.
+    const markers: Record<StreamingDiagnosticField, RegExp> = {
+      readinessPhase: /readiness {5}\S/,
+      fractionResident: /· resident \d\.\d{3}/,
+      churn: /· churn \d\.\d{3}/,
+      wantedNodes: /[\d,]+ wanted/,
+      residentNodes: /· [\d,]+ resident/,
+      inFlightNodes: /[\d,]+ in-flight/,
+      queuedNodes: /[\d,]+ queued/,
+      decodedPendingNodes: /[\d,]+ decoded-pending ·/,
+      failedNodes: /[\d,]+ failed/,
+      knownNodes: /[\d,]+ known/,
+      visibleNodes: /[\d,]+ visible/,
+      residentPoints: /points {8}[\d,]+ resident/,
+      decodedPendingPoints: /decoded-pending \//,
+      pointBudget: /[\d,]+ budget/,
+      lastTickMs: /tick \d/,
+      cameraVelocity: /camera \d/,
+      cameraState: /u\/s \(\w+\)/,
+      effectiveMaxConcurrent: /concurrency [\d,]+/,
+      pressureDepthReduction: /pressure -[\d,]+ depth/,
+      fpsBudgetFactor: /fps budget ×/,
+      fullRescoreCount: /rescores [\d,]+/,
+      cacheBytes: /cache {9}[\d.]+ [KMGT]?B \//,
+      cacheEntries: /[\d,]+ entries/,
+      cacheMaxBytes: /\/ [\d.]+ [KMGT]?B ·/,
+      cacheHits: /hits [\d,]+/,
+      cacheMisses: /misses [\d,]+/,
+      cacheEvictions: /evict [\d,]+/,
+      generationId: /generation {4}[\d,]+/,
+      decodeRetryCount: /decode retries [\d,]+/,
+      uploadPendingNodes: /upload queue {2}[\d,]+ nodes/,
+      uploadPendingBytes: /nodes · [\d.]+ [KMGT]?B ·/,
+      residentDecodedBytes: /resident decoded [\d.]+ [KMGT]?B/,
     };
 
     // The map covers exactly the field list — no field left unmarked, none stale.
     expect(Object.keys(markers).sort()).toEqual([...STREAMING_DIAGNOSTIC_FIELDS].sort());
     for (const field of STREAMING_DIAGNOSTIC_FIELDS) {
-      expect(text, `field ${field} not reachable in output`).toContain(markers[field]);
+      expect(text, `field ${field} not reachable in output`).toMatch(markers[field]);
     }
   });
 
@@ -170,7 +170,7 @@ describe('formatStreamingDiagnostics', () => {
     // All three quantities on this line are unavailable, none rendered as 0.
     expect(uploadLine).not.toContain('0 nodes');
     expect(uploadLine).not.toContain('0 B');
-    expect((uploadLine!.match(/unavailable/g) ?? []).length).toBe(3);
+    expect(uploadLine!.match(/unavailable/g) ?? []).toHaveLength(3);
   });
 
   it('prints fractionResident/churn as "unavailable" when readiness is unknown', () => {

--- a/tests/streamingDiagnosticsFormat.test.ts
+++ b/tests/streamingDiagnosticsFormat.test.ts
@@ -27,39 +27,7 @@ import {
   evaluateRefinementReadiness,
   type SchedulerReadinessFacts,
 } from '../src/render/streaming/refinementReadiness';
-
-const FACTS: SchedulerReadinessFacts = {
-  wantedCount: 100,
-  residentCount: 60,
-  inFlightCount: 4,
-  queuedCount: 36,
-  decodedPendingCount: 2,
-  failedCount: 1,
-};
-
-function extra(overrides: Partial<SchedulerDiagnosticsExtra> = {}): SchedulerDiagnosticsExtra {
-  return {
-    knownNodes: 28_000,
-    visibleNodes: 140,
-    residentPoints: 3_200_000,
-    decodedPendingPoints: 51_000,
-    pointBudget: 5_000_000,
-    lastTickMs: 2.5,
-    cameraVelocity: 0.75,
-    cameraStable: true,
-    effectiveMaxConcurrent: 3,
-    pressureDepthReduction: 1,
-    fpsBudgetFactor: 0.85,
-    fullRescoreCount: 12,
-    cacheBytes: 8_388_608,
-    cacheEntries: 64,
-    cacheMaxBytes: 16_777_216,
-    cacheHits: 900,
-    cacheMisses: 100,
-    cacheEvictions: 7,
-    ...overrides,
-  };
-}
+import { FACTS, extra } from './support/streamingDiagnosticsFixture';
 
 function build(overrides: Partial<SchedulerDiagnosticsExtra> = {}) {
   return buildStreamingDiagnostics(

--- a/tests/support/streamingDiagnosticsFixture.ts
+++ b/tests/support/streamingDiagnosticsFixture.ts
@@ -1,0 +1,45 @@
+/**
+ * streamingDiagnosticsFixture.ts — the shared streaming-diagnostics test fixture.
+ *
+ * A mid-load scheduler snapshot used by both streamingDiagnostics.test.ts (the
+ * record) and streamingDiagnosticsFormat.test.ts (the text rendering). Kept in
+ * one place so the two suites assert on the same numbers rather than each
+ * carrying its own copy.
+ */
+import type { SchedulerDiagnosticsExtra } from '../../src/render/streaming/streamingDiagnostics';
+import type { SchedulerReadinessFacts } from '../../src/render/streaming/refinementReadiness';
+
+/** A mid-load wanted set: 60 of 100 resident, work still moving. */
+export const FACTS: SchedulerReadinessFacts = {
+  wantedCount: 100,
+  residentCount: 60,
+  inFlightCount: 4,
+  queuedCount: 36,
+  decodedPendingCount: 2,
+  failedCount: 1,
+};
+
+/** Everything the scheduler reports today, with no optional field supplied. */
+export function extra(overrides: Partial<SchedulerDiagnosticsExtra> = {}): SchedulerDiagnosticsExtra {
+  return {
+    knownNodes: 28_000,
+    visibleNodes: 140,
+    residentPoints: 3_200_000,
+    decodedPendingPoints: 51_000,
+    pointBudget: 5_000_000,
+    lastTickMs: 2.5,
+    cameraVelocity: 0.75,
+    cameraStable: true,
+    effectiveMaxConcurrent: 3,
+    pressureDepthReduction: 1,
+    fpsBudgetFactor: 0.85,
+    fullRescoreCount: 12,
+    cacheBytes: 8_388_608,
+    cacheEntries: 64,
+    cacheMaxBytes: 16_777_216,
+    cacheHits: 900,
+    cacheMisses: 100,
+    cacheEvictions: 7,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
Adds a pure `formatStreamingDiagnostics(d: StreamingDiagnostics | null): string`
to `streamingDiagnostics.ts`. It renders every value field of the record as
grouped text — readiness and derived terms, wanted-set node counts, points
versus budget, scheduler tick and camera state, adaptation factors, and the
cache tier — and returns `(no active stream)` for null input. A field named in
the record's `unavailable` list prints the literal word `unavailable` instead of
a fabricated zero, keeping the null-vs-unavailable distinction the record exists
to preserve.

The `?debug=1` overlay now shows this text below the load telemetry, refreshed
each poll from the existing diagnostics supplier; the `streamingDiagnostics`
metrics-JSON entry is unchanged. New unit tests cover null, fully-populated, and
unavailable-field records. No changes to main.ts or Viewer.ts; index chunk
stays within budget.
