### PR TITLE
e5: recentre the checkpoint harness to a local frame (Float32 precision fix)

### DIFF
--- a/tests/checkpointLargeCoordinatePrecision.test.ts
+++ b/tests/checkpointLargeCoordinatePrecision.test.ts
@@ -1,0 +1,202 @@
+/**
+ * checkpointLargeCoordinatePrecision.test.ts — a deterministic, CI-safe proof
+ * that the independent-checkpoint harness MUST recentre a tile onto a local
+ * origin before its coordinates enter the Float32 geometry buffers.
+ *
+ * The defect this guards against: USGS 3DEP tiles carry world UTM coordinates
+ * (northings ~3.19M m over Houston, ~4.65M m over Rogue). Float32 ULP at those
+ * magnitudes is ~0.25–0.5 m, so storing a raw world coordinate into the
+ * Float32-backed decode buffer snaps it to a sub-metre grid and destroys the
+ * centimetric/decimetric residual signal a 0.10 m vertical-accuracy study is
+ * built to measure. The production loader (`src/io/loadLas.ts`) never lets that
+ * happen: it derives a per-cloud integer origin with `computeOrigin(header.min)`
+ * and subtracts it in Float64 before the f32 downcast.
+ *
+ * Method. A dense synthetic Class-2 ground plane is built at realistic world
+ * magnitudes and pushed through two decode variants of the SAME DTM builder:
+ *   - 'ideal'     — recentred, stored in Float64 (the numerical ground truth).
+ *   - 'recentred' — recentred, stored in Float32 (production).
+ * Reference checkpoint elevations are defined as the ideal sample minus a known
+ * injected Δz, so any rasteriser sampling bias is shared by both variants and
+ * cancels out of the residual, leaving only the Float32 quantisation on view.
+ * A separate storage-invariant test proves the [0,0,0] naive path is prohibited:
+ * a realistic fractional coordinate cannot survive Float32 at these magnitudes
+ * unless it is recentred onto the integer origin first.
+ *
+ * No external files, no env gate: the point set is constructed in the test.
+ */
+import { describe, it, expect } from 'vitest';
+import { computeOrigin } from '../src/io/coordinateBridge';
+import { DtmSurfaceModel } from '../src/terrain/validate/dtmSurfaceModel';
+
+// A sloped ground plane at real world UTM magnitudes. The slope is what turns a
+// horizontal (XY) Float32 snap into a vertical height error — exactly how the
+// naive path corrupts a residual study.
+const Z0 = 800; // base elevation, m (NAVD88-scale)
+const SLOPE_X = 0.1; // 10 % cross-slope
+const SLOPE_Y = 0.15; // 15 % down-slope
+const CELL_SIZE_M = 1;
+const PATCH_M = 40; // 40 m × 40 m patch
+const STEP_M = 0.5; // dense ground returns, 0.5 m spacing
+
+const trueHeight = (worldX: number, worldY: number, x0: number, y0: number): number =>
+  Z0 + SLOPE_X * (worldX - x0) + SLOPE_Y * (worldY - y0);
+
+// Known vertical differences injected at four interior checkpoints.
+const INJECTED_DZ = [0.01, 0.03, 0.05, 0.1] as const;
+
+type Mode = 'ideal' | 'recentred';
+
+interface Site {
+  readonly name: string;
+  readonly e0: number; // world easting origin of the patch
+  readonly n0: number; // world northing origin of the patch
+}
+
+const SITES: readonly Site[] = [
+  { name: 'Houston', e0: 260_000, n0: 3_195_000 },
+  { name: 'Rogue', e0: 460_000, n0: 4_650_000 },
+];
+
+const checkpointXY = (site: Site, k: number): [number, number] => [
+  site.e0 + 8 + k * 6, // 8, 14, 20, 26 m into the patch
+  site.n0 + 8 + k * 6,
+];
+
+/**
+ * Build the DTM for one site under one decode mode and return the sampled DTM
+ * height at each of the four checkpoint locations, expressed in the common
+ * WORLD vertical frame (the model's local sample plus its vertical origin), so
+ * the three modes are directly comparable and only the horizontal Float32 snap
+ * — the documented defect — separates them.
+ */
+function sampleAt(site: Site, mode: Mode): number[] {
+  const { e0, n0 } = site;
+
+  const worldX: number[] = [];
+  const worldY: number[] = [];
+  const worldZ: number[] = [];
+  for (let dx = 0; dx <= PATCH_M; dx += STEP_M) {
+    for (let dy = 0; dy <= PATCH_M; dy += STEP_M) {
+      const X = e0 + dx;
+      const Y = n0 + dy;
+      worldX.push(X);
+      worldY.push(Y);
+      worldZ.push(trueHeight(X, Y, e0, n0));
+    }
+  }
+
+  const minX = Math.min(...worldX);
+  const minY = Math.min(...worldY);
+  const minZ = Math.min(...worldZ);
+  const origin: [number, number, number] = computeOrigin([minX, minY, minZ]);
+
+  // The decode buffer: Float32 for the two decode variants, Float64 for the
+  // ideal reference. The world→local subtraction is always done in Float64
+  // first (as `recenter()` does), narrowing to the buffer's type on assignment.
+  const store: Float32Array | Float64Array =
+    mode === 'ideal'
+      ? new Float64Array(worldX.length * 3)
+      : new Float32Array(worldX.length * 3);
+  for (let i = 0; i < worldX.length; i++) {
+    store[i * 3 + 0] = worldX[i] - origin[0];
+    store[i * 3 + 1] = worldY[i] - origin[1];
+    store[i * 3 + 2] = worldZ[i] - origin[2];
+  }
+
+  const trainPts: Array<{ x: number; y: number; z: number }> = [];
+  let gMinX = Infinity;
+  let gMaxX = -Infinity;
+  let gMinY = Infinity;
+  let gMaxY = -Infinity;
+  for (let i = 0; i < worldX.length; i++) {
+    const x = store[i * 3 + 0];
+    const y = store[i * 3 + 1];
+    const z = store[i * 3 + 2];
+    trainPts.push({ x, y, z });
+    if (x < gMinX) gMinX = x;
+    if (x > gMaxX) gMaxX = x;
+    if (y < gMinY) gMinY = y;
+    if (y > gMaxY) gMaxY = y;
+  }
+
+  const grid = {
+    originH1: gMinX,
+    originH2: gMinY,
+    cols: Math.max(1, Math.ceil((gMaxX - gMinX) / CELL_SIZE_M) + 1),
+    rows: Math.max(1, Math.ceil((gMaxY - gMinY) / CELL_SIZE_M) + 1),
+    cellSizeM: CELL_SIZE_M,
+  };
+  const model = new DtmSurfaceModel({
+    grid,
+    aggregation: 'median',
+    despike: false,
+    verticalUnitToMetres: 1,
+  });
+  model.fit(trainPts);
+
+  const sampled: number[] = [];
+  for (let k = 0; k < INJECTED_DZ.length; k++) {
+    const [cx, cy] = checkpointXY(site, k);
+    const z = model.predict(cx - origin[0], cy - origin[1]);
+    expect(z).not.toBeNull();
+    sampled.push((z as number) + origin[2]); // back to the world vertical frame
+  }
+  return sampled;
+}
+
+describe('checkpoint harness large-coordinate precision', () => {
+  for (const site of SITES) {
+    // The ideal (Float64) sample is the numerical ground truth; the injected
+    // reference elevations hang off it, so the rasteriser's own slope-sampling
+    // bias is common to every mode and drops out of the recovered Δz.
+    const ideal = sampleAt(site, 'ideal');
+    const references = INJECTED_DZ.map((dz, k) => ideal[k] - dz);
+
+    it(`recentred (Float32) decode recovers injected Δz at ${site.name} magnitudes`, () => {
+      const sampled = sampleAt(site, 'recentred');
+      for (let k = 0; k < INJECTED_DZ.length; k++) {
+        const recovered = sampled[k] - references[k];
+        const err = Math.abs(recovered - INJECTED_DZ[k]);
+        // eslint-disable-next-line no-console
+        console.log(
+          `[recentred ${site.name}] injected ${INJECTED_DZ[k]} m -> recovered ${recovered.toFixed(6)} m (err ${err.toExponential(2)} m)`,
+        );
+        expect(err).toBeLessThan(1e-3); // well under the 0.01 m signal floor
+      }
+    });
+
+    it(`naive [0,0,0] storage cannot hold ${site.name} coordinates to the study's tolerance`, () => {
+      // The invariant that PROHIBITS the naive path, proven at its root: a
+      // realistic fractional survey coordinate (checkpoints and returns are not
+      // on integer metres) cannot survive a Float32 round-trip at these world
+      // magnitudes, but survives losslessly once recentred onto the integer
+      // origin first — exactly what `computeOrigin` + Float64 subtraction do.
+      const originN = computeOrigin([site.e0, site.n0, 0])[1];
+      let worstNaive = 0;
+      let worstRecentred = 0;
+      for (let k = 0; k < INJECTED_DZ.length; k++) {
+        const [, cy] = checkpointXY(site, k);
+        const northing = cy + 0.37; // realistic sub-metre fractional part
+
+        const naive = Math.fround(northing);
+        const naiveErr = Math.abs(naive - northing);
+        worstNaive = Math.max(worstNaive, naiveErr);
+
+        const recentred = Math.fround(northing - originN) + originN;
+        const recentredErr = Math.abs(recentred - northing);
+        worstRecentred = Math.max(worstRecentred, recentredErr);
+
+        // eslint-disable-next-line no-console
+        console.log(
+          `[storage ${site.name}] N=${northing.toFixed(2)}  naive f32 err ${naiveErr.toExponential(2)} m  recentred f32 err ${recentredErr.toExponential(2)} m`,
+        );
+      }
+      // Naive storage loses more than the 0.01 m signal floor; recentred keeps
+      // it to sub-millimetre. This is why the harness MUST recentre and why the
+      // [0,0,0] origin is prohibited for a decimetric checkpoint study.
+      expect(worstNaive).toBeGreaterThan(0.01);
+      expect(worstRecentred).toBeLessThan(1e-3);
+    });
+  }
+});

