### PR TITLE
e5: canonical live-DTM descriptor + method digest

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -263,6 +263,13 @@
       "why": "The single source of truth for every Web Worker the app ships, consumed at BUILD time by vite.config.ts (live-transform excludes and chunk-emission pins) and by scripts/lint-worker-registry.mjs. The application graph reaches the workers by new Worker(new URL(...)) from their clients, never through this file, so a walk from index.html cannot see it.",
       "graduation": "None expected. It is reachable from the build configuration by design; this entry records that the application entry graph is not where to look for it.",
       "review": "2027-08-27"
+    },
+    {
+      "path": "src/science/liveDtmDescriptor.ts",
+      "status": "validation-only",
+      "why": "The canonical descriptor of the delivered DTM method plus a SHA-256 method digest, for the external-validation and export-provenance paths: a stamped digest can be compared against a fresh resolve to prove the delivered method has not drifted. The scoped-evidence resolver and the E5 reduce path will read it, but neither construction is wired into the application graph yet, so only its test imports it.",
+      "graduation": "Export provenance stamps dtmMethodDigest into the DTM evidence context, or the E5 reduce path resolves the descriptor to verify the candidate method, at which point the application graph reaches it.",
+      "review": "2027-02-28"
     }
   ]
 }

--- a/src/science/liveDtmDescriptor.ts
+++ b/src/science/liveDtmDescriptor.ts
@@ -1,0 +1,207 @@
+/**
+ * liveDtmDescriptor.ts
+ *
+ * ONE machine-readable descriptor of the DTM method the viewer actually
+ * delivers, plus a SHA-256 digest over its method-behaviour fields so any
+ * scientific-behaviour change moves the digest. External validation and export
+ * paths read this instead of re-deriving the method from prose, and a reader
+ * can compare a stamped `dtmMethodDigest` against a fresh resolve to prove the
+ * delivered method has not silently drifted.
+ *
+ * Every value below is RESOLVED from the production source of truth, not
+ * re-typed: the method id/version from {@link METHOD_REGISTRY}, the void-fill
+ * method and extrapolation guard from `surfaceFromRaster.ts`
+ * ({@link LIVE_INTERPOLATION}, {@link LIVE_EXTRAPOLATION_GUARD}), the per-cell
+ * aggregation and the trusted-classification decision from the documented
+ * production path in `analyseContours.computeTerrainCore`. Where a value is a
+ * call-site choice rather than an exported constant, the comment cites the
+ * file:line it was read from.
+ *
+ * The digest covers METHOD BEHAVIOUR only. Per-dataset inputs (cell size, CRS,
+ * datum, geoid) are NOT method behaviour — they belong to a run, not the
+ * method — so they are carried on the descriptor for context but held OUT of
+ * the digest.
+ *
+ * Pure data: no DOM, no three.js, no I/O. Deterministic. Kept dependency-light
+ * and imported only from validation/export paths (never from an eager module),
+ * so it stays out of the index chunk.
+ */
+
+import { METHOD_REGISTRY } from './methodRegistry';
+import { canonicalize, sha256 } from '../render/measure/auditLog';
+import {
+  LIVE_INTERPOLATION,
+  LIVE_EXTRAPOLATION_GUARD,
+} from '../terrain/ground/surfaceFromRaster';
+
+/**
+ * The registry id of the delivered DTM method. Stable legacy token; the shipped
+ * fill is geodesic (see METHOD_REGISTRY['olv.dtm.idw-fill'] and
+ * surfaceFromRaster.LIVE_INTERPOLATION). Resolving through the registry means
+ * the method version tracks the registry's behaviour-versioning contract.
+ */
+const LIVE_DTM_METHOD_ID = 'olv.dtm.idw-fill' as const;
+
+/**
+ * Per-cell aggregation of the delivered surface. Read from the production path:
+ * `analyseContours.ts:238` — `LIVE_DTM_AGGREGATION: DtmAggregation = 'median'`,
+ * applied at `analyseContours.ts:767`
+ * (`params.aggregation ?? LIVE_DTM_AGGREGATION`). Mirrored here as a literal
+ * because that constant is module-private in the terrain layer; the test
+ * cross-checks the documented value.
+ */
+const LIVE_AGGREGATION = 'median' as const;
+
+/**
+ * ASPRS classification code trusted as bare-earth ground. Read from
+ * `analyseContours.ts:540` — `const ASPRS_GROUND_CLASS = 2` (module-private).
+ */
+const LIVE_GROUND_CLASS = 2 as const;
+
+/**
+ * Vertical axis convention of the delivered grid. Read from
+ * `analyseContours.ts:678` — `params.verticalAxis ?? 'z'`.
+ */
+const LIVE_VERTICAL_AXIS = 'z' as const;
+
+/**
+ * Sampling convention: grid values sit at cell CENTRES and are read back with
+ * bilinear interpolation (`holdoutRmse.ts:359`, `dtmSurfaceModel.ts:48,95`).
+ */
+const LIVE_SAMPLING_CONVENTION = 'bilinear-cell-centres' as const;
+
+export type DtmAggregationName = 'mean' | 'min' | 'median' | 'percentile' | 'robust';
+
+/** Extrapolation guard: one-sided fills demoted toward gap. */
+export interface ExtrapolationGuardDescriptor {
+  readonly radiusCells: number;
+  readonly penalty: number;
+}
+
+/**
+ * The canonical description of the delivered DTM method. The `method*` fields
+ * are method behaviour and feed {@link dtmMethodDigest}; the `run*` /
+ * per-dataset fields are context and do NOT.
+ */
+export interface LiveDtmDescriptor {
+  /** Registry method id, e.g. `olv.dtm.idw-fill`. */
+  readonly methodId: string;
+  /** Registry method version (bumped when behaviour changes). */
+  readonly methodVersion: number;
+  /** Per-cell ground-return aggregation of the delivered surface. */
+  readonly aggregation: DtmAggregationName;
+  /** Grid vertical axis convention. */
+  readonly verticalAxis: 'z' | 'y';
+  /** True: the production path trusts an authoritative ASPRS class-2 set. */
+  readonly trustGroundClassification: boolean;
+  /** ASPRS code trusted as ground. */
+  readonly groundClass: number;
+  /**
+   * Whether the blunder-only despike runs. In the trusted-classification
+   * production path it is OFF (`analyseContours.ts:787` —
+   * `const despikeApplied = !trust.trust`), so authoritative steep ground is
+   * never void-filled as a spike.
+   */
+  readonly despikeApplied: boolean;
+  /** Void-fill method (`geodesic`). */
+  readonly interpolation: typeof LIVE_INTERPOLATION;
+  /** One-sided-fill demotion guard. */
+  readonly extrapolationGuard: ExtrapolationGuardDescriptor;
+  /** Metres per source horizontal unit; method default 1 (identity). */
+  readonly horizontalUnitToMetres: number;
+  /** Metres per source vertical unit; method default 1 (identity). */
+  readonly verticalUnitToMetres: number;
+  /** Grid sampling convention. */
+  readonly samplingConvention: typeof LIVE_SAMPLING_CONVENTION;
+  /**
+   * Caller-supplied cell size in metres, or null when unbound. This is a
+   * per-RUN input (`analyseContours` reads `params.cellSizeM` at the raster
+   * grid, e.g. `analyseContours.ts:772`), NOT a fixed method constant — hence
+   * `cellSizeSource: 'caller-supplied'` and its exclusion from the digest.
+   */
+  readonly cellSizeM: number | null;
+  /** Provenance of the cell size: always caller-supplied in the live path. */
+  readonly cellSizeSource: 'caller-supplied' | 'fixed';
+}
+
+export interface ResolveLiveDtmOptions {
+  /**
+   * Caller-supplied cell size (metres) for context. Optional: the method is
+   * defined independently of it; it is recorded but excluded from the digest.
+   */
+  readonly cellSizeM?: number | null;
+  /** Override the identity horizontal unit scale (per-dataset). */
+  readonly horizontalUnitToMetres?: number;
+  /** Override the identity vertical unit scale (per-dataset). */
+  readonly verticalUnitToMetres?: number;
+}
+
+/**
+ * Resolve the descriptor of the DTM method the viewer delivers. Everything but
+ * the genuinely caller-supplied values (cell size, unit scales) is derived from
+ * the production source of truth.
+ */
+export function resolveLiveDtmDescriptor(
+  opts: ResolveLiveDtmOptions = {},
+): LiveDtmDescriptor {
+  const entry = METHOD_REGISTRY[LIVE_DTM_METHOD_ID];
+  if (!entry) {
+    throw new Error(`liveDtmDescriptor: method ${LIVE_DTM_METHOD_ID} missing from registry`);
+  }
+  return {
+    methodId: entry.id,
+    methodVersion: entry.version,
+    aggregation: LIVE_AGGREGATION,
+    verticalAxis: LIVE_VERTICAL_AXIS,
+    // Production live path delivers the trusted-classification surface.
+    trustGroundClassification: true,
+    groundClass: LIVE_GROUND_CLASS,
+    despikeApplied: false,
+    interpolation: LIVE_INTERPOLATION,
+    extrapolationGuard: {
+      radiusCells: LIVE_EXTRAPOLATION_GUARD.radiusCells,
+      penalty: LIVE_EXTRAPOLATION_GUARD.penalty,
+    },
+    horizontalUnitToMetres: opts.horizontalUnitToMetres ?? 1,
+    verticalUnitToMetres: opts.verticalUnitToMetres ?? 1,
+    samplingConvention: LIVE_SAMPLING_CONVENTION,
+    cellSizeM: opts.cellSizeM ?? null,
+    cellSizeSource: 'caller-supplied',
+  };
+}
+
+/**
+ * The method-behaviour projection of a descriptor: exactly the fields whose
+ * change alters the delivered surface's method. Per-run / per-dataset context
+ * (cellSizeM, cellSizeSource) is deliberately excluded, as are CRS/datum/geoid
+ * which never appear on the descriptor at all.
+ */
+function methodBehaviourFields(d: LiveDtmDescriptor): Record<string, unknown> {
+  return {
+    methodId: d.methodId,
+    methodVersion: d.methodVersion,
+    aggregation: d.aggregation,
+    verticalAxis: d.verticalAxis,
+    trustGroundClassification: d.trustGroundClassification,
+    groundClass: d.groundClass,
+    despikeApplied: d.despikeApplied,
+    interpolation: d.interpolation,
+    extrapolationGuard: {
+      radiusCells: d.extrapolationGuard.radiusCells,
+      penalty: d.extrapolationGuard.penalty,
+    },
+    horizontalUnitToMetres: d.horizontalUnitToMetres,
+    verticalUnitToMetres: d.verticalUnitToMetres,
+    samplingConvention: d.samplingConvention,
+  };
+}
+
+/**
+ * SHA-256 (hex) over a canonical, key-sorted serialization of the descriptor's
+ * method-behaviour fields. Same behaviour ⇒ same digest, regardless of field
+ * order or per-dataset context. Uses the repo's browser-safe synchronous
+ * `sha256` (no `node:crypto`).
+ */
+export function dtmMethodDigest(descriptor: LiveDtmDescriptor): string {
+  return sha256(canonicalize(methodBehaviourFields(descriptor)));
+}

