### PR TITLE
feat(e5): recompute manifest class-histogram + ground invariants

### DIFF
--- a/scripts/e5/verify-input-manifest.mjs
+++ b/scripts/e5/verify-input-manifest.mjs
@@ -10,10 +10,14 @@
  * `${basename}:${sha256}` lines, tiles sorted by basename); the homogeneity
  * claim matches the members (homogeneousFrame ⇔ one horizontalEpsg + one
  * verticalEpsg + one geoidModel); the geoid summary equals the set of member
- * geoids; and the creation-vs-acquisition separation holds — every tile has a
- * fileCreationYear, no tile still carries a captureYear, acquisitionYear is
- * present (possibly null) with an acquisitionDateSource, and the summary never
- * relabels a creation year as an acquisition year.
+ * geoids; each classHistogram is a plain object of non-negative integers whose
+ * values sum to pointCount, with groundPointCount === classHistogram['2'] and
+ * (when present) groundPointFraction the ground/point ratio to six decimals;
+ * the summary's tilesWithoutGround and allTilesHaveGround are recomputed from
+ * the members, not trusted; and the creation-vs-acquisition separation holds —
+ * every tile has a fileCreationYear, no tile still carries a captureYear,
+ * acquisitionYear is present (possibly null) with an acquisitionDateSource, and
+ * the summary never relabels a creation year as an acquisition year.
  *
  * A missing manifest file is a loud failure, never a silent pass.
  */
@@ -96,6 +100,35 @@ export function verifyManifest(manifest, { expectedCount } = {}) {
     if (t.verticalDatum == null || t.verticalDatum === '') fail(`${b}: verticalDatum is null`);
     if (t.geoidModel == null || t.geoidModel === '') fail(`${b}: geoidModel is null`);
 
+    // Class histogram proves the per-tile point tallies.
+    const ch = t.classHistogram;
+    if (ch == null || typeof ch !== 'object' || Array.isArray(ch)) {
+      fail(`${b}: classHistogram must be a plain object`);
+    } else {
+      const values = Object.values(ch);
+      if (!values.every((v) => Number.isInteger(v) && v >= 0)) {
+        fail(`${b}: classHistogram values must be non-negative integers`);
+      } else if (Number.isInteger(t.pointCount)) {
+        const histSum = values.reduce((a, v) => a + v, 0);
+        if (histSum !== t.pointCount) {
+          fail(`${b}: classHistogram sum ${histSum} ≠ pointCount ${t.pointCount}`);
+        }
+      }
+      const groundFromHist = ch['2'] ?? 0;
+      if (t.groundPointCount !== groundFromHist) {
+        fail(`${b}: groundPointCount ${t.groundPointCount} ≠ classHistogram['2'] ${groundFromHist}`);
+      }
+      if (t.groundPointFraction != null) {
+        const expected =
+          Number.isInteger(t.pointCount) && t.pointCount > 0
+            ? Number((groundFromHist / t.pointCount).toFixed(6))
+            : 0;
+        if (Math.abs(t.groundPointFraction - expected) > 5e-7) {
+          fail(`${b}: groundPointFraction ${t.groundPointFraction} ≠ recomputed ${expected}`);
+        }
+      }
+    }
+
     // Creation-vs-acquisition separation.
     if (!Number.isInteger(t.fileCreationYear)) fail(`${b}: fileCreationYear must be an integer`);
     if ('captureYear' in t) fail(`${b}: forbidden captureYear leftover (use fileCreationYear/acquisitionYear)`);
@@ -151,6 +184,37 @@ export function verifyManifest(manifest, { expectedCount } = {}) {
       const overlap = acq.filter((y) => summary.fileCreationYears.includes(y));
       if (overlap.length > 0) {
         fail(`summary.acquisitionYears relabels creation year(s): ${overlap.join(', ')}`);
+      }
+    }
+
+    // Ground coverage: recompute from the members; don't trust the labels.
+    const groundless = tiles
+      .filter((t) => (t.groundPointCount ?? 0) === 0)
+      .map((t) => t.basename)
+      .sort((a, b) => String(a).localeCompare(String(b)));
+    if ('tilesWithoutGround' in summary) {
+      if (!Array.isArray(summary.tilesWithoutGround)) {
+        fail('summary.tilesWithoutGround must be an array');
+      } else {
+        const claimed = new Set(summary.tilesWithoutGround);
+        const actual = new Set(groundless);
+        const missing = groundless.filter((n) => !claimed.has(n));
+        const extra = [...claimed].filter((n) => !actual.has(n));
+        if (missing.length > 0 || extra.length > 0) {
+          fail(
+            `summary.tilesWithoutGround set mismatch: ` +
+              `missing [${missing.join(', ')}], unexpected [${extra.join(', ')}]`,
+          );
+        }
+      }
+    }
+    if ('allTilesHaveGround' in summary) {
+      const expected = groundless.length === 0;
+      if (summary.allTilesHaveGround !== expected) {
+        fail(
+          `summary.allTilesHaveGround=${summary.allTilesHaveGround} but ` +
+            `${groundless.length} tile(s) lack ground`,
+        );
       }
     }
   }