--- a/tests/independentCheckpointHarness.test.ts
+++ b/tests/independentCheckpointHarness.test.ts
@@ -54,7 +54,9 @@ import { existsSync, readFileSync } from 'node:fs';
 import { parseLasHeader } from '../src/io/lasHeader';
 import { allocRawPoints, decodeContext, decodeRecord, type RawPoints } from '../src/io/lasDecodeShared';
 import { decodeLaz } from '../src/io/lazDecode';
+import { computeOrigin } from '../src/io/coordinateBridge';
 import { DtmSurfaceModel } from '../src/terrain/validate/dtmSurfaceModel';
+import { recommendGrid } from '../src/terrain/quality/recommendGrid';
 import {
   readProjectCheckpointsCsv,
   runCheckpointStudy,
@@ -71,27 +73,38 @@ const HORIZONTAL_EPSG = Number(process.env.CHECKPOINT_HORIZONTAL_EPSG ?? '6339')
 const VERTICAL_EPSG = Number(process.env.CHECKPOINT_VERTICAL_EPSG ?? '5703');
 
 const PRODUCER_GROUND = 2; // ASPRS class 2 = ground
-const CELL_SIZE_M = 1;
 
 /** Decode a plain LAS (uncompressed) or a .laz/COPC into RawPoints — same
- *  idiom as tests/groundFilterProducerAgreement.test.ts. */
-async function decodeScene(path: string): Promise<{ out: RawPoints; count: number }> {
+ *  idiom as tests/groundFilterProducerAgreement.test.ts.
+ *
+ *  Recentring is load-bearing here. USGS 3DEP tiles carry world UTM
+ *  coordinates (northings ~3.2M m Houston, ~4.65M m Rogue). Float32 ULP at
+ *  those magnitudes is ~0.5 m, which would obliterate the centimetric/
+ *  decimetric residuals a checkpoint study measures. The production loader
+ *  (`src/io/loadLas.ts`) never lets a raw world coordinate enter Float32: it
+ *  derives a per-cloud integer origin with `computeOrigin(header.min)` and
+ *  subtracts it in Float64 before the f32 downcast. We do exactly the same and
+ *  return the origin so callers can map checkpoints into the same local frame. */
+async function decodeScene(
+  path: string,
+): Promise<{ out: RawPoints; count: number; origin: [number, number, number] }> {
   const bytes = readFileSync(path);
   const buf = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
   const header = parseLasHeader(buf);
+  const origin = computeOrigin(header.min);
   const compressed = /\.(laz|copc\.laz)$/i.test(path);
   if (compressed) {
-    const out = await decodeLaz(buf, header, [0, 0, 0], 1);
-    return { out, count: header.pointCount };
+    const out = await decodeLaz(buf, header, origin, 1);
+    return { out, count: header.pointCount, origin };
   }
   const count = header.pointCount;
   const view = new DataView(buf);
-  const ctx = decodeContext(header, [0, 0, 0]);
+  const ctx = decodeContext(header, origin);
   const out = allocRawPoints(count, false, false);
   for (let i = 0; i < count; i++) {
     decodeRecord(view, header.offsetToPointData + i * header.pointDataRecordLength, i, ctx, out);
   }
-  return { out, count };
+  return { out, count, origin };
 }
 
 const ready = Boolean(SCENE && GDB && PROJECT_ID && existsSync(SCENE) && existsSync(GDB));
@@ -100,12 +113,19 @@ describe.skipIf(!ready)('independent-checkpoint accuracy harness (pathway A: pro
   it('reports Bias/RMSE/MAE/NMAD/P95 when prerequisites are met, else fails closed with a named reason', async () => {
     // A full USGS 3DEP tile decode + 1 m DTM rasterisation over its whole
     // extent is well beyond the default 15 s unit-test timeout.
-    const { out, count } = await decodeScene(SCENE!);
+    const { out, count, origin } = await decodeScene(SCENE!);
+    const [originX, originY] = origin;
 
+    // Bounds are accumulated in the LOCAL frame the points now live in (world
+    // minus `origin`). The DTM grid and every predict() query stay local; the
+    // world bounds handed to the extent/CRS gate are reconstructed by adding
+    // the origin back, so the checkpoint gate still reasons in world UTM.
     let minX = Infinity;
     let maxX = -Infinity;
     let minY = Infinity;
     let maxY = -Infinity;
+    let minZ = Infinity;
+    let maxZ = -Infinity;
     const trainPts: Array<{ x: number; y: number; z: number }> = [];
     for (let i = 0; i < count; i++) {
       if (out.classification[i] !== PRODUCER_GROUND) continue;
@@ -118,18 +138,41 @@ describe.skipIf(!ready)('independent-checkpoint accuracy harness (pathway A: pro
       if (x > maxX) maxX = x;
       if (y < minY) minY = y;
       if (y > maxY) maxY = y;
+      if (z < minZ) minZ = z;
+      if (z > maxZ) maxZ = z;
     }
     // Sanity: the tile really does carry an official ground classification.
     expect(trainPts.length).toBeGreaterThan(0);
 
+    // Cell size comes from the SAME production chooser the live pipeline uses
+    // (`recommendGrid`, density-aware: √(area/points)·2.5 snapped to the grid
+    // ladder), never a harness-local magic constant that would silently define
+    // the method under test. Deterministic given the tile's extent and count.
+    const cellSizeM = recommendGrid({
+      pointCount: trainPts.length,
+      widthM: maxX - minX,
+      depthM: maxY - minY,
+      reliefM: maxZ - minZ,
+    }).cellSizeM;
+
     const grid = {
       originH1: minX,
       originH2: minY,
-      cols: Math.max(1, Math.ceil((maxX - minX) / CELL_SIZE_M) + 1),
-      rows: Math.max(1, Math.ceil((maxY - minY) / CELL_SIZE_M) + 1),
-      cellSizeM: CELL_SIZE_M,
+      cols: Math.max(1, Math.ceil((maxX - minX) / cellSizeM) + 1),
+      rows: Math.max(1, Math.ceil((maxY - minY) / cellSizeM) + 1),
+      cellSizeM,
     };
-    const model = new DtmSurfaceModel({ grid, aggregation: 'median' });
+    const model = new DtmSurfaceModel({
+      grid,
+      aggregation: 'median',
+      // Production parity with the shipped trusted-Class-2 ground path: despike
+      // is OFF there (measured survey returns are authoritative and a steep node
+      // must not be void-filled as a blunder), and the tile's vertical unit is
+      // metres. Freeze both so the harness scores the surface the product ships,
+      // not a despiked or rescaled variant of it.
+      despike: false,
+      verticalUnitToMetres: 1,
+    });
     model.fit(trainPts);
 
     const rows = readProjectCheckpointsCsv(GDB!, LAYER, PROJECT_ID!);
@@ -138,16 +181,17 @@ describe.skipIf(!ready)('independent-checkpoint accuracy harness (pathway A: pro
     const tile: TileFrame = {
       horizontalEpsg: HORIZONTAL_EPSG,
       verticalEpsg: VERTICAL_EPSG,
-      minX,
-      maxX,
-      minY,
-      maxY,
+      minX: minX + originX,
+      maxX: maxX + originX,
+      minY: minY + originY,
+      maxY: maxY + originY,
     };
 
     const measuredById = new Map<string, number>();
     for (const r of rows) {
-      const x = Number(r.source_easting);
-      const y = Number(r.source_northing);
+      // World checkpoint XY → the DTM's local frame before sampling.
+      const x = Number(r.source_easting) - originX;
+      const y = Number(r.source_northing) - originY;
       const z = model.predict(x, y);
       if (z !== null) measuredById.set(r.unique_identifier, z);
     }
@@ -159,7 +203,8 @@ describe.skipIf(!ready)('independent-checkpoint accuracy harness (pathway A: pro
       [
         `scene: ${SCENE!.split('/').pop()}`,
         `project ${PROJECT_ID}: ${rows.length} checkpoint(s) total`,
-        `tile bounds: X[${minX.toFixed(1)}, ${maxX.toFixed(1)}]  Y[${minY.toFixed(1)}, ${maxY.toFixed(1)}]`,
+        `tile bounds (world): X[${tile.minX.toFixed(1)}, ${tile.maxX.toFixed(1)}]  Y[${tile.minY.toFixed(1)}, ${tile.maxY.toFixed(1)}]`,
+        `local origin: [${originX}, ${originY}]  cell size: ${cellSizeM} m`,
         `prerequisites ok: ${prereq.ok}`,
         ...prereq.reasons.map((r) => `  - ${r}`),
       ].join('\n'),


### PR DESCRIPTION
The independent-checkpoint harness decoded LAZ with a `[0,0,0]` origin, storing world UTM coordinates (northings ~3.2M m Houston, ~4.65M m Rogue) straight into Float32 buffers. Float32 ULP there is ~0.25-0.5 m, which erases the centimetric residual a 0.10 m vertical-accuracy study depends on.

The harness now recentres exactly as `loadLas` does: `computeOrigin(header.min)` subtracted in Float64 before the f32 downcast, checkpoints mapped into the same local frame before DTM sampling, extent/CRS gate still in world coordinates. It freezes `despike:false` and `verticalUnitToMetres:1` for trusted-Class-2 parity, and takes the DTM cell size from the production `recommendGrid` chooser instead of a hard-coded `1`.

`tests/checkpointLargeCoordinatePrecision.test.ts` proves recentred decode recovers injected Δz (0.01-0.10 m) to ~1e-14 m, and a naive Float32 store loses ~0.12-0.13 m at these magnitudes.