### PR TITLE
fix(export): state the basis of every terrain report row

### DIFF
--- a/src/render/measure/terrainReportPdf.ts
+++ b/src/render/measure/terrainReportPdf.ts
@@ -193,6 +193,21 @@ export async function buildTerrainReportPdf(
     y -= 10;
   }
 
+  // ── Definitions — the panel's metric tooltips, single-sourced ─────────────
+  if (content.definitions.length > 0) {
+    ensure(34);
+    text('Definitions', M, y, 12, bold, INK);
+    y -= 6;
+    page.drawLine({ start: { x: M, y }, end: { x: PW - M, y }, thickness: 0.5, color: FRAME });
+    y -= 14;
+    for (const d of content.definitions) {
+      ensure(16);
+      y = drawWrapped(page, font, `- ${d}`, M, y, PW - 2 * M, 9, INK);
+      y -= 3;
+    }
+    y -= 10;
+  }
+
   // ── Provenance footer + the standing not-survey-grade note ───────────────
   // Bottom-anchored on the LAST page from the block's MEASURED height (the old
   // fixed start at M + 78 fit ~12 lines; Methods / Record / Manifest grew the

--- a/src/terrain/complexity/complexityEnvelope.ts
+++ b/src/terrain/complexity/complexityEnvelope.ts
@@ -7,8 +7,11 @@
  * coverage mode, source/analyzed point counts, a 0–100 confidence, and
  * ordered warnings.
  *
- * CONFIDENCE IS DERIVED, NEVER ASSERTED. It is computed from observable
- * data support only:
+ * CONFIDENCE IS DERIVED, NEVER ASSERTED. It is a WINDOW-COMPLETENESS
+ * figure computed from observable data support only — how much of the grid
+ * and of each metric window held a valid cell. Interpolated (void-filled)
+ * cells count as valid, so it says nothing about how well those cells
+ * represent the terrain; reports label it "Complexity window completeness".
  *
  *   validFraction     = valid cells / total cells      (void fraction is
  *                       1 − validFraction)

--- a/src/terrain/export/exportProvenance.ts
+++ b/src/terrain/export/exportProvenance.ts
@@ -794,8 +794,10 @@ export function provenanceLines(p: ExportProvenance): string[] {
         ? `${p.accuracy.usgsDensityReferenceFloor} density floor (reference)`
         : 'unknown',
     ),
+    // Ground-return density over measured cells, stride-scaled — not the
+    // scan's all-returns point density.
     kv(
-      'Point density',
+      'Ground density',
       p.pointDensityPerM2 != null ? `${p.pointDensityPerM2.toFixed(1)} pts/m²` : 'unknown',
     ),
   ];

--- a/src/terrain/export/terrainReportContent.ts
+++ b/src/terrain/export/terrainReportContent.ts
@@ -27,6 +27,8 @@
  *                             and the panel can never grade a product apart.
  *   - How to improve        ← {@link explainLimitations} fixes (only when the
  *                             surface is not fully-good).
+ *   - Definitions           ← {@link METRIC_TOOLTIPS} — the panel's own metric
+ *                             tooltips, imported so the two never drift.
  *   - Footer                ← {@link provenanceLines} + the not-survey-grade note.
  *
  * Honesty contract (non-negotiable, mirrors the rest of the terrain stack):
@@ -47,7 +49,10 @@ import { recommendedWorkflows, type WorkflowItem } from '../contour/recommendedW
 import { terrainProducts } from '../contour/terrainProducts';
 import { explainLimitations } from '../contour/whyNotReasons';
 import type { DatasetIntelligence } from '../datasetIntelligence';
+import { METRIC_TOOLTIPS } from '../contour/contourCopy';
 import { horizontalUnitLabel } from '../../units/units';
+import { EVIDENCE_REGISTRY } from '../../validation/claimRegistry.generated';
+import { evidenceLabel, type EvidenceLevel } from '../../validation/evidenceLevel';
 import {
   buildExportProvenance,
   provenanceLines,
@@ -86,6 +91,13 @@ export interface TerrainReportProduct {
   readonly availability: 'Available' | 'Preview' | 'Blocked';
   /** Short, honest qualifier for Preview / Blocked products (absent for Available). */
   readonly note?: string;
+  /**
+   * Evidence level of the product's registered claim, e.g.
+   * "E4 — Cross-implementation validated (baseline)". The DTM claim carries the
+   * export resolver's effective level; every other claim prints its registry
+   * baseline. Products without a single registered claim say so.
+   */
+  readonly evidence: string;
 }
 
 /**
@@ -128,7 +140,55 @@ export interface TerrainReportContent {
   readonly provenanceLines: ReadonlyArray<string>;
   /** The standing not-survey-grade note ({@link NOT_SURVEY_GRADE_NOTE}). */
   readonly notSurveyGrade: string;
+  /** The panel's metric tooltips ({@link METRIC_TOOLTIPS}), printed as Definitions. */
+  readonly definitions: ReadonlyArray<string>;
 }