--- a/tests/e5ManifestVerify.test.ts
+++ b/tests/e5ManifestVerify.test.ts
@@ -28,7 +28,7 @@ function goodManifest() {
       verticalEpsg: 5703,
       verticalDatum: 'North American Vertical Datum 1988',
       geoidModel: 'GEOID12B',
-      classHistogram: { 2: 5 },
+      classHistogram: { 1: 5, 2: 5 },
       groundPointCount: 5,
       fileCreationYear: 2021,
       acquisitionYear: null,
@@ -43,7 +43,7 @@ function goodManifest() {
       verticalEpsg: 5703,
       verticalDatum: 'North American Vertical Datum 1988',
       geoidModel: 'GEOID12B',
-      classHistogram: { 2: 8 },
+      classHistogram: { 1: 12, 2: 8 },
       groundPointCount: 8,
       fileCreationYear: 2021,
       acquisitionYear: null,
@@ -60,7 +60,8 @@ function goodManifest() {
       verticalDatum: ['North American Vertical Datum 1988'],
       geoidModel: ['GEOID12B'],
       homogeneousFrame: true,
-      tilesWithoutGround: [],
+      tilesWithoutGround: [] as string[],
+      allTilesHaveGround: true,
       fileCreationYears: [2021],
       acquisitionYears: [null] as (number | null)[],
     },
@@ -144,6 +145,95 @@ describe('E5 manifest verifier', () => {
     const r = verifyManifest(m, { expectedCount: 2 });
     expect(r.ok).toBe(false);
     expect(r.errors.join('\n')).toMatch(/relabels creation year/);
+  });
+
+  it('catches a classHistogram whose values do not sum to pointCount', () => {
+    const m = goodManifest();
+    m.tiles[0].classHistogram = { 1: 4, 2: 5 }; // sum 9 ≠ pointCount 10
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/classHistogram sum 9 ≠ pointCount 10/);
+  });
+
+  it('catches a classHistogram that is not a plain object', () => {
+    const m = goodManifest();
+    (m.tiles[0] as Record<string, unknown>).classHistogram = [5, 5];
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/classHistogram must be a plain object/);
+  });
+
+  it('catches a classHistogram with a negative count', () => {
+    const m = goodManifest();
+    m.tiles[0].classHistogram = { 1: 15, 2: -5 };
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/classHistogram values must be non-negative integers/);
+  });
+
+  it('catches groundPointCount disagreeing with classHistogram[2]', () => {
+    const m = goodManifest();
+    m.tiles[0].groundPointCount = 4; // histogram class 2 is 5
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/groundPointCount 4 ≠ classHistogram\['2'\] 5/);
+  });
+
+  it('catches a groundPointFraction that does not match the ratio', () => {
+    const m = goodManifest();
+    (m.tiles[0] as Record<string, unknown>).groundPointFraction = 0.4; // true ratio 5/10 = 0.5
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/groundPointFraction 0.4 ≠ recomputed 0.5/);
+  });
+
+  it('accepts a matching groundPointFraction', () => {
+    const m = goodManifest();
+    (m.tiles[0] as Record<string, unknown>).groundPointFraction = 0.5; // 5/10
+    (m.tiles[1] as Record<string, unknown>).groundPointFraction = 0.4; // 8/20
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.errors).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it('guards a zero-point tile without dividing by zero', () => {
+    const m = goodManifest();
+    m.tiles[0].pointCount = 0;
+    (m.tiles[0] as Record<string, unknown>).classHistogram = {};
+    m.tiles[0].groundPointCount = 0;
+    (m.tiles[0] as Record<string, unknown>).groundPointFraction = 0;
+    m.summary.tilesWithoutGround = [m.tiles[0].basename];
+    m.summary.allTilesHaveGround = false;
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.errors).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it('catches a tilesWithoutGround set that names a tile that has ground', () => {
+    const m = goodManifest();
+    m.summary.tilesWithoutGround = ['USGS_LPC_OR_Rogue_2019_B19_10TDM3746.laz'];
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/tilesWithoutGround set mismatch/);
+  });
+
+  it('catches a tilesWithoutGround set that omits a groundless tile', () => {
+    const m = goodManifest();
+    m.tiles[1].groundPointCount = 0;
+    (m.tiles[1] as Record<string, unknown>).classHistogram = { 1: 20 };
+    m.summary.tilesWithoutGround = []; // omits the now-groundless tile
+    m.summary.allTilesHaveGround = false;
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/tilesWithoutGround set mismatch/);
+  });
+
+  it('catches allTilesHaveGround that disagrees with the members', () => {
+    const m = goodManifest();
+    m.summary.allTilesHaveGround = false; // every tile actually has ground
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/allTilesHaveGround=false but 0 tile/);
   });
 
   it.each([


### PR DESCRIPTION
Hardens `scripts/e5/verify-input-manifest.mjs` (the #838 gate) so each input manifest proves its own point tallies. No manifest bytes change — verifier and tests only.

Per tile: `classHistogram` must be a plain object of non-negative integers whose values sum to `pointCount`; `groundPointCount === classHistogram['2'] ?? 0`; and when `groundPointFraction` is present it must equal the recomputed ground/point ratio to six decimals (zero-point tiles guarded, no divide-by-zero).

Summary: `tilesWithoutGround` is compared as a set against the recomputed groundless tiles (diff named on mismatch) and `allTilesHaveGround` against their count, instead of being trusted because the field exists.

Tests gain reject-and-say-why cases per new invariant; the two committed manifests (ROGUE25, HOUSTON17) still pass unchanged.

Verify: `node scripts/e5/verify-input-manifest.mjs` exit 0; `npm run validation:e5:manifests:verify` 0; `vitest run tests/e5ManifestVerify.test.ts` 22 passed; `tsc --noEmit` 0.