### PR TITLE
fix(validation): compensated summation in the checkpoint and grid statistics

### DIFF
--- a/src/validation/checkpointAccuracy.ts
+++ b/src/validation/checkpointAccuracy.ts
@@ -29,6 +29,8 @@
  * Pure arithmetic over plain arrays. No I/O, no DOM.
  */
 
+import { NeumaierSum } from '../process/numerics';
+
 /**
  * How a checkpoint was used. Only `independent` may enter an accuracy figure.
  *
@@ -376,14 +378,16 @@ function statsOf(
   const n = residuals.length;
   if (n === 0) return EMPTY_STATS;
 
-  let sum = 0;
-  let sumSq = 0;
+  // Compensated accumulation: a long residual list mixing large and small
+  // magnitudes loses low-order bits under naive `sum += r`.
+  const sumAcc = new NeumaierSum();
+  const sumSqAcc = new NeumaierSum();
   for (let i = 0; i < n; i++) {
-    sum += residuals[i];
-    sumSq += residuals[i] * residuals[i];
+    sumAcc.add(residuals[i]);
+    sumSqAcc.add(residuals[i] * residuals[i]);
   }
-  const bias = sum / n;
-  const rmse = Math.sqrt(sumSq / n);
+  const bias = sumAcc.total / n;
+  const rmse = Math.sqrt(sumSqAcc.total / n);
 
   const sorted = [...residuals].sort((a, b) => a - b);
   const median = quantileSorted(sorted, 0.5);
@@ -395,12 +399,12 @@ function statsOf(
   // spread to estimate, so the interval is null rather than zero-width.
   let standardError: number | null = null;
   if (n > 1) {
-    let ss = 0;
+    const ssAcc = new NeumaierSum();
     for (let i = 0; i < n; i++) {
       const d = residuals[i] - bias;
-      ss += d * d;
+      ssAcc.add(d * d);
     }
-    standardError = Math.sqrt(ss / (n - 1)) / Math.sqrt(n);
+    standardError = Math.sqrt(ssAcc.total / (n - 1)) / Math.sqrt(n);
   }
 
   // Coverage of the reference uncertainty over the group. sigmaCount counts the

--- a/src/validation/gridAgreement.ts
+++ b/src/validation/gridAgreement.ts
@@ -25,6 +25,8 @@
  * here validates any product; it only compares two arrays the caller supplies.
  */
 
+import { NeumaierSum } from '../process/numerics';
+
 /** Grid geometry. Two rasters are comparable only when all five agree. */
 export interface GridSpec {
   readonly originX: number;
@@ -266,20 +268,25 @@ function statsOf(signed: readonly number[], tolerance: number): ErrorStats {
       withinToleranceFraction: null,
     };
   }
-  let sum = 0;
-  let sumSq = 0;
-  let sumAbs = 0;
+  // Compensated accumulation: cell counts reach the millions, where a naive
+  // running sum drifts by O(N·ε) and mixed magnitudes drop low-order bits.
+  const sumAcc = new NeumaierSum();
+  const sumSqAcc = new NeumaierSum();
+  const sumAbsAcc = new NeumaierSum();
   let within = 0;
   const abs: number[] = [];
   for (let i = 0; i < n; i++) {
     const d = signed[i];
     const a = Math.abs(d);
-    sum += d;
-    sumSq += d * d;
-    sumAbs += a;
+    sumAcc.add(d);
+    sumSqAcc.add(d * d);
+    sumAbsAcc.add(a);
     if (a <= tolerance) within++;
     abs.push(a);
   }
+  const sum = sumAcc.total;
+  const sumSq = sumSqAcc.total;
+  const sumAbs = sumAbsAcc.total;
   const sortedSigned = [...signed].sort((x, y) => x - y);
   const sortedAbs = abs.toSorted((x, y) => x - y);
   const median = quantileSorted(sortedSigned, 0.5);

--- a/tests/checkpointAccuracy.test.ts
+++ b/tests/checkpointAccuracy.test.ts
@@ -443,3 +443,42 @@ describe('checkpointAccuracy partial reference-uncertainty coverage', () => {
     expect(r.pooled.combinedRmse).toBeNull();
   });
 });
