### PR TITLE
feat(export): emit the designed Support.tif per-cell support raster

### DIFF
--- a/src/terrain/contourStudio/contourPackageManifest.ts
+++ b/src/terrain/contourStudio/contourPackageManifest.ts
@@ -155,6 +155,16 @@ export interface PackageInput {
   };
   /** One-line citation recommendation for the README. */
   readonly citation: string;
+  /**
+   * Per-cell support split (percent of ALL DTM cells), from the same coverage
+   * states the Support raster serializes. Present only when a DTM — and thus a
+   * support raster — is in the package; the README then reports the split.
+   */
+  readonly supportCoverage?: {
+    readonly measuredPct: number;
+    readonly interpolatedPct: number;
+    readonly unsupportedPct: number;
+  };
 }
 
 interface FileSpec { role: PackageRole; ext: string; label: string; available: (a: PackageAvailability) => boolean; desc: string }
@@ -241,6 +251,24 @@ function buildReadme(stem: string, entries: readonly PackageEntry[], input: Pack
     '  Analytical contours are exact isolines of the terrain grid (use for GIS and',
     '  reproducibility). Cartographic contours are generalized and labelled for legible',
     '  maps; they are derived from the analytical geometry and are not exact.',
+  );
+
+  const sc = input.supportCoverage;
+  if (sc) {
+    const pct = (v: number): string => `${v.toFixed(1)}%`;
+    lines.push(
+      '',
+      'Surface support',
+      '  Per-cell provenance recorded in the Support raster, as a share of all DTM cells:',
+      `    Measured:     ${pct(sc.measuredPct)}`,
+      `    Interpolated: ${pct(sc.interpolatedPct)}`,
+      `    Unsupported:  ${pct(sc.unsupportedPct)}`,
+      '  Measured cells hold at least one ground return; interpolated cells are filled from',
+      '  nearby measured cells; unsupported cells have no reachable data.',
+    );
+  }
+
+  lines.push(
     '',
     'Validation scope',
     '  Validation is internal (hold-out) only. No independent field checkpoints were',

--- a/src/terrain/export/contourDeliverableBuild.ts
+++ b/src/terrain/export/contourDeliverableBuild.ts
@@ -8,10 +8,11 @@
  *
  * Scope: the deliverable bundles the CURRENT contour geometry (honestly
  * labelled analytical vs cartographic by its actual style), the DTM raster, the
- * cartographic DXF (when the geometry is cartographic), the validation JSON, the
- * Contour Studio settings JSON, provenance, a README and checksums. The rasters
- * beyond the DTM (hillshade / support / uncertainty) stay OMITTED with honest
- * reasons — never shipped as empty placeholders. Widening the set is additive.
+ * support raster (the DTM's per-cell provenance, serialized), the cartographic
+ * DXF (when the geometry is cartographic), the validation JSON, the Contour
+ * Studio settings JSON, provenance, a README and checksums. The remaining
+ * rasters (hillshade / uncertainty) stay OMITTED with honest reasons — never
+ * shipped as empty placeholders. Widening the set is additive.
  *
  * Pure and synchronous given the result: no DOM, no I/O. Reuses the same
  * serializers every other export uses, so a file in the package is byte-for-byte
@@ -85,7 +86,7 @@ const OMISSION_REASONS: Partial<Record<PackageRole, string>> = {
   'contour-map-pdf': 'Export separately via the Map sheet (PDF) product.',
   'contours-cartographic-dxf': 'Included only with a cartographic contour export.',
   'hillshade-raster': 'A shaded-relief raster is not yet part of this package.',
-  'support-raster': 'A per-cell support raster is not yet part of this package.',
+  'support-raster': 'Requires a DTM grid; none was produced for this scan.',
   'uncertainty-raster': 'A per-cell uncertainty raster is not yet part of this package.',
 };
 
@@ -103,6 +104,16 @@ interface GatheredDeliverable {
   readonly horizontalUnit: 'ft' | 'm';
   /** Elevation unit label — a declared Z unit ('m'|'ft'|'units') or 'unknown'. */
   readonly verticalUnit: string;
+  /**
+   * Per-cell support split as a share of ALL DTM cells, tallied from
+   * dtm.coverage (0 = unsupported/void, 1 = interpolated, 2 = measured) — the
+   * same states the Support.tif serializes. Null when there is no DTM.
+   */
+  readonly supportPct: {
+    readonly measuredPct: number;
+    readonly interpolatedPct: number;
+    readonly unsupportedPct: number;
+  } | null;
   readonly bytes: Map<PackageRole, Uint8Array>;
 }
 
@@ -161,6 +172,7 @@ function gatherDeliverable(
     vScale != null && Number.isFinite(vScale) && vScale > 0 ? verticalUnitLabel(vScale) : 'unknown';
 
   const bytes = new Map<PackageRole, Uint8Array>();
+  let supportPct: GatheredDeliverable['supportPct'] = null;
 
   if (hasContours && model) {
     // A `.geojson` in the package makes the same promise as one on disk: RFC
@@ -229,6 +241,49 @@ function gatherDeliverable(
         verticalUnitCode: verticalUnitGeoKeyCode(dtm.verticalUnitToMetres),
       }),
     );
+
+    // Support raster — a categorical byte map on the SAME grid/CRS as the DTM,
+    // serializing the per-cell provenance dtm.coverage already carries: 0 =
+    // unsupported/void, 1 = interpolated, 2 = measured. Purely derived; no
+    // surface height is read or touched. A full (all-ones) write mask keeps every
+    // cell, since 0 is a real class (unsupported), not NODATA; noData 255 sits
+    // outside {0,1,2} and is never written. No vertical CRS/unit — it is a
+    // classification grid, not an elevation.
+    const cov = dtm.coverage;
+    const supportMask = new Uint8Array(cov.length).fill(1);
+    bytes.set(
+      'support-raster',
+      writeGeoTiff({
+        values: cov,
+        coverage: supportMask,
+        cols: dtm.cols,
+        rows: dtm.rows,
+        cellSize: dtm.cellSizeM,
+        xllCorner: ox + dtm.originH1,
+        yllCorner: oy + dtm.originH2,
+        noData: 255,
+        epsg: dtm.horizontalEpsg ?? parseEpsg(dtm.crs),
+        isGeographic: opts.isGeographic ?? false,
+        band: 'uint8',
+      }),
+    );
+
+    // Coverage percentages for the README, tallied from the SAME array the
+    // raster serializes, so the two never disagree.
+    let measured = 0;
+    let interpolated = 0;
+    for (let i = 0; i < cov.length; i++) {
+      if (cov[i] === 2) measured++;
+      else if (cov[i] === 1) interpolated++;
+    }
+    const total = cov.length > 0 ? cov.length : 1;
+    const measuredPct = (measured / total) * 100;
+    const interpolatedPct = (interpolated / total) * 100;
+    supportPct = {
+      measuredPct,
+      interpolatedPct,
+      unsupportedPct: Math.max(0, 100 - measuredPct - interpolatedPct),
+    };
   }
 
   bytes.set('provenance-json', enc(JSON.stringify(provenanceJson(provenance), null, 2)));
@@ -270,7 +325,7 @@ function gatherDeliverable(
     );
   }
 
