### PR TITLE
fix(intelligence): tier flat scans by areal density

### DIFF
--- a/src/app/inspectorCardRefreshers.ts
+++ b/src/app/inspectorCardRefreshers.ts
@@ -86,6 +86,39 @@ export interface InspectorCardRefreshers {
   noteTerrainComplexity(derived: DerivedComplexity | null): void;
 }
 
+/** The CRS fields the unit conversions below read. */
+type UnitCrs =
+  | { readonly linearUnit?: string; readonly linearUnitToMetres?: number; readonly verticalUnitToMetres?: number }
+  | null
+  | undefined;
+
+/**
+ * The bbox spans `[x, y, z]` in METRES, or `undefined` under the same
+ * fail-closed unit gate as {@link metresCubedBbox}. The spans carry the SHAPE
+ * the volume alone loses: a wide, thin airborne swath and a compact tower can
+ * share a volume, and only the former should be tiered on points per m².
+ * A zero vertical span is kept (a perfectly flat sheet is still a valid
+ * footprint); a zero horizontal span is not, since it has no area.
+ */
+function metresBboxSpans(
+  dx: number,
+  dy: number,
+  dz: number,
+  crs: UnitCrs,
+): [number, number, number] | undefined {
+  if (!isLinearUnitKnown(crs)) return undefined;
+  const mpu = crs?.linearUnitToMetres;
+  if (!Number.isFinite(mpu) || (mpu as number) <= 0) return undefined;
+  const vmpuRaw = crs?.verticalUnitToMetres ?? mpu;
+  if (!Number.isFinite(vmpuRaw) || (vmpuRaw as number) <= 0) return undefined;
+  const sx = dx * (mpu as number);
+  const sy = dy * (mpu as number);
+  const sz = dz * (vmpuRaw as number);
+  if (!Number.isFinite(sx) || !Number.isFinite(sy) || !Number.isFinite(sz)) return undefined;
+  if (sx <= 0 || sy <= 0 || sz < 0) return undefined;
+  return [sx, sy, sz];
+}
+
 /**
  * The bounding-box volume in cubic METRES, or `undefined` when the CRS declares
  * no usable linear unit. FAIL CLOSED: an unknown-unit CRS carries the inert
@@ -101,17 +134,11 @@ function metresCubedBbox(
   dx: number,
   dy: number,
   dz: number,
-  crs:
-    | { readonly linearUnit?: string; readonly linearUnitToMetres?: number; readonly verticalUnitToMetres?: number }
-    | null
-    | undefined,
+  crs: UnitCrs,
 ): number | undefined {
-  if (!isLinearUnitKnown(crs)) return undefined;
-  const mpu = crs?.linearUnitToMetres;
-  if (!Number.isFinite(mpu) || (mpu as number) <= 0) return undefined;
-  const vmpuRaw = crs?.verticalUnitToMetres ?? mpu;
-  if (!Number.isFinite(vmpuRaw) || (vmpuRaw as number) <= 0) return undefined;
-  const v = dx * dy * dz * (mpu as number) * (mpu as number) * (vmpuRaw as number);
+  const spans = metresBboxSpans(dx, dy, dz, crs);
+  if (!spans) return undefined;
+  const v = spans[0] * spans[1] * spans[2];
   return Number.isFinite(v) && v > 0 ? v : undefined;
 }
 
@@ -210,9 +237,11 @@ export function createInspectorCardRefreshers(
       // CRS declares a REAL linear unit. An unknown-unit CRS carries the inert
       // placeholder factor 1, so multiplying by it would feed raw source-unit³
       // (feet³, degrees³) into the per-m³ bucketing and mis-tier the density.
-      // When the unit is unconfirmed, `bboxVolume` is left undefined and
-      // `classifyDensity` renders "—" rather than a wrong tier.
-      const bboxVolume = metresCubedBbox(dx, dy, dz, resolvedCrs ? resolvedCrs() : cloud.metadata?.crs);
+      // When the unit is unconfirmed, both the volume and the spans are left
+      // undefined and the density row renders "—" rather than a wrong tier.
+      const crsForUnits = resolvedCrs ? resolvedCrs() : cloud.metadata?.crs;
+      const bboxSpansM = metresBboxSpans(dx, dy, dz, crsForUnits);
+      const bboxVolume = metresCubedBbox(dx, dy, dz, crsForUnits);
       // Density numerator is the file's declared total, back-scaled when the
       // loader strided for display — matching the Scan Report, not the smaller
       // in-memory sample that would under-report the tier.
@@ -221,6 +250,11 @@ export function createInspectorCardRefreshers(
       const summary: Parameters<Inspector['setDatasetIntelligence']>[0] = {
         pointCount: n,
         bboxVolume,
+        // The spans let the summariser tier a flat airborne tile on points per
+        // footprint m². Per-m³ alone reads a wide thin swath as "Sparse" even
+        // when its pts/m² is a comfortable QL1, because most of the bounding
+        // box is empty air between the ground and the flight line.
+        bboxSpansM,
         coverageMeta: {
           coverage: 'full',
           sourcePointCount: n,
@@ -262,6 +296,7 @@ export function createInspectorCardRefreshers(
       const hMin = cloud.metadata?.header?.min;
       const hMax = cloud.metadata?.header?.max;
       let bboxVolume: number | undefined;
+      let bboxSpansM: [number, number, number] | undefined;
       if (hMin && hMax && hMin.length >= 3 && hMax.length >= 3) {
         const dx = hMax[0] - hMin[0];
         const dy = hMax[1] - hMin[1];
@@ -271,13 +306,17 @@ export function createInspectorCardRefreshers(
         // the per-m³ bucketing dropped a genuine QL1 survey a whole tier. The
         // header carries source units; the CRS carries the factors. FAIL CLOSED
         // on the unit exactly as the static path does — an unknown-unit CRS
-        // leaves `bboxVolume` undefined rather than feeding raw feet³ / degrees³
-        // into the per-m³ bucketing.
-        bboxVolume = metresCubedBbox(dx, dy, dz, resolvedCrs ? resolvedCrs() : (cloud.crs?.() ?? null));
+        // leaves the volume and the spans undefined rather than feeding raw
+        // feet³ / degrees³ into the bucketing.
+        const crsForUnits = resolvedCrs ? resolvedCrs() : (cloud.crs?.() ?? null);
+        bboxSpansM = metresBboxSpans(dx, dy, dz, crsForUnits);
+        bboxVolume = metresCubedBbox(dx, dy, dz, crsForUnits);
       }
       const summary = {
         pointCount: sourcePoints,
         bboxVolume,
+        // Same reason as the static path: a flat swath is tiered on pts/m².
+        bboxSpansM,
         coverageMeta: {
           coverage: 'resident-only' as const,
           sourcePointCount: sourcePoints ?? 0,

--- a/src/intelligence/scanStory.ts
+++ b/src/intelligence/scanStory.ts
@@ -25,6 +25,7 @@
  */
 
 import type {
+  DensityBasis,
   DensityBucket,
   GroundVisibilityBucket,
   CoverageBucket,
@@ -55,6 +56,12 @@ export interface ScanStoryInputs {
   readonly products?: readonly StoryProduct[];
   /** Dataset-intelligence buckets. */
   readonly density?: DensityBucket;
+  /**
+   * Which measure the density tier came from. A flat scan is tiered on points
+   * per m², so the row is named for that rather than claiming pts/m³. Absent
+   * reads as volumetric, the historical behaviour.
+   */
+  readonly densityBasis?: DensityBasis;
   readonly groundVisibility?: GroundVisibilityBucket;
   readonly coverageMode?: CoverageBucket | 'unknown';
   /** Georeferencing knowledge. */
@@ -177,6 +184,18 @@ function notEstablished(i: ScanStoryInputs): string[] {
   return out;
 }
 
+/**
+ * The story's density fields from a Dataset Intelligence reading. Kept here so
+ * the bucket and the measure behind it always travel together — a tier shown
+ * without its basis is what lets a pts/m² number get labelled "volumetric".
+ */
+export function densityStoryFields(
+  density: { readonly bucket: DensityBucket; readonly basis: DensityBasis } | undefined,
+): Pick<ScanStoryInputs, 'density' | 'densityBasis'> {
+  if (!density) return {};
+  return { density: density.bucket, densityBasis: density.basis };
+}
+
 export function buildScanStory(i: ScanStoryInputs): ScanStory {
   const area = formatArea(i.areaM2);
   const captureLabel = i.captureLabel ?? 'Point cloud';
@@ -262,7 +281,7 @@ export function buildExportHealth(i: ScanStoryInputs): ExportHealth {
   if (i.density && i.density !== 'unknown') {
     const label = i.density.replace('-', ' ');
     rows.push({
-      label: 'Volumetric point density',
+      label: i.densityBasis === 'areal' ? 'Areal point density' : 'Volumetric point density',
       value: label.charAt(0).toUpperCase() + label.slice(1),
       tier: i.density === 'sparse' ? 'caution' : 'good',
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,7 +102,7 @@ import { deriveClassificationAsync } from './render/class/deriveClassificationAs
 import { classifierOptions } from './render/class/classifierCues';
 import { classificationCoverage } from './render/class/classificationCoverage';
 import type { DeriveClassificationOptions } from './render/class/deriveClassification';
-import { footprintAreaM2, type ScanStoryInputs } from './intelligence/scanStory';
+import { densityStoryFields, footprintAreaM2, type ScanStoryInputs } from './intelligence/scanStory';
 import { fullScope, scopeFrom, scopeStamp, notScopedSentinel, type ClassScope } from './render/class/classScope';
 import { classificationLabel } from './render/pointInfo';
 // ObjectPanel is lazy-mounted on first scan load (v0.6 P1, step 2): only the
@@ -1704,7 +1704,7 @@ function buildCurrentStoryInputs(): ScanStoryInputs {
     areaM2,
     surfaceTier: facts?.surfaceTier,
     products: facts?.products,
-    density: di?.density.bucket,
+    ...densityStoryFields(di?.density),
     groundVisibility: di?.groundVisibility.bucket,
     coverageMode: di?.coverage.bucket,
     crsKnown: facts?.crsKnown ?? metaCrsKnown,

--- a/src/render/streaming/sampleGrade.ts
+++ b/src/render/streaming/sampleGrade.ts
@@ -17,10 +17,10 @@
  *   • VERTICAL EXTENT — the real min/max Z of the sample, for a height-span read
  *     the header's nominal bounds (which can be padded) doesn't guarantee.
  *
- * The density TIER reuses {@link classifyDensity} (points per cubic metre, the
- * app's existing convention) so a streaming grade and a static grade speak the
- * same language. The back-scale (`samplePointScale`, ≥ 1) lifts the sample's
- * density to the whole cloud, exactly as the preview scales a strided gather.
+ * The density TIER reuses {@link chooseDensityTier} (the shared areal / per-m³
+ * bands) so a streaming grade and a static grade speak the same language. The
+ * back-scale (`samplePointScale`, ≥ 1) lifts the sample's density to the whole
+ * cloud, exactly as the preview scales a strided gather.
  *
  * Pure data: no DOM, no three.js, no I/O. Deterministic. The honesty label
  * (exhaustive vs sampled, coverage %) is the runner's `coverage`, kept separate
@@ -28,18 +28,24 @@
  *
  * UNIT NOTE: positions are in the source CRS's linear unit. `metresPerUnit`
  * converts spans to metres so the densities read in SI; it defaults to 1
- * (the common projected-metres case). The classifyDensity bands are
+ * (the common projected-metres case). The density bands are
  * deliberately wide, so a modest unit error shifts a number, not a verdict.
  */
 
 import {
-  classifyDensity,
+  chooseDensityTier,
   densityLabel,
+  isTallExtent,
+  type DensityBasis,
   type DensityBucket,
 } from '../../terrain/datasetIntelligence';
 
-/** Which density measure drove the headline tier. */
-export type DensityBasis = 'areal' | 'volumetric' | 'none';
+// The areal band table, the flat/tall split and the tier choice live in
+// datasetIntelligence so the static header-derived card reads a flat swath the
+// same way this grade does. Re-exported here for the callers that already
+// import them from this module.
+export { classifyArealDensity } from '../../terrain/datasetIntelligence';
+export type { DensityBasis };
 
 /** The geometric grade of a decoded full-cloud sample. */
 export interface SampleGrade {
@@ -84,24 +90,6 @@ export interface SampleGrade {
   readonly bucketLabel: string;
   /** Which measure {@link bucket} came from — so the summary labels its unit. */
   readonly bucketBasis: DensityBasis;
-}
-
-/**
- * Tier an AREAL point density (points per m²) using bands aligned to the USGS
- * 3DEP nominal density floors the rest of the app references (QL2 ≥ 2 pts/m²,
- * QL1 ≥ 8). The output is a density word, never a quality level: below the QL2
- * floor is sparse, between the floors moderate, above QL1 dense, and
- * terrestrial / very
- * low-altitude drone (≳ 50 pts/m²) very dense. Reuses {@link DensityBucket} so
- * the streaming grade speaks the same Sparse/Moderate/Dense language as the
- * static path. Returns 'unknown' for a non-finite or non-positive density.
- */
-export function classifyArealDensity(pointsPerM2: number): DensityBucket {
-  if (!Number.isFinite(pointsPerM2) || pointsPerM2 <= 0) return 'unknown';
-  if (pointsPerM2 < 2) return 'sparse';
-  if (pointsPerM2 < 8) return 'moderate';
-  if (pointsPerM2 < 50) return 'dense';
-  return 'very-dense';
 }
 
 /** Minimum points before an occupancy ratio is meaningful rather than noise. */
@@ -211,29 +199,13 @@ export function gradeSampleDensity(
   // ── Choose the headline tier ──
   // Flat clouds (vertical span much smaller than the footprint) read truest by
   // AREA: a thin aerial swath has a low per-m³ density that misclassifies as
-  // sparse. Tall clouds (interiors, façades — vertical span comparable to the
-  // footprint) read truest by VOLUME. The 0.5 threshold splits the two.
-  const minHoriz = Math.min(spanX, spanY);
-  const isTall = minHoriz > 0 && spanZ > 0.5 * minHoriz;
-  const arealBucket = arealDensityPerM2 != null ? classifyArealDensity(arealDensityPerM2) : 'unknown';
-  const volumetricBucket =
-    volumetricDensityPerM3 != null ? classifyDensity({ residentDensity: volumetricDensityPerM3 }) : 'unknown';
-
-  let bucket: DensityBucket;
-  let bucketBasis: DensityBasis;
-  if (!isTall && arealBucket !== 'unknown') {
-    bucket = arealBucket;
-    bucketBasis = 'areal';
-  } else if (volumetricBucket !== 'unknown') {
-    bucket = volumetricBucket;
-    bucketBasis = 'volumetric';
-  } else if (arealBucket !== 'unknown') {
-    bucket = arealBucket;
-    bucketBasis = 'areal';
-  } else {
-    bucket = 'unknown';
-    bucketBasis = 'none';
-  }
+  // sparse. Tall clouds (interiors, façades) read truest by VOLUME. The split
+  // and the bands are shared with the static card (see `chooseDensityTier`).
+  const { bucket, basis: bucketBasis } = chooseDensityTier({
+    arealDensityPerM2,
+    volumetricDensityPerM3,
+    isTall: isTallExtent(spanX, spanY, spanZ),
+  });
 
   return {
     sampledPoints: n,

--- a/src/terrain/datasetIntelligence.ts
+++ b/src/terrain/datasetIntelligence.ts
@@ -147,6 +147,15 @@ export interface DatasetIntelligenceInput {
    */
   readonly bboxVolume?: number;
   /**
+   * Bounding-box spans `[x, y, z]` in METRES. Optional, and only supplied when
+   * the source CRS declares a real linear unit (same fail-closed gate as
+   * `bboxVolume`). With the spans in hand the summariser can tell a flat
+   * airborne swath from a tall interior scan and tier the flat one on points
+   * per footprint m², which is the figure a surveyor reads. Without them the
+   * density reading falls back to the volume-only estimate.
+   */
+  readonly bboxSpansM?: readonly [number, number, number];
+  /**
    * Average resident-neighbour density (points per metre cubed)
    * measured by a sampled pass. Optional — when present
    * it overrides the bbox-derived estimate.
@@ -199,7 +208,16 @@ export interface DerivedComplexity {
 
 /** The summarised, presentation-ready view. */
 export interface DatasetIntelligence {
-  readonly density: { readonly bucket: DensityBucket; readonly label: string };
+  readonly density: {
+    readonly bucket: DensityBucket;
+    readonly label: string;
+    /**
+     * Which measure produced the tier. The card and the scan story name the
+     * row after this, so an areal reading is never presented as a volumetric
+     * one.
+     */
+    readonly basis: DensityBasis;
+  };
   readonly complexity: {
     readonly bucket: ComplexityBucket;
     readonly label: string;
@@ -271,6 +289,130 @@ export function classifyDensity(
   if (candidate < 40) return 'moderate';
   if (candidate < 400) return 'dense';
   return 'very-dense';
+}
+
+/** Which density measure drove a headline density tier. */
+export type DensityBasis = 'areal' | 'volumetric' | 'none';
+
+/**
+ * Tier an AREAL point density (points per m²) using bands aligned to the USGS
+ * 3DEP nominal density floors the rest of the app references (QL2 ≥ 2 pts/m²,
+ * QL1 ≥ 8). The output is a density word, never a quality level: below the QL2
+ * floor is sparse, between the floors moderate, above QL1 dense, and
+ * terrestrial / very low-altitude drone (≳ 50 pts/m²) very dense. Shares
+ * {@link DensityBucket} with {@link classifyDensity} so an areal reading and a
+ * volumetric one speak the same Sparse/Moderate/Dense language. Returns
+ * 'unknown' for a non-finite or non-positive density.
+ */
+export function classifyArealDensity(pointsPerM2: number): DensityBucket {
+  if (!Number.isFinite(pointsPerM2) || pointsPerM2 <= 0) return 'unknown';
+  if (pointsPerM2 < 2) return 'sparse';
+  if (pointsPerM2 < 8) return 'moderate';
+  if (pointsPerM2 < 50) return 'dense';
+  return 'very-dense';
+}
+
+/**
+ * Vertical-to-horizontal span ratio at which a cloud stops reading as flat.
+ * Above it the scene has real vertical structure (an interior, a façade) and
+ * a per-volume density is the meaningful one; below it the scene is a sheet
+ * (an aerial swath, a terrain tile) whose per-volume density is diluted by a
+ * bounding box that is mostly empty air.
+ */
+export const TALL_EXTENT_RATIO = 0.5;
+
+/**
+ * Whether a bounding box counts as TALL under {@link TALL_EXTENT_RATIO}. Spans
+ * are in metres; the comparison uses the SHORTER horizontal span so a long thin
+ * corridor is not called tall just because its narrow axis is small.
+ */
+export function isTallExtent(spanX: number, spanY: number, spanZ: number): boolean {
+  if (!Number.isFinite(spanX) || !Number.isFinite(spanY) || !Number.isFinite(spanZ)) return false;
+  const minHoriz = Math.min(spanX, spanY);
+  return minHoriz > 0 && spanZ > TALL_EXTENT_RATIO * minHoriz;
+}
+
+/** A density tier together with the measure it was judged on. */
+export interface DensityTier {
+  readonly bucket: DensityBucket;
+  readonly basis: DensityBasis;
+}
+
+/**
+ * Pick the headline density tier from the two measures.
+ *
+ * Flat clouds (vertical span much smaller than the footprint) read truest by
+ * AREA: a thin airborne swath spread over a wide extent has a low per-m³
+ * density that misclassifies as sparse even when its pts/m² is a comfortable
+ * QL1. Tall clouds (interiors, façades) read truest by VOLUME. Whichever
+ * measure is missing, the other is used rather than reporting nothing.
+ *
+ * Single source for both the streaming sample grade and the static
+ * header-derived summary, so the two paths cannot drift apart.
+ */
+export function chooseDensityTier(input: {
+  readonly arealDensityPerM2: number | null;
+  readonly volumetricDensityPerM3: number | null;
+  readonly isTall: boolean;
+}): DensityTier {
+  const arealBucket =
+    input.arealDensityPerM2 != null ? classifyArealDensity(input.arealDensityPerM2) : 'unknown';
+  const volumetricBucket =
+    input.volumetricDensityPerM3 != null
+      ? classifyDensity({ residentDensity: input.volumetricDensityPerM3 })
+      : 'unknown';
+  if (!input.isTall && arealBucket !== 'unknown') {
+    return { bucket: arealBucket, basis: 'areal' };
+  }
+  if (volumetricBucket !== 'unknown') {
+    return { bucket: volumetricBucket, basis: 'volumetric' };
+  }
+  if (arealBucket !== 'unknown') {
+    return { bucket: arealBucket, basis: 'areal' };
+  }
+  return { bucket: 'unknown', basis: 'none' };
+}
+
+/**
+ * The density tier the card shows, with the measure behind it.
+ *
+ * An engine-measured `residentDensity` is already a per-m³ figure, so it stays
+ * volumetric. Otherwise, when the bbox SPANS are known in metres, the flat /
+ * tall split above decides: a flat scan is tiered on points per footprint m²,
+ * a tall one on points per m³. With no spans the reading falls back to the
+ * volume-only estimate, unchanged.
+ */
+export function classifyDensityTier(
+  input: Pick<
+    DatasetIntelligenceInput,
+    'pointCount' | 'bboxVolume' | 'residentDensity' | 'bboxSpansM'
+  >,
+): DensityTier {
+  const volumeOnly = (): DensityTier => {
+    const bucket = classifyDensity(input);
+    return { bucket, basis: bucket === 'unknown' ? 'none' : 'volumetric' };
+  };
+  if (input.residentDensity !== undefined && Number.isFinite(input.residentDensity)) {
+    return volumeOnly();
+  }
+  const spans = input.bboxSpansM;
+  const n = input.pointCount;
+  if (spans && n !== undefined && Number.isFinite(n) && n > 0) {
+    const [sx, sy, sz] = spans;
+    if (
+      Number.isFinite(sx) && Number.isFinite(sy) && Number.isFinite(sz) &&
+      sx > 0 && sy > 0 && sz >= 0
+    ) {
+      const footprintM2 = sx * sy;
+      const volumeM3 = footprintM2 * sz;
+      return chooseDensityTier({
+        arealDensityPerM2: footprintM2 > 0 ? n / footprintM2 : null,
+        volumetricDensityPerM3: volumeM3 > 0 ? n / volumeM3 : null,
+        isTall: isTallExtent(sx, sy, sz),
+      });
+    }
+  }
+  return volumeOnly();
 }
 
 /** Human label for a density bucket. */
@@ -474,7 +616,7 @@ export function summariseDataset(input: DatasetIntelligenceInput): DatasetIntell
     input.complexityDerived !== undefined ||
     input.coverageMeta !== undefined;
   if (!hasAnyData) return null;
-  const densityBucket = classifyDensity(input);
+  const densityTier = classifyDensityTier(input);
   // The engine-derived VRM/TPI reading (a real measurement with stated
   // window + units) outranks the heuristic bucket whenever a run supplied it.
   const derived = input.complexityDerived;
@@ -494,7 +636,11 @@ export function summariseDataset(input: DatasetIntelligenceInput): DatasetIntell
     ? `${Math.round(clamp(confidenceRaw, 0, 100))}%`
     : '—';
   return {
-    density: { bucket: densityBucket, label: densityLabel(densityBucket) },
+    density: {
+      bucket: densityTier.bucket,
+      label: densityLabel(densityTier.bucket),
+      basis: densityTier.basis,
+    },
     complexity: derived
       ? { bucket: complexityBucket, label: derived.label, detail: derived.detail }
       : { bucket: complexityBucket, label: complexityLabel(complexityBucket) },

--- a/src/ui/DatasetIntelligenceCard.ts
+++ b/src/ui/DatasetIntelligenceCard.ts
@@ -27,9 +27,40 @@ import {
   signalTier,
   type DatasetIntelligence,
   type DatasetIntelligenceInput,
+  type DensityBasis,
 } from '../terrain/datasetIntelligence';
 
 const EMPTY_TEXT = 'Terrain Intelligence unavailable for this dataset.';
+
+/**
+ * The density row's term + tooltip, one per measure the tier can come from.
+ *
+ * A wide, thin airborne tile has most of its bounding box filled with empty
+ * air, so its points-per-m³ reads far below what the scan actually delivers on
+ * the ground; that reading is tiered on points per footprint m² instead. The
+ * row is named after whichever measure was used, because a pts/m² number under
+ * a "volumetric" heading states the wrong unit. `'none'` (no reading at all)
+ * keeps the volumetric wording, matching the "—" the value shows.
+ */
+export const DENSITY_ROW = {
+  volumetric: {
+    label: 'Volumetric point density',
+    tooltip:
+      'Points per cubic metre (pts/m³), derived from the loader-declared point ' +
+      'count and the bounding-box volume — not areal pts/m². Bucket label: ' +
+      'sparse / moderate / dense / very dense.',
+  },
+  areal: {
+    label: 'Areal point density',
+    tooltip:
+      'Points per square metre (pts/m²) of bounding-box footprint, derived from ' +
+      'the loader-declared point count. Used instead of pts/m³ because this ' +
+      'scan is flat: its bounding box is mostly empty air, which understates a ' +
+      'per-volume reading. Bands follow the USGS 3DEP density floors ' +
+      '(QL2 2 pts/m², QL1 8 pts/m²); the bucket is a density word, not a ' +
+      'quality level.',
+  },
+} as const;
 
 /**
  * v0.3.10 trust-pass — "Terrain Confidence" can be misread as
@@ -62,6 +93,7 @@ export class DatasetIntelligenceCard {
   private readonly _detailsBody: HTMLElement;
 
   private readonly _densityValue: HTMLElement;
+  private readonly _densityName: HTMLElement;
   private readonly _complexityValue: HTMLElement;
   private readonly _groundValue: HTMLElement;
   private readonly _coverageValue: HTMLElement;
@@ -82,6 +114,15 @@ export class DatasetIntelligenceCard {
     // `<dt>/<dd>` pair is explicitly allowed by HTML 5.2 for
     // grouping, and preserves the existing flex-row CSS layout.
     this._densityValue = el('dd', { className: 'olv-di-row-value' });
+    // The density row's TERM is written by `_applyDensityBasis` on every
+    // render, since the row is named after the measure behind the tier.
+    this._densityName = el('dt', {
+      className: 'olv-di-row-name',
+      text: DENSITY_ROW.volumetric.label,
+    });
+    this._densityName.title = DENSITY_ROW.volumetric.tooltip;
+    this._densityName.style.cursor = 'help';
+    this._densityName.setAttribute('aria-describedby', '');
     this._complexityValue = el('dd', { className: 'olv-di-row-value' });
     this._groundValue = el('dd', { className: 'olv-di-row-value' });
     this._coverageValue = el('dd', { className: 'olv-di-row-value' });
@@ -113,13 +154,7 @@ export class DatasetIntelligenceCard {
     // to a first-time user; the tooltips disambiguate without adding
     // visible clutter to the panel.
     this._rows = el('dl', { className: 'olv-di-rows' }, [
-      this._row(
-        'Volumetric point density',
-        this._densityValue,
-        'Points per cubic metre (pts/m³), derived from the loader-declared point ' +
-          'count and the bounding-box volume — not areal pts/m². Bucket label: ' +
-          'sparse / moderate / dense / very dense.',
-      ),
+      el('div', { className: 'olv-di-row' }, [this._densityName, this._densityValue]),
       this._row(
         'Terrain Complexity',
         this._complexityValue,
@@ -236,6 +271,18 @@ export class DatasetIntelligenceCard {
   // ── private ──────────────────────────────────────────────────────
 
   /**
+   * Name the density row after the measure the tier actually came from. A flat
+   * airborne tile is tiered on points per m², and calling that reading
+   * "volumetric" would misreport the unit the number is in.
+   */
+  private _applyDensityBasis(basis: DensityBasis): void {
+    const copy = basis === 'areal' ? DENSITY_ROW.areal : DENSITY_ROW.volumetric;
+    this._densityName.textContent = copy.label;
+    this._densityName.title = copy.tooltip;
+    this._densityName.dataset.basis = basis;
+  }
+
+  /**
    * Build one term / definition row. The `<div class="olv-di-row">`
    * wrapper between `<dl>` and the `<dt>/<dd>` pair is allowed per
    * HTML 5.2 for grouping; it lets the existing flex layout keep
@@ -271,6 +318,7 @@ export class DatasetIntelligenceCard {
     // `data-bucket` keeps the exact bucket (semantics / tests); `data-tier`
     // drives the quiet colour accent through the honest signal-tier mapping so
     // a descriptive axis (complexity) is never coloured as good/bad.
+    this._applyDensityBasis(intel.density.basis);
     this._densityValue.textContent = intel.density.label;
     this._densityValue.dataset.bucket = intel.density.bucket;
     this._densityValue.dataset.tier = signalTier('density', intel.density.bucket);

--- a/tests/densityBasisAreal.test.ts
+++ b/tests/densityBasisAreal.test.ts
@@ -1,0 +1,196 @@
+/**
+ * densityBasisAreal.test.ts
+ *
+ * The Dataset Intelligence density tier must not call a wide, thin airborne
+ * tile "Sparse". Such a tile spreads its points over a large footprint under a
+ * bounding box that is mostly empty air, so points-per-m³ lands far below the
+ * per-m² density the scan actually delivers on the ground — the reading a
+ * surveyor checks against the USGS 3DEP floors.
+ *
+ * These cases pin the three outcomes that matter:
+ *   - a flat, well-covered tile tiers on AREAL density and stops reading Sparse;
+ *   - a genuinely thin cloud still reads Sparse on either measure;
+ *   - a tall scan (interior / façade) keeps the VOLUMETRIC behaviour.
+ *
+ * Plus the honesty half: the row is named after the measure behind the tier, in
+ * the card and in the scan story, so a pts/m² number is never shown under a
+ * "volumetric" heading.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  classifyDensityTier,
+  summariseDataset,
+  chooseDensityTier,
+  isTallExtent,
+  type DatasetIntelligenceInput,
+} from '../src/terrain/datasetIntelligence';
+import { classifyArealDensity } from '../src/render/streaming/sampleGrade';
+import { DENSITY_ROW } from '../src/ui/DatasetIntelligenceCard';
+import { buildExportHealth } from '../src/intelligence/scanStory';
+import { createInspectorCardRefreshers } from '../src/app/inspectorCardRefreshers';
+
+// A USGS-style airborne tile: 89.6M points over a 1500 × 1500 m footprint with
+// 300 m of relief. Areal ≈ 39.8 pts/m² (well above the QL1 floor of 8);
+// volumetric ≈ 0.13 pts/m³, which the per-m³ bands call sparse.
+const AIRBORNE = {
+  pointCount: 89_600_000,
+  bboxSpansM: [1500, 1500, 300] as [number, number, number],
+  bboxVolume: 1500 * 1500 * 300,
+};
+
+describe('density tier — flat airborne tiles read areally', () => {
+  it('a thin wide tile with good pts/m² is not Sparse', () => {
+    const volumeOnly = classifyDensityTier({
+      pointCount: AIRBORNE.pointCount,
+      bboxVolume: AIRBORNE.bboxVolume,
+    });
+    expect(volumeOnly).toEqual({ bucket: 'sparse', basis: 'volumetric' });
+
+    const withSpans = classifyDensityTier(AIRBORNE);
+    expect(withSpans.basis).toBe('areal');
+    expect(withSpans.bucket).toBe('dense');
+  });
+
+  it('a genuinely sparse cloud still reads Sparse', () => {
+    // 10 000 points over a square kilometre — 0.01 pts/m², below every floor.
+    const tier = classifyDensityTier({
+      pointCount: 10_000,
+      bboxSpansM: [1000, 1000, 50],
+      bboxVolume: 1000 * 1000 * 50,
+    });
+    expect(tier.bucket).toBe('sparse');
+  });
+
+  it('a tall scan keeps the volumetric reading', () => {
+    // 10 × 10 m footprint, 20 m of height: an interior / façade capture. Areal
+    // would say very-dense (2 000 pts/m²); the volume is the honest measure.
+    const tier = classifyDensityTier({
+      pointCount: 200_000,
+      bboxSpansM: [10, 10, 20],
+      bboxVolume: 10 * 10 * 20,
+    });
+    expect(tier).toEqual({ bucket: 'dense', basis: 'volumetric' });
+  });
+
+  it('an engine-measured resident density stays volumetric even with spans', () => {
+    const tier = classifyDensityTier({
+      residentDensity: 0.5,
+      pointCount: AIRBORNE.pointCount,
+      bboxSpansM: AIRBORNE.bboxSpansM,
+    });
+    expect(tier).toEqual({ bucket: 'sparse', basis: 'volumetric' });
+  });
+
+  it('no spans leaves the volume-only reading unchanged', () => {
+    expect(classifyDensityTier({ pointCount: 50_000, bboxVolume: 100 })).toEqual({
+      bucket: 'very-dense',
+      basis: 'volumetric',
+    });
+    expect(classifyDensityTier({})).toEqual({ bucket: 'unknown', basis: 'none' });
+  });
+
+  it('degenerate spans fall back rather than inventing a tier', () => {
+    // Zero footprint: no area to divide by, so the volume estimate answers.
+    expect(classifyDensityTier({ pointCount: 1_000, bboxSpansM: [0, 10, 10], bboxVolume: 100 }))
+      .toEqual({ bucket: 'moderate', basis: 'volumetric' });
+    // A perfectly flat sheet has no volume at all — areal is the only measure.
+    expect(classifyDensityTier({ pointCount: 1_000, bboxSpansM: [100, 100, 0] })).toEqual({
+      bucket: 'sparse',
+      basis: 'areal',
+    });
+  });
+
+  it('the flat / tall split uses the shorter horizontal span', () => {
+    expect(isTallExtent(2000, 40, 30)).toBe(true); // a narrow corridor with height
+    expect(isTallExtent(2000, 40, 5)).toBe(false);
+    expect(isTallExtent(0, 100, 10)).toBe(false); // degenerate footprint
+  });
+
+  it('the streaming grade and the static card share one band table', () => {
+    // Same numbers through both entry points — the thresholds exist once.
+    expect(classifyArealDensity(39.8)).toBe('dense');
+    expect(
+      chooseDensityTier({ arealDensityPerM2: 39.8, volumetricDensityPerM3: 0.13, isTall: false }),
+    ).toEqual({ bucket: 'dense', basis: 'areal' });
+  });
+});
+
+describe('density tier — the row never misnames its unit', () => {
+  it('summariseDataset reports the basis alongside the bucket', () => {
+    const intel = summariseDataset(AIRBORNE);
+    expect(intel?.density).toEqual({ bucket: 'dense', label: 'Dense', basis: 'areal' });
+  });
+
+  it('the card row copy states pts/m² for an areal reading', () => {
+    expect(DENSITY_ROW.areal.label).toBe('Areal point density');
+    expect(DENSITY_ROW.areal.label).not.toMatch(/volumetric/i);
+    expect(DENSITY_ROW.areal.tooltip).toContain('pts/m²');
+    expect(DENSITY_ROW.volumetric.tooltip).toContain('pts/m³');
+  });
+
+  it('the scan story names the density row after its basis', () => {
+    const areal = buildExportHealth({ density: 'dense', densityBasis: 'areal' });
+    expect(areal.rows.some((r) => r.label === 'Areal point density')).toBe(true);
+    const volumetric = buildExportHealth({ density: 'dense', densityBasis: 'volumetric' });
+    expect(volumetric.rows.some((r) => r.label === 'Volumetric point density')).toBe(true);
+    // Absent basis keeps the historical wording.
+    const legacy = buildExportHealth({ density: 'dense' });
+    expect(legacy.rows.some((r) => r.label === 'Volumetric point density')).toBe(true);
+  });
+});
+
+describe('density tier — the static loader hands over the spans', () => {
+  function makeInspector() {
+    const calls: DatasetIntelligenceInput[] = [];
+    const inspector = {
+      setDatasetIntelligence: (s: DatasetIntelligenceInput) => calls.push(s),
+      clearDatasetIntelligence: vi.fn(),
+      setProvenance: vi.fn(),
+    } as never;
+    return { inspector, last: () => calls[calls.length - 1] };
+  }
+
+  const METRE = { linearUnit: 'metre', linearUnitToMetres: 1 };
+  const UNKNOWN = { linearUnit: 'unknown', linearUnitToMetres: 1 };
+  const FOOT = { linearUnit: 'us-ft', linearUnitToMetres: 0.30480060960121924 };
+  const tile = {
+    pointCount: 2_850_000,
+    declaredPointCount: 89_600_000,
+    metadata: { crs: METRE },
+    bounds: () => ({
+      min: [0, 0, 0] as [number, number, number],
+      max: [1500, 1500, 300] as [number, number, number],
+    }),
+  };
+
+  it('the metre tile arrives with spans, and its tier is areal', () => {
+    const { inspector, last } = makeInspector();
+    createInspectorCardRefreshers(inspector, () => METRE)
+      .refreshDatasetIntelligenceFromStaticCloud(tile);
+    expect(last().bboxSpansM).toEqual([1500, 1500, 300]);
+    // The declared total, not the display sample, drives the reading.
+    expect(summariseDataset(last())?.density).toEqual({
+      bucket: 'dense',
+      label: 'Dense',
+      basis: 'areal',
+    });
+  });
+
+  it('spans are converted to metres, like the volume', () => {
+    const { inspector, last } = makeInspector();
+    createInspectorCardRefreshers(inspector, () => FOOT)
+      .refreshDatasetIntelligenceFromStaticCloud(tile);
+    const spans = last().bboxSpansM as [number, number, number];
+    expect(spans[0]).toBeCloseTo(457.2, 1);
+    expect(spans[2]).toBeCloseTo(91.44, 1);
+  });
+
+  it('an unknown unit fails closed — no spans, no areal claim', () => {
+    const { inspector, last } = makeInspector();
+    createInspectorCardRefreshers(inspector, () => UNKNOWN)
+      .refreshDatasetIntelligenceFromStaticCloud(tile);
+    expect(last().bboxSpansM).toBeUndefined();
+    expect(summariseDataset(last())?.density.bucket).toBe('unknown');
+  });
+});

--- a/tests/terrainReportContent.test.ts
+++ b/tests/terrainReportContent.test.ts
@@ -236,7 +236,7 @@ describe('buildTerrainReportContent — section presence + sourcing', () => {
     // Hand-built summary in the card's own vocabulary — the report must echo
     // the labels verbatim (they are the card's strings, not re-derived).
     const intelligence: DatasetIntelligence = {
-      density: { bucket: 'dense', label: 'Dense' },
+      density: { bucket: 'dense', label: 'Dense', basis: 'volumetric' },
       complexity: { bucket: 'moderate', label: 'Moderate' },
       groundVisibility: { bucket: 'good', label: 'Good' },
       coverage: { bucket: 'full', label: 'Full Dataset' },


### PR DESCRIPTION
`classifyDensity` is purely volumetric, so a thin swath over a wide footprint read about 0.13 pts/m³ and was labelled Sparse while its areal density was 39.8 pts/m².

`sampleGrade.ts` already carried a flat/tall split, wired only into the streaming grade. The split and its bands move to `datasetIntelligence.ts`; the streaming grade imports them, so there is one band table. The static path now passes bbox spans, and `DatasetIntelligence.density` carries `basis`.

The row label follows the basis, so an areal reading is never shown under a volumetric heading. Unknown units fail closed: no spans, no areal claim.

No terrain or DTM numerics touched. `main.ts` net zero.