### PR TITLE
test: negative-control coverage for floorPlanPositions and formatCount

### DIFF
--- a/tests/domFormatCount.test.ts
+++ b/tests/domFormatCount.test.ts
@@ -1,0 +1,27 @@
+/**
+ * formatCount — the compact point-count formatter, pinned at its three-band
+ * boundaries. Below 1_000 the raw integer is emitted verbatim; 1_000 and up
+ * switches to one-decimal "K"; 1_000_000 and up to one-decimal "M". The
+ * threshold cases (999 vs 1000, and the 1M crossover) are the ones a refactor
+ * would most easily shift. Imported from `ui/dom`, whose module top level is
+ * DOM-free, so no DOM shim is needed.
+ */
+import { describe, it, expect } from 'vitest';
+import { formatCount } from '../src/ui/dom';
+
+describe('formatCount', () => {
+  it('emits values below 1000 verbatim', () => {
+    expect(formatCount(0)).toBe('0');
+    expect(formatCount(999)).toBe('999');
+  });
+
+  it('switches to one-decimal K at 1000', () => {
+    expect(formatCount(1000)).toBe('1.0K');
+    expect(formatCount(1500)).toBe('1.5K');
+  });
+
+  it('switches to one-decimal M at 1_000_000', () => {
+    expect(formatCount(1_000_000)).toBe('1.0M');
+    expect(formatCount(2_500_000)).toBe('2.5M');
+  });
+});

--- a/tests/floorPlanPositions.test.ts
+++ b/tests/floorPlanPositions.test.ts
@@ -1,0 +1,59 @@
+/**
+ * floorPlanPositions — the export path prefers the viewer's denser terrain
+ * gather but must never block on it: the routing snapshot is always valid, so a
+ * gather that is absent, not strictly larger, or throws falls back to it. These
+ * are the negative controls — only a genuinely larger gather may win, and it is
+ * returned by identity (no copy) so callers see the exact buffer.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  floorPlanPositions,
+  type TerrainPositionSource,
+  type PositionsCarrier,
+} from '../src/app/floorPlanPositions';
+
+const carrier = (positions: Float32Array): PositionsCarrier => ({ positions });
+
+const sourceReturning = (
+  dense: { positions: Float32Array } | null,
+): TerrainPositionSource => ({ gatherTerrainPositions: () => dense });
+
+describe('floorPlanPositions', () => {
+  it('returns the dense gather when it is strictly larger (by identity)', () => {
+    const dense = new Float32Array([1, 2, 3, 4]);
+    const fallback = carrier(new Float32Array([9, 9]));
+    const result = floorPlanPositions(sourceReturning({ positions: dense }), fallback, 100);
+    expect(result).toBe(dense);
+  });
+
+  it('falls back when the gather is null', () => {
+    const fallback = carrier(new Float32Array([9, 9]));
+    const result = floorPlanPositions(sourceReturning(null), fallback, 100);
+    expect(result).toBe(fallback.positions);
+  });
+
+  it('falls back when the gather is smaller than the snapshot', () => {
+    const fallback = carrier(new Float32Array([9, 9, 9, 9]));
+    const dense = new Float32Array([1, 2]);
+    const result = floorPlanPositions(sourceReturning({ positions: dense }), fallback, 100);
+    expect(result).toBe(fallback.positions);
+  });
+
+  it('falls back when the gather equals the snapshot length (not strictly larger)', () => {
+    const fallback = carrier(new Float32Array([9, 9]));
+    const dense = new Float32Array([1, 2]);
+    const result = floorPlanPositions(sourceReturning({ positions: dense }), fallback, 100);
+    expect(result).toBe(fallback.positions);
+  });
+
+  it('falls back when the gather throws', () => {
+    const fallback = carrier(new Float32Array([9, 9]));
+    const source: TerrainPositionSource = {
+      gatherTerrainPositions: () => {
+        throw new Error('gather failed');
+      },
+    };
+    const result = floorPlanPositions(source, fallback, 100);
+    expect(result).toBe(fallback.positions);
+  });
+});


### PR DESCRIPTION
Adds first direct tests for two pure helpers; no source change.

`tests/floorPlanPositions.test.ts` pins the fallback contract: a strictly
larger terrain gather wins and is returned by identity; a null gather, a
smaller-or-equal gather, and a throwing gather each return the routing-snapshot
fallback. Stubs only — no DOM or viewer.

`tests/domFormatCount.test.ts` pins the three-band boundaries of `formatCount`:
verbatim below 1000 (0, 999), one-decimal K at 1000 (1.0K, 1.5K), one-decimal M
at 1_000_000 (1.0M, 2.5M). Imported from the DOM-free `ui/dom` top level.

Verify: vitest run on both files — 8 passed; tsc --noEmit — 0.