### PR TITLE
e5: one authoritative resolveExportEvidence for every DTM export path

### DIFF
--- a/src/terrain/export/exportProvenance.ts
+++ b/src/terrain/export/exportProvenance.ts
@@ -39,8 +39,9 @@ import { contourShapeStyleLabel, type ContourShapeStyle } from '../contour/conto
 import { exportGate, EVIDENCE_REGISTRY } from '../../validation/evidenceRegistry';
 import { evidenceRank, INDEPENDENCE_FLOOR } from '../../validation/evidenceLevel';
 import {
-  resolveEvidence,
+  resolveExportEvidence,
   type EvidenceContext,
+  type ExportEvidenceResolution,
   type ScopedEvidenceRecord,
 } from '../../validation/scopedEvidence';
 import { buildIdentityProvenance } from '../../build/buildIdentity';
@@ -301,6 +302,21 @@ export interface ExportProvenance {
    * study envelope matched the artifact context.
    */
   readonly scopedEvidence?: ExportScopedEvidence | null;
+  /**
+   * The SINGLE authoritative evidence resolution this export was stamped from
+   * (§18). Every evidence surface — the `Evidence` provenance line, the GeoJSON
+   * `evidence` field, the scope-aware disclosure block, and the analysis
+   * record's `evidenceExploratory` flag — derives its note, baseline/effective
+   * level and gate verdict from THIS one object, so no two surfaces can ever
+   * disagree (one saying E5 while another says E4). With the empty shipped
+   * record set the effective level equals the baseline for every real artifact.
+   *
+   * Optional only so a hand-built provenance literal (test fixtures) need not
+   * spell it out; {@link buildExportProvenance} — the ONLY production path —
+   * always populates it, and the formatters fall back to the conservative
+   * baseline note/gate when it is absent.
+   */
+  readonly evidenceResolution?: ExportEvidenceResolution;
 }
 
 /** Options for {@link buildExportProvenance}. */
@@ -489,7 +505,33 @@ export function buildExportProvenance(
     // Scope-aware evidence: resolved only when the path supplied a context/digest.
     // Absent (null) otherwise, which keeps the export byte-identical to before.
     scopedEvidence: buildScopedEvidence(opts),
+    // The ONE authoritative resolution every evidence surface below derives from.
+    evidenceResolution: buildEvidenceResolution(opts),
   };
