### PR TITLE
perf(io): decode a strided LAZ across the chunk worker pool

### DIFF
--- a/src/io/heavy/decodeLazChunked.ts
+++ b/src/io/heavy/decodeLazChunked.ts
@@ -15,6 +15,16 @@
  * returns `null` — fail-closed to the legacy whole-file path — for any file the
  * chunk table cannot describe (pointwise-compressed LAZ, an interrupted writer,
  * an unsupported record format), never a partial or a guess.
+ *
+ * STRIDE. A fast-load decode keeps one record per bucket of `stride`, and
+ * `strideSample.ts` is the reference definition of WHICH records those are — a
+ * pure function of the count, the step and a fixed seed. So the kept set is
+ * computed once up front, split across the chunk table, and each chunk emits
+ * only its own slice of it, in ascending order; the reassembly is the same
+ * ascending order the legacy decoder writes in. Every chunk is still decoded
+ * (laz-perf decompresses a chunk as a unit, and a bucket is far smaller than a
+ * chunk), so a strided parallel decode does the same decompression work as
+ * `decodeLaz` — only spread over cores, and storing only the kept records.
  */
 import { readLazChunkTable, type LazChunkRange } from './lazChunkTable';
 import { ArrayBufferRangeSource } from '../range/ArrayBufferRangeSource';
@@ -24,10 +34,13 @@ import {
   decodeContext,
   decodeRecord,
   allocRawPoints,
+  decodingUpdate,
   finalizeRawColors,
   type DecodeContext,
   type RawPoints,
 } from '../lasDecodeShared';
+import { stratifiedSampleIndices } from '../strideSample';
+import type { ProgressUpdate } from '../loadProgress';
 import type { LasHeader } from '../lasHeader';
 
 /** Record formats the per-chunk laz-perf decoder is exercised for (COPC's set). */