+
+describe('checkpointAccuracy compensated summation', () => {
+  // Residuals [1e16, 1, -1e16]: the true sum is 1, so the true bias is 1/3.
+  // Naive accumulation loses the 1 entirely (1e16 + 1 rounds to 1e16, then
+  // -1e16 cancels to 0), reporting bias 0. The Neumaier accumulator keeps it.
+  it('keeps the bias where a naive running sum cancels to zero', () => {
+    const r = checkpointAccuracy(
+      [
+        { id: 'big+', reference: 0, measured: 1e16, usage: 'independent' },
+        { id: 'one', reference: 0, measured: 1, usage: 'independent' },
+        { id: 'big-', reference: 0, measured: -1e16, usage: 'independent' },
+      ],
+      { minSample: 3 },
+    );
+    expect(r.status).toBe('reported');
+    if (r.status !== 'reported') return;
+    // Reference: exact integer arithmetic (1e16 and 1 are exact doubles).
+    expect(r.pooled.bias).toBeCloseTo(1 / 3, 12);
+  });
+
+  it('does not drift over a long alternating tail behind a large head', () => {
+    // Head 1e8 followed by 2000 alternating ±0.1 pairs and one final +1:
+    // the exact sum is 1e8 + 1. Each ±0.1 pair cancels exactly in real
+    // arithmetic; naive floating addition against the 1e8 head leaks rounding
+    // error every step, while the compensated bias stays at the true mean.
+    const checkpoints = [{ id: 'head', reference: 0, measured: 1e8, usage: 'independent' as const }];
+    for (let i = 0; i < 2000; i++) {
+      checkpoints.push({ id: `p${i}`, reference: 0, measured: 0.1, usage: 'independent' as const });
+      checkpoints.push({ id: `m${i}`, reference: 0, measured: -0.1, usage: 'independent' as const });
+    }
+    checkpoints.push({ id: 'tail', reference: 0, measured: 1, usage: 'independent' as const });
+    const r = checkpointAccuracy(checkpoints, { minSample: 3 });
+    expect(r.status).toBe('reported');
+    if (r.status !== 'reported') return;
+    const n = checkpoints.length;
+    // Reference sum computed by pairing: (1e8 + 1) exactly.
+    expect(r.pooled.bias! * n).toBeCloseTo(1e8 + 1, 6);
+  });
+});

--- a/tests/gridAgreement.test.ts
+++ b/tests/gridAgreement.test.ts
@@ -488,3 +488,18 @@ describe('compareGridsCircular', () => {
     expect(r.value.withinToleranceFraction).toBe(0);
   });
 });
+
+describe('compareGrids compensated summation', () => {
+  // Signed errors [1e16, 1, -1e16, 0]: the true sum is 1, mean 0.25. Naive
+  // accumulation cancels the 1 away (1e16 + 1 rounds to 1e16) and reports
+  // mean 0; the Neumaier accumulator keeps it.
+  it('keeps the mean signed error where a naive running sum cancels', () => {
+    const a = raster([1e16, 1, -1e16, 0]);
+    const b = raster([0, 0, 0, 0]);
+    const r = compareGrids(a, b, { tolerance: 2e16 });
+    expect(r.status).toBe('compared');
+    if (r.status !== 'compared') return;
+    // Reference: exact integer arithmetic (1e16 and 1 are exact doubles).
+    expect(r.value.meanSignedError).toBeCloseTo(0.25, 12);
+  });
+});

--- a/validation/cross-implementation/pdal-pipeline/results-dsm.json
+++ b/validation/cross-implementation/pdal-pipeline/results-dsm.json
@@ -31,7 +31,7 @@
       "maxHeightAboveGroundM": 7.916999816894531,
       "withinToleranceFraction": 1,
       "maxAbsErrorM": 0.000003784179682497779,
-      "rmseM": 0.000002183820831363381,
+      "rmseM": 0.0000021838208313633712,
       "meanSignedErrorM": 1.5744628892093716e-7
     },
     {
@@ -49,7 +49,7 @@
       "maxHeightAboveGroundM": 8.271003723144531,
       "withinToleranceFraction": 1,
       "maxAbsErrorM": 0.000003784179682497779,
-      "rmseM": 0.0000021470998586194545,
+      "rmseM": 0.000002147099858619457,
       "meanSignedErrorM": -1.3818359235528988e-8
     },
     {
@@ -67,7 +67,7 @@
       "maxHeightAboveGroundM": 8.944999694824219,
       "withinToleranceFraction": 1,
       "maxAbsErrorM": 0.000003784179682497779,
-      "rmseM": 0.000002148685786946998,
+      "rmseM": 0.000002148685786946977,
       "meanSignedErrorM": -1.420898401534032e-8
     }
   ],

