### PR TITLE
e5: scoped evidence overlays with conservative fallback

### DIFF
--- a/src/terrain/export/exportProvenance.ts
+++ b/src/terrain/export/exportProvenance.ts
@@ -38,6 +38,11 @@ import { readinessLine } from '../quality/readinessEngine';
 import { contourShapeStyleLabel, type ContourShapeStyle } from '../contour/contourShapeStyle';
 import { exportGate, EVIDENCE_REGISTRY } from '../../validation/evidenceRegistry';
 import { evidenceRank, INDEPENDENCE_FLOOR } from '../../validation/evidenceLevel';
+import {
+  resolveEvidence,
+  type EvidenceContext,
+  type ScopedEvidenceRecord,
+} from '../../validation/scopedEvidence';
 import { buildIdentityProvenance } from '../../build/buildIdentity';
 import { methodRef, methodTag } from '../../science/methodRegistry';
 import {
@@ -171,6 +176,31 @@ export interface ExportProvenanceAccuracy {
 }
 
 /**
+ * The scope-aware evidence resolution stamped into a terrain export (§7/§8/§43).
+ * Present only when the export path supplies a `methodDigest` / `evidenceContext`
+ * so applicability can be assessed; absent (null) on the common path, which keeps
+ * existing artifacts byte-identical. Records the baseline vs effective level, the
+ * matched study (or null), the applicability verdict and the method digest, so a
+ * downstream reader can see the artifact was NOT silently promoted out of scope.
+ */
+export interface ExportScopedEvidence {
+  /** The DTM-family claim resolved (e.g. 'DTM'). */
+  readonly claimId: string;
+  /** Baseline registry level (before any scoped overlay). */
+  readonly baselineEvidence: string | null;
+  /** Effective level after scoped overlay — equals baseline unless matched in scope. */
+  readonly effectiveEvidence: string | null;
+  /** Matched study id when in-scope, else null. */
+  readonly matchedScopedStudy: string | null;
+  /** Human-readable applicability verdict. */
+  readonly applicabilityVerdict: string;
+  /** The explicit resolution state string. */
+  readonly resolutionState: string;
+  /** The method digest the resolution was keyed on, or null when not supplied. */
+  readonly methodDigest: string | null;
+}
+
+/**
  * The unified provenance of one analysis run, stamped identically into every
  * export. Absent values are honest: `null` / "unknown" / "not georeferenced".
  */
@@ -264,6 +294,13 @@ export interface ExportProvenance {
    * figure the export already stated.
    */
   readonly transform?: TransformProvenance | null;
+  /**
+   * The scope-aware evidence resolution for this export, or null when the path
+   * supplied no artifact context (the common case — absent keeps the artifact
+   * byte-identical to before). Never promotes above baseline unless a registered
+   * study envelope matched the artifact context.
+   */
+  readonly scopedEvidence?: ExportScopedEvidence | null;
 }
 
 /** Options for {@link buildExportProvenance}. */
@@ -306,6 +343,21 @@ export interface ExportProvenanceOptions {
    * transform. Pure disclosure metadata — it never alters an exported figure.
    */
   readonly transform?: TransformProvenance | null;
+  /**
+   * The DTM-family claim id to resolve scope-aware evidence for. Defaults to
+   * 'DTM' when an evidence context or method digest is supplied.
+   */
+  readonly evidenceClaimId?: string;
+  /** Digest of the method that produced this artifact — the method-match anchor. */
+  readonly methodDigest?: string | null;
+  /** The artifact context checked against registered study envelopes. */
+  readonly evidenceContext?: EvidenceContext | null;
+  /**
+   * Scoped evidence records to resolve against. Defaults to the empty shipped
+   * set, so a real export never promotes above baseline. Supplied only by tests
+   * or a future path that registers a real, frozen study.
+   */
+  readonly scopedRecords?: readonly ScopedEvidenceRecord[];
 }
 
 /** Resolve the generation timestamp to an ISO string. */
@@ -434,6 +486,38 @@ export function buildExportProvenance(
     // `null` otherwise — the terrain surface products build in the source CRS
     // and reproject nothing, so this is `null` for them.
     transform: opts.transform ?? null,
+    // Scope-aware evidence: resolved only when the path supplied a context/digest.
+    // Absent (null) otherwise, which keeps the export byte-identical to before.
+    scopedEvidence: buildScopedEvidence(opts),
+  };
+}
+
+/**
+ * Resolve the scope-aware evidence block for an export, or null when the path
+ * supplied no artifact context (no `evidenceContext` and no `methodDigest`). The
+ * resolver defaults to the empty shipped record set, so with today's registry a
+ * real export never rises above its baseline level.
+ */
+function buildScopedEvidence(opts: ExportProvenanceOptions): ExportScopedEvidence | null {
+  const hasSignal =
+    opts.evidenceContext != null || (opts.methodDigest != null && opts.methodDigest !== '');
+  if (!hasSignal) return null;
+  const claimId = opts.evidenceClaimId ?? 'DTM';
+  const context: EvidenceContext = {
+    ...(opts.evidenceContext ?? {}),
+    ...(opts.methodDigest != null && opts.evidenceContext?.methodDigest == null
+      ? { methodDigest: opts.methodDigest }
+      : {}),
+  };
+  const r = resolveEvidence(claimId, context, opts.scopedRecords);
+  return {
+    claimId,
+    baselineEvidence: r.baselineEvidence,
+    effectiveEvidence: r.effectiveEvidence,
+    matchedScopedStudy: r.matchedScopedStudy,
+    applicabilityVerdict: r.applicabilityVerdict,
+    resolutionState: r.resolutionState,
+    methodDigest: context.methodDigest ?? null,
   };
 }
 
