### PR TITLE
perf(ui): defer the onboarding tour to a lazy chunk

### DIFF
--- a/src/app/tourLauncher.ts
+++ b/src/app/tourLauncher.ts
@@ -1,0 +1,31 @@
+/**
+ * tourLauncher.ts
+ *
+ * A TourHandle whose chunk loads on first use.
+ *
+ * The onboarding tour used to boot eagerly so its overlay DOM existed before
+ * either entry point could fire, which kept TourOverlay, tourSteps and their
+ * SVG spotlight machinery in the index chunk of every visit. Nothing reads
+ * that DOM until the splash chip or the palette's replay action runs, so the
+ * launcher stands in for the handle and boots the real tour behind the first
+ * call. Both entry points already tolerate a beat of latency: `start` settles
+ * layout behind a double requestAnimationFrame before the first spotlight.
+ *
+ * Boot stays once-only. The first call wins the import; every later call
+ * reuses the same booted session, so replay-after-start behaves exactly as it
+ * did when the tour booted at startup.
+ */
+import type { TourHandle } from '../ui/onboarding/bootTour';
+
+/** The shape of the lazy module the launcher boots. */
+type TourModule = { bootTour: () => TourHandle };
+
+/** A real TourHandle that defers the tour chunk until start or replay. */
+export function createTourLauncher(load: () => Promise<TourModule>): TourHandle {
+  let booted: Promise<TourHandle> | null = null;
+  const ensure = (): Promise<TourHandle> => (booted ??= load().then((m) => m.bootTour()));
+  return {
+    start: () => void ensure().then((t) => t.start()),
+    replay: () => void ensure().then((t) => t.replay()),
+  };
+}

--- a/src/lazyChunks.ts
+++ b/src/lazyChunks.ts
@@ -420,6 +420,7 @@ export const loadLasLoader = () => import('./io/loadLas');
 export const loadContextMenu = () => import('./ui/contextMenu');
 export const loadCommandPalette = () => import('./ui/CommandPalette');
 export const loadShortcutSheet = () => import('./ui/ShortcutSheet');
+export const loadTour = () => import('./ui/onboarding/bootTour');
 export const loadMeasurementExport = () => import('./export/measurementExport');
 export const loadMeasurementReport = () => import('./export/measurementReport');
 export const loadKmlExport = () => import('./export/kmlExport');

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,8 @@ import {
 } from './ui/themes';
 import type { CommandPalette } from './ui/CommandPalette';
 import type { ShortcutSheet } from './ui/ShortcutSheet';
-import { bootTour, type TourHandle } from './ui/onboarding/bootTour';
+import type { TourHandle } from './ui/onboarding/bootTour';
+import { createTourLauncher } from './app/tourLauncher';
 import { findDuplicateIds } from './ui/actionRegistry';
 import { buildActionRegistry } from './app/actionDefinitions';
 import { toggleTool } from './app/toggleTool';
@@ -225,6 +226,7 @@ import {
   loadExportStudio,
   loadReportEngine,
   loadDebugOverlay,
+  loadTour,
   loadStreamingBenchmark,
   loadInstrumentedRangeSource,
   loadViewer,
@@ -484,15 +486,17 @@ const catalogPanel = new CatalogPanel({
   },
 });
 
-// Assigned when the tour boots (below); the splash chip calls through it.
-let tour: TourHandle | null = null;
+// v0.3.9 onboarding tour, offered from the splash chip and the command
+// palette, imposed never. Deferred: the chunk boots on first start or
+// replay (app/tourLauncher.ts); boot logic lives in ui/onboarding/bootTour.ts.
+const tour: TourHandle = createTourLauncher(loadTour);
 
 const stage = new Stage(app, {
   embed,
   samples: SAMPLES,
   demoSample: DEMO_SAMPLE,
   onSample: loadFromUrl,
-  onStartTour: () => tour?.start(),
+  onStartTour: () => tour.start(),
   onOpenFile: (file) => void handleFile(file),
   // Return the promise so Stage's inline error handler can show a
   // contextual, plain-English message under the URL input + offer a Retry
@@ -1444,10 +1448,6 @@ function ensureShortcutSheet(): Promise<ShortcutSheet> {
   }
   return shortcutSheetLoading;
 }
-
-// v0.3.9 — onboarding tour; offered from the splash chip and the command
-// palette, imposed never. Boot logic lives in ui/onboarding/bootTour.ts.
-tour = bootTour();
 
 /**
  * Replay-time dispatcher — routes a recorded event back through the

--- a/src/ui/onboarding/bootTour.ts
+++ b/src/ui/onboarding/bootTour.ts
@@ -24,7 +24,7 @@ export interface TourHandle {
   readonly replay: () => void;
 }
 
-/** Build, mount, and wrap the tour. Call once at app boot. */
+/** Build, mount, and wrap the tour. Called once, by app/tourLauncher.ts on first use. */
 export function bootTour(): TourHandle {
   const session = new TourSession();
   const overlay = new TourOverlay(session);

--- a/tests/tourLauncher.test.ts
+++ b/tests/tourLauncher.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createTourLauncher } from '../src/app/tourLauncher';
+import type { TourHandle } from '../src/ui/onboarding/bootTour';
+
+function harness() {
+  const handle: TourHandle = { start: vi.fn(), replay: vi.fn() };
+  const bootTour = vi.fn(() => handle);
+  const load = vi.fn(async () => ({ bootTour }));
+  return { handle, bootTour, load, launcher: createTourLauncher(load) };
+}
+
+const settle = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe('createTourLauncher', () => {
+  it('does not load the chunk until an entry point fires', () => {
+    const { load } = harness();
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('boots on first start and forwards the call', async () => {
+    const { load, bootTour, handle, launcher } = harness();
+    launcher.start();
+    await settle();
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(bootTour).toHaveBeenCalledTimes(1);
+    expect(handle.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('boots exactly once across start and replay, in either order', async () => {
+    const { load, bootTour, handle, launcher } = harness();
+    launcher.replay();
+    launcher.start();
+    launcher.replay();
+    await settle();
+    // One import, one session: replay-after-start reuses the booted tour, the
+    // behaviour the eager boot used to guarantee.
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(bootTour).toHaveBeenCalledTimes(1);
+    expect(handle.replay).toHaveBeenCalledTimes(2);
+    expect(handle.start).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
The onboarding tour booted eagerly so its overlay DOM existed before either entry point could fire, keeping `TourOverlay`, `tourSteps` and the SVG spotlight machinery in the index chunk of every visit. Nothing reads that DOM until the splash chip or the palette's replay action runs.

A launcher (`app/tourLauncher.ts`) now stands in for the `TourHandle` and boots the tour behind the first call. Boot stays once-only: the first call wins the import and later calls reuse the booted session, so replay-after-start behaves as before. The loader rides `lazyChunks.ts`, the module the string-array transform excludes.

Live index chunk: 779 to 769 KiB. `main.ts` net zero against the ratchet. Both entry points already absorb a beat of latency behind the double requestAnimationFrame settle.