### PR TITLE
fix(export): DEM README elevation unit from the vertical factor, not horizontal

### DIFF
--- a/src/terrain/export/demPackage.ts
+++ b/src/terrain/export/demPackage.ts
@@ -26,6 +26,7 @@ import { writeAsciiGrid } from './demAsciiGrid';
 import { writeGeoTiff, verticalUnitGeoKeyCode } from './demGeoTiff';
 import { buildZip, type ZipEntry } from '../../convert/zipStore';
 import { sha256Hex } from './sha256';
+import { verticalUnitLabel } from '../../units/units';
 
 /**
  * Build a `SHA256SUMS` integrity manifest over `entries`, in the standard
@@ -56,15 +57,16 @@ function projectedUnitLabel(unit: DemLinearUnit | undefined): string {
 }
 
 /**
- * Plain vertical-unit label. The DTM grid stores elevations in the scan's
- * SOURCE vertical units (only the validation RMSEz is converted to metres), so
- * a foot-based CRS — whose vertical axis shares the linear unit family — carries
- * elevations in feet, not metres. An omitted / metre / unknown unit keeps the
- * standing metre default for back-compat.
+ * Elevation-unit word for the README, mapped from the units.ts short label
+ * (`'m'` / `'ft'` / `'units'`). The DTM stores Z in the scan's SOURCE vertical
+ * units, so the label is derived from the resolved VERTICAL factor
+ * (`dtm.verticalUnitToMetres`), never the horizontal one — a compound CRS (metre
+ * plan over a foot height, or the reverse) would otherwise stamp the README and
+ * the GeoTIFF vertical GeoKey with different units for the SAME zip. `'units'`
+ * (an absent / degenerate factor) reads `'unknown'`, the fail-closed contract
+ * the contour deliverable already uses — never a fabricated metre.
  */
