### PR TITLE
fix(ui): say which sample every colour and class figure describes

### DIFF
--- a/src/app/openScan.ts
+++ b/src/app/openScan.ts
@@ -474,7 +474,8 @@ export async function attachStaticCloud(
   // classification → intensity → elevation), gated so it never picks a mode
   // the cloud can't render, nor an RGB array too uniform to read. The rail
   // syncs off `mode` below, so this seam keeps render and chips in step.
-  const mode = recommendColorMode(result.cloud).mode;
+  const recommended = recommendColorMode(result.cloud);
+  const mode = recommended.mode;
   deps.setCurrentColorMode(mode);
   viewer.setColorMode(id, mode);
 
@@ -522,7 +523,9 @@ export async function attachStaticCloud(
     deps.inspector.addCloud(id, result.cloud.name, layerCount, result.cloud.metadata?.crs?.name ?? null, deps.layerIdentity.stableIdFor(id));
     deps.setLayerVisible(id, true);
     deps.layerService.refreshCrsFlags();
-    deps.inspector.setColorModes(availableModes(result.cloud), mode);
+    // The reason travels with the mode so the rail can say why a scan opened
+    // in it (e.g. Class passed over on a barely-classified tile).
+    deps.inspector.setColorModes(availableModes(result.cloud), mode, recommended.reason);
     deps.inspector.setDetail(result.cloud.pointCount, result.originalPointCount);
     deps.inspector.setElevationExtent(viewer.elevationExtent());
     deps.inspector.setIntensityExtent(viewer.intensityExtent());

--- a/src/render/activeColorbar.ts
+++ b/src/render/activeColorbar.ts
@@ -10,14 +10,19 @@
  *
  * Per-mode honesty rules (each is a deliberate scientific decision):
  *
- *   - **elevation** — the default elevation ramp (Turbo, exactly what
- *     `colorByElevation` paints), the CRS-declared unit or NO unit at all
- *     (an unknown unit must never be presented as metres), and a
- *     "p5–p95 window" note whenever the percentile trim narrowed the ramp,
- *     so a reader knows the endpoints are not the true extremes.
+ *   - **elevation** — the default elevation ramp (`DEFAULT_ELEVATION_PALETTE`,
+ *     Viridis — exactly what `colorByElevation` paints), the CRS-declared
+ *     unit or NO unit at all (an unknown unit must never be presented as
+ *     metres), and a percentile note whenever the trim narrowed the ramp,
+ *     so a reader knows the endpoints are not the true extremes. When the
+ *     range carries the count of the strided sample the percentiles were
+ *     taken from (`computeElevationRange` caps it at 50 000 values of the
+ *     loaded cloud), the note names that sample; otherwise it is the bare
+ *     "p5–p95 window".
  *   - **intensity** — a GRAYSCALE bar, because `colorByIntensity` paints
- *     grayscale; and no unit, because LAS intensity is a dimensionless DN
- *     whose scaling the app cannot vouch for.
+ *     grayscale; no unit, because LAS intensity is a dimensionless DN
+ *     whose scaling the app cannot vouch for; and a "loaded sample range"
+ *     note, because the raw min/max is scanned over the resident points.
  *   - **gpsTime** — normalised to seconds from the ramp window's start.
  *     Absolute GPS adjusted standard times are ~3e8 s, so raw ticks would be
  *     unreadable noise; the colour pass already normalises against the
@@ -61,6 +66,13 @@ export interface ActiveColorbarSource {
    * the endpoints are never mistaken for true min/max.
    */
   readonly trimPercent?: number;
+  /**
+   * How many values the percentile trim was taken over — the strided sample
+   * `computeElevationRange` sorted (≤ 50 000), NOT the loaded point count.
+   * Absent when the window was not computed here (streaming reseed, the
+   * project-shared scale), in which case the note stays a bare window.
+   */
+  readonly sampleCount?: number;
   /**
    * Elevation unit label from the CRS service ('m' / 'ft'), or null when the
    * CRS (or its vertical unit) is unknown. Honesty rule: null ⇒ the legend
@@ -106,6 +118,11 @@ export function buildActiveColorbarSpec(source: ActiveColorbarSource): ActiveCol
 
   switch (source.mode) {
     case 'elevation': {
+      const n = source.sampleCount;
+      const sampleNote =
+        windowNote && typeof n === 'number' && Number.isFinite(n) && n > 0
+          ? `${windowNote.replace(' window', '')} of a ${n.toLocaleString('en-US')}-point sample of the loaded cloud`
+          : windowNote;
       return {
         mode: 'elevation',
         spec: {
@@ -117,7 +134,7 @@ export function buildActiveColorbarSpec(source: ActiveColorbarSource): ActiveCol
           // suffix entirely — the honesty rule made structural.
           unit: source.elevationUnit || undefined,
         },
-        note: windowNote ?? undefined,
+        note: sampleNote ?? undefined,
       };
     }
     case 'intensity': {
@@ -129,7 +146,7 @@ export function buildActiveColorbarSpec(source: ActiveColorbarSource): ActiveCol
           max: range.max,
           label: 'Intensity',
         },
-        note: windowNote ?? undefined,
+        note: windowNote ? `${windowNote}, loaded sample range` : 'loaded sample range',
       };
     }
     case 'gpsTime': {

--- a/src/render/colorLegend.ts
+++ b/src/render/colorLegend.ts
@@ -167,6 +167,9 @@ export function buildColorLegend(host: ColorLegendHost): ColorLegend {
         mode,
         range: display,
         trimPercent,
+        // The shared window is not this cloud's percentile pass, so its
+        // sample count does not describe it.
+        sampleCount: shared ? undefined : range.sampleCount,
         elevationUnit: host.elevationUnitLabel(),
       });
     },

--- a/src/render/colorModeProvenance.ts
+++ b/src/render/colorModeProvenance.ts
@@ -55,3 +55,13 @@ export function isDerivedColorMode(mode: ColorMode): boolean {
  * something the survey recorded.
  */
 export const DERIVED_COLOR_NOTE = 'Colour is applied by the viewer, not recorded by the scan.';
+
+/**
+ * The qualifier for classification mode specifically. The plain derived note
+ * can be read as the class codes themselves being a viewer invention; they are
+ * not — the codes are the scan's own per-point attribute, only the palette is
+ * chosen here. (A heuristically derived classification is flagged as such in
+ * the Classes panel, which owns that provenance.)
+ */
+export const CLASSIFICATION_COLOR_NOTE =
+  'Palette is applied by the viewer; class codes are recorded by the scan (derived classes are marked in the Classes panel).';

--- a/src/render/colorModes.ts
+++ b/src/render/colorModes.ts
@@ -739,7 +739,7 @@ export function rampRangeForMode(
   mode: ColorMode,
   cloud: PointCloud,
   opts?: ColorForModeOptions,
-): { min: number; max: number } | null {
+): { min: number; max: number; sampleCount?: number } | null {
   const n = cloud.pointCount;
   switch (mode) {
     case 'intensity': {
@@ -774,7 +774,9 @@ export function rampRangeForMode(
         upperPercentile: 100 - trim,
         upAxis,
       });
-      return { min: r.minZ, max: r.maxZ };
+      // `sampleCount` is the strided percentile sample the window came from —
+      // passed through untouched so the legend can name it.
+      return { min: r.minZ, max: r.maxZ, sampleCount: r.sampleCount };
     }
     default:
       return null;

--- a/src/ui/ClassLegendPanel.ts
+++ b/src/ui/ClassLegendPanel.ts
@@ -3,16 +3,18 @@
  *
  * The Classification legend — one row per ASPRS class actually present in the
  * loaded scan (a positive point count), each carrying the renderer's class
- * colour swatch, the ASPRS name, a live "shown" point count, and a visibility
- * checkbox. A per-row "Solo" affordance isolates a single class; a "Show all"
+ * colour swatch, the ASPRS name, the class's loaded point count, and a
+ * visibility checkbox. A per-row "Solo" affordance isolates a single class; a "Show all"
  * button clears any filter; and a persistent banner appears only while a filter
  * is active so the user always knows the view is partial.
  *
  * DISPLAY ONLY. The panel owns a `ClassVisibility` and reports every change
  * back through `onChange` — the host (main.ts) applies the mask to the GPU and
  * re-renders the legend. The panel never touches three.js, the GPU, or the
- * analysis pipeline; counts are labelled as "shown" (post-downsample, resident)
- * points, never full-cloud totals.
+ * analysis pipeline. Counts are the LOADED (display-sample) points per class,
+ * set once in `setClasses` from the resident buffer: hiding or Solo'ing a
+ * class, or an elevation / intensity filter, does not recompute them, and they
+ * are never full-cloud totals.
  *
  * A dumb view in the same vocabulary as MeasurePanel / AnalysePanel: a
  * `readonly element`, an `el(...)`-built DOM, collapsible head, and
@@ -161,7 +163,7 @@ export class ClassLegendPanel {
     // basis as the Scan Report's "Loaded N (display sample)" row.
     this._sampleNote = el('div', {
       className: 'olv-cl-samplenote olv-hidden',
-      text: 'Counts cover the loaded display sample — not the full cloud.',
+      text: 'Counts, Solo and hide act on the loaded display sample — not the full cloud.',
     });
     this._sampleNote.setAttribute('role', 'note');
 
@@ -446,7 +448,7 @@ export class ClassLegendPanel {
     const count = el('span', {
       className: 'olv-cl-count',
       text: (this._counts.get(code) ?? 0).toLocaleString(),
-      title: 'Shown points (post-downsample)',
+      title: 'Loaded points (display sample)',
     });
 
     // Solo — isolate this one class. ClassVisibility.isolate hides every other

--- a/src/ui/Inspector.ts
+++ b/src/ui/Inspector.ts
@@ -189,7 +189,7 @@ const MODE_TITLES: Record<ColorMode, string> = {
   elevation: 'Colour points by height — low to high',
   classification: 'Colour points by their ASPRS classification code',
   normal: 'Colour points by surface-normal direction',
-  density: 'Colour points by local coverage — dark = sparse, bright = dense',
+  density: 'Colour points by local point density of the loaded sample — dark = sparse, bright = dense',
   gpsTime: 'Colour points by GPS acquisition time — dark early, bright late (Cividis)',
   returnNumber: 'Colour points by return number — dark first return, bright last (Cividis)',
   coverage:
@@ -336,6 +336,8 @@ interface RangeFilter {
  */
 function buildRangeFilter(opts: {
   title: string;
+  /** Optional one-line note under the fields naming what the seeded bounds are. */
+  caption?: string;
   /** Noun for the input aria-labels, e.g. 'elevation' or 'intensity'. */
   unit: string;
   resetTitle: string;
@@ -360,6 +362,7 @@ function buildRangeFilter(opts: {
       el('span', { className: 'olv-elev-cap', text: 'Max' }),
       maxInput,
     ]),
+    ...(opts.caption ? [el('p', { className: 'olv-chips-note', text: opts.caption })] : []),
     reset,
   ]);
   const sectionEl = section(opts.title, body);
@@ -974,12 +977,16 @@ export class Inspector {
     // "Colour trim" and tooltip'd to keep it distinct from the Elevation filter
     // below, which is what actually hides points.
     this._heightTrimRow.title =
-      'Clips the top and bottom of the elevation colour ramp so outliers don’t ' +
-      'wash out the gradient. This only affects colour — to hide points by ' +
-      'height, use the Elevation filter.';
+      'Clips the top and bottom of the elevation colour ramp (sets the colourbar ' +
+      'window) so outliers don’t wash out the gradient. This only affects colour — ' +
+      'to hide points by height, use the Elevation filter.';
     this._heightTrimSlider.setAttribute('aria-label', 'Elevation colour-ramp trim (percent)');
     this._heightTrimRow.replaceChildren(
-      el('span', { className: 'olv-height-trim-name', text: 'Colour trim' }),
+      el('span', {
+        className: 'olv-height-trim-name',
+        text: 'Colour trim',
+        title: 'Sets the colourbar window',
+      }),
       this._heightTrimSlider,
       this._heightTrimLabel,
     );
@@ -1010,12 +1017,13 @@ export class Inspector {
     const resetTitle = 'Clear the filter and show every point in this scan';
     this._elevFilter = buildRangeFilter({
       title: 'Elevation filter',
+      caption: 'Loaded sample extent; colour window is trimmed separately (Colour trim).',
       unit: 'elevation',
       resetTitle,
       onApply: (r) => this._cb.onElevationFilter?.(r),
     });
     this._intenFilter = buildRangeFilter({
-      title: 'Intensity filter',
+      title: 'Intensity filter (loaded sample range)',
       unit: 'intensity',
       resetTitle,
       onApply: (r) => this._cb.onIntensityFilter?.(r),
@@ -1709,13 +1717,24 @@ export class Inspector {
    */
   private _coverageAvailable = false;
 
-  /** Render the color-mode chips, marking `active` as selected. */
-  setColorModes(modes: ColorMode[], active: ColorMode): void {
+  /**
+   * The recommender's one-line rationale for the mode the scan opened in, or
+   * null once the analyst has picked a mode by hand (the sentence describes
+   * the opening choice only).
+   */
+  private _openingReason: string | null = null;
+
+  /**
+   * Render the color-mode chips, marking `active` as selected. `openingReason`
+   * is shown beneath the rail as one sentence until the user changes mode.
+   */
+  setColorModes(modes: ColorMode[], active: ColorMode, openingReason?: string): void {
     // The Coverage / Confidence modes are analysis-gated, not data-gated, so
     // they are never part of the per-cloud `availableModes` list — track the
     // data modes separately and always append the gated chips below.
     this._modes = modes.filter((m) => !ANALYSIS_GATED_MODES.includes(m));
     this._activeMode = active;
+    this._openingReason = openingReason ?? null;
     this._renderColorChips();
   }
 
@@ -1751,6 +1770,7 @@ export class Inspector {
         for (const other of this._chips.children) other.classList.remove('olv-chip-active');
         chip.classList.add('olv-chip-active');
         this._activeMode = mode;
+        this._openingReason = null;
         this._cb.onColorMode(mode);
         // v0.3.7 final-polish — show the trim slider when the analyst
         // picks Height. Other modes don't honour the slider so hiding
@@ -1765,7 +1785,11 @@ export class Inspector {
     // one is active. The provenance line comes first: it describes what the
     // analyst is looking at right now, while the gate note describes a mode
     // they cannot select yet.
-    const note = buildColorChipNote(this._activeMode, anyGatedDisabled);
+    const note = buildColorChipNote(
+      this._activeMode,
+      anyGatedDisabled,
+      this._openingReason ?? undefined,
+    );
     this._chipsNote.textContent = note;
     this._chipsNote.classList.toggle('olv-hidden', note === '');
     // Initial visibility for the trim row — track the active mode.

--- a/src/ui/colorChipModel.ts
+++ b/src/ui/colorChipModel.ts
@@ -12,7 +12,11 @@
  */
 
 import type { ColorMode } from '../render/colorModes';
-import { isDerivedColorMode, DERIVED_COLOR_NOTE } from '../render/colorModeProvenance';
+import {
+  isDerivedColorMode,
+  DERIVED_COLOR_NOTE,
+  CLASSIFICATION_COLOR_NOTE,
+} from '../render/colorModeProvenance';
 
 /** Tooltip shown on a gated chip while it is disabled (no analysis yet). */
 export const COVERAGE_DISABLED_TITLE = 'Run terrain analysis first';
@@ -75,12 +79,27 @@ export function buildColorChipModel(
  * yet. Both are surfaced in the flow rather than only as a chip `title`, which
  * never appears on touch.
  *
+ * Classification gets its own provenance line: the generic one reads as if the
+ * class codes were invented here, when only the palette is.
+ *
+ * `openingReason`, when given, is the recommender's one-line rationale for the
+ * mode a scan opened in (e.g. why Class was passed over on a barely-classified
+ * tile). It sits between provenance and the gate note as one sentence, and
+ * the caller drops it once the analyst picks a mode by hand.
+ *
  * Returns an empty string when there is nothing to say, so the caller can key
  * the row's visibility off the result.
  */
-export function buildColorChipNote(activeMode: ColorMode, anyGatedDisabled: boolean): string {
+export function buildColorChipNote(
+  activeMode: ColorMode,
+  anyGatedDisabled: boolean,
+  openingReason?: string,
+): string {
   const notes: string[] = [];
-  if (isDerivedColorMode(activeMode)) notes.push(DERIVED_COLOR_NOTE);
+  if (activeMode === 'classification') notes.push(CLASSIFICATION_COLOR_NOTE);
+  else if (isDerivedColorMode(activeMode)) notes.push(DERIVED_COLOR_NOTE);
+  const reason = openingReason?.trim();
+  if (reason) notes.push(`Opened ${reason.replace(/\.+$/, '')}.`);
   if (anyGatedDisabled) notes.push(`${COVERAGE_DISABLED_TITLE} to enable Coverage and Confidence.`);
   return notes.join(' ');
 }

--- a/tests/activeColorbar.test.ts
+++ b/tests/activeColorbar.test.ts
@@ -266,7 +266,7 @@ describe('rampRangeForMode — single source with colorForMode', () => {
     const cloud = makeScalarCloud();
     const trimmed = rampRangeForMode('elevation', cloud, { heightPercentileTrim: 25 });
     const raw = rampRangeForMode('elevation', cloud, { heightPercentileTrim: 0 });
-    expect(raw).toEqual({ min: 0, max: 30 });
+    expect(raw).toMatchObject({ min: 0, max: 30 });
     expect(trimmed!.min).toBeGreaterThanOrEqual(raw!.min);
     expect(trimmed!.max).toBeLessThanOrEqual(raw!.max);
   });
@@ -283,5 +283,24 @@ describe('rampRangeForMode — single source with colorForMode', () => {
     expect(rampRangeForMode('returnNumber', bare)).toBeNull();
     expect(rampRangeForMode('rgb', makeScalarCloud())).toBeNull();
     expect(rampRangeForMode('classification', makeScalarCloud())).toBeNull();
+  });
+});
+
+describe('buildActiveColorbarSpec — stated sample bases', () => {
+  it('elevation names the percentile sample when the range carries its count', () => {
+    const bar = buildActiveColorbarSpec(
+      src({ mode: 'elevation', trimPercent: 5, sampleCount: 50_000 }),
+    );
+    expect(bar!.note).toBe('p5–p95 of a 50,000-point sample of the loaded cloud');
+  });
+
+  it('elevation keeps the bare window note when no sample count is known (streaming)', () => {
+    const bar = buildActiveColorbarSpec(src({ mode: 'elevation', trimPercent: 5 }));
+    expect(bar!.note).toBe('p5–p95 window');
+  });
+
+  it('intensity says its raw window is the loaded sample range', () => {
+    const bar = buildActiveColorbarSpec(src({ mode: 'intensity' }));
+    expect(bar!.note).toBe('loaded sample range');
   });
 });

--- a/tests/classLegendSampleDisclosure.test.ts
+++ b/tests/classLegendSampleDisclosure.test.ts
@@ -207,3 +207,19 @@ describe('Capture provenance — the density footprint names its basis', () => {
     expect(signals).toMatch(/bounding.box/i);
   });
 });
+
+describe('Classes legend — every figure names the loaded sample', () => {
+  it('the count tooltip says the figure is loaded points, not a live shown count', () => {
+    const panel = new ClassLegendPanel();
+    panel.setClasses(COUNTS, { loaded: LOADED, declared: LOADED });
+    const count = (panel.element as unknown as FakeEl).querySelector('span.olv-cl-count');
+    expect(count?.title).toBe('Loaded points (display sample)');
+  });
+
+  it('the sample caption says Solo and hide scope the loaded sample', () => {
+    const panel = new ClassLegendPanel();
+    panel.setClasses(COUNTS, { loaded: LOADED, declared: 47_900_000 });
+    expect(caption(panel)?.textContent ?? '').toMatch(/Solo/);
+    expect(caption(panel)?.textContent ?? '').toMatch(/loaded display sample/);
+  });
+});

--- a/tests/colorChipModel.test.ts
+++ b/tests/colorChipModel.test.ts
@@ -12,9 +12,14 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildColorChipModel,
+  buildColorChipNote,
   COVERAGE_DISABLED_TITLE,
   ANALYSIS_GATED_MODES,
 } from '../src/ui/colorChipModel';
+import {
+  DERIVED_COLOR_NOTE,
+  CLASSIFICATION_COLOR_NOTE,
+} from '../src/render/colorModeProvenance';
 import type { ColorMode } from '../src/render/colorModes';
 
 const DATA_MODES: ColorMode[] = ['rgb', 'elevation', 'classification', 'density'];
@@ -110,5 +115,35 @@ describe('buildColorChipModel', () => {
     expect(chips[chips.length - 2].mode).toBe('coverage');
     expect(chips[chips.length - 1].mode).toBe('confidence');
     expect(chips.find((c) => c.mode === 'gpsTime')!.active).toBe(true);
+  });
+});
+
+describe('buildColorChipNote — stated bases', () => {
+  it('classification says the palette is the viewer’s but the class codes are the scan’s', () => {
+    const note = buildColorChipNote('classification', false);
+    expect(note).toBe(CLASSIFICATION_COLOR_NOTE);
+    expect(note).toMatch(/class codes are recorded by the scan/);
+    expect(note).not.toBe(DERIVED_COLOR_NOTE);
+  });
+
+  it('other derived modes keep the plain derived note', () => {
+    expect(buildColorChipNote('elevation', false)).toBe(DERIVED_COLOR_NOTE);
+  });
+
+  it('surfaces the opening-choice reason as one sentence after provenance', () => {
+    const reason =
+      'coloured by height — the scan carries classes, but too few points are classified to read';
+    const note = buildColorChipNote('elevation', false, reason);
+    expect(note.indexOf(DERIVED_COLOR_NOTE)).toBe(0);
+    expect(note).toContain('Opened ' + reason + '.');
+    // Gate note still last.
+    const all = buildColorChipNote('elevation', true, reason);
+    expect(all.endsWith('to enable Coverage and Confidence.')).toBe(true);
+    expect(all.indexOf('Opened ')).toBeLessThan(all.indexOf('Run terrain analysis first'));
+  });
+
+  it('a blank reason adds nothing', () => {
+    expect(buildColorChipNote('rgb', false, '')).toBe('');
+    expect(buildColorChipNote('rgb', false, undefined)).toBe('');
   });
 });

--- a/tests/viewerActiveColorbar.test.ts
+++ b/tests/viewerActiveColorbar.test.ts
@@ -332,3 +332,16 @@ describe('colorLegend.intensityExtent', () => {
     expect(buildColorLegend(host(state)).intensityExtent()).toBeNull();
   });
 });
+
+describe('colorLegend.activeColorbar — sample basis passthrough', () => {
+  it('static elevation reports the percentile sample count computeElevationRange used', () => {
+    const bar = activeColorbar({ ...staticCloud('elevation'), heightPercentileTrim: 5 });
+    // 4 points → the stride sample holds all 4; the note states that count.
+    expect(bar!.note).toBe('p5–p95 of a 4-point sample of the loaded cloud');
+  });
+
+  it('streaming elevation has no resident sample count and keeps the window note', () => {
+    const bar = activeColorbar(streamingState('elevation', true));
+    expect(bar!.note).toBe('p5–p95 window');
+  });
+});


### PR DESCRIPTION
Colour and class figures on screen described the display sample without saying so. Each label now names its basis; no rendered colour, ramp range, filter default or number changes.

- Class count tooltip "Shown points (post-downsample)" → "Loaded points (display sample)": the counts are set once in `setClasses` and never recomputed on hide, Solo or filters.
- Colourbar note "p5–p95 window" → "p5–p95 of a 50,000-point sample of the loaded cloud", using the `sampleCount` `computeElevationRange` already returns.
- Intensity and Elevation filter sections state that their bounds are the loaded sample's.
- The class-mode fallback reason from `recommendColorMode` now reaches the chip note instead of being discarded in `openScan`.
- Classification mode gets its own note: the palette is the viewer's, the class codes are the scan's.
- Density chip title and colour-trim tooltip reworded; stale Turbo comment fixed.

New test: `tests/classLegendSampleDisclosure.test.ts`.