+
+/**
+ * Product label → registered claim id. Only products whose deliverable maps
+ * to ONE registry claim are listed; the rest print "no single registered
+ * claim" rather than a level picked from several. Map sheet shares the
+ * CONTOURS claim (MAP_SHEET_CLAIM in mapSheetPdf.ts).
+ */
+const PRODUCT_CLAIM: Readonly<Record<string, string>> = {
+  Profiles: 'MEAS-PROFILE',
+  'DTM/DEM export': 'DTM',
+  Contours: 'CONTOURS',
+  'Map sheet': 'CONTOURS',
+};
+
+/** "E4 — Cross-implementation validated" from the registry level id. */
+function fmtLevel(level: EvidenceLevel): string {
+  return `${level.slice(0, 2)} — ${evidenceLabel(level)}`;
+}
+
+/**
+ * The evidence line for one product. The DTM claim reuses the SAME resolution
+ * the provenance was stamped from (scoped overlay included); any other claim
+ * prints its registry baseline and says so — the report path carries no
+ * artifact context to resolve them against.
+ */
+function productEvidence(label: string, provenance: ExportProvenance): string {
+  const claimId = PRODUCT_CLAIM[label];
+  if (claimId == null) return 'no single registered claim';
+  const res = provenance.evidenceResolution;
+  if (res && res.claimId === claimId && res.effectiveEvidence != null) {
+    return res.matchedStudy != null
+      ? `${fmtLevel(res.effectiveEvidence)} (in-scope study ${res.matchedStudy})`
+      : `${fmtLevel(res.effectiveEvidence)} (baseline)`;
+  }
+  const entry = EVIDENCE_REGISTRY[claimId];
+  return entry ? `${fmtLevel(entry.current)} (baseline)` : 'unregistered (E0)';
+}
+
+/**
+ * The spatially-blocked hold-out parameters analyseContours runs with —
+ * echoed as text so the disclosure line names the real procedure. Mirrors
+ * BLOCKED_CELL_CAP / BLOCKED_POINT_CAP / blockSize / folds / the 32-point
+ * floor in analyseContours.ts; a change there must be mirrored here.
+ */
+const BLOCKED_CV_TEXT =
+  '8-cell blocks, 4 folds, ground set strided to <= 20,000 points, skipped on grids over 250,000 cells';
 
 /** Format a metre value at 2 dp, or an em-dash when absent (never fabricated). */
 function fmtM(v: number | null | undefined): string {
@@ -202,10 +262,13 @@ export function buildTerrainReportContent(
   };
 
   // ── Dataset Statistics ──────────────────────────────────────────────────
-  // Footprint = grid extent (cols/rows × cell size). Honest when the grid is
-  // absent. Classification availability is inferred from whether the run
-  // dropped any classified non-ground returns (excludedByClassification > 0)
-  // OR a non-zero count was supplied — we say "yes" / "no" plainly.
+  // Grid extent = cols/rows × cell size (up to one cell of padding per axis,
+  // so not the point footprint). Honest when the grid is absent. "Non-ground
+  // classes excluded" is whether the run dropped classified non-ground returns
+  // (excludedByClassification > 0); the ground SOURCE is a separate fact —
+  // despike is off only on the trusted class-2 path (analyseContours:
+  // despikeApplied = !trust.trust), so generationParams.despike === false is
+  // the result's own record that ASPRS class 2 built the DTM.
   const cols = Number.isFinite(dtm?.cols) ? dtm.cols : null;
   const rows = Number.isFinite(dtm?.rows) ? dtm.rows : null;
   const cell = Number.isFinite(dtm?.cellSizeM) && dtm.cellSizeM > 0 ? dtm.cellSizeM : null;
@@ -216,25 +279,42 @@ export function buildTerrainReportContent(
     isGeographic: opts.isGeographic,
     linearUnit: opts.linearUnit,
   });
-  const footprint =
+  const gridExtent =
     cols != null && rows != null && cell != null
       ? `${Math.round(cols * cell).toLocaleString()} × ${Math.round(rows * cell).toLocaleString()} ${footprintUnit}`
       : DASH;
   const density = provenance.pointDensityPerM2;
-  const classified =
+  const classesExcluded =
     (result.excludedByClassification ?? 0) > 0 ? 'Yes' : 'No';
+  const groundTrusted = result.generationParams?.despike === false;
+  const groundSource = groundTrusted
+    ? 'ASPRS class 2 (trusted)'
+    : 'SMRF filter (classification not trusted)';
 
   // Dataset Intelligence bucket rows — present ONLY when the caller passed the
