### PR TITLE
e5: per-tile ASPRS class histograms for the input manifests

### DIFF
--- a/scripts/e5/enrich-class-histogram.mjs
+++ b/scripts/e5/enrich-class-histogram.mjs
@@ -12,9 +12,10 @@
  *
  * Usage: node scripts/e5/enrich-class-histogram.mjs <dir> <manifest.json>
  */
-import { readFileSync, writeFileSync, writeSync } from 'node:fs';
+import { readFileSync, writeFileSync, writeSync, mkdtempSync, rmSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 
 const [, , dir, manifestPath] = process.argv;
 if (!dir || !manifestPath) {
@@ -28,12 +29,18 @@ function classHistogram(path) {
     { type: 'readers.las', filename: path },
     { type: 'filters.stats', count: 'Classification' },
   ]);
-  const tmp = `/tmp/e5-hist-${process.pid}.json`;
-  writeFileSync(tmp, pipeline);
-  execFileSync('pdal', ['pipeline', tmp, '--metadata', `/tmp/e5-meta-${process.pid}.json`], {
-    maxBuffer: 64 << 20,
-  });
-  const meta = JSON.parse(readFileSync(`/tmp/e5-meta-${process.pid}.json`, 'utf8'));
+  // A private, unpredictable temp dir (0700) — not a fixed/PID-derived path.
+  const dir = mkdtempSync(join(tmpdir(), 'e5-hist-'));
+  const plPath = join(dir, 'pipeline.json');
+  const metaPath = join(dir, 'meta.json');
+  let meta;
+  try {
+    writeFileSync(plPath, pipeline);
+    execFileSync('pdal', ['pipeline', plPath, '--metadata', metaPath], { maxBuffer: 64 << 20 });
+    meta = JSON.parse(readFileSync(metaPath, 'utf8'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
   let counts = null;
   const walk = (o) => {
     if (counts) return;

--- a/scripts/e5/enrich-class-histogram.mjs
+++ b/scripts/e5/enrich-class-histogram.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * enrich-class-histogram.mjs — add per-tile ASPRS class histograms to an E5
+ * input manifest.
+ *
+ * The header-only manifest records point counts but not how those points are
+ * classified; the DTM candidate consumes producer Class-2 ground returns, so the
+ * manifest should state, per tile, how many Class-2 points exist. This runs a
+ * full PDAL point scan (filters.stats count:Classification) per tile, records the
+ * exact per-class counts, and derives a ground fraction. Counts are read from the
+ * file; nothing is invented.
+ *
+ * Usage: node scripts/e5/enrich-class-histogram.mjs <dir> <manifest.json>
+ */
+import { readFileSync, writeFileSync, writeSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+
+const [, , dir, manifestPath] = process.argv;
+if (!dir || !manifestPath) {
+  console.error('usage: enrich-class-histogram.mjs <dir> <manifest.json>');
+  process.exit(2);
+}
+const GROUND_CLASS = 2;
+
+function classHistogram(path) {
+  const pipeline = JSON.stringify([
+    { type: 'readers.las', filename: path },
+    { type: 'filters.stats', count: 'Classification' },
+  ]);
+  const tmp = `/tmp/e5-hist-${process.pid}.json`;
+  writeFileSync(tmp, pipeline);
+  execFileSync('pdal', ['pipeline', tmp, '--metadata', `/tmp/e5-meta-${process.pid}.json`], {
+    maxBuffer: 64 << 20,
+  });
+  const meta = JSON.parse(readFileSync(`/tmp/e5-meta-${process.pid}.json`, 'utf8'));
+  let counts = null;
+  const walk = (o) => {
+    if (counts) return;
+    if (Array.isArray(o)) return o.forEach(walk);
+    if (o && typeof o === 'object') {
+      if (o.name === 'Classification' && Array.isArray(o.counts)) {
+        counts = o.counts;
+        return;
+      }
+      Object.values(o).forEach(walk);
+    }
+  };
+  walk(meta);
+  if (!counts) throw new Error('no Classification counts in pdal output');
+  // Each entry is "value/count" as decimal strings.
+  const hist = {};
+  for (const e of counts) {
+    const [v, c] = e.split('/');
+    hist[String(Math.round(Number(v)))] = Number(c);
+  }
+  return hist;
+}
+
+const manifest = JSON.parse(readFileSync(resolve(manifestPath), 'utf8'));
+let collGround = 0;
+let collTotal = 0;
+for (const tile of manifest.tiles) {
+  const hist = classHistogram(join(dir, tile.basename));
+  const ground = hist[String(GROUND_CLASS)] ?? 0;
+  const total = Object.values(hist).reduce((a, b) => a + b, 0);
+  tile.classHistogram = hist;
+  tile.groundPointCount = ground;
+  tile.groundPointFraction = total > 0 ? Number((ground / total).toFixed(6)) : 0;
+  collGround += ground;
+  collTotal += total;
+  writeSync(2, `  ${tile.basename}  ground=${ground}  frac=${tile.groundPointFraction}\n`);
+}
+manifest.summary.groundPointFraction = collTotal > 0 ? Number((collGround / collTotal).toFixed(6)) : 0;
+manifest.summary.allTilesHaveGround = manifest.tiles.every((t) => t.groundPointCount > 0);
+manifest.$schemaNote = manifest.$schemaNote.replace(
+  'collectionDigest fixes',
+  'Per-tile class histograms are exact point-scan counts. collectionDigest fixes',
+);
+writeFileSync(resolve(manifestPath), JSON.stringify(manifest, null, 2) + '\n');
+writeSync(
+  2,
+  `\n→ ${manifestPath}: groundPointFraction=${manifest.summary.groundPointFraction}, allTilesHaveGround=${manifest.summary.allTilesHaveGround}\n`,
+);

--- a/validation/e5/manifests/HOUSTON17.input.json
+++ b/validation/e5/manifests/HOUSTON17.input.json
@@ -1,5 +1,5 @@
 {
-  "$schemaNote": "Immutable input manifest for an E5 LAZ collection. Every field is read from the file header; a null is an unknown the header did not carry, never a guess. collectionDigest fixes the exact set of input bytes. This manifest is input to a product-under-test, not field truth.",
+  "$schemaNote": "Immutable input manifest for an E5 LAZ collection. Every field is read from the file header; a null is an unknown the header did not carry, never a guess. Per-tile class histograms are exact point-scan counts. collectionDigest fixes the exact set of input bytes. This manifest is input to a product-under-test, not field truth.",
   "collectionId": "HOUSTON17",
   "role": "candidate-input",
   "generatedFrom": "pdal info --metadata (header only)",
@@ -28,7 +28,12 @@
     "captureYears": [
       2025
     ],
-    "homogeneousFrame": true
+    "homogeneousFrame": true,
+    "groundPointFraction": 0.518853,
+    "allTilesHaveGround": false,
+    "tilesWithoutGround": [
+      "USGS_LPC_TX_Houston_B24_15RTM262193.laz"
+    ]
   },
   "tiles": [
     {
@@ -55,7 +60,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 1547798,
+        "2": 3815575,
+        "7": 5869,
+        "9": 1604892,
+        "18": 12,
+        "20": 9620
+      },
+      "groundPointCount": 3815575,
+      "groundPointFraction": 0.546349
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260194.laz",
@@ -81,7 +96,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 1598375,
+        "2": 3271916,
+        "7": 3421,
+        "9": 1951739,
+        "18": 15,
+        "20": 10553
+      },
+      "groundPointCount": 3271916,
+      "groundPointFraction": 0.478629
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260195.laz",
@@ -107,7 +132,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 2753990,
+        "2": 4010654,
+        "7": 2810,
+        "9": 1820656,
+        "18": 29,
+        "20": 31267
+      },
+      "groundPointCount": 4010654,
+      "groundPointFraction": 0.465305
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260196.laz",
@@ -133,7 +168,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 4251555,
+        "2": 4970947,
+        "7": 4799,
+        "9": 578796,
+        "18": 82,
+        "20": 12775
+      },
+      "groundPointCount": 4970947,
+      "groundPointFraction": 0.50626
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260197.laz",
@@ -159,7 +204,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 1676780,
+        "2": 3336106,
+        "7": 2977,
+        "9": 2067381,
+        "18": 24,
+        "20": 9554
+      },
+      "groundPointCount": 3336106,
+      "groundPointFraction": 0.47035
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260198.laz",
@@ -185,7 +240,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 2172750,
+        "2": 4534456,
+        "7": 3432,
+        "9": 1198031,
+        "18": 287,
+        "20": 10968
+      },
+      "groundPointCount": 4534456,
+      "groundPointFraction": 0.572538
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260199.laz",
@@ -211,7 +276,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 2045278,
+        "2": 3610036,
+        "7": 4144,
+        "9": 831237,
+        "18": 17,
+        "20": 27681
+      },
+      "groundPointCount": 3610036,
+      "groundPointFraction": 0.553823
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261193.laz",
@@ -237,7 +312,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 1115984,
+        "2": 1339152,
+        "7": 13180,
+        "9": 714492,
+        "18": 8,
+        "20": 2640
+      },
+      "groundPointCount": 1339152,
+      "groundPointFraction": 0.420396
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261194.laz",
@@ -263,7 +348,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 4545930,
+        "2": 6696160,
+        "7": 1099,
+        "9": 57297,
+        "18": 30,
+        "20": 17128
+      },
+      "groundPointCount": 6696160,
+      "groundPointFraction": 0.591657
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261195.laz",
@@ -289,7 +384,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 5626372,
+        "2": 5864177,
+        "7": 4208,
+        "9": 144168,
+        "18": 59,
+        "20": 16589
+      },
+      "groundPointCount": 5864177,
+      "groundPointFraction": 0.503122
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261196.laz",
@@ -315,7 +420,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 6386864,
+        "2": 5396942,
+        "7": 6427,
+        "9": 163113,
+        "18": 73,
+        "20": 13871
+      },
+      "groundPointCount": 5396942,
+      "groundPointFraction": 0.450974
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261197.laz",
@@ -341,7 +456,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 4919871,
+        "2": 7121011,
+        "7": 1237,
+        "9": 22819,
+        "18": 22,
+        "20": 30369
+      },
+      "groundPointCount": 7121011,
+      "groundPointFraction": 0.588741
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261198.laz",
@@ -367,7 +492,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 4354379,
+        "2": 5720691,
+        "7": 2371,
+        "9": 168670,
+        "18": 38,
+        "20": 29090
+      },
+      "groundPointCount": 5720691,
+      "groundPointFraction": 0.556745
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261199.laz",
@@ -393,7 +528,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 4306801,
+        "2": 4227077,
+        "7": 4444,
+        "9": 354755,
+        "18": 46,
+        "20": 42645
+      },
+      "groundPointCount": 4227077,
+      "groundPointFraction": 0.473051
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM262193.laz",
@@ -419,7 +564,15 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 1028285,
+        "7": 10058,
+        "9": 2655296,
+        "18": 51
+      },
+      "groundPointCount": 0,
+      "groundPointFraction": 0
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM262194.laz",
@@ -445,7 +598,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 3092749,
+        "2": 6848517,
+        "7": 2379,
+        "9": 1130906,
+        "18": 57,
+        "20": 15515
+      },
+      "groundPointCount": 6848517,
+      "groundPointFraction": 0.617533
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM262195.laz",
@@ -471,7 +634,17 @@
       "captureYear": 2025,
       "captureDayOfYear": 175,
       "systemId": "AR15J AR15S",
