### PR TITLE
fix(render): density heatmap bins at the cloud's estimated spacing

### DIFF
--- a/src/render/colorModes.ts
+++ b/src/render/colorModes.ts
@@ -10,7 +10,7 @@
 import { clamp, clamp01 } from '../numeric';
 import type { PointCloud } from '../model/PointCloud';
 import { sourcePositions } from '../model/pointFrames';
-import { densityForChunk, defaultCellSizeForSpacing } from './densityColors';
+import { densityForChunk, densityCellSizeFor } from './densityColors';
 import { computeElevationRange, computeScalarRange } from './elevationRange';
 import {
   coverageColorForConfidence,
@@ -54,8 +54,9 @@ export type ColorMode =
    */
   | 'returnNumber'
   /**
-   * Density heatmap — perceptual hot-cold colouring of points-per-m² in a
-   * horizontal voxel grid. Surfaces coverage gaps an analyst would otherwise
+   * Density heatmap — perceptual hot-cold colouring of points per cell in a
+   * horizontal grid binned at the cloud's own estimated spacing (relative
+   * ramp, source horizontal units). Surfaces coverage gaps an analyst would otherwise
    * miss in the single global density figure on the Scan Report. Always
    * available because it derives from positions alone.
    */
@@ -897,14 +898,14 @@ export function colorForMode(
 
     // ── density (heatmap) ───────────────────────────────────────────────────
     case 'density': {
-      // Cell size derived from the cloud's spacing when known; otherwise
-      // default to a metre. `densityForChunk` clamps internally to safe
-      // bounds, so a missing spacing value still produces a valid heatmap.
-      const spacing = (cloud as { spacing?: number }).spacing ?? 0;
-      const cellSize = defaultCellSizeForSpacing(spacing);
+      // Bin size from the cloud's own estimated planimetric spacing. The
+      // previous code read a `spacing` field PointCloud has never carried, so
+      // every cloud fell to the 1-unit default and a sparse airborne scan
+      // rendered as per-point speckle instead of a density read.
+      const positions = sourcePositions(cloud);
       return densityForChunk({
-        positions: sourcePositions(cloud),
-        cellSize,
+        positions,
+        cellSize: densityCellSizeFor(positions),
       }).colors;
     }
 

--- a/src/render/densityColors.ts
+++ b/src/render/densityColors.ts
@@ -114,9 +114,23 @@ export interface DensityColors {
  * than the data. Returns 0 (the caller's explicit "unknown" value) for fewer
  * than two points or a degenerate footprint.
  */
-export function estimatePlanimetricSpacing(positions: Float32Array): number {
+export interface XyBounds {
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minY: number;
+  readonly maxY: number;
+}
+
+/**
+ * One-pass XY bounding box of an interleaved xyz buffer, or null when it holds
+ * no points. The same scan appears a dozen times across the tree with each
+ * caller's own clamping bolted on; this copy is shared by the density-mode
+ * spacing estimate and the local-density auto-parameters, which keep their own
+ * downstream arithmetic so neither caller's numbers move.
+ */
+export function xyBounds(positions: Float32Array): XyBounds | null {
   const n = Math.floor(positions.length / 3);
-  if (n < 2) return 0;
+  if (n === 0) return null;
   let minX = Infinity;
   let maxX = -Infinity;
   let minY = Infinity;
@@ -129,7 +143,15 @@ export function estimatePlanimetricSpacing(positions: Float32Array): number {
     if (y < minY) minY = y;
     if (y > maxY) maxY = y;
   }
-  const area = (maxX - minX) * (maxY - minY);
+  return { minX, maxX, minY, maxY };
+}
+
+export function estimatePlanimetricSpacing(positions: Float32Array): number {
+  const n = Math.floor(positions.length / 3);
+  if (n < 2) return 0;
+  const b = xyBounds(positions);
+  if (b === null) return 0;
+  const area = (b.maxX - b.minX) * (b.maxY - b.minY);
   if (!Number.isFinite(area) || area <= 0) return 0;
   return Math.sqrt(area / n);
 }

--- a/src/render/densityColors.ts
+++ b/src/render/densityColors.ts
@@ -101,6 +101,49 @@ export interface DensityColors {
  * Returns a flat interleaved RGB buffer plus a small stats record useful
  * for an inspector overlay (mean / max).
  */
+/**
+ * Average planimetric spacing of a cloud, estimated in one pass from its own
+ * XY extent: sqrt(footprint area / point count).
+ *
+ * The heatmap needs SOME spacing to size its bins, and no loader records one;
+ * the old call site read a `spacing` field that has never existed on
+ * PointCloud, so every cloud binned at the 1-unit fallback and a sparse
+ * airborne scan rendered as per-point speckle rather than a density read.
+ * A bbox estimate is deliberately crude: it under-reads spacing when the
+ * footprint is mostly empty, which only makes the bins finer, never coarser
+ * than the data. Returns 0 (the caller's explicit "unknown" value) for fewer
+ * than two points or a degenerate footprint.
+ */
+export function estimatePlanimetricSpacing(positions: Float32Array): number {
+  const n = Math.floor(positions.length / 3);
+  if (n < 2) return 0;
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (let i = 0; i < n; i++) {
+    const x = positions[i * 3];
+    const y = positions[i * 3 + 1];
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+  const area = (maxX - minX) * (maxY - minY);
+  if (!Number.isFinite(area) || area <= 0) return 0;
+  return Math.sqrt(area / n);
+}
+
+/**
+ * The bin size the density mode should use for `positions`: the default cell
+ * for the cloud's own estimated spacing. Exported as the seam the colour path
+ * calls, so a test can pin that the heatmap bins from measured spacing rather
+ * than a constant.
+ */
+export function densityCellSizeFor(positions: Float32Array): number {
+  return defaultCellSizeForSpacing(estimatePlanimetricSpacing(positions));
+}
+
 export function densityForChunk(input: DensityInput): DensityColors {
   const positions = input.positions;
   const cellSize = Math.max(1e-6, input.cellSize);

--- a/src/render/localDensitySize.ts
+++ b/src/render/localDensitySize.ts
@@ -16,6 +16,8 @@
  * size multiplier in `[minScale, maxScale]`.
  */
 
+import { xyBounds } from './densityColors';
+
 /** Inputs to `localDensitySizes`. */
 export interface LocalDensitySizeInput {
   /** Interleaved x/y/z point positions (Float32Array length is 3 · N). */
@@ -57,21 +59,10 @@ export function autoDensitySizeParams(positions: Float32Array): {
   referenceDensity: number;
 } {
   const n = positions.length / 3;
-  if (n === 0) return { cellSize: 1, referenceDensity: 1 };
-  let minX = Infinity;
-  let maxX = -Infinity;
-  let minY = Infinity;
-  let maxY = -Infinity;
-  for (let i = 0; i < n; i++) {
-    const x = positions[i * 3];
-    const y = positions[i * 3 + 1];
-    if (x < minX) minX = x;
-    if (x > maxX) maxX = x;
-    if (y < minY) minY = y;
-    if (y > maxY) maxY = y;
-  }
-  const width = Math.max(maxX - minX, 1e-6);
-  const height = Math.max(maxY - minY, 1e-6);
+  const b = xyBounds(positions);
+  if (n === 0 || b === null) return { cellSize: 1, referenceDensity: 1 };
+  const width = Math.max(b.maxX - b.minX, 1e-6);
+  const height = Math.max(b.maxY - b.minY, 1e-6);
   const area = width * height;
   const referenceDensity = Math.max(1e-9, n / area);
   // Mean inter-point spacing ≈ sqrt(area / n); a cell a few spacings wide holds

--- a/tests/densityColors.test.ts
+++ b/tests/densityColors.test.ts
@@ -9,6 +9,8 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   densityForChunk,
   defaultCellSizeForSpacing,
+  estimatePlanimetricSpacing,
+  densityCellSizeFor,
 } from '../src/render/densityColors';
 
 function pack(points: ReadonlyArray<readonly [number, number, number]>): Float32Array {
@@ -137,5 +139,37 @@ describe('defaultCellSizeForSpacing', () => {
     expect(defaultCellSizeForSpacing(0)).toBe(1);
     expect(defaultCellSizeForSpacing(-1)).toBe(1);
     expect(defaultCellSizeForSpacing(NaN)).toBe(1);
+  });
+});
+
+describe('estimatePlanimetricSpacing', () => {
+  it('recovers the spacing of a regular grid from its own extent', () => {
+    // 30x30 grid at 2-unit spacing: footprint 58x58, 900 points,
+    // sqrt(3364/900) = 1.93 — within 5% of the true 2.
+    const pts: Array<readonly [number, number, number]> = [];
+    for (let iy = 0; iy < 30; iy++)
+      for (let ix = 0; ix < 30; ix++) pts.push([ix * 2, iy * 2, 0]);
+    const est = estimatePlanimetricSpacing(pack(pts));
+    expect(est).toBeGreaterThan(1.8);
+    expect(est).toBeLessThan(2.05);
+  });
+
+  it('returns 0 for the degenerate cases the caller reads as unknown', () => {
+    expect(estimatePlanimetricSpacing(new Float32Array(0))).toBe(0);
+    expect(estimatePlanimetricSpacing(pack([[1, 2, 3]]))).toBe(0);
+    // Collinear cloud: zero-area footprint.
+    expect(estimatePlanimetricSpacing(pack([[0, 0, 0], [1, 0, 0], [2, 0, 9]]))).toBe(0);
+  });
+});
+
+describe('densityCellSizeFor', () => {
+  it('bins at the default multiple of the estimated spacing, not the 1-unit fallback', () => {
+    const pts: Array<readonly [number, number, number]> = [];
+    for (let iy = 0; iy < 30; iy++)
+      for (let ix = 0; ix < 30; ix++) pts.push([ix * 2, iy * 2, 0]);
+    const cell = densityCellSizeFor(pack(pts));
+    // 5x the ~1.93 estimate; the defect this pins against was a constant 1.
+    expect(cell).toBeGreaterThan(9);
+    expect(cell).toBeLessThan(10.5);
   });
 });

--- a/tests/densityModeWiring.test.ts
+++ b/tests/densityModeWiring.test.ts
@@ -1,0 +1,41 @@
+/**
+ * tests/densityModeWiring.test.ts
+ *
+ * Pins the density colour mode's call site: `colorForMode('density')` must
+ * size its bins from the cloud's own estimated spacing. The defect this
+ * guards read a `spacing` field PointCloud has never carried, so every cloud
+ * fell to the 1-unit fallback and rendered per-point speckle.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import * as densityColors from '../src/render/densityColors';
+import { colorForMode } from '../src/render/colorModes';
+import { PointCloud } from '../src/model/PointCloud';
+
+vi.mock('../src/render/densityColors', { spy: true });
+
+function gridCloud(): PointCloud {
+  const n = 30 * 30;
+  const positions = new Float32Array(n * 3);
+  let i = 0;
+  for (let iy = 0; iy < 30; iy++) {
+    for (let ix = 0; ix < 30; ix++) {
+      positions[i * 3] = ix * 2;
+      positions[i * 3 + 1] = iy * 2;
+      positions[i * 3 + 2] = 0;
+      i++;
+    }
+  }
+  return new PointCloud({ positions, origin: [0, 0, 0], sourceFormat: 'las', name: 'wiring-density.las' });
+}
+
+describe('density mode bin sizing', () => {
+  it('hands densityForChunk a cell sized from the estimated spacing', () => {
+    colorForMode('density', gridCloud());
+    expect(densityColors.densityForChunk).toHaveBeenCalledTimes(1);
+    const arg = vi.mocked(densityColors.densityForChunk).mock.calls[0][0];
+    // ~5x the grid's ~1.93 estimate; the defect pinned against was exactly 1.
+    expect(arg.cellSize).toBeGreaterThan(9);
+    expect(arg.cellSize).toBeLessThan(10.5);
+  });
+});


### PR DESCRIPTION
`colorForMode('density')` read `cloud.spacing`, a field `PointCloud` has never carried, so the cast always yielded 0 and every cloud binned at the 1-unit fallback. A sparse airborne scan rendered as per-point speckle rather than a density read, and the mode's doc promised points-per-square-metre for a source-unit ramp.

The bin size now comes from `densityCellSizeFor`: a one-pass planimetric spacing estimate, sqrt(footprint area / point count), through the existing 5x-spacing default. Degenerate clouds keep the old fallback. A wiring test pins the call site; the estimate and its edge cases carry their own tests.

Display only. No terrain or analysis product changes.