### PR TITLE
arch: architecture fingerprint in the release manifest + one-DTM-path guard

### DIFF
--- a/scripts/create-release-manifest.d.mts
+++ b/scripts/create-release-manifest.d.mts
@@ -1,0 +1,30 @@
+/**
+ * Types for the importable surface of `create-release-manifest.mjs`.
+ *
+ * The builder is plain ESM (it runs under bare `node` at release time), but
+ * buildManifest is a pure function tested without a staged directory, so its
+ * shape is declared here. The CLI body is guarded behind `isCliEntry`.
+ */
+
+import type { ArchitectureFingerprint } from './lint-module-graph.d.mts';
+
+export const PAYLOAD_KINDS: readonly string[];
+
+export function classifyAsset(name: string, version: string): string | null;
+
+export interface BuildManifestInput {
+  readonly version: string;
+  readonly evidence: Record<string, unknown> | null;
+  readonly assets: Record<string, { file: string; sizeBytes: number; sha256: string }>;
+  readonly builtAt: string;
+  readonly sourceDateEpoch?: string | null;
+  readonly architecture?: ArchitectureFingerprint | null;
+}
+
+export interface BuildManifestResult {
+  readonly ok: boolean;
+  readonly problems: readonly string[];
+  readonly manifest: Record<string, unknown> | null;
+}
+
+export function buildManifest(input: BuildManifestInput): BuildManifestResult;

--- a/scripts/create-release-manifest.mjs
+++ b/scripts/create-release-manifest.mjs
@@ -33,6 +33,7 @@ import { createHash } from 'node:crypto';
 import { resolve, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isCliEntry } from './lib/isCliEntry.mjs';
+import { computeArchitectureFingerprint } from './lint-module-graph.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -68,7 +69,7 @@ export function classifyAsset(name, version) {
  * the caller so this stays a pure function of its inputs and can be tested
  * without a staged directory.
  */
