### PR TITLE
fix(ui): debug overlay backend line shows the label, not the function

### DIFF
--- a/src/ui/DebugOverlay.ts
+++ b/src/ui/DebugOverlay.ts
@@ -355,7 +355,7 @@ export class DebugOverlay {
         `terrain comp  ${formatTerrainCompute(terrainCompute)}`,
       ].join('\n');
     } else {
-      this._live.textContent = `backend       ${backendLabel}\n(initialising…)`;
+      this._live.textContent = `backend       ${backendText}\n(initialising…)`;
     }
 
     if (streaming) {


### PR DESCRIPTION
The debug overlay computes `backendText = backendLabel(backend)` once, then renders it in the populated branch but interpolated the `backendLabel` function itself in the pre-first-frame (initialising) branch. That branch therefore printed the function source in place of `WebGPU` / `WebGL 2`. It now uses `backendText`, matching the populated branch.

Developer telemetry only (`?debug=1` / `?benchmark=1`); no runtime, layout, or numerical change. Surfaced while verifying that the backend-readout unification (#740) left no stragglers.