### PR TITLE
style: route the last raw z-index (coordinate HUD) through a token

### DIFF
--- a/src/styles/01-tokens.css
+++ b/src/styles/01-tokens.css
@@ -194,6 +194,7 @@
   --z-content: 1;         /* content sitting above a same-stack wash */
   --z-scene-overlay: 2;   /* decorative canvas vignette overlay */
   --z-topbar: 4;          /* click-through top bar */
+  --z-hud-readout: 6;     /* coordinate/survey corner readout, above the top bar */
   --z-hud: 10;            /* persistent navigation-bar HUD */
   --z-panel: 15;          /* Inspector panel (16 = panel + 1) */
   --z-dock: 20;           /* tool dock + left/right panels (21 = dock + 1) */

--- a/src/styles/40-inspector.css
+++ b/src/styles/40-inspector.css
@@ -539,7 +539,7 @@
    the cursor while the probe is active. Fixed bottom-left, out of the panels. */
 .olv-coordinate-hud {
   position: absolute; left: var(--space-sm); bottom: var(--space-sm);
-  z-index: 6; pointer-events: none;
+  z-index: var(--z-hud-readout); pointer-events: none;
   display: flex; flex-direction: column; gap: 2px;
   padding: var(--space-2xs) var(--space-sm);
   font-size: var(--text-xs); font-variant-numeric: tabular-nums;

--- a/tests/fixtures/style.css.original
+++ b/tests/fixtures/style.css.original
@@ -194,6 +194,7 @@
   --z-content: 1;         /* content sitting above a same-stack wash */
   --z-scene-overlay: 2;   /* decorative canvas vignette overlay */
   --z-topbar: 4;          /* click-through top bar */
+  --z-hud-readout: 6;     /* coordinate/survey corner readout, above the top bar */
   --z-hud: 10;            /* persistent navigation-bar HUD */
   --z-panel: 15;          /* Inspector panel (16 = panel + 1) */
   --z-dock: 20;           /* tool dock + left/right panels (21 = dock + 1) */
@@ -1645,7 +1646,7 @@ body.olv-theme-light .olv-empty::before {
    the cursor while the probe is active. Fixed bottom-left, out of the panels. */
 .olv-coordinate-hud {
   position: absolute; left: var(--space-sm); bottom: var(--space-sm);
-  z-index: 6; pointer-events: none;
+  z-index: var(--z-hud-readout); pointer-events: none;
   display: flex; flex-direction: column; gap: 2px;
   padding: var(--space-2xs) var(--space-sm);
   font-size: var(--text-xs); font-variant-numeric: tabular-nums;


### PR DESCRIPTION
The coordinate-HUD readout in `40-inspector.css` was the one remaining raw z-index literal (`6`) after the z-index tokenisation (#754). Add a semantic `--z-hud-readout` token in the 4<n<10 band (above `--z-topbar`, below `--z-hud`) and route the value through it — the value is unchanged, so no visual or stacking change.

Fully closes the z-index token pass: zero raw numeric z-index now remains in `src/styles`. Partition fixture regenerated; `styleCssPartition` green (3/3).