### PR TITLE
feat(science): dtmProductDigest — SHA-256 of the delivered DTM surface

### DIFF
--- a/docs/validation/unreachable-modules.json
+++ b/docs/validation/unreachable-modules.json
@@ -284,6 +284,13 @@
       "why": "The canonical descriptor of the delivered DTM method plus a SHA-256 method digest, for the external-validation and export-provenance paths: a stamped digest can be compared against a fresh resolve to prove the delivered method has not drifted. The scoped-evidence resolver and the E5 reduce path will read it, but neither construction is wired into the application graph yet, so only its test imports it.",
       "graduation": "Export provenance stamps dtmMethodDigest into the DTM evidence context, or the E5 reduce path resolves the descriptor to verify the candidate method, at which point the application graph reaches it.",
       "review": "2027-02-28"
+    },
+    {
+      "path": "src/science/dtmProductDigest.ts",
+      "status": "validation-only",
+      "why": "A SHA-256 over the delivered DTM surface itself — grid geometry, CRS codes, the explicit little-endian Z bytes, the per-cell coverage bytes and an optional method digest — so two runs can be proven to have produced the SAME surface. It complements liveDtmDescriptor.dtmMethodDigest, which proves only that the same algorithm was configured, not that the heights match. It reuses the repository's byte-wise sha256Hex and canonicalize and changes no numerical result. No export or validation harness constructs a product digest yet, so only its own test imports it; kept out of the eager graph because index.html's bundle has near-zero headroom.",
+      "graduation": "Export provenance or a reproduction harness digests an emitted DTM surface and records the value beside the method digest, at which point the application graph reaches it through src/lazyChunks.ts.",
+      "review": "2027-02-28"
     }
   ]
 }