@@ -57,15 +70,33 @@ export interface LazChunkJob {
   readonly scale: [number, number, number];
   readonly offset: [number, number, number];
   readonly ctx: DecodeContext;
+  /**
+   * Ascending chunk-LOCAL record indices to emit, or undefined to emit every
+   * record. This is the chunk's slice of the whole-file stratified sample (see
+   * `strideSample.ts`); filtering here rather than after assembly is what keeps
+   * a strided decode's buffers sized to the sample instead of the file. Small
+   * enough to be copied into a worker message (one uint32 per kept record).
+   */
+  readonly keep?: Uint32Array;
+  /**
+   * Where this chunk's emitted records start in the whole-file output. Equal to
+   * `firstPointIndex` for a full decode; for a strided one it is the number of
+   * records the earlier chunks keep. Defaults to `firstPointIndex`.
+   */
+  readonly outIndex?: number;
 }
 
 /**
- * Decode ONE chunk into a chunk-local `RawPoints`, indices 0..pointCount-1.
- * Colours are left STAGED (16-bit, not narrowed): the whole-file narrowing is a
- * per-file decision the caller applies once after every chunk is assembled, so
- * two chunks can never disagree on colour depth. Shared by the sequential
- * decoder, the parallel orchestrator, and the worker, so all three extract the
- * SAME way the legacy path does.
+ * Decode ONE chunk into a chunk-local `RawPoints`, holding the records `keep`
+ * selects (every record when it is absent) at indices 0..kept-1, in the order
+ * `keep` lists them. Colours are left STAGED (16-bit, not narrowed): the
+ * whole-file narrowing is a per-file decision the caller applies once after
+ * every chunk is assembled, so two chunks can never disagree on colour depth.
+ * Shared by the sequential decoder, the parallel orchestrator, and the worker,
+ * so all three extract the SAME way the legacy path does.
+ *
+ * The whole chunk is still decompressed whatever `keep` holds — a laszip chunk
+ * is one arithmetic-coded unit and its records cannot be reached out of order.
  */
 export function decodeLazChunkLocal(lazPerf: LazPerfModule, job: LazChunkJob): RawPoints {
   const records = decompressChunk(lazPerf, job.chunk, {
@@ -77,16 +108,19 @@ export function decodeLazChunkLocal(lazPerf: LazPerfModule, job: LazChunkJob): R
     renderOrigin: job.ctx.origin,
   });
   const view = new DataView(records.buffer, records.byteOffset, records.byteLength);
-  const local = allocRawPoints(job.pointCount, job.ctx.gpsTimeOffset !== null, job.ctx.rgbOffset !== null);
-  for (let j = 0; j < job.pointCount; j++) {
-    decodeRecord(view, j * job.pointRecordLength, j, job.ctx, local);
+  const keep = job.keep;
+  const kept = keep ? keep.length : job.pointCount;
+  const local = allocRawPoints(kept, job.ctx.gpsTimeOffset !== null, job.ctx.rgbOffset !== null);
+  for (let j = 0; j < kept; j++) {
+    const record = keep ? keep[j] : j;
+    decodeRecord(view, record * job.pointRecordLength, j, job.ctx, local);
   }
   return local;
 }
 
-/** Copy a chunk-local `RawPoints` into the whole-file `out` at `firstPointIndex`. */
-function placeChunk(out: RawPoints, local: RawPoints, firstPointIndex: number): void {
-  const p = firstPointIndex;
+/** Copy a chunk-local `RawPoints` into the whole-file `out` at `at`. */
+function placeChunk(out: RawPoints, local: RawPoints, at: number): void {
+  const p = at;
   out.positions.set(local.positions, p * 3);
   out.intensity.set(local.intensity, p);
   out.classification.set(local.classification, p);
@@ -97,8 +131,56 @@ function placeChunk(out: RawPoints, local: RawPoints, firstPointIndex: number): 
   if (out.colors16 && local.colors16) out.colors16.set(local.colors16, p * 3);
 }
 
-/** Build the per-chunk job for chunk `c`, slicing its bytes out of the file. */
-function jobFor(buffer: ArrayBuffer, header: LasHeader, ctx: DecodeContext, c: LazChunkRange): LazChunkJob {
+/** One chunk's share of the decode: its byte range, what it keeps, where it lands. */
+interface PlannedChunk {
+  readonly range: LazChunkRange;
+  /** Chunk-local indices to keep, or undefined for a full (stride 1) decode. */
+  readonly keep?: Uint32Array;
+  /** First output index this chunk writes. */
+  readonly outIndex: number;
+}
+
+/**
+ * Split the whole-file stratified sample across the chunk table.
+ *
+ * `stratifiedSampleIndices` is the reference definition of the record set a
+ * strided decode keeps — the same indices `decodeLaz` reaches one bucket at a
+ * time — so slicing that ascending list at the chunk boundaries gives each
+ * chunk exactly the records it owns, and concatenating the slices in chunk
+ * order reproduces the list. `readLazChunkTable` accumulates `firstPointIndex`
+ * chunk by chunk and refuses a table whose counts do not sum to the header's,
+ * so the ranges are contiguous, ascending and cover every record: one forward
+ * walk assigns the whole sample.
+ */
+function partitionSample(
+  chunks: readonly LazChunkRange[],
+  count: number,
+  step: number,
+): PlannedChunk[] {
+  const sample = stratifiedSampleIndices(count, step);
+  const planned: PlannedChunk[] = [];
+  let read = 0;
+  let outIndex = 0;
+  for (const range of chunks) {
+    const end = range.firstPointIndex + range.pointCount;
+    const start = read;
+    while (read < sample.length && sample[read] < end) read++;
+    const keep = new Uint32Array(read - start);
+    for (let j = 0; j < keep.length; j++) keep[j] = sample[start + j] - range.firstPointIndex;
+    planned.push({ range, keep, outIndex });
+    outIndex += keep.length;
+  }
+  return planned;
+}
+
+/** Build the per-chunk job for `planned`, slicing its bytes out of the file. */
+function jobFor(
+  buffer: ArrayBuffer,
+  header: LasHeader,
+  ctx: DecodeContext,
+  planned: PlannedChunk,
+): LazChunkJob {
+  const c = planned.range;
   return {
     chunk: buffer.slice(c.byteOffset, c.byteOffset + c.byteLength),
     pointCount: c.pointCount,
@@ -108,30 +190,79 @@ function jobFor(buffer: ArrayBuffer, header: LasHeader, ctx: DecodeContext, c: L
     scale: header.scale,
     offset: header.offset,
     ctx,
+    keep: planned.keep,
+    outIndex: planned.outIndex,
   };
+}
+
+/** What both orchestrators need: the per-chunk shares and the whole-file output. */
+interface ChunkedPlan {
+  readonly chunks: readonly PlannedChunk[];
+  readonly out: RawPoints;
+  readonly ctx: DecodeContext;
+  /** Records the finished decode holds — the sample size, not the file's count. */
+  readonly total: number;
+}
+
+/** Options shared by the sequential and parallel whole-file chunked decoders. */
+export interface ChunkedDecodeOptions {
+  readonly signal?: AbortSignal;
+  /**
+   * Keep one record per bucket of `stride`, at the jittered offset
+   * `strideSample.ts` defines (1 = every record). Same contract as `decodeLaz`.
+   */
+  readonly stride?: number;
+  readonly onProgress?: (u: ProgressUpdate) => void;
 }
 
 /**
  * Parse the chunk table and decide whether this file can take the chunked path.
- * Returns the chunk jobs and a fresh whole-file `out`, or `null` to fall back to
- * the legacy decoder (unsupported table, record format, or a count mismatch).
+ * Returns the per-chunk shares and a fresh whole-file `out`, or `null` to fall
+ * back to the legacy decoder (unsupported table, record format, or a count
+ * mismatch).
  */
 async function planChunked(
   buffer: ArrayBuffer,
   header: LasHeader,
   origin: [number, number, number],
+  stride: number,
   signal?: AbortSignal,
-): Promise<{ jobs: LazChunkJob[]; out: RawPoints; ctx: DecodeContext } | null> {
+): Promise<ChunkedPlan | null> {
   const table = await readLazChunkTable(new ArrayBufferRangeSource(buffer), signal);
   if (!table.supported) return null;
   if (!CHUNK_DECODE_FORMATS.has(header.pointFormat)) return null;
   const tableTotal = table.chunks.reduce((a, c) => a + c.pointCount, 0);
   if (tableTotal !== header.pointCount) return null;
 
+  const step = Math.max(1, Math.floor(stride));
   const ctx = decodeContext(header, origin);
-  const out = allocRawPoints(header.pointCount, ctx.gpsTimeOffset !== null, ctx.rgbOffset !== null);
-  const jobs = table.chunks.map((c) => jobFor(buffer, header, ctx, c));
-  return { jobs, out, ctx };
+  const chunks =
+    step > 1
+      ? partitionSample(table.chunks, header.pointCount, step)
+      : table.chunks.map((range) => ({ range, outIndex: range.firstPointIndex }));
+  // Sized to what the decode KEEPS. At stride 10 on a 90 M-point file that is
+  // the 9 M-record sample, not the file.
+  const total = step > 1 ? Math.ceil(header.pointCount / step) : header.pointCount;
+  const out = allocRawPoints(total, ctx.gpsTimeOffset !== null, ctx.rgbOffset !== null);
+  return { chunks, out, ctx, total };
+}
+
+/**
+ * Progress reporter matching the legacy decoder's cadence: about twenty updates
+ * across the decode, counted in kept records.
+ */
+function progressReporter(
+  total: number,
+  onProgress?: (u: ProgressUpdate) => void,
+): (done: number) => void {
+  if (!onProgress) return () => {};
+  const every = Math.max(1, Math.floor(total / 20));
+  let reported = 0;
+  return (done: number) => {
+    if (done - reported < every && done < total) return;
+    reported = done;
+    onProgress(decodingUpdate(done, total));
+  };
 }
 
 /**
@@ -143,14 +274,23 @@ export async function decodeLazChunkedSequential(
   buffer: ArrayBuffer,
   header: LasHeader,
   origin: [number, number, number],
-  signal?: AbortSignal,
+  options: ChunkedDecodeOptions = {},
 ): Promise<RawPoints | null> {
-  const plan = await planChunked(buffer, header, origin, signal);
+  const { signal } = options;
+  const plan = await planChunked(buffer, header, origin, options.stride ?? 1, signal);
   if (plan === null) return null;
   const lazPerf = await getLazPerf();
-  for (const job of plan.jobs) {
+  const report = progressReporter(plan.total, options.onProgress);
+  let done = 0;
+  for (const planned of plan.chunks) {
     signal?.throwIfAborted();
-    placeChunk(plan.out, decodeLazChunkLocal(lazPerf, job), job.firstPointIndex);
+    // A chunk the sample skips entirely holds no output record, so decompressing
+    // it could not change one. Every other chunk is decoded in full.
+    if (planned.keep && planned.keep.length === 0) continue;
+    const job = jobFor(buffer, header, plan.ctx, planned);
+    placeChunk(plan.out, decodeLazChunkLocal(lazPerf, job), planned.outIndex);
+    done += planned.keep ? planned.keep.length : planned.range.pointCount;
+    report(done);
   }
   finalizeRawColors(plan.out);
   return plan.out;
@@ -176,6 +316,16 @@ export type LazChunkDecoder = (job: LazChunkJob, signal?: AbortSignal) => Promis
  */
 const MAX_CHUNK_DECODES_IN_FLIGHT = 16;
 
+/** {@link ChunkedDecodeOptions} plus the parallel orchestrator's in-flight bound. */
+export interface ParallelDecodeOptions extends ChunkedDecodeOptions {
+  /**
+   * How many chunk decodes to keep in flight. Bounds both the pool's queue
+   * pressure and peak memory; the default keeps the pool saturated for any real
+   * cloud.
+   */
+  readonly maxInFlight?: number;
+}
+
 /**
  * Decode a whole LAZ by feeding its chunks through `decodeChunk` with a bounded
  * number in flight, assembling each into the whole-file `out` the instant it
@@ -187,31 +337,46 @@ const MAX_CHUNK_DECODES_IN_FLIGHT = 16;
  *
  * `maxInFlight` bounds both the pool's queue pressure and peak memory; the
  * default keeps the pool saturated for any real cloud. Chunks may finish out of
- * order — each is placed at its own `firstPointIndex`, into a disjoint span of
+ * order — each is placed at its own output index, into a disjoint span of
  * `out`, so order never matters.
+ *
+ * With `stride > 1` each chunk emits only its slice of the stratified sample,
+ * so the result is the same points `decodeLaz` keeps at that stride, in the same
+ * order, in an output sized to the sample.
  */
 export async function decodeLazParallel(
   buffer: ArrayBuffer,
   header: LasHeader,
   origin: [number, number, number],
   decodeChunk: LazChunkDecoder,
-  signal?: AbortSignal,
-  maxInFlight: number = MAX_CHUNK_DECODES_IN_FLIGHT,
+  options: ParallelDecodeOptions = {},
 ): Promise<RawPoints | null> {
-  const plan = await planChunked(buffer, header, origin, signal);
+  const { signal } = options;
+  const plan = await planChunked(buffer, header, origin, options.stride ?? 1, signal);
   if (plan === null) return null;
 
-  const jobs = plan.jobs;
-  const lanes = Math.max(1, Math.min(Math.floor(maxInFlight), jobs.length));
+  const chunks = plan.chunks;
+  const maxInFlight = options.maxInFlight ?? MAX_CHUNK_DECODES_IN_FLIGHT;
+  const lanes = Math.max(1, Math.min(Math.floor(maxInFlight), chunks.length));
+  const report = progressReporter(plan.total, options.onProgress);
   let next = 0;
+  let done = 0;
 
-  // Each lane pulls the next chunk index, decodes it, and places it before
-  // pulling again — so at most `lanes` decodes are in flight and each
-  // chunk-local is freed the moment it is copied into `out`.
+  // Each lane pulls the next chunk index, slices its bytes, decodes it, and
+  // places it before pulling again — so at most `lanes` compressed chunks and
+  // `lanes` decodes are in flight, and each chunk-local is freed the moment it
+  // is copied into `out`. Slicing here rather than up front keeps the file's
+  // compressed bytes from being duplicated whole.
   const runLane = async (): Promise<void> => {
-    for (let i = next++; i < jobs.length; i = next++) {
+    for (let i = next++; i < chunks.length; i = next++) {
       signal?.throwIfAborted();
-      placeChunk(plan.out, await decodeChunk(jobs[i], signal), jobs[i].firstPointIndex);
+      const planned = chunks[i];
+      // A chunk the sample skips entirely holds no output record.
+      if (planned.keep && planned.keep.length === 0) continue;
+      const job = jobFor(buffer, header, plan.ctx, planned);
+      placeChunk(plan.out, await decodeChunk(job, signal), planned.outIndex);
+      done += planned.keep ? planned.keep.length : planned.range.pointCount;
+      report(done);
     }
   };
   await Promise.all(Array.from({ length: lanes }, runLane));

--- a/src/io/heavy/worker/lazChunkWorkerClient.ts
+++ b/src/io/heavy/worker/lazChunkWorkerClient.ts
@@ -16,12 +16,16 @@
  * device-aware policy ({@link resolveDecodePoolSize}) and why workers past the
  * first are created only when there is actually a second chunk to decode.
  *
- * POOLING IS OFF BY DEFAULT, exactly as it is for COPC and EPT. Absent a flag,
- * {@link decodeLazPooled} returns null without building a worker, so the loader
- * stays on the historical main-thread `decodeLaz`. `?decodePool=on` opts in at
- * the policy's size and `?decodeWorkers=N` pins the count; the `poolSize` option
- * is the same switch for tests. It stays opt-in until a browser run on a real
- * dataset measures the throughput win against the memory cost of N WASM heaps.
+ * POOLING IS ON FOR LARGE FILES ONLY. At or above
+ * {@link PARALLEL_DECODE_MIN_POINTS} records {@link decodeLazPooled} engages the
+ * pool by default; below it, and absent a flag, it returns null without building
+ * a worker and the loader stays on the historical main-thread `decodeLaz`.
+ * `?decodePool=on` opts a smaller file in at the policy's size,
+ * `?decodeWorkers=N` pins the count, `?decodePool=off` refuses pooling outright,
+ * and the `poolSize` option is the same switch for tests. What makes the default
+ * defensible where COPC's and EPT's is not is that the chunked decode is
+ * byte-for-byte the legacy output — the same records through the same
+ * `decodeRecord` — so the only thing the flag changes is how long it takes.
  *
  * The file-level RGB bit-depth decision is NOT affected by pooling: each worker
  * returns colours STAGED (`colors16`), and `decodeLazParallel` narrows them once
@@ -37,10 +41,11 @@ import {
   type DecodePoolStats,
   type WorkerLike,
 } from '../../workerPool/DecodeWorkerPool';
-import { resolveDecodePoolSize, decodePoolOptedIn } from '../../workerPool/decodePoolSize';
+import { resolveDecodePoolSize, decodeLazPoolEnabled } from '../../workerPool/decodePoolSize';
 import { readDevFlags } from '../../../perf/devFlags';
 import type { RawPoints } from '../../lasDecodeShared';
 import type { LasHeader } from '../../lasHeader';
+import type { ProgressUpdate } from '../../loadProgress';
 import {
   decodeLazParallel,
   type LazChunkDecoder,
@@ -63,6 +68,13 @@ export interface LazChunkWorkerClientOptions {
    * behaviour does not depend on the core count of the machine running them.
    */
   readonly poolSize?: number;
+  /**
+   * Engage the pool at the device policy's size without pinning a count — what
+   * the whole-file LAZ path passes when a file is large enough to decode across
+   * workers by default. Equivalent to `?decodePool=on` for this client only;
+   * `?decodePool=off` still wins.
+   */
+  readonly poolEnabled?: boolean;
   /** Injectable worker factory — a fake worker makes the pool Node-testable. */
   readonly workerFactory?: () => WorkerLike;
 }
@@ -72,8 +84,13 @@ export class LazChunkWorkerClient {
   private readonly _pool: DecodeWorkerPool<RawPoints>;
 
   constructor(options: LazChunkWorkerClientOptions = {}) {
+    const flags = readDevFlags();
     this._pool = new DecodeWorkerPool<RawPoints>({
-      size: resolveDecodePoolSize('laz', readDevFlags(), options.poolSize),
+      size: resolveDecodePoolSize(
+        'laz',
+        options.poolEnabled ? { ...flags, decodePool: true } : flags,
+        options.poolSize,
+      ),
       createWorker: options.workerFactory ?? defaultWorkerFactory,
       messages: {
         disposed: 'The LAZ decode worker has been disposed.',
@@ -109,30 +126,65 @@ export class LazChunkWorkerClient {
 }
 
 /**
+ * Point count at which a `.laz` decodes across the pool without being asked to.
+ *
+ * Pooling costs one laz-perf WASM heap per worker plus the worker startup, on
+ * the order of a couple of hundred milliseconds for the four the hard cap
+ * allows. Below a few million points the whole decode is over inside that
+ * overhead and the pool would only add memory. Ten million is where the
+ * single-threaded decode is unambiguously the larger cost: a 10 M-point PDRF 7
+ * file measured 3.9 s on one core against 1.1 s across four workers (a 14-core
+ * laptop, threads rather than browser workers), and the files this exists for
+ * are several times that again.
+ *
+ * Deliberately the DECLARED record count, not the sampled one: a strided decode
+ * still decompresses every record (laz-perf cannot skip), so the file's size is
+ * what the work is proportional to.
+ */
+export const PARALLEL_DECODE_MIN_POINTS = 10_000_000;
+
+/** Options for {@link decodeLazPooled}; same decode contract as `decodeLaz`. */
+export interface PooledDecodeOptions {
+  /** Keep one record per bucket of `stride` (1 = every record). */
+  readonly stride?: number;
+  readonly signal?: AbortSignal;
+  readonly onProgress?: (u: ProgressUpdate) => void;
+}
+
+/**
  * Decode a whole `.laz` across a worker pool, or return null to let the caller
  * fall back to the main-thread `decodeLaz`.
  *
- * Returns null WITHOUT building a worker when pooled decoding is not opted in,
- * so the default `.laz` open is byte-for-byte the historical path. When opted
- * in, it builds a short-lived pool, fans every chunk out through it, and
- * assembles the whole-file `RawPoints`; {@link decodeLazParallel} itself returns
- * null (and the pool never spins a worker) for any file whose chunk table this
- * path cannot describe — a pointwise-compressed LAZ, an unsupported record
- * format, a count mismatch — so those also fall back cleanly. The pool is
- * disposed in every exit, including a decode error, which then propagates so the
- * caller sees the same failure `decodeLaz` would raise rather than a silent
- * slow success.
+ * A file of at least {@link PARALLEL_DECODE_MIN_POINTS} records takes this path
+ * by default — that is the one place pooled decoding is not opt-in, because the
+ * chunked decode is byte-for-byte the legacy result (same records, same order,
+ * same shared `decodeRecord`) and the alternative is a minute of one core.
+ * Smaller files still need `?decodePool=on` or `?decodeWorkers=N`, and
+ * `?decodePool=off` puts any session back on `decodeLaz`. When the pool is not
+ * engaged this returns null WITHOUT building a worker.
+ *
+ * Fails closed the same way in every other respect: {@link decodeLazParallel}
+ * returns null (and the pool never spins a worker) for any file whose chunk
+ * table this path cannot describe — a pointwise-compressed LAZ, an unsupported
+ * record format, a count mismatch. The pool is disposed in every exit, including
+ * a decode error, which then propagates so the caller sees the same failure
+ * `decodeLaz` would raise rather than a silent slow success.
  */
 export async function decodeLazPooled(
   buffer: ArrayBuffer,
   header: LasHeader,
   origin: [number, number, number],
-  signal?: AbortSignal,
+  options: PooledDecodeOptions = {},
 ): Promise<RawPoints | null> {
-  if (!decodePoolOptedIn(readDevFlags())) return null;
-  const client = new LazChunkWorkerClient();
+  const eligible = header.pointCount >= PARALLEL_DECODE_MIN_POINTS;
+  if (!decodeLazPoolEnabled(readDevFlags(), eligible)) return null;
+  const client = new LazChunkWorkerClient({ poolEnabled: true });
   try {
-    return await decodeLazParallel(buffer, header, origin, client.decode, signal);
+    return await decodeLazParallel(buffer, header, origin, client.decode, {
+      stride: options.stride,
+      signal: options.signal,
+      onProgress: options.onProgress,
+    });
   } finally {
     client.dispose();
   }

--- a/src/io/loadLas.ts
+++ b/src/io/loadLas.ts
@@ -175,21 +175,17 @@ export async function loadLas(
     // Lazy chunk: pulls laz-perf + the embedded WASM only when a `.laz`
     // file is actually opened. Uncompressed `.las` files never download it.
     const { decodeLaz } = await import('./lazDecode');
-    // A full-resolution decode (stride 1) can fan the file's chunks across a
-    // worker pool — byte-for-byte the same points, produced in parallel. It is
-    // opt-in and fails closed: `decodeLazPooled` returns null (engaging no
-    // worker) unless pooling is enabled, and for any file its chunk table
-    // cannot describe, so `decodeLaz` stays the default and the fallback. A
-    // strided fast-load stays on `decodeLaz`, which SAMPLES records the chunked
-    // path would fully decode.
-    const pooled =
-      stride === 1
-        ? await (await import('./heavy/worker/lazChunkWorkerClient')).decodeLazPooled(
-            buffer,
-            header,
-            origin,
-          )
-        : null;
+    // The file's chunks can be fanned across a worker pool — byte-for-byte the
+    // same points, produced in parallel. This holds at any stride: laz-perf
+    // cannot skip records either way, so the pooled path decompresses exactly
+    // what `decodeLaz` does and keeps the same stratified sample, only spread
+    // over cores. It fails closed — `decodeLazPooled` returns null (engaging no
+    // worker) for a small unflagged file, for a session that refused pooling,
+    // and for any file its chunk table cannot describe — so `decodeLaz` stays
+    // the fallback for all three.
+    const pooled = await (
+      await import('./heavy/worker/lazChunkWorkerClient')
+    ).decodeLazPooled(buffer, header, origin, { stride, onProgress });
     raw = pooled ?? (await decodeLaz(buffer, header, origin, stride, onProgress));
   } else {
     raw = decodeLas(buffer, header, origin, stride, onProgress);

--- a/src/io/workerPool/decodePoolSize.ts
+++ b/src/io/workerPool/decodePoolSize.ts
@@ -141,6 +141,8 @@ export interface DecodePoolFlags {
   readonly decodePool: boolean;
   /** `?decodeWorkers=N` — an explicit count, or null when unspecified. */
   readonly decodeWorkers: number | null;
+  /** `?decodePool=off` — pooled decoding refused, however it was asked for. */
+  readonly decodePoolOff?: boolean;
 }
 
 /**
@@ -177,7 +179,24 @@ export function resolveDecodePoolSize(
  * a browser run has measured the trade.
  */
 export function decodePoolOptedIn(flags: DecodePoolFlags, explicitSize?: number): boolean {
-  return explicitSize !== undefined || flags.decodePool || flags.decodeWorkers !== null;
+  // An explicit size is code asking directly (a test pinning a pool), not a URL,
+  // so it stands ahead of the session's refusal; every flag path is behind it.
+  if (explicitSize !== undefined) return true;
+  if (flags.decodePoolOff) return false;
+  return flags.decodePool || flags.decodeWorkers !== null;
+}
+
+/**
+ * Whether the whole-file LAZ decode should engage the pool. This is the ONE
+ * decode path that pools without a flag: `eligible` is the loader's size test,
+ * and a file over it decodes across workers by default because the alternative
+ * is a minute of one core. `?decodePool=off` refuses it; the opt-in flags still
+ * engage the pool for a file under the threshold, and `?decodeWorkers=N` still
+ * pins the count.
+ */
+export function decodeLazPoolEnabled(flags: DecodePoolFlags, eligible: boolean): boolean {
+  if (flags.decodePoolOff) return false;
+  return eligible || decodePoolOptedIn(flags);
 }
 
 /** The device signals the policy needs, as read from the live environment. */

--- a/src/perf/devFlags.ts
+++ b/src/perf/devFlags.ts
@@ -13,15 +13,17 @@
  *   ?uploadQueue=off         parse-only, see Staged below
  *   ?angularPrediction=off   parse-only, see Staged below
  *   ?decodePool=on           OPT-IN: pooled COPC/EPT decode workers
+ *   ?decodePool=off          OPT-OUT: no pooled decoding, whatever asked
  *   ?decodeWorkers=N         OPT-IN: pooled decode with exactly N (1-4) workers
  *
- * `decodePool` runs the other way round from the flags above: it is OFF by
- * default and can only be turned ON. Both decode clients ship on the historical
- * single-worker path until a browser measurement on a real COPC/EPT dataset
- * shows pooled decoding behaving under a fast camera sweep — throughput and the
- * memory cost of one laz-perf WASM heap per worker. Either flag enables it:
- * `?decodePool=on` uses the device-aware size policy, `?decodeWorkers=N` pins
- * the count and implies the pool is on.
+ * `decodePool` runs the other way round from the flags above: absent it, the
+ * COPC/EPT decode clients ship on the historical single-worker path until a
+ * browser measurement on a real dataset shows pooled decoding behaving under a
+ * fast camera sweep — throughput and the memory cost of one laz-perf WASM heap
+ * per worker. Either flag enables it: `?decodePool=on` uses the device-aware
+ * size policy, `?decodeWorkers=N` pins the count and implies the pool is on.
+ * The whole-file LAZ decode is the one path that engages the pool without a
+ * flag, for a large file; `?decodePool=off` is how a session refuses it.
  *
  * Consumer status, kept honest — a flag with no consumer changes nothing:
  *   - Live: `handPan` (NavController pan mode, the G/Digit4 bindings, the
@@ -91,6 +93,13 @@ export interface DevFlags {
    */
   decodePool: boolean;
   /**
+   * `?decodePool=off` — pooled decoding refused for the session. Distinct from
+   * `decodePool: false`, which only means "not asked for": the whole-file LAZ
+   * path engages the pool on its own for a large file, and this is the switch
+   * that puts such a session back on the single-threaded `decodeLaz`.
+   */
+  decodePoolOff: boolean;
+  /**
    * Resident-stickiness in the budget selection. OFF by default: absent the
    * flag, selection is the plain greedy fill it has always been. `?stickiness=on`
    * gives an already-resident, non-refining node a small score bonus so
@@ -127,6 +136,7 @@ export const DEV_FLAG_DEFAULTS: Readonly<DevFlags> = Object.freeze({
   // unverified change on the default decode path is the mistake the multi-layer
   // mount already made once.
   decodePool: false,
+  decodePoolOff: false,
   decodeWorkers: null,
   // Stickiness changes what stays on screen at the budget boundary, and flicker
   // is not observable from Node, so it stays opt-in until a browser run on a
@@ -176,6 +186,17 @@ function parseOptIn(value: string | null): boolean {
 }
 
 /**
+ * The explicit OFF half of an opt-in flag. Absence is not "off" — it leaves the
+ * decision to whoever reads the flag — so only a spelled-out negative counts,
+ * and anything unrecognised reads as unspecified.
+ */
+function parseOptOut(value: string | null): boolean {
+  if (value === null) return false;
+  const v = value.trim().toLowerCase();
+  return v === 'off' || v === '0' || v === 'false';
+}
+
+/**
  * Decode worker count. Only a whole number in `[1, 4]` counts; absence, a
  * fraction, a negative, a huge value and outright garbage all read as null so
  * the device policy decides. The upper bound mirrors
@@ -212,6 +233,7 @@ export function parseDevFlags(search: string | URLSearchParams): DevFlags {
     angularPrediction: parseOnOff(params.get('angularPrediction')),
     streamingCommitMode: parseCommitMode(params.get('streamingCommitMode')),
     decodePool: parseOptIn(params.get('decodePool')),
+    decodePoolOff: parseOptOut(params.get('decodePool')),
     residentStickiness: parseOptIn(params.get('stickiness')),
     decodeWorkers: parseWorkerCount(params.get('decodeWorkers')),
   };

--- a/tests/decodePoolSize.test.ts
+++ b/tests/decodePoolSize.test.ts
@@ -22,6 +22,7 @@ import {
   readDecodePoolEnvironment,
   DECODE_POOL_HARD_CAP,
   DECODE_POOL_MOBILE_CAP,
+  decodeLazPoolEnabled,
   type DecodeFormat,
 } from '../src/io/workerPool/decodePoolSize';
 
@@ -251,6 +252,39 @@ describe('resolveDecodePoolSize — the opt-in rule', () => {
   it('never throws in a DOM-free environment', () => {
     expect(() => resolveDecodePoolSize('copc', OFF)).not.toThrow();
     expect(() => resolveDecodePoolSize('ept', { decodePool: true, decodeWorkers: null })).not.toThrow();
+  });
+});
+
+describe('decodeLazPoolEnabled — the whole-file LAZ decode gate', () => {
+  const OFF = { decodePool: false, decodeWorkers: null };
+
+  it('engages the pool for a large file with no flag at all', () => {
+    // The one decode path that pools by default. A big LAZ decoded on one core
+    // is the defect this exists for, and the chunked result is the same bytes.
+    expect(decodeLazPoolEnabled(OFF, true)).toBe(true);
+  });
+
+  it('leaves a small file on the single-threaded path unless asked', () => {
+    expect(decodeLazPoolEnabled(OFF, false)).toBe(false);
+    expect(decodeLazPoolEnabled({ decodePool: true, decodeWorkers: null }, false)).toBe(true);
+    expect(decodeLazPoolEnabled({ decodePool: false, decodeWorkers: 2 }, false)).toBe(true);
+  });
+
+  it('?decodePool=off refuses pooling however it was asked for', () => {
+    for (const flags of [
+      { decodePool: false, decodeWorkers: null, decodePoolOff: true },
+      { decodePool: true, decodeWorkers: null, decodePoolOff: true },
+      { decodePool: false, decodeWorkers: 4, decodePoolOff: true },
+    ]) {
+      expect(decodeLazPoolEnabled(flags, true)).toBe(false);
+      expect(decodeLazPoolEnabled(flags, false)).toBe(false);
+    }
+  });
+
+  it('?decodePool=off collapses the COPC/EPT clients to one worker too', () => {
+    expect(
+      resolveDecodePoolSize('copc', { decodePool: true, decodeWorkers: 4, decodePoolOff: true }),
+    ).toBe(1);
   });
 });
 

--- a/tests/devFlags.test.ts
+++ b/tests/devFlags.test.ts
@@ -30,6 +30,7 @@ describe('parseDevFlags — defaults', () => {
       angularPrediction: true,
       streamingCommitMode: 'immediate',
       decodePool: false,
+      decodePoolOff: false,
       decodeWorkers: null,
       residentStickiness: false,
     });
@@ -81,6 +82,7 @@ describe('parseDevFlags — the program §P0 flag set', () => {
       angularPrediction: false,
       streamingCommitMode: 'immediate',
       decodePool: false,
+      decodePoolOff: false,
       decodeWorkers: null,
       residentStickiness: false,
     });

--- a/tests/lazStridedParallelDecode.test.ts
+++ b/tests/lazStridedParallelDecode.test.ts
@@ -1,0 +1,137 @@
+/**
+ * lazStridedParallelDecode.test.ts — a STRIDED chunk-parallel decode is
+ * byte-identical to the legacy strided decoder.
+ *
+ * The fast-load path decodes a huge cloud at a stride, and that sample is what
+ * the display — and every terrain product derived from it — is built on. So the
+ * parallel decode is only usable if it keeps EXACTLY the records `decodeLaz`
+ * keeps, in the same order, with every attribute the same: not the same count,
+ * the same bytes. These cases decode the committed multi-chunk LAZ both ways at
+ * several strides and compare every output array element by element, including
+ * with chunks completing out of order (what a worker pool actually does).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseLasHeader } from '../src/io/lasHeader';
+import { computeOrigin } from '../src/io/coordinateBridge';
+import { decodeLaz, getLazPerf } from '../src/io/lazDecode';
+import {
+  decodeLazChunkedSequential,
+  decodeLazParallel,
+  decodeLazChunkLocal,
+} from '../src/io/heavy/decodeLazChunked';
+import { stratifiedSampleIndices } from '../src/io/strideSample';
+import { readLazChunkTable } from '../src/io/heavy/lazChunkTable';
+import { ArrayBufferRangeSource } from '../src/io/range/ArrayBufferRangeSource';
+import type { RawPoints } from '../src/io/lasDecodeShared';
+
+function loadFixture(name: string): ArrayBuffer {
+  const b = readFileSync(resolve(__dirname, 'fixtures', name));
+  return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+}
+
+const ORIGIN: [number, number, number] = computeOrigin([500000, 4100000, 190]);
+
+/** Every array of a `RawPoints`, compared element by element. */
+function expectIdentical(actual: RawPoints, expected: RawPoints): void {
+  expect(actual.positions.length).toBe(expected.positions.length);
+  expect(actual.positions).toEqual(expected.positions);
+  expect(actual.intensity).toEqual(expected.intensity);
+  expect(actual.classification).toEqual(expected.classification);
+  expect(actual.returnNumber).toEqual(expected.returnNumber);
+  expect(actual.returnCount).toEqual(expected.returnCount);
+  expect(actual.pointSourceId).toEqual(expected.pointSourceId);
+  expect(actual.gpsTime).toEqual(expected.gpsTime);
+  expect(actual.colors).toEqual(expected.colors);
+  // The staged 16-bit buffer must be released by the single per-file narrowing,
+  // on both paths — a leftover would mean colour was narrowed somewhere else.
+  expect(actual.colors16).toBeNull();
+}
+
+describe('strided chunk-parallel LAZ decode', () => {
+  const strides = [2, 3, 7, 10, 97];
+
+  it.each(strides)('stride %i: parallel decode equals decodeLaz, element for element', async (stride) => {
+    const buf = loadFixture('multichunk.laz');
+    const header = parseLasHeader(buf);
+    const lazPerf = await getLazPerf();
+
+    const legacy = await decodeLaz(buf, header, ORIGIN, stride);
+    const parallel = await decodeLazParallel(
+      buf,
+      header,
+      ORIGIN,
+      async (job) => decodeLazChunkLocal(lazPerf, job),
+      { stride },
+    );
+
+    expect(parallel, 'chunked path supports this file').not.toBeNull();
+    expectIdentical(parallel!, legacy);
+    // The output is sized to the SAMPLE, not the file.
+    expect(parallel!.positions.length / 3).toBe(Math.ceil(header.pointCount / stride));
+  });
+
+  it.each(strides)('stride %i: the sequential chunked decoder agrees too', async (stride) => {
+    const buf = loadFixture('multichunk.laz');
+    const header = parseLasHeader(buf);
+    const legacy = await decodeLaz(buf, header, ORIGIN, stride);
+    const chunked = await decodeLazChunkedSequential(buf, header, ORIGIN, { stride });
+    expect(chunked).not.toBeNull();
+    expectIdentical(chunked!, legacy);
+  });
+
+  it('holds when the chunks complete out of order, as a worker pool makes them', async () => {
+    const buf = loadFixture('multichunk.laz');
+    const header = parseLasHeader(buf);
+    const lazPerf = await getLazPerf();
+    const legacy = await decodeLaz(buf, header, ORIGIN, 10);
+
+    // Later chunks resolve first: assembly must place by output index, never by
+    // arrival. A deterministic reversal, so the case cannot pass by luck.
+    let seen = 0;
+    const parallel = await decodeLazParallel(
+      buf,
+      header,
+      ORIGIN,
+      async (job) => {
+        const decoded = decodeLazChunkLocal(lazPerf, job);
+        const delay = 4 - (seen++ % 4);
+        for (let i = 0; i < delay; i++) await Promise.resolve();
+        return decoded;
+      },
+      { stride: 10, maxInFlight: 8 },
+    );
+    expect(parallel).not.toBeNull();
+    expectIdentical(parallel!, legacy);
+  });
+
+  it('the sample genuinely spans several chunks, so the split is exercised', async () => {
+    const buf = loadFixture('multichunk.laz');
+    const header = parseLasHeader(buf);
+    const table = await readLazChunkTable(new ArrayBufferRangeSource(buf));
+    expect(table.supported).toBe(true);
+    if (!table.supported) return;
+    expect(table.chunks.length).toBeGreaterThan(1);
+
+    // Every chunk of this fixture contributes kept records at stride 10 — the
+    // split is a real partition, not one chunk carrying the whole sample.
+    const sample = stratifiedSampleIndices(header.pointCount, 10);
+    for (const c of table.chunks) {
+      const inChunk = sample.filter(
+        (i) => i >= c.firstPointIndex && i < c.firstPointIndex + c.pointCount,
+      );
+      expect(inChunk.length).toBeGreaterThan(0);
+    }
+    expect(sample.length).toBe(Math.ceil(header.pointCount / 10));
+  });
+
+  it('fails closed on a file the chunk table cannot describe, at a stride too', async () => {
+    const tiny = loadFixture('tiny.las');
+    const header = parseLasHeader(tiny);
+    const out = await decodeLazChunkedSequential(tiny, header, computeOrigin([0, 0, 0]), {
+      stride: 5,
+    });
+    expect(out).toBeNull();
+  });
+});


### PR DESCRIPTION
laz-perf decodes sequentially, so a strided fast-load still calls `getPoint()` on every record and discards the rest. The parallel chunk decoder existed but was gated to `stride === 1` and to an opt-in flag.

The kept-record set is computed once via `stratifiedSampleIndices`, sliced at chunk boundaries, and each chunk emits its slice into a disjoint output span, so arrival order does not matter. Extraction goes through the shared `decodeRecord`. Every chunk is still decompressed in full and no chunk is skipped, so the kept points match the legacy path.

Falls back to `decodeLaz` for an unsupported chunk table, a format outside {6,7,8}, under 10M points without opt-in, or `?decodePool=off`.

Measured 3.53x at stride 10, 4 workers, 10M-point cloud.