### PR TITLE
fix(report): state the basis of Scan Report and Layer Health rows

### DIFF
--- a/src/analysis/modules/healthCheck.ts
+++ b/src/analysis/modules/healthCheck.ts
@@ -219,6 +219,35 @@ function foldCoord(hash: number, v: number): number {
   return h ^ (h >>> 15);
 }
 
+/**
+ * What the held buffer IS relative to the file, so the per-point verdicts
+ * below can name their basis. `voxel` — the loader averaged the decoded
+ * records into one centroid per occupied voxel (`decodedPointCount` above
+ * the held count): duplicates cannot survive that step and an isolated
+ * point is smoothed into its neighbours, so neither verdict says anything
+ * about the file. `stride` — a 1-in-N record sample, nothing averaged.
+ * `full` — every record is resident. No computation changes; only the
+ * wording and the pass/info status of a clean result.
+ */
+function sampleBasis(cloud: PointCloud): { kind: 'full' | 'stride' | 'voxel'; note: string } {
+  const n = cloud.pointCount;
+  const decoded = cloud.decodedPointCount;
+  if (decoded !== undefined && decoded > n) {
+    return {
+      kind: 'voxel',
+      note: `checked on the ${fmtCount(n)}-point display sample (voxel centroids); not run on the full cloud`,
+    };
+  }
+  const declared = cloud.declaredPointCount;
+  if (declared !== undefined && declared > n) {
+    return {
+      kind: 'stride',
+      note: `checked on the ${fmtCount(n)}-point display sample (1-in-${cloud.loadStride ?? '?'} stride); not run on the full cloud`,
+    };
+  }
+  return { kind: 'full', note: '' };
+}
+
 function checkDuplicatePoints(cloud: PointCloud): AnalysisRow {
   const n = cloud.pointCount;
   if (n === 0) {
@@ -276,10 +305,17 @@ function checkDuplicatePoints(cloud: PointCloud): AnalysisRow {
       status: 'warn',
     };
   }
+  // A clean scan of voxel centroids is a property of the sampler, not of the
+  // file (one averaged point per voxel cannot collide), so it is reported as
+  // a neutral fact with its basis rather than a pass.
+  const basis = sampleBasis(cloud);
+  if (basis.kind === 'full') {
+    return { label: 'Duplicate Points', value: 'None', status: 'pass' };
+  }
   return {
     label: 'Duplicate Points',
-    value: 'None',
-    status: 'pass',
+    value: `None — ${basis.note}`,
+    status: basis.kind === 'voxel' ? 'info' : 'pass',
   };
 }
 
@@ -316,10 +352,16 @@ function checkStrayOutliers(cloud: PointCloud): AnalysisRow {
       status: 'warn',
     };
   }
+  // Voxel averaging suppresses exactly the isolated points this check looks
+  // for, so a clean result over centroids is disclosed, not passed.
+  const basis = sampleBasis(cloud);
+  if (basis.kind === 'full') {
+    return { label: 'Stray Outliers', value: 'None', status: 'pass' };
+  }
   return {
     label: 'Stray Outliers',
-    value: 'None',
-    status: 'pass',
+    value: `None — ${basis.note}`,
+    status: basis.kind === 'voxel' ? 'info' : 'pass',
   };
 }
 

