### PR TITLE
fix(validation): do not treat an unknown checkpoint accuracy as 1-sigma

### DIFF
--- a/src/validation/checkpointAccuracy.ts
+++ b/src/validation/checkpointAccuracy.ts
@@ -56,6 +56,88 @@ export const LEAKING_USAGES: readonly CheckpointUsage[] = [
   'manual-correction',
 ];
 
+/**
+ * What a stated reference-uncertainty number actually means.
+ *
+ * A survey may report a number with no statement of what it is: a standard
+ * deviation, an RMSE, a 95 % positional accuracy, or a manufacturer's spec
+ * bound. Only some of those are a 1-sigma standard uncertainty, and treating a
+ * 95 % figure or a manufacturer bound as if it were 1-sigma understates the
+ * reference error by a factor of roughly two. This module therefore refuses to
+ * guess: a value whose meaning is not established is never converted to sigma.
+ */
+export const REFERENCE_UNCERTAINTY_MEANINGS = [
+  'standard-deviation',
+  'rmse',
+  '95-percent',
+  'manufacturer-bound',
+  'unknown',
+] as const;
+
+export type ReferenceUncertaintyMeaning = (typeof REFERENCE_UNCERTAINTY_MEANINGS)[number];
+
+/**
+ * A reference-survey uncertainty with its statistical meaning made explicit.
+ *
+ * `source` records where the number and its meaning came from, so a report can
+ * say why a value was or was not treated as a standard uncertainty.
+ */
+export interface ReferenceUncertainty {
+  readonly valueMetres: number;
+  readonly meaning: ReferenceUncertaintyMeaning;
+  readonly source: string;
+}
+
+/**
+ * Two-sided 95 % normal coverage factor. Dividing a 95 % positional accuracy by
+ * this recovers the 1-sigma standard deviation, ASSUMING a zero-mean normal
+ * error. Frozen alongside DEFAULT_CI_Z so the two cannot drift apart.
+ */
+export const NORMAL_95_COVERAGE_FACTOR = 1.96;
+
+/**
+ * Convert a reference uncertainty to a 1-sigma standard uncertainty, or null
+ * when its meaning does not statistically justify a sigma.
+ *
+ * - `standard-deviation` is already sigma.
+ * - `rmse` is treated as sigma under a zero-mean assumption (RMSE = sqrt(bias^2
+ *   + sigma^2), so RMSE ≈ sigma when the reference is unbiased). This matches
+ *   the USGS/ASPRS convention of combining RMSE terms in quadrature.
+ * - `95-percent` is divided by the normal coverage factor (zero-mean normal
+ *   assumption).
+ * - `manufacturer-bound` and `unknown` are NOT a standard uncertainty and yield
+ *   null: fabricating a sigma from them would assert a distribution nobody
+ *   stated.
+ */
+export function referenceSigmaFromUncertainty(u: ReferenceUncertainty): number | null {
+  switch (u.meaning) {
+    case 'standard-deviation':
+      return u.valueMetres;
+    case 'rmse':
+      return u.valueMetres;
+    case '95-percent':
+      return u.valueMetres / NORMAL_95_COVERAGE_FACTOR;
+    case 'manufacturer-bound':
+    case 'unknown':
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Wrap a bare uncertainty number in a descriptor. The meaning defaults to
+ * `unknown` (fail-closed): a legacy value with no stated meaning must NOT be
+ * silently taken as 1-sigma.
+ */
+export function referenceUncertaintyFromValue(
+  valueMetres: number,
+  meaning: ReferenceUncertaintyMeaning = 'unknown',
+  source = 'unspecified',
+): ReferenceUncertainty {
+  return { valueMetres, meaning, source };
+}
+
 export interface Checkpoint {
   readonly id: string;
   /** The product's value at the checkpoint (for example the DTM elevation). */
@@ -65,8 +147,20 @@ export interface Checkpoint {
   readonly usage: CheckpointUsage;
   /** Land cover, terrain class, or any caller-defined stratum key. */
   readonly stratum?: string;
-  /** 1-sigma uncertainty of `reference`, or null when the survey did not state one. */
+  /**
+   * 1-sigma uncertainty of `reference`, or null when the survey did not state
+   * one. This field carries the 1-sigma contract: supplying it is equivalent to
+   * a `referenceUncertainty` with meaning `standard-deviation`. When both are
+   * supplied, `referenceUncertainty` takes precedence.
+   */
   readonly referenceSigma?: number | null;
+  /**
+   * Reference uncertainty with its statistical meaning made explicit. Use this
+   * rather than `referenceSigma` when the survey stated a 95 % figure, an RMSE,
+   * a manufacturer bound, or a number of unknown meaning: only some of those may
+   * be treated as a 1-sigma standard uncertainty.
+   */
+  readonly referenceUncertainty?: ReferenceUncertainty | null;
 }
 
 /**
@@ -164,6 +258,20 @@ export interface AccuracyStats {
   readonly uncertaintyCombinationId: string | null;
   /** Quadratic mean of the stated reference sigmas, or null when none were stated. */
   readonly referenceRmse: number | null;
+  /**
+   * Whether the reference uncertainty could be established for this group.
+   *
+   * - `none-stated`: the survey stated no reference uncertainty. `referenceRmse`
+   *   is null.
+   * - `established`: every stated reference uncertainty had a meaning that
+   *   justifies a 1-sigma value, so `referenceRmse` is the quadratic mean of
+   *   those sigmas and a combined RMSE can be produced.
+   * - `not-established`: at least one checkpoint stated a reference uncertainty
+   *   whose meaning does not justify a sigma (`unknown`/`manufacturer-bound`).
+   *   `referenceRmse` and `combinedRmse` are null: the fit RMSE stands alone and
+   *   is not combined against a reference uncertainty that was never established.
+   */
+  readonly referenceUncertaintyState: 'none-stated' | 'established' | 'not-established';
 }
 
 export interface StratumAccuracy {
@@ -236,11 +344,13 @@ const EMPTY_STATS: AccuracyStats = {
   combinedRmse: null,
   uncertaintyCombinationId: null,
   referenceRmse: null,
+  referenceUncertaintyState: 'none-stated',
 };
 
 function statsOf(
   residuals: readonly number[],
   sigmas: readonly number[],
+  referenceNotEstablished: boolean,
   ciZ: number,
   combination: UncertaintyCombination | undefined,
 ): AccuracyStats {
@@ -274,13 +384,19 @@ function statsOf(
     standardError = Math.sqrt(ss / (n - 1)) / Math.sqrt(n);
   }
 
+  // A reference uncertainty of unknown meaning cannot become a sigma, so its
+  // group's referenceRmse is null and its state is not-established: the fit RMSE
+  // is still reported, but nothing is combined against a reference uncertainty
+  // that was never established.
   const referenceRmse =
-    sigmas.length === 0
+    referenceNotEstablished || sigmas.length === 0
       ? null
       : Math.sqrt(sigmas.reduce((acc, s) => acc + s * s, 0) / sigmas.length);
-  // No combination and no reference sigma both leave the combined figure null.
-  // Relabelling the observed RMSE as "combined" would assert a propagation that
-  // never happened.
+  const referenceUncertaintyState: AccuracyStats['referenceUncertaintyState'] =
+    referenceNotEstablished ? 'not-established' : sigmas.length === 0 ? 'none-stated' : 'established';
+  // No combination, no reference sigma, and an unestablished reference all leave
+  // the combined figure null. Relabelling the observed RMSE as "combined" would
+  // assert a propagation that never happened.
   const combinedRmse =
     combination && referenceRmse !== null ? combination.combine(rmse, referenceRmse) : null;
 
@@ -299,7 +415,32 @@ function statsOf(
     combinedRmse,
     uncertaintyCombinationId: combinedRmse === null ? null : combination!.id,
     referenceRmse,
+    referenceUncertaintyState,
   };
+}
+
+type ResolvedReference =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'sigma'; readonly value: number }
+  | { readonly kind: 'not-established' };
+
+/**
+ * Resolve a checkpoint's reference uncertainty to a usable 1-sigma value.
+ *
+ * `referenceUncertainty` (with its explicit meaning) wins when present. A bare
+ * `referenceSigma` carries the 1-sigma contract and is used directly. A stated
+ * uncertainty whose meaning does not justify a sigma resolves to
+ * `not-established` rather than being fabricated into one.
+ */
+function resolveReference(c: Checkpoint): ResolvedReference {
+  const u = c.referenceUncertainty;
+  if (u !== undefined && u !== null) {
+    const sigma = referenceSigmaFromUncertainty(u);
+    return sigma === null ? { kind: 'not-established' } : { kind: 'sigma', value: sigma };
+  }
+  const s = c.referenceSigma;
+  if (s === undefined || s === null) return { kind: 'none' };
+  return { kind: 'sigma', value: s };
 }
 
 /**
@@ -369,16 +510,28 @@ export function checkpointAccuracy(
   // Every consumer of sigma squares it, so -0.5 and 0.5 produce the same
   // referenceRmse and the sign error disappears into a plausible number. An
   // absent sigma (null or undefined) is a different thing and stays legal: it
-  // means the survey stated no uncertainty.
+  // means the survey stated no uncertainty. The same rule applies to a stated
+  // referenceUncertainty.valueMetres, which is a length that cannot be negative
+  // regardless of its meaning.
   const badSigma = checkpoints.filter((c) => {
+    const u = c.referenceUncertainty;
+    if (u !== undefined && u !== null) {
+      return !(Number.isFinite(u.valueMetres) && u.valueMetres >= 0);
+    }
     const s = c.referenceSigma;
     return s !== undefined && s !== null && !(Number.isFinite(s) && s >= 0);
   });
   if (badSigma.length > 0) {
     return refuse(
       'invalid-reference-sigma',
-      'referenceSigma must be finite and >= 0 when stated: ' +
-        badSigma.map((c) => `${c.id} (${String(c.referenceSigma)})`).join(', '),
+      'reference uncertainty must be finite and >= 0 when stated: ' +
+        badSigma
+          .map((c) =>
+            c.referenceUncertainty
+              ? `${c.id} (${String(c.referenceUncertainty.valueMetres)})`
+              : `${c.id} (${String(c.referenceSigma)})`,
+          )
+          .join(', '),
       badSigma.map((c) => c.id),
     );
   }
@@ -386,8 +539,12 @@ export function checkpointAccuracy(
   const residuals: Residual[] = [];
   const pooled: number[] = [];
   const pooledSigmas: number[] = [];
+  let pooledNotEstablished = false;
   const excludedNonFiniteIds: string[] = [];
-  const byStratum = new Map<string, { residuals: number[]; sigmas: number[] }>();
+  const byStratum = new Map<
+    string,
+    { residuals: number[]; sigmas: number[]; notEstablished: boolean }
+  >();
 
   for (const c of checkpoints) {
     if (!Number.isFinite(c.measured) || !Number.isFinite(c.reference)) {
@@ -398,17 +555,21 @@ export function checkpointAccuracy(
     const stratum = c.stratum ?? UNSTRATIFIED;
     residuals.push({ id: c.id, stratum, residual: r });
     pooled.push(r);
-    const sigma = c.referenceSigma;
+    // A referenceUncertainty of unknown meaning resolves to no usable sigma; it
+    // marks its group not-established rather than being silently taken as 1σ.
+    const resolved = resolveReference(c);
     let bucket = byStratum.get(stratum);
     if (!bucket) {
-      bucket = { residuals: [], sigmas: [] };
+      bucket = { residuals: [], sigmas: [], notEstablished: false };
       byStratum.set(stratum, bucket);
     }
     bucket.residuals.push(r);
-    // Validated above, so anything not null/undefined here is a usable sigma.
-    if (sigma !== undefined && sigma !== null) {
-      pooledSigmas.push(sigma);
-      bucket.sigmas.push(sigma);
+    if (resolved.kind === 'sigma') {
+      pooledSigmas.push(resolved.value);
+      bucket.sigmas.push(resolved.value);
+    } else if (resolved.kind === 'not-established') {
+      pooledNotEstablished = true;
+      bucket.notEstablished = true;
     }
   }
 
@@ -454,13 +615,19 @@ export function checkpointAccuracy(
       return {
         stratum: key,
         status: 'reported' as const,
-        stats: statsOf(bucket.residuals, bucket.sigmas, ciZ, options.uncertaintyCombination),
+        stats: statsOf(
+          bucket.residuals,
+          bucket.sigmas,
+          bucket.notEstablished,
+          ciZ,
+          options.uncertaintyCombination,
+        ),
       };
     });
 
   return {
     status: 'reported',
-    pooled: statsOf(pooled, pooledSigmas, ciZ, options.uncertaintyCombination),
+    pooled: statsOf(pooled, pooledSigmas, pooledNotEstablished, ciZ, options.uncertaintyCombination),
     strata,
     residuals,
     ciZ,

--- a/tests/checkpointGdbAdapter.test.ts
+++ b/tests/checkpointGdbAdapter.test.ts
@@ -12,9 +12,17 @@ import {
   meanAbsoluteError,
   runCheckpointStudy,
   MIN_CHECKPOINT_SAMPLE_SIZE,
+  INDEPENDENCE_NOT_ESTABLISHED,
   type RawCheckpointRow,
   type TileFrame,
+  type IndependenceProvenance,
 } from './support/checkpointGdb';
+import { referenceSigmaFromUncertainty } from '../src/validation/checkpointAccuracy';
+
+/** Provenance marking a whole set of rows externally-confirmed independent. */
+function allIndependent(rows: readonly RawCheckpointRow[]): IndependenceProvenance {
+  return { independentIds: new Set(rows.map((r) => r.unique_identifier)) };
+}
 
 const TILE: TileFrame = {
   horizontalEpsg: 6339,
@@ -148,44 +156,123 @@ describe('meanAbsoluteError', () => {
   });
 });
 
-describe('toAccuracyCheckpoints', () => {
-  it('drops rows with no measured value rather than inventing a zero residual', () => {
-    const rows = goodSample(2);
-    const measured = new Map([[rows[0].unique_identifier, 1000.1]]); // rows[1] absent
-    const cps = toAccuracyCheckpoints(rows, measured);
-    expect(cps.length).toBe(1);
-    expect(cps[0].id).toBe(rows[0].unique_identifier);
+describe('toAccuracyCheckpoints — independence, uncertainty meaning, coverage', () => {
+  it('does not treat an NVA/VVA row as independent without external provenance', () => {
+    // point_type is NVA (an accuracy-type label); no provenance is supplied.
+    const rows = [row({ point_type: 'NVA' })];
+    const measured = new Map([[rows[0].unique_identifier, 1000.02]]);
+    const { checkpoints } = toAccuracyCheckpoints(rows, measured);
+    expect(checkpoints[0].usage).not.toBe('independent');
+    expect(checkpoints[0].usage).toBe(INDEPENDENCE_NOT_ESTABLISHED);
   });
 
-  it('carries the stated accuracy through as referenceSigma', () => {
+  it('marks a checkpoint independent only when provenance names it', () => {
+    const rows = [row()];
+    const measured = new Map([[rows[0].unique_identifier, 1000.02]]);
+    const { checkpoints } = toAccuracyCheckpoints(rows, measured, {
+      independence: allIndependent(rows),
+    });
+    expect(checkpoints[0].usage).toBe('independent');
+  });
+
+  it('wraps the accuracy value with meaning unknown by default (no 1-sigma sigma)', () => {
     const rows = [row({ accuracy: '0.07' })];
     const measured = new Map([[rows[0].unique_identifier, 1000.02]]);
-    const cps = toAccuracyCheckpoints(rows, measured);
-    expect(cps[0].referenceSigma).toBeCloseTo(0.07, 12);
+    const { checkpoints } = toAccuracyCheckpoints(rows, measured);
+    const u = checkpoints[0].referenceUncertainty;
+    expect(u?.valueMetres).toBeCloseTo(0.07, 12);
+    expect(u?.meaning).toBe('unknown');
+    // The engine must not fabricate a sigma from an unknown-meaning value.
+    expect(referenceSigmaFromUncertainty(u!)).toBeNull();
+    // The legacy 1-sigma field is no longer asserted from an unlabelled value.
+    expect(checkpoints[0].referenceSigma).toBeUndefined();
+  });
+
+  it('carries a caller-stated 95-percent meaning through so a sigma can be recovered', () => {
+    const rows = [row({ accuracy: '0.098' })];
+    const measured = new Map([[rows[0].unique_identifier, 1000.02]]);
+    const { checkpoints } = toAccuracyCheckpoints(rows, measured, { accuracyMeaning: '95-percent' });
+    const u = checkpoints[0].referenceUncertainty;
+    expect(u?.meaning).toBe('95-percent');
+    expect(referenceSigmaFromUncertainty(u!)).toBeCloseTo(0.098 / 1.96, 12);
+  });
+
+  it('counts an unpredicted row in the coverage ledger rather than dropping it silently', () => {
+    const rows = goodSample(2);
+    const measured = new Map([[rows[0].unique_identifier, 1000.1]]); // rows[1] absent
+    const { checkpoints, ledger } = toAccuracyCheckpoints(rows, measured);
+    // The unpredicted row still forms no comparison...
+    expect(checkpoints.length).toBe(1);
+    expect(checkpoints[0].id).toBe(rows[0].unique_identifier);
+    // ...but it is COUNTED, not vanished: eligible = 2, predicted = 1.
+    expect(ledger.eligible).toBe(2);
+    expect(ledger.predicted).toBe(1);
+    expect(ledger.unpredicted).toBe(1);
   });
 });
 
 describe('runCheckpointStudy — end to end', () => {
-  it('reports full pooled statistics when every gate passes', () => {
+  it('reports full pooled statistics when every gate passes and independence is established', () => {
     const rows = goodSample();
     // measured = reference + 0.1 for every checkpoint -> bias should be exactly 0.1
     const measured = new Map(rows.map((r) => [r.unique_identifier, Number(r.source_elevation) + 0.1]));
-    const { prereq, result, mae } = runCheckpointStudy(rows, TILE, measured);
+    const { prereq, result, mae, coverage, predictionCoverage } = runCheckpointStudy(rows, TILE, measured, {
+      independence: allIndependent(rows),
+    });
     expect(prereq.ok).toBe(true);
     expect(result?.status).toBe('reported');
     if (result?.status === 'reported') {
       expect(result.pooled.n).toBe(MIN_CHECKPOINT_SAMPLE_SIZE);
       expect(result.pooled.bias).toBeCloseTo(0.1, 9);
       expect(result.pooled.rmse).toBeCloseTo(0.1, 9);
+      // Accuracy field left at its default unknown meaning: no reference sigma,
+      // so no combined RMSE is fabricated.
+      expect(result.pooled.referenceUncertaintyState).toBe('not-established');
+      expect(result.pooled.referenceRmse).toBeNull();
+      expect(result.pooled.combinedRmse).toBeNull();
     }
     expect(mae).toBeCloseTo(0.1, 9);
+    expect(coverage.eligible).toBe(MIN_CHECKPOINT_SAMPLE_SIZE);
+    expect(coverage.predicted).toBe(MIN_CHECKPOINT_SAMPLE_SIZE);
+    expect(predictionCoverage).toBe(1);
+  });
+
+  it('refuses (unknown-usage) rather than reporting when independence is not established', () => {
+    const rows = goodSample();
+    const measured = new Map(rows.map((r) => [r.unique_identifier, Number(r.source_elevation) + 0.1]));
+    const { prereq, result } = runCheckpointStudy(rows, TILE, measured);
+    expect(prereq.ok).toBe(true);
+    expect(result?.status).toBe('refused');
+    if (result?.status === 'refused') {
+      expect(result.reason).toBe('unknown-usage');
+    }
+  });
+
+  it('surfaces prediction coverage on a mixed covered/uncovered sample', () => {
+    // Every gate passes (all rows in extent, matching CRS, accuracy + point_type),
+    // and independence is established, but the product predicted only half of them.
+    const rows = goodSample(MIN_CHECKPOINT_SAMPLE_SIZE);
+    const predictedRows = rows.slice(0, MIN_CHECKPOINT_SAMPLE_SIZE / 2);
+    const measured = new Map(
+      predictedRows.map((r) => [r.unique_identifier, Number(r.source_elevation) + 0.1]),
+    );
+    const { coverage, predictionCoverage } = runCheckpointStudy(rows, TILE, measured, {
+      independence: allIndependent(rows),
+    });
+    expect(coverage.eligible).toBe(MIN_CHECKPOINT_SAMPLE_SIZE);
+    expect(coverage.predicted).toBe(MIN_CHECKPOINT_SAMPLE_SIZE / 2);
+    expect(coverage.unpredicted).toBe(MIN_CHECKPOINT_SAMPLE_SIZE / 2);
+    expect(predictionCoverage).toBeCloseTo(0.5, 12);
+    expect(predictionCoverage).toBe(coverage.predicted / coverage.eligible);
   });
 
   it('fails closed with result:null and mae:null on the 0-in-extent case', () => {
     const rows = [row({ source_easting: '0', source_northing: '0' })];
-    const { prereq, result, mae } = runCheckpointStudy(rows, TILE, new Map());
+    const { prereq, result, mae, coverage, predictionCoverage } = runCheckpointStudy(rows, TILE, new Map());
     expect(prereq.ok).toBe(false);
     expect(result).toBeNull();
     expect(mae).toBeNull();
+    expect(coverage.eligible).toBe(0);
+    expect(predictionCoverage).toBeNull();
   });
 });

--- a/tests/independentCheckpointHarness.test.ts
+++ b/tests/independentCheckpointHarness.test.ts
@@ -62,7 +62,13 @@ import {
   runCheckpointStudy,
   MIN_CHECKPOINT_SAMPLE_SIZE,
   type TileFrame,
+  type CheckpointAdapterOptions,
+  type IndependenceProvenance,
 } from './support/checkpointGdb';
+import {
+  REFERENCE_UNCERTAINTY_MEANINGS,
+  type ReferenceUncertaintyMeaning,
+} from '../src/validation/checkpointAccuracy';
 
 const SCENE = process.env.CHECKPOINT_SCENE;
 const GDB = process.env.CHECKPOINT_GDB;
@@ -71,6 +77,29 @@ const LAYER =
   process.env.CHECKPOINT_LAYER ?? 'Consolidated_Standardized_Checkpoints_3DEP_Version2_20250930';
 const HORIZONTAL_EPSG = Number(process.env.CHECKPOINT_HORIZONTAL_EPSG ?? '6339');
 const VERTICAL_EPSG = Number(process.env.CHECKPOINT_VERTICAL_EPSG ?? '5703');
+// Independence is NOT inferred from the GDB (a point_type is an accuracy-type
+// label, not proof a checkpoint was withheld from the product). It is supplied
+// externally: a file of unique_identifiers confirmed independent, one per line.
+// Absent it, runCheckpointStudy refuses (unknown-usage) rather than reporting an
+// independent-accuracy figure the provenance does not support.
+const INDEPENDENT_IDS_FILE = process.env.CHECKPOINT_INDEPENDENT_IDS_FILE;
+// What the GDB `accuracy` field means statistically; unknown unless external
+// metadata establishes it (for example '95-percent' for an NVA/VVA figure).
+const RAW_ACCURACY_MEANING = process.env.CHECKPOINT_ACCURACY_MEANING;
+const ACCURACY_MEANING: ReferenceUncertaintyMeaning = (
+  REFERENCE_UNCERTAINTY_MEANINGS as readonly string[]
+).includes(RAW_ACCURACY_MEANING ?? '')
+  ? (RAW_ACCURACY_MEANING as ReferenceUncertaintyMeaning)
+  : 'unknown';
+
+function loadIndependenceProvenance(): IndependenceProvenance | undefined {
+  if (!INDEPENDENT_IDS_FILE || !existsSync(INDEPENDENT_IDS_FILE)) return undefined;
+  const ids = readFileSync(INDEPENDENT_IDS_FILE, 'utf8')
+    .split(/\r\n|\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  return { independentIds: new Set(ids) };
+}
 
 const PRODUCER_GROUND = 2; // ASPRS class 2 = ground
 
@@ -196,7 +225,16 @@ describe.skipIf(!ready)('independent-checkpoint accuracy harness (pathway A: pro
       if (z !== null) measuredById.set(r.unique_identifier, z);
     }
 
-    const { prereq, result, mae } = runCheckpointStudy(rows, tile, measuredById);
+    const studyOptions: CheckpointAdapterOptions = {
+      independence: loadIndependenceProvenance(),
+      accuracyMeaning: ACCURACY_MEANING,
+    };
+    const { prereq, result, mae, coverage, predictionCoverage } = runCheckpointStudy(
+      rows,
+      tile,
+      measuredById,
+      studyOptions,
+    );
 
     // eslint-disable-next-line no-console
     console.log(
@@ -207,6 +245,10 @@ describe.skipIf(!ready)('independent-checkpoint accuracy harness (pathway A: pro
         `local origin: [${originX}, ${originY}]  cell size: ${cellSizeM} m`,
         `prerequisites ok: ${prereq.ok}`,
         ...prereq.reasons.map((r) => `  - ${r}`),
+        `independence provenance: ${studyOptions.independence ? 'supplied' : 'not supplied'}`,
+        `accuracy-field meaning: ${ACCURACY_MEANING}`,
+        `prediction coverage: ${coverage.predicted}/${coverage.eligible}` +
+          (predictionCoverage === null ? '' : ` (${(predictionCoverage * 100).toFixed(1)}%)`),
       ].join('\n'),
     );
 
@@ -217,22 +259,30 @@ describe.skipIf(!ready)('independent-checkpoint accuracy harness (pathway A: pro
       expect(mae).toBeNull();
       expect(prereq.reasons.length).toBeGreaterThan(0);
       expect(prereq.usable.length).toBeLessThan(MIN_CHECKPOINT_SAMPLE_SIZE);
+    } else if (result?.status === 'reported') {
+      // Reached only when independence provenance covered the whole sample and
+      // enough checkpoints were predicted; otherwise runCheckpointStudy refuses.
+      // eslint-disable-next-line no-console
+      console.log(
+        [
+          `n=${result.pooled.n}`,
+          `bias=${result.pooled.bias?.toFixed(4)}`,
+          `rmse=${result.pooled.rmse?.toFixed(4)}`,
+          `mae=${mae?.toFixed(4)}`,
+          `nmad=${result.pooled.nmad?.toFixed(4)}`,
+          `p95=${result.pooled.p95AbsResidual?.toFixed(4)}`,
+        ].join('  '),
+      );
+      expect(mae).not.toBeNull();
+      expect(coverage.eligible).toBeGreaterThan(0);
     } else {
-      expect(result?.status).toBe('reported');
-      if (result?.status === 'reported') {
-        // eslint-disable-next-line no-console
-        console.log(
-          [
-            `n=${result.pooled.n}`,
-            `bias=${result.pooled.bias?.toFixed(4)}`,
-            `rmse=${result.pooled.rmse?.toFixed(4)}`,
-            `mae=${mae?.toFixed(4)}`,
-            `nmad=${result.pooled.nmad?.toFixed(4)}`,
-            `p95=${result.pooled.p95AbsResidual?.toFixed(4)}`,
-          ].join('  '),
-        );
-        expect(mae).not.toBeNull();
-      }
+      // Gate passed but no independent-accuracy figure is produced: without
+      // independence provenance every checkpoint is unknown-usage, and low
+      // prediction coverage leaves too few for the sample floor. The coverage
+      // ledger is still a reported figure over the eligible checkpoints.
+      expect(result?.status).toBe('refused');
+      expect(mae).toBeNull();
+      expect(coverage.eligible).toBeGreaterThan(0);
     }
   }, 120_000);
 });

--- a/tests/referenceUncertaintySemantics.test.ts
+++ b/tests/referenceUncertaintySemantics.test.ts
@@ -1,0 +1,161 @@
+/**
+ * referenceUncertaintySemantics.test.ts
+ *
+ * A checkpoint accuracy figure may only combine the fit RMSE against a reference
+ * uncertainty when the reference number is actually a 1-sigma standard
+ * uncertainty. These tests pin the meaning-aware conversion: a value whose
+ * meaning is not established is never taken as sigma, and no combined RMSE is
+ * produced pretending it was.
+ *
+ * SYNTHETIC checkpoints only. This proves the semantics, not any product.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  checkpointAccuracy,
+  referenceSigmaFromUncertainty,
+  referenceUncertaintyFromValue,
+  NORMAL_95_COVERAGE_FACTOR,
+  type Checkpoint,
+  type ReferenceUncertainty,
+  type UncertaintyCombination,
+} from '../src/validation/checkpointAccuracy';
+
+function cp(id: string, residual: number, extra: Partial<Checkpoint> = {}): Checkpoint {
+  return { id, reference: 100, measured: 100 + residual, usage: 'independent', ...extra };
+}
+
+const RESIDUALS: ReadonlyArray<[string, number]> = [
+  ['a', 0.1],
+  ['b', -0.05],
+  ['c', 0.2],
+  ['d', 0],
+  ['e', -0.25],
+];
+const OBSERVED_RMSE = Math.sqrt(0.115 / 5);
+
+const quadratureSum: UncertaintyCombination = {
+  id: 'test-quadrature-sum-v1',
+  combine: (observed, reference) => Math.sqrt(observed * observed + reference * reference),
+};
+
+function withMeaning(u: ReferenceUncertainty): Checkpoint[] {
+  return RESIDUALS.map(([id, r]) => cp(id, r, { referenceUncertainty: u }));
+}
+
+describe('referenceSigmaFromUncertainty', () => {
+  it('returns the value unchanged for a standard deviation', () => {
+    expect(referenceSigmaFromUncertainty({ valueMetres: 0.03, meaning: 'standard-deviation', source: 's' })).toBe(0.03);
+  });
+
+  it('treats an RMSE as sigma under the zero-mean assumption', () => {
+    expect(referenceSigmaFromUncertainty({ valueMetres: 0.04, meaning: 'rmse', source: 's' })).toBe(0.04);
+  });
+
+  it('divides a 95-percent figure by the normal coverage factor', () => {
+    expect(referenceSigmaFromUncertainty({ valueMetres: 0.098, meaning: '95-percent', source: 's' })).toBeCloseTo(
+      0.098 / NORMAL_95_COVERAGE_FACTOR,
+      12,
+    );
+  });
+
+  it('refuses to fabricate a sigma from a manufacturer bound or an unknown meaning', () => {
+    expect(referenceSigmaFromUncertainty({ valueMetres: 0.05, meaning: 'manufacturer-bound', source: 's' })).toBeNull();
+    expect(referenceSigmaFromUncertainty({ valueMetres: 0.05, meaning: 'unknown', source: 's' })).toBeNull();
+  });
+});
+
+describe('referenceUncertaintyFromValue fail-closed default', () => {
+  it('defaults a bare number to unknown meaning, never 1-sigma', () => {
+    const u = referenceUncertaintyFromValue(0.05);
+    expect(u.meaning).toBe('unknown');
+    expect(referenceSigmaFromUncertainty(u)).toBeNull();
+  });
+});
+
+describe('checkpointAccuracy reference-uncertainty semantics', () => {
+  it('standard-deviation: referenceSigma == value and a combined RMSE is produced', () => {
+    const r = checkpointAccuracy(
+      withMeaning({ valueMetres: 0.03, meaning: 'standard-deviation', source: 'survey' }),
+      { minSample: 5, uncertaintyCombination: quadratureSum },
+    );
+    expect(r.status).toBe('reported');
+    if (r.status !== 'reported') return;
+    expect(r.pooled.referenceUncertaintyState).toBe('established');
+    expect(r.pooled.referenceRmse).toBeCloseTo(0.03, 12);
+    expect(r.pooled.combinedRmse).toBeCloseTo(Math.sqrt(OBSERVED_RMSE ** 2 + 0.03 ** 2), 12);
+    expect(r.pooled.uncertaintyCombinationId).toBe('test-quadrature-sum-v1');
+  });
+
+  it('95-percent: referenceSigma == value / 1.96', () => {
+    const value = 0.098;
+    const r = checkpointAccuracy(
+      withMeaning({ valueMetres: value, meaning: '95-percent', source: 'survey' }),
+      { minSample: 5, uncertaintyCombination: quadratureSum },
+    );
+    expect(r.status).toBe('reported');
+    if (r.status !== 'reported') return;
+    const sigma = value / NORMAL_95_COVERAGE_FACTOR;
+    expect(r.pooled.referenceUncertaintyState).toBe('established');
+    expect(r.pooled.referenceRmse).toBeCloseTo(sigma, 12);
+    expect(r.pooled.combinedRmse).toBeCloseTo(Math.sqrt(OBSERVED_RMSE ** 2 + sigma ** 2), 12);
+  });
+
+  for (const meaning of ['unknown', 'manufacturer-bound'] as const) {
+    it(`${meaning}: no sigma, no combined RMSE, not-established state, fit RMSE still reported`, () => {
+      const r = checkpointAccuracy(
+        withMeaning({ valueMetres: 0.05, meaning, source: 'spec' }),
+        { minSample: 5, uncertaintyCombination: quadratureSum },
+      );
+      expect(r.status).toBe('reported');
+      if (r.status !== 'reported') return;
+      expect(r.pooled.referenceUncertaintyState).toBe('not-established');
+      expect(r.pooled.referenceRmse).toBeNull();
+      expect(r.pooled.combinedRmse).toBeNull();
+      expect(r.pooled.uncertaintyCombinationId).toBeNull();
+      // The fit RMSE stands alone rather than vanishing with the reference term.
+      expect(r.pooled.rmse).toBeCloseTo(OBSERVED_RMSE, 12);
+    });
+  }
+
+  it('one unknown-meaning checkpoint marks the whole group not-established (fail-closed)', () => {
+    const mixed = [
+      cp('a', 0.1, { referenceUncertainty: { valueMetres: 0.03, meaning: 'standard-deviation', source: 's' } }),
+      cp('b', -0.05, { referenceUncertainty: { valueMetres: 0.05, meaning: 'unknown', source: 's' } }),
+      cp('c', 0.2, { referenceUncertainty: { valueMetres: 0.03, meaning: 'standard-deviation', source: 's' } }),
+      cp('d', 0, { referenceUncertainty: { valueMetres: 0.03, meaning: 'standard-deviation', source: 's' } }),
+      cp('e', -0.25, { referenceUncertainty: { valueMetres: 0.03, meaning: 'standard-deviation', source: 's' } }),
+    ];
+    const r = checkpointAccuracy(mixed, { minSample: 5, uncertaintyCombination: quadratureSum });
+    expect(r.status).toBe('reported');
+    if (r.status !== 'reported') return;
+    expect(r.pooled.referenceUncertaintyState).toBe('not-established');
+    expect(r.pooled.referenceRmse).toBeNull();
+    expect(r.pooled.combinedRmse).toBeNull();
+  });
+
+  it('a legacy bare-number descriptor defaults to unknown and never fabricates a sigma', () => {
+    const r = checkpointAccuracy(
+      RESIDUALS.map(([id, resid]) => cp(id, resid, { referenceUncertainty: referenceUncertaintyFromValue(0.05) })),
+      { minSample: 5, uncertaintyCombination: quadratureSum },
+    );
+    expect(r.status).toBe('reported');
+    if (r.status !== 'reported') return;
+    expect(r.pooled.referenceUncertaintyState).toBe('not-established');
+    expect(r.pooled.referenceRmse).toBeNull();
+    expect(r.pooled.combinedRmse).toBeNull();
+    expect(r.pooled.rmse).toBeCloseTo(OBSERVED_RMSE, 12);
+  });
+
+  it('the legacy referenceSigma field still works as a stated 1-sigma', () => {
+    const r = checkpointAccuracy(
+      RESIDUALS.map(([id, resid]) => cp(id, resid, { referenceSigma: 0.03 })),
+      { minSample: 5, uncertaintyCombination: quadratureSum },
+    );
+    expect(r.status).toBe('reported');
+    if (r.status !== 'reported') return;
+    expect(r.pooled.referenceUncertaintyState).toBe('established');
+    expect(r.pooled.referenceRmse).toBeCloseTo(0.03, 12);
+    expect(r.pooled.combinedRmse).toBeCloseTo(Math.sqrt(OBSERVED_RMSE ** 2 + 0.03 ** 2), 12);
+  });
+});

--- a/tests/support/checkpointGdb.ts
+++ b/tests/support/checkpointGdb.ts
@@ -12,10 +12,24 @@
  *   - reading rows out of the `.gdb` with GDAL's `ogr2ogr` (no FileGDB reader
  *     is written here — GDAL already reads the format correctly);
  *   - the FAIL-CLOSED prerequisite gate a checkpoint set must pass before any
- *     of its rows may be treated as an independent, usable checkpoint; and
+ *     of its rows may be paired with the tile;
+ *   - the PREDICTION-COVERAGE LEDGER: how many eligible checkpoints the product
+ *     actually predicted a value at, so a low-coverage tile reports a low
+ *     coverage rather than silently shrinking the sample; and
  *   - Mean Absolute Error, which `checkpointAccuracy()` does not report
  *     (it reports bias, RMSE, median, NMAD, P90/P95, max — MAE is computed
  *     here directly from the same residuals it returns).
+ *
+ * INDEPENDENCE IS NOT INFERRED FROM THE GDB. A 3DEP `point_type` of NVA or VVA
+ * is an accuracy-TYPE label (Non-vegetated / Vegetated Vertical Accuracy), not
+ * evidence that a checkpoint was held back from the product's calibration,
+ * registration, or parameter tuning. Whether a checkpoint is independent is a
+ * property of external provenance, and this adapter only marks a checkpoint
+ * `independent` when the caller passes provenance that says so
+ * (`IndependenceProvenance`). Absent that provenance a checkpoint is given a
+ * usage `checkpointAccuracy()` does not recognise, so it forces an
+ * `unknown-usage` refusal naming it rather than entering an independent-accuracy
+ * statistic.
  *
  * Fail-closed prerequisites, in the order checked:
  *   1. at least one checkpoint of the project falls inside the tile extent;
@@ -24,9 +38,10 @@
  *      a reprojection this module does not perform, so it is excluded, not
  *      silently reprojected);
  *   3. of those, the checkpoint states an accuracy/uncertainty value;
- *   4. of those, the checkpoint states a point_type (NVA/VVA) — the field
- *      that marks it as an independent survey observation rather than a
- *      derived or unlabelled row;
+ *   4. of those, the checkpoint states a point_type (NVA/VVA) — the accuracy-
+ *      type label 3DEP uses to distinguish a vertical-accuracy observation from
+ *      a derived or unlabelled row. This gates accuracy-type eligibility only;
+ *      it does NOT establish independence (see above);
  *   5. the surviving count is >= MIN_CHECKPOINT_SAMPLE_SIZE.
  * Any failure is reported with a specific reason string; the gate does not
  * stop at the first failure; nothing partial is computed for a closed gate.
@@ -35,8 +50,11 @@
 import { execFileSync } from 'node:child_process';
 import {
   checkpointAccuracy,
+  referenceUncertaintyFromValue,
   type Checkpoint,
   type CheckpointResult,
+  type CheckpointUsage,
+  type ReferenceUncertaintyMeaning,
 } from '../../src/validation/checkpointAccuracy';
 
 /**
@@ -259,7 +277,7 @@ export function checkpointPrerequisites(rows: readonly RawCheckpointRow[], tile:
   if (withAccuracy.length > 0 && withPointType.length < withAccuracy.length) {
     reasons.push(
       `${withAccuracy.length - withPointType.length} checkpoint(s) lack a point_type (NVA/VVA); ` +
-        'independence cannot be established without it',
+        'the accuracy-type label is required to treat the row as a vertical-accuracy observation',
     );
   }
 
@@ -274,28 +292,128 @@ export function checkpointPrerequisites(rows: readonly RawCheckpointRow[], tile:
 }
 
 /**
+ * Externally-established independence of individual checkpoints.
+ *
+ * The GDB does not carry independence (a point_type is an accuracy-type label,
+ * not proof a checkpoint was withheld from the product's calibration,
+ * registration, or tuning). The caller supplies what external provenance
+ * established:
+ *
+ *   - `independentIds`: unique_identifiers confirmed independent. A checkpoint
+ *     in this set is marked `usage: 'independent'`.
+ *   - `usageById`: a specific `CheckpointUsage` per checkpoint, for provenance
+ *     that recorded a leaking role (control/registration/parameter-tuning/
+ *     manual-correction) rather than independence. Takes precedence over
+ *     `independentIds` for the ids it names, and a leaking usage here is carried
+ *     into `checkpointAccuracy()` so it refuses over that checkpoint rather than
+ *     the adapter dropping it.
+ *
+ * A checkpoint named by neither is left at `INDEPENDENCE_NOT_ESTABLISHED`.
+ */
+export interface IndependenceProvenance {
+  readonly independentIds?: ReadonlySet<string>;
+  readonly usageById?: ReadonlyMap<string, CheckpointUsage>;
+}
+
+/**
+ * The `usage` given to a checkpoint whose independence external provenance did
+ * not confirm. It is intentionally NOT one of CHECKPOINT_USAGES: an unconfirmed
+ * checkpoint's independence is UNKNOWN, not known-leaked. `checkpointAccuracy()`
+ * does not recognise this string, so it triggers an `unknown-usage` refusal that
+ * names the checkpoint ("an unreadable usage cannot be shown to be
+ * independent"), rather than the value silently entering an independent-accuracy
+ * figure. Supply `IndependenceProvenance` to lift a checkpoint out of it.
+ */
+export const INDEPENDENCE_NOT_ESTABLISHED: string = 'independence-not-established';
+
+function resolveUsage(id: string, provenance?: IndependenceProvenance): CheckpointUsage {
+  const explicit = provenance?.usageById?.get(id);
+  if (explicit !== undefined) return explicit;
+  if (provenance?.independentIds?.has(id)) return 'independent';
+  // Cast at the parse boundary the way checkpointAccuracy() documents: the value
+  // is not a CheckpointUsage, and its isUsage() runtime check refuses it.
+  return INDEPENDENCE_NOT_ESTABLISHED as CheckpointUsage;
+}
+
+/**
+ * Prediction coverage over the checkpoints offered to the product.
+ *
+ * A checkpoint with no finite product prediction at its XY (outside the DTM's
+ * coverage, or a void inside it) carries no comparison, so it cannot become a
+ * `Checkpoint`. It is COUNTED here rather than dropped: `pooled.n` alone cannot
+ * tell a reader whether a low sample is a thin survey or a tile the product
+ * barely covered. The GDB/prediction map does not say WHY a prediction is
+ * missing, so no outside-coverage vs void distinction is fabricated.
+ */
+export interface PredictionCoverageLedger {
+  /** Checkpoints offered for comparison (rows that passed the prerequisite gate). */
+  readonly eligible: number;
+  /** Of those, the ones with a finite product prediction at their XY. */
+  readonly predicted: number;
+  /** Of those, the ones with no finite prediction. `eligible - predicted`. */
+  readonly unpredicted: number;
+}
+
+/** Optional metadata the caller establishes about the checkpoint set. */
+export interface CheckpointAdapterOptions {
+  /** Externally-established per-checkpoint independence. */
+  readonly independence?: IndependenceProvenance;
+  /**
+   * What the GDB `accuracy` field's number means statistically. The 3DEP
+   * checkpoint schema does not state this per row, so it defaults to `'unknown'`
+   * (fail-closed): an unlabelled value is NOT taken as a 1-sigma standard
+   * uncertainty. Set it (for example to `'95-percent'`) only when external
+   * metadata establishes what the field is.
+   */
+  readonly accuracyMeaning?: ReferenceUncertaintyMeaning;
+}
+
+/** `checkpointAccuracy()` input plus the coverage ledger over the same rows. */
+export interface AccuracyCheckpointBuild {
+  readonly checkpoints: Checkpoint[];
+  readonly ledger: PredictionCoverageLedger;
+}
+
+/**
  * Build `checkpointAccuracy()` input from checkpoint rows that already passed
  * `checkpointPrerequisites`, given the product's measured elevation at each
- * checkpoint's XY (by `unique_identifier`). Rows with no measured value
- * (outside DTM coverage) are dropped — they carry no comparison, not a zero.
+ * checkpoint's XY (by `unique_identifier`).
+ *
+ * Independence comes from `options.independence`, not from the GDB. The stated
+ * accuracy value is wrapped in a `ReferenceUncertainty` whose meaning is
+ * `options.accuracyMeaning` (default `'unknown'`), so an unlabelled value is
+ * never converted to a 1-sigma sigma by `checkpointAccuracy()`.
+ *
+ * Rows with no finite product prediction cannot form a comparison, so they do
+ * not become a `Checkpoint`; they are counted in the returned ledger rather than
+ * dropped silently.
  */
 export function toAccuracyCheckpoints(
   rows: readonly RawCheckpointRow[],
   measuredById: ReadonlyMap<string, number>,
-): Checkpoint[] {
+  options: CheckpointAdapterOptions = {},
+): AccuracyCheckpointBuild {
+  const meaning: ReferenceUncertaintyMeaning = options.accuracyMeaning ?? 'unknown';
   const out: Checkpoint[] = [];
+  let predicted = 0;
   for (const r of rows) {
     const measured = measuredById.get(r.unique_identifier);
     if (measured === undefined || !Number.isFinite(measured)) continue;
+    predicted++;
     out.push({
       id: r.unique_identifier,
       measured,
       reference: Number(r.source_elevation),
-      usage: 'independent',
-      referenceSigma: Number(r.accuracy),
+      usage: resolveUsage(r.unique_identifier, options.independence),
+      referenceUncertainty: referenceUncertaintyFromValue(
+        Number(r.accuracy),
+        meaning,
+        '3DEP checkpoint accuracy field',
+      ),
     });
   }
-  return out;
+  const eligible = rows.length;
+  return { checkpoints: out, ledger: { eligible, predicted, unpredicted: eligible - predicted } };
 }
 
 /** Mean Absolute Error over residuals — not reported by `checkpointAccuracy()`. */
@@ -306,29 +424,53 @@ export function meanAbsoluteError(residuals: readonly number[]): number | null {
   return sum / residuals.length;
 }
 
+const EMPTY_LEDGER: PredictionCoverageLedger = { eligible: 0, predicted: 0, unpredicted: 0 };
+
 export interface CheckpointStudyOutcome {
   readonly prereq: PrerequisiteResult;
   readonly result: CheckpointResult | null;
   readonly mae: number | null;
+  /**
+   * Prediction coverage over the gated checkpoints. Populated even when
+   * `result` is a refusal (for example an insufficient sample caused by low
+   * coverage): the count of eligible checkpoints and how many the product
+   * predicted is a reported figure, not something a refusal erases.
+   */
+  readonly coverage: PredictionCoverageLedger;
+  /**
+   * `coverage.predicted / coverage.eligible`, or null when nothing was eligible.
+   * A tile the product barely covered reports a low coverage here rather than a
+   * shrunken checkpoint sample.
+   */
+  readonly predictionCoverage: number | null;
 }
 
 /**
  * End-to-end: gate, then (only if the gate passes) compute pooled/stratified
  * accuracy plus MAE. Fails closed: `result`/`mae` stay `null` whenever
- * `prereq.ok` is false, never a partial figure over an ungated sample.
+ * `prereq.ok` is false, never a partial figure over an ungated sample. The
+ * coverage ledger is always populated (empty when the gate closed before any
+ * row was eligible).
+ *
+ * Independence and the accuracy-field meaning are supplied through `options`;
+ * with none, every checkpoint stays at `INDEPENDENCE_NOT_ESTABLISHED` and
+ * `checkpointAccuracy()` refuses (`unknown-usage`) rather than reporting an
+ * independent-accuracy figure the provenance does not support.
  */
 export function runCheckpointStudy(
   rows: readonly RawCheckpointRow[],
   tile: TileFrame,
   measuredById: ReadonlyMap<string, number>,
+  options: CheckpointAdapterOptions = {},
 ): CheckpointStudyOutcome {
   const prereq = checkpointPrerequisites(rows, tile);
   if (!prereq.ok) {
-    return { prereq, result: null, mae: null };
+    return { prereq, result: null, mae: null, coverage: EMPTY_LEDGER, predictionCoverage: null };
   }
-  const checkpoints = toAccuracyCheckpoints(prereq.usable, measuredById);
+  const { checkpoints, ledger } = toAccuracyCheckpoints(prereq.usable, measuredById, options);
   const result = checkpointAccuracy(checkpoints, { minSample: MIN_CHECKPOINT_SAMPLE_SIZE });
   const mae =
     result.status === 'reported' ? meanAbsoluteError(result.residuals.map((r) => r.residual)) : null;
-  return { prereq, result, mae };
+  const predictionCoverage = ledger.eligible === 0 ? null : ledger.predicted / ledger.eligible;
+  return { prereq, result, mae, coverage: ledger, predictionCoverage };
 }


### PR DESCRIPTION
`checkpointAccuracy` squared any stated `referenceSigma` straight into `referenceRmse`, so a survey number of unknown statistical meaning (a 95 % positional accuracy, a manufacturer bound) was silently used as a 1-sigma standard uncertainty and combined against the fit RMSE.

A `ReferenceUncertainty { valueMetres, meaning, source }` descriptor now makes the meaning explicit. Conversion to sigma happens only when justified: `standard-deviation` as is, `rmse` under a zero-mean assumption, `95-percent` divided by 1.96. `manufacturer-bound` and `unknown` yield no sigma — the group is reported `not-established`, `referenceRmse`/`combinedRmse` stay null, and the fit RMSE still stands. A bare number defaults to `unknown` (fail-closed). The legacy `referenceSigma` field keeps its 1-sigma contract.

DTM numerical output changed: NO.