### PR TITLE
build: pin LocalFileRangeSource to its own chunk

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -486,6 +486,15 @@ export default defineConfig(({ mode }) => ({
           // reaching gradeForConfidence — can't let the heuristic hoist it into
           // the eager index bundle and blow its budget.
           if (id.includes('/terrain/ground/cellConfidence')) return 'cellConfidence';
+          // LocalFileRangeSource is reached only through lazyChunks' dynamic
+          // import, and rolldown emits it as its own chunk today. Pinning it
+          // states that boundary explicitly: rolldown 1.2.6 changed its
+          // inlining heuristic and began folding this module into the shell,
+          // putting the out-of-core reader into the bundle every visitor
+          // downloads first. Same reason cellConfidence is pinned above.
+          if (id.includes('/io/range/LocalFileRangeSource')) {
+            return 'LocalFileRangeSource';
+          }
           return undefined;
         },
       },


### PR DESCRIPTION
`LocalFileRangeSource` is reached only through the `lazyChunks.ts` dynamic import, and rolldown emits it as its own chunk today, so this changes no build output: the index chunk stays at 780 KiB and the chunk is still emitted.

What it buys is an explicit boundary. rolldown 1.2.6 changed its inlining heuristic and began folding this module into the shell, putting the out-of-core reader into the bundle every visitor downloads first. `olv-chunk-emission-guard` caught it and the bundle budget measured the cost at about 25 KiB. Pinning states the boundary the dynamic import already declares, the same way `cellConfidence` is pinned directly above for the same class of reason.

Verified: build exit 0, chunk emitted, index unchanged at 780 KiB and within ceiling, tsc 0, smoke green, monolith-size / inline-imports / architecture-truth pass.