### PR TITLE
fix(validation): gate checkpoint combined RMSE to full reference coverage

### DIFF
--- a/src/validation/checkpointAccuracy.ts
+++ b/src/validation/checkpointAccuracy.ts
@@ -256,22 +256,39 @@ export interface AccuracyStats {
    */
   readonly combinedRmse: number | null;
   readonly uncertaintyCombinationId: string | null;
-  /** Quadratic mean of the stated reference sigmas, or null when none were stated. */
+  /**
+   * Quadratic mean of the stated reference sigmas, or null unless every
+   * checkpoint in the group carried a usable sigma. Reported only at full
+   * coverage: a quadratic mean over a subset combined against an observed RMSE
+   * over the whole group is a population mismatch, so partial and unestablished
+   * coverage both leave it null.
+   */
   readonly referenceRmse: number | null;
+  /** Number of checkpoints in the group that carried a usable 1-sigma reference. */
+  readonly referenceUncertaintyCount: number;
+  /**
+   * Fraction of the group that carried a usable 1-sigma reference
+   * (`referenceUncertaintyCount / n`), or null when the group is empty.
+   */
+  readonly referenceUncertaintyCoverage: number | null;
   /**
    * Whether the reference uncertainty could be established for this group.
    *
-   * - `none-stated`: the survey stated no reference uncertainty. `referenceRmse`
+   * - `none-stated`: no checkpoint stated a reference uncertainty. `referenceRmse`
    *   is null.
-   * - `established`: every stated reference uncertainty had a meaning that
-   *   justifies a 1-sigma value, so `referenceRmse` is the quadratic mean of
-   *   those sigmas and a combined RMSE can be produced.
+   * - `established`: every checkpoint carried a usable 1-sigma reference (full
+   *   coverage), so `referenceRmse` is the quadratic mean of those sigmas and a
+   *   combined RMSE can be produced.
+   * - `partial`: some but not all checkpoints carried a usable sigma. A
+   *   referenceRmse over that subset cannot be combined against an observed RMSE
+   *   over all n without mismatching populations, so `referenceRmse` and
+   *   `combinedRmse` are null and the fit RMSE stands alone.
    * - `not-established`: at least one checkpoint stated a reference uncertainty
    *   whose meaning does not justify a sigma (`unknown`/`manufacturer-bound`).
    *   `referenceRmse` and `combinedRmse` are null: the fit RMSE stands alone and
    *   is not combined against a reference uncertainty that was never established.
    */
-  readonly referenceUncertaintyState: 'none-stated' | 'established' | 'not-established';
+  readonly referenceUncertaintyState: 'none-stated' | 'established' | 'partial' | 'not-established';
 }
 
 export interface StratumAccuracy {
@@ -344,6 +361,8 @@ const EMPTY_STATS: AccuracyStats = {
   combinedRmse: null,
   uncertaintyCombinationId: null,
   referenceRmse: null,
+  referenceUncertaintyCount: 0,
+  referenceUncertaintyCoverage: null,
   referenceUncertaintyState: 'none-stated',
 };
 
@@ -384,19 +403,36 @@ function statsOf(
     standardError = Math.sqrt(ss / (n - 1)) / Math.sqrt(n);
   }
 
-  // A reference uncertainty of unknown meaning cannot become a sigma, so its
-  // group's referenceRmse is null and its state is not-established: the fit RMSE
-  // is still reported, but nothing is combined against a reference uncertainty
-  // that was never established.
-  const referenceRmse =
-    referenceNotEstablished || sigmas.length === 0
-      ? null
-      : Math.sqrt(sigmas.reduce((acc, s) => acc + s * s, 0) / sigmas.length);
+  // Coverage of the reference uncertainty over the group. sigmaCount counts the
+  // checkpoints that carried a usable 1-sigma reference; the residual population
+  // is n, so partial coverage is the case where some but not all stated one.
+  const sigmaCount = sigmas.length;
+  const referenceUncertaintyCoverage = n > 0 ? sigmaCount / n : null;
+
+  // The state gates in priority order. An unusable meaning
+  // (unknown/manufacturer-bound) fails the whole group closed regardless of how
+  // many usable sigmas the rest carried. Otherwise: no sigma is none-stated,
+  // full coverage is established, and anything between is partial.
+  //
+  // Partial coverage is refused a combined figure on purpose. referenceRmse over
+  // the covered subset combined against the observed RMSE over all n mismatches
+  // populations (RMSE_reference over k vs RMSE_observed over n), so referenceRmse
+  // is produced only at full coverage and combinedRmse follows it to null.
   const referenceUncertaintyState: AccuracyStats['referenceUncertaintyState'] =
-    referenceNotEstablished ? 'not-established' : sigmas.length === 0 ? 'none-stated' : 'established';
-  // No combination, no reference sigma, and an unestablished reference all leave
-  // the combined figure null. Relabelling the observed RMSE as "combined" would
-  // assert a propagation that never happened.
+    referenceNotEstablished
+      ? 'not-established'
+      : sigmaCount === 0
+        ? 'none-stated'
+        : sigmaCount < n
+          ? 'partial'
+          : 'established';
+  const referenceRmse =
+    referenceUncertaintyState === 'established'
+      ? Math.sqrt(sigmas.reduce((acc, s) => acc + s * s, 0) / sigmas.length)
+      : null;
+  // No combination, no reference sigma, partial coverage, and an unestablished
+  // reference all leave the combined figure null. Relabelling the observed RMSE
+  // as "combined" would assert a propagation that never happened.
   const combinedRmse =
     combination && referenceRmse !== null ? combination.combine(rmse, referenceRmse) : null;
 
@@ -415,6 +451,8 @@ function statsOf(
     combinedRmse,
     uncertaintyCombinationId: combinedRmse === null ? null : combination!.id,
     referenceRmse,
+    referenceUncertaintyCount: sigmaCount,
+    referenceUncertaintyCoverage,
     referenceUncertaintyState,
   };
 }

