### PR TITLE
test(oracle-consensus): reference-strategy coverage lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
         run: npm run lint:oracle-consensus
       - name: E5 input-manifest verify (immutable digest, no dup tiles, creation ≠ acquisition)
         run: npm run validation:e5:manifests:verify
+      - name: Reference-strategy lint (every consensus record classifies + is test-backed)
+        run: npm run lint:reference-strategy
       - name: No source files git-ignored
         run: npm run lint:no-ignored-src
       - name: No git-ignored path is tracked (local tooling committed by `git add -A`)

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "lint:digest-manifests": "node scripts/lint-digest-manifests.mjs",
     "lint:oracle-registry": "node scripts/lint-oracle-registry.mjs",
     "lint:oracle-consensus": "node scripts/lint-oracle-consensus.mjs",
+    "lint:reference-strategy": "node scripts/lint-reference-strategy.mjs",
     "verify:reference-reproducibility": "node scripts/verify-reference-reproducibility.mjs",
     "lint:pr-hygiene": "node scripts/pr-hygiene.mjs",
     "lint:license": "node scripts/lint-license.mjs",

--- a/scripts/lib/referenceCoverage.mjs
+++ b/scripts/lib/referenceCoverage.mjs
@@ -1,0 +1,113 @@
+/**
+ * referenceCoverage.mjs — one auditable view of the oracle-triangulation
+ * framework's external-validation coverage.
+ *
+ * Each `validation/oracle-consensus/*.consensus.json` record triangulates one
+ * OLV quantity against analytic truth and/or matched independent implementations
+ * (GDAL, GRASS, PROJ, ...), or documents method sensitivity against a set of
+ * established filters. This module reduces WHATEVER records are present to a flat
+ * coverage matrix — quantity, verdict class, which reference tiers back it, and
+ * which external tools — so the framework's reach can be read at a glance and
+ * grow as new families (volume, registration, ...) land. It reads the records;
+ * it does not know a roster.
+ *
+ * verdictClass derivation:
+ *   evidenceRole === 'exploratory'        -> METHOD_SENSITIVITY
+ *   else has an analytic-truth leg        -> PASS_TRUTH
+ *   else (only matched implementations)   -> PASS_REPLICATION
+ */
+import { expectedTestName } from '../lint-oracle-consensus.mjs';
+
+/** Collect every oracle entry a record carries, whether flat or under `cases`. */
+function collectOracles(record) {
+  if (Array.isArray(record.oracles)) return record.oracles;
+  if (Array.isArray(record.cases)) return record.cases.flatMap((c) => c.oracles ?? []);
+  return [];
+}
+
+/** First word of a tool string, upper-cased leader kept as the vendor token. */
+function toolLeader(tool) {
+  if (!tool || typeof tool !== 'string') return null;
+  const first = tool.trim().split(/\s+/)[0];
+  return first || null;
+}
+
+/**
+ * Reference tools that back one record. For triangulation records they come from
+ * the matched/truth oracle `tool` strings (first word). For an exploratory
+ * record there are no oracle legs — the references are the per-scene
+ * `referenceF1` keys (e.g. smrf/csf/pmf), so read them from there.
+ */
+function externalToolsFor(record, oracles) {
+  const tools = new Set();
+  for (const o of oracles) {
+    const leader = toolLeader(o.tool);
+    // "closed form ..." is the analytic-truth leg, not an external tool.
+    if (leader && !/^closed$/i.test(leader)) tools.add(leader);
+  }
+  if (record.evidenceRole === 'exploratory' && Array.isArray(record.scenes)) {
+    for (const s of record.scenes) {
+      const ref = s.referenceF1;
+      if (ref && typeof ref === 'object') {
+        for (const k of Object.keys(ref)) tools.add(k);
+      }
+    }
+  }
+  return [...tools].sort();
+}
+
+/** Distinct referenceClass values present across a record's oracle legs. */
+function referenceClassesFor(record, oracles) {
+  const classes = new Set(oracles.map((o) => o.referenceClass).filter(Boolean));
+  if (record.evidenceRole === 'exploratory') classes.add('exploratory-reference');
+  return [...classes].sort();
+}
+
+/**
+ * Derive the verdict class for one record. Returns null when the record carries
+ * no basis for a verdict (no truth leg, no matched implementations, not
+ * exploratory) — the lint treats that as a failure.
+ */
+export function deriveVerdictClass(record, oracles = collectOracles(record)) {
+  if (record.evidenceRole === 'exploratory') return 'METHOD_SENSITIVITY';
+  const hasTruth = oracles.some((o) => o.referenceClass === 'analytic-truth');
+  if (hasTruth) return 'PASS_TRUTH';
+  const matched = oracles.filter((o) => o.referenceClass === 'matched-implementation').length;
+  if (matched > 0) return 'PASS_REPLICATION';
+  return null;
+}
+
+/**
+ * Pure coverage reducer. `records` is an array of `{ file, record }` pairs.
+ * Returns one row per record, sorted by quantity then file.
+ */
+export function buildCoverage(records) {
+  const rows = records.map(({ file, record }) => {
+    const oracles = collectOracles(record);
+    return {
+      quantity: record?.contract?.quantity ?? null,
+      record: file,
+      test: expectedTestName(file),
+      verdictClass: deriveVerdictClass(record, oracles),
+      referenceClasses: referenceClassesFor(record, oracles),
+      externalTools: externalToolsFor(record, oracles),
+      evidenceRole: record?.evidenceRole ?? null,
+    };
+  });
+  rows.sort((a, b) => {
+    const q = String(a.quantity).localeCompare(String(b.quantity));
+    return q !== 0 ? q : String(a.record).localeCompare(String(b.record));
+  });
+  return rows;
+}
+
+/** Counts by verdictClass plus the sorted quantity list. */
+export function coverageSummary(coverage) {
+  const byVerdictClass = {};
+  for (const row of coverage) {
+    const key = row.verdictClass ?? 'UNCLASSIFIED';
+    byVerdictClass[key] = (byVerdictClass[key] ?? 0) + 1;
+  }
+  const quantities = [...new Set(coverage.map((r) => r.quantity).filter(Boolean))].sort();
+  return { total: coverage.length, byVerdictClass, quantities };
+}