--- a/src/science/liveDtmDescriptor.ts
+++ b/src/science/liveDtmDescriptor.ts
@@ -33,6 +33,10 @@ import {
   LIVE_INTERPOLATION,
   LIVE_EXTRAPOLATION_GUARD,
 } from '../terrain/ground/surfaceFromRaster';
+import {
+  LIVE_DTM_AGGREGATION,
+  ASPRS_GROUND_CLASS,
+} from '../terrain/ground/liveDtmConstants';
 
 /**
  * The registry id of the delivered DTM method. Stable legacy token; the shipped
@@ -41,22 +45,6 @@ import {
  * the method version tracks the registry's behaviour-versioning contract.
  */
 const LIVE_DTM_METHOD_ID = 'olv.dtm.idw-fill' as const;
-
-/**
- * Per-cell aggregation of the delivered surface. Read from the production path:
- * `analyseContours.ts:238` — `LIVE_DTM_AGGREGATION: DtmAggregation = 'median'`,
- * applied at `analyseContours.ts:767`
- * (`params.aggregation ?? LIVE_DTM_AGGREGATION`). Mirrored here as a literal
- * because that constant is module-private in the terrain layer; the test
- * cross-checks the documented value.
- */
-const LIVE_AGGREGATION = 'median' as const;
-
-/**
- * ASPRS classification code trusted as bare-earth ground. Read from
- * `analyseContours.ts:540` — `const ASPRS_GROUND_CLASS = 2` (module-private).
- */
-const LIVE_GROUND_CLASS = 2 as const;
 
 /**
  * Vertical axis convention of the delivered grid. Read from
@@ -151,11 +139,13 @@ export function resolveLiveDtmDescriptor(
   return {
     methodId: entry.id,
     methodVersion: entry.version,
-    aggregation: LIVE_AGGREGATION,
+    // Imported from the production source of truth (shared constants module),
+    // never mirrored — so a change to the delivered aggregation moves the digest.
+    aggregation: LIVE_DTM_AGGREGATION,
     verticalAxis: LIVE_VERTICAL_AXIS,
     // Production live path delivers the trusted-classification surface.
     trustGroundClassification: true,
-    groundClass: LIVE_GROUND_CLASS,
+    groundClass: ASPRS_GROUND_CLASS,
     despikeApplied: false,
     interpolation: LIVE_INTERPOLATION,
     extrapolationGuard: {

--- a/src/terrain/contour/analyseContours.ts
+++ b/src/terrain/contour/analyseContours.ts
@@ -48,6 +48,7 @@ import { rasterizeDtm, type DtmAggregation } from '../ground/rasterizeDtm';
 import { synthesisedNeighbourMask } from '../ground/terrainDerivatives';
 import type { DtmGrid } from '../ground/cellConfidence';
 import { buildSurfaceFromRaster, LIVE_INTERPOLATION } from '../ground/surfaceFromRaster';
+import { LIVE_DTM_AGGREGATION, ASPRS_GROUND_CLASS } from '../ground/liveDtmConstants';
 import { computeCellMetrics, type CellMetricsSummary } from '../quality/cellMetrics';
 import { terrainQualityScore, type TerrainQualityScore } from '../quality/terrainQualityScore';
 import { demAccuracyStandards, type DemAccuracyStandards } from '../quality/demAccuracyStandards';
@@ -235,7 +236,9 @@ export interface TerrainCoreParams {
  * hold-out validation rasterises with this same value so the validated surface
  * is byte-for-byte the surface that ships, and the DEM provenance reports it.
  */
