### PR TITLE
fix(provenance): aim EPOCH-ALIGN method at the reachable solver

### DIFF
--- a/src/science/methodRegistry.ts
+++ b/src/science/methodRegistry.ts
@@ -205,7 +205,7 @@ export const METHOD_REGISTRY: Readonly<Record<string, MethodEntry>> = {
       'olv.registration.icp-planar.',
     citation: 'Besl & McKay (1992), doi:10.1109/34.121791; Umeyama (1991) planar LS',
     category: 'registration',
-    implementation: ['src/terrain/change/alignEpochs.ts', 'src/registration/planarIcp.ts'],
+    implementation: ['src/terrain/change/alignEpochs.ts', 'src/terrain/change/icpRegister.ts'],
   },
   'olv.volume.stockpile': {
     id: 'olv.volume.stockpile',

--- a/tests/capabilityTruth.test.ts
+++ b/tests/capabilityTruth.test.ts
@@ -1,0 +1,78 @@
+/**
+ * capabilityTruth.test.ts — a shipping claim's method may only cite code the
+ * running application reaches.
+ *
+ * The provenance chain claim → method → implementation source is only honest if
+ * that source is code the product actually runs. docs/validation/unreachable-modules.json
+ * is the register of every module under src/ the application does not reach
+ * (staged, validation-only, reference-only or orphan). A claim whose
+ * softwareStatus is `shipping` asserts the product does the thing; if its
+ * method's implementation names an unreachable module, the record points a live
+ * claim at code no live path executes.
+ *
+ * This binds the two registers: for every shipping claim with a methodId, none
+ * of that method's implementation paths may appear in the unreachable register.
+ * The YAML is read the same line-based way as scripts/lint-claim-register.mjs
+ * (no YAML parser is a declared dependency).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { METHOD_REGISTRY } from '../src/science/methodRegistry';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Shipping claims paired with their methodId, from the register. */
+function shippingClaimMethods(): { claimId: string; methodId: string }[] {
+  const yaml = readFileSync(resolve(ROOT, 'docs/validation/claim-register.yaml'), 'utf8');
+  const out: { claimId: string; methodId: string; softwareStatus: string | null }[] = [];
+  let cur: (typeof out)[number] | null = null;
+  for (const raw of yaml.split('\n')) {
+    if (raw.trim() === '' || raw.trimStart().startsWith('#')) continue;
+    const line = raw.trim();
+    let m: RegExpMatchArray | null;
+    if ((m = line.match(/^-?\s*claimId:\s*(\S+)/))) {
+      cur = { claimId: m[1], methodId: '', softwareStatus: null };
+      out.push(cur);
+      continue;
+    }
+    if (!cur) continue;
+    if ((m = line.match(/^methodId:\s*(\S+)/))) cur.methodId = m[1];
+    else if ((m = line.match(/^softwareStatus:\s*(\S+)/))) cur.softwareStatus = m[1];
+  }
+  return out
+    .filter((c) => c.softwareStatus === 'shipping' && c.methodId)
+    .map(({ claimId, methodId }) => ({ claimId, methodId }));
+}
+
+/** Every module path the running application does not reach. */
+function unreachablePaths(): Set<string> {
+  const doc = JSON.parse(
+    readFileSync(resolve(ROOT, 'docs/validation/unreachable-modules.json'), 'utf8'),
+  ) as { modules: { path: string }[] };
+  return new Set(doc.modules.map((m) => m.path));
+}
+
+describe('capability truth: shipping claims cite reachable code', () => {
+  it('pairs a meaningful number of shipping claims to methods', () => {
+    expect(shippingClaimMethods().length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('no shipping claim method names an unreachable implementation module', () => {
+    const unreachable = unreachablePaths();
+    const offenders: string[] = [];
+    for (const { claimId, methodId } of shippingClaimMethods()) {
+      const entry = METHOD_REGISTRY[methodId];
+      expect(entry, `claim ${claimId} names unregistered method ${methodId}`).toBeDefined();
+      for (const p of entry.implementation) {
+        if (unreachable.has(p)) offenders.push(`${claimId} → ${methodId} → ${p}`);
+      }
+    }
+    expect(
+      offenders,
+      `shipping claims citing unreachable code:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
The EPOCH-ALIGN claim (shipping) bound its method `olv.registration.epoch-horizontal-icp` to `src/registration/planarIcp.ts`, a staged re-export listed unreachable in `docs/validation/unreachable-modules.json`. The transform that runs is `alignEpochs`, which imports `src/terrain/change/icpRegister.ts`. The implementation path now names that reachable solver.

New guard `tests/capabilityTruth.test.ts`: for every shipping claim carrying a `methodId`, none of the method's implementation paths may appear in the unreachable-modules register. It is red on the old registry entry and green after the edit.

The staged `olv.registration.icp-planar` entry is unchanged (not a shipping claim). Provenance-only; no numerical output changes.

Verify: `tsc --noEmit` exit 0; `vitest run tests/methodRegistry.test.ts tests/capabilityTruth.test.ts tests/methodSupportingTests.test.ts` 16 passed; `node scripts/lint-claim-register.mjs` exit 0.