### PR TITLE
fix(report): grade nothing on all-returns density and state each technical-report basis

### DIFF
--- a/src/app/reportExport.ts
+++ b/src/app/reportExport.ts
@@ -47,6 +47,7 @@ import type { DropZone } from '../ui/DropZone';
 import type { ScanService } from './ScanService';
 import type { loadReportEngine } from '../lazyChunks';
 import { streamingFormatToken } from '../render/streaming/StreamingSource';
+import { classificationCoverage } from '../render/class/classificationCoverage';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Pure decisions the extraction exposes — decidable without a Viewer, the report
@@ -206,6 +207,29 @@ export function exportGeoContext(deps: ReportExportDeps): GeoExportContext {
  * follow-on Studio-panel dialog). The engineering-
  * inspection template renders cleanly without visuals.
  */
+/**
+ * The classification facts the dataset-summary row states beyond presence:
+ * the share of ASPRS 0/1 codes (same rule as the on-screen scan report and the
+ * Classify gate) and whether the viewer derived the classification. The share
+ * is counted on the held points, which are a display sample when the loader
+ * strided the file — the flag says so.
+ */
+function classificationShare(cloud: {
+  readonly classification?: ArrayLike<number> | null;
+  readonly pointCount: number;
+  readonly declaredPointCount?: number;
+  readonly classificationIsDerived?: boolean;
+}): Pick<MetadataInputs, 'unclassifiedFraction' | 'unclassifiedOfDisplaySample' | 'classificationDerived'> {
+  if (!cloud.classification || !(cloud.pointCount > 0)) return {};
+  const { unclassified } = classificationCoverage(cloud.classification, cloud.pointCount);
+  return {
+    unclassifiedFraction: unclassified / cloud.pointCount,
+    unclassifiedOfDisplaySample:
+      cloud.declaredPointCount !== undefined && cloud.declaredPointCount > cloud.pointCount,
+    ...(cloud.classificationIsDerived ? { classificationDerived: true } : {}),
+  };
+}
+
 export async function generateReportPdf(templateId: string, deps: ReportExportDeps): Promise<void> {
   // the report flow needs the Viewer state; ensure it's loaded.
   await deps.viewerReady;
@@ -316,6 +340,7 @@ export async function generateReportPdf(templateId: string, deps: ReportExportDe
       hasRgb: !!staticCloud.colors,
       hasIntensity: !!staticCloud.intensity,
       hasClassification: !!staticCloud.classification,
+      ...classificationShare(staticCloud),
       ...(activeCrsLabel ? { crsName: activeCrsLabel, crsUnit: activeCrs?.linearUnit } : {}),
       // Class-filter honesty — when a filter narrows the live view, disclose
       // it so the PDF's full-cloud figures aren't read as filter-scoped.

--- a/src/diagnostics/provenance.ts
+++ b/src/diagnostics/provenance.ts
@@ -151,6 +151,18 @@ const DISCLAIMER =
   'Your scan may differ — validate against ground control if survey-grade ' +
   'accuracy is required.';
 
+/** Source string for the USGS Lidar Base Specification (QL floors, RMSEz, NVA). */
+const USGS_LBS_SOURCE = 'USGS Lidar Base Specification';
+
+/**
+ * The airborne disclaimer carries the viewer's own statement about the figure
+ * it reports, so that statement is never attributed to a cited paper.
+ */
+const AERIAL_DISCLAIMER =
+  DISCLAIMER +
+  ' The NVA-style figure this viewer reports in the Terrain report comes from ' +
+  'internally withheld points (hold-out), not independent checkpoints.';
+
 /**
  * Classify a loaded scan from its metadata signals. Pure function — same
  * inputs always produce the same fingerprint.
@@ -529,12 +541,12 @@ function matchNumeric(signals: ScanSignals): ProvenanceFingerprint | null {
       // unbounded, it does not claim to resolve the overlap.
       if (signals.densityPerSqM > PHONE_LIDAR_MAX_DENSITY_PER_SQM) {
         return terrestrialFingerprint('medium', [
-          `Density: ${signals.densityPerSqM.toFixed(0)} pts/m² over a ${footprintArea.toFixed(0)} m² bounding-box footprint`,
+          `Density: ${signals.densityPerSqM.toFixed(1)} pts/m² over a ${footprintArea.toFixed(0)} m² bounding-box footprint`,
           `Above the ${PHONE_LIDAR_MAX_DENSITY_PER_SQM} pts/m² a phone flash pattern reaches at its closest range`,
         ]);
       }
       return phoneLidarFingerprint('medium', [
-        `Density: ${signals.densityPerSqM.toFixed(0)} pts/m² over a ${footprintArea.toFixed(0)} m² bounding-box footprint`,
+        `Density: ${signals.densityPerSqM.toFixed(1)} pts/m² over a ${footprintArea.toFixed(0)} m² bounding-box footprint`,
       ]);
     }
 
@@ -572,7 +584,7 @@ function matchNumeric(signals: ScanSignals): ProvenanceFingerprint | null {
     if (signals.densityPerSqM >= 50 && footprintArea > 2000) {
       const veryDense = signals.densityPerSqM > 1000;
       return droneLidarFingerprint(veryDense ? 'high' : 'medium', [
-        `Density: ${signals.densityPerSqM.toFixed(0)} pts/m² over a ${(footprintArea / 10000).toFixed(2)} ha bounding-box mapping footprint`,
+        `Density: ${signals.densityPerSqM.toFixed(1)} pts/m² over a ${(footprintArea / 10000).toFixed(1)} ha bounding-box mapping footprint`,
       ]);
     }
 
@@ -586,7 +598,7 @@ function matchNumeric(signals: ScanSignals): ProvenanceFingerprint | null {
       signals.pointCount > 1_000_000
     ) {
       return terrestrialFingerprint('medium', [
-        `Density: ${signals.densityPerSqM.toFixed(0)} pts/m² with ${signals.pointCount.toLocaleString()} points`,
+        `Density: ${signals.densityPerSqM.toFixed(1)} pts/m² with ${signals.pointCount.toLocaleString()} points`,
       ]);
     }
   }
@@ -745,19 +757,16 @@ function aerialAlsFingerprint(
       },
       {
         label: 'Vertical accuracy (RMSEz)',
-        value: '≤ 10 cm typical for QL1 / QL2 deliveries',
-        source: 'Lohani & Ghosh 2017 §6',
+        value: 'RMSEz ≤ 10 cm required (NVA ≤ 19.6 cm) for QL1 and QL2 deliveries',
+        source: `${USGS_LBS_SOURCE}; Lohani & Ghosh 2017 §6`,
       },
       {
         label: 'NVA formula',
-        value:
-          'NVA = 1.96 × RMSEz (non-vegetated, normal distribution). This ' +
-          'viewer reports an NVA-STYLE figure from internally withheld ' +
-          'points (hold-out), not independent checkpoints.',
-        source: 'Lohani & Ghosh 2017 §6',
+        value: 'NVA = 1.96 × RMSEz (non-vegetated, normal distribution)',
+        source: USGS_LBS_SOURCE,
       },
     ],
-    disclaimer: DISCLAIMER,
+    disclaimer: AERIAL_DISCLAIMER,
   };
 }
 

--- a/src/export/BaseExportMode.ts
+++ b/src/export/BaseExportMode.ts
@@ -272,15 +272,25 @@ export function baseReportRows(
 /**
  * Build the scan-report data record an exporter feeds into the corner card.
  * Pulls common fields from the adapter and merges in mode-specific rows.
+ * `colorMode` is the mode the export FORCED; the adapter's colour-provenance
+ * note (the on-screen legend's own line) is added for every mode whose colour
+ * the viewer applied rather than the scan recorded. Omitted (older callers /
+ * tests) ⇒ no line, so their cards are unchanged.
  */
 export function buildScanReport(
   title: string,
   adapter: ExportSceneAdapter,
   extraRows: readonly ScanReportRow[] = [],
   classScopeStamp = '',
+  colorMode?: ColorMode,
 ): ScanReportData {
   const aabb = adapter.localBoundsAabb();
   const rows: ScanReportRow[] = [...baseReportRows(adapter, aabb), ...extraRows];
+  const colourNote =
+    colorMode !== undefined ? (adapter.colorProvenanceNote?.(colorMode) ?? null) : null;
+  if (colourNote) {
+    rows.push({ label: 'Colour', value: colourNote });
+  }
   // Class-filter honesty row — appended only while a filter narrows the live
   // view, so an unfiltered export's card is byte-identical to before. Pairs
   // with the top-of-image banner; the card row makes the figures' scope
@@ -405,7 +415,7 @@ export async function runStudioExport(
   // Empty when no class is hidden, so the banner + card row are no-ops and the
   // export stays byte-identical to the pre-feature image.
   const classScopeStamp = context.classScopeStamp ?? '';
-  const report = buildScanReport(reportTitle, context.adapter, extraReportRows, classScopeStamp);
+  const report = buildScanReport(reportTitle, context.adapter, extraReportRows, classScopeStamp, colorMode);
   const withReport = await composeScanReportOntoBlob(blob, report, 'bottom-right');
   // Draw the "showing N of M classes" caveat banner across the top of the
   // raster while a filter is active — the escape-hatch closure: a filtered

--- a/src/export/types.ts
+++ b/src/export/types.ts
@@ -125,6 +125,13 @@ export interface ExportSceneAdapter {
    */
   classificationAssignedFraction?(): number | null;
   /**
+   * The colour-provenance line for `mode` — the same statement the on-screen
+   * legend shows ("Colour is applied by the viewer, not recorded by the scan.")
+   * for every mode whose colour the viewer applied, or null for the scan's own
+   * recorded colour (RGB). Optional: adapters without it stamp no line.
+   */
+  colorProvenanceNote?(mode: ColorMode): string | null;
+  /**
    * Does any loaded cloud carry per-point normals? Drives the Normal Map
    * exporter's `isAvailable` gate. Streaming COPC + EPT sources never carry
    * normals (LAS/LAZ doesn't reserve a field for them and EPT writers rarely

--- a/src/render/exportAdapter.ts
+++ b/src/render/exportAdapter.ts
@@ -32,6 +32,7 @@ import { linearUnitLabel } from '../io/crs';
 // the Inspector card and the PDF report read.
 import { captureProvenance } from '../diagnostics/captureProvenance';
 import { classificationCoverage } from './class/classificationCoverage';
+import { DERIVED_COLOR_NOTE, isDerivedColorMode } from './colorModeProvenance';
 
 /**
  * The per-cloud slice the adapter reads — a structural subset of the Viewer's
@@ -327,6 +328,9 @@ export function buildExportAdapter(host: ExportAdapterHost): ExportSceneAdapter 
         assigned += producer;
       }
       return total > 0 ? assigned / total : null;
+    },
+    colorProvenanceNote(mode: ColorMode): string | null {
+      return isDerivedColorMode(mode) ? DERIVED_COLOR_NOTE : null;
     },
     hasNormals(): boolean {
       // Dispatch on the abstract `availableColorModes()` for streaming, exactly

--- a/src/render/snapshot.ts
+++ b/src/render/snapshot.ts
@@ -21,6 +21,7 @@ import { classificationText, intensityText, rgbText, type PointInfo } from './po
 import { computeScaleBar, pixelsPerMetreAt } from './scaleBar';
 import { burnInColorbarLayout, type ActiveColorbar } from './activeColorbar';
 import { colorbarStops, niceTicks, formatColorbarValue } from './colorbar';
+import { DERIVED_COLOR_NOTE, isDerivedColorMode } from './colorModeProvenance';
 
 export interface SnapshotOptions {
   /** Include the annotation markers. */
@@ -534,6 +535,18 @@ function drawScaleBar(
  * is white with a dark stroke — the same treatment as the scale bar — so it
  * reads on any cloud colour without needing a backing card.
  */
+/**
+ * The lines burned in beneath the colour bar: the legend's own note (window /
+ * normalisation) when it has one, then the derived-colour statement for every
+ * mode whose colour the viewer applied. Pure — tested apart from the canvas.
+ */
+export function colorbarBurnInNotes(active: ActiveColorbar): readonly string[] {
+  const notes: string[] = [];
+  if (active.note) notes.push(active.note);
+  if (isDerivedColorMode(active.mode)) notes.push(DERIVED_COLOR_NOTE);
+  return notes;
+}
+
 function drawColorbar(
   ctx: CanvasRenderingContext2D,
   out: HTMLCanvasElement,
@@ -564,10 +577,20 @@ function drawColorbar(
   const title = spec.unit ? `${spec.label} (${spec.unit})` : spec.label;
   const titleY = L.barY - Math.round(L.titleFontSize * 0.6);
   strokedText(title, L.barX + L.barWidth, titleY);
-  // Honesty note under the bar, smaller — e.g. "p5–p95 window".
-  if (active.note) {
-    ctx.font = font(Math.max(9, Math.round(L.fontSize * 0.85)));
-    strokedText(active.note, L.barX + L.barWidth, L.barY + L.barHeight + Math.round(L.fontSize * 1.4));
+  // Notes under the bar, smaller — the window note (e.g. "p5–p95 window")
+  // and, for every non-RGB mode, that the colour is the viewer's, not the
+  // scan's. Same string the on-screen legend shows.
+  const notes = colorbarBurnInNotes(active);
+  if (notes.length > 0) {
+    const noteSize = Math.max(9, Math.round(L.fontSize * 0.85));
+    ctx.font = font(noteSize);
+    notes.forEach((note, i) => {
+      strokedText(
+        note,
+        L.barX + L.barWidth,
+        L.barY + L.barHeight + Math.round(L.fontSize * 1.4) + i * Math.round(noteSize * 1.25),
+      );
+    });
   }
 
   // The ramp — adjacent rects sampled from the SAME stops the SVG gradient

--- a/src/report/ReportFindings.ts
+++ b/src/report/ReportFindings.ts
@@ -12,19 +12,18 @@
  *  - It reports what was *measured*. Point density, extent and attribute
  *    presence are read straight from the loaded cloud. They are stated, not
  *    judged.
- *  - A density floor is a threshold, not a quality level. A 3DEP quality level
- *    also carries vertical accuracy against independent checkpoints, coverage
- *    and collection requirements nothing here validates, so the findings say
- *    where the density sits relative to the QL1 / QL2 floors and stop there.
- *  - It only compares density against the USGS QL1 / QL2 floors when the
- *    capture-type classifier has *itself* cited USGS QL literature for this
- *    scan (an airborne-ALS delivery). The Scan Acceptance template
- *    deliberately bakes in no QL thresholds because they would be misapplied
- *    to TLS / phone / cropped subsets; this module honours the same line by
- *    gating the tier on the classifier's own applicability decision.
+ *  - A density floor is a threshold, not a quality level — and the density
+ *    this report holds is ALL RETURNS over the bounding-box footprint. USGS
+ *    QL floors are defined on nominal PULSE density, which the file does not
+ *    record (a multi-return forest tile at 10 returns/m² may be 3–4 pulses/m²),
+ *    so no finding is ever graded against a QL floor: the density row is
+ *    stated as a fact and the QL bar, where the classifier cited USGS QL
+ *    literature for an airborne delivery, is drawn as ungraded context only.
+ *    `terrain/quality/demAccuracyStandards.ts` refuses the same comparison for
+ *    the same reason.
  *  - Vertical accuracy is *never* asserted. The cloud cannot tell us RMSEz
- *    without ground control, so that finding is always rendered "—, requires
- *    ground-control validation". This is the centre of the deliverable: it
+ *    without ground control, so that finding is always rendered "—, not
+ *    evaluated in this report". This is the centre of the deliverable: it
  *    says plainly what the scan cannot prove on its own.
  *
  * Pure data: no DOM, no pdf-lib, no I/O. Deterministic — tests pin it.
@@ -64,12 +63,15 @@ export interface ReportInspectionSummary {
   /** What the report does NOT establish — always non-empty. */
   readonly caveats: readonly string[];
   /**
-   * Optional density-bar datum: the measured density against the USGS QL
-   * thresholds. Present ONLY when the QL comparison is applicable (see the
+   * Optional density-bar datum: the measured all-returns density drawn
+   * against the USGS QL pulse-density floors as CONTEXT, not a grade. Present
+   * ONLY when the classifier cited USGS QL literature for this scan (see the
    * gating rule above), so the renderer never draws a bar implying a
    * standard that doesn't apply to this capture type.
    */
   readonly densityBar?: {
+    /** Bar caption; names the floors and states that nothing is graded. */
+    readonly caption: string;
     readonly measured: number;
     readonly unit: string;
     readonly thresholds: readonly { readonly label: string; readonly value: number }[];
@@ -86,16 +88,17 @@ const USGS_QL1_PTS_PER_M2 = 8;
 const USGS_QL2_PTS_PER_M2 = 2;
 const USGS_DENSITY_SOURCE = 'Lohani & Ghosh 2017 §6 (USGS Lidar Base Spec)';
 /**
- * The technical report's density is the all-returns total over the footprint —
- * the nominal delivery density USGS QL tiers are defined against. The terrain /
- * DEM products instead grade **bare-earth (ground) density**, which is far
- * lower under canopy, so the two reports can legitimately land on different QL
- * verdicts for the same scan. Naming the basis on each keeps that from reading
- * as a contradiction.
+ * The technical report's density is the all-returns record count over the
+ * bounding-box footprint. USGS QL tiers are defined on nominal PULSE density,
+ * which the file does not record, so the row states the number and its basis
+ * and grades nothing. The terrain / DEM products separately grade
+ * **bare-earth (ground) density**, which is far lower under canopy.
  */
 const DENSITY_LABEL = 'Point density (all returns)';
-const GROUND_BASIS_NOTE =
-  ' Terrain/DEM products grade bare-earth ground density separately.';
+const DENSITY_BASIS = 'over the bounding-box footprint';
+const QL_NOT_EVALUATED =
+  'USGS QL floors are defined on nominal pulse density, which this file does not record; not evaluated.';
+const DENSITY_BAR_CAPTION = 'USGS pulse-density floors (context, not graded)';
 
 /**
  * The QL density comparison is applicable only when the classifier has cited
@@ -160,33 +163,17 @@ function densityFinding(
     return {
       label: DENSITY_LABEL,
       value,
-      detail: 'No capture-type density standard applied to this scan.',
+      detail: `All-returns density ${value} ${DENSITY_BASIS}. No capture-type density standard applied to this scan.`,
       tier: 'info',
     };
   }
-  if (d >= USGS_QL1_PTS_PER_M2) {
-    return {
-      label: DENSITY_LABEL,
-      value,
-      detail: `All-returns density is at or above the USGS QL1 density floor (≥ ${USGS_QL1_PTS_PER_M2} pts/m²).${GROUND_BASIS_NOTE}`,
-      tier: 'met',
-      source: USGS_DENSITY_SOURCE,
-    };
-  }
-  if (d >= USGS_QL2_PTS_PER_M2) {
-    return {
-      label: DENSITY_LABEL,
-      value,
-      detail: `All-returns density is at or above the USGS QL2 density floor (≥ ${USGS_QL2_PTS_PER_M2} pts/m²) and below the QL1 floor (≥ ${USGS_QL1_PTS_PER_M2} pts/m²).${GROUND_BASIS_NOTE}`,
-      tier: 'met',
-      source: USGS_DENSITY_SOURCE,
-    };
-  }
+  // Airborne delivery: the QL floors are the relevant literature, but they are
+  // pulse-density floors and this is a returns count — stated, never graded.
   return {
     label: DENSITY_LABEL,
     value,
-    detail: `All-returns density is below the USGS QL2 density floor (≥ ${USGS_QL2_PTS_PER_M2} pts/m²).${GROUND_BASIS_NOTE}`,
-    tier: 'caution',
+    detail: `All-returns density ${value} ${DENSITY_BASIS}. ${QL_NOT_EVALUATED}`,
+    tier: 'info',
     source: USGS_DENSITY_SOURCE,
   };
 }
@@ -213,15 +200,18 @@ export function buildInspectionSummary(
 
   const findings: ReportFinding[] = [];
 
-  // 1. Coverage / scale.
+  // 1. Extent / scale — the bounding box, which is not a surveyed area, and
+  //    the file's record count, which is what was delivered, not what was
+  //    captured.
+  const extent = formatArea(area);
   findings.push(
     {
-      label: 'Coverage',
-      value: formatArea(area),
+      label: 'Bounding-box extent',
+      value: Number.isFinite(area) && area > 0 ? `${extent} (not surveyed area)` : extent,
       detail:
         metadata.sourcePointCount === null
           ? 'Point count unknown from source metadata.'
-          : `${formatCount(metadata.sourcePointCount)} captured.`,
+          : `${formatCount(metadata.sourcePointCount)} delivered (file record count).`,
       tier: 'info',
     },
     // 2. Point density — the one genuinely quantitative finding.
@@ -244,13 +234,13 @@ export function buildInspectionSummary(
       : 'No classification channel — ground / feature extraction needs one.',
   });
 
-  // 4. Georeference.
+  // 4. Georeference — a declared CRS name is a fact, not a met threshold.
   if (metadata.crsName && metadata.crsName.length > 0) {
     findings.push({
       label: 'Georeference',
       value: metadata.crsName,
       detail: metadata.crsUnit ? `Linear unit: ${metadata.crsUnit}.` : undefined,
-      tier: 'met',
+      tier: 'info',
     });
   } else {
     findings.push({
@@ -265,7 +255,9 @@ export function buildInspectionSummary(
   findings.push({
     label: 'Vertical accuracy',
     value: '—',
-    detail: 'Not measured. Requires ground-control validation (NVA = 1.96 × RMSEz).',
+    detail:
+      'Not evaluated in this report. A hold-out RMSEz appears in the Terrain report when ' +
+      'terrain analysis has run; neither replaces independent ground-control checkpoints.',
     tier: 'unknown',
   });
 
@@ -286,6 +278,7 @@ export function buildInspectionSummary(
   const densityBar =
     qlApplies && Number.isFinite(metadata.density) && metadata.density > 0
       ? {
+          caption: DENSITY_BAR_CAPTION,
           measured: metadata.density,
           unit: 'pts/m²',
           thresholds: [

--- a/src/report/ReportMetadataSection.ts
+++ b/src/report/ReportMetadataSection.ts
@@ -26,6 +26,17 @@ export interface MetadataInputs {
   readonly hasRgb: boolean;
   readonly hasIntensity: boolean;
   readonly hasClassification: boolean;
+  /**
+   * Share of points carrying ASPRS code 0 (Created) or 1 (Unclassified) — the
+   * same rule as `render/class/classificationCoverage`. Absent when the channel
+   * is missing or the share cannot be counted (streaming), in which case the
+   * row states presence only.
+   */
+  readonly unclassifiedFraction?: number;
+  /** `unclassifiedFraction` was counted on the display sample, not the file. */
+  readonly unclassifiedOfDisplaySample?: boolean;
+  /** The classification was derived in the viewer (heuristic), not supplied. */
+  readonly classificationDerived?: boolean;
   /** CRS label + linear unit when the source carries projection metadata. */
   readonly crsName?: string;
   readonly crsUnit?: string;
@@ -102,6 +113,28 @@ function formatCompactCount(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return `${Math.round(n)}`;
+}
+
+/**
+ * "Yes" alone states presence, which a reader takes for a classified cloud.
+ * When the share of ASPRS 0/1 codes is known it is printed next to presence,
+ * and a viewer-derived classification says so, so the row states what the
+ * on-screen scan report states.
+ */
+function classificationValue(inputs: MetadataInputs): string {
+  if (!inputs.hasClassification) return 'No';
+  const parts: string[] = [];
+  if (inputs.classificationDerived) parts.push('derived by the viewer (heuristic)');
+  const u = inputs.unclassifiedFraction;
+  if (u !== undefined && Number.isFinite(u)) {
+    if (u <= 0) {
+      parts.push('every point carries a class');
+    } else {
+      const scope = inputs.unclassifiedOfDisplaySample ? ', of display sample' : '';
+      parts.push(`${(u * 100).toFixed(1)} % ASPRS code 0/1 (unclassified${scope})`);
+    }
+  }
+  return parts.length > 0 ? `Yes — ${parts.join('; ')}` : 'Yes';
 }
 
 /**
@@ -186,7 +219,7 @@ export function buildDatasetSummary(inputs: MetadataInputs): readonly ReportData
   rows.push(
     { label: 'RGB',            value: inputs.hasRgb ? 'Yes' : 'No' },
     { label: 'Intensity',      value: inputs.hasIntensity ? 'Yes' : 'No' },
-    { label: 'Classification', value: inputs.hasClassification ? 'Yes' : 'No' },
+    { label: 'Classification', value: classificationValue(inputs) },
   );
   if (inputs.crsName) {
     rows.push({ label: 'CRS',   value: inputs.crsName });

--- a/src/report/ReportPdfRenderer.ts
+++ b/src/report/ReportPdfRenderer.ts
@@ -770,10 +770,11 @@ function drawFinding(
 }
 
 /**
- * Small horizontal density bar: measured density against the USGS QL
- * thresholds, with labelled tick marks. Drawn only when the summary carries a
- * `densityBar` (i.e. the QL comparison is applicable), so the graphic never
- * implies a standard that doesn't apply to this capture type.
+ * Small horizontal density bar: measured all-returns density drawn against the
+ * USGS QL pulse-density floors as context, with labelled tick marks. Drawn
+ * only when the summary carries a `densityBar` (an airborne delivery), so the
+ * graphic never implies a standard that doesn't apply to this capture type;
+ * the caption states that nothing is graded.
  */
 function drawDensityBar(
   cursor: PageCursor,
@@ -794,8 +795,8 @@ function drawDensityBar(
   const top = cursor.y - 4;
   const rule = rgb(theme.rule.r, theme.rule.g, theme.rule.b);
 
-  // Caption.
-  cursor.page.drawText('Density vs USGS quality levels', {
+  // Caption — names the floors and states that nothing is graded.
+  cursor.page.drawText(sanitiseForPdf(bar.caption), {
     x: x0, y: top - BODY_FONT_SIZE + 2, size: BODY_FONT_SIZE - 1, font: bold,
     color: rgb(theme.bodyText.r, theme.bodyText.g, theme.bodyText.b),
   });
@@ -916,7 +917,7 @@ async function renderDatasetSummary(
  *
  * v0.5.5 P12 — `opts.compact` (the `provenance-compact` section, Survey
  * Summary) renders ONLY the capture-type headline + the disclaimer. The
- * signal list and the "Expected accuracy (cited literature)" block are
+ * signal list and the "Expected ranges for this capture type" block are
  * Technical Report detail; the compact form names the capture type
  * without restating the evidence chain.
  *
@@ -975,7 +976,7 @@ async function renderProvenance(
   // Literature-cited accuracy bounds — the Research-Derived ribbon.
   if (!opts?.compact && p.bounds.length > 0) {
     cursor = ensureSpace(cursor, 16 + p.bounds.length * 28, doc, accent, theme, organisation);
-    cursor.page.drawText('Expected accuracy (cited literature)', {
+    cursor.page.drawText('Expected ranges for this capture type (literature) — not measured on this scan', {
       x: MARGIN, y: cursor.y - BODY_FONT_SIZE,
       size: BODY_FONT_SIZE, font: bold,
       color: rgb(theme.bodyText.r, theme.bodyText.g, theme.bodyText.b),

--- a/tests/exportStudio.test.ts
+++ b/tests/exportStudio.test.ts
@@ -14,6 +14,7 @@
 
 import { test, expect, vi } from 'vitest';
 import * as THREE from 'three/webgpu';
+import { DERIVED_COLOR_NOTE, isDerivedColorMode } from '../src/render/colorModeProvenance';
 import {
   ExportRegistry,
   defaultExportRegistry,
@@ -63,6 +64,7 @@ function stubAdapter(opts: {
     hasIntensity: () => opts.hasIntensity ?? false,
     hasClassification: () => opts.hasClassification ?? false,
     hasNormals: () => opts.hasNormals ?? false,
+    colorProvenanceNote: (mode) => (isDerivedColorMode(mode) ? DERIVED_COLOR_NOTE : null),
     localBoundsAabb: () => (opts.aabb === undefined ? [0, 0, 0, 10, 10, 5] : opts.aabb),
     dataBoundsAabb: () => (opts.aabb === undefined ? [0, 0, 0, 10, 10, 5] : opts.aabb),
     // v0.3.2-Studio additions — exporters now delegate the actual render +
@@ -176,6 +178,17 @@ test('buildScanReport: active class filter ⇒ appends a Class filter row', () =
   const row = report.rows.find((r) => r.label === 'Class filter');
   expect(row).toBeDefined();
   expect(row?.value).toBe('Ground + Building · 2 of 5 classes');
+});
+
+test('buildScanReport: a derived colour mode adds the viewer-colour line; rgb / no mode add nothing', () => {
+  const adapter = stubAdapter({ sourceName: 'colour-fixture', sourcePointCount: 4 });
+  const line = DERIVED_COLOR_NOTE;
+  const rowsOf = (mode?: 'rgb' | 'elevation' | 'intensity') =>
+    buildScanReport('Height Map', adapter, [], '', mode).rows;
+  expect(rowsOf('elevation').find((r) => r.label === 'Colour')?.value).toBe(line);
+  expect(rowsOf('intensity').find((r) => r.label === 'Colour')?.value).toBe(line);
+  expect(rowsOf('rgb').find((r) => r.label === 'Colour')).toBeUndefined();
+  expect(JSON.stringify(rowsOf(undefined))).toBe(JSON.stringify(rowsOf('rgb')));
 });
 
 test('availableModes + unavailableModes — capability gating round-trip', () => {

--- a/tests/provenanceStatedBases.test.ts
+++ b/tests/provenanceStatedBases.test.ts
@@ -1,0 +1,85 @@
+/**
+ * provenanceStatedBases.test.ts
+ *
+ * Pins the wording of the airborne-ALS literature bounds and the precision of
+ * the density Signals lines:
+ *   - the RMSEz bound states the USGS requirement (RMSEz ≤ 10 cm, NVA ≤ 19.6 cm)
+ *     and cites the USGS Lidar Base Specification alongside Lohani & Ghosh;
+ *   - the viewer's own hold-out statement lives in the disclaimer, not in a
+ *     row attributed to a paper;
+ *   - every density Signals line prints 1 dp density and 1 dp hectares, matching
+ *     the report summary.
+ */
+import { describe, it, expect } from 'vitest';
+import { classify } from '../src/diagnostics/provenance';
+
+const bound = (fp: { bounds: readonly { label: string; value: string; source: string }[] }, label: string) =>
+  fp.bounds.find((b) => b.label === label);
+
+describe('aerial-ALS bounds state the USGS requirement and its source', () => {
+  const fp = classify({
+    sourceFormat: 'copc',
+    pointCount: 20_000_000,
+    extent: [1000, 1000, 200],
+    densityPerSqM: 20,
+  });
+
+  it('classifies the fixture as airborne', () => {
+    expect(fp.captureType).toBe('aerial-als');
+  });
+
+  it('states RMSEz as the required bound with the NVA equivalent', () => {
+    const b = bound(fp, 'Vertical accuracy (RMSEz)');
+    expect(b?.value).toBe('RMSEz ≤ 10 cm required (NVA ≤ 19.6 cm) for QL1 and QL2 deliveries');
+    expect(b?.source).toContain('USGS Lidar Base Specification');
+    expect(b?.source).toContain('Lohani & Ghosh 2017 §6');
+  });
+
+  it('keeps the NVA formula row cited to the specification, without the viewer statement', () => {
+    const b = bound(fp, 'NVA formula');
+    expect(b?.value).toBe('NVA = 1.96 × RMSEz (non-vegetated, normal distribution)');
+    expect(b?.source).toBe('USGS Lidar Base Specification');
+    expect(b?.value).not.toMatch(/viewer|hold-out/i);
+  });
+
+  it('puts the hold-out statement in the disclaimer', () => {
+    expect(fp.disclaimer).toContain('not guarantees');
+    expect(fp.disclaimer).toContain('hold-out');
+    expect(fp.disclaimer).toContain('not independent checkpoints');
+    expect(fp.bounds.every((b) => !/NVA-STYLE/i.test(b.value))).toBe(true);
+  });
+});
+
+describe('density Signals lines use 1 dp density and 1 dp hectares', () => {
+  it('drone', () => {
+    const fp = classify({
+      sourceFormat: 'laz', pointCount: 9_597_830, extent: [78.8, 124.4, 18.9], densityPerSqM: 978.94,
+    });
+    expect(fp.captureType).toBe('drone-lidar');
+    expect(fp.signals[0]).toBe('Density: 978.9 pts/m² over a 1.0 ha bounding-box mapping footprint');
+  });
+
+  it('phone', () => {
+    const fp = classify({
+      sourceFormat: 'ply', pointCount: 500_000, extent: [10, 10, 3], densityPerSqM: 5000.04,
+    });
+    expect(fp.captureType).toBe('iphone-lidar');
+    expect(fp.signals[0]).toBe('Density: 5000.0 pts/m² over a 100 m² bounding-box footprint');
+  });
+
+  it('terrestrial (station in a small room)', () => {
+    const fp = classify({
+      sourceFormat: 'e57', pointCount: 500_000, extent: [5, 4.54, 3], densityPerSqM: 20473.25,
+    });
+    expect(fp.captureType).toBe('terrestrial');
+    expect(fp.signals[0]).toBe('Density: 20473.3 pts/m² over a 23 m² bounding-box footprint');
+  });
+
+  it('terrestrial (station scale, millions of points)', () => {
+    const fp = classify({
+      sourceFormat: 'e57', pointCount: 3_000_000, extent: [30, 40, 15], densityPerSqM: 400.04,
+    });
+    expect(fp.captureType).toBe('terrestrial');
+    expect(fp.signals[0]).toBe('Density: 400.0 pts/m² with 3,000,000 points');
+  });
+});

--- a/tests/reportExport.test.ts
+++ b/tests/reportExport.test.ts
@@ -308,6 +308,32 @@ describe('generateReportPdf — the report assembly body', () => {
     expect(setError).not.toHaveBeenCalled();
   });
 
+  it('carries the unclassified share (ASPRS 0/1) and the derived flag, scoped to the display sample', async () => {
+    // 1000 resident of 2000 declared: the share is counted on the display
+    // sample and must say so. Codes: 6 ground (2), 4 unclassified (0/1).
+    const classification = new Uint8Array(1000);
+    for (let i = 0; i < 1000; i++) classification[i] = i % 10 < 6 ? 2 : (i % 2 ? 1 : 0);
+    const classified = { ...staticCloud, classification, classificationIsDerived: true };
+    const { deps, composeReportInputs } = makeReportDeps({
+      staticCloud: classified as unknown as typeof staticCloud,
+    });
+    await generateReportPdf('technical-report', deps);
+    const inputs = composeReportInputs.mock.calls[0]![0] as ReportInputs;
+    expect(inputs.metadata.hasClassification).toBe(true);
+    expect(inputs.metadata.unclassifiedFraction).toBeCloseTo(0.4, 6);
+    expect(inputs.metadata.unclassifiedOfDisplaySample).toBe(true);
+    expect(inputs.metadata.classificationDerived).toBe(true);
+  });
+
+  it('omits the unclassified share when the cloud carries no classification', async () => {
+    const { deps, composeReportInputs } = makeReportDeps({ staticCloud });
+    await generateReportPdf('technical-report', deps);
+    const inputs = composeReportInputs.mock.calls[0]![0] as ReportInputs;
+    expect(inputs.metadata.hasClassification).toBe(false);
+    expect(inputs.metadata.unclassifiedFraction).toBeUndefined();
+    expect(inputs.metadata.classificationDerived).toBeUndefined();
+  });
+
   it('assembles a streaming-cloud report from the resident preview', async () => {
     const { deps, composeReportInputs } = makeReportDeps({
       streamingCloud,

--- a/tests/reportFindings.test.ts
+++ b/tests/reportFindings.test.ts
@@ -2,7 +2,8 @@
  * reportFindings.test.ts
  *
  * Pins the honest synthesis in `buildInspectionSummary`:
- *   - density is only compared against USGS QL tiers when the classifier has
+ *   - all-returns density is never graded against a USGS QL (pulse-density)
+ *     floor; the ungraded context bar appears only when the classifier has
  *     itself cited QL literature (airborne-ALS) — never for TLS / phone /
  *     unknown / no-provenance scans;
  *   - vertical accuracy is ALWAYS reported unmeasured;
@@ -63,29 +64,26 @@ function find(summary: ReturnType<typeof buildInspectionSummary>, label: string)
 }
 
 describe('buildInspectionSummary — density tier gating', () => {
-  it('reports the QL1 density floor for airborne ALS at >= 8 pts/m²', () => {
+  it('never grades all-returns density against a USGS QL floor (pulse density is not recorded)', () => {
+    for (const d of [16, 4, 1]) {
+      const s = buildInspectionSummary(meta({ density: d }), alsProvenance());
+      const f = find(s, 'Point density (all returns)');
+      expect(f?.tier).toBe('info');
+      expect(f?.detail).toBe(
+        `All-returns density ${d.toFixed(1)} pts/m² over the bounding-box footprint. ` +
+          'USGS QL floors are defined on nominal pulse density, which this file does not record; not evaluated.',
+      );
+      expect(f?.detail).not.toMatch(/at or above|below the/i);
+    }
+  });
+
+  it('keeps the pulse-density floor bar as ungraded context for airborne ALS', () => {
     const s = buildInspectionSummary(meta({ density: 16 }), alsProvenance());
-    const d = find(s, 'Point density (all returns)');
-    expect(d?.tier).toBe('met');
-    expect(d?.detail).toMatch(/QL1/);
-    expect(d?.source).toMatch(/USGS/);
-    expect(s.densityBar?.measured).toBe(16);
+    expect(s.densityBar?.caption).toBe('USGS pulse-density floors (context, not graded)');
+    expect(s.densityBar?.thresholds.map((t) => t.label)).toEqual(['QL2', 'QL1']);
   });
 
-  it('reports the QL2 density floor (below QL1) for airborne ALS between 2 and 8', () => {
-    const s = buildInspectionSummary(meta({ density: 4 }), alsProvenance());
-    const d = find(s, 'Point density (all returns)');
-    expect(d?.tier).toBe('met');
-    expect(d?.detail).toMatch(/QL2/);
-    expect(d?.detail).toMatch(/below the QL1 floor \(≥ 8 pts\/m²\)/i);
-  });
 
-  it('flags below-QL2 as caution for airborne ALS under 2 pts/m²', () => {
-    const s = buildInspectionSummary(meta({ density: 1 }), alsProvenance());
-    const d = find(s, 'Point density (all returns)');
-    expect(d?.tier).toBe('caution');
-    expect(d?.detail).toMatch(/below the USGS QL2 density floor \(≥ 2 pts\/m²\)/i);
-  });
 
   it('does NOT apply QL tiers for TLS (no QL literature cited)', () => {
     const s = buildInspectionSummary(meta({ density: 16 }), tlsProvenance());
@@ -118,8 +116,11 @@ describe('buildInspectionSummary — honesty invariants', () => {
       const v = find(s, 'Vertical accuracy');
       expect(v?.value).toBe('—');
       expect(v?.tier).toBe('unknown');
-      expect(v?.detail).toMatch(/ground-control/i);
-      expect(v?.detail).toMatch(/1\.96/);
+      expect(v?.detail).toBe(
+        'Not evaluated in this report. A hold-out RMSEz appears in the Terrain report when ' +
+          'terrain analysis has run; neither replaces independent ground-control checkpoints.',
+      );
+      expect(v?.detail).not.toMatch(/1\.96/);
     }
   });
 
@@ -145,9 +146,18 @@ describe('buildInspectionSummary — honesty invariants', () => {
     expect(g?.value).toMatch(/No CRS/);
   });
 
-  it('marks georeference met when a CRS is declared', () => {
+  it('states a declared CRS as a fact (info), not a met threshold', () => {
     const s = buildInspectionSummary(meta());
-    expect(find(s, 'Georeference')?.tier).toBe('met');
+    expect(find(s, 'Georeference')?.tier).toBe('info');
+    expect(s.findings.some((f) => f.tier === 'met')).toBe(false);
+  });
+
+  it('names the extent as a bounding box and the count as the file record count', () => {
+    const s = buildInspectionSummary(meta());
+    const e = find(s, 'Bounding-box extent');
+    expect(e?.value).toBe('100.0 ha (not surveyed area)');
+    expect(e?.detail).toBe('15.7 M points delivered (file record count).');
+    expect(find(s, 'Coverage')).toBeUndefined();
   });
 
   it('flags a missing classification channel as a caution', () => {
@@ -174,10 +184,9 @@ describe('buildInspectionSummary — density states the threshold, not the quali
     }
   });
 
-  it('keeps the density floor each comparison was made against', () => {
-    expect(detail(16)).toMatch(/QL1 density floor \(≥ 8 pts\/m²\)/);
-    expect(detail(4)).toMatch(/QL2 density floor \(≥ 2 pts\/m²\)/);
-    expect(detail(4)).toMatch(/below the QL1 floor/i);
-    expect(detail(1)).toMatch(/below the USGS QL2 density floor \(≥ 2 pts\/m²\)/i);
+  it('states the basis (all returns over the bounding box) on every density row', () => {
+    for (const d of [16, 4, 1]) expect(detail(d)).toMatch(/over the bounding-box footprint/);
+    const s = buildInspectionSummary(meta({ density: 16 }), tlsProvenance());
+    expect(find(s, 'Point density (all returns)')?.detail).toMatch(/over the bounding-box footprint/);
   });
 });

--- a/tests/reportMetadataUnits.test.ts
+++ b/tests/reportMetadataUnits.test.ts
@@ -88,7 +88,7 @@ describe('buildDatasetSummary — fail closed on an unconfirmed unit', () => {
 describe('buildInspectionSummary — fail closed on an unconfirmed unit', () => {
   it('reports unknown extent rather than a source-unit² area as m²', () => {
     const s = buildInspectionSummary(UNCONFIRMED);
-    const coverage = s.findings.find((f) => f.label === 'Coverage');
+    const coverage = s.findings.find((f) => f.label === 'Bounding-box extent');
     expect(coverage?.value).toBe('unknown extent');
     expect(s.headline).toMatch(/unknown extent/);
   });
@@ -98,5 +98,46 @@ describe('buildInspectionSummary — fail closed on an unconfirmed unit', () => 
     const d = s.findings.find((f) => f.label === 'Point density (all returns)');
     expect(d?.value).toBe('—');
     expect(s.densityBar).toBeUndefined();
+  });
+});
+
+describe('buildDatasetSummary — classification row states share and origin', () => {
+  it('prints presence only when no share is available', () => {
+    expect(rowMap(CONFIRMED).get('Classification')).toBe('Yes');
+  });
+
+  it('prints the unclassified share (ASPRS 0/1) next to presence', () => {
+    const rows = buildDatasetSummary({ ...CONFIRMED, unclassifiedFraction: 0.953 });
+    expect(rows.find((r) => r.label === 'Classification')?.value).toBe(
+      'Yes — 95.3 % ASPRS code 0/1 (unclassified)',
+    );
+  });
+
+  it('says every point carries a class when the unclassified share is zero', () => {
+    const rows = buildDatasetSummary({ ...CONFIRMED, unclassifiedFraction: 0 });
+    expect(rows.find((r) => r.label === 'Classification')?.value).toBe(
+      'Yes — every point carries a class',
+    );
+  });
+
+  it('marks a viewer-derived classification and a display-sample share', () => {
+    const rows = buildDatasetSummary({
+      ...CONFIRMED,
+      unclassifiedFraction: 0.12,
+      unclassifiedOfDisplaySample: true,
+      classificationDerived: true,
+    });
+    expect(rows.find((r) => r.label === 'Classification')?.value).toBe(
+      'Yes — derived by the viewer (heuristic); 12.0 % ASPRS code 0/1 (unclassified, of display sample)',
+    );
+  });
+
+  it('never prints a share for an absent channel', () => {
+    const rows = buildDatasetSummary({
+      ...CONFIRMED,
+      hasClassification: false,
+      unclassifiedFraction: 1,
+    });
+    expect(rows.find((r) => r.label === 'Classification')?.value).toBe('No');
   });
 });

--- a/tests/reportPdfLayout.test.ts
+++ b/tests/reportPdfLayout.test.ts
@@ -279,7 +279,7 @@ describe('sanitiseForPdf — WinAnsi glyph policy', () => {
     const { runs } = await renderRuns(tikalInputs());
     const all = runs.map((r) => r.text).join('\n');
     expect(all).toContain('pts/m\xB2');            // ² as WinAnsi 0xB2, not "^2"
-    expect(all).toContain('1.96 \xD7 RMSEz');      // × as WinAnsi 0xD7, not "x"
+    expect(all).toContain('1.0 \xD7 GSD');          // × as WinAnsi 0xD7, not "x"
     expect(all).toContain('\x97');                 // — as CP1252 0x97, not "--"
     expect(all).not.toContain('m^2');
     expect(all).not.toContain('--');

--- a/tests/reportTemplateGoldens.test.ts
+++ b/tests/reportTemplateGoldens.test.ts
@@ -7,7 +7,7 @@
  *
  *   - Survey Summary is genuinely compact: it names the capture type
  *     (compact provenance) but contains NO "Signals" list, NO "Expected
- *     accuracy (cited literature)" block, NO Annotations section and NO
+ *     ranges for this capture type (literature)" block, NO Annotations section and NO
  *     "Declared source metadata" section.
  *   - Technical Report is the complete record: it contains all of them.
  *   - The shared dataset block renders exactly ONCE per report in both.
@@ -140,7 +140,7 @@ describe('survey-summary golden (compact)', () => {
     expect(text).toContain('Golden-fixture technical note.');
     // NO detail blocks: signals, cited accuracy, annotations, declared metadata.
     expect(text).not.toContain('Signals');
-    expect(text).not.toContain('Expected accuracy (cited literature)');
+    expect(text).not.toContain('Expected ranges for this capture type');
     expect(text).not.toContain('Annotations (');
     expect(text).not.toContain('Spalling at pier base');
     expect(text).not.toContain('Declared source metadata');
@@ -160,7 +160,8 @@ describe('technical-report golden (complete)', () => {
     expect(text).toContain('Golden-fixture technical note.');
     // Full provenance detail: signals + literature-cited bounds.
     expect(text).toContain('Signals');
-    expect(text).toContain('Expected accuracy (cited literature)');
+    expect(text).toContain('Expected ranges for this capture type (literature)');
+    expect(text).toContain('not measured on this scan');
     expect(text).toContain('source:');
     // Annotations + the v0.5.4 declared-metadata section.
     expect(text).toContain('Annotations (1)');
@@ -188,7 +189,8 @@ describe('legacy template ids render via the engine', () => {
     const { templateId, text } = await renderText(makeInputs(legacy));
     expect(templateId).toBe(expected);
     // The mapped template's signature detail block is present.
-    expect(text).toContain('Expected accuracy (cited literature)');
+    expect(text).toContain('Expected ranges for this capture type (literature)');
+    expect(text).toContain('not measured on this scan');
   });
 
   it('scan-acceptance now resolves to the real Scan QA successor', async () => {

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   captureSnapshot,
+  colorbarBurnInNotes,
   canvasToBlob,
   resolveSnapshotPlan,
   fastPathEligible,
@@ -179,5 +180,27 @@ describe('captureSnapshot — fast path', () => {
     await expect(captureSnapshot(h)).rejects.toThrow(
       'Viewer.snapshot(): canvas.toBlob returned null',
     );
+  });
+});
+
+describe('colorbarBurnInNotes — the lines under the burned-in colour bar', () => {
+  const bar = (mode: string, note?: string): ActiveColorbar =>
+    ({ mode, spec: { min: 0, max: 1 }, note } as unknown as ActiveColorbar);
+
+  it('keeps the window note and adds the derived-colour line for a non-RGB mode', () => {
+    expect(colorbarBurnInNotes(bar('elevation', 'p5–p95 window'))).toEqual([
+      'p5–p95 window',
+      'Colour is applied by the viewer, not recorded by the scan.',
+    ]);
+  });
+
+  it('emits the derived-colour line alone when there is no window note', () => {
+    expect(colorbarBurnInNotes(bar('intensity'))).toEqual([
+      'Colour is applied by the viewer, not recorded by the scan.',
+    ]);
+  });
+
+  it('adds nothing for measured (RGB) colour', () => {
+    expect(colorbarBurnInNotes(bar('rgb', 'p5–p95 window'))).toEqual(['p5–p95 window']);
   });
 });

--- a/tests/snapshotColorbarPlumbing.test.ts
+++ b/tests/snapshotColorbarPlumbing.test.ts
@@ -29,6 +29,7 @@ import type {
   ExportSceneAdapter,
 } from '../src/export/types';
 import { Viewer } from '../src/render/Viewer';
+import { DERIVED_COLOR_NOTE } from '../src/render/colorModeProvenance';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // #1 — runStudioExport requests the colorbar on the adapter snapshot
@@ -145,5 +146,14 @@ describe('Viewer export adapter → viewer.snapshot', () => {
       probe: false,
     });
     expect(sink.opts!.colorbar).toBe(false);
+  });
+});
+
+describe('Viewer export adapter → colour-provenance note for the scan-report card', () => {
+  it('returns the legend line for a derived mode and null for recorded RGB', () => {
+    const adapter = adapterOverFakeViewer({});
+    expect(adapter.colorProvenanceNote?.('elevation')).toBe(DERIVED_COLOR_NOTE);
+    expect(adapter.colorProvenanceNote?.('intensity')).toBe(DERIVED_COLOR_NOTE);
+    expect(adapter.colorProvenanceNote?.('rgb')).toBeNull();
   });
 });


### PR DESCRIPTION
The technical report graded and labelled several rows on bases it did not have. No computed number, gate or non-text export byte changes.

- Density: the report awarded "USGS QL1 density floor met" (tier `met`) from all-returns density; USGS floors are nominal pulse density, which the file does not record, and the terrain module refuses that comparison by design. Now tier `info` with the basis stated; the QL bar is captioned "context, not graded".
- Classification: "Yes" → "Yes — 95.3 % ASPRS code 0/1 (unclassified)", with "derived by the viewer" and "of display sample" when applicable.
- "Vertical accuracy — Not measured" (a constant) → "Not evaluated in this report", pointing to the Terrain report's hold-out figure.
- "points captured" → "points delivered (file record count)"; "Coverage" → "Bounding-box extent (not surveyed area)".
- Literature bounds heading says "for this capture type — not measured on this scan"; the RMSEz bound cites the USGS Lidar Base Specification as a requirement, not a "typical" value.
- Snapshot colour-bar burn-in and the export card carry the derived-colour line for non-RGB modes, via an optional adapter method so the module-graph ratchet holds.

New test: `tests/provenanceStatedBases.test.ts`.
