### PR TITLE
fix(terrain): word the boundary-share cap and the edge-risk cause as the two quantities they read

### DIFF
--- a/src/terrain/contour/terrainAssessment.ts
+++ b/src/terrain/contour/terrainAssessment.ts
@@ -336,8 +336,11 @@ export function terrainAssessment(result: AnalyseContoursResult): TerrainAssessm
     // MEASURED cells that sit within a couple of cells of the data boundary.
     // Those cells HAVE real returns; they are just least supported by
     // neighbours. The gate's tally of interpolated cells far from any
-    // measurement (dtmCellStatus 'edgeRisk') is a different quantity.
-    if (edgeFrac > HIGH_EDGE_FRACTION) caps.push(`${pctStr(edgeFrac)} of measured cells sit at the edge of the data, where the surface is least supported`);
+    // measurement (dtmCellStatus 'edgeRisk') is a different quantity and
+    // gets its own wording in whyNotReasons; the two sentences used to be
+    // identical, so a report could show 79% here and 7% there under one
+    // description.
+    if (edgeFrac > HIGH_EDGE_FRACTION) caps.push(`${pctStr(edgeFrac)} of measured cells lie within a few cells of the data boundary, where neighbour support is thinnest`);
     if (density < LOW_DENSITY_PER_M2) caps.push('ground returns are sparse');
     if (coverageMode === 'resident-only') {
       // PARTIAL STREAM: lead with the honest "only part has loaded" framing, not

--- a/src/terrain/contour/whyNotReasons.ts
+++ b/src/terrain/contour/whyNotReasons.ts
@@ -105,16 +105,14 @@ export function explainLimitations(result: AnalyseContoursResult): Limitations {
   // the gate's cell-status tally: the fraction of ALL covered cells whose
   // status is 'edgeRisk' (interpolated cells far from any measurement). It is
   // NOT cellMetrics.boundaryMeasuredRatio (measured cells near the raster
-  // boundary), despite what an earlier version of this comment claimed. The
-  // cause wording below still uses the boundary-measured phrasing, pinned by a
-  // regression test; reconciling the figure and the phrasing is a separate,
-  // behaviour-changing fix.
+  // boundary), which terrainAssessment words separately. The wording here
+  // describes the gate figure it reads.
   const edgeFrac = finite(q.edgeRiskRatio);
   if (Number.isFinite(edgeFrac) && edgeFrac > HIGH_EDGE_FRACTION) {
     emit(
       'edge',
-      `${pct(edgeFrac)} of measured cells sit at the edge of the data, where the surface is least supported.`,
-      'Extend capture past the area of interest so the edges sit on well-supported measured ground.',
+      `${pct(edgeFrac)} of the covered surface is interpolated at a long reach from any measured cell.`,
+      'Extend capture past the area of interest so the surface is supported by measured ground throughout.',
     );
   }
 

--- a/tests/terrainAssessment.test.ts
+++ b/tests/terrainAssessment.test.ts
@@ -467,7 +467,7 @@ describe('terrainAssessment', () => {
     it('the reason quotes the SAME percentages as the chips', () => {
       expect(a.reason).toMatch(/^Insufficient quality/);
       expect(a.reason).toContain('72% of the surface is interpolated');
-      expect(a.reason).toContain('53% of measured cells sit at the edge of the data');
+      expect(a.reason).toContain('53% of measured cells lie within a few cells of the data boundary');
     });
 
     it('no longer mislabels boundary-measured cells as "a long interpolation"', () => {

--- a/tests/whyNotReasons.test.ts
+++ b/tests/whyNotReasons.test.ts
@@ -118,13 +118,13 @@ describe('explainLimitations', () => {
     // tally-metric phrasing ("a long interpolation from real returns"). NOTE:
     // q here is the gate report, so q.edgeRiskRatio is actually the gate's
     // cell-status tally (dtmCellStatus 'edgeRisk'), not
-    // cellMetrics.boundaryMeasuredRatio as this comment once claimed; the
-    // engine reads the gate figure while wording it as the boundary metric.
-    // Reconciling figure and phrasing is a separate behaviour-changing fix
-    // (see the matching note in whyNotReasons.ts).
+    // cellMetrics.boundaryMeasuredRatio as this comment once claimed. The
+    // cause now describes the gate figure it reads, and must not borrow the
+    // boundary-share wording terrainAssessment uses for the other quantity.
     const r = fixture({ edgeRiskRatio: 0.53 });
     expect(causeText(r)).not.toMatch(/long interpolation/i);
-    expect(causeText(r)).toMatch(/53% of measured cells sit at the edge of the data/);
+    expect(causeText(r)).not.toMatch(/of measured cells/);
+    expect(causeText(r)).toMatch(/53% of the covered surface is interpolated at a long reach from any measured cell/);
   });
 
   it('low ground visibility / low confidence → ground-visibility cause + fix', () => {


### PR DESCRIPTION
Two different quantities produced the same sentence, "N% of measured cells sit at the edge of the data, where the surface is least supported":

- `terrainAssessment.ts` caps surface status on `cellMetrics.boundaryMeasuredRatio`, the share of measured cells within a few cells of the raster boundary.
- `whyNotReasons.ts` emits its edge cause on the gate's `edgeRiskRatio`, the share of covered cells interpolated far from any measurement.

A terrain report for a sparse-ground airborne tile showed 79% in the verdict reason and "Edge risk 7%" in Coverage Analysis under the one description. Each site now words the figure it reads. `HIGH_EDGE_FRACTION` and the cap logic are untouched, so no verdict or export-readiness outcome changes.

Tests updated: `terrainAssessment.test.ts`, `whyNotReasons.test.ts`.
