### PR TITLE
fix(docs-site): footer states AGPL-3.0-only, not MIT

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -225,7 +225,7 @@ export default defineConfig({
     socialLinks: [{ icon: 'github', link: GITHUB }],
 
     footer: {
-      message: 'MIT licensed. Local-first: the viewer never uploads your data.',
+      message: 'AGPL-3.0-only licensed. Local-first: the viewer never uploads your data.',
       copyright: `© Aurtech — OpenLiDARViewer v${pkg.version}`,
     },
 

--- a/scripts/lint-license.mjs
+++ b/scripts/lint-license.mjs
@@ -92,6 +92,13 @@ export function checkLicense(root) {
   must(!/under the MIT license/.test(main), 'src/main.ts console banner still claims the MIT license.');
   must(/AGPL-3\.0-only license/.test(main), 'src/main.ts console banner does not name AGPL-3.0-only.');
 
+  // The docs site's VitePress theme footer. It renders on every published docs
+  // page, so a stale "MIT licensed" there is a wrong-license public declaration
+  // just like the manifest surfaces above. lint:license did not read it before.
+  const docsSiteConfig = read('docs-site/.vitepress/config.mts') || '';
+  must(!/\bMIT licensed\b/.test(docsSiteConfig), 'docs-site/.vitepress/config.mts footer still claims "MIT licensed" as the current license.');
+  must(/AGPL-3\.0-only/.test(docsSiteConfig), 'docs-site/.vitepress/config.mts footer does not name AGPL-3.0-only.');
+
   if (version) {
     const notes = read(`docs/releases/RELEASE_NOTES_v${version}.md`);
     must(notes != null, `docs/releases/RELEASE_NOTES_v${version}.md is missing.`);

--- a/tests/licenseLint.test.ts
+++ b/tests/licenseLint.test.ts
@@ -29,6 +29,7 @@ function writeValidFixture(root: string): void {
     'OpenLiDARViewer v0.6.7 and later is licensed under the GNU Affero General Public License v3.0 only (AGPL-3.0-only).',
   ].join('\n\n'));
   w('src/main.ts', 'console.log(`OpenLiDARViewer v${x} — open source under the AGPL-3.0-only license.`);\n');
+  w('docs-site/.vitepress/config.mts', "export default { themeConfig: { footer: { message: 'AGPL-3.0-only licensed. Local-first: the viewer never uploads your data.' } } };\n");
   w('docs/releases/RELEASE_NOTES_v0.6.7.md', '# v0.6.7\n## Licensing change\nFirst release under AGPL-3.0-only.\n');
 }
 
@@ -88,6 +89,14 @@ describe('lint:license boundary', () => {
     // The valid fixture's MANIFEST already carries "released under MIT through
     // v0.6.6"; that historical sentence must not trip the guard.
     expect(checkLicense(root)).toEqual([]);
+  });
+
+  it('rejects a docs-site footer that still claims MIT', () => {
+    writeFileSync(
+      resolve(root, 'docs-site/.vitepress/config.mts'),
+      "export default { themeConfig: { footer: { message: 'MIT licensed. Local-first: the viewer never uploads your data.' } } };\n",
+    );
+    expect(checkLicense(root).some((p: string) => /config\.mts footer/.test(p))).toBe(true);
   });
 
   it('rejects codemeta.json declaring the MIT SPDX URL', () => {


### PR DESCRIPTION
The VitePress docs footer read "MIT licensed. Local-first: the viewer never uploads your data." — a pre-v0.6.7 relic. The project is AGPL-3.0-only across LICENSE, package.json, README, CITATION.cff, codemeta.json, and .zenodo.json, so the footer was a wrong-licence public declaration on every published docs page.

Changes:
- Footer message now names AGPL-3.0-only.
- `scripts/lint-license.mjs` reads `docs-site/.vitepress/config.mts` and fails if the footer claims "MIT licensed" or omits AGPL-3.0-only.
- Adds a mutation test rejecting a fixture footer that claims MIT.

No version-bearing surface touched. lint:license exit 0; licenseLint.test.ts passes (13); tsc --noEmit clean.