### PR TITLE
fix(qa): state what each fitness row was graded on and lead with the actual limiter

### DIFF
--- a/src/terrain/contour/terrainAssessment.ts
+++ b/src/terrain/contour/terrainAssessment.ts
@@ -111,6 +111,15 @@ export interface TerrainAssessment {
   readonly notRecommendedFor: string;
   /** Real values behind the verdict, each with a plain label + rating. */
   readonly supportingMetrics: ReadonlyArray<SupportingMetric>;
+  /**
+   * The ACTUAL causes of a below-Good surface verdict, in the order they are
+   * applied: the surface caps that fired (each quoting its figure — the same
+   * strings `reason` joins) followed by any supporting metric rated 'poor' that
+   * no cap already names (DTM quality, vertical RMSE — the two that feed the
+   * Limited rule without a cap of their own). Empty for Good and Blocked.
+   * Disclosure only: nothing here changes a status.
+   */
+  readonly limiters?: ReadonlyArray<string>;
 }
 
 /** Status ordering for capping (Good is best). */
@@ -319,6 +328,7 @@ export function terrainAssessment(result: AnalyseContoursResult): TerrainAssessm
   // ── reason (one plain line) ───────────────────────────────────────────
   const gateReason = q.reasons?.find((r) => r && r.trim().length > 0);
   let reason: string;
+  const limiters: string[] = [];
   if (status === 'Blocked') {
     reason = noUsableDtm
       ? 'No usable bare-earth surface — too little measured ground to contour.'
@@ -342,6 +352,14 @@ export function terrainAssessment(result: AnalyseContoursResult): TerrainAssessm
     // description.
     if (edgeFrac > HIGH_EDGE_FRACTION) caps.push(`${pctStr(edgeFrac)} of measured cells lie within a few cells of the data boundary, where neighbour support is thinnest`);
     if (density < LOW_DENSITY_PER_M2) caps.push('ground returns are sparse');
+    // Every cap above has a matching 'poor' chip; only these two poor chips
+    // have no cap of their own, yet count toward the Limited rule.
+    limiters.push(...caps);
+    for (const m of supportingMetrics) {
+      if (m.rating !== 'poor') continue;
+      if (m.label === 'DTM quality') limiters.push(`DTM quality ${m.value} is rated poor`);
+      else if (m.label === 'Vertical RMSE') limiters.push(`vertical RMSE ${m.value} is rated poor`);
+    }
     if (coverageMode === 'resident-only') {
       // PARTIAL STREAM: lead with the honest "only part has loaded" framing, not
       // the sparse interpolation / edge figures (which are streaming artefacts
@@ -427,6 +445,7 @@ export function terrainAssessment(result: AnalyseContoursResult): TerrainAssessm
     useCaution,
     notRecommendedFor,
     supportingMetrics,
+    limiters,
   };
 }
 

--- a/src/terrain/contour/terrainProducts.ts
+++ b/src/terrain/contour/terrainProducts.ts
@@ -31,8 +31,16 @@ import {
   type ReadinessTier,
 } from '../quality/readinessEngine';
 
-/** The product-status word — the deliverable vocabulary, not the grade one. */
+/**
+ * The product-status word — the deliverable vocabulary for deliverable rows;
+ * inspection rows on a Limited surface carry the hero's own word ('Limited')
+ * so the list never says "Preview" under a "Limited" headline. Same grade
+ * underneath (caution) — only the word differs.
+ */
 export type ProductStatusWord = ReadinessTier;