-  // card's summary through. The labels are the card's own strings (already
-  // honest: 'unknown' buckets render as "—"), so the PDF and the Inspector can
-  // never disagree on a bucket.
+  // card's summary through. The labels are the card's own strings, so the PDF
+  // and the Inspector can never disagree on a bucket. A row whose bucket is
+  // 'unknown' is OMITTED: the card renders "—" for it, and a dash in a report
+  // reads as a pending measurement rather than an absent signal.
   const intel = opts.intelligence ?? null;
+  const densityLabel =
+    intel?.density.basis === 'volumetric'
+      ? 'Volumetric point density (all returns, bounding box)'
+      : 'Areal point density (all returns, header footprint)';
   const intelligenceRows: TerrainReportRow[] = intel
     ? [
-        { label: 'Point density (class)', value: intel.density.label },
-        { label: 'Terrain complexity', value: intel.complexity.label },
-        { label: 'Ground visibility', value: intel.groundVisibility.label },
-        { label: 'Metric stability', value: intel.confidence.label },
+        ...(intel.density.bucket !== 'unknown'
+          ? [{ label: densityLabel, value: intel.density.label }]
+          : []),
+        ...(intel.complexity.bucket !== 'unknown'
+          ? [{ label: 'Terrain complexity', value: intel.complexity.label }]
+          : []),
+        ...(intel.groundVisibility.bucket !== 'unknown'
+          ? [{ label: 'Ground visibility', value: intel.groundVisibility.label }]
+          : []),
+        ...(intel.confidence.band !== 'unknown'
+          ? [{ label: 'Metric stability', value: intel.confidence.label }]
+          : []),
       ]
     : [];
 