--- a/src/science/dtmProductDigest.ts
+++ b/src/science/dtmProductDigest.ts
@@ -1,0 +1,164 @@
+/**
+ * dtmProductDigest.ts
+ *
+ * A SHA-256 over the actual DTM SURFACE the viewer produced — the product, not
+ * the method. It answers a question `dtmMethodDigest` cannot: did two runs emit
+ * the SAME grid of heights? The method digest (`liveDtmDescriptor.ts`) proves
+ * only that the same algorithm was configured; two runs of one algorithm over
+ * different points, or over the same points after a numerical change upstream,
+ * share a method digest yet deliver different surfaces. This digest moves the
+ * moment any delivered cell, any coverage state, the grid geometry, the CRS
+ * codes, or the recorded method digest changes.
+ *
+ * WHAT IS HASHED, and why exactly this. The digest is taken over one framed
+ * byte stream:
+ *
+ *   [4-byte LE uint32: header byte length] [header UTF-8] [Z bytes] [coverage bytes]
+ *
+ *   header  — a canonical, key-sorted, explicitly-typed JSON object carrying
+ *             schemaVersion, cols, rows, cellSizeM, originH1, originH2,
+ *             horizontalEpsg, verticalEpsg, dtype ('Float64' | 'Float32'),
+ *             endianness ('LE'), the two payload byte lengths, and the optional
+ *             methodDigest. The header's own length prefix and its recorded
+ *             payload lengths frame every section, so no two distinct inputs
+ *             concatenate to the same stream.
+ *   Z bytes — the elevation array written element-by-element as EXPLICIT
+ *             little-endian floats through a DataView (`setFloat64` /
+ *             `setFloat32` with littleEndian = true), NOT the typed array's
+ *             own `.buffer`. A raw buffer view is host-endian, so the same
+ *             surface would digest differently on a big-endian machine; writing
+ *             LE explicitly makes the digest platform-independent. `dtype`
+ *             records the element width so a Float32 surface and a Float64
+ *             surface of equal values never collide, and the endianness field
+ *             records the convention the bytes were written in.
+ *   coverage — the per-cell provenance array (Uint8, one byte per cell); byte
+ *             order is not a concern for a single-byte element.
+ *
+ * The digest is deliberately blind to per-run confidence, counts, warnings and
+ * prose: two runs that agree on geometry, heights, coverage, CRS and method
+ * ARE the same product regardless of those. CRS codes are IN because a grid of
+ * identical numbers under a different horizontal/vertical EPSG is a different
+ * surface on the ground.
+ *
+ * Pure data: no DOM, no three.js, no I/O. Deterministic. Reuses the repo's
+ * synchronous byte-wise `sha256Hex` (no new crypto). Consumed by validation and
+ * (later) export-provenance paths only; never imported from an eager module, so
+ * it stays out of the index chunk.
+ */
+
+import { canonicalize } from '../render/measure/auditLog';
+import { sha256Hex } from '../terrain/export/sha256';
+
+/** Schema of the digested header. Bump only on a breaking layout change. */
+export const DTM_PRODUCT_DIGEST_SCHEMA = 1 as const;
+
+/**
+ * The minimal projection of a DTM surface the digest reads. `DtmGrid`
+ * (`terrain/ground/cellConfidence.ts`) — the shipped product — is structurally
+ * assignable to this, as is the validation surface from `dtmSurfaceModel.ts`.
+ * `z` accepts either float width so the digest survives the Float32 → Float64
+ * flip; the element type is recorded in the digest either way.
+ */
+export interface DtmProductInput {
+  /** Elevation per cell, row-major. */
+  readonly z: Float32Array | Float64Array;
+  /** Per-cell provenance/coverage state, one byte per cell, row-major. */
+  readonly coverage: Uint8Array;
+  readonly cols: number;
+  readonly rows: number;
+  readonly cellSizeM: number;
+  readonly originH1: number;
+  readonly originH2: number;
+  /** Numeric horizontal EPSG, or null/undefined when the resolver had none. */
+  readonly horizontalEpsg?: number | null;
+  /** Numeric vertical EPSG, or null/undefined when none was declared. */
+  readonly verticalEpsg?: number | null;
+}
+
+/** The float width of the Z array, recorded in the digest header. */
+type FloatDtype = 'Float64' | 'Float32';
+
+function floatDtype(z: Float32Array | Float64Array): FloatDtype {
+  if (z instanceof Float64Array) return 'Float64';
+  if (z instanceof Float32Array) return 'Float32';
+  throw new TypeError('dtmProductDigest: z must be a Float32Array or Float64Array');
+}
+
+/**
+ * Serialize `z` as explicit little-endian float bytes through a DataView, so
+ * the byte stream is identical on any host regardless of native endianness.
+ */
+function zBytesLE(z: Float32Array | Float64Array, dtype: FloatDtype): Uint8Array {
+  const bytesPerElem = dtype === 'Float64' ? 8 : 4;
+  const out = new Uint8Array(z.length * bytesPerElem);
+  const dv = new DataView(out.buffer);
+  if (dtype === 'Float64') {
+    for (let i = 0; i < z.length; i++) dv.setFloat64(i * 8, z[i], true);
+  } else {
+    for (let i = 0; i < z.length; i++) dv.setFloat32(i * 4, z[i], true);
+  }
+  return out;
+}
+
+/**
+ * SHA-256 (lowercase hex) over a DTM surface's geometry, CRS, delivered heights
+ * and coverage, plus an optional method digest. Identical surfaces yield an
+ * identical digest; any change to a Z cell, a coverage state, the grid
+ * geometry, the CRS codes, the float width, or `methodDigest` moves it.
+ *
+ * `methodDigest`, when supplied, binds a surface to the method that made it:
+ * two surfaces equal in every cell but produced under different method digests
+ * digest differently, so the pair (surface, method) is what is proven equal.
+ */
+export function dtmProductDigest(dtm: DtmProductInput, methodDigest?: string): string {
+  const dtype = floatDtype(dtm.z);
+  const cellCount = dtm.cols * dtm.rows;
+  if (dtm.z.length !== cellCount) {
+    throw new RangeError(
+      `dtmProductDigest: z.length ${dtm.z.length} does not match cols*rows ${cellCount}`,
+    );
+  }
+  if (dtm.coverage.length !== cellCount) {
+    throw new RangeError(
+      `dtmProductDigest: coverage.length ${dtm.coverage.length} does not match cols*rows ${cellCount}`,
+    );
+  }
+
+  const zBytes = zBytesLE(dtm.z, dtype);
+  const coverageBytes = dtm.coverage;
+
+  // Explicitly-typed, key-sorted header. `?? null` normalises absent CRS codes
+  // and method digest to a single form so an undefined and an explicit null
+  // produce one digest.
+  const headerBytes = new TextEncoder().encode(
+    canonicalize({
+      schemaVersion: DTM_PRODUCT_DIGEST_SCHEMA,
+      cols: dtm.cols,
+      rows: dtm.rows,
+      cellSizeM: dtm.cellSizeM,
+      originH1: dtm.originH1,
+      originH2: dtm.originH2,
+      horizontalEpsg: dtm.horizontalEpsg ?? null,
+      verticalEpsg: dtm.verticalEpsg ?? null,
+      dtype,
+      endianness: 'LE',
+      zByteLength: zBytes.length,
+      coverageByteLength: coverageBytes.length,
+      methodDigest: methodDigest ?? null,
+    }),
+  );
+
+  // Frame: [header length as 4-byte LE uint32][header][Z bytes][coverage bytes].
+  // The length prefix plus the two byte lengths recorded inside the header make
+  // every section boundary explicit, so distinct inputs cannot alias.
+  const stream = new Uint8Array(4 + headerBytes.length + zBytes.length + coverageBytes.length);
+  new DataView(stream.buffer).setUint32(0, headerBytes.length, true);
+  let at = 4;
+  stream.set(headerBytes, at);
+  at += headerBytes.length;
+  stream.set(zBytes, at);
+  at += zBytes.length;
+  stream.set(coverageBytes, at);
+
+  return sha256Hex(stream);
+}