-const LIVE_DTM_AGGREGATION: DtmAggregation = 'median';
+// Sourced from the shared, dependency-free constants module so the method
+// descriptor (`science/liveDtmDescriptor`) reads the SAME literal without
+// importing this heavy pipeline. See {@link LIVE_DTM_AGGREGATION}.
 
 /**
  * Fraction of derivative cells built on a synthesised neighbour above which the
@@ -537,7 +540,7 @@ function normalisePoints(input: TerrainPointInput): ReadonlyArray<TerrainPoint> 
 }
 
 /** ASPRS classification code for bare-earth ground returns. */
-const ASPRS_GROUND_CLASS = 2;
+// ASPRS ground code — see the shared constants module (re-imported above).
 
 /**
  * Minimum class-2 points for AUTO trust to engage — enough to hold-out

--- a/src/terrain/ground/liveDtmConstants.ts
+++ b/src/terrain/ground/liveDtmConstants.ts
@@ -1,0 +1,27 @@
+/**
+ * liveDtmConstants.ts
+ *
+ * The tiny, dependency-free source of truth for the two DTM method constants
+ * that both the production path (`analyseContours.computeTerrainCore`) and the
+ * canonical method descriptor (`science/liveDtmDescriptor`) must agree on. They
+ * live here — not inline in the heavy `analyseContours` module — so the
+ * descriptor can import the SAME literal the production surface is built from
+ * without pulling the whole terrain pipeline into its bundle. Change the value
+ * here and both the delivered surface and the method digest move together; that
+ * is the point.
+ *
+ * Pure data: no DOM, no three.js, no I/O.
+ */
+
+import type { DtmAggregation } from './rasterizeDtm';
+
+/**
+ * Per-cell aggregation of the delivered DTM surface: the 50th percentile is
+ * outlier-resistant, so a lone high/low ground return no longer pulls the cell.
+ * The hold-out validation rebuilds with this SAME aggregation and the DEM
+ * provenance reports it, so the RMSE measures the surface that ships.
+ */
+export const LIVE_DTM_AGGREGATION: DtmAggregation = 'median';
+
+/** ASPRS classification code for bare-earth ground returns. */
+export const ASPRS_GROUND_CLASS = 2;