--- a/scripts/lint-reference-strategy.mjs
+++ b/scripts/lint-reference-strategy.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * lint-reference-strategy.mjs — the external-validation coverage gate.
+ *
+ * The oracle-consensus lint proves each record is contract-shaped and
+ * test-backed. This lint sits one layer above it and asks a different question:
+ * does the framework, taken as a whole, present ONE auditable view of what is
+ * validated, by which reference tier, at what verdict class, backed by which
+ * test? It builds the coverage matrix (scripts/lib/referenceCoverage.mjs) from
+ * WHATEVER records are present and fails if any record cannot be placed in it:
+ *   - no derivable verdict class (no truth leg, no matched implementation, not
+ *     declared exploratory),
+ *   - no backing test file on disk (via expectedTestName), or
+ *   - no reference named at all (no external tool, no exploratory reference).
+ *
+ * On success it prints the matrix and the summary and exits 0. Passing on zero
+ * records is intentional: the framework can exist before any family merges. The
+ * matrix is computed, never committed, so it cannot drift from the records.
+ */
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isCliEntry } from './lib/isCliEntry.mjs';
+import { buildCoverage, coverageSummary } from './lib/referenceCoverage.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DIR = resolve(ROOT, 'validation/oracle-consensus');
+const TESTS = resolve(ROOT, 'tests');
+
+/** Read every consensus record present as `{ file, record }`, JSON errors surfaced. */
+function readRecords() {
+  if (!existsSync(DIR)) return { records: [], jsonErrors: [] };
+  const files = readdirSync(DIR).filter((f) => f.endsWith('.consensus.json'));
+  const records = [];
+  const jsonErrors = [];
+  for (const f of files) {
+    try {
+      records.push({ file: f, record: JSON.parse(readFileSync(resolve(DIR, f), 'utf8')) });
+    } catch (e) {
+      jsonErrors.push(`${f}: invalid JSON — ${e.message}`);
+    }
+  }
+  return { records, jsonErrors };
+}
+
+/** Problems for one coverage row. Pure over the row; test presence checked by caller. */
+export function coverageRowProblems(row, testOnDisk) {
+  const problems = [];
+  if (!row.verdictClass) {
+    problems.push(`${row.record}: no derivable verdict class (no truth leg, no matched implementation, not exploratory)`);
+  }
+  if (!testOnDisk) {
+    problems.push(`${row.record}: no backing test on disk (expected tests/${row.test})`);
+  }
+  if (row.externalTools.length === 0 && row.referenceClasses.length === 0) {
+    problems.push(`${row.record}: names no reference at all (no external tool, no reference class)`);
+  }
+  return problems;
+}
+
+function printMatrix(coverage) {
+  console.log('reference-strategy coverage matrix:');
+  for (const row of coverage) {
+    const tools = row.externalTools.length ? row.externalTools.join(', ') : '—';
+    console.log(
+      `  ${row.quantity}  ->  ${row.verdictClass}` +
+        `  [${row.referenceClasses.join(', ')}]  tools: ${tools}` +
+        `  (${row.record} -> tests/${row.test})`,
+    );
+  }
+  const summary = coverageSummary(coverage);
+  const counts = Object.entries(summary.byVerdictClass)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join(', ');
+  console.log(`summary: ${summary.total} record(s); verdict classes: ${counts || '(none)'}`);
+  console.log(`quantities: ${summary.quantities.join(', ') || '(none)'}`);
+}
+
+function main() {
+  const { records, jsonErrors } = readRecords();
+  const coverage = buildCoverage(records);
+  const problems = [...jsonErrors];
+
+  for (const row of coverage) {
+    const testOnDisk = existsSync(resolve(TESTS, row.test));
+    problems.push(...coverageRowProblems(row, testOnDisk));
+  }
+
+  if (problems.length) {
+    console.error('lint:reference-strategy FAILED:');
+    for (const p of problems) console.error('  - ' + p);
+    process.exit(1);
+  }
+
+  if (coverage.length === 0) {
+    console.log('lint:reference-strategy OK — no oracle-consensus records yet');
+    return;
+  }
+  printMatrix(coverage);
+  console.log(
+    `lint:reference-strategy OK — ${coverage.length} record(s), each classified, reference-named and test-backed`,
+  );
+}
+
+if (isCliEntry(import.meta.url)) main();