-  return { basename, provenance, isAnalytical, hasContours, dtm, horizontalUnit, verticalUnit, bytes };
+  return { basename, provenance, isAnalytical, hasContours, dtm, horizontalUnit, verticalUnit, supportPct, bytes };
 }
 
 /** Assemble the package manifest for a gathered deliverable. `pdf` flips when
@@ -281,7 +336,8 @@ function manifestFor(g: GatheredDeliverable, opts: DeliverableBuildOptions, pdf:
     decision: opts.decision,
     // Availability is read from the bytes actually gathered, so the manifest and
     // README can never claim a file the ZIP does not carry (or omit one it does).
-    // The rasters beyond the DTM have no producer yet, so they stay false.
+    // Support ships whenever a DTM does; hillshade / uncertainty have no producer
+    // yet, so they stay false.
     available: {
       pdf,
       analyticalGeojson: g.bytes.has('contours-analytical-geojson'),
@@ -290,12 +346,13 @@ function manifestFor(g: GatheredDeliverable, opts: DeliverableBuildOptions, pdf:
       cartographicDxf: g.bytes.has('contours-cartographic-dxf'),
       dtm: g.bytes.has('dtm-raster'),
       hillshade: false,
-      support: false,
+      support: g.bytes.has('support-raster'),
       uncertainty: false,
       validationJson: g.bytes.has('validation-json'),
       provenanceJson: g.bytes.has('provenance-json'),
       studioJson: g.bytes.has('contour-studio-json'),
     },
+    supportCoverage: g.supportPct ?? undefined,
     omissionReasons: OMISSION_REASONS,
     provenance: {
       crs: g.provenance.horizontalCrs,

--- a/src/terrain/export/demGeoTiff.ts
+++ b/src/terrain/export/demGeoTiff.ts
@@ -1,11 +1,13 @@
 /**
  * demGeoTiff.ts
  *
- * Write a single-band Float32 GeoTIFF for an elevation grid — the gold-standard
- * DEM exchange format. Classic (non-BigTIFF) little-endian TIFF with one
- * uncompressed strip, plus the GeoTIFF tags (ModelPixelScale, ModelTiepoint,
- * GeoKeyDirectory) and a GDAL_NODATA tag. CRS is carried by EPSG code in the
- * GeoKeys, so no WKT lookup is needed.
+ * Write a single-band GeoTIFF for a grid — the gold-standard DEM exchange
+ * format. The default band is Float32 (the elevation surface); an optional
+ * `band: 'uint8'` writes an unsigned-byte band instead, for a categorical grid
+ * such as the per-cell support map. Classic (non-BigTIFF) little-endian TIFF
+ * with one uncompressed strip, plus the GeoTIFF tags (ModelPixelScale,
+ * ModelTiepoint, GeoKeyDirectory) and a GDAL_NODATA tag. CRS is carried by EPSG
+ * code in the GeoKeys, so no WKT lookup is needed.
  *
  * Pure-data: builds and returns the file bytes; no DOM, deterministic.
  *
@@ -40,6 +42,14 @@ export interface DemGeoTiffInput {
    * between metres and feet. Never derived from the horizontal unit.
    */
   readonly verticalUnitCode?: number | null;
