### PR TITLE
chore(lint): validate oracle-registry entries (field presence + id uniqueness)

### DIFF
--- a/scripts/lint-oracle-registry.mjs
+++ b/scripts/lint-oracle-registry.mjs
@@ -15,9 +15,20 @@
  *       Two programs wrapping one library are one implementation. Summing them
  *       reports a corroboration that does not exist.
  *
- * `collectOracleProblems` is a function of the registry and records it is
- * given, so tests/oracleRegistryLint.test.ts constructs both rather than
- * depending on what the repository holds today.
+ * The O rules trust the registry to be well formed. `collectRegistryProblems`
+ * checks that assumption, because a broken entry defeats them silently:
+ *
+ *   R0  Two entries share an oracleId. The later one overwrites the earlier in
+ *       every lookup, so the first oracle's roles and lineage vanish.
+ *   R1  An entry omits oracleId, name, version, lineageGroup or license. A
+ *       dropped lineageGroup is the one O3 reads to see a double count.
+ *   R2  roleCapabilities is empty or absent, so the entry can play no role a
+ *       record may claim.
+ *   R3  domains is empty or absent.
+ *
+ * Both collectors are functions of their input, so tests/oracleRegistryLint.
+ * test.ts constructs synthetic registries and records rather than depending on
+ * what the repository holds today.
  */
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
@@ -91,6 +102,58 @@ export function collectOracleProblems(registry, records) {
   return { problems, cited, lineages: lineages.size };
 }
 