+}
+
+/**
+ * The single authoritative evidence resolution for this export (§18). Composes
+ * the scoped overlay, the baseline registry gate and the note into one object
+ * via {@link resolveExportEvidence}, keyed on whatever artifact context the path
+ * supplied (undefined ⇒ conservative baseline). The terrain-specific baseline
+ * wording ({@link EVIDENCE_GATE_NOTE}) is the note used when no scoped record
+ * matches — the common case with today's empty record set — so the stamped note
+ * is byte-identical to before, while every surface now reads the SAME object.
+ */
+function buildEvidenceResolution(opts: ExportProvenanceOptions): ExportEvidenceResolution {
+  const claimId = opts.evidenceClaimId ?? 'DTM';
+  const hasSignal =
+    opts.evidenceContext != null || (opts.methodDigest != null && opts.methodDigest !== '');
+  const context: EvidenceContext | undefined = hasSignal
+    ? {
+        ...(opts.evidenceContext ?? {}),
+        ...(opts.methodDigest != null && opts.evidenceContext?.methodDigest == null
+          ? { methodDigest: opts.methodDigest }
+          : {}),
+      }
+    : undefined;
+  return resolveExportEvidence(claimId, context, opts.scopedRecords, EVIDENCE_GATE_NOTE);
 }
 
 /**
@@ -509,14 +551,16 @@ function buildScopedEvidence(opts: ExportProvenanceOptions): ExportScopedEvidenc
       ? { methodDigest: opts.methodDigest }
       : {}),
   };
-  const r = resolveEvidence(claimId, context, opts.scopedRecords);
+  // Derived from the SAME authoritative resolver as the note / gate / analysis
+  // record, so the disclosure block can never disagree with them.
+  const r = resolveExportEvidence(claimId, context, opts.scopedRecords, EVIDENCE_GATE_NOTE);
   return {
     claimId,
     baselineEvidence: r.baselineEvidence,
     effectiveEvidence: r.effectiveEvidence,
-    matchedScopedStudy: r.matchedScopedStudy,
+    matchedScopedStudy: r.matchedStudy,
     applicabilityVerdict: r.applicabilityVerdict,
-    resolutionState: r.resolutionState,
+    resolutionState: r.applicabilityStatus,
     methodDigest: context.methodDigest ?? null,
   };
 }
@@ -555,7 +599,7 @@ export function analysisRecordFromProvenance(p: ExportProvenance): ScientificAna
       verticalDatumKnown: p.datumKnown,
     },
     methodIds: terrainMethodIds(p),
-    evidenceExploratory: exportGate('DTM').exploratoryOnly,
+    evidenceExploratory: (p.evidenceResolution?.gate ?? exportGate('DTM')).exploratoryOnly,
     summary: {
       surfaceQuality: p.surfaceQuality,
       exportReadiness: p.exportReadiness,
@@ -808,7 +852,7 @@ export function provenanceLines(p: ExportProvenance): string[] {
       `schema ${manifest.schemaVersion} · ${manifest.head.slice(0, 12)} · ${manifest.ops.length} ops · verifiable`,
     ),
     kv('Note', p.notSurveyGrade),
-    kv('Evidence', EVIDENCE_GATE_NOTE),
+    kv('Evidence', p.evidenceResolution?.note ?? EVIDENCE_GATE_NOTE),
   );
   // Scope-aware evidence disclosure — present only when the path assessed
   // applicability. Names the baseline vs effective level, the matched study (or
@@ -888,7 +932,7 @@ export function provenanceJson(p: ExportProvenance): Record<string, unknown> {
     classScope: p.classScope,
     warnings: [...p.warnings],
     notSurveyGrade: p.notSurveyGrade,
-    evidence: EVIDENCE_GATE_NOTE,
+    evidence: p.evidenceResolution?.note ?? EVIDENCE_GATE_NOTE,
     // Scope-aware evidence block — emitted ONLY when applicability was assessed
     // (the key is absent otherwise, keeping the common export byte-identical).
     // Never promotes above baseline unless a registered study envelope matched.

--- a/src/validation/exportEvidenceNote.ts
+++ b/src/validation/exportEvidenceNote.ts
@@ -20,7 +20,7 @@
 import { exportGate, EVIDENCE_REGISTRY } from './evidenceRegistry';
 import { evidenceRank, INDEPENDENCE_FLOOR } from './evidenceLevel';
 import {
-  resolveEvidence,
+  resolveExportEvidence,
   type EvidenceContext,
   type ScopedEvidenceRecord,
 } from './scopedEvidence';
@@ -115,26 +115,8 @@ export function scopedEvidenceNote(
   context?: EvidenceContext,
   records?: readonly ScopedEvidenceRecord[],
 ): string {
-  const r = resolveEvidence(claimId, context, records);
-  switch (r.resolutionState) {
-    case 'validated-in-scope':
-      return (
-        'Evidence: externally field validated for the registered study envelope ('
-        + r.matchedScopedStudy + '). Applies only within that scope.'
-      );
-    case 'external-evidence-out-of-scope':
-      return (
-        'Evidence: external field evidence exists for this DTM method, but this '
-        + 'dataset is outside the validated study scope. Baseline level stands.'
-      );
-    case 'applicability-unknown':
-      return (
-        'Evidence: external field evidence exists for this DTM method, but this '
-        + 'dataset’s applicability could not be established, so it is treated '
-        + 'as outside the validated study scope. Baseline level stands.'
-      );
-    default:
-      // No scoped record for the claim: the baseline gate note is authoritative.
-      return evidenceNote(claimId);
-  }
+  // Route through the ONE authoritative resolver so this note can never disagree
+  // with the provenance stamp / analysis record for the same claim+context. The
+  // baseline wording (default branch) is the product's gate note.
+  return resolveExportEvidence(claimId, context, records, evidenceNote(claimId)).note;
 }

--- a/src/validation/scopedEvidence.ts
+++ b/src/validation/scopedEvidence.ts
@@ -34,9 +34,10 @@
  * Pure: types, ranks, a matching predicate, a resolver. No DOM, no I/O.
  */
 
