### PR TITLE
fix(qa): wire median spacing and full classification into live QA signals

### DIFF
--- a/docs/architecture/float64-frame-migration-plan.md
+++ b/docs/architecture/float64-frame-migration-plan.md
@@ -93,7 +93,7 @@ The gate's number is the larger one because it also counts the reads inside
 frame mistake there is wrong everywhere at once, so the gate has to see it. This
 plan's number is the migration surface, which is consumers only.
 
-Measured, `outside-model`: 136 direct `.positions` reads across 43 files. Both
+Measured, `outside-model`: 141 direct `.positions` reads across 44 files. Both
 numbers are regenerated from the tree rather than quoted from memory, because
 they drift as code moves — they rose to 162 across 43 files while the placement
 architecture was landing, and have since fallen as consumers moved onto the

--- a/docs/validation/position-access-baseline.json
+++ b/docs/validation/position-access-baseline.json
@@ -1,9 +1,10 @@
 {
-  "total": 155,
+  "total": 160,
   "files": {
     "src/app/epochFramePrep.ts": 2,
     "src/app/featureExtractionInput.ts": 1,
     "src/app/floorPlanPositions.ts": 4,
+    "src/app/processStudioMount.ts": 5,
     "src/app/terrainAnalysisRunner.ts": 3,
     "src/io/copc/copcChunkDecode.ts": 1,
     "src/io/heavy/chunkedLazSource.ts": 1,

--- a/docs/validation/position-frames.json
+++ b/docs/validation/position-frames.json
@@ -29,6 +29,20 @@
       "why": "Both branches are gather output: the denser re-gather, or the space-export context that was itself copied from a gather. Extracted verbatim from main.ts; the carrier is passed in so both reads stay here."
     },
     {
+      "file": "src/app/processStudioMount.ts",
+      "symbol": "createProcessStudioFromShell.getActiveCloudData",
+      "frame": "source-local",
+      "reads": 2,
+      "why": "Hands the active static cloud's own buffer (plus its header-declared total) to the spacing probe. The shell type keeps positions structurally optional so a test fake without them reads as no data; a real accessor would force the concrete PointCloud through the seam."
+    },
+    {
+      "file": "src/app/processStudioMount.ts",
+      "symbol": "probedSpacingSourceUnits",
+      "frame": "source-local",
+      "reads": 3,
+      "why": "The spacing probe measures nearest-neighbour distance in the cloud's own source units (the QA signal converts to metres afterwards through the resolved CRS), and the buffer doubles as the memo key so a repaint never re-probes. Translation-invariant, so any frame gives the same figure; source-local is what the structural shell hands over."
+    },
+    {
       "file": "src/app/terrainAnalysisRunner.ts",
       "symbol": "createTerrainAnalysisRunner.buildResultForExport",
       "frame": "project-local",

--- a/src/app/processStudioMount.ts
+++ b/src/app/processStudioMount.ts
@@ -41,6 +41,8 @@ import type { PreflightLiveReads } from './toolPreflightInput';
 import type { PreflightActionHost } from './preflightActions';
 import type { PreflightActionRunner, PreflightView } from './toolPreflightRuntime';
 import { loadToolPreflight } from '../lazyChunks';
+import { isLinearUnitKnown } from '../geo/CoordinateTypes';
+import { medianNeighbourSpacing } from '../terrain/objectMetrics';
 
 /** LAS standard classification codes the panel keys ground/building on. */
 const CLASS_GROUND = 2;
@@ -75,14 +77,54 @@ export interface LiveScanAccessors {
   /** True when the present classification was DERIVED by OLV (heuristic), not
    *  carried by the producer. Distinguishes trusted vs derived ground/buildings. */
   getClassificationDerived(): boolean;
+  /**
+   * The active STATIC cloud's raw positions (local, source units) and the point
+   * total its header declared, for the one cheap probe this module runs: median
+   * nearest-neighbour spacing. Optional, and null when no static cloud is
+   * loaded; either absence simply leaves `medianSpacing` unstated, which the QA
+   * cloud-quality check reads as review ("not measured yet"), never a figure.
+   */
+  getActiveCloudData?():
+    | { readonly positions: Float32Array; readonly declaredPointCount?: number | null }
+    | null
+    | undefined;
+}
+
+/**
+ * Per-buffer memo of the spacing probe, in SOURCE units. A cloud's positions
+ * buffer is immutable once loaded, so one probe per buffer is exact for its
+ * life; the metre conversion stays OUTSIDE the memo so a later CRS override
+ * re-scales the same measurement instead of re-probing (or worse, keeping the
+ * old unit). WeakMap, so a closed scan's entry goes with its buffer.
+ */
+const spacingProbeCache = new WeakMap<Float32Array, number>();
+
+/** The memoised probe. Loaded positions can be a uniform display sample of the
+ *  file, so the header's declared total feeds the estimator's √(P/N) density
+ *  correction and the figure describes the SCAN, not the sample. */
+function probedSpacingSourceUnits(data: {
+  readonly positions: Float32Array;
+  readonly declaredPointCount?: number | null;
+}): number {
+  const hit = spacingProbeCache.get(data.positions);
+  if (hit !== undefined) return hit;
+  const value = medianNeighbourSpacing(data.positions, {
+    sourcePointCount: data.declaredPointCount ?? undefined,
+  });
+  spacingProbeCache.set(data.positions, value);
+  return value;
 }
 
 /**
  * Build the loose signal set from live accessors, fail-closed. A streaming
  * source wins over a static cloud (it is the active scan when mounted). Returns
- * null when nothing is loaded. Classification is reported as `partial` whenever
- * any class code is present — the conservative floor, never `full` — and ground
- * / building trust follows only from the actual class-2 / class-6 codes.
+ * null when nothing is loaded. Classification presence starts at the `partial`
+ * floor whenever any class code is present, rises to `full` only when a STATIC
+ * cloud's producer classification leaves no point in class 0 (never classified)
+ * or class 1 (unclassified), so every point carries a real class, and ground
+ * / building trust follows only from the actual class-2 / class-6 codes. A
+ * streaming legend tallies decoded nodes only, and a derived classification is
+ * a heuristic, so neither can prove fullness; both stay at `partial`.
  *
  * PRESENCE AND SIZE ARE SEPARATE. Whether a scan is loaded comes from the
  * mounted source; how many points it has comes from the format. A format that
@@ -102,15 +144,46 @@ export function signalsFromLive(a: LiveScanAccessors): RawScanSignals | null {
   const classificationProvenance = !hasClasses
     ? 'none'
     : (a.getClassificationDerived() ? 'derived' : 'producer');
+  // Presence: `full` needs a static cloud, a producer classification and no
+  // class 0 / class 1 in the legend, i.e. every loaded point carries a real
+  // class. Anything weaker stays at the `partial` floor as before.
+  const classification = !hasClasses
+    ? 'none'
+    : classificationProvenance === 'producer' &&
+        !isStreaming &&
+        !codes.includes(0) &&
+        !codes.includes(1)
+      ? 'full'
+      : 'partial';
+  const crs = a.getResolvedCrs() ?? null;
+  // Median spacing, in METRES: the memoised probe over the static cloud's
+  // positions, scaled by the resolved unit. Withheld (leaving the QA check at
+  // its honest "not measured" review) for a streaming scan, an absent data
+  // read, an unknown linear unit, or a probe that measured nothing. A throwing
+  // read also withholds it rather than costing the whole signal set.
+  let medianSpacing: number | undefined;
+  if (!isStreaming && crs != null && isLinearUnitKnown(crs)) {
+    try {
+      const data = a.getActiveCloudData?.();
+      const u2m = crs.linearUnitToMetres;
+      if (data != null && Number.isFinite(u2m) && u2m > 0) {
+        const spacing = probedSpacingSourceUnits(data) * u2m;
+        if (Number.isFinite(spacing) && spacing > 0) medianSpacing = spacing;
+      }
+    } catch {
+      medianSpacing = undefined;
+    }
+  }
   const pointCount = isStreaming ? streamPts : staticPts;
   return {
     kind: isStreaming ? 'streaming' : 'static',
     // Omitted, not zeroed, when the source states no total: `RawScanSignals`
     // leaves `pointCount` optional precisely so an unstated size stays unstated.
     ...(pointCount == null ? {} : { pointCount }),
-    crs: a.getResolvedCrs() ?? null,
-    classification: hasClasses ? 'partial' : 'none',
+    crs,
+    classification,
     classificationProvenance,
+    ...(medianSpacing === undefined ? {} : { medianSpacing }),
     groundClassified: codes.includes(CLASS_GROUND),
     hasBuildingClass: codes.includes(CLASS_BUILDING),
   };
@@ -248,8 +321,19 @@ export interface StudioViewer {
  */
 export interface ProcessStudioShell {
   getViewer(): StudioViewer;
-  /** The active STATIC cloud, or null when none is loaded. */
-  getActiveCloud(): { readonly pointCount: number } | null | undefined;
+  /**
+   * The active STATIC cloud, or null when none is loaded. `positions` and
+   * `declaredPointCount` are structurally optional (a fake without them reads
+   * as "no data", so spacing stays unstated); the live cloud carries both.
+   */
+  getActiveCloud():
+    | {
+        readonly pointCount: number;
+        readonly positions?: Float32Array;
+        readonly declaredPointCount?: number;
+      }
+    | null
+    | undefined;
   /** The active scan's id (streaming-aware), so companion layers exclude it. */
   getActiveLayerId(): string | null;
   /** The CRS service: the active scan's resolved CRS and its spatial context. */
@@ -314,6 +398,15 @@ export function createProcessStudioFromShell(shell: ProcessStudioShell): Mounted
     getResolvedCrs: () => shell.crsService.current(),
     getPresentClassCodes: () => shell.classLegend.presentCodes(),
     getClassificationDerived: () => shell.classLegend.classificationIsDerived(),
+    // The spacing probe's input: the active static cloud's own buffer and its
+    // header-declared total. A cloud without positions (or no cloud) is "no
+    // data", and the spacing signal stays unstated.
+    getActiveCloudData: () => {
+      const cloud = shell.getActiveCloud();
+      return cloud?.positions
+        ? { positions: cloud.positions, declaredPointCount: cloud.declaredPointCount ?? null }
+        : null;
+    },
   };
   return createProcessStudio({
     getSignals: () => signalsFromLive(accessors),

--- a/src/terrain/objectMetrics.ts
+++ b/src/terrain/objectMetrics.ts
@@ -105,6 +105,58 @@ const sortedBox = (a: number, b: number, c: number): BoxDims => {
   return { lengthM: s[0], widthM: s[1], heightM: s[2] };
 };
 
+/**
+ * The median nearest-neighbour spacing probe on its own, for callers that need
+ * the scan's effective resolution and nothing else (the QA cloud-quality
+ * signal). Same estimator {@link objectMetrics} embeds: a strided probe
+ * subsample, brute-force nearest neighbour, the median, then the √(P/N)
+ * density correction when `positions` is itself a uniform sample of a larger
+ * scan (pass that scan's count as `sourcePointCount`). Returns the spacing in
+ * the units of `positions`, or 0 when it cannot be measured. Deterministic and
+ * O(probe²), independent of the cloud size.
+ */
+export function medianNeighbourSpacing(
+  positions: Float32Array | ReadonlyArray<number>,
+  params: Pick<ObjectMetricsParams, 'probeSamples' | 'sourcePointCount'> = {},
+): number {
+  const n = Math.floor(positions.length / 3);
+  if (n < 4) return 0;
+  const probeN = Math.min(n, Math.max(50, Math.floor(params.probeSamples ?? 2000)));
+  const stride = Math.max(1, Math.floor(n / probeN));
+  const px: number[] = [], py: number[] = [], pz: number[] = [];
+  for (let i = 0; i < n; i += stride) {
+    const b = i * 3;
+    const x = positions[b], y = positions[b + 1], z = positions[b + 2];
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
+    px.push(x); py.push(y); pz.push(z);
+  }
+  const P = px.length;
+  if (P < 2) return 0;
+  const nnDist: number[] = [];
+  for (let i = 0; i < P; i++) {
+    let best = Infinity;
+    for (let j = 0; j < P; j++) {
+      if (j === i) continue;
+      const dx = px[i] - px[j], dy = py[i] - py[j], dz = pz[i] - pz[j];
+      const d2 = dx * dx + dy * dy + dz * dz;
+      if (d2 < best) best = d2;
+    }
+    if (Number.isFinite(best)) nnDist.push(Math.sqrt(best));
+  }
+  nnDist.sort((a, b) => a - b);
+  const probeSpacing = nnDist.length ? nnDist[Math.floor(nnDist.length / 2)] : 0;
+  // The probe measures P points of a scan of N; for a uniform sample of a 2-D
+  // manifold spacing scales as 1/√density, so the scan's spacing is the
+  // probe's × √(P/N). Same correction as objectMetrics above.
+  const fullCount = Math.max(
+    n,
+    Number.isFinite(params.sourcePointCount) && (params.sourcePointCount as number) > 0
+      ? Math.floor(params.sourcePointCount as number)
+      : 0,
+  );
+  return fullCount > P ? probeSpacing * Math.sqrt(P / fullCount) : probeSpacing;
+}
+
 export function objectMetrics(
   positions: Float32Array | ReadonlyArray<number>,
   params: ObjectMetricsParams = {},

--- a/tests/processStudioMount.test.ts
+++ b/tests/processStudioMount.test.ts
@@ -5,7 +5,9 @@
 import { describe, it, expect } from 'vitest';
 import { resolveActiveScanFacts, signalsFromLive } from '../src/app/processStudioMount';
 import type { LiveScanAccessors } from '../src/app/processStudioMount';
+import { deriveScanFacts } from '../src/process/scanFacts';
 import type { RawScanSignals } from '../src/process/scanFacts';
+import { runQaChecks } from '../src/qa/qaChecks';
 import type { CrsInfo } from '../src/io/crs';
 import { spatialContextFrom } from '../src/geo/SpatialContext';
 import { preflightSnapshot } from '../src/app/toolPreflightInput';
@@ -192,5 +194,140 @@ describe('a streaming source with no stated point total', () => {
     });
     const distance = preflights.find((p) => p.tool === 'measure-distance');
     expect(distance?.status).not.toBe('blocked');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// QA signal wiring: median spacing and full classification
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `tests/qaChecks.test.ts` pins the checks; this pins the WIRING. The mount
+ * used to supply neither `medianSpacing` nor a `full` classification, so the
+ * CLOUD_QUALITY check could only ever answer "not measured yet" and the
+ * CLASSIFICATION check could never pass, whatever the loaded scan carried.
+ * The live signals now measure spacing from the active static cloud's own
+ * positions (converted to metres through the resolved unit) and state `full`
+ * when a producer classification leaves no point unclassified.
+ */
+
+/** A flat 10 x 10 grid at 1.0 source-unit spacing, z = 0. */
+function gridPositions(): Float32Array {
+  const out = new Float32Array(10 * 10 * 3);
+  let k = 0;
+  for (let gy = 0; gy < 10; gy++) {
+    for (let gx = 0; gx < 10; gx++) {
+      out[k++] = gx;
+      out[k++] = gy;
+      out[k++] = 0;
+    }
+  }
+  return out;
+}
+
+const footCrs = { ...metreCrs, linearUnit: 'foot', linearUnitToMetres: 0.3048 } as CrsInfo;
+
+function staticGridScan(overrides: Partial<LiveScanAccessors> = {}): LiveScanAccessors {
+  return {
+    ...noScan,
+    getActivePointCount: () => 100,
+    getResolvedCrs: () => metreCrs,
+    getActiveCloudData: () => ({ positions: gridPositions() }),
+    ...overrides,
+  };
+}
+
+describe('signalsFromLive measures median spacing for the QA cloud-quality check', () => {
+  it('carries the probed spacing, in metres, on a static cloud with a known unit', () => {
+    const sig = signalsFromLive(staticGridScan())!;
+    expect(sig.medianSpacing).toBeCloseTo(1.0, 6);
+    const checks = runQaChecks(deriveScanFacts(sig));
+    const quality = checks.find((c) => c.id === 'CLOUD_QUALITY')!;
+    expect(quality.status).toBe('pass');
+    expect(quality.reason).toContain('1.00 m');
+  });
+
+  it('converts a foot-unit CRS into metres rather than stamping source units', () => {
+    const sig = signalsFromLive(staticGridScan({ getResolvedCrs: () => footCrs }))!;
+    expect(sig.medianSpacing).toBeCloseTo(0.3048, 6);
+  });
+
+  it('corrects for a display sample using the header-declared total', () => {
+    // The loaded 100 points are a uniform sample of a declared 400-point file,
+    // so the file's spacing is the probe's x sqrt(100/400) = half.
+    const sig = signalsFromLive(
+      staticGridScan({
+        getActiveCloudData: () => ({ positions: gridPositions(), declaredPointCount: 400 }),
+      }),
+    )!;
+    expect(sig.medianSpacing).toBeCloseTo(0.5, 6);
+  });
+
+  it('withholds spacing when the linear unit is unknown, fail-closed', () => {
+    const sig = signalsFromLive(staticGridScan({ getResolvedCrs: () => null }))!;
+    expect(sig.medianSpacing).toBeUndefined();
+  });
+
+  it('withholds spacing for a streaming scan (no resident buffer to probe)', () => {
+    const sig = signalsFromLive(
+      staticGridScan({ hasStreamingSource: () => true, getStreamingPointCount: () => 1000 }),
+    )!;
+    expect(sig.kind).toBe('streaming');
+    expect(sig.medianSpacing).toBeUndefined();
+  });
+
+  it('withholds spacing when the shell offers no cloud data', () => {
+    const sig = signalsFromLive(staticGridScan({ getActiveCloudData: undefined }))!;
+    expect(sig.medianSpacing).toBeUndefined();
+  });
+
+  it('degrades a throwing data read to an unstated spacing, never a lost scan', () => {
+    const sig = signalsFromLive(
+      staticGridScan({ getActiveCloudData: () => { throw new Error('buffer gone'); } }),
+    );
+    expect(sig).not.toBeNull();
+    expect(sig?.medianSpacing).toBeUndefined();
+  });
+});
+
+describe('signalsFromLive states a full classification when the producer left none unclassified', () => {
+  it('emits full for a static producer classification with no class 0 or 1', () => {
+    const sig = signalsFromLive(staticGridScan({ getPresentClassCodes: () => [2, 3, 6] }))!;
+    expect(sig.classification).toBe('full');
+    const checks = runQaChecks(deriveScanFacts(sig));
+    expect(checks.find((c) => c.id === 'CLASSIFICATION')?.status).toBe('pass');
+  });
+
+  it('stays partial while class 1 (unclassified) points remain', () => {
+    const sig = signalsFromLive(staticGridScan({ getPresentClassCodes: () => [1, 2, 6] }))!;
+    expect(sig.classification).toBe('partial');
+  });
+
+  it('stays partial while class 0 (never classified) points remain', () => {
+    const sig = signalsFromLive(staticGridScan({ getPresentClassCodes: () => [0, 2] }))!;
+    expect(sig.classification).toBe('partial');
+  });
+
+  it('never claims full for a derived classification (a heuristic, not a survey)', () => {
+    const sig = signalsFromLive(
+      staticGridScan({ getPresentClassCodes: () => [2, 6], getClassificationDerived: () => true }),
+    )!;
+    expect(sig.classification).toBe('partial');
+  });
+
+  it('never claims full for a streaming scan (the legend tallies decoded nodes only)', () => {
+    const sig = signalsFromLive(
+      staticGridScan({
+        hasStreamingSource: () => true,
+        getStreamingPointCount: () => 1000,
+        getPresentClassCodes: () => [2, 6],
+      }),
+    )!;
+    expect(sig.classification).toBe('partial');
+  });
+
+  it('still reports none for an unclassified cloud', () => {
+    const sig = signalsFromLive(staticGridScan())!;
+    expect(sig.classification).toBe('none');
   });
 });


### PR DESCRIPTION
`signalsFromLive` never supplied `medianSpacing`, so the CLOUD_QUALITY check permanently answered "Point spacing has not been measured yet", and it only ever emitted `partial`/`none`, so CLASSIFICATION could never pass on a fully classified cloud.

A new `medianNeighbourSpacing` export reuses the probe estimator `objectMetrics` already embeds (strided ~2000-point subsample, median nearest-neighbour, sqrt correction for display samples), memoised per buffer and converted through the resolved CRS unit; unknown units and streaming scans keep the honest review state. `full` is emitted for a static scan whose producer classification carries no code 0 or 1.

QA panel wording only; the existing `objectMetrics` function and every computed product are untouched.