--- a/validation/cross-implementation/pdal-pipeline/results-dtm.json
+++ b/validation/cross-implementation/pdal-pipeline/results-dtm.json
@@ -28,7 +28,7 @@
       "onlyOlv": 0,
       "withinToleranceFraction": 1,
       "maxAbsErrorM": 0.000003662109378410605,
-      "rmseM": 0.0000022006538538650567,
+      "rmseM": 0.0000022006538538650372,
       "meanSignedErrorM": 0
     },
     {
@@ -60,7 +60,7 @@
       "onlyOlv": 0,
       "withinToleranceFraction": 1,
       "maxAbsErrorM": 0.000003662109378410605,
-      "rmseM": 0.0000022006538538650546,
+      "rmseM": 0.0000022006538538650372,
       "meanSignedErrorM": 0
     }
   ],

--- a/validation/cross-implementation/studies/DSM-PDAL-WRITERS-GDAL.study.json
+++ b/validation/cross-implementation/studies/DSM-PDAL-WRITERS-GDAL.study.json
@@ -75,7 +75,7 @@
     }
   ],
   "metrics": {
-    "toleranceAbs": 0.00005,
+    "toleranceAbs": 5e-05,
     "toleranceUnit": "metre",
     "minimumComparableCells": 7500,
     "requiredWithinToleranceFraction": 1
@@ -86,9 +86,9 @@
     "comparableCells": 7500,
     "skippedCells": 0,
     "withinToleranceFraction": 1,
-    "maxAbsDiff": 0.000003784179682497779,
-    "rmse": 0.0000021599353259922987,
-    "meanDiff": 4.313964855668928e-8
+    "maxAbsDiff": 3.784179682497779e-06,
+    "rmse": 2.1599353259922987e-06,
+    "meanDiff": 4.313964855668928e-08
   },
   "rawArtifacts": [
     {
@@ -175,7 +175,7 @@
   "derivedArtifacts": [
     {
       "path": "validation/cross-implementation/pdal-pipeline/results-dsm.json",
-      "sha256": "0f4136c9742e9675911d40f1d4c67684574c48b67ccb560b8577e25d8c5844ad",
+      "sha256": "e946d22d6461253ec622afacfda818f18abfae532406042acded957f5fd70d26",
       "derivedFrom": [
         "validation/cross-implementation/pdal-pipeline/fixtures/pc-09-plane-structures.csv",
         "validation/cross-implementation/pdal-pipeline/fixtures/pc-10-rolling-structures.csv",

--- a/validation/cross-implementation/studies/DTM-PDAL-WRITERS-GDAL.study.json
+++ b/validation/cross-implementation/studies/DTM-PDAL-WRITERS-GDAL.study.json
@@ -173,7 +173,7 @@
   "derivedArtifacts": [
     {
       "path": "validation/cross-implementation/pdal-pipeline/results-dtm.json",
-      "sha256": "2d4867f4a32cd5d49ac570f3484c92538aa9c2bd7ac1187b8ce0819011c1fd35",
+      "sha256": "76ba4084c528fb9f846bc735fd702023ccf0af901eaf746c4f0620265c56798e",
       "derivedFrom": [
         "validation/cross-implementation/pdal-pipeline/fixtures/pc-06-bare-plane.csv",
         "validation/cross-implementation/pdal-pipeline/fixtures/pc-07-bare-rolling.csv",


### PR DESCRIPTION
`checkpointAccuracy` and `gridAgreement` accumulated residual statistics with naive summation while `process/numerics.ts` ships Neumaier; both now stream through `NeumaierSum`, with cancellation tests that fail on the naive form (residual patterns like [1e16, 1, -1e16] collapse to zero under naive accumulation).

The PDAL agreement evidence regenerates in the same change: the compensated sums move the last one or two digits of the recorded micrometre-scale `rmseM` figures, and landing code and evidence together keeps the committed bytes one thing. The freeze, digest-manifest, claim-register and oracle-consensus gates pass on the regenerated files.

Validation-harness only; no production import of either module exists.