### PR TITLE
e5: deterministic exposure-honest Rogue dev/holdout split (§18)

### DIFF
--- a/scripts/e5/build-rogue-split.mjs
+++ b/scripts/e5/build-rogue-split.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * build-rogue-split.mjs — deterministic, exposure-honest dev/holdout split of the
+ * 25 Rogue tiles for retrospective E5 hardening.
+ *
+ * Rogue is a RETROSPECTIVE development set; it never becomes E5. To keep a
+ * holdout honest, any tile the repository has already used (register, tests,
+ * committed metrics) is EXPOSED and forced into development — it cannot serve as
+ * an untouched holdout. The remaining unexposed tiles are split by a fixed rule:
+ * order by sha256("ROGUE-E5-HARDENING-v1" + fileSha256), fill development to the
+ * target, the rest are holdout. The ordering depends only on file content and a
+ * constant salt, so the split is reproducible and independent of tile id or
+ * order in the manifest.
+ *
+ * Usage: node scripts/e5/build-rogue-split.mjs <ROGUE25.input.json> <out.split.json>
+ */
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { resolve, dirname, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const [, , inPath, outPath] = process.argv;
+if (!inPath || !outPath) {
+  console.error('usage: build-rogue-split.mjs <input-manifest> <out.split.json>');
+  process.exit(2);
+}
+const SALT = 'ROGUE-E5-HARDENING-v1';
+const TARGET_DEV = 17;
+const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..', '..');
+
+const manifest = JSON.parse(readFileSync(resolve(inPath), 'utf8'));
+const tileId = (basename) => (basename.match(/10T[A-Z]{2}\d+/) ?? [basename])[0];
+
+/** Every tracked file (git ls-files), so exposure detection is over the repo. */
+const tracked = execFileSync('git', ['ls-files'], { cwd: ROOT, maxBuffer: 32 << 20 })
+  .toString()
+  .split('\n')
+  .filter(Boolean)
+  // A tile id appearing only in the E5 input/split manifests is not "use".
+  .filter((f) => !/validation\/e5\/manifests\/(ROGUE25|HOUSTON17)\.input\.json$/.test(f))
+  .filter((f) => !f.endsWith('ROGUE25.split.json'));
+
+/** Is this tile id referenced by any tracked file other than the manifests? */
+function isExposed(id) {
+  try {
+    execFileSync('git', ['grep', '-l', id, '--', ...tracked], { cwd: ROOT, maxBuffer: 32 << 20 });
+    return true;
+  } catch {
+    return false; // git grep exits non-zero when there is no match
+  }
+}
+
+const tiles = manifest.tiles.map((t) => {
+  const id = tileId(t.basename);
+  return {
+    tileId: id,
+    basename: t.basename,
+    sha256: t.sha256,
+    exposed: isExposed(id),
+    orderKey: createHash('sha256').update(SALT + t.sha256).digest('hex'),
+  };
+});
+
+const exposed = tiles.filter((t) => t.exposed);
+const unexposed = tiles.filter((t) => !t.exposed).sort((a, b) => a.orderKey.localeCompare(b.orderKey));
+
+const devFromUnexposed = Math.max(0, TARGET_DEV - exposed.length);
+const assign = (t, set) => ({ tileId: t.tileId, basename: t.basename, sha256: t.sha256, exposed: t.exposed, set });
+const assigned = [
+  ...exposed.map((t) => assign(t, 'development')), // exposed → forced development
+  ...unexposed.slice(0, devFromUnexposed).map((t) => assign(t, 'development')),
+  ...unexposed.slice(devFromUnexposed).map((t) => assign(t, 'holdout')),
+].sort((a, b) => a.tileId.localeCompare(b.tileId));
+
+const dev = assigned.filter((t) => t.set === 'development');
+const holdout = assigned.filter((t) => t.set === 'holdout');
+const splitDigest = createHash('sha256')
+  .update(assigned.map((t) => `${t.tileId}:${t.set}`).join('\n'))
+  .digest('hex');
+
+const out = {
+  $schemaNote:
+    'Deterministic exposure-honest dev/holdout split of the 25 Rogue tiles for RETROSPECTIVE E5 hardening. Rogue never becomes E5. Exposed tiles (already used anywhere in the repo) are forced into development; unexposed tiles are ordered by sha256(salt + fileSha256) and filled to the development target, the rest holdout. Reproducible from the input manifest alone.',
+  policy: {
+    salt: SALT,
+    targetDevelopment: TARGET_DEV,
+    rule: 'exposed → development; unexposed ordered by sha256(salt+fileSha256), first (target − exposed) → development, rest → holdout',
+  },
+  inputCollectionDigest: manifest.collectionDigest,
+  splitDigest,
+  summary: {
+    total: assigned.length,
+    development: dev.length,
+    holdout: holdout.length,
+    exposedForcedToDevelopment: exposed.map((t) => t.tileId),
+  },
+  tiles: assigned,
+};
+writeFileSync(resolve(outPath), JSON.stringify(out, null, 2) + '\n');
+console.error(
+  `→ ${outPath}: ${dev.length} development / ${holdout.length} holdout, ${exposed.length} exposed forced to dev, splitDigest ${splitDigest.slice(0, 12)}…`,
+);

--- a/tests/rogueSplit.test.ts
+++ b/tests/rogueSplit.test.ts
@@ -1,0 +1,74 @@
+/**
+ * rogueSplit.test.ts — invariants of the retrospective Rogue dev/holdout split.
+ *
+ * Rogue is a retrospective hardening set and never becomes E5; the split only has
+ * to be honest and reproducible. These checks pin the properties a reader relies
+ * on: an exposed tile (already used anywhere in the repo) is never in the holdout,
+ * the holdout is entirely unexposed, the split covers exactly the input tiles, and
+ * the recorded splitDigest is the digest of the recorded assignment.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p: string) => JSON.parse(readFileSync(resolve(ROOT, p), 'utf8'));
+const split = read('validation/e5/splits/ROGUE25.split.json') as {
+  policy: { targetDevelopment: number };
+  inputCollectionDigest: string;
+  splitDigest: string;
+  summary: { total: number; development: number; holdout: number; exposedForcedToDevelopment: string[] };
+  tiles: { tileId: string; sha256: string; exposed: boolean; set: 'development' | 'holdout' }[];
+};
+const input = read('validation/e5/manifests/ROGUE25.input.json') as {
+  collectionDigest: string;
+  tiles: { sha256: string }[];
+};
+
+describe('rogue dev/holdout split', () => {
+  it('covers exactly the 25 input tiles (sha256 set equality)', () => {
+    expect(split.tiles).toHaveLength(input.tiles.length);
+    const a = split.tiles.map((t) => t.sha256).sort();
+    const b = input.tiles.map((t) => t.sha256).sort();
+    expect(a).toEqual(b);
+  });
+
+  it('is tied to the input collection it was built from', () => {
+    expect(split.inputCollectionDigest).toBe(input.collectionDigest);
+  });
+
+  it('no exposed tile is in the holdout (the honesty invariant)', () => {
+    const leaked = split.tiles.filter((t) => t.exposed && t.set === 'holdout');
+    expect(leaked, `exposed tiles leaked into holdout: ${leaked.map((t) => t.tileId).join(', ')}`).toEqual([]);
+  });
+
+  it('the holdout is entirely unexposed', () => {
+    for (const t of split.tiles.filter((t) => t.set === 'holdout')) {
+      expect(t.exposed, `${t.tileId} in holdout must be unexposed`).toBe(false);
+    }
+  });
+
+  it('development meets the target and the counts are consistent', () => {
+    expect(split.summary.development).toBe(split.tiles.filter((t) => t.set === 'development').length);
+    expect(split.summary.holdout).toBe(split.tiles.filter((t) => t.set === 'holdout').length);
+    expect(split.summary.development + split.summary.holdout).toBe(split.summary.total);
+    expect(split.summary.development).toBe(split.policy.targetDevelopment);
+  });
+
+  it('every recorded exposed-forced tile is exposed and in development', () => {
+    for (const id of split.summary.exposedForcedToDevelopment) {
+      const t = split.tiles.find((x) => x.tileId === id)!;
+      expect(t.exposed).toBe(true);
+      expect(t.set).toBe('development');
+    }
+  });
+
+  it('the recorded splitDigest is the digest of the recorded assignment', () => {
+    const recomputed = createHash('sha256')
+      .update([...split.tiles].sort((a, b) => a.tileId.localeCompare(b.tileId)).map((t) => `${t.tileId}:${t.set}`).join('\n'))
+      .digest('hex');
+    expect(recomputed).toBe(split.splitDigest);
+  });
+});

--- a/validation/e5/splits/ROGUE25.split.json
+++ b/validation/e5/splits/ROGUE25.split.json
@@ -1,0 +1,195 @@
+{
+  "$schemaNote": "Deterministic exposure-honest dev/holdout split of the 25 Rogue tiles for RETROSPECTIVE E5 hardening. Rogue never becomes E5. Exposed tiles (already used anywhere in the repo) are forced into development; unexposed tiles are ordered by sha256(salt + fileSha256) and filled to the development target, the rest holdout. Reproducible from the input manifest alone.",
+  "policy": {
+    "salt": "ROGUE-E5-HARDENING-v1",
+    "targetDevelopment": 17,
+    "rule": "exposed → development; unexposed ordered by sha256(salt+fileSha256), first (target − exposed) → development, rest → holdout"
+  },
+  "inputCollectionDigest": "c8b8ce14d4d5204ba64aec243e028e14722bd7285e0ec98a93018f859d6d4d4b",
+  "splitDigest": "c156406a475805fc932ec871da95c4b9f33dc7529bef30d154b84e60ace22b05",
+  "summary": {
+    "total": 25,
+    "development": 17,
+    "holdout": 8,
+    "exposedForcedToDevelopment": [
+      "10TDM3746"
+    ]
+  },
+  "tiles": [
+    {
+      "tileId": "10TDM3449",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3449.laz",
+      "sha256": "841d20f45458c974e9559207acf88816c6ea3f375cb2261819c2cc9609fb05d4",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM3746",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3746.laz",
+      "sha256": "ba8b7a3b08a05a190896013d701348d00dc843f03f36654329160bb66def15c3",
+      "exposed": true,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM3846",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3846.laz",
+      "sha256": "a5b08f543f12a965aafb69b0984fd0d939428c16d48ee56dc8e0213252dea89e",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM3847",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3847.laz",
+      "sha256": "01533fd14536eda2d8e12209bcf28e41ac7096fcd781ef00217471db62340511",
+      "exposed": false,
+      "set": "holdout"
+    },
+    {
+      "tileId": "10TDM4544",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4544.laz",
+      "sha256": "b31ad5cf1e38028f299cb096c42d4ff4971bc7df8a61e2ae8d7e10c1996215a2",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM4643",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4643.laz",
+      "sha256": "5e1515bc02bf048c18576c3b613d14f150931a5eb0943a11bf2bb83978597fb0",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM4647",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4647.laz",
+      "sha256": "2f961da5f485ad38cc0f2676c126ae1c287fdec779b9e6b70372c521d6f14276",
+      "exposed": false,
+      "set": "holdout"
+    },
+    {
+      "tileId": "10TDM4648",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4648.laz",
+      "sha256": "e196d76c8953b16ac625cbaf6c9bbc991a2d40b70e0d923f133821b9bfe7fc4d",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM4849",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4849.laz",
+      "sha256": "7079f83f209be1a46b44a343857ee1d5cee9e8100d602a95dd5489e2bc50b0ac",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM4853",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4853.laz",
+      "sha256": "2d918692cf60d2c26d835dd9376b259bc1347300271ab96c0208dfc27ee39127",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM5450",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM5450.laz",
+      "sha256": "8e0e5877e8d697ca8b3957c8d1e23ccf89af373353978840e2bc87f9a500125c",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM5458",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM5458.laz",
+      "sha256": "c4772da1adf5967df5b815ae8ab677af2150b7a57f44bb9519aa04f7d1607c4a",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM5959",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM5959.laz",
+      "sha256": "da0de7a9048e3acb91a7f1b533f441a81012182d16b4c4f5aef5078b534386da",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM6151",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6151.laz",
+      "sha256": "edf7a0c890b2e0a11a059b45929708f5cf9ae15558480d78a0f7f58373013f04",
+      "exposed": false,
+      "set": "holdout"
+    },
+    {
+      "tileId": "10TDM6152",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6152.laz",
+      "sha256": "10480ed0eb0f965214fee6cef4860a2a4e60df4303f65269322aff14d1cc0689",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM6159",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6159.laz",
+      "sha256": "a1b1753cfd06a03b80dfc0d7073a4e48f079f1a218919501811d3fe5791abe79",
+      "exposed": false,
+      "set": "holdout"
+    },
+    {
+      "tileId": "10TDM6161",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6161.laz",
+      "sha256": "bb4a3f6be595d2c800173537eaef8360088b0619b995a89281fa208015b7f8ac",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM6252",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6252.laz",
+      "sha256": "a8cc9fc5c6ec17155c3956df0f92eaea035b1c45801c24d2a73ae1cfb31dd422",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM6265",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6265.laz",
+      "sha256": "5236afb85553ae239cebf0e843cd4f00d7d6a925b6ef9389892bfb8d90e5359a",
+      "exposed": false,
+      "set": "holdout"
+    },
+    {
+      "tileId": "10TDM6455",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6455.laz",
+      "sha256": "d933b811da0eb80e405f6e6b648109c9bf578553a6a6186b062c39772a53bfca",
+      "exposed": false,
+      "set": "holdout"
+    },
+    {
+      "tileId": "10TDM6470",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6470.laz",
+      "sha256": "81660a63c140381e9353ba2032b289092d3dcce817e677643af9832fa30f95f0",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM6564",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6564.laz",
+      "sha256": "8e2b5a163c5b71661bdb0c7c5c4af5bb1316943012eb90d34eacbe05a44f816e",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM6762",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6762.laz",
+      "sha256": "5cf81bf0d584faa260d86f81c68c5ed50c8ad448af8fbd5e5ba7ce13fd92b7c6",
+      "exposed": false,
+      "set": "holdout"
+    },
+    {
+      "tileId": "10TDM7851",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM7851.laz",
+      "sha256": "2cae8f32917c88ab0929871b645d18b96d2a97b8cd43e3614c298c500e497041",
+      "exposed": false,
+      "set": "development"
+    },
+    {
+      "tileId": "10TDM8061",
+      "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM8061.laz",
+      "sha256": "be12c943fa614cda9529c001d48c0c271e33df2df32fd5928c19f7a8287876f5",
+      "exposed": false,
+      "set": "holdout"
+    }
+  ]
+}


### PR DESCRIPTION
First bounded piece of Rogue retrospective hardening — no heavy compute, no fieldwork.

Splits the 25 Rogue tiles into 17 development / 8 holdout. Any tile already referenced anywhere in the repo is exposed and forced into development (only 10TDM3746, from prior ground-filter work, qualifies); the 24 unexposed tiles are ordered by sha256("ROGUE-E5-HARDENING-v1" + fileSha256) and filled to the development target, the rest holdout. The order depends only on file content, so the split reproduces from the committed input manifest alone.

A test pins the honesty invariants: no exposed tile lands in the holdout, the holdout is entirely unexposed, the split covers exactly the 25 inputs, and the recorded splitDigest matches the assignment. Validation-only.