--- a/tests/checkpointAccuracy.test.ts
+++ b/tests/checkpointAccuracy.test.ts
@@ -389,3 +389,57 @@ describe('checkpointAccuracy reference uncertainty', () => {
     expect(r.pooled.uncertaintyCombinationId).toBeNull();
   });
 });
+
+describe('checkpointAccuracy partial reference-uncertainty coverage', () => {
+  const quadratureSum: UncertaintyCombination = {
+    id: 'test-quadrature-sum-v1',
+    combine: (observed, reference) => Math.sqrt(observed * observed + reference * reference),
+  };
+
+  it('refuses a combined RMSE when only some checkpoints state a sigma', () => {
+    // Three of five carry a sigma; combining a referenceRmse over those three
+    // against the observed RMSE over all five would mismatch populations.
+    const mixed = [
+      cp('a', 0.1, { referenceSigma: 0.03 }),
+      cp('b', -0.05),
+      cp('c', 0.2, { referenceSigma: 0.03 }),
+      cp('d', 0),
+      cp('e', -0.25, { referenceSigma: 0.03 }),
+    ];
+    const r = checkpointAccuracy(mixed, { minSample: 5, uncertaintyCombination: quadratureSum });
+    expect(r.status).toBe('reported');
+    if (r.status !== 'reported') return;
+    expect(r.pooled.referenceUncertaintyState).toBe('partial');
+    expect(r.pooled.referenceUncertaintyCount).toBe(3);
+    expect(r.pooled.referenceUncertaintyCoverage).toBeCloseTo(0.6, 12);
+    expect(r.pooled.referenceRmse).toBeNull();
+    expect(r.pooled.combinedRmse).toBeNull();
+    expect(r.pooled.uncertaintyCombinationId).toBeNull();
+    // The plain fit RMSE over all five is untouched.
+    expect(r.pooled.rmse).toBeCloseTo(Math.sqrt(0.115 / 5), 12);
+  });
+
+  it('still produces a combined RMSE at full coverage', () => {
+    const full = FIVE.map((c) => ({ ...c, referenceSigma: 0.03 }));
+    const r = checkpointAccuracy(full, { minSample: 5, uncertaintyCombination: quadratureSum });
+    expect(r.status).toBe('reported');
+    if (r.status !== 'reported') return;
+    const observed = Math.sqrt(0.115 / 5);
+    expect(r.pooled.referenceUncertaintyState).toBe('established');
+    expect(r.pooled.referenceUncertaintyCount).toBe(5);
+    expect(r.pooled.referenceUncertaintyCoverage).toBeCloseTo(1, 12);
+    expect(r.pooled.referenceRmse).toBeCloseTo(0.03, 12);
+    expect(r.pooled.combinedRmse).toBeCloseTo(Math.sqrt(observed * observed + 0.03 * 0.03), 12);
+  });
+
+  it('stays none-stated when no checkpoint states a sigma', () => {
+    const r = checkpointAccuracy(FIVE, { minSample: 5, uncertaintyCombination: quadratureSum });
+    expect(r.status).toBe('reported');
+    if (r.status !== 'reported') return;
+    expect(r.pooled.referenceUncertaintyState).toBe('none-stated');
+    expect(r.pooled.referenceUncertaintyCount).toBe(0);
+    expect(r.pooled.referenceUncertaintyCoverage).toBeCloseTo(0, 12);
+    expect(r.pooled.referenceRmse).toBeNull();
+    expect(r.pooled.combinedRmse).toBeNull();
+  });
+});


### PR DESCRIPTION
Checkpoint accuracy could combine a reference RMSE computed over the subset of checkpoints that stated a usable sigma with the observed RMSE computed over all n, while labelling coverage `established` — a population mismatch (RMSE_reference over k vs RMSE_observed over n).

`statsOf` gains a partial-coverage axis. `referenceUncertaintyState` adds `'partial'`; `AccuracyStats` adds `referenceUncertaintyCount` and `referenceUncertaintyCoverage`. `referenceRmse` (and therefore `combinedRmse`) is produced only at full coverage; partial coverage reports the plain observed RMSE alone. `none-stated` and `not-established` are unchanged, and `not-established` keeps priority.

Validation statistic only — no DTM/terrain/volume/change numeric output changes. tsc clean; checkpointAccuracy, checkpointGdbAdapter, independentCheckpointHarness suites pass.