### PR TITLE
fix(provenance): read manned-aircraft ALS tiles as airborne, not drone

### DIFF
--- a/src/diagnostics/provenance.ts
+++ b/src/diagnostics/provenance.ts
@@ -374,10 +374,24 @@ function normaliseVendorString(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
 }
 
+/**
+ * Production suites that only appear on manned-aircraft deliveries: the
+ * TerraSolid family and GeoCue drive the classification step of most
+ * national programmes, and LasMonkey is the tiling/QC tool the USGS 3DEP
+ * contractors write into `generating_software`. LAStools is deliberately
+ * absent; it processes everything from phone scans to ALS.
+ */
+const AERIAL_ALS_SOFTWARE = ['lasmonkey', 'terrascan', 'terrasolid', 'geocue'];
+
 function matchSoftwareString(sw: string | undefined): ProvenanceFingerprint | null {
   if (!sw) return null;
   const lower = normaliseVendorString(sw);
 
+  for (const tag of AERIAL_ALS_SOFTWARE) {
+    if (lower.includes(tag)) {
+      return aerialAlsFingerprint('high', [`Software: ${sw}`]);
+    }
+  }
   for (const tag of PHONE_LIDAR_SOFTWARE) {
     if (lower.includes(tag)) {
       return phoneLidarFingerprint('high', [`Software: ${sw}`]);
@@ -401,6 +415,12 @@ function matchSoftwareString(sw: string | undefined): ProvenanceFingerprint | nu
 // ─────────────────────────────────────────────────────────────────────────────
 
 const PHONE_LIDAR_SENSORS = ['iphone', 'ipad', 'ios', 'arkit', 'vcsel'];
+/**
+ * Airborne instruments, plus the 3DEP contractors who write their company
+ * name into `system_identifier` (Quantum Spatial/NV5 do on every Rogue tile).
+ * Checked before the TLS list so 'leica als' is not swallowed by 'leica'.
+ */
+const AERIAL_ALS_SENSORS = ['quantum spatial', 'nv5', 'optech', 'leica als', 'riegl vq', 'riegl lms'];
 const TLS_SENSORS = ['faro focus', 'leica', 'riegl vz', 'trimble x'];
 const DRONE_LIDAR_SENSORS = ['velodyne', 'dji l1', 'dji l2', 'riegl mini', 'phoenix'];
 const SPACEBORNE_SENSORS = ['gedi', 'icesat', 'atlas', 'calipso', 'atlid'];
@@ -409,6 +429,11 @@ function matchSensorString(sensor: string | undefined): ProvenanceFingerprint | 
   if (!sensor) return null;
   const lower = normaliseVendorString(sensor);
 
+  for (const tag of AERIAL_ALS_SENSORS) {
+    if (lower.includes(tag)) {
+      return aerialAlsFingerprint('high', [`Sensor: ${sensor}`]);
+    }
+  }
   for (const tag of PHONE_LIDAR_SENSORS) {
     if (lower.includes(tag)) {
       return phoneLidarFingerprint('high', [`Sensor: ${sensor}`]);
@@ -472,6 +497,13 @@ function matchFormat(signals: ScanSignals): ProvenanceFingerprint | null {
  */
 const PHONE_LIDAR_MAX_DENSITY_PER_SQM = 7225;
 
+/**
+ * Footprint at which a dense cloud reads as a manned-aircraft tile rather
+ * than a UAV mapping file: half a standard 1 km² USGS 3DEP tile. Drone
+ * files in this repo's fixtures and the Ruzgienė 2025 sites are ≤ 10 ha.
+ */
+const PROJECT_TILE_MIN_AREA_SQM = 500_000;
+
 function matchNumeric(signals: ScanSignals): ProvenanceFingerprint | null {
   // High density on a small extent is the iPhone-LiDAR signature. Luetzenburg
   // 2021 reports 7,225 pts/m² at 25 cm down to 150 pts/m² at 2.5 m for the
@@ -526,6 +558,17 @@ function matchNumeric(signals: ScanSignals): ProvenanceFingerprint | null {
     // high density across thousands of square metres. Very high density over an
     // open footprint is the strongest low-altitude-UAV signature, so it reads
     // 'high'; the literature band (100–1000) stays 'medium'.
+    // Above 50 pts/m² density no longer separates manned ALS from UAV: a
+    // multi-return forest tile of a QL1 programme lands at 50-80 pts/m² of
+    // all returns (this repo's Rogue tiles read 53.7). Footprint does.
+    // USGS 3DEP delivers 1 km² tiles (100 ha) and drone mapping files sit
+    // well under 50 ha, so a dense cloud at project-tile scale is airborne.
+    if (signals.densityPerSqM >= 50 && footprintArea >= PROJECT_TILE_MIN_AREA_SQM) {
+      return aerialAlsFingerprint('medium', [
+        `Density: ${signals.densityPerSqM.toFixed(1)} pts/m² over a ${(footprintArea / 10000).toFixed(1)} ha bounding-box footprint`,
+        'Footprint at project-tile scale (≥ 50 ha): USGS 3DEP tiles are 1 km²',
+      ]);
+    }
     if (signals.densityPerSqM >= 50 && footprintArea > 2000) {
       const veryDense = signals.densityPerSqM > 1000;
       return droneLidarFingerprint(veryDense ? 'high' : 'medium', [

--- a/tests/provenance.test.ts
+++ b/tests/provenance.test.ts
@@ -329,3 +329,44 @@ describe('provenance — vendor tokens match however the producer punctuates', (
     expect(line).toContain('5 registered scan stations');
   });
 });
+
+describe('manned-aircraft ALS is not read as a drone', () => {
+  // A USGS 3DEP forest tile: 53.7 M points over 1 km², Quantum Spatial in
+  // system_identifier, LasMonkey in generating_software. The build under
+  // test called it "Drone-mounted LiDAR (UAV ALS)" and applied UAV bounds.
+  const rogue = (over: Partial<ScanSignals>): ScanSignals => ({
+    sourceFormat: 'laz',
+    pointCount: 53_670_848,
+    extent: [1000, 1000, 371.1],
+    densityPerSqM: 53.7,
+    ...over,
+  });
+
+  it('reads the 3DEP contractor name in system_identifier as airborne', () => {
+    const f = classify(rogue({ sensorString: 'Quantum Spatial' }));
+    expect(f.captureType).toBe('aerial-als');
+    expect(f.confidence).toBe('high');
+  });
+
+  it('reads LasMonkey in generating_software as airborne', () => {
+    const f = classify(rogue({ softwareString: 'LasMonkey 2.6.2' }));
+    expect(f.captureType).toBe('aerial-als');
+  });
+
+  it('reads a dense cloud at project-tile scale as airborne from geometry alone', () => {
+    const f = classify(rogue({}));
+    expect(f.captureType).toBe('aerial-als');
+    expect(f.confidence).toBe('medium');
+    expect(f.signals.join(' ')).toMatch(/project-tile scale/);
+  });
+
+  it('keeps a dense cloud at site scale (10 ha) as drone', () => {
+    const f = classify(rogue({ extent: [316, 320, 40], densityPerSqM: 84 }));
+    expect(f.captureType).toBe('drone-lidar');
+  });
+
+  it('still reads Leica ALS as airborne rather than the bare Leica TLS token', () => {
+    const f = classify(rogue({ sensorString: 'Leica ALS80' }));
+    expect(f.captureType).toBe('aerial-als');
+  });
+});

--- a/tests/provenanceGroundInstrument.test.ts
+++ b/tests/provenanceGroundInstrument.test.ts
@@ -247,7 +247,7 @@ describe('capture type — what counts as declared ground-based evidence', () =>
 });
 
 describe('capture type — the other bands are unchanged', () => {
-  it('a genuine airborne LAS delivery still reads aerial ALS', () => {
+  it('a genuine airborne LAS delivery still reads aerial ALS, from the declared instrument', () => {
     const s = signalsForStaticCloud({
       sourceFormat: 'laz',
       pointCount: 6_400_000,
@@ -257,6 +257,21 @@ describe('capture type — the other bands are unchanged', () => {
     const fp = classify(s);
     expect(s.sensorString).toBe('Optech Galaxy T2000');
     expect(s.declaredGroundInstrument).toBeUndefined();
+    expect(fp.captureType).toBe('aerial-als');
+    // The header names an airborne instrument, so the answer is declared
+    // rather than inferred from the 2 pts/m² density band it used to fall to.
+    expect(fp.confidence).toBe('high');
+    expect(fp.signals).toContain('Sensor: Optech Galaxy T2000');
+  });
+
+  it('a genuine airborne LAS delivery with no sensor string still reads aerial ALS from density', () => {
+    const s = signalsForStaticCloud({
+      sourceFormat: 'laz',
+      pointCount: 6_400_000,
+      bounds: () => ({ min: [0, 0, 0], max: [2000, 1600, 240] }),
+      metadata: {},
+    });
+    const fp = classify(s);
     expect(fp.captureType).toBe('aerial-als');
     expect(fp.confidence).toBe('medium');
     expect(fp.signals).toContain('Density: 2.0 pts/m² over a 320.0 ha bounding-box footprint');


### PR DESCRIPTION
A USGS 3DEP forest tile (53.7 M points, 1 km², `Quantum Spatial` in `system_identifier`, `LasMonkey 2.6.2` in `generating_software`) was reported as "Drone-mounted LiDAR (UAV ALS)" with Ruzgienė 2025 UAV bounds, so the technical report showed it failing a 100–1000 pts/m² expectation that never applied.

Two causes: the numeric ALS band stopped at 50 pts/m², and neither the contractor nor the tiling tool matched a token.

Now, above 50 pts/m² the footprint decides: ≥ 50 ha (half a 3DEP tile) reads `aerial-als`, site-scale files stay `drone-lidar`. `AERIAL_ALS_SENSORS` and `AERIAL_ALS_SOFTWARE` add the airborne instruments and production tools, checked before the TLS list so `leica als` is not swallowed by `leica`.

Existing drone fixtures (≤ 10 ha) are unchanged. One pinned Optech test moves from the density route to the declared-instrument route.