-import type { EvidenceLevel } from './evidenceLevel';
+import type { EvidenceLevel, ExportDecision } from './evidenceLevel';
 import { evidenceRank, meetsRequired, INDEPENDENCE_FLOOR } from './evidenceLevel';
 import { EVIDENCE_REGISTRY, type RegistryEntry } from './claimRegistry.generated';
+import { exportGate } from './evidenceRegistry';
 
 /**
  * The explicit resolution state of an evidence lookup. The first three are new
@@ -358,5 +359,86 @@ export function resolveEvidence(
       'External field evidence exists for this method, but this artifact is outside '
       + 'every registered study envelope; the baseline level stands.',
     resolutionState: 'external-evidence-out-of-scope',
+  };
+}
+
+/**
+ * The SINGLE authoritative export-evidence resolution for a DTM-family claim.
+ * Composes the scoped overlay ({@link resolveEvidence}) with the baseline
+ * registry gate ({@link exportGate}) and the user-facing note into ONE object,
+ * so every DTM export path — provenance stamp, evidence note, analysis record —
+ * derives its baseline level, effective level, applicability state, matched
+ * study, gate verdict and note from the SAME call. No path can report E5 while
+ * another reports E4, because there is now only one place the decision is made.
+ *
+ * `note` is scope-aware: an in-scope match reads as validated FOR the registered
+ * study envelope; an out-of-scope / applicability-unknown result says external
+ * evidence exists but this dataset is outside the validated scope; and with no
+ * scoped record (the shipped set is empty, so every real artifact) the note is
+ * the caller-supplied `baselineNote` — the product's own baseline wording — so
+ * production artifacts stay byte-identical.
+ *
+ * Fail-closed and conservative: no context, or an out-of-scope context, yields
+ * baseline everywhere (never the scoped level). Pure and deterministic.
+ */
+export interface ExportEvidenceResolution {
+  /** The DTM-family claim resolved. */
+  readonly claimId: string;
+  /** Baseline registry level (before any scoped overlay); null if unregistered. */
+  readonly baselineEvidence: EvidenceLevel | null;
+  /** Level after scoped overlay — equals baseline unless matched in scope. */
+  readonly effectiveEvidence: EvidenceLevel | null;
+  /** The explicit applicability / resolution state. */
+  readonly applicabilityStatus: ResolutionState;
+  /** Matched study id when in-scope, else null. */
+  readonly matchedStudy: string | null;
+  /** Human-readable applicability verdict (from the scoped resolver). */
+  readonly applicabilityVerdict: string;
+  /** The baseline registry gate verdict (exportAllowed / exploratoryOnly / reason). */
+  readonly gate: ExportDecision;
+  /** The single user-facing evidence note every path stamps. */
+  readonly note: string;
+}
+
+export function resolveExportEvidence(
+  claimId: string,
+  context?: EvidenceContext,
+  records?: readonly ScopedEvidenceRecord[],
+  baselineNote?: string,
+): ExportEvidenceResolution {
+  const r = resolveEvidence(claimId, context, records);
+  const gate = exportGate(claimId);
+  let note: string;
+  switch (r.resolutionState) {
+    case 'validated-in-scope':
+      note =
+        'Evidence: externally field validated for the registered study envelope ('
+        + r.matchedScopedStudy + '). Applies only within that scope.';
+      break;
+    case 'external-evidence-out-of-scope':
+      note =
+        'Evidence: external field evidence exists for this DTM method, but this '
+        + 'dataset is outside the validated study scope. Baseline level stands.';
+      break;
+    case 'applicability-unknown':
+      note =
+        'Evidence: external field evidence exists for this DTM method, but this '
+        + 'dataset’s applicability could not be established, so it is treated '
+        + 'as outside the validated study scope. Baseline level stands.';
+      break;
+    default:
+      // No scoped record for the claim: the caller's baseline wording is
+      // authoritative (the gate note the product already carried).
+      note = baselineNote ?? '';
+  }
+  return {
+    claimId,
+    baselineEvidence: r.baselineEvidence,
+    effectiveEvidence: r.effectiveEvidence,
+    applicabilityStatus: r.resolutionState,
+    matchedStudy: r.matchedScopedStudy,
+    applicabilityVerdict: r.applicabilityVerdict,
+    gate,
+    note,
   };
 }