@@ -248,16 +328,17 @@ export function buildTerrainReportContent(
       // file-scale density is the 'Ground density' row below.
       { label: 'Ground points', value: fmtInt(dtm?.sourcePointCount) },
       { label: 'Used in DTM', value: fmtInt(dtm?.analyzedPointCount) },
-      { label: 'Footprint (extent)', value: footprint },
+      { label: 'Grid extent', value: gridExtent },
       {
-        label: 'Ground density',
+        label: 'Ground density (measured cells, stride-scaled)',
         value: density != null ? `${density.toFixed(1)} pts/m²` : DASH,
       },
       ...intelligenceRows,
       { label: 'Coverage mode', value: provenance.coverageMode },
       { label: 'Horizontal CRS', value: provenance.horizontalCrs },
       { label: 'Vertical datum', value: provenance.verticalDatum },
-      { label: 'Classification available', value: classified },
+      { label: 'Non-ground classes excluded', value: classesExcluded },
+      { label: 'Ground source', value: groundSource },
       { label: 'Generated', value: fmtGenerated(provenance.generated) },
       {
         label: 'Software',
@@ -269,8 +350,12 @@ export function buildTerrainReportContent(
   // ── Terrain Assessment ──────────────────────────────────────────────────
   // Derived complexity rows (v0.5.4) source the SAME pre-formatted strings
   // the provenance stamps and the Analyse panel renders (metric, window in
-  // cells AND ground metres, Z units, derived confidence). A run that
-  // measured nothing renders an honest em-dash, never a fabricated band.
+  // cells AND ground metres, Z units). The 0–100 figure is window
+  // completeness (valid fraction × mean window support; interpolated cells
+  // count as valid — complexityEnvelope.ts), not a confidence in the metric.
+  // A run that measured nothing renders an honest em-dash, never a
+  // fabricated band. The Export note row exists only when the engine gave a
+  // reason; a Ready run prints no stand-in sentence.
   const cx = provenance.complexity;
   const assessmentSection: TerrainReportSection = {
     title: 'Terrain Assessment',
@@ -282,26 +367,25 @@ export function buildTerrainReportContent(
       },
       { label: 'Reason', value: assessment.reason },
       { label: 'Export readiness', value: assessment.exportReadiness },
-      {
-        label: 'Export note',
-        value: assessment.exportReason ? assessment.exportReason : 'ready to hand off',
-      },
+      ...(assessment.exportReason
+        ? [{ label: 'Export note', value: assessment.exportReason }]
+        : []),
       { label: 'Ruggedness (VRM)', value: cx ? cx.vrmText : DASH },
       { label: 'Landform (TPI)', value: cx ? cx.tpiText : DASH },
       {
-        label: 'Complexity confidence',
-        value: cx ? `${cx.confidence}/100 (derived from data support)` : DASH,
+        label: 'Complexity window completeness',
+        value: cx ? `${cx.confidence}/100` : DASH,
       },
     ],
   };
 
   // ── Coverage Analysis ───────────────────────────────────────────────────
   // The gate's measured/interpolated/empty/edge ratios + mean confidence and
-  // ground visibility — the same figures the panel's coverage block shows.
+  // ground share — the same figures the panel's coverage block shows. Coverage
+  // mode is printed once, under Dataset Statistics.
   const coverageSection: TerrainReportSection = {
     title: 'Coverage Analysis',
     rows: [
-      { label: 'Coverage mode', value: provenance.coverageMode },
       // These three are shares of the WHOLE grid and sum to 100%. The verdict
       // and the gate reasons quote interpolatedOfSurfaceRatio instead, which
       // excludes empty cells, so both bases appear here and each says which one
@@ -318,10 +402,16 @@ export function buildTerrainReportContent(
       { label: 'Edge risk', value: fmtPct(q?.edgeRiskRatio) },
       {
         // Not the same quantity as the "Ground visibility" bucket in Dataset
-        // Statistics, which is a categorical read. This is the classifier's
-        // ground share of all returns.
-        label: 'Ground returns (of all returns)',
-        value: fmtPct(q?.groundPointRatio),
+        // Statistics, which is a categorical read. groundPointRatio is
+        // gf.groundPointCount / gf.sourcePointCount (analyseContours): on the
+        // SMRF path the numerator is SMRF-labelled ground of the analysed
+        // stride sample and the denominator is that sample AFTER
+        // excludeNonGroundClasses dropped classes 3-7/18 — not all returns,
+        // not the ground class. On the trusted class-2 path both counts are
+        // the class-2 set, so the ratio is a meaningless 100%; say what
+        // happened instead of printing it.
+        label: 'Ground share of analysed candidates (after class exclusion)',
+        value: groundTrusted ? 'class 2 trusted' : fmtPct(q?.groundPointRatio),
       },
       {
         label: 'Mean confidence',
@@ -345,15 +435,34 @@ export function buildTerrainReportContent(
   // shows. ASCII only (the PDF renderer strips non-Latin1), so "<=" not "≤".
   const pctOf = (x: number): string => `${Math.round(x * 100)}%`;
   const relM = result.reliabilitySplit?.measured;
-  const reliabilityValue =
-    relM && relM.n >= 5 && Number.isFinite(relM.reliability)
-      ? `${pctOf(relM.reliability)} (95% CI ${pctOf(relM.ciLow)}-${pctOf(relM.ciHigh)}, |dz| <= ${fmtM(relM.tolerance)})`
-      : DASH;
+  // The reliability tolerance IS the hold-out RMSEz (analyseContours:
+  // reliabilityTolerance = validation.rmse), so the row is the share of
+  // measured-cell residuals within 1 × RMSEz — ~68-76% for any Gaussian —
+  // and is labelled as that, never as an independent tolerance.
+  const hasRel = relM != null && relM.n >= 5 && Number.isFinite(relM.reliability);
+  const reliabilityLabel = hasRel
+    ? `Within 1 × hold-out RMSEz (${fmtM(relM.tolerance)})`
+    : 'Within 1 × hold-out RMSEz';
+  const reliabilityValue = hasRel
+    ? `${pctOf(relM.reliability)} of measured-cell hold-out residuals (95% CI ${pctOf(relM.ciLow)}-${pctOf(relM.ciHigh)})`
+    : DASH;
   const blk = result.blockedAccuracy;
-  const blockedValue =
-    blk && blk.n > 0 && Number.isFinite(blk.rmse)
-      ? `${fmtM(blk.rmse)} (95% CI ${fmtM(blk.ciLow)}-${fmtM(blk.ciHigh)})`
-      : DASH;
+  const hasBlk = blk != null && blk.n > 0 && Number.isFinite(blk.rmse);
+  const blockedValue = hasBlk
+    ? `${fmtM(blk.rmse)} (95% CI ${fmtM(blk.ciLow)}-${fmtM(blk.ciHigh)})`
+    : DASH;
+  // One line that says what each RMSE tests, so the two figures are never
+  // read as competing estimates of the same thing. Parameters are the ones
+  // analyseContours runs with (BLOCKED_CV_TEXT).
+  const rmseText = hasAcc ? fmtM(provenance.accuracy?.rmseZM) : null;
+  const accuracyBases =
+    rmseText != null && rmseText !== DASH
+      ? `Random hold-out RMSEz (${rmseText}) tests interpolation between neighbouring ground points and feeds NVA/VVA. ` +
+        `Blocked spatial CV (${BLOCKED_CV_TEXT}) tests extrapolation across held-out blocks; ` +
+        (hasBlk
+          ? `quote the blocked figure (${fmtM(blk.rmse)}) for map-scale use.`
+          : 'it was not run on this grid, so no map-scale figure is available.')
+      : null;
   const qualitySection: TerrainReportSection = {
     title: 'Quality Metrics',
     rows: [
@@ -365,9 +474,14 @@ export function buildTerrainReportContent(
       { label: 'VVA-style (95th pct, hold-out)', value: hasAcc ? fmtM(provenance.accuracy?.vvaM) : DASH },
       // Measured-cell empirical reliability (Wilson CI) and the less optimistic
       // spatially-blocked RMSE — the same numbers the Analyse panel surfaces.
-      { label: 'Measured reliability', value: reliabilityValue },
+      { label: reliabilityLabel, value: reliabilityValue },
       { label: 'Blocked RMSE (spatial CV)', value: blockedValue },
-      { label: 'USGS density reference', value: qlValue === DASH ? DASH : `>= ${qlValue} floor` },
+      ...(accuracyBases != null ? [{ label: 'Accuracy bases', value: accuracyBases }] : []),
+      // The stride-scaled ground density caveat used to live only in Warnings.
+      {
+        label: 'USGS density reference',
+        value: qlValue === DASH ? DASH : `>= ${qlValue} floor (stride-scaled ground density)`,
+      },
     ],
   };
 
@@ -415,11 +529,14 @@ export function buildTerrainReportContent(
   // 'Ready' renames to 'Available' (the report speaks in take-away
   // vocabulary); Ready rows carry no reason in the view, so they carry no
   // note here either — a ready product needs no excuse.
+  // Each row also carries its claim's evidence level (productEvidence).
   const products: TerrainReportProduct[] = terrainProducts(assessment, workflowItems).map(
-    (p) =>
-      p.statusWord === 'Ready' || p.reason == null
-        ? { label: p.label, availability: p.statusWord === 'Ready' ? ('Available' as const) : p.statusWord }
-        : { label: p.label, availability: p.statusWord, note: p.reason },
+    (p) => {
+      const evidence = productEvidence(p.label, provenance);
+      return p.statusWord === 'Ready' || p.reason == null
+        ? { label: p.label, availability: p.statusWord === 'Ready' ? ('Available' as const) : p.statusWord, evidence }
+        : { label: p.label, availability: p.statusWord, note: p.reason, evidence };
+    },
   );
 
   // The workflow + products lists are ALSO surfaced as label/value sections so
@@ -437,7 +554,7 @@ export function buildTerrainReportContent(
     title: 'Terrain Products Available',
     rows: products.map((p) => ({
       label: p.label,
-      value: p.note ? `${p.availability} — ${p.note}` : p.availability,
+      value: `${p.note ? `${p.availability} — ${p.note}` : p.availability} · Evidence level: ${p.evidence}`,
     })),
   };
 
@@ -460,5 +577,7 @@ export function buildTerrainReportContent(
     provenance,
     provenanceLines: provenanceLines(provenance),
     notSurveyGrade: NOT_SURVEY_GRADE_NOTE,
+    // The panel's tooltips verbatim — imported, never retyped.
+    definitions: Object.values(METRIC_TOOLTIPS),
   };
 }

--- a/tests/provenanceConsistency.test.ts
+++ b/tests/provenanceConsistency.test.ts
@@ -507,9 +507,7 @@ describe('provenance consistency — export-ready run', () => {
     // complexity caveats join the report warnings (deduped, order kept).
     expect(reportRow(report, 'Terrain Assessment', 'Ruggedness (VRM)')).toBe(cx.vrmText);
     expect(reportRow(report, 'Terrain Assessment', 'Landform (TPI)')).toBe(cx.tpiText);
-    expect(reportRow(report, 'Terrain Assessment', 'Complexity confidence')).toBe(
-      '82/100 (derived from data support)',
-    );
+    expect(reportRow(report, 'Terrain Assessment', 'Complexity window completeness')).toBe('82/100');
     expect(report.warnings).toContain(cx.caveats[0]);
   });
 });

--- a/tests/terrainReportContent.test.ts
+++ b/tests/terrainReportContent.test.ts
@@ -253,7 +253,7 @@ describe('buildTerrainReportContent — section presence + sourcing', () => {
     const ds = withIntel.sections.find((s) => s.title === 'Dataset Statistics')!;
     const row = (label: string): string =>
       ds.rows.find((r) => r.label === label)?.value ?? '(missing)';
-    expect(row('Point density (class)')).toBe('Dense');
+    expect(row('Volumetric point density (all returns, bounding box)')).toBe('Dense');
     expect(row('Terrain complexity')).toBe('Moderate');
     expect(row('Ground visibility')).toBe('Good');
     expect(row('Metric stability')).toBe('82%');
@@ -262,7 +262,7 @@ describe('buildTerrainReportContent — section presence + sourcing', () => {
     const without = buildTerrainReportContent(readyResult(), OPTS);
     const dsWithout = without.sections.find((s) => s.title === 'Dataset Statistics')!;
     const labels = dsWithout.rows.map((r) => r.label);
-    expect(labels).not.toContain('Point density (class)');
+    expect(labels).not.toContain('Volumetric point density (all returns, bounding box)');
     expect(labels).not.toContain('Terrain complexity');
     expect(labels).not.toContain('Ground visibility');
     expect(labels).not.toContain('Metric stability');
@@ -506,8 +506,202 @@ describe('buildTerrainReportContent — §19 permit stamp in provenance', () => 
     it('does not reuse the Ground visibility label for the ground return share', () => {
       const c = buildTerrainReportContent(readyResult(), OPTS);
       const cov = c.sections.find((s) => s.title === 'Coverage Analysis');
-      expect(cov?.rows.some((x) => x.label === 'Ground returns (of all returns)')).toBe(true);
+      expect(
+        cov?.rows.some((x) => x.label === 'Ground share of analysed candidates (after class exclusion)'),
+      ).toBe(true);
       expect(cov?.rows.some((x) => x.label === 'Ground visibility')).toBe(false);
     });
+  });
+});
+
+/**
+ * Every row states the basis it is measured against. Reported from a real
+ * report: "Ground returns (of all returns) 35%" was the SMRF ground share of
+ * the analysed candidate sample AFTER class exclusion; "Measured reliability
+ * 76% (|dz| <= 0.66 m)" used the hold-out RMSE itself as the tolerance;
+ * "Ground visibility —" printed a dash for an unknown bucket; the blocked and
+ * random RMSE sat side by side with no bridging text; "Classification
+ * available Yes" said nothing about whether class 2 built the DTM.
+ */
+describe('buildTerrainReportContent — every row names its basis', () => {
+  const section = (c: TerrainReportContent, title: string) =>
+    c.sections.find((s) => s.title === title)!;
+  const rowValue = (c: TerrainReportContent, title: string, label: string) =>
+    section(c, title).rows.find((r) => r.label === label)?.value;
+  const labels = (c: TerrainReportContent, title: string) =>
+    section(c, title).rows.map((r) => r.label);
+
+  it('#1 names the ground share as the analysed-candidate share after class exclusion', () => {
+    const c = buildTerrainReportContent(readyResult(), OPTS);
+    expect(labels(c, 'Coverage Analysis')).not.toContain('Ground returns (of all returns)');
+    expect(rowValue(c, 'Coverage Analysis', 'Ground share of analysed candidates (after class exclusion)')).toBe('60%');
+  });
+
+  it('#1 prints "class 2 trusted" instead of a meaningless 100% on the trusted path', () => {
+    const base = readyResult();
+    const r = {
+      ...base,
+      generationParams: { ...base.generationParams, despike: false },
+      quality: { ...base.quality, groundPointRatio: 1 },
+    } as AnalyseContoursResult;
+    const c = buildTerrainReportContent(r, OPTS);
+    expect(rowValue(c, 'Coverage Analysis', 'Ground share of analysed candidates (after class exclusion)')).toBe(
+      'class 2 trusted',
+    );
+  });
+
+  it('#2 states that the reliability tolerance IS 1 × the hold-out RMSEz', () => {
+    const base = readyResult();
+    const r = {
+      ...base,
+      reliabilitySplit: {
+        measured: { n: 500, reliability: 0.76, ciLow: 0.75, ciHigh: 0.76, tolerance: 0.66 },
+        interpolated: null,
+      },
+    } as unknown as AnalyseContoursResult;
+    const c = buildTerrainReportContent(r, OPTS);
+    expect(labels(c, 'Quality Metrics')).not.toContain('Measured reliability');
+    expect(rowValue(c, 'Quality Metrics', 'Within 1 × hold-out RMSEz (0.66 m)')).toBe(
+      '76% of measured-cell hold-out residuals (95% CI 75%-76%)',
+    );
+  });
+
+  it('#3 omits an intelligence row whose bucket is unknown instead of printing a dash', () => {
+    const intelligence: DatasetIntelligence = {
+      density: { bucket: 'dense', label: 'Dense', basis: 'areal' },
+      complexity: { bucket: 'unknown', label: '—' },
+      groundVisibility: { bucket: 'unknown', label: '—' },
+      coverage: { bucket: 'full', label: 'Full Dataset' },
+      confidence: { value: 0, band: 'unknown', label: '—' },
+      details: {
+        coverageMode: 'Full Dataset',
+        sourcePointCount: 1,
+        analyzedPointCount: 1,
+        metricVersion: 'v0.4.4',
+        engineStatus: 'idle',
+      },
+    };
+    const c = buildTerrainReportContent(readyResult(), { ...OPTS, intelligence });
+    const ds = labels(c, 'Dataset Statistics');
+    expect(ds).toContain('Areal point density (all returns, header footprint)');
+    expect(ds).not.toContain('Terrain complexity');
+    expect(ds).not.toContain('Ground visibility');
+    expect(ds).not.toContain('Metric stability');
+    expect(section(c, 'Dataset Statistics').rows.some((r) => r.value === '—' && /visibility|stability|complexity/.test(r.label))).toBe(false);
+  });
+
+  it('#4 bridges the random hold-out and the blocked spatial CV with their true parameters', () => {
+    const base = readyResult();
+    const r = {
+      ...base,
+      blockedAccuracy: { n: 4, rmse: 3.87, mae: 2.1, ciLow: 3.5, ciHigh: 4.2 },
+    } as unknown as AnalyseContoursResult;
+    const c = buildTerrainReportContent(r, OPTS);
+    const v = rowValue(c, 'Quality Metrics', 'Accuracy bases') ?? '';
+    expect(v).toMatch(/Random hold-out RMSEz \(0\.14 m\)/);
+    expect(v).toMatch(/interpolation between neighbouring ground points/);
+    expect(v).toMatch(/feeds NVA\/VVA/);
+    expect(v).toMatch(/8-cell blocks, 4 folds/);
+    expect(v).toMatch(/<= 20,000 points/);
+    expect(v).toMatch(/extrapolation across held-out blocks/);
+    expect(v).toMatch(/blocked figure \(3\.87 m\) for map-scale use/);
+  });
+
+  it('#5 names the two density bases apart', () => {
+    const intelligence: DatasetIntelligence = {
+      density: { bucket: 'very-dense', label: 'Very Dense', basis: 'areal' },
+      complexity: { bucket: 'low', label: 'Low' },
+      groundVisibility: { bucket: 'good', label: 'Good' },
+      coverage: { bucket: 'full', label: 'Full Dataset' },
+      confidence: { value: 80, band: 'green', label: '80%' },
+      details: { coverageMode: 'Full Dataset', sourcePointCount: 1, analyzedPointCount: 1, metricVersion: 'v', engineStatus: 'active' },
+    };
+    const c = buildTerrainReportContent(readyResult(), { ...OPTS, intelligence });
+    const ds = labels(c, 'Dataset Statistics');
+    expect(ds).not.toContain('Point density (class)');
+    expect(ds).not.toContain('Ground density');
+    expect(rowValue(c, 'Dataset Statistics', 'Areal point density (all returns, header footprint)')).toBe('Very Dense');
+    expect(rowValue(c, 'Dataset Statistics', 'Ground density (measured cells, stride-scaled)')).toBe('4.2 pts/m²');
+    // The provenance footer names the same figure the same way.
+    expect(c.provenanceLines.some((l) => /^Ground density\s+4\.2 pts\/m²/.test(l))).toBe(true);
+    expect(c.provenanceLines.some((l) => /^Point density\s/.test(l))).toBe(false);
+  });
+
+  it('#6 separates "non-ground classes excluded" from the ground source', () => {
+    const c = buildTerrainReportContent(readyResult(), OPTS);
+    const ds = labels(c, 'Dataset Statistics');
+    expect(ds).not.toContain('Classification available');
+    expect(rowValue(c, 'Dataset Statistics', 'Non-ground classes excluded')).toBe('Yes');
+    expect(rowValue(c, 'Dataset Statistics', 'Ground source')).toBe('SMRF filter (classification not trusted)');
+    const base = readyResult();
+    const trusted = {
+      ...base,
+      excludedByClassification: 0,
+      generationParams: { ...base.generationParams, despike: false },
+    } as AnalyseContoursResult;
+    const t = buildTerrainReportContent(trusted, OPTS);
+    expect(rowValue(t, 'Dataset Statistics', 'Non-ground classes excluded')).toBe('No');
+    expect(rowValue(t, 'Dataset Statistics', 'Ground source')).toBe('ASPRS class 2 (trusted)');
+  });
+
+  it('#7 calls the complexity figure window completeness, not confidence', () => {
+    const base = readyResult();
+    const r = {
+      ...base,
+      complexity: {
+        band: 'moderate', vrmMedian: 0.03, vrmIqr: 0.02, vrmWindowCells: 3, vrmWindowGroundM: 3,
+        vrmText: 'vrm', tpiRadiusCells: 5, tpiRadiusGroundM: 5, tpiDominantClass: 'Flat', tpiText: 'tpi',
+        zUnitLabel: 'm', slopeAspectConvention: 'c', confidence: 99, warnings: [],
+      },
+    } as unknown as AnalyseContoursResult;
+    const c = buildTerrainReportContent(r, OPTS);
+    expect(labels(c, 'Terrain Assessment')).not.toContain('Complexity confidence');
+    expect(rowValue(c, 'Terrain Assessment', 'Complexity window completeness')).toBe('99/100');
+  });
+
+  it('#8 carries the registry evidence level per product, from the export resolver', () => {
+    const c = buildTerrainReportContent(readyResult(), OPTS);
+    const byLabel = Object.fromEntries(c.products.map((p) => [p.label, p.evidence]));
+    // DTM claim: the SAME resolution the provenance stamps.
+    expect(byLabel['DTM/DEM export']).toBe('E4 — Cross-implementation validated (baseline)');
+    expect(c.provenance.evidenceResolution?.effectiveEvidence).toBe('E4_CROSS_IMPLEMENTATION_VALIDATED');
+    expect(byLabel['Contours']).toBe('E4 — Cross-implementation validated (baseline)');
+    expect(byLabel['Map sheet']).toBe('E4 — Cross-implementation validated (baseline)');
+    expect(byLabel['Profiles']).toBe('E4 — Cross-implementation validated (baseline)');
+    expect(byLabel['Measurements']).toBe('no single registered claim');
+    expect(byLabel['Terrain review']).toBe('no single registered claim');
+    const ps = section(c, 'Terrain Products Available');
+    expect(ps.rows.find((r) => r.label === 'Contours')?.value).toBe(
+      'Available · Evidence level: E4 — Cross-implementation validated (baseline)',
+    );
+  });
+
+  it('#9 carries the panel tooltips as Definitions, single-sourced', async () => {
+    const { METRIC_TOOLTIPS } = await import('../src/terrain/contour/contourCopy');
+    const c = buildTerrainReportContent(readyResult(), OPTS);
+    expect(c.definitions).toEqual(Object.values(METRIC_TOOLTIPS));
+  });
+
+  it('#10 calls the cols·cell figure a grid extent', () => {
+    const c = buildTerrainReportContent(readyResult(), OPTS);
+    expect(labels(c, 'Dataset Statistics')).not.toContain('Footprint (extent)');
+    expect(rowValue(c, 'Dataset Statistics', 'Grid extent')).toBe('200 × 150 m');
+  });
+
+  it('#11 qualifies the USGS density reference with its basis', () => {
+    const c = buildTerrainReportContent(readyResult(), OPTS);
+    expect(rowValue(c, 'Quality Metrics', 'USGS density reference')).toBe(
+      '>= QL2 floor (stride-scaled ground density)',
+    );
+  });
+
+  it('#12 prints Coverage mode once and no constant Export note', () => {
+    const c = buildTerrainReportContent(readyResult(), OPTS);
+    const all = c.sections.flatMap((s) => s.rows.filter((r) => r.label === 'Coverage mode'));
+    expect(all).toHaveLength(1);
+    expect(labels(c, 'Terrain Assessment')).not.toContain('Export note');
+    expect(allValues(c)).not.toMatch(/ready to hand off/);
+    const p = buildTerrainReportContent(previewResult(), OPTS);
+    expect(rowValue(p, 'Terrain Assessment', 'Export note')).toMatch(/datum/i);
   });
 });

--- a/tests/terrainReportPdf.test.ts
+++ b/tests/terrainReportPdf.test.ts
@@ -201,3 +201,12 @@ describe('buildTerrainReportPdf — provenance footer stays on the page', () => 
     expect(ops.some((o) => o.page === last && o.text.startsWith('Suitability:'))).toBe(true);
   });
 });
+
+describe('buildTerrainReportPdf — Definitions block', () => {
+  it('prints the panel metric tooltips at the end of the body', async () => {
+    const bytes = await buildTerrainReportPdf(maximalResult(), MAX_OPTS);
+    const ops = await extractTextOps(bytes);
+    expect(ops.some((o) => o.text === 'Definitions')).toBe(true);
+    expect(ops.some((o) => o.text.startsWith('- RMSE'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Terrain Intelligence report rows named quantities other than the ones they printed. Each row now states what it measures; no computed number changes.

- "Ground returns (of all returns)" was SMRF ground over post-exclusion candidates; relabelled, and the trusted path prints "class 2 trusted" instead of a meaningless 100 %.
- "Measured reliability … |dz| ≤ 0.66 m" used the hold-out RMSEz itself as tolerance; now labelled "Within 1 × hold-out RMSEz".
- Rows whose bucket is unknown (ground visibility, metric stability) are omitted rather than printed as dashes.
- New "Accuracy bases" line explains random hold-out vs blocked spatial CV with the run's real parameters.
- Density rows name their basis; "Classification available" becomes "Non-ground classes excluded" plus a "Ground source" row (SMRF or ASPRS class 2).
- "Complexity confidence" → "Complexity window completeness"; "Footprint" → "Grid extent".
- Products print their evidence level from the registry; a Definitions block reuses `METRIC_TOOLTIPS`.

Tests: `terrainReportContent` +13, `terrainReportPdf` +1.
