### PR TITLE
fix(terrain): blocked hold-out builds its folds like the shipped surface

### DIFF
--- a/src/terrain/contour/analyseContours.ts
+++ b/src/terrain/contour/analyseContours.ts
@@ -672,6 +672,46 @@ export function resolveGroundFilterParams(
  * Accepts a Float32Array of XYZ triples (boxed once internally) or a
  * `TerrainPoint[]`. Deterministic.
  */
+/**
+ * Options for the DtmSurfaceModel the spatially-blocked hold-out rebuilds its
+ * fold surfaces with.
+ *
+ * Exported as a pure seam so a test can pin the invariant dtmSurfaceModel.ts
+ * states in caps: the validator MUST be handed the SAME `despike` and
+ * `verticalUnitToMetres` the shipped surface used, or every fold scores a
+ * surface the viewer never delivered. The trusted class-2 path turns the
+ * despike OFF because a steep survey node is data, not a blunder, and the
+ * vertical scale sizes the despike floor and the confidence roughness on
+ * foot-vertical scans. A statistic cannot guard this: geometry the despike
+ * would remove is also geometry a held-out block cannot predict, so the two
+ * effects are confounded in any end-to-end RMSE.
+ */
+export function blockedHoldoutModelOptions(
+  dtm: { originH1: number; originH2: number; cols: number; rows: number; cellSizeM: number },
+  aggregation: DtmAggregation,
+  despikeApplied: boolean,
+  params: Pick<
+    TerrainCoreParams,
+    'isGeographic' | 'latitudeDeg' | 'horizontalUnitToMetres' | 'verticalUnitToMetres'
+  >,
+): ConstructorParameters<typeof DtmSurfaceModel>[0] {
+  return {
+    grid: {
+      originH1: dtm.originH1,
+      originH2: dtm.originH2,
+      cols: dtm.cols,
+      rows: dtm.rows,
+      cellSizeM: dtm.cellSizeM,
+    },
+    aggregation,
+    despike: despikeApplied,
+    verticalUnitToMetres: params.verticalUnitToMetres,
+    isGeographic: params.isGeographic,
+    latitudeDeg: params.latitudeDeg,
+    horizontalUnitToMetres: params.horizontalUnitToMetres,
+  };
+}
+
 export function computeTerrainCore(
   input: TerrainPointInput,
   params: TerrainCoreParams,
@@ -893,19 +933,9 @@ export function computeTerrainCore(
     const stride = Math.max(1, Math.ceil(groundXYZ.length / BLOCKED_POINT_CAP));
     const sampled = stride > 1 ? groundXYZ.filter((_, i) => i % stride === 0) : groundXYZ;
     if (sampled.length >= 32) {
-      const model = new DtmSurfaceModel({
-        grid: {
-          originH1: dtm.originH1,
-          originH2: dtm.originH2,
-          cols: dtm.cols,
-          rows: dtm.rows,
-          cellSizeM: dtm.cellSizeM,
-        },
-        aggregation,
-        isGeographic: params.isGeographic,
-        latitudeDeg: params.latitudeDeg,
-        horizontalUnitToMetres: params.horizontalUnitToMetres,
-      });
+      const model = new DtmSurfaceModel(
+        blockedHoldoutModelOptions(dtm, aggregation, despikeApplied, params),
+      );
       const raw = spatialBlockHoldout(sampled, model, {
         blockSize: dtm.cellSizeM * 8,
         folds: 4,

--- a/tests/blockedCvSurfaceParity.test.ts
+++ b/tests/blockedCvSurfaceParity.test.ts
@@ -1,0 +1,92 @@
+/**
+ * blockedCvSurfaceParity.test.ts — the blocked hold-out scores the shipped
+ * surface.
+ *
+ * dtmParity.test.ts proves an EXPLICITLY-configured DtmSurfaceModel rebuilds
+ * the delivered DTM. This suite guards the other half: the options
+ * `computeTerrainCore` hands its INTERNAL blocked-hold-out model must carry
+ * the same `despike` and `verticalUnitToMetres` the shipped surface used —
+ * dtmSurfaceModel.ts documents both as MUST-match, or every fold scores a
+ * surface the viewer never delivered.
+ *
+ * The seam is pinned directly rather than through the blocked RMSE, because
+ * the statistic confounds the two effects: geometry the despike would remove
+ * is also geometry a held-out block cannot predict, so a despiking fold and an
+ * extrapolating fold inflate the same number.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeTerrainCore,
+  blockedHoldoutModelOptions,
+  type TerrainCoreParams,
+} from '../src/terrain/contour/analyseContours';
+import type { TerrainPoint } from '../src/terrain/TerrainContracts';
+
+const CELL_SIZE_M = 2;
+
+/** A smooth tilted plane of genuine class-2 ground, dense enough (900 points)
+ *  to clear the blocked hold-out's 32-point floor. */
+function class2Cloud(): { points: TerrainPoint[]; classification: number[] } {
+  const points: TerrainPoint[] = [];
+  for (let iy = 0; iy < 30; iy++) {
+    for (let ix = 0; ix < 30; ix++) {
+      const x = ix * CELL_SIZE_M + ((ix * 7 + iy * 3) % 5) * 0.13;
+      const y = iy * CELL_SIZE_M + ((ix * 5 + iy * 11) % 5) * 0.17;
+      points.push({ x, y, z: 100 + x * 0.05 - y * 0.03 });
+    }
+  }
+  return { points, classification: points.map(() => 2) };
+}
+
+const GRID = { originH1: 0, originH2: 0, cols: 30, rows: 30, cellSizeM: CELL_SIZE_M };
+
+describe('blockedHoldoutModelOptions', () => {
+  it('carries the shipped despike decision through to the fold builds', () => {
+    // Trusted path: despike OFF. A fold that despikes would flatten the steep
+    // survey nodes the trusted path exists to keep.
+    const trusted = blockedHoldoutModelOptions(GRID, 'median', false, {});
+    expect(trusted.despike).toBe(false);
+    // Untrusted path: despike ON, mirrored the same way.
+    const untrusted = blockedHoldoutModelOptions(GRID, 'median', true, {});
+    expect(untrusted.despike).toBe(true);
+  });
+
+  it('carries the vertical scale, so a foot scan is not validated in metres', () => {
+    const opts = blockedHoldoutModelOptions(GRID, 'median', true, {
+      verticalUnitToMetres: 0.3048,
+    });
+    expect(opts.verticalUnitToMetres).toBeCloseTo(0.3048, 10);
+  });
+
+  it('mirrors every remaining MUST-match field of the shipped build', () => {
+    const opts = blockedHoldoutModelOptions(GRID, 'mean', false, {
+      isGeographic: true,
+      latitudeDeg: 47.5,
+      horizontalUnitToMetres: 111320,
+    });
+    expect(opts.aggregation).toBe('mean');
+    expect(opts.isGeographic).toBe(true);
+    expect(opts.latitudeDeg).toBe(47.5);
+    expect(opts.horizontalUnitToMetres).toBe(111320);
+    expect(opts.grid).toEqual(GRID);
+  });
+});
+
+describe('computeTerrainCore blocked hold-out', () => {
+  it('produces a blocked estimate on the trusted path with the despike off', () => {
+    const { points, classification } = class2Cloud();
+    const core = computeTerrainCore(points, {
+      cellSizeM: CELL_SIZE_M,
+      crs: 'EPSG:32610',
+      verticalDatum: 'EPSG:5703',
+      trustGroundClassification: true,
+      classification,
+    } satisfies TerrainCoreParams & { classification: number[] });
+    expect(core.despikeApplied).toBe(false);
+    expect(core.blockedAccuracy).not.toBeNull();
+    // On a plane both fold styles rebuild exactly, so the estimate is small;
+    // this is a sanity floor, not the seam guard above.
+    expect(core.blockedAccuracy!.rmse).toBeLessThan(0.25);
+  });
+});


### PR DESCRIPTION
The spatially-blocked hold-out in `computeTerrainCore` constructed its `DtmSurfaceModel` without `despike` and `verticalUnitToMetres`. Both are documented MUST-match in `dtmSurfaceModel.ts`: on the trusted class-2 path the shipped surface runs with the despike off, so the blocked estimate scored a despiked surface the viewer never delivered, and on foot-vertical scans the despike floor and confidence roughness inside fold builds were metre-sized.

The options move into an exported pure `blockedHoldoutModelOptions`, pinned by a wiring test. The seam is tested directly because the statistic confounds the defect: geometry the despike would remove is also geometry a held-out block cannot predict.

Changes the blocked diagnostic figure only; the delivered DTM is untouched.