### PR TITLE
fix(e5): reproducible Rogue split from an immutable exposure ledger

### DIFF
--- a/scripts/e5/build-rogue-split.mjs
+++ b/scripts/e5/build-rogue-split.mjs
@@ -4,51 +4,56 @@
  * 25 Rogue tiles for retrospective E5 hardening.
  *
  * Rogue is a RETROSPECTIVE development set; it never becomes E5. To keep a
- * holdout honest, any tile the repository has already used (register, tests,
- * committed metrics) is EXPOSED and forced into development — it cannot serve as
- * an untouched holdout. The remaining unexposed tiles are split by a fixed rule:
- * order by sha256("ROGUE-E5-HARDENING-v1" + fileSha256), fill development to the
- * target, the rest are holdout. The ordering depends only on file content and a
- * constant salt, so the split is reproducible and independent of tile id or
- * order in the manifest.
+ * holdout honest, any tile the repository had already used before the split was
+ * frozen (register, tests, committed metrics) is EXPOSED and forced into
+ * development — it cannot serve as an untouched holdout. The exposed set is
+ * pinned in an immutable ledger (validation/e5/splits/ROGUE25.exposure.json) and
+ * read from there, not rediscovered by a live git scan: a later doc that mentions
+ * a tile must not silently move it out of the holdout, and the split must
+ * reproduce byte-for-byte on any machine. The remaining unexposed tiles are split
+ * by a fixed rule: order by sha256("ROGUE-E5-HARDENING-v1" + fileSha256), fill
+ * development to the target, the rest are holdout. Ordering is by UTF-16 code unit
+ * (localeCompare's ICU collation differs across machines), so the split depends
+ * only on file content, a constant salt and the pinned ledger.
  *
- * Usage: node scripts/e5/build-rogue-split.mjs <ROGUE25.input.json> <out.split.json>
+ * Usage: node scripts/e5/build-rogue-split.mjs <ROGUE25.input.json> <out.split.json> [exposure-ledger.json]
  */
-import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { resolve, dirname, join } from 'node:path';
-import { execFileSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
 
-const [, , inPath, outPath] = process.argv;
+const [, , inPath, outPath, exposurePathArg] = process.argv;
 if (!inPath || !outPath) {
-  console.error('usage: build-rogue-split.mjs <input-manifest> <out.split.json>');
+  console.error('usage: build-rogue-split.mjs <input-manifest> <out.split.json> [exposure-ledger.json]');
   process.exit(2);
 }
 const SALT = 'ROGUE-E5-HARDENING-v1';
 const TARGET_DEV = 17;
 const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..', '..');
+const EXPOSURE_PATH = exposurePathArg
+  ? resolve(exposurePathArg)
+  : resolve(ROOT, 'validation/e5/splits/ROGUE25.exposure.json');
+
+// Order by raw string code unit, never localeCompare: ICU collation varies by
+// machine/locale and would make the hashed ordering non-reproducible.
+const byCodeUnit = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
 
 const manifest = JSON.parse(readFileSync(resolve(inPath), 'utf8'));
 const tileId = (basename) => (basename.match(/10T[A-Z]{2}\d+/) ?? [basename])[0];
 
-/** Every tracked file (git ls-files), so exposure detection is over the repo. */
-const tracked = execFileSync('git', ['ls-files'], { cwd: ROOT, maxBuffer: 32 << 20 })
-  .toString()
-  .split('\n')
-  .filter(Boolean)
-  // A tile id appearing only in the E5 input/split manifests is not "use".
-  .filter((f) => !/validation\/e5\/manifests\/(ROGUE25|HOUSTON17)\.input\.json$/.test(f))
-  .filter((f) => !f.endsWith('ROGUE25.split.json'));
-
-/** Is this tile id referenced by any tracked file other than the manifests? */
-function isExposed(id) {
-  try {
-    execFileSync('git', ['grep', '-l', id, '--', ...tracked], { cwd: ROOT, maxBuffer: 32 << 20 });
-    return true;
-  } catch {
-    return false; // git grep exits non-zero when there is no match
-  }
+// Exposure comes only from the immutable ledger. Its raw bytes are hashed into
+// exposureDigest, and its collectionDigest must match the manifest it was pinned
+// against, so a ledger paired with the wrong input fails loudly.
+const exposureText = readFileSync(EXPOSURE_PATH, 'utf8');
+const exposure = JSON.parse(exposureText);
+if (exposure.collectionDigest !== manifest.collectionDigest) {
+  console.error(
+    `exposure ledger collectionDigest ${exposure.collectionDigest} does not match manifest ${manifest.collectionDigest}`,
+  );
+  process.exit(3);
 }
+const exposedIds = new Set((exposure.exposed ?? []).map((e) => e.tileId));
+const exposureDigest = createHash('sha256').update(exposureText).digest('hex');
 
 const tiles = manifest.tiles.map((t) => {
   const id = tileId(t.basename);
@@ -56,13 +61,13 @@ const tiles = manifest.tiles.map((t) => {
     tileId: id,
     basename: t.basename,
     sha256: t.sha256,
-    exposed: isExposed(id),
+    exposed: exposedIds.has(id),
     orderKey: createHash('sha256').update(SALT + t.sha256).digest('hex'),
   };
 });
 
 const exposed = tiles.filter((t) => t.exposed);
-const unexposed = tiles.filter((t) => !t.exposed).sort((a, b) => a.orderKey.localeCompare(b.orderKey));
+const unexposed = tiles.filter((t) => !t.exposed).sort((a, b) => byCodeUnit(a.orderKey, b.orderKey));
 
 const devFromUnexposed = Math.max(0, TARGET_DEV - exposed.length);
 const assign = (t, set) => ({ tileId: t.tileId, basename: t.basename, sha256: t.sha256, exposed: t.exposed, set });
@@ -70,23 +75,28 @@ const assigned = [
   ...exposed.map((t) => assign(t, 'development')), // exposed → forced development
   ...unexposed.slice(0, devFromUnexposed).map((t) => assign(t, 'development')),
   ...unexposed.slice(devFromUnexposed).map((t) => assign(t, 'holdout')),
-].sort((a, b) => a.tileId.localeCompare(b.tileId));
+].sort((a, b) => byCodeUnit(a.tileId, b.tileId));
 
 const dev = assigned.filter((t) => t.set === 'development');
 const holdout = assigned.filter((t) => t.set === 'holdout');
+// splitDigest folds in exposureDigest so the recorded split is bound to the exact
+// exposure set it was built from, not just the membership labels.
 const splitDigest = createHash('sha256')
-  .update(assigned.map((t) => `${t.tileId}:${t.set}`).join('\n'))
+  .update(`${exposureDigest}\n${assigned.map((t) => `${t.tileId}:${t.set}`).join('\n')}`)
   .digest('hex');
 
 const out = {
   $schemaNote:
-    'Deterministic exposure-honest dev/holdout split of the 25 Rogue tiles for RETROSPECTIVE E5 hardening. Rogue never becomes E5. Exposed tiles (already used anywhere in the repo) are forced into development; unexposed tiles are ordered by sha256(salt + fileSha256) and filled to the development target, the rest holdout. Reproducible from the input manifest alone.',
+    'Deterministic exposure-honest dev/holdout split of the 25 Rogue tiles for RETROSPECTIVE E5 hardening. Rogue never becomes E5. Exposed tiles are pinned in the immutable ROGUE25.exposure.json ledger and forced into development; unexposed tiles are ordered by sha256(salt + fileSha256) compared by code unit and filled to the development target, the rest holdout. Reproducible from the input manifest and the exposure ledger alone.',
   policy: {
     salt: SALT,
     targetDevelopment: TARGET_DEV,
+    exposureLedger: 'validation/e5/splits/ROGUE25.exposure.json',
+    ordering: 'UTF-16 code unit on sha256(salt+fileSha256); no locale collation',
     rule: 'exposed → development; unexposed ordered by sha256(salt+fileSha256), first (target − exposed) → development, rest → holdout',
   },
   inputCollectionDigest: manifest.collectionDigest,
+  exposureDigest,
   splitDigest,
   summary: {
     total: assigned.length,

--- a/tests/rogueSplit.test.ts
+++ b/tests/rogueSplit.test.ts
@@ -3,9 +3,11 @@
  *
  * Rogue is a retrospective hardening set and never becomes E5; the split only has
  * to be honest and reproducible. These checks pin the properties a reader relies
- * on: an exposed tile (already used anywhere in the repo) is never in the holdout,
- * the holdout is entirely unexposed, the split covers exactly the input tiles, and
- * the recorded splitDigest is the digest of the recorded assignment.
+ * on: exposure is read from the immutable ledger (not a live git scan), an exposed
+ * tile (used before the split was frozen) is never in the holdout, the holdout is
+ * entirely unexposed, the split covers exactly the input tiles, the assignment is
+ * reproducible from manifest + exposure ledger + salt using code-unit ordering,
+ * and the recorded splitDigest is the digest of the exposure set and assignment.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -14,18 +16,31 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const read = (p: string) => JSON.parse(readFileSync(resolve(ROOT, p), 'utf8'));
+const readText = (p: string) => readFileSync(resolve(ROOT, p), 'utf8');
+const read = (p: string) => JSON.parse(readText(p));
 const split = read('validation/e5/splits/ROGUE25.split.json') as {
-  policy: { targetDevelopment: number };
+  policy: { targetDevelopment: number; salt: string };
   inputCollectionDigest: string;
+  exposureDigest: string;
   splitDigest: string;
   summary: { total: number; development: number; holdout: number; exposedForcedToDevelopment: string[] };
-  tiles: { tileId: string; sha256: string; exposed: boolean; set: 'development' | 'holdout' }[];
+  tiles: { tileId: string; basename: string; sha256: string; exposed: boolean; set: 'development' | 'holdout' }[];
 };
 const input = read('validation/e5/manifests/ROGUE25.input.json') as {
   collectionDigest: string;
-  tiles: { sha256: string }[];
+  tiles: { basename: string; sha256: string }[];
 };
+const exposureText = readText('validation/e5/splits/ROGUE25.exposure.json');
+const exposure = JSON.parse(exposureText) as {
+  schemaVersion: number;
+  collectionDigest: string;
+  exposed: { tileId: string; reason: string; evidence: string }[];
+};
+const builderSrc = readText('scripts/e5/build-rogue-split.mjs');
+
+const SALT = 'ROGUE-E5-HARDENING-v1';
+const byCodeUnit = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+const tileId = (basename: string) => (basename.match(/10T[A-Z]{2}\d+/) ?? [basename])[0];
 
 describe('rogue dev/holdout split', () => {
   it('covers exactly the 25 input tiles (sha256 set equality)', () => {
@@ -37,6 +52,44 @@ describe('rogue dev/holdout split', () => {
 
   it('is tied to the input collection it was built from', () => {
     expect(split.inputCollectionDigest).toBe(input.collectionDigest);
+  });
+
+  it('reads exposure from the immutable ledger, not a live git scan', () => {
+    // The reproducibility bug this guards: exposure was discovered at build time
+    // via git ls-files + git grep, so a later doc mentioning a tile changed the
+    // split. Exposure must now come only from the pinned ledger.
+    expect(builderSrc).not.toMatch(/child_process/);
+    expect(builderSrc).not.toMatch(/execFileSync/);
+    expect(builderSrc).not.toMatch(/ls-files|git grep/);
+    expect(builderSrc).toMatch(/ROGUE25\.exposure\.json/);
+  });
+
+  it('orders by code unit, never by locale collation', () => {
+    // localeCompare's ICU collation differs across machines and would make the
+    // hashed ordering non-reproducible.
+    expect(builderSrc).not.toMatch(/\.localeCompare\(/);
+  });
+
+  it('the exposure ledger is pinned to the same collection', () => {
+    expect(exposure.collectionDigest).toBe(input.collectionDigest);
+    expect(exposure.exposed.length).toBeGreaterThan(0);
+    for (const e of exposure.exposed) {
+      expect(e.tileId).toMatch(/^10T[A-Z]{2}\d+$/);
+      expect(e.reason.length).toBeGreaterThan(0);
+      expect(e.evidence.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('records exactly the ledger exposed set as exposed and forced to development', () => {
+    const ledgerIds = exposure.exposed.map((e) => e.tileId).sort(byCodeUnit);
+    expect([...split.summary.exposedForcedToDevelopment].sort(byCodeUnit)).toEqual(ledgerIds);
+    const exposedInSplit = split.tiles.filter((t) => t.exposed).map((t) => t.tileId).sort(byCodeUnit);
+    expect(exposedInSplit).toEqual(ledgerIds);
+    for (const id of ledgerIds) {
+      const t = split.tiles.find((x) => x.tileId === id)!;
+      expect(t.exposed).toBe(true);
+      expect(t.set).toBe('development');
+    }
   });
 
   it('no exposed tile is in the holdout (the honesty invariant)', () => {
@@ -57,18 +110,35 @@ describe('rogue dev/holdout split', () => {
     expect(split.summary.development).toBe(split.policy.targetDevelopment);
   });
 
-  it('every recorded exposed-forced tile is exposed and in development', () => {
-    for (const id of split.summary.exposedForcedToDevelopment) {
-      const t = split.tiles.find((x) => x.tileId === id)!;
-      expect(t.exposed).toBe(true);
-      expect(t.set).toBe('development');
+  it('reproduces the exact membership from manifest + exposure ledger + salt', () => {
+    // Re-derive the assignment independently of the committed split, mirroring the
+    // builder: exposed (from ledger) → development; unexposed ordered by
+    // sha256(salt + fileSha256) compared by code unit, filled to the target.
+    const exposedIds = new Set(exposure.exposed.map((e) => e.tileId));
+    const tiles = input.tiles.map((t) => ({
+      tileId: tileId(t.basename),
+      exposed: exposedIds.has(tileId(t.basename)),
+      orderKey: createHash('sha256').update(SALT + t.sha256).digest('hex'),
+    }));
+    const exposed = tiles.filter((t) => t.exposed);
+    const unexposed = tiles.filter((t) => !t.exposed).sort((a, b) => byCodeUnit(a.orderKey, b.orderKey));
+    const devFromUnexposed = Math.max(0, split.policy.targetDevelopment - exposed.length);
+    const derived = new Map<string, 'development' | 'holdout'>();
+    for (const t of exposed) derived.set(t.tileId, 'development');
+    unexposed.forEach((t, i) => derived.set(t.tileId, i < devFromUnexposed ? 'development' : 'holdout'));
+    for (const t of split.tiles) {
+      expect(derived.get(t.tileId), `${t.tileId} set mismatch`).toBe(t.set);
     }
   });
 
-  it('the recorded splitDigest is the digest of the recorded assignment', () => {
-    const recomputed = createHash('sha256')
-      .update([...split.tiles].sort((a, b) => a.tileId.localeCompare(b.tileId)).map((t) => `${t.tileId}:${t.set}`).join('\n'))
-      .digest('hex');
+  it('the recorded splitDigest folds in the exposure digest and the assignment', () => {
+    const exposureDigest = createHash('sha256').update(exposureText).digest('hex');
+    expect(split.exposureDigest).toBe(exposureDigest);
+    const assignment = [...split.tiles]
+      .sort((a, b) => byCodeUnit(a.tileId, b.tileId))
+      .map((t) => `${t.tileId}:${t.set}`)
+      .join('\n');
+    const recomputed = createHash('sha256').update(`${exposureDigest}\n${assignment}`).digest('hex');
     expect(recomputed).toBe(split.splitDigest);
   });
 });

--- a/validation/e5/splits/ROGUE25.exposure.json
+++ b/validation/e5/splits/ROGUE25.exposure.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "$schemaNote": "Immutable exposure ledger for the retrospective Rogue dev/holdout split. It PINS the tiles the repository had already used before the split was frozen; those tiles are forced into development and can never serve as an untouched holdout. build-rogue-split.mjs reads exposure only from this file (not a live git scan), so a later doc that mentions a tile does not silently move it out of the holdout and the split reproduces on any machine. collectionDigest ties the ledger to the exact input collection it was pinned against.",
+  "collectionDigest": "c8b8ce14d4d5204ba64aec243e028e14722bd7285e0ec98a93018f859d6d4d4b",
+  "exposed": [
+    {
+      "tileId": "10TDM3746",
+      "reason": "used before split freeze",
+      "evidence": "cited in validation/datasets/dataset-register.yaml and validation/protocols/independent-checkpoints-v1.md, scored in validation/real-scene/gf-strata/OLV-DS-091.json, and referenced by tests/e5ManifestVerify.test.ts and tests/independentCheckpointHarness.test.ts"
+    }
+  ]
+}

--- a/validation/e5/splits/ROGUE25.split.json
+++ b/validation/e5/splits/ROGUE25.split.json
@@ -1,12 +1,15 @@
 {
-  "$schemaNote": "Deterministic exposure-honest dev/holdout split of the 25 Rogue tiles for RETROSPECTIVE E5 hardening. Rogue never becomes E5. Exposed tiles (already used anywhere in the repo) are forced into development; unexposed tiles are ordered by sha256(salt + fileSha256) and filled to the development target, the rest holdout. Reproducible from the input manifest alone.",
+  "$schemaNote": "Deterministic exposure-honest dev/holdout split of the 25 Rogue tiles for RETROSPECTIVE E5 hardening. Rogue never becomes E5. Exposed tiles are pinned in the immutable ROGUE25.exposure.json ledger and forced into development; unexposed tiles are ordered by sha256(salt + fileSha256) compared by code unit and filled to the development target, the rest holdout. Reproducible from the input manifest and the exposure ledger alone.",
   "policy": {
     "salt": "ROGUE-E5-HARDENING-v1",
     "targetDevelopment": 17,
+    "exposureLedger": "validation/e5/splits/ROGUE25.exposure.json",
+    "ordering": "UTF-16 code unit on sha256(salt+fileSha256); no locale collation",
     "rule": "exposed → development; unexposed ordered by sha256(salt+fileSha256), first (target − exposed) → development, rest → holdout"
   },
   "inputCollectionDigest": "c8b8ce14d4d5204ba64aec243e028e14722bd7285e0ec98a93018f859d6d4d4b",
-  "splitDigest": "c156406a475805fc932ec871da95c4b9f33dc7529bef30d154b84e60ace22b05",
+  "exposureDigest": "9cbb73a590318c815c5b6bc36b29b73f83e871cdbf884a8b747481c8073ea5c0",
+  "splitDigest": "6bffd73f9288708d8b867100327f1e4456495c6127686cd6857f8f7668f17649",
   "summary": {
     "total": 25,
     "development": 17,


### PR DESCRIPTION
The Rogue dev/holdout split builder discovered exposed tiles at build time with git ls-files + git grep, so a later doc mentioning a tile silently moved it out of the holdout, and it used localeCompare for the hashed ordering (ICU collation differs across machines). Neither is reproducible.

Exposure is now pinned in an immutable `validation/e5/splits/ROGUE25.exposure.json` ledger (one entry: `10TDM3746`, the tile the frozen split already forced to development). The builder reads exposure from the ledger, hashes it into `exposureDigest`, checks its `collectionDigest` against the manifest, orders by a UTF-16 code-unit comparator, and folds `exposureDigest` into `splitDigest`.

Freeze-safe: dev/holdout membership is byte-identical to the committed split (only the schema note, policy, `exposureDigest` and `splitDigest` fields change); the builder is idempotent against the committed file. Tests assert derivation from manifest + ledger + salt, code-unit ordering, and no git scan.