--- a/tests/referenceStrategy.test.ts
+++ b/tests/referenceStrategy.test.ts
@@ -1,0 +1,140 @@
+/**
+ * referenceStrategy.test.ts — the reference-coverage reducer, tested as rules
+ * rather than against whatever records exist today, plus one assertion that
+ * every committed consensus record classifies and is test-backed.
+ *
+ * scripts/lint-reference-strategy.mjs is the gate; scripts/lib/referenceCoverage.mjs
+ * is the pure reducer it runs. These cases pin the verdict-class derivation
+ * (exploratory -> METHOD_SENSITIVITY, a truth leg -> PASS_TRUTH, matched-only ->
+ * PASS_REPLICATION, nothing -> unclassified) and the tool/reference extraction,
+ * so the meaning of the coverage matrix is fixed independent of the repository's
+ * current contents.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, existsSync, readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+// @ts-expect-error — plain .mjs script, no types
+import { buildCoverage, coverageSummary, deriveVerdictClass } from '../scripts/lib/referenceCoverage.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DIR = resolve(ROOT, 'validation/oracle-consensus');
+const TESTS = resolve(ROOT, 'tests');
+
+const truthRecord = {
+  contract: { id: 'x', quantity: 'terrain.slope' },
+  oracles: [
+    { id: 'analytic', referenceClass: 'analytic-truth', tool: 'closed form atan(1)' },
+    { id: 'gdal', referenceClass: 'matched-implementation', tool: 'GDAL 3.13.3 gdaldem slope' },
+  ],
+};
+
+const matchedOnlyRecord = {
+  contract: { id: 'y', quantity: 'crs.utm-projection' },
+  oracles: [
+    { id: 'proj', referenceClass: 'matched-implementation', tool: 'PROJ 9.8.1 cs2cs' },
+    { id: 'gl', referenceClass: 'matched-implementation', tool: 'GeographicLib 2.7 GeoConvert' },
+  ],
+};
+
+const exploratoryRecord = {
+  contract: { id: 'z', quantity: 'ground.classification.f1' },
+  evidenceRole: 'exploratory',
+  scenes: [
+    { id: 'S1', olvF1: 0.8, referenceF1: { smrf: 0.86, csf: 0.95, pmf: 0.87 } },
+    { id: 'S2', olvF1: 0.9, referenceF1: { smrf: 0.93, csf: 0.94, pmf: 0.95 } },
+  ],
+};
+
+const casesRecord = {
+  contract: { id: 'c', quantity: 'terrain.aspect' },
+  cases: [
+    {
+      oracles: [
+        { id: 'analytic', referenceClass: 'analytic-truth', tool: 'closed form' },
+        { id: 'grass', referenceClass: 'matched-implementation', tool: 'GRASS 8.5.0 r.slope.aspect' },
+      ],
+    },
+  ],
+};
+
+describe('deriveVerdictClass', () => {
+  it('exploratory record -> METHOD_SENSITIVITY', () => {
+    expect(deriveVerdictClass(exploratoryRecord)).toBe('METHOD_SENSITIVITY');
+  });
+  it('record with an analytic-truth leg -> PASS_TRUTH', () => {
+    expect(deriveVerdictClass(truthRecord)).toBe('PASS_TRUTH');
+    expect(deriveVerdictClass(casesRecord)).toBe('PASS_TRUTH');
+  });
+  it('matched implementations only -> PASS_REPLICATION', () => {
+    expect(deriveVerdictClass(matchedOnlyRecord)).toBe('PASS_REPLICATION');
+  });
+  it('no truth, no matched, not exploratory -> null (unclassifiable)', () => {
+    expect(deriveVerdictClass({ contract: { quantity: 'q' }, oracles: [] })).toBeNull();
+  });
+});
+
+describe('buildCoverage', () => {
+  const coverage = buildCoverage([
+    { file: 'slope.consensus.json', record: truthRecord },
+    { file: 'crs.consensus.json', record: matchedOnlyRecord },
+    { file: 'ground.consensus.json', record: exploratoryRecord },
+  ]);
+
+  it('is sorted by quantity', () => {
+    expect(coverage.map((r: { quantity: string }) => r.quantity)).toEqual([
+      'crs.utm-projection',
+      'ground.classification.f1',
+      'terrain.slope',
+    ]);
+  });
+
+  it('extracts external tools from oracle tool leaders, dropping the closed-form leg', () => {
+    const slope = coverage.find((r: { quantity: string }) => r.quantity === 'terrain.slope');
+    expect(slope.externalTools).toEqual(['GDAL']);
+    const crs = coverage.find((r: { quantity: string }) => r.quantity === 'crs.utm-projection');
+    expect(crs.externalTools).toEqual(['GeographicLib', 'PROJ']);
+  });
+
+  it('reads exploratory tools from referenceF1 keys', () => {
+    const ground = coverage.find((r: { quantity: string }) => r.quantity === 'ground.classification.f1');
+    expect(ground.externalTools).toEqual(['csf', 'pmf', 'smrf']);
+    expect(ground.referenceClasses).toContain('exploratory-reference');
+  });
+
+  it('summary counts by verdict class', () => {
+    const summary = coverageSummary(coverage);
+    expect(summary.total).toBe(3);
+    expect(summary.byVerdictClass).toEqual({
+      PASS_TRUTH: 1,
+      PASS_REPLICATION: 1,
+      METHOD_SENSITIVITY: 1,
+    });
+  });
+});
+
+describe('committed consensus records', () => {
+  const files = existsSync(DIR)
+    ? readdirSync(DIR).filter((f) => f.endsWith('.consensus.json'))
+    : [];
+
+  it('there is at least one committed record to cover', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('every committed record classifies, names a reference, and has a backing test on disk', () => {
+    const records = files.map((f) => ({
+      file: f,
+      record: JSON.parse(readFileSync(resolve(DIR, f), 'utf8')),
+    }));
+    const coverage = buildCoverage(records);
+    for (const row of coverage) {
+      expect(row.verdictClass, `${row.record} classifies`).not.toBeNull();
+      expect(
+        row.externalTools.length + row.referenceClasses.length,
+        `${row.record} names a reference`,
+      ).toBeGreaterThan(0);
+      expect(existsSync(resolve(TESTS, row.test)), `tests/${row.test} exists`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Adds a layer above the oracle-consensus shape lint that gives one auditable view of the framework's external-validation coverage: which OLV quantity is validated, by which reference tier, at what verdict class, backed by which test.

`scripts/lib/referenceCoverage.mjs` is a pure reducer over whatever records are present. Per record it derives a verdict class (exploratory -> METHOD_SENSITIVITY, an analytic-truth leg -> PASS_TRUTH, matched implementations only -> PASS_REPLICATION), the reference tiers, and the external tools (oracle tool leaders, or per-scene referenceF1 keys for exploratory records).

`scripts/lint-reference-strategy.mjs` builds the matrix and fails if any record has no verdict class, no backing test on disk, or names no reference. Passes vacuously on zero records; prints the matrix on success. Wired into package.json and CI after lint:oracle-consensus. Matrix is computed, never committed, so it cannot drift as new families land. Test-only; no src changes.