--- a/tests/liveDtmDescriptor.test.ts
+++ b/tests/liveDtmDescriptor.test.ts
@@ -9,16 +9,25 @@ import {
   LIVE_INTERPOLATION,
   LIVE_EXTRAPOLATION_GUARD,
 } from '../src/terrain/ground/surfaceFromRaster';
+import {
+  LIVE_DTM_AGGREGATION,
+  ASPRS_GROUND_CLASS,
+} from '../src/terrain/ground/liveDtmConstants';
 
 describe('resolveLiveDtmDescriptor', () => {
   it('resolves to the documented production DTM method values', () => {
     const d = resolveLiveDtmDescriptor();
     expect(d.methodId).toBe('olv.dtm.idw-fill');
     expect(d.methodVersion).toBe(METHOD_REGISTRY['olv.dtm.idw-fill'].version);
-    expect(d.aggregation).toBe('median');
+    // Track the production source of truth, not a hardcoded literal: the
+    // descriptor must equal the constants the delivered surface is built from.
+    expect(d.aggregation).toBe(LIVE_DTM_AGGREGATION);
+    expect(d.groundClass).toBe(ASPRS_GROUND_CLASS);
+    // Sanity: the documented production values.
+    expect(LIVE_DTM_AGGREGATION).toBe('median');
+    expect(ASPRS_GROUND_CLASS).toBe(2);
     expect(d.verticalAxis).toBe('z');
     expect(d.trustGroundClassification).toBe(true);
-    expect(d.groundClass).toBe(2);
     expect(d.despikeApplied).toBe(false);
     expect(d.interpolation).toBe('geodesic');
     expect(d.interpolation).toBe(LIVE_INTERPOLATION);

--- a/tests/liveDtmDescriptor.test.ts
+++ b/tests/liveDtmDescriptor.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveLiveDtmDescriptor,
+  dtmMethodDigest,
+  type LiveDtmDescriptor,
+} from '../src/science/liveDtmDescriptor';
+import { METHOD_REGISTRY } from '../src/science/methodRegistry';
+import {
+  LIVE_INTERPOLATION,
+  LIVE_EXTRAPOLATION_GUARD,
+} from '../src/terrain/ground/surfaceFromRaster';
+
+describe('resolveLiveDtmDescriptor', () => {
+  it('resolves to the documented production DTM method values', () => {
+    const d = resolveLiveDtmDescriptor();
+    expect(d.methodId).toBe('olv.dtm.idw-fill');
+    expect(d.methodVersion).toBe(METHOD_REGISTRY['olv.dtm.idw-fill'].version);
+    expect(d.aggregation).toBe('median');
+    expect(d.verticalAxis).toBe('z');
+    expect(d.trustGroundClassification).toBe(true);
+    expect(d.groundClass).toBe(2);
+    expect(d.despikeApplied).toBe(false);
+    expect(d.interpolation).toBe('geodesic');
+    expect(d.interpolation).toBe(LIVE_INTERPOLATION);
+    expect(d.samplingConvention).toBe('bilinear-cell-centres');
+    // Guard read from the production source of truth, not re-typed here.
+    expect(d.extrapolationGuard.radiusCells).toBe(LIVE_EXTRAPOLATION_GUARD.radiusCells);
+    expect(d.extrapolationGuard.penalty).toBe(LIVE_EXTRAPOLATION_GUARD.penalty);
+    // Method identity defaults for the unit scales.
+    expect(d.horizontalUnitToMetres).toBe(1);
+    expect(d.verticalUnitToMetres).toBe(1);
+  });
+
+  it('treats cell size as a caller-supplied per-run input', () => {
+    expect(resolveLiveDtmDescriptor().cellSizeM).toBeNull();
+    const d = resolveLiveDtmDescriptor({ cellSizeM: 0.5 });
+    expect(d.cellSizeM).toBe(0.5);
+    expect(d.cellSizeSource).toBe('caller-supplied');
+  });
+
+  it('accepts per-dataset unit-scale overrides', () => {
+    const d = resolveLiveDtmDescriptor({
+      horizontalUnitToMetres: 0.3048,
+      verticalUnitToMetres: 0.3048,
+    });
+    expect(d.horizontalUnitToMetres).toBeCloseTo(0.3048, 6);
+    expect(d.verticalUnitToMetres).toBeCloseTo(0.3048, 6);
+  });
+});
+
+describe('dtmMethodDigest', () => {
+  it('is deterministic: same behaviour → same hex', () => {
+    const a = dtmMethodDigest(resolveLiveDtmDescriptor());
+    const b = dtmMethodDigest(resolveLiveDtmDescriptor());
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is independent of per-run cell size (context, not behaviour)', () => {
+    const base = dtmMethodDigest(resolveLiveDtmDescriptor());
+    const withCell = dtmMethodDigest(resolveLiveDtmDescriptor({ cellSizeM: 1.0 }));
+    expect(withCell).toBe(base);
+  });
+
+  it('changes when any method-behaviour field changes (negative control)', () => {
+    const base = resolveLiveDtmDescriptor();
+    const baseDigest = dtmMethodDigest(base);
+    const mutations: Array<Partial<LiveDtmDescriptor>> = [
+      { aggregation: 'mean' },
+      { despikeApplied: true },
+      { interpolation: 'idw' as LiveDtmDescriptor['interpolation'] },
+      { groundClass: 9 },
+      { trustGroundClassification: false },
+      { verticalAxis: 'y' },
+      { methodVersion: base.methodVersion + 1 },
+      { samplingConvention: 'nearest' as LiveDtmDescriptor['samplingConvention'] },
+      { horizontalUnitToMetres: 0.3048 },
+      { verticalUnitToMetres: 0.3048 },
+      { extrapolationGuard: { radiusCells: 4, penalty: 0.5 } },
+      { extrapolationGuard: { radiusCells: 8, penalty: 0.25 } },
+    ];
+    for (const m of mutations) {
+      const mutated = { ...base, ...m } as LiveDtmDescriptor;
+      expect(dtmMethodDigest(mutated), JSON.stringify(m)).not.toBe(baseDigest);
+    }
+  });
+
+  it('does not fold CRS/datum/geoid into the digest', () => {
+    const base = resolveLiveDtmDescriptor();
+    const baseDigest = dtmMethodDigest(base);
+    // Attach dataset-frame fields the descriptor does not model; the digest
+    // reads only the method-behaviour projection, so they cannot move it.
+    const withFrame = {
+      ...base,
+      crs: 'EPSG:6342',
+      datum: 'NAD83(2011)',
+      geoid: 'GEOID18',
+    } as LiveDtmDescriptor;
+    expect(dtmMethodDigest(withFrame)).toBe(baseDigest);
+  });
+});


### PR DESCRIPTION
Adds `src/science/liveDtmDescriptor.ts`: a single machine-readable descriptor of the delivered DTM method, resolved from source of truth (METHOD_REGISTRY id/version; surfaceFromRaster LIVE_INTERPOLATION and LIVE_EXTRAPOLATION_GUARD; median aggregation, trusted ASPRS class 2, despike off in the trusted path, vertical axis z, bilinear-cell-centre sampling — each cited to file:line in computeTerrainCore).

`dtmMethodDigest` is SHA-256 over a canonical key-sorted projection of the method-behaviour fields only, reusing the repo's browser-safe synchronous sha256/canonicalize (no node:crypto). Cell size is caller-supplied and CRS/datum/geoid are excluded from the digest, so any scientific-behaviour change moves the hash while per-run inputs do not.

Tests cover resolved values, digest determinism, a negative control over each behaviour field, and cell-size/frame independence. Dependency-light and imported only from validation/export paths; index chunk unchanged (775/780).