+
+/** The word the on-screen row prints: the status word, or 'Limited' (see `displayWord`). */
+export type ProductDisplayWord = ReadinessTier | 'Limited';
 
 /** One row of the Terrain Products list. */
 export interface TerrainProduct {
@@ -42,6 +50,18 @@ export interface TerrainProduct {
   readonly status: 'ready' | 'preview' | 'blocked';
   /** The textual verdict — carried as TEXT so the row is never colour-only. */
   readonly statusWord: ProductStatusWord;
+  /**
+   * The word the row RENDERS. Equal to `statusWord` except for inspection rows
+   * on a Limited surface, which print 'Limited' (the hero's word) instead of
+   * the export-axis 'Preview'. Same grade underneath; only the word differs.
+   */
+  readonly displayWord?: ProductDisplayWord;
+  /**
+   * Which of the TWO grades this row carries: the inspection grade (surface
+   * quality) or the deliverable grade (export readiness). Six rows, two
+   * grades — the view groups on this so six rows never imply six assessments.
+   */
+  readonly productClass?: 'inspection' | 'deliverable';
   /** ✓ / ⚠ / ✕, decorative beside the status word. */
   readonly glyph: '✓' | '⚠' | '✕';
   /**
@@ -101,9 +121,12 @@ export function terrainProducts(
   workflows: ReadonlyArray<WorkflowItem>,
 ): TerrainProduct[] {
   return workflows.map((w) => {
+    const productClass: TerrainProduct['productClass'] = DELIVERABLE_LABELS.has(w.label)
+      ? 'deliverable'
+      : 'inspection';
     const reason = productReasonFor({
       status: w.status,
-      productClass: DELIVERABLE_LABELS.has(w.label) ? 'deliverable' : 'inspection',
+      productClass,
       surfaceTier: assessment.status,
       surfaceReason: assessment.reason,
       exportReason: assessment.exportReason,
@@ -112,7 +135,14 @@ export function terrainProducts(
     return {
       label: PRODUCT_LABEL[w.label] ?? w.label,
       status: STATUS_KEY[w.status],
+      productClass,
       statusWord: statusWordFor(w.status),
+      // Inspection rows are graded off the surface tier; when that tier is
+      // Limited, print Limited (the hero's word), not the export-axis "Preview".
+      displayWord:
+        productClass === 'inspection' && w.status === 'caution' && assessment.status === 'Limited'
+          ? 'Limited'
+          : statusWordFor(w.status),
       glyph: glyphFor(w.status),
       ...(reason != null ? { reason } : {}),
     };

--- a/src/terrain/quality/scanFitness.ts
+++ b/src/terrain/quality/scanFitness.ts
@@ -95,6 +95,40 @@ export interface FitnessInputs {
    * density.
    */
   readonly densityReferenceFloor?: string | null;
+  /**
+   * What the grade actually ran on. `coverageMode` stays the surface-coverage
+   * verdict (it feeds the assessment's Preview cap and must not move); this is
+   * the separate, disclosed BASIS: a strided sample of the loaded cloud is not
+   * "the full cloud" even when the grid coverage reads 'full'. Optional —
+   * absent keeps the legacy coverageMode-only wording.
+   */
+  readonly gradedBasis?: {
+    /** True when the analysis strided the loaded cloud down to a sample. */
+    readonly sampled: boolean;
+    /** Points the grade ran on (the strided sample), or null when unknown. */
+    readonly gradedPointCount: number | null;
+    /** Ground returns the DTM actually analysed, when the sample size is unknown. */
+    readonly analysedGroundCount?: number | null;
+    /** Points resident in the viewer for this scan, when known. */
+    readonly residentPointCount?: number | null;
+  };
+  /**
+   * Mean analysed ground returns per MEASURED cell (unscaled counts). Below
+   * `REGULARITY_MIN_COUNTS` the per-cell counts are integer-quantised at a
+   * handful per cell and the median/mean readout carries no regularity
+   * information, so it is withheld (the hint says why). Optional — absent
+   * keeps the readout.
+   */
+  readonly meanCountsPerMeasuredCell?: number | null;
+  /**
+   * The assessment's OWN cause list for its verdict (`TerrainAssessment.
+   * limiters`) — the caps and poor-rated metrics that actually produced the
+   * status word. When present and non-empty the verdict's lead clause and its
+   * "+N more" count come from here, so the sentence names what capped the
+   * verdict rather than the highest-priority reviewed scorecard row. Absent or
+   * empty ⇒ the scorecard-priority fallback.
+   */
+  readonly assessmentLimiters?: ReadonlyArray<string>;
 }
 
 /** One traffic-light row in the scorecard. */
@@ -104,6 +138,11 @@ export interface FitnessDimension {
   readonly tone: FitnessTone;
   /** One-line plain-language summary with a benchmark where possible. */
   readonly summary: string;
+  /**
+   * Longer disclosure for the row's tooltip (basis, denominator, why a readout
+   * is withheld). Absent ⇒ the summary is the hint.
+   */
+  readonly hint?: string;
 }
 
 /** The full verdict-led fitness model the panel renders. */
@@ -146,12 +185,32 @@ const worst = (a: FitnessTone, b: FitnessTone): FitnessTone => (SEVERITY[a] >= S
  */
 const QL2_DENSITY = 2;
 const QL1_DENSITY = 8;
+/**
+ * Scorecard TONE bands — the SAME bands the assessment's supporting-metric
+ * chips use (terrainAssessment: bandHigh(density, 2, 1.0) and bandLow(rmse,
+ * 0.1, 0.25)), so one number never carries two tones across the panel. The
+ * chip bands feed the assessment's Limited rule and stay where they are; these
+ * mirror them.
+ */
+const DENSITY_READY = QL2_DENSITY;
+const DENSITY_OKAY = 1.0;
 /** Coverage fractions where the measured surface is trustworthy vs sparse. */
 const COVERAGE_READY = 0.8;
 const COVERAGE_OKAY = 0.5;
 /** Vertical RMSE thresholds (metres-equivalent) for ready/okay. */
 const RMSE_READY = 0.1;
-const RMSE_OKAY = 0.3;
+const RMSE_OKAY = 0.25;
+/**
+ * The density-reference badge's own gates — unchanged from before the tone
+ * bands were aligned to the chips (density ≥ QL2, RMSE ≤ 0.3 m), so aligning
+ * the row tones neither earns nor loses a badge.
+ */
+const BADGE_DENSITY_MIN = QL2_DENSITY;
+const BADGE_RMSE_MAX = 0.3;
+/** Mean analysed returns per measured cell below which median/mean is withheld. */
+const REGULARITY_MIN_COUNTS = 10;
+/** Disclosed on every density row: ground returns are not pulses. */
+const DENSITY_BASIS_NOTE = 'Ground returns only; the USGS figure counts pulses of all classes.';
 /** Unclassified fraction below which the cloud is well classified. */
 const UNCLASSIFIED_OKAY = 0.1;
 /**
@@ -166,6 +225,11 @@ const UNVERIFIED_UNIT_CAVEAT =
 
 function pct(frac: number): number {
   return Math.round(frac * 100);
+}
+
+/** Thousands-grouped integer (locale-independent, so tests and exports agree). */
+function fmtInt(n: number): string {
+  return Math.round(n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
 function georefDimension(inp: FitnessInputs): FitnessDimension {
@@ -185,9 +249,11 @@ function coverageDimension(f: number | null): FitnessDimension {
   else tone = 'review';
   const measured = pct(f);
   let summary: string;
-  if (tone === 'ready') summary = `${measured}% of the surface is measured ground — well covered.`;
-  else if (tone === 'okay') summary = `${measured}% measured; the rest is interpolated between gaps.`;
-  else summary = `Only ${measured}% is measured ground — ${100 - measured}% is interpolated, so the surface is mostly inferred.`;
+  // Denominator disclosed: the fraction is of COVERED cells (measured +
+  // interpolated), not of the whole grid — empty cells are outside it.
+  if (tone === 'ready') summary = `${measured}% of covered cells are measured ground — well covered.`;
+  else if (tone === 'okay') summary = `${measured}% of covered cells measured; the rest is interpolated between gaps.`;
+  else summary = `Only ${measured}% of covered cells is measured ground — ${100 - measured}% is interpolated, so the surface is mostly inferred.`;
   return { key: 'coverage', label: 'Coverage', tone, summary };
 }
 
@@ -208,7 +274,12 @@ function densityRegularity(mean: number, median: number | null | undefined): str
   return ` Median ${densityRound(median)} ground pts/m² (median/mean ${ratio.toFixed(2)}).`;
 }
 
-function densityDimension(d: number | null, median: number | null | undefined, unitKnown: boolean): FitnessDimension {
+function densityDimension(
+  d: number | null,
+  median: number | null | undefined,
+  unitKnown: boolean,
+  meanCounts: number | null | undefined,
+): FitnessDimension {
   if (d == null) return { key: 'density', label: 'Ground detail', tone: 'review', summary: 'Ground density unknown.' };
   // Fail closed on an unverified scale: a pts/m² figure derived off an inert
   // placeholder factor is not assertable, so hold the metric verdict rather than
@@ -222,20 +293,33 @@ function densityDimension(d: number | null, median: number | null | undefined, u
     };
   }
   let tone: FitnessTone;
-  if (d >= QL1_DENSITY) tone = 'ready';
-  else if (d >= QL2_DENSITY) tone = 'okay';
+  if (d >= DENSITY_READY) tone = 'ready';
+  else if (d >= DENSITY_OKAY) tone = 'okay';
   else tone = 'review';
   const v = densityRound(d);
   // "reference" (not "floor met"/"quality level") — this is ground-return
   // density measured against a pulse-density figure, not a QL determination.
   let summary: string;
-  if (tone === 'ready') summary = `${v} ground pts/m² — clears the ${QL1_DENSITY} pts/m² QL1 pulse-density reference.`;
-  else if (tone === 'okay') summary = `${v} ground pts/m² — clears the ${QL2_DENSITY} pts/m² QL2 pulse-density reference.`;
-  else summary = `${v} ground pts/m² — below the ${QL2_DENSITY} pts/m² QL2 pulse-density reference.`;
+  if (d >= QL1_DENSITY) summary = `${v} ground pts/m² — clears the ${QL1_DENSITY} pts/m² QL1 pulse-density reference.`;
+  else if (tone === 'ready') summary = `${v} ground pts/m² — clears the ${QL2_DENSITY} pts/m² QL2 pulse-density reference.`;
+  else if (tone === 'okay') summary = `${v} ground pts/m² — below the ${QL2_DENSITY} pts/m² QL2 pulse-density reference.`;
+  else summary = `${v} ground pts/m² — below the ${QL2_DENSITY} pts/m² QL2 pulse-density reference; sparse ground.`;
   // Median vs mean, when the median is supplied — a regularity signal only; the
-  // tone above still buckets on the mean.
-  summary += densityRegularity(d, median);
-  return { key: 'density', label: 'Ground detail', tone, summary };
+  // tone above still buckets on the mean. Withheld when the per-cell counts are
+  // too few to carry regularity information (integer-quantised at a handful of
+  // returns per cell); the hint says so.
+  let hint = `${summary} ${DENSITY_BASIS_NOTE}`;
+  const tooFewCounts =
+    meanCounts != null && Number.isFinite(meanCounts) && meanCounts < REGULARITY_MIN_COUNTS;
+  if (tooFewCounts) {
+    if (median != null && Number.isFinite(median)) {
+      hint += ` Median/mean not shown: about ${Math.round(meanCounts as number)} returns per measured cell, too few for the per-cell counts to carry regularity information.`;
+    }
+  } else {
+    summary += densityRegularity(d, median);
+    hint = `${summary} ${DENSITY_BASIS_NOTE}`;
+  }
+  return { key: 'density', label: 'Ground detail', tone, summary, hint };
 }
 
 function accuracyDimension(rmse: number | null, unit: string, unitToMetres: number, unitKnown: boolean): FitnessDimension {
@@ -260,11 +344,13 @@ function accuracyDimension(rmse: number | null, unit: string, unitToMetres: numb
   if (rmseM <= RMSE_READY) tone = 'ready';
   else if (rmseM <= RMSE_OKAY) tone = 'okay';
   else tone = 'review';
-  const v = `±${rmse.toFixed(2)} ${unit}`;
+  // An RMSE is a dispersion statistic, not a symmetric "±" bound — print it as
+  // what it is, and name the basis (internal hold-out, not checkpoints).
+  const v = `RMSE ${rmse.toFixed(2)} ${unit} (internal hold-out)`;
   let summary: string;
-  if (tone === 'ready') summary = `${v} vertical (held-out check) — tight.`;
-  else if (tone === 'okay') summary = `${v} vertical (held-out check) — moderate.`;
-  else summary = `${v} vertical (held-out check) — loose.`;
+  if (tone === 'ready') summary = `${v} — tight.`;
+  else if (tone === 'okay') summary = `${v} — moderate.`;
+  else summary = `${v} — loose.`;
   return { key: 'accuracy', label: 'Vertical accuracy', tone, summary };
 }
 
@@ -297,6 +383,28 @@ function integrityDimension(inp: FitnessInputs): FitnessDimension {
     const mode = inp.coverageMode === 'resident-only' ? 'the streamed-in part' : 'a sample';
     return { key: 'integrity', label: 'Integrity', tone: 'okay', summary: `Graded on ${mode} of the cloud, not the whole dataset.` };
   }
+  // A 'full' coverage mode says the grid spans the extent; it does not say every
+  // point was graded. When the analysis strided the loaded cloud, say so — with
+  // the sample size and, when known, how much of the cloud is resident.
+  const basis = inp.gradedBasis;
+  if (basis?.sampled) {
+    const n = basis.gradedPointCount;
+    const size = n != null && Number.isFinite(n) ? `a ${fmtInt(n)}-point sample` : 'a sample';
+    const ground =
+      n == null && basis.analysedGroundCount != null && Number.isFinite(basis.analysedGroundCount)
+        ? `: ${fmtInt(basis.analysedGroundCount)} ground returns analysed`
+        : '';
+    const resident =
+      basis.residentPointCount != null && Number.isFinite(basis.residentPointCount)
+        ? ` (${fmtInt(basis.residentPointCount)} points resident)`
+        : '';
+    return {
+      key: 'integrity',
+      label: 'Integrity',
+      tone: 'okay',
+      summary: `Graded on ${size} of the loaded cloud${ground}${resident}.`,
+    };
+  }
   return { key: 'integrity', label: 'Integrity', tone: 'ready', summary: 'Graded on the full cloud.' };
 }
 
@@ -326,7 +434,7 @@ export function buildScanFitness(inp: FitnessInputs): ScanFitness {
   const dimensions: FitnessDimension[] = [
     georefDimension(inp),
     coverageDimension(inp.measuredFraction),
-    densityDimension(inp.groundDensityPerM2, inp.medianGroundDensityPerM2, unitKnown),
+    densityDimension(inp.groundDensityPerM2, inp.medianGroundDensityPerM2, unitKnown, inp.meanCountsPerMeasuredCell),
     accuracyDimension(inp.verticalRmse, unit, unitToMetres, unitKnown),
     classificationDimension(inp.unclassifiedFraction, inp.hasGroundClass),
     integrityDimension(inp),
@@ -354,16 +462,28 @@ export function buildScanFitness(inp: FitnessInputs): ScanFitness {
   // The verdict's LEAD WORD mirrors the authoritative fitness tier (the gate's
   // status) so it never disagrees with the hero verdict — a 'Limited' scan must
   // not read as "Preview only". The clause then names the biggest limitation.
+  // The assessment's own cause list wins when it has one: those are the caps
+  // and poor-rated metrics that actually produced the status word, so the
+  // clause names the real limiter (and "+N more" counts the real causes). The
+  // scorecard-priority pick is the fallback only.
+  const causes = (inp.assessmentLimiters ?? []).filter((c) => c.trim().length > 0);
+  const leadCause = causes[0];
   const lead = reviews[0];
-  const more = reviews.length > 1 ? ` (+${reviews.length - 1} more to review)` : '';
-  const limiterClause = lead ? ` — ${limiterPhrase[lead.key]}${more}` : '';
+  let limiterClause: string;
+  if (leadCause) {
+    const more = causes.length > 1 ? ` (+${causes.length - 1} more to review)` : '';
+    limiterClause = ` — ${leadCause}${more}`;
+  } else {
+    const more = reviews.length > 1 ? ` (+${reviews.length - 1} more to review)` : '';
+    limiterClause = lead ? ` — ${limiterPhrase[lead.key]}${more}` : '';
+  }
   let verdict: string;
   if (inp.status === 'Blocked') {
     verdict = 'Not usable for terrain products as-is.';
   } else if (inp.status === 'Limited') {
-    verdict = lead ? `Limited${limiterClause}.` : 'Limited — not export-ready as-is.';
+    verdict = limiterClause ? `Limited${limiterClause}.` : 'Limited — not export-ready as-is.';
   } else if (inp.status === 'Preview') {
-    verdict = lead ? `Preview only${limiterClause}.` : 'Preview — re-run on the full cloud for a settled grade.';
+    verdict = limiterClause ? `Preview only${limiterClause}.` : 'Preview — re-run on the full cloud for a settled grade.';
   } else if (reviews.length === 0) {
     verdict = 'Ready for terrain products — coverage, density and accuracy all pass.';
   } else {
@@ -381,10 +501,14 @@ export function buildScanFitness(inp: FitnessInputs): ScanFitness {
   // partial/streaming sample would misrepresent the density. It names the 3DEP
   // pulse-density FLOOR the ground-return density clears as a REFERENCE, never a
   // quality-level grade (ground-return density is not a pulse determination).
-  const densTone = dimensions.find((d) => d.key === 'density')!.tone;
-  const accTone = dimensions.find((d) => d.key === 'accuracy')!.tone;
+  // Gated on the badge's OWN thresholds (not the row tones, which mirror the
+  // assessment chips) so the badge is earned exactly where it was before.
+  const badgeDensityOk =
+    unitKnown && inp.groundDensityPerM2 != null && inp.groundDensityPerM2 >= BADGE_DENSITY_MIN;
+  const badgeAccuracyOk =
+    unitKnown && inp.verticalRmse != null && inp.verticalRmse * unitToMetres <= BADGE_RMSE_MAX;
   const tierBadge =
-    inp.densityReferenceFloor && !provisional && densTone !== 'review' && accTone !== 'review' && inp.crsKnown
+    inp.densityReferenceFloor && !provisional && badgeDensityOk && badgeAccuracyOk && inp.crsKnown
       ? `≥ ${inp.densityReferenceFloor} density reference`
       : null;
 

--- a/src/ui/AnalysePanel.ts
+++ b/src/ui/AnalysePanel.ts
@@ -3177,6 +3177,20 @@ export class AnalysePanel {
     // assumption instead of stamping a bare "pts/m²" / "m".
     const fitLinearUnit = this._cb.getMapContext?.()?.linearUnit;
     const unitKnown = fitLinearUnit != null && fitLinearUnit !== 'unknown';
+    // What the grade ran on. The grid's coverageMode reads 'full' whenever the
+    // grid spans the extent, but the gather strides a large cloud down to a
+    // sample first; the core records that stride as its density-scaling
+    // warning, and the ground filter's analysed count (+ the returns it
+    // excluded by class) is the size of that sample.
+    const strided = r.warnings.some((w) => w.includes('uniform-stride assumption'));
+    const scanId = this._cb.getActiveScanId?.() ?? null;
+    const residentPointCount = scanId ? (this._cb.getFeatureCloud?.(scanId)?.pointCount ?? null) : null;
+    // Mean analysed returns per MEASURED cell, from the grid's own per-cell
+    // counts (unscaled). Gates the median/mean regularity readout.
+    let countSum = 0;
+    for (let i = 0; i < r.dtm.counts.length; i++) if (r.dtm.coverage[i] === 2) countSum += r.dtm.counts[i];
+    const meanCountsPerMeasuredCell =
+      r.cellMetrics.measuredCellCount > 0 ? countSum / r.cellMetrics.measuredCellCount : null;
     const inputs: FitnessInputs = {
       status: a.status,
       score: a.scoreKnown ? a.score : null,
@@ -3200,6 +3214,16 @@ export class AnalysePanel {
       hasGroundClass: hasClass,
       coverageMode: r.dtm.coverageMode,
       densityReferenceFloor: densityFloor,
+      // The result does not carry the strided sample size itself, so the row
+      // states the ground returns the DTM analysed and the resident count.
+      gradedBasis: {
+        sampled: strided,
+        gradedPointCount: null,
+        analysedGroundCount: r.dtm.analyzedPointCount,
+        residentPointCount,
+      },
+      meanCountsPerMeasuredCell,
+      assessmentLimiters: a.limiters,
     };
     const f = buildScanFitness(inputs);
 
@@ -3221,7 +3245,7 @@ export class AnalysePanel {
         tone,
         el('span', { className: 'olv-fit-sum', text: d.summary }),
       );
-      this._hint(row, d.summary);
+      this._hint(row, d.hint ?? d.summary);
       grid.append(row);
     }
     this._fitnessRow.append(grid);

--- a/src/ui/workflowCardRender.ts
+++ b/src/ui/workflowCardRender.ts
@@ -81,6 +81,29 @@ export function renderTerrainProducts(
 ): HTMLElement {
   const card = el('div', { className: 'olv-analyse-products' });
   card.append(el('div', { className: 'olv-analyse-products-head', text: 'Terrain products' }));
+  // Six rows carry TWO grades (inspection / deliverable). When the rows say
+  // which, group them under a heading that says the grade is shared, so six
+  // rows never read as six assessments. Rows without a class render as one
+  // flat list (legacy callers).
+  const classed = products.some((p) => p.productClass != null);
+  if (classed) {
+    const groups: Array<[TerrainProduct['productClass'], string]> = [
+      ['inspection', 'Inspection products — one shared grade'],
+      ['deliverable', 'Deliverable products — one shared grade'],
+    ];
+    for (const [cls, heading] of groups) {
+      const rows = products.filter((p) => p.productClass === cls);
+      if (rows.length === 0) continue;
+      card.append(el('div', { className: 'olv-analyse-why-subhead olv-analyse-products-group-head', text: heading }));
+      card.append(productList(rows, sharedReason));
+    }
+    return card;
+  }
+  card.append(productList(products, sharedReason));
+  return card;
+}
+
+function productList(products: ReadonlyArray<TerrainProduct>, sharedReason?: string): HTMLElement {
   const list = el('ul', { className: 'olv-analyse-products-list' });
   for (const p of products) {
     const row = el('li', { className: `olv-analyse-product is-${p.status}` });
@@ -90,7 +113,7 @@ export function renderTerrainProducts(
     head.append(
       glyph,
       el('span', { className: 'olv-analyse-product-label', text: p.label }),
-      el('span', { className: 'olv-analyse-product-status', text: p.statusWord }),
+      el('span', { className: 'olv-analyse-product-status', text: p.displayWord ?? p.statusWord }),
     );
     row.append(head);
     // De-dup: when a product is held back by the SAME surface reason already
@@ -108,8 +131,7 @@ export function renderTerrainProducts(
     }
     list.append(row);
   }
-  card.append(list);
-  return card;
+  return list;
 }
 
 /**

--- a/tests/scanFitness.test.ts
+++ b/tests/scanFitness.test.ts
@@ -52,7 +52,9 @@ describe('buildScanFitness — scorecard tones', () => {
 
   it('density buckets at the USGS QL floors (2 and 8 pts/m²)', () => {
     expect(tone(buildScanFitness(base({ groundDensityPerM2: 9 })), 'density')).toBe('ready');
-    expect(tone(buildScanFitness(base({ groundDensityPerM2: 3 })), 'density')).toBe('okay');
+    // 3 pts/m² clears the QL2 reference: 'ready', the same band the assessment chip gives it.
+    expect(tone(buildScanFitness(base({ groundDensityPerM2: 3 })), 'density')).toBe('ready');
+    expect(tone(buildScanFitness(base({ groundDensityPerM2: 1.3 })), 'density')).toBe('okay');
     expect(tone(buildScanFitness(base({ groundDensityPerM2: 0.9 })), 'density')).toBe('review');
   });
 

--- a/tests/scanFitnessStatedBases.test.ts
+++ b/tests/scanFitnessStatedBases.test.ts
@@ -1,0 +1,142 @@
+/**
+ * scanFitnessStatedBases.test.ts — each fitness row states what it was graded
+ * on, the verdict leads with the assessment's actual limiter, and the
+ * scorecard tones share the assessment chip bands.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildScanFitness, type FitnessInputs, type FitnessKey } from '../src/terrain/quality/scanFitness';
+
+function base(over: Partial<FitnessInputs> = {}): FitnessInputs {
+  return {
+    status: 'Good',
+    score: 88,
+    crsKnown: true,
+    datumKnown: true,
+    crsName: 'WGS 84 / UTM zone 12N',
+    datumName: 'NAVD88',
+    measuredFraction: 0.9,
+    groundDensityPerM2: 12,
+    verticalRmse: 0.07,
+    notSurveyGrade: false,
+    unit: 'm',
+    unitToMetres: 1,
+    unclassifiedFraction: 0.02,
+    hasGroundClass: true,
+    coverageMode: 'full',
+    densityReferenceFloor: 'QL1',
+    ...over,
+  };
+}
+const dim = (f: ReturnType<typeof buildScanFitness>, key: FitnessKey) => f.dimensions.find((d) => d.key === key)!;
+
+describe('integrity row states the graded basis', () => {
+  it('a strided sample never reads "full cloud"', () => {
+    const f = buildScanFitness(base({
+      gradedBasis: { sampled: true, gradedPointCount: 300_000, residentPointCount: 2_880_236 },
+    }));
+    const d = dim(f, 'integrity');
+    expect(d.tone).toBe('okay');
+    expect(d.summary).toBe('Graded on a 300,000-point sample of the loaded cloud (2,880,236 points resident).');
+    expect(d.summary).not.toMatch(/full cloud/i);
+    // A sample of the loaded cloud is not a streaming/partial coverage mode: no
+    // "still streaming" prefix and no status change.
+    expect(f.provisional).toBe(false);
+  });
+  it('without a resident count the sample sentence stands alone', () => {
+    const d = dim(buildScanFitness(base({ gradedBasis: { sampled: true, gradedPointCount: 1234 } })), 'integrity');
+    expect(d.summary).toBe('Graded on a 1,234-point sample of the loaded cloud.');
+  });
+  it('an unknown sample size states the analysed ground returns instead', () => {
+    const d = dim(buildScanFitness(base({
+      gradedBasis: { sampled: true, gradedPointCount: null, analysedGroundCount: 210_433, residentPointCount: 2_880_236 },
+    })), 'integrity');
+    expect(d.summary).toBe('Graded on a sample of the loaded cloud: 210,433 ground returns analysed (2,880,236 points resident).');
+  });
+  it('every source point graded keeps the full-cloud string', () => {
+    const d = dim(buildScanFitness(base({ gradedBasis: { sampled: false, gradedPointCount: 500 } })), 'integrity');
+    expect(d.tone).toBe('ready');
+    expect(d.summary).toBe('Graded on the full cloud.');
+  });
+  it('legacy callers (no basis) are unchanged', () => {
+    expect(dim(buildScanFitness(base()), 'integrity').summary).toBe('Graded on the full cloud.');
+  });
+});
+
+describe('verdict leads with the assessment limiter', () => {
+  it('uses the assessment cause list ahead of the scorecard priority order', () => {
+    const f = buildScanFitness(base({
+      status: 'Limited',
+      groundDensityPerM2: 1.3,
+      verticalRmse: 0.66,
+      assessmentLimiters: [
+        '79% of measured cells sit at the edge of the data, where the surface is least supported',
+        'vertical RMSE 0.66 m is rated poor',
+      ],
+    }));
+    expect(f.verdict).toBe(
+      'Limited — 79% of measured cells sit at the edge of the data, where the surface is least supported (+1 more to review).',
+    );
+  });
+  it('falls back to the scorecard order when the assessment names no cause', () => {
+    const f = buildScanFitness(base({ status: 'Limited', measuredFraction: 0.3, assessmentLimiters: [] }));
+    expect(f.verdict).toMatch(/ground coverage is sparse/);
+  });
+  it('"+N more" counts the assessment causes, not the scorecard rows', () => {
+    const f = buildScanFitness(base({ status: 'Preview', groundDensityPerM2: 0.5, assessmentLimiters: ['ground returns are sparse'] }));
+    expect(f.verdict).toBe('Preview only — ground returns are sparse.');
+  });
+});
+
+describe('scorecard tones share the assessment chip bands', () => {
+  it('density: ready ≥ 2, okay ≥ 1, review < 1 (the chip bandHigh(2, 1))', () => {
+    expect(dim(buildScanFitness(base({ groundDensityPerM2: 3 })), 'density').tone).toBe('ready');
+    expect(dim(buildScanFitness(base({ groundDensityPerM2: 1.3 })), 'density').tone).toBe('okay');
+    expect(dim(buildScanFitness(base({ groundDensityPerM2: 0.9 })), 'density').tone).toBe('review');
+  });
+  it('accuracy: ready ≤ 0.10, okay ≤ 0.25, review > 0.25 (the chip bandLow(0.1, 0.25))', () => {
+    expect(dim(buildScanFitness(base({ verticalRmse: 0.1 })), 'accuracy').tone).toBe('ready');
+    expect(dim(buildScanFitness(base({ verticalRmse: 0.25 })), 'accuracy').tone).toBe('okay');
+    expect(dim(buildScanFitness(base({ verticalRmse: 0.28 })), 'accuracy').tone).toBe('review');
+  });
+  it('the density badge still needs the old ≥ 2 pts/m² and ≤ 0.3 m gates', () => {
+    expect(buildScanFitness(base({ groundDensityPerM2: 1.5, densityReferenceFloor: 'QL3' })).tierBadge).toBeNull();
+    expect(buildScanFitness(base({ verticalRmse: 0.31 })).tierBadge).toBeNull();
+    expect(buildScanFitness(base({ verticalRmse: 0.3 })).tierBadge).toBe('≥ QL1 density reference');
+  });
+});
+
+describe('density row discloses the returns-vs-pulses basis', () => {
+  it('names ground returns vs pulses of all classes in the hint', () => {
+    const d = dim(buildScanFitness(base({ groundDensityPerM2: 1.3 })), 'density');
+    expect(d.summary).toBe('1.3 ground pts/m² — below the 2 pts/m² QL2 pulse-density reference.');
+    expect(d.hint).toMatch(/Ground returns only; the USGS figure counts pulses of all classes/);
+  });
+});
+
+describe('median/mean readout needs enough returns per cell', () => {
+  it('suppresses the readout under 10 returns per measured cell and says why', () => {
+    const d = dim(buildScanFitness(base({ groundDensityPerM2: 1.3, medianGroundDensityPerM2: 1.3, meanCountsPerMeasuredCell: 2.1 })), 'density');
+    expect(d.summary).not.toMatch(/median\/mean/);
+    expect(d.hint).toMatch(/about 2 returns per measured cell/);
+    expect(d.hint).toMatch(/Median\/mean not shown/);
+  });
+  it('keeps the readout at 10 or more returns per cell', () => {
+    const d = dim(buildScanFitness(base({ groundDensityPerM2: 12, medianGroundDensityPerM2: 11, meanCountsPerMeasuredCell: 12 })), 'density');
+    expect(d.summary).toMatch(/median\/mean 0\.92/);
+  });
+});
+
+describe('accuracy and coverage wording', () => {
+  it('an RMSE is not printed as a ± bound', () => {
+    const d = dim(buildScanFitness(base({ verticalRmse: 0.66 })), 'accuracy');
+    expect(d.summary).toBe('RMSE 0.66 m (internal hold-out) — loose.');
+    expect(dim(buildScanFitness(base({ verticalRmse: 0.07 })), 'accuracy').summary).toBe('RMSE 0.07 m (internal hold-out) — tight.');
+  });
+  it('coverage names its denominator', () => {
+    expect(dim(buildScanFitness(base({ measuredFraction: 0.76 })), 'coverage').summary).toBe(
+      '76% of covered cells measured; the rest is interpolated between gaps.',
+    );
+    expect(dim(buildScanFitness(base({ measuredFraction: 0.9 })), 'coverage').summary).toMatch(/of covered cells/);
+    expect(dim(buildScanFitness(base({ measuredFraction: 0.3 })), 'coverage').summary).toMatch(/of covered cells/);
+  });
+});

--- a/tests/scanFitnessStatedBases.test.ts
+++ b/tests/scanFitnessStatedBases.test.ts
@@ -73,9 +73,10 @@ describe('verdict leads with the assessment limiter', () => {
         'vertical RMSE 0.66 m is rated poor',
       ],
     }));
-    expect(f.verdict).toBe(
-      'Limited — 79% of measured cells sit at the edge of the data, where the surface is least supported (+1 more to review).',
-    );
+    // The lead clause is whatever sentence the assessment produced for the
+    // cap; its exact prose belongs to terrainAssessment, so match the clause
+    // identity and the tail, not the wording.
+    expect(f.verdict).toMatch(/^Limited — 79% of measured cells .*\(\+1 more to review\)\.$/);
   });
   it('falls back to the scorecard order when the assessment names no cause', () => {
     const f = buildScanFitness(base({ status: 'Limited', measuredFraction: 0.3, assessmentLimiters: [] }));

--- a/tests/terrainAssessment.test.ts
+++ b/tests/terrainAssessment.test.ts
@@ -497,3 +497,26 @@ describe('terrainAssessment', () => {
     expect(a.status).toBe('Good');
   });
 });
+
+describe('terrainAssessment — limiters name the actual causes of the verdict', () => {
+  it('a Limited surface driven by two poor metrics lists the boundary cap and the poor RMSE, not density', () => {
+    const a = terrainAssessment(
+      fixture({
+        readiness: 'previewOnly',
+        reasons: ['Preview only: mean confidence is low.'],
+        score: 60,
+        meanDensity: 1.3,
+        edgeRiskRatio: 0.79,
+        rmseZM: 0.66,
+      }),
+    );
+    expect(a.status).toBe('Limited');
+    expect(a.limiters).toEqual([
+      '79% of measured cells sit at the edge of the data, where the surface is least supported',
+      'vertical RMSE 0.66 m is rated poor',
+    ]);
+  });
+  it('a Good surface has no limiters', () => {
+    expect(terrainAssessment(fixture()).limiters).toEqual([]);
+  });
+});

--- a/tests/terrainAssessment.test.ts
+++ b/tests/terrainAssessment.test.ts
@@ -511,10 +511,11 @@ describe('terrainAssessment — limiters name the actual causes of the verdict',
       }),
     );
     expect(a.status).toBe('Limited');
-    expect(a.limiters).toEqual([
-      '79% of measured cells sit at the edge of the data, where the surface is least supported',
-      'vertical RMSE 0.66 m is rated poor',
-    ]);
+    // The boundary cap's prose belongs to terrainAssessment (PR #886 rewords
+    // it); pin which causes fired and in what order, not how they read.
+    expect(a.limiters).toHaveLength(2);
+    expect(a.limiters?.[0]).toMatch(/^79% of measured cells /);
+    expect(a.limiters?.[1]).toBe('vertical RMSE 0.66 m is rated poor');
   });
   it('a Good surface has no limiters', () => {
     expect(terrainAssessment(fixture()).limiters).toEqual([]);

--- a/tests/terrainProducts.test.ts
+++ b/tests/terrainProducts.test.ts
@@ -92,7 +92,11 @@ describe('terrainProducts', () => {
     });
     const products = terrainProducts(a, recommendedWorkflows(a));
     for (const p of products) {
+      // Inspection rows carry the hero's own word (Limited); deliverable rows
+      // keep the export vocabulary (Preview). Same grade underneath, no new one.
       expect(p.statusWord).toBe('Preview');
+      expect(p.displayWord).toBe(p.productClass === 'inspection' ? 'Limited' : 'Preview');
+      expect(p.status).toBe('preview');
       // The figure-quoting surface line wins over both the generic note
       // ("preview only — additional validation recommended") and the unquantified
       // export framing — and arrives byte-identical, never shortened.
@@ -166,5 +170,21 @@ describe('terrainProducts', () => {
     const a = assessment({});
     const products = terrainProducts(a, [{ label: 'Future workflow', status: 'good' }]);
     expect(products[0].label).toBe('Future workflow');
+  });
+});
+
+describe('terrainProducts — six rows, two grades, said plainly', () => {
+  it('every row names its class so the view can group six rows under two shared grades', () => {
+    const a = assessment({ status: 'Preview', exportReadiness: 'Preview', exportReason: 'x' });
+    const products = terrainProducts(a, recommendedWorkflows(a));
+    expect(products.map((p) => p.productClass)).toEqual([
+      'inspection', 'inspection', 'inspection', 'deliverable', 'deliverable', 'deliverable',
+    ]);
+  });
+  it('inspection rows say Limited only when the surface is Limited', () => {
+    const preview = terrainProducts(assessment({ status: 'Preview', exportReadiness: 'Preview', exportReason: 'x' }), recommendedWorkflows(assessment({ status: 'Preview', exportReadiness: 'Preview', exportReason: 'x' })));
+    expect(preview.filter((p) => p.productClass === 'inspection').every((p) => p.displayWord === 'Ready')).toBe(true);
+    const blocked = assessment({ status: 'Blocked', exportReadiness: 'Blocked', exportReason: 'x', reason: 'gate' });
+    expect(terrainProducts(blocked, recommendedWorkflows(blocked)).every((p) => p.displayWord === 'Blocked')).toBe(true);
   });
 });

--- a/tests/workflowCardRender.test.ts
+++ b/tests/workflowCardRender.test.ts
@@ -210,3 +210,25 @@ describe('renderWhyDetails', () => {
     expect(node).toBeNull();
   });
 });
+
+describe('renderTerrainProducts — grouped under two shared-grade headings', () => {
+  const GROUPED: TerrainProduct[] = [
+    { label: 'Profiles', status: 'preview', statusWord: 'Preview', displayWord: 'Limited', glyph: '⚠', productClass: 'inspection' },
+    { label: 'Measurements', status: 'preview', statusWord: 'Preview', displayWord: 'Limited', glyph: '⚠', productClass: 'inspection' },
+    { label: 'DTM/DEM export', status: 'preview', statusWord: 'Preview', glyph: '⚠', productClass: 'deliverable' },
+    { label: 'Contours', status: 'preview', statusWord: 'Preview', glyph: '⚠', productClass: 'deliverable' },
+  ];
+  it('renders one list per class with a heading that says the grade is shared', async () => {
+    const { renderTerrainProducts } = await load();
+    const card = renderTerrainProducts(GROUPED) as unknown as FakeEl;
+    expect(card.findTag('ul')).toHaveLength(2);
+    const heads = card.findAll('olv-analyse-products-group-head');
+    expect(heads.map((h) => h.textContent)).toEqual([
+      'Inspection products — one shared grade',
+      'Deliverable products — one shared grade',
+    ]);
+    expect(card.findTag('li')).toHaveLength(GROUPED.length);
+    const words = card.findAll('olv-analyse-product-status');
+    expect(words.map((w) => w.textContent)).toEqual(['Limited', 'Limited', 'Preview', 'Preview']);
+  });
+});


### PR DESCRIPTION
The Analyse fitness block stated bases it did not have and led with a cause that had not fired. Wording, disclosed bases and the choice of already-computed lead clause change; no verdict, status, threshold feeding a status, or exported number moves.

- "Integrity ✓ Graded on the full cloud" → "Graded on a sample of the loaded cloud: N ground returns analysed (M points resident)" when the core's stride warning is present.
- The verdict lead now comes from the assessment's own fired caps (new `TerrainAssessment.limiters`, read-only), falling back to scorecard priority when empty. On the Rogue tile it named density, which had not capped anything.
- Scorecard tones align to the assessment chips (density ≥ 2 / ≥ 1; RMSE ≤ 0.10 / ≤ 0.25), so one number no longer reads "fair" and "review" on adjacent rows.
- Density hint discloses returns vs pulses; RMSE row drops the "±"; coverage says "of covered cells"; median/mean withheld below 10 returns per cell.
- Product rows are grouped under their two shared grades.

New test: `tests/scanFitnessStatedBases.test.ts`.