+/**
+ * Problems in the registry's own entries. Returns `{ problems }`.
+ *
+ * Rules R0-R3 above. Missing scalar fields are reported one per field so the
+ * message names which one; a missing oracleId is labelled by list position,
+ * since there is no id to name it by.
+ */
+export function collectRegistryProblems(registry) {
+  const problems = [];
+  const seen = new Set();
+  const oracles = registry.oracles ?? [];
+
+  oracles.forEach((o, i) => {
+    const hasId = typeof o.oracleId === 'string' && o.oracleId.trim() !== '';
+    const label = hasId ? o.oracleId : `entry #${i}`;
+
+    if (hasId) {
+      if (seen.has(o.oracleId)) {
+        problems.push(
+          `[R0 duplicate-oracle-id] registry defines ${o.oracleId} more than once. ` +
+            "The later entry overwrites the earlier in every lookup, so the first oracle's roles and lineage vanish.",
+        );
+      } else {
+        seen.add(o.oracleId);
+      }
+    }
+
+    for (const field of ['oracleId', 'name', 'version', 'lineageGroup', 'license']) {
+      const v = o[field];
+      if (typeof v !== 'string' || v.trim() === '') {
+        problems.push(
+          `[R1 field-missing] registry ${label} has no ${field}. ` +
+            'Every registered oracle needs one before a study can cite it.',
+        );
+      }
+    }
+
+    if (!Array.isArray(o.roleCapabilities) || o.roleCapabilities.length === 0) {
+      problems.push(
+        `[R2 role-capabilities-empty] registry ${label} lists no roleCapabilities, ` +
+          'so it can play no role a record may claim.',
+      );
+    }
+
+    if (!Array.isArray(o.domains) || o.domains.length === 0) {
+      problems.push(`[R3 domains-empty] registry ${label} lists no domains.`);
+    }
+  });
+
+  return { problems };
+}
+
 /** Every JSON under validation/external-oracles that names oracles. */
 function* walk(dir) {
   if (!existsSync(dir)) return;
@@ -119,10 +182,11 @@ if (isCli) {
   }
 
   const { problems, cited, lineages } = collectOracleProblems(registry, records);
+  const allProblems = [...collectRegistryProblems(registry).problems, ...problems];
 
-  if (problems.length > 0) {
-    console.error(`\nlint:oracle-registry: ${problems.length} problem(s):\n`);
-    for (const p of problems) console.error(`  - ${p}`);
+  if (allProblems.length > 0) {
+    console.error(`\nlint:oracle-registry: ${allProblems.length} problem(s):\n`);
+    for (const p of allProblems) console.error(`  - ${p}`);
     console.error('');
     process.exit(1);
   }

--- a/tests/oracleRegistryLint.test.ts
+++ b/tests/oracleRegistryLint.test.ts
@@ -17,9 +17,10 @@ import { describe, it, expect } from 'vitest';
 
 // Kept on one line: @ts-expect-error applies to the line that follows it.
 // @ts-expect-error — plain .mjs script, no types
-import { collectOracleProblems } from '../scripts/lint-oracle-registry.mjs';
+import { collectOracleProblems, collectRegistryProblems } from '../scripts/lint-oracle-registry.mjs';
 
 interface Result { problems: string[]; cited: number; lineages: number }
+interface RegistryResult { problems: string[] }
 
 const REGISTRY = {
   roleDefinitions: {
@@ -148,5 +149,76 @@ describe('O3 — same lineage is not two independent legs', () => {
       { path: 'b.json', oracles: [{ oracleId: 'gdal-3.13.1' }] },
     ]);
     expect(ids(r.problems)).not.toContain('O3');
+  });
+});
+
+// The O rules trust the registry; these guard the registry entries themselves,
+// because a broken entry defeats an O rule with no error of its own — a dropped
+// lineageGroup blinds O3, a duplicate oracleId overwrites an entry in the lookup.
+const runRegistry = (registry: unknown): RegistryResult =>
+  collectRegistryProblems(registry) as RegistryResult;
+
+const validEntry = () => ({
+  oracleId: 'proj-9.8.1',
+  name: 'PROJ',
+  version: '9.8.1',
+  lineageGroup: 'proj',
+  license: 'MIT',
+  roleCapabilities: ['independent-same-quantity-implementation'],
+  domains: ['utm'],
+});
+
+describe('registry entries — the entries the O rules read must be well-formed', () => {
+  it('accepts a well-formed entry', () => {
+    expect(runRegistry({ oracles: [validEntry()] }).problems).toEqual([]);
+  });
+
+  it('R0 rejects a duplicate oracleId, which would overwrite the earlier entry', () => {
+    const dup = { ...validEntry(), lineageGroup: 'gdal', domains: ['slope'] };
+    const r = runRegistry({ oracles: [validEntry(), dup] });
+    expect(ids(r.problems)).toContain('R0');
+    expect(r.problems.find((p) => p.startsWith('[R0'))).toContain('proj-9.8.1');
+  });
+
+  it('R1 rejects a missing lineageGroup and names the field O3 depends on', () => {
+    const e = validEntry() as Record<string, unknown>;
+    delete e.lineageGroup;
+    const r = runRegistry({ oracles: [e] });
+    expect(ids(r.problems)).toContain('R1');
+    expect(r.problems.find((p) => p.startsWith('[R1'))).toContain('lineageGroup');
+  });
+
+  it('R1 flags every required scalar field by name when all are absent', () => {
+    const r = runRegistry({ oracles: [{ roleCapabilities: ['x'], domains: ['y'] }] });
+    const r1 = r.problems.filter((p) => p.startsWith('[R1'));
+    for (const field of ['oracleId', 'name', 'version', 'lineageGroup', 'license']) {
+      expect(r1.some((p) => p.includes(field))).toBe(true);
+    }
+  });
+
+  it('R1 treats an empty-string field as missing', () => {
+    const r = runRegistry({ oracles: [{ ...validEntry(), license: '   ' }] });
+    expect(ids(r.problems)).toContain('R1');
+    expect(r.problems.find((p) => p.startsWith('[R1'))).toContain('license');
+  });
+
+  it('R2 rejects an entry whose roleCapabilities is empty or absent', () => {
+    expect(ids(runRegistry({ oracles: [{ ...validEntry(), roleCapabilities: [] }] }).problems)).toContain('R2');
+    const e = validEntry() as Record<string, unknown>;
+    delete e.roleCapabilities;
+    expect(ids(runRegistry({ oracles: [e] }).problems)).toContain('R2');
+  });
+
+  it('R3 rejects an entry whose domains is empty or absent', () => {
+    expect(ids(runRegistry({ oracles: [{ ...validEntry(), domains: [] }] }).problems)).toContain('R3');
+    const e = validEntry() as Record<string, unknown>;
+    delete e.domains;
+    expect(ids(runRegistry({ oracles: [e] }).problems)).toContain('R3');
+  });
+
+  it('labels a missing-oracleId entry by list position, having no id to name', () => {
+    const r = runRegistry({ oracles: [{ name: 'X', version: '1', lineageGroup: 'x', license: 'MIT', roleCapabilities: ['r'], domains: ['d'] }] });
+    expect(ids(r.problems)).toContain('R1');
+    expect(r.problems.find((p) => p.startsWith('[R1'))).toContain('entry #0');
   });
 });


### PR DESCRIPTION
lint:oracle-registry validated study records (O0-O3) but trusted the registry's own entries. A malformed entry defeats those rules silently: a dropped `lineageGroup` blinds O3 double-count detection, and a duplicate `oracleId` overwrites the earlier entry in the lookup so its roles and lineage vanish.

Adds exported pure `collectRegistryProblems(registry)` flagging per entry:
- R0 duplicate oracleId
- R1 missing oracleId/name/version/lineageGroup/license (one message per field; empty strings count as missing)
- R2 empty or absent roleCapabilities
- R3 empty or absent domains

The CLI merges these into the problem list before `process.exit(1)`. Hand-written checks, no ajv. The committed `oracle-registry.json` conforms, so the gate stays green (exit 0, 10 oracles). Tests extend `oracleRegistryLint.test.ts` with a reject-and-say-why case per defect, asserting the R0-R3 rule id.

Lint/test only; no numerical output changes.