### PR TITLE
fix(qa): measure the unclassified share instead of reporting 0 for any classified scan

### DIFF
--- a/src/terrain/contour/analyseContours.ts
+++ b/src/terrain/contour/analyseContours.ts
@@ -365,6 +365,15 @@ export interface TerrainCore {
   /** Per-cell metric rollup: density, completeness, edge risk. */
   readonly cellMetrics: CellMetricsSummary;
   /** Classified vegetation/building/noise returns dropped before ground filtering. */
+  /**
+   * Share of source returns carrying ASPRS class 0 (created, never classified)
+   * or 1 (unclassified), or null when the scan has no classification at all.
+   * A file can be fully classified in the sense that every point holds a code
+   * and still be almost entirely code 1, which is what a raw airborne tile
+   * usually is; the fitness panel needs the measured share rather than the
+   * mere presence of the attribute.
+   */
+  readonly unclassifiedFraction: number | null;
   readonly excludedByClassification: number;
   /** ASPRS/USGS 3DEP accuracy expression: NVA, VVA, and Quality Level. */
   readonly accuracyStandards: DemAccuracyStandards;
@@ -459,6 +468,15 @@ export interface AnalyseContoursResult {
   /** Per-cell metric rollup: density, completeness, edge risk. */
   readonly cellMetrics: CellMetricsSummary;
   /** Classified vegetation/building/noise returns dropped before ground filtering. */
+  /**
+   * Share of source returns carrying ASPRS class 0 (created, never classified)
+   * or 1 (unclassified), or null when the scan has no classification at all.
+   * A file can be fully classified in the sense that every point holds a code
+   * and still be almost entirely code 1, which is what a raw airborne tile
+   * usually is; the fitness panel needs the measured share rather than the
+   * mere presence of the attribute.
+   */
+  readonly unclassifiedFraction: number | null;
   readonly excludedByClassification: number;
   /** ASPRS/USGS 3DEP accuracy expression: NVA, VVA, and Quality Level. */
   readonly accuracyStandards: DemAccuracyStandards;
@@ -740,6 +758,19 @@ export function computeTerrainCore(
   // or rooftops. The full cloud is still used for the DSM further down, so
   // above-ground height keeps measuring those very returns.
   const classFilter = excludeNonGroundClasses(points, params.classification, params.excludeClasses);
+  // Measured from the same array the filter reads, so the reported share and
+  // the exclusion tally cannot disagree.
+  const unclassifiedFraction = ((): number | null => {
+    const cls = params.classification;
+    if (cls == null || cls.length === 0) return null;
+    const n = cls.length;
+    let unclassified = 0;
+    for (let i = 0; i < n; i++) {
+      const c = cls[i];
+      if (c === 0 || c === 1) unclassified++;
+    }
+    return n > 0 ? unclassified / n : null;
+  })();
   let groundPts: ReadonlyArray<TerrainPoint> = classFilter.points;
   if (classFilter.excludedCount > 0) {
     warnings.push(
@@ -1193,6 +1224,7 @@ export function computeTerrainCore(
     quality,
     qualityScore,
     cellMetrics,
+    unclassifiedFraction,
     excludedByClassification: classFilter.excludedCount,
     accuracyStandards,
     surface,
@@ -1307,6 +1339,7 @@ export function contoursFromCore(
       qualityScore: core.qualityScore,
       cellMetrics: core.cellMetrics,
       surface: core.surface,
+      unclassifiedFraction: core.unclassifiedFraction,
       excludedByClassification: core.excludedByClassification,
       accuracyStandards: core.accuracyStandards,
       cellStatusTally: core.cellStatusTally,
@@ -1400,6 +1433,7 @@ export function contoursFromCore(
     qualityScore: core.qualityScore,
     cellMetrics: core.cellMetrics,
     surface: core.surface,
+    unclassifiedFraction: core.unclassifiedFraction,
     excludedByClassification: core.excludedByClassification,
     accuracyStandards: core.accuracyStandards,
     cellStatusTally: core.cellStatusTally,

--- a/src/terrain/contour/analyseContours.ts
+++ b/src/terrain/contour/analyseContours.ts
@@ -468,15 +468,8 @@ export interface AnalyseContoursResult {
   /** Per-cell metric rollup: density, completeness, edge risk. */
   readonly cellMetrics: CellMetricsSummary;
   /** Classified vegetation/building/noise returns dropped before ground filtering. */
-  /**
-   * Share of source returns carrying ASPRS class 0 (created, never classified)
-   * or 1 (unclassified), or null when the scan has no classification at all.
-   * A file can be fully classified in the sense that every point holds a code
-   * and still be almost entirely code 1, which is what a raw airborne tile
-   * usually is; the fitness panel needs the measured share rather than the
-   * mere presence of the attribute.
-   */
-  readonly unclassifiedFraction: number | null;
+  /** Passed through unchanged from `TerrainCore`. */
+  readonly unclassifiedFraction: TerrainCore['unclassifiedFraction'];
   readonly excludedByClassification: number;
   /** ASPRS/USGS 3DEP accuracy expression: NVA, VVA, and Quality Level. */
   readonly accuracyStandards: DemAccuracyStandards;

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -3192,10 +3192,11 @@ export class AnalysePanel {
       unit: 'm',
       unitToMetres: 1,
       unitKnown,
-      // The contour result doesn't carry the full class histogram; the presence
-      // of classified returns dropped before ground filtering tells us the
-      // source WAS classified (else ground was derived).
-      unclassifiedFraction: hasClass ? 0 : null,
+      // The measured share of ASPRS 0/1 returns, not the mere presence of the
+      // attribute. A raw airborne tile carries a code on every point and is
+      // still almost entirely code 1; reporting 0 there stamped a green
+      // "0% unclassified" on a scan that was 95% unclassified.
+      unclassifiedFraction: r.unclassifiedFraction,
       hasGroundClass: hasClass,
       coverageMode: r.dtm.coverageMode,
       densityReferenceFloor: densityFloor,

--- a/tests/unclassifiedFractionMeasured.test.ts
+++ b/tests/unclassifiedFractionMeasured.test.ts
@@ -1,0 +1,62 @@
+/**
+ * unclassifiedFractionMeasured.test.ts
+ *
+ * The fitness panel's Classification dimension reports a MEASURED share of
+ * ASPRS 0/1 returns. It previously received a hardcoded 0 whenever a
+ * classification attribute existed, which scored `ready` and printed
+ * "0% unclassified" on a raw airborne tile that was 95% code 1.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeTerrainCore, type TerrainCoreParams } from '../src/terrain/contour/analyseContours';
+import type { TerrainPoint } from '../src/terrain/TerrainContracts';
+
+const CELL = 2;
+
+/** A tilted ground plane, `groundShare` of it classified 2 and the rest 1. */
+function tile(groundShare: number): { points: TerrainPoint[]; classification: number[] } {
+  const points: TerrainPoint[] = [];
+  for (let iy = 0; iy < 30; iy++) {
+    for (let ix = 0; ix < 30; ix++) {
+      points.push({ x: ix * CELL, y: iy * CELL, z: 100 + ix * 0.05 - iy * 0.03 });
+    }
+  }
+  const cut = Math.round(points.length * groundShare);
+  const classification = points.map((_, i) => (i < cut ? 2 : 1));
+  return { points, classification };
+}
+
+const BASE: TerrainCoreParams = {
+  cellSizeM: CELL,
+  crs: 'EPSG:32610',
+  verticalDatum: 'EPSG:5703',
+  trustGroundClassification: true,
+};
+
+describe('unclassifiedFraction', () => {
+  it('measures the ASPRS 0/1 share rather than reporting presence', () => {
+    // The shape of a raw airborne tile: a thin ground return, the rest code 1.
+    const { points, classification } = tile(0.05);
+    const core = computeTerrainCore(points, { ...BASE, classification });
+    expect(core.unclassifiedFraction).toBeCloseTo(0.95, 2);
+  });
+
+  it('reports a fully producer-classified scan as none unclassified', () => {
+    const { points, classification } = tile(1);
+    const core = computeTerrainCore(points, { ...BASE, classification });
+    expect(core.unclassifiedFraction).toBe(0);
+  });
+
+  it('counts code 0 (created, never classified) as unclassified too', () => {
+    const { points } = tile(1);
+    const classification = points.map((_, i) => (i % 2 === 0 ? 0 : 2));
+    const core = computeTerrainCore(points, { ...BASE, classification });
+    expect(core.unclassifiedFraction).toBeCloseTo(0.5, 2);
+  });
+
+  it('is null when the scan carries no classification at all', () => {
+    const { points } = tile(1);
+    const core = computeTerrainCore(points, BASE);
+    expect(core.unclassifiedFraction).toBeNull();
+  });
+});


### PR DESCRIPTION
`AnalysePanel` fed `scanFitness` a literal `0` for `unclassifiedFraction` whenever a classification attribute existed. On a raw airborne tile every point carries a code and 95% of them are code 1, so the Classification dimension scored `ready` and printed "0% unclassified" beside a Classes panel showing 2.7 M unclassified returns.

`computeTerrainCore` now measures the share of ASPRS 0/1 returns from the array the class filter already reads and returns it as `unclassifiedFraction` (null when the scan has no classification). The panel passes that through. No threshold changes; a scan that is mostly code 1 now scores `review`, as the existing tone bands intended.

New test: `tests/unclassifiedFractionMeasured.test.ts`.
