### PR TITLE
feat(streaming): report scheduler-owned decode-retry and upload-queue totals

### DIFF
--- a/src/render/streaming/StreamingScheduler.ts
+++ b/src/render/streaming/StreamingScheduler.ts
@@ -848,17 +848,24 @@ export class StreamingScheduler {
   /**
    * One flat streaming-diagnostics snapshot, assembled from the SAME readiness
    * facts the phase machine acted on and the live store / cache counters. The
-   * five fields the scheduler does not track (generation id, decode-retry total,
-   * GPU-upload queue depth/bytes, resident decoded bytes) are left unset, so the
-   * record reports them as null and names them under `unavailable` rather than
-   * estimating. This is the canonical numbers source for the debug overlay and a
-   * diagnostics export — neither has to re-derive the same metrics.
+   * decode-retry total sums the live `_decodeFailures` counts; the GPU-upload
+   * queue depth and byte backlog come from the attached `_uploadQueue`, or read
+   * as null when no queue is attached. Generation id and resident decoded bytes
+   * stay unset — the scheduler totals neither — so the record reports them as
+   * null and names them under `unavailable` rather than estimating. This is the
+   * canonical numbers source for the debug overlay and a diagnostics export —
+   * neither has to re-derive the same metrics.
    */
   diagnostics(): StreamingDiagnostics {
     const facts = this.readinessFacts();
     const store = this._cloud.octree.store;
     const s = this.stats();
     const c = this.cacheStats();
+    const uploadQueue = this._uploadQueue;
+    // Per-node decode failures — the counts backoff is armed from — summed into
+    // the one cumulative retry total the overlay reads.
+    let decodeRetryCount = 0;
+    for (const failures of this._decodeFailures.values()) decodeRetryCount += failures;
     return buildStreamingDiagnostics(facts, evaluateRefinementReadiness(facts), {
       knownNodes: store.counts().known,
       visibleNodes: s.visible,
@@ -878,6 +885,9 @@ export class StreamingScheduler {
       cacheHits: c.hits,
       cacheMisses: c.misses,
       cacheEvictions: c.evictions,
+      decodeRetryCount,
+      uploadPendingNodes: uploadQueue?.pendingCount,
+      uploadPendingBytes: uploadQueue?.pendingBytes,
     });
   }
 

--- a/tests/streamingScheduler.test.ts
+++ b/tests/streamingScheduler.test.ts
@@ -10,6 +10,7 @@ import {
   selectWithinBudget,
 } from '../src/render/streaming/streamingBudget';
 import { StreamingScheduler } from '../src/render/streaming/StreamingScheduler';
+import { GpuUploadQueue } from '../src/render/gpuUploadQueue';
 import { evaluateRefinementReadiness } from '../src/render/streaming/refinementReadiness';
 import { StreamingPointCloud } from '../src/render/streaming/StreamingPointCloud';
 import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
@@ -161,21 +162,71 @@ test('diagnostics() reports the live streaming state and names what it cannot me
   expect(d.residentPoints).toBe(3100);
   expect(d.pointBudget).toBeGreaterThan(0);
   expect(d.cacheMaxBytes).toBeGreaterThan(0);
-  // The five fields the scheduler does not track are null AND named — never faked.
+  // The scheduler owns the decode-retry counter: no decode failed here, so it
+  // reports a measured zero rather than 'unavailable'.
+  expect(d.decodeRetryCount).toBe(0);
+  expect(d.unavailable).not.toContain('decodeRetryCount');
+  // The fields no counter backs — no upload queue attached, generation id and
+  // resident decoded bytes untotalled — are null AND named, never faked.
   expect(d.generationId).toBeNull();
-  expect(d.decodeRetryCount).toBeNull();
   expect(d.uploadPendingNodes).toBeNull();
   expect(d.uploadPendingBytes).toBeNull();
   expect(d.residentDecodedBytes).toBeNull();
   expect(d.unavailable).toEqual(
     expect.arrayContaining([
       'generationId',
-      'decodeRetryCount',
       'uploadPendingNodes',
       'uploadPendingBytes',
       'residentDecodedBytes',
     ]),
   );
+});
+
+test('diagnostics() surfaces the scheduler-owned decode-retry total once decodes fail', async () => {
+  const cloud = await openCloud();
+  const failingDecoder: ChunkDecoder = {
+    decode(): Promise<DecodedChunk> {
+      return Promise.reject(new Error('synthetic decode failure'));
+    },
+  };
+  const scheduler = new StreamingScheduler(
+    cloud,
+    failingDecoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    streamingBudgets('balanced', false),
+  );
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  const d = scheduler.diagnostics();
+  // Every wanted node failed to decode at least once, so the summed per-node
+  // failure counter is a real, non-null quantity — not 'unavailable'.
+  expect(d.decodeRetryCount).toBeGreaterThan(0);
+  expect(d.unavailable).not.toContain('decodeRetryCount');
+});
+
+test('diagnostics() surfaces the attached upload queue depth and byte backlog', async () => {
+  const cloud = await openCloud();
+  const uploadQueue = new GpuUploadQueue();
+  const scheduler = new StreamingScheduler(
+    cloud,
+    fakeDecoder,
+    { onNodeReady: () => {}, onNodeEvicted: () => {} },
+    streamingBudgets('balanced', false),
+    { uploadQueue, datasetId: 'sched.copc.laz' },
+  );
+  scheduler.update({ viewProjection: WIDE, cameraPosition: [0, 0, 0] });
+  await drain(scheduler);
+
+  const d = scheduler.diagnostics();
+  // Decoded nodes wait in the queue until the render loop commits them. The
+  // scheduler owns that queue, so its depth and bytes report as measured.
+  expect(d.uploadPendingNodes).toBe(uploadQueue.pendingCount);
+  expect(d.uploadPendingNodes).toBeGreaterThan(0);
+  expect(d.uploadPendingBytes).toBe(uploadQueue.pendingBytes);
+  expect(d.uploadPendingBytes).toBeGreaterThan(0);
+  expect(d.unavailable).not.toContain('uploadPendingNodes');
+  expect(d.unavailable).not.toContain('uploadPendingBytes');
 });
 
 test('nodes at real UTM-scale coordinates still reach resident (origin-localisation guard)', async () => {


### PR DESCRIPTION
StreamingScheduler.diagnostics() built its `extra` object without any scheduler-owned optional fields, so `decodeRetryCount` and the GPU-upload queue depth/bytes reported `unavailable` in the `?debug` overlay even though the scheduler held the live data.

- `decodeRetryCount`: sum of the per-node `_decodeFailures` counts (the same counts backoff is armed from).
- `uploadPendingNodes` / `uploadPendingBytes`: the attached `_uploadQueue`'s `pendingCount` / `pendingBytes`; null when no queue is attached.
- Generation id and resident decoded bytes stay unset — the scheduler totals neither.

Builder (`streamingDiagnostics.ts`) unchanged. Tests assert the fields now populate: measured zero with no failures, `> 0` under a rejecting decoder, and real queue depth/bytes with an attached upload queue. Debug/telemetry only — no DTM/terrain numerical output changes.

Verify: `tsc --noEmit` clean; `vitest run` streamingScheduler + streamingDiagnostics + streamingDiagnosticsFormat = 67 passed.