### PR TITLE
fix(science): passport fails closed + validates method ids

### DIFF
--- a/src/science/scientificArtifactPassport.ts
+++ b/src/science/scientificArtifactPassport.ts
@@ -36,12 +36,23 @@
 
 import { canonicalize, sha256 } from '../render/measure/auditLog';
 import { sha256Hex } from '../terrain/export/sha256';
-import { methodRef, methodTag, type MethodRef } from './methodRegistry';
+import { isMethodId, methodRef, methodTag, type MethodRef } from './methodRegistry';
 import type { ScientificAnalysisRecord } from './scientificAnalysisRecord';
 import { verifyProcessingManifest, type ProcessingManifest } from './processingManifest';
 import type { BuildIdentity } from '../build/buildIdentity';
 
 export const SCIENTIFIC_ARTIFACT_PASSPORT_SCHEMA = 1;
+
+/**
+ * The exact scope this passport claims, pinned as a constant so UI and exports
+ * quote it verbatim and no caller drifts into a stronger word. It is tamper
+ * EVIDENCE over internal consistency — never authentication, authorship, or
+ * accuracy beyond the recorded evidence level.
+ */
+export const PASSPORT_CLAIM_SCOPE =
+  'Tamper-evident, not authenticated. Proves only that the recorded digests ' +
+  'still recompute over the bytes and records they cover; it proves no identity, ' +
+  'no authorship, and no accuracy beyond the evidence level recorded.';
 
 /** Whether the whole-source digest was available when the passport was built. */
 export type SourceDigestStatus = 'verified' | 'unavailable';
@@ -216,6 +227,10 @@ export function buildScientificArtifactPassport(
 ): ScientificArtifactPassport {
   const record = input.analysis;
   const methodIds = input.methodIds ?? record.methods.map((m: MethodRef) => m.id);
+  // Caller-supplied ids must be registered before any digest binds to them.
+  for (const id of methodIds) {
+    if (!isMethodId(id)) throw new Error(`Unknown method id: ${id}`);
+  }
   const methodDigest = input.methodDigest ?? null;
   const sourceSha = input.source.sha256;
 
@@ -350,6 +365,10 @@ export function verifyScientificArtifactPassport(
   opts: PassportVerifyOptions = {},
 ): PassportVerificationState {
   if (!structurallyComplete(passport)) return 'INCOMPLETE';
+
+  // Fail closed: a passport built over a processing chain that did not verify
+  // intact is never VERIFIED, even when no reference material is supplied.
+  if (passport.processing.verified !== true) return 'PROCESSING_MANIFEST_CHANGED';
 
   // Processing: recompute the chain head and re-verify the op chain.
   if (opts.processing) {

--- a/tests/scientificArtifactPassport.test.ts
+++ b/tests/scientificArtifactPassport.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildScientificArtifactPassport,
   reproducibilityLine,
+  PASSPORT_CLAIM_SCOPE,
   SCIENTIFIC_ARTIFACT_PASSPORT_SCHEMA,
   type ScientificArtifactPassportInput,
 } from '../src/science/scientificArtifactPassport';
@@ -112,6 +113,23 @@ describe('buildScientificArtifactPassport', () => {
     const b = buildScientificArtifactPassport(baseInput(GEOTIFF));
     expect(a.scienceId).toBe(b.scienceId);
     expect(a.passportSha256).toBe(b.passportSha256);
+  });
+
+  it('throws before any digest when a caller supplies an unregistered method id', () => {
+    expect(() =>
+      buildScientificArtifactPassport({ ...baseInput(GEOTIFF), methodIds: ['olv.not.real'] }),
+    ).toThrow(/Unknown method id: olv\.not\.real/);
+  });
+});
+
+describe('PASSPORT_CLAIM_SCOPE', () => {
+  it('pins the tamper-evidence disclaimer and claims nothing stronger', () => {
+    const scope = PASSPORT_CLAIM_SCOPE.toLowerCase();
+    expect(scope).toContain('tamper-evident');
+    expect(scope).toContain('not authenticated');
+    expect(scope).not.toContain('certified accurate');
+    expect(scope).not.toContain('authenticated by');
+    expect(scope).not.toContain('survey-grade');
   });
 });
 

--- a/tests/scientificArtifactPassportTamper.test.ts
+++ b/tests/scientificArtifactPassportTamper.test.ts
@@ -17,7 +17,11 @@ import {
   buildScientificAnalysisRecord,
   type ScientificAnalysisRecordInput,
 } from '../src/science/scientificAnalysisRecord';
-import { buildProcessingManifest, type ProcessingOpInput } from '../src/science/processingManifest';
+import {
+  buildProcessingManifest,
+  verifyProcessingManifest,
+  type ProcessingOpInput,
+} from '../src/science/processingManifest';
 import type { BuildIdentity } from '../src/build/buildIdentity';
 
 const build: BuildIdentity = {
@@ -217,5 +221,35 @@ describe('verifyScientificArtifactPassport — one broken link', () => {
     const p = clone(buildScientificArtifactPassport(makeInput()));
     delete (p as { passportSha256?: string }).passportSha256;
     expect(verifyScientificArtifactPassport(p)).toBe('INCOMPLETE');
+  });
+});
+
+describe('verifyScientificArtifactPassport — fails closed over a broken chain', () => {
+  it('never returns VERIFIED when the processing chain did not verify intact', () => {
+    // A manifest whose op parameter was altered without re-folding the chain:
+    // the recorded head no longer covers it, so verifyProcessingManifest reports
+    // it broken and the passport records processing.verified === false.
+    const tampered = JSON.parse(JSON.stringify(manifest)) as typeof manifest;
+    (tampered.ops[0] as { params: Record<string, unknown> }).params = { cell: 1, slope: 0.99 };
+    expect(verifyProcessingManifest(tampered).ok).toBe(false);
+
+    const p = buildScientificArtifactPassport({ ...makeInput(), processing: tampered });
+    expect(p.processing.verified).toBe(false);
+
+    // Fail closed with no reference material supplied at all.
+    expect(verifyScientificArtifactPassport(p)).not.toBe('VERIFIED');
+    expect(verifyScientificArtifactPassport(p)).toBe('PROCESSING_MANIFEST_CHANGED');
+
+    // And with the full reference set supplied.
+    expect(
+      verifyScientificArtifactPassport(p, {
+        artifactBytes: ARTIFACT,
+        analysis: buildScientificAnalysisRecord(recordInput),
+        methodIds: ['olv.ground.smrf', 'olv.validation.spatial-block'],
+        methodDigest: 'deadbeef',
+        processing: tampered,
+        evidence,
+      }),
+    ).not.toBe('VERIFIED');
   });
 });


### PR DESCRIPTION
Harden the scientific-artifact passport library.

- verifyScientificArtifactPassport returns PROCESSING_MANIFEST_CHANGED whenever processing.verified !== true, so a passport built over a chain that did not verify intact never reads VERIFIED — including the no-reference internal-consistency path.
- buildScientificArtifactPassport rejects caller-supplied method ids absent from METHOD_REGISTRY before any digest is computed.
- Adds PASSPORT_CLAIM_SCOPE pinning the tamper-evident, not-authenticated disclaimer.

Library and tests only. build/verify have no production callers on main; legacyContentHash is unchanged. tsc clean; both passport suites pass (27 tests).