+  /**
+   * Sample band type. 'float32' (default) writes the IEEE-float surface — the
+   * DEM's long-standing format, byte-for-byte unchanged. 'uint8' writes a
+   * single-band unsigned-byte grid (BitsPerSample 8, SampleFormat 1) for a
+   * categorical raster such as the per-cell support map; `values` are truncated
+   * to bytes and `noData` should be a byte value outside the class set.
+   */
+  readonly band?: 'float32' | 'uint8';
 }
 
 /**
@@ -101,6 +111,8 @@ export function writeGeoTiff(input: DemGeoTiffInput): Uint8Array {
     );
   }
   const noData = input.noData ?? -9999;
+  const band = input.band ?? 'float32';
+  const bytesPerSample = band === 'uint8' ? 1 : 4;
   const epsg = input.epsg ?? null;
   const verticalEpsg = input.verticalEpsg ?? null;
 
@@ -157,11 +169,11 @@ export function writeGeoTiff(input: DemGeoTiffInput): Uint8Array {
   const noDataAscii = new TextEncoder().encode(`${noData}\0`);
 
   // ── tag table (must be ascending by tag id) ──────────────────────────────
-  const stripByteCount = cols * rows * 4;
+  const stripByteCount = cols * rows * bytesPerSample;
   const tags: Tag[] = [
     { tag: 256, type: T_LONG, count: 1, value: cols }, // ImageWidth
     { tag: 257, type: T_LONG, count: 1, value: rows }, // ImageLength
-    { tag: 258, type: T_SHORT, count: 1, value: 32 }, // BitsPerSample
+    { tag: 258, type: T_SHORT, count: 1, value: band === 'uint8' ? 8 : 32 }, // BitsPerSample
     { tag: 259, type: T_SHORT, count: 1, value: 1 }, // Compression = none
     { tag: 262, type: T_SHORT, count: 1, value: 1 }, // Photometric = BlackIsZero
     { tag: 273, type: T_LONG, count: 1, value: 0 }, // StripOffsets (patched)
@@ -169,7 +181,7 @@ export function writeGeoTiff(input: DemGeoTiffInput): Uint8Array {
     { tag: 278, type: T_LONG, count: 1, value: rows }, // RowsPerStrip
     { tag: 279, type: T_LONG, count: 1, value: stripByteCount }, // StripByteCounts
     { tag: 284, type: T_SHORT, count: 1, value: 1 }, // PlanarConfiguration
-    { tag: 339, type: T_SHORT, count: 1, value: 3 }, // SampleFormat = IEEE float
+    { tag: 339, type: T_SHORT, count: 1, value: band === 'uint8' ? 1 : 3 }, // SampleFormat: 1=uint, 3=IEEE float
     { tag: 33550, type: T_DOUBLE, count: 3, value: 0, blob: pixelScale }, // ModelPixelScale
     { tag: 33922, type: T_DOUBLE, count: 6, value: 0, blob: tiepoint }, // ModelTiepoint
     { tag: 34735, type: T_SHORT, count: geoDir.length, value: 0, blob: geoDirBlob }, // GeoKeyDirectory
@@ -221,7 +233,8 @@ export function writeGeoTiff(input: DemGeoTiffInput): Uint8Array {
     if (t.blob) out.set(t.blob, t.value);
   }
 
-  // Image strip — Float32 LE, row 0 = NORTH (grid row rows-1-r).
+  // Image strip — row 0 = NORTH (grid row rows-1-r). Float32 LE by default; a
+  // uint8 band writes one truncated byte per cell.
   let o = stripOffset;
   for (let r = 0; r < rows; r++) {
     const gridRow = rows - 1 - r;
@@ -229,8 +242,13 @@ export function writeGeoTiff(input: DemGeoTiffInput): Uint8Array {
     for (let c = 0; c < cols; c++) {
       const i = base + c;
       const v = input.coverage[i] !== 0 && Number.isFinite(input.values[i]) ? input.values[i] : noData;
-      dv.setFloat32(o, v, true);
-      o += 4;
+      if (band === 'uint8') {
+        out[o] = v & 0xff;
+        o += 1;
+      } else {
+        dv.setFloat32(o, v, true);
+        o += 4;
+      }
     }
   }
 

--- a/tests/demExport.test.ts
+++ b/tests/demExport.test.ts
@@ -316,6 +316,61 @@ describe('buildDemPackage', () => {
     expect(prov.software).toBe('OpenLiDARViewer');
   });
 
+  it('emits Support.tif — a uint8 coverage map matching dtm.coverage, on the DTM grid, with README percentages', () => {
+    const zip = buildContourDeliverableFromResult(fixtureResult(), {
+      decision: { status: 'validated', badge: 'Internal validation', caveats: [] },
+      basename: 'site',
+      worldOrigin: { x: 600000, y: 4000000 },
+      isGeographic: false,
+      softwareVersion: '0.5.9',
+      metricVersion: 'v0.4.1',
+      generatedAt: new Date('2026-07-12T00:00:00.000Z'),
+      exportPermit: null,
+    });
+
+    const support = extractEntry(zip, 'site_Support.tif');
+    expect(support, 'Support.tif must be in the package').not.toBeNull();
+    const stags = readTiffTags(support!);
+    // Single-band uint8 raster.
+    expect(stags.get(258)).toBe(8); // BitsPerSample
+    expect(stags.get(339)).toBe(1); // SampleFormat = unsigned integer
+    expect(stags.get(277)).toBe(1); // SamplesPerPixel
+    expect(stags.get(279)).toBe(COLS * ROWS * 1); // StripByteCounts = cols*rows bytes
+
+    // The byte at each pixel is the CellCoverage code — north row first, exactly
+    // as dtm.coverage records it. COV=[2,2,1,0] (row0=south) ⇒ north-first [1,0,2,2].
+    const strip = stags.get(273)!;
+    const cells = Array.from(support!.subarray(strip, strip + COLS * ROWS));
+    expect(cells).toEqual([1, 0, 2, 2]);
+    for (const v of cells) expect([0, 1, 2]).toContain(v);
+
+    // Grid + CRS match the DTM: same dimensions, same CRS, byte-identical
+    // ModelPixelScale (cell size) and ModelTiepoint (origin) as DTM.tif.
+    const dtmTif = extractEntry(zip, 'site_DTM.tif')!;
+    const dtags = readTiffTags(dtmTif);
+    expect(stags.get(256)).toBe(dtags.get(256)); // ImageWidth
+    expect(stags.get(257)).toBe(dtags.get(257)); // ImageLength
+    expect(readTiffCrsEpsg(support!)).toBe(readTiffCrsEpsg(dtmTif));
+    const geom = (bytes: Uint8Array, tags: Map<number, number>): string => {
+      const scale = Array.from(bytes.subarray(tags.get(33550)!, tags.get(33550)! + 24));
+      const tie = Array.from(bytes.subarray(tags.get(33922)!, tags.get(33922)! + 48));
+      return JSON.stringify([scale, tie]);
+    };
+    expect(geom(support!, stags)).toBe(geom(dtmTif, dtags));
+
+    // README reports the coverage split, and the three percentages sum to ~100.
+    const readme = new TextDecoder().decode(extractEntry(zip, 'site_README.txt')!);
+    expect(readme).toMatch(/Surface support/);
+    const pcts = [...readme.matchAll(/(Measured|Interpolated|Unsupported):\s+([\d.]+)%/g)];
+    expect(pcts.length).toBe(3);
+    const sum = pcts.reduce((a, m) => a + Number(m[2]), 0);
+    expect(sum).toBeCloseTo(100, 1);
+    // For this fixture (COV=[2,2,1,0]): 50 / 25 / 25.
+    expect(readme).toMatch(/Measured:\s+50\.0%/);
+    expect(readme).toMatch(/Interpolated:\s+25\.0%/);
+    expect(readme).toMatch(/Unsupported:\s+25\.0%/);
+  });
+
   it('the async builder produces a complete deliverable from a real analysed result', async () => {
     // buildContourDeliverableFromResultAsync is the streamed path the Contour
     // Studio UI uses; unlike the DEM-only fixture it reads the full ValidationReport


### PR DESCRIPTION
Finishes the support-raster seam the contour package manifest already declared (Support.tif) but the builder stubbed as omitted.

When a DTM is present, gatherDeliverable now writes a single-band uint8 GeoTIFF on the DTM grid/CRS whose byte at each cell is the CellCoverage code dtm.coverage already carries: 0 = unsupported/void, 1 = interpolated, 2 = measured — exactly the manifest role's description. The DEM GeoTIFF writer gains an optional `band: 'uint8'`; the Float32 elevation path is unchanged (default), so DTM.tif bytes are byte-identical. The package README reports the Measured/Interpolated/Unsupported coverage split, tallied from the same array the raster serializes.

Purely additive: no terrain, interpolation, or surface value is read or altered. Existing deliverables change only in the README (new coverage lines) and SHA256SUMS (the new file plus the README's hash).

Tests (tests/demExport.test.ts): Support.tif is present, single-band uint8 with values in {0,1,2} matching dtm.coverage (north-row-first), its grid/CRS/ModelPixelScale/ModelTiepoint match DTM.tif, and the README percentages sum to ~100.

Verify: tsc --noEmit 0; deliverable + manifest suites pass; lint-claims-language 0.