### PR TITLE
fix(ui): feed the dataset card measured run values instead of header constants

### DIFF
--- a/docs/architecture/architecture-map.md
+++ b/docs/architecture/architecture-map.md
@@ -29,7 +29,7 @@ keep that arrow pointing one way.
 | Export / report | `src/export`, `src/report`, `src/convert` | ~9.3k | Studio exporters, PDF/report builders, batch conversion. |
 | Application services | `src/app` | ~1.6k | Composition root and the services that own shared state. |
 | UI | `src/ui` | ~19.9k | Panels, Inspector, Studio surfaces, onboarding. |
-| Shell | `src/main.ts` | 5,531 | Wiring. **A monolith under decomposition.** |
+| Shell | `src/main.ts` | 5,529 | Wiring. **A monolith under decomposition.** |
 
 ## Composition root
 
@@ -99,7 +99,7 @@ Recorded so the next pass does not re-derive them:
   `applyPolygonReclassify`) is ALREADY extracted and tested. What remains on the
   Viewer is a thin GPU-upload wrapper.
 
-**`src/main.ts` (5,531)** — the largest blocks, which are the extraction
+**`src/main.ts` (5,529)** — the largest blocks, which are the extraction
 candidates:
 
 `buildActionRegistry` (344 lines) is now extracted to `src/app/actionDefinitions.ts`,

--- a/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
+++ b/docs/releases/KNOWN_LIMITATIONS_v0.6.7.md
@@ -8,7 +8,7 @@ Five products reach E4 this cycle: `CRS-UTM-PROJECTION` (new), `CHANGE-RASTER` a
 
 ## The two monoliths are still monoliths
 
-`src/main.ts` is 5,531 lines and `src/render/Viewer.ts` is 6,418, against stated targets of 2,500 and 2,000. The composition root shrank as the terrain-compute-path read moved into `src/app/terrainComputePath.ts`. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
+`src/main.ts` is 5,529 lines and `src/render/Viewer.ts` is 6,418, against stated targets of 2,500 and 2,000. The composition root shrank as the terrain-compute-path read moved into `src/app/terrainComputePath.ts`. The remaining blocks to lift are in `docs/architecture/architecture-map.md`.
 
 ## Out-of-core streaming holds the index, not the whole cloud
 