-function verticalUnitLabel(unit: DemLinearUnit | undefined): string {
-  return unit === 'foot' || unit === 'us-survey-foot' ? 'feet' : 'metres';
-}
+const ELEVATION_UNIT_NAME = { m: 'metres', ft: 'feet', units: 'unknown' } as const;
 
 export interface DemPackageOptions {
   /**
@@ -233,11 +235,15 @@ export function buildDemReadme(opts: DemReadmeOptions): string {
   // resolved projected linear unit (m, or ft on a foot CRS) — the grid's
   // cellSizeM is stored in SOURCE units, so a foot CRS must read "ft" not "m".
   const hUnit = isGeographic ? 'degrees' : projectedUnitLabel(opts.linearUnit);
-  // Elevation unit: the DTM stores Z in SOURCE vertical units, so a PROJECTED
-  // foot-based CRS carries elevations in feet. A geographic frame keeps the
-  // standing metre assumption for heights (its horizontal unit is degrees; the
-  // vertical unit is conventionally metres and is not separately resolved here).
-  const zUnit = isGeographic ? 'metres' : verticalUnitLabel(opts.linearUnit);
+  // Elevation unit: the DTM stores Z in SOURCE vertical units, so the label
+  // comes from the resolved VERTICAL factor — NOT opts.linearUnit (horizontal),
+  // which is what the GeoTIFF's vertical GeoKey (4099) already keys off. Honoured
+  // in both branches: a geographic frame's cells are degrees but its heights
+  // still carry the declared vertical unit. An absent / degenerate factor reads
+  // 'unknown' (fail-closed), never a fabricated metre.
+  const zUnit = dtm.verticalUnitToMetres == null
+    ? 'unknown'
+    : ELEVATION_UNIT_NAME[verticalUnitLabel(dtm.verticalUnitToMetres)];
   const reasons = quality?.reasons ?? [];
   const exportReasons = quality?.exportReasons ?? [];
   const warnings = result.warnings ?? [];

--- a/tests/demExport.test.ts
+++ b/tests/demExport.test.ts
@@ -571,6 +571,22 @@ describe('buildDemPackage', () => {
     expect(readTiffGeoKey(extractEntry(zip, 'site-dtm.tif')!, 4099)).toBe(9002);
   });
 
+  it('README elevation and the GeoTIFF vertical unit agree on a metre-plan / foot-height CRS', () => {
+    // The compound-CRS drift this fix pins: the README derived its elevation
+    // label from the HORIZONTAL unit while the GeoTIFF stamped the vertical unit
+    // from verticalUnitToMetres. A metre plan (cells 'm') over a foot vertical
+    // axis (0.3048) must now read 'feet' in the README AND 9002 in GeoKey 4099 —
+    // the same unit for the same grid in the same zip.
+    const r = fixtureResult();
+    (r.dtm as { verticalUnitToMetres?: number | null }).verticalUnitToMetres = 0.3048;
+    const zip = buildDemPackage(r, { worldOrigin: { x: 600000, y: 4000000 }, basename: 'site' });
+    const readme = new TextDecoder().decode(extractEntry(zip, 'site-README.txt')!);
+    expect(readme).toMatch(/Cell size\s+1 m\b/); // metre plan
+    expect(readme).toMatch(/Elevation unit feet/); // foot height, from the vertical factor
+    expect(readme).not.toMatch(/Elevation unit metres/);
+    expect(readTiffGeoKey(extractEntry(zip, 'site-dtm.tif')!, 4099)).toBe(9002);
+  });
+
   it('maps a metres-per-unit factor to its GeoTIFF unit code, or to none', () => {
     // The shared derivation both products now go through. An unrecognised
     // factor must yield null so the writer omits key 4099 rather than

--- a/tests/demPackageReadme.test.ts
+++ b/tests/demPackageReadme.test.ts
@@ -53,6 +53,22 @@ function previewResult(): AnalyseContoursResult {
   } as unknown as AnalyseContoursResult;
 }
 
+/**
+ * Set the resolved vertical factor (metres per source vertical unit) on a
+ * result's DTM. The README's elevation unit now derives from this — the vertical
+ * axis — not from the horizontal `linearUnit`. `null` models an unresolved
+ * vertical unit (fail-closed → 'unknown').
+ */
+function withVerticalFactor(
+  r: AnalyseContoursResult,
+  metresPerUnit: number | null,
+): AnalyseContoursResult {
+  return {
+    ...(r as unknown as Record<string, unknown>),
+    dtm: { ...(r.dtm as unknown as Record<string, unknown>), verticalUnitToMetres: metresPerUnit },
+  } as unknown as AnalyseContoursResult;
+}
+
 const OPTS: Omit<DemReadmeOptions, 'result'> = {
   basename: 'site',
   isGeographic: false,
@@ -161,16 +177,22 @@ describe('buildDemReadme — generation parameters derive from the run', () => {
 });
 
 describe('buildDemReadme — unit labels follow the source CRS (label-vs-value)', () => {
-  it('labels cell size + elevation in metres for a metric CRS (default)', () => {
-    const txt = buildDemReadme({ result: readyResult(), ...OPTS });
+  it('labels cell size + elevation in metres for a metric CRS (declared metre vertical)', () => {
+    // The elevation unit now derives from the resolved VERTICAL factor, not the
+    // horizontal unit: a metre-vertical CRS (verticalUnitToMetres === 1) reads
+    // 'metres', matching the GeoTIFF vertical GeoKey (9001) in the same package.
+    const txt = buildDemReadme({ result: withVerticalFactor(readyResult(), 1), ...OPTS });
     expect(txt).toMatch(/Cell size\s+1 m\b/);
     expect(txt).toMatch(/Grid cell size 1 m\b/);
     expect(txt).toMatch(/Elevation unit metres/);
   });
 
-  it('labels cell size + elevation in FEET on a foot CRS — never "m"/"metres"', () => {
-    // The DTM grid stores cellSizeM and Z in SOURCE units; a foot CRS carries
-    // feet, so the README must read "ft" / "feet", not the metre default.
+  it('labels cell size in FEET on a foot CRS, but an undeclared vertical unit reads "unknown"', () => {
+    // The DTM grid stores cellSizeM in SOURCE units, so a foot CRS's cell size
+    // reads "ft". The elevation unit is INDEPENDENT of the horizontal one: with
+    // no declared vertical factor it fails closed to "unknown" — the horizontal
+    // foot must never be copied onto the vertical axis (the compound-CRS drift
+    // this fix pins).
     const txt = buildDemReadme({
       result: readyResult(),
       ...OPTS,
@@ -178,17 +200,49 @@ describe('buildDemReadme — unit labels follow the source CRS (label-vs-value)'
     });
     expect(txt).toMatch(/Cell size\s+1 ft\b/);
     expect(txt).toMatch(/Grid cell size 1 ft\b/);
-    expect(txt).toMatch(/Elevation unit feet/);
-    // The drift: a foot scan must NOT assert metres anywhere in the raster block.
+    expect(txt).toMatch(/Elevation unit unknown/);
+    // A foot scan must neither assert metres nor blindly inherit the plan foot.
     expect(txt).not.toMatch(/Elevation unit metres/);
+    expect(txt).not.toMatch(/Elevation unit feet/);
     expect(txt).not.toMatch(/Cell size\s+1 m\b/);
   });
 
-  it('labels degrees for a geographic CRS, with linear elevation', () => {
-    const txt = buildDemReadme({ result: readyResult(), ...OPTS, isGeographic: true });
-    expect(txt).toMatch(/Cell size\s+1 degrees/);
-    // Geographic heights are still linear metres by the standing default.
+  it('reads FEET elevation on a metre-plan / foot-height compound CRS', () => {
+    // metre horizontal (linearUnit undefined ⇒ 'm' cells) over a foot vertical
+    // axis (verticalUnitToMetres === 0.3048). The elevation must read 'feet' from
+    // the vertical factor even though the plan unit is metres.
+    const txt = buildDemReadme({ result: withVerticalFactor(readyResult(), 0.3048), ...OPTS });
+    expect(txt).toMatch(/Cell size\s+1 m\b/);
+    expect(txt).toMatch(/Elevation unit feet/);
+    expect(txt).not.toMatch(/Elevation unit metres/);
+  });
+
+  it('reads METRES elevation on a foot-plan / metre-height compound CRS', () => {
+    // foot horizontal (cells read 'ft') over a metre vertical axis
+    // (verticalUnitToMetres === 1). The elevation must read 'metres', the reverse
+    // of the metre-plan/foot-height case.
+    const txt = buildDemReadme({
+      result: withVerticalFactor(readyResult(), 1),
+      ...OPTS,
+      linearUnit: 'foot',
+    });
+    expect(txt).toMatch(/Cell size\s+1 ft\b/);
     expect(txt).toMatch(/Elevation unit metres/);
+    expect(txt).not.toMatch(/Elevation unit feet/);
+  });
+
+  it('labels degrees for cells on a geographic CRS while honouring the vertical factor (feet)', () => {
+    // A geographic frame's cells/bounds are degrees, but its heights still carry
+    // the declared vertical unit: a foot vertical axis reads 'feet' for elevation
+    // with the cell size still 'degrees'.
+    const txt = buildDemReadme({
+      result: withVerticalFactor(readyResult(), 0.3048),
+      ...OPTS,
+      isGeographic: true,
+    });
+    expect(txt).toMatch(/Cell size\s+1 degrees/);
+    expect(txt).toMatch(/Elevation unit feet/);
+    expect(txt).not.toMatch(/Elevation unit metres/);
   });
 });
 


### PR DESCRIPTION
The DEM package README derived its elevation-unit label from the HORIZONTAL unit (`opts.linearUnit`), while the package GeoTIFF stamps the vertical unit from `dtm.verticalUnitToMetres`. On a compound CRS (metre plan over a foot height, or the reverse) the README and the GeoTIFF in the same zip disagreed on the vertical unit.

`buildDemReadme` now derives the elevation label from `dtm.verticalUnitToMetres` through `units.verticalUnitLabel` (metres / feet; unknown for an absent or degenerate factor). Geographic cells/bounds stay degrees, but elevation honours the declared vertical factor. Horizontal cell/bounds labelling is unchanged.

Metadata label only — zero DTM/terrain numerical change. Pure-metre and pure-foot CRSs have `verticalUnitToMetres` equal to the horizontal factor, so the frozen UTM-metre + NAVD88-metre deliverables produce a byte-identical README + SHA256SUMS.

Tests: README metre/feet/unknown + compound + geographic-foot cases; a metre-plan/foot-height package now agrees README 'feet' with GeoTIFF GeoKey 4099 == 9002. tsc clean; demPackageReadme + demExport green.