### PR TITLE
refactor(science): derive live-DTM descriptor despike from a trust parameter

### DIFF
--- a/src/science/liveDtmDescriptor.ts
+++ b/src/science/liveDtmDescriptor.ts
@@ -122,6 +122,13 @@ export interface ResolveLiveDtmOptions {
   readonly horizontalUnitToMetres?: number;
   /** Override the identity vertical unit scale (per-dataset). */
   readonly verticalUnitToMetres?: number;
+  /**
+   * Whether the run trusts an authoritative ASPRS class-2 set. Defaults true —
+   * the production live path. The blunder-only despike is its complement
+   * (`analyseContours.ts:790` — `const despikeApplied = !trust.trust`), so the
+   * two descriptor fields are derived from this one input rather than set apart.
+   */
+  readonly trustGroundClassification?: boolean;
 }
 
 /**
@@ -136,6 +143,10 @@ export function resolveLiveDtmDescriptor(
   if (!entry) {
     throw new Error(`liveDtmDescriptor: method ${LIVE_DTM_METHOD_ID} missing from registry`);
   }
+  // Trust and despike are one decision, not two literals: the despike is the
+  // complement of trust (`analyseContours.ts:790`). Default true keeps the
+  // production live path (trust=true, despike=false).
+  const trust = opts.trustGroundClassification ?? true;
   return {
     methodId: entry.id,
     methodVersion: entry.version,
@@ -143,10 +154,9 @@ export function resolveLiveDtmDescriptor(
     // never mirrored — so a change to the delivered aggregation moves the digest.
     aggregation: LIVE_DTM_AGGREGATION,
     verticalAxis: LIVE_VERTICAL_AXIS,
-    // Production live path delivers the trusted-classification surface.
-    trustGroundClassification: true,
+    trustGroundClassification: trust,
     groundClass: ASPRS_GROUND_CLASS,
-    despikeApplied: false,
+    despikeApplied: !trust,
     interpolation: LIVE_INTERPOLATION,
     extrapolationGuard: {
       radiusCells: LIVE_EXTRAPOLATION_GUARD.radiusCells,

--- a/tests/liveDtmDescriptor.test.ts
+++ b/tests/liveDtmDescriptor.test.ts
@@ -47,6 +47,17 @@ describe('resolveLiveDtmDescriptor', () => {
     expect(d.cellSizeSource).toBe('caller-supplied');
   });
 
+  it('derives despike from trust: trust=false flips the despike on', () => {
+    // Default keeps the production live path (trust set, despike off).
+    const def = resolveLiveDtmDescriptor();
+    expect(def.trustGroundClassification).toBe(true);
+    expect(def.despikeApplied).toBe(false);
+    // Untrusted classification is the complement (analyseContours.ts:790).
+    const untrusted = resolveLiveDtmDescriptor({ trustGroundClassification: false });
+    expect(untrusted.trustGroundClassification).toBe(false);
+    expect(untrusted.despikeApplied).toBe(true);
+  });
+
   it('accepts per-dataset unit-scale overrides', () => {
     const d = resolveLiveDtmDescriptor({
       horizontalUnitToMetres: 0.3048,
@@ -92,6 +103,21 @@ describe('dtmMethodDigest', () => {
       const mutated = { ...base, ...m } as LiveDtmDescriptor;
       expect(dtmMethodDigest(mutated), JSON.stringify(m)).not.toBe(baseDigest);
     }
+  });
+
+  it('default trust holds the digest byte-identical; trust=false moves it', () => {
+    // Pinned pre-refactor default digest: deriving despike from a trust
+    // parameter must not perturb the production default (trust=true → despike
+    // off). If this literal ever changes, the delivered method changed.
+    const DEFAULT_DIGEST =
+      '5150c0a1321a523cf4c4c8522bc549a5388acf018d6ee4f6132d71a4d1505149';
+    expect(dtmMethodDigest(resolveLiveDtmDescriptor())).toBe(DEFAULT_DIGEST);
+    // trust=false flips despike on — a method-behaviour change — so the digest
+    // must differ from the trusted default.
+    const untrusted = dtmMethodDigest(
+      resolveLiveDtmDescriptor({ trustGroundClassification: false }),
+    );
+    expect(untrusted).not.toBe(DEFAULT_DIGEST);
   });
 
   it('does not fold CRS/datum/geoid into the digest', () => {


### PR DESCRIPTION
`resolveLiveDtmDescriptor` set `trustGroundClassification` and `despikeApplied` as two decoupled literals that must stay equal to the production invariant `analyseContours.ts:790` (`despikeApplied = !trust.trust`).

Add optional `trustGroundClassification` to `ResolveLiveDtmOptions` and derive both descriptor fields from it (`despikeApplied = !trust`). Default `trust=true` keeps the production live path.

Freeze-safe: default path leaves `methodBehaviourFields` and `dtmMethodDigest` byte-identical (pinned digest `5150c0a1…505149`). A negative-control test asserts `trust=false` gives `despike=true` and a different digest. Resolver + test only; no production generation/export path stamps the new parameter. No new imports.

tsc --noEmit: 0. vitest tests/liveDtmDescriptor.test.ts: 9 passed.