--- a/docs/validation/monolith-size-baseline.json
+++ b/docs/validation/monolith-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "src/main.ts": {
-      "lines": 5531,
+      "lines": 5529,
       "goal": 2500
     },
     "src/render/Viewer.ts": {

--- a/src/app/inspectorCardRefreshers.ts
+++ b/src/app/inspectorCardRefreshers.ts
@@ -21,7 +21,23 @@ import {
 import {
   TERRAIN_METRIC_VERSION,
   type DerivedComplexity,
+  type IntelCoverageMeta,
 } from '../terrain/datasetIntelligence';
+import type { TerrainCoverageMode } from '../terrain/TerrainContracts';
+
+/** The slice of a finished terrain run the Dataset Intelligence card reads. */
+export interface TerrainRunCardFacts {
+  readonly dtm: {
+    readonly analyzedPointCount: number;
+    readonly coverageMode: TerrainCoverageMode;
+  };
+  readonly quality: {
+    /** Mean per-cell confidence, 0..100. */
+    readonly meanCellConfidence: number;
+    /** Ground returns / all returns, 0..1 (NaN when unknown). */
+    readonly groundPointRatio: number;
+  };
+}
 import type { StreamingSourceKind } from '../render/streaming/StreamingSource';
 
 export interface InspectorCardRefreshers {
@@ -65,14 +81,19 @@ export interface InspectorCardRefreshers {
   }): void;
   /**
    * Fold a real analysed-point count from a finished terrain run into the
-   * card. Only acts when the last summary came from the STREAMING path, whose
-   * attach-time summary necessarily wrote `analyzedPointCount: 0` ("no
-   * analysis yet") — without this, the Details panel keeps reading
-   * "Analyzed Points 0" forever on streamed scans, even after a run walked
-   * hundreds of thousands of points. The static path already carries a count
-   * and is left untouched.
+   * card, static or streaming. The streaming attach-time summary writes
+   * `analyzedPointCount: 0` and the static one the resident sample size;
+   * either way the Details row reads the run's walked count afterwards.
    */
   noteAnalyzedPointCount(count: number): void;
+  /**
+   * Fold a finished terrain run's measured facts into the card: the walked
+   * point count, the engine coverage mode, the mean cell confidence (Metric
+   * Stability) and the ground-return share (Ground Visibility), and mark the
+   * engine active. Non-finite values are skipped so a row never shows a
+   * number the run did not measure.
+   */
+  noteTerrainRun(run: TerrainRunCardFacts): void;
   /**
    * Fold a finished terrain run's ENGINE-DERIVED complexity (the VRM/TPI
    * summary — band + the numeric detail with window and units) into the last
@@ -161,12 +182,10 @@ export function createInspectorCardRefreshers(
     | { readonly linearUnit?: string; readonly linearUnitToMetres?: number; readonly verticalUnitToMetres?: number }
     | null,
 ): InspectorCardRefreshers {
-  // The last summary pushed by the STREAMING refresher, remembered so a
-  // finished terrain run can re-push it with the real analysed-point count
-  // (see `noteAnalyzedPointCount`). Nulled by the static refresher so a
-  // streamed-scan summary can never be merged onto a later static scan; the
-  // terrain runner's stale-result guard already prevents a result for a
-  // closed scan from reaching `noteAnalyzedPointCount` at all.
+  // The last summary pushed by the STREAMING refresher. Nulled by the static
+  // refresher so a streamed-scan summary can never be merged onto a later
+  // static scan; the terrain runner's stale-result guard already prevents a
+  // result for a closed scan from reaching the note* folds at all.
   let lastStreamingSummary: Parameters<Inspector['setDatasetIntelligence']>[0] | null = null;
   // The last summary pushed by EITHER path (static or streaming), so a
   // finished terrain run can fold its engine-derived complexity into it
@@ -256,9 +275,13 @@ export function createInspectorCardRefreshers(
         // box is empty air between the ground and the flight line.
         bboxSpansM,
         coverageMeta: {
-          coverage: 'full',
+          // A loader stride leaves only a display sample resident: the extent
+          // is complete, the point set is not, so the row must not say "Full".
+          coverage: cloud.pointCount < n ? 'display-sample' : 'full',
           sourcePointCount: n,
-          analyzedPointCount: n,
+          // What is actually resident (and what a run can walk) — the declared
+          // header total stays on `sourcePointCount`.
+          analyzedPointCount: cloud.pointCount,
           // v0.3.10 honesty pass — this path runs at load time from
           // header data ALONE. No terrain analysis has happened yet, so
           // we have nothing meaningful to say about confidence. The
@@ -343,21 +366,41 @@ export function createInspectorCardRefreshers(
     }
   }
 
-  function noteAnalyzedPointCount(count: number): void {
-    const base = lastStreamingSummary;
-    if (!base || !Number.isFinite(count) || count <= 0) return;
-    const updated = {
-      // Merge onto the CURRENT summary (which may already carry the derived
-      // complexity), so folding the count never drops the other run-fed field.
-      ...(lastSummary ?? base),
-      coverageMeta: {
-        ...base.coverageMeta!,
-        analyzedPointCount: Math.round(count),
-      },
-    };
-    lastStreamingSummary = updated;
+  /** Merge run-fed fields onto the CURRENT summary (static or streaming). */
+  function foldCoverageMeta(
+    patch: Partial<IntelCoverageMeta>,
+    extra: { groundPointRatio?: number; engineRan?: boolean } = {},
+  ): void {
+    const base = lastSummary;
+    if (!base?.coverageMeta) return;
+    const updated = { ...base, ...extra, coverageMeta: { ...base.coverageMeta, ...patch } };
     lastSummary = updated;
+    if (lastStreamingSummary) lastStreamingSummary = updated;
     inspector.setDatasetIntelligence(updated);
+  }
+
+  function noteAnalyzedPointCount(count: number): void {
+    if (!Number.isFinite(count) || count <= 0) return;
+    foldCoverageMeta({ analyzedPointCount: Math.round(count) });
+  }
+
+  function noteTerrainRun(run: TerrainRunCardFacts): void {
+    const base = lastSummary?.coverageMeta;
+    if (!base) return;
+    const count = run.dtm.analyzedPointCount;
+    const mode = run.dtm.coverageMode;
+    const confidence = run.quality.meanCellConfidence;
+    const ground = run.quality.groundPointRatio;
+    foldCoverageMeta(
+      {
+        ...(Number.isFinite(count) && count > 0 ? { analyzedPointCount: Math.round(count) } : {}),
+        // The engine's 'full' means "every RESIDENT point walked"; a strided
+        // display sample stays labelled as one. Any partial mode wins as-is.
+        coverage: mode === 'full' && base.coverage === 'display-sample' ? base.coverage : mode,
+        ...(Number.isFinite(confidence) ? { confidence } : {}),
+      },
+      { engineRan: true, ...(Number.isFinite(ground) ? { groundPointRatio: ground } : {}) },
+    );
   }
 
   function noteTerrainComplexity(derived: DerivedComplexity | null): void {
@@ -375,6 +418,7 @@ export function createInspectorCardRefreshers(
     refreshDatasetIntelligenceFromStaticCloud,
     refreshDatasetIntelligenceFromStreamingCloud,
     noteAnalyzedPointCount,
+    noteTerrainRun,
     noteTerrainComplexity,
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2621,14 +2621,12 @@ const terrainRunner = createTerrainAnalysisRunner({
     });
     inspector.setCoverageAvailable(true);
     processStudio.markProduced(['dtm', 'contours']); // run generated the DTM + contours — show them produced
-    // Fold the run's real analysed-point count into the Dataset Intelligence
-    // card — the same `dtm.analyzedPointCount` the terrain report's
-    // "Analysed points" row prints, so card and PDF agree. The streaming
-    // attach-time summary necessarily wrote `analyzedPointCount: 0` (nothing
-    // analysed yet); without this the Details row reads "Analyzed Points 0"
-    // forever on streamed scans. The refresher only acts when the last summary
-    // came from streaming, and the stale-result guard skips closed/replaced scans.
-    inspectorCards.noteAnalyzedPointCount(result.dtm.analyzedPointCount);
+    // Fold the run's measured facts into the Dataset Intelligence card: the
+    // walked count the terrain report's "Analysed points" row prints, the
+    // engine coverage mode, the mean cell confidence and the ground-return
+    // share — so card and PDF agree and no row shows a header constant as a
+    // measurement. The stale-result guard skips closed/replaced scans.
+    inspectorCards.noteTerrainRun(result);
     // Fold the run's ENGINE-DERIVED terrain complexity (the VRM/TPI summary
     // computed alongside the core, off the interactive path) into the card:
     // the band label replaces the header-time heuristic and the numeric

--- a/src/terrain/datasetIntelligence.ts
+++ b/src/terrain/datasetIntelligence.ts
@@ -77,8 +77,18 @@ export type ComplexityBucket = 'unknown' | 'low' | 'moderate' | 'high' | 'very-h
  */
 export type GroundVisibilityBucket = 'unknown' | 'poor' | 'fair' | 'good' | 'excellent';
 
-/** Streaming coverage bucket — mirrors TerrainCoverageMode. */
-export type CoverageBucket = TerrainCoverageMode;
+/**
+ * Streaming coverage bucket — the engine's TerrainCoverageMode plus one
+ * card-only reading: `'display-sample'` is a STATIC load whose resident points
+ * are a loader-strided display sample of the file (the full extent is present,
+ * not every point). The engine never emits it; the load-time summary does.
+ */
+export type CoverageBucket = TerrainCoverageMode | 'display-sample';
+
+/** Coverage meta as the card takes it — the engine's meta widened to {@link CoverageBucket}. */
+export type IntelCoverageMeta = Omit<TerrainCoverageMeta, 'coverage'> & {
+  readonly coverage: CoverageBucket;
+};
 
 /** The Dataset Intelligence rows that carry a bucket. */
 export type IntelDimension = 'density' | 'complexity' | 'groundVisibility' | 'coverage';
@@ -111,6 +121,7 @@ export function signalTier(dimension: IntelDimension, bucket: string): SignalTie
     case 'coverage':
       if (bucket === 'full') return 'strong';
       if (bucket === 'resident-only') return 'moderate';
+      if (bucket === 'display-sample') return 'neutral'; // a load fact, not a quality
       return 'weak'; // sampled — partial, carries the streaming caveat
     case 'complexity':
       return 'neutral'; // descriptive, never judged
@@ -174,6 +185,14 @@ export interface DatasetIntelligenceInput {
   /** Optional terrain-suggestion (classification histogram). */
   readonly terrainSuggestion?: TerrainSuggestionResult;
   /**
+   * Ground returns as a share of all returns, 0..1, as a finished terrain run
+   * measured it (`quality.groundPointRatio`). Feeds the ground-visibility
+   * bucket when no load-time classification histogram was attached.
+   */
+  readonly groundPointRatio?: number;
+  /** True once a terrain run's values have been folded in — drives the engine status. */
+  readonly engineRan?: boolean;
+  /**
    * ENGINE-DERIVED complexity (v0.5.4): the real VRM/TPI summary from a
    * finished terrain run. When present it OVERRIDES the heuristic
    * slope/roughness/variance bucket — the band label comes from the VRM
@@ -183,8 +202,8 @@ export interface DatasetIntelligenceInput {
    * the row then renders the heuristic bucket or an honest "—".
    */
   readonly complexityDerived?: DerivedComplexity;
-  /** Coverage envelope from the Terrain Engine. */
-  readonly coverageMeta?: TerrainCoverageMeta;
+  /** Coverage envelope from the Terrain Engine (or the load-time summary). */
+  readonly coverageMeta?: IntelCoverageMeta;
   /**
    * Metric version label — surfaced in the Details panel so power
    * users can tell which v0.3.x cut produced the summary.
@@ -493,10 +512,16 @@ export function complexityLabel(b: ComplexityBucket): string {
 export function classifyGroundVisibility(
   input: Pick<
     DatasetIntelligenceInput,
-    'terrainSuggestion' | 'meanRoughness' | 'residentDensity'
+    'terrainSuggestion' | 'meanRoughness' | 'residentDensity' | 'groundPointRatio'
   >,
 ): GroundVisibilityBucket {
-  const suggest = input.terrainSuggestion;
+  // A run-measured ground share stands in for the load-time histogram when
+  // no histogram was attached (same quantity: ground returns / all returns).
+  const suggest =
+    input.terrainSuggestion ??
+    (input.groundPointRatio !== undefined && Number.isFinite(input.groundPointRatio)
+      ? { groundFraction: input.groundPointRatio, vegetationFraction: 0 }
+      : undefined);
   const haveClass = suggest !== undefined && Number.isFinite(suggest.groundFraction);
   const haveRough = input.meanRoughness !== undefined && Number.isFinite(input.meanRoughness);
   const haveDensity =
@@ -542,7 +567,7 @@ export function groundVisibilityLabel(b: GroundVisibilityBucket): string {
 }
 
 /** Coverage bucket maps the engine's coverage mode 1:1. */
-export function classifyCoverage(meta: TerrainCoverageMeta | undefined): CoverageBucket {
+export function classifyCoverage(meta: IntelCoverageMeta | undefined): CoverageBucket {
   // Without engine output the safest reading is "sampled" — that
   // triggers the streaming-warning string downstream so the user
   // never sees an over-confident result.
@@ -559,6 +584,8 @@ export function coverageLabel(b: CoverageBucket): string {
       return 'Resident Nodes';
     case 'sampled':
       return 'Sampled Analysis';
+    case 'display-sample':
+      return 'Full extent · display sample';
   }
 }
 
@@ -571,6 +598,9 @@ export function coverageLabel(b: CoverageBucket): string {
  */
 export function coverageStreamingWarning(b: CoverageBucket): string | undefined {
   if (b === 'full') return undefined;
+  if (b === 'display-sample') {
+    return 'Analysis reads the strided display sample resident in memory, not every point in the file.';
+  }
   return 'Analysis is based on currently loaded data. Results may change as additional points stream.';
 }
 
@@ -665,7 +695,12 @@ export function summariseDataset(input: DatasetIntelligenceInput): DatasetIntell
           ? input.coverageMeta.analyzedPointCount
           : null,
       metricVersion: input.metricVersion ?? TERRAIN_METRIC_VERSION,
-      engineStatus: input.coverageMeta ? 'active' : 'idle',
+      // Active only once a run's values arrived — a load-time coverageMeta is
+      // header-derived and says nothing about the engine.
+      engineStatus:
+        input.engineRan || input.complexityDerived !== undefined || confidenceHasSignal
+          ? 'active'
+          : 'idle',
     },
   };
 }

--- a/src/ui/DatasetIntelligenceCard.ts
+++ b/src/ui/DatasetIntelligenceCard.ts
@@ -74,8 +74,8 @@ export const DENSITY_ROW = {
 const TOOLTIP_METRIC_STABILITY =
   'Metric Stability — how stable the dataset-level terrain signals ' +
   'are given coverage and analysed point count. This is NOT ground-' +
-  'classification accuracy. Renders "—" until the engine has produced ' +
-  'a measurement.';
+  'classification accuracy. Renders "—" until a terrain run has produced ' +
+  'its mean cell confidence.';
 
 /**
  * Five-row card with a Details disclosure. Construct once at Inspector
@@ -168,15 +168,17 @@ export class DatasetIntelligenceCard {
         this._groundValue,
         'How clearly the terrain surface can be inferred from the ' +
           'points — combines roughness, density, and any classification ' +
-          'signal in the source file. Renders "—" until the engine has ' +
-          'a measurement. This is NOT ground-classification accuracy.',
+          'signal in the source file. Renders "—" until a terrain run has ' +
+          'measured the ground-return share. This is NOT ground-' +
+          'classification accuracy.',
       ),
       this._row(
         'Streaming Coverage',
         this._coverageValue,
-        'Whether the analysis used the full cloud (static load), only ' +
-          'the nodes resident in memory (streaming clouds mid-load), or ' +
-          'a sampled subset. Drives the "may refine" caveat below.',
+        'Whether the analysis used every point (static load), a strided ' +
+          'display sample of the file (large static loads), only the nodes ' +
+          'resident in memory (streaming clouds mid-load), or a sampled ' +
+          'subset. Drives the "may refine" caveat below.',
       ),
       this._row(
         'Metric Stability',

--- a/tests/datasetCardMeasuredWiring.test.ts
+++ b/tests/datasetCardMeasuredWiring.test.ts
@@ -1,0 +1,137 @@
+/**
+ * datasetCardMeasuredWiring.test.ts — the Dataset Intelligence card must show
+ * MEASURED run values, not header constants, on a static (strided) load:
+ * analysed points = the resident sample, coverage never claims "Full Dataset"
+ * for a display sample, and a finished terrain run feeds ground visibility,
+ * metric stability and the engine status.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createInspectorCardRefreshers } from '../src/app/inspectorCardRefreshers';
+import {
+  summariseDataset,
+  signalTier,
+  coverageLabel,
+  type DatasetIntelligenceInput,
+} from '../src/terrain/datasetIntelligence';
+
+function makeInspector() {
+  const calls: DatasetIntelligenceInput[] = [];
+  const inspector = {
+    setDatasetIntelligence: (s: DatasetIntelligenceInput) => calls.push(s),
+    clearDatasetIntelligence: vi.fn(),
+    setProvenance: vi.fn(),
+  } as never;
+  return { inspector, last: () => calls[calls.length - 1] };
+}
+
+const METRE = { linearUnit: 'metre', linearUnitToMetres: 1 };
+/** A 53.7 M-point file loaded with a display stride — 2.88 M resident. */
+const stridedCloud = {
+  pointCount: 2_880_000,
+  declaredPointCount: 53_670_848,
+  metadata: { crs: METRE },
+  bounds: () => ({ min: [0, 0, 0] as [number, number, number], max: [100, 100, 10] as [number, number, number] }),
+};
+const fullCloud = { ...stridedCloud, pointCount: 53_670_848 };
+
+const run = {
+  dtm: { analyzedPointCount: 2_700_000, coverageMode: 'full' as const },
+  quality: { meanCellConfidence: 81, groundPointRatio: 0.42 },
+};
+
+describe('static strided load — header constants are not measurements', () => {
+  it('analysed points is the resident sample, source points the declared total', () => {
+    const { inspector, last } = makeInspector();
+    createInspectorCardRefreshers(inspector).refreshDatasetIntelligenceFromStaticCloud(stridedCloud);
+    expect(last().coverageMeta?.sourcePointCount).toBe(53_670_848);
+    expect(last().coverageMeta?.analyzedPointCount).toBe(2_880_000);
+  });
+
+  it('coverage is a neutral display-sample reading, not "Full Dataset"', () => {
+    const { inspector, last } = makeInspector();
+    createInspectorCardRefreshers(inspector).refreshDatasetIntelligenceFromStaticCloud(stridedCloud);
+    const out = summariseDataset(last());
+    expect(out?.coverage.bucket).toBe('display-sample');
+    expect(out?.coverage.label).toBe('Full extent · display sample');
+    expect(signalTier('coverage', 'display-sample')).toBe('neutral');
+    expect(coverageLabel('display-sample')).not.toContain('Full Dataset');
+  });
+
+  it('an unstrided static load still reads full coverage', () => {
+    const { inspector, last } = makeInspector();
+    createInspectorCardRefreshers(inspector).refreshDatasetIntelligenceFromStaticCloud(fullCloud);
+    expect(last().coverageMeta?.coverage).toBe('full');
+    expect(last().coverageMeta?.analyzedPointCount).toBe(53_670_848);
+  });
+
+  it('the engine reads idle before any run even though coverageMeta is attached', () => {
+    const { inspector, last } = makeInspector();
+    createInspectorCardRefreshers(inspector).refreshDatasetIntelligenceFromStaticCloud(stridedCloud);
+    expect(last().coverageMeta).toBeDefined();
+    expect(summariseDataset(last())?.details.engineStatus).toBe('idle');
+    expect(summariseDataset(last())?.groundVisibility.label).toBe('—');
+    expect(summariseDataset(last())?.confidence.label).toBe('—');
+  });
+});
+
+describe('a finished terrain run feeds the static card', () => {
+  it('noteAnalyzedPointCount folds onto a static summary (not only streaming)', () => {
+    const { inspector, last } = makeInspector();
+    const cards = createInspectorCardRefreshers(inspector);
+    cards.refreshDatasetIntelligenceFromStaticCloud(stridedCloud);
+    cards.noteAnalyzedPointCount(2_700_000);
+    expect(last().coverageMeta?.analyzedPointCount).toBe(2_700_000);
+    cards.noteAnalyzedPointCount(Number.NaN);
+    cards.noteAnalyzedPointCount(0);
+    expect(last().coverageMeta?.analyzedPointCount).toBe(2_700_000);
+  });
+
+  it('noteTerrainRun feeds count, confidence, ground ratio and engine status', () => {
+    const { inspector, last } = makeInspector();
+    const cards = createInspectorCardRefreshers(inspector);
+    cards.refreshDatasetIntelligenceFromStaticCloud(stridedCloud);
+    cards.noteTerrainRun(run);
+    const out = summariseDataset(last());
+    expect(out?.details.analyzedPointCount).toBe(2_700_000);
+    expect(out?.details.engineStatus).toBe('active');
+    expect(out?.confidence.label).toBe('81%');
+    expect(out?.confidence.band).toBe('green');
+    expect(out?.groundVisibility.bucket).toBe('good');
+    // A 'full' engine mode does not re-promote a display sample to "Full Dataset".
+    expect(out?.coverage.bucket).toBe('display-sample');
+  });
+
+  it('a non-full engine coverage mode replaces the load-time reading', () => {
+    const { inspector, last } = makeInspector();
+    const cards = createInspectorCardRefreshers(inspector);
+    cards.refreshDatasetIntelligenceFromStaticCloud(fullCloud);
+    cards.noteTerrainRun({ ...run, dtm: { ...run.dtm, coverageMode: 'sampled' } });
+    expect(summariseDataset(last())?.coverage.bucket).toBe('sampled');
+  });
+
+  it('non-finite quality fields leave the rows honest ("—") but the engine active', () => {
+    const { inspector, last } = makeInspector();
+    const cards = createInspectorCardRefreshers(inspector);
+    cards.refreshDatasetIntelligenceFromStaticCloud(stridedCloud);
+    cards.noteTerrainRun({ ...run, quality: { meanCellConfidence: Number.NaN, groundPointRatio: Number.NaN } });
+    const out = summariseDataset(last());
+    expect(out?.confidence.label).toBe('—');
+    expect(out?.groundVisibility.label).toBe('—');
+    expect(out?.details.engineStatus).toBe('active');
+  });
+
+  it('the run fold keeps the derived complexity and the streaming path still works', () => {
+    const { inspector, last } = makeInspector();
+    const cards = createInspectorCardRefreshers(inspector);
+    cards.refreshDatasetIntelligenceFromStreamingCloud({
+      sourcePointCount: 1000,
+      metadata: { header: { min: [0, 0, 0], max: [100, 100, 10] } },
+      crs: () => METRE,
+    });
+    cards.noteTerrainComplexity({ bucket: 'high', label: 'High', detail: 'VRM 0.1' });
+    cards.noteTerrainRun({ ...run, dtm: { ...run.dtm, coverageMode: 'resident-only' } });
+    expect(last().complexityDerived?.bucket).toBe('high');
+    expect(last().coverageMeta?.coverage).toBe('resident-only');
+    expect(last().coverageMeta?.analyzedPointCount).toBe(2_700_000);
+  });
+});


### PR DESCRIPTION
The Dataset Intelligence card presented header constants as run measurements on static loads.

- Details "Analyzed Points" was the declared header count (53.7 M) on a 2.88 M display sample; `noteAnalyzedPointCount` only folded on streaming scans. The static path now reports the resident count and folds the run's `dtm.analyzedPointCount` for any scan.
- "Streaming Coverage — Full Dataset" was hardcoded `'full'`. A strided static load now reads "Full extent · display sample" with a neutral tier; the run's `coverageMode` is folded afterwards. The new bucket is card-only; `TerrainCoverageMode` is unchanged.
- Ground Visibility and Metric Stability were permanent dashes; they now read the run's `quality.groundPointRatio` and `quality.meanCellConfidence`.
- "Terrain Engine: Active" required only a coverageMeta object; it now requires a folded run.

`main.ts` shrinks by two lines (`noteTerrainRun` replaces the single call). Tooltips state each basis. New test: `tests/datasetCardMeasuredWiring.test.ts`.
