### PR TITLE
feat(e5): authoritative WESM acquisition provenance for E5 inputs

### DIFF
--- a/scripts/e5/build-input-manifest.mjs
+++ b/scripts/e5/build-input-manifest.mjs
@@ -19,8 +19,15 @@
  */
 import { readdirSync, readFileSync, writeFileSync, statSync, createReadStream } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { resolve, basename, join } from 'node:path';
+import { resolve, basename, join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// Authoritative acquisition provenance (USGS 3DEP WESM), derived from WESM.csv
+// which is not vendored. The LAS header carries no acquisition date, so the ONLY
+// acquisition source is this ledger — never the filename or a LAS creation stamp.
+const WESM_LEDGER = resolve(HERE, '../../validation/e5/manifests/wesm-acquisition.json');
 
 const [, , dir, collectionId, role, out] = process.argv;
 if (!dir || !collectionId || !role || !out) {
@@ -83,6 +90,51 @@ function readHeader(path) {
   };
 }
 
+/**
+ * Look up the authoritative WESM acquisition entry for a collection. Returns the
+ * matching ledger entry, or null when the collection is not in the ledger (then
+ * acquisition stays the explicit `not-established` unknown from the header pass).
+ */
+function wesmEntryFor(collectionId) {
+  let ledger;
+  try {
+    ledger = JSON.parse(readFileSync(WESM_LEDGER, 'utf8'));
+  } catch {
+    return null;
+  }
+  const found = (ledger.collections ?? []).find((c) => c.collectionId === collectionId);
+  return found ?? null;
+}
+
+/**
+ * Merge WESM acquisition provenance into the tiles + summary. Only the
+ * acquisition fields change: acquisitionYear (single integer only when the whole
+ * collection window is one calendar year, else null) and acquisitionDateSource,
+ * plus a summary-level acquisition block carrying the authoritative window,
+ * project id, work units and QL. Never touches sha256/EPSG/geoid/counts, so the
+ * collectionDigest is unaffected.
+ */
+function mergeWesmAcquisition(tiles, summary, collectionId) {
+  const e = wesmEntryFor(collectionId);
+  if (!e) {
+    process.stderr.write(`  (no WESM entry for ${collectionId}; acquisition left not-established)\n`);
+    return;
+  }
+  for (const t of tiles) {
+    t.acquisitionYear = e.acquisitionYear ?? null;
+    t.acquisitionDateSource = 'usgs-wesm';
+  }
+  summary.acquisitionYears = [e.acquisitionYear ?? null];
+  summary.acquisition = {
+    acquisitionStart: e.collectStart,
+    acquisitionEnd: e.collectEnd,
+    acquisitionSource: 'usgs-wesm',
+    projectId: e.projectId,
+    workunits: e.workunits,
+    ql: e.ql,
+  };
+}
+
 const files = readdirSync(dir).filter((f) => /\.la[sz]$/i.test(f)).sort();
 if (files.length === 0) {
   console.error(`no LAS/LAZ files in ${dir}`);
@@ -128,6 +180,11 @@ const summary = {
     uniq((t) => t.verticalEpsg).length === 1 &&
     uniq((t) => t.geoidModel).length === 1,
 };
+
+// Overlay authoritative WESM acquisition provenance (offline; from the ledger,
+// not the LAS headers). Keeps a regenerated manifest consistent with the
+// committed one on the acquisition fields.
+mergeWesmAcquisition(tiles, summary, collectionId);
 
 const manifest = {
   $schemaNote:

--- a/scripts/e5/verify-input-manifest.mjs
+++ b/scripts/e5/verify-input-manifest.mjs
@@ -19,6 +19,17 @@
  * acquisitionYear is present (possibly null) with an acquisitionDateSource, and
  * the summary never relabels a creation year as an acquisition year.
  *
+ * A non-null acquisitionYear must name an authoritative acquisitionDateSource
+ * (the WESM provider manifest), never the `not-established` placeholder — a year
+ * is only ever recorded when the provider established it.
+ *
+ * When the WESM acquisition ledger is supplied, the verifier cross-checks it
+ * against the manifest: the authoritative horizontal/vertical EPSG and geoid must
+ * equal the manifest's single homogeneous frame (this is what proves the Houston
+ * collection is work units 1-3 at 6344 / GEOID18, not unit 4 at 6343 / GEOID12B),
+ * every tile's acquisitionYear equals the ledger year, and any summary acquisition
+ * block agrees with the ledger's window, project id, work units and QL.
+ *
  * A missing manifest file is a loud failure, never a silent pass.
  */
 import { readFileSync } from 'node:fs';
@@ -37,6 +48,9 @@ export const EXPECTED = {
 };
 
 const HEX64 = /^[0-9a-f]{64}$/;
+
+/** Acquisition sources the gate accepts for a non-null acquisitionYear. */
+export const AUTHORITATIVE_ACQ_SOURCES = new Set(['usgs-wesm']);
 
 /** tileId is the last underscore-delimited token of the basename (sans .la[sz]). */
 export function tileIdOf(basename) {
@@ -57,7 +71,7 @@ export function collectionDigestOf(tiles) {
  * Check one parsed manifest. Returns { ok, errors[], summary }. Pure: no I/O,
  * so tests can feed crafted objects.
  */
-export function verifyManifest(manifest, { expectedCount } = {}) {
+export function verifyManifest(manifest, { expectedCount, wesm } = {}) {
   const errors = [];
   const fail = (m) => errors.push(m);
 
@@ -138,6 +152,13 @@ export function verifyManifest(manifest, { expectedCount } = {}) {
     }
     if (typeof t.acquisitionDateSource !== 'string' || t.acquisitionDateSource === '') {
       fail(`${b}: acquisitionDateSource is required`);
+    } else if (Number.isInteger(t.acquisitionYear) && !AUTHORITATIVE_ACQ_SOURCES.has(t.acquisitionDateSource)) {
+      // A recorded year must come from an authoritative provider, never the
+      // not-established placeholder or any other unestablished source.
+      fail(
+        `${b}: acquisitionYear ${t.acquisitionYear} needs an authoritative acquisitionDateSource ` +
+          `(one of ${[...AUTHORITATIVE_ACQ_SOURCES].join(', ')}), got "${t.acquisitionDateSource}"`,
+      );
     }
   }
 
@@ -219,6 +240,56 @@ export function verifyManifest(manifest, { expectedCount } = {}) {
     }
   }
 
+  // WESM ledger cross-check: the authoritative provider frame must equal the
+  // manifest's single homogeneous frame, and the recorded acquisition must match
+  // the ledger. Only runs when a ledger entry is supplied.
+  if (wesm && typeof wesm === 'object') {
+    const single = (sel, label, expected) => {
+      const set = new Set(tiles.map(sel));
+      if (!(set.size === 1 && set.has(expected))) {
+        fail(`WESM ${label} mismatch: ledger ${expected}, members [${[...set].join(', ')}]`);
+      }
+    };
+    single((t) => t.horizontalEpsg, 'horizontalEpsg', wesm.horizontalEpsg);
+    single((t) => t.verticalEpsg, 'verticalEpsg', wesm.verticalEpsg);
+    single((t) => t.geoidModel, 'geoidModel', wesm.geoidModel);
+
+    const ledgerYear = wesm.acquisitionYear ?? null;
+    for (const t of tiles) {
+      const y = t.acquisitionYear ?? null;
+      if (y !== ledgerYear) {
+        fail(`${t.basename ?? '(no basename)'}: acquisitionYear ${y} ≠ WESM ledger ${ledgerYear}`);
+      }
+    }
+    if (summary && Array.isArray(summary.acquisitionYears)) {
+      const ay = summary.acquisitionYears;
+      if (!(ay.length === 1 && (ay[0] ?? null) === ledgerYear)) {
+        fail(`summary.acquisitionYears ${JSON.stringify(ay)} ≠ WESM ledger [${ledgerYear}]`);
+      }
+    }
+    const acq = summary && summary.acquisition;
+    if (acq && typeof acq === 'object') {
+      if (acq.acquisitionSource !== 'usgs-wesm') {
+        fail(`summary.acquisition.acquisitionSource must be "usgs-wesm", got "${acq.acquisitionSource}"`);
+      }
+      if (acq.projectId !== wesm.projectId) {
+        fail(`summary.acquisition.projectId ${acq.projectId} ≠ WESM ledger ${wesm.projectId}`);
+      }
+      if (acq.ql !== wesm.ql) fail(`summary.acquisition.ql "${acq.ql}" ≠ WESM ledger "${wesm.ql}"`);
+      if (acq.acquisitionStart !== wesm.collectStart) {
+        fail(`summary.acquisition.acquisitionStart "${acq.acquisitionStart}" ≠ WESM ledger "${wesm.collectStart}"`);
+      }
+      if (acq.acquisitionEnd !== wesm.collectEnd) {
+        fail(`summary.acquisition.acquisitionEnd "${acq.acquisitionEnd}" ≠ WESM ledger "${wesm.collectEnd}"`);
+      }
+      const lw = Array.isArray(wesm.workunits) ? wesm.workunits : [];
+      const aw = Array.isArray(acq.workunits) ? acq.workunits : [];
+      if (aw.length !== lw.length || aw.some((w, i) => w !== lw[i])) {
+        fail(`summary.acquisition.workunits [${aw.join(', ')}] ≠ WESM ledger [${lw.join(', ')}]`);
+      }
+    }
+  }
+
   return {
     ok: errors.length === 0,
     errors,
@@ -231,9 +302,28 @@ export function verifyManifest(manifest, { expectedCount } = {}) {
   };
 }
 
+/** The authoritative WESM acquisition ledger, keyed by collectionId. */
+export const WESM_LEDGER = resolve(MANIFEST_DIR, 'wesm-acquisition.json');
+
+/** Load the WESM ledger as a collectionId→entry map. A missing/broken ledger is
+ * a loud failure — the acquisition cross-check depends on it. */
+export function loadWesmLedger(path = WESM_LEDGER) {
+  const ledger = JSON.parse(readFileSync(path, 'utf8'));
+  const map = new Map();
+  for (const c of ledger.collections ?? []) map.set(c.collectionId, c);
+  return map;
+}
+
 /** Read + verify every pinned manifest. Returns true when all pass. */
 export function verifyAll(dir = MANIFEST_DIR) {
   let allOk = true;
+  let wesmMap;
+  try {
+    wesmMap = loadWesmLedger(resolve(dir, 'wesm-acquisition.json'));
+  } catch (e) {
+    console.error(`FAIL: cannot read WESM acquisition ledger — ${e.message}`);
+    return false;
+  }
   for (const [id, { file, expectedCount }] of Object.entries(EXPECTED)) {
     const path = resolve(dir, file);
     let manifest;
@@ -244,7 +334,13 @@ export function verifyAll(dir = MANIFEST_DIR) {
       allOk = false;
       continue;
     }
-    const { ok, errors, summary } = verifyManifest(manifest, { expectedCount });
+    const wesm = wesmMap.get(id);
+    if (!wesm) {
+      console.error(`FAIL ${id}: no WESM ledger entry for this collection`);
+      allOk = false;
+      continue;
+    }
+    const { ok, errors, summary } = verifyManifest(manifest, { expectedCount, wesm });
     if (ok) {
       console.log(
         `PASS ${id}: ${summary.tiles} tiles, digest ok, ` +

--- a/tests/e5ManifestMetadata.test.ts
+++ b/tests/e5ManifestMetadata.test.ts
@@ -4,9 +4,9 @@
  * Two metadata errors are pinned closed here. First, the geoid identifier must
  * survive in full: a WKT that says GEOID12B must not be recorded as GEOID12 — the
  * revision letter changes which model was applied. Second, the LAS header
- * creation date is not the acquisition date; the manifest must name it as
- * creation and leave acquisition an explicit unknown, never presenting a 2021
- * file-write as the 2019 Rogue flight.
+ * creation date is not the acquisition date; the manifest names it as creation
+ * and records acquisition from the authoritative USGS WESM provider metadata (the
+ * 2019 Rogue flight), never presenting the 2021 file-write as the flight year.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -31,9 +31,9 @@ describe('E5 manifest metadata correctness', () => {
     expect(parseGeoid('...Geoid12...')).toBe('GEOID12'); // no letter → no invented one
   });
 
-  for (const [name, expectedGeoid, expectedFrame] of [
-    ['ROGUE25', 'GEOID12B', 6339],
-    ['HOUSTON17', 'GEOID18', 6344],
+  for (const [name, expectedGeoid, expectedFrame, expectedAcqYear] of [
+    ['ROGUE25', 'GEOID12B', 6339, 2019],
+    ['HOUSTON17', 'GEOID18', 6344, null],
   ] as const) {
     const m = load(name);
 
@@ -42,13 +42,18 @@ describe('E5 manifest metadata correctness', () => {
       for (const t of m.tiles) expect(t.geoidModel).toBe(expectedGeoid);
     });
 
-    it(`${name} names LAS creation date as creation, not acquisition`, () => {
+    it(`${name} names LAS creation date as creation, and acquisition from WESM`, () => {
       expect(m.summary).not.toHaveProperty('captureYears');
       for (const t of m.tiles) {
         expect(t).not.toHaveProperty('captureYear');
         expect(t).toHaveProperty('fileCreationYear');
-        expect(t.acquisitionYear).toBeNull();
-        expect(t.acquisitionDateSource).toBe('not-established');
+        // Acquisition is sourced authoritatively from USGS WESM (the provider
+        // work-unit metadata), never the LAS creation field: Rogue's 2019 flight;
+        // Houston's window crosses a calendar year, so its single year stays null.
+        expect(t.acquisitionYear).toBe(expectedAcqYear);
+        expect(t.acquisitionDateSource).toBe('usgs-wesm');
+        // The file-write year is never presented as the acquisition year.
+        if (t.acquisitionYear !== null) expect(t.acquisitionYear).not.toBe(t.fileCreationYear);
       }
     });
 

--- a/tests/e5ManifestVerify.test.ts
+++ b/tests/e5ManifestVerify.test.ts
@@ -10,11 +10,13 @@ import {
   verifyManifest,
   collectionDigestOf,
   tileIdOf,
+  loadWesmLedger,
   // @ts-expect-error — plain .mjs verifier, no type declarations.
 } from '../scripts/e5/verify-input-manifest.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MDIR = resolve(ROOT, 'validation/e5/manifests');
+const WESM = loadWesmLedger(resolve(MDIR, 'wesm-acquisition.json')) as Map<string, Record<string, unknown>>;
 
 /** A minimal but internally consistent two-tile manifest. */
 function goodManifest() {
@@ -236,12 +238,75 @@ describe('E5 manifest verifier', () => {
     expect(r.errors.join('\n')).toMatch(/allTilesHaveGround=false but 0 tile/);
   });
 
+  it('catches a non-null acquisitionYear left as not-established', () => {
+    const m = goodManifest();
+    (m.tiles[0] as Record<string, unknown>).acquisitionYear = 2019; // year but placeholder source
+    m.summary.acquisitionYears = [2019];
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/needs an authoritative acquisitionDateSource/);
+  });
+
+  it('accepts a non-null acquisitionYear with an authoritative source', () => {
+    const m = goodManifest();
+    for (const t of m.tiles) {
+      (t as Record<string, unknown>).acquisitionYear = 2019; // window year, distinct from creation 2021
+      t.acquisitionDateSource = 'usgs-wesm';
+    }
+    m.summary.acquisitionYears = [2019];
+    const r = verifyManifest(m, { expectedCount: 2 });
+    expect(r.errors).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it('cross-checks a matching WESM frame', () => {
+    const m = goodManifest();
+    const wesm = {
+      horizontalEpsg: 6339,
+      verticalEpsg: 5703,
+      geoidModel: 'GEOID12B',
+      acquisitionYear: null,
+    };
+    const r = verifyManifest(m, { expectedCount: 2, wesm });
+    expect(r.errors).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it('catches a WESM geoid mismatch (guards Houston units 1-3 vs unit 4)', () => {
+    const m = goodManifest();
+    const wesm = {
+      horizontalEpsg: 6339,
+      verticalEpsg: 5703,
+      geoidModel: 'GEOID18', // ledger disagrees with the members' GEOID12B
+      acquisitionYear: null,
+    };
+    const r = verifyManifest(m, { expectedCount: 2, wesm });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/WESM geoidModel mismatch/);
+  });
+
+  it('catches an acquisitionYear that disagrees with the WESM ledger', () => {
+    const m = goodManifest();
+    const wesm = {
+      horizontalEpsg: 6339,
+      verticalEpsg: 5703,
+      geoidModel: 'GEOID12B',
+      acquisitionYear: 2019, // ledger says 2019, tiles say null
+    };
+    const r = verifyManifest(m, { expectedCount: 2, wesm });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/acquisitionYear .* ≠ WESM ledger 2019/);
+  });
+
   it.each([
-    ['ROGUE25.input.json', 25],
-    ['HOUSTON17.input.json', 17],
-  ])('committed manifest %s passes', (file, count) => {
-    const m = JSON.parse(readFileSync(resolve(MDIR, file), 'utf8'));
-    const r = verifyManifest(m, { expectedCount: count });
+    ['ROGUE25.input.json', 25, 'ROGUE25', 2019],
+    ['HOUSTON17.input.json', 17, 'HOUSTON17', null],
+  ])('committed manifest %s passes with its WESM ledger', (file, count, id, year) => {
+    const m = JSON.parse(readFileSync(resolve(MDIR, file as string), 'utf8'));
+    const wesm = WESM.get(id as string);
+    expect(wesm).toBeTruthy();
+    expect((wesm as Record<string, unknown>).acquisitionYear ?? null).toBe(year);
+    const r = verifyManifest(m, { expectedCount: count, wesm });
     expect(r.errors).toEqual([]);
     expect(r.ok).toBe(true);
   });

--- a/validation/e5/manifests/HOUSTON17.input.json
+++ b/validation/e5/manifests/HOUSTON17.input.json
@@ -36,7 +36,19 @@
     ],
     "acquisitionYears": [
       null
-    ]
+    ],
+    "acquisition": {
+      "acquisitionStart": "2024-02-18",
+      "acquisitionEnd": "2025-01-31",
+      "acquisitionSource": "usgs-wesm",
+      "projectId": 300203,
+      "workunits": [
+        "TX_Houston_1_B24",
+        "TX_Houston_2_B24",
+        "TX_Houston_3_B24"
+      ],
+      "ql": "QL 1"
+    }
   },
   "tiles": [
     {
@@ -75,7 +87,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260194.laz",
@@ -113,7 +125,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260195.laz",
@@ -151,7 +163,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260196.laz",
@@ -189,7 +201,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260197.laz",
@@ -227,7 +239,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260198.laz",
@@ -265,7 +277,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM260199.laz",
@@ -303,7 +315,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261193.laz",
@@ -341,7 +353,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261194.laz",
@@ -379,7 +391,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261195.laz",
@@ -417,7 +429,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261196.laz",
@@ -455,7 +467,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261197.laz",
@@ -493,7 +505,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261198.laz",
@@ -531,7 +543,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM261199.laz",
@@ -569,7 +581,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM262193.laz",
@@ -605,7 +617,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM262194.laz",
@@ -643,7 +655,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_TX_Houston_B24_15RTM262195.laz",
@@ -681,7 +693,7 @@
       "fileCreationYear": 2025,
       "fileCreationDayOfYear": 175,
       "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionDateSource": "usgs-wesm"
     }
   ]
 }

--- a/validation/e5/manifests/ROGUE25.input.json
+++ b/validation/e5/manifests/ROGUE25.input.json
@@ -33,8 +33,18 @@
       2021
     ],
     "acquisitionYears": [
-      null
-    ]
+      2019
+    ],
+    "acquisition": {
+      "acquisitionStart": "2019-10-05",
+      "acquisitionEnd": "2019-10-10",
+      "acquisitionSource": "usgs-wesm",
+      "projectId": 182543,
+      "workunits": [
+        "OR_RogueRiverSiskiyouNF_B1_2019"
+      ],
+      "ql": "QL 1"
+    }
   },
   "tiles": [
     {
@@ -70,8 +80,8 @@
       "groundPointFraction": 0.101884,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 15,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3746.laz",
@@ -106,8 +116,8 @@
       "groundPointFraction": 0.0392,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 15,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3846.laz",
@@ -142,8 +152,8 @@
       "groundPointFraction": 0.04878,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 19,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM3847.laz",
@@ -178,8 +188,8 @@
       "groundPointFraction": 0.040679,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4544.laz",
@@ -214,8 +224,8 @@
       "groundPointFraction": 0.044709,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4643.laz",
@@ -250,8 +260,8 @@
       "groundPointFraction": 0.044398,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4647.laz",
@@ -286,8 +296,8 @@
       "groundPointFraction": 0.058578,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4648.laz",
@@ -322,8 +332,8 @@
       "groundPointFraction": 0.059921,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4849.laz",
@@ -359,8 +369,8 @@
       "groundPointFraction": 0.063137,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM4853.laz",
@@ -395,8 +405,8 @@
       "groundPointFraction": 0.085954,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM5450.laz",
@@ -431,8 +441,8 @@
       "groundPointFraction": 0.06804,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM5458.laz",
@@ -467,8 +477,8 @@
       "groundPointFraction": 0.073388,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM5959.laz",
@@ -503,8 +513,8 @@
       "groundPointFraction": 0.050155,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6151.laz",
@@ -539,8 +549,8 @@
       "groundPointFraction": 0.049175,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6152.laz",
@@ -577,8 +587,8 @@
       "groundPointFraction": 0.048529,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6159.laz",
@@ -613,8 +623,8 @@
       "groundPointFraction": 0.035372,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6161.laz",
@@ -649,8 +659,8 @@
       "groundPointFraction": 0.037127,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6252.laz",
@@ -687,8 +697,8 @@
       "groundPointFraction": 0.080489,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6265.laz",
@@ -724,8 +734,8 @@
       "groundPointFraction": 0.042267,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6455.laz",
@@ -760,8 +770,8 @@
       "groundPointFraction": 0.025921,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6470.laz",
@@ -796,8 +806,8 @@
       "groundPointFraction": 0.073713,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6564.laz",
@@ -832,8 +842,8 @@
       "groundPointFraction": 0.040603,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM6762.laz",
@@ -868,8 +878,8 @@
       "groundPointFraction": 0.041221,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM7851.laz",
@@ -904,8 +914,8 @@
       "groundPointFraction": 0.077931,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     },
     {
       "basename": "USGS_LPC_OR_RogueSiskiyouNF_2019_B19_10TDM8061.laz",
@@ -940,8 +950,8 @@
       "groundPointFraction": 0.035187,
       "fileCreationYear": 2021,
       "fileCreationDayOfYear": 12,
-      "acquisitionYear": null,
-      "acquisitionDateSource": "not-established"
+      "acquisitionYear": 2019,
+      "acquisitionDateSource": "usgs-wesm"
     }
   ]
 }

--- a/validation/e5/manifests/wesm-acquisition.json
+++ b/validation/e5/manifests/wesm-acquisition.json
@@ -1,0 +1,34 @@
+{
+  "$schemaNote": "Authoritative acquisition provenance for the E5 collections, derived from USGS 3DEP WESM (Work-unit Extent Spatial Metadata). This is the provider's own record of when each work unit was flown and in which frame; it is not the raw CSV. The local WESM.csv (~2 MB) is not vendored, so only the acquisition-relevant fields for the two pinned collections are recorded here. Dates are the WESM collect_start/collect_end, canonicalised to ISO. acquisitionYear is a single integer only when the whole collection window falls in one calendar year; a window that crosses a year boundary is left null (ambiguous per tile) and the window is carried by collectStart/collectEnd. This ledger changes only provenance fields; it never enters any collectionDigest.",
+  "source": "USGS 3DEP WESM (Work-unit Extent Spatial Metadata)",
+  "collections": [
+    {
+      "collectionId": "ROGUE25",
+      "projectId": 182543,
+      "workunits": ["OR_RogueRiverSiskiyouNF_B1_2019"],
+      "collectStart": "2019-10-05",
+      "collectEnd": "2019-10-10",
+      "acquisitionYear": 2019,
+      "ql": "QL 1",
+      "horizontalEpsg": 6339,
+      "verticalEpsg": 5703,
+      "geoidModel": "GEOID12B",
+      "source": "USGS 3DEP WESM (Work-unit Extent Spatial Metadata)",
+      "sourceNote": "Authoritative provider acquisition manifest. Single work unit, collected 2019-10-05..2019-10-10 — one calendar year, so acquisitionYear is unambiguously 2019."
+    },
+    {
+      "collectionId": "HOUSTON17",
+      "projectId": 300203,
+      "workunits": ["TX_Houston_1_B24", "TX_Houston_2_B24", "TX_Houston_3_B24"],
+      "collectStart": "2024-02-18",
+      "collectEnd": "2025-01-31",
+      "acquisitionYear": null,
+      "ql": "QL 1",
+      "horizontalEpsg": 6344,
+      "verticalEpsg": 5703,
+      "geoidModel": "GEOID18",
+      "source": "USGS 3DEP WESM (Work-unit Extent Spatial Metadata)",
+      "sourceNote": "Authoritative provider acquisition manifest. The tiles verify homogeneous at horiz_crs 6344 / GEOID18, which selects work units 1-3 of project TX_Houston_B24; unit 4 (horiz_crs 6343 / GEOID12B) is a different frame and is excluded. The units 1-3 window spans 2024-02-18..2025-01-31 — two calendar years — so acquisitionYear is left null and the window is authoritative."
+    }
+  ]
+}


### PR DESCRIPTION
Upgrades the two E5 input manifests from "acquisition not-established" to authoritative acquisition provenance sourced from USGS 3DEP WESM (Work-unit Extent Spatial Metadata). Metadata-only: zero numerical change and collectionDigest of both manifests is byte-identical to main.

- New ledger `validation/e5/manifests/wesm-acquisition.json`: per collection, project id, work units, collect window, QL and frame (derived from WESM; the raw CSV is not vendored).
- ROGUE25: per-tile `acquisitionYear` 2019 (single-year window 2019-10-05..2019-10-10), `acquisitionDateSource` usgs-wesm.
- HOUSTON17: `acquisitionYear` stays null (units 1-3 window 2024-02-18..2025-01-31 crosses a calendar year), `acquisitionDateSource` usgs-wesm; the authoritative window lives in the summary block.
- Summary gains an `acquisition` block (start, end, source, projectId, workunits, ql).
- Generator merges the ledger offline into the acquisition fields; still reads LAZ headers for everything else.
- Verifier: any non-null year requires an authoritative source (never not-established); the ledger frame is cross-checked against the members, confirming Houston is units 1-3 / 6344 / GEOID18 (unit 4 at 6343 / GEOID12B is excluded).
- No tile sha256/pointCount/classHistogram/EPSG/geoid touched; no DTM/terrain change.

Verify: verifier exit 0 (both PASS), vitest tests/e5ManifestVerify.test.ts pass (27), tsc --noEmit 0, both collectionDigests identical to main.