### PR TITLE
docs: correct v0.6.7 validation and streaming claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ The quick report takes five to ten minutes. A longer comparison against a refere
 For reviewers, and anyone who wants to check the claims above rather than take them on trust:
 
 - [REVIEWER_QUICKSTART.md](REVIEWER_QUICKSTART.md): install and run the offline test suite from a clean clone in about two minutes.
-- [VALIDATION_REPORT_v0.6.7.md](docs/releases/VALIDATION_REPORT_v0.6.7.md): what this release validates and what it does not; the DSM and DTM surface grids reach E4 on cross-implementation agreement with PDAL, and the terrain and measurement algorithms are otherwise inherited from [VALIDATION_REPORT_v0.6.5.md](docs/releases/VALIDATION_REPORT_v0.6.5.md).
+- [VALIDATION_REPORT_v0.6.7.md](docs/releases/VALIDATION_REPORT_v0.6.7.md): what this release validates and what it does not; five products reach E4 on cross-implementation agreement this cycle — CRS-UTM-PROJECTION against GeographicLib and PROJ, CHANGE-RASTER and CHANGE-VOLUME against GRASS, and HOLDOUT-RMSE and NVA-VVA against base R — taking the register from twelve to seventeen products at E4, with the twelve carried unchanged from [VALIDATION_REPORT_v0.6.6.md](docs/releases/VALIDATION_REPORT_v0.6.6.md).
 - [KNOWN_LIMITATIONS_v0.6.7.md](docs/releases/KNOWN_LIMITATIONS_v0.6.7.md): the documented limits of this release (DSM/DTM cross-check covers the gridding step only, ground classification still partial, residual streaming flicker, no cross-CRS reprojection).
 - [REPRODUCIBILITY.md](REPRODUCIBILITY.md): the pinned toolchain and the steps to reproduce the build, tests, and reported figures.
 - [ARTIFACT_EVALUATION.md](ARTIFACT_EVALUATION.md): how to evaluate the artifact without special hardware or private data.

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -20,7 +20,7 @@ features:
   - title: Local-first by design
     details: Files are read and rendered in your browser. There is no server to upload to — your data never leaves your device.
   - title: Twelve import formats, four streaming
-    details: LAS, LAZ, E57, PLY, OBJ, GLB/GLTF, XYZ, CSV, PCD, PTX, PTS for static loads — plus four streaming paths with bounded memory: progressive COPC and EPT, 3D Tiles PNTS tilesets, and out-of-core LAS / chunked LAZ indexed via OPFS.
+    details: "LAS, LAZ, E57, PLY, OBJ, GLB/GLTF, XYZ, CSV, PCD, PTX, PTS for static loads — plus four streaming paths with bounded memory: progressive COPC and EPT, 3D Tiles PNTS tilesets, and out-of-core LAS / chunked LAZ indexed via OPFS."
     link: /formats/
     linkText: Format matrix
   - title: Honesty about uncertainty

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -19,8 +19,8 @@ hero:
 features:
   - title: Local-first by design
     details: Files are read and rendered in your browser. There is no server to upload to — your data never leaves your device.
-  - title: Twelve import formats, two streaming
-    details: LAS, LAZ, E57, PLY, OBJ, GLB/GLTF, XYZ, CSV, PCD, PTX, PTS — plus progressive COPC and EPT streaming with bounded memory.
+  - title: Twelve import formats, four streaming
+    details: LAS, LAZ, E57, PLY, OBJ, GLB/GLTF, XYZ, CSV, PCD, PTX, PTS for static loads — plus four streaming paths with bounded memory: progressive COPC and EPT, 3D Tiles PNTS tilesets, and out-of-core LAS / chunked LAZ indexed via OPFS.
     link: /formats/
     linkText: Format matrix
   - title: Honesty about uncertainty

--- a/docs-site/releases/v0.6.7.md
+++ b/docs-site/releases/v0.6.7.md
@@ -15,9 +15,14 @@ through temporary browser storage in the Origin Private File System rather than
 being read whole into memory, and 3D Tiles implicit tiling opens and streams
 where an earlier release read only an explicit tile hierarchy.
 
-This release adds no new scientific evidence claim, no new E4 promotion and no
-new validation study. The twelve registered products at E4 stay exactly as
-validated in v0.6.6. A short run of corrections rides underneath: the profile
+This release also promotes five products to `E4_CROSS_IMPLEMENTATION_VALIDATED`,
+taking the register from twelve to seventeen products at E4. CRS-UTM-PROJECTION
+is checked against GeographicLib 2.7 and PROJ 9.8.1, CHANGE-RASTER and
+CHANGE-VOLUME against GRASS 8.5.0, and HOLDOUT-RMSE and NVA-VVA against base R.
+Each is a cross-implementation check on frozen synthetic or analytic fixtures,
+not field accuracy against a surveyed reference, and no product reaches E5. The
+twelve products validated in v0.6.6 carry forward unchanged. A short run of
+corrections rides underneath: the profile
 PDF max-grade now carries the sign the panel already shows, the Inspector
 elevation rows read the source vertical unit instead of assuming metres, leaked
 panel-rail observers are disposed, a degenerate profile no longer reports full


### PR DESCRIPTION
Three public doc-truth corrections, verified against CHANGELOG.md [0.6.7], docs/releases/VALIDATION_REPORT_v0.6.7.md, and docs/validation/claim-register.yaml (17 E4 claims).

- README.md validation bullet: replaced v0.6.6's DSM/DTM headline and the v0.6.5 inheritance pointer with v0.6.7's five E4 promotions (CRS-UTM-PROJECTION, CHANGE-RASTER, CHANGE-VOLUME, HOLDOUT-RMSE, NVA-VVA), twelve to seventeen, citing the v0.6.6 report for the carried-forward twelve.
- docs-site/releases/v0.6.7.md: removed the false "no new E4 promotion / twelve stay exactly as validated" line; states the five promotions and twelve to seventeen.
- docs-site/index.md hero: "two streaming" to "four streaming" (COPC, EPT, 3D Tiles PNTS tilesets, out-of-core LAS / chunked LAZ via OPFS).

Prose only; no numerical output changes. lint-release-truth, lint-claims-language, lint-editorial-language, lint-doc-links all exit 0; tsc --noEmit exit 0.