-      "softwareId": "NV5 Geospatial Lidar Suite"
+      "softwareId": "NV5 Geospatial Lidar Suite",
+      "classHistogram": {
+        "1": 4409814,
+        "2": 7351768,
+        "7": 1073,
+        "9": 767710,
+        "18": 28,
+        "20": 17705
+      },
+      "groundPointCount": 7351768,
+      "groundPointFraction": 0.585887
     }
   ]
 }

--- a/validation/e5/manifests/ROGUE25.input.json
+++ b/validation/e5/manifests/ROGUE25.input.json
@@ -1,5 +1,5 @@
 {
-  "$schemaNote": "Immutable input manifest for an E5 LAZ collection. Every field is read from the file header; a null is an unknown the header did not carry, never a guess. collectionDigest fixes the exact set of input bytes. This manifest is input to a product-under-test, not field truth.",
+  "$schemaNote": "Immutable input manifest for an E5 LAZ collection. Every field is read from the file header; a null is an unknown the header did not carry, never a guess. Per-tile class histograms are exact point-scan counts. collectionDigest fixes the exact set of input bytes. This manifest is input to a product-under-test, not field truth.",
   "collectionId": "ROGUE25",
   "role": "reference-labelling",
   "generatedFrom": "pdal info --metadata (header only)",
@@ -28,7 +28,10 @@
     "captureYears": [
       2021
     ],
-    "homogeneousFrame": true
+    "homogeneousFrame": true,
+    "groundPointFraction": 0.051273,
+    "allTilesHaveGround": true,
+    "tilesWithoutGround": []
   },
   "tiles": [
     {
@@ -55,7 +58,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 15,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 19958442,
+        "2": 2271741,
+        "7": 48067,
+        "18": 19043
+      },
+      "groundPointCount": 2271741,
+      "groundPointFraction": 0.101884
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3746.laz",
@@ -81,7 +92,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 15,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 23091197,
+        "2": 943274,
+        "7": 27069,
+        "18": 1634
+      },
+      "groundPointCount": 943274,
+      "groundPointFraction": 0.0392
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3846.laz",
@@ -107,7 +126,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 19,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 29223270,
+        "2": 1501277,
+        "7": 49912,
+        "18": 2122
+      },
+      "groundPointCount": 1501277,
+      "groundPointFraction": 0.04878
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3847.laz",
@@ -133,7 +160,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 30425508,
+        "2": 1292536,
+        "7": 33772,
+        "18": 22081
+      },
+      "groundPointCount": 1292536,
+      "groundPointFraction": 0.040679
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4544.laz",
@@ -159,7 +194,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 66162976,
+        "2": 3100790,
+        "7": 85278,
+        "18": 5130
+      },
+      "groundPointCount": 3100790,
+      "groundPointFraction": 0.044709
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4643.laz",
@@ -185,7 +228,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 45007631,
+        "2": 2094282,
+        "7": 68557,
+        "18": 186
+      },
+      "groundPointCount": 2094282,
+      "groundPointFraction": 0.044398
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4647.laz",
@@ -211,7 +262,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 50395808,
+        "2": 3143952,
+        "7": 77454,
+        "18": 53634
+      },
+      "groundPointCount": 3143952,
+      "groundPointFraction": 0.058578
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4648.laz",
@@ -237,7 +296,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 44317274,
+        "2": 2830970,
+        "7": 71043,
+        "18": 26056
+      },
+      "groundPointCount": 2830970,
+      "groundPointFraction": 0.059921
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4849.laz",
@@ -263,7 +330,16 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 35068999,
+        "2": 2365666,
+        "7": 32316,
+        "17": 1849,
+        "18": 89
+      },
+      "groundPointCount": 2365666,
+      "groundPointFraction": 0.063137
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4853.laz",
@@ -289,7 +365,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 34461240,
+        "2": 3257965,
+        "7": 44195,
+        "18": 140245
+      },
+      "groundPointCount": 3257965,
+      "groundPointFraction": 0.085954
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM5450.laz",
@@ -315,7 +399,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 42664938,
+        "2": 3117666,
+        "7": 38460,
+        "18": 78
+      },
+      "groundPointCount": 3117666,
+      "groundPointFraction": 0.06804
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM5458.laz",
@@ -341,7 +433,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 34965251,
+        "2": 2774198,
+        "7": 62442,
+        "18": 143
+      },
+      "groundPointCount": 2774198,
+      "groundPointFraction": 0.073388
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM5959.laz",
@@ -367,7 +467,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 24374343,
+        "2": 1288446,
+        "7": 25861,
+        "18": 568
+      },
+      "groundPointCount": 1288446,
+      "groundPointFraction": 0.050155
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6151.laz",
@@ -393,7 +501,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 72220390,
+        "2": 3741335,
+        "7": 119223,
+        "18": 1169
+      },
+      "groundPointCount": 3741335,
+      "groundPointFraction": 0.049175
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6152.laz",
@@ -419,7 +535,17 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 66357574,
+        "2": 3392043,
+        "7": 126494,
+        "9": 18524,
+        "18": 1813,
+        "20": 1002
+      },
+      "groundPointCount": 3392043,
+      "groundPointFraction": 0.048529
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6159.laz",
@@ -445,7 +571,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 56597232,
+        "2": 2077348,
+        "7": 52442,
+        "18": 1320
+      },
+      "groundPointCount": 2077348,
+      "groundPointFraction": 0.035372
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6161.laz",
@@ -471,7 +605,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 35903727,
+        "2": 1386073,
+        "7": 41040,
+        "18": 2443
+      },
+      "groundPointCount": 1386073,
+      "groundPointFraction": 0.037127
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6252.laz",
@@ -497,7 +639,17 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 36172816,
+        "2": 3184591,
+        "7": 116426,
+        "9": 88311,
+        "18": 1645,
+        "20": 1692
+      },
+      "groundPointCount": 3184591,
+      "groundPointFraction": 0.080489
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6265.laz",
@@ -523,7 +675,16 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 33776781,
+        "2": 1492472,
+        "7": 37403,
+        "17": 3525,
+        "18": 82
+      },
+      "groundPointCount": 1492472,
+      "groundPointFraction": 0.042267
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6455.laz",
@@ -549,7 +710,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 87171959,
+        "2": 2321716,
+        "7": 73596,
+        "18": 262
+      },
+      "groundPointCount": 2321716,
+      "groundPointFraction": 0.025921
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6470.laz",
@@ -575,7 +744,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 32217746,
+        "2": 2567171,
+        "7": 41697,
+        "18": 133
+      },
+      "groundPointCount": 2567171,
+      "groundPointFraction": 0.073713
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6564.laz",
@@ -601,7 +778,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 47370509,
+        "2": 2007655,
+        "7": 66368,
+        "18": 885
+      },
+      "groundPointCount": 2007655,
+      "groundPointFraction": 0.040603
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6762.laz",
@@ -627,7 +812,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 68645375,
+        "2": 2953884,
+        "7": 60319,
+        "18": 702
+      },
+      "groundPointCount": 2953884,
+      "groundPointFraction": 0.041221
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM7851.laz",
@@ -653,7 +846,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 36012954,
+        "2": 3050534,
+        "7": 80093,
+        "18": 410
+      },
+      "groundPointCount": 3050534,
+      "groundPointFraction": 0.077931
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM8061.laz",
@@ -679,7 +880,15 @@
       "captureYear": 2021,
       "captureDayOfYear": 12,
       "systemId": "Quantum Spatial",
-      "softwareId": "LasMonkey 2.6.2"
+      "softwareId": "LasMonkey 2.6.2",
+      "classHistogram": {
+        "1": 66581691,
+        "2": 2431337,
+        "7": 83881,
+        "18": 142
+      },
+      "groundPointCount": 2431337,
+      "groundPointFraction": 0.035187
     }
   ]
 }


### PR DESCRIPTION
Enriches both E5 input manifests with an exact per-tile classification histogram from a full PDAL point scan (filters.stats count:Classification), plus a derived ground-point count and fraction per tile and per collection.

Findings recorded from the files, not assumed:
- Houston-B24: Class-2 ground present in 16 of 17 tiles, collection ground fraction 0.52. One tile (15RTM262193) has zero ground (water/unclassified only) and is listed in tilesWithoutGround rather than dropped — information for eligibility screening, not a convenient exclusion.
- Rogue-Siskiyou: 0.05 ground across all 25 tiles, the expected dense-canopy figure.

Validation data only; no src/bundle changes.