@@ -726,6 +810,20 @@ export function provenanceLines(p: ExportProvenance): string[] {
     kv('Note', p.notSurveyGrade),
     kv('Evidence', EVIDENCE_GATE_NOTE),
   );
+  // Scope-aware evidence disclosure — present only when the path assessed
+  // applicability. Names the baseline vs effective level, the matched study (or
+  // "none"), and the resolution state, so a reader sees no silent out-of-scope
+  // promotion. Absent entirely for the common context-free export.
+  if (p.scopedEvidence) {
+    const s = p.scopedEvidence;
+    lines.push(
+      kv(
+        'Scoped evidence',
+        `${s.resolutionState}; baseline ${s.baselineEvidence ?? 'unregistered'} → effective `
+          + `${s.effectiveEvidence ?? 'unregistered'}; study ${s.matchedScopedStudy ?? 'none'}`,
+      ),
+    );
+  }
   // The evidence-gate permit that authorised this file (§19). Absent only for a
   // non-gated path; a gated contour export always carries its decision here.
   if (p.exportPermit) {
@@ -791,6 +889,22 @@ export function provenanceJson(p: ExportProvenance): Record<string, unknown> {
     warnings: [...p.warnings],
     notSurveyGrade: p.notSurveyGrade,
     evidence: EVIDENCE_GATE_NOTE,
+    // Scope-aware evidence block — emitted ONLY when applicability was assessed
+    // (the key is absent otherwise, keeping the common export byte-identical).
+    // Never promotes above baseline unless a registered study envelope matched.
+    ...(p.scopedEvidence
+      ? {
+          scopedEvidence: {
+            claimId: p.scopedEvidence.claimId,
+            baselineEvidence: p.scopedEvidence.baselineEvidence,
+            effectiveEvidence: p.scopedEvidence.effectiveEvidence,
+            matchedScopedStudy: p.scopedEvidence.matchedScopedStudy,
+            applicabilityVerdict: p.scopedEvidence.applicabilityVerdict,
+            resolutionState: p.scopedEvidence.resolutionState,
+            methodDigest: p.scopedEvidence.methodDigest,
+          },
+        }
+      : {}),
     exportPermit: p.exportPermit
       ? {
           status: p.exportPermit.status,

--- a/src/validation/exportEvidenceNote.ts
+++ b/src/validation/exportEvidenceNote.ts
@@ -19,6 +19,11 @@
 
 import { exportGate, EVIDENCE_REGISTRY } from './evidenceRegistry';
 import { evidenceRank, INDEPENDENCE_FLOOR } from './evidenceLevel';
+import {
+  resolveEvidence,
+  type EvidenceContext,
+  type ScopedEvidenceRecord,
+} from './scopedEvidence';
 
 /**
  * The evidence note for a product identified by its claim id. Derived from the
@@ -92,4 +97,44 @@ export function evidenceStatus(claimId: string): EvidenceStatus {
   if (d.exploratoryOnly) return 'exploratory';
   if (d.allowed) return 'validated';
   return 'refused';
+}
+
+/**
+ * The SCOPE-AWARE evidence note for a DTM-family product, derived from
+ * {@link resolveEvidence}. Compact, and never shows a bare "E5": an in-scope
+ * match reads as validated FOR the registered study envelope; an out-of-scope or
+ * applicability-unknown result says external evidence exists but this dataset is
+ * outside the validated scope. With no context (or no scoped record), the wording
+ * matches the baseline note the product already carries.
+ *
+ * `records` defaults to the empty shipped set, so with today's registry this
+ * returns the baseline wording for every real artifact.
+ */
+export function scopedEvidenceNote(
+  claimId: string,
+  context?: EvidenceContext,
+  records?: readonly ScopedEvidenceRecord[],
+): string {
+  const r = resolveEvidence(claimId, context, records);
+  switch (r.resolutionState) {
+    case 'validated-in-scope':
+      return (
+        'Evidence: externally field validated for the registered study envelope ('
+        + r.matchedScopedStudy + '). Applies only within that scope.'
+      );
+    case 'external-evidence-out-of-scope':
+      return (
+        'Evidence: external field evidence exists for this DTM method, but this '
+        + 'dataset is outside the validated study scope. Baseline level stands.'
+      );
+    case 'applicability-unknown':
+      return (
+        'Evidence: external field evidence exists for this DTM method, but this '
+        + 'dataset’s applicability could not be established, so it is treated '
+        + 'as outside the validated study scope. Baseline level stands.'
+      );
+    default:
+      // No scoped record for the claim: the baseline gate note is authoritative.
+      return evidenceNote(claimId);
+  }
 }

--- a/src/validation/scopedEvidence.ts
+++ b/src/validation/scopedEvidence.ts
@@ -1,0 +1,362 @@
+/**
+ * scopedEvidence.ts
+ *
+ * SCOPED evidence overlays with a conservative fallback.
+ *
+ * The runtime evidence registry (`evidenceRegistry.ts`) carries ONE global
+ * evidence level per claim: `DTM` is `E4` for every dataset the app has ever
+ * opened. That is correct for cross-implementation evidence, which is a property
+ * of the CODE. External field validation (E5) is NOT a property of the code — it
+ * is a property of a specific study: a specific method revision, a specific CRS
+ * and geoid, a specific terrain, validated against specific ground control. If a
+ * single global `DTM = E5` switch existed, OLV would then treat a forest DTM from
+ * another country in another CRS as "externally validated" — which is false and
+ * unacceptable.
+ *
+ * This module makes external evidence SCOPED: a {@link ScopedEvidenceRecord}
+ * raises a claim's effective evidence ONLY for artifacts that fall inside its
+ * registered applicability envelope (exact agreement on the safety-critical keys:
+ * method digest, horizontal/vertical EPSG, geoid model, plus any further envelope
+ * key the record sets). Everything else falls back to the baseline registry
+ * level. The fallback is deliberately conservative: if scoped evidence exists but
+ * the artifact context is absent or incomplete, applicability CANNOT be
+ * established, so the effective level stays at baseline and the state is
+ * `applicability-unknown` — never the scoped level.
+ *
+ * A record is DATA, passed to {@link resolveEvidence}; the resolver never reads
+ * files. The shipped runtime record set {@link SCOPED_EVIDENCE_RECORDS} is EMPTY:
+ * no real field study exists yet, so no committed record may raise any real
+ * artifact above its baseline. Records are only ever created after a real, frozen
+ * study, and any file committed under `validation/evidence/scoped/` before then is
+ * an `EXAMPLE-` template that is structurally incapable of matching a real
+ * artifact.
+ *
+ * Pure: types, ranks, a matching predicate, a resolver. No DOM, no I/O.
+ */
+
+import type { EvidenceLevel } from './evidenceLevel';
+import { evidenceRank, meetsRequired, INDEPENDENCE_FLOOR } from './evidenceLevel';
+import { EVIDENCE_REGISTRY, type RegistryEntry } from './claimRegistry.generated';
+
+/**
+ * The explicit resolution state of an evidence lookup. The first three are new
+ * scoped-overlay outcomes; the last three carry the baseline registry verdict.
+ *
+ *  - `validated-in-scope`             — a scoped record's envelope matched the
+ *                                       artifact; effective evidence is the
+ *                                       scoped level.
+ *  - `external-evidence-out-of-scope` — a scoped record exists for the claim, the
+ *                                       artifact context is complete, but the
+ *                                       artifact is OUTSIDE every envelope.
+ *  - `applicability-unknown`          — a scoped record exists but the context is
+ *                                       absent/incomplete, so applicability cannot
+ *                                       be established (fails closed to baseline).
+ *  - `cross-implementation`           — baseline meets its required level and is at
+ *                                       or above the independence floor (E4+).
+ *  - `exploratory`                    — baseline below required, or self-verified.
+ *  - `refused`                        — unregistered claim, or export disabled.
+ */
+export type ResolutionState =
+  | 'validated-in-scope'
+  | 'external-evidence-out-of-scope'
+  | 'applicability-unknown'
+  | 'cross-implementation'
+  | 'exploratory'
+  | 'refused';
+
+/**
+ * The matching predicate inputs of a scoped record — the envelope the artifact
+ * context must fall inside for the record to apply. Every key is optional; a key
+ * the record SETS becomes a hard constraint (the context must supply an equal
+ * value). Keys the record omits are unconstrained.
+ */
+export interface ApplicabilityEnvelope {
+  /** Digest of the exact DTM/terrain METHOD the study validated. Safety-critical. */
+  readonly methodDigest?: string;
+  /** Horizontal CRS EPSG code the study validated. Safety-critical. */
+  readonly horizontalEpsg?: number;
+  /** Vertical CRS EPSG code the study validated. Safety-critical. */
+  readonly verticalEpsg?: number;
+  /** Geoid model the vertical datum was realised through. Safety-critical. */
+  readonly geoidModel?: string;
+  /** Vertical datum name, when the study pins it beyond the EPSG. */
+  readonly verticalDatum?: string;
+  /** Terrain stratum the study covers (e.g. 'bare-earth', 'open-terrain'). */
+  readonly terrainStratum?: string;
+  /** Named study area the checkpoints lie within. */
+  readonly studyArea?: string;
+  /** Slope band, degrees, the checkpoints span; context slope must lie within. */
+  readonly slopeRange?: readonly [number, number];
+  /** Aggregation the surface was built with (e.g. 'idw', 'mean'). */
+  readonly aggregation?: string;
+  /** Interpolation/fill the surface was built with. */
+  readonly interpolation?: string;
+  /** Grid cell size (source units) the study validated. */
+  readonly cellSize?: number;
+  /** Whether the study trusted source ground classification. */
+  readonly trustGroundClassification?: boolean;
+  /** The candidate build revision the study was frozen against. */
+  readonly candidateRevision?: string;
+}
+
+/**
+ * A scoped external-evidence record. Created ONLY after a real, frozen field
+ * study. It raises {@link resolveEvidence}'s effective evidence for `claimId` to
+ * `evidenceLevel`, but ONLY for artifacts whose context matches
+ * `applicabilityEnvelope`.
+ */
+export interface ScopedEvidenceRecord {
+  /** The claim id this record scopes (must exist in the runtime registry). */
+  readonly claimId: string;
+  /** The evidence level this study establishes inside its envelope (e.g. E5). */
+  readonly evidenceLevel: EvidenceLevel;
+  /** Stable study identifier (appears in provenance as the matched study). */
+  readonly studyId: string;
+  /** Build revision the study was frozen against. */
+  readonly candidateRevision?: string;
+  /** Registered method id the study validated. */
+  readonly methodId?: string;
+  /** Method version the study validated. */
+  readonly methodVersion?: string;
+  /** Digest of the validated method — the anchor for method-match. */
+  readonly methodDigest?: string;
+  /** Horizontal EPSG the study was performed in. */
+  readonly horizontalEpsg?: number;
+  /** Vertical EPSG the study was performed in. */
+  readonly verticalEpsg?: number;
+  /** Vertical datum name. */
+  readonly verticalDatum?: string;
+  /** Geoid model realising the vertical datum. */
+  readonly geoidModel?: string;
+  /** Grid cell size (source units). */
+  readonly cellSize?: number;
+  /** Aggregation used. */
+  readonly aggregation?: string;
+  /** Interpolation/fill used. */
+  readonly interpolation?: string;
+  /** Whether source ground classification was trusted. */
+  readonly trustGroundClassification?: boolean;
+  /** Terrain stratum covered. */
+  readonly terrainStratum?: string;
+  /** Slope band, degrees, the checkpoints span. */
+  readonly slopeRange?: readonly [number, number];
+  /** Support state (checkpoint count / distribution descriptor). */
+  readonly supportState?: string;
+  /** Named study area. */
+  readonly studyArea?: string;
+  /** Survey date (ISO), for the audit trail. */
+  readonly surveyDate?: string;
+  /** The matching predicate: the artifact context must fall inside this. */
+  readonly applicabilityEnvelope: ApplicabilityEnvelope;
+}
+
+/**
+ * The context of the artifact under export — what the resolver checks against a
+ * record's envelope. Every field is optional: a MISSING safety-critical field is
+ * exactly what triggers the conservative `applicability-unknown` fallback.
+ */
+export interface EvidenceContext {
+  /** Digest of the method that actually produced this artifact. */
+  readonly methodDigest?: string;
+  /** Horizontal CRS EPSG of this artifact. */
+  readonly horizontalEpsg?: number;
+  /** Vertical CRS EPSG of this artifact. */
+  readonly verticalEpsg?: number;
+  /** Geoid model of this artifact. */
+  readonly geoidModel?: string;
+  /** Vertical datum name of this artifact. */
+  readonly verticalDatum?: string;
+  /** Terrain stratum of this artifact. */
+  readonly terrainStratum?: string;
+  /** Named study area of this artifact. */
+  readonly studyArea?: string;
+  /** Representative slope, degrees, of this artifact (checked against slopeRange). */
+  readonly slopeDegrees?: number;
+  /** Aggregation this artifact was built with. */
+  readonly aggregation?: string;
+  /** Interpolation/fill this artifact was built with. */
+  readonly interpolation?: string;
+  /** Grid cell size (source units) of this artifact. */
+  readonly cellSize?: number;
+  /** Whether ground classification was trusted for this artifact. */
+  readonly trustGroundClassification?: boolean;
+  /** The build revision that produced this artifact. */
+  readonly candidateRevision?: string;
+}
+
+/** The full resolution result. `effectiveEvidence` is what gates may act on. */
+export interface EvidenceResolution {
+  /** The baseline registry level for the claim (null for an unregistered claim). */
+  readonly baselineEvidence: EvidenceLevel | null;
+  /** The level after scoped overlay — baseline unless a record matched in scope. */
+  readonly effectiveEvidence: EvidenceLevel | null;
+  /** The matched study id when in-scope, else null. */
+  readonly matchedScopedStudy: string | null;
+  /** Human-readable applicability verdict, for provenance / notes. */
+  readonly applicabilityVerdict: string;
+  /** The explicit resolution state. */
+  readonly resolutionState: ResolutionState;
+}
+
+/**
+ * The keys whose absence from the context makes applicability UNKNOWN rather than
+ * merely out-of-scope. A record that pins any of these requires the context to
+ * supply it; a missing one means we cannot even establish whether the artifact
+ * is the validated method/CRS, so we fail closed to baseline.
+ */
+const SAFETY_CRITICAL: readonly (keyof ApplicabilityEnvelope)[] = [
+  'methodDigest',
+  'horizontalEpsg',
+  'verticalEpsg',
+  'geoidModel',
+];
+
+/**
+ * The runtime scoped-evidence record set. INTENTIONALLY EMPTY: no real field
+ * study exists yet, so nothing may raise a real artifact above its baseline. This
+ * is the only record set `resolveEvidence` consults by default, and it is an
+ * in-memory constant — no scoped JSON is read at import (keeping the bundle light
+ * and guaranteeing no committed file can affect the running app). Tests pass
+ * their own synthetic records explicitly.
+ */
+export const SCOPED_EVIDENCE_RECORDS: readonly ScopedEvidenceRecord[] = [];
+
+interface MatchOutcome {
+  readonly matched: boolean;
+  /** A safety-critical envelope key was set but missing from the context. */
+  readonly incomplete: boolean;
+}
+
+/** Does the artifact context fall inside this envelope? */
+function matchEnvelope(env: ApplicabilityEnvelope, ctx: EvidenceContext): MatchOutcome {
+  let incomplete = false;
+  let mismatch = false;
+  for (const key of Object.keys(env) as (keyof ApplicabilityEnvelope)[]) {
+    if (env[key] === undefined) continue;
+    if (key === 'slopeRange') {
+      const [lo, hi] = env.slopeRange as readonly [number, number];
+      const s = ctx.slopeDegrees;
+      // A missing or out-of-band slope is a mismatch (not a match); slope is not
+      // safety-critical, so it never yields "unknown", only "out-of-scope".
+      if (s === undefined || s < lo || s > hi) mismatch = true;
+      continue;
+    }
+    const ctxVal = (ctx as Record<string, unknown>)[key];
+    if (ctxVal === undefined) {
+      // A safety-critical key we cannot see ⇒ applicability unknown; any other
+      // constrained key we cannot see ⇒ conservatively out-of-scope.
+      if (SAFETY_CRITICAL.includes(key)) incomplete = true;
+      else mismatch = true;
+      continue;
+    }
+    if (ctxVal !== env[key]) mismatch = true;
+  }
+  return { matched: !mismatch && !incomplete, incomplete };
+}
+
+/** Map a baseline registry entry to its resolution state (no scoped overlay). */
+function baselineState(entry: RegistryEntry | undefined): ResolutionState {
+  if (!entry || !entry.exportAllowed) return 'refused';
+  if (meetsRequired(entry.current, entry.required)
+    && evidenceRank(entry.current) >= evidenceRank(INDEPENDENCE_FLOOR)) {
+    return 'cross-implementation';
+  }
+  return 'exploratory';
+}
+
+/**
+ * Resolve the effective evidence for a claim, given the artifact context and a
+ * record set (default: the empty shipped set). Pure and deterministic.
+ *
+ * Resolution order (fail-closed at every branch):
+ *   1. No scoped record for the claim ⇒ baseline (identical to today).
+ *   2. Scoped record(s) exist but no context ⇒ baseline, `applicability-unknown`.
+ *   3. A record's envelope matches ⇒ effective = max(scoped, baseline),
+ *      `validated-in-scope` (the highest matching scoped level wins).
+ *   4. No match, and the mismatch was a missing safety-critical key ⇒ baseline,
+ *      `applicability-unknown`.
+ *   5. No match with a complete context ⇒ baseline, `external-evidence-out-of-scope`.
+ */
+export function resolveEvidence(
+  claimId: string,
+  context?: EvidenceContext,
+  records: readonly ScopedEvidenceRecord[] = SCOPED_EVIDENCE_RECORDS,
+): EvidenceResolution {
+  const entry = EVIDENCE_REGISTRY[claimId];
+  const baseline = entry?.current ?? null;
+  const forClaim = records.filter((r) => r.claimId === claimId);
+
+  if (forClaim.length === 0) {
+    return {
+      baselineEvidence: baseline,
+      effectiveEvidence: baseline,
+      matchedScopedStudy: null,
+      applicabilityVerdict: 'No scoped external evidence is registered for this claim.',
+      resolutionState: baselineState(entry),
+    };
+  }
+
+  if (context === undefined) {
+    return {
+      baselineEvidence: baseline,
+      effectiveEvidence: baseline,
+      matchedScopedStudy: null,
+      applicabilityVerdict:
+        'Scoped external evidence exists for this claim, but no artifact context was '
+        + 'supplied; applicability cannot be established, so the baseline level stands.',
+      resolutionState: 'applicability-unknown',
+    };
+  }
+
+  let best: ScopedEvidenceRecord | null = null;
+  let anyIncomplete = false;
+  for (const r of forClaim) {
+    const { matched, incomplete } = matchEnvelope(r.applicabilityEnvelope, context);
+    if (incomplete) anyIncomplete = true;
+    if (matched) {
+      if (best === null || evidenceRank(r.evidenceLevel) > evidenceRank(best.evidenceLevel)) {
+        best = r;
+      }
+    }
+  }
+
+  if (best !== null) {
+    // The highest scoped level that matched, but never BELOW baseline.
+    const effective =
+      baseline !== null && evidenceRank(baseline) >= evidenceRank(best.evidenceLevel)
+        ? baseline
+        : best.evidenceLevel;
+    return {
+      baselineEvidence: baseline,
+      effectiveEvidence: effective,
+      matchedScopedStudy: best.studyId,
+      applicabilityVerdict:
+        `Artifact matches the registered envelope of study ${best.studyId}; `
+        + 'external field evidence applies in scope.',
+      resolutionState: 'validated-in-scope',
+    };
+  }
+
+  if (anyIncomplete) {
+    return {
+      baselineEvidence: baseline,
+      effectiveEvidence: baseline,
+      matchedScopedStudy: null,
+      applicabilityVerdict:
+        'Scoped external evidence exists, but the artifact context is missing a '
+        + 'safety-critical key (method digest / EPSG / geoid); applicability is '
+        + 'unknown, so the baseline level stands.',
+      resolutionState: 'applicability-unknown',
+    };
+  }
+
+  return {
+    baselineEvidence: baseline,
+    effectiveEvidence: baseline,
+    matchedScopedStudy: null,
+    applicabilityVerdict:
+      'External field evidence exists for this method, but this artifact is outside '
+      + 'every registered study envelope; the baseline level stands.',
+    resolutionState: 'external-evidence-out-of-scope',
+  };
+}

--- a/tests/scopedEvidence.test.ts
+++ b/tests/scopedEvidence.test.ts
@@ -1,0 +1,174 @@
+/**
+ * scopedEvidence.test.ts — the scoped external-evidence overlay MUST fail closed.
+ *
+ * Every case here uses SYNTHETIC in-memory records (no committed record ships): a
+ * scoped E5 record raises effective evidence ONLY for an artifact inside its
+ * envelope, and every mismatch — wrong method digest, wrong EPSG, wrong geoid,
+ * broadened stratum, or missing context — falls back to the baseline registry
+ * level. A committed record must be a non-claimable EXAMPLE template.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  resolveEvidence,
+  type ScopedEvidenceRecord,
+  type EvidenceContext,
+} from '../src/validation/scopedEvidence';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// A synthetic frozen-study record: DTM validated to E5 for one exact method,
+// CRS, geoid and terrain stratum. NOT a real study — test data only.
+const STUDY: ScopedEvidenceRecord = {
+  claimId: 'DTM',
+  evidenceLevel: 'E5_EXTERNALLY_VALIDATED',
+  studyId: 'SYNTH-STUDY-1',
+  methodDigest: 'digest-abc',
+  horizontalEpsg: 32613,
+  verticalEpsg: 5703,
+  geoidModel: 'GEOID18',
+  terrainStratum: 'bare-earth',
+  applicabilityEnvelope: {
+    methodDigest: 'digest-abc',
+    horizontalEpsg: 32613,
+    verticalEpsg: 5703,
+    geoidModel: 'GEOID18',
+    terrainStratum: 'bare-earth',
+  },
+};
+
+// The artifact context that exactly matches the study envelope.
+const IN_ENVELOPE: EvidenceContext = {
+  methodDigest: 'digest-abc',
+  horizontalEpsg: 32613,
+  verticalEpsg: 5703,
+  geoidModel: 'GEOID18',
+  terrainStratum: 'bare-earth',
+};
+
+const RECORDS = [STUDY];
+
+describe('resolveEvidence — scoped overlay fails closed', () => {
+  it('in-envelope artifact resolves to the scoped E5 (validated-in-scope)', () => {
+    const r = resolveEvidence('DTM', IN_ENVELOPE, RECORDS);
+    expect(r.effectiveEvidence).toBe('E5_EXTERNALLY_VALIDATED');
+    expect(r.resolutionState).toBe('validated-in-scope');
+    expect(r.matchedScopedStudy).toBe('SYNTH-STUDY-1');
+    expect(r.baselineEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+  });
+
+  it('wrong methodDigest → baseline (external-evidence-out-of-scope)', () => {
+    const r = resolveEvidence('DTM', { ...IN_ENVELOPE, methodDigest: 'digest-XXX' }, RECORDS);
+    expect(r.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(r.resolutionState).toBe('external-evidence-out-of-scope');
+    expect(r.matchedScopedStudy).toBeNull();
+  });
+
+  it('wrong horizontalEpsg → baseline (out-of-scope)', () => {
+    const r = resolveEvidence('DTM', { ...IN_ENVELOPE, horizontalEpsg: 32614 }, RECORDS);
+    expect(r.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(r.resolutionState).toBe('external-evidence-out-of-scope');
+  });
+
+  it('wrong verticalEpsg → baseline (out-of-scope)', () => {
+    const r = resolveEvidence('DTM', { ...IN_ENVELOPE, verticalEpsg: 5701 }, RECORDS);
+    expect(r.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(r.resolutionState).toBe('external-evidence-out-of-scope');
+  });
+
+  it('wrong geoidModel → baseline (out-of-scope)', () => {
+    const r = resolveEvidence('DTM', { ...IN_ENVELOPE, geoidModel: 'GEOID12B' }, RECORDS);
+    expect(r.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(r.resolutionState).toBe('external-evidence-out-of-scope');
+  });
+
+  it('broadened terrainStratum (forest) not in envelope → baseline (out-of-scope)', () => {
+    const r = resolveEvidence('DTM', { ...IN_ENVELOPE, terrainStratum: 'forest' }, RECORDS);
+    expect(r.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(r.resolutionState).toBe('external-evidence-out-of-scope');
+  });
+
+  it('NO context at all → baseline + applicability-unknown (conservative default)', () => {
+    const r = resolveEvidence('DTM', undefined, RECORDS);
+    expect(r.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(r.resolutionState).toBe('applicability-unknown');
+    expect(r.matchedScopedStudy).toBeNull();
+  });
+
+  it('incomplete context (missing safety-critical geoid) → applicability-unknown', () => {
+    const { geoidModel: _omit, ...partial } = IN_ENVELOPE;
+    const r = resolveEvidence('DTM', partial, RECORDS);
+    expect(r.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(r.resolutionState).toBe('applicability-unknown');
+  });
+});
+
+describe('resolveEvidence — regression: no scoped record resolves as baseline', () => {
+  it('a claim with NO scoped record resolves exactly as baseline (with default empty set)', () => {
+    const r = resolveEvidence('DTM', IN_ENVELOPE);
+    expect(r.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(r.baselineEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(r.matchedScopedStudy).toBeNull();
+    // DTM is E4 but its required bar is E5, so absent scope it stays exploratory.
+    expect(r.resolutionState).toBe('exploratory');
+  });
+
+  it('a claim that meets its E4 required bar reads cross-implementation', () => {
+    // DSM: current E4, required E4 — meets its bar at the independence floor.
+    const r = resolveEvidence('DSM');
+    expect(r.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(r.resolutionState).toBe('cross-implementation');
+  });
+
+  it('a below-required claim with no scoped record stays exploratory', () => {
+    const r = resolveEvidence('MEAS-DISTANCE');
+    expect(r.effectiveEvidence).toBe('E3_SYNTHETICALLY_VALIDATED');
+    expect(r.resolutionState).toBe('exploratory');
+  });
+
+  it('an unregistered claim is refused with a null baseline', () => {
+    const r = resolveEvidence('NOPE-NOT-A-CLAIM');
+    expect(r.baselineEvidence).toBeNull();
+    expect(r.effectiveEvidence).toBeNull();
+    expect(r.resolutionState).toBe('refused');
+  });
+});
+
+describe('committed scoped records cannot promote a real artifact', () => {
+  // A realistic real-artifact context that a real DTM export could carry.
+  const REAL: EvidenceContext = {
+    methodDigest: 'digest-abc',
+    horizontalEpsg: 32613,
+    verticalEpsg: 5703,
+    geoidModel: 'GEOID18',
+    terrainStratum: 'bare-earth',
+  };
+
+  const dir = resolve(ROOT, 'validation/evidence/scoped');
+  const files = readdirSync(dir).filter(
+    (f) => f.endsWith('.json') && !f.endsWith('.schema.json'),
+  );
+
+  it('there is at least one committed record file to check', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const f of files) {
+    it(`${f} is a non-claimable EXAMPLE template that cannot match a real artifact`, () => {
+      // Every committed record file must be an EXAMPLE- template.
+      expect(f.startsWith('EXAMPLE-')).toBe(true);
+      const rec = JSON.parse(readFileSync(resolve(dir, f), 'utf8')) as ScopedEvidenceRecord;
+      // Resolve any registered claim against the real artifact context using ONLY
+      // this committed record — it must never rise above baseline.
+      for (const claimId of ['DTM', 'DSM', 'CHM', rec.claimId]) {
+        const r = resolveEvidence(claimId, REAL, [rec]);
+        if (r.baselineEvidence !== null) {
+          expect(r.effectiveEvidence).toBe(r.baselineEvidence);
+        }
+        expect(r.resolutionState).not.toBe('validated-in-scope');
+      }
+    });
+  }
+});

--- a/validation/evidence/scoped/EXAMPLE-scoped-evidence.json
+++ b/validation/evidence/scoped/EXAMPLE-scoped-evidence.json
@@ -1,0 +1,30 @@
+{
+  "$comment": "TEMPLATE ONLY — NOT A REAL RECORD. No field study exists yet. This file documents the record shape and is deliberately NON-CLAIMABLE: its claimId is not a registered claim and its envelope values are sentinels, so it can never match a real artifact or raise any real product above its baseline. The running app never reads this file (SCOPED_EVIDENCE_RECORDS is empty). A real record is created only after a real, frozen study, replacing every EXAMPLE- sentinel with measured values.",
+  "claimId": "EXAMPLE-CLAIM-NOT-REGISTERED",
+  "evidenceLevel": "E5_EXTERNALLY_VALIDATED",
+  "studyId": "EXAMPLE-STUDY-DO-NOT-USE",
+  "candidateRevision": "EXAMPLE-REVISION",
+  "methodId": "EXAMPLE-METHOD",
+  "methodVersion": "0",
+  "methodDigest": "EXAMPLE-METHOD-DIGEST-DO-NOT-MATCH",
+  "horizontalEpsg": 0,
+  "verticalEpsg": 0,
+  "verticalDatum": "EXAMPLE-DATUM",
+  "geoidModel": "EXAMPLE-GEOID",
+  "cellSize": 0,
+  "aggregation": "EXAMPLE-AGGREGATION",
+  "interpolation": "EXAMPLE-INTERPOLATION",
+  "trustGroundClassification": false,
+  "terrainStratum": "EXAMPLE-STRATUM",
+  "slopeRange": [0, 0],
+  "supportState": "EXAMPLE — no checkpoints",
+  "studyArea": "EXAMPLE-AREA",
+  "surveyDate": "0001-01-01",
+  "applicabilityEnvelope": {
+    "methodDigest": "EXAMPLE-METHOD-DIGEST-DO-NOT-MATCH",
+    "horizontalEpsg": 0,
+    "verticalEpsg": 0,
+    "geoidModel": "EXAMPLE-GEOID",
+    "terrainStratum": "EXAMPLE-STRATUM"
+  }
+}

--- a/validation/evidence/scoped/scoped-evidence.schema.json
+++ b/validation/evidence/scoped/scoped-evidence.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://openlidarviewer/validation/evidence/scoped/scoped-evidence.schema.json",
+  "title": "Scoped external-evidence record",
+  "description": "A scoped external-evidence record raises a claim's effective evidence level (e.g. E5) ONLY for artifacts inside its applicability envelope. A record is created ONLY after a real, frozen field study with independent ground control. Until such a study exists, the only files here are EXAMPLE- templates that cannot match a real artifact. The running app never reads these files: the runtime record set (src/validation/scopedEvidence.ts SCOPED_EVIDENCE_RECORDS) is empty. Records are data passed explicitly to resolveEvidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["claimId", "evidenceLevel", "studyId", "applicabilityEnvelope"],
+  "properties": {
+    "claimId": {
+      "type": "string",
+      "description": "The registry claim id this record scopes (e.g. DTM)."
+    },
+    "evidenceLevel": {
+      "type": "string",
+      "enum": [
+        "E0_IMPLEMENTED",
+        "E1_UNIT_VERIFIED",
+        "E2_ANALYTICALLY_VERIFIED",
+        "E3_SYNTHETICALLY_VALIDATED",
+        "E4_CROSS_IMPLEMENTATION_VALIDATED",
+        "E5_EXTERNALLY_VALIDATED",
+        "E6_INDEPENDENTLY_REPRODUCED"
+      ],
+      "description": "The evidence level this study establishes inside its envelope."
+    },
+    "studyId": { "type": "string", "description": "Stable study identifier." },
+    "candidateRevision": { "type": "string" },
+    "methodId": { "type": "string" },
+    "methodVersion": { "type": "string" },
+    "methodDigest": { "type": "string", "description": "Digest of the validated method (method-match anchor)." },
+    "horizontalEpsg": { "type": "integer" },
+    "verticalEpsg": { "type": "integer" },
+    "verticalDatum": { "type": "string" },
+    "geoidModel": { "type": "string" },
+    "cellSize": { "type": "number" },
+    "aggregation": { "type": "string" },
+    "interpolation": { "type": "string" },
+    "trustGroundClassification": { "type": "boolean" },
+    "terrainStratum": { "type": "string" },
+    "slopeRange": {
+      "type": "array",
+      "items": { "type": "number" },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "supportState": { "type": "string" },
+    "studyArea": { "type": "string" },
+    "surveyDate": { "type": "string" },
+    "applicabilityEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The matching predicate. Any key set here becomes a hard constraint the artifact context must satisfy exactly (slopeRange is a containment band). Missing safety-critical keys in the context (methodDigest, horizontalEpsg, verticalEpsg, geoidModel) yield applicability-unknown, not a match.",
+      "properties": {
+        "methodDigest": { "type": "string" },
+        "horizontalEpsg": { "type": "integer" },
+        "verticalEpsg": { "type": "integer" },
+        "geoidModel": { "type": "string" },
+        "verticalDatum": { "type": "string" },
+        "terrainStratum": { "type": "string" },
+        "studyArea": { "type": "string" },
+        "slopeRange": {
+          "type": "array",
+          "items": { "type": "number" },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "aggregation": { "type": "string" },
+        "interpolation": { "type": "string" },
+        "cellSize": { "type": "number" },
+        "trustGroundClassification": { "type": "boolean" },
+        "candidateRevision": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Evidence gating evaluated one global level per claim, so any dataset would inherit an E5 the moment DTM's level were raised. This adds a scoped overlay so external field validation applies only inside a registered study envelope.

`resolveEvidence(claimId, context, records)` returns the highest scoped level whose envelope matches the artifact context, else the baseline. A match needs exact agreement on the safety-critical keys — method digest, horizontal/vertical EPSG, geoid model — plus any envelope key a record sets. Absent or incomplete context yields `applicability-unknown` at baseline; out-of-envelope yields `external-evidence-out-of-scope`. The shipped record set is empty and the sole committed file is a non-claimable EXAMPLE template, so no real product rises above baseline. Wired into the export evidence note and terrain provenance. Adversarial tests cover method/EPSG/geoid/stratum mismatch and the no-context default.