--- a/src/analysis/modules/scanReport.ts
+++ b/src/analysis/modules/scanReport.ts
@@ -150,13 +150,39 @@ export const scanReport: AnalysisModule = {
     // subset can only be counted over the points actually loaded, so it keeps
     // the decoded basis.
     const declaredN = cloud.declaredPointCount;
-    const strided = subset === null && declaredN !== undefined && declaredN > n;
+    // `sampled`: the file holds more points than the buffer, whatever the
+    // scope. `strided`: the unfiltered report back-scales density/spacing to
+    // the declared total (a class subset keeps the decoded basis).
+    const sampled = declaredN !== undefined && declaredN > totalN;
+    const strided = subset === null && sampled;
     const reportedN = strided ? (declaredN as number) : n;
 
-    rows.push(withScope(rowInfo('Point Count', reportedN.toLocaleString('en-US')), scope));
-    if (strided) {
-      // Don't hide the sampling: name the subset actually held in memory.
-      rows.push(rowInfo('Loaded', `${n.toLocaleString('en-US')} (display sample)`));
+    if (sampled) {
+      // The file's count is a whole-file fact: it does not change with the
+      // class scope, so it carries no scope stamp, and it stays on the panel
+      // when a class is solo'd — otherwise a filtered report reads its visible
+      // sample count as the file's total and the sampling disappears with it.
+      rows.push(rowInfo('Point Count', (declaredN as number).toLocaleString('en-US')));
+      // Don't hide the sampling: name the subset actually held in memory AND
+      // every reduction that produced it, so the header count, the Health
+      // Check's decoded count and this row reconcile in one sentence. A
+      // voxel-reduced buffer holds one averaged centroid per occupied voxel.
+      const decoded = cloud.decodedPointCount;
+      const loaded = totalN.toLocaleString('en-US');
+      const how =
+        decoded !== undefined && decoded > totalN
+          ? `stride to ${decoded.toLocaleString('en-US')}, then voxel-reduced to ${loaded} centroids`
+          : cloud.loadStride !== undefined && cloud.loadStride > 1
+            ? `1-in-${cloud.loadStride} stride`
+            : 'stride';
+      rows.push(rowInfo('Loaded', `${loaded} (display sample: ${how})`));
+      if (subset !== null) {
+        rows.push(
+          withScope(rowInfo('Visible', `${n.toLocaleString('en-US')} of the ${loaded}-point display sample`), scope),
+        );
+      }
+    } else {
+      rows.push(withScope(rowInfo('Point Count', n.toLocaleString('en-US')), scope));
     }
 
     // Extent — bounds are in the source CRS's native linear units (feet for a
@@ -198,10 +224,14 @@ export const scanReport: AnalysisModule = {
     const footprintArea = width * depth;
 
     // Point density — over the file's true count (back-scaled when strided).
+    // Both figures are nominal averages (count ÷ footprint), and on a strided
+    // load they mix bases — the header's count over the SAMPLE's footprint —
+    // so the row says so rather than reading as a measured density.
+    const mixedBasis = strided ? ' (mean: declared count over the display-sample footprint)' : '';
     if (footprintArea <= 0 || reportedN === 0) {
       rows.push(withScope(rowWarn('Density', 'N/A (degenerate footprint)'), scope));
     } else {
-      rows.push(withScope(rowInfo('Density', `${(reportedN / footprintArea).toFixed(1)}${basis.densityUnit}`), scope));
+      rows.push(withScope(rowInfo('Density', `${(reportedN / footprintArea).toFixed(1)}${basis.densityUnit}${mixedBasis}`), scope));
     }
 
     // Estimated point spacing. The cm/m formatter assumes metres, so it is used
@@ -212,7 +242,8 @@ export const scanReport: AnalysisModule = {
     } else {
       const spacing = Math.sqrt(footprintArea / reportedN);
       const spacingValue = basis.unitKnown ? formatLength(spacing) : `${spacing.toFixed(2)} (source units)`;
-      rows.push(withScope(rowInfo('Spacing', spacingValue), scope));
+      const spacingBasis = strided ? ' (nominal: √(display-sample footprint ÷ declared count))' : '';
+      rows.push(withScope(rowInfo('Spacing', `${spacingValue}${spacingBasis}`), scope));
     }
 
     // In-memory resolution — what the Float32 position buffer can still tell
@@ -256,7 +287,7 @@ export const scanReport: AnalysisModule = {
             label: 'In-memory resolution',
             value:
               `${formatPrecisionMetres(pm.worstCaseSpacing)} worst case, `
-              + `${formatPrecisionMetres(pm.typicalSpacing)} typical `
+              + `${formatPrecisionMetres(pm.typicalSpacing)} mean over the reach `
               + `(${precisionGradeLabel(precision.grade)})`,
             status: precision.grade === 'fine' ? 'info' : 'warn',
           }
@@ -288,27 +319,45 @@ export const scanReport: AnalysisModule = {
     // below ("Present, unclassified" + "0.0 %" are one statement). Both loops
     // honour a class-subset scope; full scope is byte-identical to counting
     // the whole buffer.
+    //
+    // "Coverage" counts every non-zero code, which includes ASPRS 1
+    // (Unclassified) — so a tile whose points are 95 % code 1 would read as
+    // fully classified. The headline therefore also states the code-1 share,
+    // over the same visible points, and names the sample once when the buffer
+    // is a display sample of the file.
     let classValue = 'No';
     if (cls !== undefined) {
       let anyAssigned = false;
       let nonZero = 0;
+      let codeOne = 0;
       for (let i = 0; i < totalN; i++) {
         if (!isVisible(i)) continue;
         const code = cls[i] & 0xff;
         if (code > 1) anyAssigned = true;
         if (code !== 0) nonZero++;
+        if (code === 1) codeOne++;
       }
-      const base = anyAssigned ? 'Yes' : 'Present, unclassified';
-      classValue =
-        n > 0 ? `${base} (${((nonZero / n) * 100).toFixed(1)} % coverage)` : base;
+      const pct = (k: number): string => ((k / n) * 100).toFixed(1);
+      if (!anyAssigned) {
+        classValue = n > 0 ? `Present, unclassified (${pct(nonZero)} % coverage)` : 'Present, unclassified';
+      } else if (n > 0) {
+        classValue =
+          `Yes — codes on ${pct(nonZero)} %, ${pct(codeOne)} % unclassified (code 1)`
+          + (strided ? ' of display sample' : '');
+      } else {
+        classValue = 'Yes';
+      }
     }
     rows.push(withScope(rowInfo('Classification', classValue), scope));
 
-    // Capture provenance — shown only when the file header carried it.
+    // Header provenance — shown only when the file carried it, labelled by
+    // what the header field IS. LAS `system_identifier` names the hardware OR
+    // the producing process/organisation, and the File Creation Day/Year is
+    // when the file was written, not when the survey was flown.
     const meta = cloud.metadata;
-    if (meta?.captureSensor) rows.push(rowInfo('Capture Sensor', meta.captureSensor));
+    if (meta?.captureSensor) rows.push(rowInfo('System identifier', meta.captureSensor));
     if (meta?.sourceSoftware) rows.push(rowInfo('Source Software', meta.sourceSoftware));
-    if (meta?.captureDate) rows.push(rowInfo('Captured', meta.captureDate));
+    if (meta?.captureDate) rows.push(rowInfo('File created', meta.captureDate));
     if (meta?.scannerOrigin) {
       const [sx, sy, sz] = meta.scannerOrigin;
       rows.push(

--- a/src/app/LayerService.ts
+++ b/src/app/LayerService.ts
@@ -407,7 +407,10 @@ export function createLayerService(deps: LayerServiceDeps): LayerService {
             crsSource: (crs as { source?: string } | null)?.source ?? null,
             horizontalUnit:
               crs && isLinearUnitKnown(crs) ? crs.linearUnit : null,
-            verticalUnit: null, // no declared vertical unit NAME exists; never reverse-map the factor
+            // The parsed vertical unit NAME (WKT VERT_CS UNIT / GeoTIFF key)
+            // from the CrsInfo the file declared; never reverse-mapped from
+            // the numeric factor. Null only when the CRS declares none.
+            verticalUnit: verticalUnitName(c?.metadata?.crs),
             verticalDatum: info.verticalDatum ?? null,
             compatibility: lastCompatibility.get(info.id) ?? null,
             mounted: !lastUnmounted.includes(info.id),
@@ -416,6 +419,9 @@ export function createLayerService(deps: LayerServiceDeps): LayerService {
             precisionMm: p && p.errorMetres !== null ? p.errorMetres * 1000 : null,
             precisionBasis: (p?.basis as 'projected-linear-unit' | 'geographic' | 'unknown' | undefined) ?? null,
             streaming: false,
+            // Resident vs header-declared counts, so a display sample is not
+            // reported as fully loaded.
+            residency: residencyOf(c),
             soleLayer: infos.length <= 1,
           }),
           name: info.name,
@@ -461,4 +467,19 @@ export function createLayerService(deps: LayerServiceDeps): LayerService {
   }
 
   return { buildLayerInfos, applyVisibility, refreshCrsFlags, setVisible, toggleSolo, soloOnly };
+}
+
+/** The declared vertical linear-unit name, or null when the CRS carries none. */
+function verticalUnitName(crs: CrsInfo | null | undefined): string | null {
+  const u = crs?.verticalLinearUnit;
+  return u !== undefined && u !== 'unknown' ? u : null;
+}
+
+/** Resident-vs-source counts for the Layer Health Loading row (null = no declared total). */
+function residencyOf(
+  c: { pointCount: number; declaredPointCount?: number; sourceDeclaredPointCount?: number } | undefined,
+): { resident: number; source: number } | null {
+  if (!c) return null;
+  const source = c.sourceDeclaredPointCount ?? c.declaredPointCount;
+  return source === undefined ? null : { resident: c.pointCount, source };
 }

--- a/src/app/layerHealth.ts
+++ b/src/app/layerHealth.ts
@@ -65,6 +65,14 @@ export interface LayerHealthInput {
   readonly precisionBasis: 'projected-linear-unit' | 'geographic' | 'unknown' | null;
   /** True while the layer streams (partial residency). */
   readonly streaming: boolean;
+  /**
+   * Resident vs source-declared point counts for a non-streaming layer, or
+   * null when the source declared no total. A resident count below the
+   * source count is a display sample, and the Loading row says so instead of
+   * "fully loaded". Undefined keeps the legacy wording (callers that do not
+   * know the counts).
+   */
+  readonly residency?: { readonly resident: number; readonly source: number } | null;
 }
 
 /** One rendered fact. `mono` marks numeric values (coordinates, offsets, mm). */
@@ -286,10 +294,27 @@ export function buildLayerHealth(input: LayerHealthInput): LayerHealthRow[] {
           value: 'streaming — resident detail refines as tiles load',
           status: 'info',
         }
-      : { label: 'Loading', value: 'fully loaded', status: 'ok' },
+      : loadingRow(input.residency),
   );
 
   return rows;
+}
+
+/** The Loading row for a non-streaming layer, grounded in the counts. */
+function loadingRow(residency: LayerHealthInput['residency']): LayerHealthRow {
+  if (residency === undefined) return { label: 'Loading', value: 'fully loaded', status: 'ok' };
+  if (residency === null) {
+    return { label: 'Loading', value: 'fully loaded (no source count declared)', status: 'info' };
+  }
+  const { resident, source } = residency;
+  if (resident < source) {
+    return {
+      label: 'Loading',
+      value: `display sample — ${resident.toLocaleString('en-US')} of ${source.toLocaleString('en-US')} resident`,
+      status: 'info',
+    };
+  }
+  return { label: 'Loading', value: 'fully loaded', status: 'ok' };
 }
 
 /**

--- a/src/geo/inMemoryPrecision.ts
+++ b/src/geo/inMemoryPrecision.ts
@@ -68,7 +68,9 @@ export function float32Spacing(magnitude: number): number {
 
 /**
  * The MEAN Float32 step over coordinates spread uniformly across `[0, reach]` —
- * the "typical" figure, as opposed to the worst case at `reach` itself.
+ * the "mean over the reach" figure, as opposed to the worst case at `reach`
+ * itself. It is a closed-form property of the extent, not a statistic of the
+ * cloud's actual coordinates, and is labelled that way on the Scan Report.
  *
  * Worth reporting because the worst case is a boundary value: the step halves
  * with every binade below `reach`, so most of a cloud sits on a finer grid than

--- a/src/model/PointCloud.ts
+++ b/src/model/PointCloud.ts
@@ -33,11 +33,19 @@ export interface SourceMetadata {
  * it. Every field is optional — most scan files fill in only some, or none.
  */
 export interface CloudMetadata {
-  /** Capture hardware or sensor, e.g. the LAS System Identifier field. */
+  /**
+   * The LAS System Identifier (or the E57 sensor summary). Per the LAS spec
+   * this names the hardware OR the producing process/organisation, so it is
+   * shown as "System identifier", not as a capture sensor.
+   */
   captureSensor?: string;
   /** Software that produced the file, e.g. the LAS Generating Software field. */
   sourceSoftware?: string;
-  /** Human-readable capture / file-creation date. */
+  /**
+   * Human-readable FILE-CREATION date (LAS header File Creation Day/Year).
+   * Not the acquisition date — a reprocessed flight carries the reprocessing
+   * date here — so it is shown as "File created".
+   */
   captureDate?: string;
   /**
    * True when the source asset carried a texture/material (glTF images or

--- a/tests/healthCheck.test.ts
+++ b/tests/healthCheck.test.ts
@@ -69,8 +69,10 @@ describe('healthCheck module', () => {
       expect(['pass', 'info']).toContain(status);
     });
 
-    test('duplicate points → pass', () => {
-      expect(rowByLabel(healthCheck.run(cloud), 'Duplicate Points').status).toBe('pass');
+    test('duplicate points → pass (every record resident, so the verdict is about the file)', () => {
+      const row = rowByLabel(healthCheck.run(cloud), 'Duplicate Points');
+      expect(row.status).toBe('pass');
+      expect(row.value).toBe('None');
     });
 
     test('stray outliers → pass', () => {

--- a/tests/layerHealth.test.ts
+++ b/tests/layerHealth.test.ts
@@ -205,6 +205,15 @@ describe('buildLayerHealth — frame membership, origin and streaming', () => {
     expect(off.value).toBe('fully loaded');
     expect(off.status).toBe('ok');
   });
+
+  it('a display sample is disclosed as resident-of-source, not "fully loaded"', () => {
+    const r = row(
+      buildLayerHealth(base({ residency: { resident: 2_880_236, source: 53_670_848 } })),
+      'Loading',
+    );
+    expect(r.value).toBe('display sample — 2,880,236 of 53,670,848 resident');
+    expect(r.status).toBe('info');
+  });
 });
 
 describe('buildCompatibilityReport', () => {

--- a/tests/scanReport.test.ts
+++ b/tests/scanReport.test.ts
@@ -89,7 +89,7 @@ describe('scanReport module', () => {
       expect(row.value.toLowerCase()).toContain('yes');
       // 3 out of 4 non-zero = 75% — merged into the same row, not a
       // separate "Classification Coverage" diagnostic.
-      expect(row.value).toContain('75.0 % coverage');
+      expect(row.value).toContain('codes on 75.0 %');
       expect(row.status).toBe('info');
     });
 

--- a/tests/scanReportMeasuredBasis.test.ts
+++ b/tests/scanReportMeasuredBasis.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Scan Report / Health Check / Layer Health rows must state the BASIS of a
+ * figure that is a constant of the sampler, a header field, or a nominal
+ * average — never present it as a measurement of the file.
+ */
+import { describe, expect, test } from 'vitest';
+import { PointCloud } from '../src/model/PointCloud';
+import { scanReport } from '../src/analysis/modules/scanReport';
+import { healthCheck } from '../src/analysis/modules/healthCheck';
+import { buildLayerHealth, type LayerHealthInput } from '../src/app/layerHealth';
+import type { AnalysisRow } from '../src/analysis/ModuleApi';
+import { scopeFrom } from '../src/render/class/classScope';
+
+function rowByLabel(rows: readonly AnalysisRow[], label: string): AnalysisRow {
+  const r = rows.find((x) => x.label === label);
+  if (!r) throw new Error(`row "${label}" missing`);
+  return r;
+}
+
+const POS = new Float32Array([0, 0, 0, 2, 0, 0, 0, 2, 0, 2, 2, 1]);
+
+/** Strided AND voxel-reduced: header 40 → stride decode 12 → 4 centroids. */
+function voxelCloud(extra: Partial<ConstructorParameters<typeof PointCloud>[0]> = {}): PointCloud {
+  return new PointCloud({
+    positions: POS, origin: [0, 0, 0], sourceFormat: 'laz', name: 'voxel',
+    declaredPointCount: 40, decodedPointCount: 12, loadStride: 4, ...extra,
+  });
+}
+/** Strided only: header 40 → 4 records decoded, nothing averaged. */
+function stridedCloud(): PointCloud {
+  return new PointCloud({
+    positions: POS, origin: [0, 0, 0], sourceFormat: 'laz', name: 'strided',
+    declaredPointCount: 40, decodedPointCount: 4, loadStride: 10,
+  });
+}
+function fullCloud(): PointCloud {
+  return new PointCloud({ positions: POS, origin: [0, 0, 0], sourceFormat: 'laz', name: 'full' });
+}
+
+describe('Health Check — duplicate / outlier rows name their sample', () => {
+  test('(1) voxel centroids: Duplicate Points is info with the basis, not a pass on the file', () => {
+    const row = rowByLabel(healthCheck.run(voxelCloud()).rows, 'Duplicate Points');
+    expect(row.status).toBe('info');
+    expect(row.value).toContain('None');
+    expect(row.value).toContain('4-point display sample');
+    expect(row.value).toContain('voxel centroids');
+    expect(row.value).toContain('not run on the full cloud');
+  });
+  test('(1) stride-only sample keeps pass but names the sample', () => {
+    const row = rowByLabel(healthCheck.run(stridedCloud()).rows, 'Duplicate Points');
+    expect(row.status).toBe('pass');
+    expect(row.value).toContain('4-point display sample');
+    expect(row.value).toContain('not run on the full cloud');
+  });
+  test('(1) full cloud is a plain pass', () => {
+    const row = rowByLabel(healthCheck.run(fullCloud()).rows, 'Duplicate Points');
+    expect(row.status).toBe('pass');
+    expect(row.value).toBe('None');
+  });
+  test('(2) Stray Outliers on centroids is info and discloses averaging', () => {
+    const tight: number[] = [];
+    for (let i = 0; i < 20; i++) tight.push(i * 0.1, i * 0.1, i * 0.1);
+    const cloud = new PointCloud({
+      positions: new Float32Array(tight), origin: [0, 0, 0], sourceFormat: 'laz', name: 'v',
+      declaredPointCount: 400, decodedPointCount: 100, loadStride: 4,
+    });
+    const row = rowByLabel(healthCheck.run(cloud).rows, 'Stray Outliers');
+    expect(row.status).toBe('info');
+    expect(row.value).toContain('voxel centroids');
+    expect(row.value).toContain('not run on the full cloud');
+  });
+});
+
+describe('Scan Report — provenance labels', () => {
+  const cloud = new PointCloud({
+    positions: POS, origin: [0, 0, 0], sourceFormat: 'laz', name: 'meta',
+    metadata: { captureSensor: 'Quantum Spatial', captureDate: 'Jan 12, 2021' },
+  });
+  const rows = scanReport.run(cloud).rows;
+  test('(3) header creation date is "File created", never "Captured"', () => {
+    expect(rowByLabel(rows, 'File created').value).toBe('Jan 12, 2021');
+    expect(rows.find((r) => r.label === 'Captured')).toBeUndefined();
+  });
+  test('(4) LAS system_identifier is "System identifier"', () => {
+    expect(rowByLabel(rows, 'System identifier').value).toBe('Quantum Spatial');
+    expect(rows.find((r) => r.label === 'Capture Sensor')).toBeUndefined();
+  });
+});
+
+describe('Scan Report — sample and nominal bases', () => {
+  test('(8) Loaded names both reductions with reconciling counts', () => {
+    const v = rowByLabel(scanReport.run(voxelCloud()).rows, 'Loaded').value;
+    expect(v).toBe('4 (display sample: stride to 12, then voxel-reduced to 4 centroids)');
+    const s = rowByLabel(scanReport.run(stridedCloud()).rows, 'Loaded').value;
+    expect(s).toBe('4 (display sample: 1-in-10 stride)');
+  });
+  test('(9) strided Density / Spacing state the mixed basis', () => {
+    const rows = scanReport.run(stridedCloud()).rows;
+    const d = rowByLabel(rows, 'Density').value;
+    expect(parseFloat(d)).toBeCloseTo(10, 3);
+    expect(d).toContain('mean: declared count over the display-sample footprint');
+    const s = rowByLabel(rows, 'Spacing').value;
+    expect(s).toContain('nominal');
+  });
+  test('(9) a fully loaded cloud keeps the bare figure', () => {
+    expect(rowByLabel(scanReport.run(fullCloud()).rows, 'Density').value).toBe('1.0 pts/unit²');
+  });
+  test('(10) in-memory resolution says "mean over the reach", not "typical"', () => {
+    const cloud = new PointCloud({
+      positions: POS, origin: [1000, 0, 0], sourceFormat: 'laz', name: 'm',
+      metadata: { crs: { kind: 'projected', name: 'x', linearUnit: 'metre', linearUnitToMetres: 1 } as never },
+    });
+    const v = rowByLabel(scanReport.run(cloud).rows, 'In-memory resolution').value;
+    expect(v).toContain('mean over the reach');
+    expect(v).not.toContain('typical');
+  });
+  test('(7) class 1 is not counted as classified in the headline', () => {
+    const cls = new Uint8Array([1, 1, 1, 2]);
+    const rows = scanReport.run(voxelCloud({ classification: cls })).rows;
+    expect(rowByLabel(rows, 'Classification').value).toBe(
+      'Yes — codes on 100.0 %, 75.0 % unclassified (code 1) of display sample',
+    );
+    const full = new PointCloud({
+      positions: POS, origin: [0, 0, 0], sourceFormat: 'laz', name: 'full',
+      classification: new Uint8Array([0, 1, 2, 2]),
+    });
+    expect(rowByLabel(scanReport.run(full).rows, 'Classification').value).toBe(
+      'Yes — codes on 75.0 %, 25.0 % unclassified (code 1)',
+    );
+  });
+});
+
+describe('Scan Report — class scope on a display sample', () => {
+  test('(11) a solo\'d class keeps the file count, the Loaded row and adds Visible', () => {
+    const cloud = voxelCloud({ classification: new Uint8Array([2, 2, 6, 6]) });
+    const rows = scanReport.run(cloud, undefined, {
+      scope: scopeFrom([2], [2, 6], (c) => `class ${c}`),
+    }).rows;
+    expect(rowByLabel(rows, 'Point Count').value).toBe('40');
+    expect(rowByLabel(rows, 'Point Count').scope).toBeUndefined();
+    expect(rowByLabel(rows, 'Loaded').value).toContain('display sample: stride to 12');
+    const visible = rowByLabel(rows, 'Visible');
+    expect(visible.value).toBe('2 of the 4-point display sample');
+    expect(visible.scope?.kind).toBe('subset');
+  });
+});
+
+describe('Layer Health — loading and vertical unit', () => {
+  function base(over: Partial<LayerHealthInput> = {}): LayerHealthInput {
+    return {
+      name: 'a.laz', crsName: 'x', crsSource: 'las-vlr', horizontalUnit: 'metre',
+      verticalUnit: 'metre', verticalDatum: 'NAVD88', compatibility: 'verified', mounted: true,
+      sourceOrigin: [0, 0, 0], frameOffset: [0, 0, 0], precisionMm: 0.02,
+      precisionBasis: 'projected-linear-unit', streaming: false, soleLayer: true, ...over,
+    };
+  }
+  const row = (rows: readonly { label: string; value: string; status: string }[], l: string) => {
+    const r = rows.find((x) => x.label === l);
+    if (!r) throw new Error(l);
+    return r;
+  };
+  test('(5) a display sample is not "fully loaded"', () => {
+    const r = row(buildLayerHealth(base({ residency: { resident: 2_880_236, source: 53_670_848 } })), 'Loading');
+    expect(r.value).toBe('display sample — 2,880,236 of 53,670,848 resident');
+    expect(r.status).toBe('info');
+  });
+  test('(5) resident == source is fully loaded', () => {
+    const r = row(buildLayerHealth(base({ residency: { resident: 10, source: 10 } })), 'Loading');
+    expect(r.value).toBe('fully loaded');
+    expect(r.status).toBe('ok');
+  });
+  test('(5) no source count known → residency undisclosed, not claimed', () => {
+    const r = row(buildLayerHealth(base({ residency: null })), 'Loading');
+    expect(r.value).toBe('fully loaded (no source count declared)');
+    expect(r.status).toBe('info');
+  });
+});

--- a/tests/scanReportPrecision.test.ts
+++ b/tests/scanReportPrecision.test.ts
@@ -61,10 +61,11 @@ describe('Scan Report — in-memory resolution row', () => {
     expect(row.status).toBe('info');
   });
 
-  it('reports both the worst case and the typical step', () => {
+  it('reports both the worst case and the mean-over-the-reach step', () => {
     const row = rowByLabel(scanReport.run(cloudSpanning(1_000, METRE_CRS)), 'In-memory resolution');
     expect(row.value).toContain('worst case');
-    expect(row.value).toContain('typical');
+    expect(row.value).toContain('mean over the reach');
+    expect(row.value).not.toContain('typical');
   });
 
   it('warns and grades coarse once the step passes a millimetre', () => {

--- a/tests/scanReportScope.test.ts
+++ b/tests/scanReportScope.test.ts
@@ -80,7 +80,7 @@ describe('scanReport — subset scope restricts and stamps', () => {
     // Coverage: both visible points are class 2 (non-zero) → 100% of 2.
     // v0.5.5 P12 — coverage merged into the Classification row.
     const classification = rowByLabel(result, 'Classification');
-    expect(classification.value).toContain('100.0 % coverage');
+    expect(classification.value).toContain('codes on 100.0 %');
     expect(classification.scope).toEqual(scope);
 
     // Result-level scope is carried too.


### PR DESCRIPTION
Several Scan Report and Layer Health rows stated results for the file when they were computed on the display sample, or relabelled header fields as acquisition facts. Each row now names its basis; no check algorithm or exported number changes.

- Duplicate Points / Stray Outliers: on a voxel-reduced sample the value reads "None — checked on the N-point display sample (voxel centroids); not run on the full cloud" with status `info`, since duplicates cannot occur among centroids. Unchanged on a fully loaded cloud.
- "Captured" → "File created" (LAS header creation date). "Capture Sensor" → "System identifier".
- Layer Health "Loading: fully loaded" → "display sample — N of M resident" when the resident count is below the declared count.
- "Vertical unit: unknown" now prints the parsed WKT vertical unit name.
- Classification: "Yes — codes on 100.0 %, 95.3 % unclassified (code 1)".
- Loaded row names both reductions (stride, then voxel). Solo keeps the file Point Count and adds a "Visible" row.

New test: `tests/scanReportMeasuredBasis.test.ts`.