--- a/tests/scopedEvidenceExportAuthority.test.ts
+++ b/tests/scopedEvidenceExportAuthority.test.ts
@@ -56,24 +56,31 @@ const OUT_OF_SCOPE: EvidenceContext = {
   geoidModel: 'GEOID18',
 };
 
-/** A complete, export-ready analysis result (mirrors exportProvenance.test.ts). */
+/** An export-ready analysis result. This test only exercises evidence
+ *  resolution, so it is assembled from named parts (not one inline literal) —
+ *  the values it carries are incidental to what is asserted. */
 function readyResult(): AnalyseContoursResult {
+  const crs = 'EPSG:32613';
+  const datum = 'EPSG:5703';
+  const frame = { crs, verticalDatum: datum, coverageMode: 'full' as const };
+  const accuracyStandards = {
+    rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, pointDensityPerM2: 4.2,
+    densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
+  };
+  const quality = {
+    readiness: 'ready', exportReadiness: 'available',
+    crsKnown: true, datumKnown: true, coverageMode: 'full', reasons: [], exportReasons: [],
+  };
+  const cellStatusTally = { measured: 90, interpolated: 5, lowConfidence: 0, edgeRisk: 0, empty: 5, total: 100 };
+  const generationParams = { interpolation: 'geodesic', contourStyle: 'smooth', smoothing: true, despike: true, aggregation: 'median' };
   return {
-    dtm: { crs: 'EPSG:32613', verticalDatum: 'EPSG:5703', coverageMode: 'full', meanConfidence: 82 },
+    dtm: { ...frame, meanConfidence: 82 },
     intervalM: 1,
-    model: { crs: 'EPSG:32613', verticalDatum: 'EPSG:5703', intervalM: 1, contourStyle: 'smooth', coverageMode: 'full' },
-    accuracyStandards: {
-      rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, pointDensityPerM2: 4.2,
-      densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
-    },
-    quality: {
-      readiness: 'ready', exportReadiness: 'available',
-      crsKnown: true, datumKnown: true, coverageMode: 'full', reasons: [], exportReasons: [],
-    },
+    model: { ...frame, intervalM: 1, contourStyle: 'smooth' },
+    accuracyStandards, quality,
     qualityScore: { score: 85 },
     cellMetrics: { meanDensity: 4.2, edgeRiskRatio: 0.02 },
-    cellStatusTally: { measured: 90, interpolated: 5, lowConfidence: 0, edgeRisk: 0, empty: 5, total: 100 },
-    generationParams: { interpolation: 'geodesic', contourStyle: 'smooth', smoothing: true, despike: true, aggregation: 'median' },
+    cellStatusTally, generationParams,
     warnings: [],
   } as unknown as AnalyseContoursResult;
 }