-export function buildManifest({ version, evidence, assets, builtAt, sourceDateEpoch = null }) {
+export function buildManifest({ version, evidence, assets, builtAt, sourceDateEpoch = null, architecture = null }) {
   const problems = [];
   if (!version) problems.push('package version is missing');
   if (!evidence) problems.push('evidence record is missing');
@@ -156,6 +157,11 @@ export function buildManifest({ version, evidence, assets, builtAt, sourceDateEp
         liveEntryKiB: evidence.bundle?.liveEntryKiB ?? null,
         ceilingKiB: evidence.bundle?.ceilingKiB ?? null,
       },
+      // A canonical, timestamp-free fingerprint of the enforced module-graph
+      // facts (fan-out ratchets, directory-pair edges, file-level cycles). The
+      // digest binds this release to a specific architecture shape: a reviewer
+      // can recompute it from the source tree and match it byte for byte.
+      architecture,
       // The manifest hashes payload assets only — never itself, never
       // SHA256SUMS. See the header for why that cycle cannot be closed.
       artifacts: Object.fromEntries(PAYLOAD_KINDS.map((k) => [k, assets[k]])),
@@ -213,6 +219,7 @@ if (isMain()) {
     assets,
     builtAt: new Date().toISOString(),
     sourceDateEpoch: process.env.SOURCE_DATE_EPOCH ?? null,
+    architecture: computeArchitectureFingerprint(),
   });
 
   if (!built.ok) {

--- a/scripts/lint-module-graph.d.mts
+++ b/scripts/lint-module-graph.d.mts
@@ -1,0 +1,51 @@
+/**
+ * Types for the importable surface of `lint-module-graph.mjs`.
+ *
+ * The gate is plain ESM because it runs under bare `node` in CI with no build
+ * step, but the architecture-fingerprint test and the release-manifest builder
+ * import its measurement so the enforced graph facts and the published
+ * fingerprint cannot drift apart. Only the two pure, side-effect-free exports
+ * are declared; the CLI body is guarded behind `isCliEntry` and has no types.
+ */
+
+export interface ModuleGraphPairMeasurement {
+  readonly runtime: number;
+  readonly typeOnly: number;
+  readonly dynamic: number;
+  readonly edges: readonly string[];
+  readonly lines: ReadonlyMap<string, number>;
+}
+
+export interface ModuleGraphFanOutMeasurement {
+  readonly runtime: number;
+  readonly typeOnly: number;
+  readonly dynamic: number;
+  readonly modules: readonly string[];
+  readonly lines: ReadonlyMap<string, number>;
+}
+
+export interface ModuleGraphMeasurement {
+  readonly graph: ReadonlyMap<string, unknown>;
+  readonly problems: readonly string[];
+  readonly pairs: ReadonlyMap<string, ModuleGraphPairMeasurement>;
+  readonly fanOut: ReadonlyMap<string, ModuleGraphFanOutMeasurement>;
+  readonly cycles: { readonly count: number; readonly components: readonly string[][] };
+  readonly inlineOnlyTotal: number;
+  readonly totalEdges: number;
+  readonly filesScanned: number;
+}
+
+export interface ArchitectureFingerprint {
+  readonly moduleCount: number;
+  readonly edgeCount: number;
+  readonly cycleCount: number;
+  readonly mainFanOut: number;
+  readonly viewerFanOut: number;
+  readonly architectureDigest: string;
+}
+
+export function measureModuleGraph(): ModuleGraphMeasurement;
+
+export function computeArchitectureFingerprint(
+  measurement?: ModuleGraphMeasurement,
+): ArchitectureFingerprint;

--- a/scripts/lint-module-graph.mjs
+++ b/scripts/lint-module-graph.mjs
@@ -68,6 +68,8 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { resolve, dirname, relative, sep, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+import { isCliEntry } from './lib/isCliEntry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const BASELINE = resolve(ROOT, 'docs/validation/module-graph-baseline.json');
@@ -423,41 +425,13 @@ function sourceFiles(dir, out = []) {
   return out;
 }
 
-const problems = [];
-
-/** file → { value: Map(key → line), type: Map, dynamic: Map, inlineOnly: number } */
-const graph = new Map();
-
-for (const abs of sourceFiles(SRC)) {
-  const from = rel(abs);
-  const { statics, dynamics } = scanSpecifiers(readFileSync(abs, 'utf8'));
-  const entry = { value: new Map(), type: new Map(), dynamic: new Map(), inlineOnly: 0 };
-  for (const s of statics) {
-    const r = resolveSpec(abs, s.spec);
-    if (r.kind === 'unresolved') {
-      problems.push(`${from}:${s.line}: the relative specifier "${s.spec}" resolves to no file. The scan cannot classify an edge it cannot resolve.`);
-      continue;
-    }
-    if (s.inlineOnly) entry.inlineOnly++;
-    const bucket = s.typeOnly ? entry.type : entry.value;
-    if (!bucket.has(r.key)) bucket.set(r.key, s.line);
-  }
-  for (const d of dynamics) {
-    if (d.spec === null) continue; // a computed specifier names no module
-    const r = resolveSpec(abs, d.spec);
-    if (r.kind === 'unresolved') continue; // a lazy edge is not enforced either way
-    if (!entry.dynamic.has(r.key)) entry.dynamic.set(r.key, d.line);
-  }
-  graph.set(from, entry);
-}
-
 /** A module reached only by `import type` is not a runtime edge of any kind. */
 const typeOnlyKeys = (entry) => [...entry.type.keys()].filter((k) => !entry.value.has(k));
 
 // ── the seven measurements ──────────────────────────────────────────────────
 
 /** Directory-pair edges, one entry per distinct file pair. */
-function measurePair(pair) {
+function measurePair(graph, pair) {
   const runtime = [];
   const type = [];
   const dynamic = [];
@@ -478,7 +452,7 @@ function measurePair(pair) {
 }
 
 /** Distinct modules one file imports, internal files and packages alike. */
-function measureFanOut(file) {
+function measureFanOut(graph, problems, file) {
   const entry = graph.get(file);
   if (!entry) {
     problems.push(`${file}: not found in src/. The fan-out measurement names a file that does not exist.`);
@@ -500,7 +474,7 @@ function measureFanOut(file) {
  * Tarjan, iterative: the graph is 682 files deep in places and a recursive walk
  * is a stack-overflow waiting for the wrong import to be added.
  */
-function measureCycles() {
+function measureCycles(graph) {
   const index = new Map();
   const low = new Map();
   const onStack = new Set();
@@ -556,10 +530,81 @@ function measureCycles() {
   return { count: components.length, components };
 }
 
-const pairs = new Map(PAIRS.map((p) => [p.id, measurePair(p)]));
-const fanOut = new Map(FAN_OUT_FILES.map((f) => [f, measureFanOut(f)]));
-const cycles = measureCycles();
-const inlineOnlyTotal = [...graph.values()].reduce((a, e) => a + e.inlineOnly, 0);
+/**
+ * Scan src/ once and return every enforced graph fact.
+ *
+ * Pure with respect to the working tree: no console output, no process.exit,
+ * no side effect, so it is safe to import from a release/build step or a test.
+ * The CLI lint below is a thin caller of this same measurement.
+ */
+export function measureModuleGraph() {
+  const problems = [];
+  /** file → { value: Map(key → line), type: Map, dynamic: Map, inlineOnly: number } */
+  const graph = new Map();
+
+  for (const abs of sourceFiles(SRC)) {
+    const from = rel(abs);
+    const { statics, dynamics } = scanSpecifiers(readFileSync(abs, 'utf8'));
+    const entry = { value: new Map(), type: new Map(), dynamic: new Map(), inlineOnly: 0 };
+    for (const s of statics) {
+      const r = resolveSpec(abs, s.spec);
+      if (r.kind === 'unresolved') {
+        problems.push(`${from}:${s.line}: the relative specifier "${s.spec}" resolves to no file. The scan cannot classify an edge it cannot resolve.`);
+        continue;
+      }
+      if (s.inlineOnly) entry.inlineOnly++;
+      const bucket = s.typeOnly ? entry.type : entry.value;
+      if (!bucket.has(r.key)) bucket.set(r.key, s.line);
+    }
+    for (const d of dynamics) {
+      if (d.spec === null) continue; // a computed specifier names no module
+      const r = resolveSpec(abs, d.spec);
+      if (r.kind === 'unresolved') continue; // a lazy edge is not enforced either way
+      if (!entry.dynamic.has(r.key)) entry.dynamic.set(r.key, d.line);
+    }
+    graph.set(from, entry);
+  }
+
+  const pairs = new Map(PAIRS.map((p) => [p.id, measurePair(graph, p)]));
+  const fanOut = new Map(FAN_OUT_FILES.map((f) => [f, measureFanOut(graph, problems, f)]));
+  const cycles = measureCycles(graph);
+  const inlineOnlyTotal = [...graph.values()].reduce((a, e) => a + e.inlineOnly, 0);
+  // Total distinct runtime import edges (internal files and packages alike).
+  const totalEdges = [...graph.values()].reduce((a, e) => a + e.value.size, 0);
+
+  return { graph, problems, pairs, fanOut, cycles, inlineOnlyTotal, totalEdges, filesScanned: graph.size };
+}
+
+/**
+ * A canonical, timestamp-free fingerprint of the enforced architecture facts.
+ *
+ * `architectureDigest` is the sha256 of a sorted serialization of exactly the
+ * facts this gate enforces — the directory-pair edges, the two fan-out module
+ * lists, and the file-level cycle components — so the same tree always yields
+ * the same hex and any change to the enforced graph moves the digest.
+ */
+export function computeArchitectureFingerprint(measurement = measureModuleGraph()) {
+  if (measurement.problems.length > 0) {
+    throw new Error(
+      `architecture fingerprint refused; the module-graph scan reported a problem:\n  ${measurement.problems.join('\n  ')}`,
+    );
+  }
+  const enforced = {
+    edges: Object.fromEntries(PAIRS.map((p) => [p.id, measurement.pairs.get(p.id).edges])),
+    fanOut: Object.fromEntries(FAN_OUT_FILES.map((f) => [f, measurement.fanOut.get(f).modules])),
+    cycles: measurement.cycles.components,
+  };
+  const canonical = JSON.stringify(enforced);
+  const architectureDigest = createHash('sha256').update(canonical).digest('hex');
+  return {
+    moduleCount: measurement.filesScanned,
+    edgeCount: measurement.totalEdges,
+    cycleCount: measurement.cycles.count,
+    mainFanOut: measurement.fanOut.get('src/main.ts').runtime,
+    viewerFanOut: measurement.fanOut.get('src/render/Viewer.ts').runtime,
+    architectureDigest,
+  };
+}
 
 // ── --update ────────────────────────────────────────────────────────────────
 
@@ -575,8 +620,11 @@ const PURPOSE =
   + 'the static value graph. Run "node scripts/lint-module-graph.mjs --update" to bank a '
   + 'reduction. There is no flag that raises a number.';
 
-if (process.argv.includes('--update') || !existsSync(BASELINE)) {
-  if (problems.length > 0) {
+function runCli() {
+  const { graph, problems, pairs, fanOut, cycles, inlineOnlyTotal } = measureModuleGraph();
+
+  if (process.argv.includes('--update') || !existsSync(BASELINE)) {
+    if (problems.length > 0) {
     console.error('module-graph baseline NOT written; the scan itself reported a problem:\n');
     for (const p of problems) console.error(`  • ${p}`);
     process.exit(1);
@@ -690,7 +738,10 @@ const summary = [
 const dropped = PAIRS.reduce((a, p) => a + (baseline.edges[p.id].runtime - pairs.get(p.id).runtime), 0)
   + FAN_OUT_FILES.reduce((a, f) => a + (baseline.fanOut[f].runtime - fanOut.get(f).runtime), 0)
   + (baseCycles - cycles.count);
-console.log(
-  `lint:module-graph OK [runtime edges only; ${graph.size} files scanned]: ${summary.join(', ')}`
-  + (dropped > 0 ? ` (${dropped} fewer than baseline; run --update to bank it).` : '.'),
-);
+  console.log(
+    `lint:module-graph OK [runtime edges only; ${graph.size} files scanned]: ${summary.join(', ')}`
+    + (dropped > 0 ? ` (${dropped} fewer than baseline; run --update to bank it).` : '.'),
+  );
+}
+
+if (isCliEntry(import.meta.url)) runCli();

--- a/tests/architectureFingerprint.test.ts
+++ b/tests/architectureFingerprint.test.ts
@@ -1,0 +1,117 @@
+/**
+ * architectureFingerprint.test.ts: the release manifest carries a canonical,
+ * timestamp-free fingerprint of the enforced module-graph facts.
+ *
+ * The fingerprint is derived from the SAME measurement scripts/lint-module-graph.mjs
+ * enforces (directory-pair edges, the two fan-out ratchets, file-level cycles),
+ * so a reviewer can recompute it from the source tree and match it byte for
+ * byte. Three properties matter and are checked here:
+ *
+ *   1. Deterministic — the same tree yields the same hex on every run. A digest
+ *      that drifted between two calls on one tree would prove a timestamp or a
+ *      set-iteration order leaked into the canonical form.
+ *   2. Anchored to the committed baseline — the counts the fingerprint reports
+ *      are the counts the shrink-only gate holds, so the two can never disagree
+ *      silently.
+ *   3. Timestamp-free — the fingerprint object is exactly six scalar fields and
+ *      the digest is a 64-hex string; nothing date-shaped rides along.
+ *
+ * The manifest builder then threads the fingerprint into an `architecture`
+ * block, tested against buildManifest directly so it needs no staged release.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  computeArchitectureFingerprint,
+  measureModuleGraph,
+} from '../scripts/lint-module-graph.mjs';
+import { buildManifest } from '../scripts/create-release-manifest.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const BASELINE = resolve(ROOT, 'docs/validation/module-graph-baseline.json');
+
+describe('architecture fingerprint', () => {
+  it('is deterministic: the same tree yields the same digest', () => {
+    const a = computeArchitectureFingerprint();
+    const b = computeArchitectureFingerprint();
+    expect(a.architectureDigest).toBe(b.architectureDigest);
+    expect(a).toEqual(b);
+  });
+
+  it('reports exactly the six documented scalar fields', () => {
+    const fp = computeArchitectureFingerprint();
+    expect(Object.keys(fp).sort()).toEqual(
+      [
+        'architectureDigest',
+        'cycleCount',
+        'edgeCount',
+        'mainFanOut',
+        'moduleCount',
+        'viewerFanOut',
+      ].sort(),
+    );
+    for (const [k, v] of Object.entries(fp)) {
+      if (k === 'architectureDigest') continue;
+      expect(typeof v).toBe('number');
+      expect(Number.isInteger(v)).toBe(true);
+    }
+  });
+
+  it('carries no timestamp: the digest is a 64-hex string and no field is date-shaped', () => {
+    const fp = computeArchitectureFingerprint();
+    expect(fp.architectureDigest).toMatch(/^[0-9a-f]{64}$/);
+    const asText = JSON.stringify(fp);
+    // An ISO-8601 date or a plausible epoch-millis timestamp would betray a clock.
+    expect(asText).not.toMatch(/\d{4}-\d{2}-\d{2}T/);
+    expect(asText).not.toMatch(/"\d{13}"/);
+  });
+
+  it('matches the committed module-graph baseline the gate enforces', () => {
+    const fp = computeArchitectureFingerprint();
+    const baseline = JSON.parse(readFileSync(BASELINE, 'utf8'));
+    expect(fp.cycleCount).toBe(baseline.cycles.count);
+    expect(fp.mainFanOut).toBe(baseline.fanOut['src/main.ts'].runtime);
+    expect(fp.viewerFanOut).toBe(baseline.fanOut['src/render/Viewer.ts'].runtime);
+    // The live measurement and the fingerprint agree on the same counts.
+    const m = measureModuleGraph();
+    expect(m.problems).toEqual([]);
+    expect(fp.moduleCount).toBe(m.filesScanned);
+    expect(fp.mainFanOut).toBe(m.fanOut.get('src/main.ts')!.runtime);
+    expect(fp.viewerFanOut).toBe(m.fanOut.get('src/render/Viewer.ts')!.runtime);
+  });
+
+  it('is threaded into the release manifest under an `architecture` block', () => {
+    const fp = computeArchitectureFingerprint();
+    const version = '9.9.9';
+    const evidence = {
+      version,
+      commit: 'abc1234',
+      tag: `v${version}`,
+      releaseAuthoritative: true,
+      gateExit: 0,
+      stages: { mutation: 'executed' },
+    };
+    const assets = Object.fromEntries(
+      ['sourceZip', 'deployZip', 'sbom', 'evidence', 'gateLog', 'gateLogSha256', 'releaseNotes'].map(
+        (k) => [k, { file: `${k}.bin`, sizeBytes: 1, sha256: 'x' }],
+      ),
+    );
+    const built = buildManifest({
+      version,
+      evidence,
+      assets,
+      builtAt: '2026-01-01T00:00:00.000Z',
+      architecture: fp,
+    });
+    expect(built.ok).toBe(true);
+    expect(built.manifest!.architecture).toEqual(fp);
+    // The block is optional in the pure builder — omitting it leaves null,
+    // never a thrown error, so a caller that has no measurement still builds.
+    const without = buildManifest({ version, evidence, assets, builtAt: '2026-01-01T00:00:00.000Z' });
+    expect(without.ok).toBe(true);
+    expect(without.manifest!.architecture).toBeNull();
+  });
+});

--- a/tests/oneDtmPath.test.ts
+++ b/tests/oneDtmPath.test.ts
@@ -1,0 +1,140 @@
+/**
+ * oneDtmPath.test.ts: a STATIC guard that production DTM construction converges
+ * on ONE canonical implementation.
+ *
+ * #830 already proves at RUNTIME that the checkpoint validator's DTM is the
+ * cell-for-cell equal of `computeTerrainCore`'s. This test is the compile-time
+ * complement: it asserts that every path which builds a bare-earth DTM routes
+ * through the shared rasterise + surface-build primitives —
+ *   `rasterizeDtm`          (median/mean per-cell aggregation of ground returns)
+ *   `buildSurfaceFromRaster` (despike -> geodesic void-fill -> guarded confidence)
+ * — rather than reimplementing aggregation, despike or fill on its own.
+ *
+ * Two ways a second implementation could creep in, both caught here:
+ *
+ *   1. A DTM-building module stops importing the shared builder and grows its
+ *      own scatter/fill. Guarded by (B): the known producers must import both
+ *      primitives.
+ *   2. The despike / geodesic-fill / confidence primitives get imported OUTSIDE
+ *      the ground core to wire up a competing surface. Guarded by (C): those
+ *      primitives are owned by `src/terrain/ground/` and imported nowhere else.
+ *
+ * The primitives themselves are asserted to have exactly one definition each
+ * (A), so "the shared builder" names a single function, not a family.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, dirname, relative, sep, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = resolve(ROOT, 'src');
+const posix = (p: string) => p.split(sep).join('/');
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir).sort()) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      sourceFiles(full, out);
+      continue;
+    }
+    if (!name.endsWith('.ts') || name.endsWith('.test.ts') || name.endsWith('.d.ts')) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+const FILES = sourceFiles(SRC).map((abs) => ({
+  rel: posix(relative(ROOT, abs)),
+  text: readFileSync(abs, 'utf8'),
+}));
+
+/** Value (non-type-only) import specifiers a file declares. */
+function valueImports(text: string): string[] {
+  const specs: string[] = [];
+  const re = /(?:^|\n)\s*(?:import|export)\b([^;\n]*?)\bfrom\s*['"]([^'"]+)['"]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const clause = m[1];
+    // `import type { … } from` / `export type { … } from` are erased — skip.
+    if (/^\s*type\b/.test(clause)) continue;
+    specs.push(m[2]);
+  }
+  return specs;
+}
+
+/** Count of `export function NAME(` across the tree. */
+function definitionCount(name: string): number {
+  let n = 0;
+  for (const f of FILES) {
+    const re = new RegExp(`export function ${name}\\s*\\(`, 'g');
+    n += (f.text.match(re) ?? []).length;
+  }
+  return n;
+}
+
+describe('one canonical DTM path', () => {
+  // (A) The shared primitives are singletons: "the shared builder" is one
+  //     function, so routing through it is unambiguous.
+  it('defines each shared DTM primitive exactly once', () => {
+    expect(definitionCount('rasterizeDtm')).toBe(1);
+    expect(definitionCount('buildSurfaceFromRaster')).toBe(1);
+  });
+
+  // (B) Every known DTM-constructing path imports BOTH shared primitives.
+  it('routes every known DTM producer through rasterizeDtm + buildSurfaceFromRaster', () => {
+    const producers = [
+      'src/terrain/contour/analyseContours.ts', // computeTerrainCore (the delivered surface)
+      'src/terrain/validate/dtmSurfaceModel.ts', // DtmSurfaceModel (blocked cross-validation)
+      'src/terrain/validate/holdoutRmse.ts', // hold-out / checkpoint reducer
+      'src/terrain/change/compareEpochs.ts', // candidate epoch-surface generator
+    ];
+    for (const rel of producers) {
+      const f = FILES.find((x) => x.rel === rel);
+      expect(f, `${rel} is missing — update this guard if the DTM producer moved`).toBeTruthy();
+      const imps = valueImports(f!.text);
+      const usesRaster = imps.some((s) => /\/rasterizeDtm$/.test(s) || s.endsWith('ground/rasterizeDtm'));
+      const usesBuilder = imps.some((s) => /\/surfaceFromRaster$/.test(s) || s.endsWith('ground/surfaceFromRaster'));
+      expect(usesRaster, `${rel} must import rasterizeDtm`).toBe(true);
+      expect(usesBuilder, `${rel} must import buildSurfaceFromRaster`).toBe(true);
+    }
+  });
+
+  // (C) The despike and geodesic void-fill primitives — the two steps that turn
+  //     a raster of measured cells into a delivered bare-earth surface — are
+  //     OWNED by the ground core. No module outside src/terrain/ground/ may
+  //     value-import them, which is how a second surface builder would have to
+  //     reach them. (cellConfidence is deliberately NOT here: it is a shared
+  //     cell-status/confidence module read all over the terrain layer, not a
+  //     surface-assembly step.)
+  it('confines the despike + geodesic-fill surface primitives to the ground core', () => {
+    const strays: string[] = [];
+    for (const f of FILES) {
+      if (f.rel.startsWith('src/terrain/ground/')) continue;
+      for (const spec of valueImports(f.text)) {
+        // Match only the ground-relative module, not an unrelated same-named file.
+        if (/(^|\/)(despike|geodesicFill)$/.test(spec)) {
+          strays.push(`${f.rel} -> ${spec}`);
+        }
+      }
+    }
+    expect(
+      strays,
+      'these files reach a ground-core DTM primitive from outside src/terrain/ground/ — ' +
+        'a candidate second DTM path; route through buildSurfaceFromRaster instead:\n' +
+        strays.join('\n'),
+    ).toEqual([]);
+  });
+
+  // (D) Both terrain-raster backends delegate the median DTM scatter to the CPU
+  //     rasterizeDtm rather than growing a parallel GPU/CPU aggregator: the
+  //     backend contract's `gridFromPoints` slot is filled by rasterizeDtm.
+  it('wires both engine backends to rasterizeDtm for the DTM scatter', () => {
+    for (const rel of ['src/terrain/engine/cpuBackend.ts', 'src/terrain/engine/gpuBackend.ts']) {
+      const f = FILES.find((x) => x.rel === rel);
+      expect(f, `${rel} is missing`).toBeTruthy();
+      expect(f!.text).toMatch(/gridFromPoints:\s*rasterizeDtm/);
+    }
+  });
+});


### PR DESCRIPTION
Two genuinely-missing architecture-hardening pieces; no existing graph system rebuilt, no numerical behaviour changed, no src/ line touched.

TASK 1 — architecture fingerprint. lint-module-graph.mjs now exports a pure `measureModuleGraph()` and `computeArchitectureFingerprint()`; its CLI is guarded by `isCliEntry`, so the lint runs and passes exactly as before. The fingerprint is `{moduleCount, edgeCount, cycleCount, mainFanOut, viewerFanOut, architectureDigest}`, where the digest is sha256 of a sorted, timestamp-free serialization of the enforced graph facts. create-release-manifest.mjs threads it into an `architecture` block.

TASK 2 — one-DTM-path static guard. oneDtmPath.test.ts asserts every known DTM producer (computeTerrainCore, DtmSurfaceModel, hold-out/checkpoint reducer, epoch-surface generator) routes through the shared `rasterizeDtm` + `buildSurfaceFromRaster`; the despike/geodesic-fill primitives stay owned by the ground core; both engine backends delegate the median scatter to rasterizeDtm. Exactly one canonical path found.

Tests: architectureFingerprint + oneDtmPath green, moduleGraphLint unchanged, tsc clean, bucket partition OK, module-graph baseline untouched.