--- a/tests/dtmProductDigest.test.ts
+++ b/tests/dtmProductDigest.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  dtmProductDigest,
+  DTM_PRODUCT_DIGEST_SCHEMA,
+  type DtmProductInput,
+} from '../src/science/dtmProductDigest';
+
+/** A small, fully specified 2x2 Float64 surface. Cloned per test so a mutation
+ *  in one case never leaks into another. */
+function baseDtm(): DtmProductInput {
+  return {
+    z: Float64Array.from([10.0, 10.5, 11.0, 11.5]),
+    coverage: Uint8Array.from([2, 2, 1, 0]),
+    cols: 2,
+    rows: 2,
+    cellSizeM: 0.5,
+    originH1: 1000,
+    originH2: 2000,
+    horizontalEpsg: 32610,
+    verticalEpsg: 5703,
+  };
+}
+
+describe('dtmProductDigest', () => {
+  it('is a lowercase 64-char hex string', () => {
+    expect(dtmProductDigest(baseDtm())).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('gives two structurally identical surfaces the same digest', () => {
+    // Different array instances, same values — same product, same digest.
+    expect(dtmProductDigest(baseDtm())).toBe(dtmProductDigest(baseDtm()));
+  });
+
+  it('treats an undefined CRS code and an explicit null as one surface', () => {
+    const a = { ...baseDtm(), horizontalEpsg: undefined, verticalEpsg: undefined };
+    const b = { ...baseDtm(), horizontalEpsg: null, verticalEpsg: null };
+    expect(dtmProductDigest(a)).toBe(dtmProductDigest(b));
+  });
+
+  it('moves when a single Z cell changes', () => {
+    const changed = baseDtm();
+    changed.z[2] = 11.0001;
+    expect(dtmProductDigest(changed)).not.toBe(dtmProductDigest(baseDtm()));
+  });
+
+  it('moves when a coverage state changes', () => {
+    const changed = baseDtm();
+    changed.coverage[3] = 1; // was 0 (gap) → now interpolated
+    expect(dtmProductDigest(changed)).not.toBe(dtmProductDigest(baseDtm()));
+  });
+
+  it('moves on a grid-geometry change (origin, cell size, and shape)', () => {
+    const ref = dtmProductDigest(baseDtm());
+    expect(dtmProductDigest({ ...baseDtm(), originH1: 1000.5 })).not.toBe(ref);
+    expect(dtmProductDigest({ ...baseDtm(), cellSizeM: 1.0 })).not.toBe(ref);
+    // Same 4 cells, transposed grid shape (2x2 → 4x1) — a different surface.
+    expect(dtmProductDigest({ ...baseDtm(), cols: 4, rows: 1 })).not.toBe(ref);
+  });
+
+  it('moves when the CRS codes change', () => {
+    const ref = dtmProductDigest(baseDtm());
+    expect(dtmProductDigest({ ...baseDtm(), horizontalEpsg: 32611 })).not.toBe(ref);
+    expect(dtmProductDigest({ ...baseDtm(), verticalEpsg: 5705 })).not.toBe(ref);
+  });
+
+  it('binds the surface to methodDigest', () => {
+    const noMethod = dtmProductDigest(baseDtm());
+    const withA = dtmProductDigest(baseDtm(), 'aaaa');
+    const withB = dtmProductDigest(baseDtm(), 'bbbb');
+    expect(withA).not.toBe(noMethod);
+    expect(withA).not.toBe(withB);
+    // Same surface + same method digest ⇒ stable.
+    expect(dtmProductDigest(baseDtm(), 'aaaa')).toBe(withA);
+  });
+
+  it('captures the float width: equal values as Float32 vs Float64 differ', () => {
+    // Values chosen so the two widths agree exactly at every cell (0.5-steps
+    // are representable in both), isolating the dtype tag + element width as the
+    // sole difference rather than a float-rounding difference.
+    const asF64 = baseDtm();
+    const asF32: DtmProductInput = { ...baseDtm(), z: Float32Array.from([10.0, 10.5, 11.0, 11.5]) };
+    expect(Array.from(asF32.z)).toEqual(Array.from(asF64.z)); // values identical
+    expect(dtmProductDigest(asF32)).not.toBe(dtmProductDigest(asF64)); // digests are not
+  });
+
+  it('rejects a z array whose length disagrees with cols*rows', () => {
+    expect(() => dtmProductDigest({ ...baseDtm(), z: Float64Array.from([1, 2, 3]) })).toThrow(
+      /cols\*rows/,
+    );
+  });
+
+  it('rejects a coverage array whose length disagrees with cols*rows', () => {
+    expect(() =>
+      dtmProductDigest({ ...baseDtm(), coverage: Uint8Array.from([2, 2, 1]) }),
+    ).toThrow(/cols\*rows/);
+  });
+
+  it('rejects a non-float z array', () => {
+    // A caller passing an integer array would silently lose the vertical
+    // precision the digest is meant to prove; refuse it.
+    const bad = { ...baseDtm(), z: new Int32Array(4) } as unknown as DtmProductInput;
+    expect(() => dtmProductDigest(bad)).toThrow(TypeError);
+  });
+
+  it('exposes a stable schema version', () => {
+    expect(DTM_PRODUCT_DIGEST_SCHEMA).toBe(1);
+  });
+});


### PR DESCRIPTION
Adds `src/science/dtmProductDigest.ts`: a pure `dtmProductDigest(dtm, methodDigest?)` returning a SHA-256 (hex) over the delivered DTM surface — schema version, cols/rows, cell size, origin, horizontal/vertical EPSG, float dtype, the explicit little-endian Z bytes, the per-cell coverage bytes, and an optional method digest.

It answers what `dtmMethodDigest` cannot: whether two runs produced the SAME surface. The method digest proves only that the same algorithm was configured; two runs of one algorithm can still deliver different heights.

Reuses the repository's byte-wise `sha256Hex` and `canonicalize`. No new crypto, no numerical change, no new eager import — consumed by test only and registered validation-only in `unreachable-modules.json`, so the index bundle is unchanged (776/780 KiB).

Tests (`tests/dtmProductDigest.test.ts`): identical surfaces match; a single Z cell, a coverage state, grid geometry, CRS codes, and a different method digest each move the digest; equal values as Float32 vs Float64 digest differently.

Freeze-safe: additive, library + test only.