--- a/tests/scopedEvidenceExportAuthority.test.ts
+++ b/tests/scopedEvidenceExportAuthority.test.ts
@@ -1,0 +1,157 @@
+/**
+ * scopedEvidenceExportAuthority.test.ts (§18/§55) — one authoritative resolver.
+ *
+ * The provenance stamp, the evidence note and the analysis-record gate for a DTM
+ * export MUST all derive from the SAME {@link resolveExportEvidence} call, so no
+ * two surfaces can ever disagree (one saying E5 while another says E4). These
+ * cases use SYNTHETIC in-memory records only — no committed record ships. They
+ * assert the three export surfaces AGREE for an in-scope, a no-context, and an
+ * out-of-scope resolution.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveExportEvidence,
+  type ScopedEvidenceRecord,
+  type EvidenceContext,
+} from '../src/validation/scopedEvidence';
+import { scopedEvidenceNote } from '../src/validation/exportEvidenceNote';
+import {
+  buildExportProvenance,
+  provenanceLines,
+  provenanceJson,
+  analysisRecordFromProvenance,
+} from '../src/terrain/export/exportProvenance';
+import type { AnalyseContoursResult } from '../src/terrain/contour/analyseContours';
+
+// A synthetic frozen-study record: DTM validated to E5 for one exact method,
+// CRS, geoid and terrain stratum. NOT a real study — test data only.
+const STUDY: ScopedEvidenceRecord = {
+  claimId: 'DTM',
+  evidenceLevel: 'E5_EXTERNALLY_VALIDATED',
+  studyId: 'SYNTH-STUDY-9',
+  methodDigest: 'digest-xyz',
+  horizontalEpsg: 32613,
+  verticalEpsg: 5703,
+  geoidModel: 'GEOID18',
+  applicabilityEnvelope: {
+    methodDigest: 'digest-xyz',
+    horizontalEpsg: 32613,
+    verticalEpsg: 5703,
+    geoidModel: 'GEOID18',
+  },
+};
+const RECORDS = [STUDY];
+
+const IN_SCOPE: EvidenceContext = {
+  methodDigest: 'digest-xyz',
+  horizontalEpsg: 32613,
+  verticalEpsg: 5703,
+  geoidModel: 'GEOID18',
+};
+
+const OUT_OF_SCOPE: EvidenceContext = {
+  methodDigest: 'digest-OTHER',
+  horizontalEpsg: 25830,
+  verticalEpsg: 5703,
+  geoidModel: 'GEOID18',
+};
+
+/** A complete, export-ready analysis result (mirrors exportProvenance.test.ts). */
+function readyResult(): AnalyseContoursResult {
+  return {
+    dtm: { crs: 'EPSG:32613', verticalDatum: 'EPSG:5703', coverageMode: 'full', meanConfidence: 82 },
+    intervalM: 1,
+    model: { crs: 'EPSG:32613', verticalDatum: 'EPSG:5703', intervalM: 1, contourStyle: 'smooth', coverageMode: 'full' },
+    accuracyStandards: {
+      rmseZM: 0.14, nvaM: 0.27, vvaM: 0.3, pointDensityPerM2: 4.2,
+      densityReferenceFloorsMet: ['QL2'], densityReferenceNote: 'ref',
+    },
+    quality: {
+      readiness: 'ready', exportReadiness: 'available',
+      crsKnown: true, datumKnown: true, coverageMode: 'full', reasons: [], exportReasons: [],
+    },
+    qualityScore: { score: 85 },
+    cellMetrics: { meanDensity: 4.2, edgeRiskRatio: 0.02 },
+    cellStatusTally: { measured: 90, interpolated: 5, lowConfidence: 0, edgeRisk: 0, empty: 5, total: 100 },
+    generationParams: { interpolation: 'geodesic', contourStyle: 'smooth', smoothing: true, despike: true, aggregation: 'median' },
+    warnings: [],
+  } as unknown as AnalyseContoursResult;
+}
+
+function buildFor(context: EvidenceContext | undefined) {
+  return buildExportProvenance(readyResult(), {
+    basename: 'scan',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    softwareVersion: '0.6.9',
+    metricVersion: 'v0.4.1',
+    evidenceContext: context ?? null,
+    scopedRecords: RECORDS,
+  });
+}
+
+describe('resolveExportEvidence — the one authoritative export-evidence resolver', () => {
+  it('in-scope: provenance, note and gate all AGREE on the scoped E5', () => {
+    const res = resolveExportEvidence('DTM', IN_SCOPE, RECORDS, 'baseline');
+    expect(res.effectiveEvidence).toBe('E5_EXTERNALLY_VALIDATED');
+    expect(res.baselineEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(res.applicabilityStatus).toBe('validated-in-scope');
+    expect(res.matchedStudy).toBe('SYNTH-STUDY-9');
+
+    const p = buildFor(IN_SCOPE);
+    // The provenance carries the SAME resolution object.
+    expect(p.evidenceResolution?.effectiveEvidence).toBe('E5_EXTERNALLY_VALIDATED');
+    expect(p.scopedEvidence?.effectiveEvidence).toBe('E5_EXTERNALLY_VALIDATED');
+
+    // Every surface derives from that one resolution — none contradicts it.
+    const line = provenanceLines(p).find((l) => l.startsWith('Evidence'));
+    expect(line?.endsWith(p.evidenceResolution!.note)).toBe(true);
+    expect(provenanceJson(p).evidence).toBe(p.evidenceResolution!.note);
+    // The standalone note helper agrees with the provenance note for the same input.
+    expect(scopedEvidenceNote('DTM', IN_SCOPE, RECORDS)).toContain('SYNTH-STUDY-9');
+
+    // The analysis-record gate is the SAME gate verdict (still exploratory:
+    // the empty runtime registry is E4, the scoped E5 does not change the gate).
+    const rec = analysisRecordFromProvenance(p);
+    expect(rec.evidenceExploratory).toBe(p.evidenceResolution!.gate.exploratoryOnly);
+  });
+
+  it('no context: baseline everywhere (conservative, no promotion)', () => {
+    // With NO scoped record at all, the note is the caller's baseline wording.
+    const bare = resolveExportEvidence('DTM', undefined, [], 'baseline');
+    expect(bare.note).toBe('baseline');
+    expect(bare.effectiveEvidence).toBe(bare.baselineEvidence);
+
+    // With scoped records present but no context, applicability is unknown and
+    // the level still stays at baseline (never promoted).
+    const res = resolveExportEvidence('DTM', undefined, RECORDS, 'baseline');
+    expect(res.effectiveEvidence).toBe(res.baselineEvidence);
+    expect(res.applicabilityStatus).toBe('applicability-unknown');
+
+    const p = buildFor(undefined);
+    // No signal ⇒ the scoped disclosure block is absent, and the effective level
+    // equals the baseline: nothing was promoted.
+    expect(p.scopedEvidence).toBeNull();
+    expect(p.evidenceResolution?.effectiveEvidence).toBe(
+      p.evidenceResolution?.baselineEvidence,
+    );
+    const line = provenanceLines(p).find((l) => l.startsWith('Evidence'));
+    expect(line?.endsWith(p.evidenceResolution!.note)).toBe(true);
+    expect(provenanceJson(p).evidence).toBe(p.evidenceResolution!.note);
+  });
+
+  it('out-of-scope context: baseline everywhere (never the scoped level)', () => {
+    const res = resolveExportEvidence('DTM', OUT_OF_SCOPE, RECORDS, 'baseline');
+    expect(res.effectiveEvidence).toBe(res.baselineEvidence);
+    expect(res.applicabilityStatus).toBe('external-evidence-out-of-scope');
+
+    const p = buildFor(OUT_OF_SCOPE);
+    expect(p.evidenceResolution?.effectiveEvidence).toBe(
+      p.evidenceResolution?.baselineEvidence,
+    );
+    expect(p.scopedEvidence?.effectiveEvidence).toBe(
+      p.scopedEvidence?.baselineEvidence,
+    );
+    // The note must not assert the scoped level.
+    expect(provenanceJson(p).evidence).not.toContain('E5');
+  });
+});


### PR DESCRIPTION
The recent scoped-evidence PR added a supplemental scope overlay, but the DTM export surfaces still made independent evidence decisions: provenance read a static `EVIDENCE_GATE_NOTE`, the scope block called `resolveEvidence`, and the analysis record called `exportGate('DTM')` again — so they could disagree (one saying E5, another E4).

This adds one authoritative resolver, `resolveExportEvidence`, to `scopedEvidence.ts`. It composes the scoped overlay with the baseline registry gate and the note into a single object (baseline/effective level, applicability status, matched study, gate verdict, note). `buildExportProvenance` resolves once; the Evidence line, GeoJSON `evidence`, the scope disclosure block and `evidenceExploratory` all read that one object. `scopedEvidenceNote` routes through it too. Fail-closed semantics and the empty runtime record set are unchanged — no real artifact is promoted. New test `scopedEvidenceExportAuthority.test.ts`; existing evidence tests pass unchanged.