### PR TITLE
feat(validation): evidence boundary inspector view over resolveEvidence

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -34,6 +34,13 @@
       "review": "2027-02-28"
     },
     {
+      "path": "src/validation/evidenceBoundaryInspector.ts",
+      "status": "validation-only",
+      "why": "A read-only projection of one resolveEvidence() lookup: it copies the resolver's decision verbatim and adds a per-envelope-field breakdown so the scoped-evidence verdict is human-auditable. It holds no applicability logic and produces evidence ABOUT the resolver; only its own test imports it, and becoming reachable would give the running app a second place that describes the evidence boundary.",
+      "graduation": "A provenance or report surface renders the field-by-field envelope breakdown and calls buildEvidenceContractView from the application graph.",
+      "review": "2027-02-28"
+    },
+    {
       "path": "src/classification/classificationEvidence.ts",
       "status": "staged",
       "why": "The per-point evidence record for a classification decision. The derived classifier that ships does not attach one, so no production module constructs or reads the record.",

--- a/src/validation/evidenceBoundaryInspector.ts
+++ b/src/validation/evidenceBoundaryInspector.ts
@@ -1,0 +1,164 @@
+/**
+ * evidenceBoundaryInspector.ts
+ *
+ * A human-auditable VIEW over {@link resolveEvidence}. It contains NO
+ * applicability logic of its own: it calls the resolver, copies the resolver's
+ * decision verbatim, and adds a per-envelope-field breakdown that EXPLAINS why
+ * the artifact context did or did not fall inside a scoped study's envelope.
+ *
+ * The distinction matters. `resolveEvidence` is the single authority on whether
+ * external evidence applies; this module must never recompute or override its
+ * `effectiveEvidence` / `resolutionState`. It only projects that result plus a
+ * field-by-field comparison, so a reader can see exactly which envelope key
+ * matched, mismatched, was missing from the context, or was left unconstrained.
+ *
+ * Pure: it builds a plain object from the resolver's output. No DOM, no I/O.
+ */
+
+import { resolveEvidence } from './scopedEvidence';
+import type {
+  ScopedEvidenceRecord,
+  EvidenceContext,
+  ApplicabilityEnvelope,
+} from './scopedEvidence';
+import { evidenceRank } from './evidenceLevel';
+
+/** The per-field verdict of one envelope key against the artifact context. */
+export type EnvelopeCheckStatus = 'match' | 'mismatch' | 'missing' | 'unconstrained';
+
+/** One row of the envelope breakdown: what the record pinned vs what the context carried. */
+export interface EnvelopeCheck {
+  /** The envelope field name (a key of {@link ApplicabilityEnvelope}). */
+  readonly field: string;
+  /** The value the record's envelope pins for this field (undefined when unconstrained). */
+  readonly expected: unknown;
+  /** The value the artifact context supplies for this field (undefined when absent). */
+  readonly observed: unknown;
+  /**
+   * `match`         — record pins it, context supplies an equal value;
+   * `mismatch`      — record pins it, context supplies a differing value;
+   * `missing`       — record pins it, context does not supply it;
+   * `unconstrained` — the record does not pin this field.
+   */
+  readonly status: EnvelopeCheckStatus;
+}
+
+/**
+ * A pure projection of one {@link resolveEvidence} lookup. The decision fields
+ * (`effectiveEvidence`, `resolutionState`, `matchedStudy`, `applicabilityVerdict`,
+ * `baselineEvidence`) are copied verbatim from the resolver; `envelopeChecks`
+ * explains them field by field.
+ */
+export interface EvidenceContractView {
+  readonly claimId: string;
+  readonly baselineEvidence: string | null;
+  readonly effectiveEvidence: string | null;
+  /** Exactly `resolveEvidence`'s state string — never recomputed. */
+  readonly resolutionState: string;
+  readonly matchedStudy: string | null;
+  readonly applicabilityVerdict: string;
+  readonly envelopeChecks: readonly EnvelopeCheck[];
+}
+
+/**
+ * The envelope keys, in a stable display order. Every key of
+ * {@link ApplicabilityEnvelope} appears so the breakdown is complete: a field the
+ * record omits is reported `unconstrained` rather than silently dropped.
+ */
+const ENVELOPE_FIELDS: readonly (keyof ApplicabilityEnvelope)[] = [
+  'methodDigest',
+  'horizontalEpsg',
+  'verticalEpsg',
+  'geoidModel',
+  'verticalDatum',
+  'terrainStratum',
+  'studyArea',
+  'slopeRange',
+  'aggregation',
+  'interpolation',
+  'cellSize',
+  'trustGroundClassification',
+  'candidateRevision',
+];
+
+/** Compare one envelope field against the context; pure, decides nothing. */
+function checkField(
+  field: keyof ApplicabilityEnvelope,
+  env: ApplicabilityEnvelope,
+  ctx: EvidenceContext | undefined,
+): EnvelopeCheck {
+  const expected = env[field];
+  if (expected === undefined) {
+    // The record does not pin this field. Still surface any observed value.
+    const observed =
+      field === 'slopeRange' ? ctx?.slopeDegrees : (ctx as Record<string, unknown> | undefined)?.[field];
+    return { field, expected: undefined, observed, status: 'unconstrained' };
+  }
+
+  if (field === 'slopeRange') {
+    const [lo, hi] = expected as readonly [number, number];
+    const observed = ctx?.slopeDegrees;
+    if (observed === undefined) return { field, expected, observed, status: 'missing' };
+    const status: EnvelopeCheckStatus = observed >= lo && observed <= hi ? 'match' : 'mismatch';
+    return { field, expected, observed, status };
+  }
+
+  const observed = (ctx as Record<string, unknown> | undefined)?.[field];
+  if (observed === undefined) return { field, expected, observed: undefined, status: 'missing' };
+  return { field, expected, observed, status: observed === expected ? 'match' : 'mismatch' };
+}
+
+/**
+ * Pick the record whose envelope the breakdown should explain: the record that
+ * WOULD apply if any matched, otherwise the highest scoped level registered for
+ * the claim (the one the resolver considers first). Returns null when the claim
+ * has no scoped record — the caller then emits an empty breakdown.
+ */
+function selectRecord(
+  matchedStudyId: string | null,
+  forClaim: readonly ScopedEvidenceRecord[],
+): ScopedEvidenceRecord | null {
+  if (forClaim.length === 0) return null;
+  if (matchedStudyId !== null) {
+    const matched = forClaim.find((r) => r.studyId === matchedStudyId);
+    if (matched) return matched;
+  }
+  return forClaim.reduce((best, r) =>
+    best === null || evidenceRank(r.evidenceLevel) > evidenceRank(best.evidenceLevel) ? r : best,
+    null as ScopedEvidenceRecord | null,
+  );
+}
+
+/**
+ * Build the auditable view for a claim. Calls {@link resolveEvidence} and copies
+ * its decision verbatim, then attaches a per-envelope-field breakdown for the
+ * record that would apply. NEVER recomputes or overrides the resolver's verdict.
+ */
+export function buildEvidenceContractView(
+  claimId: string,
+  context?: EvidenceContext,
+  records?: readonly ScopedEvidenceRecord[],
+): EvidenceContractView {
+  const resolution =
+    records === undefined
+      ? resolveEvidence(claimId, context)
+      : resolveEvidence(claimId, context, records);
+
+  const forClaim = (records ?? []).filter((r) => r.claimId === claimId);
+  const record = selectRecord(resolution.matchedScopedStudy, forClaim);
+
+  const envelopeChecks =
+    record === null
+      ? []
+      : ENVELOPE_FIELDS.map((f) => checkField(f, record.applicabilityEnvelope, context));
+
+  return {
+    claimId,
+    baselineEvidence: resolution.baselineEvidence,
+    effectiveEvidence: resolution.effectiveEvidence,
+    resolutionState: resolution.resolutionState,
+    matchedStudy: resolution.matchedScopedStudy,
+    applicabilityVerdict: resolution.applicabilityVerdict,
+    envelopeChecks,
+  };
+}

--- a/tests/evidenceBoundaryInspector.test.ts
+++ b/tests/evidenceBoundaryInspector.test.ts
@@ -1,0 +1,159 @@
+/**
+ * evidenceBoundaryInspector.test.ts
+ *
+ * The inspector is a VIEW, not an authority. Every case asserts two things:
+ *   1. the view's decision fields are byte-equal to `resolveEvidence`'s output
+ *      (the inspector never diverges from the authority), and
+ *   2. the per-field envelope breakdown resolves each status correctly
+ *      (match / mismatch / missing / unconstrained).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveEvidence,
+  type ScopedEvidenceRecord,
+  type EvidenceContext,
+} from '../src/validation/scopedEvidence';
+import {
+  buildEvidenceContractView,
+  type EnvelopeCheckStatus,
+} from '../src/validation/evidenceBoundaryInspector';
+
+const STUDY: ScopedEvidenceRecord = {
+  claimId: 'DTM',
+  evidenceLevel: 'E5_EXTERNALLY_VALIDATED',
+  studyId: 'SYNTH-STUDY-1',
+  methodDigest: 'digest-abc',
+  horizontalEpsg: 32613,
+  verticalEpsg: 5703,
+  geoidModel: 'GEOID18',
+  terrainStratum: 'bare-earth',
+  applicabilityEnvelope: {
+    methodDigest: 'digest-abc',
+    horizontalEpsg: 32613,
+    verticalEpsg: 5703,
+    geoidModel: 'GEOID18',
+    terrainStratum: 'bare-earth',
+  },
+};
+
+const IN_ENVELOPE: EvidenceContext = {
+  methodDigest: 'digest-abc',
+  horizontalEpsg: 32613,
+  verticalEpsg: 5703,
+  geoidModel: 'GEOID18',
+  terrainStratum: 'bare-earth',
+};
+
+const RECORDS = [STUDY];
+
+/** The constrained fields of STUDY's envelope. */
+const PINNED = ['methodDigest', 'horizontalEpsg', 'verticalEpsg', 'geoidModel', 'terrainStratum'];
+
+function statusOf(
+  checks: readonly { field: string; status: EnvelopeCheckStatus }[],
+  field: string,
+): EnvelopeCheckStatus {
+  const row = checks.find((c) => c.field === field);
+  if (!row) throw new Error(`no envelope check for ${field}`);
+  return row.status;
+}
+
+/** The view's decision must equal the authority's decision, always. */
+function assertMirrorsAuthority(
+  claimId: string,
+  context?: EvidenceContext,
+  records?: readonly ScopedEvidenceRecord[],
+) {
+  const authority = resolveEvidence(claimId, context, records);
+  const view = buildEvidenceContractView(claimId, context, records);
+  expect(view.effectiveEvidence).toBe(authority.effectiveEvidence);
+  expect(view.resolutionState).toBe(authority.resolutionState);
+  expect(view.baselineEvidence).toBe(authority.baselineEvidence);
+  expect(view.matchedStudy).toBe(authority.matchedScopedStudy);
+  expect(view.applicabilityVerdict).toBe(authority.applicabilityVerdict);
+  return view;
+}
+
+describe('buildEvidenceContractView — mirrors resolveEvidence, explains the envelope', () => {
+  it('in-envelope context: effective = scoped E5, every pinned field matches', () => {
+    const view = assertMirrorsAuthority('DTM', IN_ENVELOPE, RECORDS);
+    expect(view.effectiveEvidence).toBe('E5_EXTERNALLY_VALIDATED');
+    expect(view.resolutionState).toBe('validated-in-scope');
+    expect(view.matchedStudy).toBe('SYNTH-STUDY-1');
+    for (const f of PINNED) expect(statusOf(view.envelopeChecks, f)).toBe('match');
+    // A field the record does not pin reads unconstrained.
+    expect(statusOf(view.envelopeChecks, 'cellSize')).toBe('unconstrained');
+  });
+
+  it('methodDigest mismatch: that field mismatch, effective drops to baseline (out-of-scope)', () => {
+    const view = assertMirrorsAuthority(
+      'DTM',
+      { ...IN_ENVELOPE, methodDigest: 'digest-XXX' },
+      RECORDS,
+    );
+    expect(view.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(view.resolutionState).toBe('external-evidence-out-of-scope');
+    expect(statusOf(view.envelopeChecks, 'methodDigest')).toBe('mismatch');
+    expect(statusOf(view.envelopeChecks, 'horizontalEpsg')).toBe('match');
+  });
+
+  it('EPSG mismatch: that field mismatch, effective = baseline', () => {
+    const view = assertMirrorsAuthority(
+      'DTM',
+      { ...IN_ENVELOPE, horizontalEpsg: 32614 },
+      RECORDS,
+    );
+    expect(view.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(statusOf(view.envelopeChecks, 'horizontalEpsg')).toBe('mismatch');
+  });
+
+  it('geoid mismatch: that field mismatch, effective = baseline', () => {
+    const view = assertMirrorsAuthority(
+      'DTM',
+      { ...IN_ENVELOPE, geoidModel: 'GEOID12B' },
+      RECORDS,
+    );
+    expect(view.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(statusOf(view.envelopeChecks, 'geoidModel')).toBe('mismatch');
+  });
+
+  it('terrain mismatch (forest): that field mismatch, effective = baseline', () => {
+    const view = assertMirrorsAuthority(
+      'DTM',
+      { ...IN_ENVELOPE, terrainStratum: 'forest' },
+      RECORDS,
+    );
+    expect(view.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(statusOf(view.envelopeChecks, 'terrainStratum')).toBe('mismatch');
+  });
+
+  it('missing safety-critical geoid: that field missing, state applicability-unknown', () => {
+    const { geoidModel: _omit, ...partial } = IN_ENVELOPE;
+    const view = assertMirrorsAuthority('DTM', partial, RECORDS);
+    expect(view.resolutionState).toBe('applicability-unknown');
+    expect(view.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(statusOf(view.envelopeChecks, 'geoidModel')).toBe('missing');
+    expect(statusOf(view.envelopeChecks, 'methodDigest')).toBe('match');
+  });
+
+  it('no scoped record for the claim: empty envelopeChecks, baseline reflected', () => {
+    const view = assertMirrorsAuthority('DTM', IN_ENVELOPE);
+    expect(view.envelopeChecks).toEqual([]);
+    expect(view.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(view.matchedStudy).toBeNull();
+  });
+
+  it('unregistered claim: refused, null evidence, empty checks', () => {
+    const view = assertMirrorsAuthority('NOPE-NOT-A-CLAIM', IN_ENVELOPE, RECORDS);
+    expect(view.resolutionState).toBe('refused');
+    expect(view.baselineEvidence).toBeNull();
+    expect(view.effectiveEvidence).toBeNull();
+    expect(view.envelopeChecks).toEqual([]);
+  });
+
+  it('no context at all: mirrors applicability-unknown; pinned fields read missing', () => {
+    const view = assertMirrorsAuthority('DTM', undefined, RECORDS);
+    expect(view.resolutionState).toBe('applicability-unknown');
+    for (const f of PINNED) expect(statusOf(view.envelopeChecks, f)).toBe('missing');
+  });
+});


### PR DESCRIPTION
Adds `buildEvidenceContractView(claimId, context?, records?)` in `src/validation/evidenceBoundaryInspector.ts`: a pure, read-only projection of one `resolveEvidence()` lookup. It copies the resolver's decision verbatim (baseline, effective, resolutionState, matchedStudy, applicabilityVerdict) and attaches a per-envelope-field breakdown — `match` / `mismatch` / `missing` / `unconstrained` — for the record that would apply, making the scoped-evidence boundary human-auditable.

The view carries no applicability logic. `resolveEvidence` remains the sole authority and is never recomputed or overridden. Tests assert the view's decision is byte-equal to the resolver across in-scope, each mismatch class, missing safety-critical, no-record and unregistered cases, and that each envelope status resolves correctly.

Boot-unreachable (only its test imports it), registered `validation-only`. Index bundle unchanged at 776 KiB. No numerical change.